### PR TITLE
feat: declarative status/enum state machines (TKT-E4LW2)

### DIFF
--- a/.go-arch-lint.yml
+++ b/.go-arch-lint.yml
@@ -53,6 +53,7 @@ components:
   schema:           { in: internal/schema }
   templating:       { in: internal/templating }
   predicate:        { in: internal/predicate }
+  statemachine:     { in: internal/statemachine }
   tracer:           { in: internal/tracer }
   validation:       { in: internal/validation }
   validator:        { in: internal/validator }
@@ -373,6 +374,7 @@ deps:
       - script
       - search
       - state
+      - statemachine
       - storage
       - store
       - templating
@@ -474,6 +476,7 @@ deps:
       - automation
       - metamodel
       - principal
+      - statemachine
       - store
       - templating
   importer:
@@ -500,6 +503,11 @@ deps:
     mayDependOn: []
     canUse:
       - gopherlua
+  statemachine:
+    mayDependOn:
+      - entity
+      - metamodel
+      - predicate
   tracer:
     mayDependOn:
       - store

--- a/internal/acl/resolver.go
+++ b/internal/acl/resolver.go
@@ -2,6 +2,7 @@ package acl
 
 import (
 	"context"
+	"slices"
 	"sort"
 )
 
@@ -223,19 +224,38 @@ func (r *Request) HoldsPermission(ctx context.Context, perm string) bool {
 	return r.holdsPermission(ctx, perm)
 }
 
