### PR TITLE
feat(dataentry): reveal missing required headers in analyze view (TKT-IL499B)

### DIFF
--- a/docs-project/entities/guides/GUIDE-data-entry.md
+++ b/docs-project/entities/guides/GUIDE-data-entry.md
@@ -2007,6 +2007,13 @@ with links to affected entities.
 When a dashboard is configured, a validation summary card is automatically appended showing the
 total error and warning counts with a link to the full analysis page.
 
+In each issue row the entity title links to that entity, while the message is a
+separate click target that reveals more about the failure. For a
+`content.required-headers` validation, clicking the message expands a detail row
+listing exactly which required headers the entity is missing (only exact-match
+headers; regex `pattern:` checks are not listed). A validation whose Lua script
+failed instead opens the script-error dialog from the same message click.
+
 No configuration is needed — the analysis page is always available in the sidebar.
 
 ## Documents

--- a/docs/data-entry.md
+++ b/docs/data-entry.md
@@ -2001,6 +2001,13 @@ with links to affected entities.
 When a dashboard is configured, a validation summary card is automatically appended showing the
 total error and warning counts with a link to the full analysis page.
 
+In each issue row the entity title links to that entity, while the message is a
+separate click target that reveals more about the failure. For a
+`content.required-headers` validation, clicking the message expands a detail row
+listing exactly which required headers the entity is missing (only exact-match
+headers; regex `pattern:` checks are not listed). A validation whose Lua script
+failed instead opens the script-error dialog from the same message click.
+
 No configuration is needed — the analysis page is always available in the sidebar.
 
 ## Documents

--- a/e2e/pages/analyze.page.ts
+++ b/e2e/pages/analyze.page.ts
@@ -57,8 +57,16 @@ export class AnalyzePage extends BasePage {
     return this.issueRows.count();
   }
 
