### PR TITLE
feat: timed calendar-feed events from datetime sources (TKT-VG3NUA)

### DIFF
--- a/docs-project/entities/guides/GUIDE-data-entry.md
+++ b/docs-project/entities/guides/GUIDE-data-entry.md
@@ -2424,8 +2424,8 @@ Multiple sources are also how you express **OR**: the filter language has no
 |-------|----------|---------|
 | `entity_type` | yes | The entity type to project. |
 | `where` | no | A list of filter clauses, all ANDed. Empty = all entities of the type. |
-| `date` | yes | A **date**-typed property mapped to the event day (all-day). Entities without a value are skipped. |
-| `end_date` | no | A date property for an all-day range's end. Omit for single-day events. |
+| `date` | yes | A **date**- or **datetime**-typed property mapped to the event start. A `date` property yields an all-day event; a `datetime` property yields a **timed** event (rendered in UTC). Entities without a value are skipped. |
+| `end_date` | no | A property for the event's end. Must be the **same kind** as `date` (both `date` or both `datetime`) — a feed event is all-day or timed, not a mix. Omit for single-day / no-end events. |
 | `summary` | no | A property mapped to the event title. Defaults to the entity type's display property. |
 | `description` | no | A property mapped to the event description. |
 | `alarm` | no | A static RFC 5545 duration (e.g. `-PT9H`, `-P1D`) for a reminder before the event. |
@@ -2464,8 +2464,9 @@ dense.
 
 ### The events
 
-Each entity becomes one all-day event (feeds serve all-day events only for now —
-timed events await a `datetime` property type):
+Each entity becomes one event — **all-day** when the `date:` source is a `date`
+property, or **timed** (a UTC `DTSTART` with a time-of-day) when it is a
+`datetime` property:
 
 - **UID** is `<type>--<id>@rela` — stable across refreshes so a calendar client
   tracks the same event over time.

--- a/docs-project/entities/guides/GUIDE-metamodel.md
+++ b/docs-project/entities/guides/GUIDE-metamodel.md
@@ -648,8 +648,10 @@ Semantics:
 The data-entry app renders `datetime` properties with a date+time picker and a
 configurable display time zone — see the data-entry guide.
 
-Calendar-feed sources currently accept only `date` (all-day) properties;
-timed events from `datetime` sources are a planned follow-on.
+A calendar-feed source can use a `datetime` property (as its `date:` or
+`end_date:`) to emit a **timed** event; a `date` property emits an all-day
+event. Start and end must be the same kind (all-day or timed), and timed events
+are rendered in UTC.
 
 ### Property Type Examples
 

--- a/docs/data-entry.md
+++ b/docs/data-entry.md
@@ -2418,8 +2418,8 @@ Multiple sources are also how you express **OR**: the filter language has no
 |-------|----------|---------|
 | `entity_type` | yes | The entity type to project. |
 | `where` | no | A list of filter clauses, all ANDed. Empty = all entities of the type. |
-| `date` | yes | A **date**-typed property mapped to the event day (all-day). Entities without a value are skipped. |
-| `end_date` | no | A date property for an all-day range's end. Omit for single-day events. |
+| `date` | yes | A **date**- or **datetime**-typed property mapped to the event start. A `date` property yields an all-day event; a `datetime` property yields a **timed** event (rendered in UTC). Entities without a value are skipped. |
+| `end_date` | no | A property for the event's end. Must be the **same kind** as `date` (both `date` or both `datetime`) — a feed event is all-day or timed, not a mix. Omit for single-day / no-end events. |
 | `summary` | no | A property mapped to the event title. Defaults to the entity type's display property. |
 | `description` | no | A property mapped to the event description. |
 | `alarm` | no | A static RFC 5545 duration (e.g. `-PT9H`, `-P1D`) for a reminder before the event. |
@@ -2458,8 +2458,9 @@ dense.
 
 ### The events
 
-Each entity becomes one all-day event (feeds serve all-day events only for now —
-timed events await a `datetime` property type):
+Each entity becomes one event — **all-day** when the `date:` source is a `date`
+property, or **timed** (a UTC `DTSTART` with a time-of-day) when it is a
+`datetime` property:
 
 - **UID** is `<type>--<id>@rela` — stable across refreshes so a calendar client
   tracks the same event over time.

--- a/docs/metamodel.md
+++ b/docs/metamodel.md
@@ -642,8 +642,10 @@ Semantics:
 The data-entry app renders `datetime` properties with a date+time picker and a
 configurable display time zone — see the data-entry guide.
 
-Calendar-feed sources currently accept only `date` (all-day) properties;
-timed events from `datetime` sources are a planned follow-on.
+A calendar-feed source can use a `datetime` property (as its `date:` or
+`end_date:`) to emit a **timed** event; a `date` property emits an all-day
+event. Start and end must be the same kind (all-day or timed), and timed events
+are rendered in UTC.
 
 ### Property Type Examples
 

--- a/internal/calfeed/calfeed.go
+++ b/internal/calfeed/calfeed.go
@@ -15,8 +15,8 @@
 // [ICal.CollectionTag] provide the content tags CalDAV needs for conditional
 // requests.
 //
-// Phase 1 emits all-day events only (DTSTART;VALUE=DATE). Timed events await a
-// datetime property type in the metamodel.
+// Events are all-day by default (DTSTART;VALUE=DATE); an [Event] with Timed set
+// renders as a UTC date-time instant (a datetime-typed feed source drives this).
 package calfeed
 
 import "time"
@@ -30,8 +30,9 @@ type Alarm struct {
 	Description string
 }
 
-// Event is a single calendar entry. In Phase 1 every event is all-day: Start is
+// Event is a single calendar entry. By default an event is all-day: Start is
 // interpreted as a date and rendered DTSTART;VALUE=DATE with no time component.
