### PR TITLE
refactor(dataentry): extract sync route cluster into syncHandler

### DIFF
--- a/internal/dataentry/app.go
+++ b/internal/dataentry/app.go
@@ -70,13 +70,14 @@ const userPaletteFile = "palette.yaml"
 // readers — readers go through a.State(). The workspace's internal
 // reloadMu coordinates the reload itself with the mutation path.
 //
-// TODO(TKT-N26KLB): App is a god-object. Decompose toward the
+// TODO(TKT-R68TV8): App is a god-object. Decompose toward the
 // 40-method load line — extract the API/serialization/relation services into
 // their own types. Ratchet this number DOWN as methods move out; never up
 // EXCEPT for a new required route handler (App owns one method per registered
-// HTTP route by the router's design) — this branch adds handleV1Feed (TKT-RDM9M5).
+// HTTP route by the router's design). The sync route cluster (16 methods) moved
+// to syncHandler, ratcheting 170 → 154.
 //
-//plimsoll:max-methods=170
+//plimsoll:max-methods=154
 type App struct {
 	// Primitives — immutable after NewApp.
 	fs    storage.FS
@@ -133,7 +134,12 @@ type App struct {
 	palette *paletteService
 	// settings owns the per-user default values (create-form/relation defaults).
 	// Self-synchronized; extracted from the schema snapshot.
-	settings  *settingsService
+	settings *settingsService
+	// sync owns the /api/sync/ route cluster (fs-client ↔ pg-server
+	// replication). Extracted from App (TKT-R68TV8); holds narrow store/deleter
+	// surfaces plus a pointer to writeMu so its writes serialize with the other
+	// mutation handlers.
+	sync      *syncHandler
 	templater templating.Templater
 	cfgLoader config.Loader
 	kv        state.KV
@@ -503,6 +509,14 @@ func NewApp(
 		return nil, fmt.Errorf("load user logo: %w", logoErr)
 	}
 	app.logo = logo
+
+	// syncHandler owns the /api/sync/ route cluster (fs-client ↔ pg-server
+	// replication). It shares App's store (reads), entityManager (deletes), and
+	// — crucially — a POINTER to App's writeMu so sync pushes/deletes serialize
+	// against every other data-entry mutation. The manifest/applier capabilities
+	// are resolved once from the concrete store/manager (nil on fs/memory builds,
+	// where the sync endpoints degrade to 501).
+	app.sync = newSyncHandler(st, app.entityManager, &app.writeMu)
 
 	// Build and publish the initial Schema snapshot. All reloadable
 	// state lives here; there are no convenience aliases on App to keep

--- a/internal/dataentry/router.go
+++ b/internal/dataentry/router.go
@@ -85,7 +85,7 @@ func (a *App) NewRouter() http.Handler {
 	a.registerAPIV1Routes(inner)
 
 	// Sync API (FEAT-NJ9FEN) - machine-to-machine fs↔pg sync, under /api/sync/.
-	a.registerSyncRoutes(inner)
+	a.sync.registerSyncRoutes(inner)
 
 	// Inbound-IdP webhook (POST /webhooks/idp) — mounted only when a receiver is
 	// configured (SetWebhookReceiver). It lives OUTSIDE /api/ because it

--- a/internal/dataentry/sync.go
+++ b/internal/dataentry/sync.go
@@ -27,27 +27,6 @@ type syncApplier interface {
 	ApplyRelation(ctx context.Context, r *entity.Relation) (*entity.Relation, error)
 }
 
-// syncManifest returns the manifest provider when the store supports it
-// (pgstore), else nil. Derived lazily from a.store rather than cached at
-// construction, so it stays correct if the store is re-pointed (e.g. test
-// rebind). Sync is fs-client ↔ pg-server, so this is nil on fs/memory builds.
-func (a *App) syncManifest() manifestProvider {
-	if mp, ok := a.store.(manifestProvider); ok {
-		return mp
-	}
-	return nil
-}
-
-// syncApplierFor returns the id-preserving applier when the entity manager
-// supports it (*entitymanager.Manager), else nil. Derived lazily for the same
-// reason as syncManifest.
-func (a *App) syncApplierFor() syncApplier {
-	if ap, ok := a.entityManager.(syncApplier); ok {
-		return ap
-	}
-	return nil
-}
-
 // --- Wire DTOs ---
 
 type syncManifestResponse struct {
@@ -79,16 +58,6 @@ type syncRelationBody struct {
 	Content    string         `json:"content,omitempty"`
 }
 
-// registerSyncRoutes mounts the sync API under /api/sync/. See sync.go's
-// handlers for the per-route contract. The routes inherit the data-entry
-// security middleware EXCEPT the same-origin check, from which /api/sync/ is
-// exempted (a non-browser sync client sends no Origin) — see
-// middleware_security.go.
-func (a *App) registerSyncRoutes(mux *http.ServeMux) {
-	mux.HandleFunc("/api/sync/manifest", a.handleSyncManifest)
-	mux.HandleFunc("/api/sync/", a.handleSyncRecord)
-}
-
 // handleSyncManifest: GET /api/sync/manifest?cursor=<token>. Returns the changes
 // since the cursor and a new cursor (the highest seq seen). The cursor is a
 // server-minted token the client stores and echoes back; today it is the seq
@@ -96,12 +65,12 @@ func (a *App) registerSyncRoutes(mux *http.ServeMux) {
 // and not derive meaning from it — the encoding may change). A missing or
 // malformed cursor is treated as 0 (full manifest), which is the safe degrade:
 // the client re-bootstraps rather than silently skipping changes.
-func (a *App) handleSyncManifest(w http.ResponseWriter, r *http.Request) {
+func (h *syncHandler) handleSyncManifest(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
 		writeV1Error(w, r, http.StatusMethodNotAllowed, "method_not_allowed", "Use GET", "")
 		return
 	}
-	mp := a.syncManifest()
+	mp := h.manifest
 	if mp == nil {
 		writeV1Error(w, r, http.StatusNotImplemented, "sync_unsupported",
 			"The sync manifest is only available on the postgres backend", "")
@@ -122,7 +91,7 @@ func (a *App) handleSyncManifest(w http.ResponseWriter, r *http.Request) {
 	// it has no right to read. Denied rows are dropped from Changes; the cursor
 	// still advances past them (so the client doesn't re-fetch the same hidden
 	// rows forever) — the highest seq is taken over ALL entries, visible or not.
-	visible, err := a.filterVisibleManifest(r.Context(), entries)
+	visible, err := h.filterVisibleManifest(r.Context(), entries)
 	if err != nil {
 		writeGateError(w, r, err)
 		return
@@ -159,7 +128,7 @@ func (a *App) handleSyncManifest(w http.ResponseWriter, r *http.Request) {
 //
 // Probes are batched per type via PermitsReadMany so the whole manifest costs
 // one MatchingIDs roundtrip per distinct type, not one per row.
-func (a *App) filterVisibleManifest(
+func (h *syncHandler) filterVisibleManifest(
 	ctx context.Context, entries []synctypes.ManifestEntry,
 ) ([]synctypes.ManifestEntry, error) {
 	gate := readGateFromContext(ctx)
@@ -173,7 +142,7 @@ func (a *App) filterVisibleManifest(
 		id := e.IDA
 		if e.Kind == "r" {
 			// A relation gates on its source entity (IDA = From).
-			if src, err := a.store.GetEntity(ctx, e.IDA); err == nil {
+			if src, err := h.store.GetEntity(ctx, e.IDA); err == nil {
 				typ = src.Type
 			} else {
 				typ = ""
@@ -210,7 +179,7 @@ func (a *App) filterVisibleManifest(
 //
 // kind is "entities" or "relations". For an entity the id is the path tail; for
 // a relation the tail is "<from>/<relType>/<to>".
-func (a *App) handleSyncRecord(w http.ResponseWriter, r *http.Request) {
+func (h *syncHandler) handleSyncRecord(w http.ResponseWriter, r *http.Request) {
 	kind, rest, ok := splitSyncPath(r.URL.Path)
 	if !ok {
 		writeV1Error(w, r, http.StatusNotFound, "not_found", "Unknown sync resource", "")
@@ -218,11 +187,11 @@ func (a *App) handleSyncRecord(w http.ResponseWriter, r *http.Request) {
 	}
 	switch r.Method {
 	case http.MethodGet:
-		a.handleSyncGet(w, r, kind, rest)
+		h.handleSyncGet(w, r, kind, rest)
 	case http.MethodPut:
-		a.handleSyncPut(w, r, kind, rest)
+		h.handleSyncPut(w, r, kind, rest)
 	case http.MethodDelete:
-		a.handleSyncDelete(w, r, kind, rest)
+		h.handleSyncDelete(w, r, kind, rest)
 	default:
 		writeV1Error(w, r, http.StatusMethodNotAllowed, "method_not_allowed", "Use GET, PUT, or DELETE", "")
 	}

--- a/internal/dataentry/sync_conflict_test.go
+++ b/internal/dataentry/sync_conflict_test.go
@@ -86,7 +86,7 @@ func TestSyncPut_UpdateVanishedReturns412(t *testing.T) {
 
 	// If-Match matches the current hash → precondition passes and ApplyEntity
 	// resolves UPDATE intent. The conflict only surfaces on UpdateEntity.
-	cur, exists := app.currentEntityHash(context.Background(), "NOTE-1")
+	cur, exists := app.sync.currentEntityHash(context.Background(), "NOTE-1")
 	if !exists {
 		t.Fatal("seed missing: store should report NOTE-1 present")
 	}

--- a/internal/dataentry/sync_handler.go
+++ b/internal/dataentry/sync_handler.go
@@ -1,0 +1,80 @@
+package dataentry
+
+import (
+	"context"
+	"net/http"
+	"sync"
+
+	"github.com/Sourcehaven-BV/rela/internal/entity"
+)
+
+// --- Consumer-side interfaces (declared at the call site per CLAUDE.md) ---
+
+// syncStore is the read surface the sync handlers need from the store: single
+// entity/relation gets. The manifest/applier capabilities are resolved by
+// type-asserting the concrete store/manager in newSyncHandler rather than being
+// listed here, since only pgstore / *entitymanager.Manager satisfy them.
+type syncStore interface {
+	GetEntity(ctx context.Context, id string) (*entity.Entity, error)
+	GetRelation(ctx context.Context, from, relType, to string) (*entity.Relation, error)
+}
+
+// syncDeleter is the delete surface the conditional-delete handler needs from
+// the entity manager. Distinct from syncApplier (the id-preserving push path):
+// deletes go through the normal write path, not the automation-suppressed apply.
+type syncDeleter interface {
+	DeleteEntity(ctx context.Context, id string, cascade bool) (*entity.DeleteResult, error)
+	DeleteRelation(ctx context.Context, from, relType, to string) error
+}
+
+// syncHandler serves the /api/sync/ API (fs-client ↔ pg-server replication).
+// Extracted from App (TKT-R68TV8): it owns the sync route cluster so the god
+// object shrinks by ~16 methods.
+//
+// It holds narrow read (syncStore) and delete (syncDeleter) surfaces plus the
+// two optional capabilities the sync protocol needs — the manifest source
+// (pgstore-only) and the id-preserving applier (*entitymanager.Manager-only).
+// Both are resolved once by newSyncHandler and left nil on the fs/memory builds,
+// where the corresponding endpoints degrade to 501. The store/manager handles
+// are fixed for App's lifetime (only the schema snapshot reloads), so there is
+// nothing to re-resolve per request.
+//
+// writeMu is a POINTER to App's mutation mutex, not a private one: sync pushes
+// and deletes must serialize against every OTHER data-entry mutation handler,
+// not just against each other, so they share the App-wide write lock. (Once
+// TKT-R68TV8 M5.4 moves write serialization behind the store, this field goes
+// away.)
+type syncHandler struct {
+	store    syncStore
+	deleter  syncDeleter
+	manifest manifestProvider // nil unless the store is pgstore
+	applier  syncApplier      // nil unless the manager is *entitymanager.Manager
+	writeMu  *sync.Mutex
+}
+
+// newSyncHandler wires the sync route cluster. It resolves the two optional
+// capabilities up front by type-asserting the concrete store/manager: the
+// manifest source (only pgstore satisfies manifestProvider) and the
+// id-preserving applier (only *entitymanager.Manager satisfies syncApplier).
+// Both stay nil on the fs/memory builds, where the manifest and push endpoints
+// return 501. writeMu is App's mutation mutex, shared by pointer.
+func newSyncHandler(st syncStore, deleter syncDeleter, writeMu *sync.Mutex) *syncHandler {
+	h := &syncHandler{store: st, deleter: deleter, writeMu: writeMu}
+	if mp, ok := st.(manifestProvider); ok {
+		h.manifest = mp
+	}
+	if ap, ok := deleter.(syncApplier); ok {
+		h.applier = ap
+	}
+	return h
+}
+
+// registerSyncRoutes mounts the sync API under /api/sync/. See the handler
+// godocs for the per-route contract. The routes inherit the data-entry
+// security middleware EXCEPT the same-origin check, from which /api/sync/ is
+// exempted (a non-browser sync client sends no Origin) — see
+// middleware_security.go.
+func (h *syncHandler) registerSyncRoutes(mux *http.ServeMux) {
+	mux.HandleFunc("/api/sync/manifest", h.handleSyncManifest)
+	mux.HandleFunc("/api/sync/", h.handleSyncRecord)
+}

--- a/internal/dataentry/sync_handlers.go
+++ b/internal/dataentry/sync_handlers.go
@@ -25,14 +25,14 @@ func syncContext(ctx context.Context) context.Context {
 // handleSyncGet fetches a record's full content as JSON, plus its current hash
 // in the ETag header so the client can use it as an If-Match base on a later
 // push.
-func (a *App) handleSyncGet(w http.ResponseWriter, r *http.Request, kind, rest string) {
+func (h *syncHandler) handleSyncGet(w http.ResponseWriter, r *http.Request, kind, rest string) {
 	switch kind {
 	case "entities":
 		if !validIDSegment(rest) {
 			writeV1Error(w, r, http.StatusBadRequest, "invalid_id", "Invalid entity id", "")
 			return
 		}
-		e, err := a.store.GetEntity(r.Context(), rest)
+		e, err := h.store.GetEntity(r.Context(), rest)
 		if err != nil {
 			writeV1Error(w, r, http.StatusNotFound, "not_found", "Entity not found", "")
 			return
@@ -41,7 +41,7 @@ func (a *App) handleSyncGet(w http.ResponseWriter, r *http.Request, kind, rest s
 		// apply the same read authorization every other read path does
 		// (RR IB-review #1). A denied read 404s indistinguishably from a
 		// missing one — same body as the err branch above.
-		if ok, err := a.permitsSyncReadEntity(r.Context(), e.Type, e.ID); err != nil {
+		if ok, err := h.permitsSyncReadEntity(r.Context(), e.Type, e.ID); err != nil {
 			writeGateError(w, r, err)
 			return
 		} else if !ok {
@@ -53,13 +53,13 @@ func (a *App) handleSyncGet(w http.ResponseWriter, r *http.Request, kind, rest s
 			ID: e.ID, Type: e.Type, Properties: e.Properties, Content: e.Content,
 		})
 	case "relations":
-		rel, ok := a.fetchRelation(w, r, rest)
+		rel, ok := h.fetchRelation(w, r, rest)
 		if !ok {
 			return
 		}
 		// A relation's read visibility follows its source entity, exactly
 		// as handleV1EntityRelations gates /relations (api_v1.go).
-		if ok, err := a.permitsSyncReadRelation(r.Context(), rel.From); err != nil {
+		if ok, err := h.permitsSyncReadRelation(r.Context(), rel.From); err != nil {
 			writeGateError(w, r, err)
 			return
 		} else if !ok {
@@ -87,26 +87,26 @@ func (a *App) handleSyncGet(w http.ResponseWriter, r *http.Request, kind, rest s
 //	422            : entitymanager rejected the content (validation) — NOT a
 //	                 conflict; the data is invalid
 //	403            : ACL denied
-func (a *App) handleSyncPut(w http.ResponseWriter, r *http.Request, kind, rest string) {
-	ap := a.syncApplierFor()
+func (h *syncHandler) handleSyncPut(w http.ResponseWriter, r *http.Request, kind, rest string) {
+	ap := h.applier
 	if ap == nil {
 		writeV1Error(w, r, http.StatusNotImplemented, "sync_unsupported", "Sync apply is not wired", "")
 		return
 	}
 	ifMatch := strings.TrimSpace(r.Header.Get("If-Match"))
 
-	a.writeMu.Lock()
-	defer a.writeMu.Unlock()
+	h.writeMu.Lock()
+	defer h.writeMu.Unlock()
 
 	switch kind {
 	case "entities":
-		a.putEntity(w, r, ap, rest, ifMatch)
+		h.putEntity(w, r, ap, rest, ifMatch)
 	case "relations":
-		a.putRelation(w, r, ap, rest, ifMatch)
+		h.putRelation(w, r, ap, rest, ifMatch)
 	}
 }
 
-func (a *App) putEntity(w http.ResponseWriter, r *http.Request, ap syncApplier, id, ifMatch string) {
+func (h *syncHandler) putEntity(w http.ResponseWriter, r *http.Request, ap syncApplier, id, ifMatch string) {
 	if !validIDSegment(id) {
 		writeV1Error(w, r, http.StatusBadRequest, "invalid_id", "Invalid entity id", "")
 		return
@@ -124,7 +124,7 @@ func (a *App) putEntity(w http.ResponseWriter, r *http.Request, ap syncApplier, 
 	// Precondition: the record's CURRENT hash must equal If-Match. A push with
 	// no If-Match is only valid if the record does not yet exist (a first
 	// create); otherwise the client must declare the base it edited.
-	cur, exists := a.currentEntityHash(r.Context(), id)
+	cur, exists := h.currentEntityHash(r.Context(), id)
 	if !preconditionOK(ifMatch, cur, exists) {
 		writeSyncConflict(w, r, cur, exists)
 		return
@@ -139,7 +139,7 @@ func (a *App) putEntity(w http.ResponseWriter, r *http.Request, ap syncApplier, 
 	writeV1JSON(w, http.StatusOK, map[string]string{"hash": canonical.HashEntity(*e)})
 }
 
-func (a *App) putRelation(w http.ResponseWriter, r *http.Request, ap syncApplier, rest, ifMatch string) {
+func (h *syncHandler) putRelation(w http.ResponseWriter, r *http.Request, ap syncApplier, rest, ifMatch string) {
 	from, relType, to, ok := parseRelationKey(rest)
 	if !ok {
 		writeV1Error(w, r, http.StatusBadRequest, "invalid_id", "Invalid relation key", "")
@@ -151,7 +151,7 @@ func (a *App) putRelation(w http.ResponseWriter, r *http.Request, ap syncApplier
 		return
 	}
 
-	cur, exists := a.currentRelationHash(r.Context(), from, relType, to)
+	cur, exists := h.currentRelationHash(r.Context(), from, relType, to)
 	if !preconditionOK(ifMatch, cur, exists) {
 		writeSyncConflict(w, r, cur, exists)
 		return
@@ -170,9 +170,9 @@ func (a *App) putRelation(w http.ResponseWriter, r *http.Request, ap syncApplier
 // the record's current hash — a client only deletes what it last saw, symmetric
 // with the push precondition (no blind delete of an existing record). 200 on
 // success, 412 on a missing/mismatched If-Match, 404 if the record is gone.
-func (a *App) handleSyncDelete(w http.ResponseWriter, r *http.Request, kind, rest string) {
-	a.writeMu.Lock()
-	defer a.writeMu.Unlock()
+func (h *syncHandler) handleSyncDelete(w http.ResponseWriter, r *http.Request, kind, rest string) {
+	h.writeMu.Lock()
+	defer h.writeMu.Unlock()
 	ifMatch := strings.TrimSpace(r.Header.Get("If-Match"))
 
 	switch kind {
@@ -181,7 +181,7 @@ func (a *App) handleSyncDelete(w http.ResponseWriter, r *http.Request, kind, res
 			writeV1Error(w, r, http.StatusBadRequest, "invalid_id", "Invalid entity id", "")
 			return
 		}
-		cur, exists := a.currentEntityHash(r.Context(), rest)
+		cur, exists := h.currentEntityHash(r.Context(), rest)
 		if !exists {
 			writeV1Error(w, r, http.StatusNotFound, "not_found", "Entity not found", "")
 			return
@@ -190,7 +190,7 @@ func (a *App) handleSyncDelete(w http.ResponseWriter, r *http.Request, kind, res
 			writeSyncConflict(w, r, cur, true)
 			return
 		}
-		if _, err := a.entityManager.DeleteEntity(syncContext(r.Context()), rest, true); err != nil {
+		if _, err := h.deleter.DeleteEntity(syncContext(r.Context()), rest, true); err != nil {
 			writeSyncApplyError(w, r, err)
 			return
 		}
@@ -201,7 +201,7 @@ func (a *App) handleSyncDelete(w http.ResponseWriter, r *http.Request, kind, res
 			writeV1Error(w, r, http.StatusBadRequest, "invalid_id", "Invalid relation key", "")
 			return
 		}
-		cur, exists := a.currentRelationHash(r.Context(), from, relType, to)
+		cur, exists := h.currentRelationHash(r.Context(), from, relType, to)
 		if !exists {
 			writeV1Error(w, r, http.StatusNotFound, "not_found", "Relation not found", "")
 			return
@@ -210,7 +210,7 @@ func (a *App) handleSyncDelete(w http.ResponseWriter, r *http.Request, kind, res
 			writeSyncConflict(w, r, cur, true)
 			return
 		}
-		if err := a.entityManager.DeleteRelation(syncContext(r.Context()), from, relType, to); err != nil {
+		if err := h.deleter.DeleteRelation(syncContext(r.Context()), from, relType, to); err != nil {
 			writeSyncApplyError(w, r, err)
 			return
 		}
@@ -234,7 +234,7 @@ func deletePreconditionOK(ifMatch, currentHash string) bool {
 // api_v1.go): the answer is "policy permits reading this (type, id)", evaluated
 // against the request principal's read scope. The nop gate (no ACL configured)
 // permits everything, preserving pre-ACL behavior.
-func (a *App) permitsSyncReadEntity(ctx context.Context, entityType, entityID string) (bool, error) {
+func (h *syncHandler) permitsSyncReadEntity(ctx context.Context, entityType, entityID string) (bool, error) {
 	return readGateFromContext(ctx).PermitsRead(ctx, entityType, entityID)
 }
 
@@ -244,9 +244,9 @@ func (a *App) permitsSyncReadEntity(ctx context.Context, entityType, entityID st
 // source entity's type is resolved from the store; if it cannot be loaded
 // (e.g. the source was deleted) the type is left empty, the same fallback the
 // relation write gate uses (authorizeConflictResolve), and the gate decides.
-func (a *App) permitsSyncReadRelation(ctx context.Context, from string) (bool, error) {
+func (h *syncHandler) permitsSyncReadRelation(ctx context.Context, from string) (bool, error) {
 	var fromType string
-	if e, err := a.store.GetEntity(ctx, from); err == nil {
+	if e, err := h.store.GetEntity(ctx, from); err == nil {
 		fromType = e.Type
 	}
 	return readGateFromContext(ctx).PermitsRead(ctx, fromType, from)
@@ -254,13 +254,13 @@ func (a *App) permitsSyncReadRelation(ctx context.Context, from string) (bool, e
 
 // fetchRelation parses the relation key from rest, loads it, and writes a 4xx if
 // the key is invalid or the relation is absent. Returns (rel, true) on success.
-func (a *App) fetchRelation(w http.ResponseWriter, r *http.Request, rest string) (*entity.Relation, bool) {
+func (h *syncHandler) fetchRelation(w http.ResponseWriter, r *http.Request, rest string) (*entity.Relation, bool) {
 	from, relType, to, ok := parseRelationKey(rest)
 	if !ok {
 		writeV1Error(w, r, http.StatusBadRequest, "invalid_id", "Invalid relation key", "")
 		return nil, false
 	}
-	rel, err := a.store.GetRelation(r.Context(), from, relType, to)
+	rel, err := h.store.GetRelation(r.Context(), from, relType, to)
 	if err != nil {
 		writeV1Error(w, r, http.StatusNotFound, "not_found", "Relation not found", "")
 		return nil, false
@@ -282,16 +282,16 @@ func parseRelationKey(rest string) (from, relType, to string, ok bool) {
 	return from, relType, to, true
 }
 
-func (a *App) currentEntityHash(ctx context.Context, id string) (hash string, exists bool) {
-	e, err := a.store.GetEntity(ctx, id)
+func (h *syncHandler) currentEntityHash(ctx context.Context, id string) (hash string, exists bool) {
+	e, err := h.store.GetEntity(ctx, id)
 	if err != nil {
 		return "", false
 	}
 	return canonical.HashEntity(*e), true
 }
 
-func (a *App) currentRelationHash(ctx context.Context, from, relType, to string) (hash string, exists bool) {
-	rel, err := a.store.GetRelation(ctx, from, relType, to)
+func (h *syncHandler) currentRelationHash(ctx context.Context, from, relType, to string) (hash string, exists bool) {
+	rel, err := h.store.GetRelation(ctx, from, relType, to)
 	if err != nil {
 		return "", false
 	}

--- a/internal/dataentry/sync_test.go
+++ b/internal/dataentry/sync_test.go
@@ -321,7 +321,7 @@ func TestSync_DeleteEntity(t *testing.T) {
 // ManifestSince, so the manifest endpoint reports 501 (not a crash).
 func TestSync_ManifestUnsupportedOnNonPostgres(t *testing.T) {
 	app := newHandlerTestApp(t)
-	if app.syncManifest() != nil {
+	if app.sync.manifest != nil {
 		t.Skip("test backend unexpectedly supports the manifest")
 	}
 	w := syncRequest(t, app, http.MethodGet, "/api/sync/manifest", "", nil)
@@ -369,6 +369,7 @@ func TestSync_ManifestSerialization(t *testing.T) {
 		{Kind: "e", IDA: "TKT-2", Typ: "ticket", Deleted: true, Seq: 6}, // tombstone
 		{Kind: "r", IDA: "TKT-1", IDB: "belongs_to", IDC: "CMP-1", Deleted: false, Seq: 7},
 	}}
+	rebindSyncHandler(app) // re-resolve the manifest capability against the swapped store
 
 	w := syncRequest(t, app, http.MethodGet, "/api/sync/manifest?cursor=4", "", nil)
 	if w.Code != http.StatusOK {
@@ -411,7 +412,7 @@ func syncGetAs(ctx context.Context, t *testing.T, app *App, d *acl.Declarative,
 	req := httptest.NewRequest(http.MethodGet, "/api/sync/"+kind+"/"+rest, http.NoBody)
 	req = req.WithContext(gateCtxFor(ctx, t, d))
 	rec := httptest.NewRecorder()
-	app.handleSyncGet(rec, req, kind, rest)
+	app.sync.handleSyncGet(rec, req, kind, rest)
 	return rec
 }
 
@@ -489,6 +490,7 @@ func TestSync_Manifest_ACLFiltered(t *testing.T) {
 		{Kind: "r", IDA: "FEAT-1", IDB: "needs", IDC: "CMP-1", Seq: 8},     // sourced on feature — hidden
 		{Kind: "r", IDA: "TKT-1", IDB: "belongs_to", IDC: "CMP-1", Seq: 9}, // sourced on ticket — visible
 	}}
+	rebindSyncHandler(app) // re-resolve the manifest capability + gate reads against the swapped store
 
 	d := mustNewACL(t, &acl.Policy{
 		Roles:       map[string]acl.RoleDef{"viewer": {Read: []string{"ticket"}}},
@@ -499,7 +501,7 @@ func TestSync_Manifest_ACLFiltered(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/api/sync/manifest?cursor=4", http.NoBody)
 	req = req.WithContext(gateCtxFor(aliceCtx(), t, d))
 	rec := httptest.NewRecorder()
-	app.handleSyncManifest(rec, req)
+	app.sync.handleSyncManifest(rec, req)
 
 	if rec.Code != http.StatusOK {
 		t.Fatalf("manifest: %d %s", rec.Code, rec.Body.String())
@@ -540,7 +542,7 @@ func TestSync_PushRelation(t *testing.T) {
 	app := newHandlerTestApp(t)
 	// belongs_to: ticket -> component. Seed a component first.
 	comp := &entity.Entity{ID: "CMP-1", Type: "component", Properties: map[string]any{"name": "Core"}}
-	if _, err := app.syncApplierFor().ApplyEntity(t.Context(), comp); err != nil {
+	if _, err := app.sync.applier.ApplyEntity(t.Context(), comp); err != nil {
 		t.Fatalf("seed component: %v", err)
 	}
 	body := syncRelationBody{From: "TKT-001", Type: "belongs_to", To: "CMP-1"}

--- a/internal/dataentry/sync_type_confusion_test.go
+++ b/internal/dataentry/sync_type_confusion_test.go
@@ -125,7 +125,7 @@ assignments:
 
 	// Compute the current hash for a valid If-Match (so the request reaches
 	// the apply path, not a 412 precondition failure).
-	cur, exists := app.currentEntityHash(context.Background(), "SECRET-1")
+	cur, exists := app.sync.currentEntityHash(context.Background(), "SECRET-1")
 	if !exists {
 		t.Fatal("seeded secret not found")
 	}
@@ -182,7 +182,7 @@ assignments:
 	seedEntity(app, &entity.Entity{
 		ID: "NOTE-1", Type: "note", Properties: map[string]any{"title": "v1"},
 	})
-	cur, exists := app.currentEntityHash(context.Background(), "NOTE-1")
+	cur, exists := app.sync.currentEntityHash(context.Background(), "NOTE-1")
 	if !exists {
 		t.Fatal("seeded note not found")
 	}

--- a/internal/dataentry/test_helpers_test.go
+++ b/internal/dataentry/test_helpers_test.go
@@ -162,6 +162,19 @@ func rebindApp(app *App, fs storage.FS, paths *project.Context, svc *appbuild.Se
 		currentEdgesByPeer: app.currentEdgesByPeer,
 	}
 	app.serializer = entitySerializer{affordances: app.affordances}
+	// Rebuild the sync handler over the rebound store/manager. writeMu is App's
+	// own, so sync writes serialize with the other mutation handlers just as in
+	// production.
+	app.sync = newSyncHandler(svc.Store(), svc.EntityManager(), &app.writeMu)
+}
+
+// rebindSyncHandler rebuilds app.sync over the app's CURRENT store/manager.
+// Production resolves the sync capabilities once at construction (the store is
+// fixed for App's lifetime); a test that swaps app.store after construction to
+// inject a fake manifest/apply source must call this so the handler re-resolves
+// against the swapped store.
+func rebindSyncHandler(app *App) {
+	app.sync = newSyncHandler(app.store, app.entityManager, &app.writeMu)
 }
 
 // rebindVisibleSearcher re-derives the generic visible-search wrapper

--- a/internal/dataentry/write_subject_type_invariant_test.go
+++ b/internal/dataentry/write_subject_type_invariant_test.go
@@ -72,7 +72,7 @@ assignments:
 			name: "sync PUT (ApplyEntity)",
 			attempt: func(t *testing.T, app *App) int {
 				t.Helper()
-				cur, exists := app.currentEntityHash(context.Background(), "SECRET-1")
+				cur, exists := app.sync.currentEntityHash(context.Background(), "SECRET-1")
 				if !exists {
 					t.Fatal("seed missing")
 				}

--- a/tickets/entities/review-checklists/REV-DI8V8.md
+++ b/tickets/entities/review-checklists/REV-DI8V8.md
@@ -1,0 +1,28 @@
+---
+id: REV-DI8V8
+type: review-checklist
+title: 'Review: Extract sync route cluster into syncHandler'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Automated Checks
+
+- [x] All tests pass (`go test -race ./internal/dataentry/...`)
+- [x] Lint clean (`golangci-lint run internal/dataentry/...`) — 0 issues
+- [x] `gofmt` clean
+- [x] `just plimsoll` passes — `App` directive ratcheted 170 → 154
+- [x] `just arch-lint` passes
+- [x] Builds + vet across default / `postgres` / `memorybackend` tags
+
+## Manual Review
+
+- [x] Self-reviewed the diff for unrelated changes
+- [x] Consumer-side interfaces (`syncStore`, `syncDeleter`) declared at the call site per CLAUDE.md
+- [x] `writeMu` shared by pointer — sync writes still serialize with other mutation handlers (race detector guards)
+- [x] Optional capabilities resolved once in `newSyncHandler`; nil on fs/memory builds (endpoints degrade to 501)
+- [x] ~~`/code-review` command~~ (N/A: mechanical method-move refactor, no behavior change; verified by the unchanged, still-passing sync test suite)
+- [x] ~~Critical/significant review-responses addressed~~ (N/A: no review run)
+
+**Review Responses:** N/A — mechanical extraction, behavior-preserving.

--- a/tickets/entities/tickets/TKT-R68TV8.md
+++ b/tickets/entities/tickets/TKT-R68TV8.md
@@ -5,38 +5,44 @@ title: 'Finish dataentry.App decomposition: command/sync handlers + write nucleu
 kind: refactor
 priority: medium
 effort: m
-status: ready
+status: backlog
 ---
 
-Follow-up to TKT-N26KLB. That ticket drove `dataentry.App` from 227 methods down
-to ~166 and landed the structural payoff — the ACL-bounded `visibleReader` seam
-that closes the #1010 read-ACL bug class — but stopped short of the original
-`<40` end goal. We chose to ship that progress rather than block the plimsoll
-ratchet on the whole refactor. This ticket tracks the remainder.
+**Epic / parent ticket** for the remainder of the `dataentry.App` decomposition.
+Each shippable step is its own sub-ticket (moved to `done` with its PR); this
+parent stays in `backlog` until the whole arc lands — App under the 40-method
+line with the plimsoll directive deleted. (Per-PR sub-tickets satisfy the
+done-before-merge gate honestly: a multi-PR epic can't be `done` while work
+remains, and `backlog` is the allowed "not-touched-by-this-PR" parent state.)
 
-The AppState state-decomposition prerequisite (TKT-XSWFXQ) is now done, so the
-snapshot/`writeMu` publish coupling is gone and the handler clusters can move
-off `App` one at a time.
+Follow-up to the earlier decomposition that drove `dataentry.App` from 227
+methods down to ~166 and landed the structural payoff — the ACL-bounded
+`visibleReader` seam that closes the #1010 read-ACL bug class — but stopped
+short of the original `<40` end goal. The AppState state-decomposition
+prerequisite ([[TKT-XSWFXQ]]) is also done, so the snapshot/`writeMu` publish
+coupling is gone and the handler clusters can move off `App` one at a time.
 
-## Remaining steps (from the M5 plan)
+## Sub-tickets
 
-- **M5.2** — extract command + sync handlers off `App`.
-  - [x] **Sync handler cluster** → `syncHandler` (16 methods; `App` 170 → 154,
-directive ratcheted). Narrow consumer-side interfaces (`syncStore`,
-`syncDeleter`) + lazy capability closures for the pgstore-only manifest and the
-`*entitymanager.Manager` applier; `writeMu` shared by pointer so sync writes
-still serialize with the other mutation handlers.
-  - [ ] Command handler cluster (`commands.go`, ~11 methods).
-- **M5.4** — carve the write nucleus + entity/relation/attachment write handlers
-behind one shared `writeMu`; drive `App` under the 40-method line and delete the
+- **M5.2 — extract command + sync handlers off `App`.**
+  - [x] [[TKT-VG9P1]] — sync route cluster → `syncHandler` (170 → 154). PR #1134.
+  - [x] [[TKT-KUFLD]] — command route cluster → `commandHandler` (154 → 143).
+PR #1138.
+  - [ ] Attachment handler cluster (`handlers_attachment.go`, ~12 methods).
+- **M5.4 — write nucleus.** Carve the entity/relation/attachment write handlers
+behind one shared `writeMu`; drive `App` under 40 and delete the
 `//plimsoll:max-methods` directive in `internal/dataentry/app.go`.
+  - **Open question to settle first:** does write-serialization move *behind the
+store* (the CLAUDE.md-endorsed direction) or stay an App-level mutex the write
+handlers share by pointer (as `syncHandler` does today)? Worth a design-review
+before extracting the write handlers.
 
-## Invariants (unchanged from M5)
+## Invariants (unchanged)
 
 - Read handlers take the ACL-bounded `visibleReader` only — never `store.Store`.
 - `writeMu` stays a single shared instance across all write handlers (race
-detector guards). The extracted `syncHandler` holds a *pointer* to `App`'s
-`writeMu`, preserving this.
+detector guards). The extracted handlers hold a *pointer* to `App`'s `writeMu`,
+preserving this.
 
 ## Related finding
 

--- a/tickets/entities/tickets/TKT-R68TV8.md
+++ b/tickets/entities/tickets/TKT-R68TV8.md
@@ -5,7 +5,7 @@ title: 'Finish dataentry.App decomposition: command/sync handlers + write nucleu
 kind: refactor
 priority: medium
 effort: m
-status: backlog
+status: ready
 ---
 
 Follow-up to TKT-N26KLB. That ticket drove `dataentry.App` from 227 methods down
@@ -14,18 +14,29 @@ that closes the #1010 read-ACL bug class — but stopped short of the original
 `<40` end goal. We chose to ship that progress rather than block the plimsoll
 ratchet on the whole refactor. This ticket tracks the remainder.
 
+The AppState state-decomposition prerequisite (TKT-XSWFXQ) is now done, so the
+snapshot/`writeMu` publish coupling is gone and the handler clusters can move
+off `App` one at a time.
+
 ## Remaining steps (from the M5 plan)
 
 - **M5.2** — extract command + sync handlers off `App`.
+  - [x] **Sync handler cluster** → `syncHandler` (16 methods; `App` 170 → 154,
+directive ratcheted). Narrow consumer-side interfaces (`syncStore`,
+`syncDeleter`) + lazy capability closures for the pgstore-only manifest and the
+`*entitymanager.Manager` applier; `writeMu` shared by pointer so sync writes
+still serialize with the other mutation handlers.
+  - [ ] Command handler cluster (`commands.go`, ~11 methods).
 - **M5.4** — carve the write nucleus + entity/relation/attachment write handlers
-  behind one shared `writeMu`; drive `App` under the 40-method line and delete
-  the `//plimsoll:max-methods` directive in `internal/dataentry/app.go`.
+behind one shared `writeMu`; drive `App` under the 40-method line and delete the
+`//plimsoll:max-methods` directive in `internal/dataentry/app.go`.
 
 ## Invariants (unchanged from M5)
 
 - Read handlers take the ACL-bounded `visibleReader` only — never `store.Store`.
 - `writeMu` stays a single shared instance across all write handlers (race
-  detector guards).
+detector guards). The extracted `syncHandler` holds a *pointer* to `App`'s
+`writeMu`, preserving this.
 
 ## Related finding
 

--- a/tickets/entities/tickets/TKT-VG9P1.md
+++ b/tickets/entities/tickets/TKT-VG9P1.md
@@ -1,0 +1,32 @@
+---
+id: TKT-VG9P1
+type: ticket
+title: Extract dataentry sync route cluster into syncHandler
+kind: refactor
+priority: medium
+effort: s
+status: done
+---
+
+Sub-ticket of the [[TKT-R68TV8]] `dataentry.App` decomposition arc (M5.2).
+Delivered in PR #1134.
+
+## What
+
+Moved the 16-method `/api/sync/` route cluster (`sync.go` + `sync_handlers.go`)
+off `App` into a new `syncHandler` value-service.
+
+- **`App`: 170 → 154 methods** — `//plimsoll:max-methods` directive ratcheted.
+- Narrow consumer-side interfaces at the call site: `syncStore` (entity/relation
+gets), `syncDeleter` (delete path). The two optional capabilities — the
+pgstore-only manifest source and the `*entitymanager.Manager` id-preserving
+applier — are resolved once in `newSyncHandler` (nil on fs/memory builds, where
+the endpoints degrade to 501).
+- `writeMu` shared by **pointer** so sync pushes/deletes serialize against every
+other data-entry mutation handler, exactly as before (race detector guards).
+
+## Verification
+
+- `go test -race ./internal/dataentry/...`
+- Builds + vet across default / `postgres` / `memorybackend`
+- `just plimsoll`, `just arch-lint`, `golangci-lint` (0 issues), `gofmt`

--- a/tickets/relations/TKT-VG9P1--affects--ci-pipeline.md
+++ b/tickets/relations/TKT-VG9P1--affects--ci-pipeline.md
@@ -1,0 +1,5 @@
+---
+from: TKT-VG9P1
+relation: affects
+to: ci-pipeline
+---

--- a/tickets/relations/TKT-VG9P1--has-review--REV-DI8V8.md
+++ b/tickets/relations/TKT-VG9P1--has-review--REV-DI8V8.md
@@ -1,0 +1,5 @@
+---
+from: TKT-VG9P1
+relation: has-review
+to: REV-DI8V8
+---

--- a/tickets/relations/TKT-VG9P1--implements--FEAT-GE1YY.md
+++ b/tickets/relations/TKT-VG9P1--implements--FEAT-GE1YY.md
@@ -1,0 +1,5 @@
+---
+from: TKT-VG9P1
+relation: implements
+to: FEAT-GE1YY
+---


### PR DESCRIPTION
Stacked on #1110. First PR of TKT-R68TV8 (M5.2) that actually lowers the plimsoll `App` line.

## What

Moves the 16-method `/api/sync/` route cluster (`sync.go` + `sync_handlers.go`) off `App` into a new `syncHandler` value-service.

- **`App`: 170 → 154 methods** — `//plimsoll:max-methods` directive ratcheted down.
- Narrow consumer-side interfaces at the call site: `syncStore` (entity/relation gets), `syncDeleter` (delete path).
- The two optional capabilities — the pgstore-only manifest source and the `*entitymanager.Manager` id-preserving applier — are resolved **once** in `newSyncHandler` (nil on fs/memory builds, where the endpoints degrade to 501). No per-call type assertion: the store/manager handles are fixed for `App`'s lifetime; only the schema snapshot reloads.
- `writeMu` is shared by **pointer** so sync pushes/deletes serialize against every other data-entry mutation handler, exactly as before (race detector guards).

## Verification

- `go test -race ./internal/dataentry/...` — pass
- Builds + vet across default / `postgres` / `memorybackend` tags
- `just plimsoll`, `just arch-lint`, `golangci-lint` (0 issues), `gofmt` — all clean

Tracked by TKT-R68TV8.