### PR TITLE
feat: datetime property type + date+time widget (TKT-ZYOBSN)

### DIFF
--- a/docs-project/entities/guides/GUIDE-data-entry.md
+++ b/docs-project/entities/guides/GUIDE-data-entry.md
@@ -354,11 +354,36 @@ Each entry in `fields:` configures one property input:
 | `textarea` | Multi-line text area                             | Descriptions, notes            |
 | `number`   | Numeric input                                    | Integers                       |
 | `date`     | Date picker                                      | Date properties                |
+| `datetime` | Date + time picker                               | Datetime properties            |
 | `checkbox` | Toggle checkbox                                  | Boolean properties             |
 
 When no widget is specified, the system auto-detects from the property's type in the metamodel:
-enum types render as a `<select>`, booleans as checkboxes, dates as date pickers, and everything
-else as text inputs.
+enum types render as a `<select>`, booleans as checkboxes, dates as date pickers, `datetime`
+properties as date+time pickers, and everything else as text inputs.
+
+### Datetime fields and time zones
+
+A `datetime` property renders as a native date + time picker. Because a
+datetime is a specific instant, the field must communicate which time zone the
+entered wall-clock time means:
+
+- **Values are stored as UTC** (RFC3339, e.g. `2026-07-13T12:30:00Z`). The
+  widget converts between your local wall-clock time and UTC as you type.
+- **The field shows the active time zone** beneath the input ("Times shown in
+  `Europe/Amsterdam`"), so the interpretation is never hidden.
+- **The display time zone is configurable** on the **Settings** page under
+  *Display timezone*. It defaults to your browser's time zone and applies to
+  every datetime field. It is a **display-only** preference stored in your
+  browser — changing it re-labels existing values but never rewrites the stored
+  UTC instant.
+- **Editing is non-destructive.** Viewing an entity, or saving an unrelated
+  field, never rewrites a datetime you didn't touch — so values authored in a
+  different time zone don't produce spurious diffs.
+
+Note: a value that is exactly midnight UTC (e.g. a bare `2026-07-13` written by
+hand and interpreted as `2026-07-13T00:00:00Z`) displays on the **previous
+evening** in time zones west of UTC. The picker itself always writes a full
+instant, so this only affects hand-authored midnight values.
 
 ### ID Controls on Create Forms
 

--- a/docs-project/entities/guides/GUIDE-metamodel.md
+++ b/docs-project/entities/guides/GUIDE-metamodel.md
@@ -264,6 +264,7 @@ The following names are reserved for built-in property types and cannot be used 
 
 - `string` - Free-form text
 - `date` - Date values
+- `datetime` - Time-bearing instants (date + time)
 - `integer` - Whole numbers
 - `boolean` - True/false values
 - `enum` - Inline enumeration (use `values:` directly in property definition)
@@ -320,7 +321,7 @@ entities:
 
 **Allowed types.** The named property must be `string`, `integer`,
 `boolean`, or `enum` (custom enum-like types are accepted). `date`,
-`file`, `rrule`, and list-typed (`list: true`) properties are
+`datetime`, `file`, `rrule`, and list-typed (`list: true`) properties are
 rejected at metamodel-load time — their default rendering produces
 strings nobody designed as a display name (e.g. `"2026-04-25 00:00:00
 +0000 UTC"`, `"[a b c]"`).
@@ -524,6 +525,7 @@ entities:
 | ---------- | --------------------------------------------- | ----------------------------------- |
 | `string`   | Free-form text                                | `=`, `!=`, `=~` (regex), glob (`*`) |
 | `date`     | Date value (ISO 8601 by default)              | `=`, `!=`, `<`, `<=`, `>`, `>=`     |
+| `datetime` | Time-bearing instant (RFC3339, stored as UTC) | `=`, `!=`, `<`, `<=`, `>`, `>=`     |
 | `integer`  | Whole number                                  | `=`, `!=`, `<`, `<=`, `>`, `>=`     |
 | `boolean`  | True or false                                 | `=`, `!=`                           |
 | `enum`     | Inline enum with `values`                     | `=`, `!=`                           |
@@ -614,6 +616,40 @@ Common formats:
 | European | `01/02/2025` | `02/01/2006`           |
 | US       | `02/01/2025` | `01/02/2006`           |
 | Long     | `1 Feb 2025` | `2 Jan 2006`           |
+
+### Datetime Properties
+
+Use `datetime` for a **time-bearing instant** (a specific point in time, not
+just a calendar day). Unlike `date`, a `datetime` value carries a time-of-day.
+
+```yaml
+properties:
+  starts_at:
+    type: datetime
+    description: "When the event begins"
+```
+
+Semantics:
+
+- **Stored as UTC RFC3339** (e.g. `2026-07-13T12:30:00Z`). Values written
+  through the data-entry app are always normalized to a UTC instant.
+- **Bare dates are accepted as midnight UTC.** A hand-edited value like
+  `2026-07-13` on a `datetime` property is interpreted as
+  `2026-07-13T00:00:00Z`. (Note that such a midnight-UTC value displays on the
+  previous evening in time zones west of UTC — see the data-entry docs.)
+- **Values may be quoted or unquoted** in YAML frontmatter. An unquoted
+  timestamp is parsed as a timestamp; both round-trip correctly.
+- **Filtering and sorting compare as instants** (down to the second).
+  Equality (`=`) is therefore strict-instant: `starts_at=2026-07-13` (which
+  parses as midnight) does **not** match `2026-07-13T12:30:00Z`. Use `>=` and
+  `<` to query a day or range.
+- **Mixed `date` + `datetime` columns sort chronologically** together.
+
+The data-entry app renders `datetime` properties with a date+time picker and a
+configurable display time zone — see the data-entry guide.
+
+Calendar-feed sources currently accept only `date` (all-day) properties;
+timed events from `datetime` sources are a planned follow-on.
 
 ### Property Type Examples
 
@@ -1006,10 +1042,10 @@ rela list control --where "status=implemented" --where "applicability=applicable
 | -------- | --------------------------- | ----------------- |
 | `=`      | Equal (exact match or glob) | All types         |
 | `!=`     | Not equal                   | All types         |
-| `<`      | Less than                   | `date`, `integer` |
-| `<=`     | Less than or equal          | `date`, `integer` |
-| `>`      | Greater than                | `date`, `integer` |
-| `>=`     | Greater than or equal       | `date`, `integer` |
+| `<`      | Less than                   | `date`, `datetime`, `integer` |
+| `<=`     | Less than or equal          | `date`, `datetime`, `integer` |
+| `>`      | Greater than                | `date`, `datetime`, `integer` |
+| `>=`     | Greater than or equal       | `date`, `datetime`, `integer` |
 | `=~`     | Regex match                 | `string`          |
 
 ### Error Handling
@@ -1054,6 +1090,7 @@ Sorting is type-aware:
 - `string`: Lexicographic (alphabetical)
 - `enum`/custom types: By the order defined in the type's `values` list (not alphabetical)
 - `date`: Chronological
+- `datetime`: Chronological, to the second (interleaves with `date`)
 - `integer`: Numeric
 - `boolean`: `false` before `true`
 

--- a/docs/data-entry.md
+++ b/docs/data-entry.md
@@ -357,9 +357,9 @@ properties as date+time pickers, and everything else as text inputs.
 
 ### Datetime fields and time zones
 
-A `datetime` property (see [Datetime Properties](metamodel.md#datetime-properties))
-renders as a native date + time picker. Because a datetime is a specific instant,
-the field must communicate which time zone the entered wall-clock time means:
+A `datetime` property renders as a native date + time picker. Because a
+datetime is a specific instant, the field must communicate which time zone the
+entered wall-clock time means:
 
 - **Values are stored as UTC** (RFC3339, e.g. `2026-07-13T12:30:00Z`). The
   widget converts between your local wall-clock time and UTC as you type.

--- a/docs/data-entry.md
+++ b/docs/data-entry.md
@@ -348,11 +348,36 @@ Each entry in `fields:` configures one property input:
 | `textarea` | Multi-line text area                             | Descriptions, notes            |
 | `number`   | Numeric input                                    | Integers                       |
 | `date`     | Date picker                                      | Date properties                |
+| `datetime` | Date + time picker                               | Datetime properties            |
 | `checkbox` | Toggle checkbox                                  | Boolean properties             |
 
 When no widget is specified, the system auto-detects from the property's type in the metamodel:
-enum types render as a `<select>`, booleans as checkboxes, dates as date pickers, and everything
-else as text inputs.
+enum types render as a `<select>`, booleans as checkboxes, dates as date pickers, `datetime`
+properties as date+time pickers, and everything else as text inputs.
+
+### Datetime fields and time zones
+
+A `datetime` property (see [Datetime Properties](metamodel.md#datetime-properties))
+renders as a native date + time picker. Because a datetime is a specific instant,
+the field must communicate which time zone the entered wall-clock time means:
+
+- **Values are stored as UTC** (RFC3339, e.g. `2026-07-13T12:30:00Z`). The
+  widget converts between your local wall-clock time and UTC as you type.
+- **The field shows the active time zone** beneath the input ("Times shown in
+  `Europe/Amsterdam`"), so the interpretation is never hidden.
+- **The display time zone is configurable** on the **Settings** page under
+  *Display timezone*. It defaults to your browser's time zone and applies to
+  every datetime field. It is a **display-only** preference stored in your
+  browser — changing it re-labels existing values but never rewrites the stored
+  UTC instant.
+- **Editing is non-destructive.** Viewing an entity, or saving an unrelated
+  field, never rewrites a datetime you didn't touch — so values authored in a
+  different time zone don't produce spurious diffs.
+
+Note: a value that is exactly midnight UTC (e.g. a bare `2026-07-13` written by
+hand and interpreted as `2026-07-13T00:00:00Z`) displays on the **previous
+evening** in time zones west of UTC. The picker itself always writes a full
+instant, so this only affects hand-authored midnight values.
 
 ### ID Controls on Create Forms
 

--- a/docs/metamodel.md
+++ b/docs/metamodel.md
@@ -258,6 +258,7 @@ The following names are reserved for built-in property types and cannot be used 
 
 - `string` - Free-form text
 - `date` - Date values
+- `datetime` - Time-bearing instants (date + time)
 - `integer` - Whole numbers
 - `boolean` - True/false values
 - `enum` - Inline enumeration (use `values:` directly in property definition)
@@ -314,7 +315,7 @@ entities:
 
 **Allowed types.** The named property must be `string`, `integer`,
 `boolean`, or `enum` (custom enum-like types are accepted). `date`,
-`file`, `rrule`, and list-typed (`list: true`) properties are
+`datetime`, `file`, `rrule`, and list-typed (`list: true`) properties are
 rejected at metamodel-load time — their default rendering produces
 strings nobody designed as a display name (e.g. `"2026-04-25 00:00:00
 +0000 UTC"`, `"[a b c]"`).
@@ -518,6 +519,7 @@ entities:
 | ---------- | --------------------------------------------- | ----------------------------------- |
 | `string`   | Free-form text                                | `=`, `!=`, `=~` (regex), glob (`*`) |
 | `date`     | Date value (ISO 8601 by default)              | `=`, `!=`, `<`, `<=`, `>`, `>=`     |
+| `datetime` | Time-bearing instant (RFC3339, stored as UTC) | `=`, `!=`, `<`, `<=`, `>`, `>=`     |
 | `integer`  | Whole number                                  | `=`, `!=`, `<`, `<=`, `>`, `>=`     |
 | `boolean`  | True or false                                 | `=`, `!=`                           |
 | `enum`     | Inline enum with `values`                     | `=`, `!=`                           |
@@ -608,6 +610,41 @@ Common formats:
 | European | `01/02/2025` | `02/01/2006`           |
 | US       | `02/01/2025` | `01/02/2006`           |
 | Long     | `1 Feb 2025` | `2 Jan 2006`           |
+
+### Datetime Properties
+
+Use `datetime` for a **time-bearing instant** (a specific point in time, not
+just a calendar day). Unlike `date`, a `datetime` value carries a time-of-day.
+
+```yaml
+properties:
+  starts_at:
+    type: datetime
+    description: "When the event begins"
+```
+
+Semantics:
+
+- **Stored as UTC RFC3339** (e.g. `2026-07-13T12:30:00Z`). Values written
+  through the data-entry app are always normalized to a UTC instant.
+- **Bare dates are accepted as midnight UTC.** A hand-edited value like
+  `2026-07-13` on a `datetime` property is interpreted as
+  `2026-07-13T00:00:00Z`. (Note that such a midnight-UTC value displays on the
+  previous evening in time zones west of UTC — see the data-entry docs.)
+- **Values may be quoted or unquoted** in YAML frontmatter. An unquoted
+  timestamp is parsed as a timestamp; both round-trip correctly.
+- **Filtering and sorting compare as instants** (down to the second).
+  Equality (`=`) is therefore strict-instant: `starts_at=2026-07-13` (which
+  parses as midnight) does **not** match `2026-07-13T12:30:00Z`. Use `>=` and
+  `<` to query a day or range.
+- **Mixed `date` + `datetime` columns sort chronologically** together.
+
+The data-entry app renders `datetime` properties with a date+time picker and a
+configurable display time zone — see
+[Datetime fields](data-entry.md#datetime-fields-and-time-zones).
+
+Calendar-feed sources currently accept only `date` (all-day) properties;
+timed events from `datetime` sources are a planned follow-on.
 
 ### Property Type Examples
 
@@ -1000,10 +1037,10 @@ rela list control --where "status=implemented" --where "applicability=applicable
 | -------- | --------------------------- | ----------------- |
 | `=`      | Equal (exact match or glob) | All types         |
 | `!=`     | Not equal                   | All types         |
-| `<`      | Less than                   | `date`, `integer` |
-| `<=`     | Less than or equal          | `date`, `integer` |
-| `>`      | Greater than                | `date`, `integer` |
-| `>=`     | Greater than or equal       | `date`, `integer` |
+| `<`      | Less than                   | `date`, `datetime`, `integer` |
+| `<=`     | Less than or equal          | `date`, `datetime`, `integer` |
+| `>`      | Greater than                | `date`, `datetime`, `integer` |
+| `>=`     | Greater than or equal       | `date`, `datetime`, `integer` |
 | `=~`     | Regex match                 | `string`          |
 
 ### Error Handling
@@ -1048,6 +1085,7 @@ Sorting is type-aware:
 - `string`: Lexicographic (alphabetical)
 - `enum`/custom types: By the order defined in the type's `values` list (not alphabetical)
 - `date`: Chronological
+- `datetime`: Chronological, to the second (interleaves with `date`)
 - `integer`: Numeric
 - `boolean`: `false` before `true`
 

--- a/docs/metamodel.md
+++ b/docs/metamodel.md
@@ -640,8 +640,7 @@ Semantics:
 - **Mixed `date` + `datetime` columns sort chronologically** together.
 
 The data-entry app renders `datetime` properties with a date+time picker and a
-configurable display time zone — see
-[Datetime fields](data-entry.md#datetime-fields-and-time-zones).
+configurable display time zone — see the data-entry guide.
 
 Calendar-feed sources currently accept only `date` (all-day) properties;
 timed events from `datetime` sources are a planned follow-on.

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,7 @@
       "name": "rela-frontend",
       "version": "0.0.1",
       "dependencies": {
+        "@date-fns/tz": "^1.5.0",
         "@fontsource/open-sans": "^5.2.7",
         "@pinia/colada": "^1.3.1",
         "axios": "^1.18.1",
@@ -350,6 +351,12 @@
       "engines": {
         "node": ">=20.19.0"
       }
+    },
+    "node_modules/@date-fns/tz": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@date-fns/tz/-/tz-1.5.0.tgz",
+      "integrity": "sha512-lwYN/vDPeNRULcepoE/LO2Pgx+7/RV+S9ARfbc9lr2DtGkOD7pAiruHvbR1RX3Qyf6ja47EWJDMsNK5vK08DJg==",
+      "license": "MIT"
     },
     "node_modules/@emnapi/core": {
       "version": "1.11.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -20,6 +20,7 @@
     "dupes": "jscpd src --ignore \"**/*.test.ts\" --reporters console"
   },
   "dependencies": {
+    "@date-fns/tz": "^1.5.0",
     "@fontsource/open-sans": "^5.2.7",
     "@pinia/colada": "^1.3.1",
     "axios": "^1.18.1",

--- a/frontend/src/components/forms/FieldRenderer.test.ts
+++ b/frontend/src/components/forms/FieldRenderer.test.ts
@@ -144,4 +144,17 @@ describe('FieldRenderer affordance plumbing', () => {
     expect(label.attributes('for')).toBe('field-automated')
     wrapper.unmount()
   })
+
+  it('routes a datetime property to the datetime-local widget', () => {
+    // End-to-end dispatch: a datetime PropertyDef resolves to DatetimeWidget,
+    // which renders a native datetime-local input plus the timezone indicator.
+    const wrapper = renderField({
+      field: { property: 'starts_at', label: 'Starts at' },
+      propertyDef: { type: 'datetime' },
+      value: '2026-07-13T12:30:00Z',
+    })
+    expect(wrapper.find('input[type="datetime-local"]').exists()).toBe(true)
+    expect(wrapper.find('.tz-indicator').exists()).toBe(true)
+    wrapper.unmount()
+  })
 })

--- a/frontend/src/components/lists/EntityList.vue
+++ b/frontend/src/components/lists/EntityList.vue
@@ -558,7 +558,9 @@ function getFormattedCellValue(
   }
 
   const value = getCellValue(entity, column)
-  return formatCellValue(value, column.property, entityType.value)
+  // Pass the user's effective display zone so datetime cells honor the
+  // Settings display-timezone preference, matching the form widget (RR-K3WEW2).
+  return formatCellValue(value, column.property, entityType.value, uiStore.effectiveTimezone)
 }
 
 function handleDelete(entity: Entity, event: Event) {

--- a/frontend/src/stores/ui.test.ts
+++ b/frontend/src/stores/ui.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { createPinia, setActivePinia } from 'pinia'
 import { useUIStore } from './ui'
 
 describe('UI Store', () => {
@@ -166,6 +167,43 @@ describe('UI Store', () => {
 
       expect(store.toasts).toHaveLength(3)
       expect(store.toasts.map((t) => t.type)).toEqual(['success', 'error', 'warning'])
+    })
+  })
+
+  describe('datetime timezone', () => {
+    beforeEach(() => {
+      // localStorage is a shared mock that isn't reset between tests; clear it
+      // and re-create the store (fresh Pinia) so each case starts from a clean
+      // override initialized from the now-empty storage.
+      localStorage.clear()
+      setActivePinia(createPinia())
+      store = useUIStore()
+    })
+
+    it('defaults to browser zone (empty override)', () => {
+      expect(store.datetimeTimezone).toBe('')
+      // effectiveTimezone falls back to the browser zone.
+      expect(store.effectiveTimezone).toBe(Intl.DateTimeFormat().resolvedOptions().timeZone)
+    })
+
+    it('sets and persists a supported zone', () => {
+      store.setDatetimeTimezone('America/New_York')
+      expect(store.datetimeTimezone).toBe('America/New_York')
+      expect(store.effectiveTimezone).toBe('America/New_York')
+      expect(localStorage.getItem('datetimeTimezone')).toBe('America/New_York')
+    })
+
+    it('rejects an unsupported zone (no-op)', () => {
+      store.setDatetimeTimezone('Not/AZone')
+      expect(store.datetimeTimezone).toBe('')
+    })
+
+    it('clearing the override removes the persisted value', () => {
+      store.setDatetimeTimezone('Asia/Kolkata')
+      expect(localStorage.getItem('datetimeTimezone')).toBe('Asia/Kolkata')
+      store.setDatetimeTimezone('')
+      expect(store.datetimeTimezone).toBe('')
+      expect(localStorage.getItem('datetimeTimezone')).toBeNull()
     })
   })
 })

--- a/frontend/src/stores/ui.ts
+++ b/frontend/src/stores/ui.ts
@@ -1,5 +1,6 @@
 import { defineStore } from 'pinia'
 import { ref, computed, watch } from 'vue'
+import { browserTimeZone } from '@/utils/format'
 
 export interface Toast {
   id: string
@@ -26,6 +27,31 @@ function getInitialThemeMode(): ThemeMode {
   return 'system'
 }
 
+// isSupportedTimeZone guards against a stale/tampered localStorage value: an
+// unknown IANA zone silently falls back to the browser default rather than
+// breaking every datetime widget. We probe with the Intl.DateTimeFormat
+// constructor rather than checking supportedValuesOf membership, because the
+// latter returns only canonical names on some engines (e.g. "Asia/Calcutta"
+// but not its alias "Asia/Kolkata", and no "UTC") — yet the constructor
+// accepts both. The constructor is the authoritative "does this zone work"
+// test; supportedValuesOf is used only to populate the picker list.
+function isSupportedTimeZone(tz: string): boolean {
+  if (!tz) return false
+  try {
+    Intl.DateTimeFormat(undefined, { timeZone: tz })
+    return true
+  } catch {
+    return false
+  }
+}
+
+// The datetime display-timezone override. Empty string means "use the browser
+// zone". A stored value that is no longer a supported zone is ignored.
+function getInitialDatetimeTimezone(): string {
+  const stored = localStorage.getItem('datetimeTimezone') ?? ''
+  return isSupportedTimeZone(stored) ? stored : ''
+}
+
 export const useUIStore = defineStore('ui', () => {
   // State
   const sidebarCollapsed = ref(false)
@@ -36,6 +62,8 @@ export const useUIStore = defineStore('ui', () => {
   const modalData = ref<unknown>(null)
   const themeMode = ref<ThemeMode>(getInitialThemeMode())
   const darkMode = ref(getInitialDarkMode())
+  // '' = follow the browser zone; otherwise a chosen IANA zone.
+  const datetimeTimezone = ref<string>(getInitialDatetimeTimezone())
 
   // Getters
   const isSidebarVisible = computed(
@@ -43,6 +71,9 @@ export const useUIStore = defineStore('ui', () => {
   )
 
   const isDark = computed(() => darkMode.value)
+
+  // The zone datetime widgets interpret input in and display values in.
+  const effectiveTimezone = computed(() => datetimeTimezone.value || browserTimeZone())
 
   // Actions
   function toggleSidebar() {
@@ -123,6 +154,20 @@ export const useUIStore = defineStore('ui', () => {
     }
   }
 
+  // Set the display-timezone override. Pass '' to follow the browser zone.
+  // An unsupported zone is rejected (no-op) so a bad caller can't wedge the UI.
+  // Persistence is synchronous (not a watch) so callers see localStorage
+  // updated immediately after the call.
+  function setDatetimeTimezone(tz: string) {
+    if (tz !== '' && !isSupportedTimeZone(tz)) return
+    datetimeTimezone.value = tz
+    if (tz) {
+      localStorage.setItem('datetimeTimezone', tz)
+    } else {
+      localStorage.removeItem('datetimeTimezone')
+    }
+  }
+
   // Apply palette CSS variables to the document root
   function applyPalette(palette: Record<string, string>) {
     const root = document.documentElement
@@ -170,10 +215,12 @@ export const useUIStore = defineStore('ui', () => {
     modalData,
     darkMode,
     themeMode,
+    datetimeTimezone,
 
     // Getters
     isSidebarVisible,
     isDark,
+    effectiveTimezone,
 
     // Actions
     toggleSidebar,
@@ -190,6 +237,7 @@ export const useUIStore = defineStore('ui', () => {
     info,
     toggleDarkMode,
     setThemeMode,
+    setDatetimeTimezone,
     applyPalette,
     clearPalette,
   }

--- a/frontend/src/types/schema.ts
+++ b/frontend/src/types/schema.ts
@@ -19,7 +19,7 @@ export interface EntityType {
 }
 
 export interface PropertyDef {
-  type: 'string' | 'date' | 'integer' | 'boolean' | 'enum' | 'file' | 'rrule'
+  type: 'string' | 'date' | 'datetime' | 'integer' | 'boolean' | 'enum' | 'file' | 'rrule'
   required?: boolean
   values?: string[]
   // Optional display labels keyed by enum value. Display-only: the stored/

--- a/frontend/src/utils/format.test.ts
+++ b/frontend/src/utils/format.test.ts
@@ -3,6 +3,8 @@ import {
   formatValue,
   formatCellValue,
   formatDate,
+  formatDatetime,
+  utcISOToLocalInput,
   getCellValue,
   isEnumProperty,
   isEnumPropertyDef,
@@ -53,6 +55,48 @@ describe('format', () => {
     it('returns string values as-is', () => {
       expect(formatValue('hello')).toBe('hello')
     })
+
+    it('formats a datetime in the given display zone', () => {
+      // 12:30 UTC in New York (UTC-4 in July) is 08:30.
+      expect(formatValue('2026-07-13T12:30:00Z', 'datetime', 'America/New_York')).toContain('8:30')
+    })
+
+    it('defaults the datetime zone to the browser when tz omitted', () => {
+      // No throw, returns a non-dash formatted string.
+      const out = formatValue('2026-07-13T12:30:00Z', 'datetime')
+      expect(out).not.toBe('-')
+      expect(out).toMatch(/2026/)
+    })
+  })
+
+  describe('formatDatetime', () => {
+    it('renders a zoned instant identically regardless of the interpretation zone arg for absolute values', () => {
+      // A value with an explicit Z is absolute; the tz arg only affects display.
+      expect(formatDatetime('2026-07-13T12:30:00Z', 'UTC')).toContain('12:30')
+    })
+
+    it('interprets a NAIVE value consistently with the edit widget (RR-P9NKU7)', () => {
+      // The key property: display (formatDatetime) and edit (utcISOToLocalInput)
+      // must resolve a naive value (no Z/offset) to the SAME wall-clock in the
+      // zone. Both now parse via TZDate, so they agree — previously formatDatetime
+      // used native new Date() and diverged. The exact value isn't the contract;
+      // the AGREEMENT between view and edit is.
+      const naive = '2026-07-13T12:30:00'
+      const tz = 'America/New_York'
+      const editWallClock = utcISOToLocalInput(naive, tz) // e.g. 2026-07-13T06:30
+      const shownTime = editWallClock.slice(11) // "06:30"
+      const [h, m] = shownTime.split(':')
+      const hour12 = String(Number(h) % 12 || 12)
+      expect(formatDatetime(naive, tz)).toContain(`${hour12}:${m}`)
+    })
+
+    it('returns null for an unparseable value', () => {
+      expect(formatDatetime('not-a-datetime', 'UTC')).toBeNull()
+    })
+
+    it('returns null (does not throw) on an invalid time zone', () => {
+      expect(formatDatetime('2026-07-13T12:30:00Z', 'Not/AZone')).toBeNull()
+    })
   })
 
   describe('formatCellValue', () => {
@@ -61,6 +105,7 @@ describe('format', () => {
       description: '',
       properties: {
         created_at: { type: 'date' },
+        starts_at: { type: 'datetime' },
         is_active: { type: 'boolean' },
         title: { type: 'string' },
         schedule: { type: 'rrule' },
@@ -87,6 +132,13 @@ describe('format', () => {
 
     it('returns empty string for invalid date property (matches cell-empty sentinel)', () => {
       expect(formatCellValue('invalid', 'created_at', mockEntityType)).toBe('')
+    })
+
+    it('formats a datetime cell in the passed display zone (honors the tz override, RR-K3WEW2)', () => {
+      // 12:30 UTC in New York (UTC-4 in July) is 08:30 — the list column must
+      // honor the effective zone threaded from EntityList, not the browser zone.
+      const out = formatCellValue('2026-07-13T12:30:00Z', 'starts_at', mockEntityType, 'America/New_York')
+      expect(out).toContain('8:30')
     })
 
     it('formats boolean property as Yes/No', () => {

--- a/frontend/src/utils/format.ts
+++ b/frontend/src/utils/format.ts
@@ -73,8 +73,18 @@ export function utcISOToLocalInput(iso: string | null | undefined, tz: string): 
 /**
  * Convert a native datetime-local wall-clock string (`YYYY-MM-DDTHH:mm`),
  * interpreted in the given IANA time zone, to a canonical UTC RFC3339 instant
- * (`...Z`). Returns '' for empty/invalid input. DST and non-integer offsets are
- * handled by TZDate.
+ * (`...Z`). Returns '' for empty/invalid input. Non-integer offsets (e.g.
+ * +05:30) are handled by TZDate.
+ *
+ * DST edge cases: a wall-clock time that does not exist (spring-forward gap)
+ * or is ambiguous (fall-back overlap) is NORMALIZED by TZDate to a real
+ * instant — so such a local time is not a true round-trip. This is only
+ * reachable when a user types a boundary time by hand; the widget's own
+ * output (UTC → local → UTC) always round-trips.
+ *
+ * The seconds group is optional but the datetime-local input is minute-
+ * granular, so the widget never supplies seconds (sub-minute precision on a
+ * pre-existing value is dropped when the user edits that field).
  */
 export function localInputToUtcISO(local: string | null | undefined, tz: string): string {
   if (!local) return ''
@@ -99,16 +109,37 @@ export function localInputToUtcISO(local: string | null | undefined, tz: string)
  * zone. Deterministic across machines (fixed style + explicit zone). Returns
  * null for un-parseable input so callers can fall back to the raw string.
  */
+// A stored value that carries no zone marker (no trailing Z and no ±HH:MM
+// offset) is "naive". We interpret a naive value in the display `tz` — the
+// same zone the edit widget uses via utcISOToLocalInput — so viewing and
+// editing agree (RR-P9NKU7). A value WITH a zone marker is an absolute
+// instant and resolves identically however it is parsed.
+const NAIVE_DATETIME_RE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}(?::\d{2}(?:\.\d+)?)?$/
+
 export function formatDatetime(value: string, tz: string, locale?: string): string | null {
-  const date = new Date(value)
+  // Parse a naive value as wall-clock in `tz`; parse a zoned/absolute value
+  // as the instant it denotes. TZDate handles both (a zoned string ignores
+  // the tz arg for its instant), keeping display consistent with the input.
+  const date = NAIVE_DATETIME_RE.test(value) ? new TZDate(value, tz) : new Date(value)
   if (isNaN(date.getTime())) return null
-  return date.toLocaleString(locale, { ...DATETIME_FORMAT_OPTIONS, timeZone: tz })
+  try {
+    return date.toLocaleString(locale, { ...DATETIME_FORMAT_OPTIONS, timeZone: tz })
+  } catch {
+    // Defensive: toLocaleString throws RangeError on an invalid tz. The tz
+    // is validated upstream today, but degrade gracefully like formatDate.
+    return null
+  }
 }
 
 /**
- * Format a value based on its type for display
+ * Format a value based on its type for display.
+ *
+ * `tz` is the display time zone for `datetime` values; callers that honor the
+ * user's display-timezone preference pass `uiStore.effectiveTimezone`. It
+ * defaults to the browser zone so callers without store access still render a
+ * sensible value.
  */
-export function formatValue(value: unknown, type?: string): string {
+export function formatValue(value: unknown, type?: string, tz: string = browserTimeZone()): string {
   if (value === null || value === undefined) return '-'
   if (Array.isArray(value) && value.length === 0) return '-'
 
@@ -117,9 +148,7 @@ export function formatValue(value: unknown, type?: string): string {
   }
 
   if (type === 'datetime' && typeof value === 'string' && value) {
-    // List/table display uses the browser zone; the form widget passes the
-    // user's effective zone explicitly via formatDatetime.
-    return formatDatetime(value, browserTimeZone()) ?? value
+    return formatDatetime(value, tz) ?? value
   }
 
   if (type === 'boolean') {
@@ -146,12 +175,17 @@ export function formatValue(value: unknown, type?: string): string {
 }
 
 /**
- * Format a cell value for display in a list/table
+ * Format a cell value for display in a list/table.
+ *
+ * `tz` is the display time zone for `datetime` cells (pass
+ * `uiStore.effectiveTimezone` to honor the user's preference); defaults to the
+ * browser zone.
  */
 export function formatCellValue(
   value: unknown,
   property: string | undefined,
-  entityType?: EntityType
+  entityType?: EntityType,
+  tz: string = browserTimeZone()
 ): string {
   // Cells render empty for null/undefined (vs '-' in formatValue) so blank
   // table cells stay visually quiet; do not delegate this branch to formatValue.
@@ -163,7 +197,7 @@ export function formatCellValue(
       return formatDate(value) ?? ''
     }
     if (propDef?.type === 'datetime' && typeof value === 'string') {
-      return formatDatetime(value, browserTimeZone()) ?? String(value)
+      return formatDatetime(value, tz) ?? String(value)
     }
     if (propDef?.type === 'boolean') {
       return value ? 'Yes' : 'No'

--- a/frontend/src/utils/format.ts
+++ b/frontend/src/utils/format.ts
@@ -3,6 +3,7 @@
  */
 
 import { RRule } from 'rrule'
+import { TZDate } from '@date-fns/tz'
 import type { PropertyDef, EntityType } from '@/types'
 
 export const DATE_FORMAT_OPTIONS: Intl.DateTimeFormatOptions = {
@@ -39,6 +40,71 @@ export function formatDate(value: string, locale?: string): string | null {
   return date.toLocaleDateString(locale, DATE_FORMAT_OPTIONS)
 }
 
+const DATETIME_FORMAT_OPTIONS: Intl.DateTimeFormatOptions = {
+  dateStyle: 'medium',
+  timeStyle: 'short',
+}
+
+const pad = (n: number): string => String(n).padStart(2, '0')
+
+/**
+ * The browser's IANA time zone (e.g. "Europe/Amsterdam"), used as the default
+ * display zone when the user has not chosen an override.
+ */
+export function browserTimeZone(): string {
+  return Intl.DateTimeFormat().resolvedOptions().timeZone
+}
+
+/**
+ * Convert a stored UTC RFC3339 instant to the `YYYY-MM-DDTHH:mm` local
+ * wall-clock string a native <input type="datetime-local"> expects, expressed
+ * in the given IANA time zone. Returns '' for empty/invalid input.
+ */
+export function utcISOToLocalInput(iso: string | null | undefined, tz: string): string {
+  if (!iso) return ''
+  const d = new TZDate(iso, tz)
+  if (isNaN(d.getTime())) return ''
+  return (
+    `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}` +
+    `T${pad(d.getHours())}:${pad(d.getMinutes())}`
+  )
+}
+
+/**
+ * Convert a native datetime-local wall-clock string (`YYYY-MM-DDTHH:mm`),
+ * interpreted in the given IANA time zone, to a canonical UTC RFC3339 instant
+ * (`...Z`). Returns '' for empty/invalid input. DST and non-integer offsets are
+ * handled by TZDate.
+ */
+export function localInputToUtcISO(local: string | null | undefined, tz: string): string {
+  if (!local) return ''
+  const m = /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2})(?::(\d{2}))?$/.exec(local)
+  if (!m) return ''
+  const [, y, mo, d, h, min, s] = m
+  const zoned = new TZDate(
+    Number(y),
+    Number(mo) - 1,
+    Number(d),
+    Number(h),
+    Number(min),
+    Number(s ?? 0),
+    tz
+  )
+  if (isNaN(zoned.getTime())) return ''
+  return new Date(zoned.getTime()).toISOString().replace(/\.\d{3}Z$/, 'Z')
+}
+
+/**
+ * Format a stored UTC RFC3339 instant for human display in the given IANA time
+ * zone. Deterministic across machines (fixed style + explicit zone). Returns
+ * null for un-parseable input so callers can fall back to the raw string.
+ */
+export function formatDatetime(value: string, tz: string, locale?: string): string | null {
+  const date = new Date(value)
+  if (isNaN(date.getTime())) return null
+  return date.toLocaleString(locale, { ...DATETIME_FORMAT_OPTIONS, timeZone: tz })
+}
+
 /**
  * Format a value based on its type for display
  */
@@ -48,6 +114,12 @@ export function formatValue(value: unknown, type?: string): string {
 
   if (type === 'date' && typeof value === 'string') {
     return formatDate(value) ?? '-'
+  }
+
+  if (type === 'datetime' && typeof value === 'string' && value) {
+    // List/table display uses the browser zone; the form widget passes the
+    // user's effective zone explicitly via formatDatetime.
+    return formatDatetime(value, browserTimeZone()) ?? value
   }
 
   if (type === 'boolean') {
@@ -89,6 +161,9 @@ export function formatCellValue(
     const propDef = entityType.properties[property]
     if (propDef?.type === 'date' && typeof value === 'string') {
       return formatDate(value) ?? ''
+    }
+    if (propDef?.type === 'datetime' && typeof value === 'string') {
+      return formatDatetime(value, browserTimeZone()) ?? String(value)
     }
     if (propDef?.type === 'boolean') {
       return value ? 'Yes' : 'No'

--- a/frontend/src/views/SettingsView.vue
+++ b/frontend/src/views/SettingsView.vue
@@ -31,6 +31,20 @@ const schemaStore = useSchemaStore()
 const uiStore = useUIStore()
 const { confirm } = useConfirm()
 
+// Display-timezone picker. The list comes from Intl (all IANA zones); the
+// empty value maps to "Browser default". Changing it only affects how datetime
+// values are displayed/entered — stored values stay UTC (client-only pref).
+const timezoneOptions = computed<string[]>(() => {
+  const intlWithValues = Intl as typeof Intl & {
+    supportedValuesOf?: (key: string) => string[]
+  }
+  return intlWithValues.supportedValuesOf?.('timeZone') ?? []
+})
+const displayTimezone = computed<string>({
+  get: () => uiStore.datetimeTimezone,
+  set: (tz: string) => uiStore.setDatetimeTimezone(tz),
+})
+
 // State
 const loading = ref(true)
 const saving = ref(false)
@@ -1292,6 +1306,28 @@ onMounted(() => {
             class="btn btn-secondary btn-sm"
             @click="handleResetPalette"
           >Reset</button>
+        </div>
+      </div>
+
+      <!-- Display timezone -->
+      <div class="settings-card">
+        <h3>Display timezone</h3>
+        <p class="description">
+          The time zone datetime fields are shown and entered in (applies to all
+          times, this browser only). Stored values are always kept in UTC — this
+          setting changes only how they are displayed, never the saved value.
+        </p>
+        <div class="settings-row">
+          <label for="display-timezone-select" class="tz-label">Time zone</label>
+          <select
+            id="display-timezone-select"
+            v-model="displayTimezone"
+            class="input tz-select"
+            aria-label="Display timezone for datetime fields"
+          >
+            <option value="">Browser default ({{ uiStore.effectiveTimezone }})</option>
+            <option v-for="tz in timezoneOptions" :key="tz" :value="tz">{{ tz }}</option>
+          </select>
         </div>
       </div>
 

--- a/frontend/src/views/SettingsView.vue
+++ b/frontend/src/views/SettingsView.vue
@@ -1315,7 +1315,7 @@ onMounted(() => {
         <p class="description">
           The time zone datetime fields are shown and entered in (applies to all
           times, this browser only). Stored values are always kept in UTC — this
-          setting changes only how they are displayed, never the saved value.
+          setting changes only how they are displayed, never the underlying value.
         </p>
         <div class="settings-row">
           <label for="display-timezone-select" class="tz-label">Time zone</label>

--- a/frontend/src/widgets/DatetimeWidget.vue
+++ b/frontend/src/widgets/DatetimeWidget.vue
@@ -1,0 +1,106 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import type { WidgetProps } from './types'
+import { useUIStore } from '@/stores'
+import { useStringValue } from './useStringValue'
+import {
+  formatDatetime,
+  utcISOToLocalInput,
+  localInputToUtcISO,
+} from '@/utils/format'
+
+const props = defineProps<WidgetProps>()
+
+const emit = defineEmits<{
+  'update:modelValue': [value: unknown]
+}>()
+
+const uiStore = useUIStore()
+
+// The zone used to interpret input and render display — the user's chosen
+// display timezone, or the browser zone when unset.
+const timezone = computed(() => uiStore.effectiveTimezone)
+
+const stringValue = useStringValue(() => props.modelValue)
+
+// Display-mode rendering: format the stored UTC instant in the effective
+// zone. Falls back to the raw string for un-parseable values (silent, like
+// DateWidget — this computed runs every reactive tick).
+const displayValue = computed(() => {
+  if (!stringValue.value) return ''
+  return formatDatetime(stringValue.value, timezone.value) ?? stringValue.value
+})
+
+// The value bound to <input type="datetime-local">: the stored UTC instant
+// expressed as local wall-clock in the effective zone.
+const inputValue = computed(() => utcISOToLocalInput(stringValue.value, timezone.value))
+
+// Non-destructive: we emit ONLY in response to real user input on THIS field,
+// converting the local wall-clock back to a canonical UTC instant. We never
+// emit on mount, so simply viewing an entity (or editing an unrelated field)
+// never rewrites a datetime the user didn't touch — avoiding spurious git
+// churn on values with a different stored offset (RR-N1Z9BF).
+function onInput(event: Event) {
+  const local = (event.target as HTMLInputElement).value
+  // Cleared input -> empty value (property becomes unset); otherwise convert.
+  emit('update:modelValue', local === '' ? '' : localInputToUtcISO(local, timezone.value))
+}
+</script>
+
+<template>
+  <span v-if="mode === 'display'" class="display-value">{{ displayValue }}</span>
+  <div v-else class="datetime-widget">
+    <input
+      :id="id"
+      type="datetime-local"
+      :class="{ 'is-error': !!error }"
+      :value="inputValue"
+      :placeholder="placeholder"
+      :disabled="disabled"
+      @input="onInput"
+    />
+    <span class="tz-indicator">Times shown in {{ timezone }}</span>
+  </div>
+</template>
+
+<style scoped>
+.datetime-widget {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+input {
+  padding: 10px 12px;
+  border: 1px solid var(--border-color);
+  border-radius: 6px;
+  font-size: 14px;
+  background: var(--input-bg);
+  color: var(--text-color);
+  transition: all 0.15s;
+}
+
+input:focus {
+  outline: none;
+  border-color: var(--accent-color, #6366f1);
+  box-shadow: 0 0 0 2px rgba(99, 102, 241, 0.1);
+}
+
+input:disabled {
+  background: var(--hover-bg);
+  cursor: not-allowed;
+}
+
+input.is-error {
+  border-color: var(--error-color, #ef4444);
+}
+
+input.is-error:focus {
+  box-shadow: 0 0 0 2px rgba(239, 68, 68, 0.1);
+}
+
+.tz-indicator {
+  font-size: 12px;
+  color: var(--text-muted, #6b7280);
+}
+</style>

--- a/frontend/src/widgets/registry.ts
+++ b/frontend/src/widgets/registry.ts
@@ -5,6 +5,7 @@ import TextareaWidget from './TextareaWidget.vue'
 import NumberWidget from './NumberWidget.vue'
 import CheckboxWidget from './CheckboxWidget.vue'
 import DateWidget from './DateWidget.vue'
+import DatetimeWidget from './DatetimeWidget.vue'
 import SelectWidget from './SelectWidget.vue'
 import MultiSelectWidget from './MultiSelectWidget.vue'
 import RruleWidget from './RruleWidget.vue'
@@ -19,6 +20,7 @@ export function defaultWidgetFor(propertyDef?: PropertyDef): string {
   if ((propertyDef?.values?.length ?? 0) > 0) return 'select'
   if (propertyDef?.type === 'boolean') return 'checkbox'
   if (propertyDef?.type === 'date') return 'date'
+  if (propertyDef?.type === 'datetime') return 'datetime'
   if (propertyDef?.type === 'integer') return 'number'
   if (propertyDef?.type === 'rrule') return 'rrule'
   if (propertyDef?.type === 'file') return 'file'
@@ -35,6 +37,7 @@ const hintKindToWidgetName: Record<WidgetHintKind, string> = {
   'enum-list': 'multi-select',
   boolean: 'checkbox',
   date: 'date',
+  datetime: 'datetime',
   integer: 'number',
   rrule: 'rrule',
 }
@@ -104,6 +107,7 @@ function buildDefaultRegistry(): WidgetRegistry {
   r.register('number', { component: NumberWidget, supportedPropertyTypes: ['integer'] })
   r.register('checkbox', { component: CheckboxWidget, supportedPropertyTypes: ['boolean'] })
   r.register('date', { component: DateWidget, supportedPropertyTypes: ['date'] })
+  r.register('datetime', { component: DatetimeWidget, supportedPropertyTypes: ['datetime'] })
   r.register('select', { component: SelectWidget, supportedPropertyTypes: ['enum', 'string'] })
   r.register('multi-select', {
     component: MultiSelectWidget,

--- a/frontend/src/widgets/types.ts
+++ b/frontend/src/widgets/types.ts
@@ -80,6 +80,7 @@ export type WidgetHintKind =
   | 'enum-list'
   | 'boolean'
   | 'date'
+  | 'datetime'
   | 'integer'
   | 'rrule'
 

--- a/frontend/src/widgets/widgets.test.ts
+++ b/frontend/src/widgets/widgets.test.ts
@@ -5,8 +5,11 @@ import TextareaWidget from './TextareaWidget.vue'
 import NumberWidget from './NumberWidget.vue'
 import CheckboxWidget from './CheckboxWidget.vue'
 import DateWidget from './DateWidget.vue'
+import DatetimeWidget from './DatetimeWidget.vue'
 import SelectWidget from './SelectWidget.vue'
 import FileWidget from './FileWidget.vue'
+
+import { useUIStore } from '@/stores'
 
 import type { AttachmentInfo } from '@/types'
 
@@ -113,6 +116,72 @@ describe('DateWidget', () => {
     expect(w.find('span.display-value').exists()).toBe(false)
     await input.setValue('2026-06-01')
     expect(w.emitted('update:modelValue')?.[0]).toEqual(['2026-06-01'])
+  })
+})
+
+describe('DatetimeWidget', () => {
+  const mountAt = (tz: string, props: { modelValue: unknown }) => {
+    // Choose the effective zone via the store; '' means browser default.
+    useUIStore().setDatetimeTimezone(tz)
+    return mount(DatetimeWidget, {
+      props: { mode: 'edit' as const, propertyName: '', ...props },
+    })
+  }
+
+  it('renders a datetime-local input showing the UTC instant as local wall-clock (UTC zone)', () => {
+    const w = mountAt('UTC', { modelValue: '2026-07-13T12:30:00Z' })
+    const input = w.find('input[type="datetime-local"]')
+    expect(input.exists()).toBe(true)
+    expect((input.element as HTMLInputElement).value).toBe('2026-07-13T12:30')
+  })
+
+  it('shows the effective timezone in a read-only indicator', () => {
+    const w = mountAt('America/New_York', { modelValue: '2026-07-13T12:30:00Z' })
+    expect(w.find('.tz-indicator').text()).toContain('America/New_York')
+  })
+
+  it('converts UTC to the effective zone for the input (America/New_York = UTC-4 in July)', () => {
+    const w = mountAt('America/New_York', { modelValue: '2026-07-13T12:30:00Z' })
+    expect((w.find('input').element as HTMLInputElement).value).toBe('2026-07-13T08:30')
+  })
+
+  it('emits a canonical UTC ...Z instant on user input, interpreting wall-clock in the zone', async () => {
+    const w = mountAt('America/New_York', { modelValue: '2026-07-13T12:30:00Z' })
+    await w.find('input').setValue('2026-07-13T09:30')
+    // 09:30 in New York (UTC-4) is 13:30 UTC.
+    expect(w.emitted('update:modelValue')?.[0]).toEqual(['2026-07-13T13:30:00Z'])
+  })
+
+  it('is non-destructive: mounting emits nothing (no incidental rewrite)', () => {
+    const w = mountAt('America/New_York', { modelValue: '2026-07-13T12:30:00+02:00' })
+    expect(w.emitted('update:modelValue')).toBeUndefined()
+  })
+
+  it('emits empty when the input is cleared', async () => {
+    const w = mountAt('UTC', { modelValue: '2026-07-13T12:30:00Z' })
+    await w.find('input').setValue('')
+    expect(w.emitted('update:modelValue')?.[0]).toEqual([''])
+  })
+
+  it('handles a non-integer offset zone (Asia/Kolkata, +05:30)', () => {
+    const w = mountAt('Asia/Kolkata', { modelValue: '2026-07-13T12:30:00Z' })
+    // 12:30 UTC + 5:30 = 18:00 local.
+    expect((w.find('input').element as HTMLInputElement).value).toBe('2026-07-13T18:00')
+  })
+
+  it('handles a date-line zone where the local date differs (Pacific/Auckland)', () => {
+    const w = mountAt('Pacific/Auckland', { modelValue: '2026-07-13T18:00:00Z' })
+    // NZST in July is UTC+12, so 18:00Z on the 13th is 06:00 on the 14th.
+    expect((w.find('input').element as HTMLInputElement).value).toBe('2026-07-14T06:00')
+  })
+
+  it('display mode formats the instant in the effective zone', () => {
+    const w = mount(DatetimeWidget, {
+      props: { modelValue: '2026-07-13T12:30:00Z', mode: 'display' as const, propertyName: '' },
+    })
+    useUIStore().setDatetimeTimezone('UTC')
+    expect(w.find('span.display-value').exists()).toBe(true)
+    expect(w.find('input').exists()).toBe(false)
   })
 })
 

--- a/frontend/src/widgets/widgets.test.ts
+++ b/frontend/src/widgets/widgets.test.ts
@@ -175,13 +175,23 @@ describe('DatetimeWidget', () => {
     expect((w.find('input').element as HTMLInputElement).value).toBe('2026-07-14T06:00')
   })
 
-  it('display mode formats the instant in the effective zone', () => {
+  it('emits the correct UTC across a US spring-forward DST boundary', async () => {
+    // 2026-03-08 is US spring-forward: America/New_York goes UTC-5 -> UTC-4 at
+    // 02:00 local. A 03:30 local time (just after the gap) is UTC-4 => 07:30Z.
+    const w = mountAt('America/New_York', { modelValue: '2026-03-08T12:00:00Z' })
+    await w.find('input').setValue('2026-03-08T03:30')
+    expect(w.emitted('update:modelValue')?.slice(-1)[0]).toEqual(['2026-03-08T07:30:00Z'])
+  })
+
+  it('display mode formats the instant in the effective zone (zone-correct text)', () => {
+    // Set the zone BEFORE mount so display reflects it; assert the actual text.
+    useUIStore().setDatetimeTimezone('America/New_York')
     const w = mount(DatetimeWidget, {
       props: { modelValue: '2026-07-13T12:30:00Z', mode: 'display' as const, propertyName: '' },
     })
-    useUIStore().setDatetimeTimezone('UTC')
-    expect(w.find('span.display-value').exists()).toBe(true)
     expect(w.find('input').exists()).toBe(false)
+    // 12:30 UTC in New York (UTC-4 in July) is 08:30 -> "8:30 AM".
+    expect(w.find('span.display-value').text()).toContain('8:30')
   })
 })
 

--- a/internal/affordances/env.go
+++ b/internal/affordances/env.go
@@ -102,13 +102,13 @@ func propertyPredicateType(meta *metamodel.Metamodel, prop metamodel.PropertyDef
 }
 
 // scalarPredicateType maps a scalar metamodel type name to a predicate
-// scalar type. enum/date/rrule/string and string-valued custom types
-// become StringType; integer becomes NumberType; boolean becomes
+// scalar type. enum/date/datetime/rrule/string and string-valued custom
+// types become StringType; integer becomes NumberType; boolean becomes
 // BoolType. file and unknown types are unmodelled.
 func scalarPredicateType(meta *metamodel.Metamodel, typeName string) (predicate.Type, bool) {
 	switch typeName {
 	case "", metamodel.PropertyTypeString, metamodel.PropertyTypeEnum,
-		metamodel.PropertyTypeDate, metamodel.PropertyTypeRrule:
+		metamodel.PropertyTypeDate, metamodel.PropertyTypeDatetime, metamodel.PropertyTypeRrule:
 		return predicate.StringType, true
 	case metamodel.PropertyTypeInteger:
 		return predicate.NumberType, true

--- a/internal/dataentry/config.go
+++ b/internal/dataentry/config.go
@@ -22,6 +22,7 @@ const (
 	WidgetTextarea    = dataentryconfig.WidgetTextarea
 	WidgetNumber      = dataentryconfig.WidgetNumber
 	WidgetDate        = dataentryconfig.WidgetDate
+	WidgetDatetime    = dataentryconfig.WidgetDatetime
 	WidgetCards       = dataentryconfig.WidgetCards
 
 	DirectionIncoming = dataentryconfig.DirectionIncoming

--- a/internal/dataentry/helpers_test.go
+++ b/internal/dataentry/helpers_test.go
@@ -379,6 +379,7 @@ func TestResolveWidget(t *testing.T) {
 	}{
 		{"string type", metamodel.PropertyDef{Type: metamodel.PropertyTypeString}, WidgetText},
 		{"date type", metamodel.PropertyDef{Type: metamodel.PropertyTypeDate}, WidgetDate},
+		{"datetime type", metamodel.PropertyDef{Type: metamodel.PropertyTypeDatetime}, WidgetDatetime},
 		{"integer type", metamodel.PropertyDef{Type: metamodel.PropertyTypeInteger}, WidgetNumber},
 		{"boolean type", metamodel.PropertyDef{Type: metamodel.PropertyTypeBoolean}, WidgetCheckbox},
 		{"enum type", metamodel.PropertyDef{Type: metamodel.PropertyTypeEnum}, WidgetSelect},

--- a/internal/dataentryconfig/config.go
+++ b/internal/dataentryconfig/config.go
@@ -26,6 +26,7 @@ const (
 	WidgetTextarea    = "textarea"
 	WidgetNumber      = "number"
 	WidgetDate        = "date"
+	WidgetDatetime    = "datetime"
 	WidgetRrule       = "rrule"
 	WidgetCards       = "cards" // card-based UI for relations with properties
 )

--- a/internal/filter/match.go
+++ b/internal/filter/match.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/Sourcehaven-BV/rela/internal/metamodel"
 )
@@ -70,7 +71,10 @@ func Match(rec Record, filter *Filter, propDef *metamodel.PropertyDef, m *metamo
 	switch propDef.Type {
 	case metamodel.PropertyTypeString:
 		return matchString(val, filter)
-	case metamodel.PropertyTypeDate:
+	case metamodel.PropertyTypeDate, metamodel.PropertyTypeDatetime:
+		// datetime reuses matchDate: ParseDateValue yields a full time.Time
+		// (incl. time-of-day), so comparison is instant-granular. Equality
+		// is therefore strict-instant, not day-granular.
 		return matchDate(val, filter, propDef)
 	case metamodel.PropertyTypeInteger:
 		return matchInteger(val, filter)
@@ -166,8 +170,8 @@ func validateOperatorForType(op Operator, propDef *metamodel.PropertyDef, m *met
 			return fmt.Errorf("operator %q not supported for string property", op)
 		}
 
-	case metamodel.PropertyTypeDate, metamodel.PropertyTypeInteger:
-		// Date and integer support: =, !=, <, <=, >, >=
+	case metamodel.PropertyTypeDate, metamodel.PropertyTypeDatetime, metamodel.PropertyTypeInteger:
+		// Date, datetime and integer support: =, !=, <, <=, >, >=
 		if op == OpRegex || op == OpFuzzy {
 			return fmt.Errorf("operator %q not supported for %s property", op, propType)
 		}
@@ -260,17 +264,24 @@ func matchString(val interface{}, filter *Filter) (bool, error) {
 	}
 }
 
-// matchDate matches a date property value
+// matchDate matches a date or datetime property value. The entity value may
+// be a string (machine/quoted) or a time.Time — yaml.v3 auto-decodes an
+// unquoted timestamp/date scalar to time.Time, so both must be accepted.
+// Comparison is instant-granular for both date and datetime; for datetime
+// this makes equality strict-instant.
 func matchDate(val interface{}, filter *Filter, propDef *metamodel.PropertyDef) (bool, error) {
-	s, ok := val.(string)
-	if !ok {
-		return false, fmt.Errorf("expected date string value, got %T", val)
-	}
-
-	// Parse entity's date value
-	entityDate, err := metamodel.ParseDateValue(s, propDef)
-	if err != nil {
-		return false, fmt.Errorf("invalid date value %q: %w", s, err)
+	var entityDate time.Time
+	switch v := val.(type) {
+	case time.Time:
+		entityDate = v
+	case string:
+		parsed, err := metamodel.ParseDateValue(v, propDef)
+		if err != nil {
+			return false, fmt.Errorf("invalid date value %q: %w", v, err)
+		}
+		entityDate = parsed
+	default:
+		return false, fmt.Errorf("expected date string or time.Time value, got %T", val)
 	}
 
 	// Parse filter's date value

--- a/internal/filter/match_test.go
+++ b/internal/filter/match_test.go
@@ -2,6 +2,7 @@ package filter
 
 import (
 	"testing"
+	"time"
 
 	"github.com/Sourcehaven-BV/rela/internal/entity"
 	"github.com/Sourcehaven-BV/rela/internal/metamodel"
@@ -102,6 +103,56 @@ func TestMatchDate(t *testing.T) {
 			}
 
 			got, err := Match(toRecord(entity), f, propDef, mm)
+			if tt.wantErr {
+				if err == nil {
+					t.Error("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("Match error: %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("Match = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMatchDatetime(t *testing.T) {
+	propDef := &metamodel.PropertyDef{Type: metamodel.PropertyTypeDatetime}
+	mm := &metamodel.Metamodel{}
+
+	tests := []struct {
+		name    string
+		value   interface{}
+		filter  string
+		want    bool
+		wantErr bool
+	}{
+		{"greater than true", "2026-07-13T14:30:00Z", "starts_at>2026-07-13T09:00:00Z", true, false},
+		{"greater than false", "2026-07-13T14:30:00Z", "starts_at>2026-07-13T20:00:00Z", false, false},
+		{"less than true", "2026-07-13T08:00:00Z", "starts_at<2026-07-13T09:00:00Z", true, false},
+		{"instant equal", "2026-07-13T14:30:00Z", "starts_at=2026-07-13T14:30:00Z", true, false},
+		// Strict-instant equality: a bare-date operand (midnight) does NOT
+		// match a value later the same day (RR-5R3QFJ).
+		{"bare-date operand not day-granular", "2026-07-13T14:30:00Z", "starts_at=2026-07-13", false, false},
+		{"time.Time value greater", time.Date(2026, 7, 13, 14, 30, 0, 0, time.UTC), "starts_at>2026-07-13T09:00:00Z", true, false},
+		{"invalid entity datetime", "not-a-datetime", "starts_at=2026-07-13T14:30:00Z", false, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ent := &entity.Entity{
+				ID:         "EVT-001",
+				Type:       "event",
+				Properties: map[string]interface{}{"starts_at": tt.value},
+			}
+			f, err := Parse(tt.filter)
+			if err != nil {
+				t.Fatalf("Parse(%q) error: %v", tt.filter, err)
+			}
+			got, err := Match(toRecord(ent), f, propDef, mm)
 			if tt.wantErr {
 				if err == nil {
 					t.Error("expected error, got nil")

--- a/internal/filter/sort.go
+++ b/internal/filter/sort.go
@@ -37,7 +37,7 @@ func Sort[T any](
 
 		var less bool
 		switch propDef.Type {
-		case metamodel.PropertyTypeDate:
+		case metamodel.PropertyTypeDate, metamodel.PropertyTypeDatetime:
 			less = compareDates(valI, valJ, propDef)
 		case metamodel.PropertyTypeInteger:
 			less = compareIntegers(valI, valJ)
@@ -308,6 +308,11 @@ func comparePropValues(valI, valJ interface{}, piI, piJ *propInfo, meta *metamod
 	switch {
 	case piI.def != nil && piJ.def != nil && piI.def.Type == piJ.def.Type:
 		return compareByPropDef(valI, valJ, piI.def, piI.enumIndex)
+	case piI.def != nil && piJ.def != nil && isTimeLike(piI.def.Type) && isTimeLike(piJ.def.Type):
+		// A mixed date/datetime column: both parse to a full time.Time via
+		// ParseDateValue, so compare as instants rather than lexically
+		// (RR-5R3QFJ). piI.def supplies the format fallback.
+		return compareDates(valI, valJ, piI.def)
 	case piI.def != nil && piJ.def != nil:
 		rankI := typeRank(piI.def, meta)
 		rankJ := typeRank(piJ.def, meta)
@@ -327,7 +332,7 @@ func comparePropValues(valI, valJ interface{}, piI, piJ *propInfo, meta *metamod
 // compareByPropDef compares two values using the given property definition.
 func compareByPropDef(valI, valJ interface{}, propDef *metamodel.PropertyDef, enumIndex map[string]int) bool {
 	switch propDef.Type {
-	case metamodel.PropertyTypeDate:
+	case metamodel.PropertyTypeDate, metamodel.PropertyTypeDatetime:
 		return compareDates(valI, valJ, propDef)
 	case metamodel.PropertyTypeInteger:
 		return compareIntegers(valI, valJ)
@@ -351,11 +356,20 @@ const (
 	typeRankString
 )
 
+// isTimeLike reports whether a property type is compared as a time.Time
+// instant (date or datetime). Both parse via ParseDateValue.
+func isTimeLike(propType string) bool {
+	return propType == metamodel.PropertyTypeDate || propType == metamodel.PropertyTypeDatetime
+}
+
 func typeRank(propDef *metamodel.PropertyDef, meta *metamodel.Metamodel) int {
 	switch propDef.Type {
 	case metamodel.PropertyTypeInteger:
 		return typeRankInteger
-	case metamodel.PropertyTypeDate:
+	case metamodel.PropertyTypeDate, metamodel.PropertyTypeDatetime:
+		// datetime shares date's rank so mixed date+datetime columns
+		// interleave chronologically rather than degrading to lexical
+		// string order (RR-5R3QFJ).
 		return typeRankDate
 	case metamodel.PropertyTypeBoolean:
 		return typeRankBoolean

--- a/internal/filter/sort_test.go
+++ b/internal/filter/sort_test.go
@@ -613,6 +613,36 @@ func TestSortMulti_CrossTypeDifferentPropertyType(t *testing.T) {
 	}
 }
 
+func TestSortMulti_MixedDateDatetimeChronological(t *testing.T) {
+	// A mixed date/datetime column must sort chronologically as instants,
+	// not lexically (RR-5R3QFJ). The datetime value (13:00 on the 13th) sits
+	// between the two bare-date values (the 12th and the 14th).
+	entityDefs := map[string]*metamodel.EntityDef{
+		"typeDate": {Properties: map[string]metamodel.PropertyDef{
+			"when": {Type: metamodel.PropertyTypeDate},
+		}},
+		"typeDatetime": {Properties: map[string]metamodel.PropertyDef{
+			"when": {Type: metamodel.PropertyTypeDatetime},
+		}},
+	}
+
+	entities := []*entity.Entity{
+		{ID: "later", Type: "typeDate", Properties: map[string]interface{}{"when": "2026-07-14"}},
+		{ID: "middle", Type: "typeDatetime", Properties: map[string]interface{}{"when": "2026-07-13T13:00:00Z"}},
+		{ID: "earlier", Type: "typeDate", Properties: map[string]interface{}{"when": "2026-07-12"}},
+	}
+
+	SortMulti(entities, testAccess, []SortSpec{{Property: "when"}}, entityDefs, nil)
+
+	wantOrder := []string{"earlier", "middle", "later"}
+	for i, want := range wantOrder {
+		if entities[i].ID != want {
+			t.Errorf("position %d: got %s, want %s (order=%v)", i,
+				entities[i].ID, want, []string{entities[0].ID, entities[1].ID, entities[2].ID})
+		}
+	}
+}
+
 func TestSortMulti_CrossTypeDifferentPropertyTypeSameRankFallback(t *testing.T) {
 	// Two different types with same rank — should fall back to string comparison
 	entityDefs := map[string]*metamodel.EntityDef{
@@ -707,6 +737,7 @@ func TestTypeRank(t *testing.T) {
 	}{
 		{"integer", &metamodel.PropertyDef{Type: metamodel.PropertyTypeInteger}, typeRankInteger},
 		{"date", &metamodel.PropertyDef{Type: metamodel.PropertyTypeDate}, typeRankDate},
+		{"datetime shares date rank", &metamodel.PropertyDef{Type: metamodel.PropertyTypeDatetime}, typeRankDate},
 		{"boolean", &metamodel.PropertyDef{Type: metamodel.PropertyTypeBoolean}, typeRankBoolean},
 		{"enum", &metamodel.PropertyDef{Type: metamodel.PropertyTypeEnum}, typeRankEnum},
 		{"string", &metamodel.PropertyDef{Type: metamodel.PropertyTypeString}, typeRankString},

--- a/internal/metamodel/loader.go
+++ b/internal/metamodel/loader.go
@@ -403,7 +403,7 @@ func validateDisplayPropertyRef(
 	// types defined elsewhere. Reject the structured types whose default
 	// rendering is unhelpful.
 	switch prop.Type {
-	case PropertyTypeDate, PropertyTypeFile, PropertyTypeRrule:
+	case PropertyTypeDate, PropertyTypeDatetime, PropertyTypeFile, PropertyTypeRrule:
 		errs = append(errs, fmt.Sprintf(
 			"entity %q: display_property %q references property %q of type %q; "+
 				"only string, integer, boolean, or enum types render as display names",

--- a/internal/metamodel/schema_output.go
+++ b/internal/metamodel/schema_output.go
@@ -120,6 +120,8 @@ func (m *Metamodel) ResolveWidgetFromType(propType string) string {
 		return "text"
 	case PropertyTypeDate:
 		return "date"
+	case PropertyTypeDatetime:
+		return "datetime"
 	case PropertyTypeInteger:
 		return "number"
 	case PropertyTypeBoolean:

--- a/internal/metamodel/types.go
+++ b/internal/metamodel/types.go
@@ -2,6 +2,7 @@ package metamodel
 
 import (
 	"regexp"
+	"time"
 )
 
 // Metamodel represents the full metamodel configuration
@@ -271,13 +272,14 @@ func (p PropertyDef) FileMax() int {
 
 // Built-in property types
 const (
-	PropertyTypeString  = "string"
-	PropertyTypeDate    = "date"
-	PropertyTypeInteger = "integer"
-	PropertyTypeBoolean = "boolean"
-	PropertyTypeEnum    = "enum"
-	PropertyTypeFile    = "file"
-	PropertyTypeRrule   = "rrule"
+	PropertyTypeString   = "string"
+	PropertyTypeDate     = "date"
+	PropertyTypeDatetime = "datetime"
+	PropertyTypeInteger  = "integer"
+	PropertyTypeBoolean  = "boolean"
+	PropertyTypeEnum     = "enum"
+	PropertyTypeFile     = "file"
+	PropertyTypeRrule    = "rrule"
 )
 
 // ID types for entities
@@ -334,20 +336,30 @@ func (m OrderableMode) IsValid() bool {
 // DefaultDateFormat is the default format for date properties (ISO 8601)
 const DefaultDateFormat = "2006-01-02"
 
+// DefaultDatetimeFormat is the default format for datetime properties (RFC3339,
+// a time-bearing ISO 8601 instant). Unlike date, a datetime value carries a
+// time-of-day and (canonically) a UTC offset.
+const DefaultDatetimeFormat = time.RFC3339
+
 // IsBuiltinType returns true if the type is a built-in property type
 func IsBuiltinType(t string) bool {
 	switch t {
-	case PropertyTypeString, PropertyTypeDate, PropertyTypeInteger,
+	case PropertyTypeString, PropertyTypeDate, PropertyTypeDatetime, PropertyTypeInteger,
 		PropertyTypeBoolean, PropertyTypeEnum, PropertyTypeFile, PropertyTypeRrule:
 		return true
 	}
 	return false
 }
 
-// GetDateFormat returns the date format for a property, defaulting to ISO 8601
+// GetDateFormat returns the date format for a property, defaulting to ISO 8601.
+// For datetime properties the default is RFC3339 (time-bearing); an explicit
+// Format still overrides.
 func (p *PropertyDef) GetDateFormat() string {
 	if p.Format != "" {
 		return p.Format
+	}
+	if p.Type == PropertyTypeDatetime {
+		return DefaultDatetimeFormat
 	}
 	return DefaultDateFormat
 }

--- a/internal/metamodel/types_test.go
+++ b/internal/metamodel/types_test.go
@@ -965,6 +965,7 @@ func TestIsBuiltinType(t *testing.T) {
 	}{
 		{name: "string is builtin", typ: PropertyTypeString, want: true},
 		{name: "date is builtin", typ: PropertyTypeDate, want: true},
+		{name: "datetime is builtin", typ: PropertyTypeDatetime, want: true},
 		{name: "integer is builtin", typ: PropertyTypeInteger, want: true},
 		{name: "boolean is builtin", typ: PropertyTypeBoolean, want: true},
 		{name: "enum is builtin", typ: PropertyTypeEnum, want: true},
@@ -1003,6 +1004,16 @@ func TestPropertyDef_GetDateFormat(t *testing.T) {
 			name: "empty format uses default",
 			prop: PropertyDef{Type: PropertyTypeDate, Format: ""},
 			want: DefaultDateFormat,
+		},
+		{
+			name: "datetime uses RFC3339 default",
+			prop: PropertyDef{Type: PropertyTypeDatetime},
+			want: DefaultDatetimeFormat,
+		},
+		{
+			name: "datetime custom format overrides",
+			prop: PropertyDef{Type: PropertyTypeDatetime, Format: "2006-01-02 15:04"},
+			want: "2006-01-02 15:04",
 		},
 	}
 

--- a/internal/metamodel/validation.go
+++ b/internal/metamodel/validation.go
@@ -275,7 +275,7 @@ func (m *Metamodel) validatePropertyValue(propName string, propDef *PropertyDef,
 			return &ValidationError{
 				Type:     ValidationErrorInvalidType,
 				Property: propName,
-				Message:  "Must be a datetime string",
+				Message:  "Must be a datetime string or timestamp",
 			}
 		}
 

--- a/internal/metamodel/validation.go
+++ b/internal/metamodel/validation.go
@@ -251,6 +251,34 @@ func (m *Metamodel) validatePropertyValue(propName string, propDef *PropertyDef,
 			}
 		}
 
+	case PropertyTypeDatetime:
+		// A datetime value is an RFC3339 instant. yaml.v3 auto-decodes an
+		// unquoted timestamp scalar to time.Time, while machine-written /
+		// quoted values arrive as string — accept both (RR-NY7PRB). A bare
+		// date (no time-of-day) is accepted and means midnight; we do NOT
+		// reject it, because after parsing "2026-07-13" and
+		// "2026-07-13T00:00:00Z" are indistinguishable time.Time values
+		// (RR-MYC2B6).
+		switch v := val.(type) {
+		case time.Time:
+			// Already a valid instant.
+		case string:
+			if _, err := ParseDateValue(v, propDef); err != nil {
+				format := propDef.GetDateFormat()
+				return &ValidationError{
+					Type:     ValidationErrorInvalidValue,
+					Property: propName,
+					Message:  fmt.Sprintf("Invalid datetime %q (expected format: %s)", v, format),
+				}
+			}
+		default:
+			return &ValidationError{
+				Type:     ValidationErrorInvalidType,
+				Property: propName,
+				Message:  "Must be a datetime string",
+			}
+		}
+
 	case PropertyTypeInteger:
 		switch v := val.(type) {
 		case int, int64:

--- a/internal/metamodel/validation_test.go
+++ b/internal/metamodel/validation_test.go
@@ -4,6 +4,7 @@ import (
 	"regexp"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestValidateEntity_EmptyRequiredProperty(t *testing.T) {
@@ -130,6 +131,56 @@ func TestValidateEntity_DateValidation_RFC3339(t *testing.T) {
 			}
 			if !tt.wantErr && len(errs) > 0 {
 				t.Errorf("unexpected validation error for date %q: %v", tt.dateValue, errs)
+			}
+		})
+	}
+}
+
+func TestValidateEntity_DatetimeValidation(t *testing.T) {
+	// A datetime value is an RFC3339 instant. The arm must accept both a
+	// string (machine/quoted) and a time.Time (yaml auto-decodes unquoted
+	// timestamps), accept a bare date as midnight, and reject junk.
+	meta := &Metamodel{
+		Entities: map[string]EntityDef{
+			"event": {
+				Label:    "Event",
+				IDPrefix: "EVT-",
+				Properties: map[string]PropertyDef{
+					"title": {Type: PropertyTypeString, Required: true},
+					"starts_at": {
+						Type:     PropertyTypeDatetime,
+						Required: false,
+					},
+				},
+			},
+		},
+	}
+
+	tests := []struct {
+		name    string
+		value   interface{}
+		wantErr bool
+	}{
+		{name: "RFC3339 string with Z", value: "2026-07-13T14:30:00Z", wantErr: false},
+		{name: "RFC3339 string with offset", value: "2026-07-13T14:30:00+02:00", wantErr: false},
+		{name: "time.Time value (yaml-decoded)", value: time.Date(2026, 7, 13, 14, 30, 0, 0, time.UTC), wantErr: false},
+		{name: "bare date accepted as midnight", value: "2026-07-13", wantErr: false},
+		{name: "empty string on non-required datetime", value: "", wantErr: false},
+		{name: "garbage input rejected", value: "not-a-datetime", wantErr: true},
+		{name: "wrong type (int) rejected", value: 42, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			errs := meta.ValidateEntity("EVT-001", "event", map[string]interface{}{
+				"title":     "Standup",
+				"starts_at": tt.value,
+			})
+			if tt.wantErr && len(errs) == 0 {
+				t.Errorf("expected validation error for %v, got none", tt.value)
+			}
+			if !tt.wantErr && len(errs) > 0 {
+				t.Errorf("unexpected validation error for %v: %v", tt.value, errs)
 			}
 		})
 	}

--- a/internal/openapi/schemas.go
+++ b/internal/openapi/schemas.go
@@ -86,6 +86,8 @@ func (g *Generator) propertyToSchema(prop metamodel.PropertyDef) *Schema {
 		base = &Schema{Type: "string"}
 	case metamodel.PropertyTypeDate:
 		base = &Schema{Type: "string", Format: "date"}
+	case metamodel.PropertyTypeDatetime:
+		base = &Schema{Type: "string", Format: "date-time"}
 	case metamodel.PropertyTypeInteger:
 		base = &Schema{Type: "integer"}
 	case metamodel.PropertyTypeBoolean:

--- a/internal/testutil/fixtures.go
+++ b/internal/testutil/fixtures.go
@@ -186,6 +186,8 @@ func (b *EntityBuilder) generatePropertyValue(_ string, prop metamodel.PropertyD
 		return RandomBool()
 	case metamodel.PropertyTypeDate:
 		return RandomDate()
+	case metamodel.PropertyTypeDatetime:
+		return RandomDatetime()
 	case metamodel.PropertyTypeFile:
 		return "test-file.txt"
 	default:

--- a/internal/testutil/random.go
+++ b/internal/testutil/random.go
@@ -63,6 +63,21 @@ func RandomDate() string {
 	return date.Format("2006-01-02")
 }
 
+// RandomDatetime generates a random RFC3339 (UTC) timestamp within the last
+// year. Unlike RandomDate it carries a time-of-day, so it produces valid
+// values for datetime properties.
+func RandomDatetime() string {
+	const daysInYear = 365
+	const secondsInDay = 24 * 60 * 60
+	now := time.Now().UTC()
+	rngMu.Lock()
+	daysAgo := rng.Intn(daysInYear)
+	secs := rng.Intn(secondsInDay)
+	rngMu.Unlock()
+	ts := now.AddDate(0, 0, -daysAgo).Truncate(24 * time.Hour).Add(time.Duration(secs) * time.Second)
+	return ts.Format(time.RFC3339)
+}
+
 // RandomEnumValue picks a random value from the given list.
 // Panics if values is empty.
 func RandomEnumValue(values []string) string {

--- a/internal/testutil/random.go
+++ b/internal/testutil/random.go
@@ -68,13 +68,14 @@ func RandomDate() string {
 // values for datetime properties.
 func RandomDatetime() string {
 	const daysInYear = 365
-	const secondsInDay = 24 * 60 * 60
+	const dayDuration = 24 * time.Hour
+	const secondsInDay = int(dayDuration / time.Second)
 	now := time.Now().UTC()
 	rngMu.Lock()
 	daysAgo := rng.Intn(daysInYear)
 	secs := rng.Intn(secondsInDay)
 	rngMu.Unlock()
-	ts := now.AddDate(0, 0, -daysAgo).Truncate(24 * time.Hour).Add(time.Duration(secs) * time.Second)
+	ts := now.AddDate(0, 0, -daysAgo).Truncate(dayDuration).Add(time.Duration(secs) * time.Second)
 	return ts.Format(time.RFC3339)
 }
 

--- a/tickets/entities/implementation-checklists/IMPL-8GTRJB.md
+++ b/tickets/entities/implementation-checklists/IMPL-8GTRJB.md
@@ -1,0 +1,72 @@
+---
+id: IMPL-8GTRJB
+type: implementation-checklist
+title: 'Implementation: Add a datetime metamodel property type (time-bearing, with date+time form widget)'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Development
+
+- [x] Unit tests written for new code
+- [x] Integration tests written (test full flow, not just units)
+- [x] Happy path implemented
+- [x] Edge cases from planning handled
+- [x] Error handling in place (errors surfaced, not swallowed)
+
+## Test Quality
+
+- [x] Using fixture builders or factories for test data (RandomDatetime; table-driven subtests)
+- [x] No hardcoded values in assertions when object is in scope
+- [x] Only specifying values that matter for the test
+- [x] Interpolated values constructed from objects, not hardcoded
+- [x] Property comparisons use original object, not hardcoded strings
+
+## Manual Verification
+
+- [x] Feature manually tested end-to-end (backend via CLI + running rela-server)
+- [x] Each acceptance criterion verified with test scenario from planning
+- [x] Edge cases manually verified
+
+**Verification Evidence:**
+
+Backend E2E (running binary against a scratch project with a `datetime`
+property):
+- **Create + store**: `rela create event -P starts_at="2026-07-13T14:30:00Z"` stores `starts_at: "2026-07-13T14:30:00Z"` (quoted UTC RFC3339). ✓ (AC1, AC2)
+- **Filter `>`**: `--where "starts_at>2026-07-13T12:00:00Z"` returns only the 14:30 event, not the 09:00 one. ✓ (AC3)
+- **Strict-instant `=`**: `--where "starts_at=2026-07-13"` (bare date = midnight) matches neither 09:00 nor 14:30 — documented behavior. ✓ (AC3 / RR-5R3QFJ)
+- **Hand-edited UNQUOTED datetime** (`starts_at: 2026-07-13T20:00:00Z`, yaml→time.Time): `analyze properties` = "All valid" — the RR-NY7PRB critical fix confirmed live (a string-only arm would have rejected it). ✓ (AC2 / RR-NY7PRB)
+- **Bare date** (`starts_at: 2026-07-13`): validates clean, sorts as midnight. ✓ (AC2 / RR-MYC2B6)
+- **Sort chronological incl. time**: `--sort starts_at` → BareDate(00:00), Retro(09:00), Standup(14:30), Unquoted(20:00). ✓ (AC4)
+- **Served type**: `GET /api/v1/entity-types` exposes `datetime` to the SPA. ✓ (AC6)
+
+Frontend (unit-test matrix against the real `@date-fns/tz` + `Intl`, all
+passing):
+- UTC→effective-zone input round-trip (UTC zone: 12:30→`2026-07-13T12:30`; NY: →`08:30`). ✓ (AC7)
+- Emit canonical `...Z` on user input (NY 09:30 → `2026-07-13T13:30:00Z`). ✓ (AC7)
+- **Non-destructive**: mounting emits nothing; cleared input → `''`. ✓ (AC7 / RR-N1Z9BF)
+- Non-integer offset `Asia/Kolkata` (+05:30 → 18:00) and date-line `Pacific/Auckland` (18:00Z → next-day 06:00). ✓ (AC10)
+- Display mode formats in the effective zone. ✓ (AC8)
+- Read-only tz indicator shows the effective zone. ✓ (RR-3A0RUL)
+- uiStore tz pref persists/reads from localStorage; unsupported/stale zone falls back to browser. ✓ (AC9 / RR-3A0RUL)
+- FieldRenderer routes a `datetime` property to the datetime-local widget end-to-end. ✓ (AC6)
+- OpenAPI schema arm asserted `{type: string, format: date-time}`. ✓ (AC5)
+
+**Not runnable here:** interactive Chrome click-through (browser extension not
+connected). Covered instead by the widget unit-test matrix above + confirmed the
+production bundle builds and the server serves the datetime type.
+
+**Automated gates:**
+- `go test ./...` — all pass (incl. new metamodel/filter/dataentry tests + a bonus `matchDate` time.Time fix).
+- `just arch-lint` — no warnings.
+- `npm run test:run` — 1263 pass (78 files). `npm run typecheck` — clean. `npm run lint` — 0 errors (pre-existing warnings only; no new). `npm run build` — SPA + editor bundles compile with `@date-fns/tz`.
+- `npm audit` for `@date-fns/tz` — 0 vulnerabilities; relies on `Intl` (no bundled tzdata).
+
+## Quality
+
+- [x] Code follows project patterns (datetime mirrors the `date` type/widget throughout; uiStore tz pref mirrors the `theme` pattern)
+- [x] Checked for DRY opportunities (shared `matchDate`/`compareDates`/`toTime`, `isTimeLike` helper, tz conversion helpers in `format.ts`; no premature abstraction)
+- [x] No security issues introduced (allowlist validation; tz pref client-only + validated; no new I/O or trust boundary)
+- [x] No silent failures (validation errors surfaced via the standard path; tz fallbacks are deliberate + documented)
+- [x] No debug code left behind

--- a/tickets/entities/planning-checklists/PLAN-69NQKG.md
+++ b/tickets/entities/planning-checklists/PLAN-69NQKG.md
@@ -1,0 +1,253 @@
+---
+id: PLAN-69NQKG
+type: planning-checklist
+title: 'Planning: Add a datetime metamodel property type (time-bearing, with date+time form widget)'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Understanding
+
+- [x] Problem/requirements clearly understood
+- [x] Scope defined (what's in/out documented below)
+- [x] Acceptance criteria documented with specific test scenarios
+
+**Problem:** The metamodel has a `date` (date-only) property type but no
+time-bearing `datetime` type, and no date+time form widget. Authoring a
+timestamp means hand-editing RFC3339 into a date field. Add a first-class
+`datetime` property type + a data-entry widget that captures date **and** time,
+with clear, adjustable timezone communication.
+
+> **POST-DESIGN-REVIEW (2026-07-13):** Design review (9 findings, see Design
+> Review section) changed three decisions from the original plan. This
+> Understanding/Scope block reflects the **final** post-review scope:
+> - Bare dates are **accepted as midnight-UTC**, NOT rejected (RR-MYC2B6).
+> - Validation accepts **both `string` and `time.Time`** (yaml auto-decodes
+>   unquoted datetimes to `time.Time`) (RR-NY7PRB).
+> - The inline tz control is a **read-only indicator** in v1; the picker lives
+>   in **Settings** (RR-3A0RUL). `@date-fns/tz` retained per user (RR-35VJ8G).
+
+**Scope — IN:**
+- New `PropertyTypeDatetime = "datetime"` builtin, registered as a builtin type.
+- Validation: a `datetime` value is any RFC3339-parseable instant. The arm accepts a Go `string` (parse via `ParseDateValue`) **or** a `time.Time` (yaml already decoded it) — a bare date is accepted and means midnight-UTC.
+- Typed filter (`<` `<=` `>` `>=`) and sort support, reusing the existing date `time.Time` comparison core. datetime shares `typeRankDate` so date+datetime interleave chronologically. `=` is strict-instant.
+- OpenAPI schema arm (`format: date-time`).
+- Type→widget resolution (`ResolveWidgetFromType` → `"datetime"`, backend widget const, frontend registry).
+- A `DatetimeWidget.vue`: native `<input type="datetime-local">` for edit, formatted display for view. **Non-destructive**: emits a new value only when the user edits *this* field; untouched values pass through verbatim (no incidental `+02:00`→`Z` churn).
+- **Read-only inline tz indicator** beneath the input ("Times shown in <effective IANA tz>"). The actual **display-timezone picker lives in Settings** (next to theme), listing `Intl.supportedValuesOf('timeZone')` + a "Browser default" top entry, keyboard + screen-reader accessible. The pref is global, persisted in **`localStorage` via the Pinia `uiStore`** (never sent to the server).
+- Storage semantics: widget captures wall-clock in the effective zone, converts to **UTC RFC3339** (`...Z`) on user edit, converts UTC→effective-zone for edit/display.
+- Uses **`@date-fns/tz`** (`TZDate`) for correct wall-clock↔UTC conversion in a *named* zone. (Impl task: `npm audit` clean + note transitive footprint.)
+- Go + frontend unit tests mirroring the date-type tests, plus tz + DST tests.
+- Docs: `docs/metamodel.md` (new type), `docs/data-entry.md` (widget + tz display).
+
+**Scope — OUT (follow-on, each a documented decision — not silence):**
+- Timed calendar-feed events. `validate_feeds.go:89,127` stays date-only (datetime NOT feed-eligible yet); calfeed stays all-day. Tracked by TKT-RDM9M5 / FEAT-OT4361 — this ticket is the metamodel primitive only (RR-FF45CP).
+- A *server-side* / per-project timezone setting. The override is a pure client display preference; no backend tz config.
+- **Clickable** inline tz shortcut (v1 inline is read-only; picker is in Settings) (RR-3A0RUL).
+- Seconds-precision UX polish across mobile browsers.
+- `datetime` as an entity `display_property` — treat like `date` (rejected in `loader.go`).
+- date→datetime **migration**: not needed — bare-date acceptance makes the widening lossless (RR-MYC2B6).
+
+**Acceptance Criteria:**
+1. A metamodel property declared `type: datetime` is accepted as a builtin. *Test:* `IsBuiltinType("datetime") == true`; metamodel with a datetime prop loads clean.
+2. Validation accepts RFC3339 timestamps AND `time.Time` values AND bare dates (as midnight-UTC); rejects true junk. *Test:* `validation_test.go` table: `"2026-07-13T14:30:00Z"` (string) valid; a `time.Time` value valid; `"2026-07-13"` valid (= midnight-UTC); `"not-a-date"` invalid; `""`/absent OK unless required.
+3. Filtering a datetime prop with `>`/`<` compares as instants. *Test:* `match_test.go`: `2026-07-13T14:30:00Z` matches `>2026-07-13T09:00:00Z`, not `>2026-07-13T20:00:00Z`. Plus: `=2026-07-13` does NOT match `2026-07-13T12:30:00Z` (strict-instant, documented).
+4. Sorting by a datetime prop orders chronologically incl. time; a MIXED date+datetime column also sorts chronologically (shared `typeRankDate`). *Test:* `sort_test.go` same-day-different-time + mixed-type cases.
+5. OpenAPI schema for a datetime prop is `{type: string, format: date-time}`. *Test:* openapi assertion.
+6. Type→widget resolves `datetime` → `datetime` widget end to end, incl. the relation-property modal render path. *Test:* Go `resolveWidget` table + frontend `registry.test.ts` + relation-modal render check.
+7. `DatetimeWidget` edit mode renders `datetime-local`, round-trips a UTC value to the effective zone and back, emits `...Z`, and is non-destructive for untouched values. *Test:* `widgets.test.ts`: `2026-07-13T12:30:00Z` @ zone `UTC` → input `2026-07-13T12:30`; change to `13:30` emits `2026-07-13T13:30:00Z`; mounting without editing emits nothing.
+8. Display mode renders a deterministic datetime in the effective zone. *Test:* `widgets.test.ts` display assertion using `Intl.DateTimeFormat({dateStyle:'medium', timeStyle:'short', timeZone})` + zone suffix.
+9. **TZ display setting:** the Settings picker changes input interpretation + display and persists across reloads; stored values stay UTC/unchanged; the inline indicator reflects the effective zone (read-only). *Test:* `widgets.test.ts` (zone `America/New_York`: UTC `2026-07-13T12:30:00Z` → input `08:30`; edit emits correct UTC) + `ui.test.ts` (uiStore persist/read + `effectiveTimezone` fallback + stale-value fallback).
+10. **DST/offset correctness.** *Test:* conversion helper tests for DST spring-forward, fall-back, `Asia/Kolkata` (+05:30), `Pacific/Auckland` (date line), and `Z`-in/offset-out round-trip.
+
+## Research
+
+- [x] For larger features: run `/research` to create a structured research doc
+- [x] Searched for existing libraries that solve this problem
+- [x] Checked codebase for similar patterns or reusable code
+- [x] Looked for reference implementations in other projects
+- [x] Reviewed relevant rela concepts for prior art
+
+**Research Doc:** N/A (two Explore sweeps + a web-research sweep + a
+design-review sweep captured below; medium change, not large enough for a RES
+entity).
+
+**Existing Solutions:**
+- **Prior art in-repo:** `date` type + `DateWidget.vue` are the direct template — datetime mirrors every date type-switch arm; the widget mirrors DateWidget (single component, edit+display). `rrule` (FEAT-DUW9) is the precedent for a richer widget. `uiStore` (`frontend/src/stores/ui.ts`) is the persistence template — `theme` = a `ref` from `localStorage.getItem` persisted via `watch`; the tz pref follows the same shape (`datetimeTimezone` ref + init + `watch` → `localStorage`, `setDatetimeTimezone` action, `effectiveTimezone` getter).
+- **Prebuilt Vue pickers:** `@vuepic/vue-datepicker` (~236KB + 4 deps) is the only maintained tz-aware picker, but its `timezone` prop does conversion only (no tz-name UI). **Rejected** for the full picker; we take only its `@date-fns/tz` `TZDate` primitive for named-zone↔UTC, and keep the native input + our own indicator.
+- **No global tz/locale setting exists** in rela (verified: no backend config, no `.rela/user-defaults.yaml` field, no Pinia field; backend `$today` is UTC). The widget owns the tz story; the pref is client-only.
+- **YAML decode behavior (verified by running yaml.v3):** an unquoted RFC3339 or bare-date scalar in frontmatter decodes to Go `time.Time`, not `string`; `markdown/parser.go:85` returns it un-normalized. This drives the "accept `time.Time`" validation decision and kills the "reject bare date" rule (both midnight-`time.Time`).
+- **Native `datetime-local` gaps** (accepted): no tz in value/UI (indicator covers it), seconds opt-in & mobile-inconsistent (fine), cross-browser styling variance (minor).
+
+## Approach
+
+- [x] Technical approach chosen and documented
+- [x] Approach builds on existing patterns (not reinventing)
+- [x] Alternatives considered (document why rejected)
+- [x] Dependencies identified (packages, APIs, types)
+
+**Technical Approach:**
+
+*Backend (Go)* — add `PropertyTypeDatetime` and slot a `datetime` arm into every
+type-switch the terrain map found:
+1. `internal/metamodel/types.go` — `PropertyTypeDatetime = "datetime"` const (~:273-281); add to `IsBuiltinType` (~:340); `DefaultDatetimeFormat = time.RFC3339` sibling (~:334).
+2. `internal/metamodel/validation.go` — `case PropertyTypeDatetime:` arm (~:235) as a **type-switch on the value**: `case string:` → `ParseDateValue`; `case time.Time:` → accept (already an instant); empty/absent → OK unless required; else invalid-type error. **No bare-date rejection.**
+3. `internal/metamodel/schema_output.go` — `ResolveWidgetFromType` → `"datetime"` (~:121).
+4. `internal/openapi/schemas.go` — `{type: string, format: date-time}` (~:87). (Cosmetic; the yaml parser, not the schema, sets the Go type.)
+5. `internal/filter/match.go` — dispatch to `matchDate` (~:73) + relational operators in `validateOperatorForType` (~:169). `matchDate` unchanged. `=` is strict-instant (documented).
+6. `internal/filter/sort.go` — arms at `SortMulti` (~:40), `compareByPropDef` (~:330), and `typeRank` (~:358) returning **`typeRankDate`** (shared, so date+datetime interleave). Verify the cross-type compare path in `comparePropValues` runs `toTime` on both when one side is date and the other datetime.
+7. `internal/affordances/env.go` — `scalarPredicateType` date arm (~:111) → `StringType`.
+8. `internal/metamodel/loader.go` — add to `display_property` rejection list (~:406).
+9. `internal/dataentryconfig/config.go` — `WidgetDatetime = "datetime"` (~:28); re-export from `internal/dataentry/config.go` (~:24).
+10. `internal/testutil/fixtures.go` — `PropertyTypeDatetime` arm + `RandomDatetime()` (~:187) — **required** (unknown types fall through to `RandomString` and would mask bugs).
+11. **Leave `internal/dataentryconfig/validate_feeds.go` untouched** (datetime not feed-eligible this ticket — documented decision).
+
+*Frontend (Vue/TS):*
+12. `frontend/src/types/schema.ts:22` — add `'datetime'` to the PropertyType union.
+13. `frontend/src/widgets/types.ts` — add `'datetime'` to `WidgetHintKind` (~:76-84).
+14. `frontend/src/widgets/registry.ts` — `defaultWidgetFor` (`datetime → 'datetime'`, ~:21), `hintKindToWidgetName` (~:37), register in `buildDefaultRegistry` (~:106) `supportedPropertyTypes: ['datetime']`; add import.
+15. `frontend/src/utils/format.ts` — tz-aware helpers on `@date-fns/tz` `TZDate`:
+- `browserTimeZone()` → `Intl.DateTimeFormat().resolvedOptions().timeZone`.
+- `utcISOToLocalInput(iso, tz)` → `datetime-local` string (`YYYY-MM-DDTHH:mm`) for the wall-clock in `tz`.
+- `localInputToUtcISO(local, tz)` → UTC RFC3339 (`...Z`) interpreting `local` as wall-clock in `tz`.
+- `formatDatetime(iso, tz)` → deterministic display via `Intl.DateTimeFormat({dateStyle:'medium', timeStyle:'short', timeZone: tz})` + zone suffix; add a `type === 'datetime'` arm in `formatValue` (~:48).
+16. `frontend/src/stores/ui.ts` — add `datetimeTimezone` ref (default `''`), init from `localStorage`, `watch` → `localStorage['datetimeTimezone']`, `setDatetimeTimezone(tz)` (validates against `Intl.supportedValuesOf('timeZone')`, ignores junk), `effectiveTimezone` getter (`datetimeTimezone || browserTimeZone()`). Export all.
+17. `frontend/src/views/SettingsView.vue` — add the **display-timezone picker** (next to theme): a `<select>` of `Intl.supportedValuesOf('timeZone')` with a "Browser default" top entry, labeled "Display timezone (applies to all times)", wired to `uiStore.setDatetimeTimezone`, keyboard + a11y-labeled.
+18. **New** `frontend/src/widgets/DatetimeWidget.vue` — mirrors `DateWidget.vue`: display → `formatDatetime(value, effectiveTimezone)`; edit → `<input type="datetime-local">` bound via `utcISOToLocalInput`/`localInputToUtcISO` against `effectiveTimezone`. **Non-destructive**: dirty-track; emit `...Z` only on real user input to *this* field; never on mount; untouched → original string passes through. Beneath it a **read-only** `<span>` "Times shown in {effectiveTimezone}" (not clickable in v1). Reads `effectiveTimezone` from `uiStore`.
+
+**Storage semantics (the crux):** stored value is UTC RFC3339 (`...Z`) once
+authored by the widget. On the backend a bare date decodes to midnight-UTC and
+is stored verbatim (no server-side local-zone guessing — none exists). The
+widget round-trips effective-zone-wall-clock ↔ UTC at the edge and is
+non-destructive for values it didn't author, so switching the display zone
+re-labels existing values without rewriting bytes. **Known cosmetic quirk
+(documented):** a *pre-existing* bare/midnight-UTC value viewed in a western
+zone displays on the previous evening (e.g. `2026-07-13T00:00:00Z` shows
+`2026-07-12 20:00` in `America/New_York`) — inherent to interpreting a real
+instant; the widget never *creates* such values.
+
+**Alternatives considered:**
+- *Reject bare dates* — rejected: unimplementable post-yaml-parse (midnight ≡ bare date as `time.Time`); would also break hand-edited/legacy files. Accept as midnight-UTC instead.
+- *Clickable inline tz control* — rejected for v1: a global setting shown per-field is a mode error; picker in Settings + read-only inline indicator.
+- *Reuse `date` type with a custom `Format`* — rejected: no distinct type for filter/sort/feed to key on.
+- *Full `@vuepic/vue-datepicker`* — rejected: 236KB + 4 deps; take only its `@date-fns/tz` primitive.
+- *`Intl`-only (no lib)* — considered (RR-35VJ8G); user elected to add `@date-fns/tz` upfront. `Intl`-only stays a documented fallback.
+- *Store local wall-clock / store with offset* — rejected: UTC instant is unambiguous.
+- *Separate `ParseDatetimeValue`* — rejected: `ParseDateValue` already parses RFC3339 + preserves time.
+
+**Files to modify:** (backend) types.go, validation.go, schema_output.go,
+openapi/schemas.go, filter/match.go, filter/sort.go, affordances/env.go,
+metamodel/loader.go, dataentryconfig/config.go, dataentry/config.go,
+testutil/fixtures.go; (frontend) types/schema.ts, widgets/types.ts,
+widgets/registry.ts, utils/format.ts, stores/ui.ts, views/SettingsView.vue, **+
+new** widgets/DatetimeWidget.vue; (deps) frontend package.json
+(+`@date-fns/tz`); (docs) docs/metamodel.md, docs/data-entry.md. Plus mirrored
+test files (+ ui.test.ts). **Left untouched (documented):** validate_feeds.go,
+calfeed, internal/migration.
+
+**Dependencies:** one new frontend dep — **`@date-fns/tz`** (relies on `Intl`
+for the tz db; no bundled tzdata). Impl task: `npm audit` clean + note
+footprint. No Go deps.
+
+## Security Considerations
+
+- [x] Input sources identified (user input, config, external APIs)
+- [x] Input validation approach defined (allowlist preferred over blocklist)
+- [x] Security-sensitive operations identified (file access, auth, crypto)
+- [x] Error handling doesn't leak sensitive information
+
+**Input Sources & Validation:**
+- *Datetime property value* (widget/API/hand-edited markdown): validated **allowlist-style** — must be a `time.Time` or an RFC3339-parseable string via `ParseDateValue`. Invalid → validation error via the normal metamodel path (400/422), no silent acceptance.
+- *Filter operand* (query string): parsed the same way; malformed → filter error, not panic.
+- *TZ pref* (Settings picker → localStorage): validated against `Intl.supportedValuesOf('timeZone')`; unrecognized/tampered value falls back to the browser zone (no throw). Client-only; never reaches the server.
+- No file access, auth, or crypto. Error messages reference expected format only.
+
+**Security-Sensitive Operations:** none. Value-type addition + a client display
+preference; no new I/O or server trust boundary.
+
+## Test Plan
+
+- [x] Test scenarios documented for each acceptance criterion
+- [x] Edge cases identified and documented
+- [x] Negative test cases defined (invalid input, error conditions)
+- [x] Integration test approach defined (not just unit tests)
+
+**Test Scenarios (per AC):** see AC list above — each names its test file. Key
+additions from review: AC2 covers `string` + `time.Time` + bare-date + empty;
+AC4 covers mixed date/datetime chronological sort; AC7 covers non-destructive
+mount; AC10 covers the DST/offset matrix.
+
+**Edge Cases:**
+- Empty/missing → unset unless required (early-return in the arm; widget omits key).
+- Bare date `2026-07-13` → **valid**, = midnight-UTC.
+- `time.Time` inbound (unquoted yaml) → valid.
+- Explicit offset `2026-07-13T14:30:00+02:00` → accepted (RFC3339), compared as instant; widget re-emits `...Z` **only if the user edits it**.
+- DST spring-forward (nonexistent wall time) / fall-back (ambiguous) → resolution pinned by `TZDate`, asserted in tests.
+- `Asia/Kolkata` (+05:30) and `Pacific/Auckland` (date line) → offset + date-shift correctness.
+- Pre-existing midnight-UTC value in a western zone → displays prior evening (documented, tested as expected behavior).
+- Stale/invalid localStorage tz → fall back to browser zone.
+
+**Negative Tests:** non-parseable value → validation error; bad filter operand →
+filter error not panic; datetime as `display_property` → loader rejects;
+tampered tz pref → safe fallback.
+
+**Integration approach:** existing metamodel-load + filter + sort suites
+exercise the arms together (add datetime rows). Frontend: FieldRenderer dispatch
+test confirms a `datetime` field renders `DatetimeWidget` end to end,
+**including the relation-property modal path**. Manual E2E: create an entity
+type with a datetime prop (entity + relation), edit via data-entry, confirm
+round-trip; change the Settings tz and confirm existing values re-label (not
+rewrite) and new edits store correct UTC; edit an unrelated field on an entity
+with a `+02:00` datetime and confirm **no diff** on the datetime.
+
+## Risk Assessment
+
+- [x] Technical risks assessed with mitigations
+- [x] Security risks assessed (see Security Considerations)
+- [x] Effort estimated (xs/s/m/l/xl)
+
+**Risks:**
+- *Missed a type-switch arm* → terrain map + design review enumerate all sites (incl. `validate_feeds.go`, fixtures); `IsBuiltinType` + a load test catches "unknown type".
+- *TZ/DST conversion bugs* → `@date-fns/tz` `TZDate` + explicit DST/offset/date-line test matrix (AC10).
+- *Git churn from incidental rewrites* → non-destructive widget (dirty-track); confirm per-property PATCH only sends changed fields.
+- *Bare-date display surprise* → documented; widget never creates such values.
+- *New dependency* → small, `Intl`-backed, `npm audit` gate.
+- *Scope creep into calfeed* → explicitly OUT; `validate_feeds.go` untouched.
+
+**Effort:** **M** — many small mechanical type-switch arms + one new widget
+(tz-aware, non-destructive) + uiStore field + Settings picker + tests (incl.
+DST) + docs + one small dep.
+
+## Documentation Planning
+
+- [x] User-facing docs identified (skip if internal refactor)
+- [x] Docs-checklist will be created when entering implementation
+
+**Documentation Impact:**
+- [x] docs/metamodel.md — new `datetime` builtin (alongside `date`); UTC RFC3339 storage; bare-date = midnight-UTC; `=` is strict-instant.
+- [x] docs/data-entry.md — the datetime widget, the Settings display-timezone picker (client-only, display-only), the bare-date display quirk, and that datetime feed sources are a follow-on.
+- [ ] docs/cli-reference.md — N/A.
+- [ ] CLAUDE.md — N/A.
+- [ ] README.md — N/A.
+
+## Design Review
+
+- [x] Run `/design-review` before starting implementation
+- [x] All critical/significant findings addressed in plan
+
+**Design Review Findings (2026-07-13):** 9 findings — 2 critical, 5 significant,
+2 minor. Two criticals were verified by running the yaml.v3 parser directly. All
+addressed (8) or wont-fix with reason (1); no open critical/significant.
+
+| RR | Sev | Finding | Resolution |
+|----|-----|---------|-----------|
+| RR-NY7PRB | critical | yaml decodes unquoted datetimes to `time.Time`, not `string` | Validation arm accepts `string` **and** `time.Time` |
+| RR-MYC2B6 | critical | Bare-date rejection unimplementable post-parse | **Dropped**; bare date = midnight-UTC; no migration |
+| RR-N1Z9BF | significant | View+save rewrites `+02:00`→`Z` (git churn) | Non-destructive widget; dirty-track; pass-through untouched |
+| RR-5R3QFJ | significant | Mixed date/datetime sort lexical; `=` undefined | Share `typeRankDate`; `=` documented strict-instant |
+| RR-FF45CP | significant | Feed gate rejects datetime | Leave gate date-only; feeds are the follow-on (documented) |
+| RR-3A0RUL | significant | Global tz control shown per-field (mode error) | Picker in Settings; inline = read-only indicator (v1) |
+| RR-35VJ8G | significant | Prefer Intl-only over `@date-fns/tz` | **wont-fix**: user elected the lib; `npm audit` gate; Intl fallback documented |
+| RR-GBL60P | minor | Empty/required + relation-modal path | Early-return on empty; verify relation-modal render |
+| RR-QIIAZB | minor | Fixtures fallthrough; display format; DST tests | `RandomDatetime` required; deterministic `Intl` format; DST test matrix |

--- a/tickets/entities/planning-checklists/PLAN-69NQKG.md
+++ b/tickets/entities/planning-checklists/PLAN-69NQKG.md
@@ -227,9 +227,9 @@ DST) + docs + one small dep.
 **Documentation Impact:**
 - [x] docs/metamodel.md — new `datetime` builtin (alongside `date`); UTC RFC3339 storage; bare-date = midnight-UTC; `=` is strict-instant.
 - [x] docs/data-entry.md — the datetime widget, the Settings display-timezone picker (client-only, display-only), the bare-date display quirk, and that datetime feed sources are a follow-on.
-- [ ] docs/cli-reference.md — N/A.
-- [ ] CLAUDE.md — N/A.
-- [ ] README.md — N/A.
+- [x] ~~docs/cli-reference.md~~ (N/A: no command changes)
+- [x] ~~CLAUDE.md~~ (N/A: no new cross-cutting convention)
+- [x] ~~README.md~~ (N/A: not a project-level change)
 
 ## Design Review
 

--- a/tickets/entities/review-checklists/REV-5DVEIG.md
+++ b/tickets/entities/review-checklists/REV-5DVEIG.md
@@ -9,43 +9,58 @@ status: in-progress
 
 ## Automated Checks
 
-- [ ] All tests pass (`just test`)
-- [ ] Lint clean (`just lint`)
-- [ ] Coverage maintained (`just coverage-check`)
+- [x] All tests pass (`go test ./...` green; frontend `npm run test:run` 1271 pass / 78 files)
+- [x] Lint clean (`just arch-lint` no warnings; `npm run lint` 0 errors — 89 pre-existing warnings in `stress/` + max-lines only)
+- [x] Coverage maintained (`just coverage-check` PASS — total 76.7%, all package floors satisfied)
 
 ## Code Review
 
-- [ ] Run `/code-review` command (invokes cranky-code-reviewer agent)
-- [ ] All critical review-responses addressed
-- [ ] All significant review-responses addressed
-- [ ] Self-reviewed the diff for unrelated changes
+- [x] Run `/code-review` command (invoked cranky-code-reviewer agent)
+- [x] All critical review-responses addressed (none — 0 critical found)
+- [x] All significant review-responses addressed (RR-K3WEW2, RR-P9NKU7 — both fixed + regression tests)
+- [x] Self-reviewed the diff for unrelated changes (only datetime-scoped source + tests + docs; build artifacts gitignored)
 
-**Review Responses:** <!-- List IDs of review-response entities created, e.g.,
-RR-xxxx -->
+**Review Responses:** 7 findings, 0 critical / 2 significant / 3 minor / 2 nit —
+all `addressed`:
+- RR-K3WEW2 (significant) — list/table columns now honor the display-timezone override (threaded `effectiveTimezone` through `formatValue`/`formatCellValue` + `EntityList.vue`).
+- RR-P9NKU7 (significant) — `formatDatetime` parses naive values via `TZDate` so view/edit agree.
+- RR-B1JI4C (minor) — display-mode test asserts zone-correct text; added `formatDatetime` test block.
+- RR-D6W86R (minor) — added DST spring-forward emit test + docstring note on gap/overlap normalization.
+- RR-2Y3ALS (minor) — `formatDatetime` returns null (not throw) on invalid tz.
+- RR-HOLGCD (nit) — documented minute-granular sub-minute drop.
+- RR-1TBFJS (nit) — reworded datetime validation error to "…string or timestamp".
+
+(Design-review round, earlier: 9 findings, 2 critical, all addressed/wont-fix —
+see the ticket's has-review-response links.)
 
 ## Acceptance Verification
 
-- [ ] Each acceptance criterion tested (reference planning checklist)
-- [ ] Test evidence documented in implementation checklist
+- [x] Each acceptance criterion tested (reference planning checklist)
+- [x] Test evidence documented in implementation checklist (IMPL-8GTRJB)
 
-**Acceptance Status:**
-<!-- For each acceptance criterion, state PASS/FAIL with evidence -->
+**Acceptance Status:** all PASS — evidence in IMPL-8GTRJB. Summary:
+- AC1 builtin registration — PASS (`IsBuiltinType` test + CLI load).
+- AC2 validation (string + time.Time + bare date + empty; junk rejected) — PASS (table test + live `analyze properties` on unquoted + bare-date files).
+- AC3 filter `>`/`<` instant + strict-instant `=` — PASS (match_test + live CLI `--where`).
+- AC4 sort chronological incl. mixed date/datetime — PASS (sort_test + live CLI `--sort`).
+- AC5 OpenAPI `date-time` — PASS.
+- AC6 type→widget end-to-end incl. FieldRenderer dispatch — PASS.
+- AC7 widget round-trip + non-destructive — PASS (widgets.test; mount emits nothing).
+- AC8 zone-correct display — PASS (now asserts text, not existence).
+- AC9 tz override persist/fallback + honored in lists AND form — PASS (ui.test + format.test + widget test).
+- AC10 DST/offset/date-line — PASS (Kolkata +05:30, Auckland date-line, spring-forward boundary).
 
 ## Documentation (enhancements only)
 
-Skip this section for bugs and internal refactors.
-
-- [ ] Docs-checklist created and linked via `has-docs`
-- [ ] User-facing documentation updated
-- [ ] Docs-checklist marked as done
-
-**Docs Checklist:** <!-- e.g., DOCS-xxxx -->
+- [x] ~~Docs-checklist created and linked via `has-docs`~~ (N/A: docs updated inline in this ticket — `docs/metamodel.md` Datetime Properties section + `docs/data-entry.md` Datetime fields and time zones section; no separate docs-checklist warranted for a two-file doc update)
+- [x] User-facing documentation updated (metamodel.md + data-entry.md)
+- [x] ~~Docs-checklist marked as done~~ (N/A per above)
 
 ## Final Checks
 
-- [ ] Commit message explains the why, not just what
-- [ ] No TODOs or FIXMEs left unaddressed
-- [ ] Ready for another developer to use
+- [x] Commit message explains the why, not just what (two commits: feature + review-fixes, each with rationale)
+- [x] No TODOs or FIXMEs left unaddressed
+- [x] Ready for another developer to use
 
 ## Pull Request
 
@@ -53,4 +68,4 @@ Skip this section for bugs and internal refactors.
 - [ ] All CI checks pass
 - [ ] PR URL documented below
 
-**PR:** <!-- e.g., https://github.com/org/repo/pull/123 -->
+**PR:** <!-- pending /pr -->

--- a/tickets/entities/review-checklists/REV-5DVEIG.md
+++ b/tickets/entities/review-checklists/REV-5DVEIG.md
@@ -2,7 +2,7 @@
 id: REV-5DVEIG
 type: review-checklist
 title: 'Review: Add a datetime metamodel property type (time-bearing, with date+time form widget)'
-status: in-progress
+status: done
 ---
 
 <!-- @managed: claude-workflow v1 -->
@@ -64,8 +64,8 @@ see the ticket's has-review-response links.)
 
 ## Pull Request
 
-- [ ] Run `/pr` command to create PR and monitor CI
-- [ ] All CI checks pass
-- [ ] PR URL documented below
+- [x] Run `/pr` command to create PR and monitor CI
+- [x] All CI checks pass (E2E toast-locator collision fixed; the only remaining "Rela Tickets" failure is the self-referential gate that clears when this ticket → done)
+- [x] PR URL documented below
 
-**PR:** <!-- pending /pr -->
+**PR:** https://github.com/sourcehaven-bv/rela/pull/1131

--- a/tickets/entities/review-checklists/REV-5DVEIG.md
+++ b/tickets/entities/review-checklists/REV-5DVEIG.md
@@ -1,0 +1,56 @@
+---
+id: REV-5DVEIG
+type: review-checklist
+title: 'Review: Add a datetime metamodel property type (time-bearing, with date+time form widget)'
+status: in-progress
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Automated Checks
+
+- [ ] All tests pass (`just test`)
+- [ ] Lint clean (`just lint`)
+- [ ] Coverage maintained (`just coverage-check`)
+
+## Code Review
+
+- [ ] Run `/code-review` command (invokes cranky-code-reviewer agent)
+- [ ] All critical review-responses addressed
+- [ ] All significant review-responses addressed
+- [ ] Self-reviewed the diff for unrelated changes
+
+**Review Responses:** <!-- List IDs of review-response entities created, e.g.,
+RR-xxxx -->
+
+## Acceptance Verification
+
+- [ ] Each acceptance criterion tested (reference planning checklist)
+- [ ] Test evidence documented in implementation checklist
+
+**Acceptance Status:**
+<!-- For each acceptance criterion, state PASS/FAIL with evidence -->
+
+## Documentation (enhancements only)
+
+Skip this section for bugs and internal refactors.
+
+- [ ] Docs-checklist created and linked via `has-docs`
+- [ ] User-facing documentation updated
+- [ ] Docs-checklist marked as done
+
+**Docs Checklist:** <!-- e.g., DOCS-xxxx -->
+
+## Final Checks
+
+- [ ] Commit message explains the why, not just what
+- [ ] No TODOs or FIXMEs left unaddressed
+- [ ] Ready for another developer to use
+
+## Pull Request
+
+- [ ] Run `/pr` command to create PR and monitor CI
+- [ ] All CI checks pass
+- [ ] PR URL documented below
+
+**PR:** <!-- e.g., https://github.com/org/repo/pull/123 -->

--- a/tickets/entities/review-responses/RR-1TBFJS.md
+++ b/tickets/entities/review-responses/RR-1TBFJS.md
@@ -1,0 +1,9 @@
+---
+id: RR-1TBFJS
+type: review-response
+title: Datetime validation type-error message misleading (accepts time.Time too)
+finding: 'validation.go datetime arm default case returns ''Must be a datetime string'' but the arm also accepts time.Time. For the int-rejected case the message implies only strings are valid. Fix: reword to ''Must be a datetime string or timestamp''.'
+severity: nit
+resolution: Fixed. The datetime validation arm's default-case error message is now 'Must be a datetime string or timestamp' (was 'Must be a datetime string'), reflecting that the arm accepts both string and time.Time.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-2Y3ALS.md
+++ b/tickets/entities/review-responses/RR-2Y3ALS.md
@@ -1,0 +1,9 @@
+---
+id: RR-2Y3ALS
+type: review-response
+title: formatDatetime throws on invalid tz where siblings degrade to null
+finding: 'formatDatetime calls toLocaleString(locale, {timeZone: tz}) which throws RangeError on a bad zone, unlike sibling formatDate which returns null. Unreachable today (tz always from validated effectiveTimezone or browserTimeZone), but it''s an exported util a future caller could pass an unvalidated zone to. Fix: wrap the toLocaleString call in try/catch and return null on failure.'
+severity: minor
+resolution: Fixed. formatDatetime's toLocaleString call is now wrapped in try/catch returning null on RangeError (invalid tz), degrading gracefully like formatDate. Test in format.test.ts asserts null (no throw) for tz 'Not/AZone'.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-35VJ8G.md
+++ b/tickets/entities/review-responses/RR-35VJ8G.md
@@ -1,0 +1,9 @@
+---
+id: RR-35VJ8G
+type: review-response
+title: Prefer Intl-only over @date-fns/tz unless a prototype proves the need
+finding: 'Plan adds @date-fns/tz for arbitrary-zone conversion. But the only two operations needed - render a UTC instant in zone X, and convert a wall-clock-in-zone-X to UTC - are both doable with Intl.DateTimeFormat({timeZone}) + a ~30-line offset helper, no bundled tzdata (Intl uses the OS db), no new dep. Dependency additions are one-way doors here. Recommendation: prototype Intl-only first (it also cleanly handles non-integer offsets like +05:30 that kill naive math); only pull @date-fns/tz if the Intl approach proves insufficient, and if so note transitive footprint + CVE check. Removes the supply-chain/bundle concern entirely if Intl suffices.'
+severity: significant
+reason: 'User elected to add @date-fns/tz upfront rather than prototype Intl-only (''any reason not to just add the tz lib?''). @date-fns/tz relies on Intl for the tz database (no bundled tzdata), is small, and is the primitive VueDatePicker uses. Implementation task added: verify no CVEs (npm audit) and note transitive footprint when adding. Intl-only remains a documented fallback if the lib disappoints.'
+status: wont-fix
+---

--- a/tickets/entities/review-responses/RR-3A0RUL.md
+++ b/tickets/entities/review-responses/RR-3A0RUL.md
@@ -1,0 +1,9 @@
+---
+id: RR-3A0RUL
+type: review-response
+title: 'TZ override: global setting presented as per-field label (mode-error UX)'
+finding: 'The clickable ''Times shown in {tz}'' sits under a field but writes uiStore.datetimeTimezone (global, persisted). A user reads it as this field''s tz, clicks to fix one value, and silently re-labels every datetime field app-wide forever - a mode error, and undiscoverable as a setting later. Fix: (1) label states the global scope explicitly (''Display timezone (all times) - {tz}''); (2) the primary control lives in Settings next to theme (the pattern being copied); the inline affordance is a read-only indicator that deep-links there; (3) zone list uses Intl.supportedValuesOf(''timeZone'') with type-ahead + a ''Browser default'' top entry, NOT a hardcoded list; (4) keyboard + screen-reader accessible (''Display timezone, currently Europe/Amsterdam'').'
+severity: significant
+resolution: 'v1: inline affordance is a READ-ONLY ''Times shown in <effectiveTz>'' indicator (NOT clickable) per user decision. The actual timezone picker lives in Settings (next to theme), using Intl.supportedValuesOf(''timeZone'') with a ''Browser default'' top entry, keyboard + screen-reader accessible. uiStore.datetimeTimezone still holds the global pref; the widget reads effectiveTimezone from it. Clickable inline shortcut deferred to a follow-up. Avoids the mode-error entirely (no inline mutation).'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-5R3QFJ.md
+++ b/tickets/entities/review-responses/RR-5R3QFJ.md
@@ -1,0 +1,9 @@
+---
+id: RR-5R3QFJ
+type: review-response
+title: Mixed date/datetime sort degrades to lexical; datetime = date-operand semantics undefined
+finding: 'sort.go comparePropValues only compares by value when both props share a type string. date and datetime differ, so a mixed-column sort falls to typeRank then compareStrings (lexical, not chronological). Fix: datetime shares typeRankDate (so date+datetime interleave chronologically) AND the cross-type path must run toTime on both. Separately, matchDate uses .Equal (instant-equal to the second): a filter `due=2026-07-13` vs a stored `2026-07-13T12:30:00Z` parses operand as midnight and never matches. Decide + document: is datetime `=` strict-instant or day-granular? Recommend documenting strict-instant and steering users to `>=`/`<` for ranges, or add day-granular `=` for datetime.'
+severity: significant
+resolution: 'Accepted into plan. (1) datetime shares typeRankDate (NOT a separate rank) so date+datetime interleave chronologically in mixed sorts; verify the cross-type compare path in comparePropValues runs toTime on both when one side is date and the other datetime (may need to treat date/datetime as same-type for the equality gate). (2) Document datetime `=` as STRICT-INSTANT (second-granular): `due=2026-07-13` (midnight) will not match `2026-07-13T12:30:00Z`; steer users to `>=`/`<` ranges for day queries. Add match_test + sort_test cases covering mixed date/datetime and strict-instant equality.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-B1JI4C.md
+++ b/tickets/entities/review-responses/RR-B1JI4C.md
@@ -1,0 +1,9 @@
+---
+id: RR-B1JI4C
+type: review-response
+title: Display-mode widget test asserts existence, not zone-correct output
+finding: 'widgets.test.ts display-mode test sets the zone after mount and only asserts span.display-value exists and input absent; it never checks the rendered text is zone-correct, so the formatDatetime display path is untested for correctness. Fix: mount with a known non-UTC zone (e.g. America/New_York) and assert the formatted text contains the expected local time.'
+severity: minor
+resolution: Fixed. The display-mode widget test now sets zone America/New_York BEFORE mount and asserts the rendered text contains '8:30' (zone-correct), not just element existence. Added a dedicated formatDatetime describe block in format.test.ts with zone-correctness, naive-consistency, null-on-unparseable, and null-on-bad-tz cases.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-D6W86R.md
+++ b/tickets/entities/review-responses/RR-D6W86R.md
@@ -1,0 +1,9 @@
+---
+id: RR-D6W86R
+type: review-response
+title: No real DST-transition instant is tested
+finding: 'The ''DST is handled'' claim in localInputToUtcISO''s docstring is never exercised by a spring-forward/fall-back instant; the emit test uses a plain July date (fixed offset). TZDate normalizes a nonexistent gap local time (spring-forward 02:30->03:30) and picks first occurrence on fall-back, which is reasonable but asymmetric on round-trip. Fix: add a test pinning a DST-transition instant, and note in the docstring that gap/overlap local times are normalized (not a true round-trip).'
+severity: minor
+resolution: 'Fixed. Added a widget test pinning a US spring-forward instant: mount America/New_York, set 2026-03-08T03:30 (just past the 02:00 gap, UTC-4), assert emit = 2026-03-08T07:30:00Z. Also expanded the localInputToUtcISO docstring to note that gap/overlap local times are NORMALIZED by TZDate (not a true round-trip), reachable only via hand-typed boundary times.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-FF45CP.md
+++ b/tickets/entities/review-responses/RR-FF45CP.md
@@ -1,0 +1,9 @@
+---
+id: RR-FF45CP
+type: review-response
+title: 'Calendar feed: validate_feeds.go rejects datetime; calfeed emits all-day only'
+finding: 'validate_feeds.go:89,127 hard-reject a feed date/end_date source unless Type == PropertyTypeDate (verified), so a datetime prop cannot back a feed today. And calfeed emits VALUE=DATE all-day only. The plan declared timed feeds OUT of scope (that is TKT-RDM9M5/FEAT-OT4361), which is defensible, BUT the plan must at least DECIDE: (a) leave the gate as-is (datetime not feed-eligible yet) - acceptable and consistent with ''metamodel primitive only'' scope; or (b) allow datetime in the gate now but keep all-day rendering (confusing - drops the time). Recommendation: keep (a), leave validate_feeds.go untouched, and note in docs that datetime feed sources are the follow-on ticket. Just make it an explicit, documented decision, not silence.'
+severity: significant
+resolution: 'Explicit decision: option (a) - datetime is NOT feed-eligible in this ticket. Leave validate_feeds.go:89,127 untouched (feed sources stay date-only). This ticket is the metamodel primitive only; timed feed sources + timed DTSTART are the follow-on (TKT-RDM9M5/FEAT-OT4361). Document in docs/data-entry.md that datetime feed sources are not yet supported and point to the follow-on ticket. No silent gap - documented boundary.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-GBL60P.md
+++ b/tickets/entities/review-responses/RR-GBL60P.md
@@ -1,0 +1,9 @@
+---
+id: RR-GBL60P
+type: review-response
+title: Empty/required datetime handling + relation-property render path unspecified
+finding: 'Two gaps: (1) Empty datetime: <input datetime-local> yields '''' when cleared; the validation arm must early-return OK on ''''/absent unless required, and the widget should omit the key rather than emit '''' (mirror how the date arm handles empties - verify it does). (2) PropertyDef is shared by entity and relation schemas; datetime must render in the data-entry relation-property modal (a separate render path from the entity form), and filter/sort/affordances run on relations too. Add explicit verification that DatetimeWidget is reachable from the relation modal.'
+severity: minor
+resolution: 'Accepted into plan. (1) Empty datetime: validation arm early-returns OK on ''''/absent unless required (mirror date arm - verify it does); widget omits the key rather than emitting '''' when cleared. (2) Add explicit test/verification that DatetimeWidget renders in the data-entry relation-property modal (separate render path from entity form) since PropertyDef is shared by entity+relation schemas.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-HOLGCD.md
+++ b/tickets/entities/review-responses/RR-HOLGCD.md
@@ -1,0 +1,9 @@
+---
+id: RR-HOLGCD
+type: review-response
+title: Sub-minute precision dropped when editing (datetime-local is minute-granular)
+finding: 'datetime-local input is minute-granular: a stored 12:30:45Z displays as 12:30 and re-emits 12:30:00Z when edited, dropping seconds. Non-destructive design protects untouched values, so only bites when a user edits a sub-minute-precision field. Inherent HTML-input limitation, not a bug. The optional :ss group in localInputToUtcISO''s regex is effectively dead for the widget. Fix: one-line doc note; no code change required.'
+severity: nit
+resolution: Documented. Added a note to the localInputToUtcISO docstring that the input is minute-granular so sub-minute precision on a pre-existing value is dropped when that field is edited (the optional :ss regex group is dead for the widget). No code change needed - inherent to <input type=datetime-local>, and the non-destructive design protects untouched values.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-K3WEW2.md
+++ b/tickets/entities/review-responses/RR-K3WEW2.md
@@ -1,0 +1,9 @@
+---
+id: RR-K3WEW2
+type: review-response
+title: Display-timezone override ignored in list/table columns
+finding: 'format.ts formatValue/formatCellValue hardcode browserTimeZone() for the datetime branch; EntityList.vue calls formatCellValue with no tz, so list/table datetime cells always render in the browser zone, ignoring the user''s Settings display-timezone override. The DatetimeWidget uses uiStore.effectiveTimezone, so the FORM honors the override but LISTS do not. This contradicts the shipped copy (SettingsView ''applies to all times'', docs ''applies to every datetime field''). Fix: thread effectiveTimezone into the list path (add a tz param to formatValue/formatCellValue defaulting to browserTimeZone, pass uiStore.effectiveTimezone from EntityList), so the override is honored everywhere.'
+severity: significant
+resolution: 'Fixed. formatValue and formatCellValue now take an optional tz param (default browserTimeZone()); EntityList.vue passes uiStore.effectiveTimezone so list/table datetime cells honor the Settings display-timezone override, matching the form widget. Regression test added in format.test.ts (formatCellValue with America/New_York asserts 8:30 for a 12:30Z value). Verified: entity detail already uses the widget''s display mode (already zone-aware), so lists were the only gap.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-MYC2B6.md
+++ b/tickets/entities/review-responses/RR-MYC2B6.md
@@ -1,0 +1,9 @@
+---
+id: RR-MYC2B6
+type: review-response
+title: Bare-date rejection for datetime is unimplementable post-yaml-parse
+finding: 'Plan rejects a bare date (2026-07-13) on a datetime prop. But ParseDateValue returns time.Time, and 2026-07-13T00:00:00Z (typed midnight) and 2026-07-13 (no time) both yield identical midnight time.Time (verified). Post-parse you cannot distinguish them; and yaml has already collapsed the lexical form to time.Time before validation runs, so the raw string isn''t even available on the file-load path. The rule can only be enforced on the raw JSON request string at the data-entry API boundary, giving inconsistent enforcement (API strict, file-load lax). Recommendation: DROP bare-date rejection; treat a bare date as midnight-UTC (lossless date->datetime widening, matches every other date system). This also removes the need for a date->datetime migration (finding 8).'
+severity: critical
+resolution: 'DROP bare-date rejection. Backend: a bare date on a datetime prop parses to midnight UTC (2026-07-13 -> 2026-07-13T00:00:00Z), stored verbatim, NO server-side local-tz guessing (backend is deliberately UTC; no such setting exists). Frontend date-shift concern confirmed real (2026-07-13T00:00:00Z displays as 2026-07-12 20:00 in America/New_York). Resolution: the WIDGET never emits a bare/midnight-only value - a user always picks a real time, so any shift is a meaningful true-instant shift. Bare/midnight values exist only via hand-edit/legacy; we accept them verbatim and DOCUMENT that pre-existing bare dates display at midnight-UTC (prior evening in western zones) rather than heuristically un-shifting them (can''t distinguish typed-midnight from bare-date). Lossless date->datetime widening; no migration needed.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-N1Z9BF.md
+++ b/tickets/entities/review-responses/RR-N1Z9BF.md
@@ -1,0 +1,9 @@
+---
+id: RR-N1Z9BF
+type: review-response
+title: Widget must be non-destructive for datetime values it did not author (git churn)
+finding: 'Widget always emits `...Z`. If a file stores `due: 2026-07-13T12:30:00+02:00`, opening the entity and saving an UNRELATED field round-trips the datetime through zone->UTC and rewrites it to `...Z` (same instant, different bytes) => spurious git diff on an untouched field. Fix: dirty-track per field; emit a new value ONLY when the user interacts with THIS field; pass the original stored string through verbatim otherwise. Confirm the data-entry PATCH path sends only changed fields (per-property auto-save from TKT-E6094 suggests it does). Canonicalization to Z, if wanted, must be an explicit migration, not an incidental side effect of viewing.'
+severity: significant
+resolution: 'Accepted into plan. Widget is non-destructive: (a) dirty-track per field, emit only on user interaction with THIS field, never on mount; (b) untouched fields pass their original stored string through verbatim. Data-entry uses per-property auto-save (TKT-E6094) which PATCHes only the changed field, so an untouched datetime is never re-sent - confirm in impl. No incidental Z-canonicalization. Widget always emits ...Z only for values the user actually edits.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-NY7PRB.md
+++ b/tickets/entities/review-responses/RR-NY7PRB.md
@@ -1,0 +1,9 @@
+---
+id: RR-NY7PRB
+type: review-response
+title: Validation arm must accept time.Time, not just string (yaml auto-decodes datetimes)
+finding: 'yaml.v3 auto-decodes an unquoted RFC3339 scalar in frontmatter to Go time.Time, not string (verified: `due: 2026-07-13T12:30:00Z` -> time.Time; only survives as string if quoted). markdown/parser.go:85 returns the raw map with time.Time intact (no normalization). A datetime validation arm shaped like the date arm (validation.go:235, `s, ok := val.(string)`) will reject hand-edited unquoted datetimes with ''Must be a datetime string''. The existing date type shares this latent bug but rarely bites. Fix: the datetime arm must accept BOTH string (parse via ParseDateValue) and time.Time (already an instant), normalizing to a canonical UTC RFC3339 instant. Note format:date-time in openapi is cosmetic; the yaml parser decides the Go type.'
+severity: critical
+resolution: 'Confirmed by running yaml.v3: unquoted RFC3339 and bare dates both decode to time.Time; markdown/parser.go:85 returns them un-normalized. Datetime validation arm will accept a type-switch: case string -> parse via ParseDateValue; case time.Time -> already a valid instant, accept. Empty/absent -> OK unless required. Mirrors the requirement, fixes the hand-edit-rejection bug the date arm latently has.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-P9NKU7.md
+++ b/tickets/entities/review-responses/RR-P9NKU7.md
@@ -1,0 +1,9 @@
+---
+id: RR-P9NKU7
+type: review-response
+title: Display vs edit disagree on naive (offset-less) stored datetimes
+finding: 'formatDatetime parses with native new Date(value) (interprets a naive ''YYYY-MM-DDTHH:MM:SS'' string in the browser/runtime zone), while utcISOToLocalInput parses with new TZDate(iso, tz) (interprets it in the effective display zone). For a naive stored value (no Z/offset) reachable via ParseDateValue''s fallback list, display and edit-input then show different instants. The widget always emits ...Z so it only bites pre-existing/hand-authored naive data, but view and edit silently disagree. Fix: make formatDatetime parse via TZDate too so both share one interpretation; treat naive values consistently (assumed = effective zone).'
+severity: significant
+resolution: 'Fixed. formatDatetime now parses a naive (no Z/offset) value via TZDate (same construction path as utcISOToLocalInput) instead of native new Date(), so display and edit resolve a naive value to the SAME wall-clock. Confirmed empirically: both now agree (previously formatDatetime read naive as browser-local while the input read it via TZDate). A zoned/absolute value is unaffected. Test in format.test.ts asserts view/edit agreement for a naive value (the agreement is the contract, not a specific value).'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-QIIAZB.md
+++ b/tickets/entities/review-responses/RR-QIIAZB.md
@@ -1,0 +1,9 @@
+---
+id: RR-QIIAZB
+type: review-response
+title: Fixtures fallthrough, display format, and DST/offset conversion tests
+finding: '(1) testutil/fixtures.go: unknown types fall through to RandomString(), so without a datetime arm, conformance/fuzz tests would feed invalid datetimes and mask bugs - the RandomDatetime arm is required, not optional. (2) Display format for formatDatetime must be pinned deterministically: recommend Intl.DateTimeFormat({dateStyle:''medium'', timeStyle:''short'', timeZone: effectiveTz}) with the zone appended so it''s unambiguous. (3) Conversion helpers need explicit tests for DST spring-forward (nonexistent wall time), fall-back (ambiguous), a non-integer-offset zone (Asia/Kolkata +05:30), the date line (Pacific/Auckland), and Z-in/offset-out round-trip. Hard-to-write tests here are a signal Intl-only (RR-35VJ8G) is safer.'
+severity: minor
+resolution: 'Accepted into plan. (1) RandomDatetime() arm in fixtures.go is required (unknown types fall through to RandomString and would feed invalid values). (2) Display format pinned: Intl.DateTimeFormat({dateStyle:''medium'', timeStyle:''short'', timeZone: effectiveTz}) with the zone appended. (3) Conversion helper tests required for: DST spring-forward, fall-back, Asia/Kolkata +05:30, Pacific/Auckland date-line, and Z-in/offset-out round-trip. These become AC test scenarios.'
+status: addressed
+---

--- a/tickets/entities/tickets/TKT-ZYOBSN.md
+++ b/tickets/entities/tickets/TKT-ZYOBSN.md
@@ -5,7 +5,7 @@ title: Add a datetime metamodel property type (time-bearing, with date+time form
 kind: enhancement
 priority: medium
 effort: m
-status: in-progress
+status: review
 ---
 
 ## Description

--- a/tickets/entities/tickets/TKT-ZYOBSN.md
+++ b/tickets/entities/tickets/TKT-ZYOBSN.md
@@ -5,7 +5,7 @@ title: Add a datetime metamodel property type (time-bearing, with date+time form
 kind: enhancement
 priority: medium
 effort: m
-status: review
+status: done
 ---
 
 ## Description

--- a/tickets/entities/tickets/TKT-ZYOBSN.md
+++ b/tickets/entities/tickets/TKT-ZYOBSN.md
@@ -3,8 +3,9 @@ id: TKT-ZYOBSN
 type: ticket
 title: Add a datetime metamodel property type (time-bearing, with date+time form widget)
 kind: enhancement
-priority: low
-status: backlog
+priority: medium
+effort: m
+status: in-progress
 ---
 
 ## Description

--- a/tickets/relations/TKT-ZYOBSN--has-implementation--IMPL-8GTRJB.md
+++ b/tickets/relations/TKT-ZYOBSN--has-implementation--IMPL-8GTRJB.md
@@ -1,0 +1,5 @@
+---
+from: TKT-ZYOBSN
+relation: has-implementation
+to: IMPL-8GTRJB
+---

--- a/tickets/relations/TKT-ZYOBSN--has-planning--PLAN-69NQKG.md
+++ b/tickets/relations/TKT-ZYOBSN--has-planning--PLAN-69NQKG.md
@@ -1,0 +1,5 @@
+---
+from: TKT-ZYOBSN
+relation: has-planning
+to: PLAN-69NQKG
+---

--- a/tickets/relations/TKT-ZYOBSN--has-review--REV-5DVEIG.md
+++ b/tickets/relations/TKT-ZYOBSN--has-review--REV-5DVEIG.md
@@ -1,0 +1,5 @@
+---
+from: TKT-ZYOBSN
+relation: has-review
+to: REV-5DVEIG
+---

--- a/tickets/relations/TKT-ZYOBSN--has-review-response--RR-1TBFJS.md
+++ b/tickets/relations/TKT-ZYOBSN--has-review-response--RR-1TBFJS.md
@@ -1,0 +1,5 @@
+---
+from: TKT-ZYOBSN
+relation: has-review-response
+to: RR-1TBFJS
+---

--- a/tickets/relations/TKT-ZYOBSN--has-review-response--RR-2Y3ALS.md
+++ b/tickets/relations/TKT-ZYOBSN--has-review-response--RR-2Y3ALS.md
@@ -1,0 +1,5 @@
+---
+from: TKT-ZYOBSN
+relation: has-review-response
+to: RR-2Y3ALS
+---

--- a/tickets/relations/TKT-ZYOBSN--has-review-response--RR-35VJ8G.md
+++ b/tickets/relations/TKT-ZYOBSN--has-review-response--RR-35VJ8G.md
@@ -1,0 +1,5 @@
+---
+from: TKT-ZYOBSN
+relation: has-review-response
+to: RR-35VJ8G
+---

--- a/tickets/relations/TKT-ZYOBSN--has-review-response--RR-3A0RUL.md
+++ b/tickets/relations/TKT-ZYOBSN--has-review-response--RR-3A0RUL.md
@@ -1,0 +1,5 @@
+---
+from: TKT-ZYOBSN
+relation: has-review-response
+to: RR-3A0RUL
+---

--- a/tickets/relations/TKT-ZYOBSN--has-review-response--RR-5R3QFJ.md
+++ b/tickets/relations/TKT-ZYOBSN--has-review-response--RR-5R3QFJ.md
@@ -1,0 +1,5 @@
+---
+from: TKT-ZYOBSN
+relation: has-review-response
+to: RR-5R3QFJ
+---

--- a/tickets/relations/TKT-ZYOBSN--has-review-response--RR-B1JI4C.md
+++ b/tickets/relations/TKT-ZYOBSN--has-review-response--RR-B1JI4C.md
@@ -1,0 +1,5 @@
+---
+from: TKT-ZYOBSN
+relation: has-review-response
+to: RR-B1JI4C
+---

--- a/tickets/relations/TKT-ZYOBSN--has-review-response--RR-D6W86R.md
+++ b/tickets/relations/TKT-ZYOBSN--has-review-response--RR-D6W86R.md
@@ -1,0 +1,5 @@
+---
+from: TKT-ZYOBSN
+relation: has-review-response
+to: RR-D6W86R
+---

--- a/tickets/relations/TKT-ZYOBSN--has-review-response--RR-FF45CP.md
+++ b/tickets/relations/TKT-ZYOBSN--has-review-response--RR-FF45CP.md
@@ -1,0 +1,5 @@
+---
+from: TKT-ZYOBSN
+relation: has-review-response
+to: RR-FF45CP
+---

--- a/tickets/relations/TKT-ZYOBSN--has-review-response--RR-GBL60P.md
+++ b/tickets/relations/TKT-ZYOBSN--has-review-response--RR-GBL60P.md
@@ -1,0 +1,5 @@
+---
+from: TKT-ZYOBSN
+relation: has-review-response
+to: RR-GBL60P
+---

--- a/tickets/relations/TKT-ZYOBSN--has-review-response--RR-HOLGCD.md
+++ b/tickets/relations/TKT-ZYOBSN--has-review-response--RR-HOLGCD.md
@@ -1,0 +1,5 @@
+---
+from: TKT-ZYOBSN
+relation: has-review-response
+to: RR-HOLGCD
+---

--- a/tickets/relations/TKT-ZYOBSN--has-review-response--RR-K3WEW2.md
+++ b/tickets/relations/TKT-ZYOBSN--has-review-response--RR-K3WEW2.md
@@ -1,0 +1,5 @@
+---
+from: TKT-ZYOBSN
+relation: has-review-response
+to: RR-K3WEW2
+---

--- a/tickets/relations/TKT-ZYOBSN--has-review-response--RR-MYC2B6.md
+++ b/tickets/relations/TKT-ZYOBSN--has-review-response--RR-MYC2B6.md
@@ -1,0 +1,5 @@
+---
+from: TKT-ZYOBSN
+relation: has-review-response
+to: RR-MYC2B6
+---

--- a/tickets/relations/TKT-ZYOBSN--has-review-response--RR-N1Z9BF.md
+++ b/tickets/relations/TKT-ZYOBSN--has-review-response--RR-N1Z9BF.md
@@ -1,0 +1,5 @@
+---
+from: TKT-ZYOBSN
+relation: has-review-response
+to: RR-N1Z9BF
+---

--- a/tickets/relations/TKT-ZYOBSN--has-review-response--RR-NY7PRB.md
+++ b/tickets/relations/TKT-ZYOBSN--has-review-response--RR-NY7PRB.md
@@ -1,0 +1,5 @@
+---
+from: TKT-ZYOBSN
+relation: has-review-response
+to: RR-NY7PRB
+---

--- a/tickets/relations/TKT-ZYOBSN--has-review-response--RR-P9NKU7.md
+++ b/tickets/relations/TKT-ZYOBSN--has-review-response--RR-P9NKU7.md
@@ -1,0 +1,5 @@
+---
+from: TKT-ZYOBSN
+relation: has-review-response
+to: RR-P9NKU7
+---

--- a/tickets/relations/TKT-ZYOBSN--has-review-response--RR-QIIAZB.md
+++ b/tickets/relations/TKT-ZYOBSN--has-review-response--RR-QIIAZB.md
@@ -1,0 +1,5 @@
+---
+from: TKT-ZYOBSN
+relation: has-review-response
+to: RR-QIIAZB
+---


### PR DESCRIPTION
## Summary

Adds a first-class **`datetime`** metamodel property type (a time-bearing instant, distinct from the date-only `date` type) plus a data-entry date+time widget with configurable timezone display. Delivers TKT-ZYOBSN / FEAT-27UZ51.

## What's included

**Backend (Go)** — `datetime` slotted into every property-type switch:
- Builtin registration (`types.go`), validation accepting **both `string` and `time.Time`** (yaml auto-decodes unquoted timestamps), `ResolveWidgetFromType`, OpenAPI `format: date-time`, filter (`matchDate`) + operator gate, sort (shares `date`'s rank so mixed date/datetime columns sort chronologically), affordances, `display_property` rejection, widget constants, test fixtures.
- Bonus: `matchDate` now accepts `time.Time`, fixing a latent bug where a yaml-decoded **`date`** value would error on filter.

**Frontend (Vue/TS)** — new `DatetimeWidget.vue`:
- Native `<input type="datetime-local">`, converts local wall-clock ↔ **UTC RFC3339** via `@date-fns/tz` (one small dep; relies on `Intl`, 0 vulns).
- **Non-destructive**: emits only on real user input, never on mount — so viewing/editing an unrelated field never rewrites a datetime (no spurious git diffs).
- Read-only "Times shown in <tz>" indicator; the actual **display-timezone picker lives in Settings** (client-only, display-only, persisted in `localStorage`). Lists **and** forms honor the override.

## Key design decisions (from design + code review)

- **Stored as UTC RFC3339.** Bare dates accepted as midnight-UTC (rejecting them is unimplementable post-yaml-parse). No migration needed.
- **`=` is strict-instant** (second-granular); use `>=`/`<` for day ranges.
- **Calendar-feed integration is out of scope** — feeds stay date-only/all-day; timed feeds are the follow-on (TKT-RDM9M5 / FEAT-OT4361). Documented, not silent.

## Testing

- Go: full suite + arch-lint + coverage (76.7%, floors pass). New metamodel/filter/dataentry/testutil tests.
- Frontend: 1271 tests (incl. DST spring-forward, `Asia/Kolkata` +05:30, `Pacific/Auckland` date-line, non-destructive mount, zone-correct display, list-column tz override).
- Manual E2E against a running `rela-server`: create/store/filter/sort, unquoted + bare-date hand-edits validate, strict-instant `=`.
- `just ci` green locally.

## Review trail

Design review: 9 findings (2 critical, verified by running the yaml parser) — all addressed/wont-fix.
Code review: 7 findings (2 significant) — all addressed. See linked `review-response` entities on TKT-ZYOBSN.
