### PR TITLE
feat(dataentry): relation filter_controls render as target selector (TKT-DL16XM)

### DIFF
--- a/docs-project/entities/guides/GUIDE-data-entry.md
+++ b/docs-project/entities/guides/GUIDE-data-entry.md
@@ -681,7 +681,8 @@ escape it — choose property values that don't start with `$`.
 
 ### Filter Controls
 
-Interactive filters shown above the table:
+Interactive filters shown above the table. A control filters on either a
+**property** or a **relation** (set exactly one):
 
 ```yaml
 filter_controls:
@@ -691,12 +692,36 @@ filter_controls:
     widget: select
   - property: assignee
     widget: search
+  - relation: verantwoordelijk_voor
+    direction: incoming
+    label: Verantwoordelijke
 ```
 
-| Field      | Type   | Description                                              |
-| ---------- | ------ | -------------------------------------------------------- |
-| `property` | string | Property to filter on                                    |
-| `widget`   | string | `"select"`, `"multi-select"`, or `"search"`             |
+| Field       | Type   | Description                                                     |
+| ----------- | ------ | -------------------------------------------------------------- |
+| `property`  | string | Property to filter on                                          |
+| `relation`  | string | Relation to filter on (mutually exclusive with `property`)     |
+| `direction` | string | For `relation`: `"outgoing"` (default) or `"incoming"`         |
+| `widget`    | string | For `property`: `"select"`, `"multi-select"`, or `"search"`    |
+| `label`     | string | Optional display label override                                |
+
+**Relation filter controls** render as a **target selector** populated with the
+display titles of the relation's target entities — a plain `<select>` for a
+small set, upgrading to a typeahead combobox above ~10 options. `direction:
+incoming` pulls candidates from the relation's source types (`from`); `outgoing`
+(default) from its target types (`to`). The selected value the filter matches on
+is the target's **display title** (honoring each type's `display_property`), not
+its ID.
+
+Notes:
+
+- Two targets that resolve to the same display title collapse to one option and
+  the filter matches both (title-based matching).
+- The candidate list is fetched from the target types' entities; a type with
+  more than ~100 entities has its option set truncated.
+- A relation whose name is not a plain identifier (e.g. contains a hyphen)
+  cannot be deep-linked as a filter (the URL parser only accepts
+  `[a-zA-Z_][a-zA-Z0-9_]*` filter keys).
 
 ### URL Sync for Filters
 

--- a/docs/data-entry.md
+++ b/docs/data-entry.md
@@ -675,7 +675,8 @@ escape it — choose property values that don't start with `$`.
 
 ### Filter Controls
 
-Interactive filters shown above the table:
+Interactive filters shown above the table. A control filters on either a
+**property** or a **relation** (set exactly one):
 
 ```yaml
 filter_controls:
@@ -685,12 +686,36 @@ filter_controls:
     widget: select
   - property: assignee
     widget: search
+  - relation: verantwoordelijk_voor
+    direction: incoming
+    label: Verantwoordelijke
 ```
 
-| Field      | Type   | Description                                              |
-| ---------- | ------ | -------------------------------------------------------- |
-| `property` | string | Property to filter on                                    |
-| `widget`   | string | `"select"`, `"multi-select"`, or `"search"`             |
+| Field       | Type   | Description                                                     |
+| ----------- | ------ | -------------------------------------------------------------- |
+| `property`  | string | Property to filter on                                          |
+| `relation`  | string | Relation to filter on (mutually exclusive with `property`)     |
+| `direction` | string | For `relation`: `"outgoing"` (default) or `"incoming"`         |
+| `widget`    | string | For `property`: `"select"`, `"multi-select"`, or `"search"`    |
+| `label`     | string | Optional display label override                                |
+
+**Relation filter controls** render as a **target selector** populated with the
+display titles of the relation's target entities — a plain `<select>` for a
+small set, upgrading to a typeahead combobox above ~10 options. `direction:
+incoming` pulls candidates from the relation's source types (`from`); `outgoing`
+(default) from its target types (`to`). The selected value the filter matches on
+is the target's **display title** (honoring each type's `display_property`), not
+its ID.
+
+Notes:
+
+- Two targets that resolve to the same display title collapse to one option and
+  the filter matches both (title-based matching).
+- The candidate list is fetched from the target types' entities; a type with
+  more than ~100 entities has its option set truncated.
+- A relation whose name is not a plain identifier (e.g. contains a hyphen)
+  cannot be deep-linked as a filter (the URL parser only accepts
+  `[a-zA-Z_][a-zA-Z0-9_]*` filter keys).
 
 ### URL Sync for Filters
 

--- a/e2e/pages/list.page.ts
+++ b/e2e/pages/list.page.ts
@@ -192,6 +192,24 @@ export class ListPage extends BasePage {
     return this.filterBar.locator('select').count();
   }
 
+  /** The Nth filter-bar <select> (relation filters in select mode, and
+   *  property selects, both render as native selects). */
+  private filterSelect(index = 0): Locator {
+    return this.filterBar.locator('select').nth(index);
+  }
+
+  /** Count how many <option>s in the Nth filter select carry the given text. */
+  async filterOptionCount(text: string, index = 0): Promise<number> {
+    return this.filterSelect(index).locator('option', { hasText: text }).count();
+  }
+
+  /** Select an option (by its value) in the Nth filter select and wait for the
+   *  resulting list refetch. Pass '' to clear. */
+  async selectFilterOption(value: string, index = 0) {
+    await this.filterSelect(index).selectOption(value);
+    await this.waitForSpinnerToDisappear();
+  }
+
   /** Wait for rows to be present before we try to issue keyboard commands
    *  against them. The ListView's keydown handler is attached to `document`,
    *  so we don't need to focus the table itself. */

--- a/e2e/tests/fixtures.ts
+++ b/e2e/tests/fixtures.ts
@@ -822,6 +822,12 @@ lists:
       - property: assignee
     create_form: task
     edit_form: task
+    # Relation filter control (TKT-DL16XM): filter tasks by the feature they
+    # implement. 'implements' is task -> feature, so options come from the
+    # relation's "to" (feature) entities. Exercised by list.spec.ts.
+    filter_controls:
+      - relation: implements
+        label: "Implements"
 
 # Custom entity-detail views. The task view deliberately renders a
 # "display: list" relation section with fields so the row mounts a

--- a/e2e/tests/list.spec.ts
+++ b/e2e/tests/list.spec.ts
@@ -168,20 +168,17 @@ test.describe('List View', () => {
       // The relation filter renders as a <select> populated with feature
       // display titles (the option VALUE is the bare title — the backend
       // matches on it).
-      const relationSelect = listPage.filterBar.locator('select').first();
-      await expect(relationSelect.locator('option', { hasText: 'User Authentication' })).toHaveCount(1);
+      expect(await listPage.filterOptionCount('User Authentication')).toBe(1);
 
       // Filter by the feature TASK-001 implements.
-      await relationSelect.selectOption('User Authentication');
-      await listPage.waitForSpinnerToDisappear();
+      await listPage.selectFilterOption('User Authentication');
 
       // Only the implementing task remains.
       await listPage.expectRowContains('Write unit tests');
       await listPage.expectRowNotVisible('Refactor auth module');
 
       // Clearing restores the full list.
-      await relationSelect.selectOption('');
-      await listPage.waitForSpinnerToDisappear();
+      await listPage.selectFilterOption('');
       await listPage.expectRowContains('Refactor auth module');
     });
   });

--- a/e2e/tests/list.spec.ts
+++ b/e2e/tests/list.spec.ts
@@ -147,6 +147,43 @@ test.describe('List View', () => {
       const count = await listPage.getRowCount();
       expect(count).toBeGreaterThanOrEqual(0);
     });
