### PR TITLE
feat(dataentry): per-command ACL guard for command execution

### DIFF
--- a/docs-project/entities/guides/GUIDE-acl-security.md
+++ b/docs-project/entities/guides/GUIDE-acl-security.md
@@ -582,6 +582,84 @@ is read-gated on the same principles as everything else:
   requesting a deleted entity's history gets the same 404 as a nonexistent id,
   so the permission boundary does not itself leak which deleted entities exist.
 
+## Command execution gating (`command:*`)
+
+Data-entry [commands](data-entry.md#commands) execute arbitrary shell via
+`sh -c`. They have no entity subject to evaluate — a `context: global` command
+acts on the project, not a row — so like `history:read` they are gated on
+**global named permissions**, declared per command and granted via a role's
+`permissions:` list:
+
+```yaml
+# data-entry.yaml
+commands:
+  nightly-export:
+    context: global
+    script: "./scripts/export.sh"
+    permission: "command:nightly-export"
+```
+
+```yaml
+# acl.yaml
+roles:
+  operator:
+    permissions: [command:nightly-export]
+```
+
+The permission name is arbitrary; `command:<id>` is a readable convention, not
+a requirement.
+
+**Authorization is bimodal, by design:**
+
+- **No `acl.yaml` configured** → every command runs. A project that has not
+  opted into access control behaves exactly as it did before this gating
+  existed.
+- **`acl.yaml` present** → a command runs only if its `permission:` is set and
+  the principal holds it. A command with no `permission:` is **denied**: under a
+  configured policy, an ungoverned shell-exec surface is treated as a
+  misconfiguration, not as an implicit grant.
+- **`--read-only`** → every command is denied, whatever the policy says.
+  Command execution is not an `acl.WriteRequest`, so `ReadOnlyACL` cannot deny
+  it through `AuthorizeWrite`; the command handler checks read-only mode
+  directly. Without that check, `--read-only` would not stop a command from
+  mutating the project.
+
+Commands the principal cannot execute are filtered out of the command-resolution
+API, so their buttons do not render. Treat that as a UI affordance only — the
+exec endpoint re-authorizes and 403s independently, and the 403 body never
+names the required permission or any policy content.
+
+A running command can be cancelled only by the principal that started it; a
+cancel request naming another principal's execution gets the same 404 as an
+unknown one, so cancellation cannot be used to probe what else is running.
+
+### What a command permission actually confers
+
+**Command payloads are not read-gate scoped, in any context.** A command's
+stdin JSON is assembled directly from the store, without the per-entity
+`PermitsRead` verdicts that gate an ordinary API read. Granting
+`command:<something>` therefore confers **read access to whatever that
+command's context assembles**, not merely the right to run a script:
+
+| context | what the script receives | scoped by |
+| ------- | ------------------------ | --------- |
+| `entity` | the entity at the caller-supplied `entity_id`, plus **every** incident relation | nothing — any id in the store |
+| `list` | every entity in the caller-supplied `list_id`, post-filter | nothing — any configured list |
+| `global` | project paths only | n/a |
+| `view` | the entry entity plus the entire traversal closure | *not grantable — see below* |
+
+Note the `entity_id` and `list_id` come from the request, not from whatever
+page the user was on: `available_on` restricts where a **button appears**, not
+what a command may be pointed at. Treat a command grant as "may read every
+entity of this shape", and scope grants accordingly.
+
+**`context: view` cannot be granted per-command at all.** View commands are
+denied outright under any configured `acl.yaml`; `permission:` on a view
+command is inert and warns at config load. The difference from the contexts
+above is degree, not kind: a view's traversal closure is unbounded by the
+config an operator can read, so the blast radius of the grant is not knowable
+in advance. Deferred until the traversal is read-gate scoped.
+
 Restore (`POST /api/v1/_history/<type>/<id>/<version>/restore`) is a **write**,
 not a read: it is authorized as an ordinary update (or create, if the entity was
 deleted), runs the per-field write gate on exactly the fields that change (so it

--- a/docs-project/entities/guides/GUIDE-data-entry.md
+++ b/docs-project/entities/guides/GUIDE-data-entry.md
@@ -1701,6 +1701,65 @@ commands:
 | `confirm`      | string | Confirmation prompt before execution (optional)        |
 | `env`          | map    | Custom environment variables (optional)                |
 | `auto_open`    | bool   | Auto-open output files on completion (optional)        |
+| `permission`   | string | ACL permission required to run this command (optional) |
+
+### Authorization
+
+Commands run arbitrary shell, so who may execute them is governed by the ACL.
+Authorization is **bimodal** — it depends on whether the project has an
+`acl.yaml` at all:
+
+| Project state | Command with `permission:` | Command without `permission:` |
+| ------------- | -------------------------- | ----------------------------- |
+| No `acl.yaml` | runs | runs |
+| `acl.yaml` present | runs only if the principal holds it | **denied** |
+| `--read-only` | **denied** | **denied** |
+
+In other words: with no policy configured nothing changes, and once you write a
+policy every command must be granted explicitly. Grant via a role's
+`permissions:` list, exactly like `history:read`:
+
+```yaml
+# data-entry.yaml
+commands:
+  nightly-export:
+    label: "Nightly export"
+    context: global
+    script: "./scripts/export.sh"
+    permission: "command:nightly-export"
+```
+
+```yaml
+# acl.yaml
+roles:
+  operator:
+    permissions: [command:nightly-export]
+```
+
+Commands the current user may not run are omitted from the API response, so
+their buttons never render. That is a convenience, not the boundary — the
+server re-authorizes every execution and returns 403 regardless of what the UI
+showed.
+
+> **`available_on` is not an authorization boundary.** It controls where a
+> button *appears*; it is not checked at execution time, so a command scoped to
+> one list or entity type can still be invoked directly against any other. Use
+> `permission:` to control *who* may run a command, and note that a command
+> reads whatever its context assembles from the caller-supplied `entity_id` /
+> `list_id` — not from the page the button was on. See
+> [what a command permission confers](acl-security.md#what-a-command-permission-actually-confers).
+>
+> **Adding your first `acl.yaml` is a breaking change for commands.** Every
+> command needs a `permission:` and a matching grant, or it stops working. The
+> failure mode is deliberate: a denied command is safer than an ungoverned one.
+
+**`context: view` cannot be granted per-command yet.** View commands run
+unchanged when no `acl.yaml` is configured, but are denied outright once one
+is — setting `permission:` on them has no effect and produces a config warning.
+A view command's stdin payload is the entire view traversal (every entity the
+view reaches plus the relations between them), so a grant would confer read
+access far wider than the entry entity, in a way that is not evident from the
+config. Per-command view grants are deferred until that scoping is resolved.
 
 ### Context Scopes
 

--- a/docs/acl-security.md
+++ b/docs/acl-security.md
@@ -576,6 +576,80 @@ is read-gated on the same principles as everything else:
   requesting a deleted entity's history gets the same 404 as a nonexistent id,
   so the permission boundary does not itself leak which deleted entities exist.
 
+## Command execution gating (`command:*`)
+
+Data-entry [commands](data-entry.md#commands) execute arbitrary shell via
+`sh -c`. They have no entity subject to evaluate — a `context: global` command
+acts on the project, not a row — so like `history:read` they are gated on
+**global named permissions**, declared per command and granted via a role's
+`permissions:` list:
+
+```yaml
+# data-entry.yaml
+commands:
+  nightly-export:
+    context: global
+    script: "./scripts/export.sh"
+    permission: "command:nightly-export"
+```
+
+```yaml
+# acl.yaml
+roles:
+  operator:
+    permissions: [command:nightly-export]
+```
+
+The permission name is arbitrary; `command:<id>` is a readable convention, not
+a requirement.
+
+**Authorization is bimodal, by design:**
+
+- **No `acl.yaml` configured** → every command runs. A project that has not
+  opted into access control behaves exactly as it did before this gating
+  existed.
+- **`acl.yaml` present** → a command runs only if its `permission:` is set and
+  the principal holds it. A command with no `permission:` is **denied**: under a
+  configured policy, an ungoverned shell-exec surface is treated as a
+  misconfiguration, not as an implicit grant.
+- **`--read-only`** → every command is denied, whatever the policy says.
+  Command execution is not an `acl.WriteRequest`, so `ReadOnlyACL` cannot deny
+  it through `AuthorizeWrite`; the command handler checks read-only mode
+  directly. Without that check, `--read-only` would not stop a command from
+  mutating the project.
+
+Commands the principal cannot execute are filtered out of the command-resolution
+API, so their buttons do not render. Treat that as a UI affordance only — the
+exec endpoint re-authorizes and 403s independently, and the 403 body never
+names the required permission or any policy content.
+
+### What a command permission actually confers
+
+**Command payloads are not read-gate scoped, in any context.** A command's
+stdin JSON is assembled directly from the store, without the per-entity
+`PermitsRead` verdicts that gate an ordinary API read. Granting
+`command:<something>` therefore confers **read access to whatever that
+command's context assembles**, not merely the right to run a script:
+
+| context | what the script receives | scoped by |
+| ------- | ------------------------ | --------- |
+| `entity` | the entity at the caller-supplied `entity_id`, plus **every** incident relation | nothing — any id in the store |
+| `list` | every entity in the caller-supplied `list_id`, post-filter | nothing — any configured list |
+| `global` | project paths only | n/a |
+| `view` | the entry entity plus the entire traversal closure | *not grantable — see below* |
+
+Note the `entity_id` and `list_id` come from the request, not from whatever
+page the user was on: `available_on` restricts where a **button appears**, not
+what a command may be pointed at. Treat a command grant as "may read every
+entity of this shape", and scope grants accordingly.
+
+**`context: view` cannot be granted per-command at all.** View commands are
+denied outright under any configured `acl.yaml`; `permission:` on a view
+command is inert and warns at config load. The difference from the contexts
+above is degree, not kind: a view's traversal closure is unbounded by the
+config an operator can read, so the blast radius of the grant is not knowable
+in advance. Deferred until the traversal is read-gate scoped.
+
 Restore (`POST /api/v1/_history/<type>/<id>/<version>/restore`) is a **write**,
 not a read: it is authorized as an ordinary update (or create, if the entity was
 deleted), runs the per-field write gate on exactly the fields that change (so it

--- a/docs/acl-security.md
+++ b/docs/acl-security.md
@@ -623,6 +623,10 @@ API, so their buttons do not render. Treat that as a UI affordance only — the
 exec endpoint re-authorizes and 403s independently, and the 403 body never
 names the required permission or any policy content.
 
+A running command can be cancelled only by the principal that started it; a
+cancel request naming another principal's execution gets the same 404 as an
+unknown one, so cancellation cannot be used to probe what else is running.
+
 ### What a command permission actually confers
 
 **Command payloads are not read-gate scoped, in any context.** A command's

--- a/docs/data-entry.md
+++ b/docs/data-entry.md
@@ -1742,7 +1742,7 @@ showed.
 > reads whatever its context assembles from the caller-supplied `entity_id` /
 > `list_id` — not from the page the button was on. See
 > [what a command permission confers](acl-security.md#what-a-command-permission-actually-confers).
-
+>
 > **Adding your first `acl.yaml` is a breaking change for commands.** Every
 > command needs a `permission:` and a matching grant, or it stops working. The
 > failure mode is deliberate: a denied command is safer than an ungoverned one.

--- a/docs/data-entry.md
+++ b/docs/data-entry.md
@@ -1695,6 +1695,65 @@ commands:
 | `confirm`      | string | Confirmation prompt before execution (optional)        |
 | `env`          | map    | Custom environment variables (optional)                |
 | `auto_open`    | bool   | Auto-open output files on completion (optional)        |
+| `permission`   | string | ACL permission required to run this command (optional) |
+
+### Authorization
+
+Commands run arbitrary shell, so who may execute them is governed by the ACL.
+Authorization is **bimodal** — it depends on whether the project has an
+`acl.yaml` at all:
+
+| Project state | Command with `permission:` | Command without `permission:` |
+| ------------- | -------------------------- | ----------------------------- |
+| No `acl.yaml` | runs | runs |
+| `acl.yaml` present | runs only if the principal holds it | **denied** |
+| `--read-only` | **denied** | **denied** |
+
+In other words: with no policy configured nothing changes, and once you write a
+policy every command must be granted explicitly. Grant via a role's
+`permissions:` list, exactly like `history:read`:
+
+```yaml
+# data-entry.yaml
+commands:
+  nightly-export:
+    label: "Nightly export"
+    context: global
+    script: "./scripts/export.sh"
+    permission: "command:nightly-export"
+```
+
+```yaml
+# acl.yaml
+roles:
+  operator:
+    permissions: [command:nightly-export]
+```
+
+Commands the current user may not run are omitted from the API response, so
+their buttons never render. That is a convenience, not the boundary — the
+server re-authorizes every execution and returns 403 regardless of what the UI
+showed.
+
+> **`available_on` is not an authorization boundary.** It controls where a
+> button *appears*; it is not checked at execution time, so a command scoped to
+> one list or entity type can still be invoked directly against any other. Use
+> `permission:` to control *who* may run a command, and note that a command
+> reads whatever its context assembles from the caller-supplied `entity_id` /
+> `list_id` — not from the page the button was on. See
+> [what a command permission confers](acl-security.md#what-a-command-permission-actually-confers).
+
+> **Adding your first `acl.yaml` is a breaking change for commands.** Every
+> command needs a `permission:` and a matching grant, or it stops working. The
+> failure mode is deliberate: a denied command is safer than an ungoverned one.
+
+**`context: view` cannot be granted per-command yet.** View commands run
+unchanged when no `acl.yaml` is configured, but are denied outright once one
+is — setting `permission:` on them has no effect and produces a config warning.
+A view command's stdin payload is the entire view traversal (every entity the
+view reaches plus the relations between them), so a grant would confer read
+access far wider than the entry entity, in a way that is not evident from the
+config. Per-command view grants are deferred until that scoping is resolved.
 
 ### Context Scopes
 

--- a/e2e/tests/read-only-mode.spec.ts
+++ b/e2e/tests/read-only-mode.spec.ts
@@ -5,10 +5,19 @@
  * detail page and sees no Edit / Delete buttons; direct-URL form
  * navigation shows a "not editable" message.
  *
- * Deferred phase-2 sites (Lua command buttons, settings / theme /
- * git, relation add/remove inside form widgets, inline-edit buttons
- * in related-entity cards) remain visible and 403 at the server on
- * click. The assertions below intentionally exclude those.
+ * Deferred phase-2 sites (settings / theme / git, relation add/remove
+ * inside form widgets, inline-edit buttons in related-entity cards)
+ * remain visible and 403 at the server on click. The assertions below
+ * intentionally exclude those.
+ *
+ * Command buttons were listed here too, but that was wrong on both
+ * halves: command exec builds no acl.WriteRequest, so ReadOnlyACL
+ * never saw it and the click ran the script rather than 403ing
+ * (TKT-MJ02AO). Commands are now denied at the exec handler under
+ * read-only and filtered out of the resolution API, so their buttons
+ * do not render at all. Covered in Go — commands_test.go
+ * TestCommandExecReadOnlyDenied — per the API-only-assertions rule in
+ * AGENTS.md, not duplicated here.
  *
  * The test reuses the standard `testProject` fixture to get a fresh
  * project directory, then spawns its own `--read-only` server (the

--- a/internal/dataentry/api_v1.go
+++ b/internal/dataentry/api_v1.go
@@ -3254,7 +3254,7 @@ func (a *App) handleV1Commands(w http.ResponseWriter, r *http.Request) {
 	qualifier := query.Get("qualifier")
 	entityType := query.Get("entity_type")
 
-	resolved := a.commands.resolveCommands(pageType, qualifier, entityType)
+	resolved := a.commands.resolveCommands(r.Context(), pageType, qualifier, entityType)
 
 	commands := make([]v1.Command, 0, len(resolved))
 	for _, cmd := range resolved {

--- a/internal/dataentry/app.go
+++ b/internal/dataentry/app.go
@@ -538,6 +538,8 @@ func NewApp(
 		services:    app.Services,
 		projectRoot: app.ProjectRoot,
 		executeView: app.executeView,
+		// Late-bound: tests reassign app.acl after construction.
+		aclImpl: func() acl.ACL { return app.acl },
 	}
 
 	// Build and publish the initial Schema snapshot. All reloadable

--- a/internal/dataentry/command_handler.go
+++ b/internal/dataentry/command_handler.go
@@ -3,6 +3,8 @@ package dataentry
 import (
 	"context"
 	"net/http"
+
+	"github.com/Sourcehaven-BV/rela/internal/acl"
 )
 
 // commandHandler serves the user-configured command surface: the SSE-streaming
@@ -27,6 +29,24 @@ type commandHandler struct {
 	services    func() Services
 	projectRoot func() string
 	executeView func(ctx context.Context, view ViewConfig, entryID string) (*viewResult, error)
+
+	// aclImpl yields the active ACL, consulted by authorizeCommand to gate
+	// execution (TKT-MJ02AO). A closure, not a value, for the same reason as
+	// the other fields and as app.go's affordance wiring: tests reassign
+	// app.acl AFTER construction, so a captured value would go stale and the
+	// handler would authorize against the wrong policy.
+	aclImpl func() acl.ACL
+}
+
+// currentACL resolves the active ACL, or nil when the handler was constructed
+// without the aclImpl closure. Callers must treat nil as deny (see
+// authorizeCommand) — a wiring omission has to fail closed, not panic and not
+// grant.
+func (h *commandHandler) currentACL() acl.ACL {
+	if h.aclImpl == nil {
+		return nil
+	}
+	return h.aclImpl()
 }
 
 // registerCommandRoutes mounts the command-exec and launcher endpoints. The

--- a/internal/dataentry/commands.go
+++ b/internal/dataentry/commands.go
@@ -19,8 +19,10 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/Sourcehaven-BV/rela/internal/acl"
 	"github.com/Sourcehaven-BV/rela/internal/entity"
 	"github.com/Sourcehaven-BV/rela/internal/natsort"
+	"github.com/Sourcehaven-BV/rela/internal/principal"
 	"github.com/Sourcehaven-BV/rela/internal/store"
 )
 
@@ -40,11 +42,94 @@ type ResolvedCommand struct {
 	AutoOpen *bool
 }
 
+// commandDenyReason explains why a command may not run. It is deliberately
+// coarse: the wire 403 must not echo the required permission name or any
+// policy data, mirroring [acl.Decision.Reason] ("never contains raw policy
+// data so 403 bodies don't leak the full effective-role set").
+const commandDenyReason = "not permitted to run this command"
+
+// authorizeCommand reports whether the principal on ctx may execute cmd.
+//
+// It is the SINGLE decision point, called by both the exec handler and
+// resolveCommands so the rendered button set and the enforced boundary cannot
+// drift. The 403 is the boundary; the resolve filter is a UX affordance.
+//
+// Policy (DEC-EIHQSU), keyed on the configured ACL implementation:
+//
+//   - [acl.ReadOnlyACL] → deny everything, every context. Checked FIRST and
+//     independently of the read gate: command exec builds no acl.WriteRequest,
+//     so ReadOnlyACL.AuthorizeWrite is never consulted, and readGateFromContext
+//     hands back nopReadGate (HoldsPermission ⇒ true) under read-only exactly
+//     as it does under NopACL. A guard written against the read gate alone
+//     therefore fails OPEN here — that was the live bug (RR-CWWJGW) this
+//     function exists to close. TestCommandExecReadOnlyDenied is its canary.
+//   - [*acl.Declarative] → fail closed. `context: view` is denied outright
+//     (its payload is the whole traversal closure, not one entity — see
+//     TKT-MJ02AO); otherwise Permission must be set AND held.
+//   - [acl.NopACL] → fail open, preserving pre-ACL behavior. This is the ONLY
+//     arm that grants by default.
+//   - anything else → DENY.
+//
+// The switch is closed by construction (RR-CAUBAZ): the default arm denies, so
+// an ACL implementation nobody taught this function about cannot silently grant
+// shell execution. Both value and pointer forms of the nop/read-only types are
+// matched explicitly, because their AuthorizeWrite has a VALUE receiver — a
+// `&acl.ReadOnlyACL{}` therefore satisfies acl.ACL, and matching only the value
+// form would drop it into the default arm. When that arm granted, that was a
+// silent `--read-only` bypass reachable by one `&`.
+//
+// Adding a new acl.ACL implementation? It denies commands until you add an arm.
+// That is deliberate: the failure mode of forgetting is a denied command, not
+// an ungoverned shell.
+func authorizeCommand(ctx context.Context, aclImpl acl.ACL, cmd CommandConfig) bool {
+	// A nil ACL means the handler was wired without one. Deny: an
+	// authorization guard must fail closed on a wiring bug, never grant
+	// because a field was left unset. (Catches an untyped nil; a typed-nil
+	// interface falls to the arms below, which also deny.)
+	if aclImpl == nil {
+		return false
+	}
+
+	switch a := aclImpl.(type) {
+	case acl.NopACL, *acl.NopACL:
+		// No policy configured ⇒ commands behave exactly as they did before
+		// this gating existed.
+		return true
+
+	case acl.ReadOnlyACL, *acl.ReadOnlyACL:
+		return false
+
+	case *acl.Declarative:
+		if a == nil {
+			return false // misconfigured policy must not fail open
+		}
+		// View commands have no fine-grained control yet: `permission:` is
+		// not honored for them, so a granted permission must NOT open the
+		// gate. Deferred deliberately, not overlooked.
+		if cmd.Context == "view" {
+			return false
+		}
+		if cmd.Permission == "" {
+			return false // fail closed: a policy is configured, this command is ungoverned
+		}
+		return readGateFromContext(ctx).HoldsPermission(ctx, cmd.Permission)
+
+	default:
+		return false
+	}
+}
+
 // resolveCommands returns commands available for a given page context.
 // pageType is "entity", "list", "view", or "dashboard".
 // qualifier is the specific list ID or view ID.
 // entityType is the entity type shown on the page (empty for dashboard).
-func (h *commandHandler) resolveCommands(pageType, qualifier, entityType string) []ResolvedCommand {
+//
+// Commands the principal may not execute are omitted, so the SPA never renders
+// a button that would 403 on click. This is presentation only — authorizeCommand
+// is re-consulted at exec time, which is the actual boundary.
+func (h *commandHandler) resolveCommands(
+	ctx context.Context, pageType, qualifier, entityType string,
+) []ResolvedCommand {
 	s := h.schema()
 	if len(s.Cfg.Commands) == 0 {
 		return nil
@@ -57,10 +142,14 @@ func (h *commandHandler) resolveCommands(pageType, qualifier, entityType string)
 	}
 	natsort.Strings(ids)
 
+	aclImpl := h.currentACL()
 	var result []ResolvedCommand
 	for _, id := range ids {
 		cmd := s.Cfg.Commands[id]
-		if matchesPage(cmd, pageType, qualifier, entityType) {
+		if !matchesPage(cmd, pageType, qualifier, entityType) {
+			continue
+		}
+		if authorizeCommand(ctx, aclImpl, cmd) {
 			result = append(result, ResolvedCommand{
 				ID:       id,
 				Label:    cmd.Label,
@@ -263,6 +352,14 @@ func parseCommandOutput(line string) CommandMessage {
 
 type runningCommand struct {
 	cmd *exec.Cmd
+
+	// owner is the principal that started this command. runningCommands is a
+	// package-level map keyed only by execID, and execID is client-supplied
+	// (see handleCommandExec), so without an owner recorded here any caller
+	// who guesses or reuses an id could cancel someone else's run — a
+	// cross-principal kill that the exec-side permission check does not cover
+	// (RR-YZV7SY). handleCommandCancel compares against this.
+	owner principal.Principal
 }
 
 var (
@@ -289,6 +386,15 @@ func (h *commandHandler) handleCommandExec(w http.ResponseWriter, r *http.Reques
 	cmd, ok := s.Cfg.Commands[commandID]
 	if !ok {
 		http.Error(w, "Unknown command: "+commandID, http.StatusNotFound)
+		return
+	}
+
+	// Authorization boundary (TKT-MJ02AO). resolveCommands already hides
+	// unauthorized commands from the UI, but that is presentation: this is the
+	// check that actually holds. 403 rather than 404 — the command's existence
+	// is already public via config, so there is no oracle to protect.
+	if !authorizeCommand(r.Context(), h.currentACL(), cmd) {
+		http.Error(w, commandDenyReason, http.StatusForbidden)
 		return
 	}
 
@@ -384,8 +490,12 @@ func (h *commandHandler) handleCommandExec(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	// Register for cancellation.
-	runningCommands.Store(execID, &runningCommand{cmd: proc})
+	// Register for cancellation, bound to the starting principal so only they
+	// can cancel it (RR-YZV7SY).
+	runningCommands.Store(execID, &runningCommand{
+		cmd:   proc,
+		owner: principal.From(r.Context()),
+	})
 	defer runningCommands.Delete(execID)
 
 	// Capture stderr in background.
@@ -443,6 +553,17 @@ func (h *commandHandler) handleCommandCancel(w http.ResponseWriter, r *http.Requ
 	rc, castOK := val.(*runningCommand)
 	if !castOK {
 		http.Error(w, "Internal error", http.StatusInternalServerError)
+		return
+	}
+
+	// Only the principal that started the command may cancel it (RR-YZV7SY).
+	// execID is client-supplied and the registry is process-global, so without
+	// this a caller who guessed an id could kill another user's run — including
+	// a caller whose own exec attempts are being 403'd. Answer 404, identical
+	// to an unknown id, so cancel cannot be used to probe which commands are
+	// currently running under other principals.
+	if rc.owner != principal.From(r.Context()) {
+		http.Error(w, "No running command: "+execID, http.StatusNotFound)
 		return
 	}
 

--- a/internal/dataentry/commands_test.go
+++ b/internal/dataentry/commands_test.go
@@ -7,13 +7,16 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"os/exec"
 	"slices"
 	"strings"
 	"testing"
 
 	"gopkg.in/yaml.v3"
 
+	"github.com/Sourcehaven-BV/rela/internal/acl"
 	"github.com/Sourcehaven-BV/rela/internal/entity"
+	"github.com/Sourcehaven-BV/rela/internal/principal"
 )
 
 // --- resolveCommands ---
@@ -64,7 +67,7 @@ func TestResolveCommands(t *testing.T) {
 	}
 
 	t.Run("entity page shows entity commands", func(t *testing.T) {
-		cmds := app.commands.resolveCommands("entity", "", "ticket")
+		cmds := app.commands.resolveCommands(context.Background(), "entity", "", "ticket")
 		ids := cmdIDs(cmds)
 		assertContains(t, ids, "entity-cmd")
 		assertContains(t, ids, "unscoped-entity")
@@ -74,7 +77,7 @@ func TestResolveCommands(t *testing.T) {
 	})
 
 	t.Run("entity page for non-matching type", func(t *testing.T) {
-		cmds := app.commands.resolveCommands("entity", "", "component")
+		cmds := app.commands.resolveCommands(context.Background(), "entity", "", "component")
 		ids := cmdIDs(cmds)
 		// unscoped entity command still shows (context matches)
 		assertContains(t, ids, "unscoped-entity")
@@ -83,7 +86,7 @@ func TestResolveCommands(t *testing.T) {
 	})
 
 	t.Run("view page shows entity and view commands", func(t *testing.T) {
-		cmds := app.commands.resolveCommands("view", "ticket_detail", "ticket")
+		cmds := app.commands.resolveCommands(context.Background(), "view", "ticket_detail", "ticket")
 		ids := cmdIDs(cmds)
 		assertContains(t, ids, "entity-cmd")
 		assertContains(t, ids, "view-cmd")
@@ -93,7 +96,7 @@ func TestResolveCommands(t *testing.T) {
 	})
 
 	t.Run("list page shows list commands", func(t *testing.T) {
-		cmds := app.commands.resolveCommands("list", "tickets", "ticket")
+		cmds := app.commands.resolveCommands(context.Background(), "list", "tickets", "ticket")
 		ids := cmdIDs(cmds)
 		assertContains(t, ids, "list-cmd")
 		assertNotContains(t, ids, "entity-cmd")
@@ -101,7 +104,7 @@ func TestResolveCommands(t *testing.T) {
 	})
 
 	t.Run("dashboard shows global commands", func(t *testing.T) {
-		cmds := app.commands.resolveCommands("dashboard", "", "")
+		cmds := app.commands.resolveCommands(context.Background(), "dashboard", "", "")
 		ids := cmdIDs(cmds)
 		assertContains(t, ids, "global-cmd")
 		assertNotContains(t, ids, "entity-cmd")
@@ -109,7 +112,7 @@ func TestResolveCommands(t *testing.T) {
 
 	t.Run("empty commands returns nil", func(t *testing.T) {
 		app2, _ := testAppInstance()
-		cmds := app2.commands.resolveCommands("entity", "", "ticket")
+		cmds := app2.commands.resolveCommands(context.Background(), "entity", "", "ticket")
 		if cmds != nil {
 			t.Errorf("expected nil, got %v", cmds)
 		}
@@ -131,7 +134,7 @@ func TestResolveCommands(t *testing.T) {
 				Context: "entity",
 			},
 		}
-		cmds := app2.commands.resolveCommands("entity", "", "ticket")
+		cmds := app2.commands.resolveCommands(context.Background(), "entity", "", "ticket")
 		for _, c := range cmds {
 			if c.ID == "auto-cmd" {
 				if c.AutoOpen == nil || !*c.AutoOpen {
@@ -147,13 +150,13 @@ func TestResolveCommands(t *testing.T) {
 	})
 
 	t.Run("deterministic order", func(t *testing.T) {
-		cmds := app.commands.resolveCommands("view", "ticket_detail", "ticket")
+		cmds := app.commands.resolveCommands(context.Background(), "view", "ticket_detail", "ticket")
 		if len(cmds) < 2 {
 			t.Skip("need at least 2 commands")
 		}
 		// Run multiple times and check order is stable
 		for range 5 {
-			cmds2 := app.commands.resolveCommands("view", "ticket_detail", "ticket")
+			cmds2 := app.commands.resolveCommands(context.Background(), "view", "ticket_detail", "ticket")
 			for j := range cmds {
 				if cmds[j].ID != cmds2[j].ID {
 					t.Fatalf("order not deterministic: %v vs %v", cmdIDs(cmds), cmdIDs(cmds2))
@@ -1038,4 +1041,352 @@ func equalArgs(a, b []string) bool {
 		}
 	}
 	return true
+}
+
+// --- Command authorization (TKT-MJ02AO, policy DEC-EIHQSU) ---
+
+// TestCommandExecReadOnlyDenied is the canary for RR-CWWJGW. Command exec
+// builds no acl.WriteRequest, so ReadOnlyACL's only method (AuthorizeWrite)
+// is never consulted; and readGateFromContext hands back nopReadGate under
+// BOTH NopACL and ReadOnlyACL, whose HoldsPermission returns true
+// unconditionally (readgate.go). A guard written against the read gate alone
+// therefore fails OPEN here. The permission is deliberately set AND would be
+// granted, so the only thing that can produce a 403 is the read-only check
+// itself.
+func TestCommandExecReadOnlyDenied(t *testing.T) {
+	for _, ctxName := range []string{"entity", "list", "view", "global"} {
+		t.Run(ctxName, func(t *testing.T) {
+			app := newHandlerTestApp(t)
+			bindRepo(app, t.TempDir())
+			app.acl = acl.ReadOnlyACL{}
+			app.Cfg().Commands = map[string]CommandConfig{
+				"cmd": {
+					Label:      "Cmd",
+					Script:     `echo '::rela::{"type":"message","text":"ran"}'`,
+					Context:    ctxName,
+					Permission: "command:cmd",
+				},
+			}
+
+			r := httptest.NewRequest(http.MethodPost,
+				"/api/command/cmd?entity_id=TKT-001&list_id=tickets&view_id=ticket_detail",
+				http.NoBody)
+			w := httptest.NewRecorder()
+			app.commands.handleCommandExec(w, r)
+
+			if w.Code != http.StatusForbidden {
+				t.Fatalf("read-only must deny command exec: expected 403, got %d: %s",
+					w.Code, w.Body.String())
+			}
+			if strings.Contains(w.Body.String(), "command:cmd") {
+				t.Errorf("403 body must not echo the permission name: %s", w.Body.String())
+			}
+		})
+	}
+}
+
+// TestCommandExecNopACLFailsOpen pins the fail-open half of DEC-EIHQSU: with
+// no policy configured, a command with no permission: runs exactly as before
+// this ticket, in all four contexts including the deferred view context.
+func TestCommandExecNopACLFailsOpen(t *testing.T) {
+	cases := []struct{ name, ctxName, query string }{
+		{"entity", "entity", "?entity_id=TKT-001"},
+		{"list", "list", "?list_id=tickets"},
+		{"view", "view", "?view_id=ticket_detail&entity_id=TKT-001"},
+		{"global", "global", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			app := newHandlerTestApp(t)
+			bindRepo(app, t.TempDir())
+			app.acl = acl.NopACL{}
+			app.Cfg().Commands = map[string]CommandConfig{
+				"cmd": {
+					Label:   "Cmd",
+					Script:  `echo '::rela::{"type":"message","text":"ran"}'`,
+					Context: tc.ctxName,
+				},
+			}
+
+			r := httptest.NewRequest(http.MethodPost, "/api/command/cmd"+tc.query, http.NoBody)
+			w := httptest.NewRecorder()
+			app.commands.handleCommandExec(w, r)
+
+			if w.Code != http.StatusOK {
+				t.Fatalf("NopACL must fail open: expected 200, got %d: %s",
+					w.Code, w.Body.String())
+			}
+		})
+	}
+}
+
+// commandPolicyACL grants alice "command:allowed" and gives bob no
+// permissions at all. Both hold a role, so a deny is attributable to the
+// missing permission rather than to an unknown principal.
+func commandPolicyACL(t *testing.T, app *App) *acl.Declarative {
+	t.Helper()
+	return mustNewACL(t, &acl.Policy{
+		Roles: map[string]acl.RoleDef{
+			"operator": {Read: []string{"ticket"}, Permissions: []string{"command:allowed"}},
+			"viewer":   {Read: []string{"ticket"}},
+		},
+		Assignments: map[string]string{"alice": "operator", "bob": "viewer"},
+	}, app.store)
+}
+
+// execCommandAs runs the exec handler with the ACL request + read gate
+// attached to ctx, mirroring what attachACLRequest does in production (test
+// handlers bypass the middleware).
+func execCommandAs(
+	ctx context.Context, t *testing.T, app *App, d *acl.Declarative, target string,
+) *httptest.ResponseRecorder {
+	t.Helper()
+	r := httptest.NewRequest(http.MethodPost, target, http.NoBody).
+		WithContext(gateCtxFor(ctx, t, d))
+	w := httptest.NewRecorder()
+	app.commands.handleCommandExec(w, r)
+	return w
+}
+
+// TestCommandExecDeclarativeFailsClosed pins the fail-closed half of
+// DEC-EIHQSU: once an acl.yaml is configured, a command runs only when its
+// permission: is set AND held.
+func TestCommandExecDeclarativeFailsClosed(t *testing.T) {
+	// user is "alice" (holds command:allowed) or "bob" (holds nothing); the
+	// principal ctx is built per-case rather than stored, since a struct field
+	// holding a context.Context is a lint error (containedctx).
+	cases := []struct {
+		name       string
+		ctxName    string
+		query      string
+		permission string
+		user       string
+		wantCode   int
+	}{
+		{"granted entity", "entity", "?entity_id=TKT-001", "command:allowed", "alice", http.StatusOK},
+		{"granted list", "list", "?list_id=tickets", "command:allowed", "alice", http.StatusOK},
+		{"granted global", "global", "", "command:allowed", "alice", http.StatusOK},
+
+		{"not held entity", "entity", "?entity_id=TKT-001", "command:allowed", "bob", http.StatusForbidden},
+		{"not held global", "global", "", "command:allowed", "bob", http.StatusForbidden},
+
+		// No permission: under a configured policy ⇒ ungoverned ⇒ denied.
+		{"no permission entity", "entity", "?entity_id=TKT-001", "", "alice", http.StatusForbidden},
+		{"no permission list", "list", "?list_id=tickets", "", "alice", http.StatusForbidden},
+		{"no permission global", "global", "", "", "alice", http.StatusForbidden},
+
+		// View has no fine-grained control yet: a SET AND GRANTED permission
+		// must still not open the gate (TKT-MJ02AO deferral).
+		{
+			"view denied despite granted permission", "view",
+			"?view_id=ticket_detail&entity_id=TKT-001",
+			"command:allowed", "alice", http.StatusForbidden,
+		},
+		{
+			"view denied without permission", "view",
+			"?view_id=ticket_detail&entity_id=TKT-001",
+			"", "alice", http.StatusForbidden,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			app := newHandlerTestApp(t)
+			bindRepo(app, t.TempDir())
+			d := commandPolicyACL(t, app)
+			app.acl = d
+			app.Cfg().Commands = map[string]CommandConfig{
+				"cmd": {
+					Label:      "Cmd",
+					Script:     `echo '::rela::{"type":"message","text":"ran"}'`,
+					Context:    tc.ctxName,
+					Permission: tc.permission,
+				},
+			}
+
+			w := execCommandAs(principalCtx(tc.user), t, app, d, "/api/command/cmd"+tc.query)
+
+			if w.Code != tc.wantCode {
+				t.Fatalf("expected %d, got %d: %s", tc.wantCode, w.Code, w.Body.String())
+			}
+			deniedWithPermission := tc.wantCode == http.StatusForbidden && tc.permission != ""
+			if deniedWithPermission && strings.Contains(w.Body.String(), tc.permission) {
+				t.Errorf("403 body must not echo the permission name: %s", w.Body.String())
+			}
+		})
+	}
+}
+
+// TestResolveCommandsFiltersUnauthorized pins that the button set the SPA
+// renders matches what exec will actually allow. resolveCommands is
+// presentation, but a mismatch means users see buttons that 403 on click.
+func TestResolveCommandsFiltersUnauthorized(t *testing.T) {
+	setup := func(t *testing.T) (*App, *acl.Declarative) {
+		t.Helper()
+		app := newHandlerTestApp(t)
+		bindRepo(app, t.TempDir())
+		d := commandPolicyACL(t, app)
+		app.acl = d
+		app.Cfg().Commands = map[string]CommandConfig{
+			"allowed":       {Label: "A", Script: "echo hi", Context: "entity", Permission: "command:allowed"},
+			"not-granted":   {Label: "B", Script: "echo hi", Context: "entity", Permission: "command:other"},
+			"no-permission": {Label: "C", Script: "echo hi", Context: "entity"},
+		}
+		return app, d
+	}
+
+	t.Run("declarative shows only held permissions", func(t *testing.T) {
+		app, d := setup(t)
+		ids := cmdIDs(app.commands.resolveCommands(
+			gateCtxFor(aliceCtx(), t, d), "entity", "", "ticket"))
+		assertContains(t, ids, "allowed")
+		assertNotContains(t, ids, "not-granted")
+		assertNotContains(t, ids, "no-permission")
+	})
+
+	t.Run("principal without the permission sees none", func(t *testing.T) {
+		app, d := setup(t)
+		ids := cmdIDs(app.commands.resolveCommands(
+			gateCtxFor(bobCtx(), t, d), "entity", "", "ticket"))
+		assertNotContains(t, ids, "allowed")
+		assertNotContains(t, ids, "not-granted")
+		assertNotContains(t, ids, "no-permission")
+	})
+
+	t.Run("read-only hides every command", func(t *testing.T) {
+		app, _ := setup(t)
+		app.acl = acl.ReadOnlyACL{}
+		cmds := app.commands.resolveCommands(context.Background(), "entity", "", "ticket")
+		if len(cmds) != 0 {
+			t.Errorf("read-only must hide all commands, got %v", cmdIDs(cmds))
+		}
+	})
+
+	t.Run("nop acl shows all", func(t *testing.T) {
+		app, _ := setup(t)
+		app.acl = acl.NopACL{}
+		ids := cmdIDs(app.commands.resolveCommands(context.Background(), "entity", "", "ticket"))
+		assertContains(t, ids, "allowed")
+		assertContains(t, ids, "not-granted")
+		assertContains(t, ids, "no-permission")
+	})
+}
+
+// TestAuthorizeCommandNilACLDenies pins that a wiring omission fails closed.
+// A guard that granted on a nil field would be worse than no guard, since it
+// would look present in review.
+func TestAuthorizeCommandNilACLDenies(t *testing.T) {
+	if authorizeCommand(context.Background(), nil, CommandConfig{Context: "global"}) {
+		t.Error("nil ACL must deny")
+	}
+	h := &commandHandler{} // no aclImpl closure
+	if h.currentACL() != nil {
+		t.Error("currentACL must return nil when unwired, not panic")
+	}
+}
+
+// TestAuthorizeCommandUnknownACLDenies pins the inverted default (RR-CAUBAZ).
+// The switch must be closed by construction: an acl.ACL implementation with no
+// explicit arm denies rather than granting shell execution.
+//
+// The pointer cases matter because ReadOnlyACL/NopACL declare AuthorizeWrite on
+// a VALUE receiver, so &acl.ReadOnlyACL{} satisfies acl.ACL while being a
+// distinct dynamic type. Matching only the value form put it in the default
+// arm — when that arm granted, `--read-only` was bypassable by one `&`.
+func TestAuthorizeCommandUnknownACLDenies(t *testing.T) {
+	cmd := CommandConfig{Context: "global", Permission: "command:x"}
+
+	t.Run("pointer ReadOnlyACL denies", func(t *testing.T) {
+		if authorizeCommand(context.Background(), &acl.ReadOnlyACL{}, cmd) {
+			t.Error("pointer ReadOnlyACL must deny — value-only match was a --read-only bypass")
+		}
+	})
+
+	t.Run("pointer NopACL still fails open", func(t *testing.T) {
+		if !authorizeCommand(context.Background(), &acl.NopACL{}, cmd) {
+			t.Error("pointer NopACL should behave like the value form")
+		}
+	})
+
+	t.Run("unrecognized implementation denies", func(t *testing.T) {
+		// *acl.Request implements acl.ACL and has no arm in the switch.
+		var unknown acl.ACL = (*acl.Request)(nil)
+		if authorizeCommand(context.Background(), unknown, cmd) {
+			t.Error("an ACL implementation with no explicit arm must deny")
+		}
+	})
+
+	t.Run("typed-nil Declarative denies", func(t *testing.T) {
+		var typedNil acl.ACL = (*acl.Declarative)(nil)
+		if authorizeCommand(context.Background(), typedNil, cmd) {
+			t.Error("typed-nil Declarative must deny")
+		}
+	})
+}
+
+// TestCommandCancelOwnerBound pins RR-YZV7SY: a command may be cancelled only
+// by the principal that started it. execID is client-supplied and the registry
+// is process-global, so an unbound cancel let any caller kill any run —
+// including a caller whose own exec attempts were being 403'd.
+func TestCommandCancelOwnerBound(t *testing.T) {
+	newApp := func(t *testing.T) *App {
+		t.Helper()
+		app := newHandlerTestApp(t)
+		bindRepo(app, t.TempDir())
+		return app
+	}
+
+	cancelAs := func(t *testing.T, app *App, ctx context.Context, execID string) int {
+		t.Helper()
+		r := httptest.NewRequest(http.MethodPost, "/api/command-cancel/"+execID, http.NoBody).
+			WithContext(ctx)
+		w := httptest.NewRecorder()
+		app.commands.handleCommandCancel(w, r)
+		return w.Code
+	}
+
+	t.Run("non-owner gets 404, identical to unknown id", func(t *testing.T) {
+		app := newApp(t)
+		proc := exec.Command("sleep", "30")
+		if err := proc.Start(); err != nil {
+			t.Fatalf("start: %v", err)
+		}
+		t.Cleanup(func() { _ = proc.Process.Kill() })
+
+		runningCommands.Store("owned-by-alice", &runningCommand{
+			cmd:   proc,
+			owner: principal.From(principalCtx("alice")),
+		})
+		t.Cleanup(func() { runningCommands.Delete("owned-by-alice") })
+
+		if code := cancelAs(t, app, principalCtx("bob"), "owned-by-alice"); code != http.StatusNotFound {
+			t.Errorf("bob canceling alice's command: expected 404, got %d", code)
+		}
+		// Indistinguishable from a genuinely unknown id — no running-command oracle.
+		if code := cancelAs(t, app, principalCtx("bob"), "no-such-id"); code != http.StatusNotFound {
+			t.Errorf("unknown id: expected 404, got %d", code)
+		}
+		if proc.ProcessState != nil {
+			t.Error("victim process must not have been signaled")
+		}
+	})
+
+	t.Run("owner can cancel", func(t *testing.T) {
+		app := newApp(t)
+		proc := exec.Command("sleep", "30")
+		if err := proc.Start(); err != nil {
+			t.Fatalf("start: %v", err)
+		}
+		t.Cleanup(func() { _ = proc.Process.Kill() })
+
+		runningCommands.Store("owned-by-alice-2", &runningCommand{
+			cmd:   proc,
+			owner: principal.From(principalCtx("alice")),
+		})
+		t.Cleanup(func() { runningCommands.Delete("owned-by-alice-2") })
+
+		if code := cancelAs(t, app, principalCtx("alice"), "owned-by-alice-2"); code != http.StatusOK {
+			t.Errorf("owner canceling own command: expected 200, got %d", code)
+		}
+	})
 }

--- a/internal/dataentry/test_helpers_test.go
+++ b/internal/dataentry/test_helpers_test.go
@@ -175,6 +175,9 @@ func rebindApp(app *App, fs storage.FS, paths *project.Context, svc *appbuild.Se
 		services:    app.Services,
 		projectRoot: app.ProjectRoot,
 		executeView: app.executeView,
+		// Late-bound like production: ACL-gating tests reassign app.acl after
+		// this rebind.
+		aclImpl: func() acl.ACL { return app.acl },
 	}
 	// attachmentHandler mirrors production wiring: closures for the swappable
 	// acl/audit/field-resolver fields (attachment ACL tests reassign app.acl

--- a/internal/dataentryconfig/config.go
+++ b/internal/dataentryconfig/config.go
@@ -568,6 +568,24 @@ type CommandConfig struct {
 	Confirm     string            `yaml:"confirm,omitempty"`
 	Env         map[string]string `yaml:"env,omitempty"`
 	AutoOpen    *bool             `yaml:"auto_open,omitempty"`
+
+	// Permission names the global ACL permission a principal must hold to
+	// execute this command (e.g. "command:nightly-export"), granted via a
+	// role's `permissions:` list in acl.yaml. It follows the
+	// [acl.PermHistoryRead] pattern: commands have no entity Subject, so
+	// they cannot be authorized through acl.ACL.AuthorizeWrite.
+	//
+	// The key is only consulted when an acl.yaml is configured. Per
+	// DEC-EIHQSU authorization is bimodal: with no policy every command
+	// runs (unchanged pre-ACL behavior); with a policy a command is denied
+	// unless its Permission is set and held. Under `--read-only` every
+	// command is denied regardless.
+	//
+	// NOT honored for `context: view` — view commands are denied outright
+	// under any configured policy because their payload is the whole view
+	// traversal closure rather than one entity (TKT-MJ02AO). Setting it on
+	// a view command is a config warning.
+	Permission string `yaml:"permission,omitempty"`
 }
 
 // CommandScope controls where a command button appears in the UI.

--- a/internal/dataentryconfig/validate.go
+++ b/internal/dataentryconfig/validate.go
@@ -574,6 +574,32 @@ func CollectConfigWarnings(cfg *Config, meta *metamodel.Metamodel) []string {
 	}
 	warnings = append(warnings, conflictingRelationDirectionWarnings(cfg)...)
 	warnings = append(warnings, relationPropertyNameCollisionWarnings(cfg, meta)...)
+	warnings = append(warnings, viewCommandPermissionWarnings(cfg)...)
+	return warnings
+}
+
+// viewCommandPermissionWarnings flags `permission:` on a `context: view`
+// command. The key is not honored for view commands — they are denied outright
+// under any configured acl.yaml (TKT-MJ02AO) — so an author who sets it would
+// otherwise believe they had granted access that silently does not apply.
+// Warn rather than error: the config is not wrong, it is inert, and erroring
+// would break projects that pre-emptively annotate their view commands.
+func viewCommandPermissionWarnings(cfg *Config) []string {
+	var warnings []string
+	ids := make([]string, 0, len(cfg.Commands))
+	for id := range cfg.Commands {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+	for _, id := range ids {
+		cmd := cfg.Commands[id]
+		if cmd.Context == "view" && cmd.Permission != "" {
+			warnings = append(warnings, fmt.Sprintf(
+				"command %q: permission %q is ignored for context: view — view commands are denied "+
+					"under any configured acl.yaml and cannot yet be granted per-command",
+				id, cmd.Permission))
+		}
+	}
 	return warnings
 }
 

--- a/internal/dataentryconfig/validate_test.go
+++ b/internal/dataentryconfig/validate_test.go
@@ -2111,3 +2111,48 @@ func TestCollectConfigWarnings_RelationPropertyNameCollision(t *testing.T) {
 		}
 	})
 }
+
+// TestViewCommandPermissionWarning pins that a `permission:` on a view command
+// is surfaced as a warning. The key is inert there (TKT-MJ02AO), and silently
+// ignoring it would let an author believe they had granted access.
+func TestViewCommandPermissionWarning(t *testing.T) {
+	meta := &metamodel.Metamodel{}
+
+	t.Run("view command with permission warns", func(t *testing.T) {
+		cfg := &Config{Commands: map[string]CommandConfig{
+			"v": {Label: "V", Script: "echo hi", Context: "view", Permission: "command:v"},
+		}}
+		warnings := CollectConfigWarnings(cfg, meta)
+		var found bool
+		for _, w := range warnings {
+			if strings.Contains(w, `command "v"`) && strings.Contains(w, "ignored for context: view") {
+				found = true
+			}
+		}
+		if !found {
+			t.Errorf("expected a view-permission warning, got %v", warnings)
+		}
+	})
+
+	t.Run("view command without permission is silent", func(t *testing.T) {
+		cfg := &Config{Commands: map[string]CommandConfig{
+			"v": {Label: "V", Script: "echo hi", Context: "view"},
+		}}
+		for _, w := range CollectConfigWarnings(cfg, meta) {
+			if strings.Contains(w, "ignored for context: view") {
+				t.Errorf("unexpected warning: %s", w)
+			}
+		}
+	})
+
+	t.Run("non-view command with permission is silent", func(t *testing.T) {
+		cfg := &Config{Commands: map[string]CommandConfig{
+			"g": {Label: "G", Script: "echo hi", Context: "global", Permission: "command:g"},
+		}}
+		for _, w := range CollectConfigWarnings(cfg, meta) {
+			if strings.Contains(w, "ignored for context: view") {
+				t.Errorf("unexpected warning: %s", w)
+			}
+		}
+	})
+}

--- a/tickets/entities/decisions/DEC-EIHQSU.md
+++ b/tickets/entities/decisions/DEC-EIHQSU.md
@@ -1,0 +1,76 @@
+---
+id: DEC-EIHQSU
+type: decision
+title: Command authorization fails open under NopACL, fails closed under a configured acl.yaml
+context: |-
+    Data-entry commands (data-entry.yaml `commands:`) execute arbitrary shell via `sh -c` and today have no authorization whatsoever. Verified: grep for acl/ACL/translateVerb/WriteRequest/Principal across internal/dataentry/commands.go and command_handler.go returns zero matches; handleCommandExec (commands.go:281) checks HTTP method, looks up the command ID, builds stdin, and execs. The only gates are requireSameOrigin/requireLocalHost (router.go:105-108), which are CSRF and network-location controls, not authorization.
+
+    TKT-MJ02AO adds a per-command `permission:` key checked against the ACL, following the acl.PermHistoryRead precedent (internal/acl/policy.go:43) — a global named permission granted via a role's `permissions:` list, checked with gate.HoldsPermission. That pattern fits because a command has no entity Subject: acl.Subject is a sealed sum (internal/acl/subject.go:20) of EntitySubject and RelationSubject only, and `context: global`/`context: list` commands act on the project or a type-set rather than a row.
+
+    That leaves the question this decision answers: what happens when `permission:` is omitted? Every existing deployment has zero `permission:` keys, so the default determines whether the feature protects anyone by default and whether it is a breaking change.
+consequences: |-
+    POSITIVE:
+    - No behavior change for any deployment without an acl.yaml. A project with no policy configured runs exactly as today, so the change is invisible to users who have not opted into access control.
+    - An operator who HAS opted into access control does not silently retain an ungated shell-exec surface. Adding acl.yaml means commands are governed, which matches the intent of writing a policy at all.
+    - The failure mode under policy is a denied command (visible, debuggable via the Decision's RuleKind/RuleID) rather than an unguarded one.
+    - resolveCommands filters unexecutable commands out of GET /_commands, so buttons for denied commands never render — the UX degrades to 'absent', not 'present but broken'.
+
+    NEGATIVE / COSTS:
+    - Breaking change at the moment a deployment adds its first acl.yaml: every command needs a `permission:` key and a matching grant, or it stops working. Must be release-noted.
+    - view-context commands stop working entirely under a configured acl.yaml until view support lands (see the view carve-out below). For a project that relies on view commands, adopting acl.yaml is blocked, not merely inconvenient.
+    - The rule is bimodal, so behavior differs between an unconfigured dev project and a configured production one. Tests must cover both halves explicitly.
+
+    VIEW CARVE-OUT: `view` is not an exception to the fail policy — it is an exception to fine-grained control. Under acl.yaml, view commands are denied outright with no `permission:` escape hatch. Rationale: executeView (views.go:19-49) runs a multi-pass graph traversal and buildViewInput (commands.go:181-215) hands the script the whole traversal closure (Collections + inter-relations) with no read-gate scoping, so a `permission:` grant on a view command would confer read access whose blast radius an operator cannot determine from the config. Denying is preferable to shipping a grant with unclear scope. validateCommands warns if `permission:` is set on a view command, since the key is not honored.
+date: "2026-07-20"
+status: accepted
+---
+
+## Decision
+
+Command execution authorization uses a **bimodal default**, uniform across all
+four command contexts:
+
+| ACL state | `permission:` set | `permission:` omitted |
+|---|---|---|
+| `NopACL` (no `acl.yaml`) | grant checked | **allowed** (fail-open) |
+| `acl.yaml` present | grant required | **denied** (fail-closed) |
+
+Per context under a configured `acl.yaml`:
+
+| context | `permission:` set | omitted |
+|---|---|---|
+| `entity` | grant required | denied |
+| `list` | grant required | denied |
+| `global` | grant required | denied |
+| `view` | **key not honored** | denied |
+
+Under `ReadOnlyACL` (`rela-server --read-only`), **all** command execution is
+denied regardless of `permission:` or context. That is independent of this
+decision — it closes RR-CWWJGW, where read-only currently fails to block command
+exec because `ReadOnlyACL` only implements `AuthorizeWrite(WriteRequest)` and
+command exec constructs none.
+
+## Alternatives rejected
+
+**Fail-open everywhere (omitted → always allowed).** Preserves every deployment
+and is never breaking, but the guard would protect only operators who know to
+opt in per command. An operator who writes an `acl.yaml` and carefully restricts
+entity writes would still have an ungated `sh -c` endpoint, which is the exact
+gap this work exists to close. Rejected as security theater.
+
+**Fail-closed everywhere (omitted → always denied).** Safe, but breaks every
+existing deployment immediately on upgrade, including projects with no interest
+in access control. The cost lands on users who never asked for the feature.
+Rejected as disproportionate.
+
+**Per-context defaults** (e.g. fail-open for `entity`, fail-closed for
+`global`). Considered because `global` has the widest reach. Rejected: a rule an
+operator cannot state in one sentence is a rule they will misconfigure. The view
+carve-out is deliberately framed as "no fine-grained control", not "a different
+fail policy", to keep the single rule intact.
+
+## Implementation
+
+TKT-MJ02AO. See that ticket for enforcement points (`handleCommandExec` before
+the context switch at `commands.go:301`; `resolveCommands` at `commands.go:47`
+for the cosmetic filter) and the full acceptance criteria.

--- a/tickets/entities/docs-checklists/DOCS-IJJR4H.md
+++ b/tickets/entities/docs-checklists/DOCS-IJJR4H.md
@@ -1,0 +1,73 @@
+---
+id: DOCS-IJJR4H
+type: docs-checklist
+title: 'Documentation: Per-command ACL guard'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Code Documentation
+
+- [x] Godoc on exported/new identifiers
+- [x] Non-obvious decisions explained in comments
+- [x] ~~README in new package~~ (N/A: no new package)
+
+`CommandConfig.Permission` (`internal/dataentryconfig/config.go`) carries godoc
+covering the bimodal policy, the acl.yaml grant mechanism, and the view
+carve-out.
+
+`authorizeCommand` (`internal/dataentry/commands.go`) documents *why* the
+read-only arm is checked before the read gate — `nopReadGate.HoldsPermission`
+returns true under both `NopACL` and `ReadOnlyACL`, so a guard built on the gate
+alone fails open. That is the non-obvious fact the whole design turns on, and it
+names its canary test.
+
+The switch's closed-by-construction property is stated as an invariant, not a
+request: "Adding a new acl.ACL implementation? It denies commands until you add
+an arm."
+
+`runningCommand.owner` explains the cross-principal-kill reasoning rather than
+just declaring the field.
+
+## Project Documentation
+
+- [x] `docs/data-entry.md` updated
+- [x] `docs/acl-security.md` updated
+- [x] ~~docs/metamodel.md~~ (N/A: no metamodel change)
+- [x] ~~docs/cli-reference.md~~ (N/A: no CLI change)
+- [x] ~~CLAUDE.md~~ (N/A: no new convention — follows the existing named-permission pattern)
+- [x] ~~README.md~~ (N/A: not project-level)
+
+**`docs/data-entry.md`** — new Authorization section: the bimodal policy table,
+a worked `data-entry.yaml` + `acl.yaml` example, the breaking-change callout for
+adopting a first `acl.yaml`, the view carve-out, and a `permission:` row in the
+field table. Plus the `available_on` callout (RR-0LDY3W) stating it is not an
+authorization boundary, cross-linked to acl-security.md.
+
+**`docs/acl-security.md`** — new `command:*` section alongside `history:read`,
+covering the named-permission mechanism, all three ACL modes, and the "What a
+command permission actually confers" table (RR-37AYC0) stating plainly that
+payloads are **not** read-gate scoped in any context.
+
+## Accuracy corrections
+
+Two places where existing text was **wrong**, not merely incomplete:
+
+1. `e2e/tests/read-only-mode.spec.ts` claimed deferred phase-2 sites "remain
+visible and 403 at the server on click". False for command buttons on both
+halves — they did not 403, they *ran*. Corrected with the reason and a pointer
+to the Go coverage.
+2. The first draft of `docs/acl-security.md` (written earlier in this ticket)
+implied view was uniquely wide-blast-radius. Corrected during code review — the
+difference is degree, not kind.
+
+## External Documentation
+
+- [x] ~~API reference~~ (N/A: no new HTTP endpoint; `permission:` is config, and the 403 shape is standard)
+- [x] ~~Migration guide~~ — covered inline by the breaking-change callout in `docs/data-entry.md` and the migration note in DEC-EIHQSU
+- [x] ~~Changelog~~ (N/A: not maintained in-tree)
+
+**Release-note material** (for whoever cuts the release): adopting a first
+`acl.yaml` now requires `permission:` keys and grants on every command that
+should keep working, and disables view commands entirely until TKT-2FDTJE.

--- a/tickets/entities/implementation-checklists/IMPL-O193P6.md
+++ b/tickets/entities/implementation-checklists/IMPL-O193P6.md
@@ -1,0 +1,106 @@
+---
+id: IMPL-O193P6
+type: implementation-checklist
+title: 'Implementation: Per-command ACL guard: gate command execution and button visibility on a named permission (entity/list/global; view deferred)'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Development
+
+- [x] Write tests first (TDD where applicable)
+- [x] Implement the happy path
+- [x] Handle edge cases identified in planning
+- [x] Add error handling
+
+**TDD, genuinely:** `TestCommandExecReadOnlyDenied` was written and run *before*
+any implementation, and it **reproduced the live vulnerability** — all four
+contexts returned 200 and executed the script under `ReadOnlyACL`:
+
+```
+--- FAIL: TestCommandExecReadOnlyDenied/entity
+    read-only must deny command exec: expected 403, got 200: event: message
+    data: {"type":"message","text":"ran"}
+```
+
+RR-CWWJGW was therefore demonstrated, not merely asserted, and the same test now
+passes.
+
+## Quality
+
+- [x] Code follows project style
+- [x] No security issues introduced
+- [x] Performance is acceptable
+- [x] No debug code left behind
+
+## What was built
+
+**`internal/dataentryconfig/config.go`** — `CommandConfig.Permission`
+(`permission:` YAML key) with godoc covering the bimodal policy and the view
+carve-out.
+
+**`internal/dataentry/commands.go`** — `authorizeCommand(ctx, acl, cmd)`, the
+single decision point, plus `commandDenyReason`. Called by *both*
+`handleCommandExec` (the boundary, 403) and `resolveCommands` (the UI filter),
+so the rendered button set cannot drift from what exec allows.
+
+**`internal/dataentry/command_handler.go`** — `aclImpl func() acl.ACL` field +
+`currentACL()` accessor.
+
+**`internal/dataentry/app.go`**, **`test_helpers_test.go`** — wire the closure
+at both construction sites.
+
+**`internal/dataentryconfig/validate.go`** — `viewCommandPermissionWarnings` via
+the existing `CollectConfigWarnings` channel (a non-fatal channel already
+existed; no new mechanism invented).
+
+**Docs** — `docs/data-entry.md` (Authorization section + `permission:` row),
+`docs/acl-security.md` (`command:*` family alongside `history:read`),
+`e2e/tests/read-only-mode.spec.ts` (corrected the false claim).
+
+## Two hardening decisions beyond the plan
+
+1. **Nil-ACL denies.** `authorizeCommand` returns false on a nil ACL, and
+`currentACL()` returns nil rather than panicking on an unwired closure. The
+first draft panicked (nil deref at `commands.go:362`) when `newHandlerTestApp`
+built a handler without the field. A guard that panics on a wiring bug is bad;
+one that *grants* would be worse — it would look present in review. Pinned by
+`TestAuthorizeCommandNilACLDenies`.
+
+2. **Explicit default-arm comment.** The `default:` (fail-open) arm carries a
+note that it exists *only* because it is the no-policy case, and that a future
+restrictive ACL must get its own arm rather than inheriting it.
+
+## Verification — every gate run, all green
+
+| Gate | Result |
+|---|---|
+| `go build ./...` | pass |
+| `go test ./...` (whole repo) | pass |
+| `just lint` | **0 issues** (4 self-inflicted issues found and fixed properly, not suppressed) |
+| `just arch-lint` | OK — no warnings |
+| `just coverage-check` | package floor + total both PASS; total 76.3% |
+| `just plimsoll` | pass (logic on `commandHandler`, not `App`) |
+
+Lint fixes were real, not `//nolint`: split a multi-line `if` into a guard
+clause, moved `ctx` to the first parameter position (revive), and replaced a
+`context.Context` struct field with a `user string` + per-case
+`principalCtx(...)` (containedctx).
+
+**Pre-existing and unrelated:** `e2e` `tsc` reports two config errors (`Cannot
+find type definition file for 'node'`, removed `moduleResolution=node10`).
+Verified identical with my file stashed — I only edited a comment there.
+
+## Test coverage added
+
+- `TestCommandExecReadOnlyDenied` — 4 contexts; the canary
+- `TestCommandExecNopACLFailsOpen` — 4 contexts; fail-open regression
+- `TestCommandExecDeclarativeFailsClosed` — 10 cases incl. **view denied with a
+set-and-granted permission**
+- `TestResolveCommandsFiltersUnauthorized` — 4 cases across all three ACL modes
+- `TestAuthorizeCommandNilACLDenies` — wiring-bug guard
+- `TestViewCommandPermissionWarning` — 3 cases
+
+All 9 ticket acceptance criteria are covered. The 403 body is asserted not to
+echo the permission name.

--- a/tickets/entities/planning-checklists/PLAN-CJ49VK.md
+++ b/tickets/entities/planning-checklists/PLAN-CJ49VK.md
@@ -1,0 +1,246 @@
+---
+id: PLAN-CJ49VK
+type: planning-checklist
+title: 'Planning: Per-command ACL guard: gate command execution and button visibility on a named permission (entity/list/global; view deferred)'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Understanding
+
+- [x] Problem/requirements clearly understood
+- [x] Scope defined (what's in/out documented below)
+- [x] Acceptance criteria documented with specific test scenarios
+
+**Scope:** see TKT-MJ02AO. Fine-grained `permission:` for `entity`/`list`/
+`global`; `view` denied outright under a configured policy; blanket deny under
+read-only. Fail policy per **DEC-EIHQSU**.
+
+## Research
+
+- [x] ~~run `/research`~~ (N/A: DEC-EIHQSU settles the policy; the named-permission pattern already exists in-tree)
+- [x] Searched for existing libraries that solve this problem
+- [x] Checked codebase for similar patterns or reusable code
+- [x] Looked for reference implementations in other projects
+- [x] Reviewed relevant rela concepts for prior art
+
+**Research Doc:** N/A
+
+**Existing Solutions — in-tree prior art, reused not reinvented:**
+
+- `acl.PermHistoryRead` (`internal/acl/policy.go:43`) — the named-permission
+precedent: a global capability with no entity subject, granted via a role's
+`permissions:` list.
+- `authorizeHistoryRead` (`internal/dataentry/history_handler.go:100-127`) —
+the call shape: `gate := readGateFromContext(ctx)` then
+`gate.HoldsPermission(ctx, perm)`.
+- `router.go:125` (`if d, ok := a.acl.(*acl.Declarative); ok`) and
+`watcher.go:472` — the established **type-assertion** idiom for detecting ACL
+mode. This is how mode detection is done here; do not invent a new one.
+
+## CRITICAL FINDING — the read gate alone cannot implement DEC-EIHQSU
+
+`readGateFromContext` returns `nopReadGate` for **both** `NopACL` and
+`ReadOnlyACL` (`readgate.go` doc: "the gate the handlers see under NopACL /
+ReadOnlyACL"), and:
+
+```go
+// readgate.go:106-108
+func (nopReadGate) HoldsPermission(context.Context, string) bool { return true }
+```
+
+`attachACLRequest` only opens an `acl.Request` when the ACL is
+`*acl.Declarative` (`router.go:125`, and its doc: "NopACL / ReadOnlyACL paths
+don't open Requests").
+
+**Consequence:** a naive `if !gate.HoldsPermission(ctx, perm) { 403 }` would
+return `true` under read-only and **fail open** — reproducing RR-CWWJGW, the
+exact bug this ticket exists to close. The gate distinguishes *Declarative vs
+not*; it cannot distinguish *NopACL vs ReadOnlyACL*, and DEC-EIHQSU needs all
+three modes.
+
+**Resolution:** discriminate on `App.acl` by type assertion (the in-tree idiom),
+then consult the gate only in the Declarative branch:
+
+| `App.acl` type | behavior |
+|---|---|
+| `*acl.Declarative` | fail-closed; `permission:` required and checked via `gate.HoldsPermission`; `view` denied unconditionally |
+| `acl.ReadOnlyACL` | deny **all** command exec, all contexts |
+| anything else (`NopACL`) | fail-open; execute as today |
+
+Ordering matters: check ReadOnlyACL **before** the Declarative branch, and
+default-deny only in the Declarative branch — a future third ACL impl must not
+silently land in the fail-open default. Add a comment saying so.
+
+## Approach
+
+- [x] Technical approach chosen and documented
+- [x] Approach builds on existing patterns (not reinventing)
+- [x] Alternatives considered (document why rejected)
+- [x] Dependencies identified (packages, APIs, types)
+
+**Technical Approach:**
+
+1. **`CommandConfig.Permission`** — new `permission` YAML key
+(`internal/dataentryconfig/config.go:563`).
+
+2. **`commandHandler.aclMode`** — a new narrow closure field on the handler
+(`command_handler.go:26-31`), consistent with its existing consumer-side closure
+style (`schema`, `services`, `projectRoot`, `executeView`). Returns a small enum
+resolved from `App.acl`, so the handler never imports the ACL decision logic
+itself.
+
+3. **`authorizeCommand(ctx, cmd) (bool, string)`** — one function, the single
+decision point, returning allow + a deny reason for the 403 body. Used by
+**both** exec and resolve so they cannot drift.
+
+4. **Exec enforcement** — call it in `handleCommandExec` before the context
+switch (`commands.go:301`), 403 on deny.
+
+5. **Resolve filtering** — call it in `resolveCommands` (`commands.go:47`) so
+`GET /_commands` omits unexecutable commands.
+
+6. **`validateCommands` warning** — `permission:` set on a `context: view`
+command warns (the key is not honored; silently ignoring would mislead).
+
+**Alternatives considered:**
+
+- *`gate.HoldsPermission` alone.* **Rejected — fails open under read-only**
+(see Critical Finding). This is the trap this plan exists to document.
+- *Extend `acl.ACL` with an `AuthorizeCommand` method.* Rejected: changes a
+sealed, widely-implemented interface for one consumer; `Subject` is a sealed sum
+and a command has no entity subject.
+- *Enforce only at exec, no resolve filtering.* Rejected: buttons would render
+and then 403 on click — the UX TKT-72SCPR depends on requires the filter.
+- *Separate allow-logic for exec and resolve.* Rejected: two paths that must
+agree will drift. One function, two callers.
+
+**Files to modify:**
+
+- `internal/dataentryconfig/config.go` — `Permission` field
+- `internal/dataentryconfig/validate.go` — view+permission warning
+- `internal/dataentry/command_handler.go` — `aclMode` closure
+- `internal/dataentry/commands.go` — `authorizeCommand`, exec 403, resolve filter
+- `internal/dataentry/app.go` — wire `aclMode` (~L588, next to the existing `acl:` closure)
+- `internal/dataentry/commands_test.go`, `internal/dataentryconfig/validate_test.go` — tests
+- `docs/data-entry.md`, `docs/acl-security.md`
+- `e2e/tests/read-only-mode.spec.ts` — correct the deferred-sites comment
+
+## Security Considerations
+
+- [x] Input sources identified (user input, config, external APIs)
+- [x] Input validation approach defined (allowlist preferred over blocklist)
+- [x] Security-sensitive operations identified (file access, auth, crypto)
+- [x] Error handling doesn't leak sensitive information
+
+**Input sources:** `permission:` is admin-authored config, validated at load.
+The request supplies only the command ID (looked up in a closed map) and the
+context IDs — unchanged by this ticket.
+
+**Security-sensitive operation:** this *is* the authorization layer for a `sh
+-c` endpoint. Two failure modes to guard:
+
+1. **Fail-open under read-only** — the Critical Finding above. Pinned by a test
+asserting 403 under `ReadOnlyACL` *with* a granted permission.
+2. **Default-deny placement** — the deny must be the default *inside* the
+Declarative branch, not a fallthrough. A future ACL impl must not inherit
+fail-open by accident.
+
+**Error handling:** the 403 body names the denial in general terms and must not
+echo the required permission name or policy contents — consistent with
+`acl.Decision.Reason` ("never contains raw policy data so 403 bodies don't leak
+the full effective-role set", `acl.go:110-112`). Do not include the
+`permission:` value in the response.
+
+**Not weakened:** POST-only (`commands.go:282`, the `<img src>` RCE fix),
+same-origin/local-host middleware, and `cmd.label` text interpolation all
+unchanged.
+
+## Test Plan
+
+- [x] Test scenarios documented for each acceptance criterion
+- [x] Edge cases identified and documented
+- [x] Negative test cases defined (invalid input, error conditions)
+- [x] Integration test approach defined (not just unit tests)
+
+All Go, via `httptest`, alongside the existing `commands_test.go` suite. Per
+`e2e/tests/AGENTS.md:45` these are HTTP-shape assertions and belong in Go, not
+Playwright.
+
+| Scenario | Expect |
+|---|---|
+| Declarative, `permission: X`, principal holds X | 200, command runs |
+| Declarative, `permission: X`, principal lacks X | 403 |
+| Declarative, no `permission:`, entity/list/global | 403 (fail-closed) |
+| Declarative, `context: view`, `permission:` set **and granted** | 403 (key not honored) |
+| Declarative, `context: view`, no permission | 403 |
+| **ReadOnlyACL, `permission:` set and granted** | **403 — the fail-open trap** |
+| ReadOnlyACL, any context incl. view | 403 |
+| NopACL, no `permission:`, all four contexts incl. view | 200 (fail-open regression) |
+| NopACL, `permission:` set | 200 (no policy to check against) |
+| `resolveCommands` under Declarative | denied commands absent from the list |
+| `resolveCommands` under NopACL | list unchanged from today |
+| `validateCommands`, `permission:` on view command | warning emitted |
+
+**Edge cases:**
+
+- Empty-string `permission:` — treat as unset, not as a permission named `""`
+- Command ID present but principal denied — 403, not 404 (the command's
+existence is already public via config; no oracle concern)
+- Resolve returning an empty list — must serialize as `[]`, not `null`
+(frontend iterates it)
+- View command under NopACL must still populate `RELA_VIEW_ID` etc. — the
+deferral must not alter the payload
+
+**Negative tests:** malformed/unknown permission name in config → validation
+error or warning per the decision; 403 body must not contain the permission
+name.
+
+## Risk Assessment
+
+- [x] Technical risks assessed with mitigations
+- [x] Security risks assessed (see Security Considerations)
+- [x] Effort estimated (xs/s/m/l/xl)
+
+**Risks:**
+
+1. **Silent fail-open** — the Critical Finding. *Mitigation:* the ReadOnlyACL +
+granted-permission test is the canary; write it first.
+2. **Breaking existing deployments** — DEC-EIHQSU accepts this for
+`acl.yaml` users. *Mitigation:* NopACL regression test across all four contexts;
+release note.
+3. **Exec/resolve drift** — *Mitigation:* one `authorizeCommand`, two callers.
+4. **Test-helper reassignment** — `test_helpers_test.go:149` does
+`app.acl = svc.ACL()` after construction, and `app.go:494/588` deliberately use
+closures (`func() acl.ACL { return app.acl }`) to tolerate that. The new
+`aclMode` closure **must** follow the same late-binding pattern or tests that
+swap the ACL post-construction will see a stale mode.
+5. **`plimsoll` god-object limits** — adding methods to `App`. *Mitigation:*
+put the logic on `commandHandler`/free functions, not `App`.
+
+**Effort:** `l` — confirmed.
+
+## Documentation Planning
+
+- [x] User-facing docs identified (skip if internal refactor)
+- [x] Docs-checklist will be created when entering implementation
+
+- [x] `docs/data-entry.md` — the `permission:` key; that `view` cannot be gated per-command yet; that commands are denied under `--read-only`
+- [x] `docs/acl-security.md` — the command-permission family alongside `history:read`; the bimodal fail policy (DEC-EIHQSU)
+- [x] `e2e/tests/read-only-mode.spec.ts:8` — correct the false "403 at the server on click" claim for command buttons
+- [ ] ~~docs/metamodel.md~~ (N/A: no metamodel change)
+- [ ] ~~docs/cli-reference.md~~ (N/A: no CLI change)
+- [ ] ~~README.md~~ (N/A: not project-level)
+
+## Design Review
+
+- [x] Run `/design-review` before starting implementation
+- [x] All critical/significant findings addressed in plan
+
+**Design Review Findings:** this ticket *is* the remediation of RR-65KG68,
+RR-CWWJGW and RR-L6UXCF from TKT-72SCPR's review. The Critical Finding above was
+surfaced during this ticket's own planning by reading `readgate.go` before
+writing code — it would have produced a silently fail-open guard.
+
+Policy settled in **DEC-EIHQSU** (accepted 2026-07-20).

--- a/tickets/entities/planning-checklists/PLAN-CNDJ78.md
+++ b/tickets/entities/planning-checklists/PLAN-CNDJ78.md
@@ -1,0 +1,346 @@
+---
+id: PLAN-CNDJ78
+type: planning-checklist
+title: 'Planning: Render list/view/global commands in the data-entry SPA (backend serves all four contexts, frontend renders only entity)'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+> **DESIGN REVIEW COMPLETE — 3 critical, 2 significant, 1 minor.**
+> The Security Considerations section below was **factually wrong** in its
+> first draft and has been rewritten.
+>
+> **BLOCKING DECISIONS RESOLVED (2026-07-20).** Decision A is answered by
+> **TKT-MJ02AO** (per-command ACL guard), which this ticket now
+> `depends-on`. Decision B is folded into that ticket. TKT-72SCPR stays in
+> `planning` until TKT-MJ02AO lands — see "Sequencing" below.
+
+## Understanding
+
+- [x] Problem/requirements clearly understood
+- [x] Scope defined (what's in/out documented below)
+- [x] Acceptance criteria documented with specific test scenarios
+
+**Scope:**
+
+IN: generalize `CommandModal.vue` off its `entityId` prop (as a **closed
+union**, not an open map — RR-KNEF4K); extract a `useCommands()` composable +
+`CommandButtons.vue`; mount on dashboard and list surfaces; fix the
+command-stream cancellation leak; strengthen two thin Go SSE tests; e2e
+click-through for dashboard + list.
+
+OUT: Lua command backend (TKT-XTNED); **all ACL/permission work → TKT-MJ02AO**;
+changes to command config schema or SSE protocol; API-level Playwright specs
+(prohibited by `e2e/tests/AGENTS.md:45`, already covered in Go).
+
+**Re-scoped by review:** the `available_on.views` fix is not a simple "pass
+`qualifier`" (RR-N643V4). See Approach.
+
+## Sequencing (post-review)
+
+**TKT-MJ02AO must land first.** It adds a `permission:` key to `CommandConfig`,
+403s unauthorized exec, denies all command exec under `ReadOnlyACL`, and filters
+`resolveCommands` by held permission.
+
+Two things follow for this ticket once it lands:
+
+1. **Button visibility comes for free.** `GET /_commands` returns only
+commands the principal may execute, so `CommandButtons.vue` renders a
+permission-filtered list with no client-side ACL logic. Do **not** add
+client-side permission checks — the server filter is the single source of truth,
+and the 403 is the boundary.
+2. **The read-only e2e assertion becomes writable.** TKT-MJ02AO corrects
+`e2e/tests/read-only-mode.spec.ts:8`; this ticket can then assert that no
+command buttons render under `--read-only`, which is currently false.
+
+## Research
+
+- [x] ~~For larger features: run `/research`~~ (N/A: backend contract already exists and dictates the frontend shape)
+- [x] Searched for existing libraries that solve this problem
+- [x] Checked codebase for similar patterns or reusable code
+- [x] Looked for reference implementations in other projects
+- [x] Reviewed relevant rela concepts for prior art
+
+**Research Doc:** N/A — see above.
+
+**Existing Solutions:**
+
+No library applies; internal wiring against an existing in-tree API.
+
+Prior art reused rather than reinvented:
+
+- `composables/useScopeNavigation.ts` — the convention. Named export, reactive
+params as **getter functions** (`useScopeNavigation.ts:21`, called at
+`EntityDetail.vue:64` as `useScopeNavigation(() => props.entityId)`), returns
+refs + functions, loader invoked explicitly by the consumer.
+- `composables/useEvents.ts` — existing SSE composable with connection lifecycle.
+- `EntityDetail.vue:312-331` — BUG-6C3V abort pattern (double guard: explicit
+`signal.aborted` **and** `isCancelledFetch(err)`). Preserve verbatim.
+- `EntityList.vue:653-664` — existing `.list-header` flex header.
+
+**Findings that changed the plan:**
+
+1. **`ListView.vue` is an 11-line pass-through** (`<EntityList :list-id="id" />`).
+The list command row belongs in `components/lists/EntityList.vue`.
+
+2. **The `entityId` coupling is one line** — `CommandModal.vue:42-45` is the
+only use of `props.entityId`. The real cost driver is avoiding triplication of
+~85 lines across three surfaces.
+
+3. **Command-stream cancellation leak** (pre-existing). `EntityDetail.vue:648`
+aborts only the *list* fetch; `CommandModal.vue` has no `AbortController` and no
+`onBeforeUnmount`. **In scope** — see Risk 4.
+
+## Approach
+
+- [x] Technical approach chosen and documented
+- [x] Approach builds on existing patterns (not reinventing)
+- [x] Alternatives considered (document why rejected)
+- [x] Dependencies identified (packages, APIs, types)
+
+**Technical Approach:**
+
+1. **`composables/useCommands.ts`** — `useCommands(ctx: () => GetCommandsParams)`.
+Owns the abortable list fetch (lifting `EntityDetail.vue:312-331` verbatim),
+exposes `commands` ref + `loadCommands()`.
+
+2. **`components/commands/CommandButtons.vue`** — desktop row, mobile overflow
+menu, outside-click watcher (`EntityDetail.vue:304-310`), `CommandModal` ref,
+`runCommand` delegation. One modal instance **per surface** (design-review
+confirmed this seam; a shared singleton would race).
+
+3. **`CommandModal.vue`** — replace `entityId: string` with a **closed
+discriminated union** (RR-KNEF4K), NOT `Record<string,string>`:
+   ```ts
+   type CommandParams =
+     | { entity_id: string }
+     | { entity_id: string; view_id: string }
+     | { list_id: string }
+     | Record<string, never>   // global
+   ```
+Keeps `exec_id` structurally unreachable from any call site.
+
+4. **Cancellation** — add an `AbortController` around the exec stream and abort
+it in `onBeforeUnmount`; allow Close while running.
+
+**`available_on.views` (RR-N643V4) — re-scoped.** Passing `qualifier` with
+`pageType: 'entity'` fixes nothing: `matchesPage` `case "entity"`
+(`commands.go:94-97`) reads only `scope.EntityTypes`. The real fix requires
+sending `pageType: 'view'` when a view is active, which also changes which
+unscoped and `context: view` commands resolve. **Decide during
+implementation-planning whether to take that behavioral delta or drop the AC.**
+Do not ship the no-op version.
+
+Call sites: `EntityDetail.vue` (migrate existing), `EntityList.vue` (`pageType:
+'list'`, `qualifier` = `props.listId`), `DashboardView.vue` (`pageType:
+'dashboard'`, no qualifier).
+
+**Alternatives considered:**
+
+- *Copy the block into each surface.* Rejected: triplicates BUG-6C3V.
+- *Composable only, no component.* Rejected: leaves ~35 template lines per surface.
+- *`params: Record<string,string>`.* **Rejected by review (RR-KNEF4K)** — an
+open map into a `sh -c` endpoint's query string.
+- *Client-side permission filtering.* **Rejected** — TKT-MJ02AO filters
+server-side; duplicating it client-side invites drift and implies the client is
+a boundary.
+- *Move exec into `api/commands.ts`.* Deferred; follow-up.
+
+## Security Considerations
+
+- [x] Input sources identified (user input, config, external APIs)
+- [x] Input validation approach defined (allowlist preferred over blocklist)
+- [x] Security-sensitive operations identified (file access, auth, crypto)
+- [x] Error handling doesn't leak sensitive information
+
+> **REWRITTEN AFTER DESIGN REVIEW.** The original claimed "the server already
+> authorizes these." That is false. Three critical findings came from that one
+> wrong assumption. **TKT-MJ02AO makes it true**; until it lands, the
+> statements below describe the live system.
+
+**Security posture of command execution (pre-TKT-MJ02AO):**
+
+1. **No authorization on command execution.** (RR-65KG68) `handleCommandExec`
+(`commands.go:281`) does four things before `sh -c`: method check, command-ID
+lookup, stdin build, exec. Grep for
+`acl|ACL|translateVerb|WriteRequest|Principal` across `commands.go` and
+`command_handler.go` → **zero matches**. Only gates are
+`requireSameOrigin`/`requireLocalHost` (`router.go:105-108`) — CSRF and
+network-location, not authorization.
+
+2. **`--read-only` does NOT block command execution.** (RR-CWWJGW)
+`acl.ReadOnlyACL` (`internal/acl/readonly.go:18`) implements exactly one method,
+`AuthorizeWrite(WriteRequest)`. Command exec constructs no `WriteRequest`. There
+is also **no frontend read-only state** — the SPA hides Edit/Delete/+New because
+the *server omits affordances*, not because the client knows the mode.
+
+3. **`available_on` is display scoping, NOT an authorization boundary.**
+(RR-L6UXCF) `matchesPage` runs only on the GET `/_commands` render path; exec
+never validates the supplied IDs against `cmd.AvailableOn`.
+
+4. **`validateCommands` (`validate.go:1255`) is config-load validation only.**
+It checks referenced IDs exist in config; it establishes nothing at request
+time. Citing it as the input-validation story was the original error.
+
+**What this ticket changes, given the dependency:**
+
+With TKT-MJ02AO landed first, this ticket renders buttons against a surface that
+is genuinely gated: unauthorized principals get a filtered command list and a
+403 if they forge a request. The dashboard mount is then safe to ship.
+**Shipping this ticket before TKT-MJ02AO would put an ungated shell-exec button
+on the first page every user lands on** — hence the `depends-on`.
+
+**Preserved boundaries (do not regress):**
+
+- `cmd.label` renders via text interpolation (`{{ cmd.label }}`), never
+`v-html`. XSS boundary for admin-authored config.
+- POST-only on exec (`commands.go:282`) — the `<img src>` RCE fix documented
+at `commands.go:274-279`.
+- CSRF Origin allowlist, covered in Go by `middleware_security_test.go` /
+`router_security_test.go`. Per AGENTS.md do **not** add an e2e equivalent.
+
+## Test Plan
+
+- [x] Test scenarios documented for each acceptance criterion
+- [x] Edge cases identified and documented
+- [x] Negative test cases defined (invalid input, error conditions)
+- [x] Integration test approach defined (not just unit tests)
+
+**Layering rule (`e2e/tests/AGENTS.md:45`):** HTTP-shape assertions in Go;
+click-through journeys only in Playwright. `request.fetch(...)` /
+`api.rawRequest(...)` are eslint errors in `tests/**/*.spec.ts`.
+
+| AC | Layer | Scenario |
+|---|---|---|
+| global renders + executes | vitest + e2e | dashboard button mounts; e2e clicks, modal opens |
+| list renders, `available_on.lists` scoping | vitest + e2e | scoped command present for matching list, **absent** for non-matching |
+| view scoping | vitest | **REWRITTEN — see below** |
+| `CommandModal` without entity | vitest | mount with `{}` params; assert URL has no `entity_id` |
+| entity behavior unchanged | vitest | existing `CommandModal.test.ts` green with only the prop-shape edit |
+| cancellation | vitest | unmount mid-stream aborts the fetch; Close enabled while running |
+| Go SSE assertions | Go | strengthen `TestHandleCommandExecListContext:713` / `ViewContext:733` |
+| global env contract | Go | assert `RELA_ENTITY_ID` **absent** (not empty) for global input (RR-I3VLJV) |
+| read-only | e2e | no command buttons render under `--read-only` (**requires TKT-MJ02AO**) |
+| e2e click-through | e2e | dashboard + list |
+
+**REWRITTEN per RR-N643V4 — the original view-scoping test was unfalsifiable.**
+It asserted `getCommands` was *called with* a qualifier, i.e. it asserted the
+mock, and would pass green against a broken implementation. Replace with: seed a
+command with `available_on.views: [X]`, render on view X → assert the button
+**appears**; render on view Y → assert it **does not**. Assert the resolved
+command list, never the call arguments.
+
+Frontend convention: **`.test.ts` co-located**. Mock via `globalThis.fetch` spy
+with the teardown trio from `CommandModal.test.ts:52-68` (restore fetch, clear
+`document.body.innerHTML`, reset modal/confirm singletons). Modal DOM queried
+via `document.querySelector` (`attachTo: document.body`).
+
+**Edge Cases:**
+
+- Empty command list → no button row, no overflow button
+- **Permission-filtered to empty** (post-MJ02AO) → same as empty; assert no stray container renders
+- Dashboard has no qualifier — assert the param is **omitted**, not sent empty
+- Rapid navigation between lists → BUG-6C3V abort path
+- `DashboardView` has no abort controller today (`onMounted` only) — the composable introduces the pattern fresh there
+- Long `cmd.label` on mobile → overflow menu
+- Command with `confirm:` on a non-entity surface → confirm modal still gates
+- Unknown/stale qualifier → empty set, fail-closed
+- `natsort` (`commands.go:58`) means button order shifts on rename — pin e2e assertions or they flake
+
+**Negative Tests:**
+
+- Non-matching `available_on.lists` → button absent (paired positive/negative
+fixtures, per `feature_summary`/`feature_readonly` at `fixtures.ts:1030-1051`)
+- Command list fetch 500s → `commands = []`, no throw, page still renders
+- SSE `error` event → `success=false`, error text shown
+- Aborted fetch → silently ignored, no console error
+
+## Risk Assessment
+
+- [x] Technical risks assessed with mitigations
+- [x] Security risks assessed (see Security Considerations)
+- [x] Effort estimated (xs/s/m/l/xl)
+
+**Risks:**
+
+1. **Regressing shipped entity-detail behavior.** *Mitigation:* migrate it
+last; keep `CommandModal.test.ts` green throughout as the canary.
+
+2. **Shared `e2e/tests/fixtures.ts`.** `fixtures.ts:1039-1046` warns that
+adding config shifts counts asserted in `settings.spec.ts` and
+`entity-detail.spec.ts`. `createTestProject()` takes no parameters — no per-test
+override. *Mitigation:* run the full e2e suite before and after; budget for
+touching those assertions. **Coordinate with TKT-MJ02AO**, which will also touch
+this fixture to add `permission:` cases.
+
+3. **Type union mismatch** — `GetCommandsParams.pageType` uses `'dashboard'`,
+`Command.context` uses `'global'` (`api/commands.ts:5` vs
+`types/config.ts:387`). Writing `pageType: 'global'` yields an empty list and no
+error. *Mitigation:* a `const` map the compiler enforces, **not** a comment.
+
+4. **Cancellation leak — IN SCOPE.** With three surfaces, rapid navigation
+spawns unbounded `sh -c` processes: `commands.go:360` binds to `r.Context()`,
+but nothing client-side aborts the stream, so the request stays open and the
+process lives. `runningCommands` grows; `Close` is `:disabled="running"`
+(`CommandModal.vue:169`) so the user cannot dismiss them.
+
+5. **`DashboardView` header needs a flex wrapper** — `h1` + `p` are stacked
+blocks with no actions container, unlike `.list-header`.
+
+6. **Dependency slip.** If TKT-MJ02AO is delayed, the temptation will be to
+ship the frontend anyway. *Mitigation:* the `depends-on` relation plus the
+read-only AC, which cannot pass without it.
+
+**Effort:** `m` — confirmed. The ACL work moved to TKT-MJ02AO (`l`), so this
+stays frontend-plus-tests as originally sized.
+
+## Documentation Planning
+
+- [x] User-facing docs identified (skip if internal refactor)
+- [x] Docs-checklist will be created when entering implementation
+
+**Documentation Impact:**
+
+- [x] `docs/data-entry.md` — **required.** Correct wording about which contexts
+render, and note that `context: global` scripts receive **no**
+`RELA_ENTITY_ID`/`RELA_ENTITY_TYPE`, with a `set -u` recommendation (RR-I3VLJV).
+The `permission:` key and the `available_on`-is-not-authz note are documented by
+TKT-MJ02AO.
+- [ ] ~~docs/metamodel.md~~ (N/A: no metamodel change)
+- [ ] ~~docs/cli-reference.md~~ (N/A: no CLI change)
+- [ ] ~~CLAUDE.md~~ (N/A: follows existing composable pattern)
+- [ ] ~~README.md~~ (N/A: not project-level)
+
+## Design Review
+
+- [x] Run `/design-review` before starting implementation
+- [x] All critical/significant findings addressed in plan
+
+**Design Review Findings:**
+
+| ID | Severity | Title | Resolution |
+|---|---|---|---|
+| RR-65KG68 | critical | No authorization layer on command exec | deferred → TKT-MJ02AO |
+| RR-CWWJGW | critical | `--read-only` does not block command exec | deferred → TKT-MJ02AO |
+| RR-N643V4 | critical | `available_on.views` fix doesn't work; test unfalsifiable | addressed in plan |
+| RR-L6UXCF | significant | `available_on` not enforced at exec time | deferred → TKT-MJ02AO |
+| RR-KNEF4K | significant | Open `params` map into shell-exec query string | addressed in plan |
+| RR-I3VLJV | minor | `RELA_ENTITY_ID` absent for global commands | addressed in plan |
+
+**Resolved open questions:**
+
+1. *Cancellation leak* → **fix here.** A direct consequence of going from one
+surface to three. Risk 4.
+2. *Move exec into `api/commands.ts`* → **defer.** But verify the raw `fetch`
+at `CommandModal.vue:48` isn't missing an interceptor the axios client applies.
+3. *Is `CommandButtons.vue` the right seam* → **yes.** One modal per surface.
+
+**Blocking decisions — RESOLVED:**
+
+- **A. Read-only mode** → **option 1, gate exec on ACL**, scoped to
+**TKT-MJ02AO** as a prep PR. Per-command configurable `permission:`, plus a
+blanket deny under `ReadOnlyACL`, plus permission-filtered resolution so buttons
+hide.
+- **B. Exec-time scope enforcement (RR-L6UXCF)** → **folded into TKT-MJ02AO**,
+same file and review.

--- a/tickets/entities/review-checklists/REV-NGPPA5.md
+++ b/tickets/entities/review-checklists/REV-NGPPA5.md
@@ -2,55 +2,101 @@
 id: REV-NGPPA5
 type: review-checklist
 title: 'Review: Per-command ACL guard: gate command execution and button visibility on a named permission (entity/list/global; view deferred)'
-status: in-progress
+status: done
 ---
 
 <!-- @managed: claude-workflow v1 -->
 
 ## Automated Checks
 
-- [ ] All tests pass (`just test`)
-- [ ] Lint clean (`just lint`)
-- [ ] Coverage maintained (`just coverage-check`)
+- [x] All tests pass (`just test`)
+- [x] Lint clean (`just lint`)
+- [x] Coverage maintained (`just coverage-check`)
+
+Full `just ci` green on the final commit: golangci-lint **0 issues**,
+go-arch-lint **OK - No warnings found**, markdownlint **0 issues in 0 files**,
+whole-repo `go test ./...` pass, coverage package floor + total both **PASS**,
+frontend build ok, `✓ Docs are up to date.`
+
+Two failures were found and fixed during this phase rather than papered over:
+
+1. **MD028** — blank line inside a blockquote in the new Authorization section.
+2. **`docs-check` failure — the important one.** `docs/acl-security.md` and
+`docs/data-entry.md` are **auto-generated** from
+`docs-project/entities/guides/`. The implementation phase had edited the
+generated files directly, so every word of the new documentation would have been
+silently wiped by the next `just docs` run. Moved to the source guides
+(`GUIDE-acl-security.md`, `GUIDE-data-entry.md`) and regenerated; generation
+verified idempotent across two consecutive runs.
 
 ## Code Review
 
-- [ ] Run `/code-review` command (invokes cranky-code-reviewer agent)
-- [ ] All critical review-responses addressed
-- [ ] All significant review-responses addressed
-- [ ] Self-reviewed the diff for unrelated changes
+- [x] Run `/code-review` command (invokes cranky-code-reviewer agent)
+- [x] All critical review-responses addressed
+- [x] All significant review-responses addressed
+- [x] Self-reviewed the diff for unrelated changes
 
-**Review Responses:** <!-- List IDs of review-response entities created, e.g.,
-RR-xxxx -->
+**Review Responses:** RR-YZV7SY, RR-CAUBAZ, RR-37AYC0 (significant, all
+**addressed**); RR-0LDY3W (minor, **addressed**); RR-PG8HR2 (minor, **deferred**
+with justification → TKT-JRY8V5).
+
+No critical findings. Two adversarial passes plus independent verification of
+every load-bearing claim; the cancel bypass was confirmed with a throwaway PoC
+test (written, run, deleted) rather than accepted on assertion.
+
+Self-review of the production diff found no unrelated changes, no debug code, no
+TODOs. The `tickets/` additions are the project dogfooding its own tracker and
+belong in the commit.
 
 ## Acceptance Verification
 
-- [ ] Each acceptance criterion tested (reference planning checklist)
-- [ ] Test evidence documented in implementation checklist
+- [x] Each acceptance criterion tested (reference planning checklist)
+- [x] Test evidence documented in implementation checklist
 
-**Acceptance Status:**
-<!-- For each acceptance criterion, state PASS/FAIL with evidence -->
+**Acceptance Status:** all 9 PASS.
+
+| # | Criterion | Evidence |
+|---|---|---|
+| 1 | `permission: X` runs for a holder, 403s for a non-holder (entity/list/global) | `TestCommandExecDeclarativeFailsClosed` — granted×3, not-held×2 |
+| 2 | Unauthorized commands absent from `GET /_commands` | `TestResolveCommandsFiltersUnauthorized` |
+| 3 | No `acl.yaml` ⇒ unchanged in all four contexts incl. view | `TestCommandExecNopACLFailsOpen` (4 subtests) |
+| 4 | `acl.yaml` + no `permission:` ⇒ denied | `TestCommandExecDeclarativeFailsClosed` — 3 no-permission cases |
+| 5 | View denied **even when set and granted** | `TestCommandExecDeclarativeFailsClosed` — "view denied despite granted permission" |
+| 6 | `validateCommands` warns on view + `permission:` | `TestViewCommandPermissionWarning` (3 subtests) |
+| 7 | `--read-only` denies every command, every context | `TestCommandExecReadOnlyDenied` (4 subtests) — **failed before the fix, proving the vuln** |
+| 8 | `docs/acl-security.md` documents `command:*` and the view limitation | `GUIDE-acl-security.md` → generated; verified by `docs-check` |
+| 9 | `read-only-mode.spec.ts` comment corrected | committed |
+
+Beyond the stated criteria, two review-driven properties are also pinned:
+`TestAuthorizeCommandUnknownACLDenies` (4 subtests — the fail-closed switch) and
+`TestCommandCancelOwnerBound` (2 subtests — cross-principal kill).
 
 ## Documentation (enhancements only)
 
-Skip this section for bugs and internal refactors.
+- [x] Docs-checklist created and linked via `has-docs`
+- [x] User-facing documentation updated
+- [x] Docs-checklist marked as done
 
-- [ ] Docs-checklist created and linked via `has-docs`
-- [ ] User-facing documentation updated
-- [ ] Docs-checklist marked as done
-
-**Docs Checklist:** <!-- e.g., DOCS-xxxx -->
+**Docs Checklist:** DOCS-IJJR4H
 
 ## Final Checks
 
-- [ ] Commit message explains the why, not just what
-- [ ] No TODOs or FIXMEs left unaddressed
-- [ ] Ready for another developer to use
+- [x] Commit message explains the why, not just what
+- [x] No TODOs or FIXMEs left unaddressed
+- [x] Ready for another developer to use
+
+The commit message leads with the vulnerability and the non-obvious constraint
+(the read gate cannot implement this policy because `nopReadGate` covers both
+`NopACL` and `ReadOnlyACL`), not with a list of touched files.
 
 ## Pull Request
 
-- [ ] Run `/pr` command to create PR and monitor CI
-- [ ] All CI checks pass
-- [ ] PR URL documented below
+- [x] Run `/pr` command to create PR and monitor CI
+- [x] ~~All CI checks pass~~ (N/A at time of writing: remote CI was still
+running when this checklist had to reach `status: done` — the ticket cannot be
+`done` without it, and the PR cannot exist without the ticket being `done`.
+Local `just ci` is fully green, which runs the same gates. Remote status is
+tracked on the PR itself.)
+- [x] PR URL documented below
 
-**PR:** <!-- e.g., https://github.com/org/repo/pull/123 -->
+**PR:** https://github.com/sourcehaven-bv/rela/pull/1180

--- a/tickets/entities/review-checklists/REV-NGPPA5.md
+++ b/tickets/entities/review-checklists/REV-NGPPA5.md
@@ -1,0 +1,56 @@
+---
+id: REV-NGPPA5
+type: review-checklist
+title: 'Review: Per-command ACL guard: gate command execution and button visibility on a named permission (entity/list/global; view deferred)'
+status: in-progress
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Automated Checks
+
+- [ ] All tests pass (`just test`)
+- [ ] Lint clean (`just lint`)
+- [ ] Coverage maintained (`just coverage-check`)
+
+## Code Review
+
+- [ ] Run `/code-review` command (invokes cranky-code-reviewer agent)
+- [ ] All critical review-responses addressed
+- [ ] All significant review-responses addressed
+- [ ] Self-reviewed the diff for unrelated changes
+
+**Review Responses:** <!-- List IDs of review-response entities created, e.g.,
+RR-xxxx -->
+
+## Acceptance Verification
+
+- [ ] Each acceptance criterion tested (reference planning checklist)
+- [ ] Test evidence documented in implementation checklist
+
+**Acceptance Status:**
+<!-- For each acceptance criterion, state PASS/FAIL with evidence -->
+
+## Documentation (enhancements only)
+
+Skip this section for bugs and internal refactors.
+
+- [ ] Docs-checklist created and linked via `has-docs`
+- [ ] User-facing documentation updated
+- [ ] Docs-checklist marked as done
+
+**Docs Checklist:** <!-- e.g., DOCS-xxxx -->
+
+## Final Checks
+
+- [ ] Commit message explains the why, not just what
+- [ ] No TODOs or FIXMEs left unaddressed
+- [ ] Ready for another developer to use
+
+## Pull Request
+
+- [ ] Run `/pr` command to create PR and monitor CI
+- [ ] All CI checks pass
+- [ ] PR URL documented below
+
+**PR:** <!-- e.g., https://github.com/org/repo/pull/123 -->

--- a/tickets/entities/review-responses/RR-0LDY3W.md
+++ b/tickets/entities/review-responses/RR-0LDY3W.md
@@ -1,0 +1,28 @@
+---
+id: RR-0LDY3W
+type: review-response
+title: available_on is not enforced at exec; docs should say so explicitly now that authorization is documented next to it
+finding: |-
+    resolveCommands filters on matchesPage (commands.go:132) but handleCommandExec never checks page scope — it dispatches purely on cmd.Context (commands.go:383). So a command scoped via `available_on: {lists: [tickets]}` is executable from anywhere by direct POST with any list_id.
+
+    This does NOT create resolve/exec drift in the authorization verdict: both call authorizeCommand, which does not consider page scope, so they agree on allow/deny. The drift is only that resolve additionally hides buttons that exec would still run. That is the safe direction (no false-allow in the UI), so it is not a bug.
+
+    It is a documentation gap, and this ticket sharpens it: docs/data-entry.md now has an Authorization section sitting directly above the available_on documentation. A reader encountering `available_on` next to `permission` will reasonably infer that both restrict. One does; the other is presentation only.
+
+    This is the same substance as RR-L6UXCF (filed against TKT-72SCPR, deferred to this ticket), whose fallback obligation was: 'If exec-time enforcement is rejected, the fallback obligation is to document that available_on is display scoping only.' Exec-time matchesPage enforcement was NOT implemented in this PR, so that fallback obligation is now due.
+
+    ACTION: one sentence in docs/data-entry.md under available_on — 'available_on controls where a button appears; it is not an authorization boundary. Use permission: to control who may execute a command.'
+severity: minor
+resolution: |-
+    FIXED. docs/data-entry.md now carries an explicit callout in the Authorization section, directly above the available_on documentation:
+
+      'available_on is not an authorization boundary. It controls where a button appears; it is not checked at execution time, so a command scoped to one list or entity type can still be invoked directly against any other. Use permission: to control who may run a command, and note that a command reads whatever its context assembles from the caller-supplied entity_id / list_id — not from the page the button was on.'
+
+    It cross-links to the new 'What a command permission actually confers' section in docs/acl-security.md (RR-37AYC0), so the two halves of the mental model — where a button shows vs. what a grant confers — are connected rather than discoverable separately.
+
+    This discharges the fallback obligation recorded on RR-L6UXCF: exec-time matchesPage enforcement was not implemented in this PR, so the documentation alternative was owed. The claim that available_on restricts is no longer left for a reader to infer from its adjacency to permission:.
+status: addressed
+---
+
+Cheap to close and it discharges an obligation already accepted on RR-L6UXCF.
+Recommend fixing in this PR rather than deferring again.

--- a/tickets/entities/review-responses/RR-37AYC0.md
+++ b/tickets/entities/review-responses/RR-37AYC0.md
@@ -1,0 +1,61 @@
+---
+id: RR-37AYC0
+type: review-response
+title: entity/list command payloads bypass the read gate, so a command:* grant is a read-everything oracle — contradicting the docs shipped in this ticket
+finding: |-
+    This ticket deferred `context: view` on the stated grounds that its payload is the whole traversal closure 'assembled without read-gate scoping', so a grant would confer read access wider than the entry entity. That reasoning is correct. The problem is it applies to the contexts that WERE shipped as grantable.
+
+    VERIFIED:
+
+    - `context: entity` — handleCommandExec calls svc.Store.GetEntity(r.Context(), entityID) directly (commands.go:387) with NO PermitsRead check, and entityID comes straight from the query string. relationsForEntity (commands.go:233) then loads every incident relation with store.DirectionBoth. So a principal holding one entity-command permission can point it at ANY entity id in the store and receive that entity plus all its relations on the script's stdin.
+    - `context: list` — listFromStoreByTypes performs a raw ListEntities drain with no ReadQuery scoping, and list_id is caller-supplied, so the principal can select any configured list rather than the one whose page they are on.
+
+    CONSEQUENCE: a single `command:*` grant is materially broader than 'may run this script'. It is closer to 'may read every entity of the selected shape', because the script receives the payload regardless of the principal's per-entity read verdicts.
+
+    WHY THIS IS A DOCS DEFECT, NOT ONLY A CODE ONE: docs/acl-security.md as written in this ticket singles out view as the wide-blast-radius context and implies the others are narrow. An operator reading it would reasonably conclude that granting `command:export-ticket` is scoped to tickets the grantee can already read. It is not. The docs currently overstate the safety of the shipped contexts.
+
+    MINIMUM ACTION (docs, no code): state plainly that a command permission confers read access to whatever the command's context assembles — for entity, any entity id the caller supplies; for list, any configured list — and that command payloads are NOT read-gate scoped in any context. That makes the view deferral a difference of degree rather than kind, which is what it actually is.
+
+    FULL FIX (code, likely its own ticket): scope the payload builders through readGateFromContext — PermitsRead for the entity context, ReadQuery for the list context — and then reconsider whether the view deferral is still necessary or whether the same scoping generalizes.
+severity: significant
+resolution: |-
+    FIXED at the docs level (the minimum action the finding specified); the code-level read-gate scoping is deferred with a reason.
+
+    docs/acl-security.md gained a 'What a command permission actually confers' section stating plainly that command payloads are NOT read-gate scoped in ANY context, with a table showing exactly what each context hands the script and what scopes it:
+
+      entity  → the entity at the caller-supplied entity_id + every incident relation | scoped by: nothing
+      list    → every entity in the caller-supplied list_id, post-filter              | scoped by: nothing
+      global  → project paths only                                                    | n/a
+      view    → entry + entire traversal closure                                      | not grantable
+
+    It now says explicitly: 'Treat a command grant as "may read every entity of this shape", and scope grants accordingly', and notes that entity_id/list_id come from the request rather than the page the user was on.
+
+    The view paragraph was rewritten to stop implying view is categorically different: 'The difference from the contexts above is degree, not kind: a view's traversal closure is unbounded by the config an operator can read, so the blast radius of the grant is not knowable in advance.' That is the honest distinction and it preserves the deferral rationale without overstating the safety of what shipped.
+
+    DEFERRED (code): routing the payload builders through readGateFromContext — PermitsRead for entity, ReadQuery for list. That is a behavior change to what existing commands receive on stdin (a command that today sees all entities of a type would start seeing a subset), so it can break working scripts and deserves its own ticket with a migration note. Documenting the current behavior accurately is the correct interim: an operator can now make an informed grant decision, which they could not with the previous text.
+status: addressed
+---
+
+## Evidence
+
+`internal/dataentry/commands.go:385-391`, entity context — no read gate:
+
+```go
+case "entity":
+	entityID := r.URL.Query().Get("entity_id")
+	svc := h.services()
+	entityDomain, err := svc.Store.GetEntity(r.Context(), entityID)
+	if err != nil { ... 404 ... }
+	input = h.buildEntityInput(r.Context(), entityDomain)
+```
+
+Compare the read path, which *does* gate — `history_handler.go:114`
+(`a.gateReadOrNotFound`) and the `PermitsRead` contract in `readgate.go`.
+
+## Why I am filing this against my own change
+
+The ticket's view-deferral rationale is sound, and I wrote it. But applying that
+reasoning consistently means the shipped contexts have the same property to a
+lesser degree, and the docs I wrote imply otherwise. Correcting the docs is
+cheap and honest; leaving them is the kind of overstatement that gets an
+operator to grant something they would not have.

--- a/tickets/entities/review-responses/RR-65KG68.md
+++ b/tickets/entities/review-responses/RR-65KG68.md
@@ -1,0 +1,55 @@
+---
+id: RR-65KG68
+type: review-response
+title: 'Plan''s security claim is false: command exec has no authorization layer at all'
+finding: |-
+    PLAN-CNDJ78's Security Considerations states 'This does not weaken any check — the server already authorizes these.' This is factually wrong and it is load-bearing for the plan's risk assessment.
+
+    VERIFIED: grep for acl/ACL/translateVerb/WriteRequest/ReadOnly/Principal across internal/dataentry/commands.go and internal/dataentry/command_handler.go returns ZERO matches. handleCommandExec (commands.go:281) does exactly four things before spawning a shell: HTTP method check, command-ID lookup in s.Cfg.Commands, stdin build, then exec.CommandContext(r.Context(), "sh", "-c", cmd.Script).
+
+    The only gates on /api/command/ are requireSameOrigin and requireLocalHost (router.go:105-108) — CSRF and network-location controls, which answer 'did this come from our page on this host', never 'may this principal do this'. attachACLRequest (router.go:157) merely attaches an acl.Request to context for downstream consumers; handleCommandExec never reads it.
+
+    Per internal/dataentry/CLAUDE.md every write path must route through translateVerb and re-authorize. Command exec does neither, because it is not recognized as a write path at all.
+
+    FAILURE SCENARIO: deployment with acl.Declarative policy denying user alice write on entity type 'secret'. Admin configures a context:global command whose script mutates the project. Alice's ACL is irrelevant — she POSTs /api/command/{id} and the shell runs as the server process with full project access. Today she cannot reach it because no button exists. This ticket adds one to the dashboard, the first page every user lands on.
+
+    The plan does not need to FIX this (it is pre-existing), but it must not assert the opposite. The honest statement is: 'command execution has no authorization layer; this ticket increases the number of principals who can trivially reach it.'
+severity: critical
+resolution: 'PLAN-CNDJ78 Security Considerations rewritten to state the true posture. Fix scoped to TKT-MJ02AO: named permission per command following the acl.PermHistoryRead precedent (internal/acl/policy.go:43), 403 on unauthorized exec in handleCommandExec.'
+reason: 'Deferred to TKT-MJ02AO (per-command ACL guard), created as a prep PR at the user''s direction and linked via TKT-72SCPR depends-on TKT-MJ02AO. Justification for deferring rather than fixing in place: adding authorization to command exec is a backend change to the acl/dataentry boundary requiring a config-schema addition (permission: key), a policy decision on the omitted-permission default, and its own test matrix — materially larger than the frontend rendering ticket it was filed against, and mixing them would make both harder to review. The finding is NOT dismissed: the plan''s false ''the server already authorizes these'' claim has been deleted and replaced with an accurate description of the live posture, and TKT-72SCPR cannot ship first (the depends-on plus a read-only acceptance criterion that fails without MJ02AO enforce the ordering).'
+status: deferred
+---
+
+## Evidence
+
+`internal/dataentry/commands.go:281` — `handleCommandExec`, no authz:
+
+```go
+func (h *commandHandler) handleCommandExec(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost { ... }
+	commandID := strings.TrimPrefix(r.URL.Path, "/api/command/")
+	s := h.schema()
+	cmd, ok := s.Cfg.Commands[commandID]
+	if !ok { ... }
+	// ... straight to building input, then sh -c
+```
+
+Grep result (verified directly, not via subagent):
+
+```
+grep -n "acl|ACL|translateVerb|WriteRequest|ReadOnly|readOnly|Principal" \
+  internal/dataentry/commands.go internal/dataentry/command_handler.go
+(no matches)
+```
+
+## Required plan change
+
+Rewrite PLAN-CNDJ78 Security Considerations. Delete the "the server already
+authorizes these" sentence. Replace with an explicit statement that command exec
+is an unauthenticated-by-design operator-trust surface, and that this ticket
+widens reachability.
+
+## Recommended (separate ticket, not this one)
+
+Gate `handleCommandExec` on an ACL op. Out of scope here, but the plan should
+link a follow-up rather than leave the surface undocumented.

--- a/tickets/entities/review-responses/RR-CAUBAZ.md
+++ b/tickets/entities/review-responses/RR-CAUBAZ.md
@@ -1,0 +1,68 @@
+---
+id: RR-CAUBAZ
+type: review-response
+title: authorizeCommand's type switch fails OPEN on any unrecognized acl.ACL, including a pointer ReadOnlyACL
+finding: |-
+    authorizeCommand (internal/dataentry/commands.go:81) switches on the concrete ACL type with `default: return true`. Fail-open is the wrong default arm for an authorization boundary: an ACL implementation the switch does not recognize grants every command.
+
+    CONCRETE BYPASS: acl.ReadOnlyACL.AuthorizeWrite has a VALUE receiver (internal/acl/readonly.go:21), so BOTH acl.ReadOnlyACL and *acl.ReadOnlyACL satisfy acl.ACL (Go method-set rule: a pointer's method set includes value-receiver methods). `case acl.ReadOnlyACL:` matches only the value form. Wiring appbuild.WithACL(&acl.ReadOnlyACL{}) compiles cleanly, falls through to default, and returns true — every command executes under a server started with --read-only. The exact bug this ticket exists to close, reintroduced through a pointer.
+
+    VERIFIED NOT LIVE TODAY: grep for `&acl.ReadOnlyACL|&acl.NopACL|\*acl.ReadOnlyACL|\*acl.NopACL` across the repo returns ZERO hits; cmd/rela-server/main.go:126 passes the value form. So this is latent, not an exploitable bug in the shipped build.
+
+    BUT the tree already contains a fourth acl.ACL implementation with no arm: *acl.Request (internal/acl/request.go:84) implements AuthorizeWrite. It is not wired as App.acl today (it is per-request and lives in context), but it is a real implementation that would hit `default` and fail open. The complete implementer set is: acl.NopACL (value), acl.ReadOnlyACL (value), *acl.Declarative (pointer, has an arm), *acl.Request (pointer, NO arm).
+
+    appbuild.WithACL accepts any acl.ACL from any caller, and the guard against this is a code comment at commands.go:70 ("A future ACL implementation MUST get an explicit arm above"). A comment is not an enforcement mechanism, and nothing in the compiler or a test prevents the regression.
+
+    RECOMMENDED (inverts the failure direction, closed by construction):
+
+      switch a := aclImpl.(type) {
+      case acl.NopACL:            // the ONLY fail-open arm
+          return true
+      case acl.ReadOnlyACL, *acl.ReadOnlyACL:
+          return false
+      case *acl.Declarative:
+          ...
+      default:
+          return false            // unknown implementation ⇒ deny
+      }
+
+    This also subsumes the typed-nil gap: `if aclImpl == nil` (commands.go:77) catches only an untyped nil, so a typed-nil of any implementation other than *acl.Declarative currently reaches default and returns true. With default deny, it denies.
+severity: significant
+resolution: |-
+    FIXED. Inverted the type switch so it is closed by construction (internal/dataentry/commands.go).
+
+    - `default:` now returns FALSE. An acl.ACL implementation with no explicit arm denies rather than granting shell execution.
+    - `case acl.NopACL, *acl.NopACL:` is now the ONLY fail-open arm, and is explicit rather than implicit.
+    - `case acl.ReadOnlyACL, *acl.ReadOnlyACL:` matches both forms, closing the pointer bypass. Because AuthorizeWrite has a value receiver, &acl.ReadOnlyACL{} satisfies acl.ACL; under the old value-only match it fell to default and granted, which was a --read-only bypass reachable by adding one `&`.
+    - The typed-nil gap is subsumed: any typed-nil other than *acl.Declarative now lands in default and denies.
+
+    The godoc was rewritten to state the invariant rather than request it: 'Adding a new acl.ACL implementation? It denies commands until you add an arm. That is deliberate: the failure mode of forgetting is a denied command, not an ungoverned shell.'
+
+    Pinned by TestAuthorizeCommandUnknownACLDenies with 4 subtests: pointer ReadOnlyACL denies, pointer NopACL still fails open, an unrecognized implementation (*acl.Request — the real fourth implementer identified in review) denies, and typed-nil Declarative denies. All pass.
+status: addressed
+---
+
+## Why the current shape is risky even though it works today
+
+Three separate things have to stay in agreement for the boundary to hold, and
+none is checked by a test or linter:
+
+1. the `default: return true` arm,
+2. the convention that `ReadOnlyACL`/`NopACL` are always passed by value,
+3. a comment telling future authors to add an arm.
+
+Inverting the default collapses all three into one compiler-checked property: a
+new or wrapped ACL denies until someone deliberately opts it into fail-open.
+
+## Suggested test to pin it
+
+```go
+func TestAuthorizeCommandUnknownACLDenies(t *testing.T) {
+	// A pointer ReadOnlyACL satisfies acl.ACL via the value receiver but is
+	// a distinct dynamic type — it must not fall through to fail-open.
+	if authorizeCommand(context.Background(), &acl.ReadOnlyACL{},
+		CommandConfig{Context: "global"}) {
+		t.Error("pointer ReadOnlyACL must deny")
+	}
+}
+```

--- a/tickets/entities/review-responses/RR-CWWJGW.md
+++ b/tickets/entities/review-responses/RR-CWWJGW.md
@@ -1,0 +1,65 @@
+---
+id: RR-CWWJGW
+type: review-response
+title: --read-only does not block command execution; this ticket puts a button on the dashboard
+finding: |-
+    Read-only mode is enforced exclusively through acl.ReadOnlyACL.AuthorizeWrite(WriteRequest) (internal/acl/readonly.go:21). Command exec never constructs a WriteRequest (see the sibling finding), so --read-only does NOT stop a command from mutating the project, writing entities, or running arbitrary shell.
+
+    VERIFIED: internal/acl/readonly.go implements exactly one method, AuthorizeWrite. cmd/rela-server/main.go:125-126 wires it via appbuild.WithACL(acl.ReadOnlyACL{}). There is no HTTP-layer read-only middleware — grep for RELA_READ_ONLY/ReadOnlyACL across cmd/ and internal/cli/ shows wiring only at the ACL/entitymanager layer.
+
+    Compounding: there is NO frontend read-only state whatsoever. grep for readOnly/read_only/readonly across frontend/src returns only CodeMirror editor attributes, form-field `readonly` config flags, and Vue's `readonly()` helper — nothing representing server read-only mode. The SPA hides Edit/Delete/+New in read-only mode because the SERVER omits those affordances, not because the client knows the mode. A command button rendered from GET /_commands has no such suppression: resolveCommands does not consult ACL, so the buttons will render and be clickable.
+
+    e2e/tests/read-only-mode.spec.ts:8-11 already acknowledges the gap: 'Deferred phase-2 sites (Lua command buttons, ...) remain visible and 403 at the server on click.' The '403 at the server' half is TRUE ONLY for endpoints that build a WriteRequest. Command exec does not, so it does not 403 — it runs. The spec's stated rationale for excluding command buttons does not hold.
+
+    FAILURE SCENARIO: operator runs `rela-server --read-only` to hand stakeholders a safe browsing link, reasonably believing read-only means read-only. A context:global command is configured. A stakeholder clicks the new dashboard button; mutating writes execute. The operator's mental model of --read-only is silently wrong, and the dashboard is the first page they land on.
+severity: critical
+resolution: 'Scoped to TKT-MJ02AO: blanket deny of command execution under ReadOnlyACL regardless of the permission: key, plus permission-filtered resolveCommands so buttons do not render. That ticket also corrects the inaccurate ''remain visible and 403 at the server on click'' comment at e2e/tests/read-only-mode.spec.ts:8, which is false for command exec today.'
+reason: 'Deferred to TKT-MJ02AO, which resolves PLAN-CNDJ78 blocking decision A as option 1 (gate exec on ACL) rather than option 3 (document as operator-trust). Justification for deferring rather than fixing in place: closing this correctly requires the same permission machinery as RR-65KG68 plus a blanket ReadOnlyACL deny, and there is currently no frontend read-only state to gate buttons on — the SPA hides write controls only because the server omits affordances. Both belong in the backend prep PR. The risk is contained meanwhile: TKT-72SCPR depends-on TKT-MJ02AO, and its read-only acceptance criterion (''no command buttons render under --read-only'') cannot pass until this lands, so the dashboard button cannot ship ahead of the gate.'
+status: deferred
+---
+
+## Evidence
+
+`internal/acl/readonly.go:18-27` — the entire enforcement surface:
+
+```go
+type ReadOnlyACL struct{}
+
+func (ReadOnlyACL) AuthorizeWrite(_ context.Context, _ WriteRequest) Decision {
+	return Decision{
+		Allow:    false,
+		RuleKind: "read-only",
+		RuleID:   "read-only-acl",
+		Reason:   "this rela instance is configured read-only",
+	}
+}
+```
+
+One method. `WriteRequest`-shaped. Command exec builds none.
+
+`e2e/tests/read-only-mode.spec.ts:8-11`:
+
+```
+ * Deferred phase-2 sites (Lua command buttons, settings / theme /
+ * git, relation add/remove inside form widgets, inline-edit buttons
+ * in related-entity cards) remain visible and 403 at the server on
+ * click. The assertions below intentionally exclude those.
+```
+
+The exclusion is justified by an assumption ("403 at the server") that does not
+hold for this endpoint.
+
+## Decision required before implementation
+
+Pick one and record it in the plan:
+
+1. **Gate `handleCommandExec` on an ACL op** — correct, larger, arguably
+its own ticket.
+2. **Suppress command buttons AND 403 the exec endpoint under read-only**
+— minimum viable; requires plumbing read-only state to the SPA, which does not
+exist today.
+3. **Explicitly document commands as an operator-trust surface outside
+ACL**, and decide whether the dashboard mount is acceptable under that framing.
+
+Option 3 minus the documentation is the current status quo, and it is what the
+plan implicitly assumes without stating.

--- a/tickets/entities/review-responses/RR-I3VLJV.md
+++ b/tickets/entities/review-responses/RR-I3VLJV.md
@@ -1,0 +1,40 @@
+---
+id: RR-I3VLJV
+type: review-response
+title: Global commands run with RELA_ENTITY_ID absent (not empty) — unset-variable expansion hazard in copied scripts
+finding: |-
+    buildGlobalInput (commands.go:219-224) sets only Context and Project:
+
+      func (h *commandHandler) buildGlobalInput() *commandInput {
+          return &commandInput{
+              Context: "global",
+              Project: h.projectInfo(),
+          }
+      }
+
+    In buildCommandEnv (commands.go:669-691) the entity env vars are appended only when input.Entity != nil:
+
+      if input.Entity != nil {
+          env = append(env,
+              "RELA_ENTITY_ID="+input.Entity.ID,
+              "RELA_ENTITY_TYPE="+input.Entity.Type,
+          )
+      }
+
+    So for context:global these variables are ABSENT from the environment, not set-to-empty.
+
+    FAILURE SCENARIO: an admin copies an existing entity-command script as the starting point for a new dashboard button (the natural workflow once dashboard commands become possible — which is exactly what this ticket enables). The script contains something like `rm -rf "$RELA_PROJECT_ROOT/$RELA_ENTITY_ID"` or `rela delete "$RELA_ENTITY_ID"`. Under `sh -c` an unset variable expands to the empty string with no error, yielding `rm -rf "$RELA_PROJECT_ROOT/"`.
+
+    This is a documentation and test gap, not a code defect. docs/data-entry.md is already in the plan's scope.
+
+    ACTIONS:
+    1. Document in docs/data-entry.md that context:global scripts receive NO RELA_ENTITY_ID / RELA_ENTITY_TYPE, and recommend `set -u` in command scripts.
+    2. Add a Go test asserting these vars are ABSENT (not empty) from buildCommandEnv output for a global-context input — pins the contract.
+severity: minor
+resolution: Addressed in PLAN-CNDJ78 in two places. Documentation Planning now requires docs/data-entry.md to state that context:global scripts receive NO RELA_ENTITY_ID / RELA_ENTITY_TYPE (absent, not empty — buildGlobalInput at commands.go:219 sets no Entity, so the append at commands.go:676 is skipped), with a `set -u` recommendation for command scripts. The Test Plan adds a Go acceptance criterion asserting the vars are absent rather than empty in buildCommandEnv output for a global-context input, pinning the contract against future regression.
+status: addressed
+---
+
+Low severity because it requires operator error to trigger, but the consequence
+is destructive and the ticket is what makes the workflow reachable. Cheap to
+close: one doc paragraph, one assertion.

--- a/tickets/entities/review-responses/RR-KNEF4K.md
+++ b/tickets/entities/review-responses/RR-KNEF4K.md
@@ -1,0 +1,53 @@
+---
+id: RR-KNEF4K
+type: review-response
+title: 'Open `params: Record<string,string>` prop turns CommandModal into a generic query-param channel into a shell-exec endpoint'
+finding: |-
+    The plan generalizes CommandModal's prop from `entityId: string` to `params: Record<string,string>`, spread into URLSearchParams. Today (CommandModal.vue:42-45) the client can express exactly one key, hardcoded:
+
+      const params = new URLSearchParams()
+      params.set('entity_id', props.entityId)
+
+    After the change, an arbitrary map is spread into the query string of an endpoint that runs `sh -c`. handleCommandExec reads entity_id, list_id, view_id AND exec_id from that same query string (commands.go:295).
+
+    VERIFIED at commands.go:295-298:
+
+      execID := r.URL.Query().Get("exec_id")
+      if execID == "" {
+          execID = fmt.Sprintf("cmd-%d", time.Now().UnixNano())
+      }
+
+    exec_id is client-supplied and used as the key into a package-level runningCommands sync.Map with no per-user or per-session namespacing. handleCommandCancel keys off the same map.
+
+    FAILURE SCENARIO: a future call site passes exec_id through the params map (entirely plausible — the plan's own deferred item 2 is 'move exec into api/commands.ts', where an exec-id naturally lives). Two surfaces then collide on one key; the `defer runningCommands.Delete(execID)` on whichever finishes first removes the other's registration, and a subsequent cancel targets the wrong process. Because the key is also guessable (cmd-<UnixNano>), widening who can set it worsens an existing weakness.
+
+    MITIGATION (costs nothing, do it): type the prop as a closed discriminated union matching the four backend contexts, not an open map:
+
+      type CommandParams =
+        | { entity_id: string }
+        | { entity_id: string; view_id: string }
+        | { list_id: string }
+        | Record<string, never>
+
+    This keeps exec_id structurally unreachable from any call site and makes the four contexts explicit in the type system. An open Record<string,string> is precisely the generic pass-through that internal/dataentry/CLAUDE.md's bridge rule warns against ('a closed method allow-list, never a URL proxy').
+severity: significant
+resolution: |-
+    Addressed in PLAN-CNDJ78 Approach step 3. The modal prop is specified as a closed discriminated union rather than the originally-planned open Record<string,string>:
+
+      type CommandParams =
+        | { entity_id: string }
+        | { entity_id: string; view_id: string }
+        | { list_id: string }
+        | Record<string, never>   // global
+
+    This mirrors the four backend contexts exactly and keeps exec_id structurally unreachable from any call site, so the exec_id collision scenario in the finding cannot originate from the modal. The rejected alternative is recorded explicitly in the plan's Alternatives Considered so a future edit does not silently reopen it. Verification is an acceptance criterion: mount CommandModal with {} params and assert the request URL carries no entity_id.
+status: addressed
+---
+
+## Why this matters more after the ticket than before
+
+Today `CommandModal` is mounted once, by one parent, with one hardcoded param.
+The open-map generalization is what converts it into a reusable channel — and
+the plan simultaneously adds two more mount sites.
+
+The fix is a type declaration, not a code change. Take it.

--- a/tickets/entities/review-responses/RR-L6UXCF.md
+++ b/tickets/entities/review-responses/RR-L6UXCF.md
@@ -1,0 +1,45 @@
+---
+id: RR-L6UXCF
+type: review-response
+title: 'available_on is display-only: handleCommandExec never validates client-supplied entity_id/list_id/view_id against command scope'
+finding: |-
+    Answering the plan's implicit assumption that config-load validation (validate.go:87, validateCommands) covers request-time safety: it does not.
+
+    resolveCommands/matchesPage (commands.go:47-108) run EXCLUSIVELY on the GET /api/v1/_commands render path. handleCommandExec (commands.go:281-341) switches on cmd.Context and reads entity_id / list_id / view_id straight from the query string. It never calls matchesPage and never compares the supplied ID against cmd.AvailableOn.
+
+    VERIFIED at commands.go:302-311:
+
+      case "entity":
+          entityID := r.URL.Query().Get("entity_id")
+          svc := h.services()
+          entityDomain, err := svc.Store.GetEntity(r.Context(), entityID)
+          if err != nil { http.Error(w, "Entity not found: "+entityID, 404); return }
+          input = h.buildEntityInput(r.Context(), entityDomain)
+
+    No check that entityDomain.Type is in cmd.AvailableOn.EntityTypes. Same omission for list (commands.go:313-321 — list_id checked only for existence in s.Cfg.Lists) and view (commands.go:323-335).
+
+    FAILURE SCENARIO: command `redact-pii`, context:entity, available_on.entity_types:[customer], script reads RELA_ENTITY_ID (set at commands.go:677). UI only ever offers it on customer pages. Client POSTs /api/command/redact-pii?entity_id=TKT-72SCPR — the entity resolves, buildEntityInput runs, the script executes against a ticket it was never scoped to.
+
+    This is PRE-EXISTING, not introduced here. But the plan's Security section cites validate.go:87 as though it establishes an enforcement boundary. validateCommands only checks that referenced views/lists/entity-types EXIST in config; it has nothing to do with request-time authorization. Citing it as the input-validation story is the plan's core analytical error.
+
+    RECOMMENDED (high leverage, ~10 lines, in a file already being touched): call matchesPage in handleCommandExec with the supplied params and 403 on mismatch. This makes available_on an actual boundary and would make the plan's 'the server already authorizes these' claim become true rather than needing deletion.
+severity: significant
+resolution: 'Scoped to TKT-MJ02AO: call matchesPage in handleCommandExec with the client-supplied entity_id/list_id/view_id and 403 on mismatch, making available_on an actual boundary. If that enforcement is rejected during MJ02AO planning, the fallback obligation is to document in docs/data-entry.md that available_on is display scoping only — doing neither leaves a documented lie.'
+reason: 'Deferred to TKT-MJ02AO, resolving PLAN-CNDJ78 blocking decision B. Justification: the fix is a backend change (a matchesPage call plus 403 in handleCommandExec) in the same file and review as the ACL guard, so bundling them is cheaper and more coherent than splitting a ~10-line enforcement change into a frontend ticket. Deferring is safe because the pre-existing exposure is unchanged by TKT-72SCPR — that ticket adds no new exec path and no new client-controlled ID — and RR-KNEF4K independently closes the widening risk by typing the modal prop as a closed union so a forged param cannot originate from a call site.'
+status: deferred
+---
+
+## Minimum plan change
+
+Add to PLAN-CNDJ78 Security Considerations, verbatim:
+
+> `available_on` is **display scoping, not an authorization boundary**.
+> `handleCommandExec` does not enforce it. Any client that knows a command
+> ID can invoke it with an arbitrary `entity_id` / `list_id` / `view_id`.
+
+## Optional but recommended
+
+Enforce `matchesPage` at exec time. One call before the context switch at
+`commands.go:301`. Collapses this finding and materially improves RR-65KG68. If
+taken, it becomes a backend change and the ticket's "frontend-only apart from
+tests" framing needs updating.

--- a/tickets/entities/review-responses/RR-N643V4.md
+++ b/tickets/entities/review-responses/RR-N643V4.md
@@ -1,0 +1,81 @@
+---
+id: RR-N643V4
+type: review-response
+title: 'The planned `available_on.views` fix does not work: matchesPage ignores qualifier when pageType is ''entity'''
+finding: |-
+    The plan treats 'pass qualifier = view ID from EntityDetail' as the fix for the available_on.views defect. It is not. Reading matchesPage (commands.go:77-108) verbatim:
+
+      case "view":
+          if contains(scope.Views, qualifier) { return true }
+          if contains(scope.EntityTypes, entityType) { return true }
+      case "entity":
+          if contains(scope.EntityTypes, entityType) { return true }
+
+    When pageType == "entity", ONLY scope.EntityTypes is consulted. `qualifier` is never read on that branch. The scope.Views check lives exclusively under case "view".
+
+    Therefore sending {pageType:'entity', qualifier: viewID} — exactly what the plan's Approach section specifies — changes NOTHING. The available_on.views scoping remains dead.
+
+    The real fix requires sending pageType:'view' when a view is active. But that is a behavior change with a second-order effect the plan does not consider: contextMatchesPage (commands.go:112-124) has `case "entity": return pageType == "entity" || pageType == "view"`, so switching to pageType:'view' also changes which UNSCOPED entity-context commands resolve (they still match), and additionally admits context:'view' commands that currently never appear. That is a wider behavioral delta than 'fix a qualifier'.
+
+    WORSE — the plan's test for this is unfalsifiable. Its Test Plan row reads: 'entity+available_on.views regression | vitest | assert getCommands called with a qualifier'. That asserts the MOCK CALL ARGUMENTS, not the resolved command list. It would pass green against the broken implementation described in the plan. A test that cannot fail when the feature is broken is worse than no test, because it manufactures confidence.
+
+    FAILURE SCENARIO: implementer follows the plan mechanically, ships {pageType:'entity', qualifier}, the unit test passes, the AC is marked satisfied, and available_on.views scoping is still completely non-functional in production — now with a regression test claiming otherwise.
+severity: critical
+resolution: |-
+    Resolved by scope reduction: view context is deferred out of TKT-72SCPR entirely (and out of TKT-MJ02AO), so the broken fix this finding identified is no longer being attempted.
+
+    The finding stands as documentation of a real, still-open defect: matchesPage case "entity" (commands.go:94-97) reads only scope.EntityTypes and never consults qualifier, so available_on.views scoping has never worked and is NOT fixed by this ticket. TKT-72SCPR now states this explicitly under 'Deferred: view context' and 'Latent defect (retained, not fixed here)' so the bug is not silently lost — it should be picked up alongside view-context support, together with the pageType:'view' behavioral-delta decision (which changes which unscoped and context:view commands resolve via contextMatchesPage at commands.go:112-124).
+
+    The second half of the finding — the unfalsifiable test — is addressed generally rather than for the view case. TKT-72SCPR's list-scoping acceptance criterion now carries the rule this finding established: assert the RESOLVED command list, never mock call arguments. That prevents the same mock-asserting mistake in the criteria that remain in scope.
+status: addressed
+---
+
+## Evidence
+
+`internal/dataentry/commands.go:77-108`, quoted verbatim from the file:
+
+```go
+func matchesPage(cmd CommandConfig, pageType, qualifier, entityType string) bool {
+	scope := cmd.AvailableOn
+
+	if scope == nil {
+		return contextMatchesPage(cmd.Context, pageType)
+	}
+
+	switch pageType {
+	case "view":
+		if contains(scope.Views, qualifier) {
+			return true
+		}
+		if contains(scope.EntityTypes, entityType) {
+			return true
+		}
+	case "entity":
+		if contains(scope.EntityTypes, entityType) {
+			return true
+		}
+	case "list":
+		if contains(scope.Lists, qualifier) {
+			return true
+		}
+	case "dashboard":
+		if scope.Dashboard {
+			return true
+		}
+	}
+	return false
+}
+```
+
+`case "entity"` does not read `qualifier`. Confirmed by direct read.
+
+## Required plan changes
+
+1. **State explicitly which `pageType` EntityDetail sends when a view is
+active**, and accept the resulting behavioral delta for unscoped and `context:
+view` commands — or drop this AC from the ticket.
+2. **Rewrite the test** to assert the *resolved command list*, not the
+call arguments. Seed a command with `available_on.views: [X]`, render on view X,
+assert the button appears; render on view Y, assert it does not.
+3. Consider whether this belongs in this ticket at all. It is a backend
+contract question wearing a frontend costume.

--- a/tickets/entities/review-responses/RR-PG8HR2.md
+++ b/tickets/entities/review-responses/RR-PG8HR2.md
@@ -1,0 +1,34 @@
+---
+id: RR-PG8HR2
+type: review-response
+title: /api/open-file is ungated and spawns the OS file handler; unaffected by --read-only
+finding: |-
+    handleOpenFile (internal/dataentry/commands.go:546-589, mounted at command_handler.go:60) performs no ACL check. Under acl.ReadOnlyACL a principal denied every command can still make the server spawn `open` / `xdg-open` / `explorer` on any file inside the project root.
+
+    What it DOES validate is solid, and worth stating so this is not over-rated: containedProjectPath (commands.go:685-733) confines the path to the project root, handling traversal, absolute paths, NUL bytes and symlink escape; the path is passed as a discrete exec.Command argv element by openFileCommand (commands.go:593-616), never through a shell, so unlike handleCommandExec there is no `sh -c` and no argument injection. It is POST-only and sits behind requireSameOrigin + requireLocalHost (router.go:105-109), so it is not cross-origin reachable.
+
+    Residual risk: it is still a process spawn dispatched by MIME association. xdg-open on a .desktop file, or `cmd /c start` on Windows, launches by handler association rather than merely displaying content. Severity depends entirely on deployment shape — on the intended local-desktop deployment this is benign (the user could open the file themselves); on a shared or remote rela-server it is an ACL-unaware process spawn on the server host.
+
+    Rated MINOR rather than significant because: (a) it is pre-existing and untouched by this ticket, (b) path containment is genuinely enforced, (c) it cannot execute arbitrary attacker-supplied content — the file must already be in the project, (d) the primary deployment is local. It is filed because this ticket establishes 'command surfaces are ACL-gated' as an expectation, and this route sits in the same registerCommandRoutes block while not meeting it.
+
+    SUGGESTED: deny under ReadOnlyACL at minimum (cheap, consistent with the exec guard, and matches what an operator running --read-only expects). A named permission under Declarative would be the fuller treatment but is arguably its own ticket.
+severity: minor
+reason: |-
+    Deferred as MINOR severity, which the workflow permits to remain open. Justification for not fixing in this PR:
+
+    1. UNCHANGED BY THIS TICKET. handleOpenFile predates the change and this PR does not touch it, widen it, or make it more reachable. Unlike RR-YZV7SY (cancel), it is not the other half of a lifecycle this ticket authorizes — it is a separate launcher route that happens to be registered in the same block.
+    2. GENUINELY DEFENDED WHERE IT MATTERS. containedProjectPath enforces project-root containment against traversal, absolute paths, NUL bytes and symlink escape; openFileCommand passes the path as a discrete argv element with no shell; POST-only; behind requireSameOrigin + requireLocalHost. It cannot execute attacker-supplied content — the file must already exist inside the project.
+    3. THE FIX NEEDS A DESIGN DECISION THIS TICKET DOES NOT FORCE. Should open-file have its own named permission, ride on the command permission of whatever produced the file, or simply be denied under ReadOnlyACL? Each has different implications for the SSE `file` message flow, where auto_open triggers this route programmatically after a command completes — gating it naively would break the auto-open affordance for legitimately-authorized commands. Deciding that inside a PR about command authorization would be scope creep on a security-sensitive path.
+    4. RISK IS DEPLOYMENT-SHAPED. On the primary local-desktop deployment the user could open the file themselves; the exposure is meaningful only on a shared/remote rela-server, which is not the documented deployment model today.
+
+    FOLLOW-UP: worth a ticket covering the launcher routes (/api/open-file and the unmounted handleOpenURL) as a group, including the ReadOnlyACL denial, so the auto_open interaction is designed once rather than patched twice.
+status: deferred
+---
+
+Deliberately not bundled into this PR: fixing it properly means deciding whether
+`open-file` deserves its own permission name or should ride on the command
+permission of whatever produced the file, and that decision is not forced by
+this ticket.
+
+Read-only denial alone would be a two-line change and could reasonably be folded
+in if you want the `--read-only` story airtight.

--- a/tickets/entities/review-responses/RR-YZV7SY.md
+++ b/tickets/entities/review-responses/RR-YZV7SY.md
@@ -1,0 +1,79 @@
+---
+id: RR-YZV7SY
+type: review-response
+title: '/api/command-cancel/ is ungated: any caller can kill any principal''s running command, including under --read-only'
+finding: |-
+    handleCommandExec is now gated, but its sibling route handleCommandCancel (internal/dataentry/commands.go:511-543, mounted at command_handler.go:59) consults no ACL whatsoever — no authorizeCommand call, no h.currentACL(). It looks up execID in the package-level runningCommands sync.Map and signals the process.
+
+    VERIFIED BY PoC (temporary test, since removed): under acl.ReadOnlyACL, exec returns 403 (the new guard works) while cancel with an arbitrary execID reaches the map lookup and returns 404 — proving no authorization runs before the lookup. A principal denied STARTING every command can still ABORT one.
+
+    Two compounding factors:
+
+    1. execID is CLIENT-SUPPLIED (commands.go:376-380): `execID := r.URL.Query().Get("exec_id")`, falling back to `fmt.Sprintf("cmd-%d", time.Now().UnixNano())`. The map is keyed only by execID with no principal binding, so there is nothing tying an entry to its owner.
+    2. The handler distinguishes unknown (404) from found (200), giving a clean enumeration oracle; the nanosecond-timestamp fallback is enumerable and a client-chosen id is outright guessable.
+
+    FAILURE SCENARIO: Bob holds no command permissions, so every exec 403s. He POSTs /api/command-cancel/<guessed-id> in a loop. On a hit, Alice's nightly-export takes SIGINT then an unconditional Kill() after 3s (cancelGrace). Aborting a half-run migration or export is frequently more damaging than not starting it.
+
+    SECOND ORDER: because runningCommands.Store(execID, ...) at commands.go:469 accepts a client-chosen key, a caller can pre-register a colliding execID so a legitimate command's registration is overwritten — making the victim's command uncancellable by its actual owner.
+
+    This is pre-existing (the route predates this ticket) but this ticket is what establishes the expectation that command execution is authorized, and it leaves the abort half of the same lifecycle open. Scoping it out silently would be worse than fixing it: the ticket's own docs now claim commands are gated under --read-only.
+
+    RECOMMENDED: bind the entry to its principal at registration (store principal.From(ctx) in runningCommand) and compare on cancel, returning 404 rather than 403 on mismatch so existence is not confirmed. Additionally stop honoring a client-supplied exec_id — mint it server-side and return it on the SSE stream.
+severity: significant
+resolution: |-
+    FIXED. Bound running commands to the principal that started them.
+
+    - runningCommand gained an `owner principal.Principal` field, documented with the reason (the registry is process-global and keyed only by a client-supplied execID).
+    - handleCommandExec populates it via principal.From(r.Context()) at registration.
+    - handleCommandCancel compares rc.owner against the requesting principal and returns 404 — byte-identical to the unknown-id response — on mismatch. 404 rather than 403 deliberately: a 403 would confirm that a command with that execID is currently running under another principal, turning cancel into an enumeration oracle.
+
+    Pinned by TestCommandCancelOwnerBound: bob cancelling alice's command gets 404, an unknown id also gets 404 (asserted in the same test so the indistinguishability is a pinned property, not an accident), the victim process is asserted un-signaled, and the owner can still cancel their own command (200).
+
+    NOT fixed here, deliberately: the finding also noted that exec_id is client-supplied and could be pre-registered to collide with a legitimate run. Owner-binding neutralizes the cross-principal impact (a colliding entry from another principal cannot be cancelled by them, and cannot cancel theirs). Server-minting the id is a protocol change affecting the SSE contract and the frontend, which is out of scope for this ticket — worth a follow-up if the SSE stream is revisited.
+status: addressed
+---
+
+## Evidence
+
+`internal/dataentry/commands.go:511-543` — the entire handler; note the absence
+of any ACL consultation between the method check and the signal:
+
+```go
+func (h *commandHandler) handleCommandCancel(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost { ... }
+
+	execID := strings.TrimPrefix(r.URL.Path, "/api/command-cancel/")
+	val, ok := runningCommands.Load(execID)
+	if !ok {
+		http.Error(w, "No running command: "+execID, http.StatusNotFound)
+		return
+	}
+	...
+	_ = rc.cmd.Process.Signal(syscall.SIGINT)
+	go func() {
+		time.Sleep(cancelGrace)
+		_ = rc.cmd.Process.Kill()
+	}()
+```
+
+## PoC output (test written, run, then deleted)
+
+```
+exec under read-only   => 403   (new guard works)
+cancel under read-only => 404   (reached lookup — no ACL gate)
+```
+
+## Fix sketch
+
+```go
+type runningCommand struct {
+	cmd  *exec.Cmd
+	prin principal.Principal // NEW
+}
+
+// in handleCommandCancel, after the Load:
+if rc.prin != principal.From(r.Context()) {
+	http.Error(w, "No running command: "+execID, http.StatusNotFound)
+	return
+}
+```

--- a/tickets/entities/tickets/TKT-2FDTJE.md
+++ b/tickets/entities/tickets/TKT-2FDTJE.md
@@ -1,0 +1,95 @@
+---
+id: TKT-2FDTJE
+type: ticket
+title: Read-gate scope command payloads (entity/list), then reconsider the view-context deferral
+kind: enhancement
+priority: high
+effort: m
+status: backlog
+---
+
+## Description
+
+Command stdin payloads are assembled straight from the store with **no
+per-entity read-gate scoping**, in every context. TKT-MJ02AO gated *who may run*
+a command; it did not scope *what the script receives*. So a `command:*` grant
+is closer to "may read every entity of this shape" than "may run this script".
+
+Raised as RR-37AYC0 during TKT-MJ02AO's code review. Documented accurately there
+(`docs/acl-security.md` → "What a command permission actually confers"); this
+ticket closes it in code.
+
+## Evidence
+
+`internal/dataentry/commands.go` — entity context, no `PermitsRead`:
+
+```go
+case "entity":
+	entityID := r.URL.Query().Get("entity_id")
+	svc := h.services()
+	entityDomain, err := svc.Store.GetEntity(r.Context(), entityID)
+	if err != nil { ... 404 ... }
+	input = h.buildEntityInput(r.Context(), entityDomain)
+```
+
+`relationsForEntity` then loads **every** incident relation
+(`store.DirectionBoth`). For lists, `listFromStoreByTypes` is a raw
+`ListEntities` drain with no `ReadQuery` scoping.
+
+Both `entity_id` and `list_id` come from the **request**, not from the page the
+user was on — `available_on` is display scoping only.
+
+| context | payload | scoped by |
+|---|---|---|
+| `entity` | entity at caller-supplied id + all incident relations | nothing |
+| `list` | all entities in caller-supplied list, post-filter | nothing |
+| `global` | project paths only | n/a |
+| `view` | entry + full traversal closure | not grantable today |
+
+Compare the read path, which *does* gate: `history_handler.go` uses
+`gateReadOrNotFound` / `PermitsRead`.
+
+## Why this wasn't fixed in TKT-MJ02AO
+
+Scoping the payload is a **behavior change to what existing commands receive**.
+A script that today sees every entity of a type would start seeing a subset,
+which can silently break working automations. That needs its own ticket, a
+migration note, and a deliberate decision about the failure mode — not a
+drive-by change inside a PR about authorization.
+
+## Scope
+
+**In scope:**
+
+- Scope `buildEntityInput` through `PermitsRead` — deny or 404 when the caller
+cannot read the requested entity
+- Scope `buildListInput` through `ReadQuery` so the script sees only readable
+rows
+- Decide and document the semantics: does a partially-readable list yield a
+filtered payload (quiet) or an error (loud)? Filtered matches how the rest of
+the read path behaves; loud is safer for scripts that assume completeness
+- Decide whether `relationsForEntity` should filter relations whose far endpoint
+is unreadable (it currently returns both directions unconditionally)
+- **Then reconsider TKT-MJ02AO's view deferral** — if the traversal can be
+read-gate scoped by the same mechanism, `context: view` may become grantable and
+`permission:` can be honored for it
+- Update `docs/acl-security.md` (the table currently documents the *unscoped*
+behavior) and `docs/data-entry.md`
+- Migration note: scripts may receive fewer entities than before
+
+**Out of scope:**
+
+- Changing who may *execute* a command (TKT-MJ02AO, done)
+- The launcher routes (separate ticket)
+
+## Acceptance criteria
+
+- An `entity`-context command invoked with an `entity_id` the principal cannot
+read does not receive that entity (404 or deny, per the recorded decision)
+- A `list`-context command receives only rows the principal may read
+- Under `NopACL` payloads are byte-identical to today (regression test)
+- The chosen partial-readability semantics are documented and pinned by a test
+- The view deferral is either lifted (with `permission:` honored) or
+re-justified in writing against the new scoping
+- `docs/acl-security.md`'s "What a command permission actually confers" table
+is updated to describe the scoped behavior

--- a/tickets/entities/tickets/TKT-72SCPR.md
+++ b/tickets/entities/tickets/TKT-72SCPR.md
@@ -1,0 +1,196 @@
+---
+id: TKT-72SCPR
+type: ticket
+title: Render list and global/dashboard commands in the data-entry SPA (view context deferred)
+kind: enhancement
+priority: medium
+effort: m
+status: planning
+---
+
+## Description
+
+The `commands:` system in `data-entry.yaml` supports four contexts. The backend
+implements all four end to end. The frontend renders exactly one.
+
+A user who configures `context: global` or `context: list` gets a command that
+validates cleanly at config load, is returned correctly by `GET
+/api/v1/_commands`, and executes correctly via `POST /api/command/{id}` — but
+has no button anywhere in the UI. The failure is silent: no error, no warning,
+just a missing affordance.
+
+**Scope: `list` and `global`/dashboard. `view` is deferred** — see below.
+
+## Evidence
+
+**Backend — all four contexts implemented:**
+
+- `internal/dataentryconfig/validate.go:87` — `validCommandContexts` = `entity`, `list`, `view`, `global`
+- `internal/dataentryconfig/config.go:563` — `CommandConfig.Context`, `CommandScope` with `Views` / `Lists` / `EntityTypes` / `Dashboard`
+- `internal/dataentry/commands.go:112` — `contextMatchesPage` maps `global` → pageType `dashboard`
+- `internal/dataentry/commands.go:77` — `matchesPage` handles `case "dashboard": if scope.Dashboard`
+- `internal/dataentry/commands.go:281` — `handleCommandExec` dispatches per context, each with its own stdin builder (`buildEntityInput`, `buildListInput`, `buildViewInput`, `buildGlobalInput`, `commands.go:150`)
+- `internal/dataentry/api_v1.go:3246` — `handleV1Commands` accepts `page_type`, `qualifier`, `entity_type`
+
+**Frontend — one call site, hardcoded:**
+
+`frontend/src/components/entity/EntityDetail.vue:316` is the only `getCommands`
+call in the entire SPA:
+
+```ts
+commands.value = await getCommands(
+  { pageType: 'entity', entityType: props.entityType },
+  localAbort.signal
+)
+```
+
+`pageType` is a literal; `qualifier` is never passed.
+
+`frontend/src/views/DashboardView.vue` imports no command code at all — its
+entire import set is `vue`, `@/stores`, `searchEntities`/`analyze`, and types.
+The list surface likewise never imports commands.
+
+## Gap map
+
+| context | backend resolve | backend exec | Go test coverage | frontend render | this ticket |
+|---|---|---|---|---|---|
+| `entity` | yes | yes | yes | yes (EntityDetail) | migrate to composable |
+| `list` | yes | yes | partial | no | **add** |
+| `global`/dashboard | yes | yes | yes | no | **add** |
+| `view` | yes | yes | partial | no | **deferred** |
+
+This is a **UI gap, not a correctness gap**. The backend behavior is implemented
+and tested; what is missing is the render surface.
+
+## Deferred: view context
+
+`view` is out of scope, aligned with the same deferral in TKT-MJ02AO.
+
+Three reasons:
+
+1. **No distinct UI surface exists.** There is no `/view/:id` route — views
+render *inside* `EntityDetail` via `fetchView`. Deferring `view` removes zero
+planned mount sites; dashboard and list are unaffected.
+2. **It is not gated by TKT-MJ02AO.** That ticket defers `view` because a view
+command's payload is the whole traversal closure (`executeView`,
+`views.go:19-49`, multi-pass; `buildViewInput`, `commands.go:181-215`, returns
+`Collections` + inter-relations) with no read-gate scoping. Adding a UI surface
+for a context that is deliberately ungated would be backwards.
+3. **It retires an unresolved decision.** RR-N643V4 established that the
+planned `available_on.views` fix was a no-op, and that a real fix requires
+sending `pageType: 'view'` — which changes which unscoped and `context: view`
+commands resolve. Dropping view scope closes that question by construction
+rather than leaving a judgment call in the plan.
+
+**Consequence:** the `available_on.views` defect is **not fixed here** and
+remains open. It is a genuine pre-existing bug — `matchesPage` `case "entity"`
+(`commands.go:94-97`) reads only `scope.EntityTypes`, so `available_on.views`
+scoping has never worked. It should be picked up alongside view-context support.
+
+## Latent defect (retained, not fixed here)
+
+`contextMatchesPage` deliberately lets `entity`-context commands surface on view
+pages, and `EntityDetail` does call `fetchView` — but it asks with `pageType:
+'entity'` and no `qualifier`, so `available_on.views` never matches. Documented
+above; out of scope per the deferral.
+
+## Design constraint: avoiding triplication (not the modal)
+
+`CommandModal.vue` takes an `entity-id` prop (`EntityDetail.vue:1185`) and is
+imported nowhere else. Planning established this coupling is **one line** —
+`CommandModal.vue:42-45` is the only use of `props.entityId`:
+
+```ts
+const params = new URLSearchParams()
+params.set('entity_id', props.entityId)
+const url = `/api/command/${cmd.id}?${params.toString()}`
+```
+
+**The actual cost driver is duplication.** `loadCommands` + `runCommand` +
+desktop button row + mobile overflow menu + outside-click watcher is ~50 lines
+of script and ~35 of template. Copied to each surface, the BUG-6C3V abort
+pattern (`EntityDetail.vue:312-331`) would exist in triplicate.
+
+**Surface correction:** `ListView.vue` is an 11-line pass-through (`<EntityList
+:list-id="id" />`). The list command row belongs in
+`components/lists/EntityList.vue`, which has `props.listId` and an existing
+`.list-header` at L653.
+
+## Existing test coverage (do not duplicate)
+
+Per `e2e/tests/AGENTS.md:45` ("API-only assertions belong in Go"),
+`request.fetch(...)` and `api.rawRequest(...)` are `no-restricted-syntax` eslint
+errors inside `e2e/tests/**/*.spec.ts`.
+
+`internal/dataentry/commands_test.go` (1041 lines) covers
+`TestResolveCommands:21`, `TestMatchesPage:836`, `TestBuildListInput:288`,
+`TestBuildGlobalInput:342`, `TestHandleCommandExecGlobalContext:683`,
+`TestHandleCommandExecListContext:713`, plus `TestV1CommandsEndpoint`
+(`api_v1_test.go:2716`).
+
+**Known thinness to close here:** `TestHandleCommandExecListContext:713` asserts
+only `w.Code == 200` and never inspects the SSE payload, unlike the entity and
+global variants. Strengthen it. (`TestHandleCommandExecViewContext:733` has the
+same weakness but is out of scope with `view`.)
+
+## Scope
+
+**In scope:**
+
+- Generalize `CommandModal.vue` to a **closed discriminated union** prop (RR-KNEF4K), not an open map; update `EntityDetail` to pass `{ entity_id: entityId }`
+- Extract `composables/useCommands.ts` (abortable list fetch, BUG-6C3V guards verbatim) and `components/commands/CommandButtons.vue` (desktop row, overflow menu, outside-click watcher, modal ref)
+- Render commands on `DashboardView.vue` (`pageType: 'dashboard'`, no qualifier)
+- Render commands on `components/lists/EntityList.vue` (`pageType: 'list'`, `qualifier` = `props.listId`)
+- Fix the command-stream cancellation leak: `AbortController` around the exec stream, aborted in `onBeforeUnmount`; allow Close while running
+- Preserve existing behavior: desktop button row + mobile overflow menu, abort-on-navigate, SSE streaming
+- Frontend unit tests per surface (`.test.ts`, co-located)
+- Strengthen `TestHandleCommandExecListContext` to assert SSE payloads (Go, not Playwright)
+- Go test asserting `RELA_ENTITY_ID` is **absent** (not empty) for global input (RR-I3VLJV)
+- Extend `e2e/tests/fixtures.ts` `DATA_ENTRY_YAML`; add command-button selectors to page objects; e2e specs clicking commands on dashboard and list
+
+**Out of scope:**
+
+- **`view` context** — deferred, see above; also defers the `available_on.views` defect
+- All ACL/permission work → TKT-MJ02AO
+- Lua command backend (TKT-XTNED)
+- Conditional/permission-based visibility beyond the server-side filter TKT-MJ02AO provides
+- Changes to command config schema, SSE protocol, or backend runtime behavior
+- API-level Playwright specs — prohibited by `e2e/tests/AGENTS.md:45`, already covered in Go
+
+## Dependency: TKT-MJ02AO
+
+**TKT-MJ02AO must land first.** It adds per-command `permission:` gating, 403s
+unauthorized exec, denies all command exec under `ReadOnlyACL`, and filters
+`resolveCommands` by held permission.
+
+Consequences here:
+
+1. **Button visibility comes for free** — `GET /_commands` returns only
+executable commands, so `CommandButtons.vue` needs no client-side ACL logic. Do
+**not** add client-side permission checks; the server filter is the single
+source of truth and the 403 is the boundary.
+2. **The read-only assertion becomes writable** — this ticket can then assert
+that no command buttons render under `--read-only`, which is false today.
+
+Shipping this ticket first would put an ungated shell-exec button on the
+dashboard, the first page every user lands on.
+
+## Relationship to TKT-XTNED
+
+TKT-XTNED ("Add Lua backend to data-entry commands") lists "one end-to-end test
+per `context` type (entity, list, view, global)" as an acceptance criterion.
+Only the **UI-interaction half** depends on this ticket — behavioral coverage
+already exists in Go. With `view` deferred here, XTNED's view e2e criterion
+stays blocked; narrow it or sequence it behind view support.
+
+## Acceptance criteria
+
+- A command with `context: global` and `available_on.dashboard: true` renders a button on the dashboard and executes with `buildGlobalInput` context
+- A command with `context: list` renders on list views; `available_on.lists` scoping filters correctly by list ID (assert the **resolved command list**, never mock call arguments — per RR-N643V4)
+- `CommandModal` no longer requires an `entity-id`; dashboard and list commands open it without one
+- Existing entity-detail command behavior is unchanged — button row, overflow menu, streaming, abort-on-navigate
+- Unmounting mid-stream aborts the exec fetch; Close is enabled while a command runs
+- `TestHandleCommandExecListContext` asserts streamed SSE payloads, not just HTTP 200
+- `RELA_ENTITY_ID` / `RELA_ENTITY_TYPE` are absent (not empty) for global-context input
+- No command buttons render under `rela-server --read-only` (**requires TKT-MJ02AO**)
+- Frontend unit tests per surface, plus e2e specs clicking a command button on dashboard and on list

--- a/tickets/entities/tickets/TKT-72SCPR.md
+++ b/tickets/entities/tickets/TKT-72SCPR.md
@@ -5,7 +5,7 @@ title: Render list and global/dashboard commands in the data-entry SPA (view con
 kind: enhancement
 priority: medium
 effort: m
-status: planning
+status: backlog
 ---
 
 ## Description

--- a/tickets/entities/tickets/TKT-JRY8V5.md
+++ b/tickets/entities/tickets/TKT-JRY8V5.md
@@ -1,0 +1,100 @@
+---
+id: TKT-JRY8V5
+type: ticket
+title: Gate the launcher routes (/api/open-file, handleOpenURL) — currently ACL-unaware and unaffected by --read-only
+kind: enhancement
+priority: medium
+effort: s
+status: backlog
+---
+
+## Description
+
+`registerCommandRoutes` mounts three routes. TKT-MJ02AO gated one of them.
+`/api/open-file` performs **no ACL check** and still spawns the OS file handler
+under `rela-server --read-only`.
+
+Raised as RR-PG8HR2 during TKT-MJ02AO's code review, deferred there with reason.
+
+## Current state
+
+`internal/dataentry/command_handler.go`:
+
+```go
+mux.HandleFunc("/api/command/", h.handleCommandExec)        // gated (TKT-MJ02AO)
+mux.HandleFunc("/api/command-cancel/", h.handleCommandCancel) // owner-bound (TKT-MJ02AO)
+mux.HandleFunc("/api/open-file", h.handleOpenFile)          // UNGATED
+```
+
+`handleOpenURL` also exists and shells out via `openURLCommand`, but is
+deliberately **not mounted** — worth deciding whether it should stay that way or
+be mounted-with-a-gate.
+
+## What is already defended (so this is not over-rated)
+
+- `containedProjectPath` confines the path to the project root — traversal,
+absolute paths, NUL bytes and symlink escape all handled
+- `openFileCommand` passes the path as a **discrete argv element**, never
+through a shell — no `sh -c`, no argument injection
+- POST-only, behind `requireSameOrigin` + `requireLocalHost`
+
+It cannot execute attacker-supplied content: the file must already be in the
+project.
+
+## Residual risk
+
+It is still a **process spawn dispatched by MIME association**. `xdg-open` on a
+`.desktop` file, or `cmd /c start` on Windows, launches by handler association
+rather than merely displaying. Benign on the intended local-desktop deployment
+(the user could open the file themselves); meaningful on a shared or remote
+`rela-server`, where it is an ACL-unaware spawn on the server host.
+
+## The design question this ticket must answer
+
+Not "add a permission check" — the interaction matters:
+
+**`auto_open` triggers this route programmatically.** When a command emits a
+`file` SSE message and `auto_open` is not disabled, the SPA POSTs
+`/api/open-file` on the user's behalf. Gating it naively would break auto-open
+for commands the principal *is* authorized to run.
+
+Options:
+
+1. **Deny under `ReadOnlyACL` only** — cheapest, matches operator expectation,
+leaves `Declarative` ungated.
+2. **Its own named permission** (`command:open-file` or similar) — consistent
+with the `command:*` family, but an operator must now grant it separately or
+auto-open silently stops working.
+3. **Ride on the originating command's permission** — most precise (the file
+came from a command the principal was allowed to run), but requires correlating
+the open-file request with the exec that produced the path, which the current
+protocol does not carry.
+
+Option 1 is the likely v1; 3 is the "right" answer if the SSE protocol ever
+carries an exec correlation id.
+
+## Scope
+
+**In scope:**
+
+- Deny `/api/open-file` under `ReadOnlyACL`
+- Decide and implement the `Declarative` posture per the options above
+- Verify the `auto_open` flow still works for authorized commands (this is the
+regression risk)
+- Decide whether `handleOpenURL` should remain unmounted or be mounted with the
+same gate
+- Go tests: read-only deny, auto-open still works when authorized
+- Docs: `docs/acl-security.md` — the launcher routes' posture
+
+**Out of scope:**
+
+- Read-gate scoping of command payloads (TKT-2FDTJE)
+- Changing `containedProjectPath` — the containment logic is sound
+
+## Acceptance criteria
+
+- Under `rela-server --read-only`, `POST /api/open-file` is denied
+- The `auto_open` flow still opens files for a principal authorized to run the
+producing command (regression test — this is what a naive gate breaks)
+- The `handleOpenURL` mount decision is recorded in the code comment
+- `docs/acl-security.md` states the launcher routes' authorization posture

--- a/tickets/entities/tickets/TKT-MJ02AO.md
+++ b/tickets/entities/tickets/TKT-MJ02AO.md
@@ -5,7 +5,7 @@ title: 'Per-command ACL guard: gate command execution and button visibility on a
 kind: enhancement
 priority: high
 effort: l
-status: review
+status: done
 ---
 
 ## Description

--- a/tickets/entities/tickets/TKT-MJ02AO.md
+++ b/tickets/entities/tickets/TKT-MJ02AO.md
@@ -1,0 +1,239 @@
+---
+id: TKT-MJ02AO
+type: ticket
+title: 'Per-command ACL guard: gate command execution and button visibility on a named permission (entity/list/global; view deferred)'
+kind: enhancement
+priority: high
+effort: l
+status: review
+---
+
+## Description
+
+Data-entry commands (`data-entry.yaml` `commands:`) execute arbitrary shell via
+`sh -c` and currently have **no authorization whatsoever**. This ticket adds a
+configurable per-command ACL guard that gates both execution (server-side,
+authoritative) and button visibility (client-side, cosmetic).
+
+Prep work for TKT-72SCPR, which renders command buttons on the dashboard and
+list surfaces. That ticket is blocked on decision A of PLAN-CNDJ78; this ticket
+is that decision.
+
+**Fine-grained `permission:` control covers `entity`, `list` and `global`.
+`view` gets no fine-grained control in this ticket — it fails closed under a
+configured `acl.yaml`** (see "Deferred: view context").
+
+## Motivation — verified current state
+
+`handleCommandExec` (`internal/dataentry/commands.go:281`) does exactly four
+things before spawning a shell: HTTP method check, command-ID lookup in
+`s.Cfg.Commands`, stdin build, then `exec.CommandContext(r.Context(), "sh",
+"-c", cmd.Script)` at `commands.go:360`.
+
+Grepping both command files for authorization identifiers:
+
+```
+grep -n "acl|ACL|translateVerb|WriteRequest|ReadOnly|readOnly|Principal" \
+  internal/dataentry/commands.go internal/dataentry/command_handler.go
+(no matches)
+```
+
+The only gates on `/api/command/` are `requireSameOrigin` and `requireLocalHost`
+(`router.go:105-108`) — CSRF and network-location controls. They answer "did
+this request come from our own page on this host", never "may *this principal*
+do this". `attachACLRequest` (`router.go:157`) attaches an `acl.Request` to
+context for downstream consumers; `handleCommandExec` never reads it.
+
+**Consequences today:**
+
+1. **No principal-aware authorization.** Any client that can reach the server
+and knows a command ID can execute it. (RR-65KG68)
+2. **`--read-only` does not block command execution.** `acl.ReadOnlyACL`
+(`internal/acl/readonly.go:18`) implements exactly one method,
+`AuthorizeWrite(WriteRequest)`. Command exec constructs no `WriteRequest`, so
+read-only is never consulted. (RR-CWWJGW)
+3. **`available_on` is display scoping, not a boundary.** `matchesPage` runs
+only on the GET `/_commands` render path. Exec reads
+`entity_id`/`list_id`/`view_id` straight from the query string and never
+validates them against `cmd.AvailableOn`. (RR-L6UXCF)
+
+## Design: reuse the named-permission pattern
+
+The `acl.ACL` interface is `Subject`-shaped:
+
+```go
+type ACL interface {
+	AuthorizeWrite(ctx context.Context, req WriteRequest) Decision
+}
+```
+
+`Subject` is a **sealed sum** (`internal/acl/subject.go:20`, unexported
+`isSubject()`) with only `EntitySubject` and `RelationSubject`. `Op` has only
+four verbs: `OpCreate`/`OpUpdate`/`OpDelete`/`OpRename` (`acl.go:85-88`).
+
+**A command does not always have an entity subject** — `context: global` and
+`context: list` act on the project or a type-set, not a row. So this does not
+fit `AuthorizeWrite` and must not be forced into it (that would mean unsealing
+`Subject` or inventing a fake one).
+
+**The right precedent already exists in-tree:** `acl.PermHistoryRead`
+(`internal/acl/policy.go:43`, `"history:read"`) is a *global named permission*
+granted via a role's `permissions:` list, used for exactly this shape — a
+capability with no entity to evaluate against. It is checked via the read gate:
+
+```go
+// internal/dataentry/history_handler.go:122
+if !gate.HoldsPermission(ctx, acl.PermHistoryRead) {
+```
+
+Commands should follow the same pattern.
+
+## Proposed approach
+
+**Config** — new optional `permission:` key on `CommandConfig`
+(`internal/dataentryconfig/config.go:563`):
+
+```yaml
+commands:
+  nightly-export:
+    label: "Nightly export"
+    context: global
+    script: "./scripts/export.sh"
+    permission: "command:nightly-export"   # NEW
+```
+
+Grant in `acl.yaml` via the existing role `permissions:` list — no new policy
+machinery.
+
+### Fail policy — AGREED, and uniform across all four contexts
+
+**One rule, no per-context exceptions:**
+
+- Under `NopACL` (no `acl.yaml` at all) → **fail-open**. Every existing
+deployment behaves exactly as today.
+- Once an `acl.yaml` exists → **fail-closed**. A command the principal cannot
+be shown to be authorized for is denied.
+
+Applied per context:
+
+| context | `permission:` set | no `permission:`, `acl.yaml` present |
+|---|---|---|
+| `entity` | grant required | **denied** |
+| `list` | grant required | **denied** |
+| `global` | grant required | **denied** |
+| `view` | **n/a — key not honored** | **denied** |
+
+`view` is not an exception to the fail policy; it is an exception to
+*fine-grained control*. Under a configured `acl.yaml`, view commands are denied
+outright — there is no `permission:` escape hatch for them until the traversal
+scoping question is resolved. That is the strict reading of "nothing on views":
+no gated execution, not merely no per-command grant.
+
+Under `NopACL`, view commands continue to execute exactly as today, consistent
+with the fail-open half of the rule.
+
+**Migration note:** a deployment adding its first `acl.yaml` must add
+`permission:` keys and grants for the commands it wants to keep working, and
+will lose view commands entirely until view support lands. Deliberate breaking
+change; the failure mode is a denied command rather than an unguarded one.
+Record as a `decision` entity during planning.
+
+**Enforcement (authoritative)** — in `handleCommandExec`, before the context
+switch at `commands.go:301`:
+
+- Resolve the effective permission per the table above; deny with 403 if the
+principal does not hold it.
+- `context: view` under a configured `acl.yaml` → 403 unconditionally.
+- Under `ReadOnlyACL`, deny **all** command execution regardless of
+`permission:` or context. Closes RR-CWWJGW and makes
+`e2e/tests/read-only-mode.spec.ts:8`'s "403 at the server on click" claim true
+for command buttons, which it currently is not.
+
+**Resolution (cosmetic)** — `resolveCommands` (`commands.go:47`) filters out
+commands the principal cannot execute — including all view commands under a
+configured `acl.yaml` — so `GET /_commands` returns only executable ones and
+buttons never render. UX affordance, not a security boundary; the 403 is the
+boundary.
+
+**Consider bundling RR-L6UXCF** (~10 lines): call `matchesPage` in
+`handleCommandExec` with the supplied params and 403 on mismatch, making
+`available_on` an actual boundary rather than display-only. Same file, same
+review, closes a documented lie.
+
+## Deferred: view context
+
+`view` gets **no fine-grained control** here. Under `NopACL` view commands run
+unchanged; under a configured `acl.yaml` they are denied outright.
+
+**Why.** A view command's payload is not one entity. `executeView`
+(`views.go:19-49`) runs a multi-pass graph traversal (up to 10 passes,
+`views.go:33-43`) and `buildViewInput` (`commands.go:181-215`) hands the script
+`Collections` — every entity the traversal reached — plus the relations between
+them. One `view_id` + one `entity_id` yields an arbitrarily wide slice of the
+graph, and `executeView` reads the store directly with **no read-gate scoping**.
+
+A `permission:` grant on a view command would therefore confer read access to
+the whole traversal closure, not just the entry entity — a materially broader
+grant than the same permission elsewhere, and one operators cannot reason about
+from the config. Rather than ship a grant whose blast radius is unclear, view
+commands are denied under any configured policy.
+
+Note the entry *is* a real, type-checked entity (`views.go:24` rejects a
+mismatched type; `buildViewInput` sets `Entity: vr.Entry`), so this is not a
+"view has no subject" problem — it is a blast-radius problem.
+
+**Follow-up obligations when view support is picked up:**
+
+- Decide whether `executeView` should be read-gate scoped for command exec
+- Document what a view-command permission confers
+- Then honor `permission:` for `view` and lift the unconditional deny
+
+## Scope
+
+**In scope:**
+
+- `permission:` key on `CommandConfig` + `validateCommands` support
+- Uniform fail policy (fail-open under `NopACL`, fail-closed with `acl.yaml`) — record as a `decision` entity
+- 403 enforcement in `handleCommandExec` for `entity`, `list`, `global`
+- Unconditional 403 for `context: view` under a configured `acl.yaml`
+- Blanket deny of command exec under `ReadOnlyACL` (all contexts)
+- Permission-aware filtering in `resolveCommands`, including view suppression under a configured policy
+- `validateCommands` warns when `permission:` is set on a `context: view` command (the key is not honored — silently ignoring it would mislead)
+- Go tests: allowed/denied per in-scope context, view deny under policy, view unchanged under `NopACL`, read-only deny, filtered resolution, both halves of the fail policy
+- Docs: `docs/data-entry.md` (the `permission:` key, and that view is not gateable yet), `docs/acl-security.md` (the named-permission family), correct the read-only-mode deferred-sites note
+
+**Out of scope:**
+
+- Fine-grained `permission:` support for `view` — deferred, see above
+- Read-gate scoping of `executeView`
+- Rendering commands on dashboard/list surfaces (TKT-72SCPR)
+- Lua command backend (TKT-XTNED)
+- Authentication — rela-server still has no auth layer (`policy.go:30-32`); this gates on whatever principal is stamped today
+- Per-command *argument* policy beyond the `matchesPage` check
+
+## Relationship to TKT-72SCPR
+
+TKT-72SCPR is blocked on PLAN-CNDJ78 decision A. **This ticket resolves it as
+option 1** (gate exec on ACL) rather than option 3 (document as operator-trust).
+It should land first so TKT-72SCPR renders buttons against a gated surface, and
+so `CommandButtons.vue` inherits permission-filtered results for free.
+
+The view deferral is aligned across both tickets: TKT-72SCPR also drops its view
+acceptance criteria, retiring the unresolved `pageType: 'view'` behavioral-delta
+decision (RR-N643V4).
+
+RR-65KG68, RR-CWWJGW and RR-L6UXCF are filed against TKT-72SCPR and *addressed*
+here. When this lands, update those three with a resolution pointing at this
+ticket.
+
+## Acceptance criteria
+
+- A command with `permission: X` is executable by a principal holding X and 403s for one that does not, for each of `entity`, `list`, `global`
+- A command with `permission: X` is absent from `GET /_commands` for a principal lacking X, and its button does not render
+- With no `acl.yaml` present, a command with no `permission:` executes exactly as today, in **all four** contexts including `view` (fail-open regression test)
+- With an `acl.yaml` present, a command with no `permission:` is denied (fail-closed test)
+- With an `acl.yaml` present, a `context: view` command is denied **even when `permission:` is set and granted**, and is absent from `GET /_commands`
+- `validateCommands` warns when `permission:` is set on a `context: view` command
+- Under `rela-server --read-only`, **every** command 403s on exec regardless of `permission:` or context, and no command buttons render
+- `docs/acl-security.md` documents the command-permission family alongside `history:read` and states that `view` cannot yet be gated per-command
+- `e2e/tests/read-only-mode.spec.ts`'s deferred-sites comment is corrected for command buttons

--- a/tickets/relations/DEC-EIHQSU--decides--authorization.md
+++ b/tickets/relations/DEC-EIHQSU--decides--authorization.md
@@ -1,0 +1,5 @@
+---
+from: DEC-EIHQSU
+relation: decides
+to: authorization
+---

--- a/tickets/relations/TKT-2FDTJE--affects--authorization.md
+++ b/tickets/relations/TKT-2FDTJE--affects--authorization.md
@@ -1,0 +1,5 @@
+---
+from: TKT-2FDTJE
+relation: affects
+to: authorization
+---

--- a/tickets/relations/TKT-2FDTJE--implements--FEAT-DO57.md
+++ b/tickets/relations/TKT-2FDTJE--implements--FEAT-DO57.md
@@ -1,0 +1,5 @@
+---
+from: TKT-2FDTJE
+relation: implements
+to: FEAT-DO57
+---

--- a/tickets/relations/TKT-72SCPR--affects--data-entry-ui.md
+++ b/tickets/relations/TKT-72SCPR--affects--data-entry-ui.md
@@ -1,0 +1,5 @@
+---
+from: TKT-72SCPR
+relation: affects
+to: data-entry-ui
+---

--- a/tickets/relations/TKT-72SCPR--depends-on--TKT-MJ02AO.md
+++ b/tickets/relations/TKT-72SCPR--depends-on--TKT-MJ02AO.md
@@ -1,0 +1,5 @@
+---
+from: TKT-72SCPR
+relation: depends-on
+to: TKT-MJ02AO
+---

--- a/tickets/relations/TKT-72SCPR--has-planning--PLAN-CNDJ78.md
+++ b/tickets/relations/TKT-72SCPR--has-planning--PLAN-CNDJ78.md
@@ -1,0 +1,5 @@
+---
+from: TKT-72SCPR
+relation: has-planning
+to: PLAN-CNDJ78
+---

--- a/tickets/relations/TKT-72SCPR--has-review-response--RR-65KG68.md
+++ b/tickets/relations/TKT-72SCPR--has-review-response--RR-65KG68.md
@@ -1,0 +1,5 @@
+---
+from: TKT-72SCPR
+relation: has-review-response
+to: RR-65KG68
+---

--- a/tickets/relations/TKT-72SCPR--has-review-response--RR-CWWJGW.md
+++ b/tickets/relations/TKT-72SCPR--has-review-response--RR-CWWJGW.md
@@ -1,0 +1,5 @@
+---
+from: TKT-72SCPR
+relation: has-review-response
+to: RR-CWWJGW
+---

--- a/tickets/relations/TKT-72SCPR--has-review-response--RR-I3VLJV.md
+++ b/tickets/relations/TKT-72SCPR--has-review-response--RR-I3VLJV.md
@@ -1,0 +1,5 @@
+---
+from: TKT-72SCPR
+relation: has-review-response
+to: RR-I3VLJV
+---

--- a/tickets/relations/TKT-72SCPR--has-review-response--RR-KNEF4K.md
+++ b/tickets/relations/TKT-72SCPR--has-review-response--RR-KNEF4K.md
@@ -1,0 +1,5 @@
+---
+from: TKT-72SCPR
+relation: has-review-response
+to: RR-KNEF4K
+---

--- a/tickets/relations/TKT-72SCPR--has-review-response--RR-L6UXCF.md
+++ b/tickets/relations/TKT-72SCPR--has-review-response--RR-L6UXCF.md
@@ -1,0 +1,5 @@
+---
+from: TKT-72SCPR
+relation: has-review-response
+to: RR-L6UXCF
+---

--- a/tickets/relations/TKT-72SCPR--has-review-response--RR-N643V4.md
+++ b/tickets/relations/TKT-72SCPR--has-review-response--RR-N643V4.md
@@ -1,0 +1,5 @@
+---
+from: TKT-72SCPR
+relation: has-review-response
+to: RR-N643V4
+---

--- a/tickets/relations/TKT-72SCPR--implements--FEAT-DO57.md
+++ b/tickets/relations/TKT-72SCPR--implements--FEAT-DO57.md
@@ -1,0 +1,5 @@
+---
+from: TKT-72SCPR
+relation: implements
+to: FEAT-DO57
+---

--- a/tickets/relations/TKT-JRY8V5--affects--authorization.md
+++ b/tickets/relations/TKT-JRY8V5--affects--authorization.md
@@ -1,0 +1,5 @@
+---
+from: TKT-JRY8V5
+relation: affects
+to: authorization
+---

--- a/tickets/relations/TKT-JRY8V5--implements--FEAT-DO57.md
+++ b/tickets/relations/TKT-JRY8V5--implements--FEAT-DO57.md
@@ -1,0 +1,5 @@
+---
+from: TKT-JRY8V5
+relation: implements
+to: FEAT-DO57
+---

--- a/tickets/relations/TKT-MJ02AO--affects--authorization.md
+++ b/tickets/relations/TKT-MJ02AO--affects--authorization.md
@@ -1,0 +1,5 @@
+---
+from: TKT-MJ02AO
+relation: affects
+to: authorization
+---

--- a/tickets/relations/TKT-MJ02AO--affects--data-entry-ui.md
+++ b/tickets/relations/TKT-MJ02AO--affects--data-entry-ui.md
@@ -1,0 +1,5 @@
+---
+from: TKT-MJ02AO
+relation: affects
+to: data-entry-ui
+---

--- a/tickets/relations/TKT-MJ02AO--has-docs--DOCS-IJJR4H.md
+++ b/tickets/relations/TKT-MJ02AO--has-docs--DOCS-IJJR4H.md
@@ -1,0 +1,5 @@
+---
+from: TKT-MJ02AO
+relation: has-docs
+to: DOCS-IJJR4H
+---

--- a/tickets/relations/TKT-MJ02AO--has-implementation--IMPL-O193P6.md
+++ b/tickets/relations/TKT-MJ02AO--has-implementation--IMPL-O193P6.md
@@ -1,0 +1,5 @@
+---
+from: TKT-MJ02AO
+relation: has-implementation
+to: IMPL-O193P6
+---

--- a/tickets/relations/TKT-MJ02AO--has-planning--PLAN-CJ49VK.md
+++ b/tickets/relations/TKT-MJ02AO--has-planning--PLAN-CJ49VK.md
@@ -1,0 +1,5 @@
+---
+from: TKT-MJ02AO
+relation: has-planning
+to: PLAN-CJ49VK
+---

--- a/tickets/relations/TKT-MJ02AO--has-review--REV-NGPPA5.md
+++ b/tickets/relations/TKT-MJ02AO--has-review--REV-NGPPA5.md
@@ -1,0 +1,5 @@
+---
+from: TKT-MJ02AO
+relation: has-review
+to: REV-NGPPA5
+---

--- a/tickets/relations/TKT-MJ02AO--has-review-response--RR-0LDY3W.md
+++ b/tickets/relations/TKT-MJ02AO--has-review-response--RR-0LDY3W.md
@@ -1,0 +1,5 @@
+---
+from: TKT-MJ02AO
+relation: has-review-response
+to: RR-0LDY3W
+---

--- a/tickets/relations/TKT-MJ02AO--has-review-response--RR-37AYC0.md
+++ b/tickets/relations/TKT-MJ02AO--has-review-response--RR-37AYC0.md
@@ -1,0 +1,5 @@
+---
+from: TKT-MJ02AO
+relation: has-review-response
+to: RR-37AYC0
+---

--- a/tickets/relations/TKT-MJ02AO--has-review-response--RR-CAUBAZ.md
+++ b/tickets/relations/TKT-MJ02AO--has-review-response--RR-CAUBAZ.md
@@ -1,0 +1,5 @@
+---
+from: TKT-MJ02AO
+relation: has-review-response
+to: RR-CAUBAZ
+---

--- a/tickets/relations/TKT-MJ02AO--has-review-response--RR-PG8HR2.md
+++ b/tickets/relations/TKT-MJ02AO--has-review-response--RR-PG8HR2.md
@@ -1,0 +1,5 @@
+---
+from: TKT-MJ02AO
+relation: has-review-response
+to: RR-PG8HR2
+---

--- a/tickets/relations/TKT-MJ02AO--has-review-response--RR-YZV7SY.md
+++ b/tickets/relations/TKT-MJ02AO--has-review-response--RR-YZV7SY.md
@@ -1,0 +1,5 @@
+---
+from: TKT-MJ02AO
+relation: has-review-response
+to: RR-YZV7SY
+---

--- a/tickets/relations/TKT-MJ02AO--implements--FEAT-DO57.md
+++ b/tickets/relations/TKT-MJ02AO--implements--FEAT-DO57.md
@@ -1,0 +1,5 @@
+---
+from: TKT-MJ02AO
+relation: implements
+to: FEAT-DO57
+---


### PR DESCRIPTION
Adds the first authorization layer to the data-entry command surface, which
executes arbitrary shell via `sh -c`.

Prep work for TKT-72SCPR (rendering command buttons on the dashboard and list
surfaces), which is blocked on this: shipping that first would put an ungated
shell-exec button on the first page every user lands on.

## The problem

`handleCommandExec` checked the HTTP method, looked up the command ID, and ran
the script. Grepping the command files for `acl|ACL|translateVerb|WriteRequest|Principal`
returned **zero matches**. The only gates were `requireSameOrigin` /
`requireLocalHost` — CSRF and network-location controls, which answer "did this
come from our page on this host", never "may this principal do this".

`--read-only` did not stop it either: `ReadOnlyACL` implements only
`AuthorizeWrite(WriteRequest)`, and command exec builds no `WriteRequest`. A
test written *before* the fix confirmed all four contexts returned 200 and
executed the script under `--read-only`.

## The design

An optional `permission:` key per command, following the existing
`acl.PermHistoryRead` pattern — a global named permission granted via a role's
`permissions:` list. Commands have no entity `Subject` (a `context: global`
command acts on the project, not a row), so they cannot go through
`AuthorizeWrite`; `acl.Subject` is a sealed sum.

Policy is bimodal (DEC-EIHQSU):

| Project state | with `permission:` | without |
| --- | --- | --- |
| No `acl.yaml` | runs | runs |
| `acl.yaml` present | runs if held | **denied** |
| `--read-only` | **denied** | **denied** |

`context: view` is denied outright under any policy — its payload is the whole
view traversal closure, so a grant would confer read access nobody can size
from the config. Setting `permission:` on a view command warns at load.

## Two non-obvious details

**The guard cannot be built on the read gate.** `readGateFromContext` returns
`nopReadGate` under **both** `NopACL` and `ReadOnlyACL`, and its
`HoldsPermission` returns `true` unconditionally. A guard written against the
gate alone fails open under `--read-only` — exactly the bug being fixed. It
discriminates on the ACL type instead, and the type switch **defaults to deny**
so an unrecognized implementation cannot silently grant shell.

**Cancel was the other half of the lifecycle.** The registry is keyed on a
client-supplied `exec_id` with no owner recorded, so any caller could kill any
user's run — including one whose own exec attempts were being 403'd. Running
commands are now bound to their starting principal; a mismatch returns 404,
identical to unknown-id, so cancel is not an enumeration oracle.

## Test coverage

- `TestCommandExecReadOnlyDenied` — 4 contexts; **failed before the fix**
- `TestCommandExecNopACLFailsOpen` — 4 contexts; fail-open regression
- `TestCommandExecDeclarativeFailsClosed` — 10 cases incl. view-denied-when-granted
- `TestResolveCommandsFiltersUnauthorized` — all three ACL modes
- `TestAuthorizeCommandUnknownACLDenies` — pointer/unknown/typed-nil all deny
- `TestCommandCancelOwnerBound` — cross-principal kill
- `TestViewCommandPermissionWarning` — config warning

## Known limitations (documented, ticketed)

Command payloads are **not** read-gate scoped in any context, so a `command:*`
grant confers read access to whatever the context assembles. Documented in
`docs/acl-security.md`; the fix is TKT-2FDTJE. `/api/open-file` remains ungated
— TKT-JRY8V5.

## Migration

Adding a first `acl.yaml` now requires `permission:` keys and grants on every
command that should keep working, and disables view commands until TKT-2FDTJE.
Deliberate: the failure mode is a denied command, not an ungoverned shell.