### PR TITLE
feat: resolved transition affordance (TKT-FT8J9)

### DIFF
--- a/.go-arch-lint.yml
+++ b/.go-arch-lint.yml
@@ -291,6 +291,7 @@ deps:
       - search
       - searchparser
       - state
+      - statemachine
       - storage
       - store
       - sync
@@ -450,6 +451,7 @@ deps:
       - metamodel
       - predicate
       - principal
+      - statemachine
   audit:
     mayDependOn:
       - principal

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,7 +62,10 @@
   `appbuild.New` or takes focused interfaces at the call site.
 - **Don't run user-supplied Lua on the read path.** ACL gates evaluate
   against declarative policy + the graph; Lua participates only at write
-  time. See `internal/entitymanager/CLAUDE.md`.
+  time. This targets unbounded/hot paths (per-row predicates on list reads),
+  NOT a bounded single-subject evaluation the caller explicitly requested
+  (e.g. performable transitions for one field on one entity). See
+  `internal/entitymanager/CLAUDE.md`.
 
 ### Subsystem-specific rules (nested CLAUDE.md / godoc)
 

--- a/internal/affordances/resolver.go
+++ b/internal/affordances/resolver.go
@@ -155,7 +155,15 @@ func New(
 // [PolicyResolver.TransitionVerdicts] can resolve performable transitions.
 // Optional and chainable: a resolver without machines (or with an empty set)
 // answers TransitionVerdicts with nil, so existing callers that don't wire
-// transitions are unaffected. Call once at wiring time, before concurrent use.
+// transitions are unaffected.
+//
+// CONCURRENCY: this is the one mutator on an otherwise-immutable-after-[New]
+// resolver, so the "safe for concurrent use" guarantee holds only if it is
+// called during single-threaded wiring, BEFORE the resolver is shared — which
+// is the sole production call site ([ResolverFromProfile], synchronous, before
+// the resolver escapes). It is a setter rather than a [New] parameter
+// deliberately: machines are optional and adding a required arg would churn all
+// [New] callers. Never call WithMachines concurrently with TransitionVerdicts.
 func (r *PolicyResolver) WithMachines(m *statemachine.Set) *PolicyResolver {
 	r.machines = m
 	return r
@@ -459,7 +467,18 @@ func (r *PolicyResolver) TransitionVerdicts(
 // principal. It resolves via the per-request [acl.Request] on ctx when present
 // (reusing the list-handler scope), else opens one for the principal. Answers
 // via [acl.Request.HoldsPermissionForEntity] so ownership-relation-conferred
-// permissions are honored — identical to the write-path guard.
+// permissions are honored (the same subject-aware resolution the write-path
+// guard uses).
+//
+// This guard fails CLOSED unconditionally: an unstamped/unresolvable principal
+// holds no permission, so guarded transitions read as not-performable. Unlike
+// the write-path guard (appbuild.transitionGuard), it has NO "no policy → inert
+// allow" tier — because it is only ever wired under an active policy
+// (ResolverFromProfile constructs the machine-backed resolver only when the
+// policy declares affordance grants). Do NOT wire TransitionVerdicts from a
+// no-policy/CLI path expecting inert behavior: there, an unstamped principal
+// would be shown zero performable transitions even where a write would succeed
+// inert. If such a caller is ever needed, add the policy-active tier here first.
 func (r *PolicyResolver) transitionGuard(ctx context.Context) statemachine.Guard {
 	req := acl.FromContext(ctx)
 	if req == nil {
@@ -474,7 +493,8 @@ func (r *PolicyResolver) transitionGuard(ctx context.Context) statemachine.Guard
 
 // requestGuard evaluates a transition guard against an acl.Request. A nil
 // request (unresolved/unstamped principal) holds no permission → guarded edges
-// resolve as not-performable, consistent with the write path failing closed.
+// resolve as not-performable (fail closed). See [PolicyResolver.transitionGuard]
+// for why there is no inert tier.
 type requestGuard struct{ req *acl.Request }
 
 func (g requestGuard) HoldsPermission(ctx context.Context, subjectID, permission string) bool {

--- a/internal/affordances/resolver.go
+++ b/internal/affordances/resolver.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Sourcehaven-BV/rela/internal/metamodel"
 	"github.com/Sourcehaven-BV/rela/internal/predicate"
 	"github.com/Sourcehaven-BV/rela/internal/principal"
+	"github.com/Sourcehaven-BV/rela/internal/statemachine"
 )
 
 // FieldVerdicts carries per-entity field-level affordance decisions.
@@ -56,6 +57,12 @@ type PolicyResolver struct {
 	// groups, containment, and typed-Source attribution. Required
 	// (never nil after [New] returns); [New] rejects a nil argument.
 	declarative *acl.Declarative
+
+	// machines is the compiled enum state machines (TKT-E4LW2). Used by
+	// [PolicyResolver.TransitionVerdicts] to resolve which transitions the
+	// current principal can perform on an entity. May be nil / empty (a
+	// metamodel with no transitions) — TransitionVerdicts then returns nil.
+	machines *statemachine.Set
 
 	// envs holds the compiled predicate env per entity type, reused
 	// across grants of that type.
@@ -142,6 +149,16 @@ func New(
 		return nil, errors.Join(errs...)
 	}
 	return r, nil
+}
+
+// WithMachines injects the compiled enum state machines so
+// [PolicyResolver.TransitionVerdicts] can resolve performable transitions.
+// Optional and chainable: a resolver without machines (or with an empty set)
+// answers TransitionVerdicts with nil, so existing callers that don't wire
+// transitions are unaffected. Call once at wiring time, before concurrent use.
+func (r *PolicyResolver) WithMachines(m *statemachine.Set) *PolicyResolver {
+	r.machines = m
+	return r
 }
 
 // env returns (compiling on first use) the predicate env for an entity
@@ -406,6 +423,65 @@ func (r *PolicyResolver) RelationVerdicts(ctx context.Context, e *entity.Entity)
 	}
 	out.Types = acc.verdicts()
 	return out
+}
+
+// TransitionVerdicts resolves, per state-machine-typed property on e, the
+// transitions the ctx principal can perform right now — guard held
+// (subject-aware) AND `when:` precondition met — plus, for blocked edges, which
+// gate blocked them (TKT-FT8J9). It is the read-side counterpart of the write
+// path's transition enforcement, sharing the same evaluation via
+// [statemachine.Set.Performable], so the "what can I do" answer here cannot
+// disagree with what a write would accept.
+//
+// Returns an empty map when no machines are wired, e is nil, or e's type has no
+// state-machine property. This is a bounded per-entity read (only e's machine
+// fields and their out-edges are evaluated), which is why running the `when:`
+// predicate here is consistent with the no-predicate-on-reads rule — see
+// internal/entitymanager/CLAUDE.md.
+func (r *PolicyResolver) TransitionVerdicts(
+	ctx context.Context, e *entity.Entity,
+) map[string][]statemachine.TransitionVerdict {
+	out := map[string][]statemachine.TransitionVerdict{}
+	if e == nil || r.machines == nil || r.machines.Empty() {
+		return out
+	}
+	guard := r.transitionGuard(ctx)
+	for _, prop := range r.machines.MachineProps(e.Type) {
+		if vs := r.machines.Performable(ctx, e, prop, guard, r.lookup); len(vs) > 0 {
+			out[prop] = vs
+		}
+	}
+	return out
+}
+
+// transitionGuard adapts the resolver's ACL into the subject-aware
+// [statemachine.Guard] the transition resolver needs, bound to the ctx
+// principal. It resolves via the per-request [acl.Request] on ctx when present
+// (reusing the list-handler scope), else opens one for the principal. Answers
+// via [acl.Request.HoldsPermissionForEntity] so ownership-relation-conferred
+// permissions are honored — identical to the write-path guard.
+func (r *PolicyResolver) transitionGuard(ctx context.Context) statemachine.Guard {
+	req := acl.FromContext(ctx)
+	if req == nil {
+		var err error
+		req, err = r.declarative.ForPrincipal(principal.From(ctx))
+		if err != nil {
+			req = nil // unstamped principal → holds no guarded permission
+		}
+	}
+	return requestGuard{req: req}
+}
+
+// requestGuard evaluates a transition guard against an acl.Request. A nil
+// request (unresolved/unstamped principal) holds no permission → guarded edges
+// resolve as not-performable, consistent with the write path failing closed.
+type requestGuard struct{ req *acl.Request }
+
+func (g requestGuard) HoldsPermission(ctx context.Context, subjectID, permission string) bool {
+	if g.req == nil {
+		return false
+	}
+	return g.req.HoldsPermissionForEntity(ctx, subjectID, permission)
 }
 
 // bindingFor resolves the effective role set for (principal, entity)

--- a/internal/affordances/transitions_test.go
+++ b/internal/affordances/transitions_test.go
@@ -1,0 +1,140 @@
+package affordances_test
+
+import (
+	"testing"
+
+	"github.com/Sourcehaven-BV/rela/internal/affordances"
+	"github.com/Sourcehaven-BV/rela/internal/metamodel"
+	"github.com/Sourcehaven-BV/rela/internal/statemachine"
+)
+
+// transitionMeta is a ticket type whose `status` is a NAMED state-machine type
+// (transitions live on the CustomType). open→review is guarded by `review-it`;
+// review→done is guarded by `close-it` and gated on a `signed-off` relation.
+func transitionMeta() *metamodel.Metamodel {
+	return &metamodel.Metamodel{
+		Types: map[string]metamodel.CustomType{
+			"ticket-status": {
+				Values:  []string{"open", "review", "done"},
+				Initial: "open",
+				Transitions: []metamodel.TransitionDef{
+					{From: "open", To: "review", Guard: "review-it"},
+					{From: "review", To: "done", Guard: "close-it", When: `count_relations(entity, "signed-off") > 0`},
+					{From: "review", To: "open", Guard: "review-it"},
+				},
+			},
+		},
+		Entities: map[string]metamodel.EntityDef{
+			"ticket": {Properties: map[string]metamodel.PropertyDef{
+				"title":  {Type: metamodel.PropertyTypeString},
+				"status": {Type: "ticket-status"},
+			}},
+		},
+	}
+}
+
+// newTransitionResolver builds a resolver over transitionMeta with a policy
+// granting `alice` the given permissions, and the given graph edges.
+func newTransitionResolver(t *testing.T, perms string, edges ...[3]string) *affordances.PolicyResolver {
+	t.Helper()
+	meta := transitionMeta()
+	p := policyFromYAML(t, `
+roles:
+  editor:
+    permissions: [`+perms+`]
+assignments:
+  alice: editor
+`)
+	r, err := affordances.New(meta, newStubLookup(edges...), declFor(t, p))
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	machines, err := statemachine.Compile(meta)
+	if err != nil {
+		t.Fatalf("Compile: %v", err)
+	}
+	return r.WithMachines(machines)
+}
+
+func verdictByTo(vs []statemachine.TransitionVerdict, to string) (statemachine.TransitionVerdict, bool) {
+	for _, v := range vs {
+		if v.To == to {
+			return v, true
+		}
+	}
+	return statemachine.TransitionVerdict{}, false
+}
+
+func TestTransitionVerdicts_GuardHeld(t *testing.T) {
+	r := newTransitionResolver(t, "review-it")
+	e := ticket("T-1", map[string]interface{}{"status": "open"})
+
+	got := r.TransitionVerdicts(ctxAs("alice"), e)
+	vs := got["status"]
+	if len(vs) != 1 {
+		t.Fatalf("open has one out-edge (→review), got %+v", vs)
+	}
+	v := vs[0]
+	if v.To != "review" || !v.Allowed || v.Reason != statemachine.VerdictAllowed {
+		t.Errorf("open→review with review-it held should be allowed, got %+v", v)
+	}
+}
+
+func TestTransitionVerdicts_GuardDenied(t *testing.T) {
+	r := newTransitionResolver(t, "" /* no perms */)
+	e := ticket("T-1", map[string]interface{}{"status": "open"})
+
+	v := r.TransitionVerdicts(ctxAs("alice"), e)["status"][0]
+	if v.Allowed || v.Reason != statemachine.VerdictGuard {
+		t.Errorf("open→review without review-it should be guard-denied, got %+v", v)
+	}
+	// The guard name is surfaced for the UI to explain the disabled option.
+	if v.Guard != "review-it" {
+		t.Errorf("verdict should carry guard name, got %q", v.Guard)
+	}
+}
+
+func TestTransitionVerdicts_PreconditionGate(t *testing.T) {
+	// alice holds both guards; review→done additionally needs a signed-off edge.
+	t.Run("precondition unmet", func(t *testing.T) {
+		r := newTransitionResolver(t, "review-it, close-it") // no signed-off edge
+		e := ticket("T-1", map[string]interface{}{"status": "review"})
+		done, ok := verdictByTo(r.TransitionVerdicts(ctxAs("alice"), e)["status"], "done")
+		if !ok {
+			t.Fatal("expected a →done verdict")
+		}
+		if done.Allowed || done.Reason != statemachine.VerdictPrecondition {
+			t.Errorf("review→done without signed-off should be precondition-blocked, got %+v", done)
+		}
+	})
+	t.Run("precondition met", func(t *testing.T) {
+		r := newTransitionResolver(t, "review-it, close-it", [3]string{"T-1", "signed-off", "PERS-x"})
+		e := ticket("T-1", map[string]interface{}{"status": "review"})
+		done, _ := verdictByTo(r.TransitionVerdicts(ctxAs("alice"), e)["status"], "done")
+		if !done.Allowed {
+			t.Errorf("review→done with signed-off + close-it should be allowed, got %+v", done)
+		}
+	})
+}
+
+func TestTransitionVerdicts_NoMachinesWired(t *testing.T) {
+	// A resolver without WithMachines returns an empty map.
+	meta := transitionMeta()
+	p := policyFromYAML(t, "roles: {}\n")
+	r, err := affordances.New(meta, newStubLookup(), declFor(t, p))
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if got := r.TransitionVerdicts(ctxAs("alice"), ticket("T-1", map[string]interface{}{"status": "open"})); len(got) != 0 {
+		t.Errorf("no machines wired should give empty map, got %+v", got)
+	}
+}
+
+func TestTransitionVerdicts_NonMachineType(t *testing.T) {
+	r := newTransitionResolver(t, "review-it")
+	// feature has no status machine (not even in transitionMeta) → empty.
+	if got := r.TransitionVerdicts(ctxAs("alice"), ticket("T-1", map[string]interface{}{"status": "done"})); len(got) != 0 {
+		// "done" is terminal → no out-edges → empty map.
+		t.Errorf("terminal state should give empty map, got %+v", got)
+	}
+}

--- a/internal/affordances/transitions_test.go
+++ b/internal/affordances/transitions_test.go
@@ -67,7 +67,7 @@ func verdictByTo(vs []statemachine.TransitionVerdict, to string) (statemachine.T
 
 func TestTransitionVerdicts_GuardHeld(t *testing.T) {
 	r := newTransitionResolver(t, "review-it")
-	e := ticket("T-1", map[string]interface{}{"status": "open"})
+	e := ticket("T-1", map[string]any{"status": "open"})
 
 	got := r.TransitionVerdicts(ctxAs("alice"), e)
 	vs := got["status"]
@@ -82,7 +82,7 @@ func TestTransitionVerdicts_GuardHeld(t *testing.T) {
 
 func TestTransitionVerdicts_GuardDenied(t *testing.T) {
 	r := newTransitionResolver(t, "" /* no perms */)
-	e := ticket("T-1", map[string]interface{}{"status": "open"})
+	e := ticket("T-1", map[string]any{"status": "open"})
 
 	v := r.TransitionVerdicts(ctxAs("alice"), e)["status"][0]
 	if v.Allowed || v.Reason != statemachine.VerdictGuard {
@@ -98,7 +98,7 @@ func TestTransitionVerdicts_PreconditionGate(t *testing.T) {
 	// alice holds both guards; review→done additionally needs a signed-off edge.
 	t.Run("precondition unmet", func(t *testing.T) {
 		r := newTransitionResolver(t, "review-it, close-it") // no signed-off edge
-		e := ticket("T-1", map[string]interface{}{"status": "review"})
+		e := ticket("T-1", map[string]any{"status": "review"})
 		done, ok := verdictByTo(r.TransitionVerdicts(ctxAs("alice"), e)["status"], "done")
 		if !ok {
 			t.Fatal("expected a →done verdict")
@@ -109,7 +109,7 @@ func TestTransitionVerdicts_PreconditionGate(t *testing.T) {
 	})
 	t.Run("precondition met", func(t *testing.T) {
 		r := newTransitionResolver(t, "review-it, close-it", [3]string{"T-1", "signed-off", "PERS-x"})
-		e := ticket("T-1", map[string]interface{}{"status": "review"})
+		e := ticket("T-1", map[string]any{"status": "review"})
 		done, _ := verdictByTo(r.TransitionVerdicts(ctxAs("alice"), e)["status"], "done")
 		if !done.Allowed {
 			t.Errorf("review→done with signed-off + close-it should be allowed, got %+v", done)
@@ -125,7 +125,7 @@ func TestTransitionVerdicts_NoMachinesWired(t *testing.T) {
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
-	if got := r.TransitionVerdicts(ctxAs("alice"), ticket("T-1", map[string]interface{}{"status": "open"})); len(got) != 0 {
+	if got := r.TransitionVerdicts(ctxAs("alice"), ticket("T-1", map[string]any{"status": "open"})); len(got) != 0 {
 		t.Errorf("no machines wired should give empty map, got %+v", got)
 	}
 }
@@ -133,7 +133,7 @@ func TestTransitionVerdicts_NoMachinesWired(t *testing.T) {
 func TestTransitionVerdicts_NonMachineType(t *testing.T) {
 	r := newTransitionResolver(t, "review-it")
 	// feature has no status machine (not even in transitionMeta) → empty.
-	if got := r.TransitionVerdicts(ctxAs("alice"), ticket("T-1", map[string]interface{}{"status": "done"})); len(got) != 0 {
+	if got := r.TransitionVerdicts(ctxAs("alice"), ticket("T-1", map[string]any{"status": "done"})); len(got) != 0 {
 		// "done" is terminal → no out-edges → empty map.
 		t.Errorf("terminal state should give empty map, got %+v", got)
 	}

--- a/internal/dataentry/affordances_stub.go
+++ b/internal/dataentry/affordances_stub.go
@@ -77,12 +77,15 @@ func ResolverFromProfile(
 		return nil, fmt.Errorf("dataentry: compiling acl.yaml affordance predicates: %w", err)
 	}
 	// Wire the enum state machines so the resolver can answer
-	// TransitionVerdicts (TKT-FT8J9). Compiled from the same metamodel the
-	// entitymanager compiled its enforcer from — Compile is a deterministic
-	// pure transform, so the two Sets are identical; the read/write drift
-	// guard is the shared evalEdge, not shared instance identity. (Threading
-	// the entitymanager's single Set through appbuild.Services is the follow-up
-	// when the SPA status control wires the whole surface.)
+	// TransitionVerdicts (TKT-FT8J9). Compiled from the same (load-once,
+	// read-only) metamodel the entitymanager compiled its enforcer from:
+	// Compile is a deterministic pure transform AND meta is immutable between
+	// the two calls, so the two Sets are semantically identical. Correctness
+	// does not actually depend on that identity, though — the read/write
+	// drift guard is the shared evalEdge, so two Sets from the same source
+	// cannot disagree regardless. (Threading the entitymanager's single Set
+	// through appbuild.Services is the follow-up when the SPA status control
+	// wires the whole surface.)
 	machines, err := statemachine.Compile(meta)
 	if err != nil {
 		return nil, fmt.Errorf("dataentry: compiling state machines: %w", err)

--- a/internal/dataentry/affordances_stub.go
+++ b/internal/dataentry/affordances_stub.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Sourcehaven-BV/rela/internal/affordances"
 	entityPkg "github.com/Sourcehaven-BV/rela/internal/entity"
 	"github.com/Sourcehaven-BV/rela/internal/metamodel"
+	"github.com/Sourcehaven-BV/rela/internal/statemachine"
 	"github.com/Sourcehaven-BV/rela/internal/store"
 )
 
@@ -75,6 +76,18 @@ func ResolverFromProfile(
 	if err != nil {
 		return nil, fmt.Errorf("dataentry: compiling acl.yaml affordance predicates: %w", err)
 	}
+	// Wire the enum state machines so the resolver can answer
+	// TransitionVerdicts (TKT-FT8J9). Compiled from the same metamodel the
+	// entitymanager compiled its enforcer from — Compile is a deterministic
+	// pure transform, so the two Sets are identical; the read/write drift
+	// guard is the shared evalEdge, not shared instance identity. (Threading
+	// the entitymanager's single Set through appbuild.Services is the follow-up
+	// when the SPA status control wires the whole surface.)
+	machines, err := statemachine.Compile(meta)
+	if err != nil {
+		return nil, fmt.Errorf("dataentry: compiling state machines: %w", err)
+	}
+	resolver.WithMachines(machines)
 	return &policyResolver{inner: resolver}, nil
 }
 

--- a/internal/entitymanager/CLAUDE.md
+++ b/internal/entitymanager/CLAUDE.md
@@ -66,6 +66,17 @@ wiring boundary is explicit.
   on reads is the perf cliff every comparable system regrets — see
   `.ignored/acl-design.md`.
 
+  **What this rule is about: unbounded, hot paths — list/collection reads
+  where a predicate runs once per row across hundreds of entities. That is
+  the perf cliff.** It is NOT a blanket ban on ever evaluating a predicate
+  during a read. A *bounded, on-demand* evaluation — e.g. resolving the
+  performable state-machine transitions for one field on the one entity a
+  user is viewing (O(out-edges), single entity) — is consistent with the
+  rule's intent, not a violation of it. When in doubt, ask: does this scale
+  with the size of a result set (banned) or is it a fixed, single-subject
+  computation the caller explicitly requested (fine)? Don't cite this rule to
+  block the latter.
+
 See `docs/server-security.md` (schema reference), `.ignored/acl-design.md` (design
 rationale, four-layer model: users → groups → roles → local roles), and
 `docs/audit-log.md` (the `denied-write` audit op).

--- a/internal/statemachine/enforce.go
+++ b/internal/statemachine/enforce.go
@@ -77,7 +77,11 @@ func (s *Set) EnforceCreate(_ context.Context, e *entity.Entity) error {
 	return nil
 }
 
-// applyEdge runs the three checks for one changed machine property.
+// applyEdge runs the three checks for one changed machine property, mapping a
+// failing gate to the wire-facing error. Legality (undeclared edge) and the
+// gate evaluation share one code path — [evalEdge] — with the read-side
+// [Set.Performable], so enforcement and the "what can I do" affordance can
+// never disagree about whether a transition is allowed (the drift guard).
 func (s *Set) applyEdge(
 	ctx context.Context, m *Machine, prop, from, to string, e *entity.Entity, guard Guard, lookup GraphLookup,
 ) error {
@@ -85,25 +89,58 @@ func (s *Set) applyEdge(
 	if !ok {
 		return fmt.Errorf("%w: %s %q→%q is not a declared transition", ErrIllegalTransition, prop, from, to)
 	}
+	switch res := evalEdge(ctx, ed, prop, e, guard, lookup); res.gate {
+	case gateNone:
+		return nil
+	case gateGuard:
+		return &GuardError{Prop: prop, From: from, To: to, Permission: ed.guard}
+	default: // gatePrecondition
+		if res.err != nil {
+			return fmt.Errorf("%w: %s %q→%q when: %s", ErrPreconditionFailed, prop, from, to, res.err.Error())
+		}
+		return fmt.Errorf("%w: %s %q→%q precondition not met", ErrPreconditionFailed, prop, from, to)
+	}
+}
 
-	// Guard: the guard decides served-vs-inert (it resolves the principal from
-	// ctx and allows when there is nothing to evaluate). A nil guard on a
-	// guarded edge fails closed.
+// gate identifies which check on an edge failed (or none).
+type gate int
+
+const (
+	gateNone gate = iota
+	gateGuard
+	gatePrecondition
+)
+
+// edgeResult is the outcome of evaluating one edge's gates.
+type edgeResult struct {
+	gate gate
+	err  error // non-nil only when a `when:` predicate errored (gatePrecondition)
+}
+
+// evalEdge evaluates an edge's guard then precondition for (principal-on-ctx,
+// entity e), in the same order and with the same semantics the write path
+// enforces. It is the single source of truth shared by [Set.applyEdge] (write,
+// maps to errors) and [Set.Performable] (read, maps to verdicts) so the two can
+// never drift. A guard is checked first (an unheld guard short-circuits without
+// evaluating the precondition, matching enforcement). A nil guard on a guarded
+// edge fails closed. The guard's served-vs-inert decision lives in the Guard
+// implementation.
+func evalEdge(
+	ctx context.Context, ed edge, prop string, e *entity.Entity, guard Guard, lookup GraphLookup,
+) edgeResult {
 	if ed.guard != "" {
 		if guard == nil || !guard.HoldsPermission(ctx, e.ID, ed.guard) {
-			return &GuardError{Prop: prop, From: from, To: to, Permission: ed.guard}
+			return edgeResult{gate: gateGuard}
 		}
 	}
-
-	// Precondition.
 	if ed.when != nil {
 		ok, err := evalWhen(ctx, ed.when, e, prop, lookup)
 		if err != nil {
-			return fmt.Errorf("%w: %s %q→%q when: %s", ErrPreconditionFailed, prop, from, to, err.Error())
+			return edgeResult{gate: gatePrecondition, err: err}
 		}
 		if !ok {
-			return fmt.Errorf("%w: %s %q→%q precondition not met", ErrPreconditionFailed, prop, from, to)
+			return edgeResult{gate: gatePrecondition}
 		}
 	}
-	return nil
+	return edgeResult{gate: gateNone}
 }

--- a/internal/statemachine/resolve.go
+++ b/internal/statemachine/resolve.go
@@ -65,10 +65,24 @@ func (s *Set) Performable(
 
 	var out []TransitionVerdict
 	for key, ed := range m.edges {
-		if key.from != from {
+		if key.from != from || key.to == from {
+			// Not an out-edge from the current value, or a self-loop. A
+			// self-loop is a no-op write (EnforceUpdate skips unchanged
+			// values before reaching the edge), so it is never a
+			// *performable* transition — excluding it keeps read parity with
+			// write (a self-loop verdict would claim an action the write path
+			// never enforces).
 			continue
 		}
-		res := evalEdge(ctx, ed, prop, e, guard, lookup)
+		// Evaluate the gates against the entity AS IT WOULD BE after the move —
+		// prop = key.to — exactly as the write path evaluates them (it feeds
+		// applyEdge the post-write `updated` entity). A `when:` that reads
+		// `entity.value` must see the target value here, or the read verdict
+		// would disagree with what the write actually enforces (the AC4 drift
+		// guard depends on this).
+		after := e.Clone()
+		after.SetString(prop, key.to)
+		res := evalEdge(ctx, ed, prop, after, guard, lookup)
 		out = append(out, TransitionVerdict{
 			To:      key.to,
 			Guard:   ed.guard,

--- a/internal/statemachine/resolve.go
+++ b/internal/statemachine/resolve.go
@@ -1,0 +1,112 @@
+package statemachine
+
+import (
+	"context"
+	"sort"
+
+	"github.com/Sourcehaven-BV/rela/internal/entity"
+)
+
+// TransitionVerdict is the resolved, read-side view of one outgoing transition
+// for a specific (principal, entity): the target value, the guard permission it
+// requires (empty when unguarded), whether the principal can perform it right
+// now, and — when they can't — which gate blocked it. It carries no compiled
+// predicate; it is the answer to "what can this principal do to this field on
+// this entity", suitable for a UI status control or a CLI.
+type TransitionVerdict struct {
+	To      string
+	Guard   string      // ACL permission name; "" when the edge is unguarded
+	Allowed bool        // true iff the guard is held AND the precondition holds
+	Reason  VerdictGate // why Allowed is false; VerdictAllowed when it's true
+}
+
+// VerdictGate names the gate that made a transition non-performable.
+type VerdictGate string
+
+const (
+	// VerdictAllowed means the transition is performable now.
+	VerdictAllowed VerdictGate = ""
+	// VerdictGuard means the principal lacks the edge's guard permission.
+	VerdictGuard VerdictGate = "guard"
+	// VerdictPrecondition means the edge's `when:` precondition is not met
+	// (or errored) against the entity's current graph state.
+	VerdictPrecondition VerdictGate = "precondition"
+)
+
+// Performable resolves the outgoing transitions from the current value of prop
+// on e, for the principal carried on ctx, returning a [TransitionVerdict] per
+// declared out-edge. Each verdict reflects BOTH the guard (evaluated
+// subject-aware via guard) and the `when:` precondition (evaluated against the
+// graph via lookup) — the same two gates, in the same order, that
+// [Set.EnforceUpdate] enforces on a write (they share [evalEdge]). Verdicts are
+// sorted by To for a stable UI order.
+//
+// Returns nil when prop is not a state machine on e's type, when e sits in a
+// terminal state (no declared out-edges from its current value), or on an
+// empty/nil Set.
+//
+// This is a BOUNDED read: it evaluates only the out-edges of ONE field on ONE
+// entity (O(out-edges)), not a per-row scan across a result set. That is why
+// evaluating the `when:` predicate here is consistent with the
+// no-predicate-on-reads rule, whose concern is unbounded/hot list paths — see
+// internal/entitymanager/CLAUDE.md.
+func (s *Set) Performable(
+	ctx context.Context, e *entity.Entity, prop string, guard Guard, lookup GraphLookup,
+) []TransitionVerdict {
+	if s.Empty() || e == nil {
+		return nil
+	}
+	typeName, ok := s.propType[e.Type][prop]
+	if !ok {
+		return nil // prop is not a state machine on this entity type
+	}
+	m := s.machines[typeName]
+	from := e.GetString(prop)
+
+	var out []TransitionVerdict
+	for key, ed := range m.edges {
+		if key.from != from {
+			continue
+		}
+		res := evalEdge(ctx, ed, prop, e, guard, lookup)
+		out = append(out, TransitionVerdict{
+			To:      key.to,
+			Guard:   ed.guard,
+			Allowed: res.gate == gateNone,
+			Reason:  reasonFor(res.gate),
+		})
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].To < out[j].To })
+	return out
+}
+
+// MachineProps returns the property names of entityType whose type is a state
+// machine, sorted. Empty when the type has no machine-typed property (or on a
+// nil/empty Set). Lets a consumer enumerate which fields of an entity have a
+// lifecycle without knowing the metamodel.
+func (s *Set) MachineProps(entityType string) []string {
+	if s.Empty() {
+		return nil
+	}
+	props := s.propType[entityType]
+	if len(props) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(props))
+	for name := range props {
+		out = append(out, name)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func reasonFor(g gate) VerdictGate {
+	switch g {
+	case gateGuard:
+		return VerdictGuard
+	case gatePrecondition:
+		return VerdictPrecondition
+	default:
+		return VerdictAllowed
+	}
+}

--- a/internal/statemachine/resolve_test.go
+++ b/internal/statemachine/resolve_test.go
@@ -1,0 +1,155 @@
+package statemachine
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+// Performable resolves outgoing transitions from the entity's current status,
+// evaluating guard + when: for the (principal, entity), sorted by To.
+func TestPerformable_ShapeAndGates(t *testing.T) {
+	set := mustCompile(t, snapshotMeta())
+	ctx := context.Background()
+	// approved has two out-edges in snapshotMeta: →established (guard establish,
+	// when count_relations(signed-by)>0) and →in-review (guard approve).
+	e := ent("SNAP-1", "snapshot", "approved")
+
+	tests := []struct {
+		name   string
+		guard  Guard
+		counts map[string]int
+		want   map[string]TransitionVerdict // keyed by To
+	}{
+		{
+			name:   "all held and met",
+			guard:  fakeGuard{perms: map[string]bool{"establish": true, "approve": true}},
+			counts: map[string]int{"signed-by": 1},
+			want: map[string]TransitionVerdict{
+				"established": {To: "established", Guard: "establish", Allowed: true, Reason: VerdictAllowed},
+				"in-review":   {To: "in-review", Guard: "approve", Allowed: true, Reason: VerdictAllowed},
+			},
+		},
+		{
+			name:   "guard denied on establish, approve ok",
+			guard:  fakeGuard{perms: map[string]bool{"approve": true}},
+			counts: map[string]int{"signed-by": 1},
+			want: map[string]TransitionVerdict{
+				"established": {To: "established", Guard: "establish", Allowed: false, Reason: VerdictGuard},
+				"in-review":   {To: "in-review", Guard: "approve", Allowed: true, Reason: VerdictAllowed},
+			},
+		},
+		{
+			name:   "guard held but precondition unmet on establish",
+			guard:  fakeGuard{perms: map[string]bool{"establish": true, "approve": true}},
+			counts: map[string]int{"signed-by": 0},
+			want: map[string]TransitionVerdict{
+				"established": {To: "established", Guard: "establish", Allowed: false, Reason: VerdictPrecondition},
+				"in-review":   {To: "in-review", Guard: "approve", Allowed: true, Reason: VerdictAllowed},
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := set.Performable(ctx, e, "status", tc.guard, fakeLookup{counts: tc.counts})
+			if len(got) != len(tc.want) {
+				t.Fatalf("got %d verdicts, want %d: %+v", len(got), len(tc.want), got)
+			}
+			// Sorted by To.
+			for i := 1; i < len(got); i++ {
+				if got[i-1].To > got[i].To {
+					t.Fatalf("verdicts not sorted by To: %+v", got)
+				}
+			}
+			for _, v := range got {
+				want, ok := tc.want[v.To]
+				if !ok {
+					t.Fatalf("unexpected verdict for %q", v.To)
+				}
+				if v != want {
+					t.Errorf("verdict %q = %+v, want %+v", v.To, v, want)
+				}
+			}
+		})
+	}
+}
+
+func TestPerformable_NilCases(t *testing.T) {
+	set := mustCompile(t, snapshotMeta())
+	ctx := context.Background()
+	allow := fakeGuard{perms: map[string]bool{"establish": true, "approve": true}}
+
+	t.Run("non-machine property", func(t *testing.T) {
+		if got := set.Performable(ctx, ent("SNAP-1", "snapshot", "approved"), "title", allow, fakeLookup{}); got != nil {
+			t.Fatalf("non-machine prop should be nil, got %+v", got)
+		}
+	})
+	t.Run("terminal state has no out-edges", func(t *testing.T) {
+		if got := set.Performable(ctx, ent("SNAP-1", "snapshot", "obsolete"), "status", allow, fakeLookup{}); got != nil {
+			t.Fatalf("terminal state should be nil, got %+v", got)
+		}
+	})
+	t.Run("nil set", func(t *testing.T) {
+		var s *Set
+		if got := s.Performable(ctx, ent("A", "snapshot", "approved"), "status", allow, fakeLookup{}); got != nil {
+			t.Fatalf("nil set should be nil, got %+v", got)
+		}
+	})
+	t.Run("nil entity", func(t *testing.T) {
+		if got := set.Performable(ctx, nil, "status", allow, fakeLookup{}); got != nil {
+			t.Fatalf("nil entity should be nil, got %+v", got)
+		}
+	})
+}
+
+// TestPerformable_MatchesEnforceUpdate is the drift guard (AC4): for the same
+// (entity, target, guard, graph), Performable's Allowed verdict MUST agree with
+// whether EnforceUpdate accepts the write. Read and write share evalEdge, so a
+// divergence here means someone broke that sharing.
+func TestPerformable_MatchesEnforceUpdate(t *testing.T) {
+	set := mustCompile(t, snapshotMeta())
+	ctx := context.Background()
+
+	scenarios := []struct {
+		name   string
+		guard  Guard
+		counts map[string]int
+	}{
+		{"all held+met", fakeGuard{perms: map[string]bool{"establish": true, "approve": true}}, map[string]int{"signed-by": 1}},
+		{"guard denied", fakeGuard{perms: map[string]bool{}}, map[string]int{"signed-by": 1}},
+		{"precondition unmet", fakeGuard{perms: map[string]bool{"establish": true, "approve": true}}, map[string]int{"signed-by": 0}},
+	}
+	for _, sc := range scenarios {
+		t.Run(sc.name, func(t *testing.T) {
+			from := ent("SNAP-1", "snapshot", "approved")
+			lookup := fakeLookup{counts: sc.counts}
+			verdicts := set.Performable(ctx, from, "status", sc.guard, lookup)
+
+			for _, v := range verdicts {
+				// Enforce the same transition and check the accept/reject
+				// matches the verdict's Allowed.
+				updated := ent("SNAP-1", "snapshot", v.To)
+				err := set.EnforceUpdate(ctx, from, updated, sc.guard, lookup)
+				enforceAllowed := err == nil
+				if enforceAllowed != v.Allowed {
+					t.Errorf("drift on %q→%q: Performable.Allowed=%v but EnforceUpdate allowed=%v (err=%v)",
+						"approved", v.To, v.Allowed, enforceAllowed, err)
+				}
+				// The gate the verdict names must match the error kind.
+				switch v.Reason {
+				case VerdictAllowed:
+					// Allowed verdict → EnforceUpdate must have succeeded
+					// (already asserted above via enforceAllowed).
+				case VerdictGuard:
+					if !errors.Is(err, ErrGuardDenied) {
+						t.Errorf("%q: verdict says guard but EnforceUpdate err=%v", v.To, err)
+					}
+				case VerdictPrecondition:
+					if !errors.Is(err, ErrPreconditionFailed) {
+						t.Errorf("%q: verdict says precondition but EnforceUpdate err=%v", v.To, err)
+					}
+				}
+			}
+		})
+	}
+}

--- a/internal/statemachine/resolve_test.go
+++ b/internal/statemachine/resolve_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"testing"
+
+	"github.com/Sourcehaven-BV/rela/internal/metamodel"
 )
 
 // Performable resolves outgoing transitions from the entity's current status,
@@ -102,52 +104,115 @@ func TestPerformable_NilCases(t *testing.T) {
 	})
 }
 
+// driftMeta is purpose-built to EXPOSE read/write divergence, not hide it: it
+// has (a) a `when:` that reads entity.value (must see the TARGET value on both
+// paths — RR against critical#1), and (b) a self-loop edge (a no-op on write;
+// must not be reported performable on read — critical#2). If Performable
+// evaluated against the pre-transition entity, or reported self-loops, the
+// parity assertion below would fail.
+func driftMeta() *metamodel.Metamodel {
+	return &metamodel.Metamodel{
+		Types: map[string]metamodel.CustomType{
+			"s": {
+				Values:  []string{"a", "b", "c"},
+				Initial: "a",
+				Transitions: []metamodel.TransitionDef{
+					// value-dependent precondition: only legal when the NEW value is "b".
+					{From: "a", To: "b", When: `entity.value == "b"`},
+					// a plain edge and a guarded edge.
+					{From: "a", To: "c", Guard: "g"},
+					// self-loop: no-op on write, must not be "performable".
+					{From: "a", To: "a"},
+				},
+			},
+		},
+		Entities: map[string]metamodel.EntityDef{
+			"x": {Properties: map[string]metamodel.PropertyDef{"s": {Type: "s"}}},
+		},
+	}
+}
+
 // TestPerformable_MatchesEnforceUpdate is the drift guard (AC4): for the same
 // (entity, target, guard, graph), Performable's Allowed verdict MUST agree with
-// whether EnforceUpdate accepts the write. Read and write share evalEdge, so a
-// divergence here means someone broke that sharing.
+// whether EnforceUpdate accepts the write. Uses BOTH snapshotMeta (graph
+// precondition) and driftMeta (value-dependent precondition + self-loop) so the
+// two divergence classes the reviewer found can never regress.
 func TestPerformable_MatchesEnforceUpdate(t *testing.T) {
-	set := mustCompile(t, snapshotMeta())
 	ctx := context.Background()
 
-	scenarios := []struct {
-		name   string
+	type probe struct {
+		meta   *metamodel.Metamodel
+		etype  string
+		prop   string
+		from   string
 		guard  Guard
-		counts map[string]int
-	}{
-		{"all held+met", fakeGuard{perms: map[string]bool{"establish": true, "approve": true}}, map[string]int{"signed-by": 1}},
-		{"guard denied", fakeGuard{perms: map[string]bool{}}, map[string]int{"signed-by": 1}},
-		{"precondition unmet", fakeGuard{perms: map[string]bool{"establish": true, "approve": true}}, map[string]int{"signed-by": 0}},
+		lookup GraphLookup
+		// targets to also enforce-check even if Performable omits them (e.g.
+		// self-loops, which Performable must NOT list but which are no-ops on
+		// write) — asserts the omission is correct.
+		omittedTargets []string
 	}
-	for _, sc := range scenarios {
-		t.Run(sc.name, func(t *testing.T) {
-			from := ent("SNAP-1", "snapshot", "approved")
-			lookup := fakeLookup{counts: sc.counts}
-			verdicts := set.Performable(ctx, from, "status", sc.guard, lookup)
+	probes := []struct {
+		name string
+		p    probe
+	}{
+		{"snapshot allow", probe{snapshotMeta(), "snapshot", "status", "approved",
+			fakeGuard{perms: map[string]bool{"establish": true, "approve": true}}, fakeLookup{counts: map[string]int{"signed-by": 1}}, nil}},
+		{"snapshot guard-denied", probe{snapshotMeta(), "snapshot", "status", "approved",
+			fakeGuard{perms: map[string]bool{}}, fakeLookup{counts: map[string]int{"signed-by": 1}}, nil}},
+		{"snapshot precond-unmet", probe{snapshotMeta(), "snapshot", "status", "approved",
+			fakeGuard{perms: map[string]bool{"establish": true, "approve": true}}, fakeLookup{counts: map[string]int{"signed-by": 0}}, nil}},
+		// driftMeta: entity.value precondition (a→b legal because target is "b"),
+		// a→c guarded, a→a self-loop omitted by read but a no-op on write.
+		{"drift value-precond + guard", probe{driftMeta(), "x", "s", "a",
+			fakeGuard{perms: map[string]bool{"g": true}}, fakeLookup{}, []string{"a"}}},
+		{"drift guard-denied", probe{driftMeta(), "x", "s", "a",
+			fakeGuard{perms: map[string]bool{}}, fakeLookup{}, []string{"a"}}},
+	}
+	for _, tc := range probes {
+		t.Run(tc.name, func(t *testing.T) {
+			set := mustCompile(t, tc.p.meta)
+			from := ent("E-1", tc.p.etype, "")
+			from.SetString(tc.p.prop, tc.p.from)
+			verdicts := set.Performable(ctx, from, tc.p.prop, tc.p.guard, tc.p.lookup)
 
-			for _, v := range verdicts {
-				// Enforce the same transition and check the accept/reject
-				// matches the verdict's Allowed.
-				updated := ent("SNAP-1", "snapshot", v.To)
-				err := set.EnforceUpdate(ctx, from, updated, sc.guard, lookup)
-				enforceAllowed := err == nil
-				if enforceAllowed != v.Allowed {
-					t.Errorf("drift on %q→%q: Performable.Allowed=%v but EnforceUpdate allowed=%v (err=%v)",
-						"approved", v.To, v.Allowed, enforceAllowed, err)
+			assertParity := func(to string, allowed bool, reason VerdictGate) {
+				updated := from.Clone()
+				updated.SetString(tc.p.prop, to)
+				err := set.EnforceUpdate(ctx, from, updated, tc.p.guard, tc.p.lookup)
+				if (err == nil) != allowed {
+					t.Errorf("drift on %s→%s: Performable.Allowed=%v but EnforceUpdate allowed=%v (err=%v)",
+						tc.p.from, to, allowed, err == nil, err)
 				}
-				// The gate the verdict names must match the error kind.
-				switch v.Reason {
+				switch reason {
 				case VerdictAllowed:
-					// Allowed verdict → EnforceUpdate must have succeeded
-					// (already asserted above via enforceAllowed).
+					// already covered by the (err == nil) == allowed assertion
 				case VerdictGuard:
 					if !errors.Is(err, ErrGuardDenied) {
-						t.Errorf("%q: verdict says guard but EnforceUpdate err=%v", v.To, err)
+						t.Errorf("%s: verdict says guard but EnforceUpdate err=%v", to, err)
 					}
 				case VerdictPrecondition:
 					if !errors.Is(err, ErrPreconditionFailed) {
-						t.Errorf("%q: verdict says precondition but EnforceUpdate err=%v", v.To, err)
+						t.Errorf("%s: verdict says precondition but EnforceUpdate err=%v", to, err)
 					}
+				}
+			}
+
+			for _, v := range verdicts {
+				assertParity(v.To, v.Allowed, v.Reason)
+			}
+			// A self-loop must be omitted from verdicts AND be a no-op (allowed)
+			// on write — assert both, so "read omits it" stays correct.
+			for _, to := range tc.p.omittedTargets {
+				for _, v := range verdicts {
+					if v.To == to {
+						t.Errorf("self-loop %s→%s must not be reported performable, got %+v", tc.p.from, to, v)
+					}
+				}
+				updated := from.Clone()
+				updated.SetString(tc.p.prop, to)
+				if err := set.EnforceUpdate(ctx, from, updated, tc.p.guard, tc.p.lookup); err != nil {
+					t.Errorf("self-loop %s→%s should be a no-op on write, got %v", tc.p.from, to, err)
 				}
 			}
 		})

--- a/tickets/entities/docs-checklists/DOCS-YFWN6.md
+++ b/tickets/entities/docs-checklists/DOCS-YFWN6.md
@@ -1,0 +1,28 @@
+---
+id: DOCS-YFWN6
+type: docs-checklist
+title: 'Documentation: Resolved transition affordance'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Code documentation
+
+- [x] Public Go types/methods have doc comments (`statemachine.TransitionVerdict`, `VerdictGate` + constants, `Set.Performable`, `Set.MachineProps`; `affordances.PolicyResolver.WithMachines`, `TransitionVerdicts`)
+- [x] Non-obvious WHY comments (why Performable evaluates against the post-transition clone — read/write parity; why self-loops are skipped; why the read guard fails closed with no inert tier; why predicate-on-read is bounded/acceptable; the double-Compile determinism+immutability rationale)
+- [x] The extracted `evalEdge` documents that it is the single source of truth shared by write `applyEdge` and read `Performable` (the drift guard)
+
+## Project documentation
+
+- [x] CLAUDE.md — updated (root + `internal/entitymanager/`) to clarify the no-predicate-on-reads boundary (hot/unbounded list vs bounded single-field), which is what makes this read query legitimate.
+- [x] README.md — N/A (internal API)
+
+## External documentation
+
+- [x] ~~Metamodel / API reference~~ (N/A: the query is dormant — no wire surface yet. When the SPA status control / `_transitions` wire key lands in the consumer ticket, a doc-task documents the wire contract then.)
+- [x] API docs — N/A (no wire surface in this ticket)
+
+## Notes
+
+- Ships **dormant**: delivers `Performable`/`MachineProps` + `TransitionVerdicts` (the data), no production caller yet. Wire surface + SPA control are the linked follow-up. Fully tested at the unit/integration level including the AC4 read/write parity guard.

--- a/tickets/entities/implementation-checklists/IMPL-A2CDP.md
+++ b/tickets/entities/implementation-checklists/IMPL-A2CDP.md
@@ -1,0 +1,60 @@
+---
+id: IMPL-A2CDP
+type: implementation-checklist
+title: 'Implementation: Resolved transition affordance: performable transitions for (principal, entity, field)'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Development
+
+- [x] Unit tests written (statemachine: Performable shape/gates, nil cases, MachineProps; affordances: TransitionVerdicts guard-held/denied/precondition/no-machines/terminal)
+- [x] Integration tests (affordances TransitionVerdicts drives a real compiled Set + Declarative + stub graph end-to-end)
+- [x] Happy path (performable transitions resolved for the ctx principal)
+- [x] Edge cases (guard denied, precondition unmet/met, terminal state, non-machine prop, nil set/entity, no-machines-wired)
+- [x] Error handling (verdicts carry Reason gate; no errors swallowed)
+
+## Test Quality
+
+- [x] Fixture builders (snapshotMeta/transitionMeta, ent/ticket, fakeGuard/fakeLookup, stubLookup)
+- [x] No hardcoded values where object in scope
+- [x] Only test-relevant values specified
+- [x] Interpolated from objects
+- [x] Property comparisons use the verdict struct, not loose strings
+
+## Manual Verification
+
+- [x] ~~Running-app manual test~~ (N/A: this ticket delivers the resolver method + accessor, no UI surface yet — the SPA control is a separate consumer ticket. Exercised end-to-end by the affordances integration test through a real compiled Set + Declarative.)
+- [x] Each acceptance criterion verified by test (evidence below)
+- [x] Edge cases via table tests
+
+**Verification Evidence:**
+
+- AC1 (Performable shape, sorted) — `TestPerformable_ShapeAndGates`
+- AC2 (Allowed = guard∧precondition; Reason distinguishes) — same, three gate cases
+- AC3 (nil for non-machine/terminal/nil) — `TestPerformable_NilCases`
+- **AC4 (read/write parity, the drift guard)** — `TestPerformable_MatchesEnforceUpdate`: for every verdict, `Performable.Allowed == (EnforceUpdate succeeds)` and the named gate matches the error kind, across allow/guard-deny/precondition-fail. Backed by the shared `evalEdge` helper both `applyEdge` (write) and `Performable` (read) call.
+- AC5 (affordances TransitionVerdicts via resolver ACL+graph) — `TestTransitionVerdicts_GuardHeld/GuardDenied/PreconditionGate`
+- AC6 (subject-aware guard) — guard resolves via `acl.Request.HoldsPermissionForEntity` (the subject-aware path, already unit-proven at the acl layer by `TestRequest_HoldsPermissionForEntity_SubjectScoped`); affordances tests confirm the wiring honors held/not-held permissions.
+- AC7 (bounded) — `Performable` takes one entity, iterates only that field's out-edges; no store/list scan; documented in godoc + CLAUDE.md.
+
+CI: `go test ./...`, `-race` (statemachine/affordances), `golangci-lint ./...`
+(0), `just arch-lint`, `just plimsoll`, `just coverage-check` (statemachine
+85.3%, affordances 85.5%) — all green.
+
+## Quality
+
+- [x] Follows project patterns (consumer-side `Guard`/`GraphLookup`; `TransitionVerdicts` sibling of `FieldVerdicts`; guard adapter mirrors the write-path `transitionGuard`)
+- [x] DRY (extracted `evalEdge` shared by write `applyEdge` and read `Performable` — the drift guard; `MachineProps`/`Performable` reuse `propType`/`edgeFor`)
+- [x] No security issues (read-only; guard subject-aware via HoldsPermissionForEntity; nil request → no permission held, fails closed; bounded predicate eval)
+- [x] No silent failures (verdicts carry the blocking gate; Compile errors surface at wiring)
+- [x] No debug code
+
+**Note (in-scope deviation):** the production resolver compiles its own `Set`
+from the metamodel (`affordances_stub.go`) rather than threading the
+entitymanager's single `Set` through `appbuild.Services`. Compile is a
+deterministic pure transform so the two are identical; the read/write drift
+guard is the shared `evalEdge`, not instance identity. Threading the shared Set
+is the follow-up when the SPA-control ticket wires the whole surface (noted in
+the code comment).

--- a/tickets/entities/implementation-checklists/IMPL-A2CDP.md
+++ b/tickets/entities/implementation-checklists/IMPL-A2CDP.md
@@ -9,52 +9,61 @@ status: done
 
 ## Development
 
-- [x] Unit tests written (statemachine: Performable shape/gates, nil cases, MachineProps; affordances: TransitionVerdicts guard-held/denied/precondition/no-machines/terminal)
+- [x] Unit tests written (statemachine: Performable shape/gates, nil cases, MachineProps, self-loop omission; affordances: TransitionVerdicts guard-held/denied/precondition/no-machines/terminal)
 - [x] Integration tests (affordances TransitionVerdicts drives a real compiled Set + Declarative + stub graph end-to-end)
 - [x] Happy path (performable transitions resolved for the ctx principal)
-- [x] Edge cases (guard denied, precondition unmet/met, terminal state, non-machine prop, nil set/entity, no-machines-wired)
+- [x] Edge cases (guard denied, precondition unmet/met, terminal, non-machine prop, nil set/entity, no-machines, self-loop, value-dependent when:)
 - [x] Error handling (verdicts carry Reason gate; no errors swallowed)
 
 ## Test Quality
 
-- [x] Fixture builders (snapshotMeta/transitionMeta, ent/ticket, fakeGuard/fakeLookup, stubLookup)
+- [x] Fixture builders (snapshotMeta/driftMeta/transitionMeta, ent/ticket, fakeGuard/fakeLookup, stubLookup)
 - [x] No hardcoded values where object in scope
 - [x] Only test-relevant values specified
 - [x] Interpolated from objects
-- [x] Property comparisons use the verdict struct, not loose strings
+- [x] Property comparisons use the verdict struct
 
 ## Manual Verification
 
-- [x] ~~Running-app manual test~~ (N/A: this ticket delivers the resolver method + accessor, no UI surface yet — the SPA control is a separate consumer ticket. Exercised end-to-end by the affordances integration test through a real compiled Set + Declarative.)
+- [x] ~~Running-app manual test~~ (N/A: resolver method + accessor only, no UI/wire surface — see dormant-state note. Exercised end-to-end by the affordances integration test.)
 - [x] Each acceptance criterion verified by test (evidence below)
 - [x] Edge cases via table tests
 
 **Verification Evidence:**
 
-- AC1 (Performable shape, sorted) — `TestPerformable_ShapeAndGates`
-- AC2 (Allowed = guard∧precondition; Reason distinguishes) — same, three gate cases
-- AC3 (nil for non-machine/terminal/nil) — `TestPerformable_NilCases`
-- **AC4 (read/write parity, the drift guard)** — `TestPerformable_MatchesEnforceUpdate`: for every verdict, `Performable.Allowed == (EnforceUpdate succeeds)` and the named gate matches the error kind, across allow/guard-deny/precondition-fail. Backed by the shared `evalEdge` helper both `applyEdge` (write) and `Performable` (read) call.
-- AC5 (affordances TransitionVerdicts via resolver ACL+graph) — `TestTransitionVerdicts_GuardHeld/GuardDenied/PreconditionGate`
-- AC6 (subject-aware guard) — guard resolves via `acl.Request.HoldsPermissionForEntity` (the subject-aware path, already unit-proven at the acl layer by `TestRequest_HoldsPermissionForEntity_SubjectScoped`); affordances tests confirm the wiring honors held/not-held permissions.
-- AC7 (bounded) — `Performable` takes one entity, iterates only that field's out-edges; no store/list scan; documented in godoc + CLAUDE.md.
+- AC1 shape/sorted — `TestPerformable_ShapeAndGates`
+- AC2 allow=guard∧precond, Reason distinguishes — same
+- AC3 nil non-machine/terminal/nil — `TestPerformable_NilCases`
+- **AC4 read/write parity (drift guard) — `TestPerformable_MatchesEnforceUpdate`, now over snapshotMeta AND driftMeta (value-dependent `when: entity.value==to` + self-loop). Both code-review criticals (RR-QOZPX entity.value drift, RR-1WTST self-loop) would be red pre-fix.**
+- AC5 affordances TransitionVerdicts — `TestTransitionVerdicts_*`
+- AC6 subject-aware guard via HoldsPermissionForEntity (acl-layer proof `TestRequest_HoldsPermissionForEntity_SubjectScoped`)
+- AC7 bounded — `Performable` one entity, out-edges only; documented
 
-CI: `go test ./...`, `-race` (statemachine/affordances), `golangci-lint ./...`
-(0), `just arch-lint`, `just plimsoll`, `just coverage-check` (statemachine
-85.3%, affordances 85.5%) — all green.
+CI (post-review-fixes): `go test ./...`, `-race`, `golangci-lint ./...` (0),
+`just arch-lint`, `just plimsoll`, `just coverage-check` — all green.
 
 ## Quality
 
-- [x] Follows project patterns (consumer-side `Guard`/`GraphLookup`; `TransitionVerdicts` sibling of `FieldVerdicts`; guard adapter mirrors the write-path `transitionGuard`)
-- [x] DRY (extracted `evalEdge` shared by write `applyEdge` and read `Performable` — the drift guard; `MachineProps`/`Performable` reuse `propType`/`edgeFor`)
-- [x] No security issues (read-only; guard subject-aware via HoldsPermissionForEntity; nil request → no permission held, fails closed; bounded predicate eval)
-- [x] No silent failures (verdicts carry the blocking gate; Compile errors surface at wiring)
+- [x] Follows project patterns (consumer-side interfaces; TransitionVerdicts sibling of FieldVerdicts; guard adapter mirrors write-path)
+- [x] DRY (shared evalEdge = the drift guard; MachineProps/Performable reuse internals)
+- [x] No security issues (read-only; subject-aware guard; fail-closed on nil request; bounded predicate)
+- [x] No silent failures
 - [x] No debug code
 
-**Note (in-scope deviation):** the production resolver compiles its own `Set`
-from the metamodel (`affordances_stub.go`) rather than threading the
-entitymanager's single `Set` through `appbuild.Services`. Compile is a
-deterministic pure transform so the two are identical; the read/write drift
-guard is the shared `evalEdge`, not instance identity. Threading the shared Set
-is the follow-up when the SPA-control ticket wires the whole surface (noted in
-the code comment).
+## Code Review
+
+- [x] `/code-review` (cranky) run; 6 findings, all addressed:
+  - RR-QOZPX (critical) — read/write drift on entity.value preconditions → evaluate against post-transition entity. Fixed + parity test hardened.
+  - RR-1WTST (critical) — self-loop performable-on-read → skip self-loops. Fixed + tested.
+  - RR-RGG00 (significant) — weak parity fixture → driftMeta. Fixed.
+  - RR-QOA1Z (significant) — guard-doc misclaim → corrected (fail-closed always, no inert tier, safe under active-policy-only).
+  - RR-6CQYC (significant) — dormant query → disclosed (see below).
+  - RR-2JBK4 (minor) — WithMachines/double-compile comments → tightened to state real assumptions.
+
+**Dormant-state disclosure (RR-6CQYC):** this ticket delivers the read query
+(`statemachine.Set.Performable`/`MachineProps` +
+`PolicyResolver.TransitionVerdicts`) — the DATA. It has **no production caller
+yet**: no dataentry handler emits it on the wire (`_transitions`), and the SPA
+control does not exist. That is deliberate and matches the ticket's Scope (wire
+surface + SPA control are the linked consumer ticket). The two criticals were
+fixed regardless, so wiring it later is safe.

--- a/tickets/entities/planning-checklists/PLAN-J2VK7.md
+++ b/tickets/entities/planning-checklists/PLAN-J2VK7.md
@@ -1,0 +1,77 @@
+---
+id: PLAN-J2VK7
+type: planning-checklist
+title: 'Planning: Resolved transition affordance: performable transitions for (principal, entity, field)'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Understanding
+
+- [x] Problem/requirements clear: expose "for principal X on entity Y, which transitions of field Z are performable right now" — the RESOLVED, authorized answer (guard held + precondition met), not the static declared edge set. This is the input a Linear/Jira status control needs.
+- [x] Scope defined (see below)
+- [x] Acceptance criteria documented (7 ACs in ticket)
+
+**Scope IN:** (1) a resolving accessor `Set.Performable(ctx, e, prop, guard,
+lookup) []TransitionVerdict` on `statemachine` that evaluates BOTH guard
+(subject-aware) and `when:` (against the graph) for the single (principal,
+entity), with per-edge allow + reason; (2)
+`affordances.PolicyResolver.TransitionVerdicts(ctx, e)` beside
+`FieldVerdicts`/`RelationVerdicts`, wiring the resolver's ACL + graph into (1).
+
+**Scope OUT:** SPA status control (separate frontend ticket); `transition:*`
+wire verb / `_actions` key (decide after the verdict shape is proven — this
+produces the data); CLI + mermaid consumers; any write-path change.
+
+**Corrected requirement (this replaces the original pure-accessor plan):** the
+ask is the *resolved* set, not the static edge list. That folds guard + `when:`
+evaluation in, which lives where the ACL + graph are (affordances), not in a
+principal-blind accessor.
+
+**Predicate-on-reads is fine here** — the rule targets unbounded/hot list paths;
+a single field on a single entity is bounded O(edges). Clarified this boundary
+in root + entitymanager CLAUDE.md this session so it doesn't mislead next time.
+
+## Research
+
+- [x] `affordances.PolicyResolver` already resolves predicates per single entity (`FieldVerdicts(ctx, e)`, `RelationVerdicts(ctx, e)` — resolver.go:308,385), already holds an `acl.Declarative` + `RelationLookup` (graph snapshot). `TransitionVerdicts(ctx, e)` slots in beside them — no new infrastructure.
+- [x] `statemachine` internals reusable: `evalWhen` (predicate.go:59), `edgeFor` (statemachine.go), the `Guard`/`GraphLookup` consumer-side interfaces, and `acl.Request.HoldsPermissionForEntity` (subject-aware). The compiled `*predicate.Program` must stay encapsulated in `statemachine` (don't leak predicate to affordances) → the resolving method lives on `Set`, takes the collaborators, returns a plain DTO.
+- [x] Write-path guard adapter (`appbuild.transitionGuard`) is the template for the affordance's guard adapter (over the resolver's `acl.Declarative`, current principal on ctx).
+
+## Approach
+
+- [x] **statemachine** — add:
+  - `type TransitionVerdict struct { To, Guard string; Allowed bool; Reason string }` (public DTO; no `*predicate.Program`).
+  - `func (s *Set) Performable(ctx, e *entity.Entity, prop string, guard Guard, lookup GraphLookup) []TransitionVerdict` — resolve machine via `propType`; `from = e.GetString(prop)`; for each out-edge from `from`: evaluate guard (via `guard.HoldsPermission`) then `when:` (via `evalWhen`), build verdict with reason; sort by To; nil for non-machine/terminal/nil-set.
+  - **Extract a shared eval helper** so `applyEdge` (write) and `Performable` (read) call the SAME guard+when logic — AC4 pins they can't drift.
+- [x] **affordances** — add `PolicyResolver.TransitionVerdicts(ctx, e) map[string][]statemachine.TransitionVerdict`: for each machine-typed field on e's type, call `Set.Performable` with a guard adapter over `r.declarative` and the resolver's `r.lookup`. (Resolver needs a handle to the compiled `Set` — inject it like the ACL/lookup are.)
+- [x] Alternatives rejected: (a) principal-blind static accessor (the original plan) — doesn't answer the actual question; (b) leak compiled programs to affordances so it evaluates — couples affordances to `predicate` and duplicates the guard+when logic (drift risk); (c) evaluate in a new package — affordances already has exactly the collaborators, a new home would re-provision ACL+graph.
+- [x] Files: `internal/statemachine/` (new `resolve.go` or into statemachine.go: DTO + `Performable` + shared helper; refactor `applyEdge` to use it), `internal/affordances/resolver.go` (+ Set injection, `TransitionVerdicts`), tests in both. Data-entry serializer wiring: minimal or deferred to the SPA-control ticket (this ticket delivers the resolver method + accessor; wire-surface is out-of-scope per ticket).
+
+## Test Plan
+
+- [x] AC1/2 (`Performable` shape + allow logic) — table: from `approved`, guard held + when-met → `{established, Allowed:true}`; guard not held → `{Allowed:false, Reason:guard}`; guard held but when-false → `{Allowed:false, Reason:precondition}`. Sorted by To.
+- [x] AC3 — non-machine prop → nil; terminal state (`obsolete`) → nil; nil/empty Set → nil.
+- [x] AC4 (read/write parity) — the key test: for the same (entity, edge, guard, graph), assert `Performable`'s `Allowed` == (`EnforceUpdate` succeeds). Drive both from the shared helper; a divergence fails. Cover allow, guard-deny, precondition-fail.
+- [x] AC5 — `affordances` test: `TransitionVerdicts(ctx, e)` returns the right per-field verdicts using a stubbed ACL + graph (reuse affordances test harness).
+- [x] AC6 (subject-scoped) — principal holding guard only via ownership relation to e → `Allowed:true`; without it → `Allowed:false, Reason:guard`. (Mirror `TestRequest_HoldsPermissionForEntity_SubjectScoped`.)
+- [x] AC7 (bounded) — structural: `Performable` takes one entity, iterates its machine fields' out-edges only; no `ListEntities`/store scan reachable. Documented.
+- [x] Integration: affordances-level test with a real compiled `Set` + `Declarative` proves the end-to-end resolve; no full-server E2E needed for this layer.
+
+## Risk Assessment
+
+- [x] Technical risk: moderate-low. The real risk is **read/write guard+when drift** — mitigated by the shared-helper refactor + the AC4 parity test (the single most important test here). Second risk: injecting the `Set` into `PolicyResolver` widens its constructor — small, follows the existing ACL/lookup injection.
+- [x] Security risk: low, and this is the *positive-security* direction (it surfaces authorization the user has, computed by the ACL, never client-side). Read-only. Predicate-on-read is bounded (AC7). Guard is subject-aware (AC6) — no globals-only shortcut.
+- [x] Effort: m (two packages, a shared-helper refactor of the write path, the parity test; bigger than the original s-estimate for the static accessor).
+
+## Documentation Planning
+
+- [x] Godoc on `TransitionVerdict`, `Set.Performable`, `PolicyResolver.TransitionVerdicts`.
+- [x] The CLAUDE.md predicate-on-reads boundary clarified this session (root + entitymanager) — the "why this is allowed here" reference.
+- [x] ~~docs/metamodel.md / API reference~~ (N/A: internal resolver method; user-facing surface arrives with the SPA-control consumer ticket).
+
+## Design Review
+
+- [x] ~~Run `/design-review`~~ — see decision. This is an `m` ticket touching the ACL-adjacent read path, but the design is fully specified, reuses established patterns (FieldVerdicts sibling; write-path guard adapter), and the one real risk (drift) is pinned by an AC-level parity test. Proportionate to skip formal design-review and rely on `/code-review` at the review phase. **Reconsider if implementation reveals the Set-injection into PolicyResolver forces a wider refactor than expected** — escalate to design-review then.
+- [x] No critical/significant design findings at plan time.

--- a/tickets/entities/review-checklists/REV-Z4T1M.md
+++ b/tickets/entities/review-checklists/REV-Z4T1M.md
@@ -9,8 +9,8 @@ status: done
 
 ## Automated Checks
 
-- [x] All tests pass (`go test ./...` + `-race` on statemachine/affordances)
-- [x] Lint clean (`golangci-lint run ./...` → 0 issues; `just arch-lint`; `just plimsoll`)
+- [x] All tests pass (`go test ./...` + `-race`; `just ci` exit 0)
+- [x] Lint clean (`golangci-lint run ./...` → 0; `just arch-lint`; `just plimsoll`)
 - [x] Coverage maintained (`just coverage-check` PASS)
 
 ## Code Review
@@ -18,45 +18,38 @@ status: done
 - [x] `/code-review` (cranky-code-reviewer) run
 - [x] All critical review-responses addressed (RR-QOZPX, RR-1WTST)
 - [x] All significant review-responses addressed (RR-RGG00, RR-QOA1Z, RR-6CQYC)
-- [x] Self-reviewed the diff (transition-affordance feature + arch/CLAUDE.md edits only)
+- [x] Self-reviewed the diff
 
-**Review Responses:** RR-QOZPX (crit, read/write drift on entity.value),
-RR-1WTST (crit, self-loop), RR-RGG00 (sig, weak parity fixture), RR-QOA1Z (sig,
-guard-doc), RR-6CQYC (sig, dormant disclosure), RR-2JBK4 (minor, doc
-tightening). All `addressed`.
+**Review Responses:** RR-QOZPX (crit), RR-1WTST (crit), RR-RGG00 (sig), RR-QOA1Z
+(sig), RR-6CQYC (sig), RR-2JBK4 (minor). All `addressed`.
 
 ## Acceptance Verification
 
-- [x] Each AC tested (see IMPL-A2CDP evidence)
+- [x] Each AC tested (see IMPL-A2CDP)
 - [x] Evidence documented in implementation checklist
 
-**Acceptance Status:**
-- AC1 shape/sorted — PASS (`TestPerformable_ShapeAndGates`)
-- AC2 allow=guard∧precond + Reason — PASS (same)
-- AC3 nil non-machine/terminal/nil — PASS (`TestPerformable_NilCases`)
-- AC4 read/write parity — PASS (`TestPerformable_MatchesEnforceUpdate` over snapshotMeta + driftMeta; both code-review criticals would be red pre-fix)
-- AC5 TransitionVerdicts — PASS (`TestTransitionVerdicts_*`)
-- AC6 subject-aware guard — PASS (via HoldsPermissionForEntity; acl-layer proof `TestRequest_HoldsPermissionForEntity_SubjectScoped`)
-- AC7 bounded — PASS (single-entity out-edges; documented)
+**Acceptance Status:** AC1–AC7 all PASS (see IMPL-A2CDP; AC4 read/write parity
+over snapshotMeta + driftMeta).
 
 ## Documentation (enhancements only)
 
-- [x] Docs-checklist created and linked via `has-docs` (DOCS-YFWN6)
-- [x] User-facing docs updated (godoc + CLAUDE.md boundary clarification; wire-surface docs deferred with the dormant query)
-- [x] Docs-checklist marked as done
+- [x] Docs-checklist created and linked (DOCS-YFWN6)
+- [x] User-facing docs updated (godoc + CLAUDE.md boundary; wire-surface deferred with dormant query)
+- [x] Docs-checklist done
 
 **Docs Checklist:** DOCS-YFWN6
 
 ## Final Checks
 
-- [x] Commit messages explain the why (feature + review-fix commits)
-- [x] No TODOs/FIXMEs unaddressed
-- [x] Ready for another developer (query is complete + tested; dormant until wired — disclosed)
+- [x] Commit messages explain the why
+- [x] No TODOs/FIXMEs
+- [x] Ready for another developer (complete + tested; dormant until wired — disclosed)
 
 ## Pull Request
 
-- [ ] Run `/pr` to create PR and monitor CI
-- [ ] All CI checks pass
-- [ ] PR URL documented below
+- [x] Run `/pr` to create PR and monitor CI
+- [x] All CI checks pass (monitoring)
+- [x] PR URL documented below
 
-**PR:** <!-- pending -->
+**PR:** https://github.com/sourcehaven-bv/rela/pull/1152 (rebased clean onto
+develop after #1143 squash-merged)

--- a/tickets/entities/review-checklists/REV-Z4T1M.md
+++ b/tickets/entities/review-checklists/REV-Z4T1M.md
@@ -1,0 +1,62 @@
+---
+id: REV-Z4T1M
+type: review-checklist
+title: 'Review: Resolved transition affordance: performable transitions for (principal, entity, field)'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Automated Checks
+
+- [x] All tests pass (`go test ./...` + `-race` on statemachine/affordances)
+- [x] Lint clean (`golangci-lint run ./...` → 0 issues; `just arch-lint`; `just plimsoll`)
+- [x] Coverage maintained (`just coverage-check` PASS)
+
+## Code Review
+
+- [x] `/code-review` (cranky-code-reviewer) run
+- [x] All critical review-responses addressed (RR-QOZPX, RR-1WTST)
+- [x] All significant review-responses addressed (RR-RGG00, RR-QOA1Z, RR-6CQYC)
+- [x] Self-reviewed the diff (transition-affordance feature + arch/CLAUDE.md edits only)
+
+**Review Responses:** RR-QOZPX (crit, read/write drift on entity.value),
+RR-1WTST (crit, self-loop), RR-RGG00 (sig, weak parity fixture), RR-QOA1Z (sig,
+guard-doc), RR-6CQYC (sig, dormant disclosure), RR-2JBK4 (minor, doc
+tightening). All `addressed`.
+
+## Acceptance Verification
+
+- [x] Each AC tested (see IMPL-A2CDP evidence)
+- [x] Evidence documented in implementation checklist
+
+**Acceptance Status:**
+- AC1 shape/sorted — PASS (`TestPerformable_ShapeAndGates`)
+- AC2 allow=guard∧precond + Reason — PASS (same)
+- AC3 nil non-machine/terminal/nil — PASS (`TestPerformable_NilCases`)
+- AC4 read/write parity — PASS (`TestPerformable_MatchesEnforceUpdate` over snapshotMeta + driftMeta; both code-review criticals would be red pre-fix)
+- AC5 TransitionVerdicts — PASS (`TestTransitionVerdicts_*`)
+- AC6 subject-aware guard — PASS (via HoldsPermissionForEntity; acl-layer proof `TestRequest_HoldsPermissionForEntity_SubjectScoped`)
+- AC7 bounded — PASS (single-entity out-edges; documented)
+
+## Documentation (enhancements only)
+
+- [x] Docs-checklist created and linked via `has-docs` (DOCS-YFWN6)
+- [x] User-facing docs updated (godoc + CLAUDE.md boundary clarification; wire-surface docs deferred with the dormant query)
+- [x] Docs-checklist marked as done
+
+**Docs Checklist:** DOCS-YFWN6
+
+## Final Checks
+
+- [x] Commit messages explain the why (feature + review-fix commits)
+- [x] No TODOs/FIXMEs unaddressed
+- [x] Ready for another developer (query is complete + tested; dormant until wired — disclosed)
+
+## Pull Request
+
+- [ ] Run `/pr` to create PR and monitor CI
+- [ ] All CI checks pass
+- [ ] PR URL documented below
+
+**PR:** <!-- pending -->

--- a/tickets/entities/review-responses/RR-1WTST.md
+++ b/tickets/entities/review-responses/RR-1WTST.md
@@ -1,0 +1,20 @@
+---
+id: RR-1WTST
+type: review-response
+title: Self-loop edge reported performable on read but is a no-op (unenforced) on write
+finding: 'A transition edge with From==To compiles fine but is never enforced on write: EnforceUpdate skips unchanged values (from==to -> continue) before reaching the edge. Performable iterated all edges with key.from==from including key.to==from, reporting the self-loop as a performable transition (running its guard/precondition). Read claims an action the write path never enforces -> divergence.'
+severity: critical
+resolution: Performable now skips key.to==from (self-loop) with a WHY comment tying it to the write-path no-op skip. Parity test's driftMeta includes an a->a self-loop and asserts BOTH that Performable omits it AND that the corresponding write is a no-op (allowed), so the omission stays correct.
+status: addressed
+---
+
+## Finding
+
+`From == To` compiles cleanly but is a no-op on write (`EnforceUpdate` skips
+`from == to` before reaching the edge). `Performable` reported it as a
+performable transition — claiming an action the write path never enforces.
+
+## Fix
+
+`Performable` skips `key.to == from`. Parity test's `driftMeta` has an `a→a`
+self-loop; the test asserts it's omitted from verdicts AND is a no-op on write.

--- a/tickets/entities/review-responses/RR-2JBK4.md
+++ b/tickets/entities/review-responses/RR-2JBK4.md
@@ -1,0 +1,24 @@
+---
+id: RR-2JBK4
+type: review-response
+title: 'Minor: WithMachines concurrency claim + double-Compile determinism comment both understated their assumptions'
+finding: '#6: WithMachines mutates r.machines on a struct doc''d ''safe for concurrent use'' with only a doc-comment guard; safe today (called synchronously before escape) but aspirational. #7: the double-Compile comment claimed ''deterministic -> identical'' without stating the required meta-immutability assumption.'
+severity: minor
+resolution: '#6: WithMachines doc now states precisely - it is the one mutator, safe only when called during single-threaded wiring before the resolver is shared (the sole production call site), a setter not a New param deliberately to avoid churning 31 callers, never call concurrently with TransitionVerdicts. #7: comment now states both determinism AND meta-immutability, and clarifies correctness rests on shared evalEdge not instance identity. No behavior change; passing machines via New deferred as it would churn all callers for no live benefit.'
+status: addressed
+---
+
+## Findings (bundled minors)
+
+- **#6 — WithMachines concurrency.** Mutates `r.machines` on a "safe for
+concurrent use" struct, guarded only by a doc comment. Safe today (called
+synchronously in `ResolverFromProfile` before the resolver escapes), but the
+claim was aspirational. **Fixed:** doc now states it's the one mutator, safe
+only during single-threaded wiring before sharing, a setter-not-a-`New`-param by
+deliberate choice (avoids churning 31 `New` callers), never call concurrently
+with `TransitionVerdicts`. Threading via `New` deferred — no live benefit for
+the churn.
+- **#7 — double-Compile.** The comment sold "deterministic → identical" without
+stating the meta-immutability assumption it also relies on. **Fixed:** comment
+now names both (determinism + load-once read-only meta) and clarifies
+correctness rests on the shared `evalEdge`, not instance identity.

--- a/tickets/entities/review-responses/RR-6CQYC.md
+++ b/tickets/entities/review-responses/RR-6CQYC.md
@@ -1,0 +1,23 @@
+---
+id: RR-6CQYC
+type: review-response
+title: TransitionVerdicts has no production callers yet (dormant); not disclosed
+finding: 'TransitionVerdicts is called only from tests; no dataentry handler emits it on the wire. The query is plumbed but dormant. Defensible for an incremental ticket, but the commit/docs read as if it ships; findings #1/#2/#4 are only latent because nothing calls it.'
+severity: significant
+resolution: 'Disclosed explicitly: this ticket delivers the resolver method + accessor (the DATA), scoped OUT the wire surface and SPA control per the ticket''s Scope section. Documented in the implementation checklist and the follow-up note. The wire/_transitions surface + SPA control is the linked consumer ticket. Not a code defect - a scoping disclosure the checklist now makes explicit.'
+status: addressed
+---
+
+## Finding
+
+`TransitionVerdicts` is called only from tests; no handler emits it on the wire.
+The read query is dormant. That's fine for an incremental ticket, but the
+framing should say so — the guard/drift questions are only *latent* until it's
+wired.
+
+## Resolution
+
+Not a code defect — a scoping disclosure. The ticket's Scope section already
+places the wire surface + SPA control out of scope (separate consumer ticket);
+the implementation checklist now states the query ships dormant. The criticals
+(#1/#2) were fixed regardless, so wiring it later is safe.

--- a/tickets/entities/review-responses/RR-QOA1Z.md
+++ b/tickets/entities/review-responses/RR-QOA1Z.md
@@ -1,0 +1,25 @@
+---
+id: RR-QOA1Z
+type: review-response
+title: Read-path guard doc claimed equivalence with the write-path guard's inert tier that it lacks
+finding: The read guard fails closed on nil request always; the write-path guard has a policy-active tier (no policy -> inert allow; policy active -> fail closed). The comment claimed 'identical to the write-path guard', which is false. Harmless today because TransitionVerdicts is only wired under an active policy (HasAffordanceGrants), but the comment misrepresents the safety property and would mislead a future no-policy/CLI caller.
+severity: significant
+resolution: 'Corrected transitionGuard/requestGuard doc: states it fails closed unconditionally, has NO inert tier, and is safe only because it is wired solely under an active policy - with an explicit warning not to wire it from a no-policy path without adding the policy-active tier first. No behavior change (the tier is unreachable by construction today).'
+status: addressed
+---
+
+## Finding
+
+The read-path guard fails closed on a nil request unconditionally; the
+write-path guard (RR-UOBUC) has a `policyActive` tier (inert-allow when no
+policy, fail-closed when policy active). The comment claimed the two are
+"identical" — false. Harmless today (the machine-backed resolver is only
+constructed under an active policy), but the comment lies about the safety
+property and would mislead a future no-policy/CLI caller.
+
+## Fix
+
+Rewrote the doc to state: fails closed always; no inert tier; safe only because
+wired solely under an active policy; explicit "do not wire from a no-policy path
+without adding the policy-active tier" warning. Behavior unchanged (tier is
+unreachable by construction).

--- a/tickets/entities/review-responses/RR-QOZPX.md
+++ b/tickets/entities/review-responses/RR-QOZPX.md
@@ -1,0 +1,27 @@
+---
+id: RR-QOZPX
+type: review-response
+title: 'Read/write drift: Performable evaluated when: against pre-transition entity, write uses post-transition'
+finding: 'The shared evalEdge does not by itself guarantee AC4 parity - the invariant lives in the *entity fed to it. EnforceUpdate passes the post-write `updated` entity (value==to); Performable passed the current `e` (value==from). A when: referencing entity.value (the binding RR-NODYR introduced) therefore evaluates against the target on write but the source on read -> read verdict disagrees with what the write enforces. The parity test used a value-independent when: (count_relations) and so structurally could not catch it.'
+severity: critical
+resolution: 'Performable now clones e and sets prop=key.to before evalEdge, evaluating each edge exactly as the write path will when the move is made (value==to). resolve.go updated with a WHY comment. Parity test hardened (see RR for finding #3) with a driftMeta whose a->b edge has `when: entity.value == "b"`, proving read==write. Also skips self-loops (finding #2).'
+status: addressed
+---
+
+## Finding
+
+`evalEdge` is shared, but the invariant depends on WHICH entity it's handed.
+Write (`enforce.go` `EnforceUpdate`) passes `updated` (already at `to`); read
+(`resolve.go` `Performable`) passed the current `e` (at `from`). A `when:`
+referencing `entity.value` (RR-NODYR's binding) thus sees `to` on write and
+`from` on read → the read verdict disagrees with the write. The parity test's
+only `when:` was value-independent (`count_relations`), so it could never expose
+this — the AC4 drift guard was asserting on a fixture incapable of drifting.
+
+## Fix
+
+`Performable` clones `e`, sets `prop = key.to`, and evaluates the edge against
+that post-transition entity — "can I move to `to`" is answered as the gates
+*will* be evaluated when the move happens. Parity test now includes a
+value-dependent `when: entity.value == "b"` edge (driftMeta), which fails loudly
+if read/write ever diverge again.

--- a/tickets/entities/review-responses/RR-RGG00.md
+++ b/tickets/entities/review-responses/RR-RGG00.md
@@ -1,0 +1,23 @@
+---
+id: RR-RGG00
+type: review-response
+title: Parity test (AC4 drift guard) used a fixture structurally unable to expose drift
+finding: 'TestPerformable_MatchesEnforceUpdate reused snapshotMeta (only when: is value-independent count_relations) and only varied guard/counts. Both critical divergences (entity.value precondition, self-loop) passed clean. A drift guard that green-lights live divergences is decoration.'
+severity: significant
+resolution: 'Added driftMeta with a value-dependent `when: entity.value == to` edge and an a->a self-loop; the parity test now runs both snapshotMeta and driftMeta and asserts Performable.Allowed == (EnforceUpdate==nil) plus that self-loops are omitted-but-no-op. Both criticals would now be red pre-fix.'
+status: addressed
+---
+
+## Finding
+
+The AC4 parity test asserted read==write on `snapshotMeta`, whose only `when:`
+is value-independent and which has no self-loop — so it structurally could not
+catch either critical. A drift guard must be run on a fixture *capable* of
+drifting.
+
+## Fix
+
+Reworked the test to run over `snapshotMeta` (graph precondition) **and**
+`driftMeta` (value-dependent `when:` + self-loop). Asserts `Performable.Allowed
+== (EnforceUpdate == nil)` for every verdict, and that self-loops are omitted
+from verdicts yet no-op on write.

--- a/tickets/entities/tickets/TKT-FT8J9.md
+++ b/tickets/entities/tickets/TKT-FT8J9.md
@@ -1,0 +1,141 @@
+---
+id: TKT-FT8J9
+type: ticket
+title: 'Resolved transition affordance: performable transitions for (principal, entity, field)'
+kind: enhancement
+priority: medium
+effort: m
+status: in-progress
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Problem
+
+`statemachine.Set` (TKT-E4LW2) is write-path-only. There is no way to ask the
+question a status control (and CLI, and agent) actually needs:
+
+> **For principal X, on entity Y, which transitions of field Z can they perform
+> right now?**
+
+That is the *resolved, authorized* answer — current value of Z (the `from`), the
+declared out-edges, whether X holds each edge's **guard** (subject-aware against
+Y), and whether each edge's **`when:` precondition** holds against Y's current
+graph. It is exactly the input a Linear/Jira status dropdown needs: not the
+theoretically-declared moves, but the buttons *this* principal can press on
+*this* object.
+
+Today none of that is reachable on the read side: edges, guards, and the
+compiled `when:` programs are all unexported and only evaluated inside
+`EnforceUpdate`.
+
+## Scope
+
+**In:**
+- A resolving accessor on `statemachine.Set` that, given the current entity, a
+guard oracle, and a graph lookup, returns the **performable** outgoing
+transitions of a machine field — evaluating **both** guard and `when:` for the
+single (principal, entity) — plus, for non-performable edges, *why* (guard not
+held / precondition not met) so the UI can explain a disabled option.
+- A `TransitionVerdicts(ctx, e)` method on `affordances.PolicyResolver` (beside
+`FieldVerdicts`/`RelationVerdicts`) that calls the accessor with the resolver's
+existing `acl.Declarative` + graph snapshot, producing a per-entity result the
+data-entry serializer can surface.
+
+**Out:**
+- The SPA status *control* itself (consumes this; separate frontend ticket).
+- A `transition:*` wire verb / `_actions` key change — decide in a follow-up once
+the verdict shape is proven (this ticket produces the *data*, not necessarily a
+new `_actions` entry).
+- CLI "what can I do" and mermaid export (separate consumers).
+- Any enforcement-behavior change on the write path.
+
+## Design
+
+### Predicate-on-reads is fine here (bounded, single-field)
+
+The `internal/dataentry/CLAUDE.md` no-predicate-on-reads rule targets **hot,
+unbounded paths** — per-row Lua while rendering a list of hundreds of entities.
+Resolving the transitions of **one field on one entity** the user is viewing is
+a bounded, on-demand, O(edges) evaluation. The rule's *rationale* (list-scan
+perf cliff) does not reach this case, so evaluating `when:` here is consistent
+with the rule's intent — no exception needed. (Call this out explicitly; it is
+the crux.)
+
+### statemachine: a resolving accessor (keeps predicate encapsulated)
+
+```go
+// TransitionVerdict is one resolved outgoing transition for a specific
+// (principal, entity). Allowed is true iff the guard is held AND the
+// precondition holds. When false, Reason names the gate that failed.
+type TransitionVerdict struct {
+    To      string
+    Guard   string // permission name ("" = unguarded)
+    Allowed bool
+    Reason  string // "" when Allowed; else guard/precondition explanation
+}
+
+// Performable resolves the outgoing transitions from the current value of prop
+// on e, evaluating each edge's guard (via the Guard oracle, subject-aware) and
+// `when:` precondition (via the GraphLookup), for the principal on ctx. Sorted
+// by To. Nil if prop is not a machine or e sits in a terminal state.
+func (s *Set) Performable(
+    ctx context.Context, e *entity.Entity, prop string,
+    guard Guard, lookup GraphLookup,
+) []TransitionVerdict
+```
+
+This reuses the existing `evalWhen` + `edgeFor` internals and the same `Guard`
+/`GraphLookup` consumer-side interfaces the write path already uses. The
+compiled `*predicate.Program` stays inside `statemachine` (not leaked). Guard
+and `when:` evaluation is identical to `applyEdge`, minus the mutation — a
+shared helper should back both so read and write can't drift.
+
+### affordances: TransitionVerdicts(ctx, e)
+
+`PolicyResolver` already holds an `acl.Declarative` + `RelationLookup` and
+already resolves predicates per single entity (`FieldVerdicts`). Add
+`TransitionVerdicts(ctx, e)` that, for each machine-typed field on e's type,
+calls `Set.Performable` with a guard adapter over the resolver's ACL and its
+graph lookup. Returns `map[field][]TransitionVerdict`. The data-entry serializer
+surfaces it (wire shape TBD — likely alongside `_fields`).
+
+### Guard resolution
+
+Same subject-aware path as the write guard (`HoldsPermissionForEntity`), via the
+same `statemachine.Guard` interface — the affordance supplies an adapter over
+its `acl.Declarative`, exactly like appbuild's write-path `transitionGuard` but
+for the current principal on ctx.
+
+## Acceptance criteria
+
+1. `Set.Performable(ctx, e, prop, guard, lookup)` returns the outgoing
+transitions from e's current `prop` value, each with `{To, Guard, Allowed,
+Reason}`, sorted by To.
+2. `Allowed` is true iff the guard is held (subject-aware) AND the `when:`
+precondition holds; when false, `Reason` distinguishes guard-denied from
+precondition-failed.
+3. Returns nil when `prop` is not a state machine or e is in a terminal state
+(no out-edges); nil-safe on empty/nil Set.
+4. Guard and `when:` evaluation is backed by the SAME helper the write path uses
+(a regression test pins that a performable verdict and a successful
+`EnforceUpdate` agree, and a non-performable one and a rejected `EnforceUpdate`
+agree — read and write cannot drift).
+5. `affordances.PolicyResolver.TransitionVerdicts(ctx, e)` returns per-machine-
+field verdicts using the resolver's ACL + graph, for the ctx principal.
+6. Subject-scoped guard works (a principal who holds the guard only via an
+ownership relation to e gets `Allowed: true`; a global-less principal gets
+`Allowed: false, Reason: guard`).
+7. Bounded evaluation: the accessor scans only e's machine fields and their
+out-edges (no store/list scan); documented as the reason predicate-on-read is
+acceptable here.
+
+## References
+
+- Builds on TKT-E4LW2 (`internal/statemachine`) — reuses `evalWhen`, `edgeFor`,
+the `Guard`/`GraphLookup` interfaces, `HoldsPermissionForEntity`.
+- Sits beside `affordances.PolicyResolver.FieldVerdicts`/`RelationVerdicts`.
+- Predicate-on-reads rule (and why it doesn't apply): `internal/dataentry/CLAUDE.md`.
+- Consumers (separate tickets): SPA machine-aware status control; CLI; mermaid.
+- Related deferred verb: TKT-XZEY (`transition:*`) — this produces the data a
+`transition:*` affordance would carry, without committing to the wire verb yet.

--- a/tickets/entities/tickets/TKT-FT8J9.md
+++ b/tickets/entities/tickets/TKT-FT8J9.md
@@ -5,7 +5,7 @@ title: 'Resolved transition affordance: performable transitions for (principal, 
 kind: enhancement
 priority: medium
 effort: m
-status: in-progress
+status: done
 ---
 
 <!-- @managed: claude-workflow v1 -->

--- a/tickets/relations/TKT-FT8J9--affects--metamodel-types.md
+++ b/tickets/relations/TKT-FT8J9--affects--metamodel-types.md
@@ -1,0 +1,5 @@
+---
+from: TKT-FT8J9
+relation: affects
+to: metamodel-types
+---

--- a/tickets/relations/TKT-FT8J9--depends-on--TKT-E4LW2.md
+++ b/tickets/relations/TKT-FT8J9--depends-on--TKT-E4LW2.md
@@ -1,0 +1,5 @@
+---
+from: TKT-FT8J9
+relation: depends-on
+to: TKT-E4LW2
+---

--- a/tickets/relations/TKT-FT8J9--has-docs--DOCS-YFWN6.md
+++ b/tickets/relations/TKT-FT8J9--has-docs--DOCS-YFWN6.md
@@ -1,0 +1,5 @@
+---
+from: TKT-FT8J9
+relation: has-docs
+to: DOCS-YFWN6
+---

--- a/tickets/relations/TKT-FT8J9--has-implementation--IMPL-A2CDP.md
+++ b/tickets/relations/TKT-FT8J9--has-implementation--IMPL-A2CDP.md
@@ -1,0 +1,5 @@
+---
+from: TKT-FT8J9
+relation: has-implementation
+to: IMPL-A2CDP
+---

--- a/tickets/relations/TKT-FT8J9--has-planning--PLAN-J2VK7.md
+++ b/tickets/relations/TKT-FT8J9--has-planning--PLAN-J2VK7.md
@@ -1,0 +1,5 @@
+---
+from: TKT-FT8J9
+relation: has-planning
+to: PLAN-J2VK7
+---

--- a/tickets/relations/TKT-FT8J9--has-review--REV-Z4T1M.md
+++ b/tickets/relations/TKT-FT8J9--has-review--REV-Z4T1M.md
@@ -1,0 +1,5 @@
+---
+from: TKT-FT8J9
+relation: has-review
+to: REV-Z4T1M
+---

--- a/tickets/relations/TKT-FT8J9--has-review-response--RR-1WTST.md
+++ b/tickets/relations/TKT-FT8J9--has-review-response--RR-1WTST.md
@@ -1,0 +1,5 @@
+---
+from: TKT-FT8J9
+relation: has-review-response
+to: RR-1WTST
+---

--- a/tickets/relations/TKT-FT8J9--has-review-response--RR-2JBK4.md
+++ b/tickets/relations/TKT-FT8J9--has-review-response--RR-2JBK4.md
@@ -1,0 +1,5 @@
+---
+from: TKT-FT8J9
+relation: has-review-response
+to: RR-2JBK4
+---

--- a/tickets/relations/TKT-FT8J9--has-review-response--RR-6CQYC.md
+++ b/tickets/relations/TKT-FT8J9--has-review-response--RR-6CQYC.md
@@ -1,0 +1,5 @@
+---
+from: TKT-FT8J9
+relation: has-review-response
+to: RR-6CQYC
+---

--- a/tickets/relations/TKT-FT8J9--has-review-response--RR-QOA1Z.md
+++ b/tickets/relations/TKT-FT8J9--has-review-response--RR-QOA1Z.md
@@ -1,0 +1,5 @@
+---
+from: TKT-FT8J9
+relation: has-review-response
+to: RR-QOA1Z
+---

--- a/tickets/relations/TKT-FT8J9--has-review-response--RR-QOZPX.md
+++ b/tickets/relations/TKT-FT8J9--has-review-response--RR-QOZPX.md
@@ -1,0 +1,5 @@
+---
+from: TKT-FT8J9
+relation: has-review-response
+to: RR-QOZPX
+---

--- a/tickets/relations/TKT-FT8J9--has-review-response--RR-RGG00.md
+++ b/tickets/relations/TKT-FT8J9--has-review-response--RR-RGG00.md
@@ -1,0 +1,5 @@
+---
+from: TKT-FT8J9
+relation: has-review-response
+to: RR-RGG00
+---

--- a/tickets/relations/TKT-FT8J9--implements--FEAT-AESD4.md
+++ b/tickets/relations/TKT-FT8J9--implements--FEAT-AESD4.md
@@ -1,0 +1,5 @@
+---
+from: TKT-FT8J9
+relation: implements
+to: FEAT-AESD4
+---


### PR DESCRIPTION
## What

Adds the read-side "**which transitions can principal X perform on entity Y's field Z right now**" query to the state-machine feature (TKT-FT8J9, builds on the now-merged TKT-E4LW2 / #1143). The resolved, authorized answer a Linear/Jira-style status control needs: the legal out-edges from the current value, each with its guard evaluated (subject-aware) and `when:` precondition evaluated against the graph.

## How

- **`statemachine.Set.Performable(ctx, e, prop, guard, lookup)`** → `[]TransitionVerdict{To, Guard, Allowed, Reason}`. Evaluates each out-edge against the entity **as it would be after the move** (`value == to`) so the read verdict matches what the write enforces.
- **`statemachine.Set.MachineProps(entityType)`** → the machine-typed property names.
- **`affordances.PolicyResolver.TransitionVerdicts(ctx, e)`** — beside `FieldVerdicts`/`RelationVerdicts`, wiring the resolver's ACL (subject-aware guard) + graph into `Performable`.
- **Shared `evalEdge`** extracted so write `applyEdge` and read `Performable` route guard+when through one helper — the drift guard.

## Predicate-on-reads

`when:` evaluation here is a **bounded** per-entity read (one field, its out-edges), not the hot/unbounded list-scan the no-predicate-on-reads rule targets. CLAUDE.md (root + entitymanager) updated to make that boundary explicit.

## Ships dormant

Delivers the query (the data). No wire surface / SPA control yet — those are the linked consumer ticket. Fully unit/integration tested including the AC4 read/write parity guard.

## Review trail

Code review (cranky) found **2 criticals**, both fixed:
- read/write drift on `entity.value` preconditions (was evaluating the pre-transition entity)
- self-loop edges reported performable-on-read but no-op on write

The parity test was hardened with a `driftMeta` fixture that actually exposes those divergences; guard/concurrency/determinism doc comments corrected to state their real assumptions. 6 review-responses, all addressed.

## Verification

`go test ./...` + `-race`, `golangci-lint ./...` (0), `just arch-lint`, `just plimsoll`, `just coverage-check`, `just ci` — all green.