### PR TITLE
test(pgstore): verify relation-rename versioning on atomic RenameEntity (TKT-9TQ6I)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -232,7 +232,16 @@ Rules when touching this:
   lose history). Rename **stitches** (not forks): the entitymanager captures a
   `rename` version per incident relation on the new triple carrying
   `prev_from`/`prev_to`, and `relationLineageIDs` walks those links so history is
-  continuous. Read/restore is gated on **both** endpoints (FROM ∧ TO) — the FROM
+  continuous. Since #1127 the store renames **atomically** (bulk in-place
+  `UPDATE relations SET from_id=...`), so a relation KEEPS its `rel_record_id`
+  across the rename — the lineage is already continuous on one id and the
+  `rename` version merely appends a marker (the `prev_from`/`prev_to` stitch walk
+  finds no fork; it stays as belt-and-braces for any future non-atomic path).
+  Rename capture is **sync-only best-effort**: the atomic re-key does NOT bump
+  `relations.updated_at` (TKT-9TQ6I), so the sweep cannot back-fill a rename the
+  synchronous hook misses — acceptable because a miss loses only the rename
+  marker, never lineage continuity. Read/restore is gated on **both** endpoints
+  (FROM ∧ TO) — the FROM
   entity only _owns_ the UI placement, it is not the auth boundary (a TO-side
   oracle otherwise). Relations have NO field-level redaction today; relation
   history exposes exactly what a live relation GET does. `RelationHistoryReader`/

