### PR TITLE
feat(metamodel): enum value display labels (TKT-G6R5YE)

### DIFF
--- a/docs-project/entities/guides/GUIDE-metamodel.md
+++ b/docs-project/entities/guides/GUIDE-metamodel.md
@@ -171,6 +171,46 @@ types:
     values: [critical, high, medium, low]
 ```
 
+#### Display Labels
+
+Enum values are stored as-is (typically snake_case identifiers). For a
+friendlier data-entry UI you can attach an optional human-readable **label** to
+any value with a `labels:` map keyed by value:
+
+```yaml
+types:
+  status:
+    values: [draft, in_progress, wont_fix]
+    labels:
+      in_progress: In Progress
+      wont_fix: Won't Fix
+```
+
+Labels also work on inline enums:
+
+```yaml
+properties:
+  status:
+    type: enum
+    values: [open, in_progress, closed]
+    labels:
+      in_progress: In Progress
+```
+
+Notes:
+
+- **Labels are display-only.** The stored value, the value submitted by forms,
+  validation, and badge colours all key on the raw value — only the text shown
+  in the data-entry UI changes. A value with no entry in `labels` renders raw.
+- Labels are surfaced in the data-entry web UI (select dropdowns, badges across
+  lists / detail / kanban, and filter menus). The CLI and the OpenAPI `enum`
+  output stay value-based.
+- `labels` is optional and backwards compatible: existing metamodels with plain
+  value lists are unchanged and need no migration.
+- When a property references a custom type, labels come from the **custom
+  type**; an inline `labels` map on such a property is ignored (mirroring how an
+  inline `values` list is ignored there).
+
 ### Regex Validations
 
 Define validation patterns with user-friendly error messages. Multiple patterns

--- a/docs/metamodel.md
+++ b/docs/metamodel.md
@@ -165,6 +165,46 @@ types:
     values: [critical, high, medium, low]
 ```
 
+#### Display Labels
+
+Enum values are stored as-is (typically snake_case identifiers). For a
+friendlier data-entry UI you can attach an optional human-readable **label** to
+any value with a `labels:` map keyed by value:
+
+```yaml
+types:
+  status:
+    values: [draft, in_progress, wont_fix]
+    labels:
+      in_progress: In Progress
+      wont_fix: Won't Fix
+```
+
+Labels also work on inline enums:
+
+```yaml
+properties:
+  status:
+    type: enum
+    values: [open, in_progress, closed]
+    labels:
+      in_progress: In Progress
+```
+
+Notes:
+
+- **Labels are display-only.** The stored value, the value submitted by forms,
+  validation, and badge colours all key on the raw value — only the text shown
+  in the data-entry UI changes. A value with no entry in `labels` renders raw.
+- Labels are surfaced in the data-entry web UI (select dropdowns, badges across
+  lists / detail / kanban, and filter menus). The CLI and the OpenAPI `enum`
+  output stay value-based.
+- `labels` is optional and backwards compatible: existing metamodels with plain
+  value lists are unchanged and need no migration.
+- When a property references a custom type, labels come from the **custom
+  type**; an inline `labels` map on such a property is ignored (mirroring how an
+  inline `values` list is ignored there).
+
 ### Regex Validations
 
 Define validation patterns with user-friendly error messages. Multiple patterns

--- a/frontend/src/components/common/Badge.test.ts
+++ b/frontend/src/components/common/Badge.test.ts
@@ -195,4 +195,103 @@ describe('Badge', () => {
       expect(wrapper.find('.badge').classes()).toContain('badge--gray')
     })
   })
+
+  describe('enum labels', () => {
+    // Register an entity type whose `status` property is an inline enum with a
+    // label for in_progress, so getEnumLabel resolves via the property def.
+    function withInlineLabel() {
+      const schemaStore = useSchemaStore()
+      schemaStore.entityTypes = new Map([
+        [
+          'ticket',
+          {
+            label: 'Ticket',
+            properties: {
+              status: {
+                type: 'enum',
+                values: ['in_progress', 'done'],
+                labels: { in_progress: 'In Progress' },
+              },
+            },
+          },
+        ],
+      ]) as never
+      return schemaStore
+    }
+
+    it('renders the label when the metamodel configures one', () => {
+      withInlineLabel()
+      const wrapper = mount(Badge, {
+        props: { value: 'in_progress', property: 'status' },
+      })
+      expect(wrapper.text()).toBe('In Progress')
+    })
+
+    it('suppresses CSS capitalize for a labeled value (author chose the casing)', () => {
+      withInlineLabel()
+      const wrapper = mount(Badge, {
+        props: { value: 'in_progress', property: 'status' },
+      })
+      expect(wrapper.find('.badge').classes()).toContain('badge--labeled')
+    })
+
+    it('keeps color styling keyed on the raw value, not the label', () => {
+      const schemaStore = withInlineLabel()
+      schemaStore.styles = { status: { in_progress: 'badge-orange' } }
+      const wrapper = mount(Badge, {
+        props: { value: 'in_progress', property: 'status' },
+      })
+      // Text is the label; color still resolves from the value key.
+      expect(wrapper.text()).toBe('In Progress')
+      expect(wrapper.find('.badge').classes()).toContain('badge--orange')
+    })
+
+    it('falls back to the raw value (with capitalize) when no label configured', () => {
+      withInlineLabel()
+      const wrapper = mount(Badge, {
+        props: { value: 'done', property: 'status' },
+      })
+      expect(wrapper.text()).toBe('done')
+      // No label → capitalize stays on (badge--labeled absent).
+      expect(wrapper.find('.badge').classes()).not.toContain('badge--labeled')
+    })
+
+    it('resolves labels from a referenced custom type', () => {
+      const schemaStore = useSchemaStore()
+      schemaStore.entityTypes = new Map([
+        [
+          'ticket',
+          { label: 'Ticket', properties: { priority: { type: 'priority_t' } } },
+        ],
+      ]) as never
+      schemaStore.customTypes = new Map([
+        ['priority_t', { values: ['hi'], labels: { hi: 'High' } }],
+      ]) as never
+      const wrapper = mount(Badge, {
+        props: { value: 'hi', property: 'priority' },
+      })
+      expect(wrapper.text()).toBe('High')
+    })
+
+    it('escapes label text (no HTML injection from a metamodel label)', () => {
+      const schemaStore = useSchemaStore()
+      schemaStore.entityTypes = new Map([
+        [
+          'ticket',
+          {
+            label: 'Ticket',
+            properties: {
+              status: { type: 'enum', values: ['x'], labels: { x: '<img src=x>' } },
+            },
+          },
+        ],
+      ]) as never
+      const wrapper = mount(Badge, {
+        props: { value: 'x', property: 'status' },
+      })
+      // Rendered as text, not parsed into an element.
+      expect(wrapper.find('img').exists()).toBe(false)
+      expect(wrapper.text()).toBe('<img src=x>')
+    })
+  })
 })

--- a/frontend/src/components/common/Badge.vue
+++ b/frontend/src/components/common/Badge.vue
@@ -68,17 +68,19 @@ const displayText = computed(() => label.value ?? props.value)
   font-size: 12px;
   font-weight: 500;
   text-transform: capitalize;
-  /* Guard long labels from blowing out list columns / kanban cards. */
+}
+
+/* A metamodel-authored label is already in its intended casing; don't let
+   capitalize override the author's choice (e.g. "iOS", "high priority").
+   Labels can also be arbitrarily long (unlike snake_case values), so guard
+   them from blowing out list columns / kanban cards — scoped to labeled
+   badges only, leaving raw-value badges rendered exactly as before. */
+.badge--labeled {
+  text-transform: none;
   max-width: 24ch;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-}
-
-/* A metamodel-authored label is already in its intended casing; don't let
-   capitalize override the author's choice (e.g. "iOS", "high priority"). */
-.badge--labeled {
-  text-transform: none;
 }
 
 .badge--blue {

--- a/frontend/src/components/common/Badge.vue
+++ b/frontend/src/components/common/Badge.vue
@@ -39,11 +39,23 @@ const badgeClass = computed(() => {
   }
   return 'badge--gray'
 })
+
+// The metamodel-authored display label for this enum value, if any. Color
+// styling above still keys on the raw `value` (the wire identity); only the
+// text shown changes. When no label is configured we fall back to the raw
+// value and let CSS `capitalize` prettify it as before.
+const label = computed(() =>
+  schemaStore.getEnumLabel(props.value, props.property, props.entityType),
+)
+const displayText = computed(() => label.value ?? props.value)
 </script>
 
 <template>
-  <span class="badge" :class="badgeClass">
-    {{ value }}
+  <!-- When the metamodel supplies a label the author already chose the display
+       form, so we suppress CSS capitalize; label text is interpolated (escaped),
+       never v-html. -->
+  <span class="badge" :class="[badgeClass, { 'badge--labeled': label !== undefined }]">
+    {{ displayText }}
   </span>
 </template>
 
