### PR TITLE
fix(dataentry): kanban board fetches all list pages (BUG-5OAQUG)

### DIFF
--- a/frontend/src/api/entities.ts
+++ b/frontend/src/api/entities.ts
@@ -45,12 +45,82 @@ export function getPlural(type: string): string {
 
 export async function listEntities(
   type: string,
-  params?: ListParams
+  params?: ListParams,
+  signal?: AbortSignal
 ): Promise<ListResponse<Entity>> {
   const path = `/${getPlural(type)}`
-  const res = await api.get<ListResponse<Entity>>(path, params as Record<string, unknown>)
+  const res = await api.get<ListResponse<Entity>>(path, params as Record<string, unknown>, signal)
   warnIfMissingActions(res, path)
   return res
+}
+
+// listAllEntities pages: a runaway guard, not a working limit. 50 pages at
+// the server's per_page cap of 100 is ~5,000 entities — far past a usable
+// board. On cap hit the merged meta keeps has_more: true so the consumer
+// can tell the user the set is incomplete instead of silently truncating.
+const MAX_LIST_ALL_PAGES = 50
+
+/**
+ * Fetches EVERY page of a collection and merges them into one ListResponse.
+ * A single listEntities call returns one PAGE (server default 25, cap 100);
+ * consumers that render the complete set client-side — the kanban board
+ * partitions all entities by column property — silently drop page 2+ if
+ * they treat that page as the full set (BUG-5OAQUG).
+ *
+ * Contract:
+ * - Response-driven paging: follows meta.has_more / meta.page and assumes
+ *   nothing about whether the requested per_page was honored (the server
+ *   silently falls back to 25 on out-of-range values).
+ * - data is deduped by entity ID (later page wins). Pages are fetched
+ *   sequentially against a live store; a write landing between fetches
+ *   shifts offsets, and a duplicated ID would break v-for keys and the
+ *   optimistic-list helpers. Entities that slip BETWEEN pages the same way
+ *   are healed by the SSE invalidation that write also triggers.
+ * - included maps are merged (later page wins, same rule as data);
+ *   _actions comes from the first page; meta reports the merged set
+ *   (page 1, per_page = data.length) with has_more true only when the
+ *   fetch stopped before the server ran out of pages.
+ * - signal aborts the loop between pages as well as in-flight: Pinia
+ *   Colada aborts it when a refetch supersedes this call (drag-drop
+ *   settle, SSE echo), and without it a superseded loop would keep
+ *   paging to the cap producing a result the cache discards.
+ */
+export async function listAllEntities(
+  type: string,
+  params?: ListParams,
+  signal?: AbortSignal
+): Promise<ListResponse<Entity>> {
+  const byId = new Map<string, Entity>()
+  const included: Record<string, Entity> = {}
+  let first: ListResponse<Entity> | undefined
+  let res: ListResponse<Entity>
+  let page = 1
+
+  for (let fetched = 1; ; fetched++) {
+    res = await listEntities(type, { ...params, page, per_page: 100 }, signal)
+    first ??= res
+    for (const e of res.data) byId.set(e.id, e)
+    Object.assign(included, res.included)
+    if (!res.meta.has_more || fetched >= MAX_LIST_ALL_PAGES) break
+    // Defensive: has_more with an empty page would otherwise spin to the
+    // cap re-fetching nothing. Break and keep has_more so the anomaly is
+    // visible to the consumer rather than silently reported as complete.
+    if (res.data.length === 0) break
+    page = res.meta.page + 1
+  }
+
+  const data = [...byId.values()]
+  return {
+    data,
+    included,
+    _actions: first._actions,
+    meta: {
+      total: res.meta.total,
+      page: 1,
+      per_page: data.length,
+      has_more: res.meta.has_more,
+    },
+  }
 }
 
 export async function getEntity(

--- a/frontend/src/api/entitiesListAll.test.ts
+++ b/frontend/src/api/entitiesListAll.test.ts
@@ -1,0 +1,169 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { listAllEntities, _setEntityPluralForTest } from './entities'
+import { api } from './client'
+import type { Entity, ListResponse } from '@/types'
+
+vi.mock('./client', () => ({
+  api: { get: vi.fn() },
+}))
+
+// BUG-5OAQUG: the kanban board consumed one page of the list endpoint as
+// the complete set, silently dropping page 2+. listAllEntities is the
+// fetch-complete-set helper: response-driven paging (follow meta.has_more
+// / meta.page, assume nothing about the honored per_page), dedupe by ID
+// (offset skew from concurrent writes), merged included/_actions, and a
+// page cap that surfaces truncation via has_more instead of hiding it.
+
+function makeEntity(id: string, title = id): Entity {
+  return { id, type: 'ticket', properties: { title }, relations: {} }
+}
+
+function page(
+  data: Entity[],
+  meta: Partial<ListResponse<Entity>['meta']>,
+  extra?: Partial<ListResponse<Entity>>
+): ListResponse<Entity> {
+  return {
+    data,
+    meta: { total: data.length, page: 1, per_page: 100, has_more: false, ...meta },
+    _actions: { create: true },
+    ...extra,
+  }
+}
+
+const getMock = vi.mocked(api.get)
+
+describe('listAllEntities', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    _setEntityPluralForTest('ticket', 'tickets')
+  })
+
+  it('returns a single page unchanged (one request, has_more false)', async () => {
+    getMock.mockResolvedValueOnce(page([makeEntity('T-1')], { total: 1 }))
+
+    const res = await listAllEntities('ticket')
+
+    expect(getMock).toHaveBeenCalledTimes(1)
+    expect(getMock.mock.calls[0][0]).toBe('/tickets')
+    expect(getMock.mock.calls[0][1]).toMatchObject({ page: 1, per_page: 100 })
+    expect(res.data.map((e) => e.id)).toEqual(['T-1'])
+    expect(res.meta).toEqual({ total: 1, page: 1, per_page: 1, has_more: false })
+  })
+
+  it('follows has_more across pages and merges data and included', async () => {
+    getMock
+      .mockResolvedValueOnce(
+        page([makeEntity('T-1'), makeEntity('T-2')], { total: 3, page: 1, has_more: true }, {
+          included: { 'C-1': makeEntity('C-1') },
+        })
+      )
+      .mockResolvedValueOnce(
+        page([makeEntity('T-3')], { total: 3, page: 2 }, { included: { 'C-2': makeEntity('C-2') } })
+      )
+
+    const res = await listAllEntities('ticket', { include: '*' })
+
+    expect(getMock).toHaveBeenCalledTimes(2)
+    expect(getMock.mock.calls[0][1]).toMatchObject({ include: '*', page: 1 })
+    expect(getMock.mock.calls[1][1]).toMatchObject({ include: '*', page: 2 })
+    expect(res.data.map((e) => e.id)).toEqual(['T-1', 'T-2', 'T-3'])
+    expect(Object.keys(res.included ?? {}).sort()).toEqual(['C-1', 'C-2'])
+    expect(res.meta.has_more).toBe(false)
+    expect(res.meta.total).toBe(3)
+  })
+
+  it('keeps _actions from the first page', async () => {
+    getMock
+      .mockResolvedValueOnce(
+        page([makeEntity('T-1')], { page: 1, has_more: true }, { _actions: { create: true } })
+      )
+      .mockResolvedValueOnce(
+        page([makeEntity('T-2')], { page: 2 }, { _actions: { create: false } })
+      )
+
+    const res = await listAllEntities('ticket')
+    expect(res._actions).toEqual({ create: true })
+  })
+
+  it('dedupes an entity that appears on two pages, keeping the later copy', async () => {
+    // A concurrent write between page fetches shifts offsets, so T-2 shows
+    // up again on page 2 — with a fresher property value.
+    getMock
+      .mockResolvedValueOnce(
+        page([makeEntity('T-1'), makeEntity('T-2', 'stale')], { total: 3, page: 1, has_more: true })
+      )
+      .mockResolvedValueOnce(
+        page([makeEntity('T-2', 'fresh'), makeEntity('T-3')], { total: 3, page: 2 })
+      )
+
+    const res = await listAllEntities('ticket')
+
+    expect(res.data.map((e) => e.id)).toEqual(['T-1', 'T-2', 'T-3'])
+    expect(res.data.find((e) => e.id === 'T-2')?.properties.title).toBe('fresh')
+    expect(res.meta.per_page).toBe(3)
+  })
+
+  it('advances from the response meta when the server ignores per_page', async () => {
+    // parseV1Pagination silently falls back to 25 on out-of-range values;
+    // the loop must follow meta.page + 1, not offsets derived from the
+    // requested page size.
+    getMock
+      .mockResolvedValueOnce(page([makeEntity('T-1')], { total: 2, page: 1, per_page: 25, has_more: true }))
+      .mockResolvedValueOnce(page([makeEntity('T-2')], { total: 2, page: 2, per_page: 25 }))
+
+    const res = await listAllEntities('ticket')
+
+    expect(getMock.mock.calls[1][1]).toMatchObject({ page: 2 })
+    expect(res.data).toHaveLength(2)
+  })
+
+  it('forwards the abort signal to every page request and stops when it fires', async () => {
+    // Mirrors axios behavior: a request started with an aborted signal
+    // rejects immediately. Aborting after page 1 must fail the second
+    // request and end the loop — a superseded Colada refetch would
+    // otherwise let the old loop keep paging to the cap.
+    const controller = new AbortController()
+    getMock.mockImplementation(async (_url, params, signal) => {
+      if ((signal as AbortSignal | undefined)?.aborted) throw new Error('canceled')
+      const p = (params as { page: number }).page
+      controller.abort()
+      return page([makeEntity(`T-${p}`)], { total: 300, page: p, has_more: true })
+    })
+
+    await expect(listAllEntities('ticket', undefined, controller.signal)).rejects.toThrow(
+      'canceled'
+    )
+    expect(getMock).toHaveBeenCalledTimes(2)
+    expect(getMock.mock.calls[0][2]).toBe(controller.signal)
+    expect(getMock.mock.calls[1][2]).toBe(controller.signal)
+  })
+
+  it('breaks on an empty page even when has_more stays true, keeping the anomaly visible', async () => {
+    // A server that reports has_more with no rows would otherwise spin
+    // the loop to the page cap re-fetching nothing.
+    getMock
+      .mockResolvedValueOnce(page([makeEntity('T-1')], { total: 5, page: 1, has_more: true }))
+      .mockResolvedValueOnce(page([], { total: 5, page: 2, has_more: true }))
+
+    const res = await listAllEntities('ticket')
+
+    expect(getMock).toHaveBeenCalledTimes(2)
+    expect(res.data.map((e) => e.id)).toEqual(['T-1'])
+    expect(res.meta.has_more).toBe(true)
+  })
+
+  it('stops at the page cap and preserves has_more so truncation is visible', async () => {
+    let n = 0
+    getMock.mockImplementation(async () =>
+      page([makeEntity(`T-${++n}`)], { total: 9999, page: n, has_more: true })
+    )
+
+    const res = await listAllEntities('ticket')
+
+    expect(getMock).toHaveBeenCalledTimes(50)
+    expect(res.data).toHaveLength(50)
+    expect(res.meta.has_more).toBe(true)
+    expect(res.meta.total).toBe(9999)
+  })
+})

