### PR TITLE
refactor(dataentry): extract settingsService + delete dead mutateState

### DIFF
--- a/internal/dataentry/acl_sidebar_test.go
+++ b/internal/dataentry/acl_sidebar_test.go
@@ -60,23 +60,24 @@ func sidebarPolicy() *acl.Policy {
 // installSidebarConfig publishes a Config snapshot carrying one plain
 // list, one filtered list, and one kanban over tickets.
 func installSidebarConfig(app *App) {
-	app.mutateState(func(s *AppState) {
-		cfg := *s.Cfg
-		cfg.Lists = map[string]dataentryconfig.List{
-			"all-tickets": {EntityType: "ticket", Title: "All"},
-			"open-tickets": {EntityType: "ticket", Title: "Open",
-				Filters: []dataentryconfig.FilterConfig{{Property: "status", Operator: "=", Value: "open"}}},
-		}
-		cfg.Kanbans = map[string]dataentryconfig.Kanban{
-			"board": {EntityType: "ticket", ColumnProperty: "status"},
-		}
-		cfg.Navigation = []dataentryconfig.NavigationEntry{
-			{Label: "All", List: "all-tickets"},
-			{Label: "Open", List: "open-tickets"},
-			{Label: "Board", Kanban: "board"},
-		}
-		s.Cfg = &cfg
-	})
+	cur := app.State()
+	next := *cur // shallow copy of the snapshot
+	cfg := *cur.Cfg
+	cfg.Lists = map[string]dataentryconfig.List{
+		"all-tickets": {EntityType: "ticket", Title: "All"},
+		"open-tickets": {EntityType: "ticket", Title: "Open",
+			Filters: []dataentryconfig.FilterConfig{{Property: "status", Operator: "=", Value: "open"}}},
+	}
+	cfg.Kanbans = map[string]dataentryconfig.Kanban{
+		"board": {EntityType: "ticket", ColumnProperty: "status"},
+	}
+	cfg.Navigation = []dataentryconfig.NavigationEntry{
+		{Label: "All", List: "all-tickets"},
+		{Label: "Open", List: "open-tickets"},
+		{Label: "Board", Kanban: "board"},
+	}
+	next.Cfg = &cfg
+	app.state.Store(&next)
 }
 
 // sidebarCountsByLabel performs a sidebar request and returns the

--- a/internal/dataentry/app.go
+++ b/internal/dataentry/app.go
@@ -43,16 +43,17 @@ import (
 //
 // This snapshot is being decomposed: state owned by exactly one service is
 // moving out into that service (self-synchronized), leaving AppState to hold
-// only genuinely co-derived reload state. The user-uploaded logo was the first
-// to move — see [logoStore]. What remains here is the config/metamodel and the
-// fields derived from them together.
+// only genuinely co-derived reload state. The logo ([logoStore]), palette
+// ([paletteService]), and user defaults ([settingsService]) have moved out.
+// What remains is the config/metamodel and the style map derived from them
+// together — the co-derived core that a later PR collapses into a schema
+// provider.
 type AppState struct {
-	Cfg          *Config
-	Meta         *metamodel.Metamodel
-	StyleMap     map[string]map[string]string
-	StyledTypes  map[string]bool
-	UserDefaults *UserDefaults
-	OpenAPIGen   *openapi.Generator
+	Cfg         *Config
+	Meta        *metamodel.Metamodel
+	StyleMap    map[string]map[string]string
+	StyledTypes map[string]bool
+	OpenAPIGen  *openapi.Generator
 }
 
 // ConfigFile is the conventional filename for data-entry configuration within a rela project.
@@ -147,7 +148,10 @@ type App struct {
 	// from Cfg.Palette + the override). Self-synchronized; extracted from
 	// AppState. The reload/save paths hand it the current Cfg.Palette so it can
 	// recompute — see paletteService.Reresolve.
-	palette   *paletteService
+	palette *paletteService
+	// settings owns the per-user default values (create-form/relation defaults).
+	// Self-synchronized; extracted from AppState.
+	settings  *settingsService
 	templater templating.Templater
 	cfgLoader config.Loader
 	kv        state.KV
@@ -284,23 +288,6 @@ func (a *App) luaWriteDeps() lua.WriteDeps {
 		},
 		EntityManager: a.entityManager,
 	}
-}
-
-// mutateState atomically updates the published AppState. It takes
-// writeMu, builds a shallow copy of the current snapshot, runs the
-// caller's mutator on the copy, and publishes the copy via state.Store.
-//
-// This is the canonical way for mutation handlers to change reloadable
-// fields like UserDefaults or UserPalette. Reaching through a.State()
-// to assign field values directly is a bug — it scribbles on the shared
-// snapshot pointer that lock-free readers also hold.
-func (a *App) mutateState(fn func(*AppState)) {
-	a.writeMu.Lock()
-	defer a.writeMu.Unlock()
-	cur := a.state.Load()
-	next := *cur // shallow copy of the snapshot
-	fn(&next)
-	a.state.Store(&next)
 }
 
 // SetSecurityConfig configures the HTTP security middlewares applied by
@@ -514,7 +501,7 @@ func NewApp(
 
 	app.serializer = entitySerializer{affordances: app.affordances}
 
-	userDefaults := app.userState.loadUserDefaults()
+	app.settings = newSettingsService(kv)
 
 	// palette owns the user override + resolved palette. Surface a broken
 	// palette rather than silently falling back to defaults (which the next
@@ -538,11 +525,10 @@ func NewApp(
 	// state lives here; there are no convenience aliases on App to keep
 	// in sync.
 	app.state.Store(&AppState{
-		Cfg:          &cfg,
-		Meta:         meta,
-		StyleMap:     styleMap,
-		StyledTypes:  styledTypes,
-		UserDefaults: userDefaults,
+		Cfg:         &cfg,
+		Meta:        meta,
+		StyleMap:    styleMap,
+		StyledTypes: styledTypes,
 		OpenAPIGen: openapi.New(meta, openapi.Config{
 			Title:       cfg.App.Name + " API",
 			Description: cfg.App.Description,

--- a/internal/dataentry/app_test.go
+++ b/internal/dataentry/app_test.go
@@ -779,7 +779,7 @@ func TestUserDefaultsLoadSave(t *testing.T) {
 	bindRepoWithFS(app, fs, ctx)
 
 	t.Run("load returns nil when file missing", func(t *testing.T) {
-		ud := app.userState.loadUserDefaults()
+		ud := app.settings.UserDefaults()
 		if ud != nil {
 			t.Errorf("expected nil, got %+v", ud)
 		}
@@ -797,10 +797,10 @@ func TestUserDefaultsLoadSave(t *testing.T) {
 				},
 			},
 		}
-		if err := app.userState.saveUserDefaults(context.Background(), ud); err != nil {
+		if err := app.settings.Save(context.Background(), ud); err != nil {
 			t.Fatalf("save error: %v", err)
 		}
-		loaded := app.userState.loadUserDefaults()
+		loaded := app.settings.UserDefaults()
 		if loaded == nil {
 			t.Fatal("expected non-nil loaded defaults")
 		}
@@ -822,13 +822,11 @@ func TestUserDefaultsLoadSave(t *testing.T) {
 	})
 
 	t.Run("nil kv is safe", func(t *testing.T) {
-		app2, _ := testAppInstance()
-		app2.kv = nil
-		ud := app2.userState.loadUserDefaults()
-		if ud != nil {
+		nilSettings := newSettingsService(nil)
+		if ud := nilSettings.UserDefaults(); ud != nil {
 			t.Errorf("expected nil, got %+v", ud)
 		}
-		if err := app2.userState.saveUserDefaults(context.Background(), &UserDefaults{}); err != nil {
+		if err := nilSettings.Save(context.Background(), &UserDefaults{}); err != nil {
 			t.Errorf("expected no error, got %v", err)
 		}
 	})

--- a/internal/dataentry/settings_handlers.go
+++ b/internal/dataentry/settings_handlers.go
@@ -156,7 +156,7 @@ func (a *App) handleAPISettingsCRUD(w http.ResponseWriter, r *http.Request) {
 //nolint:gocognit // assembles the settings response from many independent optional sources; each block guards a distinct setting, with no shared structure to factor out.
 func (a *App) handleAPIGetSettings(w http.ResponseWriter, r *http.Request) {
 	s := a.State()
-	ud := s.UserDefaults
+	ud := a.settings.UserDefaults()
 	if ud == nil {
 		ud = &UserDefaults{}
 	}
@@ -260,9 +260,9 @@ func (a *App) handleAPIGetSettings(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, data)
 }
 
-// handleAPISaveSettings saves the user defaults from JSON input. The save
-// to disk and the publication of the new AppState happen atomically via
-// mutateState so concurrent readers see a coherent snapshot.
+// handleAPISaveSettings saves the user defaults from JSON input. The
+// settingsService persists and republishes atomically so concurrent readers
+// see a coherent snapshot.
 func (a *App) handleAPISaveSettings(w http.ResponseWriter, r *http.Request) {
 	var input APIUserDefaults
 	if err := json.NewDecoder(r.Body).Decode(&input); err != nil {
@@ -283,21 +283,10 @@ func (a *App) handleAPISaveSettings(w http.ResponseWriter, r *http.Request) {
 		})
 	}
 
-	// Save to file under writeMu, then publish a new AppState with the
-	// updated UserDefaults via mutateState. The save and the publish
-	// are wrapped together so a concurrent reader cannot observe a
-	// State whose UserDefaults disagrees with what's on disk.
-	var saveErr error
-	ctx := r.Context()
-	a.mutateState(func(s *AppState) {
-		if err := a.userState.saveUserDefaults(ctx, &ud); err != nil {
-			saveErr = err
-			return
-		}
-		s.UserDefaults = &ud
-	})
-	if saveErr != nil {
-		writeJSONError(w, http.StatusInternalServerError, "failed to save settings: "+saveErr.Error())
+	// The service persists and republishes the defaults atomically, so a
+	// concurrent reader can't observe defaults that disagree with disk.
+	if err := a.settings.Save(r.Context(), &ud); err != nil {
+		writeJSONError(w, http.StatusInternalServerError, "failed to save settings: "+err.Error())
 		return
 	}
 

--- a/internal/dataentry/settings_service.go
+++ b/internal/dataentry/settings_service.go
@@ -1,0 +1,82 @@
+package dataentry
+
+import (
+	"context"
+	"sync"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/Sourcehaven-BV/rela/internal/state"
+)
+
+// settingsService owns the per-user default values (`.rela/user-defaults.yaml`)
+// edited via the settings UI: the create-form defaults and relation defaults
+// the SPA pre-fills.
+//
+// Self-synchronizing (its own RWMutex), extracted from the App-wide AppState
+// snapshot. Unlike the palette/logo services, a bad user-defaults file is
+// non-fatal — it's a UI convenience, not data the next save could destroy — so
+// a read error degrades to "no defaults" rather than surfacing, matching the
+// prior behavior.
+type settingsService struct {
+	kv state.KV
+
+	mu       sync.RWMutex
+	defaults *UserDefaults
+}
+
+// newSettingsService builds the service over the given KV and loads the
+// persisted defaults (nil when absent/unreadable — non-fatal by design).
+func newSettingsService(kv state.KV) *settingsService {
+	s := &settingsService{kv: kv}
+	s.defaults = s.load()
+	return s
+}
+
+// UserDefaults returns the current defaults, or nil when none are saved.
+func (s *settingsService) UserDefaults() *UserDefaults {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.defaults
+}
+
+// Save persists the defaults and updates the cache atomically. The on-disk
+// write happens first; the cache advances only on success.
+func (s *settingsService) Save(ctx context.Context, ud *UserDefaults) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if err := s.persist(ctx, ud); err != nil {
+		return err
+	}
+	s.defaults = ud
+	return nil
+}
+
+// load reads .rela/user-defaults.yaml. Returns nil if the file doesn't exist or
+// can't be parsed — user defaults are a non-critical UI convenience.
+func (s *settingsService) load() *UserDefaults {
+	if s.kv == nil {
+		return nil
+	}
+	data, err := s.kv.Get(context.Background(), userDefaultsFile)
+	if err != nil {
+		return nil
+	}
+	var ud UserDefaults
+	if err := yaml.Unmarshal(data, &ud); err != nil {
+		return nil
+	}
+	return &ud
+}
+
+// persist writes the defaults to .rela/user-defaults.yaml. Caller holds s.mu.
+func (s *settingsService) persist(ctx context.Context, ud *UserDefaults) error {
+	if s.kv == nil {
+		return nil
+	}
+	data, err := yaml.Marshal(ud)
+	if err != nil {
+		return err
+	}
+	return s.kv.Put(ctx, userDefaultsFile, data)
+}

--- a/internal/dataentry/test_helpers_test.go
+++ b/internal/dataentry/test_helpers_test.go
@@ -144,6 +144,7 @@ func rebindApp(app *App, fs storage.FS, paths *project.Context, svc *appbuild.Se
 	// app.palette after this with newPaletteService(kv, cfgPalette).
 	app.logo, _ = newLogoStore(svc.State())
 	app.palette, _ = newPaletteService(svc.State(), nil)
+	app.settings = newSettingsService(svc.State())
 	app.acl = svc.ACL()
 	app.auditSink = svc.Audit()
 	// Wire a minimal documentService for tests that hit the documents
@@ -249,12 +250,11 @@ func newAppFromParts(cfg *Config, meta *metamodel.Metamodel, f *fixture) *App {
 		_ = app.palette.Reresolve(cfg.Palette)
 	}
 	app.state.Store(&AppState{
-		Cfg:          cfg,
-		Meta:         meta,
-		StyleMap:     styleMap,
-		StyledTypes:  styledTypes,
-		UserDefaults: &UserDefaults{},
-		OpenAPIGen:   openAPIGen,
+		Cfg:         cfg,
+		Meta:        meta,
+		StyleMap:    styleMap,
+		StyledTypes: styledTypes,
+		OpenAPIGen:  openAPIGen,
 	})
 	return app
 }
@@ -343,12 +343,11 @@ func newHandlerTestApp(t *testing.T) *App {
 	// router walk test hits every route, including _openapi.json, which
 	// panics on a nil OpenAPIGen.
 	app.state.Store(&AppState{
-		Cfg:          cfg,
-		Meta:         meta,
-		StyleMap:     styleMap,
-		StyledTypes:  styledTypes,
-		UserDefaults: &UserDefaults{},
-		OpenAPIGen:   openapi.New(meta, openapi.Config{Title: cfg.App.Name}),
+		Cfg:         cfg,
+		Meta:        meta,
+		StyleMap:    styleMap,
+		StyledTypes: styledTypes,
+		OpenAPIGen:  openapi.New(meta, openapi.Config{Title: cfg.App.Name}),
 	})
 	return app
 }

--- a/internal/dataentry/userstate.go
+++ b/internal/dataentry/userstate.go
@@ -4,20 +4,17 @@ import (
 	"context"
 	"encoding/json"
 
-	"gopkg.in/yaml.v3"
-
 	"github.com/Sourcehaven-BV/rela/internal/state"
 )
 
-// userStateStore persists per-user UI state to the project's `.rela/` KV store:
-// the sidebar logo, UI state (expanded groups, active list), user defaults, and
-// the user palette override. Extracted from App (TKT-N26KLB M5.3): every method
-// is a load/save pair over the KV store and touches nothing else, so they form
-// a cohesive store with a single dependency.
+// userStateStore persists the SPA's UI state (expanded groups, active list) to
+// `.rela/ui-state.json`. Originally a grab-bag of per-user customization
+// (logo, palette, defaults, UI state); the logo/palette/defaults each moved
+// into their own self-synchronized service, leaving this as the UI-state store.
 //
-// These are NOT the entity store — they're the per-user customization layer
-// that rides alongside it (gitignored `.rela/` files). Writes here do not go
-// through entitymanager; they are local UI preferences, not graph mutations.
+// This is NOT the entity store — it's the per-user customization layer that
+// rides alongside it (gitignored `.rela/` files). Writes here do not go through
+// entitymanager; they are local UI preferences, not graph mutations.
 type userStateStore struct {
 	kv state.KV
 }
@@ -52,33 +49,4 @@ func (s userStateStore) saveUIState(st UIState) error {
 		return err
 	}
 	return s.kv.Put(context.Background(), uiStateFile, data)
-}
-
-// loadUserDefaults reads .rela/user-defaults.yaml and returns the parsed defaults.
-// Returns nil if the file doesn't exist or can't be parsed.
-func (s userStateStore) loadUserDefaults() *UserDefaults {
-	if s.kv == nil {
-		return nil
-	}
-	data, err := s.kv.Get(context.Background(), userDefaultsFile)
-	if err != nil {
-		return nil
-	}
-	var ud UserDefaults
-	if err := yaml.Unmarshal(data, &ud); err != nil {
-		return nil
-	}
-	return &ud
-}
-
-// saveUserDefaults writes the user defaults to .rela/user-defaults.yaml.
-func (s userStateStore) saveUserDefaults(ctx context.Context, ud *UserDefaults) error {
-	if s.kv == nil {
-		return nil
-	}
-	data, err := yaml.Marshal(ud)
-	if err != nil {
-		return err
-	}
-	return s.kv.Put(ctx, userDefaultsFile, data)
 }

--- a/internal/dataentry/watcher.go
+++ b/internal/dataentry/watcher.go
@@ -322,12 +322,11 @@ func (a *App) rebuildState(configChanged, metaChanged bool) {
 	}
 
 	a.state.Store(&AppState{
-		Cfg:          newCfg,
-		Meta:         newMeta,
-		StyleMap:     newStyleMap,
-		StyledTypes:  newStyledTypes,
-		UserDefaults: current.UserDefaults,
-		OpenAPIGen:   newOpenAPI,
+		Cfg:         newCfg,
+		Meta:        newMeta,
+		StyleMap:    newStyleMap,
+		StyledTypes: newStyledTypes,
+		OpenAPIGen:  newOpenAPI,
 	})
 }
 

--- a/tickets/entities/tickets/TKT-XSWFXQ.md
+++ b/tickets/entities/tickets/TKT-XSWFXQ.md
@@ -56,5 +56,5 @@ methods. The method-count ratchet is the handler-split follow-up
 
 - [x] `logoStore` (PR #1105)
 - [x] `paletteService` (PR #1107)
-- [ ] `settingsService` + delete `mutateState` (PR #1109)
+- [x] `settingsService` + delete `mutateState` (PR #1109)
 - [ ] `schemaProvider` collapses `AppState` (PR #1110)


### PR DESCRIPTION
**PR 3 of the AppState decomposition.** Stacks on #1107 (paletteService) → #1105 (logoStore). Merge those first.

## Why

`UserDefaults` (per-user create-form / relation defaults) was the last owned-state field on the `AppState` snapshot. Its save went through `mutateState` + the App-wide `writeMu`.

## What

- Extract `UserDefaults` into a `settingsService` behind its own `sync.RWMutex` (`UserDefaults()` / `Save()`). A broken defaults file degrades to "no defaults" (non-fatal UI convenience — unchanged behavior), unlike palette/logo which surface errors.
- **`mutateState` now has zero callers** (logo→#1105, palette→#1107, defaults→here) — **delete it**. `AppState` is reduced to the genuinely co-derived `Cfg`/`Meta`/`StyleMap`/`StyledTypes`/`OpenAPIGen` core.
- `userStateStore` is now just the UI-state store; stale doc comment + unused `yaml` import cleaned up.
- The sidebar test's `Cfg` snapshot mutation inlines the copy-and-publish `mutateState` used to provide.

## Payoff so far

Across #1105 → #1107 → this PR: **7 fields removed from `AppState`**, and the entire `mutateState` + publish-`writeMu` write-serialization apparatus for reloadable UI state is **gone**. What remains is the co-derived config/metamodel core, which the next PR collapses into a schema provider.

(The `writeMu` uses that remain are Job-2 — entity-write serialization — a separate concern not in this arc.)

## Verification

- `go build ./...` (+ `-tags postgres`, `-tags memorybackend`) ✅
- `go test -race ./internal/dataentry/...` ✅
- `just arch-lint` ✅ · `just plimsoll` ✅ · `golangci-lint` → 0 issues

## Next

PR4: openapi/style providers. PR5: collapse the residual AppState into a schema provider.