### PR TITLE
refactor(dataentry): collapse AppState into a schemaProvider

### DIFF
--- a/internal/dataentry/acl_sidebar_test.go
+++ b/internal/dataentry/acl_sidebar_test.go
@@ -77,7 +77,7 @@ func installSidebarConfig(app *App) {
 		{Label: "Board", Kanban: "board"},
 	}
 	next.Cfg = &cfg
-	app.state.Store(&next)
+	app.schema.Publish(&next)
 }
 
 // sidebarCountsByLabel performs a sidebar request and returns the

--- a/internal/dataentry/app.go
+++ b/internal/dataentry/app.go
@@ -10,7 +10,6 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
-	"sync/atomic"
 
 	"gopkg.in/yaml.v3"
 
@@ -37,25 +36,6 @@ import (
 	"github.com/Sourcehaven-BV/rela/internal/validator"
 )
 
-// AppState bundles the reloadable fields of App into an immutable snapshot,
-// published via atomic.Pointer. Callers Load() once and work against a
-// coherent snapshot, instead of holding a read lock around the entire request.
-//
-// This snapshot is being decomposed: state owned by exactly one service is
-// moving out into that service (self-synchronized), leaving AppState to hold
-// only genuinely co-derived reload state. The logo ([logoStore]), palette
-// ([paletteService]), and user defaults ([settingsService]) have moved out.
-// What remains is the config/metamodel and the style map derived from them
-// together — the co-derived core that a later PR collapses into a schema
-// provider.
-type AppState struct {
-	Cfg         *Config
-	Meta        *metamodel.Metamodel
-	StyleMap    map[string]map[string]string
-	StyledTypes map[string]bool
-	OpenAPIGen  *openapi.Generator
-}
-
 // ConfigFile is the conventional filename for data-entry configuration within a rela project.
 const ConfigFile = dataentryconfig.ConfigFile
 
@@ -72,20 +52,22 @@ const userPaletteFile = "palette.yaml"
 //
 // # Concurrency model
 //
-// All reloadable state (config, metamodel, graph, style map, palette,
-// user defaults, OpenAPI generator) lives in an immutable AppState struct
-// held via atomic.Pointer. Handlers call a.State() once at entry and work
-// against a coherent snapshot for the duration of the request — no lock
-// acquisition, no risk of observing a half-reloaded world.
+// The co-derived reload core (config, metamodel, style map, OpenAPI
+// generator) lives in an immutable [Schema] published via [schemaProvider]'s
+// atomic.Pointer. Handlers call a.State() once at entry and work against a
+// coherent snapshot for the duration of the request — no lock acquisition, no
+// risk of observing a half-reloaded world. Independently-owned reloadable
+// state (logo, palette, user defaults) lives in its own self-synchronized
+// service, not the snapshot.
 //
-// Reloads (triggered by the file watcher or by Reload) build a new
-// AppState and publish it atomically via a.state.Store. The previous
-// state is garbage-collected once no reader holds it.
+// Reloads (triggered by the file watcher or by Reload) derive a new Schema
+// and publish it atomically via a.schema.Reload. The previous snapshot is
+// garbage-collected once no reader holds it.
 //
 // Mutations (CreateEntity, UpdateEntity, DeleteEntity, CreateRelation,
 // UpdateRelation, DeleteRelation, SetProperty, action scripts) serialize
 // via writeMu. writeMu excludes concurrent mutations but does NOT block
-// readers — readers go through state.Load(). The workspace's internal
+// readers — readers go through a.State(). The workspace's internal
 // reloadMu coordinates the reload itself with the mutation path.
 //
 // TODO(TKT-N26KLB): App is a god-object. Decompose toward the
