### PR TITLE
Operator version-purge primitive for compliance redaction (TKT-BW6UUL)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -235,6 +235,25 @@ Rules when touching this:
   history exposes exactly what a live relation GET does. `RelationHistoryReader`/
   `RelationVersionWriter` are SEPARATE optional capabilities, type-asserted
   independently of the entity ones.
+- **Version purge** (TKT-BW6UUL, postgres only) is the audited, irreversible
+  exception to append-only history — hard-deletes version rows for compliance
+  redaction. `VersionPurger`/`RelationVersionPurger` are SEPARATE optional
+  capabilities (`purge.go`), one `PurgeVersions`/`PurgeRelationVersions` method
+  each. Load-bearing guardrails (design-review, do not relax): the whole op runs
+  under **`sweepAdvisoryLockKey`** (mutually exclusive with a sweep tick — a purge
+  racing a capture-insert loses the erasure); it **REFUSES while a live row still
+  holds the content** unless `--force-live` (else the sweep re-captures it within
+  one interval — a `VersionOpPurge` no-content tombstone whose content_hash = the
+  live hash suppresses that re-capture via the sweep's existing dedup); it
+  **REFUSES a rename row** (purging one orphans/forks the lineage walk — v1 is
+  non-rename-only); `--all` purges the **fenced lineage** (`lineageCTE` /
+  `relationLineageIDs`), never `WHERE id=$1` (id-reuse would destroy unrelated
+  history). CLI-only (`history-purge`/`relation-history-purge`), dry-run by
+  default; trust boundary is operator shell (no ACL check — like `db migrate`),
+  audited via the `audit.Audit` sink (`OpPurgeVersion`, `svc.Audit()`), never
+  echoing purged content. `schema_versions` is projection-only + FK-shared, so
+  purge never deletes it. Purge is necessary-not-sufficient for erasure (live
+  row / PITR backups survive) — see the postgres-backend guide.
 - DSN is read from the `RELA_DATABASE_URL` env var **only** — there is no
   `--database-url` flag, so the credential never lands in `ps`/shell history.
   `appbuild.Discover` reads the env into `appbuild.Config.DatabaseURL`; the

--- a/docs-project/entities/guides/GUIDE-cli-reference.md
+++ b/docs-project/entities/guides/GUIDE-cli-reference.md
@@ -471,6 +471,64 @@ rela relation-restore TKT-42 blocks TKT-99 2
 
 ---
 
+### rela history-purge
+
+Hard-delete an entity's version history for compliance (leaked secret, PII, GDPR
+erasure). The deliberate, audited, **irreversible** exception to append-only
+history. **PostgreSQL build only.** Operator-only: the trust boundary is shell +
+`RELA_DATABASE_URL` access (no ACL check), like `rela db migrate`.
+
+```bash
+rela history-purge <id> (--vseq N | --content-hash H | --all) --reason "..." [--commit] [--yes] [--force-live]
+```
+
+**Arguments / flags:**
+
+- `id` — the entity whose history to purge
+- `--vseq N` — purge the single version row with this vseq (from `rela history`)
+- `--content-hash H` — purge every row in the lineage with this content hash
+  (erase a value everywhere it was captured; verifiable afterward)
+- `--all` — purge the entity's entire (fenced) history
+- `--reason "..."` — **required**; recorded in the audit trail. Do NOT put the
+  secret here (logged in cleartext)
+- `--commit` — actually delete. **Without it the command is a dry-run** that only
+  shows what would be purged
+- `--yes` — skip the type-the-id confirmation (scripts); requires `--commit`
+- `--force-live` — purge even though the live row still holds the content (writes
+  a tombstone so the sweep will not re-capture it). Prefer redacting the live
+  value first.
+
+Purge **refuses** while the live row still holds the content (unless
+`--force-live`) and **refuses** a rename row. It is one necessary step, not
+cryptographic erasure — PITR/backup lifecycle is the operator's responsibility.
+
+**Examples:**
+
+```bash
+rela history-purge TKT-42 --content-hash abc123 --reason "erase SSN per DPO-42"          # dry-run
+rela history-purge TKT-42 --content-hash abc123 --reason "erase SSN per DPO-42" --commit  # do it
+```
+
+---
+
+### rela relation-history-purge
+
+The relation analog of `rela history-purge`, addressing a relation by its
+three-part key. Same flags, guardrails, and irreversibility. **PostgreSQL build
+only.**
+
+```bash
+rela relation-history-purge <from> <type> <to> (--vseq N | --content-hash H | --all) --reason "..." [--commit] [--yes] [--force-live]
+```
+
+**Examples:**
+
+```bash
+rela relation-history-purge TKT-42 blocks TKT-99 --all --reason "erase per request" --commit
+```
+
+---
+
 ### rela attach
 
 Attach file(s) to an entity.

--- a/docs-project/entities/guides/GUIDE-postgres-backend.md
+++ b/docs-project/entities/guides/GUIDE-postgres-backend.md
@@ -207,6 +207,47 @@ global `history:read`). In the web UI, a relation's history is owned by its
 a History affordance. Restore goes through the normal write path; re-creating a
 relation whose endpoint entity no longer exists is refused (409).
 
+### Purging history for compliance
+
+History is append-only by design. When you must actually **remove** content from
+history — a leaked secret, PII, a GDPR erasure request — the `history-purge` /
+`relation-history-purge` commands hard-delete version snapshot rows. This is the
+deliberate, audited, **irreversible** exception to the append-only model, and it
+is **operator-only**: the trust boundary is shell access plus the database
+credential (`RELA_DATABASE_URL`), the same as `rela db migrate` — the CLI applies
+no ACL check.
+
+```bash
+# Dry-run (the DEFAULT): shows exactly what would be purged, deletes nothing.
+rela history-purge TKT-42 --content-hash <h> --reason "erase SSN per DPO-42"
+
+# Commit the deletion (irreversible). Confirmation asks you to type the id.
+rela history-purge TKT-42 --content-hash <h> --reason "erase SSN per DPO-42" --commit
+```
+
+Target a specific row by `--vseq` (from `rela history`), every row holding a
+value by `--content-hash` (the "erase this value everywhere it was captured"
+operation — verifiable, since afterward no row carries that hash), or the whole
+lineage with `--all`. `--reason` is required and recorded in the audit trail;
+**do not put the secret itself in `--reason`** (it is logged in cleartext). The
+purge itself is audited (who, what, count, when) — that record is the surviving
+compliance trail and never contains the purged content.
+
+Two guardrails you will hit:
+
+- **Purge refuses while the live entity/relation still holds the content.** The
+  version sweep reconciles history *toward* the live row, so purging history
+  without first redacting the live value would just re-capture it within a few
+  minutes. Redact (or delete) the live value first; or pass `--force-live`, which
+  writes a tombstone that stops the sweep from re-capturing.
+- **Purge refuses a `rename` row** (purging one would sever unrelated history).
+  Select non-rename rows by `--vseq`/`--content-hash`.
+
+**Purge is one necessary step, not cryptographic erasure.** It removes rows from
+the primary database; a value may still survive in your PITR/base backups and WAL
+until their retention expires — accounting for the backup lifecycle is the
+operator's separate responsibility.
+
 ## Other scope notes
 
 - The desktop app (`rela-desktop`) is filesystem-only; there is no PostgreSQL

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -465,6 +465,64 @@ rela relation-restore TKT-42 blocks TKT-99 2
 
 ---
 
+### rela history-purge
+
+Hard-delete an entity's version history for compliance (leaked secret, PII, GDPR
+erasure). The deliberate, audited, **irreversible** exception to append-only
+history. **PostgreSQL build only.** Operator-only: the trust boundary is shell +
+`RELA_DATABASE_URL` access (no ACL check), like `rela db migrate`.
+
+```bash
+rela history-purge <id> (--vseq N | --content-hash H | --all) --reason "..." [--commit] [--yes] [--force-live]
+```
+
+**Arguments / flags:**
+
+- `id` — the entity whose history to purge
+- `--vseq N` — purge the single version row with this vseq (from `rela history`)
+- `--content-hash H` — purge every row in the lineage with this content hash
+  (erase a value everywhere it was captured; verifiable afterward)
+- `--all` — purge the entity's entire (fenced) history
+- `--reason "..."` — **required**; recorded in the audit trail. Do NOT put the
+  secret here (logged in cleartext)
+- `--commit` — actually delete. **Without it the command is a dry-run** that only
+  shows what would be purged
+- `--yes` — skip the type-the-id confirmation (scripts); requires `--commit`
+- `--force-live` — purge even though the live row still holds the content (writes
+  a tombstone so the sweep will not re-capture it). Prefer redacting the live
+  value first.
+
+Purge **refuses** while the live row still holds the content (unless
+`--force-live`) and **refuses** a rename row. It is one necessary step, not
+cryptographic erasure — PITR/backup lifecycle is the operator's responsibility.
+
+**Examples:**
+
+```bash
+rela history-purge TKT-42 --content-hash abc123 --reason "erase SSN per DPO-42"          # dry-run
+rela history-purge TKT-42 --content-hash abc123 --reason "erase SSN per DPO-42" --commit  # do it
+```
+
+---
+
+### rela relation-history-purge
+
+The relation analog of `rela history-purge`, addressing a relation by its
+three-part key. Same flags, guardrails, and irreversibility. **PostgreSQL build
+only.**
+
+```bash
+rela relation-history-purge <from> <type> <to> (--vseq N | --content-hash H | --all) --reason "..." [--commit] [--yes] [--force-live]
+```
+
+**Examples:**
+
+```bash
+rela relation-history-purge TKT-42 blocks TKT-99 --all --reason "erase per request" --commit
+```
+
+---
+
 ### rela attach
 
 Attach file(s) to an entity.

--- a/docs/postgres-backend.md
+++ b/docs/postgres-backend.md
@@ -201,6 +201,47 @@ global `history:read`). In the web UI, a relation's history is owned by its
 a History affordance. Restore goes through the normal write path; re-creating a
 relation whose endpoint entity no longer exists is refused (409).
 
+### Purging history for compliance
+
+History is append-only by design. When you must actually **remove** content from
+history — a leaked secret, PII, a GDPR erasure request — the `history-purge` /
+`relation-history-purge` commands hard-delete version snapshot rows. This is the
+deliberate, audited, **irreversible** exception to the append-only model, and it
+is **operator-only**: the trust boundary is shell access plus the database
+credential (`RELA_DATABASE_URL`), the same as `rela db migrate` — the CLI applies
+no ACL check.
+
+```bash
+# Dry-run (the DEFAULT): shows exactly what would be purged, deletes nothing.
+rela history-purge TKT-42 --content-hash <h> --reason "erase SSN per DPO-42"
+
+# Commit the deletion (irreversible). Confirmation asks you to type the id.
+rela history-purge TKT-42 --content-hash <h> --reason "erase SSN per DPO-42" --commit
+```
+
+Target a specific row by `--vseq` (from `rela history`), every row holding a
+value by `--content-hash` (the "erase this value everywhere it was captured"
+operation — verifiable, since afterward no row carries that hash), or the whole
+lineage with `--all`. `--reason` is required and recorded in the audit trail;
+**do not put the secret itself in `--reason`** (it is logged in cleartext). The
+purge itself is audited (who, what, count, when) — that record is the surviving
+compliance trail and never contains the purged content.
+
+Two guardrails you will hit:
+
+- **Purge refuses while the live entity/relation still holds the content.** The
+  version sweep reconciles history *toward* the live row, so purging history
+  without first redacting the live value would just re-capture it within a few
+  minutes. Redact (or delete) the live value first; or pass `--force-live`, which
+  writes a tombstone that stops the sweep from re-capturing.
+- **Purge refuses a `rename` row** (purging one would sever unrelated history).
+  Select non-rename rows by `--vseq`/`--content-hash`.
+
+**Purge is one necessary step, not cryptographic erasure.** It removes rows from
+the primary database; a value may still survive in your PITR/base backups and WAL
+until their retention expires — accounting for the backup lifecycle is the
+operator's separate responsibility.
+
 ## Other scope notes
 
 - The desktop app (`rela-desktop`) is filesystem-only; there is no PostgreSQL

--- a/internal/audit/audit.go
+++ b/internal/audit/audit.go
@@ -45,6 +45,15 @@ const (
 	// carries automation:<name>. Forensic: isolate every elevated write with
 	// `op == "acl-bypass"`.
 	OpACLBypass = "acl-bypass"
+
+	// OpPurgeVersion records an operator hard-delete of version snapshot rows
+	// (TKT-BW6UUL) — the deliberate, irreversible exception to append-only
+	// history, for compliance redaction. Subject names the entity/relation whose
+	// lineage was purged; Summary carries the count, the vseq(s) or content-hash
+	// targeted, and the operator's --reason. The purged CONTENT is never recorded
+	// (that would defeat the purge); this record is the surviving forensic trail
+	// showing who purged what and why. Isolate with `op == "purge-version"`.
+	OpPurgeVersion = "purge-version"
 )
 
 // Subject identifies what an op acted on. Exactly one of {Type, ID}

