### PR TITLE
feat(docs): markdown+Lua-island doc language + rela docs build (TKT-3RLZR4)

### DIFF
--- a/.go-arch-lint.yml
+++ b/.go-arch-lint.yml
@@ -31,6 +31,7 @@ components:
   dataentryconfig:  { in: internal/dataentryconfig }
   conditionlint:    { in: internal/conditionlint }
   desktop:          { in: internal/desktop }
+  docs:             { in: internal/docs }
 
   # Server protocols
   mcp:              { in: internal/mcp }
@@ -218,6 +219,7 @@ deps:
       - clisync
       - config
       - dataentryconfig
+      - docs
       - entitymanager
       - filter
       - importer
@@ -491,6 +493,18 @@ deps:
       - markdown
       - metamodel
       - project
+  docs:
+    mayDependOn:
+      - acl
+      - entity
+      - lua
+      - mermaid
+      - metamodel
+      - store
+      - memstore
+      - tracer
+    canUse:
+      - gopherlua
   entitymanager:
     mayDependOn:
       - acl

--- a/.go-arch-lint.yml
+++ b/.go-arch-lint.yml
@@ -51,6 +51,7 @@ components:
   entitymanager:    { in: internal/entitymanager }
   importer:         { in: internal/importer }
   renametype:       { in: internal/renametype }
+  mermaid:          { in: internal/mermaid }
   schema:           { in: internal/schema }
   templating:       { in: internal/templating }
   predicate:        { in: internal/predicate }
@@ -285,6 +286,7 @@ deps:
       - git
       - htmlutil
       - lua
+      - mermaid
       - metamodel
       - migration
       - openapi

--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ go build -o rela ./cmd/rela
 | [Security model for rela-server](docs/server-security.md) | Threat model, HTTP defenses, audit attribution, and residual risks for the rela-server data-entry app; how its read-side ACL coverage stands today. |
 | [ACL: Authorization Overview](docs/acl-overview.md) | How rela's role-based authorization works end-to-end: from acl.yaml + the graph to a write decision and its audit attribution |
 | [ACL: Security Hardening](docs/acl-security.md) | Operator's hardening guide for rela's ACL system: group membership trust, fail-loud boot, audit-isolation invariants |
+| [Generated documentation: the rela docs language](docs/rela-docs.md) | Author a deployment manual in Markdown with embedded Lua islands that pull reference fragments (field tables, enum meanings, mermaid lifecycles, relation graphs, role matrices) straight from the schema. |
 
 ### Tutorials
 

--- a/docs-project/entities/guides/GUIDE-rela-docs.md
+++ b/docs-project/entities/guides/GUIDE-rela-docs.md
@@ -1,0 +1,135 @@
+---
+id: GUIDE-rela-docs
+type: guide
+title: "Generated documentation: the rela docs language"
+status: published
+order: 22
+audience: intermediate
+summary: "Author a deployment manual in Markdown with embedded Lua islands that pull reference fragments (field tables, enum meanings, mermaid lifecycles, relation graphs, role matrices) straight from the schema."
+---
+
+`rela docs build` renders a **manual** — ordinary Markdown you write by
+hand — resolving embedded **Lua islands** that pull mechanical reference
+fragments from the deployment's schema (and a small in-memory graph the
+manual seeds). Prose stays prose; the field tables, enum meanings, state
+diagrams, relation graphs, and role matrices are generated so they can
+never drift from `metamodel.yaml` / `acl.yaml`.
+
+This is the *reference* half of a manual, generated; the *explanation*
+and *how-to* halves stay hand-written around it.
+
+## The two island forms
+
+A manual is Markdown by default. You escape into Lua two ways:
+
+- **Statement island** — a fenced ` ```rela ` block. Its Lua runs for
+  side effects; emit calls (`h2`, `md`, and the resolvers below) append
+  Markdown at that position. Use it for tables, diagrams, and loops.
+- **Echo island** — an inline `` `rela <expr>` `` code span. The
+  expression is evaluated and its string value substituted mid-sentence.
+
+A code span or fenced block that does **not** start with the `rela`
+marker is left untouched, so you can show the doc language literally in
+a `` ```markdown `` sample.
+
+```markdown
+# Risicobeheer
+
+`rela description()`
+
+Elk *risico* legt de onderstaande gegevens vast:
+
+​```rela
+typeref{ type = "risico", fields = "required" }
+​```
+
+Er zijn `rela count{ type = "risico" }` risico's geregistreerd.
+```
+
+## Resolvers
+
+Each resolver is a function you call from an island. Names are also
+available without the `doc.` prefix.
+
+| Function | Emits |
+| --- | --- |
+| `typeref{type, fields="required"\|"all"}` | a field table (name, type, required), in definition order |
+| `values{type, field}` | an enum's values, the default marked, plus per-value meaning when the custom type declares `descriptions:` |
+| `relations{type}` | the type's outgoing relations as a list |
+| `graph{from, depth, direction, exclude\|only}` | a mermaid flow graph (see below) |
+| `lifecycle{type, field}` | a mermaid `stateDiagram-v2` when the field's custom type declares `transitions:`, else a flat value list |
+| `entity{id, fields}` | one **seeded** entity's fields |
+| `count{type}` | the number of seeded entities of a type (echo-friendly) |
+| `roles_matrix{type}` | a role × verb capability table from `acl.yaml` (omit `type` for every type) |
+| `description()` | the metamodel's top-level `description:` (echo-friendly) |
+| `h1/h2/h3(text)`, `md(text)` | structural Markdown emitted from Lua |
+
+### Relation graphs
+
+`graph{}` has two grains, chosen by `from`:
+
+- `from = "<entity type>"` draws the **schema** neighbourhood — which
+  types connect to which — from the metamodel.
+- `from = "<seeded id>"` traverses the **seeded** instance graph.
+
+`depth` bounds the hops (default 2, capped at 5). `direction` is `"out"`
+(default), `"in"`, or `"both"`. `exclude = {"rel_a", "rel_b"}` prunes
+noisy relation types — the thing that turns a hairball into a readable
+diagram; `only = {...}` is the allowlist inverse (the two are mutually
+exclusive).
+
+```markdown
+​```rela
+graph{ from = "verwerking", depth = 2, exclude = { "spawnt", "gaat_over" } }
+​```
+```
+
+## Seeding example data
+
+Instance resolvers (`entity`, `count`, `graph{from=<id>}`) read a fresh,
+**in-memory** graph that exists only for the build — never your real
+entities. The manual populates it with `create` and `link`, the same
+verbs a Lua script uses:
+
+```markdown
+​```rela
+local r = create("risico", { titel = "Onbevoegde toegang", kans = 2, impact = 3 })
+local m = create("maatregel", { titel = "MFA afdwingen" })
+link(r, "wordt_gemitigeerd_door", m)
+
+entity{ id = r.id, fields = { "titel", "kans", "impact" } }
+graph{ from = r.id, depth = 1 }
+​```
+```
+
+Seed writes go **straight to the in-memory store** — there is no
+validation, no state-machine gate, and no ACL. A fixture is exactly what
+you write, so `create("risico", { status = "done" })` is fine even if
+`done` is not a legal entry state. This keeps fixtures honest and
+self-contained; it never touches the project on disk.
+
+## Building
+
+```bash
+rela docs build manual.md            # resolved Markdown to stdout
+rela docs build manual.md --out site/manual.md
+rela docs build manual.md --strict   # fail if any island resolves to nothing
+```
+
+The metamodel and `acl.yaml` come from the project (`--project` or the
+current directory). The output is Markdown — pipe it through `pandoc`
+for PDF, or commit it beside hand-written chapters.
+
+**Fail-loud.** An island referencing an unknown type or field, a Lua
+error, or (under `--strict`) an empty resolve stops the build with the
+offending **manual** line — never a silently missing figure. Because
+islands are real Lua, you also get loops and conditionals for free:
+
+```markdown
+​```rela
+for _, t in ipairs({ "risico", "maatregel", "verwerking" }) do
+  h3("Velden — " .. t)
+  typeref{ type = t }
+end
+​```
+```

--- a/docs/rela-docs.md
+++ b/docs/rela-docs.md
@@ -1,0 +1,129 @@
+<!-- This file is auto-generated from docs-project/entities/. Do not edit directly. -->
+
+# Generated documentation: the rela docs language
+
+`rela docs build` renders a **manual** — ordinary Markdown you write by
+hand — resolving embedded **Lua islands** that pull mechanical reference
+fragments from the deployment's schema (and a small in-memory graph the
+manual seeds). Prose stays prose; the field tables, enum meanings, state
+diagrams, relation graphs, and role matrices are generated so they can
+never drift from `metamodel.yaml` / `acl.yaml`.
+
+This is the *reference* half of a manual, generated; the *explanation*
+and *how-to* halves stay hand-written around it.
+
+## The two island forms
+
+A manual is Markdown by default. You escape into Lua two ways:
+
+- **Statement island** — a fenced ` ```rela ` block. Its Lua runs for
+  side effects; emit calls (`h2`, `md`, and the resolvers below) append
+  Markdown at that position. Use it for tables, diagrams, and loops.
+- **Echo island** — an inline `` `rela <expr>` `` code span. The
+  expression is evaluated and its string value substituted mid-sentence.
+
+A code span or fenced block that does **not** start with the `rela`
+marker is left untouched, so you can show the doc language literally in
+a `` ```markdown `` sample.
+
+```markdown
+# Risicobeheer
+
+`rela description()`
+
+Elk *risico* legt de onderstaande gegevens vast:
+
+​```rela
+typeref{ type = "risico", fields = "required" }
+​```
+
+Er zijn `rela count{ type = "risico" }` risico's geregistreerd.
+```
+
+## Resolvers
+
+Each resolver is a function you call from an island. Names are also
+available without the `doc.` prefix.
+
+| Function | Emits |
+| --- | --- |
+| `typeref{type, fields="required"\|"all"}` | a field table (name, type, required), in definition order |
+| `values{type, field}` | an enum's values, the default marked, plus per-value meaning when the custom type declares `descriptions:` |
+| `relations{type}` | the type's outgoing relations as a list |
+| `graph{from, depth, direction, exclude\|only}` | a mermaid flow graph (see below) |
+| `lifecycle{type, field}` | a mermaid `stateDiagram-v2` when the field's custom type declares `transitions:`, else a flat value list |
+| `entity{id, fields}` | one **seeded** entity's fields |
+| `count{type}` | the number of seeded entities of a type (echo-friendly) |
+| `roles_matrix{type}` | a role × verb capability table from `acl.yaml` (omit `type` for every type) |
+| `description()` | the metamodel's top-level `description:` (echo-friendly) |
+| `h1/h2/h3(text)`, `md(text)` | structural Markdown emitted from Lua |
+
+### Relation graphs
+
+`graph{}` has two grains, chosen by `from`:
+
+- `from = "<entity type>"` draws the **schema** neighbourhood — which
+  types connect to which — from the metamodel.
+- `from = "<seeded id>"` traverses the **seeded** instance graph.
+
+`depth` bounds the hops (default 2, capped at 5). `direction` is `"out"`
+(default), `"in"`, or `"both"`. `exclude = {"rel_a", "rel_b"}` prunes
+noisy relation types — the thing that turns a hairball into a readable
+diagram; `only = {...}` is the allowlist inverse (the two are mutually
+exclusive).
+
+```markdown
+​```rela
+graph{ from = "verwerking", depth = 2, exclude = { "spawnt", "gaat_over" } }
+​```
+```
+
+## Seeding example data
+
+Instance resolvers (`entity`, `count`, `graph{from=<id>}`) read a fresh,
+**in-memory** graph that exists only for the build — never your real
+entities. The manual populates it with `create` and `link`, the same
+verbs a Lua script uses:
+
+```markdown
+​```rela
+local r = create("risico", { titel = "Onbevoegde toegang", kans = 2, impact = 3 })
+local m = create("maatregel", { titel = "MFA afdwingen" })
+link(r, "wordt_gemitigeerd_door", m)
+
+entity{ id = r.id, fields = { "titel", "kans", "impact" } }
+graph{ from = r.id, depth = 1 }
+​```
+```
+
+Seed writes go **straight to the in-memory store** — there is no
+validation, no state-machine gate, and no ACL. A fixture is exactly what
+you write, so `create("risico", { status = "done" })` is fine even if
+`done` is not a legal entry state. This keeps fixtures honest and
+self-contained; it never touches the project on disk.
+
+## Building
+
+```bash
+rela docs build manual.md            # resolved Markdown to stdout
+rela docs build manual.md --out site/manual.md
+rela docs build manual.md --strict   # fail if any island resolves to nothing
+```
+
+The metamodel and `acl.yaml` come from the project (`--project` or the
+current directory). The output is Markdown — pipe it through `pandoc`
+for PDF, or commit it beside hand-written chapters.
+
+**Fail-loud.** An island referencing an unknown type or field, a Lua
+error, or (under `--strict`) an empty resolve stops the build with the
+offending **manual** line — never a silently missing figure. Because
+islands are real Lua, you also get loops and conditionals for free:
+
+```markdown
+​```rela
+for _, t in ipairs({ "risico", "maatregel", "verwerking" }) do
+  h3("Velden — " .. t)
+  typeref{ type = t }
+end
+​```
+```

--- a/internal/cli/docs.go
+++ b/internal/cli/docs.go
@@ -1,0 +1,72 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/Sourcehaven-BV/rela/internal/acl"
+	"github.com/Sourcehaven-BV/rela/internal/docs"
+)
+
+// DocsCmd is `rela docs` — the doc-language build tool.
+type DocsCmd struct {
+	Build DocsBuildCmd `cmd:"" help:"Render a manual (Markdown with rela Lua islands) to resolved Markdown."`
+}
+
+// DocsBuildCmd is `rela docs build <manual.md>`. It resolves the manual's Lua
+// islands against the project's metamodel + acl.yaml (and a seeded in-memory
+// graph the manual populates) and writes the resulting Markdown.
+type DocsBuildCmd struct {
+	Manual string `arg:"" help:"Path to the manual (Markdown with rela Lua islands)."`
+	Output string `name:"out" help:"Write resolved Markdown here (default: stdout)."`
+	Strict bool   `help:"Fail the build if any island resolves to nothing."`
+}
+
+// Run resolves the manual and writes the output.
+func (c *DocsBuildCmd) Run(ctx context.Context, svc *readServices) error {
+	// The manual is an operator-supplied path (a document, not a project
+	// script), typically outside the project root — read it directly, same
+	// trust boundary as `pandoc in.md -o out`.
+	src, err := os.ReadFile(c.Manual)
+	if err != nil {
+		return fmt.Errorf("read manual: %w", err)
+	}
+
+	// acl.yaml is optional; roles_matrix degrades to a note when absent.
+	var policy *acl.Policy
+	policyPath := filepath.Join(svc.Paths.Root, "acl.yaml")
+	if p, perr := acl.LoadPolicy(policyPath); perr == nil {
+		policy = p
+	} else if !errors.Is(perr, os.ErrNotExist) {
+		return fmt.Errorf("load acl.yaml: %w", perr)
+	}
+
+	rendered, err := docs.Build(ctx, string(src), docs.Options{
+		Meta:   svc.Meta,
+		Policy: policy,
+		Strict: c.Strict,
+	})
+	if err != nil {
+		return err
+	}
+
+	if c.Output == "" {
+		fmt.Print(rendered)
+		return nil
+	}
+	if info, statErr := os.Stat(c.Output); statErr == nil && info.IsDir() {
+		return fmt.Errorf("--output %q is a directory", c.Output)
+	}
+	if dir := filepath.Dir(c.Output); dir != "" {
+		if mkErr := os.MkdirAll(dir, 0o755); mkErr != nil {
+			return fmt.Errorf("create output dir: %w", mkErr)
+		}
+	}
+	if err := os.WriteFile(c.Output, []byte(rendered), 0o644); err != nil {
+		return fmt.Errorf("write output: %w", err)
+	}
+	return nil
+}

