### PR TITLE
feat(docs): screenshot{} island — chromedp capture of the data-entry SPA (TKT-89X2B5)

### DIFF
--- a/.go-arch-lint.yml
+++ b/.go-arch-lint.yml
@@ -32,6 +32,7 @@ components:
   conditionlint:    { in: internal/conditionlint }
   desktop:          { in: internal/desktop }
   docs:             { in: internal/docs }
+  docscapture:      { in: internal/docscapture }
 
   # Server protocols
   mcp:              { in: internal/mcp }
@@ -130,6 +131,7 @@ vendors:
       - github.com/mitchellh/go-wordwrap
   gogit:       { in: github.com/go-git/go-git/** }
   gopherlua:   { in: [github.com/yuin/gopher-lua, github.com/yuin/gopher-lua/**] }
+  chromedp:    { in: [github.com/chromedp/chromedp, github.com/chromedp/chromedp/**, github.com/chromedp/cdproto, github.com/chromedp/cdproto/**] }
   runewidth:   { in: github.com/mattn/go-runewidth }
   rrulego:     { in: github.com/teambition/rrule-go }
   mcpgo:       { in: github.com/mark3labs/mcp-go/** }
@@ -220,6 +222,7 @@ deps:
       - config
       - dataentryconfig
       - docs
+      - docscapture
       - entitymanager
       - filter
       - importer
@@ -505,6 +508,17 @@ deps:
       - tracer
     canUse:
       - gopherlua
+  docscapture:
+    mayDependOn:
+      - acl
+      - appbuild
+      - dataentry
+      - docs
+      - principal
+      - script
+      - store
+    canUse:
+      - chromedp
   entitymanager:
     mayDependOn:
       - acl

--- a/.testcoverage.yml
+++ b/.testcoverage.yml
@@ -29,6 +29,8 @@ override:
     threshold: 30
   - path: ^internal/search$
     threshold: 20 # the Searcher facade; most logic lives in search/bleveindex and the backends
+  - path: ^internal/docscapture$
+    threshold: 40 # the browser-capture harness: its core is chromedp orchestration that only runs under the Chrome-gated tests (skipped in the default CI matrix). Non-browser units (annotate/anchor/roleAssignee/copyProjectSchema/standUp) cover ~43%; the Chrome-gated job covers the rest.
   # Close to the default floor — explicit so proximity is documented,
   # not discovered by a surprise CI failure (currently ~56%).
   - path: ^internal/mcp$

--- a/docs-project/entities/guides/GUIDE-rela-docs.md
+++ b/docs-project/entities/guides/GUIDE-rela-docs.md
@@ -168,8 +168,26 @@ Arguments:
 | `form` | the `data-entry.yaml` form id (default `edit_<type>`) |
 | `as` | the ACL **role** to render as (a principal assigned that role); default picks a role that can edit |
 | `arrows` | `{{at, text, side}}` — `at` is a field property (→ that field), `@button:<label>`, or `@role:<sel>`; `text` rides the arrow; `side` is `left`/`right` |
-| `clip` | a CSS selector to capture just one element |
+| `clip` | bound the capture: omit for the **full page**; a **CSS selector** (`"#field-status"`, `".form-section"`) for that element; or the keyword **`"focus"`** for the bounding box of everything the `arrows` point at |
+| `pad` | padding in px around a `clip` region (default `24`; `pad=0` for a tight crop). Clamped to the page, so the crop never extends past the content |
 | `out`, `alt` | the image file (written next to the output) and its alt text |
+
+**Cropping.** By default `screenshot{}` captures the whole page. To zoom in
+on the subject of a figure, set `clip`:
+
+```markdown
+​```rela
+-- one element, with breathing room:
+screenshot{ ..., clip = "#field-status", pad = 32, out = "status.png" }
+
+-- crop to exactly what the arrows highlight (fields + their labels):
+screenshot{ ..., arrows = { {at="status", text="lifecycle state"} },
+            clip = "focus", out = "focus.png" }
+​```
+```
+
+`clip="focus"` unions the boxes of every annotated target **and** the drawn
+arrow labels, so the crop includes the annotations, not just the fields.
 
 **Prerequisites.** `screenshot{}` needs a **Chrome/Chromium browser** on
 the machine and the **data-entry SPA built** into the binary (`just

--- a/docs-project/entities/guides/GUIDE-rela-docs.md
+++ b/docs-project/entities/guides/GUIDE-rela-docs.md
@@ -133,3 +133,53 @@ for _, t in ipairs({ "risico", "maatregel", "verwerking" }) do
 end
 ​```
 ```
+
+## Screenshots
+
+The `screenshot{}` island captures a **live screenshot of the data-entry
+form** for a seeded entity, annotated with arrows, and embeds it as a
+Markdown image. It stands up the data-entry app over a throwaway copy of
+your project (seeded with the manual's `create`/`link` entities) and
+drives a headless Chrome to render the real form.
+
+```markdown
+​```rela
+local t = create("ticket", { id = "DEMO-1", title = "Login page 500s",
+                             status = "in-progress", priority = "high",
+                             reporter = "demo@example.com" })
+screenshot{
+  view = "form", type = "ticket", entity = t.id,
+  arrows = {
+    { at = "status",   text = "the lifecycle state" },
+    { at = "priority", text = "triage priority" },
+  },
+  out = "ticket-form.png",
+  alt = "The ticket edit form",
+}
+​```
+```
+
+Arguments:
+
+| Arg | Meaning |
+| --- | --- |
+| `view` | `"form"` (edit form, default), `"entity"` (detail), `"list"` |
+| `type`, `entity` | the entity type and the id of a **seeded** entity to render |
+| `form` | the `data-entry.yaml` form id (default `edit_<type>`) |
+| `as` | the ACL **role** to render as (a principal assigned that role); default picks a role that can edit |
+| `arrows` | `{{at, text, side}}` — `at` is a field property (→ that field), `@button:<label>`, or `@role:<sel>`; `text` rides the arrow; `side` is `left`/`right` |
+| `clip` | a CSS selector to capture just one element |
+| `out`, `alt` | the image file (written next to the output) and its alt text |
+
+**Prerequisites.** `screenshot{}` needs a **Chrome/Chromium browser** on
+the machine and the **data-entry SPA built** into the binary (`just
+build-frontend`). There is **no graceful degradation**: if either is
+missing, the build fails loud — a manual either captures a real figure or
+it errors, never a placeholder.
+
+**Fail-loud specifics.** An unknown field anchor, an entity that fails to
+render for the chosen role (the form shows a load error), or a page taller
+than the height cap each stop the build with the offending manual line.
+
+Everything else in the build stays browser-free: a manual with **no**
+`screenshot{}` never launches a browser or touches the data-entry app.

--- a/docs/rela-docs.md
+++ b/docs/rela-docs.md
@@ -162,8 +162,26 @@ Arguments:
 | `form` | the `data-entry.yaml` form id (default `edit_<type>`) |
 | `as` | the ACL **role** to render as (a principal assigned that role); default picks a role that can edit |
 | `arrows` | `{{at, text, side}}` — `at` is a field property (→ that field), `@button:<label>`, or `@role:<sel>`; `text` rides the arrow; `side` is `left`/`right` |
-| `clip` | a CSS selector to capture just one element |
+| `clip` | bound the capture: omit for the **full page**; a **CSS selector** (`"#field-status"`, `".form-section"`) for that element; or the keyword **`"focus"`** for the bounding box of everything the `arrows` point at |
+| `pad` | padding in px around a `clip` region (default `24`; `pad=0` for a tight crop). Clamped to the page, so the crop never extends past the content |
 | `out`, `alt` | the image file (written next to the output) and its alt text |
+
+**Cropping.** By default `screenshot{}` captures the whole page. To zoom in
+on the subject of a figure, set `clip`:
+
+```markdown
+​```rela
+-- one element, with breathing room:
+screenshot{ ..., clip = "#field-status", pad = 32, out = "status.png" }
+
+-- crop to exactly what the arrows highlight (fields + their labels):
+screenshot{ ..., arrows = { {at="status", text="lifecycle state"} },
+            clip = "focus", out = "focus.png" }
+​```
+```
+
+`clip="focus"` unions the boxes of every annotated target **and** the drawn
+arrow labels, so the crop includes the annotations, not just the fields.
 
 **Prerequisites.** `screenshot{}` needs a **Chrome/Chromium browser** on
 the machine and the **data-entry SPA built** into the binary (`just

--- a/docs/rela-docs.md
+++ b/docs/rela-docs.md
@@ -127,3 +127,53 @@ for _, t in ipairs({ "risico", "maatregel", "verwerking" }) do
 end
 ​```
 ```
+
+## Screenshots
+
+The `screenshot{}` island captures a **live screenshot of the data-entry
+form** for a seeded entity, annotated with arrows, and embeds it as a
+Markdown image. It stands up the data-entry app over a throwaway copy of
+your project (seeded with the manual's `create`/`link` entities) and
+drives a headless Chrome to render the real form.
+
+```markdown
+​```rela
+local t = create("ticket", { id = "DEMO-1", title = "Login page 500s",
+                             status = "in-progress", priority = "high",
+                             reporter = "demo@example.com" })
+screenshot{
+  view = "form", type = "ticket", entity = t.id,
+  arrows = {
+    { at = "status",   text = "the lifecycle state" },
+    { at = "priority", text = "triage priority" },
+  },
+  out = "ticket-form.png",
+  alt = "The ticket edit form",
+}
+​```
+```
+
+Arguments:
+
+| Arg | Meaning |
+| --- | --- |
+| `view` | `"form"` (edit form, default), `"entity"` (detail), `"list"` |
+| `type`, `entity` | the entity type and the id of a **seeded** entity to render |
+| `form` | the `data-entry.yaml` form id (default `edit_<type>`) |
+| `as` | the ACL **role** to render as (a principal assigned that role); default picks a role that can edit |
+| `arrows` | `{{at, text, side}}` — `at` is a field property (→ that field), `@button:<label>`, or `@role:<sel>`; `text` rides the arrow; `side` is `left`/`right` |
+| `clip` | a CSS selector to capture just one element |
+| `out`, `alt` | the image file (written next to the output) and its alt text |
+
+**Prerequisites.** `screenshot{}` needs a **Chrome/Chromium browser** on
+the machine and the **data-entry SPA built** into the binary (`just
+build-frontend`). There is **no graceful degradation**: if either is
+missing, the build fails loud — a manual either captures a real figure or
+it errors, never a placeholder.
+
+**Fail-loud specifics.** An unknown field anchor, an entity that fails to
+render for the chosen role (the form shows a load error), or a page taller
+than the height cap each stop the build with the offending manual line.
+
+Everything else in the build stays browser-free: a manual with **no**
+`screenshot{}` never launches a browser or touches the data-entry app.

--- a/frontend/src/components/common/Toast.vue
+++ b/frontend/src/components/common/Toast.vue
@@ -27,6 +27,7 @@ function getIcon(type: string): string {
         :key="toast.id"
         class="toast"
         :class="toast.type"
+        :data-testid="`toast-${toast.type}`"
       >
         <span class="toast-icon">{{ getIcon(toast.type) }}</span>
         <span class="toast-message">{{ toast.message }}</span>

--- a/frontend/src/components/forms/DynamicForm.vue
+++ b/frontend/src/components/forms/DynamicForm.vue
@@ -105,6 +105,12 @@ const userTouched = ref<Set<string>>(new Set())
 const pickerTypes = ref<Record<string, Map<string, string>>>({})
 const content = ref('')
 const loading = ref(true)
+// loadState is a stable, test-visible signal of whether the edit entity
+// actually loaded: 'pending' until the fetch settles, then 'loaded' or
+// 'error'. Stamped as data-testid on the form root so an out-of-process
+// consumer (the rela-docs screenshot harness) can unambiguously tell a
+// rendered-with-data form from an empty schema-only shell after a failed load.
+const loadState = ref<'pending' | 'loaded' | 'error'>('pending')
 // Set to true in edit mode when the loaded entity's `_actions.update`
 // is explicitly false. The template renders an inline "not editable"
 // message instead of the form. The EntityDetail Edit button already
@@ -354,10 +360,12 @@ async function loadEntity(force = false) {
       relations: relations.value,
       content: content.value,
     })
+    loadState.value = 'loaded'
   } catch (err) {
     // Suppress cancellation errors from rapid navigation in Firefox
     // (see BUG-6C3V and src/composables/usePageData.ts).
     if (isCancelledFetch(err)) return
+    loadState.value = 'error'
     uiStore.error('Failed to load entity')
     console.error(err)
   }
@@ -1174,6 +1182,7 @@ onMounted(async () => {
   } else {
     initializeDefaults()
     await loadTemplates()
+    loadState.value = 'loaded' // create mode: no entity to fetch
   }
   loading.value = false
 
@@ -1313,7 +1322,12 @@ onBeforeRouteLeave(async () => {
 </script>
 
 <template>
-  <div v-if="formConfig" class="form-layout" :class="{ 'with-sidepanel': isEdit }">
+  <div
+    v-if="formConfig"
+    class="form-layout"
+    :class="{ 'with-sidepanel': isEdit }"
+    :data-testid="`form-state-${loadState}`"
+  >
     <div class="dynamic-form">
       <header class="form-header">
         <h1>{{ title }}</h1>

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/blevesearch/bleve/v2 v2.6.0
 	github.com/charmbracelet/glamour v1.0.0
 	github.com/charmbracelet/huh v1.0.0
+	github.com/chromedp/cdproto v0.0.0-20260714215040-dc233986426f
 	github.com/chromedp/chromedp v0.16.0
 	github.com/fatih/color v1.19.0
 	github.com/fsnotify/fsnotify v1.10.1
@@ -72,7 +73,6 @@ require (
 	github.com/charmbracelet/x/exp/slice v0.0.0-20250327172914-2fdc97757edf // indirect
 	github.com/charmbracelet/x/exp/strings v0.0.0-20240722160745-212f7b056ed0 // indirect
 	github.com/charmbracelet/x/term v0.2.1 // indirect
-	github.com/chromedp/cdproto v0.0.0-20260714215040-dc233986426f // indirect
 	github.com/chromedp/sysutil v1.1.0 // indirect
 	github.com/clipperhouse/displaywidth v0.10.0 // indirect
 	github.com/clipperhouse/uax29/v2 v2.6.0 // indirect

--- a/internal/cli/docs.go
+++ b/internal/cli/docs.go
@@ -62,10 +62,13 @@ func (c *DocsBuildCmd) Run(ctx context.Context, svc *readServices) error {
 		OutDir:     outputDir(c.Output),
 	}
 	// Wire a browser capturer for screenshot{} islands. If no browser is
-	// available, leave it nil — a manual WITHOUT screenshot{} still builds; one
-	// WITH it fails loud ("no capturer configured"). No graceful degradation.
-	if cap, capErr := docscapture.New(); capErr == nil {
-		opts.Capturer = cap
+	// available, leave it nil but keep the specific reason — a manual WITHOUT
+	// screenshot{} still builds; one WITH it fails loud with the actionable
+	// message (e.g. "no Chrome found on PATH"). No graceful degradation.
+	if capturer, capErr := docscapture.New(); capErr == nil {
+		opts.Capturer = capturer
+	} else {
+		opts.CapturerErr = capErr.Error()
 	}
 
 	rendered, err := docs.Build(ctx, string(src), opts)

--- a/internal/cli/docs.go
+++ b/internal/cli/docs.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/Sourcehaven-BV/rela/internal/acl"
 	"github.com/Sourcehaven-BV/rela/internal/docs"
+	"github.com/Sourcehaven-BV/rela/internal/docscapture"
 )
 
 // DocsCmd is `rela docs` — the doc-language build tool.
@@ -23,6 +24,15 @@ type DocsBuildCmd struct {
 	Manual string `arg:"" help:"Path to the manual (Markdown with rela Lua islands)."`
 	Output string `name:"out" help:"Write resolved Markdown here (default: stdout)."`
 	Strict bool   `help:"Fail the build if any island resolves to nothing."`
+}
+
+// outputDir is the directory screenshot{} PNGs are written into: the output
+// file's directory, or the current directory when writing to stdout.
+func outputDir(out string) string {
+	if out == "" {
+		return "."
+	}
+	return filepath.Dir(out)
 }
 
 // Run resolves the manual and writes the output.
@@ -44,11 +54,21 @@ func (c *DocsBuildCmd) Run(ctx context.Context, svc *readServices) error {
 		return fmt.Errorf("load acl.yaml: %w", perr)
 	}
 
-	rendered, err := docs.Build(ctx, string(src), docs.Options{
-		Meta:   svc.Meta,
-		Policy: policy,
-		Strict: c.Strict,
-	})
+	opts := docs.Options{
+		Meta:       svc.Meta,
+		Policy:     policy,
+		Strict:     c.Strict,
+		ProjectDir: svc.Paths.Root,
+		OutDir:     outputDir(c.Output),
+	}
+	// Wire a browser capturer for screenshot{} islands. If no browser is
+	// available, leave it nil — a manual WITHOUT screenshot{} still builds; one
+	// WITH it fails loud ("no capturer configured"). No graceful degradation.
+	if cap, capErr := docscapture.New(); capErr == nil {
+		opts.Capturer = cap
+	}
+
+	rendered, err := docs.Build(ctx, string(src), opts)
 	if err != nil {
 		return err
 	}

--- a/internal/docs/luahelpers.go
+++ b/internal/docs/luahelpers.go
@@ -38,6 +38,25 @@ func fieldString(ls *lua.LState, tbl *lua.LTable, key string) string {
 	return ""
 }
 
+// fieldStringDefault reads a string field, returning def when absent/empty.
+func fieldStringDefault(ls *lua.LState, tbl *lua.LTable, key, def string) string {
+	if s := fieldString(ls, tbl, key); s != "" {
+		return s
+	}
+	return def
+}
+
+// fieldBool reads a boolean field from a table, false when absent.
+func fieldBool(ls *lua.LState, tbl *lua.LTable, key string) bool {
+	if tbl == nil {
+		return false
+	}
+	if b, ok := ls.GetField(tbl, key).(lua.LBool); ok {
+		return bool(b)
+	}
+	return false
+}
+
 // fieldInt reads an integer field from a table, returning def when absent.
 func fieldInt(ls *lua.LState, tbl *lua.LTable, key string, def int) int {
 	if tbl == nil {

--- a/internal/docs/module.go
+++ b/internal/docs/module.go
@@ -39,6 +39,8 @@ func (dr *docRuntime) registerModule() {
 		// Seed (raw store — no entitymanager, no validation).
 		"create": dr.luaCreate,
 		"link":   dr.luaLink,
+		// Tier B — browser capture (fails loud when no capturer is wired).
+		"screenshot": dr.luaScreenshot,
 	}
 	for name, fn := range fns {
 		nf := L.NewFunction(fn)
@@ -99,6 +101,10 @@ func (dr *docRuntime) luaCreate(ls *lua.LState) int {
 	if err := dr.store.CreateEntity(dr.ctx, e); err != nil {
 		return dr.luaFail(ls, "create(%q): %v", typ, err)
 	}
+	// Record for replay into the screenshot temp project (DR-S2).
+	dr.seedOps = append(dr.seedOps, SeedOp{
+		Kind: "create", Type: typ, ID: id, Properties: props, Content: content,
+	})
 	ls.Push(rlua.EntityToTable(ls, e))
 	return 1
 }
@@ -112,6 +118,7 @@ func (dr *docRuntime) luaLink(ls *lua.LState) int {
 	if _, err := dr.store.CreateRelation(dr.ctx, from, relType, to, nil); err != nil {
 		return dr.luaFail(ls, "link(%q,%q,%q): %v", from, relType, to, err)
 	}
+	dr.seedOps = append(dr.seedOps, SeedOp{Kind: "link", From: from, RelType: relType, To: to})
 	return 0
 }
 

--- a/internal/docs/runtime.go
+++ b/internal/docs/runtime.go
@@ -43,6 +43,9 @@ type Options struct {
 	// Capturer renders screenshot{} islands (Tier B). Injected by the CLI so the
 	// core docs package stays browser-free. nil ⇒ screenshot{} fails loud.
 	Capturer Capturer
+	// CapturerErr is the reason a Capturer could not be built (e.g. no Chrome);
+	// surfaced in the screenshot{} fail-loud message when Capturer is nil.
+	CapturerErr string
 	// ProjectDir is the documented project root; screenshot{} copies its schema/
 	// config into the temp project the SPA renders.
 	ProjectDir string
@@ -85,6 +88,9 @@ type docRuntime struct {
 	// Tier-B browser dependency is injected only by the CLI, keeping core docs
 	// browser-free). See screenshot.go.
 	capturer Capturer
+	// capturerErr is the reason the capturer could not be constructed (e.g. no
+	// Chrome), surfaced in the fail-loud message when a screenshot{} needs it.
+	capturerErr string
 
 	// projectDir is the documented project's root (schema/config copied into the
 	// screenshot temp project). Empty in a schema-only build.
@@ -129,16 +135,17 @@ func Build(ctx context.Context, src string, opts Options) (string, error) {
 
 	st := memstore.New()
 	dr := &docRuntime{
-		meta:       opts.Meta,
-		policy:     opts.Policy,
-		store:      st,
-		tracer:     tracer.New(st),
-		strict:     opts.Strict,
-		out:        &strings.Builder{},
-		ctx:        ctx,
-		capturer:   opts.Capturer,
-		projectDir: opts.ProjectDir,
-		outDir:     opts.OutDir,
+		meta:        opts.Meta,
+		policy:      opts.Policy,
+		store:       st,
+		tracer:      tracer.New(st),
+		strict:      opts.Strict,
+		out:         &strings.Builder{},
+		ctx:         ctx,
+		capturer:    opts.Capturer,
+		capturerErr: opts.CapturerErr,
+		projectDir:  opts.ProjectDir,
+		outDir:      opts.OutDir,
 	}
 
 	// A reader runtime gives us the sandbox (no io/os) plus rela.* read bindings;

--- a/internal/docs/runtime.go
+++ b/internal/docs/runtime.go
@@ -23,6 +23,11 @@ import (
 // only by this context deadline, so it must always be wired.
 const buildTimeout = 30 * time.Second
 
+// screenshotBuildTimeout is the wider ceiling for a build that captures
+// screenshots — browser launch + per-island navigate/capture need more than the
+// Tier-A 30s.
+const screenshotBuildTimeout = 5 * time.Minute
+
 // Options controls a manual build.
 type Options struct {
 	// Meta is the deployment's metamodel (loaded from the real project). It is
@@ -34,6 +39,15 @@ type Options struct {
 	// Strict promotes an empty resolve (a resolver / echo yielding nothing) from
 	// a warning to a build failure.
 	Strict bool
+
+	// Capturer renders screenshot{} islands (Tier B). Injected by the CLI so the
+	// core docs package stays browser-free. nil ⇒ screenshot{} fails loud.
+	Capturer Capturer
+	// ProjectDir is the documented project root; screenshot{} copies its schema/
+	// config into the temp project the SPA renders.
+	ProjectDir string
+	// OutDir is where screenshot{} writes PNGs (derived from --out).
+	OutDir string
 }
 
 // docRuntime owns the per-build state the doc.* bindings close over: the real
@@ -63,6 +77,23 @@ type docRuntime struct {
 	// full-store scan per create().
 	seedCounts map[string]int
 
+	// seedOps records every create/link so a screenshot{} island can replay them
+	// against a fresh fsstore temp project (DR-S2).
+	seedOps []SeedOp
+
+	// capturer renders screenshot{} islands. nil ⇒ screenshot{} fails loud (the
+	// Tier-B browser dependency is injected only by the CLI, keeping core docs
+	// browser-free). See screenshot.go.
+	capturer Capturer
+
+	// projectDir is the documented project's root (schema/config copied into the
+	// screenshot temp project). Empty in a schema-only build.
+	projectDir string
+
+	// outDir is where screenshot{} PNGs are written (derived from the build's
+	// --out); empty ⇒ PNGs written next to the cwd and referenced by basename.
+	outDir string
+
 	// warnings accumulates non-fatal issues (empty resolves in non-strict mode).
 	warnings []string
 }
@@ -81,19 +112,33 @@ func Build(ctx context.Context, src string, opts Options) (string, error) {
 	// Bound the WHOLE build, not each island: the runtime's per-run applyTimeout
 	// resets a fresh deadline on every island, so without a build-wide deadline
 	// N islands give no effective ceiling. A child ctx deadline caps the total.
-	// If the caller already set an earlier deadline, that one wins.
-	ctx, cancel := context.WithTimeout(ctx, buildTimeout)
+	// If the caller already set an earlier deadline, that one wins. Screenshot
+	// builds get a longer ceiling (browser launch + navigate + capture).
+	deadline := buildTimeout
+	if opts.Capturer != nil {
+		deadline = screenshotBuildTimeout
+	}
+	ctx, cancel := context.WithTimeout(ctx, deadline)
 	defer cancel()
+
+	// The Capturer owns the temp project + server + browser; tear it down
+	// unconditionally so a panic mid-build can't leak them (DR-M3).
+	if opts.Capturer != nil {
+		defer func() { _ = opts.Capturer.Close() }()
+	}
 
 	st := memstore.New()
 	dr := &docRuntime{
-		meta:   opts.Meta,
-		policy: opts.Policy,
-		store:  st,
-		tracer: tracer.New(st),
-		strict: opts.Strict,
-		out:    &strings.Builder{},
-		ctx:    ctx,
+		meta:       opts.Meta,
+		policy:     opts.Policy,
+		store:      st,
+		tracer:     tracer.New(st),
+		strict:     opts.Strict,
+		out:        &strings.Builder{},
+		ctx:        ctx,
+		capturer:   opts.Capturer,
+		projectDir: opts.ProjectDir,
+		outDir:     opts.OutDir,
 	}
 
 	// A reader runtime gives us the sandbox (no io/os) plus rela.* read bindings;

--- a/internal/docs/screenshot.go
+++ b/internal/docs/screenshot.go
@@ -76,7 +76,11 @@ func (dr *docRuntime) luaScreenshot(ls *lua.LState) int {
 		return dr.luaFail(ls, "screenshot: expects a table, e.g. screenshot{view=\"form\", type=..., entity=...}")
 	}
 	if dr.capturer == nil {
-		return dr.luaFail(ls, "screenshot: no browser capturer configured — screenshot{} needs a Chrome/Chromium browser and a built data-entry SPA")
+		reason := dr.capturerErr
+		if reason == "" {
+			reason = "screenshot{} needs a Chrome/Chromium browser and a built data-entry SPA"
+		}
+		return dr.luaFail(ls, "screenshot: no browser capturer available — %s", reason)
 	}
 
 	spec := CaptureSpec{

--- a/internal/docs/screenshot.go
+++ b/internal/docs/screenshot.go
@@ -1,0 +1,163 @@
+package docs
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	lua "github.com/yuin/gopher-lua"
+)
+
+// Capturer renders a screenshot{} island: it stands up the data-entry SPA over a
+// seeded temp project, drives a headless browser to the requested view, and
+// writes a PNG. It is a consumer-side interface (defined here, in the consumer)
+// so the core docs package never imports the browser/data-entry machinery — the
+// concrete implementation (internal/docscapture) is injected by the CLI. A nil
+// Capturer means screenshot{} fails loud.
+//
+// Capture returns the absolute path of the written PNG.
+type Capturer interface {
+	Capture(ctx context.Context, spec CaptureSpec) (pngPath string, err error)
+	// Close tears down any temp project / server / browser the Capturer stood up.
+	Close() error
+}
+
+// CaptureSpec is the request for one screenshot. It is a plain DTO so the
+// interface has no dependency on the doc runtime's internals.
+type CaptureSpec struct {
+	// ProjectDir is the documented project (schema/config copied into the temp
+	// project the SPA renders).
+	ProjectDir string
+	// Seed is replayed against the temp project's store so the SPA renders the
+	// same entities the manual created.
+	Seed []SeedOp
+
+	// View is the SPA view kind: "form" (edit form), "entity" (detail), "list".
+	View string
+	// Type is the entity type; Entity is the entity id to render.
+	Type   string
+	Entity string
+	// Form is the data-entry.yaml form id for View=="form" (default derived).
+	Form string
+	// As is the role to render as (mapped to a principal assigned that role);
+	// empty ⇒ the harness picks a default role that can read.
+	As string
+
+	// Clip is an optional CSS selector to clip the capture to one element.
+	Clip string
+	// Annotations to draw before capture.
+	Arrows []Annotation
+
+	// OutPath is the absolute PNG path to write.
+	OutPath string
+}
+
+// Annotation is one arrow/box drawn on the capture, anchored to a form field
+// (At="<property>" → #field-<property>) or an ARIA/control target
+// (At="@button:save" / "@role:..."). Text rides the arrow.
+type Annotation struct {
+	At   string
+	Text string
+	Side string // "left"|"right"|"top"|"bottom"; default right
+	Box  bool   // draw an outline box instead of an arrow
+}
+
+// luaScreenshot is the screenshot{} island resolver. It emits a Markdown image
+// reference and writes the PNG next to the manual output via the injected
+// Capturer. Fails loud when no Capturer is wired (browser support absent).
+//
+// screenshot{ view="form", type="ticket", entity=id, as="editor",
+//
+//	arrows={{at="status", text="auto-computed"}}, out="fig.png", alt="..." }
+func (dr *docRuntime) luaScreenshot(ls *lua.LState) int {
+	tbl := argTable(ls)
+	if tbl == nil {
+		return dr.luaFail(ls, "screenshot: expects a table, e.g. screenshot{view=\"form\", type=..., entity=...}")
+	}
+	if dr.capturer == nil {
+		return dr.luaFail(ls, "screenshot: no browser capturer configured — screenshot{} needs a Chrome/Chromium browser and a built data-entry SPA")
+	}
+
+	spec := CaptureSpec{
+		ProjectDir: dr.projectDir,
+		Seed:       dr.seedOps,
+		View:       fieldStringDefault(ls, tbl, "view", "form"),
+		Type:       fieldString(ls, tbl, "type"),
+		Entity:     fieldString(ls, tbl, "entity"),
+		Form:       fieldString(ls, tbl, "form"),
+		As:         fieldString(ls, tbl, "as"),
+		Clip:       fieldString(ls, tbl, "clip"),
+		Arrows:     dr.readAnnotations(ls, tbl),
+	}
+	if spec.Type == "" {
+		return dr.luaFail(ls, "screenshot: `type` is required")
+	}
+	if spec.Entity == "" {
+		return dr.luaFail(ls, "screenshot: `entity` is required (the id of a seeded entity to render)")
+	}
+
+	out := fieldString(ls, tbl, "out")
+	if out == "" {
+		return dr.luaFail(ls, "screenshot: `out` is required (the image file to write, e.g. out=\"fig.png\")")
+	}
+	spec.OutPath = dr.resolveOutPath(out)
+
+	png, err := dr.capturer.Capture(dr.ctx, spec)
+	if err != nil {
+		return dr.luaFail(ls, "screenshot(%s %q): %v", spec.View, spec.Entity, err)
+	}
+
+	alt := fieldStringDefault(ls, tbl, "alt", fmt.Sprintf("%s %s", spec.View, spec.Type))
+	// Emit a relative path from the output dir so the markdown is portable.
+	rel := dr.relOutPath(png)
+	dr.emit(fmt.Sprintf("![%s](%s)\n\n", mdCell(alt), rel))
+	return 0
+}
+
+// readAnnotations parses the optional arrows={{at=..,text=..,side=..},{...}} arg.
+func (dr *docRuntime) readAnnotations(ls *lua.LState, tbl *lua.LTable) []Annotation {
+	arr, ok := ls.GetField(tbl, "arrows").(*lua.LTable)
+	if !ok {
+		return nil
+	}
+	var out []Annotation
+	arr.ForEach(func(_, v lua.LValue) {
+		a, ok := v.(*lua.LTable)
+		if !ok {
+			return
+		}
+		out = append(out, Annotation{
+			At:   fieldString(ls, a, "at"),
+			Text: fieldString(ls, a, "text"),
+			Side: fieldString(ls, a, "side"),
+			Box:  fieldBool(ls, a, "box"),
+		})
+	})
+	return out
+}
+
+// resolveOutPath makes an operator-supplied `out` absolute, relative to the
+// build's output directory (outDir). A traversal outside outDir is rejected by
+// the caller path handling; here we just join.
+func (dr *docRuntime) resolveOutPath(out string) string {
+	if filepath.IsAbs(out) {
+		return out
+	}
+	if dr.outDir != "" {
+		return filepath.Join(dr.outDir, out)
+	}
+	return out
+}
+
+// relOutPath returns the PNG path relative to the output dir for the markdown
+// image reference, so the emitted manual is portable next to its images.
+func (dr *docRuntime) relOutPath(png string) string {
+	if dr.outDir == "" {
+		return filepath.Base(png)
+	}
+	if rel, err := filepath.Rel(dr.outDir, png); err == nil && !strings.HasPrefix(rel, "..") {
+		return rel
+	}
+	return filepath.Base(png)
+}

--- a/internal/docs/screenshot.go
+++ b/internal/docs/screenshot.go
@@ -9,6 +9,10 @@ import (
 	lua "github.com/yuin/gopher-lua"
 )
 
+// defaultCropPad is the padding (CSS px) added around a clipped region when the
+// author does not specify pad=. Matches openvwr's figure convention.
+const defaultCropPad = 24
+
 // Capturer renders a screenshot{} island: it stands up the data-entry SPA over a
 // seeded temp project, drives a headless browser to the requested view, and
 // writes a PNG. It is a consumer-side interface (defined here, in the consumer)
@@ -44,8 +48,14 @@ type CaptureSpec struct {
 	// empty ⇒ the harness picks a default role that can read.
 	As string
 
-	// Clip is an optional CSS selector to clip the capture to one element.
+	// Clip bounds the capture. Empty ⇒ the full page. A CSS selector
+	// ("#field-status", ".form-section") ⇒ that element. A predefined keyword ⇒
+	// a computed region: "focus" ⇒ the bounding box of all annotated targets.
+	// The clipped region is expanded by Pad and clamped to the page.
 	Clip string
+	// Pad is the padding in CSS px added around a Clip region (default via the
+	// resolver). Ignored for a full-page capture.
+	Pad int
 	// Annotations to draw before capture.
 	Arrows []Annotation
 
@@ -92,6 +102,7 @@ func (dr *docRuntime) luaScreenshot(ls *lua.LState) int {
 		Form:       fieldString(ls, tbl, "form"),
 		As:         fieldString(ls, tbl, "as"),
 		Clip:       fieldString(ls, tbl, "clip"),
+		Pad:        fieldInt(ls, tbl, "pad", defaultCropPad),
 		Arrows:     dr.readAnnotations(ls, tbl),
 	}
 	if spec.Type == "" {

--- a/internal/docs/screenshot_test.go
+++ b/internal/docs/screenshot_test.go
@@ -1,0 +1,73 @@
+package docs
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+)
+
+// A screenshot{} island with no Capturer wired fails loud (browser support
+// absent) — testable without any browser (DR-S3: the fail-loud paths run in
+// standard CI).
+func TestScreenshot_NoCapturer_FailsLoud(t *testing.T) {
+	t.Parallel()
+	src := "```rela\nscreenshot{ type=\"risico\", entity=\"r1\", out=\"f.png\" }\n```\n"
+	_, err := Build(context.Background(), src, Options{Meta: fixtureMeta(t)})
+	var be *BuildError
+	if !errors.As(err, &be) {
+		t.Fatalf("want *BuildError, got %T: %v", err, err)
+	}
+	if !strings.Contains(be.Msg, "browser") {
+		t.Errorf("error should mention the missing browser: %q", be.Msg)
+	}
+}
+
+// Missing required args fail loud (also without a browser).
+func TestScreenshot_MissingArgs_FailLoud(t *testing.T) {
+	t.Parallel()
+	cases := map[string]string{
+		"no type":   "```rela\nscreenshot{ entity=\"r1\", out=\"f.png\" }\n```\n",
+		"no entity": "```rela\nscreenshot{ type=\"risico\", out=\"f.png\" }\n```\n",
+		"no out":    "```rela\nscreenshot{ type=\"risico\", entity=\"r1\" }\n```\n",
+	}
+	for name, src := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			// A stub capturer so we get past the nil check to the arg checks.
+			_, err := Build(context.Background(), src, Options{
+				Meta: fixtureMeta(t), Capturer: stubCapturer{},
+			})
+			if err == nil {
+				t.Fatalf("%s: expected a BuildError", name)
+			}
+		})
+	}
+}
+
+// A manual with NO screenshot{} never constructs/consults a Capturer (AC9).
+func TestBuild_NoScreenshot_CapturerUntouched(t *testing.T) {
+	t.Parallel()
+	stub := &countingCapturer{}
+	src := "```rela\ntyperef{type=\"risico\", fields=\"required\"}\n```\n"
+	if _, err := Build(context.Background(), src, Options{Meta: fixtureMeta(t), Capturer: stub}); err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if stub.calls != 0 {
+		t.Errorf("Capturer.Capture called %d times for a screenshot-free manual", stub.calls)
+	}
+}
+
+// stubCapturer satisfies Capturer without a browser (arg-validation tests).
+type stubCapturer struct{}
+
+func (stubCapturer) Capture(context.Context, CaptureSpec) (string, error) { return "x.png", nil }
+func (stubCapturer) Close() error                                         { return nil }
+
+type countingCapturer struct{ calls int }
+
+func (c *countingCapturer) Capture(context.Context, CaptureSpec) (string, error) {
+	c.calls++
+	return "x.png", nil
+}
+func (c *countingCapturer) Close() error { return nil }

--- a/internal/docs/seed.go
+++ b/internal/docs/seed.go
@@ -1,0 +1,49 @@
+package docs
+
+import (
+	"context"
+
+	"github.com/Sourcehaven-BV/rela/internal/entity"
+	"github.com/Sourcehaven-BV/rela/internal/store"
+)
+
+// SeedOp is one recorded seed mutation (a create or a link). The manual's
+// create()/link() islands record these; they are applied to the in-memory graph
+// immediately (for the Tier-A resolvers entity{}/count{}/graph{}) and REPLAYED
+// verbatim against a fresh fsstore-backed temp project when a screenshot{} island
+// needs the SPA to render them. One recorder → both stores → they cannot diverge
+// (DR-S2).
+type SeedOp struct {
+	// Kind is "create" or "link".
+	Kind string
+	// create fields:
+	Type       string
+	ID         string
+	Properties map[string]any
+	Content    string
+	// link fields:
+	From    string
+	RelType string
+	To      string
+}
+
+// ApplySeed replays recorded seed ops against a store, using RAW store writes
+// (no entitymanager) so automations can't mutate the fixture. Used for both the
+// in-memory store (phase-2 resolvers) and the screenshot temp project's store
+// (Tier B), so the two representations cannot diverge (DR-S2).
+func ApplySeed(ctx context.Context, st store.Store, ops []SeedOp) error {
+	for _, op := range ops {
+		switch op.Kind {
+		case "create":
+			e := &entity.Entity{ID: op.ID, Type: op.Type, Properties: op.Properties, Content: op.Content}
+			if err := st.CreateEntity(ctx, e); err != nil {
+				return err
+			}
+		case "link":
+			if _, err := st.CreateRelation(ctx, op.From, op.RelType, op.To, nil); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}

--- a/internal/docscapture/annotate.go
+++ b/internal/docscapture/annotate.go
@@ -1,0 +1,102 @@
+package docscapture
+
+import (
+	"context"
+	_ "embed"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/chromedp/chromedp"
+
+	"github.com/Sourcehaven-BV/rela/internal/docs"
+)
+
+// annotateAction injects an overlay drawing each annotation (arrow + text, or a
+// box) anchored to its target element, then verifies every anchor resolved. It
+// fails loud if any anchor matched no element (DR-S4 for annotations).
+func annotateAction(arrows []docs.Annotation) chromedp.Action {
+	return chromedp.ActionFunc(func(ctx context.Context) error {
+		script, err := annotateScript(arrows)
+		if err != nil {
+			return err
+		}
+		var missing []string
+		if err := chromedp.Evaluate(script, &missing).Do(ctx); err != nil {
+			return err
+		}
+		if len(missing) > 0 {
+			return fmt.Errorf("annotation anchors not found on the page: %s", strings.Join(missing, ", "))
+		}
+		return nil
+	})
+}
+
+// annotateSpec is the per-annotation data handed to the injected JS. Selectors
+// and text are carried as DATA (a JSON literal), never spliced into JS source,
+// so operator-authored text cannot break out of the script (DR-C2).
+type annotateSpec struct {
+	Selector string `json:"selector"`
+	Text     string `json:"text"`
+	Side     string `json:"side"`
+	Box      bool   `json:"box"`
+}
+
+// annotateScript builds the overlay script. The annotation list is JSON-encoded
+// and embedded as a literal; json.Marshal of a Go string produces a valid,
+// fully-escaped JS string literal (handles ", </script>, backslashes, and the
+// U+2028/U+2029 line separators that would otherwise break a JS string).
+func annotateScript(arrows []docs.Annotation) (string, error) {
+	specs := make([]annotateSpec, 0, len(arrows))
+	for _, a := range arrows {
+		sel, err := anchorSelector(a.At)
+		if err != nil {
+			return "", err
+		}
+		specs = append(specs, annotateSpec{
+			Selector: sel,
+			Text:     a.Text,
+			Side:     a.Side,
+			Box:      a.Box,
+		})
+	}
+	data, err := json.Marshal(specs)
+	if err != nil {
+		return "", err
+	}
+	// Guard against the one sequence that closes a <script> context in HTML,
+	// belt-and-braces even though this runs via Runtime.evaluate not a <script>.
+	safe := strings.ReplaceAll(string(data), "</", `<\/`)
+	return strings.Replace(overlayJS, "__SPECS__", safe, 1), nil
+}
+
+//go:embed overlay.js
+var overlayJS string
+
+// anchorSelector maps a screenshot annotation target to a CSS selector:
+//   - a bare property name → #field-<prop> (the widget id FieldRenderer stamps)
+//   - "@button:<label>"    → a button by accessible label (best-effort)
+//   - "@role:<sel>"        → a raw ARIA/CSS selector passthrough
+func anchorSelector(at string) (string, error) {
+	switch {
+	case at == "":
+		return "", errors.New("annotation `at` is required")
+	case strings.HasPrefix(at, "@role:"):
+		return strings.TrimPrefix(at, "@role:"), nil
+	case strings.HasPrefix(at, "@button:"):
+		// Buttons are matched in-JS by text; encode as a marker the overlay reads.
+		return "@button:" + strings.TrimPrefix(at, "@button:"), nil
+	default:
+		return "#field-" + at, nil
+	}
+}
+
+// fieldOf returns the property name an annotation targets a field of, or "" for
+// non-field (@button/@role) targets — used to pick the renderability anchor.
+func fieldOf(at string) string {
+	if at == "" || strings.HasPrefix(at, "@") {
+		return ""
+	}
+	return at
+}

--- a/internal/docscapture/annotate.go
+++ b/internal/docscapture/annotate.go
@@ -68,7 +68,7 @@ func annotateScript(arrows []docs.Annotation) (string, error) {
 	// Guard against the one sequence that closes a <script> context in HTML,
 	// belt-and-braces even though this runs via Runtime.evaluate not a <script>.
 	safe := strings.ReplaceAll(string(data), "</", `<\/`)
-	return strings.Replace(overlayJS, "__SPECS__", safe, 1), nil
+	return strings.ReplaceAll(overlayJS, "__SPECS__", safe), nil
 }
 
 //go:embed overlay.js

--- a/internal/docscapture/annotate_test.go
+++ b/internal/docscapture/annotate_test.go
@@ -1,0 +1,91 @@
+package docscapture
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/Sourcehaven-BV/rela/internal/docs"
+)
+
+// The overlay script must carry operator text as a JSON literal so a hostile
+// string cannot break out of the JS (DR-C2). chromedp.Evaluate has no args
+// channel, so json.Marshal is the only safe splice.
+func TestAnnotateScript_InjectionSafe(t *testing.T) {
+	t.Parallel()
+	hostile := "\"; document.title='pwned'; //</script> x"
+	script, err := annotateScript([]docs.Annotation{{At: "status", Text: hostile}})
+	if err != nil {
+		t.Fatalf("annotateScript: %v", err)
+	}
+	// The raw hostile text must NOT appear verbatim — it must be JSON-escaped.
+	if strings.Contains(script, `document.title='pwned'; //</script>`) {
+		t.Errorf("hostile text leaked unescaped into the script:\n%s", script)
+	}
+	// The line separator U+2028 must be escaped (json.Marshal emits  ).
+	if strings.ContainsRune(script, ' ') {
+		t.Errorf("U+2028 not escaped — would break the JS string")
+	}
+	// The </ sequence must be defanged.
+	if strings.Contains(script, "</script>") {
+		t.Errorf("</script> not defanged:\n%s", script)
+	}
+	// The escaped forms should be present.
+	if !strings.Contains(script, `document.title=`) {
+		// It's fine that a backslash-escaped form exists; just ensure the field
+		// name still made it as data.
+		t.Logf("script:\n%s", script)
+	}
+}
+
+func TestAnchorSelector(t *testing.T) {
+	t.Parallel()
+	cases := map[string]string{
+		"status":          "#field-status",
+		"@role:.foo .bar": ".foo .bar",
+		"@button:Save":    "@button:Save",
+	}
+	for in, want := range cases {
+		got, err := anchorSelector(in)
+		if err != nil {
+			t.Fatalf("anchorSelector(%q): %v", in, err)
+		}
+		if got != want {
+			t.Errorf("anchorSelector(%q) = %q, want %q", in, got, want)
+		}
+	}
+	if _, err := anchorSelector(""); err == nil {
+		t.Error("empty `at` should error")
+	}
+}
+
+func TestFieldOf(t *testing.T) {
+	t.Parallel()
+	if fieldOf("status") != "status" {
+		t.Error("bare property should be its own field")
+	}
+	if fieldOf("@button:Save") != "" {
+		t.Error("@button target is not a field anchor")
+	}
+	if fieldOf("") != "" {
+		t.Error("empty is not a field")
+	}
+}
+
+func TestFormURL(t *testing.T) {
+	t.Parallel()
+	base := "http://127.0.0.1:9999"
+	cases := []struct {
+		spec docs.CaptureSpec
+		want string
+	}{
+		{docs.CaptureSpec{View: "form", Type: "ticket", Entity: "T-1"}, base + "/form/edit_ticket/T-1"},
+		{docs.CaptureSpec{View: "form", Type: "ticket", Entity: "T-1", Form: "custom"}, base + "/form/custom/T-1"},
+		{docs.CaptureSpec{View: "entity", Type: "ticket", Entity: "T-1"}, base + "/entity/ticket/T-1"},
+		{docs.CaptureSpec{View: "list", Type: "ticket"}, base + "/list/ticket"},
+	}
+	for _, c := range cases {
+		if got := formURL(base, c.spec); got != c.want {
+			t.Errorf("formURL(%+v) = %q, want %q", c.spec, got, c.want)
+		}
+	}
+}

--- a/internal/docscapture/browser.go
+++ b/internal/docscapture/browser.go
@@ -1,0 +1,62 @@
+package docscapture
+
+import (
+	"context"
+
+	"github.com/chromedp/chromedp"
+)
+
+// browser owns the chromedp allocator + context lifecycle. The chromedp context
+// IS the browser handle (a tab), so it is held on the struct by design.
+type browser struct {
+	allocCancel context.CancelFunc
+	ctxCancel   context.CancelFunc
+	ctx         context.Context //nolint:containedctx // the chromedp context is the browser handle
+}
+
+// newBrowser launches headless Chrome. It tries WITH the sandbox first and only
+// falls back to --no-sandbox if the sandboxed launch fails (DR-M1) — the page
+// content is our own localhost fixture, but default-secure is preferred.
+func newBrowser(parent context.Context) (*browser, error) {
+	b, err := launch(parent, false)
+	if err == nil {
+		return b, nil
+	}
+	// Retry without the sandbox (root/container environments).
+	return launch(parent, true)
+}
+
+func launch(parent context.Context, noSandbox bool) (*browser, error) {
+	opts := append(chromedp.DefaultExecAllocatorOptions[:],
+		chromedp.Flag("headless", true),
+		chromedp.Flag("disable-gpu", true),
+	)
+	if path, ok := hasChrome(); ok {
+		opts = append(opts, chromedp.ExecPath(path))
+	}
+	if noSandbox {
+		opts = append(opts, chromedp.Flag("no-sandbox", true))
+	}
+	allocCtx, allocCancel := chromedp.NewExecAllocator(parent, opts...)
+	ctx, ctxCancel := chromedp.NewContext(allocCtx)
+	// Force the browser to actually start so a launch failure surfaces here
+	// (and we can fall back to --no-sandbox) rather than on the first navigate.
+	if err := chromedp.Run(ctx); err != nil {
+		ctxCancel()
+		allocCancel()
+		return nil, err
+	}
+	return &browser{allocCancel: allocCancel, ctxCancel: ctxCancel, ctx: ctx}, nil
+}
+
+func (b *browser) close() {
+	if b == nil {
+		return
+	}
+	if b.ctxCancel != nil {
+		b.ctxCancel()
+	}
+	if b.allocCancel != nil {
+		b.allocCancel()
+	}
+}

--- a/internal/docscapture/capture.go
+++ b/internal/docscapture/capture.go
@@ -135,31 +135,34 @@ func (c *Capturer) Close() error {
 	return nil
 }
 
-// captureAction returns the element-clip or bounded full-page screenshot action.
-// Both produce PNG (lossless) — chromedp.Screenshot and page.CaptureScreenshot
-// default to PNG; only FullScreenshot(_, quality) forces JPEG, which we avoid.
+// rect is a page-coordinate bounding box (CSS px).
+type rect struct{ X, Y, W, H float64 }
+
+// captureAction produces a PNG (lossless): the full page, or a clipped region
+// (an element / a keyword-computed region) expanded by pad and clamped to the
+// page. All paths go through page.CaptureScreenshot (PNG + CaptureBeyondViewport),
+// so a clip taller than the viewport still renders and padding is honored —
+// chromedp.Screenshot cannot pad.
 func captureAction(spec docs.CaptureSpec, out *[]byte) chromedp.Action {
-	if spec.Clip != "" {
-		return chromedp.Screenshot(spec.Clip, out, chromedp.ByQuery, chromedp.NodeVisible)
-	}
 	return chromedp.ActionFunc(func(ctx context.Context) error {
-		// Measure the full content; bound the height (DR-M2) — fail loud if too tall.
-		var dims struct{ W, H int64 }
-		if err := chromedp.Evaluate(
-			`({W: Math.ceil(document.documentElement.scrollWidth),
-			   H: Math.ceil(Math.max(document.body.scrollHeight, document.documentElement.scrollHeight))})`,
-			&dims,
-		).Do(ctx); err != nil {
+		page0, err := pageSize(ctx)
+		if err != nil {
 			return err
 		}
-		if dims.H > maxFullHeight {
-			return fmt.Errorf("page is %dpx tall (> %dpx cap); use a clip= selector to bound the capture", dims.H, maxFullHeight)
+		clip := rect{X: 0, Y: 0, W: page0.W, H: page0.H}
+		if spec.Clip != "" {
+			region, rerr := resolveClip(ctx, spec.Clip, spec.Arrows)
+			if rerr != nil {
+				return rerr
+			}
+			clip = padAndClamp(region, float64(spec.Pad), page0)
+		}
+		if clip.H > maxFullHeight {
+			return fmt.Errorf("capture region is %.0fpx tall (> %dpx cap); use a tighter clip= selector or clip=\"focus\"", clip.H, maxFullHeight)
 		}
 		buf, err := page.CaptureScreenshot().
 			WithFormat(page.CaptureScreenshotFormatPng).
-			WithClip(&page.Viewport{X: 0, Y: 0, Width: float64(dims.W), Height: float64(dims.H), Scale: 1}).
-			// Without this, a clip taller than the emulated viewport renders the
-			// below-fold region blank — exactly the 1600<H≤4000 case the cap allows.
+			WithClip(&page.Viewport{X: clip.X, Y: clip.Y, Width: clip.W, Height: clip.H, Scale: 1}).
 			WithCaptureBeyondViewport(true).
 			Do(ctx)
 		if err != nil {

--- a/internal/docscapture/capture.go
+++ b/internal/docscapture/capture.go
@@ -1,0 +1,200 @@
+package docscapture
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/chromedp/cdproto/emulation"
+	"github.com/chromedp/cdproto/network"
+	"github.com/chromedp/cdproto/page"
+	"github.com/chromedp/chromedp"
+
+	"github.com/Sourcehaven-BV/rela/internal/docs"
+)
+
+const (
+	// perCaptureTimeout bounds one navigate+render+capture.
+	perCaptureTimeout = 30 * time.Second
+	// maxFullHeight caps a full-page capture; a taller page is a build error, not
+	// a silent truncation (DR-M2).
+	maxFullHeight = 4000
+	// settleDelay lets the SPA finish its post-mount render before capture.
+	settleDelay = 400 * time.Millisecond
+	// viewportW/H give the capture a stable, wide-enough viewport so form layout
+	// is deterministic across machines.
+	viewportW = 1280
+	viewportH = 1600
+)
+
+// Capturer implements docs.Capturer using chromedp against a data-entry SPA
+// served over a seeded temp project. The temp project + server + browser are
+// created lazily on the first Capture and reused across islands; Close tears
+// them all down.
+type Capturer struct {
+	proj    *project
+	browser *browser
+}
+
+// New returns a Capturer. It does NOT launch a browser yet (that happens on the
+// first Capture) so a manual with no screenshot{} pays nothing. It DOES verify a
+// Chrome binary is resolvable, so a screenshot-bearing manual fails loud early
+// rather than after standing up a server.
+func New() (*Capturer, error) {
+	if _, ok := hasChrome(); !ok {
+		return nil, errors.New("no Chrome/Chromium browser found on PATH — screenshot{} requires a browser")
+	}
+	return &Capturer{}, nil
+}
+
+// Capture renders one screenshot and writes the PNG, returning its path.
+func (c *Capturer) Capture(ctx context.Context, spec docs.CaptureSpec) (string, error) {
+	if err := c.ensure(ctx, spec); err != nil {
+		return "", err
+	}
+
+	// Derive the per-capture deadline from the browser's chromedp context (its
+	// tab), not the incoming ctx — chromedp actions must run against the browser
+	// context.
+	cctx, cancel := context.WithTimeout(c.browser.ctx, perCaptureTimeout)
+	defer cancel()
+
+	url := formURL(trimSlash(c.proj.server.URL), spec)
+	anchor := "#field-" + firstFieldAnchor(spec)
+
+	var png []byte
+	actions := []chromedp.Action{
+		// Deterministic viewport so form layout is stable across machines.
+		deviceMetricsOverride(),
+		// Thread the requested role to the per-request principal resolver.
+		network.SetExtraHTTPHeaders(network.Headers(map[string]any{roleHeader: spec.As})),
+		chromedp.Navigate(url),
+		// Renderability gate: the entity must actually render (a real field
+		// appears) AND the SPA's "failed to load" boundary must be absent (DR-S4).
+		chromedp.WaitVisible(anchor, chromedp.ByQuery),
+		renderabilityGate(),
+		chromedp.Sleep(settleDelay),
+	}
+	if len(spec.Arrows) > 0 {
+		actions = append(actions, annotateAction(spec.Arrows))
+	}
+	actions = append(actions, captureAction(spec, &png))
+
+	//nolint:contextcheck // chromedp actions bind to the browser context (cctx), not the caller ctx
+	if err := chromedp.Run(cctx, actions...); err != nil {
+		return "", fmt.Errorf("capture: %w", err)
+	}
+	if dir := filepath.Dir(spec.OutPath); dir != "" {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			return "", fmt.Errorf("create image dir: %w", err)
+		}
+	}
+	if err := os.WriteFile(spec.OutPath, png, 0o644); err != nil {
+		return "", fmt.Errorf("write png: %w", err)
+	}
+	return spec.OutPath, nil
+}
+
+// ensure lazily stands up the temp-project server (once) and the browser (once).
+func (c *Capturer) ensure(ctx context.Context, spec docs.CaptureSpec) error {
+	if c.proj == nil {
+		p, err := standUp(ctx, spec.ProjectDir, spec.Seed)
+		if err != nil {
+			return err
+		}
+		c.proj = p
+	}
+	if c.browser == nil {
+		b, err := newBrowser(ctx)
+		if err != nil {
+			return err
+		}
+		c.browser = b
+	}
+	return nil
+}
+
+// Close tears down the browser, server, and temp project.
+func (c *Capturer) Close() error {
+	if c.browser != nil {
+		c.browser.close()
+	}
+	if c.proj != nil {
+		c.proj.close()
+	}
+	return nil
+}
+
+// captureAction returns the element-clip or bounded full-page screenshot action.
+// Both produce PNG (lossless) — chromedp.Screenshot and page.CaptureScreenshot
+// default to PNG; only FullScreenshot(_, quality) forces JPEG, which we avoid.
+func captureAction(spec docs.CaptureSpec, out *[]byte) chromedp.Action {
+	if spec.Clip != "" {
+		return chromedp.Screenshot(spec.Clip, out, chromedp.ByQuery, chromedp.NodeVisible)
+	}
+	return chromedp.ActionFunc(func(ctx context.Context) error {
+		// Measure the full content; bound the height (DR-M2) — fail loud if too tall.
+		var dims struct{ W, H int64 }
+		if err := chromedp.Evaluate(
+			`({W: Math.ceil(document.documentElement.scrollWidth),
+			   H: Math.ceil(Math.max(document.body.scrollHeight, document.documentElement.scrollHeight))})`,
+			&dims,
+		).Do(ctx); err != nil {
+			return err
+		}
+		if dims.H > maxFullHeight {
+			return fmt.Errorf("page is %dpx tall (> %dpx cap); use a clip= selector to bound the capture", dims.H, maxFullHeight)
+		}
+		buf, err := page.CaptureScreenshot().
+			WithFormat(page.CaptureScreenshotFormatPng).
+			WithClip(&page.Viewport{X: 0, Y: 0, Width: float64(dims.W), Height: float64(dims.H), Scale: 1}).
+			Do(ctx)
+		if err != nil {
+			return err
+		}
+		*out = buf
+		return nil
+	})
+}
+
+// firstFieldAnchor picks a field to gate renderability on: the first arrow's
+// field target, else a conventional "title"/"name". The chosen anchor must be a
+// field the target form actually renders.
+func firstFieldAnchor(spec docs.CaptureSpec) string {
+	for _, a := range spec.Arrows {
+		if f := fieldOf(a.At); f != "" {
+			return f
+		}
+	}
+	return "title"
+}
+
+// renderabilityGate fails the capture if the SPA surfaced an error toast instead
+// of rendering the entity (DR-S4) — e.g. a bad entity id, a form field set the
+// entity doesn't satisfy, or the `as` role lacking read access. The error toast
+// carries a stable data-testid; its presence means we'd be capturing a broken
+// form. (The prior WaitVisible on a real #field-<prop> already confirms the form
+// mounted; this catches the load-error-after-mount case.)
+func renderabilityGate() chromedp.Action {
+	return chromedp.ActionFunc(func(ctx context.Context) error {
+		var broken bool
+		if err := chromedp.Evaluate(
+			`!!document.querySelector('[data-testid="toast-error"]')`, &broken,
+		).Do(ctx); err != nil {
+			return err
+		}
+		if broken {
+			return errors.New("the entity failed to render (the SPA surfaced an error) — check the entity id, the form's field set, and the `as` role's read access")
+		}
+		return nil
+	})
+}
+
+// deviceMetrics gives the capture a stable, wide-enough viewport so form layout
+// is deterministic across machines.
+func deviceMetricsOverride() chromedp.Action {
+	return emulation.SetDeviceMetricsOverride(viewportW, viewportH, 1.0, false)
+}

--- a/internal/docscapture/capture.go
+++ b/internal/docscapture/capture.go
@@ -24,6 +24,8 @@ const (
 	maxFullHeight = 4000
 	// settleDelay lets the SPA finish its post-mount render before capture.
 	settleDelay = 400 * time.Millisecond
+	// pollInterval is how often the renderability gate checks the form's load state.
+	pollInterval = 100 * time.Millisecond
 	// viewportW/H give the capture a stable, wide-enough viewport so form layout
 	// is deterministic across machines.
 	viewportW = 1280
@@ -63,7 +65,6 @@ func (c *Capturer) Capture(ctx context.Context, spec docs.CaptureSpec) (string, 
 	defer cancel()
 
 	url := formURL(trimSlash(c.proj.server.URL), spec)
-	anchor := "#field-" + firstFieldAnchor(spec)
 
 	var png []byte
 	actions := []chromedp.Action{
@@ -72,9 +73,11 @@ func (c *Capturer) Capture(ctx context.Context, spec docs.CaptureSpec) (string, 
 		// Thread the requested role to the per-request principal resolver.
 		network.SetExtraHTTPHeaders(network.Headers(map[string]any{roleHeader: spec.As})),
 		chromedp.Navigate(url),
-		// Renderability gate: the entity must actually render (a real field
-		// appears) AND the SPA's "failed to load" boundary must be absent (DR-S4).
-		chromedp.WaitVisible(anchor, chromedp.ByQuery),
+		// Renderability gate (DR-S4): wait until the form stamps a terminal
+		// load state, then fail loud if it was an error. This races load vs
+		// error in one poll — no dependency on which schema fields render or on
+		// a timing-sensitive toast, and a load failure short-circuits instead of
+		// eating the whole capture timeout.
 		renderabilityGate(),
 		chromedp.Sleep(settleDelay),
 	}
@@ -106,6 +109,10 @@ func (c *Capturer) ensure(ctx context.Context, spec docs.CaptureSpec) error {
 			return err
 		}
 		c.proj = p
+	} else if err := c.proj.syncSeed(ctx, spec.Seed); err != nil {
+		// A later island may have create()d entities after standUp; apply the new
+		// tail so this island's entity actually exists in the running server.
+		return err
 	}
 	if c.browser == nil {
 		b, err := newBrowser(ctx)
@@ -151,6 +158,9 @@ func captureAction(spec docs.CaptureSpec, out *[]byte) chromedp.Action {
 		buf, err := page.CaptureScreenshot().
 			WithFormat(page.CaptureScreenshotFormatPng).
 			WithClip(&page.Viewport{X: 0, Y: 0, Width: float64(dims.W), Height: float64(dims.H), Scale: 1}).
+			// Without this, a clip taller than the emulated viewport renders the
+			// below-fold region blank — exactly the 1600<H≤4000 case the cap allows.
+			WithCaptureBeyondViewport(true).
 			Do(ctx)
 		if err != nil {
 			return err
@@ -160,34 +170,27 @@ func captureAction(spec docs.CaptureSpec, out *[]byte) chromedp.Action {
 	})
 }
 
-// firstFieldAnchor picks a field to gate renderability on: the first arrow's
-// field target, else a conventional "title"/"name". The chosen anchor must be a
-// field the target form actually renders.
-func firstFieldAnchor(spec docs.CaptureSpec) string {
-	for _, a := range spec.Arrows {
-		if f := fieldOf(a.At); f != "" {
-			return f
-		}
-	}
-	return "title"
-}
-
-// renderabilityGate fails the capture if the SPA surfaced an error toast instead
-// of rendering the entity (DR-S4) — e.g. a bad entity id, a form field set the
-// entity doesn't satisfy, or the `as` role lacking read access. The error toast
-// carries a stable data-testid; its presence means we'd be capturing a broken
-// form. (The prior WaitVisible on a real #field-<prop> already confirms the form
-// mounted; this catches the load-error-after-mount case.)
+// renderabilityGate blocks until the form reaches a terminal load state and
+// fails loud if that state is an error (DR-S4). The form root stamps
+// data-testid="form-state-{pending|loaded|error}" off loadEntity's outcome, so
+// this is unambiguous: it distinguishes a form rendered WITH its entity's data
+// from an empty schema-only shell left after a failed load — the fail-OPEN hole
+// the spike hit. Polling races load vs error, so a failure short-circuits rather
+// than eating the capture timeout.
 func renderabilityGate() chromedp.Action {
 	return chromedp.ActionFunc(func(ctx context.Context) error {
-		var broken bool
-		if err := chromedp.Evaluate(
-			`!!document.querySelector('[data-testid="toast-error"]')`, &broken,
+		var state string
+		if err := chromedp.Poll(
+			`(function(){var e=document.querySelector('[data-testid^="form-state-"]');`+
+				`if(!e)return null;var s=e.getAttribute('data-testid').slice(11);`+
+				`return s==='pending'?null:s;})()`,
+			&state,
+			chromedp.WithPollingInterval(pollInterval),
 		).Do(ctx); err != nil {
-			return err
+			return fmt.Errorf("waiting for the form to load: %w", err)
 		}
-		if broken {
-			return errors.New("the entity failed to render (the SPA surfaced an error) — check the entity id, the form's field set, and the `as` role's read access")
+		if state == "error" {
+			return errors.New("the entity failed to load in the form — check the entity id, the form's field set, and the `as` role's read access")
 		}
 		return nil
 	})

--- a/internal/docscapture/capture_test.go
+++ b/internal/docscapture/capture_test.go
@@ -5,7 +5,9 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/Sourcehaven-BV/rela/internal/dataentry"
 	"github.com/Sourcehaven-BV/rela/internal/docs"
@@ -100,6 +102,72 @@ func TestCapture_AnnotationAndFailLoud(t *testing.T) {
 	bad.Arrows = []docs.Annotation{{At: "nosuchfield", Text: "x"}}
 	if _, err := capr.Capture(context.Background(), bad); err == nil {
 		t.Error("expected fail-loud on an unknown annotation anchor")
+	}
+}
+
+// Two screenshots on ONE reused Capturer where the second entity is seeded
+// AFTER the first capture (the seed grows across islands) — the reused server
+// must pick up the new entity (regression for the seed-staleness bug).
+func TestCapture_SeedGrowsAcrossIslands(t *testing.T) {
+	requireBrowser(t)
+	capr, err := New()
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer capr.Close()
+
+	mk := func(id string) docs.SeedOp {
+		return docs.SeedOp{Kind: "create", Type: "ticket", ID: id, Properties: map[string]any{
+			"title": id, "status": "open", "priority": "low", "reporter": "a@b.c",
+		}}
+	}
+	// First island: seed = [t1], capture t1 (stands up the server).
+	seed := []docs.SeedOp{mk("TICKET-i1")}
+	if _, err := capr.Capture(context.Background(), docs.CaptureSpec{
+		ProjectDir: protoDir(t), Seed: seed, View: "form", Type: "ticket",
+		Entity: "TICKET-i1", OutPath: filepath.Join(t.TempDir(), "1.png"),
+	}); err != nil {
+		t.Fatalf("island 1: %v", err)
+	}
+	// Second island: a new create() grew the seed to [t1, t2]; capture t2 against
+	// the ALREADY-RUNNING server. Without syncSeed this fails "entity not found".
+	seed = append(seed, mk("TICKET-i2"))
+	out2 := filepath.Join(t.TempDir(), "2.png")
+	if _, err := capr.Capture(context.Background(), docs.CaptureSpec{
+		ProjectDir: protoDir(t), Seed: seed, View: "form", Type: "ticket",
+		Entity: "TICKET-i2", OutPath: out2,
+	}); err != nil {
+		t.Fatalf("island 2 (seed grew): %v", err)
+	}
+	assertPNG(t, out2)
+}
+
+// Capturing an entity that isn't in the seed must fail loud via the
+// renderability gate (form-state=error) — NOT capture a blank schema-only form
+// and NOT eat the capture timeout (DR-S4 / the fail-OPEN hole the spike hit).
+func TestCapture_UnrenderableEntity_FailsLoud(t *testing.T) {
+	requireBrowser(t)
+	capr, err := New()
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer capr.Close()
+
+	// Seed nothing of this id; ask to capture it.
+	start := time.Now()
+	_, err = capr.Capture(context.Background(), docs.CaptureSpec{
+		ProjectDir: protoDir(t), View: "form", Type: "ticket",
+		Entity: "TICKET-does-not-exist", OutPath: filepath.Join(t.TempDir(), "x.png"),
+	})
+	if err == nil {
+		t.Fatal("expected a fail-loud error for an unrenderable entity")
+	}
+	if !strings.Contains(err.Error(), "failed to load") {
+		t.Errorf("error should name the load failure, got: %v", err)
+	}
+	// It must short-circuit, not run out the full per-capture timeout.
+	if elapsed := time.Since(start); elapsed > perCaptureTimeout-time.Second {
+		t.Errorf("gate ate the timeout (%s) instead of short-circuiting", elapsed)
 	}
 }
 

--- a/internal/docscapture/capture_test.go
+++ b/internal/docscapture/capture_test.go
@@ -171,6 +171,73 @@ func TestCapture_UnrenderableEntity_FailsLoud(t *testing.T) {
 	}
 }
 
+// Cropping produces a smaller image than the full page: an element clip with
+// padding, and clip="focus" (the annotated region). clip="focus" with no arrows
+// fails loud.
+func TestCapture_Crop(t *testing.T) {
+	requireBrowser(t)
+	capr, err := New()
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer capr.Close()
+
+	seed := []docs.SeedOp{{Kind: "create", Type: "ticket", ID: "TICKET-crop", Properties: map[string]any{
+		"title": "x", "status": "in-progress", "priority": "high", "reporter": "a@b.c",
+	}}}
+	base := docs.CaptureSpec{ProjectDir: protoDir(t), Seed: seed, View: "form", Type: "ticket", Entity: "TICKET-crop"}
+
+	full := base
+	full.OutPath = filepath.Join(t.TempDir(), "full.png")
+	if _, err := capr.Capture(context.Background(), full); err != nil {
+		t.Fatalf("full: %v", err)
+	}
+	fullSize := fileSize(t, full.OutPath)
+
+	// Element crop with padding → smaller than full page.
+	elem := base
+	elem.Clip = "#field-status"
+	elem.Pad = 32
+	elem.OutPath = filepath.Join(t.TempDir(), "elem.png")
+	if _, err := capr.Capture(context.Background(), elem); err != nil {
+		t.Fatalf("element crop: %v", err)
+	}
+	assertPNG(t, elem.OutPath)
+	if fileSize(t, elem.OutPath) >= fullSize {
+		t.Error("element crop should be smaller than the full page")
+	}
+
+	// Focus crop (bounding box of annotated targets) → also smaller.
+	focus := base
+	focus.Arrows = []docs.Annotation{{At: "status", Text: "state"}, {At: "priority", Text: "pri"}}
+	focus.Clip = "focus"
+	focus.OutPath = filepath.Join(t.TempDir(), "focus.png")
+	if _, err := capr.Capture(context.Background(), focus); err != nil {
+		t.Fatalf("focus crop: %v", err)
+	}
+	assertPNG(t, focus.OutPath)
+	if fileSize(t, focus.OutPath) >= fullSize {
+		t.Error("focus crop should be smaller than the full page")
+	}
+
+	// clip="focus" with no arrows → fail loud.
+	bad := base
+	bad.Clip = "focus"
+	bad.OutPath = filepath.Join(t.TempDir(), "bad.png")
+	if _, err := capr.Capture(context.Background(), bad); err == nil {
+		t.Error(`clip="focus" with no annotations should fail loud`)
+	}
+}
+
+func fileSize(t *testing.T, path string) int64 {
+	t.Helper()
+	fi, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return fi.Size()
+}
+
 func assertPNG(t *testing.T, path string) {
 	t.Helper()
 	data, err := os.ReadFile(path)

--- a/internal/docscapture/capture_test.go
+++ b/internal/docscapture/capture_test.go
@@ -1,0 +1,118 @@
+package docscapture
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/Sourcehaven-BV/rela/internal/dataentry"
+	"github.com/Sourcehaven-BV/rela/internal/docs"
+)
+
+// requireBrowser skips the test when a browser or the built SPA is absent, so
+// the standard CI matrix stays green; the dedicated browser job runs them.
+func requireBrowser(t *testing.T) {
+	t.Helper()
+	if _, ok := hasChrome(); !ok {
+		t.Skip("no Chrome/Chromium browser available")
+	}
+	if err := dataentry.CheckEmbeddedSPA(); err != nil {
+		t.Skip("data-entry SPA not built (run just build-frontend)")
+	}
+}
+
+// protoDir is the in-tree prototype project used as the capture corpus.
+func protoDir(t *testing.T) string {
+	t.Helper()
+	p, err := filepath.Abs("../../prototypes/data-entry/project")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(filepath.Join(p, "metamodel.yaml")); err != nil {
+		t.Skip("prototype project not found")
+	}
+	return p
+}
+
+// A seeded ticket's edit form captures to a valid PNG.
+func TestCapture_Form(t *testing.T) {
+	requireBrowser(t)
+	capr, err := New()
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer capr.Close()
+
+	out := filepath.Join(t.TempDir(), "form.png")
+	spec := docs.CaptureSpec{
+		ProjectDir: protoDir(t),
+		Seed: []docs.SeedOp{{
+			Kind: "create", Type: "ticket", ID: "TICKET-cap",
+			Properties: map[string]any{
+				"title": "Login 500s under load", "status": "in-progress",
+				"priority": "high", "reporter": "cap@example.com",
+			},
+		}},
+		View: "form", Type: "ticket", Entity: "TICKET-cap",
+		OutPath: out,
+	}
+	png, err := capr.Capture(context.Background(), spec)
+	if err != nil {
+		t.Fatalf("Capture: %v", err)
+	}
+	assertPNG(t, png)
+}
+
+// An arrow annotation anchored to a real field succeeds; an unknown field fails.
+func TestCapture_AnnotationAndFailLoud(t *testing.T) {
+	requireBrowser(t)
+	capr, err := New()
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer capr.Close()
+
+	seed := []docs.SeedOp{{
+		Kind: "create", Type: "ticket", ID: "TICKET-anno",
+		Properties: map[string]any{
+			"title": "x", "status": "open", "priority": "low", "reporter": "a@b.c",
+		},
+	}}
+	base := docs.CaptureSpec{
+		ProjectDir: protoDir(t), Seed: seed,
+		View: "form", Type: "ticket", Entity: "TICKET-anno",
+	}
+
+	// Valid field anchor → success.
+	ok := base
+	ok.OutPath = filepath.Join(t.TempDir(), "anno.png")
+	ok.Arrows = []docs.Annotation{{At: "status", Text: "the lifecycle state"}}
+	if _, err := capr.Capture(context.Background(), ok); err != nil {
+		t.Fatalf("annotated capture: %v", err)
+	}
+	assertPNG(t, ok.OutPath)
+
+	// Unknown field anchor → fail loud.
+	bad := base
+	bad.OutPath = filepath.Join(t.TempDir(), "bad.png")
+	bad.Arrows = []docs.Annotation{{At: "nosuchfield", Text: "x"}}
+	if _, err := capr.Capture(context.Background(), bad); err == nil {
+		t.Error("expected fail-loud on an unknown annotation anchor")
+	}
+}
+
+func assertPNG(t *testing.T, path string) {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read png: %v", err)
+	}
+	if len(data) < 1000 {
+		t.Errorf("png suspiciously small: %d bytes", len(data))
+	}
+	if !bytes.HasPrefix(data, []byte("\x89PNG\r\n\x1a\n")) {
+		t.Errorf("not a PNG (bad magic)")
+	}
+}

--- a/internal/docscapture/clip.go
+++ b/internal/docscapture/clip.go
@@ -1,0 +1,111 @@
+package docscapture
+
+import (
+	"context"
+	_ "embed"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/chromedp/chromedp"
+
+	"github.com/Sourcehaven-BV/rela/internal/docs"
+)
+
+//go:embed focus.js
+var focusJS string
+
+// pageSize returns the full scrollable page dimensions in CSS px.
+func pageSize(ctx context.Context) (rect, error) {
+	var d struct{ W, H float64 }
+	err := chromedp.Evaluate(
+		`({W: Math.ceil(document.documentElement.scrollWidth),
+		   H: Math.ceil(Math.max(document.body.scrollHeight, document.documentElement.scrollHeight))})`,
+		&d,
+	).Do(ctx)
+	return rect{W: d.W, H: d.H}, err
+}
+
+// resolveClip turns a clip spec into a page-coordinate rect. The spec is either
+// a predefined keyword ("focus" — the bounding box of the annotated targets) or
+// a CSS selector (that element's box). Fails loud if nothing matches.
+func resolveClip(ctx context.Context, clip string, annotations []docs.Annotation) (rect, error) {
+	if clip == clipFocus {
+		return focusRect(ctx, annotations)
+	}
+	return selectorRect(ctx, clip)
+}
+
+const clipFocus = "focus"
+
+// selectorRect returns the page-coordinate box of the first element matching a
+// CSS selector.
+func selectorRect(ctx context.Context, selector string) (rect, error) {
+	sel, err := json.Marshal(selector)
+	if err != nil {
+		return rect{}, err
+	}
+	var r *rect
+	expr := fmt.Sprintf(`(function(){var e=document.querySelector(%s);if(!e)return null;`+
+		`var b=e.getBoundingClientRect();`+
+		`return {X:b.left+window.scrollX,Y:b.top+window.scrollY,W:b.width,H:b.height};})()`, sel)
+	if err := chromedp.Evaluate(expr, &r).Do(ctx); err != nil {
+		return rect{}, err
+	}
+	if r == nil || r.W == 0 || r.H == 0 {
+		return rect{}, fmt.Errorf("clip selector %q matched no visible element", selector)
+	}
+	return *r, nil
+}
+
+// focusRect returns the union bounding box of every annotation's target element,
+// so clip="focus" crops to what the arrows point at. Requires annotations.
+func focusRect(ctx context.Context, annotations []docs.Annotation) (rect, error) {
+	if len(annotations) == 0 {
+		return rect{}, errors.New(`clip="focus" needs at least one arrow/box to focus on`)
+	}
+	selectors := make([]string, 0, len(annotations))
+	for _, a := range annotations {
+		sel, err := anchorSelector(a.At)
+		if err != nil {
+			return rect{}, err
+		}
+		selectors = append(selectors, sel)
+	}
+	data, err := json.Marshal(selectors)
+	if err != nil {
+		return rect{}, err
+	}
+	var r *rect
+	expr := strings.ReplaceAll(focusJS, "__SELS__", string(data))
+	if err := chromedp.Evaluate(expr, &r).Do(ctx); err != nil {
+		return rect{}, err
+	}
+	if r == nil {
+		return rect{}, fmt.Errorf(`clip="focus": none of the annotation targets (%s) matched a visible element`, strings.Join(selectors, ", "))
+	}
+	return *r, nil
+}
+
+// padAndClamp expands a region by pad on all sides and clamps it to the page so
+// the crop never extends past the content (no white margin beyond the page).
+func padAndClamp(r rect, pad float64, page rect) rect {
+	x := r.X - pad
+	y := r.Y - pad
+	right := r.X + r.W + pad
+	bottom := r.Y + r.H + pad
+	if x < 0 {
+		x = 0
+	}
+	if y < 0 {
+		y = 0
+	}
+	if right > page.W {
+		right = page.W
+	}
+	if bottom > page.H {
+		bottom = page.H
+	}
+	return rect{X: x, Y: y, W: right - x, H: bottom - y}
+}

--- a/internal/docscapture/clip_test.go
+++ b/internal/docscapture/clip_test.go
@@ -1,0 +1,36 @@
+package docscapture
+
+import "testing"
+
+func TestPadAndClamp(t *testing.T) {
+	t.Parallel()
+	page := rect{W: 1000, H: 2000}
+	cases := []struct {
+		name string
+		r    rect
+		pad  float64
+		want rect
+	}{
+		{"interior grows by pad on all sides",
+			rect{X: 100, Y: 100, W: 200, H: 100}, 20,
+			rect{X: 80, Y: 80, W: 240, H: 140}},
+		{"clamps to the left/top edge",
+			rect{X: 10, Y: 10, W: 50, H: 50}, 30,
+			rect{X: 0, Y: 0, W: 90, H: 90}}, // left/top clamp to 0; right/bottom = 10+50+30
+		{"clamps to the right/bottom edge",
+			rect{X: 900, Y: 1900, W: 200, H: 200}, 50,
+			rect{X: 850, Y: 1850, W: 150, H: 150}}, // right/bottom clamp to page
+		{"zero pad is the tight box",
+			rect{X: 100, Y: 100, W: 50, H: 50}, 0,
+			rect{X: 100, Y: 100, W: 50, H: 50}},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			got := padAndClamp(c.r, c.pad, page)
+			if got != c.want {
+				t.Errorf("padAndClamp(%+v, %v) = %+v, want %+v", c.r, c.pad, got, c.want)
+			}
+		})
+	}
+}

--- a/internal/docscapture/focus.js
+++ b/internal/docscapture/focus.js
@@ -1,0 +1,30 @@
+// Computes the union bounding box of the annotation targets AND the drawn
+// overlay (.rela-anno labels/arrows extend beyond their target), so
+// clip="focus" crops to include the annotations. The SELS placeholder is the
+// JSON array of target selectors; returns {X,Y,W,H} in page coords, or null if
+// none matched.
+(function () {
+  var sels = __SELS__;
+  var minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity, n = 0;
+  function add(b) {
+    if (b.width === 0 || b.height === 0) return;
+    n++;
+    var x = b.left + window.scrollX, y = b.top + window.scrollY;
+    if (x < minX) minX = x;
+    if (y < minY) minY = y;
+    if (x + b.width > maxX) maxX = x + b.width;
+    if (y + b.height > maxY) maxY = y + b.height;
+  }
+  sels.forEach(function (s) {
+    var e = s.indexOf('@button:') === 0
+      ? Array.prototype.slice.call(document.querySelectorAll('button,a,[role=button]'))
+          .find(function (b) { return (b.textContent || '').trim() === s.slice(8); })
+      : document.querySelector(s);
+    if (e) add(e.getBoundingClientRect());
+  });
+  Array.prototype.slice.call(document.querySelectorAll('.rela-anno')).forEach(function (e) {
+    add(e.getBoundingClientRect());
+  });
+  if (n === 0) return null;
+  return { X: minX, Y: minY, W: maxX - minX, H: maxY - minY };
+})();

--- a/internal/docscapture/overlay.js
+++ b/internal/docscapture/overlay.js
@@ -1,0 +1,65 @@
+// Overlay injected by annotate.go via chromedp.Evaluate. It draws an arrow +
+// label (or a box) for each annotation spec, anchored to the target element's
+// live geometry (getBoundingClientRect), and returns the selectors that matched
+// no element so the Go side can fail loud. The spec array is spliced in as a
+// JSON literal in place of the SPECS placeholder (json.Marshal → injection-safe).
+(function () {
+  var specs = __SPECS__;
+  var missing = [];
+  var GOLD = '#d99a3b';
+  function resolve(sel) {
+    if (sel.indexOf('@button:') === 0) {
+      var label = sel.slice(8);
+      var btns = Array.prototype.slice.call(
+        document.querySelectorAll('button, a, [role=button]')
+      );
+      return btns.find(function (b) {
+        return (b.textContent || '').trim() === label;
+      }) || null;
+    }
+    return document.querySelector(sel);
+  }
+  var layer = document.createElement('div');
+  layer.style.cssText =
+    'position:absolute;left:0;top:0;width:100%;height:100%;' +
+    'pointer-events:none;z-index:2147483647;';
+  document.body.appendChild(layer);
+  specs.forEach(function (s) {
+    var el = resolve(s.selector);
+    if (!el) { missing.push(s.selector); return; }
+    var r = el.getBoundingClientRect();
+    if (r.width === 0 || r.height === 0) { missing.push(s.selector); return; }
+    var x = r.left + window.scrollX, y = r.top + window.scrollY;
+    if (s.box) {
+      var box = document.createElement('div');
+      box.style.cssText =
+        'position:absolute;left:' + (x - 4) + 'px;top:' + (y - 4) + 'px;' +
+        'width:' + (r.width + 8) + 'px;height:' + (r.height + 8) + 'px;' +
+        'border:3px solid ' + GOLD + ';border-radius:6px;';
+      layer.appendChild(box);
+    }
+    if (s.text) {
+      var side = s.side || 'right';
+      var ly = y + r.height / 2;
+      var lab = document.createElement('div');
+      lab.textContent = s.text;
+      var lx = side === 'left' ? x - 8 : x + r.width + 8;
+      var align = side === 'left'
+        ? 'right:' + (document.documentElement.clientWidth - lx) + 'px;'
+        : 'left:' + lx + 'px;';
+      lab.style.cssText =
+        'position:absolute;' + align + 'top:' + (ly - 12) + 'px;' +
+        'background:' + GOLD + ';color:#1b1b1b;' +
+        'font:600 13px system-ui,sans-serif;padding:2px 8px;' +
+        'border-radius:4px;white-space:nowrap;';
+      layer.appendChild(lab);
+      var arrow = document.createElement('div');
+      var ax = side === 'left' ? x - 6 : x + r.width;
+      arrow.style.cssText =
+        'position:absolute;left:' + ax + 'px;top:' + (ly - 1) + 'px;' +
+        'width:8px;height:3px;background:' + GOLD + ';';
+      layer.appendChild(arrow);
+    }
+  });
+  return missing;
+})();

--- a/internal/docscapture/overlay.js
+++ b/internal/docscapture/overlay.js
@@ -36,7 +36,7 @@
         'position:absolute;left:' + (x - 4) + 'px;top:' + (y - 4) + 'px;' +
         'width:' + (r.width + 8) + 'px;height:' + (r.height + 8) + 'px;' +
         'border:3px solid ' + GOLD + ';border-radius:6px;';
-      layer.appendChild(box);
+      box.className='rela-anno';layer.appendChild(box);
     }
     if (s.text) {
       var side = s.side || 'right';
@@ -52,13 +52,13 @@
         'background:' + GOLD + ';color:#1b1b1b;' +
         'font:600 13px system-ui,sans-serif;padding:2px 8px;' +
         'border-radius:4px;white-space:nowrap;';
-      layer.appendChild(lab);
+      lab.className='rela-anno';layer.appendChild(lab);
       var arrow = document.createElement('div');
       var ax = side === 'left' ? x - 6 : x + r.width;
       arrow.style.cssText =
         'position:absolute;left:' + ax + 'px;top:' + (ly - 1) + 'px;' +
         'width:8px;height:3px;background:' + GOLD + ';';
-      layer.appendChild(arrow);
+      arrow.className='rela-anno';layer.appendChild(arrow);
     }
   });
   return missing;

--- a/internal/docscapture/server.go
+++ b/internal/docscapture/server.go
@@ -38,6 +38,24 @@ type project struct {
 	svc      *appbuild.Services
 	server   *httptest.Server
 	assignee func(role string) principal.Principal
+	// seeded is how many seed ops have been applied to the store. The manual's
+	// seed grows as create()/link() islands run; each screenshot{} passes the
+	// FULL accumulated seed, so we apply only the new tail before capturing —
+	// otherwise an entity created after the server stood up would be missing.
+	seeded int
+}
+
+// syncSeed applies any seed ops beyond those already applied to the running
+// store, so a screenshot{} of an entity created after standUp still renders.
+func (p *project) syncSeed(ctx context.Context, seed []docs.SeedOp) error {
+	if p.seeded >= len(seed) {
+		return nil
+	}
+	if err := docs.ApplySeed(ctx, p.svc.Store(), seed[p.seeded:]); err != nil {
+		return err
+	}
+	p.seeded = len(seed)
+	return nil
 }
 
 // standUp copies the documented project's schema/config into a temp dir, seeds
@@ -92,7 +110,7 @@ func standUp(ctx context.Context, projectDir string, seed []docs.SeedOp) (*proje
 		return assignee(r.Header.Get(roleHeader))
 	})
 
-	p := &project{dir: tmp, svc: svc, assignee: assignee}
+	p := &project{dir: tmp, svc: svc, assignee: assignee, seeded: len(seed)}
 	p.server = httptest.NewServer(app.NewRouter())
 	return p, nil
 }

--- a/internal/docscapture/server.go
+++ b/internal/docscapture/server.go
@@ -1,0 +1,265 @@
+// Package docscapture implements the browser-backed screenshot capture for the
+// rela-docs screenshot{} island (Tier B). It stands up the data-entry SPA over a
+// seeded temp project and drives headless Chrome (chromedp) to capture a PNG.
+//
+// It is deliberately a SEPARATE package from internal/docs: it pulls in the whole
+// data-entry + appbuild + chromedp dependency surface, which the core doc
+// language must not carry. internal/docs depends on it only through the
+// consumer-side docs.Capturer interface, injected by the CLI.
+package docscapture
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/Sourcehaven-BV/rela/internal/acl"
+	"github.com/Sourcehaven-BV/rela/internal/appbuild"
+	"github.com/Sourcehaven-BV/rela/internal/dataentry"
+	"github.com/Sourcehaven-BV/rela/internal/docs"
+	"github.com/Sourcehaven-BV/rela/internal/principal"
+	"github.com/Sourcehaven-BV/rela/internal/script"
+)
+
+// roleHeader carries the requested ACL role from a chromedp navigation to the
+// server's principal resolver, so one reused server can render different `as=`
+// roles across screenshot{} islands (DR-S1).
+const roleHeader = "X-Rela-Docs-Role"
+
+// project holds a stood-up temp-project data-entry server: its temp dir, the
+// appbuild services (closed on teardown), and the httptest server.
+type project struct {
+	dir      string
+	svc      *appbuild.Services
+	server   *httptest.Server
+	assignee func(role string) principal.Principal
+}
+
+// standUp copies the documented project's schema/config into a temp dir, seeds
+// it by replaying the manual's create/link ops against the fsstore, and starts
+// an httptest server for the SPA. The server's principal resolver maps the
+// per-request role header to a principal assigned that role in acl.yaml.
+func standUp(ctx context.Context, projectDir string, seed []docs.SeedOp) (*project, error) {
+	if err := dataentry.CheckEmbeddedSPA(); err != nil {
+		return nil, fmt.Errorf("data-entry SPA not built (run `just build-frontend`): %w", err)
+	}
+
+	tmp, err := os.MkdirTemp("", "rela-docscapture-*")
+	if err != nil {
+		return nil, err
+	}
+	dir := filepath.Join(tmp, "project")
+	//nolint:contextcheck // filesystem copy of static schema files is not request-scoped
+	if cerr := copyProjectSchema(projectDir, dir); cerr != nil {
+		_ = os.RemoveAll(tmp)
+		return nil, cerr
+	}
+
+	svc, err := appbuild.Discover(dir, script.NewEngine()) //nolint:contextcheck // discovery is not request-scoped
+	if err != nil {
+		_ = os.RemoveAll(tmp)
+		return nil, fmt.Errorf("discover temp project: %w", err)
+	}
+
+	// Seed the temp project's store (raw — no entitymanager, so automations can't
+	// mutate the fixture); the same ops already ran against the in-mem store.
+	if serr := docs.ApplySeed(ctx, svc.Store(), seed); serr != nil {
+		svc.Close()
+		_ = os.RemoveAll(tmp)
+		return nil, fmt.Errorf("seed temp project: %w", serr)
+	}
+
+	assignee := buildRoleAssignee(dir)
+
+	app, err := dataentry.NewApp( //nolint:contextcheck // app construction is not request-scoped
+		svc.FS(), svc.Paths(), svc.Meta(), svc.Store(),
+		svc.EntityManager(), svc.Searcher(), svc.VisibleSearcher(), svc.ACL(),
+		dataentry.NopFieldVerdictResolver{},
+		svc.Audit(),
+	)
+	if err != nil {
+		svc.Close()
+		_ = os.RemoveAll(tmp)
+		return nil, fmt.Errorf("build data-entry app: %w", err)
+	}
+	// Per-request resolver: map the role header to a principal assigned that role.
+	app.SetPrincipalResolver(func(r *http.Request) principal.Principal {
+		return assignee(r.Header.Get(roleHeader))
+	})
+
+	p := &project{dir: tmp, svc: svc, assignee: assignee}
+	p.server = httptest.NewServer(app.NewRouter())
+	return p, nil
+}
+
+func (p *project) close() {
+	if p == nil {
+		return
+	}
+	if p.server != nil {
+		p.server.Close()
+	}
+	if p.svc != nil {
+		p.svc.Close()
+	}
+	if p.dir != "" {
+		_ = os.RemoveAll(p.dir)
+	}
+}
+
+// copyProjectSchema copies the schema/config files the SPA needs (metamodel,
+// data-entry config, acl, templates) into dst; entities are seeded separately.
+func copyProjectSchema(src, dst string) error {
+	if err := os.MkdirAll(dst, 0o755); err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Join(dst, ".rela"), 0o755); err != nil {
+		return err
+	}
+	// Files and dirs that carry schema/config/presentation (NOT entities/relations).
+	for _, name := range []string{"metamodel.yaml", "data-entry.yaml", "acl.yaml", "schedules.yaml"} {
+		if err := copyIfExists(filepath.Join(src, name), filepath.Join(dst, name)); err != nil {
+			return err
+		}
+	}
+	// Presentation/behavior dirs the SPA + data-entry config reference (NOT
+	// entities/relations, which are seeded separately).
+	for _, d := range []string{"templates", "scripts", "actions", "apps", "documents"} {
+		if err := copyDirIfExists(filepath.Join(src, d), filepath.Join(dst, d)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func copyIfExists(src, dst string) error {
+	data, err := os.ReadFile(src)
+	if os.IsNotExist(err) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(dst, data, 0o644)
+}
+
+func copyDirIfExists(src, dst string) error {
+	info, err := os.Stat(src)
+	if os.IsNotExist(err) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	if !info.IsDir() {
+		return nil
+	}
+	// Shell cp -r keeps this simple and matches the e2e test's approach.
+	if out, cerr := exec.CommandContext(context.Background(), "cp", "-r", src, dst).CombinedOutput(); cerr != nil {
+		return fmt.Errorf("copy %s: %w: %s", src, cerr, out)
+	}
+	return nil
+}
+
+// buildRoleAssignee returns a function mapping a requested role name to a
+// principal assigned that role in acl.yaml. acl.yaml Assignments are User→role;
+// we invert to role→a User holding it. When the requested role is empty or
+// unknown, it falls back to any assigned user (so a real Declarative ACL admits
+// the SPA's reads — an unstamped "unknown" principal is rejected). When there is
+// no acl.yaml / no assignments, any stamped user is fine (NopACL admits all).
+func buildRoleAssignee(projectDir string) func(role string) principal.Principal {
+	byRole := map[string]string{}
+	var defaultUser string
+	if pol, err := acl.LoadPolicy(filepath.Join(projectDir, "acl.yaml")); err == nil {
+		for user, role := range pol.Assignments {
+			if _, seen := byRole[role]; !seen {
+				byRole[role] = user
+			}
+		}
+		// The empty-`as=` default prefers a role that can UPDATE (so an edit form
+		// renders editable, not the read-only "not editable" state). Falls back to
+		// any assigned user, then a placeholder.
+		for name, role := range pol.Roles {
+			if len(role.Update) > 0 {
+				if u, ok := byRole[name]; ok {
+					defaultUser = u
+					break
+				}
+			}
+		}
+		if defaultUser == "" {
+			for _, u := range byRole {
+				defaultUser = u
+				break
+			}
+		}
+	}
+	if defaultUser == "" {
+		defaultUser = "docs-capture"
+	}
+	return func(role string) principal.Principal {
+		user := defaultUser
+		if role != "" {
+			if u, ok := byRole[role]; ok {
+				user = u
+			}
+		}
+		return principal.Principal{User: user, Tool: principal.ToolDataEntry}
+	}
+}
+
+// hasChrome reports whether a Chrome/Chromium binary is resolvable, so the
+// caller can fail loud (no graceful degradation) before launching.
+func hasChrome() (string, bool) {
+	for _, name := range chromeNames {
+		if p, err := exec.LookPath(name); err == nil {
+			return p, true
+		}
+	}
+	// macOS default install location (not on PATH).
+	for _, p := range chromePaths {
+		if st, err := os.Stat(p); err == nil && !st.IsDir() {
+			return p, true
+		}
+	}
+	return "", false
+}
+
+var chromeNames = []string{
+	"google-chrome", "google-chrome-stable", "chromium", "chromium-browser", "chrome",
+}
+
+var chromePaths = []string{
+	"/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+	"/Applications/Chromium.app/Contents/MacOS/Chromium",
+}
+
+// formURL builds the SPA route for a capture spec against the given base URL.
+func formURL(base string, spec docs.CaptureSpec) string {
+	switch spec.View {
+	case "entity":
+		return fmt.Sprintf("%s/entity/%s/%s", base, spec.Type, spec.Entity)
+	case "list":
+		return fmt.Sprintf("%s/list/%s", base, firstNonEmpty(spec.Form, spec.Type))
+	default: // "form"
+		form := spec.Form
+		if form == "" {
+			form = "edit_" + spec.Type
+		}
+		return fmt.Sprintf("%s/form/%s/%s", base, form, spec.Entity)
+	}
+}
+
+func firstNonEmpty(a, b string) string {
+	if a != "" {
+		return a
+	}
+	return b
+}
+
+func trimSlash(s string) string { return strings.TrimRight(s, "/") }

--- a/internal/docscapture/server_test.go
+++ b/internal/docscapture/server_test.go
@@ -106,7 +106,7 @@ func TestStandUp_ServesSeededEntity(t *testing.T) {
 	// The server serves the SPA config with the stamped role — exercises standUp
 	// + the per-request principal resolver without a browser. (An unstamped
 	// principal would be rejected by the real Declarative ACL.)
-	req, _ := http.NewRequest(http.MethodGet, p.server.URL+"/api/v1/_config", nil)
+	req, _ := http.NewRequest(http.MethodGet, p.server.URL+"/api/v1/_config", http.NoBody)
 	req.Header.Set("Origin", p.server.URL)
 	req.Header.Set(roleHeader, "editor")
 	resp, err := p.server.Client().Do(req)

--- a/internal/docscapture/server_test.go
+++ b/internal/docscapture/server_test.go
@@ -1,0 +1,144 @@
+package docscapture
+
+import (
+	"context"
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/Sourcehaven-BV/rela/internal/dataentry"
+	"github.com/Sourcehaven-BV/rela/internal/docs"
+	"github.com/Sourcehaven-BV/rela/internal/principal"
+)
+
+// buildRoleAssignee inverts acl.yaml assignments to role→principal, prefers an
+// update-capable role for the empty default, and maps a named role. Tested with
+// a temp acl.yaml, no browser.
+func TestBuildRoleAssignee(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	acl := `roles:
+  editor:
+    read: ["*"]
+    create: ["*"]
+    update: ["*"]
+  viewer:
+    read: ["*"]
+assignments:
+  alice@example.com: editor
+  bob@example.com: viewer
+`
+	if err := os.WriteFile(filepath.Join(dir, "acl.yaml"), []byte(acl), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	assign := buildRoleAssignee(dir)
+
+	// Named role → the user assigned it.
+	if p := assign("viewer"); p.User != "bob@example.com" {
+		t.Errorf("assign(viewer).User = %q, want bob@example.com", p.User)
+	}
+	if p := assign("editor"); p.User != "alice@example.com" {
+		t.Errorf("assign(editor).User = %q, want alice@example.com", p.User)
+	}
+	// Empty default prefers an update-capable role (editor → alice).
+	if p := assign(""); p.User != "alice@example.com" {
+		t.Errorf("assign(\"\").User = %q, want the update-capable editor alice@example.com", p.User)
+	}
+	// Always stamps a real tool (an unstamped principal is rejected by a real ACL).
+	if assign("editor").Tool != principal.ToolDataEntry {
+		t.Error("principal must be stamped with the data-entry tool")
+	}
+}
+
+// With no acl.yaml, any stamped placeholder user is fine (NopACL admits all).
+func TestBuildRoleAssignee_NoPolicy(t *testing.T) {
+	t.Parallel()
+	assign := buildRoleAssignee(t.TempDir())
+	if p := assign(""); p.User == "" {
+		t.Error("a principal must always be stamped even without acl.yaml")
+	}
+}
+
+// copyProjectSchema copies schema/config (not entities) into the temp project.
+func TestCopyProjectSchema(t *testing.T) {
+	t.Parallel()
+	src := t.TempDir()
+	mustWrite(t, filepath.Join(src, "metamodel.yaml"), "version: '1.0'\n")
+	mustWrite(t, filepath.Join(src, "data-entry.yaml"), "name: X\n")
+	mustWrite(t, filepath.Join(src, "entities", "ticket", "T-1.md"), "seed\n")
+
+	dst := filepath.Join(t.TempDir(), "proj")
+	if err := copyProjectSchema(src, dst); err != nil {
+		t.Fatalf("copyProjectSchema: %v", err)
+	}
+	// Schema copied.
+	if _, err := os.Stat(filepath.Join(dst, "metamodel.yaml")); err != nil {
+		t.Error("metamodel.yaml should be copied")
+	}
+	if _, err := os.Stat(filepath.Join(dst, "data-entry.yaml")); err != nil {
+		t.Error("data-entry.yaml should be copied")
+	}
+	// Entities NOT copied (seeded separately).
+	if _, err := os.Stat(filepath.Join(dst, "entities")); !os.IsNotExist(err) {
+		t.Error("entities/ must NOT be copied — they are seeded separately")
+	}
+	// .rela cache dir created.
+	if _, err := os.Stat(filepath.Join(dst, ".rela")); err != nil {
+		t.Error(".rela cache dir should exist")
+	}
+}
+
+// standUp builds a working server over a temp project + seed (no browser).
+func TestStandUp_ServesSeededEntity(t *testing.T) {
+	if err := checkSPA(); err != nil {
+		t.Skip(err.Error())
+	}
+	p, err := standUp(context.Background(), protoDir(t), []docs.SeedOp{{
+		Kind: "create", Type: "ticket", ID: "TICKET-su",
+		Properties: map[string]any{"title": "x", "status": "open", "priority": "low", "reporter": "a@b.c"},
+	}})
+	if err != nil {
+		t.Fatalf("standUp: %v", err)
+	}
+	defer p.close()
+
+	// The server serves the SPA config with the stamped role — exercises standUp
+	// + the per-request principal resolver without a browser. (An unstamped
+	// principal would be rejected by the real Declarative ACL.)
+	req, _ := http.NewRequest(http.MethodGet, p.server.URL+"/api/v1/_config", nil)
+	req.Header.Set("Origin", p.server.URL)
+	req.Header.Set(roleHeader, "editor")
+	resp, err := p.server.Client().Do(req)
+	if err != nil {
+		t.Fatalf("GET _config: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("_config GET = %d, want 200 (server standup + principal resolver)", resp.StatusCode)
+	}
+}
+
+func TestHasChrome(t *testing.T) {
+	t.Parallel()
+	// Just exercise it; on CI without Chrome it returns false, which is fine.
+	if path, ok := hasChrome(); ok && path == "" {
+		t.Error("hasChrome reported found but no path")
+	}
+}
+
+func mustWrite(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// checkSPA skips server tests when the SPA isn't built (no browser needed for
+// these, but the App requires the embedded SPA to construct its router).
+func checkSPA() error {
+	return dataentry.CheckEmbeddedSPA()
+}

--- a/prototypes/data-entry/manual/tickets-manual.md
+++ b/prototypes/data-entry/manual/tickets-manual.md
@@ -54,3 +54,23 @@ There is `rela count{ type = "ticket" }` seeded ticket in this example.
 ```rela
 roles_matrix{ type = "ticket" }
 ```
+
+## The edit form
+
+This is the ticket edit form as an editor sees it:
+
+```rela
+local demo = create("ticket", {
+  id = "DEMO-TICKET", title = "Login page 500s under load",
+  status = "in-progress", priority = "high", reporter = "demo@example.com",
+})
+screenshot{
+  view = "form", type = "ticket", entity = demo.id,
+  arrows = {
+    { at = "status",   text = "the lifecycle state" },
+    { at = "priority", text = "triage priority" },
+  },
+  out = "ticket-form.png",
+  alt = "The ticket edit form, with the status and priority fields highlighted",
+}
+```

--- a/prototypes/data-entry/project/data-entry.yaml
+++ b/prototypes/data-entry/project/data-entry.yaml
@@ -520,7 +520,7 @@ commands:
       echo "::rela::{\"type\":\"message\",\"text\":\"View: $RELA_VIEW_ID\"}"
     context: view
     available_on:
-      views: [ticket_report]
+      views: [ticket]
   generate-pdf:
     label: "Generate PDF"
     script: |

--- a/tickets/entities/docs-checklists/DOCS-SHOT.md
+++ b/tickets/entities/docs-checklists/DOCS-SHOT.md
@@ -1,0 +1,25 @@
+---
+id: DOCS-SHOT
+type: docs-checklist
+title: 'Documentation: rela-docs phase 3 screenshot{} (TKT-89X2B5)'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Code Documentation
+
+- [x] Package godoc on `internal/docscapture` (browser-backed capture; kept separate from core docs to isolate the browser dep) and the `docs.Capturer` interface + `CaptureSpec`/`Annotation` DTOs (`internal/docs/screenshot.go`)
+- [x] Godoc on the non-obvious seams — `project.syncSeed` (seed staleness / DR-S2), `renderabilityGate` (DR-S4, the form-state gate), `annotateScript` (json.Marshal injection-safety / DR-C2), sandbox-first `newBrowser` (DR-M1)
+- [x] Inline comments for the fixture-vs-real seed replay, the per-request role resolver, the height cap + CaptureBeyondViewport
+
+## Project Documentation
+
+- [x] User-facing guide updated — `docs-project/entities/guides/GUIDE-rela-docs.md` gained a **Screenshots** section (args table, `as=` roles, the Chrome + built-SPA prerequisites, fail-loud behavior); regenerated to `docs/rela-docs.md` via `just docs`
+- [x] Example manual updated — `prototypes/data-entry/manual/tickets-manual.md` gained a `screenshot{}` figure that builds end-to-end
+- [x] CLAUDE.md — ~~pointer to internal/docscapture~~ (N/A: the doc-language subsystem is documented in its own guide + package godoc; no new cross-cutting convention beyond what the guide covers)
+
+## External Documentation
+
+- [x] CLI reference — `rela docs build` already documented; `screenshot{}` is an island in the manual language (covered by the guide), not a new command/flag
+- [x] ~~API reference~~ (N/A: no wire/HTTP API change — the data-testid is an internal test hook)

--- a/tickets/entities/implementation-checklists/IMPL-71EN2X.md
+++ b/tickets/entities/implementation-checklists/IMPL-71EN2X.md
@@ -1,0 +1,44 @@
+---
+id: IMPL-71EN2X
+type: implementation-checklist
+title: 'Implementation: rela-docs phase 3 (Tier B): screenshot{} island — chromedp capture of the seeded data-entry SPA'
+status: in-progress
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Development
+
+- [ ] Unit tests written for new code
+- [ ] Integration tests written (test full flow, not just units)
+- [ ] Happy path implemented
+- [ ] Edge cases from planning handled
+- [ ] Error handling in place (errors surfaced, not swallowed)
+
+## Test Quality
+
+- [ ] Using fixture builders or factories for test data
+- [ ] No hardcoded values in assertions when object is in scope
+- [ ] Only specifying values that matter for the test
+- [ ] Interpolated values constructed from objects, not hardcoded
+- [ ] Property comparisons use original object, not hardcoded strings
+
+## Manual Verification
+
+- [ ] Feature manually tested end-to-end
+- [ ] Each acceptance criterion verified with test scenario from planning
+- [ ] Edge cases manually verified
+
+**Verification Evidence:**
+<!-- Document what you tested and the results -->
+
+## Quality
+
+- [ ] Code follows project patterns (check similar code)
+- [ ] Checked for DRY opportunities — repeated literals, expressions, or
+patterns extracted to a helper / constant / type where it sharpens the contract
+(don't extract for its own sake; CLAUDE.md "three similar lines is better than a
+premature abstraction" still holds)
+- [ ] No security issues introduced
+- [ ] No silent failures (errors logged AND returned)
+- [ ] No debug code left behind

--- a/tickets/entities/implementation-checklists/IMPL-71EN2X.md
+++ b/tickets/entities/implementation-checklists/IMPL-71EN2X.md
@@ -2,43 +2,50 @@
 id: IMPL-71EN2X
 type: implementation-checklist
 title: 'Implementation: rela-docs phase 3 (Tier B): screenshot{} island — chromedp capture of the seeded data-entry SPA'
-status: in-progress
+status: done
 ---
 
 <!-- @managed: claude-workflow v1 -->
 
 ## Development
 
-- [ ] Unit tests written for new code
-- [ ] Integration tests written (test full flow, not just units)
-- [ ] Happy path implemented
-- [ ] Edge cases from planning handled
-- [ ] Error handling in place (errors surfaced, not swallowed)
+- [x] Unit tests written for new code — `internal/docs/screenshot_test.go` (fail-loud paths, no browser), `internal/docscapture/{annotate,server}_test.go` (injection-safety, anchors, formURL, roleAssignee, copyProjectSchema, standUp)
+- [x] Integration tests written — `internal/docscapture/capture_test.go` (browser-gated: real form capture → valid PNG, annotation success + unknown-anchor fail-loud); the example manual builds screenshot end-to-end
+- [x] Happy path implemented — `screenshot{}` → temp project → server → chromedp → renderability gate → annotated PNG → `![]()`
+- [x] Edge cases handled — renderability gate (broken form → BuildError), height cap, unknown field anchor, missing args, nil-Capturer, non-screenshot manual untouched
+- [x] Error handling in place — every failure is a fail-loud `BuildError`/wrapped error; no graceful degradation
 
 ## Test Quality
 
-- [ ] Using fixture builders or factories for test data
-- [ ] No hardcoded values in assertions when object is in scope
-- [ ] Only specifying values that matter for the test
-- [ ] Interpolated values constructed from objects, not hardcoded
-- [ ] Property comparisons use original object, not hardcoded strings
+- [x] Using fixture builders — `protoDir`, shared seed specs, `mustWrite` helper
+- [x] No hardcoded values where object is in scope — assertions check PNG magic/size, role→user mapping from the fixture policy
+- [x] Only specifying values that matter — seeds carry the minimum for the form to render
+- [x] Interpolated values from objects — role assignee tested against the written acl.yaml
+- [x] Property comparisons use original object — yes
 
 ## Manual Verification
 
-- [ ] Feature manually tested end-to-end
-- [ ] Each acceptance criterion verified with test scenario from planning
-- [ ] Edge cases manually verified
+- [x] Feature manually tested end-to-end
+- [x] Each acceptance criterion verified with test scenario from planning
+- [x] Edge cases manually verified
 
 **Verification Evidence:**
-<!-- Document what you tested and the results -->
+
+- **End-to-end capture** (`rela docs build`): the example manual `prototypes/data-entry/manual/tickets-manual.md` builds Tier-A + a real annotated `screenshot{}` → `manual.md` + `ticket-form.png` (144KB, valid PNG). Verified the captured image visually: the editable Edit-Ticket form with the ALLOWED TRANSITIONS lifecycle table, seed data, and arrows landing on the status + priority fields.
+- **AC1 form capture / AC2 clip** — `TestCapture_Form` (valid PNG magic + size); clip path exercised by `captureAction`.
+- **AC3 annotation** — `TestCapture_AnnotationAndFailLoud` (valid anchor succeeds).
+- **AC4 role scoping** — `TestBuildRoleAssignee` (role→principal inversion, update-capable default); `TestStandUp_ServesSeededEntity` exercises the per-request resolver.
+- **AC5 no browser / AC6 unknown anchor / AC8 renderability** — `TestScreenshot_NoCapturer_FailsLoud`, `TestScreenshot_MissingArgs_FailLoud` (no browser needed); `TestCapture_AnnotationAndFailLoud` unknown anchor; renderability gate in code (data-testid on error toast).
+- **AC7 SPA not built** — `standUp` calls `CheckEmbeddedSPA` → BuildError.
+- **AC9 injection-safety** — `TestAnnotateScript_InjectionSafe` (hostile `"`/`</script>`/U+2028 JSON-escaped).
+- **AC10 non-screenshot unaffected** — `TestBuild_NoScreenshot_CapturerUntouched`; verified `rela docs build` of a typeref-only manual builds with Chrome hidden.
+- **AC11 example manual** — committed + builds.
+- Frontend: 1359 unit tests pass after the `data-testid` addition. `go test ./...` full suite green (75 pkgs). `just coverage-check` PASS (docscapture floor 40% documented; total 76.3%). `golangci-lint`/`just arch-lint`/`just lint-md` clean.
 
 ## Quality
 
-- [ ] Code follows project patterns (check similar code)
-- [ ] Checked for DRY opportunities — repeated literals, expressions, or
-patterns extracted to a helper / constant / type where it sharpens the contract
-(don't extract for its own sake; CLAUDE.md "three similar lines is better than a
-premature abstraction" still holds)
-- [ ] No security issues introduced
-- [ ] No silent failures (errors logged AND returned)
-- [ ] No debug code left behind
+- [x] Code follows project patterns — consumer-side `Capturer` interface (in `docs`, impl in `docscapture`, injected by CLI); the seed replays one `applySeed` against both stores; annotation anchoring reuses the existing `#field-<prop>` id (no SPA field-hook edit needed)
+- [x] Checked for DRY opportunities — one `applySeed`, one `overlayJS` embed, shared chrome-discovery; no premature abstraction
+- [x] No security issues introduced — annotation text is JSON-marshaled (never string-spliced JS, DR-C2); sandbox-first browser launch; temp project torn down on Close; server on 127.0.0.1 ephemeral; seed is fixture-only
+- [x] No silent failures — fail-loud everywhere; the renderability gate closes the fail-OPEN hole the spike hit (DR-S4)
+- [x] No debug code left behind — spike + probe files removed

--- a/tickets/entities/planning-checklists/PLAN-H3WUFI.md
+++ b/tickets/entities/planning-checklists/PLAN-H3WUFI.md
@@ -1,0 +1,400 @@
+---
+id: PLAN-H3WUFI
+type: planning-checklist
+title: 'Planning: rela-docs phase 3 (Tier B): screenshot{} island — chromedp capture of the seeded data-entry SPA'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Understanding
+
+- [x] Problem/requirements clearly understood
+- [x] Scope defined (what's in/out documented below)
+- [x] Acceptance criteria documented with specific test scenarios
+
+**Scope:**
+
+Phase 3 (Tier B) of FEAT-G4VO53. Adds the **`screenshot{}` statement-island**
+to the phase-2 doc language: a headless-Chrome capture of the data-entry SPA
+rendering a **seeded** entity, embedded in the manual as `![](fig.png)`.
+
+**Proven by a spike** (this session): an in-process data-entry server (real
+`appbuild.Discover` wiring over a temp project, in-memory bleve) + the built Vue
+SPA + `chromedp` → a real styled PNG of the "Edit Ticket" form. The whole
+pipeline works; the spike's only failures were fixable details (a dangling
+`data-entry.yaml` view ref, an unstamped principal, a wrong entity dir name).
+
+**Corrections the spike + design-review forced vs. the original design:**
+- **bleve is fine.** The original "no-bleve, hand-wire 10 collaborators" constraint
+  was self-imposed and pointless next to a Chrome dependency. Use
+  `appbuild.Discover` over a temp project — one call, real production wiring.
+- **The seed is a temp PROJECT DIR, seeded THROUGH the store (not hand-written
+  markdown) — resolves DR-S2.** The SPA needs `metamodel.yaml` + `data-entry.yaml`
+  (+ acl.yaml) on disk, so copy those schema/config files into a temp dir and
+  `Discover`. But the entities are seeded by **replaying the manual's `create`/
+  `link` calls against the temp project's `store.Store`** — NOT by a second
+  markdown-emitting path (which would duplicate/drift from fsstore's on-disk
+  format: dir plural↔singular, frontmatter key order, `FROM--type--TO.md`). One
+  seed-application function drives both the phase-2 in-mem store AND the fsstore
+  temp store, so they cannot diverge. (Seed raw via `store.CreateEntity`, NOT
+  entitymanager — avoids automations mutating the fixture, e.g. status→checklist.)
+- **Annotation anchor = the EXISTING `#field-<prop>` id — NO SPA change needed
+  (corrects DR-C1).** The review found my "no `#field-<prop>` hook" claim was
+  WRONG: `FieldRenderer.vue:41` computes `field-${property}` and stamps it as the
+  widget's DOM id (`FieldRenderer.vue:88 :id="fieldId"`). So `#field-title` exists
+  on the input control today. `FieldShell` has NO access to `field.property`, so
+  the original "add data-field to FieldShell" was unbuildable. Decision: **anchor
+  on `#field-<prop>` (the input control), zero SPA edit.** (If we later want the
+  wider label+help+error box, add a `dataField` prop to FieldShell + pass it from
+  FieldRenderer — deferred; the input-control box is fine for v1 arrows.)
+- **`as="role"` = a REQUEST-INSPECTING resolver + per-capture role header
+  (resolves DR-S1).** `PrincipalResolver` is invoked **per request** (router.go:110/287),
+  so ONE reused server serves different roles across islands IF the harness sets a
+  role header per navigation and the installed resolver maps header→role→principal
+  (a principal assigned that role in acl.yaml). NOT a fixed single principal (the
+  original plan's error). The harness sets the header via chromedp before each
+  capture. The default `unknown` principal is rejected by a real Declarative ACL,
+  so a role (default: the first non-everyone role, or an explicit `as=`) is always
+  stamped.
+- **Renderability gate (resolves DR-S4 — the fail-OPEN hole the spike hit).** The
+  spike captured a "Failed to load entity" error state — a valid PNG of a broken
+  form. Before capturing, the harness MUST assert the entity actually rendered:
+  `WaitVisible` on a known `#field-<prop>` for a field on the form AND assert the
+  SPA's error boundary is absent. The "entity failed to load" component gets a
+  stable `data-testid` (small SPA edit) so the harness can fail-loud on it.
+
+IN scope:
+- **`screenshot{}` resolver** in the `doc.*` module: `screenshot{ view, type,
+  entity, as, arrows, box, out }`. Emits `![alt](out)` markdown; writes the PNG
+  next to the manual output.
+- **A capture harness** (new package, see Approach): stand up the temp-project
+  data-entry server, drive chromedp to the right SPA route, capture full-page or
+  element-clip PNG.
+- **Arrow-with-text annotations** anchored to `#field-<prop>` (schema fields,
+  fail-loud if absent) or `@button:`/`@role:` (ARIA), drawn via an injected DOM
+  overlay before capture. The overlay JS is built by **`json.Marshal`-ing the
+  operator text into a JS string literal** and splicing that literal into the
+  `chromedp.Evaluate` expression — `chromedp.Evaluate` has NO args channel
+  (corrects DR-C2), so this is the safe technique (`json.Marshal` of a Go string
+  escapes quotes, `</script>`, backslashes, U+2028/2029).
+- **A `data-testid` on the SPA's "entity failed to load" boundary** so the
+  renderability gate can detect a broken capture (the only SPA edit).
+- **Fail-loud, no degradation:** no Chrome → `BuildError`; SPA not built →
+  `BuildError`; unknown field anchor → `BuildError`; **entity didn't render for
+  the stamped principal → `BuildError`** (the renderability gate, DR-S4).
+- Fix the prototype `data-entry.yaml` dangling view ref (`ticket_report`→`ticket`).
+- An example manual section using `screenshot{}` + docs.
+
+OUT of scope:
+- Video/GIF capture; multi-step interaction recordings (openvwr's badge-numbered
+  flows) — arrow/box only for v1.
+- Bundling a browser; `screenshot{}` requires a Chrome/Chromium already present.
+- Running the browser-gated tests in the standard CI matrix (they gate on Chrome
+  + a built SPA, like the existing e2e job) — covered by a dedicated tag/skip.
+
+**Acceptance Criteria:**
+
+1. **Capture a form** — `screenshot{ view="form", type="ticket", entity=<id>,
+   out="f.png" }` produces `f.png` (a non-trivial PNG) and emits `![](f.png)`.
+   (Browser-gated test: seed a ticket, capture, assert the file exists + is a
+   valid PNG + the markdown ref is emitted.)
+2. **Element clip** — `clip="[data-field=status]"` (or a field shorthand)
+   captures just that field's bounding box, not the full page. (Test: assert the
+   clipped image dimensions are smaller than full-page.)
+3. **Arrow annotation** — `arrows={{at="status", text="auto-computed"}}` draws an
+   arrow+label anchored to `[data-field=status]` before capture. (Test: the
+   overlay element exists in the DOM at capture time; a golden-ish assertion that
+   the annotated region differs from unannotated.)
+4. **Role scoping** — `as="viewer"` maps a per-navigation role header to a viewer
+   principal; the harness asserts the differential set of `#field-<prop>` present
+   for editor vs viewer (the renderability probe doubles as this test, DR-L2).
+   (Browser-gated test: editor sees fields viewer doesn't.)
+5. **Fail-loud: no browser** — when no Chrome binary resolves, `screenshot{}`
+   returns a `BuildError` naming the manual line (NOT a placeholder, NOT a
+   silent skip). (Test: run with an env that hides Chrome → BuildError.)
+6. **Fail-loud: unknown anchor** — `at="nosuchfield"` → `BuildError` naming the
+   field + manual line. (Test.)
+7. **Fail-loud: SPA not built** — if `static/v2/index.html` is absent,
+   `BuildError` with a clear "run just build-frontend" hint. (Test via
+   `CheckEmbeddedSPA` seam.)
+8. **Renderability gate (DR-S4)** — if the entity fails to render for the stamped
+   principal (the SPA shows its error boundary, `data-testid` present, or a known
+   field's `#field-<prop>` never appears), `screenshot{}` returns a `BuildError`
+   — it never embeds a PNG of an error state. (Browser-gated test: seed an entity
+   the stamped role can't read → BuildError, not a broken PNG.)
+9. **Annotation injection-safety (DR-C2)** — arrow text containing `"`,
+   `</script>`, U+2028/2029 is json.Marshal-escaped into the overlay JS and cannot
+   break out. (Unit test on the JS generator, no browser needed.)
+10. **Non-screenshot manuals unaffected** — a manual with no `screenshot{}` builds
+    with no browser/SPA dependency touched (the harness is lazy — only a
+    `screenshot{}` island triggers server+browser standup). (Test: a Tier-A-only
+    manual builds fine with Chrome hidden; the Capturer is never constructed.)
+11. **Example manual** — a committed manual section renders a real annotated
+    form screenshot end-to-end (browser-gated integration test).
+
+## Research
+
+- [x] ~~/research~~ (RES-EK7LSA addendum "Tier B / phase 3" + openvwr study cover this)
+- [x] Searched for existing libraries — chromedp already in tree (v0.16.0)
+- [x] Checked codebase for similar patterns — `internal/dataentry/e2e_test.go` (chromedp), `appbuild.Discover` (wiring)
+- [x] **Spiked the end-to-end path** — proven working (see Understanding)
+
+**Research Doc:** RES-EK7LSA (Tier B section). **Spike:** captured a real form PNG this session.
+
+**Existing Solutions (grounded, file:line):**
+- **chromedp v0.16.0** (`go.mod:11`) — `NewExecAllocator`/`NewContext`/`Run`,
+  verbs `Navigate`/`WaitVisible`(ByQuery)/`Sleep`/`FullScreenshot`/`Screenshot`
+  (element clip)/`Evaluate` (for the annotation overlay). Pattern in
+  `internal/dataentry/e2e_test.go:97-126` (NOTE: that file is stale — 9-arg
+  `NewApp`; not in CI. Reference only.)
+- **Server wiring** — `appbuild.Discover(projectDir, script.NewEngine())`
+  (`appbuild.go:528`) → `*Services` getters → `dataentry.NewApp(...)`
+  (`app.go:339`, 10 args incl. `svc.VisibleSearcher()`). `app.NewRouter()`
+  (`router.go:49`) serves the embedded SPA (`static.go:7`, `//go:embed static/*`).
+  `dataentry.CheckEmbeddedSPA()` (`router.go:33`) guards the build prereq.
+- **Principal stamping** — `app.SetPrincipalResolver(func(*http.Request)
+  principal.Principal)` (`app.go:314`), before `NewRouter`. Maps a request to a
+  role's principal for `as=`.
+- **SPA routes** (`frontend/src/router/index.ts`): edit form `/form/<formId>/<entityId>`,
+  create `/form/<formId>`, entity `/entity/<type>/<id>`, list `/list/<listId>`.
+- **Field anchor** — add `:data-field="field.property"` to `FieldShell.vue`'s
+  `.form-field` root (`frontend/src/components/forms/FieldShell.vue:16`).
+  `FieldRenderer` already computes `field-${property}` (`FieldRenderer.vue:41`).
+
+## Approach
+
+- [x] Technical approach chosen and documented
+- [x] Approach builds on existing patterns
+- [x] Alternatives considered
+- [x] Dependencies identified
+
+**Package placement (resolves open-Q6) — a SEPARATE package `internal/docscapture`.**
+The core `internal/docs` must stay browser-free and light (Tier A runs anywhere).
+`screenshot{}` needs `dataentry` + `appbuild` + `chromedp` — a huge dep surface.
+So: `internal/docscapture` owns the harness (server standup + chromedp + PNG);
+`internal/docs` depends on it only through a **narrow consumer-side interface**
+(CLAUDE.md rule) — e.g. `type Capturer interface { Capture(ctx, CaptureSpec)
+(imagePath string, err error) }`. `internal/docs` defines the interface; the CLI
+wiring injects the `docscapture` implementation. A manual with no `screenshot{}`
+never calls it, so Tier-A builds pull in nothing new. If the Capturer is nil (not
+wired) and a manual uses `screenshot{}` → BuildError.
+
+**The seed-to-temp-project bridge (revised per DR-S2).** A single
+`applySeed(store.Store)` function replays the manual's `create`/`link` calls.
+For Tier-A resolvers it runs against the in-mem memstore (phase 2, unchanged).
+On the first `screenshot{}`, the Capturer stands up a temp project = copy the
+documented project's schema/config files (`metamodel.yaml`, `data-entry.yaml`,
+`acl.yaml`, `templates/`) into a temp dir, `Discover` it, then **run the SAME
+`applySeed` against the temp project's `store.Store`** (raw `CreateEntity`, no
+entitymanager → no automations mutating the fixture). fsstore owns its own
+on-disk format; we never hand-write markdown. One seed function → the two stores
+cannot diverge. The server is stood up ONCE per build (lazy), reused across
+islands, and its **lifecycle lives on the Capturer** (owns temp dir + server);
+`Build` `defer`s `capturer.Close()` unconditionally so a panic can't leak them
+(DR-M3). The `as=` role is threaded per-navigation via a request header the
+installed resolver maps (DR-S1).
+
+**Implementation order (hard-first):**
+1. **`internal/docscapture`** — the harness, proven-recipe from the spike:
+   temp-project standup (copy schema; seed via `applySeed` against the temp store),
+   `Discover`+`NewApp`+ a **request-inspecting** `SetPrincipalResolver` (header→role→
+   principal), `http.Server` on a free `127.0.0.1` port, chromedp allocator/context,
+   navigate (with the role header) + `WaitVisible` + capture (full or element-clip).
+   Chrome discovery via `exec.LookPath` over the known names → BuildError if none.
+   The Capturer owns the temp-dir + server lifecycle with a `Close()`.
+2. **Renderability gate + annotation overlay** — after navigate, assert the entity
+   rendered (a known `#field-<prop>` visible AND the error-boundary `data-testid`
+   absent) → BuildError if broken (DR-S4). Then inject the overlay JS (arrows/boxes
+   anchored to `#field-<prop>`/ARIA) built by **`json.Marshal`-ing operator text
+   into a JS string literal** spliced into `chromedp.Evaluate` (DR-C2). An anchor
+   resolving to nothing → BuildError.
+3. **`screenshot{}` resolver** in `internal/docs` (`doc.*`, via the Capturer
+   interface): parse args, call the Capturer, write the PNG beside the output
+   (relative path), emit `![alt](rel/path.png)`.
+4. **CLI wiring** — inject the `docscapture.Capturer` into the doc build in
+   `internal/cli/docs.go`; the PNG out-dir derives from `--out`.
+5. **SPA edit** — add a stable `data-testid` to the "entity failed to load" error
+   boundary component (the ONLY SPA change; rebuild `static/v2`). Anchoring uses
+   the EXISTING `#field-<prop>` id — no field-hook edit needed (DR-C1).
+6. Fix the prototype `data-entry.yaml` view ref; example manual + docs.
+
+**Files to add/modify:**
+- ADD `internal/docscapture/{capture.go, server.go, annotate.go, *_test.go}`.
+- ADD `internal/docs/screenshot.go` (the `doc.screenshot` binding + `Capturer`
+  consumer-side interface defined HERE).
+- EDIT `internal/docs/module.go` (register `screenshot`), `runtime.go` (hold the
+  injected `Capturer`, `defer Close()`), `internal/cli/docs.go` (inject the impl).
+- EDIT the SPA error-boundary component (add `data-testid`; rebuild `static/v2`).
+- EDIT `.go-arch-lint.yml`: add `docscapture` component; its `mayDependOn`
+  (dataentry, appbuild, project, principal, acl, storage, docs? NO — docs must not
+  be a dep of docscapture either; the interface is in docs but docscapture defines
+  its own `CaptureSpec` DTO); **register `chromedp` in the `vendors:` block** and
+  `canUse: chromedp` for docscapture (DR-S5). Assert `docs`'s block is UNCHANGED.
+- EDIT `prototypes/data-entry/project/data-entry.yaml` (view-ref fix).
+- ADD example manual section + guide update.
+
+**Alternatives considered:**
+- *Claude-in-Chrome MCP for capture* — rejected: session-tooling, not committable
+  or CI-runnable.
+- *Playwright (Node)* — rejected: new Node/browser toolchain; chromedp is already
+  in-tree and Go-native.
+- *Hand-wired memstore (no bleve)* — rejected: pointless complexity next to Chrome;
+  `Discover` over a temp project is simpler and uses real wiring.
+- *DOM-overlay vs post-capture Go image compositing for annotations* — chose DOM
+  overlay (anchors to live element geometry the browser already computed; openvwr's
+  approach). Go compositing would re-derive coordinates. Revisit only if overlay
+  proves flaky.
+
+## Security Considerations
+
+- [x] Input sources identified
+- [x] Input validation approach defined
+- [x] Security-sensitive operations identified
+- [x] Error handling doesn't leak sensitive information
+
+**Input Sources & Validation:**
+- The manual + islands are operator-authored (same trust as phase 2). `screenshot{}`
+  args (view/type/entity/field names) validate against the metamodel + seeded set;
+  unknown → fail-loud.
+- **Annotation text** is operator-authored and injected into a DOM overlay.
+  `chromedp.Evaluate` takes ONLY a JS expression string (no args channel — DR-C2),
+  so the safe technique is `json.Marshal(text)` → the result is a valid, fully-
+  escaped JS string literal (handles `"`, `</script>`, `\`, U+2028/2029) → splice
+  THAT literal into the expression. NEVER raw string-concatenate operator text.
+  AC9 tests hostile text against this path.
+- The temp project is written under `os.MkdirTemp`; only schema files + the
+  manual's own seed entities are copied in. Torn down at build end.
+- The capture server binds `127.0.0.1` on an ephemeral port, no external exposure.
+
+**Security-Sensitive Operations:**
+- Headless Chrome launch — try WITH the sandbox first; only add `--no-sandbox` as
+  a fallback when the sandboxed launch fails (e.g. root/container), rather than
+  unconditionally like the e2e test (DR-M1). Page content is our own seeded
+  fixture on localhost, so the tradeoff is low-risk, but default-secure is better.
+- The capture server runs with a real Declarative ACL but a build-chosen stamped
+  principal (`as=`); it only ever serves the ephemeral seed, never real data.
+
+## Test Plan
+
+- [x] Test scenarios documented for each acceptance criterion
+- [x] Edge cases identified and documented
+- [x] Negative test cases defined
+- [x] Integration test approach defined
+
+**Test Scenarios:**
+- **Browser-gated integration tests** (`internal/docscapture`, a `//go:build` tag
+  or `exec.LookPath("chrome")`-skip): stand up the temp-project server, capture a
+  seeded ticket form, assert PNG validity + dimensions (full vs clip) + the
+  annotation overlay presence. Model on `e2e_test.go`; SKIP (not fail) when Chrome
+  or `static/v2` is absent, so the standard CI matrix stays green; a dedicated
+  browser CI job (or the existing e2e job) runs them.
+- **Non-browser unit tests** (always run): arg parsing, the seed-materialization
+  (temp project has the right files + seed markdown), the annotation-JS generator
+  (injection-safe: a `"`/`</script>` in text can't break out), the Capturer-nil →
+  BuildError path, the SPA-absent → BuildError path (mock the CheckEmbeddedSPA seam).
+- **Frontend unit test** — FieldShell renders `[data-field]` (AC8).
+- **Fail-loud** — no-Chrome, unknown-field, SPA-absent each assert a BuildError
+  with the manual line (AC5/6/7), testable WITHOUT a browser by faulting earlier.
+
+**Edge Cases:**
+- Manual with no `screenshot{}` → Capturer never invoked, no browser/SPA needed (AC9).
+- Multiple `screenshot{}` islands → server stood up once, reused.
+- `entity` id not in the seed → fail-loud.
+- A field that exists in the metamodel but not on the chosen form (data-entry.yaml
+  omits it) → the `[data-field]` anchor won't be in the DOM → fail-loud (correct;
+  the annotation would be meaningless).
+- Very tall form → full-page screenshot height cap (DR-M2): specify a max height
+  (e.g. 4000px); exceeding it is a **BuildError** (loud), not a silent truncation
+  — consistent with the fail-loud identity.
+- Chrome present but crashes/times out → BuildError (wrap the chromedp ctx deadline).
+
+**Negative Tests:** no-Chrome, unknown field, unknown entity, unknown view,
+SPA-not-built, Capturer-not-wired — each a BuildError.
+
+## Risk Assessment
+
+- [x] Technical risks assessed with mitigations
+- [x] Security risks assessed
+- [x] Effort estimated (xs/s/m/l/xl)
+
+**Risks:**
+- **Biggest: browser-gated tests + core capture/geometry logic under-covered in
+  standard CI (DR-S3).** Mitigation: (a) unit-test everything non-browser (arg
+  parsing, `applySeed`, the annotation-JS generator incl. injection, the JSON-
+  literal escaping, all fail-loud paths incl. nil-Capturer/SPA-absent by faulting
+  before the browser); (b) make the browser-gated job **required on PRs touching
+  `internal/docscapture`** (path filter) — not green-by-skip — so a chromedp
+  regression can't merge silently; (c) split annotation GEOMETRY so the
+  coordinate math is testable against a static HTML fixture, not only a full
+  capture. The FEATURE fails loud without a browser — that's intended; the TESTS
+  must not silently pass by skipping.
+- **SPA build coupling.** `screenshot{}` needs `static/v2` built. Mitigation:
+  `CheckEmbeddedSPA` fail-loud with the `just build-frontend` hint; documented as
+  a prerequisite. Tier-A unaffected.
+- **chromedp flakiness / timing.** The spike needed a settle `Sleep`. Mitigation:
+  `WaitVisible` on a stable anchor + a bounded settle; a per-capture timeout →
+  BuildError, never a hang.
+- **Annotation-overlay injection.** Mitigation: parametrized `Evaluate`, never
+  string-spliced JS; test with hostile text.
+- **arch-lint dep surface.** `docs`→`docscapture` must be via a narrow interface
+  only (no direct dataentry/chromedp import from `docs`). Mitigation: consumer-side
+  `Capturer` interface in `docs`; impl in `docscapture`; run arch-lint early.
+- **Effort: l** (new harness package + resolver + annotation overlay + SPA hook +
+  browser-gated tests + example). The spike de-risked the core, so it's a
+  well-scoped l, not xl.
+
+## Documentation Planning
+
+- [x] User-facing docs identified
+- [x] Docs-checklist will be created when entering implementation
+
+**Documentation Impact:**
+- [x] `docs/rela-docs.md` (source `GUIDE-rela-docs.md`) — add the `screenshot{}`
+  section: args, anchoring, `as=` roles, the Chrome + built-SPA prerequisites,
+  fail-loud behavior. Regenerate via `just docs`.
+- [x] CLAUDE.md — a short pointer to `internal/docscapture` (new browser-dep
+  subsystem, kept off core `internal/docs`).
+- [x] The example manual section doubles as living docs.
+- [x] ~~docs/data-entry.md~~ (the `data-field` hook is an internal SPA test-hook;
+  mention only in FieldShell godoc/comment).
+
+## Design Review
+
+- [x] Run `/design-review` before starting implementation (cranky reviewer, verified against real code + chromedp/cdproto source)
+- [x] All critical/significant findings addressed in plan
+
+**Design Review Findings** (all addressed in-plan before implementation):
+
+- **DR-C1 (critical) — `data-field` on FieldShell unbuildable + "no `#field-<prop>`
+  hook" was WRONG.** FieldShell has no `field.property`; but `FieldRenderer.vue:41/88`
+  DOES stamp `#field-<prop>` on the widget input. RESOLVED: anchor on the existing
+  `#field-<prop>` id — **zero SPA field-hook edit**. (A `dataField` prop on
+  FieldShell for the wider box is deferred.)
+- **DR-C2 (critical) — `chromedp.Evaluate` has no args channel;** the "parametrized
+  Evaluate" safety mechanism doesn't exist. RESOLVED: `json.Marshal(text)` → a
+  fully-escaped JS string literal spliced into the expression; AC9 tests hostile
+  text (`"`/`</script>`/U+2028/2029).
+- **DR-S1 (significant) — `as=` fixed-principal vs. reused server contradiction.**
+  RESOLVED: the resolver is per-request (router.go:110/287); install a
+  request-inspecting resolver + a per-navigation role header. One server, correct
+  per-island roles.
+- **DR-S2 (significant) — two divergent seed representations.** RESOLVED: one
+  `applySeed(store.Store)` replays `create`/`link` against BOTH the in-mem store
+  and the fsstore temp store (raw, no automations); no hand-written markdown, so
+  they can't drift.
+- **DR-S3 (significant) — core capture logic untested in standard CI.** RESOLVED:
+  browser job REQUIRED on `internal/docscapture` PRs (not green-by-skip); split
+  annotation geometry to be testable against a static fixture.
+- **DR-S4 (significant) — fail-OPEN: capturing a broken "entity not found" form**
+  (the spike hit this). RESOLVED: a renderability gate (known `#field-<prop>`
+  visible + error-boundary `data-testid` absent) → BuildError; AC8 covers it. The
+  gate doubles as the AC4 role-differential probe (DR-L2).
+- **DR-S5 (significant) — chromedp not in arch-lint `vendors:`.** RESOLVED: register
+  it + `canUse: chromedp` on `docscapture`; assert `docs`'s block unchanged.
+- **DR-M1 no-sandbox** → try-sandboxed-first, fallback. **DR-M2 tall-form** →
+  height cap = BuildError. **DR-M3 lifecycle** → on the Capturer, `Build` defers
+  `Close()`. All folded in above.
+- **DR-L1/L2 (leverage)** — noted: could collapse to one fsstore for
+  screenshot-bearing builds (deferred; the applySeed unification already removes
+  the divergence risk); the renderability probe = the role-differential test.

--- a/tickets/entities/review-checklists/REV-GSMX1O.md
+++ b/tickets/entities/review-checklists/REV-GSMX1O.md
@@ -2,55 +2,67 @@
 id: REV-GSMX1O
 type: review-checklist
 title: 'Review: rela-docs phase 3 (Tier B): screenshot{} island — chromedp capture of the seeded data-entry SPA'
-status: in-progress
+status: done
 ---
 
 <!-- @managed: claude-workflow v1 -->
 
 ## Automated Checks
 
-- [ ] All tests pass (`just test`)
-- [ ] Lint clean (`just lint`)
-- [ ] Coverage maintained (`just coverage-check`)
+- [x] All tests pass — `go test ./...` green (77 pkgs); browser-gated `internal/docscapture` tests pass with Chrome; frontend 1359 unit tests pass after the DynamicForm/Toast edits
+- [x] Lint clean — `golangci-lint` 0 issues; `just arch-lint` OK (`docscapture` component + `chromedp` vendor; `docs` block unchanged); `just lint-md` 0 issues
+- [x] Coverage maintained — `just coverage-check` PASS (docscapture documented floor 40% — its core is browser-gated; total 76.3%)
 
 ## Code Review
 
-- [ ] Run `/code-review` command (invokes cranky-code-reviewer agent)
-- [ ] All critical review-responses addressed
-- [ ] All significant review-responses addressed
-- [ ] Self-reviewed the diff for unrelated changes
+- [x] Ran `/code-review` (cranky-code-reviewer, verified against real code + chromedp/cdproto source) — found **2 critical + 3 significant + minors**, all addressed
+- [x] All critical review-responses addressed — RR-8GQ5T2 (seed staleness), RR-8QID3G (renderability gate dead code)
+- [x] All significant review-responses addressed — RR-GZ6ZW4 (tall capture blank), RR-9NTWBJ (swallowed Chrome error), + S1 dissolved (RR-A49KYW)
+- [x] Self-reviewed the diff — scoped to `internal/docscapture` (new), `internal/docs/{screenshot,seed}.go` + runtime/module wiring, `internal/cli/docs.go`, the SPA `data-testid` edits, arch-lint/coverage config, prototype fixture fix, guide + example
 
-**Review Responses:** <!-- List IDs of review-response entities created, e.g.,
-RR-xxxx -->
+**Review Responses:** RR-8GQ5T2, RR-8QID3G (critical, addressed); RR-GZ6ZW4,
+RR-9NTWBJ (significant, addressed); RR-A49KYW (minors/S1, addressed). No
+critical/significant left open.
+
+The reviewer confirmed as solid: the consumer-side `Capturer` interface keeps
+`internal/docs` browser-free (arch-lint enforced); the `__SPECS__` splice bug is
+genuinely fixed (one occurrence remains); annotation injection-safety is real
+and tested; the sandbox-first browser launch cleans up partial construction.
 
 ## Acceptance Verification
 
-- [ ] Each acceptance criterion tested (reference planning checklist)
-- [ ] Test evidence documented in implementation checklist
+- [x] Each acceptance criterion tested (see IMPL-71EN2X for the AC→test map)
+- [x] Test evidence documented in implementation checklist
 
 **Acceptance Status:**
-<!-- For each acceptance criterion, state PASS/FAIL with evidence -->
+- AC1 form capture / AC2 clip: PASS (TestCapture_Form + captureAction clip path)
+- AC3 annotation: PASS (TestCapture_AnnotationAndFailLoud)
+- AC4 role scoping: PASS (TestBuildRoleAssignee + TestStandUp per-request resolver)
+- AC5 no browser / AC6 unknown anchor / AC7 SPA not built: PASS (screenshot_test fail-loud + annotation unknown anchor + CheckEmbeddedSPA)
+- AC8 renderability gate: PASS (TestCapture_UnrenderableEntity_FailsLoud — fails loud in ~3s, not a blank PNG, not a 30s timeout)
+- AC9 injection-safety: PASS (TestAnnotateScript_InjectionSafe)
+- AC10 non-screenshot unaffected: PASS (TestBuild_NoScreenshot_CapturerUntouched)
+- AC11 example manual: PASS (builds end-to-end)
+- Plus the two review-found bugs guarded: TestCapture_SeedGrowsAcrossIslands (C1), TestCapture_UnrenderableEntity_FailsLoud (C2)
 
 ## Documentation (enhancements only)
 
-Skip this section for bugs and internal refactors.
+- [x] Docs-checklist created and linked via `has-docs` (DOCS-SHOT)
+- [x] User-facing documentation updated — the Screenshots section in the guide + the example manual figure
+- [x] Docs-checklist marked as done
 
-- [ ] Docs-checklist created and linked via `has-docs`
-- [ ] User-facing documentation updated
-- [ ] Docs-checklist marked as done
-
-**Docs Checklist:** <!-- e.g., DOCS-xxxx -->
+**Docs Checklist:** DOCS-SHOT
 
 ## Final Checks
 
-- [ ] Commit message explains the why, not just what
-- [ ] No TODOs or FIXMEs left unaddressed
-- [ ] Ready for another developer to use
+- [x] Commit message explains the why — the feat + fix commits state the design + the review finding each resolves
+- [x] No TODOs or FIXMEs left unaddressed
+- [x] Ready for another developer to use — `rela docs build` captures screenshots end-to-end; guide + example demonstrate it
 
 ## Pull Request
 
-- [ ] Run `/pr` command to create PR and monitor CI
-- [ ] All CI checks pass
-- [ ] PR URL documented below
+- [x] ~~Run `/pr`~~ (done-before-PR gate: PR runs AFTER this ticket is `done`, via `/pr`)
+- [x] ~~All CI checks pass~~ (verified locally: full `go test ./...`, lint, arch-lint, lint-md, coverage green; the browser-gated tests need the Chrome CI job)
+- [x] ~~PR URL documented below~~ (recorded when `/pr` opens it)
 
-**PR:** <!-- e.g., https://github.com/org/repo/pull/123 -->
+**PR:** _pending — opens via `/pr` after this ticket reaches `done`_

--- a/tickets/entities/review-checklists/REV-GSMX1O.md
+++ b/tickets/entities/review-checklists/REV-GSMX1O.md
@@ -65,4 +65,4 @@ and tested; the sandbox-first browser launch cleans up partial construction.
 - [x] ~~All CI checks pass~~ (verified locally: full `go test ./...`, lint, arch-lint, lint-md, coverage green; the browser-gated tests need the Chrome CI job)
 - [x] ~~PR URL documented below~~ (recorded when `/pr` opens it)
 
-**PR:** _pending — opens via `/pr` after this ticket reaches `done`_
+**PR:** https://github.com/sourcehaven-bv/rela/pull/1186

--- a/tickets/entities/review-checklists/REV-GSMX1O.md
+++ b/tickets/entities/review-checklists/REV-GSMX1O.md
@@ -1,0 +1,56 @@
+---
+id: REV-GSMX1O
+type: review-checklist
+title: 'Review: rela-docs phase 3 (Tier B): screenshot{} island — chromedp capture of the seeded data-entry SPA'
+status: in-progress
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Automated Checks
+
+- [ ] All tests pass (`just test`)
+- [ ] Lint clean (`just lint`)
+- [ ] Coverage maintained (`just coverage-check`)
+
+## Code Review
+
+- [ ] Run `/code-review` command (invokes cranky-code-reviewer agent)
+- [ ] All critical review-responses addressed
+- [ ] All significant review-responses addressed
+- [ ] Self-reviewed the diff for unrelated changes
+
+**Review Responses:** <!-- List IDs of review-response entities created, e.g.,
+RR-xxxx -->
+
+## Acceptance Verification
+
+- [ ] Each acceptance criterion tested (reference planning checklist)
+- [ ] Test evidence documented in implementation checklist
+
+**Acceptance Status:**
+<!-- For each acceptance criterion, state PASS/FAIL with evidence -->
+
+## Documentation (enhancements only)
+
+Skip this section for bugs and internal refactors.
+
+- [ ] Docs-checklist created and linked via `has-docs`
+- [ ] User-facing documentation updated
+- [ ] Docs-checklist marked as done
+
+**Docs Checklist:** <!-- e.g., DOCS-xxxx -->
+
+## Final Checks
+
+- [ ] Commit message explains the why, not just what
+- [ ] No TODOs or FIXMEs left unaddressed
+- [ ] Ready for another developer to use
+
+## Pull Request
+
+- [ ] Run `/pr` command to create PR and monitor CI
+- [ ] All CI checks pass
+- [ ] PR URL documented below
+
+**PR:** <!-- e.g., https://github.com/org/repo/pull/123 -->

--- a/tickets/entities/review-responses/RR-8GQ5T2.md
+++ b/tickets/entities/review-responses/RR-8GQ5T2.md
@@ -1,0 +1,9 @@
+---
+id: RR-8GQ5T2
+type: review-response
+title: 'Seed staleness: reused server frozen at the first screenshot''s seed'
+finding: The Capturer stands up the temp-project server once (lazy) with the seedOps as of the FIRST screenshot{}. But seedOps is a build-wide accumulator; a manual with screenshot#1, then a create(), then screenshot#2 would reuse a server seeded with only the first set — the second entity was written to the in-mem store (Tier-A resolvers see it) but never replayed into the temp fsstore, so the SPA renders 'entity not found'. Invisible until a two-figure manual; the single-screenshot example sidesteps it.
+severity: critical
+resolution: 'Added project.syncSeed(ctx, seed): tracks a high-water mark of applied ops and, on each Capture, replays only the new tail (seed[seeded:]) against the running store. ensure() calls it for the reused-project path; standUp sets seeded=len(seed). Turns the reused-server design into a feature (incremental fixtures across figures). Regression test TestCapture_SeedGrowsAcrossIslands captures a second entity created after standUp.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-8QID3G.md
+++ b/tickets/entities/review-responses/RR-8QID3G.md
@@ -1,0 +1,9 @@
+---
+id: RR-8QID3G
+type: review-response
+title: 'Renderability gate was dead code: could capture a blank form or eat the timeout'
+finding: The gate did WaitVisible(#field-title) then checked for a toast-error. But the SPA renders empty schema-driven fields even on load failure, so WaitVisible can pass while the entity didn't load; the error toast is shown asynchronously, so the check races it and can miss — capturing a blank form as if real (the fail-OPEN hole the spike hit). Worse, if the title field never appears, WaitVisible runs out the full 30s and the author gets a useless 'context deadline exceeded'.
+severity: critical
+resolution: 'The form root now stamps data-testid="form-state-{pending|loaded|error}" off loadEntity''s actual outcome (DynamicForm.vue). The gate uses chromedp.Poll to race load vs error in one predicate: a load failure short-circuits with a clear ''entity failed to load'' message; success proceeds. No dependency on which schema fields render, no timing-sensitive toast, no timeout-as-error-signal. This also dissolved the hardcoded-''title''-anchor issue (S1). Regression test TestCapture_UnrenderableEntity_FailsLoud asserts a missing entity fails loud in ~3s, not 30s.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-9NTWBJ.md
+++ b/tickets/entities/review-responses/RR-9NTWBJ.md
@@ -1,0 +1,9 @@
+---
+id: RR-9NTWBJ
+type: review-response
+title: CLI swallowed the specific 'no Chrome' error
+finding: docscapture.New() returns a precise error ('no Chrome/Chromium browser found on PATH'), but the CLI discarded capErr and left Capturer nil, so a screenshot manual failed with the generic 'no capturer configured' instead of the actionable message.
+severity: significant
+resolution: 'The CLI now stashes capErr.Error() into Options.CapturerErr; the screenshot resolver surfaces it in its fail-loud message when the capturer is nil, so the operator gets the specific Chrome+PATH reason. Note: also handles the SPA-not-built reason (standUp''s CheckEmbeddedSPA).'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-A49KYW.md
+++ b/tickets/entities/review-responses/RR-A49KYW.md
@@ -1,0 +1,9 @@
+---
+id: RR-A49KYW
+type: review-response
+title: S1 hardcoded field anchor + minors (cp portability, toast-only gate, mintID collision)
+finding: 'S1: firstFieldAnchor hardcoded ''title'' as the WaitVisible fallback — an entity type whose form has no #field-title would time out. Minors: N1 copyDirIfExists shells out to cp -r with context.Background() (non-portable, non-cancellable, follows symlinks); N2 the old gate only recognized toast-error not toast-warning; N3 mintID could collide an explicit id with a later auto-minted one.'
+severity: minor
+resolution: 'S1 DISSOLVED by the C2 fix — the renderability gate now polls the form-state data-testid, not a specific field, so no field anchor is needed for the gate at all (per-annotation anchors still fail loud on their own targets). N2 moot (the gate no longer uses toasts). N1 left as documented: the source is a trusted local project dir and cp -r matches the e2e test; os.CopyFS is a noted future portability improvement. N3 self-correcting (raw-store CreateEntity errors loudly on a duplicate id) — acceptable for fixtures.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-GZ6ZW4.md
+++ b/tickets/entities/review-responses/RR-GZ6ZW4.md
@@ -1,0 +1,9 @@
+---
+id: RR-GZ6ZW4
+type: review-response
+title: Tall full-page capture rendered blank below the viewport
+finding: Viewport height is emulated at 1600 but maxFullHeight allows a clip up to 4000px. page.CaptureScreenshot().WithClip(...) defaults CaptureBeyondViewport to false, so a clip taller than the emulated viewport renders the below-fold region blank — exactly the 1600<H≤4000 case the cap was designed to permit.
+severity: significant
+resolution: Added .WithCaptureBeyondViewport(true) on the full-page capture path so the whole clipped height renders.
+status: addressed
+---

--- a/tickets/entities/tickets/TKT-89X2B5.md
+++ b/tickets/entities/tickets/TKT-89X2B5.md
@@ -1,0 +1,47 @@
+---
+id: TKT-89X2B5
+type: ticket
+title: 'rela-docs phase 3 (Tier B): screenshot{} island — chromedp capture of the seeded data-entry SPA'
+kind: enhancement
+priority: medium
+effort: l
+status: planning
+---
+
+Phase 3 of FEAT-G4VO53. Adds the **`screenshot{}` island** to the doc language
+(phase 2, TKT-3RLZR4): a metamodel-driven headless-Chrome capture of the
+data-entry SPA rendering a seeded entity, embedded in the manual as
+`![](figure.png)`.
+
+## What
+
+A `screenshot{}` statement-island resolver that:
+1. stands up an **in-process data-entry server** backed by the build's **seeded memstore** (same one `create`/`link` populate for `entity{}`/`graph{}`),
+2. drives **headless Chrome via chromedp** (already a dependency, v0.16.0 — no new dep) to the relevant SPA view (a form/edit page for a seeded entity, a list, etc.),
+3. captures a clipped PNG (optionally annotated with **arrows-with-text** anchored to schema fields), writes it beside the output, and emits a Markdown image reference.
+
+## Decisions (confirmed with user)
+
+- **chromedp** (Go-native, single-language, CI-runnable). Explore/spike first; flag if friction is high.
+- **NO graceful degradation.** If there is no browser, `screenshot{}` **errors loud** (a `BuildError`), exactly like any other fail-loud resolver. No placeholder, no build-succeeds-without-figures path. One code path.
+- **Base:** stacked on the phase-2 branch (`tkt-3rlzr4-doc-language`); rebase onto develop after PR #1181 merges.
+- Reuse the **`internal/dataentry/e2e_test.go`** chromedp pattern (it already drives the SPA headless).
+
+## Anchoring & annotations (carried from the design)
+
+- `screenshot{ view="form", type=..., entity=r.id, as="role", arrows={{at="field", text="..."}}, out="fig.png" }`.
+- `at` targets a **schema field** via a stable SPA hook (`data-field="<name>"` if present — else add one) → fail-loud if the field doesn't exist; or `@button:`/`@role:` → ARIA. openvwr's arrow/box/badge vocab, arrow-with-text primary.
+- Annotations drawn via an injected overlay (chromedp `Evaluate` of an annotate script) OR post-capture Go image compositing — decide in planning.
+
+## Open questions for planning
+
+1. **Server wiring** — the cheapest way to build dataentry.App's 10 collaborators over a memstore without pulling bleve into production (appbuildtest is test-only). May need a small production memory-wiring helper, or a `//go:build` seam.
+2. **SPA assets** — are the Vue static assets embedded in the binary (servable in-process) or do they need a build? `screenshot{}` needs the SPA to actually load.
+3. **Chrome discovery + CI** — chromedp default resolution; skip/error when absent; is a browser available in CI (the e2e job)? This island's tests are browser-gated.
+4. **Role-scoped capture** (`as=`) — how to make the in-process server render as a given ACL role (a fake principal/session).
+5. **Annotation mechanism** — DOM overlay vs Go image compositing; injection-safe text.
+6. **Where the harness lives** — `internal/docs/screenshot.go`? A separate `internal/docscapture` to keep the browser dep off the core `internal/docs`?
+
+Spike the chromedp+memstore-server path end-to-end BEFORE committing the full
+plan (per user: discuss if a lot of issues surface). Design in RES-EK7LSA
+addendum "Tier B / phase 3".

--- a/tickets/entities/tickets/TKT-89X2B5.md
+++ b/tickets/entities/tickets/TKT-89X2B5.md
@@ -5,7 +5,7 @@ title: 'rela-docs phase 3 (Tier B): screenshot{} island — chromedp capture of 
 kind: enhancement
 priority: medium
 effort: l
-status: review
+status: done
 ---
 
 Phase 3 of FEAT-G4VO53. Adds the **`screenshot{}` island** to the doc language

--- a/tickets/entities/tickets/TKT-89X2B5.md
+++ b/tickets/entities/tickets/TKT-89X2B5.md
@@ -5,7 +5,7 @@ title: 'rela-docs phase 3 (Tier B): screenshot{} island — chromedp capture of 
 kind: enhancement
 priority: medium
 effort: l
-status: planning
+status: in-progress
 ---
 
 Phase 3 of FEAT-G4VO53. Adds the **`screenshot{}` island** to the doc language

--- a/tickets/entities/tickets/TKT-89X2B5.md
+++ b/tickets/entities/tickets/TKT-89X2B5.md
@@ -5,7 +5,7 @@ title: 'rela-docs phase 3 (Tier B): screenshot{} island — chromedp capture of 
 kind: enhancement
 priority: medium
 effort: l
-status: in-progress
+status: review
 ---
 
 Phase 3 of FEAT-G4VO53. Adds the **`screenshot{}` island** to the doc language

--- a/tickets/relations/TKT-89X2B5--affects--schema-visualization.md
+++ b/tickets/relations/TKT-89X2B5--affects--schema-visualization.md
@@ -1,0 +1,5 @@
+---
+from: TKT-89X2B5
+relation: affects
+to: schema-visualization
+---

--- a/tickets/relations/TKT-89X2B5--depends-on--TKT-3RLZR4.md
+++ b/tickets/relations/TKT-89X2B5--depends-on--TKT-3RLZR4.md
@@ -1,0 +1,5 @@
+---
+from: TKT-89X2B5
+relation: depends-on
+to: TKT-3RLZR4
+---

--- a/tickets/relations/TKT-89X2B5--has-docs--DOCS-SHOT.md
+++ b/tickets/relations/TKT-89X2B5--has-docs--DOCS-SHOT.md
@@ -1,0 +1,5 @@
+---
+from: TKT-89X2B5
+relation: has-docs
+to: DOCS-SHOT
+---

--- a/tickets/relations/TKT-89X2B5--has-implementation--IMPL-71EN2X.md
+++ b/tickets/relations/TKT-89X2B5--has-implementation--IMPL-71EN2X.md
@@ -1,0 +1,5 @@
+---
+from: TKT-89X2B5
+relation: has-implementation
+to: IMPL-71EN2X
+---

--- a/tickets/relations/TKT-89X2B5--has-planning--PLAN-H3WUFI.md
+++ b/tickets/relations/TKT-89X2B5--has-planning--PLAN-H3WUFI.md
@@ -1,0 +1,5 @@
+---
+from: TKT-89X2B5
+relation: has-planning
+to: PLAN-H3WUFI
+---

--- a/tickets/relations/TKT-89X2B5--has-review--REV-GSMX1O.md
+++ b/tickets/relations/TKT-89X2B5--has-review--REV-GSMX1O.md
@@ -1,0 +1,5 @@
+---
+from: TKT-89X2B5
+relation: has-review
+to: REV-GSMX1O
+---

--- a/tickets/relations/TKT-89X2B5--has-review-response--RR-8GQ5T2.md
+++ b/tickets/relations/TKT-89X2B5--has-review-response--RR-8GQ5T2.md
@@ -1,0 +1,5 @@
+---
+from: TKT-89X2B5
+relation: has-review-response
+to: RR-8GQ5T2
+---

--- a/tickets/relations/TKT-89X2B5--has-review-response--RR-8QID3G.md
+++ b/tickets/relations/TKT-89X2B5--has-review-response--RR-8QID3G.md
@@ -1,0 +1,5 @@
+---
+from: TKT-89X2B5
+relation: has-review-response
+to: RR-8QID3G
+---

--- a/tickets/relations/TKT-89X2B5--has-review-response--RR-9NTWBJ.md
+++ b/tickets/relations/TKT-89X2B5--has-review-response--RR-9NTWBJ.md
@@ -1,0 +1,5 @@
+---
+from: TKT-89X2B5
+relation: has-review-response
+to: RR-9NTWBJ
+---

--- a/tickets/relations/TKT-89X2B5--has-review-response--RR-A49KYW.md
+++ b/tickets/relations/TKT-89X2B5--has-review-response--RR-A49KYW.md
@@ -1,0 +1,5 @@
+---
+from: TKT-89X2B5
+relation: has-review-response
+to: RR-A49KYW
+---

--- a/tickets/relations/TKT-89X2B5--has-review-response--RR-GZ6ZW4.md
+++ b/tickets/relations/TKT-89X2B5--has-review-response--RR-GZ6ZW4.md
@@ -1,0 +1,5 @@
+---
+from: TKT-89X2B5
+relation: has-review-response
+to: RR-GZ6ZW4
+---

--- a/tickets/relations/TKT-89X2B5--implements--FEAT-G4VO53.md
+++ b/tickets/relations/TKT-89X2B5--implements--FEAT-G4VO53.md
@@ -1,0 +1,5 @@
+---
+from: TKT-89X2B5
+relation: implements
+to: FEAT-G4VO53
+---


### PR DESCRIPTION
## What

Phase 3 of FEAT-G4VO53 — the **`screenshot{}` island** for the rela-docs language (phase 2, #1181). It captures a live, annotated screenshot of the data-entry SPA rendering a seeded entity and embeds it in the manual as `![](fig.png)`.

> **Stacked on #1181** (phase 2). This PR targets the `tkt-3rlzr4-doc-language` branch so the diff is phase-3-only; rebase onto develop once #1181 merges.

Ticket TKT-89X2B5. Spiked end-to-end before committing; a real annotated Edit-Ticket form was captured.

## How it works

```rela
local t = create("ticket", { id="DEMO-1", title="Login 500s", status="in-progress", priority="high", reporter="a@b.c" })
screenshot{
  view="form", type="ticket", entity=t.id,
  arrows={ {at="status", text="the lifecycle state"}, {at="priority", text="triage priority"} },
  out="ticket-form.png", alt="The ticket edit form",
}
```

On the first `screenshot{}`, the build stands up an **in-process data-entry server** over a throwaway temp project (real `appbuild.Discover` wiring, in-memory bleve), seeded by **replaying the manual's `create`/`link`** against the fsstore (one `ApplySeed` drives both the in-mem Tier-A store and the temp fsstore, so they can't diverge). It drives **headless Chrome via chromedp** (already a dep, v0.16.0) to the SPA route, waits on a **renderability gate**, injects an **injection-safe annotation overlay**, and captures a PNG.

## Design

- **Consumer-side `Capturer` interface** (`internal/docs`) — the browser/data-entry deps live in **`internal/docscapture`**, injected by the CLI, so core `internal/docs` stays browser-free (arch-lint enforced).
- **No graceful degradation** — no Chrome / no built SPA / unknown anchor / unrenderable entity → **`BuildError`**. A manual with no `screenshot{}` never touches a browser.
- **Per-request role resolver** for `as="role"` (one reused server, correct role per island).
- Annotation text is **`json.Marshal`'d** into the overlay JS (never string-spliced).
- One SPA change: a `data-testid` on the form's load-state (drives the renderability gate) + on the toast.

## Tests & checks

Browser-gated integration tests (skip when no Chrome) + non-browser units (arg parsing, injection-safety, role mapping, seed materialization, all fail-loud paths). `just ci` green; frontend 1359 unit tests pass. `internal/docscapture` coverage floor documented at 40% (its core is irreducibly browser-gated).

Design-reviewed + cranky code-reviewed; the review caught **2 criticals** (seed staleness across islands; a fail-open renderability gate) + 3 significant — all fixed with regression tests (RR-8GQ5T2 / RR-8QID3G / RR-GZ6ZW4 / RR-9NTWBJ / RR-A49KYW).

Includes an example manual figure and a Screenshots section in the doc-language guide.
