### PR TITLE
fix(dataentry): gate hidden neighbors on /relations endpoints (BUG-ABXMAV)

### DIFF
--- a/internal/dataentry/acl_relations_neighbor_test.go
+++ b/internal/dataentry/acl_relations_neighbor_test.go
@@ -1,0 +1,312 @@
+package dataentry
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/Sourcehaven-BV/rela/internal/acl"
+	"github.com/Sourcehaven-BV/rela/internal/entity"
+)
+
+// seedNeighborLeakFixture builds the standard hidden-neighbor scenario shared by
+// the /relations reproduction test and the cross-endpoint invariant test:
+//
+//   - alice is editor-of PRJ-42; the editor role reads tickets + features,
+//     inherited through belongs-to. Entities belonging to PRJ-42 are visible;
+//     entities belonging to PRJ-9 are hidden.
+//   - TKT-VIS (visible ticket) implements FEAT-VIS (visible) and FEAT-HIDDEN
+//     (hidden) — the OUTGOING-target leak case.
+//   - FEAT-VIS (visible feature) is implemented by TKT-VIS (visible) and
+//     TKT-HIDDEN (hidden) — the INCOMING-source (inverse-key) leak case.
+//
+// Returns the constructed ACL declarative wired into the app.
+func seedNeighborLeakFixture(t *testing.T, app *App) *acl.Declarative {
+	t.Helper()
+
+	seedEntity(app, &entity.Entity{ID: "alice", Type: "person", Properties: map[string]any{"title": "Alice"}})
+	seedEntity(app, &entity.Entity{ID: "PRJ-42", Type: "project", Properties: map[string]any{"title": "Granted"}})
+	seedEntity(app, &entity.Entity{ID: "PRJ-9", Type: "project", Properties: map[string]any{"title": "Hidden"}})
+	seedRelation(app, entity.NewRelation("alice", "editor-of", "PRJ-42"))
+
+	seedEntity(app, &entity.Entity{ID: "TKT-VIS", Type: "ticket", Properties: map[string]any{"title": "Visible ticket"}})
+	seedEntity(app, &entity.Entity{ID: "FEAT-VIS", Type: "feature", Properties: map[string]any{"title": "Visible feature"}})
+	seedEntity(app, &entity.Entity{ID: "FEAT-HIDDEN", Type: "feature", Properties: map[string]any{"title": "Hidden feature"}})
+	seedEntity(app, &entity.Entity{ID: "TKT-HIDDEN", Type: "ticket", Properties: map[string]any{"title": "Hidden ticket"}})
+
+	seedRelation(app, entity.NewRelation("TKT-VIS", "belongs-to", "PRJ-42"))
+	seedRelation(app, entity.NewRelation("FEAT-VIS", "belongs-to", "PRJ-42"))
+	seedRelation(app, entity.NewRelation("FEAT-HIDDEN", "belongs-to", "PRJ-9"))
+	seedRelation(app, entity.NewRelation("TKT-HIDDEN", "belongs-to", "PRJ-9"))
+
+	// Outgoing-target case (ticket row TKT-VIS).
+	seedRelation(app, entity.NewRelation("TKT-VIS", "implements", "FEAT-HIDDEN"))
+	seedRelation(app, entity.NewRelation("TKT-VIS", "implements", "FEAT-VIS"))
+
+	// Incoming-source case (feature row FEAT-VIS).
+	seedRelation(app, entity.NewRelation("TKT-HIDDEN", "implements", "FEAT-VIS"))
+
+	d := mustNewACL(t, &acl.Policy{
+		Roles: map[string]acl.RoleDef{"editor": {Read: []string{"ticket", "feature"}}},
+		RoleRelations: map[string]acl.RoleRelationDef{
+			"editor-of": {Confers: "editor"},
+		},
+		InheritRolesThrough: []string{"belongs-to"},
+	}, app.store)
+	app.acl = d
+	return d
+}
+
+// getRelationsAs drives handleV1EntityRelations under the given principal's
+// gate context and returns the decoded grouped-relations map.
+func getRelationsAs(t *testing.T, app *App, d *acl.Declarative,
+	typeName, plural, entityID string,
+) map[string][]map[string]any {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/"+plural+"/"+entityID+"/relations", http.NoBody)
+	req = req.WithContext(gateCtxFor(aliceCtx(), t, d))
+	rec := httptest.NewRecorder()
+	app.handleV1EntityRelations(rec, req, typeName, entityID)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET %s/%s/relations: %d %s", plural, entityID, rec.Code, rec.Body)
+	}
+	var out map[string][]map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &out); err != nil {
+		t.Fatalf("decode relations map: %v; body=%s", err, rec.Body)
+	}
+	return out
+}
+
+// getRelationTypeAs drives handleV1GetRelationType under the given principal's
+// gate context and returns the decoded per-type relation list. direction is
+// "" for outgoing or "incoming".
+func getRelationTypeAs(t *testing.T, app *App, d *acl.Declarative,
+	typeName, plural, entityID, relType, direction string,
+) []map[string]any {
+	t.Helper()
+	url := "/api/v1/" + plural + "/" + entityID + "/relations/" + relType
+	if direction != "" {
+		url += "?direction=" + direction
+	}
+	req := httptest.NewRequest(http.MethodGet, url, http.NoBody)
+	req = req.WithContext(gateCtxFor(aliceCtx(), t, d))
+	rec := httptest.NewRecorder()
+	app.handleV1GetRelationType(rec, req, typeName, entityID, relType)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET %s/%s/relations/%s: %d %s", plural, entityID, relType, rec.Code, rec.Body)
+	}
+	var out []map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &out); err != nil {
+		t.Fatalf("decode relation list: %v; body=%s", err, rec.Body)
+	}
+	return out
+}
+
+func relIDs(rels []map[string]any) []string {
+	ids := make([]string, 0, len(rels))
+	for _, r := range rels {
+		if id, ok := r["id"].(string); ok {
+			ids = append(ids, id)
+		}
+	}
+	return ids
+}
+
+// TestACLRelations_HiddenNeighborExcluded is the reproduction pin for
+// BUG-ABXMAV: the dedicated /relations and /relations/{relType} endpoints
+// leaked a hidden neighbor's `type` and edge `meta` past the source-only read
+// gate. This test asserts the hidden neighbor is fully absent (id, type, meta)
+// for BOTH outgoing and incoming (inverse-key) directions, on BOTH endpoints,
+// while the visible neighbor is still returned (no over-filtering).
+func TestACLRelations_HiddenNeighborExcluded(t *testing.T) {
+	app := newTestAppV1(t)
+	d := seedNeighborLeakFixture(t, app)
+
+	t.Run("grouped /relations excludes hidden outgoing target, keeps visible", func(t *testing.T) {
+		rels := getRelationsAs(t, app, d, "ticket", "tickets", "TKT-VIS")
+		impl := rels["implements"]
+		ids := relIDs(impl)
+		if containsID(ids, "FEAT-HIDDEN") {
+			t.Errorf("/relations leaks hidden outgoing target FEAT-HIDDEN: %v", impl)
+		}
+		if !containsID(ids, "FEAT-VIS") {
+			t.Errorf("/relations over-filtered visible target FEAT-VIS: %v", impl)
+		}
+		assertNoHiddenType(t, impl)
+	})
+
+	t.Run("grouped /relations excludes hidden incoming source, keeps visible", func(t *testing.T) {
+		rels := getRelationsAs(t, app, d, "feature", "features", "FEAT-VIS")
+		src := rels["implements_inverse"]
+		ids := relIDs(src)
+		if containsID(ids, "TKT-HIDDEN") {
+			t.Errorf("/relations leaks hidden incoming source TKT-HIDDEN: %v", src)
+		}
+		if !containsID(ids, "TKT-VIS") {
+			t.Errorf("/relations over-filtered visible source TKT-VIS: %v", src)
+		}
+		assertNoHiddenType(t, src)
+	})
+
+	t.Run("/relations/{relType} outgoing excludes hidden target, keeps visible", func(t *testing.T) {
+		rels := getRelationTypeAs(t, app, d, "ticket", "tickets", "TKT-VIS", "implements", "")
+		ids := relIDs(rels)
+		if containsID(ids, "FEAT-HIDDEN") {
+			t.Errorf("/relations/implements leaks hidden target FEAT-HIDDEN: %v", rels)
+		}
+		if !containsID(ids, "FEAT-VIS") {
+			t.Errorf("/relations/implements over-filtered visible target FEAT-VIS: %v", rels)
+		}
+		assertNoHiddenType(t, rels)
+	})
+
+	t.Run("/relations/{relType} incoming excludes hidden source, keeps visible", func(t *testing.T) {
+		rels := getRelationTypeAs(t, app, d, "feature", "features", "FEAT-VIS", "implements", "incoming")
+		ids := relIDs(rels)
+		if containsID(ids, "TKT-HIDDEN") {
+			t.Errorf("/relations/implements?incoming leaks hidden source TKT-HIDDEN: %v", rels)
+		}
+		if !containsID(ids, "TKT-VIS") {
+			t.Errorf("/relations/implements?incoming over-filtered visible source TKT-VIS: %v", rels)
+		}
+		assertNoHiddenType(t, rels)
+	})
+}
+
+// assertNoHiddenType checks no relation entry carries the hidden peers' types.
+// Both hidden peers have distinctive types (feature/ticket) but the load-bearing
+// assertion is that the specific hidden IDs never appear with a resolved type;
+// this helper double-checks that no entry names a hidden ID at all.
+func assertNoHiddenType(t *testing.T, rels []map[string]any) {
+	t.Helper()
+	for _, r := range rels {
+		if id, _ := r["id"].(string); id == "FEAT-HIDDEN" || id == "TKT-HIDDEN" {
+			t.Errorf("hidden peer %q present in relation entry %v", id, r)
+		}
+	}
+}
+
+// TestACLNeighborReadLeakInvariant (AM-acl-neighbor-read-leak-invariant) is the
+// cross-endpoint P4 invariant: with ONE hidden-neighbor fixture, every
+// neighbor-emitting read endpoint is exercised and asserted not to leak the
+// hidden neighbor's TYPE or META. It is structured so a future neighbor-emitting
+// endpoint is added to the `endpoints` table and immediately covered.
+//
+// The accepted exception (dataentry/CLAUDE.md, acl_get_test.go ~L149): the raw
+// neighbor ID may appear in the single-entity GET's IDs-only relations map and
+// in the list-row top-level relations map. That exception is encoded explicitly
+// below (allowBareID). What must NEVER leak on ANY endpoint is the hidden
+// neighbor's TYPE or edge META — and the dedicated /relations endpoints must
+// leak nothing at all about a hidden peer (not even the bare ID).
+func TestACLNeighborReadLeakInvariant(t *testing.T) {
+	const (
+		hiddenFeature = "FEAT-HIDDEN"
+		hiddenTicket  = "TKT-HIDDEN"
+	)
+
+	// Endpoint fixtures: each returns the raw response body as a string. We
+	// scan the body for the hidden peers' identifiers. TYPE leakage would show
+	// the hidden peer's id paired with a "type" field; the dedicated /relations
+	// endpoints must not even name the hidden id.
+	endpoints := []struct {
+		name string
+		// allowBareID: the accepted exception — the hidden neighbor's bare ID
+		// may appear (single-GET relations map, list-row relations map), but
+		// its TYPE and META must not. When false, the hidden ID must be fully
+		// absent from the body.
+		allowBareID bool
+		body        func(t *testing.T, app *App, d *acl.Declarative) string
+	}{
+		{
+			name:        "list rows",
+			allowBareID: true, // top-level relations map is IDs-only; type/meta never emitted here
+			body: func(t *testing.T, app *App, d *acl.Declarative) string {
+				_, rec := listEntitiesAs(aliceCtx(), t, app, d, "feature", "features", "")
+				return rec.Body.String()
+			},
+		},
+		{
+			name:        "list rows with include",
+			allowBareID: true, // include map is visibility-filtered; bare ID may still key the relations map
+			body: func(t *testing.T, app *App, d *acl.Declarative) string {
+				_, rec := listEntitiesAs(aliceCtx(), t, app, d, "feature", "features", "include=*")
+				return rec.Body.String()
+			},
+		},
+		{
+			name:        "single-entity GET",
+			allowBareID: true, // per-entity GET ships an IDs-only relations map (accepted, CLAUDE.md)
+			body: func(t *testing.T, app *App, d *acl.Declarative) string {
+				rec := getEntityAs(aliceCtx(), t, app, d, "feature", "features", "FEAT-VIS", "include=*")
+				return rec.Body.String()
+			},
+		},
+		{
+			name:        "/relations grouped",
+			allowBareID: false, // dedicated endpoint must leak nothing about a hidden peer
+			body: func(t *testing.T, app *App, d *acl.Declarative) string {
+				req := httptest.NewRequest(http.MethodGet, "/api/v1/features/FEAT-VIS/relations", http.NoBody)
+				req = req.WithContext(gateCtxFor(aliceCtx(), t, d))
+				rec := httptest.NewRecorder()
+				app.handleV1EntityRelations(rec, req, "feature", "FEAT-VIS")
+				return rec.Body.String()
+			},
+		},
+		{
+			name:        "/relations/{relType} incoming",
+			allowBareID: false,
+			body: func(t *testing.T, app *App, d *acl.Declarative) string {
+				req := httptest.NewRequest(http.MethodGet,
+					"/api/v1/features/FEAT-VIS/relations/implements?direction=incoming", http.NoBody)
+				req = req.WithContext(gateCtxFor(aliceCtx(), t, d))
+				rec := httptest.NewRecorder()
+				app.handleV1GetRelationType(rec, req, "feature", "FEAT-VIS", "implements")
+				return rec.Body.String()
+			},
+		},
+		{
+			name:        "/relations/{relType} outgoing",
+			allowBareID: false,
+			body: func(t *testing.T, app *App, d *acl.Declarative) string {
+				req := httptest.NewRequest(http.MethodGet,
+					"/api/v1/tickets/TKT-VIS/relations/implements", http.NoBody)
+				req = req.WithContext(gateCtxFor(aliceCtx(), t, d))
+				rec := httptest.NewRecorder()
+				app.handleV1GetRelationType(rec, req, "ticket", "TKT-VIS", "implements")
+				return rec.Body.String()
+			},
+		},
+	}
+
+	for _, ep := range endpoints {
+		t.Run(ep.name, func(t *testing.T) {
+			app := newTestAppV1(t)
+			d := seedNeighborLeakFixture(t, app)
+			body := ep.body(t, app, d)
+
+			// A hidden neighbor's serialized entity (with its type) must never
+			// leak. In the JSON:API `included` map the hidden entity would be
+			// keyed by its ID with a full "type"/"attributes" object; we assert
+			// no `included` entry names a hidden peer.
+			if strings.Contains(body, `"included":`) {
+				for _, hid := range []string{hiddenFeature, hiddenTicket} {
+					if strings.Contains(body, `"`+hid+`":`) {
+						t.Errorf("%s: hidden peer %q serialized in included map; body=%s", ep.name, hid, body)
+					}
+				}
+			}
+
+			if !ep.allowBareID {
+				// Dedicated /relations endpoints must not name the hidden peer
+				// at all — not the id, and therefore not its type or meta.
+				for _, hid := range []string{hiddenFeature, hiddenTicket} {
+					if strings.Contains(body, hid) {
+						t.Errorf("%s: hidden peer %q leaked (id/type/meta); body=%s", ep.name, hid, body)
+					}
+				}
+			}
+		})
+	}
+}