--- a/internal/entitymanager/manager.go
+++ b/internal/entitymanager/manager.go
@@ -815,13 +815,21 @@ func (m *Manager) RenameEntity(
 	m.recordEntityVersion(ctx, store.VersionOpRename, postEntity, oldID)
 
 	// Capture a `rename` version for each incident relation, on its NEW triple,
-	// carrying the pre-rename endpoints (prev_from/prev_to). This stitches the
-	// relation's history across the endpoint rename so it reads as one continuous
-	// timeline rather than a delete of the old triple + create of the new one.
-	// The new triples exist now (the store's atomic RenameEntity created them);
-	// the version's key is the post-rename endpoint, so WriteRelationVersion
-	// resolves the new rel_record_id. triggered_by attributes the versions to
-	// this rename.
+	// carrying the pre-rename endpoints (prev_from/prev_to). The version's key is
+	// the post-rename endpoint, so WriteRelationVersion resolves the surviving
+	// rel_record_id; triggered_by attributes the versions to this rename.
+	//
+	// Since #1127 the store renames atomically (a bulk in-place
+	// `UPDATE relations SET from_id=...`), so the relation KEEPS its
+	// rel_record_id across the rename — the lineage is already continuous on one
+	// id and this version merely appends a rename MARKER to it (the
+	// prev_from/prev_to stitch walk finds no fork; it is harmless belt-and-braces
+	// for a future non-atomic path). Capture here is SYNC-ONLY BEST-EFFORT: the
+	// atomic re-key does not bump relations.updated_at (see
+	// TestRelationRenameDoesNotBumpUpdatedAt), so the reconciliation sweep cannot
+	// back-fill a rename this hook misses. That is acceptable — a missed capture
+	// loses only the rename marker, never history continuity, because the
+	// underlying lineage stays intact on the surviving rel_record_id.
 	if len(preRenameRels) > 0 {
 		renameTB := "rename-entity:" + oldID + "->" + newID
 		for _, rel := range preRenameRels {

--- a/internal/entitymanager/relation_version_hook_test.go
+++ b/internal/entitymanager/relation_version_hook_test.go
@@ -155,6 +155,11 @@ func TestRelationVersionHook_CascadeDeleteCapturesEveryEdge(t *testing.T) {
 // records a `rename` relation version per incident edge, on the NEW triple,
 // carrying the pre-rename endpoints — so the edge's history stays continuous
 // instead of reading as a delete+create.
+//
+// This is the MANAGER half of rename-version coverage: it asserts the record
+// Manager.RenameEntity emits. The STORE half — that pgstore persists that
+// rename version on the surviving rel_record_id (no fork) — is asserted by
+// pgstore.TestRelationVersionRenameAtomicPath. Neither is redundant.
 func TestRelationVersionHook_RenameStitchesEndpoints(t *testing.T) {
 	mgr, rec := newRelationVersionManager(t)
 	ctx := ctxWithPrincipal("bob", principal.ToolMCP)

--- a/internal/store/pgstore/relation_version.go
+++ b/internal/store/pgstore/relation_version.go
@@ -94,12 +94,19 @@ func contentHashOfRelation(in store.RelationVersionInput) string {
 //
 // Unlike entity history, relation lineage needs NO recursive rename-fencing CTE:
 // rel_record_id is a stable surrogate carried across delete+recreate (a fresh id
-// is minted), so it fences those lifecycles apart for free. An endpoint RENAME,
-// however, rewrites a relation as create-new-triple + delete-old-triple at the
-// store level, so the new triple gets a FRESH rel_record_id and a `rename`
-// version row (on the new lineage) carries prev_from/prev_to = the old triple.
-// A relation's full history is therefore the current rel_record_id PLUS every
-// predecessor lineage reachable by following those rename links back — see
+// is minted), so it fences those lifecycles apart for free.
+//
+// Since #1127 an endpoint RENAME is an ATOMIC in-place `UPDATE relations SET
+// from_id/to_id=...` (see entity.go RenameEntity), so the relation KEEPS its
+// rel_record_id across the rename — the lineage is already continuous on one id
+// and the `rename` version row (carrying prev_from/prev_to = the old triple) is
+// just a marker on that same lineage, not a fork. The predecessor-lineage walk
+// below (relationLineageIDs) therefore normally finds no fork on the current
+// live path; it remains as belt-and-braces for any historical or future path
+// that DOES mint a fresh id on rename (the pre-#1127 delete-old + create-new
+// decomposition, whose rows may still exist in older databases). A relation's
+// full history is therefore the current rel_record_id PLUS every predecessor
+// lineage reachable by following those rename links back — see
 // relationLineageIDs.
 
 // relationLineageIDs returns every rel_record_id that makes up a relation's

--- a/internal/store/pgstore/relation_version_test.go
+++ b/internal/store/pgstore/relation_version_test.go
@@ -147,51 +147,123 @@ func TestRelationVersionRecreateStartsFreshLineage(t *testing.T) {
 	require.Equal(t, "gen2", snap.Content)
 }
 
-// TestRelationVersionRenameStitchesLineage proves the prev_from/prev_to rename
-// link stitches a renamed relation's history into one continuous timeline
-// across the fresh rel_record_id the new triple gets. Mirrors what the
-// entitymanager does on an endpoint rename (old triple deleted, new triple
-// created + a rename version carrying the old endpoints).
-func TestRelationVersionRenameStitchesLineage(t *testing.T) {
+// TestRelationVersionRenameAtomicPath verifies relation-rename versioning
+// against the REAL production path (TKT-9TQ6I). Since #1127, the entitymanager
+// renames an entity via the store's ATOMIC RenameEntity (a single bulk
+// `UPDATE relations SET from_id=$2 ...`), NOT the old rename.Rename
+// decomposition (delete-old + create-new). Two consequences this test pins:
+//
+//  1. The relation row keeps the SAME rel_record_id across the rename (in-place
+//     UPDATE, not delete+create). So the lineage is ALREADY continuous on one
+//     id — no fork, and the prev_from/prev_to stitch walk is redundant (it just
+//     finds no predecessor). The rename `version` the entitymanager records
+//     (via WriteRelationVersion with RecordID=0 → resolves the key → the
+//     surviving rel_record_id) simply appends to that one lineage.
+//  2. The atomic re-key does NOT bump relations.updated_at (RR-N5YK81, now the
+//     live path) — see TestRelationRenameDoesNotBumpUpdatedAt. That means the
+//     sweep cannot back-fill a missed rename capture; documented as best-effort
+//     (the lineage stays continuous regardless, so a missed rename version only
+//     loses the rename MARKER, not history continuity).
+//
+// This is the STORE half of rename-version coverage: it asserts the store
+// persists the rename version on the surviving rel_record_id. The MANAGER half —
+// that Manager.RenameEntity emits the right record (new triple, prev_from/
+// prev_to, per incident edge) — is asserted in the entitymanager package by
+// TestRelationVersionHook_RenameStitchesEndpoints. Neither is redundant; keep
+// both.
+func TestRelationVersionRenameAtomicPath(t *testing.T) {
 	pool := newScopedPool(t)
 	s, err := pgstore.New(pool)
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = s.Close() })
 	ctx := context.Background()
 
-	// Old edge A--links-->B: create + a captured version.
-	_, err = s.CreateRelation(ctx, "A", "links", "B", &store.RelationData{Content: "v1"})
+	// A live edge A--links-->X with a captured create version.
+	require.NoError(t, s.CreateEntity(ctx, mkEntity("A", "ticket", "")))
+	require.NoError(t, s.CreateEntity(ctx, mkEntity("X", "ticket", "")))
+	_, err = s.CreateRelation(ctx, "A", "links", "X", &store.RelationData{Content: "v1"})
 	require.NoError(t, err)
-	oldRID := relRecordID(ctx, t, pool, "A", "links", "B")
-	c := newRelVersionInput(oldRID, "A", "links", "B", "v1")
+	rid := relRecordID(ctx, t, pool, "A", "links", "X")
+	c := newRelVersionInput(rid, "A", "links", "X", "v1")
 	c.Op = store.VersionOpCreate
 	require.NoError(t, s.WriteRelationVersion(ctx, c))
 
-	// Rename A->A2: the new triple A2--links-->B is created (fresh rel_record_id)
-	// and the old one deleted, exactly as rename.Rename does.
-	_, err = s.CreateRelation(ctx, "A2", "links", "B", &store.RelationData{Content: "v1"})
+	// Rename A->A2 through the REAL atomic store path.
+	_, err = s.RenameEntity(ctx, "A", "A2")
 	require.NoError(t, err)
-	require.NoError(t, s.DeleteRelation(ctx, "A", "links", "B"))
-	newRID := relRecordID(ctx, t, pool, "A2", "links", "B")
-	require.NotEqual(t, oldRID, newRID)
 
-	// The rename version lands on the NEW lineage, carrying the old endpoints.
-	ren := newRelVersionInput(newRID, "A2", "links", "B", "v1")
+	// The relation kept its rel_record_id — continuous single lineage, no fork.
+	ridAfter := relRecordID(ctx, t, pool, "A2", "links", "X")
+	require.Equal(t, rid, ridAfter, "atomic rename carries rel_record_id (no fork)")
+
+	// Capture the rename version exactly as the entitymanager does: keyed on the
+	// NEW triple, RecordID=0 (WriteRelationVersion resolves it to the surviving
+	// rel_record_id), carrying the pre-rename endpoints.
+	ren := newRelVersionInput(0, "A2", "links", "X", "v1")
 	ren.Op = store.VersionOpRename
 	ren.PrevFrom = "A"
-	ren.PrevTo = "B"
+	ren.PrevTo = "X"
 	require.NoError(t, s.WriteRelationVersion(ctx, ren))
 
-	// Reading history via the NEW key must include BOTH the pre-rename create
-	// (old lineage) and the rename row — one continuous timeline.
-	metas, err := s.ListRelationVersions(ctx, "A2", "links", "B")
+	// History via the new key is one continuous timeline on the surviving
+	// lineage: the pre-rename create + the rename row. No orphaned lineage.
+	metas, err := s.ListRelationVersions(ctx, "A2", "links", "X")
 	require.NoError(t, err)
-	require.Len(t, metas, 2, "history stitches old create + new rename")
+	require.Len(t, metas, 2, "continuous timeline on the surviving rel_record_id")
 	require.Equal(t, store.VersionOpCreate, metas[0].Op)
-	require.Equal(t, "A", metas[0].From, "oldest version carries the pre-rename endpoint")
+	require.Equal(t, "A", metas[0].From, "the create version still carries the pre-rename endpoint")
 	require.Equal(t, store.VersionOpRename, metas[1].Op)
 	require.Equal(t, "A2", metas[1].From)
 	require.Equal(t, "A", metas[1].PrevFrom)
+
+	// Prove no FORK directly, not just via Len==2 (which the stitch-walk could
+	// satisfy from two lineages): both version rows must sit on the ONE surviving
+	// rel_record_id, and that id must be `rid`.
+	var distinctLineages int
+	require.NoError(t, pool.QueryRow(ctx,
+		`SELECT COUNT(DISTINCT rel_record_id) FROM relation_versions WHERE rel_record_id = $1`, rid).Scan(&distinctLineages))
+	require.Equal(t, 1, distinctLineages)
+	var total, onRid int
+	require.NoError(t, pool.QueryRow(ctx, `SELECT COUNT(*) FROM relation_versions`).Scan(&total))
+	require.NoError(t, pool.QueryRow(ctx,
+		`SELECT COUNT(*) FROM relation_versions WHERE rel_record_id = $1`, rid).Scan(&onRid))
+	require.Equal(t, total, onRid, "every version row is on the surviving lineage — no forked rel_record_id")
+}
+
+// TestRelationRenameDoesNotBumpUpdatedAt pins the RR-N5YK81 fact (now the live
+// atomic path): the entity rename's relation re-key does NOT touch
+// relations.updated_at. Consequence: the sweep (which uses updated_at) cannot
+// back-fill a rename capture that the synchronous hook missed. This is accepted
+// as best-effort — the lineage stays continuous on the surviving rel_record_id
+// regardless, so a missed rename version loses only the rename MARKER, not
+// history continuity. If a future change wants sweep back-fill for renames, bump
+// updated_at in the atomic re-key (entity.go RenameEntity) — this test guards
+// the current documented behavior.
+func TestRelationRenameDoesNotBumpUpdatedAt(t *testing.T) {
+	pool := newScopedPool(t)
+	s, err := pgstore.New(pool)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = s.Close() })
+	ctx := context.Background()
+
+	require.NoError(t, s.CreateEntity(ctx, mkEntity("A", "ticket", "")))
+	require.NoError(t, s.CreateEntity(ctx, mkEntity("X", "ticket", "")))
+	_, err = s.CreateRelation(ctx, "A", "links", "X", &store.RelationData{Content: "v1"})
+	require.NoError(t, err)
+
+	var before string
+	require.NoError(t, pool.QueryRow(ctx,
+		`SELECT updated_at::text FROM relations WHERE from_id='A' AND rel_type='links' AND to_id='X'`).Scan(&before))
+
+	_, err = s.RenameEntity(ctx, "A", "A2")
+	require.NoError(t, err)
+
+	var after string
+	require.NoError(t, pool.QueryRow(ctx,
+		`SELECT updated_at::text FROM relations WHERE from_id='A2' AND rel_type='links' AND to_id='X'`).Scan(&after))
+
+	require.Equal(t, before, after,
+		"atomic rename re-key does not bump relations.updated_at (documented best-effort; sweep can't back-fill a missed rename)")
 }
 
 // TestSweepCapturesSettledRelations drives the sweep against a settled relation

--- a/tickets/entities/implementation-checklists/IMPL-ZWW6W.md
+++ b/tickets/entities/implementation-checklists/IMPL-ZWW6W.md
@@ -1,0 +1,21 @@
+---
+id: IMPL-ZWW6W
+type: implementation-checklist
+title: 'Implementation: Re-verify relation-rename versioning against the atomic store.RenameEntity path (post #1127)'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Development
+
+- [x] Rewrote stale `TestRelationVersionRenameStitchesLineage` → `TestRelationVersionRenameAtomicPath` (drives real `store.RenameEntity`)
+- [x] Added `TestRelationRenameDoesNotBumpUpdatedAt` pinning the no-updated_at-bump fact
+- [x] Documented sync-only-best-effort decision (manager.go comment, relation_version.go godoc, CLAUDE.md)
+
+## Quality
+
+- [x] Tests pass (`go test -tags postgres ./internal/store/pgstore/` + entitymanager)
+- [x] Lint clean (default build, changed pkgs)
+- [x] `go vet -tags postgres` clean
+- [x] ~~New user-facing behavior~~ (N/A: test + doc only, no behavior change)

--- a/tickets/entities/review-checklists/REV-5CWH8.md
+++ b/tickets/entities/review-checklists/REV-5CWH8.md
@@ -1,0 +1,53 @@
+---
+id: REV-5CWH8
+type: review-checklist
+title: 'Review: Re-verify relation-rename versioning against the atomic store.RenameEntity path (post #1127)'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Automated Checks
+
+- [x] All tests pass (`go test -tags postgres ./internal/store/pgstore/` + entitymanager — green)
+- [x] Lint clean (default-build `golangci-lint` on changed pkgs: 0 issues; postgres test file not linted in CI)
+- [x] ~~Coverage maintained~~ (N/A: test-only + doc change, adds coverage)
+
+## Code Review
+
+- [x] Run `/code-review` command (cranky-code-reviewer)
+- [x] All critical review-responses addressed (none)
+- [x] All significant review-responses addressed (RR-QT7C5 — stale godoc, fixed)
+- [x] Self-reviewed the diff for unrelated changes (removed a dangling stale doc comment I'd left)
+
+**Review Responses:** RR-QT7C5 (significant, addressed), RR-YFQ9E (minor,
+addressed)
+
+## Acceptance Verification
+
+- [x] Each acceptance criterion tested (ticket tasks 1-3)
+- [x] Test evidence documented below
+
+**Acceptance Status:**
+
+- Task 1 (fix stale test): PASS — `TestRelationVersionRenameStitchesLineage` → `TestRelationVersionRenameAtomicPath`, drives real `store.RenameEntity`, asserts same `rel_record_id` + no fork.
+- Task 2 (end-to-end capture): PASS — store-half asserted here (rename version persisted on surviving lineage); manager-half asserted by `TestRelationVersionHook_RenameStitchesEndpoints`. Cross-referenced.
+- Task 3 (updated_at decision): PASS — documented sync-only-best-effort; pinned by `TestRelationRenameDoesNotBumpUpdatedAt`; rationale in manager.go + CLAUDE.md + relation_version.go godoc.
+
+## Documentation (enhancements only)
+
+- [x] ~~Docs-checklist created~~ (N/A: internal test-hardening ticket, no user-facing docs; developer docs updated in CLAUDE.md + godoc)
+
+## Final Checks
+
+- [x] Commit message explains the why, not just what
+- [x] No TODOs or FIXMEs left unaddressed
+- [x] Ready for another developer to use
+
+## Pull Request
+
+- [x] Run `/pr` command to create PR and monitor CI
+- [ ] All CI checks pass
+- [ ] PR URL documented below
+
+**PR:** <!-- filled after creation -->

--- a/tickets/entities/review-checklists/REV-5CWH8.md
+++ b/tickets/entities/review-checklists/REV-5CWH8.md
@@ -47,7 +47,7 @@ addressed)
 ## Pull Request
 
 - [x] Run `/pr` command to create PR and monitor CI
-- [ ] All CI checks pass
-- [ ] PR URL documented below
+- [x] All CI checks pass (monitored post-creation)
+- [x] PR URL documented below
 
-**PR:** <!-- filled after creation -->
+**PR:** https://github.com/sourcehaven-bv/rela/pull/1153

--- a/tickets/entities/review-responses/RR-QT7C5.md
+++ b/tickets/entities/review-responses/RR-QT7C5.md
@@ -1,0 +1,9 @@
+---
+id: RR-QT7C5
+type: review-response
+title: Stale RelationHistoryReader godoc describes pre-#1127 create+delete rename model
+finding: 'internal/store/pgstore/relation_version.go:97-100 still asserted that an endpoint rename ''rewrites a relation as create-new-triple + delete-old-triple ... so the new triple gets a FRESH rel_record_id''. Since #1127 rename is an atomic in-place UPDATE that keeps the rel_record_id; this is the primary design comment for relation lineage and contradicted the very behavior TKT-9TQ6I documents.'
+severity: significant
+resolution: Rewrote the godoc to state the atomic rename keeps the rel_record_id (continuous single lineage) and that relationLineageIDs is belt-and-braces for the historical/pre-#1127 forked path, mirroring the manager.go comment.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-YFQ9E.md
+++ b/tickets/entities/review-responses/RR-YFQ9E.md
@@ -1,0 +1,9 @@
+---
+id: RR-YFQ9E
+type: review-response
+title: No-fork guarantee tested only via Len==2, not directly
+finding: TestRelationVersionRenameAtomicPath asserted 'no orphaned lineage' via require.Len(metas, 2), which the stitch-walk could satisfy from two lineages. The no-fork property rested only on the relations-table rel_record_id equality, not on the version rows themselves.
+severity: minor
+resolution: 'Added direct assertions: COUNT(DISTINCT rel_record_id) on the surviving id == 1, and total relation_versions rows == rows on rid — proving every version row sits on the one surviving lineage.'
+status: addressed
+---

--- a/tickets/entities/tickets/TKT-9TQ6I.md
+++ b/tickets/entities/tickets/TKT-9TQ6I.md
@@ -4,7 +4,8 @@ type: ticket
 title: 'Re-verify relation-rename versioning against the atomic store.RenameEntity path (post #1127)'
 kind: test
 priority: medium
-status: backlog
+effort: s
+status: done
 ---
 
 ## Context

--- a/tickets/relations/TKT-9TQ6I--has-implementation--IMPL-ZWW6W.md
+++ b/tickets/relations/TKT-9TQ6I--has-implementation--IMPL-ZWW6W.md
@@ -1,0 +1,5 @@
+---
+from: TKT-9TQ6I
+relation: has-implementation
+to: IMPL-ZWW6W
+---

--- a/tickets/relations/TKT-9TQ6I--has-review--REV-5CWH8.md
+++ b/tickets/relations/TKT-9TQ6I--has-review--REV-5CWH8.md
@@ -1,0 +1,5 @@
+---
+from: TKT-9TQ6I
+relation: has-review
+to: REV-5CWH8
+---

--- a/tickets/relations/TKT-9TQ6I--has-review-response--RR-QT7C5.md
+++ b/tickets/relations/TKT-9TQ6I--has-review-response--RR-QT7C5.md
@@ -1,0 +1,5 @@
+---
+from: TKT-9TQ6I
+relation: has-review-response
+to: RR-QT7C5
+---

--- a/tickets/relations/TKT-9TQ6I--has-review-response--RR-YFQ9E.md
+++ b/tickets/relations/TKT-9TQ6I--has-review-response--RR-YFQ9E.md
@@ -1,0 +1,5 @@
+---
+from: TKT-9TQ6I
+relation: has-review-response
+to: RR-YFQ9E
+---


### PR DESCRIPTION
## What

Re-verifies relation-rename versioning against the **atomic** `store.RenameEntity` path that #1127 (BUG-5QDV6F) introduced. Before #1127, entity rename decomposed into per-relation delete-old + create-new (fresh `rel_record_id`, stitched via `prev_from`/`prev_to`); now it is a single in-place `UPDATE relations SET from_id=...` that **keeps** the `rel_record_id`.

Test + documentation only — no production behavior change.

## Changes

- **Rewrote the stale test** `TestRelationVersionRenameStitchesLineage` → `TestRelationVersionRenameAtomicPath`: drives the real `store.RenameEntity`, asserts the relation keeps its `rel_record_id` (continuous single lineage), captures the rename version exactly as the entitymanager does (`WriteRelationVersion` with `RecordID=0`), and asserts **directly** (via `COUNT(DISTINCT rel_record_id)`) that no forked lineage exists.
- **Added** `TestRelationRenameDoesNotBumpUpdatedAt`: pins that the atomic re-key does not bump `relations.updated_at`.
- **Documented the `updated_at` decision** — rename capture is **sync-only best-effort** (a missed capture loses only the rename *marker*, never lineage continuity, because the id survives). Rationale in `manager.go`, the `RelationHistoryReader` godoc in `relation_version.go` (which still described the retired pre-#1127 model), and `CLAUDE.md`.

## Coverage split (kept intentionally)

- **Store half** (this PR, pgstore): rename version persisted on the surviving `rel_record_id`, no fork.
- **Manager half** (existing, entitymanager): `TestRelationVersionHook_RenameStitchesEndpoints` — the record `Manager.RenameEntity` emits.

Cross-referenced in both test doc comments.

## Review

`/code-review` (cranky-code-reviewer) run: 1 significant (stale godoc — fixed, RR-QT7C5), 1 minor (no-fork assertion hardened — RR-YFQ9E). No critical findings.

Closes TKT-9TQ6I.