### PR TITLE
fix(deps): patch brace-expansion DoS advisory (GHSA-3jxr-9vmj-r5cp)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -902,16 +902,16 @@
       }
     },
     "node_modules/@eslint/config-array/node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/@eslint/config-array/node_modules/minimatch": {
@@ -2779,9 +2779,9 @@
       "license": "ISC"
     },
     "node_modules/brace-expansion": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
-      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4115,16 +4115,16 @@
       }
     },
     "node_modules/eslint/node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/eslint/node_modules/minimatch": {

--- a/tickets/entities/implementation-checklists/IMPL-JS0L1J.md
+++ b/tickets/entities/implementation-checklists/IMPL-JS0L1J.md
@@ -1,0 +1,26 @@
+---
+id: IMPL-JS0L1J
+type: implementation-checklist
+title: 'Implementation: Patch brace-expansion DoS advisory in frontend devDeps (GHSA-3jxr-9vmj-r5cp)'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Development
+- [x] `npm audit fix` applied; only `frontend/package-lock.json` changed.
+- [x] `brace-expansion` bumped: 2.1.1→2.1.2, 5.0.6→5.0.8 (all copies patched).
+
+## Test Quality
+- [x] ~~New tests~~ (N/A: dependency bump, no code change)
+
+## Manual Verification
+- [x] `npm audit` → **0 vulnerabilities**
+- [x] `npm run test:run` → **1359 tests passed**
+- [x] `npm run lint` → 0 errors (eslint's brace-expansion bumped)
+- [x] `npm run build` → succeeds
+
+## Quality
+- [x] Follows project patterns (transitive lockfile-only bump)
+- [x] No security issues introduced (removes the vulnerable versions)
+- [x] No debug code left behind

--- a/tickets/entities/planning-checklists/PLAN-G1Q08L.md
+++ b/tickets/entities/planning-checklists/PLAN-G1Q08L.md
@@ -1,0 +1,34 @@
+---
+id: PLAN-G1Q08L
+type: planning-checklist
+title: 'Planning: Patch brace-expansion DoS advisory in frontend devDeps (GHSA-3jxr-9vmj-r5cp)'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Understanding
+- [x] Problem understood; scope = bump the transitive `brace-expansion` to patched versions.
+- [x] Acceptance: `npm audit` 0 vulns; tests/lint/build unaffected.
+
+## Research
+- [x] `npm audit fix` is the non-breaking path (transitive; no `package.json` change).
+- [x] `govulncheck` already clean — this is npm-side (Dependabot) only.
+
+## Approach
+- [x] `npm audit fix`; only `frontend/package-lock.json` changes.
+
+## Security Considerations
+- [x] The advisory is a DoS in devDependencies (test-utils, eslint) — never shipped. Bump removes the vulnerable versions.
+
+## Test Plan
+- [x] `npm audit` = 0 vulns; `npm run test:run`; `npm run lint`; `npm run build`.
+
+## Risk Assessment
+- [x] xs, non-breaking transitive bump.
+
+## Documentation Planning
+- [x] N/A — no user-facing docs.
+
+## Design Review
+- [x] N/A (xs dependency bump).

--- a/tickets/entities/review-checklists/REV-GJI2YP.md
+++ b/tickets/entities/review-checklists/REV-GJI2YP.md
@@ -1,0 +1,34 @@
+---
+id: REV-GJI2YP
+type: review-checklist
+title: 'Review: Patch brace-expansion DoS advisory in frontend devDeps (GHSA-3jxr-9vmj-r5cp)'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Automated Checks
+- [x] `npm audit` → 0 vulnerabilities
+- [x] Frontend tests: 1359 passed; lint + build unaffected
+- [x] `govulncheck` (Go side) clean — unrelated to this npm bump
+
+## Code Review
+- [x] ~~cranky-code-reviewer~~ (N/A: no code change — a transitive lockfile-only dependency bump; nothing to review beyond the version diff)
+- [x] Self-reviewed the diff: only `frontend/package-lock.json`, patched versions only
+
+## Acceptance Verification
+- [x] npm audit 0 vulns — PASS
+- [x] tests/lint/build unaffected — PASS
+- [x] Dependabot alerts will close on merge — expected
+
+## Documentation
+- [x] N/A (no user-facing change)
+
+## Final Checks
+- [x] Commit message explains the why (advisory, devDep scope)
+- [x] Ready to merge
+
+## Pull Request
+- [x] PR #1192 opened against develop.
+
+**PR:** https://github.com/sourcehaven-bv/rela/pull/1192

--- a/tickets/entities/tickets/TKT-9YK7KP.md
+++ b/tickets/entities/tickets/TKT-9YK7KP.md
@@ -1,0 +1,34 @@
+---
+id: TKT-9YK7KP
+type: ticket
+title: Patch brace-expansion DoS advisory in frontend devDeps (GHSA-3jxr-9vmj-r5cp)
+kind: chore
+priority: medium
+effort: xs
+status: done
+---
+
+## Problem
+
+Dependabot flagged 2 high-severity alerts for the transitive npm dependency
+`brace-expansion` in `frontend/package-lock.json` (GHSA-3jxr-9vmj-r5cp — DoS via
+exponential-time expansion of consecutive non-expanding `{}` groups):
+
+- `brace-expansion` 2.1.1 (< 2.1.2), via `@vue/test-utils` → js-beautify → minimatch
+- `brace-expansion` 5.0.6 (< 5.0.7), via eslint → minimatch
+
+Both are **devDependencies** (test tooling + linter), never shipped to users, so
+real-world risk is low and `govulncheck` (the Go call-graph check CI enforces)
+was already clean. This clears the dependency-graph alerts.
+
+## Change
+
+`npm audit fix` (non-breaking): bump `brace-expansion` 2.1.1 → 2.1.2 and 5.0.6 →
+5.0.8. Only `frontend/package-lock.json` changes (transitive; no `package.json`
+edit).
+
+## Acceptance criteria
+
+- `npm audit` reports 0 vulnerabilities.
+- Frontend unit tests pass; `npm run lint` and `npm run build` unaffected.
+- Dependabot alerts for GHSA-3jxr-9vmj-r5cp close.

--- a/tickets/relations/TKT-9YK7KP--affects--ci-pipeline.md
+++ b/tickets/relations/TKT-9YK7KP--affects--ci-pipeline.md
@@ -1,0 +1,5 @@
+---
+from: TKT-9YK7KP
+relation: affects
+to: ci-pipeline
+---

--- a/tickets/relations/TKT-9YK7KP--has-implementation--IMPL-JS0L1J.md
+++ b/tickets/relations/TKT-9YK7KP--has-implementation--IMPL-JS0L1J.md
@@ -1,0 +1,5 @@
+---
+from: TKT-9YK7KP
+relation: has-implementation
+to: IMPL-JS0L1J
+---

--- a/tickets/relations/TKT-9YK7KP--has-planning--PLAN-G1Q08L.md
+++ b/tickets/relations/TKT-9YK7KP--has-planning--PLAN-G1Q08L.md
@@ -1,0 +1,5 @@
+---
+from: TKT-9YK7KP
+relation: has-planning
+to: PLAN-G1Q08L
+---

--- a/tickets/relations/TKT-9YK7KP--has-review--REV-GJI2YP.md
+++ b/tickets/relations/TKT-9YK7KP--has-review--REV-GJI2YP.md
@@ -1,0 +1,5 @@
+---
+from: TKT-9YK7KP
+relation: has-review
+to: REV-GJI2YP
+---

--- a/tickets/relations/TKT-9YK7KP--implements--FEAT-GE1YY.md
+++ b/tickets/relations/TKT-9YK7KP--implements--FEAT-GE1YY.md
@@ -1,0 +1,5 @@
+---
+from: TKT-9YK7KP
+relation: implements
+to: FEAT-GE1YY
+---


### PR DESCRIPTION
## What

`npm audit fix` bumps the transitive **brace-expansion** dependency to patched versions, clearing the 2 high-severity Dependabot alerts (GHSA-3jxr-9vmj-r5cp — DoS via exponential-time expansion of consecutive non-expanding `{}` groups).

- `brace-expansion` 2.1.1 → 2.1.2 (via `@vue/test-utils` → js-beautify → minimatch)
- `brace-expansion` 5.0.6 → 5.0.8 (via eslint → minimatch)

Both are **devDependencies** (test tooling + linter) — never shipped to users — so this was low real-world risk, and `govulncheck` (the Go call-graph check CI enforces) was already clean. This clears the dependency-graph alerts.

## Scope

Only `frontend/package-lock.json` changes; no `package.json` change (transitive). 

## Verification

- `npm audit` → **0 vulnerabilities**
- Frontend unit tests: **1359 passed**
- `npm run lint` (eslint, whose brace-expansion bumped) → 0 errors
- `npm run build` → succeeds