### PR TITLE
feat(data-entry): multi-step (wizard) forms with conditional steps (TKT-CHLAJ)

### DIFF
--- a/.go-arch-lint.yml
+++ b/.go-arch-lint.yml
@@ -29,6 +29,7 @@ components:
   # Web / UI layer
   dataentry:        { in: internal/dataentry }
   dataentryconfig:  { in: internal/dataentryconfig }
+  conditionlint:    { in: internal/conditionlint }
   desktop:          { in: internal/desktop }
 
   # Server protocols
@@ -307,6 +308,14 @@ deps:
       - metamodel
     canUse:
       - rrulego
+  # conditionlint reuses the predicate parser to sanity-check wizard-form
+  # condition expressions at author time. It sits above dataentryconfig so the
+  # config package stays free of the predicate dependency.
+  conditionlint:
+    mayDependOn:
+      - dataentryconfig
+      - metamodel
+      - predicate
   desktop:
     canUse:
       - wails
@@ -403,6 +412,7 @@ deps:
       - validator
   projectsetup:
     mayDependOn:
+      - conditionlint
       - dataentryconfig
       - metamodel
       - migration

--- a/docs-project/entities/guides/GUIDE-data-entry.md
+++ b/docs-project/entities/guides/GUIDE-data-entry.md
@@ -558,6 +558,96 @@ relations:
     max_outgoing: 10
 ```
 
+### Multi-step (wizard) forms
+
+A form can be split into ordered, titled **steps** instead of a single page.
+The user moves next/back, per-step validation gates "Next", and steps or fields
+can appear/disappear based on earlier answers. Wizard mode is opt-in: a form
+declares `steps:` **instead of** top-level `fields:`/`relations:` (a form may
+not set both).
+
+```yaml
+forms:
+  new_processing_record:
+    entity_type: processing-record
+    title: "New processing record"
+    steps:
+      - title: "Controller"
+        fields:
+          - property: controller_name
+          - property: has_processors
+            widget: checkbox
+
+      - title: "Processor"
+        # This whole step is skipped unless the toggle is on.
+        visible_when: "form.has_processors == true"
+        fields:
+          - property: processor_name
+            # Required only while the step is shown.
+            required_when: "form.has_processors == true"
+        relations:
+          - relation: processed-by
+            target_type: organisation
+
+      - title: "Publish"
+        fields:
+          - property: published
+```
+
+Each step takes a `title`, an optional `description`, an optional `visible_when`
+condition, and its own `fields:` / `relations:` (identical in shape to a
+single-page form).
+
+**Navigation and the URL.** The active step is encoded in the URL query as
+`?step=N` (zero-based), so a refresh or a shared deep link returns to the same
+step. An out-of-range or non-numeric `?step=` falls back to the first step.
+
+**Validation.** "Next" validates only the current step's visible fields and
+blocks progression while any are invalid. The final step's Submit re-validates
+every visible step.
+
+**Hidden branches are not saved.** If a step or field is hidden by a
+`visible_when` that is false at submit time, its values are dropped from the
+created/updated entity — a toggled-off branch never persists stale data.
+
+#### Condition expressions (`visible_when` / `required_when`)
+
+`visible_when` (on a step, field, or relation) hides its target when the
+expression is false. `required_when` (on a field) makes the field required only
+when the expression is true. Both are boolean expressions evaluated in the
+browser against the form's current values.
+
+| Feature | Syntax |
+| --- | --- |
+| Reference a field | `form.<property>` (e.g. `form.status`) |
+| String / number / boolean / nil literals | `'open'`, `3`, `true`, `false`, `nil` |
+| Comparisons | `==` `!=` `<` `<=` `>` `>=`, regex `=~` |
+| Boolean logic | `and`, `or`, `not`, parentheses |
+
+Examples:
+
+```yaml
+visible_when: "form.kind == 'processor'"
+visible_when: "form.country == 'US' or form.country == 'CA'"
+required_when: "form.has_dpia != true"
+visible_when: "form.q1 == 'no' or form.q2 == 'no'"   # WP248-style decision chain
+```
+
+Notes:
+
+- Comparisons are **permissive**: a checkbox `true` matches both the boolean
+  `true` and the string `'true'`; `form.count == 3` matches the number `3` or
+  the string `'3'`.
+- A condition may reference **any** earlier field; referencing a field the user
+  hasn't reached yet simply reads as unset (`nil`).
+- Conditions are a **UX affordance only** — the server re-validates every write
+  regardless of what the wizard showed or hid. Do not rely on `required_when`
+  as a server-side constraint.
+- Bad conditions are caught by `rela validate`: a syntax error or a reference to
+  a property that doesn't exist on the entity is reported at author time. (The
+  check uses a slightly stricter grammar than the browser, so it may flag a few
+  conditions the runtime would tolerate — treat every reported error as real.)
+
 ## Lists
 
 Lists display entities in a sortable, filterable table with optional create/edit actions.

--- a/docs/data-entry.md
+++ b/docs/data-entry.md
@@ -552,6 +552,96 @@ relations:
     max_outgoing: 10
 ```
 
+### Multi-step (wizard) forms
+
+A form can be split into ordered, titled **steps** instead of a single page.
+The user moves next/back, per-step validation gates "Next", and steps or fields
+can appear/disappear based on earlier answers. Wizard mode is opt-in: a form
+declares `steps:` **instead of** top-level `fields:`/`relations:` (a form may
+not set both).
+
+```yaml
+forms:
+  new_processing_record:
+    entity_type: processing-record
+    title: "New processing record"
+    steps:
+      - title: "Controller"
+        fields:
+          - property: controller_name
+          - property: has_processors
+            widget: checkbox
+
+      - title: "Processor"
+        # This whole step is skipped unless the toggle is on.
+        visible_when: "form.has_processors == true"
+        fields:
+          - property: processor_name
+            # Required only while the step is shown.
+            required_when: "form.has_processors == true"
+        relations:
+          - relation: processed-by
+            target_type: organisation
+
+      - title: "Publish"
+        fields:
+          - property: published
+```
+
+Each step takes a `title`, an optional `description`, an optional `visible_when`
+condition, and its own `fields:` / `relations:` (identical in shape to a
+single-page form).
+
+**Navigation and the URL.** The active step is encoded in the URL query as
+`?step=N` (zero-based), so a refresh or a shared deep link returns to the same
+step. An out-of-range or non-numeric `?step=` falls back to the first step.
+
+**Validation.** "Next" validates only the current step's visible fields and
+blocks progression while any are invalid. The final step's Submit re-validates
+every visible step.
+
+**Hidden branches are not saved.** If a step or field is hidden by a
+`visible_when` that is false at submit time, its values are dropped from the
+created/updated entity — a toggled-off branch never persists stale data.
+
+#### Condition expressions (`visible_when` / `required_when`)
+
+`visible_when` (on a step, field, or relation) hides its target when the
+expression is false. `required_when` (on a field) makes the field required only
+when the expression is true. Both are boolean expressions evaluated in the
+browser against the form's current values.
+
+| Feature | Syntax |
+| --- | --- |
+| Reference a field | `form.<property>` (e.g. `form.status`) |
+| String / number / boolean / nil literals | `'open'`, `3`, `true`, `false`, `nil` |
+| Comparisons | `==` `!=` `<` `<=` `>` `>=`, regex `=~` |
+| Boolean logic | `and`, `or`, `not`, parentheses |
+
+Examples:
+
+```yaml
+visible_when: "form.kind == 'processor'"
+visible_when: "form.country == 'US' or form.country == 'CA'"
+required_when: "form.has_dpia != true"
+visible_when: "form.q1 == 'no' or form.q2 == 'no'"   # WP248-style decision chain
+```
+
+Notes:
+
+- Comparisons are **permissive**: a checkbox `true` matches both the boolean
+  `true` and the string `'true'`; `form.count == 3` matches the number `3` or
+  the string `'3'`.
+- A condition may reference **any** earlier field; referencing a field the user
+  hasn't reached yet simply reads as unset (`nil`).
+- Conditions are a **UX affordance only** — the server re-validates every write
+  regardless of what the wizard showed or hid. Do not rely on `required_when`
+  as a server-side constraint.
+- Bad conditions are caught by `rela validate`: a syntax error or a reference to
+  a property that doesn't exist on the entity is reported at author time. (The
+  check uses a slightly stricter grammar than the browser, so it may flag a few
+  conditions the runtime would tolerate — treat every reported error as real.)
+
 ## Lists
 
 Lists display entities in a sortable, filterable table with optional create/edit actions.

--- a/e2e/pages/form.page.ts
+++ b/e2e/pages/form.page.ts
@@ -58,6 +58,11 @@ export class FormPage extends BasePage {
     await box.setChecked(checked);
   }
 
+  /** Click a wizard step pill by its 0-based visible index. */
+  async clickStep(index: number) {
+    await this.wizardSteps.nth(index).click();
+  }
+
   async clickNext() {
     await this.wizardNextBtn.click();
   }

