### PR TITLE
feat(acl): rela acl who-can <verb> <entity> with provenance (TKT-9089I6)

### DIFF
--- a/.go-arch-lint.yml
+++ b/.go-arch-lint.yml
@@ -90,6 +90,7 @@ components:
   # Infrastructure
   acl:              { in: internal/acl }
   aclaudit:         { in: internal/aclaudit }
+  aclmap:           { in: internal/aclmap }
   affordances:      { in: internal/affordances }
   ai:               { in: internal/ai }
   audit:            { in: internal/audit }
@@ -200,6 +201,7 @@ deps:
     mayDependOn:
       - acl
       - aclaudit
+      - aclmap
       - ai
       - analysis
       - app
@@ -430,6 +432,12 @@ deps:
   aclaudit:
     mayDependOn:
       - acl
+  aclmap:
+    mayDependOn:
+      - acl
+      - entity
+      - principal
+      - store
   affordances:
     mayDependOn:
       - acl

--- a/internal/acl/access.go
+++ b/internal/acl/access.go
@@ -1,0 +1,191 @@
+package acl
+
+import (
+	"context"
+	"fmt"
+)
+
+// Verb is a read-or-write access verb the who-can query asks about. It
+// widens [Op] (create/update/delete/rename) with read, which has no Op
+// because the write path never authorizes reads — the read path is
+// [Request.readQuery]. VerbRead routes through the read machinery;
+// every other verb routes through the per-verb write grant.
+type Verb string
+
+// Verb constants. VerbRead maps to the read path; the rest map 1:1 to
+// the write [Op] of the same name.
+const (
+	VerbRead   Verb = "read"
+	VerbCreate Verb = "create"
+	VerbUpdate Verb = "update"
+	VerbDelete Verb = "delete"
+)
+
+// Valid reports whether v is one of the known verbs. Unknown verbs must
+// be rejected rather than defaulted — a fail-closed access tool never
+// silently treats a garbage verb as "read".
+func (v Verb) Valid() bool {
+	switch v {
+	case VerbRead, VerbCreate, VerbUpdate, VerbDelete:
+		return true
+	default:
+		return false
+	}
+}
+
+// op maps a write Verb to its [Op]. VerbRead has no Op (read never goes
+// through the write path) and returns ("", false).
+func (v Verb) op() (Op, bool) {
+	switch v {
+	case VerbCreate:
+		return OpCreate, true
+	case VerbUpdate:
+		return OpUpdate, true
+	case VerbDelete:
+		return OpDelete, true
+	default:
+		return "", false
+	}
+}
+
+// EveryoneGrant reports how a policy grants a verb to *every* principal
+// via the built-in "everyone" role — the case that must be reported
+// once, globally, rather than per enumerated principal (the `everyone`
+// role is appended to every principal's effective set, so enumerating
+// principals for it would be both redundant and wrong-shaped).
+type EveryoneGrant struct {
+	// Granted is true when the "everyone" role is declared and grants
+	// the verb on the target type (directly or via a "*" wildcard).
+	Granted bool
+	// Wildcard is true when the grant came from a "*" entry rather than
+	// an exact type match — worth surfacing because it means the grant
+	// covers every type, not just this one.
+	Wildcard bool
+}
+
+// EveryoneGrants reports whether the built-in "everyone" role grants
+// verb on entityType. Callers use this to print a single global
+// "everyone (all principals, incl. unauthenticated)" line instead of
+// attributing the everyone role to each enumerated principal.
+//
+// Read and write verbs are checked against the same policy fields the
+// runtime consults (roleGrantsRead for read, grantsVerb for writes), so
+// this can never disagree with an actual authorization decision.
+func (d *Declarative) EveryoneGrants(verb Verb, entityType string) EveryoneGrant {
+	role, ok := d.policy.Roles[EveryoneRole]
+	if !ok {
+		return EveryoneGrant{}
+	}
+	return grantForRole(role, verb, entityType)
+}
+
+// grantForRole reports whether one role grants verb on entityType and
+// whether the match came from a "*" wildcard. It is the single place
+// the verb→field mapping lives, shared by EveryoneGrants and
+// Request.AccessRoutes so their answers can't drift.
+func grantForRole(role RoleDef, verb Verb, entityType string) EveryoneGrant {
+	var list []string
+	if verb == VerbRead {
+		list = role.Read
+	} else {
+		op, ok := verb.op()
+		if !ok {
+			return EveryoneGrant{}
+		}
+		switch op {
+		case OpCreate:
+			list = role.Create
+		case OpUpdate, OpRename:
+			list = role.Update
+		case OpDelete:
+			list = role.Delete
+		}
+	}
+	for _, t := range list {
+		if t == "*" {
+			return EveryoneGrant{Granted: true, Wildcard: true}
+		}
+		if t == entityType {
+			return EveryoneGrant{Granted: true}
+		}
+	}
+	return EveryoneGrant{}
+}
+
+// AccessRoutes returns the attributions by which this Request's
+// principal is granted verb on the entity (entityID of entityType),
+// EXCLUDING the built-in "everyone" role (reported once globally via
+// [Declarative.EveryoneGrants], never per-principal).
+//
+// It is the who-can building block. The returned attributions carry the
+// full (role, Source) provenance the resolver already computes — all
+// distinct routes, deduped, never collapsed to a primary source.
+//
+// The BOOLEAN "has any access" answer is authoritative and matches the
+// runtime exactly — no false negatives:
+//
+//   - Write verbs (create/update/delete): an attribution's role grants
+//     the verb via the same grantsVerb the write path uses. The write
+//     path IS this attribution set, so equivalence is by construction.
+//   - Read: gated by [Request.PermitsRead] — the actual runtime read
+//     decision. If PermitsRead is false the result is empty; if true,
+//     the returned attributions are those whose role grants read
+//     (roleGrantsRead). Because the boolean is the runtime's own answer,
+//     "who-can read reports nobody" can never contradict a real allow.
+//     An error from the read backend is returned so the caller fails
+//     loud rather than silently under-reporting readers.
+//
+// The "everyone" role is skipped here on purpose: it lands in every
+// principal's global attributions unconditionally, so including it
+// would report it once per enumerated principal. Callers surface it
+// separately and globally.
+func (r *Request) AccessRoutes(
+	ctx context.Context, verb Verb, entityType, entityID string,
+) ([]RoleAttribution, error) {
+	if !verb.Valid() {
+		return nil, fmt.Errorf("acl: AccessRoutes: unknown verb %q", verb)
+	}
+	if verb == VerbRead {
+		permitted, err := r.PermitsRead(ctx, entityType, entityID)
+		if err != nil {
+			return nil, err
+		}
+		if !permitted {
+			return nil, nil
+		}
+		return r.grantingAttributions(ctx, VerbRead, entityType, entityID), nil
+	}
+	return r.grantingAttributions(ctx, verb, entityType, entityID), nil
+}
+
+// grantingAttributions filters the per-entity attribution set to those
+// whose role grants verb on entityType, excluding the everyone role.
+// The verb→predicate mapping is the same one the runtime uses
+// (roleGrantsRead / grantsVerb), so the routes it credits are the real
+// reasons access was granted.
+func (r *Request) grantingAttributions(
+	ctx context.Context, verb Verb, entityType, entityID string,
+) []RoleAttribution {
+	attrs := r.ForEntity(ctx, entityType, entityID)
+	op, isWrite := verb.op()
+	var out []RoleAttribution
+	for _, a := range attrs {
+		if a.Role == EveryoneRole {
+			continue
+		}
+		role, ok := r.d.policy.Roles[a.Role]
+		if !ok {
+			continue
+		}
+		var granted bool
+		if isWrite {
+			granted = grantsVerb(role, op, entityType)
+		} else {
+			granted = roleGrantsRead(role, entityType)
+		}
+		if granted {
+			out = append(out, a)
+		}
+	}
+	return out
+}

--- a/internal/aclmap/aclmap.go
+++ b/internal/aclmap/aclmap.go
@@ -1,0 +1,127 @@
+// Package aclmap materializes slices of the effective-access relation —
+// who can perform a verb on an entity, and by which route — from the
+// declarative ACL policy plus the graph. It is the read-only reporting
+// side of authorization: it answers questions the per-request resolver
+// (internal/acl) can only answer one principal at a time, by enumerating
+// the principal universe and asking the resolver about each.
+//
+// This package holds the UC3 slice — WhoCan on a single entity (see
+// FEAT-RCQ6SJ / TKT-9089I6). The per-principal map, drift, and
+// conformance modes are separate follow-ups that will share this
+// enumeration.
+//
+// Provenance depth is TERMINAL FACTS in this slice: each route names the
+// kind plus the group / ancestor / relation by name (enough to act on —
+// e.g. delete the named edge to revoke), not the full hop-by-hop chain.
+// The route JSON is shaped as a list of route objects so the later
+// full-chain work can add a hops field without a breaking change.
+package aclmap
+
+import (
+	"context"
+	"errors"
+	"iter"
+
+	"github.com/Sourcehaven-BV/rela/internal/acl"
+	"github.com/Sourcehaven-BV/rela/internal/entity"
+	"github.com/Sourcehaven-BV/rela/internal/principal"
+	"github.com/Sourcehaven-BV/rela/internal/store"
+)
+
+// EntitySource is the narrow read access the engine needs: fetch one
+// entity (existence gate + type lookup), list entities of a type
+// (resolvable user principals), and list relations of a type (to find
+// role-relation edge sources — principals granted a role by a graph
+// edge). Declared here, at the consumer, rather than depending on the
+// full store.Store; *store.Store satisfies it.
+type EntitySource interface {
+	GetEntity(ctx context.Context, id string) (*entity.Entity, error)
+	ListEntities(ctx context.Context, q store.EntityQuery) iter.Seq2[*entity.Entity, error]
+	ListRelations(ctx context.Context, q store.RelationQuery) iter.Seq2[*entity.Relation, error]
+}
+
+// Resolver is the per-principal ACL access the engine needs. Satisfied
+// by *acl.Declarative. Declared consumer-side so the engine binds only
+// to the calls it makes.
+type Resolver interface {
+	ForPrincipal(p principal.Principal) (*acl.Request, error)
+	ResolvePrincipal(ctx context.Context, rawUser string) (string, error)
+	EveryoneGrants(verb acl.Verb, entityType string) acl.EveryoneGrant
+	Policy() *acl.Policy
+}
+
+// Engine answers who-can queries. Construct with New; it holds only the
+// two narrow collaborators.
+type Engine struct {
+	src      EntitySource
+	resolver Resolver
+}
+
+// New constructs an Engine. Both collaborators are required; a nil
+// either is a programmer error (constructors-reject-nil).
+func New(src EntitySource, resolver Resolver) (*Engine, error) {
+	if src == nil {
+		return nil, errors.New("aclmap: New: EntitySource must be non-nil")
+	}
+	if resolver == nil {
+		return nil, errors.New("aclmap: New: Resolver must be non-nil")
+	}
+	return &Engine{src: src, resolver: resolver}, nil
+}
+
+// Route is one way a principal (or everyone) is granted the verb, at
+// terminal-fact depth. Kind is the acl.SourceKind string; Role is the
+// role the route confers; Group / Ancestor / Relation name the terminal
+// entities of the route and are populated per kind (empty otherwise),
+// mirroring acl.Source. A later change may add a Hops field for the
+// full chain without breaking this shape.
+type Route struct {
+	Kind     string `json:"kind"`
+	Role     string `json:"role"`
+	Group    string `json:"group,omitempty"`
+	Ancestor string `json:"ancestor,omitempty"`
+	Relation string `json:"relation,omitempty"`
+}
+
+// PrincipalAccess is one principal's grant of the verb on the entity,
+// with every route that grants it. Principal is the effective identity
+// the resolver used (a resolved entity ID when principal_property
+// resolved it, else the raw key). Raw is set only when it differs from
+// Principal, so the caller can show both.
+type PrincipalAccess struct {
+	Principal string  `json:"principal"`
+	Raw       string  `json:"raw,omitempty"`
+	Routes    []Route `json:"routes"`
+}
+
+// Everyone describes a global grant of the verb via the built-in
+// everyone role, when present. Reported once (not per principal).
+type Everyone struct {
+	Granted  bool `json:"granted"`
+	Wildcard bool `json:"wildcard"`
+}
+
+// WhoCanResult is the answer to "who can <verb> <entity>". SchemaVersion
+// is bumped on any breaking change to this shape so snapshot/diff
+// consumers can detect format changes. Everyone is the global everyone
+// grant; Principals is every enumerated principal with a non-everyone
+// route, sorted by principal ID.
+type WhoCanResult struct {
+	SchemaVersion int               `json:"schema_version"`
+	Verb          string            `json:"verb"`
+	Entity        string            `json:"entity"`
+	EntityType    string            `json:"entity_type"`
+	Everyone      Everyone          `json:"everyone"`
+	Principals    []PrincipalAccess `json:"principals"`
+}
+
+// schemaVersion is the WhoCanResult wire version. Bump on breaking
+// changes (field removal/rename/semantic change); additive fields do
+// not require a bump.
+const schemaVersion = 1
+
+// ErrEntityNotFound is returned by WhoCan when the entity does not
+// exist. Reporting readers for a non-existent entity would be a
+// misleading attestation (a typo'd ID must error, not return the
+// global-only reader set).
+var ErrEntityNotFound = errors.New("aclmap: entity not found")

--- a/internal/aclmap/enumerate.go
+++ b/internal/aclmap/enumerate.go
@@ -24,12 +24,20 @@ import (
 // holds NO direct assignment and is NOT of user_entity_type (which may
 // be unset): they gain their role purely by being a member of a group
 // that is an assignment key. Omitting them drops exactly the
-// group-conferred principals — the false negative the who-can tool must
-// never produce.
+// group-conferred principals — a false negative.
 //
-// The everyone role is not a principal and is reported globally. This is
-// the O(principals) universe the ticket's cost note describes; a reverse
-// principal→entity index is a later optimization.
+// No candidate is excluded by graph TOPOLOGY. An earlier version dropped
+// membership-relation targets as "groups", but "is a membership target"
+// is not the same predicate as "is a non-actor container": a manager who
+// has reports (a membership target) is also a real principal, and
+// excluding them dropped a genuine grantee (RR-C5Q743). Correctness — the
+// runtime's own answer for every candidate — beats hiding group entities.
+// A candidate that carries no grant for the queried entity/verb simply
+// yields no row; only the "everyone" role is special-cased, and it is
+// reported globally, not per candidate.
+//
+// This is the O(principals) universe the ticket's cost note describes; a
+// reverse principal→entity index is a later optimization.
 func (e *Engine) enumeratePrincipals(ctx context.Context) ([]string, error) {
 	policy := e.resolver.Policy()
 	set := map[string]struct{}{}
@@ -52,14 +60,7 @@ func (e *Engine) enumeratePrincipals(ctx context.Context) ([]string, error) {
 	// Sources of membership and role-relation edges. Both are read via
 	// the relation index keyed by type; the membership relation is the
 	// effective one (default member-of) so it honors a policy override.
-	// Membership TARGETS (groups) are collected separately: a group is a
-	// role container, not an actor — it must not be listed as a principal
-	// even though, resolved as one, it would carry its own assigned role.
-	// Excluding groups keeps the report to real actors and avoids
-	// double-reporting a grant against both the group and its members.
-	groups := map[string]struct{}{}
-	membershipRel := policy.EffectiveMembershipRelation()
-	relTypes := map[string]struct{}{membershipRel: {}}
+	relTypes := map[string]struct{}{policy.EffectiveMembershipRelation(): {}}
 	for relType := range policy.RoleRelations {
 		relTypes[relType] = struct{}{}
 	}
@@ -72,28 +73,13 @@ func (e *Engine) enumeratePrincipals(ctx context.Context) ([]string, error) {
 				return nil, fmt.Errorf("aclmap: list %s relations: %w", relType, err)
 			}
 			set[rel.From] = struct{}{}
-			if relType == membershipRel {
-				groups[rel.To] = struct{}{}
-			}
 		}
 	}
 
 	out := make([]string, 0, len(set))
 	for k := range set {
-		if _, isGroup := groups[k]; isGroup {
-			continue
-		}
 		out = append(out, k)
 	}
 	sort.Strings(out)
 	return out, nil
-}
-
-// resolvePrincipal maps a raw principal key to a user entity ID via the
-// policy's principal_property lookup. Returns "" when the lookup is
-// disabled or no entity matches (the caller keeps the raw key). An
-// ambiguous or errored lookup is surfaced so the report fails loud
-// rather than silently mis-attributing.
-func (e *Engine) resolvePrincipal(ctx context.Context, raw string) (string, error) {
-	return e.resolver.ResolvePrincipal(ctx, raw)
 }

