### PR TITLE
refactor(dataentry): extract command route cluster into commandHandler

### DIFF
--- a/internal/dataentry/api_v1.go
+++ b/internal/dataentry/api_v1.go
@@ -3243,7 +3243,7 @@ func (a *App) handleV1Commands(w http.ResponseWriter, r *http.Request) {
 	qualifier := query.Get("qualifier")
 	entityType := query.Get("entity_type")
 
-	resolved := a.resolveCommands(pageType, qualifier, entityType)
+	resolved := a.commands.resolveCommands(pageType, qualifier, entityType)
 
 	commands := make([]v1.Command, 0, len(resolved))
 	for _, cmd := range resolved {

--- a/internal/dataentry/app.go
+++ b/internal/dataentry/app.go
@@ -75,9 +75,10 @@ const userPaletteFile = "palette.yaml"
 // their own types. Ratchet this number DOWN as methods move out; never up
 // EXCEPT for a new required route handler (App owns one method per registered
 // HTTP route by the router's design). The sync route cluster (16 methods) moved
-// to syncHandler, ratcheting 170 → 154.
+// to syncHandler (170 → 154); the command cluster (11 methods) moved to
+// commandHandler (154 → 143).
 //
-//plimsoll:max-methods=154
+//plimsoll:max-methods=143
 type App struct {
 	// Primitives — immutable after NewApp.
 	fs    storage.FS
@@ -139,7 +140,12 @@ type App struct {
 	// replication). Extracted from App (TKT-R68TV8); holds narrow store/deleter
 	// surfaces plus a pointer to writeMu so its writes serialize with the other
 	// mutation handlers.
-	sync      *syncHandler
+	sync *syncHandler
+	// commands owns the user-configured command surface (SSE shell-exec,
+	// file/URL launchers, command resolution). Extracted from App (TKT-R68TV8);
+	// holds narrow closures over the schema snapshot, Services bundle, project
+	// root, and the view executor.
+	commands  *commandHandler
 	templater templating.Templater
 	cfgLoader config.Loader
 	kv        state.KV
@@ -517,6 +523,17 @@ func NewApp(
 	// are resolved once from the concrete store/manager (nil on fs/memory builds,
 	// where the sync endpoints degrade to 501).
 	app.sync = newSyncHandler(st, app.entityManager, &app.writeMu)
+
+	// commandHandler owns the user-configured command surface. Its
+	// collaborators are narrow closures over App: the schema snapshot (command/
+	// list/view config), the Services read bundle, the project root (exec cwd +
+	// env), and the view executor for view-context commands.
+	app.commands = &commandHandler{
+		schema:      app.State,
+		services:    app.Services,
+		projectRoot: app.ProjectRoot,
+		executeView: app.executeView,
+	}
 
 	// Build and publish the initial Schema snapshot. All reloadable
 	// state lives here; there are no convenience aliases on App to keep

--- a/internal/dataentry/command_handler.go
+++ b/internal/dataentry/command_handler.go
@@ -1,0 +1,41 @@
+package dataentry
+
+import (
+	"context"
+	"net/http"
+)
+
+// commandHandler serves the user-configured command surface: the SSE-streaming
+// shell-exec endpoints (/api/command/, /api/command-cancel/), the file/URL
+// launchers (/api/open-file, /api/open-url), and the command-resolution query
+// behind /api/v1/_commands. Extracted from App (TKT-R68TV8) to shrink the god
+// object.
+//
+// Its collaborators are supplied as narrow closures over App (consumer-side
+// interfaces per CLAUDE.md) rather than a handle to App itself:
+//
+//   - schema yields the current Schema snapshot (command/list/view config).
+//   - services yields the read Services bundle passed to the store helpers.
+//   - projectRoot is the exec cwd + the RELA_PROJECT_ROOT env base.
+//   - executeView runs a view (a views-cluster method) to assemble the stdin
+//     payload for a view-context command.
+//
+// The handler owns no mutable state of its own; runningCommands (the in-flight
+// exec registry) stays a package-level sync.Map shared with handleCommandCancel.
+type commandHandler struct {
+	schema      func() *Schema
+	services    func() Services
+	projectRoot func() string
+	executeView func(ctx context.Context, view ViewConfig, entryID string) (*viewResult, error)
+}
+
+// registerCommandRoutes mounts the command-exec and launcher endpoints. The
+// command-resolution query is mounted separately under /api/v1/ by the v1
+// router (handleV1Commands delegates to h.resolve). handleOpenURL is a method
+// on the handler (exercised by tests) but, matching the pre-extraction router,
+// is not mounted here.
+func (h *commandHandler) registerCommandRoutes(mux *http.ServeMux) {
+	mux.HandleFunc("/api/command/", h.handleCommandExec)
+	mux.HandleFunc("/api/command-cancel/", h.handleCommandCancel)
+	mux.HandleFunc("/api/open-file", h.handleOpenFile)
+}

--- a/internal/dataentry/commands.go
+++ b/internal/dataentry/commands.go
@@ -42,8 +42,8 @@ type ResolvedCommand struct {
 // pageType is "entity", "list", "view", or "dashboard".
 // qualifier is the specific list ID or view ID.
 // entityType is the entity type shown on the page (empty for dashboard).
-func (a *App) resolveCommands(pageType, qualifier, entityType string) []ResolvedCommand {
-	s := a.State()
+func (h *commandHandler) resolveCommands(pageType, qualifier, entityType string) []ResolvedCommand {
+	s := h.schema()
 	if len(s.Cfg.Commands) == 0 {
 		return nil
 	}
@@ -150,12 +150,12 @@ type commandProjectInfo struct {
 	Metamodel string `json:"metamodel"`
 }
 
-func (a *App) buildEntityInput(ctx context.Context, e *entity.Entity) *commandInput {
+func (h *commandHandler) buildEntityInput(ctx context.Context, e *entity.Entity) *commandInput {
 	return &commandInput{
 		Context:   "entity",
 		Entity:    e,
-		Relations: relationsForEntity(ctx, a.Services(), e.ID),
-		Project:   a.projectInfo(),
+		Relations: relationsForEntity(ctx, h.services(), e.ID),
+		Project:   h.projectInfo(),
 	}
 }
 
@@ -173,16 +173,16 @@ func relationsForEntity(ctx context.Context, svc Services, id string) []*entity.
 	return rels
 }
 
-func (a *App) buildListInput(listID string, entities []*entity.Entity) *commandInput {
+func (h *commandHandler) buildListInput(listID string, entities []*entity.Entity) *commandInput {
 	return &commandInput{
 		Context:  "list",
 		ListID:   listID,
 		Entities: entities,
-		Project:  a.projectInfo(),
+		Project:  h.projectInfo(),
 	}
 }
 
-func (a *App) buildViewInput(ctx context.Context, viewID string, vr *viewResult) *commandInput {
+func (h *commandHandler) buildViewInput(ctx context.Context, viewID string, vr *viewResult) *commandInput {
 	// Collect all entity IDs in the result set.
 	idSet := map[string]bool{vr.Entry.ID: true}
 	for _, entities := range vr.Collections {
@@ -192,7 +192,7 @@ func (a *App) buildViewInput(ctx context.Context, viewID string, vr *viewResult)
 	}
 
 	// Gather relations between entities in the result set.
-	svc := a.Services()
+	svc := h.services()
 	var rels []*entity.Relation
 	for id := range idSet {
 		q := store.RelationQuery{EntityID: id, Direction: store.DirectionOutgoing}
@@ -217,20 +217,20 @@ func (a *App) buildViewInput(ctx context.Context, viewID string, vr *viewResult)
 		Entity:      vr.Entry,
 		Collections: collections,
 		Relations:   rels,
-		Project:     a.projectInfo(),
+		Project:     h.projectInfo(),
 	}
 }
 
-func (a *App) buildGlobalInput() *commandInput {
+func (h *commandHandler) buildGlobalInput() *commandInput {
 	return &commandInput{
 		Context: "global",
-		Project: a.projectInfo(),
+		Project: h.projectInfo(),
 	}
 }
 
-func (a *App) projectInfo() commandProjectInfo {
+func (h *commandHandler) projectInfo() commandProjectInfo {
 	return commandProjectInfo{
-		Root:      a.ProjectRoot(),
+		Root:      h.projectRoot(),
 		Metamodel: "metamodel.yaml",
 	}
 }
@@ -283,14 +283,14 @@ var (
 // browser tab, bypassing same-origin policy entirely.
 //
 //nolint:funlen // dispatches over every command context and argument shape inline; each branch is one command variant, and extracting them would fragment the request lifecycle.
-func (a *App) handleCommandExec(w http.ResponseWriter, r *http.Request) {
+func (h *commandHandler) handleCommandExec(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
 		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
 		return
 	}
 
 	commandID := strings.TrimPrefix(r.URL.Path, "/api/command/")
-	s := a.State()
+	s := h.schema()
 	cmd, ok := s.Cfg.Commands[commandID]
 	if !ok {
 		http.Error(w, "Unknown command: "+commandID, http.StatusNotFound)
@@ -307,13 +307,13 @@ func (a *App) handleCommandExec(w http.ResponseWriter, r *http.Request) {
 	switch cmd.Context {
 	case "entity":
 		entityID := r.URL.Query().Get("entity_id")
-		svc := a.Services()
+		svc := h.services()
 		entityDomain, err := svc.Store.GetEntity(r.Context(), entityID)
 		if err != nil {
 			http.Error(w, "Entity not found: "+entityID, http.StatusNotFound)
 			return
 		}
-		input = a.buildEntityInput(r.Context(), entityDomain)
+		input = h.buildEntityInput(r.Context(), entityDomain)
 	case "list":
 		listID := r.URL.Query().Get("list_id")
 		listCfg, found := s.Cfg.Lists[listID]
@@ -321,9 +321,9 @@ func (a *App) handleCommandExec(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, "List not found: "+listID, http.StatusNotFound)
 			return
 		}
-		entities := listFromStoreByTypes(r.Context(), a.Services(), []string{listCfg.EntityType})
+		entities := listFromStoreByTypes(r.Context(), h.services(), []string{listCfg.EntityType})
 		entities = applyFilters(entities, listCfg.Filters)
-		input = a.buildListInput(listID, entities)
+		input = h.buildListInput(listID, entities)
 	case "view":
 		viewID := r.URL.Query().Get("view_id")
 		entityID := r.URL.Query().Get("entity_id")
@@ -332,14 +332,14 @@ func (a *App) handleCommandExec(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, "View not found: "+viewID, http.StatusNotFound)
 			return
 		}
-		vr, err := a.executeView(r.Context(), viewCfg, entityID)
+		vr, err := h.executeView(r.Context(), viewCfg, entityID)
 		if err != nil {
 			http.Error(w, "View error: "+err.Error(), http.StatusBadRequest)
 			return
 		}
-		input = a.buildViewInput(r.Context(), viewID, vr)
+		input = h.buildViewInput(r.Context(), viewID, vr)
 	case "global":
-		input = a.buildGlobalInput()
+		input = h.buildGlobalInput()
 	default:
 		http.Error(w, "Invalid command context: "+cmd.Context, http.StatusBadRequest)
 		return
@@ -365,8 +365,8 @@ func (a *App) handleCommandExec(w http.ResponseWriter, r *http.Request) {
 	proc := exec.CommandContext(r.Context(), "sh", "-c", cmd.Script)
 	proc.Cancel = func() error { return proc.Process.Signal(syscall.SIGINT) }
 	proc.WaitDelay = cancelGrace
-	proc.Dir = a.ProjectRoot()
-	proc.Env = a.buildCommandEnv(cmd, input)
+	proc.Dir = h.projectRoot()
+	proc.Env = h.buildCommandEnv(cmd, input)
 	proc.Stdin = strings.NewReader(string(inputJSON))
 
 	stdout, err := proc.StdoutPipe()
@@ -433,7 +433,7 @@ func (a *App) handleCommandExec(w http.ResponseWriter, r *http.Request) {
 }
 
 // handleCommandCancel handles POST /api/command-cancel/{execID}.
-func (a *App) handleCommandCancel(w http.ResponseWriter, r *http.Request) {
+func (h *commandHandler) handleCommandCancel(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
 		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
 		return
@@ -468,7 +468,9 @@ func (a *App) handleCommandCancel(w http.ResponseWriter, r *http.Request) {
 }
 
 // handleOpenFile handles POST /api/open-file to open or reveal files.
-func (a *App) handleOpenFile(w http.ResponseWriter, r *http.Request) { // coverage-ignore: requires OS interaction
+//
+// coverage-ignore: requires OS interaction
+func (h *commandHandler) handleOpenFile(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
 		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
 		return
@@ -481,7 +483,7 @@ func (a *App) handleOpenFile(w http.ResponseWriter, r *http.Request) { // covera
 		return
 	}
 
-	resolved, err := containedProjectPath(a.ProjectRoot(), filePath)
+	resolved, err := containedProjectPath(h.projectRoot(), filePath)
 	switch {
 	case errors.Is(err, errPathNotFound):
 		http.Error(w, "file not found", http.StatusNotFound)
@@ -536,7 +538,9 @@ func openFileCommand(goos, action, filePath string) *exec.Cmd {
 }
 
 // handleOpenURL handles POST /api/open-url to open URLs in the default browser.
-func (a *App) handleOpenURL(w http.ResponseWriter, r *http.Request) { // coverage-ignore: requires OS interaction
+//
+// coverage-ignore: requires OS interaction
+func (h *commandHandler) handleOpenURL(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
 		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
 		return
@@ -667,10 +671,10 @@ func validateOpenURL(raw string) error {
 	return errors.New("disallowed url scheme")
 }
 
-func (a *App) buildCommandEnv(cmd CommandConfig, input *commandInput) []string {
+func (h *commandHandler) buildCommandEnv(cmd CommandConfig, input *commandInput) []string {
 	env := os.Environ()
 	env = append(env,
-		"RELA_PROJECT_ROOT="+a.ProjectRoot(),
+		"RELA_PROJECT_ROOT="+h.projectRoot(),
 		"RELA_CONTEXT="+cmd.Context,
 	)
 	if input.Entity != nil {

--- a/internal/dataentry/commands_test.go
+++ b/internal/dataentry/commands_test.go
@@ -63,7 +63,7 @@ func TestResolveCommands(t *testing.T) {
 	}
 
 	t.Run("entity page shows entity commands", func(t *testing.T) {
-		cmds := app.resolveCommands("entity", "", "ticket")
+		cmds := app.commands.resolveCommands("entity", "", "ticket")
 		ids := cmdIDs(cmds)
 		assertContains(t, ids, "entity-cmd")
 		assertContains(t, ids, "unscoped-entity")
@@ -73,7 +73,7 @@ func TestResolveCommands(t *testing.T) {
 	})
 
 	t.Run("entity page for non-matching type", func(t *testing.T) {
-		cmds := app.resolveCommands("entity", "", "component")
+		cmds := app.commands.resolveCommands("entity", "", "component")
 		ids := cmdIDs(cmds)
 		// unscoped entity command still shows (context matches)
 		assertContains(t, ids, "unscoped-entity")
@@ -82,7 +82,7 @@ func TestResolveCommands(t *testing.T) {
 	})
 
 	t.Run("view page shows entity and view commands", func(t *testing.T) {
-		cmds := app.resolveCommands("view", "ticket_detail", "ticket")
+		cmds := app.commands.resolveCommands("view", "ticket_detail", "ticket")
 		ids := cmdIDs(cmds)
 		assertContains(t, ids, "entity-cmd")
 		assertContains(t, ids, "view-cmd")
@@ -92,7 +92,7 @@ func TestResolveCommands(t *testing.T) {
 	})
 
 	t.Run("list page shows list commands", func(t *testing.T) {
-		cmds := app.resolveCommands("list", "tickets", "ticket")
+		cmds := app.commands.resolveCommands("list", "tickets", "ticket")
 		ids := cmdIDs(cmds)
 		assertContains(t, ids, "list-cmd")
 		assertNotContains(t, ids, "entity-cmd")
@@ -100,7 +100,7 @@ func TestResolveCommands(t *testing.T) {
 	})
 
 	t.Run("dashboard shows global commands", func(t *testing.T) {
-		cmds := app.resolveCommands("dashboard", "", "")
+		cmds := app.commands.resolveCommands("dashboard", "", "")
 		ids := cmdIDs(cmds)
 		assertContains(t, ids, "global-cmd")
 		assertNotContains(t, ids, "entity-cmd")
@@ -108,7 +108,7 @@ func TestResolveCommands(t *testing.T) {
 
 	t.Run("empty commands returns nil", func(t *testing.T) {
 		app2, _ := testAppInstance()
-		cmds := app2.resolveCommands("entity", "", "ticket")
+		cmds := app2.commands.resolveCommands("entity", "", "ticket")
 		if cmds != nil {
 			t.Errorf("expected nil, got %v", cmds)
 		}
@@ -130,7 +130,7 @@ func TestResolveCommands(t *testing.T) {
 				Context: "entity",
 			},
 		}
-		cmds := app2.resolveCommands("entity", "", "ticket")
+		cmds := app2.commands.resolveCommands("entity", "", "ticket")
 		for _, c := range cmds {
 			if c.ID == "auto-cmd" {
 				if c.AutoOpen == nil || !*c.AutoOpen {
@@ -146,13 +146,13 @@ func TestResolveCommands(t *testing.T) {
 	})
 
 	t.Run("deterministic order", func(t *testing.T) {
-		cmds := app.resolveCommands("view", "ticket_detail", "ticket")
+		cmds := app.commands.resolveCommands("view", "ticket_detail", "ticket")
 		if len(cmds) < 2 {
 			t.Skip("need at least 2 commands")
 		}
 		// Run multiple times and check order is stable
 		for range 5 {
-			cmds2 := app.resolveCommands("view", "ticket_detail", "ticket")
+			cmds2 := app.commands.resolveCommands("view", "ticket_detail", "ticket")
 			for j := range cmds {
 				if cmds[j].ID != cmds2[j].ID {
 					t.Fatalf("order not deterministic: %v vs %v", cmdIDs(cmds), cmdIDs(cmds2))
@@ -255,7 +255,7 @@ func TestBuildEntityInput(t *testing.T) {
 	bindRepo(app, "/test/project")
 	seedRelation(app, entity.NewRelation(entities.ticket1.ID, "depends_on", entities.ticket2.ID))
 
-	input := app.buildEntityInput(context.Background(), entities.ticket1)
+	input := app.commands.buildEntityInput(context.Background(), entities.ticket1)
 
 	if input.Context != "entity" {
 		t.Errorf("expected entity context, got %s", input.Context)
@@ -289,7 +289,7 @@ func TestBuildListInput(t *testing.T) {
 	bindRepo(app, "/test/project")
 	entities := entitiesByType(app, "ticket")
 
-	input := app.buildListInput("tickets", entities)
+	input := app.commands.buildListInput("tickets", entities)
 
 	if input.Context != "list" {
 		t.Errorf("expected list context, got %s", input.Context)
@@ -319,7 +319,7 @@ func TestBuildViewInput(t *testing.T) {
 		t.Fatalf("executeView: %v", err)
 	}
 
-	input := app.buildViewInput(context.Background(), "test_view", vr)
+	input := app.commands.buildViewInput(context.Background(), "test_view", vr)
 
 	if input.Context != "view" {
 		t.Errorf("expected view context, got %s", input.Context)
@@ -342,7 +342,7 @@ func TestBuildGlobalInput(t *testing.T) {
 	app, _ := testAppInstance()
 	bindRepo(app, "/test/project")
 
-	input := app.buildGlobalInput()
+	input := app.commands.buildGlobalInput()
 
 	if input.Context != "global" {
 		t.Errorf("expected global context, got %s", input.Context)
@@ -363,8 +363,8 @@ func TestBuildCommandEnv(t *testing.T) {
 		Context: "entity",
 		Env:     map[string]string{"FORMAT": "pdf"},
 	}
-	input := app.buildEntityInput(context.Background(), entities.ticket1)
-	env := app.buildCommandEnv(cmd, input)
+	input := app.commands.buildEntityInput(context.Background(), entities.ticket1)
+	env := app.commands.buildCommandEnv(cmd, input)
 
 	envMap := envToMap(env)
 	if envMap["RELA_PROJECT_ROOT"] != "/test/project" {
@@ -389,8 +389,8 @@ func TestBuildCommandEnvListContext(t *testing.T) {
 	bindRepo(app, "/test/project")
 
 	cmd := CommandConfig{Script: "echo hi", Context: "list"}
-	input := app.buildListInput("tickets", nil)
-	env := app.buildCommandEnv(cmd, input)
+	input := app.commands.buildListInput("tickets", nil)
+	env := app.commands.buildCommandEnv(cmd, input)
 
 	envMap := envToMap(env)
 	if envMap["RELA_LIST_ID"] != "tickets" {
@@ -407,9 +407,9 @@ func TestBuildCommandEnvViewContext(t *testing.T) {
 		Context: "view",
 		ViewID:  "ticket_detail",
 		Entity:  entities.ticket1,
-		Project: app.projectInfo(),
+		Project: app.commands.projectInfo(),
 	}
-	env := app.buildCommandEnv(cmd, input)
+	env := app.commands.buildCommandEnv(cmd, input)
 
 	envMap := envToMap(env)
 	if envMap["RELA_VIEW_ID"] != "ticket_detail" {
@@ -576,7 +576,7 @@ func TestHandleCommandExec(t *testing.T) {
 	t.Run("success stream", func(t *testing.T) {
 		r := httptest.NewRequest(http.MethodPost, "/api/command/test-echo?entity_id=TKT-001&entity_type=ticket", http.NoBody)
 		w := httptest.NewRecorder()
-		app.handleCommandExec(w, r)
+		app.commands.handleCommandExec(w, r)
 
 		if w.Code != http.StatusOK {
 			t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
@@ -618,7 +618,7 @@ func TestHandleCommandExec(t *testing.T) {
 	t.Run("unknown command", func(t *testing.T) {
 		r := httptest.NewRequest(http.MethodPost, "/api/command/nonexistent", http.NoBody)
 		w := httptest.NewRecorder()
-		app.handleCommandExec(w, r)
+		app.commands.handleCommandExec(w, r)
 		if w.Code != http.StatusNotFound {
 			t.Errorf("expected 404, got %d", w.Code)
 		}
@@ -627,7 +627,7 @@ func TestHandleCommandExec(t *testing.T) {
 	t.Run("entity not found", func(t *testing.T) {
 		r := httptest.NewRequest(http.MethodPost, "/api/command/test-echo?entity_id=NOPE", http.NoBody)
 		w := httptest.NewRecorder()
-		app.handleCommandExec(w, r)
+		app.commands.handleCommandExec(w, r)
 		if w.Code != http.StatusNotFound {
 			t.Errorf("expected 404, got %d", w.Code)
 		}
@@ -636,7 +636,7 @@ func TestHandleCommandExec(t *testing.T) {
 	t.Run("method not allowed", func(t *testing.T) {
 		r := httptest.NewRequest(http.MethodDelete, "/api/command/test-echo", http.NoBody)
 		w := httptest.NewRecorder()
-		app.handleCommandExec(w, r)
+		app.commands.handleCommandExec(w, r)
 		if w.Code != http.StatusMethodNotAllowed {
 			t.Errorf("expected 405, got %d", w.Code)
 		}
@@ -656,7 +656,7 @@ func TestHandleCommandExecFailing(t *testing.T) {
 
 	r := httptest.NewRequest(http.MethodPost, "/api/command/fail-cmd?entity_id=TKT-001", http.NoBody)
 	w := httptest.NewRecorder()
-	app.handleCommandExec(w, r)
+	app.commands.handleCommandExec(w, r)
 
 	events := parseSSEEvents(t, w.Body)
 	var hasError, hasDone bool
@@ -692,7 +692,7 @@ func TestHandleCommandExecGlobalContext(t *testing.T) {
 
 	r := httptest.NewRequest(http.MethodPost, "/api/command/global-cmd", http.NoBody)
 	w := httptest.NewRecorder()
-	app.handleCommandExec(w, r)
+	app.commands.handleCommandExec(w, r)
 
 	if w.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d", w.Code)
@@ -722,7 +722,7 @@ func TestHandleCommandExecListContext(t *testing.T) {
 
 	r := httptest.NewRequest(http.MethodPost, "/api/command/list-cmd?list_id=tickets", http.NoBody)
 	w := httptest.NewRecorder()
-	app.handleCommandExec(w, r)
+	app.commands.handleCommandExec(w, r)
 
 	if w.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
@@ -742,7 +742,7 @@ func TestHandleCommandExecViewContext(t *testing.T) {
 
 	r := httptest.NewRequest(http.MethodPost, "/api/command/view-cmd?view_id=ticket_detail&entity_id=TKT-001", http.NoBody)
 	w := httptest.NewRecorder()
-	app.handleCommandExec(w, r)
+	app.commands.handleCommandExec(w, r)
 
 	if w.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
@@ -756,7 +756,7 @@ func TestHandleCommandCancel(t *testing.T) {
 		app, _ := testAppInstance()
 		r := httptest.NewRequest(http.MethodPost, "/api/command-cancel/nonexistent", http.NoBody)
 		w := httptest.NewRecorder()
-		app.handleCommandCancel(w, r)
+		app.commands.handleCommandCancel(w, r)
 		if w.Code != http.StatusNotFound {
 			t.Errorf("expected 404, got %d", w.Code)
 		}
@@ -766,7 +766,7 @@ func TestHandleCommandCancel(t *testing.T) {
 		app, _ := testAppInstance()
 		r := httptest.NewRequest(http.MethodGet, "/api/command-cancel/test", http.NoBody)
 		w := httptest.NewRecorder()
-		app.handleCommandCancel(w, r)
+		app.commands.handleCommandCancel(w, r)
 		if w.Code != http.StatusMethodNotAllowed {
 			t.Errorf("expected 405, got %d", w.Code)
 		}
@@ -781,7 +781,7 @@ func TestHandleOpenURL(t *testing.T) {
 	t.Run("missing url", func(t *testing.T) {
 		r := httptest.NewRequest(http.MethodPost, "/api/open-url", http.NoBody)
 		w := httptest.NewRecorder()
-		app.handleOpenURL(w, r)
+		app.commands.handleOpenURL(w, r)
 		if w.Code != http.StatusBadRequest {
 			t.Errorf("expected 400, got %d", w.Code)
 		}
@@ -790,7 +790,7 @@ func TestHandleOpenURL(t *testing.T) {
 	t.Run("invalid scheme", func(t *testing.T) {
 		r := httptest.NewRequest(http.MethodPost, "/api/open-url?url=ftp://evil.com", http.NoBody)
 		w := httptest.NewRecorder()
-		app.handleOpenURL(w, r)
+		app.commands.handleOpenURL(w, r)
 		if w.Code != http.StatusBadRequest {
 			t.Errorf("expected 400, got %d", w.Code)
 		}
@@ -799,7 +799,7 @@ func TestHandleOpenURL(t *testing.T) {
 	t.Run("method not allowed", func(t *testing.T) {
 		r := httptest.NewRequest(http.MethodGet, "/api/open-url?url=https://example.com", http.NoBody)
 		w := httptest.NewRecorder()
-		app.handleOpenURL(w, r)
+		app.commands.handleOpenURL(w, r)
 		if w.Code != http.StatusMethodNotAllowed {
 			t.Errorf("expected 405, got %d", w.Code)
 		}
@@ -814,7 +814,7 @@ func TestHandleOpenFile(t *testing.T) {
 	t.Run("missing path", func(t *testing.T) {
 		r := httptest.NewRequest(http.MethodPost, "/api/open-file", http.NoBody)
 		w := httptest.NewRecorder()
-		app.handleOpenFile(w, r)
+		app.commands.handleOpenFile(w, r)
 		if w.Code != http.StatusBadRequest {
 			t.Errorf("expected 400, got %d", w.Code)
 		}
@@ -823,7 +823,7 @@ func TestHandleOpenFile(t *testing.T) {
 	t.Run("method not allowed", func(t *testing.T) {
 		r := httptest.NewRequest(http.MethodGet, "/api/open-file?path=/tmp/test", http.NoBody)
 		w := httptest.NewRecorder()
-		app.handleOpenFile(w, r)
+		app.commands.handleOpenFile(w, r)
 		if w.Code != http.StatusMethodNotAllowed {
 			t.Errorf("expected 405, got %d", w.Code)
 		}

--- a/internal/dataentry/router.go
+++ b/internal/dataentry/router.go
@@ -75,9 +75,7 @@ func (a *App) NewRouter() http.Handler {
 
 	// APIs used by Vue SPA
 	inner.HandleFunc("/api/help/", a.handleEntityHelp)
-	inner.HandleFunc("/api/command/", a.handleCommandExec)
-	inner.HandleFunc("/api/command-cancel/", a.handleCommandCancel)
-	inner.HandleFunc("/api/open-file", a.handleOpenFile)
+	a.commands.registerCommandRoutes(inner)
 	inner.HandleFunc("/api/git/status", a.handleGitStatus)
 	inner.HandleFunc("/api/git/sync", a.handleGitSync)
 

--- a/internal/dataentry/test_helpers_test.go
+++ b/internal/dataentry/test_helpers_test.go
@@ -166,6 +166,15 @@ func rebindApp(app *App, fs storage.FS, paths *project.Context, svc *appbuild.Se
 	// own, so sync writes serialize with the other mutation handlers just as in
 	// production.
 	app.sync = newSyncHandler(svc.Store(), svc.EntityManager(), &app.writeMu)
+	// commandHandler holds closures over App methods, which read the fields
+	// rebound above — so it stays valid after this rebind. (Rebuilt rather than
+	// relying on a nil zero value, since newHandlerTestApp bypasses NewApp.)
+	app.commands = &commandHandler{
+		schema:      app.State,
+		services:    app.Services,
+		projectRoot: app.ProjectRoot,
+		executeView: app.executeView,
+	}
 }
 
 // rebindSyncHandler rebuilds app.sync over the app's CURRENT store/manager.

--- a/tickets/entities/review-checklists/REV-3YZMJ.md
+++ b/tickets/entities/review-checklists/REV-3YZMJ.md
@@ -1,0 +1,29 @@
+---
+id: REV-3YZMJ
+type: review-checklist
+title: 'Review: Extract command route cluster into commandHandler'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Automated Checks
+
+- [x] All tests pass (`go test -race ./internal/dataentry/...`)
+- [x] Lint clean (`golangci-lint run internal/dataentry/...`) — 0 issues
+- [x] `gofmt` clean
+- [x] `just plimsoll` passes — `App` directive ratcheted 154 → 143
+- [x] `just arch-lint` passes
+- [x] Builds + vet across default / `postgres` / `memorybackend` tags
+
+## Manual Review
+
+- [x] Self-reviewed the diff for unrelated changes
+- [x] Collaborators are narrow closures over App (consumer-side), mirroring `affordanceService`
+- [x] Routing behavior unchanged — same endpoints mounted; `handleOpenURL` stays a tested-but-unmounted method as before
+- [x] `resolveCommands` moved with the cluster; `handleV1Commands` delegates via `a.commands.resolveCommands`
+- [x] Handler owns no mutable state — in-flight exec registry stays a package-level `sync.Map`
+- [x] ~~`/code-review` command~~ (N/A: mechanical method-move refactor, no behavior change; verified by the unchanged, still-passing command test suite)
+- [x] ~~Critical/significant review-responses addressed~~ (N/A: no review run)
+
+**Review Responses:** N/A — mechanical extraction, behavior-preserving.

--- a/tickets/entities/tickets/TKT-KUFLD.md
+++ b/tickets/entities/tickets/TKT-KUFLD.md
@@ -1,0 +1,33 @@
+---
+id: TKT-KUFLD
+type: ticket
+title: Extract dataentry command route cluster into commandHandler
+kind: refactor
+priority: medium
+effort: s
+status: done
+---
+
+Sub-ticket of the [[TKT-R68TV8]] `dataentry.App` decomposition arc (M5.2).
+Delivered in PR #1138 (stacked on [[TKT-VG9P1]] / #1134).
+
+## What
+
+Moved the 11-method user-command surface (`commands.go`) off `App` into a new
+`commandHandler`.
+
+- **`App`: 154 → 143 methods** — `//plimsoll:max-methods` directive ratcheted.
+- Covers the SSE shell-exec endpoints (`/api/command/`, `/api/command-cancel/`),
+the file/URL launchers (`/api/open-file`; `handleOpenURL` stays a tested method,
+unmounted as before), and `resolveCommands` (consumed by `handleV1Commands`,
+which now delegates via `a.commands.resolveCommands`).
+- Collaborators are narrow **closures over App** (consumer-side interfaces),
+mirroring `affordanceService`: `schema`, `services`, `projectRoot`,
+`executeView`. The handler owns no mutable state — the in-flight exec registry
+stays a package-level `sync.Map`.
+
+## Verification
+
+- `go test -race ./internal/dataentry/...`
+- Builds + vet across default / `postgres` / `memorybackend`
+- `just plimsoll`, `just arch-lint`, `golangci-lint` (0 issues), `gofmt`

--- a/tickets/entities/tickets/TKT-R68TV8.md
+++ b/tickets/entities/tickets/TKT-R68TV8.md
@@ -5,47 +5,44 @@ title: 'Finish dataentry.App decomposition: command/sync handlers + write nucleu
 kind: refactor
 priority: medium
 effort: m
-status: ready
+status: backlog
 ---
 
-Follow-up to TKT-N26KLB. That ticket drove `dataentry.App` from 227 methods down
-to ~166 and landed the structural payoff — the ACL-bounded `visibleReader` seam
-that closes the #1010 read-ACL bug class — but stopped short of the original
-`<40` end goal. We chose to ship that progress rather than block the plimsoll
-ratchet on the whole refactor. This ticket tracks the remainder.
+**Epic / parent ticket** for the remainder of the `dataentry.App` decomposition.
+Each shippable step is its own sub-ticket (moved to `done` with its PR); this
+parent stays in `backlog` until the whole arc lands — App under the 40-method
+line with the plimsoll directive deleted. (Per-PR sub-tickets satisfy the
+done-before-merge gate honestly: a multi-PR epic can't be `done` while work
+remains, and `backlog` is the allowed "not-touched-by-this-PR" parent state.)
 
-The AppState state-decomposition prerequisite (TKT-XSWFXQ) is now done, so the
-snapshot/`writeMu` publish coupling is gone and the handler clusters can move
-off `App` one at a time.
+Follow-up to the earlier decomposition that drove `dataentry.App` from 227
+methods down to ~166 and landed the structural payoff — the ACL-bounded
+`visibleReader` seam that closes the #1010 read-ACL bug class — but stopped
+short of the original `<40` end goal. The AppState state-decomposition
+prerequisite ([[TKT-XSWFXQ]]) is also done, so the snapshot/`writeMu` publish
+coupling is gone and the handler clusters can move off `App` one at a time.
 
-## Remaining steps (from the M5 plan)
+## Sub-tickets
 
-- **M5.2** — extract command + sync handlers off `App`.
-  - [x] **Sync handler cluster** → `syncHandler` (16 methods; `App` 170 → 154,
-directive ratcheted). Narrow consumer-side interfaces (`syncStore`,
-`syncDeleter`) + capabilities resolved once from the concrete store/manager;
-`writeMu` shared by pointer so sync writes still serialize with the other
-mutation handlers.
-  - [x] **Command handler cluster** → `commandHandler` (11 methods; `App` 154 →
-143, directive ratcheted). Owns the SSE shell-exec endpoints, the file/URL
-launchers, and `resolveCommands` (consumed by `handleV1Commands`). Narrow
-closures over the schema snapshot, Services bundle, project root, and the view
-executor; no mutable state (the in-flight exec registry stays a package-level
-`sync.Map`).
-- **M5.4** — carve the write nucleus + entity/relation/attachment write handlers
-behind one shared `writeMu`; drive `App` under the 40-method line and delete the
+- **M5.2 — extract command + sync handlers off `App`.**
+  - [x] [[TKT-VG9P1]] — sync route cluster → `syncHandler` (170 → 154). PR #1134.
+  - [x] [[TKT-KUFLD]] — command route cluster → `commandHandler` (154 → 143).
+PR #1138.
+  - [ ] Attachment handler cluster (`handlers_attachment.go`, ~12 methods).
+- **M5.4 — write nucleus.** Carve the entity/relation/attachment write handlers
+behind one shared `writeMu`; drive `App` under 40 and delete the
 `//plimsoll:max-methods` directive in `internal/dataentry/app.go`.
   - **Open question to settle first:** does write-serialization move *behind the
 store* (the CLAUDE.md-endorsed direction) or stay an App-level mutex the write
 handlers share by pointer (as `syncHandler` does today)? Worth a design-review
 before extracting the write handlers.
 
-## Invariants (unchanged from M5)
+## Invariants (unchanged)
 
 - Read handlers take the ACL-bounded `visibleReader` only — never `store.Store`.
 - `writeMu` stays a single shared instance across all write handlers (race
-detector guards). The extracted `syncHandler` holds a *pointer* to `App`'s
-`writeMu`, preserving this.
+detector guards). The extracted handlers hold a *pointer* to `App`'s `writeMu`,
+preserving this.
 
 ## Related finding
 

--- a/tickets/entities/tickets/TKT-R68TV8.md
+++ b/tickets/entities/tickets/TKT-R68TV8.md
@@ -5,44 +5,47 @@ title: 'Finish dataentry.App decomposition: command/sync handlers + write nucleu
 kind: refactor
 priority: medium
 effort: m
-status: backlog
+status: ready
 ---
 
-**Epic / parent ticket** for the remainder of the `dataentry.App` decomposition.
-Each shippable step is its own sub-ticket (moved to `done` with its PR); this
-parent stays in `backlog` until the whole arc lands — App under the 40-method
-line with the plimsoll directive deleted. (Per-PR sub-tickets satisfy the
-done-before-merge gate honestly: a multi-PR epic can't be `done` while work
-remains, and `backlog` is the allowed "not-touched-by-this-PR" parent state.)
+Follow-up to TKT-N26KLB. That ticket drove `dataentry.App` from 227 methods down
+to ~166 and landed the structural payoff — the ACL-bounded `visibleReader` seam
+that closes the #1010 read-ACL bug class — but stopped short of the original
+`<40` end goal. We chose to ship that progress rather than block the plimsoll
+ratchet on the whole refactor. This ticket tracks the remainder.
 
-Follow-up to the earlier decomposition that drove `dataentry.App` from 227
-methods down to ~166 and landed the structural payoff — the ACL-bounded
-`visibleReader` seam that closes the #1010 read-ACL bug class — but stopped
-short of the original `<40` end goal. The AppState state-decomposition
-prerequisite ([[TKT-XSWFXQ]]) is also done, so the snapshot/`writeMu` publish
-coupling is gone and the handler clusters can move off `App` one at a time.
+The AppState state-decomposition prerequisite (TKT-XSWFXQ) is now done, so the
+snapshot/`writeMu` publish coupling is gone and the handler clusters can move
+off `App` one at a time.
 
-## Sub-tickets
+## Remaining steps (from the M5 plan)
 
-- **M5.2 — extract command + sync handlers off `App`.**
-  - [x] [[TKT-VG9P1]] — sync route cluster → `syncHandler` (170 → 154). PR #1134.
-  - [x] [[TKT-KUFLD]] — command route cluster → `commandHandler` (154 → 143).
-PR #1138.
-  - [ ] Attachment handler cluster (`handlers_attachment.go`, ~12 methods).
-- **M5.4 — write nucleus.** Carve the entity/relation/attachment write handlers
-behind one shared `writeMu`; drive `App` under 40 and delete the
+- **M5.2** — extract command + sync handlers off `App`.
+  - [x] **Sync handler cluster** → `syncHandler` (16 methods; `App` 170 → 154,
+directive ratcheted). Narrow consumer-side interfaces (`syncStore`,
+`syncDeleter`) + capabilities resolved once from the concrete store/manager;
+`writeMu` shared by pointer so sync writes still serialize with the other
+mutation handlers.
+  - [x] **Command handler cluster** → `commandHandler` (11 methods; `App` 154 →
+143, directive ratcheted). Owns the SSE shell-exec endpoints, the file/URL
+launchers, and `resolveCommands` (consumed by `handleV1Commands`). Narrow
+closures over the schema snapshot, Services bundle, project root, and the view
+executor; no mutable state (the in-flight exec registry stays a package-level
+`sync.Map`).
+- **M5.4** — carve the write nucleus + entity/relation/attachment write handlers
+behind one shared `writeMu`; drive `App` under the 40-method line and delete the
 `//plimsoll:max-methods` directive in `internal/dataentry/app.go`.
   - **Open question to settle first:** does write-serialization move *behind the
 store* (the CLAUDE.md-endorsed direction) or stay an App-level mutex the write
 handlers share by pointer (as `syncHandler` does today)? Worth a design-review
 before extracting the write handlers.
 
-## Invariants (unchanged)
+## Invariants (unchanged from M5)
 
 - Read handlers take the ACL-bounded `visibleReader` only — never `store.Store`.
 - `writeMu` stays a single shared instance across all write handlers (race
-detector guards). The extracted handlers hold a *pointer* to `App`'s `writeMu`,
-preserving this.
+detector guards). The extracted `syncHandler` holds a *pointer* to `App`'s
+`writeMu`, preserving this.
 
 ## Related finding
 

--- a/tickets/relations/TKT-KUFLD--affects--ci-pipeline.md
+++ b/tickets/relations/TKT-KUFLD--affects--ci-pipeline.md
@@ -1,0 +1,5 @@
+---
+from: TKT-KUFLD
+relation: affects
+to: ci-pipeline
+---

--- a/tickets/relations/TKT-KUFLD--depends-on--TKT-VG9P1.md
+++ b/tickets/relations/TKT-KUFLD--depends-on--TKT-VG9P1.md
@@ -1,0 +1,5 @@
+---
+from: TKT-KUFLD
+relation: depends-on
+to: TKT-VG9P1
+---

--- a/tickets/relations/TKT-KUFLD--has-review--REV-3YZMJ.md
+++ b/tickets/relations/TKT-KUFLD--has-review--REV-3YZMJ.md
@@ -1,0 +1,5 @@
+---
+from: TKT-KUFLD
+relation: has-review
+to: REV-3YZMJ
+---

--- a/tickets/relations/TKT-KUFLD--implements--FEAT-GE1YY.md
+++ b/tickets/relations/TKT-KUFLD--implements--FEAT-GE1YY.md
@@ -1,0 +1,5 @@
+---
+from: TKT-KUFLD
+relation: implements
+to: FEAT-GE1YY
+---


### PR DESCRIPTION
Stacked on #1134. Second handler-cluster extraction of TKT-R68TV8 (M5.2).

## What

Moves the 11-method user-command surface (`commands.go`) off `App` into a new `commandHandler`.

- **`App`: 154 → 143 methods** — `//plimsoll:max-methods` directive ratcheted down again.
- Covers the SSE shell-exec endpoints (`/api/command/`, `/api/command-cancel/`), the file/URL launchers (`/api/open-file`; `handleOpenURL` stays a tested method, unmounted as before), and `resolveCommands` (consumed by `handleV1Commands`, which now delegates via `a.commands.resolveCommands`).
- Collaborators are narrow **closures over App** (consumer-side interfaces per CLAUDE.md), mirroring `affordanceService`: `schema func() *Schema`, `services func() Services`, `projectRoot func() string`, `executeView func(...)`. No handle to `App`.
- The handler owns **no mutable state** — the in-flight exec registry stays a package-level `sync.Map` shared with the cancel handler.
- Routing consolidated behind `commandHandler.registerCommandRoutes`; behavior unchanged (same routes mounted as before).

## Verification

- `go test -race ./internal/dataentry/...` — pass
- Builds + vet across default / `postgres` / `memorybackend` tags
- `just plimsoll`, `just arch-lint`, `golangci-lint` (0 issues), `gofmt` — all clean

Tracked by TKT-R68TV8.