### PR TITLE
chore(tickets): close FEAT-G4VO53 as implemented

### DIFF
--- a/tickets/entities/features/FEAT-G4VO53.md
+++ b/tickets/entities/features/FEAT-G4VO53.md
@@ -2,8 +2,9 @@
 id: FEAT-G4VO53
 type: feature
 title: Generated deployment documentation (rela docs)
-description: 'Generate per-deployment end-user + operator/support documentation for a rela project. REFRAMED 2026-07-21 (see RES-EK7LSA addendum): phase 2 is a doc LANGUAGE — markdown authored by a human with mechanical fragments pulled from the schema/graph via Lua islands (```rela blocks / `rela` inline echoes), NOT a static push-generator. Phases: 1a/1a.5/1b doc-fields (DONE); phase 2 = Tier A (language + resolvers: typeref/values/relations/graph/lifecycle/entity/count/roles_matrix + memstore seed, no browser); phase 3 = Tier B (screenshot island via Playwright).'
-status: proposed
+summary: Author a deployment manual in Markdown with embedded Lua islands that pull schema-derived reference (field tables, enum meanings, mermaid lifecycles, relation graphs, role matrices) and live data-entry screenshots straight from metamodel.yaml + acl.yaml, built by the standalone rela-docs binary.
+description: 'Generate per-deployment end-user + operator/support documentation for a rela project. IMPLEMENTED via a doc LANGUAGE — markdown authored by a human with mechanical fragments pulled from the schema/graph via Lua islands (```rela blocks / `rela` inline echoes), NOT a static push-generator. Delivered: phase 1a/1a.5/1b doc-fields; phase 2 Tier A (language + resolvers: typeref/values/relations/graph/lifecycle/entity/count/roles_matrix + memstore seed, no browser); phase 3 Tier B (screenshot island via chromedp, not Playwright); the standalone `rela-docs` binary (chromedp unlinked from `rela`, TKT-X00CDI); and a committed dogfood handbook example (TKT-YLFJRG). All merged in #1187.'
+status: implemented
 ---
 
 # Generated deployment documentation (`rela docs`)


### PR DESCRIPTION
## What

The rela-docs generator feature (FEAT-G4VO53) is fully delivered — all 7 implementing tickets are `done` and shipped in #1187. Mark the feature `implemented`, refresh its description (phase 3 shipped via **chromedp**, not Playwright as originally planned; adds the standalone `rela-docs` binary and the dogfood handbook), and add the required docs summary.

## Delivered under this feature

| Ticket | What |
|--------|------|
| TKT-0YBFT8 / TKT-JO2SAD | metamodel + ACL doc-fields (phase 1a/1b) |
| TKT-DUQBD0 | data-entry help surfaces the doc-fields |
| TKT-3RLZR4 | the markdown+Lua doc language + resolvers (Tier A) |
| TKT-89X2B5 | the `screenshot{}` island (Tier B, chromedp) |
| TKT-X00CDI | standalone `rela-docs` binary (chromedp unlinked from `rela`) |
| TKT-YLFJRG | committed dogfood operator handbook example |

## Verification

`analyze_validations` → all 120 rules pass; `analyze_cardinality` clean. Only `tickets/entities/features/FEAT-G4VO53.md` changes.