### PR TITLE
refactor(dataentry): extract self-synchronized logoStore from AppState

### DIFF
--- a/internal/dataentry/api_v1.go
+++ b/internal/dataentry/api_v1.go
@@ -2611,7 +2611,7 @@ func (a *App) handleV1Sidebar(w http.ResponseWriter, r *http.Request) {
 		},
 		Navigation: navigation,
 	}
-	resp.LogoURL = s.LogoURL()
+	resp.LogoURL = a.logo.URL()
 
 	writeV1JSON(w, http.StatusOK, resp)
 }

--- a/internal/dataentry/app.go
+++ b/internal/dataentry/app.go
@@ -37,16 +37,15 @@ import (
 	"github.com/Sourcehaven-BV/rela/internal/validator"
 )
 
-// AppState bundles the reloadable fields of App into an immutable snapshot.
+// AppState bundles the reloadable fields of App into an immutable snapshot,
+// published via atomic.Pointer. Callers Load() once and work against a
+// coherent snapshot, instead of holding a read lock around the entire request.
 //
-// During this PR, App still holds the same fields as plain struct fields
-// (Cfg, meta, g, styleMap, styledTypes, userDefaults, palette, userPalette,
-// openAPIGen) and the AppState is published in parallel via atomic.Pointer.
-// Handlers will be migrated to read from the snapshot in a subsequent PR.
-//
-// The fields here mirror the workspace.workspaceState pattern: callers
-// Load() once and work against a coherent snapshot, instead of holding a
-// read lock around the entire request.
+// This snapshot is being decomposed: state owned by exactly one service is
+// moving out into that service (self-synchronized), leaving AppState to hold
+// only genuinely co-derived reload state. The user-uploaded logo was the first
+// to move — see [logoStore]. What remains here is the config/metamodel and the
+// fields derived from them together.
 type AppState struct {
 	Cfg          *Config
 	Meta         *metamodel.Metamodel
@@ -56,14 +55,6 @@ type AppState struct {
 	Palette      *ResolvedPalette
 	UserPalette  *PaletteConfig
 	OpenAPIGen   *openapi.Generator
-
-	// User-uploaded sidebar logo. Empty UserLogoExt means "no logo
-	// configured"; UserLogoBytes/UserLogoHash are populated together.
-	// Bytes live in-memory (≤256 KiB) so GET /_theme/logo doesn't hit
-	// disk on every request.
-	UserLogoBytes []byte
-	UserLogoExt   string
-	UserLogoHash  string
 }
 
 // ConfigFile is the conventional filename for data-entry configuration within a rela project.
@@ -147,9 +138,13 @@ type App struct {
 	// App (TKT-N26KLB); pure transform — handlers pass the entity's already-
 	// loaded outgoing relations, the serializer does no loading.
 	serializer entitySerializer
-	// userState persists per-user UI state (logo, UI state, defaults, palette)
+	// userState persists per-user UI state (UI state, defaults, palette)
 	// to the .rela/ KV store. Extracted from App (TKT-N26KLB M5.3).
 	userState userStateStore
+	// logo owns the user-uploaded sidebar logo — persistence AND the served
+	// in-memory cache — self-synchronized. Extracted from AppState so the
+	// logo no longer rides the App-wide snapshot + writeMu.
+	logo      *logoStore
 	templater templating.Templater
 	cfgLoader config.Loader
 	kv        state.KV
@@ -523,31 +518,26 @@ func NewApp(
 		return nil, fmt.Errorf("load user palette: %w", paletteErr)
 	}
 
-	logoBytes, logoExt, logoErr := app.userState.loadUserLogo()
+	// logo owns its own persistence + served cache. Same read-error policy as
+	// palette: surface a corrupt .rela/theme/ rather than silently overwriting
+	// it on the next save.
+	logo, logoErr := newLogoStore(kv)
 	if logoErr != nil {
-		// Same policy as palette: surface read errors so a corrupt
-		// .rela/theme/ doesn't get silently overwritten on next save.
 		return nil, fmt.Errorf("load user logo: %w", logoErr)
 	}
-	var logoHash string
-	if logoExt != "" {
-		logoHash = hashLogoBytes(logoBytes)
-	}
+	app.logo = logo
 
 	// Build and publish the initial AppState snapshot. All reloadable
 	// state lives here; there are no convenience aliases on App to keep
 	// in sync.
 	app.state.Store(&AppState{
-		Cfg:           &cfg,
-		Meta:          meta,
-		StyleMap:      styleMap,
-		StyledTypes:   styledTypes,
-		UserDefaults:  userDefaults,
-		Palette:       ResolvePalette(cfg.Palette, userPalette),
-		UserPalette:   userPalette,
-		UserLogoBytes: logoBytes,
-		UserLogoExt:   logoExt,
-		UserLogoHash:  logoHash,
+		Cfg:          &cfg,
+		Meta:         meta,
+		StyleMap:     styleMap,
+		StyledTypes:  styledTypes,
+		UserDefaults: userDefaults,
+		Palette:      ResolvePalette(cfg.Palette, userPalette),
+		UserPalette:  userPalette,
 		OpenAPIGen: openapi.New(meta, openapi.Config{
 			Title:       cfg.App.Name + " API",
 			Description: cfg.App.Description,

--- a/internal/dataentry/handlers_theme.go
+++ b/internal/dataentry/handlers_theme.go
@@ -37,15 +37,15 @@ func (a *App) handleAPIThemeLogo(w http.ResponseWriter, r *http.Request) {
 // SVG can't be coerced into a script-execution context, even on direct
 // navigation, and so cache-busting works via the URL alone.
 func (a *App) handleAPIGetThemeLogo(w http.ResponseWriter, _ *http.Request) {
-	s := a.State()
-	if s.UserLogoExt == "" || len(s.UserLogoBytes) == 0 {
+	logoBytes, logoExt, _ := a.logo.Get()
+	if logoExt == "" || len(logoBytes) == 0 {
 		writeJSONError(w, http.StatusNotFound, "no logo set")
 		return
 	}
-	ct := logoContentType(s.UserLogoExt)
+	ct := logoContentType(logoExt)
 	if ct == "" {
-		// Should never happen — saveUserLogo validates the extension
-		// before persisting, and loadUserLogo treats unknown values as
+		// Should never happen — logoStore.Save validates the extension
+		// before persisting, and its load treats unknown values as
 		// "not set". Treat as a server-side bug rather than serving
 		// bytes with no Content-Type.
 		writeJSONError(w, http.StatusInternalServerError, "logo has unknown extension")
@@ -62,12 +62,12 @@ func (a *App) handleAPIGetThemeLogo(w http.ResponseWriter, _ *http.Request) {
 	// The URL contains a content hash — any update produces a different
 	// URL, so the cached response can never go stale.
 	h.Set("Cache-Control", "public, max-age=86400, immutable")
-	_, _ = w.Write(s.UserLogoBytes)
+	_, _ = w.Write(logoBytes)
 }
 
-// handleAPIPutThemeLogo accepts a multipart upload, validates it, and
-// persists the bytes + extension under writeMu via mutateState so the
-// AppState snapshot is coherent for concurrent readers.
+// handleAPIPutThemeLogo accepts a multipart upload, validates it, and persists
+// the bytes + extension via the self-synchronized logo store, which publishes
+// the new bytes atomically for concurrent readers.
 func (a *App) handleAPIPutThemeLogo(w http.ResponseWriter, r *http.Request) {
 	r.Body = http.MaxBytesReader(w, r.Body, maxLogoUploadBytes)
 
@@ -117,31 +117,14 @@ func (a *App) handleAPIPutThemeLogo(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	hash := hashLogoBytes(bytes)
-
-	var saveErr error
-	ctx := r.Context()
-	a.mutateState(func(s *AppState) {
-		if err := a.userState.saveUserLogo(ctx, bytes, ext); err != nil {
-			// On failure the snapshot copy is left untouched and
-			// mutateState republishes a bytewise-identical pointer.
-			// Cheap (one struct copy) and keeps the path simple — do
-			// not "optimize" by skipping the publish.
-			saveErr = err
-			return
-		}
-		s.UserLogoBytes = bytes
-		s.UserLogoExt = ext
-		s.UserLogoHash = hash
-	})
-	if saveErr != nil {
-		writeJSONError(w, http.StatusInternalServerError, "failed to save logo: "+saveErr.Error())
+	if err := a.logo.Save(r.Context(), bytes, ext); err != nil {
+		writeJSONError(w, http.StatusInternalServerError, "failed to save logo: "+err.Error())
 		return
 	}
 
 	writeJSON(w, map[string]any{
 		"ok":      true,
-		"logoUrl": logoURLForHash(hash),
+		"logoUrl": logoURLForHash(hashLogoBytes(bytes)),
 	})
 }
 
@@ -150,19 +133,8 @@ func (a *App) handleAPIPutThemeLogo(w http.ResponseWriter, r *http.Request) {
 // idempotent), so callers that don't track current logo state can just
 // hit the endpoint.
 func (a *App) handleAPIDeleteThemeLogo(w http.ResponseWriter, r *http.Request) {
-	var deleteErr error
-	ctx := r.Context()
-	a.mutateState(func(s *AppState) {
-		if err := a.userState.deleteUserLogo(ctx); err != nil {
-			deleteErr = err
-			return
-		}
-		s.UserLogoBytes = nil
-		s.UserLogoExt = ""
-		s.UserLogoHash = ""
-	})
-	if deleteErr != nil {
-		writeJSONError(w, http.StatusInternalServerError, "failed to delete logo: "+deleteErr.Error())
+	if err := a.logo.Delete(r.Context()); err != nil {
+		writeJSONError(w, http.StatusInternalServerError, "failed to delete logo: "+err.Error())
 		return
 	}
 	w.WriteHeader(http.StatusNoContent)

--- a/internal/dataentry/handlers_theme_package.go
+++ b/internal/dataentry/handlers_theme_package.go
@@ -37,9 +37,9 @@ func (a *App) handleAPIThemeExport(w http.ResponseWriter, r *http.Request) {
 		writeJSONError(w, http.StatusMethodNotAllowed, "method not allowed")
 		return
 	}
-	s := a.State()
-	manifest := buildExportManifest(s)
-	zipBytes, err := buildThemeZip(manifest, s.UserLogoBytes, s.UserLogoExt)
+	logoBytes, logoExt, _ := a.logo.Get()
+	manifest := buildExportManifest(a.State(), logoExt)
+	zipBytes, err := buildThemeZip(manifest, logoBytes, logoExt)
 	if err != nil {
 		writeJSONError(w, http.StatusInternalServerError, "failed to build theme package: "+err.Error())
 		return
@@ -100,23 +100,11 @@ func (a *App) handleAPIThemeImport(w http.ResponseWriter, r *http.Request) {
 
 	logoURL := ""
 	if pkg.Logo != nil {
-		hash := hashLogoBytes(pkg.Logo.Bytes)
-		var saveErr error
-		ctx := r.Context()
-		a.mutateState(func(s *AppState) {
-			if err := a.userState.saveUserLogo(ctx, pkg.Logo.Bytes, pkg.Logo.Ext); err != nil {
-				saveErr = err
-				return
-			}
-			s.UserLogoBytes = pkg.Logo.Bytes
-			s.UserLogoExt = pkg.Logo.Ext
-			s.UserLogoHash = hash
-		})
-		if saveErr != nil {
-			writeJSONError(w, http.StatusInternalServerError, "failed to save logo: "+saveErr.Error())
+		if err := a.logo.Save(r.Context(), pkg.Logo.Bytes, pkg.Logo.Ext); err != nil {
+			writeJSONError(w, http.StatusInternalServerError, "failed to save logo: "+err.Error())
 			return
 		}
-		logoURL = logoURLForHash(hash)
+		logoURL = logoURLForHash(hashLogoBytes(pkg.Logo.Bytes))
 	}
 
 	writeJSON(w, APIThemeImportResponse{
@@ -128,7 +116,7 @@ func (a *App) handleAPIThemeImport(w http.ResponseWriter, r *http.Request) {
 // buildExportManifest composes the manifest written into the zip,
 // drawing the palette from user state when available and falling back
 // to the project palette otherwise.
-func buildExportManifest(s *AppState) *dataentryconfig.ThemeManifest {
+func buildExportManifest(s *AppState, logoExt string) *dataentryconfig.ThemeManifest {
 	m := &dataentryconfig.ThemeManifest{
 		Name:    s.Cfg.App.Name,
 		Version: "1.0.0",
@@ -144,8 +132,8 @@ func buildExportManifest(s *AppState) *dataentryconfig.ThemeManifest {
 		m.PaletteConfig = *s.Cfg.Palette
 	}
 
-	if s.UserLogoExt != "" {
-		m.Logo = "logo." + s.UserLogoExt
+	if logoExt != "" {
+		m.Logo = "logo." + logoExt
 	}
 	return m
 }

--- a/internal/dataentry/handlers_theme_package_test.go
+++ b/internal/dataentry/handlers_theme_package_test.go
@@ -164,7 +164,7 @@ func TestThemeImport_RoundTrip(t *testing.T) {
 	}
 
 	dest := newHandlerTestApp(t)
-	if dest.State().UserLogoExt != "" {
+	if _, ext, _ := dest.logo.Get(); ext != "" {
 		t.Fatal("dest should not start with a logo")
 	}
 
@@ -190,8 +190,8 @@ func TestThemeImport_RoundTrip(t *testing.T) {
 		t.Errorf("logoUrl: %q", resp.LogoURL)
 	}
 
-	if !bytes.Equal(dest.State().UserLogoBytes, pngBytes) {
-		t.Error("dest UserLogoBytes does not match round-tripped bytes")
+	if gotBytes, _, _ := dest.logo.Get(); !bytes.Equal(gotBytes, pngBytes) {
+		t.Error("dest logo bytes do not match round-tripped bytes")
 	}
 	if dest.State().UserPalette != nil {
 		t.Error("dest UserPalette should not be auto-saved on import")
@@ -219,7 +219,7 @@ func TestThemeImport_Errors(t *testing.T) {
 			if !strings.Contains(w.Body.String(), tt.wantSubstr) {
 				t.Errorf("body: %q does not contain %q", w.Body.String(), tt.wantSubstr)
 			}
-			if app.State().UserLogoExt != "" {
+			if _, ext, _ := app.logo.Get(); ext != "" {
 				t.Error("rejected import must not have mutated state")
 			}
 		})

--- a/internal/dataentry/handlers_theme_test.go
+++ b/internal/dataentry/handlers_theme_test.go
@@ -104,16 +104,16 @@ func TestThemeLogo_RoundTrip(t *testing.T) {
 		t.Errorf("expected hashed URL, got %q", put.LogoURL)
 	}
 
-	// State should reflect the upload.
-	s := app.State()
-	if s.UserLogoExt != "png" {
-		t.Errorf("expected ext=png, got %q", s.UserLogoExt)
+	// The logo store should reflect the upload.
+	gotBytes, gotExt, gotHash := app.logo.Get()
+	if gotExt != "png" {
+		t.Errorf("expected ext=png, got %q", gotExt)
 	}
-	if !bytes.Equal(s.UserLogoBytes, pngBytes) {
-		t.Error("UserLogoBytes does not match upload")
+	if !bytes.Equal(gotBytes, pngBytes) {
+		t.Error("logo bytes do not match upload")
 	}
-	if s.UserLogoHash == "" {
-		t.Error("UserLogoHash empty after upload")
+	if gotHash == "" {
+		t.Error("logo hash empty after upload")
 	}
 
 	// GET should return the bytes byte-for-byte.
@@ -146,8 +146,8 @@ func TestThemeLogo_RoundTrip(t *testing.T) {
 	if delW.Code != http.StatusNoContent {
 		t.Fatalf("DELETE: expected 204, got %d", delW.Code)
 	}
-	if app.State().UserLogoExt != "" {
-		t.Error("UserLogoExt not cleared after DELETE")
+	if _, ext, _ := app.logo.Get(); ext != "" {
+		t.Error("logo ext not cleared after DELETE")
 	}
 
 	// Subsequent GET should 404.
@@ -182,7 +182,7 @@ func TestThemeLogo_Validation(t *testing.T) {
 			if tt.wantContent != "" && !strings.Contains(w.Body.String(), tt.wantContent) {
 				t.Errorf("body: %q does not contain %q", w.Body.String(), tt.wantContent)
 			}
-			if app.State().UserLogoExt != "" {
+			if _, ext, _ := app.logo.Get(); ext != "" {
 				t.Error("rejected upload should not have mutated state")
 			}
 		})
@@ -207,8 +207,8 @@ func TestThemeLogo_AcceptedFormats(t *testing.T) {
 			if w.Code != http.StatusOK {
 				t.Fatalf("expected 200, got %d body=%s", w.Code, w.Body.String())
 			}
-			if app.State().UserLogoExt != tt.ext {
-				t.Errorf("ext: got %q, want %q", app.State().UserLogoExt, tt.ext)
+			if _, ext, _ := app.logo.Get(); ext != tt.ext {
+				t.Errorf("ext: got %q, want %q", ext, tt.ext)
 			}
 		})
 	}
@@ -223,7 +223,7 @@ func TestThemeLogo_TooLarge(t *testing.T) {
 	if w.Code != http.StatusRequestEntityTooLarge {
 		t.Errorf("expected 413, got %d body=%s", w.Code, w.Body.String())
 	}
-	if app.State().UserLogoExt != "" {
+	if _, ext, _ := app.logo.Get(); ext != "" {
 		t.Error("oversized upload must not mutate state")
 	}
 }

--- a/internal/dataentry/logo_store.go
+++ b/internal/dataentry/logo_store.go
@@ -1,0 +1,189 @@
+package dataentry
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"sync"
+
+	"github.com/Sourcehaven-BV/rela/internal/state"
+)
+
+// logoStore owns the user-uploaded sidebar logo end to end: the persisted
+// bytes/extension in the `.rela/theme/` KV store AND the in-memory cache the
+// GET handler serves without hitting disk.
+//
+// It is self-synchronizing: a sync.RWMutex guards the cached triple so reads
+// (Get/URL) never block each other and writes (Save/Delete) publish the new
+// bytes atomically. This is deliberately NOT part of the App-wide AppState
+// snapshot — the logo has exactly one reader path and one writer path, so it
+// owns its own state rather than riding the shared snapshot + writeMu (the
+// pattern the AppState-decomposition arc pushes every peripheral service
+// toward).
+//
+// Bytes live in-memory (≤256 KiB, MaxUserLogoBytes) so GET /_theme/logo
+// doesn't hit disk on every request.
+type logoStore struct {
+	kv state.KV
+
+	mu    sync.RWMutex
+	bytes []byte
+	ext   string
+	hash  string
+}
+
+// newLogoStore builds a logoStore over the given KV and loads the persisted
+// logo into the cache. A read error is surfaced (not masked) so a corrupt
+// `.rela/theme/` doesn't get silently overwritten on the next save.
+func newLogoStore(kv state.KV) (*logoStore, error) {
+	s := &logoStore{kv: kv}
+	bytes, ext, err := s.load()
+	if err != nil {
+		return nil, err
+	}
+	s.bytes = bytes
+	s.ext = ext
+	if ext != "" {
+		s.hash = hashLogoBytes(bytes)
+	}
+	return s, nil
+}
+
+// Get returns the cached logo bytes, extension, and content hash. An empty
+// ext means "no logo configured"; bytes/hash are populated together with ext.
+//
+//nolint:gocritic // unnamedResult: handler-style (bytes, ext, hash) is clearer than naming
+func (s *logoStore) Get() ([]byte, string, string) {
+	// A nil store reads as "no logo configured" so App values constructed
+	// without a logo store (chiefly narrow test fixtures) behave like the
+	// former zero-value AppState instead of panicking.
+	if s == nil {
+		return nil, "", ""
+	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.bytes, s.ext, s.hash
+}
+
+// URL returns the public, cache-busting URL for the current logo, or nil when
+// no logo is set. Single source of truth for handlers that surface the URL to
+// the SPA, so a future change (signing, expiry) lands in one place.
+func (s *logoStore) URL() *string {
+	if s == nil {
+		return nil
+	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if s.hash == "" {
+		return nil
+	}
+	u := logoURLForHash(s.hash)
+	return &u
+}
+
+// Save persists the bytes + extension and updates the cache atomically. The
+// on-disk write happens first; the cache is only advanced once the write
+// succeeds, so a failed write leaves the served logo unchanged.
+func (s *logoStore) Save(ctx context.Context, bytes []byte, ext string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if err := s.persist(ctx, bytes, ext); err != nil {
+		return err
+	}
+	s.bytes = bytes
+	s.ext = ext
+	s.hash = hashLogoBytes(bytes)
+	return nil
+}
+
+// Delete clears the persisted logo and the cache. Idempotent: deleting when no
+// logo is set still succeeds (the on-disk Delete is itself idempotent).
+func (s *logoStore) Delete(ctx context.Context) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if err := s.remove(ctx); err != nil {
+		return err
+	}
+	s.bytes = nil
+	s.ext = ""
+	s.hash = ""
+	return nil
+}
+
+// load reads the persisted logo bytes and extension. Returns (nil, "", nil)
+// when no logo is set. A sidecar file present without matching bytes (or vice
+// versa) is treated as "no logo set" so a half-written state during a crash
+// doesn't trip up the boot path.
+//
+// Returns a non-nil error only when the kv layer reports an unexpected failure
+// (corrupt filesystem, permission denied) — callers should surface those
+// instead of silently masking them.
+//
+//nolint:gocritic // unnamedResult: handler-style (bytes, ext, err) is clearer than naming
+func (s *logoStore) load() ([]byte, string, error) {
+	if s.kv == nil {
+		return nil, "", nil
+	}
+	ctx := context.Background()
+
+	logoBytes, err := s.kv.Get(ctx, userLogoFile)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) || os.IsNotExist(err) {
+			return nil, "", nil
+		}
+		return nil, "", fmt.Errorf("read %s: %w", userLogoFile, err)
+	}
+
+	extBytes, err := s.kv.Get(ctx, userLogoExtFile)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) || os.IsNotExist(err) {
+			// Bytes present but sidecar missing — treat as not-set. The user
+			// can re-upload to recover; we don't proactively clean up so a
+			// future fix can recover the bytes.
+			return nil, "", nil
+		}
+		return nil, "", fmt.Errorf("read %s: %w", userLogoExtFile, err)
+	}
+
+	ext := string(extBytes)
+	if _, ok := allowedLogoExts[ext]; !ok {
+		// Sidecar contains an unknown extension — treat as not-set. Same
+		// reasoning as the missing-sidecar case.
+		return nil, "", nil
+	}
+
+	return logoBytes, ext, nil
+}
+
+// persist writes the bytes and extension sidecar. Caller holds s.mu.
+func (s *logoStore) persist(ctx context.Context, bytes []byte, ext string) error {
+	if s.kv == nil {
+		return errors.New("kv not configured")
+	}
+	if _, ok := allowedLogoExts[ext]; !ok {
+		return fmt.Errorf("invalid logo extension %q", ext)
+	}
+	if err := s.kv.Put(ctx, userLogoFile, bytes); err != nil {
+		return fmt.Errorf("write %s: %w", userLogoFile, err)
+	}
+	if err := s.kv.Put(ctx, userLogoExtFile, []byte(ext)); err != nil {
+		return fmt.Errorf("write %s: %w", userLogoExtFile, err)
+	}
+	return nil
+}
+
+// remove deletes both the bytes file and the sidecar. Idempotent. Caller holds
+// s.mu.
+func (s *logoStore) remove(ctx context.Context) error {
+	if s.kv == nil {
+		return nil
+	}
+	if err := s.kv.Delete(ctx, userLogoFile); err != nil {
+		return fmt.Errorf("delete %s: %w", userLogoFile, err)
+	}
+	if err := s.kv.Delete(ctx, userLogoExtFile); err != nil {
+		return fmt.Errorf("delete %s: %w", userLogoExtFile, err)
+	}
+	return nil
+}

--- a/internal/dataentry/settings_handlers.go
+++ b/internal/dataentry/settings_handlers.go
@@ -253,7 +253,7 @@ func (a *App) handleAPIGetSettings(w http.ResponseWriter, r *http.Request) {
 		AllRelations:  allRelations,
 		EntityTypes:   s.Meta.EntityTypes(),
 	}
-	data.LogoURL = s.LogoURL()
+	data.LogoURL = a.logo.URL()
 
 	writeJSON(w, data)
 }

--- a/internal/dataentry/test_helpers_test.go
+++ b/internal/dataentry/test_helpers_test.go
@@ -138,6 +138,9 @@ func rebindApp(app *App, fs storage.FS, paths *project.Context, svc *appbuild.Se
 	app.cfgLoader = svc.Config()
 	app.kv = svc.State()
 	app.userState = userStateStore{kv: svc.State()}
+	// logo store over the same kv; fresh fixtures have no logo on disk so the
+	// load can't error (a nil-return matches production's clean-boot path).
+	app.logo, _ = newLogoStore(svc.State())
 	app.acl = svc.ACL()
 	app.auditSink = svc.Audit()
 	// Wire a minimal documentService for tests that hit the documents

--- a/internal/dataentry/theme_logo.go
+++ b/internal/dataentry/theme_logo.go
@@ -73,16 +73,3 @@ func hashLogoBytes(b []byte) string {
 	sum := sha256.Sum256(b)
 	return hex.EncodeToString(sum[:6])
 }
-
-// LogoURL returns the public URL for the user-uploaded logo (including
-// the cache-busting query parameter), or nil when no logo is set. The
-// single source of truth for handlers that surface the URL to the SPA,
-// so a future change (signing, expiry, alternate cache strategy) lands
-// in one place.
-func (s *AppState) LogoURL() *string {
-	if s.UserLogoHash == "" {
-		return nil
-	}
-	u := logoURLForHash(s.UserLogoHash)
-	return &u
-}

--- a/internal/dataentry/userstate.go
+++ b/internal/dataentry/userstate.go
@@ -3,7 +3,6 @@ package dataentry
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"os"
 
@@ -125,88 +124,4 @@ func (s userStateStore) saveUserPalette(ctx context.Context, p *PaletteConfig) e
 		return err
 	}
 	return s.kv.Put(ctx, userPaletteFile, data)
-}
-
-// loadUserLogo reads the persisted logo bytes and extension. Returns
-// (nil, "", nil) when no logo is set. A sidecar file present without
-// matching bytes (or vice versa) is treated as "no logo set" so a
-// half-written state during a crash doesn't trip up the boot path.
-//
-// Returns a non-nil error only when the kv layer reports an unexpected
-// failure (corrupt filesystem, permission denied) — callers should
-// surface those instead of silently masking them.
-//
-// Concurrency: NOT safe to call in parallel with saveUserLogo or
-// deleteUserLogo (the bytes/sidecar pair is read non-atomically). Boot
-// path calls this before publishing the App; future reload paths must
-// hold writeMu (i.e. invoke from inside mutateState).
-//
-//nolint:gocritic // unnamedResult: handler-style (bytes, ext, err) is clearer than naming for two callers
-func (s userStateStore) loadUserLogo() ([]byte, string, error) {
-	if s.kv == nil {
-		return nil, "", nil
-	}
-	ctx := context.Background()
-
-	logoBytes, err := s.kv.Get(ctx, userLogoFile)
-	if err != nil {
-		if errors.Is(err, os.ErrNotExist) || os.IsNotExist(err) {
-			return nil, "", nil
-		}
-		return nil, "", fmt.Errorf("read %s: %w", userLogoFile, err)
-	}
-
-	extBytes, err := s.kv.Get(ctx, userLogoExtFile)
-	if err != nil {
-		if errors.Is(err, os.ErrNotExist) || os.IsNotExist(err) {
-			// Bytes present but sidecar missing — treat as not-set.
-			// The user can re-upload to recover; we don't proactively
-			// clean up so a future fix can recover the bytes.
-			return nil, "", nil
-		}
-		return nil, "", fmt.Errorf("read %s: %w", userLogoExtFile, err)
-	}
-
-	ext := string(extBytes)
-	if _, ok := allowedLogoExts[ext]; !ok {
-		// Sidecar contains an unknown extension — treat as not-set.
-		// Same reasoning as the missing-sidecar case.
-		return nil, "", nil
-	}
-
-	return logoBytes, ext, nil
-}
-
-// saveUserLogo persists the bytes and extension. Caller must hold
-// writeMu (i.e. invoke from inside mutateState) so the bytes/sidecar
-// pair cannot be observed half-written by a concurrent reload.
-func (s userStateStore) saveUserLogo(ctx context.Context, bytes []byte, ext string) error {
-	if s.kv == nil {
-		return errors.New("kv not configured")
-	}
-	if _, ok := allowedLogoExts[ext]; !ok {
-		return fmt.Errorf("invalid logo extension %q", ext)
-	}
-	if err := s.kv.Put(ctx, userLogoFile, bytes); err != nil {
-		return fmt.Errorf("write %s: %w", userLogoFile, err)
-	}
-	if err := s.kv.Put(ctx, userLogoExtFile, []byte(ext)); err != nil {
-		return fmt.Errorf("write %s: %w", userLogoExtFile, err)
-	}
-	return nil
-}
-
-// deleteUserLogo removes both the bytes file and the sidecar. Idempotent;
-// missing files are not errors.
-func (s userStateStore) deleteUserLogo(ctx context.Context) error {
-	if s.kv == nil {
-		return nil
-	}
-	if err := s.kv.Delete(ctx, userLogoFile); err != nil {
-		return fmt.Errorf("delete %s: %w", userLogoFile, err)
-	}
-	if err := s.kv.Delete(ctx, userLogoExtFile); err != nil {
-		return fmt.Errorf("delete %s: %w", userLogoExtFile, err)
-	}
-	return nil
 }

--- a/tickets/entities/tickets/TKT-XSWFXQ.md
+++ b/tickets/entities/tickets/TKT-XSWFXQ.md
@@ -1,0 +1,53 @@
+---
+id: TKT-XSWFXQ
+type: ticket
+title: Decompose dataentry.App AppState into self-synchronized services + schema provider
+kind: refactor
+priority: medium
+effort: m
+status: ready
+---
+
+Continuation of the [[TKT-N26KLB]] `dataentry.App` decomposition arc (that
+ticket is done; this is the next coherent unit — state, not handlers).
+
+## Problem
+
+`AppState` was an 8-field snapshot grab-bag published via `atomic.Pointer` on
+`App`. It hoisted per-service mutable state (logo bytes, user palette, user
+defaults) up to `App`, forcing every write of that state through `mutateState`
++ the App-wide `writeMu`. `rebuildState` hand-copied every field forward on
+each reload. The mutex existed only because unrelated state shared one pointer.
+
+## What landed (4 stacked PRs)
+
+Peripheral-first: push each field's state down into a service that owns it
+(self-synchronized behind its own `sync.RWMutex`), so the shared snapshot +
+publish-mutex shrink to only genuinely co-derived reload state.
+
+- **`logoStore`** — user-uploaded sidebar logo (bytes/ext/hash) + served cache.
+Removed 3 `AppState` fields; 2 `mutateState` callers gone.
+- **`paletteService`** — user palette override + resolved palette. The resolved
+palette derives from `Cfg.Palette`, so the config→palette dependency is made
+explicit as `Reresolve(cfgPalette)`. Removed 2 fields + the last `mutateState`
+writes.
+- **`settingsService`** — per-user default values. Removed the last field; with
+zero callers left, **`mutateState` is deleted**.
+- **`schemaProvider`** — the co-derived core `{Cfg, Meta, StyleMap, StyledTypes,
+OpenAPIGen}`. `AppState`→`Schema`; the `atomic.Pointer` + reload derivation move
+off `App` into the provider. `App.State()` delegates to `schema.Current()` so
+all ~300 `a.State().Meta`/`Cfg` readers stay verbatim.
+
+## Result
+
+`AppState` (8-field grab-bag) → `Schema` (5-field co-derived core with a
+dedicated provider). logo/palette/defaults each own their state behind their own
+mutex. `mutateState` and the publish-side `writeMu` coupling are gone.
+
+## Out of scope
+
+- `writeMu`'s remaining Job-2 uses (entity-write serialization) — a separate
+concern, belongs behind the store.
+- The plimsoll `App` method-line is unchanged: this arc cuts state/fields, not
+methods. The method-count ratchet is the handler-split follow-up
+([[TKT-R68TV8]]).

--- a/tickets/relations/TKT-XSWFXQ--affects--ci-pipeline.md
+++ b/tickets/relations/TKT-XSWFXQ--affects--ci-pipeline.md
@@ -1,0 +1,5 @@
+---
+from: TKT-XSWFXQ
+relation: affects
+to: ci-pipeline
+---

--- a/tickets/relations/TKT-XSWFXQ--depends-on--TKT-N26KLB.md
+++ b/tickets/relations/TKT-XSWFXQ--depends-on--TKT-N26KLB.md
@@ -1,0 +1,5 @@
+---
+from: TKT-XSWFXQ
+relation: depends-on
+to: TKT-N26KLB
+---

--- a/tickets/relations/TKT-XSWFXQ--implements--FEAT-GE1YY.md
+++ b/tickets/relations/TKT-XSWFXQ--implements--FEAT-GE1YY.md
@@ -1,0 +1,5 @@
+---
+from: TKT-XSWFXQ
+relation: implements
+to: FEAT-GE1YY
+---


### PR DESCRIPTION
## Why

`dataentry.App` is the biggest god-object in the tree (170 methods; plimsoll-pinned). A large part of what keeps it tangled is `AppState` — a shared snapshot struct that hoisted per-service mutable state up to `App`, forcing every write of that state through `mutateState` + the App-wide `writeMu`.

This is **PR 1 of a peripheral-first decomposition**: push each field's state down into a service that owns it (self-synchronized), so the shared snapshot + publish-mutex shrink toward only genuinely co-derived reload state.

## What

Extract the user-uploaded sidebar logo (`UserLogoBytes/Ext/Hash`) into a `logoStore` that owns its own in-memory cache behind its own `sync.RWMutex`:

- `Get() (bytes, ext, hash)` / `URL() *string` — lock-free-ish reads (RLock), nil-receiver-safe so narrow test fixtures behave like the old zero-value snapshot.
- `Save(ctx, bytes, ext)` / `Delete(ctx)` — persist to the `.rela/theme/` KV, then advance the cache atomically under the write lock.

Result:
- **3 fields removed from `AppState`** (`UserLogoBytes/Ext/Hash`).
- **2 `mutateState` callers gone** (logo PUT + theme-package import).
- Logo persistence is now testable in isolation and no longer serializes against unrelated state changes on the global `writeMu`.
- `AppState.LogoURL()` → `logoStore.URL()`; `userStateStore.{load,save,delete}UserLogo` → `logoStore` methods.

No behavior change: same wire responses, same on-disk layout, same cache-busting URL.

## Verification

- `go build ./...` (+ `-tags postgres`, `-tags memorybackend`) ✅
- `go test -race ./internal/dataentry/...` ✅
- `just arch-lint` ✅
- `just plimsoll` ✅ (App load line unchanged — this PR reduces `AppState` fields, not `App` methods; method-line ratchets land in the later handler-split PRs)
- `golangci-lint run internal/dataentry/...` → 0 issues

## Next in the arc

paletteService → settingsService (UserDefaults) → openapi/style providers → schema coherence-core (collapses AppState, removes `mutateState` + publish-`writeMu`).