### PR TITLE
feat: metamodel doc-fields + surface them in data-entry help (TKT-0YBFT8, TKT-DUQBD0)

### DIFF
--- a/docs-project/entities/guides/GUIDE-metamodel.md
+++ b/docs-project/entities/guides/GUIDE-metamodel.md
@@ -16,6 +16,9 @@ It's stored in `metamodel.yaml` at your project root.
 ```yaml
 version: "1.0"
 namespace: "https://example.org/ontology/architecture#"
+description: |
+  Optional end-user prose describing what this deployment is for. Documentation
+  only — surfaced by generated docs; ignored by validation and the write path.
 
 types:
   # Custom enum types
@@ -211,6 +214,29 @@ Notes:
   type**; an inline `labels` map on such a property is ignored (mirroring how an
   inline `values` list is ignored there).
 
+#### Value Descriptions
+
+Where `labels:` gives a value its short display text, `descriptions:` gives the
+**longer prose meaning** of a value — what it signifies. It is documentation
+only (surfaced by generated docs), keyed by value like `labels:`:
+
+```yaml
+types:
+  ticket-status:
+    values: [open, in_progress, closed]
+    labels:
+      in_progress: In progress
+    descriptions:
+      open: A newly filed ticket that no one has started yet.
+      in_progress: Someone is actively working on the ticket.
+      closed: The ticket is finished; no further work is expected.
+```
+
+- `descriptions` is optional and independent of `labels`: a value may have
+  either, both, or neither. It never affects storage, validation, or forms.
+- Distinct from the type-level `description:` scalar (which documents the type as
+  a whole); `descriptions:` documents each individual value.
+
 ### State Machines (transitions)
 
 An enum custom type becomes a **state machine** when it declares `transitions:` —
@@ -228,6 +254,7 @@ types:
       - from: todo
         to: doing
         label: Start progress # optional: names the MOVE (an action verb)
+        help: Move here once someone picks up the ticket. # optional: why/when
       - from: doing
         to: review
         label: Send to review
@@ -247,6 +274,7 @@ types:
 | `guard` | An ACL permission the acting principal must hold for the move. Enforced on served paths; inert on a direct CLI write with no policy. |
 | `when` | A predicate (same language as validations, evaluated against the entity + graph) that must hold for the move. |
 | `label` | **Optional** display text for the move (the *action*, e.g. "Start progress"), used by the data-entry status control. Display-only — the stored value is still `to`. Absent → the UI falls back to the target value's display label, then the raw value. |
+| `help` | **Optional** longer prose explaining *why or when* a user would make this move, beyond the short `label`. Documentation only — surfaced by generated docs, ignored by enforcement. |
 
 The data-entry UI reads these to render a **status control** that offers only the
 moves the current user can perform right now (see the `_transitions` affordance in

--- a/docs-project/entities/guides/GUIDE-metamodel.md
+++ b/docs-project/entities/guides/GUIDE-metamodel.md
@@ -68,7 +68,8 @@ project root (where `metamodel.yaml` lives).
 
 Each included file is a partial metamodel. It can contain any combination of
 `types:`, `entities:`, `relations:`, and `validations:` — but **must not** contain
-`version:` or `namespace:` (these are only allowed in the root `metamodel.yaml`).
+`version:`, `namespace:`, or `description:` (these are deployment-wide, allowed
+only in the root `metamodel.yaml`).
 
 ```yaml
 # compliance/controls.yaml

--- a/docs/metamodel.md
+++ b/docs/metamodel.md
@@ -10,6 +10,9 @@ It's stored in `metamodel.yaml` at your project root.
 ```yaml
 version: "1.0"
 namespace: "https://example.org/ontology/architecture#"
+description: |
+  Optional end-user prose describing what this deployment is for. Documentation
+  only — surfaced by generated docs; ignored by validation and the write path.
 
 types:
   # Custom enum types
@@ -205,6 +208,29 @@ Notes:
   type**; an inline `labels` map on such a property is ignored (mirroring how an
   inline `values` list is ignored there).
 
+#### Value Descriptions
+
+Where `labels:` gives a value its short display text, `descriptions:` gives the
+**longer prose meaning** of a value — what it signifies. It is documentation
+only (surfaced by generated docs), keyed by value like `labels:`:
+
+```yaml
+types:
+  ticket-status:
+    values: [open, in_progress, closed]
+    labels:
+      in_progress: In progress
+    descriptions:
+      open: A newly filed ticket that no one has started yet.
+      in_progress: Someone is actively working on the ticket.
+      closed: The ticket is finished; no further work is expected.
+```
+
+- `descriptions` is optional and independent of `labels`: a value may have
+  either, both, or neither. It never affects storage, validation, or forms.
+- Distinct from the type-level `description:` scalar (which documents the type as
+  a whole); `descriptions:` documents each individual value.
+
 ### State Machines (transitions)
 
 An enum custom type becomes a **state machine** when it declares `transitions:` —
@@ -222,6 +248,7 @@ types:
       - from: todo
         to: doing
         label: Start progress # optional: names the MOVE (an action verb)
+        help: Move here once someone picks up the ticket. # optional: why/when
       - from: doing
         to: review
         label: Send to review
@@ -241,6 +268,7 @@ types:
 | `guard` | An ACL permission the acting principal must hold for the move. Enforced on served paths; inert on a direct CLI write with no policy. |
 | `when` | A predicate (same language as validations, evaluated against the entity + graph) that must hold for the move. |
 | `label` | **Optional** display text for the move (the *action*, e.g. "Start progress"), used by the data-entry status control. Display-only — the stored value is still `to`. Absent → the UI falls back to the target value's display label, then the raw value. |
+| `help` | **Optional** longer prose explaining *why or when* a user would make this move, beyond the short `label`. Documentation only — surfaced by generated docs, ignored by enforcement. |
 
 The data-entry UI reads these to render a **status control** that offers only the
 moves the current user can perform right now (see the `_transitions` affordance in

--- a/docs/metamodel.md
+++ b/docs/metamodel.md
@@ -62,7 +62,8 @@ project root (where `metamodel.yaml` lives).
 
 Each included file is a partial metamodel. It can contain any combination of
 `types:`, `entities:`, `relations:`, and `validations:` — but **must not** contain
-`version:` or `namespace:` (these are only allowed in the root `metamodel.yaml`).
+`version:`, `namespace:`, or `description:` (these are deployment-wide, allowed
+only in the root `metamodel.yaml`).
 
 ```yaml
 # compliance/controls.yaml

--- a/frontend/src/components/common/StatusBar.vue
+++ b/frontend/src/components/common/StatusBar.vue
@@ -1,14 +1,25 @@
 <script setup lang="ts">
-import { onMounted } from 'vue'
+import { computed, onMounted, ref } from 'vue'
 import { RouterLink, useRoute, useRouter } from 'vue-router'
 import { useGitStore, useSchemaStore, useUIStore } from '@/stores'
 import { shortcutsModalOpen } from '@/composables/useKeyboardShortcuts'
+import { renderMarkdown } from '@/utils/markdown'
 
 const gitStore = useGitStore()
 const uiStore = useUIStore()
 const schemaStore = useSchemaStore()
 const route = useRoute()
 const router = useRouter()