--- a/internal/cli/cli_wiring.go
+++ b/internal/cli/cli_wiring.go
@@ -7,6 +7,7 @@ import (
 	"github.com/Sourcehaven-BV/rela/internal/analysis"
 	"github.com/Sourcehaven-BV/rela/internal/appbuild"
 	"github.com/Sourcehaven-BV/rela/internal/attachment"
+	"github.com/Sourcehaven-BV/rela/internal/audit"
 	"github.com/Sourcehaven-BV/rela/internal/config"
 	"github.com/Sourcehaven-BV/rela/internal/entity"
 	"github.com/Sourcehaven-BV/rela/internal/entitymanager"
@@ -38,7 +39,7 @@ import (
 // breadth of the CLI surface. Ratchet candidate — purpose-grouped sub-bundles
 // (read / write / analyze) would let each command bind only what it uses.
 //
-//plimsoll:max-exported-methods=28
+//plimsoll:max-exported-methods=29
 type cliServices struct {
 	svc        *appbuild.Services
 	attachment *attachment.Service
@@ -61,9 +62,16 @@ func (s *cliServices) FS() storage.FS                  { return s.svc.FS() }
 
 func (s *cliServices) EntityManager() entitymanager.EntityManager { return s.svc.EntityManager() }
 func (s *cliServices) Validator() validator.Validator             { return s.svc.Validator() }
-func (s *cliServices) LuaCache() *lua.Cache                       { return s.svc.ScriptEngine().LuaCache() }
-func (s *cliServices) LuaWriteDeps() lua.WriteDeps                { return s.svc.LuaWriteDeps() }
-func (s *cliServices) State() state.KV                            { return s.svc.State() }
+
+// Audit exposes the audit sink so the version-purge CLI commands (TKT-BW6UUL)
+// can record the forensic purge event. Purge is a store-level destructive op
+// with no entity write, so it does NOT route through entitymanager.Manager (the
+// write-path audit hook) — it emits the OpPurgeVersion record directly through
+// this sink, the same sink the Manager writes to.
+func (s *cliServices) Audit() audit.Audit          { return s.svc.Audit() }
+func (s *cliServices) LuaCache() *lua.Cache        { return s.svc.ScriptEngine().LuaCache() }
+func (s *cliServices) LuaWriteDeps() lua.WriteDeps { return s.svc.LuaWriteDeps() }
+func (s *cliServices) State() state.KV             { return s.svc.State() }
 
 // LuaReadDeps surfaces the read-only Lua capability bundle —
 // scheduler.WorkspaceProvider requires it.

--- a/internal/cli/history_purge.go
+++ b/internal/cli/history_purge.go
@@ -1,0 +1,243 @@
+package cli
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/Sourcehaven-BV/rela/internal/audit"
+	"github.com/Sourcehaven-BV/rela/internal/principal"
+	"github.com/Sourcehaven-BV/rela/internal/store"
+)
+
+// HistoryPurgeCmd HARD-DELETES entity version snapshot rows for compliance
+// redaction (TKT-BW6UUL) — the deliberate, audited, IRREVERSIBLE exception to
+// append-only history. Operator-only: the trust boundary is shell +
+// RELA_DATABASE_URL access (same as `rela db migrate` / `rela restore`), NOT an
+// ACL permission — the CLI applies no per-invocation ACL. pgstore-build only.
+//
+// Safety: **dry-run is the DEFAULT**; nothing is deleted without --commit. A
+// --commit requires typing the entity id to confirm (or --yes for scripts).
+// Purge REFUSES when the live row still holds the content (the sweep would
+// re-capture it) unless --force-live, and REFUSES a rename row (purging it would
+// orphan lineage). Every purge is audited (op=purge-version) with the required
+// --reason; the purged content is never logged.
+type HistoryPurgeCmd struct {
+	ID          string `arg:"" help:"Entity ID whose version history to purge."`
+	Vseq        int64  `help:"Purge the single version row with this vseq (see 'rela history <id>')." default:"0"`
+	ContentHash string `help:"Purge every version row in the lineage with this content hash (erase a value everywhere)." default:""`
+	All         bool   `help:"Purge the entity's entire (fenced) version history."`
+	Reason      string `help:"Required: operator justification, recorded in the audit trail. Do NOT put the secret being purged here (it is logged in cleartext)." default:""`
+	Commit      bool   `help:"Actually delete. Without this, the command is a dry-run that only shows what WOULD be purged."`
+	Yes         bool   `help:"Skip the type-the-id confirmation (for scripts). Requires --commit."`
+	ForceLive   bool   `help:"Purge even though a live row still holds the content; writes a tombstone so the sweep won't re-capture it. Redact the live value first when possible."`
+}
+
+// Run dispatches `rela history-purge <id> ...`.
+func (c *HistoryPurgeCmd) Run(ctx context.Context, svc *cliServices) error {
+	purger, ok := svc.Store().(store.VersionPurger)
+	if !ok {
+		out.WriteMessage("The active storage backend does not support version purge " +
+			"(a PostgreSQL-build compliance feature).")
+		return nil
+	}
+	if err := validatePurgeFlags(c.Reason, c.Vseq, c.ContentHash, c.All); err != nil {
+		return err
+	}
+	p := principal.From(ctx)
+	req := store.VersionPurgeRequest{
+		EntityID:      c.ID,
+		Selector:      store.PurgeSelector{Vseq: c.Vseq, ContentHash: c.ContentHash, All: c.All},
+		Reason:        c.Reason,
+		ForceLive:     c.ForceLive,
+		PrincipalUser: p.User,
+		PrincipalTool: p.Tool,
+	}
+
+	// Always preview first (DryRun), so the operator sees exactly what will die
+	// and any refusal BEFORE anything is deleted — even with --commit.
+	preview := req
+	preview.DryRun = true
+	res, err := purger.PurgeVersions(ctx, preview)
+	if err != nil {
+		return fmt.Errorf("purge history for %q: %w", c.ID, err)
+	}
+	if refused := reportPurgePreview(res, c.ID, !c.Commit); refused || !c.Commit {
+		return nil
+	}
+	if !c.Yes && !confirmPurge(c.ID) {
+		out.WriteMessage("Cancelled")
+		return nil
+	}
+
+	// Confirmed: do the real (destructive) purge.
+	final, err := purger.PurgeVersions(ctx, req)
+	if err != nil {
+		return fmt.Errorf("purge history for %q: %w", c.ID, err)
+	}
+	auditPurge(svc.Audit(), p, audit.Subject{Kind: "entity", ID: c.ID}, final, c.Reason)
+	out.WriteSuccess("Purged %d version row(s) for %s. This is irreversible.", final.Purged, c.ID)
+	if final.TombstoneWritten {
+		out.WriteInfo("Wrote a purge tombstone (a live row still held the content); the sweep will not re-capture it.")
+	}
+	return nil
+}
+
+// RelationHistoryPurgeCmd is the relation analog.
+type RelationHistoryPurgeCmd struct {
+	From        string `arg:"" help:"Source entity ID (the relation's 'from')."`
+	Type        string `arg:"" help:"Relation type."`
+	To          string `arg:"" help:"Target entity ID (the relation's 'to')."`
+	Vseq        int64  `help:"Purge the single version row with this vseq." default:"0"`
+	ContentHash string `help:"Purge every version row in the lineage with this content hash." default:""`
+	All         bool   `help:"Purge the relation's entire (fenced) version history."`
+	Reason      string `help:"Required: operator justification (logged cleartext — not the secret)." default:""`
+	Commit      bool   `help:"Actually delete. Without this, a dry-run showing what WOULD be purged."`
+	Yes         bool   `help:"Skip the confirmation (scripts). Requires --commit."`
+	ForceLive   bool   `help:"Purge even though the live relation still holds the content (writes a tombstone)."`
+}
+
+// Run dispatches `rela relation-history-purge <from> <type> <to> ...`.
+func (c *RelationHistoryPurgeCmd) Run(ctx context.Context, svc *cliServices) error {
+	purger, ok := svc.Store().(store.RelationVersionPurger)
+	if !ok {
+		out.WriteMessage("The active storage backend does not support relation version purge " +
+			"(a PostgreSQL-build compliance feature).")
+		return nil
+	}
+	if err := validatePurgeFlags(c.Reason, c.Vseq, c.ContentHash, c.All); err != nil {
+		return err
+	}
+	p := principal.From(ctx)
+	key := fmt.Sprintf("%s--%s--%s", c.From, c.Type, c.To)
+	req := store.RelationVersionPurgeRequest{
+		From: c.From, Type: c.Type, To: c.To,
+		Selector:      store.PurgeSelector{Vseq: c.Vseq, ContentHash: c.ContentHash, All: c.All},
+		Reason:        c.Reason,
+		ForceLive:     c.ForceLive,
+		PrincipalUser: p.User,
+		PrincipalTool: p.Tool,
+	}
+
+	preview := req
+	preview.DryRun = true
+	res, err := purger.PurgeRelationVersions(ctx, preview)
+	if err != nil {
+		return fmt.Errorf("purge relation history for %s: %w", key, err)
+	}
+	if refused := reportPurgePreview(res, key, !c.Commit); refused || !c.Commit {
+		return nil
+	}
+	if !c.Yes && !confirmPurge(key) {
+		out.WriteMessage("Cancelled")
+		return nil
+	}
+
+	final, err := purger.PurgeRelationVersions(ctx, req)
+	if err != nil {
+		return fmt.Errorf("purge relation history for %s: %w", key, err)
+	}
+	auditPurge(svc.Audit(), p, audit.Subject{
+		Kind: "relation", RelationType: c.Type, FromID: c.From, ToID: c.To,
+	}, final, c.Reason)
+	out.WriteSuccess("Purged %d version row(s) for %s. This is irreversible.", final.Purged, key)
+	if final.TombstoneWritten {
+		out.WriteInfo("Wrote a purge tombstone (a live relation still held the content); the sweep will not re-capture it.")
+	}
+	return nil
+}
+
+// --- shared helpers ---
+
+func validatePurgeFlags(reason string, vseq int64, hash string, all bool) error {
+	if strings.TrimSpace(reason) == "" {
+		return errors.New("--reason is required (recorded in the audit trail; do not include the secret)")
+	}
+	n := 0
+	if vseq != 0 {
+		n++
+	}
+	if hash != "" {
+		n++
+	}
+	if all {
+		n++
+	}
+	if n != 1 {
+		return errors.New("specify exactly one of --vseq, --content-hash, or --all")
+	}
+	return nil
+}
+
+// reportPurgePreview prints the resolved targets and any refusal. Returns true
+// if the purge was REFUSED (rename row present, or live row without --force-live)
+// so the caller stops. In dry-run mode it always prints the preview and the
+// caller returns without deleting.
+func reportPurgePreview(res *store.PurgeResult, target string, dryRun bool) (refused bool) {
+	if len(res.Targets) == 0 {
+		out.WriteMessage("Nothing to purge for %s (no matching version rows).", target)
+		return true
+	}
+	if dryRun {
+		out.WriteInfo("DRY RUN — would purge %d version row(s) for %s:", len(res.Targets), target)
+	}
+	for _, t := range res.Targets {
+		line := fmt.Sprintf("  vseq %d  %s  %s", t.Vseq, t.Op, t.CreatedAt.Format("2006-01-02 15:04:05"))
+		if t.IsRename {
+			line += "  [RENAME — refused: purging it would orphan lineage]"
+		}
+		out.WriteInfo("%s", line)
+	}
+	if res.RenameInTargets {
+		out.WriteMessage("Refused: the target set contains a rename row. " +
+			"Purging a rename row orphans lineage; select non-rename rows (by --vseq or --content-hash).")
+		return true
+	}
+	if res.LiveRowExists && !dryRun {
+		// Only reached when --commit was set but --force-live was not (the store
+		// refused and deleted nothing).
+		out.WriteMessage("Refused: the live entity/relation still holds this content — the sweep would " +
+			"re-capture it. Redact the live value (or delete it) first, or pass --force-live.")
+		return true
+	}
+	if res.LiveRowExists && dryRun {
+		out.WriteInfo("NOTE: a live row still holds this content. A --commit will REFUSE " +
+			"unless you also pass --force-live (which writes a sweep-suppressing tombstone).")
+	}
+	return false
+}
+
+func confirmPurge(target string) bool {
+	fmt.Printf("This IRREVERSIBLY deletes version history for %s.\nType the id/key to confirm: ", target)
+	reader := bufio.NewReader(os.Stdin)
+	response, err := reader.ReadString('\n')
+	if err != nil {
+		return false
+	}
+	return strings.TrimSpace(response) == target
+}
+
+// auditPurge records the forensic purge event through the audit sink. It records
+// identity + count + reason + the vseqs/hash targeted — NEVER the purged content.
+func auditPurge(sink audit.Audit, p principal.Principal, subj audit.Subject, res *store.PurgeResult, reason string) {
+	// Summarize the targeted vseqs compactly (count + range), not an enumeration.
+	summary := fmt.Sprintf("purged=%d reason=%q", res.Purged, reason)
+	if len(res.Targets) > 0 {
+		summary += fmt.Sprintf(" vseq_range=[%d,%d]",
+			res.Targets[0].Vseq, res.Targets[len(res.Targets)-1].Vseq)
+	}
+	if res.TombstoneWritten {
+		summary += " tombstone=true"
+	}
+	sink.Record(audit.Record{
+		Time:      time.Now().UTC(),
+		Op:        audit.OpPurgeVersion,
+		Subject:   &subj,
+		Principal: p,
+		Summary:   summary,
+	})
+}

--- a/internal/cli/kong.go
+++ b/internal/cli/kong.go
@@ -48,7 +48,7 @@ var (
 // so growth is structural here) — over the 20-field load line. Revisit grouping
 // subcommands into sub-structs; ratchet this number down if/when that lands.
 //
-//plimsoll:max-fields=43
+//plimsoll:max-fields=45
 type CLI struct {
 	// Global flags.
 	Project string `help:"Project directory (default: auto-detect from cwd)." env:"RELA_PROJECT"`
@@ -90,14 +90,17 @@ type CLI struct {
 
 	RelationHistory RelationHistoryCmd `cmd:"" name:"relation-history" help:"Show a relation's version history (postgres build)."`
 	RelationRestore RelationRestoreCmd `cmd:"" name:"relation-restore" help:"Restore a relation to a past version (postgres build)."`
-	Attach          AttachCmd          `cmd:"" help:"Attach file(s) to an entity."`
-	Attachments     AttachmentsCmd     `cmd:"" help:"List attachments for an entity."`
-	Detach          DetachCmd          `cmd:"" help:"Remove the attachment from an entity property."`
-	Gc              GcCmd              `cmd:"" name:"gc" help:"Garbage collect orphaned files."`
-	Script          ScriptCmd          `cmd:"" help:"Execute a Lua script against the graph."`
-	Scheduler       SchedulerCmd       `cmd:"" help:"Run scheduled Lua tasks."`
-	Renumber        RenumberCmd        `cmd:"" help:"Renumber managed order properties on orderable relations."`
-	Sync            SyncCmd            `cmd:"" help:"Sync local changes with a remote rela-server."`
+
+	HistoryPurge         HistoryPurgeCmd         `cmd:"" name:"history-purge" help:"Hard-delete an entity's version history for compliance (postgres build; irreversible)."`
+	RelationHistoryPurge RelationHistoryPurgeCmd `cmd:"" name:"relation-history-purge" help:"Hard-delete a relation's version history for compliance (postgres build; irreversible)."`
+	Attach               AttachCmd               `cmd:"" help:"Attach file(s) to an entity."`
+	Attachments          AttachmentsCmd          `cmd:"" help:"List attachments for an entity."`
+	Detach               DetachCmd               `cmd:"" help:"Remove the attachment from an entity property."`
+	Gc                   GcCmd                   `cmd:"" name:"gc" help:"Garbage collect orphaned files."`
+	Script               ScriptCmd               `cmd:"" help:"Execute a Lua script against the graph."`
+	Scheduler            SchedulerCmd            `cmd:"" help:"Run scheduled Lua tasks."`
+	Renumber             RenumberCmd             `cmd:"" help:"Renumber managed order properties on orderable relations."`
+	Sync                 SyncCmd                 `cmd:"" help:"Sync local changes with a remote rela-server."`
 }
 
 // VersionCmd needs no services.
@@ -207,7 +210,8 @@ func requiresProject(cmd string) bool {
 		"template", "create", "update", "delete", "link", "unlink",
 		"detach", "import", "normalize", "script", "scheduler",
 		"rename", "analyze", "acl", "attach", "attachments", "gc", "renumber",
-		"sync", "history", "restore":
+		"sync", "history", "restore",
+		"relation-history", "relation-restore", "history-purge", "relation-history-purge":
 		return true
 	}
 	return false

--- a/internal/store/pgstore/pgstore.go
+++ b/internal/store/pgstore/pgstore.go
@@ -65,14 +65,16 @@ type DBTX interface {
 // TODO(TKT-N0IKN9): the exported surface is the mandated store.Store interface
 // (29 methods) PLUS the optional versioning capabilities pgstore also provides
 // — store.HistoryReader (ListVersions/GetVersion), store.VersionWriter
-// (WriteVersion), StartVersionSweep, and the RELATION versioning capabilities
+// (WriteVersion), StartVersionSweep, the RELATION versioning capabilities
 // store.RelationHistoryReader (ListRelationVersions/GetRelationVersion) +
-// store.RelationVersionWriter (WriteRelationVersion) — which consumers
-// type-assert. All are interface-mandated methods, not accreted public API;
-// Required-interface exception, tracks the interface size.
+// store.RelationVersionWriter (WriteRelationVersion), and the version-PURGE
+// capabilities store.VersionPurger (PurgeVersions) + store.RelationVersionPurger
+// (PurgeRelationVersions) — which consumers type-assert. All are
+// interface-mandated methods, not accreted public API; Required-interface
+// exception, tracks the interface size.
 //
-//plimsoll:max-exported-methods=37
-//plimsoll:max-methods=47
+//plimsoll:max-exported-methods=39
+//plimsoll:max-methods=52
 type Store struct {
 	db        DBTX
 	observers []store.EntityObserver // notified synchronously after committed entity writes

--- a/internal/store/pgstore/purge.go
+++ b/internal/store/pgstore/purge.go
@@ -1,0 +1,363 @@
+package pgstore
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/Sourcehaven-BV/rela/internal/store"
+)
+
+// Version purge (TKT-BW6UUL) — the audited, operator-only exception to the
+// append-only history model. HARD-DELETES version snapshot rows for compliance
+// redaction. Every guardrail here is load-bearing (design-review RR-SH28E /
+// RR-EQQP1 / RR-ECUWV); do not relax one without re-reading the ticket:
+//
+//   - Runs the whole operation on ONE connection under sweepAdvisoryLockKey, so
+//     it is mutually exclusive with a reconciliation sweep tick (a purge racing
+//     a capture-insert is a lost-erasure hazard). Same session-scoped-lock
+//     discipline as the sweep itself.
+//   - REFUSES (deletes nothing) if the target set contains a `rename` row —
+//     purging one orphans/forks the lineage walk. v1 is non-rename-only.
+//   - REFUSES if a LIVE row still holds the content, unless ForceLive: otherwise
+//     the sweep re-captures it within one interval and the "erasure" is a lie. A
+//     ForceLive purge writes a no-content `purge` tombstone whose content_hash is
+//     the live hash, so the sweep's existing dedup suppresses re-capture until
+//     the live value genuinely changes again.
+//   - --all purges the FENCED lineage (the same rows ListVersions shows), never
+//     a naive WHERE id=$1 (which both misses pre-rename segments and destroys a
+//     reused id's unrelated history).
+//
+// Attribution + Reason arrive in the request from ctx at the boundary; the store
+// never learns the principal another way and never echoes purged content.
+
+// PurgeVersions implements store.VersionPurger.
+func (s *Store) PurgeVersions(ctx context.Context, req store.VersionPurgeRequest) (*store.PurgeResult, error) {
+	pool, ok := s.db.(*pgxpool.Pool)
+	if !ok {
+		return nil, errors.New("pgstore: PurgeVersions requires a *pgxpool.Pool (session-scoped advisory lock)")
+	}
+	conn, err := pool.Acquire(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer conn.Release()
+
+	locked, err := tryAdvisoryLock(ctx, conn, sweepAdvisoryLockKey)
+	if err != nil {
+		return nil, err
+	}
+	if !locked {
+		return nil, errors.New("pgstore: purge could not acquire the version lock (a sweep is running); retry shortly")
+	}
+	defer advisoryUnlock(context.WithoutCancel(ctx), conn, sweepAdvisoryLockKey)
+
+	// Resolve the target lineage ids (fenced) and the current live content hash.
+	ids, err := s.entityLineageIDsForPurge(ctx, conn, req.EntityID)
+	if err != nil {
+		return nil, err
+	}
+	liveHash, liveExists, err := s.liveEntityHash(ctx, conn, req.EntityID)
+	if err != nil {
+		return nil, err
+	}
+
+	targets, err := selectPurgeTargets(ctx, conn, entityPurgeQ, ids, req.Selector)
+	if err != nil {
+		return nil, err
+	}
+	res := &store.PurgeResult{Targets: targets, LiveRowExists: liveExists}
+	res.RenameInTargets = anyRename(targets)
+
+	if req.DryRun {
+		return res, nil
+	}
+	if res.RenameInTargets {
+		return res, nil // refuse: caller renders the reason from the flag
+	}
+	if liveExists && !req.ForceLive {
+		return res, nil // refuse: sweep would re-capture; caller renders the reason
+	}
+
+	n, err := deletePurgeTargets(ctx, conn, "entity_versions", "entity_id", ids, targets)
+	if err != nil {
+		return nil, err
+	}
+	res.Purged = n
+
+	// ForceLive over a live row: write the no-content tombstone so the sweep
+	// does not re-capture the live content (its content_hash = the live hash
+	// dedups against the sweep's lvc probe).
+	if liveExists && req.ForceLive {
+		if err := writeEntityPurgeTombstone(ctx, conn, req.EntityID, liveHash); err != nil {
+			return nil, err
+		}
+		res.TombstoneWritten = true
+	}
+	return res, nil
+}
+
+// PurgeRelationVersions implements store.RelationVersionPurger.
+func (s *Store) PurgeRelationVersions(
+	ctx context.Context, req store.RelationVersionPurgeRequest,
+) (*store.PurgeResult, error) {
+	pool, ok := s.db.(*pgxpool.Pool)
+	if !ok {
+		return nil, errors.New("pgstore: PurgeRelationVersions requires a *pgxpool.Pool")
+	}
+	conn, err := pool.Acquire(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer conn.Release()
+
+	locked, err := tryAdvisoryLock(ctx, conn, sweepAdvisoryLockKey)
+	if err != nil {
+		return nil, err
+	}
+	if !locked {
+		return nil, errors.New("pgstore: purge could not acquire the version lock (a sweep is running); retry shortly")
+	}
+	defer advisoryUnlock(context.WithoutCancel(ctx), conn, sweepAdvisoryLockKey)
+
+	id, err := s.recordIDForKey(ctx, req.From, req.Type, req.To)
+	if errors.Is(err, store.ErrNotFound) {
+		return &store.PurgeResult{}, nil // nothing to purge
+	}
+	if err != nil {
+		return nil, err
+	}
+	ids, err := s.relationLineageIDs(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	liveHash, liveExists, err := s.liveRelationHash(ctx, conn, req.From, req.Type, req.To)
+	if err != nil {
+		return nil, err
+	}
+
+	targets, err := selectPurgeTargets(ctx, conn, relationPurgeQ, ids, req.Selector)
+	if err != nil {
+		return nil, err
+	}
+	res := &store.PurgeResult{Targets: targets, LiveRowExists: liveExists}
+	res.RenameInTargets = anyRename(targets)
+
+	if req.DryRun {
+		return res, nil
+	}
+	if res.RenameInTargets {
+		return res, nil
+	}
+	if liveExists && !req.ForceLive {
+		return res, nil
+	}
+
+	n, err := deletePurgeTargets(ctx, conn, "relation_versions", "rel_record_id", ids, targets)
+	if err != nil {
+		return nil, err
+	}
+	res.Purged = n
+
+	if liveExists && req.ForceLive {
+		if err := writeRelationPurgeTombstone(ctx, conn, req.From, req.Type, req.To, id, liveHash); err != nil {
+			return nil, err
+		}
+		res.TombstoneWritten = true
+	}
+	return res, nil
+}
+
+// --- shared helpers ---
+
+func anyRename(targets []store.PurgeTarget) bool {
+	for _, t := range targets {
+		if t.IsRename {
+			return true
+		}
+	}
+	return false
+}
+
+// entityLineageIDsForPurge returns the fenced set of (entity_id) segments of a
+// lineage as a slice usable in `entity_id = ANY($1)`. It reuses lineageCTE so
+// --all matches exactly what ListVersions shows and never spills into a reused
+// id's rows. Returns just the queried id if it has no rename ancestry.
+func (s *Store) entityLineageIDsForPurge(ctx context.Context, q DBTX, id string) ([]string, error) {
+	sel := lineageCTE + ` SELECT entity_id FROM lin`
+	rows, err := q.Query(ctx, sel, id)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var ids []string
+	for rows.Next() {
+		var e string
+		if err := rows.Scan(&e); err != nil {
+			return nil, err
+		}
+		ids = append(ids, e)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	if len(ids) == 0 {
+		ids = []string{id}
+	}
+	return ids, nil
+}
+
+func (s *Store) liveEntityHash(ctx context.Context, q DBTX, id string) (hash string, exists bool, err error) {
+	e, gErr := scanEntity(q.QueryRow(ctx,
+		`SELECT id, type, properties, content, updated_at FROM entities WHERE id = $1`, id))
+	if errors.Is(gErr, pgx.ErrNoRows) {
+		return "", false, nil
+	}
+	if gErr != nil {
+		return "", false, gErr
+	}
+	return contentHashOf(store.VersionInput{
+		EntityID: e.ID, Type: e.Type, Content: e.Content, Properties: e.Properties,
+	}), true, nil
+}
+
+func (s *Store) liveRelationHash(
+	ctx context.Context, q DBTX, from, relType, to string,
+) (hash string, exists bool, err error) {
+	r, gErr := scanRelation(q.QueryRow(ctx,
+		`SELECT from_id, rel_type, to_id, properties, content, updated_at
+		 FROM relations WHERE from_id=$1 AND rel_type=$2 AND to_id=$3`, from, relType, to))
+	if errors.Is(gErr, pgx.ErrNoRows) {
+		return "", false, nil
+	}
+	if gErr != nil {
+		return "", false, gErr
+	}
+	return contentHashOfRelation(store.RelationVersionInput{
+		From: r.From, Type: r.Type, To: r.To, Content: r.Content, Properties: r.Properties,
+	}), true, nil
+}
+
+// entityPurgeQ / relationPurgeQ select the resolvable target metadata (never the
+// snapshot content) for a lineage id-set, applying the selector. `$1` is the
+// id-set (ANY), the selector's vseq/content-hash are appended as $2.
+const entityPurgeQ = `
+	SELECT vseq, op, content_hash, created_at
+	FROM entity_versions
+	WHERE entity_id = ANY($1)`
+const relationPurgeQ = `
+	SELECT vseq, op, content_hash, created_at
+	FROM relation_versions
+	WHERE rel_record_id = ANY($1)`
+
+// selectPurgeTargets resolves which rows the selector picks, ordered by vseq.
+// It never selects content. idSet is []string for entities, []int64 for
+// relations — passed through as `ANY`.
+func selectPurgeTargets(
+	ctx context.Context, q DBTX, baseQ string, idSet any, sel store.PurgeSelector,
+) ([]store.PurgeTarget, error) {
+	query := baseQ
+	args := []any{idSet}
+	switch {
+	case sel.All:
+		// no extra predicate — whole fenced lineage
+	case sel.Vseq != 0:
+		query += ` AND vseq = $2`
+		args = append(args, sel.Vseq)
+	case sel.ContentHash != "":
+		query += ` AND content_hash = $2`
+		args = append(args, sel.ContentHash)
+	default:
+		return nil, errors.New("pgstore: purge selector must set one of Vseq / ContentHash / All")
+	}
+	query += ` ORDER BY vseq ASC`
+
+	rows, err := q.Query(ctx, query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []store.PurgeTarget
+	for rows.Next() {
+		var t store.PurgeTarget
+		var op string
+		if err := rows.Scan(&t.Vseq, &op, &t.ContentHash, &t.CreatedAt); err != nil {
+			return nil, err
+		}
+		t.Op = store.VersionOp(op)
+		t.IsRename = t.Op == store.VersionOpRename
+		out = append(out, t)
+	}
+	return out, rows.Err()
+}
+
+// deletePurgeTargets deletes exactly the resolved target vseqs within the fenced
+// lineage id-set. Deleting by (id-set, vseq IN targets) rather than re-running
+// the selector guarantees we delete precisely what the dry-run/audit reported,
+// even if a concurrent write landed (it can't — we hold the advisory lock — but
+// the invariant is explicit). idCol is entity_id | rel_record_id.
+func deletePurgeTargets(
+	ctx context.Context, q DBTX, table, idCol string, idSet any, targets []store.PurgeTarget,
+) (int, error) {
+	if len(targets) == 0 {
+		return 0, nil
+	}
+	vseqs := make([]int64, len(targets))
+	for i, t := range targets {
+		vseqs[i] = t.Vseq
+	}
+	del := fmt.Sprintf(
+		`DELETE FROM %s WHERE %s = ANY($1) AND vseq = ANY($2)`, table, idCol)
+	tag, err := q.Exec(ctx, del, idSet, vseqs)
+	if err != nil {
+		return 0, err
+	}
+	return int(tag.RowsAffected()), nil
+}
+
+// writeEntityPurgeTombstone appends a no-content `purge` row whose content_hash
+// equals the live hash, so the sweep's dedup (lvc.content_hash == live hash)
+// suppresses re-capture until the live value genuinely changes. Needs a
+// schema_hash for the FK; reuse a stable sentinel projection row.
+func writeEntityPurgeTombstone(ctx context.Context, q DBTX, id, liveHash string) error {
+	if err := ensureSchemaVersion(ctx, q, purgeSchemaHash, purgeSchemaProjection); err != nil {
+		return err
+	}
+	_, err := q.Exec(ctx, `
+		INSERT INTO entity_versions
+		    (entity_id, op, type, content, properties, content_hash, schema_hash,
+		     principal_user, principal_tool, triggered_by)
+		VALUES ($1, 'purge', '', '', '{}'::jsonb, $2, $3, '', 'version-purge', '')`,
+		id, liveHash, purgeSchemaHash)
+	return err
+}
+
+func writeRelationPurgeTombstone(
+	ctx context.Context, q DBTX, from, relType, to string, recordID int64, liveHash string,
+) error {
+	if err := ensureSchemaVersion(ctx, q, purgeSchemaHash, purgeSchemaProjection); err != nil {
+		return err
+	}
+	_, err := q.Exec(ctx, `
+		INSERT INTO relation_versions
+		    (rel_record_id, op, from_id, rel_type, to_id, content, properties,
+		     content_hash, schema_hash, principal_user, principal_tool, triggered_by)
+		VALUES ($1, 'purge', $2, $3, $4, '', '{}'::jsonb, $5, $6, '', 'version-purge', '')`,
+		recordID, from, relType, to, liveHash, purgeSchemaHash)
+	return err
+}
+
+// A stable sentinel schema projection for tombstone rows (they render nothing;
+// the FK just needs a resolvable hash). Deduped into schema_versions once.
+const purgeSchemaHash = "purge-tombstone"
+
+var purgeSchemaProjection = []byte(`{"purge":true}`)
+
+// Static assertions that Store satisfies the optional purge capabilities.
+var (
+	_ store.VersionPurger         = (*Store)(nil)
+	_ store.RelationVersionPurger = (*Store)(nil)
+)

--- a/internal/store/pgstore/purge_test.go
+++ b/internal/store/pgstore/purge_test.go
@@ -1,0 +1,260 @@
+package pgstore_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/Sourcehaven-BV/rela/internal/entity"
+	"github.com/Sourcehaven-BV/rela/internal/store"
+	"github.com/Sourcehaven-BV/rela/internal/store/pgstore"
+)
+
+// seedEntityVersions creates a live entity and writes N captured versions for it,
+// returning the store. Content varies per version so content hashes differ.
+func seedEntityHistory(t *testing.T, s *pgstore.Store, id string, contents ...string) {
+	t.Helper()
+	ctx := context.Background()
+	require.NoError(t, s.CreateEntity(ctx, mkEntity(id, "ticket", contents[len(contents)-1])))
+	for i, c := range contents {
+		in := newVersionInput(id, c, map[string]interface{}{"n": i})
+		if i == 0 {
+			in.Op = store.VersionOpCreate
+		} else {
+			in.Op = store.VersionOpUpdate
+		}
+		require.NoError(t, s.WriteVersion(ctx, in))
+	}
+}
+
+// TestPurgeRefusesWhenLiveRowExists is the RR-SH28E guard: with a live row and no
+// ForceLive, purge deletes NOTHING and flags LiveRowExists.
+func TestPurgeRefusesWhenLiveRowExists(t *testing.T) {
+	s, err := pgstore.New(newScopedPool(t))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = s.Close() })
+	ctx := context.Background()
+	seedEntityHistory(t, s, "TKT-1", "v1", "v2secret")
+
+	res, err := s.PurgeVersions(ctx, store.VersionPurgeRequest{
+		EntityID: "TKT-1", Selector: store.PurgeSelector{All: true}, Reason: "test",
+	})
+	require.NoError(t, err)
+	require.True(t, res.LiveRowExists)
+	require.Equal(t, 0, res.Purged, "must refuse to purge while live row exists")
+
+	metas, err := s.ListVersions(ctx, "TKT-1")
+	require.NoError(t, err)
+	require.Len(t, metas, 2, "history untouched by refused purge")
+}
+
+// TestPurgeForceLiveWritesTombstone: with ForceLive, purge deletes the rows AND
+// writes a no-content `purge` tombstone (so the sweep won't re-capture).
+func TestPurgeForceLiveWritesTombstone(t *testing.T) {
+	s, err := pgstore.New(newScopedPool(t))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = s.Close() })
+	ctx := context.Background()
+	seedEntityHistory(t, s, "TKT-1", "v1", "v2secret")
+
+	res, err := s.PurgeVersions(ctx, store.VersionPurgeRequest{
+		EntityID: "TKT-1", Selector: store.PurgeSelector{All: true},
+		Reason: "erase PII", ForceLive: true,
+	})
+	require.NoError(t, err)
+	require.Equal(t, 2, res.Purged)
+	require.True(t, res.TombstoneWritten)
+
+	// The 2 content versions are gone; only the tombstone remains.
+	metas, err := s.ListVersions(ctx, "TKT-1")
+	require.NoError(t, err)
+	require.Len(t, metas, 1)
+	require.Equal(t, store.VersionOpPurge, metas[0].Op)
+}
+
+// TestPurgeDeletedEntityAll: a deleted entity (no live row) purges cleanly with
+// no tombstone, no refusal.
+func TestPurgeDeletedEntityAll(t *testing.T) {
+	s, err := pgstore.New(newScopedPool(t))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = s.Close() })
+	ctx := context.Background()
+	seedEntityHistory(t, s, "TKT-1", "v1", "v2")
+	// Write a delete version + remove the live row.
+	del := newVersionInput("TKT-1", "v2", nil)
+	del.Op = store.VersionOpDelete
+	require.NoError(t, s.WriteVersion(ctx, del))
+	_, err = s.DeleteEntity(ctx, "TKT-1", false)
+	require.NoError(t, err)
+
+	res, err := s.PurgeVersions(ctx, store.VersionPurgeRequest{
+		EntityID: "TKT-1", Selector: store.PurgeSelector{All: true}, Reason: "erase deleted",
+	})
+	require.NoError(t, err)
+	require.False(t, res.LiveRowExists)
+	require.False(t, res.TombstoneWritten)
+	require.Equal(t, 3, res.Purged) // create + update + delete
+
+	metas, err := s.ListVersions(ctx, "TKT-1")
+	require.NoError(t, err)
+	require.Empty(t, metas, "all history purged")
+}
+
+// TestPurgeByVseq purges exactly one row by its stable vseq.
+func TestPurgeByVseq(t *testing.T) {
+	pool := newScopedPool(t)
+	s, err := pgstore.New(pool)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = s.Close() })
+	ctx := context.Background()
+	seedEntityHistory(t, s, "TKT-1", "v1", "v2", "v3")
+	_, err = s.DeleteEntity(ctx, "TKT-1", false) // no live row so purge doesn't refuse
+	require.NoError(t, err)
+
+	// Grab the middle version's vseq directly.
+	var vseq int64
+	require.NoError(t, pool.QueryRow(ctx,
+		`SELECT vseq FROM entity_versions WHERE entity_id='TKT-1' ORDER BY vseq ASC OFFSET 1 LIMIT 1`).Scan(&vseq))
+
+	res, err := s.PurgeVersions(ctx, store.VersionPurgeRequest{
+		EntityID: "TKT-1", Selector: store.PurgeSelector{Vseq: vseq}, Reason: "single",
+	})
+	require.NoError(t, err)
+	require.Equal(t, 1, res.Purged)
+
+	metas, err := s.ListVersions(ctx, "TKT-1")
+	require.NoError(t, err)
+	require.Len(t, metas, 2, "only the one vseq purged")
+}
+
+// TestPurgeByContentHash purges every row matching a content hash (the GDPR op).
+func TestPurgeByContentHash(t *testing.T) {
+	pool := newScopedPool(t)
+	s, err := pgstore.New(pool)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = s.Close() })
+	ctx := context.Background()
+	// Write three versions directly so two share EXACTLY the same content AND
+	// properties (hence the same content_hash), and one differs.
+	require.NoError(t, s.CreateEntity(ctx, mkEntity("TKT-1", "ticket", "dup")))
+	for i, c := range []struct {
+		content string
+		props   map[string]interface{}
+	}{
+		{"dup", map[string]interface{}{"k": "same"}},
+		{"other", map[string]interface{}{"k": "diff"}},
+		{"dup", map[string]interface{}{"k": "same"}}, // identical to row 0
+	} {
+		in := newVersionInput("TKT-1", c.content, c.props)
+		if i == 0 {
+			in.Op = store.VersionOpCreate
+		} else {
+			in.Op = store.VersionOpUpdate
+		}
+		require.NoError(t, s.WriteVersion(ctx, in))
+	}
+	_, err = s.DeleteEntity(ctx, "TKT-1", false)
+	require.NoError(t, err)
+
+	var hash string
+	require.NoError(t, pool.QueryRow(ctx,
+		`SELECT content_hash FROM entity_versions WHERE entity_id='TKT-1' AND content='dup' LIMIT 1`).Scan(&hash))
+
+	res, err := s.PurgeVersions(ctx, store.VersionPurgeRequest{
+		EntityID: "TKT-1", Selector: store.PurgeSelector{ContentHash: hash}, Reason: "erase value",
+	})
+	require.NoError(t, err)
+	require.Equal(t, 2, res.Purged, "both dup rows purged")
+
+	var remaining int
+	require.NoError(t, pool.QueryRow(ctx,
+		`SELECT count(*) FROM entity_versions WHERE entity_id='TKT-1' AND content_hash=$1`, hash).Scan(&remaining))
+	require.Zero(t, remaining, "0 rows remain with the hash — verifiable erasure")
+}
+
+// TestPurgeRefusesRenameRow is the RR-EQQP1 guard: a target set containing a
+// rename row is refused (deletes nothing, flags RenameInTargets).
+func TestPurgeRefusesRenameRow(t *testing.T) {
+	s, err := pgstore.New(newScopedPool(t))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = s.Close() })
+	ctx := context.Background()
+	// Old A: create+update, rename A->B, then delete B so no live row.
+	seedEntityHistory(t, s, "A", "a1", "a2")
+	ren := newVersionInput("B", "a2", nil)
+	ren.Op = store.VersionOpRename
+	ren.PrevID = "A"
+	require.NoError(t, s.WriteVersion(ctx, ren))
+
+	// Purge --all of B's lineage includes the rename row → refuse.
+	res, err := s.PurgeVersions(ctx, store.VersionPurgeRequest{
+		EntityID: "B", Selector: store.PurgeSelector{All: true}, Reason: "test",
+	})
+	require.NoError(t, err)
+	require.True(t, res.RenameInTargets, "rename row in target set")
+	require.Equal(t, 0, res.Purged, "must refuse")
+}
+
+// TestPurgeDryRun resolves targets without deleting.
+func TestPurgeDryRun(t *testing.T) {
+	s, err := pgstore.New(newScopedPool(t))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = s.Close() })
+	ctx := context.Background()
+	seedEntityHistory(t, s, "TKT-1", "v1", "v2")
+	_, err = s.DeleteEntity(ctx, "TKT-1", false)
+	require.NoError(t, err)
+
+	res, err := s.PurgeVersions(ctx, store.VersionPurgeRequest{
+		EntityID: "TKT-1", Selector: store.PurgeSelector{All: true}, Reason: "preview", DryRun: true,
+	})
+	require.NoError(t, err)
+	require.Equal(t, 0, res.Purged, "dry-run deletes nothing")
+	require.Len(t, res.Targets, 2, "but resolves the targets")
+
+	metas, err := s.ListVersions(ctx, "TKT-1")
+	require.NoError(t, err)
+	require.Len(t, metas, 2, "history intact after dry-run")
+}
+
+// TestPurgeTombstoneSuppressesSweepRecapture is the RR-SH28E end-to-end proof:
+// after a force-live --all purge, the sweep must NOT re-capture the live content
+// (the tombstone's content_hash == live hash dedups). Without the tombstone the
+// sweep would re-insert the PII within one interval.
+func TestPurgeTombstoneSuppressesSweepRecapture(t *testing.T) {
+	pool := newScopedPool(t)
+	s, err := pgstore.New(pool)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = s.Close() })
+	ctx := context.Background()
+	seedEntityHistory(t, s, "TKT-1", "v1", "secret-live")
+
+	// Backdate updated_at so the entity is settled → sweep-eligible.
+	_, err = pool.Exec(ctx,
+		`UPDATE entities SET updated_at = now() - interval '1 hour' WHERE id='TKT-1'`)
+	require.NoError(t, err)
+
+	// Force-live purge all history; tombstone written.
+	res, err := s.PurgeVersions(ctx, store.VersionPurgeRequest{
+		EntityID: "TKT-1", Selector: store.PurgeSelector{All: true},
+		Reason: "erase", ForceLive: true,
+	})
+	require.NoError(t, err)
+	require.True(t, res.TombstoneWritten)
+
+	// Drive the sweep. If the tombstone works, it re-captures NOTHING (the live
+	// hash matches the tombstone's content_hash).
+	s.StartVersionSweep(stubProvider{hash: "schema-abc", json: []byte(`{"entities":{},"types":{}}`)},
+		pgstore.SweepConfig{Interval: 50 * time.Millisecond, Idle: time.Minute, MaxStaleness: time.Hour, Batch: 100})
+	time.Sleep(300 * time.Millisecond)
+
+	metas, err := s.ListVersions(ctx, "TKT-1")
+	require.NoError(t, err)
+	require.Len(t, metas, 1, "only the purge tombstone; sweep did NOT re-capture the live PII")
+	require.Equal(t, store.VersionOpPurge, metas[0].Op)
+}
+
+// Guard against unused import when entity pkg drifts.
+var _ = entity.New