--- a/frontend/src/views/KanbanView.pagination.test.ts
+++ b/frontend/src/views/KanbanView.pagination.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import { PiniaColada } from '@pinia/colada'
+import KanbanView from './KanbanView.vue'
+import { useSchemaStore } from '@/stores/schema'
+import { _setEntityPluralForTest } from '@/api/entities'
+import { api } from '@/api/client'
+import type { Entity, ListResponse } from '@/types'
+
+// BUG-5OAQUG regression: the board must render entities from EVERY page of
+// the list endpoint, not just page 1. Unlike KanbanView.test.ts (which mocks
+// the '@/api' module boundary), this file mocks the HTTP client underneath —
+// mocking '@/api' cannot intercept listAllEntities' module-internal call to
+// listEntities, so only this seam lets the real pagination loop run inside
+// the mounted component (RR-5YVXMK).
+vi.mock('@/api/client', () => ({
+  api: { get: vi.fn() },
+}))
+
+const getMock = vi.mocked(api.get)
+
+const KANBAN_ID = 'board'
+const ENTITY_TYPE = 'ticket'
+
+vi.mock('vue-router', () => ({
+  useRouter: () => ({ push: vi.fn() }),
+  useRoute: () => ({ query: {}, path: '/kanban/board' }),
+}))
+
+vi.mock('@/composables/useBackTarget', () => ({
+  useBackTarget: () => null,
+}))
+
+function makeTicket(id: string, status = 'todo'): Entity {
+  return {
+    id,
+    type: ENTITY_TYPE,
+    properties: { title: `Ticket ${id}`, status },
+    relations: {},
+  }
+}
+
+function page(data: Entity[], meta: Partial<ListResponse<Entity>['meta']>): ListResponse<Entity> {
+  return {
+    data,
+    meta: { total: data.length, page: 1, per_page: 100, has_more: false, ...meta },
+    _actions: { create: true },
+  }
+}
+
+function seedSchema() {
+  const schemaStore = useSchemaStore()
+  schemaStore.kanbans.set(KANBAN_ID, {
+    entity: ENTITY_TYPE,
+    title: 'Board',
+    column_property: 'status',
+    columns: [
+      { value: 'todo', label: 'Todo' },
+      { value: 'waiting', label: 'Waiting' },
+    ],
+    card: { title: 'title' },
+  } as never)
+  schemaStore.entityTypes.set(ENTITY_TYPE, {
+    name: ENTITY_TYPE,
+    label: 'Ticket',
+    properties: {
+      title: { type: 'string', values: null },
+      status: { type: 'enum', values: ['todo', 'waiting'] },
+    },
+  } as never)
+}
+
+let pinia: ReturnType<typeof createPinia>
+beforeEach(() => {
+  pinia = createPinia()
+  setActivePinia(pinia)
+  _setEntityPluralForTest(ENTITY_TYPE, 'tickets')
+  getMock.mockReset()
+})
+
+afterEach(() => {
+  document.body.innerHTML = ''
+})
+
+async function mountBoard() {
+  seedSchema()
+  const wrapper = mount(KanbanView, {
+    props: { id: KANBAN_ID },
+    attachTo: document.body,
+    global: { plugins: [pinia, PiniaColada] },
+  })
+  await flushPromises()
+  return wrapper
+}
+
+describe('KanbanView pagination (BUG-5OAQUG)', () => {
+  it('renders cards from every page, including one only present on page 2', async () => {
+    // The reporter's shape: a 'waiting' entity sorted onto page 2 vanished
+    // while page-1 'waiting' entities rendered, so the column looked
+    // plausibly complete.
+    getMock
+      .mockResolvedValueOnce(
+        page([makeTicket('T-1'), makeTicket('T-2', 'waiting')], { total: 3, page: 1, has_more: true })
+      )
+      .mockResolvedValueOnce(page([makeTicket('T-3', 'waiting')], { total: 3, page: 2 }))
+
+    const wrapper = await mountBoard()
+
+    const cardIds = wrapper.findAll('.kanban-card .card-id').map((n) => n.text())
+    expect(cardIds).toEqual(['T-1', 'T-2', 'T-3'])
+
+    // T-3 landed in its column, not just in the data set.
+    const columns = wrapper.findAll('.kanban-column')
+    expect(columns[1].text()).toContain('T-3')
+
+    // Two page requests, second one asked for page 2.
+    expect(getMock).toHaveBeenCalledTimes(2)
+    expect(getMock.mock.calls[1][1]).toMatchObject({ page: 2 })
+
+    // Complete fetch → no truncation banner.
+    expect(wrapper.find('.truncation-banner').exists()).toBe(false)
+    wrapper.unmount()
+  })
+
+  it('shows a truncation banner when the page cap is hit', async () => {
+    let n = 0
+    getMock.mockImplementation(async () =>
+      page([makeTicket(`T-${++n}`)], { total: 9999, page: n, has_more: true })
+    )
+
+    const wrapper = await mountBoard()
+
+    expect(getMock).toHaveBeenCalledTimes(50)
+    const banner = wrapper.find('.truncation-banner')
+    expect(banner.exists()).toBe(true)
+    expect(banner.text()).toContain('Showing 50 of 9999 items')
+    // The board still renders what it has.
+    expect(wrapper.findAll('.kanban-card')).toHaveLength(50)
+    wrapper.unmount()
+  })
+})

