### PR TITLE
chore(lint): enable modernize omitzero + fix findings (TKT-QXHFJZ)

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -171,13 +171,6 @@ linters:
       ignored-functions:
         - strings.SplitN
         - make
-    modernize:
-      # omitzero flags `omitempty` on nested struct fields (a latent
-      # marshaling bug, not a mechanical simplification). It needs a
-      # per-site decision about the intended wire shape, so it is
-      # triaged separately rather than auto-fixed. See TKT (omitzero triage).
-      disable:
-        - omitzero
     nakedret:
       max-func-lines: 30
     nestif:

--- a/internal/dataentry/api_v1.go
+++ b/internal/dataentry/api_v1.go
@@ -659,7 +659,7 @@ func (a *App) handleV1CreateEntity(w http.ResponseWriter, r *http.Request, typeN
 		Prefix     string            `json:"prefix,omitempty"`
 		Properties map[string]any    `json:"properties"`
 		Content    string            `json:"content,omitempty"`
-		Relations  v1.RelationsField `json:"relations,omitempty"`
+		Relations  v1.RelationsField `json:"relations"`
 	}
 
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
@@ -1059,7 +1059,7 @@ func (a *App) handleV1UpdateEntity(w http.ResponseWriter, r *http.Request, typeN
 		Properties      map[string]any    `json:"properties,omitempty"`
 		PropertiesUnset []string          `json:"properties_unset,omitempty"`
 		Content         *string           `json:"content,omitempty"`
-		Relations       v1.RelationsField `json:"relations,omitempty"`
+		Relations       v1.RelationsField `json:"relations"`
 	}
 
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {

--- a/internal/dataentryconfig/palette.go
+++ b/internal/dataentryconfig/palette.go
@@ -25,7 +25,11 @@ var ValidBadgeNames = map[string]bool{
 type PaletteConfig struct {
 	PaletteColors `yaml:",inline"`
 	Badges        map[string]string `yaml:"badges,omitempty" json:"badges,omitempty"`
-	Dark          DarkMode          `yaml:"dark,omitempty"   json:"dark,omitempty"`
+	// Dark is a struct, so json `omitempty` would not omit it (it has no
+	// effect on struct fields); `omitzero` omits a zero-value DarkMode,
+	// which is the intended "no dark config" behavior. Its MarshalJSON
+	// still renders a non-zero value as `false` or an explicit palette.
+	Dark DarkMode `yaml:"dark,omitempty" json:"dark,omitzero"`
 }
 
 // PaletteColors holds the 8 named color roles. All fields are optional;
@@ -106,7 +110,8 @@ func (d DarkMode) MarshalYAML() (any, error) {
 
 // MarshalJSON serializes DarkMode to JSON. Returns `false` or the
 // explicit PaletteColors object. A zero-value DarkMode marshals to
-// `null` (omitted in `omitempty` contexts).
+// `null`; the enclosing field uses `json:",omitzero"` so an unset
+// DarkMode is omitted entirely rather than emitted as `"dark":null`.
 func (d DarkMode) MarshalJSON() ([]byte, error) {
 	if d.Explicit != nil {
 		return json.Marshal(d.Explicit)

--- a/internal/entity/entity.go
+++ b/internal/entity/entity.go
@@ -45,7 +45,7 @@ type Entity struct {
 	Type         string              `json:"type"`
 	Properties   map[string]any      `json:"properties,omitempty"`
 	Content      string              `json:"content,omitempty"`
-	UpdatedAt    time.Time           `json:"updated_at,omitempty"`
+	UpdatedAt    time.Time           `json:"updated_at,omitzero"`
 	Inaccessible []InaccessibleField `json:"inaccessible,omitempty"`
 }
 
@@ -211,7 +211,7 @@ type Relation struct {
 	To           string              `json:"to"`
 	Properties   map[string]any      `json:"properties,omitempty"`
 	Content      string              `json:"content,omitempty"`
-	UpdatedAt    time.Time           `json:"updated_at,omitempty"`
+	UpdatedAt    time.Time           `json:"updated_at,omitzero"`
 	Inaccessible []InaccessibleField `json:"inaccessible,omitempty"`
 }
 

--- a/tickets/entities/tickets/TKT-QXHFJZ.md
+++ b/tickets/entities/tickets/TKT-QXHFJZ.md
@@ -1,0 +1,63 @@
+---
+id: TKT-QXHFJZ
+type: ticket
+title: 'Triage modernize omitzero findings: omitempty on non-omittable fields'
+kind: chore
+priority: low
+effort: xs
+status: ready
+---
+
+## Description
+
+The `modernize` linter (enabled in the modernize-autofix PR) has an `omitzero`
+analyzer that flags `,omitempty` JSON tags on fields where `omitempty` has no
+effect — most commonly struct-typed fields like `time.Time`, which `omitempty`
+never omits (a zero `time.Time` still marshals to `"0001-01-01T00:00:00Z"`).
+
+`omitzero` was **disabled** in `.golangci.yml` when modernize was enabled,
+because — unlike the other modernize analyzers — its fix is behavior-adjacent
+(it changes wire output), not a pure mechanical rewrite. This ticket triages and
+applies the three findings.
+
+## Findings
+
+| Site | Field | Correct fix |
+|------|-------|-------------|
+| `internal/entity/entity.go:48` | `Entity.UpdatedAt time.Time` `json:"updated_at,omitempty"` | switch to `,omitzero` (Go 1.24+) |
+| `internal/entity/entity.go:214` | `Relation.UpdatedAt time.Time` `json:"updated_at,omitempty"` | switch to `,omitzero` |
+| `internal/dataentry/api_v1.go:662` | request DTO `Relations v1.RelationsField` `json:"relations,omitempty"` | drop `,omitempty` (decode-only struct) |
+
+## Analysis
+
+**The two `time.Time` fields** — `omitempty` silently does nothing on a struct,
+so a zero `UpdatedAt` currently serializes as `"0001-01-01T00:00:00Z"` in the
+CLI `-o json` output and MCP export paths (`internal/output/output.go`,
+`internal/mcp/convert.go` — the API/wire layer uses its own `apiwire/v1.Entity`,
+not these tags). Switching to `,omitzero` makes it actually omit the key when
+unset, which is clearly the original intent. This **is** a wire-output change
+(the `0001-...` string disappears when the timestamp is zero), but:
+
+- no golden/snapshot test asserts `updated_at` in JSON output (grep-verified),
+- the emitted zero-value string was never meaningful,
+
+so it is a safe, intent-preserving fix.
+
+**The `api_v1.go` request struct** is decode-only
+(`json.NewDecoder(...).Decode`); `omitempty` only affects *encoding*, so the tag
+is inert here regardless. The field has a custom `UnmarshalJSON` + `IsEmpty()`.
+The right fix is to just drop the pointless `,omitempty` rather than add
+`,omitzero` to a struct that is never marshaled.
+
+## Approach
+
+1. `entity.go` ×2: `,omitempty` → `,omitzero` on the `UpdatedAt time.Time` fields.
+2. `api_v1.go`: drop `,omitempty` from the decode-only `Relations` field.
+3. Remove the `omitzero` entry from the `modernize.disable` list in `.golangci.yml`.
+4. `golangci-lint run ./...` → 0 issues; `go test ./...`.
+
+## Context
+
+Follow-up to the modernize-linter enablement PR (sibling to TKT-AHUNF "Enable
+additional golangci-lint v2 linters"). Deferred from that PR precisely because
+these three are the non-mechanical residue of the modernize suite.

--- a/tickets/relations/TKT-QXHFJZ--affects--ci-pipeline.md
+++ b/tickets/relations/TKT-QXHFJZ--affects--ci-pipeline.md
@@ -1,0 +1,5 @@
+---
+from: TKT-QXHFJZ
+relation: affects
+to: ci-pipeline
+---

--- a/tickets/relations/TKT-QXHFJZ--implements--FEAT-022.md
+++ b/tickets/relations/TKT-QXHFJZ--implements--FEAT-022.md
@@ -1,0 +1,5 @@
+---
+from: TKT-QXHFJZ
+relation: implements
+to: FEAT-022
+---


### PR DESCRIPTION
## Summary

Re-enables the `modernize` **`omitzero`** analyzer (disabled in the modernize-autofix PR pending triage) and fixes its findings. Implements **TKT-QXHFJZ**.

> **Stacked on #1108** (`chore/modernize-autofix`), which is stacked on #1106. Merge order: #1106 → #1108 → this.

`omitzero` flags `,omitempty` on fields where it has no effect (structs — `omitempty` never omits a struct). The findings split into three intents:

| Site | Fix | Why |
|------|-----|-----|
| `entity.go` — `Entity.UpdatedAt` / `Relation.UpdatedAt` (`time.Time`) | `,omitempty` → `,omitzero` | `omitempty` never omitted the timestamp; a zero `UpdatedAt` currently serializes as `"0001-01-01T00:00:00Z"` in CLI `-o json` / MCP export. `omitzero` omits it, matching intent. |
| `api_v1.go` ×2 — `Relations v1.RelationsField` on decode-only request structs | drop `,omitempty` | `omitempty` only affects encoding; these structs are only ever decoded, so the tag was inert. |
| `palette.go` — `PaletteConfig.Dark DarkMode` | `,omitempty` → `,omitzero` (+ doc fix) | `PaletteConfig` is marshaled to the SPA; `omitempty` on the `DarkMode` struct never omitted it, so an unset dark config emitted `"dark":null`. `omitzero` omits it. Corrected the now-accurate `MarshalJSON` doc comment. |

**Wire-output change** (intended): zero `UpdatedAt` and unset `Dark` are now omitted from JSON rather than emitted as `"0001-..."` / `"dark":null`. No golden/snapshot test asserted those; all round-trip tests use non-zero values and are unaffected.

## Verification

- `golangci-lint run ./...` (clean cache) → **0 issues** (`omitzero` now enabled repo-wide)
- `go build ./...` → OK
- `go test ./...` → **69 packages pass**

## Notes

The ticket `TKT-QXHFJZ` (with `affects`→`ci-pipeline`, `implements`→`FEAT-022`) is included in-tree under `tickets/` since this repo dogfoods rela for issue tracking. All `analyze_*` checks pass for it.