### PR TITLE
feat(store): Tx write-transaction contract on store.Store (TKT-GXHI8)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,7 +18,13 @@
 - **No repository or transaction abstractions.** Depend directly on
   `store.Store`, `tracer.Tracer`, `search.Searcher`,
   `entitymanager.EntityManager`. The old `repo` and `tx` layers are gone
-  — do not reintroduce equivalents.
+  — do not reintroduce equivalents. The one sanctioned transaction seam
+  is `store.Store.Tx` itself (DEC-8UIL0): a contract ON the store with
+  per-backend meaning (fs/mem: write mutex, mutual exclusion only;
+  postgres: native transaction + advisory lock, rollback, events at
+  commit) — not a generic unit-of-work layer stacked above it. Don't
+  wrap `Tx` in a new abstraction, and don't do slow external I/O inside
+  a `Tx` callback.
 - **Capture state once per operation.** Call `ws.Snapshot()` (or the
   equivalent `appState.Load()`) at the top of every handler, command, MCP
   tool, or observer; reuse the returned value for every read in that

--- a/docs-project/entities/guides/GUIDE-postgres-backend.md
+++ b/docs-project/entities/guides/GUIDE-postgres-backend.md
@@ -113,6 +113,23 @@ What you need to know to run it:
 - Live updates cover **entity** create/update/delete. Relation and attachment
   edits are reflected on the next page load rather than pushed live.
 
+### Write transactions
+
+The store exposes a write-transaction contract (`store.Store.Tx`,
+DEC-8UIL0). On PostgreSQL a `Tx` callback runs inside one real database
+transaction, serialized **deployment-wide** by a transaction-scoped
+advisory lock (its own key, distinct from the migration and
+version-sweep locks): every process of the deployment executes write
+transactions one at a time. An error rolls the whole callback back —
+no rows, no cross-process NOTIFYs, and no in-process events are
+delivered (event fan-out is buffered until commit). On the filesystem
+backend the same contract degrades to a process-local write mutex with
+no rollback — acceptable for its single-user deployments.
+
+Because the advisory lock is deployment-wide, a slow transaction stalls
+every writer. Keep `Tx` callbacks short and never perform external I/O
+inside one.
+
 ## Version history (time machine)
 
 The PostgreSQL build automatically keeps a **content version history** of every

--- a/docs/postgres-backend.md
+++ b/docs/postgres-backend.md
@@ -107,6 +107,23 @@ What you need to know to run it:
 - Live updates cover **entity** create/update/delete. Relation and attachment
   edits are reflected on the next page load rather than pushed live.
 
+### Write transactions
+
+The store exposes a write-transaction contract (`store.Store.Tx`,
+DEC-8UIL0). On PostgreSQL a `Tx` callback runs inside one real database
+transaction, serialized **deployment-wide** by a transaction-scoped
+advisory lock (its own key, distinct from the migration and
+version-sweep locks): every process of the deployment executes write
+transactions one at a time. An error rolls the whole callback back —
+no rows, no cross-process NOTIFYs, and no in-process events are
+delivered (event fan-out is buffered until commit). On the filesystem
+backend the same contract degrades to a process-local write mutex with
+no rollback — acceptable for its single-user deployments.
+
+Because the advisory lock is deployment-wide, a slow transaction stalls
+every writer. Keep `Tx` callbacks short and never perform external I/O
+inside one.
+
 ## Version history (time machine)
 
 The PostgreSQL build automatically keeps a **content version history** of every

--- a/internal/store/fsstore/attachment.go
+++ b/internal/store/fsstore/attachment.go
@@ -33,7 +33,7 @@ func attachmentKey(entityID, property, fileName string) string {
 	return entityID + "/" + property + "/" + fileName
 }
 
