### PR TITLE
fix: badge colors never resolve when a property's name differs from its custom-type name (BUG-28Y0Y2)

### DIFF
--- a/frontend/src/components/common/Badge.test.ts
+++ b/frontend/src/components/common/Badge.test.ts
@@ -82,6 +82,78 @@ describe('Badge', () => {
     })
   })
 
+  describe('custom-type keyed styles (BUG-28Y0Y2)', () => {
+    // The server keys the styles map by custom-type name, not property name.
+    function withCustomType() {
+      const schemaStore = useSchemaStore()
+      schemaStore.entityTypes = new Map([
+        ['ticket', { label: 'Ticket', properties: { status: { type: 'ticket-status' } } }],
+      ]) as never
+      schemaStore.customTypes = new Map([
+        ['ticket-status', { values: ['todo', 'doing', 'done'] }],
+      ]) as never
+      return schemaStore
+    }
+
+    it('resolves the color via the custom-type name when property ≠ type', () => {
+      const schemaStore = withCustomType()
+      schemaStore.styles = { 'ticket-status': { todo: 'badge-yellow' } }
+
+      const wrapper = mount(Badge, {
+        props: { value: 'todo', property: 'status' },
+      })
+
+      expect(wrapper.find('.badge').classes()).toContain('badge--yellow')
+    })
+
+    it('prefers the type-keyed styles over property-keyed ones', () => {
+      const schemaStore = withCustomType()
+      schemaStore.styles = {
+        'ticket-status': { todo: 'badge-yellow' },
+        status: { todo: 'badge-red' },
+      }
+
+      const wrapper = mount(Badge, {
+        props: { value: 'todo', property: 'status' },
+      })
+
+      expect(wrapper.find('.badge').classes()).toContain('badge--yellow')
+    })
+
+    it('uses the entityType prop to disambiguate same-named properties', () => {
+      const schemaStore = useSchemaStore()
+      schemaStore.entityTypes = new Map([
+        ['bug', { label: 'Bug', properties: { status: { type: 'bug-status' } } }],
+        ['ticket', { label: 'Ticket', properties: { status: { type: 'ticket-status' } } }],
+      ]) as never
+      schemaStore.customTypes = new Map([
+        ['bug-status', { values: ['open'] }],
+        ['ticket-status', { values: ['open'] }],
+      ]) as never
+      schemaStore.styles = {
+        'bug-status': { open: 'badge-red' },
+        'ticket-status': { open: 'badge-blue' },
+      }
+
+      const wrapper = mount(Badge, {
+        props: { value: 'open', property: 'status', entityType: 'ticket' },
+      })
+
+      expect(wrapper.find('.badge').classes()).toContain('badge--blue')
+    })
+
+    it('still normalizes the value when resolving through the type key', () => {
+      const schemaStore = withCustomType()
+      schemaStore.styles = { 'ticket-status': { in_progress: 'badge-orange' } }
+
+      const wrapper = mount(Badge, {
+        props: { value: 'In Progress', property: 'status' },
+      })
+
+      expect(wrapper.find('.badge').classes()).toContain('badge--orange')
+    })
+  })
+
   describe('fallback color', () => {
     it('uses gray class for unknown values', () => {
       const wrapper = mount(Badge, {

--- a/frontend/src/components/common/Badge.vue
+++ b/frontend/src/components/common/Badge.vue
@@ -6,7 +6,10 @@ import type { EntityType } from '@/types'
 const props = defineProps<{
   value: string
   property?: string
-  entityType?: EntityType
+  // Accepts a type-name string OR a resolved EntityType, matching the schema
+  // store's resolution API — widget call sites hold the name, list/kanban
+  // call sites hold the object.
+  entityType?: string | EntityType
 }>()
 
 const schemaStore = useSchemaStore()
@@ -23,17 +26,20 @@ const badgeClassNames: Record<string, string> = {
   'badge-yellow': 'badge--yellow',
 }
 
-// Look up style by (property, value). The cross-property fallback that
-// scanned every styled property for a value match was removed (RR-UD2D):
-// it produced non-deterministic colours when a value (e.g. 'open') was
-// styled under multiple properties. Audited consumers all pass an
-// explicit :property=. A missing property -> the default gray; that's
-// the correct "no styling configured" answer.
+// Look up style by (property, value). The server keys the styles map by
+// custom-type name, so resolution goes through the schema store's
+// stylesForProperty (property -> its custom type -> styles), with a
+// property-name fallback. The cross-property fallback that scanned every
+// styled property for a value match was removed (RR-UD2D): it produced
+// non-deterministic colours when a value (e.g. 'open') was styled under
+// multiple properties. Audited consumers all pass an explicit :property=.
+// A missing property -> the default gray; that's the correct "no styling
+// configured" answer.
 const badgeClass = computed(() => {
   if (!props.property) return 'badge--gray'
   // Normalize: lowercase, spaces to underscores (keep underscores as-is)
   const valueKey = props.value.toLowerCase().replace(/\s/g, '_')
-  const propStyles = schemaStore.styles[props.property]
+  const propStyles = schemaStore.stylesForProperty(props.property, props.entityType)
   if (propStyles && propStyles[valueKey]) {
     return badgeClassNames[propStyles[valueKey]] || 'badge--gray'
   }

--- a/frontend/src/stores/schema.test.ts
+++ b/frontend/src/stores/schema.test.ts
@@ -378,4 +378,85 @@ describe('Schema Store', () => {
       expect(store.getEnumLabel('x', 'status')).toBe('Bug X')
     })
   })
+
+  describe('stylesForProperty', () => {
+    // The server keys `styles` by custom-type name (buildStyleMap /
+    // validateStyles), so resolution must go property -> custom type -> styles.
+    it('resolves styles via the custom-type name when property ≠ type (BUG-28Y0Y2)', () => {
+      const store = useSchemaStore()
+      store.entityTypes = new Map([
+        ['ticket', { label: 'Ticket', properties: { status: { type: 'ticket-status' } } }],
+      ]) as never
+      store.customTypes = new Map([['ticket-status', { values: ['todo', 'doing'] }]]) as never
+      store.styles = { 'ticket-status': { todo: 'badge-yellow' } }
+      expect(store.stylesForProperty('status')).toEqual({ todo: 'badge-yellow' })
+    })
+
+    it('prefers the type-keyed entry over a property-keyed one', () => {
+      const store = useSchemaStore()
+      store.entityTypes = new Map([
+        ['ticket', { label: 'Ticket', properties: { status: { type: 'ticket-status' } } }],
+      ]) as never
+      store.customTypes = new Map([['ticket-status', { values: ['todo'] }]]) as never
+      store.styles = {
+        'ticket-status': { todo: 'badge-yellow' },
+        status: { todo: 'badge-red' },
+      }
+      expect(store.stylesForProperty('status')).toEqual({ todo: 'badge-yellow' })
+    })
+
+    it('resolves a TYPE name passed as the property (EntityDetail view sections pass PropType)', () => {
+      const store = useSchemaStore()
+      store.entityTypes = new Map([
+        ['ticket', { label: 'Ticket', properties: { status: { type: 'ticket-status' } } }],
+      ]) as never
+      store.customTypes = new Map([['ticket-status', { values: ['todo'] }]]) as never
+      store.styles = { 'ticket-status': { todo: 'badge-yellow' } }
+      // No property is *named* ticket-status; the direct-key fallback must hit.
+      expect(store.stylesForProperty('ticket-status')).toEqual({ todo: 'badge-yellow' })
+    })
+
+    it('falls back to the property name when the property has no custom type', () => {
+      const store = useSchemaStore()
+      store.entityTypes = new Map([
+        ['ticket', { label: 'Ticket', properties: { status: { type: 'enum', values: ['open'] } } }],
+      ]) as never
+      store.styles = { status: { open: 'badge-blue' } }
+      expect(store.stylesForProperty('status')).toEqual({ open: 'badge-blue' })
+    })
+
+    it('disambiguates via the given entity type when property types differ across entities', () => {
+      const store = useSchemaStore()
+      store.entityTypes = new Map([
+        ['bug', { label: 'Bug', properties: { status: { type: 'bug-status' } } }],
+        ['ticket', { label: 'Ticket', properties: { status: { type: 'ticket-status' } } }],
+      ]) as never
+      store.customTypes = new Map([
+        ['bug-status', { values: ['open'] }],
+        ['ticket-status', { values: ['open'] }],
+      ]) as never
+      store.styles = {
+        'bug-status': { open: 'badge-red' },
+        'ticket-status': { open: 'badge-blue' },
+      }
+      expect(store.stylesForProperty('status', 'ticket')).toEqual({ open: 'badge-blue' })
+      // Without a disambiguator the first-inserted type wins (documented tie-break).
+      expect(store.stylesForProperty('status')).toEqual({ open: 'badge-red' })
+    })
+
+    it('resolves relation-type properties too', () => {
+      const store = useSchemaStore()
+      store.relationTypes = new Map([
+        ['blocks', { label: 'blocks', properties: { weight: { type: 'weight_t' } } }],
+      ]) as never
+      store.customTypes = new Map([['weight_t', { values: ['high'] }]]) as never
+      store.styles = { weight_t: { high: 'badge-orange' } }
+      expect(store.stylesForProperty('weight')).toEqual({ high: 'badge-orange' })
+    })
+
+    it('returns undefined when nothing is styled', () => {
+      const store = useSchemaStore()
+      expect(store.stylesForProperty('status')).toBeUndefined()
+    })
+  })
 })

--- a/frontend/src/stores/schema.ts
+++ b/frontend/src/stores/schema.ts
@@ -101,13 +101,27 @@ export const useSchemaStore = defineStore('schema', () => {
     property: string,
     entityType?: string | EntityType,
   ): Record<string, string> | undefined {
-    const fromDef = (def?: PropertyDef) => {
+    return scanPropertyDefs(property, entityType, (def) => {
       if (!def) return undefined
       if (def.labels) return def.labels
       // Property references a custom type → labels live on that custom type.
       const ct = def.type ? customTypes.value.get(def.type) : undefined
       return ct?.labels
-    }
+    })
+  }
+
+  // Shared resolution scaffold for the per-property lookups above/below:
+  // walk the property defs named `property` (given entityType first, then
+  // entity then relation types) and return the first def the extractor
+  // accepts. A def the extractor rejects does NOT stop the scan — first-wins
+  // is on "first def that yields a result", which is what makes the
+  // labelsForProperty tie-break documented above hold identically for every
+  // extractor sharing this walk.
+  function scanPropertyDefs<T>(
+    property: string,
+    entityType: string | EntityType | undefined,
+    fromDef: (def?: PropertyDef) => T | undefined,
+  ): T | undefined {
     if (entityType) {
       const et = typeof entityType === 'string' ? entityTypes.value.get(entityType) : entityType
       const hit = fromDef(et?.properties?.[property])
@@ -123,6 +137,36 @@ export const useSchemaStore = defineStore('schema', () => {
     }
     return undefined
   }
+
+  // Resolve the custom-type name a property refers to, or undefined when the
+  // property is an inline enum / built-in type.
+  function customTypeNameForProperty(
+    property: string,
+    entityType?: string | EntityType,
+  ): string | undefined {
+    return scanPropertyDefs(property, entityType, (def) =>
+      def?.type && customTypes.value.has(def.type) ? def.type : undefined,
+    )
+  }
+
+  // Resolve the badge style map (value → badge class) for a property. The
+  // server keys `styles` by CUSTOM-TYPE name (buildStyleMap; validateStyles
+  // rejects other keys), so resolve the property to its custom type first.
+  // The direct-key fallback is load-bearing, not defensive: EntityDetail's
+  // view sections pass the property's TYPE name as `property` (sections.go
+  // populates PropType from the def), which is already the styles key and
+  // matches no property def — the fallback is the only path that resolves
+  // it. It also covers a property whose name coincides with its type.
+  const stylesForProperty = computed(
+    () =>
+      (
+        property: string,
+        entityType?: string | EntityType,
+      ): Record<string, string> | undefined => {
+        const typeName = customTypeNameForProperty(property, entityType)
+        return (typeName ? styles.value[typeName] : undefined) ?? styles.value[property]
+      },
+  )
 
   // Return the display label for an enum value, or undefined when no label is
   // configured (caller falls back to the raw value). Display-only: the value
@@ -277,6 +321,7 @@ export const useSchemaStore = defineStore('schema', () => {
     getAction,
     getEnumLabel,
     resolveOptionLabels,
+    stylesForProperty,
     entityTypeList,
     relationTypeList,
 

--- a/frontend/src/widgets/MultiSelectWidget.vue
+++ b/frontend/src/widgets/MultiSelectWidget.vue
@@ -53,7 +53,13 @@ function onUpdate(value: string[]) {
       {{ arrayValue.join(', ') }}
     </span>
     <template v-else>
-      <Badge v-for="v in arrayValue" :key="v" :value="v" :property="propertyName" />
+      <Badge
+        v-for="v in arrayValue"
+        :key="v"
+        :value="v"
+        :property="propertyName"
+        :entity-type="entityType"
+      />
     </template>
   </span>
   <TagSelect

--- a/frontend/src/widgets/SelectWidget.vue
+++ b/frontend/src/widgets/SelectWidget.vue
@@ -86,6 +86,7 @@ function onChange(event: Event) {
     v-if="mode === 'display' && safeStringValue"
     :value="safeStringValue"
     :property="propertyName"
+    :entity-type="entityType"
   />
   <span v-else-if="mode === 'display'" class="display-value" />
   <div v-else class="select-widget">

--- a/tickets/entities/automated-measures/badge-style-type-key-test.md
+++ b/tickets/entities/automated-measures/badge-style-type-key-test.md
@@ -1,0 +1,15 @@
+---
+id: badge-style-type-key-test
+type: automated-measure
+title: 'Test: Badge resolves styles via the property''s custom-type name (property ≠ type)'
+description: 'Badge.test.ts case where the property name differs from its custom-type name (e.g. property status of type ticket-status): asserts the configured color class is applied instead of badge--gray, plus the property-name fallback for inline enums.'
+kind: test
+location: frontend/src/components/common/Badge.test.ts, frontend/src/stores/schema.test.ts
+status: active
+---
+
+Unit test in `Badge.test.ts` (plus schema-store coverage for `styleFor`) where
+the property name differs from its custom-type name — e.g. property `status` of
+type `ticket-status` with `styles: { ticket-status: ... }` — asserting the badge
+gets the configured color class, not `badge--gray`. Also covers the fallback
+path where styles are keyed directly by property name (inline enums).

--- a/tickets/entities/bug-analysis-checklists/BUGA-3L86DI.md
+++ b/tickets/entities/bug-analysis-checklists/BUGA-3L86DI.md
@@ -1,0 +1,60 @@
+---
+id: BUGA-3L86DI
+type: bug-analysis-checklist
+title: 'Analysis: Badge colors never resolve when a property''s name differs from its custom-type name'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Reproduction
+
+- [x] Bug reproduced locally
+- [x] Minimal reproduction steps documented
+- [x] Environment/conditions noted
+
+Confirmed by code inspection on `develop`:
+
+- `internal/dataentry/app.go:853-882` — `buildStyleMap` keys the map by **type name**: explicit entries iterate `cfg.Styles` (whose keys `internal/dataentryconfig/validate.go:1368` `validateStyles` requires to be metamodel types), and auto-assign iterates `meta.Types`. Emitted as `styles` on `/api/v1/_config` (`api_v1.go:1913`, `apiwire/v1/responses.go:191`).
+- `frontend/src/stores/schema.ts:204` — stored verbatim: `styles.value = configData.styles`.
+- `frontend/src/components/common/Badge.vue:36` — `schemaStore.styles[props.property]` indexes by **property name**; miss → `badge--gray`.
+
+Live repro: the in-tree `tickets/` project defines type `ticket_status`
+(metamodel.yaml:18) used by property `status` (metamodel.yaml:333), and
+`tickets/data-entry.yaml:6` styles `ticket_status:` — those badges render gray.
+Only Badge.vue reads `schemaStore.styles`, so this is the single broken
+consumer.
+
+## Root Cause
+
+- [x] Immediate cause identified (why1)
+- [x] Contributing factors found (why2-3)
+- [x] Systemic cause explored (why4-5)
+
+1. **why1**: Badge.vue looks up `styles[propertyName]` but the server keys the map by custom-type name; the lookup only hits when a property is named identically to its type.
+2. **why2**: The `styles` wire field is a bare `Record<string, Record<string, string>>` on both sides — the outer key's semantics (type name, enforced server-side by `validateStyles`) exist only in Go comments, so the SPA author plausibly assumed property names.
+3. **why3**: Badge's unit tests seed `schemaStore.styles` keyed by property names (`status`, `priority`), encoding the wrong assumption; no test wires a realistic `_config` payload (type-keyed) through to a rendered badge, and no e2e asserts badge colors, so the miss ships silently as cosmetic gray.
+
+## Fix Planning
+
+- [x] Fix approach determined
+- [x] Regression test planned
+- [x] Related areas checked for similar issues
+
+**Approach** (frontend-only): add `styleFor(property, value, entityType?)` to
+the schema store, mirroring `labelsForProperty`'s resolution (schema.ts:100):
+resolve the property def (entityType first, then first-wins scan of
+entity/relation types), take `def.type` when it names a custom type, and look up
+`styles[typeName]`; fall back to `styles[property]` (covers
+property-name==type-name configs and keeps existing tests meaningful). Badge.vue
+calls it instead of indexing `styles` directly. Server unchanged — its keying is
+validated and correct.
+
+**Regression test**: `badge-style-type-key-test` — Badge.test.ts case with
+property `status` of custom type `ticket-status`, styles keyed by
+`ticket-status`, asserting the configured class; plus
+type-key-wins-over-property-key and fallback cases.
+
+**Related areas**: grep shows Badge.vue is the only `schemaStore.styles`
+consumer; kanban/list/detail/side-panel all render through Badge, so one fix
+covers all surfaces.

--- a/tickets/entities/bugs/BUG-28Y0Y2.md
+++ b/tickets/entities/bugs/BUG-28Y0Y2.md
@@ -1,0 +1,51 @@
+---
+id: BUG-28Y0Y2
+type: bug
+title: Badge colors never resolve when a property's name differs from its custom-type name
+description: Badge.vue looks up styling by property name, but the server emits the styles map keyed by custom-type name. They only coincide when a property happens to be named identically to its type, so most enum/status badges render gray regardless of the configured styles.
+priority: medium
+effort: s
+why1: Badge.vue indexes the /_config styles map by property name, but buildStyleMap keys it by custom-type name (validated so by validateStyles), so the lookup misses whenever property name ≠ type name and falls back to gray.
+why2: The styles wire field is an untyped Record<string, Record<string, string>> on both sides; the outer key's semantics live only in Go comments and server-side validation, so the SPA consumer assumed property-name keys.
+why3: Badge's unit tests seed schemaStore.styles keyed by property names, encoding the wrong assumption, and no test or e2e wires a real type-keyed _config payload through to a rendered badge color, so the mismatch shipped as silent cosmetic gray.
+why4: 'No test wires a realistic server payload through to a rendered badge: frontend unit tests hand-construct store state instead of deriving fixtures from the wire contract, and no e2e asserts badge colors, so a key-semantics mismatch had no failing check anywhere.'
+why5: Cross-boundary wire contracts between the Go server and the TS SPA are informal duck-typed JSON maps whose key semantics live in comments and server-side validation only — nothing shared or generated makes a consumer's wrong assumption a compile- or CI-time failure.
+prevention: 'Regression tests (badge-style-type-key-test) pin the type-keyed resolution end-to-end: schema.test.ts covers stylesForProperty''s resolution/fallback/disambiguation and Badge.test.ts renders realistic type-keyed store state to CSS classes, so a future consumer assuming property-name keys fails CI. The styles-key contract is now documented at both ends (stylesForProperty comment references buildStyleMap/validateStyles).'
+status: done
+---
+
+## Summary
+
+Badge.vue looks up styling by **property name**, but the server emits the styles
+map keyed by **custom-type name**. They only coincide when a property happens to
+be named identically to its type, so in practice most enum/status badges render
+gray regardless of the configured `styles:`.
+
+## Where
+
+- **Server** (`internal/dataentry/app.go`, `buildStyleMap`) builds `StyleMap` keyed by type name (`cfg.Styles` is keyed by type; it also auto-assigns colors per custom type). Emitted on `/api/v1/_config` as `styles`.
+- **SPA** (`frontend/src/stores/schema.ts`) stores it verbatim: `styles.value = configData.styles` — a `Record<typeName, Record<value, cssClass>>`.
+- **SPA** (`frontend/src/components/common/Badge.vue`, ~L36): `const propStyles = schemaStore.styles[props.property]` — indexes by property name, not type name. Miss → `badge--gray`.
+
+## Repro
+
+Metamodel: `types: { ticket-status: {values: [todo, doing, ...]} }`, entity
+property `status: { type: ticket-status }`. Config: `styles: { ticket-status: {
+todo: yellow, ... } }` (valid — must be keyed by a defined type). GET any entity
+→ the status badge is gray. Confirmed the same in the in-tree `tickets/` project
+(`styles: ticket_status:`, property `status`) — its badges are gray too.
+
+## Impact
+
+Every badge across lists, kanban, detail view, and the new status control.
+Purely cosmetic (no data/security effect), but the `styles:` config is
+effectively dead for any type ≠ property naming.
+
+## Fix direction
+
+Resolve property → its custom-type name, then key styles by that type (falling
+back to the property name for inline enums the server may key by property). The
+schema store already has the exact pattern in `labelsForProperty`
+(`customTypes.value.get(def.type)`); add a sibling `styleFor(property, value,
+entityType)` and point Badge at it. One shared component, ~15 lines, plus a
+`Badge.test.ts` case where property ≠ type.

--- a/tickets/entities/implementation-checklists/IMPL-RAIF9B.md
+++ b/tickets/entities/implementation-checklists/IMPL-RAIF9B.md
@@ -1,0 +1,67 @@
+---
+id: IMPL-RAIF9B
+type: implementation-checklist
+title: 'Implementation: Badge colors never resolve when a property''s name differs from its custom-type name'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Development
+
+- [x] Unit tests written for new code
+- [x] Integration tests written (test full flow, not just units)
+- [x] Happy path implemented
+- [x] Edge cases from planning handled
+- [x] Error handling in place (errors surfaced, not swallowed)
+
+Changes (frontend-only, as planned):
+
+- `frontend/src/stores/schema.ts` — added `customTypeNameForProperty` (mirrors `labelsForProperty`'s resolution order and first-wins tie-break) and the exported `stylesForProperty(property, entityType?)` getter: type-keyed lookup first, property-name fallback.
+- `frontend/src/components/common/Badge.vue` — `badgeClass` resolves via `schemaStore.stylesForProperty(props.property, props.entityType)`; value normalization and gray fallback unchanged.
+- Tests: `schema.test.ts` +6 cases (type-key resolution, type-over-property precedence, property fallback, entityType disambiguation + documented first-wins tie-break, relation-type properties, unstyled → undefined); `Badge.test.ts` +4 cases (property ≠ type renders configured class, type key wins, entityType disambiguation, value normalization through the type key). The Badge cases are component-level integration: realistic type-keyed store state → rendered CSS class.
+
+Edge cases: no `property` prop → gray (unchanged); property without custom type
+(inline enum) → property-name fallback; same property name with different types
+across entity types → `entityType` disambiguates, else documented first-wins. No
+error paths added (pure lookup; miss → gray is the designed answer).
+
+## Test Quality
+
+- [x] Using fixture builders or factories for test data
+- [x] No hardcoded values in assertions when object is in scope
+- [x] Only specifying values that matter for the test
+- [x] Interpolated values constructed from objects, not hardcoded
+- [x] Property comparisons use original object, not hardcoded strings
+
+Followed the file's existing conventions (`withCustomType()` helper mirroring
+`withInlineLabel()`; minimal store state per case).
+
+## Manual Verification
+
+- [x] Feature manually tested end-to-end
+- [x] Each acceptance criterion verified with test scenario from planning
+- [x] Edge cases manually verified
+
+**Verification Evidence:**
+
+Built the SPA (`npm run build`) into the embedded bundle, built `rela-server`,
+ran it against the in-tree `tickets/` project (property `status` / type
+`ticket_status` — the repro case). `/api/v1/_config` confirmed `styles` keyed
+only by type names. Browser (puppeteer) on `/list/all_tickets`: 94 badges —
+badge--blue 17, badge--orange 23, badge--yellow 15, badge--purple 12,
+badge--green 22, badge--gray 5 (the grays are the *configured* `backlog: gray` /
+`wont-fix: gray` values). Screenshot verified visually: kind=Enhancement blue,
+status Done green, priority High orange, effort M yellow — matching
+`tickets/data-entry.yaml` `styles:`. Pre-fix these all rendered gray.
+
+## Quality
+
+- [x] Code follows project patterns (check similar code)
+- [x] Checked for DRY opportunities — resolution deliberately mirrors `labelsForProperty` rather than merging with it: labels resolve from per-def data (def.labels / ct.labels), styles from the flat server map — the two mechanisms the schema.ts comment already documents as separate. Shared `fromDef` shape kept, predicate differs.
+- [x] No security issues introduced
+- [x] No silent failures (errors logged AND returned)
+- [x] No debug code left behind
+
+`npm run test:run` 1339/1339 pass, `npm run typecheck` clean, `npm run lint` 0
+errors (89 pre-existing warnings).

--- a/tickets/entities/review-checklists/REV-UJBEGC.md
+++ b/tickets/entities/review-checklists/REV-UJBEGC.md
@@ -16,7 +16,8 @@ status: done
 `just test` + `just lint` (0 issues) + `just coverage-check` (package 50% /
 total 65% thresholds satisfied, total 76.1%) all passed. After the review fixes,
 the frontend suite re-ran green (1340 tests), typecheck clean, ESLint 0 errors,
-jscpd no new duplication; the review fixes touched no Go code.
+jscpd no new duplication; the review fixes touched no Go code. `just ci` passed
+end-to-end before push.
 
 ## Code Review
 
@@ -67,6 +68,4 @@ Skip this section for bugs and internal refactors.
 - [x] All CI checks pass
 - [x] PR URL documented below
 
-**PR:** in flight — /pr running now (done-gate requires the bug done +
-validation clean before the PR exists); URL recorded here as soon as it is open
-and CI is green.
+**PR:** https://github.com/sourcehaven-bv/rela/pull/1157

--- a/tickets/entities/review-checklists/REV-UJBEGC.md
+++ b/tickets/entities/review-checklists/REV-UJBEGC.md
@@ -1,0 +1,72 @@
+---
+id: REV-UJBEGC
+type: review-checklist
+title: 'Review: Badge colors never resolve when a property''s name differs from its custom-type name'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Automated Checks
+
+- [x] All tests pass (`just test`)
+- [x] Lint clean (`just lint`)
+- [x] Coverage maintained (`just coverage-check`)
+
+`just test` + `just lint` (0 issues) + `just coverage-check` (package 50% /
+total 65% thresholds satisfied, total 76.1%) all passed. After the review fixes,
+the frontend suite re-ran green (1340 tests), typecheck clean, ESLint 0 errors,
+jscpd no new duplication; the review fixes touched no Go code.
+
+## Code Review
+
+- [x] Run `/code-review` command (invokes cranky-code-reviewer agent)
+- [x] All critical review-responses addressed
+- [x] All significant review-responses addressed
+- [x] Self-reviewed the diff for unrelated changes
+
+**Review Responses:** RR-BTUN4L (significant, addressed), RR-OCXFPC
+(significant, addressed), RR-9J59FE (minor, addressed), RR-0VUEF6 (minor,
+addressed), RR-HOMQAU (nit, addressed), RR-7C1E3G (nit, wont-fix with reason).
+No critical findings.
+
+Notable: the reviewer's EntityDetail wiring suggestion (part of RR-BTUN4L) was
+investigated and rejected with evidence — those cells pass the property's TYPE
+name (`cell.propType`) as `:property`, which is already the styles key; the
+direct-key fallback resolves it and is now documented + test-pinned.
+
+## Acceptance Verification
+
+- [x] Each acceptance criterion tested (reference planning checklist)
+- [x] Test evidence documented in implementation checklist
+
+**Acceptance Status:**
+
+- Property ≠ type resolves configured color: PASS (Badge.test.ts + schema.test.ts cases; live browser check on tickets/ project — 94 badges colored per data-entry.yaml styles).
+- Property-name/direct-key fallback preserved: PASS (existing tests unchanged and green; new EntityDetail PropType pin test).
+- entityType disambiguation: PASS (store + component tests; widgets now forward entity-type).
+- No regression in labels/normalization/gray default: PASS (full suite 1340 green; RR-UD2D non-determinism guard untouched).
+
+## Documentation (enhancements only)
+
+Skip this section for bugs and internal refactors.
+
+- [x] ~~Docs-checklist created and linked via `has-docs`~~ (N/A: bug fix)
+- [x] ~~User-facing documentation updated~~ (N/A: behavior now matches the already-documented `styles:` config)
+- [x] ~~Docs-checklist marked as done~~ (N/A: bug fix)
+
+## Final Checks
+
+- [x] Commit message explains the why, not just what
+- [x] No TODOs or FIXMEs left unaddressed
+- [x] Ready for another developer to use
+
+## Pull Request
+
+- [x] Run `/pr` command to create PR and monitor CI
+- [x] All CI checks pass
+- [x] PR URL documented below
+
+**PR:** in flight — /pr running now (done-gate requires the bug done +
+validation clean before the PR exists); URL recorded here as soon as it is open
+and CI is green.

--- a/tickets/entities/review-responses/RR-0VUEF6.md
+++ b/tickets/entities/review-responses/RR-0VUEF6.md
@@ -1,0 +1,9 @@
+---
+id: RR-0VUEF6
+type: review-response
+title: stylesForProperty fallback comment misstated the fallback's role
+finding: Reviewer read the property-name fallback as effectively dead for server-authored data and asked for the comment to say it's defensive-only.
+severity: minor
+resolution: 'Investigation showed the opposite: the fallback is load-bearing — EntityDetail view sections pass the property''s TYPE name as :property (server PropType), which matches no property def and resolves only via the direct-key fallback. Comment rewritten to document that contract, and a schema.test.ts case pins it.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-7C1E3G.md
+++ b/tickets/entities/review-responses/RR-7C1E3G.md
@@ -1,0 +1,9 @@
+---
+id: RR-7C1E3G
+type: review-response
+title: PropertyDef.type TS union omits custom-type names
+finding: def.type is checked against customTypes at runtime, but the TS union for PropertyDef.type only lists built-in type names — an off-schema runtime value the code relies on.
+severity: nit
+reason: Pre-existing divergence that labelsForProperty already relies on identically; the fix inherits rather than introduces it. Widening PropertyDef.type or adding a customType field is a cross-cutting types cleanup out of scope for this cosmetic bug fix.
+status: wont-fix
+---

--- a/tickets/entities/review-responses/RR-9J59FE.md
+++ b/tickets/entities/review-responses/RR-9J59FE.md
@@ -1,0 +1,9 @@
+---
+id: RR-9J59FE
+type: review-response
+title: 'Badge test used `entityType: ''ticket'' as never` cast'
+finding: The disambiguation test passed a string entityType through a cast, exercising a path no real caller could use given the object-only prop type.
+severity: minor
+resolution: Cast removed after the prop was widened to string | EntityType; the string path is now a real, typed contract used by the widget call sites.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-BTUN4L.md
+++ b/tickets/entities/review-responses/RR-BTUN4L.md
@@ -1,0 +1,9 @@
+---
+id: RR-BTUN4L
+type: review-response
+title: Badge entityType disambiguator not wired at widget/detail call sites
+finding: Only EntityList/KanbanView pass :entity-type to Badge. SelectWidget/MultiSelectWidget receive entityType in WidgetProps but don't forward it, and EntityDetail's four Badge cells pass nothing — so same-named properties backed by different custom types fall to the arbitrary first-wins tie-break.
+severity: significant
+resolution: 'SelectWidget and MultiSelectWidget now forward :entity-type="entityType" to Badge. EntityDetail was investigated and deliberately NOT wired: its view-section cells pass cell.propType — the property''s TYPE name (sections.go populates PropType from pd.Type) — as :property, which is already the exact styles key; the store''s direct-key fallback resolves it, now documented in the stylesForProperty comment and pinned by a schema.test.ts case.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-HOMQAU.md
+++ b/tickets/entities/review-responses/RR-HOMQAU.md
@@ -1,0 +1,9 @@
+---
+id: RR-HOMQAU
+type: review-response
+title: customTypeNameForProperty duplicated labelsForProperty's scan scaffold
+finding: The entityType-first-then-entity-then-relation scan loop was copy-pasted; two copies would drift.
+severity: nit
+resolution: Extracted shared scanPropertyDefs<T>(property, entityType, fromDef) helper; both labelsForProperty and customTypeNameForProperty now use it, making the first-wins tie-break identical by construction.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-OCXFPC.md
+++ b/tickets/entities/review-responses/RR-OCXFPC.md
@@ -1,0 +1,9 @@
+---
+id: RR-OCXFPC
+type: review-response
+title: Badge entityType prop typed object-only, blocking string callers
+finding: 'stylesForProperty accepts string | EntityType, but Badge''s prop was entityType?: EntityType (object only). The widget/detail call sites hold the entity type as a string, so wiring them through would have required casts (the smell already visible as `as never` in tests).'
+severity: significant
+resolution: 'Badge''s prop widened to entityType?: string | EntityType with a comment explaining which call sites hold which shape; both stylesForProperty and getEnumLabel already accept the union. The test''s `as never` cast is gone.'
+status: addressed
+---

--- a/tickets/relations/BUG-28Y0Y2--adds-measure--badge-style-type-key-test.md
+++ b/tickets/relations/BUG-28Y0Y2--adds-measure--badge-style-type-key-test.md
@@ -1,0 +1,5 @@
+---
+from: BUG-28Y0Y2
+relation: adds-measure
+to: badge-style-type-key-test
+---

--- a/tickets/relations/BUG-28Y0Y2--affects--data-entry-ui.md
+++ b/tickets/relations/BUG-28Y0Y2--affects--data-entry-ui.md
@@ -1,0 +1,5 @@
+---
+from: BUG-28Y0Y2
+relation: affects
+to: data-entry-ui
+---

--- a/tickets/relations/BUG-28Y0Y2--fixes--FEAT-4OEJ.md
+++ b/tickets/relations/BUG-28Y0Y2--fixes--FEAT-4OEJ.md
@@ -1,0 +1,5 @@
+---
+from: BUG-28Y0Y2
+relation: fixes
+to: FEAT-4OEJ
+---

--- a/tickets/relations/BUG-28Y0Y2--has-bug-analysis--BUGA-3L86DI.md
+++ b/tickets/relations/BUG-28Y0Y2--has-bug-analysis--BUGA-3L86DI.md
@@ -1,0 +1,5 @@
+---
+from: BUG-28Y0Y2
+relation: has-bug-analysis
+to: BUGA-3L86DI
+---

--- a/tickets/relations/BUG-28Y0Y2--has-implementation--IMPL-RAIF9B.md
+++ b/tickets/relations/BUG-28Y0Y2--has-implementation--IMPL-RAIF9B.md
@@ -1,0 +1,5 @@
+---
+from: BUG-28Y0Y2
+relation: has-implementation
+to: IMPL-RAIF9B
+---

--- a/tickets/relations/BUG-28Y0Y2--has-review--REV-UJBEGC.md
+++ b/tickets/relations/BUG-28Y0Y2--has-review--REV-UJBEGC.md
@@ -1,0 +1,5 @@
+---
+from: BUG-28Y0Y2
+relation: has-review
+to: REV-UJBEGC
+---

--- a/tickets/relations/BUG-28Y0Y2--has-review-response--RR-0VUEF6.md
+++ b/tickets/relations/BUG-28Y0Y2--has-review-response--RR-0VUEF6.md
@@ -1,0 +1,5 @@
+---
+from: BUG-28Y0Y2
+relation: has-review-response
+to: RR-0VUEF6
+---

--- a/tickets/relations/BUG-28Y0Y2--has-review-response--RR-7C1E3G.md
+++ b/tickets/relations/BUG-28Y0Y2--has-review-response--RR-7C1E3G.md
@@ -1,0 +1,5 @@
+---
+from: BUG-28Y0Y2
+relation: has-review-response
+to: RR-7C1E3G
+---

--- a/tickets/relations/BUG-28Y0Y2--has-review-response--RR-9J59FE.md
+++ b/tickets/relations/BUG-28Y0Y2--has-review-response--RR-9J59FE.md
@@ -1,0 +1,5 @@
+---
+from: BUG-28Y0Y2
+relation: has-review-response
+to: RR-9J59FE
+---

--- a/tickets/relations/BUG-28Y0Y2--has-review-response--RR-BTUN4L.md
+++ b/tickets/relations/BUG-28Y0Y2--has-review-response--RR-BTUN4L.md
@@ -1,0 +1,5 @@
+---
+from: BUG-28Y0Y2
+relation: has-review-response
+to: RR-BTUN4L
+---

--- a/tickets/relations/BUG-28Y0Y2--has-review-response--RR-HOMQAU.md
+++ b/tickets/relations/BUG-28Y0Y2--has-review-response--RR-HOMQAU.md
@@ -1,0 +1,5 @@
+---
+from: BUG-28Y0Y2
+relation: has-review-response
+to: RR-HOMQAU
+---

--- a/tickets/relations/BUG-28Y0Y2--has-review-response--RR-OCXFPC.md
+++ b/tickets/relations/BUG-28Y0Y2--has-review-response--RR-OCXFPC.md
@@ -1,0 +1,5 @@
+---
+from: BUG-28Y0Y2
+relation: has-review-response
+to: RR-OCXFPC
+---


### PR DESCRIPTION
## Summary

The server keys the `/api/v1/_config` `styles` map by **custom-type name** (`buildStyleMap`; `validateStyles` rejects other keys), but `Badge.vue` indexed it by **property name** — so configured badge colors only applied when a property happened to share its type's name, and everything else rendered gray.

- `schema.ts`: new `stylesForProperty(property, entityType?)` getter resolves the property to its custom type (same resolution order and first-wins tie-break as `labelsForProperty`, via a shared `scanPropertyDefs` scaffold), with a direct-key fallback that is load-bearing for EntityDetail's view sections (they pass the TYPE name as `:property`).
- `Badge.vue`: resolves through the store getter; `entityType` prop widened to `string | EntityType` so string-holding call sites can disambiguate.
- `SelectWidget`/`MultiSelectWidget`: forward `:entity-type` to Badge.

## Verification

- 11 new unit tests (schema store resolution/fallback/disambiguation + Badge component rendering); full suite 1340 green, typecheck/lint clean, `just ci` passes.
- Manually verified against the in-tree `tickets/` project (property `status` / type `ticket_status`): badges across the list view now render the configured colors instead of gray.

Closes BUG-28Y0Y2 (tracker entities included in this PR).