### PR TITLE
feat(acl): grant roles from verified identity assertions (TKT-RP3X3Q)

### DIFF
--- a/cmd/rela-server/main.go
+++ b/cmd/rela-server/main.go
@@ -205,7 +205,29 @@ func buildJWTResolver(idv *jwtauth.Verifier, f *serverFlags) (resolver dataentry
 	if idv == nil {
 		return dataentry.JWTPrincipalResolver(nil, ""), ""
 	}
-	return dataentry.JWTPrincipalResolver(idv, f.jwtHeader), f.jwtHeader
+	return dataentry.JWTPrincipalResolver(assertionVerifierAdapter{idv}, f.jwtHeader), f.jwtHeader
+}
+
+// assertionVerifierAdapter bridges the concrete jwtauth.Verifier to the
+// dataentry resolver's expected shape, translating jwtauth.AssertionClaims into
+// dataentry.AssertedIdentity. Same rationale as webhookVerifierAdapter below:
+// the wiring layer is the one place allowed to import both packages, so
+// dataentry needn't depend on jwtauth and jwtauth stays an arch-lint leaf.
+type assertionVerifierAdapter struct{ v *jwtauth.Verifier }
+
+func (a assertionVerifierAdapter) VerifyAssertion(
+	ctx context.Context, raw string,
+) (dataentry.AssertedIdentity, error) {
+	c, err := a.v.VerifyAssertion(ctx, raw)
+	if err != nil {
+		return dataentry.AssertedIdentity{}, err
+	}
+	return dataentry.AssertedIdentity{
+		Subject: c.Subject,
+		OrgID:   c.OrgID,
+		OrgSlug: c.OrgSlug,
+		Roles:   c.Roles,
+	}, nil
 }
 
 // wireWebhookReceiver enables POST /webhooks/idp when -webhook-audience and

--- a/docs-project/entities/guides/GUIDE-acl-overview.md
+++ b/docs-project/entities/guides/GUIDE-acl-overview.md
@@ -222,6 +222,65 @@ authenticated and what it resolved to without a graph round-trip.
 For large user-entity sets, push the property equality into a backend
 index — see GUIDE-acl-security.
 
+## Roles from a verified identity assertion
+
+When rela runs behind an OIDC identity proxy that signs an identity
+assertion (see GUIDE-server-security for the `--jwt-*` flags), the
+assertion's `roles` claim can grant policy roles directly — so an
+operator maintains group membership in the IdP rather than restating it
+per-user in `assignments`.
+
+```yaml
+asserted_role_assignments:
+  admin: editor                # a claim value → one role
+  compliance: [editor, auditor] # …or several
+```
+
+A claim value never names a rela role directly: it selects an entry the
+operator wrote here. An IdP therefore cannot grant a role the deployment
+did not choose to expose, however its own role names change.
+
+Rules and fallbacks:
+
+- **Verified assertions only.** Roles are populated exclusively by the
+  JWT resolver, after signature verification. The `--principal-header`
+  path and direct-loopback requests never carry roles, and no header is
+  read as a role source. This is enforced by the type system, not by
+  convention — see the `internal/principal` package doc.
+- **Absent key ⇒ no-op.** A policy without `asserted_role_assignments`
+  behaves byte-for-byte as before.
+- **No match** grants nothing; an unmapped claim is simply ignored.
+- **Undeclared target role** is dropped silently at resolution, matching
+  how `assignments` treats an unknown role name.
+- **Exact matching after trimming.** Surrounding whitespace is stripped
+  from both the policy key and the incoming claim, so a padded key like
+  `"  admin  "` still matches the claim `admin`. Matching is otherwise
+  exact — `Admin` does not match `admin`. A key that is blank after
+  trimming is rejected at load, since it could never match and would
+  sit inert.
+- **`everyone` is rejected as a target** — it already applies to every
+  principal, so granting it from a claim would double-report the role
+  with no effect.
+- **Multiple claims accumulate.** A principal holding `["admin",
+  "compliance"]` gets the union of both mappings, deduplicated.
+- **No user entity required.** A verified principal whose subject
+  resolves to no `user_entity_type` entity still receives its asserted
+  roles — this is an SSO-provisioned user's first request. It does not
+  receive anything keyed on a graph entity (local roles, ancestry).
+
+Asserted roles are attributed with source kind `asserted`, carrying the
+claim that granted them, so `rela acl who-can` and the audit log
+distinguish "granted by our policy" from "granted by a claim in a token".
+
+`rela acl who-can` reports these in a **separate** section from the
+`everyone` grant, and deliberately does not enumerate holders: whoever
+presents the claim gets the role, and that population lives in the IdP,
+not the graph. Listing them as principals — or folding them into the
+`everyone` line — would tell an operator the grant reaches everybody.
+
+The assertion's `org_id` / `org_slug` are recorded on the principal for
+audit attribution. **Nothing evaluates them** — see GUIDE-acl-security.
+
 Given the graph:
 
 ```text

--- a/docs-project/entities/guides/GUIDE-acl-security.md
+++ b/docs-project/entities/guides/GUIDE-acl-security.md
@@ -194,6 +194,69 @@ index.
   fail-closed. Don't assume one `acl.yaml` grants the same authority on
   every transport.
 
+## Roles from a verified assertion (`asserted_role_assignments`)
+
+`asserted_role_assignments` maps a `roles` claim from a signed identity
+assertion to a policy role (see GUIDE-acl-overview for the mechanics).
+Three properties are load-bearing.
+
+**The trust boundary is the signature, and it is enforced structurally.**
+`internal/acl` verifies nothing — it trusts the `Principal` absolutely.
+A role reaching it from an unverified source would therefore be a
+complete authorization bypass, not a degradation. The assertion claims
+live in *unexported* fields on `principal.Principal`, populated only by
+`principal.Verified`, which only the JWT resolver calls after signature
+verification. No composite literal anywhere in the tree can forge a
+role; the compiler enforces this rather than a reviewer remembering to.
+
+Consequence for operators: **never introduce a header that is trusted as
+a role source.** Trusting `X-Asserted-Roles` the way `X-Forwarded-User`
+is trusted under `--principal-header` would hand role selection to
+anyone who can reach the server. The header path deliberately cannot
+carry roles at all.
+
+**The claim → role indirection is the second control.** A claim value
+never becomes a role name; it only ever selects an entry the operator
+authored. An attacker who influences role names in the IdP still cannot
+name a rela role the operator has not mapped. Keep the mapping minimal
+and review it like any other grant — `rela acl audit` flags a claim that
+maps to a privileged role.
+
+**Revocation lags by one assertion lifetime.** rela re-checks nothing
+between requests: an assertion stays valid until its `exp`, so a role
+revoked in the IdP keeps working in rela until the token expires. With
+Pratique that window is **up to 9 minutes** (`AssertionTTL`). rela has
+no revocation channel — there is nothing to "push" a revocation to. If
+your incident response depends on cutting access faster than the token
+lifetime, you must restart or otherwise intervene at the proxy; do not
+assume revoking in the IdP takes effect immediately downstream.
+
+### `org_id` is recorded, not enforced
+
+A verified assertion's `org_id` / `org_slug` are stamped on the
+principal and appear in the audit log. **Nothing in `internal/acl`
+evaluates them.**
+
+Read that literally before designing around it: a principal in org A
+holding a role sees **every entity that role grants, in every org**.
+There is no tenant isolation. The org in your audit log records which
+tenant a request *came from*; it does not constrain what that request
+could reach.
+
+This is a deliberate scope decision, not an oversight — ACL evaluation
+is additive (any role granting the verb allows it, and no rule can
+subtract), so a cross-cutting "deny unless org matches" needs its own
+design rather than a field check bolted onto the resolver. A test
+(`TestAssertedRoles_OrgIsNotEvaluated`) pins the absence of enforcement
+so it cannot be mistaken for an omission, and fails the day a partial
+org check is added.
+
+If you need per-tenant separation today, model it in the graph:
+containment edges plus `inherit_roles_through` scope roles to a subtree
+positively, and read-filtering follows for free. That works only if no
+role grants a broad wildcard read — a global `read: ["*"]` defeats any
+org scoping, in this design or any other.
+
 ## Fail-loud on malformed `acl.yaml`
 
 A malformed `acl.yaml` fails boot. This is intentional: silently

--- a/docs-project/entities/guides/GUIDE-audit-log.md
+++ b/docs-project/entities/guides/GUIDE-audit-log.md
@@ -56,6 +56,9 @@ Every record is one line of JSON:
 | `before` / `after` | For `rename-entity` only — the identity diff                   |
 | `principal.user` | The OS user (from `$USER`) that initiated the operation           |
 | `principal.tool` | `cli`, `mcp`, `data-entry`, `scheduler`, or `desktop`             |
+| `principal.raw_user` | Optional. The pre-resolution identifier, when `principal_property` substituted a graph entity ID into `user` |
+| `principal.org_id` / `principal.org_slug` | Optional. The tenant from a verified identity assertion. **Attribution only — see the warning below** |
+| `principal.roles` | Optional. The `roles` claim from a verified identity assertion |
 | `triggered_by` | Optional. Engine-initiated writes carry `automation:<name>`, `schedule:<task-name>`, or `cascade:delete-entity:<id>` |
 | `summary`     | One-line human-readable summary; for updates names *which* properties changed but never their values (secret-leak defense) |
 
@@ -132,6 +135,34 @@ behind a reverse proxy that *strips the same header from inbound
 requests* and *sets it from an authenticated source*. A direct
 client can otherwise spoof the header at will. See
 [`docs/server-security.md`](server-security.md) for deployment guidance.
+
+### Verified-assertion fields (`org_id`, `org_slug`, `roles`)
+
+When rela verifies a signed identity assertion (the `--jwt-*` flags),
+the record additionally carries the assertion's tenant and role claims:
+
+```json
+{
+  "principal": {
+    "user": "usr_abc123", "tool": "data-entry",
+    "org_id": "org_acme", "org_slug": "acme", "roles": ["admin"]
+  }
+}
+```
+
+All three are omitted entirely for every other entry point, so records
+from a CLI, MCP, or header-mode deployment are byte-identical to what
+earlier versions wrote.
+
+> **`org_id` in this log does NOT mean rela enforced tenant isolation.**
+> Nothing in the ACL evaluates it — a principal in one org can reach
+> every entity its roles grant, in every org. The field records which
+> tenant a request came from, not what it was allowed to touch. See
+> GUIDE-acl-security for the full rationale.
+
+`roles` records the IdP's role names as asserted, before any policy
+mapping — so an investigator can see what the token claimed, separately
+from what `acl.yaml` chose to grant it.
 
 Header values are trimmed, length-capped at 256 runes, and have
 control characters replaced with a space — defense-in-depth against

--- a/docs-project/entities/guides/GUIDE-server-security.md
+++ b/docs-project/entities/guides/GUIDE-server-security.md
@@ -227,6 +227,28 @@ attribution and any `acl.yaml` assignments survive an email change.
 The verification rejects non-ES256 algorithms (including `alg:none`),
 a wrong issuer or audience, and expired or unsigned tokens.
 
+**Other claims.** Beyond `sub`, rela projects `org_id`, `org_slug`, and
+`roles` from the verified assertion onto the principal. All are optional
+— an assertion carrying only a subject is perfectly valid, so a proxy
+that models neither orgs nor roles works unchanged.
+
+- **`roles`** (array of strings) can grant `acl.yaml` roles via
+  `asserted_role_assignments`, letting you maintain group membership in
+  the IdP instead of restating it per-user. See
+  GUIDE-acl-overview.
+- **`org_id` / `org_slug`** are recorded for audit attribution.
+  **Nothing evaluates them** — they do not provide tenant isolation.
+  See GUIDE-acl-security.
+
+Claims are read only from a token that passed every verification step,
+and only this resolver can populate them — the `--principal-header` path
+carries no roles by construction. `roles` is bounded (32 entries, 256
+runes each) so a malformed or hostile IdP cannot amplify one request.
+
+Note that revocation lags: an issued assertion is honored until its
+`exp`, so a role revoked in the IdP survives in rela for up to one token
+lifetime. See GUIDE-acl-security.
+
 **Chain order.** When several sources are configured, `$RELA_DATAENTRY_USER`
 (local-dev override) wins, then the verified JWT, then the plain
 `--principal-header`, then `unknown`. A verified JWT is preferred over

--- a/docs/acl-overview.md
+++ b/docs/acl-overview.md
@@ -216,6 +216,62 @@ authenticated and what it resolved to without a graph round-trip.
 For large user-entity sets, push the property equality into a backend
 index — see GUIDE-acl-security.
 
+## Roles from a verified identity assertion
+
+When rela runs behind an OIDC identity proxy that signs an identity
+assertion (see GUIDE-server-security for the `--jwt-*` flags), the
+assertion's `roles` claim can grant policy roles directly — so an
+operator maintains group membership in the IdP rather than restating it
+per-user in `assignments`.
+
+```yaml
+asserted_role_assignments:
+  admin: editor                # a claim value → one role
+  compliance: [editor, auditor] # …or several
+```
+
+A claim value never names a rela role directly: it selects an entry the
+operator wrote here. An IdP therefore cannot grant a role the deployment
+did not choose to expose, however its own role names change.
+
+Rules and fallbacks:
+
+- **Verified assertions only.** Roles are populated exclusively by the
+  JWT resolver, after signature verification. The `--principal-header`
+  path and direct-loopback requests never carry roles, and no header is
+  read as a role source. This is enforced by the type system, not by
+  convention — see the `internal/principal` package doc.
+- **Absent key ⇒ no-op.** A policy without `asserted_role_assignments`
+  behaves byte-for-byte as before.
+- **No match** grants nothing; an unmapped claim is simply ignored.
+- **Undeclared target role** is dropped silently at resolution, matching
+  how `assignments` treats an unknown role name.
+- **Exact matching after trimming.** `admin` and `  admin  ` match;
+  `Admin` does not. A blank claim key is rejected at load, since it
+  could never match and would sit inert.
+- **`everyone` is rejected as a target** — it already applies to every
+  principal, so granting it from a claim would double-report the role
+  with no effect.
+- **Multiple claims accumulate.** A principal holding `["admin",
+  "compliance"]` gets the union of both mappings, deduplicated.
+- **No user entity required.** A verified principal whose subject
+  resolves to no `user_entity_type` entity still receives its asserted
+  roles — this is an SSO-provisioned user's first request. It does not
+  receive anything keyed on a graph entity (local roles, ancestry).
+
+Asserted roles are attributed with source kind `asserted`, carrying the
+claim that granted them, so `rela acl who-can` and the audit log
+distinguish "granted by our policy" from "granted by a claim in a token".
+
+`rela acl who-can` reports these in a **separate** section from the
+`everyone` grant, and deliberately does not enumerate holders: whoever
+presents the claim gets the role, and that population lives in the IdP,
+not the graph. Listing them as principals — or folding them into the
+`everyone` line — would tell an operator the grant reaches everybody.
+
+The assertion's `org_id` / `org_slug` are recorded on the principal for
+audit attribution. **Nothing evaluates them** — see GUIDE-acl-security.
+
 Given the graph:
 
 ```text

--- a/docs/acl-overview.md
+++ b/docs/acl-overview.md
@@ -246,9 +246,12 @@ Rules and fallbacks:
 - **No match** grants nothing; an unmapped claim is simply ignored.
 - **Undeclared target role** is dropped silently at resolution, matching
   how `assignments` treats an unknown role name.
-- **Exact matching after trimming.** `admin` and `  admin  ` match;
-  `Admin` does not. A blank claim key is rejected at load, since it
-  could never match and would sit inert.
+- **Exact matching after trimming.** Surrounding whitespace is stripped
+  from both the policy key and the incoming claim, so a padded key like
+  `"  admin  "` still matches the claim `admin`. Matching is otherwise
+  exact — `Admin` does not match `admin`. A key that is blank after
+  trimming is rejected at load, since it could never match and would
+  sit inert.
 - **`everyone` is rejected as a target** — it already applies to every
   principal, so granting it from a claim would double-report the role
   with no effect.

--- a/docs/acl-security.md
+++ b/docs/acl-security.md
@@ -188,6 +188,69 @@ index.
   fail-closed. Don't assume one `acl.yaml` grants the same authority on
   every transport.
 
+## Roles from a verified assertion (`asserted_role_assignments`)
+
+`asserted_role_assignments` maps a `roles` claim from a signed identity
+assertion to a policy role (see GUIDE-acl-overview for the mechanics).
+Three properties are load-bearing.
+
+**The trust boundary is the signature, and it is enforced structurally.**
+`internal/acl` verifies nothing — it trusts the `Principal` absolutely.
+A role reaching it from an unverified source would therefore be a
+complete authorization bypass, not a degradation. The assertion claims
+live in *unexported* fields on `principal.Principal`, populated only by
+`principal.Verified`, which only the JWT resolver calls after signature
+verification. No composite literal anywhere in the tree can forge a
+role; the compiler enforces this rather than a reviewer remembering to.
+
+Consequence for operators: **never introduce a header that is trusted as
+a role source.** Trusting `X-Asserted-Roles` the way `X-Forwarded-User`
+is trusted under `--principal-header` would hand role selection to
+anyone who can reach the server. The header path deliberately cannot
+carry roles at all.
+
+**The claim → role indirection is the second control.** A claim value
+never becomes a role name; it only ever selects an entry the operator
+authored. An attacker who influences role names in the IdP still cannot
+name a rela role the operator has not mapped. Keep the mapping minimal
+and review it like any other grant — `rela acl audit` flags a claim that
+maps to a privileged role.
+
+**Revocation lags by one assertion lifetime.** rela re-checks nothing
+between requests: an assertion stays valid until its `exp`, so a role
+revoked in the IdP keeps working in rela until the token expires. With
+Pratique that window is **up to 9 minutes** (`AssertionTTL`). rela has
+no revocation channel — there is nothing to "push" a revocation to. If
+your incident response depends on cutting access faster than the token
+lifetime, you must restart or otherwise intervene at the proxy; do not
+assume revoking in the IdP takes effect immediately downstream.
+
+### `org_id` is recorded, not enforced
+
+A verified assertion's `org_id` / `org_slug` are stamped on the
+principal and appear in the audit log. **Nothing in `internal/acl`
+evaluates them.**
+
+Read that literally before designing around it: a principal in org A
+holding a role sees **every entity that role grants, in every org**.
+There is no tenant isolation. The org in your audit log records which
+tenant a request *came from*; it does not constrain what that request
+could reach.
+
+This is a deliberate scope decision, not an oversight — ACL evaluation
+is additive (any role granting the verb allows it, and no rule can
+subtract), so a cross-cutting "deny unless org matches" needs its own
+design rather than a field check bolted onto the resolver. A test
+(`TestAssertedRoles_OrgIsNotEvaluated`) pins the absence of enforcement
+so it cannot be mistaken for an omission, and fails the day a partial
+org check is added.
+
+If you need per-tenant separation today, model it in the graph:
+containment edges plus `inherit_roles_through` scope roles to a subtree
+positively, and read-filtering follows for free. That works only if no
+role grants a broad wildcard read — a global `read: ["*"]` defeats any
+org scoping, in this design or any other.
+
 ## Fail-loud on malformed `acl.yaml`
 
 A malformed `acl.yaml` fails boot. This is intentional: silently

--- a/docs/audit-log.md
+++ b/docs/audit-log.md
@@ -152,7 +152,7 @@ earlier versions wrote.
 > Nothing in the ACL evaluates it — a principal in one org can reach
 > every entity its roles grant, in every org. The field records which
 > tenant a request came from, not what it was allowed to touch. See
-> [`docs/acl-security.md`](acl-security.md) for the full rationale.
+> GUIDE-acl-security for the full rationale.
 
 `roles` records the IdP's role names as asserted, before any policy
 mapping — so an investigator can see what the token claimed, separately

--- a/docs/audit-log.md
+++ b/docs/audit-log.md
@@ -50,6 +50,9 @@ Every record is one line of JSON:
 | `before` / `after` | For `rename-entity` only — the identity diff                   |
 | `principal.user` | The OS user (from `$USER`) that initiated the operation           |
 | `principal.tool` | `cli`, `mcp`, `data-entry`, `scheduler`, or `desktop`             |
+| `principal.raw_user` | Optional. The pre-resolution identifier, when `principal_property` substituted a graph entity ID into `user` |
+| `principal.org_id` / `principal.org_slug` | Optional. The tenant from a verified identity assertion. **Attribution only — see the warning below** |
+| `principal.roles` | Optional. The `roles` claim from a verified identity assertion |
 | `triggered_by` | Optional. Engine-initiated writes carry `automation:<name>`, `schedule:<task-name>`, or `cascade:delete-entity:<id>` |
 | `summary`     | One-line human-readable summary; for updates names *which* properties changed but never their values (secret-leak defense) |
 
@@ -126,6 +129,34 @@ behind a reverse proxy that *strips the same header from inbound
 requests* and *sets it from an authenticated source*. A direct
 client can otherwise spoof the header at will. See
 [`docs/server-security.md`](server-security.md) for deployment guidance.
+
+### Verified-assertion fields (`org_id`, `org_slug`, `roles`)
+
+When rela verifies a signed identity assertion (the `--jwt-*` flags),
+the record additionally carries the assertion's tenant and role claims:
+
+```json
+{
+  "principal": {
+    "user": "usr_abc123", "tool": "data-entry",
+    "org_id": "org_acme", "org_slug": "acme", "roles": ["admin"]
+  }
+}
+```
+
+All three are omitted entirely for every other entry point, so records
+from a CLI, MCP, or header-mode deployment are byte-identical to what
+earlier versions wrote.
+
+> **`org_id` in this log does NOT mean rela enforced tenant isolation.**
+> Nothing in the ACL evaluates it — a principal in one org can reach
+> every entity its roles grant, in every org. The field records which
+> tenant a request came from, not what it was allowed to touch. See
+> [`docs/acl-security.md`](acl-security.md) for the full rationale.
+
+`roles` records the IdP's role names as asserted, before any policy
+mapping — so an investigator can see what the token claimed, separately
+from what `acl.yaml` chose to grant it.
 
 Header values are trimmed, length-capped at 256 runes, and have
 control characters replaced with a space — defense-in-depth against

--- a/docs/server-security.md
+++ b/docs/server-security.md
@@ -221,6 +221,28 @@ attribution and any `acl.yaml` assignments survive an email change.
 The verification rejects non-ES256 algorithms (including `alg:none`),
 a wrong issuer or audience, and expired or unsigned tokens.
 
+**Other claims.** Beyond `sub`, rela projects `org_id`, `org_slug`, and
+`roles` from the verified assertion onto the principal. All are optional
+— an assertion carrying only a subject is perfectly valid, so a proxy
+that models neither orgs nor roles works unchanged.
+
+- **`roles`** (array of strings) can grant `acl.yaml` roles via
+  `asserted_role_assignments`, letting you maintain group membership in
+  the IdP instead of restating it per-user. See
+  [`docs/acl-overview.md`](acl-overview.md).
+- **`org_id` / `org_slug`** are recorded for audit attribution.
+  **Nothing evaluates them** — they do not provide tenant isolation.
+  See [`docs/acl-security.md`](acl-security.md).
+
+Claims are read only from a token that passed every verification step,
+and only this resolver can populate them — the `--principal-header` path
+carries no roles by construction. `roles` is bounded (32 entries, 256
+runes each) so a malformed or hostile IdP cannot amplify one request.
+
+Note that revocation lags: an issued assertion is honored until its
+`exp`, so a role revoked in the IdP survives in rela for up to one token
+lifetime. See [`docs/acl-security.md`](acl-security.md).
+
 **Chain order.** When several sources are configured, `$RELA_DATAENTRY_USER`
 (local-dev override) wins, then the verified JWT, then the plain
 `--principal-header`, then `unknown`. A verified JWT is preferred over

--- a/docs/server-security.md
+++ b/docs/server-security.md
@@ -229,10 +229,10 @@ that models neither orgs nor roles works unchanged.
 - **`roles`** (array of strings) can grant `acl.yaml` roles via
   `asserted_role_assignments`, letting you maintain group membership in
   the IdP instead of restating it per-user. See
-  [`docs/acl-overview.md`](acl-overview.md).
+  GUIDE-acl-overview.
 - **`org_id` / `org_slug`** are recorded for audit attribution.
   **Nothing evaluates them** — they do not provide tenant isolation.
-  See [`docs/acl-security.md`](acl-security.md).
+  See GUIDE-acl-security.
 
 Claims are read only from a token that passed every verification step,
 and only this resolver can populate them — the `--principal-header` path
@@ -241,7 +241,7 @@ runes each) so a malformed or hostile IdP cannot amplify one request.
 
 Note that revocation lags: an issued assertion is honored until its
 `exp`, so a role revoked in the IdP survives in rela for up to one token
-lifetime. See [`docs/acl-security.md`](acl-security.md).
+lifetime. See GUIDE-acl-security.
 
 **Chain order.** When several sources are configured, `$RELA_DATAENTRY_USER`
 (local-dev override) wins, then the verified JWT, then the plain

--- a/internal/acl/access.go
+++ b/internal/acl/access.go
@@ -3,6 +3,7 @@ package acl
 import (
 	"context"
 	"fmt"
+	"sort"
 )
 
 // Verb is a read-or-write access verb the who-can query asks about. It
@@ -77,6 +78,51 @@ func (d *Declarative) EveryoneGrants(verb Verb, entityType string) EveryoneGrant
 		return EveryoneGrant{}
 	}
 	return grantForRole(role, verb, entityType)
+}
+
+// AssertedGrant is one (claim → role) mapping that grants a verb, for reporting
+// grants whose holders are NOT enumerable from the graph: the population that
+// presents a given claim lives in the IdP.
+//
+// This is deliberately NOT folded into [EveryoneGrant]. An everyone grant
+// applies to every principal — reporting it globally is a true statement. An
+// asserted grant applies to an unknown subset, so reporting it the same way
+// would tell an operator that everyone holds the role.
+type AssertedGrant struct {
+	Claim    string
+	Role     string
+	Wildcard bool
+}
+
+// AssertedGrants reports every asserted_role_assignments mapping that grants
+// verb on entityType. Uses the same grantForRole helper as [EveryoneGrants] and
+// Request.AccessRoutes, so a reported grant can never disagree with an actual
+// authorization decision.
+//
+// Undeclared target roles are skipped, matching what the resolver does at
+// attribution time. Results are sorted by (claim, role) for a stable artifact.
+func (d *Declarative) AssertedGrants(verb Verb, entityType string) []AssertedGrant {
+	var out []AssertedGrant
+	for claim, roles := range d.policy.AssertedRoles {
+		for _, name := range roles {
+			role, declared := d.policy.Roles[name]
+			if !declared {
+				continue
+			}
+			if g := grantForRole(role, verb, entityType); g.Granted {
+				out = append(out, AssertedGrant{
+					Claim: claim, Role: name, Wildcard: g.Wildcard,
+				})
+			}
+		}
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Claim != out[j].Claim {
+			return out[i].Claim < out[j].Claim
+		}
+		return out[i].Role < out[j].Role
+	})
+	return out
 }
 
 // grantForRole reports whether one role grants verb on entityType and

