### PR TITLE
feat: machine-aware status control (_transitions + SPA StatusControl + entry-locked create) (TKT-3G93B8)

### DIFF
--- a/docs-project/entities/guides/GUIDE-metamodel.md
+++ b/docs-project/entities/guides/GUIDE-metamodel.md
@@ -211,6 +211,49 @@ Notes:
   type**; an inline `labels` map on such a property is ignored (mirroring how an
   inline `values` list is ignored there).
 
+### State Machines (transitions)
+
+An enum custom type becomes a **state machine** when it declares `transitions:` —
+the legal value→value moves. Instead of any value changing to any other, only the
+declared edges are allowed; the write path rejects an undeclared move (`422`), and
+each edge can additionally require an ACL permission (`guard`, `403`) and/or a data
+precondition (`when`, `422`).
+
+```yaml
+types:
+  ticket-status:
+    values: [todo, doing, review, done]
+    initial: todo # the only value a newly created entity may enter at
+    transitions:
+      - from: todo
+        to: doing
+        label: Start progress # optional: names the MOVE (an action verb)
+      - from: doing
+        to: review
+        label: Send to review
+      - from: review
+        to: done
+        guard: close # requires the `close` ACL permission
+        when: 'count_relations(entity, "reviewed-by") > 0' # precondition
+      - from: review
+        to: doing
+        label: Reopen
+```
+
+| Field | Meaning |
+| ----- | ------- |
+| `from` / `to` | Source and target values; both must be declared in `values`. |
+| `initial` | The only value a **create** may set (else `default`). New entities are pinned to it — a create cannot enter a guarded mid-lifecycle state. |
+| `guard` | An ACL permission the acting principal must hold for the move. Enforced on served paths; inert on a direct CLI write with no policy. |
+| `when` | A predicate (same language as validations, evaluated against the entity + graph) that must hold for the move. |
+| `label` | **Optional** display text for the move (the *action*, e.g. "Start progress"), used by the data-entry status control. Display-only — the stored value is still `to`. Absent → the UI falls back to the target value's display label, then the raw value. |
+
+The data-entry UI reads these to render a **status control** that offers only the
+moves the current user can perform right now (see the `_transitions` affordance in
+the [data-entry API reference](data-entry/api-reference.md)). `transitions` is
+optional and backwards compatible: an enum type without it keeps the historical
+"any value may change to any other" behavior.
+
 ### Regex Validations
 
 Define validation patterns with user-friendly error messages. Multiple patterns
@@ -296,7 +339,7 @@ Each entity type defines:
 
 ### Display name
 
-Every entity type has a _primary property_ — the property whose value
+Every entity type has a *primary property* — the property whose value
 is the entity's display name. When unset, rela picks one
 automatically: it checks `title`, `name`, `label` in that order (when
 each is a required string property), then falls back to any required

--- a/docs/data-entry/api-reference.md
+++ b/docs/data-entry/api-reference.md
@@ -527,6 +527,63 @@ fields, omit hidden fields, and filter enum options, then commits only
 the visible + writable keys; the server fills hidden / read-only
 defaults itself (downstream of the gate).
 
+## Transition affordances: `_transitions` (TKT-3G93B8)
+
+A per-entity GET response also carries `_transitions` for every property whose
+type is an **enum state machine** (a `CustomType` with declared `transitions:` —
+see [the metamodel guide](../metamodel.md)). It is the resolved answer to "which
+moves can *this* principal make on *this* field of *this* entity right now",
+computed from the same evaluation the write path enforces (guard + `when:`
+precondition). The SPA renders a machine field as a status control offering only
+the performable moves, rather than a plain enum select listing every value.
+
+### Wire shape
+
+```json
+{
+  "id": "TKT-001",
+  "type": "ticket",
+  "properties": { "status": "todo" },
+  "_transitions": {
+    "status": [
+      { "to": "doing", "label": "Start progress", "allowed": true },
+      { "to": "done",  "label": "Complete", "guard": "close",
+        "allowed": false, "reason": "guard" }
+    ]
+  }
+}
+```
+
+Each entry is one declared out-edge from the field's current value:
+
+| Field | Meaning |
+|---|---|
+| `to` | Target value the move lands on. |
+| `label` | Optional display text for the **move** (the action, e.g. "Start progress"). Absent → the SPA falls back to the target value's display label, then the raw value. Authored via `label:` on the transition in the metamodel. |
+| `guard` | ACL permission the move requires; absent when unguarded. |
+| `allowed` | `true` iff the principal holds the guard AND the `when:` precondition holds. |
+| `reason` | Why `allowed` is false: `guard` or `precondition`. Absent when allowed. Advisory (the control shows only allowed moves, so this feeds a tooltip/CLI, not the render gate). |
+
+`_transitions` is **keyed only by machine-typed properties** — a plain enum field
+has no entry, and the SPA falls back to the ordinary enum control. The map is
+**absent entirely** when the server wires no state machines (no policy /
+non-machine metamodel / older server), the same "feature not available" signal
+`_fields` uses via its pointer. Like every affordance map it is a **UI hint,
+never authorization**: the write path re-enforces the transition (guard 403,
+legality / precondition 422), so a stale verdict simply surfaces the existing
+structured error (attempt-and-recover).
+
+### Create is an entry, not a transition
+
+On the create form there is no prior state to move *from*, and a machine may only
+be entered at its initial value (see BUG-X1C7S). The create dry-run
+(`?dry_run=true`) therefore **locks** every machine field: it pins the property to
+the machine's entry value, marks it `writable: false` in `_fields`, and omits it
+from `_transitions`. The SPA renders it read-only at the initial state; the
+create-commit filter drops the (non-writable) key so the server applies the
+initial itself. A client cannot enter a machine at a non-initial state — the real
+create rejects it regardless of the hint.
+
 ### View-section row entities (TKT-IHC7D)
 
 Cards/list view sections (`display: properties | list | content | cards`)

--- a/docs/data-entry/api-reference.md
+++ b/docs/data-entry/api-reference.md
@@ -564,8 +564,12 @@ Each entry is one declared out-edge from the field's current value:
 | `allowed` | `true` iff the principal holds the guard AND the `when:` precondition holds. |
 | `reason` | Why `allowed` is false: `guard` or `precondition`. Absent when allowed. Advisory (the control shows only allowed moves, so this feeds a tooltip/CLI, not the render gate). |
 
-`_transitions` is **keyed only by machine-typed properties** — a plain enum field
-has no entry, and the SPA falls back to the ordinary enum control. The map is
+`_transitions` is **keyed by every machine-typed property** — a plain enum field
+has no entry, and the SPA falls back to the ordinary enum control. A machine
+field in a **terminal state** (no performable out-edges) still carries its key
+with an **empty list** (`"status": []`): the key's presence is what tells the SPA
+"this is a state machine — render the status control (here, with no moves)"
+rather than a full enum select that would offer illegal targets. The map is
 **absent entirely** when the server wires no state machines (no policy /
 non-machine metamodel / older server), the same "feature not available" signal
 `_fields` uses via its pointer. Like every affordance map it is a **UI hint,

--- a/docs/metamodel.md
+++ b/docs/metamodel.md
@@ -205,6 +205,49 @@ Notes:
   type**; an inline `labels` map on such a property is ignored (mirroring how an
   inline `values` list is ignored there).
 
+### State Machines (transitions)
+
+An enum custom type becomes a **state machine** when it declares `transitions:` —
+the legal value→value moves. Instead of any value changing to any other, only the
+declared edges are allowed; the write path rejects an undeclared move (`422`), and
+each edge can additionally require an ACL permission (`guard`, `403`) and/or a data
+precondition (`when`, `422`).
+
+```yaml
+types:
+  ticket-status:
+    values: [todo, doing, review, done]
+    initial: todo # the only value a newly created entity may enter at
+    transitions:
+      - from: todo
+        to: doing
+        label: Start progress # optional: names the MOVE (an action verb)
+      - from: doing
+        to: review
+        label: Send to review
+      - from: review
+        to: done
+        guard: close # requires the `close` ACL permission
+        when: 'count_relations(entity, "reviewed-by") > 0' # precondition
+      - from: review
+        to: doing
+        label: Reopen
+```
+
+| Field | Meaning |
+| ----- | ------- |
+| `from` / `to` | Source and target values; both must be declared in `values`. |
+| `initial` | The only value a **create** may set (else `default`). New entities are pinned to it — a create cannot enter a guarded mid-lifecycle state. |
+| `guard` | An ACL permission the acting principal must hold for the move. Enforced on served paths; inert on a direct CLI write with no policy. |
+| `when` | A predicate (same language as validations, evaluated against the entity + graph) that must hold for the move. |
+| `label` | **Optional** display text for the move (the *action*, e.g. "Start progress"), used by the data-entry status control. Display-only — the stored value is still `to`. Absent → the UI falls back to the target value's display label, then the raw value. |
+
+The data-entry UI reads these to render a **status control** that offers only the
+moves the current user can perform right now (see the `_transitions` affordance in
+the [data-entry API reference](data-entry/api-reference.md)). `transitions` is
+optional and backwards compatible: an enum type without it keeps the historical
+"any value may change to any other" behavior.
+
 ### Regex Validations
 
 Define validation patterns with user-friendly error messages. Multiple patterns

--- a/docs/metamodel.md
+++ b/docs/metamodel.md
@@ -333,7 +333,7 @@ Each entity type defines:
 
 ### Display name
 
-Every entity type has a _primary property_ — the property whose value
+Every entity type has a *primary property* — the property whose value
 is the entity's display name. When unset, rela picks one
 automatically: it checks `title`, `name`, `label` in that order (when
 each is a required string property), then falls back to any required

--- a/frontend/src/components/common/Badge.vue
+++ b/frontend/src/components/common/Badge.vue
@@ -56,6 +56,9 @@ const displayText = computed(() => label.value ?? props.value)
        never v-html. -->
   <span class="badge" :class="[badgeClass, { 'badge--labeled': label !== undefined }]">
     {{ displayText }}
+    <!-- Optional trailing adornment (e.g. a dropdown caret when the badge is an
+         interactive control). Empty for the common read-only badge. -->
+    <slot />
   </span>
 </template>
 

--- a/frontend/src/components/entity/sectionEditFields.test.ts
+++ b/frontend/src/components/entity/sectionEditFields.test.ts
@@ -75,6 +75,35 @@ describe('buildSectionEditFields', () => {
     const title = out.find((f) => f.property === 'title')
     expect(title?.verdict).toBeUndefined()
   })
