### PR TITLE
fix(metamodel): accept top-level attachments: key in loader (BUG-5XIN07)

### DIFF
--- a/internal/dataentry/handlers_attachment_write_test.go
+++ b/internal/dataentry/handlers_attachment_write_test.go
@@ -7,10 +7,14 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/Sourcehaven-BV/rela/internal/acl"
 	v1 "github.com/Sourcehaven-BV/rela/internal/apiwire/v1"
+	"github.com/Sourcehaven-BV/rela/internal/attachment"
+	"github.com/Sourcehaven-BV/rela/internal/dataentryconfig"
 	"github.com/Sourcehaven-BV/rela/internal/entity"
+	"github.com/Sourcehaven-BV/rela/internal/metamodel"
 	"github.com/Sourcehaven-BV/rela/internal/principal"
 	"github.com/Sourcehaven-BV/rela/internal/store"
 )
@@ -416,5 +420,116 @@ func TestAttachmentDelete_MultiLeavesSiblings(t *testing.T) {
 	g := getAttachmentAs(aliceCtx(), t, app, d, "ticket", "tickets", "TKT-001", "docs", "b.txt")
 	if g.Code != http.StatusOK || g.Body.String() != "b" {
 		t.Errorf("sibling b.pdf must survive; GET got %d body=%q", g.Code, g.Body)
+	}
+}
+
+// globalAttachmentsMetamodelYAML is a real metamodel with a *global*
+// top-level `attachments:` block (allow: + scan_cmd:). The `report` file
+// property deliberately sets neither accept nor scan_cmd, so both the MIME
+// allowlist and the scan command must fall through from the global block.
+//
+// The scan_cmd is a stub shell command that exits non-zero (reject) when the
+// uploaded bytes contain the marker "INFECTED", and zero (clean) otherwise.
+const globalAttachmentsMetamodelYAML = `
+version: "1.0"
+types: {}
+relations: {}
+entities:
+  ticket:
+    label: Ticket
+    id_prefix: "TKT-"
+    id_type: sequential
+    properties:
+      title:
+        type: string
+        required: true
+      report:
+        type: file
+attachments:
+  allow: [text/plain]
+  scan_cmd: ["sh", "-c", '! grep -q INFECTED "$1"', "sh", "{in}"]
+`
+
+// newGlobalAttachmentsApp builds an App whose metamodel is parsed from
+// globalAttachmentsMetamodelYAML through the real loader (metamodel.Parse) —
+// so these HTTP integration tests transitively depend on the BUG-5XIN07
+// whitelist fix: revert it and Parse rejects the `attachments:` key here,
+// failing this helper before any upload runs. A real command runner is wired
+// so the global scan command actually executes on the upload path.
+func newGlobalAttachmentsApp(t *testing.T) (*App, *acl.Declarative) {
+	t.Helper()
+
+	meta, err := metamodel.Parse([]byte(globalAttachmentsMetamodelYAML))
+	if err != nil {
+		t.Fatalf("parse global-attachments metamodel: %v", err)
+	}
+
+	cfg := &dataentryconfig.Config{
+		App:        dataentryconfig.AppConfig{Name: "Test App"},
+		Forms:      make(map[string]dataentryconfig.Form),
+		Lists:      make(map[string]dataentryconfig.List),
+		Views:      make(map[string]dataentryconfig.ViewConfig),
+		Kanbans:    make(map[string]dataentryconfig.Kanban),
+		Navigation: []dataentryconfig.NavigationEntry{},
+	}
+
+	app := newAppFromParts(cfg, meta, newFixture())
+	runner, err := attachment.NewCmdRunner(5*time.Second, store.MaxAttachmentBytes)
+	if err != nil {
+		t.Fatalf("NewCmdRunner: %v", err)
+	}
+	app.attachmentRunner = runner
+
+	d := writeACL(t, app)
+	app.acl = d
+	seedEntity(app, &entity.Entity{ID: "TKT-001", Type: "ticket", Properties: map[string]any{"title": "T1"}})
+	return app, d
+}
+
+// TestAttachmentUpload_GlobalAllowlistEnforced is an end-to-end guard that the
+// global `attachments.allow:` block gates uploads through the real HTTP handler
+// (not via a per-property Accept). A text file passes; a PNG (sniffs as
+// image/png, not in the allowlist) is rejected 422. Regression coverage for
+// BUG-5XIN07: the metamodel here is parsed through the real loader (see
+// newGlobalAttachmentsApp), so reverting the whitelist fix fails this test at
+// parse time; no prior test round-tripped the global allowlist through the
+// upload path.
+func TestAttachmentUpload_GlobalAllowlistEnforced(t *testing.T) {
+	app, d := newGlobalAttachmentsApp(t)
+
+	ok := putAttachmentAs(aliceCtx(), t, app, d, "TKT-001", "report", "clean.txt", []byte("hello"))
+	if ok.Code != http.StatusOK {
+		t.Fatalf("allowed text upload: got %d, want 200; body=%s", ok.Code, ok.Body)
+	}
+
+	// A real PNG header sniffs as image/png, which the global allowlist omits.
+	png := []byte("\x89PNG\r\n\x1a\n\x00\x00\x00\x0dIHDR")
+	bad := putAttachmentAs(aliceCtx(), t, app, d, "TKT-001", "report", "pic.png", png)
+	if bad.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("disallowed png upload: got %d, want 422; body=%s", bad.Code, bad.Body)
+	}
+}
+
+// TestAttachmentUpload_GlobalScanCmdRejects is an end-to-end guard that the
+// global `attachments.scan_cmd:` runs on the upload path and rejects an
+// "infected" file. A clean text file passes; a text file containing the
+// marker the stub scanner flags is rejected. Both go through the same real
+// HTTP handler + policy processor + command runner as production.
+func TestAttachmentUpload_GlobalScanCmdRejects(t *testing.T) {
+	app, d := newGlobalAttachmentsApp(t)
+
+	clean := putAttachmentAs(aliceCtx(), t, app, d, "TKT-001", "report", "clean.txt", []byte("all good"))
+	if clean.Code != http.StatusOK {
+		t.Fatalf("clean upload: got %d, want 200; body=%s", clean.Code, clean.Body)
+	}
+
+	infected := putAttachmentAs(aliceCtx(), t, app, d, "TKT-001", "report", "virus.txt", []byte("contains INFECTED payload"))
+	if infected.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("scanned-reject upload: got %d, want 422; body=%s", infected.Code, infected.Body)
+	}
+	// The rejected upload must not overwrite the clean attachment.
+	get := getAttachmentAs(aliceCtx(), t, app, d, "ticket", "tickets", "TKT-001", "report", "clean.txt")
+	if get.Code != http.StatusOK || get.Body.String() != "all good" {
+		t.Errorf("clean attachment must survive a rejected scan; GET got %d body=%q", get.Code, get.Body)
 	}
 }

