### PR TITLE
test(loader): guard dataentryconfig + acl key allowlists against struct drift (TKT-ELX09J)

### DIFF
--- a/internal/acl/policy_parity_test.go
+++ b/internal/acl/policy_parity_test.go
@@ -1,0 +1,30 @@
+package acl
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+// TestKnownPolicyKeysMatchStruct guards the same drift class as BUG-5XIN07 (the
+// metamodel loader's whitelist), applied to acl.yaml: knownPolicyKeys is a
+// hand-maintained duplicate of the Policy struct's top-level yaml tags (the
+// declaration even carries a "keep in sync" comment). This asserts every
+// top-level yaml tag on Policy is in knownPolicyKeys, so a newly-added field
+// can't silently start emitting an unknown-key warning for valid config.
+func TestKnownPolicyKeysMatchStruct(t *testing.T) {
+	for field := range reflect.TypeFor[Policy]().Fields() {
+		tag := field.Tag.Get("yaml")
+		if tag == "" || tag == "-" {
+			continue // computed / non-YAML field
+		}
+		key := strings.Split(tag, ",")[0]
+		if key == "" {
+			continue
+		}
+		if !knownPolicyKeys[key] {
+			t.Errorf("Policy field %q (yaml:%q) is not in knownPolicyKeys — "+
+				"LoadPolicy will warn on valid config that uses it", field.Name, key)
+		}
+	}
+}

--- a/internal/dataentryconfig/validate_test.go
+++ b/internal/dataentryconfig/validate_test.go
@@ -2,11 +2,35 @@ package dataentryconfig
 
 import (
 	"errors"
+	"reflect"
 	"strings"
 	"testing"
 
 	"github.com/Sourcehaven-BV/rela/internal/metamodel"
 )
+
+// TestValidTopLevelKeysMatchConfigStruct guards the same drift class as
+// BUG-5XIN07 (the metamodel loader's whitelist), applied to data-entry.yaml:
+// validTopLevelKeys is a hand-maintained duplicate of the Config struct's
+// top-level yaml tags, so a newly-added field could be silently rejected by
+// checkUnknownKeys. This asserts every top-level yaml tag on Config is
+// whitelisted, so such a field fails this test before it can reach a user.
+func TestValidTopLevelKeysMatchConfigStruct(t *testing.T) {
+	for field := range reflect.TypeFor[Config]().Fields() {
+		tag := field.Tag.Get("yaml")
+		if tag == "" || tag == "-" {
+			continue // computed / non-YAML field
+		}
+		key := strings.Split(tag, ",")[0]
+		if key == "" {
+			continue
+		}
+		if !validTopLevelKeys[key] {
+			t.Errorf("Config field %q (yaml:%q) is not in validTopLevelKeys — "+
+				"checkUnknownKeys will reject a config that uses it", field.Name, key)
+		}
+	}
+}
 
 // testMetamodel returns a metamodel for testing
 func testMetamodel() *metamodel.Metamodel {

--- a/tickets/entities/review-checklists/REV-ELX0.md
+++ b/tickets/entities/review-checklists/REV-ELX0.md
@@ -1,0 +1,22 @@
+---
+id: REV-ELX0
+type: review-checklist
+title: 'Review: loader allowlist parity tests (dataentryconfig + acl)'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Automated Checks
+
+- [x] Both new parity tests pass (`TestValidTopLevelKeysMatchConfigStruct`, `TestKnownPolicyKeysMatchStruct`)
+- [x] Lint clean on both packages (`golangci-lint run ./internal/dataentryconfig/... ./internal/acl/...` → 0 issues)
+- [x] ~~Coverage~~ (N/A: test-only change, no production code touched — floors cannot drop)
+
+## Manual Review
+
+- [x] Each test verified to bite: removing an allowlist entry (`palette` / `inherit_roles_through`) fails the corresponding test; restoring passes
+- [x] Confirmed both allowlists are currently in sync with their structs — purely additive coverage, no latent bug found
+- [x] `acl` test placed in an internal-package file (`policy_parity_test.go`) because `knownPolicyKeys` is unexported
+- [x] Mirrors the established `metamodel.TestValidTopLevelKeysMatchStruct` pattern (RR-GHDQXC follow-up from BUG-5XIN07)
+- [x] PR: https://github.com/sourcehaven-bv/rela/pull/1103

--- a/tickets/entities/tickets/TKT-ELX09J.md
+++ b/tickets/entities/tickets/TKT-ELX09J.md
@@ -5,7 +5,7 @@ title: Apply whitelist-vs-struct parity tests to dataentryconfig + acl loaders
 kind: test
 priority: low
 effort: xs
-status: backlog
+status: done
 ---
 
 ## Problem

--- a/tickets/relations/TKT-ELX09J--has-review--REV-ELX0.md
+++ b/tickets/relations/TKT-ELX09J--has-review--REV-ELX0.md
@@ -1,0 +1,5 @@
+---
+from: TKT-ELX09J
+relation: has-review
+to: REV-ELX0
+---


### PR DESCRIPTION
## Why

BUG-5XIN07 (#1097) was caused by a top-level-key allowlist (`validTopLevelKeys`) drifting from the struct it validates — a new struct field was added without its allowlist entry, so the loader rejected valid config. That fix added a reflection-parity test to the metamodel loader.

The **same hand-maintained-allowlist-vs-struct pattern** exists in two sibling loaders with no guard (surfaced by review, RR-GHDQXC):

- `internal/dataentryconfig/validate.go` — `validTopLevelKeys` vs the `Config` struct
- `internal/acl/policy.go` — `knownPolicyKeys` vs the `Policy` struct (its declaration even carries a "keep in sync with Policy's yaml tags" comment)

## What

Add a reflection parity test to each, mirroring `metamodel.TestValidTopLevelKeysMatchStruct`: assert every top-level `yaml` tag on the config struct is present in its allowlist. Skips computed fields (empty / `-` tag).

- `TestValidTopLevelKeysMatchConfigStruct` (dataentryconfig, internal test)
- `TestKnownPolicyKeysMatchStruct` (acl, new internal-package `policy_parity_test.go` — `knownPolicyKeys` is unexported, so the test can't live in the `acl_test` package)

Effect differs slightly per loader: dataentry *rejects* an unknown key (hard error), acl *warns* — so an out-of-sync field is a silently-rejected config for dataentry and a spurious warning for acl. Both are guarded.

## Verification

- Both allowlists are **currently in sync** with their structs — this is purely additive coverage, no latent bug found.
- Confirmed each test bites: removing an allowlist entry (`palette` / `inherit_roles_through`) fails the corresponding test; restoring passes.
- Test-only change; `go test` + lint clean on both packages.