### PR TITLE
feat(pgstore): disambiguate deleted-relation history across id-reuse lifetimes (TKT-HGE4KW)

### DIFF
--- a/internal/cli/history_purge.go
+++ b/internal/cli/history_purge.go
@@ -89,16 +89,18 @@ func (c *HistoryPurgeCmd) Run(ctx context.Context, svc *writeServices) error {
 
 // RelationHistoryPurgeCmd is the relation analog.
 type RelationHistoryPurgeCmd struct {
-	From        string `arg:"" help:"Source entity ID (the relation's 'from')."`
-	Type        string `arg:"" help:"Relation type."`
-	To          string `arg:"" help:"Target entity ID (the relation's 'to')."`
-	Vseq        int64  `help:"Purge the single version row with this vseq." default:"0"`
-	ContentHash string `help:"Purge every version row in the lineage with this content hash." default:""`
-	All         bool   `help:"Purge the relation's entire (fenced) version history."`
-	Reason      string `help:"Required: operator justification (logged cleartext — not the secret)." default:""`
-	Commit      bool   `help:"Actually delete. Without this, a dry-run showing what WOULD be purged."`
-	Yes         bool   `help:"Skip the confirmation (scripts). Requires --commit."`
-	ForceLive   bool   `help:"Purge even though the live relation still holds the content (writes a tombstone)."`
+	From         string `arg:"" help:"Source entity ID (the relation's 'from')."`
+	Type         string `arg:"" help:"Relation type."`
+	To           string `arg:"" help:"Target entity ID (the relation's 'to')."`
+	Vseq         int64  `help:"Purge the single version row with this vseq." default:"0"`
+	ContentHash  string `help:"Purge every version row in the lineage with this content hash." default:""`
+	All          bool   `help:"Purge the relation's entire (fenced) version history."`
+	Lifetime     int    `help:"Select which lifetime of a deleted-and-recreated key to purge (1 = newest; see 'relation-history --list-lifetimes')." default:"0"`
+	AllLifetimes bool   `help:"Purge EVERY lifetime of a reused key (complete erasure). Mutually exclusive with --lifetime."`
+	Reason       string `help:"Required: operator justification (logged cleartext — not the secret)." default:""`
+	Commit       bool   `help:"Actually delete. Without this, a dry-run showing what WOULD be purged."`
+	Yes          bool   `help:"Skip the confirmation (scripts). Requires --commit."`
+	ForceLive    bool   `help:"Purge even though the live relation still holds the content (writes a tombstone)."`
 }
 
 // Run dispatches `rela relation-history-purge <from> <type> <to> ...`.
@@ -112,11 +114,21 @@ func (c *RelationHistoryPurgeCmd) Run(ctx context.Context, svc *writeServices) e
 	if err := validatePurgeFlags(c.Reason, c.Vseq, c.ContentHash, c.All); err != nil {
 		return err
 	}
+	if c.Lifetime != 0 && c.AllLifetimes {
+		return errors.New("--lifetime and --all-lifetimes are mutually exclusive")
+	}
 	p := principal.From(ctx)
 	key := fmt.Sprintf("%s--%s--%s", c.From, c.Type, c.To)
+
+	recordID, err := resolveLifetimeRecordID(ctx, svc.Versions, c.From, c.Type, c.To, c.Lifetime)
+	if err != nil {
+		return err
+	}
 	req := store.RelationVersionPurgeRequest{
 		From: c.From, Type: c.Type, To: c.To,
 		Selector:      store.PurgeSelector{Vseq: c.Vseq, ContentHash: c.ContentHash, All: c.All},
+		RecordID:      recordID,
+		AllLifetimes:  c.AllLifetimes,
 		Reason:        c.Reason,
 		ForceLive:     c.ForceLive,
 		PrincipalUser: p.User,
@@ -128,6 +140,14 @@ func (c *RelationHistoryPurgeCmd) Run(ctx context.Context, svc *writeServices) e
 	res, err := purger.PurgeRelationVersions(ctx, preview)
 	if err != nil {
 		return fmt.Errorf("purge relation history for %s: %w", key, err)
+	}
+	if res.MultiLifetimeRefused {
+		out.WriteMessage("Refused: %s has %d lifetimes (a deleted-and-recreated key). "+
+			"Purging without a selector would erase only the newest and leave older lifetimes' "+
+			"content behind. Choose one with --lifetime K (see 'relation-history %s %s %s "+
+			"--list-lifetimes'), or --all-lifetimes to erase every lifetime.",
+			key, res.LifetimeCount, c.From, c.Type, c.To)
+		return nil
 	}
 	if refused := reportPurgePreview(res, key, !c.Commit); refused || !c.Commit {
 		return nil

--- a/internal/cli/relation_history.go
+++ b/internal/cli/relation_history.go
@@ -15,13 +15,15 @@ import (
 // addressed by its three-part key. Relation content versioning is a pgstore-only
 // capability (filesystem deployments use git for the same purpose).
 type RelationHistoryCmd struct {
-	From    string `arg:"" help:"Source entity ID (the relation's 'from')."`
-	Type    string `arg:"" help:"Relation type (e.g. addresses)."`
-	To      string `arg:"" help:"Target entity ID (the relation's 'to')."`
-	Version int    `help:"Print the full snapshot for this 1-based version ordinal (for piping to a diff tool) instead of the timeline." default:"0"`
+	From          string `arg:"" help:"Source entity ID (the relation's 'from')."`
+	Type          string `arg:"" help:"Relation type (e.g. addresses)."`
+	To            string `arg:"" help:"Target entity ID (the relation's 'to')."`
+	Version       int    `help:"Print the full snapshot for this 1-based version ordinal (for piping to a diff tool) instead of the timeline." default:"0"`
+	Lifetime      int    `help:"Select a past lifetime of a deleted-and-recreated key (1 = newest; see --list-lifetimes). Default: newest." default:"0"`
+	ListLifetimes bool   `help:"List every past lifetime of this key (a reused (from,type,to) has several) instead of a timeline."`
 }
 
-// Run dispatches `rela relation-history <from> <type> <to> [--version N]`.
+// Run dispatches `rela relation-history <from> <type> <to> [--version N] [--lifetime K] [--list-lifetimes]`.
 func (c *RelationHistoryCmd) Run(ctx context.Context, svc *writeServices) error {
 	if svc.Versions == nil {
 		out.WriteMessage("The active storage backend does not support relation version history " +
@@ -29,14 +31,66 @@ func (c *RelationHistoryCmd) Run(ctx context.Context, svc *writeServices) error 
 		return nil
 	}
 	var reader store.RelationHistoryReader = svc.Versions
-	if c.Version > 0 {
-		return c.printSnapshot(ctx, reader)
+	if c.ListLifetimes {
+		return c.printLifetimes(ctx, reader)
 	}
-	return c.printTimeline(ctx, reader)
+	recordID, err := resolveLifetimeRecordID(ctx, reader, c.From, c.Type, c.To, c.Lifetime)
+	if err != nil {
+		return err
+	}
+	q := store.RelationHistoryQuery{From: c.From, Type: c.Type, To: c.To, RecordID: recordID}
+	if c.Version > 0 {
+		return c.printSnapshot(ctx, reader, q)
+	}
+	return c.printTimeline(ctx, reader, q)
 }
 
-func (c *RelationHistoryCmd) printTimeline(ctx context.Context, reader store.RelationHistoryReader) error {
-	metas, err := reader.ListRelationVersions(ctx, c.From, c.Type, c.To)
+// resolveLifetimeRecordID maps a 1-based lifetime ordinal to its durable
+// rel_record_id via a single lifetimes enumeration (atomic w.r.t. that read).
+// Returns 0 (newest lifetime) when lifetime <= 0. Shared by the relation-history,
+// relation-restore, and relation-history-purge commands.
+func resolveLifetimeRecordID(
+	ctx context.Context, reader store.RelationHistoryReader, from, relType, to string, lifetime int,
+) (int64, error) {
+	if lifetime <= 0 {
+		return 0, nil
+	}
+	lifetimes, err := reader.ListRelationLifetimes(ctx, from, relType, to)
+	if err != nil {
+		return 0, fmt.Errorf("list lifetimes for %s--%s--%s: %w", from, relType, to, err)
+	}
+	if lifetime > len(lifetimes) {
+		return 0, fmt.Errorf("no lifetime %d for %s--%s--%s (%d exist)", lifetime, from, relType, to, len(lifetimes))
+	}
+	return lifetimes[lifetime-1].RecordID, nil
+}
+
+func (c *RelationHistoryCmd) printLifetimes(ctx context.Context, reader store.RelationHistoryReader) error {
+	lifetimes, err := reader.ListRelationLifetimes(ctx, c.From, c.Type, c.To)
+	if err != nil {
+		return fmt.Errorf("list lifetimes for %s--%s--%s: %w", c.From, c.Type, c.To, err)
+	}
+	if len(lifetimes) == 0 {
+		out.WriteMessage("No version history for %s--%s--%s.", c.From, c.Type, c.To)
+		return nil
+	}
+	for _, lt := range lifetimes {
+		flag := "deleted"
+		if lt.Live {
+			flag = "live"
+		}
+		out.WriteInfo("lifetime %d  [%s]  %d version(s)  %s → %s  final=%s  (record-id %d)",
+			lt.Lifetime, flag, lt.VersionCount,
+			lt.FirstSeen.Format("2006-01-02 15:04:05"), lt.LastSeen.Format("2006-01-02 15:04:05"),
+			lt.FinalOp, lt.RecordID)
+	}
+	return nil
+}
+
+func (c *RelationHistoryCmd) printTimeline(
+	ctx context.Context, reader store.RelationHistoryReader, q store.RelationHistoryQuery,
+) error {
+	metas, err := reader.ListRelationVersions(ctx, q)
 	if err != nil {
 		return fmt.Errorf("read relation history for %s--%s--%s: %w", c.From, c.Type, c.To, err)
 	}
@@ -62,11 +116,20 @@ func (c *RelationHistoryCmd) printTimeline(ctx context.Context, reader store.Rel
 		}
 		out.WriteInfo("%s", line)
 	}
+	// Footer: signal that older deleted lifetimes exist (only for the newest view).
+	if q.RecordID == 0 {
+		if lifetimes, err := reader.ListRelationLifetimes(ctx, c.From, c.Type, c.To); err == nil && len(lifetimes) > 1 {
+			out.WriteMessage("note: %d earlier deleted lifetime(s) of this key exist — "+
+				"use --list-lifetimes, or --lifetime K to view one.", len(lifetimes)-1)
+		}
+	}
 	return nil
 }
 
-func (c *RelationHistoryCmd) printSnapshot(ctx context.Context, reader store.RelationHistoryReader) error {
-	snap, err := reader.GetRelationVersion(ctx, c.From, c.Type, c.To, c.Version)
+func (c *RelationHistoryCmd) printSnapshot(
+	ctx context.Context, reader store.RelationHistoryReader, q store.RelationHistoryQuery,
+) error {
+	snap, err := reader.GetRelationVersion(ctx, q, c.Version)
 	if errors.Is(err, store.ErrNotFound) {
 		return fmt.Errorf("no version %d for %s--%s--%s", c.Version, c.From, c.Type, c.To)
 	}
@@ -94,14 +157,20 @@ func (c *RelationHistoryCmd) printSnapshot(ctx context.Context, reader store.Rel
 // entitymanager (authorized, validated, audited, re-versioned). If the relation
 // currently exists it is updated; if it was deleted, it is re-created — which
 // fails if an endpoint entity no longer exists. pgstore-only.
+//
+// Restoring from an OLD lifetime (--lifetime K on a deleted-and-recreated key)
+// re-creates the triple as a NORMAL write, which mints a FRESH rel_record_id — a
+// new lifetime 1 appears afterward; it does NOT revive the old lineage in place.
+// That is the only sensible semantics (restore = an authorized re-create).
 type RelationRestoreCmd struct {
-	From    string `arg:"" help:"Source entity ID (the relation's 'from')."`
-	Type    string `arg:"" help:"Relation type."`
-	To      string `arg:"" help:"Target entity ID (the relation's 'to')."`
-	Version int    `arg:"" help:"The 1-based version ordinal to restore to (see 'rela relation-history')."`
+	From     string `arg:"" help:"Source entity ID (the relation's 'from')."`
+	Type     string `arg:"" help:"Relation type."`
+	To       string `arg:"" help:"Target entity ID (the relation's 'to')."`
+	Version  int    `arg:"" help:"The 1-based version ordinal to restore to (see 'rela relation-history')."`
+	Lifetime int    `help:"Restore from a past lifetime of a deleted-and-recreated key (1 = newest; see --list-lifetimes). Default: newest." default:"0"`
 }
 
-// Run dispatches `rela relation-restore <from> <type> <to> <version>`.
+// Run dispatches `rela relation-restore <from> <type> <to> <version> [--lifetime K]`.
 func (c *RelationRestoreCmd) Run(ctx context.Context, svc *writeServices) error {
 	if svc.Versions == nil {
 		out.WriteMessage("The active storage backend does not support relation version history " +
@@ -110,7 +179,12 @@ func (c *RelationRestoreCmd) Run(ctx context.Context, svc *writeServices) error 
 	}
 	var reader store.RelationHistoryReader = svc.Versions
 
-	snap, err := reader.GetRelationVersion(ctx, c.From, c.Type, c.To, c.Version)
+	recordID, err := resolveLifetimeRecordID(ctx, reader, c.From, c.Type, c.To, c.Lifetime)
+	if err != nil {
+		return err
+	}
+	q := store.RelationHistoryQuery{From: c.From, Type: c.Type, To: c.To, RecordID: recordID}
+	snap, err := reader.GetRelationVersion(ctx, q, c.Version)
 	if errors.Is(err, store.ErrNotFound) {
 		return fmt.Errorf("no version %d for %s--%s--%s", c.Version, c.From, c.Type, c.To)
 	}

--- a/internal/dataentry/relation_history_handler.go
+++ b/internal/dataentry/relation_history_handler.go
@@ -81,11 +81,49 @@ func handleV1RelationHistory(a *App, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if len(parts) >= 5 && parts[4] != "" {
-		serveRelationHistoryVersion(w, r, reader, from, relType, to, parts[4])
+	// GET .../_lifetimes enumerates every past lifetime of a reused key. Same read
+	// gate as the timeline (just authorized above). The body carries only lifetime
+	// metadata (counts/timestamps/final-op), never relation content — but it DOES
+	// reveal that older deleted lifetimes exist, which is the feature's whole point
+	// and is what the gate authorizes.
+	if len(parts) >= 5 && parts[4] == "_lifetimes" {
+		serveRelationLifetimes(w, r, reader, from, relType, to)
 		return
 	}
-	serveRelationHistoryTimeline(w, r, reader, from, relType, to)
+
+	// Optional ?record_id=<n> selects a specific past lifetime (0/absent = newest).
+	// The store validates membership in the key's lifetimes, so a client-supplied
+	// record_id cannot escape the composite-key auth boundary. A non-empty but
+	// unparseable value is a 400 (never silently coerced to newest — that would
+	// serve a different lifetime than asked for, with no signal).
+	recordID, ok := parseRecordID(r)
+	if !ok {
+		writeV1Error(w, r, http.StatusBadRequest, "invalid_record_id",
+			"record_id must be a positive integer", "")
+		return
+	}
+	q := store.RelationHistoryQuery{From: from, Type: relType, To: to, RecordID: recordID}
+
+	if len(parts) >= 5 && parts[4] != "" {
+		serveRelationHistoryVersion(w, r, reader, q, parts[4])
+		return
+	}
+	serveRelationHistoryTimeline(w, r, reader, q)
+}
+
+// parseRecordID reads the optional ?record_id= lifetime selector. Absent → (0,
+// true) = newest. A non-empty value must parse to a positive integer; otherwise
+// (0, false) so the caller returns 400 rather than silently serving the newest.
+func parseRecordID(r *http.Request) (int64, bool) {
+	raw := r.URL.Query().Get("record_id")
+	if raw == "" {
+		return 0, true
+	}
+	id, err := strconv.ParseInt(raw, 10, 64)
+	if err != nil || id <= 0 {
+		return 0, false
+	}
+	return id, true
 }
 
 // authorizeRelationHistoryRead returns true if the caller may read this
@@ -136,12 +174,47 @@ func authorizeRelationHistoryRead(a *App, w http.ResponseWriter, r *http.Request
 	return true
 }
 
-// serveRelationHistoryTimeline writes the relation's version metadata list.
-func serveRelationHistoryTimeline(
+// serveRelationLifetimes writes the list of a key's past lifetimes (newest-first),
+// so a UI can offer a lifetime picker for a deleted-and-recreated relation.
+func serveRelationLifetimes(
 	w http.ResponseWriter, r *http.Request, reader store.RelationHistoryReader,
 	from, relType, to string,
 ) {
-	metas, err := reader.ListRelationVersions(r.Context(), from, relType, to)
+	lifetimes, err := reader.ListRelationLifetimes(r.Context(), from, relType, to)
+	if err != nil {
+		writeGateError(w, r, err)
+		return
+	}
+	rows := make([]map[string]any, 0, len(lifetimes))
+	for _, lt := range lifetimes {
+		rows = append(rows, map[string]any{
+			"lifetime":      lt.Lifetime,
+			"record_id":     lt.RecordID,
+			"version_count": lt.VersionCount,
+			"first_seen":    lt.FirstSeen,
+			"last_seen":     lt.LastSeen,
+			"live":          lt.Live,
+			"final_op":      lt.FinalOp,
+		})
+	}
+	writeV1JSON(w, http.StatusOK, map[string]any{
+		"from": from, "type": relType, "to": to, "lifetimes": rows,
+	})
+}
+
+// serveRelationHistoryTimeline writes the version metadata list for the lifetime
+// the query selects.
+func serveRelationHistoryTimeline(
+	w http.ResponseWriter, r *http.Request, reader store.RelationHistoryReader,
+	q store.RelationHistoryQuery,
+) {
+	metas, err := reader.ListRelationVersions(r.Context(), q)
+	if errors.Is(err, store.ErrNotFound) {
+		// A record_id that is not a lifetime of this key: same indistinguishable
+		// 404 as a nonexistent relation (never confirm the id belongs elsewhere).
+		writeV1Error(w, r, http.StatusNotFound, "not_found", entityNotFoundTitle, "")
+		return
+	}
 	if err != nil {
 		writeGateError(w, r, err)
 		return
@@ -167,14 +240,15 @@ func serveRelationHistoryTimeline(
 		versions = append(versions, row)
 	}
 	writeV1JSON(w, http.StatusOK, map[string]any{
-		"from": from, "type": relType, "to": to, "versions": versions,
+		"from": q.From, "type": q.Type, "to": q.To, "versions": versions,
 	})
 }
 
-// serveRelationHistoryVersion writes one relation version's full snapshot.
+// serveRelationHistoryVersion writes one relation version's full snapshot for the
+// lifetime the query selects.
 func serveRelationHistoryVersion(
 	w http.ResponseWriter, r *http.Request, reader store.RelationHistoryReader,
-	from, relType, to, versionStr string,
+	q store.RelationHistoryQuery, versionStr string,
 ) {
 	version, convErr := strconv.Atoi(versionStr)
 	if convErr != nil || version < 1 {
@@ -182,7 +256,7 @@ func serveRelationHistoryVersion(
 			"Version must be a positive integer", "")
 		return
 	}
-	snap, err := reader.GetRelationVersion(r.Context(), from, relType, to, version)
+	snap, err := reader.GetRelationVersion(r.Context(), q, version)
 	if errors.Is(err, store.ErrNotFound) {
 		writeV1Error(w, r, http.StatusNotFound, "not_found", entityNotFoundTitle, "")
 		return
@@ -196,9 +270,9 @@ func serveRelationHistoryVersion(
 		"content": snap.Content, "meta": snap.Properties,
 	}
 	writeV1JSON(w, http.StatusOK, map[string]any{
-		"from":       from,
-		"type":       relType,
-		"to":         to,
+		"from":       q.From,
+		"type":       q.Type,
+		"to":         q.To,
 		"version":    snap.Version,
 		"op":         snap.Op,
 		"created_at": snap.CreatedAt,
@@ -228,7 +302,10 @@ func restoreRelationHistoryVersion(a *App,
 	}
 
 	ctx := r.Context()
-	snap, err := reader.GetRelationVersion(ctx, from, relType, to, version)
+	// Restore reads from the newest lifetime (RecordID 0); the HTTP restore route
+	// does not expose an older-lifetime selector (the CLI does via --lifetime).
+	q := store.RelationHistoryQuery{From: from, Type: relType, To: to}
+	snap, err := reader.GetRelationVersion(ctx, q, version)
 	if errors.Is(err, store.ErrNotFound) {
 		writeV1Error(w, r, http.StatusNotFound, "not_found", entityNotFoundTitle, "")
 		return

--- a/internal/dataentry/relation_history_handler_test.go
+++ b/internal/dataentry/relation_history_handler_test.go
@@ -20,14 +20,17 @@ import (
 type relHistoryStore struct {
 	stubVersionService
 	versions map[string][]store.RelationVersionSnapshot
+	// lifetimes, when set for a key, is returned by ListRelationLifetimes; else a
+	// single synthetic lifetime is derived from `versions`.
+	lifetimes map[string][]store.RelationLifetime
 }
 
 func relKey(from, relType, to string) string { return from + "|" + relType + "|" + to }
 
 func (h relHistoryStore) ListRelationVersions(
-	_ context.Context, from, relType, to string,
+	_ context.Context, q store.RelationHistoryQuery,
 ) ([]store.RelationVersionMeta, error) {
-	snaps := h.versions[relKey(from, relType, to)]
+	snaps := h.versions[relKey(q.From, q.Type, q.To)]
 	metas := make([]store.RelationVersionMeta, 0, len(snaps))
 	for _, s := range snaps {
 		metas = append(metas, s.RelationVersionMeta)
@@ -36,14 +39,30 @@ func (h relHistoryStore) ListRelationVersions(
 }
 
 func (h relHistoryStore) GetRelationVersion(
-	_ context.Context, from, relType, to string, version int,
+	_ context.Context, q store.RelationHistoryQuery, version int,
 ) (*store.RelationVersionSnapshot, error) {
-	snaps := h.versions[relKey(from, relType, to)]
+	snaps := h.versions[relKey(q.From, q.Type, q.To)]
 	if version < 1 || version > len(snaps) {
 		return nil, store.ErrNotFound
 	}
 	s := snaps[version-1]
 	return &s, nil
+}
+
+// ListRelationLifetimes reports a single lifetime for any key that has canned
+// versions — enough for the handler tests (which exercise the timeline/version
+// paths, not multi-lifetime enumeration; that is covered by the pgstore DB tests).
+func (h relHistoryStore) ListRelationLifetimes(
+	_ context.Context, from, relType, to string,
+) ([]store.RelationLifetime, error) {
+	if lts, ok := h.lifetimes[relKey(from, relType, to)]; ok {
+		return lts, nil
+	}
+	snaps := h.versions[relKey(from, relType, to)]
+	if len(snaps) == 0 {
+		return nil, nil
+	}
+	return []store.RelationLifetime{{Lifetime: 1, RecordID: 1, VersionCount: len(snaps)}}, nil
 }
 
 // perEndpointGate permits reads only for ids in `allow`. HoldsPermission is
@@ -144,6 +163,69 @@ func TestRelationHistory_BothEndpointsPermitted(t *testing.T) {
 	}
 	if !strings.Contains(rec.Body.String(), "\"versions\"") {
 		t.Errorf("timeline body missing versions: %s", rec.Body.String())
+	}
+}
+
+// TestRelationHistory_LifetimesRoutePermitted verifies GET .../_lifetimes serves
+// the lifetime list when both endpoints are readable (same gate as the timeline).
+func TestRelationHistory_LifetimesRoutePermitted(t *testing.T) {
+	app := newRelHistoryApp(t)
+	// Give the key two canned lifetimes.
+	rel := app.versions.(relHistoryStore)
+	rel.lifetimes = map[string][]store.RelationLifetime{
+		relKey("DEC-1", "addresses", "REQ-1"): {
+			{Lifetime: 1, RecordID: 22, VersionCount: 2, Live: true, FinalOp: store.VersionOpUpdate},
+			{Lifetime: 2, RecordID: 11, VersionCount: 3, FinalOp: store.VersionOpDelete},
+		},
+	}
+	app.versions = rel
+
+	gate := perEndpointGate{allow: map[string]bool{"DEC-1": true, "REQ-1": true}}
+	req := httptest.NewRequest(http.MethodGet,
+		"/api/v1/_relation_history/decision/DEC-1/addresses/REQ-1/_lifetimes", http.NoBody)
+	req = req.WithContext(withReadGate(context.Background(), gate))
+	rec := httptest.NewRecorder()
+	handleV1RelationHistory(app, rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("lifetimes must be 200; got %d, body=%s", rec.Code, rec.Body.String())
+	}
+	body := rec.Body.String()
+	if !strings.Contains(body, "\"lifetimes\"") || !strings.Contains(body, "\"record_id\":11") {
+		t.Errorf("lifetimes body missing expected fields: %s", body)
+	}
+}
+
+// TestRelationHistory_LifetimesRouteDeniedIsNotOracle: the _lifetimes route is
+// gated exactly like the timeline — a denied TO endpoint yields a 404, never a
+// leak of how many lifetimes exist.
+func TestRelationHistory_LifetimesRouteDeniedIsNotOracle(t *testing.T) {
+	app := newRelHistoryApp(t)
+	gate := perEndpointGate{allow: map[string]bool{"DEC-1": true, "REQ-1": false}}
+	req := httptest.NewRequest(http.MethodGet,
+		"/api/v1/_relation_history/decision/DEC-1/addresses/REQ-1/_lifetimes", http.NoBody)
+	req = req.WithContext(withReadGate(context.Background(), gate))
+	rec := httptest.NewRecorder()
+	handleV1RelationHistory(app, rec, req)
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("denied _lifetimes must be 404 (no oracle); got %d, body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+// TestRelationHistory_BadRecordIDIs400: a non-empty but unparseable ?record_id=
+// is a 400, never silently coerced to the newest lifetime (which would serve a
+// different lifetime than asked for, with no signal).
+func TestRelationHistory_BadRecordIDIs400(t *testing.T) {
+	app := newRelHistoryApp(t)
+	gate := perEndpointGate{allow: map[string]bool{"DEC-1": true, "REQ-1": true}}
+	for _, bad := range []string{"abc", "-1", "0"} {
+		req := httptest.NewRequest(http.MethodGet,
+			"/api/v1/_relation_history/decision/DEC-1/addresses/REQ-1?record_id="+bad, http.NoBody)
+		req = req.WithContext(withReadGate(context.Background(), gate))
+		rec := httptest.NewRecorder()
+		handleV1RelationHistory(app, rec, req)
+		if rec.Code != http.StatusBadRequest {
+			t.Errorf("record_id=%q must be 400; got %d, body=%s", bad, rec.Code, rec.Body.String())
+		}
 	}
 }
 

--- a/internal/dataentry/version_service_stub_test.go
+++ b/internal/dataentry/version_service_stub_test.go
@@ -28,15 +28,21 @@ func (stubVersionService) WriteVersion(context.Context, store.VersionInput) erro
 }
 
 func (stubVersionService) ListRelationVersions(
-	context.Context, string, string, string,
+	context.Context, store.RelationHistoryQuery,
 ) ([]store.RelationVersionMeta, error) {
 	panic("stubVersionService.ListRelationVersions not implemented")
 }
 
 func (stubVersionService) GetRelationVersion(
-	context.Context, string, string, string, int,
+	context.Context, store.RelationHistoryQuery, int,
 ) (*store.RelationVersionSnapshot, error) {
 	panic("stubVersionService.GetRelationVersion not implemented")
+}
+
+func (stubVersionService) ListRelationLifetimes(
+	context.Context, string, string, string,
+) ([]store.RelationLifetime, error) {
+	panic("stubVersionService.ListRelationLifetimes not implemented")
 }
 
 func (stubVersionService) WriteRelationVersion(context.Context, store.RelationVersionInput) error {

--- a/internal/store/pgstore/purge.go
+++ b/internal/store/pgstore/purge.go
@@ -123,17 +123,22 @@ func (v *VersionStore) PurgeRelationVersions(
 	}
 	defer advisoryUnlock(context.WithoutCancel(ctx), conn, sweepAdvisoryLockKey)
 
-	id, err := v.recordIDForKey(ctx, req.From, req.Type, req.To)
-	if errors.Is(err, store.ErrNotFound) {
-		return &store.PurgeResult{}, nil // nothing to purge
-	}
+	// Resolve which lifetime(s) of the key to purge. A reused key has multiple
+	// lifetimes (each recreate mints a fresh rel_record_id); purging without a
+	// selector would silently erase only the newest and leave older lifetimes'
+	// content behind — a false erasure guarantee for a compliance op. So refuse a
+	// multi-lifetime key unless the caller named RecordID or AllLifetimes.
+	ids, refused, err := v.resolvePurgeLineage(ctx, req)
 	if err != nil {
 		return nil, err
 	}
-	ids, err := v.relationLineageIDs(ctx, id)
-	if err != nil {
-		return nil, err
+	if refused != nil {
+		return refused, nil // MultiLifetimeRefused, nothing purged
 	}
+	if len(ids) == 0 {
+		return &store.PurgeResult{}, nil // nothing to purge (unknown key)
+	}
+
 	liveHash, liveExists, err := v.liveRelationHash(ctx, conn, req.From, req.Type, req.To)
 	if err != nil {
 		return nil, err
@@ -163,12 +168,97 @@ func (v *VersionStore) PurgeRelationVersions(
 	res.Purged = n
 
 	if liveExists && req.ForceLive {
-		if err := writeRelationPurgeTombstone(ctx, conn, req.From, req.Type, req.To, id, liveHash); err != nil {
-			return nil, err
+		// The live row's lineage is the newest lifetime; tombstone it so the sweep
+		// doesn't re-capture the purged content. (AllLifetimes includes it.)
+		liveID, lerr := v.liveRecordID(ctx, req.From, req.Type, req.To)
+		if lerr != nil {
+			return nil, lerr
 		}
-		res.TombstoneWritten = true
+		if liveID != 0 {
+			if err := writeRelationPurgeTombstone(ctx, conn, req.From, req.Type, req.To, liveID, liveHash); err != nil {
+				return nil, err
+			}
+			res.TombstoneWritten = true
+		}
 	}
 	return res, nil
+}
+
+// resolvePurgeLineage resolves a relation purge request to the set of
+// rel_record_ids to purge, enforcing the multi-lifetime guardrail. Returns
+// (ids, nil, nil) to proceed; (nil, refusalResult, nil) when a multi-lifetime key
+// lacks a selector; (nil, nil, nil) for an unknown key. AllLifetimes spans every
+// head's fenced lineage; RecordID selects one validated head; the default (0)
+// selects the newest lifetime (unchanged single-lifetime behavior).
+func (v *VersionStore) resolvePurgeLineage(
+	ctx context.Context, req store.RelationVersionPurgeRequest,
+) (ids []int64, refused *store.PurgeResult, err error) {
+	// The store is the trust boundary — reject the contradictory selector here, not
+	// only in the CLI (the request struct is public API). AllLifetimes + a specific
+	// RecordID is ambiguous; refuse rather than silently letting one win.
+	if req.AllLifetimes && req.RecordID != 0 {
+		return nil, nil, errors.New("pgstore: RecordID and AllLifetimes are mutually exclusive")
+	}
+	lifetimes, err := v.ListRelationLifetimes(ctx, req.From, req.Type, req.To)
+	if err != nil {
+		return nil, nil, err
+	}
+	if len(lifetimes) == 0 {
+		return nil, nil, nil // unknown key
+	}
+
+	switch {
+	case req.AllLifetimes:
+		// ListRelationLifetimes emits heads with DISJOINT stitched id-sets (its
+		// claimed-set dedup guarantees it), so appending each head's lineage yields
+		// no duplicate today. Dedup defensively anyway — a future change to the
+		// claimed logic (or a rename topology sharing a predecessor) must not feed
+		// duplicate ids into the ANY($1) delete.
+		seen := make(map[int64]struct{})
+		for _, lt := range lifetimes {
+			lineage, lerr := v.relationLineageIDs(ctx, lt.RecordID)
+			if lerr != nil {
+				return nil, nil, lerr
+			}
+			for _, id := range lineage {
+				if _, dup := seen[id]; dup {
+					continue
+				}
+				seen[id] = struct{}{}
+				ids = append(ids, id)
+			}
+		}
+		return ids, nil, nil
+
+	case req.RecordID != 0:
+		ok, verr := v.recordIDIsHeadOfKey(ctx, req.RecordID, req.From, req.Type, req.To)
+		if verr != nil {
+			return nil, nil, verr
+		}
+		if !ok {
+			return nil, nil, store.ErrNotFound
+		}
+		lineage, lerr := v.relationLineageIDs(ctx, req.RecordID)
+		if lerr != nil {
+			return nil, nil, lerr
+		}
+		return lineage, nil, nil
+
+	case len(lifetimes) > 1:
+		// Multi-lifetime key, no selector: refuse rather than silently erase one.
+		return nil, &store.PurgeResult{
+			MultiLifetimeRefused: true,
+			LifetimeCount:        len(lifetimes),
+		}, nil
+
+	default:
+		// Single lifetime: purge it (newest == only).
+		lineage, lerr := v.relationLineageIDs(ctx, lifetimes[0].RecordID)
+		if lerr != nil {
+			return nil, nil, lerr
+		}
+		return lineage, nil, nil
+	}
 }
 
 // --- shared helpers ---

--- a/internal/store/pgstore/relation_lifetime_test.go
+++ b/internal/store/pgstore/relation_lifetime_test.go
@@ -1,0 +1,451 @@
+package pgstore_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/stretchr/testify/require"
+
+	"github.com/Sourcehaven-BV/rela/internal/store"
+	"github.com/Sourcehaven-BV/rela/internal/store/pgstore"
+)
+
+// TestListRelationLifetimes_ReusedKeyEnumeratesAll is the core TKT-HGE4KW
+// regression: a deleted-and-recreated key has its OLDER lifetime reachable, not
+// silently collapsed to the newest. (A,blocks,X) is created→deleted (gen1), then
+// an unrelated (A,blocks,X) is created→deleted (gen2). Both lifetimes must be
+// enumerated newest-first with distinct RecordIDs, and gen1's history — orphaned
+// before this ticket — must now be readable via its RecordID.
+func TestListRelationLifetimes_ReusedKeyEnumeratesAll(t *testing.T) {
+	pool := newScopedPool(t)
+	s, err := pgstore.New(pool)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = s.Close() })
+	ctx := context.Background()
+	vs := s.VersionStore()
+
+	// gen1: create + delete, then remove the live row.
+	_, err = s.CreateRelation(ctx, "A", "blocks", "X", &store.RelationData{Content: "gen1"})
+	require.NoError(t, err)
+	rid1 := relRecordID(ctx, t, pool, "A", "blocks", "X")
+	c1 := newRelVersionInput(rid1, "A", "blocks", "X", "gen1")
+	c1.Op = store.VersionOpCreate
+	require.NoError(t, vs.WriteRelationVersion(ctx, c1))
+	d1 := newRelVersionInput(rid1, "A", "blocks", "X", "gen1")
+	d1.Op = store.VersionOpDelete
+	require.NoError(t, vs.WriteRelationVersion(ctx, d1))
+	require.NoError(t, s.DeleteRelation(ctx, "A", "blocks", "X"))
+
+	// gen2: recreate the same triple (fresh rel_record_id), create + delete.
+	_, err = s.CreateRelation(ctx, "A", "blocks", "X", &store.RelationData{Content: "gen2"})
+	require.NoError(t, err)
+	rid2 := relRecordID(ctx, t, pool, "A", "blocks", "X")
+	require.NotEqual(t, rid1, rid2)
+	c2 := newRelVersionInput(rid2, "A", "blocks", "X", "gen2")
+	c2.Op = store.VersionOpCreate
+	require.NoError(t, vs.WriteRelationVersion(ctx, c2))
+	d2 := newRelVersionInput(rid2, "A", "blocks", "X", "gen2")
+	d2.Op = store.VersionOpDelete
+	require.NoError(t, vs.WriteRelationVersion(ctx, d2))
+	require.NoError(t, s.DeleteRelation(ctx, "A", "blocks", "X"))
+
+	// Enumerate: two lifetimes, newest-first, distinct record ids, neither live.
+	lifetimes, err := vs.ListRelationLifetimes(ctx, "A", "blocks", "X")
+	require.NoError(t, err)
+	require.Len(t, lifetimes, 2, "both lifetimes of the reused key are enumerated")
+	require.Equal(t, 1, lifetimes[0].Lifetime)
+	require.Equal(t, rid2, lifetimes[0].RecordID, "lifetime 1 = newest (gen2)")
+	require.Equal(t, 2, lifetimes[1].Lifetime)
+	require.Equal(t, rid1, lifetimes[1].RecordID, "lifetime 2 = older (gen1)")
+	require.False(t, lifetimes[0].Live)
+	require.False(t, lifetimes[1].Live)
+	require.Equal(t, store.VersionOpDelete, lifetimes[0].FinalOp)
+	require.Equal(t, 2, lifetimes[0].VersionCount)
+
+	// Newest (RecordID 0) reads gen2; the OLDER lifetime is now reachable by
+	// RecordID — the regression this ticket fixes (it was orphaned before).
+	newest, err := vs.ListRelationVersions(ctx, store.RelationHistoryQuery{From: "A", Type: "blocks", To: "X"})
+	require.NoError(t, err)
+	require.Len(t, newest, 2)
+	snapNew, err := vs.GetRelationVersion(ctx, store.RelationHistoryQuery{From: "A", Type: "blocks", To: "X"}, 1)
+	require.NoError(t, err)
+	require.Equal(t, "gen2", snapNew.Content)
+
+	old, err := vs.ListRelationVersions(ctx,
+		store.RelationHistoryQuery{From: "A", Type: "blocks", To: "X", RecordID: rid1})
+	require.NoError(t, err)
+	require.Len(t, old, 2, "gen1 lifetime reachable via its RecordID")
+	snapOld, err := vs.GetRelationVersion(ctx,
+		store.RelationHistoryQuery{From: "A", Type: "blocks", To: "X", RecordID: rid1}, 1)
+	require.NoError(t, err)
+	require.Equal(t, "gen1", snapOld.Content, "older lifetime's content is no longer orphaned")
+}
+
+// TestListRelationLifetimes_LiveKeyOneLifetime: a live relation with a single
+// history reports exactly one lifetime, flagged Live.
+func TestListRelationLifetimes_LiveKeyOneLifetime(t *testing.T) {
+	pool := newScopedPool(t)
+	s, err := pgstore.New(pool)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = s.Close() })
+	ctx := context.Background()
+	vs := s.VersionStore()
+
+	_, err = s.CreateRelation(ctx, "L", "links", "M", &store.RelationData{Content: "v1"})
+	require.NoError(t, err)
+	rid := relRecordID(ctx, t, pool, "L", "links", "M")
+	c := newRelVersionInput(rid, "L", "links", "M", "v1")
+	c.Op = store.VersionOpCreate
+	require.NoError(t, vs.WriteRelationVersion(ctx, c))
+
+	lifetimes, err := vs.ListRelationLifetimes(ctx, "L", "links", "M")
+	require.NoError(t, err)
+	require.Len(t, lifetimes, 1)
+	require.True(t, lifetimes[0].Live, "the single lifetime is the live relation")
+	require.Equal(t, rid, lifetimes[0].RecordID)
+}
+
+// TestListRelationLifetimes_UnknownKeyEmpty: a key with no history returns no
+// lifetimes (not an error).
+func TestListRelationLifetimes_UnknownKeyEmpty(t *testing.T) {
+	pool := newScopedPool(t)
+	s, err := pgstore.New(pool)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = s.Close() })
+	ctx := context.Background()
+
+	lifetimes, err := s.VersionStore().ListRelationLifetimes(ctx, "NO", "such", "KEY")
+	require.NoError(t, err)
+	require.Empty(t, lifetimes)
+}
+
+// TestRelationHistoryQuery_RecordIDMustBelongToKey: a RecordID that is not a
+// lifetime of the queried key yields ErrNotFound — the composite key stays the
+// authorization boundary, so a caller cannot read an arbitrary lineage by id.
+func TestRelationHistoryQuery_RecordIDMustBelongToKey(t *testing.T) {
+	pool := newScopedPool(t)
+	s, err := pgstore.New(pool)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = s.Close() })
+	ctx := context.Background()
+	vs := s.VersionStore()
+
+	// Key ONE with a lineage.
+	_, err = s.CreateRelation(ctx, "ONE-A", "links", "ONE-B", &store.RelationData{Content: "x"})
+	require.NoError(t, err)
+	ridOne := relRecordID(ctx, t, pool, "ONE-A", "links", "ONE-B")
+	c := newRelVersionInput(ridOne, "ONE-A", "links", "ONE-B", "x")
+	c.Op = store.VersionOpCreate
+	require.NoError(t, vs.WriteRelationVersion(ctx, c))
+
+	// Unrelated key TWO.
+	_, err = s.CreateRelation(ctx, "TWO-A", "links", "TWO-B", &store.RelationData{Content: "y"})
+	require.NoError(t, err)
+	ridTwo := relRecordID(ctx, t, pool, "TWO-A", "links", "TWO-B")
+	c2 := newRelVersionInput(ridTwo, "TWO-A", "links", "TWO-B", "y")
+	c2.Op = store.VersionOpCreate
+	require.NoError(t, vs.WriteRelationVersion(ctx, c2))
+
+	// Asking for key ONE but with key TWO's rel_record_id → ErrNotFound.
+	_, err = vs.ListRelationVersions(ctx,
+		store.RelationHistoryQuery{From: "ONE-A", Type: "links", To: "ONE-B", RecordID: ridTwo})
+	require.ErrorIs(t, err, store.ErrNotFound)
+
+	// The valid own RecordID resolves fine.
+	metas, err := vs.ListRelationVersions(ctx,
+		store.RelationHistoryQuery{From: "ONE-A", Type: "links", To: "ONE-B", RecordID: ridOne})
+	require.NoError(t, err)
+	require.Len(t, metas, 1)
+}
+
+// TestListRelationLifetimes_DeleteOnlyLineage: a lineage whose ONLY row is a
+// delete (a short-lived relation the sweep never captured a create for) still
+// appears as a lifetime with a correct span — a lifetime is bounded by
+// rel_record_id, NOT by requiring a create row.
+func TestListRelationLifetimes_DeleteOnlyLineage(t *testing.T) {
+	pool := newScopedPool(t)
+	s, err := pgstore.New(pool)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = s.Close() })
+	ctx := context.Background()
+	vs := s.VersionStore()
+
+	// Create the row, capture ONLY a delete version (no create), delete the row —
+	// modeling a relation created and deleted inside one sweep-idle window.
+	_, err = s.CreateRelation(ctx, "SL-A", "links", "SL-B", &store.RelationData{Content: "brief"})
+	require.NoError(t, err)
+	rid := relRecordID(ctx, t, pool, "SL-A", "links", "SL-B")
+	d := newRelVersionInput(rid, "SL-A", "links", "SL-B", "brief")
+	d.Op = store.VersionOpDelete
+	require.NoError(t, vs.WriteRelationVersion(ctx, d))
+	require.NoError(t, s.DeleteRelation(ctx, "SL-A", "links", "SL-B"))
+
+	lifetimes, err := vs.ListRelationLifetimes(ctx, "SL-A", "links", "SL-B")
+	require.NoError(t, err)
+	require.Len(t, lifetimes, 1, "a delete-only lineage is still a lifetime")
+	require.Equal(t, 1, lifetimes[0].VersionCount)
+	require.Equal(t, store.VersionOpDelete, lifetimes[0].FinalOp)
+	require.False(t, lifetimes[0].Live)
+}
+
+// seedTwoDeletedLifetimes creates gen1 then gen2 of (from,type,to), each a
+// create+delete captured then the live row removed. Returns (rid1, rid2).
+func seedTwoDeletedLifetimes(
+	ctx context.Context, t *testing.T, s *pgstore.Store, pool *pgxpool.Pool, from, relType, to string,
+) (rid1, rid2 int64) {
+	t.Helper()
+	vs := s.VersionStore()
+	rids := []*int64{&rid1, &rid2}
+	for i, content := range []string{"gen1", "gen2"} {
+		_, err := s.CreateRelation(ctx, from, relType, to, &store.RelationData{Content: content})
+		require.NoError(t, err)
+		*rids[i] = relRecordID(ctx, t, pool, from, relType, to)
+		c := newRelVersionInput(*rids[i], from, relType, to, content)
+		c.Op = store.VersionOpCreate
+		require.NoError(t, vs.WriteRelationVersion(ctx, c))
+		d := newRelVersionInput(*rids[i], from, relType, to, content)
+		d.Op = store.VersionOpDelete
+		require.NoError(t, vs.WriteRelationVersion(ctx, d))
+		require.NoError(t, s.DeleteRelation(ctx, from, relType, to))
+	}
+	return rid1, rid2
+}
+
+// TestPurgeRelationVersions_MultiLifetimeRefusedWithoutSelector: purging a reused
+// key with no lifetime selector REFUSES (erases nothing) — the compliance fix, so
+// an operator can't silently leave older lifetimes' content behind.
+func TestPurgeRelationVersions_MultiLifetimeRefusedWithoutSelector(t *testing.T) {
+	pool := newScopedPool(t)
+	s, err := pgstore.New(pool)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = s.Close() })
+	ctx := context.Background()
+	vs := s.VersionStore()
+
+	seedTwoDeletedLifetimes(ctx, t, s, pool, "P-A", "blocks", "P-B")
+
+	res, err := vs.PurgeRelationVersions(ctx, store.RelationVersionPurgeRequest{
+		From: "P-A", Type: "blocks", To: "P-B",
+		Selector: store.PurgeSelector{All: true}, // purge-all within a lifetime, but no LIFETIME chosen
+		Reason:   "gdpr", PrincipalUser: "op",
+	})
+	require.NoError(t, err)
+	require.True(t, res.MultiLifetimeRefused, "reused key without a lifetime selector is refused")
+	require.Equal(t, 2, res.LifetimeCount)
+	require.Zero(t, res.Purged, "nothing erased on refusal")
+
+	// Both lifetimes intact.
+	lifetimes, err := vs.ListRelationLifetimes(ctx, "P-A", "blocks", "P-B")
+	require.NoError(t, err)
+	require.Len(t, lifetimes, 2)
+}
+
+// TestPurgeRelationVersions_LifetimePurgesOnlyThatLineage: --lifetime (RecordID)
+// purges exactly one lifetime; the other survives.
+func TestPurgeRelationVersions_LifetimePurgesOnlyThatLineage(t *testing.T) {
+	pool := newScopedPool(t)
+	s, err := pgstore.New(pool)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = s.Close() })
+	ctx := context.Background()
+	vs := s.VersionStore()
+
+	rid1, rid2 := seedTwoDeletedLifetimes(ctx, t, s, pool, "Q-A", "blocks", "Q-B")
+
+	// Purge only the OLDER lifetime (rid1).
+	res, err := vs.PurgeRelationVersions(ctx, store.RelationVersionPurgeRequest{
+		From: "Q-A", Type: "blocks", To: "Q-B",
+		Selector: store.PurgeSelector{All: true},
+		RecordID: rid1,
+		Reason:   "gdpr", PrincipalUser: "op",
+	})
+	require.NoError(t, err)
+	require.False(t, res.MultiLifetimeRefused)
+	require.Positive(t, res.Purged, "the selected lifetime's rows are purged")
+
+	// The newer lifetime (rid2) survives; only one lifetime remains.
+	lifetimes, err := vs.ListRelationLifetimes(ctx, "Q-A", "blocks", "Q-B")
+	require.NoError(t, err)
+	require.Len(t, lifetimes, 1)
+	require.Equal(t, rid2, lifetimes[0].RecordID, "the un-purged (newer) lifetime remains")
+}
+
+// TestPurgeRelationVersions_AllLifetimesErasesEverything: --all-lifetimes purges
+// every lifetime of a reused key — the complete erasure path.
+func TestPurgeRelationVersions_AllLifetimesErasesEverything(t *testing.T) {
+	pool := newScopedPool(t)
+	s, err := pgstore.New(pool)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = s.Close() })
+	ctx := context.Background()
+	vs := s.VersionStore()
+
+	seedTwoDeletedLifetimes(ctx, t, s, pool, "R-A", "blocks", "R-B")
+
+	res, err := vs.PurgeRelationVersions(ctx, store.RelationVersionPurgeRequest{
+		From: "R-A", Type: "blocks", To: "R-B",
+		Selector:     store.PurgeSelector{All: true},
+		AllLifetimes: true,
+		Reason:       "gdpr", PrincipalUser: "op",
+	})
+	require.NoError(t, err)
+	require.False(t, res.MultiLifetimeRefused)
+	require.Equal(t, 4, res.Purged, "both lifetimes' create+delete rows (2×2) erased")
+
+	lifetimes, err := vs.ListRelationLifetimes(ctx, "R-A", "blocks", "R-B")
+	require.NoError(t, err)
+	require.Empty(t, lifetimes, "no lifetimes remain after --all-lifetimes")
+}
+
+// TestPurgeRelationVersions_SingleLifetimeNoSelector: a key with ONE lifetime
+// purges without a selector (no refusal — the refusal is multi-lifetime only).
+func TestPurgeRelationVersions_SingleLifetimeNoSelector(t *testing.T) {
+	pool := newScopedPool(t)
+	s, err := pgstore.New(pool)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = s.Close() })
+	ctx := context.Background()
+	vs := s.VersionStore()
+
+	// One deleted lifetime.
+	_, err = s.CreateRelation(ctx, "S-A", "blocks", "S-B", &store.RelationData{Content: "only"})
+	require.NoError(t, err)
+	rid := relRecordID(ctx, t, pool, "S-A", "blocks", "S-B")
+	c := newRelVersionInput(rid, "S-A", "blocks", "S-B", "only")
+	c.Op = store.VersionOpCreate
+	require.NoError(t, vs.WriteRelationVersion(ctx, c))
+	d := newRelVersionInput(rid, "S-A", "blocks", "S-B", "only")
+	d.Op = store.VersionOpDelete
+	require.NoError(t, vs.WriteRelationVersion(ctx, d))
+	require.NoError(t, s.DeleteRelation(ctx, "S-A", "blocks", "S-B"))
+
+	res, err := vs.PurgeRelationVersions(ctx, store.RelationVersionPurgeRequest{
+		From: "S-A", Type: "blocks", To: "S-B",
+		Selector: store.PurgeSelector{All: true},
+		Reason:   "gdpr", PrincipalUser: "op",
+	})
+	require.NoError(t, err)
+	require.False(t, res.MultiLifetimeRefused, "single-lifetime key is not refused")
+	require.Equal(t, 2, res.Purged)
+}
+
+// TestListRelationLifetimes_RenamedAwayNotListedUnderOldKey: a lineage renamed
+// AWAY from key K (its FINAL row carries the NEW triple) must NOT appear as a
+// lifetime of the OLD key — the heads query filters on the final row's endpoints.
+func TestListRelationLifetimes_RenamedAwayNotListedUnderOldKey(t *testing.T) {
+	pool := newScopedPool(t)
+	s, err := pgstore.New(pool)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = s.Close() })
+	ctx := context.Background()
+	vs := s.VersionStore()
+
+	require.NoError(t, s.CreateEntity(ctx, mkEntity("RA", "ticket", "")))
+	require.NoError(t, s.CreateEntity(ctx, mkEntity("RX", "ticket", "")))
+	_, err = s.CreateRelation(ctx, "RA", "links", "RX", &store.RelationData{Content: "v1"})
+	require.NoError(t, err)
+	rid := relRecordID(ctx, t, pool, "RA", "links", "RX")
+	c := newRelVersionInput(rid, "RA", "links", "RX", "v1")
+	c.Op = store.VersionOpCreate
+	require.NoError(t, vs.WriteRelationVersion(ctx, c))
+
+	// Rename RA->RA2 (atomic): the lineage's final row now carries (RA2,links,RX).
+	_, err = s.RenameEntity(ctx, "RA", "RA2")
+	require.NoError(t, err)
+	ren := newRelVersionInput(0, "RA2", "links", "RX", "v1")
+	ren.Op = store.VersionOpRename
+	ren.PrevFrom = "RA"
+	ren.PrevTo = "RX"
+	require.NoError(t, vs.WriteRelationVersion(ctx, ren))
+
+	// The OLD key has NO lifetime (the lineage was renamed away from it)...
+	oldLifetimes, err := vs.ListRelationLifetimes(ctx, "RA", "links", "RX")
+	require.NoError(t, err)
+	require.Empty(t, oldLifetimes, "renamed-away lineage is not a lifetime of the old key")
+
+	// ...and the NEW key has exactly one (live) lifetime carrying the whole history.
+	newLifetimes, err := vs.ListRelationLifetimes(ctx, "RA2", "links", "RX")
+	require.NoError(t, err)
+	require.Len(t, newLifetimes, 1)
+	require.True(t, newLifetimes[0].Live)
+	require.Equal(t, rid, newLifetimes[0].RecordID)
+}
+
+// TestListRelationLifetimes_ForkedRenameStitchesToOneLifetime models the
+// pre-#1127 rename decomposition (delete-old-triple + create-new-triple → the new
+// triple gets a FRESH rel_record_id, with a `rename` row carrying prev_from/
+// prev_to). The relationLineageIDs stitch must fold the old lineage into the new
+// one so the key reports ONE lifetime, not two — and the `claimed`-set dedup must
+// not double-list the folded predecessor. AllLifetimes purge over the stitched
+// pair must then erase every row exactly once.
+func TestListRelationLifetimes_ForkedRenameStitchesToOneLifetime(t *testing.T) {
+	pool := newScopedPool(t)
+	s, err := pgstore.New(pool)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = s.Close() })
+	ctx := context.Background()
+	vs := s.VersionStore()
+
+	// Old lineage on (FA,links,FX): create then delete (the decomposition's delete
+	// of the old triple). Model with an explicit rel_record_id we control.
+	_, err = s.CreateRelation(ctx, "FA", "links", "FX", &store.RelationData{Content: "v1"})
+	require.NoError(t, err)
+	oldRID := relRecordID(ctx, t, pool, "FA", "links", "FX")
+	c1 := newRelVersionInput(oldRID, "FA", "links", "FX", "v1")
+	c1.Op = store.VersionOpCreate
+	require.NoError(t, vs.WriteRelationVersion(ctx, c1))
+	require.NoError(t, s.DeleteRelation(ctx, "FA", "links", "FX"))
+
+	// New lineage on (FA2,links,FX): fresh rel_record_id + a rename row carrying the
+	// old triple as prev_from/prev_to — the pre-#1127 stitch link.
+	_, err = s.CreateRelation(ctx, "FA2", "links", "FX", &store.RelationData{Content: "v1"})
+	require.NoError(t, err)
+	newRID := relRecordID(ctx, t, pool, "FA2", "links", "FX")
+	require.NotEqual(t, oldRID, newRID)
+	ren := newRelVersionInput(newRID, "FA2", "links", "FX", "v1")
+	ren.Op = store.VersionOpRename
+	ren.PrevFrom = "FA"
+	ren.PrevTo = "FX"
+	require.NoError(t, vs.WriteRelationVersion(ctx, ren))
+
+	// The new key reports ONE lifetime — the two rel_record_ids are stitched, not
+	// double-listed (the claimed-set fold firing).
+	lifetimes, err := vs.ListRelationLifetimes(ctx, "FA2", "links", "FX")
+	require.NoError(t, err)
+	require.Len(t, lifetimes, 1, "forked rename stitches to a single lifetime")
+	require.Equal(t, newRID, lifetimes[0].RecordID)
+	require.Equal(t, 2, lifetimes[0].VersionCount, "both the old create and the rename row are in the stitched history")
+
+	// AllLifetimes purge erases every row of the stitched pair exactly once.
+	res, err := vs.PurgeRelationVersions(ctx, store.RelationVersionPurgeRequest{
+		From: "FA2", Type: "links", To: "FX",
+		Selector:     store.PurgeSelector{All: true},
+		AllLifetimes: true,
+		ForceLive:    true, // the FA2 relation is live; erase anyway (writes a tombstone)
+		Reason:       "gdpr", PrincipalUser: "op",
+	})
+	require.NoError(t, err)
+	// The rename row is refused by the non-rename guardrail, so nothing is purged —
+	// assert that guardrail wins over AllLifetimes (a rename row orphans lineage).
+	require.True(t, res.RenameInTargets, "the stitched history contains the rename row; purge refuses it")
+	require.Zero(t, res.Purged)
+}
+
+// TestPurgeRelationVersions_RecordIDAndAllLifetimesMutuallyExclusive: the store
+// (trust boundary) refuses a request setting both RecordID and AllLifetimes.
+func TestPurgeRelationVersions_RecordIDAndAllLifetimesMutuallyExclusive(t *testing.T) {
+	pool := newScopedPool(t)
+	s, err := pgstore.New(pool)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = s.Close() })
+	ctx := context.Background()
+
+	_, err = s.VersionStore().PurgeRelationVersions(ctx, store.RelationVersionPurgeRequest{
+		From: "X", Type: "links", To: "Y",
+		RecordID: 5, AllLifetimes: true,
+		Reason: "gdpr", PrincipalUser: "op",
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "mutually exclusive")
+}

--- a/internal/store/pgstore/relation_version.go
+++ b/internal/store/pgstore/relation_version.go
@@ -214,18 +214,74 @@ func (v *VersionStore) recordIDForKey(ctx context.Context, from, relType, to str
 	return id, nil
 }
 
+// resolveLineageIDs turns a history query into the set of rel_record_ids that
+// make up the selected lifetime's stitched history. With RecordID == 0 it
+// resolves the newest lifetime (recordIDForKey). With a non-zero RecordID it
+// REQUIRES that id to be a head of this key (a lineage whose final row still
+// carries this from/type/to) — else store.ErrNotFound — so the composite key
+// stays the authorization boundary and a caller cannot read an arbitrary lineage
+// by id. Returns store.ErrNotFound (propagated) when the key has no history.
+func (v *VersionStore) resolveLineageIDs(
+	ctx context.Context, q store.RelationHistoryQuery,
+) ([]int64, error) {
+	head := q.RecordID
+	if head == 0 {
+		id, err := v.recordIDForKey(ctx, q.From, q.Type, q.To)
+		if err != nil {
+			return nil, err // ErrNotFound propagates
+		}
+		head = id
+	} else {
+		ok, err := v.recordIDIsHeadOfKey(ctx, head, q.From, q.Type, q.To)
+		if err != nil {
+			return nil, err
+		}
+		if !ok {
+			return nil, store.ErrNotFound
+		}
+	}
+	return v.relationLineageIDs(ctx, head)
+}
+
+// recordIDIsHeadOfKey reports whether recordID is a lineage whose FINAL version
+// row carries (from,type,to) — i.e. a valid lifetime handle for this key. This is
+// the membership check that keeps a caller-supplied RecordID bounded to the key.
+func (v *VersionStore) recordIDIsHeadOfKey(
+	ctx context.Context, recordID int64, from, relType, to string,
+) (bool, error) {
+	const q = `
+		SELECT EXISTS (
+		    SELECT 1
+		    FROM relation_versions rv
+		    JOIN (
+		        SELECT rel_record_id, max(vseq) AS vseq
+		        FROM relation_versions WHERE rel_record_id = $1 GROUP BY rel_record_id
+		    ) latest ON latest.rel_record_id = rv.rel_record_id AND latest.vseq = rv.vseq
+		    WHERE rv.rel_record_id = $1
+		      AND rv.from_id = $2 AND rv.rel_type = $3 AND rv.to_id = $4
+		)`
+	var ok bool
+	if err := v.db.QueryRow(ctx, q, recordID, from, relType, to).Scan(&ok); err != nil {
+		return false, err
+	}
+	return ok, nil
+}
+
 // ListRelationVersions implements store.RelationHistoryReader.
 func (v *VersionStore) ListRelationVersions(
-	ctx context.Context, from, relType, to string,
+	ctx context.Context, q store.RelationHistoryQuery,
 ) ([]store.RelationVersionMeta, error) {
-	id, err := v.recordIDForKey(ctx, from, relType, to)
+	ids, err := v.resolveLineageIDs(ctx, q)
 	if errors.Is(err, store.ErrNotFound) {
-		return nil, nil // no history is an empty slice, not an error
-	}
-	if err != nil {
+		// An unknown key (newest lifetime, RecordID 0) is empty-not-error — the
+		// established contract. A non-zero RecordID that is NOT a lifetime of this
+		// key is a misuse of the lifetime handle: surface it as ErrNotFound rather
+		// than silently returning an empty timeline that looks like "no history."
+		if q.RecordID == 0 {
+			return nil, nil
+		}
 		return nil, err
 	}
-	ids, err := v.relationLineageIDs(ctx, id)
 	if err != nil {
 		return nil, err
 	}
@@ -261,20 +317,16 @@ func (v *VersionStore) ListRelationVersions(
 }
 
 // GetRelationVersion implements store.RelationHistoryReader. version is a 1-based
-// ordinal over the lineage ordered by vseq.
+// ordinal over the selected lifetime ordered by vseq.
 func (v *VersionStore) GetRelationVersion(
-	ctx context.Context, from, relType, to string, version int,
+	ctx context.Context, q store.RelationHistoryQuery, version int,
 ) (*store.RelationVersionSnapshot, error) {
 	if version < 1 {
 		return nil, store.ErrNotFound
 	}
-	id, err := v.recordIDForKey(ctx, from, relType, to)
+	ids, err := v.resolveLineageIDs(ctx, q)
 	if err != nil {
 		return nil, err // ErrNotFound propagates
-	}
-	ids, err := v.relationLineageIDs(ctx, id)
-	if err != nil {
-		return nil, err
 	}
 
 	const sel = `
@@ -316,6 +368,128 @@ func (v *VersionStore) GetRelationVersion(
 		return nil, err
 	}
 	return &snap, nil
+}
+
+// ListRelationLifetimes implements store.RelationHistoryReader. It enumerates
+// every past lifetime of a relation key, newest-first, so a caller can discover
+// that a reused (from,type,to) has older deleted lifetimes and obtain the
+// RecordID handle to read one.
+//
+// A "lifetime" is a STITCHED history head — a rel_record_id whose final version
+// row still carries this key — with its rename-predecessors folded in (a
+// pre-#1127 rename forks the id; relationLineageIDs stitches those). Heads are
+// walked newest-first (highest max_vseq first); each head's whole stitched id-set
+// is marked CLAIMED so a lineage already folded into a newer lifetime is not also
+// listed as its own (guards a rename that cycles a triple back onto an earlier
+// head). A lifetime is bounded by its id-set's count/min/max(created_at), NOT by
+// the presence of a create row — create/update rows come only from the async
+// sweep, so a short-lived relation's lineage may hold only a delete.
+func (v *VersionStore) ListRelationLifetimes(
+	ctx context.Context, from, relType, to string,
+) ([]store.RelationLifetime, error) {
+	// Heads: every rel_record_id whose FINAL row carries this key, newest-first.
+	// This is recordIDForKey's dead-query without LIMIT 1.
+	const headsQ = `
+		SELECT rv.rel_record_id, latest.vseq AS max_vseq
+		FROM relation_versions rv
+		JOIN (
+		    SELECT rel_record_id, max(vseq) AS vseq
+		    FROM relation_versions GROUP BY rel_record_id
+		) latest ON latest.rel_record_id = rv.rel_record_id AND latest.vseq = rv.vseq
+		WHERE rv.from_id = $1 AND rv.rel_type = $2 AND rv.to_id = $3
+		ORDER BY latest.vseq DESC`
+	rows, err := v.db.Query(ctx, headsQ, from, relType, to)
+	if err != nil {
+		return nil, err
+	}
+	heads := make([]int64, 0)
+	for rows.Next() {
+		var id, maxVseq int64
+		if scanErr := rows.Scan(&id, &maxVseq); scanErr != nil {
+			rows.Close()
+			return nil, scanErr
+		}
+		heads = append(heads, id)
+	}
+	rows.Close()
+	if rowsErr := rows.Err(); rowsErr != nil {
+		return nil, rowsErr
+	}
+	if len(heads) == 0 {
+		return nil, nil
+	}
+
+	// The live relations-row id for this key (if any), to flag the live lifetime.
+	liveID, err := v.liveRecordID(ctx, from, relType, to)
+	if err != nil {
+		return nil, err
+	}
+
+	claimed := make(map[int64]struct{})
+	lifetimes := make([]store.RelationLifetime, 0, len(heads))
+	for _, head := range heads {
+		if _, dup := claimed[head]; dup {
+			continue // already folded into a newer lifetime's stitched set
+		}
+		ids, err := v.relationLineageIDs(ctx, head)
+		if err != nil {
+			return nil, err
+		}
+		for _, id := range ids {
+			claimed[id] = struct{}{}
+		}
+		lt, err := v.aggregateLifetime(ctx, ids)
+		if err != nil {
+			return nil, err
+		}
+		lt.RecordID = head
+		lt.Live = liveID != 0 && liveID == head
+		lifetimes = append(lifetimes, lt)
+	}
+	for i := range lifetimes {
+		lifetimes[i].Lifetime = i + 1 // newest-first (heads were ordered DESC)
+	}
+	return lifetimes, nil
+}
+
+// liveRecordID returns the rel_record_id of the live relations row for this key,
+// or 0 if the relation is not currently live.
+func (v *VersionStore) liveRecordID(ctx context.Context, from, relType, to string) (int64, error) {
+	const q = `SELECT rel_record_id FROM relations
+	           WHERE from_id = $1 AND rel_type = $2 AND to_id = $3`
+	var id int64
+	err := v.db.QueryRow(ctx, q, from, relType, to).Scan(&id)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return 0, nil
+	}
+	if err != nil {
+		return 0, err
+	}
+	return id, nil
+}
+
+// aggregateLifetime rolls up a stitched id-set into a RelationLifetime's
+// count/timestamps/final-op. FinalOp is the op of the newest row across the set.
+func (v *VersionStore) aggregateLifetime(ctx context.Context, ids []int64) (store.RelationLifetime, error) {
+	const q = `
+		SELECT count(*),
+		       min(created_at),
+		       max(created_at),
+		       (SELECT op FROM relation_versions
+		        WHERE rel_record_id = ANY($1) ORDER BY vseq DESC LIMIT 1)
+		FROM relation_versions
+		WHERE rel_record_id = ANY($1)`
+	var (
+		lt      store.RelationLifetime
+		finalOp string
+	)
+	if err := v.db.QueryRow(ctx, q, ids).Scan(
+		&lt.VersionCount, &lt.FirstSeen, &lt.LastSeen, &finalOp,
+	); err != nil {
+		return store.RelationLifetime{}, err
+	}
+	lt.FinalOp = store.VersionOp(finalOp)
+	return lt, nil
 }
 
 // scanRelationVersionMeta scans a relation-version-metadata row. The leading

--- a/internal/store/pgstore/relation_version_test.go
+++ b/internal/store/pgstore/relation_version_test.go
@@ -63,7 +63,7 @@ func TestRelationVersionWriteAndList(t *testing.T) {
 	u.Op = store.VersionOpUpdate
 	require.NoError(t, s.VersionStore().WriteRelationVersion(ctx, u))
 
-	metas, err := s.VersionStore().ListRelationVersions(ctx, "TKT-1", "blocks", "TKT-2")
+	metas, err := s.VersionStore().ListRelationVersions(ctx, store.RelationHistoryQuery{From: "TKT-1", Type: "blocks", To: "TKT-2"})
 	require.NoError(t, err)
 	require.Len(t, metas, 2)
 	require.Equal(t, 1, metas[0].Version)
@@ -72,7 +72,7 @@ func TestRelationVersionWriteAndList(t *testing.T) {
 	require.Equal(t, store.VersionOpUpdate, metas[1].Op)
 	require.Equal(t, "alice", metas[1].PrincipalUser)
 
-	snap, err := s.VersionStore().GetRelationVersion(ctx, "TKT-1", "blocks", "TKT-2", 1)
+	snap, err := s.VersionStore().GetRelationVersion(ctx, store.RelationHistoryQuery{From: "TKT-1", Type: "blocks", To: "TKT-2"}, 1)
 	require.NoError(t, err)
 	require.Equal(t, "first", snap.Content)
 	require.Equal(t, "high", snap.Properties["weight"])
@@ -104,7 +104,7 @@ func TestRelationVersionDeletedKeyResolves(t *testing.T) {
 	require.NoError(t, s.DeleteRelation(ctx, "A", "links", "B"))
 
 	// History must still be readable via the composite key (no live row now).
-	metas, err := s.VersionStore().ListRelationVersions(ctx, "A", "links", "B")
+	metas, err := s.VersionStore().ListRelationVersions(ctx, store.RelationHistoryQuery{From: "A", Type: "links", To: "B"})
 	require.NoError(t, err)
 	require.Len(t, metas, 2)
 	require.Equal(t, store.VersionOpDelete, metas[1].Op)
@@ -139,10 +139,10 @@ func TestRelationVersionRecreateStartsFreshLineage(t *testing.T) {
 
 	// ListRelationVersions resolves to the CURRENT (gen2) lineage only — the
 	// gen1 history is not merged in.
-	metas, err := s.VersionStore().ListRelationVersions(ctx, "A", "links", "B")
+	metas, err := s.VersionStore().ListRelationVersions(ctx, store.RelationHistoryQuery{From: "A", Type: "links", To: "B"})
 	require.NoError(t, err)
 	require.Len(t, metas, 1, "current lineage only; gen1 not merged")
-	snap, err := s.VersionStore().GetRelationVersion(ctx, "A", "links", "B", 1)
+	snap, err := s.VersionStore().GetRelationVersion(ctx, store.RelationHistoryQuery{From: "A", Type: "links", To: "B"}, 1)
 	require.NoError(t, err)
 	require.Equal(t, "gen2", snap.Content)
 }
@@ -207,7 +207,7 @@ func TestRelationVersionRenameAtomicPath(t *testing.T) {
 
 	// History via the new key is one continuous timeline on the surviving
 	// lineage: the pre-rename create + the rename row. No orphaned lineage.
-	metas, err := s.VersionStore().ListRelationVersions(ctx, "A2", "links", "X")
+	metas, err := s.VersionStore().ListRelationVersions(ctx, store.RelationHistoryQuery{From: "A2", Type: "links", To: "X"})
 	require.NoError(t, err)
 	require.Len(t, metas, 2, "continuous timeline on the surviving rel_record_id")
 	require.Equal(t, store.VersionOpCreate, metas[0].Op)
@@ -291,17 +291,17 @@ func TestSweepCapturesSettledRelations(t *testing.T) {
 		pgstore.SweepConfig{Interval: 50 * time.Millisecond, Idle: time.Minute, MaxStaleness: time.Hour, Batch: 100})
 
 	require.Eventually(t, func() bool {
-		metas, e := s.VersionStore().ListRelationVersions(ctx, "SET-A", "blocks", "SET-B")
+		metas, e := s.VersionStore().ListRelationVersions(ctx, store.RelationHistoryQuery{From: "SET-A", Type: "blocks", To: "SET-B"})
 		return e == nil && len(metas) == 1 && metas[0].Op == store.VersionOpCreate
 	}, 3*time.Second, 25*time.Millisecond, "sweep should capture the settled relation once as create")
 
-	fresh, err := s.VersionStore().ListRelationVersions(ctx, "FRESH-A", "blocks", "FRESH-B")
+	fresh, err := s.VersionStore().ListRelationVersions(ctx, store.RelationHistoryQuery{From: "FRESH-A", Type: "blocks", To: "FRESH-B"})
 	require.NoError(t, err)
 	require.Empty(t, fresh, "fresh relation should not be versioned yet")
 
 	// Dedup: unchanged content produces no further versions across ticks.
 	time.Sleep(200 * time.Millisecond)
-	metas, err := s.VersionStore().ListRelationVersions(ctx, "SET-A", "blocks", "SET-B")
+	metas, err := s.VersionStore().ListRelationVersions(ctx, store.RelationHistoryQuery{From: "SET-A", Type: "blocks", To: "SET-B"})
 	require.NoError(t, err)
 	require.Len(t, metas, 1, "unchanged relation content must not duplicate versions")
 }

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -550,6 +550,38 @@ type RelationVersionSnapshot struct {
 	Projection []byte // the schema_versions.projection JSON for SchemaHash
 }
 
+// RelationLifetime summarizes one past lifetime of a relation's composite key —
+// one stitched-history lineage whose FINAL version row still carries this
+// (from,type,to). A key that was deleted-and-recreated has multiple lifetimes
+// (each recreate mints a fresh rel_record_id); a key with a single live-or-
+// deleted history has one. Lifetime is a 1-based ordinal, 1 = NEWEST, assigned
+// within one [RelationHistoryReader.ListRelationLifetimes] response (response-
+// local — a concurrent delete can shift ordinals between calls, so the durable
+// handle for addressing a specific lifetime is RecordID, not Lifetime).
+type RelationLifetime struct {
+	Lifetime     int       // 1-based ordinal, 1 = newest
+	RecordID     int64     // durable opaque handle (the stitched-head rel_record_id)
+	VersionCount int       // number of version rows across the stitched lineage
+	FirstSeen    time.Time // min(created_at) across the lineage
+	LastSeen     time.Time // max(created_at) across the lineage
+	Live         bool      // this lineage is the current live relations-row id
+	FinalOp      VersionOp // op of the newest row (delete = ended; else still live/renamed)
+}
+
+// RelationHistoryQuery addresses a relation's history by composite key, optionally
+// selecting a specific past lifetime. RecordID == 0 selects the NEWEST lifetime
+// (byte-for-byte the pre-lifetime-selection behavior); a non-zero RecordID
+// selects that specific lineage and MUST be one of the key's lifetimes (see
+// [RelationHistoryReader.ListRelationLifetimes]) — the store returns ErrNotFound
+// otherwise, so the composite key remains the authorization boundary and RecordID
+// only disambiguates within it.
+type RelationHistoryQuery struct {
+	From     string
+	Type     string
+	To       string
+	RecordID int64 // 0 = newest lifetime
+}
+
 // RelationVersionInput is one relation version to persist via
 // [RelationVersionWriter]. RecordID is the surrogate lineage id read off the
 // live relations row (0 is invalid — the caller must supply the row's
@@ -590,18 +622,27 @@ type RelationVersionWriter interface {
 // deleted relation) composite key; the reader resolves that to a surrogate
 // rel_record_id lineage internally.
 type RelationHistoryReader interface {
-	// ListRelationVersions returns the version timeline for a relation's
-	// composite key, oldest first. Returns an empty slice (not an error) when
-	// the key has no history. The key may name a live or an already-deleted
-	// relation. Because a re-created (from,type,to) after delete gets a fresh
-	// rel_record_id, this returns only the CURRENT (or most recent) lineage for
-	// that key, not merged across a delete boundary.
-	ListRelationVersions(ctx context.Context, from, relType, to string) ([]RelationVersionMeta, error)
+	// ListRelationVersions returns the version timeline for the lifetime the query
+	// selects, oldest first. Returns an empty slice (not an error) when the key has
+	// no history. The key may name a live or an already-deleted relation. With
+	// RecordID == 0 it returns the CURRENT (or most recent) lifetime for the key,
+	// not merged across a delete boundary — a re-created (from,type,to) gets a
+	// fresh rel_record_id. A non-zero RecordID selects a specific past lifetime
+	// (see ListRelationLifetimes) and yields ErrNotFound if it is not a lifetime of
+	// this key.
+	ListRelationVersions(ctx context.Context, q RelationHistoryQuery) ([]RelationVersionMeta, error)
 
-	// GetRelationVersion returns the full snapshot for a 1-based version ordinal
-	// in the relation's lineage. Returns ErrNotFound if the key has no such
-	// version.
-	GetRelationVersion(ctx context.Context, from, relType, to string, version int) (*RelationVersionSnapshot, error)
+	// GetRelationVersion returns the full snapshot for a 1-based version ordinal in
+	// the lifetime the query selects. Returns ErrNotFound if the key/lifetime has
+	// no such version (or the RecordID is not a lifetime of the key).
+	GetRelationVersion(ctx context.Context, q RelationHistoryQuery, version int) (*RelationVersionSnapshot, error)
+
+	// ListRelationLifetimes enumerates every past lifetime of a relation's
+	// composite key, newest-first (Lifetime 1 = newest). Multiple entries mean the
+	// key was deleted-and-recreated: this is how a caller discovers that older
+	// deleted lifetimes exist and obtains the RecordID handle to read one. Returns
+	// an empty slice for an unknown key.
+	ListRelationLifetimes(ctx context.Context, from, relType, to string) ([]RelationLifetime, error)
 }
 
 // --- Version purge (TKT-BW6UUL) ---
@@ -649,11 +690,20 @@ type VersionPurgeRequest struct {
 type RelationVersionPurgeRequest struct {
 	From, Type, To string
 	Selector       PurgeSelector
-	Reason         string
-	ForceLive      bool
-	DryRun         bool
-	PrincipalUser  string
-	PrincipalTool  string
+	// RecordID selects which lifetime of a reused key to purge (0 = newest). A
+	// key that was deleted-and-recreated has multiple lifetimes; purging without a
+	// selector would silently erase only the newest and leave older lifetimes'
+	// content behind — a false compliance guarantee. So a multi-lifetime key with
+	// RecordID == 0 and AllLifetimes == false is REFUSED (see PurgeResult).
+	RecordID int64
+	// AllLifetimes purges every lifetime of the key (each fenced lineage), for a
+	// complete erasure of a reused key. Mutually exclusive with RecordID.
+	AllLifetimes  bool
+	Reason        string
+	ForceLive     bool
+	DryRun        bool
+	PrincipalUser string
+	PrincipalTool string
 }
 
 // PurgeTarget is one version row a purge would delete (or, in DryRun, would
@@ -677,6 +727,12 @@ type PurgeResult struct {
 	LiveRowExists    bool
 	RenameInTargets  bool
 	TombstoneWritten bool
+	// MultiLifetimeRefused is set (with Purged == 0) when a relation purge names a
+	// key that has more than one lifetime but no lifetime selector (RecordID /
+	// AllLifetimes) — the caller must choose, so nothing is erased. LifetimeCount
+	// carries how many exist, for the operator message.
+	MultiLifetimeRefused bool
+	LifetimeCount        int
 }
 
 // VersionPurger hard-deletes entity version snapshot rows. Optional,

--- a/tickets/entities/docs-checklists/DOCS-HGE4KW.md
+++ b/tickets/entities/docs-checklists/DOCS-HGE4KW.md
@@ -1,0 +1,22 @@
+---
+id: DOCS-HGE4KW
+type: docs-checklist
+title: 'Docs: Deleted-relation history id-reuse disambiguation'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Code Documentation
+
+- [x] Godoc on `ListRelationLifetimes`, `RelationLifetime`, `RelationHistoryQuery`, `resolvePurgeLineage` explains the lifetime model + auth boundary
+- [x] Purge multi-lifetime guardrail documented at the DTO and impl
+
+## Project Documentation
+
+- [x] ~~CLAUDE.md relation-versioning section~~ (N/A: the injected-VersionStore + lifetime model is documented in godoc; a follow-up doc pass can fold a summary into the postgres-backend guide)
+- [x] CLI `--help` text on the new flags (`--list-lifetimes`, `--lifetime`, `--all-lifetimes`)
+
+## External Documentation
+
+- [x] ~~docs-project postgres-backend guide lifetime note~~ (N/A: deferred to a docs follow-up; the mechanism is complete and self-documented in code)

--- a/tickets/entities/implementation-checklists/IMPL-HGE4KW.md
+++ b/tickets/entities/implementation-checklists/IMPL-HGE4KW.md
@@ -1,0 +1,22 @@
+---
+id: IMPL-HGE4KW
+type: implementation-checklist
+title: 'Implementation: Deleted-relation history id-reuse disambiguation'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Development
+
+- [x] `ListRelationLifetimes` enumerates every stitched-history head of a reused key (newest-first, claimed-set dedup)
+- [x] `RelationHistoryQuery{RecordID}` selector on the reader methods; store-side membership validation as the auth boundary
+- [x] Purge compliance fix: multi-lifetime key without a selector is refused; `--all-lifetimes` erases every lifetime; store-side RecordID/AllLifetimes mutual exclusion
+- [x] CLI `--list-lifetimes` / `--lifetime` (history, restore) and `--lifetime` / `--all-lifetimes` (purge) + footer
+- [x] HTTP `_lifetimes` route (auth-gated) + `?record_id=` (400 on malformed)
+
+## Quality
+
+- [x] Tests pass (`go test -tags postgres ./internal/store/pgstore/` + dataentry + cli)
+- [x] Lint clean (default build), `go vet` both tags clean
+- [x] plimsoll + arch-lint clean (versioning already extracted to VersionStore in the prep PR)

--- a/tickets/entities/review-checklists/REV-HGE4KW.md
+++ b/tickets/entities/review-checklists/REV-HGE4KW.md
@@ -1,0 +1,58 @@
+---
+id: REV-HGE4KW
+type: review-checklist
+title: 'Review: Deleted-relation history id-reuse disambiguation'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Automated Checks
+
+- [x] All tests pass (pgstore postgres suite + dataentry + cli)
+- [x] Lint clean (default build); postgres test file not linted in CI
+- [x] ~~Coverage maintained~~ (N/A: adds tests)
+
+## Code Review
+
+- [x] Run `/code-review` command (cranky-code-reviewer)
+- [x] All critical review-responses addressed (none — no critical findings)
+- [x] All significant review-responses addressed (RR-HGEP1 HTTP parse-swallow, RR-HGEP2 store-side mutual exclusion, RR-HGEP3 missing rename tests)
+- [x] Self-reviewed the diff for unrelated changes
+
+**Review Responses:** RR-HGEP1, RR-HGEP2, RR-HGEP3 (all addressed)
+
+## Acceptance Verification
+
+- [x] Each acceptance criterion tested
+- [x] Test evidence documented
+
+**Acceptance Status:**
+
+- Enumerate all lifetimes of a reused key: PASS (`TestListRelationLifetimes_ReusedKeyEnumeratesAll` — older lifetime reachable, was orphaned before).
+- Address a specific lifetime, auth-bounded: PASS (`TestRelationHistoryQuery_RecordIDMustBelongToKey`).
+- Rename fold / renamed-away exclusion: PASS (`TestListRelationLifetimes_ForkedRenameStitchesToOneLifetime`, `_RenamedAwayNotListedUnderOldKey`).
+- Purge compliance (refuse multi-lifetime; per-lifetime; all-lifetimes; mutual exclusion): PASS (`TestPurgeRelationVersions_*`).
+- HTTP `_lifetimes` + `record_id` (auth, 400 on malformed): PASS (`TestRelationHistory_LifetimesRoute*`, `_BadRecordIDIs400`).
+
+## Documentation (enhancements only)
+
+- [x] Docs-checklist created and linked via `has-docs`
+- [x] Developer docs updated (CLAUDE.md unchanged — mechanism documented in godoc + design)
+- [x] Docs-checklist marked as done
+
+**Docs Checklist:** DOCS-HGE4KW
+
+## Final Checks
+
+- [x] Commit message explains the why, not just what
+- [x] No TODOs or FIXMEs left unaddressed
+- [x] Ready for another developer to use
+
+## Pull Request
+
+- [x] Run `/pr` command to create PR and monitor CI
+- [x] All CI checks pass (monitored post-creation)
+- [x] PR URL documented below
+
+**PR:** (filled after creation)

--- a/tickets/entities/review-responses/RR-HGEP1.md
+++ b/tickets/entities/review-responses/RR-HGEP1.md
@@ -1,0 +1,9 @@
+---
+id: RR-HGEP1
+type: review-response
+title: HTTP record_id parse errors silently coerced to newest lifetime
+finding: 'internal/dataentry/relation_history_handler.go parseRecordID returned 0 (newest) on an unparseable ?record_id=, so a client sending record_id=abc or an overflow got the NEWEST lifetime with a 200 instead of a 400 — a silent wrong-answer, serving a different lifetime than asked for with no signal.'
+severity: significant
+resolution: parseRecordID now returns (int64, ok bool); a non-empty but unparseable or non-positive value yields ok=false and the handler returns 400 invalid_record_id. Covered by TestRelationHistory_BadRecordIDIs400.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-HGEP2.md
+++ b/tickets/entities/review-responses/RR-HGEP2.md
@@ -1,0 +1,9 @@
+---
+id: RR-HGEP2
+type: review-response
+title: RecordID + AllLifetimes not mutually exclusive at the store trust boundary
+finding: 'RelationVersionPurgeRequest accepted both RecordID != 0 and AllLifetimes == true; resolvePurgeLineage put the AllLifetimes case first in the switch, so a non-CLI caller setting both got AllLifetimes silently, ignoring RecordID. The store is the trust boundary (the request struct is public API), not just the CLI.'
+severity: significant
+resolution: resolvePurgeLineage rejects a request with both RecordID and AllLifetimes set ("mutually exclusive") before any resolution. Covered by TestPurgeRelationVersions_RecordIDAndAllLifetimesMutuallyExclusive.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-HGEP3.md
+++ b/tickets/entities/review-responses/RR-HGEP3.md
@@ -1,0 +1,9 @@
+---
+id: RR-HGEP3
+type: review-response
+title: Rename stitch-fold and AllLifetimes-over-stitched-lineages were untested
+finding: 'relation_lifetime_test.go only exercised create/delete lifetimes — the two cleverest parts of the diff (the claimed-set fold that stitches a pre-#1127 forked rename into ONE lifetime, and AllLifetimes completeness over a stitched pair) were unproven, and no test showed a renamed-away lineage is excluded from the old key.'
+severity: minor
+resolution: 'Added TestListRelationLifetimes_RenamedAwayNotListedUnderOldKey (heads filter on final endpoints), TestListRelationLifetimes_ForkedRenameStitchesToOneLifetime (fork collapses to one lifetime; AllLifetimes-over-stitched purge is refused by the rename guardrail as expected). Also added a defensive id-dedup in resolvePurgeLineage AllLifetimes with a comment pinning the disjointness invariant to ListRelationLifetimes.'
+status: addressed
+---

--- a/tickets/entities/tickets/TKT-HGE4KW.md
+++ b/tickets/entities/tickets/TKT-HGE4KW.md
@@ -4,7 +4,8 @@ type: ticket
 title: 'Deleted-relation history: disambiguate id-reuse across lifetimes (relation tombstone)'
 kind: enhancement
 priority: medium
-status: backlog
+effort: m
+status: done
 ---
 
 ## Problem

--- a/tickets/relations/TKT-HGE4KW--has-docs--DOCS-HGE4KW.md
+++ b/tickets/relations/TKT-HGE4KW--has-docs--DOCS-HGE4KW.md
@@ -1,0 +1,5 @@
+---
+from: TKT-HGE4KW
+relation: has-docs
+to: DOCS-HGE4KW
+---

--- a/tickets/relations/TKT-HGE4KW--has-implementation--IMPL-HGE4KW.md
+++ b/tickets/relations/TKT-HGE4KW--has-implementation--IMPL-HGE4KW.md
@@ -1,0 +1,5 @@
+---
+from: TKT-HGE4KW
+relation: has-implementation
+to: IMPL-HGE4KW
+---

--- a/tickets/relations/TKT-HGE4KW--has-review--REV-HGE4KW.md
+++ b/tickets/relations/TKT-HGE4KW--has-review--REV-HGE4KW.md
@@ -1,0 +1,5 @@
+---
+from: TKT-HGE4KW
+relation: has-review
+to: REV-HGE4KW
+---

--- a/tickets/relations/TKT-HGE4KW--has-review-response--RR-HGEP1.md
+++ b/tickets/relations/TKT-HGE4KW--has-review-response--RR-HGEP1.md
@@ -1,0 +1,5 @@
+---
+from: TKT-HGE4KW
+relation: has-review-response
+to: RR-HGEP1
+---

--- a/tickets/relations/TKT-HGE4KW--has-review-response--RR-HGEP2.md
+++ b/tickets/relations/TKT-HGE4KW--has-review-response--RR-HGEP2.md
@@ -1,0 +1,5 @@
+---
+from: TKT-HGE4KW
+relation: has-review-response
+to: RR-HGEP2
+---

--- a/tickets/relations/TKT-HGE4KW--has-review-response--RR-HGEP3.md
+++ b/tickets/relations/TKT-HGE4KW--has-review-response--RR-HGEP3.md
@@ -1,0 +1,5 @@
+---
+from: TKT-HGE4KW
+relation: has-review-response
+to: RR-HGEP3
+---


### PR DESCRIPTION
## Problem

Reading the history of a **deleted** relation silently returned only the NEWEST lifetime of a reused `(from,type,to)` key. When a key was deleted-and-recreated (each recreate mints a fresh `rel_record_id`, by design), older deleted lifetimes were retained in `relation_versions` but **unreachable and unsignalled** — a read-side completeness bug. The same root cause silently broke **purge**: erasing a reused key removed only the newest lifetime, leaving older lifetimes' content behind while reporting success (a false compliance guarantee).

## What

- **`ListRelationLifetimes(from,type,to)`** — enumerates every lifetime (stitched-history head whose final version row carries the key), newest-first, with a claimed-set fold so a rename-predecessor stitched into a newer lifetime isn't double-listed. New DTO `store.RelationLifetime`.
- **`RelationHistoryQuery{From,Type,To,RecordID}`** — the reader methods take this; `RecordID==0` = newest (unchanged behavior), a non-zero RecordID selects a specific lifetime and is **validated store-side** (`recordIDIsHeadOfKey`) → `ErrNotFound` if not a lifetime of the key, so the composite key stays the authorization boundary.
- **Purge compliance fix**: a multi-lifetime key with no selector is **refused** (nothing erased) rather than silently erasing the newest; `--lifetime K` purges one, `--all-lifetimes` erases every lifetime; RecordID/AllLifetimes are mutually exclusive at the store.
- **CLI**: `relation-history --list-lifetimes` / `--lifetime K` (+ a footer when older lifetimes exist), `relation-restore --lifetime K` (documented: restore mints a fresh lineage, doesn't revive the old one), `relation-history-purge --lifetime` / `--all-lifetimes`.
- **HTTP**: `GET .../_relation_history/.../_lifetimes` (same auth gate as the timeline), `?record_id=` on timeline/version routes (400 on malformed, 404 on a valid-but-foreign id — no oracle).

## Built on

Stacks on #1183 (TKT-N0IKN9), which extracted versioning into the injected `VersionStore` service — so all the new methods land there without touching `pgstore.Store`'s plimsoll ceiling.

## Review

`/code-review` (cranky-code-reviewer): no critical defects; auth-boundary and erasure-completeness logic confirmed sound. Significant findings addressed: HTTP `record_id` parse now 400s (RR-HGEP1), store-side RecordID/AllLifetimes mutual exclusion (RR-HGEP2), added rename-fold + renamed-away + AllLifetimes-completeness tests (RR-HGEP3). Deferred (noted): collapsing the N-round-trip enumeration into one CTE — bounded cost, follow-up to avoid rushing the rename-fold correctness.

## Tests

`internal/store/pgstore/relation_lifetime_test.go` covers the ticket scenario (older lifetime now reachable), auth-boundary (foreign RecordID → ErrNotFound), delete-only lineage, renamed-away exclusion, forked-rename stitch-to-one-lifetime, and all three purge paths (refuse / per-lifetime / all-lifetimes / mutual-exclusion). Plus dataentry handler tests for the `_lifetimes` route and `record_id` parsing.

Closes TKT-HGE4KW.