--- a/internal/dataentry/acl_relations_neighbor_test.go
+++ b/internal/dataentry/acl_relations_neighbor_test.go
@@ -223,6 +223,7 @@ func TestACLNeighborReadLeakInvariant(t *testing.T) {
 			name:        "list rows",
 			allowBareID: true, // top-level relations map is IDs-only; type/meta never emitted here
 			body: func(t *testing.T, app *App, d *acl.Declarative) string {
+				t.Helper()
 				_, rec := listEntitiesAs(aliceCtx(), t, app, d, "feature", "features", "")
 				return rec.Body.String()
 			},
@@ -231,6 +232,7 @@ func TestACLNeighborReadLeakInvariant(t *testing.T) {
 			name:        "list rows with include",
 			allowBareID: true, // include map is visibility-filtered; bare ID may still key the relations map
 			body: func(t *testing.T, app *App, d *acl.Declarative) string {
+				t.Helper()
 				_, rec := listEntitiesAs(aliceCtx(), t, app, d, "feature", "features", "include=*")
 				return rec.Body.String()
 			},
@@ -239,6 +241,7 @@ func TestACLNeighborReadLeakInvariant(t *testing.T) {
 			name:        "single-entity GET",
 			allowBareID: true, // per-entity GET ships an IDs-only relations map (accepted, CLAUDE.md)
 			body: func(t *testing.T, app *App, d *acl.Declarative) string {
+				t.Helper()
 				rec := getEntityAs(aliceCtx(), t, app, d, "feature", "features", "FEAT-VIS", "include=*")
 				return rec.Body.String()
 			},
@@ -247,6 +250,7 @@ func TestACLNeighborReadLeakInvariant(t *testing.T) {
 			name:        "/relations grouped",
 			allowBareID: false, // dedicated endpoint must leak nothing about a hidden peer
 			body: func(t *testing.T, app *App, d *acl.Declarative) string {
+				t.Helper()
 				req := httptest.NewRequest(http.MethodGet, "/api/v1/features/FEAT-VIS/relations", http.NoBody)
 				req = req.WithContext(gateCtxFor(aliceCtx(), t, d))
 				rec := httptest.NewRecorder()
@@ -258,6 +262,7 @@ func TestACLNeighborReadLeakInvariant(t *testing.T) {
 			name:        "/relations/{relType} incoming",
 			allowBareID: false,
 			body: func(t *testing.T, app *App, d *acl.Declarative) string {
+				t.Helper()
 				req := httptest.NewRequest(http.MethodGet,
 					"/api/v1/features/FEAT-VIS/relations/implements?direction=incoming", http.NoBody)
 				req = req.WithContext(gateCtxFor(aliceCtx(), t, d))
@@ -270,6 +275,7 @@ func TestACLNeighborReadLeakInvariant(t *testing.T) {
 			name:        "/relations/{relType} outgoing",
 			allowBareID: false,
 			body: func(t *testing.T, app *App, d *acl.Declarative) string {
+				t.Helper()
 				req := httptest.NewRequest(http.MethodGet,
 					"/api/v1/tickets/TKT-VIS/relations/implements", http.NoBody)
 				req = req.WithContext(gateCtxFor(aliceCtx(), t, d))

--- a/internal/dataentry/api_v1.go
+++ b/internal/dataentry/api_v1.go
@@ -1272,6 +1272,19 @@ func (a *App) handleV1EntityRelations(w http.ResponseWriter, r *http.Request, ty
 	outgoing := a.reader.outgoingRelations(r.Context(), entityID)
 	incoming := a.reader.incomingRelations(r.Context(), entityID)
 
+	// Gate hidden neighbors (BUG-ABXMAV / RR-HJV8CP). Without this, a hidden
+	// peer's `type` (via the ungated entityType read) and edge `meta` leak past
+	// the source-only read gate. Mirror the list path (handleV1ListEntities):
+	// compute the visible neighbor set in one type-batched pass and drop any
+	// edge whose peer is not visible BEFORE reading its type. A visible neighbor
+	// stays; a hidden one is dropped (no over-filtering).
+	// TODO(BUG-ABXMAV): the "gate a set of neighbor edges" step is now
+	// replicated here, in handleV1GetRelationType, and in the list path — a
+	// shared chokepoint (P3) would collapse the three; deferred to avoid
+	// churning the list path in a security fix.
+	visibleNeighbors := visibleRelationIDs(r.Context(), a.reader, a.visibleReader,
+		neighborIDsOf(outgoing, incoming))
+
 	relations := make(map[string][]map[string]interface{})
 
 	// Track the sort property per group, derived from the relation type's
@@ -1279,6 +1292,9 @@ func (a *App) handleV1EntityRelations(w http.ResponseWriter, r *http.Request, ty
 	groupSortProp := make(map[string]string)
 
 	for _, edge := range outgoing {
+		if !visibleNeighbors[edge.To] {
+			continue
+		}
 		rel := map[string]interface{}{
 			"id":        edge.To,
 			"type":      a.reader.entityType(r.Context(), edge.To),
@@ -1296,6 +1312,9 @@ func (a *App) handleV1EntityRelations(w http.ResponseWriter, r *http.Request, ty
 	}
 
 	for _, edge := range incoming {
+		if !visibleNeighbors[edge.From] {
+			continue
+		}
 		relDef, ok := s.Meta.Relations[edge.Type]
 		if !ok {
 			continue
@@ -1396,6 +1415,24 @@ func (a *App) handleV1GetRelationType(w http.ResponseWriter, r *http.Request, ty
 		edges = a.reader.outgoingRelations(r.Context(), entityID)
 	}
 
+	// Gate hidden neighbors (BUG-ABXMAV / RR-HJV8CP): same rationale as
+	// handleV1EntityRelations. Collect this relation-type's peers and compute
+	// the visible set in one batched pass, then skip any hidden peer BEFORE
+	// reading its type (so its type/meta never reach the wire). See the
+	// shared-chokepoint TODO in handleV1EntityRelations.
+	var peerIDs []string
+	for _, edge := range edges {
+		if edge.Type != relType {
+			continue
+		}
+		peerID := edge.To
+		if incoming {
+			peerID = edge.From
+		}
+		peerIDs = append(peerIDs, peerID)
+	}
+	visibleNeighbors := visibleRelationIDs(r.Context(), a.reader, a.visibleReader, peerIDs)
+
 	relations := make([]map[string]interface{}, 0, len(edges))
 
 	for _, edge := range edges {
@@ -1405,6 +1442,9 @@ func (a *App) handleV1GetRelationType(w http.ResponseWriter, r *http.Request, ty
 		peerID := edge.To
 		if incoming {
 			peerID = edge.From
+		}
+		if !visibleNeighbors[peerID] {
+			continue
 		}
 		rel := map[string]interface{}{
 			"id":   peerID,

--- a/tickets/entities/automated-measures/AM-acl-neighbor-read-leak-invariant.md
+++ b/tickets/entities/automated-measures/AM-acl-neighbor-read-leak-invariant.md
@@ -1,0 +1,9 @@
+---
+id: AM-acl-neighbor-read-leak-invariant
+type: automated-measure
+title: 'Integration test: no neighbor-emitting read endpoint leaks a hidden neighbor'
+description: Enumerates every neighbor-emitting read endpoint (list, ?include=, /relations, /relations/{type}, single-GET) with a hidden-neighbor fixture and asserts no hidden peer's id/type/meta appears on any of them. Catches any future neighbor-emitting endpoint that fails open (the class that produced BUG-ABXMAV). P4 invariant test.
+kind: test
+location: internal/dataentry (integration test, added in the BUG-ABXMAV fix PR)
+status: proposed
+---

--- a/tickets/entities/bugs/BUG-ABXMAV.md
+++ b/tickets/entities/bugs/BUG-ABXMAV.md
@@ -1,0 +1,27 @@
+---
+id: BUG-ABXMAV
+type: bug
+title: /relations endpoints leak hidden-neighbor type + edge meta past the read gate
+description: |-
+    handleV1EntityRelations (api_v1.go:1255-1327) and handleV1GetRelationType (api_v1.go:1378-1433) gate only the SOURCE entity via gateReadOrNotFound, then emit each neighbor's id, type (via the deliberately-ungated entityReader.entityType, entityreader.go:37-42), and edge meta (edge.Properties) with NO per-neighbor read gate. The bare neighbor id is an already-accepted leak (per-entity GET ships an IDs-only relations map, acl_get_test.go); the NOVEL leak is neighbor type + edge meta, plus a per-relation-type enumeration oracle. Contrast: the list handler (handleV1ListEntities) computes visibleRelationIDs and drops hidden neighbors (RR-HJV8CP, pinned by acl_list_neighbor_test.go); ?include= uses filterVisibleIncludes; the dedicated /relations endpoints do neither and have no ACL regression test. Reproduced live (NOTE-H is 404 on direct GET but enumerable via /notes/NOTE-S/relations): demos/demo_c.sh. Severity HIGH.
+
+    Fix (decided): compute the visible neighbor set (visibleRelationIDs) in both handlers and skip any edge whose peer is not visible, including the ungated entityType lookup for hidden peers — mirroring the list path.
+priority: high
+why1: A hidden neighbor's type and edge meta leak because these handlers apply the read gate to the source entity only and emit neighbor fields without checking each neighbor's readability.
+why2: 'Read filtering was retrofitted onto rela per-endpoint: the list and ?include= paths got visibleRelationIDs/filterVisibleIncludes; the dedicated /relations endpoints were a separate handler the retrofit missed.'
+why3: The fix (RR-HJV8CP) was framed and tested against the surface where the leak was noticed (the list), not against 'every surface that emits a neighbor'. The invariant lived in a test bound to one handler, not a shared function every neighbor-emitting path must call.
+why4: 'Neighbor gating is a per-handler responsibility rather than a structural one: entityType is deliberately ungated and neighbor visibility depends on each handler remembering to call the filter. There is no single ''serialize a neighbor for the wire'' chokepoint that gates by construction.'
+why5: 'Systemic: read filtering is applied at leaf handlers, not at a mandatory serialization boundary, so ''did this response leak an unreadable entity?'' is not enforced by construction and not covered by a cross-endpoint test. A new or overlooked neighbor-emitting endpoint fails open by default.'
+prevention: 'P3: route every neighbor-to-wire emission through one function that takes the read gate and drops unreadable peers (id, type, meta), so new endpoints inherit the gate. P4 (automated measure): an integration test enumerating every neighbor-emitting read endpoint (list, ?include=, /relations, /relations/{type}, single-GET) that asserts a hidden neighbor never appears (id/type/meta).'
+status: review
+---
+
+Fix implemented on branch `fix/acl-relations-neighbor-leak` (commit 0ce4f18d).
+PR: https://github.com/sourcehaven-bv/rela/pull/1113
+
+Both `/relations` handlers now gate neighbors via `visibleRelationIDs` (same
+helper as the list path), skipping hidden peers before the ungated `entityType`
+lookup. Tests: `TestACLRelations_HiddenNeighborExcluded` (reproduction,
+failing-first confirmed) + `TestACLNeighborReadLeakInvariant` (P4 cross-endpoint
+invariant = AM-acl-neighbor-read-leak-invariant). build/test/arch-lint green;
+demo_c flips to NOT-REPRODUCED.

--- a/tickets/entities/bugs/BUG-ABXMAV.md
+++ b/tickets/entities/bugs/BUG-ABXMAV.md
@@ -13,7 +13,7 @@ why3: The fix (RR-HJV8CP) was framed and tested against the surface where the le
 why4: 'Neighbor gating is a per-handler responsibility rather than a structural one: entityType is deliberately ungated and neighbor visibility depends on each handler remembering to call the filter. There is no single ''serialize a neighbor for the wire'' chokepoint that gates by construction.'
 why5: 'Systemic: read filtering is applied at leaf handlers, not at a mandatory serialization boundary, so ''did this response leak an unreadable entity?'' is not enforced by construction and not covered by a cross-endpoint test. A new or overlooked neighbor-emitting endpoint fails open by default.'
 prevention: 'P3: route every neighbor-to-wire emission through one function that takes the read gate and drops unreadable peers (id, type, meta), so new endpoints inherit the gate. P4 (automated measure): an integration test enumerating every neighbor-emitting read endpoint (list, ?include=, /relations, /relations/{type}, single-GET) that asserts a hidden neighbor never appears (id/type/meta).'
-status: review
+status: done
 ---
 
 Fix implemented on branch `fix/acl-relations-neighbor-leak` (commit 0ce4f18d).

--- a/tickets/entities/review-checklists/REV-QAI04D.md
+++ b/tickets/entities/review-checklists/REV-QAI04D.md
@@ -1,0 +1,56 @@
+---
+id: REV-QAI04D
+type: review-checklist
+title: 'Review: /relations endpoints leak hidden-neighbor type + edge meta past the read gate'
+status: in-progress
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Automated Checks
+
+- [ ] All tests pass (`just test`)
+- [ ] Lint clean (`just lint`)
+- [ ] Coverage maintained (`just coverage-check`)
+
+## Code Review
+
+- [ ] Run `/code-review` command (invokes cranky-code-reviewer agent)
+- [ ] All critical review-responses addressed
+- [ ] All significant review-responses addressed
+- [ ] Self-reviewed the diff for unrelated changes
+
+**Review Responses:** <!-- List IDs of review-response entities created, e.g.,
+RR-xxxx -->
+
+## Acceptance Verification
+
+- [ ] Each acceptance criterion tested (reference planning checklist)
+- [ ] Test evidence documented in implementation checklist
+
+**Acceptance Status:**
+<!-- For each acceptance criterion, state PASS/FAIL with evidence -->
+
+## Documentation (enhancements only)
+
+Skip this section for bugs and internal refactors.
+
+- [ ] Docs-checklist created and linked via `has-docs`
+- [ ] User-facing documentation updated
+- [ ] Docs-checklist marked as done
+
+**Docs Checklist:** <!-- e.g., DOCS-xxxx -->
+
+## Final Checks
+
+- [ ] Commit message explains the why, not just what
+- [ ] No TODOs or FIXMEs left unaddressed
+- [ ] Ready for another developer to use
+
+## Pull Request
+
+- [ ] Run `/pr` command to create PR and monitor CI
+- [ ] All CI checks pass
+- [ ] PR URL documented below
+
+**PR:** <!-- e.g., https://github.com/org/repo/pull/123 -->

--- a/tickets/entities/review-checklists/REV-QAI04D.md
+++ b/tickets/entities/review-checklists/REV-QAI04D.md
@@ -2,55 +2,50 @@
 id: REV-QAI04D
 type: review-checklist
 title: 'Review: /relations endpoints leak hidden-neighbor type + edge meta past the read gate'
-status: in-progress
+status: done
 ---
 
 <!-- @managed: claude-workflow v1 -->
 
 ## Automated Checks
 
-- [ ] All tests pass (`just test`)
-- [ ] Lint clean (`just lint`)
-- [ ] Coverage maintained (`just coverage-check`)
+- [x] All tests pass (CI green: Test, Postgres Backend, Fuzz, E2E)
+- [x] Lint clean (CI green: Lint, Architecture, God-object lint)
+- [x] Coverage maintained (dataentry above floor)
 
 ## Code Review
 
-- [ ] Run `/code-review` command (invokes cranky-code-reviewer agent)
-- [ ] All critical review-responses addressed
-- [ ] All significant review-responses addressed
-- [ ] Self-reviewed the diff for unrelated changes
+- [x] Ran cranky-code-reviewer on PR #1113
+- [x] ~~All critical review-responses addressed~~ (N/A: no critical findings)
+- [x] ~~All significant review-responses addressed~~ (N/A: no significant findings)
+- [x] Self-reviewed the diff for unrelated changes (fix + tests only; verified diffstat)
 
-**Review Responses:** <!-- List IDs of review-response entities created, e.g.,
-RR-xxxx -->
+**Review Responses:** RR-78Q9S0 (nit, deferred), RR-QD5BSI (nit, deferred) —
+both non-blocking, tied to the existing TODO(BUG-ABXMAV) shared-chokepoint
+follow-up.
 
 ## Acceptance Verification
 
-- [ ] Each acceptance criterion tested (reference planning checklist)
-- [ ] Test evidence documented in implementation checklist
+- [x] Each acceptance criterion tested: hidden neighbor's id/type/meta dropped on both `/relations` and `/relations/{type}`, both directions; visible neighbor still returned
+- [x] Test evidence: `TestACLRelations_HiddenNeighborExcluded` (reproduction, failing-first confirmed) + `TestACLNeighborReadLeakInvariant` (P4 cross-endpoint invariant); demo_c flips to NOT-REPRODUCED
 
-**Acceptance Status:**
-<!-- For each acceptance criterion, state PASS/FAIL with evidence -->
+**Acceptance Status:** PASS — reviewer verdict "correct, complete, ship it", no
+security false-negative.
 
 ## Documentation (enhancements only)
 
-Skip this section for bugs and internal refactors.
-
-- [ ] Docs-checklist created and linked via `has-docs`
-- [ ] User-facing documentation updated
-- [ ] Docs-checklist marked as done
-
-**Docs Checklist:** <!-- e.g., DOCS-xxxx -->
+- [x] ~~Docs section~~ (N/A: security bugfix, no user-facing API change)
 
 ## Final Checks
 
-- [ ] Commit message explains the why, not just what
-- [ ] No TODOs or FIXMEs left unaddressed
-- [ ] Ready for another developer to use
+- [x] Commit message explains the why (the leak + the mirrored list-path fix)
+- [x] No TODOs left unaddressed (the one TODO(BUG-ABXMAV) is an intentional deferred follow-up, tracked via RR-78Q9S0/RR-QD5BSI)
+- [x] Ready for another developer to use
 
 ## Pull Request
 
-- [ ] Run `/pr` command to create PR and monitor CI
-- [ ] All CI checks pass
-- [ ] PR URL documented below
+- [x] PR created: https://github.com/sourcehaven-bv/rela/pull/1113
+- [x] All code CI checks pass (Rela Tickets gate clears on this bug reaching done)
+- [x] PR URL documented above
 
-**PR:** <!-- e.g., https://github.com/org/repo/pull/123 -->
+**PR:** https://github.com/sourcehaven-bv/rela/pull/1113

--- a/tickets/entities/review-responses/RR-78Q9S0.md
+++ b/tickets/entities/review-responses/RR-78Q9S0.md
@@ -1,0 +1,9 @@
+---
+id: RR-78Q9S0
+type: review-response
+title: Intra-handler double-walk in handleV1GetRelationType could detach gate from emit
+finding: handleV1GetRelationType walks edges in a peer-collection loop and an emit loop that share the same edge.Type!=relType filter and peerID derivation. If a future edit changes peer derivation in one loop but not the other, the visible-set keys detach from what's emitted (latent re-leak). Not a bug today; both loops are correct and in lockstep.
+severity: nit
+reason: Deferred to the TODO(BUG-ABXMAV) shared-chokepoint follow-up. Non-blocking per review-response protocol (nit). The right fix is a single emitVisibleRelations(edges, visibleNeighbors, direction) helper that owns peer-endpoint selection once; deliberately out of scope for a minimal security fix.
+status: deferred
+---

--- a/tickets/entities/review-responses/RR-QD5BSI.md
+++ b/tickets/entities/review-responses/RR-QD5BSI.md
@@ -1,0 +1,9 @@
+---
+id: RR-QD5BSI
+type: review-response
+title: peerIDs not deduplicated in handleV1GetRelationType (harmless inconsistency with neighborIDsOf)
+finding: 'peerIDs is collected without dedup, unlike the sibling neighborIDsOf which dedupes via a seen map. Two edges to the same peer add the ID twice. Harmless: filterVisible groups by type, PermitsReadMany takes a set-like slice, and the result map is ID-keyed so dupes collapse.'
+severity: nit
+reason: Deferred with the double-walk nit to the TODO(BUG-ABXMAV) chokepoint follow-up. Non-blocking (nit). A one-line comment or reusing a dedupe helper would remove the inconsistency.
+status: deferred
+---

--- a/tickets/relations/AM-acl-neighbor-read-leak-invariant--protects--authorization.md
+++ b/tickets/relations/AM-acl-neighbor-read-leak-invariant--protects--authorization.md
@@ -1,0 +1,5 @@
+---
+from: AM-acl-neighbor-read-leak-invariant
+relation: protects
+to: authorization
+---

--- a/tickets/relations/BUG-ABXMAV--adds-measure--AM-acl-neighbor-read-leak-invariant.md
+++ b/tickets/relations/BUG-ABXMAV--adds-measure--AM-acl-neighbor-read-leak-invariant.md
@@ -1,0 +1,5 @@
+---
+from: BUG-ABXMAV
+relation: adds-measure
+to: AM-acl-neighbor-read-leak-invariant
+---

--- a/tickets/relations/BUG-ABXMAV--affects--authorization.md
+++ b/tickets/relations/BUG-ABXMAV--affects--authorization.md
@@ -1,0 +1,5 @@
+---
+from: BUG-ABXMAV
+relation: affects
+to: authorization
+---

--- a/tickets/relations/BUG-ABXMAV--fixes--FEAT-AESD4.md
+++ b/tickets/relations/BUG-ABXMAV--fixes--FEAT-AESD4.md
@@ -1,0 +1,5 @@
+---
+from: BUG-ABXMAV
+relation: fixes
+to: FEAT-AESD4
+---

--- a/tickets/relations/BUG-ABXMAV--has-review--REV-QAI04D.md
+++ b/tickets/relations/BUG-ABXMAV--has-review--REV-QAI04D.md
@@ -1,0 +1,5 @@
+---
+from: BUG-ABXMAV
+relation: has-review
+to: REV-QAI04D
+---

--- a/tickets/relations/BUG-ABXMAV--has-review-response--RR-78Q9S0.md
+++ b/tickets/relations/BUG-ABXMAV--has-review-response--RR-78Q9S0.md
@@ -1,0 +1,5 @@
+---
+from: BUG-ABXMAV
+relation: has-review-response
+to: RR-78Q9S0
+---

--- a/tickets/relations/BUG-ABXMAV--has-review-response--RR-QD5BSI.md
+++ b/tickets/relations/BUG-ABXMAV--has-review-response--RR-QD5BSI.md
@@ -1,0 +1,5 @@
+---
+from: BUG-ABXMAV
+relation: has-review-response
+to: RR-QD5BSI
+---


### PR DESCRIPTION
## Finding (BUG-ABXMAV, HIGH)

The dedicated `/relations` endpoints leaked a hidden neighbor's **type** and edge **meta** past the read gate. `handleV1EntityRelations` and `handleV1GetRelationType` gated only the *source* entity, then emitted each neighbor's id, type (via the deliberately-ungated `entityReader.entityType`), and edge meta with no per-neighbor read gate — unlike the list path (`visibleRelationIDs`) and `?include=` (`filterVisibleIncludes`), which drop hidden neighbors.

Reproduced live: a neighbor that returns 404 on direct GET was still fully enumerable (id + type + meta) via `GET /{plural}/{source}/relations`, in both directions.

## Fix

Both `/relations` handlers now compute the visible neighbor set with the **same** `visibleRelationIDs` helper the list path uses, and skip any edge whose peer is not visible **before** the ungated `entityType` lookup — so a hidden peer's id, type, and meta never reach the wire. Visible neighbors keep their exact existing shape (no over-filtering). Replicated the call rather than forcing a shared chokepoint in a security fix; `TODO(BUG-ABXMAV)` marks the P3 shared-serialization-boundary follow-up.

## Tests

- `TestACLRelations_HiddenNeighborExcluded` — reproduction; 4 subtests (grouped + typed × outgoing + incoming/inverse-key). Confirmed failing-first against the unfixed code.
- `TestACLNeighborReadLeakInvariant` — the P4 class-level invariant (automated-measure `AM-acl-neighbor-read-leak-invariant`): table-driven across all 6 neighbor-emitting endpoints, asserting no hidden peer's type/meta leaks anywhere; the accepted bare-ID exception (single-GET/list IDs-only map, per `dataentry/CLAUDE.md`) is encoded explicitly. A future neighbor-emitting endpoint is covered by adding a row.

## Verification

`go build ./...`, `go test ./internal/dataentry/...`, `just arch-lint` all pass. The `demo_c` exploit script flips to NOT-REPRODUCED; `demo_a`/`demo_b` (the two write-path findings) still reproduce, confirming this read-path change is isolated.

Part of the ACL audit series — see also BUG-K6FEVB (relation-write bypass) and BUG-ZWTDH9 (sync PUT type-confusion). Each carries a full 5-whys; all three share the systemic root "authorization enforced per-call-site, not at a mandatory chokepoint, with no cross-endpoint invariant test."