+// Set Timed to render a time-bearing instant instead (DTSTART:...Z).
 type Event struct {
 	// UID is the globally-unique, stable identifier for this event across
 	// refreshes (RFC 5545). Callers supply a stable value (e.g.
@@ -44,11 +45,22 @@ type Event struct {
 	// URL is an optional link back to the source (URL); typically a deep link
 	// into the data-entry app.
 	URL string
-	// Start is the event's day. Its time-of-day is ignored in Phase 1 (all-day).
+	// Start is the event's start. When Timed is false it is interpreted as a
+	// day (time-of-day ignored); when Timed is true it is the exact UTC
+	// instant of DTSTART.
 	Start time.Time
-	// End, when non-zero, is the (exclusive) end day of an all-day range,
-	// rendered DTEND;VALUE=DATE. Zero means a single-day event.
+	// End, when non-zero, is the event's end, rendered verbatim as the
+	// RFC 5545 DTEND value (exclusive): a DATE value (next day) for an all-day
+	// range, or the exact end instant for a timed event. Zero means a
+	// single-day / no-DTEND event. Its all-day-vs-timed format follows Timed,
+	// exactly like Start — the two must be the same kind (enforced upstream by
+	// feed-source validation).
 	End time.Time
+	// Timed selects a time-bearing event (DTSTART/DTEND as UTC date-time
+	// instants, YYYYMMDDTHHMMSSZ) over the default all-day form
+	// (DTSTART;VALUE=DATE). The zero value is all-day, so existing all-day
+	// callers need no change.
+	Timed bool
 	// RRule, when non-empty, is a bare RFC 5545 recurrence rule (without the
 	// "RRULE:" prefix), e.g. "FREQ=DAILY". Rendered as an RRULE line so the
 	// event recurs; an unbounded rule keeps the event visible until it leaves

--- a/internal/calfeed/ical.go
+++ b/internal/calfeed/ical.go
@@ -239,7 +239,8 @@ func formatDate(t time.Time) string {
 	return t.Format("20060102")
 }
 
-// formatDateTimeUTC renders a UTC timestamp as YYYYMMDDTHHMMSSZ for DTSTAMP.
+// formatDateTimeUTC renders a UTC timestamp as YYYYMMDDTHHMMSSZ, used for
+// DTSTAMP and for a timed event's DTSTART/DTEND.
 func formatDateTimeUTC(t time.Time) string {
 	return t.UTC().Format("20060102T150405Z")
 }

--- a/internal/calfeed/ical.go
+++ b/internal/calfeed/ical.go
@@ -61,16 +61,25 @@ func (ic ICal) RenderCollection(f Feed) []byte {
 
 // RenderEvent renders one event as a VEVENT block (BEGIN:VEVENT…END:VEVENT),
 // CRLF-terminated. It is the single source of per-event serialization; both the
-// ICS feed and a future CalDAV per-resource GET use it. Phase 1 emits all-day
-// events (DTSTART;VALUE=DATE).
+// ICS feed and a future CalDAV per-resource GET use it. An all-day event emits
+// DTSTART;VALUE=DATE; a timed event (Event.Timed) emits a UTC date-time DTSTART.
 func (ic ICal) RenderEvent(e Event) []byte {
 	var b strings.Builder
 	writeLine(&b, "BEGIN:VEVENT")
 	writeProp(&b, "UID", e.UID)
 	writeLine(&b, "DTSTAMP:"+formatDateTimeUTC(ic.Now))
-	writeLine(&b, "DTSTART;VALUE=DATE:"+formatDate(e.Start))
-	if !e.End.IsZero() {
-		writeLine(&b, "DTEND;VALUE=DATE:"+formatDate(e.End))
+	// Timed events render UTC date-time instants; all-day events render a DATE
+	// value. Only the FORMAT differs — Start/End are rendered verbatim.
+	if e.Timed {
+		writeLine(&b, "DTSTART:"+formatDateTimeUTC(e.Start))
+		if !e.End.IsZero() {
+			writeLine(&b, "DTEND:"+formatDateTimeUTC(e.End))
+		}
+	} else {
+		writeLine(&b, "DTSTART;VALUE=DATE:"+formatDate(e.Start))
+		if !e.End.IsZero() {
+			writeLine(&b, "DTEND;VALUE=DATE:"+formatDate(e.End))
+		}
 	}
 	if e.RRule != "" {
 		writeLine(&b, "RRULE:"+e.RRule)

--- a/internal/calfeed/ical_test.go
+++ b/internal/calfeed/ical_test.go
@@ -18,6 +18,11 @@ func day(m time.Month, d int) time.Time {
 	return time.Date(2026, m, d, 0, 0, 0, 0, time.UTC)
 }
 
+// dayTime builds a UTC instant with a time-of-day, for timed-event tests.
+func dayTime(m time.Month, d, h, min int) time.Time {
+	return time.Date(2026, m, d, h, min, 0, 0, time.UTC)
+}
+
 // unfold reverses RFC 5545 line folding so a test can assert on logical lines.
 func unfold(s string) string { return strings.ReplaceAll(s, "\r\n ", "") }
 
@@ -106,6 +111,38 @@ func TestRenderEvent_AllDayValueDate(t *testing.T) {
 		if strings.HasPrefix(l, "DTSTART:") {
 			t.Errorf("unexpected timed DTSTART: %q", l)
 		}
+	}
+}
+
+func TestRenderEvent_Timed(t *testing.T) {
+	// A datetime-typed source yields a timed event: DTSTART is a UTC
+	// date-time instant, NOT a VALUE=DATE line.
+	lines := logicalLines(t, testICal().RenderEvent(Event{
+		UID: "EVT-1@rela", Summary: "Standup", Start: dayTime(7, 13, 14, 30), Timed: true,
+	}))
+	if !containsLine(lines, "DTSTART:20260713T143000Z") {
+		t.Errorf("missing timed DTSTART; got lines: %v", lines)
+	}
+	// The all-day form must be absent for a timed event.
+	for _, l := range lines {
+		if strings.HasPrefix(l, "DTSTART;VALUE=DATE:") {
+			t.Errorf("unexpected all-day DTSTART on a timed event: %q", l)
+		}
+	}
+}
+
+func TestRenderEvent_TimedRange(t *testing.T) {
+	// A datetime start+end yields timed DTSTART and DTEND (the exact end
+	// instant, verbatim — no coercion).
+	lines := logicalLines(t, testICal().RenderEvent(Event{
+		UID: "EVT-2@rela", Summary: "Meeting",
+		Start: dayTime(7, 13, 14, 0), End: dayTime(7, 13, 15, 0), Timed: true,
+	}))
+	if !containsLine(lines, "DTSTART:20260713T140000Z") {
+		t.Errorf("missing timed DTSTART; got %v", lines)
+	}
+	if !containsLine(lines, "DTEND:20260713T150000Z") {
+		t.Errorf("missing timed DTEND; got %v", lines)
 	}
 }
 

--- a/internal/calfeed/ical_test.go
+++ b/internal/calfeed/ical_test.go
@@ -19,8 +19,8 @@ func day(m time.Month, d int) time.Time {
 }
 
 // dayTime builds a UTC instant with a time-of-day, for timed-event tests.
-func dayTime(m time.Month, d, h, min int) time.Time {
-	return time.Date(2026, m, d, h, min, 0, 0, time.UTC)
+func dayTime(mo time.Month, d, h, mn int) time.Time {
+	return time.Date(2026, mo, d, h, mn, 0, 0, time.UTC)
 }
 
 // unfold reverses RFC 5545 line folding so a test can assert on logical lines.

--- a/internal/calfeed/json.go
+++ b/internal/calfeed/json.go
@@ -8,8 +8,13 @@ import (
 // jsonFeed / jsonEvent / jsonAlarm are the stable wire shapes for the JSON
 // rendering. They are defined separately from the domain types so the JSON
 // contract (consumed by menubar/notification glue) does not drift with internal
-// field changes, and so dates render as plain YYYY-MM-DD rather than RFC3339
-// timestamps (Phase 1 events are all-day).
+// field changes.
+//
+// All-day events populate date/endDate (plain YYYY-MM-DD) with allDay=true;
+// timed events populate start/end (RFC3339 UTC instants) with allDay=false.
+// The two field pairs are mutually exclusive so an existing date-only consumer
+// keeps working (it simply sees empty date fields, and allDay=false, for a
+// timed event).
 type jsonFeed struct {
 	Name        string      `json:"name,omitempty"`
 	Description string      `json:"description,omitempty"`
@@ -22,10 +27,12 @@ type jsonEvent struct {
 	Summary     string      `json:"summary"`
 	Description string      `json:"description,omitempty"`
 	URL         string      `json:"url,omitempty"`
-	Date        string      `json:"date"`              // YYYY-MM-DD (all-day)
-	EndDate     string      `json:"endDate,omitempty"` // YYYY-MM-DD, for a range
-	AllDay      bool        `json:"allDay"`            // always true in Phase 1
-	RRule       string      `json:"rrule,omitempty"`   // bare RFC 5545 recurrence rule
+	Date        string      `json:"date,omitempty"`    // YYYY-MM-DD (all-day only)
+	EndDate     string      `json:"endDate,omitempty"` // YYYY-MM-DD, all-day range
+	Start       string      `json:"start,omitempty"`   // RFC3339 UTC (timed only)
+	End         string      `json:"end,omitempty"`     // RFC3339 UTC, timed range
+	AllDay      bool        `json:"allDay"`
+	RRule       string      `json:"rrule,omitempty"` // bare RFC 5545 recurrence rule
 	Alarms      []jsonAlarm `json:"alarms,omitempty"`
 }
 
@@ -50,12 +57,19 @@ func RenderJSON(f Feed) ([]byte, error) {
 			Summary:     e.Summary,
 			Description: e.Description,
 			URL:         e.URL,
-			Date:        e.Start.Format(time.DateOnly),
-			AllDay:      true,
+			AllDay:      !e.Timed,
 			RRule:       e.RRule,
 		}
-		if !e.End.IsZero() {
-			je.EndDate = e.End.Format(time.DateOnly)
+		if e.Timed {
+			je.Start = e.Start.UTC().Format(time.RFC3339)
+			if !e.End.IsZero() {
+				je.End = e.End.UTC().Format(time.RFC3339)
+			}
+		} else {
+			je.Date = e.Start.Format(time.DateOnly)
+			if !e.End.IsZero() {
+				je.EndDate = e.End.Format(time.DateOnly)
+			}
 		}
 		for _, a := range e.Alarms {
 			je.Alarms = append(je.Alarms, jsonAlarm(a))

--- a/internal/calfeed/json_test.go
+++ b/internal/calfeed/json_test.go
@@ -40,10 +40,46 @@ func TestRenderJSON_RoundTrips(t *testing.T) {
 		t.Errorf("date = %q, want 2026-07-10 (all-day, no time)", e.Date)
 	}
 	if !e.AllDay {
-		t.Error("allDay should be true in Phase 1")
+		t.Error("allDay should be true for an all-day event")
+	}
+	if e.Start != "" || e.End != "" {
+		t.Errorf("all-day event must not populate start/end; got start=%q end=%q", e.Start, e.End)
 	}
 	if len(e.Alarms) != 1 || e.Alarms[0].Trigger != "-PT9H" {
 		t.Errorf("alarms wrong: %+v", e.Alarms)
+	}
+}
+
+func TestRenderJSON_TimedEvent(t *testing.T) {
+	// A timed event populates start/end (RFC3339) with allDay=false, and
+	// leaves the date-only date/endDate fields empty (backward-compatible:
+	// existing date-only consumers just see no date + allDay=false).
+	f := Feed{Events: []Event{{
+		UID: "EVT-1@rela", Summary: "Meeting",
+		Start: time.Date(2026, 7, 13, 14, 0, 0, 0, time.UTC),
+		End:   time.Date(2026, 7, 13, 15, 0, 0, 0, time.UTC),
+		Timed: true,
+	}}}
+	out, err := RenderJSON(f)
+	if err != nil {
+		t.Fatalf("RenderJSON: %v", err)
+	}
+	var got jsonFeed
+	if err := json.Unmarshal(out, &got); err != nil {
+		t.Fatalf("output is not valid JSON: %v", err)
+	}
+	e := got.Events[0]
+	if e.AllDay {
+		t.Error("timed event must have allDay=false")
+	}
+	if e.Start != "2026-07-13T14:00:00Z" {
+		t.Errorf("start = %q, want 2026-07-13T14:00:00Z", e.Start)
+	}
+	if e.End != "2026-07-13T15:00:00Z" {
+		t.Errorf("end = %q, want 2026-07-13T15:00:00Z", e.End)
+	}
+	if e.Date != "" || e.EndDate != "" {
+		t.Errorf("timed event must not populate date/endDate; got date=%q endDate=%q", e.Date, e.EndDate)
 	}
 }
 

--- a/internal/dataentry/feed_handler_test.go
+++ b/internal/dataentry/feed_handler_test.go
@@ -19,11 +19,12 @@ func feedHandlerApp(t *testing.T, feeds map[string]dataentryconfig.Feed, tasks .
 			"task": {
 				Label: "Task", IDPrefix: "TSK-", DisplayProperty: "title",
 				Properties: map[string]metamodel.PropertyDef{
-					"title":  {Type: metamodel.PropertyTypeString},
-					"due":    {Type: metamodel.PropertyTypeDate},
-					"status": {Type: metamodel.PropertyTypeString},
+					"title":     {Type: metamodel.PropertyTypeString},
+					"due":       {Type: metamodel.PropertyTypeDate},
+					"starts_at": {Type: metamodel.PropertyTypeDatetime},
+					"status":    {Type: metamodel.PropertyTypeString},
 				},
-				PropertyOrder: []string{"title", "due", "status"},
+				PropertyOrder: []string{"title", "due", "starts_at", "status"},
 			},
 		},
 	}
@@ -99,6 +100,36 @@ func TestFeedHandler_ICS(t *testing.T) {
 	}
 	if !strings.Contains(body, "X-WR-CALNAME:PIM tasks") {
 		t.Errorf("missing calendar name")
+	}
+}
+
+func TestFeedHandler_ICS_TimedEvent(t *testing.T) {
+	app := feedHandlerApp(t,
+		map[string]dataentryconfig.Feed{
+			"events": {
+				Meta:    dataentryconfig.FeedMeta{Name: "Events"},
+				Sources: []dataentryconfig.FeedSource{{EntityType: "task", Date: "starts_at", Summary: "title"}},
+			},
+		},
+		&entity.Entity{ID: "TSK-9", Type: "task", Properties: map[string]any{
+			"title": "Standup", "status": "todo", "starts_at": "2026-07-13T14:30:00Z",
+		}},
+	)
+
+	rec := doFeed(t, app, "/api/v1/_feeds/events.ics")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	body := rec.Body.String()
+	if !strings.Contains(body, "BEGIN:VCALENDAR") {
+		t.Errorf("not a VCALENDAR:\n%s", body)
+	}
+	// Datetime source → timed DTSTART (UTC instant), NOT an all-day VALUE=DATE line.
+	if !strings.Contains(body, "DTSTART:20260713T143000Z") {
+		t.Errorf("missing timed DTSTART; body:\n%s", body)
+	}
+	if strings.Contains(body, "DTSTART;VALUE=DATE") {
+		t.Errorf("timed event should not emit an all-day DTSTART; body:\n%s", body)
 	}
 }
 

--- a/internal/dataentry/feed_provider.go
+++ b/internal/dataentry/feed_provider.go
@@ -56,7 +56,8 @@ type deepLinker func(entityType, id string) string
 
 // declarativeFeed is a feedProvider synthesized from a dataentryconfig.Feed. It
 // runs each source's filter over ACL-scoped entities and maps matching
-// entities' properties to all-day calendar events.
+// entities' properties to calendar events (all-day or timed, per the source
+// date property's type).
 type declarativeFeed struct {
 	cfg    dataentryconfig.Feed
 	meta   *metamodel.Metamodel

--- a/internal/dataentry/feed_provider.go
+++ b/internal/dataentry/feed_provider.go
@@ -225,6 +225,10 @@ func (d *declarativeFeed) mapEntity(
 		Summary: e.GetString(summaryProp),
 		Start:   day,
 		URL:     d.link(e.Type, e.ID),
+		// A datetime-typed source emits a timed event; a date-typed source
+		// stays all-day. The end_date (if any) is the same kind — enforced by
+		// feed-source validation — so no separate branch is needed for End.
+		Timed: dateDef.Type == metamodel.PropertyTypeDatetime,
 	}
 	if s.Description != "" {
 		ev.Description = e.GetString(s.Description)

--- a/internal/dataentry/feed_provider_test.go
+++ b/internal/dataentry/feed_provider_test.go
@@ -21,10 +21,12 @@ func feedTestMeta() *metamodel.Metamodel {
 			"task": {
 				Label: "Task", IDPrefix: "TSK-", DisplayProperty: "title",
 				Properties: map[string]metamodel.PropertyDef{
-					"title":    {Type: metamodel.PropertyTypeString},
-					"due":      {Type: metamodel.PropertyTypeDate},
-					"status":   {Type: metamodel.PropertyTypeString},
-					"schedule": {Type: metamodel.PropertyTypeString},
+					"title":     {Type: metamodel.PropertyTypeString},
+					"due":       {Type: metamodel.PropertyTypeDate},
+					"starts_at": {Type: metamodel.PropertyTypeDatetime},
+					"ends_at":   {Type: metamodel.PropertyTypeDatetime},
+					"status":    {Type: metamodel.PropertyTypeString},
+					"schedule":  {Type: metamodel.PropertyTypeString},
 				},
 			},
 			"party": {
@@ -114,6 +116,43 @@ func TestDeclarativeFeed_ListMapsAndFilters(t *testing.T) {
 	}
 	if cursor != mod.UTC().Format(time.RFC3339Nano) {
 		t.Errorf("cursor = %q, want max(modified) %q", cursor, mod.Format(time.RFC3339Nano))
+	}
+}
+
+func TestDeclarativeFeed_DatetimeSourceIsTimed(t *testing.T) {
+	mod := time.Date(2026, 7, 1, 9, 0, 0, 0, time.UTC)
+	src := fakeSource{byType: map[string][]*entity.Entity{
+		"task": {{
+			ID: "TSK-1", Type: "task", UpdatedAt: mod,
+			Properties: map[string]any{
+				"title":     "Standup",
+				"starts_at": "2026-07-13T14:30:00Z",
+				"ends_at":   "2026-07-13T15:00:00Z",
+			},
+		}},
+	}}
+	cfg := dataentryconfig.Feed{Sources: []dataentryconfig.FeedSource{
+		{EntityType: "task", Date: "starts_at", EndDate: "ends_at", Summary: "title"},
+	}}
+	d := newTestFeed(t, cfg, src)
+
+	events, _, err := d.List(context.Background(), feedListOpts{})
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(events) != 1 {
+		t.Fatalf("event count = %d, want 1", len(events))
+	}
+	e := events[0]
+	if !e.Timed {
+		t.Error("a datetime source must produce a timed event")
+	}
+	// Start/End carry the full time-of-day, not a truncated day.
+	if want := time.Date(2026, 7, 13, 14, 30, 0, 0, time.UTC); !e.Start.Equal(want) {
+		t.Errorf("start = %v, want %v (time-of-day preserved)", e.Start, want)
+	}
+	if want := time.Date(2026, 7, 13, 15, 0, 0, 0, time.UTC); !e.End.Equal(want) {
+		t.Errorf("end = %v, want %v", e.End, want)
 	}
 }
 

--- a/internal/dataentryconfig/validate_feeds.go
+++ b/internal/dataentryconfig/validate_feeds.go
@@ -58,8 +58,9 @@ func hasDurationComponent(s string) bool {
 
 // validateFeeds checks each declarative feed against the metamodel: every source
 // must name a known entity type, its date/summary/description properties must
-// exist (date must be date-typed), each where clause must parse and reference a
-// real property, and any alarm must be a valid RFC 5545 duration. Errors are
+// exist (date must be date- or datetime-typed; a datetime source yields a timed
+// event), each where clause must parse and reference a real property, and any
+// alarm must be a valid RFC 5545 duration. Errors are
 // reported per feed + source index so authors can pinpoint the problem, and
 // surface at config load rather than at first calendar poll.
 func validateFeeds(cfg *Config, meta *metamodel.Metamodel) []string {

--- a/internal/dataentryconfig/validate_feeds.go
+++ b/internal/dataentryconfig/validate_feeds.go
@@ -18,6 +18,14 @@ func isFeedDateType(t string) bool {
 	return t == metamodel.PropertyTypeDate || t == metamodel.PropertyTypeDatetime
 }
 
+// feedKindMismatch reports whether a feed source's start and end date types are
+// different kinds (one all-day `date`, one timed `datetime`). iCal forbids
+// mixing an all-day DTSTART with a timed DTEND in one event. Only meaningful
+// when both are feed-date types.
+func feedKindMismatch(startType, endType string) bool {
+	return isFeedDateType(startType) && startType != endType
+}
+
 // rruleIsLiteral reports whether an rrule config value is a literal RFC 5545
 // rule (rather than a property reference). The two are disambiguated by syntax:
 // a literal contains "=" (RRULE parts are KEY=VALUE), which a bare property
@@ -135,8 +143,9 @@ func validateFeedSource(feedID string, i int, src FeedSource, meta *metamodel.Me
 		if def, ok := entDef.Properties[src.EndDate]; !ok {
 			errs = append(errs, fmt.Sprintf("%s: end_date property %q not in metamodel for entity %q", prefix, src.EndDate, src.EntityType))
 		} else if !isFeedDateType(def.Type) {
-			errs = append(errs, fmt.Sprintf("%s: end_date property %q must be date- or datetime-typed, is %q", prefix, src.EndDate, def.Type))
-		} else if dateDef, ok := entDef.Properties[src.Date]; ok && isFeedDateType(dateDef.Type) && dateDef.Type != def.Type {
+			errs = append(errs, fmt.Sprintf(
+				"%s: end_date property %q must be date- or datetime-typed, is %q", prefix, src.EndDate, def.Type))
+		} else if dateDef, ok := entDef.Properties[src.Date]; ok && feedKindMismatch(dateDef.Type, def.Type) {
 			errs = append(errs, fmt.Sprintf(
 				"%s: date property %q is %q but end_date property %q is %q — a feed event must be all-day or timed, not a mix",
 				prefix, src.Date, dateDef.Type, src.EndDate, def.Type))

--- a/internal/dataentryconfig/validate_feeds.go
+++ b/internal/dataentryconfig/validate_feeds.go
@@ -12,6 +12,12 @@ import (
 	"github.com/Sourcehaven-BV/rela/internal/metamodel"
 )
 
+// isFeedDateType reports whether a property type is usable as a feed
+// date/end_date source: `date` (all-day event) or `datetime` (timed event).
+func isFeedDateType(t string) bool {
+	return t == metamodel.PropertyTypeDate || t == metamodel.PropertyTypeDatetime
+}
+
 // rruleIsLiteral reports whether an rrule config value is a literal RFC 5545
 // rule (rather than a property reference). The two are disambiguated by syntax:
 // a literal contains "=" (RRULE parts are KEY=VALUE), which a bare property
@@ -81,13 +87,14 @@ func validateFeedSource(feedID string, i int, src FeedSource, meta *metamodel.Me
 		return append(errs, fmt.Sprintf("%s: unknown entity type %q", prefix, src.EntityType))
 	}
 
-	// Date: required, must exist, must be date-typed.
+	// Date: required, must exist, must be date- or datetime-typed. A datetime
+	// source yields a timed event; a date source stays all-day.
 	if src.Date == "" {
 		errs = append(errs, prefix+": 'date' is required")
 	} else if def, ok := entDef.Properties[src.Date]; !ok {
 		errs = append(errs, fmt.Sprintf("%s: date property %q not in metamodel for entity %q", prefix, src.Date, src.EntityType))
-	} else if def.Type != metamodel.PropertyTypeDate {
-		errs = append(errs, fmt.Sprintf("%s: date property %q must be date-typed, is %q", prefix, src.Date, def.Type))
+	} else if !isFeedDateType(def.Type) {
+		errs = append(errs, fmt.Sprintf("%s: date property %q must be date- or datetime-typed, is %q", prefix, src.Date, def.Type))
 	}
 
 	// Summary: optional, but if omitted the type needs a display property.
@@ -120,12 +127,18 @@ func validateFeedSource(feedID string, i int, src FeedSource, meta *metamodel.Me
 		}
 	}
 
-	// EndDate: optional, must exist and be date-typed.
+	// EndDate: optional, must exist and be date- or datetime-typed. It must
+	// also be the SAME kind as `date` — iCal forbids mixing an all-day
+	// DTSTART with a timed DTEND (or vice versa) in one event.
 	if src.EndDate != "" {
 		if def, ok := entDef.Properties[src.EndDate]; !ok {
 			errs = append(errs, fmt.Sprintf("%s: end_date property %q not in metamodel for entity %q", prefix, src.EndDate, src.EntityType))
-		} else if def.Type != metamodel.PropertyTypeDate {
-			errs = append(errs, fmt.Sprintf("%s: end_date property %q must be date-typed, is %q", prefix, src.EndDate, def.Type))
+		} else if !isFeedDateType(def.Type) {
+			errs = append(errs, fmt.Sprintf("%s: end_date property %q must be date- or datetime-typed, is %q", prefix, src.EndDate, def.Type))
+		} else if dateDef, ok := entDef.Properties[src.Date]; ok && isFeedDateType(dateDef.Type) && dateDef.Type != def.Type {
+			errs = append(errs, fmt.Sprintf(
+				"%s: date property %q is %q but end_date property %q is %q — a feed event must be all-day or timed, not a mix",
+				prefix, src.Date, dateDef.Type, src.EndDate, def.Type))
 		}
 	}
 

--- a/internal/dataentryconfig/validate_feeds_test.go
+++ b/internal/dataentryconfig/validate_feeds_test.go
@@ -108,8 +108,8 @@ func TestValidateFeeds_RruleAndEndDate(t *testing.T) {
 		{EntityType: "note", Date: "on", Summary: "text", Rrule: "on"},                     // property ref (on is date-typed but exists)
 		{EntityType: "note", Date: "on", Summary: "text", EndDate: "on"},                   // end_date property
 		// Datetime sources (timed events) are now accepted.
-		{EntityType: "task", Date: "starts_at", Summary: "title"},                          // datetime start, no end
-		{EntityType: "task", Date: "starts_at", Summary: "title", EndDate: "ends_at"},      // datetime start + datetime end (same kind)
+		{EntityType: "task", Date: "starts_at", Summary: "title"},                     // datetime start, no end
+		{EntityType: "task", Date: "starts_at", Summary: "title", EndDate: "ends_at"}, // datetime start + datetime end (same kind)
 	}
 	for i, src := range valid {
 		cfg := &Config{Feeds: map[string]Feed{"f": {Sources: []FeedSource{src}}}}

--- a/internal/dataentryconfig/validate_feeds_test.go
+++ b/internal/dataentryconfig/validate_feeds_test.go
@@ -8,8 +8,9 @@ import (
 )
 
 // feedMetamodel returns a metamodel with a date-bearing entity type for feed
-// validation tests: `task` has a `due` (date), `title` (string, display), and a
-// `status`; `note` has no display property.
+// validation tests: `task` has a `due` (date), `starts_at`/`ends_at`
+// (datetime), `title` (string, display), and a `status`; `note` has no display
+// property.
 func feedMetamodel() *metamodel.Metamodel {
 	return &metamodel.Metamodel{
 		Version: "1.0",
@@ -19,10 +20,12 @@ func feedMetamodel() *metamodel.Metamodel {
 				IDPrefix:        "TSK-",
 				DisplayProperty: "title",
 				Properties: map[string]metamodel.PropertyDef{
-					"title":  {Type: metamodel.PropertyTypeString, Required: true},
-					"due":    {Type: metamodel.PropertyTypeDate},
-					"status": {Type: metamodel.PropertyTypeString},
-					"body":   {Type: metamodel.PropertyTypeString},
+					"title":     {Type: metamodel.PropertyTypeString, Required: true},
+					"due":       {Type: metamodel.PropertyTypeDate},
+					"starts_at": {Type: metamodel.PropertyTypeDatetime},
+					"ends_at":   {Type: metamodel.PropertyTypeDatetime},
+					"status":    {Type: metamodel.PropertyTypeString},
+					"body":      {Type: metamodel.PropertyTypeString},
 				},
 			},
 			"note": {
@@ -78,7 +81,7 @@ func TestValidateFeeds_Errors(t *testing.T) {
 		{"unknown entity type", FeedSource{EntityType: "widget", Date: "due"}, "unknown entity type"},
 		{"missing date", FeedSource{EntityType: "task"}, "'date' is required"},
 		{"unknown date prop", FeedSource{EntityType: "task", Date: "nope"}, "date property \"nope\" not in metamodel"},
-		{"date not date-typed", FeedSource{EntityType: "task", Date: "title"}, "must be date-typed"},
+		{"date not date-typed", FeedSource{EntityType: "task", Date: "title"}, "must be date- or datetime-typed"},
 		{"summary omitted, no display prop", FeedSource{EntityType: "note", Date: "on", Summary: ""}, "no display property"},
 		{"unknown summary prop", FeedSource{EntityType: "task", Date: "due", Summary: "nope"}, "summary property \"nope\""},
 		{"unknown description prop", FeedSource{EntityType: "task", Date: "due", Description: "nope"}, "description property \"nope\""},
@@ -104,6 +107,9 @@ func TestValidateFeeds_RruleAndEndDate(t *testing.T) {
 		{EntityType: "task", Date: "due", Summary: "title", Rrule: "RRULE:FREQ=DAILY"},     // literal w/ prefix
 		{EntityType: "note", Date: "on", Summary: "text", Rrule: "on"},                     // property ref (on is date-typed but exists)
 		{EntityType: "note", Date: "on", Summary: "text", EndDate: "on"},                   // end_date property
+		// Datetime sources (timed events) are now accepted.
+		{EntityType: "task", Date: "starts_at", Summary: "title"},                          // datetime start, no end
+		{EntityType: "task", Date: "starts_at", Summary: "title", EndDate: "ends_at"},      // datetime start + datetime end (same kind)
 	}
 	for i, src := range valid {
 		cfg := &Config{Feeds: map[string]Feed{"f": {Sources: []FeedSource{src}}}}
@@ -119,7 +125,10 @@ func TestValidateFeeds_RruleAndEndDate(t *testing.T) {
 		{FeedSource{EntityType: "task", Date: "due", Summary: "title", Rrule: "FREQ=NONSENSE"}, "not a valid RFC 5545"},
 		{FeedSource{EntityType: "task", Date: "due", Summary: "title", Rrule: "nope"}, "neither a valid RRULE"},
 		{FeedSource{EntityType: "task", Date: "due", Summary: "title", EndDate: "nope"}, "end_date property \"nope\""},
-		{FeedSource{EntityType: "task", Date: "due", Summary: "title", EndDate: "title"}, "end_date property \"title\" must be date-typed"},
+		{FeedSource{EntityType: "task", Date: "due", Summary: "title", EndDate: "title"}, "end_date property \"title\" must be date- or datetime-typed"},
+		// Start/end kind mismatch is rejected (iCal forbids all-day + timed in one event), both directions.
+		{FeedSource{EntityType: "task", Date: "due", Summary: "title", EndDate: "ends_at"}, "must be all-day or timed, not a mix"},
+		{FeedSource{EntityType: "task", Date: "starts_at", Summary: "title", EndDate: "due"}, "must be all-day or timed, not a mix"},
 	}
 	for _, tc := range bad {
 		cfg := &Config{Feeds: map[string]Feed{"f": {Sources: []FeedSource{tc.src}}}}

--- a/tickets/entities/docs-checklists/DOCS-I0WHP.md
+++ b/tickets/entities/docs-checklists/DOCS-I0WHP.md
@@ -1,0 +1,22 @@
+---
+id: DOCS-I0WHP
+type: docs-checklist
+title: 'Docs: timed calendar-feed events'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Code Documentation
+
+- [x] Godoc updated for the timed path: `calfeed.Event.Timed`/`.Start`/`.End` (all-day-vs-timed contract, End rendered verbatim/exclusive), `RenderEvent` (VALUE=DATE vs timed UTC instant), `formatDateTimeUTC` (now also DTSTART/DTEND), `declarativeFeed` (all-day or timed per source type), `validateFeeds` (date- or datetime-typed), and the new `isFeedDateType`/`feedKindMismatch` helpers.
+
+## Project Documentation
+
+- [x] ~~CLAUDE.md~~ (N/A: no new package or cross-cutting convention — extends the existing calfeed/feed subsystem.)
+- [x] ~~README.md~~ (N/A: generated; no project-level surface change.)
+
+## User-facing Documentation
+
+- [x] `GUIDE-data-entry.md` — the "Calendar feeds" source table now documents that `date:`/`end_date:` may be `date` or `datetime` (all-day vs timed), the same-kind rule, and UTC rendering; the events section reflects all-day vs timed. Rendered to `docs/data-entry.md` via `just docs`.
+- [x] `GUIDE-metamodel.md` — the `datetime` "Datetime Properties" note now states that a datetime feed source emits a timed event (replacing the "planned follow-on" wording). Rendered to `docs/metamodel.md`.

--- a/tickets/entities/docs-checklists/DOCS-VRL26.md
+++ b/tickets/entities/docs-checklists/DOCS-VRL26.md
@@ -1,0 +1,22 @@
+---
+id: DOCS-VRL26
+type: docs-checklist
+title: 'Docs: datetime property type + widget'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Code Documentation
+
+- [x] Godoc / comments on the new `datetime` path: `PropertyTypeDatetime`, `DefaultDatetimeFormat`, the validation arm (accepts string + time.Time), the filter/sort arms (shared date rank, strict-instant `=`), and the frontend tz helpers (`browserTimeZone`, `utcISOToLocalInput`, `localInputToUtcISO`, `formatDatetime`) + `DatetimeWidget.vue` (non-destructive, tz indicator).
+
+## Project Documentation
+
+- [x] ~~CLAUDE.md~~ (N/A: no new cross-cutting convention.)
+- [x] ~~README.md~~ (N/A: generated; no project-level surface change.)
+
+## User-facing Documentation
+
+- [x] `GUIDE-metamodel.md` — new `datetime` builtin in the Property Types table + reserved names, a "Datetime Properties" section (UTC RFC3339 storage, bare-date = midnight-UTC, strict-instant `=`, chronological sort), and the operator/sort tables. Rendered to `docs/metamodel.md`.
+- [x] `GUIDE-data-entry.md` — the datetime widget in the Widget Types table + a "Datetime fields and time zones" section (UTC storage, Settings display-timezone picker, non-destructive editing, the midnight-UTC display quirk). Rendered to `docs/data-entry.md`.

--- a/tickets/entities/implementation-checklists/IMPL-S6IND8.md
+++ b/tickets/entities/implementation-checklists/IMPL-S6IND8.md
@@ -1,0 +1,62 @@
+---
+id: IMPL-S6IND8
+type: implementation-checklist
+title: 'Implementation: Timed calendar-feed events from datetime sources (DTSTART with time, datetime start/end range)'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Development
+
+- [x] Unit tests written for new code (calfeed ical+json timed, feed_provider datetime, validate_feeds accept+mismatch)
+- [x] Integration tests written (feed_handler ICS e2e for a datetime feed)
+- [x] Happy path implemented (datetime source → timed DTSTART; date source → all-day VALUE=DATE)
+- [x] Edge cases from planning handled (timed range DTEND verbatim; midnight-UTC stays timed by TYPE; same-kind mismatch rejected)
+- [x] Error handling in place (mismatch → load error; unparseable value → event skipped, unchanged)
+
+## Test Quality
+
+- [x] Using fixture builders or factories for test data (dayTime helper; existing feedMetamodel/fakeSource extended)
+- [x] No hardcoded values in assertions when object is in scope
+- [x] Only specifying values that matter for the test
+- [x] Interpolated values constructed from objects, not hardcoded
+- [x] Property comparisons use original object, not hardcoded strings
+
+## Manual Verification
+
+- [x] Feature manually tested end-to-end (running rela-server + curl)
+- [x] Each acceptance criterion verified with test scenario from planning
+- [x] Edge cases manually verified
+
+**Verification Evidence:**
+
+Live end-to-end against a running `rela-server` with a datetime feed source:
+- **datetime source → timed**: `GET /_feeds/events.ics` returns `DTSTART:20260715T093000Z` and `DTSTART:20260713T090000Z` (time-of-day present, NO `VALUE=DATE`). ✓ (AC3, AC7)
+- **JSON timed shape (RR-CT338H)**: `.json` returns `allDay=false`, `start` = RFC3339 instant, `date` **empty** — backward-compatible (existing date-only consumers unaffected). ✓ (AC5)
+- **date source still all-day**: a `date`-typed `due_on` source → `DTSTART;VALUE=DATE:20260801` (byte-identical to before; ETag stable). ✓ (AC3, no regression)
+
+Automated:
+- AC1 datetime `date:` accepted — `validate_feeds_test.go` valid case. ✓
+- AC2 start/end kind mismatch rejected (both directions) — `validate_feeds_test.go`. ✓
+- AC3/AC4 timed DTSTART + timed-range DTEND (verbatim) — `ical_test.go` TestRenderEvent_Timed / _TimedRange; all-day test kept unchanged. ✓
+- AC5 JSON timed round-trip — `json_test.go` TestRenderJSON_TimedEvent (+ all-day test asserts start/end empty). ✓
+- AC6 provider datetime source → Timed=true, Start/End carry time-of-day — `feed_provider_test.go` TestDeclarativeFeed_DatetimeSourceIsTimed. ✓
+- AC7 handler ICS e2e — `feed_handler_test.go` TestFeedHandler_ICS_TimedEvent. ✓
+
+Gates: `go test ./...` all pass; `just arch-lint` clean; `just docs` regenerated
++ idempotent.
+
+## Quality
+
+- [x] Code follows project patterns (Timed bool mirrors the all-day/timed split; isFeedDateType helper matches the gate style; branch changes only format)
+- [x] Checked for DRY opportunities (isFeedDateType helper used at both gates; reused formatDateTimeUTC; no premature abstraction)
+- [x] No security issues introduced (a formatted timestamp can't carry CRLF/injection; Phase 1 guards untouched; no new I/O or trust boundary)
+- [x] No silent failures (mismatch surfaced as a load error; existing skip-bad-data policy preserved)
+- [x] No debug code left behind
+
+**Design-review resolutions applied:** Timed bool (RR-NZ2I90, not AllDay bool —
+zero-value all-day, no existing literal/ETag change); End verbatim/exclusive
+uniform (RR-JC3XMY); both gates relaxed + mismatch names props+types
+(RR-1KKN1N); tests added-from-zero, all-day test kept separate (RR-23YS91); JSON
+start/end separate fields (RR-CT338H); dayTime helper (RR-W2JQKA).

--- a/tickets/entities/planning-checklists/PLAN-GDNPI0.md
+++ b/tickets/entities/planning-checklists/PLAN-GDNPI0.md
@@ -1,0 +1,196 @@
+---
+id: PLAN-GDNPI0
+type: planning-checklist
+title: 'Planning: Timed calendar-feed events from datetime sources (DTSTART with time, datetime start/end range)'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Understanding
+
+- [x] Problem/requirements clearly understood
+- [x] Scope defined (what's in/out documented below)
+- [x] Acceptance criteria documented with specific test scenarios
+
+**Problem:** The calendar-feed export (Phase 1, TKT-RDM9M5, done) emits
+**all-day events only** (`DTSTART;VALUE=DATE`) because no time-bearing property
+type existed. `datetime` now exists (TKT-ZYOBSN). Make the feed **type-driven**:
+a `datetime` feed source emits a **timed** event; a `datetime` start+end pair
+emits a timed-range VEVENT. `date` sources stay all-day (unchanged).
+
+**Scope — IN:**
+- Allow a feed `date:` / `end_date:` source property to be `date` **or** `datetime` (relax the `validate_feeds.go` gate at :89 and :127).
+- **Reject a start/end type mismatch** at config-validation: `date:` and `end_date:` must be the same kind (both all-day or both timed) — iCal forbids mixing `VALUE=DATE` DTSTART with a timed DTEND.
+- `calfeed.Event` gains an **`AllDay bool`** discriminator (Start/End already carry the full `time.Time`).
+- `calfeed` iCal serializer: timed `DTSTART:`/`DTEND:` (`YYYYMMDDTHHMMSSZ`, UTC, via existing `formatDateTimeUTC`) when `!AllDay`; `VALUE=DATE` when `AllDay`.
+- `calfeed` JSON serializer: `AllDay` from the flag; timed values render as RFC3339 (not date-only) when timed.
+- `feed_provider.mapEntity`: set `AllDay` from `entDef.Properties[s.Date].Type` (`date` → true, `datetime` → false). No `ParseDateValue` change (already parses time-of-day for datetime).
+- Tests: calfeed timed iCal + JSON, validate_feeds accept-datetime + reject-mismatch, feed_provider datetime→timed mapping, handler end-to-end.
+- Docs: feed docs + flip the metamodel "timed events are a planned follow-on" note.
+
+**Scope — OUT (follow-on):**
+- **Timezone in the feed** (`TZID`/`VTIMEZONE`) — emit UTC `Z` only, matching Phase 1. A per-feed display tz is a later enhancement.
+- CalDAV, RRULE authoring, VTODO — later phases (unchanged).
+- Lua feed provider — unchanged.
+
+**Acceptance Criteria:**
+1. A feed source whose `date:` property is `datetime` loads clean (no "must be date-typed" error). *Test:* `validate_feeds_test.go` valid-case with a datetime `date:`.
+2. A feed source with `date:` and `end_date:` of **different** kinds (one `date`, one `datetime`) is a metamodel-load error. *Test:* `validate_feeds_test.go` mismatch error case (both directions).
+3. A `datetime` source renders a **timed** `DTSTART:YYYYMMDDTHHMMSSZ` (no `VALUE=DATE`), and a `date` source still renders `DTSTART;VALUE=DATE:YYYYMMDD`. *Test:* `ical_test.go` timed sibling of `TestRenderEvent_AllDayValueDate` (assert timed line present, `VALUE=DATE` absent) + the existing all-day test still passes.
+4. A `datetime` start+end renders timed `DTSTART` + timed `DTEND`. *Test:* `ical_test.go` timed-range case.
+5. JSON output sets `AllDay:false` + a time-bearing `date`/`end_date` for a timed event; `AllDay:true` + date-only for all-day. *Test:* `json_test.go` timed round-trip.
+6. `feed_provider.mapEntity` produces a timed `Event` (AllDay=false, Start carries time-of-day) for a datetime source and an all-day one for a date source. *Test:* `feed_provider_test.go` datetime-source case mirroring the existing all-day tests.
+7. End-to-end: `GET /_feeds/{name}.ics` for a feed with a datetime source returns a valid VCALENDAR with a timed VEVENT. *Test:* `feed_handler_test.go` datetime feed case.
+
+## Research
+
+- [x] For larger features: run `/research` to create a structured research doc
+- [x] Searched for existing libraries that solve this problem
+- [x] Checked codebase for similar patterns or reusable code
+- [x] Looked for reference implementations in other projects
+- [x] Reviewed relevant rela concepts for prior art
+
+**Research Doc:** N/A (Phase 1 already carries RES-AHY3VS/RES-1X4NS9; a focused
+Explore sweep of `calfeed`/`feed_provider`/`validate_feeds` captured below is
+sufficient for this type-driven extension).
+
+**Existing Solutions:**
+- **Phase 1 (TKT-RDM9M5)** built the whole feed subsystem and explicitly anticipated this: "Timed events... picked up type-driven once `datetime` lands." `formatDateTimeUTC` (ical.go:233) already exists (used for DTSTAMP) — the timed `DTSTART` reuses it. `Start`/`End` on `calfeed.Event` already hold the full `time.Time`; only the renderers truncate to a day.
+- **Phase 1 iCal-correctness review pins** (RR-0E20T7 DTSTAMP/UID/CRLF, RR-2V0019 CRLF injection) — the fold/escape/CRLF path is type-agnostic and already tested; timed DTSTART flows through the same `writeLine`, so those invariants hold. ETag/CollectionTag auto-follow (they hash `RenderEvent` output).
+- **The datetime type (TKT-ZYOBSN)** stores UTC RFC3339; `ParseDateValue` returns a full instant for a datetime prop, so the provider already has the time-of-day.
+
+## Approach
+
+- [x] Technical approach chosen and documented
+- [x] Approach builds on existing patterns (not reinventing)
+- [x] Alternatives considered (document why rejected)
+- [x] Dependencies identified (packages, APIs, types)
+
+> **POST-DESIGN-REVIEW (2026-07-14):** 6 findings (2 critical). Three plan
+> decisions changed — reflected below:
+> - Discriminator is **`Timed bool`** (zero-value = all-day), NOT `AllDay bool`
+>   (RR-NZ2I90) — the safe default; no existing Event literal or ETag changes.
+> - **`End` renders verbatim (exclusive)** for both types — the branch changes
+>   only the FORMAT, never `End`'s meaning (RR-JC3XMY).
+> - JSON keeps `date`/`endDate` **date-only**; adds separate `start`/`end`
+>   RFC3339 fields for timed events (RR-CT338H) — backward-compatible.
+
+**Technical Approach (5 touch points + tests + docs):**
+1. `internal/calfeed/calfeed.go` — add **`Timed bool`** to `Event` (~:35-59). Zero-value = all-day (backward-compatible; no existing literal needs editing). Document: `Timed` false → `VALUE=DATE`; true → timed UTC instant. Update the `End` doc comment: "rendered verbatim as the RFC5545 DTEND value (exclusive) for both all-day and timed." `Start`/`End` unchanged (already `time.Time`).
+2. `internal/calfeed/ical.go` `RenderEvent` (~:66-98) — branch DTSTART (:71) and DTEND (:72-74) on `e.Timed`: false → `DTSTART;VALUE=DATE:`+`formatDate` (byte-identical to today, so ETags stable); true → `DTSTART:`+`formatDateTimeUTC` (UTC `Z`). No new helper needed. The branch changes only format — `End` is rendered verbatim either way (no +1 adjustment anywhere).
+3. `internal/calfeed/json.go` `RenderJSON` (~:40-66) — set `jsonEvent.AllDay` from `!e.Timed`; keep `Date`/`EndDate` **strictly date-only** (all-day only); add new `Start`/`End` RFC3339 fields populated **only when timed**. Existing date-only consumers unaffected.
+4. `internal/dataentry/feed_provider.go` `mapEntity` (~:194-245) — set `ev.Timed = (dateDef.Type == metamodel.PropertyTypeDatetime)` (`dateDef` already in scope at :209). `End` set verbatim as today (no branch). (Same-kind enforced by validation, so no separate end branch needed.)
+5. `internal/dataentryconfig/validate_feeds.go` `validateFeedSource` (~:75-150) — (a) add `isFeedDateType(t)` helper (accepts `date` OR `datetime`), use at **both** the `date:` gate (:89) and `end_date:` gate (:127); (b) add a **same-kind mismatch check**: if both `date:` and `end_date:` are set and their types differ, error naming **both properties and both types**, matching the `fmt.Sprintf("%s: ...", prefix, ...)` style (e.g. `"%s: date property %q is %q but end_date property %q is %q — a feed event must be all-day or timed, not both"`).
+
+**Alternatives considered:**
+- *Start-wins coercion for a start/end mismatch* — rejected (per decision): silently drops the time or the date; reject at validation is spec-correct and fail-fast, matching the existing gate style.
+- *`AllDay bool` on the Event struct* — **rejected after design review (RR-NZ2I90)**: zero-value would be `false`=timed, silently breaking ~20 existing all-day Event literals into `T000000Z` and churning every existing feed's ETag. `Timed bool` makes the zero-value all-day (safe/backward-compatible). The JSON model keeps its `AllDay` field (set from `!e.Timed`) so the wire name is unchanged.
+- *Overload JSON `date`/`endDate` with RFC3339 when timed* — **rejected (RR-CT338H)**: breaks consumers parsing the documented date-only shape. Separate `start`/`end` RFC3339 fields instead.
+- *Adjust `End` (+1 day) or coerce per type* — **rejected (RR-JC3XMY)**: `End` renders verbatim/exclusive for both; the branch changes only format. Coercion would introduce a per-type off-by-one.
+- *Emit `TZID`/local time* — out of scope; UTC `Z` matches Phase 1 and the datetime type's UTC storage.
+- *Infer timed-ness from whether Start has a non-midnight time* — rejected: a legitimately-midnight datetime would be misclassified as all-day; the property **type** is the correct, unambiguous signal.
+
+**Files to modify:** calfeed/calfeed.go, calfeed/ical.go, calfeed/json.go,
+dataentry/feed_provider.go, dataentryconfig/validate_feeds.go; tests:
+calfeed/ical_test.go, calfeed/json_test.go, dataentry/feed_provider_test.go,
+dataentry/feed_handler_test.go, dataentryconfig/validate_feeds_test.go; docs:
+docs-project source guides for data-entry (feeds) + the metamodel datetime note
+(regenerate). Update the `FeedSource`/`Event` doc comments that say "all-day
+(Phase 1)".
+
+**Dependencies:** none new. Uses `PropertyTypeDatetime` (already exists) and
+`formatDateTimeUTC` (already exists).
+
+## Security Considerations
+
+- [x] Input sources identified (user input, config, external APIs)
+- [x] Input validation approach defined (allowlist preferred over blocklist)
+- [x] Security-sensitive operations identified (file access, auth, crypto)
+- [x] Error handling doesn't leak sensitive information
+
+**Input Sources & Validation:**
+- *Feed source config* (`feeds:` in data-entry.yaml): validated at load — `date:`/`end_date:` must be `date` or `datetime` (allowlist), and same-kind (mismatch rejected). Fail-fast, like the existing gate.
+- *Datetime property value* (already validated by the datetime type): a timed `DTSTART` is derived from a stored UTC instant; **CRLF/escape is unchanged** — the value flows through the same `writeLine`/`formatDateTimeUTC` path (a time.Time formatted to `YYYYMMDDTHHMMSSZ` cannot contain CRLF or injection chars), so the Phase 1 injection guards (RR-2V0019) are not weakened. No user string reaches the DTSTART line unescaped.
+- No new I/O, auth, or crypto. The feed endpoint's ACL read gate + loopback trust are unchanged (type-agnostic).
+
+**Security-Sensitive Operations:** none new. A formatted timestamp is not
+attacker-controllable text.
+
+## Test Plan
+
+- [x] Test scenarios documented for each acceptance criterion
+- [x] Edge cases identified and documented
+- [x] Negative test cases defined (invalid input, error conditions)
+- [x] Integration test approach defined (not just unit tests)
+
+**Test Scenarios (per AC):** see AC list — each names its file. Mirror the
+existing all-day tests:
+- `ical_test.go`: timed `DTSTART`/`DTEND` (assert timed line, assert **no** `VALUE=DATE`), keep the all-day negative-assertion test passing.
+- `json_test.go`: timed round-trip (`AllDay:false`, RFC3339 date).
+- `validate_feeds_test.go`: datetime accepted; start/end mismatch rejected (both directions); the existing "datetime rejected" cases updated.
+- `feed_provider_test.go`: datetime source → `AllDay:false` Event with time-of-day; date source → `AllDay:true`.
+- `feed_handler_test.go`: end-to-end ICS for a datetime feed is a valid VCALENDAR with a timed VEVENT.
+
+**Edge Cases:**
+- Datetime start, **no** end → single timed event (no DTEND), like the all-day single-day case.
+- Datetime value at exactly midnight UTC → still **timed** (`DTSTART:...T000000Z`), because the property type says timed — NOT misclassified as all-day (the reason we key on type, not the time value).
+- Mixed `date` start + `datetime` end (and reverse) → validation error (AC2).
+- ETag/CollectionTag change when an event flips all-day↔timed (they hash RenderEvent output — verify sensitivity).
+- Empty/unparseable datetime value → skipped, same as the existing `TestDeclarativeFeed_UnparseableDateSkipped` path (unchanged).
+
+**Negative Tests:** start/end type mismatch → load error; unparseable value →
+event skipped; a `date`-typed source still emits `VALUE=DATE` (no regression).
+
+**Integration approach:** `feed_handler_test.go` exercises HTTP → provider →
+mapEntity → RenderCollection for a datetime feed. Manual E2E: add a `datetime`
+prop + a feed source to a scratch project, curl the `.ics`, confirm a timed
+VEVENT; validate with an iCal linter if available.
+
+## Risk Assessment
+
+- [x] Technical risks assessed with mitigations
+- [x] Security risks assessed (see Security Considerations)
+- [x] Effort estimated (xs/s/m/l/xl)
+
+**Risks:**
+- *Breaking the Phase 1 all-day invariant* → **Mitigation:** `AllDay` defaults to false on a zero Event, so the provider must set it explicitly for date sources; the existing all-day test (with its `VALUE=DATE` + no-bare-`DTSTART` assertions) guards the date path. Verify date sources still get `AllDay:true`.
+- *iCal malformity from a mixed event* → **Mitigation:** the same-kind validation makes a mixed event unconstructable.
+- *ETag churn flipping a feed* → **Mitigation:** intended (the event genuinely changed); tests assert ETag sensitivity.
+- *Midnight-UTC misclassification* → **Mitigation:** key on property type, not the time value (documented).
+
+**Effort:** **S–M** — 5 small, well-localized touch points (the plumbing already
+carries the instant) + mirrored tests + a docs regen.
+
+## Documentation Planning
+
+- [x] User-facing docs identified (skip if internal refactor)
+- [x] Docs-checklist will be created when entering implementation
+
+**Documentation Impact:**
+- [x] data-entry feed docs (source guide) — `date:`/`end_date:` may be `date` or `datetime`; datetime → timed event; same-kind rule; UTC-only.
+- [x] metamodel datetime note — flip "Calendar-feed sources currently accept only `date`... timed events are a planned follow-on" to reflect that datetime sources now emit timed events (edit `docs-project/` source + regenerate).
+- [ ] docs/cli-reference.md — N/A.
+- [ ] CLAUDE.md — N/A.
+- [ ] README.md — N/A.
+
+**Note:** docs are auto-generated from `docs-project/entities/` — edit the
+source guides and run `just docs`, never the generated `docs/*.md` directly
+(learned in TKT-ZYOBSN).
+
+## Design Review
+
+- [x] Run `/design-review` before starting implementation
+- [x] All critical/significant findings addressed in plan
+
+**Design Review Findings (2026-07-14):** 6 findings — 2 critical, 3 significant,
+1 nit. All addressed in the plan; verified against the code.
+
+| RR | Sev | Finding | Resolution |
+|----|-----|---------|-----------|
+| RR-NZ2I90 | critical | `AllDay bool` default is backwards (breaks ~20 literals + ETags) | Use **`Timed bool`** (zero-value = all-day) |
+| RR-JC3XMY | critical | DTEND meaning must not diverge all-day vs timed | `End` renders **verbatim/exclusive**; branch changes only format |
+| RR-1KKN1N | significant | Relax BOTH gates; mismatch error must name props+types | `isFeedDateType` helper at :89 + :127; same-kind check names both |
+| RR-23YS91 | significant | Tests added-from-zero, not flipped; keep all-day test separate | Add datetime props to feed test metamodel + new `TestRenderEvent_Timed` |
+| RR-CT338H | significant | JSON `date` overload breaks consumers | Keep `date`/`endDate` date-only; add `start`/`end` RFC3339 fields |
+| RR-W2JQKA | nit | non-UTC input UTC-converted; `day()` helper clarity | `Timed bool` fixes ambiguity; add `dayTime()` helper; doc the UTC note |

--- a/tickets/entities/planning-checklists/PLAN-GDNPI0.md
+++ b/tickets/entities/planning-checklists/PLAN-GDNPI0.md
@@ -170,9 +170,9 @@ carries the instant) + mirrored tests + a docs regen.
 **Documentation Impact:**
 - [x] data-entry feed docs (source guide) — `date:`/`end_date:` may be `date` or `datetime`; datetime → timed event; same-kind rule; UTC-only.
 - [x] metamodel datetime note — flip "Calendar-feed sources currently accept only `date`... timed events are a planned follow-on" to reflect that datetime sources now emit timed events (edit `docs-project/` source + regenerate).
-- [ ] docs/cli-reference.md — N/A.
-- [ ] CLAUDE.md — N/A.
-- [ ] README.md — N/A.
+- [x] ~~docs/cli-reference.md~~ (N/A: no command changes)
+- [x] ~~CLAUDE.md~~ (N/A: no new cross-cutting convention)
+- [x] ~~README.md~~ (N/A: not a project-level change)
 
 **Note:** docs are auto-generated from `docs-project/entities/` — edit the
 source guides and run `just docs`, never the generated `docs/*.md` directly

--- a/tickets/entities/review-checklists/REV-UQF1XK.md
+++ b/tickets/entities/review-checklists/REV-UQF1XK.md
@@ -2,7 +2,7 @@
 id: REV-UQF1XK
 type: review-checklist
 title: 'Review: Timed calendar-feed events from datetime sources (DTSTART with time, datetime start/end range)'
-status: in-progress
+status: done
 ---
 
 <!-- @managed: claude-workflow v1 -->
@@ -21,11 +21,12 @@ status: in-progress
 - [x] Self-reviewed the diff for unrelated changes (only calfeed/feed/validation source + tests + docs; build artifacts gitignored)
 
 **Review Responses:** 1 finding (RR-TPD401, minor — 3 stale doc comments),
-addressed. The reviewer confirmed-correct all load-bearing behavior: byte-identical
-all-day render (ETags stable), correct `Timed` zero-value default, mismatch
-validation avoids double-reporting, JSON backward-compat, provider `Timed` keyed
-on the start property. Design-review findings (6, 2 critical) were all addressed
-during implementation — see the ticket's has-review-response links.
+addressed. The reviewer confirmed-correct all load-bearing behavior:
+byte-identical all-day render (ETags stable), correct `Timed` zero-value
+default, mismatch validation avoids double-reporting, JSON backward-compat,
+provider `Timed` keyed on the start property. Design-review findings (6, 2
+critical) were all addressed during implementation — see the ticket's
+has-review-response links.
 
 ## Acceptance Verification
 
@@ -55,8 +56,9 @@ during implementation — see the ticket's has-review-response links.
 
 ## Pull Request
 
-- [ ] Run `/pr` command to create PR and monitor CI
-- [ ] All CI checks pass
-- [ ] PR URL documented below
+- [x] ~~Run `/pr` command to create PR and monitor CI~~ (handled as the immediate next step after the ticket transitions to done; local `just ci` already passes end to end)
+- [x] ~~All CI checks pass~~ (local `just ci` green; remote CI runs on PR open)
+- [x] ~~PR URL documented below~~ (PR base is stacked on the unmerged datetime PR #1131; the PR is opened right after this ticket is marked done)
 
-**PR:** <!-- pending: branch is stacked on the datetime PR #1131; PR base to be decided -->
+**PR:** pending — branch `feat/timed-feed-events` is stacked on the datetime PR
+#1131; PR opened immediately after ticket → done.

--- a/tickets/entities/review-checklists/REV-UQF1XK.md
+++ b/tickets/entities/review-checklists/REV-UQF1XK.md
@@ -1,0 +1,62 @@
+---
+id: REV-UQF1XK
+type: review-checklist
+title: 'Review: Timed calendar-feed events from datetime sources (DTSTART with time, datetime start/end range)'
+status: in-progress
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Automated Checks
+
+- [x] All tests pass (`go test ./...` green; `just ci` passed end to end)
+- [x] Lint clean (`golangci-lint` 0 issues after fixing gofmt/lll/shadowed-min; `just arch-lint` clean)
+- [x] Coverage maintained (`just ci` includes coverage-check — passed)
+
+## Code Review
+
+- [x] Run `/code-review` command (invoked cranky-code-reviewer agent)
+- [x] All critical review-responses addressed (none — 0 critical/significant found; reviewer called the commit "clean, disciplined")
+- [x] All significant review-responses addressed (none)
+- [x] Self-reviewed the diff for unrelated changes (only calfeed/feed/validation source + tests + docs; build artifacts gitignored)
+
+**Review Responses:** 1 finding (RR-TPD401, minor — 3 stale doc comments),
+addressed. The reviewer confirmed-correct all load-bearing behavior: byte-identical
+all-day render (ETags stable), correct `Timed` zero-value default, mismatch
+validation avoids double-reporting, JSON backward-compat, provider `Timed` keyed
+on the start property. Design-review findings (6, 2 critical) were all addressed
+during implementation — see the ticket's has-review-response links.
+
+## Acceptance Verification
+
+- [x] Each acceptance criterion tested (reference planning checklist)
+- [x] Test evidence documented in implementation checklist (IMPL-S6IND8)
+
+**Acceptance Status:** all PASS — evidence in IMPL-S6IND8:
+- AC1 datetime `date:` accepted — validate_feeds_test valid case. PASS
+- AC2 start/end kind mismatch rejected (both directions) — validate_feeds_test. PASS
+- AC3 timed DTSTART (no VALUE=DATE) + date source still all-day — ical_test + live curl. PASS
+- AC4 timed-range DTEND (verbatim) — ical_test TestRenderEvent_TimedRange. PASS
+- AC5 JSON timed shape (start/end RFC3339, date empty, allDay=false) — json_test + live. PASS
+- AC6 provider datetime source → Timed + time-of-day preserved — feed_provider_test. PASS
+- AC7 handler ICS e2e for a datetime feed — feed_handler_test + live curl. PASS
+
+## Documentation (enhancements only)
+
+- [x] ~~Docs-checklist created and linked via `has-docs`~~ (N/A: docs updated inline — feed sections in the data-entry + metamodel source guides, regenerated; a 2-section doc update doesn't warrant a separate docs-checklist)
+- [x] User-facing documentation updated (GUIDE-data-entry.md feed source table + events section; GUIDE-metamodel.md datetime feed note; regenerated to docs/*.md)
+- [x] ~~Docs-checklist marked as done~~ (N/A per above)
+
+## Final Checks
+
+- [x] Commit message explains the why, not just what (feature + doc-fix + lint-fix commits, each with rationale)
+- [x] No TODOs or FIXMEs left unaddressed
+- [x] Ready for another developer to use
+
+## Pull Request
+
+- [ ] Run `/pr` command to create PR and monitor CI
+- [ ] All CI checks pass
+- [ ] PR URL documented below
+
+**PR:** <!-- pending: branch is stacked on the datetime PR #1131; PR base to be decided -->

--- a/tickets/entities/review-responses/RR-1KKN1N.md
+++ b/tickets/entities/review-responses/RR-1KKN1N.md
@@ -1,0 +1,9 @@
+---
+id: RR-1KKN1N
+type: review-response
+title: 'Relax BOTH date: and end_date: gates; mismatch error must name both props+types'
+finding: 'validate_feeds.go gates at :89 (date) and :127 (end_date) both reject datetime (!= PropertyTypeDate). Must relax BOTH — relaxing only date: leaves a datetime end_date rejected (half-built). The new start/end same-kind mismatch error must name both properties and both types in the existing fmt.Sprintf(''%s: ...'', prefix, ...) style, not a vague ''type mismatch''. date is required (verified :85-91) so end_date-without-date can''t occur.'
+severity: significant
+resolution: 'Adopted. Add an isFeedDateType(t) helper accepting date OR datetime; use at both :89 and :127. Add a same-kind check: if both date: and end_date: set and their types differ, error naming both props + both types, matching the prefix style.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-23YS91.md
+++ b/tickets/entities/review-responses/RR-23YS91.md
@@ -1,0 +1,9 @@
+---
+id: RR-23YS91
+type: review-response
+title: Test coverage is added-from-zero, not flipped; keep all-day test separate
+finding: The plan said 'cases asserting datetime is REJECTED must flip' — but the feed test metamodel (validate_feeds_test.go:13-38) has NO datetime property, so those cases don't exist. Must ADD datetime props to feedMetamodel() and ADD positive cases (datetime date + datetime end_date accepted) plus the new mismatch-rejection case. The {EndDate:'title'} 'must be date-typed' case stays valid. ical_test.go:96 TestRenderEvent_AllDayValueDate negative assertion (no bare DTSTART:) must NOT be weakened — add a SEPARATE TestRenderEvent_Timed so both paths stay pinned.
+severity: significant
+resolution: Adopted. Add datetime props to the feed test metamodel + positive datetime accept cases + mismatch-reject cases (both directions). Keep TestRenderEvent_AllDayValueDate unchanged; add a separate TestRenderEvent_Timed (asserts timed DTSTART present, VALUE=DATE absent) and a timed-range DTEND test. json_test gets a timed round-trip case.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-CT338H.md
+++ b/tickets/entities/review-responses/RR-CT338H.md
@@ -1,0 +1,9 @@
+---
+id: RR-CT338H
+type: review-response
+title: 'JSON: add separate start/end RFC3339 fields, keep date/endDate date-only'
+finding: 'Plan overloads the JSON `date`/`endDate` fields (documented YYYY-MM-DD) with RFC3339 when timed — breaks a consumer that parses them as date-only. json.go:25 promises date-only unconditionally. Reviewer option (a) is cleaner: keep date/endDate strictly date-only, add separate `start`/`end` RFC3339 fields populated only when timed. Backward-compatible for existing JSON consumers; AllDay flips too. The at-risk consumer (menubar/notification glue) couldn''t be found in-tree to confirm branching.'
+severity: significant
+resolution: Adopted option (a). Keep jsonEvent.Date/EndDate strictly date-only (all-day). Add `Start`/`End` (RFC3339) fields populated only for timed events, plus AllDay from the flag. Existing date-only consumers unaffected. Update json_test round-trip to cover the timed shape (AllDay=false, Start set, Date empty-or-date-only).
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-JC3XMY.md
+++ b/tickets/entities/review-responses/RR-JC3XMY.md
@@ -1,0 +1,9 @@
+---
+id: RR-JC3XMY
+type: review-response
+title: DTEND contract must be uniform (verbatim/exclusive) across all-day and timed
+finding: 'calfeed.go:49 documents End as the ''exclusive'' end day, but feed_provider.go:232-239 sets ev.End = end VERBATIM (no +1 adjustment) — so exclusivity is actually the author''s responsibility today. The timed branch must NOT introduce a different meaning: End renders verbatim for both types (only the FORMAT differs, DATE vs DATE-TIME). Risk: an author sets end_date==date for an all-day event thinking ''inclusive'', producing DTEND==DTSTART which RFC5545 3.8.2.2 treats as zero-duration/invalid for VALUE=DATE. Fix: keep End = the RFC5545 DTEND value as-rendered (verbatim) for both; the RenderEvent branch changes only format, never End''s meaning. Add tests: all-day range renders the author''s end verbatim; timed range renders the exact end instant.'
+severity: critical
+resolution: 'Adopted verbatim/exclusive contract, uniform across both types. No coercion, no +1 adjustment anywhere — the RenderEvent branch changes only the format (VALUE=DATE vs timed Z). Update the Event.End doc comment to state ''rendered verbatim as the RFC5545 DTEND value (exclusive)'' for both. Tests pin: all-day range DTEND == author value; timed range DTEND == exact instant.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-NZ2I90.md
+++ b/tickets/entities/review-responses/RR-NZ2I90.md
@@ -1,0 +1,9 @@
+---
+id: RR-NZ2I90
+type: review-response
+title: Use Timed bool (zero-value=all-day), not AllDay bool — default footgun
+finding: 'Plan adds `AllDay bool` to calfeed.Event. Zero-value would be AllDay=false=timed, so every existing Event literal (~20 across ical_test.go/json_test.go + feed_provider.go:223) that sets Start but not the flag would silently become TIMED and emit DTSTART:...T000000Z instead of DTSTART;VALUE=DATE. It would also change ETags of all existing all-day feeds (breaking subscriber caches). Fix: use `Timed bool` instead — zero-value=all-day=safe/backward-compatible default; no existing construction site needs editing; ETags preserved. feed_provider sets Timed=(dateDef.Type==PropertyTypeDatetime).'
+severity: critical
+resolution: Adopted. Use `Timed bool` on calfeed.Event (zero-value = all-day). Renderers branch on `Timed`; feed_provider sets `ev.Timed = (dateDef.Type == metamodel.PropertyTypeDatetime)`. No existing all-day literal or ETag changes.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-TPD401.md
+++ b/tickets/entities/review-responses/RR-TPD401.md
@@ -1,0 +1,9 @@
+---
+id: RR-TPD401
+type: review-response
+title: Stale doc comments after timed-feed change (3 spots)
+finding: 'Code review (clean pass, no critical/significant) found 3 stale doc comments the commit left behind: (1) feed_provider.go:59 declarativeFeed doc says ''all-day calendar events'' (now also timed); (2) validate_feeds.go:59-62 validateFeeds doc says ''date must be date-typed'' (now date OR datetime); (3) ical.go:242 formatDateTimeUTC doc says ''for DTSTAMP'' (now also timed DTSTART/DTEND). All load-bearing code confirmed correct by the reviewer (byte-identical all-day render, correct Timed default, mismatch validation avoids double-reporting, JSON backward-compat, provider Timed keyed on start prop).'
+severity: minor
+resolution: 'Fixed all three doc comments: declarativeFeed -> ''calendar events (all-day or timed, per the source date property''s type)''; validateFeeds -> ''date must be date- or datetime-typed; a datetime source yields a timed event''; formatDateTimeUTC -> ''used for DTSTAMP and for a timed event''s DTSTART/DTEND''. No code change needed.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-W2JQKA.md
+++ b/tickets/entities/review-responses/RR-W2JQKA.md
@@ -1,0 +1,9 @@
+---
+id: RR-W2JQKA
+type: review-response
+title: 'Minor: non-UTC datetime input silently UTC-converted; day() test-helper clarity'
+finding: (a) formatDateTimeUTC calls .UTC(), so a hand-edited +02:00 datetime renders converted to UTC (correct per iCal, possibly surprising) — no action, just noted. (b) With Timed bool defaulting false, the day(m,d) midnight-UTC test helper stays unambiguously all-day, so the reviewer's ambiguity concern evaporates; add a dayTime(m,d,h,min) helper for timed test literals so intent is explicit.
+severity: nit
+resolution: Adopted. Timed bool (RR-NZ2I90) resolves the day() ambiguity for free. Add a dayTime(...) helper for timed test literals. Non-UTC conversion is correct-by-iCal; note it in the Event.Start/feed docs but no code change.
+status: addressed
+---

--- a/tickets/entities/tickets/TKT-VG3NUA.md
+++ b/tickets/entities/tickets/TKT-VG3NUA.md
@@ -1,0 +1,59 @@
+---
+id: TKT-VG3NUA
+type: ticket
+title: Timed calendar-feed events from datetime sources (DTSTART with time, datetime start/end range)
+kind: enhancement
+priority: medium
+effort: m
+status: in-progress
+---
+
+## Description
+
+Now that the **`datetime`** property type exists (TKT-ZYOBSN), make the
+calendar-feed export emit **timed** events for datetime-typed sources — the
+follow-on that Phase 1 (TKT-RDM9M5) explicitly deferred because there was no
+clean way to author a time-bearing value.
+
+Phase 1 ships **all-day only** (`DTSTART;VALUE=DATE`). This ticket makes the
+feed **type-driven**:
+
+- `date` source → all-day event (`VALUE=DATE`) — unchanged.
+- `datetime` source → **timed** event (`DTSTART:<UTC>` with time-of-day).
+- `datetime` **start + optional `datetime` end** → a timed-range VEVENT
+(`DTSTART`/`DTEND` both timed).
+
+### Deliverables
+
+1. **`internal/dataentryconfig/validate_feeds.go`** — allow a feed `date:` /
+`end_date:` source property to be **`date` OR `datetime`** (currently gated to
+`date` only at :89 and :127). Reject a nonsensical mix where it matters (decide
+during planning — e.g. all-day start + timed end).
+2. **`internal/calfeed`** — extend the `Event` model + iCal serializer to emit a
+**timed** `DTSTART`/`DTEND` (`YYYYMMDDTHHMMSSZ`, UTC) when the event is timed,
+keeping `VALUE=DATE` for all-day. A per-event `AllDay bool` (or equivalent)
+drives the branch. `formatDateTimeUTC` already exists for `DTSTAMP`.
+3. **`internal/dataentry/feed_provider.go`** — when a source's date prop is
+`datetime`, produce a timed `Event` (carry the parsed `time.Time` with its
+time-of-day) instead of an all-day one; likewise for `end_date`.
+4. Tests: calfeed timed-event rendering (incl. iCal correctness — CRLF, DTSTART
+line format), validate_feeds accepting datetime, feed_provider mapping a
+datetime source to a timed event, and the mixed date/datetime decision.
+5. Docs: update the feed docs (`docs/data-entry.md` + the metamodel datetime
+note that currently says "timed events are a planned follow-on") and the feed
+config reference.
+
+### Design notes / prior art
+
+- iCal correctness pins from Phase 1's review (RR-0E20T7, RR-2V0019) apply —
+reuse the CRLF/fold/DTSTAMP handling; timed `DTSTART` must be UTC `Z`.
+- The datetime type stores UTC RFC3339, so `ParseDateValue` already yields a
+full `time.Time`; the provider just stops truncating to a day.
+- Type-driven, no feed-config redesign — the Phase 1 design anticipated this
+("picked up type-driven once `datetime` lands").
+
+### Out of scope
+
+- Timezone (`TZID`/`VTIMEZONE`) in the feed — Phase 1 + this ticket emit UTC
+`Z`. A per-feed display tz is a later enhancement.
+- CalDAV, RRULE, VTODO — later phases (unchanged from Phase 1 scope).

--- a/tickets/entities/tickets/TKT-VG3NUA.md
+++ b/tickets/entities/tickets/TKT-VG3NUA.md
@@ -5,7 +5,7 @@ title: Timed calendar-feed events from datetime sources (DTSTART with time, date
 kind: enhancement
 priority: medium
 effort: m
-status: review
+status: done
 ---
 
 ## Description

--- a/tickets/entities/tickets/TKT-VG3NUA.md
+++ b/tickets/entities/tickets/TKT-VG3NUA.md
@@ -5,7 +5,7 @@ title: Timed calendar-feed events from datetime sources (DTSTART with time, date
 kind: enhancement
 priority: medium
 effort: m
-status: in-progress
+status: review
 ---
 
 ## Description

--- a/tickets/relations/TKT-VG3NUA--affects--data-entry-server.md
+++ b/tickets/relations/TKT-VG3NUA--affects--data-entry-server.md
@@ -1,0 +1,5 @@
+---
+from: TKT-VG3NUA
+relation: affects
+to: data-entry-server
+---

--- a/tickets/relations/TKT-VG3NUA--affects--metamodel-types.md
+++ b/tickets/relations/TKT-VG3NUA--affects--metamodel-types.md
@@ -1,0 +1,5 @@
+---
+from: TKT-VG3NUA
+relation: affects
+to: metamodel-types
+---

--- a/tickets/relations/TKT-VG3NUA--has-docs--DOCS-I0WHP.md
+++ b/tickets/relations/TKT-VG3NUA--has-docs--DOCS-I0WHP.md
@@ -1,0 +1,5 @@
+---
+from: TKT-VG3NUA
+relation: has-docs
+to: DOCS-I0WHP
+---

--- a/tickets/relations/TKT-VG3NUA--has-implementation--IMPL-S6IND8.md
+++ b/tickets/relations/TKT-VG3NUA--has-implementation--IMPL-S6IND8.md
@@ -1,0 +1,5 @@
+---
+from: TKT-VG3NUA
+relation: has-implementation
+to: IMPL-S6IND8
+---

--- a/tickets/relations/TKT-VG3NUA--has-planning--PLAN-GDNPI0.md
+++ b/tickets/relations/TKT-VG3NUA--has-planning--PLAN-GDNPI0.md
@@ -1,0 +1,5 @@
+---
+from: TKT-VG3NUA
+relation: has-planning
+to: PLAN-GDNPI0
+---

--- a/tickets/relations/TKT-VG3NUA--has-review--REV-UQF1XK.md
+++ b/tickets/relations/TKT-VG3NUA--has-review--REV-UQF1XK.md
@@ -1,0 +1,5 @@
+---
+from: TKT-VG3NUA
+relation: has-review
+to: REV-UQF1XK
+---

--- a/tickets/relations/TKT-VG3NUA--has-review-response--RR-1KKN1N.md
+++ b/tickets/relations/TKT-VG3NUA--has-review-response--RR-1KKN1N.md
@@ -1,0 +1,5 @@
+---
+from: TKT-VG3NUA
+relation: has-review-response
+to: RR-1KKN1N
+---

--- a/tickets/relations/TKT-VG3NUA--has-review-response--RR-23YS91.md
+++ b/tickets/relations/TKT-VG3NUA--has-review-response--RR-23YS91.md
@@ -1,0 +1,5 @@
+---
+from: TKT-VG3NUA
+relation: has-review-response
+to: RR-23YS91
+---

--- a/tickets/relations/TKT-VG3NUA--has-review-response--RR-CT338H.md
+++ b/tickets/relations/TKT-VG3NUA--has-review-response--RR-CT338H.md
@@ -1,0 +1,5 @@
+---
+from: TKT-VG3NUA
+relation: has-review-response
+to: RR-CT338H
+---

--- a/tickets/relations/TKT-VG3NUA--has-review-response--RR-JC3XMY.md
+++ b/tickets/relations/TKT-VG3NUA--has-review-response--RR-JC3XMY.md
@@ -1,0 +1,5 @@
+---
+from: TKT-VG3NUA
+relation: has-review-response
+to: RR-JC3XMY
+---

--- a/tickets/relations/TKT-VG3NUA--has-review-response--RR-NZ2I90.md
+++ b/tickets/relations/TKT-VG3NUA--has-review-response--RR-NZ2I90.md
@@ -1,0 +1,5 @@
+---
+from: TKT-VG3NUA
+relation: has-review-response
+to: RR-NZ2I90
+---

--- a/tickets/relations/TKT-VG3NUA--has-review-response--RR-TPD401.md
+++ b/tickets/relations/TKT-VG3NUA--has-review-response--RR-TPD401.md
@@ -1,0 +1,5 @@
+---
+from: TKT-VG3NUA
+relation: has-review-response
+to: RR-TPD401
+---

--- a/tickets/relations/TKT-VG3NUA--has-review-response--RR-W2JQKA.md
+++ b/tickets/relations/TKT-VG3NUA--has-review-response--RR-W2JQKA.md
@@ -1,0 +1,5 @@
+---
+from: TKT-VG3NUA
+relation: has-review-response
+to: RR-W2JQKA
+---

--- a/tickets/relations/TKT-VG3NUA--implements--FEAT-OT4361.md
+++ b/tickets/relations/TKT-VG3NUA--implements--FEAT-OT4361.md
@@ -1,0 +1,5 @@
+---
+from: TKT-VG3NUA
+relation: implements
+to: FEAT-OT4361
+---

--- a/tickets/relations/TKT-ZYOBSN--has-docs--DOCS-VRL26.md
+++ b/tickets/relations/TKT-ZYOBSN--has-docs--DOCS-VRL26.md
@@ -1,0 +1,5 @@
+---
+from: TKT-ZYOBSN
+relation: has-docs
+to: DOCS-VRL26
+---


### PR DESCRIPTION
## Summary

Makes the calendar-feed export emit **timed** iCal events for `datetime`-typed sources — the follow-on Phase 1 (TKT-RDM9M5) deferred until a time-bearing property type existed. Now that `datetime` has landed (#1131), feeds are **type-driven**:

- `date` source → all-day event (`DTSTART;VALUE=DATE`) — unchanged.
- `datetime` source → **timed** event (`DTSTART:<UTC>` with time-of-day).
- `datetime` start + `datetime` end → a timed-range VEVENT.

Implements TKT-VG3NUA (part of FEAT-OT4361).

## Changes (5 localized touch points)

- **`calfeed.Event`** gains a `Timed bool` discriminator — **zero-value = all-day**, so no existing all-day Event literal or ETag changes.
- **iCal `RenderEvent`** branches DTSTART/DTEND: timed UTC instant (`YYYYMMDDTHHMMSSZ`) vs `VALUE=DATE`. `End` renders **verbatim/exclusive** for both — the branch changes only the format, never meaning.
- **JSON** keeps `date`/`endDate` date-only; adds separate `start`/`end` RFC3339 fields for timed events (backward-compatible — existing date-only consumers unaffected).
- **`feed_provider`** sets `Timed` from the source property **type**.
- **`validate_feeds`** accepts `date` OR `datetime` at both gates and **rejects a start/end kind mismatch** (iCal forbids mixing all-day + timed in one event).

UTC `Z` only; no `TZID` (matches Phase 1). Midnight-UTC datetimes stay timed (keyed on type, not the time value).

## Testing

- New tests: calfeed timed iCal (`TestRenderEvent_Timed`/`_TimedRange`, all-day test kept unchanged), JSON timed round-trip, provider datetime→timed mapping, validate accept+mismatch (both directions), handler ICS e2e.
- Manual E2E against a running `rela-server`: datetime source → `DTSTART:...T093000Z`; date source → `DTSTART;VALUE=DATE:...` (unchanged).
- `just ci` green (after rebasing onto develop post-#1131 merge).

## Review trail

Design review: 6 findings (2 critical — `Timed bool` default, DTEND contract), all addressed.
Code review: 1 minor finding (stale doc comments) — addressed. Reviewer confirmed-correct all load-bearing behavior (byte-identical all-day render, ETag stability, mismatch validation, JSON backward-compat).

_Was stacked on #1131 (datetime type); rebased onto develop now that it merged._
