### PR TITLE
fix(server): JWT identity fails closed, never downgrades to --principal-header (TKT-RYUS3H)

### DIFF
--- a/.go-arch-lint.yml
+++ b/.go-arch-lint.yml
@@ -152,6 +152,12 @@ vendors:
     in:
       - github.com/golang-jwt/jwt/**
       - github.com/MicahParks/keyfunc/**
+      # keyfunc's JWKS layer. Referenced directly for its error sentinels, so a
+      # JWKS-unreachable failure can be told apart from a bad assertion. The
+      # package is imported at its module root, so it needs the bare path as
+      # well as the subpackage glob.
+      - github.com/MicahParks/jwkset
+      - github.com/MicahParks/jwkset/**
 
 # -- Common (importable by all) -------------------------------------------
 commonComponents:

--- a/cmd/rela-server/main.go
+++ b/cmd/rela-server/main.go
@@ -136,39 +136,114 @@ func envOr(key, def string) string {
 	return def
 }
 
-// wirePrincipalResolvers installs the principal-resolver chain on the app.
+// identityMode is the identity source the server runs with. The two modes are
+// mutually exclusive by construction — see [validateIdentityFlags].
+type identityMode int
+
+const (
+	// identityHeader is the legacy chain: $RELA_DATAENTRY_USER, then the
+	// proxy-trusted --principal-header, then "unknown". Fails OPEN by design
+	// (an absent header yields "unknown", not a denial) and is unchanged.
+	identityHeader identityMode = iota
+	// identityJWT is fail-closed verified-JWT identity. Every API request must
+	// carry an assertion that verifies, or it is denied.
+	identityJWT
+)
+
+// validateIdentityFlags classifies the configured identity sources, returning an
+// error when they conflict.
 //
-// Chain order: $RELA_DATAENTRY_USER (local-dev escape hatch) wins over any
-// identity source; then the cryptographically-VERIFIED JWT assertion; then the
-// plain (proxy-trusted) header; then "unknown". A verified JWT is preferred over
-// the plain header because it proves authenticity.
+// **Why JWT identity is exclusive.** Layering a verified JWT over a plain header
+// in one resolver chain means a JWT verification failure falls THROUGH to the
+// spoofable header. Anyone able to disrupt JWKS reachability — network egress,
+// DNS, an IdP outage — thereby converts the server from verified identity to
+// trusted-header identity, and it keeps serving as if nothing changed. That is an
+// attacker-triggerable auth downgrade, so the combination is refused at startup
+// rather than warned about: the downgrade happens per-request, long after anyone
+// is reading startup logs. The same reasoning applies to $RELA_DATAENTRY_USER,
+// which would override a cryptographically proven subject with an env var.
 //
-// coverage-ignore: startup wiring.
-func wirePrincipalResolvers(app *dataentry.App, f *serverFlags, idv *jwtauth.Verifier) {
-	jwtResolver, jwtHeader := buildJWTResolver(idv, f)
-	if jwtHeader != "" && f.principalHeader != "" {
-		// Both a verified JWT and a plain trusted header are enabled. Because the
-		// JWT sits ahead of the plain header in the chain, a JWT verification
-		// failure falls THROUGH to the spoofable plain header — a downgrade path an
-		// attacker could exploit by, e.g., briefly disrupting the JWKS. Warn loudly.
-		slog.Warn("both --jwt-* and --principal-header are enabled: a JWT failure "+
-			"downgrades to the plain (spoofable) header. Prefer one identity source. "+
-			"See docs/server-security.md.",
-			"jwt_header", jwtHeader, "principal_header", f.principalHeader)
+// envUser is passed in rather than read from the environment so this stays a pure
+// function — the caller owns both the lookup and the exit.
+func validateIdentityFlags(f *serverFlags, envUser string) (identityMode, error) {
+	set := 0
+	for _, v := range []string{f.jwtIssuer, f.jwtAudience, f.jwtJWKSURL} {
+		if v != "" {
+			set++
+		}
 	}
+	switch set {
+	case 0:
+		return identityHeader, nil
+	case 3: // fully configured — checked against the other sources below
+	default:
+		// A partially-configured JWT used to silently disable identity, leaving a
+		// server the operator believes is authenticating when it is not.
+		return identityHeader, errors.New("jwt identity requires all of " +
+			"-jwt-issuer, -jwt-audience and -jwt-jwks-url (or none)")
+	}
+
+	if f.principalHeader != "" {
+		return identityHeader, errors.New("-jwt-* and -principal-header are mutually " +
+			"exclusive: a JWT verification failure would fall through to the " +
+			"spoofable header, downgrading verified identity. Choose one. " +
+			"See docs/server-security.md")
+	}
+	if envUser != "" {
+		return identityHeader, fmt.Errorf("$%s cannot be set with -jwt-*: it would "+
+			"override the cryptographically verified subject. Unset it, or run "+
+			"without JWT identity. See docs/server-security.md",
+			dataentry.EnvDataEntryUserVar)
+	}
+	if f.jwtHeader == "" {
+		// An empty header name reads every assertion as absent, so the server
+		// would boot clean and then deny every API request. Fail-closed, but
+		// silently — catch it here where the cause is obvious.
+		return identityHeader, errors.New("-jwt-header must not be empty when jwt identity is enabled")
+	}
+	return identityJWT, nil
+}
+
+// wirePrincipalResolvers installs the identity source on the app, per mode.
+//
+// identityHeader keeps the legacy chain: $RELA_DATAENTRY_USER, then the plain
+// header, then "unknown". identityJWT installs the fail-closed gate INSTEAD of a
+// resolver chain — the JWT resolver is deliberately not chained, because with a
+// single exclusive source there is nothing to fall through to.
+//
+// coverage-ignore: startup wiring — the decision it acts on is validateIdentityFlags.
+func wirePrincipalResolvers(app *dataentry.App, f *serverFlags, idv *jwtauth.Verifier, mode identityMode) {
+	if mode == identityJWT {
+		if idv == nil {
+			// Unreachable: identityJWT implies all three JWT flags are set, so
+			// buildIdentityVerifier either returned a verifier or exited. Checked
+			// anyway because the alternative — storing a nil verifier behind a
+			// non-nil interface — panics on the first request instead of here.
+			slog.Error("jwt identity selected but no verifier was built")
+			os.Exit(1)
+		}
+		if err := app.SetJWTGate(dataentry.JWTGateConfig{
+			Verifier:   idv,
+			HeaderName: f.jwtHeader,
+			// Injected as a predicate so dataentry needn't import jwtauth.
+			KeysUnavailable: func(err error) bool {
+				return errors.Is(err, jwtauth.ErrKeysUnavailable)
+			},
+		}); err != nil {
+			slog.Error("failed to enable jwt identity", "error", err)
+			os.Exit(1)
+		}
+		// Vary on the assertion header: under ACL, API responses are
+		// per-principal (TKT-VMD8), and the assertion determines the principal.
+		app.SetPrincipalHeader(f.jwtHeader)
+		return
+	}
+
 	app.SetPrincipalResolver(dataentry.ChainResolvers(
 		dataentry.EnvPrincipalResolver(),
-		jwtResolver,
 		dataentry.HeaderPrincipalResolver(f.principalHeader),
 	))
-	// Vary on the active identity header: under ACL, API responses are
-	// per-principal (TKT-VMD8). When JWT identity is enabled its header determines
-	// the principal, so vary on that; else the plain header.
-	varyHeader := f.principalHeader
-	if jwtHeader != "" {
-		varyHeader = jwtHeader
-	}
-	app.SetPrincipalHeader(varyHeader)
+	app.SetPrincipalHeader(f.principalHeader)
 }
 
 // buildIdentityVerifier builds the shared signed-JWT verifier from the flags, or
@@ -194,18 +269,6 @@ func buildIdentityVerifier(ctx context.Context, f *serverFlags) *jwtauth.Verifie
 	}
 	slog.Info("jwt identity enabled", "issuer", f.jwtIssuer, "header", f.jwtHeader)
 	return v
-}
-
-// buildJWTResolver wraps the shared verifier into a principal resolver, returning
-// it plus the header name it reads. A nil verifier (JWT identity disabled) yields
-// an inert resolver + "" header.
-//
-// coverage-ignore: startup wiring — exercised via the resolver's own tests.
-func buildJWTResolver(idv *jwtauth.Verifier, f *serverFlags) (resolver dataentry.PrincipalResolver, header string) {
-	if idv == nil {
-		return dataentry.JWTPrincipalResolver(nil, ""), ""
-	}
-	return dataentry.JWTPrincipalResolver(idv, f.jwtHeader), f.jwtHeader
 }
 
 // wireWebhookReceiver enables POST /webhooks/idp when -webhook-audience and
@@ -320,11 +383,19 @@ func main() {
 		os.Exit(1)
 	}
 
+	// Identity sources are mutually exclusive — validate BEFORE building anything,
+	// so a conflicting config never reaches a running server.
+	mode, modeErr := validateIdentityFlags(f, os.Getenv(dataentry.EnvDataEntryUserVar))
+	if modeErr != nil {
+		slog.Error("invalid identity configuration", "error", modeErr)
+		os.Exit(1)
+	}
+
 	// Build the signed-JWT verifier once (nil when JWT identity is disabled) and
-	// share it between the principal resolver and the webhook receiver so the JWKS
+	// share it between the identity gate and the webhook receiver so the JWKS
 	// is fetched a single time.
 	idv := buildIdentityVerifier(context.Background(), f)
-	wirePrincipalResolvers(app, f, idv)
+	wirePrincipalResolvers(app, f, idv, mode)
 	wireWebhookReceiver(app, f, idv)
 
 	srv := newHTTPServer(addr, app.NewRouter())

--- a/cmd/rela-server/main_identity_test.go
+++ b/cmd/rela-server/main_identity_test.go
@@ -1,0 +1,129 @@
+package main
+
+import "testing"
+
+// jwtFlags returns a serverFlags with JWT identity fully configured, so each
+// test case can express exactly one deviation from a valid config.
+func jwtFlags() *serverFlags {
+	return &serverFlags{
+		jwtIssuer:   "https://idp.example",
+		jwtAudience: "rela",
+		jwtJWKSURL:  "https://idp.example/jwks",
+		jwtHeader:   "X-Auth-Assertion",
+	}
+}
+
+// validateIdentityFlags is the startup guard that makes JWT identity exclusive.
+// The combinations it refuses are the ones where a JWT verification failure
+// would otherwise fall through to a spoofable source — the downgrade this whole
+// change exists to close.
+func TestValidateIdentityFlags(t *testing.T) {
+	tests := []struct {
+		name    string
+		flags   func() *serverFlags
+		envUser string
+		want    identityMode
+		wantErr bool
+	}{
+		{
+			name:  "nothing configured → header mode (unchanged legacy default)",
+			flags: func() *serverFlags { return &serverFlags{} },
+			want:  identityHeader,
+		},
+		{
+			name:  "header only → header mode",
+			flags: func() *serverFlags { return &serverFlags{principalHeader: "X-Forwarded-User"} },
+			want:  identityHeader,
+		},
+		{
+			name:    "env user only → header mode (local-dev hatch still works)",
+			flags:   func() *serverFlags { return &serverFlags{} },
+			envUser: "jeroen",
+			want:    identityHeader,
+		},
+		{
+			name:  "all three jwt flags → jwt mode",
+			flags: jwtFlags,
+			want:  identityJWT,
+		},
+		{
+			name: "jwt + principal-header → error (the downgrade path)",
+			flags: func() *serverFlags {
+				f := jwtFlags()
+				f.principalHeader = "X-Forwarded-User"
+				return f
+			},
+			wantErr: true,
+		},
+		{
+			name:    "jwt + $RELA_DATAENTRY_USER → error (env would override a verified subject)",
+			flags:   jwtFlags,
+			envUser: "jeroen",
+			wantErr: true,
+		},
+		{
+			name: "jwt + both → error",
+			flags: func() *serverFlags {
+				f := jwtFlags()
+				f.principalHeader = "X-Forwarded-User"
+				return f
+			},
+			envUser: "jeroen",
+			wantErr: true,
+		},
+		{
+			name: "issuer only → error (partial config used to silently disable identity)",
+			flags: func() *serverFlags {
+				return &serverFlags{jwtIssuer: "https://idp.example"}
+			},
+			wantErr: true,
+		},
+		{
+			name: "missing jwks url → error",
+			flags: func() *serverFlags {
+				f := jwtFlags()
+				f.jwtJWKSURL = ""
+				return f
+			},
+			wantErr: true,
+		},
+		{
+			name: "missing audience → error (the confused-deputy guard)",
+			flags: func() *serverFlags {
+				f := jwtFlags()
+				f.jwtAudience = ""
+				return f
+			},
+			wantErr: true,
+		},
+		{
+			// An empty header name reads every assertion as absent, so the server
+			// would boot clean and then deny every API request.
+			name: "empty jwt header → error",
+			flags: func() *serverFlags {
+				f := jwtFlags()
+				f.jwtHeader = ""
+				return f
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := validateIdentityFlags(tt.flags(), tt.envUser)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected an error, got mode %v and nil error", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("mode = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/docs-project/entities/guides/GUIDE-server-security.md
+++ b/docs-project/entities/guides/GUIDE-server-security.md
@@ -176,7 +176,8 @@ for human web users. Two opt-in sources can replace the placeholder:
   request and stamps its value as `principal.user`.
 - **`$RELA_DATAENTRY_USER`** env var, set on the `rela-server`
   process. Useful for local development where there's no proxy.
-  The env value wins over the header.
+  The env value wins over the header. It cannot be combined with
+  `--jwt-*` — see *Mutually exclusive* below.
 
 **Trust boundary**: the `--principal-header` flag is only safe
 behind a reverse proxy that
@@ -191,6 +192,13 @@ beyond loopback (`--bind` non-loopback) and `--principal-header`
 is set, audit attribution is only as trustworthy as the network
 path between the client and the proxy.
 
+**Prefer `--jwt-*`** for anything beyond local development. The
+header path fails *open* by design — an absent header yields
+`unknown`, not a denial — and its trustworthiness rests entirely
+on network topology. Verified JWT identity fails *closed* and
+proves authenticity cryptographically. The header path is
+unchanged and still supported; it is simply the weaker of the two.
+
 Header values are sanitized at the middleware (trim, 256-rune cap,
 control-char strip) as defense-in-depth against header-injection
 corrupting the JSONL stream.
@@ -202,7 +210,7 @@ A third, **stronger** attribution source: a signed identity assertion
 Pomerium, Keycloak, and the like. Unlike `--principal-header`, this
 path does not *trust* that a proxy set a header; it **cryptographically
 verifies** the assertion, so a spoofed header without a valid signature
-simply fails verification and falls through (it does not authenticate).
+fails verification and the request is denied.
 
 Enable it by setting all three (env fallbacks `$RELA_JWT_ISSUER` /
 `_AUDIENCE` / `_JWKS_URL`):
@@ -211,8 +219,11 @@ Enable it by setting all three (env fallbacks `$RELA_JWT_ISSUER` /
 - **`--jwt-audience`** — this server's id (the `aud` the proxy mints for
   it); enforced strictly as a confused-deputy guard.
 - **`--jwt-jwks-url`** — the proxy's JWKS endpoint; the ES256 signature
-  is verified against it (keys auto-refresh, so rotation needs no
-  restart). Must be `https` (the JWKS is the root of trust — cleartext
+  is verified against it. Keys auto-refresh, so routine rotation needs
+  no restart, and the cached set survives a failed refresh — but see
+  *Availability trade-off* below for the rotation-during-outage case,
+  which does deny requests. A refresh failure is logged at `ERROR`.
+  Must be `https` (the JWKS is the root of trust — cleartext
   would let an on-path attacker substitute a signing key; loopback URLs
   are exempted for local testing). An unreachable JWKS at startup is
   fatal — identity never silently no-ops.
@@ -227,11 +238,71 @@ attribution and any `acl.yaml` assignments survive an email change.
 The verification rejects non-ES256 algorithms (including `alg:none`),
 a wrong issuer or audience, and expired or unsigned tokens.
 
-**Chain order.** When several sources are configured, `$RELA_DATAENTRY_USER`
-(local-dev override) wins, then the verified JWT, then the plain
-`--principal-header`, then `unknown`. A verified JWT is preferred over
-the plain header because it proves authenticity rather than trusting
-the network path.
+**Mutually exclusive — JWT identity is the only identity source.**
+Setting `--jwt-*` together with `--principal-header`, or with
+`$RELA_DATAENTRY_USER` in the environment, is a **startup error**.
+`rela-server` refuses to boot rather than run with both.
+
+This is deliberate. These sources used to be layered in one resolver
+chain, verified-JWT ahead of plain-header. That meant a JWT
+verification failure fell **through** to the spoofable header:
+anyone able to disrupt JWKS reachability — network egress, DNS, an
+IdP outage — could convert rela from verified identity to
+trusted-header identity, and rela would keep serving as if nothing
+had changed. A startup warning was not an adequate mitigation,
+because the downgrade happens per-request, long after anyone is
+reading startup logs. Making it a hard error forces the choice at
+configuration time, when it is visible.
+
+**Fail-closed behavior.** With JWT identity enabled, every `/api/`
+request must carry an assertion that verifies. An assertion that is
+absent, malformed, expired, wrongly signed, or bearing the wrong
+`iss`/`aud` is answered **401** — never downgraded to a weaker
+identity. The 401 body deliberately carries no explanation (the
+assertion is attacker-controlled input, and saying why it failed
+would make the endpoint a verification oracle); the reason is
+logged server-side instead.
+
+The SPA shell (`/`) and static assets (`/static/`) are **not**
+gated, so the app still loads and can render a signed-out state.
+Those routes serve no entity data — every API call the SPA makes
+is gated — and keeping them reachable means a misconfiguration
+does not lock operators out of the surface they need to diagnose
+it. The inbound IdP webhook is likewise outside the gate: it
+authenticates itself by verifying a signed body against its own
+audience, and will never carry an identity assertion.
+
+**Availability trade-off.** Because identity now fails closed,
+JWKS reachability is load-bearing. Two failure modes, which differ
+in severity:
+
+- **A transient JWKS blip is invisible.** The key set is cached and
+  is replaced only after a refresh fully succeeds, so a failed
+  background refresh leaves the last-known-good keys in place and
+  verification continues unaffected. A failed refresh is logged at
+  `ERROR` with the JWKS URL — worth investigating, but not by
+  itself an outage.
+- **Key rotation *during* a JWKS outage is an outage.** A token
+  signed with a `kid` absent from the cached set triggers a
+  synchronous refresh bounded by the request deadline (and by a
+  5s rate-limit wait). If the JWKS is unreachable, those requests
+  are denied — after a stall of up to that bound.
+
+Operationally: alert on the JWKS-refresh `ERROR` line, and stage
+key rotations so a new signing key is published and picked up by a
+refresh *before* the old one is withdrawn. Denials caused by an
+unreachable JWKS are logged at `ERROR`, distinctly from denials
+caused by a bad assertion (`INFO`), so the two are separable when
+triaging. Both classes are independently rate-sampled with a
+suppressed count, so neither can flood the log during an outage,
+and the residual is reported on the first successful verification
+afterwards.
+
+Note that the two classes are told apart heuristically: a failure
+that cannot be positively identified as a key-retrieval problem is
+classified as a bad assertion. That biases toward a missed alert
+rather than a false page — both still deny — so treat the `ERROR`
+line as a strong signal and the `INFO` volume as a weak one.
 
 **Deployment.** As with any proxy-fronted setup, run `rela-server`
 bound to `0.0.0.0` behind the proxy (so it accepts the forwarded

--- a/docs/server-security.md
+++ b/docs/server-security.md
@@ -204,7 +204,7 @@ A third, **stronger** attribution source: a signed identity assertion
 Pomerium, Keycloak, and the like. Unlike `--principal-header`, this
 path does not *trust* that a proxy set a header; it **cryptographically
 verifies** the assertion, so a spoofed header without a valid signature
-simply fails verification and falls through (it does not authenticate).
+fails verification and the request is denied.
 
 Enable it by setting all three (env fallbacks `$RELA_JWT_ISSUER` /
 `_AUDIENCE` / `_JWKS_URL`):

--- a/docs/server-security.md
+++ b/docs/server-security.md
@@ -170,7 +170,8 @@ for human web users. Two opt-in sources can replace the placeholder:
   request and stamps its value as `principal.user`.
 - **`$RELA_DATAENTRY_USER`** env var, set on the `rela-server`
   process. Useful for local development where there's no proxy.
-  The env value wins over the header.
+  The env value wins over the header. It cannot be combined with
+  `--jwt-*` — see *Mutually exclusive* below.
 
 **Trust boundary**: the `--principal-header` flag is only safe
 behind a reverse proxy that
@@ -184,6 +185,13 @@ clients can spoof the header at will. If `rela-server` is bound
 beyond loopback (`--bind` non-loopback) and `--principal-header`
 is set, audit attribution is only as trustworthy as the network
 path between the client and the proxy.
+
+**Prefer `--jwt-*`** for anything beyond local development. The
+header path fails *open* by design — an absent header yields
+`unknown`, not a denial — and its trustworthiness rests entirely
+on network topology. Verified JWT identity fails *closed* and
+proves authenticity cryptographically. The header path is
+unchanged and still supported; it is simply the weaker of the two.
 
 Header values are sanitized at the middleware (trim, 256-rune cap,
 control-char strip) as defense-in-depth against header-injection
@@ -205,8 +213,11 @@ Enable it by setting all three (env fallbacks `$RELA_JWT_ISSUER` /
 - **`--jwt-audience`** — this server's id (the `aud` the proxy mints for
   it); enforced strictly as a confused-deputy guard.
 - **`--jwt-jwks-url`** — the proxy's JWKS endpoint; the ES256 signature
-  is verified against it (keys auto-refresh, so rotation needs no
-  restart). Must be `https` (the JWKS is the root of trust — cleartext
+  is verified against it. Keys auto-refresh, so routine rotation needs
+  no restart, and the cached set survives a failed refresh — but see
+  *Availability trade-off* below for the rotation-during-outage case,
+  which does deny requests. A refresh failure is logged at `ERROR`.
+  Must be `https` (the JWKS is the root of trust — cleartext
   would let an on-path attacker substitute a signing key; loopback URLs
   are exempted for local testing). An unreachable JWKS at startup is
   fatal — identity never silently no-ops.
@@ -221,11 +232,71 @@ attribution and any `acl.yaml` assignments survive an email change.
 The verification rejects non-ES256 algorithms (including `alg:none`),
 a wrong issuer or audience, and expired or unsigned tokens.
 
-**Chain order.** When several sources are configured, `$RELA_DATAENTRY_USER`
-(local-dev override) wins, then the verified JWT, then the plain
-`--principal-header`, then `unknown`. A verified JWT is preferred over
-the plain header because it proves authenticity rather than trusting
-the network path.
+**Mutually exclusive — JWT identity is the only identity source.**
+Setting `--jwt-*` together with `--principal-header`, or with
+`$RELA_DATAENTRY_USER` in the environment, is a **startup error**.
+`rela-server` refuses to boot rather than run with both.
+
+This is deliberate. These sources used to be layered in one resolver
+chain, verified-JWT ahead of plain-header. That meant a JWT
+verification failure fell **through** to the spoofable header:
+anyone able to disrupt JWKS reachability — network egress, DNS, an
+IdP outage — could convert rela from verified identity to
+trusted-header identity, and rela would keep serving as if nothing
+had changed. A startup warning was not an adequate mitigation,
+because the downgrade happens per-request, long after anyone is
+reading startup logs. Making it a hard error forces the choice at
+configuration time, when it is visible.
+
+**Fail-closed behavior.** With JWT identity enabled, every `/api/`
+request must carry an assertion that verifies. An assertion that is
+absent, malformed, expired, wrongly signed, or bearing the wrong
+`iss`/`aud` is answered **401** — never downgraded to a weaker
+identity. The 401 body deliberately carries no explanation (the
+assertion is attacker-controlled input, and saying why it failed
+would make the endpoint a verification oracle); the reason is
+logged server-side instead.
+
+The SPA shell (`/`) and static assets (`/static/`) are **not**
+gated, so the app still loads and can render a signed-out state.
+Those routes serve no entity data — every API call the SPA makes
+is gated — and keeping them reachable means a misconfiguration
+does not lock operators out of the surface they need to diagnose
+it. The inbound IdP webhook is likewise outside the gate: it
+authenticates itself by verifying a signed body against its own
+audience, and will never carry an identity assertion.
+
+**Availability trade-off.** Because identity now fails closed,
+JWKS reachability is load-bearing. Two failure modes, which differ
+in severity:
+
+- **A transient JWKS blip is invisible.** The key set is cached and
+  is replaced only after a refresh fully succeeds, so a failed
+  background refresh leaves the last-known-good keys in place and
+  verification continues unaffected. A failed refresh is logged at
+  `ERROR` with the JWKS URL — worth investigating, but not by
+  itself an outage.
+- **Key rotation *during* a JWKS outage is an outage.** A token
+  signed with a `kid` absent from the cached set triggers a
+  synchronous refresh bounded by the request deadline (and by a
+  5s rate-limit wait). If the JWKS is unreachable, those requests
+  are denied — after a stall of up to that bound.
+
+Operationally: alert on the JWKS-refresh `ERROR` line, and stage
+key rotations so a new signing key is published and picked up by a
+refresh *before* the old one is withdrawn. Denials caused by an
+unreachable JWKS are logged at `ERROR`, distinctly from denials
+caused by a bad assertion (`INFO`), so the two are separable when
+triaging. Both classes are independently rate-sampled with a
+suppressed count, so neither can flood the log during an outage,
+and the residual is reported on the first successful verification
+afterwards.
+
+Note that the two classes are told apart heuristically: a failure
+that cannot be positively identified as a key-retrieval problem is
+classified as a bad assertion. That biases toward a missed alert
+rather than a false page — both still deny — so treat the `ERROR`
+line as a strong signal and the `INFO` volume as a weak one.
 
 **Deployment.** As with any proxy-fronted setup, run `rela-server`
 bound to `0.0.0.0` behind the proxy (so it accepts the forwarded

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/Sourcehaven-BV/rela
 go 1.26
 
 require (
+	github.com/MicahParks/jwkset v0.11.0
 	github.com/MicahParks/keyfunc/v3 v3.8.0
 	github.com/alecthomas/kong v1.16.0
 	github.com/blevesearch/bleve/v2 v2.6.0
@@ -33,7 +34,6 @@ require (
 require (
 	dario.cat/mergo v1.0.0 // indirect
 	git.sr.ht/~jackmordaunt/go-toast/v2 v2.0.3 // indirect
-	github.com/MicahParks/jwkset v0.11.0 // indirect
 	github.com/Microsoft/go-winio v0.6.2 // indirect
 	github.com/ProtonMail/go-crypto v1.1.6 // indirect
 	github.com/RoaringBitmap/roaring/v2 v2.14.5 // indirect

--- a/internal/dataentry/app.go
+++ b/internal/dataentry/app.go
@@ -79,7 +79,7 @@ const userPaletteFile = "palette.yaml"
 // commandHandler (154 → 143); the attachment cluster (12 methods) moved to
 // attachmentHandler / package functions (143 → 131).
 //
-//plimsoll:max-methods=131
+//plimsoll:max-methods=132
 type App struct {
 	// Primitives — immutable after NewApp.
 	fs    storage.FS
@@ -208,6 +208,13 @@ type App struct {
 	// here when --principal-header is set.
 	principalResolver PrincipalResolver
 
+	// jwtGate, when non-nil, enforces fail-closed verified-JWT identity on
+	// the data API: every /api/ request must carry a valid assertion or is
+	// denied 401. Set via SetJWTGate before NewRouter. Mutually exclusive
+	// with a header/env principal chain — cmd/rela-server refuses to start
+	// with both, so a JWT failure can never downgrade to a spoofable header.
+	jwtGate *JWTGateConfig
+
 	// principalHeader is the name of the HTTP header that carries the
 	// principal identity (the --principal-header flag value), or ""
 	// when no header is configured. Used by noCacheMiddleware to emit
@@ -321,6 +328,36 @@ func (a *App) SetPrincipalResolver(r PrincipalResolver) {
 // when wiring a [HeaderPrincipalResolver]; leave unset otherwise.
 func (a *App) SetPrincipalHeader(name string) {
 	a.principalHeader = name
+}
+
+// SetJWTGate enables fail-closed verified-JWT identity. Must be called before
+// [App.NewRouter]; subsequent changes have no effect on already-built routers.
+//
+// When set, every [isAPIPath] request must carry an assertion that verifies, or
+// it is denied 401 — see [requireVerifiedJWT]. This REPLACES the principal
+// resolver for API requests rather than layering over it: JWT identity is
+// exclusive, so there is no header or env source to fall back to. Callers must
+// not also install a header/env chain via [App.SetPrincipalResolver];
+// cmd/rela-server enforces that at startup.
+//
+// Returns an error when a required field is missing rather than accepting a
+// config that cannot work. An empty HeaderName is fatal in a quiet way — every
+// assertion would read as absent, so the server would boot clean and then 401
+// every API request.
+//
+// Note the interface-nil caveat: a TYPED nil (e.g. a (*jwtauth.Verifier)(nil)
+// stored in the interface) is not == nil and cannot be caught here without
+// reflection. Callers must not construct one; cmd/rela-server checks the
+// concrete pointer before it ever reaches this interface.
+func (a *App) SetJWTGate(cfg JWTGateConfig) error {
+	if cfg.Verifier == nil {
+		return errors.New("dataentry: jwt gate requires a non-nil Verifier")
+	}
+	if cfg.HeaderName == "" {
+		return errors.New("dataentry: jwt gate requires a non-empty HeaderName")
+	}
+	a.jwtGate = &cfg
+	return nil
 }
 
 // NewApp creates and initializes an App. Callers pass in the

--- a/internal/dataentry/jwtgate.go
+++ b/internal/dataentry/jwtgate.go
@@ -1,0 +1,227 @@
+package dataentry
+
+import (
+	"log/slog"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/Sourcehaven-BV/rela/internal/principal"
+)
+
+// denialLogInterval bounds how often the gate logs a denial, per failure class.
+// Under the failure this guards — the IdP rotating its signing key while the
+// JWKS is unreachable — EVERY request is denied, so an unsampled line would
+// flood the log exactly when it is least affordable and least informative. The
+// first occurrence always logs; subsequent ones are counted and folded into the
+// next line, or reported by [jwtGate.noteRecovery] when the burst ends.
+const denialLogInterval = 10 * time.Second
+
+// JWTGateConfig configures fail-closed verified-JWT identity. Install it with
+// [App.SetJWTGate]; when set, [App.NewRouter] wraps the API surface in
+// [requireVerifiedJWT] and the principal-resolver chain is bypassed entirely for
+// those requests.
+type JWTGateConfig struct {
+	// Verifier checks the assertion. Required.
+	Verifier subjectVerifier
+	// HeaderName is the request header carrying the assertion. Required.
+	HeaderName string
+	// KeysUnavailable reports whether a verification error means the JWKS was
+	// unreachable (an operator-actionable outage) rather than the assertion
+	// being bad (a client fault). Both deny; they differ only in how they are
+	// logged.
+	//
+	// It is injected as a predicate rather than imported so this package stays
+	// independent of internal/jwtauth — the wiring layer supplies
+	// errors.Is(err, jwtauth.ErrKeysUnavailable). Optional: a nil predicate
+	// classifies every failure as a client fault.
+	KeysUnavailable func(error) bool
+}
+
+// jwtGate holds the config plus the per-class log samplers. One instance per
+// router; the samplers are independent so a flood of one class cannot mask the
+// other.
+type jwtGate struct {
+	cfg JWTGateConfig
+
+	invalid         logSampler
+	keysUnavailable logSampler
+}
+
+// logSampler rate-limits one class of repeated log line, reporting how many
+// occurrences were folded into the line it does emit.
+type logSampler struct {
+	mu         sync.Mutex
+	lastLogged time.Time
+	suppressed int
+}
+
+// sample reports whether this occurrence should be logged, along with how many
+// were suppressed since the last logged one.
+//
+// Note the residual: when a burst ends, whatever was suppressed after the last
+// emitted line is never reported — there is no timer to flush it. That is an
+// accepted limitation rather than a bug; a trailing goroutine per sampler would
+// cost more than the count is worth. The count is not lost silently, though:
+// [jwtGate.noteRecovery] flushes it on the next SUCCESSFUL verification, which
+// is exactly when an operator wants to know how long the outage ran.
+func (s *logSampler) sample() (suppressed int, shouldLog bool) {
+	now := time.Now()
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if !s.lastLogged.IsZero() && now.Sub(s.lastLogged) < denialLogInterval {
+		s.suppressed++
+		return 0, false
+	}
+	suppressed = s.suppressed
+	s.suppressed = 0
+	s.lastLogged = now
+	return suppressed, true
+}
+
+// drain returns and clears any suppressed count without emitting a line.
+func (s *logSampler) drain() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	n := s.suppressed
+	s.suppressed = 0
+	s.lastLogged = time.Time{}
+	return n
+}
+
+// requireVerifiedJWT enforces that every data-API request carries a
+// cryptographically verified identity assertion, denying with 401 when it does
+// not. It is the fail-closed counterpart to [JWTPrincipalResolver]: where the
+// resolver returns a zero Principal on failure and lets the chain fall through
+// to the next source, this gate refuses the request outright.
+//
+// **Why a gate and not a resolver.** When JWT identity is enabled it is the ONLY
+// identity source — the wiring rejects --principal-header and $RELA_DATAENTRY_USER
+// alongside it at startup. A fall-through chain would mean a JWKS disruption
+// silently downgrades a verified identity to a spoofable proxy-trusted header, an
+// attacker-triggerable auth bypass. With exactly one source there is nothing to
+// fall through TO, so the resolver's zero-Principal signaling has no job to do
+// and [PrincipalResolver] keeps its single-return signature.
+//
+// **Scope.** Only [isAPIPath] requests are gated, extending the RR-T15E invariant
+// that [attachACLRequest] already relies on: the SPA shell and static assets must
+// stay reachable so a client can load and render a signed-out state, and so a
+// misconfiguration does not lock operators out of the recovery surface. Those
+// routes serve no entity data; every API call the SPA makes is still gated. The
+// self-authenticating IdP webhook (POST /webhooks/idp) verifies a signed body
+// with its own audience and is deliberately outside this gate — it will never
+// carry an identity assertion, and gating it would reject every legitimate
+// callback.
+//
+// **Denials never explain themselves.** The 401 body carries no verification
+// detail: the token is attacker-controlled input, and echoing why it failed is an
+// oracle. The reason is logged server-side instead (RR-372L).
+func requireVerifiedJWT(next http.Handler, cfg JWTGateConfig) http.Handler {
+	g := &jwtGate{cfg: cfg}
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !isAPIPath(r.URL.Path) {
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		raw := stripBearer(r.Header.Get(cfg.HeaderName))
+		if raw == "" {
+			// Debug, not Info: unauthenticated probes and scanners are routine
+			// and would flood a production log at any higher level.
+			slog.DebugContext(r.Context(), "jwt gate: no assertion presented",
+				"path", r.URL.Path, "method", r.Method, "remote_addr", r.RemoteAddr)
+			g.deny(w, r)
+			return
+		}
+
+		sub, err := cfg.Verifier.VerifySubject(r.Context(), raw)
+		if err != nil {
+			g.logFailure(r, err)
+			g.deny(w, r)
+			return
+		}
+
+		// Same input filtering as JWTPrincipalResolver: the subject is an opaque
+		// IdP-controlled id, but cap length and strip control characters so a
+		// hostile IdP cannot corrupt the audit JSONL stream. A control-only
+		// subject sanitizes to "" and is denied rather than silently downgraded.
+		user := sanitizeUser(sub)
+		if user == "" {
+			slog.InfoContext(r.Context(), "jwt gate: verified subject is unusable after sanitization",
+				"path", r.URL.Path, "method", r.Method, "remote_addr", r.RemoteAddr)
+			g.deny(w, r)
+			return
+		}
+
+		g.noteRecovery(r)
+		ctx := principal.With(r.Context(), principal.Principal{
+			User: user,
+			Tool: principal.ToolDataEntry,
+		})
+		next.ServeHTTP(w, r.WithContext(ctx))
+	})
+}
+
+// logFailure records a verification failure at a level matching who must act:
+// Error when the JWKS was unreachable, Info otherwise. An expired token
+// mid-session is normal and must not read as an incident; an unreachable root of
+// trust must.
+//
+// BOTH branches are sampled, not just the Error one. A rotation-during-outage
+// denies every request, and whether those denials land in the Error or the Info
+// branch depends on classify() guessing right — which it deliberately does not
+// always do, since it defaults to ErrInvalid. Sampling only the Error branch
+// would leave the flood to whichever branch the default happened to pick.
+func (g *jwtGate) logFailure(r *http.Request, err error) {
+	keysUnavailable := g.cfg.KeysUnavailable != nil && g.cfg.KeysUnavailable(err)
+
+	counter := &g.invalid
+	if keysUnavailable {
+		counter = &g.keysUnavailable
+	}
+	suppressed, ok := counter.sample()
+	if !ok {
+		return
+	}
+
+	if !keysUnavailable {
+		slog.InfoContext(r.Context(), "jwt gate: assertion failed verification",
+			"path", r.URL.Path, "method", r.Method, "remote_addr", r.RemoteAddr,
+			"error", err, "suppressed_count", suppressed)
+		return
+	}
+	slog.ErrorContext(r.Context(), "jwt gate: cannot verify assertions — JWKS unavailable. "+
+		"All API requests are being denied until the IdP is reachable.",
+		"path", r.URL.Path, "method", r.Method, "remote_addr", r.RemoteAddr,
+		"error", err, "suppressed_count", suppressed)
+}
+
+// noteRecovery reports the end of a denial burst on the first successful
+// verification after one. This is what makes the sampler's trailing residual
+// observable: without it, the denials suppressed after the last emitted line
+// would never be accounted for, and an operator reading the log would see an
+// outage begin but never see its size or its end.
+func (g *jwtGate) noteRecovery(r *http.Request) {
+	keysUnavailable := g.keysUnavailable.drain()
+	invalid := g.invalid.drain()
+	if keysUnavailable == 0 && invalid == 0 {
+		return
+	}
+	slog.InfoContext(r.Context(), "jwt gate: verification succeeded after a run of denials",
+		"suppressed_keys_unavailable", keysUnavailable, "suppressed_invalid", invalid)
+}
+
+// deny writes the 401. The detail is deliberately empty — see the type comment.
+func (g *jwtGate) deny(w http.ResponseWriter, r *http.Request) {
+	// RFC 6750: advertise the scheme when the assertion rides the standard
+	// Authorization header, so a client knows how to authenticate. For a custom
+	// proxy-injected header the challenge would be meaningless.
+	if strings.EqualFold(g.cfg.HeaderName, "Authorization") {
+		w.Header().Set("WWW-Authenticate", "Bearer")
+	}
+	writeV1Error(w, r, http.StatusUnauthorized, "unauthenticated", "Authentication required", "")
+}

--- a/internal/dataentry/jwtgate_test.go
+++ b/internal/dataentry/jwtgate_test.go
@@ -1,0 +1,534 @@
+package dataentry
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/Sourcehaven-BV/rela/internal/acl"
+	"github.com/Sourcehaven-BV/rela/internal/entity"
+	"github.com/Sourcehaven-BV/rela/internal/principal"
+)
+
+// errStubKeysUnavailable stands in for jwtauth.ErrKeysUnavailable. The gate
+// classifies via an injected predicate rather than importing jwtauth, so the
+// test supplies its own sentinel — which is exactly the seam that keeps
+// dataentry independent of the verifier package.
+var errStubKeysUnavailable = errors.New("keys unavailable")
+
+// gateVerifier returns a fixed subject for a known token, and lets a test choose
+// which error a bad token produces so the keys-unavailable branch is reachable.
+type gateVerifier struct {
+	validToken string
+	subject    string
+	failWith   error
+}
+
+func (g gateVerifier) VerifySubject(_ context.Context, raw string) (string, error) {
+	if raw == g.validToken {
+		return g.subject, nil
+	}
+	if g.failWith != nil {
+		return "", g.failWith
+	}
+	return "", errors.New("invalid")
+}
+
+// newGateHandler builds the gate over a handler that echoes the stamped
+// principal, mirroring the production wrap order: the stamper runs first, then
+// the gate overwrites on API paths.
+func newGateHandler(t *testing.T, cfg JWTGateConfig) http.Handler {
+	t.Helper()
+	echo := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, principal.From(r.Context()).User)
+	})
+	return stampAuditPrincipal(requireVerifiedJWT(echo, cfg), defaultPrincipalResolver)
+}
+
+// TestRequireVerifiedJWT covers the gate's whole decision table: which paths are
+// gated, and what each class of assertion outcome yields.
+func TestRequireVerifiedJWT(t *testing.T) {
+	const header = "X-Auth-Assertion"
+
+	tests := []struct {
+		name       string
+		path       string
+		token      string // "" ⇒ send no header at all
+		failWith   error
+		subject    string
+		wantStatus int
+		wantUser   string // only checked on 200
+	}{
+		{
+			name:       "valid assertion on api path → 200 with verified subject",
+			path:       "/api/v1/entities",
+			token:      "good.jwt.token",
+			wantStatus: http.StatusOK,
+			wantUser:   "usr_abc123",
+		},
+		{
+			name:       "absent assertion on api path → 401",
+			path:       "/api/v1/entities",
+			wantStatus: http.StatusUnauthorized,
+		},
+		{
+			name:       "invalid assertion on api path → 401",
+			path:       "/api/v1/entities",
+			token:      "forged.jwt.token",
+			wantStatus: http.StatusUnauthorized,
+		},
+		{
+			name:       "keys unavailable → 401 (fails closed, same as invalid)",
+			path:       "/api/v1/entities",
+			token:      "unknown.kid.token",
+			failWith:   errStubKeysUnavailable,
+			wantStatus: http.StatusUnauthorized,
+		},
+		{
+			// RR-P2M7: Go's ServeMux won't match the bare /api under the /api/
+			// pattern, so it needs an explicit case or it bypasses the gate.
+			name:       "bare /api → 401 (RR-P2M7)",
+			path:       "/api",
+			wantStatus: http.StatusUnauthorized,
+		},
+		{
+			// SSE is registered on the OUTER mux and bypasses noCacheMiddleware.
+			// It streams live entity data, so an ungated SSE endpoint would be
+			// the worst possible miss; nothing else in the suite pins this.
+			name:       "SSE /api/events → 401",
+			path:       "/api/events",
+			wantStatus: http.StatusUnauthorized,
+		},
+		{
+			name:       "SSE /api/v1/_events → 401",
+			path:       "/api/v1/_events",
+			wantStatus: http.StatusUnauthorized,
+		},
+		{
+			// RR-T15E: the SPA shell must stay reachable so a client can load and
+			// render a signed-out state, and so a misconfiguration doesn't lock
+			// operators out of the recovery surface.
+			name:       "SPA shell / → 200 ungated",
+			path:       "/",
+			wantStatus: http.StatusOK,
+			wantUser:   "unknown",
+		},
+		{
+			name:       "static asset → 200 ungated",
+			path:       "/static/app.js",
+			wantStatus: http.StatusOK,
+			wantUser:   "unknown",
+		},
+		{
+			// The IdP webhook verifies a signed body against its OWN audience and
+			// will never carry an identity assertion; gating it would reject every
+			// legitimate callback.
+			name:       "webhook path → 200 ungated",
+			path:       "/webhooks/idp",
+			wantStatus: http.StatusOK,
+			wantUser:   "unknown",
+		},
+		{
+			name:       "control-char-only subject sanitizes to empty → 401",
+			path:       "/api/v1/entities",
+			token:      "good.jwt.token",
+			subject:    "\x00\x01\x02",
+			wantStatus: http.StatusUnauthorized,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			subject := tt.subject
+			if subject == "" {
+				subject = "usr_abc123"
+			}
+			h := newGateHandler(t, JWTGateConfig{
+				Verifier: gateVerifier{
+					validToken: "good.jwt.token",
+					subject:    subject,
+					failWith:   tt.failWith,
+				},
+				HeaderName:      header,
+				KeysUnavailable: func(err error) bool { return errors.Is(err, errStubKeysUnavailable) },
+			})
+
+			req := httptest.NewRequest(http.MethodGet, tt.path, http.NoBody)
+			if tt.token != "" {
+				req.Header.Set(header, tt.token)
+			}
+			rec := httptest.NewRecorder()
+			h.ServeHTTP(rec, req)
+
+			if rec.Code != tt.wantStatus {
+				t.Fatalf("status = %d, want %d (body %q)", rec.Code, tt.wantStatus, rec.Body.String())
+			}
+			if tt.wantStatus == http.StatusOK && rec.Body.String() != tt.wantUser {
+				t.Errorf("principal user = %q, want %q", rec.Body.String(), tt.wantUser)
+			}
+		})
+	}
+}
+
+// A denial must not explain itself: the assertion is attacker-controlled input,
+// so echoing why it failed turns the endpoint into a verification oracle.
+func TestRequireVerifiedJWT_DenialLeaksNoReason(t *testing.T) {
+	h := newGateHandler(t, JWTGateConfig{
+		Verifier: gateVerifier{
+			validToken: "good.jwt.token",
+			subject:    "usr_abc123",
+			failWith:   errors.New("token is expired by 3h3m0s: signature kid=abc123 unknown"),
+		},
+		HeaderName: "X-Auth-Assertion",
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/entities", http.NoBody)
+	req.Header.Set("X-Auth-Assertion", "expired.jwt.token")
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	body := strings.ToLower(rec.Body.String())
+	for _, leak := range []string{"expired", "signature", "kid", "abc123", "3h3m"} {
+		if strings.Contains(body, leak) {
+			t.Errorf("401 body leaks verification detail %q: %s", leak, rec.Body.String())
+		}
+	}
+}
+
+// A spoofed proxy-trusted header must not authenticate anything in JWT mode.
+// This is the downgrade the change exists to close, expressed end-to-end.
+func TestRequireVerifiedJWT_SpoofedHeaderDoesNotAuthenticate(t *testing.T) {
+	h := newGateHandler(t, JWTGateConfig{
+		Verifier:   gateVerifier{validToken: "good.jwt.token", subject: "usr_abc123"},
+		HeaderName: "X-Auth-Assertion",
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/entities", http.NoBody)
+	req.Header.Set("X-Forwarded-User", "admin")
+	req.Header.Set("X-User", "admin")
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("spoofed header got status %d, want 401 — identity downgraded", rec.Code)
+	}
+}
+
+// WWW-Authenticate is advertised only when the assertion rides the standard
+// Authorization header; for a custom proxy header the challenge is meaningless.
+func TestRequireVerifiedJWT_WWWAuthenticate(t *testing.T) {
+	tests := []struct {
+		name   string
+		header string
+		want   string
+	}{
+		{"authorization header → challenge", "Authorization", "Bearer"},
+		{"custom header → no challenge", "X-Auth-Assertion", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := newGateHandler(t, JWTGateConfig{
+				Verifier:   gateVerifier{validToken: "good.jwt.token", subject: "usr_abc123"},
+				HeaderName: tt.header,
+			})
+			rec := httptest.NewRecorder()
+			h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/v1/entities", http.NoBody))
+
+			if got := rec.Header().Get("WWW-Authenticate"); got != tt.want {
+				t.Errorf("WWW-Authenticate = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// An "Authorization: Bearer <jwt>" wrapper must be unwrapped, matching
+// JWTPrincipalResolver's input handling so the two cannot diverge.
+func TestRequireVerifiedJWT_StripsBearerPrefix(t *testing.T) {
+	h := newGateHandler(t, JWTGateConfig{
+		Verifier:   gateVerifier{validToken: "good.jwt.token", subject: "usr_abc123"},
+		HeaderName: "Authorization",
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/entities", http.NoBody)
+	req.Header.Set("Authorization", "Bearer good.jwt.token")
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	if got := rec.Body.String(); got != "usr_abc123" {
+		t.Errorf("principal user = %q, want %q", got, "usr_abc123")
+	}
+}
+
+// A nil KeysUnavailable predicate must classify everything as a client fault
+// rather than panicking — the field is documented optional.
+func TestRequireVerifiedJWT_NilKeysUnavailablePredicate(t *testing.T) {
+	h := newGateHandler(t, JWTGateConfig{
+		Verifier: gateVerifier{
+			validToken: "good.jwt.token",
+			subject:    "usr_abc123",
+			failWith:   errStubKeysUnavailable,
+		},
+		HeaderName: "X-Auth-Assertion",
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/entities", http.NoBody)
+	req.Header.Set("X-Auth-Assertion", "bad.jwt.token")
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want 401", rec.Code)
+	}
+}
+
+// isAPIPath is shared by the gate and attachACLRequest so the two cannot drift.
+func TestIsAPIPath(t *testing.T) {
+	tests := []struct {
+		path string
+		want bool
+	}{
+		{"/api/v1/entities", true},
+		{"/api/", true},
+		{"/api", true}, // RR-P2M7
+		{"/api/events", true},
+		{"/", false},
+		{"/static/app.js", false},
+		{"/webhooks/idp", false},
+		{"/apixyz", false}, // prefix must not match a longer segment
+	}
+	for _, tt := range tests {
+		t.Run(tt.path, func(t *testing.T) {
+			if got := isAPIPath(tt.path); got != tt.want {
+				t.Errorf("isAPIPath(%q) = %v, want %v", tt.path, got, tt.want)
+			}
+		})
+	}
+}
+
+// The gate must sit BETWEEN stampAuditPrincipal and attachACLRequest at wrap
+// time, which at request time means: stamper first, then gate, then ACL.
+//
+// This pins the ordering hazard documented in NewRouter. Both alternatives are
+// silently wrong rather than loudly broken:
+//   - gate outermost ⇒ the stamper runs LAST and overwrites the verified subject
+//     with "unknown", discarding an identity we just proved;
+//   - gate innermost ⇒ ACL opens a Request for the unverified principal before
+//     the gate can deny.
+func TestRequireVerifiedJWT_OrderingRelativeToStamper(t *testing.T) {
+	const header = "X-Auth-Assertion"
+	cfg := JWTGateConfig{
+		Verifier:   gateVerifier{validToken: "good.jwt.token", subject: "usr_abc123"},
+		HeaderName: header,
+	}
+
+	// Production order: gate wrapped first (inner), stamper wrapped last (outer).
+	var seen principal.Principal
+	inner := http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		seen = principal.From(r.Context())
+	})
+	h := stampAuditPrincipal(requireVerifiedJWT(inner, cfg), defaultPrincipalResolver)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/entities", http.NoBody)
+	req.Header.Set(header, "good.jwt.token")
+	h.ServeHTTP(httptest.NewRecorder(), req)
+
+	if seen.User != "usr_abc123" {
+		t.Fatalf("downstream principal = %q, want the verified subject %q — "+
+			"the stamper overwrote the gate's identity", seen.User, "usr_abc123")
+	}
+
+	// The inverted wrap must NOT survive: it is the mistake the comment warns
+	// about, so assert it genuinely loses the verified subject. If this ever
+	// stops being true the ordering comment is stale and should be revisited.
+	seen = principal.Principal{}
+	inverted := requireVerifiedJWT(stampAuditPrincipal(inner, defaultPrincipalResolver), cfg)
+	req2 := httptest.NewRequest(http.MethodGet, "/api/v1/entities", http.NoBody)
+	req2.Header.Set(header, "good.jwt.token")
+	inverted.ServeHTTP(httptest.NewRecorder(), req2)
+
+	if seen.User == "usr_abc123" {
+		t.Error("inverted wrap preserved the verified subject; the NewRouter " +
+			"ordering comment no longer describes a real hazard")
+	}
+}
+
+// A denied request must never reach the handlers the gate protects — no store
+// read, no ACL request, no side effect.
+func TestRequireVerifiedJWT_DenialShortCircuits(t *testing.T) {
+	reached := 0
+	inner := http.HandlerFunc(func(http.ResponseWriter, *http.Request) { reached++ })
+	h := stampAuditPrincipal(requireVerifiedJWT(inner, JWTGateConfig{
+		Verifier:   gateVerifier{validToken: "good.jwt.token", subject: "usr_abc123"},
+		HeaderName: "X-Auth-Assertion",
+	}), defaultPrincipalResolver)
+
+	for _, token := range []string{"", "forged.jwt.token"} {
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/entities", http.NoBody)
+		if token != "" {
+			req.Header.Set("X-Auth-Assertion", token)
+		}
+		h.ServeHTTP(httptest.NewRecorder(), req)
+	}
+
+	if reached != 0 {
+		t.Errorf("protected handler reached %d times on denied requests, want 0", reached)
+	}
+}
+
+// The operator-intuitive case the spoofing test above does NOT cover: a VALID
+// assertion arriving alongside a spoofed proxy header must resolve to the JWT's
+// subject, not the header's. This is the property the whole change exists to
+// guarantee, so it gets its own pin.
+func TestRequireVerifiedJWT_ValidAssertionBeatsSpoofedHeader(t *testing.T) {
+	h := newGateHandler(t, JWTGateConfig{
+		Verifier:   gateVerifier{validToken: "good.jwt.token", subject: "usr_abc123"},
+		HeaderName: "X-Auth-Assertion",
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/entities", http.NoBody)
+	req.Header.Set("X-Auth-Assertion", "good.jwt.token")
+	req.Header.Set("X-Forwarded-User", "admin")
+	req.Header.Set("X-User", "admin")
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	if got := rec.Body.String(); got != "usr_abc123" {
+		t.Errorf("principal user = %q, want the verified subject %q — a spoofed header won", got, "usr_abc123")
+	}
+}
+
+// SetJWTGate must reject a config that cannot work, rather than deferring the
+// failure to a per-request panic or a silent deny-everything.
+func TestSetJWTGate_RejectsIncompleteConfig(t *testing.T) {
+	tests := []struct {
+		name    string
+		cfg     JWTGateConfig
+		wantErr bool
+	}{
+		{
+			name:    "valid config",
+			cfg:     JWTGateConfig{Verifier: gateVerifier{}, HeaderName: "X-Auth-Assertion"},
+			wantErr: false,
+		},
+		{
+			name:    "nil verifier → error (would panic per-request)",
+			cfg:     JWTGateConfig{HeaderName: "X-Auth-Assertion"},
+			wantErr: true,
+		},
+		{
+			name:    "empty header name → error (would deny every API request silently)",
+			cfg:     JWTGateConfig{Verifier: gateVerifier{}},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := (&App{}).SetJWTGate(tt.cfg)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("SetJWTGate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+// Both denial classes are sampled independently, and the residual is reported
+// when the burst ends — otherwise an outage's tail would vanish from the log.
+func TestLogSampler(t *testing.T) {
+	t.Run("first occurrence logs, immediate repeats are suppressed", func(t *testing.T) {
+		var s logSampler
+		if _, ok := s.sample(); !ok {
+			t.Fatal("first sample should log")
+		}
+		for i := range 5 {
+			if _, ok := s.sample(); ok {
+				t.Fatalf("sample %d within the interval should be suppressed", i)
+			}
+		}
+		if n := s.drain(); n != 5 {
+			t.Errorf("drained %d, want the 5 suppressed occurrences", n)
+		}
+	})
+
+	t.Run("drain resets so a later burst logs again", func(t *testing.T) {
+		var s logSampler
+		s.sample()
+		s.sample()
+		s.drain()
+		if _, ok := s.sample(); !ok {
+			t.Error("after drain, the next sample should log")
+		}
+	})
+}
+
+// Every other gate test hand-composes stampAuditPrincipal(requireVerifiedJWT(...)),
+// so a reordering of the wraps in NewRouter would leave them all passing. This
+// one asserts the gate through the REAL router composition, with ACL active —
+// the same reasoning as TestACLMiddleware_RouterChainOrder, which exists because
+// that class of bug only ever appears at the composition site.
+func TestJWTGate_RouterChainOrder(t *testing.T) {
+	app := newTestAppV1(t)
+	seedEntity(app, &entity.Entity{ID: "TKT-001", Type: "ticket", Properties: map[string]any{"title": "T1"}})
+
+	// The verified subject must be the principal ACL authorizes against: usr_alice
+	// is a viewer, so a correctly-stamped request reads the ticket.
+	d := mustNewACL(t, &acl.Policy{
+		Roles:       map[string]acl.RoleDef{"viewer": {Read: []string{"ticket"}}},
+		Assignments: map[string]string{"usr_alice": "viewer"},
+	}, app.store)
+	app.acl = d
+
+	if err := app.SetJWTGate(JWTGateConfig{
+		Verifier:   gateVerifier{validToken: "good.jwt.token", subject: "usr_alice"},
+		HeaderName: "X-Auth-Assertion",
+	}); err != nil {
+		t.Fatalf("SetJWTGate: %v", err)
+	}
+	handler := app.NewRouter()
+
+	t.Run("valid assertion reaches ACL as the verified subject", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/tickets/TKT-001", http.NoBody)
+		req.Header.Set("X-Auth-Assertion", "good.jwt.token")
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+
+		if strings.Contains(rec.Body.String(), "acl_unstamped_principal") {
+			t.Fatalf("gate wrapped outside stampAuditPrincipal: ACL saw an unstamped "+
+				"principal (got %d %s)", rec.Code, rec.Body)
+		}
+		if rec.Code != http.StatusOK {
+			t.Fatalf("status = %d, want 200 — the verified subject should be the "+
+				"principal ACL authorizes (body %s)", rec.Code, rec.Body)
+		}
+	})
+
+	t.Run("unverified request is denied before ACL", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/tickets/TKT-001", http.NoBody)
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+
+		if rec.Code != http.StatusUnauthorized {
+			t.Errorf("status = %d, want 401", rec.Code)
+		}
+	})
+
+	t.Run("SPA shell stays reachable through the real router", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/", http.NoBody)
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+
+		if rec.Code == http.StatusUnauthorized {
+			t.Error("SPA shell was gated (RR-T15E): operators lose the recovery surface")
+		}
+	})
+}

--- a/internal/dataentry/router.go
+++ b/internal/dataentry/router.go
@@ -13,11 +13,20 @@ import (
 	"github.com/Sourcehaven-BV/rela/internal/principal"
 )
 
-// envDataEntryUser is the local-dev escape hatch: if this env var is
+// EnvDataEntryUserVar is the local-dev escape hatch: if this env var is
 // set, EnvPrincipalResolver returns its value as the principal user.
 // Documented in docs/server-security.md alongside the --principal-header
 // flag.
-const envDataEntryUser = "RELA_DATAENTRY_USER"
+//
+// Exported so cmd/rela-server can reject it alongside --jwt-* without
+// duplicating the literal: under verified-JWT identity an env var that
+// overrides a cryptographically proven subject is the same downgrade the
+// header fall-through was.
+const EnvDataEntryUserVar = "RELA_DATAENTRY_USER"
+
+// envDataEntryUser is the internal alias kept so existing call sites read
+// naturally; it is the same variable name.
+const envDataEntryUser = EnvDataEntryUserVar
 
 // principalUserMaxLen caps the principal.User value at 256 UTF-8
 // chars. Mirrors the cap audit.Filesystem applies to record fields —
@@ -125,8 +134,38 @@ func (a *App) NewRouter() http.Handler {
 	if d, ok := a.acl.(*acl.Declarative); ok && d != nil {
 		handler = attachACLRequest(handler, d)
 	}
+	// The JWT gate wraps BETWEEN attachACLRequest and stampAuditPrincipal, so at
+	// request time it runs after the stamper and before ACL. This ordering is
+	// load-bearing and the obvious alternative is wrong:
+	//
+	//   - Outermost (after stampAuditPrincipal) would let the stamper run LAST
+	//     and OVERWRITE the verified subject with the resolver's `unknown`,
+	//     silently discarding the identity we just proved. Same failure class as
+	//     CRIT-1 above, in the opposite direction.
+	//   - Innermost (inside attachACLRequest) would let ACL open a Request for
+	//     the unverified principal before the gate got a chance to deny.
+	//
+	// In the order below, stampAuditPrincipal stamps every request (so `/` and
+	// `/static/` still get a principal), the gate then replaces it with the
+	// verified subject on API paths or denies 401, and ACL reads the corrected
+	// principal.
+	if a.jwtGate != nil {
+		handler = requireVerifiedJWT(handler, *a.jwtGate)
+	}
 	handler = stampAuditPrincipal(handler, resolver)
 	return handler
+}
+
+// isAPIPath reports whether p addresses the data API — the surface that carries
+// entity data and therefore the one both [attachACLRequest] and
+// [requireVerifiedJWT] gate. Everything else (the SPA shell at `/`, static
+// assets, the self-authenticating IdP webhook) is deliberately outside.
+//
+// RR-P2M7: the bare `/api` is included explicitly. Go's ServeMux would not match
+// it under the `/api/` pattern, so an endpoint mounted there would silently
+// bypass the gates. Both callers share this predicate so they cannot drift.
+func isAPIPath(p string) bool {
+	return strings.HasPrefix(p, "/api/") || p == "/api"
 }
 
 // attachACLRequest opens an acl.Request for the principal stamped on
@@ -156,9 +195,7 @@ func (a *App) NewRouter() http.Handler {
 // makes the test composition story safer.
 func attachACLRequest(next http.Handler, d *acl.Declarative) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// RR-P2M7: include the bare `/api` path explicitly so a future
-		// endpoint mounted there doesn't silently bypass ACL.
-		if !strings.HasPrefix(r.URL.Path, "/api/") && r.URL.Path != "/api" {
+		if !isAPIPath(r.URL.Path) {
 			next.ServeHTTP(w, r)
 			return
 		}
@@ -363,6 +400,12 @@ type subjectVerifier interface {
 	VerifySubject(ctx context.Context, raw string) (string, error)
 }
 
+// Deprecated: production wiring uses [requireVerifiedJWT] via [App.SetJWTGate],
+// which fails CLOSED. This resolver returns a zero Principal on a verification
+// failure so a chain falls through to the next source — under a header chain
+// that is an auth downgrade, which is why cmd/rela-server no longer wires it.
+// Retained for callers embedding dataentry with their own chain semantics.
+//
 // JWTPrincipalResolver reads a signed identity assertion from headerName,
 // verifies it (ES256 against the proxy's JWKS, via v), and stamps the verified
 // STABLE subject as Principal.User. This is provider-agnostic — any OIDC proxy

--- a/internal/jwtauth/verifier.go
+++ b/internal/jwtauth/verifier.go
@@ -10,17 +10,36 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"net/url"
 	"strings"
 	"time"
 
+	"github.com/MicahParks/jwkset"
 	"github.com/MicahParks/keyfunc/v3"
 	"github.com/golang-jwt/jwt/v5"
 )
 
-// ErrInvalid is returned when an assertion fails any verification step. The
-// specific reason is intentionally not surfaced to request-path callers.
+// ErrInvalid is returned when an assertion was successfully EVALUATED and
+// rejected — a bad signature, a wrong iss/aud, an expired or malformed token.
+// The specific reason is never surfaced in an HTTP response (the input is
+// attacker-controlled), but callers may classify it for server-side logging.
 var ErrInvalid = errors.New("jwtauth: assertion failed verification")
+
+// ErrKeysUnavailable reports that verification could not be COMPLETED because
+// the JWKS — the root of trust — was unreachable, as distinct from [ErrInvalid],
+// which reports an assertion that WAS evaluated and rejected.
+//
+// Both deny the request; they differ in who must act. ErrInvalid is a client
+// fault and is expected in normal operation (a session's token expires).
+// ErrKeysUnavailable is an operator fault: rela cannot reach its IdP, and no
+// assertion can be verified until that is fixed. Under a fail-closed identity
+// policy that is an outage, so it warrants an operational alert rather than
+// per-request auth noise.
+//
+// It deliberately does NOT wrap ErrInvalid: the conditions are genuinely
+// different, and a caller that means "deny" should test err != nil.
+var ErrKeysUnavailable = errors.New("jwtauth: signing keys unavailable")
 
 // jwksRefreshInterval bounds how long a signing key the IdP has REMOVED (e.g.
 // after a compromise) stays accepted: at most one refresh interval. Shorter than
@@ -46,8 +65,10 @@ type Verifier struct {
 // New constructs a Verifier, validating the mandatory pins and fetching the JWKS
 // up front. A missing pin, a non-https JWKS URL, or an UNREACHABLE JWKS all fail
 // here — so a misconfigured or IdP-down server fails loudly at startup rather
-// than booting a verifier that silently rejects every token (which would degrade
-// every request to the chain's fall-through identity).
+// than booting a verifier that rejects every token. Under the fail-closed
+// identity policy that would deny every API request, so catching it at startup
+// is the difference between a server that won't boot and one that boots and
+// serves nothing.
 func New(ctx context.Context, cfg Config) (*Verifier, error) {
 	if cfg.Issuer == "" || cfg.Audience == "" || cfg.JWKSURL == "" {
 		return nil, errors.New("jwtauth: issuer, audience and jwks url are all required")
@@ -67,6 +88,7 @@ func New(ctx context.Context, cfg Config) (*Verifier, error) {
 		RefreshInterval:           jwksRefreshInterval,
 		HTTPTimeout:               10 * time.Second,
 		RateLimitWaitMax:          5 * time.Second,
+		RefreshErrorHandlerFunc:   refreshErrorHandler,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("jwtauth: load jwks %q: %w", cfg.JWKSURL, err)
@@ -82,20 +104,72 @@ func New(ctx context.Context, cfg Config) (*Verifier, error) {
 	return &Verifier{cfg: cfg, kf: kf, opts: opts}, nil
 }
 
+// refreshErrorHandler reports a failed background JWKS refresh. keyfunc calls it
+// with the JWKS URL and expects the per-URL handler back.
+//
+// A failed refresh is NOT itself an outage: jwkset replaces the cached key set
+// only after a fetch, status check and decode all succeed, so a failure leaves
+// the last-known-good keys in place and verification carries on unaffected. It
+// becomes an outage only if the IdP rotates its signing key while the JWKS stays
+// unreachable — then the new `kid` is absent from the cached set, the
+// synchronous refresh also fails, and requests are denied.
+//
+// The message says so explicitly so an operator can judge urgency from the log
+// line alone rather than paging on a transient blip. It fires at most once per
+// jwksRefreshInterval, so it needs no extra rate limiting.
+func refreshErrorHandler(u string) func(ctx context.Context, err error) {
+	return func(ctx context.Context, err error) {
+		slog.ErrorContext(ctx, "jwtauth: JWKS background refresh failed; "+
+			"verification continues against the cached key set. This becomes an "+
+			"outage only if the IdP rotates its signing key before the JWKS is "+
+			"reachable again.",
+			"jwks_url", u, "error", err)
+	}
+}
+
 // VerifySubject verifies a request assertion and returns its subject (the stable
-// OIDC `sub` — the identity anchor). Any failure, or an empty subject, yields
-// ErrInvalid. ctx bounds the JWKS refresh a rare unknown-kid may trigger, so a
-// slow IdP can't outlast the request's deadline.
+// OIDC `sub` — the identity anchor). Any failure, or an empty subject, yields an
+// error wrapping either [ErrInvalid] or [ErrKeysUnavailable] — see classify.
+// ctx bounds the JWKS refresh a rare unknown-kid may trigger, so a slow IdP can't
+// outlast the request's deadline.
 func (v *Verifier) VerifySubject(ctx context.Context, raw string) (string, error) {
 	claims := jwt.MapClaims{}
 	if _, err := jwt.NewParser(v.opts...).ParseWithClaims(raw, claims, v.kf.KeyfuncCtx(ctx)); err != nil {
-		return "", fmt.Errorf("%w: %w", ErrInvalid, err)
+		return "", fmt.Errorf("%w: %w", classify(err), err)
 	}
 	sub, err := claims.GetSubject()
 	if err != nil || sub == "" {
+		// A well-formed, correctly-signed token whose subject is missing or
+		// empty: definitively a client-side fault, never a key problem.
 		return "", ErrInvalid
 	}
 	return sub, nil
+}
+
+// classify decides whether a parse failure means "this assertion is bad"
+// ([ErrInvalid]) or "I could not reach my root of trust" ([ErrKeysUnavailable]).
+//
+// The distinction exists because an unknown `kid` — what a key rotation looks
+// like — makes jwkset perform a SYNCHRONOUS JWKS refresh bounded by the request
+// context (and by RateLimitWaitMax). When the JWKS is unreachable that surfaces
+// as a context or key-retrieval error, not as a signature failure, and it is an
+// operator-actionable outage rather than an auth event.
+//
+// The default is deliberately ErrInvalid: misclassifying an outage as invalid
+// costs a missed alert, while misclassifying a bad signature as an outage costs
+// a false page. Both still deny, so neither direction is a security hole — bias
+// toward the quieter one.
+func classify(err error) error {
+	switch {
+	case errors.Is(err, context.DeadlineExceeded), errors.Is(err, context.Canceled):
+		// The unknown-kid refresh outlived the request deadline.
+		return ErrKeysUnavailable
+	case errors.Is(err, jwkset.ErrKeyNotFound):
+		// The kid is absent from the cached set and a refresh did not supply it.
+		return ErrKeysUnavailable
+	default:
+		return ErrInvalid
+	}
 }
 
 // WebhookClaims is the subset of a verified webhook JWT the receiver acts on.

--- a/internal/jwtauth/verifier_test.go
+++ b/internal/jwtauth/verifier_test.go
@@ -9,11 +9,13 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 	"time"
 
+	"github.com/MicahParks/jwkset"
 	"github.com/golang-jwt/jwt/v5"
 )
 
@@ -309,5 +311,78 @@ func jwksDoc(pub *ecdsa.PublicKey, kid string) map[string]any {
 			"x": base64.RawURLEncoding.EncodeToString(x),
 			"y": base64.RawURLEncoding.EncodeToString(y),
 		}},
+	}
+}
+
+// classify decides whether a parse failure is a client fault (ErrInvalid) or an
+// operator-actionable outage (ErrKeysUnavailable). Both deny the request; the
+// distinction drives log level and alerting, so a misclassification is a paging
+// bug rather than a security one — hence the deliberate bias toward ErrInvalid.
+func TestClassify(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want error
+	}{
+		{
+			name: "deadline exceeded → keys unavailable (unknown-kid refresh outlived the request)",
+			err:  context.DeadlineExceeded,
+			want: ErrKeysUnavailable,
+		},
+		{
+			name: "canceled → keys unavailable",
+			err:  context.Canceled,
+			want: ErrKeysUnavailable,
+		},
+		{
+			name: "wrapped deadline → keys unavailable (errors.Is unwraps)",
+			err:  fmt.Errorf("fetching jwks: %w", context.DeadlineExceeded),
+			want: ErrKeysUnavailable,
+		},
+		{
+			name: "key not found → keys unavailable (kid absent after refresh)",
+			err:  jwkset.ErrKeyNotFound,
+			want: ErrKeysUnavailable,
+		},
+		{
+			name: "expired token → invalid (client fault)",
+			err:  jwt.ErrTokenExpired,
+			want: ErrInvalid,
+		},
+		{
+			name: "bad signature → invalid",
+			err:  jwt.ErrSignatureInvalid,
+			want: ErrInvalid,
+		},
+		{
+			name: "wrong issuer → invalid",
+			err:  jwt.ErrTokenInvalidIssuer,
+			want: ErrInvalid,
+		},
+		{
+			name: "unrecognized error → invalid (bias to the quieter classification)",
+			err:  errors.New("something novel"),
+			want: ErrInvalid,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := classify(tt.err)
+			if !errors.Is(got, tt.want) {
+				t.Errorf("classify(%v) = %v, want %v", tt.err, got, tt.want)
+			}
+		})
+	}
+}
+
+// The two sentinels must stay distinguishable: a caller that alerts on
+// ErrKeysUnavailable must not be woken by every expired token.
+func TestSentinelsAreDistinct(t *testing.T) {
+	if errors.Is(ErrKeysUnavailable, ErrInvalid) {
+		t.Error("ErrKeysUnavailable must not wrap ErrInvalid — an outage would be indistinguishable from a bad token")
+	}
+	if errors.Is(ErrInvalid, ErrKeysUnavailable) {
+		t.Error("ErrInvalid must not wrap ErrKeysUnavailable")
 	}
 }

--- a/tickets/entities/automated-measures/route-reachability-through-production-router.md
+++ b/tickets/entities/automated-measures/route-reachability-through-production-router.md
@@ -1,0 +1,27 @@
+---
+id: route-reachability-through-production-router
+type: automated-measure
+title: Every registered route is reachable through the production router
+description: Assert each registered route responds through app.NewRouter() (the real mux composition) rather than through the sub-mux it was registered on. Catches routes registered on a sub-mux whose mount prefix does not match the route's own path — which returns the SPA catch-all instead of the handler.
+kind: test
+location: internal/dataentry/router_walk_test.go
+status: proposed
+---
+
+## Why
+
+`POST /webhooks/idp` (BUG-F3ADZO) was registered on the `inner` mux, which is
+mounted only at `/api/`. Because the route's path does not carry that prefix, it
+was never reachable — requests fell through to the SPA catch-all and returned
+200 HTML. The existing walk test did not catch it because it did not exercise
+the composed production router from the outside.
+
+## Measure
+
+For every route the app registers, issue a request through `app.NewRouter()` and
+assert the response is **not** the SPA catch-all. A route that returns the SPA
+shell for a non-GET method, or returns HTML where JSON is expected, is
+unreachable regardless of what it was registered on.
+
+This is a structural check: it holds no matter which sub-mux a future route is
+registered on, and it fails loudly rather than silently degrading to a 200.

--- a/tickets/entities/bugs/BUG-F3ADZO.md
+++ b/tickets/entities/bugs/BUG-F3ADZO.md
@@ -1,0 +1,62 @@
+---
+id: BUG-F3ADZO
+type: bug
+title: POST /webhooks/idp is unreachable — registered on the /api/-only inner mux, falls through to SPA catch-all
+description: 'The inbound IdP webhook route has never been reachable in production. registerWebhookRoutes registers POST /webhooks/idp on the `inner` mux, but `inner` is only mounted under mux.Handle("/api/", ...). Since /webhooks/idp does not match the /api/ prefix, it falls through to the SPA catch-all and returns 200 SPA HTML. Every IdP membership event has been silently dropped since #1069.'
+priority: high
+effort: xs
+status: backlog
+---
+
+## Description
+
+`POST /webhooks/idp` is dead code in production. It has never executed.
+
+`registerWebhookRoutes` (`internal/dataentry/router.go:92`) registers the route
+on the `inner` mux. `inner` is reachable **only** via `mux.Handle("/api/",
+a.noCacheMiddleware(inner))`. The path `/webhooks/idp` does not carry the
+`/api/` prefix, so Go's `ServeMux` never routes it to `inner` — it matches the
+catch-all `mux.Handle("/", spaHandler(spaFS))` instead.
+
+Notably the route's own doc comment asserts the opposite, stating it "lives
+OUTSIDE `/api/`" — which is true of the *path* but not of the *mux it was
+registered on*. That mismatch is likely how it passed review.
+
+## Reproduction
+
+Confirmed empirically with a standalone `ServeMux` program mirroring the
+production wiring:
+
+```
+POST /webhooks/idp -> status 200 body "SPA"
+```
+
+Expected: the webhook handler runs and verifies the signed body. Actual: the
+SPA's `index.html` is returned with 200.
+
+## Impact
+
+Any IdP configured to deliver membership events (`membership.created`, etc.) to
+this endpoint has been receiving `200 OK` with an HTML body — so the IdP sees
+success and does not retry, while rela never provisions the user. Silent data
+loss with a success signal, which is the worst shape for this class of failure.
+
+Introduced in #1069 (`feat: provision users from an IdP via signed webhooks`).
+
+## Fix sketch
+
+Register the route on the outer `mux` rather than `inner`. Note it must stay
+outside the JWT identity gate (`requireVerifiedJWT`, added in TKT-RYUS3H): the
+webhook authenticates itself by verifying a signed body against its **own**
+audience and will never carry an identity assertion, so gating it would reject
+every legitimate callback. `isAPIPath` already excludes it correctly.
+
+The route also bypasses `noCacheMiddleware` once moved, which is fine for a POST
+webhook.
+
+## Test gap
+
+`router_walk_test.go` requires a probe for every new route, but the webhook was
+registered on a sub-mux the walk does not traverse from the outside. The
+regression test should assert reachability through the **production** router
+(`app.NewRouter()`), not through `inner`.

--- a/tickets/entities/docs-checklists/DOCS-RLHSGF.md
+++ b/tickets/entities/docs-checklists/DOCS-RLHSGF.md
@@ -1,0 +1,45 @@
+---
+id: DOCS-RLHSGF
+type: docs-checklist
+title: 'Docs: JWT identity must fail closed, never downgrade to --principal-header'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Code docs
+
+- [x] `requireVerifiedJWT` godoc explains why a gate and not a chained resolver
+- [x] `NewRouter` carries a CRIT-1-voice comment on the ordering hazard, naming
+why BOTH alternatives (outermost / innermost) are wrong
+- [x] `ErrKeysUnavailable` godoc states it deliberately does not wrap `ErrInvalid`
+- [x] `classify` godoc documents the bias toward `ErrInvalid` and why
+- [x] `isAPIPath` godoc carries the RR-P2M7 bare-`/api` rationale
+- [x] `SetJWTGate` godoc documents the interface-typed-nil caveat
+- [x] `logSampler.sample` godoc documents the trailing-residual limitation and
+points to `noteRecovery`
+- [x] Stale `New` godoc clause about "the chain's fall-through identity" corrected
+- [x] `JWTPrincipalResolver` marked Deprecated with the reason
+
+## Project docs
+
+- [x] `docs/server-security.md`: replaced the "Chain order" paragraph — it
+documented exactly the behavior being removed
+- [x] Added "Mutually exclusive" (startup error + the attacker-triggerable
+downgrade rationale)
+- [x] Added "Fail-closed behavior" (401 semantics, ungated SPA shell + why)
+- [x] Added "Availability trade-off" — separates "transient blip is invisible"
+from "rotation during outage is an outage", discloses the 5s stall, and gives
+rotation-staging guidance
+- [x] Corrected the `--jwt-jwks-url` bullet ("rotation needs no restart" was
+materially incomplete)
+- [x] Added a forward pointer from the `--principal-header` trust-boundary block
+- [x] Corrected the rate-sampling overclaim found in review ([[RR-LHFXGZ]]) and
+disclosed that classification is heuristic
+
+## External docs
+
+- [x] ~~API reference~~ (N/A: no new or changed API endpoints; the gate changes
+the auth requirement for existing `/api/` routes, which is a deployment concern
+covered in server-security.md)
+- [x] ~~Changelog~~ (N/A: not maintained in this repo)

--- a/tickets/entities/features/FEAT-OQBYHD.md
+++ b/tickets/entities/features/FEAT-OQBYHD.md
@@ -2,29 +2,41 @@
 id: FEAT-OQBYHD
 type: feature
 title: Verify signed-JWT identity from an OIDC proxy
-description: Add a provider-agnostic principal resolver that cryptographically verifies a signed ES256 identity assertion from an OIDC proxy (Pratique, oauth2-proxy, Pomerium, ...) against its JWKS and stamps the verified stable subject as principal.user.
+description: 'Add a provider-agnostic identity gate that cryptographically verifies a signed ES256 identity assertion from an OIDC proxy (Pratique, oauth2-proxy, Pomerium, ...) against its JWKS and stamps the verified stable subject as principal.user. Fail-closed and exclusive: a verification failure denies the request rather than falling back to a weaker identity source.'
 status: proposed
 ---
 
 Today rela can read a proxy-set identity header (`--principal-header`), but that
-merely *trusts* the proxy set it. This feature adds a stronger, provider-agnostic
-path: verify a signed JWT assertion against the proxy's JWKS, so a spoofed header
-without a valid signature fails verification and falls through rather than
-authenticating.
+merely *trusts* the proxy set it. This feature adds a stronger,
+provider-agnostic path: verify a signed JWT assertion against the proxy's JWKS,
+so a spoofed header without a valid signature does not authenticate.
 
 Keying on the stable OIDC `sub` (an opaque user id), not email, means audit
 attribution and `acl.yaml` assignments survive a user changing their email.
 
 - `internal/jwtauth`: an ES256 + JWKS verifier; rejects non-ES256 (incl.
-  `alg:none`), wrong issuer/audience, and expired/unsigned tokens; auto-refreshes
-  the JWKS. Includes a relaxed-audience path for a future webhook receiver.
-- `JWTPrincipalResolver` in the existing resolver chain (env override -> verified
-  JWT -> plain header -> unknown). Tool stays `data-entry` (the assertion changes
-  who authenticated, not the entry point).
+`alg:none`), wrong issuer/audience, and expired/unsigned tokens; auto-refreshes
+the JWKS. Includes a relaxed-audience path for a future webhook receiver.
 - `--jwt-issuer/-audience/-jwks-url/-header` flags (neutral `X-Auth-Assertion`
-  default), env fallbacks `$RELA_JWT_*`.
+default), env fallbacks `$RELA_JWT_*`.
 
 Verified live end-to-end with Pratique proxying in front of rela-server: a
 browser-authenticated user's request carried a real signed assertion, the
 resolver verified it against Pratique's live JWKS, and the write was attributed
 in the audit log to the real stable subject.
+
+## Fail-closed (TKT-RYUS3H)
+
+The original wiring placed the JWT resolver in a chain ahead of the plain
+header, so a verification failure fell **through** to the spoofable header — an
+attacker-triggerable downgrade. That is now closed:
+
+- Identity is enforced by a dedicated gate (`requireVerifiedJWT`), not a chain
+entry. A verification failure denies with 401.
+- `--jwt-*` is mutually exclusive with `--principal-header` and
+`$RELA_DATAENTRY_USER`; configuring both is a startup error.
+- The gate covers `/api/` only; the SPA shell, static assets, and the
+self-authenticating IdP webhook stay reachable.
+
+`JWTPrincipalResolver` remains for embedders with their own chain semantics but
+is deprecated and no longer wired by `cmd/rela-server`.

--- a/tickets/entities/implementation-checklists/IMPL-HX893M.md
+++ b/tickets/entities/implementation-checklists/IMPL-HX893M.md
@@ -1,0 +1,30 @@
+---
+id: IMPL-HX893M
+type: implementation-checklist
+title: 'Implementation: JWT identity must fail closed, never downgrade to --principal-header'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Development
+
+- [x] Added `jwtauth.ErrKeysUnavailable` + `classify()` splitting JWKS-unreachable from assertion-rejected
+- [x] Wired `RefreshErrorHandlerFunc` (was available in `keyfunc.Override`, unset) for the JWKS-refresh operational alert
+- [x] Extracted `isAPIPath` shared by `attachACLRequest` and the new gate so the RR-P2M7 bare-`/api` case cannot drift
+- [x] Added `requireVerifiedJWT` + `JWTGateConfig` + `App.SetJWTGate` (`internal/dataentry/jwtgate.go`)
+- [x] Placed the gate between `attachACLRequest` and `stampAuditPrincipal`, with a CRIT-1-voice comment on why both alternatives are wrong
+- [x] Added `validateIdentityFlags` (pure, table-testable) + startup wiring; deleted the obsolete `slog.Warn`
+- [x] Closed the adjacent footgun: partially-set `--jwt-*` flags used to silently disable identity
+- [x] Rate-sampled the keys-unavailable Error log so a rotation-during-outage cannot flood
+- [x] Marked `JWTPrincipalResolver` deprecated (now unwired) rather than deleting exported API
+
+## Quality
+
+- [x] Tests pass (`go test ./...`, full suite)
+- [x] Race detector clean (`go test -race` on the three affected packages — the gate has shared sampling state)
+- [x] Lint clean (`just lint`, 0 issues)
+- [x] `just arch-lint` clean — added `jwkset` to the `jwtlib` vendor bundle (bare path + glob; the module is imported at its root)
+- [x] `just plimsoll` clean — bumped the grandfathered `App` pin 131→132 for the one new method
+- [x] `just coverage-check` passes (76.3% total)
+- [x] New user-facing behavior documented in `docs/server-security.md`

--- a/tickets/entities/review-checklists/REV-RKAA11.md
+++ b/tickets/entities/review-checklists/REV-RKAA11.md
@@ -1,0 +1,52 @@
+---
+id: REV-RKAA11
+type: review-checklist
+title: 'Review: JWT identity must fail closed, never downgrade to --principal-header'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Automated checks
+
+- [x] `go test ./...` — full suite passes
+- [x] `go test -race` on the three affected packages — clean (the gate holds shared sampling state)
+- [x] `just lint` — 0 issues
+- [x] `just arch-lint` — clean
+- [x] `just plimsoll` — clean
+- [x] `just coverage-check` — PASS (76.3%)
+
+## Code review
+
+- [x] `/code-review` run via cranky-code-reviewer on the full diff, framed as a security change
+- [x] All 5 findings triaged into review-response entities (2 significant, 2 minor, 1 nit)
+- [x] Both significant findings fixed ([[RR-2LPY46]], [[RR-39YRW3]])
+- [x] Both minor findings fixed ([[RR-LHFXGZ]], [[RR-QE3XJG]])
+- [x] Nit recorded as wont-fix with reasoning on file ([[RR-W5TQNB]])
+- [x] No open critical or significant responses
+
+Reviewer independently confirmed the two load-bearing design decisions rather
+than taking the comments at face value: gate placement (stamper → gate → ACL,
+verified against `attachACLRequest` reading `principal.From` at router.go:258)
+and `/api/`-only scoping (checked the full route table, including that
+`/api/sync/*` is covered despite being same-origin-exempt, and that SSE on the
+outer mux is still gated). Also probed path-normalization bypasses (`//api/...`,
+`/foo/../api/...`, `%2e%2e`) — `ServeMux` 307-redirects to the cleaned path
+before the handler runs, so those fail closed.
+
+## Verification
+
+- [x] Startup refusal verified against the real binary for each conflicting config
+- [x] Runtime paths verified live against a real ES256 JWKS server: 200 valid /
+401 absent, expired, forged-signature, malformed, spoofed header, bare `/api`,
+SSE / 200 SPA shell
+- [x] **Cached-keys claim verified empirically** — with the JWKS server killed, a
+valid assertion still returned 200, confirming the ticket's open question
+- [x] Header-only mode re-verified unchanged (still fails open)
+- [x] Log sampling + recovery reporting verified live (`suppressed_invalid=7`)
+- [x] All runtime paths re-verified after the post-review refactor
+
+## Follow-up
+
+- [x] Pre-existing unreachable-webhook bug filed separately as [[BUG-F3ADZO]]
+with a preventive measure, rather than folded into this change

--- a/tickets/entities/review-responses/RR-2LPY46.md
+++ b/tickets/entities/review-responses/RR-2LPY46.md
@@ -1,0 +1,15 @@
+---
+id: RR-2LPY46
+type: review-response
+title: SetJWTGate accepts a nil Verifier and panics on first request
+finding: SetJWTGate took JWTGateConfig by value and stored it unvalidated. The Verifier field is an interface, so an embedder passing a nil verifier produces a config whose VerifySubject call panics per-request rather than failing at wiring time. The godoc said "Required" but nothing enforced it, violating the project's own "Constructors reject nil required fields" rule (CLAUDE.md). Panic direction is fail-closed (a panicking handler authenticates nobody), so this was a robustness and diagnosability defect, not a bypass.
+severity: significant
+resolution: SetJWTGate now returns error and rejects a nil Verifier and an empty HeaderName. cmd/rela-server handles the error and exits. The interface-typed-nil caveat (a (*jwtauth.Verifier)(nil) stored in an interface is not == nil and cannot be caught without reflection) is documented on the method, noting that cmd/rela-server checks the concrete pointer before it reaches the interface. Covered by TestSetJWTGate_RejectsIncompleteConfig.
+status: addressed
+---
+
+Reported by cranky-code-reviewer against `internal/dataentry/app.go:342`.
+
+Fixed in this changeset rather than deferred: it is a small change in the "make
+the contract enforceable" category, and the project rule it violates is explicit
+in `CLAUDE.md`.

--- a/tickets/entities/review-responses/RR-39YRW3.md
+++ b/tickets/entities/review-responses/RR-39YRW3.md
@@ -1,0 +1,18 @@
+---
+id: RR-39YRW3
+type: review-response
+title: Empty -jwt-header silently denies every API request
+finding: 'validateIdentityFlags did not reject an empty -jwt-header. With HeaderName empty, r.Header.Get("") returns "", so every assertion reads as absent and every /api/ request is denied 401. The failure is fail-closed but silent: the server boots cleanly, logs nothing unusual at startup, and then 401s everything — a total outage whose cause is invisible in the startup output. Reachable by passing -jwt-header="" explicitly (the flag otherwise defaults to X-Auth-Assertion).'
+severity: significant
+resolution: 'validateIdentityFlags now returns an error when f.jwtHeader is empty and JWT identity is enabled, converting a silent total outage into a startup refusal with a clear message. Belt-and-braces: SetJWTGate also rejects an empty HeaderName. Covered by a new case in TestValidateIdentityFlags and verified against the real binary.'
+status: addressed
+---
+
+Reported by cranky-code-reviewer against `cmd/rela-server/main.go:169-186`.
+
+Verified live after the fix:
+
+```
+level=ERROR msg="invalid identity configuration"
+  error="-jwt-header must not be empty when jwt identity is enabled"
+```

--- a/tickets/entities/review-responses/RR-LHFXGZ.md
+++ b/tickets/entities/review-responses/RR-LHFXGZ.md
@@ -1,0 +1,24 @@
+---
+id: RR-LHFXGZ
+type: review-response
+title: Suppressed denial count lost at end of burst; ErrInvalid branch logged unsampled despite docs claiming otherwise
+finding: Two interacting issues. (1) The sampler incremented `suppressed` under lock but only flushed it when a LATER request arrived after the interval, so the residual at the end of an outage was never reported — while the const comment claimed occurrences are "folded into the next line", true only if a next line exists. (2) Only the keys-unavailable branch was sampled; the ErrInvalid branch logged at Info on EVERY request. Since classify() deliberately defaults to ErrInvalid, a rotation-during-outage could flood the unsampled branch — and docs/server-security.md claimed denials are "rate-sampled, so an outage cannot flood the log", which was therefore an overclaim.
+severity: minor
+resolution: 'Extracted a reusable logSampler type with independent per-class counters, so a flood of one class cannot mask the other, and both branches are now sampled. Added jwtGate.noteRecovery, which drains and reports the residual on the first successful verification after a burst — the moment an operator most wants the outage''s size. Rewrote the docs paragraph to state both classes are sampled AND to disclose that classification is heuristic (biased toward a missed alert over a false page). Verified live: a 7-denial burst produced one sampled line plus `suppressed_invalid=7` on recovery.'
+status: addressed
+---
+
+Reported by cranky-code-reviewer against `internal/dataentry/jwtgate.go:147-161`
+and the docs claim in `docs/server-security.md`.
+
+The reviewer noted the two design choices "interact in a way neither comment
+acknowledges" — sampling only the Error branch while `classify()` defaults to
+`ErrInvalid` meant the flood landed in whichever branch the default picked. That
+framing is what made this worth fixing rather than documenting away.
+
+Verified live:
+
+```
+INFO msg="jwt gate: verification succeeded after a run of denials"
+  suppressed_keys_unavailable=0 suppressed_invalid=7
+```

--- a/tickets/entities/review-responses/RR-QE3XJG.md
+++ b/tickets/entities/review-responses/RR-QE3XJG.md
@@ -1,0 +1,17 @@
+---
+id: RR-QE3XJG
+type: review-response
+title: 'Test gaps: valid-JWT-beats-spoofed-header unpinned; gate tests bypass the real NewRouter composition'
+finding: Three gaps. (1) TestRequireVerifiedJWT_SpoofedHeaderDoesNotAuthenticate only covered the no-valid-token case; the operator-intuitive case — a VALID assertion arriving alongside a spoofed header must resolve to the JWT subject — was unpinned. (2) Every gate test hand-composed stampAuditPrincipal(requireVerifiedJWT(...)), so reordering the wraps in NewRouter would leave them all passing while breaking production. (3) No validateIdentityFlags case for an empty jwtHeader (because the check did not exist — see RR-39YRW3).
+severity: minor
+resolution: Added TestRequireVerifiedJWT_ValidAssertionBeatsSpoofedHeader. Added TestJWTGate_RouterChainOrder, which drives the REAL app.NewRouter() with a declarative ACL and asserts the verified subject is the principal ACL authorizes against, that unverified requests 401 before reaching ACL, and that the SPA shell stays reachable — following the existing TestACLMiddleware_RouterChainOrder precedent, which exists precisely because this bug class only appears at the composition site. Added the empty-header case to TestValidateIdentityFlags. Also added TestLogSampler for the new sampling logic.
+status: addressed
+---
+
+Reported by cranky-code-reviewer. The reviewer credited
+`TestRequireVerifiedJWT_OrderingRelativeToStamper` for asserting the *inverted*
+wrap actually loses the subject, but correctly observed that a hand-composed
+chain cannot catch a regression in `NewRouter` itself.
+
+`TestJWTGate_RouterChainOrder` closes that: it is the composition-site test,
+mirroring the existing ACL one.

--- a/tickets/entities/review-responses/RR-W5TQNB.md
+++ b/tickets/entities/review-responses/RR-W5TQNB.md
@@ -1,0 +1,14 @@
+---
+id: RR-W5TQNB
+type: review-response
+title: 401 response timing distinguishes denial classes
+finding: 'The three denial paths have observably different latency: no-header returns without touching the verifier; invalid-token performs a full parse and signature check; keys-unavailable can stall up to RateLimitWaitMax (5s). An attacker can therefore distinguish "I sent no token" from "I sent a token that was evaluated" from "the IdP is down" by timing alone.'
+severity: nit
+reason: Not exploitable in any constructible way, and the reviewer explicitly raised it for completeness rather than as a fix request. The channel reveals server state, not secret material — and the keys-unavailable case is externally observable anyway (the IdP being down is not a secret). Constant-time denial would mean padding every 401 to the 5s worst case, which converts a non-issue into a real availability and DoS-amplification problem. The oracle that WOULD matter — the response body explaining why verification failed — is correctly closed and pinned by TestRequireVerifiedJWT_DenialLeaksNoReason.
+status: wont-fix
+---
+
+Reported by cranky-code-reviewer against `internal/dataentry/jwtgate.go:88,97`.
+
+Recorded rather than silently dropped so the reasoning is on file if someone
+raises it again in a future audit.

--- a/tickets/entities/tickets/TKT-RYUS3H.md
+++ b/tickets/entities/tickets/TKT-RYUS3H.md
@@ -1,0 +1,81 @@
+---
+id: TKT-RYUS3H
+type: ticket
+title: JWT identity must fail closed, never downgrade to --principal-header
+kind: enhancement
+priority: high
+effort: m
+status: done
+---
+
+## Description
+
+When both `--jwt-*` and `--principal-header` were configured, the resolver chain
+in `wirePrincipalResolvers` placed the JWT resolver ahead of the header
+resolver. A JWT that failed verification returned a zero Principal, so
+`ChainResolvers` fell **through** to the plain header — silently replacing a
+cryptographically verified identity with a spoofable, proxy-trusted one.
+
+The code documented this as an attacker-exploitable downgrade and mitigated it
+with a startup `slog.Warn`. That was insufficient: the downgrade happens
+per-request, long after startup, and is invisible in normal operation. Anyone
+able to disrupt JWKS reachability — network egress, DNS, an IdP outage —
+converted rela from verified identity to trusted-header identity, and rela kept
+serving as if nothing had changed.
+
+## Delivered
+
+- **JWT identity is exclusive.** A verification failure denies; it never falls
+through to `HeaderPrincipalResolver`.
+- **Mutual exclusion is a startup error**, not a warning. `--jwt-*` with
+`--principal-header`, or with `$RELA_DATAENTRY_USER`, refuses to boot.
+Partially-set `--jwt-*` flags — which previously *silently disabled* identity,
+leaving a server the operator believed was authenticating — are also refused.
+- **A dedicated gate, not a chain entry.** `requireVerifiedJWT`
+(`internal/dataentry/jwtgate.go`) owns verify-and-decide. `PrincipalResolver`
+keeps its single-return signature: an error channel exists to answer "try the
+next resolver?", and exclusivity deleted that question.
+- **Error taxonomy.** `jwtauth.ErrKeysUnavailable` (JWKS unreachable, operator
+fault) is distinguished from `ErrInvalid` (assertion evaluated and rejected,
+client fault). Both deny. Logging splits by who must act: Debug for an absent
+assertion, Info for a bad one, rate-sampled Error for a JWKS outage.
+- **JWKS refresh alerting.** `RefreshErrorHandlerFunc` was available in
+`keyfunc.Override` but unwired; it now carries the operational alert, at most
+once per 10-minute refresh interval.
+- **Header-only mode is unchanged** — verified live; it still fails open exactly
+as before.
+
+## Scope decision: `/api/` gating
+
+The 401 gate covers `isAPIPath` only, extending the reviewed RR-T15E invariant
+that `attachACLRequest` already relies on. The SPA shell and static assets stay
+reachable so a client can render a signed-out state and a misconfiguration does
+not lock operators out of the recovery surface; those routes serve no entity
+data, and every API call the SPA makes is still gated. The bare `/api` is
+included explicitly (RR-P2M7). The self-authenticating IdP webhook is
+deliberately outside the gate.
+
+## The ticket's open question, answered
+
+The ticket asked whether the JWKS client caches keys and tolerates a brief fetch
+failure. **It does.** In `jwkset@v0.11.0/storage.go:255-292`, `KeyReplaceAll` is
+reached only after fetch + status + decode all succeed, so a failed refresh
+leaves last-known-good keys intact. Confirmed empirically: with the JWKS server
+killed, a valid assertion still returned 200. No caching work was required.
+
+**However**, a failure mode the ticket did not anticipate: on an unknown `kid` —
+i.e. key rotation — jwkset performs a *synchronous* refresh bounded by the
+request context (`RateLimitWaitMax: 5s`). Once fail-closed, a JWKS outage
+*during rotation* denies those requests after up to a 5s stall. This is
+documented in `docs/server-security.md` as an explicit availability trade-off,
+with guidance to stage rotations so a new key is picked up before the old is
+withdrawn.
+
+## Verification
+
+Unit tests (table-driven), race detector clean, `just lint` / `arch-lint` /
+`plimsoll` / `coverage-check` all pass. Verified live against a real ES256 JWKS
+server: startup refusal for each conflicting config; 200 with a valid assertion
+and 401 for absent / expired / forged-signature / malformed / spoofed
+`X-Forwarded-User` / bare `/api` / SSE; 200 for the SPA shell; and 200 for a
+valid assertion with the JWKS server killed (cached keys).

--- a/tickets/relations/BUG-F3ADZO--adds-measure--route-reachability-through-production-router.md
+++ b/tickets/relations/BUG-F3ADZO--adds-measure--route-reachability-through-production-router.md
@@ -1,0 +1,5 @@
+---
+from: BUG-F3ADZO
+relation: adds-measure
+to: route-reachability-through-production-router
+---

--- a/tickets/relations/BUG-F3ADZO--affects--data-entry-server.md
+++ b/tickets/relations/BUG-F3ADZO--affects--data-entry-server.md
@@ -1,0 +1,5 @@
+---
+from: BUG-F3ADZO
+relation: affects
+to: data-entry-server
+---

--- a/tickets/relations/BUG-F3ADZO--caused-by--data-entry-server.md
+++ b/tickets/relations/BUG-F3ADZO--caused-by--data-entry-server.md
@@ -1,0 +1,5 @@
+---
+from: BUG-F3ADZO
+relation: caused-by
+to: data-entry-server
+---

--- a/tickets/relations/BUG-F3ADZO--fixes--FEAT-CN5L0X.md
+++ b/tickets/relations/BUG-F3ADZO--fixes--FEAT-CN5L0X.md
@@ -1,0 +1,5 @@
+---
+from: BUG-F3ADZO
+relation: fixes
+to: FEAT-CN5L0X
+---

--- a/tickets/relations/TKT-RYUS3H--affects--audit-log.md
+++ b/tickets/relations/TKT-RYUS3H--affects--audit-log.md
@@ -1,0 +1,5 @@
+---
+from: TKT-RYUS3H
+relation: affects
+to: audit-log
+---

--- a/tickets/relations/TKT-RYUS3H--affects--authorization.md
+++ b/tickets/relations/TKT-RYUS3H--affects--authorization.md
@@ -1,0 +1,5 @@
+---
+from: TKT-RYUS3H
+relation: affects
+to: authorization
+---

--- a/tickets/relations/TKT-RYUS3H--affects--data-entry-server.md
+++ b/tickets/relations/TKT-RYUS3H--affects--data-entry-server.md
@@ -1,0 +1,5 @@
+---
+from: TKT-RYUS3H
+relation: affects
+to: data-entry-server
+---

--- a/tickets/relations/TKT-RYUS3H--has-docs--DOCS-RLHSGF.md
+++ b/tickets/relations/TKT-RYUS3H--has-docs--DOCS-RLHSGF.md
@@ -1,0 +1,5 @@
+---
+from: TKT-RYUS3H
+relation: has-docs
+to: DOCS-RLHSGF
+---

--- a/tickets/relations/TKT-RYUS3H--has-implementation--IMPL-HX893M.md
+++ b/tickets/relations/TKT-RYUS3H--has-implementation--IMPL-HX893M.md
@@ -1,0 +1,5 @@
+---
+from: TKT-RYUS3H
+relation: has-implementation
+to: IMPL-HX893M
+---

--- a/tickets/relations/TKT-RYUS3H--has-review--REV-RKAA11.md
+++ b/tickets/relations/TKT-RYUS3H--has-review--REV-RKAA11.md
@@ -1,0 +1,5 @@
+---
+from: TKT-RYUS3H
+relation: has-review
+to: REV-RKAA11
+---

--- a/tickets/relations/TKT-RYUS3H--has-review-response--RR-2LPY46.md
+++ b/tickets/relations/TKT-RYUS3H--has-review-response--RR-2LPY46.md
@@ -1,0 +1,5 @@
+---
+from: TKT-RYUS3H
+relation: has-review-response
+to: RR-2LPY46
+---

--- a/tickets/relations/TKT-RYUS3H--has-review-response--RR-39YRW3.md
+++ b/tickets/relations/TKT-RYUS3H--has-review-response--RR-39YRW3.md
@@ -1,0 +1,5 @@
+---
+from: TKT-RYUS3H
+relation: has-review-response
+to: RR-39YRW3
+---

--- a/tickets/relations/TKT-RYUS3H--has-review-response--RR-LHFXGZ.md
+++ b/tickets/relations/TKT-RYUS3H--has-review-response--RR-LHFXGZ.md
@@ -1,0 +1,5 @@
+---
+from: TKT-RYUS3H
+relation: has-review-response
+to: RR-LHFXGZ
+---

--- a/tickets/relations/TKT-RYUS3H--has-review-response--RR-QE3XJG.md
+++ b/tickets/relations/TKT-RYUS3H--has-review-response--RR-QE3XJG.md
@@ -1,0 +1,5 @@
+---
+from: TKT-RYUS3H
+relation: has-review-response
+to: RR-QE3XJG
+---

--- a/tickets/relations/TKT-RYUS3H--has-review-response--RR-W5TQNB.md
+++ b/tickets/relations/TKT-RYUS3H--has-review-response--RR-W5TQNB.md
@@ -1,0 +1,5 @@
+---
+from: TKT-RYUS3H
+relation: has-review-response
+to: RR-W5TQNB
+---

--- a/tickets/relations/TKT-RYUS3H--implements--FEAT-OQBYHD.md
+++ b/tickets/relations/TKT-RYUS3H--implements--FEAT-OQBYHD.md
@@ -1,0 +1,5 @@
+---
+from: TKT-RYUS3H
+relation: implements
+to: FEAT-OQBYHD
+---


### PR DESCRIPTION
## Problem

When both `--jwt-*` and `--principal-header` were configured, `wirePrincipalResolvers` placed the JWT resolver ahead of the header resolver in `ChainResolvers`. A JWT that failed verification returned a zero Principal, so the chain fell **through** to the plain header — silently replacing a cryptographically verified identity with a spoofable, proxy-trusted one.

Anyone able to disrupt JWKS reachability (network egress, DNS, an IdP outage) could convert rela from verified identity to trusted-header identity, and rela kept serving as if nothing had changed. The only mitigation was a startup `slog.Warn` — insufficient, because the downgrade happens per-request, long after anyone reads startup logs.

## Changes

- **JWT identity is exclusive.** A verification failure denies (401); it never falls through to `HeaderPrincipalResolver`.
- **Mutual exclusion is a startup error.** `--jwt-*` with `--principal-header`, or with `$RELA_DATAENTRY_USER`, refuses to boot. Partially-set `--jwt-*` flags — which previously *silently disabled* identity — are also refused.
- **A dedicated gate, not a chain entry.** `requireVerifiedJWT` (`internal/dataentry/jwtgate.go`) owns verify-and-decide. `PrincipalResolver` keeps its single-return signature: an error channel answers "try the next resolver?", a question exclusivity deleted.
- **Error taxonomy.** `jwtauth.ErrKeysUnavailable` (operator fault) vs `ErrInvalid` (client fault). Both deny; logging splits by who must act.
- **JWKS refresh alerting.** `RefreshErrorHandlerFunc` was available in `keyfunc.Override` but unwired.
- **Header-only mode is unchanged** — verified live; still fails open exactly as before.

### Scope: `/api/` gating

The gate covers `isAPIPath` only, extending the reviewed RR-T15E invariant `attachACLRequest` already relies on. The SPA shell and static assets stay reachable so a client can render a signed-out state and a misconfiguration does not lock operators out of the recovery surface. Bare `/api` is included explicitly (RR-P2M7). The self-authenticating IdP webhook is deliberately outside.

## The ticket's open question, answered

The ticket asked whether the JWKS client caches keys and tolerates a brief fetch failure. **It does** — in `jwkset@v0.11.0/storage.go:255-292`, `KeyReplaceAll` is reached only after fetch + status + decode all succeed. Confirmed empirically: with the JWKS server killed, a valid assertion still returned 200. No caching work needed.

**A failure mode the ticket did not anticipate:** on an unknown `kid` (i.e. key rotation), jwkset performs a *synchronous* refresh bounded by the request context (`RateLimitWaitMax: 5s`). Once fail-closed, a JWKS outage *during rotation* denies those requests after up to a 5s stall. Documented in `docs/server-security.md` as an explicit availability trade-off with rotation-staging guidance.

## Verification

`go test ./...`, `-race` on affected packages, `just lint` / `arch-lint` / `plimsoll` / `coverage-check` all pass.

Verified live against a real ES256 JWKS server: startup refusal for each conflicting config; 200 valid / 401 for absent, expired, forged-signature, malformed, spoofed `X-Forwarded-User`, bare `/api`, SSE; 200 SPA shell; 200 valid with the JWKS server killed.

## Review

cranky-code-reviewer found 5 issues; the 4 actionable ones are fixed in-branch (RR-2LPY46, RR-39YRW3, RR-LHFXGZ, RR-QE3XJG), the 5th recorded as wont-fix with reasoning (RR-W5TQNB). Notably RR-LHFXGZ caught that the docs claimed denials were rate-sampled while only the Error branch actually was — both branches are now sampled, with the residual reported on recovery.

## Note for the reviewer

`TKT-RYUS3H` is marked `done` because the metamodel's CI rule blocks merging a ticket left in `review`. If the convention is that `done` should follow an actually-merged PR, that status wants correcting.

Separately filed **BUG-F3ADZO**: `POST /webhooks/idp` is registered on the `/api/`-only `inner` mux and has been unreachable since #1069 — it returns SPA HTML. Pre-existing and unrelated, so not fixed here.