--- a/internal/metamodel/loader.go
+++ b/internal/metamodel/loader.go
@@ -22,6 +22,7 @@ var validTopLevelKeys = map[string]bool{
 	"validations": true,
 	"automations": true,
 	"includes":    true,
+	"attachments": true,
 }
 
 // knownTypos maps common misspellings to the correct key name.

--- a/internal/metamodel/loader_test.go
+++ b/internal/metamodel/loader_test.go
@@ -6,6 +6,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -880,6 +881,67 @@ widgets:
 				t.Errorf("expected error containing %q, got: %v", tt.wantErr, err)
 			}
 		})
+	}
+}
+
+// TestParse_AttachmentsTopLevelKeyAccepted is the regression guard for
+// BUG-5XIN07: a documented top-level `attachments:` block must round-trip
+// through the real loader (not just unmarshal into the struct — the whitelist
+// in checkUnknownKeys is a separate gate that this exercises). Asserting the
+// parsed Attachments field is populated proves the wiring, not merely that no
+// error was returned.
+func TestParse_AttachmentsTopLevelKeyAccepted(t *testing.T) {
+	yaml := `
+version: "1.0"
+entities:
+  requirement:
+    label: Requirement
+    id_prefix: "REQ-"
+    id_type: sequential
+    properties:
+      title:
+        type: string
+types: {}
+relations: {}
+attachments:
+  allow: [image/png]
+  scan_cmd: [clamdscan, --no-summary, --fdpass, "{in}"]
+`
+	m, err := Parse([]byte(yaml))
+	if err != nil {
+		t.Fatalf("valid attachments block rejected: %v", err)
+	}
+	if m.Attachments == nil {
+		t.Fatal("attachments block parsed but Attachments field is nil")
+	}
+	if got, want := m.Attachments.Allow, []string{"image/png"}; len(got) != len(want) || got[0] != want[0] {
+		t.Errorf("attachments.allow = %v, want %v", got, want)
+	}
+	if len(m.Attachments.ScanCmd) == 0 || m.Attachments.ScanCmd[0] != "clamdscan" {
+		t.Errorf("attachments.scan_cmd = %v, want it to start with clamdscan", m.Attachments.ScanCmd)
+	}
+}
+
+// TestValidTopLevelKeysMatchStruct closes the systemic root cause of BUG-5XIN07:
+// validTopLevelKeys is a hand-maintained duplicate of the Metamodel struct's
+// top-level yaml tags, and the two silently drifted (the attachments field was
+// added without its whitelist entry). This asserts every top-level yaml tag on
+// the struct is whitelisted, so a future top-level field cannot be rejected by
+// its own loader without failing this test first.
+func TestValidTopLevelKeysMatchStruct(t *testing.T) {
+	for field := range reflect.TypeFor[Metamodel]().Fields() {
+		tag := field.Tag.Get("yaml")
+		if tag == "" || tag == "-" {
+			continue // computed field, not loaded from YAML
+		}
+		key := strings.Split(tag, ",")[0]
+		if key == "" {
+			continue
+		}
+		if !validTopLevelKeys[key] {
+			t.Errorf("Metamodel field %q (yaml:%q) is not in validTopLevelKeys — "+
+				"the loader will reject a metamodel that uses it", field.Name, key)
+		}
 	}
 }
 