+
+  it('attaches per-field transitions from entry._transitions (TKT-3G93B8)', () => {
+    const entry = makeEntity({
+      _transitions: { status: [{ to: 'closed', label: 'Close', allowed: true }] },
+    })
+    const out = buildSectionEditFields(makeFields(), entry, schemaResolver)
+    const status = out.find((f) => f.property === 'status')
+    // A machine field carries its transitions → routes to StatusControl.
+    expect(status?.transitions).toEqual([{ to: 'closed', label: 'Close', allowed: true }])
+    // A non-machine field has no transitions → renders its ordinary widget.
+    const title = out.find((f) => f.property === 'title')
+    expect(title?.transitions).toBeUndefined()
+  })
+
+  it('passes an empty transitions list through (terminal machine field)', () => {
+    // Key present with [] must survive so the detail view still routes to the
+    // StatusControl (not a full enum select) at a terminal state.
+    const entry = makeEntity({ _transitions: { status: [] } })
+    const out = buildSectionEditFields(makeFields(), entry, schemaResolver)
+    const status = out.find((f) => f.property === 'status')
+    expect(status?.transitions).toEqual([])
+  })
+
+  it('leaves transitions undefined for a source without _transitions (list row)', () => {
+    // A ViewEntity row carries no `_transitions`, so its status field keeps the
+    // ordinary widget rather than a status control.
+    const out = buildSectionEditFields(makeFields(), makeEntity(), schemaResolver)
+    expect(out.find((f) => f.property === 'status')?.transitions).toBeUndefined()
+  })
 })
 
 describe('sectionShouldRouteToInlineEdit', () => {

--- a/frontend/src/components/entity/sectionEditFields.ts
+++ b/frontend/src/components/entity/sectionEditFields.ts
@@ -6,7 +6,7 @@
 // the SFC's router / pinia / schema-store wiring (TKT-IHC7B).
 
 import type { ViewEntity, ViewSectionField } from '@/api'
-import type { Entity, FieldAffordance, PropertyDef } from '@/types'
+import type { Entity, FieldAffordance, PropertyDef, TransitionOption } from '@/types'
 import { defaultRegistry } from '@/widgets/registry'
 import { viewFieldRoutingHint } from '@/widgets/viewRouting'
 import { isFieldWritable } from '@/utils/affordances'
@@ -25,6 +25,11 @@ void defaultRegistry
 export interface FieldVerdictSource {
   type: string
   _fields?: Record<string, FieldAffordance>
+  // Present on a full Entity (the entry section), absent on a cards/list
+  // ViewEntity row. When present for a property, that field is a state machine
+  // and routes to the StatusControl (TKT-3G93B8); rows have no `_transitions`,
+  // so they keep the ordinary widget.
+  _transitions?: Record<string, TransitionOption[]>
 }
 
 // buildSectionEditFields shapes a properties section's fields for
@@ -47,11 +52,13 @@ export function buildSectionEditFields(
     if (!f.property) continue
     const def = getPropertyDef(source.type, f.property)
     const verdict = source._fields?.[f.property]
+    const transitions = source._transitions?.[f.property]
     if (def) {
       out.push({
         property: f.property,
         label: f.label,
         verdict,
+        transitions,
         kind: 'schema',
         propertyDef: def,
       })
@@ -60,6 +67,7 @@ export function buildSectionEditFields(
         property: f.property,
         label: f.label,
         verdict,
+        transitions,
         kind: 'hint',
         routingHint: viewFieldRoutingHint(f),
       })

--- a/frontend/src/components/forms/DynamicForm.vue
+++ b/frontend/src/components/forms/DynamicForm.vue
@@ -32,6 +32,7 @@ import { useAutoSave } from '@/composables/useAutoSave'
 import { useFormWizard } from '@/composables/useFormWizard'
 import type { Bindings } from '@/utils/conditions'
 import { registerForm } from './dirtyFormRegistry'
+import { adoptLockedFieldValues } from './stagedEntity'
 import AutoSaveIndicator from './AutoSaveIndicator.vue'
 import FormFieldList from './FormFieldList.vue'
 import MarkdownEditor from './MarkdownEditor.vue'
@@ -526,17 +527,12 @@ async function refreshStagedAffordances() {
 
     fieldAffordances.value = candidate._fields ?? {}
     relationAffordances.value = candidate._relations ?? {}
-    // Entry-locked create fields (TKT-3G93B8 / BUG-X1C7S): the server pins a
-    // state-machine field to its initial value and marks it writable=false. Adopt
-    // that value into formData so the locked control DISPLAYS the initial state
-    // (not whatever the user may have typed before it locked). The commit filter
-    // already omits writable=false keys, so the server applies the initial
-    // regardless — this only keeps the visible value honest.
-    for (const [name, verdict] of Object.entries(candidate._fields ?? {})) {
-      if (verdict.writable === false && candidate.properties && name in candidate.properties) {
-        formData.value[name] = candidate.properties[name]
-      }
-    }
+    // Entry-locked create fields (TKT-3G93B8 / BUG-X1C7S): adopt the server's
+    // authoritative value for every read-only field (a machine field the server
+    // pinned to its initial value, or any policy-read-only field) so the locked
+    // control DISPLAYS the server value, not stale user input. Scoped to read-only
+    // fields, so it never clobbers an editable one. See adoptLockedFieldValues.
+    adoptLockedFieldValues(candidate._fields, candidate.properties, formData.value)
     // The dry-run strips hidden fields from `properties`; the remaining
     // keys are exactly the visible-by-default props the field filter
     // needs to render (since they won't appear in the sparse `_fields`).
@@ -1217,6 +1213,16 @@ onMounted(async () => {
           delete formData.value[property]
         } else {
           formData.value[property] = value
+        }
+        // A committed state-machine move changes which transitions are now
+        // performable — the loaded `_transitions` reflect the PRE-move state
+        // (RR-NI145G). The PATCH response's fresh `_transitions` isn't threaded
+        // through the autosave merge, so reload the entity to refresh the
+        // status control (mirrors onAttachmentChanged's reload for
+        // `_attachments`). Fire-and-forget: this is a UI-hint refresh, and the
+        // write already succeeded.
+        if (property in transitions.value) {
+          void loadEntity(true)
         }
       },
       applyServerContent: (c) => {

--- a/frontend/src/components/forms/DynamicForm.vue
+++ b/frontend/src/components/forms/DynamicForm.vue
@@ -17,6 +17,7 @@ import type {
   FieldAffordance,
   RelationAffordance,
   AttachmentInfo,
+  TransitionOption,
 } from '@/types'
 import { getTemplates, createRelation, dryRunCreateEntity, ApiError, getErrorMessage } from '@/api'
 import type { RelationCardState } from './RelationCards.vue'
@@ -72,6 +73,11 @@ const relationAffordances = ref<Record<string, RelationAffordance>>({})
 // Per-`file`-property attachment metadata from the loaded entity, passed
 // to the file widget so it can show the current file + drive upload/remove.
 const attachments = ref<Record<string, AttachmentInfo[]>>({})
+// Per-state-machine-field transition verdicts from the loaded entity
+// (`_transitions`, TKT-3G93B8). Present only for machine-typed fields; drives
+// the StatusControl (only-allowed moves) instead of the plain enum select. A
+// field absent here renders as an ordinary widget.
+const transitions = ref<Record<string, TransitionOption[]>>({})
 // TKT-3I5U: in create mode the form models a staged `++new++` entity
 // and re-derives affordances from the server's dry-run (no persist) as
 // the user types. `stagedVisibleProps` holds the property keys the
@@ -267,6 +273,16 @@ function optionVerdictsFor(field: FormFieldOrRelation): Record<string, boolean> 
   return optionVerdictsForVerdict(fieldAffordances.value[field.property])
 }
 
+// TKT-3G93B8 transition helper: the server-resolved outgoing transitions for a
+// state-machine field (`_transitions`). Undefined for a non-machine field, so
+// FieldRenderer renders the ordinary widget; a machine field routes to the
+// StatusControl. Only present in edit mode (a create locks the field instead —
+// see applyCreateLock on the backend).
+function transitionsFor(field: FormFieldOrRelation): TransitionOption[] | undefined {
+  if (!field.property) return undefined
+  return transitions.value[field.property]
+}
+
 // TKT-3I5U: build the create-commit property map, sending ONLY visible
 // and writable keys. Hidden fields (stripped from the staged dry-run's
 // visible set) and read-only fields (writable=false in `_fields`) are
@@ -331,6 +347,7 @@ async function loadEntity(force = false) {
     fieldAffordances.value = entity._fields ?? {}
     relationAffordances.value = entity._relations ?? {}
     attachments.value = entity._attachments ?? {}
+    transitions.value = entity._transitions ?? {}
     originalData.value = JSON.stringify({
       formData: formData.value,
       relations: relations.value,
@@ -509,6 +526,17 @@ async function refreshStagedAffordances() {
 
     fieldAffordances.value = candidate._fields ?? {}
     relationAffordances.value = candidate._relations ?? {}
+    // Entry-locked create fields (TKT-3G93B8 / BUG-X1C7S): the server pins a
+    // state-machine field to its initial value and marks it writable=false. Adopt
+    // that value into formData so the locked control DISPLAYS the initial state
+    // (not whatever the user may have typed before it locked). The commit filter
+    // already omits writable=false keys, so the server applies the initial
+    // regardless — this only keeps the visible value honest.
+    for (const [name, verdict] of Object.entries(candidate._fields ?? {})) {
+      if (verdict.writable === false && candidate.properties && name in candidate.properties) {
+        formData.value[name] = candidate.properties[name]
+      }
+    }
     // The dry-run strips hidden fields from `properties`; the remaining
     // keys are exactly the visible-by-default props the field filter
     // needs to render (since they won't appear in the sparse `_fields`).
@@ -1392,6 +1420,7 @@ onBeforeRouteLeave(async () => {
               :get-property-def="getPropertyDef"
               :is-field-readonly="isFieldReadonly"
               :option-verdicts-for="optionVerdictsFor"
+              :transitions-for="transitionsFor"
               @update-field="updateField"
               @attachment-changed="onAttachmentChanged"
               @update-relation="updateRelation"

--- a/frontend/src/components/forms/FieldRenderer.test.ts
+++ b/frontend/src/components/forms/FieldRenderer.test.ts
@@ -7,7 +7,7 @@
 import { describe, it, expect } from 'vitest'
 import { mount } from '@vue/test-utils'
 import FieldRenderer from './FieldRenderer.vue'
-import type { FormFieldOrRelation, PropertyDef } from '@/types'
+import type { FormFieldOrRelation, PropertyDef, TransitionOption } from '@/types'
 
 function renderField(opts: {
   field: FormFieldOrRelation
@@ -15,6 +15,7 @@ function renderField(opts: {
   value: unknown
   readonly?: boolean
   optionVerdicts?: Record<string, boolean>
+  transitionOptions?: TransitionOption[]
 }) {
   return mount(FieldRenderer, {
     props: {
@@ -23,6 +24,7 @@ function renderField(opts: {
       value: opts.value,
       readonly: opts.readonly,
       optionVerdicts: opts.optionVerdicts,
+      transitionOptions: opts.transitionOptions,
     },
     attachTo: document.body,
   })
@@ -142,6 +144,47 @@ describe('FieldRenderer affordance plumbing', () => {
     const label = wrapper.find('.checkbox-wrapper label')
     expect(input.attributes('id')).toBe('field-automated')
     expect(label.attributes('for')).toBe('field-automated')
+    wrapper.unmount()
+  })
+
+  // TKT-3G93B8: a state-machine field (transitionOptions present) routes to
+  // the StatusControl instead of the plain enum select.
+  it('routes a machine field to StatusControl when _transitions present', () => {
+    const wrapper = renderField({
+      field: { property: 'status', label: 'Status' },
+      propertyDef: { type: 'enum', values: ['todo', 'doing', 'done'] },
+      value: 'todo',
+      transitionOptions: [{ to: 'doing', label: 'Start progress', allowed: true }],
+    })
+    // StatusControl renders its trigger; no plain enum <select>.
+    expect(wrapper.find('.status-control').exists()).toBe(true)
+    expect(wrapper.find('select').exists()).toBe(false)
+    wrapper.unmount()
+  })
+
+  it('falls back to the enum select for a non-machine field (no _transitions)', () => {
+    const wrapper = renderField({
+      field: { property: 'kind', label: 'Kind' },
+      propertyDef: { type: 'enum', values: ['enhancement', 'refactor'] },
+      value: 'enhancement',
+      // transitionOptions undefined → ordinary widget.
+    })
+    expect(wrapper.find('select').exists()).toBe(true)
+    expect(wrapper.find('.status-control').exists()).toBe(false)
+    wrapper.unmount()
+  })
+
+  it('routes a terminal machine field (empty _transitions) to StatusControl', () => {
+    // An empty array is still a machine field — it must NOT fall back to the
+    // full enum select (which would misleadingly offer every value).
+    const wrapper = renderField({
+      field: { property: 'status', label: 'Status' },
+      propertyDef: { type: 'enum', values: ['todo', 'done'] },
+      value: 'done',
+      transitionOptions: [],
+    })
+    expect(wrapper.find('.status-control').exists()).toBe(true)
+    expect(wrapper.find('select').exists()).toBe(false)
     wrapper.unmount()
   })
 

--- a/frontend/src/components/forms/FieldRenderer.vue
+++ b/frontend/src/components/forms/FieldRenderer.vue
@@ -1,8 +1,9 @@
 <script setup lang="ts">
 import { computed } from 'vue'
-import type { FormFieldOrRelation, PropertyDef, AttachmentInfo } from '@/types'
+import type { FormFieldOrRelation, PropertyDef, AttachmentInfo, TransitionOption } from '@/types'
 import { defaultRegistry, defaultWidgetFor } from '@/widgets/registry'
 import FieldShell from './FieldShell.vue'
+import StatusControl from './StatusControl.vue'
 
 const props = defineProps<{
   field: FormFieldOrRelation
@@ -15,6 +16,14 @@ const props = defineProps<{
   // map denies it or the existing transition rules deny it — the two
   // signals are independent and either one is sufficient.
   optionVerdicts?: Record<string, boolean>
+  // Machine-aware status control (TKT-3G93B8): the server-resolved outgoing
+  // transitions for a state-machine field. When present (and non-empty), the
+  // field renders as a StatusControl showing only performable moves instead of
+  // the ordinary enum widget. Undefined for a non-machine field → default
+  // widget. An empty array means a machine field with no performable move (e.g.
+  // a terminal state) — still routed to StatusControl so it shows the current
+  // state without a picker, rather than a misleading full enum select.
+  transitionOptions?: TransitionOption[]
   // File-widget context: the owning entity identity + current attachment
   // LIST + the property's `max`, forwarded so the file widget can
   // upload/preview/remove. Only the file-property edit path supplies these.
@@ -46,6 +55,13 @@ const widgetComponent = computed(() =>
 )
 
 const isCheckbox = computed(() => resolvedWidgetName.value === 'checkbox')
+
+// A field is machine-aware when the server sent a `_transitions` entry for it
+// (even an empty array — that's a terminal-state machine, still not a plain
+// enum). Undefined means "not a state machine" and the field falls back to its
+// ordinary widget. The current value is coerced to a string for the badge.
+const isMachineField = computed(() => props.transitionOptions !== undefined)
+const currentValue = computed(() => (props.value == null ? '' : String(props.value)))
 </script>
 
 <template>
@@ -57,8 +73,18 @@ const isCheckbox = computed(() => resolvedWidgetName.value === 'checkbox')
     :error="error"
     :label-position="isCheckbox ? 'after' : 'before'"
   >
+    <StatusControl
+      v-if="isMachineField"
+      :model-value="currentValue"
+      :property="field.property || ''"
+      :entity-type="entityType"
+      :transitions="transitionOptions || []"
+      :disabled="readonly"
+      @update:model-value="emit('update', $event)"
+    />
     <component
       :is="widgetComponent"
+      v-else
       :id="fieldId"
       :model-value="value"
       :mode="'edit'"

--- a/frontend/src/components/forms/FormFieldList.vue
+++ b/frontend/src/components/forms/FormFieldList.vue
@@ -8,7 +8,13 @@
  * The parent owns all state and validation; this component is presentational
  * and re-emits every edit so the parent's handlers stay authoritative.
  */
-import type { FormFieldOrRelation, PropertyDef, RelationAffordance, AttachmentInfo } from '@/types'
+import type {
+  FormFieldOrRelation,
+  PropertyDef,
+  RelationAffordance,
+  AttachmentInfo,
+  TransitionOption,
+} from '@/types'
 import FieldRenderer from './FieldRenderer.vue'
 import RelationCards from './RelationCards.vue'
 import RelationPicker from './RelationPicker.vue'
@@ -28,6 +34,9 @@ defineProps<{
   getPropertyDef: (name: string) => PropertyDef | undefined
   isFieldReadonly: (field: FormFieldOrRelation) => boolean
   optionVerdictsFor: (field: FormFieldOrRelation) => Record<string, boolean> | undefined
+  // Resolved state-machine transitions per field (TKT-3G93B8); undefined for a
+  // non-machine field. Present → FieldRenderer renders the StatusControl.
+  transitionsFor: (field: FormFieldOrRelation) => TransitionOption[] | undefined
 }>()
 
 const emit = defineEmits<{
@@ -53,6 +62,7 @@ const emit = defineEmits<{
       :error="errors[field.property]"
       :readonly="isFieldReadonly(field)"
       :option-verdicts="optionVerdictsFor(field)"
+      :transition-options="transitionsFor(field)"
       :entity-type="entityType"
       :entity-id="entityId"
       :attachments="attachments[field.property]"

--- a/frontend/src/components/forms/SectionEditForm.vue
+++ b/frontend/src/components/forms/SectionEditForm.vue
@@ -14,13 +14,14 @@
 
 import { computed, onBeforeUnmount, reactive, ref, watch, type Ref } from 'vue'
 import type { Component } from 'vue'
-import type { FieldAffordance, PropertyDef, Entity, AttachmentInfo } from '@/types'
+import type { FieldAffordance, PropertyDef, Entity, AttachmentInfo, TransitionOption } from '@/types'
 import type { WidgetRoutingHint } from '@/widgets/types'
 import { defaultRegistry } from '@/widgets/registry'
 import { useAutoSave, type AutoSaveErrorInfo } from '@/composables/useAutoSave'
 import { isFieldWritable, optionVerdictsFor } from '@/utils/affordances'
 import { isClearedForType } from '@/utils/formValue'
 import FieldShell from './FieldShell.vue'
+import StatusControl from './StatusControl.vue'
 import AutoSaveIndicator from './AutoSaveIndicator.vue'
 
 // Discriminated union: each field resolves its widget via either the
@@ -30,6 +31,11 @@ export type SectionEditField = {
   property: string
   label: string
   verdict?: FieldAffordance
+  // Machine-aware status control (TKT-3G93B8): when present (even empty), the
+  // field is a state machine and renders as a StatusControl instead of its
+  // resolved widget. Undefined = not a machine field (or a surface without
+  // `_transitions`, e.g. cards/list rows) → the ordinary widget.
+  transitions?: TransitionOption[]
 } & (
   | { kind: 'schema'; propertyDef: PropertyDef }
   | { kind: 'hint'; routingHint: WidgetRoutingHint }
@@ -224,8 +230,17 @@ defineExpose({
       >
         <dt>{{ row.field.label }}</dt>
         <dd>
+          <StatusControl
+            v-if="row.field.transitions !== undefined"
+            :model-value="formData[row.field.property] == null ? '' : String(formData[row.field.property])"
+            :property="row.field.property"
+            :entity-type="entityType"
+            :transitions="row.field.transitions"
+            :disabled="!row.writable"
+            @update:model-value="(v: string) => onFieldUpdate(row.field, v)"
+          />
           <FieldShell
-            v-if="row.writable"
+            v-else-if="row.writable"
             :field-id="`section-edit-${row.field.property}`"
             :error="autoSave.fieldErrors.value[row.field.property]"
           >

--- a/frontend/src/components/forms/StatusControl.test.ts
+++ b/frontend/src/components/forms/StatusControl.test.ts
@@ -1,0 +1,111 @@
+// TKT-3G93B8: StatusControl renders ONLY the server-resolved allowed moves,
+// labels them as transitions (action), and commits the target on select.
+
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import StatusControl from './StatusControl.vue'
+import type { TransitionOption } from '@/types'
+
+function renderControl(opts: {
+  modelValue: string
+  transitions: TransitionOption[]
+  disabled?: boolean
+}) {
+  return mount(StatusControl, {
+    props: {
+      modelValue: opts.modelValue,
+      property: 'status',
+      entityType: 'ticket',
+      transitions: opts.transitions,
+      disabled: opts.disabled,
+    },
+    attachTo: document.body,
+  })
+}
+
+describe('StatusControl', () => {
+  it('shows only allowed moves, labeled by their action label', async () => {
+    const wrapper = renderControl({
+      modelValue: 'todo',
+      transitions: [
+        { to: 'doing', label: 'Start progress', allowed: true },
+        { to: 'done', label: 'Complete', guard: 'close', allowed: false, reason: 'guard' },
+      ],
+    })
+    // Open the menu.
+    await wrapper.find('.status-trigger').trigger('click')
+
+    const moves = wrapper.findAll('.status-move')
+    expect(moves).toHaveLength(1) // only the allowed one
+    expect(moves[0].text()).toContain('Start progress')
+    // The non-performable 'Complete' move is not rendered at all.
+    expect(wrapper.text()).not.toContain('Complete')
+    wrapper.unmount()
+  })
+
+  it('falls back to the raw target value when no action label is set', async () => {
+    const wrapper = renderControl({
+      modelValue: 'todo',
+      transitions: [{ to: 'doing', allowed: true }],
+    })
+    await wrapper.find('.status-trigger').trigger('click')
+    // No label and no schema-store enum label configured → raw value.
+    expect(wrapper.find('.status-move-label').text()).toBe('doing')
+    wrapper.unmount()
+  })
+
+  it('emits update:modelValue with the target when a move is selected', async () => {
+    const wrapper = renderControl({
+      modelValue: 'todo',
+      transitions: [{ to: 'doing', label: 'Start progress', allowed: true }],
+    })
+    await wrapper.find('.status-trigger').trigger('click')
+    await wrapper.find('.status-move').trigger('click')
+
+    const emitted = wrapper.emitted('update:modelValue')
+    expect(emitted).toBeTruthy()
+    expect(emitted![0]).toEqual(['doing'])
+    wrapper.unmount()
+  })
+
+  it('renders no picker in a terminal state (no allowed moves)', () => {
+    const wrapper = renderControl({
+      modelValue: 'done',
+      transitions: [], // terminal
+    })
+    // The trigger renders (showing the current state) but is inert.
+    const trigger = wrapper.find('.status-trigger')
+    expect(trigger.exists()).toBe(true)
+    expect(trigger.attributes('disabled')).toBeDefined()
+    // No caret, no menu.
+    expect(wrapper.find('.status-caret').exists()).toBe(false)
+    expect(wrapper.find('.status-menu').exists()).toBe(false)
+    wrapper.unmount()
+  })
+
+  it('excludes a self-loop move even if the server sent one', async () => {
+    const wrapper = renderControl({
+      modelValue: 'doing',
+      transitions: [
+        { to: 'doing', label: 'Re-open', allowed: true }, // self-loop
+        { to: 'done', label: 'Complete', allowed: true },
+      ],
+    })
+    await wrapper.find('.status-trigger').trigger('click')
+    const moves = wrapper.findAll('.status-move')
+    expect(moves).toHaveLength(1)
+    expect(moves[0].text()).toContain('Complete')
+    wrapper.unmount()
+  })
+
+  it('does not open when disabled', async () => {
+    const wrapper = renderControl({
+      modelValue: 'todo',
+      transitions: [{ to: 'doing', label: 'Start progress', allowed: true }],
+      disabled: true,
+    })
+    await wrapper.find('.status-trigger').trigger('click')
+    expect(wrapper.find('.status-menu').exists()).toBe(false)
+    wrapper.unmount()
+  })
+})

--- a/frontend/src/components/forms/StatusControl.vue
+++ b/frontend/src/components/forms/StatusControl.vue
@@ -101,7 +101,6 @@ onBeforeUnmount(() => document.removeEventListener('click', handleClickOutside))
     <ul v-if="open && hasMoves" class="status-menu" role="menu">
       <li v-for="move in allowedMoves" :key="move.to" role="none">
         <button type="button" class="status-move" role="menuitem" @click.stop="selectMove(move)">
-          <span class="status-move-arrow" aria-hidden="true">&rarr;</span>
           <span class="status-move-label">{{ moveLabel(move) }}</span>
         </button>
       </li>
@@ -122,7 +121,10 @@ onBeforeUnmount(() => document.removeEventListener('click', handleClickOutside))
   display: inline-flex;
   align-items: center;
   gap: 4px;
-  padding: 2px 4px;
+  /* Match the vertical footprint of sibling inputs/selects so the control
+     aligns in a form grid instead of floating small next to them. */
+  min-height: 40px;
+  padding: 2px 6px;
   border: none;
   border-radius: 6px;
   background: transparent;
@@ -163,7 +165,6 @@ onBeforeUnmount(() => document.removeEventListener('click', handleClickOutside))
 .status-move {
   display: flex;
   align-items: center;
-  gap: 8px;
   width: 100%;
   padding: 8px 10px;
   border: none;
@@ -177,9 +178,5 @@ onBeforeUnmount(() => document.removeEventListener('click', handleClickOutside))
 
 .status-move:hover {
   background: var(--hover-bg);
-}
-
-.status-move-arrow {
-  color: var(--muted-text);
 }
 </style>

--- a/frontend/src/components/forms/StatusControl.vue
+++ b/frontend/src/components/forms/StatusControl.vue
@@ -94,8 +94,9 @@ onBeforeUnmount(() => document.removeEventListener('click', handleClickOutside))
       :aria-expanded="open"
       @click.stop="toggle"
     >
-      <Badge :value="modelValue" :property="property" />
-      <span v-if="hasMoves" class="status-caret" aria-hidden="true">&#9662;</span>
+      <Badge :value="modelValue" :property="property">
+        <span v-if="hasMoves" class="status-caret" aria-hidden="true">&#9662;</span>
+      </Badge>
     </button>
 
     <ul v-if="open && hasMoves" class="status-menu" role="menu">
@@ -139,7 +140,8 @@ onBeforeUnmount(() => document.removeEventListener('click', handleClickOutside))
    its type + padding up (scoped, so list/table badges elsewhere are untouched). */
 .status-trigger :deep(.badge) {
   font-size: 14px;
-  padding: 6px 12px;
+  /* Extra right padding so the in-badge caret has room. */
+  padding: 6px 10px 6px 12px;
 }
 
 .status-trigger:hover:not(:disabled) {
@@ -152,9 +154,14 @@ onBeforeUnmount(() => document.removeEventListener('click', handleClickOutside))
   background: transparent;
 }
 
+/* Caret lives INSIDE the badge (Badge's trailing slot), so it inherits the
+   badge's text colour and reads as part of the colored control. Bumped up from
+   the old 10px so it's clearly a dropdown affordance. */
 .status-caret {
-  font-size: 10px;
-  color: var(--muted-text);
+  margin-left: 6px;
+  font-size: 13px;
+  line-height: 1;
+  opacity: 0.75;
 }
 
 .status-menu {

--- a/frontend/src/components/forms/StatusControl.vue
+++ b/frontend/src/components/forms/StatusControl.vue
@@ -1,0 +1,184 @@
+<script setup lang="ts">
+/**
+ * StatusControl — a machine-aware status picker (TKT-3G93B8).
+ *
+ * Unlike a plain enum <select> (which lists every value), this control shows
+ * ONLY the transitions the server resolved as performable for this principal on
+ * this entity, sourced from the entity's `_transitions` wire map. Each option is
+ * named by its MOVE (the action label, e.g. "Start progress"), falling back to
+ * the target value's display label and then the raw value. Selecting a move
+ * commits it as an atomic single-field change (the parent routes `update`
+ * through the same field-save path any widget uses).
+ *
+ * No client-side ACL (dataentry/CLAUDE.md): the options are exactly what the
+ * server said are allowed; this component never evaluates guards or predicates.
+ * The write is re-enforced server-side (attempt-and-recover), so a stale verdict
+ * simply surfaces the existing structured-error toast.
+ */
+import { computed, ref, onMounted, onBeforeUnmount } from 'vue'
+import type { TransitionOption } from '@/types'
+import { useSchemaStore } from '@/stores/schema'
+import Badge from '@/components/common/Badge.vue'
+
+const props = defineProps<{
+  // Current value of the state-machine field (the entity's present state).
+  modelValue: string
+  // The property's wire binding, used for label + badge-style lookup.
+  property: string
+  entityType?: string
+  // The resolved outgoing transitions for this field (from entity._transitions).
+  // The server sends every declared out-edge with an `allowed` flag; this
+  // control renders only the allowed ones as selectable moves.
+  transitions: TransitionOption[]
+  disabled?: boolean
+}>()
+
+const emit = defineEmits<{
+  'update:modelValue': [value: string]
+}>()
+
+const schemaStore = useSchemaStore()
+
+// Show only performable moves — the "only allowed" contract. A self-loop (to ==
+// current) is never offered; the server already excludes it, but guard here too.
+const allowedMoves = computed(() =>
+  props.transitions
+    .filter((t) => t.allowed && t.to !== props.modelValue)
+    .slice()
+    .sort((a, b) => moveLabel(a).localeCompare(moveLabel(b)))
+)
+
+const hasMoves = computed(() => allowedMoves.value.length > 0)
+
+// A move's display text: its action label, else the target value's state label,
+// else the raw target value. Keeps transitions reading as verbs, not states.
+function moveLabel(t: TransitionOption): string {
+  if (t.label && t.label.trim() !== '') return t.label
+  return schemaStore.getEnumLabel(t.to, props.property, props.entityType) ?? t.to
+}
+
+const open = ref(false)
+const containerRef = ref<HTMLElement | null>(null)
+
+function toggle() {
+  if (props.disabled || !hasMoves.value) return
+  open.value = !open.value
+}
+
+function selectMove(t: TransitionOption) {
+  open.value = false
+  if (t.to === props.modelValue) return
+  emit('update:modelValue', t.to)
+}
+
+function handleClickOutside(e: MouseEvent) {
+  if (!containerRef.value) return
+  if (!containerRef.value.contains(e.target as Node)) open.value = false
+}
+
+onMounted(() => document.addEventListener('click', handleClickOutside))
+onBeforeUnmount(() => document.removeEventListener('click', handleClickOutside))
+</script>
+
+<template>
+  <div ref="containerRef" class="status-control">
+    <button
+      type="button"
+      class="status-trigger"
+      :class="{ 'is-static': disabled || !hasMoves }"
+      :disabled="disabled || !hasMoves"
+      :aria-haspopup="hasMoves ? 'menu' : undefined"
+      :aria-expanded="open"
+      @click.stop="toggle"
+    >
+      <Badge :value="modelValue" :property="property" />
+      <span v-if="hasMoves" class="status-caret" aria-hidden="true">&#9662;</span>
+    </button>
+
+    <ul v-if="open && hasMoves" class="status-menu" role="menu">
+      <li v-for="move in allowedMoves" :key="move.to" role="none">
+        <button type="button" class="status-move" role="menuitem" @click.stop="selectMove(move)">
+          <span class="status-move-arrow" aria-hidden="true">&rarr;</span>
+          <span class="status-move-label">{{ moveLabel(move) }}</span>
+        </button>
+      </li>
+    </ul>
+  </div>
+</template>
+
+<style scoped>
+.status-control {
+  position: relative;
+  display: inline-block;
+}
+
+.status-trigger {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 8px;
+  border: 1px solid var(--border-color);
+  border-radius: 6px;
+  background: var(--input-bg);
+  color: var(--text-color);
+  cursor: pointer;
+  font-size: 14px;
+  transition: all 0.15s;
+}
+
+.status-trigger:hover:not(:disabled) {
+  border-color: var(--accent-color, #6366f1);
+}
+
+.status-trigger.is-static {
+  cursor: default;
+  border-color: transparent;
+  background: transparent;
+  padding-left: 0;
+}
+
+.status-trigger:disabled {
+  cursor: not-allowed;
+}
+
+.status-caret {
+  font-size: 10px;
+  color: var(--muted-text);
+}
+
+.status-menu {
+  position: absolute;
+  z-index: 20;
+  margin: 4px 0 0;
+  padding: 4px;
+  list-style: none;
+  min-width: 180px;
+  background: var(--input-bg);
+  border: 1px solid var(--border-color);
+  border-radius: 6px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.12);
+}
+
+.status-move {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  padding: 8px 10px;
+  border: none;
+  border-radius: 4px;
+  background: transparent;
+  color: var(--text-color);
+  cursor: pointer;
+  font-size: 14px;
+  text-align: left;
+}
+
+.status-move:hover {
+  background: var(--hover-bg);
+}
+
+.status-move-arrow {
+  color: var(--muted-text);
+}
+</style>

--- a/frontend/src/components/forms/StatusControl.vue
+++ b/frontend/src/components/forms/StatusControl.vue
@@ -115,33 +115,31 @@ onBeforeUnmount(() => document.removeEventListener('click', handleClickOutside))
   display: inline-block;
 }
 
+/* The badge carries its own colour/shape, so the trigger stays chromeless —
+   no border or fill — just the badge plus a caret. A rounded-hover tint is the
+   only affordance that it's interactive. */
 .status-trigger {
   display: inline-flex;
   align-items: center;
-  gap: 6px;
-  padding: 4px 8px;
-  border: 1px solid var(--border-color);
+  gap: 4px;
+  padding: 2px 4px;
+  border: none;
   border-radius: 6px;
-  background: var(--input-bg);
+  background: transparent;
   color: var(--text-color);
   cursor: pointer;
   font-size: 14px;
-  transition: all 0.15s;
+  transition: background 0.15s;
 }
 
 .status-trigger:hover:not(:disabled) {
-  border-color: var(--accent-color, #6366f1);
+  background: var(--hover-bg);
 }
 
+.status-trigger:disabled,
 .status-trigger.is-static {
   cursor: default;
-  border-color: transparent;
   background: transparent;
-  padding-left: 0;
-}
-
-.status-trigger:disabled {
-  cursor: not-allowed;
 }
 
 .status-caret {

--- a/frontend/src/components/forms/StatusControl.vue
+++ b/frontend/src/components/forms/StatusControl.vue
@@ -54,7 +54,10 @@ const hasMoves = computed(() => allowedMoves.value.length > 0)
 // else the raw target value. Keeps transitions reading as verbs, not states.
 function moveLabel(t: TransitionOption): string {
   if (t.label && t.label.trim() !== '') return t.label
-  return schemaStore.getEnumLabel(t.to, props.property, props.entityType) ?? t.to
+  // `||` not `??`: an explicit empty-string enum label must fall through to the
+  // raw value, not render a blank move (RR-NN5414).
+  const stateLabel = schemaStore.getEnumLabel(t.to, props.property, props.entityType)
+  return stateLabel && stateLabel.trim() !== '' ? stateLabel : t.to
 }
 
 const open = ref(false)

--- a/frontend/src/components/forms/StatusControl.vue
+++ b/frontend/src/components/forms/StatusControl.vue
@@ -134,6 +134,14 @@ onBeforeUnmount(() => document.removeEventListener('click', handleClickOutside))
   transition: background 0.15s;
 }
 
+/* The base Badge is a small 12px table pill; as the primary edit control it
+   needs more presence so it doesn't read as tiny next to bordered inputs. Scale
+   its type + padding up (scoped, so list/table badges elsewhere are untouched). */
+.status-trigger :deep(.badge) {
+  font-size: 14px;
+  padding: 6px 12px;
+}
+
 .status-trigger:hover:not(:disabled) {
   background: var(--hover-bg);
 }

--- a/frontend/src/components/forms/stagedEntity.test.ts
+++ b/frontend/src/components/forms/stagedEntity.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { STAGED_ID, isStaged } from './stagedEntity'
+import { STAGED_ID, isStaged, adoptLockedFieldValues } from './stagedEntity'
 
 describe('stagedEntity sentinel (TKT-3I5U)', () => {
   it('STAGED_ID is the documented form-only sentinel', () => {
@@ -16,5 +16,39 @@ describe('stagedEntity sentinel (TKT-3I5U)', () => {
   it('the sentinel cannot collide with a prefix-based real ID', () => {
     // Real IDs are <PREFIX>-<n>; the sentinel has no hyphen-prefix shape.
     expect(STAGED_ID).not.toMatch(/^[A-Z]+-/)
+  })
+})
+
+describe('adoptLockedFieldValues (TKT-3G93B8 / BUG-X1C7S)', () => {
+  it('adopts the server value for a read-only (machine-locked) field', () => {
+    const formData: Record<string, unknown> = { status: 'doing', title: 'user typed' }
+    adoptLockedFieldValues(
+      { status: { writable: false } },
+      { status: 'todo', title: 'user typed' },
+      formData
+    )
+    // The locked field takes the server's initial; the editable field is untouched.
+    expect(formData.status).toBe('todo')
+    expect(formData.title).toBe('user typed')
+  })
+
+  it('leaves writable (editable) fields untouched even if echoed', () => {
+    const formData: Record<string, unknown> = { status: 'mine' }
+    adoptLockedFieldValues({ status: { writable: true } }, { status: 'server' }, formData)
+    expect(formData.status).toBe('mine')
+  })
+
+  it('does not adopt a read-only field the server did not send', () => {
+    const formData: Record<string, unknown> = { status: 'mine' }
+    // writable=false but absent from properties (e.g. hidden + stripped): skip.
+    adoptLockedFieldValues({ status: { writable: false } }, {}, formData)
+    expect(formData.status).toBe('mine')
+  })
+
+  it('is a no-op when fields or properties are absent', () => {
+    const formData: Record<string, unknown> = { status: 'mine' }
+    adoptLockedFieldValues(undefined, { status: 'x' }, formData)
+    adoptLockedFieldValues({ status: { writable: false } }, undefined, formData)
+    expect(formData.status).toBe('mine')
   })
 })

--- a/frontend/src/components/forms/stagedEntity.ts
+++ b/frontend/src/components/forms/stagedEntity.ts
@@ -1,3 +1,5 @@
+import type { FieldAffordance } from '@/types'
+
 // Staged-entity sentinel for the create form (TKT-3I5U).
 //
 // The create form models "create" as editing a staged (uncommitted)
@@ -11,4 +13,33 @@ export const STAGED_ID = '++new++'
 
 export function isStaged(id: string | undefined): boolean {
   return id === STAGED_ID
+}
+
+// adoptLockedFieldValues copies the server's authoritative value into `formData`
+// for every field the create dry-run reported as read-only (`writable === false`),
+// mutating formData in place (TKT-3G93B8 / BUG-X1C7S).
+//
+// The motivating case is a state-machine field the server locks to its initial
+// value: the control must DISPLAY that initial, not whatever the user typed
+// before it locked. The rule is deliberately scoped to *read-only* fields, which
+// covers both machine-locked and any policy-read-only field — a read-only field's
+// value is server-owned, so adopting the server's echo is correct in general and
+// never clobbers a user-editable field. On create the echo usually equals the
+// submitted value (a harmless self-copy); it differs only when the server
+// overrides (the lock case). The commit filter still omits writable=false keys,
+// so this only keeps the *displayed* value honest.
+//
+// A field is adopted only when the server actually sent a value for it (present
+// in `properties`) — an absent key is left untouched.
+export function adoptLockedFieldValues(
+  fields: Record<string, FieldAffordance> | undefined,
+  properties: Record<string, unknown> | undefined,
+  formData: Record<string, unknown>
+): void {
+  if (!fields || !properties) return
+  for (const [name, verdict] of Object.entries(fields)) {
+    if (verdict.writable === false && name in properties) {
+      formData[name] = properties[name]
+    }
+  }
 }

--- a/frontend/src/types/entity.ts
+++ b/frontend/src/types/entity.ts
@@ -42,6 +42,16 @@ export interface Entity {
   // on every per-entity response (GET, PATCH, POST, clone), absent on list
   // rows. The file widget reads this to render download links / previews.
   _attachments?: Record<string, AttachmentInfo[]>
+  // Per-state-machine-field transition verdicts on per-entity GET
+  // responses (TKT-3G93B8). Keyed by property name; the value lists the
+  // outgoing transitions resolved for the requesting principal on this
+  // entity. Only state-machine-typed fields appear — a plain enum field
+  // has no key, and the SPA falls back to the ordinary enum control.
+  // Absent entirely when the server wires no state machines (older server
+  // or no policy). A UI hint, never authorization — the write path
+  // re-enforces every transition (attempt-and-recover). See
+  // docs/data-entry/api-reference.md.
+  _transitions?: Record<string, TransitionOption[]>
   inaccessible?: InaccessibleField[]
   // Soft-validation findings on mutation responses (DEC-HWZHA).
   // Present on PATCH/POST results; absent on GETs.
@@ -65,6 +75,23 @@ export interface RelationAffordance {
   creatable?: boolean
   removable?: boolean
   fields?: Record<string, FieldAffordance>
+}
+
+// TransitionOption is one resolved outgoing move of a state-machine field
+// (TKT-3G93B8), the wire projection of the backend's TransitionVerdict.
+// `to` is the target value; `label` is optional display text for the MOVE
+// (the action, e.g. "Start progress") — when absent the UI falls back to the
+// target value's display label. `guard` names the permission the move
+// requires (empty when unguarded). `allowed` reports whether the requesting
+// principal may perform it now. `reason` names the blocking gate when not
+// allowed (`guard` | `precondition`); empty when allowed. The status control
+// shows only allowed moves, so `reason` is advisory (tooltip), not a gate.
+export interface TransitionOption {
+  to: string
+  label?: string
+  guard?: string
+  allowed: boolean
+  reason?: string
 }
 
 // AttachmentInfo describes one file attached to a `file`-type property,

--- a/internal/affordances/resolver.go
+++ b/internal/affordances/resolver.go
@@ -169,6 +169,24 @@ func (r *PolicyResolver) WithMachines(m *statemachine.Set) *PolicyResolver {
 	return r
 }
 
+// EntryValues returns, for each state-machine-typed property of entityType, the
+// value a create must enter at (the machine's Initial, else Default — BUG-X1C7S)
+// (TKT-3G93B8). A create form uses it to lock a machine field to its initial
+// value: the field is not freely editable on create. Returns an empty map when
+// no machines are wired or entityType has no machine-typed property.
+func (r *PolicyResolver) EntryValues(entityType string) map[string]string {
+	out := map[string]string{}
+	if r.machines == nil || r.machines.Empty() {
+		return out
+	}
+	for _, prop := range r.machines.MachineProps(entityType) {
+		if entry := r.machines.EntryValue(entityType, prop); entry != "" {
+			out[prop] = entry
+		}
+	}
+	return out
+}
+
 // env returns (compiling on first use) the predicate env for an entity
 // type. Envs are cached so every grant of a type shares one.
 func (r *PolicyResolver) env(entityType string) (*predicate.Env, error) {

--- a/internal/affordances/resolver.go
+++ b/internal/affordances/resolver.go
@@ -473,9 +473,20 @@ func (r *PolicyResolver) TransitionVerdicts(
 	}
 	guard := r.transitionGuard(ctx)
 	for _, prop := range r.machines.MachineProps(e.Type) {
-		if vs := r.machines.Performable(ctx, e, prop, guard, r.lookup); len(vs) > 0 {
-			out[prop] = vs
+		// Emit an entry for EVERY machine-typed property, even when there are no
+		// performable out-edges (a terminal state, or all edges gated). The
+		// presence of the key is how a consumer distinguishes "this field is a
+		// state machine (render the status control, possibly empty)" from "not a
+		// machine field (render the ordinary enum widget)". Dropping terminal
+		// fields would make a done ticket's status fall back to a full enum
+		// select that offers illegal moves — see TKT-3G93B8. A nil slice from
+		// Performable normalizes to an empty (non-nil) slice so it serializes as
+		// [] rather than null.
+		vs := r.machines.Performable(ctx, e, prop, guard, r.lookup)
+		if vs == nil {
+			vs = []statemachine.TransitionVerdict{}
 		}
+		out[prop] = vs
 	}
 	return out
 }

--- a/internal/affordances/transitions_test.go
+++ b/internal/affordances/transitions_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/Sourcehaven-BV/rela/internal/affordances"
+	"github.com/Sourcehaven-BV/rela/internal/entity"
 	"github.com/Sourcehaven-BV/rela/internal/metamodel"
 	"github.com/Sourcehaven-BV/rela/internal/statemachine"
 )
@@ -130,11 +131,31 @@ func TestTransitionVerdicts_NoMachinesWired(t *testing.T) {
 	}
 }
 
-func TestTransitionVerdicts_NonMachineType(t *testing.T) {
+func TestTransitionVerdicts_TerminalStateKeyPresentEmpty(t *testing.T) {
 	r := newTransitionResolver(t, "review-it")
-	// feature has no status machine (not even in transitionMeta) → empty.
-	if got := r.TransitionVerdicts(ctxAs("alice"), ticket("T-1", map[string]any{"status": "done"})); len(got) != 0 {
-		// "done" is terminal → no out-edges → empty map.
-		t.Errorf("terminal state should give empty map, got %+v", got)
+	// "done" is terminal (no out-edges), but status IS a machine field: the key
+	// must be PRESENT with an empty slice so a consumer still renders the status
+	// control (not a full enum select that would offer illegal moves) — TKT-3G93B8.
+	got := r.TransitionVerdicts(ctxAs("alice"), ticket("T-1", map[string]any{"status": "done"}))
+	vs, ok := got["status"]
+	if !ok {
+		t.Fatalf("terminal machine field must keep its key, got %+v", got)
+	}
+	if len(vs) != 0 {
+		t.Errorf("terminal state should have no performable moves, got %+v", vs)
+	}
+	if vs == nil {
+		t.Errorf("empty verdict slice must be non-nil so it serializes as [] not null")
+	}
+}
+
+func TestTransitionVerdicts_NonMachineTypeAbsent(t *testing.T) {
+	r := newTransitionResolver(t, "review-it")
+	// An entity type with NO machine-typed property (not in transitionMeta) gets
+	// no keys at all — this is the signal the SPA uses to fall back to the
+	// ordinary enum widget.
+	got := r.TransitionVerdicts(ctxAs("alice"), entity.New("F-1", "feature"))
+	if len(got) != 0 {
+		t.Errorf("non-machine entity type should give empty map, got %+v", got)
 	}
 }

--- a/internal/apiwire/v1/responses.go
+++ b/internal/apiwire/v1/responses.go
@@ -46,6 +46,18 @@ type Entity struct {
 	// non-per-entity shapes. The SPA's file widget reads this to render the
 	// download links / previews instead of the raw stored path string(s).
 	Attachments *map[string][]Attachment `json:"_attachments,omitempty"`
+	// Transitions maps a state-machine-typed property name to the LIST of its
+	// outgoing transitions resolved for the requesting principal on this entity
+	// (TKT-3G93B8): each carries the target value, an optional action label,
+	// the guard permission (if any), whether the principal may perform it right
+	// now, and — when not — which gate blocked it. Only properties whose type is
+	// a state machine appear; a plain enum field has no entry, and the SPA falls
+	// back to the ordinary enum control. Same pointer / closed-world semantics as
+	// FieldAffordances: present (possibly empty) on every per-entity response
+	// (GET / PATCH / POST create / clone) when the resolver can answer
+	// transitions, nil on list rows and when no state machines are wired. It is a
+	// UI hint, never authorization — the write path re-enforces every transition.
+	Transitions *map[string][]Transition `json:"_transitions,omitempty"`
 	// Warnings lists soft-condition findings surfaced by the write
 	// path. Populated only by mutation responses (PATCH); read paths
 	// leave it nil. Each warning has a stable `code`, an RFC 6901
@@ -71,6 +83,26 @@ type RelationAffordance struct {
 	Creatable *bool                      `json:"creatable,omitempty"`
 	Removable *bool                      `json:"removable,omitempty"`
 	Fields    map[string]FieldAffordance `json:"fields,omitempty"`
+}
+
+// Transition is one resolved outgoing move of a state-machine-typed property
+// on a per-entity response (TKT-3G93B8). It is the wire projection of
+// statemachine.TransitionVerdict.
+//
+// To is the target value. Label is optional display text for the MOVE (the
+// action, e.g. "Start progress"); when empty the SPA falls back to the target
+// value's display label. Guard is the ACL permission the move requires (empty
+// when unguarded). Allowed reports whether the requesting principal may perform
+// it now (guard held AND precondition met). Reason names the blocking gate when
+// Allowed is false ("guard" or "precondition"); empty when Allowed is true. The
+// SPA shows only Allowed transitions, so Reason is advisory (tooltip/CLI), not a
+// rendering gate.
+type Transition struct {
+	To      string `json:"to"`
+	Label   string `json:"label,omitempty"`
+	Guard   string `json:"guard,omitempty"`
+	Allowed bool   `json:"allowed"`
+	Reason  string `json:"reason,omitempty"`
 }
 
 // Attachment describes one file attached to a `file`-type property, as

--- a/internal/dataentry/affordances.go
+++ b/internal/dataentry/affordances.go
@@ -16,6 +16,7 @@ import (
 	entityPkg "github.com/Sourcehaven-BV/rela/internal/entity"
 	"github.com/Sourcehaven-BV/rela/internal/metamodel"
 	"github.com/Sourcehaven-BV/rela/internal/principal"
+	"github.com/Sourcehaven-BV/rela/internal/statemachine"
 	"github.com/Sourcehaven-BV/rela/internal/store"
 )
 
@@ -160,6 +161,27 @@ func (svc affordanceService) computeCollectionActions(ctx context.Context, entit
 type FieldVerdictResolver interface {
 	FieldVerdicts(ctx context.Context, e *entityPkg.Entity) FieldVerdicts
 	RelationVerdicts(ctx context.Context, e *entityPkg.Entity) RelationVerdicts
+}
+
+// TransitionResolver is the OPTIONAL sibling of [FieldVerdictResolver] that
+// answers state-machine transition verdicts for an entity (TKT-3G93B8). It is
+// kept separate — and type-asserted, not embedded — because only the
+// policy-backed resolver can answer it; the Nop and Demo resolvers don't
+// implement it, so `_transitions` is simply absent under them (the SPA falls
+// back to the ordinary enum control). This mirrors the store's optional
+// capabilities (e.g. HistoryReader), which are also type-asserted rather than
+// forced into the base interface.
+//
+// The returned map is keyed by property name; each value is the resolved
+// outgoing transitions for the ctx principal on e. An empty map means "no
+// machine-typed property on this entity" (or no machines wired).
+type TransitionResolver interface {
+	TransitionVerdicts(ctx context.Context, e *entityPkg.Entity) map[string][]statemachine.TransitionVerdict
+	// EntryValues returns, per state-machine-typed property of entityType, the
+	// value a create must enter at (the machine's Initial/Default — BUG-X1C7S).
+	// The create form uses it to lock the field to its initial value. Empty when
+	// entityType has no machine-typed property.
+	EntryValues(entityType string) map[string]string
 }
 
 // FieldVerdicts carries per-entity field-level affordance decisions.
@@ -893,6 +915,82 @@ func (svc affordanceService) stripHiddenProperties(ctx context.Context, e *entit
 	}
 }
 
+// computeTransitions returns the per-entity `_transitions` wire map: for each
+// state-machine-typed property, the resolved outgoing transitions for the ctx
+// principal on e. Returns nil (→ `_transitions` omitted from the wire) when the
+// active resolver does not implement [TransitionResolver] (Nop / Demo) or has no
+// machine-typed property for this entity — the SPA then falls back to the
+// ordinary enum control. An empty (non-nil) map is possible for a
+// TransitionResolver whose machines don't cover e's type; it serializes as
+// `_transitions: {}`, the same closed-world "resolver present, no deviations"
+// signal the other affordance maps use.
+func (svc affordanceService) computeTransitions(
+	ctx context.Context, e *entityPkg.Entity,
+) map[string][]v1.Transition {
+	tr, ok := svc.resolver().(TransitionResolver)
+	if !ok {
+		return nil
+	}
+	verdicts := tr.TransitionVerdicts(ctx, e)
+	out := make(map[string][]v1.Transition, len(verdicts))
+	for prop, vs := range verdicts {
+		wire := make([]v1.Transition, 0, len(vs))
+		for _, v := range vs {
+			wire = append(wire, v1.Transition{
+				To:      v.To,
+				Label:   v.Label,
+				Guard:   v.Guard,
+				Allowed: v.Allowed,
+				Reason:  string(v.Reason),
+			})
+		}
+		out[prop] = wire
+	}
+	return out
+}
+
+// applyCreateLock adjusts a create-candidate response so every state-machine
+// field is locked to its entry value (BUG-X1C7S / TKT-3G93B8). A create is an
+// ENTRY, not a transition: the machine field must not be freely editable and
+// must carry the initial value the server will accept. For each machine-typed
+// property of entityType it (a) pins result.Properties[field] to the entry
+// value, (b) marks it read-only in _fields so the SPA renders it locked and the
+// create-commit filter omits it (the server then applies the initial), and (c)
+// drops it from _transitions — offering "moves" on an entity that does not yet
+// exist would be nonsensical, and the SPA keys the locked-field render off the
+// entry, not off transitions.
+//
+// No-op when the resolver can't answer entry values (Nop / Demo) or the type has
+// no machine field. Called only from the create dry-run path — GET / PATCH keep
+// the normal editable + _transitions shape.
+func (svc affordanceService) applyCreateLock(result *v1.Entity, entityType string) {
+	tr, ok := svc.resolver().(TransitionResolver)
+	if !ok {
+		return
+	}
+	entries := tr.EntryValues(entityType)
+	if len(entries) == 0 {
+		return
+	}
+	fields := map[string]v1.FieldAffordance{}
+	if result.FieldAffordances != nil {
+		fields = *result.FieldAffordances
+	}
+	for prop, entry := range entries {
+		if result.Properties != nil {
+			result.Properties[prop] = entry
+		}
+		locked := false
+		fa := fields[prop]
+		fa.Writable = &locked
+		fields[prop] = fa
+		if result.Transitions != nil {
+			delete(*result.Transitions, prop)
+		}
+	}
+	result.FieldAffordances = &fields
+}
+
 // attachEntityAffordances writes the per-entity `_fields` and
 // `_relations` wire maps onto result. Called by paths that return a
 // per-entity response (GET, PATCH, POST, clone, action) — list rows
@@ -903,6 +1001,9 @@ func (svc affordanceService) attachEntityAffordances(ctx context.Context, e *ent
 	relations := svc.computeRelationAffordances(ctx, e)
 	result.FieldAffordances = &fields
 	result.RelationAffordances = &relations
+	if transitions := svc.computeTransitions(ctx, e); transitions != nil {
+		result.Transitions = &transitions
+	}
 	// Pass the same verdicts so a policy-hidden `file` property's attachments
 	// are omitted from `_attachments` — otherwise the hidden-field boundary
 	// the rest of the response maintains would leak the file's metadata and a

--- a/internal/dataentry/affordances.go
+++ b/internal/dataentry/affordances.go
@@ -924,8 +924,15 @@ func (svc affordanceService) stripHiddenProperties(ctx context.Context, e *entit
 // TransitionResolver whose machines don't cover e's type; it serializes as
 // `_transitions: {}`, the same closed-world "resolver present, no deviations"
 // signal the other affordance maps use.
+//
+// fieldVerdicts is the same [FieldVerdicts] the caller resolved for `_fields` /
+// `_attachments`; a property hidden by field-visibility policy is OMITTED here
+// (RR-DENG8U). A machine's out-edge set is a function of its current value, so
+// emitting `_transitions` for a hidden field would leak that value back through
+// the wire past the strip that `stripHiddenProperties` performs on `properties`
+// / `_title` — mirror the same boundary attachments already keep.
 func (svc affordanceService) computeTransitions(
-	ctx context.Context, e *entityPkg.Entity,
+	ctx context.Context, e *entityPkg.Entity, fieldVerdicts FieldVerdicts,
 ) map[string][]v1.Transition {
 	tr, ok := svc.resolver().(TransitionResolver)
 	if !ok {
@@ -934,6 +941,9 @@ func (svc affordanceService) computeTransitions(
 	verdicts := tr.TransitionVerdicts(ctx, e)
 	out := make(map[string][]v1.Transition, len(verdicts))
 	for prop, vs := range verdicts {
+		if !fieldVerdicts.IsVisible(prop) {
+			continue // hidden field: don't leak its state via out-edges
+		}
 		wire := make([]v1.Transition, 0, len(vs))
 		for _, v := range vs {
 			wire = append(wire, v1.Transition{
@@ -963,23 +973,37 @@ func (svc affordanceService) computeTransitions(
 // No-op when the resolver can't answer entry values (Nop / Demo) or the type has
 // no machine field. Called only from the create dry-run path — GET / PATCH keep
 // the normal editable + _transitions shape.
-func (svc affordanceService) applyCreateLock(result *v1.Entity, entityType string) {
+//
+// A machine field hidden by field-visibility policy is skipped entirely
+// (RR-C3OJ33): stripHiddenProperties already removed it from result.Properties,
+// and re-inserting its entry value here would both re-leak it on the wire and
+// make it re-appear in the SPA create form (which derives visible create fields
+// from the response's property keys). Its create is still constrained — the
+// server rejects a non-entry value on the real create regardless of the hint.
+func (svc affordanceService) applyCreateLock(
+	ctx context.Context, result *v1.Entity, candidate *entityPkg.Entity,
+) {
 	tr, ok := svc.resolver().(TransitionResolver)
 	if !ok {
 		return
 	}
-	entries := tr.EntryValues(entityType)
+	entries := tr.EntryValues(candidate.Type)
 	if len(entries) == 0 {
 		return
 	}
+	fieldVerdicts := svc.resolver().FieldVerdicts(ctx, candidate)
 	fields := map[string]v1.FieldAffordance{}
 	if result.FieldAffordances != nil {
 		fields = *result.FieldAffordances
 	}
+	if result.Properties == nil {
+		result.Properties = map[string]any{}
+	}
 	for prop, entry := range entries {
-		if result.Properties != nil {
-			result.Properties[prop] = entry
+		if !fieldVerdicts.IsVisible(prop) {
+			continue // hidden: leave it stripped, don't re-add to the wire
 		}
+		result.Properties[prop] = entry
 		locked := false
 		fa := fields[prop]
 		fa.Writable = &locked
@@ -1001,7 +1025,7 @@ func (svc affordanceService) attachEntityAffordances(ctx context.Context, e *ent
 	relations := svc.computeRelationAffordances(ctx, e)
 	result.FieldAffordances = &fields
 	result.RelationAffordances = &relations
-	if transitions := svc.computeTransitions(ctx, e); transitions != nil {
+	if transitions := svc.computeTransitions(ctx, e, verdicts); transitions != nil {
 		result.Transitions = &transitions
 	}
 	// Pass the same verdicts so a policy-hidden `file` property's attachments

--- a/internal/dataentry/affordances_policy.go
+++ b/internal/dataentry/affordances_policy.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/Sourcehaven-BV/rela/internal/affordances"
 	entityPkg "github.com/Sourcehaven-BV/rela/internal/entity"
+	"github.com/Sourcehaven-BV/rela/internal/statemachine"
 	"github.com/Sourcehaven-BV/rela/internal/store"
 )
 
@@ -50,6 +51,23 @@ func (p *policyResolver) RelationVerdicts(ctx context.Context, e *entityPkg.Enti
 		}
 	}
 	return out
+}
+
+// TransitionVerdicts forwards to the wrapped policy resolver, making
+// policyResolver satisfy [TransitionResolver] (TKT-3G93B8). The affordances
+// resolver returns statemachine verdicts directly (no wire-shape mapping here);
+// the serializer maps them to v1.Transition. Only the policy-backed resolver
+// implements this — Nop / Demo do not, so `_transitions` is absent under them.
+func (p *policyResolver) TransitionVerdicts(
+	ctx context.Context, e *entityPkg.Entity,
+) map[string][]statemachine.TransitionVerdict {
+	return p.inner.TransitionVerdicts(ctx, e)
+}
+
+// EntryValues forwards to the wrapped policy resolver so policyResolver
+// satisfies the create-lock half of [TransitionResolver] (TKT-3G93B8).
+func (p *policyResolver) EntryValues(entityType string) map[string]string {
+	return p.inner.EntryValues(entityType)
 }
 
 // storeRelationLookup implements [affordances.RelationLookup] against a

--- a/internal/dataentry/api_v1.go
+++ b/internal/dataentry/api_v1.go
@@ -859,7 +859,7 @@ func (a *App) handleV1DryRunCreate(w http.ResponseWriter, r *http.Request, typeN
 	// A create ENTERS the machine at its initial state; it is not a transition.
 	// Lock every state-machine field to its entry value so the create form
 	// renders it read-only at the initial state (BUG-X1C7S / TKT-3G93B8).
-	a.serializer.affordances.applyCreateLock(&result, typeName)
+	a.serializer.affordances.applyCreateLock(r.Context(), &result, candidate)
 	if idWarning != nil {
 		result.Warnings = append(result.Warnings, *idWarning)
 	}

--- a/internal/dataentry/api_v1.go
+++ b/internal/dataentry/api_v1.go
@@ -856,6 +856,10 @@ func (a *App) handleV1DryRunCreate(w http.ResponseWriter, r *http.Request, typeN
 	// re-derive as the form changes. includeRelations=false: no edges
 	// exist for an unsaved entity.
 	result := a.serializer.forWire(r.Context(), candidate, nil, a.Meta(), plural)
+	// A create ENTERS the machine at its initial state; it is not a transition.
+	// Lock every state-machine field to its entry value so the create form
+	// renders it read-only at the initial state (BUG-X1C7S / TKT-3G93B8).
+	a.serializer.affordances.applyCreateLock(&result, typeName)
 	if idWarning != nil {
 		result.Warnings = append(result.Warnings, *idWarning)
 	}

--- a/internal/dataentry/transitions_wire_test.go
+++ b/internal/dataentry/transitions_wire_test.go
@@ -1,0 +1,168 @@
+package dataentry
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	v1 "github.com/Sourcehaven-BV/rela/internal/apiwire/v1"
+	"github.com/Sourcehaven-BV/rela/internal/entity"
+	"github.com/Sourcehaven-BV/rela/internal/statemachine"
+)
+
+// fakeTransitionResolver is a FieldVerdictResolver that ALSO implements
+// TransitionResolver, so tests can drive the `_transitions` wire path and the
+// create-lock without compiling a real state machine. The base field/relation
+// verdicts are permissive (empty).
+type fakeTransitionResolver struct {
+	verdicts map[string][]statemachine.TransitionVerdict
+	entries  map[string]string
+}
+
+func (f fakeTransitionResolver) FieldVerdicts(context.Context, *entity.Entity) FieldVerdicts {
+	return FieldVerdicts{}
+}
+
+func (f fakeTransitionResolver) RelationVerdicts(context.Context, *entity.Entity) RelationVerdicts {
+	return RelationVerdicts{}
+}
+
+func (f fakeTransitionResolver) TransitionVerdicts(
+	_ context.Context, _ *entity.Entity,
+) map[string][]statemachine.TransitionVerdict {
+	return f.verdicts
+}
+
+func (f fakeTransitionResolver) EntryValues(string) map[string]string {
+	return f.entries
+}
+
+// Compile-time assertion that the fake satisfies both seams.
+var (
+	_ FieldVerdictResolver = fakeTransitionResolver{}
+	_ TransitionResolver   = fakeTransitionResolver{}
+)
+
+func getEntityV1(t *testing.T, app *App, typeName, plural, id string) v1.Entity {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/"+plural+"/"+id, http.NoBody)
+	rec := httptest.NewRecorder()
+	app.handleV1GetEntity(rec, req, typeName, plural, id)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET %s: got %d, want 200; body=%s", id, rec.Code, rec.Body.String())
+	}
+	var e v1.Entity
+	if err := json.NewDecoder(rec.Body).Decode(&e); err != nil {
+		t.Fatalf("decode GET: %v", err)
+	}
+	return e
+}
+
+// AC1: a per-entity GET carries `_transitions` for a machine-typed field,
+// mapping every field of the TransitionVerdict onto the wire shape (to, label,
+// guard, allowed, reason).
+func TestTransitionsWire_GETCarriesTransitions(t *testing.T) {
+	app := newTestAppV1(t)
+	app.fieldResolver = fakeTransitionResolver{
+		verdicts: map[string][]statemachine.TransitionVerdict{
+			"status": {
+				{To: "doing", Label: "Start progress", Allowed: true, Reason: statemachine.VerdictAllowed},
+				{To: "done", Label: "Complete", Guard: "close", Allowed: false, Reason: statemachine.VerdictGuard},
+			},
+		},
+	}
+	seedEntity(app, &entity.Entity{
+		ID:         "TKT-001",
+		Type:       "ticket",
+		Properties: map[string]any{"title": "x", "status": "todo"},
+	})
+
+	e := getEntityV1(t, app, "ticket", "tickets", "TKT-001")
+	if e.Transitions == nil {
+		t.Fatalf("expected _transitions present, got nil")
+	}
+	got := (*e.Transitions)["status"]
+	if len(got) != 2 {
+		t.Fatalf("expected 2 transitions, got %d: %+v", len(got), got)
+	}
+
+	start := got[0]
+	if start.To != "doing" || start.Label != "Start progress" || !start.Allowed || start.Reason != "" {
+		t.Errorf("start move wire mismatch: %+v", start)
+	}
+	complete := got[1]
+	badComplete := complete.To != "done" || complete.Label != "Complete" ||
+		complete.Guard != "close" || complete.Allowed || complete.Reason != "guard"
+	if badComplete {
+		t.Errorf("complete move wire mismatch: %+v", complete)
+	}
+}
+
+// AC1 (absence): a resolver that does NOT implement TransitionResolver (the
+// default Nop, or the plain fakeResolver) leaves `_transitions` off the wire —
+// the SPA then falls back to the ordinary enum control.
+func TestTransitionsWire_AbsentWithoutTransitionResolver(t *testing.T) {
+	app := newTestAppV1(t)
+	// newTestAppV1 wires NopFieldVerdictResolver, which does not implement
+	// TransitionResolver.
+	seedEntity(app, &entity.Entity{
+		ID:         "TKT-002",
+		Type:       "ticket",
+		Properties: map[string]any{"title": "x", "status": "todo"},
+	})
+
+	e := getEntityV1(t, app, "ticket", "tickets", "TKT-002")
+	if e.Transitions != nil {
+		t.Fatalf("expected _transitions absent under non-TransitionResolver, got %+v", *e.Transitions)
+	}
+}
+
+// AC4: the create dry-run locks a machine field to its entry value — the field
+// is marked read-only in `_fields`, its value is pinned to the entry, and it
+// carries no `_transitions` (a create is an entry, not a move).
+func TestTransitionsWire_CreateLocksMachineField(t *testing.T) {
+	app := newTestAppV1(t)
+	app.fieldResolver = fakeTransitionResolver{
+		// On a create candidate the resolver would still report transitions
+		// from the seeded value; applyCreateLock must strip them for the
+		// locked field.
+		verdicts: map[string][]statemachine.TransitionVerdict{
+			"status": {{To: "doing", Label: "Start progress", Allowed: true}},
+		},
+		entries: map[string]string{"status": "todo"},
+	}
+
+	body := `{"properties":{"title":"new ticket","status":"doing"}}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/tickets?dry_run=true", strings.NewReader(body))
+	rec := httptest.NewRecorder()
+	app.handleV1DryRunCreate(rec, req, "ticket", "tickets")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("dry-run create: got %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	var e v1.Entity
+	if err := json.NewDecoder(rec.Body).Decode(&e); err != nil {
+		t.Fatalf("decode dry-run: %v", err)
+	}
+
+	// Value pinned to the entry, overriding the "doing" the client sent.
+	if got := e.Properties["status"]; got != "todo" {
+		t.Errorf("status must be pinned to entry %q, got %v", "todo", got)
+	}
+	// Field marked read-only so the SPA renders it locked.
+	if e.FieldAffordances == nil {
+		t.Fatalf("expected _fields present")
+	}
+	fa, ok := (*e.FieldAffordances)["status"]
+	if !ok || fa.Writable == nil || *fa.Writable {
+		t.Errorf("status must be writable=false on create, got %+v (present=%v)", fa, ok)
+	}
+	// No transitions for the locked field — create is an entry, not a move.
+	if e.Transitions != nil {
+		if _, present := (*e.Transitions)["status"]; present {
+			t.Errorf("locked machine field must not carry _transitions on create, got %+v", *e.Transitions)
+		}
+	}
+}

--- a/internal/dataentry/transitions_wire_test.go
+++ b/internal/dataentry/transitions_wire_test.go
@@ -54,11 +54,13 @@ var (
 	_ TransitionResolver   = fakeTransitionResolver{}
 )
 
-func getEntityV1(t *testing.T, app *App, typeName, plural, id string) v1.Entity {
+// getEntityV1 GETs a ticket (the only type newTestAppV1 defines) and decodes
+// the v1 wire shape.
+func getEntityV1(t *testing.T, app *App, id string) v1.Entity {
 	t.Helper()
-	req := httptest.NewRequest(http.MethodGet, "/api/v1/"+plural+"/"+id, http.NoBody)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/tickets/"+id, http.NoBody)
 	rec := httptest.NewRecorder()
-	app.handleV1GetEntity(rec, req, typeName, plural, id)
+	app.handleV1GetEntity(rec, req, "ticket", "tickets", id)
 	if rec.Code != http.StatusOK {
 		t.Fatalf("GET %s: got %d, want 200; body=%s", id, rec.Code, rec.Body.String())
 	}
@@ -88,7 +90,7 @@ func TestTransitionsWire_GETCarriesTransitions(t *testing.T) {
 		Properties: map[string]any{"title": "x", "status": "todo"},
 	})
 
-	e := getEntityV1(t, app, "ticket", "tickets", "TKT-001")
+	e := getEntityV1(t, app, "TKT-001")
 	if e.Transitions == nil {
 		t.Fatalf("expected _transitions present, got nil")
 	}
@@ -122,9 +124,38 @@ func TestTransitionsWire_AbsentWithoutTransitionResolver(t *testing.T) {
 		Properties: map[string]any{"title": "x", "status": "todo"},
 	})
 
-	e := getEntityV1(t, app, "ticket", "tickets", "TKT-002")
+	e := getEntityV1(t, app, "TKT-002")
 	if e.Transitions != nil {
 		t.Fatalf("expected _transitions absent under non-TransitionResolver, got %+v", *e.Transitions)
+	}
+}
+
+// A terminal machine field (no performable out-edges) must keep its key with an
+// empty list, so the SPA still renders the status control instead of falling
+// back to a full enum select that would offer illegal moves (TKT-3G93B8).
+func TestTransitionsWire_TerminalStateKeyPresent(t *testing.T) {
+	app := newTestAppV1(t)
+	app.fieldResolver = fakeTransitionResolver{
+		verdicts: map[string][]statemachine.TransitionVerdict{
+			"status": {}, // terminal: key present, no moves
+		},
+	}
+	seedEntity(app, &entity.Entity{
+		ID:         "TKT-004",
+		Type:       "ticket",
+		Properties: map[string]any{"title": "x", "status": "done"},
+	})
+
+	e := getEntityV1(t, app, "TKT-004")
+	if e.Transitions == nil {
+		t.Fatalf("expected _transitions present for a machine field")
+	}
+	got, ok := (*e.Transitions)["status"]
+	if !ok {
+		t.Fatalf("terminal machine field must keep its key, got %+v", *e.Transitions)
+	}
+	if len(got) != 0 {
+		t.Errorf("terminal field should have no moves, got %+v", got)
 	}
 }
 
@@ -145,7 +176,7 @@ func TestTransitionsWire_HiddenMachineFieldOmitted(t *testing.T) {
 		Properties: map[string]any{"title": "x", "status": "todo"},
 	})
 
-	e := getEntityV1(t, app, "ticket", "tickets", "TKT-003")
+	e := getEntityV1(t, app, "TKT-003")
 	// The hidden value is stripped from properties...
 	if _, present := e.Properties["status"]; present {
 		t.Errorf("hidden status must be stripped from properties, got %v", e.Properties["status"])

--- a/internal/dataentry/transitions_wire_test.go
+++ b/internal/dataentry/transitions_wire_test.go
@@ -20,10 +20,18 @@ import (
 type fakeTransitionResolver struct {
 	verdicts map[string][]statemachine.TransitionVerdict
 	entries  map[string]string
+	hidden   map[string]bool // field name → hidden (Visible=false)
 }
 
 func (f fakeTransitionResolver) FieldVerdicts(context.Context, *entity.Entity) FieldVerdicts {
-	return FieldVerdicts{}
+	if len(f.hidden) == 0 {
+		return FieldVerdicts{}
+	}
+	vis := map[string]bool{}
+	for name := range f.hidden {
+		vis[name] = false
+	}
+	return FieldVerdicts{Visible: vis}
 }
 
 func (f fakeTransitionResolver) RelationVerdicts(context.Context, *entity.Entity) RelationVerdicts {
@@ -117,6 +125,63 @@ func TestTransitionsWire_AbsentWithoutTransitionResolver(t *testing.T) {
 	e := getEntityV1(t, app, "ticket", "tickets", "TKT-002")
 	if e.Transitions != nil {
 		t.Fatalf("expected _transitions absent under non-TransitionResolver, got %+v", *e.Transitions)
+	}
+}
+
+// RR-DENG8U: a machine field hidden by field-visibility policy must NOT leak its
+// current state via `_transitions` — the out-edge set is a function of the
+// current value, so emitting it would defeat the hidden-field strip.
+func TestTransitionsWire_HiddenMachineFieldOmitted(t *testing.T) {
+	app := newTestAppV1(t)
+	app.fieldResolver = fakeTransitionResolver{
+		verdicts: map[string][]statemachine.TransitionVerdict{
+			"status": {{To: "doing", Label: "Start progress", Allowed: true}},
+		},
+		hidden: map[string]bool{"status": true},
+	}
+	seedEntity(app, &entity.Entity{
+		ID:         "TKT-003",
+		Type:       "ticket",
+		Properties: map[string]any{"title": "x", "status": "todo"},
+	})
+
+	e := getEntityV1(t, app, "ticket", "tickets", "TKT-003")
+	// The hidden value is stripped from properties...
+	if _, present := e.Properties["status"]; present {
+		t.Errorf("hidden status must be stripped from properties, got %v", e.Properties["status"])
+	}
+	// ...and must not reappear via _transitions.
+	if e.Transitions != nil {
+		if _, present := (*e.Transitions)["status"]; present {
+			t.Errorf("hidden machine field must not carry _transitions (leak), got %+v", *e.Transitions)
+		}
+	}
+}
+
+// RR-C3OJ33: the create dry-run must not re-insert a hidden machine field's entry
+// value into the response (which would re-leak it AND re-surface it in the SPA
+// create form, whose visible-field set derives from the response property keys).
+func TestTransitionsWire_CreateLockSkipsHiddenField(t *testing.T) {
+	app := newTestAppV1(t)
+	app.fieldResolver = fakeTransitionResolver{
+		entries: map[string]string{"status": "todo"},
+		hidden:  map[string]bool{"status": true},
+	}
+
+	body := `{"properties":{"title":"new ticket"}}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/tickets?dry_run=true", strings.NewReader(body))
+	rec := httptest.NewRecorder()
+	app.handleV1DryRunCreate(rec, req, "ticket", "tickets")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("dry-run create: got %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	var e v1.Entity
+	if err := json.NewDecoder(rec.Body).Decode(&e); err != nil {
+		t.Fatalf("decode dry-run: %v", err)
+	}
+	// The hidden field's entry value must NOT be re-added to the wire.
+	if _, present := e.Properties["status"]; present {
+		t.Errorf("create-lock must not re-insert a hidden field, got %v", e.Properties["status"])
 	}
 }
 

--- a/internal/metamodel/types.go
+++ b/internal/metamodel/types.go
@@ -159,6 +159,14 @@ type TransitionDef struct {
 	From string `yaml:"from"` // Source value; must be one of CustomType.Values
 	To   string `yaml:"to"`   // Target value; must be one of CustomType.Values
 
+	// Label is optional display text for the MOVE (the action), not the
+	// destination state — e.g. "Start progress" for todo→doing rather than the
+	// state noun "Doing". Purely presentational: a machine-aware status control
+	// lists transitions as verbs. Empty falls back to the target value's display
+	// label (CustomType.Labels[To]) and then the raw To value. Display-only; the
+	// executable machine ignores it for enforcement.
+	Label string `yaml:"label,omitempty"`
+
 	// Guard names an ACL permission the acting principal must hold for this
 	// transition. Enforced only on served paths (a principal exists); inert
 	// on direct CLI writes. Empty means the transition is legal for anyone

--- a/internal/statemachine/compile.go
+++ b/internal/statemachine/compile.go
@@ -145,7 +145,7 @@ func compileMachine(typeName string, ct metamodel.CustomType) (machine *Machine,
 					"type %q: transition[%d] %s→%s when: %v", typeName, i, tr.From, tr.To, err))
 			}
 		}
-		edges[key] = edge{guard: tr.Guard, when: prog}
+		edges[key] = edge{guard: tr.Guard, when: prog, label: tr.Label}
 	}
 
 	return &Machine{name: typeName, edges: edges, entry: entry}, problems

--- a/internal/statemachine/label_entry_test.go
+++ b/internal/statemachine/label_entry_test.go
@@ -1,0 +1,71 @@
+package statemachine
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Sourcehaven-BV/rela/internal/metamodel"
+)
+
+// labelMeta is a two-value machine whose single edge carries a move label, plus
+// a distinct Initial, exercising Performable's Label passthrough and EntryValue.
+func labelMeta() *metamodel.Metamodel {
+	return &metamodel.Metamodel{
+		Types: map[string]metamodel.CustomType{
+			"task-status": {
+				Values:  []string{"todo", "doing", "done"},
+				Initial: "todo",
+				Default: "done", // deliberately != Initial: EntryValue must prefer Initial.
+				Transitions: []metamodel.TransitionDef{
+					{From: "todo", To: "doing", Label: "Start progress"},
+					{From: "doing", To: "done"}, // no label: Performable surfaces ""
+				},
+			},
+		},
+		Entities: map[string]metamodel.EntityDef{
+			"task": {Properties: map[string]metamodel.PropertyDef{
+				"status": {Type: "task-status"},
+			}},
+		},
+	}
+}
+
+// Performable surfaces the edge's move label verbatim (empty when unset); the
+// display-layer fallback to a state label is the SPA's job, not the machine's.
+func TestPerformable_SurfacesLabel(t *testing.T) {
+	set := mustCompile(t, labelMeta())
+	ctx := context.Background()
+
+	got := set.Performable(ctx, ent("T-1", "task", "todo"), "status", inertGuard{}, fakeLookup{})
+	if len(got) != 1 {
+		t.Fatalf("expected 1 verdict from todo, got %d: %+v", len(got), got)
+	}
+	if got[0].To != "doing" || got[0].Label != "Start progress" {
+		t.Errorf("labeled move mismatch: %+v", got[0])
+	}
+
+	// An unlabeled edge surfaces an empty Label (fallback happens downstream).
+	got = set.Performable(ctx, ent("T-1", "task", "doing"), "status", inertGuard{}, fakeLookup{})
+	if len(got) != 1 || got[0].To != "done" || got[0].Label != "" {
+		t.Errorf("unlabeled move must surface empty Label, got %+v", got)
+	}
+}
+
+// EntryValue returns the machine's entry (Initial, else Default) for a machine
+// field, and "" for a non-machine field or unknown type.
+func TestEntryValue(t *testing.T) {
+	set := mustCompile(t, labelMeta())
+
+	if got := set.EntryValue("task", "status"); got != "todo" {
+		t.Errorf("EntryValue(task,status) = %q, want %q (Initial, not Default)", got, "todo")
+	}
+	if got := set.EntryValue("task", "title"); got != "" {
+		t.Errorf("EntryValue for non-machine prop = %q, want \"\"", got)
+	}
+	if got := set.EntryValue("nonexistent", "status"); got != "" {
+		t.Errorf("EntryValue for unknown type = %q, want \"\"", got)
+	}
+	if got := EmptySet().EntryValue("task", "status"); got != "" {
+		t.Errorf("EntryValue on empty set = %q, want \"\"", got)
+	}
+}

--- a/internal/statemachine/resolve.go
+++ b/internal/statemachine/resolve.go
@@ -15,6 +15,7 @@ import (
 // this entity", suitable for a UI status control or a CLI.
 type TransitionVerdict struct {
 	To      string
+	Label   string      // display text for the MOVE; "" falls back to the target value's label at the display layer
 	Guard   string      // ACL permission name; "" when the edge is unguarded
 	Allowed bool        // true iff the guard is held AND the precondition holds
 	Reason  VerdictGate // why Allowed is false; VerdictAllowed when it's true
@@ -85,6 +86,7 @@ func (s *Set) Performable(
 		res := evalEdge(ctx, ed, prop, after, guard, lookup)
 		out = append(out, TransitionVerdict{
 			To:      key.to,
+			Label:   ed.label,
 			Guard:   ed.guard,
 			Allowed: res.gate == gateNone,
 			Reason:  reasonFor(res.gate),

--- a/internal/statemachine/statemachine.go
+++ b/internal/statemachine/statemachine.go
@@ -101,10 +101,13 @@ type GraphLookup interface {
 }
 
 // edge is one compiled transition. guard is the (possibly empty) ACL
-// permission; when is the (possibly nil) compiled precondition.
+// permission; when is the (possibly nil) compiled precondition; label is the
+// (possibly empty) display text for the move, surfaced on a read verdict for a
+// status control (display-only, never consulted for enforcement).
 type edge struct {
 	guard string
 	when  *predicate.Program
+	label string
 }
 
 // Machine is one compiled enum state machine: the indexed edge set plus the
@@ -140,6 +143,21 @@ type Set struct {
 // Empty reports whether the set has no machines. A metamodel with no
 // transitions compiles to an empty set; Enforce is then a no-op.
 func (s *Set) Empty() bool { return s == nil || len(s.machines) == 0 }
+
+// EntryValue returns the compiled entry value (Initial, else Default) for the
+// state-machine property prop on entityType — the only value a create may set
+// (BUG-X1C7S). Returns "" when prop is not a state machine on entityType or the
+// Set is empty; a create form uses it to lock the field to its initial state.
+func (s *Set) EntryValue(entityType, prop string) string {
+	if s.Empty() {
+		return ""
+	}
+	typeName, ok := s.propType[entityType][prop]
+	if !ok {
+		return ""
+	}
+	return s.machines[typeName].entry
+}
 
 // EmptySet returns a machine-less [Set] whose Enforce methods are no-ops. It is
 // the explicit "no state machines" value for wiring sites and tests that need a

--- a/tickets/entities/docs-checklists/DOCS-V9830X.md
+++ b/tickets/entities/docs-checklists/DOCS-V9830X.md
@@ -1,0 +1,27 @@
+---
+id: DOCS-V9830X
+type: docs-checklist
+title: 'Docs: Machine-aware status control (TKT-3G93B8)'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Code Documentation
+
+- [x] Godoc / TSDoc on new exported symbols (statemachine.EntryValue, TransitionVerdict.Label, v1.Transition, TransitionResolver, computeTransitions, applyCreateLock, StatusControl.vue, adoptLockedFieldValues)
+- [x] Non-obvious decisions explained inline (visibility gating rationale, create-is-entry-not-transition, stale-menu reload)
+
+## Project Documentation
+
+- [x] docs/data-entry/api-reference.md — new `## Transition affordances: _transitions` section (wire shape table, create-lock semantics, UI-hint-not-authorization note)
+- [x] docs/metamodel.md — new `### State Machines (transitions)` subsection under Custom Types (transitions/initial/guard/when/label, with the new `label` field documented)
+
+## External Documentation
+
+- [x] ~~README / tutorials~~ (N/A: incremental affordance surface, covered by api-reference + metamodel guide)
+
+## Verification
+
+- [x] Docs cross-reference each other (metamodel `label` → api-reference `_transitions`; api-reference → metamodel state-machine section)
+- [x] Wire-shape example matches the actual v1.Transition JSON tags

--- a/tickets/entities/implementation-checklists/IMPL-ZPQHEW.md
+++ b/tickets/entities/implementation-checklists/IMPL-ZPQHEW.md
@@ -1,0 +1,72 @@
+---
+id: IMPL-ZPQHEW
+type: implementation-checklist
+title: 'Implementation: Machine-aware status control: surface _transitions on the wire + SPA performable-transition UI + entry-locked create field'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Development
+
+- [x] Unit tests written for new code
+- [x] Integration tests written (dry-run create + GET through the serializer)
+- [x] Happy path implemented
+- [x] Edge cases from planning handled
+- [x] Error handling in place (errors surfaced, not swallowed)
+
+## Test Quality
+
+- [x] Using focused fakes (fakeTransitionResolver, labelMeta) for test data
+- [x] No hardcoded values in assertions when object is in scope
+- [x] Only specifying values that matter for the test
+- [x] ~~Interpolated values constructed from objects~~ (N/A: fixed enum values)
+- [x] Property comparisons use the verdict/wire object
+
+## Manual Verification
+
+- [x] Each acceptance criterion verified via automated test scenario
+
+**Verification Evidence:**
+
+Backend (`go test ./internal/dataentry ./internal/statemachine ...` — all pass):
+- AC1: `TestTransitionsWire_GETCarriesTransitions` — GET carries `_transitions`
+with full wire mapping (to/label/guard/allowed/reason);
+`TestTransitionsWire_AbsentWithoutTransitionResolver` — absent under Nop.
+- AC4: `TestTransitionsWire_CreateLocksMachineField` — dry-run pins the field to
+entry, marks writable=false, strips `_transitions`.
+- AC5 label fallback: `TestPerformable_SurfacesLabel`; `TestEntryValue`.
+- Drift guard untouched: existing `TestPerformable_MatchesEnforceUpdate` still passes.
+
+Frontend (`npm run test:run` — 1338 pass incl. new):
+- AC2: `FieldRenderer.test.ts` routes machine field → StatusControl, non-machine
+→ SelectWidget, terminal (empty) → StatusControl.
+- AC2/AC3: `StatusControl.test.ts` — only allowed moves shown, action-labeled
+(+ raw-value fallback), commit emits target, self-loop excluded, terminal =
+inert, disabled = no menu.
+
+Coverage: `just coverage-check` PASS (statemachine 86.5%, all floors met). Lint:
+`just arch-lint` OK; golangci-lint 0 issues; eslint 0 errors on new files.
+
+Note on create-lock SPA coverage: the `formData` value-adoption in
+`refreshStagedAffordances` is verified at its boundaries (backend
+`TestTransitionsWire_CreateLocksMachineField` pins the wire; existing
+`FieldRenderer` readonly tests cover the disabled render). A full DynamicForm
+mount test was not added — the repo's own convention (FieldRenderer.test.ts
+header) avoids the full-mount cost, and the behavior is contract-covered.
+
+## Quality
+
+- [x] Code follows project patterns (optional-capability type-assert like store
+HistoryReader; consumer-side TransitionResolver interface; affordance-map wire
+idiom)
+- [x] Checked for DRY — reused evalEdge drift guard, existing useAutoSave commit
+path, existing isFieldReadonly for create-lock; no premature abstraction
+- [x] No security issues — `_transitions` is server-computed, read-only hint;
+write path re-enforces (attempt-and-recover); no client-side ACL
+- [x] No silent failures
+- [x] No debug code left behind
+
+**Scope note:** included a small additive `metamodel.TransitionDef.Label`
+(user-approved) to satisfy "name options as their transition"; display-only, no
+enforcement change, fully backward compatible.

--- a/tickets/entities/planning-checklists/PLAN-QQLK3F.md
+++ b/tickets/entities/planning-checklists/PLAN-QQLK3F.md
@@ -125,7 +125,7 @@ Effort: l (confirmed).
 **Documentation Impact:**
 - [x] docs/data-entry/api-reference.md — `_transitions` wire shape
 - [x] docs/metamodel.md — TransitionDef `label`
-- [ ] N/A others
+- [x] ~~other docs~~ (N/A: no README/tutorial/CLI impact)
 
 ## Design Review
 

--- a/tickets/entities/planning-checklists/PLAN-QQLK3F.md
+++ b/tickets/entities/planning-checklists/PLAN-QQLK3F.md
@@ -1,0 +1,136 @@
+---
+id: PLAN-QQLK3F
+type: planning-checklist
+title: 'Planning: Machine-aware status control: surface _transitions on the wire + SPA performable-transition UI + entry-locked create field'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Understanding
+
+- [x] Problem/requirements clearly understood
+- [x] Scope defined (what's in/out documented below)
+- [x] Acceptance criteria documented with specific test scenarios
+
+**Scope:**
+
+IN:
+1. `metamodel.TransitionDef.Label` (new optional YAML `label`) — display text for the *move* (transitions are actions, not states).
+2. `statemachine`: carry label on compiled edge + `TransitionVerdict.Label`; add `Set.EntryValue(type, prop)` read accessor.
+3. Wire: `v1.Entity._transitions` (`map[field][]Transition{to,label,guard,allowed,reason}`), pointer/closed-world like `_fields`.
+4. dataentry: optional `TransitionResolver` interface, type-asserted in `attachEntityAffordances`; per-entity responses only. Create-lock via dry-run `_fields[field].writable=false` + entry value.
+5. New SPA `StatusControl.vue`: shows only ALLOWED transitions, labeled by action label; commit-on-select via useAutoSave. FieldRenderer routes machine field → StatusControl, else SelectWidget (fallback).
+6. Create form: machine field locked to initial value.
+
+OUT: CLI/mermaid consumers; `transition:*` ACL verb; any enforcement / FT8J9
+read-query change.
+
+**Acceptance Criteria:**
+1. Entity GET carries `_transitions` for machine fields (from TransitionVerdicts), absent otherwise + absent under Nop resolver. Test: serializer test with a machine-typed fixture vs non-machine.
+2. SPA renders machine field as StatusControl showing ONLY performable moves, each action-labeled; non-machine falls back to SelectWidget. Test: component test from `_transitions` fixture.
+3. Selecting a move commits an atomic field PATCH; 403/422 surfaces existing structured error. Test: StatusControl commit test asserts scheduleFieldSave called.
+4. Create form: machine field not freely editable (locked to initial). Test: create-form/dry-run lock test.
+5. `TransitionVerdict.Label` fallback: transition label → state label → raw value. Test: statemachine resolve test.
+
+## Research
+
+- [x] ~~run `/research`~~ (N/A: pure consumer of merged TKT-FT8J9 + small additive schema field)
+- [x] Searched codebase for similar patterns
+- [x] Reviewed prior art
+
+**Existing Solutions:**
+- `SelectWidget.vue` already consumes a `transitions: Record<current, next[]>` prop and gates options — but fed from STATIC form config, not the wire. Reuse the seam concept, but "only-allowed + action labels" is a genuinely different control → new `StatusControl.vue`.
+- Optional-capability type-assert pattern (store's `HistoryReader`/`Formatter`) → `TransitionResolver` sibling interface, same idiom.
+- `useAutoSave.scheduleFieldSave` = existing atomic single-field PATCH path (commit-on-select).
+- `statemachine.Set` already holds compiled `m.entry` → expose as `EntryValue`.
+
+## Approach
+
+Backend: TransitionDef.Label → edge.label → TransitionVerdict.Label
+(display-only, no enforcement change). `_transitions` on v1.Entity, filled in
+attachEntityAffordances via a type-asserted `TransitionResolver`. Create-lock
+threads entry via dry-run `_fields`.
+
+SPA: `_transitions` on Entity type; new StatusControl.vue (menu of
+only-performable, action-labeled, commit-on-select); FieldRenderer routes to it
+when `_transitions[field]` present.
+
+**Files to modify:**
+- `internal/metamodel/types.go` (TransitionDef.Label)
+- `internal/statemachine/{statemachine,compile,resolve}.go` (edge.label, Verdict.Label, EntryValue)
+- `internal/affordances/resolver.go` (Label passthrough — already returns statemachine.TransitionVerdict, so free)
+- `internal/apiwire/v1/responses.go` (Entity.Transitions, Transition)
+- `internal/dataentry/{affordances,affordances_policy,affordances_stub,entityserializer}.go` (TransitionResolver, attach)
+- `frontend/src/types/entity.ts`, `frontend/src/components/forms/StatusControl.vue`, `FieldRenderer.vue`, `DynamicForm.vue`
+- `docs/data-entry/api-reference.md`
+
+## Security Considerations
+
+- [x] Input sources identified
+- [x] Input validation approach defined
+- [x] Security-sensitive operations identified
+- [x] Error handling doesn't leak sensitive information
+
+**Input Sources & Validation:** `_transitions` is server-COMPUTED (from
+TransitionVerdicts under the request principal) — not client input. `label` is
+operator-authored metamodel config (trusted, like existing `Labels`). The SPA
+reads server booleans; NO client-side ACL (dataentry/CLAUDE.md).
+Attempt-and-recover: server re-enforces every write — `_transitions` is a UI
+hint, never authorization.
+
+**Security-Sensitive Operations:** The transition write is the existing
+entitymanager write path (already guard/precondition-enforced by TKT-E4LW2).
+This ticket adds NO new write path — StatusControl PATCHes
+`{properties:{field:to}}` through the same gated update. A tampered
+`_transitions` can only widen the *displayed* options; the write still 403/422s.
+
+## Test Plan
+
+- [x] Test scenarios documented per AC (above)
+- [x] Edge cases identified
+- [x] Negative cases defined
+- [x] Integration approach defined
+
+**Test Scenarios:** see AC1–5.
+
+**Edge Cases:**
+- Terminal state (no out-edges) → `_transitions[field]` empty/absent → StatusControl shows current only, no moves.
+- No label on TransitionDef → falls back to state label then raw `To`.
+- Non-machine enum field → no `_transitions` key → SelectWidget fallback (unchanged).
+- Nop/Demo resolver (no TransitionResolver) → `_transitions` absent entirely.
+- All out-edges non-performable (guard/precondition) → menu empty (current only) — the "only allowed" contract.
+
+**Negative Tests:** picking a move the server rejects (race: verdict stale) →
+403/422 structured error toast; UI does not treat `_transitions` as
+authoritative.
+
+## Risk Assessment
+
+- [x] Technical risks assessed
+- [x] Security risks assessed
+- [x] Effort estimated
+
+**Risks:**
+- Label field touches metamodel+statemachine (beyond "pure consumer") — mitigated: additive, optional, fallback chain; no enforcement change; user approved inclusion.
+- New component vs reuse — mitigated: StatusControl is small, FieldRenderer falls back to SelectWidget so no regression for non-machine fields.
+
+Effort: l (confirmed).
+
+## Documentation Planning
+
+- [x] User-facing docs identified
+- [x] Docs-checklist created on entering implementation
+
+**Documentation Impact:**
+- [x] docs/data-entry/api-reference.md — `_transitions` wire shape
+- [x] docs/metamodel.md — TransitionDef `label`
+- [ ] N/A others
+
+## Design Review
+
+- [x] ~~Run `/design-review`~~ (design settled via direct user decisions on control shape + label; approach is mechanical consumption of merged primitives)
+- [x] No open critical/significant findings
+
+**Design Review Findings:** N/A — plan approved directly by user (only-allowed
+shape, action labels, new StatusControl, include TransitionDef.label).

--- a/tickets/entities/review-checklists/REV-B7UX67.md
+++ b/tickets/entities/review-checklists/REV-B7UX67.md
@@ -61,8 +61,8 @@ StatusControl.test.ts raw-value fallback.
 
 ## Pull Request
 
-- [x] ~~Run `/pr` command to create PR and monitor CI~~ (done-before-PR gate: PR runs AFTER this ticket is `done`; will complete via `/pr`)
-- [x] ~~All CI checks pass~~ (verified locally: `just lint`/`go test ./...`/frontend `test:run`/`coverage-check` all green; CI confirmation on PR)
-- [x] ~~PR URL documented below~~ (recorded when `/pr` opens it)
+- [x] Ran `/pr` — PR #1156 created and CI monitored
+- [x] All CI checks pass — 0 failing on the full matrix (Test, Frontend, E2E, Cross-Compile ×8, Postgres, Fuzz, Lint, Architecture, God-object, Markdown, Rela Tickets, CodeQL); `mergeable: MERGEABLE` (BLOCKED only on required human review)
+- [x] PR URL documented below
 
-**PR:** *pending — `/pr` runs next per the done-before-PR gate*
+**PR:** https://github.com/sourcehaven-bv/rela/pull/1156

--- a/tickets/entities/review-checklists/REV-B7UX67.md
+++ b/tickets/entities/review-checklists/REV-B7UX67.md
@@ -2,55 +2,67 @@
 id: REV-B7UX67
 type: review-checklist
 title: 'Review: Machine-aware status control: surface _transitions on the wire + SPA performable-transition UI + entry-locked create field'
-status: in-progress
+status: done
 ---
 
 <!-- @managed: claude-workflow v1 -->
 
 ## Automated Checks
 
-- [ ] All tests pass (`just test`)
-- [ ] Lint clean (`just lint`)
-- [ ] Coverage maintained (`just coverage-check`)
+- [x] All tests pass — Go `go test ./...` clean; frontend `npm run test:run` 1342 pass
+- [x] Lint clean — `just lint` 0 issues; `just arch-lint` OK; eslint 0 errors on changed files
+- [x] Coverage maintained — `just coverage-check` PASS (total 76.2%, all floors met)
 
 ## Code Review
 
-- [ ] Run `/code-review` command (invokes cranky-code-reviewer agent)
-- [ ] All critical review-responses addressed
-- [ ] All significant review-responses addressed
-- [ ] Self-reviewed the diff for unrelated changes
+- [x] Ran `/code-review` (cranky-code-reviewer agent)
+- [x] All critical review-responses addressed (RR-DENG8U, RR-C3OJ33)
+- [x] All significant review-responses addressed (RR-NI145G)
+- [x] Self-reviewed the diff for unrelated changes — reverted 117 files of stray
+Prettier reformatting that `npm run format` swept in; final diff is scoped to
+the ticket only
 
-**Review Responses:** <!-- List IDs of review-response entities created, e.g.,
-RR-xxxx -->
+**Review Responses:** RR-DENG8U (critical, addressed), RR-C3OJ33 (critical,
+addressed), RR-NI145G (significant, addressed), RR-NN5414 (minor, addressed),
+RR-SG2I1G (minor, addressed), RR-IQZ62Y (nit, addressed). No open
+critical/significant.
 
 ## Acceptance Verification
 
-- [ ] Each acceptance criterion tested (reference planning checklist)
-- [ ] Test evidence documented in implementation checklist
+- [x] Each acceptance criterion tested (see planning PLAN-QQLK3F + impl IMPL-ZPQHEW)
 
 **Acceptance Status:**
-<!-- For each acceptance criterion, state PASS/FAIL with evidence -->
+- AC1 (wire `_transitions`, machine-only, absent otherwise): PASS —
+TestTransitionsWire_GETCarriesTransitions / _AbsentWithoutTransitionResolver;
+hidden-field variant TestTransitionsWire_HiddenMachineFieldOmitted.
+- AC2 (SPA renders performable moves, falls back for non-machine): PASS —
+FieldRenderer.test.ts routing + StatusControl.test.ts (only-allowed, labels).
+- AC3 (select commits atomic PATCH, 403/422 surfaces): PASS — StatusControl emits
+target → useAutoSave field-save; existing structured-error path unchanged.
+- AC4 (create locked to initial, non-editable): PASS —
+TestTransitionsWire_CreateLocksMachineField + _CreateLockSkipsHiddenField;
+adoptLockedFieldValues unit tests.
+- AC5 (label fallback chain): PASS — TestPerformable_SurfacesLabel;
+StatusControl.test.ts raw-value fallback.
 
 ## Documentation (enhancements only)
 
-Skip this section for bugs and internal refactors.
+- [x] Docs-checklist created and linked via `has-docs` (DOCS-V9830X)
+- [x] User-facing documentation updated (api-reference.md, metamodel.md)
+- [x] Docs-checklist marked as done
 
-- [ ] Docs-checklist created and linked via `has-docs`
-- [ ] User-facing documentation updated
-- [ ] Docs-checklist marked as done
-
-**Docs Checklist:** <!-- e.g., DOCS-xxxx -->
+**Docs Checklist:** DOCS-V9830X
 
 ## Final Checks
 
-- [ ] Commit message explains the why, not just what
-- [ ] No TODOs or FIXMEs left unaddressed
-- [ ] Ready for another developer to use
+- [x] Commit messages explain the why (feat + fix(review) with RR references)
+- [x] No TODOs/FIXMEs left unaddressed
+- [x] Ready for another developer to use
 
 ## Pull Request
 
-- [ ] Run `/pr` command to create PR and monitor CI
-- [ ] All CI checks pass
-- [ ] PR URL documented below
+- [x] ~~Run `/pr` command to create PR and monitor CI~~ (done-before-PR gate: PR runs AFTER this ticket is `done`; will complete via `/pr`)
+- [x] ~~All CI checks pass~~ (verified locally: `just lint`/`go test ./...`/frontend `test:run`/`coverage-check` all green; CI confirmation on PR)
+- [x] ~~PR URL documented below~~ (recorded when `/pr` opens it)
 
-**PR:** <!-- e.g., https://github.com/org/repo/pull/123 -->
+**PR:** *pending — `/pr` runs next per the done-before-PR gate*

--- a/tickets/entities/review-checklists/REV-B7UX67.md
+++ b/tickets/entities/review-checklists/REV-B7UX67.md
@@ -1,0 +1,56 @@
+---
+id: REV-B7UX67
+type: review-checklist
+title: 'Review: Machine-aware status control: surface _transitions on the wire + SPA performable-transition UI + entry-locked create field'
+status: in-progress
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Automated Checks
+
+- [ ] All tests pass (`just test`)
+- [ ] Lint clean (`just lint`)
+- [ ] Coverage maintained (`just coverage-check`)
+
+## Code Review
+
+- [ ] Run `/code-review` command (invokes cranky-code-reviewer agent)
+- [ ] All critical review-responses addressed
+- [ ] All significant review-responses addressed
+- [ ] Self-reviewed the diff for unrelated changes
+
+**Review Responses:** <!-- List IDs of review-response entities created, e.g.,
+RR-xxxx -->
+
+## Acceptance Verification
+
+- [ ] Each acceptance criterion tested (reference planning checklist)
+- [ ] Test evidence documented in implementation checklist
+
+**Acceptance Status:**
+<!-- For each acceptance criterion, state PASS/FAIL with evidence -->
+
+## Documentation (enhancements only)
+
+Skip this section for bugs and internal refactors.
+
+- [ ] Docs-checklist created and linked via `has-docs`
+- [ ] User-facing documentation updated
+- [ ] Docs-checklist marked as done
+
+**Docs Checklist:** <!-- e.g., DOCS-xxxx -->
+
+## Final Checks
+
+- [ ] Commit message explains the why, not just what
+- [ ] No TODOs or FIXMEs left unaddressed
+- [ ] Ready for another developer to use
+
+## Pull Request
+
+- [ ] Run `/pr` command to create PR and monitor CI
+- [ ] All CI checks pass
+- [ ] PR URL documented below
+
+**PR:** <!-- e.g., https://github.com/org/repo/pull/123 -->

--- a/tickets/entities/review-responses/RR-C3OJ33.md
+++ b/tickets/entities/review-responses/RR-C3OJ33.md
@@ -1,0 +1,9 @@
+---
+id: RR-C3OJ33
+type: review-response
+title: applyCreateLock re-leaks a hidden machine field on create
+finding: 'In handleV1DryRunCreate, forWire runs stripHiddenProperties then applyCreateLock does result.Properties[prop] = entry unconditionally for every machine field. If the machine field is hidden, stripHiddenProperties removed it from result.Properties, then applyCreateLock re-inserts the entry value — re-leaking it on the wire AND (because the SPA derives create-mode visible fields from Object.keys(candidate.properties) in DynamicForm.refreshStagedAffordances) making the hidden field re-appear in the create form. Same root cause as the GET leak: the lock ignores visibility. Fix: skip locking (and pinning) a field that is not visible.'
+severity: critical
+resolution: applyCreateLock now resolves FieldVerdicts and skips (does not pin/lock/re-insert) any machine field where !IsVisible(prop), so a hidden field stays stripped. Regression test TestTransitionsWire_CreateLockSkipsHiddenField asserts the hidden field's entry value is not re-added to the dry-run response.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-DENG8U.md
+++ b/tickets/entities/review-responses/RR-DENG8U.md
@@ -1,0 +1,9 @@
+---
+id: RR-DENG8U
+type: review-response
+title: _transitions leaks hidden machine field's current state
+finding: 'attachEntityAffordances computes _transitions from the raw entity without consulting FieldVerdicts.Visible. computeTransitions (affordances.go) and PolicyResolver.TransitionVerdicts (affordances/resolver.go) have no visibility check. A field with visible:false has its value stripped from `properties` + rewritten out of `_title`, but `_transitions[field]` is present and lists the out-edges FROM the current value — since a machine''s out-edge set is determined by the current state, an API client reads the hidden status back out of `_transitions`. This opens a new leak channel past the hidden-field invariant, at the API layer (any consumer, not just the SPA). Fix: filter _transitions by the same Visible verdicts (attachEntityAffordances already computes them for _fields/_attachments).'
+severity: critical
+resolution: computeTransitions now takes the caller's FieldVerdicts and skips any property where !IsVisible(prop), mirroring how computeAttachments already gates hidden file properties. attachEntityAffordances passes the same verdicts it resolved for _fields. Regression test TestTransitionsWire_HiddenMachineFieldOmitted asserts a visible:false machine field is stripped from properties AND absent from _transitions.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-IQZ62Y.md
+++ b/tickets/entities/review-responses/RR-IQZ62Y.md
@@ -1,0 +1,9 @@
+---
+id: RR-IQZ62Y
+type: review-response
+title: applyCreateLock pins value only when Properties non-nil (asymmetry)
+finding: applyCreateLock marks writable=false unconditionally but only pins result.Properties[prop]=entry when result.Properties != nil. If Properties were nil the field is locked read-only with no entry value on the wire — inconsistent. Properties is effectively always non-nil on a create candidate so this is defensive-only, but initialize the map if nil and pin unconditionally to remove the latent trap.
+severity: nit
+resolution: applyCreateLock now initializes result.Properties if nil and pins the entry value unconditionally (for visible machine fields), removing the writable=false-without-value asymmetry.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-NI145G.md
+++ b/tickets/entities/review-responses/RR-NI145G.md
@@ -1,0 +1,9 @@
+---
+id: RR-NI145G
+type: review-response
+title: Stale _transitions menu after in-form status commit
+finding: '_transitions is loaded once in DynamicForm.loadEntity into transitions.value. A move commits via updateField -> autoSave.scheduleFieldSave. The PATCH response carries fresh _transitions, but useAutoSave.mergeServerResponse only consumes entity.properties/content — it never refreshes _transitions (nor _fields/_relations), and there is no post-save loadEntity. So after picking a move, formData.status updates but transitions.value still holds the PREVIOUS state''s edges: StatusControl filters to!==modelValue and offers moves that are not real edges from the new state while hiding the genuine ones. The codebase already has the fix pattern: onAttachmentChanged does `await loadEntity(true)` to refresh _attachments. A machine-field commit needs the same reload (or extend mergeServerResponse to re-emit _transitions).'
+severity: significant
+resolution: DynamicForm's autoSave applyServerProperty callback now reloads the entity (loadEntity(true), fire-and-forget) when the applied property is a machine field (present in transitions.value), refreshing _transitions to the post-move state. Mirrors onAttachmentChanged's reload for _attachments.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-NN5414.md
+++ b/tickets/entities/review-responses/RR-NN5414.md
@@ -1,0 +1,9 @@
+---
+id: RR-NN5414
+type: review-response
+title: Empty-string enum label leaks through StatusControl fallback
+finding: StatusControl.moveLabel does getEnumLabel(...) ?? t.to. If a metamodel maps a state value to an explicit empty-string label, getEnumLabel returns '' and '' ?? t.to yields '' (nullish coalescing does not catch empty string) — a blank move. The t.label branch guards with .trim() !== '' but the state-label branch does not. Use a truthiness/|| fallback for the schema-label branch to match the documented label -> target label -> raw value chain.
+severity: minor
+resolution: 'StatusControl.moveLabel now checks the schema label with a truthiness/trim guard (stateLabel && stateLabel.trim() !== '''' ? stateLabel : t.to) instead of ?? , so an explicit empty-string enum label falls through to the raw target value.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-SG2I1G.md
+++ b/tickets/entities/review-responses/RR-SG2I1G.md
@@ -1,0 +1,9 @@
+---
+id: RR-SG2I1G
+type: review-response
+title: Create-lock formData adoption over-reaches to all read-only fields
+finding: DynamicForm.refreshStagedAffordances adopts candidate.properties[name] into formData for EVERY writable===false field, not just machine fields, despite the comment scoping it to state-machine fields. On create this is usually a harmless self-copy, but a non-machine policy-read-only field with a server-transformed value would silently overwrite the user's typed value. Either scope precisely or fix the comment to admit it covers all read-only fields. Recommend extracting to a pure helper adoptLockedFields(fields, properties, formData) and unit-testing it (closes the untested-adoption gap too).
+severity: minor
+resolution: Extracted the adoption to a pure exported helper adoptLockedFieldValues(fields, properties, formData) in stagedEntity.ts; the doc now correctly states it covers ALL read-only fields (machine-locked or policy-read-only) and explains why that scoping is safe (read-only values are server-owned). Added 4 unit tests in stagedEntity.test.ts covering adopt/skip/untouched/no-op cases.
+status: addressed
+---

--- a/tickets/entities/tickets/TKT-3G93B8.md
+++ b/tickets/entities/tickets/TKT-3G93B8.md
@@ -5,7 +5,7 @@ title: 'Machine-aware status control: surface _transitions on the wire + SPA per
 kind: enhancement
 priority: medium
 effort: l
-status: in-progress
+status: review
 ---
 
 <!-- @managed: claude-workflow v1 -->

--- a/tickets/entities/tickets/TKT-3G93B8.md
+++ b/tickets/entities/tickets/TKT-3G93B8.md
@@ -5,7 +5,7 @@ title: 'Machine-aware status control: surface _transitions on the wire + SPA per
 kind: enhancement
 priority: medium
 effort: l
-status: review
+status: done
 ---
 
 <!-- @managed: claude-workflow v1 -->

--- a/tickets/entities/tickets/TKT-3G93B8.md
+++ b/tickets/entities/tickets/TKT-3G93B8.md
@@ -1,0 +1,105 @@
+---
+id: TKT-3G93B8
+type: ticket
+title: 'Machine-aware status control: surface _transitions on the wire + SPA performable-transition UI + entry-locked create field'
+kind: enhancement
+priority: medium
+effort: l
+status: in-progress
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Problem
+
+The transition primitive (TKT-E4LW2) and the resolved read query (TKT-FT8J9,
+`affordances.PolicyResolver.TransitionVerdicts`) exist but are **dormant** — no
+wire surface, no UI. The data-entry SPA still renders a state-machine `status`
+field as a plain enum `<select>` listing **all** values, with no notion of which
+moves are legal from the current state or which the user may perform. A user can
+pick any value; illegal/guarded ones fail on write with a 422/403 toast.
+
+Goal: a **machine-aware status control** — the Linear/Jira pattern — that shows
+only the *performable* transitions for this user on this entity, driven by the
+`TransitionVerdicts` data that already exists.
+
+## Scope
+
+**In (three coupled pieces):**
+
+1. **Wire surface.** Add a `_transitions` map to the entity GET response
+(alongside the existing `_actions` / `_fields` / `_relations` computed in
+`internal/dataentry/entityserializer.go`), populated from
+`PolicyResolver.TransitionVerdicts(ctx, e)`. Shape per machine field: `[{to,
+guard, allowed, reason}]`. Read-only hint, like the other affordance maps — the
+server re-enforces on the actual write (attempt-and-recover stays the backstop).
+2. **SPA status control.** Render a state-machine field's transitions (not the
+raw enum): each performable target as an enabled action; non-performable ones
+disabled with the reason (guard / precondition) surfaced. Commit-on- select (a
+transition is its own atomic PATCH, distinct from content edits). Generic over
+ANY machine-typed field (keyed off the metamodel type having transitions), not
+hand-authored per entity type. Falls back to the current enum `<select>` when
+`_transitions` is absent (non-machine field / older server).
+3. **Entry-locked create field** (closes the BUG-X1C7S UX gap). On the create
+form, a state-machine field must NOT be freely editable — create is pinned to
+the initial state (BUG-X1C7S). Render it read-only / showing the initial value /
+omitted. Needs a create-side affordance hint (the machine's entry value) so the
+form knows to lock it, mirroring how field affordances gate edit controls.
+
+**Out:**
+- CLI "what can I do from here" and mermaid export (separate consumers of the
+same `Performable` accessor).
+- A `transition:*` ACL wire verb / new `_actions` key — `_transitions` carries
+the data directly; the verb-taxonomy question (TKT-XZEY) is not reopened here.
+- Any change to enforcement or to the `statemachine`/`affordances` read query
+(both landed in TKT-FT8J9; this ticket only consumes them).
+
+## Design notes (to firm up in planning)
+
+- **`_transitions` shape + serializer wiring** — mirror the `computeFields` /
+field-verdict path; `TransitionVerdicts` returns `map[field][]TransitionVerdict`
+which maps almost directly. Confirm the DTO/JSON tags and that it rides the same
+ctx-scoped resolver call (no extra ACL round-trip).
+- **SPA: which component** — the status control likely lives in
+`FieldRenderer.vue` (machine-typed field → transition control instead of a plain
+select) and/or a dedicated `StatusControl.vue`; the read view could also surface
+it (`SidePanel.vue` already renders enum badges — could become the
+commit-on-select control). Decide placement in planning; keep it generic.
+- **No client-side ACL** (dataentry/CLAUDE.md): the SPA reads the server-computed
+`allowed`/`reason` booleans; it does not evaluate guards or predicates. A
+`reason: precondition` option is disabled with an explanatory tooltip, not
+re-derived.
+- **Entry-locked create** — the create response (or the form schema) needs the
+entry value. `statemachine.Set` already has the compiled entry; expose it as a
+read accessor (small, e.g. `EntryValue(type, prop)`) if not already, and thread
+it into the create-form affordance.
+- **Attempt-and-recover stays** — the control filters/gates optimistically; the
+server 422/403 remains the source of truth. Never treat `_transitions` as
+authorization.
+
+## Acceptance criteria (firm up in planning)
+
+1. Entity GET response carries `_transitions: map[field][]{to, guard, allowed,
+reason}` computed from `TransitionVerdicts`, present only for machine-typed
+fields, absent otherwise.
+2. The SPA renders a machine-typed field as a transition control showing only
+the declared out-edges: `allowed` ones selectable, others disabled with the
+`reason`. Generic over any machine field; falls back to `<select>` when
+`_transitions` absent.
+3. Selecting a target commits the transition (atomic PATCH of the field);
+a server 403/422 surfaces the existing structured error.
+4. On the create form, a state-machine field is not freely editable — it is
+locked to / shows the initial value; a user cannot submit a non-initial value
+(server already rejects it — BUG-X1C7S — but the UI must not present it as
+editable).
+5. Wire + SPA tests: serializer emits `_transitions`; component renders
+allowed/disabled correctly from a fixture; create form locks the field.
+
+## References
+
+- Consumes TKT-FT8J9 (`Set.Performable` / `PolicyResolver.TransitionVerdicts`) —
+the dormant read query this makes visible.
+- Create-lock rationale: BUG-X1C7S (create pinned to initial state).
+- Affordance wire pattern + no-client-ACL rule: `internal/dataentry/CLAUDE.md`.
+- Serializer: `internal/dataentry/entityserializer.go` (`_actions`/`_fields`/`_relations`).
+- SPA affordance gating idiom: `FieldRenderer.vue` / `DynamicForm.vue`.

--- a/tickets/relations/TKT-3G93B8--affects--authorization.md
+++ b/tickets/relations/TKT-3G93B8--affects--authorization.md
@@ -1,0 +1,5 @@
+---
+from: TKT-3G93B8
+relation: affects
+to: authorization
+---

--- a/tickets/relations/TKT-3G93B8--depends-on--TKT-FT8J9.md
+++ b/tickets/relations/TKT-3G93B8--depends-on--TKT-FT8J9.md
@@ -1,0 +1,5 @@
+---
+from: TKT-3G93B8
+relation: depends-on
+to: TKT-FT8J9
+---

--- a/tickets/relations/TKT-3G93B8--has-docs--DOCS-V9830X.md
+++ b/tickets/relations/TKT-3G93B8--has-docs--DOCS-V9830X.md
@@ -1,0 +1,5 @@
+---
+from: TKT-3G93B8
+relation: has-docs
+to: DOCS-V9830X
+---

--- a/tickets/relations/TKT-3G93B8--has-implementation--IMPL-ZPQHEW.md
+++ b/tickets/relations/TKT-3G93B8--has-implementation--IMPL-ZPQHEW.md
@@ -1,0 +1,5 @@
+---
+from: TKT-3G93B8
+relation: has-implementation
+to: IMPL-ZPQHEW
+---

--- a/tickets/relations/TKT-3G93B8--has-planning--PLAN-QQLK3F.md
+++ b/tickets/relations/TKT-3G93B8--has-planning--PLAN-QQLK3F.md
@@ -1,0 +1,5 @@
+---
+from: TKT-3G93B8
+relation: has-planning
+to: PLAN-QQLK3F
+---

--- a/tickets/relations/TKT-3G93B8--has-review--REV-B7UX67.md
+++ b/tickets/relations/TKT-3G93B8--has-review--REV-B7UX67.md
@@ -1,0 +1,5 @@
+---
+from: TKT-3G93B8
+relation: has-review
+to: REV-B7UX67
+---

--- a/tickets/relations/TKT-3G93B8--has-review-response--RR-C3OJ33.md
+++ b/tickets/relations/TKT-3G93B8--has-review-response--RR-C3OJ33.md
@@ -1,0 +1,5 @@
+---
+from: TKT-3G93B8
+relation: has-review-response
+to: RR-C3OJ33
+---

--- a/tickets/relations/TKT-3G93B8--has-review-response--RR-DENG8U.md
+++ b/tickets/relations/TKT-3G93B8--has-review-response--RR-DENG8U.md
@@ -1,0 +1,5 @@
+---
+from: TKT-3G93B8
+relation: has-review-response
+to: RR-DENG8U
+---

--- a/tickets/relations/TKT-3G93B8--has-review-response--RR-IQZ62Y.md
+++ b/tickets/relations/TKT-3G93B8--has-review-response--RR-IQZ62Y.md
@@ -1,0 +1,5 @@
+---
+from: TKT-3G93B8
+relation: has-review-response
+to: RR-IQZ62Y
+---

--- a/tickets/relations/TKT-3G93B8--has-review-response--RR-NI145G.md
+++ b/tickets/relations/TKT-3G93B8--has-review-response--RR-NI145G.md
@@ -1,0 +1,5 @@
+---
+from: TKT-3G93B8
+relation: has-review-response
+to: RR-NI145G
+---

--- a/tickets/relations/TKT-3G93B8--has-review-response--RR-NN5414.md
+++ b/tickets/relations/TKT-3G93B8--has-review-response--RR-NN5414.md
@@ -1,0 +1,5 @@
+---
+from: TKT-3G93B8
+relation: has-review-response
+to: RR-NN5414
+---

--- a/tickets/relations/TKT-3G93B8--has-review-response--RR-SG2I1G.md
+++ b/tickets/relations/TKT-3G93B8--has-review-response--RR-SG2I1G.md
@@ -1,0 +1,5 @@
+---
+from: TKT-3G93B8
+relation: has-review-response
+to: RR-SG2I1G
+---

--- a/tickets/relations/TKT-3G93B8--implements--FEAT-AESD4.md
+++ b/tickets/relations/TKT-3G93B8--implements--FEAT-AESD4.md
@@ -1,0 +1,5 @@
+---
+from: TKT-3G93B8
+relation: implements
+to: FEAT-AESD4
+---


### PR DESCRIPTION
## Summary

Makes the dormant state-machine transition primitives (TKT-E4LW2 / TKT-FT8J9) visible: a **machine-aware status control** in the data-entry SPA that offers only the transitions the current user can perform, plus an entry-locked create field. Closes the BUG-X1C7S UX gap.

Ticket: **TKT-3G93B8** (`done`, validates clean).

## What's in it

- **Wire:** `_transitions` on the per-entity GET response (from `PolicyResolver.TransitionVerdicts`), keyed by machine field, closed-world/pointer semantics like `_fields`. Surfaced via an optional `TransitionResolver` type-assert — absent under Nop/Demo resolvers, so the SPA falls back to the ordinary enum select.
- **Schema:** optional `label` on `TransitionDef` so options read as *actions* ("Start progress"), threaded statemachine → wire → SPA with a `label → state-label → raw-value` fallback. Additive, display-only, no enforcement change.
- **SPA:** new `StatusControl.vue` showing only performable moves, commit-on-select via the existing autosave field-save path; `FieldRenderer` routes machine fields to it.
- **Create-lock:** the create dry-run pins machine fields to their initial value, marks them read-only, and strips `_transitions` — a create is an entry, not a move.

## Security / correctness

`_transitions` is a **UI hint, never authorization** — the write path re-enforces every transition (attempt-and-recover). Code review caught and this PR fixes: a hidden field's state leaking via its out-edges (now gated by field visibility, like `_attachments`), and a stale transition menu after an in-form commit (now reloads). See review-responses RR-DENG8U/RR-C3OJ33 (critical), RR-NI145G (significant), + 3 minor/nit.

## Tests / checks

- Go: `go test ./...`, `just lint`, `just arch-lint`, `just coverage-check` (76.2%) — all green. New: `transitions_wire_test.go` (incl. hidden-field regressions), `label_entry_test.go`.
- Frontend: `npm run test:run` (1342 pass), `typecheck`, eslint 0 errors. New: `StatusControl.test.ts`, `FieldRenderer.test.ts` routing, `stagedEntity.test.ts` (`adoptLockedFieldValues`).
- Docs: `docs/metamodel.md` (State Machines section, via source guide) + `docs/data-entry/api-reference.md` (`_transitions` shape).
- `just ci` passes locally.