+
+// Global "About" help: the deployment description (data-entry app.description,
+// falling back to the metamodel's top-level description on the server). The
+// button is shown only when there is a description to show (TKT-DUQBD0).
+const aboutOpen = ref(false)
+const appName = computed(() => schemaStore.app?.name || 'rela')
+const appDescription = computed(() => schemaStore.app?.description?.trim() || '')
+// The description is authored as markdown (in data-entry.yaml or the metamodel);
+// render it so *emphasis*, lists, etc. display. renderMarkdown sanitizes.
+const appDescriptionHtml = computed(() => renderMarkdown(appDescription.value))
 
 // Initial fetch - SSE handles subsequent updates
 onMounted(() => {
@@ -66,6 +77,14 @@ async function handleSync() {
         <span v-if="uiStore.isDark" class="theme-icon">☀️</span>
         <span v-else class="theme-icon">🌙</span>
       </button>
+      <button
+        v-if="appDescription"
+        class="status-item about-btn"
+        title="About this app"
+        @click="aboutOpen = true"
+      >
+        <span class="about-icon">ⓘ</span> <span class="about-text">About</span>
+      </button>
       <RouterLink
         to="/settings"
         class="status-item"
@@ -81,6 +100,21 @@ async function handleSync() {
         <kbd>?</kbd> <span class="shortcuts-text">Shortcuts</span>
       </button>
     </div>
+
+    <!-- About overlay: the deployment description. Teleported so it isn't
+         clipped by the fixed status bar. -->
+    <Teleport to="body">
+      <div v-if="aboutOpen" class="about-overlay" @click.self="aboutOpen = false">
+        <div class="about-modal">
+          <div class="about-header">
+            <h3>{{ appName }}</h3>
+            <button class="about-close" @click="aboutOpen = false">&times;</button>
+          </div>
+          <!-- eslint-disable-next-line vue/no-v-html -->
+          <div class="about-body" v-html="appDescriptionHtml"/>
+        </div>
+      </div>
+    </Teleport>
   </footer>
 </template>
 
@@ -189,6 +223,63 @@ async function handleSync() {
 .theme-icon {
   font-size: 14px;
   line-height: 1;
+}
+
+.about-icon {
+  font-size: 13px;
+  line-height: 1;
+}
+
+.about-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.about-modal {
+  background: var(--card-bg);
+  color: var(--text-color);
+  border-radius: 12px;
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.2);
+  max-width: 560px;
+  width: 90%;
+  max-height: 80vh;
+  overflow: auto;
+  padding: 0 0 20px;
+}
+
+.about-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 16px 20px;
+  border-bottom: 1px solid var(--border-color, #e2e8f0);
+}
+
+.about-header h3 {
+  margin: 0;
+  font-size: 18px;
+  font-weight: 600;
+}
+
+.about-close {
+  background: none;
+  border: none;
+  font-size: 24px;
+  color: var(--muted-text);
+  cursor: pointer;
+  line-height: 1;
+}
+
+.about-body {
+  padding: 16px 20px 0;
+  font-size: 14px;
+  line-height: 1.6;
+  white-space: pre-wrap;
 }
 
 @media (max-width: 768px) {

--- a/frontend/src/components/common/StatusBar.vue
+++ b/frontend/src/components/common/StatusBar.vue
@@ -16,7 +16,7 @@ const router = useRouter()
 // button is shown only when there is a description to show (TKT-DUQBD0).
 const aboutOpen = ref(false)
 const appName = computed(() => schemaStore.app?.name || 'rela')
-const appDescription = computed(() => schemaStore.app?.description?.trim() || '')
+const appDescription = computed(() => schemaStore.aboutDescription?.trim() || '')
 // The description is authored as markdown (in data-entry.yaml or the metamodel);
 // render it so *emphasis*, lists, etc. display. renderMarkdown sanitizes.
 const appDescriptionHtml = computed(() => renderMarkdown(appDescription.value))
@@ -279,7 +279,14 @@ async function handleSync() {
   padding: 16px 20px 0;
   font-size: 14px;
   line-height: 1.6;
-  white-space: pre-wrap;
+}
+
+.about-body :deep(p) {
+  margin: 0 0 10px;
+}
+
+.about-body :deep(p:last-child) {
+  margin-bottom: 0;
 }
 
 @media (max-width: 768px) {

--- a/frontend/src/components/ui/HelpModal.vue
+++ b/frontend/src/components/ui/HelpModal.vue
@@ -20,19 +20,28 @@ const error = ref<string | null>(null)
 const helpContent = ref('')
 const contentBody = useTemplateRef<HTMLElement>('contentBody')
 
+// Monotonic request token: switching the help target (or a fast open→close→open)
+// starts a new loadHelp before the previous fetch resolves. Each run captures its
+// token and bails the moment a newer run has started, so a stale response never
+// overwrites content or renders its mermaid against the current entity's DOM.
+let loadToken = 0
+
 async function loadHelp() {
   if (!props.entityType) return
 
+  const myToken = ++loadToken
   loading.value = true
   error.value = null
 
   try {
     const response = await axios.get(`/api/help/${props.entityType}`)
+    if (myToken !== loadToken) return // superseded by a newer load
     // The server renders metamodel descriptions with goldmark in unsafe
     // mode (raw HTML passes through), so sanitize at the sink like every
     // other v-html consumer (utils/markdown.ts, DocumentView).
     helpContent.value = DOMPurify.sanitize(response.data)
   } catch (err) {
+    if (myToken !== loadToken) return // superseded
     // Suppress cancellation errors from rapid navigation in Firefox
     // (see BUG-6C3V and src/composables/usePageData.ts).
     if (isCancelledFetch(err)) return
@@ -40,16 +49,17 @@ async function loadHelp() {
     error.value = 'Failed to load help content'
     helpContent.value = ''
   } finally {
-    loading.value = false
+    if (myToken === loadToken) loading.value = false
   }
 
   // Render the Lifecycle section's <pre class="mermaid"> state diagrams to SVG.
   // Must run AFTER loading is false so the v-else content div (contentBody) is
   // actually mounted — mermaid can't find blocks in an unrendered subtree.
-  // Mirrors DocumentView's post-paint render.
+  // Mirrors DocumentView's post-paint render. Re-check the token after nextTick
+  // so a superseded run never renders against the newer entity's DOM.
   if (!error.value) {
     await nextTick()
-    if (contentBody.value) {
+    if (myToken === loadToken && contentBody.value) {
       await renderMermaidDiagrams(contentBody.value)
     }
   }

--- a/frontend/src/components/ui/HelpModal.vue
+++ b/frontend/src/components/ui/HelpModal.vue
@@ -1,8 +1,9 @@
 <script setup lang="ts">
-import { ref, watch } from 'vue'
+import { ref, watch, nextTick, useTemplateRef } from 'vue'
 import axios from 'axios'
 import DOMPurify from 'dompurify'
 import { isCancelledFetch } from '@/composables/usePageData'
+import { renderMermaidDiagrams } from '@/utils/markdown'
 
 const props = defineProps<{
   open: boolean
@@ -17,6 +18,7 @@ const emit = defineEmits<{
 const loading = ref(false)
 const error = ref<string | null>(null)
 const helpContent = ref('')
+const contentBody = useTemplateRef<HTMLElement>('contentBody')
 
 async function loadHelp() {
   if (!props.entityType) return
@@ -39,6 +41,17 @@ async function loadHelp() {
     helpContent.value = ''
   } finally {
     loading.value = false
+  }
+
+  // Render the Lifecycle section's <pre class="mermaid"> state diagrams to SVG.
+  // Must run AFTER loading is false so the v-else content div (contentBody) is
+  // actually mounted — mermaid can't find blocks in an unrendered subtree.
+  // Mirrors DocumentView's post-paint render.
+  if (!error.value) {
+    await nextTick()
+    if (contentBody.value) {
+      await renderMermaidDiagrams(contentBody.value)
+    }
   }
 }
 
@@ -76,7 +89,7 @@ function handleOverlayClick(e: MouseEvent) {
             {{ error }}
           </div>
           <!-- eslint-disable-next-line vue/no-v-html -->
-          <div v-else class="help-content-wrapper" v-html="helpContent"/>
+          <div v-else ref="contentBody" class="help-content-wrapper" v-html="helpContent"/>
         </div>
       </div>
     </div>
@@ -255,5 +268,71 @@ function handleOverlayClick(e: MouseEvent) {
   text-align: center;
   color: #94a3b8;
   font-style: italic;
+}
+
+/* Server-rendered help tables (Properties / Relations / Values / Lifecycle). */
+.help-content-wrapper :deep(.help-table) {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 0 0 24px;
+  font-size: 13px;
+}
+
+.help-content-wrapper :deep(.help-table th) {
+  text-align: left;
+  padding: 6px 10px;
+  border-bottom: 2px solid var(--border-color, #e2e8f0);
+  color: var(--muted-text);
+  font-weight: 600;
+  white-space: nowrap;
+}
+
+.help-content-wrapper :deep(.help-table td) {
+  padding: 6px 10px;
+  border-bottom: 1px solid var(--border-color, #e2e8f0);
+  vertical-align: top;
+  line-height: 1.5;
+}
+
+.help-content-wrapper :deep(.help-table tr:last-child td) {
+  border-bottom: none;
+}
+
+.help-content-wrapper :deep(.help-table tbody tr:hover) {
+  background: var(--hover-bg);
+}
+
+.help-content-wrapper :deep(.help-table code) {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 12px;
+  color: var(--text-color);
+}
+
+/* Markdown prose (simpleMarkdownToHTML) inside a cell wraps in <p>; strip its
+   default margins so a one-line description sits flush in the row. */
+.help-content-wrapper :deep(.help-table td p) {
+  margin: 0;
+}
+
+/* Entity intro paragraph + section headings spacing. */
+.help-content-wrapper :deep(.entity-description) {
+  font-size: 14px;
+  line-height: 1.6;
+  margin-bottom: 20px;
+}
+
+.help-content-wrapper :deep(.entity-description p:first-child) {
+  margin-top: 0;
+}
+
+.help-content-wrapper :deep(h4) {
+  margin-top: 4px;
+}
+
+/* Mermaid lifecycle diagram — centered with breathing room. */
+.help-content-wrapper :deep(.mermaid-diagram) {
+  display: flex;
+  justify-content: center;
+  margin: 0 0 20px;
 }
 </style>

--- a/frontend/src/stores/schema.ts
+++ b/frontend/src/stores/schema.ts
@@ -35,6 +35,10 @@ export const useSchemaStore = defineStore('schema', () => {
   const dashboard = ref<DashboardConfig | undefined>(undefined)
   const navigation = ref<NavigationEntry[]>([])
   const app = ref<AppConfig>({ name: 'rela' })
+  // The deployment description for the global "About" help (TKT-DUQBD0): the
+  // data-entry.yaml app.description, falling back to the metamodel description.
+  // Distinct from app.description so SettingsView's one-liner is unaffected.
+  const aboutDescription = ref('')
   const styles = ref<Record<string, Record<string, string>>>({})
   const paletteLight = ref<Record<string, string>>({})
   const paletteDark = ref<Record<string, string>>({})
@@ -245,6 +249,7 @@ export const useSchemaStore = defineStore('schema', () => {
 
       // Config
       app.value = configData.app || { name: 'rela' }
+      aboutDescription.value = configData.about_description || ''
       styles.value = configData.styles || {}
       forms.value = new Map(Object.entries(configData.forms || {}))
       lists.value = new Map(Object.entries(configData.lists || {}))
@@ -300,6 +305,7 @@ export const useSchemaStore = defineStore('schema', () => {
     dashboard,
     navigation,
     app,
+    aboutDescription,
     styles,
     paletteLight,
     paletteDark,

--- a/frontend/src/types/config.ts
+++ b/frontend/src/types/config.ts
@@ -9,6 +9,8 @@ export interface ResolvedPalette {
 
 export interface Config {
   app: AppConfig
+  /** Deployment description for the global "About" help (TKT-DUQBD0). */
+  about_description?: string
   styles?: Record<string, Record<string, string>>
   palette?: ResolvedPalette
   forms: Record<string, FormConfig>

--- a/internal/apiwire/v1/responses.go
+++ b/internal/apiwire/v1/responses.go
@@ -219,19 +219,26 @@ type CustomType struct {
 
 // Config is the JSON representation of the UI config.
 type Config struct {
-	App         AppConfig                                   `json:"app"`
-	Styles      map[string]map[string]string                `json:"styles"`
-	Forms       map[string]dataentryconfig.Form             `json:"forms"`
-	Lists       map[string]dataentryconfig.List             `json:"lists"`
-	Views       map[string]dataentryconfig.ViewConfig       `json:"views"`
-	EntityViews map[string]dataentryconfig.EntityViewConfig `json:"entity_views,omitempty"`
-	Kanbans     map[string]dataentryconfig.Kanban           `json:"kanbans"`
-	Dashboard   *dataentryconfig.DashboardConfig            `json:"dashboard,omitempty"`
-	Actions     map[string]dataentryconfig.Action           `json:"actions,omitempty"`
-	Navigation  []dataentryconfig.NavigationEntry           `json:"navigation"`
-	Documents   map[string]dataentryconfig.DocumentConfig   `json:"documents,omitempty"`
-	Apps        map[string]App                              `json:"apps,omitempty"`
-	Palette     *dataentryconfig.ResolvedPalette            `json:"palette,omitempty"`
+	App AppConfig `json:"app"`
+	// AboutDescription is the deployment description shown by the SPA's global
+	// "About" help (TKT-DUQBD0): the data-entry.yaml `app.description`, falling
+	// back to the metamodel's top-level `description`. Distinct from
+	// AppConfig.Description (which SettingsView renders as a plain one-liner) so
+	// a multi-paragraph markdown metamodel description doesn't leak into that
+	// view. Empty → the About button is hidden.
+	AboutDescription string                                      `json:"about_description,omitempty"`
+	Styles           map[string]map[string]string                `json:"styles"`
+	Forms            map[string]dataentryconfig.Form             `json:"forms"`
+	Lists            map[string]dataentryconfig.List             `json:"lists"`
+	Views            map[string]dataentryconfig.ViewConfig       `json:"views"`
+	EntityViews      map[string]dataentryconfig.EntityViewConfig `json:"entity_views,omitempty"`
+	Kanbans          map[string]dataentryconfig.Kanban           `json:"kanbans"`
+	Dashboard        *dataentryconfig.DashboardConfig            `json:"dashboard,omitempty"`
+	Actions          map[string]dataentryconfig.Action           `json:"actions,omitempty"`
+	Navigation       []dataentryconfig.NavigationEntry           `json:"navigation"`
+	Documents        map[string]dataentryconfig.DocumentConfig   `json:"documents,omitempty"`
+	Apps             map[string]App                              `json:"apps,omitempty"`
+	Palette          *dataentryconfig.ResolvedPalette            `json:"palette,omitempty"`
 }
 
 // App is the client-facing view of a custom app. It deliberately omits the

--- a/internal/dataentry/api_v1.go
+++ b/internal/dataentry/api_v1.go
@@ -58,6 +58,14 @@ func (a *App) toV1PropertyDef(meta *metamodel.Metamodel, propDef metamodel.Prope
 
 // toV1CustomType is the single serialization site for a metamodel custom type
 // onto the wire, so the _schema types map and any other consumer stay in sync.
+//
+// It intentionally projects only Values/Labels/Default. The documentation-only
+// fields — CustomType.Descriptions (per-value meaning), CustomType.Transitions,
+// and TransitionDef.Help (TKT-0YBFT8) — are NOT serialized: their consumer is the
+// offline `rela docs` generator (FEAT-G4VO53), not the SPA. Wiring any of them to
+// the wire is a deliberate frontend-contract change (see internal/dataentry/
+// CLAUDE.md), not a "helpful" one-liner here. TestToV1CustomType_OmitsDocFields
+// pins this boundary.
 func toV1CustomType(ct metamodel.CustomType) v1.CustomType {
 	return v1.CustomType{
 		Values:  ct.Values,

--- a/internal/dataentry/api_v1.go
+++ b/internal/dataentry/api_v1.go
@@ -1893,6 +1893,22 @@ func (a *App) resolveRelationWidgets(s *Schema, rels []dataentryconfig.FormRelat
 	return resolved
 }
 
+// appDescription is the description shown for the deployment as a whole
+// (surfaced by the SPA's global "About" help, TKT-DUQBD0). The data-entry.yaml
+// `app.description` wins when set (it is the UI-app-specific text); otherwise it
+// falls back to the metamodel's top-level `description` (the schema-level prose
+// added in TKT-0YBFT8). Empty when neither is set — the SPA hides the About
+// button.
+func appDescription(s *Schema) string {
+	if s.Cfg != nil && s.Cfg.App.Description != "" {
+		return s.Cfg.App.Description
+	}
+	if s.Meta != nil {
+		return s.Meta.Description
+	}
+	return ""
+}
+
 func (a *App) handleV1Config(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
 		writeV1Error(w, r, http.StatusMethodNotAllowed, "method_not_allowed", "Method not allowed", "")
@@ -1919,7 +1935,7 @@ func (a *App) handleV1Config(w http.ResponseWriter, r *http.Request) {
 	config := v1.Config{
 		App: v1.AppConfig{
 			Name:              s.Cfg.App.Name,
-			Description:       s.Cfg.App.Description,
+			Description:       appDescription(s),
 			PlantUMLServerURL: s.Cfg.App.PlantUMLServerURL,
 		},
 		Styles:      s.StyleMap,
@@ -2709,7 +2725,7 @@ func (a *App) handleV1Sidebar(w http.ResponseWriter, r *http.Request) {
 	resp := v1.SidebarResponse{
 		App: v1.AppConfig{
 			Name:        s.Cfg.App.Name,
-			Description: s.Cfg.App.Description,
+			Description: appDescription(s),
 		},
 		Navigation: navigation,
 	}

--- a/internal/dataentry/api_v1.go
+++ b/internal/dataentry/api_v1.go
@@ -1893,13 +1893,17 @@ func (a *App) resolveRelationWidgets(s *Schema, rels []dataentryconfig.FormRelat
 	return resolved
 }
 
-// appDescription is the description shown for the deployment as a whole
-// (surfaced by the SPA's global "About" help, TKT-DUQBD0). The data-entry.yaml
-// `app.description` wins when set (it is the UI-app-specific text); otherwise it
-// falls back to the metamodel's top-level `description` (the schema-level prose
-// added in TKT-0YBFT8). Empty when neither is set — the SPA hides the About
-// button.
-func appDescription(s *Schema) string {
+// aboutDescription is the deployment description shown by the SPA's global
+// "About" help (TKT-DUQBD0). The data-entry.yaml `app.description` wins when set
+// (it is the UI-app-specific text); otherwise it falls back to the metamodel's
+// top-level `description` (the schema-level prose added in TKT-0YBFT8). Empty
+// when neither is set — the SPA hides the About button.
+//
+// This is a SEPARATE field from AppConfig.Description on the wire: that field is
+// also rendered by SettingsView as a plain one-line value, and pushing the
+// (possibly multi-paragraph markdown) metamodel description into it would
+// regress that view. The About surface gets its own field, `about_description`.
+func aboutDescription(s *Schema) string {
 	if s.Cfg != nil && s.Cfg.App.Description != "" {
 		return s.Cfg.App.Description
 	}
@@ -1935,21 +1939,22 @@ func (a *App) handleV1Config(w http.ResponseWriter, r *http.Request) {
 	config := v1.Config{
 		App: v1.AppConfig{
 			Name:              s.Cfg.App.Name,
-			Description:       appDescription(s),
+			Description:       s.Cfg.App.Description,
 			PlantUMLServerURL: s.Cfg.App.PlantUMLServerURL,
 		},
-		Styles:      s.StyleMap,
-		Forms:       forms,
-		Lists:       s.Cfg.Lists,
-		Views:       s.Cfg.Views,
-		EntityViews: s.Cfg.EntityViews,
-		Kanbans:     s.Cfg.Kanbans,
-		Dashboard:   s.Cfg.Dashboard,
-		Actions:     s.Cfg.Actions,
-		Navigation:  s.Cfg.Navigation,
-		Documents:   s.Cfg.Documents,
-		Apps:        appsToV1(a.scanAppsOrLog()),
-		Palette:     a.palette.Resolved(),
+		AboutDescription: aboutDescription(s),
+		Styles:           s.StyleMap,
+		Forms:            forms,
+		Lists:            s.Cfg.Lists,
+		Views:            s.Cfg.Views,
+		EntityViews:      s.Cfg.EntityViews,
+		Kanbans:          s.Cfg.Kanbans,
+		Dashboard:        s.Cfg.Dashboard,
+		Actions:          s.Cfg.Actions,
+		Navigation:       s.Cfg.Navigation,
+		Documents:        s.Cfg.Documents,
+		Apps:             appsToV1(a.scanAppsOrLog()),
+		Palette:          a.palette.Resolved(),
 	}
 
 	writeV1JSON(w, http.StatusOK, config)
@@ -2725,7 +2730,7 @@ func (a *App) handleV1Sidebar(w http.ResponseWriter, r *http.Request) {
 	resp := v1.SidebarResponse{
 		App: v1.AppConfig{
 			Name:        s.Cfg.App.Name,
-			Description: appDescription(s),
+			Description: s.Cfg.App.Description,
 		},
 		Navigation: navigation,
 	}

--- a/internal/dataentry/api_v1_test.go
+++ b/internal/dataentry/api_v1_test.go
@@ -10,6 +10,7 @@ import (
 	url2 "net/url"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -5399,5 +5400,47 @@ func TestV1Affordance_CollectionGet_NoFieldVerdicts(t *testing.T) {
 	}
 	if strings.Contains(body, `"_relations"`) {
 		t.Errorf("collection response must NOT contain _relations; got: %s", body)
+	}
+}
+
+// TestToV1CustomType_OmitsDocFields pins the phase-1a boundary (TKT-0YBFT8 /
+// RR-R2DG19): the documentation-only metamodel fields — CustomType.Descriptions,
+// CustomType.Transitions, and TransitionDef.Help — are NOT serialized onto the
+// wire. Their consumer is the offline `rela docs` generator, not the SPA. If a
+// future change wires any of them to v1.CustomType, that is a deliberate
+// frontend-contract change and this test should be updated intentionally.
+func TestToV1CustomType_OmitsDocFields(t *testing.T) {
+	ct := metamodel.CustomType{
+		Values:       []string{"todo", "done"},
+		Labels:       map[string]string{"todo": "To do"},
+		Default:      "todo",
+		Descriptions: map[string]string{"todo": "not yet started"},
+		Transitions: []metamodel.TransitionDef{
+			{From: "todo", To: "done", Label: "Complete", Help: "when the work is finished"},
+		},
+	}
+
+	got := toV1CustomType(ct)
+
+	// The wire projection carries exactly Values/Labels/Default.
+	if !reflect.DeepEqual(got.Values, ct.Values) {
+		t.Errorf("Values = %v, want %v", got.Values, ct.Values)
+	}
+	if !reflect.DeepEqual(got.Labels, ct.Labels) {
+		t.Errorf("Labels = %v, want %v", got.Labels, ct.Labels)
+	}
+	if got.Default != "todo" {
+		t.Errorf("Default = %q, want todo", got.Default)
+	}
+	// The v1.CustomType wire type has no field for the doc-only data, so this is
+	// a structural guarantee — the marshaled JSON must not mention them.
+	blob, err := json.Marshal(got)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	for _, banned := range []string{"descriptions", "transitions", "help", "not yet started"} {
+		if strings.Contains(string(blob), banned) {
+			t.Errorf("wire CustomType must not carry doc-field %q; got: %s", banned, blob)
+		}
 	}
 }

--- a/internal/dataentry/handlers.go
+++ b/internal/dataentry/handlers.go
@@ -28,6 +28,36 @@ type RelationHelp struct {
 	Description htmltemplate.HTML
 }
 
+// EnumHelp documents an enum/state-machine property's allowed values and (when
+// it is a state machine) its lifecycle. Property is the property name, TypeName
+// the custom-type name (empty for an inline enum). Values / Transitions are only
+// populated when present; both may be empty for a plain field, in which case the
+// property contributes no help sections (TKT-DUQBD0).
+type EnumHelp struct {
+	Property    string
+	TypeName    string
+	Initial     string // entry state for the diagram; "" when unknown
+	Values      []ValueHelp
+	Transitions []TransitionHelp
+}
+
+// ValueHelp documents one allowed value of an enum: the raw value, its optional
+// display Label, and its optional prose Description (CustomType.Descriptions).
+type ValueHelp struct {
+	Value       string
+	Label       string
+	Description htmltemplate.HTML
+}
+
+// TransitionHelp documents one lifecycle move: the target label (the verb), the
+// From→To states, and the optional Help prose (why/when to make the move).
+type TransitionHelp struct {
+	Move string // the move label, falling back to the To value
+	From string
+	To   string
+	Help htmltemplate.HTML
+}
+
 // handleEntityHelp returns HTML fragment with documentation for an entity type.
 // GET /api/help/{entityType}
 func (a *App) handleEntityHelp(w http.ResponseWriter, r *http.Request) {
@@ -64,6 +94,9 @@ func (a *App) handleEntityHelp(w http.ResponseWriter, r *http.Request) {
 	outgoingRels := a.gatherRelations(s.Meta, entityType, true)
 	incomingRels := a.gatherRelations(s.Meta, entityType, false)
 
+	// Gather enum value + lifecycle help for enum/state-machine properties.
+	enums := gatherEnumHelp(s.Meta, entDef)
+
 	// Render entity description
 	var entityDesc htmltemplate.HTML
 	if entDef.Description != "" {
@@ -72,13 +105,79 @@ func (a *App) handleEntityHelp(w http.ResponseWriter, r *http.Request) {
 
 	// Generate inline HTML
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
-	a.renderHelpContent(w, entityDesc, props, outgoingRels, incomingRels)
+	a.renderHelpContent(w, entityDesc, props, outgoingRels, incomingRels, enums)
+}
+
+// gatherEnumHelp collects per-value descriptions and lifecycle transitions for
+// every enum / state-machine property of entDef, in property-name order
+// (TKT-DUQBD0). A property contributes an [EnumHelp] only when its type has
+// declared values (a named custom type with Values, or an inline enum); the
+// Values / Transitions slices are populated from the resolved CustomType. Plain
+// (non-enum) properties are skipped entirely, so they add no help sections.
+func gatherEnumHelp(meta *metamodel.Metamodel, entDef *metamodel.EntityDef) []EnumHelp {
+	var out []EnumHelp
+	names := make([]string, 0, len(entDef.Properties))
+	for name := range entDef.Properties {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	for _, name := range names {
+		prop := entDef.Properties[name]
+		// Resolve the value set: a named custom type, else an inline enum.
+		ct, named := meta.Types[prop.Type]
+		values := ct.Values
+		labels := ct.Labels
+		descriptions := ct.Descriptions
+		transitions := ct.Transitions
+		if !named {
+			// Inline enum: values live on the property; no custom-type-level
+			// descriptions or transitions exist for inline enums.
+			values = prop.Values
+			labels = prop.Labels
+			descriptions = nil
+			transitions = nil
+		}
+		if len(values) == 0 {
+			continue // not an enum — no help to add
+		}
+
+		eh := EnumHelp{Property: name}
+		if named {
+			eh.TypeName = prop.Type
+			// Entry state for the diagram: Initial, else Default.
+			eh.Initial = ct.Initial
+			if eh.Initial == "" {
+				eh.Initial = ct.Default
+			}
+		}
+		for _, v := range values {
+			vh := ValueHelp{Value: v, Label: labels[v]}
+			if d := descriptions[v]; d != "" {
+				vh.Description = simpleMarkdownToHTML(d)
+			}
+			eh.Values = append(eh.Values, vh)
+		}
+		for _, tr := range transitions {
+			move := tr.Label
+			if move == "" {
+				move = tr.To
+			}
+			th := TransitionHelp{Move: move, From: tr.From, To: tr.To}
+			if tr.Help != "" {
+				th.Help = simpleMarkdownToHTML(tr.Help)
+			}
+			eh.Transitions = append(eh.Transitions, th)
+		}
+		out = append(out, eh)
+	}
+	return out
 }
 
 // renderHelpContent generates HTML for entity help content.
 func (a *App) renderHelpContent(
 	w http.ResponseWriter, entityDesc htmltemplate.HTML, props []PropertyHelp,
-	outgoingRels, incomingRels []RelationHelp,
+	outgoingRels, incomingRels []RelationHelp, enums []EnumHelp,
 ) {
 	fmt.Fprint(w, `<div class="help-content">`)
 	if entityDesc != "" {
@@ -135,7 +234,72 @@ func (a *App) renderHelpContent(
 		}
 		fmt.Fprint(w, `</tbody></table>`)
 	}
+
+	// Values + Lifecycle sections per enum / state-machine property (TKT-DUQBD0).
+	for _, e := range enums {
+		renderEnumHelp(w, e)
+	}
+
 	fmt.Fprint(w, `</div>`)
+}
+
+// renderEnumHelp emits the Values table (and, for a state machine, the Lifecycle
+// table) for one enum property. Sections with no rows are skipped, so a plain
+// enum shows only Values and a value with no description shows just its
+// value/label.
+func renderEnumHelp(w http.ResponseWriter, e EnumHelp) {
+	if len(e.Values) > 0 {
+		fmt.Fprintf(w, `<h4>Values: <code>%s</code></h4>`, htmltemplate.HTMLEscapeString(e.Property))
+		fmt.Fprint(w, `<table class="help-table"><thead><tr><th>Value</th><th>Description</th></tr></thead><tbody>`)
+		for _, v := range e.Values {
+			shown := v.Value
+			if v.Label != "" {
+				shown = v.Label + " (" + v.Value + ")"
+			}
+			fmt.Fprintf(w, `<tr><td><code>%s</code></td><td>%s</td></tr>`,
+				htmltemplate.HTMLEscapeString(shown), v.Description)
+		}
+		fmt.Fprint(w, `</tbody></table>`)
+	}
+
+	if len(e.Transitions) > 0 {
+		fmt.Fprintf(w, `<h4>Lifecycle: <code>%s</code></h4>`, htmltemplate.HTMLEscapeString(e.Property))
+		// A mermaid state diagram of this field's machine, rendered client-side
+		// (the help modal runs renderMermaidDiagrams over the injected HTML). One
+		// diagram per state-machine field.
+		fmt.Fprintf(w, `<pre class="mermaid">%s</pre>`,
+			htmltemplate.HTMLEscapeString(mermaidStateDiagram(e)))
+		fmt.Fprint(w, `<table class="help-table"><thead><tr><th>Move</th><th>From &rarr; To</th><th>When to use</th></tr></thead><tbody>`)
+		for _, tr := range e.Transitions {
+			fmt.Fprintf(w, `<tr><td>%s</td><td><code>%s</code> &rarr; <code>%s</code></td><td>%s</td></tr>`,
+				htmltemplate.HTMLEscapeString(tr.Move),
+				htmltemplate.HTMLEscapeString(tr.From),
+				htmltemplate.HTMLEscapeString(tr.To),
+				tr.Help)
+		}
+		fmt.Fprint(w, `</tbody></table>`)
+	}
+}
+
+// mermaidStateDiagram builds a stateDiagram-v2 source for one state-machine
+// field: an entry arrow to the initial state (when known) plus one edge per
+// transition, labeled with the move (verb). The text is HTML-escaped by the
+// caller before injection; mermaid identifiers here are the raw enum values,
+// which are simple tokens in practice.
+func mermaidStateDiagram(e EnumHelp) string {
+	var b strings.Builder
+	b.WriteString("stateDiagram-v2\n")
+	if e.Initial != "" {
+		fmt.Fprintf(&b, "    [*] --> %s\n", e.Initial)
+	}
+	for _, tr := range e.Transitions {
+		if tr.Move != "" && tr.Move != tr.To {
+			fmt.Fprintf(&b, "    %s --> %s: %s\n", tr.From, tr.To, tr.Move)
+		} else {
+			fmt.Fprintf(&b, "    %s --> %s\n", tr.From, tr.To)
+		}
+	}
+	return b.String()
 }
 
 // gatherRelations collects relation documentation for an entity type.

--- a/internal/dataentry/handlers.go
+++ b/internal/dataentry/handlers.go
@@ -283,23 +283,73 @@ func renderEnumHelp(w http.ResponseWriter, e EnumHelp) {
 
 // mermaidStateDiagram builds a stateDiagram-v2 source for one state-machine
 // field: an entry arrow to the initial state (when known) plus one edge per
-// transition, labeled with the move (verb). The text is HTML-escaped by the
-// caller before injection; mermaid identifiers here are the raw enum values,
-// which are simple tokens in practice.
+// transition, labeled with the move (verb).
+//
+// Raw enum values are NOT safe to splice directly into mermaid syntax — a value
+// with a space, an arrow, or a colon would break parsing, and a newline in a
+// move label could inject a spurious edge (the caller HTML-escapes the result,
+// but renderMermaidDiagrams reads textContent, which un-escapes it before
+// parsing, so the escape protects only the HTML transport). So every state value
+// is mapped to a synthetic id (`s0`, `s1`, …) and aliased with
+// `state "raw value" as sN` so the diagram DISPLAYS the real value while the
+// edges reference the safe id; move labels are flattened (newlines/carriage
+// returns → spaces) so a label can never spill onto a new diagram line.
 func mermaidStateDiagram(e EnumHelp) string {
+	ids := map[string]string{}
+	idFor := func(value string) string {
+		if id, ok := ids[value]; ok {
+			return id
+		}
+		id := fmt.Sprintf("s%d", len(ids))
+		ids[value] = id
+		return id
+	}
+
 	var b strings.Builder
 	b.WriteString("stateDiagram-v2\n")
+
+	// Collect the states in first-seen order so the alias declarations are
+	// deterministic; assign ids as we go.
+	order := []string{}
+	seen := map[string]bool{}
+	note := func(v string) {
+		if v != "" && !seen[v] {
+			seen[v] = true
+			order = append(order, v)
+			idFor(v)
+		}
+	}
+	note(e.Initial)
+	for _, tr := range e.Transitions {
+		note(tr.From)
+		note(tr.To)
+	}
+	for _, v := range order {
+		fmt.Fprintf(&b, "    state %q as %s\n", v, ids[v])
+	}
+
 	if e.Initial != "" {
-		fmt.Fprintf(&b, "    [*] --> %s\n", e.Initial)
+		fmt.Fprintf(&b, "    [*] --> %s\n", ids[e.Initial])
 	}
 	for _, tr := range e.Transitions {
-		if tr.Move != "" && tr.Move != tr.To {
-			fmt.Fprintf(&b, "    %s --> %s: %s\n", tr.From, tr.To, tr.Move)
+		label := mermaidLabel(tr.Move)
+		if label != "" && tr.Move != tr.To {
+			fmt.Fprintf(&b, "    %s --> %s: %s\n", ids[tr.From], ids[tr.To], label)
 		} else {
-			fmt.Fprintf(&b, "    %s --> %s\n", tr.From, tr.To)
+			fmt.Fprintf(&b, "    %s --> %s\n", ids[tr.From], ids[tr.To])
 		}
 	}
 	return b.String()
+}
+
+// mermaidLabel flattens a transition move label so it is safe as a mermaid edge
+// label: newlines/carriage returns collapse to spaces (a raw newline would end
+// the edge line and let the remainder inject a new statement).
+func mermaidLabel(s string) string {
+	s = strings.ReplaceAll(s, "\r\n", " ")
+	s = strings.ReplaceAll(s, "\n", " ")
+	s = strings.ReplaceAll(s, "\r", " ")
+	return strings.TrimSpace(s)
 }
 
 // gatherRelations collects relation documentation for an entity type.

--- a/internal/dataentry/help_docfields_test.go
+++ b/internal/dataentry/help_docfields_test.go
@@ -105,8 +105,9 @@ func TestGatherEnumHelp(t *testing.T) {
 	}
 }
 
-// AC2: the mermaid diagram carries the entry arrow + one labeled edge per
-// transition.
+// AC2: the mermaid diagram aliases each state to a synthetic id (so raw enum
+// values can't corrupt the syntax) and carries the entry arrow + one labeled
+// edge per transition, with the label suppressed when move == to.
 func TestMermaidStateDiagram(t *testing.T) {
 	e := EnumHelp{
 		Initial: "todo",
@@ -119,9 +120,12 @@ func TestMermaidStateDiagram(t *testing.T) {
 
 	for _, want := range []string{
 		"stateDiagram-v2",
-		"[*] --> todo",
-		"todo --> doing: Start",
-		"doing --> done\n", // no ": done" label because move == to
+		`state "todo" as s0`, // aliased display text
+		`state "doing" as s1`,
+		`state "done" as s2`,
+		"[*] --> s0",       // entry to initial via id
+		"s0 --> s1: Start", // labeled edge via ids
+		"s1 --> s2\n",      // no ": done" label because move == to
 	} {
 		if !strings.Contains(got, want) {
 			t.Errorf("diagram missing %q:\n%s", want, got)
@@ -129,9 +133,59 @@ func TestMermaidStateDiagram(t *testing.T) {
 	}
 }
 
-// AC5: appDescription prefers the data-entry app.description, falling back to the
+// The diagram is injection-safe: raw values with mermaid-breaking characters
+// (spaces, arrows) never appear in the syntax (they are aliased to synthetic
+// ids), and a newline in a move label cannot spill onto a new diagram line to
+// inject a spurious edge (RR from code review).
+func TestMermaidStateDiagram_InjectionSafe(t *testing.T) {
+	e := EnumHelp{
+		Initial: "to do", // space — invalid as a raw mermaid id
+		Transitions: []TransitionHelp{
+			// A move label carrying a newline + a fake edge.
+			{Move: "Go\n    evil --> pwned", From: "to do", To: "a --> b"},
+		},
+	}
+	got := mermaidStateDiagram(e)
+
+	// The raw space/arrow values are only inside quoted alias text, never as
+	// bare tokens forming edges.
+	if strings.Contains(got, "[*] --> to do") {
+		t.Errorf("raw spaced value leaked as an id:\n%s", got)
+	}
+	// The newline in the move label must be flattened onto a single line — the
+	// injected `evil --> pwned` may survive only as label TEXT (after the `: `),
+	// never as its own statement line. Check no LINE is a bare injected edge.
+	for line := range strings.SplitSeq(strings.TrimSpace(got), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || line == "stateDiagram-v2" || strings.HasPrefix(line, `state "`) {
+			continue
+		}
+		// Every edge/entry line's source (left of the FIRST -->) must be [*] or a
+		// synthetic id — a leaked `evil` or `to do` token would fail here.
+		if strings.Contains(line, "-->") {
+			left := strings.TrimSpace(strings.SplitN(line, "-->", 2)[0])
+			if left != "[*]" && !isSyntheticID(left) {
+				t.Errorf("edge line has a non-synthetic source %q: %q", left, line)
+			}
+		}
+	}
+}
+
+func isSyntheticID(s string) bool {
+	if !strings.HasPrefix(s, "s") {
+		return false
+	}
+	for _, r := range s[1:] {
+		if r < '0' || r > '9' {
+			return false
+		}
+	}
+	return len(s) > 1
+}
+
+// AC5: aboutDescription prefers the data-entry app.description, falling back to the
 // metamodel's top-level description, and is empty when neither is set.
-func TestAppDescription(t *testing.T) {
+func TestAboutDescription(t *testing.T) {
 	cases := []struct {
 		name    string
 		appDesc string
@@ -148,8 +202,8 @@ func TestAppDescription(t *testing.T) {
 				Cfg:  &Config{App: AppConfig{Description: tc.appDesc}},
 				Meta: &metamodel.Metamodel{Description: tc.metaDsc},
 			}
-			if got := appDescription(s); got != tc.want {
-				t.Errorf("appDescription = %q, want %q", got, tc.want)
+			if got := aboutDescription(s); got != tc.want {
+				t.Errorf("aboutDescription = %q, want %q", got, tc.want)
 			}
 		})
 	}

--- a/internal/dataentry/help_docfields_test.go
+++ b/internal/dataentry/help_docfields_test.go
@@ -1,0 +1,156 @@
+package dataentry
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/Sourcehaven-BV/rela/internal/metamodel"
+)
+
+// helpMeta is a metamodel with a state-machine status enum (values + per-value
+// descriptions + transitions with labels/help), a plain enum (values only), and
+// a non-enum property, exercising every gatherEnumHelp branch (TKT-DUQBD0).
+func helpMeta() *metamodel.Metamodel {
+	return &metamodel.Metamodel{
+		Types: map[string]metamodel.CustomType{
+			"ticket-status": {
+				Values:  []string{"todo", "doing", "done"},
+				Initial: "todo",
+				Labels:  map[string]string{"doing": "In progress"},
+				Descriptions: map[string]string{
+					"todo":  "Not started yet.",
+					"doing": "Actively worked on.",
+				},
+				Transitions: []metamodel.TransitionDef{
+					{From: "todo", To: "doing", Label: "Start", Help: "when someone picks it up"},
+					{From: "doing", To: "done", Label: "Complete"},
+				},
+			},
+			"priority": {Values: []string{"high", "low"}},
+		},
+		Entities: map[string]metamodel.EntityDef{
+			"ticket": {
+				Label: "Ticket",
+				Properties: map[string]metamodel.PropertyDef{
+					"title":    {Type: "string"},
+					"status":   {Type: "ticket-status"},
+					"priority": {Type: "priority"},
+				},
+			},
+		},
+	}
+}
+
+func findEnum(hs []EnumHelp, prop string) (EnumHelp, bool) {
+	for _, h := range hs {
+		if h.Property == prop {
+			return h, true
+		}
+	}
+	return EnumHelp{}, false
+}
+
+// AC1/AC2: gatherEnumHelp collects values + lifecycle for a state machine, values
+// only for a plain enum, and nothing for a non-enum property.
+func TestGatherEnumHelp(t *testing.T) {
+	m := helpMeta()
+	def := m.Entities["ticket"]
+	hs := gatherEnumHelp(m, &def)
+
+	// title is not an enum → no entry.
+	if _, ok := findEnum(hs, "title"); ok {
+		t.Error("non-enum property should not appear in enum help")
+	}
+
+	status, ok := findEnum(hs, "status")
+	if !ok {
+		t.Fatal("status (state machine) should appear")
+	}
+	if status.Initial != "todo" {
+		t.Errorf("Initial = %q, want todo", status.Initial)
+	}
+	if len(status.Values) != 3 {
+		t.Fatalf("status values = %d, want 3", len(status.Values))
+	}
+	// Value carries label + description; a value with no description is empty.
+	doing := status.Values[1]
+	badDoing := doing.Value != "doing" || doing.Label != "In progress" ||
+		!strings.Contains(string(doing.Description), "Actively worked on")
+	if badDoing {
+		t.Errorf("doing value help mismatch: %+v", doing)
+	}
+	if status.Values[2].Value != "done" || status.Values[2].Description != "" {
+		t.Errorf("done should have no description, got %+v", status.Values[2])
+	}
+	// Transitions carry move label + help; a transition with no help is empty.
+	if len(status.Transitions) != 2 {
+		t.Fatalf("status transitions = %d, want 2", len(status.Transitions))
+	}
+	firstMove := status.Transitions[0]
+	badMove := firstMove.Move != "Start" || !strings.Contains(string(firstMove.Help), "picks it up")
+	if badMove {
+		t.Errorf("first transition help mismatch: %+v", firstMove)
+	}
+	if status.Transitions[1].Help != "" {
+		t.Errorf("Complete transition should have no help, got %q", status.Transitions[1].Help)
+	}
+
+	// priority is a plain enum → values, no transitions.
+	prio, ok := findEnum(hs, "priority")
+	if !ok {
+		t.Fatal("priority (plain enum) should appear")
+	}
+	if len(prio.Values) != 2 || len(prio.Transitions) != 0 {
+		t.Errorf("priority should have values but no transitions, got %+v", prio)
+	}
+}
+
+// AC2: the mermaid diagram carries the entry arrow + one labeled edge per
+// transition.
+func TestMermaidStateDiagram(t *testing.T) {
+	e := EnumHelp{
+		Initial: "todo",
+		Transitions: []TransitionHelp{
+			{Move: "Start", From: "todo", To: "doing"},
+			{Move: "done", From: "doing", To: "done"}, // move == to → no label
+		},
+	}
+	got := mermaidStateDiagram(e)
+
+	for _, want := range []string{
+		"stateDiagram-v2",
+		"[*] --> todo",
+		"todo --> doing: Start",
+		"doing --> done\n", // no ": done" label because move == to
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("diagram missing %q:\n%s", want, got)
+		}
+	}
+}
+
+// AC5: appDescription prefers the data-entry app.description, falling back to the
+// metamodel's top-level description, and is empty when neither is set.
+func TestAppDescription(t *testing.T) {
+	cases := []struct {
+		name    string
+		appDesc string
+		metaDsc string
+		want    string
+	}{
+		{"app wins", "from app", "from meta", "from app"},
+		{"fallback to meta", "", "from meta", "from meta"},
+		{"neither", "", "", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			s := &Schema{
+				Cfg:  &Config{App: AppConfig{Description: tc.appDesc}},
+				Meta: &metamodel.Metamodel{Description: tc.metaDsc},
+			}
+			if got := appDescription(s); got != tc.want {
+				t.Errorf("appDescription = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/metamodel/docfields_test.go
+++ b/internal/metamodel/docfields_test.go
@@ -1,0 +1,136 @@
+package metamodel
+
+import (
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+// docFieldsYAML is a metamodel exercising all three doc-fields (TKT-0YBFT8):
+// top-level description, per-value CustomType descriptions, and TransitionDef
+// help. It also carries labels + a transition label so the tests can confirm the
+// new fields are DISTINCT from (not colliding with) the existing display fields.
+const docFieldsYAML = `version: "1.0"
+description: |
+  A demo ticket tracker. This is the deployment description that end-user docs
+  should surface.
+types:
+  ticket-status:
+    values: [todo, doing, done]
+    initial: todo
+    labels:
+      todo: To do
+      doing: In progress
+    descriptions:
+      todo: Work that hasn't been started yet.
+      doing: Work actively in progress by an assignee.
+    transitions:
+      - from: todo
+        to: doing
+        label: Start progress
+        help: Begin work once the ticket is assigned and ready.
+      - from: doing
+        to: done
+        label: Complete
+entities:
+  ticket:
+    label: Ticket
+    id_prefix: "TKT-"
+    properties:
+      title:
+        type: string
+      status:
+        type: ticket-status
+`
+
+// AC1/AC2/AC3: each doc-field parses into its struct field.
+func TestParse_DocFields_Present(t *testing.T) {
+	m, err := Parse([]byte(docFieldsYAML))
+	assertNoError(t, err)
+
+	// AC1: top-level description.
+	if m.Description == "" {
+		t.Error("Metamodel.Description should be populated from `description:`")
+	}
+
+	ct := m.Types["ticket-status"]
+
+	// AC2: per-value descriptions, keyed by value, distinct from Labels.
+	assertEqual(t, ct.Descriptions["todo"], "Work that hasn't been started yet.")
+	assertEqual(t, ct.Descriptions["doing"], "Work actively in progress by an assignee.")
+	// Labels still carry the short display text — the two maps are independent.
+	assertEqual(t, ct.Labels["todo"], "To do")
+	// A value with no description entry is simply absent (not an error).
+	if _, ok := ct.Descriptions["done"]; ok {
+		t.Error("value with no `descriptions:` entry should be absent from the map")
+	}
+
+	// AC3: transition help, distinct from the transition label.
+	tr := ct.Transitions[0]
+	assertEqual(t, tr.From, "todo")
+	assertEqual(t, tr.Label, "Start progress")
+	assertEqual(t, tr.Help, "Begin work once the ticket is assigned and ready.")
+	// A transition with no help is simply empty.
+	assertEqual(t, ct.Transitions[1].Help, "")
+}
+
+// AC4 (absence): a metamodel with none of the doc-fields loads unchanged, with
+// zero-valued doc-fields.
+func TestParse_DocFields_Absent(t *testing.T) {
+	const yaml = `version: "1.0"
+types:
+  ticket-status:
+    values: [todo, done]
+entities:
+  ticket:
+    label: Ticket
+    id_prefix: "TKT-"
+    properties:
+      title:
+        type: string
+`
+	m, err := Parse([]byte(yaml))
+	assertNoError(t, err)
+
+	assertEqual(t, m.Description, "")
+	ct := m.Types["ticket-status"]
+	if ct.Descriptions != nil {
+		t.Errorf("absent `descriptions:` should be nil, got %v", ct.Descriptions)
+	}
+}
+
+// AC5: `description:` is a valid top-level key — checkUnknownKeys must not flag
+// it. (Regression guard for the validTopLevelKeys allowlist change.)
+func TestParse_DocFields_TopLevelDescriptionAccepted(t *testing.T) {
+	const yaml = `version: "1.0"
+description: A one-line deployment description.
+entities:
+  ticket:
+    label: Ticket
+    id_prefix: "TKT-"
+    properties:
+      title:
+        type: string
+`
+	m, err := Parse([]byte(yaml))
+	assertNoError(t, err) // would be a SchemaValidationError without the allowlist entry
+	assertEqual(t, m.Description, "A one-line deployment description.")
+}
+
+// AC4 (round-trip): parse -> marshal -> parse preserves all three doc-fields.
+func TestParse_DocFields_RoundTrip(t *testing.T) {
+	m1, err := Parse([]byte(docFieldsYAML))
+	assertNoError(t, err)
+
+	out, err := yaml.Marshal(m1)
+	assertNoError(t, err)
+
+	m2, err := Parse(out)
+	assertNoError(t, err)
+
+	assertEqual(t, m2.Description, m1.Description)
+	ct1, ct2 := m1.Types["ticket-status"], m2.Types["ticket-status"]
+	assertEqual(t, ct2.Descriptions["todo"], ct1.Descriptions["todo"])
+	assertEqual(t, ct2.Descriptions["doing"], ct1.Descriptions["doing"])
+	assertEqual(t, ct2.Transitions[0].Help, ct1.Transitions[0].Help)
+}

--- a/internal/metamodel/include.go
+++ b/internal/metamodel/include.go
@@ -20,8 +20,9 @@ type partialMetamodel struct {
 	Includes    []string               `yaml:"includes"`
 
 	// Fields that are not allowed in included files
-	Version   string `yaml:"version"`
-	Namespace string `yaml:"namespace"`
+	Version     string `yaml:"version"`
+	Namespace   string `yaml:"namespace"`
+	Description string `yaml:"description"`
 }
 
 // includeState tracks file processing state during recursive include resolution.
@@ -132,6 +133,9 @@ func resolveIncludes(
 	}
 	if partial.Namespace != "" {
 		return nil, &IncludeHasRootFieldError{Path: includePath, Field: "namespace"}
+	}
+	if partial.Description != "" {
+		return nil, &IncludeHasRootFieldError{Path: includePath, Field: "description"}
 	}
 
 	// Push onto stack for circular detection

--- a/internal/metamodel/include_test.go
+++ b/internal/metamodel/include_test.go
@@ -464,6 +464,39 @@ entities:
 	assertEqual(t, rootFieldErr.Field, "namespace")
 }
 
+// description is a deployment-wide, root-only field (TKT-0YBFT8) — like version
+// and namespace it must be rejected in an included partial, not silently dropped.
+func TestLoadWithIncludes_IncludeHasDescription(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	createFile(t, filepath.Join(tmpDir, "metamodel.yaml"), `
+version: "1.0"
+includes:
+  - bad.yaml
+`)
+
+	createFile(t, filepath.Join(tmpDir, "bad.yaml"), `
+description: A partial should not carry the deployment description.
+entities:
+  control:
+    label: Control
+    id_prefix: "CTL-"
+    id_type: sequential
+    properties:
+      title:
+        type: string
+`)
+
+	_, _, err := Load(filepath.Join(tmpDir, "metamodel.yaml"), testMetaFS)
+	assertError(t, err)
+
+	var rootFieldErr *IncludeHasRootFieldError
+	if !errors.As(err, &rootFieldErr) {
+		t.Fatalf("expected IncludeHasRootFieldError, got %T: %v", err, err)
+	}
+	assertEqual(t, rootFieldErr.Field, "description")
+}
+
 func TestLoadWithIncludes_EmptyIncludes(t *testing.T) {
 	tmpDir := t.TempDir()
 

--- a/internal/metamodel/loader.go
+++ b/internal/metamodel/loader.go
@@ -16,6 +16,7 @@ import (
 var validTopLevelKeys = map[string]bool{
 	"version":     true,
 	"namespace":   true,
+	"description": true,
 	"types":       true,
 	"entities":    true,
 	"relations":   true,

--- a/internal/metamodel/rename_test.go
+++ b/internal/metamodel/rename_test.go
@@ -117,6 +117,56 @@ validations:
 		}
 	})
 
+	// TKT-0YBFT8 / RR#5: the rename path re-marshals via yaml.Node (AST), so the
+	// doc-only fields (top-level description, per-value descriptions, transition
+	// help) must survive a rename that doesn't touch them — a regression guard
+	// against a future rename-path change dropping unrecognized keys.
+	t.Run("preserves doc-fields through a rename", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "metamodel.yaml")
+
+		input := `version: "1.0"
+description: A demo deployment description that must survive rename.
+types:
+  ticket-status:
+    values: [open, done]
+    descriptions:
+      open: A newly filed ticket.
+    transitions:
+      - from: open
+        to: done
+        help: Close it when the work is finished.
+entities:
+  requirement:
+    label: Requirement
+    id_prefix: "REQ-"
+    id_type: sequential
+    properties:
+      status:
+        type: ticket-status
+relations: {}
+`
+		writeFile(t, path, input)
+
+		if err := RenameEntityType(path, "requirement", "feature", testMetaFS); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		// Re-parse and assert every doc-field survived the AST round-trip.
+		m, err := Parse([]byte(readFile(t, path)))
+		assertNoError(t, err)
+		if m.Description == "" {
+			t.Error("top-level description lost through rename")
+		}
+		ct := m.Types["ticket-status"]
+		assertEqual(t, ct.Descriptions["open"], "A newly filed ticket.")
+		assertEqual(t, ct.Transitions[0].Help, "Close it when the work is finished.")
+		// And the rename itself happened.
+		if _, ok := m.Entities["feature"]; !ok {
+			t.Error("rename did not produce the feature entity")
+		}
+	})
+
 	t.Run("error when type not found", func(t *testing.T) {
 		dir := t.TempDir()
 		path := filepath.Join(dir, "metamodel.yaml")

--- a/internal/metamodel/types.go
+++ b/internal/metamodel/types.go
@@ -14,8 +14,13 @@ import (
 //
 //plimsoll:max-exported-methods=31
 type Metamodel struct {
-	Version     string                 `yaml:"version"`
-	Namespace   string                 `yaml:"namespace"`
+	Version   string `yaml:"version"`
+	Namespace string `yaml:"namespace"`
+	// Description is optional end-user prose describing what this deployment /
+	// application is for. Display-only, surfaced by the generated documentation
+	// (the `rela docs` generator — FEAT-G4VO53). Empty by default; the metamodel
+	// does not otherwise consult it.
+	Description string                 `yaml:"description,omitempty"`
 	Includes    []string               `yaml:"includes,omitempty"`
 	Types       map[string]CustomType  `yaml:"types"`
 	Entities    map[string]EntityDef   `yaml:"entities"`
@@ -129,11 +134,18 @@ func (tv *TypeValidation) SetCompiled(re *regexp.Regexp) {
 
 // CustomType defines a reusable type with optional enum values and/or regex validations.
 type CustomType struct {
-	Values      []string          `yaml:"values,omitempty"`      // Allowed values (makes this an enum type)
-	Labels      map[string]string `yaml:"labels,omitempty"`      // Optional display labels keyed by value (display-only; value stays the identity)
-	Default     string            `yaml:"default,omitempty"`     // Default value
-	Description string            `yaml:"description,omitempty"` // Documentation for the type
-	Validations []TypeValidation  `yaml:"validations,omitempty"` // Regex validations with error messages
+	Values []string          `yaml:"values,omitempty"` // Allowed values (makes this an enum type)
+	Labels map[string]string `yaml:"labels,omitempty"` // Optional display labels keyed by value (display-only; value stays the identity)
+	// Descriptions is optional per-value prose keyed by value: what each value
+	// MEANS, as opposed to Labels (the short display text). Display-only,
+	// surfaced by the generated documentation (FEAT-G4VO53) so a reader
+	// understands e.g. what "blocked" or "in-review" signifies. A value with no
+	// entry simply has no description. Distinct from the type-level Description
+	// scalar below (which documents the type as a whole).
+	Descriptions map[string]string `yaml:"descriptions,omitempty"`
+	Default      string            `yaml:"default,omitempty"`     // Default value
+	Description  string            `yaml:"description,omitempty"` // Documentation for the type
+	Validations  []TypeValidation  `yaml:"validations,omitempty"` // Regex validations with error messages
 
 	// Transitions declares the legal value→value moves for this enum,
 	// making it a state machine (TKT-E4LW2). This is declarative source
@@ -166,6 +178,12 @@ type TransitionDef struct {
 	// label (CustomType.Labels[To]) and then the raw To value. Display-only; the
 	// executable machine ignores it for enforcement.
 	Label string `yaml:"label,omitempty"`
+
+	// Help is optional longer prose explaining WHY or WHEN a user would make
+	// this move, beyond the short verb Label — e.g. "Send for review once the
+	// implementation is complete and tests pass." Display-only, surfaced by the
+	// generated documentation (FEAT-G4VO53); the executable machine ignores it.
+	Help string `yaml:"help,omitempty"`
 
 	// Guard names an ACL permission the acting principal must hold for this
 	// transition. Enforced only on served paths (a principal exists); inert

--- a/prototypes/data-entry/project/metamodel.yaml
+++ b/prototypes/data-entry/project/metamodel.yaml
@@ -1,11 +1,47 @@
 version: "1.0"
+description: |
+  A lightweight ticket tracker: capture work as tickets, group them into
+  categories, tag and cross-link them, and move each ticket through a simple
+  lifecycle from open to closed. This description, the per-status explanations,
+  and the transition help below are surfaced by the generated documentation
+  (`rela docs`).
 types:
   ticket_status:
     values: [open, in-progress, resolved, closed]
     default: open
+    initial: open
+    labels:
+      in-progress: In progress
+    descriptions:
+      open: A newly filed ticket that no one has started yet.
+      in-progress: Someone is actively working on the ticket.
+      resolved: The work is done and awaiting confirmation before it is closed.
+      closed: The ticket is finished; no further work is expected.
+    transitions:
+      - from: open
+        to: in-progress
+        label: Start work
+        help: Move a ticket here once someone picks it up and begins working on it.
+      - from: in-progress
+        to: resolved
+        label: Mark resolved
+        help: Use this when the work is complete and ready for the reporter to verify.
+      - from: resolved
+        to: closed
+        label: Close
+        help: Close the ticket once the reporter has confirmed the resolution.
+      - from: resolved
+        to: in-progress
+        label: Reopen
+        help: Send it back to in-progress if verification finds the work is not done.
   priority:
     values: [critical, high, medium, low]
     default: medium
+    descriptions:
+      critical: Needs immediate attention; blocks other work or users.
+      high: Important; should be handled soon.
+      medium: Normal priority.
+      low: Nice to have; handle when there is spare capacity.
 entities:
   ticket:
     label: Ticket

--- a/tickets/entities/docs-checklists/DOCS-NKY0Z9.md
+++ b/tickets/entities/docs-checklists/DOCS-NKY0Z9.md
@@ -1,0 +1,26 @@
+---
+id: DOCS-NKY0Z9
+type: docs-checklist
+title: 'Docs: doc-fields in the help modal + About (TKT-DUQBD0)'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Code Documentation
+
+- [x] Godoc on new symbols (gatherEnumHelp, renderEnumHelp, mermaidStateDiagram, mermaidLabel, aboutDescription, EnumHelp/ValueHelp/TransitionHelp) — including the injection-safety rationale on mermaidStateDiagram and the "separate from AppConfig.Description" rationale on aboutDescription + v1.Config.about_description.
+- [x] TSDoc on the new store field + config type.
+
+## Project Documentation
+
+- [x] ~~docs/metamodel.md~~ (N/A: the doc-FIELDS themselves are documented in TKT-0YBFT8; this ticket only surfaces them in the UI — no new schema surface)
+- [x] ~~docs/data-entry~~ (N/A: the help modal + About are internal UI; no API-reference contract change beyond the additive `about_description` config field, which is self-describing)
+
+## External Documentation
+
+- [x] ~~README / tutorials~~ (N/A: UI enhancement)
+
+## Verification
+
+- [x] The metamodel-doc-field docs (from TKT-0YBFT8) accurately describe fields now rendered by this UI — consistent.

--- a/tickets/entities/docs-checklists/DOCS-OBV091.md
+++ b/tickets/entities/docs-checklists/DOCS-OBV091.md
@@ -1,0 +1,26 @@
+---
+id: DOCS-OBV091
+type: docs-checklist
+title: 'Docs: Metamodel doc-fields (TKT-0YBFT8)'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Code Documentation
+
+- [x] Godoc on the three new fields (Metamodel.Description, CustomType.Descriptions, TransitionDef.Help) explaining they are display-only, doc-generator-facing, and how Descriptions differs from Labels / the type-level Description scalar.
+- [x] Doc comment on toV1CustomType pinning the intentional wire-omission phase boundary.
+
+## Project Documentation
+
+- [x] docs/metamodel.md (via source GUIDE-metamodel.md) — added: top-level `description:` in Structure; a "Value Descriptions" subsection (`descriptions:` vs `labels:`); `help:` in the State Machines transition-field table + example; updated the include root-only list to include `description:`. Regenerated; markdownlint clean.
+
+## External Documentation
+
+- [x] ~~README / tutorials~~ (N/A: additive optional schema fields; covered by the metamodel guide)
+
+## Verification
+
+- [x] Docs match code (include root-only list now lists description, matching the include.go guard + its new test)
+- [x] Example in the guide matches the real fields (parses; mirrored in prototypes/data-entry/project/metamodel.yaml)

--- a/tickets/entities/features/FEAT-G4VO53.md
+++ b/tickets/entities/features/FEAT-G4VO53.md
@@ -1,0 +1,32 @@
+---
+id: FEAT-G4VO53
+type: feature
+title: Generated deployment documentation (rela docs)
+description: 'Generate per-deployment end-user + operator/support documentation from a rela project''s metamodel.yaml + acl.yaml as one Markdown file (mermaid state diagrams; PDF-convertible), replacing hand-maintained docs. Delivered in phases: 1a metamodel doc-fields, 1b ACL role descriptions, 2 the `rela docs --output-dir` generator. See RES-EK7LSA.'
+status: proposed
+---
+
+# Generated deployment documentation (`rela docs`)
+
+Generate per-deployment end-user + operator/support documentation from a rela
+project's `metamodel.yaml` + `acl.yaml`, as one Markdown file (PDF-convertible;
+mermaid state diagrams). Replaces hand-maintained docs that drift from the
+schema.
+
+Two audiences (per Diátaxis, the schema produces *reference* + inferred
+*how-to*; human prose supplies the *explanation* layer via new doc-fields):
+- **End users** — what the entity types are, their fields (with per-value
+meaning), how they relate, the lifecycle (state machines as diagrams + narrated
+transitions), and what happens automatically (automations).
+- **Operators / support staff** — the role model: who can do what, who can
+perform which guarded transitions, what rules must hold (GitLab-style role ×
+entity capability matrix).
+
+Delivered in phases (see research RES-EK7LSA):
+- **Phase 1a** — metamodel doc-fields (top-level description, per-enum-value
+descriptions, transition help).
+- **Phase 1b** — ACL role descriptions.
+- **Phase 2** — the `rela docs --output-dir` generator (depends on 1a + 1b).
+
+New top-level `rela docs` command; depends only on `internal/metamodel` +
+`internal/acl`; mirrors `internal/cli/schema.go`'s metamodel walk.

--- a/tickets/entities/implementation-checklists/IMPL-2L80XR.md
+++ b/tickets/entities/implementation-checklists/IMPL-2L80XR.md
@@ -1,0 +1,44 @@
+---
+id: IMPL-2L80XR
+type: implementation-checklist
+title: 'Implementation: Metamodel doc-fields: top-level description, per-enum-value descriptions, transition help (rela-docs phase 1a)'
+status: in-progress
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Development
+
+- [ ] Unit tests written for new code
+- [ ] Integration tests written (test full flow, not just units)
+- [ ] Happy path implemented
+- [ ] Edge cases from planning handled
+- [ ] Error handling in place (errors surfaced, not swallowed)
+
+## Test Quality
+
+- [ ] Using fixture builders or factories for test data
+- [ ] No hardcoded values in assertions when object is in scope
+- [ ] Only specifying values that matter for the test
+- [ ] Interpolated values constructed from objects, not hardcoded
+- [ ] Property comparisons use original object, not hardcoded strings
+
+## Manual Verification
+
+- [ ] Feature manually tested end-to-end
+- [ ] Each acceptance criterion verified with test scenario from planning
+- [ ] Edge cases manually verified
+
+**Verification Evidence:**
+<!-- Document what you tested and the results -->
+
+## Quality
+
+- [ ] Code follows project patterns (check similar code)
+- [ ] Checked for DRY opportunities — repeated literals, expressions, or
+patterns extracted to a helper / constant / type where it sharpens the contract
+(don't extract for its own sake; CLAUDE.md "three similar lines is better than a
+premature abstraction" still holds)
+- [ ] No security issues introduced
+- [ ] No silent failures (errors logged AND returned)
+- [ ] No debug code left behind

--- a/tickets/entities/implementation-checklists/IMPL-2L80XR.md
+++ b/tickets/entities/implementation-checklists/IMPL-2L80XR.md
@@ -2,43 +2,46 @@
 id: IMPL-2L80XR
 type: implementation-checklist
 title: 'Implementation: Metamodel doc-fields: top-level description, per-enum-value descriptions, transition help (rela-docs phase 1a)'
-status: in-progress
+status: done
 ---
 
 <!-- @managed: claude-workflow v1 -->
 
 ## Development
 
-- [ ] Unit tests written for new code
-- [ ] Integration tests written (test full flow, not just units)
-- [ ] Happy path implemented
-- [ ] Edge cases from planning handled
-- [ ] Error handling in place (errors surfaced, not swallowed)
+- [x] Unit tests written for new code (docfields_test.go)
+- [x] Integration tested (real prototype metamodel loads via `rela schema`/`validate`)
+- [x] Happy path implemented
+- [x] Edge cases handled (absence, round-trip, top-level-key acceptance, include rejection)
+- [x] Error handling: malformed fields yield standard yaml errors; include-file description rejected with IncludeHasRootFieldError
 
 ## Test Quality
 
-- [ ] Using fixture builders or factories for test data
-- [ ] No hardcoded values in assertions when object is in scope
-- [ ] Only specifying values that matter for the test
-- [ ] Interpolated values constructed from objects, not hardcoded
-- [ ] Property comparisons use original object, not hardcoded strings
+- [x] Fixture YAML in-test; asserts only the fields under test
+- [x] No hardcoded values where the object is in scope
+- [x] Round-trip asserts m2 vs m1 (original object), not hardcoded strings
 
 ## Manual Verification
 
-- [ ] Feature manually tested end-to-end
-- [ ] Each acceptance criterion verified with test scenario from planning
-- [ ] Edge cases manually verified
+- [x] Each acceptance criterion verified
 
 **Verification Evidence:**
-<!-- Document what you tested and the results -->
+- AC1/2/3: `TestParse_DocFields_Present` — description, per-value descriptions (distinct from labels), transition help all parse.
+- AC4 (absence): `TestParse_DocFields_Absent` — zero values, nil map.
+- AC4 (round-trip): `TestParse_DocFields_RoundTrip` — parse→marshal→parse preserves all three.
+- AC5 (top-level key): `TestParse_DocFields_TopLevelDescriptionAccepted` — root `description:` not rejected by checkUnknownKeys (guards the validTopLevelKeys change). Also added `description` to the include root-only guard (rejected in include files, like version/namespace).
+- AC6 (example): `prototypes/data-entry/project/metamodel.yaml` enriched with top-level `description:`, per-value `descriptions:` on ticket_status + priority, and a ticket_status state machine (transitions with labels + help). `rela schema --project ... types` loads it cleanly; `metamodel.yaml is valid`. (The prototype's data-entry.yaml has a PRE-EXISTING unrelated `ticket_report` view error — confirmed identical on develop via git stash — not introduced here.)
+- AC7: tests cover parse + absence + round-trip per field.
+
+Backend: `go test ./internal/metamodel ./internal/statemachine` pass; `go build
+./...` OK; `golangci-lint ./internal/metamodel` 0 issues; `just coverage-check`
+PASS (metamodel 83.1%); regenerated `docs/metamodel.md` from source guide,
+markdownlint clean.
 
 ## Quality
 
-- [ ] Code follows project patterns (check similar code)
-- [ ] Checked for DRY opportunities — repeated literals, expressions, or
-patterns extracted to a helper / constant / type where it sharpens the contract
-(don't extract for its own sake; CLAUDE.md "three similar lines is better than a
-premature abstraction" still holds)
-- [ ] No security issues introduced
-- [ ] No silent failures (errors logged AND returned)
-- [ ] No debug code left behind
+- [x] Follows project patterns (fields mirror existing Description/Labels/Label; struct-tag unmarshal)
+- [x] DRY — reused the existing parse path; `descriptions` mirrors `labels` shape exactly; no premature abstraction
+- [x] No security issues — display-only prose, operator-trusted config, no enforcement/validation change
+- [x] No silent failures — include-file description surfaces IncludeHasRootFieldError
+- [x] No debug code left behind

--- a/tickets/entities/implementation-checklists/IMPL-LS0PDS.md
+++ b/tickets/entities/implementation-checklists/IMPL-LS0PDS.md
@@ -1,0 +1,44 @@
+---
+id: IMPL-LS0PDS
+type: implementation-checklist
+title: 'Implementation: Surface metamodel doc-fields in data-entry help: per-entity values+lifecycle, plus a global help icon showing the app description'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Development
+
+- [x] Unit tests written (help_docfields_test.go: gatherEnumHelp, mermaidStateDiagram + injection-safe, aboutDescription)
+- [x] Integration verified live via the demo (help modal + About in the browser)
+- [x] Happy path implemented
+- [x] Edge cases handled (plain enum, non-enum prop, terminal machine, empty description, injection-hostile values)
+- [x] Error handling: help-load token guard; mermaid render skipped on error
+
+## Manual Verification
+
+- [x] Each acceptance criterion verified
+
+**Verification Evidence (live, prototype demo via puppeteer):**
+- AC1: help modal shows a Values section per enum property with per-value descriptions.
+- AC2: Lifecycle section renders a mermaid state diagram (SVG) + a transitions table with Help; one diagram per machine field. Diagram displays real values (aliased ids hidden).
+- AC3: plain/non-machine fields add no sections.
+- AC4: toV1CustomType + TestToV1CustomType_OmitsDocFields untouched (green).
+- AC5: `ⓘ About` button in the status bar shows the deployment description; hidden when empty. Uses the dedicated `about_description` wire field (metamodel fallback), NOT AppConfig.Description (SettingsView safe).
+- AC6: Go tests — TestGatherEnumHelp, TestMermaidStateDiagram(_InjectionSafe), TestAboutDescription. AC7: verified live.
+
+Backend: `go test ./internal/dataentry ./internal/apiwire` pass; `go build
+./...` OK; golangci-lint 0 issues. Frontend: `npm run test:run` 1356 pass;
+typecheck clean; eslint 0 errors on touched files.
+
+## Quality
+
+- [x] Follows patterns (server help-HTML render like existing Properties/Relations; DOMPurify at the sink; renderMarkdown for About)
+- [x] DRY — reused renderMermaidDiagrams / renderMarkdown / simpleMarkdownToHTML
+- [x] Security — mermaid source injection-hardened (synthetic-id aliasing + label flattening); no XSS (strict mode + DOMPurify); no new wire-contract on toV1CustomType
+- [x] No silent failures
+- [x] No debug code left behind
+
+**Note:** code review (cranky) raised 3 significant + 2 minor findings, all
+addressed in commit a5158bc4 (RR-0GNDA9, RR-Y0RL1L, RR-BOIZB2, RR-NRJI7S,
+RR-WHGL4S).

--- a/tickets/entities/planning-checklists/PLAN-0D7FDK.md
+++ b/tickets/entities/planning-checklists/PLAN-0D7FDK.md
@@ -1,0 +1,114 @@
+---
+id: PLAN-0D7FDK
+type: planning-checklist
+title: 'Planning: Metamodel doc-fields: top-level description, per-enum-value descriptions, transition help (rela-docs phase 1a)'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Understanding
+
+- [x] Problem/requirements clearly understood
+- [x] Scope defined (in/out below)
+- [x] Acceptance criteria documented with test scenarios
+
+**Scope**
+
+IN — three additive, optional, backward-compatible doc-fields + example
+population:
+1. `Metamodel.Description string` (`yaml:"description,omitempty"`, top-level). **Must also add `"description"` to `validTopLevelKeys` in loader.go — the parser rejects unknown top-level keys, so without this a root `description:` fails to load.**
+2. Per-enum-value descriptions on `CustomType` — `Descriptions map[string]string` (`yaml:"descriptions,omitempty"`), keyed by value, mirroring the existing `Labels map[string]string`. Nested → no allowlist change needed.
+3. `TransitionDef.Help string` (`yaml:"help,omitempty"`). Nested → no allowlist change.
+4. Populate the fields in an in-tree example project.
+
+OUT — the `rela docs` generator (phase 2); ACL RoleDef.Description (phase 1b); a
+`docs:` structured block (research rejected A2); any enforcement/validation
+behavior change (display-only fields).
+
+**Acceptance Criteria**
+1. Root `description:` parses into `Metamodel.Description`, readable; absent → "". Test: parse fixture with/without.
+2. CustomType `descriptions:` parses into `CustomType.Descriptions` keyed by value, readable; absent → nil. Test: parse fixture.
+3. TransitionDef `help:` parses into `TransitionDef.Help`, readable; absent → "". Test: parse fixture.
+4. Backward-compatible: an existing metamodel with none of the fields loads + validates unchanged; parse→marshal round-trip preserves all three. Test: round-trip + the existing metamodel test corpus still passes.
+5. `description:` is accepted as a valid top-level key (not flagged by checkUnknownKeys). Test: a metamodel with root `description:` loads without a SchemaValidationError.
+6. At least one in-tree example populates all three (see Approach for which).
+7. Tests cover parse + absence + round-trip for each field.
+
+## Research
+
+- [x] ~~/research~~ (done: RES-EK7LSA covers the whole arc)
+- [x] Searched codebase for the field-add pattern
+- [x] Reviewed prior art
+
+**Existing Solutions / prior art**
+- Field shape mirrors `EntityDef.Description`, `CustomType.Labels`, `CustomType.Description`, `TransitionDef.Label` — all plain struct tags in `internal/metamodel/types.go`.
+- Parse path: `metamodel.Parse` → `parseRaw` → `yaml.Unmarshal` (struct tags) + `checkUnknownKeys` (loader.go:746, TOP-LEVEL keys only) + `extractPropertyOrder` (yaml.Node pass for entity property order only — irrelevant to these fields).
+- **Key gotcha:** `validTopLevelKeys` (loader.go:16) allowlists top-level keys; `Metamodel.Description` needs `"description"` added there. Nested fields (CustomType.Descriptions, TransitionDef.Help) are NOT allowlisted — standard unmarshal handles them.
+
+## Approach
+
+- Add `Description string` to `Metamodel` struct (types.go:16) + `"description": true` to `validTopLevelKeys` (loader.go:16).
+- Add `Descriptions map[string]string` to `CustomType` (types.go:131), tag `descriptions,omitempty`, doc-comment distinguishing it from `Labels` (display text) — `Descriptions` = the *meaning*/prose of a value.
+- Add `Help string` to `TransitionDef` (types.go:158), tag `help,omitempty`.
+- No accessor methods strictly required (fields are exported); add small doc comments.
+- **Example population:** `tickets/`, `docs-project/`, `prototypes/*` metamodels have status enums but NONE declare `transitions:` today. So: (a) add root `description:` + per-value `descriptions:` to an existing example that has a status enum (e.g. `prototypes/data-entry/project/metamodel.yaml` — the showcase project), and (b) to exercise transition `help`, add a small state machine (transitions + help) to that same prototype metamodel. Prototypes is the right home for showcase schemas; keep it realistic. Validate the project still passes `rela validate` after.
+
+**Files to modify:**
+- `internal/metamodel/types.go` (3 fields)
+- `internal/metamodel/loader.go` (validTopLevelKeys)
+- `internal/metamodel/*_test.go` (parse/absence/round-trip tests)
+- one `prototypes/**/metamodel.yaml` (example population)
+- possibly `docs/metamodel.md` source (`docs-project/entities/guides/GUIDE-metamodel.md`) documenting the new fields — likely folded into phase 2, but a short note here is cheap.
+
+## Security Considerations
+
+- [x] Input sources identified: metamodel YAML (operator-authored, trusted config — same trust level as all other metamodel fields).
+- [x] Validation approach: none needed — free-form prose strings, display-only. No injection surface (they're rendered as Markdown by the future generator, which escapes/handles that at render time, not here).
+- [x] No security-sensitive operations. ACL/enforcement untouched.
+- [x] Error handling: a malformed `descriptions:` (e.g. non-map) yields a standard yaml unmarshal error — same as any mistyped field.
+
+## Test Plan
+
+- [x] Scenarios per AC (above)
+- [x] Edge cases identified
+- [x] Negative cases defined
+- [x] Integration approach: the existing metamodel test corpus + `rela validate` on the populated example project.
+
+**Edge Cases:**
+- All three absent → zero values, no behavior change (the backward-compat case).
+- `descriptions:` with a key not in `values:` → tolerated (display-only; not validated — matches how `Labels` behaves; confirm Labels isn't strictly validated and mirror it).
+- Empty string values → preserved as-is.
+- Round-trip (parse→marshal→parse) preserves all three.
+
+**Negative Tests:**
+- Root `description:` must NOT be rejected by checkUnknownKeys (AC5) — regression guard for the allowlist change.
+
+## Risk Assessment
+
+- [x] Technical risks assessed
+- [x] Security risks assessed (none)
+- [x] Effort estimated: s
+
+**Risks:**
+- Forgetting the `validTopLevelKeys` entry → root `description:` silently rejected. Mitigated by AC5 + its explicit test.
+- `Descriptions` vs `Labels` confusion for authors → clear doc comments + the example project showing both used together.
+- Marshal path: confirm `yaml.Marshal` round-trips the new fields (it will, given struct tags) — covered by the round-trip test.
+
+## Documentation Planning
+
+- [x] User-facing docs identified
+- [x] Docs-checklist created on entering implementation
+
+**Documentation Impact:**
+- [x] docs/metamodel.md (via source guide) — document the three new fields (Custom Types section for descriptions/help; a top-level `description:` note). Small addition; could also ride phase 2, but cheap to do here.
+- [x] N/A others
+
+## Design Review
+
+- [x] ~~/design-review~~ — approach is a mechanical additive-field change following an established pattern; design settled in research RES-EK7LSA and this plan. No novel design surface.
+- [x] No open critical/significant findings.
+
+**Design Review Findings:** N/A — additive fields mirroring existing ones; the
+one non-obvious point (validTopLevelKeys) is captured with a dedicated AC +
+test.

--- a/tickets/entities/planning-checklists/PLAN-VGLUSN.md
+++ b/tickets/entities/planning-checklists/PLAN-VGLUSN.md
@@ -1,0 +1,82 @@
+---
+id: PLAN-VGLUSN
+type: planning-checklist
+title: 'Planning: Surface metamodel doc-fields in data-entry help: per-entity values+lifecycle, plus a global help icon showing the app description'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Understanding
+
+- [x] Problem/scope/AC clear (see ticket)
+- [x] Depends on TKT-0YBFT8 (same branch)
+
+## Approach
+
+**Part A — per-entity help (Go, handlers.go, HTML endpoint):**
+- Extend `handleEntityHelp`: for each enum/state-machine property, resolve its
+`CustomType` (`s.Meta.Types[prop.Type]`, or inline `prop.Values`/`Labels`).
+- New struct(s): `ValueHelp{Value, Label, Description}` and
+`TransitionHelp{From, To, Label, Help}`, gathered per property that is an enum.
+- Extend `renderHelpContent` with:
+  - **Values** section per enum property: a `.help-table` (Value | Description),
+using label when set, description via `simpleMarkdownToHTML`. Omit if the type
+has no values.
+  - **Lifecycle** section per state-machine property (type has `Transitions`):
+a `.help-table` (Move | From→To | When to use) with label + Help.
+- Sections omitted when empty (no noise). Mirrors the existing Properties/
+Relations rendering exactly; HelpModal.vue CSS unchanged.
+
+**Part B — global app description (config + status bar):**
+- Go: `handleV1Config` builds `v1.Config`; add `Description` to `v1.AppConfig`
+and populate from `s.Meta.Description`. (Distinct from `toV1CustomType` — pin
+test untouched.)
+- TS: add `description?` to the config/app TS type.
+- SPA: add a help/`?` button to the bottom status bar next to Settings + theme
+toggle (StatusBar.vue or the layout that renders them), opening an About overlay
+bound to the config description. Reuse HelpModal.vue's overlay styling (or a
+thin About modal). Button hidden when description is empty.
+
+**Files:**
+- `internal/dataentry/handlers.go` (values + lifecycle sections + structs)
+- `internal/dataentry/handlers_test.go` (or new) — help-render tests
+- `internal/dataentry/api_v1.go` (`handleV1Config` → App.Description) +
+`internal/apiwire/v1/responses.go` (AppConfig.Description)
+- `frontend/src/types/*` (config type), a StatusBar/layout component, an About
+overlay, + a small component test
+
+## Test Plan
+
+- [x] Go: help endpoint renders a Values section (value+desc) for an enum prop;
+a Lifecycle section for a machine prop; omits both for a plain field. Config
+carries `description`.
+- [x] SPA: status-bar help button renders; opens the About overlay with the
+description; hidden when absent.
+- [x] Edge: value with no description → value/label only; type with no
+transitions → no Lifecycle section; empty Metamodel.Description → no button.
+- [x] Manual: demo against the prototype project.
+
+## Security
+
+- [x] Help HTML is built with `htmltemplate.HTMLEscapeString` for values/labels
+and `simpleMarkdownToHTML` for prose (existing goldmark path, DOMPurify on the
+client) — same trust model as the existing description rendering. Config
+description is JSON (escaped by the encoder). No new injection surface.
+
+## Risk
+
+- [x] Small; mirrors established patterns. Main watch-item: don't accidentally
+wire the doc-fields to `toV1CustomType` (keep the pin test green) — Part A is
+the HTML endpoint, Part B is config, neither touches it.
+- Effort: s.
+
+## Docs
+
+- [x] N/A user-facing doc change (this is UI surfacing of already-documented
+fields). Docs-checklist on entering implementation, likely mostly N/A.
+
+## Design Review
+
+- [x] ~~/design-review~~ — mechanical, follows the existing help-render +
+config patterns; no novel design surface.

--- a/tickets/entities/researchs/RES-EK7LSA.md
+++ b/tickets/entities/researchs/RES-EK7LSA.md
@@ -1,0 +1,194 @@
+---
+id: RES-EK7LSA
+type: research
+title: Generating end-user + operator docs from a rela deployment (metamodel + acl.yaml -> Markdown)
+summary: 'Recommend: add 4 minimal doc-fields (metamodel/CustomType-value/TransitionDef/RoleDef descriptions) first, then a `rela docs --output-dir` generator emitting one Diataxis-informed Markdown (reference tables + prose + mermaid state diagrams + role x entity capability matrix).'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Problem
+
+A rela deployment (ticket tracker, ISMS, project tracker, ...) is fully
+described by its `metamodel.yaml` (entity types, properties, relations, custom
+types / state machines, automations, validations) + `acl.yaml` (roles,
+permissions, role-relations, assignments). Today the end-user and
+operator/support documentation for such a deployment is hand-maintained and
+drifts from the schema.
+
+Goal: `rela docs --output-dir ./site` generates **one Markdown file** (PDF-
+convertible; mermaid fences for diagrams) documenting a specific deployment for:
+- **End users** — what the things are, the fields, how they connect, the
+lifecycle (state machines), what happens automatically.
+- **Operators / support staff** — the role model: who can do what, who can
+perform which guarded transitions, what rules must hold.
+
+Decided up front: one big Markdown for v1; new top-level `rela docs` command;
+**design the doc-oriented schema fields first, then build the generator.**
+
+## Context
+
+### External best-practice survey
+
+**Diátaxis** (the standard doc framework — diataxis.fr) splits docs into four
+modes on two axes (acquisition↔application, action↔cognition):
+
+| Mode | Serves | Can a schema generate it? |
+| --- | --- | --- |
+| **Reference** | practitioner at work — facts | **YES — the natural fit.** Schema-derived docs excel here: accurate, complete, structural. |
+| **Explanation** | learner — the "why" | **NO — needs human prose.** Meaning/rationale can't be derived from structure. |
+| **Tutorial** | beginner — guided lesson | **NO — needs human authoring.** Pedagogical sequencing. |
+| **How-to** | competent user — a task | **PARTIAL.** Workflows *can* be inferred from transitions + automations. |
+
+**This is the load-bearing insight for the phase split:** a generator produces
+excellent *reference*, and can infer *how-to* from lifecycle/automation data,
+but the *explanation* layer (what a status MEANS, why a role EXISTS, when to
+make a move) is exactly what a schema lacks — so the metamodel/ACL need new
+prose fields to carry it. Generating from today's schema alone yields a dry
+reference; the doc- field additions are what upgrade it toward genuinely useful
+end-user docs. (This directly justifies "additions first, generator second.")
+
+**Roles/permissions presentation** (GitLab docs, access-control-matrix best
+practice): a narrative **role table upfront** (each role + a one-line "what it's
+for"), then permissions **grouped by feature area** as tables with **roles as
+columns, actions as rows, ✓ = granted**, plus footnotes for conditional nuance.
+Model roles/groups as subjects (not individuals). State the rationale for each
+role — "essential for audits and training new administrators." For rela the
+"feature areas" map cleanly to **entity types** (per-type: who can
+create/read/update/delete, who holds each transition guard).
+
+**Lifecycle/workflow** (Jira workflow docs): a status is a single state; a
+transition is a one-way verb-named link ("transition names should tell the user
+what to do — think verbs"); the available transitions are shown on the item
+view. rela already matches this exactly (TransitionDef.Label = the verb).
+Mermaid `stateDiagram-v2` renders it: `[*] --> <Initial>` for entry + `From -->
+To : <Label>` per edge, guard/precondition annotated in the edge label.
+
+Sources: [Diátaxis](https://diataxis.fr/start-here/), [GitLab
+permissions](https://docs.gitlab.com/user/permissions/), [Access-control matrix
+best practice](https://frontegg.com/blog/access-control-matrix), [Jira
+workflows](https://support.atlassian.com/jira-cloud-administration/docs/work-with-issue-workflows/),
+[Mermaid state diagrams](https://mermaid.js.org/syntax/stateDiagram.html).
+
+### Internal survey — what the schema already carries
+
+Everything the generator reads is available from `*metamodel.Metamodel` +
+`*acl.Policy`, read-only (confirmed via Explore + code read):
+
+- **Entity types**: `Metamodel.EntityTypes()`, `EntityDef{Label, LabelPlural,
+Description, PropertyOrder, Properties}` — `GetPropertyOrder()` gives properties
+in definition order.
+- **Properties**: `PropertyDef{Type, Required, Values, Labels, Default,
+Description, List, ...}`.
+- **Relations**: `RelationDef{Label, Description, From, To, Inverse (GetLabel),
+Min/MaxOutgoing/Incoming, Symmetric}` — outgoing/incoming per type derivable
+(mirror `schema.go writeEntityRelations`).
+- **State machines**: `CustomType{Values, Labels, Default, Description, Initial,
+Transitions[]}`; `TransitionDef{From, To, Label, Guard, When}`. Fully
+declarative — **the generator needs only `metamodel`, NOT the compiled
+`statemachine.Set`** (that adds only runtime/principal evaluation, wrong for
+docs).
+- **Automations**: `Metamodel.Automations[] {On{Entity,Property,Becomes,From,...},
+Do[]{Set/Value, CreateRelation, CreateEntity, Lua}}` —
+`On.Property`+`On.Becomes` is precisely "when status becomes X, this happens",
+narratable for how-to.
+- **Validations**: `Metamodel.Validations[] {Name, Description, When, Then,
+Severity}` — "rules that must hold".
+- **ACL**: `Policy{Roles map[string]RoleDef, Assignments map[string]string,
+RoleRelations}`; `RoleDef{Create/Update/Delete/Read []string, Permissions
+[]string, ...affordance grants}`. Roles × entity-types × verbs + which roles
+hold which transition-guard permissions = the operator matrix.
+
+**Reuse seam**: mirror `internal/cli/schema.go` (already walks the metamodel to
+text/JSON/graphviz — `writeEntityProperties`, `writePropertyDetail`,
+`writeEntityRelations`, sorted-name helpers). New top-level `rela docs` command
+taking `*readServices` (gives `svc.Meta`) + `--output-dir`; register in
+`requiresProject`. File-writing precedent: `internal/cli/apps.go`. Depend only
+on `internal/metamodel` + `internal/acl`.
+
+### The gaps — doc-oriented fields that DON'T exist yet (confirmed by code read)
+
+| Missing field | Where | Carries (the "explanation" layer) |
+| --- | --- | --- |
+| top-level `description` / `title` | `Metamodel` root | "What is this app / deployment for" |
+| per-value descriptions | `CustomType` (has `Labels`, no descriptions) | what each status/enum value *means* |
+| `help` / `description` | `TransitionDef` (has `Label`, no help) | why/when to make this move |
+| `description` | ACL `RoleDef` (+ optional top-level policy desc) | what each role is for — the audit/operator rationale |
+
+All additive, optional, backward-compatible — same shape as existing
+`Description`/`Label` fields. ACL fields are informational only (no enforcement
+impact); `analyze_*`/write paths ignore them.
+
+### Constraints
+
+- No new deps beyond `metamodel`/`acl` (arch-lint). `just docs` already exists
+(Lua content pipeline) — naming overlap at project level only, not in the CLI;
+`rela docs` is fine.
+- Mermaid rendering deferred by choosing Markdown output: mermaid fences render
+in GitHub/GitLab/most Markdown→PDF pipelines with no bundled JS. (An HTML site
+would reopen the mermaid-JS question — out of scope for v1.)
+- ACL `When:` predicates and automation Lua are opaque strings — the generator
+surfaces them verbatim (or a simplified gloss), not an interpretation.
+
+## Options
+
+### Field additions (Phase 1) — how much to add
+
+**A1. Minimal four fields** (recommended). Add exactly the four gaps above
+(metamodel description, CustomType per-value descriptions, TransitionDef help,
+RoleDef description). Small, additive, each independently useful. Effort: S.
+
+**A2. Richer doc block per entity.** Add a structured `docs:` sub-block on
+EntityDef (intro, usage notes, examples). More expressive but invites scope
+creep and a mini-CMS-in-YAML; the overlay-file idea (rejected earlier) was the
+alternative to this. Effort: M. Rejected — start with A1, extend if output reads
+thin.
+
+### Generator output structure (Phase 2)
+
+**B1. Diátaxis-informed single Markdown** (recommended):
+1. **Overview** — top-level description, entity catalog (one line each).
+2. **Per entity type** (the bulk): description; **Fields** table (name, type,
+required, allowed values + per-value meaning); **Relationships** in prose;
+**Lifecycle** = mermaid stateDiagram + a narrated transition table (move,
+from→to, who can (guard→roles), when (precondition), help); **What happens
+automatically** (automations matching this type); **Rules** (validations).
+3. **Roles & permissions** (operator section) — narrative role table +
+per-entity-type capability matrix (roles × CRUD + guarded transitions).
+4. **Appendix: schema reference** — the dry enumerations.
+
+**B2. Pure reference dump** — tables only, no narrative/lifecycle prose. Simpler
+generator but ignores the Diátaxis insight; the doc-fields would be underused.
+Rejected.
+
+### Phase split
+
+**C1. Additions first, then generator** (decided by user; recommended). Phase-1
+ticket(s) add the four fields (+ populate them in the in-tree example projects
+so the generator has real content to render). Phase-2 ticket builds `rela docs`.
+Clean dependency: the generator renders a complete surface on day one.
+
+## Recommendation
+
+**A1 + B1 + C1.** Add the four minimal doc-fields first (metamodel top-level
+description, CustomType per-value descriptions, TransitionDef help, ACL RoleDef
+description), then build `rela docs --output-dir` emitting one Diátaxis-informed
+Markdown file: reference tables as the backbone, the new prose fields supplying
+the explanation layer, mermaid state diagrams + narrated transitions for
+lifecycle, and a GitLab-style role×entity capability matrix for the operator
+audience.
+
+**Key tradeoff accepted:** the generator produces excellent *reference* and
+decent *how-to* (lifecycle/automations), but never *tutorial* or deep
+*explanation* — those remain human-authored. The four doc-fields inject just
+enough explanation into the reference scaffold to make it genuinely end-user-
+and operator-useful without turning the metamodel into a CMS. Starting minimal
+(A1, not a `docs:` block) keeps the schema clean; we extend only if real output
+reads thin.
+
+**Suggested ticket breakdown:**
+- TKT (Phase 1a): metamodel doc-fields — top-level description, CustomType
+per-value descriptions, TransitionDef help. Populate in-tree examples.
+- TKT (Phase 1b): ACL RoleDef description (+ optional policy description).
+- TKT (Phase 2): `rela docs --output-dir` generator (depends on 1a+1b).

--- a/tickets/entities/review-checklists/REV-579D21.md
+++ b/tickets/entities/review-checklists/REV-579D21.md
@@ -1,0 +1,54 @@
+---
+id: REV-579D21
+type: review-checklist
+title: 'Review: Surface metamodel doc-fields in data-entry help: per-entity values + lifecycle (mermaid), plus a global About help'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Automated Checks
+
+- [x] All tests pass — `go test ./internal/dataentry ./internal/apiwire` green; frontend `npm run test:run` 1356 pass
+- [x] Lint clean — golangci-lint 0 issues; eslint 0 errors on touched files; markdownlint N/A
+- [x] Coverage maintained — dataentry package floor holds (new pure-function tests added)
+
+## Code Review
+
+- [x] Ran `/code-review` (cranky-code-reviewer) — no critical; 3 significant + 2 minor
+- [x] All significant addressed: RR-0GNDA9 (mermaid injection), RR-Y0RL1L (SettingsView regression), RR-BOIZB2 (help-load race)
+- [x] Minors addressed: RR-NRJI7S (pre-wrap), RR-WHGL4S (test coverage)
+- [x] Self-reviewed the diff — scoped to handlers/api_v1/wire + HelpModal/StatusBar/store/config-type + tests
+
+**Review Responses:** RR-0GNDA9, RR-Y0RL1L, RR-BOIZB2 (significant, addressed);
+RR-NRJI7S, RR-WHGL4S (minor, addressed). No open critical/significant.
+
+## Acceptance Verification
+
+- [x] Each AC verified (see IMPL-LS0PDS)
+
+**Acceptance Status:** AC1 Values / AC2 Lifecycle+mermaid / AC3 empty-omitted /
+AC4 pin-test-untouched / AC5 About button / AC6 Go tests / AC7 live demo — all
+PASS.
+
+## Documentation (enhancements only)
+
+- [x] Docs-checklist created + linked (DOCS-NKY0Z9)
+- [x] User-facing docs — N/A (UI surfacing of already-documented fields; additive self-describing `about_description`)
+- [x] Docs-checklist done
+
+**Docs Checklist:** DOCS-NKY0Z9
+
+## Final Checks
+
+- [x] Commit messages explain the why (feat + fix(review) with RR refs)
+- [x] No TODOs/FIXMEs
+- [x] Ready for another developer to use
+
+## Pull Request
+
+- [x] ~~Run `/pr`~~ (done-before-PR gate: PR runs after the ticket is `done`; bundled with TKT-0YBFT8)
+- [x] ~~All CI checks pass~~ (verified locally: go test/lint, frontend test/typecheck/eslint; CI confirms on the PR)
+- [x] ~~PR URL documented below~~ (recorded when `/pr` opens it)
+
+**PR:** *pending — `/pr` runs next for the tkt-0ybft8 bundle*

--- a/tickets/entities/review-checklists/REV-579D21.md
+++ b/tickets/entities/review-checklists/REV-579D21.md
@@ -51,4 +51,4 @@ PASS.
 - [x] ~~All CI checks pass~~ (verified locally: go test/lint, frontend test/typecheck/eslint; CI confirms on the PR)
 - [x] ~~PR URL documented below~~ (recorded when `/pr` opens it)
 
-**PR:** *pending — `/pr` runs next for the tkt-0ybft8 bundle*
+**PR:** https://github.com/sourcehaven-bv/rela/pull/1173

--- a/tickets/entities/review-checklists/REV-Q3119A.md
+++ b/tickets/entities/review-checklists/REV-Q3119A.md
@@ -2,55 +2,58 @@
 id: REV-Q3119A
 type: review-checklist
 title: 'Review: Metamodel doc-fields: top-level description, per-enum-value descriptions, transition help (rela-docs phase 1a)'
-status: in-progress
+status: done
 ---
 
 <!-- @managed: claude-workflow v1 -->
 
 ## Automated Checks
 
-- [ ] All tests pass (`just test`)
-- [ ] Lint clean (`just lint`)
-- [ ] Coverage maintained (`just coverage-check`)
+- [x] All tests pass — `go test ./...` clean (full suite)
+- [x] Lint clean — `just lint` 0 issues; `just arch-lint` OK; markdownlint clean
+- [x] Coverage maintained — `just coverage-check` PASS (metamodel 83.1%)
 
 ## Code Review
 
-- [ ] Run `/code-review` command (invokes cranky-code-reviewer agent)
-- [ ] All critical review-responses addressed
-- [ ] All significant review-responses addressed
-- [ ] Self-reviewed the diff for unrelated changes
+- [x] Ran `/code-review` (cranky-code-reviewer) — no critical findings; parse path, backward-compat, and projection/hash exclusion all verified correct
+- [x] All critical review-responses addressed — none raised
+- [x] All significant review-responses addressed — RR-IXK2F5 (include-guard test)
+- [x] Self-reviewed the diff for unrelated changes — scoped to metamodel + docs + one dataentry serialization comment/test
 
-**Review Responses:** <!-- List IDs of review-response entities created, e.g.,
-RR-xxxx -->
+**Review Responses:** RR-IXK2F5 (significant, addressed), RR-PAQF5U (minor,
+addressed), RR-R2DG19 (minor, addressed). No open critical/significant.
 
 ## Acceptance Verification
 
-- [ ] Each acceptance criterion tested (reference planning checklist)
-- [ ] Test evidence documented in implementation checklist
+- [x] Each acceptance criterion tested (see IMPL-2L80XR)
 
 **Acceptance Status:**
-<!-- For each acceptance criterion, state PASS/FAIL with evidence -->
+- AC1 description parse: PASS (TestParse_DocFields_Present)
+- AC2 per-value descriptions: PASS (same; keyed by value, distinct from Labels)
+- AC3 transition help: PASS (same)
+- AC4 backward-compat + round-trip: PASS (TestParse_DocFields_Absent, _RoundTrip; + rename-path round-trip test)
+- AC5 top-level key accepted: PASS (TestParse_DocFields_TopLevelDescriptionAccepted; + include-rejection TestLoadWithIncludes_IncludeHasDescription)
+- AC6 example populated: PASS (prototypes/data-entry/project/metamodel.yaml; loads via `rela schema`)
+- AC7 tests per field: PASS
 
 ## Documentation (enhancements only)
 
-Skip this section for bugs and internal refactors.
+- [x] Docs-checklist created and linked via `has-docs` (DOCS-OBV091)
+- [x] User-facing documentation updated (metamodel guide → docs/metamodel.md)
+- [x] Docs-checklist marked as done
 
-- [ ] Docs-checklist created and linked via `has-docs`
-- [ ] User-facing documentation updated
-- [ ] Docs-checklist marked as done
-
-**Docs Checklist:** <!-- e.g., DOCS-xxxx -->
+**Docs Checklist:** DOCS-OBV091
 
 ## Final Checks
 
-- [ ] Commit message explains the why, not just what
-- [ ] No TODOs or FIXMEs left unaddressed
-- [ ] Ready for another developer to use
+- [x] Commit messages explain the why (feat + test/docs review commit with RR refs)
+- [x] No TODOs/FIXMEs left unaddressed
+- [x] Ready for another developer to use
 
 ## Pull Request
 
-- [ ] Run `/pr` command to create PR and monitor CI
-- [ ] All CI checks pass
-- [ ] PR URL documented below
+- [x] ~~Run `/pr` after the ticket is `done`~~ (done-before-PR gate: PR runs AFTER this ticket is `done`; completes via `/pr`)
+- [x] ~~All CI checks pass~~ (verified locally: `go test ./...` / `just lint` / `just arch-lint` / `just coverage-check` all green; CI confirms on the PR)
+- [x] ~~PR URL documented below~~ (recorded when `/pr` opens it)
 
-**PR:** <!-- e.g., https://github.com/org/repo/pull/123 -->
+**PR:** *pending — `/pr` runs next per the done-before-PR gate*

--- a/tickets/entities/review-checklists/REV-Q3119A.md
+++ b/tickets/entities/review-checklists/REV-Q3119A.md
@@ -1,0 +1,56 @@
+---
+id: REV-Q3119A
+type: review-checklist
+title: 'Review: Metamodel doc-fields: top-level description, per-enum-value descriptions, transition help (rela-docs phase 1a)'
+status: in-progress
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Automated Checks
+
+- [ ] All tests pass (`just test`)
+- [ ] Lint clean (`just lint`)
+- [ ] Coverage maintained (`just coverage-check`)
+
+## Code Review
+
+- [ ] Run `/code-review` command (invokes cranky-code-reviewer agent)
+- [ ] All critical review-responses addressed
+- [ ] All significant review-responses addressed
+- [ ] Self-reviewed the diff for unrelated changes
+
+**Review Responses:** <!-- List IDs of review-response entities created, e.g.,
+RR-xxxx -->
+
+## Acceptance Verification
+
+- [ ] Each acceptance criterion tested (reference planning checklist)
+- [ ] Test evidence documented in implementation checklist
+
+**Acceptance Status:**
+<!-- For each acceptance criterion, state PASS/FAIL with evidence -->
+
+## Documentation (enhancements only)
+
+Skip this section for bugs and internal refactors.
+
+- [ ] Docs-checklist created and linked via `has-docs`
+- [ ] User-facing documentation updated
+- [ ] Docs-checklist marked as done
+
+**Docs Checklist:** <!-- e.g., DOCS-xxxx -->
+
+## Final Checks
+
+- [ ] Commit message explains the why, not just what
+- [ ] No TODOs or FIXMEs left unaddressed
+- [ ] Ready for another developer to use
+
+## Pull Request
+
+- [ ] Run `/pr` command to create PR and monitor CI
+- [ ] All CI checks pass
+- [ ] PR URL documented below
+
+**PR:** <!-- e.g., https://github.com/org/repo/pull/123 -->

--- a/tickets/entities/review-checklists/REV-Q3119A.md
+++ b/tickets/entities/review-checklists/REV-Q3119A.md
@@ -56,4 +56,4 @@ addressed), RR-R2DG19 (minor, addressed). No open critical/significant.
 - [x] ~~All CI checks pass~~ (verified locally: `go test ./...` / `just lint` / `just arch-lint` / `just coverage-check` all green; CI confirms on the PR)
 - [x] ~~PR URL documented below~~ (recorded when `/pr` opens it)
 
-**PR:** *pending — `/pr` runs next per the done-before-PR gate*
+**PR:** https://github.com/sourcehaven-bv/rela/pull/1173 (bundled with TKT-DUQBD0)

--- a/tickets/entities/review-responses/RR-0GNDA9.md
+++ b/tickets/entities/review-responses/RR-0GNDA9.md
@@ -1,0 +1,9 @@
+---
+id: RR-0GNDA9
+type: review-response
+title: Mermaid diagram-source injection via raw enum values/labels
+finding: mermaidStateDiagram spliced raw enum values (from/to) and move labels directly into stateDiagram-v2 syntax. The whole diagram was HTMLEscapeString'd before <pre>, but renderMermaidDiagrams reads pre.textContent, which un-escapes before mermaid parses — so the escape protects only the HTML transport. A move label with a newline injects a spurious edge; a value with a space/arrow breaks parsing. Not XSS (mermaid securityLevel:strict), but corrupts/misrepresents the lifecycle diagram.
+severity: significant
+resolution: 'mermaidStateDiagram now aliases every state to a synthetic id (`state "value" as sN`) so raw values never appear as bare tokens, and flattens move-label newlines (mermaidLabel). The diagram displays the real values but the edges reference safe ids. Verified live: renders identically, no s0/s1 shown to the user. Tests: TestMermaidStateDiagram (aliased output) + TestMermaidStateDiagram_InjectionSafe.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-BOIZB2.md
+++ b/tickets/entities/review-responses/RR-BOIZB2.md
@@ -1,0 +1,9 @@
+---
+id: RR-BOIZB2
+type: review-response
+title: HelpModal loadHelp concurrency race (stale mermaid render)
+finding: loadHelp has no request cancellation; the watch fires on both props.open and props.entityType. Switching help target (or fast open/close/open) starts a second loadHelp before the first axios.get resolves — two flows race to set helpContent and both call renderMermaidDiagrams against whatever DOM is current, risking a stale/mismatched diagram.
+severity: significant
+resolution: 'Added a monotonic loadToken: each run captures its token and bails (before writing content, on error, and after nextTick before rendering) the moment a newer run starts. A superseded load never overwrites content or renders mermaid against the newer entity''s DOM.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-IXK2F5.md
+++ b/tickets/entities/review-responses/RR-IXK2F5.md
@@ -1,0 +1,9 @@
+---
+id: RR-IXK2F5
+type: review-response
+title: Include root-only guard for `description` is untested
+finding: 'include.go:137-139 rejects `description:` in included partial files (like version/namespace), but no test exercises it. include_test.go has TestLoadWithIncludes_IncludeHasVersion / _IncludeHasNamespace but no _IncludeHasDescription; docfields_test.go is parse-only. An untested guard rots: a future refactor could drop it and an included `description:` would be silently accepted + discarded. Fix: add the sibling test (5-line copy of the namespace one).'
+severity: significant
+resolution: 'Added TestLoadWithIncludes_IncludeHasDescription (include_test.go) — a partial file carrying `description:` is rejected with IncludeHasRootFieldError{Field: "description"}, mirroring the version/namespace sibling tests. The guard is now covered.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-NRJI7S.md
+++ b/tickets/entities/review-responses/RR-NRJI7S.md
@@ -1,0 +1,9 @@
+---
+id: RR-NRJI7S
+type: review-response
+title: About body used pre-wrap on rendered-markdown HTML
+finding: '.about-body had white-space: pre-wrap, but the body is renderMarkdown HTML (block elements) — pre-wrap preserves source newlines between block tags, doubling vertical gaps. Right for raw text, wrong for rendered markdown.'
+severity: minor
+resolution: 'Dropped pre-wrap; added :deep(p) margins for clean paragraph spacing. Verified: markdown renders correctly (emphasis shows, no doubled gaps).'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-PAQF5U.md
+++ b/tickets/entities/review-responses/RR-PAQF5U.md
@@ -1,0 +1,9 @@
+---
+id: RR-PAQF5U
+type: review-response
+title: Metamodel guide doesn't list `description` as a root-only include field
+finding: 'GUIDE-metamodel.md (regenerated into docs/metamodel.md) says included partials ''must not contain version: or namespace:''. The code now also rejects description: in includes (include.go:137) but the doc sentence wasn''t updated — doc/code drift. One-word fix: add ''or description:''.'
+severity: minor
+resolution: Updated the include-file root-only sentence in GUIDE-metamodel.md (source) to include `description:` alongside version/namespace, and regenerated docs/metamodel.md. Doc now matches the code.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-R2DG19.md
+++ b/tickets/entities/review-responses/RR-R2DG19.md
@@ -1,0 +1,9 @@
+---
+id: RR-R2DG19
+type: review-response
+title: Pin that the wire serializer intentionally drops the doc-fields (phase boundary)
+finding: toV1CustomType (dataentry/api_v1.go) projects only Values/Labels/Default and drops Descriptions; nothing carries Transitions/Help to the wire. Correct for phase 1a (a FUTURE generator renders these), but the fields are inert today. A future dev might 'helpfully' wire Descriptions to the wire without the frontend contract change dataentry/CLAUDE.md requires. Recommend a small test pinning the intentional omission so the phase boundary is explicit.
+severity: minor
+resolution: Documented the intentional omission on toV1CustomType (the single wire-serialization site) and added TestToV1CustomType_OmitsDocFields pinning that Descriptions/Transitions/Help never reach the wire (v1.CustomType has no field for them; marshaled JSON asserted free of those keys). A future wiring must intentionally update the test + the frontend contract. Also added a rename-path round-trip test (RR#5) asserting the doc-fields survive RenameEntityType's AST re-marshal.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-WHGL4S.md
+++ b/tickets/entities/review-responses/RR-WHGL4S.md
@@ -1,0 +1,9 @@
+---
+id: RR-WHGL4S
+type: review-response
+title: 'Test coverage: HTML render + injection escaping untested'
+finding: gatherEnumHelp/mermaidStateDiagram/appDescription were tested but the hand-rolled HTML render (renderEnumHelp/renderHelpContent), the XSS/injection escaping of malicious values, the config wire-through, and the Vue components had no tests.
+severity: minor
+resolution: Added TestMermaidStateDiagram_InjectionSafe (space/arrow values + newline-label injection) and aboutDescription fallback test; updated TestMermaidStateDiagram for the aliased output. HelpModal/StatusBar component tests were not added — the behavior (mermaid render timing, token guard, About markdown) is verified live via puppeteer; a component test for the token-guard remains a defensible-to-defer gap. The renderEnumHelp HTML-string escaping is covered indirectly (values go through htmltemplate.HTMLEscapeString; prose through simpleMarkdownToHTML+DOMPurify at the sink, the established pattern).
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-Y0RL1L.md
+++ b/tickets/entities/review-responses/RR-Y0RL1L.md
@@ -1,0 +1,9 @@
+---
+id: RR-Y0RL1L
+type: review-response
+title: appDescription fallback regressed SettingsView
+finding: The appDescription fallback overloaded AppConfig.Description (config + sidebar) with the metamodel's top-level description when app.description was empty. But AppConfig.Description is ALSO rendered by SettingsView as a plain one-line value — so the metamodel's (possibly multi-paragraph markdown) description would dump raw there. Unintended UI regression in a view the ticket never mentions.
+severity: significant
+resolution: 'Added a SEPARATE wire field v1.Config.about_description (helper renamed aboutDescription); AppConfig.Description restored to s.Cfg.App.Description only, so SettingsView is unchanged. New store field schemaStore.aboutDescription (from configData.about_description); StatusBar''s About reads it. Verified: config shows about_description populated + app.description empty.'
+status: addressed
+---

--- a/tickets/entities/tickets/TKT-0YBFT8.md
+++ b/tickets/entities/tickets/TKT-0YBFT8.md
@@ -1,0 +1,75 @@
+---
+id: TKT-0YBFT8
+type: ticket
+title: 'Metamodel doc-fields: top-level description, per-enum-value descriptions, transition help (rela-docs phase 1a)'
+kind: enhancement
+priority: medium
+effort: s
+status: in-progress
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Problem
+
+The `rela docs` generator (FEAT-G4VO53, phase 2) turns a deployment's schema
+into end-user + operator docs. Per the research (RES-EK7LSA / Diátaxis), a
+schema generates excellent *reference* but the *explanation* layer — what a
+status means, why/when to make a transition, what the whole app is for — can't
+be derived from structure. The metamodel has `Description` on
+entities/properties/ relations/types and per-value `Labels`, but is missing
+three prose fields the generator needs. This ticket adds them first (phase 1a)
+so phase 2 renders a complete surface on day one.
+
+## Scope
+
+**In:**
+1. `Metamodel.Description string` (top-level, `yaml:"description,omitempty"`) — a
+paragraph describing the deployment/app.
+2. Per-enum-value descriptions on `CustomType` — the *meaning* of each value
+(distinct from `Labels`, which is display text). Shape: a `map[string]string`
+keyed by value (mirrors `Labels`), e.g. `ValueDescriptions` / `descriptions:`.
+3. `TransitionDef.Help string` (`yaml:"help,omitempty"`) — why/when to make this
+move, beyond the verb `Label`.
+4. Populate all three in the in-tree example project(s) so the generator has real
+content and the fields have live usage examples.
+
+**Out:**
+- The `rela docs` generator itself (phase 2, separate ticket).
+- ACL `RoleDef.Description` (phase 1b, separate ticket).
+- Any `docs:` structured sub-block (research rejected A2 — keep it minimal).
+- Enforcement/validation behavior changes — these are display-only; `analyze_*`
+and write paths ignore them.
+
+## Design notes (firm up in planning)
+
+- All three are additive + optional; a metamodel without them loads and behaves
+exactly as before. Same pattern as the existing `Description`/`Labels` fields.
+- Confirm YAML round-trips and that the fields survive `metamodel` parse/marshal
+and any migration/normalization passes.
+- Naming: `ValueDescriptions` vs `Descriptions` for the CustomType map — pick to
+read well in YAML (`descriptions:` keyed by value) and not collide with the
+existing `Description` scalar on CustomType.
+- Which example project(s) to populate: the in-tree ones the generator will be
+demoed against (e.g. `tickets/` and/or a prototype project). Keep additions
+realistic, not lorem ipsum.
+
+## Acceptance criteria (firm up in planning)
+
+1. `Metamodel.Description` parses from `description:` at the metamodel root and is
+readable via the metamodel API; absent → empty, no behavior change.
+2. CustomType carries per-value descriptions parsed from YAML, keyed by value,
+readable via the metamodel API; absent → empty.
+3. `TransitionDef.Help` parses from `help:` and is readable; absent → empty.
+4. All three are backward-compatible: existing metamodels (no new fields) load
+and validate unchanged; round-trip (parse→marshal) preserves them.
+5. At least one in-tree example project populates all three fields with realistic
+content.
+6. Tests cover parse + absence + round-trip for each field.
+
+## References
+
+- Research: RES-EK7LSA (Diátaxis framing, the four gaps).
+- Feature: FEAT-G4VO53 (rela-docs arc).
+- Mirror the existing field shape in `internal/metamodel/types.go`
+(`EntityDef.Description`, `CustomType.Labels`, `TransitionDef.Label`).

--- a/tickets/entities/tickets/TKT-0YBFT8.md
+++ b/tickets/entities/tickets/TKT-0YBFT8.md
@@ -5,7 +5,7 @@ title: 'Metamodel doc-fields: top-level description, per-enum-value descriptions
 kind: enhancement
 priority: medium
 effort: s
-status: in-progress
+status: review
 ---
 
 <!-- @managed: claude-workflow v1 -->

--- a/tickets/entities/tickets/TKT-0YBFT8.md
+++ b/tickets/entities/tickets/TKT-0YBFT8.md
@@ -5,7 +5,7 @@ title: 'Metamodel doc-fields: top-level description, per-enum-value descriptions
 kind: enhancement
 priority: medium
 effort: s
-status: review
+status: done
 ---
 
 <!-- @managed: claude-workflow v1 -->

--- a/tickets/entities/tickets/TKT-DUQBD0.md
+++ b/tickets/entities/tickets/TKT-DUQBD0.md
@@ -1,0 +1,68 @@
+---
+id: TKT-DUQBD0
+type: ticket
+title: 'Surface metamodel doc-fields in data-entry help: per-entity values + lifecycle (mermaid), plus a global About help'
+kind: enhancement
+priority: medium
+effort: s
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Problem
+
+Phase 1a (TKT-0YBFT8) added three metamodel doc-fields (`Metamodel.Description`,
+`CustomType.Descriptions` per-value, `TransitionDef.Help`), but nothing renders
+them yet. The data-entry help modal (FEAT-8cwr, `/api/help/{type}`, server HTML)
+shows entity/property/relation descriptions but has no enum-values or lifecycle
+section, and there's no place for the top-level app description. This surfaces
+them in the existing help UI now, without the offline generator (phase 2).
+
+## Scope
+
+**In:**
+1. **Values section** per enum/state-machine property: value + label +
+`CustomType.Descriptions[value]`.
+2. **Lifecycle section** per state-machine property: a **mermaid
+`stateDiagram-v2` diagram** (one per machine field) — `[*] --> initial` + `from
+--> to: move` per transition — PLUS a transitions table (move, from→to, `Help`).
+Mermaid is bundled in the SPA; the help modal now runs `renderMermaidDiagrams`
+over the injected HTML (mirrors DocumentView), so the `<pre class="mermaid">`
+blocks the server emits render as SVG.
+3. Server-side in `handleEntityHelp`/`renderHelpContent`
+(`internal/dataentry/handlers.go`); sections omitted when empty.
+4. **Global About help** in the bottom status bar (next to Settings + theme
+toggle): a `ⓘ About` button opening an overlay with the deployment description
+(`v1.AppConfig.Description`, which now falls back to `Metamodel.Description`
+when the data-entry.yaml `app.description` is empty). Button hidden when there
+is no description.
+
+**Out:**
+- Per-value / transition tooltips on the JSON `_schema`/`_transitions` wire
+(in-context) — deferred; a separate contract change. The help endpoint (1,2)
+does NOT touch `toV1CustomType` or its pin test.
+- The offline `rela docs` generator (phase 2).
+
+## Acceptance criteria
+
+1. Entity help with an enum property → Values section (value + description; no
+description → value/label only).
+2. State-machine property → Lifecycle section with a mermaid state diagram
+(rendered as SVG in the modal) + a transitions table (label + Help). One diagram
+per distinct state-machine field.
+3. Empty → sections omitted (no noise on plain fields).
+4. `toV1CustomType` + its pin test untouched.
+5. Global `ⓘ About` button in the status bar shows the app/deployment
+description; hidden when empty.
+6. Go tests cover the values + lifecycle (incl. mermaid block) render and the
+config-description fallback.
+7. Verified live in the demo (prototype project): descriptions/help/diagram
+render in the modal; About shows the description.
+
+## References
+
+- Depends on TKT-0YBFT8 (fields). Same branch/PR bundle.
+- Feature: FEAT-G4VO53; FEAT-8cwr (help modal).
+- `internal/dataentry/handlers.go`; `handleV1Config`/`v1.AppConfig`;
+`HelpModal.vue`; `StatusBar.vue`; `utils/markdown.ts` (renderMermaidDiagrams).

--- a/tickets/relations/FEAT-G4VO53--has-research--RES-EK7LSA.md
+++ b/tickets/relations/FEAT-G4VO53--has-research--RES-EK7LSA.md
@@ -1,0 +1,5 @@
+---
+from: FEAT-G4VO53
+relation: has-research
+to: RES-EK7LSA
+---

--- a/tickets/relations/FEAT-G4VO53--requires--metamodel-types.md
+++ b/tickets/relations/FEAT-G4VO53--requires--metamodel-types.md
@@ -1,0 +1,5 @@
+---
+from: FEAT-G4VO53
+relation: requires
+to: metamodel-types
+---

--- a/tickets/relations/FEAT-G4VO53--requires--schema-visualization.md
+++ b/tickets/relations/FEAT-G4VO53--requires--schema-visualization.md
@@ -1,0 +1,5 @@
+---
+from: FEAT-G4VO53
+relation: requires
+to: schema-visualization
+---

--- a/tickets/relations/RES-EK7LSA--researches--authorization.md
+++ b/tickets/relations/RES-EK7LSA--researches--authorization.md
@@ -1,0 +1,5 @@
+---
+from: RES-EK7LSA
+relation: researches
+to: authorization
+---

--- a/tickets/relations/RES-EK7LSA--researches--schema-visualization.md
+++ b/tickets/relations/RES-EK7LSA--researches--schema-visualization.md
@@ -1,0 +1,5 @@
+---
+from: RES-EK7LSA
+relation: researches
+to: schema-visualization
+---

--- a/tickets/relations/TKT-0YBFT8--affects--metamodel-types.md
+++ b/tickets/relations/TKT-0YBFT8--affects--metamodel-types.md
@@ -1,0 +1,5 @@
+---
+from: TKT-0YBFT8
+relation: affects
+to: metamodel-types
+---

--- a/tickets/relations/TKT-0YBFT8--has-docs--DOCS-OBV091.md
+++ b/tickets/relations/TKT-0YBFT8--has-docs--DOCS-OBV091.md
@@ -1,0 +1,5 @@
+---
+from: TKT-0YBFT8
+relation: has-docs
+to: DOCS-OBV091
+---

--- a/tickets/relations/TKT-0YBFT8--has-implementation--IMPL-2L80XR.md
+++ b/tickets/relations/TKT-0YBFT8--has-implementation--IMPL-2L80XR.md
@@ -1,0 +1,5 @@
+---
+from: TKT-0YBFT8
+relation: has-implementation
+to: IMPL-2L80XR
+---

--- a/tickets/relations/TKT-0YBFT8--has-planning--PLAN-0D7FDK.md
+++ b/tickets/relations/TKT-0YBFT8--has-planning--PLAN-0D7FDK.md
@@ -1,0 +1,5 @@
+---
+from: TKT-0YBFT8
+relation: has-planning
+to: PLAN-0D7FDK
+---

--- a/tickets/relations/TKT-0YBFT8--has-review--REV-Q3119A.md
+++ b/tickets/relations/TKT-0YBFT8--has-review--REV-Q3119A.md
@@ -1,0 +1,5 @@
+---
+from: TKT-0YBFT8
+relation: has-review
+to: REV-Q3119A
+---

--- a/tickets/relations/TKT-0YBFT8--has-review-response--RR-IXK2F5.md
+++ b/tickets/relations/TKT-0YBFT8--has-review-response--RR-IXK2F5.md
@@ -1,0 +1,5 @@
+---
+from: TKT-0YBFT8
+relation: has-review-response
+to: RR-IXK2F5
+---

--- a/tickets/relations/TKT-0YBFT8--has-review-response--RR-PAQF5U.md
+++ b/tickets/relations/TKT-0YBFT8--has-review-response--RR-PAQF5U.md
@@ -1,0 +1,5 @@
+---
+from: TKT-0YBFT8
+relation: has-review-response
+to: RR-PAQF5U
+---

--- a/tickets/relations/TKT-0YBFT8--has-review-response--RR-R2DG19.md
+++ b/tickets/relations/TKT-0YBFT8--has-review-response--RR-R2DG19.md
@@ -1,0 +1,5 @@
+---
+from: TKT-0YBFT8
+relation: has-review-response
+to: RR-R2DG19
+---

--- a/tickets/relations/TKT-0YBFT8--implements--FEAT-G4VO53.md
+++ b/tickets/relations/TKT-0YBFT8--implements--FEAT-G4VO53.md
@@ -1,0 +1,5 @@
+---
+from: TKT-0YBFT8
+relation: implements
+to: FEAT-G4VO53
+---

--- a/tickets/relations/TKT-DUQBD0--affects--metamodel-types.md
+++ b/tickets/relations/TKT-DUQBD0--affects--metamodel-types.md
@@ -1,0 +1,5 @@
+---
+from: TKT-DUQBD0
+relation: affects
+to: metamodel-types
+---

--- a/tickets/relations/TKT-DUQBD0--depends-on--TKT-0YBFT8.md
+++ b/tickets/relations/TKT-DUQBD0--depends-on--TKT-0YBFT8.md
@@ -1,0 +1,5 @@
+---
+from: TKT-DUQBD0
+relation: depends-on
+to: TKT-0YBFT8
+---

--- a/tickets/relations/TKT-DUQBD0--has-docs--DOCS-NKY0Z9.md
+++ b/tickets/relations/TKT-DUQBD0--has-docs--DOCS-NKY0Z9.md
@@ -1,0 +1,5 @@
+---
+from: TKT-DUQBD0
+relation: has-docs
+to: DOCS-NKY0Z9
+---

--- a/tickets/relations/TKT-DUQBD0--has-implementation--IMPL-LS0PDS.md
+++ b/tickets/relations/TKT-DUQBD0--has-implementation--IMPL-LS0PDS.md
@@ -1,0 +1,5 @@
+---
+from: TKT-DUQBD0
+relation: has-implementation
+to: IMPL-LS0PDS
+---

--- a/tickets/relations/TKT-DUQBD0--has-planning--PLAN-VGLUSN.md
+++ b/tickets/relations/TKT-DUQBD0--has-planning--PLAN-VGLUSN.md
@@ -1,0 +1,5 @@
+---
+from: TKT-DUQBD0
+relation: has-planning
+to: PLAN-VGLUSN
+---

--- a/tickets/relations/TKT-DUQBD0--has-review--REV-579D21.md
+++ b/tickets/relations/TKT-DUQBD0--has-review--REV-579D21.md
@@ -1,0 +1,5 @@
+---
+from: TKT-DUQBD0
+relation: has-review
+to: REV-579D21
+---

--- a/tickets/relations/TKT-DUQBD0--has-review-response--RR-0GNDA9.md
+++ b/tickets/relations/TKT-DUQBD0--has-review-response--RR-0GNDA9.md
@@ -1,0 +1,5 @@
+---
+from: TKT-DUQBD0
+relation: has-review-response
+to: RR-0GNDA9
+---

--- a/tickets/relations/TKT-DUQBD0--has-review-response--RR-BOIZB2.md
+++ b/tickets/relations/TKT-DUQBD0--has-review-response--RR-BOIZB2.md
@@ -1,0 +1,5 @@
+---
+from: TKT-DUQBD0
+relation: has-review-response
+to: RR-BOIZB2
+---

--- a/tickets/relations/TKT-DUQBD0--has-review-response--RR-NRJI7S.md
+++ b/tickets/relations/TKT-DUQBD0--has-review-response--RR-NRJI7S.md
@@ -1,0 +1,5 @@
+---
+from: TKT-DUQBD0
+relation: has-review-response
+to: RR-NRJI7S
+---

--- a/tickets/relations/TKT-DUQBD0--has-review-response--RR-WHGL4S.md
+++ b/tickets/relations/TKT-DUQBD0--has-review-response--RR-WHGL4S.md
@@ -1,0 +1,5 @@
+---
+from: TKT-DUQBD0
+relation: has-review-response
+to: RR-WHGL4S
+---

--- a/tickets/relations/TKT-DUQBD0--has-review-response--RR-Y0RL1L.md
+++ b/tickets/relations/TKT-DUQBD0--has-review-response--RR-Y0RL1L.md
@@ -1,0 +1,5 @@
+---
+from: TKT-DUQBD0
+relation: has-review-response
+to: RR-Y0RL1L
+---

--- a/tickets/relations/TKT-DUQBD0--implements--FEAT-G4VO53.md
+++ b/tickets/relations/TKT-DUQBD0--implements--FEAT-G4VO53.md
@@ -1,0 +1,5 @@
+---
+from: TKT-DUQBD0
+relation: implements
+to: FEAT-G4VO53
+---


### PR DESCRIPTION
## Summary

Two tickets in the rela-docs generator arc (FEAT-G4VO53), bundled because the second consumes the first:

- **TKT-0YBFT8** — adds three additive, optional, display-only doc-fields to the metamodel: top-level `description`, per-enum-value `descriptions` (the *meaning* of each value, distinct from `labels`), and transition `help` (why/when to make a move). Backward-compatible; mirrors existing `Description`/`Labels`/`Label` fields.
- **TKT-DUQBD0** — surfaces those fields in the data-entry **help system**: the `/api/help/{type}` modal gains a **Values** section (per-value descriptions) and a **Lifecycle** section with a rendered **mermaid state diagram** per state-machine field + a transitions table (with `help`), and a global **About** button in the status bar shows the deployment description.

Grounded in research **RES-EK7LSA** (Diátaxis: a schema generates *reference*; these prose fields supply the *explanation* layer the offline `rela docs` generator — phase 2 — and this in-app help both consume).

## Notable design points

- **Doc-fields are display-only.** No enforcement/validation/analyze behavior change. `metamodel.Description` is added to the parser's top-level allowlist + the include root-only guard (rejected in partials like version/namespace).
- **Mermaid injection-hardened.** State values are aliased to synthetic ids (`state "todo" as s0`) and move-label newlines flattened, so a metamodel value with a space/arrow or a newline can't corrupt/inject the diagram. Not XSS (mermaid strict + DOMPurify), but the diagram can't be made to lie. Renders identically (real labels shown).
- **`toV1CustomType` untouched** — the doc-fields deliberately don't reach the `_schema` wire (pinned by `TestToV1CustomType_OmitsDocFields`). The About description rides a **separate** `v1.Config.about_description` field so it doesn't regress SettingsView's one-line `app.description` render.

## Tests / checks

- Go: `go test ./...`, `just lint`, `just arch-lint`, `just coverage-check` — all green. New: `docfields_test.go`, `include`/`rename` round-trip guards, `help_docfields_test.go` (incl. `TestMermaidStateDiagram_InjectionSafe`), the wire-omission pin test.
- Frontend: `npm run test:run` (1356), typecheck, eslint — clean.
- Docs: `docs/metamodel.md` (via source guide) documents the three fields.
- `just ci` passes locally. Verified live in a demo (help modal renders the values/lifecycle/diagram; About shows the description).

Both tickets `done` and validate clean.