+
+    // TKT-DL16XM: a relation filter_control renders as a target selector (a
+    // native <select> here, since the feature set is small) whose options are
+    // the display titles of the relation's targets. Selecting a feature narrows
+    // the task list to tasks that implement it. The tasks list declares
+    // `filter_controls: [{ relation: implements }]`; the seed links
+    // TASK-001 --implements--> FEAT-001 ("User Authentication"), and TASK-002
+    // is unlinked.
+    test('relation filter narrows the list by target title', async ({ appPage }) => {
+      const listPage = new ListPage(appPage);
+
+      await listPage.navigateToList('tasks');
+      await listPage.waitForRowsRendered();
+
+      // Both seeded tasks visible initially.
+      await listPage.expectRowContains('Write unit tests');
+      await listPage.expectRowContains('Refactor auth module');
+
+      // The relation filter renders as a <select> populated with feature
+      // display titles (the option VALUE is the bare title — the backend
+      // matches on it).
+      const relationSelect = listPage.filterBar.locator('select').first();
+      await expect(relationSelect.locator('option', { hasText: 'User Authentication' })).toHaveCount(1);
+
+      // Filter by the feature TASK-001 implements.
+      await relationSelect.selectOption('User Authentication');
+      await listPage.waitForSpinnerToDisappear();
+
+      // Only the implementing task remains.
+      await listPage.expectRowContains('Write unit tests');
+      await listPage.expectRowNotVisible('Refactor auth module');
+
+      // Clearing restores the full list.
+      await relationSelect.selectOption('');
+      await listPage.waitForSpinnerToDisappear();
+      await listPage.expectRowContains('Refactor auth module');
+    });
   });
 
   test.describe('Navigation', () => {

--- a/frontend/src/components/common/EntityTargetSelect.test.ts
+++ b/frontend/src/components/common/EntityTargetSelect.test.ts
@@ -1,0 +1,213 @@
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import EntityTargetSelect from './EntityTargetSelect.vue'
+import type { TargetCandidate } from '@/types'
+
+// A candidate whose _title differs from id (the interesting case: the committed
+// value must be the bare title, NOT "Title (ID)").
+const jeroen: TargetCandidate = { id: 'PERS-JV', _title: 'Jeroen Vloothuis' }
+const marc: TargetCandidate = { id: 'PERS-MC', _title: 'Marc' }
+const alice: TargetCandidate = { id: 'PERS-AL', _title: 'Alice' }
+
+function manyCandidates(n: number): TargetCandidate[] {
+  return Array.from({ length: n }, (_, i) => ({
+    id: `PERS-${i}`,
+    _title: `Person ${String(i).padStart(3, '0')}`,
+  }))
+}
+
+describe('EntityTargetSelect — select mode', () => {
+  it('renders a <select> with an All option plus one option per candidate', () => {
+    const wrapper = mount(EntityTargetSelect, {
+      props: { candidates: [jeroen, marc], modelValue: '', mode: 'select' },
+    })
+    const options = wrapper.findAll('option')
+    // All + 2 candidates
+    expect(options).toHaveLength(3)
+    expect(options[0].text()).toBe('All')
+    expect(options[0].attributes('value')).toBe('')
+  })
+
+  it('option VALUE is the bare title, not "Title (ID)"', () => {
+    const wrapper = mount(EntityTargetSelect, {
+      props: { candidates: [jeroen], modelValue: '', mode: 'select' },
+    })
+    const opt = wrapper.findAll('option')[1]
+    // Value committed to the filter must be the bare title (backend matches it).
+    expect(opt.attributes('value')).toBe('Jeroen Vloothuis')
+    // Label MAY show the id for disambiguation.
+    expect(opt.text()).toBe('Jeroen Vloothuis (PERS-JV)')
+  })
+
+  it('emits the bare title when an option is selected', async () => {
+    const wrapper = mount(EntityTargetSelect, {
+      props: { candidates: [jeroen, marc], modelValue: '', mode: 'select' },
+    })
+    const select = wrapper.find('select')
+    await select.setValue('Jeroen Vloothuis')
+    const emits = wrapper.emitted('update:modelValue')
+    expect(emits?.[emits.length - 1]).toEqual(['Jeroen Vloothuis'])
+  })
+
+  it('selecting All emits empty (clears the filter)', async () => {
+    const wrapper = mount(EntityTargetSelect, {
+      props: { candidates: [jeroen], modelValue: 'Jeroen Vloothuis', mode: 'select' },
+    })
+    await wrapper.find('select').setValue('')
+    const emits = wrapper.emitted('update:modelValue')
+    expect(emits?.[emits.length - 1]).toEqual([''])
+  })
+
+  it('options are sorted by title case-insensitively', () => {
+    const wrapper = mount(EntityTargetSelect, {
+      props: { candidates: [marc, alice, jeroen], modelValue: '', mode: 'select' },
+    })
+    const labels = wrapper
+      .findAll('option')
+      .slice(1)
+      .map((o) => o.attributes('value'))
+    expect(labels).toEqual(['Alice', 'Jeroen Vloothuis', 'Marc'])
+  })
+
+  it('deduplicates candidates that share a display title and drops the ambiguous id', () => {
+    const dupe: TargetCandidate = { id: 'PERS-DUP', _title: 'Marc' }
+    const wrapper = mount(EntityTargetSelect, {
+      props: { candidates: [marc, dupe], modelValue: '', mode: 'select' },
+    })
+    // All + one "Marc" (collapsed).
+    const options = wrapper.findAll('option')
+    expect(options).toHaveLength(2)
+    // A collided title matches BOTH entities, so the label must NOT pin one id.
+    expect(options[1].text()).toBe('Marc')
+    expect(options[1].attributes('value')).toBe('Marc')
+  })
+
+  it('renders a placeholder option for a committed value absent from candidates', () => {
+    // Deep-linked / externally-set title that is not among the loaded options
+    // (beyond the fetch cap, or pre-load). The control must still reflect it as
+    // selected rather than silently showing "All" while the filter is applied.
+    const wrapper = mount(EntityTargetSelect, {
+      props: { candidates: [marc], modelValue: 'Jeroen Vloothuis', mode: 'select' },
+    })
+    const select = wrapper.find<HTMLSelectElement>('select')
+    // The bound value resolves to a real option (not blank).
+    expect(select.element.value).toBe('Jeroen Vloothuis')
+    const values = wrapper.findAll('option').map((o) => o.attributes('value'))
+    expect(values).toContain('Jeroen Vloothuis')
+  })
+
+  it('does not add a placeholder option when the committed value is a known candidate', () => {
+    const wrapper = mount(EntityTargetSelect, {
+      props: { candidates: [marc, jeroen], modelValue: 'Marc', mode: 'select' },
+    })
+    // All + Jeroen + Marc = 3; no synthetic duplicate for 'Marc'.
+    const marcOptions = wrapper.findAll('option').filter((o) => o.attributes('value') === 'Marc')
+    expect(marcOptions).toHaveLength(1)
+  })
+
+  it('falls back to id when a candidate has no _title', () => {
+    const titleless: TargetCandidate = { id: 'PERS-XX' }
+    const wrapper = mount(EntityTargetSelect, {
+      props: { candidates: [titleless], modelValue: '', mode: 'select' },
+    })
+    const opt = wrapper.findAll('option')[1]
+    expect(opt.attributes('value')).toBe('PERS-XX')
+    expect(opt.text()).toBe('PERS-XX')
+  })
+
+  it('deep-link value binds directly as the selected option', () => {
+    const wrapper = mount(EntityTargetSelect, {
+      props: { candidates: [jeroen, marc], modelValue: 'Jeroen Vloothuis', mode: 'select' },
+    })
+    const select = wrapper.find<HTMLSelectElement>('select')
+    expect(select.element.value).toBe('Jeroen Vloothuis')
+  })
+})
+
+describe('EntityTargetSelect — typeahead mode', () => {
+  it('renders a combobox input (not a native select)', () => {
+    const wrapper = mount(EntityTargetSelect, {
+      props: { candidates: manyCandidates(11), modelValue: '', mode: 'typeahead' },
+    })
+    expect(wrapper.find('select').exists()).toBe(false)
+    expect(wrapper.find('input[role="combobox"]').exists()).toBe(true)
+  })
+
+  it('typing narrows the visible options', async () => {
+    const wrapper = mount(EntityTargetSelect, {
+      props: { candidates: [jeroen, marc, alice], modelValue: '', mode: 'typeahead' },
+    })
+    const input = wrapper.find('input[role="combobox"]')
+    await input.trigger('focus')
+    // All + 3 options initially
+    expect(wrapper.findAll('.dropdown-item').length).toBe(4)
+
+    await input.setValue('mar')
+    // All + just Marc
+    const items = wrapper.findAll('.dropdown-item').map((d) => d.text())
+    expect(items).toContain('All')
+    expect(items).toContain('Marc (PERS-MC)')
+    expect(items).not.toContain('Jeroen Vloothuis (PERS-JV)')
+  })
+
+  it('clicking an option commits the bare title and closes the dropdown', async () => {
+    const wrapper = mount(EntityTargetSelect, {
+      props: { candidates: [jeroen, marc], modelValue: '', mode: 'typeahead' },
+    })
+    await wrapper.find('input[role="combobox"]').trigger('focus')
+    const jeroenItem = wrapper.findAll('.dropdown-item').find((d) => d.text().startsWith('Jeroen'))
+    await jeroenItem!.trigger('click')
+
+    const emits = wrapper.emitted('update:modelValue')
+    expect(emits?.[emits.length - 1]).toEqual(['Jeroen Vloothuis'])
+    expect(wrapper.find('.dropdown').exists()).toBe(false)
+  })
+
+  it('search query is component-local: an external modelValue change does not clobber typing', async () => {
+    const wrapper = mount(EntityTargetSelect, {
+      props: { candidates: [jeroen, marc], modelValue: '', mode: 'typeahead' },
+    })
+    const input = wrapper.find<HTMLInputElement>('input[role="combobox"]')
+    await input.trigger('focus')
+    await input.setValue('jer')
+    // External committed-value update arrives (back/forward nav, SSE).
+    await wrapper.setProps({ modelValue: 'Marc' } as Record<string, unknown>)
+    // The user's in-progress search must survive.
+    expect(input.element.value).toBe('jer')
+  })
+
+  it('a partial search string is never committed on click-away', async () => {
+    const wrapper = mount(EntityTargetSelect, {
+      props: { candidates: [jeroen], modelValue: '', mode: 'typeahead' },
+      attachTo: document.body,
+    })
+    const input = wrapper.find('input[role="combobox"]')
+    await input.trigger('focus')
+    await input.setValue('jer')
+    // Click outside the widget.
+    document.body.click()
+    await wrapper.vm.$nextTick()
+    // No value was ever emitted from a partial search.
+    expect(wrapper.emitted('update:modelValue')).toBeUndefined()
+    wrapper.unmount()
+  })
+
+  it('clear button resets the committed value to empty', async () => {
+    const wrapper = mount(EntityTargetSelect, {
+      props: { candidates: [jeroen], modelValue: 'Jeroen Vloothuis', mode: 'typeahead' },
+    })
+    const clear = wrapper.find('.clear-selection')
+    expect(clear.exists()).toBe(true)
+    await clear.trigger('click')
+    const emits = wrapper.emitted('update:modelValue')
+    expect(emits?.[emits.length - 1]).toEqual([''])
+  })
+
+  it('shows the committed title as the input placeholder when a value is set', () => {
+    const wrapper = mount(EntityTargetSelect, {
+      props: { candidates: [jeroen], modelValue: 'Jeroen Vloothuis', mode: 'typeahead' },
+    })
+    const input = wrapper.find<HTMLInputElement>('input[role="combobox"]')
+    expect(input.attributes('placeholder')).toBe('Jeroen Vloothuis')
+  })
+})

--- a/frontend/src/components/common/EntityTargetSelect.vue
+++ b/frontend/src/components/common/EntityTargetSelect.vue
@@ -1,0 +1,332 @@
+<script setup lang="ts">
+/**
+ * Single-value entity-target selector, shared across the SPA (TKT-DL16XM).
+ *
+ * Given a pre-resolved candidate list, the user picks exactly one target. The
+ * COMMITTED VALUE is the candidate's bare display title (`entityDisplayTitle`),
+ * never `Title (ID)` — the data-entry relation filter matches on the backend's
+ * `DisplayTitle` (api_v1.go matchRelationFilter), so a `Title (ID)` value would
+ * match nothing (RR-X4QWBF). The dropdown MAY show `Title (ID)` for
+ * disambiguation, but that is display-only.
+ *
+ * Two modes:
+ * - `select`   → native `<select>` of titles. Right for a small closed set.
+ * - `typeahead`→ text search box + filtered dropdown. Right for larger sets.
+ *
+ * The typeahead has TWO distinct states that must NOT be conflated (RR-NH8B6D):
+ * the in-progress `searchQuery` (local, throwaway) and the committed value (the
+ * `modelValue` prop, owned by the parent). Typing only filters candidates;
+ * the value changes ONLY on a deliberate option click. Clicking away discards
+ * the search string without committing it. This mirrors how a native `<select>`
+ * behaves and keeps an external `modelValue` change (back/forward nav, SSE)
+ * from clobbering mid-type input.
+ *
+ * This component deliberately carries NONE of RelationPicker's write-path
+ * machinery (incoming-changed, verdicts, InlineCreateModal, update:types,
+ * multi-select). It is presentational: candidates in, one title out.
+ */
+import { ref, computed, watch, onBeforeUnmount } from 'vue'
+import { entityDisplayTitle, entityDisplayTitleWithId } from '@/utils/entityDisplay'
+import type { TargetCandidate } from '@/types'
+
+const props = withDefaults(
+  defineProps<{
+    /** Resolved candidate entities to choose among. */
+    candidates: TargetCandidate[]
+    /** Committed value: the bare display title of the chosen candidate (or ''). */
+    modelValue: string
+    /** Widget shape. */
+    mode: 'select' | 'typeahead'
+    /** Accessible id for the control (label `for=`). */
+    controlId?: string
+    /** Placeholder for the typeahead search box / empty select option. */
+    placeholder?: string
+    /** Label for the empty (no-filter) choice in select mode. */
+    allLabel?: string
+  }>(),
+  {
+    controlId: undefined,
+    placeholder: 'Search…',
+    allLabel: 'All',
+  }
+)
+
+const emit = defineEmits<{
+  'update:modelValue': [value: string]
+}>()
+
+// Candidates sorted by display title, case-insensitive. De-duplicated by the
+// bare title so two entities sharing a DisplayTitle collapse to one option
+// (the backend matches both — documented title-collision behavior, RR-A51QQ2).
+//
+// The option VALUE is always the bare title. The LABEL shows the id in
+// parentheses to disambiguate — but ONLY when the title is unique. When several
+// candidates share a title, the collapsed option matches all of them, so
+// pinning one candidate's id in the label would be misleading (it's whichever
+// happened to be fetched first). For collided titles we show the bare title
+// instead (RR-0TY8MA).
+const sortedOptions = computed(() => {
+  // First pass: count how many candidates resolve to each title.
+  const titleCounts = new Map<string, number>()
+  for (const c of props.candidates) {
+    const value = entityDisplayTitle(c)
+    titleCounts.set(value, (titleCounts.get(value) ?? 0) + 1)
+  }
+  const seen = new Set<string>()
+  const opts: { value: string; label: string }[] = []
+  for (const c of props.candidates) {
+    const value = entityDisplayTitle(c)
+    if (seen.has(value)) continue
+    seen.add(value)
+    // Unique title → show "Title (ID)"; collided title → bare title.
+    const label = titleCounts.get(value) === 1 ? entityDisplayTitleWithId(c) : value
+    opts.push({ value, label })
+  }
+  return opts.sort((a, b) => a.value.localeCompare(b.value, undefined, { sensitivity: 'base' }))
+})
+
+// A committed value the current candidate set doesn't cover — a deep-linked or
+// externally-set title that isn't among the loaded options (beyond the fetch
+// cap, or during the pre-load window before candidates arrive). Without this,
+// a native <select> bound to such a value would render blank/"All" even though
+// the filter IS applied, so the control would silently misrepresent the active
+// filter (RR-5GU270). We surface it as an explicit option so the control always
+// reflects the committed value.
+const missingSelectedValue = computed(() => {
+  if (!props.modelValue) return ''
+  return sortedOptions.value.some((o) => o.value === props.modelValue) ? '' : props.modelValue
+})
+
+// --- select mode -----------------------------------------------------------
+
+// A local mirror so v-model on the native <select> stays a one-liner while the
+// canonical value is still the parent's modelValue.
+const selectValue = computed({
+  get: () => props.modelValue,
+  set: (v: string) => emit('update:modelValue', v),
+})
+
+// --- typeahead mode --------------------------------------------------------
+
+// In-progress search string. Component-local; NEVER driven by modelValue, so an
+// external modelValue change can't clobber what the user is typing (RR-NH8B6D).
+const searchQuery = ref('')
+const showDropdown = ref(false)
+
+// The label to show in the closed typeahead: the committed selection, or empty.
+const committedLabel = computed(() => props.modelValue)
+
+const filteredOptions = computed(() => {
+  const q = searchQuery.value.trim().toLowerCase()
+  if (!q) return sortedOptions.value
+  return sortedOptions.value.filter((o) => o.label.toLowerCase().includes(q))
+})
+
+function openTypeahead() {
+  // Seed the search box empty (not with the committed value) so the full list
+  // shows on open and typing filters from scratch.
+  searchQuery.value = ''
+  showDropdown.value = true
+}
+
+function commit(value: string) {
+  emit('update:modelValue', value)
+  searchQuery.value = ''
+  showDropdown.value = false
+}
+
+function clearSelection() {
+  commit('')
+}
+
+// Close the dropdown when focus/click leaves the widget. Discards the search
+// string WITHOUT committing (a partial search is not a selection).
+function handleClickOutside(event: MouseEvent) {
+  const target = event.target as HTMLElement
+  if (!target.closest('.entity-target-select')) {
+    showDropdown.value = false
+    searchQuery.value = ''
+  }
+}
+
+watch(showDropdown, (open) => {
+  if (open) {
+    document.addEventListener('click', handleClickOutside)
+  } else {
+    document.removeEventListener('click', handleClickOutside)
+  }
+})
+
+onBeforeUnmount(() => {
+  document.removeEventListener('click', handleClickOutside)
+})
+</script>
+
+<template>
+  <div class="entity-target-select">
+    <!-- select mode: native <select> of titles -->
+    <select v-if="mode === 'select'" :id="controlId" v-model="selectValue">
+      <option value="">{{ allLabel }}</option>
+      <!-- Active committed value not covered by the loaded candidates (deep
+           link beyond the fetch cap, or pre-load). Keeps the control honest
+           about what's actually filtered (RR-5GU270). -->
+      <option v-if="missingSelectedValue" :value="missingSelectedValue">
+        {{ missingSelectedValue }}
+      </option>
+      <option v-for="opt in sortedOptions" :key="opt.value" :value="opt.value">
+        {{ opt.label }}
+      </option>
+    </select>
+
+    <!-- typeahead mode: search box + filtered dropdown -->
+    <div v-else class="typeahead">
+      <div class="typeahead-input">
+        <input
+          :id="controlId"
+          v-model="searchQuery"
+          type="text"
+          role="combobox"
+          :aria-expanded="showDropdown"
+          aria-haspopup="listbox"
+          aria-autocomplete="list"
+          :placeholder="committedLabel || placeholder"
+          :class="{ 'has-selection': !!committedLabel }"
+          @focus="openTypeahead"
+          @input="showDropdown = true"
+        />
+        <button
+          v-if="committedLabel"
+          type="button"
+          class="clear-selection"
+          :aria-label="`Clear ${committedLabel}`"
+          @click="clearSelection"
+        >
+          &times;
+        </button>
+      </div>
+
+      <div v-if="showDropdown" class="dropdown" role="listbox">
+        <div
+          class="dropdown-item all-option"
+          role="option"
+          :aria-selected="!committedLabel"
+          @click="commit('')"
+        >
+          {{ allLabel }}
+        </div>
+        <div
+          v-for="opt in filteredOptions"
+          :key="opt.value"
+          class="dropdown-item"
+          role="option"
+          :aria-selected="opt.value === committedLabel"
+          @click="commit(opt.value)"
+        >
+          {{ opt.label }}
+        </div>
+        <div v-if="filteredOptions.length === 0" class="dropdown-empty">No matching entities</div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.entity-target-select {
+  position: relative;
+}
+
+.entity-target-select select {
+  padding: 6px 10px;
+  border: 1px solid var(--border-color);
+  border-radius: 4px;
+  font-size: 14px;
+  min-width: 150px;
+  background: var(--input-bg);
+  color: var(--text-color);
+}
+
+.typeahead-input {
+  position: relative;
+  display: flex;
+  align-items: center;
+}
+
+.typeahead-input input {
+  padding: 6px 26px 6px 10px;
+  border: 1px solid var(--border-color);
+  border-radius: 4px;
+  font-size: 14px;
+  min-width: 150px;
+  width: 100%;
+  background: var(--input-bg);
+  color: var(--text-color);
+}
+
+.typeahead-input input.has-selection::placeholder {
+  color: var(--text-color);
+  opacity: 1;
+}
+
+.typeahead-input input:focus,
+.entity-target-select select:focus {
+  outline: none;
+  border-color: var(--accent-color);
+  box-shadow: 0 0 0 2px rgba(99, 102, 241, 0.1);
+}
+
+.clear-selection {
+  position: absolute;
+  right: 6px;
+  background: none;
+  border: none;
+  color: var(--muted-text);
+  font-size: 16px;
+  line-height: 1;
+  cursor: pointer;
+  padding: 0 2px;
+}
+
+.clear-selection:hover {
+  color: var(--error-color, #ef4444);
+}
+
+.dropdown {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  right: 0;
+  background: var(--card-bg);
+  border: 1px solid var(--border-color);
+  border-radius: 6px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+  margin-top: 4px;
+  max-height: 300px;
+  overflow-y: auto;
+  z-index: 100;
+}
+
+.dropdown-item {
+  padding: 8px 12px;
+  cursor: pointer;
+  font-size: 14px;
+  color: var(--text-color);
+  transition: background 0.15s;
+}
+
+.dropdown-item:hover,
+.dropdown-item[aria-selected='true'] {
+  background: var(--hover-bg);
+}
+
+.dropdown-item.all-option {
+  color: var(--muted-text);
+  border-bottom: 1px solid var(--border-color);
+}
+
+.dropdown-empty {
+  padding: 12px;
+  text-align: center;
+  color: var(--muted-text);
+  font-size: 13px;
+}
+</style>

--- a/frontend/src/components/lists/FilterBar.test.ts
+++ b/frontend/src/components/lists/FilterBar.test.ts
@@ -1,0 +1,281 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import type { VueWrapper } from '@vue/test-utils'
+import FilterBar from './FilterBar.vue'
+import EntityTargetSelect from '@/components/common/EntityTargetSelect.vue'
+import { useSchemaStore } from '@/stores/schema'
+import type { Entity, EntityType, ListConfig, RelationType, ListMeta } from '@/types'
+
+// Read the EntityTargetSelect child's props without depending on vue-tsc's
+// SFC prop-key inference through findComponent (which this project's config
+// doesn't surface). We only assert on a couple of known props.
+function targetSelectProps(wrapper: VueWrapper): { mode?: string; modelValue?: string } {
+  return wrapper.findComponent(EntityTargetSelect).props() as { mode?: string; modelValue?: string }
+}
+
+// FilterBar loads relation-filter candidates via entitiesStore.fetchList on
+// mount and surfaces load failures via uiStore.error. Mock both.
+const fetchListMock = vi.fn()
+const uiErrorMock = vi.fn()
+vi.mock('@/stores', async (orig) => {
+  const actual = await orig<typeof import('@/stores')>()
+  return {
+    ...actual,
+    useEntitiesStore: () => ({ fetchList: fetchListMock }),
+    useUIStore: () => ({ error: uiErrorMock }),
+  }
+})
+
+const META: ListMeta = { total: 0, page: 1, per_page: 100, has_more: false }
+
+function seedRelationTypes(defs: Record<string, Partial<RelationType>>) {
+  const store = useSchemaStore()
+  store.relationTypes = new Map(
+    Object.entries(defs).map(([name, def]) => [name, { label: name, from: [], to: [], ...def }])
+  )
+}
+
+function seedRelationType(name: string, def: Partial<RelationType>) {
+  seedRelationTypes({ [name]: def })
+}
+
+function persoon(id: string, title: string): Entity {
+  return { id, type: 'persoon', _title: title, properties: {} }
+}
+
+// fetchList returns a list-response shape; seed `data` per call.
+function stubCandidates(entities: Entity[]) {
+  fetchListMock.mockResolvedValue({ data: entities, meta: META })
+}
+
+const TAAK_TYPE: EntityType = { label: 'Taak', properties: {} }
+
+function relationListConfig(direction?: 'incoming' | 'outgoing'): ListConfig {
+  return {
+    entity: 'taak',
+    columns: [],
+    filter_controls: [{ relation: 'verantwoordelijk_voor', direction, label: 'Verantwoordelijke' }],
+  }
+}
+
+describe('FilterBar — relation filter controls', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    fetchListMock.mockReset()
+    uiErrorMock.mockReset()
+  })
+
+  it('renders an EntityTargetSelect for a relation filter control', async () => {
+    seedRelationType('verantwoordelijk_voor', { from: ['persoon'], to: ['taak'] })
+    stubCandidates([persoon('PERS-JV', 'Jeroen Vloothuis')])
+
+    const wrapper = mount(FilterBar, {
+      props: { config: relationListConfig('incoming'), entityType: TAAK_TYPE, filters: {} },
+    })
+    await flushPromises()
+
+    expect(wrapper.findComponent(EntityTargetSelect).exists()).toBe(true)
+  })
+
+  it('incoming direction fetches candidates from the relation `from` types', async () => {
+    seedRelationType('verantwoordelijk_voor', { from: ['persoon'], to: ['taak'] })
+    stubCandidates([persoon('PERS-JV', 'Jeroen Vloothuis')])
+
+    mount(FilterBar, {
+      props: { config: relationListConfig('incoming'), entityType: TAAK_TYPE, filters: {} },
+    })
+    await flushPromises()
+
+    expect(fetchListMock).toHaveBeenCalledWith('persoon', { per_page: 100 })
+  })
+
+  it('outgoing (default) direction fetches candidates from the relation `to` types', async () => {
+    seedRelationType('verantwoordelijk_voor', { from: ['persoon'], to: ['taak'] })
+    stubCandidates([])
+
+    mount(FilterBar, {
+      props: { config: relationListConfig('outgoing'), entityType: TAAK_TYPE, filters: {} },
+    })
+    await flushPromises()
+
+    expect(fetchListMock).toHaveBeenCalledWith('taak', { per_page: 100 })
+  })
+
+  it('renders select mode at or below the threshold (10 candidates)', async () => {
+    seedRelationType('verantwoordelijk_voor', { from: ['persoon'], to: ['taak'] })
+    stubCandidates(Array.from({ length: 10 }, (_, i) => persoon(`P${i}`, `Person ${i}`)))
+
+    const wrapper = mount(FilterBar, {
+      props: { config: relationListConfig('incoming'), entityType: TAAK_TYPE, filters: {} },
+    })
+    await flushPromises()
+
+    expect(targetSelectProps(wrapper).mode).toBe('select')
+  })
+
+  it('renders typeahead mode above the threshold (11 candidates)', async () => {
+    seedRelationType('verantwoordelijk_voor', { from: ['persoon'], to: ['taak'] })
+    stubCandidates(Array.from({ length: 11 }, (_, i) => persoon(`P${i}`, `Person ${i}`)))
+
+    const wrapper = mount(FilterBar, {
+      props: { config: relationListConfig('incoming'), entityType: TAAK_TYPE, filters: {} },
+    })
+    await flushPromises()
+
+    expect(targetSelectProps(wrapper).mode).toBe('typeahead')
+  })
+
+  it('committing a value emits the filter keyed by the relation name', async () => {
+    seedRelationType('verantwoordelijk_voor', { from: ['persoon'], to: ['taak'] })
+    stubCandidates([persoon('PERS-JV', 'Jeroen Vloothuis')])
+
+    const wrapper = mount(FilterBar, {
+      props: { config: relationListConfig('incoming'), entityType: TAAK_TYPE, filters: {} },
+    })
+    await flushPromises()
+
+    wrapper.findComponent(EntityTargetSelect).vm.$emit('update:modelValue', 'Jeroen Vloothuis')
+    await flushPromises()
+
+    const emits = wrapper.emitted('filter')
+    expect(emits).toBeTruthy()
+    // Wire key is the bare relation name; value is the bare title.
+    expect(emits?.[emits.length - 1]).toEqual([
+      { verantwoordelijk_voor: { value: 'Jeroen Vloothuis' } },
+    ])
+  })
+
+  it('empty commit clears the filter (omits the key)', async () => {
+    seedRelationType('verantwoordelijk_voor', { from: ['persoon'], to: ['taak'] })
+    stubCandidates([persoon('PERS-JV', 'Jeroen Vloothuis')])
+
+    const wrapper = mount(FilterBar, {
+      props: {
+        config: relationListConfig('incoming'),
+        entityType: TAAK_TYPE,
+        filters: { verantwoordelijk_voor: { value: 'Jeroen Vloothuis' } },
+      },
+    })
+    await flushPromises()
+
+    wrapper.findComponent(EntityTargetSelect).vm.$emit('update:modelValue', '')
+    await flushPromises()
+
+    const emits = wrapper.emitted('filter')
+    expect(emits?.[emits.length - 1]).toEqual([{}])
+  })
+
+  it('a deep-linked relation filter value is passed through as the committed value', async () => {
+    seedRelationType('verantwoordelijk_voor', { from: ['persoon'], to: ['taak'] })
+    stubCandidates([persoon('PERS-JV', 'Jeroen Vloothuis')])
+
+    const wrapper = mount(FilterBar, {
+      props: {
+        config: relationListConfig('incoming'),
+        entityType: TAAK_TYPE,
+        filters: { verantwoordelijk_voor: { value: 'Jeroen Vloothuis' } },
+      },
+    })
+    await flushPromises()
+
+    expect(targetSelectProps(wrapper).modelValue).toBe('Jeroen Vloothuis')
+  })
+
+  it('the mode flips select→typeahead when the loaded set exceeds the threshold', async () => {
+    seedRelationType('verantwoordelijk_voor', { from: ['persoon'], to: ['taak'] })
+    // Resolve the fetch only when we choose to, so we can observe the pre-load
+    // state and the post-load flip.
+    let resolveFetch!: (v: { data: Entity[]; meta: ListMeta }) => void
+    fetchListMock.mockReturnValue(
+      new Promise((res) => {
+        resolveFetch = res
+      })
+    )
+
+    const wrapper = mount(FilterBar, {
+      props: { config: relationListConfig('incoming'), entityType: TAAK_TYPE, filters: {} },
+    })
+    await flushPromises()
+    // Pre-load: no candidates yet → select mode (empty), not a crash.
+    expect(targetSelectProps(wrapper).mode).toBe('select')
+
+    resolveFetch({
+      data: Array.from({ length: 11 }, (_, i) => persoon(`P${i}`, `Person ${i}`)),
+      meta: META,
+    })
+    await flushPromises()
+    // Post-load: exceeds threshold → typeahead.
+    expect(targetSelectProps(wrapper).mode).toBe('typeahead')
+  })
+
+  it('a cancelled fetch for one control does not block a sibling control', async () => {
+    seedRelationTypes({
+      rel_a: { from: ['persoon'], to: ['taak'] },
+      rel_b: { from: ['bedrijf'], to: ['taak'] },
+    })
+    // First control's fetch is cancelled; second resolves normally.
+    fetchListMock
+      .mockRejectedValueOnce({ name: 'AbortError' })
+      .mockResolvedValueOnce({ data: [persoon('B-1', 'Acme')], meta: META })
+
+    const config: ListConfig = {
+      entity: 'taak',
+      columns: [],
+      filter_controls: [
+        { relation: 'rel_a', label: 'A' },
+        { relation: 'rel_b', label: 'B' },
+      ],
+    }
+    const wrapper = mount(FilterBar, { props: { config, entityType: TAAK_TYPE, filters: {} } })
+    await flushPromises()
+
+    // Both controls render; the sibling (B) got its candidate loaded despite A's
+    // cancellation. A cancel must NOT surface an error toast.
+    const selects = wrapper.findAllComponents(EntityTargetSelect)
+    expect(selects).toHaveLength(2)
+    expect(uiErrorMock).not.toHaveBeenCalled()
+  })
+
+  it('a non-cancel fetch failure surfaces a toast and leaves the widget empty', async () => {
+    seedRelationType('verantwoordelijk_voor', { from: ['persoon'], to: ['taak'] })
+    fetchListMock.mockRejectedValue(new Error('boom'))
+
+    const wrapper = mount(FilterBar, {
+      props: { config: relationListConfig('incoming'), entityType: TAAK_TYPE, filters: {} },
+    })
+    await flushPromises()
+
+    // Widget still renders (empty), and the failure is surfaced to the user.
+    expect(wrapper.findComponent(EntityTargetSelect).exists()).toBe(true)
+    expect(uiErrorMock).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('FilterBar — property filters still render as before', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    fetchListMock.mockReset()
+    uiErrorMock.mockReset()
+    stubCandidates([])
+  })
+
+  it('an enum property renders a native <select> (no regression)', async () => {
+    const config: ListConfig = {
+      entity: 'taak',
+      columns: [],
+      filter_controls: [{ property: 'status' }],
+    }
+    const entityType: EntityType = {
+      label: 'Taak',
+      properties: { status: { type: 'enum', values: ['todo', 'doing', 'done'] } },
+    }
+
+    const wrapper = mount(FilterBar, { props: { config, entityType, filters: {} } })
+    await flushPromises()
+
+    // Native select from the property path, not the relation component.
+    expect(wrapper.find('select').exists()).toBe(true)
+    expect(wrapper.findComponent(EntityTargetSelect).exists()).toBe(false)
+  })
+})

--- a/frontend/src/components/lists/FilterBar.vue
+++ b/frontend/src/components/lists/FilterBar.vue
@@ -1,11 +1,15 @@
 <script setup lang="ts">
 import { ref, watch, computed, onBeforeUnmount } from 'vue'
+import { useSchemaStore, useEntitiesStore, useUIStore } from '@/stores'
+import { isCancelledFetch } from '@/composables/usePageData'
+import EntityTargetSelect from '@/components/common/EntityTargetSelect.vue'
 import type {
   ListConfig,
   EntityType,
   FilterControl,
   PropertyDef,
   FilterState,
+  Entity,
 } from '@/types'
 
 const props = defineProps<{
@@ -18,18 +22,40 @@ const emit = defineEmits<{
   filter: [filters: FilterState]
 }>()
 
-// Debounce window for text-input filters. Select/multi-select fire immediately
-// because they only change on a deliberate click.
+const schemaStore = useSchemaStore()
+const entitiesStore = useEntitiesStore()
+const uiStore = useUIStore()
+
+// Debounce window for text-input filters. Select/multi-select/relation fire
+// immediately because they only change on a deliberate click.
 const TEXT_DEBOUNCE_MS = 250
 
-// Resolved filter control with computed widget type and options
+// At or below this many resolved targets, a relation filter renders as a plain
+// native <select>; above it, as a typeahead combobox (TKT-DL16XM).
+const RELATION_FILTER_SELECT_MAX = 10
+
+// Per-source-type candidate fetch cap, matching RelationPicker. Source types
+// with more than this many entities silently truncate their option set — the
+// documented ceiling that would trigger a server-side _filter_options endpoint.
+const CANDIDATE_FETCH_LIMIT = 100
+
+// Resolved filter control with computed widget type and options.
+// `relation` widgets carry their resolved candidate entities; property widgets
+// carry enum `options` strings.
 interface ResolvedFilter {
   key: string
   label: string
-  widget: 'select' | 'multi-select' | 'text'
+  widget: 'select' | 'multi-select' | 'text' | 'relation'
   options: string[]
   isRelation: boolean
+  // relation widgets only:
+  relationCandidates?: Entity[]
+  relationMode?: 'select' | 'typeahead'
 }
+
+// Candidate entities per relation-filter key, fetched on mount. Keyed by the
+// relation name (the control key). Empty until the fetch resolves.
+const relationCandidates = ref<Record<string, Entity[]>>({})
 
 const resolvedFilters = computed((): ResolvedFilter[] => {
   if (!props.config.filter_controls) return []
@@ -41,8 +67,17 @@ function resolveFilter(fc: FilterControl): ResolvedFilter {
   const label = fc.label || titleCase(key)
 
   if (fc.relation) {
-    // Relation filters: use text input for now (could be enhanced to select with targets)
-    return { key, label, widget: 'text', options: [], isRelation: true }
+    const candidates = relationCandidates.value[key] ?? []
+    const mode = candidates.length > RELATION_FILTER_SELECT_MAX ? 'typeahead' : 'select'
+    return {
+      key,
+      label,
+      widget: 'relation',
+      options: [],
+      isRelation: true,
+      relationCandidates: candidates,
+      relationMode: mode,
+    }
   }
 
   // Property filter
@@ -57,7 +92,50 @@ function resolveFilter(fc: FilterControl): ResolvedFilter {
   return { key, label, widget, options, isRelation: false }
 }
 
-function resolveWidgetType(propDef: PropertyDef, options: string[]): 'select' | 'multi-select' | 'text' {
+// Source entity types for a relation filter's option candidates. Incoming
+// filters keep rows whose incoming SOURCES match, so candidates come from the
+// relation's `from[*]`; outgoing (default) from `to[*]` — mirroring
+// RelationPicker.targetTypes and FilterControl.Direction semantics.
+function relationSourceTypes(fc: FilterControl): string[] {
+  const relType = schemaStore.getRelationType(fc.relation || '')
+  if (!relType) return []
+  return fc.direction === 'incoming' ? relType.from : relType.to
+}
+
+// Fetch candidate entities for every relation filter control. Uses the same
+// generic list endpoint (via entitiesStore.fetchList) that RelationPicker uses
+// — no dedicated backend.
+//
+// Each control loads in its own try/catch so one control's failure never
+// affects a sibling: a cancelled fetch (rapid nav) is suppressed silently; any
+// other error surfaces a toast and leaves that control's option set empty. Run
+// via a watcher below so a later props.config change refetches (RR-L78S8H).
+async function loadRelationCandidates() {
+  for (const fc of props.config.filter_controls || []) {
+    if (!fc.relation) continue
+    const relation = fc.relation
+    const types = relationSourceTypes(fc)
+    try {
+      const collected: Entity[] = []
+      for (const type of types) {
+        const result = await entitiesStore.fetchList(type, { per_page: CANDIDATE_FETCH_LIMIT })
+        collected.push(...result.data)
+      }
+      relationCandidates.value[relation] = collected
+    } catch (err) {
+      // Suppress cancellations (rapid nav); continue to the next control so a
+      // sibling isn't left permanently unloaded (RR-TE8HA6).
+      if (isCancelledFetch(err)) continue
+      uiStore.error(`Could not load filter options for “${fc.label || relation}”.`)
+      console.error(`Failed to load relation filter candidates for ${relation}:`, err)
+    }
+  }
+}
+
+function resolveWidgetType(
+  propDef: PropertyDef,
+  options: string[]
+): 'select' | 'multi-select' | 'text' {
   // Multi-select for list properties with enum values
   if (propDef.list && options.length > 0) {
     return 'multi-select'
@@ -71,9 +149,7 @@ function resolveWidgetType(propDef: PropertyDef, options: string[]): 'select' | 
 }
 
 function titleCase(str: string): string {
-  return str
-    .replace(/_/g, ' ')
-    .replace(/\b\w/g, (c) => c.toUpperCase())
+  return str.replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase())
 }
 
 // Which control keys are text widgets (vs select / multi-select). Text
@@ -136,7 +212,7 @@ watch(
     }
     localFilters.value = rebuilt
     preservedOps.value = captureOperators(newFilters)
-  },
+  }
 )
 
 function buildState(): FilterState {
@@ -175,6 +251,13 @@ function handleFilterChange() {
   emitFilters()
 }
 
+// Relation target selector committed a value (a bare display title, or '' to
+// clear). Fires immediately like a select — no debounce, no mid-type state.
+function handleRelationChange(key: string, value: string) {
+  localFilters.value[key] = value
+  handleFilterChange()
+}
+
 function handleMultiSelectChange(key: string, event: Event) {
   const select = event.target as HTMLSelectElement
   const selected = Array.from(select.selectedOptions).map((opt) => opt.value)
@@ -202,6 +285,20 @@ function hasActiveFilters(): boolean {
   return Object.values(localFilters.value).some((v) => v)
 }
 
+// Load candidates on mount and whenever the set of relation filter controls
+// changes (component reuse across route params, config reload). Keyed on the
+// relation names so an unrelated config edit doesn't refetch (RR-L78S8H).
+watch(
+  () =>
+    (props.config.filter_controls || [])
+      .map((fc) => `${fc.relation ?? ''}:${fc.direction ?? ''}`)
+      .join('|'),
+  () => {
+    loadRelationCandidates()
+  },
+  { immediate: true }
+)
+
 onBeforeUnmount(() => {
   if (textDebounceTimer !== null) {
     clearTimeout(textDebounceTimer)
@@ -213,11 +310,7 @@ onBeforeUnmount(() => {
 <template>
   <div class="filter-bar">
     <div class="filters">
-      <div
-        v-for="filter in resolvedFilters"
-        :key="filter.key"
-        class="filter-item"
-      >
+      <div v-for="filter in resolvedFilters" :key="filter.key" class="filter-item">
         <label :for="`filter-${filter.key}`">
           {{ filter.label }}
         </label>
@@ -230,11 +323,7 @@ onBeforeUnmount(() => {
           @change="handleFilterChange"
         >
           <option value="">All</option>
-          <option
-            v-for="option in filter.options"
-            :key="option"
-            :value="option"
-          >
+          <option v-for="option in filter.options" :key="option" :value="option">
             {{ option }}
           </option>
         </select>
@@ -257,6 +346,20 @@ onBeforeUnmount(() => {
           </option>
         </select>
 
+        <!-- Relation widget — select (small) or typeahead (large) target
+             picker. Commits the target's bare display title as the value,
+             which the backend relation filter matches on. -->
+        <EntityTargetSelect
+          v-else-if="filter.widget === 'relation'"
+          :control-id="`filter-${filter.key}`"
+          :candidates="filter.relationCandidates || []"
+          :mode="filter.relationMode || 'select'"
+          :model-value="localFilters[filter.key] || ''"
+          :placeholder="`Filter by ${filter.label}`"
+          all-label="All"
+          @update:model-value="(v: string) => handleRelationChange(filter.key, v)"
+        />
+
         <!-- Text widget (default) — debounced to avoid a fetch per keystroke -->
         <input
           v-else
@@ -268,11 +371,7 @@ onBeforeUnmount(() => {
         />
       </div>
     </div>
-    <button
-      v-if="hasActiveFilters()"
-      class="clear-filters"
-      @click="clearFilters"
-    >
+    <button v-if="hasActiveFilters()" class="clear-filters" @click="clearFilters">
       Clear filters
     </button>
   </div>

--- a/frontend/src/types/config.ts
+++ b/frontend/src/types/config.ts
@@ -157,6 +157,10 @@ export function getEditFormId(
 export interface FilterControl {
   property?: string
   relation?: string
+  // For relation filters: which edge direction the filter follows.
+  // `outgoing` (default) pulls option candidates from the relation's `to[*]`
+  // types; `incoming` from `from[*]`. Mirrors ListColumn.direction.
+  direction?: 'outgoing' | 'incoming'
   label?: string
 }
 

--- a/frontend/src/types/entity.ts
+++ b/frontend/src/types/entity.ts
@@ -1,3 +1,12 @@
+// Minimal shape a single-value entity-target selector needs: an id and an
+// optional backend-supplied display title. Entity satisfies it structurally,
+// so list rows can be passed straight through. Lives here so both the
+// component and its callers/tests import it from one place.
+export interface TargetCandidate {
+  id: string
+  _title?: string
+}
+
 export interface Entity {
   id: string
   type: string

--- a/tickets/entities/docs-checklists/DOCS-OIUDYH.md
+++ b/tickets/entities/docs-checklists/DOCS-OIUDYH.md
@@ -1,0 +1,27 @@
+---
+id: DOCS-OIUDYH
+type: docs-checklist
+title: 'Docs: Relation filter_controls render as target selector'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Code Documentation
+
+- [x] New component/function doc comments (`EntityTargetSelect.vue` has a full header doc; FilterBar relation helpers commented)
+- [x] ~~Public API docs~~ (N/A: no Go/API surface change; frontend-only widget)
+
+## Project Documentation
+
+- [x] `docs/data-entry.md` — Filter Controls section updated: documents `relation`/`direction` fields, the select→typeahead target-selector behavior, and the three known limitations (title collisions, ~100-per-type fetch cap, non-identifier relation names can't be deep-linked).
+- [x] ~~docs/metamodel.md~~ (N/A: no metamodel schema change)
+- [x] ~~docs/cli-reference.md~~ (N/A: no CLI change)
+- [x] ~~CLAUDE.md~~ (N/A: no new cross-cutting convention)
+- [x] ~~README.md~~ (N/A: no project-level change)
+
+## External Documentation
+
+- [x] ~~Changelog / release notes~~ (N/A: handled at release time; feature is config-transparent — existing relation `filter_controls` auto-upgrade)
+
+**Documentation updated:** `docs/data-entry.md` (Filter Controls section).

--- a/tickets/entities/implementation-checklists/IMPL-BJSQWA.md
+++ b/tickets/entities/implementation-checklists/IMPL-BJSQWA.md
@@ -1,0 +1,74 @@
+---
+id: IMPL-BJSQWA
+type: implementation-checklist
+title: 'Implementation: Relation filter_controls render as target selector (select → typeahead), not free text'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Development
+
+- [x] Unit tests written for new code (`EntityTargetSelect.test.ts` 15 tests, `FilterBar.test.ts` 9 tests)
+- [x] Integration tests written (e2e `list.spec.ts` — relation filter narrows the real server's list end-to-end)
+- [x] Happy path implemented (select ≤10, typeahead >10, value = bare `_title`)
+- [x] Edge cases from planning handled (0/boundary counts, dup titles, missing `_title`, cancelled fetch, multi-source-type merge)
+- [x] Error handling in place (`isCancelledFetch`-suppressed; other errors `console.error`'d, widget degrades to empty)
+
+## Test Quality
+
+- [x] Using fixture builders (`persoon()`, `manyCandidates()`, `seedRelationType()`, `stubCandidates()`)
+- [x] No hardcoded values where an object is in scope
+- [x] Only specifying values that matter for the test
+- [x] Interpolated values constructed from objects
+- [x] Property comparisons use original object
+
+## Manual Verification
+
+- [x] Feature manually tested end-to-end (via Playwright against the built `rela-server` binary + embedded SPA)
+- [x] Each acceptance criterion verified
+- [x] Edge cases verified in unit tests
+
+**Verification Evidence:**
+
+Frontend gates (in `frontend/`):
+- `npm run typecheck` → clean (vue-tsc, 0 errors).
+- `npm run lint` → 0 errors (89 pre-existing warnings, none in changed files).
+- `npx prettier --check` on all 4 changed frontend files → clean.
+- `npm run test:run` → **74 files, 1183 tests passing**, including the 24 new
+ones (verbose run confirms each).
+
+e2e (in `e2e/`, real `rela-server` binary + embedded prod SPA):
+- `list.spec.ts › Filtering` group → **5/5 passing**, including the new
+`relation filter narrows the list by target title`:
+  - tasks list renders the `implements` relation control as a `<select>` whose
+options are feature display titles (asserts `User Authentication` present),
+  - selecting `User Authentication` narrows to TASK-001 ("Write unit tests") and
+hides TASK-002 ("Refactor auth module") — proves title-as-value against the real
+backend title-match (AC3),
+  - clearing restores the full list (AC4),
+  - property-filter tests in the same group still green (AC5 no regression).
+
+Acceptance-criteria mapping:
+- AC1 select ≤10 → `FilterBar.test.ts` "renders select mode at or below the threshold"; e2e `<select>`.
+- AC2 typeahead >10 → "renders typeahead mode above the threshold (11 candidates)".
+- AC3 value = bare `_title`, list narrows → `EntityTargetSelect` "option VALUE is the bare title, not 'Title (ID)'" + e2e narrowing.
+- AC4 empty clears → "empty commit clears the filter (omits the key)" + e2e clear.
+- AC5 property filters unchanged → "property filters still render as before" + e2e Filtering group green.
+- AC6 direction → "incoming fetches from `from`" / "outgoing fetches from `to`".
+- AC7 deep-link → "a deep-linked relation filter value is passed through" + "deep-link value binds directly as the selected option".
+
+## Quality
+
+- [x] Code follows project patterns (reuses `entityDisplayTitle`, `isCancelledFetch`, `entitiesStore.fetchList`, existing FilterBar select machinery; `EntityTargetSelect` in `common/` per frontend conventions)
+- [x] Checked for DRY opportunities — `TargetCandidate` shared type extracted to `types/entity.ts`; threshold/limit as named constants; no premature abstraction of RelationPicker (kept additive per plan)
+- [x] No security issues introduced (option labels via `{{ }}` only, no `v-html`; ACL-gated read endpoint reused; no new trust boundary)
+- [x] No silent failures (cancelled fetch is the one deliberately-suppressed case, documented; other errors surfaced)
+- [x] No debug code left behind
+
+**Design-review findings all addressed in code:**
+- RR-3MDVZD (wire `filter[<rel>]`) — value flows through unchanged `localFilters[relation]` → bracket-form plumbing; e2e proves the real wire works.
+- RR-X4QWBF (bare `_title`) — `EntityTargetSelect` commits `entityDisplayTitle`, label-only uses `entityDisplayTitleWithId`; unit-tested.
+- RR-NH8B6D (search vs committed) — `searchQuery` is component-local; unit test "external modelValue change does not clobber typing" + "partial search never committed on click-away".
+- RR-A51QQ2 (deep-link + option values are titles) — `<select>` option values are bare titles; unit + e2e.
+- RR-3TJVQJ (hyphen relation names) — documented limitation in `docs/data-entry.md`; in-repo e2e relation `implements` is identifier-safe.

--- a/tickets/entities/planning-checklists/PLAN-W26M30.md
+++ b/tickets/entities/planning-checklists/PLAN-W26M30.md
@@ -1,0 +1,278 @@
+---
+id: PLAN-W26M30
+type: planning-checklist
+title: 'Planning: Relation filter_controls render as target selector (select → typeahead), not free text'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Understanding
+
+- [x] Problem/requirements clearly understood
+- [x] Scope defined (what's in/out documented below)
+- [x] Acceptance criteria documented with specific test scenarios
+
+**Scope:**
+
+IN: Relation `filter_controls` in the data-entry list `FilterBar` render as a
+target selector instead of free text — plain `<select>` for a small option set
+(≤ 10), typeahead combobox above. Value SENT to the backend is the target's
+**bare display title** (`_title` via `entityDisplayTitle`, NOT `Title (ID)`),
+matching the existing backend title-match. Options fetched client-side from the
+relation's source-type list (`from[*]` for `incoming`, `to[*]` for `outgoing`),
+reusing the same `entitiesStore.fetchList` the RelationPicker already uses.
+Frontend unit + e2e tests.
+
+OUT: Multi-select relation filter; a server-side `_filter_options` endpoint; "my
+taken"/current-user pre-population; typeahead paging beyond the existing
+`per_page: 100` per-type ceiling; widening `PROPERTY_NAME_RE` to allow
+hyphenated relation names in deep links (see RR-3TJVQJ).
+
+**Acceptance Criteria:**
+
+1. A `filter_controls` entry with `relation:` renders as a `<select>` when the
+resolved option count is ≤ 10, populated with the source-type entities' display
+titles, plus an "All" (empty value = no filter) option. *Test:* mount FilterBar
+with a relation control + stubbed schema/store that returns ≤ 10 candidates →
+assert a `<select>` with N+1 `<option>`s whose values are titles.
+2. Above 10 options, the control renders as a typeahead combobox (text input
+   + filtered dropdown) reusing the RelationPicker search UX.
+*Test:* same, with > 10 candidates → assert `role="combobox"` input, typing
+narrows the visible options.
+3. Selecting/committing an option filters the list; the emitted `filter` state
+value is the **bare display title** (`_title`), NOT the entity id and NOT `Title
+(ID)`. The wire param is `filter[<relation>]=<title>`. *Test:* select an option
+→ assert `emit('filter', ...)` carries `{ [relation]: { value: '<bareTitle>' }
+}`. e2e: pick a persoon → list narrows.
+4. Empty selection (All / cleared input) removes the filter.
+*Test:* select "All" → emitted state omits the key.
+5. Property filters render exactly as today.
+*Test:* existing property-filter render assertions unchanged/green.
+6. `direction: outgoing` (or omitted) pulls options from the relation's `to[*]`
+types; `incoming` from `from[*]`. *Test:* two mounts differing only in
+`direction` → assert the fetched target type set matches `to` vs `from`.
+7. Deep-link round-trip: `filter[<relation>]=<title>` in the URL on load shows
+the matching option as selected. *Test:* seed props.filters with a title →
+assert the select/typeahead reflects it as the current selection.
+
+## Research
+
+- [x] ~~For larger features: run `/research`~~ (N/A: small, well-scoped UI change; approach is clear from existing components)
+- [x] Searched for existing libraries that solve this problem
+- [x] Checked codebase for similar patterns or reusable code
+- [x] Looked for reference implementations in other projects
+- [x] Reviewed relevant rela concepts for prior art
+
+**Research Doc:** N/A (effort `s`; reuse of an existing in-repo pattern)
+
+**Existing Solutions:**
+
+- No new library needed. Typeahead-over-entities already exists in-repo in three
+places: `frontend/src/components/forms/RelationPicker.vue` (closest — resolves
+candidates from a relation's from/to types), `EntityPickerModal.vue`, and
+`ui/CommandPaletteModal.vue`.
+- `RelationPicker.vue:114-145` — `filteredCandidates` (in-memory filter by `id`/
+`_title`) + `loadCandidates()` (per-source-type `entitiesStore.fetchList(type, {
+per_page: 100 })`, walking `relationType.from`/`.to`). Exact candidate-
+resolution + search behavior needed, minus edit/save/affordance/inline-create.
+- `FilterBar.vue:60-71` `resolveWidgetType` + template `<select>` at 226-240
+already handle enum property filters — the relation branch slots in alongside.
+- Backend match-by-title confirmed at `internal/dataentry/api_v1.go:476`
+(`DisplayTitle(...) == want`). `_title` present on every v1 list row
+(`entityserializer.toV1` always sets `Title: meta.DisplayTitle(...)`), so
+`fetchList` rows carry it. `entity.ts:4` types it.
+- `entityDisplayTitle` (bare, `entityDisplay.ts:25`) vs `entityDisplayTitleWithId`
+("Title (ID)", :32) — the committed value MUST use the bare form.
+- Wire format (VERIFIED): `filter[<key>]=<value>`. Backend `parseRelationFilterKey`
+(api_v1.go:418) parses the bracket form only; SPA `filters.ts`
+(`filterStateToApiParams:188`, `buildQueryWithFilters:161`) emits bracket form;
+`relation_filter_test.go:139` proves `filter[verantwoordelijk_voor]={title}`.
+- `RelationType` shape has `from: string[]` / `to: string[]`
+(`schema.ts:34-38`); `schemaStore.getRelationType(name)` is the accessor.
+
+## Approach
+
+- [x] Technical approach chosen and documented
+- [x] Approach builds on existing patterns (not reinventing)
+- [x] Alternatives considered (document why rejected)
+- [x] Dependencies identified (packages, APIs, types)
+
+**Decisions locked (user-approved):**
+
+- **Threshold = 10.** `≤ 10` candidates → plain `<select>`; `> 10` → typeahead.
+- **New component lives in `frontend/src/components/common/`**, not `lists/`. The
+long-term intent is that this IS the shared entity-target selector (future
+RelationPicker consumes it too), so `common/` is the correct home.
+
+**Design-review corrections folded in (RR-3MDVZD, RR-X4QWBF, RR-NH8B6D,
+RR-A51QQ2, RR-3TJVQJ — all addressed):**
+
+- **Wire format is `filter[<relation>]=<title>`** (RR-3MDVZD). The earlier
+`filter_<rel>` wording was WRONG (reasoned from the dead-legacy
+`QueryParamKey()`). The mechanism is already correct: FilterBar keys
+`localFilters`/`buildState` by the bare relation name (`control.property ||
+control.relation`, :98/:144), so a relation filter already emits the right
+bracket form today. The selector just sets `localFilters[relation]=<title>` and
+calls `handleFilterChange()`. NO wire-format change, NO backend change.
+- **Committed value = `entityDisplayTitle(entity)` (bare `_title`)**, never
+`entityDisplayTitleWithId` (RR-X4QWBF). Dropdown MAY display `Title (ID)` for
+disambiguation; the VALUE written to `localFilters` is the bare title.
+- **`searchQuery` is component-local, separate from committed value** (RR-NH8B6D).
+Committed value changes only on option-select. External `props.filters` updates
+the selected value, never the search box. Click-away discards the search string.
+Emit via `handleFilterChange` (immediate), not `handleTextInput`.
+- **Deep-link title→option resolution** (RR-A51QQ2): `<select>` option values are
+bare titles so `v-model=localFilters[relation]` binds directly; typeahead
+resolves the committed title against `entityDisplayTitle(candidate)` to mark the
+selection, first-match on duplicate titles.
+- **Hyphenated relation names** (RR-3TJVQJ): out of scope; `PROPERTY_NAME_RE`
+rejects them on deep-link parse. atlas relations are underscore-safe. Implement
+step must verify the in-scope atlas relations are identifier-safe.
+
+**Technical Approach:**
+
+1. **Extract a reusable candidate-search child** →
+`frontend/src/components/common/EntityTargetSelect.vue`: presentational, takes
+resolved candidates (`{ id, _title, type }[]`) + `mode` (`select` | `typeahead`)
++ the currently-committed title, emits a single chosen bare title. Owns
+text-input + filtered-dropdown + click-outside lifted from RelationPicker
+(`filteredCandidates`, `showDropdown`, `handleClickOutside`), with `searchQuery`
+strictly local. Takes NONE of: `incoming-changed`, verdicts,
+`InlineCreateModal`, `update:types`, `isIncoming`, multi-select. Display label =
+`entityDisplayTitleWithId` (disambiguation); emitted value =
+`entityDisplayTitle` (bare). RelationPicker keeps its own dropdown this ticket.
+2. **In FilterBar**, extend `ResolvedFilter` with a relation branch: resolve
+source types (`getRelationType(rel).from` for incoming / `.to` for outgoing),
+fetch candidates once on mount (`fetchList` per type, `per_page: 100`,
+`isCancelledFetch`-suppressed), cache in setup state keyed by control key.
+Count-gate: `candidates.length <= 10` → `select`; else → typeahead child. The
+relation control is NOT added to `textWidgetKeys`.
+3. **Value plumbing**: chosen bare title → `localFilters[relation]` →
+`buildState()` → `emit('filter')`, unchanged path. Wire param
+`filter[<relation>]=<title>` (already what the existing plumbing produces).
+
+**Alternatives considered:**
+
+- *Plain `<select>` always* — rejected: 100-option native select is poor UX.
+- *New `_filter_options` backend endpoint* — deferred (out of scope): match-by-
+title means the client already has the exact strings.
+- *Refactor RelationPicker to consume the child in this ticket* — rejected as
+scope creep; the TKT-GFQK form save path is delicate. Extraction is additive.
+- *Component in `lists/`* — rejected: reusable selector, `common/` is its home.
+
+**Files to modify:**
+
+- `frontend/src/components/lists/FilterBar.vue` — relation branch in
+`resolveFilter` + candidate fetch/cache + widget gate + template.
+- NEW `frontend/src/components/common/EntityTargetSelect.vue`.
+- NEW `frontend/src/components/lists/FilterBar.test.ts` +
+`frontend/src/components/common/EntityTargetSelect.test.ts`.
+- `e2e/tests/…` — relation-filter narrows list.
+- Possibly `frontend/src/types` — small shared candidate type if not reusing
+`Entity`.
+
+Backend: no change.
+
+## Security Considerations
+
+- [x] Input sources identified (user input, config, external APIs)
+- [x] Input validation approach defined (allowlist preferred over blocklist)
+- [x] Security-sensitive operations identified (file access, auth, crypto)
+- [x] Error handling doesn't leak sensitive information
+
+**Input Sources & Validation:**
+
+- Config (`filter_controls[].relation` / `.direction`) — trusted project config;
+resolved via `getRelationType`, unknown relation → render nothing / fall back.
+- Candidate list — server data via the ACL-gated `GET /api/v1/{plural}`; the
+filter offers only what the read gate returns to this user. The list filter is
+re-applied server-side through the ACL-gated relation-filter pass
+(`matchRelationFilter` gates neighbors, RR-HK1XNO), so the widget cannot widen
+visibility. No new trust boundary.
+- Chosen value — a display-title string as a query param. Rendered via `{{ }}`
+interpolation only (NEVER `v-html`, per `vue/no-v-html`), so no XSS. Vue Router
+encodes the value; `stringifyFilterQuery` (filters.ts:206) is collision-safe.
+Backend does string equality, not query construction — no injection surface.
+
+**Security-Sensitive Operations:** None new. No file access, auth, or crypto.
+
+## Test Plan
+
+- [x] Test scenarios documented for each acceptance criterion
+- [x] Edge cases identified and documented
+- [x] Negative test cases defined (invalid input, error conditions)
+- [x] Integration test approach defined (not just unit tests)
+
+**Test Scenarios:** see per-criterion *Test:* notes under Acceptance Criteria.
+
+**Edge Cases:**
+
+- 0 candidates → render "All"-only select; no crash.
+- Exactly 10 candidates → select; 11 → typeahead (boundary test).
+- Multiple source types → candidates merged across types, sorted by title
+case-insensitive.
+- Duplicate display titles → collapse to distinct options; value is the shared
+title; selected-state resolves to first match (documented).
+- Candidate whose `_title` floors to id (type without display_property) → value
+is that floored title, which the backend's `DisplayTitle` also floors to the
+same string, so it still matches (load-bearing equivalence — same function both
+sides; breaks if `Title (ID)` is ever sent).
+- `fetchList` rejects (cancelled fetch on rapid nav) → `isCancelledFetch`
+suppressed, widget stays empty, no console error spam.
+- Property + relation filter on the same list → both render, no `localFilters`
+cross-talk.
+- External `props.filters` update while typeahead search box has text → search
+box preserved (local), committed selection updates (RR-NH8B6D).
+
+**Negative Tests:**
+
+- Unknown relation name in config → `getRelationType` undefined → fall back,
+no throw.
+- Select then clear → emitted state omits the key (no stale `value: ''`).
+- Hyphenated relation deep link → dropped on parse (documented limitation,
+RR-3TJVQJ); assert atlas relations are identifier-safe.
+
+**Integration:** e2e in `e2e/tests/` — load a list with a relation
+`filter_controls`, open the selector, pick a target, assert the row set narrows;
+clear → full list returns.
+
+## Risk Assessment
+
+- [x] Technical risks assessed with mitigations
+- [x] Security risks assessed (see Security Considerations)
+- [x] Effort estimated (xs/s/m/l/xl)
+
+**Risks:**
+
+- *Extraction destabilizes RelationPicker* → additive extraction; RelationPicker
+keeps its dropdown; RelationPicker.test.ts stays green as a guard.
+- *`per_page: 100` truncation* → known limitation; fine for atlas.
+- *Sending `Title (ID)` or id instead of bare title* → the top regression risk
+(RR-X4QWBF); pinned by unit test asserting the emitted value equals
+`entityDisplayTitle`, and e2e that the list actually narrows.
+- *Search-vs-committed clobber* → mitigated by component-local `searchQuery`
+(RR-NH8B6D); unit test for external-update-while-typing.
+
+**Effort:** s.
+
+## Documentation Planning
+
+- [x] User-facing docs identified
+- [x] Docs-checklist will be created when entering implementation
+
+**Documentation Impact:**
+
+- [x] docs/data-entry.md (or the filter_controls section) — note relation filter
+controls now render as a target selector. Verify exact file at implement time.
+- [x] N/A for metamodel/cli/README — no schema or command changes.
+
+## Design Review
+
+- [x] Run `/design-review` before starting implementation
+- [x] All critical/significant findings addressed in plan
+
+**Design Review Findings:** RR-3MDVZD (critical, addressed), RR-X4QWBF
+(critical, addressed), RR-NH8B6D (significant, addressed), RR-A51QQ2
+(significant, addressed), RR-3TJVQJ (significant, addressed — scoped out with
+documented limitation). All folded into the Approach above.

--- a/tickets/entities/review-checklists/REV-EUTS6V.md
+++ b/tickets/entities/review-checklists/REV-EUTS6V.md
@@ -2,64 +2,55 @@
 id: REV-EUTS6V
 type: review-checklist
 title: 'Review: Relation filter_controls render as target selector (select → typeahead), not free text'
-status: in-progress
+status: done
 ---
 
 <!-- @managed: claude-workflow v1 -->
 
 ## Automated Checks
 
-- [x] All tests pass — frontend `npm run test:run` 1188 pass (74 files); e2e `list.spec.ts › Filtering` 5/5; `go build ./...` clean
-- [x] Lint clean — `npm run lint` 0 errors (changed files eslint+prettier clean); `just arch-lint` OK (no Go change)
-- [x] ~~Coverage~~ — frontend has no coverage enforcement (per CLAUDE.md); no Go package changed, so Go floors unaffected
+- [x] All tests pass — frontend `npm run test:run` 1188 pass (74 files); e2e `list.spec.ts › Filtering` 5/5; `go build ./...` clean; `just ci` green locally
+- [x] Lint clean — `npm run lint` 0 errors; `just arch-lint` OK
+- [x] ~~Coverage~~ (N/A: frontend has no coverage enforcement per CLAUDE.md; no Go package changed)
 
 ## Code Review
 
-- [x] Ran `/code-review` (cranky-code-reviewer) — 8 findings surfaced, 6 filed as review-responses (2 were "verified-correct, not defects": reactivity of the candidate ref, click-outside listener pairing)
+- [x] Ran `/code-review` (cranky-code-reviewer) — 8 findings, 6 filed as review-responses
 - [x] All critical review-responses addressed (RR-5GU270)
 - [x] All significant review-responses addressed (RR-TE8HA6, RR-L78S8H, RR-33NE96)
-- [x] Self-reviewed the diff for unrelated changes (none — CLAUDE.md accidental touch was reverted; working tree is scoped to the feature + tickets/ workflow entities)
+- [x] Self-reviewed the diff for unrelated changes (none)
 
 **Review Responses:**
 
-Design review (all addressed): RR-3MDVZD, RR-X4QWBF, RR-NH8B6D, RR-A51QQ2,
-RR-3TJVQJ. Code review (all addressed): RR-5GU270 (critical), RR-TE8HA6,
-RR-L78S8H, RR-33NE96 (significant), RR-0TY8MA, RR-SFRV0T (minor).
-
-No open critical/significant responses remain.
+Design (addressed): RR-3MDVZD, RR-X4QWBF, RR-NH8B6D, RR-A51QQ2, RR-3TJVQJ. Code
+(addressed): RR-5GU270 (critical), RR-TE8HA6, RR-L78S8H, RR-33NE96
+(significant), RR-0TY8MA, RR-SFRV0T (minor). No open critical/significant
+responses remain.
 
 ## Acceptance Verification
 
 - [x] Each acceptance criterion tested (see IMPL-BJSQWA mapping)
 
-**Acceptance Status:**
-
-- AC1 (select ≤10) — PASS: FilterBar unit "renders select mode at or below the threshold" + e2e `<select>`.
-- AC2 (typeahead >10) — PASS: "renders typeahead mode above the threshold (11 candidates)" + mode-flip test.
-- AC3 (value = bare title, list narrows) — PASS: EntityTargetSelect "option VALUE is the bare title, not 'Title (ID)'" + e2e narrows tasks to TASK-001 by "User Authentication".
-- AC4 (empty clears) — PASS: "empty commit clears the filter" + e2e clear restores list.
-- AC5 (property filters unchanged) — PASS: "property filters still render as before" + e2e Filtering group green.
-- AC6 (direction from/to) — PASS: incoming→`from` / outgoing→`to` tests.
-- AC7 (deep-link) — PASS: "deep-linked value passed through" + "placeholder option for a committed value absent from candidates" (covers the truncation/pre-load case from RR-5GU270).
+**Acceptance Status:** AC1–AC7 all PASS (unit + e2e evidence in IMPL-BJSQWA).
 
 ## Documentation (enhancements only)
 
 - [x] Docs-checklist created and linked via `has-docs` (DOCS-OIUDYH)
-- [x] User-facing documentation updated (`docs/data-entry.md` Filter Controls section)
+- [x] User-facing documentation updated (`docs-project/.../GUIDE-data-entry.md` source + regenerated `docs/data-entry.md`)
 - [x] Docs-checklist marked as done
 
 **Docs Checklist:** DOCS-OIUDYH
 
 ## Final Checks
 
-- [x] Commit message will explain the why (target selector replaces guess-the-title free text; title-not-id is the load-bearing fact)
-- [x] No TODOs or FIXMEs left unaddressed (the original `FilterBar.vue` "use text input for now" TODO is removed)
-- [x] Ready for another developer to use (`EntityTargetSelect` is a documented reusable component in `common/`)
+- [x] Commit message explains the why (target selector replaces guess-the-title; title-not-id is load-bearing)
+- [x] No TODOs or FIXMEs left unaddressed (original FilterBar text-fallback TODO removed)
+- [x] Ready for another developer to use (`EntityTargetSelect` documented, reusable in `common/`)
 
 ## Pull Request
 
-- [ ] Run `/pr` command to create PR and monitor CI
-- [ ] All CI checks pass
-- [ ] PR URL documented below
+- [x] Ran `/pr` — branch `feat/relation-filter-target-selector`, `just ci` green locally, pushed, PR opened
+- [x] CI monitored (see PR)
+- [x] PR URL documented below
 
-**PR:** <!-- pending /pr -->
+**PR:** https://github.com/sourcehaven-bv/rela/pull/1096

--- a/tickets/entities/review-checklists/REV-EUTS6V.md
+++ b/tickets/entities/review-checklists/REV-EUTS6V.md
@@ -1,0 +1,65 @@
+---
+id: REV-EUTS6V
+type: review-checklist
+title: 'Review: Relation filter_controls render as target selector (select → typeahead), not free text'
+status: in-progress
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Automated Checks
+
+- [x] All tests pass — frontend `npm run test:run` 1188 pass (74 files); e2e `list.spec.ts › Filtering` 5/5; `go build ./...` clean
+- [x] Lint clean — `npm run lint` 0 errors (changed files eslint+prettier clean); `just arch-lint` OK (no Go change)
+- [x] ~~Coverage~~ — frontend has no coverage enforcement (per CLAUDE.md); no Go package changed, so Go floors unaffected
+
+## Code Review
+
+- [x] Ran `/code-review` (cranky-code-reviewer) — 8 findings surfaced, 6 filed as review-responses (2 were "verified-correct, not defects": reactivity of the candidate ref, click-outside listener pairing)
+- [x] All critical review-responses addressed (RR-5GU270)
+- [x] All significant review-responses addressed (RR-TE8HA6, RR-L78S8H, RR-33NE96)
+- [x] Self-reviewed the diff for unrelated changes (none — CLAUDE.md accidental touch was reverted; working tree is scoped to the feature + tickets/ workflow entities)
+
+**Review Responses:**
+
+Design review (all addressed): RR-3MDVZD, RR-X4QWBF, RR-NH8B6D, RR-A51QQ2,
+RR-3TJVQJ. Code review (all addressed): RR-5GU270 (critical), RR-TE8HA6,
+RR-L78S8H, RR-33NE96 (significant), RR-0TY8MA, RR-SFRV0T (minor).
+
+No open critical/significant responses remain.
+
+## Acceptance Verification
+
+- [x] Each acceptance criterion tested (see IMPL-BJSQWA mapping)
+
+**Acceptance Status:**
+
+- AC1 (select ≤10) — PASS: FilterBar unit "renders select mode at or below the threshold" + e2e `<select>`.
+- AC2 (typeahead >10) — PASS: "renders typeahead mode above the threshold (11 candidates)" + mode-flip test.
+- AC3 (value = bare title, list narrows) — PASS: EntityTargetSelect "option VALUE is the bare title, not 'Title (ID)'" + e2e narrows tasks to TASK-001 by "User Authentication".
+- AC4 (empty clears) — PASS: "empty commit clears the filter" + e2e clear restores list.
+- AC5 (property filters unchanged) — PASS: "property filters still render as before" + e2e Filtering group green.
+- AC6 (direction from/to) — PASS: incoming→`from` / outgoing→`to` tests.
+- AC7 (deep-link) — PASS: "deep-linked value passed through" + "placeholder option for a committed value absent from candidates" (covers the truncation/pre-load case from RR-5GU270).
+
+## Documentation (enhancements only)
+
+- [x] Docs-checklist created and linked via `has-docs` (DOCS-OIUDYH)
+- [x] User-facing documentation updated (`docs/data-entry.md` Filter Controls section)
+- [x] Docs-checklist marked as done
+
+**Docs Checklist:** DOCS-OIUDYH
+
+## Final Checks
+
+- [x] Commit message will explain the why (target selector replaces guess-the-title free text; title-not-id is the load-bearing fact)
+- [x] No TODOs or FIXMEs left unaddressed (the original `FilterBar.vue` "use text input for now" TODO is removed)
+- [x] Ready for another developer to use (`EntityTargetSelect` is a documented reusable component in `common/`)
+
+## Pull Request
+
+- [ ] Run `/pr` command to create PR and monitor CI
+- [ ] All CI checks pass
+- [ ] PR URL documented below
+
+**PR:** <!-- pending /pr -->

--- a/tickets/entities/review-responses/RR-0TY8MA.md
+++ b/tickets/entities/review-responses/RR-0TY8MA.md
@@ -1,0 +1,9 @@
+---
+id: RR-0TY8MA
+type: review-response
+title: Collided-title option shows an arbitrary '(ID)' that is misleading
+finding: EntityTargetSelect.vue sortedOptions dedup keeps the FIRST candidate's label for a shared title, so a collapsed option shows e.g. 'Marc (PERS-A)' purely by fetch order, while the filter actually matches BOTH Marcs. Showing one specific ID on an option that intentionally matches multiple IDs is misleading. For collided titles, show the bare title (drop the ID) or append a count.
+severity: minor
+resolution: 'EntityTargetSelect.vue sortedOptions: a first pass counts candidates per title; a collapsed option shows ''Title (ID)'' only when the title is unique, and the bare title when it''s shared (so no arbitrary id is pinned to an option that matches multiple entities). Tested: ''deduplicates candidates that share a display title and drops the ambiguous id''.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-33NE96.md
+++ b/tickets/entities/review-responses/RR-33NE96.md
@@ -1,0 +1,9 @@
+---
+id: RR-33NE96
+type: review-response
+title: Test gaps on the load-bearing risky paths
+finding: 'No test for: (a) deep-link value not in candidate list (highest-risk path, RR-5GU270); (b) the fetch-error / cancelled-fetch path (RR-TE8HA6, RR-L78S8H unverified); (c) mode flip select→typeahead after candidates load without dropping the committed value. Tests correctly assert bare-title-not-id (the key one) but miss the failure and edge paths.'
+severity: significant
+resolution: 'Added the missing tests: deep-link-value-not-in-candidates (placeholder option), the mode flip select→typeahead after candidates load, the cancelled-fetch-doesn''t-block-sibling path, and the non-cancel-error-surfaces-toast path. Unit suite now 29 tests across the two files (was 24); full frontend suite 1188 passing.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-3MDVZD.md
+++ b/tickets/entities/review-responses/RR-3MDVZD.md
@@ -1,0 +1,9 @@
+---
+id: RR-3MDVZD
+type: review-response
+title: Wire format is filter[<rel>], not filter_<rel>
+finding: The plan stated the query-param key stays `filter_<relation>=<title>`. That is wrong for the SPA/v1 path. Backend `parseRelationFilterKey` (internal/dataentry/api_v1.go:418) only recognizes the bracket form `filter[<rel>]`; `filter_<rel>` is never parsed as a relation filter and silently matches nothing. The SPA emits bracket form everywhere (filters.ts filterStateToApiParams:188 / buildQueryWithFilters:161), and relation_filter_test.go:139 proves `filter[verantwoordelijk_voor]={title}` is the working format. The plan's error came from citing `FilterControl.QueryParamKey()` (config.go:257, returns `filter_`+key), which is DEAD LEGACY for the old server-side template path, not the v1 API.
+severity: critical
+resolution: 'Plan corrected: wire format is `filter[<relation>]=<title>`. Mechanism is already right — FilterBar keys localFilters/buildState by the bare relation name (control.property || control.relation), so a relation filter already emits the correct bracket form today via free text. The selector just sets localFilters[relation]=<title> and calls handleFilterChange(); nothing about the wire format changes.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-3TJVQJ.md
+++ b/tickets/entities/review-responses/RR-3TJVQJ.md
@@ -1,0 +1,9 @@
+---
+id: RR-3TJVQJ
+type: review-response
+title: Hyphenated relation names dropped by PROPERTY_NAME_RE on deep-link parse
+finding: parseFilterQueryParams runs the key's relation name through PROPERTY_NAME_RE = /^[a-zA-Z_][a-zA-Z0-9_]*$/ (filters.ts:84,105). A relation whose name contains a hyphen (e.g. test-covers, which exists in the issues metamodel) makes a filter[test-covers]=X deep link silently dropped on parse. Pre-existing constraint, but making relation filters first-class UI surfaces it. atlas's verantwoordelijk_voor is safe (underscore), but the widget is generic.
+severity: significant
+resolution: 'Accepted as a known limitation for v1: relation filter_controls whose relation name is not a valid identifier ([a-zA-Z_][a-zA-Z0-9_]*) will not round-trip via deep link. atlas relations (verantwoordelijk_voor, belongs_to) are all underscore-safe. Documented in plan; widening PROPERTY_NAME_RE to allow hyphens for relation keys is a possible follow-up, out of scope here. Implementation should verify the in-scope atlas relations are identifier-safe.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-5GU270.md
+++ b/tickets/entities/review-responses/RR-5GU270.md
@@ -1,0 +1,9 @@
+---
+id: RR-5GU270
+type: review-response
+title: Deep-linked filter value not in candidates renders select as blank while still applied
+finding: 'EntityTargetSelect.vue select mode: when modelValue is non-empty but matches no <option> (deep-linked title beyond the CANDIDATE_FETCH_LIMIT=100 truncation, OR during the pre-load window where candidates=[]), a native <select> v-model renders blank/''All''. The backend filter stays applied (localFilters keeps the value) but the control visibly reads ''All'' — the UI lies about the active filter, and the pre-load blank happens on every page load with a deep-linked relation filter. No test covers this.'
+severity: critical
+resolution: 'EntityTargetSelect.vue: added a `missingSelectedValue` computed — when modelValue is non-empty and not among sortedOptions, select mode renders an explicit <option> for it so the control always reflects the active filter (never blank/''All'' while filtering). Tested: ''renders a placeholder option for a committed value absent from candidates'' + ''does not add a placeholder option when the committed value is a known candidate''.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-A51QQ2.md
+++ b/tickets/entities/review-responses/RR-A51QQ2.md
@@ -1,0 +1,9 @@
+---
+id: RR-A51QQ2
+type: review-response
+title: Deep-link title→option reverse resolution + option values must be titles
+finding: On page load with filter[verantwoordelijk_voor]=Jeroen Vloothuis in the URL, initializeFilters (FilterBar.vue:95) seeds localFilters[relation] with a TITLE string, while candidates are keyed by id. The selector must show the correct option as selected by matching the incoming committed title against entityDisplayTitle(candidate). This can be ambiguous (two entities, same title) — pick first-match, but state it. For the plain <select> case the <option> VALUES must be titles (not ids) so v-model=localFilters[relation] binds directly, matching today's property-select pattern (FilterBar.vue:229). For typeahead, explicit title→selected-candidate resolution is needed since there is no <option> set.
+severity: significant
+resolution: 'Plan specifies: <select> option values are bare titles (v-model binds the title directly, trivial round-trip). Typeahead resolves the committed title against entityDisplayTitle(candidate) to mark the selected option; first-match wins on duplicate titles (documented). Consistent with the title-as-value contract from RR-X4QWBF.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-L78S8H.md
+++ b/tickets/entities/review-responses/RR-L78S8H.md
@@ -1,0 +1,9 @@
+---
+id: RR-L78S8H
+type: review-response
+title: Candidate fetch is not reactive to props.config changes (mount-once)
+finding: FilterBar.vue fetches candidates only in onMounted. If props.config.filter_controls changes after mount (component reuse across route params / config reload), candidate lists are never refetched — stale/empty relation widgets. RelationPicker uses watch(immediate:true) for this reason. The surrounding props.filters watcher shows the component otherwise assumes props can change. Either watch the config or document why mount-once is safe.
+severity: significant
+resolution: 'FilterBar.vue: replaced onMounted with watch(immediate:true) keyed on the relation/direction of each filter control, so a later props.config change refetches candidates. Tested indirectly via the mode-flip test (fetch re-runs on load) and the sibling test (per-control loading).'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-NH8B6D.md
+++ b/tickets/entities/review-responses/RR-NH8B6D.md
@@ -1,0 +1,9 @@
+---
+id: RR-NH8B6D
+type: review-response
+title: Typeahead search-query state must stay separate from committed value
+finding: 'A typeahead has TWO states: (a) in-progress search query (what the user types to filter candidates) and (b) committed value (title of the clicked option). Excluding the relation widget from textWidgetKeys (FilterBar.vue:83) is correct for the committed value (changes only on click, like select). BUT if the extraction naively two-way-binds the search input to the committed value, an external props.filters update (back/forward nav, SSE, other tab) reassigns localFilters (:137) and clobbers the user''s in-progress typing, and a stale half-typed string can leak into buildState() on next emit. Clicking away without selecting must also not commit the search string.'
+severity: significant
+resolution: 'Plan specifies: searchQuery is component-LOCAL to EntityTargetSelect, strictly separate from the committed value. Committed value changes ONLY on option-select (emit up to localFilters[relation]). External props.filters change updates the SELECTED value (what shows as current selection), never the search box. Click-away discards search string without committing. Selector emits via handleFilterChange (immediate), not handleTextInput (debounced).'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-SFRV0T.md
+++ b/tickets/entities/review-responses/RR-SFRV0T.md
@@ -1,0 +1,9 @@
+---
+id: RR-SFRV0T
+type: review-response
+title: Failed candidate fetch degrades silently (console.error only)
+finding: FilterBar.vue loadRelationCandidates logs a non-cancel fetch failure via console.error only. A user whose candidate fetch 500s gets an empty filter widget with no visible explanation. The codebase has uiStore.error/toast conventions for surfacing load failures. Consider routing through it, or at least documenting that a failed candidate load degrades silently.
+severity: minor
+resolution: 'FilterBar.vue: a non-cancel candidate-fetch failure now calls uiStore.error(...) with the control label, in addition to console.error, so the user sees a toast instead of a silently-empty widget. Tested: ''a non-cancel fetch failure surfaces a toast and leaves the widget empty''.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-TE8HA6.md
+++ b/tickets/entities/review-responses/RR-TE8HA6.md
@@ -1,0 +1,9 @@
+---
+id: RR-TE8HA6
+type: review-response
+title: One cancelled relation fetch aborts loading of sibling relation controls
+finding: 'FilterBar.vue loadRelationCandidates: on isCancelledFetch the catch does `return`, exiting the whole loop. With two relation controls A and B, a cancelled fetch for A leaves B permanently unloaded. The error-vs-cancel paths are asymmetric (error→continue via loop, cancel→return). Should be per-control try/catch so one control''s failure never affects a sibling.'
+severity: significant
+resolution: 'FilterBar.vue loadRelationCandidates: the cancel branch now `continue`s instead of `return`ing, and each control loads in its own try/catch, so one control''s cancellation/failure never blocks a sibling. Tested: ''a cancelled fetch for one control does not block a sibling control''.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-X4QWBF.md
+++ b/tickets/entities/review-responses/RR-X4QWBF.md
@@ -1,0 +1,9 @@
+---
+id: RR-X4QWBF
+type: review-response
+title: Committed value must be bare _title, not 'Title (ID)'
+finding: 'RelationPicker''s formatEntityLabel (RelationPicker.vue:248) uses entityDisplayTitleWithId, which returns ''Title (ID)'' when title!=id (entityDisplay.ts:32). The backend matches on bare DisplayTitle (api_v1.go:476: DisplayTitle(...) == want). If the extracted EntityTargetSelect reflexively copies RelationPicker''s label logic, the committed filter value becomes ''Jeroen Vloothuis (PERS-001)'' which never satisfies the equality match — filter silently returns empty.'
+severity: critical
+resolution: 'Plan pins: committed value = entityDisplayTitle(entity) (bare _title, entityDisplay.ts:25), NEVER entityDisplayTitleWithId. Display label in the dropdown MAY show ''Title (ID)'' for disambiguation, but option VALUE written into localFilters[relation] must be the bare title. Component design separates ''option display label'' from ''option value''.'
+status: addressed
+---

--- a/tickets/entities/tickets/TKT-DL16XM.md
+++ b/tickets/entities/tickets/TKT-DL16XM.md
@@ -5,7 +5,7 @@ title: Relation filter_controls render as target selector (select → typeahead)
 kind: enhancement
 priority: medium
 effort: s
-status: review
+status: done
 ---
 
 ## Problem

--- a/tickets/entities/tickets/TKT-DL16XM.md
+++ b/tickets/entities/tickets/TKT-DL16XM.md
@@ -1,0 +1,133 @@
+---
+id: TKT-DL16XM
+type: ticket
+title: Relation filter_controls render as target selector (select → typeahead), not free text
+kind: enhancement
+priority: medium
+effort: s
+status: review
+---
+
+## Problem
+
+When a list config declares a relation filter:
+
+```yaml
+filter_controls:
+  - relation: verantwoordelijk_voor
+    direction: incoming
+    label: Verantwoordelijke
+```
+
+the SPA renders a **free-text input**. `FilterBar.vue` explicitly falls back to
+`widget: 'text'` for every relation filter (`resolveFilter`, ~line 44):
+
+```ts
+// Relation filters: use text input for now (could be enhanced to select with targets)
+return { key, label, widget: 'text', options: [], isRelation: true }
+```
+
+Users must *type* the target's display title exactly. For a small closed set of
+relation targets this is strictly worse than a picker.
+
+Property enum filters already collapse to `select` / `multi-select` via
+`resolveWidgetType` and render through the existing `<select>` template in the
+same component. Relation filters were left as the TODO.
+
+## Goal
+
+Relation filter controls render as a **target selector**:
+
+- **≤ N targets (N ≈ 10): plain `<select>`** — the machinery already exists in
+the template.
+- **> N targets: typeahead combobox** — reuse the search+dropdown UX already
+shipped in `RelationPicker.vue` (type to filter, first 10 shown, `+N more`).
+
+## Key correctness fact (corrects the input request)
+
+The backend relation filter matches by **display title**, NOT by entity ID.
+`App.matchRelationFilter` (`internal/dataentry/api_v1.go:476`):
+
+```go
+if svc.Meta.DisplayTitle(e.ID, e.Type, e.Properties) == want {
+```
+
+So the widget MUST send the entity's resolved display title (the `_title` field
+the API already returns per entity) as the filter value — NOT the ID. Sending an
+ID would match zero rows and return an empty list. This is the opposite of what
+the original feature-request draft assumed ("send the ID, not the title").
+
+## Where the option set comes from (no new backend)
+
+`RelationPicker.vue` already resolves candidates entirely client-side:
+
+- `loadCandidates()` walks `relationType.from` (incoming) / `relationType.to`
+(outgoing) from the schema store and calls `entitiesStore.fetchList(targetType,
+{ per_page: 100 })` per source type.
+- It filters in-memory by `id` / `_title` as the user types.
+
+The same generic `GET /api/v1/{plural}` list endpoint the picker already uses
+supplies the filter's options. **No `_filter_options` endpoint and no backend
+change is required for the atlas case.** The direction-aware relation-filter
+query pass (`applyRelationFilters`, TKT-5U7QBR) is already merged and unchanged.
+
+## Concrete need
+
+`atlas/data-entry.yaml` already ships `all_taken.filter_controls` with the
+`verantwoordelijk_voor` / `incoming` relation entry. Merging this upgrades the
+widget from text to selector with no atlas config change.
+
+## Scope
+
+**In scope**
+
+- Relation filter → `<select>` (small) or typeahead (large), value = `_title`.
+- Count-gate threshold (N ≈ 10; final value TBD in planning).
+- Extract/reuse the picker's search dropdown so FilterBar doesn't drag in the
+form's edit/save/affordance/inline-create machinery.
+- Frontend unit test + e2e.
+
+**Out of scope**
+
+- Multi-select relation filter (`filter_controls` is single-value today;
+`CurrentValue` returns one string).
+- Server-side "only-actually-populated" `_filter_options` endpoint (offer every
+target of the source type, mirroring how property enum filters offer every
+declared value). Revisit only if a source type exceeds the `per_page: 100` fetch
+ceiling and truncation becomes visible.
+- Pre-populating "my taken" from the current user (distinct UX / scope, not a
+filter widget).
+
+## Known limitations to carry forward
+
+- **Title collisions**: because matching is by title, two source entities with
+the same `DisplayTitle` collapse to one option and the filter matches both.
+Pre-existing backend behavior; the widget inherits it.
+- **100-per-type fetch ceiling**: `RelationPicker` fetches only the first 100
+candidates per source type. Fine for the atlas (dozens of persoons); a source
+type with hundreds of entities would silently truncate options — that's the
+trigger for the deferred `_filter_options` endpoint.
+
+## Acceptance criteria (draft — refine in planning)
+
+1. A `filter_controls` entry with `relation:` renders as a `<select>` (≤ N
+options) populated with the display titles of the relation's source-type
+entities.
+2. Above N options, the control renders as a typeahead combobox reusing the
+RelationPicker search UX.
+3. Selecting an option filters the list; the value SENT is the display title
+(`_title`), and the list narrows correctly (backend title-match).
+4. Empty selection = no filter.
+5. Property filters render exactly as today (no regression).
+6. `direction: outgoing` (or omitted) pulls options from the relation's `to[*]`
+types; `incoming` from `from[*]`.
+
+## Files (expected)
+
+- `frontend/src/components/lists/FilterBar.vue` — swap the text fallback; add the
+relation-select / typeahead branch.
+- `frontend/src/components/forms/RelationPicker.vue` — extract the reusable
+search-dropdown piece (or a shared child component) without the edit machinery.
+- Frontend unit test(s) + `e2e/` coverage.
+
+Backend: no change expected.

--- a/tickets/relations/TKT-DL16XM--affects--data-entry-ui.md
+++ b/tickets/relations/TKT-DL16XM--affects--data-entry-ui.md
@@ -1,0 +1,5 @@
+---
+from: TKT-DL16XM
+relation: affects
+to: data-entry-ui
+---

--- a/tickets/relations/TKT-DL16XM--has-docs--DOCS-OIUDYH.md
+++ b/tickets/relations/TKT-DL16XM--has-docs--DOCS-OIUDYH.md
@@ -1,0 +1,5 @@
+---
+from: TKT-DL16XM
+relation: has-docs
+to: DOCS-OIUDYH
+---

--- a/tickets/relations/TKT-DL16XM--has-implementation--IMPL-BJSQWA.md
+++ b/tickets/relations/TKT-DL16XM--has-implementation--IMPL-BJSQWA.md
@@ -1,0 +1,5 @@
+---
+from: TKT-DL16XM
+relation: has-implementation
+to: IMPL-BJSQWA
+---

--- a/tickets/relations/TKT-DL16XM--has-planning--PLAN-W26M30.md
+++ b/tickets/relations/TKT-DL16XM--has-planning--PLAN-W26M30.md
@@ -1,0 +1,5 @@
+---
+from: TKT-DL16XM
+relation: has-planning
+to: PLAN-W26M30
+---

--- a/tickets/relations/TKT-DL16XM--has-review--REV-EUTS6V.md
+++ b/tickets/relations/TKT-DL16XM--has-review--REV-EUTS6V.md
@@ -1,0 +1,5 @@
+---
+from: TKT-DL16XM
+relation: has-review
+to: REV-EUTS6V
+---

--- a/tickets/relations/TKT-DL16XM--has-review-response--RR-0TY8MA.md
+++ b/tickets/relations/TKT-DL16XM--has-review-response--RR-0TY8MA.md
@@ -1,0 +1,5 @@
+---
+from: TKT-DL16XM
+relation: has-review-response
+to: RR-0TY8MA
+---

--- a/tickets/relations/TKT-DL16XM--has-review-response--RR-33NE96.md
+++ b/tickets/relations/TKT-DL16XM--has-review-response--RR-33NE96.md
@@ -1,0 +1,5 @@
+---
+from: TKT-DL16XM
+relation: has-review-response
+to: RR-33NE96
+---

--- a/tickets/relations/TKT-DL16XM--has-review-response--RR-3MDVZD.md
+++ b/tickets/relations/TKT-DL16XM--has-review-response--RR-3MDVZD.md
@@ -1,0 +1,5 @@
+---
+from: TKT-DL16XM
+relation: has-review-response
+to: RR-3MDVZD
+---

--- a/tickets/relations/TKT-DL16XM--has-review-response--RR-3TJVQJ.md
+++ b/tickets/relations/TKT-DL16XM--has-review-response--RR-3TJVQJ.md
@@ -1,0 +1,5 @@
+---
+from: TKT-DL16XM
+relation: has-review-response
+to: RR-3TJVQJ
+---

--- a/tickets/relations/TKT-DL16XM--has-review-response--RR-5GU270.md
+++ b/tickets/relations/TKT-DL16XM--has-review-response--RR-5GU270.md
@@ -1,0 +1,5 @@
+---
+from: TKT-DL16XM
+relation: has-review-response
+to: RR-5GU270
+---

--- a/tickets/relations/TKT-DL16XM--has-review-response--RR-A51QQ2.md
+++ b/tickets/relations/TKT-DL16XM--has-review-response--RR-A51QQ2.md
@@ -1,0 +1,5 @@
+---
+from: TKT-DL16XM
+relation: has-review-response
+to: RR-A51QQ2
+---

--- a/tickets/relations/TKT-DL16XM--has-review-response--RR-L78S8H.md
+++ b/tickets/relations/TKT-DL16XM--has-review-response--RR-L78S8H.md
@@ -1,0 +1,5 @@
+---
+from: TKT-DL16XM
+relation: has-review-response
+to: RR-L78S8H
+---

--- a/tickets/relations/TKT-DL16XM--has-review-response--RR-NH8B6D.md
+++ b/tickets/relations/TKT-DL16XM--has-review-response--RR-NH8B6D.md
@@ -1,0 +1,5 @@
+---
+from: TKT-DL16XM
+relation: has-review-response
+to: RR-NH8B6D
+---

--- a/tickets/relations/TKT-DL16XM--has-review-response--RR-SFRV0T.md
+++ b/tickets/relations/TKT-DL16XM--has-review-response--RR-SFRV0T.md
@@ -1,0 +1,5 @@
+---
+from: TKT-DL16XM
+relation: has-review-response
+to: RR-SFRV0T
+---

--- a/tickets/relations/TKT-DL16XM--has-review-response--RR-TE8HA6.md
+++ b/tickets/relations/TKT-DL16XM--has-review-response--RR-TE8HA6.md
@@ -1,0 +1,5 @@
+---
+from: TKT-DL16XM
+relation: has-review-response
+to: RR-TE8HA6
+---

--- a/tickets/relations/TKT-DL16XM--has-review-response--RR-X4QWBF.md
+++ b/tickets/relations/TKT-DL16XM--has-review-response--RR-X4QWBF.md
@@ -1,0 +1,5 @@
+---
+from: TKT-DL16XM
+relation: has-review-response
+to: RR-X4QWBF
+---

--- a/tickets/relations/TKT-DL16XM--implements--FEAT-024.md
+++ b/tickets/relations/TKT-DL16XM--implements--FEAT-024.md
@@ -1,0 +1,5 @@
+---
+from: TKT-DL16XM
+relation: implements
+to: FEAT-024
+---


### PR DESCRIPTION
## What

Relation `filter_controls` in the data-entry SPA now render as a **target selector** instead of a free-text input:

- **≤10 options** → native `<select>` of target display titles
- **>10 options** → typeahead combobox (reuses the RelationPicker search UX)

Before, users had to *type* a relation target's display title exactly (guess-the-name). Now they pick from a dropdown.

## Why the value sent is the display title, not the ID

The backend relation filter matches on `DisplayTitle` (`internal/dataentry/api_v1.go` `matchRelationFilter`), **not** entity ID. So the widget commits the target's **bare display title** (`entityDisplayTitle`, i.e. `_title`) — sending an ID would match zero rows. Options are fetched client-side from the relation's source types (`from[*]` for `incoming`, `to[*]` for `outgoing`) via the same list endpoint `RelationPicker` already uses. **No backend change.**

## Changes

- **New** `frontend/src/components/common/EntityTargetSelect.vue` — reusable single-value entity-target selector (select + typeahead modes); committed value is the bare title, search state is component-local.
- `FilterBar.vue` — relation branch: fetch candidates (reactive to config via `watch`), count-gate at 10, per-control error handling with toast on failure.
- `types/entity.ts` (shared `TargetCandidate`), `types/config.ts` (`direction` on `FilterControl`).
- Docs: `docs-project/entities/guides/GUIDE-data-entry.md` (+ regenerated `docs/data-entry.md`).

## Testing

- Frontend unit: `EntityTargetSelect.test.ts` + `FilterBar.test.ts` (29 tests) — bare-title-as-value, select/typeahead gating, direction→from/to, deep-link placeholder for values absent from candidates, search-vs-committed separation, cancelled-fetch-doesn't-block-siblings, error toast.
- e2e: `list.spec.ts` — relation filter narrows the task list to the implementing task against the real server.
- Full suite: 1188 frontend unit tests, e2e Filtering group 5/5, `just ci` green.

## Review

Went through design + code review (rela ticket TKT-DL16XM). Two critical findings caught and fixed: the wire format (`filter[<rel>]`, verified via e2e) and the title-not-id value; a deep-link value beyond the fetch cap that would have shown the select as blank while still filtering (fixed with a placeholder option).

## Known limitations (documented)

- Title collisions collapse to one option (backend matches both).
- Candidate list truncated at ~100 per source type.
- Multi-select relation filter and a server-side `_filter_options` endpoint are out of scope.