@@ -56,6 +68,17 @@ const badgeClass = computed(() => {
   font-size: 12px;
   font-weight: 500;
   text-transform: capitalize;
+  /* Guard long labels from blowing out list columns / kanban cards. */
+  max-width: 24ch;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* A metamodel-authored label is already in its intended casing; don't let
+   capitalize override the author's choice (e.g. "iOS", "high priority"). */
+.badge--labeled {
+  text-transform: none;
 }
 
 .badge--blue {

--- a/frontend/src/components/lists/AdHocFilterMenu.test.ts
+++ b/frontend/src/components/lists/AdHocFilterMenu.test.ts
@@ -73,6 +73,45 @@ describe('AdHocFilterMenu', () => {
     wrapper.unmount()
   })
 
+  it('shows enum labels in the value picker but applies the raw value', async () => {
+    const labeledType = {
+      name: 'ticket',
+      label: 'Ticket',
+      properties: {
+        status: {
+          type: 'enum',
+          values: ['open', 'in_progress'],
+          labels: { in_progress: 'In Progress' },
+        },
+      },
+    }
+    const schema = useSchemaStore()
+    schema.entityTypes.set('ticket', labeledType as never)
+
+    const wrapper = mount(AdHocFilterMenu, {
+      props: { mode: 'list', entityType: labeledType as never },
+      attachTo: document.body,
+    })
+    await wrapper.find('.filter-btn').trigger('click')
+    await flushPromises()
+
+    const statusOption = wrapper
+      .findAll('.filter-option')
+      .find((n) => n.text().includes('Status'))
+    await statusOption!.trigger('click')
+
+    // Value picker shows the label, not the raw snake_case value.
+    const labeledOption = wrapper
+      .findAll('.filter-option')
+      .find((n) => n.text().trim() === 'In Progress')
+    expect(labeledOption).toBeDefined()
+    await labeledOption!.trigger('click')
+
+    // But the emitted filter value is the raw wire value.
+    expect(wrapper.emitted('apply')?.[0]).toEqual(['status', 'in_progress'])
+    wrapper.unmount()
+  })
+
   it('emits apply with free-text value when property has no enum values', async () => {
     const wrapper = mount(AdHocFilterMenu, {
       props: { mode: 'list', entityType: ticketType as never },

--- a/frontend/src/components/lists/AdHocFilterMenu.vue
+++ b/frontend/src/components/lists/AdHocFilterMenu.vue
@@ -146,6 +146,17 @@ const valueOptions = computed((): string[] => {
   return []
 })
 
+// Display label for a value option in the picker. Prefers the selected
+// property's own labels; in search mode falls back to a cross-type lookup via
+// the schema store. Value stays the filter identity — labels are display-only.
+function valueLabel(value: string): string {
+  const sel = selected.value
+  if (!sel) return value
+  const inline = sel.propertyDef?.labels?.[value]
+  if (inline !== undefined) return inline
+  return schemaStore.getEnumLabel(value, sel.property) ?? value
+}
+
 function titleCase(str: string): string {
   return str.replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase())
 }
@@ -300,7 +311,7 @@ defineExpose({ open: openMenu, close })
             @click="commit(value)"
             @mouseenter="menuIndex = index"
           >
-            {{ value }}
+            {{ valueLabel(value) }}
           </div>
         </div>
 

--- a/frontend/src/components/lists/FilterBar.vue
+++ b/frontend/src/components/lists/FilterBar.vue
@@ -28,7 +28,14 @@ interface ResolvedFilter {
   label: string
   widget: 'select' | 'multi-select' | 'text'
   options: string[]
+  // Display labels keyed by option value (display-only; filter value stays raw).
+  optionLabels: Record<string, string>
   isRelation: boolean
+}
+
+// Resolve the display text for an option value in a filter dropdown.
+function optionText(filter: ResolvedFilter, option: string): string {
+  return filter.optionLabels[option] ?? option
 }
 
 const resolvedFilters = computed((): ResolvedFilter[] => {
@@ -42,19 +49,19 @@ function resolveFilter(fc: FilterControl): ResolvedFilter {
 
   if (fc.relation) {
     // Relation filters: use text input for now (could be enhanced to select with targets)
-    return { key, label, widget: 'text', options: [], isRelation: true }
+    return { key, label, widget: 'text', options: [], optionLabels: {}, isRelation: true }
   }
 
   // Property filter
   const propDef = props.entityType?.properties[fc.property || '']
   if (!propDef) {
-    return { key, label, widget: 'text', options: [], isRelation: false }
+    return { key, label, widget: 'text', options: [], optionLabels: {}, isRelation: false }
   }
 
   const options = propDef.values || []
   const widget = resolveWidgetType(propDef, options)
 
-  return { key, label, widget, options, isRelation: false }
+  return { key, label, widget, options, optionLabels: propDef.labels || {}, isRelation: false }
 }
 
 function resolveWidgetType(propDef: PropertyDef, options: string[]): 'select' | 'multi-select' | 'text' {
@@ -235,7 +242,7 @@ onBeforeUnmount(() => {
             :key="option"
             :value="option"
           >
-            {{ option }}
+            {{ optionText(filter, option) }}
           </option>
         </select>
 
@@ -253,7 +260,7 @@ onBeforeUnmount(() => {
             :value="option"
             :selected="getMultiSelectValues(filter.key).includes(option)"
           >
-            {{ option }}
+            {{ optionText(filter, option) }}
           </option>
         </select>
 

--- a/frontend/src/components/lists/FilterBar.vue
+++ b/frontend/src/components/lists/FilterBar.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { ref, watch, computed, onBeforeUnmount } from 'vue'
+import { useSchemaStore } from '@/stores/schema'
 import type {
   ListConfig,
   EntityType,
@@ -13,6 +14,8 @@ const props = defineProps<{
   entityType?: EntityType
   filters: FilterState
 }>()
+
+const schemaStore = useSchemaStore()
 
 const emit = defineEmits<{
   filter: [filters: FilterState]
@@ -60,8 +63,9 @@ function resolveFilter(fc: FilterControl): ResolvedFilter {
 
   const options = propDef.values || []
   const widget = resolveWidgetType(propDef, options)
+  const optionLabels = schemaStore.resolveOptionLabels(propDef, fc.property || '', props.entityType)
 
-  return { key, label, widget, options, optionLabels: propDef.labels || {}, isRelation: false }
+  return { key, label, widget, options, optionLabels, isRelation: false }
 }
 
 function resolveWidgetType(propDef: PropertyDef, options: string[]): 'select' | 'multi-select' | 'text' {

--- a/frontend/src/components/ui/TagSelect.vue
+++ b/frontend/src/components/ui/TagSelect.vue
@@ -18,6 +18,10 @@ const props = defineProps<{
   // displayed (so the user can see + remove them) but are flagged
   // disabled in the dropdown so they can't be re-added.
   optionVerdicts?: Record<string, boolean>
+  // optionLabels: display text keyed by option value. Display-only — the
+  // option's value (and thus the emitted selection) stays the raw value.
+  // Absent keys fall back to showing the value itself.
+  optionLabels?: Record<string, string>
 }>()
 
 const emit = defineEmits<{
@@ -26,7 +30,8 @@ const emit = defineEmits<{
 
 const data = computed(() =>
   props.options.map((opt) => ({
-    text: opt,
+    // Display label (falls back to the value); value stays the raw identity.
+    text: props.optionLabels?.[opt] ?? opt,
     value: opt,
     // Server-side affordance verdict denies this option → render
     // disabled in the dropdown so the user can't pick it.

--- a/frontend/src/stores/schema.test.ts
+++ b/frontend/src/stores/schema.test.ts
@@ -304,4 +304,61 @@ describe('Schema Store', () => {
       ])
     })
   })
+
+  describe('getEnumLabel', () => {
+    it('returns the inline-enum label for a value', () => {
+      const store = useSchemaStore()
+      store.entityTypes = new Map([
+        [
+          'ticket',
+          {
+            label: 'Ticket',
+            properties: {
+              status: { type: 'enum', values: ['in_progress'], labels: { in_progress: 'In Progress' } },
+            },
+          },
+        ],
+      ]) as never
+      expect(store.getEnumLabel('in_progress', 'status')).toBe('In Progress')
+    })
+
+    it('resolves a label from a referenced custom type', () => {
+      const store = useSchemaStore()
+      store.entityTypes = new Map([
+        ['ticket', { label: 'Ticket', properties: { priority: { type: 'priority_t' } } }],
+      ]) as never
+      store.customTypes = new Map([
+        ['priority_t', { values: ['hi'], labels: { hi: 'High' } }],
+      ]) as never
+      expect(store.getEnumLabel('hi', 'priority')).toBe('High')
+    })
+
+    it('returns undefined when no label is configured (caller falls back to value)', () => {
+      const store = useSchemaStore()
+      store.entityTypes = new Map([
+        ['ticket', { label: 'Ticket', properties: { status: { type: 'enum', values: ['done'] } } }],
+      ]) as never
+      expect(store.getEnumLabel('done', 'status')).toBeUndefined()
+    })
+
+    it('returns undefined when property is absent', () => {
+      const store = useSchemaStore()
+      expect(store.getEnumLabel('x')).toBeUndefined()
+    })
+
+    it('prefers the given entity type when the same property name differs across types', () => {
+      const store = useSchemaStore()
+      store.entityTypes = new Map([
+        [
+          'bug',
+          { label: 'Bug', properties: { status: { type: 'enum', values: ['x'], labels: { x: 'Bug X' } } } },
+        ],
+        [
+          'ticket',
+          { label: 'Ticket', properties: { status: { type: 'enum', values: ['x'], labels: { x: 'Ticket X' } } } },
+        ],
+      ]) as never
+      expect(store.getEnumLabel('x', 'status', 'ticket')).toBe('Ticket X')
+    })
+  })
 })

--- a/frontend/src/stores/schema.test.ts
+++ b/frontend/src/stores/schema.test.ts
@@ -360,5 +360,22 @@ describe('Schema Store', () => {
       ]) as never
       expect(store.getEnumLabel('x', 'status', 'ticket')).toBe('Ticket X')
     })
+
+    it('falls back to first-inserted type on collision when no entity type given', () => {
+      const store = useSchemaStore()
+      // Insertion order fixes the tie-break: `bug` first, so `bug`'s label wins
+      // when the caller does not disambiguate. Pins the documented behavior.
+      store.entityTypes = new Map([
+        [
+          'bug',
+          { label: 'Bug', properties: { status: { type: 'enum', values: ['x'], labels: { x: 'Bug X' } } } },
+        ],
+        [
+          'ticket',
+          { label: 'Ticket', properties: { status: { type: 'enum', values: ['x'], labels: { x: 'Ticket X' } } } },
+        ],
+      ]) as never
+      expect(store.getEnumLabel('x', 'status')).toBe('Bug X')
+    })
   })
 })

--- a/frontend/src/stores/schema.ts
+++ b/frontend/src/stores/schema.ts
@@ -5,6 +5,7 @@ import { registerEntityPlurals } from '@/api/entities'
 import { getErrorMessage } from '@/api/errors'
 import type {
   EntityType,
+  PropertyDef,
   RelationType,
   CustomType,
   FormConfig,
@@ -80,6 +81,56 @@ export const useSchemaStore = defineStore('schema', () => {
 
   const entityTypeList = computed(() => Array.from(entityTypes.value.entries()))
   const relationTypeList = computed(() => Array.from(relationTypes.value.entries()))
+
+  // Resolve the enum labels map for a property. A property may either name a
+  // custom type (labels live on the custom type) or declare an inline enum
+  // (labels live on the property def). The `entityType` disambiguator may be a
+  // type-name string OR a resolved EntityType object (callers hold one or the
+  // other); when given we look up that type's property first. Otherwise (and as
+  // a fallback) we scan entity and relation types for the first matching
+  // property name — mirroring how `styles` collapses by property name across
+  // types, which holds for the data-entry model.
+  function labelsForProperty(
+    property: string,
+    entityType?: string | EntityType,
+  ): Record<string, string> | undefined {
+    const fromDef = (def?: PropertyDef) => {
+      if (!def) return undefined
+      if (def.labels) return def.labels
+      // Property references a custom type → labels live on that custom type.
+      const ct = def.type ? customTypes.value.get(def.type) : undefined
+      return ct?.labels
+    }
+    if (entityType) {
+      const et = typeof entityType === 'string' ? entityTypes.value.get(entityType) : entityType
+      const hit = fromDef(et?.properties?.[property])
+      if (hit) return hit
+    }
+    for (const [, def] of entityTypes.value) {
+      const hit = fromDef(def.properties?.[property])
+      if (hit) return hit
+    }
+    for (const [, def] of relationTypes.value) {
+      const hit = fromDef(def.properties?.[property])
+      if (hit) return hit
+    }
+    return undefined
+  }
+
+  // Return the display label for an enum value, or undefined when no label is
+  // configured (caller falls back to the raw value). Display-only: the value
+  // stays the wire identity.
+  const getEnumLabel = computed(
+    () =>
+      (
+        value: string,
+        property?: string,
+        entityType?: string | EntityType,
+      ): string | undefined => {
+        if (!property) return undefined
+        return labelsForProperty(property, entityType)?.[value]
+      },
+  )
 
   // Actions
   async function load(): Promise<void> {
@@ -192,6 +243,7 @@ export const useSchemaStore = defineStore('schema', () => {
     getView,
     getKanban,
     getAction,
+    getEnumLabel,
     entityTypeList,
     relationTypeList,
 

--- a/frontend/src/stores/schema.ts
+++ b/frontend/src/stores/schema.ts
@@ -86,10 +86,17 @@ export const useSchemaStore = defineStore('schema', () => {
   // custom type (labels live on the custom type) or declare an inline enum
   // (labels live on the property def). The `entityType` disambiguator may be a
   // type-name string OR a resolved EntityType object (callers hold one or the
-  // other); when given we look up that type's property first. Otherwise (and as
-  // a fallback) we scan entity and relation types for the first matching
-  // property name — mirroring how `styles` collapses by property name across
-  // types, which holds for the data-entry model.
+  // other); when given we look up that type's property first.
+  //
+  // When no entityType is given (e.g. the cross-type search filter, which has
+  // no single owning type — see AdHocFilterMenu's documented union) we scan
+  // entity then relation types and return the FIRST matching property name that
+  // has labels. That is a deliberate first-wins tie-break: if two types define
+  // labels for the same property name with different text, the first-inserted
+  // type wins. Labels are display-only, so this is acceptable for v1; callers
+  // that know their type should pass it to avoid the ambiguity. (Note this is a
+  // per-type-def scan, NOT the flat server-authored `styles` map — the two are
+  // separate mechanisms that merely happen to both collapse by property name.)
   function labelsForProperty(
     property: string,
     entityType?: string | EntityType,
@@ -129,6 +136,31 @@ export const useSchemaStore = defineStore('schema', () => {
       ): string | undefined => {
         if (!property) return undefined
         return labelsForProperty(property, entityType)?.[value]
+      },
+  )
+
+  // Resolve the value→label map to feed an enum picker (select / multi-select /
+  // filter dropdown). Single source of truth so the widgets and filter bars
+  // don't each reimplement the inline-vs-custom-type resolution and drift. A
+  // property def's own `labels` (populated by the server for both inline enums
+  // and custom-type-backed properties) wins; otherwise fall back to a
+  // schema-store lookup by (property, entityType) for callers that only hold a
+  // property name. Values without a label are omitted (caller shows them raw).
+  const resolveOptionLabels = computed(
+    () =>
+      (
+        propertyDef: PropertyDef | undefined,
+        property: string,
+        entityType?: string | EntityType,
+      ): Record<string, string> => {
+        const inline = propertyDef?.labels
+        if (inline && Object.keys(inline).length > 0) return inline
+        const out: Record<string, string> = {}
+        for (const value of propertyDef?.values ?? []) {
+          const label = labelsForProperty(property, entityType)?.[value]
+          if (label !== undefined) out[value] = label
+        }
+        return out
       },
   )
 
@@ -244,6 +276,7 @@ export const useSchemaStore = defineStore('schema', () => {
     getKanban,
     getAction,
     getEnumLabel,
+    resolveOptionLabels,
     entityTypeList,
     relationTypeList,
 

--- a/frontend/src/types/schema.ts
+++ b/frontend/src/types/schema.ts
@@ -22,6 +22,9 @@ export interface PropertyDef {
   type: 'string' | 'date' | 'integer' | 'boolean' | 'enum' | 'file' | 'rrule'
   required?: boolean
   values?: string[]
+  // Optional display labels keyed by enum value. Display-only: the stored/
+  // submitted value stays the raw value; labels never become wire identities.
+  labels?: Record<string, string>
   default?: string
   description?: string
   format?: string
@@ -64,6 +67,8 @@ export interface InverseDef {
 
 export interface CustomType {
   values: string[]
+  // Optional display labels keyed by value. Display-only; see PropertyDef.labels.
+  labels?: Record<string, string>
   default?: string
 }
 

--- a/frontend/src/views/KanbanView.test.ts
+++ b/frontend/src/views/KanbanView.test.ts
@@ -225,3 +225,68 @@ describe('KanbanView card property fields', () => {
     wrapper.unmount()
   })
 })
+
+describe('KanbanView column header enum labels', () => {
+  // Seed a board grouped by `status` whose column carries no explicit label
+  // (label === value, the auto-generated shape) and whose status enum defines
+  // a display label. The header must resolve the enum label.
+  function seedLabeledBoard() {
+    const schemaStore = useSchemaStore()
+    schemaStore.kanbans.set(KANBAN_ID, {
+      entity: ENTITY_TYPE,
+      title: 'Board',
+      column_property: 'status',
+      columns: [{ value: 'todo', label: 'todo' }],
+      card: { title: 'title', fields: [{ property: 'status' }] },
+    } as never)
+    schemaStore.entityTypes.set(ENTITY_TYPE, {
+      name: ENTITY_TYPE,
+      label: 'Ticket',
+      properties: {
+        title: { type: 'string' },
+        status: { type: 'enum', values: ['todo'], labels: { todo: 'To Do' } },
+      },
+    } as never)
+  }
+
+  it('shows the enum label in the column header when no explicit column label', async () => {
+    seedLabeledBoard()
+    const ticket = makeTicket('T-7')
+    ticket.properties = { title: 'Ticket T-7', status: 'todo' }
+    seedBoard([ticket])
+    const wrapper = mount(KanbanView, {
+      props: { id: KANBAN_ID },
+      attachTo: document.body,
+      global: { plugins: [pinia, PiniaColada] },
+    })
+    await flushPromises()
+
+    expect(wrapper.find('.column-title').text()).toBe('To Do')
+    wrapper.unmount()
+  })
+
+  it('keeps an explicit kanban column label over the enum label', async () => {
+    const schemaStore = useSchemaStore()
+    seedLabeledBoard()
+    // Override the column with an explicit, different label.
+    schemaStore.kanbans.set(KANBAN_ID, {
+      entity: ENTITY_TYPE,
+      title: 'Board',
+      column_property: 'status',
+      columns: [{ value: 'todo', label: 'Backlog' }],
+      card: { title: 'title', fields: [{ property: 'status' }] },
+    } as never)
+    const ticket = makeTicket('T-8')
+    ticket.properties = { title: 'Ticket T-8', status: 'todo' }
+    seedBoard([ticket])
+    const wrapper = mount(KanbanView, {
+      props: { id: KANBAN_ID },
+      attachTo: document.body,
+      global: { plugins: [pinia, PiniaColada] },
+    })
+    await flushPromises()
+
+    expect(wrapper.find('.column-title').text()).toBe('Backlog')
+    wrapper.unmount()
+  })
+})

--- a/frontend/src/views/KanbanView.vue
+++ b/frontend/src/views/KanbanView.vue
@@ -154,6 +154,22 @@ const swimlanes = computed(() => {
 
 const hasSwimmlanes = computed(() => swimlanes.value.length > 0)
 
+// Column header text. An explicit kanban-config column label wins; otherwise
+// fall back to the enum's display label for the grouping value, then the raw
+// value. Keeps headers consistent with the card badges (which resolve labels
+// via Badge). `column.label` defaults to the value for auto-generated columns
+// (see the columns computed), so treat label===value as "no explicit label".
+function columnTitle(column: { value: string; label?: string }): string {
+  if (column.label && column.label !== column.value) return column.label
+  const property = kanbanConfig.value?.column_property
+  const entityTypeName = kanbanConfig.value?.entity
+  return (
+    schemaStore.getEnumLabel(column.value, property, entityTypeName) ??
+    column.label ??
+    column.value
+  )
+}
+
 const entitiesByColumn = computed(() => {
   const grouped: Record<string, Entity[]> = {}
   const property = kanbanConfig.value?.column_property || ''
@@ -444,7 +460,7 @@ function createNew() {
         @drop="onDrop($event, column.value)"
       >
         <div class="column-header">
-          <span class="column-title">{{ column.label || column.value }}</span>
+          <span class="column-title">{{ columnTitle(column) }}</span>
           <span class="column-count">{{ entitiesByColumn[column.value]?.length || 0 }}</span>
         </div>
 
@@ -495,7 +511,7 @@ function createNew() {
           :key="column.value"
           class="swimlane-column-header"
         >
-          <span class="column-title">{{ column.label || column.value }}</span>
+          <span class="column-title">{{ columnTitle(column) }}</span>
         </div>
       </div>
 

--- a/frontend/src/widgets/MultiSelectWidget.vue
+++ b/frontend/src/widgets/MultiSelectWidget.vue
@@ -2,6 +2,7 @@
 import { computed } from 'vue'
 import TagSelect from '@/components/ui/TagSelect.vue'
 import Badge from '@/components/common/Badge.vue'
+import { useSchemaStore } from '@/stores/schema'
 import type { WidgetProps } from './types'
 
 const props = defineProps<WidgetProps>()
@@ -10,7 +11,23 @@ const emit = defineEmits<{
   'update:modelValue': [value: unknown]
 }>()
 
+const schemaStore = useSchemaStore()
+
 const options = computed(() => props.propertyDef?.values || [])
+
+// Display labels keyed by value for the edit-mode dropdown. Inline enums
+// carry labels on the property def; custom-type-backed enums resolve via the
+// schema store. Value stays the wire identity.
+const optionLabels = computed<Record<string, string>>(() => {
+  const inline = props.propertyDef?.labels
+  if (inline && Object.keys(inline).length > 0) return inline
+  const out: Record<string, string> = {}
+  for (const opt of options.value) {
+    const label = schemaStore.getEnumLabel(opt, props.propertyName, props.entityType)
+    if (label !== undefined) out[opt] = label
+  }
+  return out
+})
 
 const arrayValue = computed(() => {
   if (Array.isArray(props.modelValue)) return props.modelValue.map(String)
@@ -54,6 +71,7 @@ function onUpdate(value: string[]) {
     :placeholder="placeholder || 'Select...'"
     :disabled="disabled"
     :option-verdicts="optionVerdicts"
+    :option-labels="optionLabels"
     @update:model-value="onUpdate"
   />
 </template>

--- a/frontend/src/widgets/MultiSelectWidget.vue
+++ b/frontend/src/widgets/MultiSelectWidget.vue
@@ -15,19 +15,11 @@ const schemaStore = useSchemaStore()
 
 const options = computed(() => props.propertyDef?.values || [])
 
-// Display labels keyed by value for the edit-mode dropdown. Inline enums
-// carry labels on the property def; custom-type-backed enums resolve via the
-// schema store. Value stays the wire identity.
-const optionLabels = computed<Record<string, string>>(() => {
-  const inline = props.propertyDef?.labels
-  if (inline && Object.keys(inline).length > 0) return inline
-  const out: Record<string, string> = {}
-  for (const opt of options.value) {
-    const label = schemaStore.getEnumLabel(opt, props.propertyName, props.entityType)
-    if (label !== undefined) out[opt] = label
-  }
-  return out
-})
+// Display labels keyed by value for the edit-mode dropdown (value stays the
+// wire identity). Shared resolver so all enum pickers agree; see the store.
+const optionLabels = computed<Record<string, string>>(() =>
+  schemaStore.resolveOptionLabels(props.propertyDef, props.propertyName, props.entityType)
+)
 
 const arrayValue = computed(() => {
   if (Array.isArray(props.modelValue)) return props.modelValue.map(String)

--- a/frontend/src/widgets/SelectWidget.vue
+++ b/frontend/src/widgets/SelectWidget.vue
@@ -2,9 +2,12 @@
 import { computed } from 'vue'
 import type { WidgetProps } from './types'
 import { useStringValue } from './useStringValue'
+import { useSchemaStore } from '@/stores/schema'
 import Badge from '@/components/common/Badge.vue'
 
 const props = defineProps<WidgetProps>()
+
+const schemaStore = useSchemaStore()
 
 const emit = defineEmits<{
   'update:modelValue': [value: unknown]
@@ -32,6 +35,16 @@ const safeStringValue = computed(() => {
 })
 
 const options = computed(() => props.propertyDef?.values || [])
+
+// Display label for an option value. Edit-mode `<option>` text shows the
+// label; the option's :value stays the raw value (the submitted identity).
+// Inline enums carry labels on the property def; a property referencing a
+// custom type resolves its labels via the schema store.
+function optionLabel(opt: string): string {
+  const inline = props.propertyDef?.labels?.[opt]
+  if (inline !== undefined) return inline
+  return schemaStore.getEnumLabel(opt, props.propertyName, props.entityType) ?? opt
+}
 
 const hasTransitions = computed(
   () => !!props.transitions && Object.keys(props.transitions).length > 0
@@ -91,7 +104,7 @@ function onChange(event: Event) {
         :disabled="isOptionDisabled(opt)"
         :class="{ 'disabled-transition': isOptionDisabled(opt) }"
       >
-        {{ opt }}{{ isOptionDisabled(opt) ? ' (not allowed)' : '' }}
+        {{ optionLabel(opt) }}{{ isOptionDisabled(opt) ? ' (not allowed)' : '' }}
       </option>
     </select>
 

--- a/frontend/src/widgets/SelectWidget.vue
+++ b/frontend/src/widgets/SelectWidget.vue
@@ -36,14 +36,14 @@ const safeStringValue = computed(() => {
 
 const options = computed(() => props.propertyDef?.values || [])
 
-// Display label for an option value. Edit-mode `<option>` text shows the
-// label; the option's :value stays the raw value (the submitted identity).
-// Inline enums carry labels on the property def; a property referencing a
-// custom type resolves its labels via the schema store.
+// Display labels keyed by value (value stays the submitted identity). Shared
+// resolver so all enum pickers agree; see the store. Edit-mode `<option>` text
+// shows the label, falling back to the raw value when unlabeled.
+const optionLabels = computed(() =>
+  schemaStore.resolveOptionLabels(props.propertyDef, props.propertyName, props.entityType)
+)
 function optionLabel(opt: string): string {
-  const inline = props.propertyDef?.labels?.[opt]
-  if (inline !== undefined) return inline
-  return schemaStore.getEnumLabel(opt, props.propertyName, props.entityType) ?? opt
+  return optionLabels.value[opt] ?? opt
 }
 
 const hasTransitions = computed(

--- a/frontend/src/widgets/types.ts
+++ b/frontend/src/widgets/types.ts
@@ -55,10 +55,14 @@ export interface WidgetProps<T = unknown> {
   // The property's attachment cap (metamodel `max`, default 1). Drives the
   // file widget's mode: replace at 1, add-up-to-max above.
   max?: number
-  // Owning entity identity, supplied to the file widget so it can build
-  // the upload/delete URL in edit mode. Optional — present only on the
-  // file-property edit path; other widgets ignore it.
+  // Owning entity type. Two consumers: the file widget builds the
+  // upload/delete URL from it, and the enum widgets pass it as the
+  // disambiguator for enum-label resolution (getEnumLabel) when the same
+  // property name exists on multiple types. Optional — FieldRenderer forwards
+  // the form's entity type; widgets that don't need it ignore it.
   entityType?: string
+  // Owning entity ID, supplied to the file widget for the upload/delete URL
+  // in edit mode. Optional — present only on the file-property edit path.
   entityId?: string
 }
 

--- a/frontend/src/widgets/widgets.test.ts
+++ b/frontend/src/widgets/widgets.test.ts
@@ -129,6 +129,23 @@ describe('SelectWidget', () => {
     expect(w.emitted('update:modelValue')?.[0]).toEqual(['review'])
   })
 
+  it('shows inline enum labels as option text while keeping the raw value', () => {
+    const labeled = {
+      type: 'enum' as const,
+      values: ['open', 'in_progress'],
+      labels: { in_progress: 'In Progress' },
+    }
+    const w = mount(SelectWidget, {
+      props: { modelValue: 'open', mode: 'edit' as const, propertyName: 'status', propertyDef: labeled },
+    })
+    const byValue = Object.fromEntries(w.findAll('option').map((o) => [o.attributes('value'), o]))
+    // Option value stays the raw wire value; only the visible text is the label.
+    expect(byValue['in_progress'].text()).toBe('In Progress')
+    expect(byValue['in_progress'].attributes('value')).toBe('in_progress')
+    // Unlabeled value falls back to the raw value.
+    expect(byValue['open'].text()).toBe('open')
+  })
+
   it('disables options denied by optionVerdicts', () => {
     const w = mount(SelectWidget, {
       props: { modelValue: 'open', mode: 'edit' as const, propertyName: '', propertyDef: def, optionVerdicts: { done: false } },

--- a/frontend/src/widgets/wrapperWidgets.test.ts
+++ b/frontend/src/widgets/wrapperWidgets.test.ts
@@ -64,6 +64,25 @@ describe('MultiSelectWidget', () => {
     expect(tag.props('disabled')).toBe(true)
     expect(tag.props('optionVerdicts')).toEqual({ a: false })
   })
+
+  it('passes inline enum labels to TagSelect as optionLabels (value stays raw)', () => {
+    const w = mount(MultiSelectWidget, {
+      props: {
+        modelValue: [],
+        mode: 'edit' as const,
+        propertyName: 'status',
+        propertyDef: {
+          type: 'enum',
+          values: ['open', 'in_progress'],
+          labels: { in_progress: 'In Progress' },
+        },
+      },
+      global: { stubs },
+    })
+    const tag = w.findComponent({ name: 'TagSelect' })
+    expect(tag.props('options')).toEqual(['open', 'in_progress'])
+    expect(tag.props('optionLabels')).toEqual({ in_progress: 'In Progress' })
+  })
 })
 
 describe('RruleWidget', () => {

--- a/internal/apiwire/v1/responses.go
+++ b/internal/apiwire/v1/responses.go
@@ -132,12 +132,13 @@ type EntityType struct {
 
 // PropertyDef is the JSON representation of a property definition.
 type PropertyDef struct {
-	Type        string   `json:"type"`
-	Required    bool     `json:"required"`
-	Default     string   `json:"default,omitempty"`
-	Values      []string `json:"values,omitempty"`
-	Description string   `json:"description,omitempty"`
-	List        bool     `json:"list,omitempty"`
+	Type        string            `json:"type"`
+	Required    bool              `json:"required"`
+	Default     string            `json:"default,omitempty"`
+	Values      []string          `json:"values,omitempty"`
+	Labels      map[string]string `json:"labels,omitempty"` // Display labels keyed by value; value stays the wire identity
+	Description string            `json:"description,omitempty"`
+	List        bool              `json:"list,omitempty"`
 	// Max is the attachment cap for a `file` property (default 1). The SPA's
 	// file widget reads it to switch between replace-mode and multi-file
 	// add-mode. Omitted unless set above 1.
@@ -179,8 +180,9 @@ type InverseDef struct {
 
 // CustomType is the JSON representation of a custom type.
 type CustomType struct {
-	Values  []string `json:"values"`
-	Default string   `json:"default,omitempty"`
+	Values  []string          `json:"values"`
+	Labels  map[string]string `json:"labels,omitempty"` // Display labels keyed by value; value stays the wire identity
+	Default string            `json:"default,omitempty"`
 }
 
 // Config is the JSON representation of the UI config.

--- a/internal/dataentry/api_v1.go
+++ b/internal/dataentry/api_v1.go
@@ -41,12 +41,27 @@ func (a *App) toV1PropertyDef(meta *metamodel.Metamodel, propDef metamodel.Prope
 		List:        propDef.List,
 		Max:         propDef.Max,
 	}
+	// Labels mirror Values: a property naming a custom type inherits that
+	// type's values and labels; an inline `labels` map on a custom-typed
+	// property is ignored, exactly as inline `values` is.
 	if ct, ok := meta.Types[propDef.Type]; ok {
 		pd.Values = ct.Values
+		pd.Labels = ct.Labels
 	} else if len(propDef.Values) > 0 {
 		pd.Values = propDef.Values
+		pd.Labels = propDef.Labels
 	}
 	return pd
+}
+
+// toV1CustomType is the single serialization site for a metamodel custom type
+// onto the wire, so the _schema types map and any other consumer stay in sync.
+func toV1CustomType(ct metamodel.CustomType) v1.CustomType {
+	return v1.CustomType{
+		Values:  ct.Values,
+		Labels:  ct.Labels,
+		Default: ct.Default,
+	}
 }
 
 // --- API v1 Router ---
@@ -1721,10 +1736,7 @@ func (a *App) handleV1Schema(w http.ResponseWriter, r *http.Request) {
 	}
 
 	for name, def := range s.Meta.Types {
-		schema.Types[name] = v1.CustomType{
-			Values:  def.Values,
-			Default: def.Default,
-		}
+		schema.Types[name] = toV1CustomType(def)
 	}
 
 	writeV1JSON(w, http.StatusOK, schema)

--- a/internal/dataentry/api_v1_test.go
+++ b/internal/dataentry/api_v1_test.go
@@ -1808,6 +1808,85 @@ func TestV1SchemaWithCustomTypes(t *testing.T) {
 	}
 }
 
+// TestV1SchemaEnumLabels pins that display labels flow onto the wire for both
+// enum forms, and that label copy mirrors value precedence (a custom-typed
+// property inherits the custom type's labels; an inline `labels` map on such a
+// property is ignored, exactly as inline `values` is). See TKT-G6R5YE.
+func TestV1SchemaEnumLabels(t *testing.T) {
+	app := newTestAppV1(t)
+
+	app.Meta().Types = map[string]metamodel.CustomType{
+		"status_type": {
+			Values: []string{"open", "in_progress"},
+			Labels: map[string]string{"in_progress": "In Progress"},
+		},
+	}
+	app.Meta().Entities["ticket"] = metamodel.EntityDef{
+		Label: "Ticket",
+		Properties: map[string]metamodel.PropertyDef{
+			"title": {Type: "string", Required: true},
+			// Custom-type-backed: labels come from status_type; the inline
+			// labels here must be ignored (dead config), mirroring values.
+			"status": {Type: "status_type", Labels: map[string]string{"open": "SHOULD-BE-IGNORED"}},
+			// Inline enum with its own labels.
+			"kind": {Type: "enum", Values: []string{"bug", "feat"}, Labels: map[string]string{"feat": "Feature"}},
+		},
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/_schema", http.NoBody)
+	rec := httptest.NewRecorder()
+	app.handleV1Schema(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", rec.Code)
+	}
+
+	var schema v1.Schema
+	if err := json.NewDecoder(rec.Body).Decode(&schema); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	// Custom type carries its labels in the types map.
+	if got := schema.Types["status_type"].Labels["in_progress"]; got != "In Progress" {
+		t.Errorf("custom type label: got %q, want %q", got, "In Progress")
+	}
+
+	props := schema.Entities["ticket"].Properties
+
+	// Custom-typed property inherits the custom type's labels, not the inline one.
+	statusLabels := props["status"].Labels
+	if got := statusLabels["in_progress"]; got != "In Progress" {
+		t.Errorf("status inherited label: got %q, want %q", got, "In Progress")
+	}
+	if _, present := statusLabels["open"]; present {
+		t.Errorf("inline labels on a custom-typed property must be ignored, got %v", statusLabels)
+	}
+
+	// Inline enum carries its own labels.
+	if got := props["kind"].Labels["feat"]; got != "Feature" {
+		t.Errorf("inline enum label: got %q, want %q", got, "Feature")
+	}
+}
+
+// TestV1SchemaEnumLabelsOmittedWhenAbsent pins that a label-less enum emits no
+// `labels` key (omitempty), so existing metamodels are byte-for-byte unchanged.
+func TestV1SchemaEnumLabelsOmittedWhenAbsent(t *testing.T) {
+	app := newTestAppV1(t)
+	app.Meta().Entities["ticket"] = metamodel.EntityDef{
+		Label: "Ticket",
+		Properties: map[string]metamodel.PropertyDef{
+			"kind": {Type: "enum", Values: []string{"bug", "feat"}},
+		},
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/_schema", http.NoBody)
+	rec := httptest.NewRecorder()
+	app.handleV1Schema(rec, req)
+
+	if strings.Contains(rec.Body.String(), "\"labels\"") {
+		t.Errorf("expected no labels key for a label-less enum, body: %s", rec.Body.String())
+	}
+}
+
 func TestV1PaginationLinkHeaders(t *testing.T) {
 	app := newTestAppV1(t)
 

--- a/internal/metamodel/loader_test.go
+++ b/internal/metamodel/loader_test.go
@@ -2392,3 +2392,61 @@ entities:
 		t.Errorf("expected InvalidIDPrefixError, got %T: %v", err, err)
 	}
 }
+
+// TestParse_EnumLabels covers optional per-value display labels on both enum
+// forms: a named custom type and an inline `type: enum` property. Labels are
+// display-only; parsing must accept them and leave values untouched. A
+// string-list enum with no labels must parse with a nil Labels map (so it
+// round-trips byte-for-byte). See TKT-G6R5YE.
+func TestParse_EnumLabels(t *testing.T) {
+	yaml := `version: "1.0"
+types:
+  status_t:
+    values: [open, in_progress]
+    labels:
+      in_progress: In Progress
+entities:
+  ticket:
+    label: Ticket
+    id_prefix: "TKT-"
+    properties:
+      title:
+        type: string
+      status:
+        type: status_t
+      kind:
+        type: enum
+        values: [bug, feat]
+        labels:
+          feat: Feature
+      priority:
+        type: enum
+        values: [low, high]
+`
+	meta, err := Parse([]byte(yaml))
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+
+	// Custom type labels.
+	ct := meta.Types["status_t"]
+	if got := ct.Labels["in_progress"]; got != "In Progress" {
+		t.Errorf("custom type label: got %q, want %q", got, "In Progress")
+	}
+	// Values are untouched.
+	if len(ct.Values) != 2 || ct.Values[0] != "open" {
+		t.Errorf("custom type values changed: %v", ct.Values)
+	}
+
+	props := meta.Entities["ticket"].Properties
+
+	// Inline enum labels.
+	if got := props["kind"].Labels["feat"]; got != "Feature" {
+		t.Errorf("inline enum label: got %q, want %q", got, "Feature")
+	}
+
+	// A label-less inline enum has a nil Labels map (round-trip safety).
+	if props["priority"].Labels != nil {
+		t.Errorf("label-less enum should have nil Labels, got %v", props["priority"].Labels)
+	}
+}

--- a/internal/metamodel/types.go
+++ b/internal/metamodel/types.go
@@ -128,10 +128,11 @@ func (tv *TypeValidation) SetCompiled(re *regexp.Regexp) {
 
 // CustomType defines a reusable type with optional enum values and/or regex validations.
 type CustomType struct {
-	Values      []string         `yaml:"values,omitempty"`      // Allowed values (makes this an enum type)
-	Default     string           `yaml:"default,omitempty"`     // Default value
-	Description string           `yaml:"description,omitempty"` // Documentation for the type
-	Validations []TypeValidation `yaml:"validations,omitempty"` // Regex validations with error messages
+	Values      []string          `yaml:"values,omitempty"`      // Allowed values (makes this an enum type)
+	Labels      map[string]string `yaml:"labels,omitempty"`      // Optional display labels keyed by value (display-only; value stays the identity)
+	Default     string            `yaml:"default,omitempty"`     // Default value
+	Description string            `yaml:"description,omitempty"` // Documentation for the type
+	Validations []TypeValidation  `yaml:"validations,omitempty"` // Regex validations with error messages
 }
 
 // EntityDef defines an entity type in the metamodel
@@ -195,13 +196,14 @@ type PropertySchema interface {
 
 // PropertyDef defines a property on an entity or relation
 type PropertyDef struct {
-	Type        string   `yaml:"type"`
-	Required    bool     `yaml:"required,omitempty"`
-	Values      []string `yaml:"values,omitempty"` // For inline enum types
-	Default     string   `yaml:"default,omitempty"`
-	Description string   `yaml:"description,omitempty"` // Documentation for the property
-	Format      string   `yaml:"format,omitempty"`      // Date format (Go layout, e.g., "2006-01-02")
-	List        bool     `yaml:"list,omitempty"`        // True for multi-select properties (allows multiple values)
+	Type        string            `yaml:"type"`
+	Required    bool              `yaml:"required,omitempty"`
+	Values      []string          `yaml:"values,omitempty"` // For inline enum types
+	Labels      map[string]string `yaml:"labels,omitempty"` // Optional display labels keyed by value (display-only; value stays the identity)
+	Default     string            `yaml:"default,omitempty"`
+	Description string            `yaml:"description,omitempty"` // Documentation for the property
+	Format      string            `yaml:"format,omitempty"`      // Date format (Go layout, e.g., "2006-01-02")
+	List        bool              `yaml:"list,omitempty"`        // True for multi-select properties (allows multiple values)
 	// Unique constrains the property to a natural key: no two entities of
 	// the same type may carry the same non-empty value. Enforced at write
 	// time by the entitymanager (a colliding create/update is rejected as

--- a/internal/openapi/generator_test.go
+++ b/internal/openapi/generator_test.go
@@ -270,6 +270,40 @@ func TestGenerator_PropertyTypes(t *testing.T) {
 	}
 }
 
+// TestGenerator_EnumLabelsDoNotLeakIntoEnum pins that display labels never
+// enter the OpenAPI `enum` — a JSON Schema enum is the set of accepted values,
+// not display text. Labels are a data-entry-UI concern only (TKT-G6R5YE).
+func TestGenerator_EnumLabelsDoNotLeakIntoEnum(t *testing.T) {
+	meta := &metamodel.Metamodel{
+		Entities: map[string]metamodel.EntityDef{
+			"test": {
+				Label: "Test",
+				Properties: map[string]metamodel.PropertyDef{
+					"status": {
+						Type:   "enum",
+						Values: []string{"open", "in_progress"},
+						Labels: map[string]string{"in_progress": "In Progress"},
+					},
+				},
+			},
+		},
+	}
+
+	spec := New(meta, Config{}).Generate()
+	media := spec.Paths["/api/v1/tests"].Post.RequestBody.Content["application/json"]
+	statusSchema := media.Schema.Properties["properties"].Properties["status"]
+
+	want := []string{"open", "in_progress"}
+	if len(statusSchema.Enum) != len(want) {
+		t.Fatalf("enum = %v, want %v", statusSchema.Enum, want)
+	}
+	for i, v := range want {
+		if statusSchema.Enum[i] != v {
+			t.Errorf("enum[%d] = %q, want %q (labels must not appear)", i, statusSchema.Enum[i], v)
+		}
+	}
+}
+
 func TestGenerator_DefaultConfig(t *testing.T) {
 	meta := &metamodel.Metamodel{}
 	gen := New(meta, Config{})

--- a/internal/openapi/schemas.go
+++ b/internal/openapi/schemas.go
@@ -377,6 +377,7 @@ func (g *Generator) addCommonSchemas(spec *Spec) {
 			"required":    BooleanSchema(),
 			"default":     StringSchema(),
 			"values":      ArraySchema(StringSchema()),
+			"labels":      {Type: "object", AdditionalProperties: StringSchema()},
 			"description": StringSchema(),
 			"list":        BooleanSchema(),
 		},
@@ -400,6 +401,7 @@ func (g *Generator) addCommonSchemas(spec *Spec) {
 		Type: "object",
 		Properties: map[string]*Schema{
 			"values":  ArraySchema(StringSchema()),
+			"labels":  {Type: "object", AdditionalProperties: StringSchema()},
 			"default": StringSchema(),
 		},
 	}

--- a/tickets/entities/docs-checklists/DOCS-WZ3NAD.md
+++ b/tickets/entities/docs-checklists/DOCS-WZ3NAD.md
@@ -1,0 +1,24 @@
+---
+id: DOCS-WZ3NAD
+type: docs-checklist
+title: 'Docs: Enum values support a display label/title for better UX on snake_case values'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Code Documentation
+
+- [x] Godoc / comments on new exported symbols — `CustomType.Labels`, `PropertyDef.Labels` (Go); `getEnumLabel`, `resolveOptionLabels`, `labelsForProperty` (store JSDoc-style comments)
+- [x] ~~README~~ (N/A: no project-level change)
+
+## Project Documentation
+
+- [x] `docs/metamodel.md` — added "Display Labels" subsection under Enum Types documenting the `labels:` map on custom types and inline enums, the display-only/value-stays-identity semantics, surfaces covered, back-compat, and custom-type precedence.
+- [x] ~~`docs/data-entry.md`~~ (N/A: metamodel.md is the canonical place for the enum feature; data-entry.md documents UI config, not per-value metamodel shape)
+- [x] ~~`docs/cli-reference.md`~~ (N/A: no CLI change)
+- [x] CLAUDE.md — no new pattern/convention that belongs there (feature follows existing consumer-side + store-getter patterns)
+
+## External Documentation
+
+- [x] ~~Changelog / release notes~~ (N/A: handled at release time; no separate changelog file in-tree)

--- a/tickets/entities/features/FEAT-JIBWQP.md
+++ b/tickets/entities/features/FEAT-JIBWQP.md
@@ -1,0 +1,25 @@
+---
+id: FEAT-JIBWQP
+type: feature
+title: Human-readable labels for enum property values
+summary: Allow the metamodel to declare a display label/title for each enum value so snake_case values render as human-friendly text in data-entry UI while keeping the value as the stored identity.
+description: Allow the metamodel to declare an optional display label per enum value so snake_case values render as human-friendly text in data-entry select widgets and badges, while the stored value remains the snake_case identity.
+status: proposed
+---
+
+## Feature: Human-readable labels for enum values
+
+Enum property values are snake_case identifiers (e.g. `in_progress`,
+`wont_fix`). Today the data-entry UI renders these raw in select dropdowns and
+badges, which is poor UX.
+
+This feature lets the metamodel author declare an optional human-readable
+**label** for each enum value. The label is display-only: the stored value (and
+everything keyed on it — validation, badge color lookup, transitions, option
+verdicts, existing entity data) stays the snake_case identifier.
+
+Applies to both enum declaration forms:
+- Named custom types (`types:` section)
+- Inline `type: enum` properties
+
+Backwards compatible: enums without labels continue to render the raw value.

--- a/tickets/entities/implementation-checklists/IMPL-MFE4M0.md
+++ b/tickets/entities/implementation-checklists/IMPL-MFE4M0.md
@@ -1,0 +1,58 @@
+---
+id: IMPL-MFE4M0
+type: implementation-checklist
+title: 'Implementation: Enum values support a display label/title for better UX on snake_case values'
+status: in-progress
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Development
+
+- [x] Unit tests written for new code
+- [x] Integration tests written (test full flow, not just units) — `_schema` API round-trip + live-server end-to-end verification
+- [x] Happy path implemented
+- [x] Edge cases from planning handled
+- [x] Error handling in place (errors surfaced, not swallowed) — N/A control flow: labels are optional/tolerant by design; no new error paths
+
+## Test Quality
+
+- [x] Using fixture builders or factories for test data — seeded metamodel/store fixtures; existing `newTestAppV1`
+- [x] No hardcoded values in assertions when object is in scope
+- [x] Only specifying values that matter for the test
+- [x] Interpolated values constructed from objects, not hardcoded
+- [x] Property comparisons use original object, not hardcoded strings
+
+## Manual Verification
+
+- [x] Feature manually tested end-to-end (live `rela-server`, `_schema` + OpenAPI + entity create)
+- [x] Each acceptance criterion verified
+- [x] Edge cases manually verified
+
+**Verification Evidence:**
+
+Built `rela-server`, ran against a scratch project with a labeled custom type
+(`ticket_status`) and a labeled inline list-enum (`tags`):
+
+- **AC1 (custom type):** `/_schema` → `types.ticket_status.labels = {in_progress: "In Progress", wont_fix: "Won't Fix"}`; the `status` property (custom-type-backed) inherited those labels on the wire.
+- **AC2 (inline enum):** `tags` property carried `labels = {needs_review: "Needs Review"}`.
+- **AC3/AC4 (badge + fallback):** covered by `Badge.test.ts` — label shown when configured, color class still derived from the raw value, no-label value falls back to raw + capitalize.
+- **AC5 (back-compat):** `title` (non-enum) emitted no `labels` key (omitempty); `TestParse_EnumLabels` asserts a label-less enum parses with nil Labels; `TestV1SchemaEnumLabelsOmittedWhenAbsent` asserts no `labels` key emitted.
+- **AC6 (validation value-based):** created entities via API stored raw `in_progress`/`wont_fix`; validation unchanged.
+- **AC7 (kanban/filter/edit surfaces):** `KanbanView.test.ts` (column header resolves enum label, explicit config label still wins), `AdHocFilterMenu.test.ts` (picker shows label, applies raw value), FilterBar option text via `optionText`.
+- **OpenAPI reach guard:** live `_openapi.json` `status` enum = `[backlog, in_progress, wont_fix, done]` (no labels); `TestGenerator_EnumLabelsDoNotLeakIntoEnum` pins it.
+
+Precedence (RR-UAV796): `TestV1SchemaEnumLabels` asserts a custom-typed property
+inherits the custom type's labels and that an inline `labels` map on such a
+property is ignored.
+
+Note: browser-based visual check was not run (Chrome extension not connected);
+the render logic is covered by the widget/component unit tests above.
+
+## Quality
+
+- [x] Code follows project patterns (consumer-side lookup via store getter mirrors existing `styles`; shared `toV1CustomType` helper avoids drift)
+- [x] Checked for DRY opportunities — extracted `toV1CustomType` (two serialization sites), `labelsForProperty`/`getEnumLabel` store getter (reused by Badge, SelectWidget, MultiSelect, Kanban, AdHocFilter)
+- [x] No security issues introduced — labels rendered via `{{ }}` text interpolation (escaped), no `v-html`; escaping test in `Badge.test.ts`
+- [x] No silent failures
+- [x] No debug code left behind

--- a/tickets/entities/implementation-checklists/IMPL-MFE4M0.md
+++ b/tickets/entities/implementation-checklists/IMPL-MFE4M0.md
@@ -2,7 +2,7 @@
 id: IMPL-MFE4M0
 type: implementation-checklist
 title: 'Implementation: Enum values support a display label/title for better UX on snake_case values'
-status: in-progress
+status: done
 ---
 
 <!-- @managed: claude-workflow v1 -->

--- a/tickets/entities/planning-checklists/PLAN-BCP0HF.md
+++ b/tickets/entities/planning-checklists/PLAN-BCP0HF.md
@@ -1,0 +1,173 @@
+---
+id: PLAN-BCP0HF
+type: planning-checklist
+title: 'Planning: Enum values support a display label/title for better UX on snake_case values'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Understanding
+
+- [x] Problem/requirements clearly understood
+- [x] Scope defined (what's in/out documented below)
+- [x] Acceptance criteria documented with specific test scenarios
+
+**Scope:**
+
+IN: optional per-value display labels for enum properties (named custom types +
+inline `type: enum`); labels carried over the v1 `_schema` API; rendered
+wherever enum values display in the data-entry web UI — centrally via `Badge`
+(lists, entity detail, kanban cards, side panel, form widgets) plus the
+edit/filter dropdown option text and kanban column headers. Backwards compatible
+— label-less enums render raw value.
+
+OUT: changing stored/wire value identity; i18n/multi-locale; labels for non-enum
+types; OpenAPI enum output (stays value-only); CLI display of labels.
+
+**Acceptance Criteria:**
+1. Named custom type with labels → data-entry select shows label, submits value. (test: schema API returns labels; widget renders label text, `<option>` value is the snake_case value)
+2. Inline `type: enum` with labels → same behavior.
+3. Badge display (single + multi) shows label; color styling still keys on value. Covers list rows, entity detail, kanban cards, side panel — all funnel through Badge.
+4. Enum with no labels → identical to today (raw value shown).
+5. Existing string-list `values:` metamodels load without error, no migration.
+6. Validation error messages remain value-based and correct.
+7. Kanban column headers and filter/edit dropdown option text show the label (label resolved) — no raw/label mismatch across surfaces.
+
+## Research
+
+- [x] ~~run `/research`~~ (N/A: approach clear, decision settled with user)
+- [x] Searched for existing patterns
+- [x] Checked codebase for similar patterns or reusable code
+- [x] Looked for reference implementations
+- [x] Reviewed relevant rela concepts for prior art
+
+**Research Doc:** N/A
+
+**Existing Solutions:**
+- Enum values are `[]string` end-to-end: YAML → Go (`metamodel.CustomType.Values`, `PropertyDef.Values`) → v1 wire → TS → Vue. No object shape today.
+- **`Badge.vue` is the single shared enum render surface** — used directly in `EntityList` (rows+cards), `EntityDetail` (enum cells), `KanbanView` (card fields), `SidePanel`, and via the form widgets. It already imports `useSchemaStore()` for color lookup keyed on `(property, value)`. This is the leverage point.
+- Existing label conventions to stay consistent with: `EntityDef.Label`/`LabelPlural`, `InverseDef.Label`. Per-value display string is a keyed set → a map is the right shape; keep the field named `labels`.
+- Prior art: TKT-JVA0D/TKT-YR7OW worked these widgets; RR-506Q warns against borrowing a display label as a wire identifier → keep value as identity.
+
+## Approach
+
+- [x] Technical approach chosen and documented
+- [x] Approach builds on existing patterns
+- [x] Alternatives considered
+- [x] Dependencies identified
+
+**Technical Approach (sidecar `labels:` map; frontend centered on Badge):**
+
+Add optional `Labels map[string]string` (keyed by value) beside `Values
+[]string`. No migration, no tolerant parser.
+
+*Backend:*
+1. **Structs** (`internal/metamodel/types.go`): add `Labels map[string]string \`yaml:"labels,omitempty"\``to`CustomType`and`PropertyDef`. **`omitempty` is required** (RR-O2JF23) — AST-based YAML write-back (`schema/cleanup.go:236`, `metamodel/rename.go:84`) preserves the field; omitempty avoids spurious `labels: {}` diffs.
+2. **Loader validation** (`internal/metamodel/loader.go`): **silent tolerance** (RR-I57OBI) — a `labels` key not in `values` is harmless (never rendered) and the loader has no warn channel; matches permissive-storage philosophy. No load change beyond parsing.
+3. **Validation** (`internal/metamodel/validation.go`): unchanged — stays keyed on `values`; labels never enter error messages.
+4. **v1 wire** (`internal/apiwire/v1/responses.go`): add `Labels map[string]string \`json:"labels,omitempty"\``to`PropertyDef`and`CustomType`(mirror`values` omitempty).
+5. **v1 serialization** (`internal/dataentry/api_v1.go`): copy `Labels` with the **exact same precedence as `Values`** (RR-UAV796) — `toV1PropertyDef`: `if ct,ok := meta.Types[propDef.Type]; ok { pd.Labels = ct.Labels } else if len(propDef.Values) > 0 { pd.Labels = propDef.Labels }`. Property referencing a custom type gets the custom type's labels; inline `labels` on a custom-typed property is intentionally ignored. Extract a shared `toV1CustomType(ct)` helper so `handleV1Schema`'s custom-type loop and `toV1PropertyDef` don't drift.
+6. **OpenAPI self-schema** (`internal/openapi/schemas.go` 373–405): add `labels` to the self-describing PropertyDef/CustomType schema. Enum output (`base.Enum`) stays value-only (add a regression test asserting this).
+7. **TS types** (`frontend/src/types/schema.ts`): add `labels?: Record<string,string>` to `PropertyDef` and `CustomType`.
+
+*Frontend (centered on Badge — RR-TRMD4O):*
+8. **`Badge.vue`** resolves the label itself via `useSchemaStore()`, keyed on `(property, value)`, same lookup path it uses for color. Display = `labelFor(value) ?? value`; **`:value` prop stays the raw wire value** (color key untouched). This automatically fixes list rows, entity detail, kanban cards, side panel — no per-call plumbing.
+- Drop `text-transform: capitalize` when a real label is present (RR-L6XI6S) — the author already chose the display form; only capitalize the fallback raw value.
+- Add `max-width` + ellipsis on `.badge` for long labels (RR-KQ1DXS).
+9. **`SelectWidget.vue` / `MultiSelectWidget.vue`**: display mode already delegates to Badge → free. For **edit mode**, `<option>` text = label, `:value` = value; TagSelect options show label. (RR-UZ6Q3G)
+10. **`KanbanView.vue`** column header: resolve the enum label for the grouping property so header matches card badges (RR-UZ6Q3G).
+11. **Filter dropdowns** (`FilterBar`, `AdHocFilterMenu`): option text shows label; filter value stays the raw value (RR-UZ6Q3G).
+
+**Alternatives considered:** object-list `values: [{value,label}]` — rejected
+(per user): breaks every `.Values []string` consumer, needs tolerant
+unmarshaller + migration. Threading labels through only the form widgets —
+rejected (RR-TRMD4O): misses the majority of display surfaces; Badge is the
+correct chokepoint.
+
+**Files to modify:**
+- `internal/metamodel/types.go`, `loader.go`, `validation.go` (validation: verify-only)
+- `internal/apiwire/v1/responses.go`
+- `internal/dataentry/api_v1.go` (+ `toV1CustomType` helper)
+- `internal/openapi/schemas.go`
+- `frontend/src/types/schema.ts`
+- `frontend/src/components/common/Badge.vue` (primary frontend change)
+- `frontend/src/widgets/SelectWidget.vue`, `MultiSelectWidget.vue` (edit-mode option text)
+- `frontend/src/components/.../KanbanView.vue` (column header)
+- `frontend/src/components/.../FilterBar.vue`, `AdHocFilterMenu.vue` (filter option text)
+- Tests + `docs/metamodel.md`, `docs/data-entry.md`
+
+## Security Considerations
+
+- [x] Input sources identified
+- [x] Input validation approach defined
+- [x] Security-sensitive operations identified
+- [x] Error handling doesn't leak sensitive information
+
+**Input Sources & Validation:**
+- `labels` comes from the trusted metamodel YAML (author-controlled, same trust level as `values`). Not end-user input.
+- Rendered via Vue `{{ }}` text interpolation (auto-escaped), never `v-html`. VERIFIED in review: the only `v-html` uses are sanitized markdown, none on the enum/label path. Add a test asserting label text is escaped.
+
+**Security-Sensitive Operations:** none (display-only string mapping).
+
+## Test Plan
+
+- [x] Test scenarios documented for each acceptance criterion
+- [x] Edge cases identified
+- [x] Negative test cases defined
+- [x] Integration test approach defined
+
+**Test Scenarios (extend existing tests, don't duplicate):**
+- Go — `internal/dataentry/api_v1_test.go`: `toV1PropertyDef`/`handleV1Schema` copy `Labels` with custom-type-vs-inline precedence (AC1/AC2); string-list-only metamodel round-trips unchanged (AC5). `internal/openapi/generator_test.go`: `enum` output stays value-only (reach guard). `internal/metamodel` loader test: parses `labels:` on both forms.
+- Frontend — `frontend/src/components/common/Badge.test.ts`: Badge resolves label from store, shows label, color class derived from value, no-label falls back to raw + capitalize (AC3/AC4). `frontend/src/widgets/widgets.test.ts`: SelectWidget `<option>` text=label / value=value; MultiSelect per-chip label.
+
+**Edge Cases:**
+- Partial labels → unmapped values render raw (per-element for list enums).
+- `labels` key not in `values` → silently ignored.
+- Empty `labels: {}` → behaves as no labels.
+- Label = a different value's string → harmless for display (doc note).
+- Unicode → escaped text, fine.
+- Very long label → ellipsis via `.badge max-width` (RR-KQ1DXS).
+
+**Negative Tests:**
+- `type: enum` with no `values` still fails load (unchanged).
+- Submitting a label string as a value fails enum validation (value-based).
+
+## Risk Assessment
+
+- [x] Technical risks assessed with mitigations
+- [x] Security risks assessed
+- [x] Effort estimated (m)
+
+**Risks:**
+- Frontend scope was under-estimated (Badge is used in ~5 surfaces) — mitigated by centering on Badge, which covers them in one place. Still m; edit/filter/kanban option text is incremental.
+- XSS via metamodel label → text interpolation only; escaping test.
+- Badge color regression → color key stays on value; test asserts color-from-value while text shows label.
+- Wire drift (Go struct / OpenAPI self-schema / TS) → update in lockstep; shared `toV1CustomType`; `just arch-lint` + build.
+- Author-casing override by `capitalize` → drop capitalize when label present.
+
+**Effort:** m
+
+## Documentation Planning
+
+- [x] User-facing docs identified
+- [x] Docs-checklist will be created when entering implementation
+
+**Documentation Impact:**
+- [x] docs/metamodel.md — document `labels:` on enum types (custom + inline), value-stays-identity
+- [x] docs/data-entry.md — label rendering across badges/lists/kanban/forms
+- [ ] ~~CLI reference~~ (N/A: no CLI change)
+- [ ] ~~README~~ (N/A)
+
+## Design Review
+
+- [x] Run `/design-review` before starting implementation
+- [x] All critical/significant findings addressed in plan
+
+**Design Review Findings:** RR-TRMD4O (critical, Badge-centered — addressed in
+plan §8), RR-L6XI6S (significant, capitalize — §8), RR-UZ6Q3G (significant,
+kanban/filter/edit surfaces — §9–11, AC7), RR-UAV796 (significant, label
+precedence + shared helper — §5), RR-I57OBI (significant, silent tolerance —
+§2), RR-O2JF23 (minor, omitempty — §1), RR-KQ1DXS (minor, ellipsis + :value
+guardrail — §8). All folded into the approach; to be marked `addressed` during
+implementation.

--- a/tickets/entities/review-checklists/REV-TJHHFY.md
+++ b/tickets/entities/review-checklists/REV-TJHHFY.md
@@ -1,0 +1,56 @@
+---
+id: REV-TJHHFY
+type: review-checklist
+title: 'Review: Enum values support a display label/title for better UX on snake_case values'
+status: in-progress
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Automated Checks
+
+- [ ] All tests pass (`just test`)
+- [ ] Lint clean (`just lint`)
+- [ ] Coverage maintained (`just coverage-check`)
+
+## Code Review
+
+- [ ] Run `/code-review` command (invokes cranky-code-reviewer agent)
+- [ ] All critical review-responses addressed
+- [ ] All significant review-responses addressed
+- [ ] Self-reviewed the diff for unrelated changes
+
+**Review Responses:** <!-- List IDs of review-response entities created, e.g.,
+RR-xxxx -->
+
+## Acceptance Verification
+
+- [ ] Each acceptance criterion tested (reference planning checklist)
+- [ ] Test evidence documented in implementation checklist
+
+**Acceptance Status:**
+<!-- For each acceptance criterion, state PASS/FAIL with evidence -->
+
+## Documentation (enhancements only)
+
+Skip this section for bugs and internal refactors.
+
+- [ ] Docs-checklist created and linked via `has-docs`
+- [ ] User-facing documentation updated
+- [ ] Docs-checklist marked as done
+
+**Docs Checklist:** <!-- e.g., DOCS-xxxx -->
+
+## Final Checks
+
+- [ ] Commit message explains the why, not just what
+- [ ] No TODOs or FIXMEs left unaddressed
+- [ ] Ready for another developer to use
+
+## Pull Request
+
+- [ ] Run `/pr` command to create PR and monitor CI
+- [ ] All CI checks pass
+- [ ] PR URL documented below
+
+**PR:** <!-- e.g., https://github.com/org/repo/pull/123 -->

--- a/tickets/entities/review-checklists/REV-TJHHFY.md
+++ b/tickets/entities/review-checklists/REV-TJHHFY.md
@@ -2,7 +2,7 @@
 id: REV-TJHHFY
 type: review-checklist
 title: 'Review: Enum values support a display label/title for better UX on snake_case values'
-status: in-progress
+status: done
 ---
 
 <!-- @managed: claude-workflow v1 -->
@@ -10,15 +10,16 @@ status: in-progress
 ## Automated Checks
 
 - [x] All tests pass (`just test`) — Go: all `internal/...` packages ok; Frontend: 1195 vitest tests pass
-- [x] Lint clean (`just lint`) — golangci-lint 0 issues on changed packages; ESLint 0 errors in changed files; `just arch-lint` OK
+- [x] Lint clean (`just lint`) — golangci-lint 0 issues; ESLint 0 errors in changed files; `just arch-lint` OK
 - [x] Coverage maintained (`just coverage-check`) — package floor + total (77.2%) PASS
+- [x] Full `just ci` green locally (exit 0), incl. docs-check after regenerating from `docs-project/`
 
 ## Code Review
 
-- [x] Run `/code-review` command (cranky-code-reviewer) — 2 design-review rounds + 1 code-review round
+- [x] Run `/code-review` (cranky-code-reviewer) — 2 design-review rounds + 1 code-review round
 - [x] All critical review-responses addressed (RR-TRMD4O)
 - [x] All significant review-responses addressed (RR-L6XI6S, RR-UZ6Q3G, RR-UAV796, RR-I57OBI, RR-OAQMDM, RR-BPFGG6)
-- [x] Self-reviewed the diff for unrelated changes — no unrelated changes; frontend build artifacts gitignored
+- [x] Self-reviewed the diff for unrelated changes — none; frontend build artifacts gitignored
 
 **Review Responses:**
 
@@ -36,7 +37,7 @@ status: in-progress
 2. Inline enum labels → **PASS** (`TestParse_EnumLabels`, `TestV1SchemaEnumLabels`, `widgets.test.ts`).
 3. Badge shows label, color keyed on value → **PASS** (`Badge.test.ts` 'keeps color styling keyed on the raw value').
 4. No-label enum unchanged → **PASS** (`Badge.test.ts` fallback; `TestV1SchemaEnumLabelsOmittedWhenAbsent`).
-5. Existing string-list metamodels load, no migration → **PASS** (`TestParse_EnumLabels` nil-Labels; omitempty; no migration added).
+5. Existing string-list metamodels load, no migration → **PASS** (`TestParse_EnumLabels` nil-Labels; omitempty; no migration).
 6. Validation value-based → **PASS** (validation.go untouched; live API stored raw values).
 7. Kanban/filter/edit surfaces show labels, raw value preserved → **PASS** (`KanbanView.test.ts`, `AdHocFilterMenu.test.ts`).
 Reach guard (OpenAPI enum value-only) → **PASS**
@@ -45,7 +46,7 @@ Reach guard (OpenAPI enum value-only) → **PASS**
 ## Documentation (enhancements only)
 
 - [x] Docs-checklist created and linked via `has-docs` (DOCS-WZ3NAD)
-- [x] User-facing documentation updated (`docs/metamodel.md` enum Display Labels section)
+- [x] User-facing documentation updated (`docs-project/.../GUIDE-metamodel.md` → `docs/metamodel.md` Display Labels section)
 - [x] Docs-checklist marked as done
 
 **Docs Checklist:** DOCS-WZ3NAD
@@ -58,8 +59,8 @@ Reach guard (OpenAPI enum value-only) → **PASS**
 
 ## Pull Request
 
-- [ ] Run `/pr` command to create PR and monitor CI
-- [ ] All CI checks pass
-- [ ] PR URL documented below
+- [x] Run `/pr` command to create PR and monitor CI
+- [x] All CI checks pass (verified green after ticket-status push; see PR)
+- [x] PR URL documented below
 
-**PR:** <!-- pending -->
+**PR:** https://github.com/sourcehaven-bv/rela/pull/1099

--- a/tickets/entities/review-checklists/REV-TJHHFY.md
+++ b/tickets/entities/review-checklists/REV-TJHHFY.md
@@ -9,43 +9,52 @@ status: in-progress
 
 ## Automated Checks
 
-- [ ] All tests pass (`just test`)
-- [ ] Lint clean (`just lint`)
-- [ ] Coverage maintained (`just coverage-check`)
+- [x] All tests pass (`just test`) — Go: all `internal/...` packages ok; Frontend: 1195 vitest tests pass
+- [x] Lint clean (`just lint`) — golangci-lint 0 issues on changed packages; ESLint 0 errors in changed files; `just arch-lint` OK
+- [x] Coverage maintained (`just coverage-check`) — package floor + total (77.2%) PASS
 
 ## Code Review
 
-- [ ] Run `/code-review` command (invokes cranky-code-reviewer agent)
-- [ ] All critical review-responses addressed
-- [ ] All significant review-responses addressed
-- [ ] Self-reviewed the diff for unrelated changes
+- [x] Run `/code-review` command (cranky-code-reviewer) — 2 design-review rounds + 1 code-review round
+- [x] All critical review-responses addressed (RR-TRMD4O)
+- [x] All significant review-responses addressed (RR-L6XI6S, RR-UZ6Q3G, RR-UAV796, RR-I57OBI, RR-OAQMDM, RR-BPFGG6)
+- [x] Self-reviewed the diff for unrelated changes — no unrelated changes; frontend build artifacts gitignored
 
-**Review Responses:** <!-- List IDs of review-response entities created, e.g.,
-RR-xxxx -->
+**Review Responses:**
+
+- Design review (plan): RR-TRMD4O (critical), RR-L6XI6S, RR-UZ6Q3G, RR-UAV796, RR-I57OBI (significant), RR-O2JF23, RR-KQ1DXS (minor) — all addressed
+- Code review (impl): RR-OAQMDM, RR-BPFGG6 (significant, addressed), RR-20371R (minor, addressed), RR-6R4P6A (nit, addressed), RR-30SVO6 (nit, deferred — documented known limitation)
 
 ## Acceptance Verification
 
-- [ ] Each acceptance criterion tested (reference planning checklist)
-- [ ] Test evidence documented in implementation checklist
+- [x] Each acceptance criterion tested
+- [x] Test evidence documented in implementation checklist (IMPL-MFE4M0)
 
 **Acceptance Status:**
-<!-- For each acceptance criterion, state PASS/FAIL with evidence -->
+
+1. Named custom type labels → **PASS** (`TestV1SchemaEnumLabels`, live `_schema`; `Badge.test.ts` custom-type resolution).
+2. Inline enum labels → **PASS** (`TestParse_EnumLabels`, `TestV1SchemaEnumLabels`, `widgets.test.ts`).
+3. Badge shows label, color keyed on value → **PASS** (`Badge.test.ts` 'keeps color styling keyed on the raw value').
+4. No-label enum unchanged → **PASS** (`Badge.test.ts` fallback; `TestV1SchemaEnumLabelsOmittedWhenAbsent`).
+5. Existing string-list metamodels load, no migration → **PASS** (`TestParse_EnumLabels` nil-Labels; omitempty; no migration added).
+6. Validation value-based → **PASS** (validation.go untouched; live API stored raw values).
+7. Kanban/filter/edit surfaces show labels, raw value preserved → **PASS** (`KanbanView.test.ts`, `AdHocFilterMenu.test.ts`).
+Reach guard (OpenAPI enum value-only) → **PASS**
+(`TestGenerator_EnumLabelsDoNotLeakIntoEnum`, live `_openapi.json`).
 
 ## Documentation (enhancements only)
 
-Skip this section for bugs and internal refactors.
+- [x] Docs-checklist created and linked via `has-docs` (DOCS-WZ3NAD)
+- [x] User-facing documentation updated (`docs/metamodel.md` enum Display Labels section)
+- [x] Docs-checklist marked as done
 
-- [ ] Docs-checklist created and linked via `has-docs`
-- [ ] User-facing documentation updated
-- [ ] Docs-checklist marked as done
-
-**Docs Checklist:** <!-- e.g., DOCS-xxxx -->
+**Docs Checklist:** DOCS-WZ3NAD
 
 ## Final Checks
 
-- [ ] Commit message explains the why, not just what
-- [ ] No TODOs or FIXMEs left unaddressed
-- [ ] Ready for another developer to use
+- [x] Commit message explains the why, not just what
+- [x] No TODOs or FIXMEs left unaddressed
+- [x] Ready for another developer to use
 
 ## Pull Request
 
@@ -53,4 +62,4 @@ Skip this section for bugs and internal refactors.
 - [ ] All CI checks pass
 - [ ] PR URL documented below
 
-**PR:** <!-- e.g., https://github.com/org/repo/pull/123 -->
+**PR:** <!-- pending -->

--- a/tickets/entities/review-responses/RR-20371R.md
+++ b/tickets/entities/review-responses/RR-20371R.md
@@ -1,0 +1,9 @@
+---
+id: RR-20371R
+type: review-response
+title: Four drifted inline-vs-store label resolutions (DRY / latent invariant)
+finding: SelectWidget, MultiSelectWidget, AdHocFilterMenu, and FilterBar each resolve option labels slightly differently; FilterBar has NO store fallback (relies on the backend inlining custom-type labels onto every property def). Correct today because api_v1 copies ct.Labels into pd.Labels, but a load-bearing invariant held by four implementations. A shared resolveOptionLabels(propertyDef, propertyName, entityType) helper would make it explicit.
+severity: minor
+resolution: Added a single schema-store getter resolveOptionLabels(propertyDef, property, entityType) as the source of truth. SelectWidget, MultiSelectWidget, and FilterBar now all use it (FilterBar previously had no store fallback — gap closed). AdHocFilterMenu keeps its per-value valueLabel because it operates on a dynamic cross-type union with no upfront options map.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-30SVO6.md
+++ b/tickets/entities/review-responses/RR-30SVO6.md
@@ -1,0 +1,9 @@
+---
+id: RR-30SVO6
+type: review-response
+title: Kanban columnTitle label!==value heuristic can override explicit config label
+finding: KanbanView columnTitle treats column.label===column.value as 'no explicit label' and falls through to the enum label, so an author who deliberately sets label equal to the value gets it overridden. Narrow, display-only edge; the config shape can't distinguish 'absent' from 'present-equal-to-value' without a change. Known limitation.
+severity: nit
+reason: Display-only, extremely narrow edge (author explicitly sets a kanban column label equal to the raw value AND wants the raw value shown despite an enum label existing). Cannot be distinguished from 'no label' without a config-shape change (an explicit null/absent marker), which is out of scope for this ticket. Documented as a known limitation in the KanbanView columnTitle comment.
+status: deferred
+---

--- a/tickets/entities/review-responses/RR-6R4P6A.md
+++ b/tickets/entities/review-responses/RR-6R4P6A.md
@@ -1,0 +1,9 @@
+---
+id: RR-6R4P6A
+type: review-response
+title: Stale WidgetProps.entityType docstring
+finding: types.ts WidgetProps.entityType comment says 'present only on the file-property edit path'; SelectWidget/MultiSelectWidget now consume it as the enum-label disambiguator and FieldRenderer forwards it broadly. Update the comment.
+severity: nit
+resolution: Updated WidgetProps.entityType docstring to note it is also the enum-label disambiguator consumed by the select widgets and forwarded broadly by FieldRenderer; split out the entityId comment.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-BPFGG6.md
+++ b/tickets/entities/review-responses/RR-BPFGG6.md
@@ -1,0 +1,9 @@
+---
+id: RR-BPFGG6
+type: review-response
+title: 'Cross-type label scan: inaccurate styles analogy + untested collision'
+finding: 'labelsForProperty falls back to scanning entity+relation types and returning the first-inserted match when entityType is omitted (first-wins on collision). This is defensible (search-mode filters have no single type; mirrors the documented AdHocFilterMenu union), but: (a) the doc comment inaccurately claims it mirrors how `styles` collapses — `styles` is a flat server-authored config map, not a per-type-def scan; (b) no test pins the ambiguous no-entityType first-wins behavior. Fix the comment and add a collision test.'
+severity: significant
+resolution: Rewrote labelsForProperty's comment to document the deliberate first-wins tie-break and to correct the styles analogy (it is a per-type-def scan, not the flat server-authored styles map). Added schema.test.ts 'falls back to first-inserted type on collision when no entity type given' pinning the behavior.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-I57OBI.md
+++ b/tickets/entities/review-responses/RR-I57OBI.md
@@ -1,0 +1,8 @@
+---
+id: RR-I57OBI
+type: review-response
+title: Loader has no warn channel; labels validation must be silent or a real diagnostic
+finding: 'The plan says ''optional load-warn if a labels key isn''t in values'', but the loader has no warn severity — validate() accumulates hard errors into SchemaValidationError (loader.go:227-243). Options: (a) silent tolerance (matches permissive-storage philosophy, simplest, recommended), or (b) a real hard-error diagnostic added alongside the enum-empty check in validatePropertyDefs (loader.go:685) AND validateCustomTypes (loader.go:442). Pick one; the plan currently assumes a channel that doesn''t exist. A labels key not in values is harmless (never rendered), so silent tolerance is defensible.'
+severity: significant
+status: open
+---

--- a/tickets/entities/review-responses/RR-I57OBI.md
+++ b/tickets/entities/review-responses/RR-I57OBI.md
@@ -4,5 +4,6 @@ type: review-response
 title: Loader has no warn channel; labels validation must be silent or a real diagnostic
 finding: 'The plan says ''optional load-warn if a labels key isn''t in values'', but the loader has no warn severity — validate() accumulates hard errors into SchemaValidationError (loader.go:227-243). Options: (a) silent tolerance (matches permissive-storage philosophy, simplest, recommended), or (b) a real hard-error diagnostic added alongside the enum-empty check in validatePropertyDefs (loader.go:685) AND validateCustomTypes (loader.go:442). Pick one; the plan currently assumes a channel that doesn''t exist. A labels key not in values is harmless (never rendered), so silent tolerance is defensible.'
 severity: significant
-status: open
+resolution: Chose silent tolerance (option a). A labels key not in values is harmless (never rendered) and matches the permissive-storage philosophy; no loader diagnostic added. Verified by TestParse_EnumLabels (labels parse without error).
+status: addressed
 ---

--- a/tickets/entities/review-responses/RR-KQ1DXS.md
+++ b/tickets/entities/review-responses/RR-KQ1DXS.md
@@ -4,5 +4,6 @@ type: review-response
 title: Long labels overflow badges/options; Badge has no max-width/ellipsis
 finding: Badge.vue has no max-width/ellipsis (lines 51-59) and `<option>` cannot wrap. A long label will blow out list columns and kanban cards. Add CSS max-width + ellipsis on .badge as part of this work, or explicitly accept the risk. Also document that `:value` on Badge stays the raw wire value (color key) and label is a separate concern, so nobody 'simplifies' by passing label as :value and breaking color for multi-word labels.
 severity: minor
-status: open
+resolution: 'Badge .badge gained max-width: 24ch + overflow ellipsis + nowrap. The :value=raw-value / label-is-separate guardrail is documented in Badge.vue comments and the metamodel docs; store getter keeps color keyed on value. Verified by Badge.test.ts ''keeps color styling keyed on the raw value''.'
+status: addressed
 ---

--- a/tickets/entities/review-responses/RR-KQ1DXS.md
+++ b/tickets/entities/review-responses/RR-KQ1DXS.md
@@ -1,0 +1,8 @@
+---
+id: RR-KQ1DXS
+type: review-response
+title: Long labels overflow badges/options; Badge has no max-width/ellipsis
+finding: Badge.vue has no max-width/ellipsis (lines 51-59) and `<option>` cannot wrap. A long label will blow out list columns and kanban cards. Add CSS max-width + ellipsis on .badge as part of this work, or explicitly accept the risk. Also document that `:value` on Badge stays the raw wire value (color key) and label is a separate concern, so nobody 'simplifies' by passing label as :value and breaking color for multi-word labels.
+severity: minor
+status: open
+---

--- a/tickets/entities/review-responses/RR-L6XI6S.md
+++ b/tickets/entities/review-responses/RR-L6XI6S.md
@@ -1,0 +1,8 @@
+---
+id: RR-L6XI6S
+type: review-response
+title: 'Badge text-transform: capitalize overrides author label casing'
+finding: 'Badge.vue has `text-transform: capitalize`. Once an author-supplied label flows in (e.g. `high priority` -> `High Priority`, or an intentionally-cased label), capitalize silently overrides the author''s chosen display form. Plan must drop `capitalize` when a real label is present and only apply it to the fallback raw value.'
+severity: significant
+status: open
+---

--- a/tickets/entities/review-responses/RR-L6XI6S.md
+++ b/tickets/entities/review-responses/RR-L6XI6S.md
@@ -4,5 +4,6 @@ type: review-response
 title: 'Badge text-transform: capitalize overrides author label casing'
 finding: 'Badge.vue has `text-transform: capitalize`. Once an author-supplied label flows in (e.g. `high priority` -> `High Priority`, or an intentionally-cased label), capitalize silently overrides the author''s chosen display form. Plan must drop `capitalize` when a real label is present and only apply it to the fallback raw value.'
 severity: significant
-status: open
+resolution: 'Badge adds a badge--labeled class (text-transform: none) when a label is present, so author casing is preserved; the raw-value fallback keeps capitalize. Verified by Badge.test.ts ''suppresses CSS capitalize for a labeled value''.'
+status: addressed
 ---

--- a/tickets/entities/review-responses/RR-O2JF23.md
+++ b/tickets/entities/review-responses/RR-O2JF23.md
@@ -4,5 +4,6 @@ type: review-response
 title: Labels field needs yaml omitempty for round-trip safety
 finding: 'Metamodel YAML write-back (schema/cleanup.go:236, metamodel/rename.go:84) is AST/node-based, so a new struct field is round-trip-safe. But the new `Labels map[string]string` must carry `yaml:"labels,omitempty"` so an empty map never emits `labels: {}` and creates spurious diffs on every rename/cleanup run. Verified no struct-level MarshalYAML on Metamodel/CustomType/PropertyDef exists.'
 severity: minor
-status: open
+resolution: Labels field carries yaml:"labels,omitempty" on both CustomType and PropertyDef, and json:"labels,omitempty" on the wire structs. Verified by TestV1SchemaEnumLabelsOmittedWhenAbsent (no labels key emitted for a label-less enum) and live-server check that a non-enum property emits no labels key.
+status: addressed
 ---

--- a/tickets/entities/review-responses/RR-O2JF23.md
+++ b/tickets/entities/review-responses/RR-O2JF23.md
@@ -1,0 +1,8 @@
+---
+id: RR-O2JF23
+type: review-response
+title: Labels field needs yaml omitempty for round-trip safety
+finding: 'Metamodel YAML write-back (schema/cleanup.go:236, metamodel/rename.go:84) is AST/node-based, so a new struct field is round-trip-safe. But the new `Labels map[string]string` must carry `yaml:"labels,omitempty"` so an empty map never emits `labels: {}` and creates spurious diffs on every rename/cleanup run. Verified no struct-level MarshalYAML on Metamodel/CustomType/PropertyDef exists.'
+severity: minor
+status: open
+---

--- a/tickets/entities/review-responses/RR-OAQMDM.md
+++ b/tickets/entities/review-responses/RR-OAQMDM.md
@@ -1,0 +1,9 @@
+---
+id: RR-OAQMDM
+type: review-response
+title: Badge ellipsis max-width applies to all badges (unlabeled regression)
+finding: 'Badge.vue put `max-width: 24ch` + nowrap + ellipsis on the base `.badge` rule, so a pre-existing raw enum value >24 chars that rendered fully before now truncates — a rendering change for badges unrelated to the feature. Scope the truncation to `.badge--labeled` (labels are the overflow risk this ticket introduced), leaving unlabeled badges unchanged.'
+severity: significant
+resolution: 'Moved max-width: 24ch + overflow ellipsis + nowrap from the base .badge rule to .badge--labeled, so unlabeled raw-value badges render exactly as before; only author-supplied labels (the new overflow risk) are truncated.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-TRMD4O.md
+++ b/tickets/entities/review-responses/RR-TRMD4O.md
@@ -4,5 +4,6 @@ type: review-response
 title: Center label resolution on Badge, not the form widgets
 finding: 'The plan threads labels through SelectWidget/MultiSelectWidget display mode, but Badge is the shared render surface used directly in EntityList (rows+cards), EntityDetail (enum cells), KanbanView (card fields), and SidePanel. Wiring only the form widgets leaves every list/detail/kanban/side-panel enum showing the raw snake_case value — the majority of the UI the reach decision claims to cover. Correct design: make Badge resolve the label itself via useSchemaStore (which it already imports for color lookup), keyed on (property, value). Form widgets then need no display-mode label plumbing.'
 severity: critical
-status: open
+resolution: Label resolution centered on Badge via a new schema-store getter getEnumLabel(value, property, entityType?). Badge resolves and displays the label while keeping :value (and color lookup) on the raw value. This covers list rows, entity detail, kanban cards, and side panel in one place. Verified by Badge.test.ts.
+status: addressed
 ---

--- a/tickets/entities/review-responses/RR-TRMD4O.md
+++ b/tickets/entities/review-responses/RR-TRMD4O.md
@@ -1,0 +1,8 @@
+---
+id: RR-TRMD4O
+type: review-response
+title: Center label resolution on Badge, not the form widgets
+finding: 'The plan threads labels through SelectWidget/MultiSelectWidget display mode, but Badge is the shared render surface used directly in EntityList (rows+cards), EntityDetail (enum cells), KanbanView (card fields), and SidePanel. Wiring only the form widgets leaves every list/detail/kanban/side-panel enum showing the raw snake_case value — the majority of the UI the reach decision claims to cover. Correct design: make Badge resolve the label itself via useSchemaStore (which it already imports for color lookup), keyed on (property, value). Form widgets then need no display-mode label plumbing.'
+severity: critical
+status: open
+---

--- a/tickets/entities/review-responses/RR-UAV796.md
+++ b/tickets/entities/review-responses/RR-UAV796.md
@@ -4,5 +4,6 @@ type: review-response
 title: Label-copy precedence must mirror value precedence (custom-type vs inline)
 finding: toV1PropertyDef resolves custom-type Values by type-name (if meta.Types[propDef.Type] exists) else inline propDef.Values. Label copy must replicate this exact branch so a property referencing a custom type gets the CUSTOM TYPE's labels, and an inline `labels` map on a custom-typed property is (intentionally) ignored, matching how inline `values` is ignored there. Also handleV1Schema custom-type loop is a second independent CustomType serialization site — consider a shared toV1CustomType(ct) helper so the two don't drift.
 severity: significant
-status: open
+resolution: 'toV1PropertyDef copies Labels with the identical custom-type-vs-inline branch as Values. Extracted shared toV1CustomType(ct) used by both the _schema types loop and (implicitly) the property path. Verified by TestV1SchemaEnumLabels: custom-typed property inherits the custom type''s labels; inline labels on a custom-typed property are ignored.'
+status: addressed
 ---

--- a/tickets/entities/review-responses/RR-UAV796.md
+++ b/tickets/entities/review-responses/RR-UAV796.md
@@ -1,0 +1,8 @@
+---
+id: RR-UAV796
+type: review-response
+title: Label-copy precedence must mirror value precedence (custom-type vs inline)
+finding: toV1PropertyDef resolves custom-type Values by type-name (if meta.Types[propDef.Type] exists) else inline propDef.Values. Label copy must replicate this exact branch so a property referencing a custom type gets the CUSTOM TYPE's labels, and an inline `labels` map on a custom-typed property is (intentionally) ignored, matching how inline `values` is ignored there. Also handleV1Schema custom-type loop is a second independent CustomType serialization site — consider a shared toV1CustomType(ct) helper so the two don't drift.
+severity: significant
+status: open
+---

--- a/tickets/entities/review-responses/RR-UZ6Q3G.md
+++ b/tickets/entities/review-responses/RR-UZ6Q3G.md
@@ -1,0 +1,8 @@
+---
+id: RR-UZ6Q3G
+type: review-response
+title: Kanban column headers and filter/edit dropdowns show raw values
+finding: 'Kanban column headers (KanbanView.vue) render the raw enum value outside any Badge, and filter dropdowns (FilterBar, AdHocFilterMenu, TagSelect options) plus the edit `<option>` list present raw values. Result: card badge says ''In Progress'' while the column header / filter option says ''in_progress''. Plan must decide per-surface: resolve the enum label for the kanban column header, the edit `<option>` text, and filter option lists (or explicitly scope-out with the inconsistency accepted in writing).'
+severity: significant
+status: open
+---

--- a/tickets/entities/review-responses/RR-UZ6Q3G.md
+++ b/tickets/entities/review-responses/RR-UZ6Q3G.md
@@ -4,5 +4,6 @@ type: review-response
 title: Kanban column headers and filter/edit dropdowns show raw values
 finding: 'Kanban column headers (KanbanView.vue) render the raw enum value outside any Badge, and filter dropdowns (FilterBar, AdHocFilterMenu, TagSelect options) plus the edit `<option>` list present raw values. Result: card badge says ''In Progress'' while the column header / filter option says ''in_progress''. Plan must decide per-surface: resolve the enum label for the kanban column header, the edit `<option>` text, and filter option lists (or explicitly scope-out with the inconsistency accepted in writing).'
 severity: significant
-status: open
+resolution: Kanban column headers use a new columnTitle() that resolves the enum label (explicit config label still wins). Edit-mode <option> text in SelectWidget shows the label; MultiSelect passes optionLabels to TagSelect. Filter dropdowns (FilterBar optionText, AdHocFilterMenu valueLabel) show the label while the filter value stays raw. Verified by KanbanView.test.ts and AdHocFilterMenu.test.ts.
+status: addressed
 ---

--- a/tickets/entities/tickets/TKT-G6R5YE.md
+++ b/tickets/entities/tickets/TKT-G6R5YE.md
@@ -5,7 +5,7 @@ title: Enum values support a display label/title for better UX on snake_case val
 kind: enhancement
 priority: medium
 effort: m
-status: in-progress
+status: review
 ---
 
 ## Problem

--- a/tickets/entities/tickets/TKT-G6R5YE.md
+++ b/tickets/entities/tickets/TKT-G6R5YE.md
@@ -1,0 +1,51 @@
+---
+id: TKT-G6R5YE
+type: ticket
+title: Enum values support a display label/title for better UX on snake_case values
+kind: enhancement
+priority: medium
+effort: m
+status: in-progress
+---
+
+## Problem
+
+Enum property values are snake_case identifiers (`in_progress`, `wont_fix`,
+`needs_investigation`). The data-entry UI renders them raw in select dropdowns
+and badges — poor UX for end users who see `in_progress` instead of "In
+Progress".
+
+## Goal
+
+Allow the metamodel author to declare an optional display **label** per enum
+value. The label is display-only; the stored/wire value stays the snake_case
+identifier so validation, badge color lookup, transitions, option verdicts, and
+existing entity data are unaffected.
+
+## Scope
+
+**In scope**
+- Metamodel: optional per-value labels for both named custom types (`types:`) and inline `type: enum` properties.
+- Backend serialization to the frontend (v1 `_schema` API) carries labels.
+- Frontend: `SelectWidget`, `MultiSelectWidget`, `Badge` render the label when present, value otherwise.
+- Backwards compatibility: label-less enums render the raw value exactly as today.
+
+**Out of scope**
+- Changing the stored value or wire identity of any enum value.
+- i18n / multi-locale labels.
+- Labels for non-enum property types.
+- OpenAPI `enum` output (stays value-only — JSON Schema enums are values, not labels).
+
+## Acceptance criteria
+
+1. A named custom type can declare labels; the data-entry select shows the label, submits the value.
+2. An inline `type: enum` property can declare labels with the same behavior.
+3. A badge (display mode, single and multi) shows the label while color styling still keys on the value.
+4. An enum with no labels behaves identically to today (raw value shown).
+5. Existing metamodels (string-list `values:`) load without error and without migration.
+6. Validation error messages remain correct (value-based).
+
+## Open design decision
+
+Label shape — sidecar map vs. object list — to be settled in planning. See the
+technical approach.

--- a/tickets/entities/tickets/TKT-G6R5YE.md
+++ b/tickets/entities/tickets/TKT-G6R5YE.md
@@ -5,7 +5,7 @@ title: Enum values support a display label/title for better UX on snake_case val
 kind: enhancement
 priority: medium
 effort: m
-status: review
+status: done
 ---
 
 ## Problem

--- a/tickets/relations/FEAT-JIBWQP--requires--metamodel-types.md
+++ b/tickets/relations/FEAT-JIBWQP--requires--metamodel-types.md
@@ -1,0 +1,5 @@
+---
+from: FEAT-JIBWQP
+relation: requires
+to: metamodel-types
+---

--- a/tickets/relations/TKT-G6R5YE--affects--metamodel-types.md
+++ b/tickets/relations/TKT-G6R5YE--affects--metamodel-types.md
@@ -1,0 +1,5 @@
+---
+from: TKT-G6R5YE
+relation: affects
+to: metamodel-types
+---

--- a/tickets/relations/TKT-G6R5YE--has-docs--DOCS-WZ3NAD.md
+++ b/tickets/relations/TKT-G6R5YE--has-docs--DOCS-WZ3NAD.md
@@ -1,0 +1,5 @@
+---
+from: TKT-G6R5YE
+relation: has-docs
+to: DOCS-WZ3NAD
+---

--- a/tickets/relations/TKT-G6R5YE--has-implementation--IMPL-MFE4M0.md
+++ b/tickets/relations/TKT-G6R5YE--has-implementation--IMPL-MFE4M0.md
@@ -1,0 +1,5 @@
+---
+from: TKT-G6R5YE
+relation: has-implementation
+to: IMPL-MFE4M0
+---

--- a/tickets/relations/TKT-G6R5YE--has-planning--PLAN-BCP0HF.md
+++ b/tickets/relations/TKT-G6R5YE--has-planning--PLAN-BCP0HF.md
@@ -1,0 +1,5 @@
+---
+from: TKT-G6R5YE
+relation: has-planning
+to: PLAN-BCP0HF
+---

--- a/tickets/relations/TKT-G6R5YE--has-review--REV-TJHHFY.md
+++ b/tickets/relations/TKT-G6R5YE--has-review--REV-TJHHFY.md
@@ -1,0 +1,5 @@
+---
+from: TKT-G6R5YE
+relation: has-review
+to: REV-TJHHFY
+---

--- a/tickets/relations/TKT-G6R5YE--has-review-response--RR-20371R.md
+++ b/tickets/relations/TKT-G6R5YE--has-review-response--RR-20371R.md
@@ -1,0 +1,5 @@
+---
+from: TKT-G6R5YE
+relation: has-review-response
+to: RR-20371R
+---

--- a/tickets/relations/TKT-G6R5YE--has-review-response--RR-30SVO6.md
+++ b/tickets/relations/TKT-G6R5YE--has-review-response--RR-30SVO6.md
@@ -1,0 +1,5 @@
+---
+from: TKT-G6R5YE
+relation: has-review-response
+to: RR-30SVO6
+---

--- a/tickets/relations/TKT-G6R5YE--has-review-response--RR-6R4P6A.md
+++ b/tickets/relations/TKT-G6R5YE--has-review-response--RR-6R4P6A.md
@@ -1,0 +1,5 @@
+---
+from: TKT-G6R5YE
+relation: has-review-response
+to: RR-6R4P6A
+---

--- a/tickets/relations/TKT-G6R5YE--has-review-response--RR-BPFGG6.md
+++ b/tickets/relations/TKT-G6R5YE--has-review-response--RR-BPFGG6.md
@@ -1,0 +1,5 @@
+---
+from: TKT-G6R5YE
+relation: has-review-response
+to: RR-BPFGG6
+---

--- a/tickets/relations/TKT-G6R5YE--has-review-response--RR-I57OBI.md
+++ b/tickets/relations/TKT-G6R5YE--has-review-response--RR-I57OBI.md
@@ -1,0 +1,5 @@
+---
+from: TKT-G6R5YE
+relation: has-review-response
+to: RR-I57OBI
+---

--- a/tickets/relations/TKT-G6R5YE--has-review-response--RR-KQ1DXS.md
+++ b/tickets/relations/TKT-G6R5YE--has-review-response--RR-KQ1DXS.md
@@ -1,0 +1,5 @@
+---
+from: TKT-G6R5YE
+relation: has-review-response
+to: RR-KQ1DXS
+---

--- a/tickets/relations/TKT-G6R5YE--has-review-response--RR-L6XI6S.md
+++ b/tickets/relations/TKT-G6R5YE--has-review-response--RR-L6XI6S.md
@@ -1,0 +1,5 @@
+---
+from: TKT-G6R5YE
+relation: has-review-response
+to: RR-L6XI6S
+---

--- a/tickets/relations/TKT-G6R5YE--has-review-response--RR-O2JF23.md
+++ b/tickets/relations/TKT-G6R5YE--has-review-response--RR-O2JF23.md
@@ -1,0 +1,5 @@
+---
+from: TKT-G6R5YE
+relation: has-review-response
+to: RR-O2JF23
+---

--- a/tickets/relations/TKT-G6R5YE--has-review-response--RR-OAQMDM.md
+++ b/tickets/relations/TKT-G6R5YE--has-review-response--RR-OAQMDM.md
@@ -1,0 +1,5 @@
+---
+from: TKT-G6R5YE
+relation: has-review-response
+to: RR-OAQMDM
+---

--- a/tickets/relations/TKT-G6R5YE--has-review-response--RR-TRMD4O.md
+++ b/tickets/relations/TKT-G6R5YE--has-review-response--RR-TRMD4O.md
@@ -1,0 +1,5 @@
+---
+from: TKT-G6R5YE
+relation: has-review-response
+to: RR-TRMD4O
+---

--- a/tickets/relations/TKT-G6R5YE--has-review-response--RR-UAV796.md
+++ b/tickets/relations/TKT-G6R5YE--has-review-response--RR-UAV796.md
@@ -1,0 +1,5 @@
+---
+from: TKT-G6R5YE
+relation: has-review-response
+to: RR-UAV796
+---

--- a/tickets/relations/TKT-G6R5YE--has-review-response--RR-UZ6Q3G.md
+++ b/tickets/relations/TKT-G6R5YE--has-review-response--RR-UZ6Q3G.md
@@ -1,0 +1,5 @@
+---
+from: TKT-G6R5YE
+relation: has-review-response
+to: RR-UZ6Q3G
+---

--- a/tickets/relations/TKT-G6R5YE--implements--FEAT-JIBWQP.md
+++ b/tickets/relations/TKT-G6R5YE--implements--FEAT-JIBWQP.md
@@ -1,0 +1,5 @@
+---
+from: TKT-G6R5YE
+relation: implements
+to: FEAT-JIBWQP
+---


### PR DESCRIPTION
## Summary

Adds optional human-readable **display labels** for enum property values in the metamodel, so snake_case values (`in_progress`) render as "In Progress" in the data-entry web UI. Labels are **display-only** — the stored value, submitted value, validation, and badge colours all stay keyed on the raw value.

Ticket: **TKT-G6R5YE** · Feature: **FEAT-JIBWQP**

## Approach

Sidecar `labels: map[string]string` (keyed by value) alongside the existing `values []string`, on both `CustomType` and inline `PropertyDef`. Chosen over an object-list shape because it keeps `values` a plain string list — **no migration, no tolerant parser, existing metamodels unchanged**.

```yaml
types:
  status:
    values: [draft, in_progress, wont_fix]
    labels:
      in_progress: In Progress
      wont_fix: Won't Fix
```

## Changes

**Backend** — `internal/metamodel` (structs, `omitempty`), `internal/apiwire/v1` (wire), `internal/dataentry/api_v1.go` (`toV1PropertyDef` copies labels with the same custom-type-vs-inline precedence as values; shared `toV1CustomType` helper), `internal/openapi` (self-schema; enum output stays value-only).

**Frontend** — label resolution centered on `Badge` via a shared `getEnumLabel` / `resolveOptionLabels` schema-store getter, reused by `SelectWidget`, `MultiSelectWidget`, `FilterBar`, `KanbanView` column headers, and `AdHocFilterMenu`. `Badge` shows the label while colour/`:value` stay on the raw value; `.badge--labeled` drops CSS capitalize (honours author casing) and adds ellipsis for long labels.

## Value stays the identity

Verified across every surface: `<option>`/chip `:value`, filter values, submitted data, and badge colour keys all remain the raw snake_case value. Labels never become a wire identity. OpenAPI `enum` stays value-only (regression test pins it).

## Testing

- Backend: metamodel loader parse, `_schema` API (precedence + omitempty), OpenAPI enum-value-only regression guard.
- Frontend: `Badge` (label + colour-from-value + XSS escaping + fallback), widgets (option label vs raw value), Kanban column headers, AdHoc filter (label shown, raw value applied), store getters (incl. cross-type collision tie-break).
- `just ci` green; end-to-end verified against a live `rela-server` (schema API, OpenAPI, entity create).

## Review

2 design-review rounds + 1 code-review round → 12 review-responses, all resolved (11 addressed, 1 nit deferred with reason). No critical/correctness issues survived.

## Docs

`docs-project/entities/guides/GUIDE-metamodel.md` (→ generated `docs/metamodel.md`) — new "Display Labels" section.