-  async clickFirstIssueRow() {
-    await this.issueRows.first().click();
+  /**
+   * Navigate to the entity of the first entity-linked issue. The row's
+   * click targets are split (TKT-IL499B): the entity-title cell
+   * navigates, while the message cell reveals detail. Navigation is
+   * triggered by clicking the title, not the row — and only rows with a
+   * real entity expose a clickable title (ID-gap / load-error rows do
+   * not), so target the first clickable title rather than the first row.
+   */
+  async clickFirstIssueEntity() {
+    await this.page.locator('.entity-title.clickable').first().click();
   }
 
   async clickRefresh() {

--- a/e2e/tests/analyze.spec.ts
+++ b/e2e/tests/analyze.spec.ts
@@ -43,7 +43,7 @@ test.describe('Analyze Page', () => {
     }
   });
 
-  test('clicking an issue row navigates to that entity', async ({ appPage, api }) => {
+  test('clicking an issue entity title navigates to that entity', async ({ appPage, api }) => {
     const created = await api.createEntity('features', {
       properties: { title: 'Analyze nav check', status: 'draft', priority: 'high' },
     });
@@ -52,7 +52,7 @@ test.describe('Analyze Page', () => {
       await analyze.navigate();
 
       if ((await analyze.getIssueRowCount()) > 0) {
-        await analyze.clickFirstIssueRow();
+        await analyze.clickFirstIssueEntity();
         await expect(appPage).toHaveURL(/\/entity\//);
       }
     } finally {

--- a/frontend/src/components/common/IssuesTable.vue
+++ b/frontend/src/components/common/IssuesTable.vue
@@ -1,0 +1,319 @@
+<script setup lang="ts">
+import { ref } from 'vue'
+import { useRouter } from 'vue-router'
+import type { AnalyzeIssue } from '@/types'
+import { useSchemaStore } from '@/stores'
+import { useScriptErrorStore } from '@/stores/scriptError'
+
+// Renders one analysis check's issues as a table. The row's click
+// targets are split (TKT-IL499B): the entity-title cell navigates to the
+// entity; the message cell reveals "why did this fire" detail — either
+// the ScriptErrorDialog (Lua failures) or an expandable detail row
+// listing structured detail (e.g. missing headers). Neither cell is
+// interactive when it has nothing to do.
+const props = defineProps<{ issues: AnalyzeIssue[] }>()
+
+const router = useRouter()
+const schemaStore = useSchemaStore()
+const scriptErrorStore = useScriptErrorStore()
+
+interface IssueRow {
+  key: string
+  issue: AnalyzeIssue
+}
+
+// A stable per-row key so expand state survives re-render.
+function rowsFor(issues: AnalyzeIssue[]): IssueRow[] {
+  return issues.map((issue) => ({
+    key: `${issue.checkType}:${issue.entityType}:${issue.entityId}:${issue.message}`,
+    issue,
+  }))
+}
+
+function getEntityTitle(issue: AnalyzeIssue): string {
+  return issue.title?.trim() || issue.entityId
+}
+
+function getEntityTypeLabel(type: string): string {
+  return schemaStore.entityTypes.get(type)?.label || type
+}
+
+const expandedRows = ref<Set<string>>(new Set())
+function isExpanded(key: string): boolean {
+  return expandedRows.value.has(key)
+}
+
+// The entity-title cell navigates. Inert when the issue has no entity
+// (e.g. script-error / load-error rows).
+function canNavigate(issue: AnalyzeIssue): boolean {
+  return Boolean(issue.entityId && issue.entityType)
+}
+function onEntityClick(issue: AnalyzeIssue) {
+  if (canNavigate(issue)) {
+    router.push(`/entity/${issue.entityType}/${issue.entityId}`)
+  }
+}
+
+// The message cell reveals detail: script-error rows open the dialog;
+// rows with structured detail toggle the expandable detail row.
+function hasDetailReveal(issue: AnalyzeIssue): boolean {
+  return Boolean(issue.scriptError) || Boolean(issue.detail?.length)
+}
+function onMessageClick(key: string, issue: AnalyzeIssue, ev: Event) {
+  if (issue.scriptError) {
+    const trigger = ev.currentTarget instanceof HTMLElement ? ev.currentTarget : null
+    scriptErrorStore.show(issue.scriptError, trigger)
+    return
+  }
+  if (issue.detail?.length) {
+    const next = new Set(expandedRows.value)
+    if (next.has(key)) next.delete(key)
+    else next.add(key)
+    expandedRows.value = next
+  }
+}
+</script>
+
+<template>
+  <div class="issues-table-wrapper">
+    <table class="issues-table">
+      <thead>
+        <tr>
+          <th>Entity</th>
+          <th>Type</th>
+          <th>Message</th>
+          <th>Severity</th>
+        </tr>
+      </thead>
+      <tbody>
+        <template v-for="row in rowsFor(props.issues)" :key="row.key">
+          <tr class="issue-row">
+            <td class="entity-cell">
+              <template v-if="row.issue.entityId">
+                <span
+                  class="entity-title"
+                  :class="{ clickable: canNavigate(row.issue) }"
+                  :role="canNavigate(row.issue) ? 'button' : undefined"
+                  :tabindex="canNavigate(row.issue) ? 0 : undefined"
+                  @click="onEntityClick(row.issue)"
+                  @keydown.enter="onEntityClick(row.issue)"
+                  @keydown.space.prevent="onEntityClick(row.issue)"
+                  >{{ getEntityTitle(row.issue) }}</span
+                >
+                <span class="entity-id">{{ row.issue.entityId }}</span>
+              </template>
+              <span v-else class="entity-empty">&mdash;</span>
+            </td>
+            <td>
+              <span v-if="row.issue.entityType" class="type-badge">{{
+                getEntityTypeLabel(row.issue.entityType)
+              }}</span>
+              <span v-else class="entity-empty">&mdash;</span>
+            </td>
+            <td class="message-cell">
+              <span
+                v-if="hasDetailReveal(row.issue)"
+                class="message-toggle"
+                role="button"
+                tabindex="0"
+                :aria-expanded="row.issue.detail?.length ? isExpanded(row.key) : undefined"
+                @click="onMessageClick(row.key, row.issue, $event)"
+                @keydown.enter="onMessageClick(row.key, row.issue, $event)"
+                @keydown.space.prevent="onMessageClick(row.key, row.issue, $event)"
+              >
+                <span
+                  v-if="row.issue.detail?.length"
+                  class="disclosure"
+                  :class="{ open: isExpanded(row.key) }"
+                  aria-hidden="true"
+                  >&#9656;</span
+                >
+                {{ row.issue.message }}
+              </span>
+              <span v-else>{{ row.issue.message }}</span>
+            </td>
+            <td>
+              <span class="severity-badge" :class="row.issue.severity">
+                {{ row.issue.severity.toUpperCase() }}
+              </span>
+            </td>
+          </tr>
+          <tr v-if="row.issue.detail?.length && isExpanded(row.key)" class="issue-detail-row">
+            <td colspan="4">
+              <div class="detail-label">Missing required headers:</div>
+              <ul class="detail-list">
+                <li v-for="(d, i) in row.issue.detail" :key="i">{{ d }}</li>
+              </ul>
+            </td>
+          </tr>
+        </template>
+      </tbody>
+    </table>
+  </div>
+</template>
+
+<style scoped>
+.issues-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.issues-table th {
+  text-align: left;
+  padding: 10px 16px;
+  background: var(--hover-bg);
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--muted-text);
+  border-bottom: 1px solid var(--border-color);
+}
+
+.issues-table td {
+  padding: 12px 16px;
+  border-bottom: 1px solid var(--border-color);
+  font-size: 14px;
+}
+
+.issue-row {
+  transition: background 0.15s;
+}
+
+.issue-row:last-child td {
+  border-bottom: none;
+}
+
+/* `display: flex` on the <td> collapses the cell box so its border
+ * doesn't span the row height (visible discontinuity between rows).
+ * Keep the td as a normal table-cell and stack the two spans with
+ * block display + margin instead. */
+.entity-title {
+  display: block;
+  color: var(--accent-color, #6366f1);
+  font-weight: 500;
+}
+
+/* Split click targets (TKT-IL499B): the entity title navigates, the
+ * message toggles detail. Each is an independently focusable button. */
+.entity-title.clickable {
+  cursor: pointer;
+}
+
+.entity-title.clickable:hover {
+  text-decoration: underline;
+}
+
+.entity-title.clickable:focus-visible {
+  outline: 2px solid var(--accent-color, #6366f1);
+  outline-offset: 2px;
+  border-radius: 2px;
+}
+
+.message-toggle {
+  cursor: pointer;
+  display: inline;
+}
+
+.message-toggle:focus-visible {
+  outline: 2px solid var(--accent-color, #6366f1);
+  outline-offset: 2px;
+  border-radius: 2px;
+}
+
+.disclosure {
+  display: inline-block;
+  margin-right: 4px;
+  font-size: 11px;
+  color: var(--muted-text);
+  transition: transform 0.15s;
+}
+
+.disclosure.open {
+  transform: rotate(90deg);
+}
+
+.issue-detail-row td {
+  background: var(--hover-bg);
+  padding: 8px 20px 12px;
+}
+
+.detail-label {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--muted-text);
+  margin-bottom: 4px;
+}
+
+.detail-list {
+  margin: 0;
+  padding-left: 20px;
+}
+
+.detail-list li {
+  font-family: monospace;
+  font-size: 13px;
+  color: var(--text-color);
+}
+
+.entity-id {
+  display: block;
+  margin-top: 2px;
+  font-family: monospace;
+  font-size: 12px;
+  color: var(--muted-text);
+}
+
+.entity-empty {
+  color: var(--muted-text);
+  font-size: 14px;
+}
+
+.type-badge {
+  display: inline-block;
+  padding: 4px 8px;
+  background: var(--hover-bg);
+  border-radius: 4px;
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  color: var(--muted-text);
+}
+
+.message-cell {
+  color: var(--text-color);
+  overflow-wrap: anywhere;
+  word-break: break-word;
+}
+
+.severity-badge {
+  display: inline-block;
+  padding: 4px 10px;
+  border-radius: 4px;
+  font-size: 11px;
+  font-weight: 600;
+}
+
+.severity-badge.error {
+  background: color-mix(in srgb, var(--error-color) 15%, transparent);
+  color: var(--error-color);
+}
+
+.severity-badge.warning {
+  background: color-mix(in srgb, var(--warning-color) 15%, transparent);
+  color: var(--warning-color);
+}
+
+.issues-table-wrapper {
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+}
+
+@media (max-width: 768px) {
+  .issues-table th,
+  .issues-table td {
+    padding: 8px 10px;
+    font-size: 12px;
+  }
+}
+</style>

--- a/frontend/src/components/common/IssuesTable.vue
+++ b/frontend/src/components/common/IssuesTable.vue
@@ -22,10 +22,17 @@ interface IssueRow {
   issue: AnalyzeIssue
 }
 
-// A stable per-row key so expand state survives re-render.
+// A stable per-row key so expand state survives re-render. The index is
+// part of the key because two distinct rules with the same Description
+// can be violated by the same entity, yielding identical
+// entityId+message rows; without the index those would collide (Vue
+// treats duplicate keys as one node, cross-linking their expand state).
+// The list only re-renders on a fresh analyze load, so index-based keys
+// are stable within a render and resetting expand state on reload is
+// acceptable.
 function rowsFor(issues: AnalyzeIssue[]): IssueRow[] {
-  return issues.map((issue) => ({
-    key: `${issue.checkType}:${issue.entityType}:${issue.entityId}:${issue.message}`,
+  return issues.map((issue, i) => ({
+    key: `${i}:${issue.checkType}:${issue.entityType}:${issue.entityId}`,
     issue,
   }))
 }

--- a/frontend/src/types/config.ts
+++ b/frontend/src/types/config.ts
@@ -277,6 +277,13 @@ export interface AnalyzeIssue {
   severity: 'error' | 'warning'
   checkType: string
   /**
+   * Optional structured specifics about why the issue fired, beyond the
+   * flat message. For content required-headers violations it lists the
+   * missing exact headers. Absent on rows with no structured detail;
+   * the message cell reveals it in an expandable detail row.
+   */
+  detail?: string[]
+  /**
    * Present only on validation script-error rows. Carries the same
    * envelope as the action surface so the UI can branch: rows with
    * scriptError open ScriptErrorDialog instead of navigating.

--- a/frontend/src/views/AnalyzeView.test.ts
+++ b/frontend/src/views/AnalyzeView.test.ts
@@ -74,7 +74,7 @@ describe('AnalyzeView click discrimination', () => {
     return wrapper
   }
 
-  it('opens ScriptErrorDialog (via store) when a script-error row is clicked', async () => {
+  it('opens ScriptErrorDialog (via store) when the message cell of a script-error row is clicked', async () => {
     const scriptError = makeScriptError()
     const wrapper = await mountWith([
       makeIssue({
@@ -87,14 +87,14 @@ describe('AnalyzeView click discrimination', () => {
     const store = useScriptErrorStore()
     expect(store.current).toBeNull()
 
-    const row = wrapper.find('.issue-row')
-    await row.trigger('click')
+    // The message cell — not the row — owns the "why did this fire" reveal.
+    await wrapper.find('.message-toggle').trigger('click')
 
     expect(store.current).toEqual(scriptError)
     expect(routerPush).not.toHaveBeenCalled()
   })
 
-  it('navigates to the entity when a regular violation row is clicked', async () => {
+  it('navigates to the entity when the entity-title cell is clicked (message cell does not navigate)', async () => {
     const wrapper = await mountWith([
       makeIssue({
         entityId: 'note-2',
@@ -105,14 +105,17 @@ describe('AnalyzeView click discrimination', () => {
     ])
 
     const store = useScriptErrorStore()
-    const row = wrapper.find('.issue-row')
-    await row.trigger('click')
+    await wrapper.find('.entity-title').trigger('click')
 
     expect(routerPush).toHaveBeenCalledWith('/entity/note/note-2')
     expect(store.current).toBeNull()
+
+    // A plain violation (no detail, no scriptError) has no interactive
+    // message affordance, so nothing there navigates.
+    expect(wrapper.find('.message-toggle').exists()).toBe(false)
   })
 
-  it('does nothing when a load-error row (no entity, no scriptError) is clicked', async () => {
+  it('does nothing when a load-error row (no entity, no scriptError, no detail) is clicked', async () => {
     const wrapper = await mountWith([
       makeIssue({
         title: 'missing-script',
@@ -121,25 +124,28 @@ describe('AnalyzeView click discrimination', () => {
     ])
 
     const store = useScriptErrorStore()
-    const row = wrapper.find('.issue-row')
-    await row.trigger('click')
+    // Neither cell is interactive on a load-error row.
+    expect(wrapper.find('.entity-title').exists()).toBe(false)
+    expect(wrapper.find('.message-toggle').exists()).toBe(false)
+    await wrapper.find('.issue-row').trigger('click')
 
     expect(routerPush).not.toHaveBeenCalled()
     expect(store.current).toBeNull()
   })
 
-  it('marks clickable rows with the .clickable class and inert rows without it', async () => {
+  it('marks the entity title clickable only when the issue has an entity', async () => {
     const wrapper = await mountWith([
-      makeIssue({ scriptError: makeScriptError() }), // script-error: clickable
-      makeIssue({ entityId: 'note-1', entityType: 'note' }), // entity: clickable
-      makeIssue({ title: 'missing-script' }), // load-error: NOT clickable
+      makeIssue({ scriptError: makeScriptError() }), // script-error: no entity
+      makeIssue({ entityId: 'note-1', entityType: 'note' }), // entity: navigable
+      makeIssue({ title: 'missing-script' }), // load-error: no entity
     ])
 
     const rows = wrapper.findAll('.issue-row')
     expect(rows).toHaveLength(3)
-    expect(rows[0].classes()).toContain('clickable')
-    expect(rows[1].classes()).toContain('clickable')
-    expect(rows[2].classes()).not.toContain('clickable')
+    // Only the row with a real entity exposes a clickable title.
+    expect(rows[0].find('.entity-title').exists()).toBe(false)
+    expect(rows[1].find('.entity-title').classes()).toContain('clickable')
+    expect(rows[2].find('.entity-title').exists()).toBe(false)
   })
 
   it('renders an em-dash when entity cell or type cell is empty (preserves row separators)', async () => {
@@ -219,8 +225,8 @@ describe('AnalyzeView section rendering (GH#785)', () => {
     // Rows carry the duplicate message — pins the message-cell rendering,
     // not just the row count.
     expect(rows[0].text()).toContain(duplicateMessage)
-    // Duplicates rows have real entities, so they must be clickable.
-    expect(rows[0].classes()).toContain('clickable')
+    // Duplicates rows have real entities, so their title must be clickable.
+    expect(rows[0].find('.entity-title').classes()).toContain('clickable')
   })
 
   it('renders an ID Gaps card with inert rows for each missing ID', async () => {
@@ -241,8 +247,8 @@ describe('AnalyzeView section rendering (GH#785)', () => {
 
     const rows = gaps!.findAll('.issue-row')
     expect(rows).toHaveLength(1)
-    // Gap rows have no entity, so they must not be clickable.
-    expect(rows[0].classes()).not.toContain('clickable')
+    // Gap rows have no entity, so there's no clickable title.
+    expect(rows[0].find('.entity-title').exists()).toBe(false)
     expect(rows[0].text()).toContain(gapMessage)
   })
 
@@ -358,5 +364,81 @@ describe('AnalyzeView entity title rendering', () => {
 
     const row = wrapper.find('.issue-row')
     expect(row.find('.entity-title').text()).toBe('note-2')
+  })
+})
+
+// TKT-IL499B: content required-headers violations carry a `detail` list
+// of missing headers. Clicking the message cell expands a full-width
+// detail row listing them; clicking again collapses it.
+describe('AnalyzeView missing-header detail', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    routerPush.mockReset()
+    analyzeMock.mockReset()
+    const schema = useSchemaStore()
+    schema.entityTypes.set('ncr', { label: 'NCR' } as never)
+  })
+
+  async function mountWith(issues: AnalyzeIssue[]) {
+    analyzeMock.mockResolvedValue(makeResult(issues))
+    const wrapper = mount(AnalyzeView, { attachTo: document.body })
+    await flushPromises()
+    return wrapper
+  }
+
+  function detailIssue() {
+    return makeIssue({
+      entityId: 'NCR-001',
+      entityType: 'ncr',
+      title: 'Verklaring van Toepasselijkheid',
+      message: 'NCR body moet standaardkoppen bevatten',
+      severity: 'error',
+      checkType: 'Validations',
+      detail: ['## Beschrijving', '## Oorzaak'],
+    })
+  }
+
+  it('toggles the detail row listing the missing headers on message click', async () => {
+    const wrapper = await mountWith([detailIssue()])
+
+    // Collapsed by default: no detail row.
+    expect(wrapper.find('.issue-detail-row').exists()).toBe(false)
+
+    const toggle = wrapper.find('.message-toggle')
+    expect(toggle.attributes('aria-expanded')).toBe('false')
+
+    await toggle.trigger('click')
+    const detail = wrapper.find('.issue-detail-row')
+    expect(detail.exists()).toBe(true)
+    const items = detail.findAll('.detail-list li').map((li) => li.text())
+    expect(items).toEqual(['## Beschrijving', '## Oorzaak'])
+    expect(wrapper.find('.message-toggle').attributes('aria-expanded')).toBe('true')
+    // Expanding detail must not navigate.
+    expect(routerPush).not.toHaveBeenCalled()
+
+    // Clicking again collapses.
+    await wrapper.find('.message-toggle').trigger('click')
+    expect(wrapper.find('.issue-detail-row').exists()).toBe(false)
+  })
+
+  it('is keyboard-operable: Enter on the message cell expands the detail', async () => {
+    const wrapper = await mountWith([detailIssue()])
+    await wrapper.find('.message-toggle').trigger('keydown.enter')
+    expect(wrapper.find('.issue-detail-row').exists()).toBe(true)
+  })
+
+  it('shows no expand affordance when the issue has no detail', async () => {
+    const wrapper = await mountWith([
+      makeIssue({
+        entityId: 'NCR-002',
+        entityType: 'ncr',
+        message: 'some other rule',
+        severity: 'error',
+        checkType: 'Validations',
+      }),
+    ])
+    expect(wrapper.find('.message-toggle').exists()).toBe(false)
+    expect(wrapper.find('.disclosure').exists()).toBe(false)
+    expect(wrapper.find('.issue-detail-row').exists()).toBe(false)
   })
 })

--- a/frontend/src/views/AnalyzeView.test.ts
+++ b/frontend/src/views/AnalyzeView.test.ts
@@ -427,6 +427,41 @@ describe('AnalyzeView missing-header detail', () => {
     expect(wrapper.find('.issue-detail-row').exists()).toBe(true)
   })
 
+  it('renders two same-message rows on one entity as distinct, independently-expandable rows', async () => {
+    // Two content rules sharing a Description, both violated by NCR-001,
+    // produce identical entityId+message rows. They must not collide on
+    // the row key (else Vue merges them and expand cross-links).
+    const sharedMessage = 'NCR body moet standaardkoppen bevatten'
+    const wrapper = await mountWith([
+      makeIssue({
+        entityId: 'NCR-001',
+        entityType: 'ncr',
+        message: sharedMessage,
+        severity: 'error',
+        checkType: 'Validations',
+        detail: ['## Oorzaak'],
+      }),
+      makeIssue({
+        entityId: 'NCR-001',
+        entityType: 'ncr',
+        message: sharedMessage,
+        severity: 'error',
+        checkType: 'Validations',
+        detail: ['## Corrigerende maatregel'],
+      }),
+    ])
+
+    const toggles = wrapper.findAll('.message-toggle')
+    expect(toggles).toHaveLength(2)
+
+    // Expanding the first must not expand the second.
+    await toggles[0].trigger('click')
+    const detailRows = wrapper.findAll('.issue-detail-row')
+    expect(detailRows).toHaveLength(1)
+    expect(detailRows[0].text()).toContain('## Oorzaak')
+    expect(detailRows[0].text()).not.toContain('## Corrigerende maatregel')
+  })
+
   it('shows no expand affordance when the issue has no detail', async () => {
     const wrapper = await mountWith([
       makeIssue({

--- a/frontend/src/views/AnalyzeView.vue
+++ b/frontend/src/views/AnalyzeView.vue
@@ -1,16 +1,11 @@
 <script setup lang="ts">
 import { ref, computed, onMounted } from 'vue'
-import { useRouter } from 'vue-router'
 import { analyze } from '@/api'
 import type { AnalyzeResult, AnalyzeIssue } from '@/types'
-import { useSchemaStore } from '@/stores'
-import { useScriptErrorStore } from '@/stores/scriptError'
 import { useBackTarget } from '@/composables/useBackTarget'
 import BackButton from '@/components/common/BackButton.vue'
+import IssuesTable from '@/components/common/IssuesTable.vue'
 
-const router = useRouter()
-const schemaStore = useSchemaStore()
-const scriptErrorStore = useScriptErrorStore()
 const backTarget = useBackTarget()
 
 // Check type definitions with descriptions. Three-way contract:
@@ -103,10 +98,6 @@ function shouldShowIssues(checkKey: string): boolean {
   return filterCheckType.value === checkKey
 }
 
-function getEntityTitle(issue: AnalyzeIssue): string {
-  return issue.title?.trim() || issue.entityId
-}
-
 // Methods
 async function loadAnalysis() {
   loading.value = true
@@ -116,30 +107,6 @@ async function loadAnalysis() {
     console.error('Analyze error:', err)
   } finally {
     loading.value = false
-  }
-}
-
-function getEntityTypeLabel(type: string): string {
-  const def = schemaStore.entityTypes.get(type)
-  return def?.label || type
-}
-
-// An issue is clickable if it has a structured Lua-failure envelope
-// (opens ScriptErrorDialog) or a real entity (navigates). LoadError
-// rows have neither and stay inert.
-function isClickable(issue: AnalyzeIssue): boolean {
-  if (issue.scriptError) return true
-  return Boolean(issue.entityId && issue.entityType)
-}
-
-function onIssueClick(issue: AnalyzeIssue, ev: Event) {
-  if (issue.scriptError) {
-    const trigger = ev.currentTarget instanceof HTMLElement ? ev.currentTarget : null
-    scriptErrorStore.show(issue.scriptError, trigger)
-    return
-  }
-  if (issue.entityId && issue.entityType) {
-    router.push(`/entity/${issue.entityType}/${issue.entityId}`)
   }
 }
 
@@ -203,50 +170,10 @@ onMounted(() => {
           </div>
 
           <template v-else>
-            <div v-if="shouldShowIssues(checkType.key) && getFilteredIssuesForCheck(checkType.key).length > 0" class="issues-table-wrapper">
-            <table class="issues-table">
-              <thead>
-                <tr>
-                  <th>Entity</th>
-                  <th>Type</th>
-                  <th>Message</th>
-                  <th>Severity</th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr
-                  v-for="(issue, idx) in getFilteredIssuesForCheck(checkType.key)"
-                  :key="`${checkType.key}-${idx}-${issue.entityType}-${issue.entityId}`"
-                  class="issue-row"
-                  :class="{ clickable: isClickable(issue) }"
-                  :tabindex="isClickable(issue) ? 0 : -1"
-                  @click="onIssueClick(issue, $event)"
-                  @keydown.enter="onIssueClick(issue, $event)"
-                  @keydown.space.prevent="onIssueClick(issue, $event)"
-                >
-                  <td class="entity-cell">
-                    <template v-if="issue.entityId">
-                      <span class="entity-title">{{ getEntityTitle(issue) }}</span>
-                      <span class="entity-id">{{ issue.entityId }}</span>
-                    </template>
-                    <template v-else>
-                      <span class="entity-empty">&mdash;</span>
-                    </template>
-                  </td>
-                  <td>
-                    <span v-if="issue.entityType" class="type-badge">{{ getEntityTypeLabel(issue.entityType) }}</span>
-                    <span v-else class="entity-empty">&mdash;</span>
-                  </td>
-                  <td class="message-cell">{{ issue.message }}</td>
-                  <td>
-                    <span class="severity-badge" :class="issue.severity">
-                      {{ issue.severity.toUpperCase() }}
-                    </span>
-                  </td>
-                </tr>
-              </tbody>
-            </table>
-            </div>
+            <IssuesTable
+              v-if="shouldShowIssues(checkType.key) && getFilteredIssuesForCheck(checkType.key).length > 0"
+              :issues="getFilteredIssuesForCheck(checkType.key)"
+            />
           </template>
         </div>
       </div>
@@ -414,118 +341,5 @@ onMounted(() => {
 
 .check-icon {
   font-size: 16px;
-}
-
-/* Issues table */
-.issues-table {
-  width: 100%;
-  border-collapse: collapse;
-}
-
-.issues-table th {
-  text-align: left;
-  padding: 10px 16px;
-  background: var(--hover-bg);
-  font-size: 11px;
-  font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.04em;
-  color: var(--muted-text);
-  border-bottom: 1px solid var(--border-color);
-}
-
-.issues-table td {
-  padding: 12px 16px;
-  border-bottom: 1px solid var(--border-color);
-  font-size: 14px;
-}
-
-.issue-row {
-  transition: background 0.15s;
-}
-
-.issue-row.clickable {
-  cursor: pointer;
-}
-
-.issue-row.clickable:hover,
-.issue-row.clickable:focus-visible {
-  background: var(--hover-bg);
-  outline: none;
-}
-
-.issue-row:last-child td {
-  border-bottom: none;
-}
-
-/* `display: flex` on the <td> collapses the cell box so its border
- * doesn't span the row height (visible discontinuity between rows).
- * Keep the td as a normal table-cell and stack the two spans with
- * block display + margin instead. */
-.entity-title {
-  display: block;
-  color: var(--accent-color, #6366f1);
-  font-weight: 500;
-}
-
-.entity-id {
-  display: block;
-  margin-top: 2px;
-  font-family: monospace;
-  font-size: 12px;
-  color: var(--muted-text);
-}
-
-.entity-empty {
-  color: var(--muted-text);
-  font-size: 14px;
-}
-
-.type-badge {
-  display: inline-block;
-  padding: 4px 8px;
-  background: var(--hover-bg);
-  border-radius: 4px;
-  font-size: 11px;
-  font-weight: 600;
-  text-transform: uppercase;
-  color: var(--muted-text);
-}
-
-.message-cell {
-  color: var(--text-color);
-  overflow-wrap: anywhere;
-  word-break: break-word;
-}
-
-.severity-badge {
-  display: inline-block;
-  padding: 4px 10px;
-  border-radius: 4px;
-  font-size: 11px;
-  font-weight: 600;
-}
-
-.severity-badge.error {
-  background: color-mix(in srgb, var(--error-color) 15%, transparent);
-  color: var(--error-color);
-}
-
-.severity-badge.warning {
-  background: color-mix(in srgb, var(--warning-color) 15%, transparent);
-  color: var(--warning-color);
-}
-
-.issues-table-wrapper {
-  overflow-x: auto;
-  -webkit-overflow-scrolling: touch;
-}
-
-@media (max-width: 768px) {
-  .issues-table th,
-  .issues-table td {
-    padding: 8px 10px;
-    font-size: 12px;
-  }
 }
 </style>

--- a/internal/dataentry/analyze.go
+++ b/internal/dataentry/analyze.go
@@ -37,6 +37,12 @@ type AnalysisIssue struct {
 	Message    string
 	Severity   string // "error" or "warning"
 
+	// Detail carries optional structured specifics about why the issue
+	// fired, beyond the flat Message. For content required-headers
+	// violations it holds the missing exact headers. Nil for issues
+	// with no structured detail.
+	Detail []string
+
 	// ScriptError carries the raw *lua.ScriptError for validation
 	// rules whose Lua script failed. Non-nil only on script-error
 	// rows; the HTTP handler converts it to a wire envelope using
@@ -445,8 +451,8 @@ func (svc analyzeService) analyzeValidations(ctx context.Context, meta *metamode
 			continue
 		}
 		severity := rule.GetSeverity()
-		for _, id := range full.Violations {
-			e, err := st.GetEntity(ctx, id)
+		for _, v := range full.Violations {
+			e, err := st.GetEntity(ctx, v.EntityID)
 			if err != nil {
 				continue
 			}
@@ -456,6 +462,7 @@ func (svc analyzeService) analyzeValidations(ctx context.Context, meta *metamode
 				Title:      meta.DisplayTitle(e.ID, e.Type, e.Properties),
 				Message:    rule.Description,
 				Severity:   severity,
+				Detail:     v.Detail,
 			})
 		}
 		// Surface Lua failures and load failures so the UI shows

--- a/internal/dataentry/analyze_test.go
+++ b/internal/dataentry/analyze_test.go
@@ -381,6 +381,45 @@ func TestAnalyzeValidations(t *testing.T) {
 	}
 }
 
+// TestAnalyzeValidations_AttachesMissingHeaderDetail covers TKT-IL499B
+// (RR-UFUX7T): a content required-headers violation must carry the
+// missing exact headers through to AnalysisIssue.Detail, so the
+// data-entry analyze view can reveal *which* headers are missing rather
+// than only the flat rule description. Guards against the loop silently
+// dropping Detail on the way from RuleResult to AnalysisIssue.
+func TestAnalyzeValidations_AttachesMissingHeaderDetail(t *testing.T) {
+	g := newFixture()
+	meta := &metamodel.Metamodel{
+		Entities: map[string]metamodel.EntityDef{"ncr": {}},
+		Validations: []metamodel.ValidationRule{
+			{
+				Name:        "ncr-standard-headers",
+				Description: "NCR body moet standaardkoppen bevatten",
+				EntityType:  "ncr",
+				Severity:    "error",
+				Content: &metamodel.ContentRule{
+					RequiredHeaders: []metamodel.HeaderCheck{
+						{Header: "## Beschrijving"},
+						{Header: "## Oorzaak"},
+					},
+				},
+			},
+		},
+	}
+	g.AddNode(&entity.Entity{ID: "NCR-001", Type: "ncr", Content: "# NCR\n## Beschrijving\ntext"})
+
+	svc := newAnalyzeService(t, g, meta)
+	section := svc.analyzeValidations(context.Background(), meta)
+
+	if len(section.Issues) != 1 {
+		t.Fatalf("expected 1 issue, got %d", len(section.Issues))
+	}
+	got := section.Issues[0].Detail
+	if len(got) != 1 || got[0] != "## Oorzaak" {
+		t.Errorf("Detail = %v, want [## Oorzaak]", got)
+	}
+}
+
 // TestAnalyzeValidations_SurfacesScriptError covers RR-MG0LG: a Lua
 // rule that fails to compile must appear as an error issue in the
 // analyze view rather than vanishing silently. The data-entry web

--- a/internal/dataentry/api_v1.go
+++ b/internal/dataentry/api_v1.go
@@ -1916,6 +1916,7 @@ func (a *App) handleV1Analyze(w http.ResponseWriter, r *http.Request) {
 			Message:    issue.Message,
 			Severity:   issue.Severity,
 			CheckType:  section,
+			Detail:     issue.Detail,
 		}
 		if issue.ScriptError != nil {
 			env := buildScriptErrorEnvelope(issue.ScriptError, fullDetail, "")

--- a/internal/dataentry/api_v1_test.go
+++ b/internal/dataentry/api_v1_test.go
@@ -2317,6 +2317,69 @@ func TestV1AnalyzeWithIssues(t *testing.T) {
 	_ = result
 }
 
+// TestV1Analyze_ContentDetailPassthrough covers TKT-IL499B: a content
+// required-headers violation must carry the missing exact headers to the
+// wire as APIIssue.detail, so the SPA can reveal which headers are
+// missing. Rows without detail must omit the field entirely (omitempty).
+func TestV1Analyze_ContentDetailPassthrough(t *testing.T) {
+	meta := &metamodel.Metamodel{
+		Entities: map[string]metamodel.EntityDef{
+			"ncr": {Label: "NCR", IDPrefix: "NCR-"},
+		},
+		Validations: []metamodel.ValidationRule{
+			{
+				Name:        "ncr-standard-headers",
+				Description: "NCR body moet standaardkoppen bevatten",
+				EntityType:  "ncr",
+				Severity:    "error",
+				Content: &metamodel.ContentRule{
+					RequiredHeaders: []metamodel.HeaderCheck{
+						{Header: "## Beschrijving"},
+						{Header: "## Oorzaak"},
+					},
+				},
+			},
+		},
+	}
+	cfg := &dataentryconfig.Config{App: dataentryconfig.AppConfig{Name: "Test"}}
+	app := newAppFromParts(cfg, meta, newFixture())
+	seedEntity(app, &entity.Entity{ID: "NCR-001", Type: "ncr", Content: "# NCR\n## Beschrijving\ntext"})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/_analyze", http.NoBody)
+	rec := httptest.NewRecorder()
+	app.handleV1Analyze(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+	var result APIAnalysisResult
+	if err := json.NewDecoder(rec.Body).Decode(&result); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	var found *APIIssue
+	for i := range result.Issues {
+		if result.Issues[i].EntityID == "NCR-001" {
+			found = &result.Issues[i]
+			break
+		}
+	}
+	if found == nil {
+		t.Fatalf("no issue for NCR-001; issues=%+v", result.Issues)
+	}
+	if len(found.Detail) != 1 || found.Detail[0] != "## Oorzaak" {
+		t.Errorf("Detail = %v, want [## Oorzaak]", found.Detail)
+	}
+
+	// omitempty: the raw JSON must not carry a "detail" key on rows
+	// without structured detail. Re-encode this issue with no detail
+	// and confirm the key is absent.
+	blank, _ := json.Marshal(APIIssue{EntityID: "X", Message: "m", Severity: "error"})
+	if strings.Contains(string(blank), "detail") {
+		t.Errorf("expected detail omitted when empty, got %s", blank)
+	}
+}
+
 // newAnalyzeScriptErrorApp builds an App with one inline-Lua validation
 // rule that fails to compile, so handleV1Analyze produces a script-error
 // issue. Wires SecurityConfig so allowFullScriptDetail can branch on

--- a/internal/dataentry/settings_handlers.go
+++ b/internal/dataentry/settings_handlers.go
@@ -31,6 +31,13 @@ type APIIssue struct {
 	Severity   string `json:"severity"` // "error" or "warning"
 	CheckType  string `json:"checkType"`
 
+	// Detail carries optional structured specifics about why the issue
+	// fired, beyond the flat Message. For content required-headers
+	// violations it holds the missing exact headers. Absent (omitempty)
+	// on rows with no structured detail; the frontend reveals it in an
+	// expandable detail row under the message.
+	Detail []string `json:"detail,omitempty"`
+
 	// ScriptError carries the structured Lua-failure envelope for
 	// validation script-error rows. Absent (omitempty) on every
 	// other row. The frontend uses presence as the discriminator:

--- a/internal/validation/content_rule.go
+++ b/internal/validation/content_rule.go
@@ -30,6 +30,40 @@ func CheckContentRule(content string, rule *metamodel.ContentRule) bool {
 	return true
 }
 
+// MissingRequiredHeaders returns the match-strings of every *exact*
+// required header the content is missing, for surfacing which headers a
+// content-rule violation is about (e.g. in the data-entry analyze view).
+//
+// It is a detail-only helper, NOT the pass/fail authority — that stays
+// CheckContentRule. Two deliberate narrowings versus CheckContentRule:
+//
+//   - Pattern header checks (IsPattern) are skipped: their match-string
+//     is a raw regex, which is misleading to show a user as a header to
+//     add. Only literal, actionable exact headers are reported.
+//   - Checks with an empty match-string are skipped, mirroring the
+//     trivial-pass semantics of MatchHeaderExact/MatchHeaderPattern (an
+//     empty match satisfies trivially, so it is never "missing").
+//
+// Returns nil (not an empty slice) when nothing is missing, so callers
+// can attach it conditionally and omitempty drops it on the wire.
+func MissingRequiredHeaders(content string, rule *metamodel.ContentRule) []string {
+	if rule == nil {
+		return nil
+	}
+
+	headers := markdown.ExtractHeaders(content)
+	var missing []string
+	for _, hc := range rule.RequiredHeaders {
+		if hc.IsPattern() || hc.GetMatchString() == "" {
+			continue
+		}
+		if !matchHeaderCheck(headers, hc) {
+			missing = append(missing, hc.GetMatchString())
+		}
+	}
+	return missing
+}
+
 // CheckChecklistRule validates checklist items against a metamodel
 // checklist rule. Returns true when items are acceptable (or when rule
 // is nil, or when there are no items).

--- a/internal/validation/content_rule_test.go
+++ b/internal/validation/content_rule_test.go
@@ -92,6 +92,93 @@ func TestCheckContentRule(t *testing.T) {
 	}
 }
 
+func TestMissingRequiredHeaders(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		content string
+		rule    *metamodel.ContentRule
+		want    []string
+	}{
+		{
+			name:    "nil rule returns nil",
+			content: "# Title",
+			rule:    nil,
+			want:    nil,
+		},
+		{
+			name:    "all present returns nil",
+			content: "# Title\n## Beschrijving\n## Oorzaak",
+			rule: &metamodel.ContentRule{
+				RequiredHeaders: []metamodel.HeaderCheck{
+					{Header: "## Beschrijving"},
+					{Header: "## Oorzaak"},
+				},
+			},
+			want: nil,
+		},
+		{
+			name:    "one missing returns that one",
+			content: "# Title\n## Beschrijving",
+			rule: &metamodel.ContentRule{
+				RequiredHeaders: []metamodel.HeaderCheck{
+					{Header: "## Beschrijving"},
+					{Header: "## Oorzaak"},
+				},
+			},
+			want: []string{"## Oorzaak"},
+		},
+		{
+			name:    "multiple missing returns all (no short-circuit)",
+			content: "# Title",
+			rule: &metamodel.ContentRule{
+				RequiredHeaders: []metamodel.HeaderCheck{
+					{Header: "## Beschrijving"},
+					{Header: "## Oorzaak"},
+				},
+			},
+			want: []string{"## Beschrijving", "## Oorzaak"},
+		},
+		{
+			name:    "pattern check excluded even when missing",
+			content: "# Title",
+			rule: &metamodel.ContentRule{
+				RequiredHeaders: []metamodel.HeaderCheck{
+					{Pattern: "## (Alternative|Alternatives)"},
+					{Header: "## Oorzaak"},
+				},
+			},
+			want: []string{"## Oorzaak"},
+		},
+		{
+			name:    "empty match-string check skipped",
+			content: "# Title",
+			rule: &metamodel.ContentRule{
+				RequiredHeaders: []metamodel.HeaderCheck{
+					{},
+					{Header: "## Oorzaak"},
+				},
+			},
+			want: []string{"## Oorzaak"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := MissingRequiredHeaders(tt.content, tt.rule)
+			if len(got) != len(tt.want) {
+				t.Fatalf("MissingRequiredHeaders() = %v, want %v", got, tt.want)
+			}
+			for i := range tt.want {
+				if got[i] != tt.want[i] {
+					t.Errorf("MissingRequiredHeaders()[%d] = %q, want %q", i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}
+
 func TestCheckChecklistRule(t *testing.T) {
 	t.Parallel()
 	tests := []struct {

--- a/internal/validation/validation.go
+++ b/internal/validation/validation.go
@@ -19,6 +19,13 @@ type Violation struct {
 	Severity    string // "error" or "warning"
 	EntityID    string
 	EntityTitle string
+
+	// Detail carries optional structured specifics about *why* this
+	// violation fired, for surfacing beyond the flat Description. For
+	// content required-headers rules it holds the missing exact
+	// headers (see MissingRequiredHeaders). Nil for violations with no
+	// structured detail (Lua, then-filter, property rules).
+	Detail []string
 }
 
 // Result aggregates the outputs of a validation pass: rule findings,
@@ -299,9 +306,15 @@ func (s *Service) checkEntityAgainstRule(
 		}
 	}
 
-	// Check content rules
+	// Check content rules. On failure, attach the missing exact
+	// headers as structured Detail (nil when the failure is a pattern
+	// or checklist miss, which carry no actionable literal detail).
 	if rule.Content != nil && !CheckContentRule(e.Content, rule.Content) {
-		out.Violations = append(out.Violations, newViolation(rule, e, rule.Description))
+		v := newViolation(rule, e, rule.Description)
+		if missing := MissingRequiredHeaders(e.Content, rule.Content); len(missing) > 0 {
+			v.Detail = missing
+		}
+		out.Violations = append(out.Violations, v)
 	}
 
 	return out

--- a/internal/validation/validation_test.go
+++ b/internal/validation/validation_test.go
@@ -139,6 +139,43 @@ func TestCheckWarnings(t *testing.T) {
 	}
 }
 
+func TestContentViolationCarriesMissingHeaderDetail(t *testing.T) {
+	t.Parallel()
+	meta := &metamodel.Metamodel{
+		Entities: map[string]metamodel.EntityDef{
+			"ncr": {Label: "NCR", IDPrefixes: []string{"NCR-"}},
+		},
+		Validations: []metamodel.ValidationRule{
+			{
+				Name:        "ncr-standard-headers",
+				Description: "NCR body moet standaardkoppen bevatten",
+				EntityType:  "ncr",
+				Severity:    "error",
+				Content: &metamodel.ContentRule{
+					RequiredHeaders: []metamodel.HeaderCheck{
+						{Header: "## Beschrijving"},
+						{Header: "## Oorzaak"},
+					},
+				},
+			},
+		},
+	}
+
+	entities := []*entity.Entity{
+		{ID: "NCR-001", Type: "ncr", Content: "# NCR\n## Beschrijving\nsome text"},
+	}
+
+	svc := New(meta, lua.ReadDeps{})
+	violations := svc.Check(context.Background(), entities, nil).Violations
+	if len(violations) != 1 {
+		t.Fatalf("got %d violations, want 1", len(violations))
+	}
+	got := violations[0].Detail
+	if len(got) != 1 || got[0] != "## Oorzaak" {
+		t.Errorf("Detail = %v, want [## Oorzaak]", got)
+	}
+}
+
 func TestCountBySeverity(t *testing.T) {
 	t.Parallel()
 	violations := []Violation{

--- a/internal/validator/validator.go
+++ b/internal/validator/validator.go
@@ -28,12 +28,22 @@ type Violation struct {
 	EntityTitle string
 }
 
+// RuleViolation is one entity's violation of a rule, with optional
+// structured detail about why it fired (e.g. which required headers are
+// missing). Detail is nil for violations that carry no structured
+// specifics (Lua, then-filter, property rules).
+type RuleViolation struct {
+	EntityID string
+	Detail   []string
+}
+
 // RuleResult is the full per-rule outcome surfaced to consumers that
 // want to render Lua-script failures (rule did not run) distinctly
 // from violations (rule ran and found a problem with an entity).
 type RuleResult struct {
-	// Violations is the list of entity IDs that violated the rule.
-	Violations []string
+	// Violations is the list of entities that violated the rule, each
+	// with optional structured detail.
+	Violations []RuleViolation
 	// ScriptErrors describe Lua failures (compile, runtime, timeout,
 	// contract). Each carries enough context (path, line, source
 	// slice) to render an actionable message.
@@ -94,7 +104,11 @@ func (v *GenericValidator) CheckRule(ctx context.Context, rule metamodel.Validat
 	if err != nil {
 		return nil, err
 	}
-	return full.Violations, nil
+	ids := make([]string, 0, len(full.Violations))
+	for _, vi := range full.Violations {
+		ids = append(ids, vi.EntityID)
+	}
+	return ids, nil
 }
 
 // CheckRuleFull runs a single rule and returns the full result —
@@ -112,11 +126,14 @@ func (v *GenericValidator) CheckRuleFull(
 
 	result := v.svc.CheckRule(ctx, rule, candidates, nil)
 	out := RuleResult{
-		Violations:   make([]string, 0, len(result.Violations)),
+		Violations:   make([]RuleViolation, 0, len(result.Violations)),
 		ScriptErrors: result.ScriptErrors,
 	}
 	for _, vi := range result.Violations {
-		out.Violations = append(out.Violations, vi.EntityID)
+		out.Violations = append(out.Violations, RuleViolation{
+			EntityID: vi.EntityID,
+			Detail:   vi.Detail,
+		})
 	}
 	for _, le := range result.LoadErrors {
 		out.LoadErrors = append(out.LoadErrors, LoadError{

--- a/internal/validator/validator_test.go
+++ b/internal/validator/validator_test.go
@@ -125,6 +125,55 @@ func TestGenericValidator_CheckRule_NoMatches(t *testing.T) {
 	}
 }
 
+func TestGenericValidator_CheckRuleFull_ContentDetail(t *testing.T) {
+	s := memstore.New()
+	ctx := context.Background()
+	_ = s.CreateEntity(ctx, &entity.Entity{
+		ID: "NCR-1", Type: "ncr", Content: "# NCR\n## Beschrijving\ntext",
+	})
+
+	rule := metamodel.ValidationRule{
+		Name:        "ncr-standard-headers",
+		Description: "NCR body moet standaardkoppen bevatten",
+		EntityType:  "ncr",
+		Severity:    "error",
+		Content: &metamodel.ContentRule{
+			RequiredHeaders: []metamodel.HeaderCheck{
+				{Header: "## Beschrijving"},
+				{Header: "## Oorzaak"},
+			},
+		},
+	}
+	meta := &metamodel.Metamodel{
+		Entities:    map[string]metamodel.EntityDef{"ncr": {Label: "NCR"}},
+		Validations: []metamodel.ValidationRule{rule},
+	}
+	v := validator.New(s, meta, lua.ReadDeps{Meta: meta})
+
+	full, err := v.CheckRuleFull(ctx, rule)
+	if err != nil {
+		t.Fatalf("CheckRuleFull error: %v", err)
+	}
+	if len(full.Violations) != 1 {
+		t.Fatalf("got %d violations, want 1", len(full.Violations))
+	}
+	if full.Violations[0].EntityID != "NCR-1" {
+		t.Errorf("EntityID = %q, want NCR-1", full.Violations[0].EntityID)
+	}
+	if d := full.Violations[0].Detail; len(d) != 1 || d[0] != "## Oorzaak" {
+		t.Errorf("Detail = %v, want [## Oorzaak]", d)
+	}
+
+	// CheckRule (the []string wrapper) still returns just the ID.
+	ids, err := v.CheckRule(ctx, rule)
+	if err != nil {
+		t.Fatalf("CheckRule error: %v", err)
+	}
+	if len(ids) != 1 || ids[0] != "NCR-1" {
+		t.Errorf("CheckRule ids = %v, want [NCR-1]", ids)
+	}
+}
+
 func TestGenericValidator_CheckRule_WrongEntityType(t *testing.T) {
 	v := newTestValidator(t)
 	// Rule scoped to decision type; only DEC-1 is candidate, has owner=""

--- a/tickets/entities/docs-checklists/DOCS-W71G70.md
+++ b/tickets/entities/docs-checklists/DOCS-W71G70.md
@@ -1,0 +1,24 @@
+---
+id: DOCS-W71G70
+type: docs-checklist
+title: 'Docs: missing-header detail in analyze view'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Code Documentation
+
+- [x] Godoc on `MissingRequiredHeaders` (`internal/validation/content_rule.go`) — states it's a detail-only helper, NOT the pass/fail authority, and documents the two deliberate narrowings (pattern-check excluded, empty-match-string skipped) with rationale.
+- [x] Godoc on `Violation.Detail` (validation.go), `RuleViolation` (validator.go), `AnalysisIssue.Detail` (analyze.go), `APIIssue.Detail` (settings_handlers.go), `AnalyzeIssue.detail` (config.ts) — each notes it's optional/per-violation and nil for non-content violations.
+- [x] Comment on `IssuesTable.vue` `rowsFor` explaining the index-in-key collision guard (RR-D2BOYL).
+
+## Project Documentation
+
+- [x] ~~CLAUDE.md~~ (N/A: no new package, convention, or boundary — additive field threading.)
+- [x] ~~README.md~~ (N/A: no project-level surface change.)
+
+## User-facing Documentation
+
+- [x] `docs/data-entry.md` — analyze-page section now documents the split click targets (entity title navigates; message reveals detail) and that a `content.required-headers` violation expands a detail row listing the missing exact headers (pattern checks excluded), plus the script-error-dialog path from the same message click.
+- [x] ~~api-reference.md~~ (N/A: the `analyze_*` MCP tools / CLI surface is unchanged — detail is data-entry-view only per RR-1GP8NI; the `/api/v1/_analyze` REST endpoint's `APIIssue` gains an optional `detail` but that endpoint's field list is not exhaustively documented in api-reference.md.)

--- a/tickets/entities/implementation-checklists/IMPL-6R4CXE.md
+++ b/tickets/entities/implementation-checklists/IMPL-6R4CXE.md
@@ -1,0 +1,69 @@
+---
+id: IMPL-6R4CXE
+type: implementation-checklist
+title: 'Implementation: Analysis view: reveal which detail failed a validation (missing headers etc.) on hover/click'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Development
+
+- [x] Unit tests written for new code (`content_rule_test.go` `TestMissingRequiredHeaders`; `validator_test.go` `TestGenericValidator_CheckRuleFull_ContentDetail`)
+- [x] Integration tests written (`validation_test.go` `TestContentViolationCarriesMissingHeaderDetail`; `analyze_test.go` `TestAnalyzeValidations_AttachesMissingHeaderDetail`; `api_v1_test.go` `TestV1Analyze_ContentDetailPassthrough` — store→validator→analyze→API round-trip)
+- [x] Happy path implemented (missing exact headers surfaced end-to-end)
+- [x] Edge cases from planning handled (pattern-check excluded, empty match-string skipped, nil-when-none, per-violation detail)
+- [x] Error handling in place (no new error paths; detail is additive/omitempty)
+
+## Test Quality
+
+- [x] Using fixture builders (`makeIssue`/`makeResult` in `AnalyzeView.test.ts`; table tests in Go)
+- [x] No hardcoded values in assertions when object is in scope
+- [x] Only specifying values that matter for the test
+- [x] Interpolated values constructed from objects, not hardcoded
+- [x] Property comparisons use original object, not hardcoded strings
+
+## Manual Verification
+
+- [x] Feature manually tested end-to-end
+- [x] Each acceptance criterion verified with test scenario from planning
+- [x] Edge cases manually verified
+
+**Verification Evidence:**
+
+Ran the real data-entry server (`rela-server`) against a throwaway project with
+an NCR entity-type + `content.required-headers` rule (`## Beschrijving`, `##
+Oorzaak`, `## Corrigerende maatregel`) and an NCR-001 entity that has only `##
+Beschrijving`.
+
+- **API (curl `/api/v1/_analyze`)** returned the Validations issue with
+`"detail": ["## Oorzaak", "## Corrigerende maatregel"]` — the two genuinely
+missing headers, omitting the present one. omitempty confirmed (field only
+present when populated). This exercises the full store→validator→analyze→wire
+chain including the RR-UFUX7T loop rewrite.
+- **AC1 (expand)** — in the browser, the Validations row showed the flat message
+with a ▸ disclosure; clicking the message expanded a full-width detail row
+"Missing required headers: ## Oorzaak / ## Corrigerende maatregel" in monospace.
+Screenshot captured; matches the reported use case.
+- **AC1 (collapse)** — second click collapsed the detail row (`aria-expanded`
+toggled false, detail row removed from DOM).
+- **AC2 (split targets)** — clicking the entity title routed to
+`/entity/ncr/NCR-001`; the message click did not navigate. Confirmed the row is
+no longer a single click target.
+- **CLI scope boundary (RR-1GP8NI)** — `rela analyze validations` still shows only
+the flat description (no detail), as intended.
+
+Automated: `go test ./internal/...` all pass (incl. validation, validator,
+dataentry, analysis, cli, mcp — the RuleResult blast-radius consumers). Frontend
+`npm run test:run` 1181 pass (11 existing AnalyzeView tests updated for the new
+split-target interaction + 4 new detail-row tests). `just arch-lint` clean,
+`golangci-lint` 0 issues on changed packages, `vue-tsc` + eslint clean on
+`AnalyzeView.vue` / `IssuesTable.vue`.
+
+## Quality
+
+- [x] Code follows project patterns (reused the `description` override slot; detail threads the same way `scriptError` does)
+- [x] Checked for DRY opportunities — extracted the issues table into `IssuesTable.vue` (kept `AnalyzeView.vue` under the `max-lines` god-component cap and made the table independently testable/reusable)
+- [x] No security issues introduced (detail is metamodel-authored, escaped `{{ }}`/`:aria-expanded`, no `v-html`; ACL-filtered upstream)
+- [x] No silent failures
+- [x] No debug code left behind

--- a/tickets/entities/planning-checklists/PLAN-YGNLZH.md
+++ b/tickets/entities/planning-checklists/PLAN-YGNLZH.md
@@ -1,0 +1,186 @@
+---
+id: PLAN-YGNLZH
+type: planning-checklist
+title: 'Planning: Analysis view: reveal which detail failed a validation (missing headers etc.) on hover/click'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Understanding
+
+- [x] Problem/requirements clearly understood
+- [x] Scope defined (what's in/out documented below)
+- [x] Acceptance criteria documented with specific test scenarios
+
+**Scope:**
+
+IN:
+- Surface *which required (exact-match) headers are missing* for content-rule (`content.required-headers`) violations in the data-entry **Analysis view** Validations table.
+- **Split the row's click targets** (per user decision): the **entity-title cell** navigates to the entity; the **message cell** toggles a full-width **detail row** listing the missing headers. The row is no longer a single click target. See RR-7UJUAI.
+- Thread the detail from the content-rule checker up through the validation → validator → analyze → API → SPA chain.
+
+OUT (explicit scope boundaries):
+- **Pattern-based header checks** (`IsPattern()`) — excluded from the detail, because `GetMatchString()` returns a raw regex that is misleading to show a user (RR-ZOGG1X). Only exact `Header` misses are reported.
+- **CLI `analyze`/`validate`** — those consume the *separate* `validator.Violation` struct via `CheckAll`, which does NOT gain `Detail` under this plan (RR-1GP8NI). Data-entry Analysis view only.
+- Checklist-rule / property-rule / cardinality detail; Lua-rule messages (already dynamic).
+- Write-path/autosave 422 surface (that is FEAT-13863O's other ticket TKT-1ARGYN).
+
+**Acceptance Criteria:**
+1. Given an entity failing a `content.required-headers` rule with exact headers `## Beschrijving` and `## Oorzaak` both missing, the Analysis view MESSAGE cell shows the rule description; clicking it expands a full-width detail row listing the two missing headers by name; clicking again collapses it. Test: unit test on `MissingRequiredHeaders` asserts it returns exactly the two match-strings; component test on `AnalyzeView.vue` asserts click toggles the detail row and it contains the headers.
+2. Clicking the **entity-title** cell navigates to the entity (`/entity/:type/:id`) — unchanged destination, now scoped to the title cell rather than the whole row. Test: component test asserts title-cell click routes; message-cell click does NOT route.
+3. Satisfied entity → no issue row (unchanged). Existing analyze tests stay green.
+4. Lua-script-failure row → clicking the message cell opens the existing `ScriptErrorDialog` (the script-error detail moves to the message cell alongside missing-header detail — the message cell owns all "why did this fire" reveal). Title cell inert (no entity). Existing script-error tests updated for the new trigger location.
+5. Non-content (then-filter / Lua) violation → no `detail` on the wire (omitempty), message cell has no expand affordance (no detail row). Test asserts absent `detail`.
+6. A `pattern:` header miss → NOT listed in detail (RR-ZOGG1X). Test asserts pattern checks are excluded.
+
+## Research
+
+- [x] For larger features: run `/research` — N/A (m-effort, well-scoped, single reported case)
+- [x] Searched for existing libraries — N/A (internal plumbing + existing Vue)
+- [x] Checked codebase for similar patterns or reusable code
+- [x] Looked for reference implementations in other projects
+- [x] Reviewed relevant rela concepts for prior art
+
+**Research Doc:** N/A — effort m, approach is clear from the code.
+
+**Existing Solutions / prior art in-codebase:**
+- **`scriptError` envelope** (`ScriptErrorEnvelope`, `AnalysisIssue.ScriptError`, `AnalyzeIssue.scriptError`, `ScriptErrorDialog` opened from `AnalyzeView.onIssueClick`) is the precedent for carrying structured per-issue detail end-to-end and click-to-reveal. This ticket adds a *lighter* per-issue detail (a string list rendered in an inline detail row).
+- **Lua violations already carry a dynamic per-entity message** (`LuaViolation.Message` → `Violation.Description` via `runLuaForEntity`, validation.go:337-346). `newViolation(rule, e, description)` already treats `description` as an override slot.
+- **The missing-header identity is already computed and discarded**: `CheckContentRule` (`content_rule.go:17-21`) loops `rule.RequiredHeaders` and returns `false` on the first miss.
+
+## Approach
+
+- [x] Technical approach chosen and documented
+- [x] Approach builds on existing patterns (not reinventing)
+- [x] Alternatives considered (document why rejected)
+- [x] Dependencies identified
+- [x] Design-review findings folded in (RR-UFUX7T, RR-ZOGG1X, RR-M2880C, RR-7UJUAI, RR-WFJQ1I, RR-1GP8NI, RR-WJ65QK)
+
+**Technical Approach:**
+
+Add an optional structured `Detail []string` to a violation and thread it
+through the two lossy narrowing points: (a) `CheckContentRule` returns only
+`bool`; (b) `validator.RuleResult.Violations` flattens `[]Violation` to
+`[]string` of IDs and `analyzeValidations` re-derives the message from
+`rule.Description`.
+
+1. **`internal/validation/content_rule.go`** — add `MissingRequiredHeaders(content string, rule *metamodel.ContentRule) []string`:
+   - Iterate `rule.RequiredHeaders`; for each `hc`, **skip if `hc.IsPattern()`** (RR-ZOGG1X) and **skip if `hc.GetMatchString() == ""`** (RR-M2880C — mirrors the primitives' trivial-pass); otherwise if `!matchHeaderCheck(headers, hc)` collect `hc.GetMatchString()` (the exact `## Header` string, which reads naturally — RR-WJ65QK).
+   - Collect **all** misses (no short-circuit).
+   - Return **`nil`** (not `[]string{}`) when nothing is missing (RR-WJ65QK).
+   - Keep `CheckContentRule` behaviorally identical: it still short-circuits on the first miss for exact AND pattern AND checklist (do NOT re-route it through `MissingRequiredHeaders`, which ignores patterns/checklist). `MissingRequiredHeaders` is a *detail-only* helper, not the pass/fail authority.
+
+2. **`internal/validation/validation.go`** — add `Detail []string` to the `Violation` struct. In `checkEntityAgainstRule`'s content branch (line 303-305): when `!CheckContentRule(...)`, compute `missing := MissingRequiredHeaders(e.Content, rule.Content)` and attach it, **only when `len(missing) > 0`** (RR-WJ65QK). Base `Description` stays `rule.Description`. Lua/then-filter call sites keep `Detail == nil` (RR-WFJQ1I: detail is per-*violation*, empty for non-content).
+
+3. **`internal/validator/validator.go`** — change `RuleResult.Violations` from `[]string` to a small exported struct, e.g. `type RuleViolation struct { EntityID string; Detail []string }`. `CheckRuleFull` populates `EntityID` + `Detail` from each `validation.Violation`. Keep `CheckRule` (public `[]string` method used by `mcp/tools_analysis.go:252`) as a wrapper mapping to `EntityID`s — its callers and tests are untouched.
+
+4. **`internal/dataentry/analyze.go`** — `AnalysisIssue` gains `Detail []string`. **Rewrite the loop at line 448** (RR-UFUX7T — this is the critical one): `for _, v := range full.Violations { e, err := st.GetEntity(ctx, v.EntityID); ...; Message: rule.Description, Detail: v.Detail }`. The loop var is now the struct, not a bare `id string`. Add a test asserting `AnalysisIssue.Detail` is populated (guards the no-op regression).
+
+5. **Wire** — `APIIssue` (`settings_handlers.go:26-41`) gains `Detail []string` with `json:"detail,omitempty"`; `handleV1Analyze` mapping (`api_v1.go` ~1910-1932) copies it; `visibleAnalysisIssues` passthrough unaffected. omitempty drops both nil and empty → absent on the wire.
+
+6. **Frontend** — `AnalyzeIssue` (`config.ts:271-285`) gains `detail?: string[]`. Rework `AnalyzeView.vue` from row-wide click to **split cell targets** (RR-7UJUAI):
+   - **Remove** the row-level `@click`/`@keydown`/`tabindex`/`clickable` on `<tr>` (lines ~220-225). The row is no longer interactive.
+   - **Entity-title cell** (line ~227-235): make the title (`.entity-title`) a `role="button"` with `tabindex="0"`, `@click`/`@keydown.enter`/`@keydown.space.prevent` → a new `onEntityClick(issue)` that does the `router.push('/entity/:type/:id')` (only when `entityId && entityType`).
+   - **Message cell** (line 240): make the message text a `role="button"` with `tabindex="0"`, `aria-expanded`, `aria-controls`, `@click`/keyboard → `onMessageClick(issue, idx)`. If `issue.scriptError` → open `ScriptErrorDialog` (move that branch here). Else if `issue.detail?.length` → toggle a per-row `expanded` state (a `Set<string>` or `ref` keyed by the row's stable key). If neither, the message is plain text (no button role).
+   - **Detail row**: wrap the `v-for` body in `<template v-for>` so each issue emits (a) the `<tr class="issue-row">` and (b) a second `<tr class="issue-detail-row" v-if="isExpanded(key)">` with a single `<td colspan="4">` holding a `<ul>` of `issue.detail` (each `## Header` as an escaped `{{ }}` list item — **no `v-html`**, RR-WJ65QK). Give both `<tr>`s distinct `:key`s (`key` and `key + '-detail'`).
+   - Scoped CSS for `.issue-detail-row` (muted background, small "Missing required headers:" label + the list). Full table width, not squished into the message cell (per user decision).
+
+**Alternatives considered:**
+- *Row-wide click + native `title` tooltip* (earlier plan/RR-7UJUAI) — superseded by user request: split the click targets instead. Better because (a) each target is independently focusable → clean keyboard a11y with no `@click.stop` propagation dance, and (b) a persistent expanded detail row beats an ephemeral hover tooltip for scanning/copying header names.
+- *Expand inside the message cell* (detail `<ul>` inside the `<td>`) — rejected per user: leaves the detail squished under one column with dead space beside it. The full-width `colspan` detail row reads cleanly.
+- *Rewrite the NCR rule as Lua* — rejected: abandons the declarative `content.required-headers` form and hides the logic in per-project Lua.
+- *Bake the header list into the flat `Description` string* — rejected: mixes static + computed text in one untyped string, harder to style, and loses the detail-on-demand UX.
+
+**Files to modify:**
+- `internal/validation/content_rule.go` (+ `content_rule_test.go`)
+- `internal/validation/validation.go` (+ tests)
+- `internal/validator/validator.go` (+ tests)
+- `internal/dataentry/analyze.go` (+ `analyze_test.go`)
+- `internal/dataentry/settings_handlers.go`, `internal/dataentry/api_v1.go` (+ handler test asserting `detail` passthrough)
+- `frontend/src/types/config.ts`, `frontend/src/views/AnalyzeView.vue` (+ component test)
+
+## Security Considerations
+
+- [x] Input sources identified
+- [x] Input validation approach defined
+- [x] Security-sensitive operations identified
+- [x] Error handling doesn't leak sensitive information
+
+**Input Sources & Validation:**
+- `detail` values are exact header match-strings from the **metamodel** (`rule.RequiredHeaders[].Header`), not user free-text or file paths. Rendered via Vue text interpolation in the detail `<ul>` (auto-escaped); no `v-html` (RR-WJ65QK).
+- ACL: detail rides inside `AnalysisIssue`, already ACL-filtered by `visibleAnalysisIssues` before serialization. No new visibility surface.
+
+**Security-Sensitive Operations:** none new.
+
+## Test Plan
+
+- [x] Test scenarios documented for each acceptance criterion
+- [x] Edge cases identified
+- [x] Negative test cases defined
+- [x] Integration test approach defined
+
+**Test Scenarios:**
+- AC1: `content_rule_test.go` table test on `MissingRequiredHeaders` (all-present→nil; one missing→that one; multiple→all). `analyze_test.go`: rule + fixture entity → `AnalysisIssue.Detail` populated (guards RR-UFUX7T). `AnalyzeView` component test: message-cell click toggles the detail `<tr>`; the detail row lists the headers; a second click collapses.
+- AC2: component test — title-cell click calls `router.push`; message-cell click does NOT navigate.
+- AC3: existing analyze tests green.
+- AC4: script-error row — message-cell click opens `ScriptErrorDialog` (updated trigger); title cell inert.
+- AC5: then-filter/property violation → `Detail` nil → API omits `detail` → message cell is plain text, no detail row.
+- AC6: `pattern:` header check → excluded from `MissingRequiredHeaders` output (RR-ZOGG1X).
+
+**Edge Cases:**
+- Empty match-string `HeaderCheck{}` → skipped, not surfaced as a header named "" (RR-M2880C).
+- Pattern header → excluded (RR-ZOGG1X).
+- Rule with both header + checklist failing → header detail only; no panic.
+- Rule with `lua:` + `content:` → Lua short-circuits; content detail not reached (RR-WFJQ1I) — expected, documented.
+- Multiple violations same EntityID (Lua) → each is its own row; Lua ones have nil detail (no expand).
+- Expand state keyed by the row's stable key → survives re-render; two rows expanded independently.
+- `MissingRequiredHeaders(content, nil)` → nil, no panic.
+- git-crypt unreadable body → entity skipped upstream (unchanged).
+- Long missing-header list → full-width detail row wraps; no horizontal overflow.
+
+**Negative Tests:**
+- API round-trip with no detail → JSON omits `detail`; SPA `issue.detail?.length` falsy → no button role, no detail row.
+
+**Integration approach:** `analyze_test.go` exercises store → validator →
+analyze → `AnalysisIssue` with a real fixture + real rule. Wire mapping covered
+by extending an existing `handleV1Analyze` handler test to assert `detail`
+passthrough.
+
+## Risk Assessment
+
+- [x] Technical risks assessed with mitigations
+- [x] Security risks assessed
+- [x] Effort estimated
+
+**Risks:**
+- *Silent no-op if analyze.go loop not rewritten* (RR-UFUX7T) — mitigated by the explicit step 4 + a `Detail`-populated assertion test.
+- *`RuleResult.Violations` type change* — blast radius verified small: only `analyze.go:448` consumes `full.Violations`; `CheckRule` `[]string` wrapper covers `mcp/tools_analysis.go`; CLI/analysis use the separate `validator.Violation`/`CheckAll` (RR-1GP8NI).
+- *Row → split-cell click rework* is the largest frontend change. Moving from one row handler to two cell handlers + a `<template v-for>` detail row must preserve: script-error dialog trigger (now on message cell), entity nav (now on title cell), keyboard operability of both targets, and the `:key` split. Mitigated by the AC2/AC4 component tests and running the app.
+
+**Effort:** m — mechanical backend threading across ~6 files, one genuine type
+change (`RuleResult.Violations`), plus a moderate `AnalyzeView.vue` rework
+(split targets + detail row).
+
+## Documentation Planning
+
+- [x] User-facing docs identified
+- [x] Docs-checklist will be created when entering implementation
+
+**Documentation Impact:**
+- [x] `docs/data-entry.md` (or analyze-view section, if present) — note content-rule violations now show which required headers are missing (click the message to expand), and that the entity title (not the whole row) navigates. Confirm exact file during implementation; N/A if no analyze-view doc exists.
+- [x] N/A for docs/metamodel.md, cli-reference.md, CLAUDE.md, README.md — no schema/command/convention change.
+
+## Design Review
+
+- [x] Run `/design-review` before starting implementation
+- [x] All critical/significant findings addressed in plan
+
+**Design Review Findings (all folded into Approach above):**
+- RR-UFUX7T (critical) — analyze.go loop rewrite. Addressed: step 4.
+- RR-ZOGG1X (significant) — exclude pattern checks. Addressed: step 1 + scope boundary + AC6.
+- RR-M2880C (significant) — empty-match-string skip. Addressed: step 1.
+- RR-7UJUAI (significant) — click-target a11y. Addressed via user-directed **split cell targets** (title navigates, message toggles a detail row); each target independently focusable, no `@click.stop`. Addressed: step 6.
+- RR-WFJQ1I (minor) — detail is per-violation/empty for non-content. Addressed: step 2 + edge cases.
+- RR-1GP8NI (minor) — CLI scope boundary. Addressed: scope OUT.
+- RR-WJ65QK (nit) — nil not empty slice, escaped render. Addressed: steps 1/2/6.

--- a/tickets/entities/review-checklists/REV-1GG5WN.md
+++ b/tickets/entities/review-checklists/REV-1GG5WN.md
@@ -58,7 +58,7 @@ a11y "done right."
 ## Pull Request
 
 - [x] Run `/pr` command to create PR and monitor CI
-- [ ] All CI checks pass
+- [x] All CI checks pass
 - [x] PR URL documented below
 
 **PR:** https://github.com/sourcehaven-bv/rela/pull/1100

--- a/tickets/entities/review-checklists/REV-1GG5WN.md
+++ b/tickets/entities/review-checklists/REV-1GG5WN.md
@@ -1,0 +1,56 @@
+---
+id: REV-1GG5WN
+type: review-checklist
+title: 'Review: Analysis view: reveal which detail failed a validation (missing headers etc.) on hover/click'
+status: in-progress
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Automated Checks
+
+- [ ] All tests pass (`just test`)
+- [ ] Lint clean (`just lint`)
+- [ ] Coverage maintained (`just coverage-check`)
+
+## Code Review
+
+- [ ] Run `/code-review` command (invokes cranky-code-reviewer agent)
+- [ ] All critical review-responses addressed
+- [ ] All significant review-responses addressed
+- [ ] Self-reviewed the diff for unrelated changes
+
+**Review Responses:** <!-- List IDs of review-response entities created, e.g.,
+RR-xxxx -->
+
+## Acceptance Verification
+
+- [ ] Each acceptance criterion tested (reference planning checklist)
+- [ ] Test evidence documented in implementation checklist
+
+**Acceptance Status:**
+<!-- For each acceptance criterion, state PASS/FAIL with evidence -->
+
+## Documentation (enhancements only)
+
+Skip this section for bugs and internal refactors.
+
+- [ ] Docs-checklist created and linked via `has-docs`
+- [ ] User-facing documentation updated
+- [ ] Docs-checklist marked as done
+
+**Docs Checklist:** <!-- e.g., DOCS-xxxx -->
+
+## Final Checks
+
+- [ ] Commit message explains the why, not just what
+- [ ] No TODOs or FIXMEs left unaddressed
+- [ ] Ready for another developer to use
+
+## Pull Request
+
+- [ ] Run `/pr` command to create PR and monitor CI
+- [ ] All CI checks pass
+- [ ] PR URL documented below
+
+**PR:** <!-- e.g., https://github.com/org/repo/pull/123 -->

--- a/tickets/entities/review-checklists/REV-1GG5WN.md
+++ b/tickets/entities/review-checklists/REV-1GG5WN.md
@@ -57,8 +57,8 @@ a11y "done right."
 
 ## Pull Request
 
-- [ ] Run `/pr` command to create PR and monitor CI
+- [x] Run `/pr` command to create PR and monitor CI
 - [ ] All CI checks pass
-- [ ] PR URL documented below
+- [x] PR URL documented below
 
 **PR:** https://github.com/sourcehaven-bv/rela/pull/1100

--- a/tickets/entities/review-checklists/REV-1GG5WN.md
+++ b/tickets/entities/review-checklists/REV-1GG5WN.md
@@ -61,4 +61,4 @@ a11y "done right."
 - [ ] All CI checks pass
 - [ ] PR URL documented below
 
-**PR:** <!-- pending -->
+**PR:** https://github.com/sourcehaven-bv/rela/pull/1100

--- a/tickets/entities/review-checklists/REV-1GG5WN.md
+++ b/tickets/entities/review-checklists/REV-1GG5WN.md
@@ -2,50 +2,58 @@
 id: REV-1GG5WN
 type: review-checklist
 title: 'Review: Analysis view: reveal which detail failed a validation (missing headers etc.) on hover/click'
-status: in-progress
+status: done
 ---
 
 <!-- @managed: claude-workflow v1 -->
 
 ## Automated Checks
 
-- [ ] All tests pass (`just test`)
-- [ ] Lint clean (`just lint`)
-- [ ] Coverage maintained (`just coverage-check`)
+- [x] All tests pass — `go test ./internal/...` green; frontend `npm run test:run` 1182 pass (16 in AnalyzeView.test.ts incl. new rowKey-collision test)
+- [x] Lint clean — `just arch-lint` OK; `golangci-lint` 0 issues on changed pkgs; `vue-tsc` + eslint clean on `AnalyzeView.vue` / `IssuesTable.vue` / `config.ts`
+- [x] Coverage maintained — `just coverage-check` PASS (package floor 50% + total 65% both satisfied; total 77.2%). validation 89.9%, validator 83.8%, dataentry 79.9%
 
 ## Code Review
 
-- [ ] Run `/code-review` command (invokes cranky-code-reviewer agent)
-- [ ] All critical review-responses addressed
-- [ ] All significant review-responses addressed
-- [ ] Self-reviewed the diff for unrelated changes
+- [x] Ran cranky-code-reviewer on commit 130c1970 (diff vs develop)
+- [x] All critical review-responses addressed — none raised
+- [x] All significant review-responses addressed — none raised
+- [x] Self-reviewed the diff for unrelated changes — none (build artifacts gitignored; stray dir removed)
 
-**Review Responses:** <!-- List IDs of review-response entities created, e.g.,
-RR-xxxx -->
+**Review Responses:** Design-review (pre-impl): RR-UFUX7T (critical), RR-ZOGG1X,
+RR-M2880C, RR-7UJUAI (significant), RR-WFJQ1I, RR-1GP8NI (minor), RR-WJ65QK
+(nit) — all `addressed` in the implementation. Code-review (this phase):
+RR-D2BOYL (minor) — rowKey collision for two same-Description rules on one
+entity; `addressed` (index folded into key + regression test). The reviewer
+raised no critical/significant findings and called the threading "airtight" and
+a11y "done right."
 
 ## Acceptance Verification
 
-- [ ] Each acceptance criterion tested (reference planning checklist)
-- [ ] Test evidence documented in implementation checklist
+- [x] Each acceptance criterion tested (see planning checklist ACs)
+- [x] Test evidence documented in implementation checklist
 
 **Acceptance Status:**
-<!-- For each acceptance criterion, state PASS/FAIL with evidence -->
+- AC1 (expand shows missing headers) — PASS: `MissingRequiredHeaders` unit + `analyze` integration + API round-trip + browser (screenshot: "Missing required headers: ## Oorzaak / ## Corrigerende maatregel"); collapse verified (aria-expanded toggles, detail row removed).
+- AC2 (title navigates, message doesn't) — PASS: component test + browser (title → `/entity/ncr/NCR-001`).
+- AC3 (satisfied → no row) — PASS: existing analyze tests green.
+- AC4 (script-error → dialog from message cell) — PASS: updated component test.
+- AC5 (non-content → no detail, omitempty) — PASS: wire test asserts omission.
+- AC6 (pattern excluded) — PASS: `content_rule_test.go` case.
 
 ## Documentation (enhancements only)
 
-Skip this section for bugs and internal refactors.
+- [x] Docs-checklist created and linked via `has-docs` (DOCS-W71G70)
+- [x] User-facing documentation updated — `docs-project/.../GUIDE-data-entry.md` (source) → regenerated `docs/data-entry.md` via `just docs`
+- [x] Docs-checklist marked as done
 
-- [ ] Docs-checklist created and linked via `has-docs`
-- [ ] User-facing documentation updated
-- [ ] Docs-checklist marked as done
-
-**Docs Checklist:** <!-- e.g., DOCS-xxxx -->
+**Docs Checklist:** DOCS-W71G70
 
 ## Final Checks
 
-- [ ] Commit message explains the why, not just what
-- [ ] No TODOs or FIXMEs left unaddressed
-- [ ] Ready for another developer to use
+- [x] Commit message explains the why, not just what (2 commits: feat + review-fix)
+- [x] No TODOs or FIXMEs left unaddressed
+- [x] Ready for another developer to use
 
 ## Pull Request
 
@@ -53,4 +61,4 @@ Skip this section for bugs and internal refactors.
 - [ ] All CI checks pass
 - [ ] PR URL documented below
 
-**PR:** <!-- e.g., https://github.com/org/repo/pull/123 -->
+**PR:** <!-- pending -->

--- a/tickets/entities/review-responses/RR-1GP8NI.md
+++ b/tickets/entities/review-responses/RR-1GP8NI.md
@@ -1,0 +1,11 @@
+---
+id: RR-1GP8NI
+type: review-response
+title: 'Scope boundary: CLI analyze/validate use validator.Violation/CheckAll and will NOT show detail'
+finding: internal/cli/analyze.go and validate.go and internal/analysis/analysis.go consume the separate validator.Violation struct (via CheckAll), not RuleResult.Violations. Under this plan that struct does NOT gain Detail, so CLI analyze/validate won't surface missing-header detail. Acceptable since the ticket targets the data-entry Analysis view only, but state it explicitly as a scope boundary so it isn't mistaken for an oversight. Also confirm no consumer JSON-marshals validation.Violation directly (grep showed field-name reads only -> safe).
+severity: minor
+resolution: 'Documented as explicit scope boundary (OUT): CLI analyze/validate use the separate validator.Violation/CheckAll path which does not gain Detail; data-entry Analysis view only. Grep confirmed no direct JSON-marshal of validation.Violation.'
+status: addressed
+---
+
+See finding property.

--- a/tickets/entities/review-responses/RR-7UJUAI.md
+++ b/tickets/entities/review-responses/RR-7UJUAI.md
@@ -1,0 +1,11 @@
+---
+id: RR-7UJUAI
+type: review-response
+title: Prefer native title tooltip over custom click-expand (a11y + propagation risk)
+finding: 'The row is the interactive element (tabindex, @keydown.enter, @keydown.space.prevent -> onIssueClick; AnalyzeView.vue:222-225). A custom inner click-expand with @click.stop contains the mouse click, but (a) it won''t be keyboard-reachable unless given role=button + tabindex, and (b) keyboard users pressing Enter/Space on the row still navigate, never expand. Simplest robust answer: use the native title attribute on the message cell for the missing-header list (hover tooltip, zero JS, no propagation/a11y risk). This satisfies the user''s ''mouseover'' ask. If click-expand is kept, it needs a real focusable button. Recommendation: ship the native title tooltip; treat click-expand as optional polish only if a focusable button is added.'
+severity: significant
+resolution: 'Resolved via user-directed split cell targets (supersedes the native-title-tooltip proposal): the entity-title cell navigates (onEntityClick), the message cell toggles a full-width colspan detail row (onMessageClick) and also owns the script-error dialog. Row-level click removed. Each target is an independently focusable role=button (tabindex, aria-expanded on message), so keyboard a11y works for both with no @click.stop propagation dance. Plan step 6.'
+status: addressed
+---
+
+See finding property.

--- a/tickets/entities/review-responses/RR-D2BOYL.md
+++ b/tickets/entities/review-responses/RR-D2BOYL.md
@@ -1,0 +1,11 @@
+---
+id: RR-D2BOYL
+type: review-response
+title: IssuesTable rowKey can collide for two same-description rules on one entity
+finding: 'IssuesTable.vue rowKey is `${checkType}:${entityType}:${entityId}:${message}`, dropping the array index the old AnalyzeView key had. Two distinct content rules with the same Description text, both violated by the same entity, produce two AnalysisIssues with identical entityId+message (message = rule.Description) -> identical Vue :key within the Validations section. Vue dev-warns and treats them as one node; the shared expandedRows entry means expanding one expands both. Old index-based key was collision-free. Fix: fold the array index back into the key (rowsFor maps with (issue, i) -> key `${i}:...`). Index is stable enough since the list only re-renders on a fresh analyze load. Add a rowsFor uniqueness test for two same-description rules.'
+severity: minor
+resolution: Folded the array index back into the IssuesTable rowKey (`${i}:${checkType}:${entityType}:${entityId}`) with a comment explaining why. Added AnalyzeView.test.ts case asserting two same-message rows on one entity render as two distinct, independently-expandable rows (expanding one does not expand the other).
+status: addressed
+---
+
+See finding property.

--- a/tickets/entities/review-responses/RR-M2880C.md
+++ b/tickets/entities/review-responses/RR-M2880C.md
@@ -1,0 +1,11 @@
+---
+id: RR-M2880C
+type: review-response
+title: MissingRequiredHeaders must preserve empty-match-string trivial-pass semantics
+finding: 'matchHeaderCheck / MatchHeaderExact / MatchHeaderPattern treat an empty match string as trivially satisfied (content.go:50-53, 64-67 return true for ""). A malformed HeaderCheck{} with neither Header nor Pattern currently passes. If MissingRequiredHeaders collects GetMatchString() for anything it deems unsatisfied, a blank check surfaces as a missing header named "". MissingRequiredHeaders must mirror the primitives: skip checks whose GetMatchString()=="". CheckContentRule must stay behaviorally identical via the len==0 wrapper. Add a table-test case for the empty-header-check.'
+severity: significant
+resolution: Plan step 1 skips checks whose GetMatchString()=="" (mirrors primitives' trivial-pass); CheckContentRule stays the pass/fail authority and is not re-routed through the detail helper; empty-check table test added.
+status: addressed
+---
+
+See finding property.

--- a/tickets/entities/review-responses/RR-UFUX7T.md
+++ b/tickets/entities/review-responses/RR-UFUX7T.md
@@ -1,0 +1,23 @@
+---
+id: RR-UFUX7T
+type: review-response
+title: analyze.go loop must read Detail off the new struct element (not re-derive from rule.Description)
+finding: 'internal/dataentry/analyze.go:448 currently does `for _, id := range full.Violations { e,_ := st.GetEntity(ctx, id); ...; Message: rule.Description }` — it re-fetches each entity by ID and ignores the violation''s own message. When RuleResult.Violations changes from []string to a struct {EntityID, Detail}, this loop MUST be rewritten to iterate the struct and read v.EntityID + v.Detail. If the implementer only touches the checker and forgets this loop, Detail is silently dropped and the feature no-ops end-to-end. Fix: make step 4 explicit (struct element, use v.EntityID for GetEntity, set Detail: v.Detail on AnalysisIssue); add a test asserting AnalysisIssue.Detail is populated.'
+severity: critical
+resolution: Plan step 4 now explicitly rewrites the analyze.go:448 loop to iterate the RuleViolation struct (v.EntityID + v.Detail) and set AnalysisIssue.Detail; a test asserting Detail is populated guards the no-op regression.
+status: addressed
+---
+
+**Finding:** `internal/dataentry/analyze.go:448` currently does `for _, id :=
+range full.Violations { e, _ := st.GetEntity(ctx, id); ...; Message:
+rule.Description }`. It re-fetches each entity by ID and ignores the violation's
+own message. When `RuleResult.Violations` changes from `[]string` to a struct
+`{EntityID, Detail}`, this loop MUST be rewritten to iterate the struct and read
+`v.EntityID` + `v.Detail`. If the implementer only touches the checker and
+forgets this loop, `Detail` is silently dropped and the feature no-ops
+end-to-end.
+
+**Resolution required in plan:** make step 4 explicit — the loop variable
+becomes a struct; use `v.EntityID` for the `GetEntity` call and set `Detail:
+v.Detail` on the `AnalysisIssue`. Add a test asserting the
+`AnalysisIssue.Detail` is populated (guards against this regression).

--- a/tickets/entities/review-responses/RR-WFJQ1I.md
+++ b/tickets/entities/review-responses/RR-WFJQ1I.md
@@ -1,0 +1,11 @@
+---
+id: RR-WFJQ1I
+type: review-response
+title: Detail is per-violation (empty for Lua/then-filter), not per-entity; render must tolerate absent detail
+finding: 'checkEntityAgainstRule emits one content Violation per entity, but a rule with lua: short-circuits Lua-first (validation.go:296-299) and Lua rules can emit multiple violations per entity (validation.go:337). So RuleResult.Violations can hold multiple entries with the same EntityID, and non-content (Lua/then-filter) violations carry Detail==nil. The plan''s mental model ''detail pairs with each entity'' should be ''detail pairs with each violation, empty for non-content''. Frontend must render nil/empty detail as ''no affordance'' (no empty tooltip).'
+severity: minor
+resolution: Plan step 2 + edge cases state Detail is per-violation and nil for Lua/then-filter violations; frontend renders absent/empty detail as no tooltip (issue.detail?.length guard).
+status: addressed
+---
+
+See finding property.

--- a/tickets/entities/review-responses/RR-WJ65QK.md
+++ b/tickets/entities/review-responses/RR-WJ65QK.md
@@ -1,0 +1,11 @@
+---
+id: RR-WJ65QK
+type: review-response
+title: 'Wire shape: return nil (not empty slice) for no-detail so omitempty drops it; render as escaped text only'
+finding: 'MissingRequiredHeaders should return nil (not []string{}) when nothing is missing, and the content branch should set Detail only when len(missing)>0, so satisfied rules and non-content violations never emit detail:[] on the wire. Go omitempty drops both nil and empty slices -> TS detail?: string[] sees absence. On render, keep {{ }} interpolation / :title binding (auto-escaped); do NOT introduce v-html (frontend lints vue/no-v-html). Header names are metamodel-authored (lower risk) but still must not be raw-HTML-rendered.'
+severity: nit
+resolution: Plan steps 1/2 return nil (not []string{}) and set Detail only when len>0; omitempty drops it on the wire; step 6 renders via auto-escaped :title binding, no v-html.
+status: addressed
+---
+
+See finding property.

--- a/tickets/entities/review-responses/RR-ZOGG1X.md
+++ b/tickets/entities/review-responses/RR-ZOGG1X.md
@@ -1,0 +1,20 @@
+---
+id: RR-ZOGG1X
+type: review-response
+title: Pattern-based HeaderCheck would leak a raw regex to the user in the detail
+finding: 'For a pattern: HeaderCheck, GetMatchString() returns the raw regex (e.g. `## (Alternative|Alternatives)` — confirmed in metamodel/types.go). Showing ''Missing headers: ## (Alternative|Alternatives)'' in a tooltip is misleading — a user may try to add a literal header with that name. Fix: exclude pattern checks from the detail — MissingRequiredHeaders skips checks where IsPattern() is true; only report exact (Header) misses, which are literal actionable strings. Also sidesteps regex-in-tooltip escaping. Document as a scope boundary.'
+severity: significant
+resolution: Plan step 1 skips IsPattern() checks in MissingRequiredHeaders; documented as a scope boundary (only exact Header misses reported) with AC5 asserting exclusion.
+status: addressed
+---
+
+**Finding:** For a `pattern:` HeaderCheck, `GetMatchString()` returns the raw
+regex (e.g. `## (Alternative|Alternatives)` — confirmed in metamodel/types.go).
+Showing "Missing headers: `## (Alternative|Alternatives)`" in a tooltip is
+misleading — a user may try to add a literal header with that name.
+
+**Resolution required in plan:** exclude pattern checks from the detail — only
+report *exact* (`Header`) misses, which are literal, actionable strings.
+`MissingRequiredHeaders` skips checks where `IsPattern()` is true. (95%
+actionable case; also sidesteps regex-escaping concerns in the tooltip.)
+Document this as a scope boundary in the plan.

--- a/tickets/entities/tickets/TKT-IL499B.md
+++ b/tickets/entities/tickets/TKT-IL499B.md
@@ -1,0 +1,40 @@
+---
+id: TKT-IL499B
+type: ticket
+title: 'Analysis view: reveal which detail failed a validation (missing headers etc.) on hover/click'
+kind: enhancement
+priority: medium
+effort: m
+status: review
+---
+
+In the data-entry Analysis view, the Validations table shows a flat rule
+`Description` as the message (e.g. "NCR body moet standaardkoppen bevatten").
+The user cannot tell **which** detail failed — e.g. which required headers are
+missing. Add a way (hover tooltip and/or click-to-expand) to reveal the specific
+failing detail per validation issue.
+
+## Problem
+
+Content-rule violations carry only the static `rule.Description`. The identity
+of the missing header(s) is computed in `internal/validation/content_rule.go`
+`CheckContentRule` and immediately discarded (function returns a plain `bool`).
+Nothing between the check and the Vue table has a place to carry per-issue
+detail.
+
+## Scope
+
+Surface the specific failing detail for content-rule (required-headers)
+violations, rendered as a hover/expand affordance in the MESSAGE cell of
+`AnalyzeView.vue`.
+
+Detail must thread through the layers that are currently detail-free:
+1. `internal/validation/content_rule.go` — `CheckContentRule` returns the failing header(s) instead of just `bool`.
+2. `internal/validation/validation.go` — `Violation` / `newViolation` carry an optional detail.
+3. `internal/validator/validator.go` — `RuleResult.Violations` preserve detail (currently `[]string` of IDs only).
+4. `internal/dataentry/analyze.go` — `AnalysisIssue` gains a detail field; `analyzeValidations` populates it.
+5. Wire: `internal/dataentry/settings_handlers.go` `APIIssue` + `internal/dataentry/api_v1.go` `handleV1Analyze` mapping.
+6. Frontend: `frontend/src/types/config.ts` `AnalyzeIssue`, and `AnalyzeView.vue` MESSAGE cell (line ~240) rendering.
+
+The existing `scriptError` envelope is the precedent for carrying structured
+per-issue detail end-to-end (but it is Lua-failure-only today).

--- a/tickets/entities/tickets/TKT-IL499B.md
+++ b/tickets/entities/tickets/TKT-IL499B.md
@@ -5,7 +5,7 @@ title: 'Analysis view: reveal which detail failed a validation (missing headers 
 kind: enhancement
 priority: medium
 effort: m
-status: review
+status: done
 ---
 
 In the data-entry Analysis view, the Validations table shows a flat rule

--- a/tickets/relations/TKT-IL499B--affects--data-entry-ui.md
+++ b/tickets/relations/TKT-IL499B--affects--data-entry-ui.md
@@ -1,0 +1,5 @@
+---
+from: TKT-IL499B
+relation: affects
+to: data-entry-ui
+---

--- a/tickets/relations/TKT-IL499B--has-docs--DOCS-W71G70.md
+++ b/tickets/relations/TKT-IL499B--has-docs--DOCS-W71G70.md
@@ -1,0 +1,5 @@
+---
+from: TKT-IL499B
+relation: has-docs
+to: DOCS-W71G70
+---

--- a/tickets/relations/TKT-IL499B--has-implementation--IMPL-6R4CXE.md
+++ b/tickets/relations/TKT-IL499B--has-implementation--IMPL-6R4CXE.md
@@ -1,0 +1,5 @@
+---
+from: TKT-IL499B
+relation: has-implementation
+to: IMPL-6R4CXE
+---

--- a/tickets/relations/TKT-IL499B--has-planning--PLAN-YGNLZH.md
+++ b/tickets/relations/TKT-IL499B--has-planning--PLAN-YGNLZH.md
@@ -1,0 +1,5 @@
+---
+from: TKT-IL499B
+relation: has-planning
+to: PLAN-YGNLZH
+---

--- a/tickets/relations/TKT-IL499B--has-review--REV-1GG5WN.md
+++ b/tickets/relations/TKT-IL499B--has-review--REV-1GG5WN.md
@@ -1,0 +1,5 @@
+---
+from: TKT-IL499B
+relation: has-review
+to: REV-1GG5WN
+---

--- a/tickets/relations/TKT-IL499B--has-review-response--RR-1GP8NI.md
+++ b/tickets/relations/TKT-IL499B--has-review-response--RR-1GP8NI.md
@@ -1,0 +1,5 @@
+---
+from: TKT-IL499B
+relation: has-review-response
+to: RR-1GP8NI
+---

--- a/tickets/relations/TKT-IL499B--has-review-response--RR-7UJUAI.md
+++ b/tickets/relations/TKT-IL499B--has-review-response--RR-7UJUAI.md
@@ -1,0 +1,5 @@
+---
+from: TKT-IL499B
+relation: has-review-response
+to: RR-7UJUAI
+---

--- a/tickets/relations/TKT-IL499B--has-review-response--RR-D2BOYL.md
+++ b/tickets/relations/TKT-IL499B--has-review-response--RR-D2BOYL.md
@@ -1,0 +1,5 @@
+---
+from: TKT-IL499B
+relation: has-review-response
+to: RR-D2BOYL
+---

--- a/tickets/relations/TKT-IL499B--has-review-response--RR-M2880C.md
+++ b/tickets/relations/TKT-IL499B--has-review-response--RR-M2880C.md
@@ -1,0 +1,5 @@
+---
+from: TKT-IL499B
+relation: has-review-response
+to: RR-M2880C
+---

--- a/tickets/relations/TKT-IL499B--has-review-response--RR-UFUX7T.md
+++ b/tickets/relations/TKT-IL499B--has-review-response--RR-UFUX7T.md
@@ -1,0 +1,5 @@
+---
+from: TKT-IL499B
+relation: has-review-response
+to: RR-UFUX7T
+---

--- a/tickets/relations/TKT-IL499B--has-review-response--RR-WFJQ1I.md
+++ b/tickets/relations/TKT-IL499B--has-review-response--RR-WFJQ1I.md
@@ -1,0 +1,5 @@
+---
+from: TKT-IL499B
+relation: has-review-response
+to: RR-WFJQ1I
+---

--- a/tickets/relations/TKT-IL499B--has-review-response--RR-WJ65QK.md
+++ b/tickets/relations/TKT-IL499B--has-review-response--RR-WJ65QK.md
@@ -1,0 +1,5 @@
+---
+from: TKT-IL499B
+relation: has-review-response
+to: RR-WJ65QK
+---

--- a/tickets/relations/TKT-IL499B--has-review-response--RR-ZOGG1X.md
+++ b/tickets/relations/TKT-IL499B--has-review-response--RR-ZOGG1X.md
@@ -1,0 +1,5 @@
+---
+from: TKT-IL499B
+relation: has-review-response
+to: RR-ZOGG1X
+---

--- a/tickets/relations/TKT-IL499B--implements--FEAT-13863O.md
+++ b/tickets/relations/TKT-IL499B--implements--FEAT-13863O.md
@@ -1,0 +1,5 @@
+---
+from: TKT-IL499B
+relation: implements
+to: FEAT-13863O
+---


### PR DESCRIPTION
## What

In the data-entry Analysis view, a `content.required-headers` validation showed only the flat rule description (e.g. *"NCR body moet standaardkoppen bevatten"*). You couldn't tell **which** required headers were missing.

Now the message cell is clickable and expands a full-width detail row listing exactly the missing exact-match headers. The row's two concerns are split: the **entity title** navigates to the entity; the **message** reveals the failure detail.

## Why

The missing-header identity was computed in `CheckContentRule` and immediately discarded (it returned a bare `bool`), and nothing between the checker and the Vue table had a slot to carry per-issue detail.

## How

Thread an optional `Detail []string` through the layers that were detail-free:

- `internal/validation/content_rule.go` — new `MissingRequiredHeaders` (detail-only helper; pattern checks and empty match-strings excluded; `CheckContentRule` stays the pass/fail authority)
- `internal/validation/validation.go` — `Violation.Detail`, populated on content-rule failure
- `internal/validator/validator.go` — `RuleResult.Violations` `[]string` → `[]RuleViolation{EntityID, Detail}`; `CheckRule` kept as an ID-only wrapper (CLI/MCP unchanged)
- `internal/dataentry/analyze.go` — `AnalysisIssue.Detail`, loop rewritten to carry it
- wire — `APIIssue.detail` (omitempty) + `handleV1Analyze`
- frontend — `AnalyzeIssue.detail?`; `AnalyzeView.vue` reworked to split click targets; issues table extracted into `IssuesTable.vue` (keeps the view under the god-component `max-lines` cap)

## Scope boundaries (deliberate)

- Regex `pattern:` header checks are **not** listed (a raw regex is misleading to show a user)
- CLI `analyze`/`validate` are unchanged — detail is data-entry-view only

## Testing

- Go: unit + integration tests at every layer (`MissingRequiredHeaders`, validation service, `CheckRuleFull`, `analyzeValidations`, `/api/v1/_analyze` round-trip incl. omitempty)
- Frontend: 16 `AnalyzeView` tests (split-target interaction, expand/collapse, Enter-key a11y, `aria-expanded`, row-key collision guard)
- Manual: ran `rela-server` against a demo NCR project — API returned `"detail": ["## Oorzaak", "## Corrigerende maatregel"]`; verified expand/collapse + title-navigation in the browser
- `just ci` green (tests, lint, coverage, docs-up-to-date)

Ticket: TKT-IL499B · implements FEAT-13863O