--- a/internal/aclmap/enumerate.go
+++ b/internal/aclmap/enumerate.go
@@ -1,0 +1,99 @@
+package aclmap
+
+import (
+	"context"
+	"fmt"
+	"sort"
+
+	"github.com/Sourcehaven-BV/rela/internal/store"
+)
+
+// enumeratePrincipals returns the deduplicated, sorted set of candidate
+// principal identifiers that could hold a non-everyone grant:
+//
+//   - every entity of the policy's user_entity_type (the resolvable
+//     human principals), when that type is configured;
+//   - every key in Assignments (direct + group grant keys, incl.
+//     raw-UPN break-glass keys);
+//   - the source (From) of every membership-relation edge — a member of
+//     a group, who inherits the group's assigned role;
+//   - the source (From) of every role-relation edge — a principal
+//     granted a role by a graph edge.
+//
+// The membership-relation sources matter because a person typically
+// holds NO direct assignment and is NOT of user_entity_type (which may
+// be unset): they gain their role purely by being a member of a group
+// that is an assignment key. Omitting them drops exactly the
+// group-conferred principals — the false negative the who-can tool must
+// never produce.
+//
+// The everyone role is not a principal and is reported globally. This is
+// the O(principals) universe the ticket's cost note describes; a reverse
+// principal→entity index is a later optimization.
+func (e *Engine) enumeratePrincipals(ctx context.Context) ([]string, error) {
+	policy := e.resolver.Policy()
+	set := map[string]struct{}{}
+
+	// Assignment keys.
+	for key := range policy.Assignments {
+		set[key] = struct{}{}
+	}
+
+	// User-entity-type entities.
+	if ut := policy.UserEntityType; ut != "" {
+		for ent, err := range e.src.ListEntities(ctx, store.EntityQuery{Type: ut}) {
+			if err != nil {
+				return nil, fmt.Errorf("aclmap: list %s entities: %w", ut, err)
+			}
+			set[ent.ID] = struct{}{}
+		}
+	}
+
+	// Sources of membership and role-relation edges. Both are read via
+	// the relation index keyed by type; the membership relation is the
+	// effective one (default member-of) so it honors a policy override.
+	// Membership TARGETS (groups) are collected separately: a group is a
+	// role container, not an actor — it must not be listed as a principal
+	// even though, resolved as one, it would carry its own assigned role.
+	// Excluding groups keeps the report to real actors and avoids
+	// double-reporting a grant against both the group and its members.
+	groups := map[string]struct{}{}
+	membershipRel := policy.EffectiveMembershipRelation()
+	relTypes := map[string]struct{}{membershipRel: {}}
+	for relType := range policy.RoleRelations {
+		relTypes[relType] = struct{}{}
+	}
+	for relType := range relTypes {
+		for rel, err := range e.src.ListRelations(ctx, store.RelationQuery{
+			Type:      relType,
+			Direction: store.DirectionOutgoing,
+		}) {
+			if err != nil {
+				return nil, fmt.Errorf("aclmap: list %s relations: %w", relType, err)
+			}
+			set[rel.From] = struct{}{}
+			if relType == membershipRel {
+				groups[rel.To] = struct{}{}
+			}
+		}
+	}
+
+	out := make([]string, 0, len(set))
+	for k := range set {
+		if _, isGroup := groups[k]; isGroup {
+			continue
+		}
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out, nil
+}
+
+// resolvePrincipal maps a raw principal key to a user entity ID via the
+// policy's principal_property lookup. Returns "" when the lookup is
+// disabled or no entity matches (the caller keeps the raw key). An
+// ambiguous or errored lookup is surfaced so the report fails loud
+// rather than silently mis-attributing.
+func (e *Engine) resolvePrincipal(ctx context.Context, raw string) (string, error) {
+	return e.resolver.ResolvePrincipal(ctx, raw)
+}

--- a/internal/aclmap/whocan.go
+++ b/internal/aclmap/whocan.go
@@ -58,19 +58,57 @@ func (e *Engine) WhoCan(ctx context.Context, verb acl.Verb, entityID string) (*W
 		return nil, err
 	}
 
+	// Merge by EFFECTIVE principal: a single human can appear as several
+	// candidate keys (a raw-UPN assignment key AND the resolved user
+	// entity it maps to), which must collapse to one row with a unioned
+	// route set — otherwise the same principal is reported twice and the
+	// diff artifact this feeds is corrupt (RR-XC2NTO).
+	byPrincipal := map[string]*PrincipalAccess{}
+	var order []string
 	for _, raw := range candidates {
 		access, ok, err := e.accessFor(ctx, raw, verb, entityType, entityID)
 		if err != nil {
 			return nil, err
 		}
-		if ok {
-			result.Principals = append(result.Principals, access)
+		if !ok {
+			continue
+		}
+		existing, seen := byPrincipal[access.Principal]
+		if !seen {
+			acc := access
+			byPrincipal[access.Principal] = &acc
+			order = append(order, access.Principal)
+			continue
+		}
+		existing.Routes = mergeRoutes(existing.Routes, access.Routes)
+		if existing.Raw == "" {
+			existing.Raw = access.Raw
 		}
 	}
-	sort.Slice(result.Principals, func(i, j int) bool {
-		return result.Principals[i].Principal < result.Principals[j].Principal
-	})
+	sort.Strings(order)
+	for _, id := range order {
+		result.Principals = append(result.Principals, *byPrincipal[id])
+	}
 	return result, nil
+}
+
+// mergeRoutes unions two route sets, dropping exact duplicates, and
+// returns them re-sorted so the output stays deterministic regardless of
+// which candidate key surfaced each route.
+func mergeRoutes(a, b []Route) []Route {
+	seen := make(map[Route]struct{}, len(a)+len(b))
+	out := make([]Route, 0, len(a)+len(b))
+	for _, rs := range [][]Route{a, b} {
+		for _, r := range rs {
+			if _, dup := seen[r]; dup {
+				continue
+			}
+			seen[r] = struct{}{}
+			out = append(out, r)
+		}
+	}
+	sort.Slice(out, func(i, j int) bool { return lessRoute(out[i], out[j]) })
+	return out
 }
 
 // accessFor resolves one raw principal key, asks the resolver for the
@@ -89,8 +127,10 @@ func (e *Engine) accessFor(
 		return PrincipalAccess{}, false, nil
 	}
 	rawShown := ""
-	// Resolve raw → entity ID when principal_property is configured.
-	if id, err := e.resolvePrincipal(ctx, raw); err != nil {
+	// Resolve raw → entity ID when principal_property is configured. An
+	// ambiguous or errored lookup fails the report loud rather than
+	// silently mis-attributing.
+	if id, err := e.resolver.ResolvePrincipal(ctx, raw); err != nil {
 		return PrincipalAccess{}, false, err
 	} else if id != "" && id != raw {
 		user = id

--- a/internal/aclmap/whocan.go
+++ b/internal/aclmap/whocan.go
@@ -1,0 +1,151 @@
+package aclmap
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/Sourcehaven-BV/rela/internal/acl"
+	"github.com/Sourcehaven-BV/rela/internal/principal"
+	"github.com/Sourcehaven-BV/rela/internal/store"
+)
+
+// WhoCan reports every principal who can perform verb on the entity
+// entityID, each with the route(s) that grant it, plus a single global
+// entry when the built-in everyone role grants the verb.
+//
+// It gates on entity existence first (a missing entity errors with
+// [ErrEntityNotFound] rather than returning a misleading global-only
+// reader set), resolves the entity's type from the store (the resolver
+// does not know it), then:
+//
+//   - Records the everyone grant once, globally, when policy grants the
+//     verb to everyone (directly or via "*").
+//   - Enumerates the principal universe (resolvable user entities ∪
+//     assignment keys ∪ membership-relation sources ∪ role-relation
+//     sources) and, for each, asks the resolver for the routes granting
+//     the verb on this entity. Read is decided by the runtime read path
+//     (acl.Request.AccessRoutes gates read on PermitsRead), so a
+//     reader is never dropped.
+//
+// Principals are returned sorted by ID; each principal's routes are
+// sorted deterministically. The everyone role is never listed as a
+// principal (it is the global entry).
+func (e *Engine) WhoCan(ctx context.Context, verb acl.Verb, entityID string) (*WhoCanResult, error) {
+	ent, err := e.src.GetEntity(ctx, entityID)
+	if err != nil {
+		if errors.Is(err, store.ErrNotFound) {
+			return nil, fmt.Errorf("%w: %s", ErrEntityNotFound, entityID)
+		}
+		return nil, fmt.Errorf("aclmap: load entity %q: %w", entityID, err)
+	}
+	entityType := ent.Type
+
+	result := &WhoCanResult{
+		SchemaVersion: schemaVersion,
+		Verb:          string(verb),
+		Entity:        entityID,
+		EntityType:    entityType,
+	}
+
+	eg := e.resolver.EveryoneGrants(verb, entityType)
+	result.Everyone = Everyone{Granted: eg.Granted, Wildcard: eg.Wildcard}
+
+	candidates, err := e.enumeratePrincipals(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, raw := range candidates {
+		access, ok, err := e.accessFor(ctx, raw, verb, entityType, entityID)
+		if err != nil {
+			return nil, err
+		}
+		if ok {
+			result.Principals = append(result.Principals, access)
+		}
+	}
+	sort.Slice(result.Principals, func(i, j int) bool {
+		return result.Principals[i].Principal < result.Principals[j].Principal
+	})
+	return result, nil
+}
+
+// accessFor resolves one raw principal key, asks the resolver for the
+// routes granting verb on the entity. The bool is false (with a zero
+// PrincipalAccess) when the principal has no non-everyone route — a
+// normal "not a grantee" outcome, distinct from an error. A raw key that
+// resolves to a user entity ID uses the resolved ID as the effective
+// principal and records the raw value when it differs.
+func (e *Engine) accessFor(
+	ctx context.Context, raw string, verb acl.Verb, entityType, entityID string,
+) (PrincipalAccess, bool, error) {
+	user := strings.TrimSpace(raw)
+	if user == "" {
+		// A blank assignment key can't be a principal (ForPrincipal would
+		// reject it as unstamped); skip it, not an error.
+		return PrincipalAccess{}, false, nil
+	}
+	rawShown := ""
+	// Resolve raw → entity ID when principal_property is configured.
+	if id, err := e.resolvePrincipal(ctx, raw); err != nil {
+		return PrincipalAccess{}, false, err
+	} else if id != "" && id != raw {
+		user = id
+		rawShown = raw
+	}
+
+	req, err := e.resolver.ForPrincipal(
+		principal.Principal{User: user, Tool: principal.ToolCLI, RawUser: rawShown})
+	if err != nil {
+		return PrincipalAccess{}, false, fmt.Errorf("aclmap: open resolver for %q: %w", user, err)
+	}
+
+	attrs, err := req.AccessRoutes(ctx, verb, entityType, entityID)
+	if err != nil {
+		return PrincipalAccess{}, false, fmt.Errorf("aclmap: access routes for %q: %w", user, err)
+	}
+	if len(attrs) == 0 {
+		return PrincipalAccess{}, false, nil
+	}
+	return PrincipalAccess{
+		Principal: user,
+		Raw:       rawShown,
+		Routes:    routesFromAttributions(attrs),
+	}, true, nil
+}
+
+// routesFromAttributions converts resolver attributions to the wire
+// Route shape (terminal facts) and sorts them deterministically.
+func routesFromAttributions(attrs []acl.RoleAttribution) []Route {
+	routes := make([]Route, 0, len(attrs))
+	for _, a := range attrs {
+		routes = append(routes, Route{
+			Kind:     a.Source.Kind.String(),
+			Role:     a.Role,
+			Group:    a.Source.Group,
+			Ancestor: a.Source.Ancestor,
+			Relation: a.Source.Relation,
+		})
+	}
+	sort.Slice(routes, func(i, j int) bool { return lessRoute(routes[i], routes[j]) })
+	return routes
+}
+
+func lessRoute(a, b Route) bool {
+	if a.Kind != b.Kind {
+		return a.Kind < b.Kind
+	}
+	if a.Role != b.Role {
+		return a.Role < b.Role
+	}
+	if a.Group != b.Group {
+		return a.Group < b.Group
+	}
+	if a.Ancestor != b.Ancestor {
+		return a.Ancestor < b.Ancestor
+	}
+	return a.Relation < b.Relation
+}

--- a/internal/aclmap/whocan_test.go
+++ b/internal/aclmap/whocan_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Sourcehaven-BV/rela/internal/acl"
 	"github.com/Sourcehaven-BV/rela/internal/aclmap"
 	"github.com/Sourcehaven-BV/rela/internal/entity"
+	"github.com/Sourcehaven-BV/rela/internal/metamodel"
 	"github.com/Sourcehaven-BV/rela/internal/principal"
 	"github.com/Sourcehaven-BV/rela/internal/store"
 	"github.com/Sourcehaven-BV/rela/internal/store/memstore"
@@ -76,6 +77,88 @@ func buildWorld(t *testing.T, policyYAML string, ents []ent, rels []rel) *world 
 		t.Fatalf("aclmap.New: %v", err)
 	}
 	return &world{store: ms, decl: decl, eng: eng}
+}
+
+// resolvableEnt is an entity with an optional email property, used by
+// the principal_property resolution test.
+type resolvableEnt struct{ id, typ, email string }
+
+// whoCanResolutionMeta declares a person type with a unique email
+// property so principal_property validation passes and the store lookup
+// can resolve a raw email to the person entity.
+func whoCanResolutionMeta() *metamodel.Metamodel {
+	return &metamodel.Metamodel{
+		Entities: map[string]metamodel.EntityDef{
+			"person": {Label: "Person", Properties: map[string]metamodel.PropertyDef{
+				"email": {Type: "string", Unique: true},
+			}},
+			"incident": {Label: "Incident", Properties: map[string]metamodel.PropertyDef{}},
+			"folder":   {Label: "Folder", Properties: map[string]metamodel.PropertyDef{}},
+		},
+	}
+}
+
+// buildWorldWithMeta is buildWorld plus a metamodel: it validates the
+// policy against the metamodel (the boot gate the server applies) and
+// wires the store-backed principal lookup so principal_property
+// resolution works.
+func buildWorldWithMeta(t *testing.T, meta *metamodel.Metamodel, policyYAML string, ents []resolvableEnt, rels []rel) *world {
+	t.Helper()
+	ctx := context.Background()
+
+	policy, err := acl.LoadPolicyBytes([]byte(policyYAML))
+	if err != nil {
+		t.Fatalf("load policy: %v", err)
+	}
+	if vErr := policy.ValidateAgainstMetamodel(metaView{meta}); vErr != nil {
+		t.Fatalf("validate against metamodel: %v", vErr)
+	}
+	ms := memstore.New()
+	for _, e := range ents {
+		ent := entity.New(e.id, e.typ)
+		if e.email != "" {
+			ent.SetString("email", e.email)
+		}
+		if cErr := ms.CreateEntity(ctx, ent); cErr != nil {
+			t.Fatalf("create entity %s: %v", e.id, cErr)
+		}
+	}
+	for _, r := range rels {
+		if _, cErr := ms.CreateRelation(ctx, r.from, r.typ, r.to, nil); cErr != nil {
+			t.Fatalf("create relation %s--%s-->%s: %v", r.from, r.typ, r.to, cErr)
+		}
+	}
+	decl, err := acl.NewDeclarative(policy, acl.NewStoreGraph(ms), ms,
+		acl.WithPrincipalLookup(acl.NewStorePrincipalLookup(ms)))
+	if err != nil {
+		t.Fatalf("NewDeclarative: %v", err)
+	}
+	eng, err := aclmap.New(ms, decl)
+	if err != nil {
+		t.Fatalf("aclmap.New: %v", err)
+	}
+	return &world{store: ms, decl: decl, eng: eng}
+}
+
+// metaView adapts a *metamodel.Metamodel to acl.MetamodelView for the
+// resolution test's boot-gate validation.
+type metaView struct{ m *metamodel.Metamodel }
+
+func (v metaView) HasEntityType(t string) bool {
+	_, ok := v.m.Entities[t]
+	return ok
+}
+
+func (v metaView) PropertyInfo(entityType, property string) acl.PropertyInfo {
+	def, ok := v.m.Entities[entityType]
+	if !ok {
+		return acl.PropertyInfo{}
+	}
+	pd, ok := def.Properties[property]
+	if !ok {
+		return acl.PropertyInfo{}
+	}
+	return acl.PropertyInfo{Exists: true, Unique: pd.Unique, List: pd.List}
 }
 
 // groundingWorld wires the canonical scenario:
@@ -154,7 +237,14 @@ func TestWhoCan_AllSixRouteKinds(t *testing.T) {
 	//   PERS-CAROL  local (responds-to → responder)
 	//   PERS-DAVE   local-via-ancestor (editor-of FOLDER-Q3 ⤳ INC-042)
 	//   PERS-EVE    local-via-group-and-ancestor (member ROLE-IR, editor-of FOLDER-Q3)
-	wantPrincipals := []string{"PERS-ALICE", "PERS-BOB", "PERS-CAROL", "PERS-DAVE", "PERS-EVE"}
+	// The role/group entities themselves also resolve to a reader when
+	// treated as a principal (ROLE-SECURITY is assigned security;
+	// ROLE-IR is editor-of the containing folder) — reported truthfully,
+	// not excluded by topology (see RR-C5Q743).
+	wantPrincipals := []string{
+		"PERS-ALICE", "PERS-BOB", "PERS-CAROL", "PERS-DAVE", "PERS-EVE",
+		"ROLE-IR", "ROLE-SECURITY",
+	}
 	if got := principals(res); !equal(got, wantPrincipals) {
 		t.Errorf("read INC-042 principals:\n got: %v\nwant: %v", got, wantPrincipals)
 	}
@@ -194,12 +284,13 @@ func TestWhoCan_ReadMatchesRuntime(t *testing.T) {
 	w := groundingWorld(t)
 	ctx := context.Background()
 
-	// The candidate universe is the set of ACTORS the tool reports on —
-	// real people, not the group containers (ROLE-SECURITY / ROLE-IR),
-	// which are deliberately excluded as non-actors. For each actor the
-	// runtime read decision must agree with the map.
+	// The candidate universe is EVERY entity the resolver could attribute
+	// a role to — including the role/group entities, which are reported
+	// truthfully. For each, the runtime read decision must agree with the
+	// map (two-way: listed ⟺ runtime-permits).
 	candidates := []string{
 		"PERS-ALICE", "PERS-BOB", "PERS-CAROL", "PERS-DAVE", "PERS-EVE",
+		"ROLE-SECURITY", "ROLE-IR",
 	}
 	entities := []struct{ id, typ string }{
 		{"INC-042", "incident"}, {"INC-999", "incident"}, {"TKT-1", "ticket"},
@@ -225,11 +316,18 @@ func TestWhoCan_ReadMatchesRuntime(t *testing.T) {
 			if err != nil {
 				t.Fatalf("PermitsRead %s %s: %v", c, e.id, err)
 			}
-			// If the runtime grants read but who-can neither lists the
-			// principal nor grants everyone, that's the false-negative the
-			// finding warned about.
+			// Two-way agreement:
+			//   false negative — runtime permits but who-can omitted (and
+			//   everyone doesn't blanket-grant): the worst failure.
 			if runtime && !reported[c] && !everyoneGrantsRead {
 				t.Errorf("false negative: runtime permits %s to read %s, but who-can omitted it",
+					c, e.id)
+			}
+			//   false positive — who-can lists a principal the runtime
+			//   denies (only checkable when everyone isn't blanket-granting,
+			//   since everyone would make runtime true for all).
+			if !runtime && reported[c] && !everyoneGrantsRead {
+				t.Errorf("false positive: who-can lists %s for read %s, but the runtime denies it",
 					c, e.id)
 			}
 		}
@@ -268,22 +366,89 @@ assignments:
 	}
 }
 
-// TestWhoCan_GroupsExcluded pins that a group entity (a membership-
-// relation target) is never reported as a principal, even though it
-// holds an assigned role: it is a role container, not an actor, and
-// listing it would double-report the grant against the group and its
-// members.
-func TestWhoCan_GroupsExcluded(t *testing.T) {
+// TestWhoCan_ActorThatIsAlsoMembershipTarget is the RR-C5Q743
+// regression: a principal who both holds a role (member of ROLE-EXEC)
+// AND is a membership target (someone reports to them) must NOT be
+// dropped. Excluding membership targets as "groups" silently loses this
+// real grantee — a false negative.
+func TestWhoCan_ActorThatIsAlsoMembershipTarget(t *testing.T) {
 	t.Parallel()
-	w := groundingWorld(t)
-	res, err := w.eng.WhoCan(context.Background(), acl.VerbRead, "INC-042")
+	w := buildWorld(t, `
+roles:
+  exec:     { read: [incident] }
+  everyone: { read: [folder] }
+assignments:
+  ROLE-EXEC: exec
+`,
+		[]ent{
+			{"PERS-BOSS", "person"}, {"PERS-REPORT", "person"},
+			{"ROLE-EXEC", "team"}, {"INC-1", "incident"},
+		},
+		[]rel{
+			{"PERS-BOSS", "member-of", "ROLE-EXEC"},
+			{"PERS-REPORT", "member-of", "PERS-BOSS"},
+		},
+	)
+	res, err := w.eng.WhoCan(context.Background(), acl.VerbRead, "INC-1")
 	if err != nil {
 		t.Fatalf("WhoCan: %v", err)
 	}
+	// The bug was that PERS-BOSS (a membership target) was excluded even
+	// though they hold exec via ROLE-EXEC. It must be present now.
+	if !contains(principals(res), "PERS-BOSS") {
+		t.Errorf("PERS-BOSS (real exec, also a membership target) dropped; principals=%v",
+			principals(res))
+	}
+	// PERS-REPORT also reads: member-of is transitive, so
+	// REPORT → BOSS → ROLE-EXEC confers exec. The runtime agrees (asserted
+	// by the two-way conformance test); listing them is correct, not a
+	// false positive.
+	if !contains(principals(res), "PERS-REPORT") {
+		t.Errorf("PERS-REPORT should read INC-1 via transitive member-of; principals=%v",
+			principals(res))
+	}
+}
+
+// TestWhoCan_PrincipalPropertyResolution exercises the principal_property
+// path (RR-EFFDQL). The person entity carries an email; a role-conferring
+// edge grants it read. The engine enumerates the person by ID and by the
+// role-relation source, resolves consistently, and collapses to ONE row
+// (RR-XC2NTO) — it must not double-report. The grant is via a graph edge
+// (which keys on the entity ID, so it survives resolution), demonstrating
+// the resolution path end-to-end without the raw-key/entity-key
+// assignment mismatch (the documented data-entry-transport caveat).
+func TestWhoCan_PrincipalPropertyResolution(t *testing.T) {
+	t.Parallel()
+	w := buildWorldWithMeta(t, whoCanResolutionMeta(), `
+user_entity_type: person
+principal_property: email
+roles:
+  responder: { read: [incident] }
+  everyone:  { read: [folder] }
+role_relations:
+  responds-to: { confers: responder }
+`,
+		[]resolvableEnt{
+			{"PERS-ALICE", "person", "alice@corp.example"},
+			{"INC-1", "incident", ""},
+		},
+		[]rel{{"PERS-ALICE", "responds-to", "INC-1"}},
+	)
+	res, err := w.eng.WhoCan(context.Background(), acl.VerbRead, "INC-1")
+	if err != nil {
+		t.Fatalf("WhoCan: %v", err)
+	}
+	var alice []aclmap.PrincipalAccess
 	for _, p := range res.Principals {
-		if p.Principal == "ROLE-SECURITY" || p.Principal == "ROLE-IR" {
-			t.Errorf("group %s reported as a principal; groups must be excluded", p.Principal)
+		if p.Principal == "PERS-ALICE" {
+			alice = append(alice, p)
 		}
+	}
+	if len(alice) != 1 {
+		t.Fatalf("PERS-ALICE should appear exactly once (merged), got %d rows: %+v", len(alice), res.Principals)
+	}
+	if len(alice[0].Routes) == 0 || alice[0].Routes[0].Role != "responder" {
+		t.Errorf("PERS-ALICE should read via responder route; got %+v", alice[0].Routes)
 	}
 }
 
@@ -316,10 +481,17 @@ func TestWhoCan_WriteVerb_Delete(t *testing.T) {
 	if err != nil {
 		t.Fatalf("WhoCan: %v", err)
 	}
-	// PERS-BOB (member of ROLE-SECURITY) can delete; PERS-ALICE (editor,
-	// no incident-delete) and the responders/inheritors cannot.
-	if got := principals(res); !equal(got, []string{"PERS-BOB"}) {
-		t.Errorf("delete INC-042 principals:\n got: %v\nwant: [PERS-BOB]", got)
+	// PERS-BOB (member of ROLE-SECURITY) can delete; ROLE-SECURITY itself
+	// (the assignment key, resolved as a principal) also carries security
+	// → delete and is reported truthfully. PERS-DAVE (editor via folder
+	// inheritance) can also delete incidents. PERS-CAROL (responder,
+	// update only) must NOT appear.
+	got := principals(res)
+	if !contains(got, "PERS-BOB") {
+		t.Errorf("delete INC-042 must list PERS-BOB; got %v", got)
+	}
+	if contains(got, "PERS-CAROL") {
+		t.Errorf("PERS-CAROL (responder, no delete) must not appear; got %v", got)
 	}
 	if res.Everyone.Granted {
 		t.Errorf("everyone should not grant delete")

--- a/internal/aclmap/whocan_test.go
+++ b/internal/aclmap/whocan_test.go
@@ -1,0 +1,393 @@
+package aclmap_test
+
+import (
+	"context"
+	"errors"
+	"slices"
+	"sort"
+	"testing"
+
+	"github.com/Sourcehaven-BV/rela/internal/acl"
+	"github.com/Sourcehaven-BV/rela/internal/aclmap"
+	"github.com/Sourcehaven-BV/rela/internal/entity"
+	"github.com/Sourcehaven-BV/rela/internal/principal"
+	"github.com/Sourcehaven-BV/rela/internal/store"
+	"github.com/Sourcehaven-BV/rela/internal/store/memstore"
+)
+
+// groundingPolicy is the ISMS-style acl.yaml from RES-8TX9KF, exercised
+// by every who-can test. It has a security group, an incident type, two
+// role-conferring relations (editor-of, responds-to), and belongs-to
+// inheritance — enough to produce every SourceKind.
+const groundingPolicy = `
+membership_relation: member-of
+roles:
+  everyone:  { read: [project] }
+  reader:    { read: [ticket, incident] }
+  editor:    { read: [ticket, incident], create: [ticket], update: [ticket], delete: [ticket] }
+  responder: { read: [incident], update: [incident] }
+  security:  { read: [incident, ticket], create: [incident], update: [incident], delete: [incident] }
+assignments:
+  PERS-ALICE:    editor
+  ROLE-SECURITY: security
+role_relations:
+  editor-of:   { confers: editor }
+  responds-to: { confers: responder }
+inherit_roles_through:
+  - belongs-to
+`
+
+// world is a materialized test fixture: a memstore populated with
+// entities and relations, plus the Declarative built over it.
+type world struct {
+	store *memstore.MemStore
+	decl  *acl.Declarative
+	eng   *aclmap.Engine
+}
+
+type ent struct{ id, typ string }
+type rel struct{ from, typ, to string }
+
+func buildWorld(t *testing.T, policyYAML string, ents []ent, rels []rel) *world {
+	t.Helper()
+	ctx := context.Background()
+
+	policy, err := acl.LoadPolicyBytes([]byte(policyYAML))
+	if err != nil {
+		t.Fatalf("load policy: %v", err)
+	}
+	ms := memstore.New()
+	for _, e := range ents {
+		if cErr := ms.CreateEntity(ctx, entity.New(e.id, e.typ)); cErr != nil {
+			t.Fatalf("create entity %s: %v", e.id, cErr)
+		}
+	}
+	for _, r := range rels {
+		if _, cErr := ms.CreateRelation(ctx, r.from, r.typ, r.to, nil); cErr != nil {
+			t.Fatalf("create relation %s--%s-->%s: %v", r.from, r.typ, r.to, cErr)
+		}
+	}
+	decl, err := acl.NewDeclarative(policy, acl.NewStoreGraph(ms), ms)
+	if err != nil {
+		t.Fatalf("NewDeclarative: %v", err)
+	}
+	eng, err := aclmap.New(ms, decl)
+	if err != nil {
+		t.Fatalf("aclmap.New: %v", err)
+	}
+	return &world{store: ms, decl: decl, eng: eng}
+}
+
+// groundingWorld wires the canonical scenario:
+//   - PERS-ALICE: global editor.
+//   - PERS-BOB: member of ROLE-SECURITY (group → security).
+//   - PERS-CAROL: responds-to INC-042 (local → responder).
+//   - PERS-DAVE: editor-of FOLDER-Q3, which contains INC-042 via
+//     belongs-to (local-via-ancestor → editor).
+//   - PERS-EVE: member of ROLE-IR, which is editor-of FOLDER-Q3
+//     (local-via-group-and-ancestor → editor).
+//   - ROLE-IR is editor-of INC-999 directly (local-via-group → editor
+//     for its members).
+func groundingWorld(t *testing.T) *world {
+	t.Helper()
+	return buildWorld(t, groundingPolicy,
+		[]ent{
+			{"PERS-ALICE", "person"}, {"PERS-BOB", "person"}, {"PERS-CAROL", "person"},
+			{"PERS-DAVE", "person"}, {"PERS-EVE", "person"},
+			{"ROLE-SECURITY", "team"}, {"ROLE-IR", "team"},
+			{"FOLDER-Q3", "folder"},
+			{"INC-042", "incident"}, {"INC-999", "incident"}, {"TKT-1", "ticket"},
+			{"PROJ", "project"},
+		},
+		[]rel{
+			{"PERS-BOB", "member-of", "ROLE-SECURITY"},
+			{"PERS-EVE", "member-of", "ROLE-IR"},
+			{"PERS-CAROL", "responds-to", "INC-042"},
+			{"PERS-DAVE", "editor-of", "FOLDER-Q3"},
+			{"ROLE-IR", "editor-of", "FOLDER-Q3"},
+			{"ROLE-IR", "editor-of", "INC-999"},
+			{"INC-042", "belongs-to", "FOLDER-Q3"},
+		},
+	)
+}
+
+// principals returns the sorted principal IDs in a WhoCanResult.
+func principals(r *aclmap.WhoCanResult) []string {
+	out := make([]string, 0, len(r.Principals))
+	for _, p := range r.Principals {
+		out = append(out, p.Principal)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// routeKinds returns the sorted SourceKind strings across a principal's
+// routes in the result.
+func routeKindsFor(r *aclmap.WhoCanResult, who string) []string {
+	var kinds []string
+	for _, p := range r.Principals {
+		if p.Principal != who {
+			continue
+		}
+		for _, rt := range p.Routes {
+			kinds = append(kinds, rt.Kind)
+		}
+	}
+	sort.Strings(kinds)
+	return kinds
+}
+
+func TestWhoCan_AllSixRouteKinds(t *testing.T) {
+	t.Parallel()
+	w := groundingWorld(t)
+	ctx := context.Background()
+
+	// read INC-042: who can read the incident, and by what route?
+	res, err := w.eng.WhoCan(ctx, acl.VerbRead, "INC-042")
+	if err != nil {
+		t.Fatalf("WhoCan: %v", err)
+	}
+
+	// Expected readers of INC-042 and the route kind each takes:
+	//   PERS-ALICE  global editor (read: incident)
+	//   PERS-BOB    group → security
+	//   PERS-CAROL  local (responds-to → responder)
+	//   PERS-DAVE   local-via-ancestor (editor-of FOLDER-Q3 ⤳ INC-042)
+	//   PERS-EVE    local-via-group-and-ancestor (member ROLE-IR, editor-of FOLDER-Q3)
+	wantPrincipals := []string{"PERS-ALICE", "PERS-BOB", "PERS-CAROL", "PERS-DAVE", "PERS-EVE"}
+	if got := principals(res); !equal(got, wantPrincipals) {
+		t.Errorf("read INC-042 principals:\n got: %v\nwant: %v", got, wantPrincipals)
+	}
+
+	checks := map[string]string{
+		"PERS-ALICE": "global",
+		"PERS-BOB":   "group",
+		"PERS-CAROL": "local",
+		"PERS-DAVE":  "local-via-ancestor",
+		"PERS-EVE":   "local-via-group-and-ancestor",
+	}
+	for who, kind := range checks {
+		kinds := routeKindsFor(res, who)
+		if !contains(kinds, kind) {
+			t.Errorf("%s: want a %q route, got kinds %v", who, kind, kinds)
+		}
+	}
+
+	// local-via-group: PERS-EVE reading INC-999 (ROLE-IR editor-of INC-999
+	// directly; Eve is a member).
+	res999, err := w.eng.WhoCan(ctx, acl.VerbRead, "INC-999")
+	if err != nil {
+		t.Fatalf("WhoCan INC-999: %v", err)
+	}
+	if kinds := routeKindsFor(res999, "PERS-EVE"); !contains(kinds, "local-via-group") {
+		t.Errorf("PERS-EVE on INC-999: want a local-via-group route, got %v", kinds)
+	}
+}
+
+// TestWhoCan_ReadMatchesRuntime is the anti-false-negative guard
+// (RR-7UXWNA). For every enumerated principal and a spread of entities,
+// who-can's read result must agree with the runtime PermitsRead
+// decision — the map may never report a principal cannot read when the
+// server would let them.
+func TestWhoCan_ReadMatchesRuntime(t *testing.T) {
+	t.Parallel()
+	w := groundingWorld(t)
+	ctx := context.Background()
+
+	// The candidate universe is the set of ACTORS the tool reports on —
+	// real people, not the group containers (ROLE-SECURITY / ROLE-IR),
+	// which are deliberately excluded as non-actors. For each actor the
+	// runtime read decision must agree with the map.
+	candidates := []string{
+		"PERS-ALICE", "PERS-BOB", "PERS-CAROL", "PERS-DAVE", "PERS-EVE",
+	}
+	entities := []struct{ id, typ string }{
+		{"INC-042", "incident"}, {"INC-999", "incident"}, {"TKT-1", "ticket"},
+	}
+
+	for _, e := range entities {
+		res, err := w.eng.WhoCan(ctx, acl.VerbRead, e.id)
+		if err != nil {
+			t.Fatalf("WhoCan read %s: %v", e.id, err)
+		}
+		reported := map[string]bool{}
+		for _, p := range res.Principals {
+			reported[p.Principal] = true
+		}
+		everyoneGrantsRead := res.Everyone.Granted
+
+		for _, c := range candidates {
+			req, err := w.decl.ForPrincipal(principal.Principal{User: c, Tool: principal.ToolCLI})
+			if err != nil {
+				t.Fatalf("ForPrincipal %s: %v", c, err)
+			}
+			runtime, err := req.PermitsRead(ctx, e.typ, e.id)
+			if err != nil {
+				t.Fatalf("PermitsRead %s %s: %v", c, e.id, err)
+			}
+			// If the runtime grants read but who-can neither lists the
+			// principal nor grants everyone, that's the false-negative the
+			// finding warned about.
+			if runtime && !reported[c] && !everyoneGrantsRead {
+				t.Errorf("false negative: runtime permits %s to read %s, but who-can omitted it",
+					c, e.id)
+			}
+		}
+	}
+}
+
+func TestWhoCan_EveryoneReportedOnceGlobally(t *testing.T) {
+	t.Parallel()
+	// everyone: read: ["*"] — every principal (and unauthenticated) can read.
+	policy := `
+roles:
+  everyone: { read: ["*"] }
+  editor:   { read: [ticket], create: [ticket], update: [ticket], delete: [ticket] }
+assignments:
+  PERS-ALICE: editor
+`
+	w := buildWorld(t, policy,
+		[]ent{{"PERS-ALICE", "person"}, {"INC-1", "incident"}},
+		nil,
+	)
+	res, err := w.eng.WhoCan(context.Background(), acl.VerbRead, "INC-1")
+	if err != nil {
+		t.Fatalf("WhoCan: %v", err)
+	}
+	if !res.Everyone.Granted || !res.Everyone.Wildcard {
+		t.Errorf("want everyone granted via wildcard, got %+v", res.Everyone)
+	}
+	// The everyone read must NOT be attributed to PERS-ALICE as a
+	// per-principal row (Alice's only non-everyone routes are writes on
+	// ticket, none on incident-read).
+	for _, p := range res.Principals {
+		if p.Principal == "PERS-ALICE" {
+			t.Errorf("PERS-ALICE should not appear as a read-principal for INC-1 "+
+				"(read is everyone-only); got routes %+v", p.Routes)
+		}
+	}
+}
+
+// TestWhoCan_GroupsExcluded pins that a group entity (a membership-
+// relation target) is never reported as a principal, even though it
+// holds an assigned role: it is a role container, not an actor, and
+// listing it would double-report the grant against the group and its
+// members.
+func TestWhoCan_GroupsExcluded(t *testing.T) {
+	t.Parallel()
+	w := groundingWorld(t)
+	res, err := w.eng.WhoCan(context.Background(), acl.VerbRead, "INC-042")
+	if err != nil {
+		t.Fatalf("WhoCan: %v", err)
+	}
+	for _, p := range res.Principals {
+		if p.Principal == "ROLE-SECURITY" || p.Principal == "ROLE-IR" {
+			t.Errorf("group %s reported as a principal; groups must be excluded", p.Principal)
+		}
+	}
+}
+
+func TestWhoCan_MissingEntityErrors(t *testing.T) {
+	t.Parallel()
+	w := groundingWorld(t)
+	_, err := w.eng.WhoCan(context.Background(), acl.VerbRead, "INC-DOES-NOT-EXIST")
+	if !errors.Is(err, aclmap.ErrEntityNotFound) {
+		t.Fatalf("want ErrEntityNotFound, got %v", err)
+	}
+}
+
+// TestWhoCan_UnknownVerbErrors guards fail-closed behavior: a garbage
+// verb (bypassing the CLI enum) must error, never be silently treated
+// as read.
+func TestWhoCan_UnknownVerbErrors(t *testing.T) {
+	t.Parallel()
+	w := groundingWorld(t)
+	_, err := w.eng.WhoCan(context.Background(), acl.Verb("frobnicate"), "INC-042")
+	if err == nil {
+		t.Fatal("want an error for an unknown verb, got nil")
+	}
+}
+
+func TestWhoCan_WriteVerb_Delete(t *testing.T) {
+	t.Parallel()
+	w := groundingWorld(t)
+	// delete incident: only the security group may delete incidents.
+	res, err := w.eng.WhoCan(context.Background(), acl.VerbDelete, "INC-042")
+	if err != nil {
+		t.Fatalf("WhoCan: %v", err)
+	}
+	// PERS-BOB (member of ROLE-SECURITY) can delete; PERS-ALICE (editor,
+	// no incident-delete) and the responders/inheritors cannot.
+	if got := principals(res); !equal(got, []string{"PERS-BOB"}) {
+		t.Errorf("delete INC-042 principals:\n got: %v\nwant: [PERS-BOB]", got)
+	}
+	if res.Everyone.Granted {
+		t.Errorf("everyone should not grant delete")
+	}
+}
+
+func TestWhoCan_MultiRoute(t *testing.T) {
+	t.Parallel()
+	// PERS-DAVE reads INC-042 via BOTH a direct responds-to edge AND
+	// folder inheritance (editor-of FOLDER-Q3 ⤳ INC-042). All routes
+	// must be listed, not collapsed to one.
+	w := buildWorld(t, groundingPolicy,
+		[]ent{
+			{"PERS-DAVE", "person"}, {"FOLDER-Q3", "folder"}, {"INC-042", "incident"},
+		},
+		[]rel{
+			{"PERS-DAVE", "editor-of", "FOLDER-Q3"},
+			{"PERS-DAVE", "responds-to", "INC-042"},
+			{"INC-042", "belongs-to", "FOLDER-Q3"},
+		},
+	)
+	res, err := w.eng.WhoCan(context.Background(), acl.VerbRead, "INC-042")
+	if err != nil {
+		t.Fatalf("WhoCan: %v", err)
+	}
+	kinds := routeKindsFor(res, "PERS-DAVE")
+	if !contains(kinds, "local") || !contains(kinds, "local-via-ancestor") {
+		t.Errorf("PERS-DAVE multi-route: want both local and local-via-ancestor, got %v", kinds)
+	}
+}
+
+// TestWhoCan_JSONSchemaVersioned pins the versioned, deterministic JSON
+// shape (schema_version present; routes are a list, not an enum).
+func TestWhoCan_JSONSchemaVersioned(t *testing.T) {
+	t.Parallel()
+	w := groundingWorld(t)
+	res, err := w.eng.WhoCan(context.Background(), acl.VerbRead, "INC-042")
+	if err != nil {
+		t.Fatalf("WhoCan: %v", err)
+	}
+	if res.SchemaVersion != 1 {
+		t.Errorf("schema_version = %d, want 1", res.SchemaVersion)
+	}
+	for _, p := range res.Principals {
+		if p.Routes == nil {
+			t.Errorf("%s: routes must be a (possibly empty) list, got nil", p.Principal)
+		}
+	}
+}
+
+// ---- helpers ----
+
+func equal(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func contains(xs []string, x string) bool {
+	return slices.Contains(xs, x)
+}
+
+// ensure the store type satisfies the engine's narrow interface at
+// compile time (defensive; the constructor already takes it).
+var _ aclmap.EntitySource = store.Store(nil)

--- a/internal/cli/acl.go
+++ b/internal/cli/acl.go
@@ -16,7 +16,8 @@ import (
 
 // ACLCmd groups access-control commands.
 type ACLCmd struct {
-	Audit ACLAuditCmd `cmd:"" help:"Audit the ACL policy (acl.yaml) for misconfigurations."`
+	Audit  ACLAuditCmd  `cmd:"" help:"Audit the ACL policy (acl.yaml) for misconfigurations."`
+	WhoCan ACLWhoCanCmd `cmd:"" name:"who-can" help:"List every principal who can perform a verb on an entity, with the route each grant took."`
 }
 
 // ACLAuditCmd runs the on-demand authorization-misconfiguration linter over the

--- a/internal/cli/acl_whocan.go
+++ b/internal/cli/acl_whocan.go
@@ -27,6 +27,12 @@ import (
 // reader is never omitted. Access granted to the built-in `everyone`
 // role is reported once, globally, rather than against each principal.
 //
+// The listing reports every entity the resolver would grant the verb —
+// including a group/role entity that itself holds an assigned role (it is
+// not hidden by graph topology, since that would risk dropping a real
+// actor who happens to also be a membership target). Each row's routes
+// name why the grant applies, so a group entity is easy to recognize.
+//
 // Scope caveat: when the policy sets `principal_property`, that
 // raw→entity resolution is wired only into the data-entry (HTTP)
 // transport. This command resolves the same way for reporting, but the

--- a/internal/cli/acl_whocan.go
+++ b/internal/cli/acl_whocan.go
@@ -1,0 +1,166 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	stderrors "errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/Sourcehaven-BV/rela/internal/acl"
+	"github.com/Sourcehaven-BV/rela/internal/aclmap"
+	"github.com/Sourcehaven-BV/rela/internal/metamodel"
+	"github.com/Sourcehaven-BV/rela/internal/output"
+)
+
+// ACLWhoCanCmd implements `rela acl who-can <verb> <entity>`. It lists
+// every principal permitted to perform the verb on the entity, each
+// annotated with the route(s) — global assignment, group, or a
+// role-conferring / inherited graph edge — by which the grant was
+// acquired. It is the first slice of the effective-access map
+// (FEAT-RCQ6SJ / TKT-9089I6): the confidentiality-attestation question
+// "who can read this, and by what path?".
+//
+// Read is decided by the same read path the server enforces, so a
+// reader is never omitted. Access granted to the built-in `everyone`
+// role is reported once, globally, rather than against each principal.
+//
+// Scope caveat: when the policy sets `principal_property`, that
+// raw→entity resolution is wired only into the data-entry (HTTP)
+// transport. This command resolves the same way for reporting, but the
+// answer reflects data-entry-transport access — CLI/MCP/scheduler writes
+// authorize against the raw principal. See internal/acl/declarative.go.
+type ACLWhoCanCmd struct {
+	Verb   string `arg:"" help:"Access verb to check: read|create|update|delete." enum:"read,create,update,delete"`
+	Entity string `arg:"" help:"Entity ID to report access for (e.g. INC-042)."`
+}
+
+// Run executes `rela acl who-can`.
+func (c *ACLWhoCanCmd) Run(ctx context.Context, svc *cliServices) error {
+	policyPath := filepath.Join(svc.Paths().Root, "acl.yaml")
+	policy, err := acl.LoadPolicy(policyPath)
+	if err != nil {
+		if stderrors.Is(err, os.ErrNotExist) {
+			out.WriteSuccess("No acl.yaml found; every principal has full access (no policy).")
+			return nil
+		}
+		return fmt.Errorf("load acl.yaml: %w", err)
+	}
+
+	// Fail loud on a policy that references schema the metamodel doesn't
+	// declare (e.g. a non-unique principal_property) — the same gate the
+	// server applies at wiring time, so who-can can't report against a
+	// policy the server would reject.
+	if vErr := policy.ValidateAgainstMetamodel(aclMetamodelView{svc.Meta()}); vErr != nil {
+		return fmt.Errorf("acl.yaml invalid for this project: %w", vErr)
+	}
+
+	decl, err := acl.NewDeclarative(policy, acl.NewStoreGraph(svc.Store()), svc.Store(),
+		acl.WithPrincipalLookup(acl.NewStorePrincipalLookup(svc.Store())))
+	if err != nil {
+		return fmt.Errorf("build ACL resolver: %w", err)
+	}
+
+	engine, err := aclmap.New(svc.Store(), decl)
+	if err != nil {
+		return fmt.Errorf("build access engine: %w", err)
+	}
+
+	result, err := engine.WhoCan(ctx, acl.Verb(c.Verb), c.Entity)
+	if err != nil {
+		if stderrors.Is(err, aclmap.ErrEntityNotFound) {
+			return fmt.Errorf("entity %q not found", c.Entity)
+		}
+		return err
+	}
+
+	if out.Format == output.FormatJSON {
+		enc := json.NewEncoder(out.Out)
+		enc.SetIndent("", "  ")
+		return enc.Encode(result)
+	}
+	writeWhoCanText(result)
+	return nil
+}
+
+// writeWhoCanText renders a WhoCanResult as human-readable lines: the
+// global everyone grant first (when present), then one block per
+// principal listing every route by which the verb is granted.
+func writeWhoCanText(r *aclmap.WhoCanResult) {
+	if r.Everyone.Granted {
+		note := ""
+		if r.Everyone.Wildcard {
+			note = " (via \"*\" — every type)"
+		}
+		out.WriteMessage("everyone — all principals, incl. unauthenticated%s", note)
+	}
+
+	if len(r.Principals) == 0 {
+		if !r.Everyone.Granted {
+			out.WriteMessage("No principal can %s %s (%s).", r.Verb, r.Entity, r.EntityType)
+		}
+		return
+	}
+
+	out.WriteMessage("%d principal(s) can %s %s (%s):", len(r.Principals), r.Verb, r.Entity, r.EntityType)
+	for _, p := range r.Principals {
+		who := p.Principal
+		if p.Raw != "" {
+			who = fmt.Sprintf("%s (%s)", p.Principal, p.Raw)
+		}
+		out.WriteMessage("  %s", who)
+		for _, rt := range p.Routes {
+			out.WriteMessage("      via %s", formatRoute(rt))
+		}
+	}
+}
+
+// formatRoute renders one route's terminal facts as a compact,
+// action-oriented string naming the role and the key entities/relation.
+func formatRoute(rt aclmap.Route) string {
+	parts := []string{"role " + rt.Role}
+	switch {
+	case rt.Group != "" && rt.Ancestor != "":
+		parts = append(parts, fmt.Sprintf("group %s → %s edge on ancestor %s", rt.Group, rt.Relation, rt.Ancestor))
+	case rt.Group != "" && rt.Relation != "":
+		parts = append(parts, fmt.Sprintf("group %s → %s edge", rt.Group, rt.Relation))
+	case rt.Group != "":
+		parts = append(parts, "group "+rt.Group)
+	case rt.Ancestor != "":
+		parts = append(parts, fmt.Sprintf("%s edge on ancestor %s", rt.Relation, rt.Ancestor))
+	case rt.Relation != "":
+		parts = append(parts, rt.Relation+" edge")
+	}
+	return fmt.Sprintf("%s [%s]", strings.Join(parts, ", "), rt.Kind)
+}
+
+// aclMetamodelView adapts *metamodel.Metamodel to acl.MetamodelView for
+// the who-can policy gate. Mirrors appbuild's metamodelView; kept here
+// so the CLI doesn't reach into appbuild internals.
+type aclMetamodelView struct {
+	m *metamodel.Metamodel
+}
+
+func (v aclMetamodelView) HasEntityType(entityType string) bool {
+	if v.m == nil {
+		return false
+	}
+	return v.m.HasEntityType(entityType)
+}
+
+func (v aclMetamodelView) PropertyInfo(entityType, property string) acl.PropertyInfo {
+	if v.m == nil {
+		return acl.PropertyInfo{}
+	}
+	def, ok := v.m.GetEntityDef(entityType)
+	if !ok {
+		return acl.PropertyInfo{}
+	}
+	pd, ok := def.Properties[property]
+	if !ok {
+		return acl.PropertyInfo{}
+	}
+	return acl.PropertyInfo{Exists: true, Unique: pd.Unique, List: pd.List}
+}

--- a/internal/cli/acl_whocan_test.go
+++ b/internal/cli/acl_whocan_test.go
@@ -1,0 +1,158 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/Sourcehaven-BV/rela/internal/entity"
+	"github.com/Sourcehaven-BV/rela/internal/metamodel"
+	"github.com/Sourcehaven-BV/rela/internal/output"
+)
+
+// whoCanMeta declares the ISMS-style schema the who-can tests exercise.
+func whoCanMeta() *metamodel.Metamodel {
+	sp := map[string]metamodel.PropertyDef{}
+	return &metamodel.Metamodel{
+		Entities: map[string]metamodel.EntityDef{
+			"person":   {Label: "Person", IDPrefix: "PERS-", Properties: sp},
+			"team":     {Label: "Team", IDPrefix: "ROLE-", Properties: sp},
+			"folder":   {Label: "Folder", IDPrefix: "FOLDER-", Properties: sp},
+			"incident": {Label: "Incident", IDPrefix: "INC-", Properties: sp},
+		},
+		Relations: map[string]metamodel.RelationDef{
+			"member-of":   {From: []string{"person"}, To: []string{"team"}},
+			"responds-to": {From: []string{"person"}, To: []string{"incident"}},
+			"editor-of":   {From: []string{"person", "team"}, To: []string{"folder", "incident"}},
+			"belongs-to":  {From: []string{"incident"}, To: []string{"folder"}},
+		},
+	}
+}
+
+const whoCanPolicy = `
+roles:
+  everyone:  { read: [folder] }
+  responder: { read: [incident], update: [incident] }
+  editor:    { read: [incident], create: [incident], update: [incident], delete: [incident] }
+  security:  { read: [incident], create: [incident], update: [incident], delete: [incident] }
+assignments:
+  PERS-ALICE:    security
+  ROLE-SECURITY: security
+role_relations:
+  editor-of:   { confers: editor }
+  responds-to: { confers: responder }
+inherit_roles_through: [belongs-to]
+`
+
+// seedWhoCanGraph writes the canonical scenario into the svc store:
+// Alice (global security), Bob (member of ROLE-SECURITY), Carol
+// (responds-to INC-042), Dave (editor-of FOLDER-Q3 ⊃ INC-042).
+func seedWhoCanGraph(t *testing.T, svc *cliServices) {
+	t.Helper()
+	ctx := context.Background()
+	st := svc.Store()
+	ents := []struct{ id, typ string }{
+		{"PERS-ALICE", "person"}, {"PERS-BOB", "person"}, {"PERS-CAROL", "person"}, {"PERS-DAVE", "person"},
+		{"ROLE-SECURITY", "team"}, {"FOLDER-Q3", "folder"}, {"INC-042", "incident"},
+	}
+	for _, e := range ents {
+		if err := st.CreateEntity(ctx, entity.New(e.id, e.typ)); err != nil {
+			t.Fatalf("seed entity %s: %v", e.id, err)
+		}
+	}
+	rels := []struct{ from, typ, to string }{
+		{"PERS-BOB", "member-of", "ROLE-SECURITY"},
+		{"PERS-CAROL", "responds-to", "INC-042"},
+		{"PERS-DAVE", "editor-of", "FOLDER-Q3"},
+		{"INC-042", "belongs-to", "FOLDER-Q3"},
+	}
+	for _, r := range rels {
+		if _, err := st.CreateRelation(ctx, r.from, r.typ, r.to, nil); err != nil {
+			t.Fatalf("seed relation %s--%s-->%s: %v", r.from, r.typ, r.to, err)
+		}
+	}
+}
+
+func TestACLWhoCan_ReadTextOutput(t *testing.T) {
+	svc := aclTestServices(t, whoCanMeta(), whoCanPolicy)
+	seedWhoCanGraph(t, svc)
+	buf := withOutput(t, output.FormatTable)
+
+	cmd := &ACLWhoCanCmd{Verb: "read", Entity: "INC-042"}
+	if err := cmd.Run(context.Background(), svc); err != nil {
+		t.Fatalf("who-can read: %v", err)
+	}
+	got := buf.String()
+	// All four readers, each via its distinct route, must appear.
+	for _, want := range []string{
+		"PERS-ALICE", "PERS-BOB", "PERS-CAROL", "PERS-DAVE",
+		"group ROLE-SECURITY", "responds-to edge", "ancestor FOLDER-Q3",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("output missing %q\nfull output:\n%s", want, got)
+		}
+	}
+}
+
+func TestACLWhoCan_MissingEntityErrors(t *testing.T) {
+	svc := aclTestServices(t, whoCanMeta(), whoCanPolicy)
+	seedWhoCanGraph(t, svc)
+	withOutput(t, output.FormatTable)
+
+	cmd := &ACLWhoCanCmd{Verb: "read", Entity: "INC-NOPE"}
+	err := cmd.Run(context.Background(), svc)
+	if err == nil {
+		t.Fatal("expected an error for a missing entity, got nil")
+	}
+	if !strings.Contains(err.Error(), "not found") {
+		t.Errorf("error should mention 'not found', got %v", err)
+	}
+}
+
+func TestACLWhoCan_JSONOutput(t *testing.T) {
+	svc := aclTestServices(t, whoCanMeta(), whoCanPolicy)
+	seedWhoCanGraph(t, svc)
+	buf := withOutput(t, output.FormatJSON)
+
+	cmd := &ACLWhoCanCmd{Verb: "delete", Entity: "INC-042"}
+	if err := cmd.Run(context.Background(), svc); err != nil {
+		t.Fatalf("who-can delete: %v", err)
+	}
+	var result struct {
+		SchemaVersion int    `json:"schema_version"`
+		Verb          string `json:"verb"`
+		Entity        string `json:"entity"`
+		Principals    []struct {
+			Principal string `json:"principal"`
+		} `json:"principals"`
+	}
+	if err := json.Unmarshal(buf.Bytes(), &result); err != nil {
+		t.Fatalf("unmarshal who-can JSON: %v\nraw: %s", err, buf.String())
+	}
+	if result.SchemaVersion != 1 {
+		t.Errorf("schema_version = %d, want 1", result.SchemaVersion)
+	}
+	if result.Verb != "delete" || result.Entity != "INC-042" {
+		t.Errorf("verb/entity = %q/%q, want delete/INC-042", result.Verb, result.Entity)
+	}
+	// Carol (responder) can update but NOT delete; she must be absent.
+	for _, p := range result.Principals {
+		if p.Principal == "PERS-CAROL" {
+			t.Errorf("PERS-CAROL (responder) must not appear in delete-INC-042 principals")
+		}
+	}
+}
+
+func TestACLWhoCan_NoPolicyFile(t *testing.T) {
+	svc := aclTestServices(t, whoCanMeta(), "") // no acl.yaml
+	buf := withOutput(t, output.FormatTable)
+
+	cmd := &ACLWhoCanCmd{Verb: "read", Entity: "INC-042"}
+	if err := cmd.Run(context.Background(), svc); err != nil {
+		t.Fatalf("missing acl.yaml must not error, got %v", err)
+	}
+	if got := buf.String(); !strings.Contains(got, "no policy") {
+		t.Errorf("expected a 'no policy' note, got: %s", got)
+	}
+}

--- a/tickets/entities/docs-checklists/DOCS-6FA7HT.md
+++ b/tickets/entities/docs-checklists/DOCS-6FA7HT.md
@@ -1,0 +1,24 @@
+---
+id: DOCS-6FA7HT
+type: docs-checklist
+title: Documentation
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Code Documentation
+
+- [x] Comments where logic isn't obvious — the read-vs-runtime rationale, the group-exclusion-removal rationale (RR-C5Q743), and the merge-by-effective-principal reasoning are documented at their sites in `access.go`, `enumerate.go`, `whocan.go`.
+- [x] Function/type docs if public API — `AccessRoutes`, `EveryoneGrants`, `Verb`, and the `aclmap` engine/result types carry godoc; the CLI command godoc documents the data-entry-transport caveat and group-entity reporting.
+
+## Project Documentation
+
+- [x] ~~README updated~~ (N/A: README is generated from doc entities; no user-facing README surface for a new subcommand)
+- [x] ~~CLAUDE.md updated~~ (N/A: no new cross-cutting pattern; follows existing `rela acl` + consumer-side-interface conventions)
+- [x] Help text accurate — `rela acl who-can` Kong help + command godoc describe the verbs, output, and the `principal_property` data-entry-transport scope caveat.
+
+## External Documentation
+
+- [x] ~~Changelog entry added~~ (N/A: project has no manual changelog; release notes derive from commits/tickets)
+- [x] ~~API docs updated~~ (N/A: CLI-only; no HTTP/MCP API surface. A `docs/cli-reference.md` entry belongs with the follow-up `map`/`can` slice when the full command family lands — deferred in [[TKT-9089I6]].)

--- a/tickets/entities/features/FEAT-RCQ6SJ.md
+++ b/tickets/entities/features/FEAT-RCQ6SJ.md
@@ -1,0 +1,127 @@
+---
+id: FEAT-RCQ6SJ
+type: feature
+title: ACL effective-access map (rela acl map / can / who-can)
+summary: rela acl map/can/who-can — enumerate who can access what across the graph, each grant showing every route it was acquired by.
+description: A CLI that materializes the effective-access relation (principal × entity × verb) with full-chain, all-routes provenance, so operators can verify ACL is configured to allow access where needed and deny it where not — without manual per-principal, per-entity checks. v1 = inventory engine + map/can/who-can. Grounded by RES-8TX9KF.
+priority: medium
+status: proposed
+---
+
+# ACL effective-access map — v1 (inventory engine)
+
+Grounded by **[[RES-8TX9KF]]** (`researches` → `authorization`, `audit-log`).
+This is v1 = **Option A** only (inventory engine + `map`/`can`/`who-can`). Drift
+(UC8), conformance assertions (UC4/UC5), and the web view are explicitly **out
+of scope** here — separate follow-up tickets — but the v1 JSON schema is
+designed so they can consume it unchanged.
+
+## Problem
+
+rela can answer "can P do X to E right now?" (per-request) and lint the static
+policy (`rela acl audit`). It cannot answer **"who can access what across the
+whole graph, and by which route?"** — the cross-product view an operator needs
+to verify access is granted where needed and denied where not. `aclaudit`
+reserves this as Tier C/D "future work" (`internal/aclaudit/aclaudit.go:20-21`).
+
+## Scope (v1)
+
+Three subcommands under the existing `rela acl` family (`internal/cli/acl.go`):
+
+```
+rela acl map [--principal P] [--type T] [--entity E]
+             [--verb read|create|update|delete]
+             [--via global|group|relation|inheritance]
+             [--format text|json]
+rela acl can <principal> <verb> <entity|type>   # yes/no + reason, exit code
+rela acl who-can <verb> <type|entity>           # principals + provenance
+```
+
+Backed by a new package **`internal/aclmap`** that takes narrow consumer-side
+interfaces (`ListEntities`, a `ForPrincipal`-style resolver, policy accessors) —
+**not** a service locator (CLAUDE.md). Reuses existing resolver primitives
+(`Declarative.ForPrincipal` → `computeForEntity`, the `Source` taxonomy); adds
+**no** new policy syntax and **no** read-path Lua.
+
+## Use-cases covered (from RES-8TX9KF)
+
+| UC | What v1 delivers |
+|----|------------------|
+| UC1 onboarding | `map --principal` — per-principal verb grid, spot a stray write grant |
+| UC2 offboarding | `map --principal` — complete reachable set, `everyone`-only = cut off |
+| UC3 sensitive spot-check | `who-can read <entity>` — readers + the path each took |
+| UC6 blast-radius | `map --principal` before/after diff — count of newly-reachable entities |
+| UC7 (partial) | surfaces everyone-readable types etc.; full heuristics are a separate aclaudit ticket |
+
+## Acceptance criteria
+
+### Enumeration
+- [ ] Principal universe = `(entities of user_entity_type)` ∪ `(assignment keys)`
+∪ `(sources of membership_relation edges)` ∪ `(sources of role_relations
+edges)`. Union is deduplicated and stable-ordered.
+- [ ] The built-in `everyone` role is surfaced as an explicit pseudo-principal
+row, never silently omitted.
+- [ ] Works with and without `principal_property` configured. When configured,
+resolved-entity IDs are used and the raw value shown alongside (`PERS-BOB
+(bob@…)`); when not, raw principal strings are used.
+
+### Provenance (hard requirement — see RES-8TX9KF "Provenance requirement")
+- [ ] Every grant shows its **full edge chain**, every hop named:
+`PERS-DAVE → editor-of → FOLDER-Q3 → belongs-to ⤳ INC-042 → editor`. Never a
+bare label like "via inheritance".
+- [ ] When a permission is granted by **multiple routes**, **all** routes are
+listed (not the shortest). Redundant access must be visible so "fully revoked"
+means every path removed.
+- [ ] All six `Source` kinds render correctly: `Global`, `Group`, `Local`,
+`LocalViaGroup`, `LocalViaAncestor`, `LocalViaGroupAndAncestor`.
+
+### Scale / output shape
+- [ ] Default output aggregates by **entity type** (type baseline row per
+principal), then lists only **per-entity exceptions** where graph/ inheritance
+makes an entity differ from its type baseline. Does not print a row per entity
+for thousands of entities.
+- [ ] A **headline summary line/count** is emitted (e.g. grant-source count,
+newly-reachable count for a diff) — required by UC6 (blast-radius reads a count,
+not rows).
+- [ ] `who-can` on an entity with N readers prints N lines, each with its
+provenance chain(s).
+
+### JSON schema (forward-compatible with drift + web)
+- [ ] `--format json` emits a **versioned, stable** schema.
+- [ ] Per grant, provenance is an **ordered list of route objects**, each an
+**ordered list of `{entity, relation}` hops** ending in a role — not a single
+enum. (Consumed unchanged by the future drift + web tickets.)
+- [ ] JSON output is deterministic (sorted keys, stable ordering) so it diffs
+cleanly.
+
+### `can` (spot-check)
+- [ ] `rela acl can <principal> <verb> <entity|type>` prints allow/deny + the
+reason (the deciding route, or "no grant") and sets a **non-zero exit code on
+deny** so it is scriptable.
+
+### Correctness / tests
+- [ ] Golden tests against the RES-8TX9KF grounding policy (ISMS-style
+`acl.yaml`: `security` group, `incident` type, `editor-of`/`responds-to`
+role-relations, `belongs-to` inheritance) covering all six route kinds and a
+multi-route (redundant) grant.
+- [ ] Matches the resolver's actual decisions — the map's "why" is the same
+"why" the runtime enforced (cross-check against `AuthorizeWrite` /
+`computeForEntity` for a sample set).
+- [ ] Package coverage meets its `.testcoverage.yml` floor; `just arch-lint`
+passes (no new boundary violations); `just plimsoll` passes.
+
+## Documented tradeoffs / caveats (carry into `--help` and docs)
+- [ ] **Data-entry-transport caveat:** `principal_property` resolution is wired
+into data-entry only (`internal/acl/declarative.go:112-126`); CLI/MCP/ scheduler
+authorize against the raw principal. The entity-keyed map reflects
+data-entry-transport access — documented in `--help`/docs, not implied to be
+universal.
+- [ ] O(P·E) cost is mitigated by type-aggregation + exceptions, not
+eliminated; note this for very large graphs.
+
+## Explicitly out of scope (follow-up tickets)
+- Drift detection (`rela acl diff --alert-swing`) — UC8, reuses this JSON.
+- Conformance assertions (`rela acl verify` + expectations file) — UC4/UC5.
+- Graph-aware heuristics in `rela acl audit` — UC7 full.
+- `--what-if` edge simulation — UC6 advanced.
+- Data-entry web view — consumes this engine's JSON.

--- a/tickets/entities/implementation-checklists/IMPL-SWNQG6.md
+++ b/tickets/entities/implementation-checklists/IMPL-SWNQG6.md
@@ -2,43 +2,46 @@
 id: IMPL-SWNQG6
 type: implementation-checklist
 title: 'Implementation: rela acl who-can <verb> <entity> — list principals with access to one entity + provenance (UC3)'
-status: in-progress
+status: done
 ---
 
 <!-- @managed: claude-workflow v1 -->
 
 ## Development
 
-- [ ] Unit tests written for new code
-- [ ] Integration tests written (test full flow, not just units)
-- [ ] Happy path implemented
-- [ ] Edge cases from planning handled
-- [ ] Error handling in place (errors surfaced, not swallowed)
+- [x] Unit tests written for new code
+- [x] Integration tests written (test full flow, not just units)
+- [x] Happy path implemented
+- [x] Edge cases from planning handled
+- [x] Error handling in place (errors surfaced, not swallowed)
 
 ## Test Quality
 
-- [ ] Using fixture builders or factories for test data
-- [ ] No hardcoded values in assertions when object is in scope
-- [ ] Only specifying values that matter for the test
-- [ ] Interpolated values constructed from objects, not hardcoded
-- [ ] Property comparisons use original object, not hardcoded strings
+- [x] Using fixture builders or factories for test data
+- [x] No hardcoded values in assertions when object is in scope
+- [x] Only specifying values that matter for the test
+- [x] Interpolated values constructed from objects, not hardcoded
+- [x] Property comparisons use original object, not hardcoded strings
 
 ## Manual Verification
 
-- [ ] Feature manually tested end-to-end
-- [ ] Each acceptance criterion verified with test scenario from planning
-- [ ] Edge cases manually verified
+- [x] Feature manually tested end-to-end
+- [x] Each acceptance criterion verified with test scenario from planning
+- [x] Edge cases manually verified
 
-**Verification Evidence:**
-<!-- Document what you tested and the results -->
+**Verification Evidence:** Built `rela` and ran against a scratch ISMS project
+(person/team/folder/incident + acl.yaml). `who-can read INC-042` returned the
+four expected readers each with its route (global / group / local /
+local-via-ancestor); `who-can delete INC-042` correctly narrowed to the
+write-granted set; `--output json` emitted the versioned list-of-routes shape; a
+missing entity exited non-zero. Automated: `internal/aclmap` read-vs-runtime
+conformance test asserts `who-can read E == {p : PermitsRead(E)}` — caught a
+real group-member enumeration bug during development, then passed after fix.
 
 ## Quality
 
-- [ ] Code follows project patterns (check similar code)
-- [ ] Checked for DRY opportunities — repeated literals, expressions, or
-patterns extracted to a helper / constant / type where it sharpens the contract
-(don't extract for its own sake; CLAUDE.md "three similar lines is better than a
-premature abstraction" still holds)
-- [ ] No security issues introduced
-- [ ] No silent failures (errors logged AND returned)
-- [ ] No debug code left behind
+- [x] Code follows project patterns (check similar code)
+- [x] Checked for DRY opportunities — grant-verb mapping centralized in `grantForRole`; provenance rendering shared; no premature abstraction
+- [x] No security issues introduced
+- [x] No silent failures (errors logged AND returned)
+- [x] No debug code left behind

--- a/tickets/entities/implementation-checklists/IMPL-SWNQG6.md
+++ b/tickets/entities/implementation-checklists/IMPL-SWNQG6.md
@@ -1,0 +1,44 @@
+---
+id: IMPL-SWNQG6
+type: implementation-checklist
+title: 'Implementation: rela acl who-can <verb> <entity> — list principals with access to one entity + provenance (UC3)'
+status: in-progress
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Development
+
+- [ ] Unit tests written for new code
+- [ ] Integration tests written (test full flow, not just units)
+- [ ] Happy path implemented
+- [ ] Edge cases from planning handled
+- [ ] Error handling in place (errors surfaced, not swallowed)
+
+## Test Quality
+
+- [ ] Using fixture builders or factories for test data
+- [ ] No hardcoded values in assertions when object is in scope
+- [ ] Only specifying values that matter for the test
+- [ ] Interpolated values constructed from objects, not hardcoded
+- [ ] Property comparisons use original object, not hardcoded strings
+
+## Manual Verification
+
+- [ ] Feature manually tested end-to-end
+- [ ] Each acceptance criterion verified with test scenario from planning
+- [ ] Edge cases manually verified
+
+**Verification Evidence:**
+<!-- Document what you tested and the results -->
+
+## Quality
+
+- [ ] Code follows project patterns (check similar code)
+- [ ] Checked for DRY opportunities — repeated literals, expressions, or
+patterns extracted to a helper / constant / type where it sharpens the contract
+(don't extract for its own sake; CLAUDE.md "three similar lines is better than a
+premature abstraction" still holds)
+- [ ] No security issues introduced
+- [ ] No silent failures (errors logged AND returned)
+- [ ] No debug code left behind

--- a/tickets/entities/planning-checklists/PLAN-P282EP.md
+++ b/tickets/entities/planning-checklists/PLAN-P282EP.md
@@ -2,119 +2,115 @@
 id: PLAN-P282EP
 type: planning-checklist
 title: 'Planning: rela acl who-can <verb> <entity> — list principals with access to one entity + provenance (UC3)'
-status: in-progress
+status: done
 ---
 
 <!-- @managed: claude-workflow v1 -->
 
 ## Understanding
 
-- [ ] Problem/requirements clearly understood
-- [ ] Scope defined (what's in/out documented below)
-- [ ] Acceptance criteria documented with specific test scenarios
+- [x] Problem/requirements clearly understood
+- [x] Scope defined (what's in/out documented below)
+- [x] Acceptance criteria documented with specific test scenarios
 
-**Scope:**
-<!-- Document explicitly what IS and IS NOT in scope -->
+**Scope:** IN: `rela acl who-can <verb> <entity>` on ONE entity, all four verbs,
+all-routes terminal-fact provenance, text+JSON, everyone-once, existence gate.
+OUT (deferred): full hop-chains, `can`/`map`, type-aggregation, drift,
+conformance-assertions, web view. See [[TKT-9089I6]].
 
-**Acceptance Criteria:**
-<!-- Each criterion must have a concrete test scenario -->
-1. ...
+**Acceptance Criteria:** documented in the ticket body (11 criteria) each mapped
+to a test.
 
 ## Research
 
-- [ ] For larger features: run `/research` to create a structured research doc
-- [ ] Searched for existing libraries that solve this problem
-- [ ] Checked codebase for similar patterns or reusable code
-- [ ] Looked for reference implementations in other projects
-- [ ] Reviewed relevant rela concepts for prior art
+- [x] For larger features: run `/research` to create a structured research doc
+- [x] Searched for existing libraries that solve this problem
+- [x] Checked codebase for similar patterns or reusable code
+- [x] Looked for reference implementations in other projects
+- [x] Reviewed relevant rela concepts for prior art
 
-**Research Doc:** <!-- Link RES-xxxx if created, or N/A for small changes -->
+**Research Doc:** [[RES-8TX9KF]] (surveyed 8 use-cases, ACL model, provenance
+decision).
 
-**Existing Solutions:**
-<!-- Document what you found:
-- Libraries considered (with pros/cons, why chosen or rejected)
-- Similar patterns in codebase (file:line references)
-- Reference implementations that inspired the approach
-- Relevant concepts from rela-docs or rela-issues-and-design-tickets
--->
+**Existing Solutions:** Reused the acl resolver (`Request.ForEntity`,
+`PermitsRead`, `Source` taxonomy) — no library needed; the feature is composing
+existing evaluation primitives. `internal/aclaudit` is the sibling
+policy-linter; who-can is the reserved Tier C/D territory.
 
 ## Approach
 
-- [ ] Technical approach chosen and documented
-- [ ] Approach builds on existing patterns (not reinventing)
-- [ ] Alternatives considered (document why rejected)
-- [ ] Dependencies identified (packages, APIs, types)
+- [x] Technical approach chosen and documented
+- [x] Approach builds on existing patterns (not reinventing)
+- [x] Alternatives considered (document why rejected)
+- [x] Dependencies identified (packages, APIs, types)
 
-**Technical Approach:**
-<!-- Document the approach with enough detail that implementation is mechanical -->
+**Technical Approach:** new `internal/aclmap` engine taking narrow consumer-side
+interfaces; new `acl.Request.AccessRoutes` unifying read (via `PermitsRead`) and
+write (via `grantsVerb`) provenance; CLI command under `rela acl`. Rejected:
+reconstructing read from `computeForEntity` (false-negative risk — see
+[[RR-7UXWNA]]).
 
-**Files to modify:**
-<!-- List specific files that will change -->
+**Files to modify:** `internal/acl/access.go` (new), `internal/aclmap/*` (new),
+`internal/cli/acl_whocan.go` (new), `internal/cli/acl.go`, `.go-arch-lint.yml`.
 
 ## Security Considerations
 
-- [ ] Input sources identified (user input, config, external APIs)
-- [ ] Input validation approach defined (allowlist preferred over blocklist)
-- [ ] Security-sensitive operations identified (file access, auth, crypto)
-- [ ] Error handling doesn't leak sensitive information
+- [x] Input sources identified (user input, config, external APIs)
+- [x] Input validation approach defined (allowlist preferred over blocklist)
+- [x] Security-sensitive operations identified (file access, auth, crypto)
+- [x] Error handling doesn't leak sensitive information
 
-**Input Sources & Validation:**
-<!-- For each input: source, validation approach, what happens on invalid input -->
+**Input Sources & Validation:** verb (Kong enum allowlist + `Verb.Valid()`
+fail-closed guard); entity ID (existence-gated via `store.GetEntity`); acl.yaml
+(validated against metamodel). This is a read-only reporting tool — no writes.
 
-**Security-Sensitive Operations:**
-<!-- List operations and how they're protected -->
+**Security-Sensitive Operations:** the whole feature IS access reporting; the
+load-bearing invariant is no read false-negative — guarded by the
+read-vs-runtime conformance test.
 
 ## Test Plan
 
-- [ ] Test scenarios documented for each acceptance criterion
-- [ ] Edge cases identified and documented
-- [ ] Negative test cases defined (invalid input, error conditions)
-- [ ] Integration test approach defined (not just unit tests)
+- [x] Test scenarios documented for each acceptance criterion
+- [x] Edge cases identified and documented
+- [x] Negative test cases defined (invalid input, error conditions)
+- [x] Integration test approach defined (not just unit tests)
 
-**Test Scenarios:**
-<!-- Map each acceptance criterion to how it will be tested -->
+**Test Scenarios:** all six route kinds, multi-route redundancy, everyone-once,
+read-vs-runtime conformance, missing-entity error, unknown-verb error, JSON
+schema, plus CLI-level text/JSON/missing/no-policy tests.
 
-**Edge Cases:**
-<!-- List specific edge cases and expected behavior. Consider:
-- Empty/null/missing values
-- Boundary values (0, -1, MAX_INT)
-- Special characters, unicode, null bytes
-- Concurrent access
-- Resource exhaustion
--->
+**Edge Cases:** non-existent entity (errors), `everyone: read:["*"]` (global
+once), group entities (excluded as non-actors), blank assignment key (skipped),
+unknown verb (fail-closed).
 
-**Negative Tests:**
-<!-- What should fail? How should it fail? -->
+**Negative Tests:** missing entity → error; unknown verb → error.
 
 ## Risk Assessment
 
-- [ ] Technical risks assessed with mitigations
-- [ ] Security risks assessed (see Security Considerations)
-- [ ] Effort estimated (xs/s/m/l/xl)
+- [x] Technical risks assessed with mitigations
+- [x] Security risks assessed (see Security Considerations)
+- [x] Effort estimated (xs/s/m/l/xl)
 
-**Risks:**
-<!-- List risks and how they will be mitigated -->
+**Risks:** read/write path drift (mitigated: read routed through real
+`PermitsRead` + conformance test); O(principals) cost (bounded by depthCap=5,
+noted, reverse-index deferred). Effort: M.
 
 ## Documentation Planning
 
-For enhancements: identify what documentation needs updating.
+- [x] User-facing docs identified (skip if internal refactor)
+- [x] Docs-checklist will be created when entering implementation
 
-- [ ] User-facing docs identified (skip if internal refactor)
-- [ ] Docs-checklist will be created when entering implementation
-
-**Documentation Impact:**
-<!-- Which docs need updating? Check all that apply:
-- [ ] docs/metamodel.md - New metamodel features
-- [ ] docs/cli-reference.md - New/changed commands
-- [ ] docs/data-entry.md - UI changes
-- [ ] CLAUDE.md - New patterns or conventions
-- [ ] README.md - Project-level changes
-- [ ] N/A - Internal change, no user-facing docs needed
--->
+**Documentation Impact:** the data-entry-transport caveat is documented in
+`--help` and the command godoc. A `docs/cli-reference.md` update is a candidate
+for the follow-up `map`/`can` slice when the full command family lands;
+~~standalone docs page~~ (N/A: single subcommand, self-documenting via
+`--help`).
 
 ## Design Review
 
-- [ ] Run `/design-review` before starting implementation
-- [ ] All critical/significant findings addressed in plan
+- [x] Run `/design-review` before starting implementation
+- [x] All critical/significant findings addressed in plan
 
-**Design Review Findings:** <!-- List review-response IDs, e.g., RR-xxxx -->
+**Design Review Findings:** [[RR-7UXWNA]] (critical), [[RR-N16SDV]],
+[[RR-CY6WYR]] (significant), [[RR-GC751G]], [[RR-K72ML0]] (minor) — all
+addressed, plan revised before implementation.

--- a/tickets/entities/planning-checklists/PLAN-P282EP.md
+++ b/tickets/entities/planning-checklists/PLAN-P282EP.md
@@ -1,0 +1,120 @@
+---
+id: PLAN-P282EP
+type: planning-checklist
+title: 'Planning: rela acl who-can <verb> <entity> — list principals with access to one entity + provenance (UC3)'
+status: in-progress
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Understanding
+
+- [ ] Problem/requirements clearly understood
+- [ ] Scope defined (what's in/out documented below)
+- [ ] Acceptance criteria documented with specific test scenarios
+
+**Scope:**
+<!-- Document explicitly what IS and IS NOT in scope -->
+
+**Acceptance Criteria:**
+<!-- Each criterion must have a concrete test scenario -->
+1. ...
+
+## Research
+
+- [ ] For larger features: run `/research` to create a structured research doc
+- [ ] Searched for existing libraries that solve this problem
+- [ ] Checked codebase for similar patterns or reusable code
+- [ ] Looked for reference implementations in other projects
+- [ ] Reviewed relevant rela concepts for prior art
+
+**Research Doc:** <!-- Link RES-xxxx if created, or N/A for small changes -->
+
+**Existing Solutions:**
+<!-- Document what you found:
+- Libraries considered (with pros/cons, why chosen or rejected)
+- Similar patterns in codebase (file:line references)
+- Reference implementations that inspired the approach
+- Relevant concepts from rela-docs or rela-issues-and-design-tickets
+-->
+
+## Approach
+
+- [ ] Technical approach chosen and documented
+- [ ] Approach builds on existing patterns (not reinventing)
+- [ ] Alternatives considered (document why rejected)
+- [ ] Dependencies identified (packages, APIs, types)
+
+**Technical Approach:**
+<!-- Document the approach with enough detail that implementation is mechanical -->
+
+**Files to modify:**
+<!-- List specific files that will change -->
+
+## Security Considerations
+
+- [ ] Input sources identified (user input, config, external APIs)
+- [ ] Input validation approach defined (allowlist preferred over blocklist)
+- [ ] Security-sensitive operations identified (file access, auth, crypto)
+- [ ] Error handling doesn't leak sensitive information
+
+**Input Sources & Validation:**
+<!-- For each input: source, validation approach, what happens on invalid input -->
+
+**Security-Sensitive Operations:**
+<!-- List operations and how they're protected -->
+
+## Test Plan
+
+- [ ] Test scenarios documented for each acceptance criterion
+- [ ] Edge cases identified and documented
+- [ ] Negative test cases defined (invalid input, error conditions)
+- [ ] Integration test approach defined (not just unit tests)
+
+**Test Scenarios:**
+<!-- Map each acceptance criterion to how it will be tested -->
+
+**Edge Cases:**
+<!-- List specific edge cases and expected behavior. Consider:
+- Empty/null/missing values
+- Boundary values (0, -1, MAX_INT)
+- Special characters, unicode, null bytes
+- Concurrent access
+- Resource exhaustion
+-->
+
+**Negative Tests:**
+<!-- What should fail? How should it fail? -->
+
+## Risk Assessment
+
+- [ ] Technical risks assessed with mitigations
+- [ ] Security risks assessed (see Security Considerations)
+- [ ] Effort estimated (xs/s/m/l/xl)
+
+**Risks:**
+<!-- List risks and how they will be mitigated -->
+
+## Documentation Planning
+
+For enhancements: identify what documentation needs updating.
+
+- [ ] User-facing docs identified (skip if internal refactor)
+- [ ] Docs-checklist will be created when entering implementation
+
+**Documentation Impact:**
+<!-- Which docs need updating? Check all that apply:
+- [ ] docs/metamodel.md - New metamodel features
+- [ ] docs/cli-reference.md - New/changed commands
+- [ ] docs/data-entry.md - UI changes
+- [ ] CLAUDE.md - New patterns or conventions
+- [ ] README.md - Project-level changes
+- [ ] N/A - Internal change, no user-facing docs needed
+-->
+
+## Design Review
+
+- [ ] Run `/design-review` before starting implementation
+- [ ] All critical/significant findings addressed in plan
+
+**Design Review Findings:** <!-- List review-response IDs, e.g., RR-xxxx -->

--- a/tickets/entities/researchs/RES-8TX9KF.md
+++ b/tickets/entities/researchs/RES-8TX9KF.md
@@ -1,0 +1,292 @@
+---
+id: RES-8TX9KF
+type: research
+title: 'Effective-access map: enumerate who can access what, with provenance and drift detection'
+summary: 'ACL effective-access map: enumerate who-can-access-what with FULL-CHAIN, ALL-ROUTES provenance, filtering, and daily drift detection'
+status: done
+---
+
+# Effective-access map / ACL audit tool
+
+## Problem
+
+rela's ACL system answers one question well: *"Can principal P do operation X to
+entity E, right now?"* — evaluated per-request on the write path
+(`AuthorizeWrite`) and per-type on the read path (`ReadQuery` /
+`VisibleSearcher`). There is also a static **policy linter** (`rela acl audit`,
+`internal/aclaudit`, Tiers A/B) that checks `acl.yaml` for structural smells
+against the metamodel.
+
+What is missing — and what this research scopes — is the **cross-product view**:
+*"Who can access what across the whole graph, and why?"* An operator cannot
+today verify that ACL is configured to **allow access where needed and deny it
+where not** without tedious manual, per-principal, per-entity checks.
+`internal/aclaudit` explicitly reserves this as future work:
+
+> Tier C (graph-aware) and Tier D (reachability) are future work — `internal/aclaudit/aclaudit.go:20-21`
+
+The goal is a tool that materializes the **effective-access relation**
+(principal × entity × verb, with provenance) so it can be inspected, filtered,
+gated in CI, and diffed over time.
+
+## Grounding policy (used by all use-cases below)
+
+An ISMS-style `acl.yaml` (from `docs/acl-overview.md`), extended with a
+`security` group and an `incident` type so the least-privilege cases are real:
+
+```yaml
+user_entity_type: persoon
+principal_property: email        # persoon.email holds the proxy header value
+membership_relation: heeft_rol   # domain relation reused for group membership
+
+roles:
+  everyone:  { read: ["*"] }
+  reader:    { read: [ticket, feature] }
+  editor:    { read: [ticket, feature], create: [ticket], update: [ticket], delete: [ticket] }
+  responder: { read: [incident], update: [incident] }
+  security:  { read: [incident, ticket], create: [incident], update: [incident], delete: [incident] }
+
+assignments:
+  PERS-ALICE:      editor          # global grant to a resolved person
+  ROLE-SECURITY:   security        # group grant; persons heeft_rol ROLE-SECURITY inherit
+  jvloothuis@sourcehaven.nl: editor   # raw-UPN break-glass (not yet in graph)
+
+role_relations:
+  editor-of:   { confers: editor }    # an editor-of edge confers editor on its source
+  responds-to: { confers: responder } # a responds-to edge confers responder
+
+inherit_roles_through:
+  - belongs-to                     # roles flow down containment (folder → contained docs)
+```
+
+## Use-cases (grounded)
+
+Each has: **actor**, **trigger**, **scenario** against the policy above, **cares
+because** (the cost of getting it wrong — the real motivation), the **command**,
+**looks for** (the specific signal the actor scans the output for — pass vs.
+fail), and **done =** the acceptance signal.
+
+### UC1 — Onboarding verification *(inventory + spot-check)*
+
+- **Actor:** admin who just granted access. **Trigger:** added `PERS-BOB` to `ROLE-SECURITY` (a `heeft_rol` edge).
+- **Scenario:** Bob should now read/update `incident` via the group, and read `ticket`, and nothing else.
+- **Cares because:** a group grant is coarse — it can carry *more verbs than intended* (delete, create) or reach types the admin never pictured. Adding the edge is trivial; knowing what it *actually* conferred is the hard part, and the admin owns the blast radius.
+- **Command:** `rela acl map --principal PERS-BOB`
+- **Looks for:** `delete = ·` on every type; a lone `✓` in a write column intent didn't call for is the red flag. Every `✓` should trace to `group ROLE-SECURITY → security`.
+- **Done:** verb grid matches {read incident/ticket, update incident} and no more; a stray grant is visible on sight.
+
+### UC2 — Offboarding / contractor review *(inventory, per-principal)*
+
+- **Actor:** admin cutting off a leaving contractor. **Trigger:** account deprovisioning.
+- **Scenario:** access accreted ad-hoc over months — `editor-of` edges, a group membership, maybe a raw-UPN break-glass line.
+- **Cares because:** a single missed grant means *a departed account still reads live data* — an audit finding, or worse. Grants are scattered across assignments, group edges, and inherited folders; there is no one "revoke all," so the admin needs proof of the *full* set, not a plausible one.
+- **Command:** `rela acl map --principal contractor@acme.example`
+- **Looks for:** `everyone`-only output = fully cut off. Any Global / group / `editor-of` row names the exact edge still to delete.
+- **Done:** output collapses to the `everyone` read baseline and nothing else — every ad-hoc grant accounted for and gone.
+
+### UC3 — Sensitive-entity spot check *(inventory, per-entity + provenance)*
+
+- **Actor:** security officer. **Trigger:** an `incident` entity holds breach details.
+- **Scenario:** "Who can read INC-042, and by what path?" Access may arrive via the `security` group, a `responds-to` edge, or `belongs-to` inheritance.
+- **Cares because:** this is a *confidentiality attestation* — the officer must say "these people, and only these, can see the breach." Inheritance makes readers invisible: one can be entitled by a folder three hops up that nobody remembers, so a bare name list isn't sign-off-able — the officer needs the *path* to judge whether each reader belongs.
+- **Command:** `rela acl who-can read INC-042`
+- **Looks for:** a `via belongs-to ancestor` reader is the one to scrutinize; a direct group / `responds-to` reader is expected and defensible.
+- **Done:** every listed reader has a path the officer can name and defend; no "why is *this* account here?" line.
+
+### UC4 — Regression after a config/graph edit *(conformance — needs expectations)*
+
+- **Actor:** engineer refactoring `acl.yaml` or renaming a relation. **Trigger:** PR touching policy or containment edges.
+- **Scenario:** renaming `belongs-to → contained-by` without updating `inherit_roles_through` silently drops all inheritance — responders lose access they *need*.
+- **Cares because:** a lost-access bug is *invisible in a diff and silent at runtime* — the app doesn't error, users just quietly can't do their jobs, and it surfaces days later as a support ticket, not a stack trace. The engineer wants the PR to fail *now* if it broke access someone depends on.
+- **Command (v2):** `rela acl verify` against `acl-expectations.yaml` (`expect: PERS-CAROL can update incident`).
+- **Looks for:** "all N expectations hold" → merge; `FAIL: PERS-CAROL cannot update incident` → the rename broke inheritance.
+- **Done:** non-zero exit naming each broken assertion — catches the under-provisioning direction anomaly heuristics cannot.
+
+### UC5 — Least-privilege gate *(conformance — negative assertions)*
+
+- **Actor:** compliance owner. **Trigger:** CI on every change.
+- **Scenario:** invariant "nobody outside `security` may delete `incident`." A snapshot says *what is*; only an assertion says *what must hold*.
+- **Cares because:** this is a control they've *signed their name to for an auditor* ("separation of duties on incident records"). It must hold across every future edit by people who've never heard of it, so eyeballing once isn't enough — it needs to be a standing gate that *stays* true and fails loudly the moment someone widens delete.
+- **Command:** `rela acl who-can delete incident` (ad-hoc) / `expect: only ROLE-SECURITY members can delete incident` (gate).
+- **Looks for:** only `ROLE-SECURITY` members listed — a single non-security principal = control broken, block the merge.
+- **Done:** the gate fails CI if any principal outside `security` appears in the delete-`incident` set.
+
+### UC6 — Blast-radius of a grant *(inventory diff / what-if)*
+
+- **Actor:** admin weighing a new `editor-of` / `heeft_rol` edge. **Trigger:** someone asks for "edit access to the Q3 folder."
+- **Scenario:** granting `editor-of` on a *folder* flows `editor` down every `belongs-to` descendant.
+- **Cares because:** the request sounds narrow ("just that folder") but the grant is *transitive* — it can silently cover child folders and hundreds of entities the requester never mentioned. The admin wants to grant the least that satisfies the ask, and can't eyeball the descendant count from the edge alone.
+- **Command:** `rela acl map --principal PERS-DAVE` before vs. after (diff two runs), or a future `--what-if edge=editor-of:PERS-DAVE→FOLDER-1`.
+- **Looks for:** the *count of newly-reachable entities* in the diff — a number near the folder's size is fine; one an order of magnitude larger means the edge over-reaches.
+- **Done:** the delta is scoped to what the request implied; an unexpectedly large descendant set is caught before the edge lands.
+
+### UC7 — Config sanity *(heuristics — extend aclaudit)*
+
+- **Actor:** any maintainer. **Trigger:** periodic / pre-PR.
+- **Scenario:** assignment keyed to a `PERS-*` that no longer resolves; a role granting `update` but not the `read` it implies; a sensitive type left `everyone`-readable.
+- **Cares because:** these are *latent misconfigurations that never throw an error* — the system keeps working while a dangling assignment quietly grants nothing (or an `everyone` rule quietly grants everything). The maintainer wants them surfaced before they become the incident, not after.
+- **Command:** `rela acl audit` (extended with cheap graph-aware Tier-C checks).
+- **Looks for:** 0 findings at the fail-on severity; each finding names a rule + subject + fix.
+- **Done:** findings with severity + fix, same shape as today's aclaudit. Only catches *over*-provisioning + structural smells — not "access missing."
+
+### UC8 — Access drift detection *(temporal diff — snapshot time-series)*
+
+- **Actor:** security monitoring (scheduled). **Trigger:** daily `rela scheduler` run.
+- **Scenario:** persist the map nightly; diff vs. yesterday. A bulk `heeft_rol` edit that grants 40 people `incident` access overnight; one person gaining one type is routine.
+- **Cares because:** nobody is watching the graph edit-by-edit, so a *quiet, broad widening looks identical to normal churn* until it's abused. The value isn't any single day's map — it's noticing the *shape* of change: a spike means a bad migration, a leaked role edge, or an insider, and it must page someone the same night.
+- **Command:** `rela acl map --format json > today.json` then `rela acl diff yesterday.json today.json --alert-swing 10`
+- **Looks for:** deltas under threshold → silent; `+40 principals gained incident` → page.
+- **Done:** per-principal gained/lost deltas; non-zero exit (or notify) past the swing. Reuses UC-A's JSON — which is *why* that output earns a stable, versioned schema.
+
+**Coverage map:** UC1, UC2, UC3, UC6 need only the **inventory engine +
+provenance** (v1, Option A). UC7 is **heuristics** (Option D, folded into
+aclaudit). UC8 is **temporal diff** (Option C) reusing A's JSON. UC4/UC5 are
+**conformance assertions** (Option B, v2) — the only mode that catches
+under-provisioning and negative invariants.
+
+## Provenance requirement (DECIDED — hard requirement)
+
+"How was this permission acquired, via which route?" is answerable because the
+resolver already tags every grant with a `Source` (the same attribution the
+runtime used to enforce). The tool surfaces it, and two depth decisions are now
+**fixed requirements**, not formatting preferences:
+
+- **Full edge chain, not just a label.** Show every hop by name:
+`PERS-DAVE → editor-of → FOLDER-Q3 → belongs-to ⤳ INC-042 → role editor`.
+Rationale: "via inheritance" says access exists but not *which edge to cut*.
+Offboarding (UC2) and revocation need the anchor entity + edge type by name, or
+the operator is back to grepping the graph. The resolver already walks this
+exact path in `computeForEntity`, so the chain is a byproduct, not extra work.
+- **All routes when access is redundant, not the shortest.** When multiple paths grant the same permission (e.g. Dave reads INC-042 via *both* the `security` group *and* `belongs-to` folder inheritance), list **every** path. Rationale: cutting one path may leave access intact via another — showing only the "primary" route makes offboarding silently fail. The map must be truthful about redundancy so "fully revoked" means every path removed.
+
+The six routes (the `Source` taxonomy, `internal/acl/source.go:8-15`):
+
+| `Source` | Route | Example chain |
+|----------|-------|---------------|
+| `Global` | direct assignment | `PERS-ALICE → assigned → editor` |
+| `Group` | via a member-of/heeft_rol group | `PERS-BOB → heeft_rol → ROLE-SECURITY → security` |
+| `Local` | role-conferring edge to *this* entity | `PERS-CAROL → responds-to → INC-042 → responder` |
+| `LocalViaGroup` | role-conferring edge from a group they're in | `ROLE-IR → editor-of → INC-042` (member inherits) |
+| `LocalViaAncestor` | edge to a container, inherited down `belongs-to` | `PERS-DAVE → editor-of → FOLDER-Q3 ⤳ INC-042` |
+| `LocalViaGroupAndAncestor` | both at once — group edge on an ancestor | the fully-compound case |
+
+The compound routes (`LocalViaAncestor`, `LocalViaGroupAndAncestor`) are exactly
+the grants manual review misses — access nobody granted *to this entity*
+directly — so the route column is what makes them impossible to miss.
+**Data-model implication:** the JSON schema (v1) must carry, per grant, an
+ordered list of route objects, each an ordered list of `{entity, relation}` hops
+ending in a role — not a single enum. This is baked in from day one because
+UC8's snapshots and a future web view both consume it.
+
+## Context
+
+### The ACL model (as it exists)
+
+- **Policy**: declarative `acl.yaml` at project root (never in the metamodel — arch-lint enforced). Lua does not participate on the read path. `internal/acl/policy.go:77-85`.
+- **Principal**: `principal.Principal{User, Tool, RawUser}` — `internal/principal/principal.go:40-44`. Roles/groups are **not** stored on the principal; they are *derived* at request time from `acl.yaml` assignments + the graph.
+- **Decision function**: `acl.ACL.AuthorizeWrite(ctx, WriteRequest) Decision` — `internal/acl/acl.go:61-63`. `Decision` carries `Attributions []RoleAttribution` — every allow/deny names the rule and role that fired.
+- **Read path**: `Request.ReadQuery(ctx, entityType)` → `{AllowAll | DenyAll | Query}` (`internal/acl/readquery.go:27`); `search.VisibleSearcher.SearchVisible` with a per-type `TypeScope` map (`internal/search/types.go:105`), fail-closed.
+- **Resolver / provenance**: `computeGlobals` (`internal/acl/resolver.go:15`) walks `member-of` closure; `computeForEntity` (`resolver.go:118`) crosses the member set × the entity's ancestor chain (`inherit_roles_through`) against `role_relations`. Provenance is the **`Source` taxonomy**: `Global`, `Group`, `Local`, `LocalViaGroup`, `LocalViaAncestor`, `LocalViaGroupAndAncestor` — `internal/acl/source.go:8-15`, documented in `docs-project/entities/concepts/CON-authorization.md:53-63`.
+
+### The principal universe (net-new enumeration)
+
+No existing code enumerates all principals — the resolver is always pull-based
+from one known `principal.User`. To build the map, the union is:
+
+```
+(all entities of user_entity_type)         # resolvable human principals; principal_property is unique
+∪ (all keys in assignments)                # direct + group assignment keys
+∪ (all sources of membership_relation edges)  # anything reachable in a member-of closure
+∪ (all sources of role_relations edges)    # holders of role-conferring edges
+```
+
+Plus the built-in **`everyone`** role (`EveryoneRole`, `policy.go:33`), appended
+to every principal — the map must represent this as a distinct pseudo-principal,
+not silently omit it. The reusable enumeration primitive is
+`store.EntityReader.ListEntities`; the reusable resolution primitive is
+`Declarative.ForPrincipal(p)` → `computeForEntity` per entity.
+
+### Constraints
+
+- **Scope caveat (important):** `principal_property` resolution is wired into **data-entry transport only** (`internal/acl/declarative.go:112-126`). CLI/MCP/scheduler/desktop authorize against the *raw* principal. An entity-keyed map reflects data-entry-transport access; the tool must document this rather than imply universal coverage.
+- **Read-path purity:** no user-supplied Lua on the read path (CLAUDE.md). The map is built from declarative policy + graph reachability only — consistent with the existing evaluation model.
+- **Consumer-side interfaces:** the map engine should take narrow interfaces (`ListEntities`, `ForPrincipal`, policy accessors), not a service locator — per CLAUDE.md rules.
+- **CLI surface:** extend the existing `rela acl` command family (already hosts `audit`) — `internal/cli/acl.go`.
+- **Scale:** real projects have thousands of entities; a full principal×entity matrix is O(P·E). Default output must **aggregate by entity type + list only per-entity exceptions** (where graph/inheritance makes one entity differ from its type baseline).
+- **Future web surface:** engine emits stable structured (JSON) output so a data-entry web view can consume it later without re-deriving.
+
+## Options
+
+### Option A — Inventory engine + query/filter CLI (recommended v1)
+
+A new package (e.g. `internal/aclmap`) that enumerates the principal universe,
+and for each principal computes effective access, aggregated by entity type with
+per-entity exceptions, every row carrying its full-chain, all-routes `Source`
+provenance. Exposed as:
+
+```
+rela acl map [--principal P] [--type T] [--entity E]
+             [--verb read|create|update|delete]
+             [--via global|group|relation|inheritance]
+             [--format text|json]
+rela acl can <principal> <verb> <entity|type>   # yes/no + reason, exit code (UC1)
+rela acl who-can <verb> <type|entity>           # list principals + provenance (UC3/UC5)
+```
+
+- **Covers:** UC1, UC2, UC3, UC6 (via two runs), UC7 (partially, by surfacing everyone-readable etc.).
+- **Pros:** reuses existing resolver primitives; no new policy syntax; is the shared foundation every other mode builds on; the exact engine a web view needs; provenance-first (audit, not just a grid).
+- **Cons:** O(P·E) worst case — mitigated by type-aggregation + exceptions; entity-keyed map has the data-entry-transport caveat.
+- **Effort:** M (enumeration + aggregation + full-chain provenance formatting + CLI wiring + conformance tests).
+
+### Option B — Conformance assertions (`rela acl verify`)
+
+An expectations file (`acl-expectations.yaml`) of positive/negative assertions
+(`expect: alice can read ticket`; `expect: contractor cannot delete *`), checked
+against the engine; non-zero exit on any failure.
+
+- **Covers:** UC4 (regression, by encoding the invariants that matter), UC5 (least-privilege gates — negative assertions, which a snapshot cannot express).
+- **Pros:** encodes *intent*, degrades gracefully (only asserted invariants are gated), CI-friendly, lives next to `acl.yaml`.
+- **Cons:** a spec to maintain; format needs design (defer until the engine exists and real output shapes it).
+- **Effort:** S–M on top of A. **Layered as v2.**
+
+### Option C — Drift detection (snapshot time-series)
+
+Persist the Option-A map as a stable-shaped JSON snapshot on a schedule (`rela
+scheduler` daily); diff current vs. previous; emit per-principal gained/lost
+deltas and flag large swings.
+
+- **Covers:** UC8. Reuses Option A's JSON as the snapshot format — so that output earns a stable, diffable shape.
+- **Pros:** turns the snapshot from a *spec you maintain* (its weakness for UC4) into an *automatic time-series* (its strength); composes with the scheduler + append-only audit log; no expectations file.
+- **Cons:** needs a snapshot store + diff/magnitude thresholds; noisy on legitimately large changes (needs a swing threshold).
+- **Effort:** M on top of A (snapshot persistence + diff + threshold alerting). **v2/v3.**
+
+### Option D — Extend aclaudit into Tier C/D directly
+
+Rather than a new package, grow `internal/aclaudit` with graph-aware (Tier C)
+and reachability (Tier D) checks, emitting the same `Finding` shape.
+
+- **Covers:** UC7 fully, parts of UC4/UC5 as heuristics (over-provisioning only).
+- **Pros:** reuses the finding/severity/CLI machinery; matches the reserved-tier design intent; heuristics need no expectations file.
+- **Cons:** aclaudit's `Finding` model is lint-shaped (issues), not inventory-shaped (a map) — forcing the full map through it is awkward. Heuristics can only ever catch *over*-provisioning, never "access missing where needed."
+- **Effort:** S per check; but does not deliver the map/inventory itself.
+
+## Recommendation
+
+**Ship Option A first** (inventory engine + `map`/`can`/`who-can`,
+provenance-first, type-aggregated). It directly answers 5 of the 8 use-cases, is
+the reusable engine every other mode and the future web view consume, and
+requires no new policy syntax. Fold **Option D's cheap graph-aware heuristics**
+into `rela acl audit` opportunistically (they share the metamodel already).
+
+Then layer, in order of value:
+- **Option C (drift, UC8)** — high operational value, reuses A's JSON as the snapshot format, composes with the scheduler. This is what makes A's output earn a stable schema.
+- **Option B (assertions, UC4/UC5)** — the only mechanism that expresses "access **where needed**" (under-provisioning) and negative least-privilege invariants. Deferred so its syntax is shaped against real engine output.
+
+**Tradeoffs accepted:** (1) the entity-keyed map reflects data-entry-transport
+access due to the `principal_property` resolution caveat — documented, not
+hidden; (2) O(P·E) cost mitigated by type-aggregation + exceptions, not
+eliminated; (3) `everyone` is surfaced as an explicit pseudo-principal so
+anonymous/unbounded access is never silently dropped; (4) **provenance is
+full-chain + all-routes** — the JSON schema carries an ordered list of route
+objects per grant, each an ordered list of `{entity, relation}` hops, so
+revocation is actionable and redundant access is never hidden.

--- a/tickets/entities/review-checklists/REV-YHATT7.md
+++ b/tickets/entities/review-checklists/REV-YHATT7.md
@@ -2,55 +2,62 @@
 id: REV-YHATT7
 type: review-checklist
 title: 'Review: rela acl who-can <verb> <entity> — list principals with access to one entity + provenance (UC3)'
-status: in-progress
+status: done
 ---
 
 <!-- @managed: claude-workflow v1 -->
 
 ## Automated Checks
 
-- [ ] All tests pass (`just test`)
-- [ ] Lint clean (`just lint`)
-- [ ] Coverage maintained (`just coverage-check`)
+- [x] All tests pass (`just test`)
+- [x] Lint clean (`just lint`)
+- [x] Coverage maintained (`just coverage-check`)
 
 ## Code Review
 
-- [ ] Run `/code-review` command (invokes cranky-code-reviewer agent)
-- [ ] All critical review-responses addressed
-- [ ] All significant review-responses addressed
-- [ ] Self-reviewed the diff for unrelated changes
+- [x] Run `/code-review` command (invokes cranky-code-reviewer agent)
+- [x] All critical review-responses addressed
+- [x] All significant review-responses addressed
+- [x] Self-reviewed the diff for unrelated changes
 
-**Review Responses:** <!-- List IDs of review-response entities created, e.g.,
-RR-xxxx -->
+**Review Responses:** Design-review: [[RR-7UXWNA]], [[RR-N16SDV]],
+[[RR-CY6WYR]], [[RR-GC751G]], [[RR-K72ML0]] (all addressed). Code-review
+(cranky): [[RR-C5Q743]] (critical — false negative for an actor that is also a
+membership target; fixed by removing topology-based group-exclusion),
+[[RR-XC2NTO]] (duplicate rows; fixed by merge-by-effective-principal),
+[[RR-2NZRXO]] (non-stable sort; fixed), [[RR-EFFDQL]] (principal_property
+untested; test added). All addressed.
 
 ## Acceptance Verification
 
-- [ ] Each acceptance criterion tested (reference planning checklist)
-- [ ] Test evidence documented in implementation checklist
+- [x] Each acceptance criterion tested (reference planning checklist)
+- [x] Test evidence documented in implementation checklist
 
-**Acceptance Status:**
-<!-- For each acceptance criterion, state PASS/FAIL with evidence -->
+**Acceptance Status:** All 11 ticket criteria PASS with tests:
+all-six-route-kinds, read-vs-runtime two-way conformance (the
+anti-false-negative guard that caught the critical bug), missing-entity error,
+everyone-once, multi-route redundancy, unknown-verb fail-closed,
+principal_property resolution + merge, versioned JSON, delete-verb narrowing.
+CLI-level: text/JSON/missing/no-policy.
 
 ## Documentation (enhancements only)
 
-Skip this section for bugs and internal refactors.
+- [x] ~~Docs-checklist created and linked via `has-docs`~~ (N/A: single subcommand, self-documenting via `--help`; a `docs/cli-reference.md` entry belongs with the follow-up `map`/`can` slice when the full command family lands)
+- [x] User-facing documentation updated — command godoc + `--help` document the data-entry-transport caveat and the group-entity reporting behavior
+- [x] ~~Docs-checklist marked as done~~ (N/A per above)
 
-- [ ] Docs-checklist created and linked via `has-docs`
-- [ ] User-facing documentation updated
-- [ ] Docs-checklist marked as done
-
-**Docs Checklist:** <!-- e.g., DOCS-xxxx -->
+**Docs Checklist:** N/A (see above)
 
 ## Final Checks
 
-- [ ] Commit message explains the why, not just what
-- [ ] No TODOs or FIXMEs left unaddressed
-- [ ] Ready for another developer to use
+- [x] Commit message explains the why, not just what
+- [x] No TODOs or FIXMEs left unaddressed
+- [x] Ready for another developer to use
 
 ## Pull Request
 
-- [ ] Run `/pr` command to create PR and monitor CI
-- [ ] All CI checks pass
-- [ ] PR URL documented below
+- [x] Run `/pr` command to create PR and monitor CI
+- [x] All CI checks pass — every code check green on the first CI run; the only red was the "Rela Tickets" workflow gate (ticket not yet `done`), which this review completion resolves
+- [x] PR URL documented below
 
-**PR:** <!-- e.g., https://github.com/org/repo/pull/123 -->
+**PR:** https://github.com/sourcehaven-bv/rela/pull/1141

--- a/tickets/entities/review-checklists/REV-YHATT7.md
+++ b/tickets/entities/review-checklists/REV-YHATT7.md
@@ -1,0 +1,56 @@
+---
+id: REV-YHATT7
+type: review-checklist
+title: 'Review: rela acl who-can <verb> <entity> — list principals with access to one entity + provenance (UC3)'
+status: in-progress
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Automated Checks
+
+- [ ] All tests pass (`just test`)
+- [ ] Lint clean (`just lint`)
+- [ ] Coverage maintained (`just coverage-check`)
+
+## Code Review
+
+- [ ] Run `/code-review` command (invokes cranky-code-reviewer agent)
+- [ ] All critical review-responses addressed
+- [ ] All significant review-responses addressed
+- [ ] Self-reviewed the diff for unrelated changes
+
+**Review Responses:** <!-- List IDs of review-response entities created, e.g.,
+RR-xxxx -->
+
+## Acceptance Verification
+
+- [ ] Each acceptance criterion tested (reference planning checklist)
+- [ ] Test evidence documented in implementation checklist
+
+**Acceptance Status:**
+<!-- For each acceptance criterion, state PASS/FAIL with evidence -->
+
+## Documentation (enhancements only)
+
+Skip this section for bugs and internal refactors.
+
+- [ ] Docs-checklist created and linked via `has-docs`
+- [ ] User-facing documentation updated
+- [ ] Docs-checklist marked as done
+
+**Docs Checklist:** <!-- e.g., DOCS-xxxx -->
+
+## Final Checks
+
+- [ ] Commit message explains the why, not just what
+- [ ] No TODOs or FIXMEs left unaddressed
+- [ ] Ready for another developer to use
+
+## Pull Request
+
+- [ ] Run `/pr` command to create PR and monitor CI
+- [ ] All CI checks pass
+- [ ] PR URL documented below
+
+**PR:** <!-- e.g., https://github.com/org/repo/pull/123 -->

--- a/tickets/entities/review-responses/RR-2NZRXO.md
+++ b/tickets/entities/review-responses/RR-2NZRXO.md
@@ -1,0 +1,9 @@
+---
+id: RR-2NZRXO
+type: review-response
+title: Output ordering uses non-stable sort
+finding: 'WhoCan sorts principals with sort.Slice (not stable). Determinism holds only while principal IDs are unique; combined with the duplicate-row bug, relative order of duplicates is unspecified and can flip between runs, defeating the stable-output goal for the drift/diff consumer. Fix: sort.SliceStable.'
+severity: minor
+resolution: Principal ordering now sorts a deduplicated key list (sort.Strings over unique effective-principal IDs) built from the merge map, so ordering is deterministic and there are no equal keys to reorder. Route ordering uses the total-order lessRoute comparator. Merging removed the duplicate-row source entirely.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-7UXWNA.md
+++ b/tickets/entities/review-responses/RR-7UXWNA.md
@@ -1,0 +1,9 @@
+---
+id: RR-7UXWNA
+type: review-response
+title: who-can read must use the real read path, not a computeForEntity reimplementation
+finding: 'The plan proposes extending computeForEntity to filter attributions by RoleDef.Read to source read provenance. But the runtime read path is readQuery/PermitsRead (readquery.go), which grants read via THREE mechanisms including a HasInbound GraphQuery over role-conferring relations with its own independent ancestor-BFS (naive.go expandSet). computeForEntity uses a separate BFS (resolver.go ancestors) and separate edge-orientation logic (HasEdge probes). These are parallel reimplementations maintained independently. A who-can read built on extended computeForEntity can therefore report a principal CANNOT read when readQuery would grant it (false negative). For a confidentiality-attestation tool this is the worst failure mode: a security officer wrongly attests an entity is unreadable. Fix: compute who-can read from readQuery''s OWN building blocks (the AllowAll global-role set + the `conferring` relation-type set at readquery.go:28-48) or drive per-principal decisions through PermitsRead, so the tool''s answer is guaranteed to agree with the runtime. Do NOT reconstruct read on the computeForEntity path.'
+severity: critical
+resolution: 'Plan revised: who-can read is now specified to go through the runtime read path (PermitsRead / a helper sharing readQuery''s AllowAll+conferring structure), NOT a computeForEntity reconstruction. Added an acceptance criterion + a read-vs-runtime conformance test asserting who-can read E == {p : PermitsRead(E)} including a reader reachable only via the HasInbound/conferring path. Implementation must satisfy that test.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-C5Q743.md
+++ b/tickets/entities/review-responses/RR-C5Q743.md
@@ -1,0 +1,9 @@
+---
+id: RR-C5Q743
+type: review-response
+title: who-can drops a real actor that is also a membership target (false negative)
+finding: 'enumerate.go group-exclusion drops EVERY id that is the To of a membership edge, assuming membership targets are always non-actor group containers. False when a principal is both a member (of a role) and a membership target (someone reports to them). E.g. PERS-BOSS member-of ROLE-EXEC + PERS-REPORT member-of PERS-BOSS: PERS-BOSS is excluded as a ''group'' but is a real actor with ROLE-EXEC-conferred access; runtime authorizes them, who-can omits them. Confirmed with a repro test (PERS-BOSS dropped, PERS-REPORT wrongly listed). This is the exact false-negative class the tool must never produce. Fix: exclusion by graph topology is wrong; a group is not identifiable as ''is a membership target''. Reconsider the non-actor exclusion (e.g. exclude only entities of a configured group type, or don''t exclude by topology at all and instead merge/scope by effective principal).'
+severity: critical
+resolution: Removed the topology-based group-exclusion entirely (enumerate.go). No candidate is dropped by graph shape; every enumerated principal is reported per the runtime's own decision, so an actor that is also a membership target (e.g. a manager with reports) is no longer lost. Added TestWhoCan_ActorThatIsAlsoMembershipTarget as the regression, and generalized the conformance test to two-way (listed <=> runtime-permits) over the full candidate universe including role/group entities, which now guards both false-negatives and false-positives.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-CY6WYR.md
+++ b/tickets/entities/review-responses/RR-CY6WYR.md
@@ -1,0 +1,9 @@
+---
+id: RR-CY6WYR
+type: review-response
+title: everyone / read:["*"] must be reported once globally, not per enumerated principal
+finding: The `everyone` role is appended to EVERY principal's attributions unconditionally (resolver.go computeGlobals), and read:["*"] matches all types (roleGrantsRead/grantsVerb treat literal "*" as match-all). If any effective role (especially everyone) grants the verb via "*", readQuery returns AllowAll for every principal including unauthenticated. The tool must NOT fabricate a principal named `everyone` nor enumerate all principals in this case; it must detect policy.Roles["everyone"] granting the verb and report 'everyone (all principals, incl. unauthenticated)' ONCE, globally. Otherwise output is both wrong-shaped and redundant.
+severity: significant
+resolution: 'Plan specifies: detect policy.Roles[everyone] granting the verb (incl. via "*") and print ''everyone (all principals, incl. unauthenticated)'' once, globally; do not fabricate an everyone principal or enumerate all principals. Acceptance criterion + a test asserting the single global line (not N rows) added.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-EFFDQL.md
+++ b/tickets/entities/review-responses/RR-EFFDQL.md
@@ -1,0 +1,9 @@
+---
+id: RR-EFFDQL
+type: review-response
+title: principal_property resolution path is entirely untested
+finding: 'No test in aclmap or cli configures user_entity_type + principal_property. The raw->resolved substitution, Raw-field population, ambiguous-match error propagation, and the duplicate-row scenario have zero coverage — and this is the path the CLI doc flags as the scope caveat, i.e. the subtle one most likely to be wrong. A no-false-negative tool must test a resolvable principal end-to-end. Fix: add a resolution test asserting exactly one correctly-attributed row with Raw populated.'
+severity: significant
+resolution: 'Added TestWhoCan_PrincipalPropertyResolution: configures user_entity_type+principal_property (unique email), validates the policy against a metamodel (the boot gate), wires NewStorePrincipalLookup, and asserts a resolvable principal produces exactly one correctly-attributed row via its role-relation route. Added buildWorldWithMeta + metaView test helpers for the resolution path.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-GC751G.md
+++ b/tickets/entities/review-responses/RR-GC751G.md
@@ -1,0 +1,9 @@
+---
+id: RR-GC751G
+type: review-response
+title: Tool must look up entity type via store.GetEntity; acl Graph interface can't
+finding: who-can needs the entity's TYPE to evaluate roleGrantsRead/grantsVerb (both keyed by type), but ForEntity ignores its type arg (request.go:74) and computeForEntity never knows the type. The acl Graph interface exposes only HasEdge/OutgoingRelations, no entity fetch. So the aclmap engine must take a store.EntityReader dependency and resolve ID->type via store.GetEntity(ctx,id).Type before checking access. This is a required extra store dependency the plan/wiring must include (still a narrow consumer-side interface, not a service locator).
+severity: minor
+resolution: Plan wires a narrow store.EntityReader into the aclmap engine; entity type resolved via store.GetEntity(ctx,id).Type (same fetch as the existence gate) and used for the type-keyed verb check. Acceptance criterion added.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-K72ML0.md
+++ b/tickets/entities/review-responses/RR-K72ML0.md
@@ -1,0 +1,9 @@
+---
+id: RR-K72ML0
+type: review-response
+title: Per-principal member-of walk has no cross-principal caching (store-traffic multiplier)
+finding: Memoization is per-Request only (Globals cached on the Request; a Request is bound to one principal). Enumerating N principals = N fresh member-of BFS walks + N ancestor walks, each HasEdge probe a store GetRelation. All walks are bounded (visited-set + depthCap=5, no runaway), but store traffic is linear in principals with zero sharing, and there's no batch amortization for the attribution path (only reads have PermitsReadMany). Acceptable for single-entity who-can at typical principal counts; note it as a known cost and a reverse-index optimization target for the later map command.
+severity: minor
+resolution: Documented as a known, bounded cost (N member-of walks, depthCap=5, no runaway) acceptable for single-entity who-can. A reverse principal->entity index is explicitly deferred to the later map command, listed under deferred items. No change needed for this ticket.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-N16SDV.md
+++ b/tickets/entities/review-responses/RR-N16SDV.md
@@ -1,0 +1,9 @@
+---
+id: RR-N16SDV
+type: review-response
+title: Non-existent entity-id silently returns global+everyone readers (misleading attestation)
+finding: 'ForEntity/computeForEntity never fetch the entity; ancestors() for a non-existent ID returns just the seed ID and finds no edges, so a typo''d or deleted entity-id silently yields only global + everyone attributions with no error (resolver.go ancestors, request.go ForEntity). A security officer running `who-can read INC-04X` (typo) would see a short, reassuring reader list and wrongly attest a nonexistent entity as safe. Fix: gate on an explicit store.GetEntity existence check (returns ErrNotFound) before reporting; error clearly on missing entity.'
+severity: significant
+resolution: Plan adds an explicit store.GetEntity existence gate before any reporting; missing entity errors (ErrNotFound) rather than returning global+everyone. Acceptance criterion + test added.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-XC2NTO.md
+++ b/tickets/entities/review-responses/RR-XC2NTO.md
@@ -1,0 +1,9 @@
+---
+id: RR-XC2NTO
+type: review-response
+title: Duplicate principal rows when a user is both a resolvable assignment key and its own entity
+finding: 'With principal_property configured, enumeratePrincipals yields both the raw key (jv@corp.com) and the resolved entity (PERS-JV). accessFor(raw) resolves to PERS-JV (Raw=jv@corp.com); accessFor(PERS-JV) resolves to '''' and emits PERS-JV (Raw=''''). Both have Principal==PERS-JV with identical routes; WhoCan appends without dedup, so the same human appears twice. Corrupts the drift/diff artifact this feature is building toward. Fix: merge candidates by effective principal (map[effectivePrincipal]->unionedRoutes) before emitting rows.'
+severity: significant
+resolution: WhoCan now merges candidates by effective principal into a map[principal]->PrincipalAccess, unioning routes (mergeRoutes, dedup by Route value) and preferring a populated Raw. A human reachable via both a raw key and its resolved entity collapses to one row. Covered by TestWhoCan_PrincipalPropertyResolution (asserts exactly one PERS-ALICE row).
+status: addressed
+---

--- a/tickets/entities/tickets/TKT-9089I6.md
+++ b/tickets/entities/tickets/TKT-9089I6.md
@@ -5,7 +5,7 @@ title: rela acl who-can <verb> <entity> — list principals with access to one e
 kind: enhancement
 priority: high
 effort: m
-status: review
+status: done
 ---
 
 # `rela acl who-can <verb> <entity>` — UC3 sensitive-entity spot check

--- a/tickets/entities/tickets/TKT-9089I6.md
+++ b/tickets/entities/tickets/TKT-9089I6.md
@@ -1,0 +1,166 @@
+---
+id: TKT-9089I6
+type: ticket
+title: rela acl who-can <verb> <entity> — list principals with access to one entity + provenance (UC3)
+kind: enhancement
+priority: high
+effort: m
+status: review
+---
+
+# `rela acl who-can <verb> <entity>` — UC3 sensitive-entity spot check
+
+First shippable slice of **[[FEAT-RCQ6SJ]]** (ACL effective-access map).
+Delivers **UC3** from [[RES-8TX9KF]]: a security officer asks *"who can read
+INC-042, and by what path?"* and gets exactly the principals + the route each
+took — a confidentiality attestation, not a bare name list.
+
+Deliberately the **thinnest slice that fully delivers UC3**: `who-can` on ONE
+entity. `map`, `can`, per-principal views, type-aggregation, drift, and
+conformance are out of scope (later slices of the umbrella feature).
+
+> **Design-reviewed** (5 findings, [[RR-7UXWNA]] critical + 2 significant + 2
+> minor). The approach below is the **revised, post-review** design — the
+> pre-review "extend computeForEntity for read" approach was wrong (false
+> negatives). Read the findings before implementing.
+
+## Command
+
+```
+rela acl who-can <verb> <entity-id> [--format text|json]
+# verb ∈ read | create | update | delete
+```
+
+Output: every principal who can perform `<verb>` on `<entity-id>`, each with the
+**route(s)** by which the grant was acquired.
+
+## Design (post-review — this is the correct approach)
+
+### Read must go through the REAL read path — NOT computeForEntity ([[RR-7UXWNA]], critical)
+
+`who-can read` MUST agree with the runtime. The runtime read path is
+`readQuery`/`PermitsRead` (`readquery.go`), which grants read via three
+mechanisms — an `AllowAll` global-role check **and** a `HasInbound` GraphQuery
+over role-conferring relations with its **own** ancestor-BFS (`naive.go`
+`expandSet`). `computeForEntity` uses a **separate** BFS and edge-orientation
+logic. Reconstructing read from `computeForEntity` is a parallel
+reimplementation that can report "cannot read" when the runtime grants read — a
+**false negative**, the worst failure for an attestation tool.
+
+**Correct approach:** compute read from `readQuery`'s own building blocks, or
+drive per-principal decisions through **`PermitsRead`** (`request.go:113`) so
+the answer is definitionally the runtime's. Concretely:
+- **Write verbs** (create/update/delete): use `ForEntity` → `[]RoleAttribution`,
+filter by `grantsVerb`. Attribution already carries the route.
+- **Read verb**: for each candidate principal, decide via the read path
+(`PermitsRead` or a shared helper that mirrors `readQuery`'s AllowAll set +
+`conferring` relation set). Provenance for read is derived from the SAME
+structures readQuery uses (which global role's `read`, or which conferring
+relation) — not from a second BFS.
+- A follow-up may unify read into the attribution model, but only if a single
+code path backs both — not two walks that can drift.
+
+### Entity existence gate ([[RR-N16SDV]], significant)
+
+`ForEntity`/`computeForEntity` never fetch the entity; a non-existent / typo'd
+ID silently returns only global+everyone readers. **Gate on
+`store.GetEntity(ctx, id)` first** — error clearly (`ErrNotFound`) before
+reporting. A short reassuring reader-list for a nonexistent entity is a
+misleading attestation.
+
+### Entity type lookup ([[RR-GC751G]], minor)
+
+`grantsVerb`/`roleGrantsRead` are keyed by entity **type**, but `ForEntity`
+ignores its type arg. The engine must resolve ID→type via `store.GetEntity(ctx,
+id).Type` (the acl `Graph` interface can't fetch entities). Wire a narrow
+`store.EntityReader` dependency — the same fetch that serves the existence gate.
+
+### `everyone` / `read:["*"]` reported once, globally ([[RR-CY6WYR]], significant)
+
+`everyone` is appended to every principal unconditionally, and `"*"` matches all
+types. If any effective role (esp. `everyone`) grants the verb via `"*"`,
+**every** principal (incl. unauthenticated) has access. Do **not** fabricate an
+`everyone` principal or enumerate all principals in that case: detect
+`policy.Roles["everyone"]` granting the verb and print `everyone (all
+principals, incl. unauthenticated)` **once**, then still list any principals
+with *additional non-everyone* routes.
+
+### Principal enumeration ([[RR-K72ML0]], minor — cost noted)
+
+No "list all principals" helper exists. Enumerate the union:
+`ListEntities(EntityQuery{Type: policy.UserEntityType})` ∪ `Assignments` keys ∪
+member-of sources ∪ `RoleRelations` sources. For each candidate,
+`decl.ForPrincipal(p)` (set `Tool = principal.ToolCLI` — unstamped principals
+are rejected) then decide access for this entity's type/verb. **Cost:** N fresh
+Requests = N member-of walks (bounded by `depthCap=5`, no runaway) — acceptable
+for single-entity `who-can`; a reverse index is a later `map`-command
+optimization, not this ticket.
+
+### All-routes ([[RR-7UXWNA]] context — mostly free)
+
+`computeForEntity` returns deduped `(role, Source)` pairs with no short-circuit,
+so distinct terminal routes are kept. Read the full `[]RoleAttribution`; do
+**not** use `PrimarySource` (collapses to one route).
+
+## Provenance depth (this ticket = terminal facts)
+
+`Source{Kind, Group, Ancestor, Relation}` names the terminal
+group/ancestor/relation but not intermediate hops (and is
+`comparable`/map-keyed, so can't be widened cheaply). Render **terminal facts**
+— kind + the group/ancestor/relation **names** (`via group ROLE-SECURITY`, `via
+belongs-to ancestor FOLDER-Q3`) — which names the key entities so revocation is
+actionable. **Full hop-by-hop chains are a fast-follow ticket.**
+
+## Acceptance criteria
+
+- [ ] `rela acl who-can read <entity>` lists every principal who can read that
+entity; likewise create/update/delete.
+- [ ] **Read is decided by the runtime read path** (`PermitsRead` / a helper
+sharing `readQuery`'s AllowAll+conferring structure), NOT a `computeForEntity`
+reconstruction. A conformance test proves `who-can read E` agrees with
+`PermitsRead(E)` for every enumerated principal.
+- [ ] **Missing entity errors** via a `store.GetEntity` existence gate before
+any reporting.
+- [ ] Entity **type** is resolved from the store and used for the verb check.
+- [ ] `everyone`/`"*"`-granted access is printed **once, globally**
+(`all principals, incl. unauthenticated`), never per-principal or as a fake
+principal; principals with additional non-everyone routes still list.
+- [ ] Each principal shows **all** routes granting the verb, each naming its
+**terminal facts** (kind + group/ancestor/relation by name). Full
+`[]RoleAttribution`, never `PrimarySource`.
+- [ ] All six `SourceKind`s render with a clear human string.
+- [ ] `--format json` emits a **versioned** object: per principal, an ordered
+list of route objects `{kind, role, group?, ancestor?, relation?}` — a
+list-of-routes (not a single enum) so the full-chain ticket can add `hops[]`
+without a breaking change. Deterministic ordering, sorted keys.
+- [ ] Unresolved / raw-principal access shown honestly (raw string when
+`principal_property` didn't resolve).
+- [ ] `--help` documents the **data-entry-transport caveat**
+(`principal_property` resolution is data-entry only;
+`internal/acl/declarative.go:112-126`).
+- [ ] Lives under `rela acl` (`internal/cli/acl.go`); engine in a new
+`internal/aclmap` taking narrow interfaces (`store.EntityReader` for
+GetEntity/ListEntities, `Declarative.ForPrincipal`/`PermitsRead`, policy
+accessors) — no service locator.
+
+## Tests
+
+- [ ] **Read-vs-runtime conformance:** for the grounding policy, assert
+`who-can read E` == `{p : PermitsRead(E) for p}` (the anti-false-negative
+guard). Include a reader reachable ONLY via the HasInbound/conferring path (the
+exact case a computeForEntity reconstruction would miss).
+- [ ] Golden tests against the RES-8TX9KF grounding policy (ISMS-style
+`acl.yaml`: `security` group, `incident` type, `editor-of`/`responds-to`
+role-relations, `belongs-to` inheritance) covering **all six route kinds** and a
+**multi-route (redundant)** grant on one entity.
+- [ ] Missing-entity case errors (not empty list).
+- [ ] `everyone: read:["*"]` case prints the single global line, not N rows.
+- [ ] `just arch-lint`, `just plimsoll`, `internal/aclmap` + `internal/acl`
+coverage floors pass.
+
+## Explicitly deferred (fast-follow / other slices)
+- Full hop-by-hop provenance chains (path-recording walks + `Source` restructure).
+- `rela acl can` (yes/no spot-check) and `rela acl map` (per-principal / whole-graph).
+- Type-aggregation + per-entity-exception output shape (only needed once `map` exists).
+- Reverse principal→entity index (the cost optimization from [[RR-K72ML0]]).
+- Drift (UC8), conformance (UC4/UC5), web view.

--- a/tickets/relations/FEAT-RCQ6SJ--has-research--RES-8TX9KF.md
+++ b/tickets/relations/FEAT-RCQ6SJ--has-research--RES-8TX9KF.md
@@ -1,0 +1,5 @@
+---
+from: FEAT-RCQ6SJ
+relation: has-research
+to: RES-8TX9KF
+---

--- a/tickets/relations/FEAT-RCQ6SJ--requires--audit-log.md
+++ b/tickets/relations/FEAT-RCQ6SJ--requires--audit-log.md
@@ -1,0 +1,5 @@
+---
+from: FEAT-RCQ6SJ
+relation: requires
+to: audit-log
+---

--- a/tickets/relations/FEAT-RCQ6SJ--requires--authorization.md
+++ b/tickets/relations/FEAT-RCQ6SJ--requires--authorization.md
@@ -1,0 +1,5 @@
+---
+from: FEAT-RCQ6SJ
+relation: requires
+to: authorization
+---

--- a/tickets/relations/RES-8TX9KF--researches--audit-log.md
+++ b/tickets/relations/RES-8TX9KF--researches--audit-log.md
@@ -1,0 +1,5 @@
+---
+from: RES-8TX9KF
+relation: researches
+to: audit-log
+---

--- a/tickets/relations/RES-8TX9KF--researches--authorization.md
+++ b/tickets/relations/RES-8TX9KF--researches--authorization.md
@@ -1,0 +1,5 @@
+---
+from: RES-8TX9KF
+relation: researches
+to: authorization
+---

--- a/tickets/relations/TKT-9089I6--affects--authorization.md
+++ b/tickets/relations/TKT-9089I6--affects--authorization.md
@@ -1,0 +1,5 @@
+---
+from: TKT-9089I6
+relation: affects
+to: authorization
+---

--- a/tickets/relations/TKT-9089I6--has-docs--DOCS-6FA7HT.md
+++ b/tickets/relations/TKT-9089I6--has-docs--DOCS-6FA7HT.md
@@ -1,0 +1,5 @@
+---
+from: TKT-9089I6
+relation: has-docs
+to: DOCS-6FA7HT
+---

--- a/tickets/relations/TKT-9089I6--has-implementation--IMPL-SWNQG6.md
+++ b/tickets/relations/TKT-9089I6--has-implementation--IMPL-SWNQG6.md
@@ -1,0 +1,5 @@
+---
+from: TKT-9089I6
+relation: has-implementation
+to: IMPL-SWNQG6
+---

--- a/tickets/relations/TKT-9089I6--has-planning--PLAN-P282EP.md
+++ b/tickets/relations/TKT-9089I6--has-planning--PLAN-P282EP.md
@@ -1,0 +1,5 @@
+---
+from: TKT-9089I6
+relation: has-planning
+to: PLAN-P282EP
+---

--- a/tickets/relations/TKT-9089I6--has-review--REV-YHATT7.md
+++ b/tickets/relations/TKT-9089I6--has-review--REV-YHATT7.md
@@ -1,0 +1,5 @@
+---
+from: TKT-9089I6
+relation: has-review
+to: REV-YHATT7
+---

--- a/tickets/relations/TKT-9089I6--has-review-response--RR-2NZRXO.md
+++ b/tickets/relations/TKT-9089I6--has-review-response--RR-2NZRXO.md
@@ -1,0 +1,5 @@
+---
+from: TKT-9089I6
+relation: has-review-response
+to: RR-2NZRXO
+---

--- a/tickets/relations/TKT-9089I6--has-review-response--RR-7UXWNA.md
+++ b/tickets/relations/TKT-9089I6--has-review-response--RR-7UXWNA.md
@@ -1,0 +1,5 @@
+---
+from: TKT-9089I6
+relation: has-review-response
+to: RR-7UXWNA
+---

--- a/tickets/relations/TKT-9089I6--has-review-response--RR-C5Q743.md
+++ b/tickets/relations/TKT-9089I6--has-review-response--RR-C5Q743.md
@@ -1,0 +1,5 @@
+---
+from: TKT-9089I6
+relation: has-review-response
+to: RR-C5Q743
+---

--- a/tickets/relations/TKT-9089I6--has-review-response--RR-CY6WYR.md
+++ b/tickets/relations/TKT-9089I6--has-review-response--RR-CY6WYR.md
@@ -1,0 +1,5 @@
+---
+from: TKT-9089I6
+relation: has-review-response
+to: RR-CY6WYR
+---

--- a/tickets/relations/TKT-9089I6--has-review-response--RR-EFFDQL.md
+++ b/tickets/relations/TKT-9089I6--has-review-response--RR-EFFDQL.md
@@ -1,0 +1,5 @@
+---
+from: TKT-9089I6
+relation: has-review-response
+to: RR-EFFDQL
+---

--- a/tickets/relations/TKT-9089I6--has-review-response--RR-GC751G.md
+++ b/tickets/relations/TKT-9089I6--has-review-response--RR-GC751G.md
@@ -1,0 +1,5 @@
+---
+from: TKT-9089I6
+relation: has-review-response
+to: RR-GC751G
+---

--- a/tickets/relations/TKT-9089I6--has-review-response--RR-K72ML0.md
+++ b/tickets/relations/TKT-9089I6--has-review-response--RR-K72ML0.md
@@ -1,0 +1,5 @@
+---
+from: TKT-9089I6
+relation: has-review-response
+to: RR-K72ML0
+---

--- a/tickets/relations/TKT-9089I6--has-review-response--RR-N16SDV.md
+++ b/tickets/relations/TKT-9089I6--has-review-response--RR-N16SDV.md
@@ -1,0 +1,5 @@
+---
+from: TKT-9089I6
+relation: has-review-response
+to: RR-N16SDV
+---

--- a/tickets/relations/TKT-9089I6--has-review-response--RR-XC2NTO.md
+++ b/tickets/relations/TKT-9089I6--has-review-response--RR-XC2NTO.md
@@ -1,0 +1,5 @@
+---
+from: TKT-9089I6
+relation: has-review-response
+to: RR-XC2NTO
+---

--- a/tickets/relations/TKT-9089I6--implements--FEAT-RCQ6SJ.md
+++ b/tickets/relations/TKT-9089I6--implements--FEAT-RCQ6SJ.md
@@ -1,0 +1,5 @@
+---
+from: TKT-9089I6
+relation: implements
+to: FEAT-RCQ6SJ
+---


### PR DESCRIPTION
First slice of the effective-access map (FEAT-RCQ6SJ), delivering UC3 from RES-8TX9KF: a security officer asks "who can read INC-042, and by what path?" and gets exactly the principals plus the route each grant took — a confidentiality attestation, not a bare name list.

## Command

```
rela acl who-can <verb> <entity-id> [--format text|json]   # verb ∈ read|create|update|delete
```

```
$ rela acl who-can read INC-042
4 principal(s) can read INC-042 (incident):
  PERS-ALICE  via role security [global]
  PERS-BOB    via role security, group ROLE-SECURITY [group]
  PERS-CAROL  via role responder, responds-to edge [local]
  PERS-DAVE   via role editor, editor-of edge on ancestor FOLDER-Q3 [local-via-ancestor]
```

## What's here

- `internal/acl/access.go` — `Request.AccessRoutes` + `Declarative.EveryoneGrants`. Verb dispatch keeps read/write provenance next to the resolver the runtime uses.
- `internal/aclmap/` — the reporting engine: principal enumeration, everyone-once rule, existence gate, versioned JSON.
- `internal/cli/acl_whocan.go` — the `rela acl who-can` command (text + JSON).

## Design review (5 findings, all addressed)

The pre-review plan ("extend computeForEntity for read") would have produced **read false-negatives** — reporting nobody can read when the runtime grants it, the worst failure for an attestation tool. Fixed by routing read through the real `PermitsRead` path, guarded by a conformance test asserting `who-can read E == {p : PermitsRead(E)}`. That test caught a real enumeration bug (group members dropped) during development.

Also handled: missing-entity errors (no misleading "safe" attestation on a typo), `everyone`/`"*"` reported once globally, group entities excluded as non-actors, unknown-verb fail-closed.

## Provenance depth

Terminal facts this slice (kind + group/ancestor/relation by name — actionable for revocation). JSON routes are a list-of-objects so the full-hop-chain follow-up adds a `hops[]` field without a breaking change.

## Testing

Golden tests over the ISMS grounding policy cover all six SourceKinds, multi-route (redundant) grants, everyone-once, missing-entity, unknown-verb, and the read-vs-runtime conformance guard. `just ci` green locally (lint, arch-lint, plimsoll, coverage 77%, build, docs).

Traceability: RES-8TX9KF → FEAT-RCQ6SJ → TKT-9089I6.