--- a/internal/acl/asserted_roles_test.go
+++ b/internal/acl/asserted_roles_test.go
@@ -1,0 +1,417 @@
+package acl_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/Sourcehaven-BV/rela/internal/acl"
+	"github.com/Sourcehaven-BV/rela/internal/principal"
+	"github.com/Sourcehaven-BV/rela/internal/store/memstore"
+)
+
+// Asserted-role granting (TKT-RP3X3Q): a role claim from a verified identity
+// assertion, mapped to a declared role through the operator's allowlist.
+//
+// These tests build a Declarative directly rather than through World, because
+// World's principalFor deliberately constructs a plain (non-assertion)
+// Principal — the whole point of principal.Verified is that assertion claims
+// cannot be set any other way.
+
+const assertedPolicy = `
+roles:
+  editor:
+    read: [ticket]
+    create: [ticket]
+    update: [ticket]
+  auditor:
+    read: [ticket]
+asserted_role_assignments:
+  admin: editor
+  compliance: [editor, auditor]
+`
+
+// assertedWorld builds a Declarative over an empty store with the given policy.
+// The store is empty on purpose: an asserted role must grant without the
+// principal existing as an entity, which is exactly the SSO-provisioned-user
+// case (see TKT-0C3II2 for the provisioning follow-up).
+func assertedWorld(t *testing.T, policyYAML string) *acl.Declarative {
+	t.Helper()
+	p, err := acl.LoadPolicyBytes([]byte(policyYAML))
+	if err != nil {
+		t.Fatalf("LoadPolicyBytes: %v", err)
+	}
+	st := memstore.New()
+	d, err := acl.NewDeclarative(p, acl.NewStoreGraph(st), st,
+		acl.WithPrincipalLookup(acl.NewStorePrincipalLookup(st)))
+	if err != nil {
+		t.Fatalf("NewDeclarative: %v", err)
+	}
+	return d
+}
+
+// verified builds a Principal carrying the given asserted role claims.
+func verified(sub string, roles ...string) principal.Principal {
+	return principal.Verified(sub, principal.ToolDataEntry, "org_acme", "acme", roles)
+}
+
+// globalRoles returns the effective global role names for p, sorted-insensitive
+// membership testing via the returned map.
+func globalRoles(t *testing.T, d *acl.Declarative, p principal.Principal) map[string]acl.Source {
+	t.Helper()
+	req, err := d.ForPrincipal(p)
+	if err != nil {
+		t.Fatalf("ForPrincipal: %v", err)
+	}
+	out := map[string]acl.Source{}
+	for _, a := range req.Globals(context.Background()).Attributions {
+		out[a.Role] = a.Source
+	}
+	return out
+}
+
+func TestAssertedRoles_ClaimGrantsMappedRole(t *testing.T) {
+	t.Parallel()
+	d := assertedWorld(t, assertedPolicy)
+
+	roles := globalRoles(t, d, verified("usr_1", "admin"))
+
+	src, ok := roles["editor"]
+	if !ok {
+		t.Fatalf("claim %q did not grant role %q; got %v", "admin", "editor", roles)
+	}
+	if src.Kind != acl.SourceAsserted {
+		t.Errorf("Source.Kind = %v, want SourceAsserted", src.Kind)
+	}
+	if src.Claim != "admin" {
+		t.Errorf("Source.Claim = %q, want %q", src.Claim, "admin")
+	}
+}
+
+func TestAssertedRoles_ClaimGrantsSeveralRoles(t *testing.T) {
+	t.Parallel()
+	// The list form: one claim, many roles. This is why the policy value is a
+	// RoleList rather than a bare string.
+	d := assertedWorld(t, assertedPolicy)
+
+	roles := globalRoles(t, d, verified("usr_1", "compliance"))
+
+	for _, want := range []string{"editor", "auditor"} {
+		if _, ok := roles[want]; !ok {
+			t.Errorf("claim %q did not grant role %q; got %v", "compliance", want, roles)
+		}
+	}
+}
+
+func TestAssertedRoles_MultipleClaimsAccumulate(t *testing.T) {
+	t.Parallel()
+	// A Pratique user routinely holds several roles; each maps independently.
+	d := assertedWorld(t, `
+roles:
+  editor:
+    read: [ticket]
+  auditor:
+    read: [ticket]
+asserted_role_assignments:
+  admin: editor
+  billing: auditor
+`)
+
+	roles := globalRoles(t, d, verified("usr_1", "admin", "billing"))
+
+	if len(roles) != 2 {
+		t.Errorf("got %d roles, want 2: %v", len(roles), roles)
+	}
+}
+
+func TestAssertedRoles_GrantsWriteAccess(t *testing.T) {
+	t.Parallel()
+	// End-to-end through the actual authorization decision, not just the
+	// attribution set — a role that resolves but doesn't authorize is useless.
+	d := assertedWorld(t, assertedPolicy)
+	req, err := d.ForPrincipal(verified("usr_1", "admin"))
+	if err != nil {
+		t.Fatalf("ForPrincipal: %v", err)
+	}
+
+	got := req.AuthorizeWrite(context.Background(), acl.WriteRequest{
+		Op:      acl.OpCreate,
+		Subject: acl.EntitySubject{Type: "ticket", ID: "TKT-1"},
+	})
+	if !got.Allow {
+		t.Errorf("asserted editor denied create on ticket: %+v", got)
+	}
+}
+
+func TestAssertedRoles_UndeclaredRoleDroppedSilently(t *testing.T) {
+	t.Parallel()
+	// Mirrors the Assignments guard: a mapping to a role the policy never
+	// declared is dropped at resolution rather than erroring, so a stale
+	// mapping cannot brick every request.
+	d := assertedWorld(t, `
+roles:
+  editor:
+    read: [ticket]
+asserted_role_assignments:
+  admin: no-such-role
+`)
+
+	roles := globalRoles(t, d, verified("usr_1", "admin"))
+
+	if len(roles) != 0 {
+		t.Errorf("undeclared role was granted: %v", roles)
+	}
+}
+
+func TestAssertedRoles_UnmappedClaimGrantsNothing(t *testing.T) {
+	t.Parallel()
+	d := assertedWorld(t, assertedPolicy)
+
+	roles := globalRoles(t, d, verified("usr_1", "some-claim-we-never-mapped"))
+
+	if len(roles) != 0 {
+		t.Errorf("unmapped claim granted roles: %v", roles)
+	}
+}
+
+func TestAssertedRoles_NoClaimsGrantsNothing(t *testing.T) {
+	t.Parallel()
+	// The header/loopback shape: a valid principal with no assertion at all
+	// must behave exactly as before this feature existed.
+	d := assertedWorld(t, assertedPolicy)
+
+	for _, tc := range []struct {
+		name string
+		p    principal.Principal
+	}{
+		{"verified with empty roles", verified("usr_1")},
+		{"plain principal", principal.Principal{User: "alice", Tool: principal.ToolDataEntry}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if roles := globalRoles(t, d, tc.p); len(roles) != 0 {
+				t.Errorf("got roles %v, want none", roles)
+			}
+		})
+	}
+}
+
+func TestAssertedRoles_ClaimIsNotAnEntityID(t *testing.T) {
+	t.Parallel()
+	// The security property behind keeping asserted_role_assignments separate
+	// from assignments: a claim value that happens to equal an entity ID in
+	// `assignments` must NOT pick up that entity's role. Colliding namespaces
+	// would be a silent cross-dimension grant.
+	d := assertedWorld(t, `
+roles:
+  editor:
+    read: [ticket]
+  superuser:
+    read: ["*"]
+assignments:
+  PERS-alice: superuser
+asserted_role_assignments:
+  admin: editor
+`)
+
+	// A token claiming the literal entity ID must not become that entity.
+	roles := globalRoles(t, d, verified("usr_1", "PERS-alice"))
+
+	if _, leaked := roles["superuser"]; leaked {
+		t.Error("claim value matched an assignments key — namespaces collided, " +
+			"which is a privilege-escalation path")
+	}
+	if len(roles) != 0 {
+		t.Errorf("got roles %v, want none", roles)
+	}
+}
+
+func TestAssertedRoles_ClaimMatchingIsExactAfterTrim(t *testing.T) {
+	t.Parallel()
+	d := assertedWorld(t, assertedPolicy)
+
+	for _, tc := range []struct {
+		name, claim string
+		wantGrant   bool
+	}{
+		{"exact", "admin", true},
+		{"leading and trailing space trimmed", "  admin  ", true},
+		{"different case does not match", "Admin", false},
+		{"substring does not match", "admi", false},
+		{"superstring does not match", "administrator", false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			roles := globalRoles(t, d, verified("usr_1", tc.claim))
+			_, granted := roles["editor"]
+			if granted != tc.wantGrant {
+				t.Errorf("claim %q granted=%v, want %v", tc.claim, granted, tc.wantGrant)
+			}
+		})
+	}
+}
+
+func TestAssertedRoles_UnmatchedPrincipalKeepsAssertedRoles(t *testing.T) {
+	t.Parallel()
+	// AC10. A verified principal whose subject resolves to no user entity keeps
+	// its asserted grants — this is the SSO-provisioned user's first request.
+	//
+	// It is ALSO a regression guard on isUnstamped: that gate keys on User/Tool
+	// and must stay untouched by this feature. Relaxing it would weaken the
+	// fail-closed check for every entry point, not just this one.
+	d := assertedWorld(t, `
+user_entity_type: person
+principal_property: email
+roles:
+  editor:
+    read: [ticket]
+asserted_role_assignments:
+  admin: editor
+`)
+
+	// Empty store: no person entity has this email.
+	roles := globalRoles(t, d, verified("nobody@example.com", "admin"))
+
+	if _, ok := roles["editor"]; !ok {
+		t.Errorf("unmatched verified principal lost its asserted roles: %v", roles)
+	}
+}
+
+func TestAssertedRoles_UnstampedPrincipalStillRejected(t *testing.T) {
+	t.Parallel()
+	// The other side of the AC10 guard: asserted roles must NOT be a way to
+	// smuggle an identity-less principal past the fail-closed gate.
+	d := assertedWorld(t, assertedPolicy)
+
+	for _, tc := range []struct {
+		name string
+		p    principal.Principal
+	}{
+		{"blank tool", principal.Verified("usr_1", "", "org", "slug", []string{"admin"})},
+		{"blank user", principal.Verified("", principal.ToolDataEntry, "org", "slug", []string{"admin"})},
+		{"unknown user", principal.Verified("unknown", principal.ToolDataEntry, "org", "slug", []string{"admin"})},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if _, err := d.ForPrincipal(tc.p); err == nil {
+				t.Error("ForPrincipal accepted an unstamped principal carrying asserted roles")
+			}
+		})
+	}
+}
+
+func TestAssertedRoles_OrgIsNotEvaluated(t *testing.T) {
+	t.Parallel()
+	// Pins the ABSENCE of org enforcement so a later reader cannot mistake the
+	// omission for an oversight — and so this fails loudly the day someone adds
+	// half an org check. Org is carried for audit attribution ONLY; a principal
+	// in org A holding a role sees every entity that role grants, in every org.
+	// Enforcement is a separate ticket by explicit decision.
+	d := assertedWorld(t, assertedPolicy)
+
+	orgA := principal.Verified("usr_1", principal.ToolDataEntry, "org_a", "a", []string{"admin"})
+	orgB := principal.Verified("usr_1", principal.ToolDataEntry, "org_b", "b", []string{"admin"})
+
+	rolesA, rolesB := globalRoles(t, d, orgA), globalRoles(t, d, orgB)
+
+	if len(rolesA) != len(rolesB) {
+		t.Fatalf("org changed the role set: %v vs %v", rolesA, rolesB)
+	}
+	for role, srcA := range rolesA {
+		srcB, ok := rolesB[role]
+		if !ok {
+			t.Errorf("role %q granted in org_a but not org_b", role)
+			continue
+		}
+		if srcA != srcB {
+			t.Errorf("role %q source differs by org: %v vs %v", role, srcA, srcB)
+		}
+	}
+}
+
+// ---- Policy validation --------------------------------------------------
+
+func TestAssertedRoles_PolicyAcceptsScalarAndList(t *testing.T) {
+	t.Parallel()
+	p, err := acl.LoadPolicyBytes([]byte(`
+roles:
+  editor: {read: [ticket]}
+  auditor: {read: [ticket]}
+asserted_role_assignments:
+  scalar: editor
+  list: [editor, auditor]
+`))
+	if err != nil {
+		t.Fatalf("LoadPolicyBytes: %v", err)
+	}
+	if got := p.AssertedRoles["scalar"]; len(got) != 1 || got[0] != "editor" {
+		t.Errorf("scalar form = %v, want [editor]", got)
+	}
+	if got := p.AssertedRoles["list"]; len(got) != 2 {
+		t.Errorf("list form = %v, want 2 entries", got)
+	}
+}
+
+func TestAssertedRoles_PolicyRejectsBlankClaimKey(t *testing.T) {
+	t.Parallel()
+	// A blank key can never match (matching is exact after trim), so the
+	// mapping would be silently inert — the failure an operator is least
+	// likely to notice.
+	for _, tc := range []struct{ name, key string }{
+		{"empty", `"": editor`},
+		{"whitespace", `"   ": editor`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := acl.LoadPolicyBytes([]byte(
+				"roles:\n  editor: {read: [ticket]}\nasserted_role_assignments:\n  " + tc.key + "\n"))
+			if err == nil {
+				t.Fatal("blank claim key accepted")
+			}
+			if !strings.Contains(err.Error(), "asserted_role_assignments") {
+				t.Errorf("error does not name the offending key: %v", err)
+			}
+		})
+	}
+}
+
+func TestAssertedRoles_PolicyRejectsEveryoneAsTarget(t *testing.T) {
+	t.Parallel()
+	// everyone already applies to every principal via SourceGlobal. Granting it
+	// again from a claim would add a second attribution for the same role under
+	// a different Source, double-reporting it downstream and buying nothing.
+	_, err := acl.LoadPolicyBytes([]byte(`
+roles:
+  everyone: {read: [ticket]}
+asserted_role_assignments:
+  admin: everyone
+`))
+	if err == nil {
+		t.Fatal("everyone accepted as an asserted-role target")
+	}
+	if !strings.Contains(err.Error(), "everyone") {
+		t.Errorf("error does not explain the everyone conflict: %v", err)
+	}
+}
+
+func TestAssertedRoles_AbsentKeyIsByteIdenticalToBefore(t *testing.T) {
+	t.Parallel()
+	// The no-op default the docs idiom requires: a policy that never mentions
+	// the key behaves exactly as it did before this feature.
+	d := assertedWorld(t, `
+roles:
+  editor:
+    read: [ticket]
+assignments:
+  alice: editor
+`)
+
+	roles := globalRoles(t, d, verified("alice", "admin"))
+
+	if _, ok := roles["editor"]; !ok {
+		t.Error("assignments-based grant broke")
+	}
+	if src := roles["editor"]; src.Kind != acl.SourceGlobal {
+		t.Errorf("Source.Kind = %v, want SourceGlobal", src.Kind)
+	}
+}

--- a/internal/acl/asserted_roles_test.go
+++ b/internal/acl/asserted_roles_test.go
@@ -352,6 +352,50 @@ asserted_role_assignments:
 	}
 }
 
+func TestAssertedRoles_PaddedClaimKeyIsNormalized(t *testing.T) {
+	t.Parallel()
+	// Regression (found in code review): a padded key used to load clean and be
+	// PERMANENTLY INERT. The resolver trims the incoming claim before an exact
+	// map lookup, so nothing could ever match the untrimmed stored key — a
+	// mapping that looks configured and silently grants nothing.
+	d := assertedWorld(t, `
+roles:
+  editor:
+    read: [ticket]
+asserted_role_assignments:
+  "  admin  ": editor
+`)
+
+	roles := globalRoles(t, d, verified("usr_1", "admin"))
+
+	if _, ok := roles["editor"]; !ok {
+		t.Errorf("padded policy key did not match claim %q — the key was stored "+
+			"untrimmed and is unmatchable: %v", "admin", roles)
+	}
+}
+
+func TestAssertedRoles_PaddedKeysMergeRatherThanClobber(t *testing.T) {
+	t.Parallel()
+	// Two keys differing only by padding collapse to one entry. Their role
+	// lists must be unioned — dropping either would silently revoke a grant.
+	d := assertedWorld(t, `
+roles:
+  editor: {read: [ticket]}
+  auditor: {read: [ticket]}
+asserted_role_assignments:
+  "admin": editor
+  " admin ": auditor
+`)
+
+	roles := globalRoles(t, d, verified("usr_1", "admin"))
+
+	for _, want := range []string{"editor", "auditor"} {
+		if _, ok := roles[want]; !ok {
+			t.Errorf("role %q lost when padded keys merged: %v", want, roles)
+		}
+	}
+}
+
 func TestAssertedRoles_PolicyRejectsBlankClaimKey(t *testing.T) {
 	t.Parallel()
 	// A blank key can never match (matching is exact after trim), so the

--- a/internal/acl/asserted_roles_test.go
+++ b/internal/acl/asserted_roles_test.go
@@ -2,6 +2,7 @@ package acl_test
 
 import (
 	"context"
+	"slices"
 	"strings"
 	"testing"
 
@@ -393,6 +394,73 @@ asserted_role_assignments:
 		if _, ok := roles[want]; !ok {
 			t.Errorf("role %q lost when padded keys merged: %v", want, roles)
 		}
+	}
+}
+
+func TestAssertedRoles_MergeIsDeterministic(t *testing.T) {
+	t.Parallel()
+	// Go randomizes map iteration, so which padded key is stored first and
+	// which merges into it varies per run. Without an explicit sort the same
+	// policy text yields a different in-memory role order on every load.
+	const policy = `
+roles:
+  editor: {read: [ticket]}
+  auditor: {read: [ticket]}
+  reviewer: {read: [ticket]}
+asserted_role_assignments:
+  "admin": editor
+  " admin ": auditor
+  "admin\t": reviewer
+`
+	var first []string
+	for i := range 50 {
+		p, err := acl.LoadPolicyBytes([]byte(policy))
+		if err != nil {
+			t.Fatalf("LoadPolicyBytes: %v", err)
+		}
+		got := []string(p.AssertedRoles["admin"])
+		if i == 0 {
+			first = got
+			continue
+		}
+		if !slices.Equal(got, first) {
+			t.Fatalf("merge order varies between loads: run 0 = %v, run %d = %v",
+				first, i, got)
+		}
+	}
+	// Sanity: all three roles survived the merge.
+	if len(first) != 3 {
+		t.Errorf("merged list = %v, want 3 roles", first)
+	}
+}
+
+func TestAssertedRoles_MergeDoesNotAliasCallerSlices(t *testing.T) {
+	t.Parallel()
+	// Validate's godoc invites operators to call it on a hand-built policy, and
+	// normalizeAssertedRoles exists precisely because policies arrive by paths
+	// other than LoadPolicy. A hand-built RoleList can have spare capacity, so
+	// appending into it during a merge would write past its length into the
+	// caller's backing array.
+	backing := make(acl.RoleList, 1, 4)
+	backing[0] = "editor"
+	sibling := append(backing[:1:4], "SENTINEL") //nolint:gocritic // deliberate share
+
+	p := &acl.Policy{
+		Roles: map[string]acl.RoleDef{
+			"editor":  {Read: []string{"ticket"}},
+			"auditor": {Read: []string{"ticket"}},
+		},
+		//nolint:gocritic // the padded key is the point: it forces the merge path
+		AssertedRoles: map[string]acl.RoleList{
+			"admin": backing, " admin": {"auditor"},
+		},
+	}
+	if err := p.Validate(); err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+
+	if sibling[1] != "SENTINEL" {
+		t.Errorf("merge clobbered a caller-owned slice: sibling = %v", sibling)
 	}
 }
 

