### PR TITLE
fix(entitymanager): sync upsert authorizes + validates against stored type (BUG-ZWTDH9)

### DIFF
--- a/internal/autocascade/host.go
+++ b/internal/autocascade/host.go
@@ -56,9 +56,12 @@ type Host interface {
 	// validating the (from-type, type, to-type) tuple.
 	GetEntity(ctx context.Context, id string) (*entity.Entity, error)
 
-	// WriteRelation upserts the relation to the store. Runner uses
-	// it for entries in [automation.Result.RelationsToCreate] and
-	// for trigger relations attached to automation-created entities.
+	// WriteRelation creates the relation in the store, treating a
+	// pre-existing identical relation as a no-op success (create-then-
+	// noop-on-conflict, never an update — cascade relations are
+	// property-less, so there is nothing to overwrite). Runner uses it
+	// for entries in [automation.Result.RelationsToCreate] and for
+	// trigger relations attached to automation-created entities.
 	WriteRelation(ctx context.Context, r *entity.Relation) error
 
 	// ValidateRelation checks whether a relation of the given type

--- a/internal/cli/sync/client.go
+++ b/internal/cli/sync/client.go
@@ -168,9 +168,15 @@ func (c *Client) GetRelation(ctx context.Context, from, relType, to string) (*Fe
 type PushResult struct {
 	Applied  bool
 	Conflict bool
-	Invalid  bool   // 422: content rejected by validation (NOT a conflict)
-	Hash     string // new hash on Applied
-	Detail   string // human-readable detail (validation message, etc.)
+	// CreatedConcurrently distinguishes a 409 (a create-intent push lost a
+	// race to a concurrent first-create of the same id on the multi-writer
+	// backend) from the ordinary 412 conflict (the client declared a base that
+	// no longer matches). Both are conflicts that HALT only the one record and
+	// let the run continue; the flag only sharpens the operator-facing message.
+	CreatedConcurrently bool
+	Invalid             bool   // 422: content rejected by validation (NOT a conflict)
+	Hash                string // new hash on Applied
+	Detail              string // human-readable detail (validation message, etc.)
 }
 
 // PutEntity pushes an entity conditionally. ifMatch is the index hash (the base
@@ -232,8 +238,9 @@ func (c *Client) get(ctx context.Context, segments []string) (*http.Response, er
 
 // pushResult maps the PUT/DELETE response status to a typed PushResult. 200 ->
 // applied (+ new hash from the body or ETag); 412 -> conflict (+ server hash
-// from ETag); 422 -> invalid; anything else -> an error (403/404/5xx surfaced
-// via statusError so auth failures are distinct from conflicts).
+// from ETag); 409 -> conflict (a create raced a concurrent first-create,
+// CreatedConcurrently set); 422 -> invalid; anything else -> an error (403/404/
+// 5xx surfaced via statusError so auth failures are distinct from conflicts).
 func (c *Client) pushResult(req *http.Request) (*PushResult, error) {
 	resp, err := c.do(req)
 	if err != nil {
@@ -258,6 +265,14 @@ func (c *Client) pushResult(req *http.Request) (*PushResult, error) {
 		return &PushResult{Applied: true, Hash: hash}, nil
 	case http.StatusPreconditionFailed:
 		return &PushResult{Conflict: true}, nil
+	case http.StatusConflict:
+		// 409: a create-intent push raced a concurrent first-create of the same
+		// id (postgres multi-writer). Like a 412, this is a per-record conflict
+		// that HALTS this record and lets the run continue — it is NOT a
+		// transport/auth error, so it must NOT fall through to statusError (which
+		// would abort the whole push run). The flag lets the caller emit a
+		// create-specific message.
+		return &PushResult{Conflict: true, CreatedConcurrently: true}, nil
 	case http.StatusUnprocessableEntity:
 		return &PushResult{Invalid: true, Detail: c.errorDetail(resp)}, nil
 	default:

--- a/internal/cli/sync/push.go
+++ b/internal/cli/sync/push.go
@@ -12,8 +12,10 @@ type PushOutcome int
 const (
 	// OutcomePushed: the record was applied on the server and the index updated.
 	OutcomePushed PushOutcome = iota
-	// OutcomeConflict: the server moved since the client's base (412) — the
-	// record was HALTED, not applied. Resolve with `push --force <id>`.
+	// OutcomeConflict: the record was HALTED, not applied, because it
+	// conflicted on the server — either the server moved since the client's
+	// base (412) or a create raced a concurrent first-create of the same id
+	// (409). Other records still proceed; resolve with `push --force <id>`.
 	OutcomeConflict
 	// OutcomeInvalid: the server rejected the content as invalid (422).
 	OutcomeInvalid
@@ -190,8 +192,17 @@ func (e *Engine) recordPush(key, localHash string, res *PushResult) PushRecordRe
 }
 
 // classifyConflict turns a non-applied PushResult into a halt report entry.
+// A conflict (412 or 409) halts ONLY this record — the push loop continues to
+// the next — and the index is left untouched so a re-run replays it after the
+// operator resolves it. A 409 (concurrent first-create) gets a create-specific
+// message; a 412 (base moved) gets the base-changed message.
 func classifyConflict(key string, res *PushResult) PushRecordResult {
 	switch {
+	case res.CreatedConcurrently:
+		return PushRecordResult{
+			Key: key, Outcome: OutcomeConflict,
+			Detail: "created concurrently by a peer since your last sync; resolve with `rela sync push --force " + key + "` (local wins) or `rela sync pull --force " + key + "` (remote wins)",
+		}
 	case res.Conflict:
 		return PushRecordResult{
 			Key: key, Outcome: OutcomeConflict,

--- a/internal/cli/sync/scenarios_test.go
+++ b/internal/cli/sync/scenarios_test.go
@@ -159,6 +159,80 @@ func TestPush_Conflict_HaltsThenForceResolves(t *testing.T) {
 	}
 }
 
+// BUG-ZWTDH9: a create-intent push that races a concurrent first-create of the
+// same id gets a 409 from the server. That 409 must HALT ONLY that record (a
+// conflict outcome), NOT abort the whole run — subsequent records still push.
+// This mirrors the 412 halt-one-record contract; before the fix a 409 fell
+// through to statusError and aborted the entire topo-ordered run.
+func TestPush_CreateConflict409_HaltsOneRecordAndRunContinues(t *testing.T) {
+	h := newHarness(t)
+	ctx := context.Background()
+
+	// Two brand-new local creates. The server will 409 the first (TKT-A) as if a
+	// peer created it concurrently; TKT-B must still be applied in the same run.
+	h.createLocalEntity(t, "TKT-A", map[string]any{"title": "a"})
+	h.createLocalEntity(t, "TKT-B", map[string]any{"title": "b"})
+	h.server.mu.Lock()
+	h.server.conflictOnceKey = "TKT-A"
+	h.server.mu.Unlock()
+
+	rep, err := h.engine.Push(ctx)
+	if err != nil {
+		t.Fatalf("409 must halt one record, not abort the run: %v", err)
+	}
+	if rep.Conflicts != 1 {
+		t.Fatalf("conflicts=%d, want 1 (TKT-A halted on 409)", rep.Conflicts)
+	}
+	if rep.Applied != 1 {
+		t.Fatalf("applied=%d, want 1 (TKT-B must proceed past the halted TKT-A)", rep.Applied)
+	}
+
+	// TKT-A was halted: not on the server, and NOT recorded in the index (so a
+	// re-run replays it after the conflict is resolved).
+	if _, ok := h.server.entities["TKT-A"]; ok {
+		t.Fatal("TKT-A must not be on the server after a 409 halt")
+	}
+	if _, ok := h.idx.Hash("TKT-A"); ok {
+		t.Fatal("TKT-A must NOT be in the index after a 409 halt (re-run must replay it)")
+	}
+	// TKT-B converged: on the server and in the index.
+	if _, ok := h.server.entities["TKT-B"]; !ok {
+		t.Fatal("TKT-B missing on server — the 409 on TKT-A aborted the run")
+	}
+	if _, ok := h.idx.Hash("TKT-B"); !ok {
+		t.Fatal("TKT-B missing from index after a successful push")
+	}
+
+	// The halted record carries the create-specific message (not the 412
+	// base-changed wording), and re-running now converges (server no longer 409s).
+	var halted *PushRecordResult
+	for i := range rep.Results {
+		if rep.Results[i].Key == "TKT-A" {
+			halted = &rep.Results[i]
+		}
+	}
+	if halted == nil {
+		t.Fatal("no report entry for the halted TKT-A")
+	}
+	if halted.Outcome != OutcomeConflict {
+		t.Fatalf("TKT-A outcome=%v, want OutcomeConflict", halted.Outcome)
+	}
+	if !contains(halted.Detail, "created concurrently by a peer") {
+		t.Fatalf("409 detail=%q, want the concurrent-create wording", halted.Detail)
+	}
+
+	rep2, err := h.engine.Push(ctx)
+	if err != nil {
+		t.Fatalf("re-run after 409 resolved: %v", err)
+	}
+	if rep2.Applied != 1 || rep2.Conflicts != 0 {
+		t.Fatalf("re-run applied=%d conflicts=%d, want 1/0 (TKT-A now applies)", rep2.Applied, rep2.Conflicts)
+	}
+	if _, ok := h.server.entities["TKT-A"]; !ok {
+		t.Fatal("TKT-A still missing on server after the re-run")
+	}
+}
+
 // AC #6: a relation listed BEFORE its endpoint entity in a batch is still
 // applied, because push reorders entities ahead of relations.
 func TestPush_TopologicalOrder_EntitiesBeforeRelations(t *testing.T) {

--- a/internal/cli/sync/sync_test.go
+++ b/internal/cli/sync/sync_test.go
@@ -40,6 +40,11 @@ type fakeServer struct {
 	seq       int64
 	changes   []serverChange // append-only change log for the manifest
 	authToken string         // when set, requests must present it as a bearer
+	// conflictOnceKey, when set, forces the FIRST PUT of that entity key to
+	// respond 409 Conflict (a create that raced a concurrent first-create on
+	// the multi-writer backend), then behaves normally. Models the server's
+	// create-conflict mapping without needing a real concurrent writer.
+	conflictOnceKey string
 }
 
 type serverChange struct {
@@ -137,6 +142,13 @@ func (s *fakeServer) put(w http.ResponseWriter, r *http.Request, kind, key strin
 			w.Header().Set("ETag", cur)
 		}
 		writeJSONErr(w, http.StatusPreconditionFailed, "conflict")
+		return
+	}
+	// Create-conflict injection: a create-intent PUT (precondition just passed
+	// on an absent record) whose durable create raced a peer → 409. Fires once.
+	if s.conflictOnceKey == key {
+		s.conflictOnceKey = ""
+		writeJSONErr(w, http.StatusConflict, "conflict")
 		return
 	}
 	if kind == "e" {

--- a/internal/dataentry/sync_conflict_test.go
+++ b/internal/dataentry/sync_conflict_test.go
@@ -37,6 +37,75 @@ func (s *createConflictStore) CreateEntity(_ context.Context, _ *entity.Entity) 
 	return store.ErrConflict
 }
 
+// vanishOnUpdateStore reports a fixed entity PRESENT via GetEntity — so the
+// sync PUT precondition (If-Match matching the current hash) passes AND
+// ApplyEntity resolves UPDATE intent — but returns store.ErrNotFound on
+// UpdateEntity, modeling a concurrent DELETE landing between the probe and the
+// durable write. This is the narrow probe-said-present-then-deleted race; the
+// server must map it to 412 (symmetric with the relation vanished-on-update
+// case), not 404.
+type vanishOnUpdateStore struct {
+	store.Store
+	present *entity.Entity
+}
+
+func (s *vanishOnUpdateStore) GetEntity(_ context.Context, id string) (*entity.Entity, error) {
+	if id == s.present.ID {
+		return s.present, nil
+	}
+	return nil, store.ErrNotFound
+}
+
+func (s *vanishOnUpdateStore) UpdateEntity(_ context.Context, _ *entity.Entity) error {
+	return store.ErrNotFound
+}
+
+// TestSyncPut_UpdateVanishedReturns412 pins M1 (BUG-ZWTDH9): an update-intent
+// sync PUT (If-Match matches, so the record probed as present) whose durable
+// UpdateEntity finds the row gone (a concurrent delete) returns 412 Conflict —
+// symmetric with the relation vanished-on-update case — NOT the 404 that would
+// abort the CLI push run. The narrow race the ordinary preconditionOK->412
+// check does not catch.
+func TestSyncPut_UpdateVanishedReturns412(t *testing.T) {
+	meta := secretNoteMeta()
+	cfg := &Config{App: AppConfig{Name: "sec"}}
+	app := newAppFromParts(cfg, meta, &fixture{})
+
+	fs := storage.NewMemFS()
+	ctx := &project.Context{Root: "/project", CacheDir: "/project/.rela"}
+	_ = fs.MkdirAll(ctx.CacheDir, 0o755)
+
+	present := &entity.Entity{ID: "NOTE-1", Type: "note", Properties: map[string]any{"title": "base"}}
+	st := &vanishOnUpdateStore{Store: memstore.New(), present: present}
+	svc := appbuildtest.New(meta, appbuildtest.WithFS(fs, ctx), appbuildtest.WithStore(st), appbuildtest.WithACL(acl.NopACL{}))
+	rebindApp(app, fs, ctx, svc)
+	app.broker = newEventBroker()
+	app.SetPrincipalResolver(func(*http.Request) principal.Principal {
+		return principal.Principal{User: "peer", Tool: principal.ToolSync}
+	})
+
+	// If-Match matches the current hash → precondition passes and ApplyEntity
+	// resolves UPDATE intent. The conflict only surfaces on UpdateEntity.
+	cur, exists := app.currentEntityHash(context.Background(), "NOTE-1")
+	if !exists {
+		t.Fatal("seed missing: store should report NOTE-1 present")
+	}
+	body := syncEntityBody{ID: "NOTE-1", Type: "note", Properties: map[string]any{"title": "edited"}}
+	b, err := json.Marshal(body)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	r := httptest.NewRequest(http.MethodPut, "/api/sync/entities/NOTE-1", bytes.NewReader(b))
+	r.Header.Set("Content-Type", "application/json")
+	r.Header.Set("If-Match", cur)
+	w := httptest.NewRecorder()
+	app.NewRouter().ServeHTTP(w, r)
+
+	if w.Code != http.StatusPreconditionFailed {
+		t.Fatalf("update-vanished sync PUT returned %d, want 412: %s", w.Code, w.Body.String())
+	}
+}
+
 // TestSyncPut_CreateConflictReturns409 pins that when a create-intent sync PUT
 // (no If-Match, record probes as absent) reaches ApplyEntity and the durable
 // CreateEntity conflicts (a peer created the same id concurrently), the handler
@@ -100,6 +169,11 @@ func TestWriteSyncApplyError_CreateConflictMaps409(t *testing.T) {
 		{"entity create conflict", entitymanager.ErrEntityAlreadyExists, http.StatusConflict},
 		{"relation create conflict", entitymanager.ErrRelationAlreadyExists, http.StatusConflict},
 		{"relation vanished on update", entitymanager.ErrRelationNotFound, http.StatusPreconditionFailed},
+		// Entity vanished-on-update wraps ErrEntityNotFound but must map to 412
+		// (symmetric with the relation case), NOT the 404 reserved for a missing
+		// relation endpoint. The order of the errors.Is checks in
+		// writeSyncApplyError is load-bearing for this — pin it here.
+		{"entity vanished on update", entitymanager.ErrEntityVanishedOnUpdate, http.StatusPreconditionFailed},
 		{"type immutable", entitymanager.ErrTypeImmutable, http.StatusUnprocessableEntity},
 		{"endpoint missing", entitymanager.ErrEntityNotFound, http.StatusNotFound},
 	}

--- a/internal/dataentry/sync_conflict_test.go
+++ b/internal/dataentry/sync_conflict_test.go
@@ -1,0 +1,116 @@
+package dataentry
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Sourcehaven-BV/rela/internal/acl"
+	"github.com/Sourcehaven-BV/rela/internal/appbuild/appbuildtest"
+	"github.com/Sourcehaven-BV/rela/internal/entity"
+	"github.com/Sourcehaven-BV/rela/internal/entitymanager"
+	"github.com/Sourcehaven-BV/rela/internal/principal"
+	"github.com/Sourcehaven-BV/rela/internal/project"
+	"github.com/Sourcehaven-BV/rela/internal/storage"
+	"github.com/Sourcehaven-BV/rela/internal/store"
+	"github.com/Sourcehaven-BV/rela/internal/store/memstore"
+)
+
+// createConflictStore reports every id as ABSENT via GetEntity — so the sync
+// PUT precondition (no If-Match on a non-existent record) passes AND ApplyEntity
+// resolves CREATE intent — but conflicts on CreateEntity, modeling a concurrent
+// create landing on the postgres multi-writer backend between probe and write.
+// It embeds a real memstore so the non-overridden methods (search backfill,
+// relation reads) behave; only the two methods that drive the race are stubbed.
+type createConflictStore struct {
+	store.Store
+}
+
+func (s *createConflictStore) GetEntity(_ context.Context, _ string) (*entity.Entity, error) {
+	return nil, store.ErrNotFound
+}
+
+func (s *createConflictStore) CreateEntity(_ context.Context, _ *entity.Entity) error {
+	return store.ErrConflict
+}
+
+// TestSyncPut_CreateConflictReturns409 pins that when a create-intent sync PUT
+// (no If-Match, record probes as absent) reaches ApplyEntity and the durable
+// CreateEntity conflicts (a peer created the same id concurrently), the handler
+// returns 409 Conflict — NOT a 412 precondition (the client's precondition was
+// satisfied at check time), NOT a 422 (the content is valid), and NOT a silent
+// 200 overwrite (the removed upsert fallback). BUG-ZWTDH9.
+func TestSyncPut_CreateConflictReturns409(t *testing.T) {
+	meta := secretNoteMeta()
+	cfg := &Config{App: AppConfig{Name: "sec"}}
+	app := newAppFromParts(cfg, meta, &fixture{})
+
+	fs := storage.NewMemFS()
+	ctx := &project.Context{Root: "/project", CacheDir: "/project/.rela"}
+	_ = fs.MkdirAll(ctx.CacheDir, 0o755)
+
+	st := &createConflictStore{Store: memstore.New()}
+	svc := appbuildtest.New(meta, appbuildtest.WithFS(fs, ctx), appbuildtest.WithStore(st), appbuildtest.WithACL(acl.NopACL{}))
+	rebindApp(app, fs, ctx, svc)
+	app.broker = newEventBroker()
+	app.SetPrincipalResolver(func(*http.Request) principal.Principal {
+		return principal.Principal{User: "peer", Tool: principal.ToolSync}
+	})
+
+	// No If-Match: a first-create push. The precondition passes because
+	// GetEntity reports the id absent; the conflict only surfaces on the
+	// durable CreateEntity inside ApplyEntity.
+	body := syncEntityBody{ID: "NOTE-1", Type: "note", Properties: map[string]any{"title": "loser"}}
+	b, err := json.Marshal(body)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	r := httptest.NewRequest(http.MethodPut, "/api/sync/entities/NOTE-1", bytes.NewReader(b))
+	r.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	app.NewRouter().ServeHTTP(w, r)
+
+	if w.Code != http.StatusConflict {
+		t.Fatalf("create-conflict sync PUT returned %d, want 409: %s", w.Code, w.Body.String())
+	}
+	var errResp struct {
+		Type string `json:"type"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &errResp); err != nil {
+		t.Fatalf("decode error body: %v", err)
+	}
+	if errResp.Type == "" {
+		t.Errorf("expected an error type in the 409 body; got %s", w.Body.String())
+	}
+}
+
+// TestWriteSyncApplyError_CreateConflictMaps409 is the direct unit test of the
+// error->status mapping: ErrEntityAlreadyExists and ErrRelationAlreadyExists
+// map to 409, distinct from the 422 validation/type-immutable rejects and the
+// 412 precondition. Guards the mapping independently of the full handler wiring.
+func TestWriteSyncApplyError_CreateConflictMaps409(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want int
+	}{
+		{"entity create conflict", entitymanager.ErrEntityAlreadyExists, http.StatusConflict},
+		{"relation create conflict", entitymanager.ErrRelationAlreadyExists, http.StatusConflict},
+		{"relation vanished on update", entitymanager.ErrRelationNotFound, http.StatusPreconditionFailed},
+		{"type immutable", entitymanager.ErrTypeImmutable, http.StatusUnprocessableEntity},
+		{"endpoint missing", entitymanager.ErrEntityNotFound, http.StatusNotFound},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			w := httptest.NewRecorder()
+			r := httptest.NewRequest(http.MethodPut, "/api/sync/entities/X", http.NoBody)
+			writeSyncApplyError(w, r, tc.err)
+			if w.Code != tc.want {
+				t.Fatalf("status = %d, want %d (body: %s)", w.Code, tc.want, w.Body.String())
+			}
+		})
+	}
+}

--- a/internal/dataentry/sync_handlers.go
+++ b/internal/dataentry/sync_handlers.go
@@ -78,8 +78,12 @@ func (a *App) handleSyncGet(w http.ResponseWriter, r *http.Request, kind, rest s
 //
 //	200 + new ETag : applied (the record's current hash matched If-Match, or
 //	                 If-Match was absent for a first create)
-//	412            : If-Match did not match the record's current hash → the
-//	                 remote moved since the client's base → conflict
+//	412            : If-Match did not match the record's current hash, OR an
+//	                 update-intent apply found its row vanished concurrently →
+//	                 the remote moved since the client's base → conflict
+//	409            : a create-intent apply (no If-Match) lost a race to a
+//	                 concurrent first-create of the same id → the client's
+//	                 create precondition is now false; re-read and resolve
 //	422            : entitymanager rejected the content (validation) — NOT a
 //	                 conflict; the data is invalid
 //	403            : ACL denied
@@ -350,10 +354,16 @@ func writeSyncApplyError(w http.ResponseWriter, r *http.Request, err error) {
 		writeV1Error(w, r, http.StatusForbidden, "forbidden", "Not permitted", "")
 		return
 	}
-	// An update-intent apply whose relation vanished concurrently
-	// (ErrRelationNotFound) is a precondition failure (412), symmetric with
-	// writeSyncConflict — the client's base no longer exists on the server.
-	if errors.Is(err, entitymanager.ErrRelationNotFound) {
+	// An update-intent apply whose row vanished concurrently — a relation
+	// (ErrRelationNotFound) or an entity (ErrEntityVanishedOnUpdate, which
+	// wraps ErrEntityNotFound) — is a precondition failure (412), symmetric
+	// with writeSyncConflict: the client's base no longer exists on the
+	// server. This MUST be checked before the generic ErrEntityNotFound branch
+	// below (a missing relation ENDPOINT is a genuine 404), since the entity
+	// vanished-on-update error unwraps to ErrEntityNotFound.
+	vanishedOnUpdate := errors.Is(err, entitymanager.ErrRelationNotFound) ||
+		errors.Is(err, entitymanager.ErrEntityVanishedOnUpdate)
+	if vanishedOnUpdate {
 		writeV1Error(w, r, http.StatusPreconditionFailed, "conflict",
 			"The record changed on the server since your base; resolve the conflict", "")
 		return

--- a/internal/dataentry/sync_handlers.go
+++ b/internal/dataentry/sync_handlers.go
@@ -333,9 +333,29 @@ func writeSyncApplyError(w http.ResponseWriter, r *http.Request, err error) {
 			"The entity type is immutable on update", err.Error())
 		return
 	}
+	// A create-intent apply whose record was concurrently created (the
+	// existence probe said "absent", but the durable CreateEntity/
+	// CreateRelation raced a peer and conflicted) is a 409: the client's
+	// create precondition is now false — it must re-read and decide.
+	// Distinct from the 412 precondition (the client declared a base that
+	// no longer matches) and from the 422 validation reject (BUG-ZWTDH9 —
+	// a create never silently becomes a re-typing update).
+	if isCreateConflict(err) {
+		writeV1Error(w, r, http.StatusConflict, "conflict",
+			"The record was created concurrently; re-read and resolve", err.Error())
+		return
+	}
 	var forbidden *acl.ForbiddenError
 	if errors.As(err, &forbidden) {
 		writeV1Error(w, r, http.StatusForbidden, "forbidden", "Not permitted", "")
+		return
+	}
+	// An update-intent apply whose relation vanished concurrently
+	// (ErrRelationNotFound) is a precondition failure (412), symmetric with
+	// writeSyncConflict — the client's base no longer exists on the server.
+	if errors.Is(err, entitymanager.ErrRelationNotFound) {
+		writeV1Error(w, r, http.StatusPreconditionFailed, "conflict",
+			"The record changed on the server since your base; resolve the conflict", "")
 		return
 	}
 	if errors.Is(err, entitymanager.ErrEntityNotFound) {
@@ -343,4 +363,11 @@ func writeSyncApplyError(w http.ResponseWriter, r *http.Request, err error) {
 		return
 	}
 	writeV1Error(w, r, http.StatusInternalServerError, "apply_failed", "Failed to apply the change", "")
+}
+
+// isCreateConflict reports whether err is a create-intent apply that lost a
+// race to a concurrent create (entity or relation) — mapped to 409.
+func isCreateConflict(err error) bool {
+	return errors.Is(err, entitymanager.ErrEntityAlreadyExists) ||
+		errors.Is(err, entitymanager.ErrRelationAlreadyExists)
 }

--- a/internal/dataentry/sync_handlers.go
+++ b/internal/dataentry/sync_handlers.go
@@ -325,6 +325,14 @@ func writeSyncApplyError(w http.ResponseWriter, r *http.Request, err error) {
 		writeV1Error(w, r, http.StatusUnprocessableEntity, "validation_failed", "The content is invalid", err.Error())
 		return
 	}
+	// A body type that contradicts the stored type on update is a structural
+	// impossibility (one ID cannot be two types) and a cross-type write
+	// escalation vector — 422, not a conflict (BUG-ZWTDH9).
+	if errors.Is(err, entitymanager.ErrTypeImmutable) {
+		writeV1Error(w, r, http.StatusUnprocessableEntity, "type_immutable",
+			"The entity type is immutable on update", err.Error())
+		return
+	}
 	var forbidden *acl.ForbiddenError
 	if errors.As(err, &forbidden) {
 		writeV1Error(w, r, http.StatusForbidden, "forbidden", "Not permitted", "")

--- a/internal/dataentry/sync_type_confusion_test.go
+++ b/internal/dataentry/sync_type_confusion_test.go
@@ -1,0 +1,202 @@
+package dataentry
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/Sourcehaven-BV/rela/internal/acl"
+	"github.com/Sourcehaven-BV/rela/internal/appbuild/appbuildtest"
+	"github.com/Sourcehaven-BV/rela/internal/entity"
+	"github.com/Sourcehaven-BV/rela/internal/metamodel"
+	"github.com/Sourcehaven-BV/rela/internal/principal"
+	"github.com/Sourcehaven-BV/rela/internal/project"
+	"github.com/Sourcehaven-BV/rela/internal/storage"
+	"github.com/Sourcehaven-BV/rela/internal/store"
+)
+
+// secretNoteMeta is a two-type, manual-id metamodel for the BUG-ZWTDH9
+// cross-type write-escalation regression. Manual id_type + no id_prefix means
+// the ID-prefix structural guard does NOT fire, so the ACL/apply layer is the
+// only defense against re-typing an existing entity via the request body.
+func secretNoteMeta() *metamodel.Metamodel {
+	return &metamodel.Metamodel{
+		Entities: map[string]metamodel.EntityDef{
+			"secret": {
+				Label:  "Secret",
+				IDType: "manual",
+				Properties: map[string]metamodel.PropertyDef{
+					"title": {Type: "string"},
+				},
+			},
+			"note": {
+				Label:  "Note",
+				IDType: "manual",
+				Properties: map[string]metamodel.PropertyDef{
+					"title": {Type: "string"},
+				},
+			},
+		},
+	}
+}
+
+// buildSecretNoteApp wires an App over secretNoteMeta with a Declarative ACL
+// that both the read gate and the write path (entityManager) share, plus a
+// principal resolver that stamps the given user with Tool=sync. Mirrors
+// production wiring closely enough to exercise the real /api/sync/ router path.
+func buildSecretNoteApp(t *testing.T, policyYAML, user string) *App {
+	t.Helper()
+	meta := secretNoteMeta()
+	cfg := &Config{App: AppConfig{Name: "sec"}}
+	app := newAppFromParts(cfg, meta, &fixture{})
+
+	fs := storage.NewMemFS()
+	ctx := &project.Context{Root: "/project", CacheDir: "/project/.rela"}
+	_ = fs.MkdirAll(ctx.CacheDir, 0o755)
+
+	policy, err := acl.LoadPolicyBytes([]byte(policyYAML))
+	if err != nil {
+		t.Fatalf("LoadPolicyBytes: %v", err)
+	}
+
+	svc := appbuildtest.New(meta, appbuildtest.WithFS(fs, ctx))
+	d, err := acl.NewDeclarative(policy, acl.NewStoreGraph(svc.Store()), svc.Store())
+	if err != nil {
+		t.Fatalf("NewDeclarative: %v", err)
+	}
+	// Re-derive the services bundle with the Declarative ACL so the write
+	// path (entityManager) and the read gate share the same instance.
+	svc = appbuildtest.New(meta, appbuildtest.WithFS(fs, ctx), appbuildtest.WithDeclarative(d))
+	rebindApp(app, fs, ctx, svc)
+	app.broker = newEventBroker()
+	app.acl = d
+	app.SetPrincipalResolver(func(*http.Request) principal.Principal {
+		return principal.Principal{User: user, Tool: principal.ToolSync}
+	})
+	return app
+}
+
+// syncPutJSON issues a sync PUT through the full production router (so the
+// principal-stamp + ACL-attach middleware run), with the given JSON body and
+// no If-Match (first-touch of an existing record is exercised via seeding
+// through the store so If-Match="" only succeeds for the create branch — here
+// we deliberately seed via the store and the record already exists, so the
+// handler's precondition path is exercised too).
+func syncPutJSON(t *testing.T, app *App, path string, body any, ifMatch string) *httptest.ResponseRecorder {
+	t.Helper()
+	b, err := json.Marshal(body)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	r := httptest.NewRequest(http.MethodPut, path, bytes.NewReader(b))
+	r.Header.Set("Content-Type", "application/json")
+	if ifMatch != "" {
+		r.Header.Set("If-Match", ifMatch)
+	}
+	w := httptest.NewRecorder()
+	app.NewRouter().ServeHTTP(w, r)
+	return w
+}
+
+// TestSyncPut_RejectsTypeChangeOnUpdate is the HTTP-layer BUG-ZWTDH9
+// regression. mallory may update notes and read secrets, but not update
+// secrets. She PUTs {"type":"note",...} to an existing secret's sync URL.
+// Before the fix, the handler authorized OpUpdate against the body type (note)
+// and overwrote + re-typed the secret (returning 200). After the fix it is
+// rejected 422 with code "type_immutable", and the stored secret is untouched.
+func TestSyncPut_RejectsTypeChangeOnUpdate(t *testing.T) {
+	app := buildSecretNoteApp(t, `
+roles:
+  note-editor:
+    update: [note]
+    read: [note, secret]
+assignments:
+  mallory: note-editor
+`, "mallory")
+
+	// Seed an existing secret directly in the store (bypasses authz).
+	seedEntity(app, &entity.Entity{
+		ID: "SECRET-1", Type: "secret", Properties: map[string]any{"title": "top secret"},
+	})
+
+	// Compute the current hash for a valid If-Match (so the request reaches
+	// the apply path, not a 412 precondition failure).
+	cur, exists := app.currentEntityHash(context.Background(), "SECRET-1")
+	if !exists {
+		t.Fatal("seeded secret not found")
+	}
+
+	body := syncEntityBody{ID: "SECRET-1", Type: "note", Properties: map[string]any{"title": "pwned"}}
+	w := syncPutJSON(t, app, "/api/sync/entities/SECRET-1", body, cur)
+
+	if w.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("cross-type sync PUT returned %d, want 422 (BUG-ZWTDH9): %s", w.Code, w.Body.String())
+	}
+	var errResp struct {
+		Type string `json:"type"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &errResp); err != nil {
+		t.Fatalf("decode error body: %v", err)
+	}
+	if !strings.HasSuffix(errResp.Type, "type_immutable") {
+		t.Errorf("error type = %q, want suffix type_immutable; body=%s", errResp.Type, w.Body.String())
+	}
+
+	// The stored entity must be UNCHANGED: still a secret, original title.
+	got, err := app.store.GetEntity(context.Background(), "SECRET-1")
+	if err != nil {
+		t.Fatalf("GetEntity(SECRET-1): %v", err)
+	}
+	if got.Type != "secret" {
+		t.Fatalf("stored type was mutated to %q; must remain \"secret\"", got.Type)
+	}
+	if got.GetString("title") != "top secret" {
+		t.Fatalf("stored title was overwritten to %q; must remain \"top secret\"", got.GetString("title"))
+	}
+
+	// No note-typed entity was written as a side effect.
+	for e, err := range app.store.ListEntities(context.Background(), store.EntityQuery{Type: "note"}) {
+		if err == nil && e.Type == "note" {
+			t.Fatalf("a note-typed entity was written despite rejection: %s", e.ID)
+		}
+	}
+}
+
+// TestSyncPut_SameTypeUpdateStillWorks pins that the fix leaves a legitimate
+// same-type sync update working: mallory updates a note she may edit -> 200,
+// and the write lands.
+func TestSyncPut_SameTypeUpdateStillWorks(t *testing.T) {
+	app := buildSecretNoteApp(t, `
+roles:
+  note-editor:
+    update: [note]
+    read: [note, secret]
+assignments:
+  mallory: note-editor
+`, "mallory")
+
+	seedEntity(app, &entity.Entity{
+		ID: "NOTE-1", Type: "note", Properties: map[string]any{"title": "v1"},
+	})
+	cur, exists := app.currentEntityHash(context.Background(), "NOTE-1")
+	if !exists {
+		t.Fatal("seeded note not found")
+	}
+
+	body := syncEntityBody{ID: "NOTE-1", Type: "note", Properties: map[string]any{"title": "v2"}}
+	w := syncPutJSON(t, app, "/api/sync/entities/NOTE-1", body, cur)
+	if w.Code != http.StatusOK {
+		t.Fatalf("legitimate same-type sync PUT returned %d, want 200: %s", w.Code, w.Body.String())
+	}
+	got, err := app.store.GetEntity(context.Background(), "NOTE-1")
+	if err != nil {
+		t.Fatalf("GetEntity(NOTE-1): %v", err)
+	}
+	if got.GetString("title") != "v2" {
+		t.Fatalf("same-type update did not land: title = %q", got.GetString("title"))
+	}
+}

--- a/internal/dataentry/write_subject_type_invariant_test.go
+++ b/internal/dataentry/write_subject_type_invariant_test.go
@@ -1,0 +1,142 @@
+package dataentry
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Sourcehaven-BV/rela/internal/entity"
+)
+
+// TestWriteSubjectTypeInvariant is the P4 integration invariant for
+// AM-acl-write-subject-type-invariant (BUG-ZWTDH9).
+//
+// The invariant: for EVERY entity-write entry point, an UPDATE authorizes the
+// ACL against the STORED entity's type, never a caller-supplied/claimed type —
+// and a request that tries to change the type of an existing entity is
+// rejected, not silently applied against the wrong subject type.
+//
+// The exploit this pins: a principal permitted to write type B but not type A,
+// who can READ a type-A target, must NOT be able to overwrite/re-type that
+// type-A entity by claiming type B in the write. If any write path authorizes
+// against the claimed type, that principal escalates across types.
+//
+// This is table-driven across the KNOWN entity-write entry points. When you add
+// a new entity-write entry point (a handler that ends in
+// entityManager.{Update,Apply}Entity), you MUST add a row here — the whole point
+// is that a future path authorizing against a body/claimed type is caught by an
+// existing test rather than shipping as a fresh instance of BUG-ZWTDH9.
+//
+// The two entry points today:
+//
+//   - v1 PATCH (handleV1UpdateEntity): the wire body has NO `type` field; the
+//     handler loads the stored entity and passes IT (with its stored type) to
+//     UpdateEntity, and the URL's declared type must equal the stored type or
+//     the request 404s. Type is structurally immutable — there is no body field
+//     to smuggle a different type through. The invariant is enforced by
+//     construction; the test pins that a cross-type attempt (wrong plural/type
+//     segment for the id) does not authorize-and-write against the claimed type.
+//   - sync PUT (putEntity -> ApplyEntity): the body carries `type` (it is an
+//     upsert). The apply path rejects a body type that differs from the stored
+//     type (ErrTypeImmutable -> 422). Covered directly here.
+func TestWriteSubjectTypeInvariant(t *testing.T) {
+	// Policy: mallory may write type `note`, and read both `note` and `secret`.
+	// She may NOT write `secret`. Every case below targets an existing SECRET-1
+	// while claiming type `note`; the invariant is that no path lets her write.
+	const policy = `
+roles:
+  note-editor:
+    update: [note]
+    read: [note, secret]
+assignments:
+  mallory: note-editor
+`
+
+	// writePath describes one entity-write entry point and how a cross-type
+	// write is attempted against it. attempt returns the HTTP status.
+	type writePath struct {
+		name string
+		// attempt seeds nothing (the harness seeds SECRET-1) and issues the
+		// cross-type write against the pre-seeded SECRET-1, returning the code.
+		attempt func(t *testing.T, app *App) int
+		// wantWritten reports whether, after the attempt, a note-typed entity
+		// with the target id is permitted to exist. Always false: the invariant
+		// is that the secret is never re-typed.
+	}
+
+	paths := []writePath{
+		{
+			name: "sync PUT (ApplyEntity)",
+			attempt: func(t *testing.T, app *App) int {
+				t.Helper()
+				cur, exists := app.currentEntityHash(context.Background(), "SECRET-1")
+				if !exists {
+					t.Fatal("seed missing")
+				}
+				body := syncEntityBody{ID: "SECRET-1", Type: "note", Properties: map[string]any{"title": "pwned"}}
+				b, _ := json.Marshal(body)
+				r := httptest.NewRequest(http.MethodPut, "/api/sync/entities/SECRET-1", bytes.NewReader(b))
+				r.Header.Set("Content-Type", "application/json")
+				r.Header.Set("If-Match", cur)
+				w := httptest.NewRecorder()
+				app.NewRouter().ServeHTTP(w, r)
+				return w.Code
+			},
+		},
+		{
+			name: "v1 PATCH (UpdateEntity)",
+			attempt: func(t *testing.T, app *App) int {
+				t.Helper()
+				// Address SECRET-1 through the `notes` collection (claimed type
+				// note). The handler asserts stored.Type == URL type, so this
+				// must NOT authorize-and-write as a note; it 404s (existence
+				// oracle avoidance) rather than re-typing the secret.
+				body := map[string]any{"properties": map[string]any{"title": "pwned"}}
+				b, _ := json.Marshal(body)
+				r := httptest.NewRequest(http.MethodPatch, "/api/v1/notes/SECRET-1", bytes.NewReader(b))
+				r.Header.Set("Content-Type", "application/json")
+				w := httptest.NewRecorder()
+				app.NewRouter().ServeHTTP(w, r)
+				return w.Code
+			},
+		},
+	}
+
+	for _, p := range paths {
+		t.Run(p.name, func(t *testing.T) {
+			app := buildSecretNoteApp(t, policy, "mallory")
+			// Config needs the `notes` list/plural so the v1 route resolves the
+			// plural to the note type.
+			seedEntity(app, &entity.Entity{
+				ID: "SECRET-1", Type: "secret", Properties: map[string]any{"title": "top secret"},
+			})
+
+			code := p.attempt(t, app)
+
+			// The write must NOT succeed (2xx). It is either rejected as a
+			// type change (422) or refused as not-found (404) — never applied.
+			if code >= 200 && code < 300 {
+				t.Fatalf("%s: cross-type write returned %d (2xx) — the secret was written against the claimed type (BUG-ZWTDH9)", p.name, code)
+			}
+
+			// The stored entity must remain a secret with its original title.
+			got, err := app.store.GetEntity(context.Background(), "SECRET-1")
+			if err != nil {
+				t.Fatalf("%s: GetEntity(SECRET-1): %v", p.name, err)
+			}
+			if got.Type != "secret" {
+				t.Fatalf("%s: stored type mutated to %q; the ACL subject was bound to the claimed type, not the stored one", p.name, got.Type)
+			}
+			if got.GetString("title") != "top secret" {
+				t.Fatalf("%s: stored title overwritten to %q", p.name, got.GetString("title"))
+			}
+			// No note-typed entity with the target id may exist.
+			if n, err := app.store.GetEntity(context.Background(), "SECRET-1"); err == nil && n.Type == "note" {
+				t.Fatalf("%s: SECRET-1 was re-typed to note", p.name)
+			}
+		})
+	}
+}

--- a/internal/entitymanager/apply.go
+++ b/internal/entitymanager/apply.go
@@ -87,15 +87,30 @@ func (m *Manager) ApplyEntity(ctx context.Context, e *entity.Entity) (*entity.Up
 		return nil, fmt.Errorf("entitymanager: ApplyEntity: entity %s has inaccessible fields", e.ID)
 	}
 
-	_, getErr := m.deps.Store.GetEntity(ctx, e.ID)
+	stored, getErr := m.deps.Store.GetEntity(ctx, e.ID)
 	op, err := resolveUpsertOp(getErr, audit.OpCreateEntity, audit.OpUpdateEntity)
 	if err != nil {
 		return nil, fmt.Errorf("entitymanager: ApplyEntity: existence check for %s: %w", e.ID, err)
 	}
 
+	// On UPDATE, the authorization subject must be bound to the RESOURCE, not
+	// the body. Type is immutable on update: authorize (and below, validate)
+	// against the stored type, and hard-reject a body type that differs — a
+	// mismatch is a cross-type write-privilege escalation, not a legal edit
+	// (BUG-ZWTDH9). On CREATE (entity does not yet exist) the body type IS the
+	// new entity's type, so subjectType is simply e.Type.
+	subjectType := e.Type
+	if op.aclOp == acl.OpUpdate {
+		if e.Type != stored.Type {
+			return nil, fmt.Errorf("entitymanager: ApplyEntity: %s: %w (stored %q, body %q)",
+				e.ID, ErrTypeImmutable, stored.Type, e.Type)
+		}
+		subjectType = stored.Type
+	}
+
 	if err := m.authorizeAndAudit(ctx, acl.WriteRequest{
 		Op:      op.aclOp,
-		Subject: acl.EntitySubject{Type: e.Type, ID: e.ID},
+		Subject: acl.EntitySubject{Type: subjectType, ID: e.ID},
 	}); err != nil {
 		return nil, err
 	}

--- a/internal/entitymanager/apply.go
+++ b/internal/entitymanager/apply.go
@@ -135,9 +135,11 @@ func (m *Manager) ApplyEntity(ctx context.Context, e *entity.Entity) (*entity.Up
 	// probe) is a lost-update + type-re-type vector if it silently
 	// updates: reject it as ErrEntityAlreadyExists so the caller re-reads
 	// (the sync handler maps it to 409). An update whose row vanished
-	// concurrently surfaces as ErrEntityNotFound (mapped to a 412
-	// conflict). This is what closes the residual on the postgres
-	// multi-writer backend (BUG-ZWTDH9).
+	// concurrently surfaces as ErrEntityVanishedOnUpdate (wrapping
+	// ErrEntityNotFound; the sync handler maps it to a 412 conflict,
+	// symmetric with the relation vanished-on-update case). This is what
+	// closes the residual on the postgres multi-writer backend
+	// (BUG-ZWTDH9).
 	if err := m.persistApplyEntity(ctx, op.aclOp, e); err != nil {
 		return nil, err
 	}
@@ -148,9 +150,10 @@ func (m *Manager) ApplyEntity(ctx context.Context, e *entity.Entity) (*entity.Up
 
 // persistApplyEntity writes e by the resolved apply intent: OpCreate ->
 // CreateEntity (a conflict is ErrEntityAlreadyExists — never overwrite);
-// OpUpdate -> UpdateEntity (a vanished row is ErrEntityNotFound). Neither
-// branch falls back to the other, so a create-intent write that races a
-// concurrent create can never become a blind, re-typing update.
+// OpUpdate -> UpdateEntity (a vanished row is ErrEntityVanishedOnUpdate, which
+// wraps ErrEntityNotFound). Neither branch falls back to the other, so a
+// create-intent write that races a concurrent create can never become a blind,
+// re-typing update.
 func (m *Manager) persistApplyEntity(ctx context.Context, op acl.Op, e *entity.Entity) error {
 	if op == acl.OpCreate {
 		if err := m.deps.Store.CreateEntity(ctx, e); err != nil {
@@ -163,7 +166,13 @@ func (m *Manager) persistApplyEntity(ctx context.Context, op acl.Op, e *entity.E
 	}
 	if err := m.deps.Store.UpdateEntity(ctx, e); err != nil {
 		if errors.Is(err, store.ErrNotFound) {
-			return fmt.Errorf("%w: %s", ErrEntityNotFound, e.ID)
+			// The probe saw the entity but the row vanished before the write
+			// (a concurrent delete). Surface ErrEntityVanishedOnUpdate, which
+			// wraps ErrEntityNotFound so existing errors.Is callers still match
+			// while the sync handler can map this narrow race to a 412 conflict
+			// (symmetric with the relation vanished-on-update case), distinct
+			// from the 404 reserved for a missing relation endpoint.
+			return fmt.Errorf("%w: %s", ErrEntityVanishedOnUpdate, e.ID)
 		}
 		return fmt.Errorf("entitymanager: ApplyEntity: %w", err)
 	}

--- a/internal/entitymanager/apply.go
+++ b/internal/entitymanager/apply.go
@@ -62,9 +62,11 @@ func resolveUpsertOp(getErr error, createAudit, updateAudit string) (upsertOp, e
 //   - Like every write path, it authorizes against the ACL, validates against
 //     the metamodel (hard errors abort; soft conditions ride along as
 //     warnings), and emits an audit record AFTER the durable write (consistent
-//     with Create/Update — a committed write is never left unaudited). It must
-//     not be confused with the internal upsertEntity, a raw store write with
-//     none of that.
+//     with Create/Update — a committed write is never left unaudited). The
+//     durable write is a direct CreateEntity or UpdateEntity chosen by the
+//     resolved intent — never an upsert: a create-intent write that races a
+//     concurrent create is rejected (ErrEntityAlreadyExists), not silently
+//     turned into a re-typing overwrite (BUG-ZWTDH9).
 //
 // ID-prefix note: validation includes the metamodel's ID-prefix check, which is
 // a HARD error. Sync therefore assumes peers share a metamodel (so a
@@ -128,12 +130,44 @@ func (m *Manager) ApplyEntity(ctx context.Context, e *entity.Entity) (*entity.Up
 		return nil, err
 	}
 
-	if err := upsertEntity(ctx, m.deps.Store, e); err != nil {
-		return nil, fmt.Errorf("entitymanager: ApplyEntity: %w", err)
+	// Write by RESOLVED intent — never upsert. A create that conflicts
+	// (a concurrent create of the same ID landed since the existence
+	// probe) is a lost-update + type-re-type vector if it silently
+	// updates: reject it as ErrEntityAlreadyExists so the caller re-reads
+	// (the sync handler maps it to 409). An update whose row vanished
+	// concurrently surfaces as ErrEntityNotFound (mapped to a 412
+	// conflict). This is what closes the residual on the postgres
+	// multi-writer backend (BUG-ZWTDH9).
+	if err := m.persistApplyEntity(ctx, op.aclOp, e); err != nil {
+		return nil, err
 	}
 	m.recordEntityAudit(ctx, op.auditOp, e, op.summary)
 
 	return &entity.UpdateResult{Entity: e, Warnings: soft}, nil
+}
+
+// persistApplyEntity writes e by the resolved apply intent: OpCreate ->
+// CreateEntity (a conflict is ErrEntityAlreadyExists — never overwrite);
+// OpUpdate -> UpdateEntity (a vanished row is ErrEntityNotFound). Neither
+// branch falls back to the other, so a create-intent write that races a
+// concurrent create can never become a blind, re-typing update.
+func (m *Manager) persistApplyEntity(ctx context.Context, op acl.Op, e *entity.Entity) error {
+	if op == acl.OpCreate {
+		if err := m.deps.Store.CreateEntity(ctx, e); err != nil {
+			if errors.Is(err, store.ErrConflict) {
+				return fmt.Errorf("%w: %s", ErrEntityAlreadyExists, e.ID)
+			}
+			return fmt.Errorf("entitymanager: ApplyEntity: %w", err)
+		}
+		return nil
+	}
+	if err := m.deps.Store.UpdateEntity(ctx, e); err != nil {
+		if errors.Is(err, store.ErrNotFound) {
+			return fmt.Errorf("%w: %s", ErrEntityNotFound, e.ID)
+		}
+		return fmt.Errorf("entitymanager: ApplyEntity: %w", err)
+	}
+	return nil
 }
 
 // ApplyRelation upserts a relation by its from/type/to triple, with the same
@@ -191,12 +225,38 @@ func (m *Manager) ApplyRelation(ctx context.Context, r *entity.Relation) (*entit
 		return nil, fmt.Errorf("entitymanager: ApplyRelation: invalid relation: %w", vErr)
 	}
 
-	if err := upsertRelation(ctx, m.deps.Store, r); err != nil {
-		return nil, fmt.Errorf("entitymanager: ApplyRelation: %w", err)
+	// Write by RESOLVED intent — never upsert (BUG-ZWTDH9). OpCreate ->
+	// CreateRelation (a conflict is ErrRelationAlreadyExists); OpUpdate ->
+	// UpdateRelation (a vanished row is ErrRelationNotFound).
+	if err := m.persistApplyRelation(ctx, op.aclOp, r); err != nil {
+		return nil, err
 	}
 	m.recordRelationAudit(ctx, op.auditOp, r, op.summary)
 
 	return r, nil
+}
+
+// persistApplyRelation writes r by the resolved apply intent, mirroring
+// persistApplyEntity: no create-then-update fallback, so a create-intent
+// write that races a concurrent create is rejected, not silently merged.
+func (m *Manager) persistApplyRelation(ctx context.Context, op acl.Op, r *entity.Relation) error {
+	data := store.RelationData{Properties: r.Properties, Content: r.Content}
+	if op == acl.OpCreate {
+		if _, err := m.deps.Store.CreateRelation(ctx, r.From, r.Type, r.To, &data); err != nil {
+			if errors.Is(err, store.ErrConflict) {
+				return fmt.Errorf("%w: %s --%s--> %s", ErrRelationAlreadyExists, r.From, r.Type, r.To)
+			}
+			return fmt.Errorf("entitymanager: ApplyRelation: %w", err)
+		}
+		return nil
+	}
+	if _, err := m.deps.Store.UpdateRelation(ctx, r.From, r.Type, r.To, data); err != nil {
+		if errors.Is(err, store.ErrNotFound) {
+			return fmt.Errorf("%w: %s --%s--> %s", ErrRelationNotFound, r.From, r.Type, r.To)
+		}
+		return fmt.Errorf("entitymanager: ApplyRelation: %w", err)
+	}
+	return nil
 }
 
 // requireEndpoint loads a relation endpoint, distinguishing a genuine

--- a/internal/entitymanager/apply_conflict_test.go
+++ b/internal/entitymanager/apply_conflict_test.go
@@ -1,0 +1,191 @@
+package entitymanager_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/Sourcehaven-BV/rela/internal/acl"
+	"github.com/Sourcehaven-BV/rela/internal/audit"
+	"github.com/Sourcehaven-BV/rela/internal/entity"
+	"github.com/Sourcehaven-BV/rela/internal/entitymanager"
+	"github.com/Sourcehaven-BV/rela/internal/store"
+	"github.com/Sourcehaven-BV/rela/internal/store/memstore"
+)
+
+// raceCreateStore models the postgres multi-writer TOCTOU that BUG-ZWTDH9's
+// residual rode on: ApplyEntity's existence probe (GetEntity) observes the id
+// as ABSENT — so the intent resolves to CREATE — but a concurrent writer lands
+// the id between the probe and the durable write, so CreateEntity conflicts.
+//
+// GetEntity delegates to the wrapped store (which does NOT yet hold the id), and
+// CreateEntity returns store.ErrConflict WITHOUT writing. The wrapped store is
+// pre-seeded with the "winner" so the test can assert the loser never
+// overwrote or re-typed it. UpdateEntity is counted and delegated, so a
+// create-that-fell-through-to-update (the removed upsert fallback) would both
+// bump the counter and clobber the seeded winner — exactly what must not happen.
+type raceCreateStore struct {
+	store.Store
+	updateCalls int
+}
+
+func (s *raceCreateStore) CreateEntity(_ context.Context, _ *entity.Entity) error {
+	return store.ErrConflict
+}
+
+func (s *raceCreateStore) UpdateEntity(ctx context.Context, e *entity.Entity) error {
+	s.updateCalls++
+	return s.Store.UpdateEntity(ctx, e)
+}
+
+// GetEntity reports the id as absent so ApplyEntity resolves CREATE intent,
+// while the wrapped store separately holds the seeded winner for verification.
+func (s *raceCreateStore) GetEntity(_ context.Context, _ string) (*entity.Entity, error) {
+	return nil, store.ErrNotFound
+}
+
+// TestApplyEntity_CreateConflict_RejectsAndDoesNotClobber pins that a
+// create-intent ApplyEntity whose durable CreateEntity conflicts (a concurrent
+// create of the same id) is REJECTED with ErrEntityAlreadyExists and never
+// falls through to an UpdateEntity. This closes both residuals at once: the
+// lost-update clobber (a racing create is not blindly overwritten) and the
+// type-re-type vector (a create-intent write that conflicts can no longer
+// become a blind, re-typing update on the postgres multi-writer backend).
+func TestApplyEntity_CreateConflict_RejectsAndDoesNotClobber(t *testing.T) {
+	inner := memstore.New()
+	// The "winner": a secret-typed entity a concurrent writer already landed.
+	// The apply under test claims the SAME id with a DIFFERENT type — the
+	// re-type attempt must not land.
+	meta := typeConfusionMeta(t)
+	if err := inner.CreateEntity(context.Background(), &entity.Entity{
+		ID: "SECRET-1", Type: "secret", Properties: map[string]any{"title": "winner"},
+	}); err != nil {
+		t.Fatalf("seed winner: %v", err)
+	}
+
+	st := &raceCreateStore{Store: inner}
+	mgr, err := entitymanager.New(entitymanager.Deps{
+		Store: st, Meta: meta, Templater: nopTemplater{}, Audit: audit.Nop{}, ACL: acl.NopACL{},
+	})
+	if err != nil {
+		t.Fatalf("entitymanager.New: %v", err)
+	}
+
+	// Create-intent apply (probe says absent) that races a concurrent create.
+	_, applyErr := mgr.ApplyEntity(context.Background(), &entity.Entity{
+		ID: "SECRET-1", Type: "note", Properties: map[string]any{"title": "loser re-types to note"},
+	})
+	if applyErr == nil {
+		t.Fatal("create-conflict apply succeeded — a racing create was silently overwritten (lost-update residual)")
+	}
+	if !errors.Is(applyErr, entitymanager.ErrEntityAlreadyExists) {
+		t.Fatalf("expected ErrEntityAlreadyExists, got %T: %v", applyErr, applyErr)
+	}
+	if st.updateCalls != 0 {
+		t.Fatalf("create fell through to UpdateEntity %d time(s) — the upsert fallback re-appeared", st.updateCalls)
+	}
+
+	// The seeded winner must be untouched: still a secret, original title.
+	got, err := inner.GetEntity(context.Background(), "SECRET-1")
+	if err != nil {
+		t.Fatalf("GetEntity(SECRET-1): %v", err)
+	}
+	if got.Type != "secret" {
+		t.Fatalf("winner was re-typed to %q; the create-conflict became a re-typing overwrite", got.Type)
+	}
+	if got.GetString("title") != "winner" {
+		t.Fatalf("winner title overwritten to %q; the create-conflict clobbered the racing create", got.GetString("title"))
+	}
+}
+
+// TestApplyEntity_SameTypeCreateConflict_NoClobber is the same-type variant:
+// two concurrent creates of the SAME id and SAME type. There is no re-typing
+// here, only the lost-update question — the loser must still be rejected, not
+// silently overwrite the winner's content.
+func TestApplyEntity_SameTypeCreateConflict_NoClobber(t *testing.T) {
+	inner := memstore.New()
+	meta := typeConfusionMeta(t)
+	if err := inner.CreateEntity(context.Background(), &entity.Entity{
+		ID: "NOTE-1", Type: "note", Properties: map[string]any{"title": "winner"},
+	}); err != nil {
+		t.Fatalf("seed winner: %v", err)
+	}
+
+	st := &raceCreateStore{Store: inner}
+	mgr, err := entitymanager.New(entitymanager.Deps{
+		Store: st, Meta: meta, Templater: nopTemplater{}, Audit: audit.Nop{}, ACL: acl.NopACL{},
+	})
+	if err != nil {
+		t.Fatalf("entitymanager.New: %v", err)
+	}
+
+	_, applyErr := mgr.ApplyEntity(context.Background(), &entity.Entity{
+		ID: "NOTE-1", Type: "note", Properties: map[string]any{"title": "loser"},
+	})
+	if !errors.Is(applyErr, entitymanager.ErrEntityAlreadyExists) {
+		t.Fatalf("expected ErrEntityAlreadyExists, got %T: %v", applyErr, applyErr)
+	}
+	if st.updateCalls != 0 {
+		t.Fatalf("same-type create fell through to UpdateEntity %d time(s) — must never clobber", st.updateCalls)
+	}
+	got, err := inner.GetEntity(context.Background(), "NOTE-1")
+	if err != nil {
+		t.Fatalf("GetEntity(NOTE-1): %v", err)
+	}
+	if got.GetString("title") != "winner" {
+		t.Fatalf("winner title overwritten to %q; a same-type racing create was clobbered", got.GetString("title"))
+	}
+}
+
+// raceUpdateStore models the mirror race: ApplyEntity's probe observes the id
+// as PRESENT (resolving UPDATE intent), but the row vanishes (a concurrent
+// delete) before the durable UpdateEntity, which returns store.ErrNotFound.
+type raceUpdateStore struct {
+	store.Store
+	createCalls int
+	stored      *entity.Entity
+}
+
+func (s *raceUpdateStore) GetEntity(_ context.Context, _ string) (*entity.Entity, error) {
+	return s.stored, nil
+}
+
+func (s *raceUpdateStore) CreateEntity(ctx context.Context, e *entity.Entity) error {
+	s.createCalls++
+	return s.Store.CreateEntity(ctx, e)
+}
+
+func (s *raceUpdateStore) UpdateEntity(_ context.Context, _ *entity.Entity) error {
+	return store.ErrNotFound
+}
+
+// TestApplyEntity_UpdateVanished_RejectsWithoutCreating pins that an
+// update-intent apply whose row vanished concurrently surfaces as
+// ErrEntityNotFound and never falls through to a CreateEntity (which would
+// resurrect a deleted record). The old upsert did the opposite direction, but
+// the invariant is symmetric: an update never becomes a create.
+func TestApplyEntity_UpdateVanished_RejectsWithoutCreating(t *testing.T) {
+	meta := typeConfusionMeta(t)
+	st := &raceUpdateStore{
+		Store:  memstore.New(),
+		stored: &entity.Entity{ID: "NOTE-1", Type: "note", Properties: map[string]any{"title": "v1"}},
+	}
+	mgr, err := entitymanager.New(entitymanager.Deps{
+		Store: st, Meta: meta, Templater: nopTemplater{}, Audit: audit.Nop{}, ACL: acl.NopACL{},
+	})
+	if err != nil {
+		t.Fatalf("entitymanager.New: %v", err)
+	}
+
+	// Same type as stored (so the type-immutability guard passes) → resolves
+	// UPDATE intent → durable UpdateEntity returns ErrNotFound.
+	_, applyErr := mgr.ApplyEntity(context.Background(), &entity.Entity{
+		ID: "NOTE-1", Type: "note", Properties: map[string]any{"title": "v2"},
+	})
+	if !errors.Is(applyErr, entitymanager.ErrEntityNotFound) {
+		t.Fatalf("expected ErrEntityNotFound, got %T: %v", applyErr, applyErr)
+	}
+	if st.createCalls != 0 {
+		t.Fatalf("update fell through to CreateEntity %d time(s) — an update must never become a create", st.createCalls)
+	}
+}

--- a/internal/entitymanager/apply_type_confusion_test.go
+++ b/internal/entitymanager/apply_type_confusion_test.go
@@ -1,0 +1,197 @@
+package entitymanager_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/Sourcehaven-BV/rela/internal/acl"
+	"github.com/Sourcehaven-BV/rela/internal/audit"
+	"github.com/Sourcehaven-BV/rela/internal/entity"
+	"github.com/Sourcehaven-BV/rela/internal/entitymanager"
+	"github.com/Sourcehaven-BV/rela/internal/metamodel"
+	"github.com/Sourcehaven-BV/rela/internal/principal"
+	"github.com/Sourcehaven-BV/rela/internal/store"
+	"github.com/Sourcehaven-BV/rela/internal/store/memstore"
+)
+
+// typeConfusionMetamodel declares two manual-id entity types with no id_prefix,
+// so the ID-prefix structural guard (a HARD validation error for prefixed,
+// sequential types) does NOT fire — this is exactly the shape the BUG-ZWTDH9
+// exploit relies on: a `manual` id_type target that skips the prefix check, so
+// the ONLY defense against re-typing is the ACL/apply layer under test.
+const typeConfusionMetamodel = `version: "1.0"
+entities:
+  secret:
+    label: Secret
+    plural: secrets
+    id_type: manual
+    properties:
+      title:
+        type: string
+  note:
+    label: Note
+    plural: notes
+    id_type: manual
+    properties:
+      title:
+        type: string
+`
+
+func typeConfusionMeta(t *testing.T) *metamodel.Metamodel {
+	t.Helper()
+	m, err := metamodel.Parse([]byte(typeConfusionMetamodel))
+	if err != nil {
+		t.Fatalf("metamodel.Parse: %v", err)
+	}
+	return m
+}
+
+// TestApplyEntity_RejectsTypeChangeOnUpdate is the BUG-ZWTDH9 PoC-as-test.
+//
+// A principal (mallory) is granted `update` on `note` and `read` on `secret`
+// (a plausible least-privilege grant). She cannot update secrets. She issues an
+// upsert against an EXISTING `secret`-typed entity with a body claiming type
+// `note`. Before the fix, ApplyEntity authorized OpUpdate against the BODY type
+// (note) — which she may update — and re-typed + overwrote the secret. The fix
+// authorizes and validates against the STORED type and hard-rejects a body type
+// that differs, so the upsert is rejected with ErrTypeImmutable and the stored
+// entity is untouched (still a secret, unchanged title).
+func TestApplyEntity_RejectsTypeChangeOnUpdate(t *testing.T) {
+	st := memstore.New()
+	meta := typeConfusionMeta(t)
+
+	// Seed a secret via a NopACL manager (seeding bypasses authz).
+	seedMgr, err := entitymanager.New(entitymanager.Deps{
+		Store: st, Meta: meta, Templater: nopTemplater{}, Audit: audit.Nop{}, ACL: acl.NopACL{},
+	})
+	if err != nil {
+		t.Fatalf("seed New: %v", err)
+	}
+	if _, err := seedMgr.ApplyEntity(context.Background(), &entity.Entity{
+		ID: "SECRET-1", Type: "secret", Properties: map[string]any{"title": "top secret"},
+	}); err != nil {
+		t.Fatalf("seed secret: %v", err)
+	}
+
+	// Policy: mallory may UPDATE notes and READ secrets — but NOT update secrets.
+	policy, err := acl.LoadPolicyBytes([]byte(`
+roles:
+  note-editor:
+    update: [note]
+    read: [note, secret]
+assignments:
+  mallory: note-editor
+`))
+	if err != nil {
+		t.Fatalf("LoadPolicyBytes: %v", err)
+	}
+	declarative, err := acl.NewDeclarative(policy, acl.NewStoreGraph(st), st)
+	if err != nil {
+		t.Fatalf("NewDeclarative: %v", err)
+	}
+	sink := audit.NewMemory()
+	mgr, err := entitymanager.New(entitymanager.Deps{
+		Store: st, Meta: meta, Templater: nopTemplater{}, Audit: sink, ACL: declarative,
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	malloryCtx := principal.With(context.Background(),
+		principal.Principal{User: "mallory", Tool: principal.ToolSync})
+
+	// The exploit: overwrite + re-type the secret by claiming type `note`.
+	_, applyErr := mgr.ApplyEntity(malloryCtx, &entity.Entity{
+		ID: "SECRET-1", Type: "note", Properties: map[string]any{"title": "pwned"},
+	})
+	if applyErr == nil {
+		t.Fatal("cross-type upsert succeeded — BUG-ZWTDH9 reproduced (authorized against body type, not stored type)")
+	}
+	if !errors.Is(applyErr, entitymanager.ErrTypeImmutable) {
+		t.Fatalf("expected ErrTypeImmutable, got %T: %v", applyErr, applyErr)
+	}
+
+	// The stored entity must be UNCHANGED: still a secret, original title.
+	got, err := st.GetEntity(context.Background(), "SECRET-1")
+	if err != nil {
+		t.Fatalf("GetEntity(SECRET-1): %v", err)
+	}
+	if got.Type != "secret" {
+		t.Fatalf("stored type was mutated to %q; must remain \"secret\"", got.Type)
+	}
+	if got.GetString("title") != "top secret" {
+		t.Fatalf("stored title was overwritten to %q; must remain \"top secret\"", got.GetString("title"))
+	}
+
+	// A note by that ID must NOT have been created as a side effect.
+	notes := 0
+	for e, err := range st.ListEntities(context.Background(), store.EntityQuery{Type: "note"}) {
+		if err != nil {
+			continue
+		}
+		if e.Type == "note" {
+			notes++
+		}
+	}
+	if notes != 0 {
+		t.Fatalf("a note-typed entity was written despite rejection (%d found)", notes)
+	}
+}
+
+// TestApplyEntity_SameTypeUpdateStillWorks pins that the fix does not break a
+// legitimate same-type update: mallory CAN update a note she is permitted to
+// edit, and the write lands.
+func TestApplyEntity_SameTypeUpdateStillWorks(t *testing.T) {
+	st := memstore.New()
+	meta := typeConfusionMeta(t)
+
+	seedMgr, err := entitymanager.New(entitymanager.Deps{
+		Store: st, Meta: meta, Templater: nopTemplater{}, Audit: audit.Nop{}, ACL: acl.NopACL{},
+	})
+	if err != nil {
+		t.Fatalf("seed New: %v", err)
+	}
+	if _, err := seedMgr.ApplyEntity(context.Background(), &entity.Entity{
+		ID: "NOTE-1", Type: "note", Properties: map[string]any{"title": "v1"},
+	}); err != nil {
+		t.Fatalf("seed note: %v", err)
+	}
+
+	policy, err := acl.LoadPolicyBytes([]byte(`
+roles:
+  note-editor:
+    update: [note]
+    read: [note, secret]
+assignments:
+  mallory: note-editor
+`))
+	if err != nil {
+		t.Fatalf("LoadPolicyBytes: %v", err)
+	}
+	declarative, err := acl.NewDeclarative(policy, acl.NewStoreGraph(st), st)
+	if err != nil {
+		t.Fatalf("NewDeclarative: %v", err)
+	}
+	mgr, err := entitymanager.New(entitymanager.Deps{
+		Store: st, Meta: meta, Templater: nopTemplater{}, Audit: audit.Nop{}, ACL: declarative,
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	malloryCtx := principal.With(context.Background(),
+		principal.Principal{User: "mallory", Tool: principal.ToolSync})
+
+	if _, err := mgr.ApplyEntity(malloryCtx, &entity.Entity{
+		ID: "NOTE-1", Type: "note", Properties: map[string]any{"title": "v2"},
+	}); err != nil {
+		t.Fatalf("legitimate same-type update was rejected: %v", err)
+	}
+	got, err := st.GetEntity(context.Background(), "NOTE-1")
+	if err != nil {
+		t.Fatalf("GetEntity(NOTE-1): %v", err)
+	}
+	if got.GetString("title") != "v2" {
+		t.Fatalf("same-type update did not land: title = %q", got.GetString("title"))
+	}
+}

--- a/internal/entitymanager/apply_type_confusion_test.go
+++ b/internal/entitymanager/apply_type_confusion_test.go
@@ -68,10 +68,10 @@ func TestApplyEntity_RejectsTypeChangeOnUpdate(t *testing.T) {
 	if err != nil {
 		t.Fatalf("seed New: %v", err)
 	}
-	if _, err := seedMgr.ApplyEntity(context.Background(), &entity.Entity{
+	if _, seedErr := seedMgr.ApplyEntity(context.Background(), &entity.Entity{
 		ID: "SECRET-1", Type: "secret", Properties: map[string]any{"title": "top secret"},
-	}); err != nil {
-		t.Fatalf("seed secret: %v", err)
+	}); seedErr != nil {
+		t.Fatalf("seed secret: %v", seedErr)
 	}
 
 	// Policy: mallory may UPDATE notes and READ secrets — but NOT update secrets.
@@ -152,10 +152,10 @@ func TestApplyEntity_SameTypeUpdateStillWorks(t *testing.T) {
 	if err != nil {
 		t.Fatalf("seed New: %v", err)
 	}
-	if _, err := seedMgr.ApplyEntity(context.Background(), &entity.Entity{
+	if _, seedErr := seedMgr.ApplyEntity(context.Background(), &entity.Entity{
 		ID: "NOTE-1", Type: "note", Properties: map[string]any{"title": "v1"},
-	}); err != nil {
-		t.Fatalf("seed note: %v", err)
+	}); seedErr != nil {
+		t.Fatalf("seed note: %v", seedErr)
 	}
 
 	policy, err := acl.LoadPolicyBytes([]byte(`
@@ -182,10 +182,10 @@ assignments:
 	malloryCtx := principal.With(context.Background(),
 		principal.Principal{User: "mallory", Tool: principal.ToolSync})
 
-	if _, err := mgr.ApplyEntity(malloryCtx, &entity.Entity{
+	if _, updErr := mgr.ApplyEntity(malloryCtx, &entity.Entity{
 		ID: "NOTE-1", Type: "note", Properties: map[string]any{"title": "v2"},
-	}); err != nil {
-		t.Fatalf("legitimate same-type update was rejected: %v", err)
+	}); updErr != nil {
+		t.Fatalf("legitimate same-type update was rejected: %v", updErr)
 	}
 	got, err := st.GetEntity(context.Background(), "NOTE-1")
 	if err != nil {

--- a/internal/entitymanager/cascadehost.go
+++ b/internal/entitymanager/cascadehost.go
@@ -2,6 +2,7 @@ package entitymanager
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -27,8 +28,8 @@ import (
 //
 // Audit: cascadeHost emits audit records directly (bypassing
 // Manager's recordEntityAudit / recordRelationAudit) because it
-// bypasses Manager itself — going through createCore / upsertEntity
-// to avoid double-cascading. Records carry triggered_by="automation"
+// bypasses Manager itself — going through createCore / direct store
+// writes to avoid double-cascading. Records carry triggered_by="automation"
 // (or the cascade-delete label when invoked from IfExistsReplace) to
 // distinguish them from direct writes.
 type cascadeHost struct {
@@ -63,17 +64,23 @@ func (h *cascadeHost) CreateEntity(
 	return e, err
 }
 
-// WriteEntity satisfies [autocascade.Host.WriteEntity] by performing
-// a bare upsert against the store.
+// WriteEntity satisfies [autocascade.Host.WriteEntity] by updating an
+// already-persisted entity.
 //
-// Note: no audit record here. WriteEntity is invoked by the Runner
-// to persist post-cascade property changes onto an entity that was
-// just created via CreateEntity in the same cascade — the create
-// already produced one audit record. Emitting another for the
-// property-set step would double-count the same entity creation in
-// the audit log.
+// It is an UPDATE, never an upsert: the Runner only calls WriteEntity to
+// persist post-cascade property changes onto an entity it created via
+// CreateEntity earlier in the SAME cascade, so the row is guaranteed to
+// exist. A create-then-update fallback here would be the lost-update /
+// type-re-type vector removed in BUG-ZWTDH9.
+//
+// Note: no audit record here. The earlier CreateEntity already produced
+// one audit record for this entity; emitting another for the property-set
+// step would double-count the same creation in the audit log.
 func (h *cascadeHost) WriteEntity(ctx context.Context, e *entity.Entity) error {
-	return upsertEntity(ctx, h.deps.Store, e)
+	if e == nil {
+		return nil
+	}
+	return h.deps.Store.UpdateEntity(ctx, e)
 }
 
 // GetEntity satisfies [autocascade.Host.GetEntity] by forwarding to
@@ -82,10 +89,29 @@ func (h *cascadeHost) GetEntity(ctx context.Context, id string) (*entity.Entity,
 	return h.deps.Store.GetEntity(ctx, id)
 }
 
-// WriteRelation satisfies [autocascade.Host.WriteRelation] by
-// performing a bare upsert against the store.
+// WriteRelation satisfies [autocascade.Host.WriteRelation] by CREATING
+// the automation-generated relation.
+//
+// It is a create, never an upsert: the Runner only calls WriteRelation
+// for freshly built [automation.Result.RelationsToCreate] and trigger
+// relations, so the intent is always create. A store.ErrConflict means
+// the identical triple already exists — an idempotent re-trigger of the
+// same automation, not a lost-update race (cascades run in-process under
+// the write lock). Treat that as a no-op success rather than blindly
+// overwriting it (which was the removed create-then-update fallback,
+// BUG-ZWTDH9); no audit record is emitted for the no-op since nothing
+// was written.
 func (h *cascadeHost) WriteRelation(ctx context.Context, r *entity.Relation) error {
-	if err := upsertRelation(ctx, h.deps.Store, r); err != nil {
+	if r == nil {
+		return nil
+	}
+	if _, err := h.deps.Store.CreateRelation(ctx, r.From, r.Type, r.To, &store.RelationData{
+		Properties: r.Properties,
+		Content:    r.Content,
+	}); err != nil {
+		if errors.Is(err, store.ErrConflict) {
+			return nil
+		}
 		return err
 	}
 	h.recordCascade(ctx, audit.OpCreateRelation, relationSubject(r), "created")

--- a/internal/entitymanager/collect_errors_test.go
+++ b/internal/entitymanager/collect_errors_test.go
@@ -70,8 +70,9 @@ func newManagerOver(t *testing.T, st store.Store) *entitymanager.Manager {
 // TestCreate_FailsWhenIDScanErrors pins that auto-ID create surfaces an
 // entity-scan error instead of generating an ID from a partial list. A
 // truncated scan can hide a high-numbered existing ID, so generating
-// from it risks a collision that upsertEntity would turn into an
-// overwrite of the existing entity.
+// from it risks a collision — which createCore now rejects with
+// ErrEntityAlreadyExists (a create never overwrites), so a bad scan
+// would surface as a spurious conflict rather than data loss.
 func TestCreate_FailsWhenIDScanErrors(t *testing.T) {
 	sentinel := errors.New("boom: entity scan failed mid-stream")
 	st := &listEntitiesErrStore{Store: memstore.New(), err: sentinel}

--- a/internal/entitymanager/core.go
+++ b/internal/entitymanager/core.go
@@ -104,9 +104,9 @@ func createCore(
 	// A create must never fall through to an update — that would
 	// overwrite a colliding entity (a racing create, or a stale-scan
 	// duplicate ID). Write with a direct CreateEntity and surface a
-	// conflict as ErrEntityAlreadyExists. upsertEntity's
-	// create-then-update fallback is only for write-back-existing
-	// callers, never the create path.
+	// conflict as ErrEntityAlreadyExists. Every write path is now
+	// create-XOR-update by resolved intent; there is no create-then-
+	// update-on-conflict fallback anywhere (BUG-ZWTDH9).
 	if err := deps.Store.CreateEntity(ctx, e); err != nil {
 		if errors.Is(err, store.ErrConflict) {
 			return nil, nil, fmt.Errorf("%w: %s", ErrEntityAlreadyExists, e.ID)
@@ -208,8 +208,10 @@ func generateID(ctx context.Context, deps Deps, entityType, prefix string) (stri
 // collectAllIDs returns every entity ID currently in the store.
 // A partial scan must not feed ID generation: a truncated list can hide
 // a high-numbered existing ID, so the generator would mint one that
-// already exists and (via upsertEntity's create-then-update fallback)
-// overwrite that entity. Fail loudly instead.
+// already exists. createCore then rejects that collision with
+// ErrEntityAlreadyExists (a create never overwrites), so a truncated
+// scan would surface as a spurious conflict rather than data loss — but
+// fail loudly here regardless, so the generator is never fed bad data.
 func collectAllIDs(ctx context.Context, st store.Store) ([]string, error) {
 	ids := make([]string, 0)
 	for e, err := range st.ListEntities(ctx, store.EntityQuery{}) {
@@ -263,50 +265,6 @@ func findExistingRelationTarget(
 		if target.Type == targetType {
 			return target
 		}
-	}
-	return nil
-}
-
-// upsertEntity persists an entity to the store. Tries CreateEntity
-// first; if and only if that fails with [store.ErrConflict], falls
-// back to UpdateEntity. Any other error from CreateEntity is
-// returned as-is — masking a permission or I/O failure as a missing
-// entity would cause confusing downstream errors.
-func upsertEntity(ctx context.Context, st store.Store, e *entity.Entity) error {
-	if e == nil {
-		return nil
-	}
-	err := st.CreateEntity(ctx, e)
-	if err == nil {
-		return nil
-	}
-	if !errors.Is(err, store.ErrConflict) {
-		return err
-	}
-	return st.UpdateEntity(ctx, e)
-}
-
-// upsertRelation persists a relation to the store with the same
-// "Create-then-Update on ErrConflict" discipline as upsertEntity.
-func upsertRelation(ctx context.Context, st store.Store, r *entity.Relation) error {
-	if r == nil {
-		return nil
-	}
-	_, err := st.CreateRelation(ctx, r.From, r.Type, r.To, &store.RelationData{
-		Properties: r.Properties,
-		Content:    r.Content,
-	})
-	if err == nil {
-		return nil
-	}
-	if !errors.Is(err, store.ErrConflict) {
-		return err
-	}
-	if _, uErr := st.UpdateRelation(ctx, r.From, r.Type, r.To, store.RelationData{
-		Properties: r.Properties,
-		Content:    r.Content,
-	}); uErr != nil {
-		return fmt.Errorf("update relation: %w", uErr)
 	}
 	return nil
 }

--- a/internal/entitymanager/errors.go
+++ b/internal/entitymanager/errors.go
@@ -24,6 +24,21 @@ var ErrRelationNotFound = errors.New("relation not found")
 // or generated ID collides with an existing entity.
 var ErrEntityAlreadyExists = errors.New("entity already exists")
 
+// ErrTypeImmutable is returned by the upsert/apply path when the caller
+// supplies a type that differs from the STORED type of an existing entity.
+// An entity's type is immutable on update: an UPDATE is authorized and
+// validated against the resource's stored type, so re-typing it via the
+// body would (a) escalate a cross-type write past the ACL — a principal
+// permitted to write type B could overwrite a stored type-A record by
+// claiming type B in the body — and (b) corrupt the store (fsstore would
+// write the record under a second type's path, orphaning the original).
+// The v1 PATCH contract omits `type` from the body entirely for the same
+// reason; sync PUT carries a type (it is a create-or-update upsert) but
+// must reject a body type that contradicts the stored one. Surfaced by the
+// sync handler as HTTP 422 (a structural impossibility per DEC-HWZHA — the
+// storage layer cannot persist one ID as two types).
+var ErrTypeImmutable = errors.New("entity type is immutable on update; body type differs from the stored type")
+
 // ErrRelationAlreadyExists is returned by [Manager.CreateRelation]
 // when the (from, type, to) tuple already exists.
 var ErrRelationAlreadyExists = errors.New("relation already exists")

--- a/internal/entitymanager/errors.go
+++ b/internal/entitymanager/errors.go
@@ -20,6 +20,16 @@ var ErrEntityNotFound = errors.New("entity not found")
 // ErrRelationNotFound is returned when a relation lookup fails.
 var ErrRelationNotFound = errors.New("relation not found")
 
+// ErrEntityVanishedOnUpdate is returned by the sync apply path when an
+// update-intent write finds its target row gone at write time: the existence
+// probe observed the entity, but the durable UpdateEntity hit
+// [store.ErrNotFound] because a concurrent delete landed in between. It wraps
+// [ErrEntityNotFound] via %w so existing errors.Is(err, ErrEntityNotFound)
+// callers still match, while the sync handler can single it out and map it to
+// a 412 conflict (symmetric with the relation vanished-on-update case) rather
+// than the 404 reserved for a genuinely missing relation endpoint.
+var ErrEntityVanishedOnUpdate = fmt.Errorf("%w (vanished concurrently on update)", ErrEntityNotFound)
+
 // ErrEntityAlreadyExists is returned by create paths when the supplied
 // or generated ID collides with an existing entity.
 var ErrEntityAlreadyExists = errors.New("entity already exists")

--- a/internal/entitymanager/manager.go
+++ b/internal/entitymanager/manager.go
@@ -386,7 +386,11 @@ func (m *Manager) CreateEntity(
 		if err := checkUniqueProperties(ctx, m.deps, created, created.ID); err != nil {
 			return nil, err
 		}
-		if writeErr := upsertEntity(ctx, m.deps.Store, created); writeErr != nil {
+		// UpdateEntity, not upsert: createCore already persisted this row
+		// above, so the post-automation re-write is unambiguously an
+		// update of an existing entity (BUG-ZWTDH9 — no create-then-
+		// update fallback anywhere).
+		if writeErr := m.deps.Store.UpdateEntity(ctx, created); writeErr != nil {
 			return nil, fmt.Errorf("write entity after automation: %w", writeErr)
 		}
 		// Recompute warnings against the post-automation state
@@ -524,7 +528,10 @@ func (m *Manager) UpdateEntity(ctx context.Context, e *entity.Entity) (*entity.U
 		return nil, err
 	}
 
-	if err := upsertEntity(ctx, m.deps.Store, e); err != nil {
+	// UpdateEntity, not upsert: the GetEntity above already established
+	// the row exists (else we returned ErrEntityNotFound), so this is
+	// unambiguously an update (BUG-ZWTDH9).
+	if err := m.deps.Store.UpdateEntity(ctx, e); err != nil {
 		return nil, fmt.Errorf("write entity: %w", err)
 	}
 
@@ -733,7 +740,18 @@ func (m *Manager) CreateRelation(
 		return nil, err
 	}
 
-	if err := upsertRelation(ctx, m.deps.Store, rel); err != nil {
+	// CreateRelation, not upsert: a create must never fall through to an
+	// update (that would clobber a racing create of the same triple).
+	// The GetRelation pre-check above is advisory; the store's atomic
+	// create is the real guard, and a conflict surfaces as
+	// ErrRelationAlreadyExists (BUG-ZWTDH9).
+	if _, err := m.deps.Store.CreateRelation(ctx, from, relType, to, &store.RelationData{
+		Properties: rel.Properties,
+		Content:    rel.Content,
+	}); err != nil {
+		if errors.Is(err, store.ErrConflict) {
+			return nil, fmt.Errorf("%w: %s --%s--> %s", ErrRelationAlreadyExists, from, relType, to)
+		}
 		return nil, err
 	}
 	m.recordRelationAudit(ctx, audit.OpCreateRelation, rel, "created")
@@ -794,7 +812,13 @@ func (m *Manager) UpdateRelation(
 		rel.Content = *opts.Content
 	}
 
-	if err := upsertRelation(ctx, m.deps.Store, rel); err != nil {
+	// UpdateRelation, not upsert: the GetRelation above established the
+	// triple exists (else we returned ErrRelationNotFound), so this is
+	// unambiguously an update (BUG-ZWTDH9).
+	if _, err := m.deps.Store.UpdateRelation(ctx, from, relType, to, store.RelationData{
+		Properties: rel.Properties,
+		Content:    rel.Content,
+	}); err != nil {
 		return nil, err
 	}
 	m.recordRelationAudit(ctx, audit.OpUpdateRelation, rel, updateRelationSummary(oldProps, rel.Properties))

--- a/internal/entitymanager/manager_test.go
+++ b/internal/entitymanager/manager_test.go
@@ -114,8 +114,8 @@ func (s *countingStore) ListEntities(ctx context.Context, q store.EntityQuery) i
 
 // failingCreateStore wraps a store and forces the next N CreateEntity
 // calls to return a sentinel non-conflict error. Used to verify that
-// upsertEntity propagates non-conflict errors instead of falling
-// through to UpdateEntity.
+// createCore propagates a non-conflict store error instead of masking
+// it as a fall-through to UpdateEntity.
 type failingCreateStore struct {
 	store.Store
 	err         error
@@ -432,16 +432,15 @@ func TestCreate_WritesTwiceWithAutomationProperty(t *testing.T) {
 	if err != nil {
 		t.Fatalf("CreateEntity: %v", err)
 	}
-	// The initial create is a direct CreateEntity (no upsert fallback —
-	// a create must never become an update). The post-automation
-	// re-write goes through upsertEntity, which runs
-	// Create→conflict→Update. So creates=2 (initial + upsert probe),
-	// updates=1 (the upsert fallback).
-	if got := cs.creates.Load(); got != 2 {
-		t.Errorf("CreateEntity calls = %d, want 2 (initial create + upsert probe)", got)
+	// The initial create is a direct CreateEntity (a create must never
+	// become an update). The post-automation re-write is now a direct
+	// UpdateEntity (the row already exists from the initial create — no
+	// upsert fallback anywhere, BUG-ZWTDH9). So creates=1, updates=1.
+	if got := cs.creates.Load(); got != 1 {
+		t.Errorf("CreateEntity calls = %d, want 1 (initial create only)", got)
 	}
 	if got := cs.updates.Load(); got != 1 {
-		t.Errorf("UpdateEntity calls = %d, want 1", got)
+		t.Errorf("UpdateEntity calls = %d, want 1 (post-automation re-write)", got)
 	}
 	if got := result.Entity.GetString("status"); got != wantStatus {
 		t.Errorf("status = %q, want %q", got, wantStatus)
@@ -556,13 +555,13 @@ func TestCreate_CascadeNoRecursion(t *testing.T) {
 
 	// Pin the invariant through store-call counts. Single-dispatch
 	// shape: requirement create (1) + cascade checklist create (1) +
-	// childAuto's Set writing via the Create→conflict→Update upsert
-	// (1 create attempt + 1 update) = 3 creates, 1 update. If the
-	// cascade re-entered Manager.CreateEntity, childAuto would be
-	// dispatched a second time, adding another conflict-create +
-	// update pair (4/2).
-	if got := cs.creates.Load(); got != 3 {
-		t.Errorf("store CreateEntity calls = %d, want 3 (recursion would add a 4th)", got)
+	// childAuto's Set persisted via cascade WriteEntity, now a direct
+	// UpdateEntity (no upsert probe — BUG-ZWTDH9) = 2 creates, 1 update.
+	// If the cascade re-entered Manager.CreateEntity, childAuto would be
+	// dispatched a second time, adding another create + update pair
+	// (3 creates / 2 updates).
+	if got := cs.creates.Load(); got != 2 {
+		t.Errorf("store CreateEntity calls = %d, want 2 (recursion would add a 3rd)", got)
 	}
 	if got := cs.updates.Load(); got != 1 {
 		t.Errorf("store UpdateEntity calls = %d, want 1 (recursion would double-fire childAuto)", got)
@@ -861,12 +860,11 @@ func TestDeleteRelation_RoundTrip(t *testing.T) {
 
 // --- Upsert error-propagation invariant (regression for C1) ---
 
-// TestCreate_PropagatesNonConflictStoreError pins that
-// upsertEntity does NOT mask a non-ErrConflict store failure by
-// falling through to UpdateEntity. With the workspace-era bug, a
-// CreateEntity that returned a generic I/O error would silently
-// reach UpdateEntity and likely return ErrNotFound, hiding the
-// real cause.
+// TestCreate_PropagatesNonConflictStoreError pins that createCore
+// does NOT mask a non-ErrConflict store failure by falling through to
+// UpdateEntity. With the workspace-era bug, a CreateEntity that
+// returned a generic I/O error would silently reach UpdateEntity and
+// likely return ErrNotFound, hiding the real cause.
 func TestCreate_PropagatesNonConflictStoreError(t *testing.T) {
 	t.Parallel()
 	sentinel := errors.New("simulated disk failure")

--- a/tickets/entities/automated-measures/AM-acl-write-subject-type-invariant.md
+++ b/tickets/entities/automated-measures/AM-acl-write-subject-type-invariant.md
@@ -1,0 +1,9 @@
+---
+id: AM-acl-write-subject-type-invariant
+type: automated-measure
+title: 'Integration test: every entity-write path authorizes against the stored type'
+description: For every entity-write entry point (v1 PATCH, sync PUT, ...), asserts the ACL subject type equals the stored entity's type and a body/claimed type differing from the stored type is rejected on update. Catches any future body-driven-subject path (the class that produced BUG-ZWTDH9). P4 invariant test.
+kind: test
+location: internal/dataentry / internal/entitymanager (integration test, added in the BUG-ZWTDH9 fix PR)
+status: proposed
+---

--- a/tickets/entities/bugs/BUG-ZWTDH9.md
+++ b/tickets/entities/bugs/BUG-ZWTDH9.md
@@ -1,0 +1,30 @@
+---
+id: BUG-ZWTDH9
+type: bug
+title: Sync PUT authorizes UPDATE against caller-supplied type, not stored type (cross-type privilege escalation)
+description: |-
+    PUT /api/sync/entities/{id} -> putEntity (sync_handlers.go:129) builds the entity from body.type, and ApplyEntity (apply.go:96-99) authorizes acl.WriteRequest{Op:OpUpdate, Subject:EntitySubject{Type:e.Type}} using that caller-supplied type. ApplyEntity calls GetEntity(e.ID) only for op-selection and DISCARDS the result (apply.go:90) — it never reads or compares the stored type. The update grant is matched against the claimed type (authz_write.go -> policy.go grantsVerb). A principal with update:[note] who can READ a secret-typed target can PUT {"type":"note",...} to overwrite and re-type it; fsstore writes entities/notes/<id>.md and leaves the original entities/secrets/<id>.md, corrupting the store; audit misattributes the type. ValidateEntity's only guard (ID-prefix) is skipped for id_type:manual. Contrast: handleV1UpdateEntity + attachmentWritePreflight reject entity.Type != typeName and authorize against the STORED type. Reproduced live: demos/demo_b.sh. Severity HIGH.
+
+    Fix (decided): on update, authorize+validate against the STORED type and hard-reject (422/409) a body type that differs — matching the v1 'type is immutable on update' contract.
+priority: high
+why1: An attacker with update:[note] can mutate a secret-typed entity because the ACL subject's Type is taken from the request body and the update grant is checked against that claimed type, not the resource's real type.
+why2: ApplyEntity is a generic create-OR-update upsert that treats the incoming entity as the source of truth for all fields including type, and authorizes 'can this principal write an entity of type X' before looking at what is on disk.
+why3: It already reads the entity via GetEntity(e.ID) but discards it (apply.go:90) — used only to pick create-vs-update; the stored type was one line away but never wired into the authz subject. The two uses of 'does it exist' (op selection vs authz subject) were never connected.
+why4: 'The sync API and the v1 PATCH path were built at different times with different contracts: v1 PATCH has no type field (type structurally immutable); sync accepts a full entity body including type. No shared ''type is immutable on update'' invariant is enforced across both, and sync''s stance was never audited against the ACL.'
+why5: 'Systemic: the authorization subject is assembled from client-controlled input at each call site, with no single chokepoint binding the ACL subject to the STORED resource. Every new write path re-decides what it authorizes against, and no test asserts ''authz subject type == the resource actually mutated''.'
+prevention: 'P2: derive Subject.Type from the loaded entity on update and reject a differing body type, via one helper used by every write entry point. P4 (automated measure): an integration test asserting, for every entity-write entry point (v1 PATCH, sync PUT, ...), that the ACL subject type equals the stored entity''s type and a mismatched body type is rejected.'
+status: review
+---
+
+Fix implemented on branch `fix/acl-sync-put-type-confusion` (commit 1c5e94eb).
+PR: (see below)
+
+ApplyEntity now captures the GetEntity result (previously discarded), rejects a
+body type != stored type with new sentinel ErrTypeImmutable -> HTTP 422
+(type_immutable), and binds the ACL subject to the stored type. ApplyRelation
+confirmed not vulnerable (resolves FromType from a store read; sync relation
+body carries no endpoint types). Tests:
+TestApplyEntity_RejectsTypeChangeOnUpdate, TestSyncPut_RejectsTypeChangeOnUpdate
+(+ same-type regressions), TestWriteSubjectTypeInvariant (P4 =
+AM-acl-write-subject-type-invariant). build / go test -race / arch-lint green;
+demo_b flips to NOT-REPRODUCED.

--- a/tickets/entities/bugs/BUG-ZWTDH9.md
+++ b/tickets/entities/bugs/BUG-ZWTDH9.md
@@ -13,7 +13,7 @@ why3: It already reads the entity via GetEntity(e.ID) but discards it (apply.go:
 why4: 'The sync API and the v1 PATCH path were built at different times with different contracts: v1 PATCH has no type field (type structurally immutable); sync accepts a full entity body including type. No shared ''type is immutable on update'' invariant is enforced across both, and sync''s stance was never audited against the ACL.'
 why5: 'Systemic: the authorization subject is assembled from client-controlled input at each call site, with no single chokepoint binding the ACL subject to the STORED resource. Every new write path re-decides what it authorizes against, and no test asserts ''authz subject type == the resource actually mutated''.'
 prevention: 'P2: derive Subject.Type from the loaded entity on update and reject a differing body type, via one helper used by every write entry point. P4 (automated measure): an integration test asserting, for every entity-write entry point (v1 PATCH, sync PUT, ...), that the ACL subject type equals the stored entity''s type and a mismatched body type is rejected.'
-status: review
+status: done
 ---
 
 Fix implemented on branch `fix/acl-sync-put-type-confusion` (commit 1c5e94eb).

--- a/tickets/entities/review-checklists/REV-E546FQ.md
+++ b/tickets/entities/review-checklists/REV-E546FQ.md
@@ -2,55 +2,57 @@
 id: REV-E546FQ
 type: review-checklist
 title: 'Review: Sync PUT authorizes UPDATE against caller-supplied type, not stored type (cross-type privilege escalation)'
-status: in-progress
+status: done
 ---
 
 <!-- @managed: claude-workflow v1 -->
 
 ## Automated Checks
 
-- [ ] All tests pass (`just test`)
-- [ ] Lint clean (`just lint`)
-- [ ] Coverage maintained (`just coverage-check`)
+- [x] All tests pass (go test -race across cli/entitymanager/dataentry/store green; CI green)
+- [x] Lint clean (golangci-lint 0 issues; arch-lint OK)
+- [x] Coverage maintained (above floors)
 
 ## Code Review
 
-- [ ] Run `/code-review` command (invokes cranky-code-reviewer agent)
-- [ ] All critical review-responses addressed
-- [ ] All significant review-responses addressed
-- [ ] Self-reviewed the diff for unrelated changes
+- [x] Ran cranky-code-reviewer twice: initial fix, then the no-upsert rework
+- [x] All critical review-responses addressed (N/A: none)
+- [x] All significant review-responses addressed: RR-K995SY (CLI 409 handling) — fixed in c95947da
+- [x] Self-reviewed the diff for unrelated changes
 
-**Review Responses:** <!-- List IDs of review-response entities created, e.g.,
-RR-xxxx -->
+**Review Responses:** RR-K995SY (significant, addressed), RR-VKJX4B (minor,
+addressed), RR-PG8YYO (nit, addressed).
 
 ## Acceptance Verification
 
-- [ ] Each acceptance criterion tested (reference planning checklist)
-- [ ] Test evidence documented in implementation checklist
+- [x] Each acceptance criterion tested: sync PUT authorizes+validates against STORED type; cross-type update rejected 422; upsert primitive removed (create rejects-on-conflict 409, update direct); cascade WriteRelation no-op proven safe (property-less edges); CLI halts one record on 409/412, run continues
+- [x] Test evidence: TestApplyEntity_RejectsTypeChangeOnUpdate, TestSyncPut_RejectsTypeChangeOnUpdate, TestWriteSubjectTypeInvariant (P4 = AM-acl-write-subject-type-invariant), TestApplyEntity_CreateConflict_RejectsAndDoesNotClobber, TestPush_CreateConflict409_HaltsOneRecordAndRunContinues, TestSyncPut_UpdateVanishedReturns412. demo_b flips to NOT-REPRODUCED
 
-**Acceptance Status:**
-<!-- For each acceptance criterion, state PASS/FAIL with evidence -->
+**Acceptance Status:** PASS — re-review verdict "BUG-ZWTDH9 fully closed;
+cascade no-op proven safe; upsert eliminated". The one significant finding (CLI
+409) was fixed and re-tested.
 
 ## Documentation (enhancements only)
 
-Skip this section for bugs and internal refactors.
-
-- [ ] Docs-checklist created and linked via `has-docs`
-- [ ] User-facing documentation updated
-- [ ] Docs-checklist marked as done
-
-**Docs Checklist:** <!-- e.g., DOCS-xxxx -->
+- [x] ~~Docs section~~ (N/A: security bugfix; internal godoc updated on autocascade.Host.WriteRelation)
 
 ## Final Checks
 
-- [ ] Commit message explains the why, not just what
-- [ ] No TODOs or FIXMEs left unaddressed
-- [ ] Ready for another developer to use
+- [x] Commit message explains the why (stored-type binding; upsert removal rationale; 409 client handling)
+- [x] No TODOs left unaddressed
+- [x] Ready for another developer to use
 
 ## Pull Request
 
-- [ ] Run `/pr` command to create PR and monitor CI
-- [ ] All CI checks pass
-- [ ] PR URL documented below
+- [x] PR created: https://github.com/sourcehaven-bv/rela/pull/1114
+- [x] All code CI checks pass (Rela Tickets gate clears on this bug reaching done)
+- [x] PR URL documented above
 
-**PR:** <!-- e.g., https://github.com/org/repo/pull/123 -->
+**PR:** https://github.com/sourcehaven-bv/rela/pull/1114
+
+## Follow-up noted
+
+The review flagged a separate `internal/rename/rename.go` with its own
+package-local `upsertEntity`/`upsertRelation` — out of scope here, worth a
+follow-up bug to check whether it shares the same unsound create-then-update
+pattern.

--- a/tickets/entities/review-checklists/REV-E546FQ.md
+++ b/tickets/entities/review-checklists/REV-E546FQ.md
@@ -1,0 +1,56 @@
+---
+id: REV-E546FQ
+type: review-checklist
+title: 'Review: Sync PUT authorizes UPDATE against caller-supplied type, not stored type (cross-type privilege escalation)'
+status: in-progress
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Automated Checks
+
+- [ ] All tests pass (`just test`)
+- [ ] Lint clean (`just lint`)
+- [ ] Coverage maintained (`just coverage-check`)
+
+## Code Review
+
+- [ ] Run `/code-review` command (invokes cranky-code-reviewer agent)
+- [ ] All critical review-responses addressed
+- [ ] All significant review-responses addressed
+- [ ] Self-reviewed the diff for unrelated changes
+
+**Review Responses:** <!-- List IDs of review-response entities created, e.g.,
+RR-xxxx -->
+
+## Acceptance Verification
+
+- [ ] Each acceptance criterion tested (reference planning checklist)
+- [ ] Test evidence documented in implementation checklist
+
+**Acceptance Status:**
+<!-- For each acceptance criterion, state PASS/FAIL with evidence -->
+
+## Documentation (enhancements only)
+
+Skip this section for bugs and internal refactors.
+
+- [ ] Docs-checklist created and linked via `has-docs`
+- [ ] User-facing documentation updated
+- [ ] Docs-checklist marked as done
+
+**Docs Checklist:** <!-- e.g., DOCS-xxxx -->
+
+## Final Checks
+
+- [ ] Commit message explains the why, not just what
+- [ ] No TODOs or FIXMEs left unaddressed
+- [ ] Ready for another developer to use
+
+## Pull Request
+
+- [ ] Run `/pr` command to create PR and monitor CI
+- [ ] All CI checks pass
+- [ ] PR URL documented below
+
+**PR:** <!-- e.g., https://github.com/org/repo/pull/123 -->

--- a/tickets/entities/review-responses/RR-K995SY.md
+++ b/tickets/entities/review-responses/RR-K995SY.md
@@ -1,0 +1,9 @@
+---
+id: RR-K995SY
+type: review-response
+title: CLI sync client aborts whole push run on the new 409 create-conflict
+finding: The no-upsert rework makes the sync server return 409 on a create-intent conflict (concurrent first-create, postgres multi-writer). The CLI pushResult mapped only 200/412/422; a 409 fell to default -> statusError -> Push returns the error, ABORTING the entire push run and discarding topo-ordered progress, instead of halting just that record like 412 does.
+severity: significant
+resolution: Added case http.StatusConflict in pushResult returning PushResult{Conflict:true, CreatedConcurrently:true}, flowing through the same classifyConflict -> OutcomeConflict path as 412 (loop continues, per-record index preserved for re-run). Added a dedicated CreatedConcurrently flag for a distinct message ('created concurrently by a peer... resolve with rela sync push/pull --force'). New client test TestPush_CreateConflict409_HaltsOneRecordAndRunContinues. Fixed in commit c95947da.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-PG8YYO.md
+++ b/tickets/entities/review-responses/RR-PG8YYO.md
@@ -1,0 +1,9 @@
+---
+id: RR-PG8YYO
+type: review-response
+title: Stale 'upserts' godoc on autocascade.Host.WriteRelation
+finding: autocascade/host.go WriteRelation godoc still said 'upserts the relation to the store' after the cascadeHost impl became create-or-noop, misleading a future implementer into thinking upsert is part of the contract.
+severity: nit
+resolution: Updated the godoc to 'create-then-noop-on-conflict, never an update — cascade relations are property-less'. No behavior change. Commit c95947da.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-VKJX4B.md
+++ b/tickets/entities/review-responses/RR-VKJX4B.md
@@ -1,0 +1,9 @@
+---
+id: RR-VKJX4B
+type: review-response
+title: Entity update-vanished mapped to 404 while relation maps to 412 (asymmetric CLI abort)
+finding: persistApplyEntity mapped an update whose row vanished (probe-said-present-then-deleted race) to ErrEntityNotFound -> 404, while the relation equivalent mapped vanished -> 412. On the CLI a 404 aborts the whole run; 412 halts one record. Asymmetric and undocumented.
+severity: minor
+resolution: Mapped sync entity update-vanished to 412 (option a), symmetric with relations. Verified the v1 PATCH 404 existence-oracle is a separate handler (writeSyncApplyError is sync-only), so unaffected. Introduced ErrEntityVanishedOnUpdate that WRAPS ErrEntityNotFound (existing errors.Is callers still match); handler checks it -> 412 before the generic ErrEntityNotFound -> 404 (order pinned by test). New test TestSyncPut_UpdateVanishedReturns412. Commit c95947da.
+status: addressed
+---

--- a/tickets/relations/AM-acl-write-subject-type-invariant--protects--authorization.md
+++ b/tickets/relations/AM-acl-write-subject-type-invariant--protects--authorization.md
@@ -1,0 +1,5 @@
+---
+from: AM-acl-write-subject-type-invariant
+relation: protects
+to: authorization
+---

--- a/tickets/relations/BUG-ZWTDH9--adds-measure--AM-acl-write-subject-type-invariant.md
+++ b/tickets/relations/BUG-ZWTDH9--adds-measure--AM-acl-write-subject-type-invariant.md
@@ -1,0 +1,5 @@
+---
+from: BUG-ZWTDH9
+relation: adds-measure
+to: AM-acl-write-subject-type-invariant
+---

--- a/tickets/relations/BUG-ZWTDH9--affects--authorization.md
+++ b/tickets/relations/BUG-ZWTDH9--affects--authorization.md
@@ -1,0 +1,5 @@
+---
+from: BUG-ZWTDH9
+relation: affects
+to: authorization
+---

--- a/tickets/relations/BUG-ZWTDH9--fixes--FEAT-AESD4.md
+++ b/tickets/relations/BUG-ZWTDH9--fixes--FEAT-AESD4.md
@@ -1,0 +1,5 @@
+---
+from: BUG-ZWTDH9
+relation: fixes
+to: FEAT-AESD4
+---

--- a/tickets/relations/BUG-ZWTDH9--has-review--REV-E546FQ.md
+++ b/tickets/relations/BUG-ZWTDH9--has-review--REV-E546FQ.md
@@ -1,0 +1,5 @@
+---
+from: BUG-ZWTDH9
+relation: has-review
+to: REV-E546FQ
+---

--- a/tickets/relations/BUG-ZWTDH9--has-review-response--RR-K995SY.md
+++ b/tickets/relations/BUG-ZWTDH9--has-review-response--RR-K995SY.md
@@ -1,0 +1,5 @@
+---
+from: BUG-ZWTDH9
+relation: has-review-response
+to: RR-K995SY
+---

--- a/tickets/relations/BUG-ZWTDH9--has-review-response--RR-PG8YYO.md
+++ b/tickets/relations/BUG-ZWTDH9--has-review-response--RR-PG8YYO.md
@@ -1,0 +1,5 @@
+---
+from: BUG-ZWTDH9
+relation: has-review-response
+to: RR-PG8YYO
+---

--- a/tickets/relations/BUG-ZWTDH9--has-review-response--RR-VKJX4B.md
+++ b/tickets/relations/BUG-ZWTDH9--has-review-response--RR-VKJX4B.md
@@ -1,0 +1,5 @@
+---
+from: BUG-ZWTDH9
+relation: has-review-response
+to: RR-VKJX4B
+---


### PR DESCRIPTION
## Finding (BUG-ZWTDH9, HIGH)

`PUT /api/sync/entities/{id}` authorized an UPDATE against the caller-supplied `type`, not the stored type — cross-type write privilege escalation. `ApplyEntity` read the existing entity via `GetEntity` only to pick create-vs-update op and **discarded** it, then authorized `EntitySubject{Type: body.Type}`. A principal with `update:[note]` who could merely *read* a `secret`-typed target could `PUT {"type":"note",...}` to overwrite and re-type it — fsstore then wrote `entities/notes/<id>.md` and left the original `entities/secrets/<id>.md` (store corruption); the audit record misattributed the type.

Reproduced live (demo_b): honest same-type write → 403; claiming `type:note` → 200, secret overwritten, duplicate file under both `secrets/` and `notes/`.

## Fix

`ApplyEntity` now captures the entity from the existing `GetEntity` probe. On update, a body type differing from the stored type is rejected with a new sentinel `ErrTypeImmutable` (→ HTTP **422** `type_immutable`), and the ACL subject is bound to the **stored** type explicitly. Create path unchanged. This aligns the sync PUT contract with the v1 PATCH path, where type is already immutable (the v1 body has no `type` field). `ApplyRelation` was checked and needs no change — it resolves the source type from a store read, and the sync relation body carries no endpoint types.

422 (not 409) because a body type contradicting the stored type is a structural impossibility per DEC-HWZHA (one ID cannot persist as two types); 412 stays reserved for If-Match conflicts.

## Tests

- `TestApplyEntity_RejectsTypeChangeOnUpdate` + `TestApplyEntity_SameTypeUpdateStillWorks` (entitymanager, PoC + regression).
- `TestSyncPut_RejectsTypeChangeOnUpdate` + `TestSyncPut_SameTypeUpdateStillWorks` (HTTP-layer through the full router — asserts 422 and the secret is untouched).
- `TestWriteSubjectTypeInvariant` — the P4 class-level invariant (automated-measure `AM-acl-write-subject-type-invariant`): table-driven across the entity-write entry points (sync PUT, v1 PATCH), asserting a cross-type write never succeeds and never re-types the stored entity. New write paths add a row.

All confirmed failing-first against the unfixed code.

## Verification

`go build ./...`, `go test -race ./internal/entitymanager/... ./internal/dataentry/...`, `just arch-lint` all pass. `demo_b` flips to NOT-REPRODUCED; `demo_a`/`demo_c` still reproduce, confirming isolation.

Part of the ACL audit series — see also BUG-K6FEVB and BUG-ABXMAV (#1113). Shared systemic root: authorization assembled from client input at each call site, with no chokepoint binding the ACL subject to the stored resource and no cross-path invariant test.