### PR TITLE
refactor(dataentry): extract self-synchronized paletteService from AppState

### DIFF
--- a/internal/dataentry/api_v1.go
+++ b/internal/dataentry/api_v1.go
@@ -1861,7 +1861,7 @@ func (a *App) handleV1Config(w http.ResponseWriter, r *http.Request) {
 		Navigation:  s.Cfg.Navigation,
 		Documents:   s.Cfg.Documents,
 		Apps:        appsToV1(a.scanAppsOrLog()),
-		Palette:     s.Palette,
+		Palette:     a.palette.Resolved(),
 	}
 
 	writeV1JSON(w, http.StatusOK, config)

--- a/internal/dataentry/app.go
+++ b/internal/dataentry/app.go
@@ -52,8 +52,6 @@ type AppState struct {
 	StyleMap     map[string]map[string]string
 	StyledTypes  map[string]bool
 	UserDefaults *UserDefaults
-	Palette      *ResolvedPalette
-	UserPalette  *PaletteConfig
 	OpenAPIGen   *openapi.Generator
 }
 
@@ -144,7 +142,12 @@ type App struct {
 	// logo owns the user-uploaded sidebar logo — persistence AND the served
 	// in-memory cache — self-synchronized. Extracted from AppState so the
 	// logo no longer rides the App-wide snapshot + writeMu.
-	logo      *logoStore
+	logo *logoStore
+	// palette owns the user palette override and the resolved palette (derived
+	// from Cfg.Palette + the override). Self-synchronized; extracted from
+	// AppState. The reload/save paths hand it the current Cfg.Palette so it can
+	// recompute — see paletteService.Reresolve.
+	palette   *paletteService
 	templater templating.Templater
 	cfgLoader config.Loader
 	kv        state.KV
@@ -512,13 +515,15 @@ func NewApp(
 	app.serializer = entitySerializer{affordances: app.affordances}
 
 	userDefaults := app.userState.loadUserDefaults()
-	userPalette, paletteErr := app.userState.loadUserPalette()
+
+	// palette owns the user override + resolved palette. Surface a broken
+	// palette rather than silently falling back to defaults (which the next
+	// save would then persist, destroying the user's data).
+	palette, paletteErr := newPaletteService(kv, cfg.Palette)
 	if paletteErr != nil {
-		// Surface the error so users notice their palette is broken
-		// rather than silently falling back to defaults (which would
-		// then be persisted on the next save, destroying their data).
 		return nil, fmt.Errorf("load user palette: %w", paletteErr)
 	}
+	app.palette = palette
 
 	// logo owns its own persistence + served cache. Same read-error policy as
 	// palette: surface a corrupt .rela/theme/ rather than silently overwriting
@@ -538,8 +543,6 @@ func NewApp(
 		StyleMap:     styleMap,
 		StyledTypes:  styledTypes,
 		UserDefaults: userDefaults,
-		Palette:      ResolvePalette(cfg.Palette, userPalette),
-		UserPalette:  userPalette,
 		OpenAPIGen: openapi.New(meta, openapi.Config{
 			Title:       cfg.App.Name + " API",
 			Description: cfg.App.Description,

--- a/internal/dataentry/apps_handler.go
+++ b/internal/dataentry/apps_handler.go
@@ -133,7 +133,7 @@ func (a *App) handleV1App(w http.ResponseWriter, r *http.Request) {
 	}
 	if entry == appCSSEntry {
 		h.Set("Content-Type", "text/css; charset=utf-8")
-		_, _ = w.Write([]byte(appCSSSource(a.State().Palette)))
+		_, _ = w.Write([]byte(appCSSSource(a.palette.Resolved())))
 		return
 	}
 	if entry == appEditorEntry {

--- a/internal/dataentry/handlers_theme_package.go
+++ b/internal/dataentry/handlers_theme_package.go
@@ -38,7 +38,7 @@ func (a *App) handleAPIThemeExport(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	logoBytes, logoExt, _ := a.logo.Get()
-	manifest := buildExportManifest(a.State(), logoExt)
+	manifest := buildExportManifest(a.State(), a.palette.UserPalette(), logoExt)
 	zipBytes, err := buildThemeZip(manifest, logoBytes, logoExt)
 	if err != nil {
 		writeJSONError(w, http.StatusInternalServerError, "failed to build theme package: "+err.Error())
@@ -116,7 +116,7 @@ func (a *App) handleAPIThemeImport(w http.ResponseWriter, r *http.Request) {
 // buildExportManifest composes the manifest written into the zip,
 // drawing the palette from user state when available and falling back
 // to the project palette otherwise.
-func buildExportManifest(s *AppState, logoExt string) *dataentryconfig.ThemeManifest {
+func buildExportManifest(s *AppState, userPalette *PaletteConfig, logoExt string) *dataentryconfig.ThemeManifest {
 	m := &dataentryconfig.ThemeManifest{
 		Name:    s.Cfg.App.Name,
 		Version: "1.0.0",
@@ -126,8 +126,8 @@ func buildExportManifest(s *AppState, logoExt string) *dataentryconfig.ThemeMani
 	}
 
 	switch {
-	case s.UserPalette != nil:
-		m.PaletteConfig = *s.UserPalette
+	case userPalette != nil:
+		m.PaletteConfig = *userPalette
 	case s.Cfg.Palette != nil:
 		m.PaletteConfig = *s.Cfg.Palette
 	}

--- a/internal/dataentry/handlers_theme_package_test.go
+++ b/internal/dataentry/handlers_theme_package_test.go
@@ -193,8 +193,8 @@ func TestThemeImport_RoundTrip(t *testing.T) {
 	if gotBytes, _, _ := dest.logo.Get(); !bytes.Equal(gotBytes, pngBytes) {
 		t.Error("dest logo bytes do not match round-tripped bytes")
 	}
-	if dest.State().UserPalette != nil {
-		t.Error("dest UserPalette should not be auto-saved on import")
+	if dest.palette.UserPalette() != nil {
+		t.Error("dest user palette should not be auto-saved on import")
 	}
 }
 

--- a/internal/dataentry/list_incoming_relation_test.go
+++ b/internal/dataentry/list_incoming_relation_test.go
@@ -96,7 +96,6 @@ func newIncomingRelApp(t *testing.T, entities []*entity.Entity, relations []*ent
 	app.state.Store(&AppState{
 		Cfg:        cfg,
 		Meta:       meta,
-		Palette:    ResolvePalette(cfg.Palette, nil),
 		OpenAPIGen: openapi.New(meta, openapi.Config{Title: cfg.App.Name}),
 	})
 	return app

--- a/internal/dataentry/palette_service.go
+++ b/internal/dataentry/palette_service.go
@@ -1,0 +1,140 @@
+package dataentry
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"sync"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/Sourcehaven-BV/rela/internal/dataentryconfig"
+	"github.com/Sourcehaven-BV/rela/internal/state"
+)
+
+// errInvalidPalette wraps a validation failure from [paletteService.Save] so
+// the HTTP handler can map it to 400 (client error) while a persistence
+// failure maps to 500. errors.Is against this sentinel is the seam.
+var errInvalidPalette = errors.New("invalid palette")
+
+// paletteService owns the theme palette: the user's raw override
+// (`.rela/palette.yaml`, edited via the settings UI) AND the resolved palette
+// the SPA/apps consume, which is a pure derivation of the project palette
+// (`Cfg.Palette`) layered with the user override.
+//
+// It is self-synchronizing (its own RWMutex) and NOT part of the App-wide
+// AppState snapshot. Because the resolved palette depends on `Cfg.Palette`,
+// which is reload state still held in AppState, the config→palette dependency
+// is made explicit here as [paletteService.Reresolve]: the reload path and the
+// save path both hand the service the current project palette and it
+// recomputes. When Cfg becomes its own provider (schema coherence-core), this
+// service reads from that provider instead of being fed the value.
+type paletteService struct {
+	kv state.KV
+
+	mu       sync.RWMutex
+	user     *PaletteConfig   // raw user override; nil == "no user palette"
+	resolved *ResolvedPalette // derived from (cfgPalette, user)
+}
+
+// newPaletteService builds the service over the given KV, loading the user
+// palette and resolving it against the supplied project palette. A read error
+// is surfaced (not masked) so a corrupt palette.yaml doesn't get silently
+// overwritten by the next save (RR-OA4A).
+func newPaletteService(kv state.KV, cfgPalette *PaletteConfig) (*paletteService, error) {
+	s := &paletteService{kv: kv}
+	user, err := s.load()
+	if err != nil {
+		return nil, err
+	}
+	s.user = user
+	s.resolved = ResolvePalette(cfgPalette, user)
+	return s, nil
+}
+
+// UserPalette returns the raw user override, or nil when none is saved.
+func (s *paletteService) UserPalette() *PaletteConfig {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.user
+}
+
+// Resolved returns the resolved palette the SPA and apps consume.
+func (s *paletteService) Resolved() *ResolvedPalette {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.resolved
+}
+
+// Save validates then persists the user palette and recomputes the resolved
+// palette against the supplied project palette, publishing both atomically.
+// The on-disk write happens first; the cache advances only on success.
+func (s *paletteService) Save(ctx context.Context, cfgPalette, input *PaletteConfig) error {
+	if err := dataentryconfig.ValidatePalette(input); err != nil {
+		return fmt.Errorf("%w: %w", errInvalidPalette, err)
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if err := s.persist(ctx, input); err != nil {
+		return err
+	}
+	s.user = input
+	s.resolved = ResolvePalette(cfgPalette, input)
+	return nil
+}
+
+// Reresolve re-reads the user palette from disk and recomputes the resolved
+// palette against the (possibly new) project palette. Called on config/meta
+// reload. If the on-disk palette can't be read, the previous user palette is
+// kept (better stale colors than a wipe) and the resolved palette is still
+// recomputed against the new project palette.
+func (s *paletteService) Reresolve(cfgPalette *PaletteConfig) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	user, err := s.load()
+	if err != nil {
+		// Keep the previous user palette; still re-resolve against new cfg.
+		s.resolved = ResolvePalette(cfgPalette, s.user)
+		return err
+	}
+	s.user = user
+	s.resolved = ResolvePalette(cfgPalette, user)
+	return nil
+}
+
+// load reads .rela/palette.yaml. Returns (nil, nil) when the file does not
+// exist (clean "no user palette" state). Returns a non-nil error if the file
+// exists but can't be read/parsed — callers MUST surface this rather than
+// silently falling back to defaults (RR-OA4A).
+//
+//nolint:nilnil // (nil, nil) is the documented "no user palette" signal
+func (s *paletteService) load() (*PaletteConfig, error) {
+	if s.kv == nil {
+		return nil, nil
+	}
+	data, err := s.kv.Get(context.Background(), userPaletteFile)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("read %s: %w", userPaletteFile, err)
+	}
+	var p PaletteConfig
+	if err := yaml.Unmarshal(data, &p); err != nil {
+		return nil, fmt.Errorf("parse %s: %w (legacy `dark: auto` is no longer supported — remove the `dark` line or set it to `false` or an explicit object)", userPaletteFile, err)
+	}
+	return &p, nil
+}
+
+// persist writes the user palette to .rela/palette.yaml. Caller holds s.mu.
+func (s *paletteService) persist(ctx context.Context, p *PaletteConfig) error {
+	if s.kv == nil {
+		return nil
+	}
+	data, err := yaml.Marshal(p)
+	if err != nil {
+		return err
+	}
+	return s.kv.Put(ctx, userPaletteFile, data)
+}

--- a/internal/dataentry/settings_handlers.go
+++ b/internal/dataentry/settings_handlers.go
@@ -250,7 +250,7 @@ func (a *App) handleAPIGetSettings(w http.ResponseWriter, r *http.Request) {
 
 	data := APISettingsData{
 		UserDefaults:  apiDefaults,
-		UserPalette:   s.UserPalette,
+		UserPalette:   a.palette.UserPalette(),
 		AllProperties: allProperties,
 		AllRelations:  allRelations,
 		EntityTypes:   s.Meta.EntityTypes(),
@@ -320,7 +320,7 @@ func (a *App) handleAPIPaletteCRUD(w http.ResponseWriter, r *http.Request) {
 
 // handleAPIGetPalette returns the current user palette.
 func (a *App) handleAPIGetPalette(w http.ResponseWriter, _ *http.Request) {
-	p := a.State().UserPalette
+	p := a.palette.UserPalette()
 	if p == nil {
 		p = &dataentryconfig.PaletteConfig{}
 	}
@@ -335,26 +335,15 @@ func (a *App) handleAPISavePalette(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := dataentryconfig.ValidatePalette(&input); err != nil {
-		writeJSONError(w, http.StatusBadRequest, "invalid palette: "+err.Error())
-		return
-	}
-
-	// Save to file and publish a new AppState atomically so concurrent
-	// readers see the new palette via state.Load() rather than
-	// observing torn writes through a shared snapshot pointer.
-	var saveErr error
-	ctx := r.Context()
-	a.mutateState(func(s *AppState) {
-		if err := a.userState.saveUserPalette(ctx, &input); err != nil {
-			saveErr = err
+	// The service validates, persists, and republishes the resolved palette
+	// (against the current project palette) atomically. A validation failure
+	// is a 400; a persistence failure is a 500.
+	if err := a.palette.Save(r.Context(), a.Cfg().Palette, &input); err != nil {
+		if errors.Is(err, errInvalidPalette) {
+			writeJSONError(w, http.StatusBadRequest, err.Error())
 			return
 		}
-		s.UserPalette = &input
-		s.Palette = dataentryconfig.ResolvePalette(s.Cfg.Palette, &input)
-	})
-	if saveErr != nil {
-		writeJSONError(w, http.StatusInternalServerError, "failed to save palette: "+saveErr.Error())
+		writeJSONError(w, http.StatusInternalServerError, "failed to save palette: "+err.Error())
 		return
 	}
 

--- a/internal/dataentry/settings_handlers_test.go
+++ b/internal/dataentry/settings_handlers_test.go
@@ -11,7 +11,6 @@ import (
 
 func TestHandleAPIPaletteCRUD(t *testing.T) {
 	app := newHandlerTestApp(t)
-	app.State().Palette = ResolvePalette(nil, nil)
 
 	t.Run("GET returns empty palette when none set", func(t *testing.T) {
 		req := httptest.NewRequest(http.MethodGet, "/api/v1/_palette", http.NoBody)
@@ -34,7 +33,7 @@ func TestHandleAPIPaletteCRUD(t *testing.T) {
 		if w.Code != http.StatusOK {
 			t.Errorf("expected 200, got %d: %s", w.Code, w.Body.String())
 		}
-		if app.State().UserPalette == nil || app.State().UserPalette.Accent != "#e11d48" {
+		if up := app.palette.UserPalette(); up == nil || up.Accent != "#e11d48" {
 			t.Error("palette not saved")
 		}
 	})
@@ -84,12 +83,12 @@ func TestWriteJSON(t *testing.T) {
 func TestLoadUserPalette(t *testing.T) {
 	t.Run("missing file returns nil with no error", func(t *testing.T) {
 		app := newHandlerTestApp(t)
-		p, err := app.userState.loadUserPalette()
+		got, err := app.palette.load()
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		if p != nil {
-			t.Errorf("expected nil palette for missing file, got %+v", p)
+		if got != nil {
+			t.Errorf("expected nil palette for missing file, got %+v", got)
 		}
 	})
 
@@ -103,7 +102,7 @@ func TestLoadUserPalette(t *testing.T) {
 		if err != nil {
 			t.Fatalf("write fixture: %v", err)
 		}
-		p, perr := app.userState.loadUserPalette()
+		p, perr := app.palette.load()
 		if perr == nil {
 			t.Fatal("expected error for legacy `dark: auto`, got nil")
 		}
@@ -121,7 +120,7 @@ func TestLoadUserPalette(t *testing.T) {
 		if err != nil {
 			t.Fatalf("write fixture: %v", err)
 		}
-		p, perr := app.userState.loadUserPalette()
+		p, perr := app.palette.load()
 		if perr != nil {
 			t.Fatalf("unexpected error: %v", perr)
 		}

--- a/internal/dataentry/test_helpers_test.go
+++ b/internal/dataentry/test_helpers_test.go
@@ -138,9 +138,12 @@ func rebindApp(app *App, fs storage.FS, paths *project.Context, svc *appbuild.Se
 	app.cfgLoader = svc.Config()
 	app.kv = svc.State()
 	app.userState = userStateStore{kv: svc.State()}
-	// logo store over the same kv; fresh fixtures have no logo on disk so the
-	// load can't error (a nil-return matches production's clean-boot path).
+	// logo + palette stores over the same kv; fresh fixtures have nothing on
+	// disk so the loads can't error (nil-returns match production's clean-boot
+	// path). Callers that need a specific project palette resolved re-wire
+	// app.palette after this with newPaletteService(kv, cfgPalette).
 	app.logo, _ = newLogoStore(svc.State())
+	app.palette, _ = newPaletteService(svc.State(), nil)
 	app.acl = svc.ACL()
 	app.auditSink = svc.Audit()
 	// Wire a minimal documentService for tests that hit the documents
@@ -240,14 +243,17 @@ func newAppFromParts(cfg *Config, meta *metamodel.Metamodel, f *fixture) *App {
 	if meta != nil {
 		openAPIGen = openapi.New(meta, openapi.Config{Title: cfg.App.Name})
 	}
+	// Re-resolve the palette against this fixture's project palette (rebindApp
+	// wired a nil-cfg default).
+	if app.palette != nil {
+		_ = app.palette.Reresolve(cfg.Palette)
+	}
 	app.state.Store(&AppState{
 		Cfg:          cfg,
 		Meta:         meta,
 		StyleMap:     styleMap,
 		StyledTypes:  styledTypes,
 		UserDefaults: &UserDefaults{},
-		Palette:      ResolvePalette(cfg.Palette, nil),
-		UserPalette:  &PaletteConfig{},
 		OpenAPIGen:   openAPIGen,
 	})
 	return app
@@ -327,17 +333,21 @@ func newHandlerTestApp(t *testing.T) *App {
 		t.Fatalf("NewRootedFS: %v", err)
 	}
 	app.kv = state.NewFSKV(kvRoot)
+	// Resolve the palette against this fixture's project palette (rebindApp
+	// wired a nil-cfg default). The user palette stays nil: the theme tests
+	// use its nil-ness as the "nothing saved yet" signal.
+	if app.palette != nil {
+		_ = app.palette.Reresolve(cfg.Palette)
+	}
 	// Populate the snapshot fields handlers deref unconditionally — the
 	// router walk test hits every route, including _openapi.json, which
-	// panics on a nil OpenAPIGen. UserPalette stays nil on purpose: the
-	// theme tests use its nil-ness as the "nothing saved yet" signal.
+	// panics on a nil OpenAPIGen.
 	app.state.Store(&AppState{
 		Cfg:          cfg,
 		Meta:         meta,
 		StyleMap:     styleMap,
 		StyledTypes:  styledTypes,
 		UserDefaults: &UserDefaults{},
-		Palette:      ResolvePalette(cfg.Palette, nil),
 		OpenAPIGen:   openapi.New(meta, openapi.Config{Title: cfg.App.Name}),
 	})
 	return app

--- a/internal/dataentry/userstate.go
+++ b/internal/dataentry/userstate.go
@@ -3,8 +3,6 @@ package dataentry
 import (
 	"context"
 	"encoding/json"
-	"fmt"
-	"os"
 
 	"gopkg.in/yaml.v3"
 
@@ -83,45 +81,4 @@ func (s userStateStore) saveUserDefaults(ctx context.Context, ud *UserDefaults) 
 		return err
 	}
 	return s.kv.Put(ctx, userDefaultsFile, data)
-}
-
-// loadUserPalette reads .rela/palette.yaml and returns the parsed
-// palette. Returns (nil, nil) when the file does not exist (clean
-// "no user palette" state — matches how ResolvePalette consumes a
-// nil user palette pointer; a sentinel error or three-return shape
-// would be more confusing for the only two callers). Returns a
-// non-nil error if the file exists but cannot be read or parsed —
-// callers MUST surface this instead of silently falling back to
-// defaults, otherwise a subsequent save would silently overwrite
-// the user's palette with framework defaults (RR-OA4A).
-//
-//nolint:nilnil // see comment above
-func (s userStateStore) loadUserPalette() (*PaletteConfig, error) {
-	if s.kv == nil {
-		return nil, nil
-	}
-	data, err := s.kv.Get(context.Background(), userPaletteFile)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return nil, nil
-		}
-		return nil, fmt.Errorf("read %s: %w", userPaletteFile, err)
-	}
-	var p PaletteConfig
-	if err := yaml.Unmarshal(data, &p); err != nil {
-		return nil, fmt.Errorf("parse %s: %w (legacy `dark: auto` is no longer supported — remove the `dark` line or set it to `false` or an explicit object)", userPaletteFile, err)
-	}
-	return &p, nil
-}
-
-// saveUserPalette writes the user palette to .rela/palette.yaml.
-func (s userStateStore) saveUserPalette(ctx context.Context, p *PaletteConfig) error {
-	if s.kv == nil {
-		return nil
-	}
-	data, err := yaml.Marshal(p)
-	if err != nil {
-		return err
-	}
-	return s.kv.Put(ctx, userPaletteFile, data)
 }

--- a/internal/dataentry/watcher.go
+++ b/internal/dataentry/watcher.go
@@ -303,20 +303,16 @@ func (a *App) rebuildState(configChanged, metaChanged bool) {
 
 	newStyleMap := current.StyleMap
 	newStyledTypes := current.StyledTypes
-	newUserPalette := current.UserPalette
-	newPalette := current.Palette
 	newOpenAPI := current.OpenAPIGen
 
 	if configChanged || metaChanged {
 		newStyleMap, newStyledTypes = buildStyleMap(newCfg, newMeta)
-		// On reload, keep the previous palette if the new file is
-		// broken — better to show stale colors than crash or wipe.
-		if up, err := a.userState.loadUserPalette(); err != nil {
+		// Re-resolve the palette against the new project palette. The service
+		// keeps the previous user override if the on-disk file is broken —
+		// better to show stale colors than crash or wipe.
+		if err := a.palette.Reresolve(newCfg.Palette); err != nil {
 			slog.Warn("watcher: keeping previous user palette",
 				"file", userPaletteFile, "error", err)
-		} else {
-			newUserPalette = up
-			newPalette = ResolvePalette(newCfg.Palette, newUserPalette)
 		}
 		// Update OpenAPI generator with new metamodel (the generator
 		// is internally synchronized; we reuse the same instance).
@@ -331,8 +327,6 @@ func (a *App) rebuildState(configChanged, metaChanged bool) {
 		StyleMap:     newStyleMap,
 		StyledTypes:  newStyledTypes,
 		UserDefaults: current.UserDefaults,
-		Palette:      newPalette,
-		UserPalette:  newUserPalette,
 		OpenAPIGen:   newOpenAPI,
 	})
 }

--- a/tickets/entities/tickets/TKT-XSWFXQ.md
+++ b/tickets/entities/tickets/TKT-XSWFXQ.md
@@ -51,3 +51,10 @@ concern, belongs behind the store.
 - The plimsoll `App` method-line is unchanged: this arc cuts state/fields, not
 methods. The method-count ratchet is the handler-split follow-up
 ([[TKT-R68TV8]]).
+
+## Delivery (stacked PRs)
+
+- [x] `logoStore` (PR #1105)
+- [x] `paletteService` (PR #1107)
+- [ ] `settingsService` + delete `mutateState` (PR #1109)
+- [ ] `schemaProvider` collapses `AppState` (PR #1110)


### PR DESCRIPTION
**PR 2 of the AppState decomposition.** Stacks on #1105 (logoStore) — base is that branch, so the diff shows only the palette change. Merge #1105 first.

## Why

`UserPalette` (the raw user override) and the resolved `Palette` both lived in the `AppState` snapshot. Consequences:
- every palette save went through `mutateState` + the App-wide `writeMu`;
- `rebuildState` hand-copied both fields forward on every reload and re-resolved inline.

## What

Extract both into a `paletteService` that owns them behind its own `sync.RWMutex`:
- `UserPalette()` / `Resolved()` — reads.
- `Save(ctx, cfgPalette, input)` — validates, persists, recomputes resolved, publishes atomically.
- `Reresolve(cfgPalette)` — re-reads the override from disk and recomputes resolved against the (possibly new) project palette; called by the reload path.

The resolved palette is a pure derivation of `Cfg.Palette` + the override. Rather than hide that, the `Cfg → palette` dependency is made **explicit** as the `cfgPalette` argument to `Save`/`Reresolve`. When `Cfg` becomes its own provider (PR5, the schema coherence-core), this service reads from that provider instead of being handed the value.

Validation moved into the service and is surfaced via an `errInvalidPalette` sentinel so the handler keeps its invalid→400 / persist-fail→500 split.

Result:
- **2 fields removed from `AppState`** (`Palette`, `UserPalette`).
- **The last two `mutateState`-based writes are gone** (palette save + theme-package import already went via logoStore in PR1).
- `TestLoadUserPalette` retargeted to drive `paletteService.load` directly; also removes a test that scribbled `app.State().Palette` on the shared snapshot pointer.

No behavior change: same GET/PUT palette semantics, same reload fallback ("keep stale colors if the file is broken"), same export manifest.

## Verification

- `go build ./...` (+ `-tags postgres`, `-tags memorybackend`) ✅
- `go test -race ./internal/dataentry/...` ✅
- `just arch-lint` ✅ · `just plimsoll` ✅ · `golangci-lint` → 0 issues

## Next

settings/UserDefaults → openapi/style providers → schema coherence-core (collapses the remaining AppState + removes `mutateState`/publish-`writeMu` entirely).