@@ -141,16 +123,16 @@ type App struct {
 	// to the .rela/ KV store. Extracted from App (TKT-N26KLB M5.3).
 	userState userStateStore
 	// logo owns the user-uploaded sidebar logo — persistence AND the served
-	// in-memory cache — self-synchronized. Extracted from AppState so the
+	// in-memory cache — self-synchronized. Extracted from the schema snapshot so the
 	// logo no longer rides the App-wide snapshot + writeMu.
 	logo *logoStore
 	// palette owns the user palette override and the resolved palette (derived
 	// from Cfg.Palette + the override). Self-synchronized; extracted from
-	// AppState. The reload/save paths hand it the current Cfg.Palette so it can
+	// Schema. The reload/save paths hand it the current Cfg.Palette so it can
 	// recompute — see paletteService.Reresolve.
 	palette *paletteService
 	// settings owns the per-user default values (create-form/relation defaults).
-	// Self-synchronized; extracted from AppState.
+	// Self-synchronized; extracted from the schema snapshot.
 	settings  *settingsService
 	templater templating.Templater
 	cfgLoader config.Loader
@@ -172,10 +154,11 @@ type App struct {
 	// whole point of having a cache in a long-lived server.
 	scriptEngine *script.Engine
 
-	// state holds the current reloadable snapshot. Readers: a.State().
-	// Writers: onReload rebuilds and publishes a new state after file
-	// changes. Initial state is published in NewApp.
-	state atomic.Pointer[AppState]
+	// schema publishes the current reloadable co-derived core (config,
+	// metamodel, style map, OpenAPI generator). Readers: a.State(). Writers:
+	// the watcher's reload path (rebuildState → schema.Reload). Initial
+	// snapshot is published in NewApp.
+	schema schemaProvider
 
 	// writeMu serializes mutation handlers (CreateEntity, UpdateEntity,
 	// etc.) against each other. Readers never take it.
@@ -260,11 +243,11 @@ func (a *App) StopWatching() {
 	}
 }
 
-// State returns the current reloadable snapshot. Handlers should call
+// State returns the current reloadable [Schema] snapshot. Handlers should call
 // State() once at entry and use the returned snapshot consistently
 // throughout, instead of making multiple calls that could see different
 // snapshots after a concurrent reload.
-func (a *App) State() *AppState { return a.state.Load() }
+func (a *App) State() *Schema { return a.schema.Current() }
 
 // Cfg returns the current data-entry config (convenience accessor).
 // Equivalent to a.State().Cfg.
@@ -273,7 +256,7 @@ func (a *App) Cfg() *Config { return a.State().Cfg }
 // Meta returns the current metamodel (convenience accessor).
 func (a *App) Meta() *metamodel.Metamodel { return a.State().Meta }
 
-// luaWriteDeps builds a lua.WriteDeps bundle using the current AppState
+// luaWriteDeps builds a lua.WriteDeps bundle using the current Schema
 // metamodel. Called per action-script invocation so that metamodel reloads
 // propagate to scripts without requiring app reconstruction. All other
 // fields are immutable for the App's lifetime.
@@ -521,10 +504,10 @@ func NewApp(
 	}
 	app.logo = logo
 
-	// Build and publish the initial AppState snapshot. All reloadable
+	// Build and publish the initial Schema snapshot. All reloadable
 	// state lives here; there are no convenience aliases on App to keep
 	// in sync.
-	app.state.Store(&AppState{
+	app.schema.Publish(&Schema{
 		Cfg:         &cfg,
 		Meta:        meta,
 		StyleMap:    styleMap,
@@ -733,7 +716,7 @@ func (a *App) activeListForEntityType(entityType string) string {
 	return a.findListByEntityType(s, s.Cfg.Navigation, entityType)
 }
 
-func (a *App) findListByEntityType(s *AppState, entries []NavigationEntry, entityType string) string {
+func (a *App) findListByEntityType(s *Schema, entries []NavigationEntry, entityType string) string {
 	for _, nav := range entries {
 		if nav.IsGroup() {
 			if found := a.findListByEntityType(s, nav.Items, entityType); found != "" {

--- a/internal/dataentry/handlers_attachment.go
+++ b/internal/dataentry/handlers_attachment.go
@@ -300,7 +300,7 @@ func (a *App) probeAttachmentCommands(meta *metamodel.Metamodel, runner *attachm
 // the App's dependencies and the GIVEN state snapshot. Cheap (a struct
 // wrapper). Takes the snapshot explicitly so the service enforces the same
 // metamodel the handler gated on — see "capture state once per operation".
-func (a *App) attachmentService(s *AppState) (*attachment.Service, error) {
+func (a *App) attachmentService(s *Schema) (*attachment.Service, error) {
 	return attachment.New(attachment.Deps{
 		Store:         a.store,
 		Meta:          s.Meta,
@@ -313,7 +313,7 @@ func (a *App) attachmentService(s *AppState) (*attachment.Service, error) {
 
 // filePropertyDef returns the metamodel def for a property from the given
 // snapshot (callers gate on isFileProperty first, so a file def is expected).
-func filePropertyDef(s *AppState, typeName, property string) metamodel.PropertyDef {
+func filePropertyDef(s *Schema, typeName, property string) metamodel.PropertyDef {
 	if def, ok := s.Meta.GetEntityDef(typeName); ok {
 		return def.Properties[property]
 	}
@@ -419,7 +419,7 @@ func (a *App) attachmentWritePreflight(
 // promises a ceiling higher than the store will actually accept — a
 // misconfigured `max_attachment_bytes` above store.MaxAttachmentBytes
 // can't make the error message lie.
-func maxAttachmentBytes(s *AppState) int64 {
+func maxAttachmentBytes(s *Schema) int64 {
 	limit := int64(DefaultMaxAttachmentBytes)
 	if n := s.Cfg.App.MaxAttachmentBytes; n > 0 {
 		limit = n

--- a/internal/dataentry/handlers_theme_package.go
+++ b/internal/dataentry/handlers_theme_package.go
@@ -116,7 +116,7 @@ func (a *App) handleAPIThemeImport(w http.ResponseWriter, r *http.Request) {
 // buildExportManifest composes the manifest written into the zip,
 // drawing the palette from user state when available and falling back
 // to the project palette otherwise.
-func buildExportManifest(s *AppState, userPalette *PaletteConfig, logoExt string) *dataentryconfig.ThemeManifest {
+func buildExportManifest(s *Schema, userPalette *PaletteConfig, logoExt string) *dataentryconfig.ThemeManifest {
 	m := &dataentryconfig.ThemeManifest{
 		Name:    s.Cfg.App.Name,
 		Version: "1.0.0",

--- a/internal/dataentry/list_incoming_relation_test.go
+++ b/internal/dataentry/list_incoming_relation_test.go
@@ -93,7 +93,7 @@ func newIncomingRelApp(t *testing.T, entities []*entity.Entity, relations []*ent
 
 	app := &App{fieldResolver: NopFieldVerdictResolver{}}
 	rebindApp(app, fs, ctx, svc)
-	app.state.Store(&AppState{
+	app.schema.Publish(&Schema{
 		Cfg:        cfg,
 		Meta:       meta,
 		OpenAPIGen: openapi.New(meta, openapi.Config{Title: cfg.App.Name}),

--- a/internal/dataentry/schema.go
+++ b/internal/dataentry/schema.go
@@ -1,0 +1,69 @@
+package dataentry
+
+import (
+	"sync/atomic"
+
+	"github.com/Sourcehaven-BV/rela/internal/metamodel"
+	"github.com/Sourcehaven-BV/rela/internal/openapi"
+)
+
+// Schema is the co-derived reload core of the data-entry app: the config and
+// metamodel, plus everything that is a pure function of the two (the style map
+// and the OpenAPI generator). These MUST move together — the style map is
+// derived from (Cfg, Meta), so publishing them independently could let a reader
+// observe a new metamodel with a stale style map.
+//
+// It is the residue of the former AppState after the independently-owned state
+// (logo, palette, user defaults) moved into their own self-synchronized
+// services. Readers Load a coherent Schema once per request via
+// [schemaProvider.Current] (exposed on App as State()).
+type Schema struct {
+	Cfg         *Config
+	Meta        *metamodel.Metamodel
+	StyleMap    map[string]map[string]string
+	StyledTypes map[string]bool
+	OpenAPIGen  *openapi.Generator
+}
+
+// schemaProvider publishes the current [Schema] via an atomic.Pointer: readers
+// Load lock-free, the watcher's reload path swaps a freshly-derived Schema in
+// atomically. Owning the pointer here (rather than as a bare field on App)
+// keeps the state-publish mechanics and the reload derivation in one place.
+type schemaProvider struct {
+	ptr atomic.Pointer[Schema]
+}
+
+// Current returns the published Schema snapshot. Nil only before the initial
+// Publish (never in a running App).
+func (p *schemaProvider) Current() *Schema { return p.ptr.Load() }
+
+// Publish installs the initial snapshot. Called once during App construction.
+func (p *schemaProvider) Publish(s *Schema) { p.ptr.Store(s) }
+
+// Reload derives a fresh Schema from the (possibly changed) config and
+// metamodel and publishes it atomically. The style map and OpenAPI generator
+// are recomputed only when config or metamodel changed; otherwise the previous
+// derivations are carried forward unchanged. Returns the new Schema so the
+// caller can drive dependent recomputation (e.g. the palette) off the same
+// values.
+//
+// The OpenAPI generator is internally synchronized and reused in place
+// (UpdateMetamodel), matching the previous behavior.
+func (p *schemaProvider) Reload(newCfg *Config, newMeta *metamodel.Metamodel, derive bool) *Schema {
+	current := p.ptr.Load()
+	next := &Schema{
+		Cfg:         newCfg,
+		Meta:        newMeta,
+		StyleMap:    current.StyleMap,
+		StyledTypes: current.StyledTypes,
+		OpenAPIGen:  current.OpenAPIGen,
+	}
+	if derive {
+		next.StyleMap, next.StyledTypes = buildStyleMap(newCfg, newMeta)
+		if next.OpenAPIGen != nil {
+			next.OpenAPIGen.UpdateMetamodel(newMeta)
+		}
+	}
+	p.ptr.Store(next)
+	return next
+}

--- a/internal/dataentry/test_helpers_test.go
+++ b/internal/dataentry/test_helpers_test.go
@@ -205,13 +205,13 @@ func reseedStore(dst, src store.Store) {
 	}
 }
 
-// newAppFromParts builds an App with a populated AppState snapshot for
+// newAppFromParts builds an App with a populated Schema snapshot for
 // tests that previously used the struct-literal pattern
 // `&App{Cfg: cfg, meta: meta, g: g}`. The App.state pointer must be
 // populated because handlers now read from it; a nil snapshot would
 // nil-deref inside a.State().
 //
-// Populates ALL AppState fields with safe defaults (UserDefaults,
+// Populates the co-derived Schema fields with safe defaults (UserDefaults,
 // Palette, UserPalette, OpenAPIGen) so handlers that touch the
 // less-common fields don't nil-deref in tests that didn't ask for them.
 func newAppFromParts(cfg *Config, meta *metamodel.Metamodel, f *fixture) *App {
@@ -249,7 +249,7 @@ func newAppFromParts(cfg *Config, meta *metamodel.Metamodel, f *fixture) *App {
 	if app.palette != nil {
 		_ = app.palette.Reresolve(cfg.Palette)
 	}
-	app.state.Store(&AppState{
+	app.schema.Publish(&Schema{
 		Cfg:         cfg,
 		Meta:        meta,
 		StyleMap:    styleMap,
@@ -342,7 +342,7 @@ func newHandlerTestApp(t *testing.T) *App {
 	// Populate the snapshot fields handlers deref unconditionally — the
 	// router walk test hits every route, including _openapi.json, which
 	// panics on a nil OpenAPIGen.
-	app.state.Store(&AppState{
+	app.schema.Publish(&Schema{
 		Cfg:         cfg,
 		Meta:        meta,
 		StyleMap:    styleMap,

--- a/internal/dataentry/watcher.go
+++ b/internal/dataentry/watcher.go
@@ -274,9 +274,9 @@ func (a *App) StartGitFetch() (stop func()) {
 	}
 }
 
-// rebuildState re-reads changed inputs and publishes a fresh AppState
-// snapshot atomically. Readers observe either the pre-reload or the
-// post-reload snapshot, never a torn state.
+// rebuildState re-reads changed inputs and publishes a fresh Schema snapshot
+// atomically. Readers observe either the pre-reload or the post-reload
+// snapshot, never a torn state.
 func (a *App) rebuildState(configChanged, metaChanged bool) {
 	current := a.State()
 	if current == nil {
@@ -301,12 +301,12 @@ func (a *App) rebuildState(configChanged, metaChanged bool) {
 
 	newMeta := a.Meta()
 
-	newStyleMap := current.StyleMap
-	newStyledTypes := current.StyledTypes
-	newOpenAPI := current.OpenAPIGen
+	// The provider recomputes the style map + OpenAPI generator (co-derived
+	// from cfg/meta) when either changed, and publishes atomically.
+	derive := configChanged || metaChanged
+	a.schema.Reload(newCfg, newMeta, derive)
 
-	if configChanged || metaChanged {
-		newStyleMap, newStyledTypes = buildStyleMap(newCfg, newMeta)
+	if derive {
 		// Re-resolve the palette against the new project palette. The service
 		// keeps the previous user override if the on-disk file is broken —
 		// better to show stale colors than crash or wipe.
@@ -314,20 +314,7 @@ func (a *App) rebuildState(configChanged, metaChanged bool) {
 			slog.Warn("watcher: keeping previous user palette",
 				"file", userPaletteFile, "error", err)
 		}
-		// Update OpenAPI generator with new metamodel (the generator
-		// is internally synchronized; we reuse the same instance).
-		if newOpenAPI != nil {
-			newOpenAPI.UpdateMetamodel(newMeta)
-		}
 	}
-
-	a.state.Store(&AppState{
-		Cfg:         newCfg,
-		Meta:        newMeta,
-		StyleMap:    newStyleMap,
-		StyledTypes: newStyledTypes,
-		OpenAPIGen:  newOpenAPI,
-	})
 }
 
 // handleSSE serves Server-Sent Events for live-reload notifications.

--- a/internal/dataentry/watcher_test.go
+++ b/internal/dataentry/watcher_test.go
@@ -526,7 +526,7 @@ func TestConcurrentReadDuringOnReload(t *testing.T) {
 						s.Cfg != nil, s.Meta != nil)
 					return
 				}
-				// Cross-field invariant: a published AppState always
+				// Cross-field invariant: a published Schema always
 				// has a StyleMap that covers every property type in
 				// its metamodel. A torn publish would yield zero or
 				// fewer entries.

--- a/tickets/entities/tickets/TKT-XSWFXQ.md
+++ b/tickets/entities/tickets/TKT-XSWFXQ.md
@@ -57,4 +57,4 @@ methods. The method-count ratchet is the handler-split follow-up
 - [x] `logoStore` (PR #1105)
 - [x] `paletteService` (PR #1107)
 - [x] `settingsService` + delete `mutateState` (PR #1109)
-- [ ] `schemaProvider` collapses `AppState` (PR #1110)
+- [x] `schemaProvider` collapses `AppState` (PR #1110)


### PR DESCRIPTION
**PR 4 (final) of the AppState decomposition.** Stacks on #1109 → #1107 → #1105. Merge those first.

## Why

After logo/palette/defaults moved into their own services (#1105–#1109), the residual `AppState` is exactly the **co-derived reload core**: `Cfg`, `Meta`, and the things that are pure functions of them — `StyleMap`/`StyledTypes` (`buildStyleMap(Cfg, Meta)`) and `OpenAPIGen` (`openapi.New(Meta)`). These *must* publish together, or a reader could observe a new metamodel with a stale style map.

Extracting style/openapi into standalone services (the original PR4 plan) would only re-fold `Cfg`/`Meta` around them in PR5 — churn. So this merges the two: give the whole co-derived core **one owner**.

## What

- Rename `AppState` → **`Schema`** and move the `atomic.Pointer` + reload derivation off `App` into a **`schemaProvider`** (`Current` / `Publish` / `Reload`). The style-map + OpenAPI recomputation now lives inside `Reload`.
- `App.State()` delegates to `schema.Current()`, so **all ~300 `a.State().Meta` / `a.State().Cfg` readers stay verbatim** — no churn at the call sites.
- `rebuildState` collapses to `a.schema.Reload(cfg, meta, derive)` + `a.palette.Reresolve(cfg.Palette)`.
- Removes the bare `state atomic.Pointer[AppState]` field and the now-unused `sync/atomic` import from `App`.

Behavior preserved: reload still publishes unconditionally (production always calls with `derive=true`), OpenAPI generator still updated in place, palette still re-resolves against the new project palette with the same stale-on-error fallback.

## The arc, complete

Across #1105 → #1107 → #1109 → this PR:
- `AppState` (8 fields, a grab-bag) → `Schema` (5 co-derived fields, one owner).
- logo / palette / user-defaults each own their state behind their own mutex.
- **`mutateState` and the publish-side `writeMu` coupling are gone.**

(`writeMu`'s remaining uses are Job-2 — entity-write serialization — a separate concern. And the plimsoll App method-line is unchanged by this arc: it cuts state/fields, not methods; the method ratchet is the handler-split work under TKT-N26KLB.)

## Verification

- `go build ./...` (+ `-tags postgres`, `-tags memorybackend`) ✅
- `go test -race ./internal/dataentry/...` ✅
- `just arch-lint` ✅ · `just plimsoll` ✅ · `golangci-lint` → 0 issues