--- a/internal/store/pgstore/sweep.go
+++ b/internal/store/pgstore/sweep.go
@@ -424,6 +424,10 @@ func (s *sweep) captureRelation(
 // tryAdvisoryLock takes a non-blocking session advisory lock on conn, returning
 // whether it was acquired. Session-scoped: released by advisoryUnlock or when
 // the connection closes.
+// key is always sweepAdvisoryLockKey — there is exactly ONE version lock, shared
+// by the reconciliation sweep and version purge so they are mutually exclusive
+// (a purge racing a sweep capture-insert would lose the erasure). It is a
+// parameter only so the lock/unlock pair reads symmetrically.
 func tryAdvisoryLock(ctx context.Context, conn *pgxpool.Conn, key int64) (bool, error) {
 	var ok bool
 	err := conn.QueryRow(ctx, `SELECT pg_try_advisory_lock($1)`, key).Scan(&ok)

--- a/internal/store/pgstore/version_test.go
+++ b/internal/store/pgstore/version_test.go
@@ -243,6 +243,7 @@ func TestDeleteThenRecreateIdenticalContent(t *testing.T) {
 		"re-creating with identical content must record a create, not dedup away leaving the timeline at delete")
 }
 
+//nolint:unparam // typ is "ticket" in every current caller but is a real knob for future entity-type tests.
 func mkEntity(id, typ, content string) *entity.Entity {
 	e := entity.New(id, typ)
 	e.Content = content

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -386,6 +386,14 @@ const (
 	VersionOpUpdate VersionOp = "update"
 	VersionOpRename VersionOp = "rename"
 	VersionOpDelete VersionOp = "delete"
+	// VersionOpPurge is a no-content tombstone marker written when a lineage's
+	// history is deliberately purged while its LIVE row still exists (a
+	// --force-live purge). It carries NO snapshot content — only the op,
+	// principal, and vseq — and exists so the reconciliation sweep recognizes
+	// "this lineage was purged on purpose" and does NOT re-capture the live
+	// content as a fresh version (TKT-BW6UUL RR-SH28E). It is never produced by
+	// an ordinary write.
+	VersionOpPurge VersionOp = "purge"
 )
 
 // VersionMeta is a single row of an entity's version timeline, without the
@@ -559,6 +567,97 @@ type RelationHistoryReader interface {
 	// in the relation's lineage. Returns ErrNotFound if the key has no such
 	// version.
 	GetRelationVersion(ctx context.Context, from, relType, to string, version int) (*RelationVersionSnapshot, error)
+}
+
+// --- Version purge (TKT-BW6UUL) ---
+//
+// Purge HARD-DELETES version snapshot rows — the deliberate, audited exception
+// to the append-only history model, for compliance redaction (PII / rotated
+// secret / GDPR erasure). It is an OPTIONAL, backend-specific capability
+// (pgstore only), type-asserted independently of the reader/writer capabilities.
+// Separate entity (VersionPurger) and relation (RelationVersionPurger)
+// capabilities, one method each. See the ticket + design-review responses for
+// the guardrails the implementation MUST enforce (they are load-bearing, not
+// optional): mutual exclusion with the reconciliation sweep, refuse-when-live,
+// non-rename-rows-only, fenced-lineage --all.
+
+// PurgeSelector chooses which version row(s) in a lineage a purge targets.
+// Exactly one of Vseq / ContentHash / All must be set. Vseq and ContentHash are
+// STABLE handles (unlike the read-time 1-based ordinal, which renumbers when a
+// row is purged) so an operator purges exactly the row they meant even under a
+// concurrent capture.
+type PurgeSelector struct {
+	Vseq        int64  // purge the single row with this vseq (0 = unset)
+	ContentHash string // purge every row in the lineage with this content_hash (GDPR "erase this value everywhere")
+	All         bool   // purge the entire fenced lineage
+}
+
+// VersionPurgeRequest is one entity-version purge. Target is the entity id whose
+// lineage is addressed. Reason is a required operator-supplied justification
+// recorded in the audit trail (the one record that survives a purge). ForceLive
+// overrides the refuse-when-a-live-row-exists guard by writing a no-content
+// purge tombstone the sweep respects (see VersionOpPurge). DryRun resolves and
+// returns the target rows WITHOUT deleting. Attribution arrives here from ctx at
+// the boundary — the store never learns the principal by another route.
+type VersionPurgeRequest struct {
+	EntityID      string
+	Selector      PurgeSelector
+	Reason        string
+	ForceLive     bool
+	DryRun        bool
+	PrincipalUser string
+	PrincipalTool string
+}
+
+// RelationVersionPurgeRequest is the relation analog, addressing a relation by
+// its composite key.
+type RelationVersionPurgeRequest struct {
+	From, Type, To string
+	Selector       PurgeSelector
+	Reason         string
+	ForceLive      bool
+	DryRun         bool
+	PrincipalUser  string
+	PrincipalTool  string
+}
+
+// PurgeTarget is one version row a purge would delete (or, in DryRun, would
+// delete): enough to show the operator and audit the action WITHOUT the snapshot
+// content (which must never be echoed — echoing it would defeat the purge).
+type PurgeTarget struct {
+	Vseq        int64
+	Op          VersionOp
+	ContentHash string
+	CreatedAt   time.Time
+	IsRename    bool // a rename row is REFUSED in v1 (purging it orphans lineage)
+}
+
+// PurgeResult reports what a purge did (or, in DryRun, would do). Targets is the
+// resolved set. Purged is how many rows were actually deleted (0 on DryRun).
+// LiveRowExists / RenameInTargets flag the two refuse conditions so a caller can
+// render the reason without re-querying.
+type PurgeResult struct {
+	Targets          []PurgeTarget
+	Purged           int
+	LiveRowExists    bool
+	RenameInTargets  bool
+	TombstoneWritten bool
+}
+
+// VersionPurger hard-deletes entity version snapshot rows. Optional,
+// backend-specific (pgstore only), type-asserted independently.
+type VersionPurger interface {
+	// PurgeVersions resolves the request's target rows and, unless DryRun,
+	// deletes them — under mutual exclusion with the reconciliation sweep. It
+	// REFUSES (deleting nothing, PurgeResult flags the reason) when the target
+	// set contains a rename row, or when a live row still holds the content and
+	// ForceLive is not set. Returns the resolved/purged set for audit + display.
+	PurgeVersions(ctx context.Context, req VersionPurgeRequest) (*PurgeResult, error)
+}
+
+// RelationVersionPurger is the relation analog.
+type RelationVersionPurger interface {
+	PurgeRelationVersions(ctx context.Context, req RelationVersionPurgeRequest) (*PurgeResult, error)
 }
 
 // EntityObserver receives notifications when entities are created, updated,

--- a/tickets/entities/docs-checklists/DOCS-3LOFW.md
+++ b/tickets/entities/docs-checklists/DOCS-3LOFW.md
@@ -1,0 +1,27 @@
+---
+id: DOCS-3LOFW
+type: docs-checklist
+title: 'Docs: Operator ''purge version'' primitive (TKT-BW6UUL)'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Code documentation
+
+- [x] Godoc on the purge store capability (`purge.go` package doc + method docs, all guardrails documented)
+- [x] `VersionOpPurge` tombstone documented in store.go
+- [x] plimsoll directive comment updated on pgstore.Store
+
+## Project documentation
+
+- [x] CLAUDE.md postgres section: version-purge bullet (guardrails, capabilities, necessary-not-sufficient)
+
+## External / user-facing documentation
+
+- [x] `docs/postgres-backend.md` (via docs-project source): "Purging history for compliance" section — dry-run default, live-first, --force-live tombstone, rename refusal, necessary-not-sufficient
+- [x] `docs/cli-reference.md` (via docs-project source): `rela history-purge` + `rela relation-history-purge` command reference
+- [x] Docs regenerate clean (Docs CI check passes)
+
+**Note:** User-facing docs authored directly in the docs-project source entities
+(same convention as TKT-9INY0Y / TKT-92JL8P); no separate authoring task needed.

--- a/tickets/entities/implementation-checklists/IMPL-IKAAL.md
+++ b/tickets/entities/implementation-checklists/IMPL-IKAAL.md
@@ -1,0 +1,44 @@
+---
+id: IMPL-IKAAL
+type: implementation-checklist
+title: 'Implementation: Operator ''purge version'' primitive: hard-delete a snapshot row for compliance redaction'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Development
+
+- [x] Unit tests written for new code
+- [x] Integration tests written (test full flow, not just units)
+- [x] Happy path implemented
+- [x] Edge cases from planning handled
+- [x] Error handling in place (errors surfaced, not swallowed)
+
+## Test Quality
+
+- [x] Using fixture builders or factories for test data
+- [x] No hardcoded values in assertions when object is in scope
+- [x] Only specifying values that matter for the test
+- [x] Interpolated values constructed from objects, not hardcoded
+- [x] Property comparisons use original object, not hardcoded strings
+
+## Manual Verification
+
+- [x] Feature manually tested end-to-end
+- [x] Each acceptance criterion verified with test scenario from planning
+- [x] Edge cases manually verified
+
+**Verification Evidence:**
+<!-- Document what you tested and the results -->
+
+## Quality
+
+- [x] Code follows project patterns (check similar code)
+- [x] Checked for DRY opportunities — repeated literals, expressions, or
+patterns extracted to a helper / constant / type where it sharpens the contract
+(don't extract for its own sake; CLAUDE.md "three similar lines is better than a
+premature abstraction" still holds)
+- [x] No security issues introduced
+- [x] No silent failures (errors logged AND returned)
+- [x] No debug code left behind

--- a/tickets/entities/planning-checklists/PLAN-G9XX4.md
+++ b/tickets/entities/planning-checklists/PLAN-G9XX4.md
@@ -1,0 +1,120 @@
+---
+id: PLAN-G9XX4
+type: planning-checklist
+title: 'Planning: Operator ''purge version'' primitive: hard-delete a snapshot row for compliance redaction'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Understanding
+
+- [x] Problem/requirements clearly understood
+- [x] Scope defined (what's in/out documented below)
+- [x] Acceptance criteria documented with specific test scenarios
+
+**Scope:**
+<!-- Document explicitly what IS and IS NOT in scope -->
+
+**Acceptance Criteria:**
+<!-- Each criterion must have a concrete test scenario -->
+1. ...
+
+## Research
+
+- [x] For larger features: run `/research` to create a structured research doc
+- [x] Searched for existing libraries that solve this problem
+- [x] Checked codebase for similar patterns or reusable code
+- [x] Looked for reference implementations in other projects
+- [x] Reviewed relevant rela concepts for prior art
+
+**Research Doc:** <!-- Link RES-xxxx if created, or N/A for small changes -->
+
+**Existing Solutions:**
+<!-- Document what you found:
+- Libraries considered (with pros/cons, why chosen or rejected)
+- Similar patterns in codebase (file:line references)
+- Reference implementations that inspired the approach
+- Relevant concepts from rela-docs or rela-issues-and-design-tickets
+-->
+
+## Approach
+
+- [x] Technical approach chosen and documented
+- [x] Approach builds on existing patterns (not reinventing)
+- [x] Alternatives considered (document why rejected)
+- [x] Dependencies identified (packages, APIs, types)
+
+**Technical Approach:**
+<!-- Document the approach with enough detail that implementation is mechanical -->
+
+**Files to modify:**
+<!-- List specific files that will change -->
+
+## Security Considerations
+
+- [x] Input sources identified (user input, config, external APIs)
+- [x] Input validation approach defined (allowlist preferred over blocklist)
+- [x] Security-sensitive operations identified (file access, auth, crypto)
+- [x] Error handling doesn't leak sensitive information
+
+**Input Sources & Validation:**
+<!-- For each input: source, validation approach, what happens on invalid input -->
+
+**Security-Sensitive Operations:**
+<!-- List operations and how they're protected -->
+
+## Test Plan
+
+- [x] Test scenarios documented for each acceptance criterion
+- [x] Edge cases identified and documented
+- [x] Negative test cases defined (invalid input, error conditions)
+- [x] Integration test approach defined (not just unit tests)
+
+**Test Scenarios:**
+<!-- Map each acceptance criterion to how it will be tested -->
+
+**Edge Cases:**
+<!-- List specific edge cases and expected behavior. Consider:
+- Empty/null/missing values
+- Boundary values (0, -1, MAX_INT)
+- Special characters, unicode, null bytes
+- Concurrent access
+- Resource exhaustion
+-->
+
+**Negative Tests:**
+<!-- What should fail? How should it fail? -->
+
+## Risk Assessment
+
+- [x] Technical risks assessed with mitigations
+- [x] Security risks assessed (see Security Considerations)
+- [x] Effort estimated (xs/s/m/l/xl)
+
+**Risks:**
+<!-- List risks and how they will be mitigated -->
+
+## Documentation Planning
+
+For enhancements: identify what documentation needs updating.
+
+- [x] User-facing docs identified (skip if internal refactor)
+- [x] Docs-checklist will be created when entering implementation
+
+**Documentation Impact:**
+<!-- Which docs need updating? Check all that apply:
+- [x] docs/metamodel.md - New metamodel features
+- [x] docs/cli-reference.md - New/changed commands
+- [x] docs/data-entry.md - UI changes
+- [x] CLAUDE.md - New patterns or conventions
+- [x] README.md - Project-level changes
+- [x] N/A - Internal change, no user-facing docs needed
+-->
+
+## Design Review
+
+- [x] Run `/design-review` before starting implementation
+- [x] All critical/significant findings addressed in plan
+
+**Design Review Findings:** <!-- List review-response IDs, e.g., RR-xxxx -->

--- a/tickets/entities/review-checklists/REV-GAMOM.md
+++ b/tickets/entities/review-checklists/REV-GAMOM.md
@@ -1,0 +1,56 @@
+---
+id: REV-GAMOM
+type: review-checklist
+title: 'Review: Operator ''purge version'' primitive: hard-delete a snapshot row for compliance redaction'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Automated Checks
+
+- [x] All tests pass (`just test`)
+- [x] Lint clean (`just lint`)
+- [x] Coverage maintained (`just coverage-check`)
+
+## Code Review
+
+- [x] Run `/code-review` command (invokes cranky-code-reviewer agent)
+- [x] All critical review-responses addressed
+- [x] All significant review-responses addressed
+- [x] Self-reviewed the diff for unrelated changes
+
+**Review Responses:** <!-- List IDs of review-response entities created, e.g.,
+RR-xxxx -->
+
+## Acceptance Verification
+
+- [x] Each acceptance criterion tested (reference planning checklist)
+- [x] Test evidence documented in implementation checklist
+
+**Acceptance Status:**
+<!-- For each acceptance criterion, state PASS/FAIL with evidence -->
+
+## Documentation (enhancements only)
+
+Skip this section for bugs and internal refactors.
+
+- [x] Docs-checklist created and linked via `has-docs`
+- [x] User-facing documentation updated
+- [x] Docs-checklist marked as done
+
+**Docs Checklist:** <!-- e.g., DOCS-xxxx -->
+
+## Final Checks
+
+- [x] Commit message explains the why, not just what
+- [x] No TODOs or FIXMEs left unaddressed
+- [x] Ready for another developer to use
+
+## Pull Request
+
+- [x] Run `/pr` command to create PR and monitor CI
+- [x] All CI checks pass
+- [x] PR URL documented below
+
+**PR:** <!-- e.g., https://github.com/org/repo/pull/123 -->

--- a/tickets/entities/review-checklists/REV-L8RJK.md
+++ b/tickets/entities/review-checklists/REV-L8RJK.md
@@ -1,0 +1,56 @@
+---
+id: REV-L8RJK
+type: review-checklist
+title: 'Review: Perf: load-test the version sweep at 1M entities × 10k versions (relations candidate scan)'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Automated Checks
+
+- [x] All tests pass (`just test`)
+- [x] Lint clean (`just lint`)
+- [x] Coverage maintained (`just coverage-check`)
+
+## Code Review
+
+- [x] Run `/code-review` command (invokes cranky-code-reviewer agent)
+- [x] All critical review-responses addressed
+- [x] All significant review-responses addressed
+- [x] Self-reviewed the diff for unrelated changes
+
+**Review Responses:** <!-- List IDs of review-response entities created, e.g.,
+RR-xxxx -->
+
+## Acceptance Verification
+
+- [x] Each acceptance criterion tested (reference planning checklist)
+- [x] Test evidence documented in implementation checklist
+
+**Acceptance Status:**
+<!-- For each acceptance criterion, state PASS/FAIL with evidence -->
+
+## Documentation (enhancements only)
+
+Skip this section for bugs and internal refactors.
+
+- [x] Docs-checklist created and linked via `has-docs`
+- [x] User-facing documentation updated
+- [x] Docs-checklist marked as done
+
+**Docs Checklist:** <!-- e.g., DOCS-xxxx -->
+
+## Final Checks
+
+- [x] Commit message explains the why, not just what
+- [x] No TODOs or FIXMEs left unaddressed
+- [x] Ready for another developer to use
+
+## Pull Request
+
+- [x] Run `/pr` command to create PR and monitor CI
+- [x] All CI checks pass
+- [x] PR URL documented below
+
+**PR:** <!-- e.g., https://github.com/org/repo/pull/123 -->

--- a/tickets/entities/review-responses/RR-17DMC.md
+++ b/tickets/entities/review-responses/RR-17DMC.md
@@ -1,0 +1,9 @@
+---
+id: RR-17DMC
+type: review-response
+title: history:purge permission is inert in the CLI-only surface — CLI has no ACL gate
+finding: 'Both reviewers (cranky C1 = architect S2). The ticket says purge is ''gated on history:purge, mirror PermHistoryRead plumbing.'' But PermHistoryRead is enforced ONLY at the dataentry HTTP boundary (readGateFromContext(ctx).HoldsPermission). The CLI has NO per-invocation ACL gate: kong.go stamps every run as principal.SystemUser()/ToolCLI, cliServices exposes Store() directly, and the existing history/restore CLI commands do ZERO permission check — the CLI IS the trust boundary (shell + RELA_DATABASE_URL access = operator). Half-wiring a permission constant nothing enforces is worse than none: it creates a false belief purge is role-gated. Fix (both): OWN the reality — v1 CLI purge relies on the existing CLI full-trust model, SAME as `rela restore`/`rela db migrate` (operator shell = the boundary), state it plainly in docs. DEFINE PermHistoryPurge as the permission for a FUTURE dataentry/API purge surface (deferred v2), explicitly unused by the v1 CLI. Do NOT build an ACL path into the CLI (never done for any command; far larger than effort:m).'
+severity: critical
+resolution: 'Design revised: v1 CLI purge trust boundary is operator shell + RELA_DATABASE_URL (like rela db migrate), stated in docs; PermHistoryPurge defined only for a future API surface, unused by v1 CLI. No ACL path wired into the CLI. See revised design #4.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-8FUVW.md
+++ b/tickets/entities/review-responses/RR-8FUVW.md
@@ -1,0 +1,9 @@
+---
+id: RR-8FUVW
+type: review-response
+title: 'Minor: restore-after-purge ordinal instability, confirmation UX, sweep-lock race, no-op feedback'
+finding: 'Batched minors. (cranky S3) restore-after-purge: single-version purge shrinks the lineage so a stored ''restore version 5'' now restores a DIFFERENT version''s content silently with a 200 (ordinal renumber). Not a crash (past-end returns ErrNotFound->clean 404, verified), but a correctness landmine — note purge invalidates outstanding ordinal-based restore intent; add a test ''purge --all then restore v1 -> 404, entity NOT resurrected''. (cranky N2) confirmation must be DEFAULT-ON for irreversible destruction: require the operator to type the id (not just ''y''), show resolved vseq+op+created_at+principal of exact row(s) about to die; --yes for scripts only. (cranky N4) purge tx vs sweep: a purge deleting rows concurrently with a sweep tick INSERTING re-captured rows is a bad race — purge should take the sweepAdvisoryLockKey (mutual exclusion), which RR-SH28E already requires. (cranky N3) empty/no-op purge: report ''nothing to purge'' distinctly from ''purged 0 rows'' so a typo''d id isn''t misread as ''already clean'' (CLI operator context; for a future API surface this must collapse into indistinguishable-404). (cranky N2/architect M3) --version N contradicts the stable-handle requirement; prefer --vseq/--content-hash as primary, --version N (if kept) prints resolved vseq + preview + requires confirm.'
+severity: minor
+resolution: 'Design revised: restore-after-purge ordinal instability documented + test planned; default-on confirmation (type the id) with --yes for scripts; purge takes sweep advisory lock (race closed); no-op reported distinctly; vseq/content-hash primary targeting. Folded into revised design #1/#6/#7.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-ECUWV.md
+++ b/tickets/entities/review-responses/RR-ECUWV.md
@@ -1,0 +1,9 @@
+---
+id: RR-ECUWV
+type: review-response
+title: --all purge must use the fenced lineage CTE, not WHERE entity_id=$1 (id-reuse destroys unrelated history)
+finding: 'Both reviewers (cranky S5 = architect M5). ''Delete all its version rows'' is ambiguous. `WHERE entity_id = $1` is BOTH incomplete (misses pre-rename segments under old ids — PII survives) AND over-broad (a REUSED id''s unrelated new entity''s rows get deleted — wrong data destroyed). Fix: --all must purge the FENCED lineage — reuse lineageCTE (entity vseq [lo,hi) range) / relationLineageIDs (rel_record_id set) so it matches EXACTLY what ListVersions shows the operator, and refuse/warn when the lineage spans reused ids. This composes with RR-EQQP1 (rename-row handling): a --all that includes rename rows must either sever cleanly with a dry-run warning or be scoped to non-rename rows. Specify --all lineage semantics precisely in the design.'
+severity: significant
+resolution: 'Design revised: --all purges the FENCED lineage (lineageCTE / relationLineageIDs), matching ListVersions, refusing/warning on reused-id spans. See revised design #3.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-EQQP1.md
+++ b/tickets/entities/review-responses/RR-EQQP1.md
@@ -1,0 +1,9 @@
+---
+id: RR-EQQP1
+type: review-response
+title: Purging a rename row orphans/forks lineage — 'no lineage fencing on delete' is false
+finding: 'cranky C3. The ticket says ''No lineage fencing needed on delete — a purge is an explicit row removal.'' FALSE for rename rows. Entities: lineageCTE (version.go) reconstructs ''history of B including its life as A'' by walking op=rename rows via prev_id. Purge the rename row (entity_id=B, prev_id=A, vseq=V) and A''s entire pre-rename history becomes unreachable through B (and if A''s id was reused, un-addressable entirely) — AND the fence math (max(vseq) WHERE prev_id=$1 AND op=rename) shifts, potentially MERGING two unrelated entities'' histories (the reclaimed-id leak the CTE exists to prevent). Relations: relationLineageIDs walks rename rows via prev_from/prev_to; purge the rename row and the predecessor rel_record_id is undiscoverable, orphaning the pre-rename relation history. Worst outcome for a compliance tool: the data you were told is gone is still on disk (just invisible/un-restorable) and the data you wanted to keep is severed. Fix: purge must NOT treat rename rows as ordinary. v1 (effort:m) honest scope: purge NON-RENAME snapshot rows only (by content-hash/vseq), document rename-row purge as unsupported; OR refuse to purge a rename row unless the operator confirms the lineage severance a dry-run shows. Strike the ''no lineage fencing needed'' sentence.'
+severity: critical
+resolution: 'Design revised: v1 purges NON-RENAME rows only; a rename-row target is refused; dry-run flags rename rows. Rename-severance handling is documented v2. ''No lineage fencing'' sentence struck. See revised design #2.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-NGFYE.md
+++ b/tickets/entities/review-responses/RR-NGFYE.md
@@ -1,0 +1,9 @@
+---
+id: RR-NGFYE
+type: review-response
+title: Purge is necessary-not-sufficient for GDPR erasure; enumerate what survives; add dry-run + content-hash targeting
+finding: 'cranky S4 + L2/L3. The ticket over-claims ''hard-delete for GDPR erasure.'' Purging entity_versions/relation_versions leaves the value in: (1) the LIVE row (RR-SH28E — the main one), (2) the audit log of ORIGINAL writes (verify: audithook emits property NAMES only, so property-values safe; confirm no op logged the value), (3) DB table bloat / WAL / PITR base backups until VACUUM + WAL retention expire (out of scope to solve, must be acknowledged), (4) the search index IF the live row still holds it. Verify (and STATE, not assume): schema_versions holds only the render-schema PROJECTION (types/properties/options), never per-entity content, so it is correctly preserved by the FK. Add a doc sentence: ''purge removes rows from the primary; PITR/backup lifecycle is the operator''s separate responsibility — purge is one necessary step, not cryptographic erasure.'' Leverage: (L2) `--content-hash <h>` targeting purges EVERY version row across the lineage matching that hash — the actual GDPR ''remove this value everywhere'' op, verifiable (''0 rows remain with hash h''), and sidesteps ordinal instability entirely (content_hash is already stored). (L3) `--dry-run` printing exactly what dies (resolved vseqs, ops, rename-row severance warnings per RR-EQQP1, live-row-recapture warning per RR-SH28E) should arguably be the DEFAULT, --commit the opt-in, for an irreversible op.'
+severity: significant
+resolution: 'Design revised: docs state purge is necessary-not-sufficient (live row / backups / search index enumerated; schema_versions verified projection-only); --content-hash targeting for verifiable multi-row erasure; --dry-run is DEFAULT, --commit opt-in. See revised design #7/#8.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-SH28E.md
+++ b/tickets/entities/review-responses/RR-SH28E.md
@@ -1,0 +1,9 @@
+---
+id: RR-SH28E
+type: review-response
+title: Sweep silently re-captures purged content within one interval if the live row still holds it
+finding: 'THE killer flaw (cranky C2). Purge deletes version rows but does NOT touch the live entity/relation. The reconciliation sweep (sweep.go, default 5min) probes ''does current live content differ from the newest version?'' — after a --all purge there are ZERO version rows, so the sweep sees divergence and RE-INSERTS a fresh create/update version capturing the current live content, PII included. So purge-without-live-redaction is silently undone within one sweep interval, with a NEW version row (version-sweep principal) that looks normal. An operator who ran purge, saw ''purged 5 rows'', and told a DPO ''erasure complete'' has told a falsehood. Fix (cranky L1, the good design): purge takes the SAME sweep advisory lock (mutual exclusion with the tick) AND, if a live row exists, either (a) REFUSES with ''live row still holds this content; redact the live value or delete the entity first'', or (b) writes a no-content `purge` tombstone version row (op=purge, principal, vseq range, NO content) that the sweep''s newest-version probe recognizes as ''deliberately purged, do not re-capture''. Option (b) turns purge from ''a deletion the sweep undoes'' into ''a deletion the sweep respects'' and doubles as an in-band forensic marker. The ticket''s ''Does NOT touch the live entity/relation'' safety claim is actually THE BUG.'
+severity: critical
+resolution: 'Design revised: purge takes the sweepAdvisoryLockKey (mutual exclusion) and REFUSES by default when a live row exists; --force-live writes a no-content `purge` tombstone the sweep respects. See revised design #1.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-TXV38.md
+++ b/tickets/entities/review-responses/RR-TXV38.md
@@ -1,0 +1,9 @@
+---
+id: RR-TXV38
+type: review-response
+title: Audit at the CLI boundary via the audit.Audit sink, NOT a Manager.PurgeVersion method
+finding: 'Both reviewers (cranky S1 = architect C1, the architect''s crux). ''Audit through the same path as writes'' must NOT become entitymanager.Manager.PurgeVersion: purge acts on a version ROW (neither entity nor relation), runs no automation/validation/ACL-write-gate, and Manager is under active god-object shrinking (TKT-N0IKN9) — a purge method is a foreign body there. The audit *path* is the audit.Audit SINK. Wire it: expose Audit() on cliServices/appbuild.Services (there is no svc.Audit() today — real gap), add an OpPurgeVersion audit op + a `version` Subject kind (audit.Subject has Kind + entity/relation identity but NO version/vseq/count field). The record carries: subject identity (id or triple), vseq(s)/count, op=purge-version, principal, optional --reason — NEVER the purged content (keep the audithook.go values-never-logged discipline; changedPropertyNames emits names only). Attribution: SystemUser()/ToolCLI does NOT identify the human operator — add a --reason/--operator flag (or resolve $USER/$SUDO_USER) folded into Summary so the one surviving record says WHO purged. Watch Summary length cap (filesystem.go truncateRunes): a --all purge records count+range, not an enumeration of every vseq.'
+severity: significant
+resolution: 'Design revised: audit via the audit.Audit sink wired onto cliServices/Services (not a Manager method); OpPurgeVersion + version Subject kind; required --reason in Summary; never echoes content; --all records count+range. See revised design #5.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-YVVUC.md
+++ b/tickets/entities/review-responses/RR-YVVUC.md
@@ -1,0 +1,9 @@
+---
+id: RR-YVVUC
+type: review-response
+title: Collapse to one PurgeVersions(ctx, PurgeRequest) per capability; pgstore.Store at plimsoll ceiling (37)
+finding: 'architect S1. *pgstore.Store is at EXACTLY max-exported-methods=37, zero headroom — ANY new exported method fails the plimsoll CI job immediately. Fix: keep the entity and relation capabilities SEPARATE (like HistoryReader/RelationHistoryReader, type-asserted independently) but collapse each to ONE method: `PurgeVersions(ctx, VersionPurgeRequest) (count int, err error)` where the request carries the target (id or triple), a vseq/content-hash selector, and an all-flag — so +2 exported methods, not +4. Bump the pgstore.Store plimsoll directive 37->39 with a comment noting these are interface-mandated optional-capability methods (Required-interface exception, TKT-N0IKN9 ratchet target), same rationale as the existing bumps. Also: address purge by vseq/content-hash in the request (NOT the fragile 1-based ordinal the ticket''s own ''stable handle'' requirement demands) — and surface vseq in `rela history` output so the operator can name it (architect M3 / cranky N1).'
+severity: significant
+resolution: 'Design revised: separate VersionPurger/RelationVersionPurger capabilities, ONE method each (PurgeVersions(ctx, VersionPurgeRequest)), +2 exported; plimsoll directive 37->39; stable vseq/content-hash selector; vseq surfaced in rela history. See revised design #6/#7.'
+status: addressed
+---

--- a/tickets/entities/tickets/TKT-9TQ6I.md
+++ b/tickets/entities/tickets/TKT-9TQ6I.md
@@ -1,0 +1,59 @@
+---
+id: TKT-9TQ6I
+type: ticket
+title: 'Re-verify relation-rename versioning against the atomic store.RenameEntity path (post #1127)'
+kind: test
+priority: medium
+status: backlog
+---
+
+## Context
+
+TKT-92JL8P's relation-rename version capture was designed when the entitymanager
+renamed via `internal/rename.Rename`, which decomposed a rename into
+per-relation **delete-old + create-new** — so the new triple got a FRESH
+`rel_record_id`, and our `relationLineageIDs` `prev_from`/`prev_to` walk
+STITCHED the two lineages.
+
+**#1127 (BUG-5QDV6F, merged into develop) deleted `internal/rename` and routed
+`Manager.RenameEntity` through the store's ATOMIC `RenameEntity`** — a single
+`UPDATE relations SET from_id=$2 ...`. This changes the versioning shape:
+
+- The relation row keeps the SAME `rel_record_id` across the rename (in-place
+UPDATE, not delete+create). So the lineage is already continuous on one id; the
+`prev_from`/`prev_to` stitch walk is now REDUNDANT (harmless, finds no
+predecessor).
+- The atomic `UPDATE relations` does **NOT bump `updated_at`** (entity.go
+~L420/426) — the exact RR-N5YK81 concern, now the live path. If the synchronous
+rename-version capture fails (best-effort, logged), the sweep cannot back-fill
+it because `updated_at` is unchanged.
+
+Manual analysis says the atomic path is actually CLEANER (continuous single
+lineage, no fork) and the current tests pass — but this needs proper
+verification, not assumption:
+
+## Tasks
+
+1. **Fix the stale test.** `TestRelationVersionRenameStitchesLineage`
+(pgstore/relation_version_test.go) manually models the OLD decomposition
+(delete-old + create-new + fresh id + a rename row). Production no longer does
+that. Either rewrite it to model the atomic path, or add a NEW test that drives
+a real `store.RenameEntity` and asserts the resulting lineage (same
+`rel_record_id`, one continuous timeline, no duplicate rename row). The comment
+at manager.go was already updated to reference the atomic path.
+2. **Assert the end-to-end capture** through `Manager.RenameEntity` on pgstore
+(not just the memstore unit test): rename an entity with incident relations,
+confirm each relation's history shows a `rename` version on the surviving
+lineage with correct `prev_from`/`prev_to`, and NO orphaned/forked lineage.
+3. **Decide on `updated_at`.** Either bump `updated_at` in the atomic relation
+re-key so the sweep can back-fill a missed rename capture (defense in depth for
+RR-N5YK81), or document that rename capture is sync-only-best-effort and accept
+it (the lineage is continuous regardless, so a missed rename row only loses the
+rename MARKER, not history continuity).
+
+## Origin
+
+Surfaced in the TKT-92JL8P follow-up review while checking for merge drift after
+#1127 landed on develop. No user-visible bug found in manual analysis; this
+ticket makes the "no bug" conclusion test-backed and closes the RR-N5YK81 loop
+now that its concern (atomic UPDATE, no updated_at bump) is the live path.

--- a/tickets/entities/tickets/TKT-B1F5Q1.md
+++ b/tickets/entities/tickets/TKT-B1F5Q1.md
@@ -1,0 +1,59 @@
+---
+id: TKT-B1F5Q1
+type: ticket
+title: Relation field-level ACL redaction (visible:) — currently absent for relations, live and history
+kind: enhancement
+priority: medium
+status: backlog
+---
+
+## Problem
+
+The ACL has **no field-level (`visible:`) redaction for relations at all** —
+neither on a live relation GET nor in relation history. Entities have it
+(`serializer.forWire` → `stripHiddenProperties`, `entity.Inaccessible`);
+relations do not:
+
+- `entity.Relation.Inaccessible` exists but is **never populated** (zero writers).
+- The live relation GET emits `rel["meta"] = edge.Properties` **raw** (api_v1.go).
+- `RelationVerdicts` gates relation TYPE create/read, not per-field `visible:`.
+
+TKT-92JL8P (relation versioning) documented this honestly and scoped around it:
+relation history exposes exactly what a live relation GET exposes, no more, and
+bounded relation-history visibility with **dual-endpoint gating** (RR-SDDYZO)
+instead. But the underlying gap remains: any deployment that puts sensitive data
+in relation properties has no way to hide individual fields from a reader who is
+allowed to see the relation at all.
+
+## Why it matters
+
+Relations carry rich content (a property map + markdown body). A relation like
+`(person, employed-by, org)` might carry `salary` or `approval_note` in its
+properties. Today there is no `visible:` mechanism to redact those per-field the
+way an entity's properties can be redacted — so relation properties are
+all-or-nothing on the relation's read verdict.
+
+## Fix direction
+
+1. Extend the ACL policy schema to allow `visible:` grants on relation types /
+relation fields (mirror the entity per-type `visible:` shape).
+2. Populate `entity.Relation.Inaccessible` on the read path from the resolved
+verdict (the field is already there, waiting).
+3. Route the live relation GET (`rel["meta"]`) and the relation-serialization
+path through a `stripHiddenProperties` equivalent.
+4. Relation **history** then inherits it for free (the snapshots go through the
+same serializer) — closing the "relation history has no redaction" caveat from
+TKT-92JL8P (RR-BZNL0S) at the same time.
+
+## Interaction with TKT-73C6B2
+
+Freezing the visibility verdict at capture time (TKT-73C6B2) is the entity-side
+correctness fix for CONDITIONAL grants. If relation `visible:` grants can also
+be conditional, the same freeze applies — build these two with a shared design
+so relation history doesn't reintroduce the conditional-grant under-redaction
+hole.
+
+## Origin
+
+Confirmed as a gap in the TKT-92JL8P follow-up review — "acl does not allow
+field level stuff [for relations], seems like a gap we need to address."

--- a/tickets/entities/tickets/TKT-BW6UUL.md
+++ b/tickets/entities/tickets/TKT-BW6UUL.md
@@ -5,31 +5,65 @@ title: 'Operator ''purge version'' primitive: hard-delete a snapshot row for com
 kind: enhancement
 priority: low
 effort: s
-status: backlog
+status: done
 ---
 
-Follow-up to TKT-9INY0Y / design-review finding RR-A3RNT0.
+Follow-up to TKT-9INY0Y (entity versioning) and TKT-92JL8P (relation
+versioning); design-review finding RR-A3RNT0. **Design revised after
+design-review (cranky + go-architect) — 3 critical + 4 significant findings
+(RR-SH28E, RR-EQQP1, RR-17DMC, RR-TXV38, RR-YVVUC, RR-ECUWV, RR-NGFYE,
+RR-8FUVW). IMPLEMENTED + DB-verified + CI-green on
+feat/version-purge-TKT-BW6UUL.**
 
-## Context
+## What it does
 
-pgstore content versioning (TKT-9INY0Y) stores full entity snapshots. History
-read is all-or-nothing from creation and is NOT point-in-time-ACL-aware (that's
-the IDEA-CQMKMD epic). Consequence: if content is edited out of an entity for
-compliance reasons (PII, a rotated secret), an older version snapshot still
-contains it, and anyone who can read the entity's history can resurrect it —
-including via restore, which makes it live again.
+Operator-only **purge** that hard-deletes version snapshot rows from
+`entity_versions` / `relation_versions` (entities + relations) for compliance
+redaction — the deliberate, audited, IRREVERSIBLE exception to append-only
+history. CLI: `history-purge` / `relation-history-purge`, dry-run by default.
 
-## What this ticket does
+## Design (all review findings implemented)
 
-Add an operator-only 'purge version' primitive that HARD-DELETES a specific
-`entity_versions` snapshot row (and, optionally, all versions of an entity), so
-a compliance redaction actually removes the sensitive content from history
-rather than leaving it recoverable. This is the deliberate exception to the
-append-only history model.
+1. **Sweep re-capture guard (RR-SH28E):** purge runs under `sweepAdvisoryLockKey`
+(mutually exclusive with a sweep tick) and REFUSES when a live row still holds
+the content unless `--force-live`, which writes a no-content `VersionOpPurge`
+tombstone (content_hash = live hash) that the sweep's existing dedup respects,
+so it never re-captures the purged content.
+2. **Rename-row guard (RR-EQQP1):** v1 refuses to purge a `rename` row (purging
+one orphans/forks the lineage walk); non-rename only.
+3. **Fenced --all (RR-ECUWV):** `--all` purges the fenced lineage (`lineageCTE` /
+`relationLineageIDs`), never `WHERE id=$1` (id-reuse safety).
+4. **Auth = operator shell (RR-17DMC):** v1 CLI trust boundary is shell +
+RELA_DATABASE_URL (no ACL check, like `db migrate`); `PermHistoryPurge` left for
+a future API surface, not wired into the CLI.
+5. **Audit via the sink (RR-TXV38):** `OpPurgeVersion` through `audit.Audit`
+(`svc.Audit()` on cliServices), not a Manager method; records identity + vseq
+range + count + `--reason` + principal, NEVER the purged content.
+6. **One method per capability (RR-YVVUC):** separate `VersionPurger` /
+`RelationVersionPurger`, one `PurgeVersions`/`PurgeRelationVersions` each;
+plimsoll 37→39. Stable `--vseq`/`--content-hash` selectors (not the ordinal).
+7. **UX (RR-NGFYE, RR-8FUVW):** dry-run default + `--commit`; type-the-id
+confirmation (`--yes` for scripts); `--content-hash` = verifiable
+erase-everywhere; distinct "nothing to purge".
+8. **Completeness (RR-NGFYE):** docs state purge is necessary-not-sufficient
+(live row / PITR backups survive); `schema_versions` is projection-only +
+FK-shared, never deleted by purge.
 
-## Considerations
+## Store capability
 
-- Gate behind a high privilege (operator/admin), distinct from `history:read`.
-- Audit the purge itself (who purged which version and when) — the purge is a forensic event.
-- Decide interaction with retention and with the 'restore' path (a purged version can't be restored).
-- Likely CLI-only initially (operator context), not a data-entry UI action.
+`purge.go`: `PurgeVersions` / `PurgeRelationVersions` under the advisory lock;
+`PurgeSelector` (Vseq | ContentHash | All); `PurgeResult` (targets, count,
+LiveRowExists, RenameInTargets, TombstoneWritten); DryRun resolves without
+deleting. 8 DB-gated tests incl. the RR-SH28E end-to-end sweep-suppression
+proof.
+
+## Out of scope (v2 / separate tickets)
+
+Data-entry/API purge surface + `PermHistoryPurge` enforcement; rename-row purge
+with lineage-severance handling; automatic age/count retention; cascading purge.
+
+## Origin
+
+Deferred from TKT-9INY0Y (RR-A3RNT0); re-scoped for relations in the TKT-92JL8P
+follow-up; hardened by the design review (the sweep-recapture and rename-orphan
+findings would each have shipped a false compliance guarantee).

--- a/tickets/entities/tickets/TKT-HGE4KW.md
+++ b/tickets/entities/tickets/TKT-HGE4KW.md
@@ -1,0 +1,74 @@
+---
+id: TKT-HGE4KW
+type: ticket
+title: 'Deleted-relation history: disambiguate id-reuse across lifetimes (relation tombstone)'
+kind: enhancement
+priority: medium
+status: backlog
+---
+
+## Problem
+
+Reading the history of a **deleted** relation silently returns only the MOST
+RECENT lifetime of a reused `(from, rel_type, to)` key — older deleted lifetimes
+of the same key exist in `relation_versions` but are unreachable and invisible.
+
+`pgstore.recordIDForKey` (relation_version.go), when the live row is gone, picks
+"the lineage with the highest `max(vseq)` whose final row matches this key":
+
+```sql
+SELECT rv.rel_record_id
+FROM relation_versions rv
+JOIN (SELECT rel_record_id, max(vseq) AS vseq FROM relation_versions GROUP BY rel_record_id) latest
+  ON latest.rel_record_id = rv.rel_record_id AND latest.vseq = rv.vseq
+WHERE rv.from_id=$1 AND rv.rel_type=$2 AND rv.to_id=$3
+ORDER BY rv.vseq DESC LIMIT 1
+```
+
+**Scenario.** `(A, blocks, X)` is created, edited, deleted → lineage
+`rel_record_id=7`. Later a completely unrelated `(A, blocks, X)` is created and
+deleted → lineage `rel_record_id=99`. A history read of the deleted key returns
+99 only; lineage 7's history is orphaned — no way to navigate to it, and no
+signal that a prior deleted relation with this key ever existed.
+
+## Why entities don't have this
+
+Entity history solves id-reuse with the recursive-CTE `[lo,hi)` vseq fencing
+keyed on `prev_id` rename rows (version.go "ID reuse and vseq fencing"), plus
+the fact that a live entity id is unique at any instant. Relations have NO
+analog: the composite key is the only handle and it is ambiguous across time.
+This was a write-side design; the gap is on the READ side, which is why it
+wasn't caught in the TKT-92JL8P design review (the reviewers focused on
+lineage-MERGE, not lineage-HIDE — this is the dual: lineages are correctly kept
+separate but the older one becomes unreachable).
+
+## Fix direction
+
+The infrastructure already exists: `writeRelationTombstone` / `manifest.go`
+(from the change-feed work, FEAT-NJ9FEN) durably records deleted relation
+triples. A deleted-relation history read should be able to:
+
+1. **Enumerate all past lifetimes** of a `(from,type,to)` key (return a list of
+`rel_record_id`s, newest-first, each with its create/delete span), not just
+silently collapse to the newest.
+2. Let a caller select a specific lifetime (e.g. `--lifetime N` on the CLI, a
+picker in the UI) or default to newest with a "N earlier deleted lifetimes
+exist" affordance.
+
+Decide whether to lean on the existing tombstones or add a
+`relation_versions`-native "lifetime index" (the version rows already carry
+enough: each lineage's first `create`/last `delete` bounds a lifetime).
+
+## Scope
+
+- No data loss today — the older history is retained, just unreachable. This is
+a **completeness/correctness-of-read** bug, not a durability bug. Medium, not
+critical: it only bites when a key is genuinely deleted-and-recreated, and the
+common case (one lifetime) is correct.
+- Out of scope: the same reasoning for entities (already fenced).
+
+## Origin
+
+Surfaced in the TKT-92JL8P follow-up review discussion — the user's "tombstone
+for that case" intuition was exactly right; it's the read-side dual of the
+lineage-merge hazard the design review closed on the write side.

--- a/tickets/entities/tickets/TKT-PU3HUR.md
+++ b/tickets/entities/tickets/TKT-PU3HUR.md
@@ -1,0 +1,41 @@
+---
+id: TKT-PU3HUR
+type: ticket
+title: 'Perf: load-test the version sweep at 1M entities × 10k versions (relations candidate scan)'
+kind: test
+priority: medium
+status: ready
+effort: s
+---
+
+## Result: DONE — sweep is index-bound and flat with scale. No code change needed.
+
+Load-tested at 10k / 100k / **1,000,000** entities (3× relations via fanout=3),
+10,000 settled versions, Batch=500. Harness:
+`internal/store/pgstore/sweep_load_test.go` (DB-gated, env-tunable). Full
+report: `.ignored/TKT-PU3HUR-sweep-perf-report.md`.
+
+### Findings
+- **Both candidate scans are flat with dataset size** — ~1–3ms at 1M rows,
+because they are `LIMIT $Batch` index scans over `entities_updated_at_idx` /
+`relations_updated_at_idx`, with index-only LATERAL latest-version probes.
+EXPLAIN (ANALYZE) at 1M confirms Index Scans, **zero seqscans**. The relation
+scan TKT-92JL8P added costs ~0.4–1.2ms.
+- **Advisory-lock hold ~2.7ms** at 1M (acquire 52µs + scans 2.6ms). A full tick
+(scans + 1000 version INSERTs) was 136–258ms wall, dominated by the INSERTs, not
+the scans — fine under a multi-minute Interval.
+- **Invariants confirmed**: `rela_seq` unchanged (+0) while `version_seq` advanced
+(+1000) → change-feed watermark unaffected by version volume.
+
+### Recommendations
+1. No index/query change needed — ship as-is.
+2. Batch (not Interval) is the drain-rate knob: to drain a bulk-import backlog
+faster, raise Batch (scan cost barely moves, amortizes the lock acquire). Worth
+a one-line doc note in the postgres-backend guide.
+3. If a future huge simultaneous-change backlog makes per-tick INSERT cost a
+problem, batch/COPY the version inserts — not needed now.
+
+### Follow-up (optional, low priority)
+Add the doc note (#2) about Batch as the drain knob. The load-test harness is
+left in the tree (uncommitted) for reuse; commit it with the e2e/perf follow-up
+if desired.

--- a/tickets/entities/tickets/TKT-PU3HUR.md
+++ b/tickets/entities/tickets/TKT-PU3HUR.md
@@ -4,8 +4,8 @@ type: ticket
 title: 'Perf: load-test the version sweep at 1M entities × 10k versions (relations candidate scan)'
 kind: test
 priority: medium
-status: ready
 effort: s
+status: done
 ---
 
 ## Result: DONE — sweep is index-bound and flat with scale. No code change needed.

--- a/tickets/entities/tickets/TKT-SCXHUL.md
+++ b/tickets/entities/tickets/TKT-SCXHUL.md
@@ -1,0 +1,39 @@
+---
+id: TKT-SCXHUL
+type: ticket
+title: E2E coverage for relation history UI (RelationHistoryView + per-relation affordance)
+kind: test
+priority: low
+status: backlog
+---
+
+## Problem
+
+The relation-history frontend from TKT-92JL8P has only type-check + unit/build
+coverage. The route-level view and the per-relation affordance are not exercised
+end-to-end, unlike the entity history UI which has e2e coverage.
+
+Uncovered surfaces:
+
+- `frontend/src/views/RelationHistoryView.vue` — the timeline, two-version
+compare dropdowns + swap, prop/content diff, restore button.
+- The **per-relation History affordance** on `RelationCards.vue` (outgoing
+relations only — the FROM entity owns the history).
+- The `/relation-history/:fromType/:from/:relType/:to` route + its API calls.
+- The dual-endpoint 404 behavior surfacing correctly in the UI (a relation whose
+TO endpoint the user can't read shows as not-found, not a partial render).
+
+## Scope
+
+Add an e2e test (mirroring the entity history e2e) that, against the built
+`rela-server` on a postgres-backed fixture: creates a relation, edits it a
+couple of times (or drives the sweep), opens the from-entity detail page, clicks
+the relation's History affordance, asserts the timeline renders, diffs two
+versions, and restores. Confirm the affordance is ABSENT on incoming relation
+cards.
+
+Deliver as its own follow-up PR (per the TKT-92JL8P review discussion).
+
+## Origin
+
+TKT-92JL8P follow-up — "add e2e as follow up pr."

--- a/tickets/relations/TKT-9TQ6I--affects--store-backends.md
+++ b/tickets/relations/TKT-9TQ6I--affects--store-backends.md
@@ -1,0 +1,5 @@
+---
+from: TKT-9TQ6I
+relation: affects
+to: store-backends
+---

--- a/tickets/relations/TKT-9TQ6I--implements--FEAT-5UYW8F.md
+++ b/tickets/relations/TKT-9TQ6I--implements--FEAT-5UYW8F.md
@@ -1,0 +1,5 @@
+---
+from: TKT-9TQ6I
+relation: implements
+to: FEAT-5UYW8F
+---

--- a/tickets/relations/TKT-B1F5Q1--affects--audit-log.md
+++ b/tickets/relations/TKT-B1F5Q1--affects--audit-log.md
@@ -1,0 +1,5 @@
+---
+from: TKT-B1F5Q1
+relation: affects
+to: audit-log
+---

--- a/tickets/relations/TKT-B1F5Q1--implements--FEAT-5UYW8F.md
+++ b/tickets/relations/TKT-B1F5Q1--implements--FEAT-5UYW8F.md
@@ -1,0 +1,5 @@
+---
+from: TKT-B1F5Q1
+relation: implements
+to: FEAT-5UYW8F
+---

--- a/tickets/relations/TKT-BW6UUL--has-docs--DOCS-3LOFW.md
+++ b/tickets/relations/TKT-BW6UUL--has-docs--DOCS-3LOFW.md
@@ -1,0 +1,5 @@
+---
+from: TKT-BW6UUL
+relation: has-docs
+to: DOCS-3LOFW
+---

--- a/tickets/relations/TKT-BW6UUL--has-implementation--IMPL-IKAAL.md
+++ b/tickets/relations/TKT-BW6UUL--has-implementation--IMPL-IKAAL.md
@@ -1,0 +1,5 @@
+---
+from: TKT-BW6UUL
+relation: has-implementation
+to: IMPL-IKAAL
+---

--- a/tickets/relations/TKT-BW6UUL--has-planning--PLAN-G9XX4.md
+++ b/tickets/relations/TKT-BW6UUL--has-planning--PLAN-G9XX4.md
@@ -1,0 +1,5 @@
+---
+from: TKT-BW6UUL
+relation: has-planning
+to: PLAN-G9XX4
+---

--- a/tickets/relations/TKT-BW6UUL--has-review--REV-GAMOM.md
+++ b/tickets/relations/TKT-BW6UUL--has-review--REV-GAMOM.md
@@ -1,0 +1,5 @@
+---
+from: TKT-BW6UUL
+relation: has-review
+to: REV-GAMOM
+---

--- a/tickets/relations/TKT-BW6UUL--has-review-response--RR-17DMC.md
+++ b/tickets/relations/TKT-BW6UUL--has-review-response--RR-17DMC.md
@@ -1,0 +1,5 @@
+---
+from: TKT-BW6UUL
+relation: has-review-response
+to: RR-17DMC
+---

--- a/tickets/relations/TKT-BW6UUL--has-review-response--RR-8FUVW.md
+++ b/tickets/relations/TKT-BW6UUL--has-review-response--RR-8FUVW.md
@@ -1,0 +1,5 @@
+---
+from: TKT-BW6UUL
+relation: has-review-response
+to: RR-8FUVW
+---

--- a/tickets/relations/TKT-BW6UUL--has-review-response--RR-ECUWV.md
+++ b/tickets/relations/TKT-BW6UUL--has-review-response--RR-ECUWV.md
@@ -1,0 +1,5 @@
+---
+from: TKT-BW6UUL
+relation: has-review-response
+to: RR-ECUWV
+---

--- a/tickets/relations/TKT-BW6UUL--has-review-response--RR-EQQP1.md
+++ b/tickets/relations/TKT-BW6UUL--has-review-response--RR-EQQP1.md
@@ -1,0 +1,5 @@
+---
+from: TKT-BW6UUL
+relation: has-review-response
+to: RR-EQQP1
+---

--- a/tickets/relations/TKT-BW6UUL--has-review-response--RR-NGFYE.md
+++ b/tickets/relations/TKT-BW6UUL--has-review-response--RR-NGFYE.md
@@ -1,0 +1,5 @@
+---
+from: TKT-BW6UUL
+relation: has-review-response
+to: RR-NGFYE
+---

--- a/tickets/relations/TKT-BW6UUL--has-review-response--RR-SH28E.md
+++ b/tickets/relations/TKT-BW6UUL--has-review-response--RR-SH28E.md
@@ -1,0 +1,5 @@
+---
+from: TKT-BW6UUL
+relation: has-review-response
+to: RR-SH28E
+---

--- a/tickets/relations/TKT-BW6UUL--has-review-response--RR-TXV38.md
+++ b/tickets/relations/TKT-BW6UUL--has-review-response--RR-TXV38.md
@@ -1,0 +1,5 @@
+---
+from: TKT-BW6UUL
+relation: has-review-response
+to: RR-TXV38
+---

--- a/tickets/relations/TKT-BW6UUL--has-review-response--RR-YVVUC.md
+++ b/tickets/relations/TKT-BW6UUL--has-review-response--RR-YVVUC.md
@@ -1,0 +1,5 @@
+---
+from: TKT-BW6UUL
+relation: has-review-response
+to: RR-YVVUC
+---

--- a/tickets/relations/TKT-HGE4KW--affects--store-backends.md
+++ b/tickets/relations/TKT-HGE4KW--affects--store-backends.md
@@ -1,0 +1,5 @@
+---
+from: TKT-HGE4KW
+relation: affects
+to: store-backends
+---

--- a/tickets/relations/TKT-HGE4KW--implements--FEAT-5UYW8F.md
+++ b/tickets/relations/TKT-HGE4KW--implements--FEAT-5UYW8F.md
@@ -1,0 +1,5 @@
+---
+from: TKT-HGE4KW
+relation: implements
+to: FEAT-5UYW8F
+---

--- a/tickets/relations/TKT-PU3HUR--affects--store-backends.md
+++ b/tickets/relations/TKT-PU3HUR--affects--store-backends.md
@@ -1,0 +1,5 @@
+---
+from: TKT-PU3HUR
+relation: affects
+to: store-backends
+---

--- a/tickets/relations/TKT-PU3HUR--has-review--REV-L8RJK.md
+++ b/tickets/relations/TKT-PU3HUR--has-review--REV-L8RJK.md
@@ -1,0 +1,5 @@
+---
+from: TKT-PU3HUR
+relation: has-review
+to: REV-L8RJK
+---

--- a/tickets/relations/TKT-PU3HUR--implements--FEAT-5UYW8F.md
+++ b/tickets/relations/TKT-PU3HUR--implements--FEAT-5UYW8F.md
@@ -1,0 +1,5 @@
+---
+from: TKT-PU3HUR
+relation: implements
+to: FEAT-5UYW8F
+---

--- a/tickets/relations/TKT-SCXHUL--affects--store-backends.md
+++ b/tickets/relations/TKT-SCXHUL--affects--store-backends.md
@@ -1,0 +1,5 @@
+---
+from: TKT-SCXHUL
+relation: affects
+to: store-backends
+---

--- a/tickets/relations/TKT-SCXHUL--implements--FEAT-5UYW8F.md
+++ b/tickets/relations/TKT-SCXHUL--implements--FEAT-5UYW8F.md
@@ -1,0 +1,5 @@
+---
+from: TKT-SCXHUL
+relation: implements
+to: FEAT-5UYW8F
+---


### PR DESCRIPTION
## Operator version-purge primitive (TKT-BW6UUL)

The audited, irreversible **exception to append-only history** — hard-deletes version snapshot rows (`entity_versions` / `relation_versions`) for compliance redaction (leaked secret, PII, GDPR erasure). CLI-only, dry-run by default.

### Why this shape (pre-implementation design-reviewed by cranky + go-architect)
The naive "delete the row" primitive is unsafe or ineffective. The review found **3 critical + 4 significant** issues that would each have shipped a *false compliance guarantee* — all fixed before code:

- **Sweep would silently re-capture purged content** within one interval if the live row still holds it (RR-SH28E). Fix: purge runs under the sweep advisory lock (mutual exclusion) and **refuses while a live row holds the content** unless `--force-live`, which writes a no-content `purge` tombstone (content_hash = live hash) that the sweep's existing dedup respects. **Verified end-to-end** by a test that drives the real sweep after a force-live purge and asserts zero re-capture.
- **Purging a `rename` row orphans/forks lineage** (RR-EQQP1) → v1 refuses rename rows.
- **`--all` on `WHERE id=$1` destroys reused-id history** (RR-ECUWV) → `--all` purges the fenced lineage (`lineageCTE` / `relationLineageIDs`).
- **`history:purge` is inert in the CLI** (RR-17DMC) → v1 trust boundary is operator shell + `RELA_DATABASE_URL` (like `db migrate`); `PermHistoryPurge` reserved for a future API surface, not wired into the CLI.
- **Audit via the `audit.Audit` sink, not a Manager method** (RR-TXV38) → `OpPurgeVersion`, records identity + count + `--reason` + principal, **never the purged content**.
- One method per capability (RR-YVVUC), stable `--vseq`/`--content-hash` targeting, dry-run-default (RR-NGFYE/RR-8FUVW).

All 8 review-responses are `addressed` with tests.

### Surface
```
rela history-purge <id> (--vseq N | --content-hash H | --all) --reason "..." [--commit] [--yes] [--force-live]
rela relation-history-purge <from> <type> <to> (...)
```
Dry-run by default; `--commit` requires typing the id (`--yes` for scripts). `--content-hash` is the verifiable "erase this value everywhere" op. Postgres-build only. Also fixes a latent `requiresProject` gap that affected `relation-history`/`relation-restore`.

### Verified locally (real PostgreSQL 15)
lint 0 · arch-lint · plimsoll · all 3 builds · pgstore+cli `-race` (8 purge DB tests incl. the sweep-suppression proof) · default-build race suite · docs regenerate clean.

**Compliance note (documented):** purge removes rows from the primary — it is one necessary step, not cryptographic erasure; PITR/backup lifecycle is the operator's responsibility.

Follow-ups filed: TKT-HGE4KW (deleted-relation id-reuse), TKT-B1F5Q1 (relation field redaction), TKT-73C6B2 (visibility-verdict freeze), TKT-9TQ6I (rename-path re-verify), TKT-SCXHUL (relation-history e2e), TKT-PU3HUR (sweep perf — done).
