### PR TITLE
chore(lint): enforce full linter set on data-entry packages

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -285,22 +285,6 @@ linters:
           - unparam
         path: internal/mcp/tools_.*\.go
       - linters:
-          - funlen
-          - gocognit
-          - gocyclo
-          - lll
-          - mnd
-          - nestif
-        path: internal/dataentry/.*\.go
-      - linters:
-          - funlen
-          - gocognit
-          - gocyclo
-          - lll
-          - mnd
-          - nestif
-        path: internal/dataentryconfig/.*\.go
-      - linters:
           - gocritic
         text: evalOrder
       - linters:

--- a/internal/dataentry/affordances.go
+++ b/internal/dataentry/affordances.go
@@ -104,7 +104,9 @@ type affordanceService struct {
 	getEntity func(ctx context.Context, id string) (*entityPkg.Entity, bool)
 	// currentEdgesByPeer returns the current edges of entityID for a relation
 	// type/direction, keyed by peer ID. Used to diff desired-vs-current edges.
-	currentEdgesByPeer func(ctx context.Context, entityID, canonical string, incoming bool) map[string]*entityPkg.Relation
+	currentEdgesByPeer func(
+		ctx context.Context, entityID, canonical string, incoming bool,
+	) map[string]*entityPkg.Relation
 }
 
 // perItemVerbs are the verbs computed per entity instance.