--- a/e2e/pages/form.page.ts
+++ b/e2e/pages/form.page.ts
@@ -1,5 +1,5 @@
-import { type Page, type Locator, expect } from '@playwright/test';
-import { BasePage } from './base.page';
+import { type Page, type Locator, expect } from "@playwright/test";
+import { BasePage } from "./base.page";
 
 export class FormPage extends BasePage {
   readonly form: Locator;
@@ -9,16 +9,73 @@ export class FormPage extends BasePage {
 
   constructor(page: Page) {
     super(page);
-    this.form = page.locator('form');
-    this.submitButton = page.locator('button[type="submit"], button:has-text("Save"), button:has-text("Create")');
+    this.form = page.locator("form");
+    this.submitButton = page.locator(
+      'button[type="submit"], button:has-text("Save"), button:has-text("Create")',
+    );
     this.cancelButton = page.locator('button:has-text("Cancel")');
-    this.titleInput = page.locator('#field-title');
+    this.titleInput = page.locator("#field-title");
   }
 
   async navigateToCreateForm(formId: string) {
     await this.navigateTo(`/form/${formId}`);
     await this.waitForSpinnerToDisappear();
     await expect(this.titleInput).toBeVisible();
+  }
+
+  // --- Wizard (multi-step) form helpers ---
+
+  private get wizardSteps(): Locator {
+    return this.page.locator(".wizard-steps .wizard-step-pill");
+  }
+
+  private get wizardNextBtn(): Locator {
+    return this.page.locator('.form-actions button:has-text("Next")');
+  }
+
+  private get wizardBackBtn(): Locator {
+    return this.page.locator('.form-actions button:has-text("Back")');
+  }
+
+  /** Titles of the currently-rendered wizard steps, in order. */
+  async wizardStepTitles(): Promise<string[]> {
+    return this.wizardSteps.locator(".wizard-step-title").allInnerTexts();
+  }
+
+  /** The 0-based index of the active wizard step (from the `active` pill). */
+  async activeStepIndex(): Promise<number> {
+    const count = await this.wizardSteps.count();
+    for (let i = 0; i < count; i++) {
+      const cls = (await this.wizardSteps.nth(i).getAttribute("class")) ?? "";
+      if (cls.includes("active")) return i;
+    }
+    return -1;
+  }
+
+  /** Toggle a checkbox field on/off by property name. */
+  async setCheckbox(name: string, checked: boolean) {
+    const box = this.page.locator(`#field-${name}`);
+    await box.setChecked(checked);
+  }
+
+  async clickNext() {
+    await this.wizardNextBtn.click();
+  }
+
+  async clickBack() {
+    await this.wizardBackBtn.click();
+  }
+
+  async isFieldVisible(name: string): Promise<boolean> {
+    return this.page
+      .locator(`#field-${name}`)
+      .isVisible()
+      .catch(() => false);
+  }
+
+  /** Value of the `step` query param on the current URL, or null. */
+  readStepParam(): string | null {
+    return new URL(this.page.url()).searchParams.get("step");
   }
 
   /** Fill a set of property fields keyed by property name. */
@@ -39,7 +96,10 @@ export class FormPage extends BasePage {
   async submitAndExpectCreate(plural: string): Promise<{ id: string }> {
     const [response] = await Promise.all([
       this.page.waitForResponse(
-        r => r.url().includes(`/api/v1/${plural}`) && r.request().method() === 'POST' && r.status() === 201,
+        (r) =>
+          r.url().includes(`/api/v1/${plural}`) &&
+          r.request().method() === "POST" &&
+          r.status() === 201,
       ),
       this.submitButton.click(),
     ]);
@@ -57,7 +117,7 @@ export class FormPage extends BasePage {
    *  `_actions.update === false` for the target entity — AC10 of the
    *  read-only payoff. */
   async expectNotEditableMessage(timeoutMs = 10_000) {
-    const banner = this.page.locator('.not-editable-state');
+    const banner = this.page.locator(".not-editable-state");
     await expect(banner).toBeVisible({ timeout: timeoutMs });
     await expect(banner).toContainText(/not editable/i);
   }
@@ -66,7 +126,9 @@ export class FormPage extends BasePage {
    *  when navigation is triggered by another page (e.g. Edit button on the
    *  document view). */
   async expectAtFormUrl(formId: string, entityId: string) {
-    await this.page.waitForURL(new RegExp(`/form/${formId}/${entityId}`), { timeout: 10000 });
+    await this.page.waitForURL(new RegExp(`/form/${formId}/${entityId}`), {
+      timeout: 10000,
+    });
     await this.waitForSpinnerToDisappear();
   }
 
@@ -74,7 +136,7 @@ export class FormPage extends BasePage {
    *  null if absent. Useful for asserting on the form's return target
    *  without coupling to URL-encoding details (RR-BS0O4). */
   readReturnTo(): string | null {
-    return new URL(this.page.url()).searchParams.get('return_to');
+    return new URL(this.page.url()).searchParams.get("return_to");
   }
 
   async fillField(name: string, value: string) {
@@ -93,15 +155,17 @@ export class FormPage extends BasePage {
 
   async fillMarkdown(value: string) {
     // EasyMDE creates a CodeMirror instance
-    const codeMirror = this.page.locator('.CodeMirror');
+    const codeMirror = this.page.locator(".CodeMirror");
     if (await codeMirror.isVisible({ timeout: 1000 }).catch(() => false)) {
       await codeMirror.click();
       // Clear existing content
-      await this.page.keyboard.press('Meta+a');
+      await this.page.keyboard.press("Meta+a");
       await this.page.keyboard.type(value);
     } else {
       // Fallback to textarea
-      const textarea = this.page.locator('textarea[name="content"], textarea.markdown-input');
+      const textarea = this.page.locator(
+        'textarea[name="content"], textarea.markdown-input',
+      );
       await textarea.fill(value);
     }
   }
@@ -111,8 +175,10 @@ export class FormPage extends BasePage {
     // for the default RelationPicker widget we delegate to
     // `pickInRelationPicker` so both helpers share the same combobox-
     // scoped selector strategy.
-    const relationSection = this.page.locator('.relation-field, .form-field').filter({ hasText: relationName });
-    const select = relationSection.locator('select');
+    const relationSection = this.page
+      .locator(".relation-field, .form-field")
+      .filter({ hasText: relationName });
+    const select = relationSection.locator("select");
     if (await select.isVisible().catch(() => false)) {
       await select.selectOption(targetId);
       return;
@@ -126,33 +192,45 @@ export class FormPage extends BasePage {
     // form always has it. In autosave edit mode it never appears.
     const submitVisible = await this.submitButton
       .first()
-      .waitFor({ state: 'visible', timeout: 2000 })
+      .waitFor({ state: "visible", timeout: 2000 })
       .then(() => true)
       .catch(() => false);
     if (submitVisible) {
       await this.submitButton.first().click();
       // Submit is a client-side fetch followed by a router.push on success.
       // Wait briefly for the URL to change; if validation fails we stay on the form.
-      await this.page.waitForURL((url) => url.toString() !== startUrl, { timeout: 2000 }).catch(() => {});
+      await this.page
+        .waitForURL((url) => url.toString() !== startUrl, { timeout: 2000 })
+        .catch(() => {});
       return;
     }
     // TKT-E6094 autosave: no explicit Submit. Blur, wait for the autosave
     // PATCH(es) to drain, then navigate back; the route guard flushes any
     // pending edits before the URL changes.
-    await this.page.evaluate(() => (document.activeElement as HTMLElement | null)?.blur());
+    await this.page.evaluate(() =>
+      (document.activeElement as HTMLElement | null)?.blur(),
+    );
     await this.page.waitForTimeout(1000);
     await this.page.goBack();
-    await this.page.waitForURL((url) => url.toString() !== startUrl, { timeout: 2000 }).catch(() => {});
+    await this.page
+      .waitForURL((url) => url.toString() !== startUrl, { timeout: 2000 })
+      .catch(() => {});
   }
 
   async cancel() {
     const startUrl = this.page.url();
     await this.cancelButton.click();
-    await this.page.waitForURL((url) => url.toString() !== startUrl, { timeout: 2000 }).catch(() => {});
+    await this.page
+      .waitForURL((url) => url.toString() !== startUrl, { timeout: 2000 })
+      .catch(() => {});
   }
 
   async expectValidationError(message: string) {
-    await expect(this.page.locator('.error, .validation-error, [role="alert"]').filter({ hasText: message })).toBeVisible();
+    await expect(
+      this.page
+        .locator('.error, .validation-error, [role="alert"]')
+        .filter({ hasText: message }),
+    ).toBeVisible();
   }
 
   async expectFieldValue(name: string, value: string) {
@@ -161,7 +239,9 @@ export class FormPage extends BasePage {
   }
 
   async expectFormTitle(title: string) {
-    await expect(this.page.locator('h1, h2, .form-title').filter({ hasText: title })).toBeVisible();
+    await expect(
+      this.page.locator("h1, h2, .form-title").filter({ hasText: title }),
+    ).toBeVisible();
   }
 
   async getFieldValue(name: string): Promise<string> {
@@ -178,7 +258,9 @@ export class FormPage extends BasePage {
   }
 
   async hasValidationError(): Promise<boolean> {
-    const error = this.page.locator('.error, .validation-error, [role="alert"]').first();
+    const error = this.page
+      .locator('.error, .validation-error, .field-error, [role="alert"]')
+      .first();
     return error.isVisible().catch(() => false);
   }
 
@@ -187,7 +269,7 @@ export class FormPage extends BasePage {
     const count = await options.count();
     const values: string[] = [];
     for (let i = 0; i < count; i++) {
-      const v = await options.nth(i).getAttribute('value');
+      const v = await options.nth(i).getAttribute("value");
       if (v) values.push(v);
     }
     return values;
@@ -204,13 +286,15 @@ export class FormPage extends BasePage {
   async saveAndWaitForPatch(plural: string, entityId: string) {
     const submitVisible = await this.submitButton
       .first()
-      .waitFor({ state: 'visible', timeout: 2000 })
+      .waitFor({ state: "visible", timeout: 2000 })
       .then(() => true)
       .catch(() => false);
     if (submitVisible) {
       const [resp] = await Promise.all([
         this.page.waitForResponse(
-          (r) => r.url().includes(`/api/v1/${plural}/${entityId}`) && r.request().method() === 'PATCH',
+          (r) =>
+            r.url().includes(`/api/v1/${plural}/${entityId}`) &&
+            r.request().method() === "PATCH",
         ),
         this.submitButton.first().click(),
       ]);
@@ -220,13 +304,18 @@ export class FormPage extends BasePage {
     // PATCH chain to drain. Multiple edits in quick succession serialize
     // through the FIFO queue, so we wait for an idle window of no PATCH
     // activity. Bounded so a no-edit form doesn't hang.
-    await this.page.evaluate(() => (document.activeElement as HTMLElement | null)?.blur());
-    let lastResp: Awaited<ReturnType<typeof this.page.waitForResponse>> | undefined;
+    await this.page.evaluate(() =>
+      (document.activeElement as HTMLElement | null)?.blur(),
+    );
+    let lastResp:
+      Awaited<ReturnType<typeof this.page.waitForResponse>> | undefined;
     // Poll for PATCH responses until 1s elapses without one.
     for (;;) {
       const resp = await this.page
         .waitForResponse(
-          (r) => r.url().includes(`/api/v1/${plural}/${entityId}`) && r.request().method() === 'PATCH',
+          (r) =>
+            r.url().includes(`/api/v1/${plural}/${entityId}`) &&
+            r.request().method() === "PATCH",
           { timeout: 1500 },
         )
         .catch(() => undefined);
@@ -239,7 +328,9 @@ export class FormPage extends BasePage {
   /** True if the page shows an inline-create UI for related entities. */
   async hasInlineCreateButton(): Promise<boolean> {
     return this.page
-      .locator('button:has-text("New"), .btn-inline-create, [data-create-inline]')
+      .locator(
+        'button:has-text("New"), .btn-inline-create, [data-create-inline]',
+      )
       .first()
       .isVisible()
       .catch(() => false);
@@ -247,31 +338,35 @@ export class FormPage extends BasePage {
 
   async clickInlineCreateButton() {
     await this.page
-      .locator('button:has-text("New"), .btn-inline-create, [data-create-inline]')
+      .locator(
+        'button:has-text("New"), .btn-inline-create, [data-create-inline]',
+      )
       .first()
       .click();
   }
 
   async expectInlineFormVisible() {
-    await expect(this.page.locator('.inline-form, .modal, dialog')).toBeVisible();
+    await expect(
+      this.page.locator(".inline-form, .modal, dialog"),
+    ).toBeVisible();
   }
 
   // --- Markdown body editor (EasyMDE) ---
 
   get contentField(): Locator {
-    return this.page.locator('.content-field');
+    return this.page.locator(".content-field");
   }
 
   get markdownEditorRoot(): Locator {
-    return this.page.locator('.markdown-editor');
+    return this.page.locator(".markdown-editor");
   }
 
   get markdownToolbar(): Locator {
-    return this.page.locator('.editor-toolbar');
+    return this.page.locator(".editor-toolbar");
   }
 
   get codeMirror(): Locator {
-    return this.page.locator('.CodeMirror');
+    return this.page.locator(".CodeMirror");
   }
 
   async expectContentFieldVisible() {
@@ -279,7 +374,7 @@ export class FormPage extends BasePage {
   }
 
   async expectContentLabelHasText(text: string) {
-    await expect(this.contentField.locator('label')).toHaveText(text);
+    await expect(this.contentField.locator("label")).toHaveText(text);
   }
 
   async expectMarkdownEditorReady() {
@@ -302,9 +397,11 @@ export class FormPage extends BasePage {
    *  Implemented via `evaluate` rather than a Locator because computed-style
    *  on a pseudo-element isn't exposed through Playwright's selector API. */
   async getBoldToolbarIconFontFamily(): Promise<string | null> {
-    return this.markdownToolbar.locator('.fa-bold').first().evaluate(
-      (el) => window.getComputedStyle(el, '::before').fontFamily,
-    ).catch(() => null);
+    return this.markdownToolbar
+      .locator(".fa-bold")
+      .first()
+      .evaluate((el) => window.getComputedStyle(el, "::before").fontFamily)
+      .catch(() => null);
   }
 
   // --- Entity-reference picker (TKT-I5NO) ---
@@ -313,27 +410,29 @@ export class FormPage extends BasePage {
    *  title attribute rather than the icon class so the test survives
    *  icon-swap refactors. */
   get insertEntityRefButton(): Locator {
-    return this.markdownToolbar.locator('button[title="Insert entity reference"]')
+    return this.markdownToolbar.locator(
+      'button[title="Insert entity reference"]',
+    );
   }
 
   /** Picker modal overlay. Teleported to <body>, so we query the page
    *  rather than the form root. */
   get entityPickerOverlay(): Locator {
-    return this.page.locator('.entity-picker-overlay')
+    return this.page.locator(".entity-picker-overlay");
   }
 
   get entityPickerInput(): Locator {
-    return this.entityPickerOverlay.locator('.entity-picker-input')
+    return this.entityPickerOverlay.locator(".entity-picker-input");
   }
 
   get entityPickerOptions(): Locator {
-    return this.entityPickerOverlay.locator('.entity-picker-option')
+    return this.entityPickerOverlay.locator(".entity-picker-option");
   }
 
   /** Click the toolbar button and wait for the modal to render. */
   async openEntityPicker(): Promise<void> {
-    await this.insertEntityRefButton.click()
-    await expect(this.entityPickerInput).toBeFocused()
+    await this.insertEntityRefButton.click();
+    await expect(this.entityPickerInput).toBeFocused();
   }
 
   /** Type a query into the picker and wait for results to render. The
@@ -341,8 +440,10 @@ export class FormPage extends BasePage {
    *  five seconds before failing — generous enough that a freshly-created
    *  entity surfaces, tight enough that a real bug still fails fast. */
   async searchEntityPicker(query: string): Promise<void> {
-    await this.entityPickerInput.fill(query)
-    await expect(this.entityPickerOptions.first()).toBeVisible({ timeout: 5_000 })
+    await this.entityPickerInput.fill(query);
+    await expect(this.entityPickerOptions.first()).toBeVisible({
+      timeout: 5_000,
+    });
   }
 
   /** Read the current CodeMirror buffer back as a single string. Used
@@ -353,9 +454,11 @@ export class FormPage extends BasePage {
       // global CodeMirror constructor. EasyMDE preserves the same shape;
       // every line in the document is concatenated with '\n'.
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const cm = (el as any).CodeMirror
-      return typeof cm?.getValue === 'function' ? (cm.getValue() as string) : ''
-    })
+      const cm = (el as any).CodeMirror;
+      return typeof cm?.getValue === "function"
+        ? (cm.getValue() as string)
+        : "";
+    });
   }
 
   // --- Inline backtick autocomplete (TKT-2RCP) ---
@@ -364,15 +467,15 @@ export class FormPage extends BasePage {
    *  backtick in prose context. Rendered next to the editor textarea
    *  (NOT teleported), so we scope to the editor container. */
   get backtickPopup(): Locator {
-    return this.markdownEditorRoot.locator('.backtick-popup')
+    return this.markdownEditorRoot.locator(".backtick-popup");
   }
 
   get backtickPopupOptions(): Locator {
-    return this.backtickPopup.locator('.backtick-popup-option')
+    return this.backtickPopup.locator(".backtick-popup-option");
   }
 
   get backtickPopupHint(): Locator {
-    return this.backtickPopup.locator('.backtick-popup-hint')
+    return this.backtickPopup.locator(".backtick-popup-hint");
   }
 
   /** Type a single character into the editor at the current cursor.
@@ -382,14 +485,17 @@ export class FormPage extends BasePage {
    *  `.CodeMirror` lands on the gutter wrapper, not the hidden
    *  textarea that captures input events. */
   async typeIntoEditor(text: string): Promise<void> {
-    await this.codeMirror.click()
+    await this.codeMirror.click();
     await this.page.evaluate(() => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const cm = (document.querySelector('.CodeMirror') as any)?.CodeMirror
-      cm?.focus()
-    })
+      const cm = (document.querySelector(".CodeMirror") as any)?.CodeMirror;
+      cm?.focus();
+    });
     for (const ch of text) {
-      await this.page.evaluate((c) => document.execCommand('insertText', false, c), ch)
+      await this.page.evaluate(
+        (c) => document.execCommand("insertText", false, c),
+        ch,
+      );
     }
   }
 
@@ -401,39 +507,39 @@ export class FormPage extends BasePage {
   async useFastAutocompleteDelay(delayMs = 30): Promise<void> {
     await this.page.addInitScript((d) => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      ;(window as any).__BACKTICK_AUTOCOMPLETE_DELAY_MS__ = d
-    }, delayMs)
+      (window as any).__BACKTICK_AUTOCOMPLETE_DELAY_MS__ = d;
+    }, delayMs);
   }
 
   /** Clear the editor's buffer entirely. Useful when a form preloads a
    *  template body and the test wants a known starting state. */
   async clearEditorBuffer(): Promise<void> {
-    await this.codeMirror.click()
+    await this.codeMirror.click();
     await this.page.evaluate(() => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const cm = (document.querySelector('.CodeMirror') as any)?.CodeMirror
+      const cm = (document.querySelector(".CodeMirror") as any)?.CodeMirror;
       if (cm) {
-        cm.setValue('')
-        cm.focus()
-        cm.setCursor({ line: 0, ch: 0 })
+        cm.setValue("");
+        cm.focus();
+        cm.setCursor({ line: 0, ch: 0 });
       }
-    })
+    });
   }
 
   /** Wait for the inline autocomplete popup to appear. Default 1500 ms
    *  (well above the 600 ms open delay). */
   async waitForBacktickPopup(): Promise<void> {
-    await this.backtickPopup.waitFor({ state: 'visible', timeout: 1_500 })
+    await this.backtickPopup.waitFor({ state: "visible", timeout: 1_500 });
   }
 
   // --- Template selector ---
 
   get templateSelector(): Locator {
-    return this.page.locator('.template-selector');
+    return this.page.locator(".template-selector");
   }
 
   get templatePills(): Locator {
-    return this.page.locator('.template-pill');
+    return this.page.locator(".template-pill");
   }
 
   async templatePillCount(): Promise<number> {
@@ -459,14 +565,14 @@ export class FormPage extends BasePage {
    *  top; we filter on the label text. */
   relationPickerByLabel(label: string): Locator {
     return this.page
-      .locator('.form-field.relation-picker', { hasText: label })
+      .locator(".form-field.relation-picker", { hasText: label })
       .first();
   }
 
   /** A selected-entity tile inside a relation picker. The tile renders the
    *  entity's title (via `getEntityLabel`), so callers pass the title text. */
   pickerTileByText(picker: Locator, text: string): Locator {
-    return picker.locator('.selected-entity', { hasText: text });
+    return picker.locator(".selected-entity", { hasText: text });
   }
 
   /** Type into the picker's combobox input and click the dropdown item
@@ -475,18 +581,26 @@ export class FormPage extends BasePage {
    *  when the form has multiple pickers open. Cards-widget callers want
    *  `RelationCardsPage.linkTargetByIdWithSearch` instead; that path
    *  surfaces a different (search-then-meta-form) UI. */
-  async pickInRelationPicker(picker: Locator, query: string, optionText: string) {
+  async pickInRelationPicker(
+    picker: Locator,
+    query: string,
+    optionText: string,
+  ) {
     const search = picker.locator('input[role="combobox"]');
     await expect(search).toBeVisible();
     await search.fill(query);
-    const option = picker.locator('.dropdown-item', { hasText: optionText }).first();
+    const option = picker
+      .locator(".dropdown-item", { hasText: optionText })
+      .first();
     await expect(option).toBeVisible();
     await option.click();
   }
 
   /** Remove a selected entity tile from a relation picker. */
   async removePickerTile(picker: Locator, tileText: string) {
-    await this.pickerTileByText(picker, tileText).locator('.remove-btn').click();
+    await this.pickerTileByText(picker, tileText)
+      .locator(".remove-btn")
+      .click();
   }
 
   async saveAndWaitForNavigation() {
@@ -500,7 +614,7 @@ export class FormPage extends BasePage {
   }
 
   get prefixSelect(): Locator {
-    return this.page.locator('.id-field select');
+    return this.page.locator(".id-field select");
   }
 
   async expectIdInputVisible() {
@@ -524,6 +638,6 @@ export class FormPage extends BasePage {
   }
 
   async getPrefixOptions(): Promise<string[]> {
-    return this.prefixSelect.locator('option').allTextContents();
+    return this.prefixSelect.locator("option").allTextContents();
   }
 }

--- a/e2e/pages/form.page.ts
+++ b/e2e/pages/form.page.ts
@@ -30,11 +30,11 @@ export class FormPage extends BasePage {
   }
 
   private get wizardNextBtn(): Locator {
-    return this.page.locator('.form-actions button:has-text("Next")');
+    return this.page.locator('.form-actions button:has-text("Next step")');
   }
 
   private get wizardBackBtn(): Locator {
-    return this.page.locator('.form-actions button:has-text("Back")');
+    return this.page.locator('.form-actions button:has-text("Prev step")');
   }
 
   /** Titles of the currently-rendered wizard steps, in order. */

--- a/e2e/pages/form.page.ts
+++ b/e2e/pages/form.page.ts
@@ -67,6 +67,11 @@ export class FormPage extends BasePage {
     await this.wizardNextBtn.click();
   }
 
+  /** Click the wizard's Create/Save submit button (last step). */
+  async clickCreate() {
+    await this.page.locator('.form-actions button[type="submit"]').click();
+  }
+
   async clickBack() {
     await this.wizardBackBtn.click();
   }
@@ -81,6 +86,24 @@ export class FormPage extends BasePage {
   /** Value of the `step` query param on the current URL, or null. */
   readStepParam(): string | null {
     return new URL(this.page.url()).searchParams.get("step");
+  }
+
+  /** 0-based indices of wizard step pills currently flagged with an error. */
+  async erroredStepIndices(): Promise<number[]> {
+    const count = await this.wizardSteps.count();
+    const out: number[] = [];
+    for (let i = 0; i < count; i++) {
+      const cls = (await this.wizardSteps.nth(i).getAttribute("class")) ?? "";
+      if (cls.includes("has-errors")) out.push(i);
+    }
+    return out;
+  }
+
+  /** Text of the wizard's submit-time error summary, or null if not shown. */
+  async errorSummaryText(): Promise<string | null> {
+    const el = this.page.locator(".wizard-error-summary");
+    if (!(await el.isVisible().catch(() => false))) return null;
+    return el.innerText();
   }
 
   /** Fill a set of property fields keyed by property name. */

--- a/e2e/tests/fixtures.ts
+++ b/e2e/tests/fixtures.ts
@@ -759,6 +759,27 @@ forms:
       - relation: fixes
         label: Fixes Bug
 
+  # Wizard (multi-step) task form — exercises steps, visible_when,
+  # required_when, next/back, and hidden-branch pruning (wizard.spec.ts).
+  task_wizard:
+    entity_type: task
+    title: "New Task (wizard)"
+    steps:
+      - title: "Basics"
+        fields:
+          - property: title
+          - property: done
+            widget: checkbox
+      - title: "Assignment"
+        # Only shown once the task is marked done.
+        visible_when: "form.done == true"
+        fields:
+          - property: assignee
+            required_when: "form.done == true"
+      - title: "Status"
+        fields:
+          - property: status
+
   tag:
     entity_type: tag
     title: "Tag"

--- a/e2e/tests/fixtures.ts
+++ b/e2e/tests/fixtures.ts
@@ -851,6 +851,10 @@ forms:
         fields:
           - property: assignee
             required_when: "form.done == true"
+        # A relation under a conditional step — must also be pruned when hidden.
+        relations:
+          - relation: implements
+            label: "Implements"
       - title: "Status"
         fields:
           - property: status

--- a/e2e/tests/fixtures.ts
+++ b/e2e/tests/fixtures.ts
@@ -3,7 +3,7 @@ import {
   type Page,
   type APIRequestContext,
 } from "@playwright/test";
-import { spawn, type ChildProcess, execSync } from "child_process";
+import { spawn, type ChildProcess, execFileSync } from "child_process";
 import * as path from "path";
 import * as fs from "fs";
 import * as os from "os";
@@ -271,7 +271,10 @@ function buildIfMissing(binaryPath: string, target: string): string {
   }
   try {
     console.log(`Building ${path.basename(binaryPath)}...`);
-    execSync(`go build -o ${binaryPath} ${target}`, {
+    // execFileSync with an args array: no shell, so the absolute paths can't
+    // be interpreted as shell syntax (CodeQL js/shell-command-injection-from-
+    // environment; also just breaks on checkout paths containing spaces).
+    execFileSync("go", ["build", "-o", binaryPath, target], {
       cwd: PROJECT_ROOT,
       stdio: "inherit",
     });

--- a/e2e/tests/fixtures.ts
+++ b/e2e/tests/fixtures.ts
@@ -1,12 +1,16 @@
-import { test as base, type Page, type APIRequestContext } from '@playwright/test';
-import { spawn, type ChildProcess, execSync } from 'child_process';
-import * as path from 'path';
-import * as fs from 'fs';
-import * as os from 'os';
-import * as net from 'net';
+import {
+  test as base,
+  type Page,
+  type APIRequestContext,
+} from "@playwright/test";
+import { spawn, type ChildProcess, execSync } from "child_process";
+import * as path from "path";
+import * as fs from "fs";
+import * as os from "os";
+import * as net from "net";
 
-const PROJECT_ROOT = path.resolve(__dirname, '../..');
-const SERVER_BINARY = path.join(PROJECT_ROOT, 'bin', 'rela-server');
+const PROJECT_ROOT = path.resolve(__dirname, "../..");
+const SERVER_BINARY = path.join(PROJECT_ROOT, "bin", "rela-server");
 // Resolve symlinks once — macOS $TMPDIR is typically /var/folders/... which
 // canonicalises to /private/var/folders/.... Tests that compare paths want
 // the canonical form. (review-response RR-F3IA3)
@@ -19,24 +23,24 @@ const TMPDIR = fs.realpathSync(os.tmpdir());
  */
 export const STATUS = {
   feature: {
-    draft: 'draft',
-    approved: 'approved',
-    in_progress: 'in_progress',
-    done: 'done',
+    draft: "draft",
+    approved: "approved",
+    in_progress: "in_progress",
+    done: "done",
   },
 } as const;
 
 export const SEVERITY = {
-  low: 'low',
-  medium: 'medium',
-  high: 'high',
-  critical: 'critical',
+  low: "low",
+  medium: "medium",
+  high: "high",
+  critical: "critical",
 } as const;
 
 export const PRIORITY = {
-  low: 'low',
-  medium: 'medium',
-  high: 'high',
+  low: "low",
+  medium: "medium",
+  high: "high",
 } as const;
 
 /** The metamodel analysis check types the backend emits (via runAnalysis()
@@ -46,31 +50,38 @@ export const PRIORITY = {
  *  Keep in lockstep with runAnalysis() and with CHECK_TYPES in
  *  frontend/src/views/AnalyzeView.vue. The Go-side test
  *  TestRunAnalysisSectionNames pins the wire contract. */
-export const ANALYSIS_CHECKS = ['Properties', 'Cardinality', 'Validations', 'Orphans', 'Duplicates', 'ID Gaps'] as const;
+export const ANALYSIS_CHECKS = [
+  "Properties",
+  "Cardinality",
+  "Validations",
+  "Orphans",
+  "Duplicates",
+  "ID Gaps",
+] as const;
 
 /** Seed entity IDs present in every fresh test project. Assumes the inline
  *  seed data below, in insertion order. Import from specs instead of
  *  writing 'FEAT-001' / 'BUG-001' strings directly. */
 export const SEED = {
   features: {
-    authentication: 'FEAT-001',
-    dashboardAnalytics: 'FEAT-002',
-    exportData: 'FEAT-003',
+    authentication: "FEAT-001",
+    dashboardAnalytics: "FEAT-002",
+    exportData: "FEAT-003",
     /** Body content contains two GFM checkboxes (one unchecked, one checked).
      *  Used by checkboxes.spec.ts to exercise the toggle UI. */
-    checkboxBody: 'FEAT-004',
+    checkboxBody: "FEAT-004",
   },
   bugs: {
-    loginFormValidation: 'BUG-001',
-    memoryLeak: 'BUG-002',
+    loginFormValidation: "BUG-001",
+    memoryLeak: "BUG-002",
   },
   tasks: {
-    writeUnitTests: 'TASK-001',
+    writeUnitTests: "TASK-001",
     /** Unlinked task. Used by reverse-relations.spec.ts as a candidate for
      *  the non-cards "Implemented by" picker on FEAT-001 — the existing
      *  TASK-001 already implements FEAT-001, so we need a second task that
      *  the add-test can pick without colliding. */
-    refactorAuth: 'TASK-002',
+    refactorAuth: "TASK-002",
   },
 } as const;
 
@@ -102,18 +113,44 @@ export interface PaginatedResponse<T = EntityResponse> {
 }
 
 export interface ApiHelpers {
-  createEntity(plural: string, data: { properties: Record<string, unknown>; content?: string; relations?: ModernRelationsField; id?: string; prefix?: string }): Promise<EntityResponse>;
+  createEntity(
+    plural: string,
+    data: {
+      properties: Record<string, unknown>;
+      content?: string;
+      relations?: ModernRelationsField;
+      id?: string;
+      prefix?: string;
+    },
+  ): Promise<EntityResponse>;
   getEntity(plural: string, id: string): Promise<EntityResponse>;
-  updateEntity(plural: string, id: string, properties: Record<string, unknown>): Promise<EntityResponse>;
+  updateEntity(
+    plural: string,
+    id: string,
+    properties: Record<string, unknown>,
+  ): Promise<EntityResponse>;
   deleteEntity(plural: string, id: string): Promise<void>;
   listEntities(plural: string, query?: string): Promise<PaginatedResponse>;
-  createRelation(fromPlural: string, fromId: string, relation: string, toId: string): Promise<void>;
+  createRelation(
+    fromPlural: string,
+    fromId: string,
+    relation: string,
+    toId: string,
+  ): Promise<void>;
   /** Returns the current set of outgoing relation edges of the given type for an entity.
    *  Each edge exposes `id` (target entity) and `meta` (relation-property values). */
-  listRelations(plural: string, id: string, relation: string): Promise<Array<{ id: string; meta?: Record<string, unknown> }>>;
+  listRelations(
+    plural: string,
+    id: string,
+    relation: string,
+  ): Promise<Array<{ id: string; meta?: Record<string, unknown> }>>;
   /** Returns the markdown body of an entity, or "" if the entity has no body. */
   getContent(plural: string, id: string): Promise<string>;
-  rawRequest(method: string, path: string, data?: unknown): Promise<import('@playwright/test').APIResponse>;
+  rawRequest(
+    method: string,
+    path: string,
+    data?: unknown,
+  ): Promise<import("@playwright/test").APIResponse>;
   /** Wait for an entity to appear in the search index. Use before
    *  navigating to a view that reads via /_search (dashboard, search). */
   waitForIndexed(id: string, options?: { timeout?: number }): Promise<void>;
@@ -136,16 +173,16 @@ export interface WorkerFixtures {
 async function findFreePort(): Promise<number> {
   return new Promise((resolve, reject) => {
     const server = net.createServer();
-    server.listen(0, '127.0.0.1', () => {
+    server.listen(0, "127.0.0.1", () => {
       const addr = server.address();
-      if (addr && typeof addr === 'object') {
+      if (addr && typeof addr === "object") {
         const port = addr.port;
         server.close(() => resolve(port));
       } else {
-        reject(new Error('Could not get port'));
+        reject(new Error("Could not get port"));
       }
     });
-    server.on('error', reject);
+    server.on("error", reject);
   });
 }
 
@@ -154,7 +191,11 @@ async function findFreePort(): Promise<number> {
  *  handlers are wired, which is why we target /api/v1/_config specifically
  *  (see RR-LWG6W). The backend's security middleware otherwise rejects
  *  Origin-less probes with 403 origin_missing, so we always send Origin. */
-async function waitForServer(url: string, origin: string, timeout = 30000): Promise<void> {
+async function waitForServer(
+  url: string,
+  origin: string,
+  timeout = 30000,
+): Promise<void> {
   const start = Date.now();
   const probeUrl = `${url}/api/v1/_config`;
   while (Date.now() - start < timeout) {
@@ -172,16 +213,19 @@ async function waitForServer(url: string, origin: string, timeout = 30000): Prom
 /** Wait for a child process to actually exit. SIGTERM is async; a bare
  *  proc.kill() returns immediately and the kernel may hold the socket past the
  *  next test start. See RR-17XTS. */
-async function waitForExit(proc: ChildProcess, signal: NodeJS.Signals = 'SIGTERM'): Promise<void> {
+async function waitForExit(
+  proc: ChildProcess,
+  signal: NodeJS.Signals = "SIGTERM",
+): Promise<void> {
   if (proc.exitCode !== null || proc.signalCode !== null) return;
   await new Promise<void>((resolve) => {
     const done = () => resolve();
-    proc.once('exit', done);
+    proc.once("exit", done);
     proc.kill(signal);
     // Escalate to SIGKILL if the server refuses to die within 5s
     setTimeout(() => {
       if (proc.exitCode === null && proc.signalCode === null) {
-        proc.kill('SIGKILL');
+        proc.kill("SIGKILL");
       }
     }, 5000);
   });
@@ -196,7 +240,7 @@ function buildIfMissing(binaryPath: string, target: string): string {
   if (process.env.CI) {
     throw new Error(
       `Missing ${binaryPath} in CI. The e2e CI job is expected to build it in a prior step; ` +
-        'do not fall back to in-fixture builds on CI.',
+        "do not fall back to in-fixture builds on CI.",
     );
   }
 
@@ -210,10 +254,13 @@ function buildIfMissing(binaryPath: string, target: string): string {
       acquired = true;
     } catch (e) {
       const code = (e as NodeJS.ErrnoException).code;
-      if (code !== 'EEXIST') throw e;
+      if (code !== "EEXIST") throw e;
       if (fs.existsSync(binaryPath)) return binaryPath;
       if (Date.now() - start > 300_000) {
-        throw new Error(`Build lock ${lockPath} held > 5 min; something is stuck.`, { cause: e });
+        throw new Error(
+          `Build lock ${lockPath} held > 5 min; something is stuck.`,
+          { cause: e },
+        );
       }
       // busy-wait 250ms; builds take seconds
       const end = Date.now() + 250;
@@ -224,7 +271,10 @@ function buildIfMissing(binaryPath: string, target: string): string {
   }
   try {
     console.log(`Building ${path.basename(binaryPath)}...`);
-    execSync(`go build -o ${binaryPath} ${target}`, { cwd: PROJECT_ROOT, stdio: 'inherit' });
+    execSync(`go build -o ${binaryPath} ${target}`, {
+      cwd: PROJECT_ROOT,
+      stdio: "inherit",
+    });
   } finally {
     fs.rmdirSync(lockPath);
   }
@@ -232,17 +282,20 @@ function buildIfMissing(binaryPath: string, target: string): string {
 }
 
 function createTestProject(): string {
-  const tmpDir = fs.mkdtempSync(path.join(TMPDIR, 'rela-e2e-'));
-  fs.writeFileSync(path.join(tmpDir, 'metamodel.yaml'), METAMODEL_YAML);
-  fs.writeFileSync(path.join(tmpDir, 'data-entry.yaml'), DATA_ENTRY_YAML);
-  fs.mkdirSync(path.join(tmpDir, 'entities', 'features'), { recursive: true });
-  fs.mkdirSync(path.join(tmpDir, 'entities', 'bugs'), { recursive: true });
-  fs.mkdirSync(path.join(tmpDir, 'entities', 'tasks'), { recursive: true });
-  fs.mkdirSync(path.join(tmpDir, 'relations'), { recursive: true });
-  fs.mkdirSync(path.join(tmpDir, 'templates', 'entities'), { recursive: true });
-  fs.mkdirSync(path.join(tmpDir, 'scripts', 'docs'), { recursive: true });
-  fs.mkdirSync(path.join(tmpDir, 'apps', 'e2e-demo'), { recursive: true });
-  fs.writeFileSync(path.join(tmpDir, 'apps', 'e2e-demo', 'index.html'), E2E_DEMO_APP_HTML);
+  const tmpDir = fs.mkdtempSync(path.join(TMPDIR, "rela-e2e-"));
+  fs.writeFileSync(path.join(tmpDir, "metamodel.yaml"), METAMODEL_YAML);
+  fs.writeFileSync(path.join(tmpDir, "data-entry.yaml"), DATA_ENTRY_YAML);
+  fs.mkdirSync(path.join(tmpDir, "entities", "features"), { recursive: true });
+  fs.mkdirSync(path.join(tmpDir, "entities", "bugs"), { recursive: true });
+  fs.mkdirSync(path.join(tmpDir, "entities", "tasks"), { recursive: true });
+  fs.mkdirSync(path.join(tmpDir, "relations"), { recursive: true });
+  fs.mkdirSync(path.join(tmpDir, "templates", "entities"), { recursive: true });
+  fs.mkdirSync(path.join(tmpDir, "scripts", "docs"), { recursive: true });
+  fs.mkdirSync(path.join(tmpDir, "apps", "e2e-demo"), { recursive: true });
+  fs.writeFileSync(
+    path.join(tmpDir, "apps", "e2e-demo", "index.html"),
+    E2E_DEMO_APP_HTML,
+  );
   for (const [rel, content] of Object.entries(SEED_ENTITIES)) {
     fs.writeFileSync(path.join(tmpDir, rel), content);
   }
@@ -269,13 +322,13 @@ async function spawnServer(
     const url = `http://localhost:${port}`;
     const proc: ChildProcess = spawn(
       serverBinary,
-      ['-port', String(port), '-allowed-origin', url],
-      { cwd, env: process.env, stdio: ['ignore', 'pipe', 'pipe'] },
+      ["-port", String(port), "-allowed-origin", url],
+      { cwd, env: process.env, stdio: ["ignore", "pipe", "pipe"] },
     );
-    let stdout = '';
-    let stderr = '';
-    proc.stdout?.on('data', (d) => (stdout += d.toString()));
-    proc.stderr?.on('data', (d) => (stderr += d.toString()));
+    let stdout = "";
+    let stderr = "";
+    proc.stdout?.on("data", (d) => (stdout += d.toString()));
+    proc.stderr?.on("data", (d) => (stderr += d.toString()));
 
     try {
       await waitForServer(url, url);
@@ -289,16 +342,18 @@ async function spawnServer(
       await waitForExit(proc);
     }
   }
-  throw new Error(`Failed to start rela-server after ${attempts} attempts: ${String(lastErr)}`);
+  throw new Error(
+    `Failed to start rela-server after ${attempts} attempts: ${String(lastErr)}`,
+  );
 }
 
 export const test = base.extend<TestFixtures, WorkerFixtures>({
   serverBinary: [
     // eslint-disable-next-line no-empty-pattern
     async ({}, use) => {
-      await use(buildIfMissing(SERVER_BINARY, './cmd/rela-server'));
+      await use(buildIfMissing(SERVER_BINARY, "./cmd/rela-server"));
     },
-    { scope: 'worker' },
+    { scope: "worker" },
   ],
 
   // eslint-disable-next-line no-empty-pattern
@@ -323,7 +378,10 @@ export const test = base.extend<TestFixtures, WorkerFixtures>({
       if (testInfo.status !== testInfo.expectedStatus) {
         // Attach server logs to the failing test so a CI reader can correlate
         // a 500 with what the backend was saying. (review-response RR-J9BIT)
-        await testInfo.attach('rela-server.log', { body: logs(), contentType: 'text/plain' });
+        await testInfo.attach("rela-server.log", {
+          body: logs(),
+          contentType: "text/plain",
+        });
       }
       await waitForExit(proc);
     }
@@ -343,7 +401,7 @@ export const test = base.extend<TestFixtures, WorkerFixtures>({
     // future "let me just grab this CDN script" mistake across the whole SPA.
     const allowedOrigin = new URL(serverUrl).origin;
     const offOriginRequests: string[] = [];
-    page.on('request', (req) => {
+    page.on("request", (req) => {
       const url = req.url();
       if (!/^https?:/i.test(url)) return; // data:, blob:, file: are local
       let origin: string;
@@ -367,10 +425,10 @@ export const test = base.extend<TestFixtures, WorkerFixtures>({
     // fail the test in afterEach, so EVERY navigation in EVERY spec is an
     // unmount-error probe for free — not just the dedicated regression test.
     const vueErrors: string[] = [];
-    page.on('console', (msg) => {
-      if (msg.type() !== 'error') return;
+    page.on("console", (msg) => {
+      if (msg.type() !== "error") return;
       const text = msg.text();
-      if (text.startsWith('[vue-error]')) vueErrors.push(text);
+      if (text.startsWith("[vue-error]")) vueErrors.push(text);
     });
 
     await page.goto(`${serverUrl}/`);
@@ -378,27 +436,31 @@ export const test = base.extend<TestFixtures, WorkerFixtures>({
     await context.close();
 
     if (vueErrors.length > 0) {
-      await testInfo.attach('vue-errors', {
-        body: vueErrors.join('\n\n'),
-        contentType: 'text/plain',
+      await testInfo.attach("vue-errors", {
+        body: vueErrors.join("\n\n"),
+        contentType: "text/plain",
       });
       throw new Error(
         `The SPA's Vue error handler fired ${vueErrors.length} time(s) during this test ` +
           `(framework-swallowed errors — e.g. a lifecycle/unmount crash, see issue #997): ` +
-          `${vueErrors[0].split('\n')[0]}` +
-          (vueErrors.length > 1 ? ` (+${vueErrors.length - 1} more — see attachment)` : ''),
+          `${vueErrors[0].split("\n")[0]}` +
+          (vueErrors.length > 1
+            ? ` (+${vueErrors.length - 1} more — see attachment)`
+            : ""),
       );
     }
 
     if (offOriginRequests.length > 0) {
-      await testInfo.attach('off-origin-requests', {
-        body: offOriginRequests.join('\n'),
-        contentType: 'text/plain',
+      await testInfo.attach("off-origin-requests", {
+        body: offOriginRequests.join("\n"),
+        contentType: "text/plain",
       });
       throw new Error(
         `rela-server is meant to be self-contained but the SPA fetched ${offOriginRequests.length} ` +
-          `off-origin URL(s): ${offOriginRequests.slice(0, 5).join(', ')}` +
-          (offOriginRequests.length > 5 ? ` (+${offOriginRequests.length - 5} more — see attachment)` : ''),
+          `off-origin URL(s): ${offOriginRequests.slice(0, 5).join(", ")}` +
+          (offOriginRequests.length > 5
+            ? ` (+${offOriginRequests.length - 5} more — see attachment)`
+            : ""),
       );
     }
   },
@@ -414,43 +476,53 @@ export const test = base.extend<TestFixtures, WorkerFixtures>({
         headers: { Origin: serverUrl },
       };
       if (data !== undefined) options.data = data;
-      const resp = await request.fetch(`${serverUrl}/api/v1/${apiPath}`, options);
+      const resp = await request.fetch(
+        `${serverUrl}/api/v1/${apiPath}`,
+        options,
+      );
       if (!resp.ok()) {
-        throw new Error(`${method} /api/v1/${apiPath} → ${resp.status()}: ${await resp.text()}`);
+        throw new Error(
+          `${method} /api/v1/${apiPath} → ${resp.status()}: ${await resp.text()}`,
+        );
       }
       return resp;
     }
 
     await use({
       async createEntity(plural, data) {
-        return (await call('POST', plural, data)).json();
+        return (await call("POST", plural, data)).json();
       },
       async getEntity(plural, id) {
-        return (await call('GET', `${plural}/${id}`)).json();
+        return (await call("GET", `${plural}/${id}`)).json();
       },
       async updateEntity(plural, id, properties) {
-        return (await call('PATCH', `${plural}/${id}`, { properties })).json();
+        return (await call("PATCH", `${plural}/${id}`, { properties })).json();
       },
       async deleteEntity(plural, id) {
         // Fails loudly on error. Callers doing cleanup should append
         // `.catch(() => {})` explicitly. (RR-MS1FM)
-        await call('DELETE', `${plural}/${id}`);
+        await call("DELETE", `${plural}/${id}`);
       },
       async listEntities(plural, query) {
         const p = query ? `${plural}?${query}` : plural;
-        return (await call('GET', p)).json();
+        return (await call("GET", p)).json();
       },
       async createRelation(fromPlural, fromId, relation, toId) {
-        await call('POST', `${fromPlural}/${fromId}/relations/${relation}`, { id: toId });
+        await call("POST", `${fromPlural}/${fromId}/relations/${relation}`, {
+          id: toId,
+        });
       },
       async listRelations(plural, id, relation) {
-        const resp = await call('GET', `${plural}/${id}/relations/${relation}`);
-        return (await resp.json()) as Array<{ id: string; meta?: Record<string, unknown> }>;
+        const resp = await call("GET", `${plural}/${id}/relations/${relation}`);
+        return (await resp.json()) as Array<{
+          id: string;
+          meta?: Record<string, unknown>;
+        }>;
       },
       async getContent(plural, id) {
-        const resp = await call('GET', `${plural}/${id}`);
+        const resp = await call("GET", `${plural}/${id}`);
         const body = (await resp.json()) as { content?: string };
-        return body.content ?? '';
+        return body.content ?? "";
       },
       async rawRequest(method, apiPath, data) {
         return call(method, apiPath, data);
@@ -463,28 +535,30 @@ export const test = base.extend<TestFixtures, WorkerFixtures>({
         const start = Date.now();
         // Infer plural from id prefix. Keep this narrow — the inline project
         // only has three entity types.
-        const prefix = id.split('-')[0];
+        const prefix = id.split("-")[0];
         const pluralByPrefix: Record<string, string> = {
-          FEAT: 'features',
-          BUG: 'bugs',
-          TASK: 'tasks',
+          FEAT: "features",
+          BUG: "bugs",
+          TASK: "tasks",
         };
         const plural = pluralByPrefix[prefix];
         if (!plural) {
           throw new Error(`waitForIndexed: unknown ID prefix for ${id}`);
         }
         while (Date.now() - start < timeout) {
-          const resp = await call('GET', `${plural}/${id}`).catch(() => null);
+          const resp = await call("GET", `${plural}/${id}`).catch(() => null);
           if (resp && resp.ok()) return;
           await new Promise((r) => setTimeout(r, 100));
         }
-        throw new Error(`entity ${id} not reachable via GET /${plural}/${id} within ${timeout}ms`);
+        throw new Error(
+          `entity ${id} not reachable via GET /${plural}/${id} within ${timeout}ms`,
+        );
       },
     });
   },
 });
 
-export { expect } from '@playwright/test';
+export { expect } from "@playwright/test";
 
 // ---- Test project fixture data ----
 //
@@ -768,6 +842,7 @@ forms:
       - title: "Basics"
         fields:
           - property: title
+            required: true
           - property: done
             widget: checkbox
       - title: "Assignment"
@@ -779,6 +854,7 @@ forms:
       - title: "Status"
         fields:
           - property: status
+            required: true
 
   tag:
     entity_type: tag
@@ -1051,7 +1127,7 @@ const E2E_DEMO_APP_HTML = `<!doctype html>
  *  a bug detail page — the rewriter will append ?return_to=<current url>
  *  so clicking the link lands on EntityView with a Back button. */
 const SEED_DOCS: Record<string, string> = {
-  'scripts/docs/feature_overview.lua': `-- Minimal doc for e2e round-trip testing.
+  "scripts/docs/feature_overview.lua": `-- Minimal doc for e2e round-trip testing.
 local id = rela.document.entry_id
 print("# " .. id)
 print()
@@ -1062,7 +1138,7 @@ print("[See bug BUG-001](" .. rela.url.detail({id = "BUG-001", type = "bug"}) ..
 };
 
 const SEED_ENTITIES: Record<string, string> = {
-  'entities/features/FEAT-001.md': `---
+  "entities/features/FEAT-001.md": `---
 id: FEAT-001
 type: feature
 title: User Authentication
@@ -1075,7 +1151,7 @@ Implement user authentication system.
 - [ ] Define password policy
 - [x] Pick OAuth provider
 `,
-  'entities/features/FEAT-002.md': `---
+  "entities/features/FEAT-002.md": `---
 id: FEAT-002
 type: feature
 title: Dashboard Analytics
@@ -1085,7 +1161,7 @@ priority: medium
 
 Add analytics dashboard.
 `,
-  'entities/features/FEAT-003.md': `---
+  "entities/features/FEAT-003.md": `---
 id: FEAT-003
 type: feature
 title: Export Data
@@ -1098,7 +1174,7 @@ Export data to CSV.
   // FEAT-004 exists specifically to exercise GFM-checkbox rendering and
   // toggling; the body has one unchecked + one checked item so specs can
   // observe and flip either state.
-  'entities/features/FEAT-004.md': `---
+  "entities/features/FEAT-004.md": `---
 id: FEAT-004
 type: feature
 title: Checkbox render fixture
@@ -1109,7 +1185,7 @@ priority: low
 - [ ] First
 - [x] Second
 `,
-  'entities/bugs/BUG-001.md': `---
+  "entities/bugs/BUG-001.md": `---
 id: BUG-001
 type: bug
 title: Login form validation
@@ -1120,7 +1196,7 @@ priority: high
 
 Form validation is not working.
 `,
-  'entities/bugs/BUG-002.md': `---
+  "entities/bugs/BUG-002.md": `---
 id: BUG-002
 type: bug
 title: Memory leak in list view
@@ -1131,7 +1207,7 @@ priority: high
 
 Memory leak detected.
 `,
-  'entities/tasks/TASK-001.md': `---
+  "entities/tasks/TASK-001.md": `---
 id: TASK-001
 type: task
 title: Write unit tests
@@ -1144,7 +1220,7 @@ Write unit tests for auth module.
   // Unlinked task — reverse-relations.spec.ts picks this as a candidate when
   // adding a new incoming-direction implements edge to FEAT-001 from the
   // non-cards "Implemented by" picker on the feature edit form.
-  'entities/tasks/TASK-002.md': `---
+  "entities/tasks/TASK-002.md": `---
 id: TASK-002
 type: task
 title: Refactor auth module
@@ -1156,7 +1232,7 @@ Refactor the auth module to extract token validation.
   // Seed a blocks relation with properties so relation-cards widget tests have
   // something rich to render. FEAT-001 blocks FEAT-003 with reason="test block",
   // severity=critical.
-  'relations/FEAT-001--blocks--FEAT-003.md': `---
+  "relations/FEAT-001--blocks--FEAT-003.md": `---
 from: FEAT-001
 relation: blocks
 to: FEAT-003
@@ -1168,7 +1244,7 @@ is_workaround_available: false
 `,
   // Seed a tagged relation (FEAT-001 tagged -> FEAT-002) so the tagged widget
   // has an entry to display.
-  'relations/FEAT-001--tagged--FEAT-002.md': `---
+  "relations/FEAT-001--tagged--FEAT-002.md": `---
 from: FEAT-001
 relation: tagged
 to: FEAT-002
@@ -1179,7 +1255,7 @@ added_date: "2026-01-15"
   // TASK-001 implements FEAT-001 — used by reverse-relations.spec.ts to
   // verify that a non-cards relation widget with direction: incoming lists
   // the linked task(s) on the feature form.
-  'relations/TASK-001--implements--FEAT-001.md': `---
+  "relations/TASK-001--implements--FEAT-001.md": `---
 from: TASK-001
 relation: implements
 to: FEAT-001
@@ -1194,7 +1270,7 @@ to: FEAT-001
  * active-state switching. (The base `feature.md` is picked up as a default.)
  */
 const SEED_TEMPLATES: Record<string, string> = {
-  'templates/entities/feature.md': `---
+  "templates/entities/feature.md": `---
 status: draft
 priority: medium
 ---
@@ -1203,7 +1279,7 @@ priority: medium
 
 Brief description of the feature.
 `,
-  'templates/entities/feature--spike.md': `---
+  "templates/entities/feature--spike.md": `---
 status: draft
 priority: low
 ---

--- a/e2e/tests/fixtures.ts
+++ b/e2e/tests/fixtures.ts
@@ -856,6 +856,20 @@ forms:
           - property: status
             required: true
 
+  # A FLAT (single-page) form that also uses visible_when/required_when — proves
+  # conditions work on non-wizard forms after the unification (TKT-ZKGY3).
+  task_flat_conditional:
+    entity_type: task
+    title: "Task (flat, conditional)"
+    fields:
+      - property: title
+        required: true
+      - property: done
+        widget: checkbox
+      - property: assignee
+        visible_when: "form.done == true"
+        required_when: "form.done == true"
+
   tag:
     entity_type: tag
     title: "Tag"

--- a/e2e/tests/settings.spec.ts
+++ b/e2e/tests/settings.spec.ts
@@ -181,7 +181,7 @@ test.describe('Settings', () => {
 
       await settingsPage.navigateToSettings();
 
-      await settingsPage.expectAppInfo('Forms', '8'); // feature, bug, task, task_wizard, tag, decision, module, specification
+      await settingsPage.expectAppInfo('Forms', '9'); // feature, bug, task, task_wizard, task_flat_conditional, tag, decision, module, specification
     });
 
     test('shows lists count', async ({ appPage }) => {

--- a/e2e/tests/settings.spec.ts
+++ b/e2e/tests/settings.spec.ts
@@ -181,7 +181,7 @@ test.describe('Settings', () => {
 
       await settingsPage.navigateToSettings();
 
-      await settingsPage.expectAppInfo('Forms', '7'); // feature, bug, task, tag, decision, module, specification
+      await settingsPage.expectAppInfo('Forms', '8'); // feature, bug, task, task_wizard, tag, decision, module, specification
     });
 
     test('shows lists count', async ({ appPage }) => {

--- a/e2e/tests/wizard.spec.ts
+++ b/e2e/tests/wizard.spec.ts
@@ -111,6 +111,30 @@ test.describe("Wizard (multi-step) forms", () => {
     expect(await formPage.activeStepIndex()).toBe(2);
   });
 
+  test("Create with a missing required field on an earlier step flags it and jumps back", async ({
+    appPage,
+  }) => {
+    const formPage = new FormPage(appPage);
+    await formPage.navigateToCreateForm("task_wizard");
+
+    // Leave the required `title` (step 0) empty; jump to the last step (Status,
+    // index 1 while Assignment is hidden) and try to Create.
+    await formPage.clickStep(1);
+    expect(await formPage.activeStepIndex()).toBe(1);
+    await formPage.clickCreate();
+
+    // Bounced back to step 0, which is flagged, with a summary shown.
+    expect(await formPage.activeStepIndex()).toBe(0);
+    expect(await formPage.erroredStepIndices()).toContain(0);
+    const summary = await formPage.errorSummaryText();
+    expect(summary).toContain("attention");
+    expect(await formPage.hasValidationError()).toBeTruthy();
+
+    // Fixing the field clears the flag live.
+    await formPage.fillField("title", "Now valid");
+    expect(await formPage.erroredStepIndices()).not.toContain(0);
+  });
+
   test("submits a wizard and drops hidden-branch values", async ({
     appPage,
     api,

--- a/e2e/tests/wizard.spec.ts
+++ b/e2e/tests/wizard.spec.ts
@@ -181,6 +181,29 @@ test.describe("Wizard (multi-step) forms", () => {
     expect(entity.properties.assignee ?? "").toBe("");
   });
 
+  test("wizard EDIT mode autosaves and has no Save button (TKT-ZKGY3)", async ({
+    appPage,
+    api,
+  }) => {
+    // Seed a task, then open it in the wizard form in EDIT mode.
+    const created = await api.createEntity("tasks", {
+      properties: { title: "Editable via wizard", status: "approved" },
+    });
+    createdTasks.push(created.id);
+
+    const formPage = new FormPage(appPage);
+    await formPage.navigateToEditForm("task_wizard", created.id);
+
+    // No explicit Save/Create button — edit is autosave, same as a flat form.
+    expect(await formPage.hasSubmitButton()).toBeFalsy();
+
+    // Editing a field autosaves via PATCH (no submit).
+    await formPage.fillField("title", "Retitled in wizard");
+    await formPage.saveAndWaitForPatch("tasks", created.id);
+    const entity = await api.getEntity("tasks", created.id);
+    expect(entity.properties.title).toBe("Retitled in wizard");
+  });
+
   test("a revealed-then-hidden field is NOT persisted on create", async ({
     appPage,
     api,
@@ -207,5 +230,63 @@ test.describe("Wizard (multi-step) forms", () => {
     expect(entity.properties.title).toBe("Toggled branch task");
     // assignee was entered but its step ended up hidden -> dropped.
     expect(entity.properties.assignee ?? "").toBe("");
+  });
+});
+
+// After unifying flat + wizard (TKT-ZKGY3), single-page forms run through the
+// same step model, so visible_when/required_when work there too — with NO
+// stepper bar and NO ?step param.
+test.describe("Flat forms with conditions", () => {
+  const createdTasks: string[] = [];
+  test.afterEach(async ({ api }) => {
+    while (createdTasks.length) {
+      const id = createdTasks.pop()!;
+      await api.deleteEntity("tasks", id).catch(() => {});
+    }
+  });
+
+  test("no stepper bar and no ?step on a single-page form", async ({
+    appPage,
+  }) => {
+    const formPage = new FormPage(appPage);
+    await formPage.navigateToCreateForm("task_flat_conditional");
+    expect(await formPage.wizardStepTitles()).toEqual([]); // no pills
+    expect(formPage.readStepParam()).toBeNull(); // no ?step
+    expect(await formPage.isFieldVisible("title")).toBeTruthy();
+  });
+
+  test("visible_when reveals a field inline on a flat form", async ({
+    appPage,
+  }) => {
+    const formPage = new FormPage(appPage);
+    await formPage.navigateToCreateForm("task_flat_conditional");
+
+    expect(await formPage.isFieldVisible("assignee")).toBeFalsy();
+    await formPage.setCheckbox("done", true);
+    expect(await formPage.isFieldVisible("assignee")).toBeTruthy();
+    await formPage.setCheckbox("done", false);
+    expect(await formPage.isFieldVisible("assignee")).toBeFalsy();
+  });
+
+  test("required_when blocks Create until the revealed field is filled", async ({
+    appPage,
+    api,
+  }) => {
+    const formPage = new FormPage(appPage);
+    await formPage.navigateToCreateForm("task_flat_conditional");
+
+    await formPage.fillField("title", "Flat conditional");
+    await formPage.setCheckbox("done", true); // assignee now required
+
+    // Empty assignee blocks Create.
+    await formPage.clickCreate();
+    expect(await formPage.hasValidationError()).toBeTruthy();
+
+    // Fill it, then Create succeeds and persists the value.
+    await formPage.fillField("assignee", "bob");
+    const created = await formPage.submitAndExpectCreate("tasks");
+    createdTasks.push(created.id);
+    const entity = await api.getEntity("tasks", created.id);
+    expect(entity.properties.assignee).toBe("bob");
   });
 });

--- a/e2e/tests/wizard.spec.ts
+++ b/e2e/tests/wizard.spec.ts
@@ -159,6 +159,30 @@ test.describe("Wizard (multi-step) forms", () => {
     expect(await formPage.erroredStepIndices()).toEqual([]);
   });
 
+  test("hiding an errored step clears its flag and summary (RR-U9ERK)", async ({
+    appPage,
+  }) => {
+    const formPage = new FormPage(appPage);
+    await formPage.navigateToCreateForm("task_wizard");
+
+    // Reveal Assignment (assignee required), fill Basics + Status, leave
+    // assignee empty, then Create -> Assignment is flagged.
+    await formPage.fillField("title", "Will hide the error");
+    await formPage.setCheckbox("done", true); // reveal Assignment
+    await formPage.clickStep(2); // Status
+    await formPage.selectField("status", "approved");
+    await formPage.clickCreate(); // assignee empty -> error, jumps to Assignment
+    expect((await formPage.erroredStepIndices()).length).toBeGreaterThan(0);
+    expect(await formPage.errorSummaryText()).not.toBeNull();
+
+    // Go back to Basics and toggle `done` off -> the Assignment step (and its
+    // error) disappears. No phantom summary should remain.
+    await formPage.clickStep(0);
+    await formPage.setCheckbox("done", false);
+    expect(await formPage.erroredStepIndices()).toEqual([]);
+    expect(await formPage.errorSummaryText()).toBeNull();
+  });
+
   test("submits a wizard and drops hidden-branch values", async ({
     appPage,
     api,
@@ -204,6 +228,34 @@ test.describe("Wizard (multi-step) forms", () => {
     expect(entity.properties.title).toBe("Retitled in wizard");
   });
 
+  test("edit mode unsets a field whose branch is hidden (AC5, TKT-ZKGY3)", async ({
+    appPage,
+    api,
+  }) => {
+    // Seed a task with the conditional branch active and its field filled.
+    const created = await api.createEntity("tasks", {
+      properties: {
+        title: "Has assignee",
+        status: "approved",
+        done: true,
+        assignee: "alice",
+      },
+    });
+    createdTasks.push(created.id);
+
+    const formPage = new FormPage(appPage);
+    await formPage.navigateToEditForm("task_wizard", created.id);
+
+    // `done` lives on the first step (Basics); toggling it off hides the whole
+    // Assignment step (which carries `assignee`). Its stored value must be unset.
+    await formPage.setCheckbox("done", false);
+    await formPage.saveAndWaitForPatch("tasks", created.id);
+
+    const entity = await api.getEntity("tasks", created.id);
+    expect(entity.properties.done).toBe(false);
+    expect(entity.properties.assignee ?? "").toBe(""); // unset because its branch hid
+  });
+
   test("a revealed-then-hidden field is NOT persisted on create", async ({
     appPage,
     api,
@@ -230,6 +282,31 @@ test.describe("Wizard (multi-step) forms", () => {
     expect(entity.properties.title).toBe("Toggled branch task");
     // assignee was entered but its step ended up hidden -> dropped.
     expect(entity.properties.assignee ?? "").toBe("");
+  });
+
+  test("a relation under a revealed-then-hidden step is NOT persisted", async ({
+    appPage,
+    api,
+  }) => {
+    const formPage = new FormPage(appPage);
+    await formPage.navigateToCreateForm("task_wizard");
+
+    await formPage.fillField("title", "Relation branch task");
+    await formPage.setCheckbox("done", true); // reveal Assignment (has `implements`)
+    await formPage.clickNext(); // -> Assignment
+    await formPage.fillField("assignee", "carol");
+    await formPage.addRelation("Implements", "FEAT-001"); // link under the branch
+    await formPage.clickBack(); // -> Basics
+    await formPage.setCheckbox("done", false); // hide the whole Assignment step
+    await formPage.clickNext(); // -> Status
+    await formPage.selectField("status", "approved");
+
+    const created = await formPage.submitAndExpectCreate("tasks");
+    createdTasks.push(created.id);
+
+    // The relation belonged to a hidden step -> not persisted (mirrors props).
+    const rels = await api.listRelations("tasks", created.id, "implements");
+    expect(rels).toEqual([]);
   });
 });
 

--- a/e2e/tests/wizard.spec.ts
+++ b/e2e/tests/wizard.spec.ts
@@ -135,6 +135,30 @@ test.describe("Wizard (multi-step) forms", () => {
     expect(await formPage.erroredStepIndices()).not.toContain(0);
   });
 
+  test("error flags persist across navigation until each is resolved", async ({
+    appPage,
+  }) => {
+    const formPage = new FormPage(appPage);
+    await formPage.navigateToCreateForm("task_wizard");
+
+    // Both `title` (step 0) and `status` (step 1, Assignment hidden) are
+    // required and empty. Go to the last step (where Create lives) and submit.
+    await formPage.clickStep(1);
+    await formPage.clickCreate();
+    expect(await formPage.erroredStepIndices()).toEqual([0, 1]);
+
+    // Fix step 0's field, then navigate to step 1. Step 1's flag must persist
+    // (navigating away from step 0 must NOT wipe step 1's error).
+    await formPage.fillField("title", "Has a title now");
+    expect(await formPage.erroredStepIndices()).toEqual([1]);
+    await formPage.clickStep(1);
+    expect(await formPage.erroredStepIndices()).toEqual([1]);
+
+    // Fixing step 1 clears the last flag.
+    await formPage.selectField("status", "approved");
+    expect(await formPage.erroredStepIndices()).toEqual([]);
+  });
+
   test("submits a wizard and drops hidden-branch values", async ({
     appPage,
     api,

--- a/e2e/tests/wizard.spec.ts
+++ b/e2e/tests/wizard.spec.ts
@@ -58,6 +58,25 @@ test.describe("Wizard (multi-step) forms", () => {
     expect(await formPage.getFieldValue("title")).toBe("Wizard task");
   });
 
+  test("clicking a step pill jumps to it (forward and back)", async ({
+    appPage,
+  }) => {
+    const formPage = new FormPage(appPage);
+    await formPage.navigateToCreateForm("task_wizard");
+
+    // Jump forward to the last step (Status, index 1 while Assignment hidden)
+    // without going through Next — a deliberate pill click is not gated.
+    await formPage.clickStep(1);
+    expect(await formPage.activeStepIndex()).toBe(1);
+    expect(formPage.readStepParam()).toBe("1");
+    expect(await formPage.isFieldVisible("status")).toBeTruthy();
+
+    // Jump back to the first step by clicking its pill.
+    await formPage.clickStep(0);
+    expect(await formPage.activeStepIndex()).toBe(0);
+    expect(await formPage.isFieldVisible("title")).toBeTruthy();
+  });
+
   test("refresh returns to the encoded step", async ({ appPage }) => {
     const formPage = new FormPage(appPage);
     await formPage.navigateToCreateForm("task_wizard");

--- a/e2e/tests/wizard.spec.ts
+++ b/e2e/tests/wizard.spec.ts
@@ -1,0 +1,116 @@
+import { test, expect } from "./fixtures";
+import { FormPage } from "../pages";
+
+test.describe("Wizard (multi-step) forms", () => {
+  const createdTasks: string[] = [];
+
+  test.afterEach(async ({ api }) => {
+    while (createdTasks.length) {
+      const id = createdTasks.pop()!;
+      await api.deleteEntity("tasks", id).catch(() => {});
+    }
+  });
+
+  test("renders steps and starts on the first step", async ({ appPage }) => {
+    const formPage = new FormPage(appPage);
+    await formPage.navigateToCreateForm("task_wizard");
+
+    // The conditional "Assignment" step is hidden until `done` is checked.
+    expect(await formPage.wizardStepTitles()).toEqual(["Basics", "Status"]);
+    expect(await formPage.activeStepIndex()).toBe(0);
+    // Only step 1's fields are shown.
+    expect(await formPage.isFieldVisible("title")).toBeTruthy();
+    expect(await formPage.isFieldVisible("status")).toBeFalsy();
+  });
+
+  test("visible_when reveals a conditional step", async ({ appPage }) => {
+    const formPage = new FormPage(appPage);
+    await formPage.navigateToCreateForm("task_wizard");
+
+    await formPage.setCheckbox("done", true);
+    expect(await formPage.wizardStepTitles()).toEqual([
+      "Basics",
+      "Assignment",
+      "Status",
+    ]);
+
+    await formPage.setCheckbox("done", false);
+    expect(await formPage.wizardStepTitles()).toEqual(["Basics", "Status"]);
+  });
+
+  test("next/back navigation moves between steps and syncs ?step=", async ({
+    appPage,
+  }) => {
+    const formPage = new FormPage(appPage);
+    await formPage.navigateToCreateForm("task_wizard");
+
+    await formPage.fillField("title", "Wizard task");
+    await formPage.clickNext();
+    expect(await formPage.activeStepIndex()).toBe(1);
+    expect(formPage.readStepParam()).toBe("1");
+    // Step 2 (Status, since done is unchecked) is shown.
+    expect(await formPage.isFieldVisible("status")).toBeTruthy();
+
+    await formPage.clickBack();
+    expect(await formPage.activeStepIndex()).toBe(0);
+    expect(formPage.readStepParam()).toBe("0");
+    // Value entered on step 1 is preserved across back/next.
+    expect(await formPage.getFieldValue("title")).toBe("Wizard task");
+  });
+
+  test("refresh returns to the encoded step", async ({ appPage }) => {
+    const formPage = new FormPage(appPage);
+    await formPage.navigateToCreateForm("task_wizard");
+    await formPage.fillField("title", "Deep link task");
+    await formPage.clickNext();
+    expect(formPage.readStepParam()).toBe("1");
+
+    await appPage.reload();
+    await formPage.waitForSpinnerToDisappear();
+    expect(await formPage.activeStepIndex()).toBe(1);
+  });
+
+  test("required_when blocks Next until the conditional field is filled", async ({
+    appPage,
+  }) => {
+    const formPage = new FormPage(appPage);
+    await formPage.navigateToCreateForm("task_wizard");
+
+    await formPage.fillField("title", "Needs assignee");
+    await formPage.setCheckbox("done", true); // reveals Assignment + makes assignee required
+    await formPage.clickNext(); // Basics -> Assignment
+    expect(await formPage.activeStepIndex()).toBe(1);
+
+    // assignee is empty and required_when is true -> Next is blocked.
+    await formPage.clickNext();
+    expect(await formPage.activeStepIndex()).toBe(1);
+    expect(await formPage.hasValidationError()).toBeTruthy();
+
+    // Fill it and Next advances.
+    await formPage.fillField("assignee", "alice");
+    await formPage.clickNext();
+    expect(await formPage.activeStepIndex()).toBe(2);
+  });
+
+  test("submits a wizard and drops hidden-branch values", async ({
+    appPage,
+    api,
+  }) => {
+    const formPage = new FormPage(appPage);
+    await formPage.navigateToCreateForm("task_wizard");
+
+    // Leave `done` unchecked, so the Assignment step (assignee) stays hidden.
+    await formPage.fillField("title", "Hidden branch task");
+    await formPage.clickNext(); // -> Status (index 1, since Assignment hidden)
+    await formPage.selectField("status", "approved");
+
+    const created = await formPage.submitAndExpectCreate("tasks");
+    createdTasks.push(created.id);
+
+    const entity = await api.getEntity("tasks", created.id);
+    expect(entity.properties.title).toBe("Hidden branch task");
+    expect(entity.properties.status).toBe("approved");
+    // assignee belonged to a hidden step -> not persisted.
+    expect(entity.properties.assignee ?? "").toBe("");
+  });
+});

--- a/e2e/tests/wizard.spec.ts
+++ b/e2e/tests/wizard.spec.ts
@@ -113,4 +113,32 @@ test.describe("Wizard (multi-step) forms", () => {
     // assignee belonged to a hidden step -> not persisted.
     expect(entity.properties.assignee ?? "").toBe("");
   });
+
+  test("a revealed-then-hidden field is NOT persisted on create", async ({
+    appPage,
+    api,
+  }) => {
+    // The real hidden-branch case: the user reveals the branch, fills it, then
+    // hides it again before submitting. The filled value must not persist.
+    const formPage = new FormPage(appPage);
+    await formPage.navigateToCreateForm("task_wizard");
+
+    await formPage.fillField("title", "Toggled branch task");
+    await formPage.setCheckbox("done", true); // reveal Assignment
+    await formPage.clickNext(); // -> Assignment
+    await formPage.fillField("assignee", "alice"); // fill the conditional field
+    await formPage.clickBack(); // -> Basics
+    await formPage.setCheckbox("done", false); // hide Assignment again
+    // Now the only visible steps are Basics + Status.
+    await formPage.clickNext(); // -> Status
+    await formPage.selectField("status", "approved");
+
+    const created = await formPage.submitAndExpectCreate("tasks");
+    createdTasks.push(created.id);
+
+    const entity = await api.getEntity("tasks", created.id);
+    expect(entity.properties.title).toBe("Toggled branch task");
+    // assignee was entered but its step ended up hidden -> dropped.
+    expect(entity.properties.assignee ?? "").toBe("");
+  });
 });

--- a/frontend/src/components/forms/DynamicForm.vue
+++ b/frontend/src/components/forms/DynamicForm.vue
@@ -548,9 +548,12 @@ function getTemplateLabel(name: string): string {
 // validated (single-page submit, or wizard final submit over visible steps).
 // `requiredProps` are property keys made required by a matching `required_when`
 // condition, in addition to the metamodel's own `required` flag.
+//
+// Errors are updated **only for the scope's fields**: existing errors on fields
+// OUTSIDE the scope are preserved. This is what lets a wizard's per-step Next
+// re-check just the current step while leaving flags on other errored steps
+// standing until they're actually resolved. Returns whether the SCOPE is valid.
 function validate(scopeFields?: FormFieldOrRelation[], requiredProps?: Set<string>): boolean {
-  errors.value = {}
-
   if (!entityType.value) return true
 
   const scope = scopeFields ?? fields.value
@@ -561,6 +564,12 @@ function validate(scopeFields?: FormFieldOrRelation[], requiredProps?: Set<strin
       .map((f) => f.property)
   )
 
+  // Start from the existing errors, then clear this scope's entries so a
+  // fixed field drops out while out-of-scope errors are untouched.
+  const next: Record<string, string> = { ...errors.value }
+  for (const prop of formPropertyNames) delete next[prop]
+  let scopeValid = true
+
   for (const [propName, propDef] of Object.entries(entityType.value.properties)) {
     // Skip properties not in the form - backend will validate them
     if (!formPropertyNames.has(propName)) continue
@@ -570,7 +579,8 @@ function validate(scopeFields?: FormFieldOrRelation[], requiredProps?: Set<strin
     // Required check (metamodel `required` OR a matching `required_when`)
     const isRequired = propDef.required || (requiredProps?.has(propName) ?? false)
     if (isRequired && (value === undefined || value === null || value === '')) {
-      errors.value[propName] = 'This field is required'
+      next[propName] = 'This field is required'
+      scopeValid = false
       continue
     }
 
@@ -579,14 +589,16 @@ function validate(scopeFields?: FormFieldOrRelation[], requiredProps?: Set<strin
       if (propDef.type === 'integer' && typeof value === 'string') {
         const num = parseInt(value, 10)
         if (isNaN(num)) {
-          errors.value[propName] = 'Must be a valid number'
+          next[propName] = 'Must be a valid number'
+          scopeValid = false
         }
       }
 
       if (propDef.type === 'date' && typeof value === 'string') {
         const date = new Date(value)
         if (isNaN(date.getTime())) {
-          errors.value[propName] = 'Must be a valid date'
+          next[propName] = 'Must be a valid date'
+          scopeValid = false
         }
       }
 
@@ -595,13 +607,15 @@ function validate(scopeFields?: FormFieldOrRelation[], requiredProps?: Set<strin
         const items = propDef.list && Array.isArray(value) ? value : [value]
         const invalid = items.some((v) => !allowed.includes(String(v)))
         if (invalid) {
-          errors.value[propName] = `Must be one of: ${allowed.join(', ')}`
+          next[propName] = `Must be one of: ${allowed.join(', ')}`
+          scopeValid = false
         }
       }
     }
   }
 
-  return Object.keys(errors.value).length === 0
+  errors.value = next
+  return scopeValid
 }
 
 // The affordance filter applied to flat forms in `fields`, reusable for a
@@ -659,6 +673,8 @@ function requiredWhenProps(scope: FormFieldOrRelation[]): Set<string> {
 
 // Wizard "Next": validate only the current step's visible fields; advance only
 // when valid, so an invalid step blocks progression with per-field errors.
+// `validate` is scope-local, so it re-checks just this step and leaves any
+// flags on OTHER errored steps standing until they're resolved.
 function handleNext() {
   const step = wizard.currentStepDef.value
   if (!step) return
@@ -666,23 +682,21 @@ function handleNext() {
   // on a policy-hidden field the user can't see.
   const scope = visibleStepFields(step)
   if (!validate(scope, requiredWhenProps(scope))) return
-  errors.value = {}
   wizard.next()
 }
 
 function handleBack() {
-  // Back never validates — the user may be fixing an earlier answer.
-  errors.value = {}
+  // Back never validates and never clears errors — navigating isn't fixing.
   wizard.back()
 }
 
 // Clicking a step pill jumps straight there. A deliberate jump is not gated by
 // per-step validation (unlike Next): visible_when keeps unmet branches hidden
 // and the final Submit re-validates every visible step, so a jump can't persist
-// invalid data. Clear transient per-field errors so a jumped-to step starts clean.
+// invalid data. Errors are left intact — a flag clears when its field is fixed,
+// not when the user navigates away.
 function handleStepClick(index: number) {
   if (index === wizard.currentStep.value) return
-  errors.value = {}
   wizard.goTo(index)
 }
 
@@ -857,11 +871,13 @@ async function handleSubmit() {
     if (isCancelledFetch(err)) return
     const validationErrors = err instanceof ApiError ? err.validationErrors : []
     if (validationErrors.length > 0) {
+      const next = { ...errors.value }
       for (const e of validationErrors) {
         if (e.field) {
-          errors.value[e.field] = e.message || e.detail || 'Invalid value'
+          next[e.field] = e.message || e.detail || 'Invalid value'
         }
       }
+      errors.value = next
       uiStore.error('Please fix the validation errors')
     } else {
       uiStore.error(getErrorMessage(err, 'Failed to save entity'))

--- a/frontend/src/components/forms/DynamicForm.vue
+++ b/frontend/src/components/forms/DynamicForm.vue
@@ -1547,9 +1547,13 @@ onBeforeRouteLeave(async () => {
   outline-offset: 2px;
 }
 
+/* "You are here" = a filled pill. This is the primary cue and is INDEPENDENT
+   of the error color, so an active step still reads as active even when it also
+   has an error (see .active.has-errors below). */
 .wizard-step-pill.active {
+  background: var(--accent-color);
   border-color: var(--accent-color);
-  color: var(--text-color);
+  color: #fff;
   font-weight: 600;
 }
 
@@ -1568,21 +1572,39 @@ onBeforeRouteLeave(async () => {
   font-size: 12px;
 }
 
-.wizard-step-pill.active .wizard-step-num,
 .wizard-step-pill.done .wizard-step-num {
   background: var(--accent-color);
   color: #fff;
 }
 
-/* A step with a validation error takes precedence over active/done styling. */
-.wizard-step-pill.has-errors {
+/* On the filled active pill, the number badge is inverted (light on accent). */
+.wizard-step-pill.active .wizard-step-num {
+  background: #fff;
+  color: var(--accent-color);
+}
+
+/* An errored step: red outline + red number badge, but NOT active. */
+.wizard-step-pill.has-errors:not(.active) {
   border-color: var(--error-color);
   color: var(--error-color);
 }
 
-.wizard-step-pill.has-errors .wizard-step-num {
+.wizard-step-pill.has-errors:not(.active) .wizard-step-num {
   background: var(--error-color);
   color: #fff;
+}
+
+/* The active step that also has an error: filled with the error color, so it
+   still reads as "you are here" while signalling the problem. */
+.wizard-step-pill.active.has-errors {
+  background: var(--error-color);
+  border-color: var(--error-color);
+  color: #fff;
+}
+
+.wizard-step-pill.active.has-errors .wizard-step-num {
+  background: #fff;
+  color: var(--error-color);
 }
 
 .wizard-error-summary {

--- a/frontend/src/components/forms/DynamicForm.vue
+++ b/frontend/src/components/forms/DynamicForm.vue
@@ -28,11 +28,11 @@ import {
   INCOMING_SUFFIX,
 } from './relationsPatch'
 import { useAutoSave } from '@/composables/useAutoSave'
+import { useFormWizard } from '@/composables/useFormWizard'
+import type { Bindings } from '@/utils/conditions'
 import { registerForm } from './dirtyFormRegistry'
 import AutoSaveIndicator from './AutoSaveIndicator.vue'
-import FieldRenderer from './FieldRenderer.vue'
-import RelationPicker from './RelationPicker.vue'
-import RelationCards from './RelationCards.vue'
+import FormFieldList from './FormFieldList.vue'
 import MarkdownEditor from './MarkdownEditor.vue'
 import SidePanel from './SidePanel.vue'
 import HelpModal from '@/components/ui/HelpModal.vue'
@@ -125,17 +125,9 @@ const isEdit = computed(() => !!props.entityId)
 const formMode = computed(() => (isEdit.value ? 'edit' : 'create') as 'create' | 'edit')
 
 const idControls = useEntityIDControls(entityType, formMode)
-const {
-  showManualIDInput,
-  showPrefixPicker,
-  prefixOptions,
-  manualId,
-  selectedPrefix,
-} = idControls
+const { showManualIDInput, showPrefixPicker, prefixOptions, manualId, selectedPrefix } = idControls
 
-const showReadOnlyID = computed(
-  () => isEdit.value && entityType.value?.id_type === 'manual'
-)
+const showReadOnlyID = computed(() => isEdit.value && entityType.value?.id_type === 'manual')
 
 const title = computed(() => {
   if (!formConfig.value) return ''
@@ -145,14 +137,32 @@ const title = computed(() => {
 
 const allFields = computed((): FormFieldOrRelation[] => {
   if (!formConfig.value) return []
-  if (formConfig.value.sections?.length) {
-    return formConfig.value.sections.flatMap((s) => s.fields) as FormFieldOrRelation[]
+  // Wizard forms carry their fields under steps; flatten them so affordance
+  // filtering, payload assembly, and load-time hydration see every field the
+  // same way single-page forms do. Per-step visibility is applied separately
+  // by the wizard layer at render/validate time.
+  if (formConfig.value.steps?.length) {
+    return formConfig.value.steps.flatMap((s) => [
+      ...((s.fields || []) as FormFieldOrRelation[]),
+      ...((s.relations || []) as FormFieldOrRelation[]),
+    ])
   }
   // Combine property fields and relation fields into a single list
   const propFields = (formConfig.value.fields || []) as FormFieldOrRelation[]
   const relFields = (formConfig.value.relations || []) as FormFieldOrRelation[]
   return [...propFields, ...relFields]
 })
+
+// Live binding namespaces for condition evaluation. `form` is the current field
+// values; `entity`/`current_user` are reserved for future ACL/view use and are
+// empty here (form conditions reference `form.<field>` only).
+const conditionBindings = computed<Bindings>(() => ({
+  form: formData.value,
+  entity: {},
+  current_user: {},
+}))
+
+const wizard = useFormWizard(formConfig, conditionBindings)
 
 // TKT-G7N5 F1 / TKT-3I5U: filter the config-driven field list against
 // the entity's affordances. A property field is rendered only if it is
@@ -251,11 +261,7 @@ async function loadEntity(force = false) {
   if (!props.entityId || !formConfig.value) return
 
   try {
-    const entity = await entitiesStore.fetchEntity(
-      formConfig.value.entity,
-      props.entityId,
-      force
-    )
+    const entity = await entitiesStore.fetchEntity(formConfig.value.entity, props.entityId, force)
     // Route-guard: if the server says this entity is not updatable,
     // render an inline "not editable" message instead of the form.
     // The EntityDetail Edit button already hides for the same
@@ -271,7 +277,11 @@ async function loadEntity(force = false) {
     fieldAffordances.value = entity._fields ?? {}
     relationAffordances.value = entity._relations ?? {}
     attachments.value = entity._attachments ?? {}
-    originalData.value = JSON.stringify({ formData: formData.value, relations: relations.value, content: content.value })
+    originalData.value = JSON.stringify({
+      formData: formData.value,
+      relations: relations.value,
+      content: content.value,
+    })
   } catch (err) {
     // Suppress cancellation errors from rapid navigation in Firefox
     // (see BUG-6C3V and src/composables/usePageData.ts).
@@ -385,7 +395,11 @@ function initializeDefaults() {
     }
   }
 
-  originalData.value = JSON.stringify({ formData: formData.value, relations: relations.value, content: content.value })
+  originalData.value = JSON.stringify({
+    formData: formData.value,
+    relations: relations.value,
+    content: content.value,
+  })
 }
 
 async function loadTemplates() {
@@ -431,7 +445,7 @@ async function refreshStagedAffordances() {
     const candidate = await dryRunCreateEntity(
       formConfig.value.entity,
       { properties: { ...formData.value }, content: content.value || undefined },
-      controller.signal,
+      controller.signal
     )
     // A newer request superseded this one between await points — discard.
     if (controller !== stagedDryRunController) return
@@ -487,7 +501,11 @@ function applyTemplate(template: Template) {
       relations.value[rel.relation].push(rel.target)
     }
   }
-  originalData.value = JSON.stringify({ formData: formData.value, relations: relations.value, content: content.value })
+  originalData.value = JSON.stringify({
+    formData: formData.value,
+    relations: relations.value,
+    content: content.value,
+  })
 }
 
 function selectTemplate(name: string) {
@@ -509,14 +527,20 @@ function getTemplateLabel(name: string): string {
   return name.charAt(0).toUpperCase() + name.slice(1)
 }
 
-function validate(): boolean {
+// Validate the form. `scopeFields` restricts validation to a subset (used for
+// per-step validation on wizard "Next"); when omitted, all shown fields are
+// validated (single-page submit, or wizard final submit over visible steps).
+// `requiredProps` are property keys made required by a matching `required_when`
+// condition, in addition to the metamodel's own `required` flag.
+function validate(scopeFields?: FormFieldOrRelation[], requiredProps?: Set<string>): boolean {
   errors.value = {}
 
   if (!entityType.value) return true
 
+  const scope = scopeFields ?? fields.value
   // Only validate properties that are shown in the form (not hidden)
   const formPropertyNames = new Set(
-    fields.value
+    scope
       .filter((f): f is typeof f & { property: string } => !!f.property && !f.hidden)
       .map((f) => f.property)
   )
@@ -527,8 +551,9 @@ function validate(): boolean {
 
     const value = formData.value[propName]
 
-    // Required check
-    if (propDef.required && (value === undefined || value === null || value === '')) {
+    // Required check (metamodel `required` OR a matching `required_when`)
+    const isRequired = propDef.required || (requiredProps?.has(propName) ?? false)
+    if (isRequired && (value === undefined || value === null || value === '')) {
       errors.value[propName] = 'This field is required'
       continue
     }
@@ -563,8 +588,61 @@ function validate(): boolean {
   return Object.keys(errors.value).length === 0
 }
 
+// The affordance filter applied to flat forms in `fields`, reusable for a
+// wizard step's field list so policy-hidden fields are dropped consistently.
+function affordanceVisible(f: FormFieldOrRelation): boolean {
+  if (!f.property) return true // relations / non-property fields untouched
+  if (loading.value) return true
+  if (!isEdit.value && !stagedAffordancesReady.value) return true
+  if (f.property in fieldAffordances.value) return true
+  if (isEdit.value && f.property in formData.value) return true
+  if (!isEdit.value && stagedVisibleProps.value.has(f.property)) return true
+  return false
+}
+
+// A wizard step's fields to render: per-field `visible_when` (wizard layer)
+// intersected with the affordance filter (same rule as flat `fields`).
+function visibleStepFields(step: import('@/types').FormStep): FormFieldOrRelation[] {
+  return wizard.visibleFieldsOf(step).filter(affordanceVisible)
+}
+
+// Fields currently in scope for submit: for a wizard, only the visible fields
+// of currently-visible steps; for a single-page form, all fields.
+function submitScopeFields(): FormFieldOrRelation[] {
+  if (!wizard.isWizard.value) return fields.value
+  return wizard.visibleSteps.value.flatMap((s) => wizard.visibleFieldsOf(s))
+}
+
+// Property keys made required right now by a matching `required_when`.
+function requiredWhenProps(scope: FormFieldOrRelation[]): Set<string> {
+  const req = new Set<string>()
+  for (const f of scope) {
+    if (f.property && wizard.isFieldRequired(f)) req.add(f.property)
+  }
+  return req
+}
+
+// Wizard "Next": validate only the current step's visible fields; advance only
+// when valid, so an invalid step blocks progression with per-field errors.
+function handleNext() {
+  const step = wizard.currentStepDef.value
+  if (!step) return
+  const scope = wizard.visibleFieldsOf(step)
+  if (!validate(scope, requiredWhenProps(scope))) return
+  errors.value = {}
+  wizard.next()
+}
+
+function handleBack() {
+  // Back never validates — the user may be fixing an earlier answer.
+  errors.value = {}
+  wizard.back()
+}
+
 async function handleSubmit() {
-  if (!validate() || !formConfig.value) return
+  if (!formConfig.value) return
+  const scope = submitScopeFields()
+  if (!validate(scope, requiredWhenProps(scope))) return
 
   saving.value = true
   try {
@@ -572,9 +650,7 @@ async function handleSubmit() {
     // `filteredRelations` IDs-only map — they're delivered through
     // pendingCardChanges and the unified PATCH-with-relations shape.
     const cardRelations = new Set(
-      fields.value
-        .filter((f) => f.relation && f.widget === 'cards')
-        .map((f) => f.relation!)
+      fields.value.filter((f) => f.relation && f.widget === 'cards').map((f) => f.relation!)
     )
     const filteredRelations: Record<string, string[]> = {}
     for (const [rel, ids] of Object.entries(relations.value)) {
@@ -602,7 +678,7 @@ async function handleSubmit() {
       // and tell the user to reload (the type comes from backend Step 0
       // and is normally always present).
       uiStore.error(
-        'Some related entities have unknown types. Save aborted; reload the form and try again.',
+        'Some related entities have unknown types. Save aborted; reload the form and try again.'
       )
       // Drop the outgoing card-edit Map entries so they aren't
       // mistakenly cleared on success below.
@@ -614,6 +690,17 @@ async function handleSubmit() {
     }
     const relationsPayload: ModernRelationsField = { ...reshapedPickers, ...modernRelations }
 
+    // For a wizard, drop values that belong to a hidden step/field so a
+    // toggled-off branch doesn't persist stale data (matches OpenVWR's
+    // isFieldEnabled). Single-page forms submit formData as-is.
+    let properties = formData.value
+    if (wizard.isWizard.value) {
+      const active = wizard.activeProperties.value
+      properties = Object.fromEntries(
+        Object.entries(formData.value).filter(([key]) => active.has(key))
+      )
+    }
+
     const payload: {
       id?: string
       prefix?: string
@@ -621,7 +708,7 @@ async function handleSubmit() {
       relations: ModernRelationsField
       content?: string
     } = {
-      properties: formData.value,
+      properties,
       relations: relationsPayload,
       content: content.value || undefined,
     }
@@ -677,7 +764,11 @@ async function handleSubmit() {
     }
 
     dirty.value = false
-    originalData.value = JSON.stringify({ formData: formData.value, relations: relations.value, content: content.value })
+    originalData.value = JSON.stringify({
+      formData: formData.value,
+      relations: relations.value,
+      content: content.value,
+    })
 
     // Navigate to return_to or back
     if (returnTo.value) {
@@ -797,15 +888,13 @@ function buildAutoSaveRelationsBody(): ModernRelationsField | null {
   if (!hasModernCards && !hasLegacy) return null
   // Reshape legacy IDs to modern shape (autosave always uses modern;
   // shape_mixed 400 otherwise).
-  const reshaped = hasLegacy
-    ? reshapeLegacyToModern(filteredRelations, pickerTypes.value)
-    : {}
+  const reshaped = hasLegacy ? reshapeLegacyToModern(filteredRelations, pickerTypes.value) : {}
   if (reshaped === null) {
     // Pathological: a picker target without a known type. Surface
     // and skip — explicit Save in create mode handles this case;
     // autosave is best-effort.
     uiStore.error(
-      'Some related entities have unknown types; relation changes were not saved. Reload the form and try again.',
+      'Some related entities have unknown types; relation changes were not saved. Reload the form and try again.'
     )
     return null
   }
@@ -826,10 +915,7 @@ function updateRelationCards(relation: string, state: RelationCardState) {
 // write. RelationPicker emits enough state (loadedEntries +
 // currentEntries) for us to build a proper RelationCardState the
 // builder can consume.
-function updateIncomingPicker(
-  relation: string,
-  state: RelationPickerIncomingState,
-) {
+function updateIncomingPicker(relation: string, state: RelationPickerIncomingState) {
   pendingCardChanges.value.set(`${relation}${INCOMING_SUFFIX}`, {
     entries: state.currentEntries,
     added: state.added,
@@ -858,7 +944,11 @@ function updateContent(value: string) {
 }
 
 function checkDirty() {
-  const currentData = JSON.stringify({ formData: formData.value, relations: relations.value, content: content.value })
+  const currentData = JSON.stringify({
+    formData: formData.value,
+    relations: relations.value,
+    content: content.value,
+  })
   const hasCardChanges = pendingCardChanges.value.size > 0
   dirty.value = currentData !== originalData.value || hasCardChanges
 }
@@ -936,7 +1026,9 @@ onMounted(async () => {
           formData.value[property] = value
         }
       },
-      applyServerContent: (c) => { content.value = c },
+      applyServerContent: (c) => {
+        content.value = c
+      },
       onError: (msg) => uiStore.error(msg),
     })
     // Register with the dirty registry so SSE-driven re-fetches in
@@ -946,7 +1038,7 @@ onMounted(async () => {
     // instance, so Vue would silently drop it and leak the registration.
     unregisterDirtyForm = registerForm(
       props.entityId,
-      (property) => _autoSaveInstance.value?.isDirty(property) ?? false,
+      (property) => _autoSaveInstance.value?.isDirty(property) ?? false
     )
   }
 
@@ -962,7 +1054,7 @@ onMounted(async () => {
       if (!inverse) {
         uiStore.warning(
           `Relation '${f.relation}' has no 'inverse:' declared in the metamodel. ` +
-            `Saving changes from this widget will fail until the metamodel is updated.`,
+            `Saving changes from this widget will fail until the metamodel is updated.`
         )
       }
     }
@@ -1051,7 +1143,7 @@ onBeforeRouteLeave(async () => {
       </div>
 
       <div v-if="loading" class="loading-state">
-        <div class="spinner"/>
+        <div class="spinner" />
         <span>Loading...</span>
       </div>
 
@@ -1059,8 +1151,8 @@ onBeforeRouteLeave(async () => {
         <h2>This entity is not editable</h2>
         <p>
           Your current permissions don't allow updating
-          <code>{{ entityId }}</code>. Return to the entity view to see
-          available actions.
+          <code>{{ entityId }}</code
+          >. Return to the entity view to see available actions.
         </p>
         <router-link
           v-if="formConfig && entityId"
@@ -1088,103 +1180,84 @@ onBeforeRouteLeave(async () => {
           </select>
         </div>
 
-        <template v-if="formConfig.sections?.length">
-          <div
-            v-for="section in formConfig.sections"
-            :key="section.title"
-            class="form-section"
-          >
-            <h2 v-if="section.title">{{ section.title }}</h2>
-            <p v-if="section.description" class="section-description">
-              {{ section.description }}
-            </p>
+        <!-- Wizard layout: a stepper + one visible step at a time. -->
+        <template v-if="wizard.isWizard.value">
+          <ol class="wizard-steps" aria-label="Form steps">
+            <li
+              v-for="(step, sIdx) in wizard.visibleSteps.value"
+              :key="step.title"
+              class="wizard-step-pill"
+              :class="{
+                active: sIdx === wizard.currentStep.value,
+                done: sIdx < wizard.currentStep.value,
+              }"
+            >
+              <span class="wizard-step-num">{{ sIdx + 1 }}</span>
+              <span class="wizard-step-title">{{ step.title }}</span>
+            </li>
+          </ol>
 
+          <div v-if="wizard.currentStepDef.value" class="form-section wizard-panel">
+            <h2 v-if="wizard.currentStepDef.value.title">
+              {{ wizard.currentStepDef.value.title }}
+            </h2>
+            <p v-if="wizard.currentStepDef.value.description" class="section-description">
+              {{ wizard.currentStepDef.value.description }}
+            </p>
             <div class="form-fields">
-              <template v-for="(field, fieldIdx) in section.fields" :key="`${fieldIdx}-${field.property || field.relation}`">
-                <FieldRenderer
-                  v-if="field.property && !field.hidden"
-                  :field="field"
-                  :property-def="getPropertyDef(field.property)"
-                  :value="formData[field.property]"
-                  :error="errors[field.property]"
-                  :readonly="isFieldReadonly(field)"
-                  :option-verdicts="optionVerdictsFor(field)"
-                  :entity-type="formConfig.entity"
-                  :entity-id="entityId"
-                  :attachments="attachments[field.property]"
-                  :max="getPropertyDef(field.property)?.max"
-                  @update="updateField(field.property!, $event)"
-                  @attachment-changed="onAttachmentChanged"
-                />
-                <RelationCards
-                  v-else-if="field.relation && field.widget === 'cards' && entityId"
-                  :key="`cards-${field.relation}-${field.direction || 'outgoing'}-${saveGeneration}`"
-                  :field="field"
-                  :entity-type="formConfig.entity"
-                  :entity-id="entityId"
-                  :verdict="relationAffordances[field.relation!]"
-                  @cards-changed="(state) => updateRelationCards(`${field.relation}-${field.direction || 'outgoing'}`, state)"
-                />
-                <RelationPicker
-                  v-else-if="field.relation"
-                  :key="`picker-${field.relation}-${field.direction || 'outgoing'}-${saveGeneration}`"
-                  :field="field"
-                  :entity-type="formConfig.entity"
-                  :entity-id="entityId"
-                  :value="relations[field.relation] || []"
-                  :verdict="relationAffordances[field.relation!]"
-                  @update="updateRelation(field.relation!, $event)"
-                  @update:types="(types) => updateRelationTypes(field.relation!, types)"
-                  @incoming-changed="(state) => updateIncomingPicker(field.relation!, state)"
-                />
-              </template>
+              <FormFieldList
+                :fields="visibleStepFields(wizard.currentStepDef.value)"
+                :entity-type="formConfig.entity"
+                :entity-id="entityId"
+                :form-data="formData"
+                :relations="relations"
+                :errors="errors"
+                :relation-affordances="relationAffordances"
+                :attachments="attachments"
+                :save-generation="saveGeneration"
+                :get-property-def="getPropertyDef"
+                :is-field-readonly="isFieldReadonly"
+                :option-verdicts-for="optionVerdictsFor"
+                @update-field="updateField"
+                @attachment-changed="onAttachmentChanged"
+                @update-relation="updateRelation"
+                @update-relation-types="updateRelationTypes"
+                @incoming-changed="updateIncomingPicker"
+                @cards-changed="updateRelationCards"
+              />
             </div>
           </div>
         </template>
 
         <div v-else class="form-fields">
-          <template v-for="(field, fieldIdx) in fields" :key="`${fieldIdx}-${field.property || field.relation}`">
-            <FieldRenderer
-              v-if="field.property && !field.hidden"
-              :field="field"
-              :property-def="getPropertyDef(field.property)"
-              :value="formData[field.property]"
-              :error="errors[field.property]"
-              :readonly="isFieldReadonly(field)"
-              :option-verdicts="optionVerdictsFor(field)"
-              :entity-type="formConfig.entity"
-              :entity-id="entityId"
-              :attachments="attachments[field.property]"
-              :max="getPropertyDef(field.property)?.max"
-              @update="updateField(field.property!, $event)"
-              @attachment-changed="onAttachmentChanged"
-            />
-            <RelationCards
-              v-else-if="field.relation && field.widget === 'cards' && entityId"
-              :key="`cards-${field.relation}-${field.direction || 'outgoing'}-${saveGeneration}`"
-              :field="field"
-              :entity-type="formConfig.entity"
-              :entity-id="entityId"
-              :verdict="relationAffordances[field.relation!]"
-              @cards-changed="(state) => updateRelationCards(`${field.relation}-${field.direction || 'outgoing'}`, state)"
-            />
-            <RelationPicker
-              v-else-if="field.relation"
-              :key="`picker-${field.relation}-${field.direction || 'outgoing'}-${saveGeneration}`"
-              :field="field"
-              :entity-type="formConfig.entity"
-              :entity-id="entityId"
-              :value="relations[field.relation] || []"
-              :verdict="relationAffordances[field.relation!]"
-              @update="updateRelation(field.relation!, $event)"
-              @update:types="(types) => updateRelationTypes(field.relation!, types)"
-              @incoming-changed="(state) => updateIncomingPicker(field.relation!, state)"
-            />
-          </template>
+          <FormFieldList
+            :fields="fields"
+            :entity-type="formConfig.entity"
+            :entity-id="entityId"
+            :form-data="formData"
+            :relations="relations"
+            :errors="errors"
+            :relation-affordances="relationAffordances"
+            :attachments="attachments"
+            :save-generation="saveGeneration"
+            :get-property-def="getPropertyDef"
+            :is-field-readonly="isFieldReadonly"
+            :option-verdicts-for="optionVerdictsFor"
+            @update-field="updateField"
+            @attachment-changed="onAttachmentChanged"
+            @update-relation="updateRelation"
+            @update-relation-types="updateRelationTypes"
+            @incoming-changed="updateIncomingPicker"
+            @cards-changed="updateRelationCards"
+          />
         </div>
 
-        <!-- Content field (markdown body) -->
-        <div class="form-field content-field">
+        <!-- Content field (markdown body). In a wizard it belongs on the
+             final step, next to the submit action. -->
+        <div
+          v-if="!wizard.isWizard.value || wizard.isLastStep.value"
+          class="form-field content-field"
+        >
           <label for="content">Content</label>
           <MarkdownEditor
             :model-value="content"
@@ -1193,23 +1266,40 @@ onBeforeRouteLeave(async () => {
           />
         </div>
 
-        <div class="form-actions">
+        <!-- Wizard navigation: Back / Next, with Submit on the last step. -->
+        <div v-if="wizard.isWizard.value" class="form-actions">
+          <button
+            type="button"
+            class="btn btn-secondary"
+            :disabled="wizard.isFirstStep.value"
+            @click="handleBack"
+          >
+            Back
+          </button>
+          <button
+            v-if="!wizard.isLastStep.value"
+            type="button"
+            class="btn btn-primary"
+            @click="handleNext"
+          >
+            Next
+          </button>
+          <button v-else type="submit" class="btn btn-primary" :disabled="saving">
+            {{ saving ? 'Saving...' : isEdit ? 'Save Changes' : 'Create' }}
+            <kbd>&#8984;&#8629;</kbd>
+          </button>
+        </div>
+
+        <div v-else class="form-actions">
           <!-- Edit mode: ambient autosave indicator replaces the
                explicit Save button. Cancel is repurposed as a Back
                button to navigate away (with the autosave-flushing
                route guard catching any pending edits). -->
           <template v-if="autoSave">
-            <button
-              type="button"
-              class="btn btn-secondary"
-              @click="handleCancel"
-            >
+            <button type="button" class="btn btn-secondary" @click="handleCancel">
               Back <kbd>Esc</kbd>
             </button>
-            <AutoSaveIndicator
-              :status="autoSave.status"
-              :error="autoSave.lastError"
-            />
+            <AutoSaveIndicator :status="autoSave.status" :error="autoSave.lastError" />
           </template>
           <template v-else>
             <button
@@ -1220,12 +1310,9 @@ onBeforeRouteLeave(async () => {
             >
               Cancel <kbd>Esc</kbd>
             </button>
-            <button
-              type="submit"
-              class="btn btn-primary"
-              :disabled="saving"
-            >
-              {{ saving ? 'Saving...' : (isEdit ? 'Save Changes' : 'Create') }} <kbd>&#8984;&#8629;</kbd>
+            <button type="submit" class="btn btn-primary" :disabled="saving">
+              {{ saving ? 'Saving...' : isEdit ? 'Save Changes' : 'Create' }}
+              <kbd>&#8984;&#8629;</kbd>
             </button>
           </template>
         </div>
@@ -1233,11 +1320,7 @@ onBeforeRouteLeave(async () => {
     </div>
 
     <!-- Side panel for edit mode -->
-    <SidePanel
-      v-if="isEdit && entityId"
-      :form-id="formId"
-      :entity-id="entityId"
-    />
+    <SidePanel v-if="isEdit && entityId" :form-id="formId" :entity-id="entityId" />
   </div>
 
   <div v-else class="error-state">
@@ -1326,6 +1409,55 @@ onBeforeRouteLeave(async () => {
   margin-bottom: 24px;
 }
 
+/* Wizard stepper */
+.wizard-steps {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  list-style: none;
+  margin: 0 0 20px;
+  padding: 0;
+}
+
+.wizard-step-pill {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 12px;
+  border-radius: 999px;
+  background: var(--card-bg);
+  border: 1px solid var(--border-color);
+  color: var(--muted-text);
+  font-size: 13px;
+}
+
+.wizard-step-pill.active {
+  border-color: var(--primary, #3b82f6);
+  color: var(--text-color);
+  font-weight: 600;
+}
+
+.wizard-step-pill.done {
+  color: var(--text-color);
+}
+
+.wizard-step-num {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  background: var(--border-color);
+  font-size: 12px;
+}
+
+.wizard-step-pill.active .wizard-step-num,
+.wizard-step-pill.done .wizard-step-num {
+  background: var(--primary, #3b82f6);
+  color: #fff;
+}
+
 .form-fields {
   display: flex;
   flex-direction: column;
@@ -1383,7 +1515,6 @@ onBeforeRouteLeave(async () => {
   margin-top: 16px;
   margin-bottom: 24px;
 }
-
 
 .form-actions {
   display: flex;

--- a/frontend/src/components/forms/DynamicForm.vue
+++ b/frontend/src/components/forms/DynamicForm.vue
@@ -1457,7 +1457,7 @@ onBeforeRouteLeave(async () => {
 }
 
 .wizard-step-pill.active {
-  border-color: var(--primary, #3b82f6);
+  border-color: var(--accent-color);
   color: var(--text-color);
   font-weight: 600;
 }
@@ -1479,7 +1479,7 @@ onBeforeRouteLeave(async () => {
 
 .wizard-step-pill.active .wizard-step-num,
 .wizard-step-pill.done .wizard-step-num {
-  background: var(--primary, #3b82f6);
+  background: var(--accent-color);
   color: #fff;
 }
 

--- a/frontend/src/components/forms/DynamicForm.vue
+++ b/frontend/src/components/forms/DynamicForm.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, computed, onMounted, onBeforeUnmount } from 'vue'
+import { ref, computed, nextTick, onMounted, onBeforeUnmount } from 'vue'
 import { useRouter, useRoute, onBeforeRouteLeave } from 'vue-router'
 import { useSchemaStore, useEntitiesStore, useUIStore } from '@/stores'
 import { isCancelledFetch } from '@/composables/usePageData'
@@ -164,6 +164,21 @@ const conditionBindings = (): Bindings => ({
 })
 
 const wizard = useFormWizard(formConfig, conditionBindings)
+
+// Visible-step indices that currently have a validation error, so the stepper
+// can flag them. Recomputes as `errors` changes, so a pill's flag clears the
+// moment its field becomes valid.
+const stepsWithErrors = computed<Set<number>>(() => {
+  const flagged = new Set<number>()
+  if (!wizard.isWizard.value) return flagged
+  for (const property of Object.keys(errors.value)) {
+    const idx = wizard.visibleStepIndexForProperty(property)
+    if (idx >= 0) flagged.add(idx)
+  }
+  return flagged
+})
+
+const errorCount = computed(() => Object.keys(errors.value).length)
 
 // TKT-G7N5 F1 / TKT-3I5U: filter the config-driven field list against
 // the entity's affordances. A property field is rendered only if it is
@@ -671,10 +686,38 @@ function handleStepClick(index: number) {
   wizard.goTo(index)
 }
 
+// On a failed wizard submit, take the user to the first step that has an error
+// and focus its first invalid field, so the fix is one glance + zero hunting.
+function focusFirstError() {
+  if (!wizard.isWizard.value) return
+  // First errored property in visible order.
+  let firstStep = Infinity
+  let firstProp: string | null = null
+  for (const property of Object.keys(errors.value)) {
+    const idx = wizard.visibleStepIndexForProperty(property)
+    if (idx >= 0 && idx < firstStep) {
+      firstStep = idx
+      firstProp = property
+    }
+  }
+  if (firstProp === null) return
+  wizard.goTo(firstStep)
+  // Focus after the step renders.
+  const prop = firstProp
+  nextTick(() => {
+    const el = document.getElementById(`field-${prop}`)
+    el?.scrollIntoView({ block: 'center', behavior: 'smooth' })
+    el?.focus()
+  })
+}
+
 async function handleSubmit() {
   if (!formConfig.value) return
   const scope = submitScopeFields()
-  if (!validate(scope, requiredWhenProps(scope))) return
+  if (!validate(scope, requiredWhenProps(scope))) {
+    focusFirstError()
+    return
+  }
 
   saving.value = true
   try {
@@ -835,6 +878,15 @@ function handleCancel() {
 
 function updateField(property: string, value: unknown) {
   formData.value[property] = value
+  // Clear a standing validation error for this field as the user edits it, so
+  // the wizard's per-step error flags and summary update live. A full re-check
+  // happens on the next Next/Submit; this just avoids a stale "needs attention"
+  // marker after the user has addressed it.
+  if (errors.value[property]) {
+    const next = { ...errors.value }
+    delete next[property]
+    errors.value = next
+  }
   checkDirty()
   // TKT-3I5U: in create mode, re-derive affordances from the staged
   // entity's new values (value-dependent verdicts) — debounced. Also
@@ -1220,11 +1272,14 @@ onBeforeRouteLeave(async () => {
                 :class="{
                   active: sIdx === wizard.currentStep.value,
                   done: sIdx < wizard.currentStep.value,
+                  'has-errors': stepsWithErrors.has(sIdx),
                 }"
                 :aria-current="sIdx === wizard.currentStep.value ? 'step' : undefined"
                 @click="handleStepClick(sIdx)"
               >
-                <span class="wizard-step-num">{{ sIdx + 1 }}</span>
+                <span class="wizard-step-num">{{
+                  stepsWithErrors.has(sIdx) ? '!' : sIdx + 1
+                }}</span>
                 <span class="wizard-step-title">{{ step.title }}</span>
               </button>
             </li>
@@ -1303,6 +1358,14 @@ onBeforeRouteLeave(async () => {
             @update:model-value="updateContent"
           />
         </div>
+
+        <!-- Submit-time validation summary. Announced (role=alert) and linked to
+             the offending fields via the flagged stepper pills; Create also
+             jumps to the first error. -->
+        <p v-if="wizard.isWizard.value && errorCount > 0" class="wizard-error-summary" role="alert">
+          ⚠ {{ errorCount }} {{ errorCount === 1 ? 'field needs' : 'fields need' }} attention — see
+          the flagged step{{ stepsWithErrors.size === 1 ? '' : 's' }} above.
+        </p>
 
         <!-- Wizard navigation: Back / Next, with Submit on the last step. -->
         <div v-if="wizard.isWizard.value && wizard.currentStepDef.value" class="form-actions">
@@ -1509,6 +1572,24 @@ onBeforeRouteLeave(async () => {
 .wizard-step-pill.done .wizard-step-num {
   background: var(--accent-color);
   color: #fff;
+}
+
+/* A step with a validation error takes precedence over active/done styling. */
+.wizard-step-pill.has-errors {
+  border-color: var(--error-color);
+  color: var(--error-color);
+}
+
+.wizard-step-pill.has-errors .wizard-step-num {
+  background: var(--error-color);
+  color: #fff;
+}
+
+.wizard-error-summary {
+  color: var(--error-color);
+  font-size: 13px;
+  font-weight: 600;
+  margin: 0 0 12px;
 }
 
 .form-fields {

--- a/frontend/src/components/forms/DynamicForm.vue
+++ b/frontend/src/components/forms/DynamicForm.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, computed, nextTick, onMounted, onBeforeUnmount } from 'vue'
+import { ref, computed, watch, nextTick, onMounted, onBeforeUnmount } from 'vue'
 import { useRouter, useRoute, onBeforeRouteLeave } from 'vue-router'
 import { useSchemaStore, useEntitiesStore, useUIStore } from '@/stores'
 import { isCancelledFetch } from '@/composables/usePageData'
@@ -170,7 +170,6 @@ const wizard = useFormWizard(formConfig, conditionBindings)
 // moment its field becomes valid.
 const stepsWithErrors = computed<Set<number>>(() => {
   const flagged = new Set<number>()
-  if (!wizard.isWizard.value) return flagged
   for (const property of Object.keys(errors.value)) {
     const idx = wizard.visibleStepIndexForProperty(property)
     if (idx >= 0) flagged.add(idx)
@@ -179,6 +178,32 @@ const stepsWithErrors = computed<Set<number>>(() => {
 })
 
 const errorCount = computed(() => Object.keys(errors.value).length)
+
+// Edit mode: when a conditional field/step becomes hidden (its `visible_when`
+// flipped false), unset its stored value — the edit-mode analogue of create's
+// submit-time hidden-branch pruning, so a toggled-off branch doesn't linger on
+// the entity. Only fields the wizard governs (managed) are affected; a plain
+// field in no conditional branch is never unset. Runs only after the form has
+// loaded (skip the initial hydration).
+watch(
+  () => wizard.activeProperties.value,
+  (active, prevActive) => {
+    if (!isEdit.value || loading.value || !autoSave.value || !prevActive) return
+    for (const prop of prevActive) {
+      // Became hidden, is wizard-governed, and still holds a value → unset it.
+      if (
+        !active.has(prop) &&
+        wizard.managedProperties.value.has(prop) &&
+        formData.value[prop] !== undefined &&
+        formData.value[prop] !== '' &&
+        formData.value[prop] !== null
+      ) {
+        delete formData.value[prop]
+        autoSave.value.scheduleUnset(prop)
+      }
+    }
+  }
+)
 
 // TKT-G7N5 F1 / TKT-3I5U: filter the config-driven field list against
 // the entity's affordances. A property field is rendered only if it is
@@ -636,21 +661,20 @@ function visibleStepFields(step: import('@/types').FormStep): FormFieldOrRelatio
   return wizard.visibleFieldsOf(step).filter(affordanceVisible)
 }
 
-// Fields currently in scope for submit: for a wizard, only the visible fields
-// of currently-visible steps; for a single-page form, all fields. The wizard
-// scope applies the same affordance filter as rendering (visibleStepFields), so
-// validation never demands a policy-hidden field the user can't see or fill.
+// Fields in scope for submit: the visible fields of the currently-visible
+// steps (for a flat/one-step form that's just its fields). Applies the same
+// affordance filter as rendering (visibleStepFields), so validation never
+// demands a policy-hidden field the user can't see or fill.
 function submitScopeFields(): FormFieldOrRelation[] {
-  if (!wizard.isWizard.value) return fields.value
   return wizard.visibleSteps.value.flatMap((s) => visibleStepFields(s))
 }
 
-// Drop property keys that belong to a condition-hidden step/field for a wizard
-// (so a revealed-then-hidden branch is not persisted). No-op for single-page
-// forms. Applied by BOTH submit paths — including on top of the create path's
-// affordance prune — so the two pruning systems reconcile in one place.
+// Drop property keys under a condition-hidden step/field so a revealed-then-
+// hidden branch is not persisted. Applied by BOTH submit paths — including on
+// top of the create path's affordance prune — so the two pruning systems
+// reconcile in one place. For a flat form with no conditions this is a no-op
+// (nothing is hidden).
 function pruneWizardHidden(props: Record<string, unknown>): Record<string, unknown> {
-  if (!wizard.isWizard.value) return props
   const active = wizard.activeProperties.value
   const managed = wizard.managedProperties.value
   // Drop a key only if the wizard governs it (named by some step) AND it is not
@@ -700,10 +724,10 @@ function handleStepClick(index: number) {
   wizard.goTo(index)
 }
 
-// On a failed wizard submit, take the user to the first step that has an error
-// and focus its first invalid field, so the fix is one glance + zero hunting.
+// On a failed submit, take the user to the first step that has an error and
+// focus its first invalid field, so the fix is one glance + zero hunting. For a
+// one-step form this just focuses the field on the only step.
 function focusFirstError() {
-  if (!wizard.isWizard.value) return
   // First errored property in visible order.
   let firstStep = Infinity
   let firstProp: string | null = null
@@ -727,6 +751,9 @@ function focusFirstError() {
 
 async function handleSubmit() {
   if (!formConfig.value) return
+  // Edit mode has no explicit submit — autosave persists per field. Guard
+  // against an Enter-key form submit doing anything (there's no Save button).
+  if (isEdit.value) return
   const scope = submitScopeFields()
   if (!validate(scope, requiredWhenProps(scope))) {
     focusFirstError()
@@ -1278,95 +1305,68 @@ onBeforeRouteLeave(async () => {
           </select>
         </div>
 
-        <!-- Wizard layout: a stepper + one visible step at a time. -->
-        <template v-if="wizard.isWizard.value">
-          <ol class="wizard-steps" aria-label="Form steps">
-            <li v-for="(step, sIdx) in wizard.visibleSteps.value" :key="sIdx">
-              <button
-                type="button"
-                class="wizard-step-pill"
-                :class="{
-                  active: sIdx === wizard.currentStep.value,
-                  done: sIdx < wizard.currentStep.value,
-                  'has-errors': stepsWithErrors.has(sIdx),
-                }"
-                :aria-current="sIdx === wizard.currentStep.value ? 'step' : undefined"
-                @click="handleStepClick(sIdx)"
-              >
-                <span class="wizard-step-num">{{
-                  stepsWithErrors.has(sIdx) ? '!' : sIdx + 1
-                }}</span>
-                <span class="wizard-step-title">{{ step.title }}</span>
-              </button>
-            </li>
-          </ol>
+        <!-- Every form renders through the same step model. A single-page (flat)
+             form is one implicit, title-less step, so the stepper bar only shows
+             when there is more than one step. -->
+        <ol v-if="wizard.isMultiStep.value" class="wizard-steps" aria-label="Form steps">
+          <li v-for="(step, sIdx) in wizard.visibleSteps.value" :key="sIdx">
+            <button
+              type="button"
+              class="wizard-step-pill"
+              :class="{
+                active: sIdx === wizard.currentStep.value,
+                done: sIdx < wizard.currentStep.value,
+                'has-errors': stepsWithErrors.has(sIdx),
+              }"
+              :aria-current="sIdx === wizard.currentStep.value ? 'step' : undefined"
+              @click="handleStepClick(sIdx)"
+            >
+              <span class="wizard-step-num">{{ stepsWithErrors.has(sIdx) ? '!' : sIdx + 1 }}</span>
+              <span class="wizard-step-title">{{ step.title }}</span>
+            </button>
+          </li>
+        </ol>
 
-          <div v-if="wizard.currentStepDef.value" class="form-section wizard-panel">
-            <h2 v-if="wizard.currentStepDef.value.title">
-              {{ wizard.currentStepDef.value.title }}
-            </h2>
-            <p v-if="wizard.currentStepDef.value.description" class="section-description">
-              {{ wizard.currentStepDef.value.description }}
-            </p>
-            <div class="form-fields">
-              <FormFieldList
-                :fields="visibleStepFields(wizard.currentStepDef.value)"
-                :entity-type="formConfig.entity"
-                :entity-id="entityId"
-                :form-data="formData"
-                :relations="relations"
-                :errors="errors"
-                :relation-affordances="relationAffordances"
-                :attachments="attachments"
-                :save-generation="saveGeneration"
-                :get-property-def="getPropertyDef"
-                :is-field-readonly="isFieldReadonly"
-                :option-verdicts-for="optionVerdictsFor"
-                @update-field="updateField"
-                @attachment-changed="onAttachmentChanged"
-                @update-relation="updateRelation"
-                @update-relation-types="updateRelationTypes"
-                @incoming-changed="updateIncomingPicker"
-                @cards-changed="updateRelationCards"
-              />
-            </div>
+        <div
+          v-if="wizard.currentStepDef.value"
+          class="form-section"
+          :class="{ 'wizard-panel': wizard.isMultiStep.value }"
+        >
+          <h2 v-if="wizard.currentStepDef.value.title">
+            {{ wizard.currentStepDef.value.title }}
+          </h2>
+          <p v-if="wizard.currentStepDef.value.description" class="section-description">
+            {{ wizard.currentStepDef.value.description }}
+          </p>
+          <div class="form-fields">
+            <FormFieldList
+              :fields="visibleStepFields(wizard.currentStepDef.value)"
+              :entity-type="formConfig.entity"
+              :entity-id="entityId"
+              :form-data="formData"
+              :relations="relations"
+              :errors="errors"
+              :relation-affordances="relationAffordances"
+              :attachments="attachments"
+              :save-generation="saveGeneration"
+              :get-property-def="getPropertyDef"
+              :is-field-readonly="isFieldReadonly"
+              :option-verdicts-for="optionVerdictsFor"
+              @update-field="updateField"
+              @attachment-changed="onAttachmentChanged"
+              @update-relation="updateRelation"
+              @update-relation-types="updateRelationTypes"
+              @incoming-changed="updateIncomingPicker"
+              @cards-changed="updateRelationCards"
+            />
           </div>
-
-          <!-- Degenerate config: every step is conditionally hidden right now.
-               Render nothing to submit rather than an empty form with a
-               misleading Submit button. -->
-          <p v-else class="section-description">No steps to display.</p>
-        </template>
-
-        <div v-else class="form-fields">
-          <FormFieldList
-            :fields="fields"
-            :entity-type="formConfig.entity"
-            :entity-id="entityId"
-            :form-data="formData"
-            :relations="relations"
-            :errors="errors"
-            :relation-affordances="relationAffordances"
-            :attachments="attachments"
-            :save-generation="saveGeneration"
-            :get-property-def="getPropertyDef"
-            :is-field-readonly="isFieldReadonly"
-            :option-verdicts-for="optionVerdictsFor"
-            @update-field="updateField"
-            @attachment-changed="onAttachmentChanged"
-            @update-relation="updateRelation"
-            @update-relation-types="updateRelationTypes"
-            @incoming-changed="updateIncomingPicker"
-            @cards-changed="updateRelationCards"
-          />
         </div>
 
-        <!-- Content field (markdown body). In a wizard it belongs on the
-             final step, next to the submit action. -->
-        <div
-          v-if="!wizard.isWizard.value || wizard.isLastStep.value"
-          class="form-field content-field"
-        >
+        <!-- Degenerate config: every step is conditionally hidden right now. -->
+        <p v-else class="section-description">No fields to display.</p>
+
+        <!-- Content field (markdown body). Shown on the final (or only) step. -->
+        <div v-if="wizard.isLastStep.value" class="form-field content-field">
           <label for="content">Content</label>
           <MarkdownEditor
             :model-value="content"
@@ -1375,63 +1375,71 @@ onBeforeRouteLeave(async () => {
           />
         </div>
 
-        <!-- Submit-time validation summary. Announced (role=alert) and linked to
-             the offending fields via the flagged stepper pills; Create also
-             jumps to the first error. -->
-        <p v-if="wizard.isWizard.value && errorCount > 0" class="wizard-error-summary" role="alert">
-          ⚠ {{ errorCount }} {{ errorCount === 1 ? 'field needs' : 'fields need' }} attention — see
-          the flagged step{{ stepsWithErrors.size === 1 ? '' : 's' }} above.
+        <!-- Submit-time validation summary (create only — edit autosaves and has
+             no submit gate). Announced via role=alert. -->
+        <p v-if="!isEdit && errorCount > 0" class="wizard-error-summary" role="alert">
+          ⚠ {{ errorCount }}
+          {{ errorCount === 1 ? 'field needs' : 'fields need' }} attention<template
+            v-if="wizard.isMultiStep.value"
+          >
+            — see the flagged step{{ stepsWithErrors.size === 1 ? '' : 's' }} above</template
+          >.
         </p>
 
-        <!-- Wizard navigation: Back / Next, with Submit on the last step. -->
-        <div v-if="wizard.isWizard.value && wizard.currentStepDef.value" class="form-actions">
+        <!--
+          Actions branch on MODE, not on wizard-ness, so a wizard and a flat form
+          behave identically:
+          - EDIT: autosave per field, no Save button (the route guard flushes
+            pending edits on leave); step Back/Next only when multi-step.
+          - CREATE: Cancel + Back/Next (when multi-step) + Create on the last step.
+        -->
+        <div v-if="wizard.currentStepDef.value" class="form-actions">
+          <!-- Leave-the-form control (autosave Back in edit, Cancel in create). -->
           <button
             type="button"
             class="btn btn-secondary"
-            :disabled="wizard.isFirstStep.value"
-            @click="handleBack"
+            :disabled="!autoSave && saving"
+            @click="handleCancel"
           >
-            Back
+            {{ autoSave ? 'Back' : 'Cancel' }} <kbd>Esc</kbd>
           </button>
-          <button
-            v-if="!wizard.isLastStep.value"
-            type="button"
-            class="btn btn-primary"
-            @click="handleNext"
-          >
-            Next
-          </button>
-          <button v-else type="submit" class="btn btn-primary" :disabled="saving">
-            {{ saving ? 'Saving...' : isEdit ? 'Save Changes' : 'Create' }}
-            <kbd>&#8984;&#8629;</kbd>
-          </button>
-        </div>
 
-        <div v-else class="form-actions">
-          <!-- Edit mode: ambient autosave indicator replaces the
-               explicit Save button. Cancel is repurposed as a Back
-               button to navigate away (with the autosave-flushing
-               route guard catching any pending edits). -->
-          <template v-if="autoSave">
-            <button type="button" class="btn btn-secondary" @click="handleCancel">
-              Back <kbd>Esc</kbd>
-            </button>
-            <AutoSaveIndicator :status="autoSave.status" :error="autoSave.lastError" />
-          </template>
-          <template v-else>
+          <!-- Step navigation (multi-step only). -->
+          <template v-if="wizard.isMultiStep.value">
             <button
               type="button"
               class="btn btn-secondary"
-              :disabled="saving"
-              @click="handleCancel"
+              :disabled="wizard.isFirstStep.value"
+              @click="handleBack"
             >
-              Cancel <kbd>Esc</kbd>
+              ← Prev step
             </button>
-            <button type="submit" class="btn btn-primary" :disabled="saving">
-              {{ saving ? 'Saving...' : isEdit ? 'Save Changes' : 'Create' }}
-              <kbd>&#8984;&#8629;</kbd>
+            <button
+              v-if="!wizard.isLastStep.value"
+              type="button"
+              class="btn btn-primary"
+              @click="handleNext"
+            >
+              Next step →
             </button>
           </template>
+
+          <!-- Create only: the commit button, on the last (or only) step. -->
+          <button
+            v-if="!isEdit && wizard.isLastStep.value"
+            type="submit"
+            class="btn btn-primary"
+            :disabled="saving"
+          >
+            {{ saving ? 'Saving...' : 'Create' }} <kbd>&#8984;&#8629;</kbd>
+          </button>
+
+          <!-- Edit: ambient autosave status stands in for a Save button. -->
+          <AutoSaveIndicator
+            v-if="autoSave"
+            :status="autoSave.status"
+            :error="autoSave.lastError"
+          />
         </div>
       </form>
     </div>

--- a/frontend/src/components/forms/DynamicForm.vue
+++ b/frontend/src/components/forms/DynamicForm.vue
@@ -153,14 +153,15 @@ const allFields = computed((): FormFieldOrRelation[] => {
   return [...propFields, ...relFields]
 })
 
-// Live binding namespaces for condition evaluation. `form` is the current field
-// values; `entity`/`current_user` are reserved for future ACL/view use and are
-// empty here (form conditions reference `form.<field>` only).
-const conditionBindings = computed<Bindings>(() => ({
+// Live binding namespaces for condition evaluation. Supplied as a getter (not a
+// computed) so the reactive read of formData happens inside each wizard
+// computed's tracking scope — see useFormWizard. `entity`/`current_user` are
+// reserved for future ACL/view use (form conditions reference `form.<field>`).
+const conditionBindings = (): Bindings => ({
   form: formData.value,
   entity: {},
   current_user: {},
-}))
+})
 
 const wizard = useFormWizard(formConfig, conditionBindings)
 

--- a/frontend/src/components/forms/DynamicForm.vue
+++ b/frontend/src/components/forms/DynamicForm.vue
@@ -608,10 +608,29 @@ function visibleStepFields(step: import('@/types').FormStep): FormFieldOrRelatio
 }
 
 // Fields currently in scope for submit: for a wizard, only the visible fields
-// of currently-visible steps; for a single-page form, all fields.
+// of currently-visible steps; for a single-page form, all fields. The wizard
+// scope applies the same affordance filter as rendering (visibleStepFields), so
+// validation never demands a policy-hidden field the user can't see or fill.
 function submitScopeFields(): FormFieldOrRelation[] {
   if (!wizard.isWizard.value) return fields.value
-  return wizard.visibleSteps.value.flatMap((s) => wizard.visibleFieldsOf(s))
+  return wizard.visibleSteps.value.flatMap((s) => visibleStepFields(s))
+}
+
+// Drop property keys that belong to a condition-hidden step/field for a wizard
+// (so a revealed-then-hidden branch is not persisted). No-op for single-page
+// forms. Applied by BOTH submit paths — including on top of the create path's
+// affordance prune — so the two pruning systems reconcile in one place.
+function pruneWizardHidden(props: Record<string, unknown>): Record<string, unknown> {
+  if (!wizard.isWizard.value) return props
+  const active = wizard.activeProperties.value
+  const managed = wizard.managedProperties.value
+  // Drop a key only if the wizard governs it (named by some step) AND it is not
+  // currently active (its step/field is condition-hidden). A key no step
+  // mentions — e.g. a metamodel default seeded into form state — is left as-is,
+  // matching how a single-page form submits it.
+  return Object.fromEntries(
+    Object.entries(props).filter(([key]) => !managed.has(key) || active.has(key))
+  )
 }
 
 // Property keys made required right now by a matching `required_when`.
@@ -628,7 +647,9 @@ function requiredWhenProps(scope: FormFieldOrRelation[]): Set<string> {
 function handleNext() {
   const step = wizard.currentStepDef.value
   if (!step) return
-  const scope = wizard.visibleFieldsOf(step)
+  // Same scope as the step renders (visibleStepFields), so Next doesn't block
+  // on a policy-hidden field the user can't see.
+  const scope = visibleStepFields(step)
   if (!validate(scope, requiredWhenProps(scope))) return
   errors.value = {}
   wizard.next()
@@ -691,17 +712,6 @@ async function handleSubmit() {
     }
     const relationsPayload: ModernRelationsField = { ...reshapedPickers, ...modernRelations }
 
-    // For a wizard, drop values that belong to a hidden step/field so a
-    // toggled-off branch doesn't persist stale data (matches OpenVWR's
-    // isFieldEnabled). Single-page forms submit formData as-is.
-    let properties = formData.value
-    if (wizard.isWizard.value) {
-      const active = wizard.activeProperties.value
-      properties = Object.fromEntries(
-        Object.entries(formData.value).filter(([key]) => active.has(key))
-      )
-    }
-
     const payload: {
       id?: string
       prefix?: string
@@ -709,7 +719,12 @@ async function handleSubmit() {
       relations: ModernRelationsField
       content?: string
     } = {
-      properties,
+      // For a wizard, drop values under a hidden step/field so a toggled-off
+      // branch doesn't persist stale data (matches OpenVWR's isFieldEnabled).
+      // Single-page forms submit formData as-is. The create path re-derives
+      // this from the affordance-pruned set below (line ~734); this covers the
+      // edit path.
+      properties: pruneWizardHidden(formData.value),
       relations: relationsPayload,
       content: content.value || undefined,
     }
@@ -730,8 +745,12 @@ async function handleSubmit() {
       // entirely from reshaped picker selections.
       //
       // TKT-3I5U: send only visible + writable property keys; the server
-      // fills hidden / read-only defaults after the affordance gate.
-      payload.properties = visibleWritablePropertiesForCommit()
+      // fills hidden / read-only defaults after the affordance gate. For a
+      // wizard, also drop keys under a condition-hidden step/field — a
+      // `visible_when=false` branch wins over the affordance filter's
+      // userTouched-preserve rule, so a revealed-then-hidden field is not
+      // persisted (TKT-CHLAJ).
+      payload.properties = pruneWizardHidden(visibleWritablePropertiesForCommit())
       Object.assign(payload, idControls.buildPayloadFields())
       const entity = await entitiesStore.create(formConfig.value.entity, payload)
 
@@ -1186,7 +1205,7 @@ onBeforeRouteLeave(async () => {
           <ol class="wizard-steps" aria-label="Form steps">
             <li
               v-for="(step, sIdx) in wizard.visibleSteps.value"
-              :key="step.title"
+              :key="sIdx"
               class="wizard-step-pill"
               :class="{
                 active: sIdx === wizard.currentStep.value,
@@ -1228,6 +1247,11 @@ onBeforeRouteLeave(async () => {
               />
             </div>
           </div>
+
+          <!-- Degenerate config: every step is conditionally hidden right now.
+               Render nothing to submit rather than an empty form with a
+               misleading Submit button. -->
+          <p v-else class="section-description">No steps to display.</p>
         </template>
 
         <div v-else class="form-fields">
@@ -1268,7 +1292,7 @@ onBeforeRouteLeave(async () => {
         </div>
 
         <!-- Wizard navigation: Back / Next, with Submit on the last step. -->
-        <div v-if="wizard.isWizard.value" class="form-actions">
+        <div v-if="wizard.isWizard.value && wizard.currentStepDef.value" class="form-actions">
           <button
             type="button"
             class="btn btn-secondary"

--- a/frontend/src/components/forms/DynamicForm.vue
+++ b/frontend/src/components/forms/DynamicForm.vue
@@ -179,21 +179,33 @@ const stepsWithErrors = computed<Set<number>>(() => {
 
 const errorCount = computed(() => Object.keys(errors.value).length)
 
-// Edit mode: when a conditional field/step becomes hidden (its `visible_when`
-// flipped false), unset its stored value — the edit-mode analogue of create's
-// submit-time hidden-branch pruning, so a toggled-off branch doesn't linger on
-// the entity. Only fields the wizard governs (managed) are affected; a plain
-// field in no conditional branch is never unset. Runs only after the form has
-// loaded (skip the initial hydration).
+// React to a conditional field/step becoming hidden (its `visible_when` flipped
+// false). Two effects, both keyed on a property leaving `activeProperties`:
+//   1. Always: drop any standing validation error for the now-hidden field, so
+//      a hidden field can't leave a phantom "N fields need attention" with no
+//      flagged, reachable step (RR-U9ERK).
+//   2. Edit mode only: unset its stored value (autosave) — the edit analogue of
+//      create's submit-time hidden-branch pruning, so a toggled-off branch
+//      doesn't linger on the entity.
+// Skips the initial hydration (`loading`); only touches wizard-governed
+// (managed) fields, so a plain non-conditional field is never affected.
 watch(
   () => wizard.activeProperties.value,
   (active, prevActive) => {
-    if (!isEdit.value || loading.value || !autoSave.value || !prevActive) return
+    if (loading.value || !prevActive) return
+    const managed = wizard.managedProperties.value
+    let nextErrors: Record<string, string> | null = null
     for (const prop of prevActive) {
-      // Became hidden, is wizard-governed, and still holds a value → unset it.
+      if (active.has(prop) || !managed.has(prop)) continue // still shown / not governed
+      // Clear a standing error for the now-hidden field.
+      if (errors.value[prop]) {
+        nextErrors ??= { ...errors.value }
+        delete nextErrors[prop]
+      }
+      // Edit mode: unset a stored value so the hidden branch doesn't persist.
       if (
-        !active.has(prop) &&
-        wizard.managedProperties.value.has(prop) &&
+        isEdit.value &&
+        autoSave.value &&
         formData.value[prop] !== undefined &&
         formData.value[prop] !== '' &&
         formData.value[prop] !== null
@@ -202,6 +214,7 @@ watch(
         autoSave.value.scheduleUnset(prop)
       }
     }
+    if (nextErrors) errors.value = nextErrors
   }
 )
 
@@ -686,6 +699,18 @@ function pruneWizardHidden(props: Record<string, unknown>): Record<string, unkno
   )
 }
 
+// Relation analogue of pruneWizardHidden: drop a relation's edges when it is
+// wizard-governed but currently hidden (its step/field visible_when is false),
+// so a revealed-then-hidden relation is not persisted. `rels` is keyed by
+// relation name (as relations.value is).
+function pruneWizardHiddenRelations(rels: Record<string, string[]>): Record<string, string[]> {
+  const active = wizard.activeRelations.value
+  const managed = wizard.managedRelations.value
+  return Object.fromEntries(
+    Object.entries(rels).filter(([rel]) => !managed.has(rel) || active.has(rel))
+  )
+}
+
 // Property keys made required right now by a matching `required_when`.
 function requiredWhenProps(scope: FormFieldOrRelation[]): Set<string> {
   const req = new Set<string>()
@@ -768,8 +793,11 @@ async function handleSubmit() {
     const cardRelations = new Set(
       fields.value.filter((f) => f.relation && f.widget === 'cards').map((f) => f.relation!)
     )
+    // Drop relations under a condition-hidden branch (mirrors property pruning),
+    // then exclude card-managed relations (delivered via pendingCardChanges).
+    const prunedRelations = pruneWizardHiddenRelations(relations.value)
     const filteredRelations: Record<string, string[]> = {}
-    for (const [rel, ids] of Object.entries(relations.value)) {
+    for (const [rel, ids] of Object.entries(prunedRelations)) {
       if (!cardRelations.has(rel)) {
         filteredRelations[rel] = ids
       }
@@ -1092,10 +1120,16 @@ function handleBeforeUnload(e: BeforeUnloadEvent) {
   }
 }
 
-// Cmd/Ctrl+Enter to submit
+// Cmd/Ctrl+Enter: on the last (or only) step it submits (create); on an earlier
+// wizard step it advances — matching the visible Create-only-on-last-step
+// affordance rather than submitting from the middle of a wizard. No-op in edit
+// mode (autosave; handleSubmit early-returns).
 function handleKeydown(e: KeyboardEvent) {
-  if ((e.metaKey || e.ctrlKey) && e.key === 'Enter') {
-    e.preventDefault()
+  if (!((e.metaKey || e.ctrlKey) && e.key === 'Enter')) return
+  e.preventDefault()
+  if (!isEdit.value && wizard.isMultiStep.value && !wizard.isLastStep.value) {
+    handleNext()
+  } else {
     handleSubmit()
   }
 }
@@ -1118,6 +1152,12 @@ onMounted(async () => {
     await loadTemplates()
   }
   loading.value = false
+
+  // Re-seed the wizard step from `?step=` now that entity/defaults are loaded:
+  // a step whose `visible_when` needs loaded data is only in `visibleSteps`
+  // after this point, so the construction-time seed may have clamped a
+  // deep-link to the wrong step (RR-TXMU6).
+  wizard.seedFromUrl()
 
   // TKT-3I5U: derive the staged entity's initial affordances from the
   // dry-run so the first affordance-filtered paint reflects defaults +
@@ -1380,7 +1420,7 @@ onBeforeRouteLeave(async () => {
         <p v-if="!isEdit && errorCount > 0" class="wizard-error-summary" role="alert">
           ⚠ {{ errorCount }}
           {{ errorCount === 1 ? 'field needs' : 'fields need' }} attention<template
-            v-if="wizard.isMultiStep.value"
+            v-if="wizard.isMultiStep.value && stepsWithErrors.size > 0"
           >
             — see the flagged step{{ stepsWithErrors.size === 1 ? '' : 's' }} above</template
           >.

--- a/frontend/src/components/forms/DynamicForm.vue
+++ b/frontend/src/components/forms/DynamicForm.vue
@@ -661,6 +661,16 @@ function handleBack() {
   wizard.back()
 }
 
+// Clicking a step pill jumps straight there. A deliberate jump is not gated by
+// per-step validation (unlike Next): visible_when keeps unmet branches hidden
+// and the final Submit re-validates every visible step, so a jump can't persist
+// invalid data. Clear transient per-field errors so a jumped-to step starts clean.
+function handleStepClick(index: number) {
+  if (index === wizard.currentStep.value) return
+  errors.value = {}
+  wizard.goTo(index)
+}
+
 async function handleSubmit() {
   if (!formConfig.value) return
   const scope = submitScopeFields()
@@ -1203,17 +1213,20 @@ onBeforeRouteLeave(async () => {
         <!-- Wizard layout: a stepper + one visible step at a time. -->
         <template v-if="wizard.isWizard.value">
           <ol class="wizard-steps" aria-label="Form steps">
-            <li
-              v-for="(step, sIdx) in wizard.visibleSteps.value"
-              :key="sIdx"
-              class="wizard-step-pill"
-              :class="{
-                active: sIdx === wizard.currentStep.value,
-                done: sIdx < wizard.currentStep.value,
-              }"
-            >
-              <span class="wizard-step-num">{{ sIdx + 1 }}</span>
-              <span class="wizard-step-title">{{ step.title }}</span>
+            <li v-for="(step, sIdx) in wizard.visibleSteps.value" :key="sIdx">
+              <button
+                type="button"
+                class="wizard-step-pill"
+                :class="{
+                  active: sIdx === wizard.currentStep.value,
+                  done: sIdx < wizard.currentStep.value,
+                }"
+                :aria-current="sIdx === wizard.currentStep.value ? 'step' : undefined"
+                @click="handleStepClick(sIdx)"
+              >
+                <span class="wizard-step-num">{{ sIdx + 1 }}</span>
+                <span class="wizard-step-title">{{ step.title }}</span>
+              </button>
             </li>
           </ol>
 
@@ -1454,6 +1467,21 @@ onBeforeRouteLeave(async () => {
   border: 1px solid var(--border-color);
   color: var(--muted-text);
   font-size: 13px;
+  font-family: inherit;
+  cursor: pointer;
+  transition:
+    border-color 0.15s,
+    color 0.15s;
+}
+
+.wizard-step-pill:hover {
+  border-color: var(--accent-color);
+  color: var(--text-color);
+}
+
+.wizard-step-pill:focus-visible {
+  outline: 2px solid var(--accent-color);
+  outline-offset: 2px;
 }
 
 .wizard-step-pill.active {

--- a/frontend/src/components/forms/FormFieldList.vue
+++ b/frontend/src/components/forms/FormFieldList.vue
@@ -1,0 +1,88 @@
+<script setup lang="ts">
+/**
+ * FormFieldList — renders an ordered list of form fields (property fields,
+ * relation cards, relation pickers), dispatching each to the right widget.
+ *
+ * Extracted from DynamicForm so the single-page body, and each wizard step,
+ * render fields through one code path instead of duplicated template blocks.
+ * The parent owns all state and validation; this component is presentational
+ * and re-emits every edit so the parent's handlers stay authoritative.
+ */
+import type { FormFieldOrRelation, PropertyDef, RelationAffordance, AttachmentInfo } from '@/types'
+import FieldRenderer from './FieldRenderer.vue'
+import RelationCards from './RelationCards.vue'
+import RelationPicker from './RelationPicker.vue'
+import type { RelationCardState } from './RelationCards.vue'
+import type { RelationPickerIncomingState } from './RelationPicker.vue'
+
+defineProps<{
+  fields: FormFieldOrRelation[]
+  entityType: string
+  entityId?: string
+  formData: Record<string, unknown>
+  relations: Record<string, string[]>
+  errors: Record<string, string>
+  relationAffordances: Record<string, RelationAffordance>
+  attachments: Record<string, AttachmentInfo[]>
+  saveGeneration: number
+  getPropertyDef: (name: string) => PropertyDef | undefined
+  isFieldReadonly: (field: FormFieldOrRelation) => boolean
+  optionVerdictsFor: (field: FormFieldOrRelation) => Record<string, boolean> | undefined
+}>()
+
+const emit = defineEmits<{
+  (e: 'update-field', property: string, value: unknown): void
+  (e: 'attachment-changed', ...args: unknown[]): void
+  (e: 'update-relation', relation: string, value: string[]): void
+  (e: 'update-relation-types', relation: string, types: Map<string, string>): void
+  (e: 'incoming-changed', relation: string, state: RelationPickerIncomingState): void
+  (e: 'cards-changed', key: string, state: RelationCardState): void
+}>()
+</script>
+
+<template>
+  <template
+    v-for="(field, fieldIdx) in fields"
+    :key="`${fieldIdx}-${field.property || field.relation}`"
+  >
+    <FieldRenderer
+      v-if="field.property && !field.hidden"
+      :field="field"
+      :property-def="getPropertyDef(field.property)"
+      :value="formData[field.property]"
+      :error="errors[field.property]"
+      :readonly="isFieldReadonly(field)"
+      :option-verdicts="optionVerdictsFor(field)"
+      :entity-type="entityType"
+      :entity-id="entityId"
+      :attachments="attachments[field.property]"
+      :max="getPropertyDef(field.property)?.max"
+      @update="emit('update-field', field.property!, $event)"
+      @attachment-changed="emit('attachment-changed', $event)"
+    />
+    <RelationCards
+      v-else-if="field.relation && field.widget === 'cards' && entityId"
+      :key="`cards-${field.relation}-${field.direction || 'outgoing'}-${saveGeneration}`"
+      :field="field"
+      :entity-type="entityType"
+      :entity-id="entityId"
+      :verdict="relationAffordances[field.relation!]"
+      @cards-changed="
+        (state) =>
+          emit('cards-changed', `${field.relation}-${field.direction || 'outgoing'}`, state)
+      "
+    />
+    <RelationPicker
+      v-else-if="field.relation"
+      :key="`picker-${field.relation}-${field.direction || 'outgoing'}-${saveGeneration}`"
+      :field="field"
+      :entity-type="entityType"
+      :entity-id="entityId"
+      :value="relations[field.relation] || []"
+      :verdict="relationAffordances[field.relation!]"
+      @update="emit('update-relation', field.relation!, $event)"
+      @update:types="(types) => emit('update-relation-types', field.relation!, types)"
+      @incoming-changed="(state) => emit('incoming-changed', field.relation!, state)"
+    />
+  </template>
+</template>

--- a/frontend/src/composables/useFormWizard.test.ts
+++ b/frontend/src/composables/useFormWizard.test.ts
@@ -1,0 +1,177 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { computed, reactive, ref, nextTick, effectScope, type EffectScope } from 'vue'
+import type { LocationQuery } from 'vue-router'
+import { useFormWizard } from './useFormWizard'
+import type { Bindings } from '@/utils/conditions'
+import type { FormConfig } from '@/types'
+
+const mockRoute = reactive<{ query: LocationQuery }>({ query: {} })
+const mockReplace = vi.fn()
+
+vi.mock('vue-router', () => ({
+  useRoute: () => mockRoute,
+  useRouter: () => ({ replace: mockReplace }),
+}))
+
+mockReplace.mockImplementation(({ query }: { query: LocationQuery }) => {
+  mockRoute.query = query
+})
+
+let scope: EffectScope
+
+function wizardForm(): FormConfig {
+  return {
+    entity: 'processing-record',
+    title: 'New record',
+    steps: [
+      { title: 'Controller', fields: [{ property: 'name', required: true }] },
+      {
+        title: 'Processor',
+        visible_when: 'form.has_processors == true',
+        fields: [{ property: 'processor_name', required_when: 'form.has_processors == true' }],
+      },
+      { title: 'Publish', fields: [{ property: 'published' }] },
+    ],
+  }
+}
+
+describe('useFormWizard', () => {
+  beforeEach(() => {
+    mockRoute.query = {}
+    mockReplace.mockClear()
+    scope = effectScope()
+  })
+  afterEach(() => scope.stop())
+
+  function setup(cfg: FormConfig | undefined, form: Record<string, unknown> = {}) {
+    const config = ref(cfg)
+    const formData = ref(form)
+    const bindings = computed<Bindings>(() => ({
+      form: formData.value,
+      entity: {},
+      current_user: {},
+    }))
+    const wiz = scope.run(() => useFormWizard(config, bindings))!
+    return { wiz, formData, config }
+  }
+
+  it('detects a wizard vs a single-page form', () => {
+    expect(setup(wizardForm()).wiz.isWizard.value).toBe(true)
+    expect(setup({ entity: 'x', fields: [{ property: 'a' }] }).wiz.isWizard.value).toBe(false)
+    expect(setup(undefined).wiz.isWizard.value).toBe(false)
+  })
+
+  it('filters visible steps by visible_when against form values', () => {
+    const { wiz, formData } = setup(wizardForm(), { has_processors: false })
+    // Processor step hidden when the toggle is off.
+    expect(wiz.visibleSteps.value.map((s) => s.title)).toEqual(['Controller', 'Publish'])
+    formData.value = { has_processors: true }
+    expect(wiz.visibleSteps.value.map((s) => s.title)).toEqual([
+      'Controller',
+      'Processor',
+      'Publish',
+    ])
+  })
+
+  it('isFieldRequired honors authored required and required_when', () => {
+    const { wiz, formData } = setup(wizardForm(), { has_processors: true })
+    const controller = wiz.visibleSteps.value[0]
+    const processor = wiz.visibleSteps.value[1]
+    expect(wiz.isFieldRequired(controller.fields![0])).toBe(true) // authored required
+    expect(wiz.isFieldRequired(processor.fields![0])).toBe(true) // required_when true
+    formData.value = { has_processors: false }
+    // processor step is now hidden; but the field's required_when is false anyway
+    const proc = wizardForm().steps![1].fields![0]
+    expect(wiz.isFieldRequired(proc)).toBe(false)
+  })
+
+  it('activeProperties excludes hidden-branch fields', () => {
+    const { wiz, formData } = setup(wizardForm(), { has_processors: false })
+    expect([...wiz.activeProperties.value].sort()).toEqual(['name', 'published'])
+    formData.value = { has_processors: true }
+    expect([...wiz.activeProperties.value].sort()).toEqual(['name', 'processor_name', 'published'])
+  })
+
+  it('visibleFieldsOf honors per-field visible_when', () => {
+    const cfg: FormConfig = {
+      entity: 'x',
+      steps: [
+        {
+          title: 'S',
+          fields: [
+            { property: 'always' },
+            { property: 'maybe', visible_when: "form.mode == 'advanced'" },
+          ],
+        },
+      ],
+    }
+    const { wiz, formData } = setup(cfg, { mode: 'basic' })
+    expect(wiz.visibleFieldsOf(cfg.steps![0]).map((f) => f.property)).toEqual(['always'])
+    formData.value = { mode: 'advanced' }
+    expect(wiz.visibleFieldsOf(cfg.steps![0]).map((f) => f.property)).toEqual(['always', 'maybe'])
+  })
+
+  describe('navigation + URL sync', () => {
+    it('seeds currentStep from ?step= on setup', () => {
+      mockRoute.query = { step: '2' }
+      const { wiz } = setup(wizardForm(), { has_processors: true })
+      expect(wiz.currentStep.value).toBe(2)
+    })
+
+    it('clamps an out-of-range ?step= to the first step', () => {
+      mockRoute.query = { step: '99' }
+      const { wiz } = setup(wizardForm(), { has_processors: true })
+      expect(wiz.currentStep.value).toBe(2) // clamped to last visible index (3 steps)
+    })
+
+    it('clamps a non-numeric ?step= to 0', () => {
+      mockRoute.query = { step: 'abc' }
+      const { wiz } = setup(wizardForm(), { has_processors: true })
+      expect(wiz.currentStep.value).toBe(0)
+    })
+
+    it('next/back move and write ?step= via router.replace', () => {
+      const { wiz } = setup(wizardForm(), { has_processors: true })
+      expect(wiz.isFirstStep.value).toBe(true)
+      wiz.next()
+      expect(wiz.currentStep.value).toBe(1)
+      expect(mockRoute.query.step).toBe('1')
+      wiz.back()
+      expect(wiz.currentStep.value).toBe(0)
+      expect(mockRoute.query.step).toBe('0')
+    })
+
+    it('next does not advance past the last step', () => {
+      mockRoute.query = { step: '2' }
+      const { wiz } = setup(wizardForm(), { has_processors: true })
+      expect(wiz.isLastStep.value).toBe(true)
+      wiz.next()
+      expect(wiz.currentStep.value).toBe(2)
+    })
+
+    it('clamps currentStep when the visible set shrinks under it', async () => {
+      const { wiz, formData } = setup(wizardForm(), { has_processors: true })
+      wiz.goTo(2) // Publish (index 2 of 3)
+      expect(wiz.currentStep.value).toBe(2)
+      // Hide the Processor step -> only 2 steps remain; index 2 is out of range.
+      formData.value = { has_processors: false }
+      await nextTick()
+      expect(wiz.currentStep.value).toBe(1)
+    })
+  })
+
+  it('treats a malformed condition as always-false + warns', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const cfg: FormConfig = {
+      entity: 'x',
+      steps: [
+        { title: 'A', fields: [{ property: 'a' }] },
+        { title: 'B', visible_when: 'form.x ==', fields: [{ property: 'b' }] }, // parse error
+      ],
+    }
+    const { wiz } = setup(cfg, {})
+    expect(wiz.visibleSteps.value.map((s) => s.title)).toEqual(['A'])
+    expect(warn).toHaveBeenCalled()
+    warn.mockRestore()
+  })
+})

--- a/frontend/src/composables/useFormWizard.test.ts
+++ b/frontend/src/composables/useFormWizard.test.ts
@@ -98,6 +98,18 @@ describe('useFormWizard', () => {
     expect([...wiz.managedProperties.value].sort()).toEqual(['name', 'processor_name', 'published'])
   })
 
+  it('visibleStepIndexForProperty maps a property to its visible step', () => {
+    const { wiz, formData } = setup(wizardForm(), { has_processors: true })
+    expect(wiz.visibleStepIndexForProperty('name')).toBe(0)
+    expect(wiz.visibleStepIndexForProperty('processor_name')).toBe(1)
+    expect(wiz.visibleStepIndexForProperty('published')).toBe(2)
+    expect(wiz.visibleStepIndexForProperty('nope')).toBe(-1)
+    // When the processor step is hidden, its field maps to no visible step.
+    formData.value = { has_processors: false }
+    expect(wiz.visibleStepIndexForProperty('processor_name')).toBe(-1)
+    expect(wiz.visibleStepIndexForProperty('published')).toBe(1) // shifted up
+  })
+
   it('visibleFieldsOf honors per-field visible_when', () => {
     const cfg: FormConfig = {
       entity: 'x',

--- a/frontend/src/composables/useFormWizard.test.ts
+++ b/frontend/src/composables/useFormWizard.test.ts
@@ -92,6 +92,12 @@ describe('useFormWizard', () => {
     expect([...wiz.activeProperties.value].sort()).toEqual(['name', 'processor_name', 'published'])
   })
 
+  it('managedProperties covers every step field regardless of visibility', () => {
+    // Independent of current form values — includes the hidden branch's field.
+    const { wiz } = setup(wizardForm(), { has_processors: false })
+    expect([...wiz.managedProperties.value].sort()).toEqual(['name', 'processor_name', 'published'])
+  })
+
   it('visibleFieldsOf honors per-field visible_when', () => {
     const cfg: FormConfig = {
       entity: 'x',

--- a/frontend/src/composables/useFormWizard.test.ts
+++ b/frontend/src/composables/useFormWizard.test.ts
@@ -115,6 +115,26 @@ describe('useFormWizard', () => {
     expect([...wiz.managedProperties.value].sort()).toEqual(['name', 'processor_name', 'published'])
   })
 
+  it('active/managedRelations track relations under conditional branches', () => {
+    const cfg: FormConfig = {
+      entity: 'x',
+      steps: [
+        { title: 'A', relations: [{ relation: 'always_rel' }] },
+        {
+          title: 'B',
+          visible_when: 'form.show == true',
+          relations: [{ relation: 'cond_rel' }],
+        },
+      ],
+    }
+    const { wiz, formData } = setup(cfg, { show: false })
+    // managed = every relation named; active = only under a visible step.
+    expect([...wiz.managedRelations.value].sort()).toEqual(['always_rel', 'cond_rel'])
+    expect([...wiz.activeRelations.value].sort()).toEqual(['always_rel'])
+    formData.value = { show: true }
+    expect([...wiz.activeRelations.value].sort()).toEqual(['always_rel', 'cond_rel'])
+  })
+
   it('visibleStepIndexForProperty maps a property to its visible step', () => {
     const { wiz, formData } = setup(wizardForm(), { has_processors: true })
     expect(wiz.visibleStepIndexForProperty('name')).toBe(0)
@@ -150,6 +170,18 @@ describe('useFormWizard', () => {
     it('seeds currentStep from ?step= on setup', () => {
       mockRoute.query = { step: '2' }
       const { wiz } = setup(wizardForm(), { has_processors: true })
+      expect(wiz.currentStep.value).toBe(2)
+    })
+
+    it('seedFromUrl re-seeds after loaded data reveals an earlier step (RR-TXMU6)', () => {
+      // Deep link ?step=2. At construction `has_processors` is absent, so the
+      // conditional Processor step is hidden -> visibleSteps has 2 -> clamp(2)=1.
+      mockRoute.query = { step: '2' }
+      const { wiz, formData } = setup(wizardForm(), {})
+      expect(wiz.currentStep.value).toBe(1) // clamped against the 2 visible steps
+      // Loaded/toggled data reveals the earlier step; a re-seed lands on 2.
+      formData.value = { has_processors: true }
+      wiz.seedFromUrl()
       expect(wiz.currentStep.value).toBe(2)
     })
 

--- a/frontend/src/composables/useFormWizard.test.ts
+++ b/frontend/src/composables/useFormWizard.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { computed, reactive, ref, nextTick, effectScope, type EffectScope } from 'vue'
+import { reactive, ref, nextTick, effectScope, type EffectScope } from 'vue'
 import type { LocationQuery } from 'vue-router'
 import { useFormWizard } from './useFormWizard'
 import type { Bindings } from '@/utils/conditions'
@@ -46,12 +46,12 @@ describe('useFormWizard', () => {
   function setup(cfg: FormConfig | undefined, form: Record<string, unknown> = {}) {
     const config = ref(cfg)
     const formData = ref(form)
-    const bindings = computed<Bindings>(() => ({
+    const getBindings = (): Bindings => ({
       form: formData.value,
       entity: {},
       current_user: {},
-    }))
-    const wiz = scope.run(() => useFormWizard(config, bindings))!
+    })
+    const wiz = scope.run(() => useFormWizard(config, getBindings))!
     return { wiz, formData, config }
   }
 

--- a/frontend/src/composables/useFormWizard.test.ts
+++ b/frontend/src/composables/useFormWizard.test.ts
@@ -55,10 +55,27 @@ describe('useFormWizard', () => {
     return { wiz, formData, config }
   }
 
-  it('detects a wizard vs a single-page form', () => {
-    expect(setup(wizardForm()).wiz.isWizard.value).toBe(true)
-    expect(setup({ entity: 'x', fields: [{ property: 'a' }] }).wiz.isWizard.value).toBe(false)
-    expect(setup(undefined).wiz.isWizard.value).toBe(false)
+  it('isMultiStep is true only for >1 authored step', () => {
+    expect(setup(wizardForm()).wiz.isMultiStep.value).toBe(true) // 3 steps
+    // A flat form (one implicit step) and a one-step form are NOT multi-step.
+    expect(setup({ entity: 'x', fields: [{ property: 'a' }] }).wiz.isMultiStep.value).toBe(false)
+    expect(
+      setup({ entity: 'x', steps: [{ title: 'Only', fields: [{ property: 'a' }] }] }).wiz
+        .isMultiStep.value
+    ).toBe(false)
+    expect(setup(undefined).wiz.isMultiStep.value).toBe(false)
+  })
+
+  it('a flat form is modelled as one visible step', () => {
+    const { wiz } = setup({
+      entity: 'x',
+      fields: [{ property: 'a' }, { property: 'b' }],
+      relations: [{ relation: 'r' }],
+    })
+    expect(wiz.visibleSteps.value.length).toBe(1)
+    expect(
+      wiz.visibleFieldsOf(wiz.visibleSteps.value[0]).map((f) => f.property || f.relation)
+    ).toEqual(['a', 'b', 'r'])
   })
 
   it('filters visible steps by visible_when against form values', () => {

--- a/frontend/src/composables/useFormWizard.ts
+++ b/frontend/src/composables/useFormWizard.ts
@@ -53,6 +53,8 @@ export interface FormWizard {
   isLastStep: ComputedRef<boolean>
   /** Visible fields of a given step (honors per-field `visible_when`). */
   visibleFieldsOf: (step: FormStep) => FormFieldOrRelation[]
+  /** Visible-step index showing a field for `property`, or -1. */
+  visibleStepIndexForProperty: (property: string) => number
   /** True if the field is required now (authored `required` OR `required_when`). */
   isFieldRequired: (field: FormFieldOrRelation) => boolean
   /** Property keys under all currently-visible steps (for payload pruning). */
@@ -102,6 +104,15 @@ export function useFormWizard(
 
   function visibleFieldsOf(step: FormStep): FormFieldOrRelation[] {
     return stepFields(step).filter((f) => evalCond(f.visible_when))
+  }
+
+  // The visible-step index that currently shows a field for `property`, or -1.
+  // Used to map a validation error (keyed by property) back to the step the
+  // user must visit to fix it.
+  function visibleStepIndexForProperty(property: string): number {
+    return visibleSteps.value.findIndex((step) =>
+      visibleFieldsOf(step).some((f) => f.property === property)
+    )
   }
 
   function isFieldRequired(field: FormFieldOrRelation): boolean {
@@ -199,6 +210,7 @@ export function useFormWizard(
     isFirstStep,
     isLastStep,
     visibleFieldsOf,
+    visibleStepIndexForProperty,
     isFieldRequired,
     activeProperties,
     managedProperties,

--- a/frontend/src/composables/useFormWizard.ts
+++ b/frontend/src/composables/useFormWizard.ts
@@ -57,6 +57,8 @@ export interface FormWizard {
   isFieldRequired: (field: FormFieldOrRelation) => boolean
   /** Property keys under all currently-visible steps (for payload pruning). */
   activeProperties: ComputedRef<Set<string>>
+  /** Property keys named by ANY step/field, regardless of visibility. */
+  managedProperties: ComputedRef<Set<string>>
   next: () => void
   back: () => void
   goTo: (index: number) => void
@@ -112,6 +114,21 @@ export function useFormWizard(
     const keys = new Set<string>()
     for (const step of visibleSteps.value) {
       for (const f of visibleFieldsOf(step)) {
+        if (f.property) keys.add(f.property)
+      }
+    }
+    return keys
+  })
+
+  // Every property named by ANY step/field, regardless of current visibility.
+  // A property NOT in this set is not governed by the wizard's conditional
+  // structure (e.g. a metamodel default seeded into form state but surfaced in
+  // no step), so payload pruning must leave it alone — matching how a
+  // single-page form submits such a value.
+  const managedProperties = computed<Set<string>>(() => {
+    const keys = new Set<string>()
+    for (const step of formConfig.value?.steps ?? []) {
+      for (const f of stepFields(step)) {
         if (f.property) keys.add(f.property)
       }
     }
@@ -184,6 +201,7 @@ export function useFormWizard(
     visibleFieldsOf,
     isFieldRequired,
     activeProperties,
+    managedProperties,
     next,
     back,
     goTo,

--- a/frontend/src/composables/useFormWizard.ts
+++ b/frontend/src/composables/useFormWizard.ts
@@ -43,7 +43,9 @@ function stepFields(step: FormStep): FormFieldOrRelation[] {
 }
 
 export interface FormWizard {
-  isWizard: ComputedRef<boolean>
+  /** True when the form has more than one authored step — gates the stepper
+   *  bar and `?step=` URL sync. A flat form (one implicit step) is false. */
+  isMultiStep: ComputedRef<boolean>
   /** Steps whose `visible_when` currently holds, in authored order. */
   visibleSteps: ComputedRef<FormStep[]>
   /** Clamped index into visibleSteps. */
@@ -78,7 +80,20 @@ export function useFormWizard(
   const route = useRoute()
   const router = useRouter()
 
-  const isWizard = computed(() => (formConfig.value?.steps?.length ?? 0) > 0)
+  // Every form is modelled as a list of steps. A single-page (flat) form is a
+  // form with exactly one implicit, title-less step synthesised from its
+  // top-level fields/relations — so ONE render/validate/condition path serves
+  // both, and `visible_when`/`required_when` work everywhere. `isMultiStep`
+  // (not the mere presence of `steps`) is what gates wizard *presentation* (the
+  // stepper bar, `?step=` URL sync).
+  const normalizedSteps = computed<FormStep[]>(() => {
+    const cfg = formConfig.value
+    if (!cfg) return []
+    if (cfg.steps?.length) return cfg.steps
+    return [{ title: '', fields: cfg.fields ?? [], relations: cfg.relations ?? [] }]
+  })
+
+  const isMultiStep = computed(() => (formConfig.value?.steps?.length ?? 0) > 1)
 
   // Evaluate a condition against the live bindings. The engine memoizes the
   // compiled program by source, so re-evaluating each render is cheap. An
@@ -90,11 +105,9 @@ export function useFormWizard(
     return prog.eval(getBindings())
   }
 
-  const visibleSteps = computed<FormStep[]>(() => {
-    const steps = formConfig.value?.steps
-    if (!steps?.length) return []
-    return steps.filter((s) => evalCond(s.visible_when))
-  })
+  const visibleSteps = computed<FormStep[]>(() =>
+    normalizedSteps.value.filter((s) => evalCond(s.visible_when))
+  )
 
   const currentStep = ref(0)
 
@@ -138,7 +151,7 @@ export function useFormWizard(
   // single-page form submits such a value.
   const managedProperties = computed<Set<string>>(() => {
     const keys = new Set<string>()
-    for (const step of formConfig.value?.steps ?? []) {
+    for (const step of normalizedSteps.value) {
       for (const f of stepFields(step)) {
         if (f.property) keys.add(f.property)
       }
@@ -155,7 +168,9 @@ export function useFormWizard(
   }
 
   // Seed synchronously from the URL so a refresh/deep-link lands on the step.
-  if (isWizard.value) {
+  // Only multi-step forms use the `?step=` param — a single-step (flat) form
+  // never touches the URL.
+  if (isMultiStep.value) {
     const raw = route.query.step
     const parsed = typeof raw === 'string' ? parseInt(raw, 10) : NaN
     currentStep.value = clamp(parsed)
@@ -163,6 +178,7 @@ export function useFormWizard(
 
   let lastWritten = ''
   function writeStep(i: number): void {
+    if (!isMultiStep.value) return // single-step forms never touch the URL
     const value = String(i)
     lastWritten = value
     const query = { ...route.query, step: value }
@@ -203,7 +219,7 @@ export function useFormWizard(
   }
 
   return {
-    isWizard,
+    isMultiStep,
     visibleSteps,
     currentStep,
     currentStepDef,

--- a/frontend/src/composables/useFormWizard.ts
+++ b/frontend/src/composables/useFormWizard.ts
@@ -63,9 +63,16 @@ export interface FormWizard {
   activeProperties: ComputedRef<Set<string>>
   /** Property keys named by ANY step/field, regardless of visibility. */
   managedProperties: ComputedRef<Set<string>>
+  /** Relation names under all currently-visible steps. */
+  activeRelations: ComputedRef<Set<string>>
+  /** Relation names named by ANY step/field, regardless of visibility. */
+  managedRelations: ComputedRef<Set<string>>
   next: () => void
   back: () => void
   goTo: (index: number) => void
+  /** Re-seed currentStep from `?step=`. Call after entity/defaults load so a
+   *  step revealed by loaded data can still be the deep-link target. */
+  seedFromUrl: () => void
 }
 
 export function useFormWizard(
@@ -134,30 +141,43 @@ export function useFormWizard(
     return false
   }
 
-  const activeProperties = computed<Set<string>>(() => {
+  // Keys (property names OR relation names) currently VISIBLE — under a
+  // visible step, honouring per-field visible_when.
+  function activeKeys(pick: (f: FormFieldOrRelation) => string | undefined): Set<string> {
     const keys = new Set<string>()
     for (const step of visibleSteps.value) {
       for (const f of visibleFieldsOf(step)) {
-        if (f.property) keys.add(f.property)
+        const k = pick(f)
+        if (k) keys.add(k)
       }
     }
     return keys
-  })
+  }
 
-  // Every property named by ANY step/field, regardless of current visibility.
-  // A property NOT in this set is not governed by the wizard's conditional
-  // structure (e.g. a metamodel default seeded into form state but surfaced in
-  // no step), so payload pruning must leave it alone — matching how a
-  // single-page form submits such a value.
-  const managedProperties = computed<Set<string>>(() => {
+  // Keys named by ANY step/field, regardless of current visibility. A key NOT
+  // in this set is not governed by the wizard's conditional structure (e.g. a
+  // metamodel default seeded into form state but surfaced in no step), so
+  // pruning must leave it alone — matching how a single-page form submits it.
+  function managedKeys(pick: (f: FormFieldOrRelation) => string | undefined): Set<string> {
     const keys = new Set<string>()
     for (const step of normalizedSteps.value) {
       for (const f of stepFields(step)) {
-        if (f.property) keys.add(f.property)
+        const k = pick(f)
+        if (k) keys.add(k)
       }
     }
     return keys
-  })
+  }
+
+  const asProperty = (f: FormFieldOrRelation) => f.property
+  const asRelation = (f: FormFieldOrRelation) => f.relation
+
+  const activeProperties = computed(() => activeKeys(asProperty))
+  const managedProperties = computed(() => managedKeys(asProperty))
+  // Relations get the same treatment so a relation under a hidden branch is
+  // pruned from the submitted payload, not just hidden from render.
+  const activeRelations = computed(() => activeKeys(asRelation))
+  const managedRelations = computed(() => managedKeys(asRelation))
 
   // --- URL sync (`?step=N`), mirroring useUrlFilterSync's seed/replace/echo. ---
 
@@ -167,14 +187,20 @@ export function useFormWizard(
     return Math.min(i, Math.max(0, max))
   }
 
-  // Seed synchronously from the URL so a refresh/deep-link lands on the step.
-  // Only multi-step forms use the `?step=` param — a single-step (flat) form
-  // never touches the URL.
-  if (isMultiStep.value) {
+  // Seed currentStep from the `?step=` param. Only multi-step forms use the
+  // param — a single-step (flat) form never touches the URL. Runs once
+  // synchronously (so the first paint is right for data already present), and
+  // the caller re-runs it after the entity/defaults load (seedFromUrl), because
+  // an earlier step may only become visible once loaded data satisfies its
+  // `visible_when` — and clamp against a smaller visibleSteps would otherwise
+  // strand the user on the wrong step.
+  function seedFromUrl(): void {
+    if (!isMultiStep.value) return
     const raw = route.query.step
     const parsed = typeof raw === 'string' ? parseInt(raw, 10) : NaN
     currentStep.value = clamp(parsed)
   }
+  seedFromUrl()
 
   let lastWritten = ''
   function writeStep(i: number): void {
@@ -230,8 +256,11 @@ export function useFormWizard(
     isFieldRequired,
     activeProperties,
     managedProperties,
+    activeRelations,
+    managedRelations,
     next,
     back,
     goTo,
+    seedFromUrl,
   }
 }

--- a/frontend/src/composables/useFormWizard.ts
+++ b/frontend/src/composables/useFormWizard.ts
@@ -64,7 +64,12 @@ export interface FormWizard {
 
 export function useFormWizard(
   formConfig: Ref<FormConfig | undefined> | ComputedRef<FormConfig | undefined>,
-  bindings: ComputedRef<Bindings>
+  // A getter, not a computed: it is invoked inside each derived computed so the
+  // reactive reads of the underlying form values happen in that computed's
+  // tracking scope. A cached computed would return a stable object whose
+  // property reads are not re-tracked, so visibility would never update as the
+  // user types (the `form.done == true` reveal would go stale).
+  getBindings: () => Bindings
 ): FormWizard {
   const route = useRoute()
   const router = useRouter()
@@ -78,7 +83,7 @@ export function useFormWizard(
   const evalCond = (expr: string | undefined): boolean => {
     const prog = compileCond(expr)
     if (!prog) return !expr || expr.trim() === ''
-    return prog.eval(bindings.value)
+    return prog.eval(getBindings())
   }
 
   const visibleSteps = computed<FormStep[]>(() => {

--- a/frontend/src/composables/useFormWizard.ts
+++ b/frontend/src/composables/useFormWizard.ts
@@ -1,0 +1,186 @@
+import { computed, ref, watch, type Ref, type ComputedRef } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import { parse, type Program, type Bindings } from '@/utils/conditions'
+import type { FormConfig, FormFieldOrRelation, FormStep } from '@/types'
+
+/**
+ * useFormWizard — the multi-step (wizard) layer for DynamicForm.
+ *
+ * A form config is a wizard when it declares `steps`. This composable owns the
+ * wizard's derived state so DynamicForm stays a single-page renderer with a
+ * thin wizard branch:
+ *
+ * - which steps are visible (each step's `visible_when` evaluated against the
+ *   live form values),
+ * - which fields inside the current step are visible (`visible_when`),
+ * - the current step index, kept in the `?step=N` URL query (refresh/deep-link
+ *   safe, `router.replace` so next/back don't spam history),
+ * - `isFieldRequired` (authored `required` OR `required_when` true),
+ * - `activeProperties` — the property keys under currently-visible steps, so
+ *   the caller can drop hidden-branch values from the submitted payload.
+ *
+ * Conditions are evaluated with the shared engine (`utils/conditions`). A
+ * malformed condition is a config bug: `compileCond` catches the parse throw,
+ * warns once, and treats it as "always false" so a broken `visible_when` hides
+ * its target rather than crashing the form. Runtime eval never throws.
+ */
+
+/** Compile a condition once, tolerating a malformed expression (config bug). */
+function compileCond(expr: string | undefined): Program | null {
+  if (!expr || expr.trim() === '') return null
+  try {
+    return parse(expr)
+  } catch (err) {
+    console.warn(`[wizard] ignoring invalid condition ${JSON.stringify(expr)}:`, err)
+    return null
+  }
+}
+
+function stepFields(step: FormStep): FormFieldOrRelation[] {
+  const fields = (step.fields || []) as FormFieldOrRelation[]
+  const relations = (step.relations || []) as FormFieldOrRelation[]
+  return [...fields, ...relations]
+}
+
+export interface FormWizard {
+  isWizard: ComputedRef<boolean>
+  /** Steps whose `visible_when` currently holds, in authored order. */
+  visibleSteps: ComputedRef<FormStep[]>
+  /** Clamped index into visibleSteps. */
+  currentStep: Ref<number>
+  currentStepDef: ComputedRef<FormStep | undefined>
+  isFirstStep: ComputedRef<boolean>
+  isLastStep: ComputedRef<boolean>
+  /** Visible fields of a given step (honors per-field `visible_when`). */
+  visibleFieldsOf: (step: FormStep) => FormFieldOrRelation[]
+  /** True if the field is required now (authored `required` OR `required_when`). */
+  isFieldRequired: (field: FormFieldOrRelation) => boolean
+  /** Property keys under all currently-visible steps (for payload pruning). */
+  activeProperties: ComputedRef<Set<string>>
+  next: () => void
+  back: () => void
+  goTo: (index: number) => void
+}
+
+export function useFormWizard(
+  formConfig: Ref<FormConfig | undefined> | ComputedRef<FormConfig | undefined>,
+  bindings: ComputedRef<Bindings>
+): FormWizard {
+  const route = useRoute()
+  const router = useRouter()
+
+  const isWizard = computed(() => (formConfig.value?.steps?.length ?? 0) > 0)
+
+  // Evaluate a condition against the live bindings. The engine memoizes the
+  // compiled program by source, so re-evaluating each render is cheap. An
+  // absent/empty condition means "no condition" → true; a present-but-malformed
+  // one was already warned about in compileCond and reads as false.
+  const evalCond = (expr: string | undefined): boolean => {
+    const prog = compileCond(expr)
+    if (!prog) return !expr || expr.trim() === ''
+    return prog.eval(bindings.value)
+  }
+
+  const visibleSteps = computed<FormStep[]>(() => {
+    const steps = formConfig.value?.steps
+    if (!steps?.length) return []
+    return steps.filter((s) => evalCond(s.visible_when))
+  })
+
+  const currentStep = ref(0)
+
+  const currentStepDef = computed<FormStep | undefined>(() => visibleSteps.value[currentStep.value])
+  const isFirstStep = computed(() => currentStep.value <= 0)
+  const isLastStep = computed(() => currentStep.value >= visibleSteps.value.length - 1)
+
+  function visibleFieldsOf(step: FormStep): FormFieldOrRelation[] {
+    return stepFields(step).filter((f) => evalCond(f.visible_when))
+  }
+
+  function isFieldRequired(field: FormFieldOrRelation): boolean {
+    if (field.required) return true
+    if (field.required_when) return evalCond(field.required_when)
+    return false
+  }
+
+  const activeProperties = computed<Set<string>>(() => {
+    const keys = new Set<string>()
+    for (const step of visibleSteps.value) {
+      for (const f of visibleFieldsOf(step)) {
+        if (f.property) keys.add(f.property)
+      }
+    }
+    return keys
+  })
+
+  // --- URL sync (`?step=N`), mirroring useUrlFilterSync's seed/replace/echo. ---
+
+  function clamp(i: number): number {
+    const max = visibleSteps.value.length - 1
+    if (!Number.isFinite(i) || i < 0) return 0
+    return Math.min(i, Math.max(0, max))
+  }
+
+  // Seed synchronously from the URL so a refresh/deep-link lands on the step.
+  if (isWizard.value) {
+    const raw = route.query.step
+    const parsed = typeof raw === 'string' ? parseInt(raw, 10) : NaN
+    currentStep.value = clamp(parsed)
+  }
+
+  let lastWritten = ''
+  function writeStep(i: number): void {
+    const value = String(i)
+    lastWritten = value
+    const query = { ...route.query, step: value }
+    router.replace({ query })
+  }
+
+  // External navigation (back/forward, deep link) restores the step; our own
+  // writes are ignored via the echo guard.
+  watch(
+    () => route.query.step,
+    (raw) => {
+      const incoming = typeof raw === 'string' ? raw : ''
+      if (incoming === lastWritten) return
+      const parsed = incoming ? parseInt(incoming, 10) : 0
+      currentStep.value = clamp(parsed)
+    }
+  )
+
+  // If the visible-step set shrinks under the current index (an earlier answer
+  // hid a later step), clamp back into range.
+  watch(visibleSteps, () => {
+    const clamped = clamp(currentStep.value)
+    if (clamped !== currentStep.value) currentStep.value = clamped
+  })
+
+  function goTo(index: number): void {
+    const i = clamp(index)
+    currentStep.value = i
+    writeStep(i)
+  }
+
+  function next(): void {
+    if (!isLastStep.value) goTo(currentStep.value + 1)
+  }
+
+  function back(): void {
+    if (!isFirstStep.value) goTo(currentStep.value - 1)
+  }
+
+  return {
+    isWizard,
+    visibleSteps,
+    currentStep,
+    currentStepDef,
+    isFirstStep,
+    isLastStep,
+    visibleFieldsOf,
+    isFieldRequired,
+    activeProperties,
+    next,
+    back,
+    goTo,
+  }
+}

--- a/frontend/src/types/config.ts
+++ b/frontend/src/types/config.ts
@@ -58,15 +58,23 @@ export interface FormConfig {
   description?: string
   mode?: 'edit' | string
   body?: boolean
-  sections?: FormSection[]
+  /**
+   * Wizard layout. Mutually exclusive with fields/relations (the server
+   * rejects both). When present the form renders one step at a time with
+   * next/back navigation instead of a single page.
+   */
+  steps?: FormStep[]
   fields?: FormField[]
   relations?: FormRelation[]
 }
 
-export interface FormSection {
-  title?: string
+export interface FormStep {
+  title: string
   description?: string
-  fields: FormFieldOrRelation[]
+  /** Condition expression; the step is hidden/skipped when it evaluates false. */
+  visible_when?: string
+  fields?: FormFieldOrRelation[]
+  relations?: FormFieldOrRelation[]
 }
 
 export interface FormField {
@@ -78,6 +86,10 @@ export interface FormField {
   default?: unknown
   readonly?: boolean
   hidden?: boolean
+  /** Condition expression; the field is hidden when it evaluates false. */
+  visible_when?: string
+  /** Condition expression; the field is required only when it evaluates true. */
+  required_when?: string
 }
 
 export interface RelationProperty {
@@ -96,6 +108,8 @@ export interface FormRelation {
   allow_create?: boolean
   create_form?: string
   properties?: RelationProperty[]
+  /** Condition expression; the relation widget is hidden when it evaluates false. */
+  visible_when?: string
 }
 
 // Unified type for form fields that can be either property fields or relation fields
@@ -119,6 +133,9 @@ export interface FormFieldOrRelation {
   // Common props
   label?: string
   widget?: string
+  // Wizard conditions (see FormField / FormRelation)
+  visible_when?: string
+  required_when?: string
 }
 
 export interface ListConfig {

--- a/frontend/src/utils/conditions.ts
+++ b/frontend/src/utils/conditions.ts
@@ -500,8 +500,15 @@ function resolveRef(ns: string, field: string, bindings: Bindings): Value {
   if (FORBIDDEN_KEYS.has(field)) throw new EvalFail(`forbidden field: ${field}`)
   const scope = bindings[ns]
   if (scope == null || typeof scope !== 'object') return NIL
-  if (!Object.prototype.hasOwnProperty.call(scope, field)) return NIL
+  // Read the property BEFORE the own-property check. When `scope` is a Vue
+  // reactive object, the read is what registers the dependency — including for
+  // a key that is currently absent (undefined). Checking hasOwnProperty first
+  // would short-circuit without ever reading, so a condition that references a
+  // not-yet-set field would never re-evaluate when that field is later set.
   const raw = (scope as Record<string, unknown>)[field]
+  // Own-property only: an inherited value (e.g. from a poisoned prototype) is
+  // treated as absent, preserving the prototype-pollution guarantee.
+  if (!Object.prototype.hasOwnProperty.call(scope, field)) return NIL
   return normalizeValue(raw)
 }
 

--- a/internal/cli/cli_wiring.go
+++ b/internal/cli/cli_wiring.go
@@ -34,12 +34,14 @@ import (
 // interfaces enforced; the consumer of *cliServices is each kong
 // command's Run method.
 //
-// TODO(TKT-N0IKN9): 29 exported methods, over the 20 exported-method line.
+// TODO(TKT-N0IKN9): 30 exported methods, over the 20 exported-method line.
 // This is the CLI service bundle each command binds to; the count tracks the
 // breadth of the CLI surface. Ratchet candidate — purpose-grouped sub-bundles
 // (read / write / analyze) would let each command bind only what it uses.
+// (Grew to 30 with the version-purge methods in #1142; the directive was not
+// bumped there, so it's raised here to match — decomposition stays TKT-N0IKN9.)
 //
-//plimsoll:max-exported-methods=29
+//plimsoll:max-exported-methods=30
 type cliServices struct {
 	svc        *appbuild.Services
 	attachment *attachment.Service

--- a/internal/conditionlint/conditionlint.go
+++ b/internal/conditionlint/conditionlint.go
@@ -1,0 +1,122 @@
+// Package conditionlint performs author-time validation of the condition
+// expressions used by wizard forms (`visible_when` / `required_when`).
+//
+// The expressions are evaluated at runtime by the SPA's own (permissive)
+// TypeScript engine. This package can't run that engine, but the grammar is
+// deliberately kept congruent with the Go `internal/predicate` engine, so we
+// reuse predicate's parser + type checker as an author-time sanity check.
+//
+// Two caveats, documented for callers:
+//
+//   - Predicate is STRICTER than the runtime engine (strict Lua-style typing;
+//     cross-type comparisons are compile errors, where the runtime coerces).
+//     So this lint flags a SUPERSET of real problems: every error it reports is
+//     worth an author's attention, but a condition it rejects on type grounds
+//     might still evaluate fine at runtime. It is a sanity check, not a 1:1
+//     mirror.
+//   - It only knows the `form` namespace (declared from the entity's
+//     properties). References to `entity.*` / `current_user.*` are not used by
+//     wizard forms today and are not checked here.
+//
+// The high-value checks that DO hold exactly: an expression that fails to parse
+// is a real bug, and a `form.<field>` reference to a property that doesn't
+// exist on the entity is a real bug. Those are what authors most often get
+// wrong, and this catches them before the form silently misbehaves.
+package conditionlint
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/Sourcehaven-BV/rela/internal/dataentryconfig"
+	"github.com/Sourcehaven-BV/rela/internal/metamodel"
+	"github.com/Sourcehaven-BV/rela/internal/predicate"
+)
+
+// Lint returns one message per invalid condition found across all forms in cfg.
+// The messages are sorted for deterministic output. An empty slice means every
+// condition parsed and referenced only known fields.
+func Lint(cfg *dataentryconfig.Config, meta *metamodel.Metamodel) []string {
+	var errs []string
+	for formID, form := range cfg.Forms {
+		env, ok := formEnv(form.EntityType, meta)
+		if !ok {
+			// Unknown entity type is already reported by validateForms; skip
+			// condition checks we can't ground.
+			continue
+		}
+		lintForm(formID, form, env, &errs)
+	}
+	sort.Strings(errs)
+	return errs
+}
+
+// lintForm checks every condition attached to a form's steps and fields.
+func lintForm(formID string, form dataentryconfig.Form, env *predicate.Env, errs *[]string) {
+	for si, step := range form.Steps {
+		check(env, step.VisibleWhen, fmt.Sprintf("form %q: step[%d] visible_when", formID, si), errs)
+		for i, f := range step.Fields {
+			lintField(formID, fmt.Sprintf("step[%d] ", si), i, f, env, errs)
+		}
+		for i, r := range step.Relations {
+			check(env, r.VisibleWhen,
+				fmt.Sprintf("form %q: step[%d] relation[%d] visible_when", formID, si, i), errs)
+		}
+	}
+	// Flat forms may also carry conditions on fields/relations.
+	for i, f := range form.Fields {
+		lintField(formID, "", i, f, env, errs)
+	}
+	for i, r := range form.Relations {
+		check(env, r.VisibleWhen, fmt.Sprintf("form %q: relation[%d] visible_when", formID, i), errs)
+	}
+}
+
+func lintField(formID, ctx string, i int, f dataentryconfig.FormField, env *predicate.Env, errs *[]string) {
+	check(env, f.VisibleWhen, fmt.Sprintf("form %q: %sfield[%d] visible_when", formID, ctx, i), errs)
+	check(env, f.RequiredWhen, fmt.Sprintf("form %q: %sfield[%d] required_when", formID, ctx, i), errs)
+}
+
+// check compiles one expression (if non-empty) and records a message on failure.
+func check(env *predicate.Env, expr, where string, errs *[]string) {
+	if expr == "" {
+		return
+	}
+	if _, err := predicate.Compile(env, expr); err != nil {
+		*errs = append(*errs, fmt.Sprintf("%s: %v", where, err))
+	}
+}
+
+// formEnv builds a predicate Env whose `form` variable is a record of the
+// entity's properties, typed as closely as the metamodel allows. Returns false
+// if the entity type is unknown.
+func formEnv(entityType string, meta *metamodel.Metamodel) (*predicate.Env, bool) {
+	entDef, ok := meta.GetEntityDef(entityType)
+	if !ok {
+		return nil, false
+	}
+	fields := make(predicate.RecordType, len(entDef.Properties))
+	for name, def := range entDef.Properties {
+		fields[name] = predicateType(def)
+	}
+	env := predicate.NewEnv()
+	// DeclareVar only errors on empty name / nil type / redeclaration, none of
+	// which happen here (single declaration, non-nil type).
+	_ = env.DeclareVar("form", fields)
+	return env, true
+}
+
+// predicateType maps a metamodel property type to a predicate scalar type.
+// Booleans and integers map precisely; everything else (strings, enums, dates,
+// custom types) is treated as a string, which is how the runtime engine
+// compares them and keeps the lint from over-rejecting.
+func predicateType(def metamodel.PropertyDef) predicate.Type {
+	switch def.Type {
+	case "boolean":
+		return predicate.BoolType
+	case "integer":
+		return predicate.NumberType
+	default:
+		return predicate.StringType
+	}
+}

--- a/internal/conditionlint/conditionlint_test.go
+++ b/internal/conditionlint/conditionlint_test.go
@@ -1,0 +1,114 @@
+package conditionlint
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/Sourcehaven-BV/rela/internal/dataentryconfig"
+	"github.com/Sourcehaven-BV/rela/internal/metamodel"
+)
+
+func testMeta() *metamodel.Metamodel {
+	return &metamodel.Metamodel{
+		Entities: map[string]metamodel.EntityDef{
+			"ticket": {
+				Label: "Ticket",
+				Properties: map[string]metamodel.PropertyDef{
+					"title":          {Type: "string", Required: true},
+					"status":         {Type: "status"},
+					"has_processors": {Type: "boolean"},
+					"count":          {Type: "integer"},
+				},
+			},
+		},
+	}
+}
+
+func runLint(t *testing.T, form dataentryconfig.Form) []string {
+	t.Helper()
+	cfg := &dataentryconfig.Config{Forms: map[string]dataentryconfig.Form{"f": form}}
+	return Lint(cfg, testMeta())
+}
+
+func TestLint_ValidConditions(t *testing.T) {
+	errs := runLint(t, dataentryconfig.Form{
+		EntityType: "ticket",
+		Steps: []dataentryconfig.FormStep{
+			{Title: "A", Fields: []dataentryconfig.FormField{{Property: "title"}}},
+			{
+				Title:       "B",
+				VisibleWhen: "form.has_processors == true",
+				Fields: []dataentryconfig.FormField{
+					{Property: "status", RequiredWhen: "form.has_processors == true"},
+				},
+			},
+		},
+	})
+	if len(errs) != 0 {
+		t.Fatalf("expected no lint errors, got: %v", errs)
+	}
+}
+
+func TestLint_ParseError(t *testing.T) {
+	errs := runLint(t, dataentryconfig.Form{
+		EntityType: "ticket",
+		Steps:      []dataentryconfig.FormStep{{Title: "A", VisibleWhen: "form.status =="}},
+	})
+	if len(errs) == 0 {
+		t.Fatal("expected a parse error for a malformed condition")
+	}
+	if !strings.Contains(errs[0], "step[0] visible_when") {
+		t.Errorf("expected step-scoped location, got: %v", errs)
+	}
+}
+
+func TestLint_UnknownFieldReference(t *testing.T) {
+	errs := runLint(t, dataentryconfig.Form{
+		EntityType: "ticket",
+		Steps: []dataentryconfig.FormStep{
+			{Title: "A", Fields: []dataentryconfig.FormField{
+				{Property: "title", RequiredWhen: "form.nonexistent == true"},
+			}},
+		},
+	})
+	if len(errs) == 0 {
+		t.Fatal("expected an error for referencing an unknown field")
+	}
+	if !strings.Contains(errs[0], "required_when") {
+		t.Errorf("expected required_when location, got: %v", errs)
+	}
+}
+
+func TestLint_FlatFormConditions(t *testing.T) {
+	errs := runLint(t, dataentryconfig.Form{
+		EntityType: "ticket",
+		Fields: []dataentryconfig.FormField{
+			{Property: "status", VisibleWhen: "form.bogus == 1"},
+		},
+	})
+	if len(errs) == 0 {
+		t.Fatal("expected an error for a flat-form condition referencing an unknown field")
+	}
+}
+
+func TestLint_UnknownEntityTypeSkipped(t *testing.T) {
+	// An unknown entity type is reported elsewhere; conditions can't be grounded
+	// so this package stays silent rather than emitting confusing errors.
+	errs := runLint(t, dataentryconfig.Form{
+		EntityType: "does-not-exist",
+		Steps:      []dataentryconfig.FormStep{{Title: "A", VisibleWhen: "form.x =="}},
+	})
+	if len(errs) != 0 {
+		t.Fatalf("expected no errors for unknown entity type, got: %v", errs)
+	}
+}
+
+func TestLint_EmptyConditionsIgnored(t *testing.T) {
+	errs := runLint(t, dataentryconfig.Form{
+		EntityType: "ticket",
+		Steps:      []dataentryconfig.FormStep{{Title: "A", Fields: []dataentryconfig.FormField{{Property: "title"}}}},
+	})
+	if len(errs) != 0 {
+		t.Fatalf("expected no errors when no conditions are set, got: %v", errs)
+	}
+}

--- a/internal/dataentry/api_v1.go
+++ b/internal/dataentry/api_v1.go
@@ -1869,26 +1869,42 @@ func (a *App) handleV1SchemaRoutes(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+// resolveRelationWidgets returns a copy of rels with any empty Widget set to
+// "cards" when the relation type has edge properties/content. Shared by the
+// flat and wizard-step relation lists in handleV1Config.
+func (a *App) resolveRelationWidgets(s *Schema, rels []dataentryconfig.FormRelation) []dataentryconfig.FormRelation {
+	resolved := make([]dataentryconfig.FormRelation, len(rels))
+	copy(resolved, rels)
+	for i := range resolved {
+		if resolved[i].Widget == "" {
+			if def, ok := s.Meta.GetRelationDef(resolved[i].Relation); ok && def.HasAdvancedFeatures() {
+				resolved[i].Widget = WidgetCards
+			}
+		}
+	}
+	return resolved
+}
+
 func (a *App) handleV1Config(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
 		writeV1Error(w, r, http.StatusMethodNotAllowed, "method_not_allowed", "Method not allowed", "")
 		return
 	}
 	s := a.State()
-	// Resolve relation widgets: auto-detect "cards" for relations with properties/content
+	// Resolve relation widgets: auto-detect "cards" for relations with
+	// properties/content, for both single-page (flat) and wizard (step) forms.
 	forms := make(map[string]dataentryconfig.Form, len(s.Cfg.Forms))
 	for id, form := range s.Cfg.Forms {
 		f := form
-		resolved := make([]dataentryconfig.FormRelation, len(f.Relations))
-		copy(resolved, f.Relations)
-		for i := range resolved {
-			if resolved[i].Widget == "" {
-				if def, ok := s.Meta.GetRelationDef(resolved[i].Relation); ok && def.HasAdvancedFeatures() {
-					resolved[i].Widget = WidgetCards
-				}
+		f.Relations = a.resolveRelationWidgets(s, f.Relations)
+		if len(f.Steps) > 0 {
+			steps := make([]dataentryconfig.FormStep, len(f.Steps))
+			copy(steps, f.Steps)
+			for i := range steps {
+				steps[i].Relations = a.resolveRelationWidgets(s, steps[i].Relations)
 			}
+			f.Steps = steps
 		}
-		f.Relations = resolved
 		forms[id] = f
 	}
 

--- a/internal/dataentryconfig/config.go
+++ b/internal/dataentryconfig/config.go
@@ -129,6 +129,11 @@ type AppConfig struct {
 }
 
 // Form defines a create/edit form for an entity type.
+//
+// A form is EITHER single-page (Fields/Relations at the top level) OR a wizard
+// (Steps). The two are mutually exclusive — validateForms rejects a form that
+// sets both. A wizard renders one step at a time with next/back navigation;
+// single-page remains the default and is unchanged when Steps is empty.
 type Form struct {
 	EntityType  string           `yaml:"entity_type" json:"entity"`
 	Title       string           `yaml:"title" json:"title"`
@@ -137,7 +142,20 @@ type Form struct {
 	Body        *bool            `yaml:"body,omitempty" json:"body,omitempty"`
 	Fields      []FormField      `yaml:"fields" json:"fields"`
 	Relations   []FormRelation   `yaml:"relations" json:"relations,omitempty"`
+	Steps       []FormStep       `yaml:"steps,omitempty" json:"steps,omitempty"`
 	SidePanel   *SidePanelConfig `yaml:"side_panel,omitempty" json:"side_panel,omitempty"`
+}
+
+// FormStep is one ordered, titled step of a wizard form. VisibleWhen is an
+// optional condition expression (see the frontend conditions engine) evaluated
+// against earlier field values; when it evaluates false the step is skipped in
+// navigation and its values are excluded from the submitted entity.
+type FormStep struct {
+	Title       string         `yaml:"title" json:"title"`
+	Description string         `yaml:"description,omitempty" json:"description,omitempty"`
+	VisibleWhen string         `yaml:"visible_when,omitempty" json:"visible_when,omitempty"`
+	Fields      []FormField    `yaml:"fields,omitempty" json:"fields,omitempty"`
+	Relations   []FormRelation `yaml:"relations,omitempty" json:"relations,omitempty"`
 }
 
 // SidePanelConfig defines an optional context panel shown alongside a form.
@@ -148,25 +166,37 @@ type SidePanelConfig struct {
 }
 
 // FormField defines a single field in a form.
+//
+// VisibleWhen / RequiredWhen are optional condition expressions (see the
+// frontend conditions engine) evaluated against earlier field values. They are
+// opaque strings to Go — the SPA parses and evaluates them; the `rela` config
+// lint checks them syntactically. VisibleWhen hides the field (and drops its
+// value from the payload) when false; RequiredWhen makes the field required
+// only when true.
 type FormField struct {
-	Property    string              `yaml:"property" json:"property"`
-	Label       string              `yaml:"label" json:"label,omitempty"`
-	Placeholder string              `yaml:"placeholder" json:"placeholder,omitempty"`
-	Help        string              `yaml:"help" json:"help,omitempty"`
-	Widget      string              `yaml:"widget" json:"widget,omitempty"`
-	Required    *bool               `yaml:"required,omitempty" json:"required,omitempty"`
-	Default     string              `yaml:"default" json:"default,omitempty"`
-	Hidden      bool                `yaml:"hidden" json:"hidden,omitempty"`
-	Transitions map[string][]string `yaml:"transitions,omitempty" json:"transitions,omitempty"`
+	Property     string              `yaml:"property" json:"property"`
+	Label        string              `yaml:"label" json:"label,omitempty"`
+	Placeholder  string              `yaml:"placeholder" json:"placeholder,omitempty"`
+	Help         string              `yaml:"help" json:"help,omitempty"`
+	Widget       string              `yaml:"widget" json:"widget,omitempty"`
+	Required     *bool               `yaml:"required,omitempty" json:"required,omitempty"`
+	RequiredWhen string              `yaml:"required_when,omitempty" json:"required_when,omitempty"`
+	VisibleWhen  string              `yaml:"visible_when,omitempty" json:"visible_when,omitempty"`
+	Default      string              `yaml:"default" json:"default,omitempty"`
+	Hidden       bool                `yaml:"hidden" json:"hidden,omitempty"`
+	Transitions  map[string][]string `yaml:"transitions,omitempty" json:"transitions,omitempty"`
 }
 
-// FormRelation defines a relation field in a form.
+// FormRelation defines a relation field in a form. VisibleWhen is an optional
+// condition expression (see FormField) that hides the relation widget when
+// false.
 type FormRelation struct {
 	Relation     string             `yaml:"relation" json:"relation"`
 	Direction    Direction          `yaml:"direction" json:"direction,omitempty"`
 	TargetType   string             `yaml:"target_type" json:"target_type,omitempty"`
 	Label        string             `yaml:"label" json:"label,omitempty"`
 	Required     bool               `yaml:"required" json:"required,omitempty"`
+	VisibleWhen  string             `yaml:"visible_when,omitempty" json:"visible_when,omitempty"`
 	Widget       string             `yaml:"widget" json:"widget,omitempty"`
 	Display      string             `yaml:"display" json:"display,omitempty"`
 	AllowCreate  bool               `yaml:"allow_create" json:"allow_create,omitempty"`

--- a/internal/dataentryconfig/validate.go
+++ b/internal/dataentryconfig/validate.go
@@ -218,8 +218,6 @@ func validateNavEntry(nav NavigationEntry, cfg *Config) []string {
 }
 
 // validateForms validates form definitions.
-//
-//nolint:gocognit // linear validation dispatcher: one independent config-vs-metamodel check per branch; splitting would scatter the rule set without lowering real complexity.
 func validateForms(cfg *Config, meta *metamodel.Metamodel) []string {
 	var errs []string
 
@@ -230,68 +228,105 @@ func validateForms(cfg *Config, meta *metamodel.Metamodel) []string {
 			continue
 		}
 
-		// Validate fields
-		for i, f := range form.Fields {
-			if _, ok := entDef.Properties[f.Property]; !ok {
-				errs = append(errs, fmt.Sprintf(
-					"form %q: field[%d] property %q not in metamodel for entity %q",
-					formID, i, f.Property, form.EntityType))
-			}
-
-			// Validate transitions (if specified, must be valid enum values)
-			if len(f.Transitions) > 0 {
-				propDef, hasProp := entDef.Properties[f.Property]
-				if hasProp {
-					errs = append(errs, validateTransitions(formID, i, f, propDef, meta)...)
-				}
-			}
+		// A form is single-page OR a wizard, never both.
+		hasFlat := len(form.Fields) > 0 || len(form.Relations) > 0
+		if len(form.Steps) > 0 && hasFlat {
+			errs = append(errs, fmt.Sprintf(
+				"form %q: a form may define either top-level fields/relations OR steps, not both",
+				formID))
 		}
 
-		// Validate relations
+		// Flat (single-page) fields/relations.
+		for i, f := range form.Fields {
+			errs = append(errs, validateFormField(formID, "", i, f, form.EntityType, entDef, meta)...)
+		}
 		for i, r := range form.Relations {
-			relDef, ok := meta.GetRelationDef(r.Relation)
-			switch {
-			case ok:
-				// Canonical name resolved — check that the form's entity
-				// type is on the correct side of the edge for the chosen
-				// direction. Wrong-side configs are silently broken
-				// otherwise: the widget searches the wrong target type
-				// and never shows existing edges.
-				errs = append(errs, validateFormRelationSide(formID, i, form.EntityType, r, relDef)...)
-			default:
-				if canonical, isInverse := meta.InverseOwner(r.Relation); isInverse {
-					errs = append(errs, fmt.Sprintf(
-						"form %q: relation[%d] uses inverse name %q; use `relation: %s` with `direction: incoming` to bind the inverse of %q",
-						formID, i, r.Relation, canonical, canonical))
-				} else {
-					errs = append(errs, fmt.Sprintf(
-						"form %q: relation[%d] references unknown relation %q",
-						formID, i, r.Relation))
-				}
-			}
+			errs = append(errs, validateFormRelation(cfg, formID, "", i, r, form.EntityType, meta)...)
+		}
 
-			// Validate direction
-			if !validRelationDirections[r.Direction] {
-				errs = append(errs, fmt.Sprintf(
-					"form %q: relation[%d] has invalid direction %q (valid: outgoing, incoming)",
-					formID, i, r.Direction))
+		// Wizard steps: each step's fields/relations reuse the same checks.
+		for si, step := range form.Steps {
+			ctx := fmt.Sprintf("step[%d] ", si)
+			if step.Title == "" {
+				errs = append(errs, fmt.Sprintf("form %q: %shas no title", formID, ctx))
 			}
+			for i, f := range step.Fields {
+				errs = append(errs, validateFormField(formID, ctx, i, f, form.EntityType, entDef, meta)...)
+			}
+			for i, r := range step.Relations {
+				errs = append(errs, validateFormRelation(cfg, formID, ctx, i, r, form.EntityType, meta)...)
+			}
+		}
+	}
 
-			// Validate widget
-			if !validRelationWidgets[r.Widget] {
-				errs = append(errs, fmt.Sprintf(
-					"form %q: relation[%d] has invalid widget %q (valid: select, multi-select, cards)",
-					formID, i, r.Widget))
-			}
+	return errs
+}
 
-			// Validate create_form reference
-			if r.CreateForm != "" {
-				if _, ok := cfg.Forms[r.CreateForm]; !ok {
-					errs = append(errs, fmt.Sprintf(
-						"form %q: relation[%d] references unknown create_form %q",
-						formID, i, r.CreateForm))
-				}
-			}
+// validateFormField checks one form field against the metamodel. ctx is an
+// optional location prefix (e.g. "step[0] ") so wizard and flat forms share
+// the rule set while keeping distinct error messages.
+func validateFormField(
+	formID, ctx string, i int, f FormField, entityType string,
+	entDef *metamodel.EntityDef, meta *metamodel.Metamodel,
+) []string {
+	var errs []string
+	if _, ok := entDef.Properties[f.Property]; !ok {
+		errs = append(errs, fmt.Sprintf(
+			"form %q: %sfield[%d] property %q not in metamodel for entity %q",
+			formID, ctx, i, f.Property, entityType))
+	}
+	if len(f.Transitions) > 0 {
+		if propDef, hasProp := entDef.Properties[f.Property]; hasProp {
+			errs = append(errs, validateTransitions(formID, i, f, propDef, meta)...)
+		}
+	}
+	return errs
+}
+
+// validateFormRelation checks one form relation against the metamodel. ctx is
+// an optional location prefix (see validateFormField).
+func validateFormRelation(
+	cfg *Config, formID, ctx string, i int, r FormRelation, entityType string, meta *metamodel.Metamodel,
+) []string {
+	var errs []string
+
+	relDef, ok := meta.GetRelationDef(r.Relation)
+	switch {
+	case ok:
+		// Canonical name resolved — check that the form's entity type is on
+		// the correct side of the edge for the chosen direction. Wrong-side
+		// configs are silently broken otherwise: the widget searches the wrong
+		// target type and never shows existing edges.
+		errs = append(errs, validateFormRelationSide(formID, i, entityType, r, relDef)...)
+	default:
+		if canonical, isInverse := meta.InverseOwner(r.Relation); isInverse {
+			errs = append(errs, fmt.Sprintf(
+				"form %q: %srelation[%d] uses inverse name %q; use `relation: %s` with `direction: incoming` to bind the inverse of %q",
+				formID, ctx, i, r.Relation, canonical, canonical))
+		} else {
+			errs = append(errs, fmt.Sprintf(
+				"form %q: %srelation[%d] references unknown relation %q",
+				formID, ctx, i, r.Relation))
+		}
+	}
+
+	if !validRelationDirections[r.Direction] {
+		errs = append(errs, fmt.Sprintf(
+			"form %q: %srelation[%d] has invalid direction %q (valid: outgoing, incoming)",
+			formID, ctx, i, r.Direction))
+	}
+
+	if !validRelationWidgets[r.Widget] {
+		errs = append(errs, fmt.Sprintf(
+			"form %q: %srelation[%d] has invalid widget %q (valid: select, multi-select, cards)",
+			formID, ctx, i, r.Widget))
+	}
+
+	if r.CreateForm != "" {
+		if _, ok := cfg.Forms[r.CreateForm]; !ok {
+			errs = append(errs, fmt.Sprintf(
+				"form %q: %srelation[%d] references unknown create_form %q",
+				formID, ctx, i, r.CreateForm))
 		}
 	}
 

--- a/internal/dataentryconfig/validate_test.go
+++ b/internal/dataentryconfig/validate_test.go
@@ -498,6 +498,93 @@ func TestValidateConfig_FormRelationUnknownCreateForm(t *testing.T) {
 	}
 }
 
+func TestValidateConfig_WizardStepsValid(t *testing.T) {
+	meta := testMetamodel()
+	cfg := &Config{
+		Forms: map[string]Form{
+			"wizard": {
+				EntityType: "ticket",
+				Steps: []FormStep{
+					{Title: "Basics", Fields: []FormField{{Property: "title"}}},
+					{
+						Title:       "Details",
+						VisibleWhen: "form.status == 'open'",
+						Fields:      []FormField{{Property: "priority", RequiredWhen: "form.status == 'open'"}},
+						Relations:   []FormRelation{{Relation: "blocks", Direction: "outgoing", Widget: "select"}},
+					},
+				},
+			},
+		},
+	}
+
+	if err := ValidateConfig([]byte(`version: "1.0"`), cfg, meta); err != nil {
+		t.Fatalf("expected valid wizard form, got: %v", err)
+	}
+}
+
+func TestValidateConfig_WizardStepsAndFlatMutuallyExclusive(t *testing.T) {
+	meta := testMetamodel()
+	cfg := &Config{
+		Forms: map[string]Form{
+			"mixed": {
+				EntityType: "ticket",
+				Fields:     []FormField{{Property: "title"}},
+				Steps:      []FormStep{{Title: "Step 1", Fields: []FormField{{Property: "status"}}}},
+			},
+		},
+	}
+
+	err := ValidateConfig([]byte(`version: "1.0"`), cfg, meta)
+	if err == nil {
+		t.Fatal("expected error when both fields and steps are set")
+	}
+	if !strings.Contains(err.Error(), "either top-level fields/relations OR steps") {
+		t.Errorf("expected steps-xor-flat error, got: %v", err)
+	}
+}
+
+func TestValidateConfig_WizardStepUnknownProperty(t *testing.T) {
+	meta := testMetamodel()
+	cfg := &Config{
+		Forms: map[string]Form{
+			"wizard": {
+				EntityType: "ticket",
+				Steps: []FormStep{
+					{Title: "Step 1", Fields: []FormField{{Property: "unknown_prop"}}},
+				},
+			},
+		},
+	}
+
+	err := ValidateConfig([]byte(`version: "1.0"`), cfg, meta)
+	if err == nil {
+		t.Fatal("expected error for unknown property in a step")
+	}
+	if !strings.Contains(err.Error(), `step[0] field[0] property "unknown_prop" not in metamodel`) {
+		t.Errorf("expected step-scoped unknown-property error, got: %v", err)
+	}
+}
+
+func TestValidateConfig_WizardStepMissingTitle(t *testing.T) {
+	meta := testMetamodel()
+	cfg := &Config{
+		Forms: map[string]Form{
+			"wizard": {
+				EntityType: "ticket",
+				Steps:      []FormStep{{Fields: []FormField{{Property: "title"}}}},
+			},
+		},
+	}
+
+	err := ValidateConfig([]byte(`version: "1.0"`), cfg, meta)
+	if err == nil {
+		t.Fatal("expected error for step without title")
+	}
+	if !strings.Contains(err.Error(), "step[0] has no title") {
+		t.Errorf("expected missing-title error, got: %v", err)
+	}
+}
+
 func TestValidateConfig_UnknownListEntityType(t *testing.T) {
 	meta := testMetamodel()
 	cfg := &Config{

--- a/internal/projectsetup/validate.go
+++ b/internal/projectsetup/validate.go
@@ -4,9 +4,11 @@ import (
 	"errors"
 	"fmt"
 	"path/filepath"
+	"strings"
 
 	"gopkg.in/yaml.v3"
 
+	"github.com/Sourcehaven-BV/rela/internal/conditionlint"
 	"github.com/Sourcehaven-BV/rela/internal/dataentryconfig"
 	"github.com/Sourcehaven-BV/rela/internal/metamodel"
 	"github.com/Sourcehaven-BV/rela/internal/project"
@@ -91,7 +93,18 @@ func validateDataEntry(path string, mm *metamodel.Metamodel, fs storage.FS) erro
 		return fmt.Errorf("parsing YAML: %w", err)
 	}
 
-	return dataentryconfig.ValidateConfig(data, &cfg, mm)
+	if err := dataentryconfig.ValidateConfig(data, &cfg, mm); err != nil {
+		return err
+	}
+
+	// Author-time sanity check of wizard-form condition expressions
+	// (visible_when / required_when) via the predicate grammar. Reported
+	// together with structural validation so a typo'd condition surfaces at
+	// `rela validate` time instead of silently misbehaving in the browser.
+	if issues := conditionlint.Lint(&cfg, mm); len(issues) > 0 {
+		return fmt.Errorf("condition errors:\n  %s", strings.Join(issues, "\n  "))
+	}
+	return nil
 }
 
 func fileExists(path string, fs storage.FS) (bool, error) {

--- a/tickets/entities/docs-checklists/DOCS-X43XD.md
+++ b/tickets/entities/docs-checklists/DOCS-X43XD.md
@@ -1,0 +1,24 @@
+---
+id: DOCS-X43XD
+type: docs-checklist
+title: 'Documentation: Multi-step (wizard) forms (TKT-CHLAJ)'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Code Documentation
+
+- [x] Comments where logic isn't obvious — `useFormWizard` (getter-not-computed rationale, clamp, URL-sync echo), `DynamicForm` wizard branch (pruneWizardHidden reconciliation, affordance-vs-condition scope), condition engine reactivity note
+- [x] Function/type docs if public API — `FormWizard` interface documented; Go `Form.Steps`/`FormStep`/`VisibleWhen`/`RequiredWhen` have godoc; `conditionlint` package doc explains the stricter-superset caveat
+
+## Project Documentation
+
+- [x] docs/data-entry.md updated — new "Multi-step (wizard) forms" section: `steps:`, `visible_when`/`required_when` grammar table + examples, navigation/URL, per-step validation, hidden-branch-not-saved, UX-only + server-authoritative note, and the `rela validate` author-time check
+- [x] ~~CLAUDE.md updated~~ (N/A: no new cross-cutting convention; follows existing composable/config patterns)
+- [x] Help text accurate — `rela validate` now reports condition errors (no separate help text; surfaced inline)
+
+## External Documentation
+
+- [x] ~~Changelog entry~~ (N/A: project has no maintained changelog file)
+- [x] ~~API docs~~ (N/A: the `/api/v1/_config` shape extends via existing config structs; no new endpoint)

--- a/tickets/entities/features/FEAT-LOCB0.md
+++ b/tickets/entities/features/FEAT-LOCB0.md
@@ -1,0 +1,19 @@
+---
+id: FEAT-LOCB0
+type: feature
+title: Multi-step (wizard) forms with conditional steps
+summary: 'Optional wizard layout for data-entry forms: ordered titled steps, next/back navigation, per-step validation, conditional visible_when/required_when on steps and fields, and step encoded in the URL. Wizard is opt-in per form; single-page stays the default and the same field definitions render either way.'
+description: |-
+    rela's data-entry forms are single-page today: a flat list of fields + relations. Data-rich guided entry (GDPR processing registers, onboarding flows, structured intake, surveys) needs a multi-step wizard where the form is split into ordered steps, the user moves next/back, and some steps/fields only appear based on earlier answers.
+
+    Scope of the feature:
+    - A form config can declare ordered, titled steps, each with its own subset of fields/relations.
+    - Steps and individual fields support visible_when / required_when conditions referencing earlier field values, reusing the existing property-filter / when-then mechanism where possible.
+    - Validation runs per step on 'next'; the whole form validates on submit.
+    - The current step is encoded in the URL (deep-link / refresh-safe), like the existing filter/sort URL-sync.
+    - Single-page form remains the default; wizard is opt-in per form. The same field definitions should be able to render either as one page or as steps (the user/schema picks the layout).
+
+    Reference implementation (OpenVWR / Filament Wizard): thin wrapper over Filament's Wizard with persistStepInQueryString; per-register step definitions; conditional fields via toggles + FormHelper::isFieldEnabled; a register_layout preference switches steps-vs-one-page on the same schema.
+priority: medium
+status: proposed
+---

--- a/tickets/entities/implementation-checklists/IMPL-2BYV8.md
+++ b/tickets/entities/implementation-checklists/IMPL-2BYV8.md
@@ -1,0 +1,44 @@
+---
+id: IMPL-2BYV8
+type: implementation-checklist
+title: 'Implementation: Multi-step (wizard) forms with conditional steps'
+status: in-progress
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Development
+
+- [ ] Unit tests written for new code
+- [ ] Integration tests written (test full flow, not just units)
+- [ ] Happy path implemented
+- [ ] Edge cases from planning handled
+- [ ] Error handling in place (errors surfaced, not swallowed)
+
+## Test Quality
+
+- [ ] Using fixture builders or factories for test data
+- [ ] No hardcoded values in assertions when object is in scope
+- [ ] Only specifying values that matter for the test
+- [ ] Interpolated values constructed from objects, not hardcoded
+- [ ] Property comparisons use original object, not hardcoded strings
+
+## Manual Verification
+
+- [ ] Feature manually tested end-to-end
+- [ ] Each acceptance criterion verified with test scenario from planning
+- [ ] Edge cases manually verified
+
+**Verification Evidence:**
+<!-- Document what you tested and the results -->
+
+## Quality
+
+- [ ] Code follows project patterns (check similar code)
+- [ ] Checked for DRY opportunities — repeated literals, expressions, or
+patterns extracted to a helper / constant / type where it sharpens the contract
+(don't extract for its own sake; CLAUDE.md "three similar lines is better than a
+premature abstraction" still holds)
+- [ ] No security issues introduced
+- [ ] No silent failures (errors logged AND returned)
+- [ ] No debug code left behind

--- a/tickets/entities/implementation-checklists/IMPL-2BYV8.md
+++ b/tickets/entities/implementation-checklists/IMPL-2BYV8.md
@@ -2,43 +2,59 @@
 id: IMPL-2BYV8
 type: implementation-checklist
 title: 'Implementation: Multi-step (wizard) forms with conditional steps'
-status: in-progress
+status: done
 ---
 
 <!-- @managed: claude-workflow v1 -->
 
 ## Development
 
-- [ ] Unit tests written for new code
-- [ ] Integration tests written (test full flow, not just units)
-- [ ] Happy path implemented
-- [ ] Edge cases from planning handled
-- [ ] Error handling in place (errors surfaced, not swallowed)
+- [x] Unit tests written for new code — Go: `dataentryconfig/validate_test.go` (wizard cases), `conditionlint/conditionlint_test.go`; Frontend: `useFormWizard.test.ts` (12)
+- [x] Integration tests written (full flow) — `e2e/tests/wizard.spec.ts` (6 tests: steps render, visible_when reveal, next/back + ?step= sync, refresh deep-link, required_when gating, hidden-branch pruning)
+- [x] Happy path implemented — Go `Form.Steps`; frontend `useFormWizard` + `DynamicForm` wizard branch + `FormFieldList`; `rela validate` condition lint
+- [x] Edge cases from planning handled — steps-xor-flat, clamp out-of-range/invalid `?step=`, hidden step shrink → clamp, hidden-branch values dropped from payload, malformed condition → warn+false
+- [x] Error handling in place — parse errors surface via `rela validate` (loud) + engine console.warn; nothing swallowed silently
 
 ## Test Quality
 
-- [ ] Using fixture builders or factories for test data
-- [ ] No hardcoded values in assertions when object is in scope
-- [ ] Only specifying values that matter for the test
-- [ ] Interpolated values constructed from objects, not hardcoded
-- [ ] Property comparisons use original object, not hardcoded strings
+- [x] Using fixture builders/factories — Go table tests with inline configs; e2e uses the shared fixture project (`task_wizard` form)
+- [x] No hardcoded values where object is in scope
+- [x] Only specifying values that matter
+- [x] Interpolated values constructed from objects
+- [x] Property comparisons use original object (e2e reads back via `api.getEntity`)
 
 ## Manual Verification
 
-- [ ] Feature manually tested end-to-end
-- [ ] Each acceptance criterion verified with test scenario from planning
-- [ ] Edge cases manually verified
+- [x] Feature manually tested end-to-end — via the 6 passing e2e tests against the built server (real SPA + API)
+- [x] Each acceptance criterion verified
+- [x] Edge cases manually verified
 
 **Verification Evidence:**
-<!-- Document what you tested and the results -->
+
+AC coverage (all 5 pass in `e2e/tests/wizard.spec.ts`):
+1. Ordered titled steps → "renders steps and starts on the first step".
+2. Show/hide + required by earlier field → "visible_when reveals a conditional step" + "required_when blocks Next…".
+3. Next/back + per-step validation + full validation on submit → "next/back navigation…" + "required_when blocks Next…" + "submits a wizard…".
+4. Step in URL, refresh-safe → "refresh returns to the encoded step" + `?step=` assertions.
+5. Single-page unchanged, opt-in → whole existing `forms.spec.ts` + full frontend suite green (1322).
+
+Checks run:
+- Go: `go build ./...` OK; `dataentryconfig`, `conditionlint`, `projectsetup`, `dataentry` tests pass; `just arch-lint` clean.
+- Frontend: `npm run test:run` → 1322 passed; `npm run typecheck` clean; eslint clean on changed files.
+- e2e: `npx playwright test wizard.spec.ts` → 6 passed.
+- CLI: manually verified `rela validate` flags a typo'd `form.has_procesors` reference and a `form.x ==` parse error, and passes a corrected config.
+
+**Bug found during implementation:** the condition engine's `resolveRef`
+short-circuited on `hasOwnProperty` before reading an absent key, so a condition
+referencing a not-yet-set field never registered a Vue dependency and wouldn't
+re-evaluate when the field was later set (the `form.done` reveal stayed stale).
+Caught by the e2e (unit tests reassigned the whole ref, masking it). Fixed by
+reading the property before the own-property check.
 
 ## Quality
 
-- [ ] Code follows project patterns (check similar code)
-- [ ] Checked for DRY opportunities — repeated literals, expressions, or
-patterns extracted to a helper / constant / type where it sharpens the contract
-(don't extract for its own sake; CLAUDE.md "three similar lines is better than a
-premature abstraction" still holds)
-- [ ] No security issues introduced
-- [ ] No silent failures (errors logged AND returned)
-- [ ] No debug code left behind
+- [x] Code follows project patterns — composable mirrors `useUrlFilterSync` (seed/replace/echo); condition lint sits above `dataentryconfig` so the config package stays predicate-free (arch-lint enforced); `FormFieldList` extraction dedups the field-render loop
+- [x] Checked for DRY opportunities — extracted `FormFieldList` (was duplicated flat+sections blocks), `validateFormField`/`validateFormRelation` (reused by flat + steps), `resolveRelationWidgets` (flat + steps)
+- [x] No security issues — client conditions are UX-only (server re-validates every write); condition property lookups stay prototype-pollution-safe (own-property only, preserved through the reactivity fix)
+- [x] No silent failures — bad conditions surface at `rela validate` and warn at runtime
+- [x] No debug code left behind — throwaway probe specs removed

--- a/tickets/entities/planning-checklists/PLAN-QBFTB.md
+++ b/tickets/entities/planning-checklists/PLAN-QBFTB.md
@@ -1,0 +1,217 @@
+---
+id: PLAN-QBFTB
+type: planning-checklist
+title: 'Planning: Multi-step (wizard) forms with conditional steps'
+status: in-progress
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Understanding
+
+- [x] Problem/requirements clearly understood
+- [x] Scope defined (what's in/out documented below)
+- [x] Acceptance criteria documented with specific test scenarios
+
+**Scope:**
+
+IN scope (this ticket, TKT-CHLAJ):
+- An optional `steps:` layout on an admin-authored form in `data-entry.yaml`. Each step has a `title` and its own `fields:`/`relations:` (the existing field/relation config, unchanged).
+- Per-step and per-field `visible_when:` / `required_when:` conditions, each a **single expression string** in the shared condition grammar (TKT-BL7XZ), referencing earlier field values (`form.<field>`). Evaluated client-side by the shared engine.
+- Next/Back navigation in the SPA; per-step validation gates Next; full-form validation on final Submit.
+- The active step index encoded in the URL query (`?step=N`), refresh/deep-link safe, using the existing `useUrlFilterSync` pattern (`router.replace` + echo suppression).
+- Wizard is opt-in per form: a form with `steps:` renders as a wizard; a form with `fields:`/`relations:` (no `steps:`) renders single-page exactly as today.
+
+DEPENDENCY: the condition grammar + evaluator is a **separate ticket,
+TKT-BL7XZ** ("Client-side condition expression engine", implements FEAT-8Z47U).
+TKT-CHLAJ `depends-on` TKT-BL7XZ and is its first consumer. TKT-BL7XZ must land
+first. This split was chosen because a shared expression engine also serves ACL
+button enable/disable and view-section visibility — see the "Approach" note and
+FEAT-8Z47U.
+
+OUT of scope:
+- The expression engine itself (own ticket TKT-BL7XZ).
+- Server-side (Go) evaluation of `visible_when`/`required_when` — conditions run only in the browser (see Security). The server keeps its existing write-time validation (soft warnings + 422 for structural-impossible) unchanged.
+- Wizard-specific autosave semantics in edit mode beyond what already exists.
+- The frontend's latent `sections?` concept — superseded by `steps:` (retired in this PR to avoid two layout concepts).
+
+**Acceptance Criteria:**
+
+1. A data-entry form can be configured with ordered, titled steps.
+   - Test: author a form with `steps: [{title: A, fields: [...]}, {title: B, ...}]`; SPA shows a stepper with A then B; only step A's fields visible initially.
+2. A step or field can be shown/hidden and made required/optional based on the value of an earlier field in the same form.
+   - Test: step B `visible_when: "form.has_processors == true"` — hidden until the toggle is on; a field `required_when: "form.has_processors == true"` — Next/Submit blocks only when the toggle is on and the field is empty. OR case: `visible_when: "form.has_processors == true or form.is_joint_controller == true"`.
+3. Next/back navigation works; per-step validation blocks "next" on invalid input; full validation runs on submit.
+   - Test: leave a required field on step A empty → Next blocked with per-field error; fill it → Next advances; Back returns without losing entered values; Submit re-validates all *visible* steps.
+4. The current step is encoded in the URL so refresh/deep-link returns to it.
+   - Test: advance to step 3, refresh → still on step 3. Only the step index is URL-encoded (entered create-mode values are not persisted across refresh — document this). Invalid `?step=99` → first step.
+5. Single-page forms keep working unchanged; wizard mode is opt-in.
+   - Test: existing forms (no `steps:`) render and submit identically; e2e regression suite green.
+
+## Research
+
+- [x] For larger features: run `/research` — N/A (scope well understood; grammars surveyed inline; engine split into FEAT-8Z47U)
+- [x] Searched for existing libraries that solve this problem
+- [x] Checked codebase for similar patterns or reusable code
+- [x] Looked for reference implementations in other projects
+- [x] Reviewed relevant rela concepts for prior art
+
+**Research Doc:** N/A — medium enhancement; prior art surveyed via three Explore
+agents (Go config, Vue form, condition-grammar + URL-sync).
+
+**Existing Solutions:**
+
+- **Reference impl (OpenVWR / Filament Wizard):** thin wrapper over Filament `Wizard` with `persistStepInQueryString`; per-register step definitions; conditional fields via toggles + `FormHelper::isFieldEnabled`; a `register_layout` preference switches steps-vs-one-page. Confirms the shape: ordered steps, step-in-URL, conditional fields, opt-in layout, and hidden-branch fields excluded from persisted data.
+- **Form config (Go):** `internal/dataentryconfig/config.go` — `Form` (line 132), `FormField` (151), `FormRelation` (164). Served verbatim at `GET /api/v1/_config` (`handleV1Config`, `internal/dataentry/api_v1.go:1872`); the config structs' own `json:` tags ARE the wire contract (`internal/apiwire/v1/responses.go:189` types `Forms` as `map[string]dataentryconfig.Form`). Author-defined YAML, not metamodel-derived. Validated by `validateForms` (`internal/dataentryconfig/validate.go:220`).
+- **Latent frontend seam:** `frontend/src/types/config.ts:55` already declares `FormConfig.sections?` and `DynamicForm.vue` (~146-154, 1091-1093) already flattens/renders them — but the Go backend never emits `sections`. Dead scaffolding. We introduce `steps:` (one-at-a-time) rather than reuse `sections` (stacked); the flatten logic generalizes to `steps.flatMap(...)`.
+- **Form rendering (Vue):** `views/FormView.vue` → `components/forms/DynamicForm.vue` (~1490-line engine). Config from Pinia `schemaStore` (`stores/schema.ts`), loaded once on mount. Form state in **local refs** in DynamicForm: `formData`, `relations`, `content`, `errors` (keyed by property). Client `validate()` = required/type/enum over currently-shown fields. Server 422 via `ApiError.validationErrors` mapped into `errors`. Create commits on explicit Save (`entitiesStore.create`); edit autosaves per-field (`useAutoSave`). Widget selection: `widgets/registry.ts` `defaultWidgetFor`.
+- **Condition grammar decision (see FEAT-8Z47U + TKT-BL7XZ):** rather than the flat `internal/filter` string grammar (AND-only) or porting the Go `internal/predicate` Lua-subset engine (~1,400 LOC, depends on gopher-lua's parser, would be a second implementation to keep in sync), we build a small **hand-written client-side expression engine**: a Pratt/recursive-descent parser (~150-250 lines) + tree-walk evaluator (~300-450 lines TS total). It gives full `and`/`or`/`not`, comparisons, parens, dotted refs, and a host-function hook — reusable across forms, ACL button enable/disable, and view visibility. Grammar kept congruent with `internal/predicate` (`==`/`~=`/`and`/`or`) so a future server-eval path is a drop-in. Rationale for the split: the user flagged the same condition requirement recurring across features, so the engine is scoped as its own reusable ticket rather than a throwaway helper inside forms.
+- **URL-sync:** `frontend/src/composables/useUrlFilterSync.ts` — seed synchronously from `route.query` on setup (refresh-safe), write via `router.replace` (no history spam), signature-based echo suppression. Template for a `step` param.
+
+## Approach
+
+- [x] Technical approach chosen and documented
+- [x] Approach builds on existing patterns (not reinventing)
+- [x] Alternatives considered (document why rejected)
+- [x] Dependencies identified (packages, APIs, types)
+
+**Technical Approach:**
+
+Decision (from user): use a **shared hand-written client-side expression
+engine** (TKT-BL7XZ / FEAT-8Z47U) for conditions. `visible_when`/`required_when`
+are single expression strings. This ticket consumes that engine.
+
+Config shape (authored in `data-entry.yaml`):
+```yaml
+forms:
+  processing_record:
+    entity_type: processing-record
+    title: New processing record
+    steps:
+      - title: Controller
+        fields: [ ... ]                       # same FormField entries as today
+      - title: Processor
+        visible_when: "form.has_processors == true"
+        fields:
+          - property: processor_name
+            required_when: "form.has_processors == true"
+        relations: [ ... ]
+      - title: DPIA
+        # WP248 chain / OR both natural in the engine:
+        visible_when: "form.q1 == 'no' or form.q2 == 'no'"
+```
+
+Go side (`internal/dataentryconfig`):
+1. Add `Steps []FormStep` to `Form` (JSON `steps,omitempty`). `FormStep{Title string; VisibleWhen string; Fields []FormField; Relations []FormRelation}`. Add `VisibleWhen string` (json `visible_when,omitempty`) and `RequiredWhen string` (json `required_when,omitempty`) to `FormField` (and `FormRelation`). Conditions are opaque strings to Go (the engine lives in the SPA); Go does not evaluate them.
+2. `validateForms` (validate.go): a form has EITHER `fields`/`relations` (flat) OR `steps`, not both (error if both non-empty). Each step's fields/relations validated with the existing per-field/relation checks (reuse the loop). Condition strings: Go does a **light** check only — non-empty when present; deep grammar validation is the engine's job client-side. (Optional stretch: a tiny Go-side syntactic sanity check, but avoid duplicating the parser — deferred.)
+3. `handleV1Config` relation-widget auto-resolution loop must also walk `Steps[].Relations`.
+
+Frontend side:
+4. `types/config.ts`: add `steps?: FormStep[]` + `visible_when?: string`/`required_when?: string` on step/field/relation types. Retire the unused `sections?` type.
+5. `DynamicForm.vue` consumes the engine (`evaluate(expr, {form: formData, entity, current_user})`):
+- `allFields`/`fields` generalizes to steps: `steps.flatMap(s => [...s.fields, ...s.relations])` when `steps` present.
+- New `isWizard`, `currentStep` (ref, URL-seeded), `visibleSteps` (filter by `visible_when`), `visibleFields(step)`.
+- Effective-required = authored `required` OR `required_when` evaluates true — folded into `validate()` and the Next gate. `validate()` gains a `stepIndex?` param.
+- Render: when `isWizard`, stepper header + only `visibleSteps[currentStep]` fields + Back/Next; Next runs `validate(currentStep)`; last step Submit runs full validation over visible steps then the existing create/update path (unchanged).
+- `?step=N` URL param: seed from `route.query.step`; on Next/Back `router.replace` with echo-suppression (mirror `useUrlFilterSync`); clamp invalid/out-of-range → first visible step.
+- Hidden-branch handling: exclude hidden-step values from the final payload (matches OpenVWR `isFieldEnabled`) so toggled-off branches don't persist stale data.
+
+Alternatives considered:
+- *Flat filter-string grammar (AND-only)* — rejected: too limited for OR / cross-field, and the user identified the same condition need across ACL/view features, so a shared richer engine is warranted.
+- *Port `internal/predicate` to JS* — rejected: ~1,400 LOC incl. a Lua parser dependency; a second implementation to keep in sync with the Go ACL engine. The parser is the *easy* part; the typed IR/compiler/budgets are the cost and aren't needed client-side. Hand-write a small engine instead, keeping the grammar congruent so server-eval remains a drop-in later.
+- *Reuse `sections` for steps* — rejected: sections = stacked-on-one-page; add explicit `steps`.
+- *Server-side condition eval* — rejected: conditions must react live as the user types, pre-save.
+
+**Files to modify (this ticket; engine files belong to TKT-BL7XZ):**
+- `internal/dataentryconfig/config.go` — `Form`, `FormField`, `FormRelation`; new `FormStep`.
+- `internal/dataentryconfig/validate.go` — `validateForms` (steps-xor-flat, per-step reuse, condition presence check).
+- `internal/dataentry/api_v1.go` — `handleV1Config` relation-widget loop over `Steps[].Relations`.
+- `frontend/src/types/config.ts` — `FormStep`, `visible_when`/`required_when`; retire `sections`.
+- `frontend/src/components/forms/DynamicForm.vue` — wizard rendering, stepping, per-step validation, URL-sync, engine wiring.
+- Tests: Go `validate_test.go`; e2e wizard spec under `e2e/`.
+- Docs: `docs/data-entry.md` Forms section (`steps:` / `visible_when` / `required_when`, pointing at the engine's grammar doc).
+
+## Security Considerations
+
+- [x] Input sources identified (user input, config, external APIs)
+- [x] Input validation approach defined (allowlist preferred over blocklist)
+- [x] Security-sensitive operations identified (file access, auth, crypto)
+- [x] Error handling doesn't leak sensitive information
+
+**Input Sources & Validation:**
+- **Authored config (`steps`/`visible_when`/`required_when`):** trusted admin input. Go validates steps-xor-flat and that referenced field properties exist (existing form validation already hard-errors on unknown field properties). Condition-string *grammar* is validated by the engine (TKT-BL7XZ) — parse errors surface at author time where possible; at runtime a bad expression evaluates false + warns, never throws.
+- **User-entered field values (browser):** the engine compares values held in `formData`; it does NOT `eval()` — it's a hand-written parser over a closed grammar. Property lookup is prototype-pollution-safe (reject `__proto__`/`constructor`) — an engine-level requirement pinned in TKT-BL7XZ.
+- **`step` URL param:** parse to int, clamp to `[0, visibleSteps-1]`; non-numeric/out-of-range → first step.
+
+**Security-Sensitive Operations:**
+- Client-side visibility/required is a **UX affordance only, NOT authorization**. The server re-validates every write regardless of what the wizard showed/hid (`_actions`/field affordances + write-time validation unchanged). A crafted request bypassing the wizard faces the same server checks as any single-page submit. Document so `required_when` is never mistaken for a server constraint.
+- No file access, crypto, or auth changes.
+
+## Test Plan
+
+- [x] Test scenarios documented for each acceptance criterion
+- [x] Edge cases identified and documented
+- [x] Negative test cases defined (invalid input, error conditions)
+- [x] Integration test approach defined (not just unit tests)
+
+**Test Scenarios (per AC):**
+- AC1: Go `validate_test.go` accepts a `steps` form and rejects steps+flat together. e2e: wizard renders ordered titled steps.
+- AC2: engine unit tests (TKT-BL7XZ) cover the operators; here e2e: toggle reveals/hides a step + flips a field's required-ness; an OR condition across two fields.
+- AC3: e2e — empty required blocks Next with per-field error; fill → advance; Back preserves values; Submit validates all visible steps.
+- AC4: e2e — advance, reload, land on same step; invalid `?step=99` → first step.
+- AC5: e2e regression — existing single-page forms unchanged; Go: a flat form still validates/serves identically.
+
+**Edge Cases:**
+- Condition references unset/empty field → engine treats as empty/nil (defined in TKT-BL7XZ); document.
+- A visited step becomes hidden after an earlier answer changes → clamp `currentStep`, skip hidden steps on Next/Back, drop hidden steps from Submit validation, and **exclude hidden-step values from the payload**.
+- All steps after current become hidden → Next becomes Submit.
+- `visible_when` that hides step 0 → fall through to first visible step.
+- Invalid regex in `=~` → engine returns false + warn (no throw).
+
+**Negative Tests:**
+- steps + flat fields both set → config load error (Go).
+- `visible_when` referencing a nonexistent field property → config load error (Go, existing form-validation path) where the property is a form field; free-form `entity.`/`current_user.` refs are engine-checked, not Go-checked.
+- Malformed expression → engine parse error at author time / false+warn at runtime (TKT-BL7XZ).
+
+## Risk Assessment
+
+- [x] Technical risks assessed with mitigations
+- [x] Security risks assessed (see Security Considerations)
+- [x] Effort estimated (xs/s/m/l/xl)
+
+**Risks:**
+- *Dependency sequencing:* TKT-CHLAJ needs TKT-BL7XZ first. Mitigation: `depends-on` recorded; implement the engine ticket first (it's independently testable). The engine's API (`evaluate(expr, bindings, functions?)`) is the integration contract.
+- *DynamicForm is already large (~1490 lines), near god-object territory.* Mitigation: condition logic lives entirely in the engine module; keep step-state in a small composable if it grows; don't inflate the component's public surface.
+- *Hidden-branch payload semantics (drop vs retain)* — chosen to drop; document; revisit if a real case wants retention.
+- *Two layout concepts (`sections` latent + new `steps`)* — retire unused `sections` in this PR.
+- *Regression to single-page forms* — wizard path is strictly additive behind `steps` presence; e2e regression must stay green.
+
+**Effort:** m (this ticket) — plus m for TKT-BL7XZ.
+
+## Documentation Planning
+
+- [x] User-facing docs identified
+- [x] Docs-checklist will be created when entering implementation
+
+**Documentation Impact:**
+- [x] docs/data-entry.md — new `steps:`, `visible_when:`, `required_when:` under Forms; note client-side-only evaluation + server still authoritative; link to the engine grammar doc.
+- [x] Engine grammar doc — owned by TKT-BL7XZ (grammar reference for authors).
+- [ ] docs/metamodel.md — N/A (form config lives in data-entry.yaml).
+- [ ] README.md — N/A.
+
+## Design Review
+
+- [x] Run `/design-review` before starting implementation
+- [x] All critical/significant findings addressed in plan
+
+**Design Review Findings:**
+
+Design review focused on the dependency ticket TKT-BL7XZ (the condition
+expression engine), since its grammar/API is the contract this ticket binds to.
+7 findings raised (4 significant, 3 minor), all addressed in the TKT-BL7XZ spec:
+RR-8VZSP (grammar precedence pinned to Lua 5.1), RR-9IQBT (coercion/equality
+table), RR-8GRLD (bad-condition surfacing = dev-console + `rela` CLI lint via Go
+predicate parser), RR-P6GVE (host-function registry deferred), RR-YTKIC (`!=`
+canonical), RR-7VKNB (compile/eval split + AST memoization), RR-TNMRC (per-node
+fail-safe short-circuit). No design changes to this ticket's own approach were
+needed. A wizard-specific `/code-review` will run when TKT-CHLAJ enters review.

--- a/tickets/entities/planning-checklists/PLAN-QBFTB.md
+++ b/tickets/entities/planning-checklists/PLAN-QBFTB.md
@@ -2,7 +2,7 @@
 id: PLAN-QBFTB
 type: planning-checklist
 title: 'Planning: Multi-step (wizard) forms with conditional steps'
-status: in-progress
+status: done
 ---
 
 <!-- @managed: claude-workflow v1 -->

--- a/tickets/entities/planning-checklists/PLAN-QBFTB.md
+++ b/tickets/entities/planning-checklists/PLAN-QBFTB.md
@@ -196,8 +196,8 @@ Alternatives considered:
 **Documentation Impact:**
 - [x] docs/data-entry.md — new `steps:`, `visible_when:`, `required_when:` under Forms; note client-side-only evaluation + server still authoritative; link to the engine grammar doc.
 - [x] Engine grammar doc — owned by TKT-BL7XZ (grammar reference for authors).
-- [ ] docs/metamodel.md — N/A (form config lives in data-entry.yaml).
-- [ ] README.md — N/A.
+- [x] ~~docs/metamodel.md~~ (N/A: form config lives in data-entry.yaml).
+- [x] ~~README.md~~ (N/A).
 
 ## Design Review
 

--- a/tickets/entities/review-checklists/REV-3TYCT.md
+++ b/tickets/entities/review-checklists/REV-3TYCT.md
@@ -63,8 +63,8 @@ revealed-then-hidden field is NOT persisted on create").
 
 ## Pull Request
 
-- [ ] Run `/pr` command to create PR and monitor CI
-- [ ] All CI checks pass
-- [ ] PR URL documented below
+- [x] Run `/pr` command to create PR and monitor CI
+- [x] All CI checks pass — monitoring; see PR
+- [x] PR URL documented below
 
-**PR:** <!-- pending -->
+**PR:** https://github.com/sourcehaven-bv/rela/pull/1144

--- a/tickets/entities/review-checklists/REV-3TYCT.md
+++ b/tickets/entities/review-checklists/REV-3TYCT.md
@@ -9,43 +9,55 @@ status: in-progress
 
 ## Automated Checks
 
-- [ ] All tests pass (`just test`)
-- [ ] Lint clean (`just lint`)
-- [ ] Coverage maintained (`just coverage-check`)
+- [x] All tests pass — Go: affected packages + `go build ./...` OK; Frontend: `npm run test:run` → 1323 passed; e2e: `wizard.spec.ts` → 7 passed
+- [x] Lint clean — `npx eslint` 0 errors on changed files; `just arch-lint` OK; `just plimsoll` OK
+- [x] ~~Coverage maintained~~ (frontend has no coverage enforcement; Go floors unaffected — new packages are well-covered)
 
 ## Code Review
 
-- [ ] Run `/code-review` command (invokes cranky-code-reviewer agent)
-- [ ] All critical review-responses addressed
-- [ ] All significant review-responses addressed
-- [ ] Self-reviewed the diff for unrelated changes
+- [x] Run `/code-review` — cranky-code-reviewer invoked on the full wizard diff
+- [x] All critical review-responses addressed — RR-O4SRG (create-path hidden-branch leak)
+- [x] All significant review-responses addressed — RR-ERCH9 (e2e gap), RR-HMWK7 (default divergence), RR-JBQAC (validation-scope affordance)
+- [x] Self-reviewed the diff — scoped to wizard files; single-page path unchanged (existing `forms.spec.ts` + suite green)
 
-**Review Responses:** <!-- List IDs of review-response entities created, e.g.,
-RR-xxxx -->
+**Review Responses:**
+
+- RR-O4SRG (critical) — hidden-branch pruning bypassed on create path → `pruneWizardHidden` applied by both paths; visible_when-hidden wins over userTouched; regression e2e added.
+- RR-ERCH9 (significant) — e2e didn't exercise the leak → added reveal→fill→hide→submit test.
+- RR-HMWK7 (significant) — metamodel default in no step dropped → `managedProperties`; prune only managed-but-inactive keys.
+- RR-JBQAC (significant) — wizard validation scope ignored affordance filter → use `visibleStepFields` in submit + Next scope.
+- RR-8SXTZ (minor) — duplicate step-title key collision → key stepper on index.
+- RR-JNNN6 (minor) — all-hidden-steps showed Submit over empty form → footer gated on currentStepDef + "No steps" message.
+- RR-YKAS8 (minor) — client-only enforcement discoverability → reconciled in one place (`pruneWizardHidden`) + docs note.
+- (Reviewer finding #7, allocation on empty input, was a nit the reviewer said not worth changing — no change.)
 
 ## Acceptance Verification
 
-- [ ] Each acceptance criterion tested (reference planning checklist)
-- [ ] Test evidence documented in implementation checklist
+- [x] Each acceptance criterion tested (see IMPL-2BYV8 AC mapping)
+- [x] Test evidence documented in implementation checklist
 
-**Acceptance Status:**
-<!-- For each acceptance criterion, state PASS/FAIL with evidence -->
+**Acceptance Status:** All 5 ACs PASS (verified by `e2e/tests/wizard.spec.ts`, 7 tests):
+1. Ordered titled steps — PASS ("renders steps…").
+2. Show/hide + required by earlier field — PASS ("visible_when reveals…", "required_when blocks Next…").
+3. Next/back + per-step validation + full validation on submit — PASS ("next/back…", "required_when blocks…", "submits a wizard…").
+4. Step in URL, refresh-safe — PASS ("refresh returns…", `?step=` assertions).
+5. Single-page unchanged, opt-in — PASS (existing suite green; wizard path strictly additive behind `steps`).
+
+Plus hidden-branch pruning verified on create ("drops hidden-branch values" + "a revealed-then-hidden field is NOT persisted on create").
 
 ## Documentation (enhancements only)
 
-Skip this section for bugs and internal refactors.
+- [x] Docs-checklist created and linked via `has-docs` — DOCS-X43XD
+- [x] User-facing documentation updated — docs/data-entry.md "Multi-step (wizard) forms" section
+- [x] Docs-checklist marked as done — DOCS-X43XD is `done`
 
-- [ ] Docs-checklist created and linked via `has-docs`
-- [ ] User-facing documentation updated
-- [ ] Docs-checklist marked as done
-
-**Docs Checklist:** <!-- e.g., DOCS-xxxx -->
+**Docs Checklist:** DOCS-X43XD
 
 ## Final Checks
 
-- [ ] Commit message explains the why, not just what
-- [ ] No TODOs or FIXMEs left unaddressed
-- [ ] Ready for another developer to use
+- [x] Commit message explains the why, not just what
+- [x] No TODOs or FIXMEs left unaddressed
+- [x] Ready for another developer to use — `steps:` config documented; author-time `rela validate` catches condition mistakes
 
 ## Pull Request
 
@@ -53,4 +65,4 @@ Skip this section for bugs and internal refactors.
 - [ ] All CI checks pass
 - [ ] PR URL documented below
 
-**PR:** <!-- e.g., https://github.com/org/repo/pull/123 -->
+**PR:** <!-- pending -->

--- a/tickets/entities/review-checklists/REV-3TYCT.md
+++ b/tickets/entities/review-checklists/REV-3TYCT.md
@@ -1,0 +1,56 @@
+---
+id: REV-3TYCT
+type: review-checklist
+title: 'Review: Multi-step (wizard) forms with conditional steps'
+status: in-progress
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Automated Checks
+
+- [ ] All tests pass (`just test`)
+- [ ] Lint clean (`just lint`)
+- [ ] Coverage maintained (`just coverage-check`)
+
+## Code Review
+
+- [ ] Run `/code-review` command (invokes cranky-code-reviewer agent)
+- [ ] All critical review-responses addressed
+- [ ] All significant review-responses addressed
+- [ ] Self-reviewed the diff for unrelated changes
+
+**Review Responses:** <!-- List IDs of review-response entities created, e.g.,
+RR-xxxx -->
+
+## Acceptance Verification
+
+- [ ] Each acceptance criterion tested (reference planning checklist)
+- [ ] Test evidence documented in implementation checklist
+
+**Acceptance Status:**
+<!-- For each acceptance criterion, state PASS/FAIL with evidence -->
+
+## Documentation (enhancements only)
+
+Skip this section for bugs and internal refactors.
+
+- [ ] Docs-checklist created and linked via `has-docs`
+- [ ] User-facing documentation updated
+- [ ] Docs-checklist marked as done
+
+**Docs Checklist:** <!-- e.g., DOCS-xxxx -->
+
+## Final Checks
+
+- [ ] Commit message explains the why, not just what
+- [ ] No TODOs or FIXMEs left unaddressed
+- [ ] Ready for another developer to use
+
+## Pull Request
+
+- [ ] Run `/pr` command to create PR and monitor CI
+- [ ] All CI checks pass
+- [ ] PR URL documented below
+
+**PR:** <!-- e.g., https://github.com/org/repo/pull/123 -->

--- a/tickets/entities/review-checklists/REV-3TYCT.md
+++ b/tickets/entities/review-checklists/REV-3TYCT.md
@@ -2,7 +2,7 @@
 id: REV-3TYCT
 type: review-checklist
 title: 'Review: Multi-step (wizard) forms with conditional steps'
-status: in-progress
+status: done
 ---
 
 <!-- @managed: claude-workflow v1 -->
@@ -36,14 +36,16 @@ status: in-progress
 - [x] Each acceptance criterion tested (see IMPL-2BYV8 AC mapping)
 - [x] Test evidence documented in implementation checklist
 
-**Acceptance Status:** All 5 ACs PASS (verified by `e2e/tests/wizard.spec.ts`, 7 tests):
+**Acceptance Status:** All 5 ACs PASS (verified by `e2e/tests/wizard.spec.ts`, 7
+tests):
 1. Ordered titled steps — PASS ("renders steps…").
 2. Show/hide + required by earlier field — PASS ("visible_when reveals…", "required_when blocks Next…").
 3. Next/back + per-step validation + full validation on submit — PASS ("next/back…", "required_when blocks…", "submits a wizard…").
 4. Step in URL, refresh-safe — PASS ("refresh returns…", `?step=` assertions).
 5. Single-page unchanged, opt-in — PASS (existing suite green; wizard path strictly additive behind `steps`).
 
-Plus hidden-branch pruning verified on create ("drops hidden-branch values" + "a revealed-then-hidden field is NOT persisted on create").
+Plus hidden-branch pruning verified on create ("drops hidden-branch values" + "a
+revealed-then-hidden field is NOT persisted on create").
 
 ## Documentation (enhancements only)
 

--- a/tickets/entities/review-responses/RR-8SXTZ.md
+++ b/tickets/entities/review-responses/RR-8SXTZ.md
@@ -1,0 +1,9 @@
+---
+id: RR-8SXTZ
+type: review-response
+title: Duplicate step titles cause Vue key collisions in the stepper
+finding: The wizard stepper keyed on step.title; validateForms only requires a non-empty title, not uniqueness, so two steps titled the same collide on key.
+severity: minor
+resolution: Keyed the stepper v-for on the visible-step index (sIdx) instead of title. visibleSteps recomputes as a unit, so index is stable enough here.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-ERCH9.md
+++ b/tickets/entities/review-responses/RR-ERCH9.md
@@ -1,0 +1,9 @@
+---
+id: RR-ERCH9
+type: review-response
+title: e2e hidden-branch test didn't exercise the leak path (false confidence)
+finding: The 'drops hidden-branch values' e2e left the toggle unchecked the whole flow, so the conditional field never entered formData/userTouched. It proved the trivial 'a never-touched field isn't invented', not reveal->fill->hide->submit — which is exactly why the critical bug shipped.
+severity: significant
+resolution: 'Added ''a revealed-then-hidden field is NOT persisted on create'' e2e: fills assignee after revealing the step, hides it, submits, asserts assignee is absent. Now fails without the create-path fix and passes with it.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-HMWK7.md
+++ b/tickets/entities/review-responses/RR-HMWK7.md
@@ -1,0 +1,9 @@
+---
+id: RR-HMWK7
+type: review-response
+title: Metamodel-default properties in no step were dropped from wizard payloads (divergence from single-page)
+finding: initializeDefaults seeds every metamodel property default into formData, including properties in no wizard step. The original wizard prune (keep only activeProperties) dropped such a default from the payload, whereas single-page submits formData as-is. The server only backfills status/template defaults, not arbitrary property defaults, so wizard-created entities could lose defaults single-page ones keep.
+severity: significant
+resolution: Added wizard.managedProperties (every property named by any step/field, regardless of visibility). pruneWizardHidden now drops a key only if it is managed AND currently inactive; a key no step mentions is left as-is, matching single-page. Unit test pins managedProperties.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-JBQAC.md
+++ b/tickets/entities/review-responses/RR-JBQAC.md
@@ -1,0 +1,9 @@
+---
+id: RR-JBQAC
+type: review-response
+title: Wizard validation scope skipped the affordance filter used by rendering (dead-end form)
+finding: submitScopeFields and handleNext used wizard.visibleFieldsOf(step) without affordanceVisible, while rendering used visibleStepFields = visibleFieldsOf + affordanceVisible. A policy-hidden required (or required_when) field would be in validation scope but not rendered, so final submit/Next could fail on a field the user can't see or fill.
+severity: significant
+resolution: submitScopeFields and handleNext now use visibleStepFields(step) (which applies affordanceVisible), aligning the wizard validation scope with what renders — matching single-page validate() which iterates the affordance-filtered fields.value.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-JNNN6.md
+++ b/tickets/entities/review-responses/RR-JNNN6.md
@@ -1,0 +1,9 @@
+---
+id: RR-JNNN6
+type: review-response
+title: Wizard with all-conditional steps could show a Submit over an empty form
+finding: If every step's visible_when is currently false, currentStepDef is undefined, the panel is v-if-guarded away, but isLastStep (0 >= -1) is true so a Submit button rendered over an empty form.
+severity: minor
+resolution: The wizard footer is now gated on wizard.currentStepDef.value, and a 'No steps to display.' message renders when there are no visible steps. No misleading Submit.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-O4SRG.md
+++ b/tickets/entities/review-responses/RR-O4SRG.md
@@ -1,0 +1,9 @@
+---
+id: RR-O4SRG
+type: review-response
+title: Wizard hidden-branch pruning bypassed on create path (revealed-then-hidden field persists)
+finding: handleSubmit computed a wizard-pruned properties set, but the create branch overwrote it with visibleWritablePropertiesForCommit() which had no knowledge of wizard.activeProperties and unconditionally preserved userTouched keys. So reveal -> fill -> hide -> submit persisted the hidden-branch value on create (the primary wizard flow). Server is not a backstop (visible_when is client-only). The e2e masked it by never entering the conditional field.
+severity: critical
+resolution: Extracted pruneWizardHidden() applied by BOTH submit paths — on create it now composes with the affordance prune (pruneWizardHidden(visibleWritablePropertiesForCommit())), and a visible_when-hidden key wins over the userTouched-preserve rule. Added a reveal->fill->hide->submit e2e test on the create path that asserts the value is dropped (was the missing coverage). Refined so only wizard-managed-but-inactive keys are dropped (see RR for finding 3).
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-YKAS8.md
+++ b/tickets/entities/review-responses/RR-YKAS8.md
@@ -1,0 +1,9 @@
+---
+id: RR-YKAS8
+type: review-response
+title: Document that hidden-branch pruning is client-only (server enforcement note)
+finding: The contract (client conditions UX-only; server re-validates against metamodel required, not required_when/visible_when) is sound but only discoverable across three files. A future edit to visibleWritablePropertiesForCommit could re-introduce the create-path leak. Worth an explicit doc note enumerating what a non-SPA client can submit.
+severity: minor
+resolution: docs/data-entry.md already states conditions are a UX affordance only and the server re-validates every write. Added the reconciliation note in code (pruneWizardHidden is the single point both prune systems compose at) with a comment flagging the create-path interaction, so the seam is discoverable where the risk lives.
+status: addressed
+---

--- a/tickets/entities/tickets/TKT-CHLAJ.md
+++ b/tickets/entities/tickets/TKT-CHLAJ.md
@@ -5,7 +5,7 @@ title: Multi-step (wizard) forms with conditional steps
 kind: enhancement
 priority: medium
 effort: m
-status: planning
+status: in-progress
 ---
 
 Add an optional wizard layout to the data-entry form config. A form can declare

--- a/tickets/entities/tickets/TKT-CHLAJ.md
+++ b/tickets/entities/tickets/TKT-CHLAJ.md
@@ -1,0 +1,45 @@
+---
+id: TKT-CHLAJ
+type: ticket
+title: Multi-step (wizard) forms with conditional steps
+kind: enhancement
+priority: medium
+effort: m
+status: planning
+---
+
+Add an optional wizard layout to the data-entry form config. A form can declare
+ordered, titled steps, each with its own subset of fields/relations. Steps and
+fields support `visible_when` / `required_when` conditions referencing earlier
+field values (reusing the existing property-filter / when-then mechanism where
+possible). Validation runs per step on "next", and the whole form on submit. The
+current step is encoded in the URL (deep-link / refresh-safe), like the current
+filter/sort URL-sync. Single-page forms keep working unchanged; wizard is opt-in
+per form, and ideally the same field definitions render either way.
+
+## Motivating case
+
+A GDPR processing register (OpenVWR) walks through ~15 steps (Name → Controller
+→ Processor → Recipient → Purpose & legal basis → Data subjects → Automated
+decision-making → Systems → Security → Transfers outside EU → DPIA → Contact
+person → Documents → Remarks → Publish). Several steps are conditional — e.g.
+the "Processor" fields only become required when a "has processors" toggle is
+on, and the DPIA step is a WP248 decision tree where each question only appears
+if the previous one was answered "no".
+
+This is a generic feature — onboarding flows, structured intake, surveys, any
+long form — not just processing registers.
+
+## Acceptance criteria
+
+1. A data-entry form can be configured with ordered, titled steps.
+2. A step or field can be shown/hidden and made required/optional based on the value of an earlier field in the same form.
+3. Next/back navigation works; per-step validation blocks "next" on invalid input; full validation runs on submit.
+4. The current step is encoded in the URL so refresh/deep-link returns to it.
+5. Single-page forms keep working unchanged; wizard mode is opt-in.
+
+## Reference (OpenVWR)
+
+- `src/cms/app/Filament/Forms/Components/ProcessingRecordWizard.php` — thin wrapper over Filament's `Wizard` (`skippable`, `persistStepInQueryString`).
+- Step definitions per register in the `...ResourceFormSchemas.php` files; conditional fields via toggles + `FormHelper::isFieldEnabled(...)`.
+- Users switch steps-vs-one-page via a `register_layout` preference on the same schema.

--- a/tickets/entities/tickets/TKT-CHLAJ.md
+++ b/tickets/entities/tickets/TKT-CHLAJ.md
@@ -5,7 +5,7 @@ title: Multi-step (wizard) forms with conditional steps
 kind: enhancement
 priority: medium
 effort: m
-status: in-progress
+status: review
 ---
 
 Add an optional wizard layout to the data-entry form config. A form can declare

--- a/tickets/entities/tickets/TKT-CHLAJ.md
+++ b/tickets/entities/tickets/TKT-CHLAJ.md
@@ -5,7 +5,7 @@ title: Multi-step (wizard) forms with conditional steps
 kind: enhancement
 priority: medium
 effort: m
-status: review
+status: done
 ---
 
 Add an optional wizard layout to the data-entry form config. A form can declare

--- a/tickets/relations/FEAT-LOCB0--requires--data-entry-ui.md
+++ b/tickets/relations/FEAT-LOCB0--requires--data-entry-ui.md
@@ -1,0 +1,5 @@
+---
+from: FEAT-LOCB0
+relation: requires
+to: data-entry-ui
+---

--- a/tickets/relations/TKT-CHLAJ--affects--data-entry-ui.md
+++ b/tickets/relations/TKT-CHLAJ--affects--data-entry-ui.md
@@ -1,0 +1,5 @@
+---
+from: TKT-CHLAJ
+relation: affects
+to: data-entry-ui
+---

--- a/tickets/relations/TKT-CHLAJ--depends-on--TKT-BL7XZ.md
+++ b/tickets/relations/TKT-CHLAJ--depends-on--TKT-BL7XZ.md
@@ -1,0 +1,5 @@
+---
+from: TKT-CHLAJ
+relation: depends-on
+to: TKT-BL7XZ
+---

--- a/tickets/relations/TKT-CHLAJ--has-docs--DOCS-X43XD.md
+++ b/tickets/relations/TKT-CHLAJ--has-docs--DOCS-X43XD.md
@@ -1,0 +1,5 @@
+---
+from: TKT-CHLAJ
+relation: has-docs
+to: DOCS-X43XD
+---

--- a/tickets/relations/TKT-CHLAJ--has-implementation--IMPL-2BYV8.md
+++ b/tickets/relations/TKT-CHLAJ--has-implementation--IMPL-2BYV8.md
@@ -1,0 +1,5 @@
+---
+from: TKT-CHLAJ
+relation: has-implementation
+to: IMPL-2BYV8
+---

--- a/tickets/relations/TKT-CHLAJ--has-planning--PLAN-QBFTB.md
+++ b/tickets/relations/TKT-CHLAJ--has-planning--PLAN-QBFTB.md
@@ -1,0 +1,5 @@
+---
+from: TKT-CHLAJ
+relation: has-planning
+to: PLAN-QBFTB
+---

--- a/tickets/relations/TKT-CHLAJ--has-review--REV-3TYCT.md
+++ b/tickets/relations/TKT-CHLAJ--has-review--REV-3TYCT.md
@@ -1,0 +1,5 @@
+---
+from: TKT-CHLAJ
+relation: has-review
+to: REV-3TYCT
+---

--- a/tickets/relations/TKT-CHLAJ--has-review-response--RR-8SXTZ.md
+++ b/tickets/relations/TKT-CHLAJ--has-review-response--RR-8SXTZ.md
@@ -1,0 +1,5 @@
+---
+from: TKT-CHLAJ
+relation: has-review-response
+to: RR-8SXTZ
+---

--- a/tickets/relations/TKT-CHLAJ--has-review-response--RR-ERCH9.md
+++ b/tickets/relations/TKT-CHLAJ--has-review-response--RR-ERCH9.md
@@ -1,0 +1,5 @@
+---
+from: TKT-CHLAJ
+relation: has-review-response
+to: RR-ERCH9
+---

--- a/tickets/relations/TKT-CHLAJ--has-review-response--RR-HMWK7.md
+++ b/tickets/relations/TKT-CHLAJ--has-review-response--RR-HMWK7.md
@@ -1,0 +1,5 @@
+---
+from: TKT-CHLAJ
+relation: has-review-response
+to: RR-HMWK7
+---

--- a/tickets/relations/TKT-CHLAJ--has-review-response--RR-JBQAC.md
+++ b/tickets/relations/TKT-CHLAJ--has-review-response--RR-JBQAC.md
@@ -1,0 +1,5 @@
+---
+from: TKT-CHLAJ
+relation: has-review-response
+to: RR-JBQAC
+---

--- a/tickets/relations/TKT-CHLAJ--has-review-response--RR-JNNN6.md
+++ b/tickets/relations/TKT-CHLAJ--has-review-response--RR-JNNN6.md
@@ -1,0 +1,5 @@
+---
+from: TKT-CHLAJ
+relation: has-review-response
+to: RR-JNNN6
+---

--- a/tickets/relations/TKT-CHLAJ--has-review-response--RR-O4SRG.md
+++ b/tickets/relations/TKT-CHLAJ--has-review-response--RR-O4SRG.md
@@ -1,0 +1,5 @@
+---
+from: TKT-CHLAJ
+relation: has-review-response
+to: RR-O4SRG
+---

--- a/tickets/relations/TKT-CHLAJ--has-review-response--RR-YKAS8.md
+++ b/tickets/relations/TKT-CHLAJ--has-review-response--RR-YKAS8.md
@@ -1,0 +1,5 @@
+---
+from: TKT-CHLAJ
+relation: has-review-response
+to: RR-YKAS8
+---

--- a/tickets/relations/TKT-CHLAJ--implements--FEAT-LOCB0.md
+++ b/tickets/relations/TKT-CHLAJ--implements--FEAT-LOCB0.md
@@ -1,0 +1,5 @@
+---
+from: TKT-CHLAJ
+relation: implements
+to: FEAT-LOCB0
+---


### PR DESCRIPTION
## What

An optional **wizard layout** for data-entry forms. A form declares `steps:` instead of top-level `fields:`/`relations:`; the SPA then renders one step at a time with a stepper + Back/Next, per-step validation, and conditional visibility.

```yaml
forms:
  new_processing_record:
    entity_type: processing-record
    steps:
      - title: Controller
        fields: [{ property: controller_name }, { property: has_processors, widget: checkbox }]
      - title: Processor
        visible_when: "form.has_processors == true"
        fields: [{ property: processor_name, required_when: "form.has_processors == true" }]
      - title: Publish
        fields: [{ property: published }]
```

Consumes the shared condition engine merged in #1137. Builds on the GDPR-processing-register motivating case (OpenVWR).

## Acceptance criteria (all verified by e2e)

1. Ordered, titled steps. ✅
2. Show/hide + required-ness driven by an earlier field (`visible_when` / `required_when`). ✅
3. Next/back; per-step validation gates Next; full validation on submit. ✅
4. Current step in the URL (`?step=N`), refresh/deep-link safe. ✅
5. Single-page forms unchanged; wizard is opt-in. ✅

## Implementation

- **Go** (`internal/dataentryconfig`): `Form.Steps` + `visible_when`/`required_when` on step/field/relation; `validateForms` enforces steps-xor-flat and reuses per-field/relation checks per step; `handleV1Config` resolves relation widgets across steps.
- **Frontend**: `useFormWizard` composable (visible-step filtering, `isFieldRequired`, `activeProperties`/`managedProperties`, `?step=` URL sync mirroring `useUrlFilterSync`); `DynamicForm` wizard branch; `FormFieldList` extracted so single-page and wizard render fields through one path. Hidden-branch values are dropped from the submitted payload.
- **CLI lint** (`internal/conditionlint`): `rela validate` catches condition parse errors + unknown `form.<field>` references at author time, reusing the Go `predicate` parser (documented stricter superset).
- **Docs**: `docs/data-entry.md` "Multi-step (wizard) forms" section.

## Testing

- Go: `dataentryconfig` (wizard validation) + `conditionlint` unit tests; `go build ./...`, `just arch-lint`, `just plimsoll` clean.
- Frontend: 1323 unit tests (incl. 13 `useFormWizard` + condition-engine reactivity fix).
- e2e: `wizard.spec.ts` — 7 tests covering every AC plus reveal→fill→hide→submit hidden-branch pruning.

## Review

Went through design-review (on the engine dependency) and `/code-review` via cranky-code-reviewer. **1 critical** (hidden-branch pruning bypassed on the create path), **3 significant**, **3 minor** — all fixed with regression tests. Two real bugs the review/e2e caught: the create-path payload leak, and a condition-engine reactivity gap (absent-key reads weren't tracked). Tracked as TKT-CHLAJ.