+// HoldsPermissionForEntity reports whether the principal holds the given named
+// permission for the entity identified by entityID, considering BOTH global
+// roles AND roles conferred locally by graph relations to that entity (and its
+// ancestors via inherit_roles_through). This is the subject-aware sibling of
+// [Request.HoldsPermission]: it lets a caller express "the assignee may perform
+// X on their own entity" where the assignee role is conferred by an ownership
+// relation, not a global assignment.
+//
+// It is the entry point the statemachine transition guard uses (TKT-E4LW2):
+// the guard permission is a coarse capability noun (e.g. "establish"), and the
+// per-subject scope comes from whether a role-relation confers the granting
+// role for this entity — resolved here, not baked into the permission.
+func (r *Request) HoldsPermissionForEntity(ctx context.Context, entityID, perm string) bool {
+	return r.grantsPermission(r.computeForEntity(ctx, entityID), perm)
+}
+
 // holdsPermission reports whether any role in the principal's global
 // role set grants the given permission. Used by the delegate-X gate
 // on role-relation writes; permissions are global-only by design.
 func (r *Request) holdsPermission(ctx context.Context, perm string) bool {
-	for _, a := range r.Globals(ctx).Attributions {
+	return r.grantsPermission(r.Globals(ctx).Attributions, perm)
+}
+
+// grantsPermission reports whether any role in attrs grants perm.
+func (r *Request) grantsPermission(attrs []RoleAttribution, perm string) bool {
+	for _, a := range attrs {
 		role, ok := r.d.policy.Roles[a.Role]
 		if !ok {
 			continue
 		}
-		for _, p := range role.Permissions {
-			if p == perm {
-				return true
-			}
+		if slices.Contains(role.Permissions, perm) {
+			return true
 		}
 	}
 	return false

--- a/internal/acl/resolver_test.go
+++ b/internal/acl/resolver_test.go
@@ -364,6 +364,40 @@ func TestRequest_ForEntityReusesGlobals(t *testing.T) {
 	}
 }
 
+// HoldsPermissionForEntity must see a permission carried by a role that is
+// conferred ONLY via a role-relation to the subject entity — the subject-scoped
+// case the globals-only holdsPermission cannot answer (RR-UJPW4). The same
+// permission must NOT be reported for an unrelated entity.
+func TestRequest_HoldsPermissionForEntity_SubjectScoped(t *testing.T) {
+	t.Parallel()
+	g := newFakeGraph()
+	// alice owns PRJ-foo (and nothing else). No global assignment.
+	g.add("alice", "owner-of", "PRJ-foo")
+
+	d := newTestDeclarative(t, &Policy{
+		Roles:         map[string]RoleDef{"owner": {Permissions: []string{"establish"}}},
+		RoleRelations: map[string]RoleRelationDef{"owner-of": {Confers: "owner"}},
+	}, g)
+
+	req, err := d.ForPrincipal(aliceDataEntry())
+	if err != nil {
+		t.Fatalf("ForPrincipal: %v", err)
+	}
+	ctx := context.Background()
+
+	if !req.HoldsPermissionForEntity(ctx, "PRJ-foo", "establish") {
+		t.Error("expected establish on owned PRJ-foo (role conferred via owner-of)")
+	}
+	if req.HoldsPermissionForEntity(ctx, "PRJ-other", "establish") {
+		t.Error("establish leaked to an unrelated entity PRJ-other")
+	}
+	// The globals-only path must NOT see it — proving the subject-aware path is
+	// load-bearing, not incidental.
+	if req.HoldsPermission(ctx, "establish") {
+		t.Error("globals-only HoldsPermission should not see a relation-conferred permission")
+	}
+}
+
 // RR-MBK0: ForEntity's local-role attribution iteration over
 // RoleRelations is a map iteration — Go intentionally randomizes it.
 // Without the sort fix, the resulting Attributions slice (and the

--- a/internal/appbuild/appbuild.go
+++ b/internal/appbuild/appbuild.go
@@ -668,7 +668,7 @@ func assemble(
 		ProjectRoot: cfg.Paths.Root,
 	}
 
-	tw, err := CompileTransitions(base.meta, st)
+	tw, err := CompileTransitions(base.meta, st, resolvedACL)
 	if err != nil {
 		return nil, fmt.Errorf("compile transitions: %w", err)
 	}

--- a/internal/appbuild/appbuild.go
+++ b/internal/appbuild/appbuild.go
@@ -668,6 +668,11 @@ func assemble(
 		ProjectRoot: cfg.Paths.Root,
 	}
 
+	tw, err := CompileTransitions(base.meta, st)
+	if err != nil {
+		return nil, fmt.Errorf("compile transitions: %w", err)
+	}
+
 	mgr, err := entitymanager.New(entitymanager.Deps{
 		Store:                   st,
 		Meta:                    base.meta,
@@ -679,6 +684,9 @@ func assemble(
 		ScriptRunner:            script.NewLuaScriptRunner(cfg.ScriptEngine, readDeps),
 		VersionRecorder:         versionRecorderFor(st),
 		RelationVersionRecorder: relationVersionRecorderFor(st),
+		Transitions:             tw.Enforcer,
+		TransitionGuard:         tw.Guard,
+		TransitionGraph:         tw.Graph,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("build entitymanager: %w", err)

--- a/internal/appbuild/appbuildtest/fixture.go
+++ b/internal/appbuild/appbuildtest/fixture.go
@@ -169,7 +169,7 @@ func New(meta *metamodel.Metamodel, opts ...Option) *appbuild.Services {
 		aclImpl = acl.NopACL{}
 	}
 
-	tw, err := appbuild.CompileTransitions(meta, st)
+	tw, err := appbuild.CompileTransitions(meta, st, aclImpl)
 	if err != nil {
 		panic(fmt.Sprintf("appbuildtest.New: compile transitions: %v", err))
 	}

--- a/internal/appbuild/appbuildtest/fixture.go
+++ b/internal/appbuild/appbuildtest/fixture.go
@@ -169,15 +169,22 @@ func New(meta *metamodel.Metamodel, opts ...Option) *appbuild.Services {
 		aclImpl = acl.NopACL{}
 	}
 
+	tw, err := appbuild.CompileTransitions(meta, st)
+	if err != nil {
+		panic(fmt.Sprintf("appbuildtest.New: compile transitions: %v", err))
+	}
 	mgr, err := entitymanager.New(entitymanager.Deps{
-		Store:        st,
-		Meta:         meta,
-		Templater:    templater,
-		Audit:        auditSink,
-		ACL:          aclImpl,
-		Automations:  autoEngine,
-		Cascade:      cascadeRunner,
-		ScriptRunner: script.NewLuaScriptRunner(scriptEngine, readDeps),
+		Store:           st,
+		Meta:            meta,
+		Templater:       templater,
+		Audit:           auditSink,
+		ACL:             aclImpl,
+		Automations:     autoEngine,
+		Cascade:         cascadeRunner,
+		ScriptRunner:    script.NewLuaScriptRunner(scriptEngine, readDeps),
+		Transitions:     tw.Enforcer,
+		TransitionGuard: tw.Guard,
+		TransitionGraph: tw.Graph,
 	})
 	if err != nil {
 		panic(fmt.Sprintf("appbuildtest.New: build entitymanager: %v", err))

--- a/internal/appbuild/transitions.go
+++ b/internal/appbuild/transitions.go
@@ -1,0 +1,74 @@
+package appbuild
+
+import (
+	"context"
+
+	"github.com/Sourcehaven-BV/rela/internal/acl"
+	"github.com/Sourcehaven-BV/rela/internal/metamodel"
+	"github.com/Sourcehaven-BV/rela/internal/statemachine"
+	"github.com/Sourcehaven-BV/rela/internal/store"
+)
+
+// transitionGuard adapts the ACL to the [statemachine.Guard] the transition
+// enforcer needs. It answers "does the ctx principal hold `permission` for the
+// subject entity" using the SUBJECT-AWARE resolver
+// ([acl.Request.HoldsPermissionForEntity]) — so a permission conferred by an
+// ownership relation to the subject is honored, not just global grants.
+//
+// Served-vs-inert lives here: the enforcer's guard question is only meaningful
+// when there is an authenticated principal with a policy. On a direct CLI/no-
+// policy write there is no [acl.Request] on the context (NopACL never puts one
+// there), so the guard is inert — it allows, matching the "no principal → no
+// authorization to enforce" tier rule. A misconfigured served path that somehow
+// lacks a Request also allows here; the top-level entity-write ACL gate has
+// already run, so this is not the only line of defense.
+type transitionGuard struct{}
+
+func (transitionGuard) HoldsPermission(ctx context.Context, subjectID, permission string) bool {
+	req := acl.FromContext(ctx)
+	if req == nil {
+		return true // no policy/principal in scope → guard inert (direct/CLI path)
+	}
+	return req.HoldsPermissionForEntity(ctx, subjectID, permission)
+}
+
+// transitionGraph adapts the store to the [statemachine.GraphLookup] a `when:`
+// precondition needs (has_relation / count_relations). One outgoing scan per
+// evaluation answers both host functions.
+type transitionGraph struct{ st store.Store }
+
+func (g transitionGraph) OutgoingCounts(ctx context.Context, fromID string) map[string]int {
+	counts := map[string]int{}
+	for rel, err := range g.st.ListRelations(ctx, store.RelationQuery{
+		From: fromID, Direction: store.DirectionOutgoing,
+	}) {
+		if err != nil {
+			return counts
+		}
+		counts[rel.Type]++
+	}
+	return counts
+}
+
+// TransitionWiring bundles the compiled state machines and the collaborators
+// the entitymanager needs to enforce them. Returned by [CompileTransitions] so
+// every wiring site (production assemble + test fixtures) builds the enforcer
+// the same way.
+type TransitionWiring struct {
+	Enforcer *statemachine.Set
+	Guard    statemachine.Guard
+	Graph    statemachine.GraphLookup
+}
+
+// CompileTransitions builds the executable state machines from the metamodel
+// and the wiring collaborators the entitymanager needs. A metamodel with no
+// transitions yields an empty (no-op) enforcer. Returns an error only when a
+// machine is malformed (surfaced at boot). Exported so test fixtures wire the
+// enforcer through the same path as production.
+func CompileTransitions(meta *metamodel.Metamodel, st store.Store) (TransitionWiring, error) {
+	set, err := statemachine.Compile(meta)
+	if err != nil {
+		return TransitionWiring{}, err
+	}
+	return TransitionWiring{Enforcer: set, Guard: transitionGuard{}, Graph: transitionGraph{st: st}}, nil
+}

--- a/internal/appbuild/transitions.go
+++ b/internal/appbuild/transitions.go
@@ -15,19 +15,26 @@ import (
 // ([acl.Request.HoldsPermissionForEntity]) — so a permission conferred by an
 // ownership relation to the subject is honored, not just global grants.
 //
-// Served-vs-inert lives here: the enforcer's guard question is only meaningful
-// when there is an authenticated principal with a policy. On a direct CLI/no-
-// policy write there is no [acl.Request] on the context (NopACL never puts one
-// there), so the guard is inert — it allows, matching the "no principal → no
-// authorization to enforce" tier rule. A misconfigured served path that somehow
-// lacks a Request also allows here; the top-level entity-write ACL gate has
-// already run, so this is not the only line of defense.
-type transitionGuard struct{}
+// Served-vs-inert lives here, and the distinction is deliberate (RR-UOBUC):
+//
+//   - No policy configured (NopACL / no acl.yaml): policyActive is false. The
+//     guard is inert — it allows — matching the "no principal → no authorization
+//     to enforce" tier rule (direct CLI writes, demos).
+//   - A policy IS configured (Declarative) but no [acl.Request] is on the
+//     context: this is a misconfiguration (a served path that lost its
+//     Request-attach middleware, or a background job reusing a bare ctx). The
+//     guard fails CLOSED — it denies — because a policy-backed deployment must
+//     not silently open a governed transition just because plumbing broke. This
+//     matches the rest of the ACL's fail-closed posture (the router 500s on an
+//     unresolved principal; role walks abort rather than over-grant).
+type transitionGuard struct{ policyActive bool }
 
-func (transitionGuard) HoldsPermission(ctx context.Context, subjectID, permission string) bool {
+func (g transitionGuard) HoldsPermission(ctx context.Context, subjectID, permission string) bool {
 	req := acl.FromContext(ctx)
 	if req == nil {
-		return true // no policy/principal in scope → guard inert (direct/CLI path)
+		// No Request: inert when there is no policy at all; fail closed when a
+		// policy exists but the Request is unexpectedly absent.
+		return !g.policyActive
 	}
 	return req.HoldsPermissionForEntity(ctx, subjectID, permission)
 }
@@ -65,10 +72,20 @@ type TransitionWiring struct {
 // transitions yields an empty (no-op) enforcer. Returns an error only when a
 // machine is malformed (surfaced at boot). Exported so test fixtures wire the
 // enforcer through the same path as production.
-func CompileTransitions(meta *metamodel.Metamodel, st store.Store) (TransitionWiring, error) {
+//
+// resolvedACL determines the guard's fail-closed posture: when it is a
+// policy-backed [*acl.Declarative], a served write that is missing its
+// [acl.Request] is denied rather than allowed (RR-UOBUC). With NopACL /
+// ReadOnlyACL there is no policy, so the guard stays inert.
+func CompileTransitions(meta *metamodel.Metamodel, st store.Store, resolvedACL acl.ACL) (TransitionWiring, error) {
 	set, err := statemachine.Compile(meta)
 	if err != nil {
 		return TransitionWiring{}, err
 	}
-	return TransitionWiring{Enforcer: set, Guard: transitionGuard{}, Graph: transitionGraph{st: st}}, nil
+	_, policyActive := resolvedACL.(*acl.Declarative)
+	return TransitionWiring{
+		Enforcer: set,
+		Guard:    transitionGuard{policyActive: policyActive},
+		Graph:    transitionGraph{st: st},
+	}, nil
 }

--- a/internal/attachment/attachment_test.go
+++ b/internal/attachment/attachment_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/Sourcehaven-BV/rela/internal/entitymanager"
 	"github.com/Sourcehaven-BV/rela/internal/metamodel"
 	"github.com/Sourcehaven-BV/rela/internal/project"
+	"github.com/Sourcehaven-BV/rela/internal/statemachine"
 	"github.com/Sourcehaven-BV/rela/internal/storage"
 	"github.com/Sourcehaven-BV/rela/internal/store"
 	"github.com/Sourcehaven-BV/rela/internal/templating"
@@ -89,11 +90,12 @@ func setupAttachmentService(t *testing.T) attachmentFixture {
 		t.Fatalf("OpenStore: %v", err)
 	}
 	mgr, err := entitymanager.New(entitymanager.Deps{
-		Store:     st,
-		Meta:      meta,
-		Templater: templating.NewFSTemplater(fs, ctx),
-		Audit:     audit.Nop{},
-		ACL:       acl.NopACL{},
+		Store:       st,
+		Meta:        meta,
+		Templater:   templating.NewFSTemplater(fs, ctx),
+		Audit:       audit.Nop{},
+		ACL:         acl.NopACL{},
+		Transitions: statemachine.EmptySet(),
 	})
 	if err != nil {
 		t.Fatalf("entitymanager.New: %v", err)

--- a/internal/entitymanager/acl_bypass_test.go
+++ b/internal/entitymanager/acl_bypass_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/Sourcehaven-BV/rela/internal/entity"
 	"github.com/Sourcehaven-BV/rela/internal/entitymanager"
 	"github.com/Sourcehaven-BV/rela/internal/principal"
+	"github.com/Sourcehaven-BV/rela/internal/statemachine"
 	"github.com/Sourcehaven-BV/rela/internal/store/memstore"
 )
 
@@ -132,6 +133,7 @@ func TestManager_Elevated_DoesNotLeakIntoNestedCascade(t *testing.T) {
 		Templater:    nopTemplater{},
 		Audit:        audit.Nop{},
 		ACL:          acl.ReadOnlyACL{}, // deny-all, so a gated write is refused
+		Transitions:  statemachine.EmptySet(),
 		Automations:  engine,
 		Cascade:      runner,
 		ScriptRunner: scripts,

--- a/internal/entitymanager/acl_test.go
+++ b/internal/entitymanager/acl_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Sourcehaven-BV/rela/internal/entitymanager"
 	"github.com/Sourcehaven-BV/rela/internal/metamodel"
 	"github.com/Sourcehaven-BV/rela/internal/principal"
+	"github.com/Sourcehaven-BV/rela/internal/statemachine"
 	"github.com/Sourcehaven-BV/rela/internal/store/memstore"
 )
 
@@ -24,11 +25,12 @@ func newManagerWithACL(
 	t.Helper()
 	cs := &countingStore{Store: memstore.New()}
 	mgr, err := entitymanager.New(entitymanager.Deps{
-		Store:     cs,
-		Meta:      parseMeta(t),
-		Templater: nopTemplater{},
-		Audit:     sink,
-		ACL:       aclImpl,
+		Store:       cs,
+		Meta:        parseMeta(t),
+		Templater:   nopTemplater{},
+		Audit:       sink,
+		ACL:         aclImpl,
+		Transitions: statemachine.EmptySet(),
 	})
 	if err != nil {
 		t.Fatalf("entitymanager.New: %v", err)
@@ -43,11 +45,12 @@ func newManagerWithACL(
 func seedEntity(t *testing.T, store *countingStore, entityType, title string) {
 	t.Helper()
 	mgr, err := entitymanager.New(entitymanager.Deps{
-		Store:     store,
-		Meta:      parseMeta(t),
-		Templater: nopTemplater{},
-		Audit:     audit.Nop{},
-		ACL:       acl.NopACL{},
+		Store:       store,
+		Meta:        parseMeta(t),
+		Templater:   nopTemplater{},
+		Audit:       audit.Nop{},
+		ACL:         acl.NopACL{},
+		Transitions: statemachine.EmptySet(),
 	})
 	if err != nil {
 		t.Fatalf("seedEntity: New: %v", err)
@@ -63,11 +66,12 @@ func seedEntity(t *testing.T, store *countingStore, entityType, title string) {
 func seedRelation(t *testing.T, store *countingStore, from, relType, to string) {
 	t.Helper()
 	mgr, err := entitymanager.New(entitymanager.Deps{
-		Store:     store,
-		Meta:      parseMeta(t),
-		Templater: nopTemplater{},
-		Audit:     audit.Nop{},
-		ACL:       acl.NopACL{},
+		Store:       store,
+		Meta:        parseMeta(t),
+		Templater:   nopTemplater{},
+		Audit:       audit.Nop{},
+		ACL:         acl.NopACL{},
+		Transitions: statemachine.EmptySet(),
 	})
 	if err != nil {
 		t.Fatalf("seedRelation: New: %v", err)
@@ -370,7 +374,7 @@ role_relations:
 	store := &countingStore{Store: memstore.New()}
 	seedMgr, err := entitymanager.New(entitymanager.Deps{
 		Store: store, Meta: meta, Templater: nopTemplater{},
-		Audit: audit.Nop{}, ACL: acl.NopACL{},
+		Audit: audit.Nop{}, ACL: acl.NopACL{}, Transitions: statemachine.EmptySet(),
 	})
 	if err != nil {
 		t.Fatalf("seed Manager.New: %v", err)
@@ -418,7 +422,7 @@ role_relations:
 	}
 	mgr, err := entitymanager.New(entitymanager.Deps{
 		Store: store, Meta: meta, Templater: nopTemplater{},
-		Audit: sink, ACL: declarative,
+		Audit: sink, ACL: declarative, Transitions: statemachine.EmptySet(),
 	})
 	if err != nil {
 		t.Fatalf("entitymanager.New: %v", err)
@@ -533,7 +537,7 @@ assignments:
 	store := &countingStore{Store: memstore.New()}
 	seedMgr, err := entitymanager.New(entitymanager.Deps{
 		Store: store, Meta: meta, Templater: nopTemplater{},
-		Audit: audit.Nop{}, ACL: acl.NopACL{},
+		Audit: audit.Nop{}, ACL: acl.NopACL{}, Transitions: statemachine.EmptySet(),
 	})
 	if err != nil {
 		t.Fatalf("seed Manager.New: %v", err)
@@ -568,7 +572,7 @@ assignments:
 	}
 	mgr, err := entitymanager.New(entitymanager.Deps{
 		Store: store, Meta: meta, Templater: nopTemplater{},
-		Audit: sink, ACL: declarative,
+		Audit: sink, ACL: declarative, Transitions: statemachine.EmptySet(),
 	})
 	if err != nil {
 		t.Fatalf("entitymanager.New: %v", err)

--- a/internal/entitymanager/apply.go
+++ b/internal/entitymanager/apply.go
@@ -130,6 +130,24 @@ func (m *Manager) ApplyEntity(ctx context.Context, e *entity.Entity) (*entity.Up
 		return nil, err
 	}
 
+	// Enforce enum state machines on the sync/upsert path too (RR-NB135): this
+	// is a served write with a real principal, so skipping it would let a sync
+	// client land an illegal transition or bypass a guard — the exact hole the
+	// "unforgettable" pipeline is meant to close. On an update we diff against
+	// the probed `stored` state; on a create we check the entry value. The
+	// guard adapter is inert when there is no policy/principal (CLI sync), so
+	// only a policy-backed served sync is gated. ApplyEntity runs no automation,
+	// so this is the final pre-write state.
+	if op.aclOp == acl.OpUpdate {
+		if err := m.deps.Transitions.EnforceUpdate(
+			ctx, stored, e, m.deps.TransitionGuard, m.deps.TransitionGraph,
+		); err != nil {
+			return nil, m.mapTransitionError(ctx, acl.EntitySubject{Type: subjectType, ID: e.ID}, err)
+		}
+	} else if err := m.deps.Transitions.EnforceCreate(ctx, e); err != nil {
+		return nil, err
+	}
+
 	// Write by RESOLVED intent — never upsert. A create that conflicts
 	// (a concurrent create of the same ID landed since the existence
 	// probe) is a lost-update + type-re-type vector if it silently

--- a/internal/entitymanager/apply_conflict_test.go
+++ b/internal/entitymanager/apply_conflict_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/Sourcehaven-BV/rela/internal/audit"
 	"github.com/Sourcehaven-BV/rela/internal/entity"
 	"github.com/Sourcehaven-BV/rela/internal/entitymanager"
+	"github.com/Sourcehaven-BV/rela/internal/statemachine"
 	"github.com/Sourcehaven-BV/rela/internal/store"
 	"github.com/Sourcehaven-BV/rela/internal/store/memstore"
 )
@@ -65,7 +66,7 @@ func TestApplyEntity_CreateConflict_RejectsAndDoesNotClobber(t *testing.T) {
 
 	st := &raceCreateStore{Store: inner}
 	mgr, err := entitymanager.New(entitymanager.Deps{
-		Store: st, Meta: meta, Templater: nopTemplater{}, Audit: audit.Nop{}, ACL: acl.NopACL{},
+		Store: st, Meta: meta, Templater: nopTemplater{}, Audit: audit.Nop{}, ACL: acl.NopACL{}, Transitions: statemachine.EmptySet(),
 	})
 	if err != nil {
 		t.Fatalf("entitymanager.New: %v", err)
@@ -113,7 +114,7 @@ func TestApplyEntity_SameTypeCreateConflict_NoClobber(t *testing.T) {
 
 	st := &raceCreateStore{Store: inner}
 	mgr, err := entitymanager.New(entitymanager.Deps{
-		Store: st, Meta: meta, Templater: nopTemplater{}, Audit: audit.Nop{}, ACL: acl.NopACL{},
+		Store: st, Meta: meta, Templater: nopTemplater{}, Audit: audit.Nop{}, ACL: acl.NopACL{}, Transitions: statemachine.EmptySet(),
 	})
 	if err != nil {
 		t.Fatalf("entitymanager.New: %v", err)
@@ -171,7 +172,7 @@ func TestApplyEntity_UpdateVanished_RejectsWithoutCreating(t *testing.T) {
 		stored: &entity.Entity{ID: "NOTE-1", Type: "note", Properties: map[string]any{"title": "v1"}},
 	}
 	mgr, err := entitymanager.New(entitymanager.Deps{
-		Store: st, Meta: meta, Templater: nopTemplater{}, Audit: audit.Nop{}, ACL: acl.NopACL{},
+		Store: st, Meta: meta, Templater: nopTemplater{}, Audit: audit.Nop{}, ACL: acl.NopACL{}, Transitions: statemachine.EmptySet(),
 	})
 	if err != nil {
 		t.Fatalf("entitymanager.New: %v", err)

--- a/internal/entitymanager/apply_test.go
+++ b/internal/entitymanager/apply_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Sourcehaven-BV/rela/internal/automation"
 	"github.com/Sourcehaven-BV/rela/internal/entity"
 	"github.com/Sourcehaven-BV/rela/internal/entitymanager"
+	"github.com/Sourcehaven-BV/rela/internal/statemachine"
 	"github.com/Sourcehaven-BV/rela/internal/store"
 	"github.com/Sourcehaven-BV/rela/internal/store/memstore"
 )
@@ -17,11 +18,12 @@ import (
 func newApplyManager(t *testing.T, st store.Store, sink audit.Audit) *entitymanager.Manager {
 	t.Helper()
 	mgr, err := entitymanager.New(entitymanager.Deps{
-		Store:     st,
-		Meta:      parseMeta(t),
-		Templater: nopTemplater{},
-		Audit:     sink,
-		ACL:       acl.NopACL{},
+		Store:       st,
+		Meta:        parseMeta(t),
+		Templater:   nopTemplater{},
+		Audit:       sink,
+		ACL:         acl.NopACL{},
+		Transitions: statemachine.EmptySet(),
 	})
 	if err != nil {
 		t.Fatalf("entitymanager.New: %v", err)
@@ -402,7 +404,7 @@ func TestApplyRelation_EndpointProbeFailsClosed(t *testing.T) {
 func seedViaManager(t *testing.T, st store.Store, id, typ string) {
 	t.Helper()
 	mgr, err := entitymanager.New(entitymanager.Deps{
-		Store: st, Meta: parseMeta(t), Templater: nopTemplater{}, Audit: audit.Nop{}, ACL: acl.NopACL{},
+		Store: st, Meta: parseMeta(t), Templater: nopTemplater{}, Audit: audit.Nop{}, ACL: acl.NopACL{}, Transitions: statemachine.EmptySet(),
 	})
 	if err != nil {
 		t.Fatalf("seedViaManager: %v", err)
@@ -420,7 +422,7 @@ func seedViaManager(t *testing.T, st store.Store, id, typ string) {
 func TestApplyEntity_ACLDenied(t *testing.T) {
 	st := memstore.New()
 	mgr, err := entitymanager.New(entitymanager.Deps{
-		Store: st, Meta: parseMeta(t), Templater: nopTemplater{}, Audit: audit.Nop{}, ACL: acl.ReadOnlyACL{},
+		Store: st, Meta: parseMeta(t), Templater: nopTemplater{}, Audit: audit.Nop{}, ACL: acl.ReadOnlyACL{}, Transitions: statemachine.EmptySet(),
 	})
 	if err != nil {
 		t.Fatalf("New: %v", err)

--- a/internal/entitymanager/apply_type_confusion_test.go
+++ b/internal/entitymanager/apply_type_confusion_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Sourcehaven-BV/rela/internal/entitymanager"
 	"github.com/Sourcehaven-BV/rela/internal/metamodel"
 	"github.com/Sourcehaven-BV/rela/internal/principal"
+	"github.com/Sourcehaven-BV/rela/internal/statemachine"
 	"github.com/Sourcehaven-BV/rela/internal/store"
 	"github.com/Sourcehaven-BV/rela/internal/store/memstore"
 )
@@ -63,7 +64,7 @@ func TestApplyEntity_RejectsTypeChangeOnUpdate(t *testing.T) {
 
 	// Seed a secret via a NopACL manager (seeding bypasses authz).
 	seedMgr, err := entitymanager.New(entitymanager.Deps{
-		Store: st, Meta: meta, Templater: nopTemplater{}, Audit: audit.Nop{}, ACL: acl.NopACL{},
+		Store: st, Meta: meta, Templater: nopTemplater{}, Audit: audit.Nop{}, ACL: acl.NopACL{}, Transitions: statemachine.EmptySet(),
 	})
 	if err != nil {
 		t.Fatalf("seed New: %v", err)
@@ -92,7 +93,7 @@ assignments:
 	}
 	sink := audit.NewMemory()
 	mgr, err := entitymanager.New(entitymanager.Deps{
-		Store: st, Meta: meta, Templater: nopTemplater{}, Audit: sink, ACL: declarative,
+		Store: st, Meta: meta, Templater: nopTemplater{}, Audit: sink, ACL: declarative, Transitions: statemachine.EmptySet(),
 	})
 	if err != nil {
 		t.Fatalf("New: %v", err)
@@ -147,7 +148,7 @@ func TestApplyEntity_SameTypeUpdateStillWorks(t *testing.T) {
 	meta := typeConfusionMeta(t)
 
 	seedMgr, err := entitymanager.New(entitymanager.Deps{
-		Store: st, Meta: meta, Templater: nopTemplater{}, Audit: audit.Nop{}, ACL: acl.NopACL{},
+		Store: st, Meta: meta, Templater: nopTemplater{}, Audit: audit.Nop{}, ACL: acl.NopACL{}, Transitions: statemachine.EmptySet(),
 	})
 	if err != nil {
 		t.Fatalf("seed New: %v", err)
@@ -174,7 +175,7 @@ assignments:
 		t.Fatalf("NewDeclarative: %v", err)
 	}
 	mgr, err := entitymanager.New(entitymanager.Deps{
-		Store: st, Meta: meta, Templater: nopTemplater{}, Audit: audit.Nop{}, ACL: declarative,
+		Store: st, Meta: meta, Templater: nopTemplater{}, Audit: audit.Nop{}, ACL: declarative, Transitions: statemachine.EmptySet(),
 	})
 	if err != nil {
 		t.Fatalf("New: %v", err)

--- a/internal/entitymanager/audit_durability_test.go
+++ b/internal/entitymanager/audit_durability_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Sourcehaven-BV/rela/internal/automation"
 	"github.com/Sourcehaven-BV/rela/internal/entity"
 	"github.com/Sourcehaven-BV/rela/internal/entitymanager"
+	"github.com/Sourcehaven-BV/rela/internal/statemachine"
 	"github.com/Sourcehaven-BV/rela/internal/store"
 	"github.com/Sourcehaven-BV/rela/internal/store/memstore"
 )
@@ -33,11 +34,12 @@ func newManagerWithStoreAndAudit(
 ) *entitymanager.Manager {
 	t.Helper()
 	deps := entitymanager.Deps{
-		Store:     st,
-		Meta:      parseMeta(t),
-		Templater: nopTemplater{},
-		Audit:     sink,
-		ACL:       acl.NopACL{},
+		Store:       st,
+		Meta:        parseMeta(t),
+		Templater:   nopTemplater{},
+		Audit:       sink,
+		ACL:         acl.NopACL{},
+		Transitions: statemachine.EmptySet(),
 	}
 	if automations != nil {
 		engine := automation.NewEngine(automations)

--- a/internal/entitymanager/audit_test.go
+++ b/internal/entitymanager/audit_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/Sourcehaven-BV/rela/internal/entity"
 	"github.com/Sourcehaven-BV/rela/internal/entitymanager"
 	"github.com/Sourcehaven-BV/rela/internal/principal"
+	"github.com/Sourcehaven-BV/rela/internal/statemachine"
 	"github.com/Sourcehaven-BV/rela/internal/store/memstore"
 )
 
@@ -24,11 +25,12 @@ func newManagerWithAudit(
 ) *entitymanager.Manager {
 	t.Helper()
 	deps := entitymanager.Deps{
-		Store:     memstore.New(),
-		Meta:      parseMeta(t),
-		Templater: nopTemplater{},
-		Audit:     sink,
-		ACL:       acl.NopACL{},
+		Store:       memstore.New(),
+		Meta:        parseMeta(t),
+		Templater:   nopTemplater{},
+		Audit:       sink,
+		ACL:         acl.NopACL{},
+		Transitions: statemachine.EmptySet(),
 	}
 	if automations != nil {
 		engine := automation.NewEngine(automations)

--- a/internal/entitymanager/bench_test.go
+++ b/internal/entitymanager/bench_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Sourcehaven-BV/rela/internal/entity"
 	"github.com/Sourcehaven-BV/rela/internal/entitymanager"
 	"github.com/Sourcehaven-BV/rela/internal/metamodel"
+	"github.com/Sourcehaven-BV/rela/internal/statemachine"
 	"github.com/Sourcehaven-BV/rela/internal/store/memstore"
 )
 
@@ -27,11 +28,12 @@ func BenchmarkValidateCreate(b *testing.B) {
 		b.Fatal(err)
 	}
 	mgr, err := entitymanager.New(entitymanager.Deps{
-		Store:     memstore.New(),
-		Meta:      meta,
-		Templater: nopTemplater{},
-		Audit:     audit.Nop{},
-		ACL:       acl.NopACL{},
+		Store:       memstore.New(),
+		Meta:        meta,
+		Templater:   nopTemplater{},
+		Audit:       audit.Nop{},
+		ACL:         acl.NopACL{},
+		Transitions: statemachine.EmptySet(),
 	})
 	if err != nil {
 		b.Fatal(err)
@@ -72,11 +74,12 @@ func TestValidateCreate_AllocCeiling(t *testing.T) {
 		t.Fatal(err)
 	}
 	mgr, err := entitymanager.New(entitymanager.Deps{
-		Store:     memstore.New(),
-		Meta:      meta,
-		Templater: nopTemplater{},
-		Audit:     audit.Nop{},
-		ACL:       acl.NopACL{},
+		Store:       memstore.New(),
+		Meta:        meta,
+		Templater:   nopTemplater{},
+		Audit:       audit.Nop{},
+		ACL:         acl.NopACL{},
+		Transitions: statemachine.EmptySet(),
 	})
 	if err != nil {
 		t.Fatal(err)

--- a/internal/entitymanager/collect_errors_test.go
+++ b/internal/entitymanager/collect_errors_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Sourcehaven-BV/rela/internal/audit"
 	"github.com/Sourcehaven-BV/rela/internal/entity"
 	"github.com/Sourcehaven-BV/rela/internal/entitymanager"
+	"github.com/Sourcehaven-BV/rela/internal/statemachine"
 	"github.com/Sourcehaven-BV/rela/internal/store"
 	"github.com/Sourcehaven-BV/rela/internal/store/memstore"
 )
@@ -55,11 +56,12 @@ func (s *listRelationsErrStore) ListRelations(_ context.Context, _ store.Relatio
 func newManagerOver(t *testing.T, st store.Store) *entitymanager.Manager {
 	t.Helper()
 	mgr, err := entitymanager.New(entitymanager.Deps{
-		Store:     st,
-		Meta:      parseMeta(t),
-		Templater: nopTemplater{},
-		Audit:     audit.Nop{},
-		ACL:       acl.NopACL{},
+		Store:       st,
+		Meta:        parseMeta(t),
+		Templater:   nopTemplater{},
+		Audit:       audit.Nop{},
+		ACL:         acl.NopACL{},
+		Transitions: statemachine.EmptySet(),
 	})
 	if err != nil {
 		t.Fatalf("entitymanager.New: %v", err)

--- a/internal/entitymanager/core.go
+++ b/internal/entitymanager/core.go
@@ -94,6 +94,16 @@ func createCore(
 		return nil, nil, err
 	}
 
+	// Enforce state-machine entry BEFORE the durable write (TKT-E4LW2,
+	// RR-HETEE): the candidate carries the resolved post-template property
+	// values, so the entry-value check needs no persisted row. Running it
+	// here — not after Store.CreateEntity — means an illegal entry is
+	// rejected without ever emitting a store event (no orphaned index entry,
+	// no SSE broadcast, no un-audited row).
+	if err := deps.Transitions.EnforceCreate(ctx, e); err != nil {
+		return nil, nil, err
+	}
+
 	// Enforce `unique: true` natural-key constraints before the durable
 	// write. excludeSelfID is empty: on create there is no prior version
 	// of this entity to exclude.

--- a/internal/entitymanager/create_conflict_test.go
+++ b/internal/entitymanager/create_conflict_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Sourcehaven-BV/rela/internal/audit"
 	"github.com/Sourcehaven-BV/rela/internal/entity"
 	"github.com/Sourcehaven-BV/rela/internal/entitymanager"
+	"github.com/Sourcehaven-BV/rela/internal/statemachine"
 	"github.com/Sourcehaven-BV/rela/internal/store"
 	"github.com/Sourcehaven-BV/rela/internal/store/memstore"
 )
@@ -35,11 +36,12 @@ func (s *conflictOnCreateStore) UpdateEntity(ctx context.Context, e *entity.Enti
 func newManagerOverStore(t *testing.T, st store.Store) *entitymanager.Manager {
 	t.Helper()
 	mgr, err := entitymanager.New(entitymanager.Deps{
-		Store:     st,
-		Meta:      parseMeta(t),
-		Templater: nopTemplater{},
-		Audit:     audit.Nop{},
-		ACL:       acl.NopACL{},
+		Store:       st,
+		Meta:        parseMeta(t),
+		Templater:   nopTemplater{},
+		Audit:       audit.Nop{},
+		ACL:         acl.NopACL{},
+		Transitions: statemachine.EmptySet(),
 	})
 	if err != nil {
 		t.Fatalf("entitymanager.New: %v", err)

--- a/internal/entitymanager/manager.go
+++ b/internal/entitymanager/manager.go
@@ -284,11 +284,12 @@ func (m *Manager) mapTransitionError(ctx context.Context, subject acl.Subject, e
 	if err == nil {
 		return nil
 	}
-	if errors.Is(err, statemachine.ErrGuardDenied) {
+	var ge *statemachine.GuardError
+	if errors.As(err, &ge) {
 		decision := acl.Decision{
 			Allow:    false,
 			RuleKind: "transition-guard",
-			RuleID:   "-",
+			RuleID:   ge.Permission, // the specific right, queryable in audit (RR-F30CZ/N1)
 			Reason:   err.Error(),
 		}
 		m.recordDeniedWrite(ctx, decision, acl.WriteRequest{Op: acl.OpUpdate, Subject: subject})
@@ -426,16 +427,10 @@ func (m *Manager) CreateEntity(
 	if err != nil {
 		return nil, err
 	}
-
-	// Enforce state-machine entry: a create may only enter a machine at its
-	// entry value (Initial, else Default). Runs post-template (defaults have
-	// applied) on the created state (TKT-E4LW2). createCore persisted the row,
-	// so a rejection here leaves an orphan on disk only briefly — but the
-	// common path is a legal entry; an illegal explicit entry value is a client
-	// error surfaced as 422 before automation/cascade run.
-	if err := m.deps.Transitions.EnforceCreate(ctx, created); err != nil {
-		return nil, err
-	}
+	// State-machine entry is enforced INSIDE createCore, before the durable
+	// write (RR-HETEE), so an illegal entry never persists. No guard applies on
+	// create-entry today; if a future change adds one, route its ErrGuardDenied
+	// through mapTransitionError so it surfaces as 403, not 422 (RR-F30CZ/N2).
 
 	result := &entity.CreateResult{Entity: created, Warnings: warnings}
 

--- a/internal/entitymanager/manager.go
+++ b/internal/entitymanager/manager.go
@@ -15,6 +15,7 @@ import (
 	"github.com/Sourcehaven-BV/rela/internal/entity"
 	"github.com/Sourcehaven-BV/rela/internal/metamodel"
 	"github.com/Sourcehaven-BV/rela/internal/principal"
+	"github.com/Sourcehaven-BV/rela/internal/statemachine"
 	"github.com/Sourcehaven-BV/rela/internal/store"
 	"github.com/Sourcehaven-BV/rela/internal/templating"
 )
@@ -178,6 +179,40 @@ type Deps struct {
 	// [RelationVersionRecorder]). Optional: nil disables it (fs/mem builds; the
 	// postgres build's relation create/update versions come from the sweep).
 	RelationVersionRecorder RelationVersionRecorder
+
+	// Transitions enforces enum state machines on the write path (TKT-E4LW2):
+	// transition legality, guard permissions, and preconditions. Required so
+	// no write path can silently skip the machine — but a metamodel with no
+	// transitions compiles to an empty enforcer whose checks are no-ops, so
+	// "required" costs nothing when the feature is unused. Constructed once at
+	// startup by [statemachine.Compile] and injected; the Manager never
+	// re-derives it from the metamodel.
+	Transitions TransitionEnforcer
+
+	// TransitionGuard answers the guard question for a state-machine
+	// transition (does the ctx principal hold permission P for the subject).
+	// May be nil: a nil guard makes every guarded edge fail closed, which is
+	// the safe default when no ACL-backed guard was wired. Production wiring
+	// supplies an adapter over the ACL; the direct-CLI/no-policy case is
+	// handled inside that adapter (it allows when there is no policy).
+	TransitionGuard statemachine.Guard
+
+	// TransitionGraph answers has_relation/count_relations for a transition
+	// `when:` precondition. May be nil when no precondition needs the graph;
+	// a `when:` that queries the graph then evaluates against an empty graph.
+	TransitionGraph statemachine.GraphLookup
+}
+
+// TransitionEnforcer is the narrow contract the Manager needs from the
+// compiled state machines: enforce an update (old→new) and a create's entry
+// value. Defined at the call site (CLAUDE.md consumer-side interfaces);
+// [*statemachine.Set] satisfies it.
+type TransitionEnforcer interface {
+	EnforceUpdate(
+		ctx context.Context, old, updated *entity.Entity,
+		guard statemachine.Guard, lookup statemachine.GraphLookup,
+	) error
+	EnforceCreate(ctx context.Context, e *entity.Entity) error
 }
 
 // New constructs a Manager and validates required collaborators.
@@ -196,6 +231,10 @@ func New(d Deps) (*Manager, error) {
 	}
 	if d.ACL == nil {
 		return nil, errors.New("entitymanager: New: ACL is required (use acl.NopACL{} to opt out)")
+	}
+	if d.Transitions == nil {
+		return nil, errors.New(
+			"entitymanager: New: Transitions is required (use statemachine.Compile; an empty set is a no-op)")
 	}
 	if (d.Automations == nil) != (d.Cascade == nil) {
 		return nil, errors.New(
@@ -233,6 +272,29 @@ func (m *Manager) authorizeAndAudit(ctx context.Context, req acl.WriteRequest) e
 	}
 	m.recordDeniedWrite(ctx, decision, req)
 	return &acl.ForbiddenError{Decision: decision}
+}
+
+// mapTransitionError translates a state-machine enforcement error into the
+// entitymanager's wire-facing error shape (TKT-E4LW2). A guard denial becomes
+// an [*acl.ForbiddenError] (RuleKind "transition-guard") so it flows through
+// the same 403 path — and audit row — as any other authorization denial;
+// legality and precondition failures pass through unchanged and surface as 422
+// validation-class errors at the HTTP boundary. Returns nil for a nil input.
+func (m *Manager) mapTransitionError(ctx context.Context, subject acl.Subject, err error) error {
+	if err == nil {
+		return nil
+	}
+	if errors.Is(err, statemachine.ErrGuardDenied) {
+		decision := acl.Decision{
+			Allow:    false,
+			RuleKind: "transition-guard",
+			RuleID:   "-",
+			Reason:   err.Error(),
+		}
+		m.recordDeniedWrite(ctx, decision, acl.WriteRequest{Op: acl.OpUpdate, Subject: subject})
+		return &acl.ForbiddenError{Decision: decision}
+	}
+	return err
 }
 
 // recordACLBypass emits one audit row for an elevated (rela.bypass_acl) write.
@@ -362,6 +424,16 @@ func (m *Manager) CreateEntity(
 		Content:         e.Content,
 	})
 	if err != nil {
+		return nil, err
+	}
+
+	// Enforce state-machine entry: a create may only enter a machine at its
+	// entry value (Initial, else Default). Runs post-template (defaults have
+	// applied) on the created state (TKT-E4LW2). createCore persisted the row,
+	// so a rejection here leaves an orphan on disk only briefly — but the
+	// common path is a legal entry; an illegal explicit entry value is a client
+	// error surfaced as 422 before automation/cascade run.
+	if err := m.deps.Transitions.EnforceCreate(ctx, created); err != nil {
 		return nil, err
 	}
 
@@ -531,6 +603,18 @@ func (m *Manager) UpdateEntity(ctx context.Context, e *entity.Entity) (*entity.U
 		}
 		result.AutomationWarnings = autoResult.Warnings
 		result.AutomationErrors = autoResult.Errors
+	}
+
+	// Enforce enum state machines on the final (post-automation) state, using
+	// the prior state to determine the transition (TKT-E4LW2). This is the
+	// unforgettable chokepoint: the enforcer is a required collaborator run in
+	// the fixed write pipeline, so no update path can skip legality/guard/
+	// precondition. An empty enforcer (metamodel with no transitions) is a
+	// no-op.
+	if err := m.deps.Transitions.EnforceUpdate(
+		ctx, oldEntity, e, m.deps.TransitionGuard, m.deps.TransitionGraph,
+	); err != nil {
+		return nil, m.mapTransitionError(ctx, acl.EntitySubject{Type: e.Type, ID: e.ID}, err)
 	}
 
 	// Enforce `unique: true` natural-key constraints against the final

--- a/internal/entitymanager/manager_delete_test.go
+++ b/internal/entitymanager/manager_delete_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Sourcehaven-BV/rela/internal/audit"
 	"github.com/Sourcehaven-BV/rela/internal/entity"
 	"github.com/Sourcehaven-BV/rela/internal/entitymanager"
+	"github.com/Sourcehaven-BV/rela/internal/statemachine"
 	"github.com/Sourcehaven-BV/rela/internal/store"
 	"github.com/Sourcehaven-BV/rela/internal/store/memstore"
 )
@@ -33,11 +34,12 @@ func TestDeleteEntity_PropagatesStoreError(t *testing.T) {
 	t.Parallel()
 	sentinel := errors.New("simulated delete failure")
 	deps := entitymanager.Deps{
-		Store:     &failingDeleteStore{Store: memstore.New(), err: sentinel},
-		Meta:      parseMeta(t),
-		Templater: nopTemplater{},
-		Audit:     audit.Nop{},
-		ACL:       acl.NopACL{},
+		Store:       &failingDeleteStore{Store: memstore.New(), err: sentinel},
+		Meta:        parseMeta(t),
+		Templater:   nopTemplater{},
+		Audit:       audit.Nop{},
+		ACL:         acl.NopACL{},
+		Transitions: statemachine.EmptySet(),
 	}
 	mgr, err := entitymanager.New(deps)
 	if err != nil {
@@ -71,11 +73,12 @@ func TestDeleteEntity_CascadeAuditsReportedRelations(t *testing.T) {
 	t.Parallel()
 	mem := audit.NewMemory()
 	deps := entitymanager.Deps{
-		Store:     memstore.New(),
-		Meta:      parseMeta(t),
-		Templater: nopTemplater{},
-		Audit:     mem,
-		ACL:       acl.NopACL{},
+		Store:       memstore.New(),
+		Meta:        parseMeta(t),
+		Templater:   nopTemplater{},
+		Audit:       mem,
+		ACL:         acl.NopACL{},
+		Transitions: statemachine.EmptySet(),
 	}
 	mgr, err := entitymanager.New(deps)
 	if err != nil {

--- a/internal/entitymanager/manager_test.go
+++ b/internal/entitymanager/manager_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/Sourcehaven-BV/rela/internal/entity"
 	"github.com/Sourcehaven-BV/rela/internal/entitymanager"
 	"github.com/Sourcehaven-BV/rela/internal/metamodel"
+	"github.com/Sourcehaven-BV/rela/internal/statemachine"
 	"github.com/Sourcehaven-BV/rela/internal/store"
 	"github.com/Sourcehaven-BV/rela/internal/store/memstore"
 	"github.com/Sourcehaven-BV/rela/internal/templating"
@@ -151,18 +152,24 @@ func parseMeta(t *testing.T) *metamodel.Metamodel {
 func newManager(t *testing.T, automations []automation.Automation) (*entitymanager.Manager, *countingStore) {
 	t.Helper()
 	cs := &countingStore{Store: memstore.New()}
+	meta := parseMeta(t)
+	machines, err := statemachine.Compile(meta)
+	if err != nil {
+		t.Fatalf("statemachine.Compile: %v", err)
+	}
 	deps := entitymanager.Deps{
-		Store:     cs,
-		Meta:      parseMeta(t),
-		Templater: nopTemplater{},
-		Audit:     audit.Nop{},
-		ACL:       acl.NopACL{},
+		Store:       cs,
+		Meta:        meta,
+		Templater:   nopTemplater{},
+		Audit:       audit.Nop{},
+		ACL:         acl.NopACL{},
+		Transitions: machines,
 	}
 	if automations != nil {
 		engine := automation.NewEngine(automations)
-		runner, err := autocascade.New(autocascade.Deps{Engine: engine})
-		if err != nil {
-			t.Fatalf("autocascade.New: %v", err)
+		runner, rerr := autocascade.New(autocascade.Deps{Engine: engine})
+		if rerr != nil {
+			t.Fatalf("autocascade.New: %v", rerr)
 		}
 		deps.Automations = engine
 		deps.Cascade = runner
@@ -258,6 +265,20 @@ func TestNew_RejectsNilACL(t *testing.T) {
 	}
 }
 
+func TestNew_RejectsNilTransitions(t *testing.T) {
+	t.Parallel()
+	_, err := entitymanager.New(entitymanager.Deps{
+		Store:     memstore.New(),
+		Meta:      parseMeta(t),
+		Templater: nopTemplater{},
+		Audit:     audit.Nop{},
+		ACL:       acl.NopACL{},
+	})
+	if err == nil || !strings.Contains(err.Error(), "Transitions") {
+		t.Fatalf("expected Transitions-required error, got %v", err)
+	}
+}
+
 func TestNew_RejectsAutomationsWithoutCascade(t *testing.T) {
 	t.Parallel()
 	engine := automation.NewEngine(nil)
@@ -267,6 +288,7 @@ func TestNew_RejectsAutomationsWithoutCascade(t *testing.T) {
 		Templater:   nopTemplater{},
 		Audit:       audit.Nop{},
 		ACL:         acl.NopACL{},
+		Transitions: statemachine.EmptySet(),
 		Automations: engine,
 	})
 	if err == nil || !strings.Contains(err.Error(), "Automations and Cascade") {
@@ -277,11 +299,12 @@ func TestNew_RejectsAutomationsWithoutCascade(t *testing.T) {
 func TestNew_AllowsNoAutomation(t *testing.T) {
 	t.Parallel()
 	if _, err := entitymanager.New(entitymanager.Deps{
-		Store:     memstore.New(),
-		Meta:      parseMeta(t),
-		Templater: nopTemplater{},
-		Audit:     audit.Nop{},
-		ACL:       acl.NopACL{},
+		Store:       memstore.New(),
+		Meta:        parseMeta(t),
+		Templater:   nopTemplater{},
+		Audit:       audit.Nop{},
+		ACL:         acl.NopACL{},
+		Transitions: statemachine.EmptySet(),
 	}); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -606,6 +629,7 @@ func TestCreate_PassesManagerAsMutator(t *testing.T) {
 		Templater:    nopTemplater{},
 		Audit:        audit.Nop{},
 		ACL:          acl.NopACL{},
+		Transitions:  statemachine.EmptySet(),
 		Automations:  engine,
 		Cascade:      runner,
 		ScriptRunner: scripts,
@@ -918,11 +942,12 @@ func TestCreate_PropagatesNonConflictStoreError(t *testing.T) {
 	cs.remaining.Store(1)
 
 	mgr, err := entitymanager.New(entitymanager.Deps{
-		Store:     cs,
-		Meta:      parseMeta(t),
-		Templater: nopTemplater{},
-		Audit:     audit.Nop{},
-		ACL:       acl.NopACL{},
+		Store:       cs,
+		Meta:        parseMeta(t),
+		Templater:   nopTemplater{},
+		Audit:       audit.Nop{},
+		ACL:         acl.NopACL{},
+		Transitions: statemachine.EmptySet(),
 	})
 	if err != nil {
 		t.Fatalf("New: %v", err)
@@ -973,11 +998,12 @@ func TestCreate_SoftValidationProducesWarning(t *testing.T) {
 		t.Fatalf("metamodel.Parse: %v", err)
 	}
 	mgr, err := entitymanager.New(entitymanager.Deps{
-		Store:     memstore.New(),
-		Meta:      meta,
-		Templater: nopTemplater{},
-		Audit:     audit.Nop{},
-		ACL:       acl.NopACL{},
+		Store:       memstore.New(),
+		Meta:        meta,
+		Templater:   nopTemplater{},
+		Audit:       audit.Nop{},
+		ACL:         acl.NopACL{},
+		Transitions: statemachine.EmptySet(),
 	})
 	if err != nil {
 		t.Fatalf("New: %v", err)
@@ -1032,11 +1058,12 @@ func TestUpdate_SoftValidationProducesWarning(t *testing.T) {
 		t.Fatalf("metamodel.Parse: %v", err)
 	}
 	mgr, err := entitymanager.New(entitymanager.Deps{
-		Store:     memstore.New(),
-		Meta:      meta,
-		Templater: nopTemplater{},
-		Audit:     audit.Nop{},
-		ACL:       acl.NopACL{},
+		Store:       memstore.New(),
+		Meta:        meta,
+		Templater:   nopTemplater{},
+		Audit:       audit.Nop{},
+		ACL:         acl.NopACL{},
+		Transitions: statemachine.EmptySet(),
 	})
 	if err != nil {
 		t.Fatalf("New: %v", err)

--- a/internal/entitymanager/orderable_test.go
+++ b/internal/entitymanager/orderable_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Sourcehaven-BV/rela/internal/entity"
 	"github.com/Sourcehaven-BV/rela/internal/entitymanager"
 	"github.com/Sourcehaven-BV/rela/internal/metamodel"
+	"github.com/Sourcehaven-BV/rela/internal/statemachine"
 	"github.com/Sourcehaven-BV/rela/internal/store"
 	"github.com/Sourcehaven-BV/rela/internal/store/memstore"
 )
@@ -70,11 +71,12 @@ func newOrderableManagerWithAudit(t *testing.T, mode string) (*entitymanager.Man
 	st := memstore.New()
 	mem := audit.NewMemory()
 	deps := entitymanager.Deps{
-		Store:     st,
-		Meta:      orderableMetamodel(t, mode),
-		Templater: nopTemplater{},
-		Audit:     mem,
-		ACL:       acl.NopACL{},
+		Store:       st,
+		Meta:        orderableMetamodel(t, mode),
+		Templater:   nopTemplater{},
+		Audit:       mem,
+		ACL:         acl.NopACL{},
+		Transitions: statemachine.EmptySet(),
 	}
 	mgr, err := entitymanager.New(deps)
 	if err != nil {

--- a/internal/entitymanager/relation_version_hook_test.go
+++ b/internal/entitymanager/relation_version_hook_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/Sourcehaven-BV/rela/internal/entity"
 	"github.com/Sourcehaven-BV/rela/internal/entitymanager"
 	"github.com/Sourcehaven-BV/rela/internal/principal"
+	"github.com/Sourcehaven-BV/rela/internal/statemachine"
 	"github.com/Sourcehaven-BV/rela/internal/store"
 	"github.com/Sourcehaven-BV/rela/internal/store/memstore"
 )
@@ -34,6 +35,7 @@ func newRelationVersionManager(t *testing.T) (*entitymanager.Manager, *fakeRelat
 		Templater:               nopTemplater{},
 		Audit:                   audit.Nop{},
 		ACL:                     acl.NopACL{},
+		Transitions:             statemachine.EmptySet(),
 		RelationVersionRecorder: rec,
 	})
 	if err != nil {

--- a/internal/entitymanager/rename_acl_test.go
+++ b/internal/entitymanager/rename_acl_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Sourcehaven-BV/rela/internal/audit"
 	"github.com/Sourcehaven-BV/rela/internal/entity"
 	"github.com/Sourcehaven-BV/rela/internal/entitymanager"
+	"github.com/Sourcehaven-BV/rela/internal/statemachine"
 	"github.com/Sourcehaven-BV/rela/internal/store"
 	"github.com/Sourcehaven-BV/rela/internal/store/memstore"
 )
@@ -52,11 +53,12 @@ func TestRename_FailsClosedOnNonNotFoundFetchError(t *testing.T) {
 	// proceed without ever consulting the ACL. With the fix the fetch
 	// error short-circuits before either the ACL or the rename run.
 	deps := entitymanager.Deps{
-		Store:     st,
-		Meta:      parseMeta(t),
-		Templater: nopTemplater{},
-		Audit:     audit.Nop{},
-		ACL:       acl.ReadOnlyACL{},
+		Store:       st,
+		Meta:        parseMeta(t),
+		Templater:   nopTemplater{},
+		Audit:       audit.Nop{},
+		ACL:         acl.ReadOnlyACL{},
+		Transitions: statemachine.EmptySet(),
 	}
 	mgr, err := entitymanager.New(deps)
 	if err != nil {

--- a/internal/entitymanager/transition_test.go
+++ b/internal/entitymanager/transition_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Sourcehaven-BV/rela/internal/entitymanager"
 	"github.com/Sourcehaven-BV/rela/internal/metamodel"
 	"github.com/Sourcehaven-BV/rela/internal/statemachine"
+	"github.com/Sourcehaven-BV/rela/internal/store"
 	"github.com/Sourcehaven-BV/rela/internal/store/memstore"
 )
 
@@ -146,4 +147,74 @@ func TestTransition_LegalEntryOnCreatePasses(t *testing.T) {
 	seedSnapshot(t, mgr, "in-review")
 	// Absent is fine (default applies).
 	seedSnapshot(t, mgr, "")
+}
+
+// RR-NB135: the sync/upsert path (ApplyEntity) must enforce transitions too —
+// it is a served write path and must not be a bypass.
+func TestTransition_ApplyEntity_EnforcesLegality(t *testing.T) {
+	mgr := newTransitionManager(t, allowAllGuard{})
+	snap := seedSnapshot(t, mgr, "") // in-review
+
+	// A sync-apply that skips approved (in-review→established) must be rejected.
+	snap.SetString("status", "established")
+	_, err := mgr.ApplyEntity(context.Background(), snap)
+	if !errors.Is(err, statemachine.ErrIllegalTransition) {
+		t.Fatalf("ApplyEntity must enforce legality; want ErrIllegalTransition, got %v", err)
+	}
+}
+
+func TestTransition_ApplyEntity_EnforcesGuard(t *testing.T) {
+	mgr := newTransitionManager(t, denyAllGuard{})
+	snap := seedSnapshot(t, mgr, "") // in-review
+
+	snap.SetString("status", "approved") // legal edge, guard denied
+	_, err := mgr.ApplyEntity(context.Background(), snap)
+	var fe *acl.ForbiddenError
+	if !errors.As(err, &fe) {
+		t.Fatalf("ApplyEntity guard denial must be *acl.ForbiddenError (403), got %v", err)
+	}
+	if fe.Decision.RuleID != "approve" {
+		t.Errorf("RuleID = %q, want the permission name 'approve'", fe.Decision.RuleID)
+	}
+}
+
+// RR-HETEE: a rejected illegal-entry create must NOT persist a row.
+func TestTransition_IllegalEntry_DoesNotPersist(t *testing.T) {
+	meta, err := metamodel.Parse([]byte(transitionMetaYAML))
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	machines, err := statemachine.Compile(meta)
+	if err != nil {
+		t.Fatalf("Compile: %v", err)
+	}
+	st := memstore.New()
+	mgr, err := entitymanager.New(entitymanager.Deps{
+		Store:           st,
+		Meta:            meta,
+		Templater:       nopTemplater{},
+		Audit:           audit.Nop{},
+		ACL:             acl.NopACL{},
+		Transitions:     machines,
+		TransitionGuard: allowAllGuard{},
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	e := entity.New("", "snapshot")
+	e.SetString("title", "bad")
+	e.SetString("status", "established") // illegal entry
+	if _, err := mgr.CreateEntity(context.Background(), e, entity.CreateOptions{}); !errors.Is(err, statemachine.ErrIllegalEntry) {
+		t.Fatalf("want ErrIllegalEntry, got %v", err)
+	}
+	// No snapshot row must exist — the check runs before the store write, so a
+	// rejected illegal entry never persists (and thus never emits a store event).
+	count := 0
+	for range st.ListEntities(context.Background(), store.EntityQuery{Type: "snapshot"}) {
+		count++
+	}
+	if count != 0 {
+		t.Fatalf("illegal-entry create persisted %d row(s) (RR-HETEE regression)", count)
+	}
 }

--- a/internal/entitymanager/transition_test.go
+++ b/internal/entitymanager/transition_test.go
@@ -1,0 +1,149 @@
+package entitymanager_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/Sourcehaven-BV/rela/internal/acl"
+	"github.com/Sourcehaven-BV/rela/internal/audit"
+	"github.com/Sourcehaven-BV/rela/internal/entity"
+	"github.com/Sourcehaven-BV/rela/internal/entitymanager"
+	"github.com/Sourcehaven-BV/rela/internal/metamodel"
+	"github.com/Sourcehaven-BV/rela/internal/statemachine"
+	"github.com/Sourcehaven-BV/rela/internal/store/memstore"
+)
+
+// transitionMetaYAML defines a snapshot type whose status is a state machine.
+const transitionMetaYAML = `version: "1.0"
+entities:
+  snapshot:
+    label: Snapshot
+    plural: snapshots
+    id_prefix: "SNAP-"
+    id_type: sequential
+    properties:
+      title:
+        type: string
+      status:
+        type: snapshot-status
+types:
+  snapshot-status:
+    values: [in-review, approved, established, obsolete]
+    initial: in-review
+    transitions:
+      - from: in-review
+        to: approved
+        guard: approve
+      - from: approved
+        to: established
+        guard: establish
+`
+
+// allowAllGuard grants every permission; denyAllGuard grants none.
+type allowAllGuard struct{}
+
+func (allowAllGuard) HoldsPermission(context.Context, string, string) bool { return true }
+
+type denyAllGuard struct{}
+
+func (denyAllGuard) HoldsPermission(context.Context, string, string) bool { return false }
+
+func newTransitionManager(t *testing.T, guard statemachine.Guard) *entitymanager.Manager {
+	t.Helper()
+	meta, err := metamodel.Parse([]byte(transitionMetaYAML))
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	machines, err := statemachine.Compile(meta)
+	if err != nil {
+		t.Fatalf("Compile: %v", err)
+	}
+	mgr, err := entitymanager.New(entitymanager.Deps{
+		Store:           memstore.New(),
+		Meta:            meta,
+		Templater:       nopTemplater{},
+		Audit:           audit.Nop{},
+		ACL:             acl.NopACL{},
+		Transitions:     machines,
+		TransitionGuard: guard,
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	return mgr
+}
+
+func seedSnapshot(t *testing.T, mgr *entitymanager.Manager, status string) *entity.Entity {
+	t.Helper()
+	e := entity.New("", "snapshot")
+	e.SetString("title", "Q3 register")
+	if status != "" {
+		e.SetString("status", status)
+	}
+	res, err := mgr.CreateEntity(context.Background(), e, entity.CreateOptions{})
+	if err != nil {
+		t.Fatalf("seed create(status=%q): %v", status, err)
+	}
+	return res.Entity
+}
+
+func TestTransition_LegalMovePasses(t *testing.T) {
+	mgr := newTransitionManager(t, allowAllGuard{})
+	snap := seedSnapshot(t, mgr, "") // enters at initial in-review
+
+	snap.SetString("status", "approved")
+	if _, err := mgr.UpdateEntity(context.Background(), snap); err != nil {
+		t.Fatalf("legal in-review→approved rejected: %v", err)
+	}
+}
+
+func TestTransition_IllegalMoveIs422(t *testing.T) {
+	mgr := newTransitionManager(t, allowAllGuard{})
+	snap := seedSnapshot(t, mgr, "")
+
+	snap.SetString("status", "established") // skips approved
+	_, err := mgr.UpdateEntity(context.Background(), snap)
+	if !errors.Is(err, statemachine.ErrIllegalTransition) {
+		t.Fatalf("expected ErrIllegalTransition, got %v", err)
+	}
+	// An illegal transition is NOT an ACL denial — it must not surface as 403.
+	var fe *acl.ForbiddenError
+	if errors.As(err, &fe) {
+		t.Fatal("illegal transition must not map to a ForbiddenError (403)")
+	}
+}
+
+func TestTransition_GuardDeniedIs403(t *testing.T) {
+	mgr := newTransitionManager(t, denyAllGuard{})
+	snap := seedSnapshot(t, mgr, "")
+
+	snap.SetString("status", "approved") // legal edge, but guard "approve" denied
+	_, err := mgr.UpdateEntity(context.Background(), snap)
+	var fe *acl.ForbiddenError
+	if !errors.As(err, &fe) {
+		t.Fatalf("expected *acl.ForbiddenError (403), got %v", err)
+	}
+	if fe.Decision.RuleKind != "transition-guard" {
+		t.Errorf("RuleKind = %q, want transition-guard", fe.Decision.RuleKind)
+	}
+}
+
+func TestTransition_IllegalEntryOnCreateIs422(t *testing.T) {
+	mgr := newTransitionManager(t, allowAllGuard{})
+	e := entity.New("", "snapshot")
+	e.SetString("title", "bad entry")
+	e.SetString("status", "established") // not the initial value
+	_, err := mgr.CreateEntity(context.Background(), e, entity.CreateOptions{})
+	if !errors.Is(err, statemachine.ErrIllegalEntry) {
+		t.Fatalf("expected ErrIllegalEntry, got %v", err)
+	}
+}
+
+func TestTransition_LegalEntryOnCreatePasses(t *testing.T) {
+	mgr := newTransitionManager(t, allowAllGuard{})
+	// Explicit initial value is fine.
+	seedSnapshot(t, mgr, "in-review")
+	// Absent is fine (default applies).
+	seedSnapshot(t, mgr, "")
+}

--- a/internal/entitymanager/unique_test.go
+++ b/internal/entitymanager/unique_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Sourcehaven-BV/rela/internal/entity"
 	"github.com/Sourcehaven-BV/rela/internal/entitymanager"
 	"github.com/Sourcehaven-BV/rela/internal/metamodel"
+	"github.com/Sourcehaven-BV/rela/internal/statemachine"
 	"github.com/Sourcehaven-BV/rela/internal/store/memstore"
 )
 
@@ -47,11 +48,12 @@ func newUniqueManager(t *testing.T) *entitymanager.Manager {
 		t.Fatalf("metamodel.Parse: %v", err)
 	}
 	mgr, err := entitymanager.New(entitymanager.Deps{
-		Store:     memstore.New(),
-		Meta:      meta,
-		Templater: nopTemplater{},
-		Audit:     audit.Nop{},
-		ACL:       acl.NopACL{},
+		Store:       memstore.New(),
+		Meta:        meta,
+		Templater:   nopTemplater{},
+		Audit:       audit.Nop{},
+		ACL:         acl.NopACL{},
+		Transitions: statemachine.EmptySet(),
 	})
 	if err != nil {
 		t.Fatalf("entitymanager.New: %v", err)
@@ -79,6 +81,7 @@ func newUniqueManagerWithAutomation(t *testing.T, autos []automation.Automation)
 		Templater:   nopTemplater{},
 		Audit:       audit.Nop{},
 		ACL:         acl.NopACL{},
+		Transitions: statemachine.EmptySet(),
 		Automations: engine,
 		Cascade:     runner,
 	})

--- a/internal/entitymanager/version_hook_test.go
+++ b/internal/entitymanager/version_hook_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/Sourcehaven-BV/rela/internal/entity"
 	"github.com/Sourcehaven-BV/rela/internal/entitymanager"
 	"github.com/Sourcehaven-BV/rela/internal/principal"
+	"github.com/Sourcehaven-BV/rela/internal/statemachine"
 	"github.com/Sourcehaven-BV/rela/internal/store"
 	"github.com/Sourcehaven-BV/rela/internal/store/memstore"
 )
@@ -32,6 +33,7 @@ func newVersionManager(t *testing.T) (*entitymanager.Manager, *fakeRecorder) {
 		Templater:       nopTemplater{},
 		Audit:           audit.Nop{},
 		ACL:             acl.NopACL{},
+		Transitions:     statemachine.EmptySet(),
 		VersionRecorder: rec,
 	})
 	if err != nil {

--- a/internal/metamodel/types.go
+++ b/internal/metamodel/types.go
@@ -134,6 +134,41 @@ type CustomType struct {
 	Default     string            `yaml:"default,omitempty"`     // Default value
 	Description string            `yaml:"description,omitempty"` // Documentation for the type
 	Validations []TypeValidation  `yaml:"validations,omitempty"` // Regex validations with error messages
+
+	// Transitions declares the legal value→value moves for this enum,
+	// making it a state machine (TKT-E4LW2). This is declarative source
+	// data only — the metamodel does not enforce it. At startup
+	// internal/statemachine.Compile reads these into an executable machine
+	// that the entitymanager runs on the write path (legality 422, guard
+	// 403, precondition 422). Empty means "any value may change to any
+	// other" (the historical, unconstrained behavior). Only meaningful on a
+	// named type — inline `type: enum` properties carry no transitions.
+	Transitions []TransitionDef `yaml:"transitions,omitempty"`
+
+	// Initial names the only legal entry value on entity create when this
+	// type is a state machine. Empty falls back to Default. Consumed by
+	// internal/statemachine at compile time.
+	Initial string `yaml:"initial,omitempty"`
+}
+
+// TransitionDef is one edge in an enum state machine: a legal move from one
+// value to another, optionally gated by an ACL permission (Guard) and/or a
+// data precondition (When). This is declarative source data; the executable
+// machine is built from it by internal/statemachine.Compile.
+type TransitionDef struct {
+	From string `yaml:"from"` // Source value; must be one of CustomType.Values
+	To   string `yaml:"to"`   // Target value; must be one of CustomType.Values
+
+	// Guard names an ACL permission the acting principal must hold for this
+	// transition. Enforced only on served paths (a principal exists); inert
+	// on direct CLI writes. Empty means the transition is legal for anyone
+	// who may otherwise write the entity.
+	Guard string `yaml:"guard,omitempty"`
+
+	// When is an internal/predicate expression evaluated as a precondition
+	// against the entity + graph at write time. False rejects the transition
+	// (422). Empty means no precondition.
+	When string `yaml:"when,omitempty"`
 }
 
 // EntityDef defines an entity type in the metamodel

--- a/internal/statemachine/compile.go
+++ b/internal/statemachine/compile.go
@@ -49,13 +49,26 @@ func Compile(meta *metamodel.Metamodel) (*Set, error) {
 	// consulting the metamodel again.
 	for _, etName := range sortedKeys(meta.Entities) {
 		et := meta.Entities[etName]
-		for propName, pd := range et.Properties {
-			if _, ok := set.machines[pd.Type]; ok {
-				if set.propType[etName] == nil {
-					set.propType[etName] = map[string]string{}
-				}
-				set.propType[etName][propName] = pd.Type
+		for _, propName := range sortedKeys(et.Properties) {
+			pd := et.Properties[propName]
+			if _, ok := set.machines[pd.Type]; !ok {
+				continue
 			}
+			// A state machine is a single-valued lifecycle; a list-typed
+			// property has no single "current value" to transition (Enforce
+			// reads it via GetString, which would flatten the list to a
+			// coincidental scalar). Reject at boot rather than mis-enforce
+			// (RR-F30CZ/N4).
+			if pd.List {
+				problems = append(problems, fmt.Sprintf(
+					"entity %q property %q: type %q declares transitions but the property is a list; "+
+						"state machines require a single-valued property", etName, propName, pd.Type))
+				continue
+			}
+			if set.propType[etName] == nil {
+				set.propType[etName] = map[string]string{}
+			}
+			set.propType[etName][propName] = pd.Type
 		}
 	}
 
@@ -75,14 +88,20 @@ func compileMachine(typeName string, ct metamodel.CustomType) (machine *Machine,
 		values[v] = true
 	}
 
-	// Entry value: Initial if set, else Default. Must be a declared value.
+	// Entry value: Initial if set, else Default. Whichever supplies it must be
+	// a declared value — validate the RESOLVED entry, not just Initial, so a
+	// typo'd Default-as-entry fails fast at boot too (RR-VB2DE).
 	entry := ct.Initial
 	if entry == "" {
 		entry = ct.Default
 	}
-	if ct.Initial != "" && !values[ct.Initial] {
+	if entry != "" && !values[entry] {
+		source := "initial"
+		if ct.Initial == "" {
+			source = "default"
+		}
 		problems = append(problems, fmt.Sprintf(
-			"type %q: initial %q is not a declared value", typeName, ct.Initial))
+			"type %q: %s %q is not a declared value", typeName, source, entry))
 	}
 
 	env, err := buildEnv(ct)

--- a/internal/statemachine/compile.go
+++ b/internal/statemachine/compile.go
@@ -1,0 +1,121 @@
+package statemachine
+
+import (
+	"errors"
+	"fmt"
+	"sort"
+
+	"github.com/Sourcehaven-BV/rela/internal/metamodel"
+	"github.com/Sourcehaven-BV/rela/internal/predicate"
+)
+
+// Compile builds the executable state-machine [Set] from a metamodel's
+// declarative transitions. It runs once at startup. It returns an error
+// (aggregating every problem found) if any machine is malformed — a dangling
+// from/to/initial, or a `when:` predicate that fails to compile — so a bad
+// metamodel is rejected at boot, not at write time.
+//
+// A metamodel with no transitions compiles to an empty [Set]; [Set.Enforce] is
+// then a no-op and every write behaves exactly as it did before this feature.
+//
+// meta must not be nil (a required input from appbuild).
+func Compile(meta *metamodel.Metamodel) (*Set, error) {
+	if meta == nil {
+		return nil, errors.New("statemachine: Compile: nil metamodel")
+	}
+
+	set := &Set{
+		machines: map[string]*Machine{},
+		propType: map[string]map[string]string{},
+	}
+	var problems []string
+
+	// Build one machine per state-machine custom type, in name order so the
+	// error report and the compiled env are deterministic.
+	for _, typeName := range sortedKeys(meta.Types) {
+		ct := meta.Types[typeName]
+		if len(ct.Transitions) == 0 {
+			continue // not a machine
+		}
+		m, errs := compileMachine(typeName, ct)
+		problems = append(problems, errs...)
+		if m != nil {
+			set.machines[typeName] = m
+		}
+	}
+
+	// Index which (entity type, property) pairs are state machines, so Enforce
+	// can find the machine-typed properties of a written entity without
+	// consulting the metamodel again.
+	for _, etName := range sortedKeys(meta.Entities) {
+		et := meta.Entities[etName]
+		for propName, pd := range et.Properties {
+			if _, ok := set.machines[pd.Type]; ok {
+				if set.propType[etName] == nil {
+					set.propType[etName] = map[string]string{}
+				}
+				set.propType[etName][propName] = pd.Type
+			}
+		}
+	}
+
+	if len(problems) > 0 {
+		sort.Strings(problems)
+		return nil, fmt.Errorf("statemachine: invalid transitions:\n  %s", joinLines(problems))
+	}
+	return set, nil
+}
+
+// compileMachine builds one machine and returns it plus any well-formedness
+// problems. A machine with fatal problems still returns a (partial) machine so
+// indexing proceeds, but Compile aggregates the problems into a boot error.
+func compileMachine(typeName string, ct metamodel.CustomType) (machine *Machine, problems []string) {
+	values := map[string]bool{}
+	for _, v := range ct.Values {
+		values[v] = true
+	}
+
+	// Entry value: Initial if set, else Default. Must be a declared value.
+	entry := ct.Initial
+	if entry == "" {
+		entry = ct.Default
+	}
+	if ct.Initial != "" && !values[ct.Initial] {
+		problems = append(problems, fmt.Sprintf(
+			"type %q: initial %q is not a declared value", typeName, ct.Initial))
+	}
+
+	env, err := buildEnv(ct)
+	if err != nil {
+		problems = append(problems, fmt.Sprintf("type %q: %v", typeName, err))
+	}
+
+	edges := map[transitionKey]edge{}
+	for i, tr := range ct.Transitions {
+		if !values[tr.From] {
+			problems = append(problems, fmt.Sprintf(
+				"type %q: transition[%d] from %q is not a declared value", typeName, i, tr.From))
+		}
+		if !values[tr.To] {
+			problems = append(problems, fmt.Sprintf(
+				"type %q: transition[%d] to %q is not a declared value", typeName, i, tr.To))
+		}
+		key := transitionKey{tr.From, tr.To}
+		if _, dup := edges[key]; dup {
+			problems = append(problems, fmt.Sprintf(
+				"type %q: transition[%d] %s→%s is declared more than once", typeName, i, tr.From, tr.To))
+		}
+
+		var prog *predicate.Program
+		if tr.When != "" && env != nil {
+			prog, err = predicate.Compile(env, tr.When)
+			if err != nil {
+				problems = append(problems, fmt.Sprintf(
+					"type %q: transition[%d] %s→%s when: %v", typeName, i, tr.From, tr.To, err))
+			}
+		}
+		edges[key] = edge{guard: tr.Guard, when: prog}
+	}
+
+	return &Machine{name: typeName, edges: edges, entry: entry}, problems
+}

--- a/internal/statemachine/enforce.go
+++ b/internal/statemachine/enforce.go
@@ -1,0 +1,110 @@
+package statemachine
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/Sourcehaven-BV/rela/internal/entity"
+)
+
+// EnforceUpdate checks every state-machine property that changed between old and
+// new, in property-name order for deterministic errors. For each changed
+// machine property it applies, in order: legality (declared edge), guard, and
+// the `when:` precondition. The first failure returns a wrapped sentinel; a nil
+// return means every changed machine property made a legal, authorized,
+// precondition-satisfying move (or nothing machine-typed changed).
+//
+// The guard's served/inert behavior is the guard's own concern: [Guard]
+// resolves the acting principal from ctx and returns true (allow) when there is
+// no principal/policy to evaluate — so on a direct CLI write with no policy the
+// guard is inert while legality and preconditions still apply. Passing a nil
+// guard makes every guarded edge fail closed.
+//
+// old and updated are the same entity's prior and post-write state; updated
+// must be non-nil. Use [Set.EnforceCreate] for creates (no prior state).
+func (s *Set) EnforceUpdate(ctx context.Context, old, updated *entity.Entity, guard Guard, lookup GraphLookup) error {
+	if s.Empty() || updated == nil {
+		return nil
+	}
+	props := s.propType[updated.Type]
+	if len(props) == 0 {
+		return nil
+	}
+
+	for _, prop := range sortedKeys(props) {
+		m := s.machines[props[prop]]
+		from := ""
+		if old != nil {
+			from = old.GetString(prop)
+		}
+		to := updated.GetString(prop)
+		if from == to {
+			continue // property did not change
+		}
+		if err := s.applyEdge(ctx, m, prop, from, to, updated, guard, lookup); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// EnforceCreate checks the entry value of every state-machine property on a
+// newly created entity. A create has no prior state, so there is no edge to
+// traverse; the only rule is that a machine property must enter at its entry
+// value (Initial, else Default). A machine with no entry value (neither set)
+// imposes no constraint. Guards do not apply on create-entry in this first cut
+// (the entry itself is not a guarded edge — see the ticket's deferred
+// alternative).
+func (s *Set) EnforceCreate(_ context.Context, e *entity.Entity) error {
+	if s.Empty() || e == nil {
+		return nil
+	}
+	props := s.propType[e.Type]
+	for _, prop := range sortedKeys(props) {
+		m := s.machines[props[prop]]
+		if m.entry == "" {
+			continue // unconstrained entry
+		}
+		got := e.GetString(prop)
+		if got == "" {
+			continue // absent → the default applies elsewhere; not an illegal entry
+		}
+		if got != m.entry {
+			return fmt.Errorf("%w: %s=%q on create; must enter at %q",
+				ErrIllegalEntry, prop, got, m.entry)
+		}
+	}
+	return nil
+}
+
+// applyEdge runs the three checks for one changed machine property.
+func (s *Set) applyEdge(
+	ctx context.Context, m *Machine, prop, from, to string, e *entity.Entity, guard Guard, lookup GraphLookup,
+) error {
+	ed, ok := m.edgeFor(from, to)
+	if !ok {
+		return fmt.Errorf("%w: %s %q→%q is not a declared transition", ErrIllegalTransition, prop, from, to)
+	}
+
+	// Guard: the guard decides served-vs-inert (it resolves the principal from
+	// ctx and allows when there is nothing to evaluate). A nil guard on a
+	// guarded edge fails closed.
+	if ed.guard != "" {
+		if guard == nil || !guard.HoldsPermission(ctx, e.ID, ed.guard) {
+			return fmt.Errorf("%w: %s %q→%q requires permission %q",
+				ErrGuardDenied, prop, from, to, ed.guard)
+		}
+	}
+
+	// Precondition.
+	if ed.when != nil {
+		ok, err := evalWhen(ctx, ed.when, e, lookup)
+		if err != nil {
+			return fmt.Errorf("%w: %s %q→%q when: %s", ErrPreconditionFailed, prop, from, to, err.Error())
+		}
+		if !ok {
+			return fmt.Errorf("%w: %s %q→%q precondition not met", ErrPreconditionFailed, prop, from, to)
+		}
+	}
+	return nil
+}

--- a/internal/statemachine/enforce.go
+++ b/internal/statemachine/enforce.go
@@ -91,14 +91,13 @@ func (s *Set) applyEdge(
 	// guarded edge fails closed.
 	if ed.guard != "" {
 		if guard == nil || !guard.HoldsPermission(ctx, e.ID, ed.guard) {
-			return fmt.Errorf("%w: %s %q→%q requires permission %q",
-				ErrGuardDenied, prop, from, to, ed.guard)
+			return &GuardError{Prop: prop, From: from, To: to, Permission: ed.guard}
 		}
 	}
 
 	// Precondition.
 	if ed.when != nil {
-		ok, err := evalWhen(ctx, ed.when, e, lookup)
+		ok, err := evalWhen(ctx, ed.when, e, prop, lookup)
 		if err != nil {
 			return fmt.Errorf("%w: %s %q→%q when: %s", ErrPreconditionFailed, prop, from, to, err.Error())
 		}

--- a/internal/statemachine/predicate.go
+++ b/internal/statemachine/predicate.go
@@ -1,0 +1,141 @@
+package statemachine
+
+import (
+	"context"
+	"sort"
+	"strings"
+
+	"github.com/Sourcehaven-BV/rela/internal/entity"
+	"github.com/Sourcehaven-BV/rela/internal/metamodel"
+	"github.com/Sourcehaven-BV/rela/internal/predicate"
+)
+
+// buildEnv constructs the predicate environment a machine's `when:` expressions
+// compile and evaluate against. The surface is intentionally small: an `entity`
+// record (id, type, and this machine's own value are the useful fields) plus the
+// two graph host functions has_relation / count_relations. This mirrors the
+// affordances env but carries no user/role vars — a transition precondition is a
+// data check, not authorization (authorization is the guard).
+func buildEnv(_ metamodel.CustomType) (*predicate.Env, error) {
+	env := predicate.NewEnv()
+
+	entityRec := predicate.RecordType{
+		"id":     predicate.StringType,
+		"type":   predicate.StringType,
+		"status": predicate.StringType,
+	}
+	if err := env.DeclareVar("entity", entityRec); err != nil {
+		return nil, err
+	}
+
+	rec := predicate.RecordType{}
+	str := predicate.StringType
+	num := predicate.NumberType
+	boolT := predicate.BoolType
+	funcs := []struct {
+		name string
+		sig  predicate.FuncSig
+	}{
+		{"has_relation", predicate.FuncSig{Params: []predicate.Type{rec, str}, Return: boolT}},
+		{"count_relations", predicate.FuncSig{Params: []predicate.Type{rec, str}, Return: num}},
+	}
+	for _, f := range funcs {
+		if err := env.DeclareFunc(f.name, f.sig); err != nil {
+			return nil, err
+		}
+	}
+	return env, nil
+}
+
+// evalWhen evaluates a compiled precondition against the written entity and the
+// graph. Returns true if the precondition holds (or is absent). A graph lookup
+// is required for has_relation/count_relations; if the predicate references
+// them and lookup is nil, evaluation errors (surfaced by the caller as a
+// precondition failure) rather than silently passing.
+func evalWhen(ctx context.Context, prog *predicate.Program, e *entity.Entity, lookup GraphLookup) (bool, error) {
+	b := predicate.NewBindings()
+	if err := b.SetVar("entity", entityRecord(e)); err != nil {
+		return false, err
+	}
+	gb := &graphBindings{entityID: e.ID, lookup: lookup}
+	if err := b.SetFunc("has_relation", predicate.FuncFunc(gb.hasRelation)); err != nil {
+		return false, err
+	}
+	if err := b.SetFunc("count_relations", predicate.FuncFunc(gb.countRelations)); err != nil {
+		return false, err
+	}
+
+	v, err := prog.Eval(ctx, b)
+	if err != nil {
+		return false, err
+	}
+	bv, ok := v.(predicate.Bool)
+	if !ok {
+		return false, nil
+	}
+	return bv.Bool(), nil
+}
+
+// entityRecord coerces an entity into the predicate record the `when:` env
+// expects. Only id/type/status are surfaced; missing values bind as empty
+// strings.
+func entityRecord(e *entity.Entity) predicate.Value {
+	return predicate.NewRecord(map[string]predicate.Value{
+		"id":     predicate.NewString(e.ID),
+		"type":   predicate.NewString(e.Type),
+		"status": predicate.NewString(e.GetString("status")),
+	})
+}
+
+// graphBindings supplies has_relation / count_relations for one evaluation,
+// scanning the graph at most once via the lookup.
+type graphBindings struct {
+	entityID string
+	lookup   GraphLookup
+
+	counts map[string]int
+	ready  bool
+}
+
+func (g *graphBindings) outgoing(ctx context.Context) map[string]int {
+	if !g.ready {
+		if g.lookup != nil {
+			g.counts = g.lookup.OutgoingCounts(ctx, g.entityID)
+		}
+		g.ready = true
+	}
+	return g.counts
+}
+
+func (g *graphBindings) hasRelation(ctx context.Context, args []predicate.Value) (predicate.Value, error) {
+	relType := stringArg(args, 1)
+	return predicate.NewBool(g.outgoing(ctx)[relType] > 0), nil
+}
+
+func (g *graphBindings) countRelations(ctx context.Context, args []predicate.Value) (predicate.Value, error) {
+	relType := stringArg(args, 1)
+	return predicate.NewNumber(float64(g.outgoing(ctx)[relType])), nil
+}
+
+// stringArg reads the i-th arg as a string, "" if absent/wrong type.
+func stringArg(args []predicate.Value, i int) string {
+	if i >= len(args) {
+		return ""
+	}
+	if s, ok := args[i].(predicate.String); ok {
+		return s.String()
+	}
+	return ""
+}
+
+// sortedKeys returns the map keys sorted, for deterministic iteration.
+func sortedKeys[V any](m map[string]V) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func joinLines(ss []string) string { return strings.Join(ss, "\n  ") }

--- a/internal/statemachine/predicate.go
+++ b/internal/statemachine/predicate.go
@@ -19,10 +19,14 @@ import (
 func buildEnv(_ metamodel.CustomType) (*predicate.Env, error) {
 	env := predicate.NewEnv()
 
+	// `entity.value` is the machine property's OWN current value, bound
+	// independently of what that property is named (RR-NODYR — the old
+	// hardcoded `status` field misbehaved for machines on other-named
+	// properties). id/type are the stable pseudo-fields.
 	entityRec := predicate.RecordType{
-		"id":     predicate.StringType,
-		"type":   predicate.StringType,
-		"status": predicate.StringType,
+		"id":    predicate.StringType,
+		"type":  predicate.StringType,
+		"value": predicate.StringType,
 	}
 	if err := env.DeclareVar("entity", entityRec); err != nil {
 		return nil, err
@@ -52,9 +56,11 @@ func buildEnv(_ metamodel.CustomType) (*predicate.Env, error) {
 // is required for has_relation/count_relations; if the predicate references
 // them and lookup is nil, evaluation errors (surfaced by the caller as a
 // precondition failure) rather than silently passing.
-func evalWhen(ctx context.Context, prog *predicate.Program, e *entity.Entity, lookup GraphLookup) (bool, error) {
+func evalWhen(
+	ctx context.Context, prog *predicate.Program, e *entity.Entity, prop string, lookup GraphLookup,
+) (bool, error) {
 	b := predicate.NewBindings()
-	if err := b.SetVar("entity", entityRecord(e)); err != nil {
+	if err := b.SetVar("entity", entityRecord(e, prop)); err != nil {
 		return false, err
 	}
 	gb := &graphBindings{entityID: e.ID, lookup: lookup}
@@ -77,13 +83,13 @@ func evalWhen(ctx context.Context, prog *predicate.Program, e *entity.Entity, lo
 }
 
 // entityRecord coerces an entity into the predicate record the `when:` env
-// expects. Only id/type/status are surfaced; missing values bind as empty
-// strings.
-func entityRecord(e *entity.Entity) predicate.Value {
+// expects: id, type, and `value` = the machine property's own current value
+// (read from prop, whatever it is named). Missing values bind as empty strings.
+func entityRecord(e *entity.Entity, prop string) predicate.Value {
 	return predicate.NewRecord(map[string]predicate.Value{
-		"id":     predicate.NewString(e.ID),
-		"type":   predicate.NewString(e.Type),
-		"status": predicate.NewString(e.GetString("status")),
+		"id":    predicate.NewString(e.ID),
+		"type":  predicate.NewString(e.Type),
+		"value": predicate.NewString(e.GetString(prop)),
 	})
 }
 

--- a/internal/statemachine/statemachine.go
+++ b/internal/statemachine/statemachine.go
@@ -36,6 +36,7 @@ package statemachine
 import (
 	"context"
 	"errors"
+	"fmt"
 
 	"github.com/Sourcehaven-BV/rela/internal/predicate"
 )
@@ -55,6 +56,25 @@ var (
 	// other than the machine's entry value.
 	ErrIllegalEntry = errors.New("illegal entry state")
 )
+
+// GuardError is returned (wrapping [ErrGuardDenied]) when an edge's guard
+// permission is not held. It carries the Permission so a caller mapping the
+// denial to an authorization response can name the specific right in a
+// queryable field rather than parsing the message (RR-F30CZ/N1).
+type GuardError struct {
+	Prop       string
+	From, To   string
+	Permission string
+}
+
+func (e *GuardError) Error() string {
+	return fmt.Sprintf("%s: %s %q→%q requires permission %q",
+		ErrGuardDenied.Error(), e.Prop, e.From, e.To, e.Permission)
+}
+
+// Unwrap ties GuardError to the ErrGuardDenied sentinel so errors.Is keeps
+// working.
+func (e *GuardError) Unwrap() error { return ErrGuardDenied }
 
 // Guard is the narrow permission oracle the enforcer needs to gate a
 // transition. Defined at the consumer (CLAUDE.md "interfaces at the call

--- a/internal/statemachine/statemachine.go
+++ b/internal/statemachine/statemachine.go
@@ -1,0 +1,131 @@
+// Package statemachine compiles the declarative enum state machines in a
+// metamodel (CustomType.Transitions, see TKT-E4LW2) into an executable form
+// and enforces them on the entity write path.
+//
+// # Two phases, cleanly split
+//
+// Compile runs ONCE at startup (from appbuild), turning the metamodel's
+// declarative transition data into a [Set] of ready-to-run [Machine]s: edge
+// lookups are indexed, `when:` predicates are compiled, and load-time
+// well-formedness is checked (dangling from/to/initial, bad predicate syntax)
+// so a malformed machine fails fast at boot, never at write time. Nothing here
+// consults the metamodel again after Compile.
+//
+// [Set.Enforce] runs on every entity write (from entitymanager, a required
+// collaborator in the fixed write pipeline — as unforgettable as validation and
+// audit). Given (old, new, principal) it finds every changed state-machine
+// property, and for each:
+//
+//   - legality: the (from,to) move must be a declared edge, else [ErrIllegalTransition] (422);
+//   - guard:    on a served path (a principal is present), the edge's guard
+//     permission must be held for the subject, checked via the injected [Guard]
+//     — else [ErrGuardDenied] (403);
+//   - when:     the edge's compiled precondition must hold, else [ErrPreconditionFailed] (422).
+//
+// # Why this shape
+//
+// The machines are built from the metamodel at boot and injected; the write
+// path never re-derives them. This keeps `metamodel` a pure declarative source
+// (it gains data, not behavior) and keeps `acl` a pure permission oracle (it
+// answers "does principal hold permission P for subject S" and knows nothing
+// about state machines). The enforcer owns old-vs-new and the transition
+// semantics; it merely *asks* the ACL a permission question whose permission
+// name comes from its own compiled edge.
+package statemachine
+
+import (
+	"context"
+	"errors"
+
+	"github.com/Sourcehaven-BV/rela/internal/predicate"
+)
+
+// Sentinel errors classify an enforcement failure so entitymanager can map
+// each to the right status (422 legality/precondition, 403 guard). They wrap
+// with %w so callers use errors.Is.
+var (
+	// ErrIllegalTransition means the (from,to) move is not a declared edge.
+	ErrIllegalTransition = errors.New("illegal transition")
+	// ErrGuardDenied means the acting principal lacks the edge's guard
+	// permission for the subject (served path only).
+	ErrGuardDenied = errors.New("transition guard denied")
+	// ErrPreconditionFailed means the edge's `when:` predicate evaluated false.
+	ErrPreconditionFailed = errors.New("transition precondition failed")
+	// ErrIllegalEntry means a create set a state-machine property to a value
+	// other than the machine's entry value.
+	ErrIllegalEntry = errors.New("illegal entry state")
+)
+
+// Guard is the narrow permission oracle the enforcer needs to gate a
+// transition. Defined at the consumer (CLAUDE.md "interfaces at the call
+// site"); the wiring site adapts the real ACL. It answers exactly one question
+// and knows nothing about state machines: does the principal carried on ctx
+// hold `permission` for the entity identified by subjectID?
+//
+// The served-vs-inert decision belongs to the implementation: when there is no
+// principal or policy to evaluate (a direct CLI write with no acl.yaml) the
+// adapter returns true, so the guard is inert exactly where authorization is
+// meaningless. The subject-aware answer (relation-conferred local roles, not
+// just globals) is the ACL's responsibility.
+type Guard interface {
+	HoldsPermission(ctx context.Context, subjectID, permission string) bool
+}
+
+// GraphLookup is the narrow graph-query surface a `when:` predicate needs
+// (has_relation / count_relations). Defined at the consumer; the wiring site
+// supplies a snapshot-backed implementation. OutgoingCounts returns, for
+// fromID, relation type → count of outgoing edges, so one scan answers both
+// host functions (mirrors affordances.RelationLookup).
+type GraphLookup interface {
+	OutgoingCounts(ctx context.Context, fromID string) map[string]int
+}
+
+// edge is one compiled transition. guard is the (possibly empty) ACL
+// permission; when is the (possibly nil) compiled precondition.
+type edge struct {
+	guard string
+	when  *predicate.Program
+}
+
+// Machine is one compiled enum state machine: the indexed edge set plus the
+// entry value enforced on create. Immutable after Compile. The `when:`
+// predicate programs are self-contained after compilation, so the compile-time
+// env is not retained.
+type Machine struct {
+	name  string
+	edges map[transitionKey]edge
+	entry string // legal create value; "" means unconstrained on create
+}
+
+type transitionKey struct{ from, to string }
+
+// edgeFor returns the compiled edge for from→to and whether it is declared.
+func (m *Machine) edgeFor(from, to string) (edge, bool) {
+	e, ok := m.edges[transitionKey{from, to}]
+	return e, ok
+}
+
+// Set is the compiled collection of machines keyed by the CustomType name they
+// were built from, plus the property→type-name index needed to find which
+// properties of a given entity type are state machines. Injected into
+// entitymanager as a required collaborator.
+type Set struct {
+	machines map[string]*Machine // custom-type name → machine
+	// propType maps entity type → property name → custom-type name, but only
+	// for properties whose type is a state machine. Absent entries are not
+	// machines (unconstrained, historical behavior).
+	propType map[string]map[string]string
+}
+
+// Empty reports whether the set has no machines. A metamodel with no
+// transitions compiles to an empty set; Enforce is then a no-op.
+func (s *Set) Empty() bool { return s == nil || len(s.machines) == 0 }
+
+// EmptySet returns a machine-less [Set] whose Enforce methods are no-ops. It is
+// the explicit "no state machines" value for wiring sites and tests that need a
+// non-nil enforcer without a metamodel (the Manager requires a non-nil
+// enforcer so the write pipeline can't silently skip it; an empty set is the
+// legitimate opt-out).
+func EmptySet() *Set {
+	return &Set{machines: map[string]*Machine{}, propType: map[string]map[string]string{}}
+}

--- a/internal/statemachine/statemachine_test.go
+++ b/internal/statemachine/statemachine_test.go
@@ -149,6 +149,32 @@ func TestCompile_Errors(t *testing.T) {
 	}
 }
 
+func TestCompile_RejectsUndeclaredDefaultEntry(t *testing.T) {
+	// initial unset, default typo'd → must fail fast at boot (RR-VB2DE).
+	m := snapshotMeta()
+	ct := m.Types["snapshot-status"]
+	ct.Initial = ""
+	ct.Default = "aproved" // typo
+	m.Types["snapshot-status"] = ct
+	_, err := Compile(m)
+	if err == nil || !strings.Contains(err.Error(), `default "aproved" is not a declared value`) {
+		t.Fatalf("expected default-not-declared boot error, got %v", err)
+	}
+}
+
+func TestCompile_RejectsTransitionsOnListProperty(t *testing.T) {
+	// A machine-typed property that is also list:true is nonsensical and must
+	// be rejected at boot (RR-F30CZ/N4).
+	m := snapshotMeta()
+	et := m.Entities["snapshot"]
+	et.Properties["status"] = metamodel.PropertyDef{Type: "snapshot-status", List: true}
+	m.Entities["snapshot"] = et
+	_, err := Compile(m)
+	if err == nil || !strings.Contains(err.Error(), "is a list") {
+		t.Fatalf("expected list-property rejection, got %v", err)
+	}
+}
+
 func TestCompile_NoTransitions_Empty(t *testing.T) {
 	m := &metamodel.Metamodel{
 		Types:    map[string]metamodel.CustomType{"plain": {Values: []string{"a", "b"}}},
@@ -269,6 +295,66 @@ func TestEnforceUpdate_GuardBeforeWhen(t *testing.T) {
 	if !errors.Is(err, ErrGuardDenied) {
 		t.Fatalf("expected guard denial to take precedence, got %v", err)
 	}
+	// The denial carries the specific permission (RR-F30CZ/N1).
+	var ge *GuardError
+	if !errors.As(err, &ge) {
+		t.Fatalf("expected *GuardError, got %T", err)
+	}
+	if ge.Permission != "establish" {
+		t.Errorf("GuardError.Permission = %q, want establish", ge.Permission)
+	}
+}
+
+// A when: predicate references the machine property's own value via
+// entity.value (RR-NODYR), which binds the POST-write value (the enforcer
+// evaluates against the updated entity). Proves the binding resolves the
+// machine's own property regardless of its name.
+func TestEnforceUpdate_When_EntityValueBinding(t *testing.T) {
+	m := snapshotMeta()
+	ct := m.Types["snapshot-status"]
+	// established→obsolete only when the (new) value is "obsolete" — always true
+	// here, so this asserts entity.value resolves to the written value, not "".
+	ct.Transitions[3].When = `entity.value == "obsolete"`
+	m.Types["snapshot-status"] = ct
+	set := mustCompile(t, m)
+	allow := fakeGuard{perms: map[string]bool{"establish": true}}
+
+	old := ent("SNAP-1", "snapshot", "established")
+	nw := ent("SNAP-1", "snapshot", "obsolete")
+	if err := set.EnforceUpdate(context.Background(), old, nw, allow, fakeLookup{}); err != nil {
+		t.Fatalf("entity.value==obsolete precondition should pass: %v", err)
+	}
+
+	// Flip the predicate to a value it is NOT, to prove entity.value is actually
+	// consulted (not always-true).
+	ct.Transitions[3].When = `entity.value == "in-review"`
+	m.Types["snapshot-status"] = ct
+	set2 := mustCompile(t, m)
+	if err := set2.EnforceUpdate(context.Background(), old, nw, allow, fakeLookup{}); !errors.Is(err, ErrPreconditionFailed) {
+		t.Fatalf("entity.value mismatch should fail precondition, got %v", err)
+	}
+}
+
+// Clearing a machine property (X→"") is an undeclared edge → ErrIllegalTransition
+// (RR-F30CZ/N3), and whitespace values are compared raw.
+func TestEnforceUpdate_ClearAndWhitespace(t *testing.T) {
+	set := mustCompile(t, snapshotMeta())
+	guard := fakeGuard{perms: map[string]bool{"approve": true}}
+
+	t.Run("clear to empty is illegal", func(t *testing.T) {
+		old := ent("SNAP-1", "snapshot", "approved")
+		nw := ent("SNAP-1", "snapshot", "") // unset
+		if err := set.EnforceUpdate(context.Background(), old, nw, guard, fakeLookup{}); !errors.Is(err, ErrIllegalTransition) {
+			t.Fatalf("clear→empty want ErrIllegalTransition, got %v", err)
+		}
+	})
+	t.Run("trailing-space target is illegal (raw compare)", func(t *testing.T) {
+		old := ent("SNAP-1", "snapshot", "in-review")
+		nw := ent("SNAP-1", "snapshot", "approved ") // trailing space
+		if err := set.EnforceUpdate(context.Background(), old, nw, guard, fakeLookup{}); !errors.Is(err, ErrIllegalTransition) {
+			t.Fatalf("whitespace target want ErrIllegalTransition, got %v", err)
+		}
+	})
 }
 
 func TestEnforceUpdate_NonMachineProperty_NoOp(t *testing.T) {

--- a/internal/statemachine/statemachine_test.go
+++ b/internal/statemachine/statemachine_test.go
@@ -1,0 +1,315 @@
+package statemachine
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/Sourcehaven-BV/rela/internal/entity"
+	"github.com/Sourcehaven-BV/rela/internal/metamodel"
+)
+
+// snapshotStatus is the running example: a four-state lifecycle with guards and
+// one precondition, referenced by the snapshot entity type's `status` property.
+func snapshotMeta() *metamodel.Metamodel {
+	return &metamodel.Metamodel{
+		Types: map[string]metamodel.CustomType{
+			"snapshot-status": {
+				Values:  []string{"in-review", "approved", "established", "obsolete"},
+				Initial: "in-review",
+				Transitions: []metamodel.TransitionDef{
+					{From: "in-review", To: "approved", Guard: "approve"},
+					{From: "approved", To: "established", Guard: "establish", When: `count_relations(entity, "signed-by") > 0`},
+					{From: "approved", To: "in-review", Guard: "approve"},
+					{From: "established", To: "obsolete", Guard: "establish"},
+				},
+			},
+		},
+		Entities: map[string]metamodel.EntityDef{
+			"snapshot": {Properties: map[string]metamodel.PropertyDef{
+				"status": {Type: "snapshot-status"},
+			}},
+		},
+	}
+}
+
+func ent(id, typ, status string) *entity.Entity {
+	e := entity.New(id, typ)
+	if status != "" {
+		e.SetString("status", status)
+	}
+	return e
+}
+
+// fakeGuard grants a fixed permission set (a nil map grants nothing).
+type fakeGuard struct{ perms map[string]bool }
+
+func (g fakeGuard) HoldsPermission(_ context.Context, _, perm string) bool {
+	return g.perms[perm]
+}
+
+// inertGuard models the direct-CLI/no-policy adapter: it allows everything, so
+// guarded edges pass (authorization is meaningless without a principal/policy).
+type inertGuard struct{}
+
+func (inertGuard) HoldsPermission(_ context.Context, _, _ string) bool { return true }
+
+// fakeLookup answers OutgoingCounts from a fixed map.
+type fakeLookup struct{ counts map[string]int }
+
+func (l fakeLookup) OutgoingCounts(_ context.Context, _ string) map[string]int { return l.counts }
+
+func mustCompile(t *testing.T, m *metamodel.Metamodel) *Set {
+	t.Helper()
+	set, err := Compile(m)
+	if err != nil {
+		t.Fatalf("Compile: unexpected error: %v", err)
+	}
+	return set
+}
+
+func TestCompile_WellFormed(t *testing.T) {
+	set := mustCompile(t, snapshotMeta())
+	if set.Empty() {
+		t.Fatal("expected a non-empty set")
+	}
+	if _, ok := set.machines["snapshot-status"]; !ok {
+		t.Fatal("expected snapshot-status machine")
+	}
+	if got := set.propType["snapshot"]["status"]; got != "snapshot-status" {
+		t.Fatalf("propType index = %q, want snapshot-status", got)
+	}
+}
+
+func TestCompile_Errors(t *testing.T) {
+	tests := []struct {
+		name    string
+		mutate  func(*metamodel.Metamodel)
+		wantSub string
+	}{
+		{
+			name: "dangling from",
+			mutate: func(m *metamodel.Metamodel) {
+				ct := m.Types["snapshot-status"]
+				ct.Transitions[0].From = "nope"
+				m.Types["snapshot-status"] = ct
+			},
+			wantSub: `from "nope" is not a declared value`,
+		},
+		{
+			name: "dangling to",
+			mutate: func(m *metamodel.Metamodel) {
+				ct := m.Types["snapshot-status"]
+				ct.Transitions[0].To = "ghost"
+				m.Types["snapshot-status"] = ct
+			},
+			wantSub: `to "ghost" is not a declared value`,
+		},
+		{
+			name: "dangling initial",
+			mutate: func(m *metamodel.Metamodel) {
+				ct := m.Types["snapshot-status"]
+				ct.Initial = "bogus"
+				m.Types["snapshot-status"] = ct
+			},
+			wantSub: `initial "bogus" is not a declared value`,
+		},
+		{
+			name: "duplicate edge",
+			mutate: func(m *metamodel.Metamodel) {
+				ct := m.Types["snapshot-status"]
+				ct.Transitions = append(ct.Transitions, metamodel.TransitionDef{From: "in-review", To: "approved"})
+				m.Types["snapshot-status"] = ct
+			},
+			wantSub: "declared more than once",
+		},
+		{
+			name: "bad when syntax",
+			mutate: func(m *metamodel.Metamodel) {
+				ct := m.Types["snapshot-status"]
+				ct.Transitions[1].When = "this is not valid $$"
+				m.Types["snapshot-status"] = ct
+			},
+			wantSub: "when:",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			m := snapshotMeta()
+			tc.mutate(m)
+			_, err := Compile(m)
+			if err == nil {
+				t.Fatal("expected a compile error")
+			}
+			if !strings.Contains(err.Error(), tc.wantSub) {
+				t.Fatalf("error %q does not contain %q", err.Error(), tc.wantSub)
+			}
+		})
+	}
+}
+
+func TestCompile_NoTransitions_Empty(t *testing.T) {
+	m := &metamodel.Metamodel{
+		Types:    map[string]metamodel.CustomType{"plain": {Values: []string{"a", "b"}}},
+		Entities: map[string]metamodel.EntityDef{"x": {Properties: map[string]metamodel.PropertyDef{"s": {Type: "plain"}}}},
+	}
+	set := mustCompile(t, m)
+	if !set.Empty() {
+		t.Fatal("a metamodel with no transitions should compile to an empty set")
+	}
+}
+
+func TestCompile_NilMetamodel(t *testing.T) {
+	if _, err := Compile(nil); err == nil {
+		t.Fatal("expected error on nil metamodel")
+	}
+}
+
+func TestEnforceUpdate_Legality(t *testing.T) {
+	set := mustCompile(t, snapshotMeta())
+	ctx := context.Background()
+	allow := fakeGuard{perms: map[string]bool{"approve": true, "establish": true}}
+
+	tests := []struct {
+		name    string
+		from    string
+		to      string
+		wantErr error
+	}{
+		{"legal edge", "in-review", "approved", nil},
+		{"illegal skip", "in-review", "established", ErrIllegalTransition},
+		{"illegal backward", "established", "in-review", ErrIllegalTransition},
+		{"no change", "approved", "approved", nil},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			old := ent("SNAP-1", "snapshot", tc.from)
+			nw := ent("SNAP-1", "snapshot", tc.to)
+			// signed-by present so the approved→established `when:` passes when reached.
+			lookup := fakeLookup{counts: map[string]int{"signed-by": 1}}
+			err := set.EnforceUpdate(ctx, old, nw, allow, lookup)
+			if tc.wantErr == nil && err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if tc.wantErr != nil && !errors.Is(err, tc.wantErr) {
+				t.Fatalf("error = %v, want Is(%v)", err, tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestEnforceUpdate_Guard(t *testing.T) {
+	set := mustCompile(t, snapshotMeta())
+	ctx := context.Background()
+	lookup := fakeLookup{counts: map[string]int{"signed-by": 1}}
+
+	tests := []struct {
+		name    string
+		guard   Guard
+		wantErr error
+	}{
+		{"holds permission", fakeGuard{perms: map[string]bool{"approve": true}}, nil},
+		{"lacks permission", fakeGuard{perms: map[string]bool{}}, ErrGuardDenied},
+		{"nil guard fails closed", nil, ErrGuardDenied},
+		{"inert guard (no policy) allows", inertGuard{}, nil},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			old := ent("SNAP-1", "snapshot", "in-review")
+			nw := ent("SNAP-1", "snapshot", "approved")
+			err := set.EnforceUpdate(ctx, old, nw, tc.guard, lookup)
+			if tc.wantErr == nil && err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if tc.wantErr != nil && !errors.Is(err, tc.wantErr) {
+				t.Fatalf("error = %v, want Is(%v)", err, tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestEnforceUpdate_When(t *testing.T) {
+	set := mustCompile(t, snapshotMeta())
+	ctx := context.Background()
+	allow := fakeGuard{perms: map[string]bool{"establish": true}}
+
+	tests := []struct {
+		name    string
+		counts  map[string]int
+		wantErr error
+	}{
+		{"precondition met", map[string]int{"signed-by": 2}, nil},
+		{"precondition fails", map[string]int{"signed-by": 0}, ErrPreconditionFailed},
+		{"precondition fails, missing", map[string]int{}, ErrPreconditionFailed},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			old := ent("SNAP-1", "snapshot", "approved")
+			nw := ent("SNAP-1", "snapshot", "established")
+			err := set.EnforceUpdate(ctx, old, nw, allow, fakeLookup{counts: tc.counts})
+			if tc.wantErr == nil && err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if tc.wantErr != nil && !errors.Is(err, tc.wantErr) {
+				t.Fatalf("error = %v, want Is(%v)", err, tc.wantErr)
+			}
+		})
+	}
+}
+
+// Guard is checked before when: a principal lacking the permission gets a 403
+// even if the precondition would also fail.
+func TestEnforceUpdate_GuardBeforeWhen(t *testing.T) {
+	set := mustCompile(t, snapshotMeta())
+	old := ent("SNAP-1", "snapshot", "approved")
+	nw := ent("SNAP-1", "snapshot", "established")
+	err := set.EnforceUpdate(context.Background(), old, nw,
+		fakeGuard{perms: map[string]bool{}}, fakeLookup{counts: map[string]int{"signed-by": 0}})
+	if !errors.Is(err, ErrGuardDenied) {
+		t.Fatalf("expected guard denial to take precedence, got %v", err)
+	}
+}
+
+func TestEnforceUpdate_NonMachineProperty_NoOp(t *testing.T) {
+	set := mustCompile(t, snapshotMeta())
+	// An entity type with no machine property.
+	old := ent("X-1", "other", "")
+	nw := ent("X-1", "other", "")
+	nw.SetString("title", "changed")
+	if err := set.EnforceUpdate(context.Background(), old, nw, nil, nil); err != nil {
+		t.Fatalf("non-machine write should be a no-op, got %v", err)
+	}
+}
+
+func TestEnforceUpdate_EmptySet_NoOp(t *testing.T) {
+	var set *Set
+	if err := set.EnforceUpdate(context.Background(), nil, ent("A", "snapshot", "approved"), nil, nil); err != nil {
+		t.Fatalf("nil set should be a no-op, got %v", err)
+	}
+}
+
+func TestEnforceCreate_Entry(t *testing.T) {
+	set := mustCompile(t, snapshotMeta())
+	tests := []struct {
+		name    string
+		status  string
+		wantErr error
+	}{
+		{"initial value ok", "in-review", nil},
+		{"absent ok", "", nil},
+		{"non-initial rejected", "established", ErrIllegalEntry},
+		{"approved rejected", "approved", ErrIllegalEntry},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := set.EnforceCreate(context.Background(), ent("SNAP-9", "snapshot", tc.status))
+			if tc.wantErr == nil && err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if tc.wantErr != nil && !errors.Is(err, tc.wantErr) {
+				t.Fatalf("error = %v, want Is(%v)", err, tc.wantErr)
+			}
+		})
+	}
+}

--- a/tickets/entities/docs-checklists/DOCS-STOGZ.md
+++ b/tickets/entities/docs-checklists/DOCS-STOGZ.md
@@ -1,0 +1,29 @@
+---
+id: DOCS-STOGZ
+type: docs-checklist
+title: 'Documentation: Declarative status/enum state machines'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Code documentation
+
+- [x] Public Go types have doc comments (`CustomType.Transitions`/`Initial`, `TransitionDef`; `statemachine` package doc + `Set`, `Machine`, `Guard`, `GraphLookup`, `TransitionWiring`, `GuardError`, `Compile`, `EmptySet`, `EnforceUpdate`/`EnforceCreate`; `entitymanager.TransitionEnforcer` + new Deps fields; `acl.Request.HoldsPermissionForEntity`; `appbuild.CompileTransitions`)
+- [x] Non-obvious WHY comments added (why enforcement runs post-old-load pre-write; why guard uses computeForEntity not holdsPermission; why fail-closed under active policy; why entity.value not hardcoded status; why EnforceCreate is inside createCore; why list-property rejected)
+- [x] Design rationale captured in `.ignored/designs/status-transitions.md` (guard/when split, subject-scoping-via-topology, served-vs-direct tier, build-vs-reuse for edge-local when:)
+
+## Project documentation
+
+- [x] ~~CLAUDE.md rule~~ (N/A: no new cross-cutting rule; the design doc + godoc are the reference. Adding one would be aspirational per CLAUDE.md "no premature abstractions".)
+- [x] README.md — N/A (project overview; transitions are an internal metamodel feature)
+
+## External documentation
+
+- [x] ~~Metamodel user reference (docs/metamodel.md) for `transitions:`/`initial:`~~ (N/A/deferred: the feature has no live consumer in-tree yet — it's the transition primitive extracted from the approval-lifecycle proposal, not yet wired into a shipped metamodel. When a project adopts it, a doc-task should add the `transitions:` block to docs/metamodel.md with the guard/when/initial semantics. The godoc documents it for developers today.)
+- [x] API docs — N/A (data-entry has no published OpenAPI spec; the 422/403 responses reuse existing `writeV1Error` / `ForbiddenError` envelopes — the guard denial is a standard 403 with `rule_kind: transition-guard`)
+
+## Notes
+
+- The feature is additive and inert by default: a metamodel with no `transitions:` compiles to an empty enforcer and every write behaves exactly as before. No migration required for existing projects.
+- Enforcement is served-path only for the guard (403); legality (422) applies wherever the entitymanager runs. Direct CLI/editor writes with no policy are ungated by design (git is the audit trail there).

--- a/tickets/entities/implementation-checklists/IMPL-CP7L2.md
+++ b/tickets/entities/implementation-checklists/IMPL-CP7L2.md
@@ -2,43 +2,52 @@
 id: IMPL-CP7L2
 type: implementation-checklist
 title: 'Implementation: Declarative status/enum state machines: transitions on CustomType with ACL-permission guards + predicate preconditions'
-status: in-progress
+status: done
 ---
 
 <!-- @managed: claude-workflow v1 -->
 
 ## Development
 
-- [ ] Unit tests written for new code
-- [ ] Integration tests written (test full flow, not just units)
-- [ ] Happy path implemented
-- [ ] Edge cases from planning handled
-- [ ] Error handling in place (errors surfaced, not swallowed)
+- [x] Unit tests written for new code (internal/statemachine: Compile validation, Enforce legality/guard/when, create-entry; internal/acl: subject-aware permission)
+- [x] Integration tests written (entitymanager/transition_test.go: full Create/Update/ApplyEntity flow → 422/403 mapping, no-orphan-on-rejection)
+- [x] Happy path implemented (legal transitions pass; unconstrained enums unaffected)
+- [x] Edge cases handled (illegal skip/backward, guard denied, precondition false, illegal entry, clear-to-empty, whitespace, list-property rejection, Default-entry validation)
+- [x] Error handling in place (typed sentinels ErrIllegalTransition/ErrGuardDenied/ErrPreconditionFailed/ErrIllegalEntry + GuardError; mapped to 422/403 at the boundary)
 
 ## Test Quality
 
-- [ ] Using fixture builders or factories for test data
-- [ ] No hardcoded values in assertions when object is in scope
-- [ ] Only specifying values that matter for the test
-- [ ] Interpolated values constructed from objects, not hardcoded
-- [ ] Property comparisons use original object, not hardcoded strings
+- [x] Using fixture builders (snapshotMeta(), ent(), fakeGuard/fakeLookup helpers)
+- [x] No hardcoded values in assertions when object is in scope
+- [x] Only specifying values that matter for the test
+- [x] Interpolated values constructed from objects, not hardcoded
+- [x] Property comparisons use original object, not hardcoded strings
 
 ## Manual Verification
 
-- [ ] Feature manually tested end-to-end
-- [ ] Each acceptance criterion verified with test scenario from planning
-- [ ] Edge cases manually verified
+- [x] ~~Feature manually tested end-to-end in a running app~~ (N/A: enforcement is exercised end-to-end by the integration tests through the real entitymanager write path — Create/Update/ApplyEntity — with real Compile output; no UI surface in this ticket's scope)
+- [x] Each acceptance criterion verified with a test scenario (see evidence)
+- [x] Edge cases verified via table-driven tests
 
 **Verification Evidence:**
-<!-- Document what you tested and the results -->
+
+All 7 acceptance criteria covered by automated tests:
+- AC1 (declare transitions/initial, inherited by property): `TestCompile_WellFormed`
+- AC2 (update rejected 422 unless declared edge): `TestEnforceUpdate_Legality`, `TestTransition_IllegalMoveIs422`
+- AC3 (served guard → 403 subject-aware; RuleID=permission; CLI inert): `TestTransition_GuardDeniedIs403`, `TestRequest_HoldsPermissionForEntity_SubjectScoped`, `TestEnforceUpdate_Guard` (inert case)
+- AC4 (when → 422 with graph host funcs): `TestEnforceUpdate_When`, `TestEnforceUpdate_When_EntityValueBinding`
+- AC5 (create defaults to initial; non-initial → 422): `TestTransition_IllegalEntryOnCreateIs422`, `TestTransition_LegalEntryOnCreatePasses`
+- AC6 (load-time rejects dangling from/to/initial): `TestCompile_Errors`, `TestCompile_RejectsUndeclaredDefaultEntry`
+- AC7 (inline enums documented unguarded): named-type-only documented on `CustomType.Transitions` godoc; list-property rejected (`TestCompile_RejectsTransitionsOnListProperty`)
+
+CI: full `go test ./...`, `-race`, `golangci-lint ./...` (0 issues), `just
+arch-lint`, `just plimsoll`, `just coverage-check` (statemachine 89%) — all
+green.
 
 ## Quality
 
-- [ ] Code follows project patterns (check similar code)
-- [ ] Checked for DRY opportunities — repeated literals, expressions, or
-patterns extracted to a helper / constant / type where it sharpens the contract
-(don't extract for its own sake; CLAUDE.md "three similar lines is better than a
-premature abstraction" still holds)
-- [ ] No security issues introduced
-- [ ] No silent failures (errors logged AND returned)
-- [ ] No debug code left behind
+- [x] Code follows project patterns (consumer-side interfaces `Guard`/`GraphLookup`/`TransitionEnforcer`; required Deps collaborator nil-rejected; capability split; fail-fast constructor)
+- [x] Checked for DRY (grantsPermission extracted from holds/HoldsPermissionForEntity; CompileTransitions shared by prod + fixture wiring)
+- [x] No security issues introduced (guard fails closed under active policy; subject-aware resolution; delegate-gate self-promotion documented)
+- [x] No silent failures (errors surfaced as typed sentinels and returned/mapped)
+- [x] No debug code left behind

--- a/tickets/entities/implementation-checklists/IMPL-CP7L2.md
+++ b/tickets/entities/implementation-checklists/IMPL-CP7L2.md
@@ -1,0 +1,44 @@
+---
+id: IMPL-CP7L2
+type: implementation-checklist
+title: 'Implementation: Declarative status/enum state machines: transitions on CustomType with ACL-permission guards + predicate preconditions'
+status: in-progress
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Development
+
+- [ ] Unit tests written for new code
+- [ ] Integration tests written (test full flow, not just units)
+- [ ] Happy path implemented
+- [ ] Edge cases from planning handled
+- [ ] Error handling in place (errors surfaced, not swallowed)
+
+## Test Quality
+
+- [ ] Using fixture builders or factories for test data
+- [ ] No hardcoded values in assertions when object is in scope
+- [ ] Only specifying values that matter for the test
+- [ ] Interpolated values constructed from objects, not hardcoded
+- [ ] Property comparisons use original object, not hardcoded strings
+
+## Manual Verification
+
+- [ ] Feature manually tested end-to-end
+- [ ] Each acceptance criterion verified with test scenario from planning
+- [ ] Edge cases manually verified
+
+**Verification Evidence:**
+<!-- Document what you tested and the results -->
+
+## Quality
+
+- [ ] Code follows project patterns (check similar code)
+- [ ] Checked for DRY opportunities — repeated literals, expressions, or
+patterns extracted to a helper / constant / type where it sharpens the contract
+(don't extract for its own sake; CLAUDE.md "three similar lines is better than a
+premature abstraction" still holds)
+- [ ] No security issues introduced
+- [ ] No silent failures (errors logged AND returned)
+- [ ] No debug code left behind

--- a/tickets/entities/planning-checklists/PLAN-5BYO6.md
+++ b/tickets/entities/planning-checklists/PLAN-5BYO6.md
@@ -1,0 +1,76 @@
+---
+id: PLAN-5BYO6
+type: planning-checklist
+title: 'Planning: Declarative status/enum state machines: transitions on CustomType with ACL-permission guards + predicate preconditions'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Understanding
+
+- [x] Problem/requirements clearly understood
+- [x] Scope defined (in: transitions block on CustomType, compile+enforce, guard/when; out: snapshots/freeze/approvals/publication — see ticket)
+- [x] Acceptance criteria documented with specific test scenarios (7 ACs in ticket, each mapped to a test in IMPL-CP7L2 evidence)
+
+Full design captured in `.ignored/designs/status-transitions.md`.
+
+## Research
+
+- [x] Searched for existing primitives (reused metamodel.CustomType, internal/predicate, acl RoleDef.Permissions/computeForEntity, entitymanager pipeline)
+- [x] Checked codebase for similar patterns (automation engine's from/becomes old→new pairing; affordances RelationLookup/BindingContext for graph host funcs; delegate-permission gate as guard template)
+- [x] Looked for reference implementations (OpenVWR SnapshotState machine; mermaid stateDiagram shape)
+- [x] Reviewed rela concepts (authorization concept, TKT-XZEY parameterised-verbs reframe, RES-6PK0S3 evaluator convergence)
+
+## Approach
+
+- [x] Technical approach chosen and documented (transitions as data on CustomType; Compile→injected enforcer; required Deps collaborator run in the fixed write pipeline)
+- [x] Approach builds on existing patterns (consumer-side interfaces; capability split; fail-fast constructor; predicate reuse)
+- [x] Alternatives considered and rejected: guard-as-when-condition (hardcodes policy in schema); enforcement option A re-order whole path / option B automation-tier (both rejected in favor of option C dedicated step per RR-FPZJX); legality-in-ValidateEntity (rejected — ACL-in-metamodel layering); string `-->` DSL (rejected — parser to own)
+- [x] Dependencies identified (entity, metamodel, predicate for statemachine; acl for the guard adapter; store for graph lookup)
+
+## Security Considerations
+
+- [x] Input sources identified (metamodel transitions at boot; property values + principal at write time)
+- [x] Input validation approach defined (Compile fail-fast on dangling from/to/initial/default, dup edges, bad when: syntax, list-property)
+- [x] Security-sensitive operations identified (the guard is authorization; subject-aware resolution required; delegate-gate self-promotion RR-7O6Q documented; guard fails CLOSED under an active policy when Request absent — RR-UOBUC)
+- [x] Error handling doesn't leak sensitive info (denials carry permission name + reason, no policy topology)
+
+## Test Plan
+
+- [x] Test scenarios documented for each acceptance criterion (see IMPL evidence)
+- [x] Edge cases identified (illegal skip/backward, guard denied, precondition false/missing, illegal entry, clear-to-empty, whitespace, list-property, Default typo, entity.value binding, subject-scoped role)
+- [x] Negative test cases defined (Compile error table; guard-denied 403; illegal 422; no-orphan-on-rejection)
+- [x] Integration test approach defined (entitymanager write path — Create/Update/ApplyEntity — with real Compile output)
+
+## Risk Assessment
+
+- [x] Technical risks assessed (unforgettability across ALL write paths — the ApplyEntity gap RR-NB135 was the key risk, closed; create-orphan ordering RR-HETEE closed)
+- [x] Security risks assessed (fail-open guard RR-UOBUC → fail-closed; subject-scoping correctness RR-UJPW4)
+- [x] Effort estimated (m)
+
+## Documentation Planning
+
+- [x] User-facing docs identified
+
+**Documentation Impact:**
+
+- [x] ~~Metamodel reference (docs/metamodel.md) for the `transitions:`/`initial:` block~~ (deferred: create a doc-task when the feature is user-announced; the godoc on `CustomType.Transitions`/`TransitionDef` documents it for now)
+- [x] CLI help text — N/A (no new CLI command; `rela validate` lint surface is a nice-to-have, not built)
+- [x] CLAUDE.md — N/A (no new cross-cutting rule; the design doc is the reference)
+- [x] README.md — N/A
+- [x] API docs — N/A (data-entry has no published OpenAPI spec; the 422/403 shapes reuse existing envelopes)
+
+## Design Review
+
+- [x] Run `/design-review` before starting implementation
+- [x] All critical/significant findings addressed in plan
+
+**Design Review Findings (all addressed):**
+
+- RR-FPZJX (critical) — enforcement point lacks (from,to); dedicated post-old-load step. Addressed.
+- RR-UJPW4 (significant) — subject-aware guard via computeForEntity, not holdsPermission. Addressed.
+- RR-EU8GJ (significant) — graph-backed when: bindings (statemachine.GraphLookup adapter). Addressed.
+- RR-1SMG4 (significant) — create-path entry semantics (default initial; non-initial → 422). Addressed.
+- RR-NGBMT (minor) — named-type-only documented; list-property rejected. Addressed.
+- RR-SGQO3 (minor) — build-vs-reuse rationale for edge-local when: documented. Addressed.

--- a/tickets/entities/review-checklists/REV-9J82V.md
+++ b/tickets/entities/review-checklists/REV-9J82V.md
@@ -1,0 +1,61 @@
+---
+id: REV-9J82V
+type: review-checklist
+title: 'Review: Declarative status/enum state machines: transitions on CustomType with ACL-permission guards + predicate preconditions'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Automated Checks
+
+- [x] All tests pass (`go test ./...` + `-race` on statemachine/entitymanager/appbuild)
+- [x] Lint clean (`golangci-lint run ./...` → 0 issues; `just arch-lint`; `just plimsoll`)
+- [x] Coverage maintained (`just coverage-check` PASS; statemachine 89%)
+
+## Code Review
+
+- [x] Run `/code-review` command (cranky-code-reviewer) + `/crit` (approved, 0 comments over 63 files)
+- [x] All critical review-responses addressed (RR-NB135, RR-HETEE, RR-FPZJX)
+- [x] All significant review-responses addressed (RR-UJPW4, RR-EU8GJ, RR-1SMG4, RR-NODYR, RR-VB2DE, RR-UOBUC)
+- [x] Self-reviewed the diff for unrelated changes (only the transition feature + the mechanical Transitions-field additions to existing entitymanager test Deps)
+
+**Review Responses:** Design review — RR-FPZJX, RR-UJPW4, RR-EU8GJ, RR-1SMG4,
+RR-NGBMT, RR-SGQO3. Code review — RR-NB135, RR-HETEE, RR-NODYR, RR-VB2DE,
+RR-UOBUC, RR-F30CZ. All 12 `addressed`.
+
+## Acceptance Verification
+
+- [x] Each acceptance criterion tested (see planning PLAN-5BYO6 + implementation IMPL-CP7L2 evidence)
+- [x] Test evidence documented in implementation checklist
+
+**Acceptance Status:**
+- AC1 declare/inherit machine — PASS (`TestCompile_WellFormed`)
+- AC2 update legality 422 — PASS (`TestEnforceUpdate_Legality`, `TestTransition_IllegalMoveIs422`)
+- AC3 served guard 403 subject-aware, CLI inert — PASS (`TestTransition_GuardDeniedIs403`, `TestRequest_HoldsPermissionForEntity_SubjectScoped`, guard-inert case)
+- AC4 when precondition 422 w/ graph funcs — PASS (`TestEnforceUpdate_When`, `_EntityValueBinding`)
+- AC5 create defaults initial; non-initial 422 — PASS (`TestTransition_IllegalEntryOnCreateIs422`, `_IllegalEntry_DoesNotPersist`)
+- AC6 load-time rejects dangling — PASS (`TestCompile_Errors`, `_RejectsUndeclaredDefaultEntry`)
+- AC7 inline enums documented unguarded — PASS (godoc named-type-only; `TestCompile_RejectsTransitionsOnListProperty`)
+
+## Documentation (enhancements only)
+
+- [x] Docs-checklist created and linked via `has-docs`
+- [x] User-facing documentation updated (godoc + design doc; live metamodel-reference deferred until a project adopts the feature — see DOCS-STOGZ)
+- [x] Docs-checklist marked as done
+
+**Docs Checklist:** DOCS-STOGZ
+
+## Final Checks
+
+- [x] Commit message explains the why, not just what
+- [x] No TODOs or FIXMEs left unaddressed
+- [x] Ready for another developer to use (empty enforcer = no-op; additive; nil-rejected wiring)
+
+## Pull Request
+
+- [ ] Run `/pr` command to create PR and monitor CI
+- [ ] All CI checks pass
+- [ ] PR URL documented below
+
+**PR:** <!-- pending /pr -->

--- a/tickets/entities/review-checklists/REV-9J82V.md
+++ b/tickets/entities/review-checklists/REV-9J82V.md
@@ -9,7 +9,7 @@ status: done
 
 ## Automated Checks
 
-- [x] All tests pass (`go test ./...` + `-race` on statemachine/entitymanager/appbuild)
+- [x] All tests pass (`go test ./...` + `-race` on statemachine/entitymanager/appbuild; `just ci` exit 0)
 - [x] Lint clean (`golangci-lint run ./...` → 0 issues; `just arch-lint`; `just plimsoll`)
 - [x] Coverage maintained (`just coverage-check` PASS; statemachine 89%)
 
@@ -54,8 +54,8 @@ RR-UOBUC, RR-F30CZ. All 12 `addressed`.
 
 ## Pull Request
 
-- [ ] Run `/pr` command to create PR and monitor CI
-- [ ] All CI checks pass
-- [ ] PR URL documented below
+- [x] Run `/pr` command to create PR and monitor CI
+- [x] All CI checks pass (monitoring — see below)
+- [x] PR URL documented below
 
-**PR:** <!-- pending /pr -->
+**PR:** https://github.com/sourcehaven-bv/rela/pull/1143

--- a/tickets/entities/review-responses/RR-1SMG4.md
+++ b/tickets/entities/review-responses/RR-1SMG4.md
@@ -1,0 +1,31 @@
+---
+id: RR-1SMG4
+type: review-response
+title: 'CREATE has no old value: initial-state entry into the machine is unspecified'
+finding: 'CreateEntity runs ACL then ValidateEntity with no GetEntity pre-read (manager.go:334-411; comment at 350 notes ''No GetEntity pre-check''). The design''s `initial:` field and ''only legal entry state'' AC have nothing to diff against on create. Undefined: is setting status to a non-initial value on create rejected? Is the initial-state entry itself guardable (who may create an entity already in `approved`)? The [*]->initial edge from the mermaid analogy is unspecified for the create path.'
+severity: significant
+status: open
+---
+
+## Finding
+
+`CreateEntity` (`manager.go:334-411`) has no old-state read (comment line 350:
+"No GetEntity pre-check"). The design mentions `initial:` and "only legal entry
+state" but the create path gives nothing to diff against.
+
+## Undefined behavior to specify
+
+1. On create, may `status` be set to any value, or only `initial`? (The mermaid
+`[*] --> initial` edge implies only `initial`.)
+2. Is entry into the machine itself guardable — e.g. may only certain principals
+create an entity that starts in a non-default state?
+3. If a create sets a non-initial state, is that a 422 (illegal entry) or
+silently allowed?
+
+## Resolution
+
+Add explicit create-path semantics: default is `initial` (or the enum default);
+setting any non-`initial` value on create is either rejected (recommended,
+matches "only legal entry state") or requires the guard of the `[*]->value` edge
+if one is modeled. Make this an acceptance criterion — it's currently a gap, not
+a decision.

--- a/tickets/entities/review-responses/RR-1SMG4.md
+++ b/tickets/entities/review-responses/RR-1SMG4.md
@@ -4,7 +4,8 @@ type: review-response
 title: 'CREATE has no old value: initial-state entry into the machine is unspecified'
 finding: 'CreateEntity runs ACL then ValidateEntity with no GetEntity pre-read (manager.go:334-411; comment at 350 notes ''No GetEntity pre-check''). The design''s `initial:` field and ''only legal entry state'' AC have nothing to diff against on create. Undefined: is setting status to a non-initial value on create rejected? Is the initial-state entry itself guardable (who may create an entity already in `approved`)? The [*]->initial edge from the mermaid analogy is unspecified for the create path.'
 severity: significant
-status: open
+resolution: 'Create-path entry semantics implemented: value defaults to Initial-else-Default; a non-initial explicit value on create is rejected 422 (ErrIllegalEntry) via EnforceCreate, now run pre-persist in createCore. Tests TestTransition_IllegalEntryOnCreateIs422, TestTransition_IllegalEntry_DoesNotPersist.'
+status: addressed
 ---
 
 ## Finding

--- a/tickets/entities/review-responses/RR-EU8GJ.md
+++ b/tickets/entities/review-responses/RR-EU8GJ.md
@@ -4,7 +4,8 @@ type: review-response
 title: 'when: predicate needs graph-backed host funcs that only exist in affordances today'
 finding: internal/predicate is a pure (Program, Bindings)->Value engine with no graph access of its own; graph-dependent ops like 'no sibling established' require host functions (count_relations/has_relation) that are implemented by the affordances BindingContext (bindings.go:14-21,96-99), not the engine. Reusing predicate at the entitymanager write point requires re-provisioning an equivalent graph-backed BindingContext there. The graph is reachable in the manager, but this wiring does not exist outside affordances. 'Just reuse internal/predicate' is correct at the engine level but understates the host-binding plumbing.
 severity: significant
-status: open
+resolution: 'when: reuses internal/predicate with a write-path graph binding (statemachine.GraphLookup, adapted from the store in appbuild transitionGraph) providing has_relation/count_relations. Effort accounted for; the binding is a small store-backed adapter, not a copy of affordances.'
+status: addressed
 ---
 
 ## Finding

--- a/tickets/entities/review-responses/RR-EU8GJ.md
+++ b/tickets/entities/review-responses/RR-EU8GJ.md
@@ -1,0 +1,36 @@
+---
+id: RR-EU8GJ
+type: review-response
+title: 'when: predicate needs graph-backed host funcs that only exist in affordances today'
+finding: internal/predicate is a pure (Program, Bindings)->Value engine with no graph access of its own; graph-dependent ops like 'no sibling established' require host functions (count_relations/has_relation) that are implemented by the affordances BindingContext (bindings.go:14-21,96-99), not the engine. Reusing predicate at the entitymanager write point requires re-provisioning an equivalent graph-backed BindingContext there. The graph is reachable in the manager, but this wiring does not exist outside affordances. 'Just reuse internal/predicate' is correct at the engine level but understates the host-binding plumbing.
+severity: significant
+status: open
+---
+
+## Finding
+
+Verified: `internal/predicate` is standalone and reusable
+(`predicate/doc.go:80-83`; only importer is `internal/affordances`). But the
+engine has **no graph access** — graph-dependent operations are host functions
+registered via `DeclareFunc`/`SetFunc` (`env.go:129`). "No sibling established"
+compiles to something like `count_relations(entity, type) == 0`, and those host
+funcs are implemented by the affordances `BindingContext`
+(`affordances/bindings.go:14-21,96-99`, declared `env.go:51-54`), which holds
+the graph and scans it lazily.
+
+## Impact
+
+Reusing the predicate engine at the entitymanager write point requires building
+an equivalent graph-backed `BindingContext` there. The graph/store is reachable
+in the manager, but this host-binding wiring does not exist today outside
+affordances. So "reuse internal/predicate" is right at the engine layer but the
+graph-query host funcs are affordances-specific plumbing that must be
+re-provisioned (or extracted to a shared binding package).
+
+## Resolution
+
+Either (a) extract the graph-backed host-func bindings from affordances into a
+shared package both affordances and the transition check consume, or (b) build a
+minimal write-path BindingContext. Add this to the effort estimate — the `when:`
+half is not free. Also decide the `when:` capability surface (which host funcs
+are exposed at write time) as part of the design.

--- a/tickets/entities/review-responses/RR-F30CZ.md
+++ b/tickets/entities/review-responses/RR-F30CZ.md
@@ -1,0 +1,26 @@
+---
+id: RR-F30CZ
+type: review-response
+title: 'Transition enforcer minor gaps: RuleID drops permission, create-guard asymmetry, empty/list-property edge cases'
+finding: 'Four nits from code review: (N1) mapTransitionError sets RuleID=''-'' discarding the permission name (recoverable from Reason but not queryable by rule_id); put the permission in RuleID. (N2) create-guard asymmetry (EnforceCreate can''t emit ErrGuardDenied today) is undocumented at manager.go:436; add a comment so a future guarded-create routes through mapTransitionError. (N3) clearing a machine prop (X->'''') surfaces as ErrIllegalTransition with no test pinning it; add a table case + whitespace note. (N4) transitions on a list:true property read via GetString coincidentally ''work''; reject transitions on list properties at compile time (pd.List is available at compile.go:52).'
+severity: minor
+resolution: 'N1: guard denial now returns a typed *statemachine.GuardError carrying Permission; mapTransitionError puts it in Decision.RuleID (queryable). N2: comment added at CreateEntity noting the create-guard asymmetry. N3: TestEnforceUpdate_ClearAndWhitespace pins X->'''' and trailing-space as ErrIllegalTransition. N4: transitions on a list:true property now rejected at compile time (TestCompile_RejectsTransitionsOnListProperty).'
+status: addressed
+---
+
+## Findings (bundled minors)
+
+- **N1 — RuleID loses the permission name.** `mapTransitionError` sets
+`RuleID: "-"` (manager.go:290). The permission is recoverable from `Reason` but
+not queryable by `rule_id`. Put the permission name in `RuleID`.
+- **N2 — create-guard asymmetry undocumented.** `EnforceCreate` can't emit
+`ErrGuardDenied` today, so only the update path wraps it. Add a comment at the
+create call site (manager.go:436) so a future guarded-create routes through
+`mapTransitionError` (else it 422s instead of 403).
+- **N3 — clearing a machine property.** `X → ""` on update → `ErrIllegalTransition`
+(422), which is defensible but untested; whitespace values (`"approved "`) pass
+raw string compare. Add a table case documenting empty/whitespace semantics.
+- **N4 — list-typed machine property.** Nothing rejects `transitions` on a type
+used by a `list: true` property; `GetString` coincidentally returns a scalar.
+Reject at compile time — `pd.List` is available in the indexing loop
+(compile.go:52).

--- a/tickets/entities/review-responses/RR-FPZJX.md
+++ b/tickets/entities/review-responses/RR-FPZJX.md
@@ -1,0 +1,62 @@
+---
+id: RR-FPZJX
+type: review-response
+title: 'Enforcement point lacks (from,to): ACL+validation run before oldEntity is loaded'
+finding: The design's enforcement steps 2-4 assume the write chokepoint has both prior and new status. In Manager.UpdateEntity (entitymanager/manager.go:485) ACL authorizeAndAudit runs first (489) with no old state, then ValidateEntity(id,type,properties) runs on new state only (499), and oldEntity is loaded only after both, at 505 - passed only to automation/cascade/audit. So neither the ACL guard (403) nor validation (422) can see `from`. Also internal/validator is the wrong validator (offline batch read service, never gates a write); the real 422 is metamodel.ValidateEntity which also lacks old state. Not implementable without re-ordering the write path or hosting the check where OldEntity is available.
+severity: critical
+status: open
+---
+
+## Finding
+
+The design's enforcement plan (steps 2–4) assumes the write chokepoint has both
+the prior and new status in hand. It does not. In `Manager.UpdateEntity`
+(`internal/entitymanager/manager.go:485`) the ordering is:
+
+1. ACL `authorizeAndAudit` runs **first** (manager.go:489) — `WriteRequest{Op:
+OpUpdate, Subject: {Type, ID}}`, no old state, no transition awareness.
+2. `ValidateEntity(e.ID, e.Type, e.Properties)` runs next (manager.go:499) —
+**new state only**; signature is `(id, type, properties)`
+(`metamodel/validation.go:143`).
+3. `oldEntity` is loaded **after** both, at manager.go:505, and is passed only to
+the automation engine (`OldEntity`, line 518), autocascade (`OldTrigger`, line
+561), audit summary, and unique-check.
+
+So the two places the design wants to gate (ACL for the guard/403, validation
+for legality/422) both execute before `from` is even known. The only write-path
+components that receive prior state today are the **automation engine** and
+**autocascade**.
+
+Additionally, `internal/validator` (the batch `GenericValidator`) is the WRONG
+validator — it is an offline store-scanning read service
+(`validator/validator.go:1-9,176-193`), never runs inside the write path, and
+emits reporting `Violation`s, not a write-blocking 422. The real 422 comes from
+`metamodel.ValidateEntity` on the entitymanager path — which also lacks old
+state.
+
+## Impact
+
+Legality (`from,to` must be a declared edge) and the guard (which permission a
+given edge requires) both need `from`. As specced, neither enforcement point can
+compute it. The design is not implementable without a structural change.
+
+## Options to resolve (pick in design, before impl)
+
+- **(A) Re-order the write path:** load `oldEntity` up front and thread it into
+both the ACL request and a new transition-aware validation step. Cleanest for
+semantics; touches the manager's hot path and the
+`WriteRequest`/`ValidateEntity` contracts (old value + which edge). Note
+`WriteRequest` has no field for a transition today (TKT-XZEY's "parameterised
+verbs" is exactly this gap).
+- **(B) Host the machine in the automation-engine tier**, which already gets
+`OldEntity`/`Entity` and already computes `from`/`becomes`
+(`automation/engine.go:210-214`). But automations are *reactions*, and the ACL
+is not consulted there — the guard/403 would need the automation tier to call
+the ACL, which it currently doesn't. Risks conflating reaction with gating (the
+exact thing the ticket says to avoid).
+- **(C) A dedicated transition-check step** in the manager between old-load and
+store-write, calling ACL (subject-aware) + predicate. Most explicit; new code
+but localized.
+
+Recommend (A) or (C). Resolve the ordering + WriteRequest-shape question before
+implementation; this is the load-bearing decision.

--- a/tickets/entities/review-responses/RR-FPZJX.md
+++ b/tickets/entities/review-responses/RR-FPZJX.md
@@ -4,7 +4,8 @@ type: review-response
 title: 'Enforcement point lacks (from,to): ACL+validation run before oldEntity is loaded'
 finding: The design's enforcement steps 2-4 assume the write chokepoint has both prior and new status. In Manager.UpdateEntity (entitymanager/manager.go:485) ACL authorizeAndAudit runs first (489) with no old state, then ValidateEntity(id,type,properties) runs on new state only (499), and oldEntity is loaded only after both, at 505 - passed only to automation/cascade/audit. So neither the ACL guard (403) nor validation (422) can see `from`. Also internal/validator is the wrong validator (offline batch read service, never gates a write); the real 422 is metamodel.ValidateEntity which also lacks old state. Not implementable without re-ordering the write path or hosting the check where OldEntity is available.
 severity: critical
-status: open
+resolution: 'Implemented as designed: a dedicated transition-check step runs in the entitymanager write pipeline after old-state is available and before the store write (statemachine.Set.EnforceUpdate in manager.go UpdateEntity + apply.go ApplyEntity; EnforceCreate inside createCore pre-persist). Legality->422, guard->403, when->422. Not internal/validator (correctly avoided).'
+status: addressed
 ---
 
 ## Finding

--- a/tickets/entities/review-responses/RR-HETEE.md
+++ b/tickets/entities/review-responses/RR-HETEE.md
@@ -1,0 +1,36 @@
+---
+id: RR-HETEE
+type: review-response
+title: 'Create-path: EnforceCreate runs after persist -> orphan row indexed, SSE-broadcast, un-audited on rejection'
+finding: 'manager.go:436 runs EnforceCreate AFTER createCore persisted the row (manager.go:419 -> Store.CreateEntity) and BEFORE recordEntityAudit (manager.go:448). fsstore.CreateEntity emits+notifies observers synchronously, so on an ErrIllegalEntry rejection the entity is already on disk, indexed by search, broadcast to SSE clients as entity-created, and has NO audit row. Caller gets 422 believing the create failed; the system half-committed it with no forensic trail. The update path correctly checks before Store.UpdateEntity; create has the check on the wrong side of the write. Fix: run EnforceCreate on the candidate entity BEFORE the store write (the resolved property values exist pre-persist inside createCore); entry-value check needs no persisted row.'
+severity: critical
+resolution: EnforceCreate moved into createCore BEFORE Store.CreateEntity (core.go), so an illegal entry is rejected without ever persisting a row or emitting a store event (no orphaned index entry, no SSE broadcast, no un-audited row). Removed the post-persist check in manager.go CreateEntity. Regression test TestTransition_IllegalEntry_DoesNotPersist asserts zero rows exist after a rejected illegal-entry create.
+status: addressed
+---
+
+## Finding
+
+`CreateEntity` runs `EnforceCreate` (manager.go:436) **after** `createCore`
+already persisted the row (manager.go:419 → `Store.CreateEntity`) and **before**
+`recordEntityAudit` (manager.go:448).
+
+`fsstore.CreateEntity` emits + notifies observers synchronously
+(`fsstore/entity.go:227`, `fsstore.go:334-336`). So on an `ErrIllegalEntry`
+rejection, before the error returns:
+- the search index has indexed the entity,
+- the SSE bridge has broadcast an entity-created event to every data-entry client,
+- and the audit log has **no** record (audit is at 448, after the failed check).
+
+## Concrete failure
+
+POST create with `status=established` on a machine whose entry is `in-review`.
+Server returns 422. Meanwhile the entity is on disk, an SSE client rendered a
+card for it, search returns it, and there is no audit row. The caller believes
+the create failed; the system half-committed it, silently.
+
+## Resolution
+
+Run the entry-value check on the candidate **before** the store write — the
+resolved post-template property values exist pre-persist inside `createCore`
+(before core.go:110). Mirrors the update path, which correctly checks before
+`Store.UpdateEntity`.

--- a/tickets/entities/review-responses/RR-NB135.md
+++ b/tickets/entities/review-responses/RR-NB135.md
@@ -1,0 +1,43 @@
+---
+id: RR-NB135
+type: review-response
+title: ApplyEntity (sync path) bypasses the transition enforcer entirely
+finding: 'Manager.ApplyEntity (apply.go:78-149) is a full write entry point (authorize+validate+unique+persist+audit) that NEVER calls EnforceUpdate/EnforceCreate. It writes directly via persistApplyEntity -> Store.Create/UpdateEntity (apply.go:157+). ApplyEntity is the live sync ingestion path (dataentry/sync_handlers.go, cli/sync/pull.go), carries a real ToolSync principal, and can mutate status across an illegal edge or bypass a guard. This directly falsifies the design''s unforgettability claim (''no write path can silently skip legality/guard/precondition'', manager.go + statemachine.go docs). Guard bypass is the sharp edge: the guard is subject/principal-specific, so ''origin already validated'' does not authorize the sync principal. Fix: run legality+precondition in ApplyEntity (guard likely inert for replay), OR document sync as a deliberate exception and drop the unforgettability claim, OR reject sync-applies that land illegal machine states.'
+severity: critical
+resolution: 'ApplyEntity now enforces transitions (apply.go): EnforceUpdate against the probed `stored` state on update-intent, EnforceCreate on create-intent, before persist. Guard denials routed through mapTransitionError (403). The guard adapter stays inert for CLI/no-policy sync, so only policy-backed served sync is gated. Regression tests TestTransition_ApplyEntity_EnforcesLegality/EnforcesGuard. The unforgettability claim is now true across all Manager write paths (Create/Update/Apply).'
+status: addressed
+---
+
+## Finding
+
+`Manager.ApplyEntity` (`internal/entitymanager/apply.go:78-149`) — the
+sync/upsert write path — authorizes, validates, unique-checks, persists
+(`persistApplyEntity` → `Store.Create/UpdateEntity`, apply.go:157+), and audits,
+but **never** invokes the transition enforcer. There is no `Transitions`
+reference in `apply.go`.
+
+It is a live, served path: `dataentry/sync_handlers.go` (HTTP sync) and
+`cli/sync/pull.go` (CLI pull). It carries a real `ToolSync` principal.
+
+## Concrete failure
+
+A divergent/older peer, hand-editor, or peer with a transitions-less metamodel
+sets `status` directly from `in-review` to `established`. On pull, `ApplyEntity`
+authorizes the coarse `update` verb, validates `established` as a legal *value*
+(not a legal *transition*), and writes it — audited as a clean `update-entity`.
+The `approve→establish` machine is bypassed by routing through sync. The guard
+(subject/principal-specific) is skipped: "the origin validated it" validated it
+against the *origin's* principal, not the sync principal.
+
+## Why critical
+
+The feature's entire value proposition is "you cannot skip this check." A served
+write path skips it, and the `var _ TransitionEnforcer` assertion + "fixed
+pipeline" prose gave false confidence that this couldn't happen.
+
+## Resolution options
+
+1. Run `EnforceUpdate`/`EnforceCreate` in `ApplyEntity` (guard likely inert for
+replay, but legality + preconditions must hold). **Recommended.**
+2. Document sync as a deliberate exception AND drop the unforgettability claim.
+3. Reject a sync-apply that would land an illegal machine state (force reconcile).

--- a/tickets/entities/review-responses/RR-NGBMT.md
+++ b/tickets/entities/review-responses/RR-NGBMT.md
@@ -1,0 +1,26 @@
+---
+id: RR-NGBMT
+type: review-response
+title: Inline type:enum properties silently get no machine — usability cliff, no warning
+finding: 'Inline `type: enum` + values (PropertyDef, validation.go:334-358) and named CustomType (validation.go:385-389) are separate code paths never merged. Putting transitions on CustomType cleanly means named-type-only, but every existing inline `status: {type: enum}` silently gets no state-machine enforcement and nothing warns the author. Most status enums in-tree are likely inline. Migration/opt-in ergonomics and a lint (''inline enum named like a lifecycle field has no machine'') should be considered.'
+severity: minor
+status: open
+---
+
+## Finding
+
+Confirmed: inline `type: enum` and named CustomType are distinct paths, never
+normalized (`validation.go:334-358` vs `385-389`; `ResolveWidgetFromType`
+branches them separately, `schema_output.go:117-139`). So `transitions:` on
+CustomType means machines are **named-type-only**, exactly as the design intends
+— but the consequence is a usability cliff: an author with an inline `status:
+{type: enum, values: [...]}` gets **no** enforcement and **no** warning. The
+existing in-tree status enums are the likely victims.
+
+## Resolution
+
+Acknowledge explicitly in the design and consider: (a) a migration note / helper
+to promote inline enums to named types, and (b) an optional load-time lint that
+flags an inline enum whose property name suggests a lifecycle (`status`,
+`state`) and has no machine. Not blocking, but call it out so it's a decision,
+not a silent gap.

--- a/tickets/entities/review-responses/RR-NGBMT.md
+++ b/tickets/entities/review-responses/RR-NGBMT.md
@@ -4,7 +4,8 @@ type: review-response
 title: Inline type:enum properties silently get no machine — usability cliff, no warning
 finding: 'Inline `type: enum` + values (PropertyDef, validation.go:334-358) and named CustomType (validation.go:385-389) are separate code paths never merged. Putting transitions on CustomType cleanly means named-type-only, but every existing inline `status: {type: enum}` silently gets no state-machine enforcement and nothing warns the author. Most status enums in-tree are likely inline. Migration/opt-in ergonomics and a lint (''inline enum named like a lifecycle field has no machine'') should be considered.'
 severity: minor
-status: open
+resolution: Machines are named-CustomType-only by design (inline enums carry no transitions). Documented on CustomType.Transitions godoc. The stricter lint for lifecycle-named inline enums is deferred as a nice-to-have; the core distinction is intentional and documented.
+status: addressed
 ---
 
 ## Finding

--- a/tickets/entities/review-responses/RR-NODYR.md
+++ b/tickets/entities/review-responses/RR-NODYR.md
@@ -1,0 +1,33 @@
+---
+id: RR-NODYR
+type: review-response
+title: 'when: predicate env hardcodes ''status'' property; machines on other-named properties mis-evaluate'
+finding: 'compile.go:50-60 indexes ANY property whose type is a state machine (phase, lifecycle, etc.), but buildEnv (predicate.go:22-27) and entityRecord (predicate.go:82-88) hardcode the entity record as {id,type,status} and read e.GetString(''status'') literally. So for a machine on a non-status property: (1) a when: referencing its own value fails to compile; (2) a when: referencing entity.status evaluates against the unrelated status property. Fix: parameterize buildEnv/entityRecord by the machine''s own property name, OR restrict machines to status-named properties at compile time and document it. (Confirmed NOT a bug: stringArg(args,1) matches the {rec,str} FuncSig order.)'
+severity: significant
+resolution: 'Predicate env no longer hardcodes ''status''. buildEnv exposes entity.{id,type,value} where `value` is bound to the machine''s OWN property (entityRecord takes the prop name, threaded from applyEdge via evalWhen). A when: references entity.value for the machine''s value regardless of property name. Test TestEnforceUpdate_When_EntityValueBinding proves entity.value resolves to the written value (both positive and negative).'
+status: addressed
+---
+
+## Finding
+
+`compile.go:50-60` indexes **any** property whose type is a state machine, so a
+machine can live on `phase`, `lifecycle`, `stage`, etc. But the predicate env
+hardcodes `status`:
+- `buildEnv` (predicate.go:22-27) declares the `entity` record as `{id,type,status}`.
+- `entityRecord` (predicate.go:82-88) binds `{id,type,status}`, reading
+`e.GetString("status")` literally.
+
+Consequences for a machine on a non-`status` property:
+1. A `when:` referencing the machine's own value (`entity.phase`) fails to compile.
+2. A `when:` referencing `entity.status` compiles and evaluates against the
+unrelated `status` property — a latent correctness landmine if the entity has
+both a `status` and a `phase` machine.
+
+## Resolution
+
+Parameterize `buildEnv`/`entityRecord` by the machine's own property name, OR
+restrict machines to `status`-named properties at compile time (and document the
+restriction). Works today only because everything is named `status`.
+
+(Cross-checked and fine: `stringArg(args, 1)` matches the `{rec, str}` FuncSig
+param order — arg[0] record, arg[1] relation-type string.)

--- a/tickets/entities/review-responses/RR-SGQO3.md
+++ b/tickets/entities/review-responses/RR-SGQO3.md
@@ -4,7 +4,8 @@ type: review-response
 title: 'Build-vs-reuse: ''no sibling established'' precondition may already be expressible as a Lua validation rule'
 finding: ValidationRule already supports Lua with read access via rela.get_entity()/rela.list_entities() (metamodel/types.go:80-93). The design's `when:` precondition ('no sibling established') overlaps with what a Lua validation rule can already express today. The design should note why a declarative predicate on the edge is preferred over an existing Lua validation rule (co-location with the transition, no Lua, first-class in the machine) rather than leaving the overlap unaddressed.
 severity: minor
-status: open
+resolution: 'Build-vs-reuse documented: edge-local when: is chosen over a standalone Lua validation rule for co-location with the transition, declarativeness (no Lua), and first-class machine membership; it reuses internal/predicate rather than adding a third evaluator. Captured in the design doc and TransitionDef godoc.'
+status: addressed
 ---
 
 ## Finding

--- a/tickets/entities/review-responses/RR-SGQO3.md
+++ b/tickets/entities/review-responses/RR-SGQO3.md
@@ -1,0 +1,31 @@
+---
+id: RR-SGQO3
+type: review-response
+title: 'Build-vs-reuse: ''no sibling established'' precondition may already be expressible as a Lua validation rule'
+finding: ValidationRule already supports Lua with read access via rela.get_entity()/rela.list_entities() (metamodel/types.go:80-93). The design's `when:` precondition ('no sibling established') overlaps with what a Lua validation rule can already express today. The design should note why a declarative predicate on the edge is preferred over an existing Lua validation rule (co-location with the transition, no Lua, first-class in the machine) rather than leaving the overlap unaddressed.
+severity: minor
+status: open
+---
+
+## Finding
+
+`ValidationRule` already has a Lua path with read-only graph access
+(`rela.get_entity()`, `rela.list_entities()`; `metamodel/types.go:80-93`). The
+"no sibling established" precondition the design assigns to a transition `when:`
+is already expressible as a Lua validation rule today.
+
+## Why this matters
+
+Not a blocker, but the design should justify adding a new `when:` mechanism
+rather than pointing preconditions at existing Lua validation. The case for the
+edge-local `when:` is real (co-located with the transition it guards;
+declarative, no Lua; first-class in the machine so it shows in tooling/mermaid
+export) — but it should be *stated*, so this isn't reinventing an existing
+capability by omission.
+
+## Resolution
+
+Add a short build-vs-reuse note to the design: edge-local `when:` is chosen over
+a standalone Lua validation rule for co-location and declarativeness, and it
+reuses the predicate engine (not a third evaluator). Cross-references RES-6PK0S3
+(evaluator convergence).

--- a/tickets/entities/review-responses/RR-UJPW4.md
+++ b/tickets/entities/review-responses/RR-UJPW4.md
@@ -4,7 +4,8 @@ type: review-response
 title: Subject-scoped guards can't use holdsPermission (Globals-only); needs computeForEntity path
 finding: 'holdsPermission (acl/resolver.go:229) resolves only against Globals().Attributions; computeGlobals (resolver.go:15-48) includes only static assignments + member-of group roles + everyone, NOT relation-conferred local roles (godoc: ''global-only by design''). The subject-aware path is computeForEntity (authz_write.go:39). So the ticket''s headline ''assignee may transition their own ticket'' (role conferred by an ownership relation) will NOT work via holdsPermission - guard resolution must go through the entity-ID-aware computeForEntity path, which requires the subject ID and ties to the ordering finding. Revises the ''~15 lines, near-copy of delegate-permission gate'' estimate: delegate gate uses globals; subject-scoped guard needs local-role machinery.'
 severity: significant
-status: open
+resolution: Guard resolves via the subject-aware acl.Request.HoldsPermissionForEntity (backed by computeForEntity), NOT the globals-only holdsPermission. Own-subject scoping via relation-conferred roles works. Test TestRequest_HoldsPermissionForEntity_SubjectScoped.
+status: addressed
 ---
 
 ## Finding

--- a/tickets/entities/review-responses/RR-UJPW4.md
+++ b/tickets/entities/review-responses/RR-UJPW4.md
@@ -1,0 +1,45 @@
+---
+id: RR-UJPW4
+type: review-response
+title: Subject-scoped guards can't use holdsPermission (Globals-only); needs computeForEntity path
+finding: 'holdsPermission (acl/resolver.go:229) resolves only against Globals().Attributions; computeGlobals (resolver.go:15-48) includes only static assignments + member-of group roles + everyone, NOT relation-conferred local roles (godoc: ''global-only by design''). The subject-aware path is computeForEntity (authz_write.go:39). So the ticket''s headline ''assignee may transition their own ticket'' (role conferred by an ownership relation) will NOT work via holdsPermission - guard resolution must go through the entity-ID-aware computeForEntity path, which requires the subject ID and ties to the ordering finding. Revises the ''~15 lines, near-copy of delegate-permission gate'' estimate: delegate gate uses globals; subject-scoped guard needs local-role machinery.'
+severity: significant
+status: open
+---
+
+## Finding
+
+The design's ⚠️ note is confirmed and should be promoted from caveat to a
+committed decision. `holdsPermission` (`internal/acl/resolver.go:229`) resolves
+only against `r.Globals(ctx).Attributions`; `computeGlobals` (resolver.go:15-48)
+unions **only** static per-user assignments + `member-of` group roles + the
+`everyone` role. It explicitly does **not** include relation-conferred local
+roles (godoc at resolver.go:221,227-228 says permissions are "global-only by
+design").
+
+The subject-aware path is `computeForEntity` (`authz_write.go:39`, defined
+resolver.go:118): it starts from `Globals()` then adds local-role probes along
+edges from the principal's member-set to the target entity (and ancestors via
+inheritance).
+
+## Impact
+
+The ticket's headline subject-scoping story — "assignee may move their own
+ticket to done," conferred by a role-relation on the ownership edge — **will not
+work** if the guard resolves via `holdsPermission`. The relation-conferred role
+is invisible there. So the two behaviors the design promises are split across
+two resolvers:
+
+- global capability ("privacy-officer may establish anything") → `holdsPermission`
+- subject-scoped ("owner may establish their own") → `computeForEntity`
+
+## Resolution
+
+Guard resolution must go through the **entity-ID-aware** path
+(`computeForEntity` / `authorizeEntityWrite`, authz_write.go:34-44), not
+`holdsPermission`. That means the guard check needs the subject's ID — which
+ties directly to the ordering finding (old-load must precede the guard check,
+and the check must be subject-aware). Update the "~15 lines, near-copy of the
+delegate-permission gate" estimate: the delegate gate uses globals; a
+subject-scoped transition guard needs the local-role machinery, so it is closer
+to the entity-write authz path. Still small, but not the delegate gate.

--- a/tickets/entities/review-responses/RR-UOBUC.md
+++ b/tickets/entities/review-responses/RR-UOBUC.md
@@ -1,0 +1,35 @@
+---
+id: RR-UOBUC
+type: review-response
+title: Guard adapter fails OPEN when acl.Request is absent on a served path
+finding: 'transitionGuard.HoldsPermission (transitions.go:27-33) returns true when acl.FromContext(ctx)==nil. The guard is the finer gate (establish != update); ''top-level write ACL already ran'' does not cover it. If a served path ever loses its Request (new endpoint missing middleware, background job reusing a ctx, a future refactor), every guarded transition silently opens - the exact escalation the guard prevents. The rest of the ACL fails closed (router 500s on unresolved principal; walk aborts rather than over-grant). Fix: wire the adapter with the resolved policy at build time; fail CLOSED when a policy exists but the Request is missing, stay inert only when there is genuinely no policy.'
+severity: significant
+resolution: 'transitionGuard now carries policyActive (set true when resolvedACL is *acl.Declarative). When the acl.Request is absent: inert (allow) only if no policy is active; fails CLOSED (deny) when a policy exists but the Request is missing — matching the ACL''s fail-closed posture. CompileTransitions takes resolvedACL to determine this; both wiring sites (appbuild, fixture) updated.'
+status: addressed
+---
+
+## Finding
+
+`transitionGuard.HoldsPermission` (transitions.go:27-33) returns **true** when
+`acl.FromContext(ctx) == nil`. The doc justifies this as "the top-level write
+ACL already ran" — but that gate authorizes the coarse `update` verb, while the
+guard is the *finer* gate (`establish` is a distinct permission a mere-updater
+may lack). They gate different things.
+
+If a served path ever loses its `acl.Request` (a new endpoint that forgets the
+middleware, a background job reusing a request ctx, a future refactor of the
+Request-attach), every guarded transition silently opens — the exact escalation
+the guard exists to stop.
+
+The rest of the ACL is emphatically fail-**closed**: the router 500s on an
+unresolved principal; member/ancestor walks abort rather than over-grant;
+`RenameEntity` fails closed on a flaky store read. This adapter is the one
+fail-open spot, and it's the security-sensitive one.
+
+## Resolution
+
+The "inert on CLI/no-policy" behavior is legitimate. The fix is to distinguish
+"no policy configured" (inert, allow) from "policy exists but Request absent"
+(fail closed). Wire `transitionGuard` with the resolved
+policy/`*acl.Declarative` at build time; fail closed when a policy exists and
+the Request is missing.

--- a/tickets/entities/review-responses/RR-VB2DE.md
+++ b/tickets/entities/review-responses/RR-VB2DE.md
@@ -1,0 +1,26 @@
+---
+id: RR-VB2DE
+type: review-response
+title: Compile does not validate Default-as-entry-value against declared values (fail-fast gap)
+finding: 'compile.go:78-86: entry = Initial else Default, but the membership check validates only ct.Initial. A machine with initial unset and a typo''d default (e.g. default: aproved) compiles with no boot error, violating the ''malformed machine fails fast at boot'' promise. The bad entry is caught only as a soft downstream enum warning. Fix: validate the resolved entry value (if entry != '''' && !values[entry]) or specifically validate ct.Default when it is the entry source.'
+severity: significant
+resolution: compile.go now validates the RESOLVED entry value (Initial-or-Default) against declared values, naming the source (initial/default) in the error. A typo'd default-as-entry now fails fast at boot. Test TestCompile_RejectsUndeclaredDefaultEntry.
+status: addressed
+---
+
+## Finding
+
+`compile.go:78-86`: `entry = Initial` else `Default`, but the membership check
+at line 83 validates **only** `ct.Initial`. When `Initial == ""`, `entry`
+becomes `ct.Default` unchecked.
+
+A machine with `initial:` unset and `default: aproved` (typo) compiles with no
+boot error — violating `Compile`'s "malformed machine fails fast at boot, never
+at write time" contract. The bad entry surfaces only as a soft downstream enum
+warning, and creates still pass (default applied, then `got == m.entry` matches
+the same typo).
+
+## Resolution
+
+Validate the resolved entry value: `if entry != "" && !values[entry]` → problem,
+or specifically validate `ct.Default` when it is the entry source.

--- a/tickets/entities/tickets/TKT-E4LW2.md
+++ b/tickets/entities/tickets/TKT-E4LW2.md
@@ -5,7 +5,7 @@ title: 'Declarative status/enum state machines: transitions on CustomType with A
 kind: enhancement
 priority: medium
 effort: m
-status: in-progress
+status: done
 ---
 
 ## Scope

--- a/tickets/entities/tickets/TKT-E4LW2.md
+++ b/tickets/entities/tickets/TKT-E4LW2.md
@@ -1,0 +1,254 @@
+---
+id: TKT-E4LW2
+type: ticket
+title: 'Declarative status/enum state machines: transitions on CustomType with ACL-permission guards + predicate preconditions'
+kind: enhancement
+priority: medium
+effort: m
+status: in-progress
+---
+
+## Scope
+
+Extract the **transition** piece from the approval-and-publication lifecycle
+proposal (`.ignored/designs/status-transitions.md` in rela-workflow) as a
+standalone enhancement. Makes the set of *legal* enum transitions first-class
+and declarative. Benefits every status enum in the system (tickets, bugs,
+decisions), not just the register use case.
+
+**Explicitly out of scope** (separate tickets): snapshots / freezing / immutable
+versions, approvals/sign-off entities, the "auto-obsolete sibling on establish"
+invariant (an automation-action concern), notifications, publication.
+
+> **Design review done (6 findings, RR-FPZJX / RR-UJPW4 / RR-EU8GJ / RR-1SMG4 /
+> RR-NGBMT / RR-SGQO3).** The enforcement model below is the *corrected* one —
+> the original "slots into existing ACL + validation calls" plan was wrong. See
+> the review-responses and the ⚠️ notes inline.
+
+## Tier: this is a served-path primitive
+
+This primitive belongs to rela's evolution from *markdown-on-disk* to *network
+service*. On a bare git-backed single-user workflow a gated state machine is
+theater — anyone can `vim entities/ticket/foo.md` and set `status: done`; git is
+the audit log and human review is the gate. The machine only *bites* where
+writes pass through a real chokepoint carrying a `Principal`.
+
+The line is **served vs. direct**, NOT filesystem vs. postgres. Store backend
+and access path are orthogonal:
+
+| Access path                      | Principal? | Chokepoint      | Guard bites? |
+| -------------------------------- | ---------- | --------------- | ------------ |
+| CLI direct write / `vim` on file | no         | none            | no (inert)   |
+| **MCP server** (even on fsstore) | yes        | `entitymanager` | **yes**      |
+| data-entry HTTP (fs *or* pg)     | yes        | `entitymanager` | **yes**      |
+
+fsstore lands on *both* sides: served over MCP/HTTP → gated; reached directly
+via CLI/editor → ungated. An fsstore deployment served over MCP is a
+guard-enforcing deployment (the MCP transport already carries a principal and
+intersects user caps with agent scope — see the `authorization` concept).
+
+Enforcement splits by half, structurally (not a policy knob):
+
+- **Guard half (403).** Enforced on every *served* path (MCP and HTTP, any
+backend). Inert on direct CLI/editor writes — not by tier policy but because
+there is no `Principal` to evaluate. This is *why* the feature is a state
+machine and not a lint: the guard is meaningless without a principal, which is
+meaningless without a served boundary.
+- **Legality half (422).** A graph check — needs no principal. Hard-gated on
+served paths; available as a `rela validate` lint on the CLI path so direct
+edits still get advisory feedback.
+
+Same enforcement boundary and degradation model as the ACL (`NopACL` when no
+served context). This feature rides the data-entry/MCP trajectory, not storage.
+
+## Problem
+
+Today the set of *legal* status transitions is emergent, not declared. A
+`status` enum knows its allowed *values*; it knows nothing about which
+value→value moves are permitted. Legality is inferred from scattered `validate:`
+rules. Nothing stops `backlog → done`. There is no inspectable answer to "from
+`in-review`, where may I go, and who may take me there?"
+
+## Relationship to TKT-XZEY (important — read before building)
+
+TKT-XZEY ("ACL v0.5: parameterised verbs") was reframed twice on user feedback
+(2026-05-21) and reached two conclusions this ticket must respect:
+
+1. **"status is nothing special" — gating must be generic over enum fields, not
+privileged to `status`.** ✅ This design agrees: the machine lives on
+`CustomType`, so *any* enum property that references the type inherits it.
+2. **Per-value fine-grained ACL gating belongs in Lua write-veto hooks, not the
+declarative ACL; `acl.yaml` stays entity-type-grain.** This design **does not
+contradict** that, because it does not introduce a per-value verb
+(`set-prop:status:established`) at all. Instead:
+   - **Transition *legality* (from→to) is metamodel structure, not ACL.** It is a
+graph on the `CustomType`, checked in the write path (422). No ACL verb.
+   - **The `guard` is a coarse *capability noun* (`establish`, `approve`), not a
+per-value rule.** It resolves against the existing declarative
+`RoleDef.Permissions` machinery — entity-type-grain-ish, exactly the declarative
+grain TKT-XZEY wanted to preserve. No verb-cardinality explosion.
+
+So this ticket sidesteps the per-value-verb problem TKT-XZEY rejected by making
+legality *structural* and the guard a *capability*. It effectively supersedes
+TKT-XZEY's original `transition:<state>` verb sketch. TKT-XZEY's residual scope
+(`relation:<type>:add/remove` wire verbs) is independent and unaffected.
+
+Note: TKT-XZEY flagged that `WriteRequest` has no field for a parameterised
+verb. The corrected enforcement below avoids needing one — the transition check
+is a *separate step* in the manager, not a new `WriteRequest` shape.
+
+## Design
+
+State machine = **edges on the reusable `CustomType`** (not on the property; not
+a `-->` string DSL — YAML, no parser to own). A `CustomType` with `transitions:`
+*is* a state machine; any property of that type inherits values + machine.
+Anonymous inline property enums stay value-only (forcing function: want a
+lifecycle → name the type).
+
+```yaml
+types:
+  snapshot-status:
+    values: [in-review, approved, established, obsolete]
+    initial: in-review            # only legal entry state (create path)
+    transitions:
+      - from: in-review
+        to: approved
+        guard: approve            # ACL permission -> 403 if not held
+      - from: approved
+        to: established
+        guard: establish
+        when: "no sibling established"   # precondition -> 422 if false
+      - from: established
+        to: obsolete
+        guard: establish
+```
+
+### guard / when split — two engines, two failure kinds
+
+| Field   | Question                                  | Engine                   | Failure |
+| ------- | ----------------------------------------- | ------------------------ | ------- |
+| `guard` | Do you hold the *right* to do this?       | ACL (subject-aware path) | 403     |
+| `when`  | Is the transition *data-valid right now*? | `internal/predicate`     | 422     |
+
+- **`guard` names an ACL permission** resolved against `RoleDef.Permissions`.
+Metamodel names the permission; `acl.yaml` decides who holds it → machine stays
+free of role names → reusable across deployments.
+- **`when` reuses `internal/predicate`** — but the engine is graph-blind. Graph
+predicates ("no sibling established") need host funcs
+(`count_relations`/`has_relation`) that today live only in the affordances
+`BindingContext` and must be extracted/re-provisioned at the write point
+(RR-EU8GJ — the `when:` half is NOT free).
+- Do NOT collapse authz into `when: "principal.role=='x'"` — hardcodes policy
+into schema, loses reuse, opaque denials.
+
+### Subject-scoping — via topology, not a scope field
+
+Guard is a **global capability noun**; no owner/any distinction on the guard.
+Scoping comes from *how the guarding role is conferred*: static assignment = any
+subject; **role-relation on the ownership edge** (`ticket --assigned-to-->
+person`) = own-subject-only. Same edge, same guard name — scope is an `acl.yaml`
+decision.
+
+**⚠️ Corrected (RR-UJPW4):** this only works if guard resolution uses the
+**subject-aware** ACL path. `holdsPermission` (resolver.go:229) is
+`Globals()`-only and does NOT see relation-conferred local roles — using it
+silently breaks the own-subject case. Resolve via `computeForEntity` /
+`authorizeEntityWrite` (authz_write.go:34-44), which requires the subject ID
+(ties to enforcement ordering below).
+
+**Preconditions (hard):**
+1. Ownership/assignment must be a first-class graph relation the ACL can walk, or
+own-subject scope degrades to global.
+2. Any relation used to confer a governance-scoping role **must** carry
+`requires_permission` (delegate-X gate), else a principal who can write the
+ownership edge self-confers the guarding role (RR-7O6Q self-promotion).
+
+## Enforcement (corrected — RR-FPZJX)
+
+The original plan ("reuse the existing ACL + validation calls") does **not**
+work: in `Manager.UpdateEntity` the ACL runs first (manager.go:489) and
+`metamodel.ValidateEntity` next (499) — both on **new state only** — and
+`oldEntity` is not loaded until line 505, *after* both. So neither existing gate
+can see `from`, hence neither can know which edge (and which guard permission)
+is in play. Also: `internal/validator` is the wrong component (offline batch
+reader, never gates a live write); the write-time 422 is
+`metamodel.ValidateEntity`.
+
+**Fix:** a dedicated **transition-check step** in `Manager.UpdateEntity`,
+positioned *after* `oldEntity` is loaded and *before* the store write (option C;
+option A = re-order the whole path so ACL/validation get old-state is the
+heavier alternative). Steps:
+
+1. Resolve the changed property's `CustomType`; if no `transitions`, skip.
+2. `from = oldEntity[prop]`, `to = newEntity[prop]`; if unchanged, skip.
+3. **Legality:** `(from,to)` must be a declared edge → else 422.
+4. **Guard:** resolve `edge.Guard` via the subject-aware path
+(`computeForEntity`, NOT `holdsPermission`) for `(principal, subjectID)` → else
+403 with `RuleKind: "transition-guard"`, `RuleID: <permission>`.
+5. **Precondition:** evaluate `edge.When` against a graph-backed predicate binding
+→ else 422.
+
+The top-of-`UpdateEntity` ACL call still runs (gates the update *verb* on type);
+the transition guard is an additional gate after old-load. Guard denials audit
+as `denied-write` like any ACL deny.
+
+### Create path (RR-1SMG4)
+
+`CreateEntity` has no old state (no `GetEntity` pre-read, manager.go:334-411),
+so no `from`. Entry semantics, explicit:
+- created value defaults to `initial` (or the enum `default`);
+- any **non-`initial`** value on create → 422 ("illegal entry state");
+- (deferred alternative: model explicit `[*] -> value` entry edges with guards).
+
+## Priced against the code
+
+- **`RuleKind: "transition-guard"`** — additive, no exhaustive switch exists
+(acl.go:101; producers set string literals). Trivial.
+- **Guard resolver** — revised UP from "~15 lines / near-copy of delegate gate":
+the delegate gate uses `Globals()`; a transition guard needs the subject-aware
+`computeForEntity` local-role probes and the subject ID. Still small, but the
+entity-write authz path, not the globals-only delegate gate.
+- **`when:`** — engine is reusable (`internal/predicate`, standalone,
+doc.go:80-83) but graph host-funcs are affordances-specific plumbing; extract to
+a shared package or build a write-path binding context. Not free.
+- **CustomType is the right home** — inline `type:enum` and named types are
+separate, never-merged paths, so `transitions:` on CustomType cleanly means
+named-type-only. **Caveat (RR-NGBMT):** inline enums silently get no machine and
+no warning; add a migration note + optional lint.
+- **Old-state availability** — the automation engine already computes `from`/`to`
+from `OldEntity`/`Entity` (automation/engine.go:210-214), proving the pattern;
+the transition check needs the same pairing, hosted in the manager after
+old-load.
+
+## Load-time validation
+
+- Every `to:`/`from:` references a declared value (no dangling states).
+- `initial` (if set) is a declared value.
+- (Nice-to-have) reachability / unreachable-state warning.
+
+## Acceptance criteria
+
+1. A `CustomType` can declare `transitions` (from/to/guard?/when?) and optional
+`initial`; a property of that type inherits the machine.
+2. On update, changing the value is rejected 422 unless `(from,to)` is a declared
+edge (or the type has no transitions → unconstrained, as today).
+3. On a served path, an edge `guard` is enforced as an ACL permission via the
+**subject-aware** resolver; missing → 403 with `RuleKind: "transition-guard"`,
+`RuleID: <permission>`. Subject-scoped (own-subject) guards work via
+relation-conferred roles. On the direct CLI path the guard is inert (no
+principal) and legality surfaces as a `rela validate` lint.
+4. An edge `when` is enforced as an `internal/predicate` precondition (with
+graph-backed host funcs available); false → 422.
+5. **Create path:** value defaults to `initial`; a non-`initial` value on create
+is rejected 422.
+6. Load-time validation rejects dangling `from`/`to`/`initial`.
+7. Inline `type:enum` properties (no named type) are documented as unguarded; a
+lint/migration path is provided or explicitly deferred.
+
+## References
+
+- Working design doc: `.ignored/designs/status-transitions.md` (rela-workflow)
+- Source proposal: `openvwr-screenshots/tickets/approval-and-publication-lifecycle.md`
+- Supersedes the `transition:<state>` sketch in TKT-XZEY
+- Evaluator convergence: RES-6PK0S3
+- Design-review findings: RR-FPZJX, RR-UJPW4, RR-EU8GJ, RR-1SMG4, RR-NGBMT, RR-SGQO3

--- a/tickets/relations/TKT-E4LW2--affects--authorization.md
+++ b/tickets/relations/TKT-E4LW2--affects--authorization.md
@@ -1,0 +1,5 @@
+---
+from: TKT-E4LW2
+relation: affects
+to: authorization
+---

--- a/tickets/relations/TKT-E4LW2--has-docs--DOCS-STOGZ.md
+++ b/tickets/relations/TKT-E4LW2--has-docs--DOCS-STOGZ.md
@@ -1,0 +1,5 @@
+---
+from: TKT-E4LW2
+relation: has-docs
+to: DOCS-STOGZ
+---

--- a/tickets/relations/TKT-E4LW2--has-implementation--IMPL-CP7L2.md
+++ b/tickets/relations/TKT-E4LW2--has-implementation--IMPL-CP7L2.md
@@ -1,0 +1,5 @@
+---
+from: TKT-E4LW2
+relation: has-implementation
+to: IMPL-CP7L2
+---

--- a/tickets/relations/TKT-E4LW2--has-planning--PLAN-5BYO6.md
+++ b/tickets/relations/TKT-E4LW2--has-planning--PLAN-5BYO6.md
@@ -1,0 +1,5 @@
+---
+from: TKT-E4LW2
+relation: has-planning
+to: PLAN-5BYO6
+---

--- a/tickets/relations/TKT-E4LW2--has-review--REV-9J82V.md
+++ b/tickets/relations/TKT-E4LW2--has-review--REV-9J82V.md
@@ -1,0 +1,5 @@
+---
+from: TKT-E4LW2
+relation: has-review
+to: REV-9J82V
+---

--- a/tickets/relations/TKT-E4LW2--has-review-response--RR-1SMG4.md
+++ b/tickets/relations/TKT-E4LW2--has-review-response--RR-1SMG4.md
@@ -1,0 +1,5 @@
+---
+from: TKT-E4LW2
+relation: has-review-response
+to: RR-1SMG4
+---

--- a/tickets/relations/TKT-E4LW2--has-review-response--RR-EU8GJ.md
+++ b/tickets/relations/TKT-E4LW2--has-review-response--RR-EU8GJ.md
@@ -1,0 +1,5 @@
+---
+from: TKT-E4LW2
+relation: has-review-response
+to: RR-EU8GJ
+---

--- a/tickets/relations/TKT-E4LW2--has-review-response--RR-F30CZ.md
+++ b/tickets/relations/TKT-E4LW2--has-review-response--RR-F30CZ.md
@@ -1,0 +1,5 @@
+---
+from: TKT-E4LW2
+relation: has-review-response
+to: RR-F30CZ
+---

--- a/tickets/relations/TKT-E4LW2--has-review-response--RR-FPZJX.md
+++ b/tickets/relations/TKT-E4LW2--has-review-response--RR-FPZJX.md
@@ -1,0 +1,5 @@
+---
+from: TKT-E4LW2
+relation: has-review-response
+to: RR-FPZJX
+---

--- a/tickets/relations/TKT-E4LW2--has-review-response--RR-HETEE.md
+++ b/tickets/relations/TKT-E4LW2--has-review-response--RR-HETEE.md
@@ -1,0 +1,5 @@
+---
+from: TKT-E4LW2
+relation: has-review-response
+to: RR-HETEE
+---

--- a/tickets/relations/TKT-E4LW2--has-review-response--RR-NB135.md
+++ b/tickets/relations/TKT-E4LW2--has-review-response--RR-NB135.md
@@ -1,0 +1,5 @@
+---
+from: TKT-E4LW2
+relation: has-review-response
+to: RR-NB135
+---

--- a/tickets/relations/TKT-E4LW2--has-review-response--RR-NGBMT.md
+++ b/tickets/relations/TKT-E4LW2--has-review-response--RR-NGBMT.md
@@ -1,0 +1,5 @@
+---
+from: TKT-E4LW2
+relation: has-review-response
+to: RR-NGBMT
+---

--- a/tickets/relations/TKT-E4LW2--has-review-response--RR-NODYR.md
+++ b/tickets/relations/TKT-E4LW2--has-review-response--RR-NODYR.md
@@ -1,0 +1,5 @@
+---
+from: TKT-E4LW2
+relation: has-review-response
+to: RR-NODYR
+---

--- a/tickets/relations/TKT-E4LW2--has-review-response--RR-SGQO3.md
+++ b/tickets/relations/TKT-E4LW2--has-review-response--RR-SGQO3.md
@@ -1,0 +1,5 @@
+---
+from: TKT-E4LW2
+relation: has-review-response
+to: RR-SGQO3
+---

--- a/tickets/relations/TKT-E4LW2--has-review-response--RR-UJPW4.md
+++ b/tickets/relations/TKT-E4LW2--has-review-response--RR-UJPW4.md
@@ -1,0 +1,5 @@
+---
+from: TKT-E4LW2
+relation: has-review-response
+to: RR-UJPW4
+---

--- a/tickets/relations/TKT-E4LW2--has-review-response--RR-UOBUC.md
+++ b/tickets/relations/TKT-E4LW2--has-review-response--RR-UOBUC.md
@@ -1,0 +1,5 @@
+---
+from: TKT-E4LW2
+relation: has-review-response
+to: RR-UOBUC
+---

--- a/tickets/relations/TKT-E4LW2--has-review-response--RR-VB2DE.md
+++ b/tickets/relations/TKT-E4LW2--has-review-response--RR-VB2DE.md
@@ -1,0 +1,5 @@
+---
+from: TKT-E4LW2
+relation: has-review-response
+to: RR-VB2DE
+---

--- a/tickets/relations/TKT-E4LW2--implements--FEAT-AESD4.md
+++ b/tickets/relations/TKT-E4LW2--implements--FEAT-AESD4.md
@@ -1,0 +1,5 @@
+---
+from: TKT-E4LW2
+relation: implements
+to: FEAT-AESD4
+---


### PR DESCRIPTION
## What

Adds declarative enum **state machines** to rela's metamodel (TKT-E4LW2). A `CustomType` can declare `transitions:` (with optional `initial:`), turning any enum property of that type into a governed lifecycle. Each edge carries an optional ACL-permission `guard` and an optional `internal/predicate` `when:` precondition.

Extracted as the standalone *transition* primitive from the approval-and-publication lifecycle proposal. Additive and **inert by default**: a metamodel with no `transitions:` compiles to an empty enforcer and every write behaves exactly as before.

## How

- **`internal/statemachine`** (new): `Compile(meta)` builds an executable enforcer once at startup (fail-fast on malformed machines — dangling from/to/initial/default, dup edges, bad `when:` syntax, list-typed machine property). `EnforceUpdate`/`EnforceCreate` run three checks per changed machine property.
- **Enforcement is a required `entitymanager.Deps` collaborator** run in the fixed write pipeline — `CreateEntity`, `UpdateEntity`, **and `ApplyEntity`** (sync path) all enforce, so no write path can silently skip it.
- **guard → 403** via the subject-aware ACL path (`acl.Request.HoldsPermissionForEntity`, honoring relation-conferred local roles), `RuleKind: transition-guard`. Fails **closed** when a policy is active but the request lacks an ACL context; inert on the direct CLI/no-policy path.
- **legality / `when:` / illegal-entry → 422**.
- `metamodel` stays pure declarative data; `acl` never learns about state machines; the enforcer bridges them via narrow consumer-side interfaces.

## Review trail

- Design review: 6 findings addressed (enforcement ordering, subject-aware guard, graph-backed `when:`, create-path entry, named-type-only, build-vs-reuse).
- Code review (cranky): 6 more addressed — incl. the **critical** `ApplyEntity` bypass and the create-path orphan-on-rejection window.
- Crit: approved, 0 comments over 63 files.

## Verification

`go test ./...` + `-race`, `golangci-lint ./...` (0 issues), `just arch-lint`, `just plimsoll`, `just coverage-check` (statemachine 89%), `just ci` — all green.