### PR TITLE
chore(pgstore): extract versioning into injected VersionStore service (TKT-N0IKN9)

### DIFF
--- a/cmd/rela-desktop/main.go
+++ b/cmd/rela-desktop/main.go
@@ -168,7 +168,7 @@ func (d *Desktop) LoadProject(dir string) string {
 	}
 
 	app, err := dataentry.NewApp(
-		fs, projCtx, svc.Meta(), svc.Store(),
+		fs, projCtx, svc.Meta(), svc.Store(), svc.Versions(),
 		svc.EntityManager(), svc.Searcher(), svc.VisibleSearcher(), svc.ACL(),
 		fieldResolver,
 		svc.Audit(),

--- a/cmd/rela-server/main.go
+++ b/cmd/rela-server/main.go
@@ -285,7 +285,7 @@ func main() {
 	fieldResolver := buildFieldResolver(svc)
 
 	app, err := dataentry.NewApp(
-		svc.FS(), svc.Paths(), svc.Meta(), svc.Store(),
+		svc.FS(), svc.Paths(), svc.Meta(), svc.Store(), svc.Versions(),
 		svc.EntityManager(), svc.Searcher(), svc.VisibleSearcher(), svc.ACL(),
 		fieldResolver,
 		svc.Audit(),

--- a/internal/appbuild/appbuild.go
+++ b/internal/appbuild/appbuild.go
@@ -56,11 +56,23 @@ import (
 // interfaces — `scheduler.WorkspaceProvider`, the data-entry app's
 // constructor inputs — through structural typing, without adapters
 // at the wiring site.
+//
+// Every exported method is a one-line accessor for a collaborator this facade
+// constructs; the count tracks the number of wired services, not an accreting
+// public API. Versions() (TKT-N0IKN9) took it to 21 — a documented facade
+// exception, not a ratchet target.
+//
+//plimsoll:max-exported-methods=21
 type Services struct {
-	fs       storage.FS
-	paths    *project.Context
-	meta     *metamodel.Metamodel
-	store    store.Store
+	fs    storage.FS
+	paths *project.Context
+	meta  *metamodel.Metamodel
+	store store.Store
+	// versions is the content-versioning service (history reads, version writes,
+	// purge), a separate concern injected by the backend recipe — nil on builds
+	// without versioning (fs/mem; fsstore uses git). Consumers bind the narrow
+	// sub-interface they need; the umbrella is the nil-able field type only.
+	versions store.VersionService
 	searcher search.Searcher
 	// visibleSearcher is the ACL-scoped search seam (TKT-BA8BSX):
 	// the generic search.NewVisible wrapper on the fs/memory builds,
@@ -96,6 +108,11 @@ func (s *Services) Meta() *metamodel.Metamodel { return s.meta }
 
 // Store returns the authoritative store.
 func (s *Services) Store() store.Store { return s.store }
+
+// Versions returns the content-versioning service, or nil on a build without
+// versioning (fs/mem). Consumers must nil-check and bind the narrow sub-interface
+// they use (history read, purge, …) rather than the umbrella.
+func (s *Services) Versions() store.VersionService { return s.versions }
 
 // Searcher returns the search service (a sentinel error-searcher when
 // the search backend failed to construct).
@@ -673,6 +690,11 @@ func assemble(
 		return nil, fmt.Errorf("compile transitions: %w", err)
 	}
 
+	// Content versioning is a separate injected service (pgstore only; nil
+	// elsewhere), NOT a store capability the manager type-asserts. Derived once
+	// here and threaded into the recorders and the Services bundle.
+	versions := versionServiceFor(st)
+
 	mgr, err := entitymanager.New(entitymanager.Deps{
 		Store:                   st,
 		Meta:                    base.meta,
@@ -682,8 +704,8 @@ func assemble(
 		Automations:             autoEngine,
 		Cascade:                 cascadeRunner,
 		ScriptRunner:            script.NewLuaScriptRunner(cfg.ScriptEngine, readDeps),
-		VersionRecorder:         versionRecorderFor(st),
-		RelationVersionRecorder: relationVersionRecorderFor(st),
+		VersionRecorder:         versionRecorderFor(versions),
+		RelationVersionRecorder: relationVersionRecorderFor(versions),
 		Transitions:             tw.Enforcer,
 		TransitionGuard:         tw.Guard,
 		TransitionGraph:         tw.Graph,
@@ -708,6 +730,7 @@ func assemble(
 		paths:           cfg.Paths,
 		meta:            base.meta,
 		store:           st,
+		versions:        versions,
 		searcher:        searcher,
 		visibleSearcher: visible,
 		entityManager:   mgr,
@@ -749,16 +772,17 @@ func (r versionRecorder) RecordVersion(ctx context.Context, v entitymanager.Vers
 	})
 }
 
-// versionRecorderFor returns a synchronous version recorder when the store
-// supports version writes (pgstore), or nil when it does not (fsstore/memstore
-// — where the entitymanager's version hook then no-ops). Returning a typed nil
-// would defeat the manager's nil check, so an unsupported store yields an
-// untyped nil interface.
-func versionRecorderFor(st store.Store) entitymanager.VersionRecorder {
-	if w, ok := st.(store.VersionWriter); ok {
-		return versionRecorder{w: w}
+// versionRecorderFor returns a synchronous version recorder when a versioning
+// service is wired (pgstore), or nil when none is (fsstore/memstore — where the
+// entitymanager's version hook then no-ops). vs is the injected version service
+// (an untyped nil on non-versioning builds); a nil service yields a nil recorder
+// so the manager's nil check works. Takes the service rather than type-asserting
+// the store — versioning is a separate injected concern, not a store capability.
+func versionRecorderFor(vs store.VersionService) entitymanager.VersionRecorder {
+	if vs == nil {
+		return nil
 	}
-	return nil
+	return versionRecorder{w: vs}
 }
 
 // relationVersionRecorder adapts a store.RelationVersionWriter to the
@@ -790,11 +814,11 @@ func (r relationVersionRecorder) RecordRelationVersion(
 }
 
 // relationVersionRecorderFor mirrors versionRecorderFor for relation versions.
-func relationVersionRecorderFor(st store.Store) entitymanager.RelationVersionRecorder {
-	if w, ok := st.(store.RelationVersionWriter); ok {
-		return relationVersionRecorder{w: w}
+func relationVersionRecorderFor(vs store.VersionService) entitymanager.RelationVersionRecorder {
+	if vs == nil {
+		return nil
 	}
-	return nil
+	return relationVersionRecorder{w: vs}
 }
 
 // (startVersionSweepIfSupported is defined per build tag in

--- a/internal/appbuild/versionsweep_nosweep.go
+++ b/internal/appbuild/versionsweep_nosweep.go
@@ -11,3 +11,9 @@ import (
 // has a version-reconciliation sweep. fsstore already gets content versioning
 // from git.
 func startVersionSweepIfSupported(_ store.Store, _ *metamodel.Metamodel) {}
+
+// versionServiceFor returns nil in non-postgres builds — content versioning is a
+// pgstore-only service (fsstore uses git). Returning a GENUINELY nil interface
+// (not a typed nil) is load-bearing: the entitymanager recorder factories and the
+// service bundles nil-check this, and a typed-nil would defeat that check.
+func versionServiceFor(_ store.Store) store.VersionService { return nil }

--- a/internal/appbuild/versionsweep_postgres.go
+++ b/internal/appbuild/versionsweep_postgres.go
@@ -36,3 +36,14 @@ func startVersionSweepIfSupported(st store.Store, meta *metamodel.Metamodel) {
 		s.StartVersionSweep(metaProjectionProvider{meta: meta}, pgstore.SweepConfig{})
 	}
 }
+
+// versionServiceFor returns the pgstore versioning service (history reads, version
+// writes, purge) sharing the store's pool. Returns a genuinely nil interface for a
+// non-pgstore store (should not happen in this build), so nil-checks downstream
+// behave correctly.
+func versionServiceFor(st store.Store) store.VersionService {
+	if s, ok := st.(*pgstore.Store); ok {
+		return s.VersionStore()
+	}
+	return nil
+}

--- a/internal/cli/cli_wiring.go
+++ b/internal/cli/cli_wiring.go
@@ -27,7 +27,12 @@ import (
 // that only queries the graph takes *readServices in its Run signature;
 // kong injects the bound instance.
 type readServices struct {
-	Store     store.Store
+	Store store.Store
+	// Versions is the content-versioning service (history, restore, purge), a
+	// pgstore-only injected concern — nil on the fs/mem builds. History/purge
+	// commands bind the narrow sub-interface they need and print an "unsupported
+	// backend" message when it is nil, instead of type-asserting the store.
+	Versions  store.VersionService
 	Meta      *metamodel.Metamodel
 	Paths     *project.Context
 	Tracer    tracer.Tracer
@@ -105,6 +110,7 @@ func newCLIBundles(svc *appbuild.Services) (*cliBundles, error) {
 	}
 	read := readServices{
 		Store:     svc.Store(),
+		Versions:  svc.Versions(),
 		Meta:      svc.Meta(),
 		Paths:     svc.Paths(),
 		Tracer:    svc.Tracer(),

--- a/internal/cli/history.go
+++ b/internal/cli/history.go
@@ -23,12 +23,12 @@ type HistoryCmd struct {
 
 // Run dispatches `rela history <id> [--version N]`.
 func (c *HistoryCmd) Run(ctx context.Context, svc *readServices) error {
-	reader, ok := svc.Store.(store.HistoryReader)
-	if !ok {
+	if svc.Versions == nil {
 		out.WriteMessage("The active storage backend does not support version history " +
 			"(content versioning is a PostgreSQL-build feature; filesystem deployments use git).")
 		return nil
 	}
+	var reader store.HistoryReader = svc.Versions
 
 	if c.Version > 0 {
 		return c.printSnapshot(ctx, reader)

--- a/internal/cli/history_purge.go
+++ b/internal/cli/history_purge.go
@@ -39,12 +39,12 @@ type HistoryPurgeCmd struct {
 
 // Run dispatches `rela history-purge <id> ...`.
 func (c *HistoryPurgeCmd) Run(ctx context.Context, svc *writeServices) error {
-	purger, ok := svc.Store.(store.VersionPurger)
-	if !ok {
+	if svc.Versions == nil {
 		out.WriteMessage("The active storage backend does not support version purge " +
 			"(a PostgreSQL-build compliance feature).")
 		return nil
 	}
+	var purger store.VersionPurger = svc.Versions
 	if err := validatePurgeFlags(c.Reason, c.Vseq, c.ContentHash, c.All); err != nil {
 		return err
 	}
@@ -103,12 +103,12 @@ type RelationHistoryPurgeCmd struct {
 
 // Run dispatches `rela relation-history-purge <from> <type> <to> ...`.
 func (c *RelationHistoryPurgeCmd) Run(ctx context.Context, svc *writeServices) error {
-	purger, ok := svc.Store.(store.RelationVersionPurger)
-	if !ok {
+	if svc.Versions == nil {
 		out.WriteMessage("The active storage backend does not support relation version purge " +
 			"(a PostgreSQL-build compliance feature).")
 		return nil
 	}
+	var purger store.RelationVersionPurger = svc.Versions
 	if err := validatePurgeFlags(c.Reason, c.Vseq, c.ContentHash, c.All); err != nil {
 		return err
 	}

--- a/internal/cli/relation_history.go
+++ b/internal/cli/relation_history.go
@@ -23,12 +23,12 @@ type RelationHistoryCmd struct {
 
 // Run dispatches `rela relation-history <from> <type> <to> [--version N]`.
 func (c *RelationHistoryCmd) Run(ctx context.Context, svc *writeServices) error {
-	reader, ok := svc.Store.(store.RelationHistoryReader)
-	if !ok {
+	if svc.Versions == nil {
 		out.WriteMessage("The active storage backend does not support relation version history " +
 			"(content versioning is a PostgreSQL-build feature; filesystem deployments use git).")
 		return nil
 	}
+	var reader store.RelationHistoryReader = svc.Versions
 	if c.Version > 0 {
 		return c.printSnapshot(ctx, reader)
 	}
@@ -103,12 +103,12 @@ type RelationRestoreCmd struct {
 
 // Run dispatches `rela relation-restore <from> <type> <to> <version>`.
 func (c *RelationRestoreCmd) Run(ctx context.Context, svc *writeServices) error {
-	reader, ok := svc.Store.(store.RelationHistoryReader)
-	if !ok {
+	if svc.Versions == nil {
 		out.WriteMessage("The active storage backend does not support relation version history " +
 			"(restore is a PostgreSQL-build feature).")
 		return nil
 	}
+	var reader store.RelationHistoryReader = svc.Versions
 
 	snap, err := reader.GetRelationVersion(ctx, c.From, c.Type, c.To, c.Version)
 	if errors.Is(err, store.ErrNotFound) {

--- a/internal/cli/restore.go
+++ b/internal/cli/restore.go
@@ -29,12 +29,12 @@ type RestoreCmd struct {
 
 // Run dispatches `rela restore <id> <version>`.
 func (c *RestoreCmd) Run(ctx context.Context, svc *writeServices) error {
-	reader, ok := svc.Store.(store.HistoryReader)
-	if !ok {
+	if svc.Versions == nil {
 		out.WriteMessage("The active storage backend does not support version history " +
 			"(restore is a PostgreSQL-build feature).")
 		return nil
 	}
+	var reader store.HistoryReader = svc.Versions
 
 	snap, err := reader.GetVersion(ctx, c.ID, c.Version)
 	if errors.Is(err, store.ErrNotFound) {

--- a/internal/dataentry/app.go
+++ b/internal/dataentry/app.go
@@ -88,7 +88,12 @@ type App struct {
 	// Core services. Some are passed in (store, entityManager,
 	// searcher); the rest are constructed from primitives inside
 	// NewApp.
-	store         store.Store
+	store store.Store
+	// versions is the content-versioning service (entity + relation history
+	// reads), a pgstore-only injected concern — nil on fs/mem builds, where the
+	// history endpoints return 501. The history handlers bind the narrow
+	// sub-interface they need rather than type-asserting the store.
+	versions      store.VersionService
 	entityManager entitymanager.EntityManager
 	searcher      search.Searcher
 	// visibleSearcher is the ACL-scoped search seam (TKT-BA8BSX):
@@ -341,6 +346,7 @@ func NewApp(
 	paths *project.Context,
 	meta *metamodel.Metamodel,
 	st store.Store,
+	versions store.VersionService,
 	em entitymanager.EntityManager,
 	searcher search.Searcher,
 	visibleSearcher search.VisibleSearcher,
@@ -463,6 +469,7 @@ func NewApp(
 		fs:              fs,
 		paths:           paths,
 		store:           st,
+		versions:        versions,
 		entityManager:   em,
 		searcher:        searcher,
 		visibleSearcher: visibleSearcher,

--- a/internal/dataentry/history_handler.go
+++ b/internal/dataentry/history_handler.go
@@ -40,14 +40,14 @@ func handleV1History(a *App, w http.ResponseWriter, r *http.Request) {
 	}
 	typeName, entityID := parts[0], parts[1]
 
-	reader, ok := a.store.(store.HistoryReader)
-	if !ok {
+	if a.versions == nil {
 		// Non-postgres backend: no version history capability. This is a
 		// capability gap, not an ACL decision, so it's safe to say so plainly.
 		writeV1Error(w, r, http.StatusNotImplemented, "history_unsupported",
 			"The active storage backend does not support version history", "")
 		return
 	}
+	var reader store.HistoryReader = a.versions
 
 	// POST .../{version}/restore is the one write on this route.
 	if len(parts) == 4 && parts[3] == "restore" {

--- a/internal/dataentry/history_handler_test.go
+++ b/internal/dataentry/history_handler_test.go
@@ -11,11 +11,14 @@ import (
 	"github.com/Sourcehaven-BV/rela/internal/store"
 )
 
-// historyStore wraps a store.Store with a canned version history, so the
-// handler's HistoryReader path can be exercised without a pgstore. Keyed by
-// entity id; each snapshot carries a type so cross-type checks can be tested.
+// historyStore is a canned version-history service, so the handler's
+// HistoryReader path can be exercised without a pgstore. Keyed by entity id; each
+// snapshot carries a type so cross-type checks can be tested. It embeds
+// stubVersionService to satisfy the whole store.VersionService umbrella and
+// overrides only the two reader methods these tests exercise; assign it to
+// App.versions.
 type historyStore struct {
-	store.Store
+	stubVersionService
 	versions map[string][]store.VersionSnapshot
 }
 
@@ -124,8 +127,7 @@ func TestHandleV1History_CrossTypeIs404(t *testing.T) {
 	tkt.Properties = map[string]any{"title": "secret ticket"}
 	f.AddNode(tkt)
 	app := newAppFromParts(nil, testMeta(), f)
-	app.store = historyStore{
-		Store: app.store,
+	app.versions = historyStore{
 		versions: map[string][]store.VersionSnapshot{
 			"TKT-SECRET": {snapshot(1, "ticket", "body", map[string]any{"title": "secret ticket"})},
 		},

--- a/internal/dataentry/relation_history_handler.go
+++ b/internal/dataentry/relation_history_handler.go
@@ -45,12 +45,12 @@ func handleV1RelationHistory(a *App, w http.ResponseWriter, r *http.Request) {
 	}
 	fromType, from, relType, to := parts[0], parts[1], parts[2], parts[3]
 
-	reader, ok := a.store.(store.RelationHistoryReader)
-	if !ok {
+	if a.versions == nil {
 		writeV1Error(w, r, http.StatusNotImplemented, "history_unsupported",
 			"The active storage backend does not support relation version history", "")
 		return
 	}
+	var reader store.RelationHistoryReader = a.versions
 
 	// POST .../{version}/restore is the one write on this route.
 	if len(parts) == 6 && parts[5] == "restore" {

--- a/internal/dataentry/relation_history_handler_test.go
+++ b/internal/dataentry/relation_history_handler_test.go
@@ -13,11 +13,12 @@ import (
 	"github.com/Sourcehaven-BV/rela/internal/store"
 )
 
-// relHistoryStore wraps a store.Store with canned relation version history so
-// the RelationHistoryReader path is exercised without a pgstore. Keyed by the
-// composite "from|type|to".
+// relHistoryStore is a canned relation-version-history service so the
+// RelationHistoryReader path is exercised without a pgstore. Keyed by the
+// composite "from|type|to". Embeds stubVersionService to satisfy the whole
+// store.VersionService umbrella; assign it to App.versions.
 type relHistoryStore struct {
-	store.Store
+	stubVersionService
 	versions map[string][]store.RelationVersionSnapshot
 }
 
@@ -87,7 +88,6 @@ func newRelHistoryApp(t *testing.T) *App {
 
 	base := newAppFromParts(nil, testMeta(), f)
 	rel := relHistoryStore{
-		Store: base.store,
 		versions: map[string][]store.RelationVersionSnapshot{
 			relKey("DEC-1", "addresses", "REQ-1"): {{
 				RelationVersionMeta: store.RelationVersionMeta{
@@ -97,7 +97,7 @@ func newRelHistoryApp(t *testing.T) *App {
 			}},
 		},
 	}
-	base.store = rel
+	base.versions = rel
 	return base
 }
 
@@ -153,7 +153,6 @@ func TestRelationHistory_DeletedRelationRequiresPermission(t *testing.T) {
 	// App with NO live endpoints, but canned history for a gone relation.
 	base := newAppFromParts(nil, testMeta(), &fixture{})
 	rel := relHistoryStore{
-		Store: base.store,
 		versions: map[string][]store.RelationVersionSnapshot{
 			relKey("GONE-A", "links", "GONE-B"): {{
 				RelationVersionMeta: store.RelationVersionMeta{
@@ -162,7 +161,7 @@ func TestRelationHistory_DeletedRelationRequiresPermission(t *testing.T) {
 			}},
 		},
 	}
-	base.store = rel
+	base.versions = rel
 
 	path := "/api/v1/_relation_history/decision/GONE-A/links/GONE-B"
 

--- a/internal/dataentry/version_service_stub_test.go
+++ b/internal/dataentry/version_service_stub_test.go
@@ -1,0 +1,58 @@
+package dataentry
+
+import (
+	"context"
+
+	"github.com/Sourcehaven-BV/rela/internal/store"
+)
+
+// stubVersionService is a test-only store.VersionService whose methods all panic.
+// A history-handler test embeds it and overrides only the one or two reader
+// methods it exercises, so it satisfies the umbrella interface without spelling
+// out every unused write/purge method. (Since the version service was extracted
+// from the store — a store just stores — the handlers bind the narrow reader
+// sub-interface, but App.versions is typed as the umbrella, so a fake assigned to
+// it must satisfy the whole surface.)
+type stubVersionService struct{}
+
+func (stubVersionService) ListVersions(context.Context, string) ([]store.VersionMeta, error) {
+	panic("stubVersionService.ListVersions not implemented")
+}
+
+func (stubVersionService) GetVersion(context.Context, string, int) (*store.VersionSnapshot, error) {
+	panic("stubVersionService.GetVersion not implemented")
+}
+
+func (stubVersionService) WriteVersion(context.Context, store.VersionInput) error {
+	panic("stubVersionService.WriteVersion not implemented")
+}
+
+func (stubVersionService) ListRelationVersions(
+	context.Context, string, string, string,
+) ([]store.RelationVersionMeta, error) {
+	panic("stubVersionService.ListRelationVersions not implemented")
+}
+
+func (stubVersionService) GetRelationVersion(
+	context.Context, string, string, string, int,
+) (*store.RelationVersionSnapshot, error) {
+	panic("stubVersionService.GetRelationVersion not implemented")
+}
+
+func (stubVersionService) WriteRelationVersion(context.Context, store.RelationVersionInput) error {
+	panic("stubVersionService.WriteRelationVersion not implemented")
+}
+
+func (stubVersionService) PurgeVersions(
+	context.Context, store.VersionPurgeRequest,
+) (*store.PurgeResult, error) {
+	panic("stubVersionService.PurgeVersions not implemented")
+}
+
+func (stubVersionService) PurgeRelationVersions(
+	context.Context, store.RelationVersionPurgeRequest,
+) (*store.PurgeResult, error) {
+	panic("stubVersionService.PurgeRelationVersions not implemented")
+}
+
+var _ store.VersionService = stubVersionService{}

--- a/internal/store/pgstore/pgstore.go
+++ b/internal/store/pgstore/pgstore.go
@@ -62,21 +62,24 @@ type DBTX interface {
 
 // Store is a PostgreSQL-backed store.Store.
 //
-// TODO(TKT-N0IKN9): the exported surface is the mandated store.Store interface
-// (29 methods) PLUS the optional versioning capabilities pgstore also provides
-// — store.HistoryReader (ListVersions/GetVersion), store.VersionWriter
-// (WriteVersion), StartVersionSweep, the RELATION versioning capabilities
-// store.RelationHistoryReader (ListRelationVersions/GetRelationVersion) +
-// store.RelationVersionWriter (WriteRelationVersion), and the version-PURGE
-// capabilities store.VersionPurger (PurgeVersions) + store.RelationVersionPurger
-// (PurgeRelationVersions) — which consumers type-assert. All are
-// interface-mandated methods, not accreted public API; Required-interface
-// exception, tracks the interface size.
+// The exported surface is the mandated store.Store interface (a Required-interface
+// exception, so its count tracks the interface size) plus two version seams that
+// own or hand out lifecycle state and so stay here: StartVersionSweep (the store's
+// own reconciliation goroutine, owning s.mu/s.sweep) and VersionStore (a one-line
+// accessor handing out the versioning service over this store's shared pool).
+// Content VERSIONING itself (entity + relation history reads, version writes,
+// purge) is NOT here: it lives in [VersionStore], a separate service injected by
+// the composition root, because a store "just stores" and versioning is a distinct
+// concern that merely shares the same database (TKT-N0IKN9). That extraction
+// dropped this struct from 40→33 exported / 53→41 total.
 //
-// (39 → 40 exported / 52 → 53 total: store.Store gained Tx, TKT-GXHI8.)
+// Do NOT add version/history/purge methods back to *Store: they belong on
+// [VersionStore], and re-adding one here would resurrect the type-assert-off-the-
+// store pattern this refactor removed. Consumers reach versioning through the
+// injected store.VersionService, never by asserting a capability on the store.
 //
-//plimsoll:max-exported-methods=40
-//plimsoll:max-methods=53
+//plimsoll:max-exported-methods=33
+//plimsoll:max-methods=41
 type Store struct {
 	db        DBTX
 	observers []store.EntityObserver // notified synchronously after committed entity writes

--- a/internal/store/pgstore/purge.go
+++ b/internal/store/pgstore/purge.go
@@ -35,8 +35,8 @@ import (
 // never learns the principal another way and never echoes purged content.
 
 // PurgeVersions implements store.VersionPurger.
-func (s *Store) PurgeVersions(ctx context.Context, req store.VersionPurgeRequest) (*store.PurgeResult, error) {
-	pool, ok := s.db.(*pgxpool.Pool)
+func (v *VersionStore) PurgeVersions(ctx context.Context, req store.VersionPurgeRequest) (*store.PurgeResult, error) {
+	pool, ok := v.db.(*pgxpool.Pool)
 	if !ok {
 		return nil, errors.New("pgstore: PurgeVersions requires a *pgxpool.Pool (session-scoped advisory lock)")
 	}
@@ -56,11 +56,11 @@ func (s *Store) PurgeVersions(ctx context.Context, req store.VersionPurgeRequest
 	defer advisoryUnlock(context.WithoutCancel(ctx), conn, sweepAdvisoryLockKey)
 
 	// Resolve the target lineage ids (fenced) and the current live content hash.
-	ids, err := s.entityLineageIDsForPurge(ctx, conn, req.EntityID)
+	ids, err := v.entityLineageIDsForPurge(ctx, conn, req.EntityID)
 	if err != nil {
 		return nil, err
 	}
-	liveHash, liveExists, err := s.liveEntityHash(ctx, conn, req.EntityID)
+	liveHash, liveExists, err := v.liveEntityHash(ctx, conn, req.EntityID)
 	if err != nil {
 		return nil, err
 	}
@@ -101,10 +101,10 @@ func (s *Store) PurgeVersions(ctx context.Context, req store.VersionPurgeRequest
 }
 
 // PurgeRelationVersions implements store.RelationVersionPurger.
-func (s *Store) PurgeRelationVersions(
+func (v *VersionStore) PurgeRelationVersions(
 	ctx context.Context, req store.RelationVersionPurgeRequest,
 ) (*store.PurgeResult, error) {
-	pool, ok := s.db.(*pgxpool.Pool)
+	pool, ok := v.db.(*pgxpool.Pool)
 	if !ok {
 		return nil, errors.New("pgstore: PurgeRelationVersions requires a *pgxpool.Pool")
 	}
@@ -123,18 +123,18 @@ func (s *Store) PurgeRelationVersions(
 	}
 	defer advisoryUnlock(context.WithoutCancel(ctx), conn, sweepAdvisoryLockKey)
 
-	id, err := s.recordIDForKey(ctx, req.From, req.Type, req.To)
+	id, err := v.recordIDForKey(ctx, req.From, req.Type, req.To)
 	if errors.Is(err, store.ErrNotFound) {
 		return &store.PurgeResult{}, nil // nothing to purge
 	}
 	if err != nil {
 		return nil, err
 	}
-	ids, err := s.relationLineageIDs(ctx, id)
+	ids, err := v.relationLineageIDs(ctx, id)
 	if err != nil {
 		return nil, err
 	}
-	liveHash, liveExists, err := s.liveRelationHash(ctx, conn, req.From, req.Type, req.To)
+	liveHash, liveExists, err := v.liveRelationHash(ctx, conn, req.From, req.Type, req.To)
 	if err != nil {
 		return nil, err
 	}
@@ -186,7 +186,7 @@ func anyRename(targets []store.PurgeTarget) bool {
 // lineage as a slice usable in `entity_id = ANY($1)`. It reuses lineageCTE so
 // --all matches exactly what ListVersions shows and never spills into a reused
 // id's rows. Returns just the queried id if it has no rename ancestry.
-func (s *Store) entityLineageIDsForPurge(ctx context.Context, q DBTX, id string) ([]string, error) {
+func (v *VersionStore) entityLineageIDsForPurge(ctx context.Context, q DBTX, id string) ([]string, error) {
 	sel := lineageCTE + ` SELECT entity_id FROM lin`
 	rows, err := q.Query(ctx, sel, id)
 	if err != nil {
@@ -210,7 +210,7 @@ func (s *Store) entityLineageIDsForPurge(ctx context.Context, q DBTX, id string)
 	return ids, nil
 }
 
-func (s *Store) liveEntityHash(ctx context.Context, q DBTX, id string) (hash string, exists bool, err error) {
+func (v *VersionStore) liveEntityHash(ctx context.Context, q DBTX, id string) (hash string, exists bool, err error) {
 	e, gErr := scanEntity(q.QueryRow(ctx,
 		`SELECT id, type, properties, content, updated_at FROM entities WHERE id = $1`, id))
 	if errors.Is(gErr, pgx.ErrNoRows) {
@@ -224,7 +224,7 @@ func (s *Store) liveEntityHash(ctx context.Context, q DBTX, id string) (hash str
 	}), true, nil
 }
 
-func (s *Store) liveRelationHash(
+func (v *VersionStore) liveRelationHash(
 	ctx context.Context, q DBTX, from, relType, to string,
 ) (hash string, exists bool, err error) {
 	r, gErr := scanRelation(q.QueryRow(ctx,
@@ -355,9 +355,3 @@ func writeRelationPurgeTombstone(
 const purgeSchemaHash = "purge-tombstone"
 
 var purgeSchemaProjection = []byte(`{"purge":true}`)
-
-// Static assertions that Store satisfies the optional purge capabilities.
-var (
-	_ store.VersionPurger         = (*Store)(nil)
-	_ store.RelationVersionPurger = (*Store)(nil)
-)

--- a/internal/store/pgstore/purge_test.go
+++ b/internal/store/pgstore/purge_test.go
@@ -25,7 +25,7 @@ func seedEntityHistory(t *testing.T, s *pgstore.Store, id string, contents ...st
 		} else {
 			in.Op = store.VersionOpUpdate
 		}
-		require.NoError(t, s.WriteVersion(ctx, in))
+		require.NoError(t, s.VersionStore().WriteVersion(ctx, in))
 	}
 }
 
@@ -38,14 +38,14 @@ func TestPurgeRefusesWhenLiveRowExists(t *testing.T) {
 	ctx := context.Background()
 	seedEntityHistory(t, s, "TKT-1", "v1", "v2secret")
 
-	res, err := s.PurgeVersions(ctx, store.VersionPurgeRequest{
+	res, err := s.VersionStore().PurgeVersions(ctx, store.VersionPurgeRequest{
 		EntityID: "TKT-1", Selector: store.PurgeSelector{All: true}, Reason: "test",
 	})
 	require.NoError(t, err)
 	require.True(t, res.LiveRowExists)
 	require.Equal(t, 0, res.Purged, "must refuse to purge while live row exists")
 
-	metas, err := s.ListVersions(ctx, "TKT-1")
+	metas, err := s.VersionStore().ListVersions(ctx, "TKT-1")
 	require.NoError(t, err)
 	require.Len(t, metas, 2, "history untouched by refused purge")
 }
@@ -59,7 +59,7 @@ func TestPurgeForceLiveWritesTombstone(t *testing.T) {
 	ctx := context.Background()
 	seedEntityHistory(t, s, "TKT-1", "v1", "v2secret")
 
-	res, err := s.PurgeVersions(ctx, store.VersionPurgeRequest{
+	res, err := s.VersionStore().PurgeVersions(ctx, store.VersionPurgeRequest{
 		EntityID: "TKT-1", Selector: store.PurgeSelector{All: true},
 		Reason: "erase PII", ForceLive: true,
 	})
@@ -68,7 +68,7 @@ func TestPurgeForceLiveWritesTombstone(t *testing.T) {
 	require.True(t, res.TombstoneWritten)
 
 	// The 2 content versions are gone; only the tombstone remains.
-	metas, err := s.ListVersions(ctx, "TKT-1")
+	metas, err := s.VersionStore().ListVersions(ctx, "TKT-1")
 	require.NoError(t, err)
 	require.Len(t, metas, 1)
 	require.Equal(t, store.VersionOpPurge, metas[0].Op)
@@ -85,11 +85,11 @@ func TestPurgeDeletedEntityAll(t *testing.T) {
 	// Write a delete version + remove the live row.
 	del := newVersionInput("TKT-1", "v2", nil)
 	del.Op = store.VersionOpDelete
-	require.NoError(t, s.WriteVersion(ctx, del))
+	require.NoError(t, s.VersionStore().WriteVersion(ctx, del))
 	_, err = s.DeleteEntity(ctx, "TKT-1", false)
 	require.NoError(t, err)
 
-	res, err := s.PurgeVersions(ctx, store.VersionPurgeRequest{
+	res, err := s.VersionStore().PurgeVersions(ctx, store.VersionPurgeRequest{
 		EntityID: "TKT-1", Selector: store.PurgeSelector{All: true}, Reason: "erase deleted",
 	})
 	require.NoError(t, err)
@@ -97,7 +97,7 @@ func TestPurgeDeletedEntityAll(t *testing.T) {
 	require.False(t, res.TombstoneWritten)
 	require.Equal(t, 3, res.Purged) // create + update + delete
 
-	metas, err := s.ListVersions(ctx, "TKT-1")
+	metas, err := s.VersionStore().ListVersions(ctx, "TKT-1")
 	require.NoError(t, err)
 	require.Empty(t, metas, "all history purged")
 }
@@ -118,13 +118,13 @@ func TestPurgeByVseq(t *testing.T) {
 	require.NoError(t, pool.QueryRow(ctx,
 		`SELECT vseq FROM entity_versions WHERE entity_id='TKT-1' ORDER BY vseq ASC OFFSET 1 LIMIT 1`).Scan(&vseq))
 
-	res, err := s.PurgeVersions(ctx, store.VersionPurgeRequest{
+	res, err := s.VersionStore().PurgeVersions(ctx, store.VersionPurgeRequest{
 		EntityID: "TKT-1", Selector: store.PurgeSelector{Vseq: vseq}, Reason: "single",
 	})
 	require.NoError(t, err)
 	require.Equal(t, 1, res.Purged)
 
-	metas, err := s.ListVersions(ctx, "TKT-1")
+	metas, err := s.VersionStore().ListVersions(ctx, "TKT-1")
 	require.NoError(t, err)
 	require.Len(t, metas, 2, "only the one vseq purged")
 }
@@ -153,7 +153,7 @@ func TestPurgeByContentHash(t *testing.T) {
 		} else {
 			in.Op = store.VersionOpUpdate
 		}
-		require.NoError(t, s.WriteVersion(ctx, in))
+		require.NoError(t, s.VersionStore().WriteVersion(ctx, in))
 	}
 	_, err = s.DeleteEntity(ctx, "TKT-1", false)
 	require.NoError(t, err)
@@ -162,7 +162,7 @@ func TestPurgeByContentHash(t *testing.T) {
 	require.NoError(t, pool.QueryRow(ctx,
 		`SELECT content_hash FROM entity_versions WHERE entity_id='TKT-1' AND content='dup' LIMIT 1`).Scan(&hash))
 
-	res, err := s.PurgeVersions(ctx, store.VersionPurgeRequest{
+	res, err := s.VersionStore().PurgeVersions(ctx, store.VersionPurgeRequest{
 		EntityID: "TKT-1", Selector: store.PurgeSelector{ContentHash: hash}, Reason: "erase value",
 	})
 	require.NoError(t, err)
@@ -186,10 +186,10 @@ func TestPurgeRefusesRenameRow(t *testing.T) {
 	ren := newVersionInput("B", "a2", nil)
 	ren.Op = store.VersionOpRename
 	ren.PrevID = "A"
-	require.NoError(t, s.WriteVersion(ctx, ren))
+	require.NoError(t, s.VersionStore().WriteVersion(ctx, ren))
 
 	// Purge --all of B's lineage includes the rename row → refuse.
-	res, err := s.PurgeVersions(ctx, store.VersionPurgeRequest{
+	res, err := s.VersionStore().PurgeVersions(ctx, store.VersionPurgeRequest{
 		EntityID: "B", Selector: store.PurgeSelector{All: true}, Reason: "test",
 	})
 	require.NoError(t, err)
@@ -207,14 +207,14 @@ func TestPurgeDryRun(t *testing.T) {
 	_, err = s.DeleteEntity(ctx, "TKT-1", false)
 	require.NoError(t, err)
 
-	res, err := s.PurgeVersions(ctx, store.VersionPurgeRequest{
+	res, err := s.VersionStore().PurgeVersions(ctx, store.VersionPurgeRequest{
 		EntityID: "TKT-1", Selector: store.PurgeSelector{All: true}, Reason: "preview", DryRun: true,
 	})
 	require.NoError(t, err)
 	require.Equal(t, 0, res.Purged, "dry-run deletes nothing")
 	require.Len(t, res.Targets, 2, "but resolves the targets")
 
-	metas, err := s.ListVersions(ctx, "TKT-1")
+	metas, err := s.VersionStore().ListVersions(ctx, "TKT-1")
 	require.NoError(t, err)
 	require.Len(t, metas, 2, "history intact after dry-run")
 }
@@ -237,7 +237,7 @@ func TestPurgeTombstoneSuppressesSweepRecapture(t *testing.T) {
 	require.NoError(t, err)
 
 	// Force-live purge all history; tombstone written.
-	res, err := s.PurgeVersions(ctx, store.VersionPurgeRequest{
+	res, err := s.VersionStore().PurgeVersions(ctx, store.VersionPurgeRequest{
 		EntityID: "TKT-1", Selector: store.PurgeSelector{All: true},
 		Reason: "erase", ForceLive: true,
 	})
@@ -250,7 +250,7 @@ func TestPurgeTombstoneSuppressesSweepRecapture(t *testing.T) {
 		pgstore.SweepConfig{Interval: 50 * time.Millisecond, Idle: time.Minute, MaxStaleness: time.Hour, Batch: 100})
 	time.Sleep(300 * time.Millisecond)
 
-	metas, err := s.ListVersions(ctx, "TKT-1")
+	metas, err := s.VersionStore().ListVersions(ctx, "TKT-1")
 	require.NoError(t, err)
 	require.Len(t, metas, 1, "only the purge tombstone; sweep did NOT re-capture the live PII")
 	require.Equal(t, store.VersionOpPurge, metas[0].Op)

--- a/internal/store/pgstore/relation_version.go
+++ b/internal/store/pgstore/relation_version.go
@@ -23,17 +23,17 @@ import (
 // capture taken BEFORE a delete (the live row still carries the id) or during a
 // rename (resolved from the pre-rename key). Callers that capture after the row
 // is gone must supply a non-zero RecordID read earlier.
-func (s *Store) WriteRelationVersion(ctx context.Context, in store.RelationVersionInput) error {
+func (v *VersionStore) WriteRelationVersion(ctx context.Context, in store.RelationVersionInput) error {
 	if in.RecordID == 0 {
 		// Resolve from the (still-live, pre-delete) row or the most-recent lineage.
-		id, err := s.recordIDForKey(ctx, in.From, in.Type, in.To)
+		id, err := v.recordIDForKey(ctx, in.From, in.Type, in.To)
 		if err != nil {
 			return fmt.Errorf("pgstore: resolve rel_record_id for %s--%s--%s: %w",
 				in.From, in.Type, in.To, err)
 		}
 		in.RecordID = id
 	}
-	tx, err := s.db.Begin(ctx)
+	tx, err := v.db.Begin(ctx)
 	if err != nil {
 		return err
 	}
@@ -116,7 +116,7 @@ func contentHashOfRelation(in store.RelationVersionInput) string {
 // the lineage whose latest row BEFORE the rename carried (prev_from, type,
 // prev_to). Cycles are impossible (each hop strictly decreases the rel_record_id
 // frontier's max vseq), but a visited-set guards regardless.
-func (s *Store) relationLineageIDs(ctx context.Context, headID int64) ([]int64, error) {
+func (v *VersionStore) relationLineageIDs(ctx context.Context, headID int64) ([]int64, error) {
 	ids := []int64{headID}
 	seen := map[int64]struct{}{headID: {}}
 	frontier := []int64{headID}
@@ -143,7 +143,7 @@ func (s *Store) relationLineageIDs(ctx context.Context, headID int64) ([]int64, 
 			  AND ren.op = 'rename'
 			  AND ren.prev_from IS NOT NULL
 			  AND ren.prev_to IS NOT NULL`
-		rows, err := s.db.Query(ctx, q, id)
+		rows, err := v.db.Query(ctx, q, id)
 		if err != nil {
 			return nil, err
 		}
@@ -178,12 +178,12 @@ func (s *Store) relationLineageIDs(ctx context.Context, headID int64) ([]int64, 
 // recent relation_versions lineage that ended at this key — i.e. the largest
 // rel_record_id whose latest row still carries this (from,type,to). Returns
 // (0, ErrNotFound) when the key has no live row and no history.
-func (s *Store) recordIDForKey(ctx context.Context, from, relType, to string) (int64, error) {
+func (v *VersionStore) recordIDForKey(ctx context.Context, from, relType, to string) (int64, error) {
 	// Live row first.
 	const live = `SELECT rel_record_id FROM relations
 	              WHERE from_id = $1 AND rel_type = $2 AND to_id = $3`
 	var id int64
-	err := s.db.QueryRow(ctx, live, from, relType, to).Scan(&id)
+	err := v.db.QueryRow(ctx, live, from, relType, to).Scan(&id)
 	if err == nil {
 		return id, nil
 	}
@@ -204,7 +204,7 @@ func (s *Store) recordIDForKey(ctx context.Context, from, relType, to string) (i
 		WHERE rv.from_id = $1 AND rv.rel_type = $2 AND rv.to_id = $3
 		ORDER BY rv.vseq DESC
 		LIMIT 1`
-	err = s.db.QueryRow(ctx, dead, from, relType, to).Scan(&id)
+	err = v.db.QueryRow(ctx, dead, from, relType, to).Scan(&id)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return 0, store.ErrNotFound
 	}
@@ -215,17 +215,17 @@ func (s *Store) recordIDForKey(ctx context.Context, from, relType, to string) (i
 }
 
 // ListRelationVersions implements store.RelationHistoryReader.
-func (s *Store) ListRelationVersions(
+func (v *VersionStore) ListRelationVersions(
 	ctx context.Context, from, relType, to string,
 ) ([]store.RelationVersionMeta, error) {
-	id, err := s.recordIDForKey(ctx, from, relType, to)
+	id, err := v.recordIDForKey(ctx, from, relType, to)
 	if errors.Is(err, store.ErrNotFound) {
 		return nil, nil // no history is an empty slice, not an error
 	}
 	if err != nil {
 		return nil, err
 	}
-	ids, err := s.relationLineageIDs(ctx, id)
+	ids, err := v.relationLineageIDs(ctx, id)
 	if err != nil {
 		return nil, err
 	}
@@ -237,7 +237,7 @@ func (s *Store) ListRelationVersions(
 		FROM relation_versions
 		WHERE rel_record_id = ANY($1)
 		ORDER BY vseq ASC`
-	rows, err := s.db.Query(ctx, sel, ids)
+	rows, err := v.db.Query(ctx, sel, ids)
 	if err != nil {
 		return nil, err
 	}
@@ -262,17 +262,17 @@ func (s *Store) ListRelationVersions(
 
 // GetRelationVersion implements store.RelationHistoryReader. version is a 1-based
 // ordinal over the lineage ordered by vseq.
-func (s *Store) GetRelationVersion(
+func (v *VersionStore) GetRelationVersion(
 	ctx context.Context, from, relType, to string, version int,
 ) (*store.RelationVersionSnapshot, error) {
 	if version < 1 {
 		return nil, store.ErrNotFound
 	}
-	id, err := s.recordIDForKey(ctx, from, relType, to)
+	id, err := v.recordIDForKey(ctx, from, relType, to)
 	if err != nil {
 		return nil, err // ErrNotFound propagates
 	}
-	ids, err := s.relationLineageIDs(ctx, id)
+	ids, err := v.relationLineageIDs(ctx, id)
 	if err != nil {
 		return nil, err
 	}
@@ -286,7 +286,7 @@ func (s *Store) GetRelationVersion(
 		WHERE rv.rel_record_id = ANY($1)
 		ORDER BY rv.vseq ASC
 		OFFSET $2 LIMIT 1`
-	row := s.db.QueryRow(ctx, sel, ids, version-1)
+	row := v.db.QueryRow(ctx, sel, ids, version-1)
 
 	var (
 		snap     store.RelationVersionSnapshot
@@ -345,10 +345,3 @@ func scanRelationVersionMeta(row scanner) (store.RelationVersionMeta, error) {
 	m.CreatedAt = created
 	return m, nil
 }
-
-// Static assertions that Store satisfies the optional relation-version
-// capabilities.
-var (
-	_ store.RelationHistoryReader = (*Store)(nil)
-	_ store.RelationVersionWriter = (*Store)(nil)
-)

--- a/internal/store/pgstore/relation_version_test.go
+++ b/internal/store/pgstore/relation_version_test.go
@@ -57,13 +57,13 @@ func TestRelationVersionWriteAndList(t *testing.T) {
 
 	c := newRelVersionInput(rid, "TKT-1", "blocks", "TKT-2", "first")
 	c.Op = store.VersionOpCreate
-	require.NoError(t, s.WriteRelationVersion(ctx, c))
+	require.NoError(t, s.VersionStore().WriteRelationVersion(ctx, c))
 
 	u := newRelVersionInput(rid, "TKT-1", "blocks", "TKT-2", "second")
 	u.Op = store.VersionOpUpdate
-	require.NoError(t, s.WriteRelationVersion(ctx, u))
+	require.NoError(t, s.VersionStore().WriteRelationVersion(ctx, u))
 
-	metas, err := s.ListRelationVersions(ctx, "TKT-1", "blocks", "TKT-2")
+	metas, err := s.VersionStore().ListRelationVersions(ctx, "TKT-1", "blocks", "TKT-2")
 	require.NoError(t, err)
 	require.Len(t, metas, 2)
 	require.Equal(t, 1, metas[0].Version)
@@ -72,7 +72,7 @@ func TestRelationVersionWriteAndList(t *testing.T) {
 	require.Equal(t, store.VersionOpUpdate, metas[1].Op)
 	require.Equal(t, "alice", metas[1].PrincipalUser)
 
-	snap, err := s.GetRelationVersion(ctx, "TKT-1", "blocks", "TKT-2", 1)
+	snap, err := s.VersionStore().GetRelationVersion(ctx, "TKT-1", "blocks", "TKT-2", 1)
 	require.NoError(t, err)
 	require.Equal(t, "first", snap.Content)
 	require.Equal(t, "high", snap.Properties["weight"])
@@ -95,16 +95,16 @@ func TestRelationVersionDeletedKeyResolves(t *testing.T) {
 
 	c := newRelVersionInput(rid, "A", "links", "B", "x")
 	c.Op = store.VersionOpCreate
-	require.NoError(t, s.WriteRelationVersion(ctx, c))
+	require.NoError(t, s.VersionStore().WriteRelationVersion(ctx, c))
 
 	// Capture a delete version (as the sync path will), then remove the live row.
 	d := newRelVersionInput(rid, "A", "links", "B", "x")
 	d.Op = store.VersionOpDelete
-	require.NoError(t, s.WriteRelationVersion(ctx, d))
+	require.NoError(t, s.VersionStore().WriteRelationVersion(ctx, d))
 	require.NoError(t, s.DeleteRelation(ctx, "A", "links", "B"))
 
 	// History must still be readable via the composite key (no live row now).
-	metas, err := s.ListRelationVersions(ctx, "A", "links", "B")
+	metas, err := s.VersionStore().ListRelationVersions(ctx, "A", "links", "B")
 	require.NoError(t, err)
 	require.Len(t, metas, 2)
 	require.Equal(t, store.VersionOpDelete, metas[1].Op)
@@ -124,7 +124,7 @@ func TestRelationVersionRecreateStartsFreshLineage(t *testing.T) {
 	rid1 := relRecordID(ctx, t, pool, "A", "links", "B")
 	c1 := newRelVersionInput(rid1, "A", "links", "B", "gen1")
 	c1.Op = store.VersionOpCreate
-	require.NoError(t, s.WriteRelationVersion(ctx, c1))
+	require.NoError(t, s.VersionStore().WriteRelationVersion(ctx, c1))
 	require.NoError(t, s.DeleteRelation(ctx, "A", "links", "B"))
 
 	// Recreate the same triple — the row gets a fresh rel_record_id.
@@ -135,14 +135,14 @@ func TestRelationVersionRecreateStartsFreshLineage(t *testing.T) {
 
 	c2 := newRelVersionInput(rid2, "A", "links", "B", "gen2")
 	c2.Op = store.VersionOpCreate
-	require.NoError(t, s.WriteRelationVersion(ctx, c2))
+	require.NoError(t, s.VersionStore().WriteRelationVersion(ctx, c2))
 
 	// ListRelationVersions resolves to the CURRENT (gen2) lineage only — the
 	// gen1 history is not merged in.
-	metas, err := s.ListRelationVersions(ctx, "A", "links", "B")
+	metas, err := s.VersionStore().ListRelationVersions(ctx, "A", "links", "B")
 	require.NoError(t, err)
 	require.Len(t, metas, 1, "current lineage only; gen1 not merged")
-	snap, err := s.GetRelationVersion(ctx, "A", "links", "B", 1)
+	snap, err := s.VersionStore().GetRelationVersion(ctx, "A", "links", "B", 1)
 	require.NoError(t, err)
 	require.Equal(t, "gen2", snap.Content)
 }
@@ -186,7 +186,7 @@ func TestRelationVersionRenameAtomicPath(t *testing.T) {
 	rid := relRecordID(ctx, t, pool, "A", "links", "X")
 	c := newRelVersionInput(rid, "A", "links", "X", "v1")
 	c.Op = store.VersionOpCreate
-	require.NoError(t, s.WriteRelationVersion(ctx, c))
+	require.NoError(t, s.VersionStore().WriteRelationVersion(ctx, c))
 
 	// Rename A->A2 through the REAL atomic store path.
 	_, err = s.RenameEntity(ctx, "A", "A2")
@@ -203,11 +203,11 @@ func TestRelationVersionRenameAtomicPath(t *testing.T) {
 	ren.Op = store.VersionOpRename
 	ren.PrevFrom = "A"
 	ren.PrevTo = "X"
-	require.NoError(t, s.WriteRelationVersion(ctx, ren))
+	require.NoError(t, s.VersionStore().WriteRelationVersion(ctx, ren))
 
 	// History via the new key is one continuous timeline on the surviving
 	// lineage: the pre-rename create + the rename row. No orphaned lineage.
-	metas, err := s.ListRelationVersions(ctx, "A2", "links", "X")
+	metas, err := s.VersionStore().ListRelationVersions(ctx, "A2", "links", "X")
 	require.NoError(t, err)
 	require.Len(t, metas, 2, "continuous timeline on the surviving rel_record_id")
 	require.Equal(t, store.VersionOpCreate, metas[0].Op)
@@ -291,17 +291,17 @@ func TestSweepCapturesSettledRelations(t *testing.T) {
 		pgstore.SweepConfig{Interval: 50 * time.Millisecond, Idle: time.Minute, MaxStaleness: time.Hour, Batch: 100})
 
 	require.Eventually(t, func() bool {
-		metas, e := s.ListRelationVersions(ctx, "SET-A", "blocks", "SET-B")
+		metas, e := s.VersionStore().ListRelationVersions(ctx, "SET-A", "blocks", "SET-B")
 		return e == nil && len(metas) == 1 && metas[0].Op == store.VersionOpCreate
 	}, 3*time.Second, 25*time.Millisecond, "sweep should capture the settled relation once as create")
 
-	fresh, err := s.ListRelationVersions(ctx, "FRESH-A", "blocks", "FRESH-B")
+	fresh, err := s.VersionStore().ListRelationVersions(ctx, "FRESH-A", "blocks", "FRESH-B")
 	require.NoError(t, err)
 	require.Empty(t, fresh, "fresh relation should not be versioned yet")
 
 	// Dedup: unchanged content produces no further versions across ticks.
 	time.Sleep(200 * time.Millisecond)
-	metas, err := s.ListRelationVersions(ctx, "SET-A", "blocks", "SET-B")
+	metas, err := s.VersionStore().ListRelationVersions(ctx, "SET-A", "blocks", "SET-B")
 	require.NoError(t, err)
 	require.Len(t, metas, 1, "unchanged relation content must not duplicate versions")
 }

--- a/internal/store/pgstore/version.go
+++ b/internal/store/pgstore/version.go
@@ -18,8 +18,8 @@ import (
 // entity_versions INSERT run in one transaction so the version row is
 // all-or-nothing (no orphaned schema_versions row, no half-write across a
 // crash). The content hash is computed here from the snapshot.
-func (s *Store) WriteVersion(ctx context.Context, in store.VersionInput) error {
-	tx, err := s.db.Begin(ctx)
+func (v *VersionStore) WriteVersion(ctx context.Context, in store.VersionInput) error {
+	tx, err := v.db.Begin(ctx)
 	if err != nil {
 		return err
 	}
@@ -139,13 +139,13 @@ func lineageWhere() string {
 }
 
 // ListVersions implements store.HistoryReader.
-func (s *Store) ListVersions(ctx context.Context, id string) ([]store.VersionMeta, error) {
+func (v *VersionStore) ListVersions(ctx context.Context, id string) ([]store.VersionMeta, error) {
 	sel := lineageCTE + `
 		SELECT DISTINCT ev.vseq, ev.op, ev.prev_id, ev.type, ev.content_hash, ev.schema_hash,
 		       ev.principal_user, ev.principal_tool, ev.triggered_by, ev.created_at
 		FROM entity_versions ev` + lineageWhere() + `
 		ORDER BY ev.vseq ASC`
-	rows, err := s.db.Query(ctx, sel, id)
+	rows, err := v.db.Query(ctx, sel, id)
 	if err != nil {
 		return nil, err
 	}
@@ -174,7 +174,7 @@ func (s *Store) ListVersions(ctx context.Context, id string) ([]store.VersionMet
 // relative to a ListVersions read taken at the same time — the lineage is
 // append-only, so an ordinal a caller already holds stays valid, but callers
 // should treat it as a cursor into a specific ListVersions result.
-func (s *Store) GetVersion(ctx context.Context, id string, version int) (*store.VersionSnapshot, error) {
+func (v *VersionStore) GetVersion(ctx context.Context, id string, version int) (*store.VersionSnapshot, error) {
 	if version < 1 {
 		return nil, store.ErrNotFound
 	}
@@ -186,7 +186,7 @@ func (s *Store) GetVersion(ctx context.Context, id string, version int) (*store.
 		JOIN schema_versions sv ON sv.hash = ev.schema_hash
 		ORDER BY ev.vseq ASC
 		OFFSET $2 LIMIT 1`
-	row := s.db.QueryRow(ctx, sel, id, version-1)
+	row := v.db.QueryRow(ctx, sel, id, version-1)
 
 	var (
 		snap  store.VersionSnapshot
@@ -236,6 +236,3 @@ func scanVersionMeta(row scanner) (store.VersionMeta, error) {
 	m.CreatedAt = created
 	return m, nil
 }
-
-// Static assertion that Store satisfies the optional capability.
-var _ store.HistoryReader = (*Store)(nil)

--- a/internal/store/pgstore/version_store.go
+++ b/internal/store/pgstore/version_store.go
@@ -1,0 +1,48 @@
+package pgstore
+
+import "github.com/Sourcehaven-BV/rela/internal/store"
+
+// VersionStore is the PostgreSQL content-versioning service: entity and relation
+// history reads, synchronous version writes, and version purge. It is a SEPARATE
+// concern from [Store] that merely shares the same database — like the in-DB
+// search backend shares the pool. A store "just stores"; versioning is injected
+// as its own service (or left nil in a deployment without it, e.g. the default
+// filesystem build), rather than advertised as a pile of optional capabilities a
+// consumer type-asserts off the store.
+//
+// It is constructed from the same [DBTX] the store uses (the shared pool). All
+// its methods are pure functions over that handle — they hold no lifecycle state
+// (no listener, no sweep, no subscriber fan-out); those stay on [Store]. The
+// reconciliation sweep ([Store.StartVersionSweep]) is the store's own goroutine
+// and does its inserts via the same free `insert*` helpers, not through this
+// service, so the two never contend on shared receiver state.
+//
+// VersionStore satisfies the version capability interfaces in the store package
+// ([store.HistoryReader], [store.VersionWriter], [store.RelationHistoryReader],
+// [store.RelationVersionWriter], [store.VersionPurger],
+// [store.RelationVersionPurger]) and their umbrella [store.VersionService]. The
+// postgres composition root builds one and injects it wherever versioning is
+// needed; the default build injects nil.
+type VersionStore struct {
+	db DBTX
+}
+
+// VersionStore returns a versioning service sharing this store's connection
+// handle. The composition root calls this in the postgres recipe to obtain the
+// service it injects; it reads the same pool the store queries, so the two never
+// diverge. Returns a fresh lightweight wrapper each call (it holds only the
+// shared handle). (The reconciliation sweep is separate — see StartVersionSweep.)
+func (s *Store) VersionStore() *VersionStore {
+	return &VersionStore{db: s.db}
+}
+
+// Compile-time checks that VersionStore provides the full version surface.
+var (
+	_ store.HistoryReader         = (*VersionStore)(nil)
+	_ store.VersionWriter         = (*VersionStore)(nil)
+	_ store.RelationHistoryReader = (*VersionStore)(nil)
+	_ store.RelationVersionWriter = (*VersionStore)(nil)
+	_ store.VersionPurger         = (*VersionStore)(nil)
+	_ store.RelationVersionPurger = (*VersionStore)(nil)
+	_ store.VersionService        = (*VersionStore)(nil)
+)

--- a/internal/store/pgstore/version_test.go
+++ b/internal/store/pgstore/version_test.go
@@ -43,13 +43,13 @@ func TestWriteVersionAndList(t *testing.T) {
 
 	in := newVersionInput("TKT-1", "first", map[string]any{"title": "one"})
 	in.Op = store.VersionOpCreate
-	require.NoError(t, s.WriteVersion(ctx, in))
+	require.NoError(t, s.VersionStore().WriteVersion(ctx, in))
 
 	in2 := newVersionInput("TKT-1", "second", map[string]any{"title": "two"})
 	in2.Op = store.VersionOpUpdate
-	require.NoError(t, s.WriteVersion(ctx, in2))
+	require.NoError(t, s.VersionStore().WriteVersion(ctx, in2))
 
-	metas, err := s.ListVersions(ctx, "TKT-1")
+	metas, err := s.VersionStore().ListVersions(ctx, "TKT-1")
 	require.NoError(t, err)
 	require.Len(t, metas, 2)
 	require.Equal(t, 1, metas[0].Version)
@@ -59,16 +59,16 @@ func TestWriteVersionAndList(t *testing.T) {
 	require.Equal(t, "alice", metas[1].PrincipalUser)
 
 	// GetVersion returns the full snapshot for a 1-based ordinal.
-	snap, err := s.GetVersion(ctx, "TKT-1", 1)
+	snap, err := s.VersionStore().GetVersion(ctx, "TKT-1", 1)
 	require.NoError(t, err)
 	require.Equal(t, "first", snap.Content)
 	require.Equal(t, "one", snap.Properties["title"])
 	require.NotEmpty(t, snap.Projection)
 
 	// Out-of-range ordinals are ErrNotFound.
-	_, err = s.GetVersion(ctx, "TKT-1", 99)
+	_, err = s.VersionStore().GetVersion(ctx, "TKT-1", 99)
 	require.ErrorIs(t, err, store.ErrNotFound)
-	_, err = s.GetVersion(ctx, "TKT-1", 0)
+	_, err = s.VersionStore().GetVersion(ctx, "TKT-1", 0)
 	require.ErrorIs(t, err, store.ErrNotFound)
 }
 
@@ -77,7 +77,7 @@ func TestListVersionsUnknownEntity(t *testing.T) {
 	s, err := pgstore.New(newScopedPool(t))
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = s.Close() })
-	metas, err := s.ListVersions(context.Background(), "NOPE-1")
+	metas, err := s.VersionStore().ListVersions(context.Background(), "NOPE-1")
 	require.NoError(t, err)
 	require.Empty(t, metas)
 }
@@ -94,21 +94,21 @@ func TestRenameLineage(t *testing.T) {
 	// v1 under OLD id.
 	old := newVersionInput("OLD-1", "content-old", nil)
 	old.Op = store.VersionOpCreate
-	require.NoError(t, s.WriteVersion(ctx, old))
+	require.NoError(t, s.VersionStore().WriteVersion(ctx, old))
 
 	// rename OLD-1 -> NEW-1: a version row under NEW-1 carrying prev_id=OLD-1.
 	ren := newVersionInput("NEW-1", "content-old", nil)
 	ren.Op = store.VersionOpRename
 	ren.PrevID = "OLD-1"
-	require.NoError(t, s.WriteVersion(ctx, ren))
+	require.NoError(t, s.VersionStore().WriteVersion(ctx, ren))
 
 	// v under NEW id.
 	upd := newVersionInput("NEW-1", "content-new", nil)
 	upd.Op = store.VersionOpUpdate
-	require.NoError(t, s.WriteVersion(ctx, upd))
+	require.NoError(t, s.VersionStore().WriteVersion(ctx, upd))
 
 	// Listing by the NEW id returns the FULL lineage, oldest first.
-	metas, err := s.ListVersions(ctx, "NEW-1")
+	metas, err := s.VersionStore().ListVersions(ctx, "NEW-1")
 	require.NoError(t, err)
 	require.Len(t, metas, 3, "lineage should include the pre-rename version")
 	require.Equal(t, store.VersionOpCreate, metas[0].Op)
@@ -140,19 +140,19 @@ func TestSweepCapturesSettledEntities(t *testing.T) {
 		pgstore.SweepConfig{Interval: 50 * time.Millisecond, Idle: time.Minute, MaxStaleness: time.Hour, Batch: 100})
 
 	require.Eventually(t, func() bool {
-		metas, e := s.ListVersions(ctx, "SET-1")
+		metas, e := s.VersionStore().ListVersions(ctx, "SET-1")
 		return e == nil && len(metas) == 1
 	}, 3*time.Second, 25*time.Millisecond, "sweep should capture the settled entity exactly once")
 
 	// The fresh entity must NOT be versioned (hasn't settled).
-	fresh, err := s.ListVersions(ctx, "FRESH-1")
+	fresh, err := s.VersionStore().ListVersions(ctx, "FRESH-1")
 	require.NoError(t, err)
 	require.Empty(t, fresh, "fresh entity should not be versioned yet")
 
 	// Dedup: after the first capture, further ticks add no new version (content
 	// unchanged). Give it a few ticks and re-check the count is still 1.
 	time.Sleep(200 * time.Millisecond)
-	metas, err := s.ListVersions(ctx, "SET-1")
+	metas, err := s.VersionStore().ListVersions(ctx, "SET-1")
 	require.NoError(t, err)
 	require.Len(t, metas, 1, "unchanged content must not produce duplicate versions")
 }
@@ -169,38 +169,38 @@ func TestReusedIDDoesNotMergeHistories(t *testing.T) {
 	// Old A: create + update, then rename A -> B.
 	a1 := newVersionInput("A", "a-content-1", nil)
 	a1.Op = store.VersionOpCreate
-	require.NoError(t, s.WriteVersion(ctx, a1))
+	require.NoError(t, s.VersionStore().WriteVersion(ctx, a1))
 	a2 := newVersionInput("A", "a-content-2", nil)
 	a2.Op = store.VersionOpUpdate
-	require.NoError(t, s.WriteVersion(ctx, a2))
+	require.NoError(t, s.VersionStore().WriteVersion(ctx, a2))
 	ren := newVersionInput("B", "a-content-2", nil)
 	ren.Op = store.VersionOpRename
 	ren.PrevID = "A"
-	require.NoError(t, s.WriteVersion(ctx, ren))
+	require.NoError(t, s.VersionStore().WriteVersion(ctx, ren))
 
 	// A brand-new, unrelated entity reclaims id A.
 	newA := newVersionInput("A", "UNRELATED-new-A", nil)
 	newA.Op = store.VersionOpCreate
-	require.NoError(t, s.WriteVersion(ctx, newA))
+	require.NoError(t, s.VersionStore().WriteVersion(ctx, newA))
 
 	// B's history is A(create) -> A(update) -> B(rename): the pre-rename life,
 	// NOT the unrelated new A.
-	bHist, err := s.ListVersions(ctx, "B")
+	bHist, err := s.VersionStore().ListVersions(ctx, "B")
 	require.NoError(t, err)
 	require.Len(t, bHist, 3, "B lineage must be its pre-rename life only")
 	require.Equal(t, store.VersionOpRename, bHist[2].Op)
 	for _, m := range bHist {
-		snap, gErr := s.GetVersion(ctx, "B", m.Version)
+		snap, gErr := s.VersionStore().GetVersion(ctx, "B", m.Version)
 		require.NoError(t, gErr)
 		require.NotEqual(t, "UNRELATED-new-A", snap.Content,
 			"the unrelated new-A content must not appear in B's history")
 	}
 
 	// The new A's history is ONLY its own create, not the old A's create+update.
-	aHist, err := s.ListVersions(ctx, "A")
+	aHist, err := s.VersionStore().ListVersions(ctx, "A")
 	require.NoError(t, err)
 	require.Len(t, aHist, 1, "reclaimed id A must see only its own lifecycle")
-	snap, err := s.GetVersion(ctx, "A", 1)
+	snap, err := s.VersionStore().GetVersion(ctx, "A", 1)
 	require.NoError(t, err)
 	require.Equal(t, "UNRELATED-new-A", snap.Content)
 }
@@ -220,10 +220,10 @@ func TestDeleteThenRecreateIdenticalContent(t *testing.T) {
 	// the same content.
 	c1 := newVersionInput("X", "same-content", nil)
 	c1.Op = store.VersionOpCreate
-	require.NoError(t, s.WriteVersion(ctx, c1))
+	require.NoError(t, s.VersionStore().WriteVersion(ctx, c1))
 	del := newVersionInput("X", "same-content", nil)
 	del.Op = store.VersionOpDelete
-	require.NoError(t, s.WriteVersion(ctx, del))
+	require.NoError(t, s.VersionStore().WriteVersion(ctx, del))
 
 	// Re-create the live entity with IDENTICAL content, then sweep it.
 	require.NoError(t, s.CreateEntity(ctx, mkEntity("X", "ticket", "same-content")))
@@ -233,7 +233,7 @@ func TestDeleteThenRecreateIdenticalContent(t *testing.T) {
 		pgstore.SweepConfig{Interval: 50 * time.Millisecond, Idle: time.Minute, MaxStaleness: time.Hour, Batch: 100})
 
 	require.Eventually(t, func() bool {
-		metas, e := s.ListVersions(ctx, "X")
+		metas, e := s.VersionStore().ListVersions(ctx, "X")
 		if e != nil || len(metas) == 0 {
 			return false
 		}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -695,6 +695,29 @@ type RelationVersionPurger interface {
 	PurgeRelationVersions(ctx context.Context, req RelationVersionPurgeRequest) (*PurgeResult, error)
 }
 
+// VersionService is the umbrella for a backend's full content-versioning surface:
+// entity + relation history reads, synchronous version writes, and purge. It is a
+// SEPARATE concern from [Store] (a store just stores) that a backend supplies as
+// its own injected service — or leaves absent (nil) where versioning isn't
+// provided (the filesystem build uses git instead). pgstore's *VersionStore
+// implements it.
+//
+// This umbrella is a WIRING vehicle only: the composition root uses it as the
+// nil-able field type it threads through the service bundles. Consumers still
+// bind the NARROW sub-interface they actually use at the call site
+// (a history command takes [RelationHistoryReader]; a recorder takes
+// [RelationVersionWriter]) — the umbrella is never a parameter to a handler or
+// command. It groups one cohesive concern (all version I/O over one connection),
+// not a cross-subsystem service locator.
+type VersionService interface {
+	HistoryReader
+	VersionWriter
+	RelationHistoryReader
+	RelationVersionWriter
+	VersionPurger
+	RelationVersionPurger
+}
+
 // EntityObserver receives notifications when entities are created, updated,
 // deleted, or renamed. Stores call observers synchronously after each write.
 // Implementations must be safe for concurrent use.


### PR DESCRIPTION
## What

Prep refactor (PR1 of 2) toward TKT-HGE4KW. **No behavior change.** `chore/*` branch: pure refactor, touches no ticket entity.

Extracts the 8 content-versioning methods off `pgstore.Store` onto a new `pgstore.VersionStore{db DBTX}` service:

- `ListVersions` / `GetVersion` / `WriteVersion`
- `ListRelationVersions` / `GetRelationVersion` / `WriteRelationVersion`
- `PurgeVersions` / `PurgeRelationVersions`

(plus the private helpers `recordIDForKey`, `relationLineageIDs`, `entityLineageIDsForPurge`, `liveEntityHash`, `liveRelationHash`).

## Why

The store advertised versioning by satisfying a pile of optional interfaces that every consumer type-asserted (`svc.Store.(store.RelationHistoryReader)`, `(store.VersionPurger)`, …). **A store should just store.** Versioning is a separate concern that merely shares the same database — like the in-DB search backend shares the pool. So it becomes an **injected service** (`store.VersionService`, nil-able), wired backend-specifically in the postgres recipe (mirroring Searcher), instead of a capability asserted off the store.

## Result

- `pgstore.Store` drops **40 → 33** exported methods (53 → 41 total). Version methods verified to touch only `s.db` — no Store lifecycle state — so the move is mechanical and behavior-preserving.
- `StartVersionSweep` stays on `Store` (owns `s.mu`/`s.sweep`); the sweep's own inserts go through the free `insert*` helpers, untouched.
- Consumers (CLI history/restore/purge commands, dataentry history handlers, entitymanager recorders) take the injected service and bind the **narrow** sub-interface at each call site; the `VersionService` umbrella is a nil-able field type only, never a handler/command param.
- Genuinely-nil interface on non-versioning builds (no typed-nil trap): `versionServiceFor` returns untyped nil; recorder factories nil-check it.
- `store.Store` interface unchanged; fs/mem builds inject nil (degrade path intact).

## Next

PR2 (TKT-HGE4KW) adds lifetime enumeration + a `RecordID` selector + the purge-erases-all-lifetimes compliance fix on top of `VersionStore`, where the new methods land without touching `Store`'s plimsoll ceiling.

## Review

`/code-review` (cranky-code-reviewer): verdict "clean refactor," no blocking findings. Addressed: removed a dead `NewVersionStore`, added a "do not re-add version methods to Store" prohibition.

(Supersedes #1182 — same commit, moved to a `chore/*` branch so the Rela Tickets require-new gate correctly exempts this ticket-less refactor.)