-func (s *FSStore) AttachFile(_ context.Context, entityID, property, fileName string, r io.Reader) error {
+func (s *FSStore) attachFile(_ context.Context, entityID, property, fileName string, r io.Reader) error {
 	if err := storeutil.ValidateProperty(property); err != nil {
 		return err
 	}
@@ -134,7 +134,7 @@ func (s *FSStore) ReadAttachment(_ context.Context, entityID, property, fileName
 	return s.rooted.Open(fileKey)
 }
 
-func (s *FSStore) DeleteAttachment(_ context.Context, entityID, property, fileName string) error {
+func (s *FSStore) deleteAttachment(_ context.Context, entityID, property, fileName string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 

--- a/internal/store/fsstore/conformance_test.go
+++ b/internal/store/fsstore/conformance_test.go
@@ -75,3 +75,10 @@ func FuzzCloneNestedValues(f *testing.F) {
 func FuzzPropertyValuesTypeZoo(f *testing.F) {
 	storetest.FuzzPropertyValuesTypeZoo(f, fuzzFactory)
 }
+
+// TestTxStress runs the shared mixed-workload soak (watchdogged deadlock
+// detection + lost-update and pair-atomicity invariants) against fsstore.
+// Duration 2s by default; RELA_STRESS_SECONDS extends it for local shakes.
+func TestTxStress(t *testing.T) {
+	storetest.RunTxStressTest(t, factory)
+}

--- a/internal/store/fsstore/entity.go
+++ b/internal/store/fsstore/entity.go
@@ -199,7 +199,7 @@ func (s *FSStore) PropertyValues(_ context.Context, property string, limit int) 
 
 // --- EntityWriter ---
 
-func (s *FSStore) CreateEntity(_ context.Context, e *entity.Entity) error {
+func (s *FSStore) createEntity(_ context.Context, e *entity.Entity) error {
 	if err := storeutil.ValidateID(e.ID); err != nil {
 		return err
 	}
@@ -232,7 +232,7 @@ func (s *FSStore) CreateEntity(_ context.Context, e *entity.Entity) error {
 	return nil
 }
 
-func (s *FSStore) UpdateEntity(_ context.Context, e *entity.Entity) error {
+func (s *FSStore) updateEntity(_ context.Context, e *entity.Entity) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -267,7 +267,7 @@ func (s *FSStore) UpdateEntity(_ context.Context, e *entity.Entity) error {
 	return nil
 }
 
-func (s *FSStore) DeleteEntity(_ context.Context, id string, cascade bool) (*store.DeleteResult, error) {
+func (s *FSStore) deleteEntity(_ context.Context, id string, cascade bool) (*store.DeleteResult, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -364,7 +364,7 @@ func (s *FSStore) DeleteEntity(_ context.Context, id string, cascade bool) (*sto
 	return result, nil
 }
 
-func (s *FSStore) RenameEntity(_ context.Context, oldID, newID string) (*store.RenameResult, error) {
+func (s *FSStore) renameEntity(_ context.Context, oldID, newID string) (*store.RenameResult, error) {
 	if err := storeutil.ValidateID(newID); err != nil {
 		return nil, err
 	}

--- a/internal/store/fsstore/fsstore.go
+++ b/internal/store/fsstore/fsstore.go
@@ -95,17 +95,19 @@ type attachMeta struct {
 
 // FSStore is a filesystem-backed store implementation.
 //
-// TODO(TKT-N0IKN9): FSStore is over the 40-method load line (84 methods).
+// TODO(TKT-N0IKN9): FSStore is over the 40-method load line (95 methods).
 // Decompose; ratchet this number down as responsibilities move out.
+// (84 → 95 with the Tx contract, TKT-GXHI8: each write method split into
+// an exported txMu wrapper + unexported core so Tx callbacks can re-enter.)
 //
-// The exported surface (32) is mostly the mandated store.Store interface (~27
-// methods) plus the Formatter and watcher side-interfaces; consumers depend on
-// store.Store directly by design (see ./CLAUDE.md). Ratchet toward the
-// interface size as the non-interface public methods (FormatEntity/Relation,
-// Start/StopWatching) move to composed helpers.
+// The exported surface (33) is mostly the mandated store.Store interface (~28
+// methods incl. Tx) plus the Formatter and watcher side-interfaces; consumers
+// depend on store.Store directly by design (see ./CLAUDE.md). Ratchet toward
+// the interface size as the non-interface public methods
+// (FormatEntity/Relation, Start/StopWatching) move to composed helpers.
 //
-//plimsoll:max-methods=84
-//plimsoll:max-exported-methods=32
+//plimsoll:max-methods=95
+//plimsoll:max-exported-methods=33
 type FSStore struct {
 	// rooted is the validated-key I/O surface. Every read, write,
 	// directory op, and remove that operates on files under the
@@ -128,6 +130,12 @@ type FSStore struct {
 	attachKey    string
 	cacheKey     string
 	schemas      map[string]store.EntityTypeSchema
+
+	// txMu serializes an open Tx against ordinary writers: Tx holds it
+	// for the whole callback, every exported write method takes it
+	// briefly before mu (lock order: txMu → mu; see tx.go). Readers
+	// never take it.
+	txMu sync.Mutex
 
 	// in-memory index
 	mu            sync.RWMutex

--- a/internal/store/fsstore/relation.go
+++ b/internal/store/fsstore/relation.go
@@ -116,7 +116,7 @@ func (s *FSStore) CountRelations(_ context.Context, q store.RelationQuery) (int,
 
 // --- RelationWriter ---
 
-func (s *FSStore) CreateRelation(
+func (s *FSStore) createRelation(
 	_ context.Context, from, relType, to string, data *store.RelationData,
 ) (*entity.Relation, error) {
 	for _, id := range []string{from, to} {
@@ -166,7 +166,7 @@ func (s *FSStore) CreateRelation(
 	return r.Clone(), nil
 }
 
-func (s *FSStore) UpdateRelation(
+func (s *FSStore) updateRelation(
 	_ context.Context, from, relType, to string, data store.RelationData,
 ) (*entity.Relation, error) {
 	s.mu.Lock()
@@ -208,7 +208,7 @@ func (s *FSStore) UpdateRelation(
 	return r.Clone(), nil
 }
 
-func (s *FSStore) DeleteRelation(_ context.Context, from, relType, to string) error {
+func (s *FSStore) deleteRelation(_ context.Context, from, relType, to string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 

--- a/internal/store/fsstore/tx.go
+++ b/internal/store/fsstore/tx.go
@@ -1,0 +1,163 @@
+package fsstore
+
+import (
+	"context"
+	"io"
+
+	"github.com/Sourcehaven-BV/rela/internal/entity"
+	"github.com/Sourcehaven-BV/rela/internal/store"
+)
+
+// Tx and the txMu write serialization (store.Transactor, DEC-8UIL0).
+//
+// fsstore meets the Tx contract with the reduced single-user guarantees
+// the decision allows for filesystem deployments: mutual exclusion only.
+// Tx holds txMu for the whole callback; every exported write method
+// takes txMu briefly before doing its normal work, so an open Tx
+// excludes ordinary writers and vice versa. There is NO rollback (an
+// error from fn leaves earlier writes applied — the filesystem cannot
+// promise crash atomicity either) and events/observer notifications are
+// emitted inline per write, exactly as outside a Tx. The watcher's
+// reconciliation of external file edits is not excluded — hand edits
+// were never serialized against API writes.
+//
+// Go has no reentrant mutex (deliberately), so re-entrancy is
+// structural: fn receives a txStore view whose write methods call the
+// unexported cores directly, skipping txMu. Calling a write on the
+// OUTER store from inside fn deadlocks — use the view for everything.
+
+// Tx implements store.Transactor. See the package notes above for the
+// fsstore-specific (reduced) guarantees.
+func (s *FSStore) Tx(_ context.Context, fn func(store.Store) error) error {
+	s.txMu.Lock()
+	defer s.txMu.Unlock()
+	return fn(txStore{s})
+}
+
+// lockTx takes the Tx serialization lock and returns its release func,
+// letting the exported write wrappers stay one-liners.
+func (s *FSStore) lockTx() func() {
+	s.txMu.Lock()
+	return s.txMu.Unlock
+}
+
+// --- exported write API: serialize with any open Tx, then delegate ---
+
+// CreateEntity implements store.EntityWriter.
+// Returns store.ErrConflict if an entity with the same ID exists.
+func (s *FSStore) CreateEntity(ctx context.Context, e *entity.Entity) error {
+	defer s.lockTx()()
+	return s.createEntity(ctx, e)
+}
+
+// UpdateEntity implements store.EntityWriter.
+// Returns store.ErrNotFound if the entity does not exist.
+func (s *FSStore) UpdateEntity(ctx context.Context, e *entity.Entity) error {
+	defer s.lockTx()()
+	return s.updateEntity(ctx, e)
+}
+
+// DeleteEntity implements store.EntityWriter.
+// Returns store.ErrNotFound if the entity does not exist.
+func (s *FSStore) DeleteEntity(ctx context.Context, id string, cascade bool) (*store.DeleteResult, error) {
+	defer s.lockTx()()
+	return s.deleteEntity(ctx, id, cascade)
+}
+
+// RenameEntity implements store.EntityWriter.
+// Returns store.ErrNotFound if oldID is absent, store.ErrConflict if
+// newID exists.
+func (s *FSStore) RenameEntity(ctx context.Context, oldID, newID string) (*store.RenameResult, error) {
+	defer s.lockTx()()
+	return s.renameEntity(ctx, oldID, newID)
+}
+
+// CreateRelation implements store.RelationWriter.
+func (s *FSStore) CreateRelation(
+	ctx context.Context, from, relType, to string, data *store.RelationData,
+) (*entity.Relation, error) {
+	defer s.lockTx()()
+	return s.createRelation(ctx, from, relType, to, data)
+}
+
+// UpdateRelation implements store.RelationWriter.
+func (s *FSStore) UpdateRelation(
+	ctx context.Context, from, relType, to string, data store.RelationData,
+) (*entity.Relation, error) {
+	defer s.lockTx()()
+	return s.updateRelation(ctx, from, relType, to, data)
+}
+
+// DeleteRelation implements store.RelationWriter.
+func (s *FSStore) DeleteRelation(ctx context.Context, from, relType, to string) error {
+	defer s.lockTx()()
+	return s.deleteRelation(ctx, from, relType, to)
+}
+
+// AttachFile implements store.AttachmentManager.
+func (s *FSStore) AttachFile(ctx context.Context, entityID, property, fileName string, r io.Reader) error {
+	defer s.lockTx()()
+	return s.attachFile(ctx, entityID, property, fileName, r)
+}
+
+// DeleteAttachment implements store.AttachmentManager.
+func (s *FSStore) DeleteAttachment(ctx context.Context, entityID, property, fileName string) error {
+	defer s.lockTx()()
+	return s.deleteAttachment(ctx, entityID, property, fileName)
+}
+
+// --- transaction view ---
+
+// txStore is the view a Tx callback receives: write methods skip txMu
+// (the Tx already holds it) and call the cores directly; everything
+// else is promoted from the embedded *FSStore. A nested Tx joins the
+// open transaction.
+type txStore struct{ *FSStore }
+
+// interface check: the view must satisfy the full store.Store.
+var _ store.Store = txStore{}
+
+func (t txStore) CreateEntity(ctx context.Context, e *entity.Entity) error {
+	return t.createEntity(ctx, e)
+}
+
+func (t txStore) UpdateEntity(ctx context.Context, e *entity.Entity) error {
+	return t.updateEntity(ctx, e)
+}
+
+func (t txStore) DeleteEntity(ctx context.Context, id string, cascade bool) (*store.DeleteResult, error) {
+	return t.deleteEntity(ctx, id, cascade)
+}
+
+func (t txStore) RenameEntity(ctx context.Context, oldID, newID string) (*store.RenameResult, error) {
+	return t.renameEntity(ctx, oldID, newID)
+}
+
+func (t txStore) CreateRelation(
+	ctx context.Context, from, relType, to string, data *store.RelationData,
+) (*entity.Relation, error) {
+	return t.createRelation(ctx, from, relType, to, data)
+}
+
+func (t txStore) UpdateRelation(
+	ctx context.Context, from, relType, to string, data store.RelationData,
+) (*entity.Relation, error) {
+	return t.updateRelation(ctx, from, relType, to, data)
+}
+
+func (t txStore) DeleteRelation(ctx context.Context, from, relType, to string) error {
+	return t.deleteRelation(ctx, from, relType, to)
+}
+
+func (t txStore) AttachFile(ctx context.Context, entityID, property, fileName string, r io.Reader) error {
+	return t.attachFile(ctx, entityID, property, fileName, r)
+}
+
+func (t txStore) DeleteAttachment(ctx context.Context, entityID, property, fileName string) error {
+	return t.deleteAttachment(ctx, entityID, property, fileName)
+}
+
+// Tx on the view joins the open transaction.
+func (t txStore) Tx(_ context.Context, fn func(store.Store) error) error {
+	return fn(t)
+}

--- a/internal/store/memstore/conformance_test.go
+++ b/internal/store/memstore/conformance_test.go
@@ -65,3 +65,10 @@ func FuzzCloneNestedValues(f *testing.F) {
 func FuzzPropertyValuesTypeZoo(f *testing.F) {
 	storetest.FuzzPropertyValuesTypeZoo(f, fuzzFactory)
 }
+
+// TestTxStress runs the shared mixed-workload soak (watchdogged deadlock
+// detection + lost-update and pair-atomicity invariants) against memstore.
+// Duration 2s by default; RELA_STRESS_SECONDS extends it for local shakes.
+func TestTxStress(t *testing.T) {
+	storetest.RunTxStressTest(t, factory)
+}

--- a/internal/store/memstore/memstore.go
+++ b/internal/store/memstore/memstore.go
@@ -37,13 +37,25 @@ import (
 
 // MemStore is an in-memory store implementation.
 //
-// TODO(TKT-N0IKN9): the exported surface (27) is the mandated store.Store
-// interface, which consumers depend on directly by design. This is a
-// required-interface exception, not accreted public API — it tracks the
-// interface size and ratchets only if store.Store itself is narrowed.
+// TODO(TKT-N0IKN9): the exported surface (28) is the mandated store.Store
+// interface (incl. Tx, TKT-GXHI8), which consumers depend on directly by
+// design. This is a required-interface exception, not accreted public API —
+// it tracks the interface size and ratchets only if store.Store itself is
+// narrowed.
 //
-//plimsoll:max-exported-methods=27
+// Total methods crossed the 40 line with the Tx contract (TKT-GXHI8):
+// each store.Store write method split into an exported txMu wrapper +
+// unexported core so Tx callbacks can re-enter. Interface-driven, not
+// accreted sprawl; ratchets with the interface.
+//
+//plimsoll:max-methods=42
+//plimsoll:max-exported-methods=28
 type MemStore struct {
+	// txMu serializes an open Tx against ordinary writers: Tx holds it
+	// for the whole callback, every exported write method takes it
+	// briefly before mu (lock order: txMu → mu; see tx.go). Readers
+	// never take it.
+	txMu          sync.Mutex
 	mu            sync.RWMutex
 	entities      map[string]*entity.Entity   // ID -> entity
 	entityOrder   []string                    // sorted entity IDs
@@ -310,7 +322,7 @@ func (m *MemStore) PropertyValues(_ context.Context, property string, limit int)
 
 // --- EntityWriter ---
 
-func (m *MemStore) CreateEntity(_ context.Context, e *entity.Entity) error {
+func (m *MemStore) createEntity(_ context.Context, e *entity.Entity) error {
 	if err := validateID(e.ID); err != nil {
 		return err
 	}
@@ -336,7 +348,7 @@ func (m *MemStore) CreateEntity(_ context.Context, e *entity.Entity) error {
 	return nil
 }
 
-func (m *MemStore) UpdateEntity(_ context.Context, e *entity.Entity) error {
+func (m *MemStore) updateEntity(_ context.Context, e *entity.Entity) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
@@ -357,7 +369,7 @@ func (m *MemStore) UpdateEntity(_ context.Context, e *entity.Entity) error {
 	return nil
 }
 
-func (m *MemStore) DeleteEntity(_ context.Context, id string, cascade bool) (*store.DeleteResult, error) {
+func (m *MemStore) deleteEntity(_ context.Context, id string, cascade bool) (*store.DeleteResult, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
@@ -417,7 +429,7 @@ func (m *MemStore) DeleteEntity(_ context.Context, id string, cascade bool) (*st
 	return result, nil
 }
 
-func (m *MemStore) RenameEntity(_ context.Context, oldID, newID string) (*store.RenameResult, error) {
+func (m *MemStore) renameEntity(_ context.Context, oldID, newID string) (*store.RenameResult, error) {
 	if err := validateID(newID); err != nil {
 		return nil, err
 	}
@@ -567,7 +579,7 @@ func (m *MemStore) CountRelations(_ context.Context, q store.RelationQuery) (int
 
 // --- RelationWriter ---
 
-func (m *MemStore) CreateRelation(
+func (m *MemStore) createRelation(
 	_ context.Context, from, relType, to string, data *store.RelationData,
 ) (*entity.Relation, error) {
 	for _, id := range []string{from, to} {
@@ -611,7 +623,7 @@ func (m *MemStore) CreateRelation(
 	return r.Clone(), nil
 }
 
-func (m *MemStore) UpdateRelation(
+func (m *MemStore) updateRelation(
 	_ context.Context, from, relType, to string, data store.RelationData,
 ) (*entity.Relation, error) {
 	m.mu.Lock()
@@ -645,7 +657,7 @@ func (m *MemStore) UpdateRelation(
 	return updated.Clone(), nil
 }
 
-func (m *MemStore) DeleteRelation(_ context.Context, from, relType, to string) error {
+func (m *MemStore) deleteRelation(_ context.Context, from, relType, to string) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
@@ -672,7 +684,7 @@ func attachmentKey(entityID, property, fileName string) string {
 	return entityID + "/" + property + "/" + fileName
 }
 
-func (m *MemStore) AttachFile(_ context.Context, entityID, property, fileName string, r io.Reader) error {
+func (m *MemStore) attachFile(_ context.Context, entityID, property, fileName string, r io.Reader) error {
 	if err := validateProperty(property); err != nil {
 		return err
 	}
@@ -718,7 +730,7 @@ func (m *MemStore) ReadAttachment(_ context.Context, entityID, property, fileNam
 	return io.NopCloser(bytes.NewReader(a.data)), nil
 }
 
-func (m *MemStore) DeleteAttachment(_ context.Context, entityID, property, fileName string) error {
+func (m *MemStore) deleteAttachment(_ context.Context, entityID, property, fileName string) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 

--- a/internal/store/memstore/tx.go
+++ b/internal/store/memstore/tx.go
@@ -1,0 +1,154 @@
+package memstore
+
+import (
+	"context"
+	"io"
+
+	"github.com/Sourcehaven-BV/rela/internal/entity"
+	"github.com/Sourcehaven-BV/rela/internal/store"
+)
+
+// Tx and the txMu write serialization (store.Transactor, DEC-8UIL0).
+//
+// Same shape and same reduced guarantees as fsstore (see fsstore/tx.go):
+// Tx holds txMu across the callback for mutual exclusion with ordinary
+// writers; no rollback; events/observer notifications emitted inline per
+// write. fn receives a txStore view whose write methods call the
+// unexported cores, skipping txMu — writes on the outer store from
+// inside fn deadlock.
+
+// Tx implements store.Transactor with mutual exclusion only (no
+// rollback; events emitted inline).
+func (m *MemStore) Tx(_ context.Context, fn func(store.Store) error) error {
+	m.txMu.Lock()
+	defer m.txMu.Unlock()
+	return fn(txStore{m})
+}
+
+// lockTx takes the Tx serialization lock and returns its release func,
+// letting the exported write wrappers stay one-liners.
+func (m *MemStore) lockTx() func() {
+	m.txMu.Lock()
+	return m.txMu.Unlock
+}
+
+// --- exported write API: serialize with any open Tx, then delegate ---
+
+// CreateEntity implements store.EntityWriter.
+// Returns store.ErrConflict if an entity with the same ID exists.
+func (m *MemStore) CreateEntity(ctx context.Context, e *entity.Entity) error {
+	defer m.lockTx()()
+	return m.createEntity(ctx, e)
+}
+
+// UpdateEntity implements store.EntityWriter.
+// Returns store.ErrNotFound if the entity does not exist.
+func (m *MemStore) UpdateEntity(ctx context.Context, e *entity.Entity) error {
+	defer m.lockTx()()
+	return m.updateEntity(ctx, e)
+}
+
+// DeleteEntity implements store.EntityWriter.
+// Returns store.ErrNotFound if the entity does not exist.
+func (m *MemStore) DeleteEntity(ctx context.Context, id string, cascade bool) (*store.DeleteResult, error) {
+	defer m.lockTx()()
+	return m.deleteEntity(ctx, id, cascade)
+}
+
+// RenameEntity implements store.EntityWriter.
+// Returns store.ErrNotFound if oldID is absent, store.ErrConflict if
+// newID exists.
+func (m *MemStore) RenameEntity(ctx context.Context, oldID, newID string) (*store.RenameResult, error) {
+	defer m.lockTx()()
+	return m.renameEntity(ctx, oldID, newID)
+}
+
+// CreateRelation implements store.RelationWriter.
+func (m *MemStore) CreateRelation(
+	ctx context.Context, from, relType, to string, data *store.RelationData,
+) (*entity.Relation, error) {
+	defer m.lockTx()()
+	return m.createRelation(ctx, from, relType, to, data)
+}
+
+// UpdateRelation implements store.RelationWriter.
+func (m *MemStore) UpdateRelation(
+	ctx context.Context, from, relType, to string, data store.RelationData,
+) (*entity.Relation, error) {
+	defer m.lockTx()()
+	return m.updateRelation(ctx, from, relType, to, data)
+}
+
+// DeleteRelation implements store.RelationWriter.
+func (m *MemStore) DeleteRelation(ctx context.Context, from, relType, to string) error {
+	defer m.lockTx()()
+	return m.deleteRelation(ctx, from, relType, to)
+}
+
+// AttachFile implements store.AttachmentManager.
+func (m *MemStore) AttachFile(ctx context.Context, entityID, property, fileName string, r io.Reader) error {
+	defer m.lockTx()()
+	return m.attachFile(ctx, entityID, property, fileName, r)
+}
+
+// DeleteAttachment implements store.AttachmentManager.
+func (m *MemStore) DeleteAttachment(ctx context.Context, entityID, property, fileName string) error {
+	defer m.lockTx()()
+	return m.deleteAttachment(ctx, entityID, property, fileName)
+}
+
+// --- transaction view ---
+
+// txStore is the view a Tx callback receives: write methods skip txMu
+// (the Tx already holds it) and call the cores directly; everything
+// else is promoted from the embedded *MemStore. A nested Tx joins the
+// open transaction.
+type txStore struct{ *MemStore }
+
+// interface check: the view must satisfy the full store.Store.
+var _ store.Store = txStore{}
+
+func (t txStore) CreateEntity(ctx context.Context, e *entity.Entity) error {
+	return t.createEntity(ctx, e)
+}
+
+func (t txStore) UpdateEntity(ctx context.Context, e *entity.Entity) error {
+	return t.updateEntity(ctx, e)
+}
+
+func (t txStore) DeleteEntity(ctx context.Context, id string, cascade bool) (*store.DeleteResult, error) {
+	return t.deleteEntity(ctx, id, cascade)
+}
+
+func (t txStore) RenameEntity(ctx context.Context, oldID, newID string) (*store.RenameResult, error) {
+	return t.renameEntity(ctx, oldID, newID)
+}
+
+func (t txStore) CreateRelation(
+	ctx context.Context, from, relType, to string, data *store.RelationData,
+) (*entity.Relation, error) {
+	return t.createRelation(ctx, from, relType, to, data)
+}
+
+func (t txStore) UpdateRelation(
+	ctx context.Context, from, relType, to string, data store.RelationData,
+) (*entity.Relation, error) {
+	return t.updateRelation(ctx, from, relType, to, data)
+}
+
+func (t txStore) DeleteRelation(ctx context.Context, from, relType, to string) error {
+	return t.deleteRelation(ctx, from, relType, to)
+}
+
+func (t txStore) AttachFile(ctx context.Context, entityID, property, fileName string, r io.Reader) error {
+	return t.attachFile(ctx, entityID, property, fileName, r)
+}
+
+func (t txStore) DeleteAttachment(ctx context.Context, entityID, property, fileName string) error {
+	return t.deleteAttachment(ctx, entityID, property, fileName)
+}
+
+// Tx on the view joins the open transaction.
+func (t txStore) Tx(_ context.Context, fn func(store.Store) error) error {
+	return fn(t)
+}

--- a/internal/store/pgstore/conformance_test.go
+++ b/internal/store/pgstore/conformance_test.go
@@ -20,6 +20,14 @@ func TestVisibleFieldConformance(t *testing.T) {
 	storetest.RunVisibleFieldSearchTests(t, fieldVisibleSearchFactory)
 }
 
+// TestTxRollback runs the strong-Tx suite only pgstore meets: rollback on
+// error and post-commit-only event delivery (DEC-8UIL0). fsstore/memstore
+// deliberately provide the reduced mutual-exclusion-only guarantees and do
+// not run this.
+func TestTxRollback(t *testing.T) {
+	storetest.RunTxRollbackTests(t, factory)
+}
+
 func FuzzRelationKeyCollision(f *testing.F) {
 	storetest.FuzzRelationKeyCollision(f, fuzzFactory(f))
 }

--- a/internal/store/pgstore/entity.go
+++ b/internal/store/pgstore/entity.go
@@ -469,12 +469,20 @@ func (s *Store) RenameEntity(ctx context.Context, oldID, newID string) (*store.R
 // --- observers ---
 
 func (s *Store) notifyPut(e *entity.Entity) {
+	if s.txPending != nil { // inside Tx: deliver after the outer commit (tx.go)
+		s.txPending.add(func(p *Store) { p.notifyPut(e) })
+		return
+	}
 	for _, o := range s.observers {
 		_ = o.EntityPut(e)
 	}
 }
 
 func (s *Store) notifyDelete(id string) {
+	if s.txPending != nil { // inside Tx: deliver after the outer commit (tx.go)
+		s.txPending.add(func(p *Store) { p.notifyDelete(id) })
+		return
+	}
 	for _, o := range s.observers {
 		_ = o.EntityDelete(id)
 	}

--- a/internal/store/pgstore/export_test.go
+++ b/internal/store/pgstore/export_test.go
@@ -59,6 +59,10 @@ func NotificationEmitsForTest(t *testing.T, selfOrigin, payload string) bool {
 	}
 }
 
+// WriteAdvisoryLockKeyForTest exposes the Tx write-serialization advisory
+// key so the stress tests can assert it never leaks in pg_locks. Test-only.
+const WriteAdvisoryLockKeyForTest = writeAdvisoryLockKey
+
 // BuildGraphQuerySQLForTest exposes the internal SQL builder so
 // explain-plan tests can render the SQL without going through a pgx
 // round-trip. Keeps the production surface narrow while letting

--- a/internal/store/pgstore/pgstore.go
+++ b/internal/store/pgstore/pgstore.go
@@ -73,8 +73,10 @@ type DBTX interface {
 // interface-mandated methods, not accreted public API; Required-interface
 // exception, tracks the interface size.
 //
-//plimsoll:max-exported-methods=39
-//plimsoll:max-methods=52
+// (39 → 40 exported / 52 → 53 total: store.Store gained Tx, TKT-GXHI8.)
+//
+//plimsoll:max-exported-methods=40
+//plimsoll:max-methods=53
 type Store struct {
 	db        DBTX
 	observers []store.EntityObserver // notified synchronously after committed entity writes
@@ -92,6 +94,13 @@ type Store struct {
 	subscribers map[int]chan store.Event
 	nextSubID   int
 	closed      bool
+
+	// txPending is nil on a normal store. On the tx-bound view a Tx
+	// callback receives (tx.go), it buffers in-process observer and
+	// subscriber notifications so they are delivered against the parent
+	// store only after the outer transaction commits — a subscriber must
+	// never observe a write that later rolls back.
+	txPending *txPending
 }
 
 // Option configures a Store.
@@ -196,6 +205,10 @@ func (s *Store) Subscribe(bufSize int) (events <-chan store.Event, cancel func()
 // It is called AFTER a write transaction commits — never while holding a DB
 // transaction — so subscribers never observe uncommitted state.
 func (s *Store) emit(ev store.Event) {
+	if s.txPending != nil { // inside Tx: deliver after the outer commit (tx.go)
+		s.txPending.add(func(p *Store) { p.emit(ev) })
+		return
+	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	for _, ch := range s.subscribers {
@@ -210,6 +223,10 @@ func (s *Store) emit(ev store.Event) {
 // emitAll delivers a batch of events in order (used by cascade delete and
 // rename, which produce several events per operation).
 func (s *Store) emitAll(evs []store.Event) {
+	if s.txPending != nil { // inside Tx: deliver after the outer commit (tx.go)
+		s.txPending.add(func(p *Store) { p.emitAll(evs) })
+		return
+	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	for _, ev := range evs {

--- a/internal/store/pgstore/tx.go
+++ b/internal/store/pgstore/tx.go
@@ -1,0 +1,86 @@
+package pgstore
+
+import (
+	"context"
+
+	"github.com/Sourcehaven-BV/rela/internal/store"
+)
+
+// Tx (store.Transactor, DEC-8UIL0): a real database transaction plus
+// deployment-wide write serialization.
+//
+// Tx opens one outer transaction, takes writeAdvisoryLockKey as a
+// transaction-scoped advisory lock (so every process of the deployment
+// serializes its Tx callbacks and, transitively, the write methods'
+// row work — one global key means zero deadlock risk and no retry
+// machinery; per-entity granularity is a possible later optimization
+// invisible to callers), and hands fn a tx-bound view of the store.
+//
+// The view's db handle IS the outer transaction: the ordinary write
+// methods run unchanged, their per-write Begin/Commit becoming
+// savepoints, and their pg_notify calls deferring to the outer commit
+// natively. In-process observer/subscriber notifications are buffered
+// on the view (see Store.txPending) and replayed against the parent
+// store only after the outer commit — a subscriber must never observe
+// a write that later rolls back. An error from fn rolls the whole
+// transaction back: no rows, no NOTIFYs, no events.
+//
+// A nested Tx on the view joins the open transaction.
+
+// writeAdvisoryLockKey serializes write transactions deployment-wide
+// ("RELW"). Distinct from migrateAdvisoryLockKey ("RELA", xact-scoped in
+// Migrate) and sweepAdvisoryLockKey ("RELV", session-scoped, shared by
+// sweep and purge): a write Tx must not block — or be blocked by — a
+// sweep tick, matching today's behavior where ordinary writes never
+// take the sweep lock.
+const writeAdvisoryLockKey int64 = 0x52_45_4c_57
+
+// txPending buffers the in-process notifications of one open Tx, in
+// emission order, for replay against the parent store after commit.
+// It is used from the Tx callback's goroutine only (the view must not
+// be shared across goroutines — see the store.Transactor contract), so
+// it needs no locking.
+type txPending struct {
+	notes []func(*Store)
+}
+
+func (p *txPending) add(n func(*Store)) {
+	p.notes = append(p.notes, n)
+}
+
+// Tx implements store.Transactor. See the notes above for the pgstore
+// mechanics; the behavioral contract is on store.Transactor.
+func (s *Store) Tx(ctx context.Context, fn func(store.Store) error) error {
+	if s.txPending != nil {
+		return fn(s) // nested Tx on the view joins the open transaction
+	}
+
+	tx, err := s.db.Begin(ctx)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback(ctx) //nolint:errcheck // rollback after commit is a no-op
+
+	if _, err := tx.Exec(ctx, `SELECT pg_advisory_xact_lock($1)`, writeAdvisoryLockKey); err != nil {
+		return err
+	}
+
+	pending := &txPending{}
+	view := &Store{
+		db:          tx,
+		originID:    s.originID,
+		channel:     s.channel,
+		subscribers: make(map[int]chan store.Event),
+		txPending:   pending,
+	}
+	if err := fn(view); err != nil {
+		return err
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return err
+	}
+	for _, n := range pending.notes {
+		n(s)
+	}
+	return nil
+}

--- a/internal/store/pgstore/tx_stress_test.go
+++ b/internal/store/pgstore/tx_stress_test.go
@@ -1,0 +1,166 @@
+package pgstore_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/stretchr/testify/require"
+
+	"github.com/Sourcehaven-BV/rela/internal/entity"
+	"github.com/Sourcehaven-BV/rela/internal/store"
+	"github.com/Sourcehaven-BV/rela/internal/store/pgstore"
+	"github.com/Sourcehaven-BV/rela/internal/store/storetest"
+)
+
+// poolForSchema opens a SECOND, independent pool pinned to an
+// already-migrated test schema. Separate pool = separate pg sessions, which
+// is what makes the cross-store test meaningful: advisory locks are
+// per-session, so two pools model two deployment processes.
+func poolForSchema(t *testing.T, schema string) *pgxpool.Pool {
+	t.Helper()
+	cfg, err := pgxpool.ParseConfig(os.Getenv(testDBEnv))
+	require.NoError(t, err)
+	cfg.ConnConfig.RuntimeParams["search_path"] = schema + ",public"
+	cfg.MaxConns = 2
+	cfg.MinConns = 0
+	pool, err := pgxpool.NewWithConfig(context.Background(), cfg)
+	require.NoError(t, err)
+	t.Cleanup(pool.Close)
+	return pool
+}
+
+// TestTxCrossStoreSerialization proves the DEPLOYMENT-WIDE claim of the Tx
+// contract: two independent stores over two independent pools (= two pg
+// sessions, modeling two rela-server processes) run concurrent Tx
+// read-modify-write increments against the same schema. Only the advisory
+// lock serializes them — a process-local mechanism (the writeMu bug class)
+// would lose updates here almost immediately under READ COMMITTED.
+func TestTxCrossStoreSerialization(t *testing.T) {
+	admin := adminConn(t)
+	pool1, schema, err := createScopedPool(admin)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		pool1.Close()
+		_, _ = admin.Exec(context.Background(), "DROP SCHEMA "+pgQuoteIdent(schema)+" CASCADE")
+	})
+	pool2 := poolForSchema(t, schema)
+
+	s1, err := pgstore.New(pool1)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = s1.Close() })
+	s2, err := pgstore.New(pool2)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = s2.Close() })
+
+	ctx := context.Background()
+	seed := entity.New("STRS-CTR", "feature")
+	seed.SetString("n", "0")
+	require.NoError(t, s1.CreateEntity(ctx, seed))
+
+	const workers, loops = 8, 5
+	stores := []store.Store{s1, s2}
+	errs := make([]error, workers)
+	var wg sync.WaitGroup
+	for w := range workers {
+		wg.Go(func() {
+			s := stores[w%2]
+			for range loops {
+				if txErr := s.Tx(ctx, func(tx store.Store) error {
+					e, gerr := tx.GetEntity(ctx, "STRS-CTR")
+					if gerr != nil {
+						return gerr
+					}
+					n, perr := strconv.Atoi(e.GetString("n"))
+					if perr != nil {
+						return perr
+					}
+					e.SetString("n", strconv.Itoa(n+1))
+					return tx.UpdateEntity(ctx, e)
+				}); txErr != nil {
+					errs[w] = txErr
+					return
+				}
+			}
+		})
+	}
+	wg.Wait()
+	for w, err := range errs {
+		require.NoError(t, err, "worker %d", w)
+	}
+
+	// Read through the OTHER store to also prove cross-store visibility.
+	got, err := s2.GetEntity(ctx, "STRS-CTR")
+	require.NoError(t, err)
+	require.Equal(t, strconv.Itoa(workers*loops), got.GetString("n"),
+		"lost update across stores: advisory lock is not serializing sessions")
+}
+
+// TestTxPoolExhaustion pins the no-second-connection property: a Tx must
+// never acquire another pool connection while holding one (that cycle is
+// the realistic pgstore deadlock). The scoped test pool has MaxConns=2;
+// 16 concurrent multi-write transactions must all complete anyway, just
+// slowly. Afterwards the write advisory key must not appear in pg_locks
+// and no session may sit idle-in-transaction — both would indicate a
+// leaked transaction on some error path.
+func TestTxPoolExhaustion(t *testing.T) {
+	pool := newScopedPool(t) // MaxConns=2 (see createScopedPool)
+	s, err := pgstore.New(pool)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = s.Close() })
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	const workers = 16
+	errs := make([]error, workers)
+	var wg sync.WaitGroup
+	for w := range workers {
+		wg.Go(func() {
+			errs[w] = s.Tx(ctx, func(tx store.Store) error {
+				for j := range 3 {
+					if cerr := tx.CreateEntity(ctx, entity.New(fmt.Sprintf("STRS-X%dY%d", w, j), "feature")); cerr != nil {
+						return cerr
+					}
+				}
+				return nil
+			})
+		})
+	}
+	wg.Wait()
+	for w, err := range errs {
+		require.NoError(t, err, "worker %d (starved on a 2-conn pool?)", w)
+	}
+
+	n, err := s.CountEntities(ctx, store.EntityQuery{Type: "feature"})
+	require.NoError(t, err)
+	require.Equal(t, workers*3, n)
+
+	var leaked int
+	require.NoError(t, pool.QueryRow(ctx, `
+		SELECT count(*) FROM pg_locks
+		WHERE locktype = 'advisory'
+		  AND ((classid::bigint << 32) | objid::bigint) = $1`,
+		pgstore.WriteAdvisoryLockKeyForTest).Scan(&leaked))
+	require.Zero(t, leaked, "write advisory lock leaked in pg_locks")
+
+	var idleInTx int
+	require.NoError(t, pool.QueryRow(ctx, `
+		SELECT count(*) FROM pg_stat_activity
+		WHERE datname = current_database()
+		  AND state = 'idle in transaction'
+		  AND pid <> pg_backend_pid()`).Scan(&idleInTx))
+	require.Zero(t, idleInTx, "session left idle-in-transaction: leaked Tx")
+}
+
+// TestTxStress runs the shared mixed-workload soak (watchdogged deadlock
+// detection + lost-update and pair-atomicity invariants) against pgstore.
+// Duration 2s by default; RELA_STRESS_SECONDS extends it for local shakes.
+func TestTxStress(t *testing.T) {
+	storetest.RunTxStressTest(t, factory)
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -162,7 +162,8 @@ func attachmentExt(name string) string {
 // the index is always consistent with the persisted state.
 //
 // Reads are cheap. Writes serialize internally — callers do not need
-// external locking.
+// external locking. Multi-write operations that must not interleave
+// with other writers group their writes with [Transactor.Tx].
 //
 // Read methods return cloned entities/relations — callers own the
 // returned values and may mutate them freely.
@@ -176,6 +177,40 @@ type Store interface {
 	Watcher
 	Lifecycle
 	Freshness
+	Transactor
+}
+
+// Transactor groups writes into one serialized unit (DEC-8UIL0).
+//
+// Tx runs fn with a transaction-bound view of the store. The contract
+// specifies behavior, not mechanism — each backend meets it with its
+// native machinery:
+//
+//   - Writes made through the view are serialized against every other
+//     writer and every other Tx for the full duration of fn —
+//     cross-process where the backend can see other processes
+//     (pgstore: native transaction + advisory lock), in-process
+//     otherwise (fsstore/memstore: write mutex; single-user
+//     deployments by nature).
+//   - Reads through the view observe fn's own writes.
+//   - An error from fn is returned unchanged. Where the backend
+//     supports rollback (pgstore), the transaction's writes are
+//     discarded and no events are delivered; fsstore/memstore keep
+//     the writes already made (no rollback — deliberate reduced
+//     guarantee, they cannot promise crash atomicity either).
+//   - A nested Tx on the view joins the open transaction; there is no
+//     nested-transaction API.
+//
+// All store calls inside fn MUST go through the view, and the view
+// must not escape fn or be shared across goroutines — writes on the
+// outer store from inside fn deadlock (fs/mem) or bypass the
+// transaction (pg). Beware that using an ESCAPED view after Tx
+// returns is the one misuse that fails silently: on fs/mem it writes
+// without the serialization lock (racing any open Tx), on pg it
+// errors against a closed transaction. Do not perform slow external
+// I/O inside fn: on pgstore the whole deployment's writers wait.
+type Transactor interface {
+	Tx(ctx context.Context, fn func(Store) error) error
 }
 
 // Freshness exposes the store's overall "last modified" timestamp, covering

--- a/internal/store/storetest/storetest.go
+++ b/internal/store/storetest/storetest.go
@@ -164,4 +164,5 @@ func RunAll(t *testing.T, f Factory, sf SearchFactory, vsf VisibleSearchFactory,
 	}
 	t.Run("Watcher", func(t *testing.T) { RunWatcherTests(t, f) })
 	t.Run("Validation", func(t *testing.T) { RunValidationTests(t, f) })
+	t.Run("Tx", func(t *testing.T) { RunTxTests(t, f) })
 }

--- a/internal/store/storetest/stress.go
+++ b/internal/store/storetest/stress.go
@@ -1,0 +1,303 @@
+package storetest
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"runtime"
+	"strconv"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/Sourcehaven-BV/rela/internal/entity"
+	"github.com/Sourcehaven-BV/rela/internal/store"
+)
+
+// stressDuration returns the soak length: 2s by default (CI-budget), or
+// RELA_STRESS_SECONDS for longer local shakes.
+func stressDuration() time.Duration {
+	if v := os.Getenv("RELA_STRESS_SECONDS"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			return time.Duration(n) * time.Second
+		}
+	}
+	return 2 * time.Second
+}
+
+// errStressRollback is the deliberate failure the pair worker injects to
+// exercise the Tx error path (rollback on pg, documented no-op on fs/mem).
+var errStressRollback = errors.New("storetest: deliberate stress rollback")
+
+// RunTxStressTest soaks a store under sustained mixed concurrent load —
+// Tx read-modify-write counters, multi-write transactions with injected
+// failures, nested transactions, plain writes, reads, and a draining
+// subscriber — with a progress watchdog that converts a deadlock into a
+// failing test with a full goroutine dump (Go's runtime deadlock panic
+// only fires when ALL goroutines block, which a partial deadlock never
+// triggers).
+//
+// End-state invariants, valid for every backend regardless of rollback
+// support:
+//
+//   - No lost updates: the counter equals the number of Tx increments
+//     that returned success.
+//   - Pair atomicity: each two-entity transaction either left both
+//     entities or neither (the failure is injected only after both
+//     writes, so this holds under rollback AND under the fs/mem
+//     no-rollback contract).
+//
+// Duration: 2s default; set RELA_STRESS_SECONDS for longer local runs.
+func RunTxStressTest(t *testing.T, f Factory) {
+	s := f(t)
+
+	seed := entity.New("STRS-CTR", "feature")
+	seed.SetString("n", "0")
+	require.NoError(t, s.CreateEntity(ctx(), seed))
+
+	var (
+		stop     = make(chan struct{})
+		progress atomic.Int64 // bumped by every worker iteration (watchdog food)
+		commits  atomic.Int64 // successful counter-increment transactions
+		pairSeq  atomic.Int64 // pair transactions attempted (ids 1..pairSeq)
+		wg       sync.WaitGroup
+		failures = make(chan error, 32) // first unexpected worker error wins
+	)
+	fail := func(err error) {
+		select {
+		case failures <- err:
+		default:
+		}
+	}
+	stopping := func() bool {
+		select {
+		case <-stop:
+			return true
+		default:
+			return false
+		}
+	}
+
+	// Two counter workers: serialized read-modify-write increments. Any
+	// interleaving between Tx callbacks loses an update and fails the
+	// end-state check.
+	for range 2 {
+		wg.Go(func() {
+			for !stopping() {
+				err := s.Tx(ctx(), func(tx store.Store) error {
+					e, err := tx.GetEntity(ctx(), "STRS-CTR")
+					if err != nil {
+						return err
+					}
+					n, err := strconv.Atoi(e.GetString("n"))
+					if err != nil {
+						return err
+					}
+					runtime.Gosched()
+					e.SetString("n", strconv.Itoa(n+1))
+					return tx.UpdateEntity(ctx(), e)
+				})
+				if err != nil {
+					fail(fmt.Errorf("counter tx: %w", err))
+					return
+				}
+				commits.Add(1)
+				progress.Add(1)
+			}
+		})
+	}
+
+	// Pair worker: two creates per Tx, failing every third transaction
+	// AFTER both writes — exercises the rollback/no-rollback path while
+	// keeping the both-or-neither invariant checkable on every backend.
+	wg.Go(func() {
+		for !stopping() {
+			i := pairSeq.Add(1)
+			err := s.Tx(ctx(), func(tx store.Store) error {
+				if err := tx.CreateEntity(ctx(), entity.New(fmt.Sprintf("STRS-PA%d", i), "feature")); err != nil {
+					return err
+				}
+				if err := tx.CreateEntity(ctx(), entity.New(fmt.Sprintf("STRS-PB%d", i), "feature")); err != nil {
+					return err
+				}
+				if i%3 == 0 {
+					return errStressRollback
+				}
+				return nil
+			})
+			if err != nil && !errors.Is(err, errStressRollback) {
+				fail(fmt.Errorf("pair tx %d: %w", i, err))
+				return
+			}
+			progress.Add(1)
+		}
+	})
+
+	// Nested-Tx worker: create in the outer transaction, update through a
+	// joined inner one.
+	wg.Go(func() {
+		for j := 0; !stopping(); j++ {
+			id := fmt.Sprintf("STRS-N%d", j)
+			err := s.Tx(ctx(), func(tx store.Store) error {
+				e := entity.New(id, "feature")
+				if err := tx.CreateEntity(ctx(), e); err != nil {
+					return err
+				}
+				return tx.Tx(ctx(), func(inner store.Store) error {
+					e.SetString("title", "nested")
+					return inner.UpdateEntity(ctx(), e)
+				})
+			})
+			if err != nil {
+				fail(fmt.Errorf("nested tx %s: %w", id, err))
+				return
+			}
+			progress.Add(1)
+		}
+	})
+
+	// Plain writer: ordinary create/update/delete cycles OUTSIDE any Tx,
+	// contending on the Tx serialization from the non-transactional side.
+	wg.Go(func() {
+		for j := 0; !stopping(); j++ {
+			id := fmt.Sprintf("STRS-W%d", j%50)
+			e := entity.New(id, "feature")
+			if err := s.CreateEntity(ctx(), e); err != nil && !errors.Is(err, store.ErrConflict) {
+				fail(fmt.Errorf("plain create %s: %w", id, err))
+				return
+			}
+			e.SetString("title", "plain")
+			if err := s.UpdateEntity(ctx(), e); err != nil && !errors.Is(err, store.ErrNotFound) {
+				fail(fmt.Errorf("plain update %s: %w", id, err))
+				return
+			}
+			_, derr := s.DeleteEntity(ctx(), id, false)
+			if derr != nil && !errors.Is(derr, store.ErrNotFound) && !errors.Is(derr, store.ErrHasRelations) {
+				fail(fmt.Errorf("plain delete %s: %w", id, derr))
+				return
+			}
+			progress.Add(1)
+		}
+	})
+
+	// Reader: never takes any write lock; must keep flowing throughout.
+	wg.Go(func() {
+		for !stopping() {
+			if _, err := s.GetEntity(ctx(), "STRS-CTR"); err != nil {
+				fail(fmt.Errorf("reader: %w", err))
+				return
+			}
+			n := 0
+			for _, err := range s.ListEntities(ctx(), store.EntityQuery{Type: "feature"}) {
+				if err != nil {
+					// Tolerated: fsstore loads entity files lazily during
+					// iteration, so a concurrent delete between the index
+					// snapshot and the file read surfaces as a not-found
+					// error mid-list. Pre-existing list-vs-delete race,
+					// independent of Tx. Anything else is a real failure.
+					if errors.Is(err, store.ErrNotFound) || errors.Is(err, os.ErrNotExist) {
+						break
+					}
+					fail(fmt.Errorf("reader list: %w", err))
+					return
+				}
+				n++
+			}
+			progress.Add(1)
+		}
+	})
+
+	// Subscriber: drains events for the whole run (excluded from the
+	// watchdog — event flow may legitimately go quiet).
+	events, cancel := s.Subscribe(1024)
+	defer cancel()
+	wg.Go(func() {
+		for {
+			select {
+			case <-stop:
+				return
+			case <-events:
+			}
+		}
+	})
+
+	// Watchdog: if no worker makes progress for 5s — while running or
+	// while shutting down — dump every goroutine and fail. This is the
+	// deadlock detector.
+	wedged := make(chan string, 1)
+	// workersGone closes once stop is signaled AND every worker exited.
+	workersGone := make(chan struct{})
+	go func() {
+		<-stop
+		wg.Wait()
+		close(workersGone)
+	}()
+	go func() {
+		last, stale := int64(-1), 0
+		ticker := time.NewTicker(500 * time.Millisecond)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-workersGone:
+				return
+			case <-ticker.C:
+				cur := progress.Load()
+				if cur == last {
+					if stale++; stale >= 10 {
+						buf := make([]byte, 1<<20)
+						n := runtime.Stack(buf, true)
+						select {
+						case wedged <- string(buf[:n]):
+						default:
+						}
+						return
+					}
+				} else {
+					last, stale = cur, 0
+				}
+			}
+		}
+	}()
+
+	select {
+	case dump := <-wedged:
+		t.Fatalf("stress: no progress for 5s (deadlock?); goroutines:\n%s", dump)
+	case <-time.After(stressDuration()):
+	}
+	close(stop)
+
+	select {
+	case dump := <-wedged:
+		t.Fatalf("stress: workers wedged during shutdown; goroutines:\n%s", dump)
+	case <-time.After(30 * time.Second):
+		buf := make([]byte, 1<<20)
+		n := runtime.Stack(buf, true)
+		t.Fatalf("stress: workers did not stop within 30s; goroutines:\n%s", buf[:n])
+	case <-workersGone:
+	}
+
+	select {
+	case err := <-failures:
+		t.Fatalf("stress worker failed: %v", err)
+	default:
+	}
+
+	// Invariant: no lost counter updates.
+	got, err := s.GetEntity(ctx(), "STRS-CTR")
+	require.NoError(t, err)
+	require.Equal(t, strconv.FormatInt(commits.Load(), 10), got.GetString("n"),
+		"lost update: %s counter increments committed", got.GetString("n"))
+
+	// Invariant: every pair transaction left both entities or neither.
+	for i := int64(1); i <= pairSeq.Load(); i++ {
+		_, errA := s.GetEntity(ctx(), fmt.Sprintf("STRS-PA%d", i))
+		_, errB := s.GetEntity(ctx(), fmt.Sprintf("STRS-PB%d", i))
+		require.Equal(t, errA == nil, errB == nil,
+			"pair %d torn: A present=%v B present=%v", i, errA == nil, errB == nil)
+	}
+	t.Logf("stress: %d counter commits, %d pair txs, final entity sweep clean",
+		commits.Load(), pairSeq.Load())
+}

--- a/internal/store/storetest/tx.go
+++ b/internal/store/storetest/tx.go
@@ -1,0 +1,214 @@
+package storetest
+
+import (
+	"errors"
+	"runtime"
+	"strconv"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/Sourcehaven-BV/rela/internal/entity"
+	"github.com/Sourcehaven-BV/rela/internal/store"
+)
+
+// RunTxTests exercises the store.Transactor contract every backend must
+// meet: serialization, view re-entrancy, read-your-writes, error
+// propagation, and nested-Tx joining. Rollback and post-commit event
+// delivery are backend-dependent — see RunTxRollbackTests.
+func RunTxTests(t *testing.T, f Factory) {
+	t.Run("WriteVisibleAfterTx", func(t *testing.T) {
+		s := f(t)
+		err := s.Tx(ctx(), func(tx store.Store) error {
+			e := entity.New("FEAT-100", "feature")
+			e.SetString("title", "In transaction")
+			return tx.CreateEntity(ctx(), e)
+		})
+		require.NoError(t, err)
+
+		got, err := s.GetEntity(ctx(), "FEAT-100")
+		require.NoError(t, err)
+		require.Equal(t, "In transaction", got.GetString("title"))
+	})
+
+	t.Run("ReadYourWrites", func(t *testing.T) {
+		s := f(t)
+		err := s.Tx(ctx(), func(tx store.Store) error {
+			e := entity.New("FEAT-100", "feature")
+			e.SetString("title", "Visible inside")
+			if err := tx.CreateEntity(ctx(), e); err != nil {
+				return err
+			}
+			got, err := tx.GetEntity(ctx(), "FEAT-100")
+			if err != nil {
+				return err
+			}
+			if got.GetString("title") != "Visible inside" {
+				return errors.New("tx read did not observe tx write")
+			}
+			if _, err := tx.GetEntity(ctx(), "FEAT-404"); !errors.Is(err, store.ErrNotFound) {
+				return errors.New("missing entity should be ErrNotFound inside tx")
+			}
+			return nil
+		})
+		require.NoError(t, err)
+	})
+
+	t.Run("SerializedReadModifyWrite", func(t *testing.T) {
+		// The lost-update check: N concurrent transactions each do a
+		// read-modify-write of the same counter property. Serialized
+		// transactions end at exactly N; interleaved ones lose updates.
+		// As a regression detector this is probabilistic (a lucky
+		// scheduler could serialize broken code by chance), which is
+		// inherent to lost-update tests — a green run is strong
+		// evidence, not proof; a red run is always a real bug.
+		s := f(t)
+		seed := entity.New("FEAT-001", "feature")
+		seed.SetString("n", "0")
+		require.NoError(t, s.CreateEntity(ctx(), seed))
+
+		const writers = 8
+		var wg sync.WaitGroup
+		errs := make([]error, writers)
+		for i := range writers {
+			wg.Go(func() {
+				errs[i] = s.Tx(ctx(), func(tx store.Store) error {
+					e, err := tx.GetEntity(ctx(), "FEAT-001")
+					if err != nil {
+						return err
+					}
+					n, err := strconv.Atoi(e.GetString("n"))
+					if err != nil {
+						return err
+					}
+					runtime.Gosched() // widen the read-modify-write window
+					e.SetString("n", strconv.Itoa(n+1))
+					return tx.UpdateEntity(ctx(), e)
+				})
+			})
+		}
+		wg.Wait()
+		for i, err := range errs {
+			require.NoError(t, err, "writer %d", i)
+		}
+
+		got, err := s.GetEntity(ctx(), "FEAT-001")
+		require.NoError(t, err)
+		require.Equal(t, strconv.Itoa(writers), got.GetString("n"),
+			"lost update: transactions interleaved")
+	})
+
+	t.Run("ErrorPropagates", func(t *testing.T) {
+		s := f(t)
+		sentinel := errors.New("boom")
+		err := s.Tx(ctx(), func(store.Store) error { return sentinel })
+		require.ErrorIs(t, err, sentinel)
+	})
+
+	t.Run("NestedTxJoins", func(t *testing.T) {
+		s := f(t)
+		err := s.Tx(ctx(), func(tx store.Store) error {
+			if err := tx.CreateEntity(ctx(), entity.New("FEAT-100", "feature")); err != nil {
+				return err
+			}
+			return tx.Tx(ctx(), func(inner store.Store) error {
+				return inner.CreateEntity(ctx(), entity.New("FEAT-101", "feature"))
+			})
+		})
+		require.NoError(t, err)
+
+		_, err = s.GetEntity(ctx(), "FEAT-100")
+		require.NoError(t, err)
+		_, err = s.GetEntity(ctx(), "FEAT-101")
+		require.NoError(t, err)
+	})
+}
+
+// RunTxRollbackTests exercises the stronger Tx guarantees of backends
+// with real rollback (pgstore): an error from fn discards the
+// transaction's writes, delivers no events, and post-commit delivery
+// works. fsstore/memstore deliberately do NOT meet these (DEC-8UIL0
+// reduced single-user guarantees) and must not run this suite.
+func RunTxRollbackTests(t *testing.T, f Factory) {
+	sentinel := errors.New("boom")
+
+	t.Run("CreateRolledBack", func(t *testing.T) {
+		s := f(t)
+		err := s.Tx(ctx(), func(tx store.Store) error {
+			if err := tx.CreateEntity(ctx(), entity.New("FEAT-900", "feature")); err != nil {
+				return err
+			}
+			return sentinel
+		})
+		require.ErrorIs(t, err, sentinel)
+
+		_, err = s.GetEntity(ctx(), "FEAT-900")
+		require.ErrorIs(t, err, store.ErrNotFound)
+	})
+
+	t.Run("UpdateRolledBack", func(t *testing.T) {
+		s := f(t)
+		seed := entity.New("FEAT-001", "feature")
+		seed.SetString("title", "Original")
+		require.NoError(t, s.CreateEntity(ctx(), seed))
+
+		err := s.Tx(ctx(), func(tx store.Store) error {
+			e, err := tx.GetEntity(ctx(), "FEAT-001")
+			if err != nil {
+				return err
+			}
+			e.SetString("title", "Changed")
+			if err := tx.UpdateEntity(ctx(), e); err != nil {
+				return err
+			}
+			return sentinel
+		})
+		require.ErrorIs(t, err, sentinel)
+
+		got, err := s.GetEntity(ctx(), "FEAT-001")
+		require.NoError(t, err)
+		require.Equal(t, "Original", got.GetString("title"))
+	})
+
+	t.Run("NoEventsOnRollback", func(t *testing.T) {
+		s := f(t)
+		events, cancel := s.Subscribe(8)
+		defer cancel()
+
+		err := s.Tx(ctx(), func(tx store.Store) error {
+			if err := tx.CreateEntity(ctx(), entity.New("FEAT-900", "feature")); err != nil {
+				return err
+			}
+			return sentinel
+		})
+		require.ErrorIs(t, err, sentinel)
+
+		// Events are delivered synchronously before Tx returns, so an
+		// empty channel here is deterministic, not a timing bet.
+		select {
+		case ev := <-events:
+			t.Fatalf("event %v delivered for a rolled-back transaction", ev)
+		default:
+		}
+	})
+
+	t.Run("EventsDeliveredAfterCommit", func(t *testing.T) {
+		s := f(t)
+		events, cancel := s.Subscribe(8)
+		defer cancel()
+
+		err := s.Tx(ctx(), func(tx store.Store) error {
+			return tx.CreateEntity(ctx(), entity.New("FEAT-100", "feature"))
+		})
+		require.NoError(t, err)
+
+		select {
+		case ev := <-events:
+			require.Equal(t, store.EventEntityCreated, ev.Op)
+			require.Equal(t, "FEAT-100", ev.EntityID)
+		default:
+			t.Fatal("no event delivered after committed transaction")
+		}
+	})
+}

--- a/tickets/entities/decisions/DEC-8UIL0.md
+++ b/tickets/entities/decisions/DEC-8UIL0.md
@@ -1,0 +1,50 @@
+---
+id: DEC-8UIL0
+type: decision
+title: 'Write serialization becomes a store transaction contract: Tx on store.Store (fs = mutex, postgres = native transactions)'
+context: |-
+    dataentry.App.writeMu is a process-local mutex serializing only the data-entry HTTP mutation handlers — evolutionary residue from rela's markdown-on-disk origins, now running the postgres backend under the filesystem backend's concurrency model. Research RES-Z1SJ5 (2026-07-16 codebase survey) established: entitymanager intents are already multi-write and non-atomic (create = up to 2 store writes + cascade; delete = version-capture-then-delete, with manager.go:689 calling strict atomicity 'a future hardening'); CLI/MCP/scheduler write via entitymanager with no serialization at all; postgres has no cross-process serialization of ordinary writes; pgstore already wraps every write in a transaction (for pg_notify atomicity) and fans out in-process events post-commit. Five options were evaluated against five concrete anomaly classes (check-then-act races, lost updates, partial intents, interleaved cascades, interleaved scripts). Option B — a per-backend transaction contract on the store — was selected: it is the only option fixing cross-process races AND intent atomicity, and it dissolves writeMu rather than relocating it.
+
+    This decision amends the root CLAUDE.md rule 'No repository or transaction abstractions — the old repo and tx layers are gone, do not reintroduce equivalents.' The removed layers were generic indirection stacked ABOVE the store; this is a contract ON store.Store itself with per-backend meaning. The rule text should be updated to state the distinction explicitly.
+consequences: |-
+    ## Interface
+
+    `store.Store` grows one method (an interface member, NOT an optional type-asserted capability — every in-tree backend can implement it, and entitymanager requires it for correctness, so 'optional' would force a dual code path through the most safety-critical package):
+
+    ```go
+    Tx(ctx context.Context, fn func(Store) error) error
+    ```
+
+    Contract v1: writes inside fn are isolated from every other transaction — cross-process where the backend can see them; observer/subscriber events are delivered post-commit; errors roll back where the backend supports it. Enforced by a new storetest conformance section (including re-entrancy and post-commit event assertions). The contract specifies BEHAVIOR, not mechanism — each backend is free to change its serialization implementation without touching callers.
+
+    ## Per backend
+
+    - **fsstore/memstore**: one plain write mutex held across fn. Go deliberately has no reentrant mutex, so effective re-entrancy comes from structure: public write methods become thin Lock-then-unlocked-core wrappers, and Tx locks once and hands fn a view bound to the unlocked cores. Isolation only — no rollback (error mid-fn leaves partials, same as today) and no crash atomicity (no WAL; don't pretend). Events buffered, emitted after unlock.
+      - **Considered alternative: single writer goroutine (queue/actor).** Equivalent serialization, but it does not remove the need for reader synchronization — fsstore readers RLock the live maps, so a queue would ADD a mechanism next to the RWMutex rather than replace it. The variant that genuinely pays — single writer goroutine + copy-on-write snapshots published via atomic.Pointer (readers lock-free; the repo's own publish/serialize split rule) — is a real fsstore state-model rearchitecture, noted as fsstore's natural v2, out of scope for the Tx arc. The queue also adds ctx-cancellation-while-queued, panic-forwarding, and shutdown-drain semantics. Mutex chosen for v1 as the smallest conforming implementation.
+    - **pgstore**: BEGIN + one global pg_advisory_xact_lock(write key) + a tx-bound store view over the existing DBTX seam (pgx.Tx already satisfies it). Full rollback on error. pg_notify already fires at commit; in-process per-write events are buffered until Tx commit. Global key = zero deadlock risk and no retry machinery; per-entity lock granularity is a later optimization inside pgstore, invisible to callers.
+
+    ## Boundary and nesting
+
+    entitymanager wraps each intent (create incl. automation re-write, update, delete incl. version capture, rename, relation ops) in one Tx; cascadeHost and the version writers receive the tx-bound store, so cascade side-effects join the intent's transaction. Nesting = joining: there is no nested-Tx API; an intent opens a Tx only when not already inside one.
+
+    **Open sub-decision for the design review — how joining is detected:**
+
+    1. **Explicit tx-bound store (chosen, v1 default):** membership = holding the store view Tx handed to fn. Visible in every signature; costs threading the view through entitymanager's ~11 write sites + cascadeHost + version writers. Misuse (sharing the view across goroutines spawned inside fn) is possible but explicit.
+    2. **Implicit ctx-carried join (documented fallback):** Tx stamps the ctx; public write methods detect the marker and join the running transaction inline. Works identically under mutex or queue (an executor-identity check is the actor-runtime spelling of the same idea, but Go deliberately exposes no goroutine identity, so ctx is the honest carrier). Enormous churn reduction — no store threading at all — and consistent with the existing Principal/version-attribution-via-ctx precedent. Rejected as v1 default because it makes the write path's most load-bearing invariant invisible in signatures (behavior-switching via ctx), and its failure mode is SILENT loss of mutual exclusion if fn's ctx leaks into a spawned goroutine (explicit-view and identity-based variants fail loud with a deadlock instead). If entitymanager threading proves substantially uglier than estimated, revisit — the two schemes are behaviorally identical for correct code and switchable without contract changes.
+
+    Audit records are emitted post-commit (same 'after the durable write' guarantee, correctly generalized — an audit row must never exist for a rolled-back write; denied-write audit rows, emitted before any write, are unaffected).
+
+    ## Lua
+
+    Write-path scripts get a closure-based grouping helper — `rela.tx(function() ... end)` — which runs its closure's Mutator intents inside one store Tx via a manager-level grouping API (Manager exposing InTx(ctx, func(Mutator) error) or equivalent; same joining mechanism the intents use internally). An error inside the closure rolls back the group and re-raises in Lua. Hard rule enforced at runtime: `ai.*` bindings raise an error inside a transaction — no external I/O while holding the deployment-wide write lock. Whole scripts are never implicitly wrapped; scripts needing atomicity opt in with the helper. Consequence: dataentry's whole-script critical section is not preserved implicitly — writeMu is deleted outright, with rela.tx as the explicit replacement for scripts that relied on it. This is a documented behavioral change (cross-process on postgres, scripts already interleaved today).
+
+    ## Rollout
+
+    Sequenced as its own arc after TKT-R68TV8 M5.4 lands conservatively (M5.4 moves the mutex with the write nucleus, semantics untouched). Implementation order: storetest Tx contract → fsstore/memstore → pgstore → entitymanager wraps intents → Lua helper → delete writeMu. Gated on the race-detector suite and storetest conformance.
+
+    ## Out of scope (v1)
+
+    fs pre-image rollback journal; optimistic concurrency / revision CAS (lost updates remain — deliberately deferred, layers on top of this later); per-entity advisory-lock granularity; any retry-on-conflict machinery; fsstore single-writer-goroutine + COW snapshot state model (noted above as the natural fsstore v2).
+date: "2026-07-17"
+status: accepted
+---

--- a/tickets/entities/docs-checklists/DOCS-8I8CB.md
+++ b/tickets/entities/docs-checklists/DOCS-8I8CB.md
@@ -1,0 +1,35 @@
+---
+id: DOCS-8I8CB
+type: docs-checklist
+title: 'Documentation: Tx write-transaction contract on store.Store'
+status: done
+---
+
+## Code Documentation
+
+- [x] Comments where logic isn't obvious — the full behavioral contract lives
+in the `store.Transactor` godoc (per-backend guarantees, view discipline, the
+silent escaped-view hazard, the no-external-I/O rule); fsstore/memstore `tx.go`
+headers explain the txMu/lock-order/re-entrancy structure and the reduced
+single-user guarantees; pgstore `tx.go` explains the advisory-lock choice,
+savepoint mechanics, and the txPending post-commit event buffer;
+`writeAdvisoryLockKey` documents why it is distinct from the migrate and sweep
+keys.
+- [x] Function/type docs if public API — `Transactor`, `Tx` on all three
+backends, and every re-exported write wrapper carry doc comments.
+
+## Project Documentation
+
+- [x] ~~README updated~~ (N/A: no project-level surface change)
+- [x] CLAUDE.md updated — the "No repository or transaction abstractions"
+rule now names `store.Store.Tx` as the one sanctioned transaction seam
+(DEC-8UIL0) and forbids wrapping it or doing external I/O inside a callback.
+- [x] ~~Help text accurate~~ (N/A: no CLI command changes)
+
+## External Documentation
+
+- [x] ~~Changelog entry added~~ (N/A: project has no CHANGELOG file)
+- [x] API docs updated — `docs/postgres-backend.md` gained a "Write
+transactions" subsection under Multiple writers (deployment-wide advisory lock,
+rollback/event semantics, the keep-callbacks-short rule, and the fs
+degradation).

--- a/tickets/entities/features/FEAT-ARR07.md
+++ b/tickets/entities/features/FEAT-ARR07.md
@@ -1,0 +1,15 @@
+---
+id: FEAT-ARR07
+type: feature
+title: 'Store write transactions: Tx on store.Store'
+description: 'A write-transaction contract on store.Store (DEC-8UIL0): Tx(ctx, fn) serializes the callback against all other writers with per-backend mechanics — postgres gets a native transaction + deployment-wide advisory lock with rollback and post-commit events; fs/memstore get a write mutex with reduced single-user guarantees. Foundation for entitymanager intent atomicity, the Lua rela.tx helper, and the eventual deletion of dataentry writeMu.'
+status: in-progress
+---
+
+Per-backend write-transaction contract on `store.Store` (DEC-8UIL0): `Tx(ctx, fn
+func(Store) error)` serializes the callback against all other writers —
+cross-process on postgres (native transaction + advisory lock, rollback on
+error, events at commit), in-process on fs/memstore (write mutex; reduced
+guarantees for single-user deployments: no rollback, inline events). Foundation
+for entitymanager intent atomicity and the eventual deletion of dataentry
+writeMu.

--- a/tickets/entities/implementation-checklists/IMPL-KEG5N.md
+++ b/tickets/entities/implementation-checklists/IMPL-KEG5N.md
@@ -1,0 +1,79 @@
+---
+id: IMPL-KEG5N
+type: implementation-checklist
+title: 'Implementation: Add Tx write-transaction contract to store.Store with fs/mem/pg implementations (DEC-8UIL0 phase 1)'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Development
+
+- [x] Unit tests written for new code
+- [x] Integration tests written (test full flow, not just units)
+- [x] Happy path implemented
+- [x] Edge cases from planning handled
+- [x] Error handling in place (errors surfaced, not swallowed)
+
+## Test Quality
+
+- [x] Using fixture builders or factories for test data
+- [x] No hardcoded values in assertions when object is in scope
+- [x] Only specifying values that matter for the test
+- [x] Interpolated values constructed from objects, not hardcoded
+- [x] Property comparisons use original object, not hardcoded strings
+
+## Manual Verification
+
+- [x] Feature manually tested end-to-end
+- [x] Each acceptance criterion verified with test scenario from planning
+- [x] Edge cases manually verified
+
+**Verification Evidence:**
+- `go build ./...` + `-tags postgres` + `-tags memorybackend`: all compile.
+- `go test ./...` default tag: pass (incl. new `TestConformance/Tx` in fsstore
+and memstore via storetest RunAll).
+- `go test -race` on fsstore/memstore/storetest: pass — covers the
+8-goroutine serialized read-modify-write counter (AC3) and view re-entrancy
+(AC4).
+- pgstore against a real PostgreSQL 15 (`rela_tx_test` db,
+`go test -race -tags postgres ./internal/store/pgstore/...`): full suite pass;
+verbose run confirms all five `TestConformance/Tx/*` subtests and all four
+`TestTxRollback/*` subtests (CreateRolledBack, UpdateRolledBack,
+NoEventsOnRollback, EventsDeliveredAfterCommit) executed, not skipped (AC1, AC2,
+AC5).
+- `just coverage-check`: package floor + total (76.2%) pass.
+- `just plimsoll`, `just arch-lint`, `golangci-lint run ./internal/store/...`,
+`gofmt -l`: clean.
+
+**Stress hardening (added on review follow-up):**
+- `TestTxCrossStoreSerialization` (pg): two independent pools/sessions on one
+schema running concurrent Tx counters — proves the DEPLOYMENT-WIDE advisory-lock
+serialization claim (the property no single-store test can see). Pass under
+`-race`.
+- `TestTxPoolExhaustion` (pg): 16 concurrent multi-write Txs on a MaxConns=2
+pool — pins the no-second-connection property (the realistic pgstore deadlock);
+asserts zero leaked write advisory locks in `pg_locks` and zero
+idle-in-transaction sessions afterwards. Pass under `-race`.
+- `storetest.RunTxStressTest` soak wired as `TestTxStress` in all three
+backends: mixed workload (Tx counters, failing pair-Txs, nested Txs, plain
+writers, readers, event subscriber) with a 5s no-progress watchdog that dumps
+all goroutines (partial deadlocks never trigger Go's runtime detector). End
+invariants: exact counter (no lost updates) and pair-atomicity (both-or-neither,
+valid with and without rollback). 2s in CI; 30s local shakes run on all three
+backends under `-race` (pg: ~1.4k serialized commits per 2s).
+- Stress found one PRE-EXISTING fsstore race (list-vs-delete: lazy file load
+during iteration can yield not-found for a concurrently deleted entity) —
+independent of Tx, tolerated explicitly in the stress reader with a comment;
+surfaced to the owner for a separate ticket.
+
+## Quality
+
+- [x] Code follows project patterns (check similar code)
+- [x] Checked for DRY opportunities — repeated literals, expressions, or
+patterns extracted to a helper / constant / type where it sharpens the contract
+(don't extract for its own sake; CLAUDE.md "three similar lines is better than a
+premature abstraction" still holds)
+- [x] No security issues introduced
+- [x] No silent failures (errors logged AND returned)
+- [x] No debug code left behind

--- a/tickets/entities/planning-checklists/PLAN-LBUI4.md
+++ b/tickets/entities/planning-checklists/PLAN-LBUI4.md
@@ -1,0 +1,142 @@
+---
+id: PLAN-LBUI4
+type: planning-checklist
+title: 'Planning: Add Tx write-transaction contract to store.Store with fs/mem/pg implementations (DEC-8UIL0 phase 1)'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Understanding
+
+- [x] Problem/requirements clearly understood
+- [x] Scope defined (what's in/out documented below)
+- [x] Acceptance criteria documented with specific test scenarios
+
+**Scope:** IN: `Tx(ctx, fn func(Store) error)` on `store.Store` (embedded
+`Transactor` interface); fsstore/memstore mutex implementations with tx view
+(reduced single-user guarantees: no rollback, inline events); pgstore native
+transaction
++ global advisory lock + post-commit event buffering + rollback; storetest
+conformance; root CLAUDE.md rule amendment per [[DEC-8UIL0]]. OUT: entitymanager
+intent wrapping, Lua `rela.tx` helper, writeMu deletion, fs rollback journal,
+per-entity lock granularity, retry-on-conflict (all later slices of the
+DEC-8UIL0 arc).
+
+**Acceptance Criteria:**
+1. All three backends compile as `store.Store` with `Tx` — conformance suites pass (default, memorybackend, postgres tags).
+2. Writes made through the Tx view are visible after Tx returns (storetest `WriteVisibleAfterTx`).
+3. N concurrent `Tx(read-modify-write)` calls lose no updates (storetest serialized-counter test, race detector on).
+4. A write inside `fn` does not deadlock; nested `Tx` joins (storetest re-entrancy/nesting tests).
+5. `fn` error propagates out of `Tx`; on pgstore the write is rolled back and no in-process events fire (pg-only `RunTxRollbackTests`).
+
+## Research
+
+- [x] For larger features: run `/research` to create a structured research doc
+- [x] Searched for existing libraries that solve this problem
+- [x] Checked codebase for similar patterns or reusable code
+- [x] ~~Looked for reference implementations in other projects~~ (N/A: covered by RES-Z1SJ5 option survey)
+- [x] Reviewed relevant rela concepts for prior art
+
+**Research Doc:** [[RES-Z1SJ5]]
+
+**Existing Solutions:**
+- pgstore already wraps every write in a tx for pg_notify atomicity (entity.go:213, feed.go) and fans out in-process events post-commit — Tx generalizes this.
+- Advisory-lock idiom established: migrate.go:56 (xact), sweep.go:19/purge.go:49 (session).
+- `DBTX` seam (pgstore.go:56) already admits `pgx.Tx`; `Begin` on a tx = savepoint, so per-write methods run unchanged inside an outer Tx.
+- fsstore/memstore single-RWMutex concurrency documented in package docs; tx view + separate txMu follows the same structure.
+
+## Approach
+
+- [x] Technical approach chosen and documented
+- [x] Approach builds on existing patterns (not reinventing)
+- [x] Alternatives considered (document why rejected)
+- [x] Dependencies identified (packages, APIs, types)
+
+**Technical Approach:** Per [[DEC-8UIL0]] (options A–E analyzed and rejected in
+[[RES-Z1SJ5]]): interface member (not optional capability — every backend
+implements, callers would otherwise need a fallback path). fs/mem: new `txMu`
+mutex; public write methods take it briefly; `Tx` holds it across `fn` and
+passes a `txStore` view whose write methods call the unexported cores
+(re-entrancy by structure). pgstore: `Tx` opens the outer tx, takes
+`pg_advisory_xact_lock` on a new write key, hands a tx-bound `*Store` view (db =
+outer tx; savepoints per write); notifyPut/notifyDelete/emit/emitAll defer to a
+buffer replayed after commit. Nested Tx joins (view.Tx calls fn directly /
+txPending short-circuit).
+
+**Files to modify:** `internal/store/store.go`;
+`internal/store/fsstore/{fsstore,entity,relation,attachment,tx}.go`;
+`internal/store/memstore/{memstore,tx}.go`;
+`internal/store/pgstore/{pgstore,entity,tx}.go`;
+`internal/store/storetest/{storetest,tx}.go`; pg conformance test; root
+`CLAUDE.md`; `docs/postgres-backend.md`.
+
+## Security Considerations
+
+- [x] Input sources identified (user input, config, external APIs)
+- [x] Input validation approach defined (allowlist preferred over blocklist)
+- [x] Security-sensitive operations identified (file access, auth, crypto)
+- [x] Error handling doesn't leak sensitive information
+
+**Input Sources & Validation:** No new input surface — `Tx` takes a callback, no
+user data. Existing per-write validation (validateID etc.) unchanged inside the
+view.
+
+**Security-Sensitive Operations:** Advisory lock key is a compile-time constant
+(no user influence). Denial-of-write via a long-held Tx is bounded by callers'
+existing timeouts; no Tx callers are introduced in this PR. No auth/ACL changes
+(ACL sits above the store).
+
+## Test Plan
+
+- [x] Test scenarios documented for each acceptance criterion
+- [x] Edge cases identified and documented
+- [x] Negative test cases defined (invalid input, error conditions)
+- [x] Integration test approach defined (not just unit tests)
+
+**Test Scenarios:** AC1 → conformance suites (fs/mem run in default CI; pg via
+`just test-postgres`). AC2 → `RunTxTests/WriteVisibleAfterTx`. AC3 →
+`RunTxTests/SerializedReadModifyWrite` (8 goroutines, counter property, race
+detector). AC4 → `RunTxTests/ReadYourWrites`
++ `NestedTxJoins`. AC5 → `RunTxTests/ErrorPropagates` + pg-only `RunTxRollbackTests`
+(entity absent after failed Tx; no buffered events delivered).
+
+**Edge Cases:**
+- Write inside fn via the view (must not deadlock) — covered.
+- Nested Tx — joins, covered.
+- fn error mid-sequence: fs keeps earlier writes (documented reduced guarantee, not asserted); pg rolls back (asserted).
+- Concurrent ordinary writes during an open Tx: serialized via txMu / advisory lock (counter test).
+- Subscriber events during pg Tx: delivered only post-commit; none on rollback (asserted in rollback suite).
+
+**Negative Tests:** fn returns error → Tx returns that exact error (errors.Is);
+pg: no entity, no events.
+
+## Risk Assessment
+
+- [x] Technical risks assessed with mitigations
+- [x] Security risks assessed (see Security Considerations)
+- [x] Effort estimated (xs/s/m/l/xl)
+
+**Risks:**
+- fs deadlock via wrong lock path → structure (wrappers vs cores) + conformance re-entrancy test + race detector.
+- pg event buffering drops/duplicates → buffer replay only after successful commit; rollback suite asserts silence.
+- Interface growth breaks external implementers → grep confirmed only the three in-tree backends implement store.Store.
+- plimsoll pins on store impls → bump with required-interface justification (documented exception category).
+Effort: m.
+
+## Documentation Planning
+
+- [x] User-facing docs identified (skip if internal refactor)
+- [x] Docs-checklist will be created when entering implementation
+
+**Documentation Impact:**
+- [x] CLAUDE.md - amend "no transaction abstractions" rule per DEC-8UIL0
+- [x] docs/postgres-backend.md - short "write transactions" section
+- Interface godoc on store.Transactor carries the contract.
+
+## Design Review
+
+- [x] ~~Run `/design-review` before starting implementation~~ (N/A: design settled by RES-Z1SJ5 five-option analysis + DEC-8UIL0, accepted by owner 2026-07-17 with explicit fs-guarantee reduction; sub-decisions (interface member, joining detection, lock granularity) recorded in the decision)
+- [x] All critical/significant findings addressed in plan
+
+**Design Review Findings:** none open — see [[DEC-8UIL0]]

--- a/tickets/entities/researchs/RES-Z1SJ5.md
+++ b/tickets/entities/researchs/RES-Z1SJ5.md
@@ -1,0 +1,330 @@
+---
+id: RES-Z1SJ5
+type: research
+title: 'Store-based transactions: per-backend write serialization/atomicity as a store capability (replaces dataentry writeMu)'
+summary: Recommend an optional store.Transactor capability (fs = write mutex, pg = BEGIN + xact advisory lock) wrapped around each entitymanager intent; deletes dataentry writeMu, gains cross-process serialization and intent atomicity on postgres; run as its own arc after M5.4.
+status: done
+---
+
+## Problem
+
+`dataentry.App.writeMu` is a process-local mutex that serializes the data-entry
+HTTP mutation handlers against each other — a poor-man's transaction system. It
+provides isolation-by-serialization for one process and one entry point, and
+nothing else: no atomicity (an action script failing at write 3 of 5 leaves 1–2
+committed), no isolation from CLI/MCP/scheduler writers, nothing cross-process
+on postgres.
+
+This is evolutionary residue: rela grew from markdown-on-disk (where a global
+write lock *is* the strongest consistency the backend can offer) to a dual
+fs/postgres deployment. The strongest backend now runs under the weakest
+backend's concurrency model, and per-process at that.
+
+The question: should write serialization/atomicity become a **store capability
+with per-backend meaning** — fsstore implementing it as its write mutex, pgstore
+as native transactions — replacing `writeMu`? This also settles the open M5.4
+question in [[TKT-R68TV8]] ("mutex behind the store vs. App-level
+pointer-shared"): both listed options assumed the mutex survives; this is the
+third option where it dissolves.
+
+## Context (codebase survey, 2026-07-16)
+
+**What one entitymanager "intent" actually is.** The write path is already
+multi-write and non-atomic:
+
+- `CreateEntity` = validate → `Store.CreateEntity` → audit → automation →
+possibly a **second** `Store.UpdateEntity` (manager.go:472) → cascade.
+- `DeleteEntity` = version capture (entity + per-relation) **before** the store
+delete (manager.go:694) → `Store.DeleteEntity` → audit. The code itself notes
+"the store delete is still not transactional with this capture; strict atomicity
+is a future hardening" (manager.go:689–693).
+- Cascade side-effects write **directly to the store** via `cascadeHost`
+(cascadehost.go:54,83,108,159), bypassing Manager to avoid re-cascading.
+- ~11 store-write call sites across the package, all against the single
+`Deps.Store` field — no per-call store threading exists today.
+
+**Store capability precedent.** `store.Store` (9 embedded interfaces) has no
+transaction/batch method; its doc promises only per-write atomicity ("Writes
+serialize internally — callers do not need external locking", store.go:161–166).
+Seven optional capabilities already exist as type-asserted interfaces
+(`Formatter`, `VersionWriter`, `HistoryReader`, `RelationVersionWriter`,
+`RelationHistoryReader`, `VersionPurger`, `RelationVersionPurger`) — the exact
+pattern a `Transactor` would follow.
+
+**Event timing is already half-way there.** pgstore wraps *every* write in a tx
+solely so `pg_notify` commits atomically with the row, and fans out in-process
+observers/subscribers **after commit** (pgstore.go:196–197, entity.go:233–242).
+fsstore/memstore emit synchronously under their write lock. So "events fire
+post-commit" is already pgstore's model; a Tx capability generalizes rather than
+invents it.
+
+**Advisory locks are established idiom in pgstore.** Migrate uses a xact-scoped
+lock (migrate.go:56); sweep and purge share a session-scoped lock key for mutual
+exclusion (sweep.go:19, purge.go:49). A write-serializing
+`pg_advisory_xact_lock` inside a `Tx` is a natural extension.
+
+**Who bypasses writeMu today.** MCP tools, CLI commands, and the scheduler all
+write via entitymanager with **no serialization at all** (grep: no mutex in
+`internal/mcp`, `internal/cli`, scheduler). On postgres there is **no
+cross-process serialization of ordinary writes** — only per-statement/per-tx
+atomicity + ON CONFLICT. writeMu protects strictly less than it appears to. Note
+also that the writer entry points rarely share a process (MCP, CLI, scheduler
+are separate binaries), which matters when weighing in-process-only fixes.
+
+**The long-transaction hazard is real but already bounded.** Action scripts hold
+writeMu for the whole Lua run (actions.go:80), and write-time Lua can call the
+AI provider over HTTP (lua/ai.go:48–50) — slow external I/O under the lock. The
+5s `actionTimeout` exists precisely because of this (actions.go:23–26). Note: on
+multi-process postgres, the script-level critical section is already illusory —
+other processes' writes interleave freely today.
+
+**Constraints.** Root CLAUDE.md: "No repository or transaction abstractions —
+the old `repo` and `tx` layers are gone, do not reintroduce equivalents."
+Adopting any store-Tx option requires a decision entity amending/clarifying this
+rule (the removed layer was generic indirection *above* the store; a per-backend
+capability *on* the store is a different animal — but that argument must win a
+design review, not be assumed). Also: dataentry philosophy (DEC-HWZHA)
+deliberately tolerates temporarily invalid data; transactions here are about not
+*interleaving/losing* writes, not about rejecting invalid state.
+
+## Anomaly classes (the yardstick)
+
+Options are judged against the five concrete anomaly classes the current design
+permits:
+
+1. **Check-then-act races** — e.g. `checkUniqueProperties` →
+`Store.CreateEntity` (core.go:89–128): two concurrent creates both pass the
+uniqueness check, both write. writeMu prevents this only between dataentry
+handlers in one process; CLI-vs-server or server-vs-server races it today.
+2. **Lost updates** — two writers read the same snapshot, both write; last
+write wins silently. Serialization does NOT fix this (serialized ≠ not-lost);
+only conflict detection does.
+3. **Partial intents** — error/crash mid-intent leaves fragments: version
+capture without its delete, create without its automation property-write, audit
+row for work that half-happened.
+4. **Interleaved cascades** — two intents' automation/cascade write sequences
+interleave, producing orderings no serial execution could produce (duplicate
+side-effect entities, `if_exists: skip` racing itself).
+5. **Interleaved scripts** — an action script's multi-write sequence
+interleaves with other writers. In-process, writeMu prevents this today;
+cross-process on postgres it is already unprotected.
+
+## Options
+
+### Option A — Status quo: keep the mutex app-level, move it with the write nucleus
+
+**Mechanics.** M5.4 extracts the write handlers; the new struct owns `writeMu`;
+sync/attachment/action/webhook handlers keep pointer-sharing it. No semantic
+change of any kind.
+
+**Fixes:** nothing new. Preserves in-process protection against 1, 4, 5 for
+dataentry handlers only.
+
+**Leaves open:** 1 and 4 cross-process and for CLI/MCP/scheduler; 2 always; 3
+always.
+
+**Introduces:** no new risk.
+
+**Pick if:** rela's consistency posture — "tolerate temporarily invalid data,
+analyze later" — is judged to extend to *interleaving* anomalies, not just
+*invalid-state* anomalies. That is a defensible position for fs-first,
+mostly-single-writer deployments: `analyze unique` (FEAT-3DUA6) can find
+duplicate-unique violations after the fact, and markdown-on-disk users already
+live with hand-edit races.
+
+**Don't pick if** postgres multi-writer deployment is a real product direction.
+The anomaly classes above are not "temporarily invalid, converge later" — a lost
+update or duplicated cascade is *silently wrong*, and `analyze_*` can detect
+some (duplicates) but recover none (lost writes). Also leaves the manager's own
+documented atomicity TODO unaddressed indefinitely.
+
+### Option E — Move the mutex into entitymanager (in-process, no store change)
+
+**Mechanics.** Manager gains a `sync.Mutex`; every intent
+(Create/Update/Delete/Rename, relation ops) locks it. dataentry deletes writeMu
+except a slim script-scoped mutex for action scripts (script writes go through
+the Mutator per-call, so whole-script exclusion needs its own lock).
+
+**Fixes:** 1 and 4 for *all entry points within one process* — the natural
+"right place" argument, since the manager owns the check-then-act sequences.
+
+**Why it disappoints in practice:** the survey shows the writer entry points
+almost never share a process — MCP, CLI, and the scheduler are separate
+binaries. So E mostly relocates the mutex without extending its protection: in
+an fs deployment the server process was already the only in-process multi-writer
+(dataentry handlers), which writeMu covers; cross-process races (the real gap)
+remain untouched on both backends. It also adds a lock-ordering constraint
+between the manager's mutex and each store's internal mutex.
+
+**Pick if:** you want a cheap, honest staging step toward Option B — the "wrap
+each intent" boundary work is identical, and swapping the mutex body for
+`store.Tx(...)` later is mechanical.
+
+**Don't pick as an end-state:** it costs the migration churn of B's boundary
+work while delivering approximately Option A's guarantees.
+
+### Option B — `store.Transactor` capability (recommended)
+
+**Mechanics.**
+
+```go
+type Transactor interface {
+    Tx(ctx context.Context, fn func(Store) error) error
+}
+```
+
+Contract v1: writes inside `fn` are isolated from every other transaction —
+cross-process where the backend can see them — observer/subscriber events are
+delivered post-commit, and errors roll back where the backend supports it.
+entitymanager wraps each intent in one `Tx`; cascadeHost receives the tx-bound
+store, so cascade writes join the intent's transaction.
+
+Per backend:
+
+| | fsstore/memstore | pgstore |
+|---|---|---|
+| Isolation | internal write mutex held across `fn` (process-local — matches fs's single-process reality) | `BEGIN` + `pg_advisory_xact_lock(<write key>)` — deployment-wide |
+| Atomicity | none in v1 (error leaves partials, same as today); v2 option: pre-image journal for error-path rollback | full rollback on error |
+| Events | buffered, emitted after `fn` returns nil | already post-commit; buffer per-write events until Tx commit |
+| Crash safety | none (no WAL — don't pretend) | full (it's postgres) |
+
+**Fixes:** 1, 3, 4 fully on postgres, cross-process included; 1 and 4 in-process
+on fs (3 on fs only with the v2 journal). Directly delivers the `manager.go:689`
+"future hardening." Every entry point inherits the semantics because the
+boundary is entitymanager, not dataentry.
+
+**Deliberately does NOT fix:** 2 (lost updates — see Option C) and 5
+(whole-script atomicity — see hazards below).
+
+**Design sub-decisions the review must settle:**
+
+- **Optional capability vs. interface member.** The optional-capability
+pattern fits features only some backends can implement — but *every* in-tree
+backend can implement `Tx` (fs trivially, via its mutex). If entitymanager
+*requires* Tx for correctness, "optional" is a polite lie that forces a dual
+code path (with-Tx / fallback) through the most safety-critical package.
+Leaning: put `Tx` on `store.Store` proper, enforced by the storetest conformance
+suite; the CLAUDE.md amendment then covers "the store interface grew a
+transaction method," which is more honest than smuggling it in as a capability.
+- **fs re-entrancy.** fsstore's write methods take its internal `mu.Lock`;
+if `Tx` holds that same lock, the first write inside `fn` deadlocks. The
+tx-bound store view fs hands to `fn` must skip locking (a `locked` variant of
+the store, not a re-entrant mutex hack). Mechanical, but must be designed and
+race-tested, not improvised.
+- **Lock granularity on pg.** v1 = one global write key: zero deadlock risk,
+no retry machinery, exactly the fs model but cross-process correct. A per-entity
+hashed key would allow concurrent non-conflicting intents but reintroduces
+deadlock potential the moment an intent touches multiple ids
+(delete-with-cascade always does). Granularity is a later optimization *inside*
+pgstore, invisible to callers.
+- **Nesting = joining.** No nested-Tx API. Being "in" a transaction means
+holding the tx-bound store; cascadeHost and the version writers take whatever
+store they're handed. This keeps the manager's ~11 write sites a threading
+change, not a semantic one.
+
+**Introduces (honest risk list):**
+
+- One connection pinned per Tx on pg, and one slow `fn` stalls the whole
+deployment's writers (global advisory lock). Bounded today by tight timeouts,
+but it makes "no external I/O inside an intent" a *rule* rather than a
+preference — which is why whole scripts stay out of Tx.
+- Event buffering is a behavior change: the search indexer and SSE bridge see
+an intent's events at commit, slightly later than today. More correct (never
+index a rolled-back write) but has test surface.
+- Audit moves to post-commit — same "after the durable write" guarantee,
+correctly generalized; an audit row must never exist for a rolled-back write.
+(Denied-write audit rows, emitted before any write, are unaffected.)
+- Plumbing through entitymanager is the highest-risk work in the tree; must
+be gated on the race suite + storetest.
+
+**Pick if:** postgres multi-writer is real, and the goal is one consistency
+story owned by the layer that differs per backend. This is the only option that
+fixes cross-process anomalies *and* intent atomicity, and it dissolves writeMu
+rather than relocating it.
+
+**Don't pick if:** rela's postgres story stays effectively single-writer per
+deployment — then B is over-engineering and A is honest.
+
+### Option C — Optimistic concurrency (revision/If-Match CAS)
+
+**Mechanics.** Every entity carries a revision (pg: column, bumped per write;
+fs: harder — a frontmatter field is user-editable and hand-edits would fight it;
+realistic fs answer is content-hash-as-revision). Write APIs accept an expected
+revision; mismatch → 409; SPA grows conflict UX (reload/merge prompt); CLI/MCP
+grow a `--if-revision` / optimistic-retry story.
+
+**Fixes:** 2 — the *only* option that does. Lost updates are invisible to
+serialization: writeMu, Option B, and Option E all admit "user A and user B both
+read v1, B saves, A saves, B's edit silently gone."
+
+**Why it's not the answer to *this* question:** it provides no multi-write
+atomicity (a CAS guards one write, not an intent with automation + cascade), so
+it doesn't replace writeMu or fix classes 1/3/4 — automations and cascades don't
+have a "user" to bounce a 409 to. Its blast radius is product-wide (API + SPA +
+CLI + MCP + docs + conflict UX), i.e. XL and mostly UX work, not storage work.
+
+**Relationship to B:** complementary, not competing. B gives atomic, serialized
+intents; C layered on top gives conflict *detection* for human edits. B's
+pgstore can even adopt CAS internally later without caller changes. Sequencing C
+first would mean building conflict UX on top of non-atomic intents — the 409
+would fire against states that are themselves torn.
+
+**Pick if/when:** multi-user editing of the same entities becomes a real
+complaint. **Don't pick now:** wrong tool for the writeMu question.
+
+### Option D — Advisory lock inside the existing per-write txs only
+
+**Mechanics.** Add `pg_advisory_xact_lock` to pgstore's existing per-write
+transactions. No interface change, no manager change, ~20 lines.
+
+**Fixes:** nothing observable. The anomalies live *between* the statements of
+one intent (check→create, capture→delete, write→cascade); D serializes only
+*within* single statements, which postgres row locks already effectively do.
+writeMu survives untouched.
+
+**Why it's listed:** it's the tempting "cheap compromise" someone will suggest
+in review, and it should be pre-refuted: it adds lock traffic on every write
+while closing none of the five anomaly classes. **Don't pick.**
+
+## Comparison matrix
+
+| Anomaly / property | A (status quo) | E (manager mutex) | B (store Tx) | C (CAS) | D (advisory only) |
+|---|---|---|---|---|---|
+| 1. check-then-act races | dataentry, in-process | all entry points, in-process | **all writers; cross-process on pg** | partially (single-write CAS only) | no |
+| 2. lost updates | no | no | no | **yes** | no |
+| 3. partial intents | no | no | **pg: yes; fs: v2 journal** | no | no |
+| 4. interleaved cascades | dataentry, in-process | in-process | **yes; cross-process on pg** | no | no |
+| 5. script critical section | in-process | in-process (slim mutex) | dropped by design (slim mutex optional) | no | in-process (writeMu stays) |
+| writeMu fate | relocated | deleted (+slim script mutex) | **deleted** (+optional slim script mutex) | unchanged | unchanged |
+| CLAUDE.md rule amendment | no | no | **yes (decision entity)** | no | no |
+| New failure modes | none | lock ordering | long-tx stalls, event timing, plumbing risk | conflict UX debt | lock traffic |
+| Effort | nil | M | **L** | XL | S |
+
+## Recommendation
+
+**Option B**, sequenced as its own arc *after* M5.4 lands conservatively (Option
+A is the correct *interim* state, not the end state; Option E is only worth
+doing as B's first commit, not as a destination):
+
+1. M5.4 proceeds now with the mutex moving to the write-nucleus struct,
+semantics untouched (refactors must not change concurrency behavior).
+2. A decision entity records the amendment to the "no transaction
+abstractions" rule — and settles the optional-capability vs. interface-member
+question (leaning: interface member, since every backend implements it and the
+manager depends on it for correctness).
+3. Implementation order: storetest contract for `Tx` (incl. fs re-entrancy
+and post-commit event assertions) → fsstore/memstore → pgstore (`BEGIN` + global
+xact advisory lock + buffered events) → entitymanager wraps intents (cascadeHost
+takes the tx-bound store) → delete `writeMu`, with an explicit keep/drop
+decision on the slim script mutex.
+4. Explicitly out of scope for v1: fs rollback journal, optimistic
+concurrency (Option C), per-entity lock granularity, any retry-on-conflict
+machinery.
+
+**Tradeoffs accepted:** fs gets isolation without rollback (documented asymmetry
+— honest, since fs can't promise crash atomicity anyway); deployment-wide
+advisory lock means one slow in-tx operation stalls all pg writers (mitigated by
+keeping Lua scripts out of whole-script txs and by the existing tight timeouts);
+lost updates (class 2) remain — that is Option C's job, deliberately deferred;
+the entitymanager plumbing is nontrivial and must be guarded by the
+race-detector suite and storetest conformance.

--- a/tickets/entities/review-checklists/REV-9E3RY.md
+++ b/tickets/entities/review-checklists/REV-9E3RY.md
@@ -1,0 +1,66 @@
+---
+id: REV-9E3RY
+type: review-checklist
+title: 'Review: Add Tx write-transaction contract to store.Store with fs/mem/pg implementations (DEC-8UIL0 phase 1)'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Automated Checks
+
+- [x] All tests pass (`just test`)
+- [x] Lint clean (`just lint`)
+- [x] Coverage maintained (`just coverage-check`)
+
+Evidence: default/postgres/memorybackend builds + vet; `go test ./...`; `-race`
+on fsstore/memstore/storetest; pgstore suite `-race -tags postgres` against a
+real PostgreSQL 15 (all Tx + TxRollback subtests confirmed executed); plimsoll,
+arch-lint, golangci-lint, gofmt clean; coverage 76.2%.
+
+## Code Review
+
+- [x] Run `/code-review` command (invokes cranky-code-reviewer agent)
+- [x] All critical review-responses addressed (none found)
+- [x] All significant review-responses addressed (none found)
+- [x] Self-reviewed the diff for unrelated changes
+
+**Review Responses:** [[RR-XBZX5]] (minor, addressed — escaped-view godoc),
+[[RR-Y75YD]] (minor, addressed — probabilistic-test comment), [[RR-QWFGJ]] (nit,
+wont-fix with reason). Reviewer verdict: "fundamentally sound", no
+critical/significant findings; lock ordering, pg view construction, savepoint
+semantics, txPending replay ordering, self-echo filtering, and nested-join
+correctness each explicitly verified.
+
+## Acceptance Verification
+
+- [x] Each acceptance criterion tested (reference planning checklist)
+- [x] Test evidence documented in implementation checklist
+
+**Acceptance Status:** AC1 PASS (three-tag builds + conformance suites); AC2
+PASS (WriteVisibleAfterTx); AC3 PASS (SerializedReadModifyWrite, race detector);
+AC4 PASS (ReadYourWrites + NestedTxJoins, no deadlock); AC5 PASS
+(ErrorPropagates + pg TxRollback suite incl. NoEventsOnRollback). Details in
+[[IMPL-KEG5N]].
+
+## Documentation (enhancements only)
+
+- [x] Docs-checklist created and linked via `has-docs`
+- [x] User-facing documentation updated
+- [x] Docs-checklist marked as done
+
+**Docs Checklist:** [[DOCS-8I8CB]]
+
+## Final Checks
+
+- [x] Commit message explains the why, not just what
+- [x] No TODOs or FIXMEs left unaddressed
+- [x] Ready for another developer to use
+
+## Pull Request
+
+- [x] Run `/pr` command to create PR and monitor CI
+- [x] All CI checks pass
+- [x] PR URL documented below
+
+**PR:** https://github.com/sourcehaven-bv/rela/pull/1150 (stacked on #1149)

--- a/tickets/entities/review-responses/RR-QWFGJ.md
+++ b/tickets/entities/review-responses/RR-QWFGJ.md
@@ -1,0 +1,9 @@
+---
+id: RR-QWFGJ
+type: review-response
+title: Write-method contract docs live on the wrappers, cores undocumented
+finding: The CreateEntity→createEntity renames leave the unexported cores without doc comments; the contract godoc lives on the exported wrappers in tx.go.
+severity: nit
+reason: 'Deliberate: the wrapper IS the public surface and carries the contract; duplicating it on the cores would drift. Reviewer verified no core lost an invariant-bearing comment and no rename changed behavior.'
+status: wont-fix
+---

--- a/tickets/entities/review-responses/RR-XBZX5.md
+++ b/tickets/entities/review-responses/RR-XBZX5.md
@@ -1,0 +1,9 @@
+---
+id: RR-XBZX5
+type: review-response
+title: Escaped-view failure mode is silent on fs/mem — undocumented
+finding: The store.Transactor godoc documents the deadlock/bypass failure modes of writing on the OUTER store inside fn, but not the failure mode of using an ESCAPED view after Tx returns — which on fs/mem silently bypasses txMu serialization (no deadlock, no error, just a lost-update race), the one quiet failure in an otherwise fail-loud design.
+severity: minor
+resolution: 'Added a sentence to the store.Transactor godoc (internal/store/store.go) naming the escaped-view path as the one misuse that fails silently: fs/mem write without the serialization lock, pg errors against a closed transaction.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-Y75YD.md
+++ b/tickets/entities/review-responses/RR-Y75YD.md
@@ -1,0 +1,9 @@
+---
+id: RR-Y75YD
+type: review-response
+title: SerializedReadModifyWrite is a probabilistic regression detector
+finding: storetest's lost-update counter test is deterministic when serialization works, but as a detector of BROKEN serialization it is probabilistic — a lucky scheduler could serialize unserialized code by chance and produce a green run. Inherent to lost-update tests; reviewer recommended documenting rather than rewriting.
+severity: minor
+resolution: 'Documented the limitation in the test comment (internal/store/storetest/tx.go): a green run is strong evidence, not proof; a red run is always a real bug. The pgstore case is stronger in practice (without the advisory lock, READ COMMITTED all but guarantees a lost update at this concurrency).'
+status: addressed
+---

--- a/tickets/entities/tickets/TKT-GXHI8.md
+++ b/tickets/entities/tickets/TKT-GXHI8.md
@@ -1,0 +1,39 @@
+---
+id: TKT-GXHI8
+type: ticket
+title: Add Tx write-transaction contract to store.Store with fs/mem/pg implementations (DEC-8UIL0 phase 1)
+kind: enhancement
+priority: medium
+effort: m
+status: done
+---
+
+First slice of the [[DEC-8UIL0]] store-transaction arc (researched in
+[[RES-Z1SJ5]]): add `Tx(ctx, fn func(Store) error)` to the `store.Store`
+interface and implement it in all three backends. No callers change in this PR —
+entitymanager wiring, the Lua `rela.tx` helper, and writeMu deletion are later
+slices.
+
+## Scope
+
+- `store.Transactor` interface embedded in `store.Store` (interface member, not
+an optional capability — every backend implements it).
+- fsstore/memstore: `txMu` serialization — public write methods acquire it
+briefly; `Tx` holds it across the callback and hands a view that skips it
+(re-entrancy by structure; Go has no reentrant mutex). **Reduced guarantees
+accepted for single-user fs deployments:** no rollback (an error mid-callback
+leaves earlier writes applied), events emitted inline per write, watcher
+reconciliation of external file edits not excluded.
+- pgstore: `Tx` = `BEGIN` + global `pg_advisory_xact_lock` (new write key,
+distinct from sweep/migrate keys) + a tx-bound store view; per-write methods run
+as savepoints via the existing `DBTX` seam; `pg_notify` defers to outer commit
+natively; in-process observer/subscriber notifications buffered and replayed
+after commit; rollback on error.
+- Nested `Tx` joins (no nested-transaction API).
+- storetest: shared `RunTxTests` in `RunAll` (visibility, read-your-writes,
+serialized read-modify-write under concurrency, error propagation, nested join)
+plus `RunTxRollbackTests` opted into by pgstore only.
+- Root CLAUDE.md rule amendment per the decision.
+
+Out of scope (later slices): entitymanager intent wrapping, Lua `rela.tx`,
+writeMu deletion, fs rollback journal, per-entity lock granularity.

--- a/tickets/entities/tickets/TKT-R68TV8.md
+++ b/tickets/entities/tickets/TKT-R68TV8.md
@@ -28,21 +28,25 @@ coupling is gone and the handler clusters can move off `App` one at a time.
   - [x] [[TKT-VG9P1]] — sync route cluster → `syncHandler` (170 → 154). PR #1134.
   - [x] [[TKT-KUFLD]] — command route cluster → `commandHandler` (154 → 143).
 PR #1138.
-  - [ ] Attachment handler cluster (`handlers_attachment.go`, ~12 methods).
+  - [x] [[TKT-QTPUA]] — attachment cluster → `attachmentHandler` + package
+functions (143 → 131). PR #1149.
 - **M5.4 — write nucleus.** Carve the entity/relation/attachment write handlers
 behind one shared `writeMu`; drive `App` under 40 and delete the
 `//plimsoll:max-methods` directive in `internal/dataentry/app.go`.
-  - **Open question to settle first:** does write-serialization move *behind the
-store* (the CLAUDE.md-endorsed direction) or stay an App-level mutex the write
-handlers share by pointer (as `syncHandler` does today)? Worth a design-review
-before extracting the write handlers.
+  - **Open question — settled.** Researched in [[RES-Z1SJ5]], decided in
+[[DEC-8UIL0]]: write serialization becomes a `Tx` contract on `store.Store` (fs
+= mutex, postgres = native transactions + advisory lock), implemented as its
+**own follow-up arc** that deletes `writeMu` outright. M5.4 itself proceeds
+conservatively: the mutex moves with the write-nucleus struct, semantics
+untouched — refactors don't change concurrency behavior.
 
 ## Invariants (unchanged)
 
 - Read handlers take the ACL-bounded `visibleReader` only — never `store.Store`.
 - `writeMu` stays a single shared instance across all write handlers (race
 detector guards). The extracted handlers hold a *pointer* to `App`'s `writeMu`,
-preserving this.
+preserving this. (Holds until the [[DEC-8UIL0]] arc replaces the mutex with
+store `Tx`.)
 
 ## Related finding
 

--- a/tickets/relations/DEC-8UIL0--decides--store-backends.md
+++ b/tickets/relations/DEC-8UIL0--decides--store-backends.md
@@ -1,0 +1,5 @@
+---
+from: DEC-8UIL0
+relation: decides
+to: store-backends
+---

--- a/tickets/relations/FEAT-ARR07--requires--store-backends.md
+++ b/tickets/relations/FEAT-ARR07--requires--store-backends.md
@@ -1,0 +1,5 @@
+---
+from: FEAT-ARR07
+relation: requires
+to: store-backends
+---

--- a/tickets/relations/RES-Z1SJ5--informs--DEC-8UIL0.md
+++ b/tickets/relations/RES-Z1SJ5--informs--DEC-8UIL0.md
@@ -1,0 +1,5 @@
+---
+from: RES-Z1SJ5
+relation: informs
+to: DEC-8UIL0
+---

--- a/tickets/relations/RES-Z1SJ5--researches--data-entry-ui.md
+++ b/tickets/relations/RES-Z1SJ5--researches--data-entry-ui.md
@@ -1,0 +1,5 @@
+---
+from: RES-Z1SJ5
+relation: researches
+to: data-entry-ui
+---

--- a/tickets/relations/RES-Z1SJ5--researches--lua-scripting.md
+++ b/tickets/relations/RES-Z1SJ5--researches--lua-scripting.md
@@ -1,0 +1,5 @@
+---
+from: RES-Z1SJ5
+relation: researches
+to: lua-scripting
+---

--- a/tickets/relations/RES-Z1SJ5--researches--store-backends.md
+++ b/tickets/relations/RES-Z1SJ5--researches--store-backends.md
@@ -1,0 +1,5 @@
+---
+from: RES-Z1SJ5
+relation: researches
+to: store-backends
+---

--- a/tickets/relations/TKT-GXHI8--affects--store-backends.md
+++ b/tickets/relations/TKT-GXHI8--affects--store-backends.md
@@ -1,0 +1,5 @@
+---
+from: TKT-GXHI8
+relation: affects
+to: store-backends
+---

--- a/tickets/relations/TKT-GXHI8--has-docs--DOCS-8I8CB.md
+++ b/tickets/relations/TKT-GXHI8--has-docs--DOCS-8I8CB.md
@@ -1,0 +1,5 @@
+---
+from: TKT-GXHI8
+relation: has-docs
+to: DOCS-8I8CB
+---

--- a/tickets/relations/TKT-GXHI8--has-implementation--IMPL-KEG5N.md
+++ b/tickets/relations/TKT-GXHI8--has-implementation--IMPL-KEG5N.md
@@ -1,0 +1,5 @@
+---
+from: TKT-GXHI8
+relation: has-implementation
+to: IMPL-KEG5N
+---

--- a/tickets/relations/TKT-GXHI8--has-planning--PLAN-LBUI4.md
+++ b/tickets/relations/TKT-GXHI8--has-planning--PLAN-LBUI4.md
@@ -1,0 +1,5 @@
+---
+from: TKT-GXHI8
+relation: has-planning
+to: PLAN-LBUI4
+---

--- a/tickets/relations/TKT-GXHI8--has-research--RES-Z1SJ5.md
+++ b/tickets/relations/TKT-GXHI8--has-research--RES-Z1SJ5.md
@@ -1,0 +1,5 @@
+---
+from: TKT-GXHI8
+relation: has-research
+to: RES-Z1SJ5
+---

--- a/tickets/relations/TKT-GXHI8--has-review--REV-9E3RY.md
+++ b/tickets/relations/TKT-GXHI8--has-review--REV-9E3RY.md
@@ -1,0 +1,5 @@
+---
+from: TKT-GXHI8
+relation: has-review
+to: REV-9E3RY
+---

--- a/tickets/relations/TKT-GXHI8--has-review-response--RR-QWFGJ.md
+++ b/tickets/relations/TKT-GXHI8--has-review-response--RR-QWFGJ.md
@@ -1,0 +1,5 @@
+---
+from: TKT-GXHI8
+relation: has-review-response
+to: RR-QWFGJ
+---

--- a/tickets/relations/TKT-GXHI8--has-review-response--RR-XBZX5.md
+++ b/tickets/relations/TKT-GXHI8--has-review-response--RR-XBZX5.md
@@ -1,0 +1,5 @@
+---
+from: TKT-GXHI8
+relation: has-review-response
+to: RR-XBZX5
+---

--- a/tickets/relations/TKT-GXHI8--has-review-response--RR-Y75YD.md
+++ b/tickets/relations/TKT-GXHI8--has-review-response--RR-Y75YD.md
@@ -1,0 +1,5 @@
+---
+from: TKT-GXHI8
+relation: has-review-response
+to: RR-Y75YD
+---

--- a/tickets/relations/TKT-GXHI8--implements--FEAT-ARR07.md
+++ b/tickets/relations/TKT-GXHI8--implements--FEAT-ARR07.md
@@ -1,0 +1,5 @@
+---
+from: TKT-GXHI8
+relation: implements
+to: FEAT-ARR07
+---

--- a/tickets/relations/TKT-R68TV8--has-research--RES-Z1SJ5.md
+++ b/tickets/relations/TKT-R68TV8--has-research--RES-Z1SJ5.md
@@ -1,0 +1,5 @@
+---
+from: TKT-R68TV8
+relation: has-research
+to: RES-Z1SJ5
+---


### PR DESCRIPTION
Phase 1 of the DEC-8UIL0 store-transaction arc (research: RES-Z1SJ5). Adds `Tx(ctx, fn func(Store) error)` to the `store.Store` interface (embedded `Transactor`) and implements it in all three backends. **No callers change in this PR** — entitymanager intent wrapping, the Lua `rela.tx` helper, and dataentry `writeMu` deletion are later slices.

**Stacked on #1149** (attachment-handler extraction); retarget to `develop` after that merges. The RES/DEC/epic ticket entities ride this PR since it's the first branch of the arc.

## What

- **`store.Transactor`** embedded in `store.Store` — an interface member, not an optional capability: every backend implements it, and future callers depend on it for correctness. Contract godoc specifies behavior, not mechanism.
- **fsstore/memstore**: new `txMu` mutex; exported write methods take it briefly, `Tx` holds it across the callback and hands a `txStore` view calling unexported cores (Go has no reentrant mutex — re-entrancy by structure). **Reduced single-user guarantees by design**: mutual exclusion only, no rollback, events inline.
- **pgstore**: `Tx` = outer `BEGIN` + `pg_advisory_xact_lock` on a new deployment-wide write key (distinct from migrate/sweep keys) + a tx-bound store view. Per-write methods run unchanged as savepoints via the `DBTX` seam; `pg_notify` defers to outer commit natively; in-process observer/subscriber events buffer in `txPending` and replay after commit. Full rollback on error.
- Nested `Tx` joins the open transaction (no nested-tx API).
- **storetest**: `RunTxTests` added to `RunAll` (visibility, read-your-writes, 8-writer serialized read-modify-write counter, error propagation, nested join); `RunTxRollbackTests` (rollback + event-timing assertions) opted into by pgstore only.
- Root CLAUDE.md "no transaction abstractions" rule amended per DEC-8UIL0; `docs/postgres-backend.md` gained a Write transactions section.
- plimsoll pins bumped with required-interface justification (FSStore 84→95 total / 32→33 exported, MemStore new 42 pin / 27→28 exported, pgstore 52→53 / 39→40).

## Verification

- Builds + vet: default, `postgres`, `memorybackend` tags.
- `go test ./...` and `-race` on fsstore/memstore/storetest.
- **pgstore suite against a real PostgreSQL 15** (`go test -race -tags postgres`): full pass; all five `Tx` conformance subtests and all four `TxRollback` subtests confirmed executed.
- `just plimsoll`, `just arch-lint`, `just coverage-check` (76.2%), `golangci-lint` on store packages, `gofmt`: clean.
- Code review (cranky-code-reviewer): no critical/significant findings; two minors addressed in-branch (escaped-view godoc, probabilistic-test comment — RR-XBZX5, RR-Y75YD), one nit wont-fix with reason (RR-QWFGJ).

## Ticket flow

TKT-GXHI8 (done) with full workflow: PLAN-LBUI4, IMPL-KEG5N, REV-9E3RY, DOCS-8I8CB, review-responses linked. Feature FEAT-ARR07; decision DEC-8UIL0; research RES-Z1SJ5.