--- a/tickets/entities/automated-measures/metamodel-toplevel-key-whitelist-parity-test.md
+++ b/tickets/entities/automated-measures/metamodel-toplevel-key-whitelist-parity-test.md
@@ -1,0 +1,9 @@
+---
+id: metamodel-toplevel-key-whitelist-parity-test
+type: automated-measure
+title: 'Test: metamodel top-level yaml keys stay in sync with validTopLevelKeys'
+description: Regression + prevention for BUG-5XIN07. TestValidTopLevelKeysMatchStruct uses reflection to assert every top-level `yaml` tag on the metamodel.Metamodel struct is present in validTopLevelKeys, so a newly-added top-level struct field can never be silently rejected by the loader's checkUnknownKeys. TestParse_AttachmentsTopLevelKeyAccepted pins the specific `attachments:` case round-tripping through Parse(). Two data-entry HTTP tests (TestAttachmentUpload_GlobalAllowlistEnforced/GlobalScanCmdRejects) parse a real metamodel with a global attachments block through the loader, so they also fail at parse time if the whitelist entry is removed.
+kind: test
+location: internal/metamodel/loader_test.go (TestValidTopLevelKeysMatchStruct, TestParse_AttachmentsTopLevelKeyAccepted); internal/dataentry/handlers_attachment_write_test.go (TestAttachmentUpload_GlobalAllowlistEnforced, TestAttachmentUpload_GlobalScanCmdRejects)
+status: active
+---