--- a/internal/acl/docs_example_test.go
+++ b/internal/acl/docs_example_test.go
@@ -1,0 +1,53 @@
+package acl_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Sourcehaven-BV/rela/internal/acl"
+	"github.com/Sourcehaven-BV/rela/internal/principal"
+	"github.com/Sourcehaven-BV/rela/internal/store/memstore"
+)
+
+// Doc-drift guard: the YAML below is copied verbatim from the
+// "Roles from a verified identity assertion" section of docs/acl-overview.md.
+// If the policy schema changes and the docs are not updated, this fails —
+// which is the point. A documented example that no longer parses is worse
+// than no example, because a reader will trust it.
+func TestDocs_AclOverviewExampleWorks(t *testing.T) {
+	p, err := acl.LoadPolicyBytes([]byte(`
+roles:
+  editor: {read: [ticket], update: [ticket]}
+  auditor: {read: [ticket]}
+asserted_role_assignments:
+  admin: editor
+  compliance: [editor, auditor]
+`))
+	if err != nil {
+		t.Fatalf("the YAML in docs/acl-overview.md does not parse: %v", err)
+	}
+	st := memstore.New()
+	d, err := acl.NewDeclarative(p, acl.NewStoreGraph(st), st)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// "A principal holding [admin, compliance] gets the union, deduplicated."
+	req, err := d.ForPrincipal(principal.Verified(
+		"usr_1", principal.ToolDataEntry, "org", "slug",
+		[]string{"admin", "compliance"}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	roles := map[string]int{}
+	for _, a := range req.Globals(context.Background()).Attributions {
+		roles[a.Role]++
+	}
+	if roles["editor"] == 0 || roles["auditor"] == 0 {
+		t.Errorf("documented union not produced: %v", roles)
+	}
+	// editor arrives via BOTH claims; distinct sources, so two attributions —
+	// but the ROLE set is what authorizes, and that is deduplicated.
+	if len(roles) != 2 {
+		t.Errorf("role set = %v, want exactly {editor, auditor}", roles)
+	}
+}

--- a/internal/acl/policy.go
+++ b/internal/acl/policy.go
@@ -420,9 +420,51 @@ func LoadPolicyBytes(data []byte) (*Policy, error) {
 	return &p, nil
 }
 
+// normalizeAssertedRoles trims surrounding whitespace from every
+// asserted_role_assignments key so the stored form matches what the resolver
+// looks up.
+//
+// Without this, a padded key like `" admin": editor` loads clean and is
+// PERMANENTLY INERT: the resolver trims the incoming claim before an exact map
+// lookup, so no claim value can ever match the untrimmed key. That fails safe
+// (the grant silently doesn't happen) but it is precisely the
+// looks-configured-but-does-nothing trap [Policy.Validate]'s blank-key check
+// exists to prevent. [Policy.EffectiveMembershipRelation] trims its value for
+// the identical reason.
+//
+// A key that is entirely blank trims to "" and is then caught by the blank-key
+// check in [Policy.Validate], so it still fails loudly rather than normalizing
+// into something matchable. Two keys that differ only by padding collapse to
+// one entry; their role lists are unioned, so no grant is lost.
+func (p *Policy) normalizeAssertedRoles() {
+	if len(p.AssertedRoles) == 0 {
+		return
+	}
+	out := make(map[string]RoleList, len(p.AssertedRoles))
+	for claim, roles := range p.AssertedRoles {
+		key := strings.TrimSpace(claim)
+		if existing, dup := out[key]; dup {
+			for _, r := range roles {
+				if !slices.Contains(existing, r) {
+					existing = append(existing, r)
+				}
+			}
+			out[key] = existing
+			continue
+		}
+		out[key] = roles
+	}
+	p.AssertedRoles = out
+}
+
 // Validate enforces security-critical invariants on the parsed
 // policy. Run automatically by [LoadPolicy] / [LoadPolicyBytes].
 // Operators can also call it before persisting a generated policy.
+//
+// It also normalizes asserted_role_assignments keys in place (see
+// [Policy.normalizeAssertedRoles]) — the one mutation it performs, placed here
+// so it cannot be bypassed by a policy that reaches the resolver through a
+// path other than LoadPolicy.
 //
 // Current checks (RR-NIGK, RR-W2J6):
 //
@@ -467,6 +509,7 @@ func LoadPolicyBytes(data []byte) (*Policy, error) {
 // TKT-TS0J5K — which can rank findings by severity and cross-check the
 // metamodel, neither of which fits a boot gate.
 func (p *Policy) Validate() error {
+	p.normalizeAssertedRoles()
 	for i, t := range p.InheritRolesThrough {
 		if isBlank(t) {
 			return fmt.Errorf("inherit_roles_through[%d]: relation type must not be empty or whitespace", i)
@@ -478,9 +521,11 @@ func (p *Policy) Validate() error {
 		}
 	}
 	for claim, roles := range p.AssertedRoles {
-		// A blank claim key can never match a real claim value (matching is
-		// exact after TrimSpace), so the mapping is silently inert — the
-		// failure mode an operator is least likely to notice.
+		// A blank claim key can never match a real claim value, so the mapping
+		// is silently inert — the failure mode an operator is least likely to
+		// notice. (Surrounding whitespace is normalized away by
+		// normalizeAssertedRoles before this runs, so only an all-blank key
+		// reaches here.)
 		if isBlank(claim) {
 			return errors.New("asserted_role_assignments: claim key must not be empty or whitespace")
 		}

--- a/internal/acl/policy.go
+++ b/internal/acl/policy.go
@@ -436,23 +436,46 @@ func LoadPolicyBytes(data []byte) (*Policy, error) {
 // check in [Policy.Validate], so it still fails loudly rather than normalizing
 // into something matchable. Two keys that differ only by padding collapse to
 // one entry; their role lists are unioned, so no grant is lost.
+//
+// Two details the merge depends on, both load-bearing:
+//
+//   - Lists are CLONED on store, never aliased. Go map iteration order is
+//     random, so which key is stored first and which merges into it varies per
+//     run; appending into a caller-owned slice with spare capacity would write
+//     past its length into the caller's backing array. Unreachable via
+//     [LoadPolicy] (the YAML unmarshaler hands over fresh slices), but this
+//     method exists precisely because policies also arrive hand-built — and
+//     [Policy.Validate] documents that as supported.
+//   - The merged list is SORTED. Otherwise the same policy text yields a
+//     different in-memory order on every load, which propagates into the
+//     resolver's attribution append order. Downstream reporting sorts anyway,
+//     so nothing observable breaks today; this keeps a future consumer from
+//     inheriting an ordering hazard that nothing in the type documents.
 func (p *Policy) normalizeAssertedRoles() {
 	if len(p.AssertedRoles) == 0 {
 		return
 	}
 	out := make(map[string]RoleList, len(p.AssertedRoles))
+	merged := map[string]bool{}
 	for claim, roles := range p.AssertedRoles {
 		key := strings.TrimSpace(claim)
-		if existing, dup := out[key]; dup {
-			for _, r := range roles {
-				if !slices.Contains(existing, r) {
-					existing = append(existing, r)
-				}
-			}
-			out[key] = existing
+		existing, dup := out[key]
+		if !dup {
+			out[key] = slices.Clone(roles)
 			continue
 		}
-		out[key] = roles
+		for _, r := range roles {
+			if !slices.Contains(existing, r) {
+				existing = append(existing, r)
+			}
+		}
+		out[key] = existing
+		merged[key] = true
+	}
+	// Sort only the merged lists: an unmerged list keeps the operator's
+	// authored order, which is what they see in `rela acl map` output.
+	for key := range merged {
+		slices.Sort(out[key])
 	}
 	p.AssertedRoles = out
 }
@@ -523,9 +546,14 @@ func (p *Policy) Validate() error {
 	for claim, roles := range p.AssertedRoles {
 		// A blank claim key can never match a real claim value, so the mapping
 		// is silently inert — the failure mode an operator is least likely to
-		// notice. (Surrounding whitespace is normalized away by
-		// normalizeAssertedRoles before this runs, so only an all-blank key
-		// reaches here.)
+		// notice.
+		//
+		// normalizeAssertedRoles has already run, so a key that TrimSpace
+		// considers blank arrives here as "". isBlank uses a narrower
+		// definition (ASCII space/tab/CR/LF) than TrimSpace (all Unicode
+		// space), and the difference is safe in this direction only: anything
+		// TrimSpace strips is already gone, so isBlank sees "" and rejects it.
+		// Widening isBlank would not break this; narrowing TrimSpace would.
 		if isBlank(claim) {
 			return errors.New("asserted_role_assignments: claim key must not be empty or whitespace")
 		}

--- a/internal/acl/policy.go
+++ b/internal/acl/policy.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"slices"
 	"strings"
 
 	"gopkg.in/yaml.v3"
@@ -96,8 +97,37 @@ type Policy struct {
 	MembershipRelation  string                     `yaml:"membership_relation"`
 	Roles               map[string]RoleDef         `yaml:"roles"`
 	Assignments         map[string]string          `yaml:"assignments"`
+	AssertedRoles       map[string]RoleList        `yaml:"asserted_role_assignments"`
 	RoleRelations       map[string]RoleRelationDef `yaml:"role_relations"`
 	InheritRolesThrough []string                   `yaml:"inherit_roles_through"`
+}
+
+// RoleList is a list of role names that accepts either a bare scalar or a
+// sequence in YAML, so the common single-role case stays terse:
+//
+//	asserted_role_assignments:
+//	  admin: editor              # scalar
+//	  auditor: [reader, auditor] # sequence
+//
+// Mirrors metamodel.StringOrSlice; duplicated rather than imported because
+// internal/acl must not depend on internal/metamodel (see the MetamodelView
+// comment below for why that boundary exists).
+type RoleList []string
+
+// UnmarshalYAML accepts a scalar or a sequence. A scalar becomes a one-element
+// list; anything else is decoded as a sequence and surfaces its own error.
+func (r *RoleList) UnmarshalYAML(unmarshal func(any) error) error {
+	var single string
+	if err := unmarshal(&single); err == nil {
+		*r = RoleList{single}
+		return nil
+	}
+	var list []string
+	if err := unmarshal(&list); err != nil {
+		return err
+	}
+	*r = list
+	return nil
 }
 
 // principalPropertyLookupEnabled reports whether the policy asks the
@@ -315,14 +345,15 @@ type RoleRelationDef struct {
 // knownPolicyKeys is the allowlist used for unknown-key warnings.
 // Keep in sync with [Policy]'s yaml tags.
 var knownPolicyKeys = map[string]bool{
-	"description":           true,
-	"user_entity_type":      true,
-	"principal_property":    true,
-	"membership_relation":   true,
-	"roles":                 true,
-	"assignments":           true,
-	"role_relations":        true,
-	"inherit_roles_through": true,
+	"description":               true,
+	"user_entity_type":          true,
+	"principal_property":        true,
+	"membership_relation":       true,
+	"roles":                     true,
+	"assignments":               true,
+	"asserted_role_assignments": true,
+	"role_relations":            true,
+	"inherit_roles_through":     true,
 }
 
 // LoadPolicy reads and parses `acl.yaml` at the given path.
@@ -444,6 +475,24 @@ func (p *Policy) Validate() error {
 	for k := range p.RoleRelations {
 		if isBlank(k) {
 			return errors.New("role_relations: relation type key must not be empty or whitespace")
+		}
+	}
+	for claim, roles := range p.AssertedRoles {
+		// A blank claim key can never match a real claim value (matching is
+		// exact after TrimSpace), so the mapping is silently inert — the
+		// failure mode an operator is least likely to notice.
+		if isBlank(claim) {
+			return errors.New("asserted_role_assignments: claim key must not be empty or whitespace")
+		}
+		// EveryoneRole already enters every principal's set as
+		// Source{Kind: SourceGlobal}. Granting it again from a claim would add a
+		// SECOND attribution for the same role under a different Source,
+		// double-reporting it in `rela acl map` and in denial diagnostics — and
+		// buying nothing, since everyone already has it.
+		if slices.Contains(roles, EveryoneRole) {
+			return fmt.Errorf(
+				"asserted_role_assignments.%s: cannot grant the %q role — "+
+					"it already applies to every principal", claim, EveryoneRole)
 		}
 	}
 	for name, role := range p.Roles {

--- a/internal/acl/request.go
+++ b/internal/acl/request.go
@@ -148,7 +148,10 @@ func (r *Request) PermitsReadMany(ctx context.Context, entityType string, ids []
 // Principal returns the principal bound at construction. Helper for
 // audit attribution; callers that already have the principal in their
 // own ctx don't need this.
-func (r *Request) Principal() principal.Principal { return r.principal }
+//
+// Cloned so a caller cannot reach the roles backing array this Request is
+// still authorizing against.
+func (r *Request) Principal() principal.Principal { return r.principal.Clone() }
 
 // ctxKey is the unexported type for context.WithValue. Required by
 // the std-lib contract that context keys are not bare strings.

--- a/internal/acl/resolver.go
+++ b/internal/acl/resolver.go
@@ -4,12 +4,14 @@ import (
 	"context"
 	"slices"
 	"sort"
+	"strings"
 )
 
 // computeGlobals walks the configured membership relation (default
 // `member-of`, see [Policy.MembershipRelation]) from the principal and
-// unions in Assignments[m] for every member m, plus the "everyone" role
-// if declared.
+// unions in Assignments[m] for every member m, plus any roles mapped from
+// the principal's verified assertion claims, plus the "everyone" role if
+// declared.
 //
 // Called once per Request via Globals(); the result is cached for the
 // lifetime of the Request.
@@ -40,6 +42,25 @@ func (r *Request) computeGlobals(ctx context.Context) GlobalRoles {
 			add(role, Source{Kind: SourceGlobal})
 		} else {
 			add(role, Source{Kind: SourceGroup, Group: m})
+		}
+	}
+	// Roles asserted by a verified identity assertion, mapped through the
+	// operator's allowlist. Like the everyone role below, these land without
+	// a graph walk — the principal need not exist as an entity at all, which
+	// is what makes an SSO-provisioned user's first request work.
+	//
+	// The claim value is NOT a role name: it only ever selects an entry the
+	// operator wrote in asserted_role_assignments, so an IdP cannot name a
+	// rela role the deployment did not choose to grant. Matching is exact
+	// after TrimSpace (Validate rejects blank keys); an undeclared target
+	// role is dropped silently, matching the Assignments guard above.
+	for _, claim := range r.principal.Roles() {
+		claim = strings.TrimSpace(claim)
+		for _, role := range policy.AssertedRoles[claim] {
+			if _, defined := policy.Roles[role]; !defined {
+				continue
+			}
+			add(role, Source{Kind: SourceAsserted, Claim: claim})
 		}
 	}
 	if _, ok := policy.Roles[EveryoneRole]; ok {

--- a/internal/acl/source.go
+++ b/internal/acl/source.go
@@ -12,6 +12,19 @@ const (
 	SourceLocalViaGroup
 	SourceLocalViaAncestor
 	SourceLocalViaGroupAndAncestor
+	// SourceAsserted: the role came from a claim in a verified identity
+	// assertion, mapped through asserted_role_assignments. Distinct from
+	// SourceGlobal because the provenance question after an incident —
+	// "was this granted by our policy, or by a claim in a token?" — has
+	// materially different answers and remediations.
+	SourceAsserted
+
+	// numSourceKinds is the count of declared kinds. It MUST be last in the
+	// const block: it is what lets TestSourceKinds_Exhaustive detect a kind
+	// added here and not registered in sourceKindPriority, both String()
+	// methods, and lessSource — none of which the compiler checks, since
+	// every switch over SourceKind has a default.
+	numSourceKinds
 )
 
 // priority defines the sort precedence used to pick the primary
@@ -32,12 +45,17 @@ func (k SourceKind) priority() int {
 }
 
 var sourceKindPriority = map[SourceKind]int{
-	SourceGlobal:                   0,
-	SourceGroup:                    1,
-	SourceLocal:                    2,
-	SourceLocalViaGroup:            3,
-	SourceLocalViaAncestor:         4,
-	SourceLocalViaGroupAndAncestor: 5,
+	SourceGlobal: 0,
+	// Asserted sorts immediately after global: like global it is a
+	// principal-wide fact rather than an entity-local one, but a policy
+	// assignment is the more specific statement about THIS deployment,
+	// so it keeps precedence when both apply.
+	SourceAsserted:                 1,
+	SourceGroup:                    2,
+	SourceLocal:                    3,
+	SourceLocalViaGroup:            4,
+	SourceLocalViaAncestor:         5,
+	SourceLocalViaGroupAndAncestor: 6,
 }
 
 // String returns the wire/log form of a SourceKind.
@@ -55,8 +73,13 @@ func (k SourceKind) String() string {
 		return "local-via-ancestor"
 	case SourceLocalViaGroupAndAncestor:
 		return "local-via-group-and-ancestor"
+	case SourceAsserted:
+		return "asserted"
+	default:
+		// Includes numSourceKinds (a count, not a kind) and any value from a
+		// future const-block addition that was never registered here.
+		return "unknown"
 	}
-	return "unknown"
 }
 
 // Source describes how a role landed in a principal's effective set.
@@ -91,6 +114,10 @@ type Source struct {
 	Group    string
 	Ancestor string
 	Relation string
+	// Claim is the asserted claim value that granted the role, populated
+	// only for SourceAsserted. Keeping it a plain string preserves Source's
+	// comparability, which attrKey and aclmap.Route both depend on.
+	Claim string
 }
 
 // String renders the human/log form of a Source. Audit and 403-body
@@ -111,8 +138,11 @@ func (s Source) String() string {
 		return "local-via-ancestor:" + s.Ancestor + ":" + s.Relation
 	case SourceLocalViaGroupAndAncestor:
 		return "local-via-group-and-ancestor:" + s.Group + ":" + s.Ancestor + ":" + s.Relation
+	case SourceAsserted:
+		return "asserted:" + s.Claim
+	default:
+		return s.Kind.String()
 	}
-	return s.Kind.String()
 }
 
 // RoleAttribution is a (role, source) pair. The same role can land
@@ -159,5 +189,10 @@ func lessSource(a, b Source) bool {
 	if a.Ancestor != b.Ancestor {
 		return a.Ancestor < b.Ancestor
 	}
-	return a.Relation < b.Relation
+	if a.Relation != b.Relation {
+		return a.Relation < b.Relation
+	}
+	// Without this, two asserted attributions differing only by claim
+	// compare equal and PrimarySource picks non-deterministically.
+	return a.Claim < b.Claim
 }

--- a/internal/acl/source_test.go
+++ b/internal/acl/source_test.go
@@ -1,6 +1,7 @@
 package acl
 
 import (
+	"slices"
 	"strings"
 	"testing"
 )
@@ -24,11 +25,62 @@ func TestSourceKindString_AllKindsRender(t *testing.T) {
 		{SourceLocalViaGroup, "local-via-group"},
 		{SourceLocalViaAncestor, "local-via-ancestor"},
 		{SourceLocalViaGroupAndAncestor, "local-via-group-and-ancestor"},
+		{SourceAsserted, "asserted"},
 	}
 	for _, c := range cases {
 		got := c.kind.String()
 		if got != c.want {
 			t.Errorf("SourceKind(%d).String() = %q, want %q", c.kind, got, c.want)
+		}
+	}
+	if len(cases) != len(allSourceKinds) {
+		t.Errorf("table covers %d kinds but %d are declared — add the new kind here",
+			len(cases), len(allSourceKinds))
+	}
+}
+
+// allSourceKinds is the single list every enum test iterates. Adding a kind to
+// the const block without adding it here fails TestSourceKinds_Exhaustive
+// below, which is the guard that makes the omission LOUD: without it, a new
+// kind silently renders "unknown" at priority 999 and every hand-maintained
+// table in this file keeps passing.
+var allSourceKinds = []SourceKind{
+	SourceGlobal,
+	SourceAsserted,
+	SourceGroup,
+	SourceLocal,
+	SourceLocalViaGroup,
+	SourceLocalViaAncestor,
+	SourceLocalViaGroupAndAncestor,
+}
+
+func TestSourceKinds_Exhaustive(t *testing.T) {
+	t.Parallel()
+	// numSourceKinds comes from the const block itself, so this walks every
+	// declared kind whether or not anyone remembered to list it in
+	// allSourceKinds. That is the whole point: the compiler checks none of
+	// this (every switch over SourceKind has a default), so a kind added to
+	// the const block and forgotten everywhere else would otherwise render
+	// "unknown" at priority 999 with every hand-maintained table still green.
+	if len(allSourceKinds) != int(numSourceKinds) {
+		t.Fatalf("allSourceKinds has %d entries but %d kinds are declared — "+
+			"add the new kind to allSourceKinds", len(allSourceKinds), numSourceKinds)
+	}
+	for i := range int(numSourceKinds) {
+		k := SourceKind(i)
+		if k.String() == "unknown" {
+			t.Errorf("SourceKind(%d) has no SourceKind.String() case", k)
+		}
+		if k.priority() == sourceKindUnknownPriority {
+			t.Errorf("SourceKind(%d) (%s) is missing from sourceKindPriority", k, k)
+		}
+		if !slices.Contains(allSourceKinds, k) {
+			t.Errorf("SourceKind(%d) (%s) is missing from allSourceKinds", k, k)
+		}
+		// Source.String() must special-case the kind too; falling through to
+		// SourceKind.String() means the kind's payload fields never render.
+		if got := (Source{Kind: k}).String(); got == "" {
+			t.Errorf("SourceKind(%d) (%s) renders empty via Source.String()", k, k)
 		}
 	}
 }
@@ -46,13 +98,11 @@ func TestSourceKindString_UnknownKind(t *testing.T) {
 
 func TestSourceKindPriority_DeclaredKinds(t *testing.T) {
 	t.Parallel()
-	// Each declared kind has a priority distinct from every other,
-	// matching the documented sort order (Global < Group < Local <
-	// LocalViaGroup < LocalViaAncestor < LocalViaGroupAndAncestor).
-	declared := []SourceKind{
-		SourceGlobal, SourceGroup, SourceLocal,
-		SourceLocalViaGroup, SourceLocalViaAncestor, SourceLocalViaGroupAndAncestor,
-	}
+	// Each declared kind has a priority distinct from every other, matching the
+	// documented sort order (Global < Asserted < Group < Local < LocalViaGroup
+	// < LocalViaAncestor < LocalViaGroupAndAncestor). allSourceKinds is written
+	// in that order, so this also pins the order itself.
+	declared := allSourceKinds
 	seen := map[int]SourceKind{}
 	for _, k := range declared {
 		p := k.priority()
@@ -111,6 +161,7 @@ func TestSourceString_PerKind(t *testing.T) {
 			},
 			"local-via-group-and-ancestor:engineering:F-eng:editor-of",
 		},
+		{"asserted", Source{Kind: SourceAsserted, Claim: "admin"}, "asserted:admin"},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
@@ -120,6 +171,38 @@ func TestSourceString_PerKind(t *testing.T) {
 				t.Errorf("Source.String() = %q, want %q", got, c.want)
 			}
 		})
+	}
+}
+
+func TestPrimarySource_AssertedClaimTiebreak(t *testing.T) {
+	t.Parallel()
+	// Two asserted attributions differing ONLY by claim must order
+	// deterministically. Without Claim in the lessSource chain they compare
+	// equal, and PrimarySource — plus every aclmap artifact downstream —
+	// becomes input-order dependent, which surfaces as a flaky golden test
+	// rather than an obvious bug.
+	a := Source{Kind: SourceAsserted, Claim: "admin"}
+	b := Source{Kind: SourceAsserted, Claim: "billing"}
+
+	if got := PrimarySource([]Source{a, b}); got != a {
+		t.Errorf("PrimarySource([a b]) = %+v, want %+v", got, a)
+	}
+	if got := PrimarySource([]Source{b, a}); got != a {
+		t.Errorf("PrimarySource([b a]) = %+v, want %+v — order-dependent result "+
+			"means Claim is missing from the lessSource tiebreak", got, a)
+	}
+}
+
+func TestPrimarySource_PolicyAssignmentBeatsAssertedClaim(t *testing.T) {
+	t.Parallel()
+	// A global policy assignment is the more specific statement about THIS
+	// deployment than a claim minted by the IdP, so it wins as primary when
+	// both grant the same role.
+	global := Source{Kind: SourceGlobal}
+	asserted := Source{Kind: SourceAsserted, Claim: "admin"}
+
+	if got := PrimarySource([]Source{asserted, global}); got != global {
+		t.Errorf("PrimarySource = %+v, want %+v (global outranks asserted)", got, global)
 	}
 }
 

--- a/internal/aclmap/aclmap.go
+++ b/internal/aclmap/aclmap.go
@@ -47,6 +47,7 @@ type Resolver interface {
 	ForPrincipal(p principal.Principal) (*acl.Request, error)
 	ResolvePrincipal(ctx context.Context, rawUser string) (string, error)
 	EveryoneGrants(verb acl.Verb, entityType string) acl.EveryoneGrant
+	AssertedGrants(verb acl.Verb, entityType string) []acl.AssertedGrant
 	Policy() *acl.Policy
 }
 
@@ -81,6 +82,7 @@ type Route struct {
 	Group    string `json:"group,omitempty"`
 	Ancestor string `json:"ancestor,omitempty"`
 	Relation string `json:"relation,omitempty"`
+	Claim    string `json:"claim,omitempty"`
 }
 
 // PrincipalAccess is one principal's grant of the verb on the entity,
@@ -101,18 +103,45 @@ type Everyone struct {
 	Wildcard bool `json:"wildcard"`
 }
 
+// ConditionalGrant is a grant that reaches whichever principals present a
+// given claim in a verified identity assertion (asserted_role_assignments).
+//
+// It is reported SEPARATELY from [Everyone] on purpose, and the distinction is
+// load-bearing. An everyone grant is a statement of fact — the role genuinely
+// applies to every principal, so reporting it globally is accurate. An asserted
+// grant applies to an unknowable SUBSET: the holders live in the IdP, not the
+// graph, so enumeratePrincipals cannot see them. Folding these into the
+// everyone slot would tell an operator that everybody holds the role, which is
+// the worst possible answer to the question this report exists to answer —
+// "who could have done this?" — asked in the worst possible moment.
+//
+// Holders is therefore deliberately absent. The honest answer is the claim
+// name plus "ask your IdP who holds it".
+type ConditionalGrant struct {
+	// Claim is the asserted claim value that triggers the grant.
+	Claim string `json:"claim"`
+	// Role is the policy role the claim maps to.
+	Role string `json:"role"`
+	// Wildcard reports whether the role's grant came from a "*" entry.
+	Wildcard bool `json:"wildcard"`
+}
+
 // WhoCanResult is the answer to "who can <verb> <entity>". SchemaVersion
 // is bumped on any breaking change to this shape so snapshot/diff
 // consumers can detect format changes. Everyone is the global everyone
 // grant; Principals is every enumerated principal with a non-everyone
 // route, sorted by principal ID.
 type WhoCanResult struct {
-	SchemaVersion int               `json:"schema_version"`
-	Verb          string            `json:"verb"`
-	Entity        string            `json:"entity"`
-	EntityType    string            `json:"entity_type"`
-	Everyone      Everyone          `json:"everyone"`
-	Principals    []PrincipalAccess `json:"principals"`
+	SchemaVersion int      `json:"schema_version"`
+	Verb          string   `json:"verb"`
+	Entity        string   `json:"entity"`
+	EntityType    string   `json:"entity_type"`
+	Everyone      Everyone `json:"everyone"`
+	// Conditional lists grants reachable via a verified assertion claim, whose
+	// holders are NOT enumerable from the graph. Sorted by (claim, role).
+	// See [ConditionalGrant] for why these are not merged into Everyone.
+	Conditional []ConditionalGrant `json:"conditional,omitempty"`
+	Principals  []PrincipalAccess  `json:"principals"`
 }
 
 // schemaVersion is the WhoCanResult wire version. Bump on breaking

--- a/internal/aclmap/conditional_test.go
+++ b/internal/aclmap/conditional_test.go
@@ -1,0 +1,190 @@
+package aclmap_test
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/Sourcehaven-BV/rela/internal/acl"
+)
+
+// Conditional (asserted-claim) grants in the who-can report (TKT-RP3X3Q).
+//
+// The load-bearing property under test is a REPORTING one: an asserted grant
+// must never be presented as an everyone grant. `rela acl who-can` is consulted
+// post-incident to answer "who could have done this?"; telling an operator that
+// everybody holds a role they cannot enumerate is worse than saying nothing.
+
+const conditionalPolicy = `
+roles:
+  editor:
+    read: [incident]
+    update: [incident]
+  auditor:
+    read: [incident]
+asserted_role_assignments:
+  admin: editor
+  compliance: [editor, auditor]
+`
+
+func TestWhoCan_ReportsAssertedGrantsSeparately(t *testing.T) {
+	w := buildWorld(t, conditionalPolicy, []ent{{"INC-1", "incident"}}, nil)
+
+	got, err := w.eng.WhoCan(context.Background(), acl.VerbUpdate, "INC-1")
+	if err != nil {
+		t.Fatalf("WhoCan: %v", err)
+	}
+
+	// The grant must NOT be reported as an everyone grant.
+	if got.Everyone.Granted {
+		t.Error("an asserted grant was reported as an everyone grant — this tells " +
+			"an operator that every principal holds the role")
+	}
+
+	// It must appear in its own section. Both claims map to `editor`, which
+	// grants update.
+	wantClaims := map[string]bool{"admin": false, "compliance": false}
+	for _, c := range got.Conditional {
+		if _, ok := wantClaims[c.Claim]; !ok {
+			t.Errorf("unexpected conditional claim %q", c.Claim)
+			continue
+		}
+		wantClaims[c.Claim] = true
+		if c.Role != "editor" {
+			t.Errorf("claim %q → role %q, want editor", c.Claim, c.Role)
+		}
+	}
+	for claim, seen := range wantClaims {
+		if !seen {
+			t.Errorf("claim %q missing from the conditional section", claim)
+		}
+	}
+}
+
+func TestWhoCan_AssertedGrantsAreNotPrincipals(t *testing.T) {
+	w := buildWorld(t, conditionalPolicy, []ent{{"INC-1", "incident"}}, nil)
+
+	got, err := w.eng.WhoCan(context.Background(), acl.VerbUpdate, "INC-1")
+	if err != nil {
+		t.Fatalf("WhoCan: %v", err)
+	}
+
+	// A claim value is not a principal and must never be enumerated as one —
+	// it would read as a real, addressable identity that does not exist.
+	for _, p := range got.Principals {
+		if p.Principal == "admin" || p.Principal == "compliance" {
+			t.Errorf("claim %q was enumerated as a principal", p.Principal)
+		}
+	}
+}
+
+func TestWhoCan_AssertedGrantsRespectVerb(t *testing.T) {
+	w := buildWorld(t, conditionalPolicy, []ent{{"INC-1", "incident"}}, nil)
+
+	// `auditor` grants read but not update, so the compliance→auditor mapping
+	// must appear for read and be absent for update.
+	read, err := w.eng.WhoCan(context.Background(), acl.VerbRead, "INC-1")
+	if err != nil {
+		t.Fatalf("WhoCan(read): %v", err)
+	}
+	var sawAuditor bool
+	for _, c := range read.Conditional {
+		if c.Role == "auditor" {
+			sawAuditor = true
+		}
+	}
+	if !sawAuditor {
+		t.Error("auditor grant missing from the read report")
+	}
+
+	update, err := w.eng.WhoCan(context.Background(), acl.VerbUpdate, "INC-1")
+	if err != nil {
+		t.Fatalf("WhoCan(update): %v", err)
+	}
+	for _, c := range update.Conditional {
+		if c.Role == "auditor" {
+			t.Error("auditor reported as granting update, which it does not")
+		}
+	}
+}
+
+func TestWhoCan_UndeclaredAssertedRoleNotReported(t *testing.T) {
+	// Matches what the resolver does at attribution time: a mapping to a role
+	// the policy never declared grants nothing, so reporting it would overstate
+	// the deployment's exposure.
+	w := buildWorld(t, `
+roles:
+  editor:
+    read: [incident]
+    update: [incident]
+asserted_role_assignments:
+  admin: editor
+  ghost: no-such-role
+`, []ent{{"INC-1", "incident"}}, nil)
+
+	got, err := w.eng.WhoCan(context.Background(), acl.VerbUpdate, "INC-1")
+	if err != nil {
+		t.Fatalf("WhoCan: %v", err)
+	}
+	for _, c := range got.Conditional {
+		if c.Claim == "ghost" {
+			t.Error("a mapping to an undeclared role was reported as a grant")
+		}
+	}
+}
+
+func TestWhoCan_NoAssertedMappingsOmitsSection(t *testing.T) {
+	// The artifact is a diff input: a policy with no asserted mappings must
+	// serialize byte-identically to what earlier versions produced.
+	w := buildWorld(t, `
+roles:
+  editor:
+    read: [incident]
+    update: [incident]
+assignments:
+  alice: editor
+`, []ent{{"INC-1", "incident"}}, nil)
+
+	got, err := w.eng.WhoCan(context.Background(), acl.VerbUpdate, "INC-1")
+	if err != nil {
+		t.Fatalf("WhoCan: %v", err)
+	}
+	if got.Conditional != nil {
+		t.Errorf("Conditional = %v, want nil", got.Conditional)
+	}
+
+	data, err := json.Marshal(got)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if strings.Contains(string(data), "conditional") {
+		t.Errorf("empty conditional section appeared in the wire format: %s", data)
+	}
+}
+
+func TestWhoCan_AssertedGrantsAreSorted(t *testing.T) {
+	// Deterministic ordering: the report feeds a diff artifact.
+	w := buildWorld(t, `
+roles:
+  a-role: {read: [incident]}
+  b-role: {read: [incident]}
+asserted_role_assignments:
+  zeta: [b-role, a-role]
+  alpha: b-role
+`, []ent{{"INC-1", "incident"}}, nil)
+
+	got, err := w.eng.WhoCan(context.Background(), acl.VerbRead, "INC-1")
+	if err != nil {
+		t.Fatalf("WhoCan: %v", err)
+	}
+	if len(got.Conditional) != 3 {
+		t.Fatalf("got %d conditional grants, want 3: %+v", len(got.Conditional), got.Conditional)
+	}
+	for i := 1; i < len(got.Conditional); i++ {
+		prev, cur := got.Conditional[i-1], got.Conditional[i]
+		if prev.Claim > cur.Claim || (prev.Claim == cur.Claim && prev.Role > cur.Role) {
+			t.Errorf("not sorted at %d: %+v then %+v", i, prev, cur)
+		}
+	}
+}

--- a/internal/aclmap/whocan.go
+++ b/internal/aclmap/whocan.go
@@ -23,6 +23,10 @@ import (
 //
 //   - Records the everyone grant once, globally, when policy grants the
 //     verb to everyone (directly or via "*").
+//   - Records any asserted-claim grants in their own Conditional section.
+//     These are NOT enumerable as principals (the holders live in the IdP,
+//     not the graph) and are deliberately not folded into the everyone
+//     grant — see [ConditionalGrant].
 //   - Enumerates the principal universe (resolvable user entities ∪
 //     assignment keys ∪ membership-relation sources ∪ role-relation
 //     sources) and, for each, asks the resolver for the routes granting
@@ -52,6 +56,15 @@ func (e *Engine) WhoCan(ctx context.Context, verb acl.Verb, entityID string) (*W
 
 	eg := e.resolver.EveryoneGrants(verb, entityType)
 	result.Everyone = Everyone{Granted: eg.Granted, Wildcard: eg.Wildcard}
+
+	// Reported in their own section, never merged into Everyone: the holders
+	// of a claim are not enumerable from the graph, so claiming they are
+	// "everyone" would be a false — and dangerously reassuring — statement.
+	for _, ag := range e.resolver.AssertedGrants(verb, entityType) {
+		result.Conditional = append(result.Conditional, ConditionalGrant{
+			Claim: ag.Claim, Role: ag.Role, Wildcard: ag.Wildcard,
+		})
+	}
 
 	candidates, err := e.enumeratePrincipals(ctx)
 	if err != nil {
@@ -168,6 +181,7 @@ func routesFromAttributions(attrs []acl.RoleAttribution) []Route {
 			Group:    a.Source.Group,
 			Ancestor: a.Source.Ancestor,
 			Relation: a.Source.Relation,
+			Claim:    a.Source.Claim,
 		})
 	}
 	sort.Slice(routes, func(i, j int) bool { return lessRoute(routes[i], routes[j]) })
@@ -187,5 +201,11 @@ func lessRoute(a, b Route) bool {
 	if a.Ancestor != b.Ancestor {
 		return a.Ancestor < b.Ancestor
 	}
-	return a.Relation < b.Relation
+	if a.Relation != b.Relation {
+		return a.Relation < b.Relation
+	}
+	// Mirrors the Claim tiebreak in acl.lessSource — without it two asserted
+	// routes differing only by claim compare equal and the artifact ordering
+	// becomes input-dependent.
+	return a.Claim < b.Claim
 }

--- a/internal/audit/audit_test.go
+++ b/internal/audit/audit_test.go
@@ -65,7 +65,7 @@ func TestRecord_JSONRoundtrip(t *testing.T) {
 			if back.Op != tt.rec.Op {
 				t.Errorf("Op round-trip: got %q want %q", back.Op, tt.rec.Op)
 			}
-			if back.Principal != tt.rec.Principal {
+			if !back.Principal.Equal(tt.rec.Principal) {
 				t.Errorf("Principal round-trip: got %+v want %+v", back.Principal, tt.rec.Principal)
 			}
 		})

--- a/internal/audit/context_test.go
+++ b/internal/audit/context_test.go
@@ -31,7 +31,7 @@ func TestPrincipalAndTriggeredBy_Orthogonal(t *testing.T) {
 	ctx := principal.With(context.Background(), original)
 	cascade := audit.WithTriggeredBy(ctx, "automation:on-create")
 
-	if got := principal.From(cascade); got != original {
+	if got := principal.From(cascade); !got.Equal(original) {
 		t.Errorf("Principal was overwritten by triggered-by wrap: got %+v, want %+v", got, original)
 	}
 	if got := audit.TriggeredByFrom(cascade); got != "automation:on-create" {

--- a/internal/audit/filesystem.go
+++ b/internal/audit/filesystem.go
@@ -201,8 +201,11 @@ func sanitize(rec Record) Record {
 	rec.Subject = sanitizeSubject(rec.Subject)
 	rec.Before = sanitizeSubject(rec.Before)
 	rec.After = sanitizeSubject(rec.After)
-	rec.Principal.User = clean(rec.Principal.User)
-	rec.Principal.Tool = clean(rec.Principal.Tool)
+	// Delegated so the verified-assertion claims (org, roles) are cleaned too —
+	// they live in unexported fields this package cannot reach. Also covers
+	// RawUser, which was previously left raw: safe by construction today (it is
+	// only ever set from an already-sanitized value) but an unpinned invariant.
+	rec.Principal = rec.Principal.Sanitized(clean)
 	rec.TriggeredBy = clean(rec.TriggeredBy)
 	rec.Summary = clean(rec.Summary)
 	return rec

--- a/internal/cli/acl_whocan.go
+++ b/internal/cli/acl_whocan.go
@@ -92,8 +92,9 @@ func (c *ACLWhoCanCmd) Run(ctx context.Context, svc *readServices) error {
 }
 
 // writeWhoCanText renders a WhoCanResult as human-readable lines: the
-// global everyone grant first (when present), then one block per
-// principal listing every route by which the verb is granted.
+// global everyone grant first (when present), then any conditional
+// (asserted-claim) grants, then one block per principal listing every
+// route by which the verb is granted.
 func writeWhoCanText(r *aclmap.WhoCanResult) {
 	if r.Everyone.Granted {
 		note := ""
@@ -103,8 +104,26 @@ func writeWhoCanText(r *aclmap.WhoCanResult) {
 		out.WriteMessage("everyone — all principals, incl. unauthenticated%s", note)
 	}
 
+	// Rendered in their own block, and never counted as principals. Whoever
+	// presents the claim gets the role, and that population lives in the IdP —
+	// so the honest report names the claim and says we cannot enumerate it.
+	if len(r.Conditional) > 0 {
+		out.WriteMessage("%d conditional grant(s) via verified assertion claims "+
+			"(holders NOT enumerable from the graph — check your identity provider):",
+			len(r.Conditional))
+		for _, c := range r.Conditional {
+			note := ""
+			if c.Wildcard {
+				note = " (via \"*\" — every type)"
+			}
+			out.WriteMessage("  claim %q → role %s%s", c.Claim, c.Role, note)
+		}
+	}
+
 	if len(r.Principals) == 0 {
-		if !r.Everyone.Granted {
+		// "No principal can ..." would be a false all-clear when a claim or the
+		// everyone role grants the verb.
+		if !r.Everyone.Granted && len(r.Conditional) == 0 {
 			out.WriteMessage("No principal can %s %s (%s).", r.Verb, r.Entity, r.EntityType)
 		}
 		return
@@ -128,6 +147,8 @@ func writeWhoCanText(r *aclmap.WhoCanResult) {
 func formatRoute(rt aclmap.Route) string {
 	parts := []string{"role " + rt.Role}
 	switch {
+	case rt.Claim != "":
+		parts = append(parts, fmt.Sprintf("asserted claim %q", rt.Claim))
 	case rt.Group != "" && rt.Ancestor != "":
 		parts = append(parts, fmt.Sprintf("group %s → %s edge on ancestor %s", rt.Group, rt.Relation, rt.Ancestor))
 	case rt.Group != "" && rt.Relation != "":

--- a/internal/dataentry/asserted_e2e_test.go
+++ b/internal/dataentry/asserted_e2e_test.go
@@ -1,0 +1,303 @@
+package dataentry
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/Sourcehaven-BV/rela/internal/acl"
+	"github.com/Sourcehaven-BV/rela/internal/entity"
+	"github.com/Sourcehaven-BV/rela/internal/principal"
+)
+
+// End-to-end: a verified assertion drives an authorization decision and lands
+// in the audit log (TKT-RP3X3Q).
+//
+// Unit tests on the resolver and on acl.computeGlobals both pass even when a
+// field is silently DROPPED between them — and there is a real dropper in the
+// path: resolvePrincipalEntity rebuilds the Principal field by field, so a
+// plain composite literal there loses org and roles while every unit test
+// stays green. These tests run the whole chain: HTTP request → resolver →
+// principal_property re-stamp → ACL decision → audit record.
+
+// e2eAssertionApp wires an App whose JWT resolver returns the given claims for
+// the token "good", with an ACL policy granting `editor` via an asserted claim.
+func e2eAssertionApp(t *testing.T, id AssertedIdentity, policy *acl.Policy) *App {
+	t.Helper()
+	app := newTestAppV1(t)
+	seedEntity(app, &entity.Entity{
+		ID: "TKT-001", Type: "ticket", Properties: map[string]any{"title": "T1"},
+	})
+
+	app.acl = mustNewACL(t, policy, app.store)
+
+	v := stubVerifier{
+		validToken: "good",
+		subject:    id.Subject,
+		orgID:      id.OrgID,
+		orgSlug:    id.OrgSlug,
+		roles:      id.Roles,
+	}
+	app.SetPrincipalResolver(ChainResolvers(JWTPrincipalResolver(v, assertionHeader)))
+	return app
+}
+
+func assertedGetTicket(t *testing.T, app *App, token string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/tickets/TKT-001", http.NoBody)
+	req.Header.Set(assertionHeader, token)
+	rec := httptest.NewRecorder()
+	app.NewRouter().ServeHTTP(rec, req)
+	return rec
+}
+
+func TestE2E_AssertedClaimAuthorizesRequest(t *testing.T) {
+	app := e2eAssertionApp(t,
+		AssertedIdentity{
+			Subject: "usr_1", OrgID: "org_acme", OrgSlug: "acme",
+			Roles: []string{"admin"},
+		},
+		&acl.Policy{
+			Roles:         map[string]acl.RoleDef{"viewer": {Read: []string{"ticket"}}},
+			AssertedRoles: map[string]acl.RoleList{"admin": {"viewer"}},
+		})
+
+	rec := assertedGetTicket(t, app, "good")
+
+	if strings.Contains(rec.Body.String(), "acl_unstamped_principal") {
+		t.Fatalf("principal was not stamped: %d %s", rec.Code, rec.Body)
+	}
+	if rec.Code != http.StatusOK {
+		t.Errorf("got %d, want 200 — the asserted claim should grant read; body=%s",
+			rec.Code, rec.Body)
+	}
+}
+
+func TestE2E_WithoutTheClaimTheRequestIsDenied(t *testing.T) {
+	// The negative half: same policy, a token whose claim maps to nothing.
+	// Without this, the test above could pass for the wrong reason (e.g. the
+	// policy accidentally granting read to everyone).
+	app := e2eAssertionApp(t,
+		AssertedIdentity{Subject: "usr_1", Roles: []string{"not-mapped"}},
+		&acl.Policy{
+			Roles:         map[string]acl.RoleDef{"viewer": {Read: []string{"ticket"}}},
+			AssertedRoles: map[string]acl.RoleList{"admin": {"viewer"}},
+		})
+
+	rec := assertedGetTicket(t, app, "good")
+
+	if rec.Code == http.StatusOK {
+		t.Errorf("got 200 for a principal holding no mapped claim; body=%s", rec.Body)
+	}
+}
+
+func TestE2E_AssertedClaimsReachTheWritePath(t *testing.T) {
+	// The Principal stamped on the request context is what the entitymanager
+	// hands to the audit sink, so asserting on it here covers the audit path
+	// without reaching into the manager's internally-wired sink.
+	app := e2eAssertionApp(t,
+		AssertedIdentity{
+			Subject: "usr_1", OrgID: "org_acme", OrgSlug: "acme",
+			Roles: []string{"admin"},
+		},
+		&acl.Policy{
+			Roles: map[string]acl.RoleDef{"editor": {
+				Read: []string{"ticket"}, Update: []string{"ticket"},
+			}},
+			AssertedRoles: map[string]acl.RoleList{"admin": {"editor"}},
+		})
+
+	req := httptest.NewRequest(http.MethodPatch, "/api/v1/tickets/TKT-001",
+		strings.NewReader(`{"properties":{"title":"updated"}}`))
+	req.Header.Set(assertionHeader, "good")
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	app.NewRouter().ServeHTTP(rec, req)
+
+	if rec.Code < 200 || rec.Code >= 300 {
+		t.Fatalf("write failed: %d %s", rec.Code, rec.Body)
+	}
+
+	got := stampedPrincipal(t, app, req)
+
+	if got.User != "usr_1" {
+		t.Errorf("User = %q, want usr_1", got.User)
+	}
+	if got.OrgID() != "org_acme" {
+		t.Errorf("OrgID = %q, want org_acme — org was dropped before the write path",
+			got.OrgID())
+	}
+	if want := []string{"admin"}; !slices.Equal(got.Roles(), want) {
+		t.Errorf("Roles = %v, want %v — roles were dropped in the chain",
+			got.Roles(), want)
+	}
+}
+
+func TestE2E_ClaimsSurvivePrincipalPropertyReStamp(t *testing.T) {
+	// The specific regression this file exists for. With principal_property
+	// enabled AND a matching entity, resolvePrincipalEntity rebuilds the
+	// Principal — replacing User with the entity ID. Everything it does not
+	// explicitly carry over is lost, silently.
+	app := newTestAppV1(t)
+	seedEntity(app, &entity.Entity{
+		ID: "TKT-001", Type: "ticket", Properties: map[string]any{"title": "T1"},
+	})
+	seedEntity(app, &entity.Entity{
+		ID: "PERS-alice", Type: "person",
+		Properties: map[string]any{"email": "alice@example.com"},
+	})
+
+	d, err := acl.NewDeclarative(
+		&acl.Policy{
+			UserEntityType:    "person",
+			PrincipalProperty: "email",
+			Roles: map[string]acl.RoleDef{"editor": {
+				Read: []string{"ticket"}, Update: []string{"ticket"},
+			}},
+			AssertedRoles: map[string]acl.RoleList{"admin": {"editor"}},
+		},
+		acl.NewStoreGraph(app.store), app.store,
+		acl.WithPrincipalLookup(acl.NewStorePrincipalLookup(app.store)),
+	)
+	if err != nil {
+		t.Fatalf("NewDeclarative: %v", err)
+	}
+	app.acl = d
+
+	// Drive the resolver + the ACL middleware, which is where the re-stamp runs,
+	// and capture the principal the downstream handler would see.
+	verified := principal.Verified("alice@example.com", principal.ToolDataEntry,
+		"org_acme", "", []string{"admin"})
+
+	var got principal.Principal
+	handler := attachACLRequest(
+		http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+			got = principal.From(r.Context())
+		}), d)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/tickets/TKT-001", http.NoBody)
+	handler.ServeHTTP(httptest.NewRecorder(),
+		req.WithContext(principal.With(req.Context(), verified)))
+
+	// The re-stamp happened: User is now the entity ID, RawUser the email.
+	if got.User != "PERS-alice" {
+		t.Fatalf("User = %q, want the resolved entity ID PERS-alice — the re-stamp "+
+			"did not run, so this test is not exercising the drop path", got.User)
+	}
+	if got.RawUser != "alice@example.com" {
+		t.Errorf("RawUser = %q, want the pre-resolution email", got.RawUser)
+	}
+	// ...and the assertion claims survived it.
+	if want := []string{"admin"}; !slices.Equal(got.Roles(), want) {
+		t.Errorf("Roles = %v, want %v — resolvePrincipalEntity dropped the claims "+
+			"when it rebuilt the Principal", got.Roles(), want)
+	}
+	if got.OrgID() != "org_acme" {
+		t.Errorf("OrgID = %q, want org_acme — dropped by the re-stamp", got.OrgID())
+	}
+}
+
+func TestE2E_ForgedAssertionGrantsNothing(t *testing.T) {
+	// A token the verifier rejects must fall through to the unstamped default,
+	// carrying no claims — not authorize with the claims it merely asserted.
+	app := e2eAssertionApp(t,
+		AssertedIdentity{Subject: "usr_1", Roles: []string{"admin"}},
+		&acl.Policy{
+			Roles:         map[string]acl.RoleDef{"viewer": {Read: []string{"ticket"}}},
+			AssertedRoles: map[string]acl.RoleList{"admin": {"viewer"}},
+		})
+
+	rec := assertedGetTicket(t, app, "forged")
+
+	if rec.Code == http.StatusOK {
+		t.Errorf("a forged token authorized the request: %d %s", rec.Code, rec.Body)
+	}
+}
+
+func TestE2E_UnmatchedPrincipalStillCarriesClaims(t *testing.T) {
+	// AC10 end-to-end: principal_property is enabled but NO person entity
+	// matches. The request must still succeed on its asserted role — this is
+	// the SSO-provisioned user's very first request.
+	app := newTestAppV1(t)
+	seedEntity(app, &entity.Entity{
+		ID: "TKT-001", Type: "ticket", Properties: map[string]any{"title": "T1"},
+	})
+
+	d, err := acl.NewDeclarative(
+		&acl.Policy{
+			UserEntityType:    "person",
+			PrincipalProperty: "email",
+			Roles:             map[string]acl.RoleDef{"viewer": {Read: []string{"ticket"}}},
+			AssertedRoles:     map[string]acl.RoleList{"admin": {"viewer"}},
+		},
+		acl.NewStoreGraph(app.store), app.store,
+		acl.WithPrincipalLookup(acl.NewStorePrincipalLookup(app.store)),
+	)
+	if err != nil {
+		t.Fatalf("NewDeclarative: %v", err)
+	}
+	app.acl = d
+
+	v := stubVerifier{
+		validToken: "good",
+		subject:    "newcomer@example.com", // no matching person entity
+		roles:      []string{"admin"},
+	}
+	app.SetPrincipalResolver(ChainResolvers(JWTPrincipalResolver(v, assertionHeader)))
+
+	rec := assertedGetTicket(t, app, "good")
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("got %d, want 200 — a verified principal with no user entity must "+
+			"keep its asserted grants (TKT-0C3II2 tracks provisioning); body=%s",
+			rec.Code, rec.Body)
+	}
+}
+
+// TestE2E_HeaderModeUnaffected pins AC3 at the integration level: with the JWT
+// resolver disabled and a plain trusted header, behavior is exactly as before
+// this feature — and no roles appear anywhere.
+func TestE2E_HeaderModeUnaffected(t *testing.T) {
+	app := newTestAppV1(t)
+	seedEntity(app, &entity.Entity{
+		ID: "TKT-001", Type: "ticket", Properties: map[string]any{"title": "T1"},
+	})
+	app.acl = mustNewACL(t, &acl.Policy{
+		Roles:       map[string]acl.RoleDef{"viewer": {Read: []string{"ticket"}}},
+		Assignments: map[string]string{"alice": "viewer"},
+	}, app.store)
+	app.SetPrincipalResolver(ChainResolvers(HeaderPrincipalResolver("X-Forwarded-User")))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/tickets/TKT-001", http.NoBody)
+	req.Header.Set("X-Forwarded-User", "alice")
+	// A header that looks like a roles claim must be inert.
+	req.Header.Set("X-Asserted-Roles", "superuser")
+	rec := httptest.NewRecorder()
+	app.NewRouter().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("header mode broke: %d %s", rec.Code, rec.Body)
+	}
+
+	p := stampedPrincipal(t, app, req)
+	if len(p.Roles()) != 0 {
+		t.Errorf("header-mode principal carried roles %v", p.Roles())
+	}
+}
+
+// stampedPrincipal runs just the resolver chain for req and returns the
+// Principal it stamps, so a test can inspect it directly.
+func stampedPrincipal(t *testing.T, app *App, req *http.Request) principal.Principal {
+	t.Helper()
+	var got principal.Principal
+	h := stampAuditPrincipal(
+		http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+			got = principal.From(r.Context())
+		}),
+		app.principalResolver,
+	)
+	h.ServeHTTP(httptest.NewRecorder(), req)
+	return got
+}

--- a/internal/dataentry/asserted_identity_test.go
+++ b/internal/dataentry/asserted_identity_test.go
@@ -181,6 +181,30 @@ func TestNonJWTResolvers_CannotSetAssertedClaims(t *testing.T) {
 	}
 }
 
+func TestNonJWTResolvers_ResolvePrincipalEntityIsTheOnlyOtherVerifiedCaller(t *testing.T) {
+	// resolvePrincipalEntity legitimately calls principal.Verified — it rebuilds
+	// the Principal when principal_property substitutes a graph entity ID. That
+	// makes it the one non-resolver path that can carry roles, so it is worth
+	// pinning that it only ever PROPAGATES claims it was given, never invents
+	// them. A principal that arrives with no roles must leave with none.
+	//
+	// The propagation direction (claims survive) is covered end-to-end by
+	// TestE2E_ClaimsSurvivePrincipalPropertyReStamp.
+	plain := principal.Principal{User: "alice", Tool: principal.ToolDataEntry}
+	if len(plain.Roles()) != 0 {
+		t.Fatal("precondition: a plain Principal already has roles")
+	}
+	// The shape resolvePrincipalEntity builds when the incoming principal has
+	// no claims: Verified with the resolved ID and whatever the original had.
+	p := principal.Verified("PERS-alice", plain.Tool, plain.OrgID(), plain.OrgSlug(), plain.Roles())
+	if len(p.Roles()) != 0 {
+		t.Errorf("rebuilding a role-less principal invented roles: %v", p.Roles())
+	}
+	if p.OrgID() != "" {
+		t.Errorf("rebuilding a principal with no org invented one: %q", p.OrgID())
+	}
+}
+
 func TestChainResolvers_JWTClaimsSurviveTheChain(t *testing.T) {
 	// The JWT resolver sits mid-chain (env → JWT → header → default). Verify the
 	// claims are not flattened by ChainResolvers on the way out.

--- a/internal/dataentry/asserted_identity_test.go
+++ b/internal/dataentry/asserted_identity_test.go
@@ -1,0 +1,228 @@
+package dataentry
+
+import (
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/Sourcehaven-BV/rela/internal/principal"
+)
+
+// Verified-assertion claims on the resolved Principal (TKT-RP3X3Q).
+
+const assertionHeader = "X-Auth-Assertion"
+
+func TestJWTPrincipalResolver_CarriesOrgAndRoles(t *testing.T) {
+	v := stubVerifier{
+		validToken: "good.jwt.token",
+		subject:    "usr_abc123",
+		orgID:      "org_acme",
+		orgSlug:    "acme",
+		roles:      []string{"admin", "billing"},
+	}
+	got := runResolver(t,
+		ChainResolvers(JWTPrincipalResolver(v, assertionHeader)),
+		map[string]string{assertionHeader: "good.jwt.token"})
+
+	if got.User != "usr_abc123" {
+		t.Errorf("User = %q, want the verified subject", got.User)
+	}
+	if got.OrgID() != "org_acme" {
+		t.Errorf("OrgID = %q, want %q", got.OrgID(), "org_acme")
+	}
+	if got.OrgSlug() != "acme" {
+		t.Errorf("OrgSlug = %q, want %q", got.OrgSlug(), "acme")
+	}
+	if want := []string{"admin", "billing"}; !slices.Equal(got.Roles(), want) {
+		t.Errorf("Roles = %v, want %v", got.Roles(), want)
+	}
+}
+
+func TestJWTPrincipalResolver_AbsentClaimsAreNotAnError(t *testing.T) {
+	// AC2. Pratique always sends org/roles, but a different OIDC proxy may not.
+	// An assertion carrying only a subject must still authenticate.
+	for _, tc := range []struct {
+		name  string
+		stub  stubVerifier
+		roles []string
+	}{
+		{"no claims at all", stubVerifier{validToken: "t", subject: "usr_1"}, nil},
+		{
+			"empty roles slice",
+			stubVerifier{validToken: "t", subject: "usr_1", roles: []string{}},
+			nil,
+		},
+		{
+			"org without roles",
+			stubVerifier{validToken: "t", subject: "usr_1", orgID: "org_a"},
+			nil,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := runResolver(t,
+				ChainResolvers(JWTPrincipalResolver(tc.stub, assertionHeader)),
+				map[string]string{assertionHeader: "t"})
+
+			if got.User != "usr_1" {
+				t.Errorf("User = %q, want the principal to still resolve", got.User)
+			}
+			if !slices.Equal(got.Roles(), tc.roles) {
+				t.Errorf("Roles = %v, want %v", got.Roles(), tc.roles)
+			}
+		})
+	}
+}
+
+func TestJWTPrincipalResolver_SanitizesClaims(t *testing.T) {
+	v := stubVerifier{
+		validToken: "t",
+		subject:    "usr_1",
+		orgID:      "org\x00bad",
+		roles:      []string{"ad\x00min", "\x00\x00", "ok"},
+	}
+	got := runResolver(t,
+		ChainResolvers(JWTPrincipalResolver(v, assertionHeader)),
+		map[string]string{assertionHeader: "t"})
+
+	if strings.ContainsRune(got.OrgID(), 0) {
+		t.Errorf("OrgID kept a control char: %q", got.OrgID())
+	}
+	for _, role := range got.Roles() {
+		if strings.ContainsRune(role, 0) {
+			t.Errorf("role kept a control char: %q", role)
+		}
+		if role == "" {
+			t.Error("an empty role survived sanitization; it can never match a " +
+				"policy mapping and only pads the attribution set")
+		}
+	}
+	// "\x00\x00" sanitizes to empty and is dropped; the other two survive.
+	if len(got.Roles()) != 2 {
+		t.Errorf("Roles = %v, want 2 surviving entries", got.Roles())
+	}
+}
+
+func TestJWTPrincipalResolver_InvalidTokenCarriesNoClaims(t *testing.T) {
+	// Verification failure must yield a zero Principal — never a principal that
+	// kept the claims from an unverified token.
+	v := stubVerifier{
+		validToken: "good.jwt.token",
+		subject:    "usr_1",
+		orgID:      "org_a",
+		roles:      []string{"admin"},
+	}
+	got := runResolver(t,
+		ChainResolvers(JWTPrincipalResolver(v, assertionHeader)),
+		map[string]string{assertionHeader: "forged.jwt.token"})
+
+	if len(got.Roles()) != 0 {
+		t.Errorf("roles survived a failed verification: %v", got.Roles())
+	}
+	if got.OrgID() != "" {
+		t.Errorf("org survived a failed verification: %q", got.OrgID())
+	}
+}
+
+// TestNonJWTResolvers_CannotSetAssertedClaims is the trust-boundary regression
+// guard, and the most important test in this file.
+//
+// ChainResolvers advances on p.User != "" and ignores every other field, so
+// nothing about the chain's shape prevents a resolver from returning a
+// role-bearing Principal. internal/acl trusts Principal absolutely — it
+// verifies nothing itself — so a role sourced from a spoofable header would be
+// a complete authorization bypass.
+//
+// The unexported fields on principal.Principal make that impossible to express
+// (only principal.Verified can populate them), which is why this test cannot
+// be written as "assert the header resolver doesn't set roles" in a way that
+// would ever fail. It is here to fail LOUDLY if someone later exports those
+// fields or hands a second resolver a Verified constructor.
+func TestNonJWTResolvers_CannotSetAssertedClaims(t *testing.T) {
+	t.Setenv(envDataEntryUser, "env-user")
+
+	for _, tc := range []struct {
+		name     string
+		resolver PrincipalResolver
+		headers  map[string]string
+	}{
+		{
+			"header resolver",
+			HeaderPrincipalResolver("X-Forwarded-User"),
+			map[string]string{"X-Forwarded-User": "alice@example.com"},
+		},
+		{"env resolver", EnvPrincipalResolver(), nil},
+		{"default resolver", defaultPrincipalResolver, nil},
+		{
+			// A header that merely LOOKS like a roles claim must do nothing.
+			"roles-shaped header is inert",
+			HeaderPrincipalResolver("X-Forwarded-User"),
+			map[string]string{
+				"X-Forwarded-User": "alice@example.com",
+				"X-Asserted-Roles": "admin,superuser",
+				"X-Roles":          "admin",
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := runResolver(t, ChainResolvers(tc.resolver), tc.headers)
+
+			if got.User == "" {
+				t.Fatal("resolver produced no principal; test is not exercising it")
+			}
+			if len(got.Roles()) != 0 {
+				t.Errorf("non-JWT resolver produced asserted roles %v — this is an "+
+					"authorization bypass", got.Roles())
+			}
+			if got.OrgID() != "" || got.OrgSlug() != "" {
+				t.Errorf("non-JWT resolver produced org claims (%q/%q)",
+					got.OrgID(), got.OrgSlug())
+			}
+		})
+	}
+}
+
+func TestChainResolvers_JWTClaimsSurviveTheChain(t *testing.T) {
+	// The JWT resolver sits mid-chain (env → JWT → header → default). Verify the
+	// claims are not flattened by ChainResolvers on the way out.
+	v := stubVerifier{
+		validToken: "t", subject: "usr_1",
+		orgID: "org_a", roles: []string{"admin"},
+	}
+	got := runResolver(t,
+		ChainResolvers(
+			EnvPrincipalResolver(), // inert: env unset
+			JWTPrincipalResolver(v, assertionHeader),
+			HeaderPrincipalResolver("X-Forwarded-User"),
+		),
+		map[string]string{
+			assertionHeader:    "t",
+			"X-Forwarded-User": "should-not-win@example.com",
+		})
+
+	if got.User != "usr_1" {
+		t.Errorf("User = %q, want the JWT subject to win over the header", got.User)
+	}
+	if want := []string{"admin"}; !slices.Equal(got.Roles(), want) {
+		t.Errorf("Roles = %v, want %v — claims lost crossing ChainResolvers", got.Roles(), want)
+	}
+}
+
+func TestPrincipalVerified_RolesAreDefensivelyCopied(t *testing.T) {
+	// A caller mutating its slice after construction must not retroactively
+	// change an authorization decision.
+	roles := []string{"admin"}
+	p := principal.Verified("usr_1", principal.ToolDataEntry, "org", "slug", roles)
+
+	roles[0] = "superuser"
+
+	if got := p.Roles(); got[0] != "admin" {
+		t.Errorf("Roles = %v, want the value at construction time", got)
+	}
+
+	// The accessor's return must be a copy too.
+	out := p.Roles()
+	out[0] = "superuser"
+	if got := p.Roles(); got[0] != "admin" {
+		t.Errorf("mutating the accessor's result changed the principal: %v", got)
+	}
+}

--- a/internal/dataentry/jwt_principal_test.go
+++ b/internal/dataentry/jwt_principal_test.go
@@ -8,19 +8,27 @@ import (
 	"github.com/Sourcehaven-BV/rela/internal/principal"
 )
 
-// stubVerifier is a SubjectVerifier that returns a fixed subject for a known
+// stubVerifier is an assertionVerifier that returns fixed claims for a known
 // token and an error otherwise — lets the resolver's behavior be tested without
 // real crypto (the crypto is covered in internal/jwtauth).
 type stubVerifier struct {
 	validToken string
 	subject    string
+	orgID      string
+	orgSlug    string
+	roles      []string
 }
 
-func (s stubVerifier) VerifySubject(_ context.Context, raw string) (string, error) {
-	if raw == s.validToken {
-		return s.subject, nil
+func (s stubVerifier) VerifyAssertion(_ context.Context, raw string) (AssertedIdentity, error) {
+	if raw != s.validToken {
+		return AssertedIdentity{}, errors.New("invalid")
 	}
-	return "", errors.New("invalid")
+	return AssertedIdentity{
+		Subject: s.subject,
+		OrgID:   s.orgID,
+		OrgSlug: s.orgSlug,
+		Roles:   s.roles,
+	}, nil
 }
 
 func TestJWTPrincipalResolver_VerifiedSubjectBecomesUser(t *testing.T) {

--- a/internal/dataentry/router.go
+++ b/internal/dataentry/router.go
@@ -182,7 +182,7 @@ func attachACLRequest(next http.Handler, d *acl.Declarative) http.Handler {
 			// a Request built from a *resolved* principal while ctx still
 			// holds the raw one, this correctly 500s as a genuine mismatch.
 			ctxPrin := principal.From(ctx)
-			if existing.Principal() != ctxPrin {
+			if !existing.Principal().Equal(ctxPrin) {
 				slog.Warn("acl: attachACLRequest: existing Request principal mismatch",
 					"path", r.URL.Path,
 					"method", r.Method,
@@ -277,7 +277,12 @@ func resolvePrincipalEntity(ctx context.Context, d *acl.Declarative, r *http.Req
 	if id == "" || id == p.User {
 		return ctx
 	}
-	return principal.With(ctx, principal.Principal{User: id, Tool: p.Tool, RawUser: p.User})
+	// Rebuild via Verified so the assertion claims survive the substitution.
+	// A plain composite literal here would silently drop org and roles — the
+	// resolved principal would keep its identity but lose every asserted grant.
+	out := principal.Verified(id, p.Tool, p.OrgID(), p.OrgSlug(), p.Roles())
+	out.RawUser = p.User
+	return principal.With(ctx, out)
 }
 
 // PrincipalResolver maps an incoming HTTP request to the audit
@@ -355,12 +360,27 @@ func EnvPrincipalResolver() PrincipalResolver {
 	}
 }
 
-// subjectVerifier verifies a signed identity assertion and returns its subject
-// (the stable OIDC `sub`). Satisfied by *jwtauth.Verifier; kept local (and
-// unexported, per the other consumer interfaces here) so the dataentry package
-// doesn't import the concrete verifier and the resolver is testable with a stub.
-type subjectVerifier interface {
-	VerifySubject(ctx context.Context, raw string) (string, error)
+// AssertedIdentity is the verified-assertion payload this package consumes. It
+// is dataentry's OWN type, not the verifier's: the wiring site adapts whatever
+// the concrete verifier returns into this shape (see the adapter in
+// cmd/rela-server), so dataentry never imports the verifier package and the
+// verifier stays an arch-lint leaf.
+//
+// Subject is the only field callers may treat as required. The rest are absent
+// for any proxy that doesn't model orgs or roles, which is not an error.
+type AssertedIdentity struct {
+	Subject string
+	OrgID   string
+	OrgSlug string
+	Roles   []string
+}
+
+// assertionVerifier verifies a signed identity assertion and projects the
+// claims this package stamps onto a Principal. Satisfied by an adapter over
+// *jwtauth.Verifier; kept local (and unexported, per the other consumer
+// interfaces here) so the resolver is testable with a stub.
+type assertionVerifier interface {
+	VerifyAssertion(ctx context.Context, raw string) (AssertedIdentity, error)
 }
 
 // JWTPrincipalResolver reads a signed identity assertion from headerName,
@@ -376,12 +396,18 @@ type subjectVerifier interface {
 // Tool is [principal.ToolDataEntry]: the assertion changes WHO authenticated, not
 // the entry point (a verified user still arrives via the data-entry HTTP surface).
 //
+// It also carries the assertion's org and role claims onto the Principal via
+// [principal.Verified]. This is the ONLY resolver that may do so — the header
+// and env resolvers have no verified source for them, and a role reaching the
+// ACL from a spoofable header would be a complete authorization bypass. The
+// unexported fields on Principal make that structural rather than a convention.
+//
 // A missing header, an "Authorization: Bearer <jwt>" wrapper (the scheme is
 // stripped case-insensitively per RFC 6750), or any verification failure yields a
 // zero Principal so the chain falls through — a nil v also yields an inert
 // resolver. Empty headerName ⇒ inert (matches the disabled-flag shape of the
 // other resolvers).
-func JWTPrincipalResolver(v subjectVerifier, headerName string) PrincipalResolver {
+func JWTPrincipalResolver(v assertionVerifier, headerName string) PrincipalResolver {
 	if v == nil || headerName == "" {
 		return func(*http.Request) principal.Principal { return principal.Principal{} }
 	}
@@ -390,19 +416,32 @@ func JWTPrincipalResolver(v subjectVerifier, headerName string) PrincipalResolve
 		if raw == "" {
 			return principal.Principal{}
 		}
-		sub, err := v.VerifySubject(r.Context(), raw)
-		if err != nil || sub == "" {
+		id, err := v.VerifyAssertion(r.Context(), raw)
+		if err != nil || id.Subject == "" {
 			return principal.Principal{}
 		}
 		// The subject is a controlled id (opaque, from the IdP), but sanitize it
 		// the same way as header/env users for defense in depth (length cap,
 		// control-char strip). A control-only value sanitizes to "" and falls
 		// through.
-		user := sanitizeUser(sub)
+		user := sanitizeUser(id.Subject)
 		if user == "" {
 			return principal.Principal{}
 		}
-		return principal.Principal{User: user, Tool: principal.ToolDataEntry}
+		// Org and roles get the same treatment. Roles are already bounded by the
+		// verifier's projection; sanitizing here covers control chars and any
+		// future verifier that forgets to. A role that sanitizes away is dropped
+		// rather than kept as "" — an empty role name can never match a policy
+		// mapping, so keeping it would only pad the attribution set.
+		roles := make([]string, 0, len(id.Roles))
+		for _, role := range id.Roles {
+			if s := sanitizeUser(role); s != "" {
+				roles = append(roles, s)
+			}
+		}
+		return principal.Verified(
+			user, principal.ToolDataEntry,
+			sanitizeUser(id.OrgID), sanitizeUser(id.OrgSlug), roles)
 	}
 }
 

--- a/internal/jwtauth/assertion_test.go
+++ b/internal/jwtauth/assertion_test.go
@@ -1,0 +1,284 @@
+package jwtauth
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"errors"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+)
+
+// VerifyAssertion — the widened identity projection (TKT-RP3X3Q).
+//
+// The claim shapes here mirror what Pratique actually mints (see
+// pratique/internal/signer/signer.go): org_id and org_slug are strings, roles
+// is an array of bare strings, and every one of them is always present.
+
+// jsonNull marks an override that should set a claim to an explicit JSON null,
+// as distinct from deleting the key. A plain nil in the override map deletes.
+var jsonNull = struct{}{}
+
+// assertionClaims builds a valid claim set, with overrides applied on top.
+func assertionClaims(over map[string]any) jwt.MapClaims {
+	c := jwt.MapClaims{
+		"iss":      testIss,
+		"aud":      testAud,
+		"sub":      "usr_abc123",
+		"email":    "alice@example.com",
+		"org_id":   "org_acme",
+		"org_slug": "acme",
+		"roles":    []any{"admin", "billing"},
+		"exp":      time.Now().Add(time.Hour).Unix(),
+		"iat":      time.Now().Unix(),
+	}
+	for k, v := range over {
+		switch v {
+		case nil:
+			delete(c, k)
+		case any(jsonNull):
+			c[k] = nil // serializes as an explicit JSON null
+		default:
+			c[k] = v
+		}
+	}
+	return c
+}
+
+func TestVerifyAssertion_ProjectsAllClaims(t *testing.T) {
+	v, mint, srv := testIssuer(t)
+	defer srv.Close()
+
+	got, err := v.VerifyAssertion(context.Background(), mint(assertionClaims(nil)))
+	if err != nil {
+		t.Fatalf("VerifyAssertion: %v", err)
+	}
+
+	if got.Subject != "usr_abc123" {
+		t.Errorf("Subject = %q, want usr_abc123", got.Subject)
+	}
+	if got.Email != "alice@example.com" {
+		t.Errorf("Email = %q", got.Email)
+	}
+	if got.OrgID != "org_acme" {
+		t.Errorf("OrgID = %q, want org_acme", got.OrgID)
+	}
+	if got.OrgSlug != "acme" {
+		t.Errorf("OrgSlug = %q, want acme", got.OrgSlug)
+	}
+	if want := []string{"admin", "billing"}; !slices.Equal(got.Roles, want) {
+		t.Errorf("Roles = %v, want %v", got.Roles, want)
+	}
+}
+
+func TestVerifyAssertion_AbsentClaimsAreNotAnError(t *testing.T) {
+	v, mint, srv := testIssuer(t)
+	defer srv.Close()
+
+	for _, tc := range []struct {
+		name      string
+		over      map[string]any
+		wantRoles []string
+		wantOrg   string
+	}{
+		{"no roles key", map[string]any{"roles": nil}, nil, "org_acme"},
+		{"empty roles array", map[string]any{"roles": []any{}}, nil, "org_acme"},
+		{"explicit null roles", map[string]any{"roles": jsonNull}, nil, "org_acme"},
+		{
+			"no org",
+			map[string]any{"org_id": nil, "org_slug": nil},
+			[]string{"admin", "billing"}, "",
+		},
+		{
+			"subject only",
+			map[string]any{"email": nil, "org_id": nil, "org_slug": nil, "roles": nil},
+			nil, "",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := v.VerifyAssertion(context.Background(), mint(assertionClaims(tc.over)))
+			if err != nil {
+				t.Fatalf("VerifyAssertion: %v", err)
+			}
+			if got.Subject != "usr_abc123" {
+				t.Errorf("Subject = %q, want the assertion to still verify", got.Subject)
+			}
+			if !slices.Equal(got.Roles, tc.wantRoles) {
+				t.Errorf("Roles = %v, want %v", got.Roles, tc.wantRoles)
+			}
+			if got.OrgID != tc.wantOrg {
+				t.Errorf("OrgID = %q, want %q", got.OrgID, tc.wantOrg)
+			}
+		})
+	}
+}
+
+func TestVerifyAssertion_MalformedClaimsAreTreatedAsAbsent(t *testing.T) {
+	v, mint, srv := testIssuer(t)
+	defer srv.Close()
+
+	for _, tc := range []struct {
+		name      string
+		over      map[string]any
+		wantRoles []string
+	}{
+		{"roles is a string, not an array", map[string]any{"roles": "admin"}, nil},
+		{"roles is an object", map[string]any{"roles": map[string]any{"a": 1}}, nil},
+		{
+			"non-string elements are skipped",
+			map[string]any{"roles": []any{"admin", 42, nil, "billing"}},
+			[]string{"admin", "billing"},
+		},
+		{"org_id is a number", map[string]any{"org_id": 42}, nil},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := v.VerifyAssertion(context.Background(), mint(assertionClaims(tc.over)))
+			if err != nil {
+				t.Fatalf("a malformed claim must not fail an otherwise valid assertion: %v", err)
+			}
+			if tc.wantRoles != nil && !slices.Equal(got.Roles, tc.wantRoles) {
+				t.Errorf("Roles = %v, want %v", got.Roles, tc.wantRoles)
+			}
+		})
+	}
+}
+
+func TestVerifyAssertion_BoundsRoles(t *testing.T) {
+	v, mint, srv := testIssuer(t)
+	defer srv.Close()
+
+	// A verified signature proves the IdP asserted these values, not that they
+	// are small. Without a cap, one request becomes N attribution entries and a
+	// proportionally huge audit line.
+	many := make([]any, 0, maxRoles*3)
+	for range maxRoles * 3 {
+		many = append(many, "role")
+	}
+	got, err := v.VerifyAssertion(context.Background(),
+		mint(assertionClaims(map[string]any{"roles": many})))
+	if err != nil {
+		t.Fatalf("VerifyAssertion: %v", err)
+	}
+	if len(got.Roles) > maxRoles {
+		t.Errorf("len(Roles) = %d, want <= %d", len(got.Roles), maxRoles)
+	}
+
+	// Per-element length is capped too.
+	long := strings.Repeat("x", maxRoleRunes*3)
+	got, err = v.VerifyAssertion(context.Background(),
+		mint(assertionClaims(map[string]any{"roles": []any{long}})))
+	if err != nil {
+		t.Fatalf("VerifyAssertion: %v", err)
+	}
+	if n := len([]rune(got.Roles[0])); n > maxRoleRunes {
+		t.Errorf("role length = %d runes, want <= %d", n, maxRoleRunes)
+	}
+}
+
+func TestVerifyAssertion_MultibyteRoleNotSplit(t *testing.T) {
+	v, mint, srv := testIssuer(t)
+	defer srv.Close()
+
+	// Truncation must not slice a multi-byte character in half.
+	role := strings.Repeat("é", maxRoleRunes*2)
+	got, err := v.VerifyAssertion(context.Background(),
+		mint(assertionClaims(map[string]any{"roles": []any{role}})))
+	if err != nil {
+		t.Fatalf("VerifyAssertion: %v", err)
+	}
+	if !strings.HasPrefix(role, got.Roles[0]) {
+		t.Error("truncation split a multi-byte rune")
+	}
+}
+
+func TestVerifyAssertion_RejectsInvalid(t *testing.T) {
+	v, mint, srv := testIssuer(t)
+	defer srv.Close()
+
+	// The security property: claims are projected ONLY from a token that passed
+	// every verification step. Each case must yield ErrInvalid and zero claims.
+	forged, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	mintForged := func(c jwt.MapClaims) string {
+		tok := jwt.NewWithClaims(jwt.SigningMethodES256, c)
+		tok.Header["kid"] = "test-key-1"
+		s, sErr := tok.SignedString(forged)
+		if sErr != nil {
+			t.Fatal(sErr)
+		}
+		return s
+	}
+	mintNone := func(c jwt.MapClaims) string {
+		tok := jwt.NewWithClaims(jwt.SigningMethodNone, c)
+		s, sErr := tok.SignedString(jwt.UnsafeAllowNoneSignatureType)
+		if sErr != nil {
+			t.Fatal(sErr)
+		}
+		return s
+	}
+
+	for _, tc := range []struct {
+		name  string
+		token string
+	}{
+		{"forged key", mintForged(assertionClaims(nil))},
+		{"alg none", mintNone(assertionClaims(nil))},
+		{"wrong issuer", mint(assertionClaims(map[string]any{"iss": "https://evil.test"}))},
+		{"wrong audience", mint(assertionClaims(map[string]any{"aud": "someone-else"}))},
+		{"expired", mint(assertionClaims(map[string]any{
+			"exp": time.Now().Add(-time.Hour).Unix(),
+		}))},
+		{"no expiry", mint(assertionClaims(map[string]any{"exp": nil}))},
+		{"empty subject", mint(assertionClaims(map[string]any{"sub": ""}))},
+		{"no subject", mint(assertionClaims(map[string]any{"sub": nil}))},
+		{"garbage", "not.a.jwt"},
+		{"empty", ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := v.VerifyAssertion(context.Background(), tc.token)
+			if !errors.Is(err, ErrInvalid) {
+				t.Errorf("err = %v, want ErrInvalid", err)
+			}
+			if got.Subject != "" || got.OrgID != "" || len(got.Roles) != 0 {
+				t.Errorf("claims leaked from an unverified token: %+v", got)
+			}
+		})
+	}
+}
+
+func TestVerifyAssertion_MatchesVerifySubject(t *testing.T) {
+	v, mint, srv := testIssuer(t)
+	defer srv.Close()
+
+	// VerifyAssertion widens VerifySubject rather than replacing it; the two
+	// must agree on identity and on what they reject.
+	for _, tc := range []struct {
+		name  string
+		token string
+	}{
+		{"valid", mint(assertionClaims(nil))},
+		{"expired", mint(assertionClaims(map[string]any{
+			"exp": time.Now().Add(-time.Hour).Unix(),
+		}))},
+		{"garbage", "not.a.jwt"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			sub, subErr := v.VerifySubject(context.Background(), tc.token)
+			got, asrErr := v.VerifyAssertion(context.Background(), tc.token)
+
+			if (subErr == nil) != (asrErr == nil) {
+				t.Errorf("disagreement: VerifySubject err=%v, VerifyAssertion err=%v", subErr, asrErr)
+			}
+			if got.Subject != sub {
+				t.Errorf("Subject = %q, VerifySubject = %q", got.Subject, sub)
+			}
+		})
+	}
+}

--- a/internal/jwtauth/verifier.go
+++ b/internal/jwtauth/verifier.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"net/url"
 	"strings"
 	"time"
@@ -98,6 +99,60 @@ func (v *Verifier) VerifySubject(ctx context.Context, raw string) (string, error
 	return sub, nil
 }
 
+// AssertionClaims is the subset of a verified identity assertion the principal
+// resolver acts on. Like [WebhookClaims] it is a typed projection — the package
+// never leaks jwt.MapClaims across its boundary — so a caller can't accidentally
+// trust an unverified claim.
+//
+// Subject is the only field callers should treat as required; the rest come back
+// zero when absent. An assertion from an OIDC proxy that doesn't model orgs or
+// roles is still perfectly valid, so a missing claim is not an error.
+type AssertionClaims struct {
+	Subject string   // the "sub" claim — the stable identity anchor
+	Email   string   // the "email" claim, if present
+	OrgID   string   // the "org_id" claim — the tenant the session is scoped to
+	OrgSlug string   // the "org_slug" claim — human-readable tenant name
+	Roles   []string // the "roles" claim — bare role names, scoped to OrgID
+}
+
+// Claim-projection bounds. A verified signature proves the IdP asserted these
+// values, NOT that they are small: a buggy or compromised IdP, or a user with
+// pathological group membership, can mint an assertion with thousands of roles.
+// Every downstream consumer would then pay per-role costs on every request
+// (attribution slices, audit-log lines). Bounding here rather than at a call
+// site means each future consumer inherits the limit instead of re-deriving it.
+const (
+	maxRoles     = 32
+	maxRoleRunes = 256
+)
+
+// VerifyAssertion verifies a request assertion and projects the identity claims
+// the principal resolver needs. Any signature/issuer/audience/expiry failure, or
+// an empty subject, yields ErrInvalid — identical to [VerifySubject], which this
+// widens rather than replaces.
+//
+// Absent org/role claims are NOT an error (see [AssertionClaims]). Roles are
+// bounded per the constants above; a non-string element is skipped rather than
+// failing the request, matching stringClaim's treatment of a malformed claim as
+// an absent one.
+func (v *Verifier) VerifyAssertion(ctx context.Context, raw string) (AssertionClaims, error) {
+	claims := jwt.MapClaims{}
+	if _, err := jwt.NewParser(v.opts...).ParseWithClaims(raw, claims, v.kf.KeyfuncCtx(ctx)); err != nil {
+		return AssertionClaims{}, fmt.Errorf("%w: %w", ErrInvalid, err)
+	}
+	sub, err := claims.GetSubject()
+	if err != nil || sub == "" {
+		return AssertionClaims{}, ErrInvalid
+	}
+	return AssertionClaims{
+		Subject: sub,
+		Email:   stringClaim(claims, "email"),
+		OrgID:   stringClaim(claims, "org_id"),
+		OrgSlug: stringClaim(claims, "org_slug"),
+		Roles:   stringSliceClaim(claims, "roles"),
+	}, nil
+}
+
 // WebhookClaims is the subset of a verified webhook JWT the receiver acts on.
 // It is a typed projection — the package never leaks jwt.MapClaims across its
 // boundary — so a caller can't accidentally trust an unverified claim.
@@ -169,6 +224,55 @@ func stringClaim(claims jwt.MapClaims, key string) string {
 		return v
 	}
 	return ""
+}
+
+// stringSliceClaim reads a string-array claim, returning nil when absent, null,
+// or not an array. Non-string elements are skipped for the same reason
+// stringClaim treats a non-string as absent: a malformed element is
+// indistinguishable from one the IdP never sent, and dropping it is strictly
+// safer than failing a request that is otherwise correctly signed.
+//
+// The result is bounded by maxRoles/maxRoleRunes; excess is dropped with a
+// single warn rather than silently, so an operator can see truncation happened
+// without the log itself becoming the amplification.
+func stringSliceClaim(claims jwt.MapClaims, key string) []string {
+	raw, ok := claims[key].([]any)
+	if !ok {
+		return nil
+	}
+	out := make([]string, 0, min(len(raw), maxRoles))
+	truncated := false
+	for _, elem := range raw {
+		s, ok := elem.(string)
+		if !ok {
+			continue
+		}
+		if len(out) >= maxRoles {
+			truncated = true
+			break
+		}
+		out = append(out, truncateRunes(s, maxRoleRunes))
+	}
+	if truncated {
+		slog.Warn("jwtauth: claim truncated",
+			"claim", key, "limit", maxRoles, "received", len(raw))
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// truncateRunes caps s at n runes, never splitting a multi-byte character.
+func truncateRunes(s string, n int) string {
+	if len(s) <= n { // len is bytes; runes <= bytes, so this is a safe fast path
+		return s
+	}
+	r := []rune(s)
+	if len(r) <= n {
+		return s
+	}
+	return string(r[:n])
 }
 
 // requireHTTPS rejects a JWKS URL that isn't https — the JWKS is the root of

--- a/internal/mcp/principal_test.go
+++ b/internal/mcp/principal_test.go
@@ -77,7 +77,7 @@ func TestPrincipalMiddleware_WithOption(t *testing.T) {
 
 	_, _ = handler(context.Background(), mcpgo.CallToolRequest{})
 
-	if captured != want {
+	if !captured.Equal(want) {
 		t.Errorf("Principal = %+v, want %+v", captured, want)
 	}
 }
@@ -111,7 +111,7 @@ func TestPrincipalMiddleware_RegisteredOnEveryTool(t *testing.T) {
 		t.Fatal("nil result")
 	}
 
-	if captured != want {
+	if !captured.Equal(want) {
 		t.Errorf("Principal stamped on handler ctx = %+v, want %+v", captured, want)
 	}
 }

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -163,7 +163,7 @@ func NewServer(deps Deps, version string, opts ...Option) (*Server, error) {
 	for _, opt := range opts {
 		opt(s)
 	}
-	if s.principal == (principal.Principal{}) {
+	if s.principal.IsZero() {
 		return nil, errors.New("mcp.NewServer: Principal is required (use WithPrincipal)")
 	}
 	if err := deps.validate(); err != nil {

--- a/internal/principal/clone_internal_test.go
+++ b/internal/principal/clone_internal_test.go
@@ -1,0 +1,65 @@
+package principal
+
+import (
+	"context"
+	"testing"
+)
+
+// In-package on purpose. The aliasing this guards against is only observable
+// on the UNEXPORTED roles field: Roles() clones on every read, so an external
+// test comparing &a.Roles()[0] to &b.Roles()[0] compares two fresh allocations
+// and can never fail — it would pass with Clone deleted. That tautology is
+// exactly what an earlier version of this test did.
+
+func TestClone_BreaksBackingArraySharing(t *testing.T) {
+	t.Parallel()
+	p := Verified("usr_1", ToolDataEntry, "org", "slug", []string{"admin"})
+	c := p.Clone()
+
+	if &c.roles[0] == &p.roles[0] {
+		t.Fatal("Clone shares the roles backing array with the original")
+	}
+
+	c.roles[0] = "superuser"
+	if p.roles[0] != "admin" {
+		t.Errorf("mutating the clone changed the original: %v", p.roles)
+	}
+}
+
+func TestFrom_DoesNotAliasTheContextValue(t *testing.T) {
+	t.Parallel()
+	// The ctx value is shared by every reader for the life of a request, so
+	// this is the widest exposure: without the clone, one consumer could
+	// mutate a role another is about to authorize against.
+	p := Verified("usr_1", ToolDataEntry, "org", "slug", []string{"admin"})
+	ctx := With(context.Background(), p)
+
+	a, b := From(ctx), From(ctx)
+
+	if len(a.roles) == 0 || len(b.roles) == 0 {
+		t.Fatal("precondition: From(ctx) returned no roles")
+	}
+	if &a.roles[0] == &b.roles[0] {
+		t.Fatal("two From(ctx) results share the roles backing array")
+	}
+
+	// And neither aliases the value still held in the context.
+	a.roles[0] = "superuser"
+	if got := From(ctx); got.roles[0] != "admin" {
+		t.Errorf("mutating a From() result corrupted the context value: %v", got.roles)
+	}
+}
+
+func TestClone_ZeroRolesDoesNotAllocate(t *testing.T) {
+	// No t.Parallel(): testing.AllocsPerRun is documented as invalid when the
+	// test runs in parallel with others (it measures process-wide allocations).
+	//
+	// Clone is on the From(ctx) hot path, called on every principal read at
+	// every entry point. The no-roles case — every CLI, MCP, scheduler and
+	// header-auth request — must stay allocation-free, so only the JWT path
+	// pays for the guarantee.
+	p := Principal{User: "alice", Tool: ToolCLI}
+	if n := testing.AllocsPerRun(100, func() { _ = p.Clone() }); n != 0 {
+		t.Errorf("Clone allocated %v times for a role-less principal, want 0", n)
+	}
+}

--- a/internal/principal/principal.go
+++ b/internal/principal/principal.go
@@ -134,6 +134,22 @@ func (p Principal) IsZero() bool {
 	return p.User == "" && p.Tool == "" && p.RawUser == ""
 }
 
+// Clone returns a deep copy of p, safe to hand to code that might outlive or
+// mutate the original.
+//
+// Principal is a value type, so a plain assignment already copies the scalar
+// fields — but the roles slice header is shared, and a caller resliced onto
+// that backing array could mutate a role another holder is about to authorize
+// against. This is the one place the compiler stops enforcing the guarantee the
+// unexported fields exist to provide, so accessors that hand out a Principal by
+// value use this instead.
+func (p Principal) Clone() Principal {
+	if len(p.roles) > 0 {
+		p.roles = slices.Clone(p.roles)
+	}
+	return p
+}
+
 // Sanitized returns a copy of p with every string field passed through clean.
 // Used at a serialization boundary (the audit JSONL writer) to bound field
 // length and strip control characters.
@@ -263,7 +279,10 @@ func With(ctx context.Context, p Principal) context.Context {
 // instance), not silent.
 func From(ctx context.Context) Principal {
 	if v, ok := ctx.Value(principalKey{}).(Principal); ok {
-		return v
+		// Cloned: the ctx value is shared by every reader for the life of the
+		// request, so handing out the roles backing array would let one
+		// consumer mutate what another is about to authorize against.
+		return v.Clone()
 	}
 	return Principal{User: "unknown", Tool: "unknown"}
 }

--- a/internal/principal/principal.go
+++ b/internal/principal/principal.go
@@ -17,11 +17,26 @@
 // consumer materializes, this package should be reabsorbed into the
 // consumer that uses it most — currently `audit`. Don't grow this
 // package speculatively.
+//
+// That gate has since opened, once (TKT-RP3X3Q): [Principal] gained the
+// verified-assertion claims — orgID, orgSlug, roles — because internal/acl
+// needs to grant roles from a signed identity assertion, and the claims have
+// nowhere else to live that both the ACL evaluator and the audit log can read.
+// The unexported-fields-plus-[Verified] shape exists so the trust boundary is
+// enforced by the compiler; see the [Principal] doc.
+//
+// The gate is not now open generally. `roles` earned its place by having an
+// evaluator; `orgID`/`orgSlug` ride along for audit attribution only and are
+// the outer limit of what belongs here. Session lifecycle, provisioning, and
+// role *expansion* remain out — they are separate concerns with their own
+// packages.
 package principal
 
 import (
 	"context"
+	"encoding/json"
 	"os"
+	"slices"
 	"strings"
 )
 
@@ -37,10 +52,173 @@ import (
 // so the audit log can record BOTH the identity that authenticated and
 // the entity it resolved to without a round-trip to the graph. Old audit
 // consumers ignore the `raw_user` key (omitempty).
+//
+// # Verified assertion claims
+//
+// orgID, orgSlug, and roles carry claims from a CRYPTOGRAPHICALLY VERIFIED
+// identity assertion. They are unexported on purpose: [Verified] is the only
+// way to populate them, so no composite literal anywhere in the tree can forge
+// a role. That matters because internal/acl trusts a Principal absolutely — it
+// verifies nothing itself — so a role reaching it from an unverified source
+// (a spoofable header, say) would be a complete authorization bypass. The
+// compiler enforces the trust boundary here rather than leaving it to a code
+// reviewer's memory.
+//
+// Read them via [Principal.OrgID], [Principal.OrgSlug], [Principal.Roles].
 type Principal struct {
-	User    string `json:"user"`
-	Tool    string `json:"tool"`
-	RawUser string `json:"raw_user,omitempty"`
+	User    string
+	Tool    string
+	RawUser string
+
+	orgID   string
+	orgSlug string
+	roles   []string
+}
+
+// Verified constructs a Principal carrying claims from a verified identity
+// assertion. Callers MUST have validated the assertion's signature before
+// calling this — see the type doc for why that is load-bearing.
+//
+// roles is defensively copied so a later mutation of the caller's slice cannot
+// retroactively change an authorization decision.
+func Verified(user, tool, orgID, orgSlug string, roles []string) Principal {
+	p := Principal{
+		User:    user,
+		Tool:    tool,
+		orgID:   orgID,
+		orgSlug: orgSlug,
+	}
+	if len(roles) > 0 {
+		p.roles = slices.Clone(roles)
+	}
+	return p
+}
+
+// OrgID returns the verified `org_id` claim, or "" when the principal did not
+// arrive with a verified assertion.
+//
+// ATTRIBUTION ONLY. Nothing in internal/acl evaluates this — a principal in
+// org A holding a role sees every entity that role grants, in EVERY org.
+// Presence of an org in the audit log does NOT imply tenant isolation.
+// Enforcement is deliberately deferred; see TKT-RP3X3Q.
+func (p Principal) OrgID() string { return p.orgID }
+
+// OrgSlug returns the verified `org_slug` claim, or "" when absent. The same
+// attribution-only caveat as [Principal.OrgID] applies.
+func (p Principal) OrgSlug() string { return p.orgSlug }
+
+// Roles returns the verified `roles` claim — bare role names scoped to
+// [Principal.OrgID]. Empty for every non-assertion entry point (CLI, MCP,
+// scheduler, a proxy-trusted header, ...).
+//
+// These are the IdP's role names, NOT rela roles: an ACL policy maps them to
+// declared roles through an operator-authored allowlist, so a claim value can
+// never name a rela role the operator did not choose to grant.
+//
+// The returned slice is a copy; mutating it cannot affect authorization.
+func (p Principal) Roles() []string {
+	if len(p.roles) == 0 {
+		return nil
+	}
+	return slices.Clone(p.roles)
+}
+
+// IsZero reports whether p carries no identity at all. Entry points use it to
+// reject an unconfigured Principal at construction time.
+//
+// This exists because Principal stopped being comparable when it gained a slice
+// field, so `p == Principal{}` no longer compiles. Deliberately NOT
+// reflect.DeepEqual: a Principal carrying only assertion claims and no
+// User/Tool is still an unusable identity and must still be rejected.
+func (p Principal) IsZero() bool {
+	return p.User == "" && p.Tool == "" && p.RawUser == ""
+}
+
+// Sanitized returns a copy of p with every string field passed through clean.
+// Used at a serialization boundary (the audit JSONL writer) to bound field
+// length and strip control characters.
+//
+// It lives here rather than in the consumer because the assertion claims are
+// unexported: a consumer cannot reach them, and a consumer that only cleaned
+// the exported fields would silently let unbounded role strings through. clean
+// is supplied by the caller so this package stays free of a policy decision
+// about what "clean" means.
+func (p Principal) Sanitized(clean func(string) string) Principal {
+	out := Principal{
+		User:    clean(p.User),
+		Tool:    clean(p.Tool),
+		RawUser: clean(p.RawUser),
+		orgID:   clean(p.orgID),
+		orgSlug: clean(p.orgSlug),
+	}
+	if len(p.roles) > 0 {
+		out.roles = make([]string, 0, len(p.roles))
+		for _, r := range p.roles {
+			out.roles = append(out.roles, clean(r))
+		}
+	}
+	return out
+}
+
+// Equal reports whether p and q carry the same identity, including the
+// assertion claims. Replaces `==`, which stopped compiling when Principal
+// gained a slice field.
+func (p Principal) Equal(q Principal) bool {
+	return p.User == q.User &&
+		p.Tool == q.Tool &&
+		p.RawUser == q.RawUser &&
+		p.orgID == q.orgID &&
+		p.orgSlug == q.orgSlug &&
+		slices.Equal(p.roles, q.roles)
+}
+
+// principalJSON is the wire format. It is a separate type because the assertion
+// claims live in unexported fields (see the [Principal] doc), which
+// encoding/json cannot reach in either direction.
+type principalJSON struct {
+	User    string   `json:"user"`
+	Tool    string   `json:"tool"`
+	RawUser string   `json:"raw_user,omitempty"`
+	OrgID   string   `json:"org_id,omitempty"`
+	OrgSlug string   `json:"org_slug,omitempty"`
+	Roles   []string `json:"roles,omitempty"`
+}
+
+// MarshalJSON emits the assertion claims alongside the exported fields. Every
+// new key is omitempty, so a record from a non-assertion entry point is
+// byte-identical to what previous versions wrote.
+func (p Principal) MarshalJSON() ([]byte, error) {
+	return json.Marshal(principalJSON{
+		User:    p.User,
+		Tool:    p.Tool,
+		RawUser: p.RawUser,
+		OrgID:   p.orgID,
+		OrgSlug: p.orgSlug,
+		Roles:   p.roles,
+	})
+}
+
+// UnmarshalJSON restores a Principal from the audit wire format.
+//
+// This is the one path that populates the assertion claims without a signature
+// check, and it is safe precisely because of what it is for: reading back a
+// record this process already wrote and verified. It must never be pointed at
+// request-path input — a Principal decoded from an untrusted payload would
+// bypass the guarantee the unexported fields exist to provide.
+func (p *Principal) UnmarshalJSON(data []byte) error {
+	var w principalJSON
+	if err := json.Unmarshal(data, &w); err != nil {
+		return err
+	}
+	*p = Principal{
+		User:    w.User,
+		Tool:    w.Tool,
+		RawUser: w.RawUser,
+		orgID:   w.OrgID,
+		orgSlug: w.OrgSlug,
+		roles:   w.Roles,
+	}
+	return nil
 }
 
 // Tool constants — the values that may appear in [Principal.Tool].

--- a/internal/principal/principal_test.go
+++ b/internal/principal/principal_test.go
@@ -10,7 +10,7 @@ import (
 func TestPrincipalFrom_DefaultsToUnknown(t *testing.T) {
 	got := principal.From(context.Background())
 	want := principal.Principal{User: "unknown", Tool: "unknown"}
-	if got != want {
+	if !got.Equal(want) {
 		t.Errorf("got %+v, want %+v", got, want)
 	}
 }
@@ -18,7 +18,7 @@ func TestPrincipalFrom_DefaultsToUnknown(t *testing.T) {
 func TestWithPrincipal_RoundTrip(t *testing.T) {
 	p := principal.Principal{User: "alice", Tool: principal.ToolCLI}
 	ctx := principal.With(context.Background(), p)
-	if got := principal.From(ctx); got != p {
+	if got := principal.From(ctx); !got.Equal(p) {
 		t.Errorf("round-trip mismatch: got %+v, want %+v", got, p)
 	}
 }

--- a/internal/principal/verified_test.go
+++ b/internal/principal/verified_test.go
@@ -1,6 +1,7 @@
 package principal_test
 
 import (
+	"context"
 	"encoding/json"
 	"slices"
 	"strings"
@@ -115,6 +116,39 @@ func TestPrincipal_Equal(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestPrincipal_AccessorsDoNotShareBackingArray(t *testing.T) {
+	t.Parallel()
+	// Principal is a value type, so a plain copy shares the roles backing
+	// array. Every accessor that hands out a Principal or its roles must clone,
+	// or one holder can mutate what another is about to authorize against.
+	p := principal.Verified("usr_1", principal.ToolDataEntry, "org", "slug",
+		[]string{"admin"})
+
+	t.Run("Clone", func(t *testing.T) {
+		t.Parallel()
+		c := p.Clone()
+		c.Roles()[0] = "superuser" // mutating the accessor result is already safe
+		if got := p.Roles(); got[0] != "admin" {
+			t.Errorf("original mutated: %v", got)
+		}
+		// The clone's own backing array must be independent.
+		if &c.Roles()[0] == &p.Roles()[0] {
+			t.Error("Clone shares the roles backing array")
+		}
+	})
+
+	t.Run("From(ctx)", func(t *testing.T) {
+		t.Parallel()
+		ctx := principal.With(context.Background(), p)
+		a := principal.From(ctx)
+		b := principal.From(ctx)
+		// Two independent readers of the same ctx must not alias.
+		if len(a.Roles()) > 0 && len(b.Roles()) > 0 && &a.Roles()[0] == &b.Roles()[0] {
+			t.Error("two From(ctx) results share the roles backing array")
+		}
+	})
 }
 
 func TestPrincipal_JSONRoundTrip(t *testing.T) {

--- a/internal/principal/verified_test.go
+++ b/internal/principal/verified_test.go
@@ -1,0 +1,184 @@
+package principal_test
+
+import (
+	"encoding/json"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/Sourcehaven-BV/rela/internal/principal"
+)
+
+// Verified-assertion claims on Principal (TKT-RP3X3Q).
+
+func TestVerified_CarriesClaims(t *testing.T) {
+	t.Parallel()
+	p := principal.Verified("usr_1", principal.ToolDataEntry, "org_a", "acme",
+		[]string{"admin", "billing"})
+
+	if p.User != "usr_1" || p.Tool != principal.ToolDataEntry {
+		t.Errorf("identity not carried: %+v", p)
+	}
+	if p.OrgID() != "org_a" || p.OrgSlug() != "acme" {
+		t.Errorf("org = %q/%q, want org_a/acme", p.OrgID(), p.OrgSlug())
+	}
+	if want := []string{"admin", "billing"}; !slices.Equal(p.Roles(), want) {
+		t.Errorf("Roles = %v, want %v", p.Roles(), want)
+	}
+}
+
+func TestVerified_NoRolesYieldsNil(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name  string
+		roles []string
+	}{
+		{"nil", nil},
+		{"empty", []string{}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			p := principal.Verified("usr_1", principal.ToolCLI, "", "", tc.roles)
+			if got := p.Roles(); got != nil {
+				t.Errorf("Roles = %v, want nil", got)
+			}
+		})
+	}
+}
+
+func TestPrincipal_ZeroValueHasNoClaims(t *testing.T) {
+	t.Parallel()
+	// Every non-assertion entry point builds Principal as a composite literal.
+	// Those must carry no claims — which the compiler guarantees, since the
+	// fields are unexported. This pins the observable half of that.
+	p := principal.Principal{User: "alice", Tool: principal.ToolCLI}
+
+	if p.OrgID() != "" || p.OrgSlug() != "" || p.Roles() != nil {
+		t.Errorf("composite-literal Principal carried claims: %+v", p)
+	}
+}
+
+func TestPrincipal_IsZero(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name string
+		p    principal.Principal
+		want bool
+	}{
+		{"zero value", principal.Principal{}, true},
+		{"user only", principal.Principal{User: "alice"}, false},
+		{"tool only", principal.Principal{Tool: principal.ToolCLI}, false},
+		{"rawuser only", principal.Principal{RawUser: "a@b.c"}, false},
+		{
+			// The case that matters: a Principal carrying ONLY assertion claims
+			// is not a usable identity and must still count as zero, so an
+			// entry point's required-Principal guard still rejects it.
+			"claims but no identity",
+			principal.Verified("", "", "org_a", "acme", []string{"admin"}),
+			true,
+		},
+		{
+			"claims with identity",
+			principal.Verified("usr_1", principal.ToolDataEntry, "org_a", "acme", nil),
+			false,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := tc.p.IsZero(); got != tc.want {
+				t.Errorf("IsZero() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestPrincipal_Equal(t *testing.T) {
+	t.Parallel()
+	base := principal.Verified("usr_1", principal.ToolDataEntry, "org_a", "acme",
+		[]string{"admin"})
+
+	for _, tc := range []struct {
+		name string
+		q    principal.Principal
+		want bool
+	}{
+		{"identical", principal.Verified("usr_1", principal.ToolDataEntry, "org_a", "acme", []string{"admin"}), true},
+		{"different user", principal.Verified("usr_2", principal.ToolDataEntry, "org_a", "acme", []string{"admin"}), false},
+		{"different org", principal.Verified("usr_1", principal.ToolDataEntry, "org_b", "acme", []string{"admin"}), false},
+		{"different roles", principal.Verified("usr_1", principal.ToolDataEntry, "org_a", "acme", []string{"billing"}), false},
+		{"no roles", principal.Verified("usr_1", principal.ToolDataEntry, "org_a", "acme", nil), false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := base.Equal(tc.q); got != tc.want {
+				t.Errorf("Equal() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestPrincipal_JSONRoundTrip(t *testing.T) {
+	t.Parallel()
+	want := principal.Verified("usr_1", principal.ToolDataEntry, "org_a", "acme",
+		[]string{"admin", "billing"})
+	want.RawUser = "alice@example.com"
+
+	data, err := json.Marshal(want)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var got principal.Principal
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if !got.Equal(want) {
+		t.Errorf("round-trip: got %+v, want %+v (json: %s)", got, want, data)
+	}
+}
+
+func TestPrincipal_JSONOmitsAbsentClaims(t *testing.T) {
+	t.Parallel()
+	// The audit log is a published wire format. A record from a non-assertion
+	// entry point must be byte-identical to what earlier versions wrote, so old
+	// consumers see no change.
+	data, err := json.Marshal(principal.Principal{User: "alice", Tool: principal.ToolCLI})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if got, want := string(data), `{"user":"alice","tool":"cli"}`; got != want {
+		t.Errorf("json = %s, want %s", got, want)
+	}
+}
+
+func TestPrincipal_Sanitized(t *testing.T) {
+	t.Parallel()
+	// Stand-in for the audit writer's clean(): uppercase marks that the field
+	// was visited, so a field the method forgets shows up as un-uppercased.
+	visit := strings.ToUpper
+
+	p := principal.Verified("usr_1", principal.ToolDataEntry, "org_a", "acme",
+		[]string{"admin", "billing"})
+	p.RawUser = "alice@example.com"
+
+	got := p.Sanitized(visit)
+
+	for _, tc := range []struct{ name, got string }{
+		{"User", got.User},
+		{"Tool", got.Tool},
+		{"RawUser", got.RawUser},
+		{"OrgID", got.OrgID()},
+		{"OrgSlug", got.OrgSlug()},
+	} {
+		if tc.got != strings.ToUpper(tc.got) {
+			t.Errorf("%s was not passed through clean: %q", tc.name, tc.got)
+		}
+	}
+	for i, role := range got.Roles() {
+		if role != strings.ToUpper(role) {
+			t.Errorf("role[%d] was not passed through clean: %q", i, role)
+		}
+	}
+	if len(got.Roles()) != 2 {
+		t.Errorf("Roles = %v, want 2 entries", got.Roles())
+	}
+}

--- a/internal/principal/verified_test.go
+++ b/internal/principal/verified_test.go
@@ -1,7 +1,6 @@
 package principal_test
 
 import (
-	"context"
 	"encoding/json"
 	"slices"
 	"strings"
@@ -116,39 +115,6 @@ func TestPrincipal_Equal(t *testing.T) {
 			}
 		})
 	}
-}
-
-func TestPrincipal_AccessorsDoNotShareBackingArray(t *testing.T) {
-	t.Parallel()
-	// Principal is a value type, so a plain copy shares the roles backing
-	// array. Every accessor that hands out a Principal or its roles must clone,
-	// or one holder can mutate what another is about to authorize against.
-	p := principal.Verified("usr_1", principal.ToolDataEntry, "org", "slug",
-		[]string{"admin"})
-
-	t.Run("Clone", func(t *testing.T) {
-		t.Parallel()
-		c := p.Clone()
-		c.Roles()[0] = "superuser" // mutating the accessor result is already safe
-		if got := p.Roles(); got[0] != "admin" {
-			t.Errorf("original mutated: %v", got)
-		}
-		// The clone's own backing array must be independent.
-		if &c.Roles()[0] == &p.Roles()[0] {
-			t.Error("Clone shares the roles backing array")
-		}
-	})
-
-	t.Run("From(ctx)", func(t *testing.T) {
-		t.Parallel()
-		ctx := principal.With(context.Background(), p)
-		a := principal.From(ctx)
-		b := principal.From(ctx)
-		// Two independent readers of the same ctx must not alias.
-		if len(a.Roles()) > 0 && len(b.Roles()) > 0 && &a.Roles()[0] == &b.Roles()[0] {
-			t.Error("two From(ctx) results share the roles backing array")
-		}
-	})
 }
 
 func TestPrincipal_JSONRoundTrip(t *testing.T) {

--- a/tickets/entities/docs-checklists/DOCS-U1H62D.md
+++ b/tickets/entities/docs-checklists/DOCS-U1H62D.md
@@ -1,0 +1,80 @@
+---
+id: DOCS-U1H62D
+type: docs-checklist
+title: 'Documentation: Surface org_id and roles from verified identity assertions (TKT-RP3X3Q)'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Code documentation
+
+- [x] Godoc on new exported types and functions
+
+`jwtauth.AssertionClaims` / `VerifyAssertion`, `principal.Verified` / `Clone` /
+`Sanitized` / `IsZero` / `Equal` / the three accessors, `acl.RoleList` /
+`AssertedGrant` / `AssertedGrants` / `SourceAsserted`,
+`aclmap.ConditionalGrant`, `dataentry.AssertedIdentity`.
+
+- [x] Rationale recorded where a reader would otherwise ask "why"
+
+The comments that carry weight rather than restating the code:
+
+- `principal.Principal` — why the claims are unexported (the ACL trusts the
+Principal absolutely, so a role from an unverified source is a bypass, not a
+degradation).
+- `principal.UnmarshalJSON` — why it is safe (reads back what this process
+wrote) and the one thing that would make it unsafe (pointing it at request-path
+input).
+- `principal.Clone` — that this is the one place the compiler stops enforcing
+the guarantee the unexported fields provide.
+- `acl.normalizeAssertedRoles` — the exact failure it prevents, and why it
+lives in `Validate` rather than `LoadPolicyBytes`.
+- `aclmap.ConditionalGrant` — why it is NOT merged into `Everyone`, in terms
+of the question the report exists to answer.
+- `acl.numSourceKinds` — that it must stay last, and what breaks otherwise.
+
+- [x] `internal/principal` package doc updated
+
+The doc explicitly gated growth on "a future ACL ticket". That gate is now
+recorded as opened once, with the reason, and the new limit stated so the
+warning keeps its force rather than reading as spent.
+
+## Project documentation
+
+- [x] `docs/acl-overview.md` — new "Roles from a verified identity assertion"
+section: both YAML forms, and a "Rules and fallbacks" list matching the idiom
+every other policy key follows (no-match, undeclared role, `everyone` rejection,
+exact-after-trim matching, absent-key no-op, multi-claim accumulation,
+no-user-entity case).
+- [x] `docs/acl-security.md` — new section covering the three load-bearing
+properties: the trust boundary and why it is structural; the claim→role
+indirection as the second control; and revocation lag stated concretely (**a
+revoked role survives in rela for up to one token lifetime — 9 minutes with
+Pratique — and rela has no revocation channel**), because an operator planning
+incident response will otherwise assume IdP revocation is immediate. Plus a
+dedicated "`org_id` is recorded, not enforced" subsection.
+- [x] `docs/server-security.md` — the widened claim surface on the JWT path,
+what is optional, and pointers to the two ACL docs.
+- [x] `docs/audit-log.md` — the new record fields, a worked example, the
+backward-compatibility note, and the org-is-not-isolation warning repeated where
+an operator reading the log will hit it.
+- [x] ~~`docs/metamodel.md`, `docs/cli-reference.md`, `docs/data-entry.md`~~
+(N/A: no metamodel, CLI-surface or UI changes — the `acl who-can` text output
+changed but its flags and invocation did not)
+
+## Verification
+
+- [x] Documented examples are executable
+
+`TestDocs_AclOverviewExampleWorks` parses the YAML copied **verbatim** from
+`docs/acl-overview.md` and asserts the documented union-and-dedup behaviour. A
+documented example that no longer parses is worse than no example, because a
+reader will trust it — so this fails if the schema drifts.
+
+- [x] Warnings placed where the reader is, not only where the author was
+
+The org-is-not-isolation warning appears in three places (`principal` godoc,
+`acl-security.md`, `audit-log.md`) because the three audiences who could
+mistakenly rely on it — an implementer reading the type, an operator writing
+policy, an investigator reading the log — each arrive from a different door.

--- a/tickets/entities/implementation-checklists/IMPL-5NC7AC.md
+++ b/tickets/entities/implementation-checklists/IMPL-5NC7AC.md
@@ -1,0 +1,98 @@
+---
+id: IMPL-5NC7AC
+type: implementation-checklist
+title: 'Implementation: Surface org_id and roles from verified identity assertions'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Development
+
+- [x] Unit tests written for new code
+- [x] Integration tests written (full flow, not just units)
+- [x] Feature implemented
+- [x] All edge cases from planning handled
+
+**What was built** — five layers, as planned:
+
+1. `internal/jwtauth`: `AssertionClaims` + `VerifyAssertion` beside the
+existing `VerifySubject`; `stringSliceClaim` helper; bounds (32 roles × 256
+runes) applied in the projection so every future consumer inherits them. jwtauth
+stays an arch-lint leaf.
+2. `internal/principal`: `orgID`/`orgSlug`/`roles` as **unexported** fields
+behind `Verified()`, plus `OrgID()`/`OrgSlug()`/`Roles()` accessors, `IsZero()`,
+`Equal()`, `Sanitized()`, and custom JSON marshalling.
+3. `internal/dataentry`: own `AssertedIdentity` type + widened
+`assertionVerifier` seam; `cmd/rela-server` adapter translates from
+`jwtauth.AssertionClaims`; `resolvePrincipalEntity` rebuilt via `Verified` so
+claims survive the re-stamp.
+4. `internal/acl`: `asserted_role_assignments` (`map[string]RoleList` with
+scalar-or-list YAML), `SourceAsserted` + `Source.Claim`, injection in
+`computeGlobals`, `Validate` rejects blank keys and `everyone` targets.
+5. `aclmap`/`cli`/`audit`: separate "conditional grants" reporting,
+`Claim` on `Route` + `lessRoute`, per-element audit sanitisation.
+
+## Manual verification
+
+- [x] Feature tested end-to-end
+- [x] Each acceptance criterion verified
+- [x] Verification evidence documented
+
+**Evidence — each AC exercised by a named test:**
+
+| AC | Test | Result |
+|---|---|---|
+| AC1 | `TestVerifyAssertion_ProjectsAllClaims`, `TestJWTPrincipalResolver_CarriesOrgAndRoles` | PASS |
+| AC2 | `TestVerifyAssertion_AbsentClaimsAreNotAnError` (5 cases incl. explicit JSON null), `TestJWTPrincipalResolver_AbsentClaimsAreNotAnError` | PASS |
+| AC3 | Existing `TestHeaderPrincipalResolver_*` pass **unmodified**; `TestE2E_HeaderModeUnaffected` | PASS |
+| AC4 | Existing default-resolver tests unmodified; `TestNonJWTResolvers_CannotSetAssertedClaims/default_resolver` | PASS |
+| AC5 | `TestAssertedRoles_ClaimGrantsMappedRole` (asserts `SourceAsserted` + `Claim`), `_ClaimGrantsSeveralRoles`, `TestE2E_AssertedClaimAuthorizesRequest` | PASS |
+| AC6 | `TestAssertedRoles_UndeclaredRoleDroppedSilently` | PASS |
+| AC7 | `TestPrincipal_Sanitized`, audit round-trip tests | PASS |
+| AC8 | Existing `nop_test.go` / `readonly_test.go` unmodified | PASS |
+| AC9 | `TestWhoCan_ReportsAssertedGrantsSeparately`, `_AssertedGrantsAreNotPrincipals`, `_NoAssertedMappingsOmitsSection` | PASS |
+| AC10 | `TestAssertedRoles_UnmatchedPrincipalKeepsAssertedRoles`, `TestE2E_UnmatchedPrincipalStillCarriesClaims` | PASS |
+
+**Two guards were fault-injected rather than assumed:**
+
+1. **The exhaustive SourceKind guard.** First version was WRONG — it derived
+the count from the hand-maintained list it was meant to check, so adding an
+unregistered kind passed. Rewritten against `numSourceKinds` (from the const
+block itself). Re-injected the fault: now fails with *"allSourceKinds has 7
+entries but 8 kinds are declared"*. Also confirmed the `exhaustive` linter does
+**not** catch this (`default-signifies-exhaustive: true` means the `default:`
+clauses satisfy it) — the test is the only guard.
+2. **The re-stamp drop.** Reverted `resolvePrincipalEntity` to the original
+composite literal; `TestE2E_ClaimsSurvivePrincipalPropertyReStamp` failed with
+*"resolvePrincipalEntity dropped the claims when it rebuilt the Principal"*.
+Restored; passes. This is the review's RR-HVN18E scenario made mechanically
+detectable.
+
+**Documented example verified:** `TestDocs_AclOverviewExampleWorks` parses the
+YAML copied verbatim from `docs/acl-overview.md` and asserts the documented
+union-and-dedup behaviour, so the docs cannot drift silently.
+
+## Quality
+
+- [x] Code follows project patterns
+- [x] No silent failures (errors surfaced, not just logged)
+
+- `just test` — full suite passes
+- `just lint` — 0 issues
+- `just arch-lint` — OK, no warnings (**jwtauth remained a leaf**, confirming
+the adapter approach from RR-CHW2AA)
+- `just coverage-check` — PASS (76.3%, both thresholds)
+- `go test -race` on all five touched packages — clean
+
+**Deliberate non-changes:**
+
+- `isUnstamped` untouched (RR-HVN18E). `TestAssertedRoles_UnstampedPrincipalStillRejected`
+pins that a claims-bearing but identity-less principal is still rejected.
+- `aclmap` schemaVersion left at 1: both new fields are `omitempty`, so a
+policy without asserted mappings serialises byte-identically
+(`TestWhoCan_NoAssertedMappingsOmitsSection` asserts the JSON).
+
+**Opportunistic fix:** `Principal.RawUser` was never sanitised in the audit
+writer (safe by construction, but an unpinned invariant in the exact function
+this ticket edits). Now covered via `Principal.Sanitized`.

--- a/tickets/entities/planning-checklists/PLAN-0R1VYM.md
+++ b/tickets/entities/planning-checklists/PLAN-0R1VYM.md
@@ -1,0 +1,347 @@
+---
+id: PLAN-0R1VYM
+type: planning-checklist
+title: 'Planning: Surface org_id and roles from verified identity assertions'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+> **Revised after design review (10 findings, all addressed).** Two sections
+> below were factually wrong in the first draft and have been corrected against
+> the source: the `isUnstamped` behaviour (RR-HVN18E) and the
+> `jwtauth → principal` dependency (RR-CHW2AA). Findings: RR-HVN18E, RR-3TKDR9,
+> RR-QZVYVJ (critical); RR-CHW2AA, RR-7F05HH, RR-MZFKO7, RR-0VHKMW, RR-74XCVE,
+> RR-TQBZ2U (significant); RR-9698LN (minor).
+
+## Understanding
+
+- [x] Problem/requirements clearly understood
+- [x] Scope defined (what's in/out documented below)
+- [x] Acceptance criteria documented with specific test scenarios
+
+**Scope:**
+
+IN: typed assertion-claims projection in `internal/jwtauth` (with bounds);
+`orgID`/`orgSlug`/`roles` on `principal.Principal` **as unexported fields behind
+a `Verified` constructor**; asserted roles grantable via a new `acl.Policy` key
++ new `SourceKind` + one block in `computeGlobals`; threading through the
+resolver chain and the audit sanitiser.
+
+OUT: org **matching/enforcement** in `acl.yaml`; auto-provisioning an unmatched
+principal (→ TKT-0C3II2); `--principal-header` gaining org/roles; the webhook
+path; the `Authorization: Bearer` transport gap; `principal_type`.
+**`isUnstamped` is explicitly out of scope — see the decision below.**
+
+Full scope statement lives on TKT-RP3X3Q; not duplicated here to avoid drift.
+
+**Acceptance Criteria:** AC1-AC10 on the ticket, each mapped to a test below.
+
+## Research
+
+- [x] ~~For larger features: run `/research`~~ (N/A: approach determined by
+direct source study of both repos; no open option space left after the
+org-scoping decision)
+- [x] Searched for existing libraries that solve this problem
+- [x] Checked codebase for similar patterns or reusable code
+- [x] Looked for reference implementations in other projects
+- [x] Reviewed relevant rela concepts for prior art
+
+**Research Doc:** N/A — see above.
+
+**Existing Solutions:**
+
+- **Libraries:** none needed. `golang-jwt` already parses the full claim set in
+`VerifySubject` (verifier.go:90) and throws it away. This is a projection
+change, not a parsing change. No new dependency.
+- **Reusable code in-repo:**
+  - `jwtauth.stringClaim` (verifier.go:167-172) — existing string-claim
+projector; needs a `[]string` sibling.
+  - `jwtauth.VerifyWebhook` (verifier.go:150-161) — the existing "verify, then
+project into a typed struct" precedent.
+  - **`metamodel.StringOrSlice` (metamodel/types.go:696-714)** — the in-tree
+scalar-or-list YAML idiom, adopted for the policy key (see Approach).
+  - `acl.EveryoneRole` injection (resolver.go:45-47) — role entering the
+effective set without a graph walk.
+  - `sanitizeUser` + `principalUserMaxLen` (dataentry/router.go:465) — the
+existing input-bounding discipline, mirrored for roles.
+  - `lua`'s `freezeTable` — the precedent for enforcing a contract structurally
+rather than conventionally; the model for the `Verified` constructor.
+- **Reference implementation:** `pratique/pkg/middleware/middleware.go:36-42` —
+the vendor's own downstream contract exposes exactly `Subject`, `Email`,
+`OrgID`, `OrgSlug`, `Roles`. This ticket mirrors that field set.
+- **Prior art in the graph:** FEAT-OQBYHD, RES-SJNSUY, TKT-9089I6 (source of the
+no-enumerable-principal problem via RR-CY6WYR).
+
+## Approach
+
+- [x] Technical approach chosen and documented
+- [x] Approach builds on existing patterns (not reinventing)
+- [x] Alternatives considered (document why rejected)
+- [x] Dependencies identified (packages, APIs, types)
+
+**Technical Approach — five layers, in dependency order:**
+
+1. **`internal/jwtauth`** — add `AssertionClaims{Subject, Email, OrgID, OrgSlug,
+Roles}` and `VerifyAssertion` beside `VerifySubject`. Same verifier, same pins;
+only the projection widens. Add a `stringSliceClaim` helper. **Bounds live
+here** (RR-0VHKMW): cap roles at 32 elements and each at 256 runes, drop excess,
+`slog.Warn` once — so every future consumer inherits the bound instead of the
+next entry point missing it. `jwtauth` **stays an arch-lint leaf** and does not
+import `principal` (RR-CHW2AA).
+
+2. **`internal/principal`** — `orgID`, `orgSlug`, `roles` as **unexported**
+fields plus `Verified(sub, tool, orgID, orgSlug string, roles []string)` and
+accessors (RR-TQBZ2U). Composite literals cannot set them, so all 21 non-test
+construction sites are compiler-prevented from forging roles. Add `IsZero()`
+(RR-3TKDR9). Custom `MarshalJSON`/`UnmarshalJSON` since `Principal` is embedded
+in the published `audit.Record` wire format (audit.go:85-94). Hostile godoc on
+org: *attribution only, nothing in `internal/acl` evaluates these, presence in
+the audit log does NOT imply tenant isolation* (RR-9698LN).
+
+3. **`internal/dataentry`** — `dataentry` declares **its own** small claims
+struct; the `cmd/rela-server` adapter translates from `jwtauth.AssertionClaims`,
+exactly as `webhookVerifierAdapter` does (main.go:244-252). `dataentry` does
+**not** import `jwtauth` (RR-74XCVE). Populate via `principal.Verified` at
+router.go:405. `resolvePrincipalEntity` (router.go:280) must carry the new
+fields through its rebuild. **`internal/mcp/server.go:166` switches to
+`IsZero()`.**
+
+4. **`internal/acl`** — `AssertedRoleAssignments map[string]<StringOrSlice>` on
+`Policy` (+ `knownPolicyKeys`, enforced by `policy_parity_test.go`), with a
+local scalar-or-list `UnmarshalYAML` so both `admin: editor` and `admin:
+[editor, auditor]` parse (RR-QZVYVJ). `acl` cannot import `metamodel`, so it
+gets its own small equivalent of `StringOrSlice` — precedented, as `metamodel`
+itself carries several such local YAML types. `SourceAsserted` kind with a
+`Claim string` on `Source` (stays comparable), added to `sourceKindPriority`,
+both `String()` methods, **and the `lessSource` tiebreak** (RR-74XCVE). One
+block in `computeGlobals` adjacent to the everyone block. `Validate` rejects a
+blank-after-trim key and rejects `EveryoneRole` as a mapping target (RR-QZVYVJ).
+Claim matching is exact after `TrimSpace`, no case folding.
+
+5. **`aclmap` + `aclaudit` + audit + docs** — a **distinct, separately-labelled**
+"conditional grants (asserted claims)" section in `acl map`, explicitly NOT
+reusing `EveryoneGrants` or its wire field (RR-MZFKO7). `Route` gains the claim
+field + `lessRoute` tiebreak. `aclaudit` Tier-A check for "asserted claim maps
+to a privileged role", cloned from `checkUngatedMembership`. `audit.sanitize`
+gains a per-element `clean()` loop for roles, `clean()` for the org fields,
+**and `RawUser`** which is currently unsanitised (RR-7F05HH). Docs per the
+Documentation Planning section.
+
+**Files to modify:**
+
+- `internal/jwtauth/verifier.go`, `verifier_test.go`
+- `internal/principal/principal.go`, `principal_test.go`
+- `internal/dataentry/router.go`, `jwt_principal_test.go`, `principal_test.go`,
+`principal_property_test.go`
+- **`internal/mcp/server.go`** (added post-review, RR-3TKDR9)
+- `cmd/rela-server/main.go`
+- `internal/acl/policy.go`, `source.go`, `resolver.go`, and their tests
+- `internal/aclmap/aclmap.go`, `whocan.go`, `enumerate.go`
+- `internal/aclaudit/tier_a.go`
+- `internal/audit/filesystem.go`
+- `docs/acl-overview.md`, `docs/acl-security.md`, `docs/server-security.md`,
+`docs/audit-log.md`
+
+**Alternatives considered:**
+
+- **Overload `Policy.Assignments` with claim values** — REJECTED. Its keys are
+matched against `members` (entity IDs from a graph walk). A claim value
+colliding with an entity ID grants across dimensions silently: a privilege
+escalation vector, and unauditable.
+- **`map[string]string` for the claim mapping** — REJECTED post-review
+(RR-QZVYVJ). Forecloses `admin → [editor, auditor]`, and `acl.yaml` is a
+published schema so widening later breaks operators. The scalar-or-list
+unmarshaller gives the terse form for free.
+- **Exported `AssertedRoles` field guarded by doc + test** — REJECTED
+post-review (RR-TQBZ2U). For a field whose entire security property is "only
+ever populated after signature verification", compiler enforcement beats
+reviewer memory.
+- **Mirroring `EveryoneGrants` for `acl map`** — REJECTED post-review
+(RR-MZFKO7). `EveryoneGrants` is a statement of fact; an asserted grant applies
+to an unknowable IdP-side subset. Reusing the global slot would tell an operator
+everyone holds the role.
+- **Full org enforcement** — REJECTED for this ticket by user decision;
+`internal/acl` has no denial primitive and `RoleDef` verbs have no `when:`. Own
+ticket, own design.
+- **Org via the predicate env / via `inherit_roles_through`** — DEFERRED with
+the above; noted as the natural first steps for the follow-up.
+- **New source kind vs. reusing `SourceGlobal`** — new kind. Reusing
+`SourceGlobal` would make audit and `acl map` unable to distinguish "granted by
+policy assignment" from "granted by a claim in a token" — precisely the
+provenance question asked post-incident.
+
+**Dependencies:** no new modules. `jwtauth` gains **no** internal dependency and
+remains an arch-lint leaf (RR-CHW2AA). `acl → principal` already exists.
+
+## Security Considerations
+
+- [x] Input sources identified (user input, config, external APIs)
+- [x] Input validation approach defined (allowlist preferred over blocklist)
+- [x] Security-sensitive operations identified (file access, auth, crypto)
+- [x] Error handling doesn't leak sensitive information
+
+**Input Sources & Validation:**
+
+| Input | Source | Validation | On invalid |
+|---|---|---|---|
+| `roles` claim | verified JWT | signature verified BEFORE projection; must be `[]any` of strings; **capped at 32 × 256 runes** | non-string elements dropped, excess truncated with a warn; never errors the request |
+| `org_id`/`org_slug` | verified JWT | string-typed, `clean()`-ed into audit | absent ⇒ empty string, not an error |
+| claim→role mapping | `acl.yaml` (operator) | **allowlist**: mapped role must exist in `policy.Roles` or the grant is dropped (mirrors resolver.go:36-38); `Validate` rejects blank-after-trim keys and `EveryoneRole` targets | dropped at resolution / load-time error |
+| role values reaching audit | derived | per-element `clean()` | sanitised |
+
+The claim→role indirection is the primary control: a claim value never becomes a
+role name directly, only via an operator-authored allowlist. An attacker able to
+influence Pratique role names still cannot name a rela role the operator has not
+mapped.
+
+**Security-Sensitive Operations:**
+
+- **Signature verification precedes projection.** `VerifyAssertion` parses claims
+only from the verified token. A forged-key token yields no claims (reuses the
+existing `_RejectsForgedKey` harness).
+- **Roles are structurally unforgeable outside the JWT path** — the `Verified`
+constructor is the only way to set them (RR-TQBZ2U). This replaces a
+documentation-and-vigilance control with a compiler-enforced one.
+- **Fail-closed preserved.** An invalid token still falls through the chain
+(`_InvalidTokenFallsThrough`) and must not produce a Principal with roles.
+- **`isUnstamped` is not touched** — see the decision below.
+- **No leakage in errors.** 403 bodies already omit attributions
+(`ForbiddenError.Error()`, acl.go:137-140); asserted provenance must not change
+that.
+- **Org is inert.** Nothing evaluates it; documented hostilely and pinned by
+`TestOrgIsNotEvaluatedByACL` (RR-9698LN).
+
+## Correction: the unmatched-principal path (RR-HVN18E)
+
+**The first draft of this plan was wrong.** It claimed an unmatched verified
+principal is "currently hard-denied by `isUnstamped`". Traced against source:
+
+- `ResolvePrincipal` returns `("", nil)` on no-match (declarative.go:141-142).
+- `resolvePrincipalEntity` hits `if id == "" || id == p.User { return ctx }`
+(router.go:277-278) and returns ctx **unchanged**.
+- `Principal.User` stays the verified `sub` — non-empty, not `"unknown"` — so
+`isUnstamped` (request.go:190-196) returns **false**.
+
+The request **already proceeds today** with zero roles. The comment at
+router.go:265-268 documents this as intended ("a principal absent from the graph
+is expected, e.g. a break-glass identity").
+
+**Therefore AC10 requires no code change, and `isUnstamped` must not be
+touched.** Relaxing it would weaken the fail-closed gate for every path, not
+just the asserted one — the exact regression this correction exists to prevent.
+
+## Test Plan
+
+- [x] Test scenarios documented for each acceptance criterion
+- [x] Edge cases identified and documented
+- [x] Negative test cases defined (invalid input, error conditions)
+- [x] Integration test approach defined (not just unit tests)
+
+**Test Scenarios:**
+
+| AC | Test |
+|---|---|
+| AC1 | `jwtauth`: ES256 token with all claims via the existing test signer ⇒ assert each `AssertionClaims` field. `dataentry`: stub ⇒ assert Principal accessors. |
+| AC2 | Table: `roles: []`, absent, `null`, `org_id` absent ⇒ valid Principal, empty fields, no error, no fallthrough. |
+| AC3 | Existing `TestHeaderPrincipalResolver_*` pass **unmodified**; plus empty org/roles assertions. |
+| AC4 | Existing default-resolver tests unmodified; plus empty-field assertions. |
+| AC5 | Policy `{admin: editor}` + roles `["admin"]` ⇒ `editor` attributed with `Kind: SourceAsserted, Claim: "admin"`. Also the list form `{admin: [editor, auditor]}` ⇒ both. |
+| AC6 | Claim → undeclared role ⇒ zero attributions, no error, no panic. |
+| AC7 | Record with org/roles/RawUser round-trips through `sanitize()`; control chars replaced, over-long elements truncated. |
+| AC8 | Existing `nop_test.go` / `readonly_test.go` unmodified and passing. |
+| AC9 | `aclmap` golden artifact: asserted grant appears in its own labelled section, **not** in the everyone/global slot. |
+| AC10 | Unmatched verified principal proceeds with asserted roles only; `isUnstamped` unchanged. |
+
+**Integration test:** unit tests are not sufficient — the real risk is a field
+silently dropped between layers. Drive a real signed assertion through the
+actual HTTP middleware stack (httptest JWKS, as `jwtauth`'s tests already do)
+and assert (a) the audit record carries org and roles, (b) an ACL decision was
+granted via `SourceAsserted`. This is what catches `resolvePrincipalEntity`
+dropping fields; a resolver unit test would pass while the real path loses them.
+
+**Trust-boundary table test (RR-TQBZ2U):** every non-JWT resolver — env
+(router.go:348), header (router.go:321), default (router.go:295) — asserts empty
+roles. First-class, not a prose bullet: `ChainResolvers` advances purely on
+`p.User != ""` and ignores every other field.
+
+**Edge Cases:**
+
+- `roles: []` / absent / `null` ⇒ empty, no error, no panic.
+- Non-string element (`["admin", 42]`) ⇒ drop the element, keep the rest.
+- Over-cap: 33+ roles, or a 300-rune role ⇒ truncated with a single warn.
+- Duplicate roles ⇒ deduped by the existing `attrKey` seen-map.
+- Claim value colliding with an entity ID ⇒ must NOT grant via `Assignments`
+(the separate-namespace property, tested explicitly).
+- Claim value `" admin"` / `"Admin"` ⇒ no match (exact after trim); blank key
+rejected at load.
+- Two asserted attributions differing only by `Claim` ⇒ deterministic sort.
+- Principal with roles but blank `Tool` ⇒ still rejected (guards the gate).
+- Verified `sub` that is literally `"unknown"` ⇒ known pre-existing 500 via
+`isBlankOrUnknown`; pinned by test, not fixed here.
+- Empty/absent `asserted_role_assignments` ⇒ byte-identical to today.
+- `TestOrgIsNotEvaluatedByACL` ⇒ two OrgIDs, identical decisions.
+
+**Negative Tests:**
+
+- Forged-key / `alg:none` / RS256 / expired ⇒ rejected, no claims, falls
+through (existing harness).
+- Header-mode request carrying a roles-ish header ⇒ no roles.
+- Unknown top-level `acl.yaml` key ⇒ still warns (proves `knownPolicyKeys` was
+updated, not bypassed).
+
+## Risk Assessment
+
+- [x] Technical risks assessed with mitigations
+- [x] Security risks assessed (see Security Considerations)
+- [x] Effort estimated (xs/s/m/l/xl)
+
+**Risks:** full list on TKT-RP3X3Q. The ones shaping implementation order:
+
+1. **`SourceKind` additions are compiler-silent** — every switch has a default.
+Mitigation: a reflective/exhaustive guard test, plus the `lessSource` tiebreak
+(RR-74XCVE).
+2. **`resolvePrincipalEntity` rebuilds the Principal field-by-field** — new
+fields dropped by default. Mitigation: the end-to-end integration test.
+3. **The `Verified` constructor touches 21 construction sites** and changes a
+published JSON wire format. Mitigation: `IsZero()` for the `mcp` guard, custom
+marshal/unmarshal, and existing audit round-trip tests.
+4. **`acl map` mis-reporting** would be worse than under-reporting
+(RR-MZFKO7). Mitigation: distinct section, golden-artifact test.
+
+**Effort:** m, trending toward the upper end after review — the `Verified`
+constructor and the custom JSON marshalling are more surface than the original
+plan assumed.
+
+## Documentation Planning
+
+- [x] User-facing docs identified
+- [x] Docs-checklist will be created when entering implementation
+
+**Documentation Impact:**
+
+- [x] `docs/acl-overview.md` — the new key with both YAML forms, plus the
+"Rules and fallbacks" list the existing keys carry (no-match, undeclared-role,
+`EveryoneRole` rejection, absent-key no-op default).
+- [x] `docs/acl-security.md` — trust boundary (roles only after signature
+verification; a header must never be a role source); the 9-minute stale-role
+window stated concretely (**a revoked admin keeps admin in rela for up to 9
+minutes**, and rela has no revocation channel — an operator planning incident
+response must know this); the org-is-not-isolation warning.
+- [x] `docs/server-security.md` — the widened claim surface on the JWT path.
+- [x] `docs/audit-log.md` — new fields, and the org-is-not-isolation warning.
+- [x] `internal/principal` package doc — record that this is the ACL-gated
+growth the doc anticipated, so the "don't grow speculatively" warning keeps its
+force.
+- [ ] ~~docs/metamodel.md, docs/cli-reference.md, docs/data-entry.md~~
+(N/A: no metamodel, CLI or UI surface changes)
+
+## Design Review
+
+- [x] Run `/design-review` before starting implementation
+- [x] All critical/significant findings addressed in plan
+
+**Design Review Findings:** RR-HVN18E, RR-3TKDR9, RR-QZVYVJ (critical);
+RR-CHW2AA, RR-7F05HH, RR-MZFKO7, RR-0VHKMW, RR-74XCVE, RR-TQBZ2U (significant);
+RR-9698LN (minor). All 10 `addressed`; two corrected factual errors in the
+original plan (RR-HVN18E, RR-CHW2AA).

--- a/tickets/entities/review-checklists/REV-0JRAHK.md
+++ b/tickets/entities/review-checklists/REV-0JRAHK.md
@@ -1,0 +1,84 @@
+---
+id: REV-0JRAHK
+type: review-checklist
+title: 'Review: Surface org_id and roles from verified identity assertions'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Automated checks
+
+- [x] `just test` — full suite passes
+- [x] `just lint` — 0 issues
+- [x] `just coverage-check` — PASS (76.3%, both thresholds)
+- [x] `just arch-lint` — OK, no warnings (jwtauth stayed a leaf)
+- [x] `go test -race` on all six touched packages — clean
+
+## Code review
+
+- [x] `cranky-code-reviewer` run against the branch diff
+- [x] All critical/significant findings addressed
+
+**Findings: 2 (1 significant, 1 minor). Both fixed.**
+
+| ID | Severity | Finding | Status |
+|---|---|---|---|
+| RR-IK355A | significant | Padded `asserted_role_assignments` key loads clean but is permanently unmatchable | addressed |
+| RR-S14ZKC | minor | `Principal` accessors handed out the roles backing array by value | addressed |
+
+**RR-IK355A is a real bug the design review did not catch**, because it only
+existed once the code was written: `Validate` rejected only all-blank keys,
+while `computeGlobals` trimmed the incoming claim and then compared against the
+untrimmed stored key. I reproduced it independently before accepting it — a `"
+admin"` key loaded clean and matched nothing, in any form. Fixed by normalizing
+keys in `Validate` (not `LoadPolicyBytes`, so no construction path bypasses it)
+rather than patching the comparison. Both regression tests were fault-injected
+to confirm they fail without the fix.
+
+The reviewer also confirmed, by direct probing rather than inspection, several
+properties I had asserted but not proven:
+
+- `principal.Verified` has exactly two production call sites, both on the JWT
+path; no reflection, no `unsafe`, no exported setter.
+- `UnmarshalJSON` is unreachable from any request path — the only struct
+embedding `Principal` with a JSON tag is `audit.Record`, and all 11 of its call
+sites are write-side. The safety comment on the method is accurate.
+- `org_id`/`org_slug` are genuinely inert: the only non-test uses of the
+accessors are the re-stamp rebuild and `Roles()` in the resolver.
+- The role bounds are non-bypassable — 100 junk elements followed by 40 strings
+still yields exactly 32, because the cap is checked on output length.
+- `truncateRunes` is multibyte-correct (300 `é` → 256 runes, no split codepoint).
+
+**On `TestNonJWTResolvers_CannotSetAssertedClaims`:** I asked the reviewer
+specifically whether my own comment — that this test may be structurally unable
+to fail — was honest, and whether the test is worth keeping. Verdict: the
+comment is accurate and the test should stay. It is a canary, not a proof; it
+fails the moment someone exports the fields or hands a second resolver
+`Verified`, which is the realistic regression. Its `got.User == ""` guard keeps
+it from silently degrading into asserting nothing.
+
+## Acceptance verification
+
+All 10 ACs verified with named tests — see the table in IMPL-5NC7AC. Two guards
+(the exhaustive `SourceKind` check and the re-stamp drop) were fault-injected
+rather than assumed; both fail correctly with actionable diagnostics when the
+fix is reverted.
+
+Test-coverage gaps the reviewer identified, now closed:
+
+- `TestAssertedRoles_PaddedClaimKeyIsNormalized` / `_PaddedKeysMergeRatherThanClobber`
+- `TestPrincipal_AccessorsDoNotShareBackingArray`
+- `TestNonJWTResolvers_ResolvePrincipalEntityIsTheOnlyOtherVerifiedCaller`
+
+## Docs
+
+- [x] `docs/acl-overview.md` — the new key, both YAML forms, rules and fallbacks
+- [x] `docs/acl-security.md` — trust boundary, the 9-minute revocation lag
+stated concretely, and an explicit "org is recorded, not enforced" section
+- [x] `docs/server-security.md` — the widened claim surface
+- [x] `docs/audit-log.md` — new fields plus the org-is-not-isolation warning
+- [x] `internal/principal` package doc — records that this is the ACL-gated
+growth the doc anticipated, and where the new limit now sits
+- [x] `TestDocs_AclOverviewExampleWorks` parses the documented YAML verbatim,
+so the example cannot rot silently

--- a/tickets/entities/review-responses/RR-0VHKMW.md
+++ b/tickets/entities/review-responses/RR-0VHKMW.md
@@ -1,0 +1,30 @@
+---
+id: RR-0VHKMW
+type: review-response
+title: 'No bound on the roles array: unbounded per-request work and audit growth from a token'
+finding: 'Nothing in the plan caps len(roles) or per-element length. A signature-verified token means the IdP said it, not that it is small — a compromised or buggy IdP, or pathological group membership, yields a very large roles array. Per request that is N map lookups in computeGlobals (cheap), N clean() calls plus a proportionally huge JSONL audit line (not cheap), and N entries in the attribution slice flowing into Decision.Attributions and denial diagnostics. The existing discipline is right there: sanitizeUser''s 256-rune cap (dataentry/router.go:465, principalUserMaxLen). The bound belongs in the jwtauth projection, not in dataentry, so every future consumer inherits it rather than the next entry point missing it.'
+severity: significant
+resolution: 'Accepted. Bounds added in the jwtauth projection (NOT in dataentry), so every future consumer inherits them rather than the next entry point silently missing the cap — the reviewer''s placement argument is right. Concretely: cap the roles array at 32 elements and each element at the existing principalUserMaxLen (256 runes), mirroring sanitizeUser''s discipline at dataentry/router.go:465; drop the excess and log once at slog.Warn so truncation is visible rather than silent. Rationale recorded on the ticket: signature verification proves the IdP asserted the claim, not that it is bounded — a buggy or compromised IdP, or pathological group membership, otherwise turns one request into N map lookups, N clean() calls and a proportionally huge JSONL audit line.'
+status: addressed
+---
+
+## Finding
+
+The plan places no cap on `len(roles)` or on per-element length. "Verified"
+means the IdP asserted it, not that it is bounded — a compromised or buggy IdP,
+or a user with pathological group membership, produces a very large array.
+
+Per-request consequences: N map lookups in `computeGlobals` (cheap), N `clean()`
+calls plus a proportionally huge JSONL audit line (not cheap), and N entries in
+the attribution slice, which flows into `Decision.Attributions` and denial
+diagnostics.
+
+## Resolution
+
+Mirror the existing discipline — `sanitizeUser`'s 256-rune cap
+(`dataentry/router.go:465`, `principalUserMaxLen`). Cap element count (32 is
+generous for a role set) and per-element length, drop the excess, log once at
+`slog.Warn`.
+
+**Put the bound in the `jwtauth` projection, not in `dataentry`**, so every
+future consumer inherits it instead of the next entry point silently missing it.

--- a/tickets/entities/review-responses/RR-3TKDR9.md
+++ b/tickets/entities/review-responses/RR-3TKDR9.md
@@ -1,0 +1,43 @@
+---
+id: RR-3TKDR9
+type: review-response
+title: Adding a slice field to Principal breaks == comparison in mcp.NewServer guard
+finding: internal/mcp/server.go:166 does `s.principal == (principal.Principal{})`. Principal is currently comparable (three string fields); the plan adds AssertedRoles []string, and slices are not comparable, so this stops compiling. The file is absent from the plan's Files to modify list. The build break is benign; the hazard is the reflexive fix — reflect.DeepEqual would silently change the guard's meaning so a Principal carrying only asserted roles would no longer count as zero.
+severity: critical
+resolution: 'Confirmed: mcp/server.go:166 does `s.principal == (principal.Principal{})` and Principal becomes non-comparable once it carries a slice field (unexported per RR-TQBZ2U, but unexported slices still break ==). Resolution: add an explicit IsZero() method on Principal and replace the comparison with `s.principal.IsZero()`. This is now unambiguous rather than a judgement call under compile pressure — the RR-TQBZ2U constructor decision means the semantics are defined in one place. Explicitly NOT reflect.DeepEqual, which would silently change the guard so a Principal carrying only roles no longer counts as zero. internal/mcp/server.go added to the plan''s Files to modify. Test: a Principal carrying only asserted roles still fails the NewServer guard.'
+status: addressed
+---
+
+## Finding
+
+`internal/mcp/server.go:166`:
+
+```go
+if s.principal == (principal.Principal{}) {
+    return nil, errors.New("mcp.NewServer: Principal is required (use WithPrincipal)")
+}
+```
+
+`principal.Principal` is currently comparable (three string fields). The plan
+adds `AssertedRoles []string` — **slices are not comparable, so this stops
+compiling.** `internal/mcp/server.go` is absent from the plan's "Files to
+modify" list.
+
+## Impact
+
+The build break is the benign half. The hazard is the reflexive fix under time
+pressure:
+
+- `reflect.DeepEqual` — a silent behaviour change; a Principal carrying only
+`AssertedRoles` would no longer be "zero", so a caller that set roles but no
+User/Tool would pass a guard designed to reject it.
+- `s.principal.User == "" && s.principal.Tool == ""` — correct, but must be a
+deliberate choice with a test, not a compile-error patch.
+
+## Resolution
+
+Make the replacement an explicit plan step with the chosen predicate stated, and
+add a test that a Principal carrying **only** asserted roles still fails the
+guard. 87 `principal.Principal{...}` composite literals exist repo-wide (21 in
+non-test code); verify none other relies on comparability or uses Principal as a
+map key before implementing.

--- a/tickets/entities/review-responses/RR-74XCVE.md
+++ b/tickets/entities/review-responses/RR-74XCVE.md
@@ -1,0 +1,38 @@
+---
+id: RR-74XCVE
+type: review-response
+title: lessSource lacks a Claim tiebreak; widening subjectVerifier naively defeats the seam's purpose
+finding: Two ordering/layering gaps. (1) lessSource (acl/source.go:152-163) sorts on priority, Group, Ancestor, Relation. A new Source.Claim field not added to that chain makes two asserted attributions differing only by Claim compare equal, so PrimarySource and mergeRoutes (aclmap/whocan.go:98-112) produce non-deterministic output. The plan mentions adding a lessRoute tiebreak for aclmap but not lessSource for acl; both need it. (2) The plan says to 'widen the subjectVerifier seam (router.go:362)'. That interface is deliberately one method returning (string, error) so dataentry does not import jwtauth, per the consumer-side-interface rule in CLAUDE.md. If widening means returning a jwtauth.AssertionClaims, dataentry now imports jwtauth and the seam's entire purpose is gone — precisely the 'leak implementation types via return values' failure CLAUDE.md calls out. The plan gestures at the adapter pattern but never states the resolution.
+severity: significant
+resolution: 'Both parts accepted. (1) Confirmed lessSource (acl/source.go:152-163) sorts on priority/Group/Ancestor/Relation only; Claim is added to that tiebreak chain AND to lessRoute in aclmap, with a test that two attributions differing only by claim sort deterministically. Without it PrimarySource and mergeRoutes emit non-deterministic order, which would surface as a flaky golden-artifact test rather than an obvious bug. (2) Seam shape decided explicitly: option (a) — dataentry declares its own small claims struct, and the cmd/rela-server adapter translates from jwtauth.AssertionClaims, exactly as webhookVerifierAdapter already does (main.go:244-252). dataentry does NOT import jwtauth, so the consumer-side-interface rule holds and this composes with RR-CHW2AA keeping jwtauth a leaf. Returning jwtauth.AssertionClaims through the seam is explicitly rejected — that is the ''leak parsing types via return values'' failure CLAUDE.md names.'
+status: addressed
+---
+
+## Finding
+
+**1. `lessSource` has no `Claim` tiebreak.**
+
+`acl/source.go:152-163` sorts on `(priority, Group, Ancestor, Relation)`. A new
+`Source.Claim` field absent from that chain makes two asserted attributions
+differing only by claim compare **equal**, so `PrimarySource` and `mergeRoutes`
+(`aclmap/whocan.go:98-112`) emit non-deterministic order. The plan calls out the
+`lessRoute` tiebreak for `aclmap` but omits `lessSource` for `acl`. Both need
+it.
+
+**2. Widening `subjectVerifier` naively defeats its purpose.**
+
+The plan says "widen the `subjectVerifier` seam (`router.go:362`)". That
+interface is deliberately one method returning `(string, error)` so `dataentry`
+does not import `jwtauth` — the consumer-side-interface rule in CLAUDE.md.
+
+If widening means returning a `jwtauth.AssertionClaims`, `dataentry` imports
+`jwtauth` and the seam's whole reason for existing is gone. This is exactly the
+"don't leak storage or parsing types via return values" failure CLAUDE.md names.
+
+## Resolution
+
+- Add `Claim` to the `lessSource` tiebreak chain and to `lessRoute`; test that
+two attributions differing only by claim sort deterministically.
+- Pick one seam shape explicitly: (a) `dataentry` declares its own small claims
+struct and the `cmd/rela-server` adapter translates, or (b) the interface
+returns the individual values. Either is fine; leaving it unstated is not.

--- a/tickets/entities/review-responses/RR-7F05HH.md
+++ b/tickets/entities/review-responses/RR-7F05HH.md
@@ -1,0 +1,39 @@
+---
+id: RR-7F05HH
+type: review-response
+title: AC7 'sanitised the same way as User/Tool' is not implementable for []string; RawUser already unsanitised
+finding: 'AC7 says roles are sanitised the same way User/Tool are (audit/filesystem.go:204). clean() takes and returns a string (filesystem.go:227) — it cannot sanitize []string, so AC7 as phrased is satisfiable by doing nothing. A per-element loop is required. On the injection question the plan''s implicit worry is overstated: the JSONL writer marshals via encoding/json which escapes newlines inside strings, so a crafted role cannot forge a log line. But clean()''s real jobs still apply per element: the 1024-rune fieldLimit cap (filesystem.go:183) and control-char replacement. Separately, RawUser is NOT sanitised at filesystem.go:204-205 — currently safe by construction because it is only ever set from an already-sanitizeUser''d value at router.go:280, but that is an unpinned invariant sitting in the exact function this ticket edits.'
+severity: significant
+resolution: 'Confirmed: clean() is func(string) string at filesystem.go:227 and cannot take []string, so AC7''s ''sanitised the same way as User/Tool'' was satisfiable by doing nothing. AC7 restated concretely: sanitize() gains a per-element loop applying clean() to each role plus the element-count cap from RR-0VHKMW, and the org fields get clean() like User/Tool. The reviewer''s correction is accepted: encoding/json escapes newlines inside strings, so a crafted role cannot forge a JSONL audit line — the log-injection worry is overstated and is NOT the justification; the real reasons are the 1024-rune fieldLimit cap (filesystem.go:183) and control-char replacement. RawUser is also added to sanitize() while in the function: currently safe by construction (only ever set from an already-sanitizeUser''d value at router.go:280) but an unpinned invariant in the exact function this ticket edits, and one line to close.'
+status: addressed
+---
+
+## Finding
+
+`sanitize` (`audit/filesystem.go:199-209`):
+
+```go
+rec.Principal.User = clean(rec.Principal.User)
+rec.Principal.Tool = clean(rec.Principal.Tool)
+```
+
+`clean` takes and returns a `string` (`filesystem.go:227`). **It cannot sanitize
+`[]string`.** AC7's "sanitised the same way `User`/`Tool` are" is therefore not
+an implementation — as phrased it would be satisfied by doing nothing.
+
+**On log injection: the plan's implicit worry is overstated.** The JSONL writer
+marshals via `encoding/json`, which escapes `\n` inside strings, so a newline in
+a role does *not* forge an audit line. But `clean`'s actual jobs still apply per
+element: the 1024-rune cap (`fieldLimit`, `filesystem.go:183`) and control-char
+replacement.
+
+**Adjacent pre-existing gap:** `RawUser` is not sanitised at
+`filesystem.go:204-205`. It is currently safe by construction — only ever set
+from an already-`sanitizeUser`'d value at `router.go:280` — but that is an
+unpinned invariant sitting in the exact function this ticket edits.
+
+## Resolution
+
+- Restate AC7 concretely: a per-element loop applying `clean` to each role,
+plus the element-count cap from the roles-bound finding.
+- Fix `RawUser` while in the function; one line, and it removes a latent trap.

--- a/tickets/entities/review-responses/RR-9698LN.md
+++ b/tickets/entities/review-responses/RR-9698LN.md
@@ -1,0 +1,39 @@
+---
+id: RR-9698LN
+type: review-response
+title: OrgID in the audit log looks like tenant isolation but nothing enforces it
+finding: 'Carrying OrgID/OrgSlug with nothing evaluating them is defensible for audit attribution, but the plan understates the risk. An operator who sees org_id in the audit log will reasonably conclude rela is org-aware. It is not: computeGlobals (acl/resolver.go:16-49), readQuery (acl/readquery.go:27-74) and grantForRole (acl/access.go:86-113) never read it. A user in org A holding an asserted role sees every entity that role grants across every org — a tenant-isolation hole that looks closed from the audit log. Mitigations are cheap and none are in the plan: a hostile godoc on the fields stating attribution-only and that presence in the audit log does NOT imply isolation; the same warning in docs/audit-log.md and docs/acl-security.md; and a TestOrgIsNotEvaluatedByACL pinning identical decisions for two different OrgIDs, so the absence of enforcement is deliberate rather than mistakable for oversight.'
+severity: minor
+resolution: 'Accepted with all three mitigations — org ships, but hostile-documented. (1) Godoc on the accessor methods and fields in internal/principal stating: attribution only, nothing in internal/acl evaluates these, and presence in the audit log does NOT imply tenant isolation. Placed where an implementer reading principal.go cannot miss it. (2) The same warning in docs/audit-log.md beside the new fields and in docs/acl-security.md. (3) A TestOrgIsNotEvaluatedByACL pinning identical decisions for two principals differing only in OrgID — it makes the ABSENCE of enforcement deliberate and machine-checked rather than mistakable for oversight, and fails loudly the day someone adds half an org check. The underlying risk is real and worth restating: a user in org A holding an asserted role currently sees every entity that role grants across every org. Enforcement is TKT-follow-up (org matching), which this test will conflict with by design when it lands.'
+status: addressed
+---
+
+## Finding
+
+Shipping `OrgID`/`OrgSlug` with nothing evaluating them is justified by the
+audit-attribution value — post-incident "which tenant was this?" without a graph
+round-trip. But the plan understates the failure mode.
+
+An operator who sees `org_id` in the audit log will reasonably conclude rela is
+org-aware. It is not: `computeGlobals` (`acl/resolver.go:16-49`), `readQuery`
+(`acl/readquery.go:27-74`) and `grantForRole` (`acl/access.go:86-113`) never
+read it. **A user in org A holding an asserted role sees every entity that role
+grants, across every org** — a tenant-isolation hole that looks closed from the
+audit log.
+
+## Resolution
+
+Ship it, with all three mitigations (cheap, none currently in the plan):
+
+1. Godoc on the fields: *"Attribution only. Nothing in `internal/acl` evaluates
+these. Presence in the audit log does NOT imply tenant isolation."* Placed where
+an implementer reading `principal.go` will hit it.
+2. The same warning in `docs/audit-log.md` beside the new fields, and in
+`docs/acl-security.md`.
+3. A `TestOrgIsNotEvaluatedByACL` — same principal, two different `OrgID`s,
+identical decisions. It pins the *absence* of enforcement so a later reader
+cannot mistake omission for oversight, and it fails loudly the day someone adds
+half an org check.
+
+Without these it is a loaded gun: a field that looks like tenant isolation will
+get trusted as if it were, by someone who was not in this review.

--- a/tickets/entities/review-responses/RR-CHW2AA.md
+++ b/tickets/entities/review-responses/RR-CHW2AA.md
@@ -1,0 +1,38 @@
+---
+id: RR-CHW2AA
+type: review-response
+title: jwtauth is a declared arch-lint leaf; the plan's jwtauth->principal dependency fails CI
+finding: 'The plan''s Dependencies line states "jwtauth -> principal (new, one-way)". .go-arch-lint.yml:469-473 declares jwtauth with `canUse: [jwtlib]` — canUse, not mayDependOn — i.e. a leaf with zero internal dependencies, and the comment says so deliberately: "Leaf: verifies signed JWTs against a JWKS. No internal deps; only the JWT vendor libs. The dataentry resolver consumes it via a local interface." Adding the edge fails `just arch-lint`. The dependency is also unnecessary: AssertionClaims is jwtauth''s own type and dataentry maps it to principal.Principal at router.go:405, exactly as the existing subjectVerifier seam keeps dataentry from importing jwtauth. The plan''s step 3 already describes the correct wiring via the webhookVerifierAdapter pattern; only the Dependencies line contradicts it.'
+severity: significant
+resolution: 'Confirmed: .go-arch-lint.yml:469-473 declares jwtauth with `canUse: [jwtlib]` (canUse, not mayDependOn) with a comment stating the leaf status is deliberate. The claimed jwtauth->principal edge is dropped from the plan''s Dependencies — it was never needed. AssertionClaims stays jwtauth''s own type; the mapping to principal.Principal happens at the dataentry construction site via the principal.Verified constructor, and cmd/rela-server adapts between them exactly as webhookVerifierAdapter already does (main.go:244-252). jwtauth remains a leaf. `just arch-lint` is part of the pre-PR check per CLAUDE.md, so this is verified rather than assumed.'
+status: addressed
+---
+
+## Finding
+
+`.go-arch-lint.yml:469-473`:
+
+```yaml
+  jwtauth:
+    # Leaf: verifies signed JWTs against a JWKS. No internal deps; only the JWT
+    # vendor libs. The dataentry resolver consumes it via a local interface.
+    canUse:
+      - jwtlib
+```
+
+`canUse`, not `mayDependOn` — a declared leaf with zero internal dependencies,
+and the comment says so on purpose. The plan's claimed `jwtauth → principal`
+edge fails `just arch-lint`.
+
+## Resolution
+
+Drop the edge; it is not needed. `AssertionClaims` is jwtauth's own type, and
+`dataentry` maps it to `principal.Principal` at the construction site
+(`router.go:405`) — the same discipline the existing `subjectVerifier` seam
+(`router.go:362`) uses to keep `dataentry` from importing `jwtauth`. The plan's
+step 3 already describes this correctly via the `webhookVerifierAdapter` pattern
+(`cmd/rela-server/main.go:244-252`); only the Dependencies line contradicts it.
+
+Related: see the finding on widening the `subjectVerifier` seam — if widening
+means returning a `jwtauth.AssertionClaims`, `dataentry` imports `jwtauth` and
+the seam's whole purpose is lost.

--- a/tickets/entities/review-responses/RR-FCWJ8Q.md
+++ b/tickets/entities/review-responses/RR-FCWJ8Q.md
@@ -1,0 +1,56 @@
+---
+id: RR-FCWJ8Q
+type: review-response
+title: normalizeAssertedRoles merge was non-deterministic and aliased caller slices
+finding: 'Two defects introduced BY the RR-IK355A fix commit (b1657597), both in normalizeAssertedRoles (policy.go). (1) Non-determinism: Go randomizes map iteration, so when several padded keys collapse to one trimmed key, which is stored first and which merges into it varies per run. Verified: 500 loads of {admin:[editor], '' admin '':[auditor], ''admin\t'':[reviewer]} produced 3 distinct orderings. Downstream reporting sorts (AssertedGrants, routesFromAttributions), so no golden artifact flakes today — but the same policy text yielded a different in-memory state on every load, and the resolver''s attribution append order varied. (2) Aliasing: the non-collision branch stored the caller''s RoleList header directly, then a later collision did append(existing, r) on it. With spare capacity that writes past len into the caller''s backing array. Verified with a constructed probe: a sibling slice''s SENTINEL element was overwritten. Unreachable via LoadPolicy (the YAML unmarshaler hands over fresh slices), but Validate''s godoc explicitly invites operators to call it on a hand-built policy, and this fix''s own rationale was that policies arrive by paths other than LoadPolicy — so it widened the contract and then wrote code safe only for the narrow one.'
+severity: significant
+resolution: 'Both fixed in normalizeAssertedRoles: slices.Clone on store so a caller-owned slice is never appended into, and slices.Sort on merged lists only (an unmerged list keeps the operator''s authored order, which is what they see in acl map output). The godoc now states both invariants and why each is load-bearing. Two regression tests added and fault-injected: TestAssertedRoles_MergeIsDeterministic (50 loads, fails with ''merge order varies between loads: run 0 = [editor auditor reviewer], run 3 = [reviewer editor auditor]'') and _MergeDoesNotAliasCallerSlices (fails with ''merge clobbered a caller-owned slice'').'
+status: addressed
+---
+
+## Finding
+
+Two defects introduced **by** the RR-IK355A fix commit, both in
+`normalizeAssertedRoles` (`policy.go`).
+
+**1. Non-deterministic merge.** Go randomizes map iteration, so when several
+padded keys collapse to one trimmed key, which is stored first and which merges
+into it varies per run. Verified — 500 loads of `{admin:[editor], " admin
+":[auditor], "admin\t":[reviewer]}`:
+
+```text
+[editor auditor reviewer] -> 381
+[auditor reviewer editor] ->  63
+[reviewer editor auditor] ->  56
+```
+
+Downstream reporting sorts (`AssertedGrants`, `routesFromAttributions`), so no
+golden artifact flakes today. But the same policy text yielded a different
+in-memory state on every load, and the resolver's attribution append order
+varied with it.
+
+**2. Aliasing.** The non-collision branch stored the caller's `RoleList` header
+directly; a later collision then did `append(existing, r)` on it. With spare
+capacity that writes **past len into the caller's backing array**. Verified with
+a constructed probe — a sibling slice's `SENTINEL` element was overwritten.
+
+Unreachable via `LoadPolicy` (the YAML unmarshaler hands over fresh slices). But
+`Validate`'s godoc explicitly invites operators to call it on a hand-built
+policy, and this fix's own rationale for living in `Validate` was that policies
+arrive by paths other than `LoadPolicy`. It widened the contract and then wrote
+code safe only for the narrow one.
+
+## Resolution
+
+- `slices.Clone` on store, so a caller-owned slice is never appended into.
+- `slices.Sort` on **merged lists only** — an unmerged list keeps the
+operator's authored order, which is what they see in `acl map` output.
+- The godoc now states both invariants and why each is load-bearing.
+
+Two regression tests, both fault-injected:
+
+- `TestAssertedRoles_MergeIsDeterministic` — 50 loads; fails with *"merge
+order varies between loads: run 0 = [editor auditor reviewer], run 3 = [reviewer
+editor auditor]"*.
+- `TestAssertedRoles_MergeDoesNotAliasCallerSlices` — fails with *"merge
+clobbered a caller-owned slice"*.

--- a/tickets/entities/review-responses/RR-HVN18E.md
+++ b/tickets/entities/review-responses/RR-HVN18E.md
@@ -1,0 +1,52 @@
+---
+id: RR-HVN18E
+type: review-response
+title: AC10 decision written against isUnstamped behaviour that does not exist; wrong fix is a broad authz regression
+finding: 'The ticket''s unmatched-principal decision and the plan claim an unmatched verified principal is currently hard-denied by isUnstamped. This is factually wrong: ResolvePrincipal returns ("", nil) on no-match (acl/declarative.go:141-142), resolvePrincipalEntity returns ctx unchanged (dataentry/router.go:277-278), so Principal.User stays the verified sub and isUnstamped returns false (acl/request.go:190-196). The request already proceeds today with zero roles. AC10 needs no code change — but the plan invites an implementer to relax isUnstamped, which is the only gate catching entry points that forgot to stamp identity, for every path. That would be a broad silent authz regression.'
+severity: critical
+resolution: 'Confirmed against source and the ticket''s decision section rewritten. Verified trace: ResolvePrincipal returns ("", nil) at declarative.go:141-142; resolvePrincipalEntity returns ctx unchanged at router.go:277-278; Principal.User stays the verified sub so isUnstamped returns false at request.go:190-196. The pre-existing comment at router.go:265-268 documents this as intended ("a principal absent from the graph is expected, e.g. a break-glass identity"). AC10 therefore requires no code change and the plan no longer implies one. isUnstamped is explicitly OUT OF SCOPE and must not be touched — stated as such on the ticket so an implementer cannot read scope into it. Two tests added: (a) unmatched verified principal proceeds with asserted roles only, pinning the behaviour so it cannot drift; (b) a Principal with asserted roles but blank Tool is still rejected, guarding the fail-closed gate against exactly the bad fix this finding warns about. The sub-sanitizes-to-"unknown" hazard (isBlankOrUnknown, request.go:199-202) is recorded as a known pre-existing edge with a test, not fixed here.'
+status: addressed
+---
+
+## Finding
+
+The ticket's unmatched-principal decision and the plan's Edge Cases both claim
+an unmatched verified principal is "currently hard-denied by `isUnstamped`".
+**This is factually wrong.** Traced:
+
+- `ResolvePrincipal` returns `("", nil)` on no-match (`acl/declarative.go:141-142`).
+- `resolvePrincipalEntity` hits `if id == "" || id == p.User { return ctx }`
+(`dataentry/router.go:277-278`) and returns ctx **unchanged** — no re-stamp.
+- `Principal.User` therefore remains the verified `sub`: non-empty and not
+`"unknown"`, so `isUnstamped` (`acl/request.go:190-196`) returns **false**.
+- `ForPrincipal` succeeds; the request proceeds today with zero global roles
+(`walkMembers` returns `{sub}`, `Assignments[sub]` misses).
+
+The existing doc comment at `router.go:265-268` states this intent outright: "a
+principal absent from the graph is expected, e.g. a break-glass identity
+assigned by raw UPN".
+
+## Impact
+
+Two directions, the second serious:
+
+1. **AC10 requires no code change.** The decision the user made is already the
+system's behaviour.
+2. **The plan invites a dangerous non-change.** An implementer reading "must
+keep hard-denying … the change here is that a verified principal is not
+unstamped merely because its subject has no entity" will go relax `isUnstamped`.
+That gate is the only thing catching an entry point that forgot to stamp
+identity, and its 500 (`router.go:229-240`) is load-bearing for **every** path,
+not just the asserted one. Relaxing it is a broad, silent authz regression.
+
+## Resolution
+
+Rewrite the decision section against what the code actually does. State
+explicitly: **`isUnstamped` is not to be touched by this ticket.** Add a test
+pinning "unmatched verified principal proceeds with asserted roles only,
+`isUnstamped` unchanged" so the absence of a change is deliberate and durable.
+
+Secondary hazard worth a test: a verified `sub` that sanitises to the literal
+`"unknown"` is treated as unstamped by `isBlankOrUnknown` (`request.go:199-202`)
+→ 500. Pre-existing, but asserted roles make it worse — a principal with valid
+cryptographic grants gets a 500 instead of its grants.

--- a/tickets/entities/review-responses/RR-IK355A.md
+++ b/tickets/entities/review-responses/RR-IK355A.md
@@ -1,0 +1,57 @@
+---
+id: RR-IK355A
+type: review-response
+title: Whitespace-padded asserted_role_assignments key loads clean but is permanently unmatchable
+finding: 'Validate rejected a claim key only when isBlank (all-blank), but computeGlobals does strings.TrimSpace on the incoming claim and then an EXACT map lookup against the untrimmed stored key. So `asserted_role_assignments: {" admin": editor}` loaded clean and was permanently inert — no claim value could ever match it. Reproduced independently: Validate ACCEPTED '' admin'', and claims "admin", " admin", "admin " all yielded 0 attributions. It fails safe (a grant silently does not happen) but it is exactly the looks-configured-but-does-nothing trap Validate''s own blank-key check exists to prevent, and EffectiveMembershipRelation (policy.go:158-163) already trims its value for the identical reason. Second-order: isBlank only treats ASCII space/tab/CR/LF as blank while TrimSpace also strips Unicode spaces, so an NBSP-only key passed Validate and was likewise inert.'
+severity: significant
+resolution: 'Fixed by normalizing at load rather than patching the comparison. Policy.normalizeAssertedRoles trims every key and is called from Policy.Validate — deliberately in Validate, not LoadPolicyBytes, so a Policy reaching the resolver through any other construction path is normalized too. An all-blank key trims to "" and is then caught by the existing blank-key check, so it still fails loudly instead of normalizing into something matchable; the Unicode-space case now collapses the same way. Keys differing only by padding merge, and their role lists are unioned so no grant is silently dropped. Two regression tests (TestAssertedRoles_PaddedClaimKeyIsNormalized, _PaddedKeysMergeRatherThanClobber) were fault-injected: with normalizeAssertedRoles removed they fail with ''the key was stored untrimmed and is unmatchable'' and ''role "auditor" lost when padded keys merged''.'
+status: addressed
+---
+
+## Finding
+
+`Validate` (`policy.go:466-472`) rejected a claim key only when `isBlank` — all
+characters blank. But `computeGlobals` (`resolver.go:57-59`) trims the
+**incoming claim** and then does an **exact** lookup against the **untrimmed
+stored key**.
+
+Reproduced independently before fixing:
+
+```text
+Validate ACCEPTED key ' admin'
+claim "admin"  -> 0 attributions
+claim " admin" -> 0 attributions
+claim "admin " -> 0 attributions
+```
+
+A padded key is therefore **permanently inert** — no claim value can ever match
+it.
+
+This fails *safe* (a grant silently doesn't happen), which is why it is
+significant rather than critical. But it is precisely the
+looks-configured-but-does-nothing trap `Validate`'s blank-key check exists to
+prevent, and the surrounding code already knows the answer:
+`EffectiveMembershipRelation` (`policy.go:158-163`) trims its value for the
+identical reason.
+
+Second-order: `isBlank` (`policy.go:593-599`) treats only ASCII space, tab, CR
+and LF as blank, while `TrimSpace` also strips Unicode spaces. An NBSP-only key
+passed `Validate` and was likewise inert.
+
+## Resolution
+
+Normalized at load rather than patching the comparison:
+`Policy.normalizeAssertedRoles` trims every key, called from `Policy.Validate` —
+deliberately there and not in `LoadPolicyBytes`, so a `Policy` reaching the
+resolver through any other construction path is normalized too.
+
+- An all-blank key trims to `""` and is caught by the existing blank-key
+check, so it still fails loudly rather than normalizing into something
+matchable.
+- The Unicode-space case collapses the same way.
+- Keys differing only by padding merge; their role lists are **unioned**, so
+no grant is silently dropped.
+
+Both regression tests were fault-injected. With `normalizeAssertedRoles` removed
+they fail with *"the key was stored untrimmed and is unmatchable"* and *"role
+\"auditor\" lost when padded keys merged"*.

--- a/tickets/entities/review-responses/RR-MZFKO7.md
+++ b/tickets/entities/review-responses/RR-MZFKO7.md
@@ -1,0 +1,43 @@
+---
+id: RR-MZFKO7
+type: review-response
+title: AC9's EveryoneGrants mirror is the wrong pattern and produces an actively misleading acl map report
+finding: 'AC9''s mitigation is to report asserted grants globally mirroring EveryoneGrants (acl/access.go:74-80). That pattern does not transfer. EveryoneGrants is a statement of fact: the everyone role genuinely applies to every principal including unauthenticated ones, so reporting it globally is accurate. An asserted grant applies to exactly those principals whose token carries the mapped claim — an unknowable subset, because the population lives in the IdP, not the graph (enumeratePrincipals at aclmap/enumerate.go:41-85 draws from assignment keys, user-entity-type entities, membership edges and role-relation edges; none sees a JWT claim). Rendering an asserted grant in the same global slot tells an operator running `rela acl map` that EVERYONE holds that role. For a mapping like {admin: superuser} that is catastrophically misleading in exactly the moment the report is consulted — post-incident, answering ''who could have done this?'''
+severity: significant
+resolution: 'Accepted — the EveryoneGrants mirror is dropped. The reviewer''s distinction is correct and load-bearing: EveryoneGrants is a statement of fact (the everyone role genuinely does apply to every principal, so reporting it globally is accurate), whereas an asserted grant applies to an unknowable subset whose population lives in the IdP, not the graph (enumeratePrincipals at aclmap/enumerate.go:41-85 draws only from graph-visible sources). Reusing the global slot would tell an operator running `rela acl map` that EVERYONE holds the mapped role — worst possible answer at the worst possible moment, since the report is consulted post-incident to answer ''who could have done this?''. AC9 rewritten: emit a distinct, separately-labelled section (''conditional grants (asserted claims)'') naming claim -> role(s) and stating explicitly that holders are not enumerable from the graph. Does not reuse the Everyone struct or its wire field. Also pinning aclmap/whocan.go:141 by test: it constructs its Principal with no asserted roles, which is correct, so nobody later ''fixes'' enumeration by injecting synthetic roles.'
+status: addressed
+---
+
+## Finding
+
+AC9 mitigates `acl map` under-reporting by "report asserted grants once,
+globally, mirroring `EveryoneGrants` (access.go:74-80)". The pattern does not
+transfer.
+
+`EveryoneGrants` is a **statement of fact**: the everyone role genuinely applies
+to every principal, including unauthenticated ones. Reporting it globally is
+*accurate*.
+
+An asserted grant is the opposite — it applies to **exactly those principals
+whose token carries the mapped claim**, an unknowable subset whose population
+lives in the IdP, not the graph. `enumeratePrincipals`
+(`aclmap/enumerate.go:41-85`) draws from assignment keys, user-entity-type
+entities, membership edge sources and role-relation edge sources; none of them
+can see a JWT claim.
+
+Rendering an asserted grant in the same "global" slot tells an operator that
+**everyone** holds that role. For `{admin: superuser}` that is catastrophically
+misleading in precisely the moment the report is consulted — post-incident,
+answering "who could have done this?"
+
+## Resolution
+
+Use a distinct, honestly-labelled section: *"conditional grants (asserted
+claims): claim `admin` → role `superuser`; holders not enumerable from the
+graph."* Same structural "no enumerable principal" problem, opposite semantics —
+do not reuse the `Everyone` struct or its wire field.
+
+Also worth an explicit test: `aclmap/whocan.go:141` constructs
+`principal.Principal{User: user, Tool: principal.ToolCLI, RawUser: rawShown}`
+with empty asserted roles. That is correct; pin it so nobody later "fixes" the
+enumeration by injecting synthetic roles.

--- a/tickets/entities/review-responses/RR-NKTI9X.md
+++ b/tickets/entities/review-responses/RR-NKTI9X.md
@@ -1,0 +1,54 @@
+---
+id: RR-NKTI9X
+type: review-response
+title: TestPrincipal_AccessorsDoNotShareBackingArray was a tautology, and a commit message vouched for it
+finding: 'The test added for RR-S14ZKC asserted `&a.Roles()[0] == &b.Roles()[0]`. Roles() clones unconditionally, so both sides are freshly allocated and the comparison can never be true — the test passed with Clone() fully reverted. Verified by simulating pre-fix From(): the unexported roles field genuinely aliased (true), while the assertion the test actually made read false. It was an external (package principal_test) test asserting on an invariant only observable on an unexported field. Worse than the missing coverage: commit b1657597''s message claimed ''Both regression tests fault-injected to confirm they fail without the fixes.'' That was true of the two acl tests and FALSE of this one — I did not fault-inject it and should not have vouched for it. A tautology in a security test file is worse than no test, because it advertises coverage that does not exist.'
+severity: significant
+resolution: 'Deleted and replaced with in-package tests (internal/principal/clone_internal_test.go, package principal) that assert on the unexported roles field directly: TestClone_BreaksBackingArraySharing and TestFrom_DoesNotAliasTheContextValue. Both fault-injected — with Clone made a no-op and removed from From(ctx) they fail with ''Clone shares the roles backing array with the original'' and ''two From(ctx) results share the roles backing array''. Added TestClone_ZeroRolesDoesNotAllocate pinning that the no-roles path (every CLI/MCP/scheduler/header request) stays allocation-free, so only the JWT path pays for the guarantee. The file header explains why these must be in-package, naming the tautology so it is not reintroduced.'
+status: addressed
+---
+
+## Finding
+
+`TestPrincipal_AccessorsDoNotShareBackingArray` asserted `&a.Roles()[0] ==
+&b.Roles()[0]`. `Roles()` clones unconditionally, so both sides are freshly
+allocated and the comparison **can never be true** — the test passed with
+`Clone()` fully reverted.
+
+Verified by simulating the pre-fix `From()`:
+
+```text
+unexported roles alias (real sharing):                    true
+assertion my test made (&a.Roles()[0]==&b.Roles()[0]):    false
+```
+
+The bug is genuinely present, and the assertion still reads `false`. It was an
+external (`package principal_test`) test asserting on an invariant only
+observable on an unexported field.
+
+**Worse than the missing coverage:** commit b1657597's message claimed *"Both
+regression tests fault-injected to confirm they fail without the fixes."* That
+was true of the two `acl` tests and **false of this one** — I did not
+fault-inject it and should not have vouched for it. A tautology in a security
+test file is worse than no test, because it advertises coverage that does not
+exist.
+
+## Resolution
+
+Deleted; replaced with in-package tests (`clone_internal_test.go`, `package
+principal`) that assert on the unexported `roles` field directly:
+
+- `TestClone_BreaksBackingArraySharing`
+- `TestFrom_DoesNotAliasTheContextValue`
+
+Both fault-injected — with `Clone` made a no-op and removed from `From(ctx)`
+they fail with *"Clone shares the roles backing array with the original"* and
+*"two From(ctx) results share the roles backing array"*.
+
+Also added `TestClone_ZeroRolesDoesNotAllocate`, pinning that the no-roles path
+— every CLI, MCP, scheduler and header-auth request — stays allocation-free, so
+only the JWT path pays for the guarantee. (Measured: 0 allocs without roles, 1
+with.)
+
+The file header explains why these must be in-package, naming the tautology so
+it is not reintroduced.

--- a/tickets/entities/review-responses/RR-QZVYVJ.md
+++ b/tickets/entities/review-responses/RR-QZVYVJ.md
@@ -1,0 +1,49 @@
+---
+id: RR-QZVYVJ
+type: review-response
+title: map[string]string forecloses one-claim-to-many-roles; EveryoneRole as target double-attributes
+finding: 'The plan''s AssertedRoleAssignments map[string]string allows one role per claim value. Iterating principal.AssertedRoles and looking each up does handle the multi-role user correctly (dedup comes free from the seen[attrKey] guard at acl/resolver.go:22-28), but the realistic operator policy `admin -> [editor, auditor]` is foreclosed, and acl.yaml is a published schema so widening later is breaking. map[string][]string costs nothing now. Separately: if a claim maps TO EveryoneRole as the target, computeGlobals adds it with Source{Kind: SourceAsserted} while the existing block at resolver.go:45-47 adds it with Source{Kind: SourceGlobal} — different attrKey, so the same role is attributed twice and double-reports in aclmap and 403 diagnostics. Also unaddressed: claim values differing only by case or leading/trailing whitespace silently never match, which is a policy that grants nothing and an operator will not notice.'
+severity: critical
+resolution: 'Resolved with the user. Underlying type is map[string][]string (many roles per claim), with a scalar-or-list UnmarshalYAML so `admin: editor` and `admin: [editor, auditor]` both parse. This matches an idiom already in-tree: metamodel.StringOrSlice (internal/metamodel/types.go:696-714) does exactly this — try string, wrap in a slice, else try slice. internal/acl cannot import metamodel (arch-lint), so acl gets its own small equivalent type; metamodel itself carries several such local YAML types, so this is precedented rather than duplication-for-its-own-sake. The EveryoneRole-as-target collision is resolved by rejecting EveryoneRole as a mapping target in Validate (cleaner than accepting and pinning the duplicate attribution). Claim-value matching is exact after TrimSpace, no case folding — pinned by test, and Validate rejects a key that is blank after trimming so a silently-never-matching policy fails loudly at load.'
+status: addressed
+---
+
+## Finding
+
+Two problems with the claim→role mapping shape.
+
+**1. `map[string]string` is a one-way door.**
+
+The ticket's own ground-truth section documents that a Pratique user routinely
+holds several roles (`["admin","billing"]`). Iterating `AssertedRoles` and
+looking each up handles that correctly — and the `seen[attrKey]` dedup at
+`acl/resolver.go:22-28` handles duplicate claim values for free. **The plan is
+right that multi-role works.**
+
+But it is one role *per claim value*. The policy an operator will actually want
+is `admin → [editor, auditor]`, and `map[string]string` forecloses it.
+`acl.yaml` is a published schema, so widening later is a breaking change.
+`map[string][]string` costs nothing today.
+
+**2. `EveryoneRole` as a mapping target double-attributes.**
+
+If a claim maps to `EveryoneRole`, `computeGlobals` adds `add(EveryoneRole,
+Source{Kind: SourceAsserted, Claim: ...})` while the existing block at
+`resolver.go:45-47` already added `add(EveryoneRole, Source{Kind:
+SourceGlobal})`. Different `Source` ⇒ different `attrKey` ⇒ **two attributions
+for one role**, which double-report in `aclmap` and in 403 diagnostics.
+
+**3. Whitespace and case are unspecified.**
+
+`Validate` gains only a non-blank-key check per the plan. A claim value
+`"Admin"` vs `"admin"`, or `" admin"`, silently never matches — a policy that
+grants nothing, which is exactly the failure an operator does not notice.
+`isBlank` (`policy.go:544`) already exists as a precedent.
+
+## Resolution
+
+- Choose `map[string][]string` unless there is a reason not to; document the
+choice in `docs/acl-overview.md`.
+- Reject `EveryoneRole` as a mapping target in `Validate`, or accept it and pin
+the duplicate with a test. Rejecting is cleaner.
+- Decide trim/case-fold semantics explicitly and pin with a test.

--- a/tickets/entities/review-responses/RR-S14ZKC.md
+++ b/tickets/entities/review-responses/RR-S14ZKC.md
@@ -1,0 +1,39 @@
+---
+id: RR-S14ZKC
+type: review-response
+title: Principal accessors handed out the roles backing array by value
+finding: Principal is a value type, so a plain struct copy shares the roles slice backing array even though Verified() clones on the way in and Roles() clones on the way out. acl.Request.Principal() (request.go:151) returned r.principal by value, and principal.From(ctx) returned the ctx-shared value — so a caller could reslice onto the shared array and mutate a role another holder was about to authorize against. Not currently exploitable (no caller does this), but the type's entire premise is that the compiler enforces the trust boundary, and this was the one place it stopped doing so.
+severity: minor
+resolution: 'Added Principal.Clone() (deep copy of the roles slice) and used it at both by-value hand-out sites: acl.Request.Principal() and principal.From(ctx). From(ctx) matters most — the ctx value is shared by every reader for the life of a request, so aliasing there is the widest exposure. TestPrincipal_AccessorsDoNotShareBackingArray asserts both: that Clone''s array is independent, and that two From(ctx) results on the same context do not alias each other.'
+status: addressed
+---
+
+## Finding
+
+`Principal` is a value type. `Verified` clones on the way in and `Roles()`
+clones on the way out, but a plain **struct copy** still shares the `roles`
+backing array.
+
+Two sites handed one out:
+
+- `acl.Request.Principal()` (`request.go:151`) — returned `r.principal` by
+value while the Request was still authorizing against it.
+- `principal.From(ctx)` — returned the ctx-shared value to every reader.
+
+A caller could reslice onto the shared array and mutate a role another holder
+was about to authorize against.
+
+Not currently exploitable — no caller does this. But the type's entire premise
+is that the compiler enforces the trust boundary, and this was the one place it
+stopped doing so.
+
+## Resolution
+
+Added `Principal.Clone()` (deep-copies the roles slice) and applied it at both
+hand-out sites. `From(ctx)` is the more important of the two: the ctx value is
+shared by every reader for the life of a request, so aliasing there has the
+widest blast radius.
+
+`TestPrincipal_AccessorsDoNotShareBackingArray` asserts both properties — that a
+`Clone`'s array is independent, and that two `From(ctx)` results on the same
+context do not alias each other.

--- a/tickets/entities/review-responses/RR-TQBZ2U.md
+++ b/tickets/entities/review-responses/RR-TQBZ2U.md
@@ -1,0 +1,49 @@
+---
+id: RR-TQBZ2U
+type: review-response
+title: Trust boundary is conventional (doc + test) where it could be structural; no test that non-JWT resolvers cannot set roles
+finding: 'The plan''s only protection against a header-sourced role is a doc section and a prose negative test. ChainResolvers (dataentry/router.go:440-450) advances purely on p.User != "" and ignores every other field, so nothing structural stops a future resolver returning {User: x, AssertedRoles: [...]} from a header — that would be full privilege escalation. Two asks. (1) Make the header-cannot-set-roles test a first-class table test over EVERY resolver (env router.go:348, header router.go:321, default router.go:295) asserting empty AssertedRoles, not a prose bullet. (2) Consider making the boundary structural rather than conventional: an unexported field plus a principal.Verified(...) constructor means AssertedRoles cannot be set by a struct literal at all, so all 21 non-test construction sites are compiler-prevented from forging roles. The codebase already shows this instinct in lua''s freezeTable. Cost: Principal stops being literal-constructible and JSON unmarshalling needs a custom UnmarshalJSON. Fallback is a lint test in the spirit of dataentry''s existing grep guards.'
+severity: significant
+resolution: 'Resolved with the user: take the structural option. principal.Principal gains unexported orgID/orgSlug/roles fields plus a principal.Verified(sub, tool, orgID, orgSlug, roles) constructor and accessor methods. Composite literals cannot set them, so all 21 non-test construction sites are compiler-prevented from forging roles — the trust boundary is enforced by the type system rather than by reviewer memory. Mirrors the freezeTable instinct in internal/lua (read-only contract enforced, not conventional). Accepted costs: Principal stops being fully literal-constructible, and audit.Record needs a custom MarshalJSON/UnmarshalJSON pair since Principal is embedded in a published wire format (audit.go:85-94). The unexported fields also resolve RR-3TKDR9 favourably: a struct with unexported slice fields is still non-comparable, so mcp/server.go:166 still needs its guard replaced — but the replacement is now unambiguous (IsZero-style method on Principal). The first-class table test over every resolver (env/header/default asserting empty roles) is still added; it is cheap and guards the runtime behaviour the type system cannot express.'
+status: addressed
+---
+
+## Finding
+
+The plan protects the trust boundary with a doc section and a prose negative
+test. That is weaker than the invariant deserves.
+
+`ChainResolvers` (`dataentry/router.go:440-450`) advances purely on `p.User !=
+""` and ignores every other field. Nothing structural prevents a future resolver
+from returning `{User: "x", AssertedRoles: [...]}` sourced from a header — which
+would be a **full privilege escalation**, since `internal/acl` trusts
+`Principal` absolutely.
+
+## Resolution
+
+**1. Make the negative test first-class.** A table test over *every* resolver —
+env (`router.go:348`), header (`router.go:321`), default (`router.go:295`) —
+asserting empty `AssertedRoles`. This is arguably the single most important
+regression test in the ticket; it should not be a prose bullet.
+
+**2. Consider making the boundary structural.** An unexported field plus a
+constructor in `principal`:
+
+```go
+func Verified(sub, tool, orgID, orgSlug string, roles []string) Principal
+```
+
+means `AssertedRoles` **cannot be set by a struct literal at all** — all 21
+non-test construction sites become compiler-prevented from forging roles. The
+codebase already shows this instinct: `lua`'s `freezeTable` makes a read-only
+contract enforced rather than conventional, and says so in its comment.
+
+Cost: `Principal` stops being plainly literal-constructible, and JSON
+unmarshalling needs a custom `UnmarshalJSON` (nothing in-repo unmarshals
+`audit.Record` today, but it is a published wire format at `audit.go:85-94`).
+Worth paying for a field whose entire security property is "only ever populated
+after signature verification."
+
+Fallback if that is too heavy: a lint test in the spirit of `dataentry`'s
+existing grep guards — no file outside the JWT resolver may mention
+`AssertedRoles:` in a composite literal.

--- a/tickets/entities/tickets/TKT-0C3II2.md
+++ b/tickets/entities/tickets/TKT-0C3II2.md
@@ -1,0 +1,75 @@
+---
+id: TKT-0C3II2
+type: ticket
+title: Auto-provision a user entity for an unmatched verified principal
+kind: enhancement
+priority: medium
+effort: m
+status: backlog
+---
+
+Follow-up to TKT-RP3X3Q. Decide and implement what happens when a
+cryptographically verified principal has **no matching user entity** in the
+graph — today it degrades to an anonymous-but-role-bearing principal.
+
+## Context
+
+TKT-RP3X3Q makes asserted roles from a verified JWT grantable in `acl.yaml`.
+That decoupled role-granting from graph membership, which raised the question:
+what should a verified principal with valid roles but no `user_entity_type`
+entity be able to do?
+
+**Decided for TKT-RP3X3Q (interim):** unmatched principal → anonymous. The
+request stays authenticated and keeps its asserted roles; it simply has no
+resolved user entity, so anything keyed on that entity (local roles via
+`role_relations`, ancestry via `inherit_roles_through`, `principal_property`
+lookups) does not apply. This is a deliberate interim position, not the end
+state.
+
+## Why a follow-up is needed
+
+Behind an OIDC proxy with SSO JIT provisioning, this is not an edge case — it is
+the **first request of every new user**. Pratique will happily mint a valid
+assertion for a freshly-provisioned member (`roles: []` or a default role) who
+has never existed in rela. The anonymous fallback means such a user gets
+asserted-role grants but silently loses every graph-derived affordance, with no
+signal to the operator that a person is transacting without an entity.
+
+Consequences worth designing away:
+
+- **Audit attribution degrades.** Writes are attributed to the raw subject with
+no entity to join against, so per-user history is harder to reconstruct.
+- **Silent, not loud.** Nothing surfaces "N verified principals have no user
+entity" — the operator finds out when someone reports missing permissions.
+- **Drift.** Users provisioned in the IdP and users present in rela diverge
+over time with no reconciliation.
+
+## Questions to answer
+
+1. **Auto-create, or not?** Options: create a `user_entity_type` entity on first
+verified request; create lazily only on first *write*; never create but surface
+an operator report; or an explicit `rela user import` reconciliation command.
+2. **If auto-created, with what?** `sub` is the stable key, but `email`,
+`org_id`/`org_slug` are also on the assertion (see TKT-RP3X3Q for the full
+verified claim set). Which become properties? Which relations, if any?
+3. **Who is the author?** An auto-created entity is a write on the read path —
+which violates the project rule against user-supplied work on reads, and needs a
+system principal, an audit story, and a decision about whether it runs inside a
+`Tx`.
+4. **Idempotency and races.** Concurrent first requests from the same subject
+must not create duplicates. `if_exists: skip` semantics, or a unique constraint
+on the principal property.
+5. **Should it be opt-in?** A deployment that treats the graph as the authority
+on who exists may want unmatched principals rejected outright rather than
+auto-created. Likely a policy key with a fail-closed default.
+6. **Interaction with `isUnstamped`.** The current fail-closed gate
+(`acl/request.go:189`) checks User/Tool only. Any change here touches a security
+gate and needs its own review.
+
+## Notes
+
+- Related: the org-enforcement follow-up also carved out of TKT-RP3X3Q. Both
+concern "what does a verified multi-tenant identity mean to the graph", and may
+want a shared decision record.
+- `create_entity` automations with `if_exists: skip` are the existing in-repo
+precedent for idempotent entity creation.

--- a/tickets/entities/tickets/TKT-RP3X3Q.md
+++ b/tickets/entities/tickets/TKT-RP3X3Q.md
@@ -5,7 +5,7 @@ title: Surface org_id and roles from verified identity assertions
 kind: enhancement
 priority: medium
 effort: m
-status: review
+status: done
 ---
 
 Extract `org_id`, `org_slug` and `roles` from the verified ES256 identity

--- a/tickets/entities/tickets/TKT-RP3X3Q.md
+++ b/tickets/entities/tickets/TKT-RP3X3Q.md
@@ -5,7 +5,7 @@ title: Surface org_id and roles from verified identity assertions
 kind: enhancement
 priority: medium
 effort: m
-status: in-progress
+status: review
 ---
 
 Extract `org_id`, `org_slug` and `roles` from the verified ES256 identity

--- a/tickets/entities/tickets/TKT-RP3X3Q.md
+++ b/tickets/entities/tickets/TKT-RP3X3Q.md
@@ -1,0 +1,211 @@
+---
+id: TKT-RP3X3Q
+type: ticket
+title: Surface org_id and roles from verified identity assertions
+kind: enhancement
+priority: medium
+effort: m
+status: in-progress
+---
+
+Extract `org_id`, `org_slug` and `roles` from the verified ES256 identity
+assertion into `principal.Principal`. Asserted **roles** become grantable in
+`acl.yaml` so policy can express role-based rules rather than per-user
+assignments; **org** is carried for audit attribution only. Verified-JWT path
+only; `--principal-header` and direct-loopback keep working with empty
+org/roles.
+
+## Problem
+
+`internal/jwtauth.VerifySubject` (verifier.go:89-99) parses the assertion into a
+`jwt.MapClaims` and returns **only** `sub` — every other claim is discarded with
+the local map. `JWTPrincipalResolver` (dataentry/router.go:384-407) then builds
+`principal.Principal{User, Tool}` at L405, so a request that arrived behind
+Pratique carrying a verified active org and role set is reduced to a username.
+
+`OrgID` exists in the JWT layer only on `jwtauth.WebhookClaims`
+(verifier.go:107) — the webhook path, not the identity path.
+
+Consequence: `acl.yaml` can only match on `Principal.User`. Roles must be
+restated per-user in `Policy.Assignments`, or derived from graph membership
+edges — duplicating an authority Pratique already maintains and signs.
+
+## Ground truth: Pratique claim shapes
+
+From `pratique/internal/signer/signer.go:186-217` (the minting code — the doc
+sample at `pratique/docs/04-architecture.md:108-124` is stale and omits four
+claims):
+
+| Claim | Type | Presence |
+|---|---|---|
+| `sub` | string | always (`usr_…` / `svc_…`) |
+| `email` | string | always (key present; `""` for service accounts) |
+| `org_id` | string | always |
+| `org_slug` | string | always |
+| `roles` | array of strings | always; guaranteed `[]`, never `null` |
+| `principal_type` | string | always (`user`/`app`/`pat`/`service`) |
+| `client_id`, `scope`, `act` | string/string/object | omitted when unset |
+
+Load-bearing facts:
+
+- **Roles are bare names** (`["admin","billing"]`), scoped to the ONE active
+org on the session — never global, never namespaced, never multi-org. Permission
+expansion stays server-side in Pratique and is never in the token.
+- **A user with no active org never receives an assertion at all**
+(`pratique/internal/app/app.go:405-407` — orgless sessions resolve as
+unauthenticated and redirect to tenant selection). So `org_id: ""` cannot arrive
+on the verified path. AC2's absent-claims case is real for the header/loopback
+paths, not for a genuine Pratique assertion.
+- **`roles` is nil-guarded** at `pratique/internal/app/adapters.go:92-95`.
+- **Assertion TTL is 9 minutes** (`signer.go:22`, hard-coded). Pratique's cache
+key includes roles, so a role change mints fresh on the next proxied request —
+but an assertion already handed downstream stays valid until `exp`. **Rela can
+act on stale roles for up to 9 minutes after a role change in Pratique.** This
+is an accepted cost upstream; faster revocation is not something the assertion
+provides.
+
+**Transport finding (noted, not addressed here):** Pratique sends the assertion
+as `Authorization: Bearer <jwt>` (`pratique/internal/proxy/proxy.go:323`) and
+strips any inbound `Authorization` first. There is no `X-Auth-Assertion` header
+anywhere in Pratique — rela's `--jwt-header` default. The deployment must
+therefore already set `--jwt-header` explicitly. Out of scope; recorded so the
+next person does not rediscover it.
+
+## Scope
+
+**In scope**
+
+- A typed assertion-claims projection in `internal/jwtauth` alongside the
+existing `VerifySubject` (reusing `stringClaim`, verifier.go:167, plus a
+string-array helper for `roles`).
+- `OrgID`, `OrgSlug`, `AssertedRoles` on `principal.Principal`.
+- Asserted roles grantable in ACL: a new `Policy` key mapping claim value →
+declared role, a new `SourceKind`, and one block in `computeGlobals`.
+- Threading through the resolver chain, the `resolvePrincipalEntity` re-stamp
+(router.go:280), and the audit sanitiser.
+
+**Out of scope**
+
+- **Org matching / enforcement in `acl.yaml`.** `internal/acl` has no denial
+primitive — evaluation is additive union semantics (declarative.go:24-26), first
+matching role wins and is never reconsidered; and
+`RoleDef.Create/Update/Delete/Read` are plain `[]string` with no `when:`. "Deny
+unless org matches" inverts the core model and needs its own design. Org is
+carried on the Principal and lands in the audit log; nothing evaluates it.
+Separate ticket.
+- **Auto-provisioning a user entity for an unmatched principal** → TKT-0C3II2.
+- The `--principal-header` path gaining org/roles (no verified source).
+- The webhook path (`WebhookClaims` already carries `OrgID`, nested in `data`).
+- The `Authorization: Bearer` transport question above.
+- `principal_type` — Pratique's own middleware does not surface it; if rela
+needs to distinguish a PAT from an interactive user that is its own ticket.
+
+## Acceptance criteria
+
+1. A verified assertion carrying `org_id`/`org_slug`/`roles` yields a Principal
+whose OrgID, OrgSlug and AssertedRoles match the claims.
+2. A verified assertion with `roles: []` yields a valid Principal with empty
+AssertedRoles — no error, no fallthrough. Same for absent keys (defensive:
+Pratique always sends them, other proxies may not).
+3. `--principal-header` requests resolve exactly as today: same User, empty
+org/roles, no behaviour change.
+4. Direct-loopback (no flags) requests resolve exactly as today.
+5. An `acl.yaml` mapping an asserted claim value to a declared role grants that
+role, attributed to a distinguishable new source kind.
+6. An asserted claim mapping to an **undeclared** role is dropped silently at
+resolution, matching the existing `Assignments` guard (resolver.go:36-38).
+7. Audit records carry the new fields, sanitised the same way `User`/`Tool` are
+(audit/filesystem.go:204).
+8. `NopACL` and `ReadOnlyACL` behaviour is unchanged (both are attribution-free
+by design, acl.go:118-122 — expected to need no edits).
+9. `rela acl map` reports asserted-role grants without silently under-reporting
+them (see risk below).
+10. A verified principal with asserted roles but **no matching user entity**
+keeps its asserted-role grants and is not denied outright — see the
+unmatched-principal decision below.
+
+## Decision: unmatched principal → anonymous
+
+**Decided (2026-07-21, with the user).** A cryptographically verified principal
+whose subject does not resolve to a `user_entity_type` entity stays
+authenticated and keeps its asserted roles. It simply has no resolved user
+entity, so everything keyed on that entity does not apply: local roles via
+`role_relations`, ancestry via `inherit_roles_through`, and `principal_property`
+lookups all no-op.
+
+Rationale: asserted roles are cryptographically verified and mapped through an
+operator-authored allowlist in `acl.yaml`. Their trustworthiness does not depend
+on a graph entity existing, so denying outright would discard a valid, verified
+grant for a bookkeeping reason. The alternative — hard-denying — makes the first
+request of every SSO JIT-provisioned user fail, which behind an OIDC proxy is a
+routine flow, not an edge case.
+
+**This is a deliberate interim position.** Auto-provisioning, reconciliation and
+operator visibility for unmatched principals are deferred to **TKT-0C3II2**,
+which also records why the anonymous fallback is unsatisfying long-term (audit
+attribution degrades; the condition is silent; IdP/graph membership drifts).
+
+Implementation consequence: `isUnstamped` (acl/request.go:189) gates on
+User/Tool and must keep hard-denying a genuinely unstamped principal — the
+change here is that a *verified* principal is not unstamped merely because its
+subject has no entity. Whichever behaviour lands must be pinned by an explicit
+test so it cannot drift silently.
+
+## Design notes
+
+- **Asserted roles fit the existing idiom well.** `EveryoneRole`
+(acl/resolver.go:45-47) is the precedent for a role entering the effective set
+without a graph walk. The new block sits adjacent, uses the same `add` closure
+and the same role-declared guard. Everything downstream — `decideFromAttrs`,
+`readQuery`, `grantsPermission`, `affordances/resolver.go:565-620`, `access.go`
+— is source-agnostic and absorbs it for free.
+- **Do not overload `Policy.Assignments`.** Its keys are matched against
+`members`, which are entity IDs from a graph walk. A claim value colliding with
+an entity ID would silently grant across dimensions — a privilege escalation
+vector, and unauditable. Separate key, mirroring how `role_relations` is
+separate despite also producing roles.
+- **`knownPolicyKeys` (acl/policy.go:302-312) is enforced by a reflection
+parity test** (`policy_parity_test.go:15-30`) — a new `Policy` field without an
+allowlist entry fails CI.
+- **`Source` must stay comparable** — it is a map key via `attrKey`
+(source.go:129-132) and mirrored into `aclmap.Route`, also a map key
+(`mergeRoutes`, whocan.go:98-112). No slices on `Source`.
+- **Adding a `SourceKind` is compiler-silent** — every switch has a default, so
+a missed entry renders `"unknown"` and sorts at priority 999. Five hand-
+maintained tables in `source_test.go` need entries; `sourceKindPriority`, both
+`String()` methods and `lessSource` all need edits. Worth adding a reflective
+guard. Note `TestSourceKindString_UniquePrefixes` (source_test.go:236)
+constrains naming.
+- **`internal/principal`'s doc explicitly gates growth on an ACL ticket** — this
+is that ticket; record the justification there.
+
+## Risks
+
+- **`rela acl map` under-reports.** `aclmap/enumerate.go:46-64` enumerates the
+principal universe from `Assignments` keys ∪ membership ∪ role-relations. A role
+granted by an asserted claim has **no enumerable principal**. Mitigation: report
+asserted grants once, globally, mirroring `EveryoneGrants` (access.go:74-80) —
+the same pattern the everyone role uses for the same reason. Covered by AC9.
+- **Trust boundary.** Nothing in `internal/acl` verifies anything; `Principal`
+is stamped by entry-point middleware and trusted absolutely. Asserted roles must
+be populated **only** after signature verification. A header trusted the way
+`X-Forwarded-User` is trusted would be a full auth bypass. Needs an explicit
+section in `docs/acl-security.md`.
+- **The anonymous fallback is silent** (see the decision above). An operator
+cannot currently tell that verified people are transacting without a user
+entity. Accepted for now; TKT-0C3II2 owns the fix.
+- **9-minute stale-role window** (above) — document it; do not try to fix it
+here.
+- **Audit wire format changes.** `audit/audit.go:91` embeds `Principal`
+directly, so new fields land in the audit log format, and
+`audit/filesystem.go:204-205` sanitises only `User`/`Tool`.
+
+## Prior art
+
+- Extends FEAT-OQBYHD (verified-JWT resolver) from `sub`-only to the full
+identity assertion.
+- Pratique's own downstream contract is `pratique/pkg/middleware/middleware.go:36-42`
+— its `Identity` exposes exactly `Subject`, `Email`, `OrgID`, `OrgSlug`,
+`Roles`, which is the field set this ticket mirrors.
+- Follow-ups carved out of this ticket: **TKT-0C3II2** (auto-provisioning an
+unmatched principal) and the org-enforcement ticket.

--- a/tickets/relations/TKT-0C3II2--affects--authorization.md
+++ b/tickets/relations/TKT-0C3II2--affects--authorization.md
@@ -1,0 +1,5 @@
+---
+from: TKT-0C3II2
+relation: affects
+to: authorization
+---

--- a/tickets/relations/TKT-0C3II2--implements--FEAT-OQBYHD.md
+++ b/tickets/relations/TKT-0C3II2--implements--FEAT-OQBYHD.md
@@ -1,0 +1,5 @@
+---
+from: TKT-0C3II2
+relation: implements
+to: FEAT-OQBYHD
+---

--- a/tickets/relations/TKT-RP3X3Q--affects--audit-log.md
+++ b/tickets/relations/TKT-RP3X3Q--affects--audit-log.md
@@ -1,0 +1,5 @@
+---
+from: TKT-RP3X3Q
+relation: affects
+to: audit-log
+---

--- a/tickets/relations/TKT-RP3X3Q--affects--authorization.md
+++ b/tickets/relations/TKT-RP3X3Q--affects--authorization.md
@@ -1,0 +1,5 @@
+---
+from: TKT-RP3X3Q
+relation: affects
+to: authorization
+---

--- a/tickets/relations/TKT-RP3X3Q--has-docs--DOCS-U1H62D.md
+++ b/tickets/relations/TKT-RP3X3Q--has-docs--DOCS-U1H62D.md
@@ -1,0 +1,5 @@
+---
+from: TKT-RP3X3Q
+relation: has-docs
+to: DOCS-U1H62D
+---

--- a/tickets/relations/TKT-RP3X3Q--has-implementation--IMPL-5NC7AC.md
+++ b/tickets/relations/TKT-RP3X3Q--has-implementation--IMPL-5NC7AC.md
@@ -1,0 +1,5 @@
+---
+from: TKT-RP3X3Q
+relation: has-implementation
+to: IMPL-5NC7AC
+---

--- a/tickets/relations/TKT-RP3X3Q--has-planning--PLAN-0R1VYM.md
+++ b/tickets/relations/TKT-RP3X3Q--has-planning--PLAN-0R1VYM.md
@@ -1,0 +1,5 @@
+---
+from: TKT-RP3X3Q
+relation: has-planning
+to: PLAN-0R1VYM
+---

--- a/tickets/relations/TKT-RP3X3Q--has-review--REV-0JRAHK.md
+++ b/tickets/relations/TKT-RP3X3Q--has-review--REV-0JRAHK.md
@@ -1,0 +1,5 @@
+---
+from: TKT-RP3X3Q
+relation: has-review
+to: REV-0JRAHK
+---

--- a/tickets/relations/TKT-RP3X3Q--has-review-response--RR-0VHKMW.md
+++ b/tickets/relations/TKT-RP3X3Q--has-review-response--RR-0VHKMW.md
@@ -1,0 +1,5 @@
+---
+from: TKT-RP3X3Q
+relation: has-review-response
+to: RR-0VHKMW
+---

--- a/tickets/relations/TKT-RP3X3Q--has-review-response--RR-3TKDR9.md
+++ b/tickets/relations/TKT-RP3X3Q--has-review-response--RR-3TKDR9.md
@@ -1,0 +1,5 @@
+---
+from: TKT-RP3X3Q
+relation: has-review-response
+to: RR-3TKDR9
+---

--- a/tickets/relations/TKT-RP3X3Q--has-review-response--RR-74XCVE.md
+++ b/tickets/relations/TKT-RP3X3Q--has-review-response--RR-74XCVE.md
@@ -1,0 +1,5 @@
+---
+from: TKT-RP3X3Q
+relation: has-review-response
+to: RR-74XCVE
+---

--- a/tickets/relations/TKT-RP3X3Q--has-review-response--RR-7F05HH.md
+++ b/tickets/relations/TKT-RP3X3Q--has-review-response--RR-7F05HH.md
@@ -1,0 +1,5 @@
+---
+from: TKT-RP3X3Q
+relation: has-review-response
+to: RR-7F05HH
+---

--- a/tickets/relations/TKT-RP3X3Q--has-review-response--RR-9698LN.md
+++ b/tickets/relations/TKT-RP3X3Q--has-review-response--RR-9698LN.md
@@ -1,0 +1,5 @@
+---
+from: TKT-RP3X3Q
+relation: has-review-response
+to: RR-9698LN
+---

--- a/tickets/relations/TKT-RP3X3Q--has-review-response--RR-CHW2AA.md
+++ b/tickets/relations/TKT-RP3X3Q--has-review-response--RR-CHW2AA.md
@@ -1,0 +1,5 @@
+---
+from: TKT-RP3X3Q
+relation: has-review-response
+to: RR-CHW2AA
+---

--- a/tickets/relations/TKT-RP3X3Q--has-review-response--RR-FCWJ8Q.md
+++ b/tickets/relations/TKT-RP3X3Q--has-review-response--RR-FCWJ8Q.md
@@ -1,0 +1,5 @@
+---
+from: TKT-RP3X3Q
+relation: has-review-response
+to: RR-FCWJ8Q
+---

--- a/tickets/relations/TKT-RP3X3Q--has-review-response--RR-HVN18E.md
+++ b/tickets/relations/TKT-RP3X3Q--has-review-response--RR-HVN18E.md
@@ -1,0 +1,5 @@
+---
+from: TKT-RP3X3Q
+relation: has-review-response
+to: RR-HVN18E
+---

--- a/tickets/relations/TKT-RP3X3Q--has-review-response--RR-IK355A.md
+++ b/tickets/relations/TKT-RP3X3Q--has-review-response--RR-IK355A.md
@@ -1,0 +1,5 @@
+---
+from: TKT-RP3X3Q
+relation: has-review-response
+to: RR-IK355A
+---

--- a/tickets/relations/TKT-RP3X3Q--has-review-response--RR-MZFKO7.md
+++ b/tickets/relations/TKT-RP3X3Q--has-review-response--RR-MZFKO7.md
@@ -1,0 +1,5 @@
+---
+from: TKT-RP3X3Q
+relation: has-review-response
+to: RR-MZFKO7
+---

--- a/tickets/relations/TKT-RP3X3Q--has-review-response--RR-NKTI9X.md
+++ b/tickets/relations/TKT-RP3X3Q--has-review-response--RR-NKTI9X.md
@@ -1,0 +1,5 @@
+---
+from: TKT-RP3X3Q
+relation: has-review-response
+to: RR-NKTI9X
+---

--- a/tickets/relations/TKT-RP3X3Q--has-review-response--RR-QZVYVJ.md
+++ b/tickets/relations/TKT-RP3X3Q--has-review-response--RR-QZVYVJ.md
@@ -1,0 +1,5 @@
+---
+from: TKT-RP3X3Q
+relation: has-review-response
+to: RR-QZVYVJ
+---

--- a/tickets/relations/TKT-RP3X3Q--has-review-response--RR-S14ZKC.md
+++ b/tickets/relations/TKT-RP3X3Q--has-review-response--RR-S14ZKC.md
@@ -1,0 +1,5 @@
+---
+from: TKT-RP3X3Q
+relation: has-review-response
+to: RR-S14ZKC
+---

--- a/tickets/relations/TKT-RP3X3Q--has-review-response--RR-TQBZ2U.md
+++ b/tickets/relations/TKT-RP3X3Q--has-review-response--RR-TQBZ2U.md
@@ -1,0 +1,5 @@
+---
+from: TKT-RP3X3Q
+relation: has-review-response
+to: RR-TQBZ2U
+---

--- a/tickets/relations/TKT-RP3X3Q--implements--FEAT-OQBYHD.md
+++ b/tickets/relations/TKT-RP3X3Q--implements--FEAT-OQBYHD.md
@@ -1,0 +1,5 @@
+---
+from: TKT-RP3X3Q
+relation: implements
+to: FEAT-OQBYHD
+---


### PR DESCRIPTION
Extract `org_id`, `org_slug` and `roles` from the verified ES256 identity
assertion into `principal.Principal`. Asserted **roles** become grantable in
`acl.yaml`, so a deployment behind an OIDC proxy maintains group membership in
the IdP instead of restating it per-user in `assignments`.

Closes TKT-RP3X3Q. Extends FEAT-OQBYHD from `sub`-only to the full assertion.

## The problem

`jwtauth.VerifySubject` parsed the whole claim set and returned **only** `sub` —
everything else was discarded with the local map. Behind Pratique, every request
carries a verified active org and role set; rela reduced that to a username, so
`acl.yaml` could only match on the principal string.

## What changed

```yaml
asserted_role_assignments:
  admin: editor                 # scalar
  compliance: [editor, auditor] # or list
```

A claim value never names a rela role directly — it selects an operator-authored
entry, so an IdP cannot grant a role the deployment did not choose to expose.

Five layers: a typed claims projection in `jwtauth` (with bounds); the claims on
`Principal`; the dataentry seam + adapter; the ACL policy key, source kind and
`computeGlobals` injection; and reporting in `aclmap`/CLI/audit.

## Three things worth a reviewer's attention

**The trust boundary is compiler-enforced.** The claims live in *unexported*
fields behind `principal.Verified()`. `internal/acl` trusts the Principal
absolutely — it verifies nothing itself — so a role arriving from a spoofable
header would be a complete auth bypass, not a degradation. Unexported fields
make that impossible to express rather than a rule reviewers must remember. All
21 non-test construction sites are structurally unable to forge a role.

**`org_id` is carried but inert, deliberately.** Nothing evaluates it. A
principal in org A still sees everything their roles grant in *every* org.
`TestAssertedRoles_OrgIsNotEvaluated` pins the *absence* of enforcement so it
reads as a decision rather than an oversight, and fails the day someone adds
half an org check. Enforcement needs a deny primitive the ACL doesn't have —
evaluation is purely additive — so it's a separate ticket.

**`isUnstamped` is deliberately untouched.** The plan originally claimed
unmatched principals were hard-denied there; tracing the code showed they
already proceed (`ResolvePrincipal` returns `""` on no-match, so
`resolvePrincipalEntity` leaves ctx unchanged). Relaxing that gate would have
weakened fail-closed behaviour for *every* entry point, not just this one.

## Behaviour preserved

- `--principal-header` and direct-loopback resolve exactly as today; their
  existing tests pass **unmodified**.
- Audit records from non-assertion entry points are byte-identical (`omitempty`).
- `NopACL` / `ReadOnlyACL` unchanged.
- A policy without `asserted_role_assignments` behaves exactly as before.

## Review history

Three passes before this PR: design review (10 findings, 3 critical), code
review of the feature commit (2), and code review of the *fix* commit (3 — two
were bugs introduced by the previous round's fixes, including a test that could
never fail). All addressed. Crit review approved with no comments.

Every guard was **fault-injected** rather than assumed — each fix was reverted
to confirm the test fails with a diagnostic naming the cause. That process
caught two things a passing suite hid: my first exhaustiveness guard passed with
an unregistered `SourceKind`, and `TestPrincipal_AccessorsDoNotShareBackingArray`
was a tautology (`Roles()` clones, so the pointer comparison could never be
true). Both replaced. Note the `exhaustive` linter does *not* catch a missing
`SourceKind` — `default-signifies-exhaustive` means the `default:` clauses
satisfy it — so the test is the only guard.

## Operational notes

- **Revocation lags up to 9 minutes.** An issued assertion is honored until its
  `exp`; rela has no revocation channel. Documented in `acl-security.md`, because
  an operator planning incident response would otherwise assume IdP revocation is
  immediate.
- **Transport gap, not addressed here:** Pratique sends the assertion as
  `Authorization: Bearer`, while rela's `--jwt-header` defaults to
  `X-Auth-Assertion`. The deployment must already set the flag explicitly. Worth
  confirming against the running config.

## Verification

`just test` · `just lint` (0 issues) · `just arch-lint` (jwtauth stayed a leaf) ·
`go test -race` on all six touched packages · `just coverage-check` (76.3%).

## Follow-ups

- **TKT-0C3II2** — auto-provisioning an unmatched principal. Behind SSO this is
  every new user's first request; today they get asserted roles but no
  graph-derived affordances, silently.
- Org enforcement — needs its own design.