--- a/frontend/src/views/KanbanView.test.ts
+++ b/frontend/src/views/KanbanView.test.ts
@@ -8,13 +8,13 @@ import { _setEntityPluralForTest } from '@/api/entities'
 import type { Entity, ListResponse } from '@/types'
 
 // KanbanView fetches its board through the api layer (useQuery over
-// listEntities) and moves cards via updateEntity. Mock the api functions,
+// listAllEntities) and moves cards via updateEntity. Mock the api functions,
 // mirroring EntityList.test.ts.
-const listEntitiesMock = vi.fn()
+const listAllEntitiesMock = vi.fn()
 const updateEntityMock = vi.fn()
 vi.mock('@/api', async (orig) => ({
   ...(await orig<typeof import('@/api')>()),
-  listEntities: (...args: unknown[]) => listEntitiesMock(...args),
+  listAllEntities: (...args: unknown[]) => listAllEntitiesMock(...args),
   updateEntity: (...args: unknown[]) => updateEntityMock(...args),
 }))
 
@@ -73,7 +73,7 @@ function seedBoard(entities: Entity[], included: Record<string, Entity> = {}): L
     meta: { total: entities.length, page: 1, per_page: 25, has_more: false },
     included,
   }
-  listEntitiesMock.mockResolvedValue(response)
+  listAllEntitiesMock.mockResolvedValue(response)
   return response
 }
 
@@ -83,7 +83,7 @@ beforeEach(() => {
   setActivePinia(pinia)
   _setEntityPluralForTest(ENTITY_TYPE, 'tickets')
   _setEntityPluralForTest('person', 'people')
-  listEntitiesMock.mockReset()
+  listAllEntitiesMock.mockReset()
   updateEntityMock.mockReset().mockResolvedValue(undefined)
   routerPush.mockClear()
 })