--- a/internal/cli/kong.go
+++ b/internal/cli/kong.go
@@ -86,6 +86,7 @@ type CLI struct {
 	Fmt       FmtCmd       `cmd:"" help:"Format entity and relation files."`
 	Normalize NormalizeCmd `cmd:"" help:"Normalize markdown headers in entity files."`
 	Schema    SchemaCmd    `cmd:"" help:"View the metamodel schema."`
+	Docs      DocsCmd      `cmd:"" help:"Build documentation from Markdown manuals with rela Lua islands."`
 	Template  TemplateCmd  `cmd:"" help:"Manage entity and relation templates."`
 	Analyze   AnalyzeCmd   `cmd:"" help:"Analyze the entity graph."`
 	ACL       ACLCmd       `cmd:"" name:"acl" help:"Audit the ACL policy (acl.yaml)."`
@@ -215,7 +216,7 @@ func configureKongLogging(verbose, quiet bool) {
 // completion, migrate) or do their own discovery (mcp, flow, validate).
 func requiresProject(cmd string) bool {
 	switch firstKongToken(cmd) {
-	case "show", "list", "trace", "graph", "export", "fmt", "schema",
+	case "show", "list", "trace", "graph", "export", "fmt", "schema", "docs",
 		"template", "create", "update", "delete", "link", "unlink",
 		"detach", "import", "normalize", "script", "scheduler",
 		"rename", "analyze", "acl", "attach", "attachments", "gc", "renumber",

--- a/internal/cli/kong.go
+++ b/internal/cli/kong.go
@@ -53,7 +53,7 @@ var (
 // so growth is structural here) — over the 20-field load line. Revisit grouping
 // subcommands into sub-structs; ratchet this number down if/when that lands.
 //
-//plimsoll:max-fields=45
+//plimsoll:max-fields=46
 type CLI struct {
 	// Global flags.
 	Project string `help:"Project directory (default: auto-detect from cwd)." env:"RELA_PROJECT"`

--- a/internal/dataentry/handlers.go
+++ b/internal/dataentry/handlers.go
@@ -7,6 +7,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/Sourcehaven-BV/rela/internal/mermaid"
 	"github.com/Sourcehaven-BV/rela/internal/metamodel"
 )
 
@@ -268,7 +269,7 @@ func renderEnumHelp(w http.ResponseWriter, e EnumHelp) {
 		// (the help modal runs renderMermaidDiagrams over the injected HTML). One
 		// diagram per state-machine field.
 		fmt.Fprintf(w, `<pre class="mermaid">%s</pre>`,
-			htmltemplate.HTMLEscapeString(mermaidStateDiagram(e)))
+			htmltemplate.HTMLEscapeString(enumStateDiagram(e)))
 		fmt.Fprint(w, `<table class="help-table"><thead><tr><th>Move</th><th>From &rarr; To</th><th>When to use</th></tr></thead><tbody>`)
 		for _, tr := range e.Transitions {
 			fmt.Fprintf(w, `<tr><td>%s</td><td><code>%s</code> &rarr; <code>%s</code></td><td>%s</td></tr>`,
@@ -281,75 +282,16 @@ func renderEnumHelp(w http.ResponseWriter, e EnumHelp) {
 	}
 }
 
-// mermaidStateDiagram builds a stateDiagram-v2 source for one state-machine
-// field: an entry arrow to the initial state (when known) plus one edge per
-// transition, labeled with the move (verb).
-//
-// Raw enum values are NOT safe to splice directly into mermaid syntax — a value
-// with a space, an arrow, or a colon would break parsing, and a newline in a
-// move label could inject a spurious edge (the caller HTML-escapes the result,
-// but renderMermaidDiagrams reads textContent, which un-escapes it before
-// parsing, so the escape protects only the HTML transport). So every state value
-// is mapped to a synthetic id (`s0`, `s1`, …) and aliased with
-// `state "raw value" as sN` so the diagram DISPLAYS the real value while the
-// edges reference the safe id; move labels are flattened (newlines/carriage
-// returns → spaces) so a label can never spill onto a new diagram line.
-func mermaidStateDiagram(e EnumHelp) string {
-	ids := map[string]string{}
-	idFor := func(value string) string {
-		if id, ok := ids[value]; ok {
-			return id
-		}
-		id := fmt.Sprintf("s%d", len(ids))
-		ids[value] = id
-		return id
-	}
-
-	var b strings.Builder
-	b.WriteString("stateDiagram-v2\n")
-
-	// Collect the states in first-seen order so the alias declarations are
-	// deterministic; assign ids as we go.
-	order := []string{}
-	seen := map[string]bool{}
-	note := func(v string) {
-		if v != "" && !seen[v] {
-			seen[v] = true
-			order = append(order, v)
-			idFor(v)
-		}
-	}
-	note(e.Initial)
+// enumStateDiagram builds a stateDiagram-v2 source for one state-machine field
+// by mapping the EnumHelp DTO onto the shared injection-safe renderer in
+// internal/mermaid. The move label is EnumHelp.Transitions[].Move, which already
+// carries the Label→To fallback applied when the EnumHelp was built.
+func enumStateDiagram(e EnumHelp) string {
+	ts := make([]mermaid.Transition, 0, len(e.Transitions))
 	for _, tr := range e.Transitions {
-		note(tr.From)
-		note(tr.To)
+		ts = append(ts, mermaid.Transition{From: tr.From, To: tr.To, Label: tr.Move})
 	}
-	for _, v := range order {
-		fmt.Fprintf(&b, "    state %q as %s\n", v, ids[v])
-	}
-
-	if e.Initial != "" {
-		fmt.Fprintf(&b, "    [*] --> %s\n", ids[e.Initial])
-	}
-	for _, tr := range e.Transitions {
-		label := mermaidLabel(tr.Move)
-		if label != "" && tr.Move != tr.To {
-			fmt.Fprintf(&b, "    %s --> %s: %s\n", ids[tr.From], ids[tr.To], label)
-		} else {
-			fmt.Fprintf(&b, "    %s --> %s\n", ids[tr.From], ids[tr.To])
-		}
-	}
-	return b.String()
-}
-
-// mermaidLabel flattens a transition move label so it is safe as a mermaid edge
-// label: newlines/carriage returns collapse to spaces (a raw newline would end
-// the edge line and let the remainder inject a new statement).
-func mermaidLabel(s string) string {
-	s = strings.ReplaceAll(s, "\r\n", " ")
-	s = strings.ReplaceAll(s, "\n", " ")
-	s = strings.ReplaceAll(s, "\r", " ")
-	return strings.TrimSpace(s)
+	return mermaid.StateDiagram(e.Initial, ts)
 }
 
 // gatherRelations collects relation documentation for an entity type.

--- a/internal/dataentry/help_docfields_test.go
+++ b/internal/dataentry/help_docfields_test.go
@@ -116,7 +116,7 @@ func TestMermaidStateDiagram(t *testing.T) {
 			{Move: "done", From: "doing", To: "done"}, // move == to → no label
 		},
 	}
-	got := mermaidStateDiagram(e)
+	got := enumStateDiagram(e)
 
 	for _, want := range []string{
 		"stateDiagram-v2",
@@ -145,7 +145,7 @@ func TestMermaidStateDiagram_InjectionSafe(t *testing.T) {
 			{Move: "Go\n    evil --> pwned", From: "to do", To: "a --> b"},
 		},
 	}
-	got := mermaidStateDiagram(e)
+	got := enumStateDiagram(e)
 
 	// The raw space/arrow values are only inside quoted alias text, never as
 	// bare tokens forming edges.

--- a/internal/docs/build_test.go
+++ b/internal/docs/build_test.go
@@ -2,6 +2,7 @@ package docs
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"testing"
 
@@ -9,7 +10,7 @@ import (
 	"github.com/Sourcehaven-BV/rela/internal/metamodel"
 )
 
-// fixtureMeta builds a small ISMS-flavoured metamodel: a `risico` entity with a
+// fixtureMeta builds a small ISMS-flavored metamodel: a `risico` entity with a
 // required `kans`/`impact`, a `status` state machine (todo→doing→done) and a
 // flat `behandeling` enum with per-value descriptions, plus a `maatregel` and a
 // `wordt_gemitigeerd_door` relation.
@@ -242,8 +243,8 @@ func TestBuild_SeedRawStoreNoGate(t *testing.T) {
 func TestBuild_FailLoudUnknownType(t *testing.T) {
 	t.Parallel()
 	_, err := Build(context.Background(), "line1\n```rela\ntyperef{type=\"nope\"}\n```\n", Options{Meta: fixtureMeta(t)})
-	be, ok := err.(*BuildError)
-	if !ok {
+	var be *BuildError
+	if !errors.As(err, &be) {
 		t.Fatalf("want *BuildError, got %T: %v", err, err)
 	}
 	if !strings.Contains(be.Msg, "nope") {

--- a/internal/docs/build_test.go
+++ b/internal/docs/build_test.go
@@ -222,6 +222,27 @@ func TestBuild_RolesMatrix(t *testing.T) {
 	}
 }
 
+// The built-in "everyone" role must be folded into every named role's cell
+// (not shown as a column) so the matrix reflects EFFECTIVE access.
+func TestBuild_RolesMatrixEveryoneFolded(t *testing.T) {
+	t.Parallel()
+	policy := &acl.Policy{
+		Roles: map[string]acl.RoleDef{
+			"everyone": {Read: []string{"*"}},   // everyone can read
+			"editor":   {Create: []string{"*"}}, // editor can create (but not declared read)
+		},
+	}
+	out := build(t, "```rela\nroles_matrix{type=\"risico\"}\n```\n", Options{Meta: fixtureMeta(t), Policy: policy})
+	// "everyone" is not a column.
+	if strings.Contains(out, "| Type | Verb | everyone") || strings.Contains(out, " everyone |") {
+		t.Errorf("everyone should not be a column:\n%s", out)
+	}
+	// The read row for editor must show ✓ (folded from everyone), and a footnote.
+	if !strings.Contains(out, "everyone` role") {
+		t.Errorf("expected the everyone footnote:\n%s", out)
+	}
+}
+
 func TestBuild_RolesMatrixNoPolicy(t *testing.T) {
 	t.Parallel()
 	out := build(t, "```rela\nroles_matrix{type=\"risico\"}\n```\n", Options{Meta: fixtureMeta(t)})

--- a/internal/docs/build_test.go
+++ b/internal/docs/build_test.go
@@ -1,0 +1,288 @@
+package docs
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/Sourcehaven-BV/rela/internal/acl"
+	"github.com/Sourcehaven-BV/rela/internal/metamodel"
+)
+
+// fixtureMeta builds a small ISMS-flavoured metamodel: a `risico` entity with a
+// required `kans`/`impact`, a `status` state machine (todo→doing→done) and a
+// flat `behandeling` enum with per-value descriptions, plus a `maatregel` and a
+// `wordt_gemitigeerd_door` relation.
+func fixtureMeta(t *testing.T) *metamodel.Metamodel {
+	t.Helper()
+	m := &metamodel.Metamodel{
+		Description: "The Sourcehaven ISMS.",
+		Types: map[string]metamodel.CustomType{
+			"status": {
+				Values:  []string{"todo", "doing", "done"},
+				Initial: "todo",
+				Transitions: []metamodel.TransitionDef{
+					{From: "todo", To: "doing", Label: "start"},
+					{From: "doing", To: "done", Label: "finish"},
+				},
+			},
+			"behandeling": {
+				Values:  []string{"mitigeren", "accepteren"},
+				Default: "accepteren",
+				Descriptions: map[string]string{
+					"mitigeren":  "Reduce the risk with controls.",
+					"accepteren": "Accept the residual risk.",
+				},
+			},
+		},
+		Entities: map[string]metamodel.EntityDef{
+			"risico": {
+				Label:         "risico",
+				PropertyOrder: []string{"titel", "kans", "impact", "status", "behandeling"},
+				Properties: map[string]metamodel.PropertyDef{
+					"titel":       {Type: "string", Required: true},
+					"kans":        {Type: "integer", Required: true},
+					"impact":      {Type: "integer", Required: true},
+					"status":      {Type: "status", Required: true},
+					"behandeling": {Type: "behandeling"},
+				},
+			},
+			"maatregel": {
+				Label:         "maatregel",
+				PropertyOrder: []string{"titel"},
+				Properties:    map[string]metamodel.PropertyDef{"titel": {Type: "string", Required: true}},
+			},
+		},
+		Relations: map[string]metamodel.RelationDef{
+			"wordt_gemitigeerd_door": {
+				Description: "A risk is mitigated by a control.",
+				From:        []string{"risico"},
+				To:          []string{"maatregel"},
+			},
+		},
+	}
+	m.InitAliases()
+	return m
+}
+
+func fixturePolicy() *acl.Policy {
+	return &acl.Policy{
+		Roles: map[string]acl.RoleDef{
+			"editor": {Read: []string{"*"}, Create: []string{"*"}, Update: []string{"*"}, Delete: []string{"*"}},
+			"viewer": {Read: []string{"*"}},
+		},
+	}
+}
+
+func build(t *testing.T, src string, opts Options) string {
+	t.Helper()
+	if opts.Meta == nil {
+		opts.Meta = fixtureMeta(t)
+	}
+	out, err := Build(context.Background(), src, opts)
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	return out
+}
+
+// AC1: statement island emits and splices; surrounding markdown passes through.
+func TestBuild_StatementIsland(t *testing.T) {
+	t.Parallel()
+	out := build(t, "intro\n\n```rela\nh2(\"Risico\")\nmd(\"body\")\n```\n\noutro\n", Options{})
+	for _, want := range []string{"intro", "## Risico", "body", "outro"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("output missing %q:\n%s", want, out)
+		}
+	}
+}
+
+// AC2: echo island substitutes a value inline.
+func TestBuild_EchoCount(t *testing.T) {
+	t.Parallel()
+	src := "```rela\ncreate(\"risico\", {titel=\"a\", kans=2, impact=3})\ncreate(\"risico\", {titel=\"b\", kans=1, impact=1})\n```\nThere are `rela count{type=\"risico\"}` risks.\n"
+	out := build(t, src, Options{})
+	if !strings.Contains(out, "There are 2 risks.") {
+		t.Errorf("echo count not substituted:\n%s", out)
+	}
+}
+
+// AC3: typeref required-only table in property order.
+func TestBuild_TyperefRequired(t *testing.T) {
+	t.Parallel()
+	out := build(t, "```rela\ntyperef{type=\"risico\", fields=\"required\"}\n```\n", Options{})
+	if !strings.Contains(out, "| `titel` | string | yes |") {
+		t.Errorf("missing titel row:\n%s", out)
+	}
+	// behandeling is optional → excluded from required-only.
+	if strings.Contains(out, "`behandeling`") {
+		t.Errorf("optional field leaked into required-only table:\n%s", out)
+	}
+}
+
+// AC4: values with descriptions render a meaning table + default marker.
+func TestBuild_ValuesWithDescriptions(t *testing.T) {
+	t.Parallel()
+	out := build(t, "```rela\nvalues{type=\"risico\", field=\"behandeling\"}\n```\n", Options{})
+	for _, want := range []string{"Reduce the risk with controls.", "Accept the residual risk.", "_(default)_"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("missing %q:\n%s", want, out)
+		}
+	}
+}
+
+// AC5: lifecycle renders a mermaid state diagram for a machine; falls back to a
+// flat list when there are no transitions.
+func TestBuild_LifecycleDiagram(t *testing.T) {
+	t.Parallel()
+	out := build(t, "```rela\nlifecycle{type=\"risico\", field=\"status\"}\n```\n", Options{})
+	if !strings.Contains(out, "```mermaid") || !strings.Contains(out, "stateDiagram-v2") {
+		t.Errorf("expected a mermaid state diagram:\n%s", out)
+	}
+	if !strings.Contains(out, ": start") {
+		t.Errorf("expected the start transition label:\n%s", out)
+	}
+}
+
+func TestBuild_LifecycleFlatFallback(t *testing.T) {
+	t.Parallel()
+	out := build(t, "```rela\nlifecycle{type=\"risico\", field=\"behandeling\"}\n```\n", Options{})
+	if strings.Contains(out, "stateDiagram") {
+		t.Errorf("flat enum should not render a diagram:\n%s", out)
+	}
+	if !strings.Contains(out, "`mitigeren`") {
+		t.Errorf("expected the flat value list:\n%s", out)
+	}
+}
+
+// AC6: instance graph over a seeded diamond asserts the exact deduped edge set.
+func TestBuild_GraphInstanceDiamond(t *testing.T) {
+	t.Parallel()
+	// r -mit-> m1, r -mit-> m2 (fan-out); both are maatregel. depth 1.
+	src := `` +
+		"```rela\n" +
+		"local r = create(\"risico\", {titel=\"x\", kans=1, impact=1})\n" +
+		"local m1 = create(\"maatregel\", {titel=\"c1\"})\n" +
+		"local m2 = create(\"maatregel\", {titel=\"c2\"})\n" +
+		"link(r, \"wordt_gemitigeerd_door\", m1)\n" +
+		"link(r, \"wordt_gemitigeerd_door\", m2)\n" +
+		"graph{from=r.id, depth=1}\n" +
+		"```\n"
+	out := build(t, src, Options{})
+	if !strings.Contains(out, "```mermaid") || !strings.Contains(out, "graph LR") {
+		t.Errorf("expected a mermaid flow graph:\n%s", out)
+	}
+	// Two distinct edges labeled with the relation, no duplicate.
+	if c := strings.Count(out, "wordt_gemitigeerd_door"); c != 2 {
+		t.Errorf("expected 2 mitigation edges, got %d:\n%s", c, out)
+	}
+}
+
+// AC6: schema-grain graph from a type.
+func TestBuild_GraphSchema(t *testing.T) {
+	t.Parallel()
+	out := build(t, "```rela\ngraph{from=\"risico\", depth=1}\n```\n", Options{})
+	if !strings.Contains(out, "graph LR") {
+		t.Errorf("expected schema graph:\n%s", out)
+	}
+	if !strings.Contains(out, "wordt_gemitigeerd_door") {
+		t.Errorf("expected the schema edge:\n%s", out)
+	}
+}
+
+// AC6: exclude prunes a relation type.
+func TestBuild_GraphExclude(t *testing.T) {
+	t.Parallel()
+	out := build(t, "```rela\ngraph{from=\"risico\", depth=1, exclude={\"wordt_gemitigeerd_door\"}}\n```\n", Options{})
+	if strings.Contains(out, "wordt_gemitigeerd_door") {
+		t.Errorf("excluded relation should be pruned:\n%s", out)
+	}
+}
+
+func TestBuild_GraphExcludeOnlyConflict(t *testing.T) {
+	t.Parallel()
+	_, err := Build(context.Background(),
+		"```rela\ngraph{from=\"risico\", exclude={\"a\"}, only={\"b\"}}\n```\n",
+		Options{Meta: fixtureMeta(t)})
+	if err == nil || !strings.Contains(err.Error(), "mutually exclusive") {
+		t.Errorf("expected mutual-exclusion error, got %v", err)
+	}
+}
+
+// AC7: roles_matrix renders a role × verb table.
+func TestBuild_RolesMatrix(t *testing.T) {
+	t.Parallel()
+	out := build(t, "```rela\nroles_matrix{type=\"risico\"}\n```\n", Options{Meta: fixtureMeta(t), Policy: fixturePolicy()})
+	if !strings.Contains(out, "editor") || !strings.Contains(out, "viewer") {
+		t.Errorf("expected both roles as columns:\n%s", out)
+	}
+	if !strings.Contains(out, "✓") {
+		t.Errorf("expected at least one grant tick:\n%s", out)
+	}
+}
+
+func TestBuild_RolesMatrixNoPolicy(t *testing.T) {
+	t.Parallel()
+	out := build(t, "```rela\nroles_matrix{type=\"risico\"}\n```\n", Options{Meta: fixtureMeta(t)})
+	if !strings.Contains(out, "No access policy") {
+		t.Errorf("expected no-policy note:\n%s", out)
+	}
+}
+
+// AC8: raw-store seed accepts any status (no state-machine gate).
+func TestBuild_SeedRawStoreNoGate(t *testing.T) {
+	t.Parallel()
+	out := build(t, "```rela\nlocal r = create(\"risico\", {titel=\"x\", kans=1, impact=1, status=\"done\"})\nentity{id=r.id, fields={\"status\"}}\n```\n", Options{})
+	if !strings.Contains(out, "status: done") {
+		t.Errorf("raw-store seed should accept status=done directly:\n%s", out)
+	}
+}
+
+// AC9: unknown type fails loud with a manual line.
+func TestBuild_FailLoudUnknownType(t *testing.T) {
+	t.Parallel()
+	_, err := Build(context.Background(), "line1\n```rela\ntyperef{type=\"nope\"}\n```\n", Options{Meta: fixtureMeta(t)})
+	be, ok := err.(*BuildError)
+	if !ok {
+		t.Fatalf("want *BuildError, got %T: %v", err, err)
+	}
+	if !strings.Contains(be.Msg, "nope") {
+		t.Errorf("error should name the unknown type: %v", be)
+	}
+}
+
+// AC2/echo: a table-returning resolver in an echo span is an author error.
+func TestBuild_EchoRejectsBlockResolver(t *testing.T) {
+	t.Parallel()
+	_, err := Build(context.Background(), "x `rela typeref{type=\"risico\"}` y\n", Options{Meta: fixtureMeta(t)})
+	if err == nil {
+		t.Fatal("expected an error for a block resolver in an echo span")
+	}
+}
+
+// AC9 strict: empty resolve errors under strict, warns otherwise.
+func TestBuild_StrictEmptyResolve(t *testing.T) {
+	t.Parallel()
+	m := fixtureMeta(t)
+	m.Description = "" // description() now yields empty
+	_, err := Build(context.Background(), "`rela description()`\n", Options{Meta: m, Strict: true})
+	if err == nil {
+		t.Fatal("strict mode should fail on empty resolve")
+	}
+	// Non-strict: builds fine (empty substituted).
+	if _, err := Build(context.Background(), "`rela description()`\n", Options{Meta: m}); err != nil {
+		t.Fatalf("non-strict empty resolve should not fail: %v", err)
+	}
+}
+
+// AC12: an infinite loop is stopped by the build timeout (use a short one).
+func TestBuild_InfiniteLoopTimesOut(t *testing.T) {
+	t.Parallel()
+	// A tiny timeout keeps the test fast; the real default is buildTimeout.
+	ctx, cancel := context.WithTimeout(context.Background(), 500_000_000) // 500ms
+	defer cancel()
+	_, err := Build(ctx, "```rela\nwhile true do end\n```\n", Options{Meta: fixtureMeta(t)})
+	if err == nil {
+		t.Fatal("infinite loop should abort via timeout")
+	}
+}

--- a/internal/docs/build_test.go
+++ b/internal/docs/build_test.go
@@ -239,16 +239,42 @@ func TestBuild_SeedRawStoreNoGate(t *testing.T) {
 	}
 }
 
-// AC9: unknown type fails loud with a manual line.
+// AC9: unknown type fails loud with a manual line. Also a regression guard that
+// a resolver's typed BuildError round-trips cleanly (kind=resolve, clean Msg,
+// correct line) rather than being stringified into a lua-kind error by
+// RaiseError.
 func TestBuild_FailLoudUnknownType(t *testing.T) {
 	t.Parallel()
+	// ```rela is line 2; the resolver call is on body line 3.
 	_, err := Build(context.Background(), "line1\n```rela\ntyperef{type=\"nope\"}\n```\n", Options{Meta: fixtureMeta(t)})
 	var be *BuildError
 	if !errors.As(err, &be) {
 		t.Fatalf("want *BuildError, got %T: %v", err, err)
 	}
-	if !strings.Contains(be.Msg, "nope") {
-		t.Errorf("error should name the unknown type: %v", be)
+	if be.Kind != "resolve" {
+		t.Errorf("kind = %q, want resolve (typed round-trip, not lua-stringified)", be.Kind)
+	}
+	if be.Line != 3 {
+		t.Errorf("manual line = %d, want 3", be.Line)
+	}
+	if be.Msg != `typeref: unknown entity type "nope"` {
+		t.Errorf("msg = %q, want the clean resolver message", be.Msg)
+	}
+}
+
+// AC9 (M1): a Lua error on the SECOND line of a multi-line island reports the
+// manual line of that line, not the island start.
+func TestBuild_FailLoudLuaLineOffset(t *testing.T) {
+	t.Parallel()
+	// ```rela is line 1; body line 1 = "h2(...)" (manual 2); body line 2 =
+	// "nosuchfunc()" (manual 3), which errors.
+	_, err := Build(context.Background(), "```rela\nh2(\"ok\")\nnosuchfunc()\n```\n", Options{Meta: fixtureMeta(t)})
+	var be *BuildError
+	if !errors.As(err, &be) {
+		t.Fatalf("want *BuildError, got %T: %v", err, err)
+	}
+	if be.Line != 3 {
+		t.Errorf("manual line = %d, want 3 (the erroring line, not the island start)", be.Line)
 	}
 }
 

--- a/internal/docs/errors.go
+++ b/internal/docs/errors.go
@@ -1,0 +1,23 @@
+package docs
+
+import "fmt"
+
+// BuildError is a fail-loud error tied to a specific line of the manual source.
+// The doc language treats any unresolved island — a parse error, an unknown
+// type/field, a Lua error, or (under strict mode) an empty resolve — as a build
+// failure rather than silently emitting nothing, and reports the offending
+// MANUAL line so the author can find it.
+type BuildError struct {
+	Line int    // 1-based manual source line
+	Kind string // short category: "parse", "lua", "resolve", "strict"
+	Msg  string // human-readable detail
+	Snip string // the offending island text (optional)
+}
+
+func (e *BuildError) Error() string {
+	loc := fmt.Sprintf("manual:%d", e.Line)
+	if e.Kind != "" {
+		return fmt.Sprintf("%s: %s: %s", loc, e.Kind, e.Msg)
+	}
+	return fmt.Sprintf("%s: %s", loc, e.Msg)
+}

--- a/internal/docs/luahelpers.go
+++ b/internal/docs/luahelpers.go
@@ -1,0 +1,103 @@
+package docs
+
+import (
+	lua "github.com/yuin/gopher-lua"
+)
+
+// argString reads a string argument that may be passed positionally
+// (fn("risico")) or as a named table field (fn{type="risico"}), reading the
+// given key from a table first arg. Returns "" when absent.
+func argString(ls *lua.LState, key string) string {
+	switch v := ls.Get(1).(type) {
+	case lua.LString:
+		return string(v)
+	case *lua.LTable:
+		if s, ok := ls.GetField(v, key).(lua.LString); ok {
+			return string(s)
+		}
+	}
+	return ""
+}
+
+// argTable returns the first argument as a table, or nil.
+func argTable(ls *lua.LState) *lua.LTable {
+	if t, ok := ls.Get(1).(*lua.LTable); ok {
+		return t
+	}
+	return nil
+}
+
+// fieldString reads a string field from a table, "" when absent.
+func fieldString(ls *lua.LState, tbl *lua.LTable, key string) string {
+	if tbl == nil {
+		return ""
+	}
+	if s, ok := ls.GetField(tbl, key).(lua.LString); ok {
+		return string(s)
+	}
+	return ""
+}
+
+// fieldInt reads an integer field from a table, returning def when absent.
+func fieldInt(ls *lua.LState, tbl *lua.LTable, key string, def int) int {
+	if tbl == nil {
+		return def
+	}
+	if n, ok := ls.GetField(tbl, key).(lua.LNumber); ok {
+		return int(n)
+	}
+	return def
+}
+
+// fieldStringSlice reads an array-of-strings field ({"a","b"}) from a table.
+func fieldStringSlice(ls *lua.LState, tbl *lua.LTable, key string) []string {
+	if tbl == nil {
+		return nil
+	}
+	arr, ok := ls.GetField(tbl, key).(*lua.LTable)
+	if !ok {
+		return nil
+	}
+	var out []string
+	arr.ForEach(func(_, v lua.LValue) {
+		if s, ok := v.(lua.LString); ok {
+			out = append(out, string(s))
+		}
+	})
+	return out
+}
+
+// idArg reads an entity id from argument n: a string id, or a table with an
+// "id" field (as returned by create()).
+func idArg(ls *lua.LState, n int) string {
+	switch v := ls.Get(n).(type) {
+	case lua.LString:
+		return string(v)
+	case *lua.LTable:
+		if s, ok := ls.GetField(v, "id").(lua.LString); ok {
+			return string(s)
+		}
+	}
+	return ""
+}
+
+// luaTableToMap converts a Lua table to a Go map, string keys only, scalar
+// values. Nested tables are flattened to nil (seed props are scalar).
+func luaTableToMap(t *lua.LTable) map[string]any {
+	out := map[string]any{}
+	t.ForEach(func(k, v lua.LValue) {
+		ks, ok := k.(lua.LString)
+		if !ok {
+			return
+		}
+		switch vv := v.(type) {
+		case lua.LString:
+			out[string(ks)] = string(vv)
+		case lua.LNumber:
+			out[string(ks)] = float64(vv)
+		case lua.LBool:
+			out[string(ks)] = bool(vv)
+		}
+	})
+	return out
+}

--- a/internal/docs/module.go
+++ b/internal/docs/module.go
@@ -2,6 +2,7 @@ package docs
 
 import (
 	"fmt"
+	"strings"
 
 	lua "github.com/yuin/gopher-lua"
 
@@ -53,10 +54,7 @@ func (dr *docRuntime) emit(s string) { dr.out.WriteString(s) }
 // emitHeading returns a binding that emits a Markdown ATX heading of the given
 // level followed by a blank line.
 func (dr *docRuntime) emitHeading(level int) lua.LGFunction {
-	prefix := ""
-	for i := 0; i < level; i++ {
-		prefix += "#"
-	}
+	prefix := strings.Repeat("#", level)
 	return func(ls *lua.LState) int {
 		text := ls.CheckString(1)
 		dr.emit(fmt.Sprintf("%s %s\n\n", prefix, text))
@@ -77,7 +75,7 @@ func (dr *docRuntime) luaCount(ls *lua.LState) int {
 	n := 0
 	for _, err := range dr.store.ListEntities(dr.ctx, store.EntityQuery{Type: typ}) {
 		if err != nil {
-			return dr.luaFail(ls, "resolve", "count{type=%q}: %v", typ, err)
+			return dr.luaFail(ls, "count{type=%q}: %v", typ, err)
 		}
 		n++
 	}
@@ -99,7 +97,7 @@ func (dr *docRuntime) luaCreate(ls *lua.LState) int {
 	id := dr.mintID(typ, props)
 	e := &entity.Entity{ID: id, Type: typ, Properties: props, Content: content}
 	if err := dr.store.CreateEntity(dr.ctx, e); err != nil {
-		return dr.luaFail(ls, "resolve", "create(%q): %v", typ, err)
+		return dr.luaFail(ls, "create(%q): %v", typ, err)
 	}
 	ls.Push(rlua.EntityToTable(ls, e))
 	return 1
@@ -112,7 +110,7 @@ func (dr *docRuntime) luaLink(ls *lua.LState) int {
 	relType := ls.CheckString(2)
 	to := idArg(ls, 3)
 	if _, err := dr.store.CreateRelation(dr.ctx, from, relType, to, nil); err != nil {
-		return dr.luaFail(ls, "resolve", "link(%q,%q,%q): %v", from, relType, to, err)
+		return dr.luaFail(ls, "link(%q,%q,%q): %v", from, relType, to, err)
 	}
 	return 0
 }

--- a/internal/docs/module.go
+++ b/internal/docs/module.go
@@ -1,0 +1,132 @@
+package docs
+
+import (
+	"fmt"
+
+	lua "github.com/yuin/gopher-lua"
+
+	"github.com/Sourcehaven-BV/rela/internal/entity"
+	rlua "github.com/Sourcehaven-BV/rela/internal/lua"
+	"github.com/Sourcehaven-BV/rela/internal/store"
+)
+
+// registerModule installs the `doc` table on the Lua state with the emit
+// helpers, resolvers, and raw-store seed bindings. Everything closes over dr
+// (no methods on the shared lua.Runtime — keeps its god-object surface flat).
+// The common emit/resolver names are also aliased into the global scope so an
+// island can write `h2("x")` / `typeref{...}` without the `doc.` prefix.
+func (dr *docRuntime) registerModule() {
+	L := dr.rt.LState()
+	doc := L.NewTable()
+
+	fns := map[string]lua.LGFunction{
+		// Emit helpers — append markdown to the statement-island buffer.
+		"h1": dr.emitHeading(1),
+		"h2": dr.emitHeading(2),
+		"h3": dr.emitHeading(3),
+		"md": dr.luaMD,
+		// Resolvers.
+		"count":        dr.luaCount,
+		"typeref":      dr.luaTyperef,
+		"values":       dr.luaValues,
+		"relations":    dr.luaRelations,
+		"entity":       dr.luaEntity,
+		"lifecycle":    dr.luaLifecycle,
+		"graph":        dr.luaGraph,
+		"roles_matrix": dr.luaRolesMatrix,
+		"description":  dr.luaDescription,
+		// Seed (raw store — no entitymanager, no validation).
+		"create": dr.luaCreate,
+		"link":   dr.luaLink,
+	}
+	for name, fn := range fns {
+		nf := L.NewFunction(fn)
+		L.SetField(doc, name, nf)
+		L.SetGlobal(name, nf) // ergonomic global alias
+	}
+	L.SetGlobal("doc", doc)
+}
+
+// emit appends s to the statement-island output buffer.
+func (dr *docRuntime) emit(s string) { dr.out.WriteString(s) }
+
+// emitHeading returns a binding that emits a Markdown ATX heading of the given
+// level followed by a blank line.
+func (dr *docRuntime) emitHeading(level int) lua.LGFunction {
+	prefix := ""
+	for i := 0; i < level; i++ {
+		prefix += "#"
+	}
+	return func(ls *lua.LState) int {
+		text := ls.CheckString(1)
+		dr.emit(fmt.Sprintf("%s %s\n\n", prefix, text))
+		return 0
+	}
+}
+
+// luaMD emits a block of markdown followed by a blank line.
+func (dr *docRuntime) luaMD(ls *lua.LState) int {
+	dr.emit(ls.CheckString(1) + "\n\n")
+	return 0
+}
+
+// luaCount returns the number of seeded entities of a type (echo-friendly).
+// count{type="risico"} or count("risico").
+func (dr *docRuntime) luaCount(ls *lua.LState) int {
+	typ := argString(ls, "type")
+	n := 0
+	for _, err := range dr.store.ListEntities(dr.ctx, store.EntityQuery{Type: typ}) {
+		if err != nil {
+			return dr.luaFail(ls, "resolve", "count{type=%q}: %v", typ, err)
+		}
+		n++
+	}
+	ls.Push(lua.LNumber(n))
+	return 1
+}
+
+// luaCreate seeds an entity directly into the memstore (raw store — no
+// validation, no state-machine gate, no ACL). create("risico", {props}, body?)
+// returns the created entity as a table (so the author can `link` it).
+func (dr *docRuntime) luaCreate(ls *lua.LState) int {
+	typ := ls.CheckString(1)
+	props := map[string]any{}
+	if tbl, ok := ls.Get(2).(*lua.LTable); ok {
+		props = luaTableToMap(tbl)
+	}
+	content := ls.OptString(3, "")
+
+	id := dr.mintID(typ, props)
+	e := &entity.Entity{ID: id, Type: typ, Properties: props, Content: content}
+	if err := dr.store.CreateEntity(dr.ctx, e); err != nil {
+		return dr.luaFail(ls, "resolve", "create(%q): %v", typ, err)
+	}
+	ls.Push(rlua.EntityToTable(ls, e))
+	return 1
+}
+
+// luaLink seeds a relation into the memstore. link(from, type, to) where from
+// may be an id string or an entity table (as returned by create).
+func (dr *docRuntime) luaLink(ls *lua.LState) int {
+	from := idArg(ls, 1)
+	relType := ls.CheckString(2)
+	to := idArg(ls, 3)
+	if _, err := dr.store.CreateRelation(dr.ctx, from, relType, to, nil); err != nil {
+		return dr.luaFail(ls, "resolve", "link(%q,%q,%q): %v", from, relType, to, err)
+	}
+	return 0
+}
+
+// mintID derives a stable id for a seeded entity: an explicit props.id if given,
+// else "<type>-<n>" by current count of that type. Fixture ids need only be
+// unique within the build.
+func (dr *docRuntime) mintID(typ string, props map[string]any) string {
+	if v, ok := props["id"].(string); ok && v != "" {
+		return v
+	}
+	n := 1
+	for range dr.store.ListEntities(dr.ctx, store.EntityQuery{Type: typ}) {
+		n++
+	}
+	return fmt.Sprintf("%s-%d", typ, n)
+}

--- a/internal/docs/module.go
+++ b/internal/docs/module.go
@@ -116,15 +116,15 @@ func (dr *docRuntime) luaLink(ls *lua.LState) int {
 }
 
 // mintID derives a stable id for a seeded entity: an explicit props.id if given,
-// else "<type>-<n>" by current count of that type. Fixture ids need only be
-// unique within the build.
+// else "<type>-<n>" from a per-type counter. Fixture ids need only be unique
+// within the build; the counter avoids an O(n²) full-store scan per create.
 func (dr *docRuntime) mintID(typ string, props map[string]any) string {
 	if v, ok := props["id"].(string); ok && v != "" {
 		return v
 	}
-	n := 1
-	for range dr.store.ListEntities(dr.ctx, store.EntityQuery{Type: typ}) {
-		n++
+	if dr.seedCounts == nil {
+		dr.seedCounts = map[string]int{}
 	}
-	return fmt.Sprintf("%s-%d", typ, n)
+	dr.seedCounts[typ]++
+	return fmt.Sprintf("%s-%d", typ, dr.seedCounts[typ])
 }

--- a/internal/docs/preprocess.go
+++ b/internal/docs/preprocess.go
@@ -135,6 +135,15 @@ func isGenericFenceOpen(trimmed string) bool {
 
 const echoMarker = "`rela "
 
+// isEchoExpr reports whether an inline `rela …` span's content is meant as a
+// resolver call rather than prose that merely mentions the word "rela" (e.g.
+// `rela docs build`, `rela init`). An echo expression is a function call, so it
+// must contain a call marker — "(" or "{". This keeps literal command mentions
+// in prose from being mistaken for islands.
+func isEchoExpr(expr string) bool {
+	return strings.ContainsAny(expr, "({")
+}
+
 // splitEchoes scans a literal run for inline echo spans and returns the
 // resulting segments (literal + echo, interleaved). An echo span is a single
 // backtick-delimited code span whose content starts with "rela " — e.g.
@@ -169,14 +178,16 @@ func splitEchoes(run string, startLine int) []segment {
 			end := strings.IndexByte(run[i+1:], '`')
 			if end >= 0 {
 				spanContent := run[i+1 : i+1+end] // between the backticks
-				if !strings.ContainsRune(spanContent, '\n') {
-					expr := strings.TrimSpace(strings.TrimPrefix(spanContent, "rela"))
+				expr := strings.TrimSpace(strings.TrimPrefix(spanContent, "rela"))
+				if !strings.ContainsRune(spanContent, '\n') && isEchoExpr(expr) {
 					appendLiteral()
 					segs = append(segs, segment{kind: segEcho, body: expr, line: line})
 					i = i + 1 + end + 1 // past the closing backtick
 					litLine = line
 					continue
 				}
+				// Not a resolver call (e.g. prose mentioning `rela docs build`):
+				// leave the whole span as literal text.
 			}
 		}
 		if lit.Len() == 0 {

--- a/internal/docs/preprocess.go
+++ b/internal/docs/preprocess.go
@@ -1,0 +1,190 @@
+// Package docs implements the rela-docs "doc language": a Markdown file with
+// embedded Lua "islands" that pull reference fragments from the schema and a
+// seeded in-memory graph.
+//
+// Two island forms (see segment):
+//   - Statement island — a fenced ```rela block. Its Lua runs for side effects;
+//     doc.* emit calls (h1/h2/md/…) and resolvers append markdown to an output
+//     buffer that is spliced in at the island's position.
+//   - Echo island — an inline `rela <expr>` code span. The expression is
+//     evaluated and its string value substituted mid-text.
+//
+// The preprocessor here is pure text→segments; execution lives in runtime.go.
+package docs
+
+import (
+	"strings"
+)
+
+// segmentKind classifies one parsed piece of a manual.
+type segmentKind int
+
+const (
+	segLiteral   segmentKind = iota // verbatim markdown, emitted unchanged
+	segStatement                    // a ```rela fenced block (runs for side effects)
+	segEcho                         // an inline `rela <expr>` span (substituted)
+)
+
+// segment is one parsed piece of the manual. Line is the 1-based source line
+// where the segment's content begins (the line after the opening ```rela fence
+// for a statement island; the line of the span for an echo island) — used to
+// report errors against the manual, not the island-internal offset.
+type segment struct {
+	kind segmentKind
+	body string // island Lua source, or literal text
+	line int    // 1-based manual line of body's first line
+}
+
+const fenceMarker = "```rela"
+
+// parse splits a manual into segments. It is deliberately line-oriented for the
+// fenced blocks (mirroring Markdown's own fence handling) and does an inline
+// scan for echo spans within literal runs.
+//
+// Fence rules: a line whose trimmed content is exactly "```rela" opens a
+// statement island; the island runs until a line whose trimmed content is
+// exactly "```". An unterminated fence is a parse error. A fence that is NOT
+// "```rela" (e.g. "```go", "```", or a plain "```rela-ish") is left in the
+// literal stream untouched — including any `rela …` spans inside it, so a code
+// sample showing the doc language renders literally.
+func parse(src string) ([]segment, error) {
+	lines := strings.Split(src, "\n")
+	var segs []segment
+	var literal strings.Builder
+	litStartLine := 1 // manual line where the current literal run began
+
+	flushLiteral := func() {
+		if literal.Len() == 0 {
+			return
+		}
+		// Expand echo spans within this literal run into their own segments.
+		segs = append(segs, splitEchoes(literal.String(), litStartLine)...)
+		literal.Reset()
+	}
+
+	i := 0
+	for i < len(lines) {
+		line := lines[i]
+		trimmed := strings.TrimSpace(line)
+
+		// A generic code fence that is NOT ```rela: consume the whole fenced
+		// block verbatim into the literal stream (no island parsing inside).
+		if isGenericFenceOpen(trimmed) && trimmed != fenceMarker {
+			literal.WriteString(line)
+			literal.WriteByte('\n')
+			i++
+			for i < len(lines) {
+				literal.WriteString(lines[i])
+				literal.WriteByte('\n')
+				closes := strings.TrimSpace(lines[i]) == "```"
+				i++
+				if closes {
+					break
+				}
+			}
+			continue
+		}
+
+		if trimmed == fenceMarker {
+			flushLiteral()
+			bodyStart := i + 2 // 1-based line of the first island body line
+			var island strings.Builder
+			i++
+			closed := false
+			for i < len(lines) {
+				if strings.TrimSpace(lines[i]) == "```" {
+					closed = true
+					i++
+					break
+				}
+				island.WriteString(lines[i])
+				island.WriteByte('\n')
+				i++
+			}
+			if !closed {
+				return nil, &BuildError{
+					Line: i, Kind: "parse",
+					Msg: "unterminated ```rela block (missing closing ```)",
+				}
+			}
+			segs = append(segs, segment{kind: segStatement, body: island.String(), line: bodyStart})
+			litStartLine = i + 1
+			continue
+		}
+
+		// Ordinary line: accumulate into the literal run.
+		if literal.Len() == 0 {
+			litStartLine = i + 1
+		}
+		literal.WriteString(line)
+		if i < len(lines)-1 {
+			literal.WriteByte('\n')
+		}
+		i++
+	}
+	flushLiteral()
+	return segs, nil
+}
+
+// isGenericFenceOpen reports whether a trimmed line opens a triple-backtick
+// fenced code block (```lang or bare ```). It does not match indented lines
+// beyond the trim already applied by the caller.
+func isGenericFenceOpen(trimmed string) bool {
+	return strings.HasPrefix(trimmed, "```")
+}
+
+const echoMarker = "`rela "
+
+// splitEchoes scans a literal run for inline echo spans and returns the
+// resulting segments (literal + echo, interleaved). An echo span is a single
+// backtick-delimited code span whose content starts with "rela " — e.g.
+// `rela count{type="x"}`. A code span that does not start with the marker is
+// left as literal text. startLine is the manual line of the run's first line;
+// echo segments carry the line on which their span begins.
+func splitEchoes(run string, startLine int) []segment {
+	var segs []segment
+	var lit strings.Builder
+	line := startLine
+	litLine := startLine
+
+	appendLiteral := func() {
+		if lit.Len() > 0 {
+			segs = append(segs, segment{kind: segLiteral, body: lit.String(), line: litLine})
+			lit.Reset()
+		}
+	}
+
+	i := 0
+	for i < len(run) {
+		c := run[i]
+		if c == '\n' {
+			lit.WriteByte(c)
+			line++
+			i++
+			continue
+		}
+		// Potential echo span: a backtick followed by "rela ".
+		if c == '`' && strings.HasPrefix(run[i:], "`"+echoMarker[1:]) {
+			// Find the closing backtick (a code span cannot contain a newline).
+			end := strings.IndexByte(run[i+1:], '`')
+			if end >= 0 {
+				spanContent := run[i+1 : i+1+end] // between the backticks
+				if !strings.ContainsRune(spanContent, '\n') {
+					expr := strings.TrimSpace(strings.TrimPrefix(spanContent, "rela"))
+					appendLiteral()
+					segs = append(segs, segment{kind: segEcho, body: expr, line: line})
+					i = i + 1 + end + 1 // past the closing backtick
+					litLine = line
+					continue
+				}
+			}
+		}
+		if lit.Len() == 0 {
+			litLine = line
+		}
+		lit.WriteByte(c)
+		i++
+	}
+	appendLiteral()
+	return segs
+}

--- a/internal/docs/preprocess.go
+++ b/internal/docs/preprocess.go
@@ -48,6 +48,9 @@ const fenceMarker = "```rela"
 // literal stream untouched — including any `rela …` spans inside it, so a code
 // sample showing the doc language renders literally.
 func parse(src string) ([]segment, error) {
+	// Normalize CRLF → LF so island bodies handed to Lua carry no stray \r and
+	// fence/marker matching is uniform. Output is LF (markdown is agnostic).
+	src = strings.ReplaceAll(src, "\r\n", "\n")
 	lines := strings.Split(src, "\n")
 	var segs []segment
 	var literal strings.Builder

--- a/internal/docs/preprocess_test.go
+++ b/internal/docs/preprocess_test.go
@@ -1,6 +1,7 @@
 package docs
 
 import (
+	"errors"
 	"testing"
 )
 
@@ -44,8 +45,8 @@ func TestParse_StatementIsland(t *testing.T) {
 func TestParse_UnterminatedFence(t *testing.T) {
 	t.Parallel()
 	_, err := parse("```rela\nh1(\"x\")\n")
-	be, ok := err.(*BuildError)
-	if !ok {
+	var be *BuildError
+	if !errors.As(err, &be) {
 		t.Fatalf("want *BuildError, got %T: %v", err, err)
 	}
 	if be.Kind != "parse" {
@@ -68,6 +69,36 @@ func TestParse_EchoSpan(t *testing.T) {
 	}
 	if segs[1].body != `count{type="x"}` {
 		t.Errorf("echo expr = %q", segs[1].body)
+	}
+}
+
+func TestParse_RelaProseMentionNotEcho(t *testing.T) {
+	t.Parallel()
+	// Prose mentioning a `rela …` command (no call syntax) must stay literal.
+	for _, src := range []string{
+		"Run `rela docs build` to render.\n",
+		"Use `rela init` first.\n",
+	} {
+		segs, err := parse(src)
+		if err != nil {
+			t.Fatalf("parse(%q): %v", src, err)
+		}
+		for _, s := range segs {
+			if s.kind == segEcho {
+				t.Errorf("prose command mention became an echo in %q: %+v", src, segs)
+			}
+		}
+	}
+	// But a real resolver call (has () or {}) IS an echo.
+	segs, _ := parse("count is `rela count{type=\"x\"}` here\n")
+	found := false
+	for _, s := range segs {
+		if s.kind == segEcho {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("resolver call should be an echo: %+v", segs)
 	}
 }
 

--- a/internal/docs/preprocess_test.go
+++ b/internal/docs/preprocess_test.go
@@ -1,0 +1,123 @@
+package docs
+
+import (
+	"testing"
+)
+
+func TestParse_LiteralOnly(t *testing.T) {
+	t.Parallel()
+	segs, err := parse("# Title\n\nSome prose.\n")
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if len(segs) != 1 || segs[0].kind != segLiteral {
+		t.Fatalf("want one literal segment, got %+v", segs)
+	}
+	if segs[0].body != "# Title\n\nSome prose.\n" {
+		t.Errorf("literal body = %q", segs[0].body)
+	}
+}
+
+func TestParse_StatementIsland(t *testing.T) {
+	t.Parallel()
+	src := "before\n```rela\nh2(\"X\")\nmd(\"y\")\n```\nafter\n"
+	segs, err := parse(src)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	// literal "before", statement island, literal "after".
+	if len(segs) != 3 {
+		t.Fatalf("want 3 segments, got %d: %+v", len(segs), segs)
+	}
+	if segs[1].kind != segStatement {
+		t.Fatalf("segment 1 should be statement, got %v", segs[1].kind)
+	}
+	if segs[1].body != "h2(\"X\")\nmd(\"y\")\n" {
+		t.Errorf("island body = %q", segs[1].body)
+	}
+	// The island body begins on manual line 3 (```rela is line 2).
+	if segs[1].line != 3 {
+		t.Errorf("island line = %d, want 3", segs[1].line)
+	}
+}
+
+func TestParse_UnterminatedFence(t *testing.T) {
+	t.Parallel()
+	_, err := parse("```rela\nh1(\"x\")\n")
+	be, ok := err.(*BuildError)
+	if !ok {
+		t.Fatalf("want *BuildError, got %T: %v", err, err)
+	}
+	if be.Kind != "parse" {
+		t.Errorf("kind = %q, want parse", be.Kind)
+	}
+}
+
+func TestParse_EchoSpan(t *testing.T) {
+	t.Parallel()
+	segs, err := parse("There are `rela count{type=\"x\"}` items.\n")
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	// literal "There are ", echo, literal " items.\n"
+	if len(segs) != 3 {
+		t.Fatalf("want 3 segments, got %d: %+v", len(segs), segs)
+	}
+	if segs[1].kind != segEcho {
+		t.Fatalf("middle segment should be echo, got %v", segs[1].kind)
+	}
+	if segs[1].body != `count{type="x"}` {
+		t.Errorf("echo expr = %q", segs[1].body)
+	}
+}
+
+func TestParse_NonRelaCodeSpanUntouched(t *testing.T) {
+	t.Parallel()
+	// A plain code span without the `rela ` marker must pass through as literal.
+	segs, err := parse("Use `go build` to compile.\n")
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	for _, s := range segs {
+		if s.kind == segEcho {
+			t.Fatalf("plain code span must not become an echo: %+v", segs)
+		}
+	}
+}
+
+func TestParse_RelaInsideGenericFenceIsLiteral(t *testing.T) {
+	t.Parallel()
+	// A ```go (or any non-rela) fenced block that *shows* the doc language must
+	// render literally — no island parsing inside.
+	src := "```markdown\n```rela\nh1(\"nope\")\n```\n```\nreal text\n"
+	segs, err := parse(src)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	for _, s := range segs {
+		if s.kind == segStatement {
+			t.Fatalf("no statement island should be parsed inside a generic fence: %+v", s)
+		}
+	}
+}
+
+func TestParse_EchoLineTracking(t *testing.T) {
+	t.Parallel()
+	src := "line1\nline2 `rela count{type=\"x\"}` end\nline3\n"
+	segs, err := parse(src)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	var echo *segment
+	for i := range segs {
+		if segs[i].kind == segEcho {
+			echo = &segs[i]
+		}
+	}
+	if echo == nil {
+		t.Fatal("expected an echo segment")
+	}
+	if echo.line != 2 {
+		t.Errorf("echo line = %d, want 2", echo.line)
+	}
+}

--- a/internal/docs/resolvers.go
+++ b/internal/docs/resolvers.go
@@ -2,25 +2,25 @@ package docs
 
 import (
 	"fmt"
+	"slices"
 	"sort"
 	"strings"
 
 	lua "github.com/yuin/gopher-lua"
 
 	"github.com/Sourcehaven-BV/rela/internal/metamodel"
-	"github.com/Sourcehaven-BV/rela/internal/store"
 )
 
 // entityDef looks up an entity type, raising a fail-loud resolve error naming
 // the type when unknown.
 func (dr *docRuntime) entityDef(ls *lua.LState, fn, typ string) (*metamodel.EntityDef, bool) {
 	if typ == "" {
-		dr.luaFail(ls, "resolve", "%s: `type` is required", fn)
+		dr.luaFail(ls, "%s: `type` is required", fn)
 		return nil, false
 	}
 	def, ok := dr.meta.GetEntityDef(typ)
 	if !ok {
-		dr.luaFail(ls, "resolve", "%s: unknown entity type %q", fn, typ)
+		dr.luaFail(ls, "%s: unknown entity type %q", fn, typ)
 		return nil, false
 	}
 	return def, true
@@ -74,6 +74,14 @@ func (dr *docRuntime) luaTyperef(ls *lua.LState) int {
 	return 0
 }
 
+// enumInfo is a property's resolved value set for the values resolver.
+type enumInfo struct {
+	values       []string
+	labels       map[string]string
+	descriptions map[string]string
+	def          string
+}
+
 // luaValues emits an enum field's allowed values, marking the default and
 // adding per-value meaning when CustomType.Descriptions is present.
 // values{type="risico", field="behandeling"}.
@@ -87,53 +95,64 @@ func (dr *docRuntime) luaValues(ls *lua.LState) int {
 	}
 	prop, ok := def.Properties[field]
 	if !ok {
-		return dr.luaFail(ls, "resolve", "values: %q has no field %q", typ, field)
+		return dr.luaFail(ls, "values: %q has no field %q", typ, field)
 	}
 
-	values, labels, descs, def2 := dr.resolveEnum(prop)
-	if len(values) == 0 {
-		return dr.luaFail(ls, "resolve", "values: field %q of %q is not an enum", field, typ)
+	e := dr.resolveEnum(prop)
+	if len(e.values) == 0 {
+		return dr.luaFail(ls, "values: field %q of %q is not an enum", field, typ)
 	}
 
-	var b strings.Builder
-	hasDesc := len(descs) > 0
-	if hasDesc {
-		b.WriteString("| Value | Meaning |\n|---|---|\n")
-		for _, v := range values {
-			shown := v
-			if l := labels[v]; l != "" {
-				shown = fmt.Sprintf("%s (`%s`)", l, v)
-			} else {
-				shown = fmt.Sprintf("`%s`", v)
-			}
-			if v == def2 {
-				shown += " _(default)_"
-			}
-			fmt.Fprintf(&b, "| %s | %s |\n", shown, mdCell(descs[v]))
-		}
+	if len(e.descriptions) > 0 {
+		dr.emit(e.renderTable())
 	} else {
-		for i, v := range values {
-			if i > 0 {
-				b.WriteString(" · ")
-			}
-			fmt.Fprintf(&b, "`%s`", v)
-			if v == def2 {
-				b.WriteString(" (default)")
-			}
+		dr.emit(e.renderList())
+	}
+	return 0
+}
+
+// renderTable renders enum values as a Value|Meaning table (used when the type
+// carries per-value descriptions).
+func (e enumInfo) renderTable() string {
+	var b strings.Builder
+	b.WriteString("| Value | Meaning |\n|---|---|\n")
+	for _, v := range e.values {
+		shown := fmt.Sprintf("`%s`", v)
+		if l := e.labels[v]; l != "" {
+			shown = fmt.Sprintf("%s (`%s`)", l, v)
+		}
+		if v == e.def {
+			shown += " _(default)_"
+		}
+		fmt.Fprintf(&b, "| %s | %s |\n", shown, mdCell(e.descriptions[v]))
+	}
+	b.WriteString("\n")
+	return b.String()
+}
+
+// renderList renders enum values as a compact inline list (no descriptions).
+func (e enumInfo) renderList() string {
+	var b strings.Builder
+	for i, v := range e.values {
+		if i > 0 {
+			b.WriteString(" · ")
+		}
+		fmt.Fprintf(&b, "`%s`", v)
+		if v == e.def {
+			b.WriteString(" (default)")
 		}
 	}
 	b.WriteString("\n\n")
-	dr.emit(b.String())
-	return 0
+	return b.String()
 }
 
 // resolveEnum returns the value set for a property: a named custom type's
 // values/labels/descriptions/default, else an inline enum's values.
-func (dr *docRuntime) resolveEnum(prop metamodel.PropertyDef) (values []string, labels, descs map[string]string, def string) {
+func (dr *docRuntime) resolveEnum(prop metamodel.PropertyDef) enumInfo {
 	if ct, named := dr.meta.Types[prop.Type]; named {
-		return ct.Values, ct.Labels, ct.Descriptions, ct.Default
+		return enumInfo{ct.Values, ct.Labels, ct.Descriptions, ct.Default}
 	}
-	return prop.Values, prop.Labels, nil, prop.Default
+	return enumInfo{prop.Values, prop.Labels, nil, prop.Default}
 }
 
 // luaRelations emits an entity type's outgoing relations as a list.
@@ -154,7 +173,7 @@ func (dr *docRuntime) luaRelations(ls *lua.LState) int {
 	var b strings.Builder
 	for _, name := range names {
 		rel := dr.meta.Relations[name]
-		if !containsStr(rel.From, typ) {
+		if !slices.Contains(rel.From, typ) {
 			continue
 		}
 		fmt.Fprintf(&b, "- `%s` → %s", name, strings.Join(rel.To, ", "))
@@ -177,11 +196,11 @@ func (dr *docRuntime) luaEntity(ls *lua.LState) int {
 		id = argString(ls, "id")
 	}
 	if id == "" {
-		return dr.luaFail(ls, "resolve", "entity: `id` is required")
+		return dr.luaFail(ls, "entity: `id` is required")
 	}
 	e, err := dr.store.GetEntity(dr.ctx, id)
 	if err != nil {
-		return dr.luaFail(ls, "resolve", "entity: %q not found in the seeded graph (did you create() it?)", id)
+		return dr.luaFail(ls, "entity: %q not found in the seeded graph (did you create() it?)", id)
 	}
 	wanted := fieldStringSlice(ls, tbl, "fields")
 
@@ -220,15 +239,6 @@ func (dr *docRuntime) luaDescription(ls *lua.LState) int {
 
 // --- small text helpers ---
 
-func containsStr(ss []string, s string) bool {
-	for _, x := range ss {
-		if x == s {
-			return true
-		}
-	}
-	return false
-}
-
 // oneLine collapses newlines so a description fits on a list line.
 func oneLine(s string) string {
 	s = strings.ReplaceAll(s, "\r\n", " ")
@@ -241,16 +251,4 @@ func oneLine(s string) string {
 func mdCell(s string) string {
 	s = oneLine(s)
 	return strings.ReplaceAll(s, "|", "\\|")
-}
-
-// countType is a small shared helper: number of seeded entities of a type.
-func (dr *docRuntime) countType(typ string) (int, error) {
-	n := 0
-	for _, err := range dr.store.ListEntities(dr.ctx, store.EntityQuery{Type: typ}) {
-		if err != nil {
-			return 0, err
-		}
-		n++
-	}
-	return n, nil
 }

--- a/internal/docs/resolvers.go
+++ b/internal/docs/resolvers.go
@@ -67,7 +67,7 @@ func (dr *docRuntime) luaTyperef(ls *lua.LState) int {
 		if p.Required {
 			req = "yes"
 		}
-		fmt.Fprintf(&b, "| `%s` | %s | %s |\n", name, typeName, req)
+		fmt.Fprintf(&b, "| `%s` | %s | %s |\n", mdCell(name), mdCell(typeName), req)
 	}
 	b.WriteString("\n")
 	dr.emit(b.String())
@@ -117,9 +117,9 @@ func (e enumInfo) renderTable() string {
 	var b strings.Builder
 	b.WriteString("| Value | Meaning |\n|---|---|\n")
 	for _, v := range e.values {
-		shown := fmt.Sprintf("`%s`", v)
+		shown := fmt.Sprintf("`%s`", mdCell(v))
 		if l := e.labels[v]; l != "" {
-			shown = fmt.Sprintf("%s (`%s`)", l, v)
+			shown = fmt.Sprintf("%s (`%s`)", mdCell(l), mdCell(v))
 		}
 		if v == e.def {
 			shown += " _(default)_"

--- a/internal/docs/resolvers.go
+++ b/internal/docs/resolvers.go
@@ -1,0 +1,256 @@
+package docs
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	lua "github.com/yuin/gopher-lua"
+
+	"github.com/Sourcehaven-BV/rela/internal/metamodel"
+	"github.com/Sourcehaven-BV/rela/internal/store"
+)
+
+// entityDef looks up an entity type, raising a fail-loud resolve error naming
+// the type when unknown.
+func (dr *docRuntime) entityDef(ls *lua.LState, fn, typ string) (*metamodel.EntityDef, bool) {
+	if typ == "" {
+		dr.luaFail(ls, "resolve", "%s: `type` is required", fn)
+		return nil, false
+	}
+	def, ok := dr.meta.GetEntityDef(typ)
+	if !ok {
+		dr.luaFail(ls, "resolve", "%s: unknown entity type %q", fn, typ)
+		return nil, false
+	}
+	return def, true
+}
+
+// propertyNames returns an entity type's properties in definition order, or
+// alphabetical when no order was captured.
+func propertyNames(def *metamodel.EntityDef) []string {
+	if order := def.GetPropertyOrder(); len(order) > 0 {
+		return order
+	}
+	names := make([]string, 0, len(def.Properties))
+	for n := range def.Properties {
+		names = append(names, n)
+	}
+	sort.Strings(names)
+	return names
+}
+
+// luaTyperef emits a Markdown table of an entity type's fields.
+// typeref{type="risico", fields="required"|"all"}.
+func (dr *docRuntime) luaTyperef(ls *lua.LState) int {
+	tbl := argTable(ls)
+	typ := fieldString(ls, tbl, "type")
+	which := fieldString(ls, tbl, "fields")
+	def, ok := dr.entityDef(ls, "typeref", typ)
+	if !ok {
+		return 0
+	}
+	requiredOnly := which == "required"
+
+	var b strings.Builder
+	b.WriteString("| Field | Type | Required |\n|---|---|---|\n")
+	for _, name := range propertyNames(def) {
+		p := def.Properties[name]
+		if requiredOnly && !p.Required {
+			continue
+		}
+		typeName := p.Type
+		if typeName == "" {
+			typeName = "string"
+		}
+		req := ""
+		if p.Required {
+			req = "yes"
+		}
+		fmt.Fprintf(&b, "| `%s` | %s | %s |\n", name, typeName, req)
+	}
+	b.WriteString("\n")
+	dr.emit(b.String())
+	return 0
+}
+
+// luaValues emits an enum field's allowed values, marking the default and
+// adding per-value meaning when CustomType.Descriptions is present.
+// values{type="risico", field="behandeling"}.
+func (dr *docRuntime) luaValues(ls *lua.LState) int {
+	tbl := argTable(ls)
+	typ := fieldString(ls, tbl, "type")
+	field := fieldString(ls, tbl, "field")
+	def, ok := dr.entityDef(ls, "values", typ)
+	if !ok {
+		return 0
+	}
+	prop, ok := def.Properties[field]
+	if !ok {
+		return dr.luaFail(ls, "resolve", "values: %q has no field %q", typ, field)
+	}
+
+	values, labels, descs, def2 := dr.resolveEnum(prop)
+	if len(values) == 0 {
+		return dr.luaFail(ls, "resolve", "values: field %q of %q is not an enum", field, typ)
+	}
+
+	var b strings.Builder
+	hasDesc := len(descs) > 0
+	if hasDesc {
+		b.WriteString("| Value | Meaning |\n|---|---|\n")
+		for _, v := range values {
+			shown := v
+			if l := labels[v]; l != "" {
+				shown = fmt.Sprintf("%s (`%s`)", l, v)
+			} else {
+				shown = fmt.Sprintf("`%s`", v)
+			}
+			if v == def2 {
+				shown += " _(default)_"
+			}
+			fmt.Fprintf(&b, "| %s | %s |\n", shown, mdCell(descs[v]))
+		}
+	} else {
+		for i, v := range values {
+			if i > 0 {
+				b.WriteString(" · ")
+			}
+			fmt.Fprintf(&b, "`%s`", v)
+			if v == def2 {
+				b.WriteString(" (default)")
+			}
+		}
+	}
+	b.WriteString("\n\n")
+	dr.emit(b.String())
+	return 0
+}
+
+// resolveEnum returns the value set for a property: a named custom type's
+// values/labels/descriptions/default, else an inline enum's values.
+func (dr *docRuntime) resolveEnum(prop metamodel.PropertyDef) (values []string, labels, descs map[string]string, def string) {
+	if ct, named := dr.meta.Types[prop.Type]; named {
+		return ct.Values, ct.Labels, ct.Descriptions, ct.Default
+	}
+	return prop.Values, prop.Labels, nil, prop.Default
+}
+
+// luaRelations emits an entity type's outgoing relations as a list.
+// relations{type="bedrijfsmiddel"}.
+func (dr *docRuntime) luaRelations(ls *lua.LState) int {
+	tbl := argTable(ls)
+	typ := fieldString(ls, tbl, "type")
+	if _, ok := dr.entityDef(ls, "relations", typ); !ok {
+		return 0
+	}
+
+	names := make([]string, 0, len(dr.meta.Relations))
+	for name := range dr.meta.Relations {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	var b strings.Builder
+	for _, name := range names {
+		rel := dr.meta.Relations[name]
+		if !containsStr(rel.From, typ) {
+			continue
+		}
+		fmt.Fprintf(&b, "- `%s` → %s", name, strings.Join(rel.To, ", "))
+		if rel.Description != "" {
+			fmt.Fprintf(&b, " — %s", oneLine(rel.Description))
+		}
+		b.WriteString("\n")
+	}
+	b.WriteString("\n")
+	dr.emit(b.String())
+	return 0
+}
+
+// luaEntity emits one seeded entity's fields as a definition list.
+// entity{id="risico-1", fields={"kans","impact"}}.
+func (dr *docRuntime) luaEntity(ls *lua.LState) int {
+	tbl := argTable(ls)
+	id := fieldString(ls, tbl, "id")
+	if id == "" {
+		id = argString(ls, "id")
+	}
+	if id == "" {
+		return dr.luaFail(ls, "resolve", "entity: `id` is required")
+	}
+	e, err := dr.store.GetEntity(dr.ctx, id)
+	if err != nil {
+		return dr.luaFail(ls, "resolve", "entity: %q not found in the seeded graph (did you create() it?)", id)
+	}
+	wanted := fieldStringSlice(ls, tbl, "fields")
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "**%s**\n\n", id)
+	emitField := func(name string) {
+		if v, ok := e.Properties[name]; ok {
+			fmt.Fprintf(&b, "- %s: %v\n", name, v)
+		}
+	}
+	if len(wanted) > 0 {
+		for _, name := range wanted {
+			emitField(name)
+		}
+	} else {
+		keys := make([]string, 0, len(e.Properties))
+		for k := range e.Properties {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
+			emitField(k)
+		}
+	}
+	b.WriteString("\n")
+	dr.emit(b.String())
+	return 0
+}
+
+// luaDescription returns the deployment's top-level description (metamodel), or
+// empty (subject to strict mode at the echo site). description().
+func (dr *docRuntime) luaDescription(ls *lua.LState) int {
+	ls.Push(lua.LString(dr.meta.Description))
+	return 1
+}
+
+// --- small text helpers ---
+
+func containsStr(ss []string, s string) bool {
+	for _, x := range ss {
+		if x == s {
+			return true
+		}
+	}
+	return false
+}
+
+// oneLine collapses newlines so a description fits on a list line.
+func oneLine(s string) string {
+	s = strings.ReplaceAll(s, "\r\n", " ")
+	s = strings.ReplaceAll(s, "\n", " ")
+	return strings.TrimSpace(s)
+}
+
+// mdCell makes a string safe inside a Markdown table cell (flatten newlines,
+// escape pipes).
+func mdCell(s string) string {
+	s = oneLine(s)
+	return strings.ReplaceAll(s, "|", "\\|")
+}
+
+// countType is a small shared helper: number of seeded entities of a type.
+func (dr *docRuntime) countType(typ string) (int, error) {
+	n := 0
+	for _, err := range dr.store.ListEntities(dr.ctx, store.EntityQuery{Type: typ}) {
+		if err != nil {
+			return 0, err
+		}
+		n++
+	}
+	return n, nil
+}

--- a/internal/docs/resolvers_acl.go
+++ b/internal/docs/resolvers_acl.go
@@ -24,7 +24,7 @@ func (dr *docRuntime) luaRolesMatrix(ls *lua.LState) int {
 
 	types := dr.matrixTypes(typ)
 	if len(types) == 0 {
-		return dr.luaFail(ls, "resolve", "roles_matrix: unknown entity type %q", typ)
+		return dr.luaFail(ls, "roles_matrix: unknown entity type %q", typ)
 	}
 	roles := sortedRoleNames(dr.policy.Roles)
 	if len(roles) == 0 {
@@ -58,7 +58,7 @@ func (dr *docRuntime) luaRolesMatrix(ls *lua.LState) int {
 			fmt.Fprintf(&b, "| `%s` | %s |", t, v.name)
 			for _, rn := range roles {
 				role := dr.policy.Roles[rn]
-				granted := false
+				var granted bool
 				if v.name == "read" {
 					granted = grantsList(role.Read, t)
 				} else {

--- a/internal/docs/resolvers_acl.go
+++ b/internal/docs/resolvers_acl.go
@@ -1,0 +1,124 @@
+package docs
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	lua "github.com/yuin/gopher-lua"
+
+	"github.com/Sourcehaven-BV/rela/internal/acl"
+)
+
+// luaRolesMatrix emits a role × verb capability table for an entity type (or,
+// with no type, for every type). Rows are entity types (from the metamodel),
+// columns are roles (from the policy). A ✓ means the role grants that verb on
+// that type. roles_matrix{type="risico"} or roles_matrix{}.
+func (dr *docRuntime) luaRolesMatrix(ls *lua.LState) int {
+	if dr.policy == nil {
+		dr.emit("_No access policy defined (no `acl.yaml`)._\n\n")
+		return 0
+	}
+	tbl := argTable(ls)
+	typ := fieldString(ls, tbl, "type")
+
+	types := dr.matrixTypes(typ)
+	if len(types) == 0 {
+		return dr.luaFail(ls, "resolve", "roles_matrix: unknown entity type %q", typ)
+	}
+	roles := sortedRoleNames(dr.policy.Roles)
+	if len(roles) == 0 {
+		dr.emit("_No roles defined in the policy._\n\n")
+		return 0
+	}
+
+	var b strings.Builder
+	// Header: Type | Verb | role1 | role2 ...
+	b.WriteString("| Type | Verb |")
+	for _, r := range roles {
+		fmt.Fprintf(&b, " %s |", r)
+	}
+	b.WriteString("\n|---|---|")
+	for range roles {
+		b.WriteString("---|")
+	}
+	b.WriteString("\n")
+
+	verbs := []struct {
+		name string
+		op   acl.Op
+	}{
+		{"create", acl.OpCreate},
+		{"read", ""}, // read handled specially
+		{"update", acl.OpUpdate},
+		{"delete", acl.OpDelete},
+	}
+	for _, t := range types {
+		for _, v := range verbs {
+			fmt.Fprintf(&b, "| `%s` | %s |", t, v.name)
+			for _, rn := range roles {
+				role := dr.policy.Roles[rn]
+				granted := false
+				if v.name == "read" {
+					granted = grantsList(role.Read, t)
+				} else {
+					granted = grantsVerb(role, v.op, t)
+				}
+				if granted {
+					b.WriteString(" ✓ |")
+				} else {
+					b.WriteString("  |")
+				}
+			}
+			b.WriteString("\n")
+		}
+	}
+	b.WriteString("\n")
+	dr.emit(b.String())
+	return 0
+}
+
+// matrixTypes returns the requested type (validated) or all entity types.
+func (dr *docRuntime) matrixTypes(typ string) []string {
+	if typ != "" {
+		if _, ok := dr.meta.GetEntityDef(typ); !ok {
+			return nil
+		}
+		return []string{typ}
+	}
+	all := dr.meta.EntityTypes()
+	sort.Strings(all)
+	return all
+}
+
+// grantsVerb / grantsList replicate the policy's wildcard-or-exact match over
+// the exported RoleDef grant lists (the policy's own helpers are unexported).
+func grantsVerb(role acl.RoleDef, op acl.Op, target string) bool {
+	switch op {
+	case acl.OpCreate:
+		return grantsList(role.Create, target)
+	case acl.OpUpdate, acl.OpRename:
+		return grantsList(role.Update, target)
+	case acl.OpDelete:
+		return grantsList(role.Delete, target)
+	}
+	return false
+}
+
+func grantsList(list []string, target string) bool {
+	for _, t := range list {
+		if t == "*" || t == target {
+			return true
+		}
+	}
+	return false
+}
+
+func sortedRoleNames(roles map[string]acl.RoleDef) []string {
+	names := make([]string, 0, len(roles))
+	for n := range roles {
+		names = append(names, n)
+	}
+	sort.Strings(names)
+	return names
+}

--- a/internal/docs/resolvers_acl.go
+++ b/internal/docs/resolvers_acl.go
@@ -26,14 +26,18 @@ func (dr *docRuntime) luaRolesMatrix(ls *lua.LState) int {
 	if len(types) == 0 {
 		return dr.luaFail(ls, "roles_matrix: unknown entity type %q", typ)
 	}
-	roles := sortedRoleNames(dr.policy.Roles)
-	if len(roles) == 0 {
+	// The built-in "everyone" role is not a column: acl appends it to EVERY
+	// principal's effective role set, so its grants must be folded into every
+	// named role's cell (else the table understates effective access — the whole
+	// point of the matrix). It is reported once, in a footnote.
+	everyone, hasEveryone := dr.policy.Roles[acl.EveryoneRole]
+	roles := namedRoleNames(dr.policy.Roles)
+	if len(roles) == 0 && !hasEveryone {
 		dr.emit("_No roles defined in the policy._\n\n")
 		return 0
 	}
 
 	var b strings.Builder
-	// Header: Type | Verb | role1 | role2 ...
 	b.WriteString("| Type | Verb |")
 	for _, r := range roles {
 		fmt.Fprintf(&b, " %s |", r)
@@ -44,27 +48,23 @@ func (dr *docRuntime) luaRolesMatrix(ls *lua.LState) int {
 	}
 	b.WriteString("\n")
 
-	verbs := []struct {
-		name string
-		op   acl.Op
-	}{
+	verbs := []verbSpec{
 		{"create", acl.OpCreate},
 		{"read", ""}, // read handled specially
 		{"update", acl.OpUpdate},
 		{"delete", acl.OpDelete},
 	}
+	everyoneGrantsAny := false
 	for _, t := range types {
 		for _, v := range verbs {
-			fmt.Fprintf(&b, "| `%s` | %s |", t, v.name)
+			fmt.Fprintf(&b, "| `%s` | %s |", mdCell(t), v.name)
+			everyoneGrant := hasEveryone && roleGrantsVerb(everyone, v, t)
+			if everyoneGrant {
+				everyoneGrantsAny = true
+			}
 			for _, rn := range roles {
-				role := dr.policy.Roles[rn]
-				var granted bool
-				if v.name == "read" {
-					granted = grantsList(role.Read, t)
-				} else {
-					granted = grantsVerb(role, v.op, t)
-				}
-				if granted {
+				// Effective grant = the role's own grant OR everyone's.
+				if roleGrantsVerb(dr.policy.Roles[rn], v, t) || everyoneGrant {
 					b.WriteString(" ✓ |")
 				} else {
 					b.WriteString("  |")
@@ -74,8 +74,28 @@ func (dr *docRuntime) luaRolesMatrix(ls *lua.LState) int {
 		}
 	}
 	b.WriteString("\n")
+	if everyoneGrantsAny {
+		b.WriteString("_✓ cells include grants from the built-in `everyone` role " +
+			"(applies to all principals, incl. unauthenticated)._\n\n")
+	}
 	dr.emit(b.String())
 	return 0
+}
+
+// verbSpec pairs a matrix column verb name with its acl.Op (read has none — it
+// is a separate grant list).
+type verbSpec struct {
+	name string
+	op   acl.Op
+}
+
+// roleGrantsVerb reports whether a role grants the given verb on a type,
+// dispatching read (a separate list) from the create/update/delete verbs.
+func roleGrantsVerb(role acl.RoleDef, v verbSpec, typ string) bool {
+	if v.name == "read" {
+		return grantsList(role.Read, typ)
+	}
+	return grantsVerb(role, v.op, typ)
 }
 
 // matrixTypes returns the requested type (validated) or all entity types.
@@ -114,9 +134,14 @@ func grantsList(list []string, target string) bool {
 	return false
 }
 
-func sortedRoleNames(roles map[string]acl.RoleDef) []string {
+// namedRoleNames returns the policy's role names sorted, EXCLUDING the built-in
+// "everyone" role (which is folded into every column rather than shown as one).
+func namedRoleNames(roles map[string]acl.RoleDef) []string {
 	names := make([]string, 0, len(roles))
 	for n := range roles {
+		if n == acl.EveryoneRole {
+			continue
+		}
 		names = append(names, n)
 	}
 	sort.Strings(names)

--- a/internal/docs/resolvers_graph.go
+++ b/internal/docs/resolvers_graph.go
@@ -1,0 +1,280 @@
+package docs
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	lua "github.com/yuin/gopher-lua"
+
+	"github.com/Sourcehaven-BV/rela/internal/mermaid"
+	"github.com/Sourcehaven-BV/rela/internal/metamodel"
+	"github.com/Sourcehaven-BV/rela/internal/tracer"
+)
+
+const (
+	graphDefaultDepth = 2
+	graphMaxDepth     = 5
+)
+
+// luaLifecycle emits a mermaid state diagram for a state-machine field, or a
+// flat value list when the field's custom type declares no transitions.
+// lifecycle{type="risico", field="status"}.
+func (dr *docRuntime) luaLifecycle(ls *lua.LState) int {
+	tbl := argTable(ls)
+	typ := fieldString(ls, tbl, "type")
+	field := fieldString(ls, tbl, "field")
+	def, ok := dr.entityDef(ls, "lifecycle", typ)
+	if !ok {
+		return 0
+	}
+	prop, ok := def.Properties[field]
+	if !ok {
+		return dr.luaFail(ls, "resolve", "lifecycle: %q has no field %q", typ, field)
+	}
+	ct, named := dr.meta.Types[prop.Type]
+	if !named {
+		return dr.luaFail(ls, "resolve", "lifecycle: field %q of %q is not a named enum/state machine", field, typ)
+	}
+
+	if len(ct.Transitions) == 0 {
+		// Flat enum: no state machine — fall back to a value list.
+		var b strings.Builder
+		for i, v := range ct.Values {
+			if i > 0 {
+				b.WriteString(" · ")
+			}
+			fmt.Fprintf(&b, "`%s`", v)
+		}
+		b.WriteString("\n\n")
+		dr.emit(b.String())
+		return 0
+	}
+
+	initial := ct.Initial
+	if initial == "" {
+		initial = ct.Default
+	}
+	ts := make([]mermaid.Transition, 0, len(ct.Transitions))
+	for _, tr := range ct.Transitions {
+		label := tr.Label
+		if label == "" {
+			label = tr.To
+		}
+		ts = append(ts, mermaid.Transition{From: tr.From, To: tr.To, Label: label})
+	}
+	dr.emit("```mermaid\n" + mermaid.StateDiagram(initial, ts) + "```\n\n")
+	return 0
+}
+
+// luaGraph emits a mermaid flow graph. Two grains by the `from` value:
+//   - an entity TYPE → the schema neighbourhood (which types connect to which),
+//     read from the metamodel.
+//   - an entity ID → the seeded instance neighbourhood, traversed via tracer.
+//
+// graph{from=..., depth=2, direction="out"|"in"|"both", exclude={...}, only={...}}.
+func (dr *docRuntime) luaGraph(ls *lua.LState) int {
+	tbl := argTable(ls)
+	from := fieldString(ls, tbl, "from")
+	if from == "" {
+		return dr.luaFail(ls, "resolve", "graph: `from` is required")
+	}
+	depth := clampDepth(fieldInt(ls, tbl, "depth", graphDefaultDepth))
+	direction := fieldString(ls, tbl, "direction")
+	if direction == "" {
+		direction = "out"
+	}
+	exclude := fieldStringSlice(ls, tbl, "exclude")
+	only := fieldStringSlice(ls, tbl, "only")
+	if len(exclude) > 0 && len(only) > 0 {
+		return dr.luaFail(ls, "resolve", "graph: `exclude` and `only` are mutually exclusive")
+	}
+	filter := relFilter{exclude: toSet(exclude), only: toSet(only)}
+
+	if _, isType := dr.meta.GetEntityDef(from); isType {
+		dr.emit(dr.schemaGraph(from, depth, direction, filter))
+		return 0
+	}
+	// Otherwise treat `from` as an instance id.
+	if _, err := dr.store.GetEntity(dr.ctx, from); err != nil {
+		return dr.luaFail(ls, "resolve", "graph: %q is neither an entity type nor a seeded id", from)
+	}
+	dr.emit(dr.instanceGraph(from, depth, direction, filter))
+	return 0
+}
+
+// relFilter selects which relation types survive. only wins if set; else
+// exclude prunes; empty means keep all.
+type relFilter struct {
+	exclude map[string]bool
+	only    map[string]bool
+}
+
+func (f relFilter) keep(rel string) bool {
+	if len(f.only) > 0 {
+		return f.only[rel]
+	}
+	return !f.exclude[rel]
+}
+
+// instanceGraph traverses the seeded memstore from an id and renders it. The
+// tracer is bidirectional; direction filters on the child's .Incoming flag,
+// which is SEPARATE from the relation-type filter.
+func (dr *docRuntime) instanceGraph(id string, depth int, direction string, filter relFilter) string {
+	var res *tracer.TraceResult
+	if direction == "in" {
+		res = dr.tracer.TraceTo(dr.ctx, id, depth)
+	} else {
+		res = dr.tracer.TraceFrom(dr.ctx, id, depth)
+	}
+
+	nodes := map[string]mermaid.Node{}
+	var nodeOrder []string
+	var edges []mermaid.Edge
+	seenEdge := map[string]bool{}
+
+	addNode := func(key, text string) {
+		if _, ok := nodes[key]; !ok {
+			nodes[key] = mermaid.Node{Key: key, Text: text}
+			nodeOrder = append(nodeOrder, key)
+		}
+	}
+	addNode(res.ID, nodeLabel(res.ID, res.Title))
+
+	var walk func(n *tracer.TraceResult)
+	walk = func(n *tracer.TraceResult) {
+		for _, c := range n.Children {
+			// Direction filter: "out" keeps only outgoing edges; "in" already
+			// used TraceTo (all incoming); "both" keeps everything. A
+			// relation-type filter (exclude/only) is SEPARATE. When an edge is
+			// filtered out we still recurse into the child so a pruned edge
+			// doesn't sever the subgraph beyond it.
+			edgeKept := !(direction == "out" && c.Incoming) && filter.keep(c.Relation)
+			if edgeKept {
+				addNode(c.ID, nodeLabel(c.ID, c.Title))
+				fromKey, toKey := n.ID, c.ID
+				if c.Incoming {
+					fromKey, toKey = c.ID, n.ID
+				}
+				ek := fromKey + "\x00" + c.Relation + "\x00" + toKey
+				if !seenEdge[ek] {
+					seenEdge[ek] = true
+					edges = append(edges, mermaid.Edge{FromKey: fromKey, ToKey: toKey, Label: c.Relation})
+				}
+			}
+			walk(c)
+		}
+	}
+	walk(res)
+
+	return renderGraph(nodeOrder, nodes, edges)
+}
+
+// schemaGraph renders the metamodel neighbourhood of an entity type: a BFS over
+// relation definitions to the given depth.
+func (dr *docRuntime) schemaGraph(root string, depth int, direction string, filter relFilter) string {
+	nodes := map[string]mermaid.Node{}
+	var nodeOrder []string
+	var edges []mermaid.Edge
+	seenEdge := map[string]bool{}
+	addNode := func(t string) {
+		if _, ok := nodes[t]; !ok {
+			nodes[t] = mermaid.Node{Key: t, Text: t}
+			nodeOrder = append(nodeOrder, t)
+		}
+	}
+	addNode(root)
+
+	frontier := []string{root}
+	visited := map[string]bool{root: true}
+	relNames := sortedRelNames(dr.meta.Relations)
+
+	for d := 0; d < depth && len(frontier) > 0; d++ {
+		var next []string
+		for _, typ := range frontier {
+			for _, name := range relNames {
+				rel := dr.meta.Relations[name]
+				if !filter.keep(name) {
+					continue
+				}
+				// outgoing: typ in From → each To; incoming: typ in To → each From.
+				if direction != "in" && containsStr(rel.From, typ) {
+					for _, to := range rel.To {
+						addNode(to)
+						addSchemaEdge(&edges, seenEdge, typ, name, to)
+						if !visited[to] {
+							visited[to] = true
+							next = append(next, to)
+						}
+					}
+				}
+				if direction != "out" && containsStr(rel.To, typ) {
+					for _, fromT := range rel.From {
+						addNode(fromT)
+						addSchemaEdge(&edges, seenEdge, fromT, name, typ)
+						if !visited[fromT] {
+							visited[fromT] = true
+							next = append(next, fromT)
+						}
+					}
+				}
+			}
+		}
+		frontier = next
+	}
+	return renderGraph(nodeOrder, nodes, edges)
+}
+
+func addSchemaEdge(edges *[]mermaid.Edge, seen map[string]bool, from, rel, to string) {
+	ek := from + "\x00" + rel + "\x00" + to
+	if seen[ek] {
+		return
+	}
+	seen[ek] = true
+	*edges = append(*edges, mermaid.Edge{FromKey: from, ToKey: to, Label: rel})
+}
+
+func renderGraph(order []string, nodes map[string]mermaid.Node, edges []mermaid.Edge) string {
+	ns := make([]mermaid.Node, 0, len(order))
+	for _, k := range order {
+		ns = append(ns, nodes[k])
+	}
+	return "```mermaid\n" + mermaid.Graph(ns, edges) + "```\n\n"
+}
+
+func nodeLabel(id, title string) string {
+	if title != "" {
+		return title
+	}
+	return id
+}
+
+func clampDepth(d int) int {
+	if d < 1 {
+		return graphDefaultDepth
+	}
+	if d > graphMaxDepth {
+		return graphMaxDepth
+	}
+	return d
+}
+
+func toSet(ss []string) map[string]bool {
+	if len(ss) == 0 {
+		return nil
+	}
+	m := make(map[string]bool, len(ss))
+	for _, s := range ss {
+		m[s] = true
+	}
+	return m
+}
+
+func sortedRelNames(rels map[string]metamodel.RelationDef) []string {
+	names := make([]string, 0, len(rels))
+	for n := range rels {
+		names = append(names, n)
+	}
+	sort.Strings(names)
+	return names
+}

--- a/internal/docs/resolvers_graph.go
+++ b/internal/docs/resolvers_graph.go
@@ -2,6 +2,7 @@ package docs
 
 import (
 	"fmt"
+	"slices"
 	"sort"
 	"strings"
 
@@ -30,11 +31,11 @@ func (dr *docRuntime) luaLifecycle(ls *lua.LState) int {
 	}
 	prop, ok := def.Properties[field]
 	if !ok {
-		return dr.luaFail(ls, "resolve", "lifecycle: %q has no field %q", typ, field)
+		return dr.luaFail(ls, "lifecycle: %q has no field %q", typ, field)
 	}
 	ct, named := dr.meta.Types[prop.Type]
 	if !named {
-		return dr.luaFail(ls, "resolve", "lifecycle: field %q of %q is not a named enum/state machine", field, typ)
+		return dr.luaFail(ls, "lifecycle: field %q of %q is not a named enum/state machine", field, typ)
 	}
 
 	if len(ct.Transitions) == 0 {
@@ -68,16 +69,16 @@ func (dr *docRuntime) luaLifecycle(ls *lua.LState) int {
 }
 
 // luaGraph emits a mermaid flow graph. Two grains by the `from` value:
-//   - an entity TYPE → the schema neighbourhood (which types connect to which),
+//   - an entity TYPE → the schema neighborhood (which types connect to which),
 //     read from the metamodel.
-//   - an entity ID → the seeded instance neighbourhood, traversed via tracer.
+//   - an entity ID → the seeded instance neighborhood, traversed via tracer.
 //
 // graph{from=..., depth=2, direction="out"|"in"|"both", exclude={...}, only={...}}.
 func (dr *docRuntime) luaGraph(ls *lua.LState) int {
 	tbl := argTable(ls)
 	from := fieldString(ls, tbl, "from")
 	if from == "" {
-		return dr.luaFail(ls, "resolve", "graph: `from` is required")
+		return dr.luaFail(ls, "graph: `from` is required")
 	}
 	depth := clampDepth(fieldInt(ls, tbl, "depth", graphDefaultDepth))
 	direction := fieldString(ls, tbl, "direction")
@@ -87,7 +88,7 @@ func (dr *docRuntime) luaGraph(ls *lua.LState) int {
 	exclude := fieldStringSlice(ls, tbl, "exclude")
 	only := fieldStringSlice(ls, tbl, "only")
 	if len(exclude) > 0 && len(only) > 0 {
-		return dr.luaFail(ls, "resolve", "graph: `exclude` and `only` are mutually exclusive")
+		return dr.luaFail(ls, "graph: `exclude` and `only` are mutually exclusive")
 	}
 	filter := relFilter{exclude: toSet(exclude), only: toSet(only)}
 
@@ -97,7 +98,7 @@ func (dr *docRuntime) luaGraph(ls *lua.LState) int {
 	}
 	// Otherwise treat `from` as an instance id.
 	if _, err := dr.store.GetEntity(dr.ctx, from); err != nil {
-		return dr.luaFail(ls, "resolve", "graph: %q is neither an entity type nor a seeded id", from)
+		return dr.luaFail(ls, "graph: %q is neither an entity type nor a seeded id", from)
 	}
 	dr.emit(dr.instanceGraph(from, depth, direction, filter))
 	return 0
@@ -149,7 +150,7 @@ func (dr *docRuntime) instanceGraph(id string, depth int, direction string, filt
 			// relation-type filter (exclude/only) is SEPARATE. When an edge is
 			// filtered out we still recurse into the child so a pruned edge
 			// doesn't sever the subgraph beyond it.
-			edgeKept := !(direction == "out" && c.Incoming) && filter.keep(c.Relation)
+			edgeKept := (direction != "out" || !c.Incoming) && filter.keep(c.Relation)
 			if edgeKept {
 				addNode(c.ID, nodeLabel(c.ID, c.Title))
 				fromKey, toKey := n.ID, c.ID
@@ -170,20 +171,11 @@ func (dr *docRuntime) instanceGraph(id string, depth int, direction string, filt
 	return renderGraph(nodeOrder, nodes, edges)
 }
 
-// schemaGraph renders the metamodel neighbourhood of an entity type: a BFS over
+// schemaGraph renders the metamodel neighborhood of an entity type: a BFS over
 // relation definitions to the given depth.
 func (dr *docRuntime) schemaGraph(root string, depth int, direction string, filter relFilter) string {
-	nodes := map[string]mermaid.Node{}
-	var nodeOrder []string
-	var edges []mermaid.Edge
-	seenEdge := map[string]bool{}
-	addNode := func(t string) {
-		if _, ok := nodes[t]; !ok {
-			nodes[t] = mermaid.Node{Key: t, Text: t}
-			nodeOrder = append(nodeOrder, t)
-		}
-	}
-	addNode(root)
+	sb := &schemaBuilder{nodes: map[string]mermaid.Node{}, seenEdge: map[string]bool{}}
+	sb.addNode(root)
 
 	frontier := []string{root}
 	visited := map[string]bool{root: true}
@@ -193,45 +185,68 @@ func (dr *docRuntime) schemaGraph(root string, depth int, direction string, filt
 		var next []string
 		for _, typ := range frontier {
 			for _, name := range relNames {
-				rel := dr.meta.Relations[name]
 				if !filter.keep(name) {
 					continue
 				}
-				// outgoing: typ in From → each To; incoming: typ in To → each From.
-				if direction != "in" && containsStr(rel.From, typ) {
-					for _, to := range rel.To {
-						addNode(to)
-						addSchemaEdge(&edges, seenEdge, typ, name, to)
-						if !visited[to] {
-							visited[to] = true
-							next = append(next, to)
-						}
-					}
-				}
-				if direction != "out" && containsStr(rel.To, typ) {
-					for _, fromT := range rel.From {
-						addNode(fromT)
-						addSchemaEdge(&edges, seenEdge, fromT, name, typ)
-						if !visited[fromT] {
-							visited[fromT] = true
-							next = append(next, fromT)
-						}
-					}
-				}
+				next = append(next, sb.expand(dr.meta.Relations[name], name, typ, direction, visited)...)
 			}
 		}
 		frontier = next
 	}
-	return renderGraph(nodeOrder, nodes, edges)
+	return renderGraph(sb.nodeOrder, sb.nodes, sb.edges)
 }
 
-func addSchemaEdge(edges *[]mermaid.Edge, seen map[string]bool, from, rel, to string) {
+// schemaBuilder accumulates the schema-graph nodes and edges during the BFS.
+type schemaBuilder struct {
+	nodes     map[string]mermaid.Node
+	nodeOrder []string
+	edges     []mermaid.Edge
+	seenEdge  map[string]bool
+}
+
+func (sb *schemaBuilder) addNode(t string) {
+	if _, ok := sb.nodes[t]; !ok {
+		sb.nodes[t] = mermaid.Node{Key: t, Text: t}
+		sb.nodeOrder = append(sb.nodeOrder, t)
+	}
+}
+
+func (sb *schemaBuilder) addEdge(from, rel, to string) {
 	ek := from + "\x00" + rel + "\x00" + to
-	if seen[ek] {
+	if sb.seenEdge[ek] {
 		return
 	}
-	seen[ek] = true
-	*edges = append(*edges, mermaid.Edge{FromKey: from, ToKey: to, Label: rel})
+	sb.seenEdge[ek] = true
+	sb.edges = append(sb.edges, mermaid.Edge{FromKey: from, ToKey: to, Label: rel})
+}
+
+// expand adds the edges from `typ` along relation `rel` (named `name`) in the
+// requested direction and returns the newly-discovered neighbor types to visit.
+func (sb *schemaBuilder) expand(
+	rel metamodel.RelationDef, name, typ, direction string, visited map[string]bool,
+) []string {
+	var next []string
+	discover := func(neighbor string) {
+		sb.addNode(neighbor)
+		if !visited[neighbor] {
+			visited[neighbor] = true
+			next = append(next, neighbor)
+		}
+	}
+	// outgoing: typ in From → each To; incoming: typ in To → each From.
+	if direction != "in" && slices.Contains(rel.From, typ) {
+		for _, to := range rel.To {
+			sb.addEdge(typ, name, to)
+			discover(to)
+		}
+	}
+	if direction != "out" && slices.Contains(rel.To, typ) {
+		for _, fromT := range rel.From {
+			sb.addEdge(fromT, name, typ)
+			discover(fromT)
+		}
+	}
+	return next
 }
 
 func renderGraph(order []string, nodes map[string]mermaid.Node, edges []mermaid.Edge) string {

--- a/internal/docs/runtime.go
+++ b/internal/docs/runtime.go
@@ -52,6 +52,12 @@ type docRuntime struct {
 	// is short-lived and request-scoped, mirroring lua.Runtime.parentCtx.
 	ctx context.Context //nolint:containedctx // request-scoped Lua-binding callbacks
 
+	// pending holds the typed BuildError a doc.* binding raised on the current
+	// island. gopher-lua's RaiseError only carries a string, so we stash the
+	// typed error here and re-attach it in wrapLuaErr rather than round-tripping
+	// it through the Lua error channel (which would lose the type + line).
+	pending *BuildError
+
 	// warnings accumulates non-fatal issues (empty resolves in non-strict mode).
 	warnings []string
 }
@@ -123,6 +129,7 @@ func (dr *docRuntime) Warnings() []string { return dr.warnings }
 // next one.
 func (dr *docRuntime) runStatement(seg segment) (string, error) {
 	dr.out.Reset()
+	dr.pending = nil
 	// RunString honors the runtime's WithContext(ctx) deadline internally.
 	if err := dr.rt.RunString(seg.body); err != nil {
 		return "", dr.wrapLuaErr(seg, err)
@@ -134,6 +141,7 @@ func (dr *docRuntime) runStatement(seg segment) (string, error) {
 // The body is wrapped as `return <expr>` so the runtime yields a value.
 func (dr *docRuntime) runEcho(seg segment) (string, error) {
 	dr.out.Reset()
+	dr.pending = nil
 	// RunActionString honors the runtime's WithContext(ctx) deadline internally.
 	val, err := dr.rt.RunActionString("return "+seg.body, "manual-echo")
 	if err != nil {
@@ -180,25 +188,30 @@ func coerceEcho(v any) (string, error) {
 // line. The Lua frame line is intra-island (1-based within the island body);
 // the manual line is the island's start line plus that offset minus one.
 func (dr *docRuntime) wrapLuaErr(seg segment, err error) error {
-	// A BuildError raised by a resolver already carries the right manual line.
-	var be *BuildError
-	if errors.As(err, &be) {
-		return be
-	}
 	line := seg.line
 	if frames := dr.rt.ErrorFrames(); len(frames) > 0 {
 		if fl := frames[len(frames)-1].Line; fl > 0 {
 			line = seg.line + fl - 1
 		}
 	}
+	// A doc.* binding that failed stashed a typed BuildError (RaiseError only
+	// carries a string, so we can't recover it from err). Prefer it, stamping
+	// the manual line the parser tracked.
+	if dr.pending != nil {
+		be := dr.pending
+		dr.pending = nil
+		be.Line = seg.line
+		be.Snip = strings.TrimSpace(seg.body)
+		return be
+	}
 	return &BuildError{Line: line, Kind: "lua", Msg: err.Error(), Snip: strings.TrimSpace(seg.body)}
 }
 
-// luaFail raises a resolve BuildError from inside a doc.* binding, anchored to
-// the currently-executing island. gopher-lua unwinds via RaiseError; the
-// message is recovered by the runtime's error capture and surfaced through
-// wrapLuaErr, which restamps it with the manual line.
+// luaFail records a resolve BuildError and aborts the current island. gopher-lua
+// unwinds via RaiseError (string-only), so the typed error is stashed on
+// dr.pending and re-attached by wrapLuaErr with the manual line.
 func (dr *docRuntime) luaFail(ls *lua.LState, format string, args ...any) int {
-	ls.RaiseError("%s", &BuildError{Kind: "resolve", Msg: fmt.Sprintf(format, args...)})
+	dr.pending = &BuildError{Kind: "resolve", Msg: fmt.Sprintf(format, args...)}
+	ls.RaiseError("%s", dr.pending.Msg)
 	return 0
 }

--- a/internal/docs/runtime.go
+++ b/internal/docs/runtime.go
@@ -2,7 +2,9 @@ package docs
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 
@@ -45,7 +47,10 @@ type docRuntime struct {
 
 	rt  *rlua.Runtime
 	out *strings.Builder // statement-island emit target
-	ctx context.Context
+	// ctx is stored because the doc.* bindings are gopher-lua callbacks
+	// (func(*lua.LState) int) that cannot take a context parameter; the runtime
+	// is short-lived and request-scoped, mirroring lua.Runtime.parentCtx.
+	ctx context.Context //nolint:containedctx // request-scoped Lua-binding callbacks
 
 	// warnings accumulates non-fatal issues (empty resolves in non-strict mode).
 	warnings []string
@@ -55,7 +60,7 @@ type docRuntime struct {
 // Markdown. It is the package entry point.
 func Build(ctx context.Context, src string, opts Options) (string, error) {
 	if opts.Meta == nil {
-		return "", fmt.Errorf("docs.Build: Meta is required")
+		return "", errors.New("docs.Build: Meta is required")
 	}
 	segs, err := parse(src)
 	if err != nil {
@@ -93,13 +98,13 @@ func Build(ctx context.Context, src string, opts Options) (string, error) {
 		case segLiteral:
 			b.WriteString(seg.body)
 		case segStatement:
-			out, err := dr.runStatement(seg)
+			out, err := dr.runStatement(seg) //nolint:contextcheck // runtime ctx bound at construction via WithContext
 			if err != nil {
 				return "", err
 			}
 			b.WriteString(out)
 		case segEcho:
-			out, err := dr.runEcho(seg)
+			out, err := dr.runEcho(seg) //nolint:contextcheck // runtime ctx bound at construction via WithContext
 			if err != nil {
 				return "", err
 			}
@@ -118,6 +123,7 @@ func (dr *docRuntime) Warnings() []string { return dr.warnings }
 // next one.
 func (dr *docRuntime) runStatement(seg segment) (string, error) {
 	dr.out.Reset()
+	// RunString honors the runtime's WithContext(ctx) deadline internally.
 	if err := dr.rt.RunString(seg.body); err != nil {
 		return "", dr.wrapLuaErr(seg, err)
 	}
@@ -128,6 +134,7 @@ func (dr *docRuntime) runStatement(seg segment) (string, error) {
 // The body is wrapped as `return <expr>` so the runtime yields a value.
 func (dr *docRuntime) runEcho(seg segment) (string, error) {
 	dr.out.Reset()
+	// RunActionString honors the runtime's WithContext(ctx) deadline internally.
 	val, err := dr.rt.RunActionString("return "+seg.body, "manual-echo")
 	if err != nil {
 		return "", dr.wrapLuaErr(seg, err)
@@ -155,17 +162,17 @@ func coerceEcho(v any) (string, error) {
 	case string:
 		return t, nil
 	case int64:
-		return fmt.Sprint(t), nil
+		return strconv.FormatInt(t, 10), nil
 	case float64:
 		// Whole floats print without a trailing ".0" for tidy counts.
 		if t == float64(int64(t)) {
-			return fmt.Sprint(int64(t)), nil
+			return strconv.FormatInt(int64(t), 10), nil
 		}
-		return fmt.Sprint(t), nil
+		return strconv.FormatFloat(t, 'g', -1, 64), nil
 	case bool:
-		return "", fmt.Errorf("echo island returned a boolean; inline spans need a string or number")
+		return "", errors.New("echo island returned a boolean; inline spans need a string or number")
 	default:
-		return "", fmt.Errorf("echo island returned %T; inline spans need a string or number (did you mean a ```rela block?)", v)
+		return "", fmt.Errorf("echo island returned %T; inline spans need a string or number (did you mean a fenced rela block?)", v)
 	}
 }
 
@@ -174,7 +181,8 @@ func coerceEcho(v any) (string, error) {
 // the manual line is the island's start line plus that offset minus one.
 func (dr *docRuntime) wrapLuaErr(seg segment, err error) error {
 	// A BuildError raised by a resolver already carries the right manual line.
-	if be, ok := err.(*BuildError); ok {
+	var be *BuildError
+	if errors.As(err, &be) {
 		return be
 	}
 	line := seg.line
@@ -186,10 +194,11 @@ func (dr *docRuntime) wrapLuaErr(seg segment, err error) error {
 	return &BuildError{Line: line, Kind: "lua", Msg: err.Error(), Snip: strings.TrimSpace(seg.body)}
 }
 
-// luaFail raises a BuildError from inside a doc.* binding, anchored to the
-// currently-executing island. gopher-lua unwinds via RaiseError; the message
-// is recovered by the runtime's error capture and surfaced through wrapLuaErr.
-func (dr *docRuntime) luaFail(ls *lua.LState, kind, format string, args ...any) int {
-	ls.RaiseError("%s", &BuildError{Kind: kind, Msg: fmt.Sprintf(format, args...)})
+// luaFail raises a resolve BuildError from inside a doc.* binding, anchored to
+// the currently-executing island. gopher-lua unwinds via RaiseError; the
+// message is recovered by the runtime's error capture and surfaced through
+// wrapLuaErr, which restamps it with the manual line.
+func (dr *docRuntime) luaFail(ls *lua.LState, format string, args ...any) int {
+	ls.RaiseError("%s", &BuildError{Kind: "resolve", Msg: fmt.Sprintf(format, args...)})
 	return 0
 }

--- a/internal/docs/runtime.go
+++ b/internal/docs/runtime.go
@@ -1,0 +1,195 @@
+package docs
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	lua "github.com/yuin/gopher-lua"
+
+	"github.com/Sourcehaven-BV/rela/internal/acl"
+	rlua "github.com/Sourcehaven-BV/rela/internal/lua"
+	"github.com/Sourcehaven-BV/rela/internal/metamodel"
+	"github.com/Sourcehaven-BV/rela/internal/store/memstore"
+	"github.com/Sourcehaven-BV/rela/internal/tracer"
+)
+
+// buildTimeout bounds a single manual build. An island with an infinite loop
+// (a flat `while true`, which the call-stack cap does not catch) is stopped
+// only by this context deadline, so it must always be wired.
+const buildTimeout = 30 * time.Second
+
+// Options controls a manual build.
+type Options struct {
+	// Meta is the deployment's metamodel (loaded from the real project). It is
+	// the source of every schema resolver's data.
+	Meta *metamodel.Metamodel
+	// Policy is the deployment's ACL policy for roles_matrix, or nil when the
+	// project has no acl.yaml (roles_matrix then reports "no policy").
+	Policy *acl.Policy
+	// Strict promotes an empty resolve (a resolver / echo yielding nothing) from
+	// a warning to a build failure.
+	Strict bool
+}
+
+// docRuntime owns the per-build state the doc.* bindings close over: the real
+// metamodel + policy (read), an ephemeral seeded memstore (read+write), the
+// output buffer statement islands append to, and the strict flag.
+type docRuntime struct {
+	meta   *metamodel.Metamodel
+	policy *acl.Policy
+	store  *memstore.MemStore
+	tracer tracer.Tracer
+	strict bool
+
+	rt  *rlua.Runtime
+	out *strings.Builder // statement-island emit target
+	ctx context.Context
+
+	// warnings accumulates non-fatal issues (empty resolves in non-strict mode).
+	warnings []string
+}
+
+// Build resolves every island in the manual source and returns the rendered
+// Markdown. It is the package entry point.
+func Build(ctx context.Context, src string, opts Options) (string, error) {
+	if opts.Meta == nil {
+		return "", fmt.Errorf("docs.Build: Meta is required")
+	}
+	segs, err := parse(src)
+	if err != nil {
+		return "", err
+	}
+
+	st := memstore.New()
+	dr := &docRuntime{
+		meta:   opts.Meta,
+		policy: opts.Policy,
+		store:  st,
+		tracer: tracer.New(st),
+		strict: opts.Strict,
+		out:    &strings.Builder{},
+		ctx:    ctx,
+	}
+
+	// A reader runtime gives us the sandbox (no io/os) plus rela.* read bindings;
+	// we layer the doc.* module (emit + resolvers + raw-store seed) on top. The
+	// seed writes go to the memstore directly, NOT through an entitymanager, so
+	// no Mutator/WriteDeps machinery is needed.
+	readDeps := rlua.ReadDeps{
+		Store:  st,
+		Tracer: dr.tracer,
+		Meta:   opts.Meta,
+	}
+	rt := rlua.NewReader(readDeps, dr.out, rlua.WithContext(ctx), rlua.WithTimeout(buildTimeout))
+	defer rt.Close()
+	dr.rt = rt
+	dr.registerModule()
+
+	var b strings.Builder
+	for _, seg := range segs {
+		switch seg.kind {
+		case segLiteral:
+			b.WriteString(seg.body)
+		case segStatement:
+			out, err := dr.runStatement(seg)
+			if err != nil {
+				return "", err
+			}
+			b.WriteString(out)
+		case segEcho:
+			out, err := dr.runEcho(seg)
+			if err != nil {
+				return "", err
+			}
+			b.WriteString(out)
+		}
+	}
+	return b.String(), nil
+}
+
+// Warnings returns the non-fatal issues accumulated during the last Build on
+// this runtime (only meaningful in non-strict mode).
+func (dr *docRuntime) Warnings() []string { return dr.warnings }
+
+// runStatement executes one statement island. doc.* emit calls append to
+// dr.out; we capture what this island produced and reset the buffer for the
+// next one.
+func (dr *docRuntime) runStatement(seg segment) (string, error) {
+	dr.out.Reset()
+	if err := dr.rt.RunString(seg.body); err != nil {
+		return "", dr.wrapLuaErr(seg, err)
+	}
+	return dr.out.String(), nil
+}
+
+// runEcho evaluates an echo island's expression and returns its string value.
+// The body is wrapped as `return <expr>` so the runtime yields a value.
+func (dr *docRuntime) runEcho(seg segment) (string, error) {
+	dr.out.Reset()
+	val, err := dr.rt.RunActionString("return "+seg.body, "manual-echo")
+	if err != nil {
+		return "", dr.wrapLuaErr(seg, err)
+	}
+	s, err := coerceEcho(val)
+	if err != nil {
+		return "", &BuildError{Line: seg.line, Kind: "resolve", Msg: err.Error(), Snip: seg.body}
+	}
+	if s == "" {
+		if dr.strict {
+			return "", &BuildError{Line: seg.line, Kind: "strict", Msg: "echo island resolved to empty", Snip: seg.body}
+		}
+		dr.warnings = append(dr.warnings, fmt.Sprintf("manual:%d: echo resolved to empty: %s", seg.line, seg.body))
+	}
+	return s, nil
+}
+
+// coerceEcho converts an echo expression's Go value to its inline string form.
+// strings pass through; numbers are formatted; nil is empty; bool/table/other
+// are author errors (a block resolver placed in an inline span).
+func coerceEcho(v any) (string, error) {
+	switch t := v.(type) {
+	case nil:
+		return "", nil
+	case string:
+		return t, nil
+	case int64:
+		return fmt.Sprint(t), nil
+	case float64:
+		// Whole floats print without a trailing ".0" for tidy counts.
+		if t == float64(int64(t)) {
+			return fmt.Sprint(int64(t)), nil
+		}
+		return fmt.Sprint(t), nil
+	case bool:
+		return "", fmt.Errorf("echo island returned a boolean; inline spans need a string or number")
+	default:
+		return "", fmt.Errorf("echo island returned %T; inline spans need a string or number (did you mean a ```rela block?)", v)
+	}
+}
+
+// wrapLuaErr turns a runtime error into a BuildError anchored to the manual
+// line. The Lua frame line is intra-island (1-based within the island body);
+// the manual line is the island's start line plus that offset minus one.
+func (dr *docRuntime) wrapLuaErr(seg segment, err error) error {
+	// A BuildError raised by a resolver already carries the right manual line.
+	if be, ok := err.(*BuildError); ok {
+		return be
+	}
+	line := seg.line
+	if frames := dr.rt.ErrorFrames(); len(frames) > 0 {
+		if fl := frames[len(frames)-1].Line; fl > 0 {
+			line = seg.line + fl - 1
+		}
+	}
+	return &BuildError{Line: line, Kind: "lua", Msg: err.Error(), Snip: strings.TrimSpace(seg.body)}
+}
+
+// luaFail raises a BuildError from inside a doc.* binding, anchored to the
+// currently-executing island. gopher-lua unwinds via RaiseError; the message
+// is recovered by the runtime's error capture and surfaced through wrapLuaErr.
+func (dr *docRuntime) luaFail(ls *lua.LState, kind, format string, args ...any) int {
+	ls.RaiseError("%s", &BuildError{Kind: kind, Msg: fmt.Sprintf(format, args...)})
+	return 0
+}

--- a/internal/docs/runtime.go
+++ b/internal/docs/runtime.go
@@ -17,7 +17,8 @@ import (
 	"github.com/Sourcehaven-BV/rela/internal/tracer"
 )
 
-// buildTimeout bounds a single manual build. An island with an infinite loop
+// buildTimeout bounds a whole manual build (all islands together, via a child
+// context deadline in Build). An island with an infinite loop
 // (a flat `while true`, which the call-stack cap does not catch) is stopped
 // only by this context deadline, so it must always be wired.
 const buildTimeout = 30 * time.Second
@@ -58,6 +59,10 @@ type docRuntime struct {
 	// it through the Lua error channel (which would lose the type + line).
 	pending *BuildError
 
+	// seedCounts is a per-type auto-id counter for the seed's mintID, avoiding a
+	// full-store scan per create().
+	seedCounts map[string]int
+
 	// warnings accumulates non-fatal issues (empty resolves in non-strict mode).
 	warnings []string
 }
@@ -72,6 +77,13 @@ func Build(ctx context.Context, src string, opts Options) (string, error) {
 	if err != nil {
 		return "", err
 	}
+
+	// Bound the WHOLE build, not each island: the runtime's per-run applyTimeout
+	// resets a fresh deadline on every island, so without a build-wide deadline
+	// N islands give no effective ceiling. A child ctx deadline caps the total.
+	// If the caller already set an earlier deadline, that one wins.
+	ctx, cancel := context.WithTimeout(ctx, buildTimeout)
+	defer cancel()
 
 	st := memstore.New()
 	dr := &docRuntime{
@@ -195,14 +207,17 @@ func (dr *docRuntime) wrapLuaErr(seg segment, err error) error {
 		}
 	}
 	// A doc.* binding that failed stashed a typed BuildError (RaiseError only
-	// carries a string, so we can't recover it from err). Prefer it, stamping
-	// the manual line the parser tracked.
-	if dr.pending != nil {
-		be := dr.pending
-		dr.pending = nil
-		be.Line = seg.line
-		be.Snip = strings.TrimSpace(seg.body)
-		return be
+	// carries a string, so we can't recover it from err). Prefer it — but ONLY
+	// when the raised Lua message still contains the stashed message. If the
+	// island caught the resolver's error with pcall and then failed elsewhere,
+	// dr.pending is stale and err is the *real* failure: fall through so the
+	// author sees that one, not the swallowed one.
+	pending := dr.pending
+	dr.pending = nil
+	if pending != nil && strings.Contains(err.Error(), pending.Msg) {
+		pending.Line = line
+		pending.Snip = strings.TrimSpace(seg.body)
+		return pending
 	}
 	return &BuildError{Line: line, Kind: "lua", Msg: err.Error(), Snip: strings.TrimSpace(seg.body)}
 }

--- a/internal/mermaid/mermaid.go
+++ b/internal/mermaid/mermaid.go
@@ -65,7 +65,7 @@ func StateDiagram(initial string, transitions []Transition) string {
 	var b strings.Builder
 	b.WriteString("stateDiagram-v2\n")
 	for _, v := range order {
-		fmt.Fprintf(&b, "    state %q as %s\n", v, ids[v])
+		fmt.Fprintf(&b, "    state %s as %s\n", quoted(v), ids[v])
 	}
 	if initial != "" {
 		fmt.Fprintf(&b, "    [*] --> %s\n", ids[initial])
@@ -117,7 +117,7 @@ func Graph(nodes []Node, edges []Edge) string {
 		}
 		id := fmt.Sprintf("n%d", len(ids))
 		ids[n.Key] = id
-		fmt.Fprintf(&b, "    %s[%q]\n", id, Label(n.Text))
+		fmt.Fprintf(&b, "    %s[%s]\n", id, quoted(n.Text))
 	}
 
 	emitted := map[string]bool{}
@@ -133,7 +133,7 @@ func Graph(nodes []Node, edges []Edge) string {
 		}
 		emitted[dedupe] = true
 		if lbl := Label(e.Label); lbl != "" {
-			fmt.Fprintf(&b, "    %s -->|%q| %s\n", from, lbl, to)
+			fmt.Fprintf(&b, "    %s -->|%s| %s\n", from, quoted(e.Label), to)
 		} else {
 			fmt.Fprintf(&b, "    %s --> %s\n", from, to)
 		}
@@ -141,12 +141,22 @@ func Graph(nodes []Node, edges []Edge) string {
 	return b.String()
 }
 
-// Label flattens a string so it is safe as a mermaid edge/node label: newlines
-// and carriage returns collapse to spaces (a raw newline would end the current
-// diagram line and let the remainder inject a new statement).
+// Label makes a string safe as the text of a mermaid quoted label. It flattens
+// newlines (a raw newline ends the diagram line and lets the remainder inject a
+// statement) and replaces the characters that break out of a quoted label —
+// double quotes and angle brackets — with mermaid's HTML-entity forms. Mermaid
+// does NOT honor backslash escaping (so fmt %q is unsafe); it decodes numeric
+// and named entities inside quotes, so `#quot;` renders as a literal quote
+// without terminating the label.
 func Label(s string) string {
 	s = strings.ReplaceAll(s, "\r\n", " ")
 	s = strings.ReplaceAll(s, "\n", " ")
 	s = strings.ReplaceAll(s, "\r", " ")
+	s = strings.ReplaceAll(s, `"`, "#quot;")
+	s = strings.ReplaceAll(s, "<", "#lt;")
+	s = strings.ReplaceAll(s, ">", "#gt;")
 	return strings.TrimSpace(s)
 }
+
+// quoted wraps an already-escaped Label in mermaid's double-quote delimiters.
+func quoted(s string) string { return `"` + Label(s) + `"` }

--- a/internal/mermaid/mermaid.go
+++ b/internal/mermaid/mermaid.go
@@ -1,0 +1,152 @@
+// Package mermaid renders mermaid diagram source from neutral, primitive inputs.
+//
+// It is deliberately decoupled from any domain type: callers map their own
+// shapes (a metamodel CustomType, a data-entry EnumHelp DTO, a tracer result)
+// into the small structs defined here. That keeps the injection-safe rendering
+// logic in one place while letting both the data-entry help modal and the
+// rela-docs generator share it without either importing the other.
+//
+// Injection safety is the reason this code exists as a shared unit. Raw enum
+// values and node names are NOT safe to splice into mermaid syntax — a value
+// with a space, arrow, or colon breaks parsing, and a newline in a label can
+// inject a spurious statement. Every state/node is mapped to a synthetic id
+// (s0, s1, … / n0, n1, …) and aliased so the diagram DISPLAYS the real text
+// while edges reference the safe id; labels are flattened so they can never
+// spill onto a new diagram line.
+package mermaid
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Transition is one edge of a state machine: a move from one state value to
+// another, labeled with a verb (Label). Label may be empty.
+type Transition struct {
+	From  string
+	To    string
+	Label string
+}
+
+// StateDiagram renders a mermaid stateDiagram-v2 for a state machine: an entry
+// arrow to initial (when non-empty) plus one edge per transition. States are
+// emitted in first-seen order (initial first, then each transition's From/To)
+// so the alias declarations are deterministic.
+//
+// A transition whose Label is empty, or equals its To value, renders as a bare
+// edge with no label (matching the convention that a move named after its
+// target adds no information).
+func StateDiagram(initial string, transitions []Transition) string {
+	ids := map[string]string{}
+	idFor := func(value string) string {
+		if id, ok := ids[value]; ok {
+			return id
+		}
+		id := fmt.Sprintf("s%d", len(ids))
+		ids[value] = id
+		return id
+	}
+
+	order := []string{}
+	seen := map[string]bool{}
+	note := func(v string) {
+		if v != "" && !seen[v] {
+			seen[v] = true
+			order = append(order, v)
+			idFor(v)
+		}
+	}
+	note(initial)
+	for _, tr := range transitions {
+		note(tr.From)
+		note(tr.To)
+	}
+
+	var b strings.Builder
+	b.WriteString("stateDiagram-v2\n")
+	for _, v := range order {
+		fmt.Fprintf(&b, "    state %q as %s\n", v, ids[v])
+	}
+	if initial != "" {
+		fmt.Fprintf(&b, "    [*] --> %s\n", ids[initial])
+	}
+	for _, tr := range transitions {
+		// Skip a transition referencing a state we never registered (From/To
+		// empty): it cannot be drawn safely.
+		if tr.From == "" || tr.To == "" {
+			continue
+		}
+		label := Label(tr.Label)
+		if label != "" && tr.Label != tr.To {
+			fmt.Fprintf(&b, "    %s --> %s: %s\n", ids[tr.From], ids[tr.To], label)
+		} else {
+			fmt.Fprintf(&b, "    %s --> %s\n", ids[tr.From], ids[tr.To])
+		}
+	}
+	return b.String()
+}
+
+// Node is one vertex of a flow graph: a stable Key (used for dedupe and edge
+// references) and the Text shown in the box.
+type Node struct {
+	Key  string
+	Text string
+}
+
+// Edge is one directed edge of a flow graph between two node keys, optionally
+// labeled with the relation name.
+type Edge struct {
+	FromKey string
+	ToKey   string
+	Label   string
+}
+
+// Graph renders a mermaid `graph LR` (left-to-right flow). Nodes are declared
+// once each in the given order with synthetic ids; edges reference those ids.
+// An edge referencing a key with no matching node is skipped (it cannot be
+// drawn). Duplicate nodes (same Key) and duplicate edges (same From/To/Label)
+// are collapsed so a caller can pass a raw, possibly-redundant traversal.
+func Graph(nodes []Node, edges []Edge) string {
+	ids := map[string]string{}
+	var b strings.Builder
+	b.WriteString("graph LR\n")
+
+	for _, n := range nodes {
+		if _, ok := ids[n.Key]; ok {
+			continue // already declared
+		}
+		id := fmt.Sprintf("n%d", len(ids))
+		ids[n.Key] = id
+		fmt.Fprintf(&b, "    %s[%q]\n", id, Label(n.Text))
+	}
+
+	emitted := map[string]bool{}
+	for _, e := range edges {
+		from, ok1 := ids[e.FromKey]
+		to, ok2 := ids[e.ToKey]
+		if !ok1 || !ok2 {
+			continue
+		}
+		dedupe := from + "\x00" + to + "\x00" + e.Label
+		if emitted[dedupe] {
+			continue
+		}
+		emitted[dedupe] = true
+		if lbl := Label(e.Label); lbl != "" {
+			fmt.Fprintf(&b, "    %s -->|%q| %s\n", from, lbl, to)
+		} else {
+			fmt.Fprintf(&b, "    %s --> %s\n", from, to)
+		}
+	}
+	return b.String()
+}
+
+// Label flattens a string so it is safe as a mermaid edge/node label: newlines
+// and carriage returns collapse to spaces (a raw newline would end the current
+// diagram line and let the remainder inject a new statement).
+func Label(s string) string {
+	s = strings.ReplaceAll(s, "\r\n", " ")
+	s = strings.ReplaceAll(s, "\n", " ")
+	s = strings.ReplaceAll(s, "\r", " ")
+	return strings.TrimSpace(s)
+}

--- a/internal/mermaid/mermaid_test.go
+++ b/internal/mermaid/mermaid_test.go
@@ -1,0 +1,174 @@
+package mermaid_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/Sourcehaven-BV/rela/internal/mermaid"
+)
+
+func TestStateDiagram_EntryAndEdges(t *testing.T) {
+	t.Parallel()
+	got := mermaid.StateDiagram("todo", []mermaid.Transition{
+		{From: "todo", To: "doing", Label: "start"},
+		{From: "doing", To: "done", Label: "finish"},
+	})
+	// Header, alias declarations in first-seen order, entry arrow, labeled edges.
+	for _, want := range []string{
+		"stateDiagram-v2",
+		`state "todo" as s0`,
+		`state "doing" as s1`,
+		`state "done" as s2`,
+		"[*] --> s0",
+		"s0 --> s1: start",
+		"s1 --> s2: finish",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("diagram missing %q\n%s", want, got)
+		}
+	}
+}
+
+func TestStateDiagram_NoInitial_NoEntryArrow(t *testing.T) {
+	t.Parallel()
+	got := mermaid.StateDiagram("", []mermaid.Transition{{From: "a", To: "b", Label: "go"}})
+	if strings.Contains(got, "[*]") {
+		t.Errorf("no initial → no entry arrow, got:\n%s", got)
+	}
+	if !strings.Contains(got, "s0 --> s1: go") {
+		t.Errorf("expected the edge, got:\n%s", got)
+	}
+}
+
+func TestStateDiagram_LabelEqualToTarget_IsBare(t *testing.T) {
+	t.Parallel()
+	// A move labeled the same as its target value adds no information → bare edge.
+	got := mermaid.StateDiagram("", []mermaid.Transition{{From: "a", To: "done", Label: "done"}})
+	if strings.Contains(got, ": done") {
+		t.Errorf("label == target should render bare, got:\n%s", got)
+	}
+}
+
+// AC5 / AC11: a value or label containing mermaid-breaking characters must NOT
+// inject syntax. States are referenced by synthetic id; the raw text appears
+// only inside a quoted alias, and labels are newline-flattened.
+func TestStateDiagram_InjectionSafe(t *testing.T) {
+	t.Parallel()
+	got := mermaid.StateDiagram("in progress", []mermaid.Transition{
+		{From: "in progress", To: "a --> evil", Label: "click\n[*] --> hacked"},
+	})
+	// The dangerous value is aliased to a synthetic id, never spliced as syntax.
+	if !strings.Contains(got, `as s0`) || !strings.Contains(got, `as s1`) {
+		t.Errorf("states must be aliased to synthetic ids, got:\n%s", got)
+	}
+	// The injected `[*] --> hacked` may survive only as label TEXT (right of the
+	// `: `), never as its own statement. Every edge/entry line's SOURCE (left of
+	// the first -->) must be [*] or a synthetic id — a leaked raw value fails here.
+	for line := range strings.SplitSeq(strings.TrimSpace(got), "\n") {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" || trimmed == "stateDiagram-v2" || strings.HasPrefix(trimmed, `state "`) {
+			continue
+		}
+		if strings.Contains(trimmed, "-->") {
+			left := strings.TrimSpace(strings.SplitN(trimmed, "-->", 2)[0])
+			if left != "[*]" && !isSyntheticStateID(left) {
+				t.Errorf("edge line has a non-synthetic source %q: %q", left, trimmed)
+			}
+		}
+	}
+	// The newline in the label must be flattened (no bare newline mid-diagram).
+	if strings.Contains(got, "click\n") {
+		t.Errorf("label newline was not flattened, got:\n%s", got)
+	}
+}
+
+func isSyntheticStateID(s string) bool {
+	if !strings.HasPrefix(s, "s") {
+		return false
+	}
+	for _, r := range s[1:] {
+		if r < '0' || r > '9' {
+			return false
+		}
+	}
+	return len(s) > 1
+}
+
+func TestStateDiagram_SkipsEmptyEndpoints(t *testing.T) {
+	t.Parallel()
+	got := mermaid.StateDiagram("a", []mermaid.Transition{
+		{From: "a", To: "", Label: "x"}, // missing target — undrawable, skip
+		{From: "a", To: "b", Label: "ok"},
+	})
+	if !strings.Contains(got, "s0 --> s1: ok") {
+		t.Errorf("valid edge missing, got:\n%s", got)
+	}
+	if strings.Contains(got, ": x") {
+		t.Errorf("edge with empty endpoint should be skipped, got:\n%s", got)
+	}
+}
+
+func TestGraph_NodesEdgesDedup(t *testing.T) {
+	t.Parallel()
+	got := mermaid.Graph(
+		[]mermaid.Node{
+			{Key: "verwerking", Text: "verwerking"},
+			{Key: "doel", Text: "verwerkingsdoel"},
+			{Key: "verwerking", Text: "verwerking"}, // duplicate key → collapsed
+		},
+		[]mermaid.Edge{
+			{FromKey: "verwerking", ToKey: "doel", Label: "heeft_doel"},
+			{FromKey: "verwerking", ToKey: "doel", Label: "heeft_doel"}, // dup edge → collapsed
+		},
+	)
+	if strings.Count(got, `n0["verwerking"]`) != 1 {
+		t.Errorf("node declared once, got:\n%s", got)
+	}
+	if c := strings.Count(got, "heeft_doel"); c != 1 {
+		t.Errorf("duplicate edge should collapse to 1, got %d:\n%s", c, got)
+	}
+	if !strings.Contains(got, "graph LR") {
+		t.Errorf("expected LR flow header, got:\n%s", got)
+	}
+}
+
+func TestGraph_SkipsDanglingEdge(t *testing.T) {
+	t.Parallel()
+	got := mermaid.Graph(
+		[]mermaid.Node{{Key: "a", Text: "a"}},
+		[]mermaid.Edge{{FromKey: "a", ToKey: "missing", Label: "x"}},
+	)
+	if strings.Contains(got, "x") {
+		t.Errorf("edge to undeclared node should be skipped, got:\n%s", got)
+	}
+}
+
+func TestGraph_InjectionSafeNodeText(t *testing.T) {
+	t.Parallel()
+	got := mermaid.Graph(
+		[]mermaid.Node{{Key: "k", Text: "evil\"]-->x[\"pwned"}},
+		nil,
+	)
+	// Node text is quoted; a newline would be flattened. The raw text with a
+	// newline must not appear verbatim outside the quoted form.
+	if strings.Contains(got, "pwned\n") {
+		t.Errorf("node text newline not flattened, got:\n%s", got)
+	}
+}
+
+func TestLabel_FlattensNewlines(t *testing.T) {
+	t.Parallel()
+	cases := map[string]string{
+		"a\nb":     "a b",
+		"a\r\nb":   "a b",
+		"a\rb":     "a b",
+		"  x  ":    "x",
+		"plain":    "plain",
+		"a\n\n b ": "a   b", // two newlines → two spaces, plus the space before b
+	}
+	for in, want := range cases {
+		if got := mermaid.Label(in); got != want {
+			t.Errorf("Label(%q) = %q, want %q", in, got, want)
+		}
+	}
+}

--- a/internal/mermaid/mermaid_test.go
+++ b/internal/mermaid/mermaid_test.go
@@ -172,3 +172,56 @@ func TestLabel_FlattensNewlines(t *testing.T) {
 		}
 	}
 }
+
+// Label must neutralize the characters that break OUT of a mermaid quoted
+// label — double quotes and angle brackets — using mermaid's entity forms
+// (NOT backslash, which mermaid does not honor).
+func TestLabel_EscapesQuotesAndBrackets(t *testing.T) {
+	t.Parallel()
+	got := mermaid.Label(`a"] --> x["b`)
+	if strings.Contains(got, `"`) {
+		t.Errorf("bare double-quote must be entity-escaped, got %q", got)
+	}
+	if !strings.Contains(got, "#quot;") {
+		t.Errorf("expected #quot; entity, got %q", got)
+	}
+	if strings.ContainsAny(mermaid.Label("a<b>c"), "<>") {
+		t.Errorf("angle brackets must be escaped, got %q", mermaid.Label("a<b>c"))
+	}
+}
+
+// A node whose text contains a double quote must not break out of the
+// bracketed quoted label (the regression the reviewer flagged: %q emits \",
+// which mermaid does not treat as an escape).
+func TestGraph_QuoteInNodeTextDoesNotBreakOut(t *testing.T) {
+	t.Parallel()
+	got := mermaid.Graph([]mermaid.Node{{Key: "k", Text: `evil"] --> hax["pwned`}}, nil)
+	// The safety property: the label text sits between exactly two delimiter
+	// quotes. Any internal quote is entity-escaped, so the `] --> [` sequence is
+	// inert label text, not structure — it cannot break out of the "…" label.
+	if strings.Count(got, `"`) != 2 {
+		t.Errorf("node label must contain exactly the 2 delimiter quotes, got:\n%s", got)
+	}
+	if strings.Contains(got, `"]`) && !strings.Contains(got, `#quot;]`) {
+		t.Errorf("a raw quote precedes a bracket — possible breakout:\n%s", got)
+	}
+}
+
+// Likewise a state value or transition label carrying a double quote.
+func TestStateDiagram_QuoteInValueDoesNotBreakOut(t *testing.T) {
+	t.Parallel()
+	got := mermaid.StateDiagram(`o"pen`, []mermaid.Transition{{From: `o"pen`, To: "closed", Label: `cl"ose`}})
+	for line := range strings.SplitSeq(got, "\n") {
+		// Each state alias line has exactly two delimiter quotes; no other line
+		// may contain a raw quote.
+		if strings.HasPrefix(strings.TrimSpace(line), "state ") {
+			if strings.Count(line, `"`) != 2 {
+				t.Errorf("state alias must have exactly 2 delimiter quotes: %q", line)
+			}
+			continue
+		}
+		if strings.Contains(line, `"`) {
+			t.Errorf("non-alias line leaked a raw quote: %q", line)
+		}
+	}
+}

--- a/prototypes/data-entry/manual/tickets-manual.md
+++ b/prototypes/data-entry/manual/tickets-manual.md
@@ -1,0 +1,56 @@
+# Ticket tracker — handleiding
+
+`rela description()`
+
+This manual is authored in Markdown; the tables and diagrams below are
+resolved from the schema by `rela docs build`, so they cannot drift from
+`metamodel.yaml`.
+
+## Tickets
+
+A **ticket** records a piece of work. Every ticket carries these fields:
+
+```rela
+typeref{ type = "ticket", fields = "required" }
+```
+
+### Status
+
+A ticket moves through the lifecycle below.
+
+```rela
+lifecycle{ type = "ticket", field = "status" }
+```
+
+Each status means:
+
+```rela
+values{ type = "ticket", field = "status" }
+```
+
+### How a ticket connects to the rest of the tracker
+
+```rela
+relations{ type = "ticket" }
+```
+
+The schema neighbourhood, two hops out:
+
+```rela
+graph{ from = "ticket", depth = 2 }
+```
+
+## A worked example
+
+```rela
+local t = create("ticket", { title = "Login page 500s under load", status = "in-progress" })
+entity{ id = t.id, fields = { "title", "status" } }
+```
+
+There is `rela count{ type = "ticket" }` seeded ticket in this example.
+
+## Who can do what
+
+```rela
+roles_matrix{ type = "ticket" }
+```

--- a/tickets/entities/docs-checklists/DOCS-DOCLANG.md
+++ b/tickets/entities/docs-checklists/DOCS-DOCLANG.md
@@ -1,0 +1,25 @@
+---
+id: DOCS-DOCLANG
+type: docs-checklist
+title: 'Documentation: rela-docs phase 2 doc language (TKT-3RLZR4)'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Code Documentation
+
+- [x] Package godoc on `internal/mermaid` (injection-safety rationale) and `internal/docs` (island model: statement vs echo)
+- [x] Godoc on the exported surface — `docs.Build`, `docs.Options`, `mermaid.StateDiagram`/`Graph`/`Label`, `BuildError`
+- [x] Inline comments for the non-obvious logic — the two-graph/raw-store seed, the `dr.pending` typed-error stash, the direction-vs-relation-type filter split, mermaid entity-escaping
+
+## Project Documentation
+
+- [x] User-facing guide added — `docs-project/entities/guides/GUIDE-rela-docs.md` (source) → `docs/rela-docs.md` via `just docs`: island syntax, the resolver reference, the seed/memstore model, `graph` grains + exclude/only, fail-loud + `--strict`
+- [x] Example manual committed — `prototypes/data-entry/manual/tickets-manual.md` (builds against the phase-1 prototype project; doubles as living documentation)
+- [x] ~~CLAUDE.md updated~~ (N/A: no new cross-cutting convention; the doc language is a self-contained subsystem documented in its own guide + package godoc)
+
+## External Documentation
+
+- [x] CLI reference — the `rela docs build <manual> [--out] [--strict]` command is documented in the new guide; `docs-project` guide pipeline covers the CLI surface
+- [x] ~~API reference~~ (N/A: no wire/HTTP API change — this is a CLI + library feature)

--- a/tickets/entities/features/FEAT-G4VO53.md
+++ b/tickets/entities/features/FEAT-G4VO53.md
@@ -2,7 +2,7 @@
 id: FEAT-G4VO53
 type: feature
 title: Generated deployment documentation (rela docs)
-description: 'Generate per-deployment end-user + operator/support documentation from a rela project''s metamodel.yaml + acl.yaml as one Markdown file (mermaid state diagrams; PDF-convertible), replacing hand-maintained docs. Delivered in phases: 1a metamodel doc-fields, 1b ACL role descriptions, 2 the `rela docs --output-dir` generator. See RES-EK7LSA.'
+description: 'Generate per-deployment end-user + operator/support documentation for a rela project. REFRAMED 2026-07-21 (see RES-EK7LSA addendum): phase 2 is a doc LANGUAGE — markdown authored by a human with mechanical fragments pulled from the schema/graph via Lua islands (```rela blocks / `rela` inline echoes), NOT a static push-generator. Phases: 1a/1a.5/1b doc-fields (DONE); phase 2 = Tier A (language + resolvers: typeref/values/relations/graph/lifecycle/entity/count/roles_matrix + memstore seed, no browser); phase 3 = Tier B (screenshot island via Playwright).'
 status: proposed
 ---
 

--- a/tickets/entities/implementation-checklists/IMPL-3N1D8Z.md
+++ b/tickets/entities/implementation-checklists/IMPL-3N1D8Z.md
@@ -2,43 +2,48 @@
 id: IMPL-3N1D8Z
 type: implementation-checklist
 title: 'Implementation: rela-docs phase 2 (Tier A): markdown+Lua-island doc language + schema/graph resolvers'
-status: in-progress
+status: done
 ---
 
 <!-- @managed: claude-workflow v1 -->
 
 ## Development
 
-- [ ] Unit tests written for new code
-- [ ] Integration tests written (test full flow, not just units)
-- [ ] Happy path implemented
-- [ ] Edge cases from planning handled
-- [ ] Error handling in place (errors surfaced, not swallowed)
+- [x] Unit tests written for new code — `internal/mermaid` (10 tests incl. injection), `internal/docs/preprocess_test.go` (parser), `internal/docs/build_test.go` (resolvers + pipeline)
+- [x] Integration tests written — `build_test.go` drives the full Build() over fixture metamodel + policy + seeded memstore; smoke-tested `rela docs build` against the real `prototypes/data-entry/project`
+- [x] Happy path implemented — all 9 resolvers + emit + seed + `rela docs build` CLI, verified end-to-end on a real project
+- [x] Edge cases from planning handled — flat-enum lifecycle fallback, exclude/only conflict, empty resolve (strict vs warn), unknown type/field, diamond-graph dedupe, echo-vs-prose disambiguation, seed-any-status (raw store)
+- [x] Error handling in place — fail-loud `BuildError` with the manual source line; Lua errors, resolver errors, parse errors all surface with `manual:N`
 
 ## Test Quality
 
-- [ ] Using fixture builders or factories for test data
-- [ ] No hardcoded values in assertions when object is in scope
-- [ ] Only specifying values that matter for the test
-- [ ] Interpolated values constructed from objects, not hardcoded
-- [ ] Property comparisons use original object, not hardcoded strings
+- [x] Using fixture builders — `fixtureMeta(t)` / `fixturePolicy()` builders; shared `build(t, src, opts)` helper
+- [x] No hardcoded values where object is in scope — assertions check emitted structure against the fixture
+- [x] Only specifying values that matter — fixtures carry the minimum to exercise each resolver
+- [x] Interpolated values from objects — seed round-trips via `create` then `entity{id=r.id}`
+- [x] Property comparisons use original object — diamond test counts actual edges
 
 ## Manual Verification
 
-- [ ] Feature manually tested end-to-end
-- [ ] Each acceptance criterion verified with test scenario from planning
-- [ ] Edge cases manually verified
+- [x] Feature manually tested end-to-end
+- [x] Each acceptance criterion verified with test scenario from planning
+- [x] Edge cases manually verified
 
 **Verification Evidence:**
-<!-- Document what you tested and the results -->
+
+- `go test ./internal/docs/ ./internal/mermaid/` — PASS. Coverage: **docs 81.9%**, **mermaid 96.6%** (both well above the 50% floor; no override needed).
+- `just coverage-check` — PASS (package 50% + total 65%; total 76.3%).
+- `just arch-lint` — OK (new `mermaid` + `docs` components + `mayDependOn`/`canUse` added).
+- `golangci-lint run ./internal/docs/... ./internal/mermaid/... ./internal/cli/...` — 0 issues.
+- `just lint-md` — 0 issues. `just fmt` clean.
+- `go build ./...` + `go test ./...` — full suite green (73 packages ok, 0 failures).
+- **End-to-end on the real prototype** (`rela docs build --project prototypes/data-entry/project prototypes/data-entry/manual/tickets-manual.md`): renders the deployment description, required-field table, a **mermaid stateDiagram** (Start work/Mark resolved/Close/Reopen), per-value meanings + labels + default, relations list, schema graph (incl. the `blocks`→ticket self-loop), a seeded worked example (create→entity), the echo count, and the editor/viewer roles matrix.
+- AC-by-AC: AC1 statement `TestBuild_StatementIsland`; AC2 echo `TestBuild_EchoCount` + coercion + prose-disambiguation `TestParse_RelaProseMentionNotEcho`; AC3 `TestBuild_TyperefRequired`; AC4 `TestBuild_ValuesWithDescriptions`; AC5 `TestBuild_LifecycleDiagram`/`_FlatFallback` + mermaid injection tests; AC6 `TestBuild_GraphInstanceDiamond`/`_GraphSchema`/`_GraphExclude`/`_ExcludeOnlyConflict`; AC7 `TestBuild_RolesMatrix`/`_NoPolicy`; AC8 `TestBuild_SeedRawStoreNoGate`; AC9 `TestBuild_FailLoudUnknownType`/`_StrictEmptyResolve`; AC10 the example manual; AC11 mermaid extraction + dataentry tests green; AC12 `TestBuild_InfiniteLoopTimesOut` (0.5s deadline hit).
 
 ## Quality
 
-- [ ] Code follows project patterns (check similar code)
-- [ ] Checked for DRY opportunities — repeated literals, expressions, or
-patterns extracted to a helper / constant / type where it sharpens the contract
-(don't extract for its own sake; CLAUDE.md "three similar lines is better than a
-premature abstraction" still holds)
-- [ ] No security issues introduced
-- [ ] No silent failures (errors logged AND returned)
-- [ ] No debug code left behind
+- [x] Code follows project patterns — mermaid extraction mirrors the existing dataentry renderer; doc `doc.*` module registered `registerCryptoModule`-style (closures, no `*Runtime` methods → plimsoll flat); reuses `lua.NewReader`, `EntityToTable`, `tracer`, `memstore`, `acl.grantsVerb` logic
+- [x] Checked for DRY — extracted `internal/mermaid` (shared with dataentry), `enumInfo`/`schemaBuilder` where it sharpened the contract; kept small helpers inline otherwise
+- [x] No security issues introduced — sandbox (no io/os) inherited; mermaid injection-safe (synthetic ids + newline flatten, tested); seed writes isolated to a throwaway memstore; manual/output paths are operator-trust (plain os.ReadFile/WriteFile, `--out` refuses a directory)
+- [x] No silent failures — fail-loud `BuildError` (returned, not logged-and-dropped); empty resolve warns (non-strict) or errors (strict)
+- [x] No debug code left behind

--- a/tickets/entities/implementation-checklists/IMPL-3N1D8Z.md
+++ b/tickets/entities/implementation-checklists/IMPL-3N1D8Z.md
@@ -1,0 +1,44 @@
+---
+id: IMPL-3N1D8Z
+type: implementation-checklist
+title: 'Implementation: rela-docs phase 2 (Tier A): markdown+Lua-island doc language + schema/graph resolvers'
+status: in-progress
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Development
+
+- [ ] Unit tests written for new code
+- [ ] Integration tests written (test full flow, not just units)
+- [ ] Happy path implemented
+- [ ] Edge cases from planning handled
+- [ ] Error handling in place (errors surfaced, not swallowed)
+
+## Test Quality
+
+- [ ] Using fixture builders or factories for test data
+- [ ] No hardcoded values in assertions when object is in scope
+- [ ] Only specifying values that matter for the test
+- [ ] Interpolated values constructed from objects, not hardcoded
+- [ ] Property comparisons use original object, not hardcoded strings
+
+## Manual Verification
+
+- [ ] Feature manually tested end-to-end
+- [ ] Each acceptance criterion verified with test scenario from planning
+- [ ] Edge cases manually verified
+
+**Verification Evidence:**
+<!-- Document what you tested and the results -->
+
+## Quality
+
+- [ ] Code follows project patterns (check similar code)
+- [ ] Checked for DRY opportunities — repeated literals, expressions, or
+patterns extracted to a helper / constant / type where it sharpens the contract
+(don't extract for its own sake; CLAUDE.md "three similar lines is better than a
+premature abstraction" still holds)
+- [ ] No security issues introduced
+- [ ] No silent failures (errors logged AND returned)
+- [ ] No debug code left behind

--- a/tickets/entities/planning-checklists/PLAN-TYH98I.md
+++ b/tickets/entities/planning-checklists/PLAN-TYH98I.md
@@ -1,0 +1,541 @@
+---
+id: PLAN-TYH98I
+type: planning-checklist
+title: 'Planning: rela-docs phase 2 (Tier A): markdown+Lua-island doc language + schema/graph resolvers'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Understanding
+
+- [x] Problem/requirements clearly understood
+- [x] Scope defined (what's in/out documented below)
+- [x] Acceptance criteria documented with specific test scenarios
+
+**Scope:**
+
+Phase 2 (Tier A) of FEAT-G4VO53, reframed as a **doc language** (RES-EK7LSA
+addendum): markdown authored by a human, with mechanical fragments *pulled* from
+the schema/seeded-graph via Lua islands. `rela docs build <manual.md>` runs a
+preprocessor over the islands and emits resolved Markdown (pandoc-able to PDF).
+
+**Runtime model (confirmed with user):** ONE graph.
+- **Schema** (`*metamodel.Metamodel` + `*acl.Policy`) is loaded from the **real
+  project** (`--project` dir).
+- **Entities/relations** come **only** from what the manual seeds via
+  `create`/`link` into a **fresh ephemeral `memstore`**, discarded post-build.
+- No real-project entity reads. So `entity{}`/`count{}`/`graph{id}` read the
+  seeded fixture — author-controlled, self-contained. No live-data concern, no
+  `--allow-live-data` gate, no two-graph split.
+
+**Seed posture (confirmed with user): RAW STORE, no validation.** The `create`/
+`link` seed bindings write **directly to `memstore`'s `store.Store` surface**
+(`CreateEntity(ctx,e) error` / `CreateRelation`) — NOT through
+`entitymanager.Manager`. No ACL, no automations, no state-machine `Initial`/
+legal-value gate. Honest "fixture" semantics: the author places exactly the
+entities they want to illustrate (`create("risico",{status="done"})` just
+works). This resolves design-review C1 — the doc runtime needs NO
+`entitymanager` and none of its 6 collaborators; the seed bindings are new thin
+bindings over `store.Store`, distinct from the existing `Mutator`-based
+`rela.create_entity`.
+
+**Determinism is NOT a goal (confirmed with user).** Islands MAY call `ai.*`/
+`http.*`/`today` (e.g. AI-generated prose) — a feature, not a bug. So the doc
+runtime routes through the normal runtime wiring; no need to neutralize
+time/net/AI bindings. (Resolves design-review S5.) The build is "stable given
+stable inputs," not byte-stable across days/network.
+
+IN scope:
+- **Island preprocessor**: markdown by default; a fenced ` ```rela ` **statement
+  island** (doc-API calls append to an output buffer at that position, PHP-echo
+  model; loops/conditionals are plain Lua) and an inline `` `rela <expr>` ``
+  **echo island** (substitutes the string value mid-sentence).
+- **Doc runtime**: a Lua runtime whose `Meta` = real project metamodel and whose
+  `Store`/`Tracer` = a fresh **memstore** + `tracer.New(memstore)`, plus a
+  captured output buffer for statement islands, and a bounded `WithTimeout`
+  (resource-exhaustion guard, see below). Seed = **new thin `create`/`link`/
+  `update` bindings that call `memstore`'s `store.Store` methods directly** (raw
+  store, no entitymanager — see Seed posture). NOT the existing `Mutator`-based
+  `rela.create_entity`.
+- **Binding namespace (settles design-review S1 / open-Q1):** resolvers +
+  emit helpers + seed live under a top-level **`doc.*`** table (e.g.
+  `doc.typeref{}`, `doc.h2()`, `doc.create()`), registered by `internal/docs`
+  as its own module (the in-tree `registerCryptoModule` pattern, `runtime.go:677`)
+  — NOT added to the `rela.*` table and NOT as `(*Runtime)` methods (keeps the
+  plimsoll god-object count flat). A thin preamble may alias the common ones
+  (`typeref = doc.typeref`, `h2 = doc.h2`, `md = doc.md`) into the island's
+  global scope for ergonomics, decided in impl.
+- **Tier-A resolver bindings** (in the `doc.*` module):
+  `typeref{type, fields}`, `values{type, field}`, `relations{type}`,
+  `graph{from, depth, exclude/only, direction}` (mermaid subgraph),
+  `lifecycle{type, field}` (mermaid stateDiagram or flat-list fallback),
+  `entity{id, fields}`, `count{type}`, `roles_matrix{type}`, `description()`,
+  plus emit helpers `h1/h2/h3/md(...)` and seed `create/link/update`.
+- **`internal/mermaid`** new package: extract `mermaidStateDiagram`+`mermaidLabel`
+  from `internal/dataentry/handlers.go` + a `CustomType`→diagram mapping; both
+  `dataentry` and `docs` import it (dataentry refactored to use it).
+- **`rela docs build`** command + a `--strict` knob (empty-resolve policy).
+- An **example manual** under `prototypes/` (ISMS-style corpus) + user docs.
+
+OUT of scope:
+- **Tier B / `screenshot{}`** — the Playwright harness (phase 3).
+- Any browser dependency, data-entry SPA rendering, PNG capture.
+- Changing `tracer` (we post-filter its output; see Approach).
+- Real-project entity reads (seeded memstore only).
+- A push-generator that emits a whole `.md` with no source manual. (A future
+  `rela docs scaffold` that generates a manual-of-islands is a follow-up, not
+  this ticket.)
+
+**Acceptance Criteria:**
+
+1. **Statement island** — a ` ```rela ` block calling `h2("X"); md("y")`
+   produces `## X\n\ny` at that position in the output; surrounding markdown is
+   passed through verbatim. (Test: preprocess a fixture string, assert output.)
+2. **Echo island** — inline `` `rela count{type="risico"}` `` substitutes the
+   count into the sentence; a code span WITHOUT the `rela` marker is left
+   untouched. **Coercion (settles S2):** the preprocessor wraps the island body
+   as `return <expr>`; the returned Go value → string is: `string`→itself,
+   `int64`/`float64`/`number`→`fmt.Sprint`, `nil`→empty (or error under
+   `--strict`), `bool`→error, `table`→error (author placed a block resolver in
+   an inline span — fail loud). An empty/absent expression (`` `rela ` ``) →
+   error naming the line. (Test: each coercion case + empty.)
+3. **`typeref{type="risico", fields="required"}`** emits a markdown table of the
+   required properties (name, type, required) read from the metamodel, in
+   `PropertyOrder`. (Test: against a fixture metamodel.)
+4. **`values{type="risico", field="behandeling"}`** emits the enum values +
+   default, and per-value meaning when `CustomType.Descriptions` is present.
+   (Test: with and without descriptions.)
+5. **`lifecycle{type, field}`** emits a mermaid `stateDiagram-v2` when the
+   custom type has `Transitions`; falls back to a flat value list when it does
+   not. Diagram is injection-safe (synthetic state ids). (Test: both; + a value
+   containing mermaid-breaking chars asserts no injection.)
+6. **`graph{}`** — TWO grains (settles S3):
+   - `from="<type>"` builds the **schema** neighbourhood from `Meta` relations
+     (which types connect to which); depth = hops in the type graph.
+   - `from="<id>"` traverses the **seeded memstore** via tracer; depth = hops in
+     the instance graph.
+   Emits mermaid `graph LR`. **`direction` filters by edge orientation
+   (`.Incoming`), which is SEPARATE from `exclude`/`only` (which filter by
+   relation TYPE `.Relation`)** — the two are distinct fields. `direction="in"`
+   uses `TraceTo`; `direction="out"`/`"both"` uses `TraceFrom` then post-filters
+   `.Incoming`. `exclude`+`only` both set → **error** (contradictory, settles
+   M2). `depth` omitted → **default 2**; hard-capped at **5** (settles C2).
+   Flatten dedupes nodes by id and edges by (from,rel,to) triple.
+   (Test: seed a **diamond-shaped** graph — asserts the exact deduped edge set,
+   catching the tracer `visited` lossy-leaf bug; + depth honored; + exclude/only
+   prune; + a type-grain case.)
+7. **`roles_matrix{type="risico"}`** emits a role×verb table (create/read/update/
+   delete ✓) from the acl policy via `grantsVerb`. (Test: fixture policy.)
+8. **Seed** — a statement island calling `create("risico", {...})` then
+   `entity{id=...}` renders the seeded entity's fields; the write went to the
+   memstore, and the real project on disk is untouched. (Test: assert store
+   isolation.)
+9. **Fail-loud** — an island referencing a nonexistent type/field, or a Lua
+   error, aborts the build with an error naming the **manual's source line**
+   (not the island-internal line — a multi-line island at manual line 40 that
+   errors on its 2nd line reports `manual.md:41`, settles M1) and the offending
+   island. Under `--strict`, an empty resolve (e.g. `description()` with no
+   top-level description) also errors; without it, warns + emits empty.
+   (Test: each failure mode + the line-offset case.)
+10. **`rela docs build manual.md`** end-to-end: an ISMS-style manual (in-tree
+    fixture, no external corpus — settles N3) with prose + islands produces a
+    complete resolved `.md`; exit 0. Output is **stable given stable inputs**
+    (NOT byte-stable across days/network — determinism is not a goal; islands
+    may use time/net/ai). Golden test uses a manual that touches no
+    time/net/ai bindings so it stays comparable. (Integration test.)
+11. **`internal/mermaid`** extraction — `dataentry` help modal still renders the
+    same diagram (no regression). The shared renderer takes a **neutral
+    primitive input** (`initial string; transitions []Transition{From,To,Label}`),
+    NOT `CustomType` and NOT `EnumHelp` — both callers map into it, reproducing
+    the SAME label fallback (`Label`→`Labels[To]`→`To`) so the two paths can't
+    drift (settles S4). New `.go-arch-lint.yml` component + `mayDependOn` edits
+    are mandatory. (Test: shared renderer unit tests + dataentry golden diagram.)
+12. **Resource bounds (settles C2)** — the doc runtime is built with a bounded
+    `WithTimeout` (default 30s inherited, or explicit); an island with an
+    infinite loop aborts at the deadline, not hangs. (Test: a `while true` island
+    times out with a clear error.)
+
+## Research
+
+- [x] ~~For larger features: run `/research`~~ (RES-EK7LSA covers this arc; the
+  2026-07-21 addendum captures the full doc-language design validated against
+  the ISMS corpus. No new research doc needed.)
+- [x] Searched for existing libraries — reuse in-tree gopher-lua runtime; no new dep.
+- [x] Checked codebase for similar patterns or reusable code (two Explore sweeps).
+- [x] Looked for reference implementations — openvwr (studied), document-mode path.
+- [x] Reviewed relevant rela concepts for prior art.
+
+**Research Doc:** RES-EK7LSA (see the ADDENDUM 2026-07-21 for the doc-language design).
+
+**Existing Solutions (grounded, file:line):**
+
+- **Lua runtime** — `internal/lua`, gopher-lua (`go.mod:26`). Sandboxed
+  (`SkipOpenLibs`, no io/os, `runtime.go:272/326`). `lua.NewReader(ReadDeps,...)`
+  (`runtime.go:249`) / `lua.NewWriter(WriteDeps,...)` (`:258`). Bindings are
+  `func(*lua.LState) int`; table-in via `luaTableToGoMap`, table/value-out via
+  `EntityToTable` (`:1080`) / `GoToLuaValue` (`:1207`). Read bindings registered
+  in `registerReadBindings` (`:682`) — **the extension point for new resolvers.**
+- **Document mode = the closest analogue.** `Engine.ExecuteDocument(path, deps,
+  stdout, docID, entryID, timeout)` (`internal/script/executor.go:98`) already
+  runs a Lua runtime and captures its **stdout as rendered markdown**
+  (`WithDocumentMode`, `runtime.go:206`). Our statement-island emit buffer is the
+  same idea; we can model the doc runtime on this path.
+- **ReadDeps/WriteDeps** — `internal/lua/deps.go:21/51`. `WriteDeps.Store` +
+  `WriteDeps.EntityManager` (a 5-method `Mutator`, `deps.go:40`) is exactly the
+  seed seam: point `Store` at `memstore.New()` and supply a memstore-backed
+  `Mutator`. `Meta *metamodel.Metamodel` stays the real project's.
+- **Write bindings** (the seed API) — `rela.create_entity` (`runtime.go:1409`),
+  `rela.create_relation` (`:1641`), `rela.update_entity` (`:1451`), registered in
+  `registerWriteBindings` (`:729`). No new API.
+- **Wire through `script.NewWriterRuntime`** (`internal/script/runtime.go:20`) so
+  AI/secrets load consistently (per CLAUDE.md, don't call `ai.LoadProvider`).
+- **Schema walk template** — `internal/cli/schema.go`: `writeEntityProperties`
+  (:301), `writePropertyDetail` (:320, incl. enum fallback to
+  `meta.Types[type].Values` at :338), `writeEntityRelations` (:346),
+  `getSortedEntityNames` (:819). Clone the walk shape for the resolvers.
+- **Metamodel types (all doc-fields CONFIRMED present)** —
+  `Metamodel.Description` (`types.go:23`), `EntityDef.Description` (:213) +
+  `PropertyOrder` (:222, stable order), `PropertyDef.{Description,Labels,Values,
+  Required,List}` (:260-314), `RelationDef.{Description,From,To,Inverse}` (:429),
+  `CustomType.{Values,Labels,Descriptions,Default,Description,Transitions,Initial}`
+  (:136-164), `TransitionDef.{From,To,Label,Help,Guard,When}` (:170-198). **No
+  metamodel changes needed** — phase 1 already added everything.
+- **tracer** — `internal/tracer/tracer.go`. `TraceFrom(ctx,id,maxDepth)` (:48,
+  bidirectional), `TraceTo` (:51, incoming), result `TraceResult{...,Relation,
+  Incoming,Children}` (:24). `tracer.New(reader)` (:70); a `memstore` satisfies
+  the reader. **NO edge-type filter** — decision below.
+- **mermaid (Go-side, unexported)** — `mermaidStateDiagram(EnumHelp)`
+  (`internal/dataentry/handlers.go:297`, synthetic-id injection-safe),
+  `mermaidLabel` (:348). Keyed on `EnumHelp` (dataentry-local), NOT `CustomType`.
+  `internal/htmlutil/mermaid.go` has fence-rewrite helpers (different concern).
+- **acl** — `internal/acl/policy.go`: `Policy.{Description,Roles,...}` (:87),
+  `RoleDef.{Description,Create,Read,Update,Delete,Permissions}` (:172),
+  **`grantsVerb(role,op,target)` (:196) = the matrix cell function.**
+  `LoadPolicy(path)` (:340, `errors.Is(err,os.ErrNotExist)` for "no policy").
+  acl deliberately does not import metamodel (arch-lint); role names + entity
+  types are strings — the matrix is a pure string cross-product.
+- **memstore** — `internal/store/memstore`, **no build tag, directly importable.**
+  `memstore.New(opts...) *MemStore` (`memstore.go:95`), satisfies `store.Store`
+  and tracer's reader. Metamodel is a **separate collaborator**, not loaded into
+  the store.
+
+## Approach
+
+- [x] Technical approach chosen and documented
+- [x] Approach builds on existing patterns (not reinventing)
+- [x] Alternatives considered (document why rejected)
+- [x] Dependencies identified
+
+**Design decisions (locked with user):**
+
+- **`graph{}` edge filtering → post-filter in the doc layer.** Call
+  `tracer.TraceFrom(ctx,id,depth)` unchanged, then prune `TraceResult.Children`
+  by `.Relation` against `exclude`/`only` in the doc package. Tracer stays a
+  clean pure-reader; filtering logic lives with the feature; smallest blast
+  radius. (Rejected: adding a filter param to the shared tracer — bigger review
+  surface, storetest implications, not needed yet.)
+- **Mermaid renderer → new `internal/mermaid` package.** Move
+  `mermaidStateDiagram`/`mermaidLabel` there, add a `StateDiagram(ct CustomType,
+  ...)` entry that builds the diagram directly from a `CustomType` (mapping
+  `Initial`/`Transitions`/`Labels`). Refactor `dataentry` to call it (its
+  `EnumHelp`→diagram path delegates). One injection-safe renderer, shared.
+- **One graph, seeded memstore, RAW-store seed (resolves C1).** The seed
+  bindings write directly to `memstore` via its `store.Store` methods
+  (`CreateEntity(ctx,e) error`, `CreateRelation`) — memstore satisfies
+  `store.Store`, so **no `entitymanager` and none of its 6 collaborators are
+  needed.** Schema resolvers read the real `Meta`; instance resolvers + seed use
+  the memstore + `tracer.New(memstore)`. acl loaded separately via
+  `acl.LoadPolicy(realRoot/acl.yaml)`. The doc runtime is thus a **reader-shaped
+  runtime plus a small raw-store write surface** — it does NOT need the full
+  `WriteDeps`/`Mutator` machinery.
+- **Determinism dropped (resolves S5).** Route through the normal runtime; `ai`/
+  `http`/`today` stay available to islands (a feature). Golden test avoids them.
+- **`--output` file semantics (resolves S6).** The manual path and `--output`
+  are **operator-supplied, arbitrary, typically absolute** paths — same trust as
+  `pandoc in.md -o out`. Use plain `os.ReadFile`/`os.WriteFile`; NO project-root
+  traversal check (`loadScript`'s `filepath.IsLocal`+`.lua` guard does not apply
+  and would wrongly reject an absolute `.md`). `--output` overwrites; refuse if
+  it names a directory; create parent dirs. Default output: stdout if `--output`
+  omitted.
+
+**Technical approach (hard-first order per user "start with the hard stuff first"):**
+
+1. **`internal/mermaid` extraction** (do first — unblocks `lifecycle`/`graph`
+   and de-risks the regression). Define a **neutral primitive input** —
+   `type Transition struct{ From, To, Label string }`, `StateDiagram(initial
+   string, ts []Transition) string` + `Graph(nodes []Node, edges []Edge) string`
+   (LR). Move `mermaidLabel` + synthetic-id logic. Refactor `dataentry/
+   handlers.go` so its `EnumHelp`→diagram path maps into `StateDiagram` (NOT the
+   reverse — mermaid must not import dataentry). Reproduce the label fallback
+   (`Label`→`Labels[To]`→`To`) once, in the `CustomType`→`[]Transition` mapper
+   the doc side uses, matching dataentry's `Move` fallback so they can't drift
+   (S4). **Add `mermaid` to `.go-arch-lint.yml`** + `dataentry`/`docs`
+   `mayDependOn`. Keep dataentry tests green + golden-compare the diagram.
+
+2. **The doc runtime + island preprocessor** (the architectural core, riskiest):
+   - New package `internal/docs` (CLI wiring in `internal/cli`).
+   - **Preprocessor**: a scanner that splits a markdown file into
+     literal-passthrough spans, ` ```rela ` fenced statement islands, and inline
+     `` `rela <expr>` `` echo spans. Track each island's **manual source line**
+     (for M1 fail-loud offset). (Non-`rela` fences/spans pass through untouched.)
+   - **Runtime**: build a runtime with real `Meta` + a fresh `memstore` +
+     `tracer.New(memstore)` + a bounded `WithTimeout`. Register the **`doc.*`
+     module** (resolvers + emit + raw-store seed bindings) via a `registerDocModule(r)`
+     helper mirroring `registerCryptoModule` (`runtime.go:677`) — closures over a
+     `docDeps` struct, NOT `(*Runtime)` methods. Statement island: run the chunk,
+     `doc.h*/doc.md` append to an output `*strings.Builder`; splice at position.
+     Echo island: **wrap body as `return <expr>`**, run via `RunActionString`
+     (`runtime.go:492`), coerce the returned `any`→string per AC2.
+   - **Fail-loud**: wrap every island run; map the Lua error frame back to the
+     **manual line** (island start line + intra-island offset − 1, M1); abort
+     with `manual.md:line` + island text. `--strict` promotes empty-resolve to error.
+   - Prove statement vs echo end-to-end with just `doc.md()`/`doc.h2()`/`count{}`
+     before writing the rest of the resolvers.
+
+   Decision on runtime construction: since the seed is **raw-store** (no
+   entitymanager) and determinism is not required, the doc runtime can be built
+   with `lua.NewReader(ReadDeps{Store: memstore, Meta: realMeta, Tracer: ...})`
+   for the read surface, plus the `doc.*` module supplying raw-store
+   `create`/`link`. Confirm during impl whether `NewReader` + a doc-write module
+   is cleaner than `NewWriter` (the latter drags in the `Mutator` surface we do
+   NOT want). Lean: `NewReader` + doc module.
+
+3. **`graph{}`** — TWO code paths behind one name:
+   - **id grain**: `direction="in"`→`tracer.TraceTo`; `"out"`/`"both"`→
+     `tracer.TraceFrom` then post-filter children by `.Incoming` (direction) AND
+     `.Relation` (exclude/only — SEPARATE fields, S3). Flatten with node-dedupe
+     (by id) + edge-dedupe (by from,rel,to) to defeat the `visited` lossy-leaf
+     (S3). `depth` default 2, cap 5 (C2).
+   - **type grain**: walk `Meta.Relations` for edges touching the type, N hops;
+     no tracer. Render via `internal/mermaid.Graph`.
+   `exclude`+`only` both set → error (M2). All node/edge labels through the
+   injection-safe path.
+
+4. **`lifecycle{}`** — `internal/mermaid.StateDiagram(CustomType)` or flat-list
+   fallback when no `Transitions`.
+
+5. **`roles_matrix{}`** — rows/cols from **BOTH** sources (M3): entity-type list
+   from `Meta.Types`/entity defs, verb grants from `Policy.Roles` via
+   `grantsVerb` (+ read). Metamodel entity types drive the rows (a role granting
+   a verb on an undeclared type is ignored with a warning). Markdown table.
+   acl.yaml absent → `LoadPolicy` returns `os.ErrNotExist` → emit a clear
+   "no policy defined" note, not a crash.
+
+6. **Mechanical resolvers** — `typeref` (mirror `writeEntityProperties`),
+   `values`, `relations` (mirror `writeEntityRelations`), `entity`, `count`,
+   `description`.
+
+7. **Seed bindings (`create`/`link`/`update`) — raw store, NOT aliases of the
+   existing write bindings.** New `doc.*` bindings that call `memstore`'s
+   `store.Store` methods directly (`CreateEntity(ctx,e) error` from
+   `memstore/tx.go`, `CreateRelation`). No entitymanager, no validation (per
+   confirmed seed posture). `link(from, type, to)` = `CreateRelation`. This is
+   real (small) work, NOT the "naming/ergonomics" the earlier draft claimed —
+   the design-review correctly flagged that mislabel; the raw-store decision is
+   what makes it small.
+
+8. **CLI + example + docs** — `rela docs build <manual>` in `internal/cli`
+   (register in `requiresProject`), `--strict` flag, `--output` path; an example
+   manual under `prototypes/data-entry/` (reuse the phase-1 corpus); a
+   `docs/rela-docs.md` guide (via the source-guide pipeline) + CLAUDE.md pointer.
+
+**Files to modify / add:**
+- ADD `internal/mermaid/{statediagram.go,graph.go,label.go,*_test.go}` (neutral
+  primitive input types).
+- EDIT `internal/dataentry/handlers.go` (map `EnumHelp`→`mermaid.StateDiagram`).
+- ADD `internal/docs/{preprocess.go,runtime.go,resolvers_*.go,seed.go,*_test.go}`.
+- The `doc.*` module is registered from `internal/docs` (closures over a deps
+  struct), invoked after runtime construction via `LState()` or a small exported
+  hook — NO new methods on `*Runtime` (plimsoll). Confirm the exact seam in impl;
+  avoid editing `internal/lua/runtime.go`'s core registration if possible.
+- EDIT `.go-arch-lint.yml` — add `mermaid` + `docs` components and `mayDependOn`
+  (mandatory, not optional — `just arch-lint` gates the PR).
+- ADD `internal/cli/docs.go` (the `rela docs build` command) + wire in the CLI
+  tree; register in `requiresProject`.
+- ADD an in-tree example manual (e.g. `prototypes/data-entry/manual/*.md`) +
+  `docs-project/entities/guides/GUIDE-rela-docs.md` (source guide) →
+  `docs/rela-docs.md` via `just docs` (confirmed with user: source-guide
+  pipeline, matching metamodel.md/acl-overview.md).
+
+## Security Considerations
+
+- [x] Input sources identified
+- [x] Input validation approach defined (allowlist preferred over blocklist)
+- [x] Security-sensitive operations identified
+- [x] Error handling doesn't leak sensitive information
+
+**Input Sources & Validation:**
+- **The manual `.md` + its Lua islands** — operator-authored, same trust level as
+  a scheduler script or `metamodel.yaml`. Islands run in the **already-sandboxed**
+  gopher-lua state (no io/os/debug; `loadfile`/`load` nilled — `runtime.go:326`).
+  Write bindings target a **throwaway memstore**, never the real store, so a
+  malicious/buggy seed cannot corrupt project data.
+- **Resolver args** (type/field/id strings) — validated against the metamodel /
+  seeded store; unknown refs **fail loud** (allowlist by construction: only
+  declared types/fields resolve).
+- **Mermaid injection** — the #1 concrete risk, carried from phase 1a.5. All
+  enum values / labels / node names routed through `internal/mermaid`'s
+  synthetic-id + `mermaidLabel` newline-flattening. **AC5 asserts a
+  mermaid-breaking value does not inject.** graph node labels get the same
+  treatment.
+- **Path handling (corrected per S6)** — the manual and `--output` are
+  operator-supplied arbitrary paths (a doc, not a project script), same trust
+  boundary as `pandoc in.md -o out`. Plain `os.ReadFile`/`os.WriteFile`; **no**
+  project-root/`filepath.IsLocal` check (that guard is for untrusted
+  project-relative script loading and would wrongly reject an absolute `.md`).
+  No shell interpolation. `--output` refuses a directory target.
+- **Resource exhaustion (C2)** — TWO vectors, both bounded:
+  (a) **infinite loop in an island** — `CallStackSize:1024` stops recursion only;
+  a flat `while true` is stopped solely by the context deadline
+  (`applyTimeout`→`L.SetContext`, `runtime.go:577`; gopher-lua honors ctx-cancel
+  at VM points). **The doc runtime MUST be built with a bounded `WithTimeout`**
+  (AC12) — do not rely on inheriting `DefaultTimeout` implicitly; set it.
+  (b) **unbounded tracer** — `graph{}` omitted `depth` → `TraceFrom(id,0)` →
+  `maxDepth<=0` is **unbounded** (`tracer.go:96`). Mitigation: `graph{}` defaults
+  `depth` to **2** and hard-caps at **5**; never passes `<=0` to the tracer.
+
+**Security-Sensitive Operations:**
+- Lua execution — contained by the existing sandbox (no io/os/debug; `loadfile`/
+  `dofile`/`load`/`loadstring`/`setmetatable`/`raw*` nilled at
+  `runtime.go:347-350`; `coroutine` present but bounded by the timeout). This is
+  the *sanctioned* place the "no user Lua on the read path" rule does not bite
+  (offline operator build; seed writes land in a throwaway memstore). Read-path
+  hot-loop concerns do not apply — one-shot build.
+- Seed writes — raw `store.Store` on a throwaway memstore; cannot touch the real
+  project. The real project dir is read-only for the whole build (metamodel +
+  acl loaded, entities never read).
+- File write (`--output`) — single operator-chosen output file.
+
+## Test Plan
+
+- [x] Test scenarios documented for each acceptance criterion
+- [x] Edge cases identified and documented
+- [x] Negative test cases defined
+- [x] Integration test approach defined
+
+**Test Scenarios (map to ACs):**
+- Preprocessor unit tests (AC1/AC2): table-driven over source strings →
+  expected spliced output; incl. non-`rela` fence/span passthrough, source-line
+  tracking, statement-vs-echo.
+- Resolver unit tests (AC3-7): each resolver against a small **fixture
+  metamodel** + (for instance resolvers) a **seeded memstore**. Build fixtures
+  with `memstore.New()` + a hand-built `*metamodel.Metamodel` (`InitAliases()`)
+  + `acl.LoadPolicyBytes` for the matrix — **no `appbuildtest`/`entitymanager`
+  needed** now the seed is raw-store (this is a direct benefit of the C1
+  resolution; the earlier draft wrongly assumed a full manager). Seed test data
+  via `memstore.CreateEntity`/`CreateRelation` directly.
+- Seed isolation (AC8): seed via `create`, read via `entity`, assert the real
+  project dir is untouched (memstore is a separate object; the build never opens
+  the real entities dir for writes). Raw-store seed means `create` always
+  succeeds regardless of state-machine `Initial` — assert `{status="done"}`
+  seeds without a transition error (the fixture-semantics guarantee).
+- Fail-loud (AC9): bad type, bad field, Lua syntax error, `--strict` empty
+  resolve — each asserts an error mentioning file:line.
+- Integration (AC10): a committed example manual → golden resolved `.md`
+  (deterministic; assert byte-stable across runs).
+- Mermaid regression (AC11): `internal/mermaid` unit tests + the existing
+  dataentry help-modal test stays green.
+
+**Edge Cases:**
+- Empty manual / manual with no islands → passthrough unchanged.
+- Island resolving to empty (`description()` w/ no top-level desc) → `--strict`
+  errors, else empty + warning.
+- Enum with no `Descriptions` → `values` emits values only (AC4 negative).
+- Custom type with no `Transitions` → `lifecycle` flat-list fallback (AC5).
+- `graph` depth 0 / unbounded (tracer treats `<=0` as unbounded — clamp/validate
+  a sane max to avoid a runaway on a large seed).
+- `exclude` + `only` both set → `only` wins (documented) or error (decide;
+  lean: error, contradictory).
+- Unicode / mermaid-breaking chars in values, labels, ids (injection).
+- Duplicate seed id / invalid seed props → entitymanager warning surfaced.
+
+**Negative Tests:**
+- Unknown `type`/`field`/`id` → fail-loud with file:line.
+- Malformed island (unterminated expr) → parse error with line.
+- `rela docs build` with no `--project` → clear error (command requires project).
+- acl.yaml absent → `roles_matrix` degrades (no policy) with a clear message,
+  not a crash.
+
+## Risk Assessment
+
+- [x] Technical risks assessed with mitigations
+- [x] Security risks assessed (see Security Considerations)
+- [x] Effort estimated (xs/s/m/l/xl)
+
+**Risks:**
+- **Preprocessor/runtime plumbing is the novel part** (everything else mirrors
+  existing walks). Mitigation: model on the existing document-mode stdout-capture
+  path; prove statement/echo end-to-end (step 2) before resolvers.
+- **`internal/mermaid` extraction could regress the help modal.** Mitigation: do
+  it first, keep dataentry tests green, golden-compare the emitted diagram.
+- **Registering doc bindings without editing core `internal/lua`.** Prefer an
+  `Option` that registers extra bindings from `internal/docs`; fall back to a
+  small core hook only if needed. Keeps the god-object/plimsoll surface of the
+  runtime from growing.
+- **arch-lint boundaries** — `internal/docs` may import
+  `metamodel`/`acl`/`tracer`/`store`/`memstore`/`lua`/`script`; must NOT pull
+  browser/dataentry-SPA deps. Run `just arch-lint` early.
+- **Effort: l** (new package + runtime + ~9 resolvers + CLI + mermaid extraction
+  + example + docs). Could split into l+m if the resolver set is staged, but the
+  user asked for "all of it" — keep as one l ticket, staged internally.
+
+## Documentation Planning
+
+- [x] User-facing docs identified
+- [x] Docs-checklist will be created when entering implementation
+
+**Documentation Impact:**
+- [x] `docs/cli-reference.md` — the new `rela docs build` command + flags.
+- [x] A new `docs/rela-docs.md` guide — the doc language: island syntax, the
+  resolver reference, the seed/memstore model, fail-loud/`--strict`. Authored via
+  the source-guide pipeline if one applies, else a plain doc.
+- [x] CLAUDE.md — a short pointer to the doc-language + `internal/docs` +
+  `internal/mermaid` (new subsystems).
+- [x] The committed **example manual** doubles as living documentation.
+- [x] ~~docs/metamodel.md~~ (N/A: no metamodel changes — phase-1 fields already exist).
+
+## Design Review
+
+- [x] Run `/design-review` before starting implementation (cranky reviewer, verified against real code)
+- [x] All critical/significant findings addressed in plan
+
+**Design Review Findings** (all addressed in-plan; no review-response entities
+needed since fixes landed directly in this plan before implementation):
+
+- **C1 (critical) — seed path wrong: `memstore` ≠ `Mutator`.** Correct: only
+  `entitymanager.Manager` satisfies `Mutator`, and it needs 6 collaborators +
+  runs the real state-machine/ACL/automations. **RESOLVED** by the confirmed
+  **raw-store seed posture**: seed bindings call `memstore`'s `store.Store`
+  methods directly, no entitymanager at all. Simplifies the runtime.
+- **C2 (critical) — resource bounds unwired.** RESOLVED: explicit `WithTimeout`
+  on the doc runtime (AC12) + `graph{}` depth default 2 / cap 5 (never passes
+  `<=0` to the unbounded tracer). See Security.
+- **S1 (significant) — binding namespace / registration seam.** RESOLVED: a
+  top-level **`doc.*`** module registered `registerCryptoModule`-style (closures,
+  not `*Runtime` methods → plimsoll flat). Namespace locked now.
+- **S2 (significant) — echo coercion undefined.** RESOLVED: AC2 pins the
+  `return <expr>` wrapping + the `any`→string coercion table.
+- **S3 (significant) — `direction` vs relation-filter conflated; tracer is
+  bidirectional + lossy `visited`.** RESOLVED: AC6 separates `direction`
+  (`.Incoming`, chooses `TraceTo`/`TraceFrom`) from `exclude`/`only`
+  (`.Relation`); node/edge dedupe on flatten; diamond-graph fixture asserts the
+  exact edge set; type-grain gets its own path/AC.
+- **S4 (significant) — mermaid input type + drift + arch-lint.** RESOLVED: AC11
+  mandates a **neutral primitive input** (not `CustomType`/`EnumHelp`), one
+  shared label-fallback, and the mandatory `.go-arch-lint.yml` edits.
+- **S5 (significant) — determinism vs always-on ai/http/time.** RESOLVED:
+  determinism is **not a goal** (confirmed); AC10 relaxed to "stable given
+  stable inputs"; islands may use ai/http/time.
+- **S6 (significant) — cited traversal helper doesn't apply.** RESOLVED:
+  Security section corrected — plain `os.ReadFile`/`WriteFile`, operator trust
+  boundary, no `filepath.IsLocal` guard.
+- **M1 — fail-loud must report the MANUAL line, not the island-internal line.**
+  RESOLVED: AC9 pins the offset arithmetic + a multi-line-island test.
+- **M2 — `exclude`+`only` both set → error** (locked, AC6).
+- **M3 — `roles_matrix` reads BOTH `Meta` and `Policy`** (rows from metamodel
+  types) — documented in step 5.
+- **M4 — time bindings vs golden test** — golden manual avoids time/net/ai
+  bindings (AC10).
+- **N1/N2/N3 — cite fixes** (`runtime.go:347-350`, coroutine note, in-tree
+  fixture only) folded into Security + AC10.

--- a/tickets/entities/researchs/RES-EK7LSA.md
+++ b/tickets/entities/researchs/RES-EK7LSA.md
@@ -192,3 +192,156 @@ reads thin.
 per-value descriptions, TransitionDef help. Populate in-tree examples.
 - TKT (Phase 1b): ACL RoleDef description (+ optional policy description).
 - TKT (Phase 2): `rela docs --output-dir` generator (depends on 1a+1b).
+
+---
+
+## ADDENDUM (2026-07-21) — reframed: from static generator to a **doc language**
+
+Phase 1a/1b shipped (TKT-0YBFT8, TKT-DUQBD0, TKT-JO2SAD). Before ticketing phase
+2, a design session (prompted by studying **sourcehaven-bv/openvwr**'s
+Playwright screenshot system for its ISMS manual) reframed phase 2. The
+recommendation above still holds for *what content to emit*; what changed is the
+**authoring model**. Superseding decision: phase 2 is **not** a push-generator
+that emits a whole `.md`; it is a **doc language** — markdown authored by a
+human, with the mechanical fragments *pulled* from the schema/graph at build.
+
+### The inversion (push → pull)
+
+- **Old (B1):** `rela docs` walks the schema and emits one big Markdown. Prose
+is either absent (dry) or robotic. Fragments can't be placed where a writer
+wants them.
+- **New:** the writer authors a normal Markdown manual and **escapes into Lua
+islands** to summon fragments. Prose stays prose; reference fragments are live
+includes that can't drift. This is Diátaxis done right — *explanation/how-to* is
+authored, *reference* is resolved.
+
+### The language — markdown with Lua islands (PHP/JSX/MDX model)
+
+Markdown by default; two island forms (chosen syntax):
+- **Statement island** — a fenced ` ```rela ` block. Runs Lua for
+side-effects; doc-API calls append to an output buffer at that position (PHP
+`echo ` model). For multi-emit / loops.
+- **Echo island** — an inline `` `rela <expr>` `` span. Substitutes the string
+value mid-sentence (interpolation).
+
+Rationale for Lua-as-engine over a bespoke `{{directive}} ` grammar: rela
+**already has** a Lua runtime (`internal/lua `, `ReadDeps `/`WriteDeps `),
+the MCP `lua_* ` tools, and `just docs ` is already a Lua content pipeline.
+The high-level doc API **is** the DSL — a *library* of functions bound into a
+doc runtime, not a new language. The escape hatch (loops, conditionals) and the
+common case are the same language, so the power tier costs zero extra grammar.
+NOTE (validated in the prototype): the markdown host earns its keep because
+manuals are ~85% prose — NOT because `{{directive}} ` reads better than `fn{}
+` (it doesn't; that was an overclaim). The host format is the value, not the
+sugar.
+
+### The doc API (island functions) — validated against the ISMS corpus
+
+Hand-resolved a real ISMS "Risicobeheer" chapter against
+`sourcehaven-bv/isms-sourcehaven `'s `metamodel.yaml ` + live `RISK-001.md `
+(prototype artifact built this session). Surface:
+
+| Function | Kind | Reads | Emits |
+| --- | --- | --- | --- |
+| `typeref{type, fields} ` | resolver | metamodel | field/relation reference table |
+| `values{type, field} ` | resolver | metamodel | enum values + per-value meaning (phase-1a `descriptions `) |
+| `relations{type} ` | resolver | metamodel | flat relation list |
+| `graph{from, depth, exclude/only, direction} ` | resolver | **`tracer `** | **mermaid subgraph** (see below) |
+| `lifecycle{type, field} ` | resolver | metamodel | mermaid `stateDiagram-v2 ` (phase-1a `TransitionDef `) or flat-list fallback |
+| `entity{id, fields} ` | resolver | **live graph** | one entity's values (worked example) |
+| `count{type} ` | resolver | live graph | a number (echo) |
+| `roles_matrix{type} ` | resolver | acl | GitLab-style role×entity capability rows |
+| `description() ` | resolver | metamodel/acl | top-level deployment prose |
+| `create `/`update `/`link ` | **seed (write)** | — | writes the throwaway memstore (see two-graph) |
+| `screenshot{...} ` | **Tier B** | seed graph | captured, annotated PNG (see below) |
+| `h1/h2/h3/md(...) ` | emit | — | structural markdown from Lua |
+
+### Three design refinements from the session (each SIMPLIFIED the design)
+
+1. **`graph{} ` = tracer + mermaid, with `depth ` + `exclude `/`only `.** Thin
+renderer over the existing `tracer ` package (bounded walk + edge filters).
+`from ` as a **type** draws the schema neighbourhood (metamodel read); `from `
+as an **id** traverses the live graph (`tracer `). `exclude ` (prune plumbing
+edges like `spawnt `/`gaat_over `) is what makes the diagram *publishable* —
+turns a hairball into the domain story. `only ` is the allowlist inverse. Node
+labels get the phase-1a.5 injection-safe treatment (`mermaidLabel `/synthetic
+ids).
+
+2. **No `seed.* ` API — reuse the EXISTING rela Lua write bindings.** The seed
+for a screenshot is just `create `/`update `/`link ` (the same `WriteDeps `
+API a scheduler script uses), bound to the throwaway memstore instead of the
+real store. So the **two-graph model IS the CLAUDE.md `ReadDeps `/`WriteDeps `
+split**: read bundle → the documented (real) project, read-only; write bundle →
+a fresh ephemeral `memstore `, discarded post-build. Writes go through
+`entitymanager `, so fixtures are valid by construction. This is the sanctioned
+place the "no user Lua on the read path" rule does NOT bite (offline operator
+build; writes land in a throwaway). It also cleanly resolves the earlier "schema
+vs live-graph" fork: `entity{id="RISK-001"} ` reads real data;
+`screenshot{entity=r.id} ` reads fixture data — different bindings, visibly
+different graphs.
+
+3. **Screenshot annotations = arrows-with-text (openvwr's actual vocabulary).**
+`arrows = {{at, text, side}, ...} ` — the label rides the shaft (the common
+case). `at ` targets a **field** (`"score" ` → schema-checked `data-field `,
+fail-loud) OR a **control** (`"@button:opslaan" ` / `"@role:..." ` → ARIA).
+Keep openvwr's `box `/`badge `/`redact ` as secondary primitives. rela beats
+openvwr here: the data-entry form IS metamodel-generated, so anchors are schema
+fields the harness knows exist — no brittle `getByRole() ` CSS; a renamed field
+breaks the build instead of drifting.
+
+### The Tier A / Tier B split (drives the phase-2/phase-3 boundary)
+
+| | **Tier A — resolvers** | **Tier B — `screenshot{} `** |
+| --- | --- | --- |
+| Reads | metamodel + graph + tracer (`ReadDeps `) | drives the live data-entry SPA |
+| Needs | nothing — pure, offline | Playwright + seeded memstore + role auth |
+| Output | inline markdown / mermaid | PNG + `![]() ` reference |
+| Runs on | any laptop, CI, anywhere | CI (or opt-in dev) only |
+| Failure | **fail-loud** on bad schema ref | **degrade**: placeholder + warning, build still succeeds |
+
+**Tier B must degrade, never block:** a manual always builds without a browser
+(full text/tables/mermaid; screenshots become placeholders). The memstore seed
+itself is browser-free and always runs, so even a degraded placeholder is
+accurate about what it would show.
+
+### openvwr — what was studied and adopted
+
+openvwr builds its ISMS manual via **pandoc + Eisvogel → PDF** from hand-written
+markdown chapters; figures are auto-generated by a **Playwright** `FIGURES
+`-list harness (`tools/screenshots/ `), selectors anchored to ARIA roles not
+pixels, annotations (`arrow `/`box `/`badge `/`redact `) anchored to
+selectors and **fail-loud** if an element is missing. Adopted: the fail-loud
+discipline, the arrow-with-text annotation vocabulary, and the "generated
+reference + hand- written narrative, pandoc-able to PDF" two-track shape.
+Improved on: the figure list is not hand-maintained — it's inline islands; and
+anchors are schema fields, not CSS.
+
+### Open questions to settle in the phase-2 ticket (none structural)
+
+1. **Function vocabulary** — lock a tight, consistent naming set before it
+ossifies (`typeref `/`values `/`relations `/`graph `/`lifecycle `/`entity
+`/`count `/ `roles_matrix `/`description `/`create `/`link `/`screenshot
+`).
+2. **Empty-resolve strictness** — an island resolving to nothing (e.g.
+`description() ` when no top-level description exists): silent `"" ` vs warn
+vs fail. Needs a per-build strictness knob (openvwr fails loud).
+3. **Island marker** — ` ```rela `/`` `rela ` `` chosen (raw source renders as
+a fenced code block on GitHub rather than garbage; greppable). Preprocessor runs
+before any markdown renderer sees the file.
+4. **Live-graph reads in a manual** — `entity{} `/`count{} ` embed real instance
+data. Powerful (can't go stale) but may warrant an opt-in per build. Distinct
+from seed/screenshot data (memstore).
+
+### Revised phase split (supersedes the "Suggested ticket breakdown" above)
+
+- **Phase 1a / 1a.5 / 1b** — doc-fields. DONE (TKT-0YBFT8, TKT-DUQBD0,
+TKT-JO2SAD).
+- **Phase 2 = Tier A** — the doc language + all schema/graph resolvers +
+markdown-island preprocessor, read-only against the real project (+ the memstore
+seed *write* wiring, since `graph `/`entity ` share the runtime and the seed
+is the same write API). Emits markdown; pandoc-able to PDF. NO browser.
+- **Phase 3 = Tier B** — the `screenshot{} ` island: metamodel-driven Playwright
+harness against the seeded memstore, arrow annotations, degradation. Depends on
+phase 2 + needs the data-entry server to accept an in-memory project handle at
+build time (the `memorybackend ` build tag proves the server can run on
+memstore — plumbing, not new capability).

--- a/tickets/entities/review-checklists/REV-9S4HQY.md
+++ b/tickets/entities/review-checklists/REV-9S4HQY.md
@@ -2,55 +2,72 @@
 id: REV-9S4HQY
 type: review-checklist
 title: 'Review: rela-docs phase 2 (Tier A): markdown+Lua-island doc language + schema/graph resolvers'
-status: in-progress
+status: done
 ---
 
 <!-- @managed: claude-workflow v1 -->
 
 ## Automated Checks
 
-- [ ] All tests pass (`just test`)
-- [ ] Lint clean (`just lint`)
-- [ ] Coverage maintained (`just coverage-check`)
+- [x] All tests pass — `go test ./...` green (73 packages); `internal/docs` + `internal/mermaid` + `internal/dataentry` + `internal/cli` all pass
+- [x] Lint clean — `golangci-lint run ./internal/docs/... ./internal/mermaid/...` 0 issues; `just arch-lint` OK (new `mermaid`+`docs` components); `just lint-md` 0 issues
+- [x] Coverage maintained — `just coverage-check` PASS; new packages well above floor (docs 82.6%, mermaid 96.8%)
 
 ## Code Review
 
-- [ ] Run `/code-review` command (invokes cranky-code-reviewer agent)
-- [ ] All critical review-responses addressed
-- [ ] All significant review-responses addressed
-- [ ] Self-reviewed the diff for unrelated changes
+- [x] Ran `/code-review` (cranky-code-reviewer, verified against real code) — verdict: **no critical**, 4 significant, several minors. All addressed.
+- [x] All critical review-responses addressed — none raised (the trust model keeps injection gaps out of critical territory; the one critical the design-review had flagged, the luaFail error round-trip, was fixed before this review)
+- [x] All significant review-responses addressed — RR-ON4PA8 (everyone role), RR-JCSIM1 (mermaid quote-escape), RR-9BU9GN (stale pending), RR-N9F6LB (resolver error line)
+- [x] Self-reviewed the diff for unrelated changes — scoped to `internal/mermaid` (new), `internal/docs` (new), `internal/cli/docs.go`+`kong.go`, `internal/dataentry/handlers.go` (mermaid delegation), `.go-arch-lint.yml`, the guide + example manual
 
-**Review Responses:** <!-- List IDs of review-response entities created, e.g.,
-RR-xxxx -->
+**Review Responses:** RR-ON4PA8, RR-JCSIM1, RR-9BU9GN, RR-N9F6LB (significant, all
+addressed) + RR-8CKDHQ (minors bundle: cell escaping, per-build timeout, mintID
+O(n²), CRLF — all addressed). No critical/significant left open.
+
+The reviewer explicitly confirmed as solid: the dataentry regression
+(`enumStateDiagram` byte-identical to the old renderer, the only divergence being
+a strictly-better empty-endpoint skip); the graph traversal correctly dedupes
+nodes AND edges despite the tracer's bidirectional double-representation (diamond
+test confirms); the schema BFS terminates and dedupes; `requiresProject`
+registration; build + arch-lint pass.
 
 ## Acceptance Verification
 
-- [ ] Each acceptance criterion tested (reference planning checklist)
-- [ ] Test evidence documented in implementation checklist
+- [x] Each acceptance criterion tested (see IMPL-3N1D8Z for the AC→test map)
+- [x] Test evidence documented in implementation checklist
 
 **Acceptance Status:**
-<!-- For each acceptance criterion, state PASS/FAIL with evidence -->
+- AC1 statement island: PASS (TestBuild_StatementIsland)
+- AC2 echo + coercion + prose-disambiguation: PASS (TestBuild_EchoCount, TestParse_RelaProseMentionNotEcho, TestBuild_EchoRejectsBlockResolver)
+- AC3 typeref: PASS (TestBuild_TyperefRequired)
+- AC4 values + descriptions: PASS (TestBuild_ValuesWithDescriptions)
+- AC5 lifecycle diagram + flat fallback + injection: PASS (TestBuild_LifecycleDiagram/_FlatFallback + mermaid injection tests incl. new quote-escape)
+- AC6 graph (diamond dedupe / schema / exclude / conflict): PASS (TestBuild_Graph*)
+- AC7 roles_matrix + everyone fold: PASS (TestBuild_RolesMatrix/_EveryoneFolded/_NoPolicy)
+- AC8 raw-store seed no-gate: PASS (TestBuild_SeedRawStoreNoGate)
+- AC9 fail-loud + line offset + strict: PASS (TestBuild_FailLoudUnknownType/_LuaLineOffset/_StrictEmptyResolve)
+- AC10 end-to-end example manual: PASS (built against the real prototype project)
+- AC11 mermaid extraction, no dataentry regression: PASS (dataentry tests green + reviewer-confirmed byte-identical)
+- AC12 infinite-loop timeout: PASS (TestBuild_InfiniteLoopTimesOut, deadline hit)
 
 ## Documentation (enhancements only)
 
-Skip this section for bugs and internal refactors.
+- [x] Docs-checklist created and linked via `has-docs` (DOCS-DOCLANG)
+- [x] User-facing documentation updated — `GUIDE-rela-docs.md` → `docs/rela-docs.md` + the committed example manual
+- [x] Docs-checklist marked as done
 
-- [ ] Docs-checklist created and linked via `has-docs`
-- [ ] User-facing documentation updated
-- [ ] Docs-checklist marked as done
-
-**Docs Checklist:** <!-- e.g., DOCS-xxxx -->
+**Docs Checklist:** DOCS-DOCLANG
 
 ## Final Checks
 
-- [ ] Commit message explains the why, not just what
-- [ ] No TODOs or FIXMEs left unaddressed
-- [ ] Ready for another developer to use
+- [x] Commit message explains the why — the feat/fix commits each state the doc-language rationale + the review finding they resolve
+- [x] No TODOs or FIXMEs left unaddressed
+- [x] Ready for another developer to use — `rela docs build` works end-to-end; guide + example manual demonstrate it
 
 ## Pull Request
 
-- [ ] Run `/pr` command to create PR and monitor CI
-- [ ] All CI checks pass
-- [ ] PR URL documented below
+- [x] ~~Run `/pr`~~ (done-before-PR gate: PR runs AFTER this ticket is `done`, via `/pr`)
+- [x] ~~All CI checks pass~~ (verified locally: full `go test ./...`, lint, arch-lint, lint-md, coverage all green; CI confirms on the PR)
+- [x] ~~PR URL documented below~~ (recorded when `/pr` opens it)
 
-**PR:** <!-- e.g., https://github.com/org/repo/pull/123 -->
+**PR:** _pending — opens via `/pr` after this ticket reaches `done`_

--- a/tickets/entities/review-checklists/REV-9S4HQY.md
+++ b/tickets/entities/review-checklists/REV-9S4HQY.md
@@ -70,4 +70,4 @@ registration; build + arch-lint pass.
 - [x] ~~All CI checks pass~~ (verified locally: full `go test ./...`, lint, arch-lint, lint-md, coverage all green; CI confirms on the PR)
 - [x] ~~PR URL documented below~~ (recorded when `/pr` opens it)
 
-**PR:** _pending — opens via `/pr` after this ticket reaches `done`_
+**PR:** https://github.com/sourcehaven-bv/rela/pull/1181

--- a/tickets/entities/review-checklists/REV-9S4HQY.md
+++ b/tickets/entities/review-checklists/REV-9S4HQY.md
@@ -1,0 +1,56 @@
+---
+id: REV-9S4HQY
+type: review-checklist
+title: 'Review: rela-docs phase 2 (Tier A): markdown+Lua-island doc language + schema/graph resolvers'
+status: in-progress
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Automated Checks
+
+- [ ] All tests pass (`just test`)
+- [ ] Lint clean (`just lint`)
+- [ ] Coverage maintained (`just coverage-check`)
+
+## Code Review
+
+- [ ] Run `/code-review` command (invokes cranky-code-reviewer agent)
+- [ ] All critical review-responses addressed
+- [ ] All significant review-responses addressed
+- [ ] Self-reviewed the diff for unrelated changes
+
+**Review Responses:** <!-- List IDs of review-response entities created, e.g.,
+RR-xxxx -->
+
+## Acceptance Verification
+
+- [ ] Each acceptance criterion tested (reference planning checklist)
+- [ ] Test evidence documented in implementation checklist
+
+**Acceptance Status:**
+<!-- For each acceptance criterion, state PASS/FAIL with evidence -->
+
+## Documentation (enhancements only)
+
+Skip this section for bugs and internal refactors.
+
+- [ ] Docs-checklist created and linked via `has-docs`
+- [ ] User-facing documentation updated
+- [ ] Docs-checklist marked as done
+
+**Docs Checklist:** <!-- e.g., DOCS-xxxx -->
+
+## Final Checks
+
+- [ ] Commit message explains the why, not just what
+- [ ] No TODOs or FIXMEs left unaddressed
+- [ ] Ready for another developer to use
+
+## Pull Request
+
+- [ ] Run `/pr` command to create PR and monitor CI
+- [ ] All CI checks pass
+- [ ] PR URL documented below
+
+**PR:** <!-- e.g., https://github.com/org/repo/pull/123 -->

--- a/tickets/entities/review-responses/RR-8CKDHQ.md
+++ b/tickets/entities/review-responses/RR-8CKDHQ.md
@@ -1,0 +1,9 @@
+---
+id: RR-8CKDHQ
+type: review-response
+title: 'Code-review minors: cell escaping, per-build timeout, mintID O(n²), CRLF'
+finding: 'Cranky-review minors: (a) mdCell pipe-escaping was applied to description cells but not typeName/enum-label/matrix-type cells; (b) buildTimeout was applied per-island via applyTimeout, giving no effective global ceiling (N islands × 30s); (c) mintID did a full O(n) ListEntities scan (each cloning every entity) per create → O(n²) seeding; (d) CRLF input left stray \r in island bodies handed to Lua.'
+severity: minor
+resolution: '(a) mdCell now applied to typeName, enum value/label, and the matrix type cell. (b) Build wraps the ctx in a single context.WithTimeout(buildTimeout) child so the whole build is bounded (an earlier caller deadline still wins). (c) mintID uses a per-type seedCounts counter. (d) parse normalizes CRLF→LF up front. Nits left as-is (documented behavior): depth=0→default, a ```rela fence with trailing text renders literally, mixed explicit/auto id collision errors loudly.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-9BU9GN.md
+++ b/tickets/entities/review-responses/RR-9BU9GN.md
@@ -1,0 +1,9 @@
+---
+id: RR-9BU9GN
+type: review-response
+title: Stale dr.pending misattributed a later error after a pcall-swallowed luaFail
+finding: The typed-BuildError stash (dr.pending) set by luaFail could be left set if an island wrapped a failing resolver in pcall (pcall/error are in the sandbox). A later, unrelated genuine error in the same island then surfaced the stale pending error — wrong message, kind, and line.
+severity: significant
+resolution: wrapLuaErr now only trusts dr.pending when the raised Lua error message still contains the stashed message (strings.Contains). A pcall-swallowed resolver failure followed by a real error() falls through to report the real failure. Also clears dr.pending unconditionally each call so it can't leak.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-JCSIM1.md
+++ b/tickets/entities/review-responses/RR-JCSIM1.md
@@ -1,0 +1,9 @@
+---
+id: RR-JCSIM1
+type: review-response
+title: mermaid Label did not escape double-quotes/brackets (injection contract broken)
+finding: internal/mermaid rendered node/state text via fmt %q, which emits Go-style backslash escaping (\") that mermaid does NOT honor — mermaid uses HTML entities. A double-quote in a value/label broke out of the quoted label (e.g. n0["a"] --> x["b"]), re-entering mermaid's tokenizer as structure. The package's whole purpose is injection-safety and its docstring claimed to handle breakout chars, but the equally-breaking " was unhandled. Existing injection tests only asserted newline flattening, giving false confidence.
+severity: significant
+resolution: 'Label now entity-escapes \" → #quot;, < → #lt;, > → #gt; (mermaid''s decoded-entity form) in addition to flattening newlines; a new quoted() helper wraps escaped text and all three render sites (state alias, node text, edge label) use it instead of %q. Added TestLabel_EscapesQuotesAndBrackets, TestGraph_QuoteInNodeTextDoesNotBreakOut, TestStateDiagram_QuoteInValueDoesNotBreakOut that feed a bare quote and assert entity-escaping + exactly-two-delimiter-quotes.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-N9F6LB.md
+++ b/tickets/entities/review-responses/RR-N9F6LB.md
@@ -1,0 +1,9 @@
+---
+id: RR-N9F6LB
+type: review-response
+title: Resolver (luaFail) errors reported the island's first line, not the resolver's actual line
+finding: wrapLuaErr computed the correct frame-adjusted manual line but the pending branch overwrote it with seg.line (the island start). So a hand-written Lua error() reported the right line but every resolver error pointed at the top of the island — inconsistent fail-loud accuracy, undercutting the design goal.
+severity: significant
+resolution: The pending branch now uses the already-computed frame-adjusted `line` instead of seg.line. TestBuild_FailLoudLuaLineOffset asserts a Lua error on the 2nd body line of a multi-line island reports the correct manual line; TestBuild_FailLoudUnknownType asserts the resolver-error line + clean message + kind=resolve.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-ON4PA8.md
+++ b/tickets/entities/review-responses/RR-ON4PA8.md
@@ -1,0 +1,9 @@
+---
+id: RR-ON4PA8
+type: review-response
+title: roles_matrix ignored the built-in everyone role
+finding: roles_matrix rendered `everyone` as a plain column and never folded its grants into other roles' rows. Since acl appends EveryoneRole to every principal's effective role set, the table understated effective permissions — worst outcome for a security-doc feature. Also the grantsVerb/grantsList replication of acl's unexported logic had already drifted (the everyone fold was what got lost).
+severity: significant
+resolution: roles_matrix now excludes `everyone` from the columns (namedRoleNames) and OR-folds its grants into every named role's cell (roleGrantsVerb). When everyone grants anything, a footnote is emitted ("✓ cells include grants from the built-in everyone role"). Regression test TestBuild_RolesMatrixEveryoneFolded asserts everyone is not a column, the fold applies, and the footnote appears.
+status: addressed
+---

--- a/tickets/entities/tickets/TKT-3RLZR4.md
+++ b/tickets/entities/tickets/TKT-3RLZR4.md
@@ -5,7 +5,7 @@ title: 'rela-docs phase 2 (Tier A): markdown+Lua-island doc language + schema/gr
 kind: enhancement
 priority: medium
 effort: l
-status: in-progress
+status: review
 ---
 
 Phase 2 of FEAT-G4VO53, reframed as a **doc language** (see RES-EK7LSA addendum

--- a/tickets/entities/tickets/TKT-3RLZR4.md
+++ b/tickets/entities/tickets/TKT-3RLZR4.md
@@ -5,7 +5,7 @@ title: 'rela-docs phase 2 (Tier A): markdown+Lua-island doc language + schema/gr
 kind: enhancement
 priority: medium
 effort: l
-status: review
+status: done
 ---
 
 Phase 2 of FEAT-G4VO53, reframed as a **doc language** (see RES-EK7LSA addendum

--- a/tickets/entities/tickets/TKT-3RLZR4.md
+++ b/tickets/entities/tickets/TKT-3RLZR4.md
@@ -1,0 +1,79 @@
+---
+id: TKT-3RLZR4
+type: ticket
+title: 'rela-docs phase 2 (Tier A): markdown+Lua-island doc language + schema/graph resolvers'
+kind: enhancement
+priority: medium
+effort: l
+status: in-progress
+---
+
+Phase 2 of FEAT-G4VO53, reframed as a **doc language** (see RES-EK7LSA addendum
+2026-07-21).
+
+## What
+
+A markdown-with-Lua-islands doc language + the Tier-A resolver library, plus a
+`rela docs build <manual.md>` command that runs the preprocessor and emits
+resolved Markdown (pandoc-able to PDF). **No browser** — Tier B (`screenshot{}`)
+is phase 3.
+
+## The language
+
+Markdown by default; escape into Lua:
+- **Statement island** — fenced ` ```rela ` block; doc-API calls append to an output buffer at that position (PHP `echo ` model); supports loops/conditionals (plain Lua).
+- **Echo island** — inline `` `rela <expr>` `` span; substitutes the string value mid-sentence.
+
+Preprocessor runs before any markdown renderer sees the file. Raw source renders
+as a fenced code block on GitHub (chosen for that reason).
+
+## Doc runtime & the two-graph model
+
+The island runtime binds rela's existing **`ReadDeps `** (read the
+documented/real project, read-only) and, for the seed, the existing **`WriteDeps
+`** `create `/`update `/`link ` bindings **bound to a throwaway `memstore
+`** (discarded post-build). This IS the CLAUDE.md ReadDeps/WriteDeps split:
+read→real project, write→ephemeral scratch. No new `seed.* ` API — reuse the
+scheduler/MCP write bindings. Sanctioned exception to "no user Lua on the read
+path" (offline operator build; writes land in a throwaway).
+
+## Tier-A resolver surface
+
+| Function | Reads | Emits |
+| --- | --- | --- |
+| `typeref{type, fields} ` | metamodel | field/relation reference table |
+| `values{type, field} ` | metamodel | enum values + per-value meaning (phase-1a `descriptions `) |
+| `relations{type} ` | metamodel | flat relation list |
+| `graph{from, depth, exclude/only, direction} ` | **`tracer `** | mermaid subgraph (type=schema neighbourhood, id=live graph) |
+| `lifecycle{type, field} ` | metamodel | mermaid `stateDiagram-v2 ` (phase-1a `TransitionDef `) or flat-list fallback |
+| `entity{id, fields} ` | live graph | one entity's values |
+| `count{type} ` | live graph | a number |
+| `roles_matrix{type} ` | acl | role×entity capability rows |
+| `description() ` | metamodel/acl | top-level deployment prose |
+| `h1/h2/h3/md(...) ` | — | structural markdown from Lua |
+
+Reuse: mirror `internal/cli/schema.go `'s metamodel walk; `graph ` over
+existing `tracer `; mermaid via phase-1a.5's injection-safe
+`mermaidStateDiagram `/`mermaidLabel `/synthetic-ids (from HelpModal path).
+Depend only on `metamodel `/`acl `/`tracer `/`store `/`lua ` — no browser,
+no new heavy deps.
+
+## Hard-first implementation order (per user: "start with the hard stuff first")
+
+1. **Doc runtime + island preprocessor** (the architectural core, riskiest): tokenize ` ```rela `/`` `rela ` `` islands; a Lua runtime binding ReadDeps (real store) + WriteDeps (memstore) + an output-buffer emit API (`h1 `/`md `/statement-island append) + echo-return semantics; fail-loud with `file:line ` on Lua error / bad ref. Prove statement vs echo end-to-end with `md() `/`h2() ` before any resolver.
+2. **`graph{} `** — the hardest resolver (tracer traversal + depth + exclude/only + mermaid render + injection-safe labels; type-vs-id dual grain).
+3. **`lifecycle{} `** — mermaid stateDiagram + flat-list fallback (reuse 1a.5).
+4. **`roles_matrix{} `** — acl walk.
+5. The mechanical resolvers: `typeref ` / `values ` / `relations ` / `entity ` / `count ` / `description `.
+6. **`create `/`link ` seed bindings** on the memstore (may land with step 1's runtime since it's the same WriteDeps API pointed at memstore).
+7. `rela docs build ` command wiring + `--strict ` knob + an example manual under `prototypes/ ` (the ISMS-style corpus) + docs.
+
+## Open questions to settle during planning (none structural)
+
+1. Function vocabulary — lock the naming set before it ossifies.
+2. Empty-resolve strictness — silent `"" ` vs warn vs fail; per-build `--strict ` knob (openvwr fails loud).
+3. Live-graph reads (`entity `/`count `) in a manual — may warrant a per-build opt-in (distinct from memstore seed data).
+4. Where `rela docs ` command + the preprocessor package live (`internal/docs `? `internal/cli `?) and how the memstore + data-entry render helpers are wired without pulling browser deps.
+
+Prototype (this session) hand-resolved a real ISMS "Risicobeheer" chapter
+against `sourcehaven-bv/isms-sourcehaven ` to validate the ergonomics.

--- a/tickets/relations/TKT-3RLZR4--affects--schema-visualization.md
+++ b/tickets/relations/TKT-3RLZR4--affects--schema-visualization.md
@@ -1,0 +1,5 @@
+---
+from: TKT-3RLZR4
+relation: affects
+to: schema-visualization
+---

--- a/tickets/relations/TKT-3RLZR4--has-docs--DOCS-DOCLANG.md
+++ b/tickets/relations/TKT-3RLZR4--has-docs--DOCS-DOCLANG.md
@@ -1,0 +1,5 @@
+---
+from: TKT-3RLZR4
+relation: has-docs
+to: DOCS-DOCLANG
+---

--- a/tickets/relations/TKT-3RLZR4--has-implementation--IMPL-3N1D8Z.md
+++ b/tickets/relations/TKT-3RLZR4--has-implementation--IMPL-3N1D8Z.md
@@ -1,0 +1,5 @@
+---
+from: TKT-3RLZR4
+relation: has-implementation
+to: IMPL-3N1D8Z
+---

--- a/tickets/relations/TKT-3RLZR4--has-planning--PLAN-TYH98I.md
+++ b/tickets/relations/TKT-3RLZR4--has-planning--PLAN-TYH98I.md
@@ -1,0 +1,5 @@
+---
+from: TKT-3RLZR4
+relation: has-planning
+to: PLAN-TYH98I
+---

--- a/tickets/relations/TKT-3RLZR4--has-review--REV-9S4HQY.md
+++ b/tickets/relations/TKT-3RLZR4--has-review--REV-9S4HQY.md
@@ -1,0 +1,5 @@
+---
+from: TKT-3RLZR4
+relation: has-review
+to: REV-9S4HQY
+---

--- a/tickets/relations/TKT-3RLZR4--has-review-response--RR-8CKDHQ.md
+++ b/tickets/relations/TKT-3RLZR4--has-review-response--RR-8CKDHQ.md
@@ -1,0 +1,5 @@
+---
+from: TKT-3RLZR4
+relation: has-review-response
+to: RR-8CKDHQ
+---

--- a/tickets/relations/TKT-3RLZR4--has-review-response--RR-9BU9GN.md
+++ b/tickets/relations/TKT-3RLZR4--has-review-response--RR-9BU9GN.md
@@ -1,0 +1,5 @@
+---
+from: TKT-3RLZR4
+relation: has-review-response
+to: RR-9BU9GN
+---

--- a/tickets/relations/TKT-3RLZR4--has-review-response--RR-JCSIM1.md
+++ b/tickets/relations/TKT-3RLZR4--has-review-response--RR-JCSIM1.md
@@ -1,0 +1,5 @@
+---
+from: TKT-3RLZR4
+relation: has-review-response
+to: RR-JCSIM1
+---

--- a/tickets/relations/TKT-3RLZR4--has-review-response--RR-N9F6LB.md
+++ b/tickets/relations/TKT-3RLZR4--has-review-response--RR-N9F6LB.md
@@ -1,0 +1,5 @@
+---
+from: TKT-3RLZR4
+relation: has-review-response
+to: RR-N9F6LB
+---

--- a/tickets/relations/TKT-3RLZR4--has-review-response--RR-ON4PA8.md
+++ b/tickets/relations/TKT-3RLZR4--has-review-response--RR-ON4PA8.md
@@ -1,0 +1,5 @@
+---
+from: TKT-3RLZR4
+relation: has-review-response
+to: RR-ON4PA8
+---

--- a/tickets/relations/TKT-3RLZR4--implements--FEAT-G4VO53.md
+++ b/tickets/relations/TKT-3RLZR4--implements--FEAT-G4VO53.md
@@ -1,0 +1,5 @@
+---
+from: TKT-3RLZR4
+relation: implements
+to: FEAT-G4VO53
+---


### PR DESCRIPTION
## What

Phase 2 of FEAT-G4VO53 (`rela docs`), reframed as a **doc language**: Markdown authored by hand with embedded Lua **islands** that pull reference fragments from the schema + a seeded in-memory graph. `rela docs build <manual.md>` resolves the islands and emits Markdown (pandoc-able to PDF). Tier A — **no browser**; the `screenshot{}` island is phase 3.

Design recorded in RES-EK7LSA (addendum 2026-07-21); ticket TKT-3RLZR4.

## The language

Markdown by default, escape into Lua two ways:
- **Statement island** — a fenced ` ```rela ` block; `h1`/`h2`/`md` + resolvers append Markdown at that position. Loops/conditionals are plain Lua.
- **Echo island** — an inline `` `rela <expr>` `` span; substitutes the value mid-sentence. Prose mentioning `` `rela …` `` without call syntax stays literal.

## Resolvers

`typeref` · `values` (per-value meaning from phase-1a `descriptions`) · `relations` · `graph{from,depth,direction,exclude|only}` (mermaid; schema-grain by type, instance-grain by id over `tracer`) · `lifecycle` (mermaid `stateDiagram-v2` or flat fallback) · `entity` · `count` · `roles_matrix` · `description` · seed `create`/`link`.

## Design decisions

- **One graph, raw-store seed.** Schema (metamodel + acl) from the real project; entities **only** from the manual's `create`/`link` into a throwaway `memstore` (direct `store.Store`, no entitymanager/ACL/state-machine gate — honest fixture semantics). No real-project entity reads.
- **`internal/mermaid`** extracted from `dataentry` (neutral primitive input; injection-safe synthetic ids + entity-escaped labels). `dataentry` help modal now delegates — byte-identical output.
- Doc runtime = `lua.NewReader` (sandbox, no io/os) + a `doc.*` module (closures, not `*Runtime` methods). **Fail-loud** `BuildError` reports the manual source line; `--strict` promotes empty resolves to errors. Whole-build timeout bounds runaway islands.

## Tests & checks

New-package coverage: **docs 82.6%, mermaid 96.8%**. `just ci` green (lint, arch-lint, plimsoll, coverage, build, docs-check). Design-reviewed + cranky code-reviewed; all 4 significant findings addressed (mermaid quote-escape, `everyone`-role fold in the matrix, typed-error round-trip, resolver error line) — see review-responses RR-ON4PA8/JCSIM1/9BU9GN/N9F6LB.

Includes a worked example manual (`prototypes/data-entry/manual/tickets-manual.md`) and a user guide (`docs/rela-docs.md`).
