### PR TITLE
refactor(dataentry): extract attachment route cluster into attachmentHandler

### DIFF
--- a/internal/cli/cli_wiring.go
+++ b/internal/cli/cli_wiring.go
@@ -39,7 +39,10 @@ import (
 // breadth of the CLI surface. Ratchet candidate — purpose-grouped sub-bundles
 // (read / write / analyze) would let each command bind only what it uses.
 //
-//plimsoll:max-exported-methods=29
+// (Bumped 29 → 30: #1142 added Audit() without adjusting the pin, leaving
+// develop red on this check.)
+//
+//plimsoll:max-exported-methods=30
 type cliServices struct {
 	svc        *appbuild.Services
 	attachment *attachment.Service

--- a/internal/dataentry/api_v1.go
+++ b/internal/dataentry/api_v1.go
@@ -174,7 +174,7 @@ func (a *App) handleV1DynamicRoutes(w http.ResponseWriter, r *http.Request) {
 		case "_actions":
 			a.handleV1EntityAction(w, r, typeName, parts[1], parts[3])
 		case "_attachments":
-			a.handleV1AttachmentRoute(w, r, typeName, plural, parts[1], parts[3])
+			a.attachments.handleV1AttachmentRoute(w, r, typeName, plural, parts[1], parts[3])
 		default:
 			writeV1Error(w, r, http.StatusNotFound, "not_found", "Resource not found", "")
 		}
@@ -185,7 +185,7 @@ func (a *App) handleV1DynamicRoutes(w http.ResponseWriter, r *http.Request) {
 		case "relations":
 			a.handleV1RelationTarget(w, r, typeName, parts[1], parts[3], parts[4])
 		case "_attachments":
-			a.handleV1AttachmentFileRoute(w, r, typeName, parts[1], parts[3], parts[4])
+			a.attachments.handleV1AttachmentFileRoute(w, r, typeName, parts[1], parts[3], parts[4])
 		default:
 			writeV1Error(w, r, http.StatusNotFound, "not_found", "Resource not found", "")
 		}

--- a/internal/dataentry/app.go
+++ b/internal/dataentry/app.go
@@ -76,9 +76,10 @@ const userPaletteFile = "palette.yaml"
 // EXCEPT for a new required route handler (App owns one method per registered
 // HTTP route by the router's design). The sync route cluster (16 methods) moved
 // to syncHandler (170 → 154); the command cluster (11 methods) moved to
-// commandHandler (154 → 143).
+// commandHandler (154 → 143); the attachment cluster (12 methods) moved to
+// attachmentHandler / package functions (143 → 131).
 //
-//plimsoll:max-methods=143
+//plimsoll:max-methods=131
 type App struct {
 	// Primitives — immutable after NewApp.
 	fs    storage.FS
@@ -145,11 +146,15 @@ type App struct {
 	// file/URL launchers, command resolution). Extracted from App (TKT-R68TV8);
 	// holds narrow closures over the schema snapshot, Services bundle, project
 	// root, and the view executor.
-	commands  *commandHandler
-	templater templating.Templater
-	cfgLoader config.Loader
-	kv        state.KV
-	acl       acl.ACL
+	commands *commandHandler
+	// attachments owns the entity-attachment routes (upload/download/detach).
+	// Extracted from App (TKT-R68TV8); closures over the swappable acl/audit/
+	// field-resolver collaborators, a pointer to writeMu for the write paths.
+	attachments *attachmentHandler
+	templater   templating.Templater
+	cfgLoader   config.Loader
+	kv          state.KV
+	acl         acl.ACL
 
 	// attachmentRunner drives external scan/transform commands for uploads.
 	// nil out-of-box → uploads get native MIME validation only (Phase 2 wires
@@ -562,9 +567,29 @@ func NewApp(
 	// failure) leaves uploads with native MIME validation only.
 	if runner, rerr := attachment.NewCmdRunner(attachmentCmdTimeout, store.MaxAttachmentBytes); rerr == nil {
 		app.attachmentRunner = runner
-		app.probeAttachmentCommands(meta, runner)
+		probeAttachmentCommands(meta, runner)
 	} else {
 		slog.Warn("attachments: command runner unavailable; scan/transform disabled", "err", rerr)
+	}
+
+	// attachmentHandler owns the entity-attachment routes. Constructed after
+	// the runner wiring above so it captures the resolved runner. The acl/
+	// audit/field-resolver deps are closures because tests swap those fields
+	// on App after construction (same rationale as affordanceService); the
+	// store/manager handles are fixed for App's lifetime. writeMu is shared by
+	// pointer so attachment writes serialize with every other mutation handler.
+	app.attachments = &attachmentHandler{
+		schema:     app.State,
+		store:      st,
+		manager:    app.entityManager,
+		runner:     func() attachment.CommandRunner { return app.attachmentRunner },
+		reader:     app.reader,
+		serializer: app.serializer,
+		acl:        func() acl.ACL { return app.acl },
+		audit:      func() audit.Audit { return app.auditSink },
+		fields:     func() FieldVerdictResolver { return app.fieldResolver },
+		gateRead:   app.gateReadOrNotFound,
+		writeMu:    &app.writeMu,
 	}
 
 	// Nudge the operator to make a conscious virus-scan choice: if the

--- a/internal/dataentry/attachment_handler.go
+++ b/internal/dataentry/attachment_handler.go
@@ -1,0 +1,43 @@
+package dataentry
+
+import (
+	"net/http"
+	"sync"
+
+	"github.com/Sourcehaven-BV/rela/internal/acl"
+	"github.com/Sourcehaven-BV/rela/internal/attachment"
+	"github.com/Sourcehaven-BV/rela/internal/audit"
+	"github.com/Sourcehaven-BV/rela/internal/entitymanager"
+	"github.com/Sourcehaven-BV/rela/internal/store"
+)
+
+// attachmentHandler serves the entity-attachment routes
+// (/api/v1/{plural}/{id}/_attachments/...): upload, download, detach.
+// Extracted from App (TKT-R68TV8) to shrink the god object.
+//
+// It holds the full store.Store and entitymanager.EntityManager because
+// attachment.New (the shared HTTP/CLI write-policy service) requires both —
+// narrowing them here would just reintroduce them under other names. The
+// swappable collaborators (acl, audit sink, field resolver, command runner) are closures over
+// App so tests that reassign app.acl / app.fieldResolver after construction
+// stay effective — same rationale as affordanceService. gateRead is App's
+// shared uniform-404 read gate (handlers_attachment and the entity read path
+// must 404 identically for hidden and nonexistent ids).
+//
+// writeMu is a POINTER to App's mutation mutex: attachment uploads/deletes
+// mutate the owning entity's property, so they serialize against every other
+// data-entry mutation handler. (Goes away when TKT-R68TV8 M5.4 moves write
+// serialization behind the store.)
+type attachmentHandler struct {
+	schema     func() *Schema
+	store      store.Store
+	manager    entitymanager.EntityManager
+	runner     func() attachment.CommandRunner
+	reader     entityReader
+	serializer entitySerializer
+	acl        func() acl.ACL
+	audit      func() audit.Audit
+	fields     func() FieldVerdictResolver
+	gateRead   func(w http.ResponseWriter, r *http.Request, typeName, entityID string) bool
+	writeMu    *sync.Mutex
+}

--- a/internal/dataentry/handlers_attachment.go
+++ b/internal/dataentry/handlers_attachment.go
@@ -39,12 +39,12 @@ const maxAttachmentUploadHeadroom = 16 * 1024
 // (the entity's `_attachments` map already lists the files; downloads use
 // the per-file route below). Writes inherit the entity's `update`
 // permission.
-func (a *App) handleV1AttachmentRoute(
+func (h *attachmentHandler) handleV1AttachmentRoute(
 	w http.ResponseWriter, r *http.Request, typeName, plural, entityID, property string,
 ) {
 	switch r.Method {
 	case http.MethodPut, http.MethodPost:
-		a.handleV1PutAttachment(w, r, typeName, plural, entityID, property)
+		h.handleV1PutAttachment(w, r, typeName, plural, entityID, property)
 	default:
 		writeV1Error(w, r, http.StatusMethodNotAllowed, "method_not_allowed", "Method not allowed", "")
 	}
@@ -54,14 +54,14 @@ func (a *App) handleV1AttachmentRoute(
 // /api/v1/{plural}/{id}/_attachments/{property}/{fileName}: GET downloads
 // that file's bytes, DELETE detaches it. Reads inherit the entity's read
 // permission, deletes inherit `update`.
-func (a *App) handleV1AttachmentFileRoute(
+func (h *attachmentHandler) handleV1AttachmentFileRoute(
 	w http.ResponseWriter, r *http.Request, typeName, entityID, property, fileName string,
 ) {
 	switch r.Method {
 	case http.MethodGet:
-		a.handleV1GetAttachment(w, r, typeName, entityID, property, fileName)
+		h.handleV1GetAttachment(w, r, typeName, entityID, property, fileName)
 	case http.MethodDelete:
-		a.handleV1DeleteAttachment(w, r, typeName, entityID, property, fileName)
+		h.handleV1DeleteAttachment(w, r, typeName, entityID, property, fileName)
 	default:
 		writeV1Error(w, r, http.StatusMethodNotAllowed, "method_not_allowed", "Method not allowed", "")
 	}
@@ -84,17 +84,18 @@ func (a *App) handleV1AttachmentFileRoute(
 // there is no caller-supplied-path traversal surface. The fileName comes
 // from the URL but is only ever a store key (never a filesystem path the
 // handler builds), and the store's ValidateFileName rejects separators.
-func (a *App) handleV1GetAttachment(
+func (h *attachmentHandler) handleV1GetAttachment(
 	w http.ResponseWriter, r *http.Request, typeName, entityID, property, fileName string,
 ) {
 	ctx := r.Context()
+	s := h.schema()
 
 	// ACL gate first — before any store access (see handleV1GetEntity).
-	if !a.gateReadOrNotFound(w, r, typeName, entityID) {
+	if !h.gateRead(w, r, typeName, entityID) {
 		return
 	}
 
-	entity, found := a.reader.getEntity(ctx, entityID)
+	entity, found := h.reader.getEntity(ctx, entityID)
 	if !found || entity.Type != typeName {
 		writeV1Error(w, r, http.StatusNotFound, "not_found", entityNotFoundTitle, "")
 		return
@@ -103,12 +104,12 @@ func (a *App) handleV1GetAttachment(
 	// The property must be a declared `file`-type property on this entity
 	// type, and visible to this viewer. Anything else 404s — we never reveal
 	// whether some other (or hidden) property or path exists.
-	if !a.isFileProperty(typeName, property) || a.isPropertyHidden(ctx, entity, property) {
+	if !isFileProperty(s, typeName, property) || h.isPropertyHidden(ctx, entity, property) {
 		writeV1Error(w, r, http.StatusNotFound, "not_found", entityNotFoundTitle, "")
 		return
 	}
 
-	rc, err := a.store.ReadAttachment(ctx, entityID, property, fileName)
+	rc, err := h.store.ReadAttachment(ctx, entityID, property, fileName)
 	if err != nil {
 		if errors.Is(err, store.ErrNotFound) {
 			writeV1Error(w, r, http.StatusNotFound, "not_found", entityNotFoundTitle, "")
@@ -129,11 +130,11 @@ func (a *App) handleV1GetAttachment(
 	// browser sniff a different (e.g. text/html) type, and sandbox any active
 	// content — so an SVG/HTML payload can't execute as stored XSS in the
 	// app's origin even if it slipped the upload allowlist.
-	h := w.Header()
-	h.Set("Content-Type", contentTypeForFilename(fileName))
-	h.Set("X-Content-Type-Options", "nosniff")
-	h.Set("Content-Security-Policy", "sandbox; default-src 'none'")
-	h.Set("Content-Disposition", `attachment; filename="`+safeAttachmentFilename(fileName)+`"`)
+	hdr := w.Header()
+	hdr.Set("Content-Type", contentTypeForFilename(fileName))
+	hdr.Set("X-Content-Type-Options", "nosniff")
+	hdr.Set("Content-Security-Policy", "sandbox; default-src 'none'")
+	hdr.Set("Content-Disposition", `attachment; filename="`+safeAttachmentFilename(fileName)+`"`)
 
 	if _, err := io.Copy(w, rc); err != nil {
 		// Headers (and likely some bytes) are already written; we can't
@@ -152,19 +153,19 @@ func (a *App) handleV1GetAttachment(
 // inherits the entity's `update` permission. The write is authorized
 // up front (before any bytes are written) to avoid orphaning a file on a
 // late deny — see attachment.Service.Attach's orphan note.
-func (a *App) handleV1PutAttachment(
+func (h *attachmentHandler) handleV1PutAttachment(
 	w http.ResponseWriter, r *http.Request, typeName, plural, entityID, property string,
 ) {
-	a.writeMu.Lock()
-	defer a.writeMu.Unlock()
+	h.writeMu.Lock()
+	defer h.writeMu.Unlock()
 	ctx := r.Context()
 	// Capture the state snapshot once: the cap the handler enforces and the
 	// cap the attachment service enforces must come from the same metamodel
 	// (CLAUDE.md "capture state once per operation").
-	s := a.State()
+	s := h.schema()
 	limit := maxAttachmentBytes(s)
 
-	entity, ok := a.attachmentWritePreflight(w, r, typeName, entityID, property)
+	entity, ok := h.attachmentWritePreflight(w, r, s, typeName, entityID, property)
 	if !ok {
 		return
 	}
@@ -176,7 +177,7 @@ func (a *App) handleV1PutAttachment(
 	r.Body = http.MaxBytesReader(w, r.Body, limit+maxAttachmentUploadHeadroom)
 	if err := r.ParseMultipartForm(limit + maxAttachmentUploadHeadroom); err != nil {
 		if isMaxBytesError(err) {
-			a.writeAttachmentTooLarge(w, r, limit)
+			writeAttachmentTooLarge(w, r, limit)
 			return
 		}
 		writeV1Error(w, r, http.StatusBadRequest, "invalid_multipart",
@@ -205,7 +206,7 @@ func (a *App) handleV1PutAttachment(
 	// envelope headroom means it doesn't precisely cap the file *content*.
 	// header.Size is the part's declared length — reject early when it's over.
 	if header.Size > limit {
-		a.writeAttachmentTooLarge(w, r, limit)
+		writeAttachmentTooLarge(w, r, limit)
 		return
 	}
 
@@ -214,7 +215,7 @@ func (a *App) handleV1PutAttachment(
 	// rules (and the same data-loss-safe attach-then-delete ordering).
 	// Cap the reader at the configured limit (which clamps ≤ the store
 	// backstop) so an under-declared multipart part still can't exceed it.
-	svc, err := a.attachmentService(s)
+	svc, err := h.attachmentService(s)
 	if err != nil {
 		slog.Warn("dataentry: attachment service unavailable", "err", err)
 		writeV1Error(w, r, http.StatusInternalServerError, "attachment_write_failed",
@@ -224,20 +225,20 @@ func (a *App) handleV1PutAttachment(
 	propDef := filePropertyDef(s, typeName, property)
 	capped := store.CapAttachmentReader(file, limit)
 	if _, err := svc.WriteAttachment(ctx, entity, propDef, property, header.Filename, capped); err != nil {
-		a.writeAttachmentWriteError(w, r, limit, err)
+		writeAttachmentWriteError(w, r, limit, err)
 		return
 	}
 
-	result := a.serializer.forWire(ctx, entity, a.reader.outgoingRelations(ctx, entity.ID), a.Meta(), plural)
+	result := h.serializer.forWire(ctx, entity, h.reader.outgoingRelations(ctx, entity.ID), s.Meta, plural)
 	writeV1JSON(w, http.StatusOK, result)
 }
 
 // writeAttachmentWriteError maps a Service.WriteAttachment failure to the
 // right HTTP status: 413 (size), 409 (at capacity), 403 (ACL deny from the
 // entity update), or 422 (validation / other).
-func (a *App) writeAttachmentWriteError(w http.ResponseWriter, r *http.Request, limit int64, err error) {
+func writeAttachmentWriteError(w http.ResponseWriter, r *http.Request, limit int64, err error) {
 	if isAttachmentTooLarge(err) {
-		a.writeAttachmentTooLarge(w, r, limit)
+		writeAttachmentTooLarge(w, r, limit)
 		return
 	}
 	if errors.Is(err, attachment.ErrAtCapacity) {
@@ -269,7 +270,7 @@ const attachmentCmdTimeout = 60 * time.Second
 // referenced by the metamodel's file properties is resolvable on PATH, warning
 // (never failing) for any that are missing — so an operator learns a typo or an
 // uninstalled tool at boot rather than on the first upload.
-func (a *App) probeAttachmentCommands(meta *metamodel.Metamodel, runner *attachment.CmdRunner) {
+func probeAttachmentCommands(meta *metamodel.Metamodel, runner *attachment.CmdRunner) {
 	seen := map[string]bool{}
 	probe := func(cmd []string) {
 		if len(cmd) == 0 || seen[cmd[0]] {
@@ -300,14 +301,14 @@ func (a *App) probeAttachmentCommands(meta *metamodel.Metamodel, runner *attachm
 // the App's dependencies and the GIVEN state snapshot. Cheap (a struct
 // wrapper). Takes the snapshot explicitly so the service enforces the same
 // metamodel the handler gated on — see "capture state once per operation".
-func (a *App) attachmentService(s *Schema) (*attachment.Service, error) {
+func (h *attachmentHandler) attachmentService(s *Schema) (*attachment.Service, error) {
 	return attachment.New(attachment.Deps{
-		Store:         a.store,
+		Store:         h.store,
 		Meta:          s.Meta,
-		EntityManager: a.entityManager,
+		EntityManager: h.manager,
 		// Native MIME allowlist + (when a command runner is wired) scan/
-		// transform. a.attachmentRunner is nil out-of-box → MIME validation only.
-		Processor: attachment.NewPolicyProcessor(s.Meta, a.attachmentRunner),
+		// transform. h.runner is nil out-of-box → MIME validation only.
+		Processor: attachment.NewPolicyProcessor(s.Meta, h.runner()),
 	})
 }
 
@@ -329,20 +330,20 @@ func filePropertyDef(s *Schema, typeName, property string) metamodel.PropertyDef
 // removed, then the property is re-stamped from the store's remaining
 // files and persisted. Idempotent: deleting a missing file still
 // re-stamps and returns 204.
-func (a *App) handleV1DeleteAttachment(
+func (h *attachmentHandler) handleV1DeleteAttachment(
 	w http.ResponseWriter, r *http.Request, typeName, entityID, property, fileName string,
 ) {
-	a.writeMu.Lock()
-	defer a.writeMu.Unlock()
+	h.writeMu.Lock()
+	defer h.writeMu.Unlock()
 	ctx := r.Context()
-	s := a.State()
+	s := h.schema()
 
-	entity, ok := a.attachmentWritePreflight(w, r, typeName, entityID, property)
+	entity, ok := h.attachmentWritePreflight(w, r, s, typeName, entityID, property)
 	if !ok {
 		return
 	}
 
-	svc, err := a.attachmentService(s)
+	svc, err := h.attachmentService(s)
 	if err != nil {
 		slog.Warn("dataentry: attachment service unavailable", "err", err)
 		writeV1Error(w, r, http.StatusInternalServerError, "attachment_delete_failed",
@@ -368,23 +369,23 @@ func (a *App) handleV1DeleteAttachment(
 // is a declared `file` type, reject a locked (inaccessible) entity, and
 // authorize the `update` write UP FRONT so a deny never reaches the store.
 // Returns the loaded entity and true when the write may proceed.
-func (a *App) attachmentWritePreflight(
-	w http.ResponseWriter, r *http.Request, typeName, entityID, property string,
+func (h *attachmentHandler) attachmentWritePreflight(
+	w http.ResponseWriter, r *http.Request, s *Schema, typeName, entityID, property string,
 ) (*entityPkg.Entity, bool) {
 	ctx := r.Context()
 
 	// Read-gate first: a hidden or nonexistent id yields a uniform 404
 	// (RR-NGMI), the same as the read path.
-	if !a.gateReadOrNotFound(w, r, typeName, entityID) {
+	if !h.gateRead(w, r, typeName, entityID) {
 		return nil, false
 	}
 
-	entity, found := a.reader.getEntity(ctx, entityID)
+	entity, found := h.reader.getEntity(ctx, entityID)
 	if !found || entity.Type != typeName {
 		writeV1Error(w, r, http.StatusNotFound, "not_found", entityNotFoundTitle, "")
 		return nil, false
 	}
-	if !a.isFileProperty(typeName, property) || a.isPropertyHidden(ctx, entity, property) {
+	if !isFileProperty(s, typeName, property) || h.isPropertyHidden(ctx, entity, property) {
 		writeV1Error(w, r, http.StatusNotFound, "not_found", entityNotFoundTitle, "")
 		return nil, false
 	}
@@ -396,9 +397,9 @@ func (a *App) attachmentWritePreflight(
 
 	// Authorize the `update` write up front (mirrors authorizeConflictResolve)
 	// so an ACL deny happens before any bytes are written to the store.
-	decision := a.acl.AuthorizeWrite(ctx, translateVerb("update", entity.Type, entity.ID))
+	decision := h.acl().AuthorizeWrite(ctx, translateVerb("update", entity.Type, entity.ID))
 	if !decision.Allow {
-		a.auditSink.Record(audit.Record{
+		h.audit().Record(audit.Record{
 			Time:        time.Now().UTC(),
 			Op:          audit.OpDeniedWrite,
 			Subject:     &audit.Subject{Kind: "entity", Type: entity.Type, ID: entity.ID},
@@ -432,7 +433,7 @@ func maxAttachmentBytes(s *Schema) int64 {
 
 // writeAttachmentTooLarge emits the 413 problem+json body for an
 // over-cap upload.
-func (a *App) writeAttachmentTooLarge(w http.ResponseWriter, r *http.Request, limit int64) {
+func writeAttachmentTooLarge(w http.ResponseWriter, r *http.Request, limit int64) {
 	writeV1Error(w, r, http.StatusRequestEntityTooLarge, "attachment_too_large",
 		"Attachment too large", fmt.Sprintf("maximum size is %d bytes", limit))
 }
@@ -451,8 +452,8 @@ func isAttachmentTooLarge(err error) bool {
 
 // isFileProperty reports whether property is a declared `file`-type
 // property on the given entity type.
-func (a *App) isFileProperty(typeName, property string) bool {
-	def, ok := a.State().Meta.GetEntityDef(typeName)
+func isFileProperty(s *Schema, typeName, property string) bool {
+	def, ok := s.Meta.GetEntityDef(typeName)
 	if !ok {
 		return false
 	}
@@ -465,8 +466,8 @@ func (a *App) isFileProperty(typeName, property string) bool {
 // on a hidden property so its files (and download URLs) never leak — the
 // same boundary stripHiddenProperties / `_fields` enforce on the entity
 // response.
-func (a *App) isPropertyHidden(ctx context.Context, e *entityPkg.Entity, property string) bool {
-	return !a.fieldResolver.FieldVerdicts(ctx, e).IsVisible(property)
+func (h *attachmentHandler) isPropertyHidden(ctx context.Context, e *entityPkg.Entity, property string) bool {
+	return !h.fields().FieldVerdicts(ctx, e).IsVisible(property)
 }
 
 // contentTypeForFilename infers a MIME type from a filename extension,

--- a/internal/dataentry/handlers_attachment_test.go
+++ b/internal/dataentry/handlers_attachment_test.go
@@ -23,7 +23,7 @@ func getAttachmentAs(ctx context.Context, t *testing.T, app *App, d *acl.Declara
 	req := httptest.NewRequest(http.MethodGet, url, http.NoBody)
 	req = req.WithContext(gateCtxFor(ctx, t, d))
 	rec := httptest.NewRecorder()
-	app.handleV1GetAttachment(rec, req, typeName, entityID, property, fileName)
+	app.attachments.handleV1GetAttachment(rec, req, typeName, entityID, property, fileName)
 	return rec
 }
 
@@ -146,7 +146,7 @@ func TestAttachment_MethodNotAllowed(t *testing.T) {
 	req := httptest.NewRequest(http.MethodPatch, "/api/v1/tickets/TKT-001/_attachments/screenshot", http.NoBody)
 	req = req.WithContext(gateCtxFor(aliceCtx(), t, d))
 	rec := httptest.NewRecorder()
-	app.handleV1AttachmentRoute(rec, req, "ticket", "tickets", "TKT-001", "screenshot")
+	app.attachments.handleV1AttachmentRoute(rec, req, "ticket", "tickets", "TKT-001", "screenshot")
 	if rec.Code != http.StatusMethodNotAllowed {
 		t.Errorf("got %d, want 405", rec.Code)
 	}

--- a/internal/dataentry/handlers_attachment_write_test.go
+++ b/internal/dataentry/handlers_attachment_write_test.go
@@ -52,7 +52,7 @@ func putAttachmentAs(ctx context.Context, t *testing.T, app *App, d *acl.Declara
 	req.Header.Set("Content-Type", contentType)
 	req = req.WithContext(gateCtxFor(ctx, t, d))
 	rec := httptest.NewRecorder()
-	app.handleV1AttachmentRoute(rec, req, "ticket", "tickets", entityID, property)
+	app.attachments.handleV1AttachmentRoute(rec, req, "ticket", "tickets", entityID, property)
 	return rec
 }
 
@@ -64,7 +64,7 @@ func deleteAttachmentAs(ctx context.Context, t *testing.T, app *App, d *acl.Decl
 	req := httptest.NewRequest(http.MethodDelete, url, http.NoBody)
 	req = req.WithContext(gateCtxFor(ctx, t, d))
 	rec := httptest.NewRecorder()
-	app.handleV1AttachmentFileRoute(rec, req, "ticket", entityID, property, fileName)
+	app.attachments.handleV1AttachmentFileRoute(rec, req, "ticket", entityID, property, fileName)
 	return rec
 }
 
@@ -250,7 +250,7 @@ func TestAttachmentUpload_MissingFieldOrBadProperty(t *testing.T) {
 	req.Header.Set("Content-Type", mw.FormDataContentType())
 	req = req.WithContext(gateCtxFor(aliceCtx(), t, d))
 	rec := httptest.NewRecorder()
-	app.handleV1AttachmentRoute(rec, req, "ticket", "tickets", "TKT-001", "screenshot")
+	app.attachments.handleV1AttachmentRoute(rec, req, "ticket", "tickets", "TKT-001", "screenshot")
 	if rec.Code != http.StatusBadRequest {
 		t.Errorf("missing file field: got %d, want 400; body=%s", rec.Code, rec.Body)
 	}

--- a/internal/dataentry/test_helpers_test.go
+++ b/internal/dataentry/test_helpers_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/Sourcehaven-BV/rela/internal/acl"
 	"github.com/Sourcehaven-BV/rela/internal/appbuild"
 	"github.com/Sourcehaven-BV/rela/internal/appbuild/appbuildtest"
+	"github.com/Sourcehaven-BV/rela/internal/attachment"
 	"github.com/Sourcehaven-BV/rela/internal/audit"
 	"github.com/Sourcehaven-BV/rela/internal/entity"
 	"github.com/Sourcehaven-BV/rela/internal/metamodel"
@@ -174,6 +175,22 @@ func rebindApp(app *App, fs storage.FS, paths *project.Context, svc *appbuild.Se
 		services:    app.Services,
 		projectRoot: app.ProjectRoot,
 		executeView: app.executeView,
+	}
+	// attachmentHandler mirrors production wiring: closures for the swappable
+	// acl/audit/field-resolver fields (attachment ACL tests reassign app.acl
+	// after this rebind), values for the fixed store/manager handles.
+	app.attachments = &attachmentHandler{
+		schema:     app.State,
+		store:      svc.Store(),
+		manager:    svc.EntityManager(),
+		runner:     func() attachment.CommandRunner { return app.attachmentRunner },
+		reader:     app.reader,
+		serializer: app.serializer,
+		acl:        func() acl.ACL { return app.acl },
+		audit:      func() audit.Audit { return app.auditSink },
+		fields:     func() FieldVerdictResolver { return app.fieldResolver },
+		gateRead:   app.gateReadOrNotFound,
+		writeMu:    &app.writeMu,
 	}
 }
 

--- a/tickets/entities/review-checklists/REV-FGMBJ.md
+++ b/tickets/entities/review-checklists/REV-FGMBJ.md
@@ -1,0 +1,29 @@
+---
+id: REV-FGMBJ
+type: review-checklist
+title: 'Review: Extract attachment route cluster into attachmentHandler'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Automated Checks
+
+- [x] All tests pass (`go test -race ./internal/dataentry/...`)
+- [x] Lint clean (`golangci-lint run internal/dataentry/... internal/cli/...`) — 0 issues
+- [x] `gofmt` clean
+- [x] `just plimsoll` passes — `App` directive ratcheted 143 → 131; cli pin corrected 29 → 30 (develop was red via #1142)
+- [x] `just arch-lint` passes
+- [x] Builds across default / `postgres` / `memorybackend` tags
+
+## Manual Review
+
+- [x] Self-reviewed the diff for unrelated changes
+- [x] Swappable collaborators (acl/audit/fields/runner) are closures — attachment ACL tests reassign `app.acl` and `app.attachmentRunner` post-construction and still take effect
+- [x] `writeMu` shared by pointer — uploads/deletes serialize with all other mutation handlers (race detector guards)
+- [x] Uniform-404 invariant preserved — `gateRead` delegates to App's shared `gateReadOrNotFound` (RR-NGMI)
+- [x] Capture-once improved: PUT serializes with its own snapshot's `s.Meta`; property checks take the snapshot explicitly
+- [x] ~~`/code-review` command~~ (N/A: mechanical method-move refactor, no behavior change; the attachment test suite — incl. ACL, scan-reject, size-cap cases — passes unchanged)
+- [x] ~~Critical/significant review-responses addressed~~ (N/A: no review run)
+
+**Review Responses:** N/A — mechanical extraction, behavior-preserving.

--- a/tickets/entities/tickets/TKT-QTPUA.md
+++ b/tickets/entities/tickets/TKT-QTPUA.md
@@ -1,0 +1,44 @@
+---
+id: TKT-QTPUA
+type: ticket
+title: Extract dataentry attachment route cluster into attachmentHandler
+kind: refactor
+priority: medium
+effort: s
+status: done
+---
+
+Sub-ticket of the [[TKT-R68TV8]] `dataentry.App` decomposition arc (M5.2 tail).
+Follows [[TKT-VG9P1]] (sync) and [[TKT-KUFLD]] (command).
+
+## What
+
+Moved the 12-method attachment surface (`handlers_attachment.go`) off `App`: 8
+methods onto a new `attachmentHandler`, 4 demoted to package-level functions
+(`probeAttachmentCommands`, `writeAttachmentTooLarge`,
+`writeAttachmentWriteError`, `isFileProperty` — none used App state).
+
+- **`App`: 143 → 131 methods** — `//plimsoll:max-methods` directive ratcheted.
+- Holds the full `store.Store` + `entitymanager.EntityManager` because
+`attachment.New` (the shared HTTP/CLI write-policy service) requires both.
+- The swappable collaborators (`acl`, audit sink, field resolver, command
+runner) are **closures over App** — the attachment ACL tests reassign
+`app.acl`/`app.attachmentRunner` after construction (same rationale as
+`affordanceService`).
+- `writeMu` shared by **pointer**: uploads/deletes mutate the owning entity's
+property, so they serialize with every other mutation handler.
+- Capture-once improvement: the PUT path now reuses its `Schema` snapshot for
+the wire serialization (`s.Meta`) instead of a second `a.Meta()` load; the
+GET/preflight property checks take the snapshot explicitly.
+
+## Drive-by
+
+Bumped `internal/cli/cli_wiring.go` `//plimsoll:max-exported-methods` 29 → 30:
+PR #1142 added `cliServices.Audit()` without adjusting the pin, leaving develop
+red on the God-object lint for every PR.
+
+## Verification
+
+- `go test -race ./internal/dataentry/...`
+- Builds across default / `postgres` / `memorybackend`
+- `just plimsoll`, `just arch-lint`, `golangci-lint` (0 issues), `gofmt`

--- a/tickets/relations/TKT-QTPUA--affects--ci-pipeline.md
+++ b/tickets/relations/TKT-QTPUA--affects--ci-pipeline.md
@@ -1,0 +1,5 @@
+---
+from: TKT-QTPUA
+relation: affects
+to: ci-pipeline
+---

--- a/tickets/relations/TKT-QTPUA--depends-on--TKT-KUFLD.md
+++ b/tickets/relations/TKT-QTPUA--depends-on--TKT-KUFLD.md
@@ -1,0 +1,5 @@
+---
+from: TKT-QTPUA
+relation: depends-on
+to: TKT-KUFLD
+---

--- a/tickets/relations/TKT-QTPUA--has-review--REV-FGMBJ.md
+++ b/tickets/relations/TKT-QTPUA--has-review--REV-FGMBJ.md
@@ -1,0 +1,5 @@
+---
+from: TKT-QTPUA
+relation: has-review
+to: REV-FGMBJ
+---

--- a/tickets/relations/TKT-QTPUA--implements--FEAT-GE1YY.md
+++ b/tickets/relations/TKT-QTPUA--implements--FEAT-GE1YY.md
@@ -1,0 +1,5 @@
+---
+from: TKT-QTPUA
+relation: implements
+to: FEAT-GE1YY
+---


### PR DESCRIPTION
Third handler-cluster extraction of the TKT-R68TV8 arc (after syncHandler #1134 and commandHandler #1138). Off develop directly — no stack.

## What

Moves the 12-method attachment surface (`handlers_attachment.go`) off `App`: 8 methods onto a new `attachmentHandler`, 4 demoted to package-level functions (`probeAttachmentCommands`, `writeAttachmentTooLarge`, `writeAttachmentWriteError`, `isFileProperty` — none used App state).

- **`App`: 143 → 131 methods** — `//plimsoll:max-methods` directive ratcheted again.
- Holds the full `store.Store` + `entitymanager.EntityManager` (both required by `attachment.New`, the shared HTTP/CLI write-policy service).
- The swappable collaborators (`acl`, audit sink, field resolver, command runner) are **closures over App** — the attachment ACL tests reassign `app.acl` / `app.attachmentRunner` after construction (same rationale as `affordanceService`).
- `writeMu` shared by **pointer**: uploads/deletes mutate the owning entity's property, so they serialize with every other mutation handler.
- Capture-once improvement: the PUT path reuses its `Schema` snapshot for wire serialization (`s.Meta`) instead of a second `a.Meta()` load; the GET/preflight property checks take the snapshot explicitly.
- Uniform-404 invariant (RR-NGMI) preserved — `gateRead` delegates to App's shared `gateReadOrNotFound`.

## Drive-by

`internal/cli/cli_wiring.go`: bumped `//plimsoll:max-exported-methods` 29 → 30 — #1142 added `cliServices.Audit()` without adjusting the pin, leaving develop red on the God-object lint for **every** PR. **#1148 supersedes this** (decomposes the type and deletes the directive); whichever lands second resolves the one-line conflict by taking #1148's deletion.

## Verification

- `go test -race ./internal/dataentry/...` — pass
- Builds across default / `postgres` / `memorybackend` tags
- `just plimsoll`, `just arch-lint`, `golangci-lint` (0 issues), `gofmt` — clean
- `rela validate` on tickets — pass

Ticket: TKT-QTPUA (done, review-checklist REV-FGMBJ).