@@ -280,7 +282,9 @@ func (d AffordanceDenialError) Error() string {
 // Values are required only for the enum-filter check; pass the
 // requested value for each key in setValues. Unknown values default
 // to allowed (an option entry of `nil` means "no override").
-func (svc affordanceService) validateFieldWrite(ctx context.Context, e *entityPkg.Entity, setKeys map[string]interface{}, unsetKeys []string) *AffordanceDenialError {
+func (svc affordanceService) validateFieldWrite(
+	ctx context.Context, e *entityPkg.Entity, setKeys map[string]interface{}, unsetKeys []string,
+) *AffordanceDenialError {
 	if e == nil {
 		return nil
 	}
@@ -447,7 +451,9 @@ func writeAffordanceDenialError(w http.ResponseWriter, denial AffordanceDenialEr
 // `target` is the entity the gate fired on — used to populate the
 // audit Subject so log readers can attribute the denial. Nil is
 // tolerated (subject left empty); callers always have it in practice.
-func (a *App) denyAffordance(ctx context.Context, w http.ResponseWriter, target *entityPkg.Entity, denial AffordanceDenialError) {
+func (a *App) denyAffordance(
+	ctx context.Context, w http.ResponseWriter, target *entityPkg.Entity, denial AffordanceDenialError,
+) {
 	var subject *audit.Subject
 	if target != nil {
 		subject = &audit.Subject{
@@ -510,7 +516,9 @@ func (svc affordanceService) relationSourceEntity(
 // `relType` is the canonical relation type; `op` selects between
 // create / remove. The verdict is per-relation-type uniform —
 // per-link affordances are predicate territory.
-func (svc affordanceService) validateRelationOp(ctx context.Context, e *entityPkg.Entity, relType string, op RelationOp) *AffordanceDenialError {
+func (svc affordanceService) validateRelationOp(
+	ctx context.Context, e *entityPkg.Entity, relType string, op RelationOp,
+) *AffordanceDenialError {
 	if e == nil {
 		return nil
 	}
@@ -551,6 +559,8 @@ func (svc affordanceService) validateRelationOp(ctx context.Context, e *entityPk
 // Called from the unified PATCH handler before
 // [App.applyRelationsModern]. Returns nil when every relation
 // operation is permitted.
+//
+//nolint:gocognit // walks every relation op against per-op ACL affordances; each branch is an independent verb check, not shared logic to extract.
 func (svc affordanceService) validateRelationsModernAffordances(
 	ctx context.Context, entityID string, e *entityPkg.Entity,
 	desired map[string]v1.RelationsUpdate,
@@ -588,7 +598,8 @@ func (svc affordanceService) validateRelationsModernAffordances(
 			source := svc.relationSourceEntity(ctx, e, ref.ID, direction)
 			if _, exists := current[ref.ID]; exists {
 				// Upsert path: not a create, but the meta may change.
-				if denial := svc.validateRelationMetaWrite(ctx, source, canonical, ref.Meta, ref.MetaUnset); denial != nil {
+				denial := svc.validateRelationMetaWrite(ctx, source, canonical, ref.Meta, ref.MetaUnset)
+				if denial != nil {
 					return denial
 				}
 				continue
@@ -625,7 +636,9 @@ func (svc affordanceService) validateRelationsModernAffordances(
 // rejected here — they're a separate concern handled by the existing
 // relation validation. The affordance check focuses on rejecting
 // keys explicitly marked non-writable.
-func (svc affordanceService) validateRelationMetaWrite(ctx context.Context, e *entityPkg.Entity, relType string, meta map[string]interface{}, metaUnset []string) *AffordanceDenialError {
+func (svc affordanceService) validateRelationMetaWrite(
+	ctx context.Context, e *entityPkg.Entity, relType string, meta map[string]interface{}, metaUnset []string,
+) *AffordanceDenialError {
 	if e == nil {
 		return nil
 	}
@@ -667,7 +680,9 @@ func (svc affordanceService) validateRelationMetaWrite(ctx context.Context, e *e
 // Empty input verdicts yield an empty (non-nil) map so the wire shape
 // is consistent: `_fields: {}` under the nop resolver, sparse entries
 // under any other.
-func (svc affordanceService) computeFieldAffordances(ctx context.Context, e *entityPkg.Entity) map[string]v1.FieldAffordance {
+func (svc affordanceService) computeFieldAffordances(
+	ctx context.Context, e *entityPkg.Entity,
+) map[string]v1.FieldAffordance {
 	return computeFieldAffordancesFrom(svc.resolver().FieldVerdicts(ctx, e))
 }
 
@@ -784,7 +799,9 @@ func (svc affordanceService) hiddenProperties(ctx context.Context, e *entityPkg.
 // (creatable=false, removable=false, or any meta-field writable=false)
 // appear in the map. Default-permissive types are absent — the SPA's
 // "no entry = default" path handles them.
-func (svc affordanceService) computeRelationAffordances(ctx context.Context, e *entityPkg.Entity) map[string]v1.RelationAffordance {
+func (svc affordanceService) computeRelationAffordances(
+	ctx context.Context, e *entityPkg.Entity,
+) map[string]v1.RelationAffordance {
 	v := svc.resolver().RelationVerdicts(ctx, e)
 	out := make(map[string]v1.RelationAffordance)
 	for relType, rv := range v.Types {
@@ -909,7 +926,9 @@ func (svc affordanceService) attachEntityAffordances(ctx context.Context, e *ent
 // The value per property is a LIST: a property may hold several files, and
 // even a single file is reported as a 1-element list (always-array wire
 // shape).
-func (svc affordanceService) computeAttachments(ctx context.Context, e *entityPkg.Entity, selfHref string, verdicts FieldVerdicts) map[string][]v1.Attachment {
+func (svc affordanceService) computeAttachments(
+	ctx context.Context, e *entityPkg.Entity, selfHref string, verdicts FieldVerdicts,
+) map[string][]v1.Attachment {
 	out := make(map[string][]v1.Attachment)
 	if selfHref == "" {
 		return out

--- a/internal/dataentry/analyze.go
+++ b/internal/dataentry/analyze.go
@@ -274,6 +274,8 @@ func (svc analyzeService) analyzeGaps(ctx context.Context, meta *metamodel.Metam
 }
 
 // analyzeCardinality checks relation cardinality constraints.
+//
+//nolint:gocognit,funlen // cardinality analysis enumerates min/max bounds across every relation def and direction; the branches are the distinct violation cases, not extractable shared logic.
 func (svc analyzeService) analyzeCardinality(ctx context.Context, meta *metamodel.Metamodel) AnalysisSection {
 	section := AnalysisSection{
 		Name:        "Cardinality",

--- a/internal/dataentry/api_v1.go
+++ b/internal/dataentry/api_v1.go
@@ -104,6 +104,15 @@ func (a *App) registerAPIV1Routes(mux *http.ServeMux) {
 	mux.HandleFunc("/api/v1/", a.handleV1DynamicRoutes)
 }
 
+// Path-segment counts for the dynamic route dispatcher below. A
+// four-segment path selects a sub-resource collection
+// (relations/_actions/_attachments); a five-segment path targets a
+// single member within one of those.
+const (
+	segmentsSubResource   = 4 // /{plural}/{id}/{sub}/{key}
+	segmentsSubResourceID = 5 // /{plural}/{id}/{sub}/{key}/{member}
+)
+
 // handleV1DynamicRoutes routes requests to the appropriate entity handler
 // based on URL. Read operations work against the snapshot returned by
 // a.State() with no locking; write operations take a.writeMu for the
@@ -153,7 +162,7 @@ func (a *App) handleV1DynamicRoutes(w http.ResponseWriter, r *http.Request) {
 		} else {
 			writeV1Error(w, r, http.StatusNotFound, "not_found", "Resource not found", "")
 		}
-	case 4:
+	case segmentsSubResource:
 		// /{plural}/{id}/relations/{relType}, /{plural}/{id}/_actions/{action},
 		// or /{plural}/{id}/_attachments/{property}
 		switch parts[2] {
@@ -166,7 +175,7 @@ func (a *App) handleV1DynamicRoutes(w http.ResponseWriter, r *http.Request) {
 		default:
 			writeV1Error(w, r, http.StatusNotFound, "not_found", "Resource not found", "")
 		}
-	case 5:
+	case segmentsSubResourceID:
 		// /{plural}/{id}/relations/{relType}/{targetId} or
 		// /{plural}/{id}/_attachments/{property}/{fileName}
 		switch parts[2] {
@@ -241,7 +250,11 @@ var errListLoad = errors.New("list load failed")
 // search_failed at the call site); ACL query failures are wrapped in
 // errACLListQuery so call sites map them via writeGateError. Everything
 // else degrades to an empty/whole set as the list endpoint always did.
-func (a *App) scopedSortedEntities(ctx context.Context, typeName string, query map[string][]string) ([]*entityPkg.Entity, error) {
+func (a *App) scopedSortedEntities(
+	ctx context.Context,
+	typeName string,
+	query map[string][]string,
+) ([]*entityPkg.Entity, error) {
 	rqr := readGateFromContext(ctx).ReadQuery(ctx, typeName)
 
 	var entities []*entityPkg.Entity
@@ -326,7 +339,11 @@ func (a *App) scopedSortedEntities(ctx context.Context, typeName string, query m
 // A free function (not an App method) taking the already-loaded meta/cfg
 // snapshot: it needs no other App state, and keeping it off the receiver keeps
 // App under its plimsoll method cap.
-func relationFilterClassifier(meta *metamodel.Metamodel, cfg *dataentryconfig.Config, typeName string) func(string) bool {
+func relationFilterClassifier(
+	meta *metamodel.Metamodel,
+	cfg *dataentryconfig.Config,
+	typeName string,
+) func(string) bool {
 	return func(key string) bool {
 		// Explicit property control → property pass.
 		if cfg.HasPropertyFilterControl(typeName, key) {
@@ -722,7 +739,8 @@ func (a *App) handleV1CreateEntity(w http.ResponseWriter, r *http.Request, typeN
 		}
 	}
 
-	result := a.serializer.forWire(r.Context(), created, a.reader.outgoingRelations(r.Context(), created.ID), a.Meta(), plural)
+	rels := a.reader.outgoingRelations(r.Context(), created.ID)
+	result := a.serializer.forWire(r.Context(), created, rels, a.Meta(), plural)
 	if len(relWarnings) > 0 {
 		result.Warnings = append(result.Warnings, relWarnings...)
 	}
@@ -994,6 +1012,7 @@ func writeGateError(w http.ResponseWriter, r *http.Request, err error) {
 		"ACL read-permission check failed", "check server logs")
 }
 
+//nolint:gocognit,funlen // update handler threads the validation-policy classes (400/422/200-with-warnings) through each field; the branches are the documented write-policy cases, not extractable shared logic.
 func (a *App) handleV1UpdateEntity(w http.ResponseWriter, r *http.Request, typeName, plural, entityID string) {
 	// Need write lock
 	a.writeMu.Lock()
@@ -1060,12 +1079,16 @@ func (a *App) handleV1UpdateEntity(w http.ResponseWriter, r *http.Request, typeN
 	// what the resolver would have surfaced on GET. Runs before any
 	// other validation so the failure mode is identical regardless of
 	// what else the PATCH body would have triggered.
-	if denial := a.affordances.validateFieldWrite(r.Context(), entity, req.Properties, req.PropertiesUnset); denial != nil {
+	if denial := a.affordances.validateFieldWrite(
+		r.Context(), entity, req.Properties, req.PropertiesUnset,
+	); denial != nil {
 		a.denyAffordance(r.Context(), w, entity, *denial)
 		return
 	}
 	if req.Relations.Modern != nil {
-		if denial := a.affordances.validateRelationsModernAffordances(r.Context(), entityID, entity, req.Relations.Modern); denial != nil {
+		if denial := a.affordances.validateRelationsModernAffordances(
+			r.Context(), entityID, entity, req.Relations.Modern,
+		); denial != nil {
 			a.denyAffordance(r.Context(), w, entity, *denial)
 			return
 		}
@@ -1145,7 +1168,8 @@ func (a *App) handleV1UpdateEntity(w http.ResponseWriter, r *http.Request, typeN
 		}
 	}
 
-	result := a.serializer.forWire(r.Context(), entity, a.reader.outgoingRelations(r.Context(), entity.ID), a.Meta(), plural)
+	rels := a.reader.outgoingRelations(r.Context(), entity.ID)
+	result := a.serializer.forWire(r.Context(), entity, rels, a.Meta(), plural)
 	if len(warnings) > 0 {
 		result.Warnings = warnings
 	}
@@ -1459,7 +1483,9 @@ func (a *App) handleV1CreateRelation(w http.ResponseWriter, r *http.Request, typ
 
 	from, to := resolveRelationEndpoints(entity.ID, req.ID, req.Direction)
 
-	_, err := a.entityManager.CreateRelation(r.Context(), from, relType, to, entityPkg.RelationOptions{Properties: req.Meta})
+	_, err := a.entityManager.CreateRelation(
+		r.Context(), from, relType, to, entityPkg.RelationOptions{Properties: req.Meta},
+	)
 	if err != nil {
 		if writeForbiddenIfACLDenied(w, err) {
 			return
@@ -1471,7 +1497,9 @@ func (a *App) handleV1CreateRelation(w http.ResponseWriter, r *http.Request, typ
 	w.WriteHeader(http.StatusCreated)
 }
 
-func (a *App) handleV1RelationTarget(w http.ResponseWriter, r *http.Request, typeName, entityID, relType, targetID string) {
+func (a *App) handleV1RelationTarget(
+	w http.ResponseWriter, r *http.Request, typeName, entityID, relType, targetID string,
+) {
 	switch r.Method {
 	case http.MethodPatch:
 		a.handleV1UpdateRelation(w, r, typeName, entityID, relType, targetID)
@@ -1482,7 +1510,9 @@ func (a *App) handleV1RelationTarget(w http.ResponseWriter, r *http.Request, typ
 	}
 }
 
-func (a *App) handleV1UpdateRelation(w http.ResponseWriter, r *http.Request, typeName, entityID, relType, targetID string) {
+func (a *App) handleV1UpdateRelation(
+	w http.ResponseWriter, r *http.Request, typeName, entityID, relType, targetID string,
+) {
 	// Need write lock
 	a.writeMu.Lock()
 	defer a.writeMu.Unlock()
@@ -1563,7 +1593,9 @@ func (a *App) handleV1UpdateRelation(w http.ResponseWriter, r *http.Request, typ
 	writeV1JSON(w, http.StatusOK, result)
 }
 
-func (a *App) handleV1DeleteRelation(w http.ResponseWriter, r *http.Request, typeName, entityID, relType, targetID string) {
+func (a *App) handleV1DeleteRelation(
+	w http.ResponseWriter, r *http.Request, typeName, entityID, relType, targetID string,
+) {
 	// Need write lock
 	a.writeMu.Lock()
 	defer a.writeMu.Unlock()
@@ -2013,6 +2045,7 @@ func (a *App) visibleAnalysisIssues(ctx context.Context, sections []AnalysisSect
 
 // --- Helper Functions ---
 
+//nolint:gocognit // resolves the include set (all vs. named relations) then fetches each target; the nesting is the include-expansion algorithm, not shared logic to extract.
 func (a *App) resolveV1Includes(ctx context.Context, entity *entityPkg.Entity, includes string) map[string]v1.Entity {
 	s := a.State()
 	included := make(map[string]v1.Entity)
@@ -2030,7 +2063,7 @@ func (a *App) resolveV1Includes(ctx context.Context, entity *entityPkg.Entity, i
 	// filter so hidden neighbors don't trigger hidden nested probes.
 	nestedFor := make(map[string]string)
 
-	if includes == "*" {
+	if includes == "*" { //nolint:nestif // include-all vs. named-include expansion is inherently nested; flattening would obscure the two-mode logic.
 		for _, edge := range a.reader.outgoingRelations(ctx, entity.ID) {
 			if target, found := a.reader.getEntity(ctx, edge.To); found {
 				candidates = append(candidates, target)
@@ -2103,6 +2136,8 @@ func (a *App) filterVisibleIncludes(ctx context.Context, candidates []*entityPkg
 // traversal). A relation key would otherwise match no property and nuke the
 // whole result set (TKT-5U7QBR). A nil predicate treats every key as a
 // property filter (the pre-TKT-5U7QBR behavior).
+//
+//nolint:gocognit,funlen // dispatches over every supported filter operator and value type; each branch is one operator's semantics, not extractable shared logic.
 func applyV1Filters(
 	entities []*entityPkg.Entity, query map[string][]string, _ string, isRelationKey func(string) bool,
 ) []*entityPkg.Entity {
@@ -2674,7 +2709,9 @@ func (c *sidebarCounts) kanbanCount(ctx context.Context, kanbanID string, kanban
 // filterCache keys on list/kanban id, not (type, filters); a
 // (type, filters)-keyed memo is the obvious upgrade if sidebar
 // latency ever warrants it.
-func (c *sidebarCounts) countWithFilters(ctx context.Context, entityType string, filters []dataentryconfig.FilterConfig) int {
+func (c *sidebarCounts) countWithFilters(
+	ctx context.Context, entityType string, filters []dataentryconfig.FilterConfig,
+) int {
 	rqr := readGateFromContext(ctx).ReadQuery(ctx, entityType)
 	if rqr.DenyAll {
 		return 0
@@ -2707,7 +2744,9 @@ func (c *sidebarCounts) countWithFilters(ctx context.Context, entityType string,
 }
 
 // navEntryToSidebarItem converts a navigation entry to a sidebar item with count.
-func (a *App) navEntryToSidebarItem(ctx context.Context, entry dataentryconfig.NavigationEntry, counts sidebarCounts) v1.SidebarItem {
+func (a *App) navEntryToSidebarItem(
+	ctx context.Context, entry dataentryconfig.NavigationEntry, counts sidebarCounts,
+) v1.SidebarItem {
 	s := a.State()
 	item := v1.SidebarItem{
 		Label: entry.Label,
@@ -2961,7 +3000,9 @@ func conflictAuditSubject(e *entityPkg.Entity, rel *entityPkg.Relation) *audit.S
 // fallback the manager uses). A deny records a `denied-write` audit
 // row and writes the standard 403 body; returns true when the write
 // may proceed.
-func (a *App) authorizeConflictResolve(ctx context.Context, w http.ResponseWriter, e *entityPkg.Entity, rel *entityPkg.Relation) bool {
+func (a *App) authorizeConflictResolve(
+	ctx context.Context, w http.ResponseWriter, e *entityPkg.Entity, rel *entityPkg.Relation,
+) bool {
 	var aclReq acl.WriteRequest
 	if rel != nil {
 		var fromType string
@@ -2992,7 +3033,9 @@ func (a *App) authorizeConflictResolve(ctx context.Context, w http.ResponseWrite
 // recordConflictResolveAudit emits the audit row for a successful
 // conflict resolution — the direct-file-write counterpart of the
 // records entitymanager emits for manager-routed writes.
-func (a *App) recordConflictResolveAudit(ctx context.Context, relPath string, e *entityPkg.Entity, rel *entityPkg.Relation) {
+func (a *App) recordConflictResolveAudit(
+	ctx context.Context, relPath string, e *entityPkg.Entity, rel *entityPkg.Relation,
+) {
 	op := audit.OpUpdateEntity
 	if rel != nil {
 		op = audit.OpUpdateRelation
@@ -3260,6 +3303,8 @@ func sectionEntityToV1(e SectionEntityData) v1.ViewEntity {
 // is registered for entityType, a default is synthesized from the
 // metamodel (see buildDefaultViewConfig) and executed through the same
 // pipeline so the response shape is identical.
+//
+//nolint:gocognit,funlen // routes the views sub-API over method and path shape; each branch is a distinct view endpoint, not shared logic to factor out.
 func (a *App) handleV1Views(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
 		writeV1Error(w, r, http.StatusMethodNotAllowed, "method_not_allowed", "Method not allowed", "")
@@ -3316,8 +3361,9 @@ func (a *App) handleV1Views(w http.ResponseWriter, r *http.Request) {
 	entityDef := s.Meta.Entities[result.Entry.Type]
 	plural := entityDef.GetPlural(result.Entry.Type)
 
+	entryRels := a.reader.outgoingRelations(r.Context(), result.Entry.ID)
 	resp := v1.ViewResponse{
-		Entry:    a.serializer.forWire(r.Context(), result.Entry, a.reader.outgoingRelations(r.Context(), result.Entry.ID), a.Meta(), plural),
+		Entry:    a.serializer.forWire(r.Context(), result.Entry, entryRels, a.Meta(), plural),
 		Sections: make([]v1.ViewSection, 0, len(sections)),
 	}
 

--- a/internal/dataentry/app.go
+++ b/internal/dataentry/app.go
@@ -349,6 +349,8 @@ func (a *App) SetPrincipalHeader(name string) {
 // relation edits) is feature-detected on `st` inside
 // [App.StartWatching] via the [storeWatcher] interface; callers do
 // not wire it.
+//
+//nolint:gocognit,funlen // composition root: validates and wires many optional collaborators, each guarded independently; the branches are wiring steps, not shared logic to extract.
 func NewApp(
 	fs storage.FS,
 	paths *project.Context,
@@ -830,7 +832,9 @@ var colorToCSSClass = map[string]string{
 // autoColors assigns colors to enum values that have no explicit style.
 var autoColors = []string{"blue", "purple", "green", "orange", "yellow", "red", "gray"}
 
-func buildStyleMap(cfg *Config, meta *metamodel.Metamodel) (styleMap map[string]map[string]string, styledTypes map[string]bool) {
+func buildStyleMap(
+	cfg *Config, meta *metamodel.Metamodel,
+) (styleMap map[string]map[string]string, styledTypes map[string]bool) {
 	sm := make(map[string]map[string]string)
 	st := make(map[string]bool)
 

--- a/internal/dataentry/apps_sdk.go
+++ b/internal/dataentry/apps_sdk.go
@@ -62,7 +62,11 @@ func appSDKSource() string {
     if (!p) return;
     delete pending[res.id];
     if (res.ok) { p.resolve(res.result); }
-    else { var e = new Error(res.error ? res.error.message : 'request failed'); e.code = res.error ? res.error.code : 'error'; p.reject(e); }
+    else {
+      var e = new Error(res.error ? res.error.message : 'request failed');
+      e.code = res.error ? res.error.code : 'error';
+      p.reject(e);
+    }
   }
   // Accept the port only from our parent (the host), one time, first wins —
   // so a nested frame the app creates cannot race the handshake and MITM us.

--- a/internal/dataentry/commands.go
+++ b/internal/dataentry/commands.go
@@ -281,6 +281,8 @@ var (
 // Restricted to POST: this endpoint runs configured shell commands and a GET
 // would let `<img src=/api/command/X>` invoke them cross-origin from any
 // browser tab, bypassing same-origin policy entirely.
+//
+//nolint:funlen // dispatches over every command context and argument shape inline; each branch is one command variant, and extracting them would fragment the request lifecycle.
 func (a *App) handleCommandExec(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
 		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)

--- a/internal/dataentry/document.go
+++ b/internal/dataentry/document.go
@@ -162,7 +162,9 @@ func (s *documentService) GetCached(ctx context.Context, entryID string) *Docume
 // (entryID, ConfigID) pair — renders of the same entry under *different*
 // document configs proceed in parallel. Command renders cache to disk;
 // script renders do not.
-func (s *documentService) Render(ctx context.Context, entryID string, cfg documentRenderConfig) (*DocumentResult, error) {
+func (s *documentService) Render(
+	ctx context.Context, entryID string, cfg documentRenderConfig,
+) (*DocumentResult, error) {
 	entities, contentHash, err := s.computeDocumentHash(ctx, entryID)
 	if err != nil {
 		return nil, fmt.Errorf("computing document hash: %w", err)
@@ -189,7 +191,8 @@ func (s *documentService) Render(ctx context.Context, entryID string, cfg docume
 // Command — these are mutually exclusive at config load (see
 // dataentryconfig.validateDocuments) so exactly one branch fires.
 func (s *documentService) doRender(
-	ctx context.Context, entryID string, cfg documentRenderConfig, entities []*entity.Entity, contentHash, cacheFile string,
+	ctx context.Context, entryID string, cfg documentRenderConfig,
+	entities []*entity.Entity, contentHash, cacheFile string,
 ) (*DocumentResult, error) {
 	var markdown string
 	var err error
@@ -520,6 +523,9 @@ func parseAttrs(s string) []parsedAttr {
 			continue
 		}
 		a := parsedAttr{name: name, raw: s[m[0]:m[1]]}
+		// Capture-group index (within attrRegex) for the unquoted value
+		// alternative — the fourth value-bearing group.
+		const unquotedValueGroup = 4
 		// Group indices in m[]: 2*k = start, 2*k+1 = end. A missing
 		// group has start == -1. A present-but-empty group (e.g. `""`)
 		// has start == end and both >= 0 — distinguish these from
@@ -532,7 +538,7 @@ func parseAttrs(s string) []parsedAttr {
 			a.value = get(3)
 			a.quoted = true
 		case m[8] >= 0: // unquoted, never empty by regex definition
-			a.value = get(4)
+			a.value = get(unquotedValueGroup)
 			a.quoted = true
 		default:
 			// boolean attribute (no = sign) — value stays "",

--- a/internal/dataentry/entityserializer.go
+++ b/internal/dataentry/entityserializer.go
@@ -41,7 +41,10 @@ type entitySerializer struct {
 // serialize their own already-gated edges keep byte-identical output. The set
 // is computed once per page by visibleRelationIDs (batched by type); this
 // transform only consults it.
-func (s entitySerializer) toV1(ctx context.Context, e *entityPkg.Entity, outgoing, incoming []*entityPkg.Relation, visibleNeighbors map[string]bool, meta *metamodel.Metamodel, plural string) v1.Entity {
+func (s entitySerializer) toV1(
+	ctx context.Context, e *entityPkg.Entity, outgoing, incoming []*entityPkg.Relation,
+	visibleNeighbors map[string]bool, meta *metamodel.Metamodel, plural string,
+) v1.Entity {
 	out := v1.Entity{
 		ID:         e.ID,
 		Type:       e.Type,
@@ -104,7 +107,10 @@ func (s entitySerializer) toV1(ctx context.Context, e *entityPkg.Entity, outgoin
 // v1.Entity should use: toV1 + strip hidden properties + attach the affordance
 // maps. Use forWireRelated for entities that appear as list rows or under
 // `included` (no affordance maps, but still strip).
-func (s entitySerializer) forWire(ctx context.Context, e *entityPkg.Entity, outgoing []*entityPkg.Relation, meta *metamodel.Metamodel, plural string) v1.Entity {
+func (s entitySerializer) forWire(
+	ctx context.Context, e *entityPkg.Entity, outgoing []*entityPkg.Relation,
+	meta *metamodel.Metamodel, plural string,
+) v1.Entity {
 	// Per-entity responses carry outgoing edges only; incoming edges reach the
 	// SPA via the dedicated /relations endpoint, not the top-level relations
 	// map. Incoming list columns are served by forWireRelated (list rows).
@@ -129,7 +135,10 @@ func (s entitySerializer) forWire(ctx context.Context, e *entityPkg.Entity, outg
 // threads it here. Pass nil to disable filtering when the caller already
 // serializes only gated edges (e.g. the search/include shapes pass nil
 // relations anyway).
-func (s entitySerializer) forWireRelated(ctx context.Context, e *entityPkg.Entity, outgoing, incoming []*entityPkg.Relation, visibleNeighbors map[string]bool, meta *metamodel.Metamodel, plural string) v1.Entity {
+func (s entitySerializer) forWireRelated(
+	ctx context.Context, e *entityPkg.Entity, outgoing, incoming []*entityPkg.Relation,
+	visibleNeighbors map[string]bool, meta *metamodel.Metamodel, plural string,
+) v1.Entity {
 	result := s.toV1(ctx, e, outgoing, incoming, visibleNeighbors, meta, plural)
 	s.affordances.stripHiddenProperties(ctx, e, &result)
 	return result

--- a/internal/dataentry/feed_handler.go
+++ b/internal/dataentry/feed_handler.go
@@ -49,9 +49,10 @@ func (a *App) handleV1Feed(w http.ResponseWriter, r *http.Request) {
 	// come from the request (matching however the client reached us — loopback,
 	// LAN, or a proxied hostname), mirroring appBaseURL.
 	base := feedBaseURL(r)
-	provider, err := newDeclarativeFeed(name, cfg, s.Meta, feedEntitySource{app: a}, func(entityType, id string) string {
+	link := func(entityType, id string) string {
 		return base + "/entity/" + entityType + "/" + id
-	})
+	}
+	provider, err := newDeclarativeFeed(name, cfg, s.Meta, feedEntitySource{app: a}, link)
 	if err != nil {
 		writeV1Error(w, r, http.StatusInternalServerError, "feed_error", "Feed misconfigured", "")
 		return

--- a/internal/dataentry/feed_provider.go
+++ b/internal/dataentry/feed_provider.go
@@ -68,7 +68,9 @@ type declarativeFeed struct {
 // newDeclarativeFeed builds a provider for one configured feed. It pre-parses
 // each source's filter clauses so a malformed clause is caught before any
 // entity is read (config validation catches this earlier still).
-func newDeclarativeFeed(feedID string, cfg dataentryconfig.Feed, meta *metamodel.Metamodel, src entitySource, link deepLinker) (*declarativeFeed, error) {
+func newDeclarativeFeed(
+	feedID string, cfg dataentryconfig.Feed, meta *metamodel.Metamodel, src entitySource, link deepLinker,
+) (*declarativeFeed, error) {
 	// Validate sources reference known types up front so List/Get can assume it.
 	for i, s := range cfg.Sources {
 		if _, ok := meta.GetEntityDef(s.EntityType); !ok {
@@ -189,7 +191,9 @@ func (d *declarativeFeed) Get(ctx context.Context, uid string) (calfeed.Event, b
 // a date value, maps its properties to a calendar event. ok=false means the
 // entity is filtered out or has no usable date (it is silently skipped, not an
 // error — a task with no due date is simply not on the calendar).
-func (d *declarativeFeed) mapEntity(e *entity.Entity, s dataentryconfig.FeedSource, entDef *metamodel.EntityDef, filters []*filter.Filter) (calfeed.Event, bool, error) {
+func (d *declarativeFeed) mapEntity(
+	e *entity.Entity, s dataentryconfig.FeedSource, entDef *metamodel.EntityDef, filters []*filter.Filter,
+) (calfeed.Event, bool, error) {
 	matched, err := filter.MatchAll(entityRecord(e), filters, entDef, d.meta)
 	if err != nil {
 		return calfeed.Event{}, false, err

--- a/internal/dataentry/handlers.go
+++ b/internal/dataentry/handlers.go
@@ -76,7 +76,10 @@ func (a *App) handleEntityHelp(w http.ResponseWriter, r *http.Request) {
 }
 
 // renderHelpContent generates HTML for entity help content.
-func (a *App) renderHelpContent(w http.ResponseWriter, entityDesc htmltemplate.HTML, props []PropertyHelp, outgoingRels, incomingRels []RelationHelp) {
+func (a *App) renderHelpContent(
+	w http.ResponseWriter, entityDesc htmltemplate.HTML, props []PropertyHelp,
+	outgoingRels, incomingRels []RelationHelp,
+) {
 	fmt.Fprint(w, `<div class="help-content">`)
 	if entityDesc != "" {
 		fmt.Fprintf(w, `<div class="entity-description">%s</div>`, entityDesc)

--- a/internal/dataentry/handlers_attachment.go
+++ b/internal/dataentry/handlers_attachment.go
@@ -39,7 +39,9 @@ const maxAttachmentUploadHeadroom = 16 * 1024
 // (the entity's `_attachments` map already lists the files; downloads use
 // the per-file route below). Writes inherit the entity's `update`
 // permission.
-func (a *App) handleV1AttachmentRoute(w http.ResponseWriter, r *http.Request, typeName, plural, entityID, property string) {
+func (a *App) handleV1AttachmentRoute(
+	w http.ResponseWriter, r *http.Request, typeName, plural, entityID, property string,
+) {
 	switch r.Method {
 	case http.MethodPut, http.MethodPost:
 		a.handleV1PutAttachment(w, r, typeName, plural, entityID, property)
@@ -52,7 +54,9 @@ func (a *App) handleV1AttachmentRoute(w http.ResponseWriter, r *http.Request, ty
 // /api/v1/{plural}/{id}/_attachments/{property}/{fileName}: GET downloads
 // that file's bytes, DELETE detaches it. Reads inherit the entity's read
 // permission, deletes inherit `update`.
-func (a *App) handleV1AttachmentFileRoute(w http.ResponseWriter, r *http.Request, typeName, entityID, property, fileName string) {
+func (a *App) handleV1AttachmentFileRoute(
+	w http.ResponseWriter, r *http.Request, typeName, entityID, property, fileName string,
+) {
 	switch r.Method {
 	case http.MethodGet:
 		a.handleV1GetAttachment(w, r, typeName, entityID, property, fileName)
@@ -80,7 +84,9 @@ func (a *App) handleV1AttachmentFileRoute(w http.ResponseWriter, r *http.Request
 // there is no caller-supplied-path traversal surface. The fileName comes
 // from the URL but is only ever a store key (never a filesystem path the
 // handler builds), and the store's ValidateFileName rejects separators.
-func (a *App) handleV1GetAttachment(w http.ResponseWriter, r *http.Request, typeName, entityID, property, fileName string) {
+func (a *App) handleV1GetAttachment(
+	w http.ResponseWriter, r *http.Request, typeName, entityID, property, fileName string,
+) {
 	ctx := r.Context()
 
 	// ACL gate first — before any store access (see handleV1GetEntity).
@@ -146,7 +152,9 @@ func (a *App) handleV1GetAttachment(w http.ResponseWriter, r *http.Request, type
 // inherits the entity's `update` permission. The write is authorized
 // up front (before any bytes are written) to avoid orphaning a file on a
 // late deny — see attachment.Service.Attach's orphan note.
-func (a *App) handleV1PutAttachment(w http.ResponseWriter, r *http.Request, typeName, plural, entityID, property string) {
+func (a *App) handleV1PutAttachment(
+	w http.ResponseWriter, r *http.Request, typeName, plural, entityID, property string,
+) {
 	a.writeMu.Lock()
 	defer a.writeMu.Unlock()
 	ctx := r.Context()
@@ -321,7 +329,9 @@ func filePropertyDef(s *AppState, typeName, property string) metamodel.PropertyD
 // removed, then the property is re-stamped from the store's remaining
 // files and persisted. Idempotent: deleting a missing file still
 // re-stamps and returns 204.
-func (a *App) handleV1DeleteAttachment(w http.ResponseWriter, r *http.Request, typeName, entityID, property, fileName string) {
+func (a *App) handleV1DeleteAttachment(
+	w http.ResponseWriter, r *http.Request, typeName, entityID, property, fileName string,
+) {
 	a.writeMu.Lock()
 	defer a.writeMu.Unlock()
 	ctx := r.Context()
@@ -358,7 +368,9 @@ func (a *App) handleV1DeleteAttachment(w http.ResponseWriter, r *http.Request, t
 // is a declared `file` type, reject a locked (inaccessible) entity, and
 // authorize the `update` write UP FRONT so a deny never reaches the store.
 // Returns the loaded entity and true when the write may proceed.
-func (a *App) attachmentWritePreflight(w http.ResponseWriter, r *http.Request, typeName, entityID, property string) (*entityPkg.Entity, bool) {
+func (a *App) attachmentWritePreflight(
+	w http.ResponseWriter, r *http.Request, typeName, entityID, property string,
+) (*entityPkg.Entity, bool) {
 	ctx := r.Context()
 
 	// Read-gate first: a hidden or nonexistent id yields a uniform 404

--- a/internal/dataentry/handlers_theme_package.go
+++ b/internal/dataentry/handlers_theme_package.go
@@ -189,13 +189,14 @@ var unsafeFilenameRe = regexp.MustCompile(`[^A-Za-z0-9_-]+`)
 // manifest's Name. Browsers will let users override it via "Save as..."
 // so this is purely cosmetic.
 func safeThemeFilename(name string) string {
+	const maxThemeFilenameLen = 64
 	cleaned := unsafeFilenameRe.ReplaceAllString(name, "_")
 	cleaned = strings.Trim(cleaned, "_")
 	if cleaned == "" {
 		return "theme"
 	}
-	if len(cleaned) > 64 {
-		cleaned = cleaned[:64]
+	if len(cleaned) > maxThemeFilenameLen {
+		cleaned = cleaned[:maxThemeFilenameLen]
 	}
 	return cleaned
 }

--- a/internal/dataentry/helpers.go
+++ b/internal/dataentry/helpers.go
@@ -200,6 +200,8 @@ func propertyIsEmpty(prop interface{}) bool {
 }
 
 // applyFilters filters entities by a set of filter conditions.
+//
+//nolint:gocognit // applies each filter operator against each entity property; the branches are per-operator match semantics, not shared logic to extract.
 func applyFilters(entities []*entity.Entity, filters []FilterConfig) []*entity.Entity {
 	if len(filters) == 0 {
 		return entities
@@ -662,7 +664,9 @@ const maxFreeTextSearchResults = 1000
 // searcher's text layer can rebuild the same fuzzy-words + exact-phrases
 // compound query the dataentry UI used to build upstream. Backend failures
 // surface to the caller.
-func runFreeTextSearchE(ctx context.Context, svc Services, sq *searchparser.SearchQuery, limit int) ([]*entity.Entity, error) {
+func runFreeTextSearchE(
+	ctx context.Context, svc Services, sq *searchparser.SearchQuery, limit int,
+) ([]*entity.Entity, error) {
 	parts := make([]string, 0, len(sq.FreeTextWords)+len(sq.FreeTextPhrases))
 	parts = append(parts, sq.FreeTextWords...)
 	for _, p := range sq.FreeTextPhrases {

--- a/internal/dataentry/mentions.go
+++ b/internal/dataentry/mentions.go
@@ -29,7 +29,9 @@ import (
 // unknown-ID UX. Context cancellation is honored — callers (HTTP handlers)
 // have already bound the request context and abandoning further lookups
 // after the client disconnects saves wasted work.
-func collectMentions(ctx context.Context, s store.EntityReader, meta *metamodel.Metamodel, contents ...string) map[string]v1.Mention {
+func collectMentions(
+	ctx context.Context, s store.EntityReader, meta *metamodel.Metamodel, contents ...string,
+) map[string]v1.Mention {
 	candidates := scanCodeSpanCandidates(contents...)
 	if len(candidates) == 0 {
 		return nil

--- a/internal/dataentry/middleware_security.go
+++ b/internal/dataentry/middleware_security.go
@@ -176,15 +176,18 @@ func (s *security) requireSameOrigin(next http.Handler) http.Handler {
 // Origin/Referer/Host with embedded newlines cannot inject fake log lines
 // into structured log destinations.
 func (s *security) reject(w http.ResponseWriter, r *http.Request, reason string) {
+	// Cap each attacker-controlled log field so a huge header can't bloat the
+	// log line.
+	const maxLogFieldLen = 200
 	origin := r.Header.Get("Origin")
 	if origin == "" {
 		origin = r.Header.Get("Referer")
 	}
 	slog.Warn("security blocked request",
 		"rule", reason,
-		"host", strconv.Quote(truncate(r.Host, 200)),
-		"origin", strconv.Quote(truncate(origin, 200)),
-		"path", strconv.Quote(truncate(r.URL.Path, 200)),
+		"host", strconv.Quote(truncate(r.Host, maxLogFieldLen)),
+		"origin", strconv.Quote(truncate(origin, maxLogFieldLen)),
+		"path", strconv.Quote(truncate(r.URL.Path, maxLogFieldLen)),
 	)
 
 	w.Header().Set("Content-Type", "application/json")

--- a/internal/dataentry/relations_modern.go
+++ b/internal/dataentry/relations_modern.go
@@ -257,6 +257,8 @@ func (a *App) collectEdgeWarnings(
 // that prevented further writes. On a write-loop error, the relations
 // already written stay written — the caller treats this as the
 // documented atomicity gap.
+//
+//nolint:gocognit // diffs desired vs. existing relation sets and issues add/remove ops per peer; the branches are the set-reconciliation cases, not shared logic to extract.
 func (a *App) applyRelationsModern(
 	ctx context.Context, entityID string, desired map[string]v1.RelationsUpdate,
 ) ([]Warning, error) {
@@ -530,7 +532,9 @@ func requiredMetaWarnings(
 // order properties (_order_out / _order_in) are finite numeric. Non-finite
 // or non-numeric values are wire-format violations (400) — the engine's
 // midpoint and sort logic depends on finite float64 values.
-func validateManagedOrderMeta(relType string, ref v1.ResourceIdentifier, edgePath string, relDef *metamodel.RelationDef) error {
+func validateManagedOrderMeta(
+	relType string, ref v1.ResourceIdentifier, edgePath string, relDef *metamodel.RelationDef,
+) error {
 	check := func(prop string) error {
 		v, present := ref.Meta[prop]
 		if !present {

--- a/internal/dataentry/sections.go
+++ b/internal/dataentry/sections.go
@@ -159,7 +159,9 @@ type SectionData struct {
 // Returns a value (not a pointer) so callers can layer on display-mode-
 // specific fields (e.g. `Content`/`HasContent` for the `content`/`cards`
 // branch) without sharing mutation across rows.
-func (a *App) buildSectionEntityData(ctx context.Context, e *entity.Entity, secFields []ViewSectionField, eDef *metamodel.EntityDef) SectionEntityData {
+func (a *App) buildSectionEntityData(
+	ctx context.Context, e *entity.Entity, secFields []ViewSectionField, eDef *metamodel.EntityDef,
+) SectionEntityData {
 	s := a.State()
 	sed := SectionEntityData{
 		ID:            e.ID,
@@ -190,6 +192,8 @@ func (a *App) buildSectionEntityData(ctx context.Context, e *entity.Entity, secF
 }
 
 // buildSections builds template-ready section data from view sections and a view result.
+//
+//nolint:gocognit,funlen // builds each section by its declared source and display mode; the branches are the distinct section kinds, not shared logic to extract.
 func (a *App) buildSections(ctx context.Context, sections []ViewSection, result *viewResult) []SectionData {
 	s := a.State()
 	out := make([]SectionData, 0, len(sections))
@@ -203,7 +207,7 @@ func (a *App) buildSections(ctx context.Context, sections []ViewSection, result 
 			Link:         sec.Link,
 		}
 
-		if sec.Source == "entry" {
+		if sec.Source == "entry" { //nolint:nestif // entry-source sections branch by display mode and property shape; the nesting is the per-mode build, not extractable logic.
 			e := result.Entry
 			entDef, _ := s.Meta.GetEntityDef(e.Type)
 
@@ -347,6 +351,8 @@ func (a *App) executeSidePanel(ctx context.Context, panel *SidePanelConfig, enti
 // carries these affordances; the read-only entity-detail view path does
 // not call this. The `viewConfig` parameter is a synthetic ViewConfig
 // hand-built from a form's SidePanel config — it is not a generic view.
+//
+//nolint:gocognit // resolves section buttons across traverse targets; the branches are per-source button-resolution cases, not shared logic to extract.
 func (a *App) resolveSectionButtonsWithTraverse(viewConfig ViewConfig, sections []SectionData, entry *entity.Entity) {
 	s := a.State()
 	for i, sec := range viewConfig.Sections {

--- a/internal/dataentry/settings_handlers.go
+++ b/internal/dataentry/settings_handlers.go
@@ -152,6 +152,8 @@ func (a *App) handleAPISettingsCRUD(w http.ResponseWriter, r *http.Request) {
 }
 
 // handleAPIGetSettings returns the settings data for the settings page.
+//
+//nolint:gocognit // assembles the settings response from many independent optional sources; each block guards a distinct setting, with no shared structure to factor out.
 func (a *App) handleAPIGetSettings(w http.ResponseWriter, r *http.Request) {
 	s := a.State()
 	ud := s.UserDefaults

--- a/internal/dataentry/sync.go
+++ b/internal/dataentry/sync.go
@@ -159,7 +159,9 @@ func (a *App) handleSyncManifest(w http.ResponseWriter, r *http.Request) {
 //
 // Probes are batched per type via PermitsReadMany so the whole manifest costs
 // one MatchingIDs roundtrip per distinct type, not one per row.
-func (a *App) filterVisibleManifest(ctx context.Context, entries []synctypes.ManifestEntry) ([]synctypes.ManifestEntry, error) {
+func (a *App) filterVisibleManifest(
+	ctx context.Context, entries []synctypes.ManifestEntry,
+) ([]synctypes.ManifestEntry, error) {
 	gate := readGateFromContext(ctx)
 
 	// Resolve the gating (type, id) for each entry, collecting ids per type.
@@ -256,8 +258,11 @@ func validIDSegment(s string) bool {
 	if strings.ContainsAny(s, "/\\") || strings.Contains(s, "..") {
 		return false
 	}
+	// asciiSpace (0x20) is the lowest printable ASCII code point; anything
+	// below it is a C0 control character and is rejected.
+	const asciiSpace = 0x20
 	for _, c := range s {
-		if c < 0x20 { // no control characters
+		if c < asciiSpace { // no control characters
 			return false
 		}
 	}

--- a/internal/dataentry/webhook.go
+++ b/internal/dataentry/webhook.go
@@ -100,7 +100,9 @@ func (a *App) registerWebhookRoutes(mux *http.ServeMux) {
 // request body is the signed JWT (the IdP sends Content-Type: application/jwt).
 // On any verification failure it answers 401 and dispatch is never called. A
 // redelivered webhook (same id) is acknowledged with 200 without re-dispatching.
-func (rec *webhookReceiver) handle(w http.ResponseWriter, r *http.Request, dispatch func(context.Context, WebhookClaims) error) {
+func (rec *webhookReceiver) handle(
+	w http.ResponseWriter, r *http.Request, dispatch func(context.Context, WebhookClaims) error,
+) {
 	raw, err := io.ReadAll(io.LimitReader(r.Body, webhookMaxBody))
 	if err != nil {
 		http.Error(w, "read failed", http.StatusBadRequest)

--- a/internal/dataentryconfig/validate.go
+++ b/internal/dataentryconfig/validate.go
@@ -217,6 +217,8 @@ func validateNavEntry(nav NavigationEntry, cfg *Config) []string {
 }
 
 // validateForms validates form definitions.
+//
+//nolint:gocognit // linear validation dispatcher: one independent config-vs-metamodel check per branch; splitting would scatter the rule set without lowering real complexity.
 func validateForms(cfg *Config, meta *metamodel.Metamodel) []string {
 	var errs []string
 
@@ -301,7 +303,9 @@ func validateForms(cfg *Config, meta *metamodel.Metamodel) []string {
 // one must be authored from a `To:` type. Mismatch returns an error;
 // when the entity is on the opposite side the message hints at
 // flipping the direction.
-func validateFormRelationSide(formID string, i int, entityType string, r FormRelation, relDef *metamodel.RelationDef) []string {
+func validateFormRelationSide(
+	formID string, i int, entityType string, r FormRelation, relDef *metamodel.RelationDef,
+) []string {
 	if entityType == "" {
 		return nil
 	}
@@ -327,7 +331,9 @@ func validateFormRelationSide(formID string, i int, entityType string, r FormRel
 }
 
 // validateTransitions checks that transition values are valid for the property's type.
-func validateTransitions(formID string, fieldIdx int, field FormField, propDef metamodel.PropertyDef, meta *metamodel.Metamodel) []string {
+func validateTransitions(
+	formID string, fieldIdx int, field FormField, propDef metamodel.PropertyDef, meta *metamodel.Metamodel,
+) []string {
 	var errs []string
 
 	// Get valid values for this property type
@@ -403,6 +409,8 @@ func validateEntityViews(cfg *Config, meta *metamodel.Metamodel) []string {
 }
 
 // validateLists validates list definitions.
+//
+//nolint:gocognit // linear validation dispatcher: one independent config-vs-metamodel check per branch; splitting would scatter the rule set without lowering real complexity.
 func validateLists(cfg *Config, meta *metamodel.Metamodel) []string {
 	var errs []string
 
@@ -643,6 +651,8 @@ func sortedListIDs(cfg *Config) []string {
 }
 
 // validateViews validates view definitions with their traversal rules and sections.
+//
+//nolint:gocognit,gocyclo,funlen // linear validation dispatcher: one independent config-vs-metamodel check per branch; splitting would scatter the rule set without lowering real complexity.
 func validateViews(cfg *Config, meta *metamodel.Metamodel) []string {
 	var errs []string
 
@@ -770,7 +780,7 @@ func validateViews(cfg *Config, meta *metamodel.Metamodel) []string {
 			}
 
 			// Validate fields (if source type is known)
-			if sourceType != "" {
+			if sourceType != "" { //nolint:nestif // nested guards each check a distinct optional field of the source config.
 				if sourceDef, ok := meta.GetEntityDef(sourceType); ok {
 					for j, f := range s.Fields {
 						if f.Property != "" && f.Property != "title" && f.Property != "id" {
@@ -875,6 +885,8 @@ func suggestRelation(name string, meta *metamodel.Metamodel) string {
 }
 
 // validateKanbans validates kanban board definitions.
+//
+//nolint:gocognit,gocyclo,funlen // linear validation dispatcher: one independent config-vs-metamodel check per branch; splitting would scatter the rule set without lowering real complexity.
 func validateKanbans(cfg *Config, meta *metamodel.Metamodel) []string {
 	var errs []string
 
@@ -887,7 +899,7 @@ func validateKanbans(cfg *Config, meta *metamodel.Metamodel) []string {
 		}
 
 		// Validate column_property exists and is enum type
-		if kanban.ColumnProperty == "" {
+		if kanban.ColumnProperty == "" { //nolint:nestif // nested guards each check a distinct optional field of the kanban config.
 			errs = append(errs, fmt.Sprintf("kanban %q: column_property is required", kanbanID))
 		} else {
 			propDef, ok := entDef.Properties[kanban.ColumnProperty]
@@ -920,7 +932,7 @@ func validateKanbans(cfg *Config, meta *metamodel.Metamodel) []string {
 		}
 
 		// Validate swimlane_property if specified
-		if kanban.SwimlaneProperty != "" {
+		if kanban.SwimlaneProperty != "" { //nolint:nestif // nested guards each check a distinct optional field of the kanban config.
 			propDef, ok := entDef.Properties[kanban.SwimlaneProperty]
 			if !ok {
 				errs = append(errs, fmt.Sprintf(
@@ -1109,6 +1121,8 @@ var actionKeyRegex = regexp.MustCompile(`^[a-z0-9]$`)
 
 // validateActions checks action definitions: ID format, set/script exclusivity,
 // script path safety, and key shortcut validity.
+//
+//nolint:gocognit // linear validation dispatcher: one independent config-vs-metamodel check per branch; splitting would scatter the rule set without lowering real complexity.
 func validateActions(cfg *Config, meta *metamodel.Metamodel) []string {
 	var errs []string
 
@@ -1289,7 +1303,7 @@ func validateDocuments(cfg *Config) []string {
 				"document %q: one of command or script must be set", docID))
 		}
 
-		if doc.Edit != nil {
+		if doc.Edit != nil { //nolint:nestif // nested branches validate distinct doc.Edit sub-fields.
 			if doc.Edit.Form == "" {
 				errs = append(errs, fmt.Sprintf(
 					"document %q: edit.form is required when edit is set", docID))
@@ -1346,6 +1360,8 @@ func validateStyles(cfg *Config, meta *metamodel.Metamodel) []string {
 }
 
 // validateCrossReferences validates that all cross-references between config sections are valid.
+//
+//nolint:gocognit // linear validation dispatcher: one independent config-vs-metamodel check per branch; splitting would scatter the rule set without lowering real complexity.
 func validateCrossReferences(cfg *Config) []string {
 	var errs []string
 

--- a/internal/dataentryconfig/validate_feeds.go
+++ b/internal/dataentryconfig/validate_feeds.go
@@ -70,6 +70,7 @@ func validateFeeds(cfg *Config, meta *metamodel.Metamodel) []string {
 	return errs
 }
 
+//nolint:gocognit // linear validation dispatcher: one independent config-vs-metamodel check per branch; splitting would scatter the rule set without lowering real complexity.
 func validateFeedSource(feedID string, i int, src FeedSource, meta *metamodel.Metamodel) []string {
 	var errs []string
 	prefix := fmt.Sprintf("feed %q: source[%d]", feedID, i)


### PR DESCRIPTION
## Summary

`internal/dataentry` and `internal/dataentryconfig` were excluded from six linters the rest of the codebase obeys (`funlen`, `gocognit`, `gocyclo`, `lll`, `mnd`, `nestif`) via two exclusion blocks in `.golangci.yml`. This removes those exclusions and makes both packages pass.

## Changes

- **Removed** both data-entry exclusion blocks from `.golangci.yml`.
- **`lll` (49)** — wrapped long lines (split signatures, extracted locals, reflowed call args). No suppressions.
- **`mnd` (8)** — replaced magic numbers with named constants at the use site (`maxLogFieldLen = 200`, `maxThemeFilenameLen = 64`, `asciiSpace = 0x20`, route-segment counts, a regex capture-group index).
- **`gocognit` / `gocyclo` / `nestif` / `funlen`** — kept the code as-is and added targeted `//nolint:<linter> // <reason>` directives on the inherently-complex validators/handlers (e.g. `validateViews`, `buildSections`, `analyzeCardinality`). Each directive explains why the complexity is intrinsic and satisfies the project's `nolintlint` require-explanation + require-specific rules.

Lint-only change; no behavior modified.

## Verification

- `golangci-lint run ./internal/dataentry/... ./internal/dataentryconfig/...` → **0 issues** (incl. tests)
- `just ci` passes locally (lint, arch-lint, plimsoll, tests, coverage, build, docs)
- `go test ./internal/dataentry/... ./internal/dataentryconfig/...` → pass