--- a/tickets/entities/bug-analysis-checklists/BUGA-JVVOSU.md
+++ b/tickets/entities/bug-analysis-checklists/BUGA-JVVOSU.md
@@ -1,0 +1,59 @@
+---
+id: BUGA-JVVOSU
+type: bug-analysis-checklist
+title: 'Analysis: attachments: top-level key rejected by metamodel loader'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Reproduction
+
+- [x] Bug reproduced locally
+- [x] Minimal reproduction steps documented
+- [x] Environment/conditions noted
+
+**Steps:** Parse a metamodel containing a valid top-level `attachments:` block
+(per `docs/attachment-security.md`), e.g. `attachments: { scan_cmd: [clamdscan,
+--no-summary, --fdpass, "{in}"] }`, then `rela validate` / `Parse`.
+
+**Observed:** `SchemaValidationError: unknown key "attachments" (valid keys:
+automations, entities, includes, namespace, relations, types, validations,
+version)`. Confirmed via a throwaway test against `internal/metamodel.Parse`.
+The whole project fails to load.
+
+## Feature-is-live verification (per user challenge)
+
+The `attachments:` block is **not dead config** — both sub-features are wired:
+
+- **`attachments.allow:`** (global MIME allowlist) — enforced on BOTH the CLI and data-entry paths. `internal/attachment/policy.go:50-52` (nil-runner-safe native step).
+- **`attachments.scan_cmd:`** (global scan fallback) — enforced on the **data-entry HTTP upload path only**. `internal/dataentry/app.go:568` wires a real `CmdRunner` into `NewPolicyProcessor` at `handlers_attachment.go:302`; `internal/metamodel/attachments.go:103-104` uses the global cmd as the per-property fallback. The **CLI path wires `nil`** (`internal/cli/cli_wiring.go:144`), so `scan_cmd` does not run under `rela attach` (allowlist still does).
+
+Conclusion: the feature works; the loader whitelist is the single broken link.
+Fix is correct, not a paper-over.
+
+## Root Cause (5-whys)
+
+- why1: `checkUnknownKeys` (`loader.go:745`) rejects `attachments` — absent from `validTopLevelKeys` (`loader.go:16`).
+- why2: Commit `5574ce01` (#1026) added the `Attachments` struct field + validator but not the whitelist entry.
+- why3: The whitelist is a hand-maintained duplicate of the struct's top-level yaml tags; they can drift.
+- why4: No test loads a full metamodel with a top-level `attachments:` block through the real `Parse()` path. Every attachment test builds `AttachmentsConfig`/`Metamodel` as a **Go struct literal** (`policy_test.go:17`, `newTestAppV1` in `api_v1_test.go:2669`), bypassing the whitelist; or exercises per-property `file` config (already whitelisted). No CLI/e2e for the config path.
+- why5 (systemic): allow-list validation is decoupled from the type it validates, and the feature's tests validate behavior via struct literals rather than round-tripping real YAML, so a wiring gap between a live documented feature and its parser is invisible to CI.
+
+## Fix Planning
+
+- [x] Fix approach determined
+- [x] Regression test planned
+- [x] Related areas checked for similar issues
+
+**Fix:** add `"attachments": true` to `validTopLevelKeys` (`loader.go:16`).
+
+**Tests (preventive measures — the `adds-measure` requirement):**
+
+1. `internal/metamodel/loader_test.go` — `TestParse_AttachmentsTopLevelKeyAccepted`: a real metamodel with a top-level `attachments: { allow, scan_cmd }` block round-trips through `Parse()` with no error AND the parsed `Attachments` field is populated (asserts wiring). **This is the test that actually catches this bug** — the HTTP test below uses struct literals and would pass even with the bug present.
+2. `internal/metamodel/loader_test.go` — `TestValidTopLevelKeysMatchStruct`: reflection parity test asserting every top-level `yaml` tag on the `Metamodel` struct is in `validTopLevelKeys`. Closes the systemic drift class (why4/why5) so no future top-level field can silently drift.
+3. `internal/dataentry/handlers_attachment_write_test.go` — extend the existing httptest upload pattern (`newTestAppV1` + `multipartBody`) to prove the **global** `attachments: { allow, scan_cmd }` config is enforced end-to-end through the real HTTP handler: a disallowed MIME is rejected (422) and a stub shell `scan_cmd` that exits non-zero rejects the upload. This is the established data-entry test pattern (httptest handler integration, used across 20+ files), chosen over a new CLI/Playwright harness.
+
+**Related areas checked:** `attachments` is the only top-level struct field
+missing from the whitelist (verified against the struct's yaml tags). No other
+drift.

--- a/tickets/entities/bugs/BUG-5XIN07.md
+++ b/tickets/entities/bugs/BUG-5XIN07.md
@@ -1,0 +1,31 @@
+---
+id: BUG-5XIN07
+type: bug
+title: 'attachments: top-level key rejected by metamodel loader'
+description: |-
+    The `attachments:` config block documented in `docs/attachment-security.md` is unmarshalled correctly by the metamodel struct (`internal/metamodel/types.go` — `Attachments *AttachmentsConfig "yaml:attachments,omitempty"`), but the loader's `checkUnknownKeys` validator rejects it because `attachments` is missing from `validTopLevelKeys` in `internal/metamodel/loader.go:16`.
+
+    Error: `unknown key "attachments" (valid keys: automations, entities, includes, namespace, relations, types, validations, version)`.
+
+    Reproduce: add any valid `attachments:` block per the docs (e.g. `attachments: { scan_cmd: [clamdscan, --no-summary, --fdpass, "{in}"] }`) and run `rela validate` — fails.
+
+    Fix: add `"attachments": true` to `validTopLevelKeys`.
+
+    Introduced in 5574ce01 `feat(attachments): cmd: processing pipeline + native MIME validation (#1026)` — the struct field and the `checkUnknownKeys` validator were both added, but the top-level key whitelist was not updated.
+
+    Impact: any user following the attachment-security docs cannot enable ClamAV scanning or a global MIME allowlist — the whole project fails to load.
+priority: high
+effort: xs
+why1: checkUnknownKeys (internal/metamodel/loader.go) rejected the top-level `attachments:` key because it was absent from the validTopLevelKeys whitelist, even though the Metamodel struct has an Attachments field and the feature is fully wired.
+why2: Commit 5574ce01 (#1026) added the Attachments struct field and the checkUnknownKeys validator but did not add the matching `attachments` entry to the validTopLevelKeys whitelist.
+why3: validTopLevelKeys is a hand-maintained duplicate of the Metamodel struct's top-level yaml tags; the two are decoupled, so a newly-added field silently drifts out of sync with the validator with nothing binding them.
+why4: No test loads a full metamodel with a top-level `attachments:` block through the real Parse()/checkUnknownKeys path. Every attachment test either builds `AttachmentsConfig` as a Go struct literal (internal/attachment/policy_test.go:17) — bypassing the whitelist — or exercises per-property `file` config (which IS whitelisted). There is no CLI test and no Playwright e2e for the scan/allowlist config path. The tests cover AttachmentsConfig *behavior* but never the YAML->struct *wiring*.
+why5: Structural allow-list validation (validTopLevelKeys) is a hand-maintained duplicate of the Metamodel struct's top-level yaml tags, with no parity check binding them; and the feature's tests validate behavior via struct literals rather than round-tripping real YAML through the loader, so a wiring gap between a live, documented feature and its config parser is invisible to CI.
+prevention: |-
+    Root cause: a hand-maintained allow-list (validTopLevelKeys) duplicated the Metamodel struct's top-level yaml tags with nothing binding them, and the attachment feature's tests validated behavior via Go struct literals rather than round-tripping real YAML through the loader — so a new top-level field could be silently rejected by its own parser with no test failing.
+
+    Prevention shipped: added TestValidTopLevelKeysMatchStruct (reflection parity — every top-level yaml tag on Metamodel must be whitelisted), so any future top-level field that isn't whitelisted fails CI at unit level. Added a loader round-trip test and two data-entry HTTP tests that parse a real metamodel with a global attachments block, so the config path is exercised through the actual loader end-to-end.
+
+    Process prevention: filed TKT-ELX09J to apply the same reflection-parity pattern to the two sibling loaders that share this footgun (internal/dataentryconfig/validate.go, internal/acl/policy.go).
+status: done
+---

--- a/tickets/entities/implementation-checklists/IMPL-EKKU9N.md
+++ b/tickets/entities/implementation-checklists/IMPL-EKKU9N.md
@@ -1,0 +1,52 @@
+---
+id: IMPL-EKKU9N
+type: implementation-checklist
+title: 'Implementation: attachments: top-level key rejected by metamodel loader'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Development
+
+- [x] Unit tests written for new code (loader round-trip + reflection parity)
+- [x] Integration tests written (HTTP upload through the real handler for global allow: + scan_cmd:)
+- [x] Happy path implemented (`"attachments": true` in validTopLevelKeys)
+- [x] Edge cases from planning handled (global-config fall-through: property sets neither Accept nor ScanCmd)
+- [x] ~~Error handling in place~~ (N/A: additive whitelist entry; no new error paths)
+
+## Test Quality
+
+- [x] Using fixture builders (`newAppFromParts`/`newGlobalAttachmentsApp`, `multipartBody`, existing writeACL/seedEntity helpers)
+- [x] No hardcoded values in assertions when object is in scope
+- [x] Only specifying values that matter for the test
+- [x] ~~Interpolated values constructed from objects~~ (N/A: fixed fixture IDs, matches package convention)
+- [x] Property comparisons use returned bytes / codes, not incidental strings
+
+## Manual Verification
+
+- [x] Feature manually tested end-to-end
+- [x] Each acceptance criterion verified
+- [x] Edge cases manually verified
+
+**Verification Evidence:**
+
+- **AC1 — `rela validate` accepts the block:** built `cmd/rela`, ran `rela --project <tmp> validate` against a project whose `metamodel.yaml` has `attachments: { allow: [image/png, text/plain], scan_cmd: [clamdscan, ...] }`. Result: `✓ metamodel.yaml is valid`, exit 0. Before the fix this failed with `unknown key "attachments"`.
+- **AC2 — tests catch the bug:** temporarily reverted the one-line fix; `TestParse_AttachmentsTopLevelKeyAccepted` and `TestValidTopLevelKeysMatchStruct` both FAILED with the exact `unknown key "attachments"` error. Restored fix → both pass.
+- **AC3 — parity test guards the class:** `TestValidTopLevelKeysMatchStruct` fails if any top-level `Metamodel` yaml tag is missing from `validTopLevelKeys` (verified by the revert above).
+- **AC4 — global allow: enforced end-to-end:** `TestAttachmentUpload_GlobalAllowlistEnforced` — text upload → 200, PNG upload → 422, through the real HTTP handler with no per-property Accept.
+- **AC5 — global scan_cmd: enforced end-to-end:** `TestAttachmentUpload_GlobalScanCmdRejects` — clean text → 200, "INFECTED" text → 422; rejected upload does not overwrite the clean attachment. Proved the *scan* (not the allowlist) is the rejecting mechanism by re-running with `attachmentRunner=nil` → infected file then passes.
+
+**Automated checks:** `go build ./...` OK; `go test ./...` all pass (one
+transient `internal/storage` fsnotify watcher-timeout flake, unrelated to
+changed packages — passes 3/3 in isolation); `golangci-lint run` on changed
+packages → 0 issues; `just coverage-check` → thresholds PASS (metamodel 82.6%,
+dataentry 79.9%, attachment 72.3%).
+
+## Quality
+
+- [x] Code follows project patterns (extended existing httptest attachment-upload pattern; table-free single-purpose tests like siblings; modern `reflect.TypeFor`/`Type.Fields()` idiom)
+- [x] Checked for DRY (`newGlobalAttachmentsApp` factors the shared app+runner+ACL+seed setup for the two HTTP subtests; reused `multipartBody`/`putAttachmentAs`/`writeACL`/`seedEntity`)
+- [x] No security issues introduced (whitelist entry only *enables* a validation path that already exists; scan stub uses array-arg exec, no shell string)
+- [x] No silent failures
+- [x] No debug code left behind (throwaway repro tests removed)

--- a/tickets/entities/review-checklists/REV-0YE2UH.md
+++ b/tickets/entities/review-checklists/REV-0YE2UH.md
@@ -1,0 +1,60 @@
+---
+id: REV-0YE2UH
+type: review-checklist
+title: 'Review: attachments: top-level key rejected by metamodel loader'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Automated Checks
+
+- [x] All tests pass (`go test ./...` + `just ci` green; CI matrix green except the ticket-status gate resolved by this transition)
+- [x] Lint clean (`golangci-lint run` → 0 issues; CI Lint/Architecture/God-object pass)
+- [x] Coverage maintained (`just coverage-check` → thresholds PASS)
+
+## Code Review
+
+- [x] Run `/code-review` (cranky-code-reviewer) — no critical issues; 1 significant, 1 minor, plus nits
+- [x] ~~All critical review-responses addressed~~ (N/A: none raised)
+- [x] All significant review-responses addressed (RR-G4A0Z1 — fixed)
+- [x] Self-reviewed the diff for unrelated changes (only loader.go + 2 test files touched)
+
+**Review Responses:**
+
+- **RR-G4A0Z1** (significant) — *addressed*. HTTP tests originally used a struct-literal metamodel, so they didn't depend on the loader fix. Rewrote `newGlobalAttachmentsApp` to parse from a real YAML string via `metamodel.Parse`. Verified: reverting the fix now fails both HTTP tests at parse time with `unknown key "attachments"`.
+- **RR-GHDQXC** (minor) — *deferred*. Sibling loaders (`dataentryconfig`, `acl`) share the same whitelist-drift class; reviewer flagged as out-of-scope follow-up. Filed **TKT-ELX09J**.
+- Nits (`slices.Equal`, `sh`/`grep` non-Windows) — acknowledged, no change (POSIX-targeted, three-lines-beats-abstraction).
+
+## Acceptance Verification
+
+**Acceptance Status:**
+
+- **AC1 — `rela validate` accepts the block:** PASS. Built `cmd/rela`, validated a project with `attachments: {allow, scan_cmd}` → `✓ valid`, exit 0.
+- **AC2 — regression tests fail without the fix:** PASS. All 4 tests fail on revert (2 loader tests, 2 HTTP tests) with the exact `unknown key "attachments"` error; pass with fix.
+- **AC3 — parity test guards the class:** PASS. `TestValidTopLevelKeysMatchStruct` catches any top-level struct field missing from the whitelist.
+- **AC4 — global allow: enforced end-to-end:** PASS. `TestAttachmentUpload_GlobalAllowlistEnforced` (text 200, PNG 422 via HTTP).
+- **AC5 — global scan_cmd: enforced end-to-end:** PASS. `TestAttachmentUpload_GlobalScanCmdRejects` (clean 200, INFECTED 422; scan proven to be the rejecting mechanism).
+
+- [x] Each acceptance criterion tested
+- [x] Test evidence documented in implementation checklist (IMPL-EKKU9N)
+
+## Documentation (enhancements only)
+
+- [x] ~~Docs-checklist~~ (N/A: bug fix, no user-facing behavior change — docs already document `attachments:`; this makes them work)
+- [x] ~~User-facing documentation updated~~ (N/A)
+- [x] ~~Docs-checklist marked as done~~ (N/A)
+
+## Final Checks
+
+- [x] Commit message explains the why, not just what
+- [x] No TODOs or FIXMEs left unaddressed
+- [x] Ready for another developer to use
+
+## Pull Request
+
+- [x] Run `/pr` command to create PR and monitor CI
+- [x] All CI checks pass (full matrix green: cross-compile ×8, Frontend, Fuzz, God-object, Architecture, CodeQL, Analyze; the "Rela Tickets" gate is resolved by this done-transition; local `just ci` green)
+- [x] PR URL documented below
+
+**PR:** https://github.com/sourcehaven-bv/rela/pull/1097

--- a/tickets/entities/review-responses/RR-G4A0Z1.md
+++ b/tickets/entities/review-responses/RR-G4A0Z1.md
@@ -1,0 +1,9 @@
+---
+id: RR-G4A0Z1
+type: review-response
+title: HTTP tests use struct-literal metamodel, don't depend on loader fix
+finding: 'newGlobalAttachmentsApp builds the Metamodel as a Go struct literal and injects via newAppFromParts, so Parse()/checkUnknownKeys is never called. Reverting the production whitelist fix leaves both HTTP tests (TestAttachmentUpload_GlobalAllowlistEnforced / GlobalScanCmdRejects) passing. Their doc comments claim ''without the loader fix such a metamodel can''t load at all'', which is true of a real deployment but false of the test. Fix: build the helper''s metamodel via metamodel.Parse([]byte(...)) so the integration tests also transitively depend on the whitelist entry (and the comment becomes accurate).'
+severity: significant
+resolution: 'Rewrote newGlobalAttachmentsApp to parse its metamodel from a real YAML string via metamodel.Parse (const globalAttachmentsMetamodelYAML) instead of a Go struct literal. The two HTTP integration tests now transitively depend on the whitelist fix. Verified: with the loader fix reverted, both tests fail at parse time with `unknown key "attachments"`. Updated the test doc comments to reflect the now-accurate linkage (fail at parse time, not just ''a real deployment'').'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-GHDQXC.md
+++ b/tickets/entities/review-responses/RR-GHDQXC.md
@@ -1,0 +1,9 @@
+---
+id: RR-GHDQXC
+type: review-response
+title: Sibling loaders (dataentryconfig, acl) share the same whitelist-drift class
+finding: internal/dataentryconfig/validate.go (validTopLevelKeys) and internal/acl/policy.go (knownPolicyKeys) use the same hand-maintained-whitelist-vs-struct pattern that caused BUG-5XIN07, with no reflection-parity test. Out of scope for this bug, but a follow-up should apply the same parity-test pattern there. Prevention material.
+severity: minor
+reason: Out of scope for this bug (reviewer explicitly flagged as follow-up material, not a defect in this change). Filed as TKT-ELX09J to apply the same reflection-parity test to internal/dataentryconfig/validate.go and internal/acl/policy.go.
+status: deferred
+---

--- a/tickets/entities/tickets/TKT-ELX09J.md
+++ b/tickets/entities/tickets/TKT-ELX09J.md
@@ -1,0 +1,40 @@
+---
+id: TKT-ELX09J
+type: ticket
+title: Apply whitelist-vs-struct parity tests to dataentryconfig + acl loaders
+kind: test
+priority: low
+effort: xs
+status: backlog
+---
+
+## Problem
+
+BUG-5XIN07 was caused by a top-level-key whitelist (`validTopLevelKeys`)
+drifting from the `Metamodel` struct's yaml tags — a new struct field was added
+without its whitelist entry, so the loader rejected valid config. That bug added
+a reflection-parity test (`TestValidTopLevelKeysMatchStruct`) to guard the
+metamodel loader.
+
+The **same hand-maintained-whitelist-vs-struct pattern** exists in two sibling
+loaders with no parity guard:
+
+- `internal/dataentryconfig/validate.go` (`validTopLevelKeys`)
+- `internal/acl/policy.go` (`knownPolicyKeys`)
+
+## What we want
+
+Apply the same reflection-parity test to both: assert every top-level `yaml` tag
+on the corresponding config struct is present in its whitelist, so a newly-added
+struct field cannot be silently rejected by its own loader.
+
+## Scope
+
+- Add a parity test in each package mirroring `internal/metamodel/loader_test.go:TestValidTopLevelKeysMatchStruct`.
+- Skip fields with empty or `-` yaml tags (computed fields).
+- If either whitelist already diverges from its struct, fix the divergence (that would itself be a latent bug).
+
+## Origin
+
+Surfaced by the cranky-code-reviewer during BUG-5XIN07 review (RR-GHDQXC).
+Prevention material for the 5-whys systemic cause.

--- a/tickets/relations/BUG-5XIN07--adds-measure--metamodel-toplevel-key-whitelist-parity-test.md
+++ b/tickets/relations/BUG-5XIN07--adds-measure--metamodel-toplevel-key-whitelist-parity-test.md
@@ -1,0 +1,5 @@
+---
+from: BUG-5XIN07
+relation: adds-measure
+to: metamodel-toplevel-key-whitelist-parity-test
+---

--- a/tickets/relations/BUG-5XIN07--affects--metamodel-types.md
+++ b/tickets/relations/BUG-5XIN07--affects--metamodel-types.md
@@ -1,0 +1,5 @@
+---
+from: BUG-5XIN07
+relation: affects
+to: metamodel-types
+---

--- a/tickets/relations/BUG-5XIN07--caused-by--metamodel-types.md
+++ b/tickets/relations/BUG-5XIN07--caused-by--metamodel-types.md
@@ -1,0 +1,5 @@
+---
+from: BUG-5XIN07
+relation: caused-by
+to: metamodel-types
+---

--- a/tickets/relations/BUG-5XIN07--fixes--FEAT-KTZJIV.md
+++ b/tickets/relations/BUG-5XIN07--fixes--FEAT-KTZJIV.md
@@ -1,0 +1,5 @@
+---
+from: BUG-5XIN07
+relation: fixes
+to: FEAT-KTZJIV
+---

--- a/tickets/relations/BUG-5XIN07--has-bug-analysis--BUGA-JVVOSU.md
+++ b/tickets/relations/BUG-5XIN07--has-bug-analysis--BUGA-JVVOSU.md
@@ -1,0 +1,5 @@
+---
+from: BUG-5XIN07
+relation: has-bug-analysis
+to: BUGA-JVVOSU
+---

--- a/tickets/relations/BUG-5XIN07--has-implementation--IMPL-EKKU9N.md
+++ b/tickets/relations/BUG-5XIN07--has-implementation--IMPL-EKKU9N.md
@@ -1,0 +1,5 @@
+---
+from: BUG-5XIN07
+relation: has-implementation
+to: IMPL-EKKU9N
+---

--- a/tickets/relations/BUG-5XIN07--has-review--REV-0YE2UH.md
+++ b/tickets/relations/BUG-5XIN07--has-review--REV-0YE2UH.md
@@ -1,0 +1,5 @@
+---
+from: BUG-5XIN07
+relation: has-review
+to: REV-0YE2UH
+---

--- a/tickets/relations/BUG-5XIN07--has-review-response--RR-G4A0Z1.md
+++ b/tickets/relations/BUG-5XIN07--has-review-response--RR-G4A0Z1.md
@@ -1,0 +1,5 @@
+---
+from: BUG-5XIN07
+relation: has-review-response
+to: RR-G4A0Z1
+---

--- a/tickets/relations/BUG-5XIN07--has-review-response--RR-GHDQXC.md
+++ b/tickets/relations/BUG-5XIN07--has-review-response--RR-GHDQXC.md
@@ -1,0 +1,5 @@
+---
+from: BUG-5XIN07
+relation: has-review-response
+to: RR-GHDQXC
+---

--- a/tickets/relations/TKT-ELX09J--affects--metamodel-types.md
+++ b/tickets/relations/TKT-ELX09J--affects--metamodel-types.md
@@ -1,0 +1,5 @@
+---
+from: TKT-ELX09J
+relation: affects
+to: metamodel-types
+---

--- a/tickets/relations/TKT-ELX09J--implements--FEAT-57oh.md
+++ b/tickets/relations/TKT-ELX09J--implements--FEAT-57oh.md
@@ -1,0 +1,5 @@
+---
+from: TKT-ELX09J
+relation: implements
+to: FEAT-57oh
+---

--- a/tickets/relations/metamodel-toplevel-key-whitelist-parity-test--protects--metamodel-types.md
+++ b/tickets/relations/metamodel-toplevel-key-whitelist-parity-test--protects--metamodel-types.md
@@ -1,0 +1,5 @@
+---
+from: metamodel-toplevel-key-whitelist-parity-test
+relation: protects
+to: metamodel-types
+---


### PR DESCRIPTION
## Problem

The `attachments:` config block documented in `docs/attachment-security.md` was rejected by the metamodel loader:

```
unknown key "attachments" (valid keys: automations, entities, includes, namespace, relations, types, validations, version)
```

The `Metamodel` struct has an `Attachments *AttachmentsConfig` field and the feature is fully wired — the global MIME `allow:` list gates uploads on both CLI and HTTP paths, and the global `scan_cmd:` runs a real `CmdRunner` on the data-entry upload path — but `validTopLevelKeys` in `internal/metamodel/loader.go` omitted `"attachments"`, so `checkUnknownKeys` rejected any project using it. The whole metamodel failed to load, so nobody could enable ClamAV scanning or a global allowlist. Regression from #1026 (the struct field + validator were added; the whitelist wasn't).

## Fix

- `internal/metamodel/loader.go` — add `"attachments": true` to `validTopLevelKeys` (one line).

## Tests

Root cause was a hand-maintained whitelist drifting from the struct, plus attachment tests that used Go struct literals and never round-tripped YAML through the loader. Both are now closed:

- **`TestValidTopLevelKeysMatchStruct`** — reflection parity: every top-level `yaml` tag on `Metamodel` must be in `validTopLevelKeys`. A future top-level field can no longer be silently rejected by its own loader.
- **`TestParse_AttachmentsTopLevelKeyAccepted`** — a real `attachments:` block round-trips through `Parse()`, `Attachments` populated.
- **`TestAttachmentUpload_GlobalAllowlistEnforced` / `TestAttachmentUpload_GlobalScanCmdRejects`** — parse a real global `attachments: {allow, scan_cmd}` metamodel through the loader and assert, through the real HTTP upload handler, that the global allowlist rejects a disallowed MIME (422) and a stub `scan_cmd` rejects an "infected" file. Because they parse real YAML, reverting the fix fails them at parse time.

All four tests fail on the exact `unknown key "attachments"` error when the one-line fix is reverted.

## Follow-up

`TKT-ELX09J` — apply the same reflection-parity pattern to two sibling loaders (`dataentryconfig`, `acl`) that share the drift class (surfaced in review).

## Verification

- `just ci` green (lint, arch-lint, coverage thresholds, build, docs-check)
- Manual: `rela validate` now accepts a project with a top-level `attachments:` block