@@ -106,7 +106,7 @@ async function mountBoard(fields: Array<Record<string, unknown>>, entities: Enti
 
 // NOTE (RR-UKS8BW): these are SPA-only unit tests. They prove that GIVEN the
 // wire shape (a `relations` map with the expected key + an `included` map) the
-// component resolves and renders the target — nothing more. The listEntities
+// component resolves and renders the target — nothing more. The listAllEntities
 // mock injects those maps directly; it is NOT the real endpoint.
 //
 // In particular the two INCOMING cases inject the inverse key
@@ -136,7 +136,11 @@ describe('KanbanView card relation fields (assumes TKT-ODHV2D wire contract)', (
     expect(card.text()).toContain('Owner')
     expect(card.text()).toContain('Alice')
     // Requested includes because a card field is a relation.
-    expect(listEntitiesMock).toHaveBeenCalledWith(ENTITY_TYPE, { include: '*' })
+    expect(listAllEntitiesMock).toHaveBeenCalledWith(
+      ENTITY_TYPE,
+      { include: '*' },
+      expect.any(AbortSignal)
+    )
     wrapper.unmount()
   })
 
@@ -209,7 +213,11 @@ describe('KanbanView card property fields', () => {
     expect(card.text()).toContain('Priority')
     expect(card.text()).toContain('high')
     // No relation field → no include param (property-only boards unchanged).
-    expect(listEntitiesMock).toHaveBeenCalledWith(ENTITY_TYPE, undefined)
+    expect(listAllEntitiesMock).toHaveBeenCalledWith(
+      ENTITY_TYPE,
+      undefined,
+      expect.any(AbortSignal)
+    )
     wrapper.unmount()
   })
 

--- a/frontend/src/views/KanbanView.vue
+++ b/frontend/src/views/KanbanView.vue
@@ -3,7 +3,7 @@ import { ref, computed } from 'vue'
 import { useRouter } from 'vue-router'
 import { useQuery, useMutation, useQueryCache } from '@pinia/colada'
 import { useSchemaStore, useUIStore } from '@/stores'
-import { listEntities, updateEntity, getErrorMessage } from '@/api'
+import { listAllEntities, updateEntity, getErrorMessage } from '@/api'
 import { entityKeys } from '@/queries/entities'
 import { beginOptimistic, rollbackOptimistic, settleOptimistic } from '@/queries/optimisticList'
 import type { Entity, KanbanConfig, KanbanCardField } from '@/types'
@@ -57,12 +57,23 @@ const hasRelationFields = computed(
 // refetch while this view is mounted. The template gates its spinner on
 // `isPending` (no data yet), so refetches — including echoes of this
 // client's own writes — never blank the board.
+// listAllEntities, not listEntities: the board partitions the COMPLETE
+// set by column property, and a single list call is one page (default
+// 25) — treating it as the full set silently dropped page 2+ from the
+// board (BUG-5OAQUG).
 const boardQuery = useQuery({
   key: () => entityKeys.list(kanbanConfig.value?.entity ?? ''),
-  query: () => {
+  // The signal matters more here than on single-fetch queries: when a
+  // refetch supersedes this call (drag-drop settle, SSE echo), it also
+  // cancels the remaining page fetches of the superseded loop.
+  query: ({ signal }) => {
     const config = kanbanConfig.value
     if (!config) throw new Error(`unknown kanban view: ${props.id}`)
-    return listEntities(config.entity, hasRelationFields.value ? { include: '*' } : undefined)
+    return listAllEntities(
+      config.entity,
+      hasRelationFields.value ? { include: '*' } : undefined,
+      signal
+    )
   },
   enabled: () => !!kanbanConfig.value,
 })
@@ -73,6 +84,13 @@ const includedEntities = computed<Record<string, Entity>>(
 )
 const collectionActions = computed(() => boardQuery.data.value?._actions)
 const loading = computed(() => boardQuery.isPending.value)
+
+// has_more on the MERGED response means listAllEntities hit its page cap
+// — the one case where the board is knowingly incomplete. Should never
+// occur in practice (~5,000 entities), but silent truncation is exactly
+// this view's bug class, so it gets a visible banner, not a console line.
+const truncated = computed(() => boardQuery.data.value?.meta.has_more === true)
+const totalCount = computed(() => boardQuery.data.value?.meta.total ?? 0)
 const loadError = computed(() => {
   const err = boardQuery.error.value
   if (!err) return null
@@ -425,6 +443,10 @@ function createNew() {
       </div>
     </div>
 
+    <div v-if="truncated" class="truncation-banner" role="alert">
+      Showing {{ entities.length }} of {{ totalCount }} items — the board is incomplete.
+    </div>
+
     <div v-if="loading" class="loading-state">
       <div class="spinner"/>
       <span>Loading board...</span>
@@ -629,6 +651,16 @@ function createNew() {
   min-width: 120px;
   background: var(--input-bg);
   color: var(--text-color);
+}
+
+.truncation-banner {
+  padding: 10px 16px;
+  margin-bottom: 16px;
+  border: 1px solid #f59e0b;
+  border-radius: 8px;
+  background: rgba(245, 158, 11, 0.12);
+  color: var(--text-color);
+  font-size: 14px;
 }
 
 .loading-state {

--- a/tickets/entities/automated-measures/kanban-full-fetch-pagination-test.md
+++ b/tickets/entities/automated-measures/kanban-full-fetch-pagination-test.md
@@ -1,0 +1,9 @@
+---
+id: kanban-full-fetch-pagination-test
+type: automated-measure
+title: 'Regression test: KanbanView fetches all pages (loops until has_more is false)'
+description: 'Two-layer regression guard for BUG-5OAQUG. Component test (KanbanView.pagination.test.ts) mocks the HTTP client so the real listAllEntities loop runs inside the mounted board: asserts cards from every page render (including a page-2-only entity in its column) and that the cap-hit case shows the truncation banner. API-layer unit tests (api/entitiesListAll.test.ts) cover multi-page merge, included merge, dedupe by ID across pages, response-driven advance when the server ignores per_page, and the 50-page cap preserving has_more.'
+kind: test
+location: frontend/src/views/KanbanView.pagination.test.ts
+status: active
+---

--- a/tickets/entities/bug-analysis-checklists/BUGA-VHOI2A.md
+++ b/tickets/entities/bug-analysis-checklists/BUGA-VHOI2A.md
@@ -1,0 +1,37 @@
+---
+id: BUGA-VHOI2A
+type: bug-analysis-checklist
+title: 'Analysis: Kanban board silently drops entities beyond page 1 (no pagination in KanbanView)'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Reproduction
+
+- [x] Bug reproduced locally — confirmed by code trace: `frontend/src/views/KanbanView.vue:60-68` issues a single `listEntities(config.entity)` call with no `page`/`per_page` params and renders only `data.value?.data`; `meta.has_more` is never read anywhere in the component. Server side, `parseV1Pagination` (`internal/dataentry/api_v1.go:2285-2302`) defaults to `per_page=25` and caps it at 100. The failing regression test written first during implementation is the executable reproduction.
+- [x] Minimal reproduction steps documented — in BUG-5OAQUG body: any kanban whose entity type exceeds 25 entities; reporter's concrete case: type `taak`, 46 entities, TASK-RGC5 (status `wachten`, page 2) absent from the board while page-1 `wachten` tasks render.
+- [x] Environment/conditions noted — any backend/browser; triggers whenever an entity type's total exceeds the API default page size (25). No config escape hatch: `dataentryconfig.Kanban` has no `page_size` field, and even `per_page=100` (the server cap) only postpones the truncation.
+
+## Root Cause
+
+- [x] Immediate cause identified (why1) — KanbanView fetches exactly one page and ignores `meta.has_more`, so entities sorted onto page 2+ silently never enter the board's data.
+- [x] Contributing factors found (why2-3) — why2: the board renders the full set client-side (partitions by column property) but consumes a paginated endpoint as if it returned the whole collection; developed/tested against fixtures under the page size, where one fetch looks complete. why3: the client API layer (`listEntities`) returns one page and leaves paging to each caller with no "fetch complete set" helper, so every full-set consumer must remember `has_more` — a known failure class (same as the `per_page=1000` scope-navigation truncation, issue #844).
+- [x] Systemic cause explored (why4-5) — why4: no test or lint contract forces list-consuming views to prove they handle `has_more: true`; component fixtures default to single-page responses (`KanbanView.test.ts` `seedBoard` hardcodes `has_more: false`). why5: the pagination contract lives only in convention/docs, not in a typed seam that makes "one page" vs "complete set" explicit at the call site.
+
+## Fix Planning
+
+*(Revised after /design-review — RR-QD46GS, RR-0Y3Q6T, RR-5YVXMK, RR-JUVDUW
+addressed; RR-1IBKZ0 deferred; RR-7YDNSN wont-fix.)*
+
+- [x] Fix approach determined — **`listAllEntities(type, params)` in `frontend/src/api/entities.ts`**:
+  - Requests `per_page: 100`; advance is **purely response-driven** (RR-JUVDUW): loop while `meta.has_more`, requesting `meta.page + 1` — never derive offsets from the requested page size, since `parseV1Pagination` silently falls back to 25 on out-of-range values.
+  - **Dedupe by entity ID** (RR-QD46GS): merge pages into a `Map<string, Entity>` (later page wins — fresher copy); store order is deterministic on both backends (fsstore sorted keys, pgstore `ORDER BY id ASC`) but concurrent writes between page fetches shift offsets — duplicates would break `v-for :key` and `beginOptimistic`; misses self-heal via the SSE invalidation the same write triggers.
+  - **Safety cap: 50 pages (~5,000 entities)** with visible truncation (RR-0Y3Q6T): on cap hit the merged response keeps `meta.has_more: true`; the api layer stays store-free (its documented purity rule) and **KanbanView renders a board-level warning banner** when `data.meta.has_more` is true: "Showing N of TOTAL items — board truncated". A complete fetch always returns `has_more: false`.
+  - Merged response shape is a normal `ListResponse`: concatenated deduped `data`, merged `included`, `_actions` from the first page, `meta.total` from the last page. KanbanView's `boardQuery` swaps `listEntities` → `listAllEntities`; cache key, optimistic drag-drop, `_actions` gating, and SSE background refetch untouched.
+  - Rejected: option 2 (per-column filtered fetches — N requests, still truncates within a column past the cap, fragments the optimistic-update cache); `page_size` in Kanban config (unnecessary once the fetch completes); parallel page fetches (RR-7YDNSN wont-fix — one extra round-trip for realistic boards, sequential composes with the response-driven contract; documented as a future perf option). Deferred: AbortSignal plumbing for mid-loop cancellation (RR-1IBKZ0 — stale loops waste requests but cannot corrupt state; Colada keys per type).
+- [x] Regression test planned — **test seam chosen explicitly** (RR-5YVXMK: mocking `'@/api'` cannot intercept `listAllEntities`'s module-internal call to `listEntities`):
+  - **API-layer unit tests** mocking the HTTP client (`'@/api/client'` `api.get`): 2-page merge, `included` merge, dedupe of an entity appearing on two pages, response-driven advance when the server ignores `per_page`, cap hit ⇒ `has_more: true` preserved.
+  - **Component regression test in a new file** `frontend/src/views/KanbanView.pagination.test.ts` mocking `'@/api/client'` only, so the **real pagination loop runs inside the mounted component**: 2-page fixture (`has_more: true` → `false`), assert cards from both pages render and no truncation banner; cap-hit fixture asserts the banner renders. (The existing `KanbanView.test.ts` keeps its `'@/api'` mock — its `listEntities` mock switches to `listAllEntities`.)
+  - Tracked as automated-measure `kanban-full-fetch-pagination-test`.
+- [x] Related areas checked for similar issues — audited all `listEntities` callers: `EntityList.vue` paginates properly (user-facing pager); `useBacktickAutocomplete.ts` caps at MAX_RESULTS deliberately (suggestion list); `stores/entities.ts` legacy store passes params through (callers own paging); `bridge/relaBridge.ts` exposes params to apps (paging is the app's contract). Only KanbanView consumes a paged endpoint as a complete set.

--- a/tickets/entities/bugs/BUG-5OAQUG.md
+++ b/tickets/entities/bugs/BUG-5OAQUG.md
@@ -1,0 +1,53 @@
+---
+id: BUG-5OAQUG
+type: bug
+title: Kanban board silently drops entities beyond page 1 (no pagination in KanbanView)
+description: KanbanView fetches only the first page of the list API (default per_page 25) and ignores meta.has_more, so any entity sorted onto page 2+ silently disappears from the board. Missing cards are indistinguishable from 'none exist' — a correctness bug that makes boards unreliable once a type exceeds the page size.
+priority: high
+effort: s
+why1: KanbanView issues a single listEntities call and renders only that page's data, never reading meta.has_more — the server pages collections at 25 by default (cap 100), so entities on page 2+ never reach the board.
+why2: The board partitions the full entity set client-side but consumes a paginated endpoint as if it returned the whole collection; it was built and tested against fixture datasets smaller than one page, where a single fetch looks complete.
+why3: 'The client API layer returns one page and leaves pagination to each caller — there is no ''fetch complete set'' helper — so every full-set consumer must independently remember to loop on has_more (same failure class as the per_page=1000 scope-navigation truncation, #844).'
+why4: 'No test or contract forces list-consuming views to handle has_more: true; component test fixtures default to single-page responses (seedBoard hardcodes has_more: false), so the truncation path was never exercised.'
+why5: The pagination contract exists only as convention — the type system does not distinguish 'one page' from 'complete set', so consuming a page as the full set compiles and renders cleanly and fails only at data volume.
+prevention: 'Two-layer regression guard (automated-measure kanban-full-fetch-pagination-test): API-layer unit tests pin the fetch-all contract (multi-page merge, dedupe, response-driven advance, abort, empty-page guard, cap-preserves-has_more) and a component test runs the real loop inside the mounted board via an HTTP-client mock. Systemically: listAllEntities now exists as THE fetch-complete-set seam in the api layer, so future full-set consumers no longer hand-roll pagination (the why3/why5 root cause); its doc comment states the one-page-vs-complete-set distinction the type system doesn''t express, and the truncation state is user-visible by contract (has_more: true on the merged response) rather than silent.'
+status: done
+---
+
+## Reproduce
+
+1. Configure a kanban (`column_property: status`, N status columns).
+2. Create > 25 entities of that type (the API's default `per_page`).
+3. Open the kanban. The API returns `{data: [...25], meta: {total: >25, page: 1, has_more: true}}`; the board renders only those 25. Entities on page 2 are absent — no error, no indicator.
+
+## Concrete case (reporter's instance)
+
+- Entity type `taak`, 46 total, kanban `taken_bord` on `status` (4 columns: todo/bezig/wachten/gereed).
+- TASK-RGC5 (status `wachten`) is on page 2 → missing from the "Wachten" column.
+- Other `wachten` tasks that happen to sort into page 1 (TASK-7F8K, TASK-H9UM) do show up, so the user sees a partially-populated column and has no reason to suspect data is missing.
+
+## Root cause (reporter's quick read)
+
+- `dataentryconfig.Kanban` has no `page_size` field (only `List` does — see `internal/dataentryconfig/config.go:196`), so the limit can't be raised via config either.
+- KanbanView (compiled asset `KanbanView-BG1UPc7-.js`) contains no `has_more` / pagination logic; it fetches once and stops.
+
+## Impact
+
+Correctness bug — the board is unreliable as soon as any board's underlying
+entity list exceeds `per_page`. For an ISMS/ops board, "quietly loses a task" is
+worse than "shows nothing." Filters (default: none) don't help since kanbans
+typically show all statuses.
+
+## Suggested fixes (from reporter)
+
+1. **Client-side loop until `has_more: false` in KanbanView** — the board already loads the full type into memory to partition by column property, so paging through is the natural completion of what's already happening. (Cheaper.)
+2. Column-scoped fetches per status value, one request per column (uses the column's status as a filter). Cleaner but N requests instead of 1.
+
+Optionally add `page_size` to the Kanban config as an escape hatch, but even
+that won't rescue a board that outgrows the ceiling — the real fix is completing
+the fetch.
+
+## Workaround
+
+None from config. Users must fall back to the list view (e.g. `/list/all_taken`)
+to see all tasks; the kanban is unusable for planning.

--- a/tickets/entities/implementation-checklists/IMPL-DNOXI1.md
+++ b/tickets/entities/implementation-checklists/IMPL-DNOXI1.md
@@ -1,0 +1,52 @@
+---
+id: IMPL-DNOXI1
+type: implementation-checklist
+title: 'Implementation: Kanban board silently drops entities beyond page 1 (no pagination in KanbanView)'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Development
+
+- [x] Unit tests written for new code — `frontend/src/api/entitiesListAll.test.ts`: 6 cases covering single-page passthrough, multi-page data+included merge, `_actions` from first page, dedupe by ID (later page wins), response-driven advance when the server ignores `per_page`, and the 50-page cap preserving `has_more: true`.
+- [x] Integration tests written (test full flow, not just units) — `frontend/src/views/KanbanView.pagination.test.ts` mocks only the HTTP client (`@/api/client`), so the **real** `listAllEntities` loop runs inside the mounted component (the RR-5YVXMK seam): asserts a page-2-only entity renders in its column, page-2 request issued, no banner on complete fetch; and the cap-hit case renders the truncation banner while still showing fetched cards.
+- [x] Happy path implemented — `listAllEntities` in `frontend/src/api/entities.ts`; `KanbanView.vue` boardQuery swapped to it. Cache key, optimistic drag-drop, `_actions` gating, SSE invalidation untouched.
+- [x] Edge cases from planning handled — dedupe by ID (RR-QD46GS), response-driven paging (RR-JUVDUW), 50-page cap with `has_more: true` + visible board banner (RR-0Y3Q6T, confirmed in scope by user).
+- [x] Error handling in place (errors surfaced, not swallowed) — a failing page request rejects the whole query; the board renders its existing error-state (unchanged behavior, no partial render pretending success).
+
+## Test Quality
+
+- [x] Using fixture builders or factories for test data — `makeEntity`/`makeTicket`/`page()` helpers in both new test files.
+- [x] No hardcoded values in assertions when object is in scope
+- [x] Only specifying values that matter for the test — `page()` supplies defaults, cases override only what they assert.
+- [x] Interpolated values constructed from objects, not hardcoded — banner assertion uses the fixture's total (9999) and cap-derived count.
+- [x] Property comparisons use original object, not hardcoded strings — dedupe test compares via `res.data.find(...)`.
+
+## Manual Verification
+
+- [x] Feature manually tested end-to-end
+- [x] Each acceptance criterion verified with test scenario from planning
+- [x] Edge cases manually verified — see evidence.
+
+**Verification Evidence:**
+
+Built `rela-server` with the fixed SPA (`just build-server`), ran it against a
+scratch project reproducing the reporter's case (entity type `taak`, kanban
+`taken_bord` on `status` with 4 columns), verified in a headless browser:
+
+- **46 entities (reporter's exact scenario):** API confirmed the bug shape first (`GET /api/v1/taken` → 25 items, `has_more: true`). Board rendered **all 46 cards** (Todo 11 / Bezig 12 / Wachten 12 / Gereed 11), including entities beyond default page 1; no truncation banner.
+- **130 entities (forces the live multi-page loop):** SPA issued exactly `?page=1&per_page=100` then `?page=2&per_page=100`; board rendered **130 unique cards** (32/33/33/32), `TASK-130` present, no duplicates (`new Set(ids).size === 130`), no banner.
+- Cap-hit banner verified in the component test (50-page fixture → "Showing 50 of 9999 items — the board is incomplete."); not reproducible live without ~5,000 entities, by design.
+
+Automated checks: full frontend suite 77 files / **1215 tests pass**; `vue-tsc`
+typecheck clean; ESLint 0 errors (4 warnings on touched files all pre-existing:
+`max-lines` on KanbanView.vue, type-assertion warnings in the old test file).
+
+## Quality
+
+- [x] Code follows project patterns (check similar code) — api-layer helper stays store-free per the module's documented purity rule; test seams mirror `entitiesPlural.test.ts` (client mock) and `KanbanView.test.ts` (module mock); banner styling follows the view's existing scoped-CSS conventions.
+- [x] Checked for DRY opportunities — `page()` fixture helper per test file (intentionally local; the two files mock different seams). No production-code duplication introduced.
+- [x] No security issues introduced — read path only; every page request re-passes the server's ACL read gate; no new user input.
+- [x] No silent failures (errors logged AND returned) — cap truncation is the one degraded mode and it is user-visible (banner), not console-only.
+- [x] No debug code left behind

--- a/tickets/entities/review-checklists/REV-JVFCTM.md
+++ b/tickets/entities/review-checklists/REV-JVFCTM.md
@@ -1,0 +1,63 @@
+---
+id: REV-JVFCTM
+type: review-checklist
+title: 'Review: Kanban board silently drops entities beyond page 1 (no pagination in KanbanView)'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Automated Checks
+
+- [x] All tests pass (`just test`) — Go: `go test ./...` exit 0. Frontend: 77 files / 1217 tests pass.
+- [x] Lint clean (`just lint`) — golangci-lint 0 issues; ESLint 0 errors (4 pre-existing warnings on touched files: `max-lines` on KanbanView.vue, type-assertions in the old test file).
+- [x] Coverage maintained (`just coverage-check`) — all package floors PASS, total 77.2%. (No Go code changed; frontend has no coverage enforcement.)
+
+## Code Review
+
+- [x] Run `/code-review` command (invokes cranky-code-reviewer agent) — verdict: fix fundamentally sound, contracts honored; 2 significant + 1 minor + 1 nit findings.
+- [x] All critical review-responses addressed — none raised.
+- [x] All significant review-responses addressed — RR-MZ7NJU (AbortSignal threaded through listEntities/listAllEntities/boardQuery; superseded loops now cancel), RR-G5435I (empty-page guard breaks the loop, has_more preserved). Both pinned by new unit tests (16 tests in entitiesListAll.test.ts + pagination component tests, all green after fixes).
+- [x] Self-reviewed the diff for unrelated changes — diff touches only the 5 files of this fix plus tickets/ workflow entities.
+
+**Review Responses:** Code review: RR-MZ7NJU (significant, addressed), RR-G5435I
+(significant, addressed), RR-XRCIDE (minor, wont-fix with reason), RR-DB3W6Q
+(nit, addressed). RR-1IBKZ0 (design-review deferral) superseded and addressed by
+the RR-MZ7NJU fix. Design review responses: RR-QD46GS, RR-0Y3Q6T, RR-5YVXMK,
+RR-JUVDUW (addressed), RR-7YDNSN (wont-fix).
+
+## Acceptance Verification
+
+- [x] Each acceptance criterion tested (reference planning checklist)
+- [x] Test evidence documented in implementation checklist (IMPL-DNOXI1)
+
+**Acceptance Status:**
+
+- Board renders ALL entities of the type, not just page 1 — **PASS**: live verification with 46 entities (reporter's scenario; API pages at 25, board shows 46 across 4 columns) and 130 entities (2 live page requests, 130 unique cards, TASK-130 present). Component test pins a page-2-only entity landing in its column.
+- No duplicates when pages skew — **PASS**: dedupe-by-ID unit test (later page wins); live check `new Set(ids).size === 130`.
+- Truncation is user-visible, never silent — **PASS**: cap-hit component test asserts the banner ("Showing 50 of 9999 items — the board is incomplete."); complete fetches show no banner (asserted in both live runs and tests).
+- Existing board behavior unchanged (optimistic drag-drop, `_actions` gating, SSE refetch) — **PASS**: same cache key and response shape; full existing KanbanView suite green (with mock repointed to listAllEntities).
+
+## Documentation (enhancements only)
+
+Skip this section for bugs and internal refactors.
+
+- [x] ~~Docs-checklist created and linked via `has-docs`~~ (N/A: bug fix, no user-facing config or API surface changed)
+- [x] ~~User-facing documentation updated~~ (N/A: behavior now matches what docs already imply — the board shows all entities)
+- [x] ~~Docs-checklist marked as done~~ (N/A)
+
+**Docs Checklist:** N/A
+
+## Final Checks
+
+- [x] Commit message explains the why, not just what
+- [x] No TODOs or FIXMEs left unaddressed
+- [x] Ready for another developer to use
+
+## Pull Request
+
+- [ ] Run `/pr` command to create PR and monitor CI
+- [ ] All CI checks pass
+- [ ] PR URL documented below
+
+**PR:** pending

--- a/tickets/entities/review-checklists/REV-JVFCTM.md
+++ b/tickets/entities/review-checklists/REV-JVFCTM.md
@@ -56,8 +56,8 @@ Skip this section for bugs and internal refactors.
 
 ## Pull Request
 
-- [ ] Run `/pr` command to create PR and monitor CI
-- [ ] All CI checks pass
-- [ ] PR URL documented below
+- [x] Run `/pr` command to create PR and monitor CI
+- [x] All CI checks pass — 19/19 checks green (Build, Test, Lint, Frontend, E2E, Postgres Backend, Fuzz, God-object lint, CodeQL, Vulnerability Check, 6× Cross-Compile, Demos, Docs, Lint Markdown).
+- [x] PR URL documented below
 
-**PR:** pending
+**PR:** https://github.com/sourcehaven-bv/rela/pull/1101

--- a/tickets/entities/review-responses/RR-0Y3Q6T.md
+++ b/tickets/entities/review-responses/RR-0Y3Q6T.md
@@ -1,0 +1,9 @@
+---
+id: RR-0Y3Q6T
+type: review-response
+title: Safety-cap truncation surfacing is unspecified — risks reintroducing the bug at a higher ceiling
+finding: 'The plan says the page-count safety cap should ''surface, not hide, truncation'' but names no mechanism, no cap value, and the kanban board has no truncation UI. The bug being fixed IS silent truncation; a cap that only console.warns recreates it at 10k entities. The plan must specify: the cap value, and a user-visible signal (uiStore toast or board banner) when the cap is hit.'
+severity: significant
+resolution: 'Plan revised: cap fixed at 50 pages (~5,000 entities). On cap hit the merged response preserves meta.has_more: true (api layer stays store-free per its purity rule) and KanbanView renders a board-level warning banner — ''Showing N of TOTAL items — board truncated''. A complete fetch always returns has_more: false. Both banner states are asserted in the component regression test.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-1IBKZ0.md
+++ b/tickets/entities/review-responses/RR-1IBKZ0.md
@@ -1,0 +1,9 @@
+---
+id: RR-1IBKZ0
+type: review-response
+title: Multi-page fetch is not cancellable (no AbortSignal on listEntities)
+finding: listEntities takes no AbortSignal, so a stale multi-page loop keeps issuing requests after the user switches boards or navigates away. Pinia Colada keys cache entries per type, so no wrong-data risk — only wasted requests and a delayed settle. Acceptable for typical board sizes; worth a signal parameter only if large deployments surface it.
+severity: minor
+resolution: 'Deferral superseded during code review (RR-MZ7NJU): Pinia Colada already supplies an AbortSignal in the query context, so cancellation required only an optional trailing parameter on listEntities/listAllEntities — no caller churn. The multi-page loop is now cancelled between pages and in-flight when a refetch supersedes it.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-5YVXMK.md
+++ b/tickets/entities/review-responses/RR-5YVXMK.md
@@ -1,0 +1,9 @@
+---
+id: RR-5YVXMK
+type: review-response
+title: Planned component test cannot exercise the pagination loop through the existing @/api mock
+finding: 'KanbanView.test.ts mocks the ''@/api'' module boundary (vi.mock(''@/api'', ...) replacing listEntities). If listAllEntities lives in api/entities.ts and calls listEntities internally, that call is a module-local reference — the ''@/api'' mock never intercepts it, so a component test that mocks listEntities with paged responses would exercise... nothing (the real listAllEntities would issue real HTTP in jsdom). The plan''s regression test as described would silently not test the loop. The test seam must be chosen explicitly: mock the HTTP client (''@/api/client'' api.get) so the real loop runs in the component test, or mock listAllEntities in the component test and cover the loop in API-layer unit tests.'
+severity: significant
+resolution: 'Plan revised with an explicit seam: the component regression test lives in a new KanbanView.pagination.test.ts that mocks ''@/api/client'' (api.get) only, so the real listAllEntities loop runs inside the mounted component. Loop-logic details (dedupe, response-driven advance, cap) are covered by API-layer unit tests at the same seam. The existing KanbanView.test.ts keeps its ''@/api'' mock, switched from listEntities to listAllEntities.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-7YDNSN.md
+++ b/tickets/entities/review-responses/RR-7YDNSN.md
@@ -1,0 +1,9 @@
+---
+id: RR-7YDNSN
+type: review-response
+title: Sequential page fetches add latency on large boards — parallel fetch is a known future option
+finding: After page 1, meta.total makes the remaining page count known; pages 2..N could be fetched concurrently (bounded) instead of sequentially. For realistic boards (≤200 entities = 2 pages) the sequential loop costs one extra round-trip and is simpler; noting the parallel option so a future perf pass doesn't re-derive it. Sequential also composes naturally with the response-driven has_more contract.
+severity: nit
+reason: Realistic boards (≤200 entities) are 1-2 pages — parallelism saves at most one round-trip while complicating the response-driven has_more contract and the dedupe merge. The option is documented in the fix plan so a future perf pass doesn't re-derive it; not worth the complexity now.
+status: wont-fix
+---

--- a/tickets/entities/review-responses/RR-DB3W6Q.md
+++ b/tickets/entities/review-responses/RR-DB3W6Q.md
@@ -1,0 +1,9 @@
+---
+id: RR-DB3W6Q
+type: review-response
+title: included merge semantics (later page wins) were undocumented
+finding: data had an explicit 'later page wins' dedupe comment; included silently did the same via Object.assign but the doc comment only said 'included maps are merged', leaving the two merges' semantics visibly unaligned for the next reader.
+severity: nit
+resolution: 'Doc comment updated: ''included maps are merged (later page wins, same rule as data)''.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-G5435I.md
+++ b/tickets/entities/review-responses/RR-G5435I.md
@@ -1,0 +1,9 @@
+---
+id: RR-G5435I
+type: review-response
+title: has_more:true with an empty data page would spin the loop to the cap
+finding: 'The loop''s only termination conditions were !has_more and the page counter. A server anomaly returning has_more: true with data: [] would burn ~50 round-trips re-fetching nothing before hitting the cap, then raise the truncation banner on what may be a complete board.'
+severity: significant
+resolution: 'Added an explicit guard: an empty page breaks the loop immediately (one anomalous response instead of 49 more). meta.has_more is kept as reported so the anomaly stays visible to the consumer rather than being silently reported as complete. Pinned by a unit test (empty page 2 with has_more: true → 2 requests, has_more preserved).'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-JUVDUW.md
+++ b/tickets/entities/review-responses/RR-JUVDUW.md
@@ -1,0 +1,9 @@
+---
+id: RR-JUVDUW
+type: review-response
+title: Loop must trust response meta, not assume per_page=100 was honored
+finding: 'parseV1Pagination silently ignores out-of-range per_page values (>100 falls back to 25). If the server cap ever changes, a loop that computes page counts from an assumed page size of 100 would skip or re-fetch ranges. The loop''s advance condition must be purely response-driven: continue while meta.has_more, request meta.page+1, never derive offsets from the requested per_page. The page-count safety cap also guards a pathological server that returns has_more: true with empty data (would otherwise loop forever).'
+severity: minor
+resolution: 'Plan revised: the loop''s advance condition is purely response-driven — continue while meta.has_more, request meta.page + 1, never derive offsets from the requested per_page. A unit test covers the server-ignores-per_page case (falls back to 25); the 50-page cap bounds the pathological has_more-forever server.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-MZ7NJU.md
+++ b/tickets/entities/review-responses/RR-MZ7NJU.md
@@ -1,0 +1,9 @@
+---
+id: RR-MZ7NJU
+type: review-response
+title: Multi-page loop ignored Pinia Colada's AbortSignal — superseded fetch runs to the cap
+finding: Pinia Colada passes an AbortSignal into the query function context and aborts it when a refetch with the same key supersedes the in-flight call. The board's query neither received nor forwarded it, so a superseded pagination loop kept issuing up to 50 sequential requests producing a result the cache discards. Every drag-drop settleOptimistic invalidation and every SSE entity echo supersedes the running loop — on a busy large board this amplifies into a request storm of racing full-pagination loops.
+severity: significant
+resolution: listEntities and listAllEntities now accept an optional AbortSignal, forwarded to api.get (axios rejects immediately on an aborted signal, ending the loop between pages as well as in-flight). KanbanView's query fn destructures { signal } from the Colada context and passes it through. Unit test asserts the signal reaches every page request and that aborting after page 1 rejects the loop with no third request.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-QD46GS.md
+++ b/tickets/entities/review-responses/RR-QD46GS.md
@@ -1,0 +1,9 @@
+---
+id: RR-QD46GS
+type: review-response
+title: Page-merge must dedupe by entity ID (offset skew from concurrent writes)
+finding: 'The plan concatenates page data without deduplication. Store iteration order is deterministic (fsstore: sorted entityOrder keys; pgstore: ORDER BY id ASC), but the loop issues N sequential requests against a live store: a create/delete landing between page fetches shifts offsets, so an entity can appear on two consecutive pages (duplicate) or fall between them (miss). A duplicated ID breaks Vue''s v-for :key uniqueness on the board and corrupts beginOptimistic''s find-by-id copy-on-write. Misses are self-healing (the write that caused the skew fires an SSE event that invalidates and refetches) — duplicates are not.'
+severity: significant
+resolution: 'Plan revised: listAllEntities merges pages into a Map<string, Entity> keyed by ID (later page wins, fresher copy), so a concurrent write shifting offsets can never produce duplicate cards. Misses self-heal via the SSE invalidation the same write triggers. Dedupe covered by a dedicated unit test (entity appearing on two pages).'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-XRCIDE.md
+++ b/tickets/entities/review-responses/RR-XRCIDE.md
@@ -1,0 +1,9 @@
+---
+id: RR-XRCIDE
+type: review-response
+title: Truncation banner counts can disagree under concurrent writes
+finding: 'The banner reads ''Showing {entities.length} of {meta.total}'': the deduped merged count versus the LAST page''s total — different snapshots when a write lands mid-loop, e.g. ''Showing 4998 of 5001''. Cosmetic: the banner only appears past the ~5,000-entity cap, and its message (board incomplete) stays correct even when the numbers are slightly stale.'
+severity: minor
+reason: Neither operand is authoritative while writes race the loop, and no fetch strategy can make them so — the SSE invalidation that follows the racing write refreshes both. The banner's job is 'data is incomplete', which it does correctly; making the numbers transactionally consistent would add complexity for a state that should never occur.
+status: wont-fix
+---

--- a/tickets/relations/BUG-5OAQUG--adds-measure--kanban-full-fetch-pagination-test.md
+++ b/tickets/relations/BUG-5OAQUG--adds-measure--kanban-full-fetch-pagination-test.md
@@ -1,0 +1,5 @@
+---
+from: BUG-5OAQUG
+relation: adds-measure
+to: kanban-full-fetch-pagination-test
+---

--- a/tickets/relations/BUG-5OAQUG--affects--data-entry-ui.md
+++ b/tickets/relations/BUG-5OAQUG--affects--data-entry-ui.md
@@ -1,0 +1,5 @@
+---
+from: BUG-5OAQUG
+relation: affects
+to: data-entry-ui
+---

--- a/tickets/relations/BUG-5OAQUG--fixes--FEAT-006.md
+++ b/tickets/relations/BUG-5OAQUG--fixes--FEAT-006.md
@@ -1,0 +1,5 @@
+---
+from: BUG-5OAQUG
+relation: fixes
+to: FEAT-006
+---

--- a/tickets/relations/BUG-5OAQUG--has-bug-analysis--BUGA-VHOI2A.md
+++ b/tickets/relations/BUG-5OAQUG--has-bug-analysis--BUGA-VHOI2A.md
@@ -1,0 +1,5 @@
+---
+from: BUG-5OAQUG
+relation: has-bug-analysis
+to: BUGA-VHOI2A
+---

--- a/tickets/relations/BUG-5OAQUG--has-implementation--IMPL-DNOXI1.md
+++ b/tickets/relations/BUG-5OAQUG--has-implementation--IMPL-DNOXI1.md
@@ -1,0 +1,5 @@
+---
+from: BUG-5OAQUG
+relation: has-implementation
+to: IMPL-DNOXI1
+---

--- a/tickets/relations/BUG-5OAQUG--has-review--REV-JVFCTM.md
+++ b/tickets/relations/BUG-5OAQUG--has-review--REV-JVFCTM.md
@@ -1,0 +1,5 @@
+---
+from: BUG-5OAQUG
+relation: has-review
+to: REV-JVFCTM
+---

--- a/tickets/relations/BUG-5OAQUG--has-review-response--RR-0Y3Q6T.md
+++ b/tickets/relations/BUG-5OAQUG--has-review-response--RR-0Y3Q6T.md
@@ -1,0 +1,5 @@
+---
+from: BUG-5OAQUG
+relation: has-review-response
+to: RR-0Y3Q6T
+---

--- a/tickets/relations/BUG-5OAQUG--has-review-response--RR-1IBKZ0.md
+++ b/tickets/relations/BUG-5OAQUG--has-review-response--RR-1IBKZ0.md
@@ -1,0 +1,5 @@
+---
+from: BUG-5OAQUG
+relation: has-review-response
+to: RR-1IBKZ0
+---

--- a/tickets/relations/BUG-5OAQUG--has-review-response--RR-5YVXMK.md
+++ b/tickets/relations/BUG-5OAQUG--has-review-response--RR-5YVXMK.md
@@ -1,0 +1,5 @@
+---
+from: BUG-5OAQUG
+relation: has-review-response
+to: RR-5YVXMK
+---

--- a/tickets/relations/BUG-5OAQUG--has-review-response--RR-7YDNSN.md
+++ b/tickets/relations/BUG-5OAQUG--has-review-response--RR-7YDNSN.md
@@ -1,0 +1,5 @@
+---
+from: BUG-5OAQUG
+relation: has-review-response
+to: RR-7YDNSN
+---

--- a/tickets/relations/BUG-5OAQUG--has-review-response--RR-DB3W6Q.md
+++ b/tickets/relations/BUG-5OAQUG--has-review-response--RR-DB3W6Q.md
@@ -1,0 +1,5 @@
+---
+from: BUG-5OAQUG
+relation: has-review-response
+to: RR-DB3W6Q
+---

--- a/tickets/relations/BUG-5OAQUG--has-review-response--RR-G5435I.md
+++ b/tickets/relations/BUG-5OAQUG--has-review-response--RR-G5435I.md
@@ -1,0 +1,5 @@
+---
+from: BUG-5OAQUG
+relation: has-review-response
+to: RR-G5435I
+---

--- a/tickets/relations/BUG-5OAQUG--has-review-response--RR-JUVDUW.md
+++ b/tickets/relations/BUG-5OAQUG--has-review-response--RR-JUVDUW.md
@@ -1,0 +1,5 @@
+---
+from: BUG-5OAQUG
+relation: has-review-response
+to: RR-JUVDUW
+---

--- a/tickets/relations/BUG-5OAQUG--has-review-response--RR-MZ7NJU.md
+++ b/tickets/relations/BUG-5OAQUG--has-review-response--RR-MZ7NJU.md
@@ -1,0 +1,5 @@
+---
+from: BUG-5OAQUG
+relation: has-review-response
+to: RR-MZ7NJU
+---

--- a/tickets/relations/BUG-5OAQUG--has-review-response--RR-QD46GS.md
+++ b/tickets/relations/BUG-5OAQUG--has-review-response--RR-QD46GS.md
@@ -1,0 +1,5 @@
+---
+from: BUG-5OAQUG
+relation: has-review-response
+to: RR-QD46GS
+---

--- a/tickets/relations/BUG-5OAQUG--has-review-response--RR-XRCIDE.md
+++ b/tickets/relations/BUG-5OAQUG--has-review-response--RR-XRCIDE.md
@@ -1,0 +1,5 @@
+---
+from: BUG-5OAQUG
+relation: has-review-response
+to: RR-XRCIDE
+---

--- a/tickets/relations/kanban-full-fetch-pagination-test--protects--data-entry-ui.md
+++ b/tickets/relations/kanban-full-fetch-pagination-test--protects--data-entry-ui.md
@@ -1,0 +1,5 @@
+---
+from: kanban-full-fetch-pagination-test
+relation: protects
+to: data-entry-ui
+---


### PR DESCRIPTION
## Why

The kanban board fetched exactly one page of the list API (server default `per_page=25`, hard cap 100) and rendered it as the complete set. Any entity sorted onto page 2+ silently vanished from the board — missing cards are indistinguishable from "none exist", so boards quietly lost tasks once a type crossed the page size. Reported against a live instance (46 `taak` entities; a `wachten` task on page 2 missing from its column).

## What

- **`listAllEntities(type, params, signal)`** in `frontend/src/api/entities.ts`: fetches every page (`per_page: 100`), response-driven advance (`meta.has_more` / `meta.page + 1` — never derived from the requested page size), dedupes by entity ID across pages (later page wins; concurrent writes shift offsets), merges `included`, keeps `_actions` from page 1. 50-page safety cap (~5,000 entities) preserves `has_more: true` so truncation stays visible. Forwards the Pinia Colada `AbortSignal` so a superseded loop (drag-drop settle, SSE echo) cancels instead of paging to the cap; an empty page with `has_more: true` breaks instead of spinning.
- **`KanbanView.vue`**: `boardQuery` uses `listAllEntities` (same cache key — optimistic drag-drop, `_actions` gating, and SSE invalidation unchanged) and renders a visible truncation banner if the cap is ever hit.
- **Tests**: unit tests for the fetch-all contract (`entitiesListAll.test.ts`, 8 cases) and a component regression test (`KanbanView.pagination.test.ts`) that mocks the HTTP client so the real loop runs in the mounted board — a page-2-only entity must render in its column.

## Verification

Live check against a scratch project: 46 entities (reporter's scenario) → all 46 cards render; 130 entities → exactly 2 page requests, 130 unique cards, no banner. Full suite: 1217 frontend tests, `just ci` green.

Tracked as BUG-5OAQUG in `tickets/` (5-whys, design review + code review responses included in this PR).