### PR TITLE
feat(visibility): read-side ACL seam — Reader + tracer decorator + conformance suite (TKT-7I07IX)

### DIFF
--- a/.go-arch-lint.yml
+++ b/.go-arch-lint.yml
@@ -8,6 +8,7 @@ exclude:
   - internal/testutil
   - internal/store/storetest
   - internal/entitymanager/entitymanagertest
+  - internal/visibility/visibilitytest
   - frontend
   - e2e
   - .claude
@@ -100,6 +101,7 @@ components:
   aclaudit:         { in: internal/aclaudit }
   aclmap:           { in: internal/aclmap }
   affordances:      { in: internal/affordances }
+  visibility:       { in: internal/visibility }
   ai:               { in: internal/ai }
   audit:            { in: internal/audit }
   jwtauth:          { in: internal/jwtauth }
@@ -484,6 +486,17 @@ deps:
       - predicate
       - principal
       - statemachine
+  # Read-side ACL enforcement seam (DEC-ZBI39P): visibility wrappers over
+  # the ungated pure readers. tracer is needed for the decorator's
+  # interface/result types; no cycle (tracer depends only on store).
+  visibility:
+    mayDependOn:
+      - acl
+      - affordances
+      - entity
+      - principal
+      - store
+      - tracer
   audit:
     mayDependOn:
       - principal

--- a/.go-arch-lint.yml
+++ b/.go-arch-lint.yml
@@ -489,13 +489,14 @@ deps:
   # Read-side ACL enforcement seam (DEC-ZBI39P): visibility wrappers over
   # the ungated pure readers. tracer is needed for the decorator's
   # interface/result types; no cycle (tracer depends only on store).
+  # Deliberately NO store: the package takes store.Store structurally
+  # through its one-method EntityGetter (RR-RT5YV8).
   visibility:
     mayDependOn:
       - acl
       - affordances
       - entity
       - principal
-      - store
       - tracer
   audit:
     mayDependOn:

--- a/.testcoverage.yml
+++ b/.testcoverage.yml
@@ -66,6 +66,7 @@ exclude:
     - ^cmd/rela                # main entry point
     - ^internal/testutil       # test helpers
     - ^internal/store/storetest # shared conformance test kit (exercised via backends)
+    - ^internal/visibility/visibilitytest # shared conformance test kit (exercised via visibility + future wirings)
     - ^internal/store/pgstore  # covered by the dedicated postgres CI job (needs a live DB; skipped without RELA_TEST_DATABASE_URL)
     - ^internal/entitymanager/entitymanagertest # shared test doubles (PanicOnUse etc.), exercised via consumers
     - ^internal/store/graphquerynaive # exercised through every backend's graphquery tests; cross-package coverage isn't attributed without -coverpkg, so its own number reads 0

--- a/.testcoverage.yml
+++ b/.testcoverage.yml
@@ -21,6 +21,11 @@ threshold:
 # Per-package minimum thresholds.
 # Set ~5pp below current measured coverage to give refactor headroom.
 override:
+  # Security-critical: the read-side ACL seam must not silently lose its
+  # tests — pinned well above the default floor (RR-L3UQL4).
+  - path: ^internal/visibility$
+    threshold: 85
+
   # Below the default floor — explicit lower floors so the gap is
   # visible. Raise these as tests are added; don't lower without reason.
   - path: ^internal/git$

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,6 +48,19 @@
   Never substitute a no-op or sentinel implementation silently — that
   defers the failure to a downstream symptom that is much harder to
   diagnose.
+- **Read-out paths go through visibility wrappers, base readers stay
+  ungated.** Read-side ACL (entity row-gating + field-level `visible:`
+  redaction) is enforced by `internal/visibility` decorators
+  (`Reader`, the tracer decorator) injected at the wiring site — never
+  by per-consumer redaction calls, and never inside `store`/`tracer`/
+  `search` themselves (DEC-ZBI39P; the `search.VisibleSearcher`
+  pattern generalized). Hidden = nonexistent (pruned subtrees,
+  withheld paths, indistinguishable 404s). A system job that may read
+  everything gets an `AllowAllReader` capability at wiring while
+  keeping its genuine `system:*` principal for audit — allow-all is
+  never inferred from identity. Write-prep reads (entitymanager
+  diffing) keep raw store access: a redacted read-modify-write would
+  clobber hidden fields.
 - **Boundaries are enforced.** `just arch-lint` checks package import
   rules; run it before PR.
 
@@ -130,6 +143,7 @@ Domain and storage:
 | `internal/tracer`        | Pure-reader graph traversal (trace, path, orphans, cycles)|
 | `internal/calfeed`       | Pure calendar-feed model + iCalendar/JSON serializers (event-granular; no store/vendor) |
 | `internal/search`        | Full-text + structured search (bleve + linear)            |
+| `internal/visibility`    | Read-side ACL wrappers: row-gate + field-redact readers, tracer decorator (DEC-ZBI39P) |
 | `internal/entitymanager` | Write path: automations, validation, audit, policy        |
 | `internal/audit`         | Append-only JSONL audit log of every successful write     |
 | `internal/principal`     | Identity attribution (`Principal{User, Tool}`) on ctx     |

--- a/internal/visibility/adapters.go
+++ b/internal/visibility/adapters.go
@@ -1,0 +1,116 @@
+package visibility
+
+import (
+	"context"
+	"errors"
+
+	"github.com/Sourcehaven-BV/rela/internal/acl"
+	"github.com/Sourcehaven-BV/rela/internal/affordances"
+	"github.com/Sourcehaven-BV/rela/internal/entity"
+	"github.com/Sourcehaven-BV/rela/internal/principal"
+)
+
+// DeclarativeGate adapts *acl.Declarative to [RowGate]. The per-principal
+// acl.Request is derived FROM CTX on every call — a ctx-attached Request
+// (acl.FromContext, the per-request amortization seam) is reused, else a
+// fresh one is opened for the ctx principal. An unstamped principal makes
+// ForPrincipal fail, which surfaces as a gate error → callers fail
+// closed (deny), never open.
+type DeclarativeGate struct {
+	d *acl.Declarative
+}
+
+// NewDeclarativeGate wraps d (required).
+func NewDeclarativeGate(d *acl.Declarative) (DeclarativeGate, error) {
+	if d == nil {
+		return DeclarativeGate{}, errors.New("visibility: NewDeclarativeGate: declarative must be non-nil")
+	}
+	return DeclarativeGate{d: d}, nil
+}
+
+// request resolves the acl.Request for this call: ctx-attached when
+// present, else freshly opened for the ctx principal.
+func (g DeclarativeGate) request(ctx context.Context) (*acl.Request, error) {
+	if r := acl.FromContext(ctx); r != nil {
+		return r, nil
+	}
+	return g.d.ForPrincipal(principal.From(ctx))
+}
+
+// PermitsRead implements [RowGate].
+func (g DeclarativeGate) PermitsRead(ctx context.Context, entityType, id string) (bool, error) {
+	r, err := g.request(ctx)
+	if err != nil {
+		return false, err
+	}
+	return r.PermitsRead(ctx, entityType, id)
+}
+
+// PermitsReadMany implements [RowGate].
+func (g DeclarativeGate) PermitsReadMany(
+	ctx context.Context, entityType string, ids []string,
+) (map[string]bool, error) {
+	r, err := g.request(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return r.PermitsReadMany(ctx, entityType, ids)
+}
+
+// PolicyRedactor adapts *affordances.PolicyResolver to [FieldRedactor]:
+// the property names whose FieldVerdicts.Visible entry is an explicit
+// false. The resolver returns zero verdicts when no policy is configured,
+// so the no-ACL path redacts nothing (NopACL byte-parity); its internal
+// failure modes already resolve fail-closed, satisfying the
+// [FieldRedactor] contract.
+type PolicyRedactor struct {
+	r *affordances.PolicyResolver
+}
+
+// NewPolicyRedactor wraps r (required).
+func NewPolicyRedactor(r *affordances.PolicyResolver) (PolicyRedactor, error) {
+	if r == nil {
+		return PolicyRedactor{}, errors.New("visibility: NewPolicyRedactor: resolver must be non-nil")
+	}
+	return PolicyRedactor{r: r}, nil
+}
+
+// HiddenProperties implements [FieldRedactor].
+func (p PolicyRedactor) HiddenProperties(ctx context.Context, e *entity.Entity) map[string]struct{} {
+	v := p.r.FieldVerdicts(ctx, e)
+	if len(v.Visible) == 0 {
+		return nil
+	}
+	out := make(map[string]struct{})
+	for name, visible := range v.Visible {
+		if !visible {
+			out[name] = struct{}{}
+		}
+	}
+	return out
+}
+
+// NopGate is the permit-all [RowGate] for wirings without an ACL policy —
+// the byte-parity path (behavior identical to pre-ACL reads).
+type NopGate struct{}
+
+// PermitsRead implements [RowGate].
+func (NopGate) PermitsRead(context.Context, string, string) (bool, error) { return true, nil }
+
+// PermitsReadMany implements [RowGate].
+func (NopGate) PermitsReadMany(_ context.Context, _ string, ids []string) (map[string]bool, error) {
+	m := make(map[string]bool, len(ids))
+	for _, id := range ids {
+		m[id] = true
+	}
+	return m, nil
+}
+
+// NopRedactor is the hide-nothing [FieldRedactor] for wirings without an
+// ACL policy.
+type NopRedactor struct{}
+
+// HiddenProperties implements [FieldRedactor].
+func (NopRedactor) HiddenProperties(context.Context, *entity.Entity) map[string]struct{} {
+	return nil
+}

--- a/internal/visibility/adapters.go
+++ b/internal/visibility/adapters.go
@@ -16,8 +16,33 @@ import (
 // fresh one is opened for the ctx principal. An unstamped principal makes
 // ForPrincipal fail, which surfaces as a gate error → callers fail
 // closed (deny), never open.
+//
+// WIRING REQUIREMENT (RR-MXKD2O): open ONE Request per logical operation
+// and attach it with [Bind] (or acl.WithRequest) before calling into the
+// wrappers. Without it, every gate probe AND every field-verdict
+// resolution opens its own Request — the Globals member-of walk re-runs
+// per collaborator (the cost RR-JJYW amortizes away), and the row-gate
+// and redactor may evaluate against different ACL snapshots if a write
+// lands mid-operation. Fail-closed still holds per decision either way;
+// binding makes the operation a single consistent, amortized scope.
 type DeclarativeGate struct {
 	d *acl.Declarative
+}
+
+// Bind opens one acl.Request for the ctx principal and attaches it to
+// the returned ctx, making every downstream gate probe and field-verdict
+// resolution reuse the same per-operation scope. Call it once at the top
+// of each logical operation (request handler, script run, job tick).
+// Fails for an unstamped principal — callers deny, never fall open.
+func (g DeclarativeGate) Bind(ctx context.Context) (context.Context, error) {
+	if r := acl.FromContext(ctx); r != nil {
+		return ctx, nil // already bound upstream; keep the existing scope
+	}
+	r, err := g.d.ForPrincipal(principal.From(ctx))
+	if err != nil {
+		return nil, err
+	}
+	return acl.WithRequest(ctx, r), nil
 }
 
 // NewDeclarativeGate wraps d (required).

--- a/internal/visibility/allowall.go
+++ b/internal/visibility/allowall.go
@@ -1,0 +1,59 @@
+package visibility
+
+import (
+	"context"
+	"errors"
+
+	"github.com/Sourcehaven-BV/rela/internal/entity"
+)
+
+// AllowAllReader is the explicit pass-through [Reader] capability for
+// system jobs (schedulers, reindexers) that legitimately read the whole
+// graph. No gate, no redaction, no copying — outputs are byte-identical
+// to raw store reads, and returned entities must be treated read-only
+// (same contract raw reads carry today).
+//
+// This is a CAPABILITY handed out at a wiring site, never inferred from
+// the principal: the job keeps its genuine system principal for audit
+// while this reader grants the visibility (DEC-ZBI39P; the read-side
+// analog of WriteDeps.ElevatedManager, TKT-D8T148). Wire it deliberately
+// and visibly.
+//
+// The one non-pass-through behavior it keeps is the [Reader.Get]
+// stored-type contract: a type-mismatched claim is a miss. That check is
+// part of Reader semantics (RR-SRZK6X), not of policy, so every
+// implementation enforces it identically.
+type AllowAllReader struct {
+	get EntityGetter
+}
+
+// NewAllowAllReader builds an AllowAllReader over get (required).
+func NewAllowAllReader(get EntityGetter) (*AllowAllReader, error) {
+	if get == nil {
+		return nil, errors.New("visibility: NewAllowAllReader: get must be non-nil")
+	}
+	return &AllowAllReader{get: get}, nil
+}
+
+// Get implements [Reader]: plain load plus the stored-type check.
+func (r *AllowAllReader) Get(ctx context.Context, entityType, id string) (*entity.Entity, bool, error) {
+	e, err := r.get.GetEntity(ctx, id)
+	if err != nil {
+		return nil, false, nil //nolint:nilerr // store miss == not-found, by design
+	}
+	if e.Type != entityType {
+		return nil, false, nil
+	}
+	return e, true, nil
+}
+
+// Filter implements [Reader]: pass-through, input returned unchanged.
+func (r *AllowAllReader) Filter(_ context.Context, candidates []*entity.Entity) []*entity.Entity {
+	return candidates
+}
+
+// FilterRelations implements [Reader]: pass-through, input returned
+// unchanged.
+func (r *AllowAllReader) FilterRelations(_ context.Context, rels []*entity.Relation) []*entity.Relation {
+	return rels
+}

--- a/internal/visibility/policyreader.go
+++ b/internal/visibility/policyreader.go
@@ -69,13 +69,16 @@ func (r *PolicyReader) Filter(ctx context.Context, candidates []*entity.Entity) 
 	}
 	byType := make(map[string][]string)
 	for _, c := range candidates {
+		if c == nil {
+			continue // fail-closed: a nil candidate must not panic the filter
+		}
 		byType[c.Type] = append(byType[c.Type], c.ID)
 	}
 	allowed := r.permittedIDs(ctx, byType)
 
 	out := make([]*entity.Entity, 0, len(candidates))
 	for _, c := range candidates {
-		if allowed[c.ID] {
+		if c != nil && allowed[c.ID] {
 			out = append(out, r.redacted(ctx, c))
 		}
 	}
@@ -93,6 +96,9 @@ func (r *PolicyReader) FilterRelations(ctx context.Context, rels []*entity.Relat
 	byType := make(map[string][]string)
 	seen := make(map[string]bool)
 	for _, rel := range rels {
+		if rel == nil {
+			continue // fail-closed: a nil relation must not panic the filter
+		}
 		for _, id := range [2]string{rel.From, rel.To} {
 			if seen[id] {
 				continue
@@ -109,7 +115,7 @@ func (r *PolicyReader) FilterRelations(ctx context.Context, rels []*entity.Relat
 
 	out := make([]*entity.Relation, 0, len(rels))
 	for _, rel := range rels {
-		if allowed[rel.From] && allowed[rel.To] {
+		if rel != nil && allowed[rel.From] && allowed[rel.To] {
 			out = append(out, rel)
 		}
 	}
@@ -152,6 +158,14 @@ func (r *PolicyReader) permittedIDs(ctx context.Context, byType map[string][]str
 // entity.Entity carries no secondary title channel — DisplayTitle
 // derivations recompute from Properties and fall back to the ID once a
 // hidden display property is stripped.
+//
+// TODO(body-redaction): Content and Inaccessible pass through verbatim.
+// Today that is correct — the `visible:` policy universe is
+// metamodel-declared properties, so a body can't be policy-hidden — but
+// if body-level redaction ever becomes policy-expressible
+// (entity.InaccessibleFieldContent exists as the reserved marker), this
+// is the spot that must learn about it, or the seam silently leaks
+// bodies (RR-J6022V).
 func (r *PolicyReader) redacted(ctx context.Context, e *entity.Entity) *entity.Entity {
 	hidden := r.redact.HiddenProperties(ctx, e)
 	if len(hidden) == 0 {

--- a/internal/visibility/policyreader.go
+++ b/internal/visibility/policyreader.go
@@ -1,0 +1,176 @@
+package visibility
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+
+	"github.com/Sourcehaven-BV/rela/internal/entity"
+)
+
+// PolicyReader is the policy-enforcing [Reader]: row-gate first, then
+// field-redact a copy. Semantics are hoisted from dataentry's
+// visibleReader/copyVisibleProperties (TKT-N26KLB) with one deliberate
+// strengthening: the stored-type check lives here, in the package, never
+// in consumers (RR-SRZK6X).
+type PolicyReader struct {
+	gate   RowGate
+	redact FieldRedactor
+	get    EntityGetter
+}
+
+// NewPolicyReader builds a PolicyReader. All collaborators are required
+// (constructors-reject-nil rule).
+func NewPolicyReader(gate RowGate, redact FieldRedactor, get EntityGetter) (*PolicyReader, error) {
+	if gate == nil {
+		return nil, errors.New("visibility: NewPolicyReader: gate must be non-nil")
+	}
+	if redact == nil {
+		return nil, errors.New("visibility: NewPolicyReader: redact must be non-nil")
+	}
+	if get == nil {
+		return nil, errors.New("visibility: NewPolicyReader: get must be non-nil")
+	}
+	return &PolicyReader{gate: gate, redact: redact, get: get}, nil
+}
+
+// Get implements [Reader]. Gate BEFORE load (hidden == missing, RR-NGMI),
+// then verify the stored type matches the caller's claim (RR-SRZK6X),
+// then redact a copy.
+func (r *PolicyReader) Get(ctx context.Context, entityType, id string) (*entity.Entity, bool, error) {
+	ok, err := r.gate.PermitsRead(ctx, entityType, id)
+	if err != nil {
+		return nil, false, err
+	}
+	if !ok {
+		return nil, false, nil
+	}
+	e, gerr := r.get.GetEntity(ctx, id)
+	if gerr != nil {
+		// Store miss == not-found; indistinguishable from a deny by design.
+		return nil, false, nil //nolint:nilerr // store miss == not-found, by design
+	}
+	if e.Type != entityType {
+		// The gate authorized the CLAIMED type; acting on a different
+		// stored type would be the BUG-ZWTDH9 escalation. Same
+		// indistinguishable miss.
+		return nil, false, nil
+	}
+	return r.redacted(ctx, e), true, nil
+}
+
+// Filter implements [Reader]: batched row-gate per type (one
+// PermitsReadMany per distinct type, RR-FRK1 shape), fail-closed
+// type-drop on gate error, then redaction of every survivor. Order is
+// preserved and a fresh slice returned; nil for empty input.
+func (r *PolicyReader) Filter(ctx context.Context, candidates []*entity.Entity) []*entity.Entity {
+	if len(candidates) == 0 {
+		return nil
+	}
+	byType := make(map[string][]string)
+	for _, c := range candidates {
+		byType[c.Type] = append(byType[c.Type], c.ID)
+	}
+	allowed := r.permittedIDs(ctx, byType)
+
+	out := make([]*entity.Entity, 0, len(candidates))
+	for _, c := range candidates {
+		if allowed[c.ID] {
+			out = append(out, r.redacted(ctx, c))
+		}
+	}
+	return out
+}
+
+// FilterRelations implements [Reader]: a relation survives only when BOTH
+// endpoints are visible (FROM ∧ TO). Endpoint types are resolved with one
+// load per distinct endpoint id; visibility with one PermitsReadMany per
+// distinct type. A missing endpoint or a gate error hides fail-closed.
+func (r *PolicyReader) FilterRelations(ctx context.Context, rels []*entity.Relation) []*entity.Relation {
+	if len(rels) == 0 {
+		return nil
+	}
+	byType := make(map[string][]string)
+	seen := make(map[string]bool)
+	for _, rel := range rels {
+		for _, id := range [2]string{rel.From, rel.To} {
+			if seen[id] {
+				continue
+			}
+			seen[id] = true
+			e, err := r.get.GetEntity(ctx, id)
+			if err != nil {
+				continue // missing endpoint: stays out of allowed → relation hidden
+			}
+			byType[e.Type] = append(byType[e.Type], id)
+		}
+	}
+	allowed := r.permittedIDs(ctx, byType)
+
+	out := make([]*entity.Relation, 0, len(rels))
+	for _, rel := range rels {
+		if allowed[rel.From] && allowed[rel.To] {
+			out = append(out, rel)
+		}
+	}
+	return out
+}
+
+// permittedIDs runs one PermitsReadMany per distinct type and returns the
+// union allowed-id set. A gate error drops that whole type fail-closed —
+// a read-ACL failure must never widen visibility — and is logged loud so
+// operators see the cause rather than silently thinner results.
+func (r *PolicyReader) permittedIDs(ctx context.Context, byType map[string][]string) map[string]bool {
+	allowed := make(map[string]bool)
+	for typeName, ids := range byType {
+		perm, err := r.gate.PermitsReadMany(ctx, typeName, ids)
+		if err != nil {
+			slog.Warn("visibility: PermitsReadMany failed; dropping type fail-closed",
+				"type", typeName, "candidates", len(ids), "err", err)
+			continue
+		}
+		for id, ok := range perm {
+			if ok {
+				allowed[id] = true
+			}
+		}
+	}
+	return allowed
+}
+
+// redacted returns e with hidden properties stripped. When nothing is
+// hidden the ORIGINAL pointer is returned (read-out contract: callers
+// must not mutate) — this keeps the no-policy path allocation-free and
+// byte-identical to a raw read. When redaction applies, the struct is
+// shallow-copied with a fresh filtered Properties map; property VALUES
+// still alias the originals, which is safe because read-out paths
+// serialize before anything can alias (the copyVisibleProperties
+// contract, TKT-IHC7D).
+//
+// No separate title fallback is needed here: unlike the wire DTO (whose
+// precomputed _title stripHiddenProperties must rewrite), an
+// entity.Entity carries no secondary title channel — DisplayTitle
+// derivations recompute from Properties and fall back to the ID once a
+// hidden display property is stripped.
+func (r *PolicyReader) redacted(ctx context.Context, e *entity.Entity) *entity.Entity {
+	hidden := r.redact.HiddenProperties(ctx, e)
+	if len(hidden) == 0 {
+		return e
+	}
+	out := *e
+	out.Properties = filterProps(e.Properties, hidden)
+	return &out
+}
+
+// filterProps returns a fresh map of props minus hidden. Never mutates
+// props (which may alias live store state).
+func filterProps(props map[string]any, hidden map[string]struct{}) map[string]any {
+	out := make(map[string]any, len(props))
+	for k, v := range props {
+		if _, h := hidden[k]; h {
+			continue
+		}
+		out[k] = v
+	}
+	return out
+}

--- a/internal/visibility/tracer.go
+++ b/internal/visibility/tracer.go
@@ -1,0 +1,257 @@
+package visibility
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+
+	"github.com/Sourcehaven-BV/rela/internal/entity"
+	"github.com/Sourcehaven-BV/rela/internal/tracer"
+)
+
+// VisibleTracer is the visibility decorator over a pure [tracer.Tracer]
+// (DEC-ZBI39P): it filters the BASE tracer's results post-hoc — the base
+// stays ACL-free (the TKT-QU7REX precedent: whole-graph scans ungated,
+// visibility applied to the results) — with hidden = nonexistent
+// semantics:
+//
+//   - a hidden trace node is pruned WITH its entire subtree (if the node
+//     doesn't exist for you, nothing reached through it does either);
+//   - a path through a hidden intermediate is withheld, indistinguishable
+//     from no-path;
+//   - hidden orphans are dropped;
+//   - HasCycle on a hidden start behaves as on a nonexistent start.
+//
+// Surviving nodes are still field-redacted: a visible entity can carry
+// hidden properties, and TraceResult.Properties / .Title are built from
+// the raw entity. Redaction always builds FRESH property maps — the base
+// tracer's maps alias live store state (RR-6IL3X7) — and applies the ID
+// title-fallback when the node's title property is hidden (RR-5N4K35).
+type VisibleTracer struct {
+	base   tracer.Tracer
+	gate   RowGate
+	redact FieldRedactor
+	get    EntityGetter
+}
+
+// NewVisibleTracer builds the decorator. All collaborators are required.
+func NewVisibleTracer(
+	base tracer.Tracer, gate RowGate, redact FieldRedactor, get EntityGetter,
+) (*VisibleTracer, error) {
+	if base == nil {
+		return nil, errors.New("visibility: NewVisibleTracer: base must be non-nil")
+	}
+	if gate == nil {
+		return nil, errors.New("visibility: NewVisibleTracer: gate must be non-nil")
+	}
+	if redact == nil {
+		return nil, errors.New("visibility: NewVisibleTracer: redact must be non-nil")
+	}
+	if get == nil {
+		return nil, errors.New("visibility: NewVisibleTracer: get must be non-nil")
+	}
+	return &VisibleTracer{base: base, gate: gate, redact: redact, get: get}, nil
+}
+
+// TraceFrom implements [tracer.Tracer].
+func (t *VisibleTracer) TraceFrom(ctx context.Context, id string, maxDepth int) *tracer.TraceResult {
+	return t.filterTree(ctx, t.base.TraceFrom(ctx, id, maxDepth))
+}
+
+// TraceTo implements [tracer.Tracer].
+func (t *VisibleTracer) TraceTo(ctx context.Context, id string, maxDepth int) *tracer.TraceResult {
+	return t.filterTree(ctx, t.base.TraceTo(ctx, id, maxDepth))
+}
+
+// filterTree gates every node of the returned tree with ONE
+// PermitsReadMany per distinct type, then rebuilds the tree pruning
+// hidden nodes (and their subtrees) and redacting the survivors. A nil
+// or hidden root yields nil — the same shape the base tracer returns for
+// an unknown id.
+func (t *VisibleTracer) filterTree(ctx context.Context, root *tracer.TraceResult) *tracer.TraceResult {
+	if root == nil {
+		return nil
+	}
+	byType := map[string][]string{}
+	collectNodeIDs(root, byType, map[string]bool{})
+	visible := t.permittedIDs(ctx, byType)
+	return t.rebuild(ctx, root, visible)
+}
+
+// collectNodeIDs walks the tree gathering distinct node ids grouped by
+// entity type (tree nodes carry Type), for the batched gate probe.
+func collectNodeIDs(n *tracer.TraceResult, byType map[string][]string, seen map[string]bool) {
+	if n == nil {
+		return
+	}
+	if !seen[n.ID] {
+		seen[n.ID] = true
+		byType[n.Type] = append(byType[n.Type], n.ID)
+	}
+	for _, c := range n.Children {
+		collectNodeIDs(c, byType, seen)
+	}
+}
+
+// rebuild returns a filtered COPY of the tree: hidden nodes prune their
+// whole subtree; surviving nodes are redacted onto fresh structs (the
+// base tree's Properties maps alias live store state and are never
+// mutated).
+func (t *VisibleTracer) rebuild(
+	ctx context.Context, n *tracer.TraceResult, visible map[string]bool,
+) *tracer.TraceResult {
+	if n == nil || !visible[n.ID] {
+		return nil
+	}
+	out := *n
+	out.Children = nil
+	t.redactNode(ctx, &out)
+	for _, c := range n.Children {
+		if fc := t.rebuild(ctx, c, visible); fc != nil {
+			out.Children = append(out.Children, fc)
+		}
+	}
+	return &out
+}
+
+// redactNode strips hidden properties from one (visible) node onto a
+// fresh map and applies the ID title-fallback when the title property is
+// hidden. Verdicts are computed against a synthetic entity built from
+// the node's own fields — the tree carries the full raw property map, so
+// `when:` predicates see the same values a store load would provide.
+func (t *VisibleTracer) redactNode(ctx context.Context, n *tracer.TraceResult) {
+	synth := &entity.Entity{ID: n.ID, Type: n.Type, Properties: n.Properties}
+	hidden := t.redact.HiddenProperties(ctx, synth)
+	if len(hidden) == 0 {
+		return
+	}
+	n.Properties = filterProps(n.Properties, hidden)
+	if _, h := hidden["title"]; h {
+		// TraceResult.Title is the literal `title` property baked in at
+		// build time — the secondary channel redaction must also close.
+		n.Title = n.ID
+	}
+}
+
+// FindPath implements [tracer.Tracer]. Any hidden step withholds the
+// WHOLE path — revealing "a path exists through something you cannot
+// see" is itself a leak — returning nil exactly like the base's no-path
+// result. (Withholding takes marginally longer than a genuine no-path
+// BFS miss; accepted residual, impractical to exploit in-memory.)
+func (t *VisibleTracer) FindPath(ctx context.Context, fromID, toID string) []tracer.PathStep {
+	steps := t.base.FindPath(ctx, fromID, toID)
+	if len(steps) == 0 {
+		return nil
+	}
+	byType := map[string][]string{}
+	seen := map[string]bool{}
+	for _, s := range steps {
+		if !seen[s.ID] {
+			seen[s.ID] = true
+			byType[s.Type] = append(byType[s.Type], s.ID)
+		}
+	}
+	visible := t.permittedIDs(ctx, byType)
+	for _, s := range steps {
+		if !visible[s.ID] {
+			return nil
+		}
+	}
+
+	out := make([]tracer.PathStep, len(steps))
+	copy(out, steps)
+	for i := range out {
+		if !t.redactStepTitle(ctx, &out[i]) {
+			return nil
+		}
+	}
+	return out
+}
+
+// redactStepTitle applies the ID title-fallback to one path step. Steps
+// carry no property map, so the entity is loaded to evaluate the field
+// verdict against real values (a synthetic entity without properties
+// could flip a `when:` predicate open). Returns false — withhold the
+// path — when the entity cannot be loaded (fail-closed).
+func (t *VisibleTracer) redactStepTitle(ctx context.Context, s *tracer.PathStep) bool {
+	e, err := t.get.GetEntity(ctx, s.ID)
+	if err != nil {
+		return false
+	}
+	hidden := t.redact.HiddenProperties(ctx, e)
+	if _, h := hidden["title"]; h {
+		s.Title = s.ID
+	}
+	return true
+}
+
+// FindOrphans implements [tracer.Tracer]: the base's orphan ids minus
+// the hidden ones. Each id's entity is loaded once (the type is needed
+// for the gate anyway); ids are gated with one PermitsReadMany per
+// distinct type (RR-MYLUSZ). A vanished entity drops fail-closed.
+func (t *VisibleTracer) FindOrphans(ctx context.Context) ([]string, error) {
+	ids, err := t.base.FindOrphans(ctx)
+	if err != nil {
+		return nil, err
+	}
+	byType := map[string][]string{}
+	for _, id := range ids {
+		e, gerr := t.get.GetEntity(ctx, id)
+		if gerr != nil {
+			continue
+		}
+		byType[e.Type] = append(byType[e.Type], id)
+	}
+	visible := t.permittedIDs(ctx, byType)
+
+	out := make([]string, 0, len(ids))
+	for _, id := range ids {
+		if visible[id] {
+			out = append(out, id)
+		}
+	}
+	return out, nil
+}
+
+// HasCycle implements [tracer.Tracer]. A hidden (or missing, or
+// gate-erroring) start returns false — the same result the base returns
+// for a nonexistent start, so the bool is not an existence oracle for
+// the start node. Note the documented residual: a VISIBLE start still
+// reports a cycle whose loop passes through hidden nodes.
+func (t *VisibleTracer) HasCycle(ctx context.Context, startID string) bool {
+	e, err := t.get.GetEntity(ctx, startID)
+	if err != nil {
+		return false
+	}
+	ok, gerr := t.gate.PermitsRead(ctx, e.Type, startID)
+	if gerr != nil {
+		slog.Warn("visibility: HasCycle gate failed; answering false fail-closed",
+			"type", e.Type, "err", gerr)
+		return false
+	}
+	if !ok {
+		return false
+	}
+	return t.base.HasCycle(ctx, startID)
+}
+
+// permittedIDs mirrors PolicyReader.permittedIDs for the decorator's own
+// gate probes: one PermitsReadMany per distinct type, fail-closed
+// type-drop on error, loud log.
+func (t *VisibleTracer) permittedIDs(ctx context.Context, byType map[string][]string) map[string]bool {
+	allowed := make(map[string]bool)
+	for typeName, ids := range byType {
+		perm, err := t.gate.PermitsReadMany(ctx, typeName, ids)
+		if err != nil {
+			slog.Warn("visibility: tracer PermitsReadMany failed; dropping type fail-closed",
+				"type", typeName, "candidates", len(ids), "err", err)
+			continue
+		}
+		for id, ok := range perm {
+			if ok {
+				allowed[id] = true
+			}
+		}
+	}
+	return allowed
+}

--- a/internal/visibility/visibility.go
+++ b/internal/visibility/visibility.go
@@ -84,8 +84,13 @@ type Reader interface {
 	// Get returns the entity when the ctx principal may read it AND its
 	// stored type matches entityType. Denied, missing, and type-mismatched
 	// are indistinguishable: (nil, false, nil). Only a gate failure is an
-	// error. The returned entity is redacted (hidden properties absent)
-	// and safe to hand to any render/serialize path.
+	// error — a store-load fault is deliberately swallowed into the same
+	// clean miss (the oracle-free contract requires it), so a backend
+	// outage reads as 404s; operators debugging phantom misses should
+	// check store health, not the gate. The returned entity's PROPERTIES
+	// are redacted (hidden names absent). Body redaction is out of scope:
+	// the `visible:` policy universe is metamodel-declared properties, so
+	// Content is not policy-hideable today and passes through verbatim.
 	Get(ctx context.Context, entityType, id string) (*entity.Entity, bool, error)
 
 	// Filter drops candidates the ctx principal may not read and redacts

--- a/internal/visibility/visibility.go
+++ b/internal/visibility/visibility.go
@@ -1,0 +1,104 @@
+// Package visibility is the read-side ACL enforcement seam: wrappers that
+// row-gate and field-redact entity reads ABOVE the (deliberately ungated)
+// base services, per DEC-ZBI39P.
+//
+// The pattern generalizes [search.VisibleSearcher]: base services stay pure
+// and ACL-unaware (store, tracer, search — see the architecture rules in
+// CLAUDE.md), and enforcement is structural — a consumer receives a wrapper
+// at its wiring site and cannot forget to filter. This replaces the
+// gate-by-convention enforcement that let the PR #1188 export paths bypass
+// field redaction.
+//
+// # Contract
+//
+//   - Gate BEFORE read: a denied row and a nonexistent row are
+//     indistinguishable (the RR-NGMI invariant — no existence oracle).
+//   - Stored type must equal the caller's claimed type: [Reader.Get]
+//     authorizes against the claimed type but verifies the loaded entity's
+//     actual type, returning not-found on mismatch (RR-SRZK6X; the
+//     read-side analog of BUG-ZWTDH9).
+//   - Hidden = nonexistent: trace subtrees below a hidden node are pruned,
+//     a path through a hidden intermediate is withheld exactly like
+//     no-path, hidden orphans are dropped.
+//   - Redaction never mutates stored state: a redacted entity is a copy;
+//     the tracer decorator builds fresh property maps and never deletes
+//     from the store-aliased ones (RR-6IL3X7).
+//   - Fail-closed: a gate or redactor failure hides, never reveals.
+//   - Read-out only: these wrappers serve presentation/read-out paths.
+//     Write-prep reads (entitymanager diffing) keep raw store access — a
+//     redacted read-modify-write would clobber hidden fields on save.
+//   - Capability, not identity: a system job that may read everything is
+//     handed an [AllowAllReader] at its wiring site while keeping its
+//     genuine system principal for audit (the read-side analog of the
+//     ElevatedManager pattern, TKT-D8T148). Allow-all is never inferred
+//     from the principal.
+//
+// Accepted residuals (documented, not defended): withholding a computed
+// path takes marginally longer than a genuine no-path miss — impractical
+// to exploit on in-memory traversal; and [tracer.Tracer.HasCycle] on a
+// VISIBLE start still reports a cycle whose loop passes through hidden
+// nodes (a single bool of topology).
+//
+// Under no ACL policy the nop collaborators ([NopGate], [NopRedactor])
+// make every wrapper byte-identical to raw access.
+package visibility
+
+import (
+	"context"
+
+	"github.com/Sourcehaven-BV/rela/internal/entity"
+)
+
+// RowGate answers entity-level read-permission questions for the principal
+// carried on ctx. Consumer-side contract of the acl read gate; the
+// production adapter is [DeclarativeGate], the permit-all one is [NopGate].
+//
+// Neither method verifies existence — they answer "the policy permits
+// reading this id IF it exists" (same contract as acl.Request).
+type RowGate interface {
+	PermitsRead(ctx context.Context, entityType, id string) (bool, error)
+	PermitsReadMany(ctx context.Context, entityType string, ids []string) (map[string]bool, error)
+}
+
+// FieldRedactor reports the property names hidden from the ctx principal
+// for one entity. The production adapter is [PolicyRedactor]; the nop one
+// is [NopRedactor].
+//
+// FAIL-CLOSED CONTRACT (RR-FJUQSF): an implementation that cannot compute
+// verdicts must return the hide-everything set (every property name of e),
+// never nil — nil means "nothing hidden" and would fail open.
+type FieldRedactor interface {
+	HiddenProperties(ctx context.Context, e *entity.Entity) map[string]struct{}
+}
+
+// EntityGetter is the single-entity load this package needs from the
+// store. Satisfied by store.Store.
+type EntityGetter interface {
+	GetEntity(ctx context.Context, id string) (*entity.Entity, error)
+}
+
+// Reader is the row-gating, field-redacting entity read-out surface.
+// Implementations: [PolicyReader] (policy-enforcing) and [AllowAllReader]
+// (explicit pass-through capability for system jobs).
+type Reader interface {
+	// Get returns the entity when the ctx principal may read it AND its
+	// stored type matches entityType. Denied, missing, and type-mismatched
+	// are indistinguishable: (nil, false, nil). Only a gate failure is an
+	// error. The returned entity is redacted (hidden properties absent)
+	// and safe to hand to any render/serialize path.
+	Get(ctx context.Context, entityType, id string) (*entity.Entity, bool, error)
+
+	// Filter drops candidates the ctx principal may not read and redacts
+	// the survivors. Order is preserved; the returned slice is fresh; a
+	// gate error drops that whole type fail-closed (logged loud). Nil for
+	// empty input.
+	Filter(ctx context.Context, candidates []*entity.Entity) []*entity.Entity
+
+	// FilterRelations keeps only relations whose BOTH endpoints are
+	// visible to the ctx principal (FROM ∧ TO — the relation-history
+	// precedent: the FROM side owns UI placement, it is not the auth
+	// boundary). Order preserved, fresh slice, fail-closed on gate error
+	// or a missing endpoint. Relations carry no field-level redaction
+	// today; row-gating is the whole contract.
+	FilterRelations(ctx context.Context, rels []*entity.Relation) []*entity.Relation
+}

--- a/internal/visibility/visibility_test.go
+++ b/internal/visibility/visibility_test.go
@@ -1,0 +1,115 @@
+package visibility_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Sourcehaven-BV/rela/internal/entity"
+	"github.com/Sourcehaven-BV/rela/internal/store/memstore"
+	"github.com/Sourcehaven-BV/rela/internal/tracer"
+	"github.com/Sourcehaven-BV/rela/internal/visibility"
+	"github.com/Sourcehaven-BV/rela/internal/visibility/visibilitytest"
+)
+
+// TestPolicyReaderConformance runs the shared suite against the
+// production PolicyReader.
+func TestPolicyReaderConformance(t *testing.T) {
+	visibilitytest.RunReaderTests(t, func(
+		t *testing.T, gate visibility.RowGate, redact visibility.FieldRedactor, get visibility.EntityGetter,
+	) visibility.Reader {
+		t.Helper()
+		r, err := visibility.NewPolicyReader(gate, redact, get)
+		if err != nil {
+			t.Fatalf("NewPolicyReader: %v", err)
+		}
+		return r
+	})
+}
+
+// TestVisibleTracerConformance runs the shared suite against the
+// production VisibleTracer decorator.
+func TestVisibleTracerConformance(t *testing.T) {
+	visibilitytest.RunTracerTests(t, func(
+		t *testing.T, base tracer.Tracer,
+		gate visibility.RowGate, redact visibility.FieldRedactor, get visibility.EntityGetter,
+	) tracer.Tracer {
+		t.Helper()
+		tr, err := visibility.NewVisibleTracer(base, gate, redact, get)
+		if err != nil {
+			t.Fatalf("NewVisibleTracer: %v", err)
+		}
+		return tr
+	})
+}
+
+// TestAllowAllReader pins the pass-through contract plus the one
+// non-pass-through behavior: the Reader-semantics stored-type check.
+func TestAllowAllReader(t *testing.T) {
+	ctx := context.Background()
+	st := memstore.New()
+	seed := &entity.Entity{ID: "T-1", Type: "ticket", Properties: map[string]any{"title": "One", "secret": "x"}}
+	if err := st.CreateEntity(ctx, seed); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	r, err := visibility.NewAllowAllReader(st)
+	if err != nil {
+		t.Fatalf("NewAllowAllReader: %v", err)
+	}
+
+	t.Run("PassThroughGet", func(t *testing.T) {
+		e, ok, gerr := r.Get(ctx, "ticket", "T-1")
+		if gerr != nil || !ok {
+			t.Fatalf("Get = (ok=%v, err=%v)", ok, gerr)
+		}
+		if e.Properties["secret"] != "x" {
+			t.Fatalf("AllowAllReader redacted: %v", e.Properties)
+		}
+	})
+	t.Run("StoredTypeCheckStillHolds", func(t *testing.T) {
+		if e, ok, gerr := r.Get(ctx, "person", "T-1"); e != nil || ok || gerr != nil {
+			t.Fatalf("cross-type Get = (%v,%v,%v), want miss", e, ok, gerr)
+		}
+	})
+	t.Run("PassThroughFilters", func(t *testing.T) {
+		ents := []*entity.Entity{seed}
+		if got := r.Filter(ctx, ents); len(got) != 1 || got[0] != seed {
+			t.Fatalf("Filter altered input: %v", got)
+		}
+		rels := []*entity.Relation{{From: "T-1", Type: "r", To: "GHOST"}}
+		if got := r.FilterRelations(ctx, rels); len(got) != 1 {
+			t.Fatalf("FilterRelations altered input: %v", got)
+		}
+	})
+}
+
+// TestConstructorsRejectNil pins the constructors-reject-nil rule for
+// every constructor in the package.
+func TestConstructorsRejectNil(t *testing.T) {
+	st := memstore.New()
+	base := tracer.New(st)
+	gate := visibility.NopGate{}
+	redact := visibility.NopRedactor{}
+
+	cases := []struct {
+		name string
+		fn   func() error
+	}{
+		{"PolicyReader nil gate", func() error { _, err := visibility.NewPolicyReader(nil, redact, st); return err }},
+		{"PolicyReader nil redact", func() error { _, err := visibility.NewPolicyReader(gate, nil, st); return err }},
+		{"PolicyReader nil get", func() error { _, err := visibility.NewPolicyReader(gate, redact, nil); return err }},
+		{"AllowAllReader nil get", func() error { _, err := visibility.NewAllowAllReader(nil); return err }},
+		{"VisibleTracer nil base", func() error { _, err := visibility.NewVisibleTracer(nil, gate, redact, st); return err }},
+		{"VisibleTracer nil gate", func() error { _, err := visibility.NewVisibleTracer(base, nil, redact, st); return err }},
+		{"VisibleTracer nil redact", func() error { _, err := visibility.NewVisibleTracer(base, gate, nil, st); return err }},
+		{"VisibleTracer nil get", func() error { _, err := visibility.NewVisibleTracer(base, gate, redact, nil); return err }},
+		{"DeclarativeGate nil", func() error { _, err := visibility.NewDeclarativeGate(nil); return err }},
+		{"PolicyRedactor nil", func() error { _, err := visibility.NewPolicyRedactor(nil); return err }},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := tc.fn(); err == nil {
+				t.Fatal("expected constructor error for nil collaborator, got nil")
+			}
+		})
+	}
+}

--- a/internal/visibility/visibilitytest/suite.go
+++ b/internal/visibility/visibilitytest/suite.go
@@ -1,0 +1,730 @@
+// Package visibilitytest is the conformance suite for the
+// internal/visibility contracts (the analog of storetest's
+// RunVisibleSearchTests): any [visibility.Reader] implementation and any
+// visibility-decorated [tracer.Tracer] must pass it. The suite owns a
+// canonical world (memstore + declarative ACL + affordances resolver) and
+// pins the security invariants from PLAN-RR12W4:
+//
+//   - hidden == missing (no existence oracle, RR-NGMI);
+//   - stored-type check inside Get (RR-SRZK6X);
+//   - redaction-on-copy, stored state never mutated (RR-6IL3X7);
+//   - title never leaks past redaction (RR-5N4K35);
+//   - both-endpoints relation rule (RR-Y7P4MQ);
+//   - fail-closed on gate error / unstamped principal;
+//   - allow-all and nop-policy parity with raw access.
+package visibilitytest
+
+import (
+	"context"
+	"maps"
+	"reflect"
+	"strings"
+	"sync"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/Sourcehaven-BV/rela/internal/acl"
+	"github.com/Sourcehaven-BV/rela/internal/affordances"
+	"github.com/Sourcehaven-BV/rela/internal/entity"
+	"github.com/Sourcehaven-BV/rela/internal/metamodel"
+	"github.com/Sourcehaven-BV/rela/internal/principal"
+	"github.com/Sourcehaven-BV/rela/internal/store"
+	"github.com/Sourcehaven-BV/rela/internal/store/memstore"
+	"github.com/Sourcehaven-BV/rela/internal/tracer"
+	"github.com/Sourcehaven-BV/rela/internal/visibility"
+)
+
+// ReaderMaker builds the Reader under test from the suite's collaborators.
+// Production impls compose exactly these three; a wiring under test (PR
+// 2/3) adapts its own construction to this shape.
+type ReaderMaker func(
+	t *testing.T, gate visibility.RowGate, redact visibility.FieldRedactor, get visibility.EntityGetter,
+) visibility.Reader
+
+// TracerMaker builds the visibility-decorated tracer under test over the
+// suite's base tracer and collaborators.
+type TracerMaker func(
+	t *testing.T, base tracer.Tracer,
+	gate visibility.RowGate, redact visibility.FieldRedactor, get visibility.EntityGetter,
+) tracer.Tracer
+
+// world is the canonical fixture: a seeded memstore plus the real ACL
+// engines (declarative gate + affordances redactor) for the canonical
+// policy below.
+type world struct {
+	store  store.Store
+	base   tracer.Tracer
+	gate   visibility.DeclarativeGate
+	redact visibility.PolicyRedactor
+}
+
+// Canonical policy. Principals:
+//
+//	alice — admin: reads everything, no field restrictions.
+//	bob   — limited: reads project+person (NOT secret); on person only
+//	        title+name are visible (salary hidden).
+//	carol — notitle: reads project+person; on person only name+salary
+//	        are visible (title hidden → ID fallback everywhere).
+const policyYAML = `
+roles:
+  admin:
+    read: ["*"]
+  limited:
+    read: [project, person]
+    visible:
+      person:
+        - field: title
+        - field: name
+  notitle:
+    read: [project, person]
+    visible:
+      person:
+        - field: name
+        - field: salary
+assignments:
+  alice: admin
+  bob: limited
+  carol: notitle
+`
+
+// suiteMeta declares the closed-world field universe the visible: blocks
+// deny from.
+func suiteMeta() *metamodel.Metamodel {
+	str := metamodel.PropertyDef{Type: metamodel.PropertyTypeString}
+	return &metamodel.Metamodel{
+		Entities: map[string]metamodel.EntityDef{
+			"project": {Properties: map[string]metamodel.PropertyDef{"title": str}},
+			"secret":  {Properties: map[string]metamodel.PropertyDef{"title": str}},
+			"person": {Properties: map[string]metamodel.PropertyDef{
+				"title":  str,
+				"name":   str,
+				"salary": {Type: metamodel.PropertyTypeInteger},
+			}},
+		},
+	}
+}
+
+// newWorld seeds the canonical graph and wires the real engines.
+//
+// Graph (all edges relation type "relates"):
+//
+//	PRJ-1 → SEC-1 → PRJ-2        (bob's only PRJ-1..PRJ-2 path runs
+//	PRJ-1 → P-1                   through a type he cannot read)
+//	PRJ-4 → SEC-3 ⇄ SEC-4        (cycle entirely inside hidden types)
+//	PRJ-3, SEC-2                  (orphans: one visible, one hidden)
+func newWorld(t *testing.T) *world {
+	t.Helper()
+	ctx := context.Background()
+	st := memstore.New()
+
+	seed := []*entity.Entity{
+		{ID: "PRJ-1", Type: "project", Properties: map[string]any{"title": "Alpha"}},
+		{ID: "PRJ-2", Type: "project", Properties: map[string]any{"title": "Beta"}},
+		{ID: "PRJ-3", Type: "project", Properties: map[string]any{"title": "Gamma"}},
+		{ID: "PRJ-4", Type: "project", Properties: map[string]any{"title": "Delta"}},
+		{ID: "SEC-1", Type: "secret", Properties: map[string]any{"title": "Hush"}},
+		{ID: "SEC-2", Type: "secret", Properties: map[string]any{"title": "Shh"}},
+		{ID: "SEC-3", Type: "secret", Properties: map[string]any{"title": "Loop A"}},
+		{ID: "SEC-4", Type: "secret", Properties: map[string]any{"title": "Loop B"}},
+		{ID: "P-1", Type: "person", Properties: map[string]any{"title": "Ann Ex", "name": "Ann", "salary": 100}},
+	}
+	for _, e := range seed {
+		if err := st.CreateEntity(ctx, e); err != nil {
+			t.Fatalf("seed entity %s: %v", e.ID, err)
+		}
+	}
+	for _, r := range [][3]string{
+		{"PRJ-1", "relates", "SEC-1"},
+		{"SEC-1", "relates", "PRJ-2"},
+		{"PRJ-1", "relates", "P-1"},
+		{"PRJ-4", "relates", "SEC-3"},
+		{"SEC-3", "relates", "SEC-4"},
+		{"SEC-4", "relates", "SEC-3"},
+	} {
+		if _, err := st.CreateRelation(ctx, r[0], r[1], r[2], nil); err != nil {
+			t.Fatalf("seed relation %v: %v", r, err)
+		}
+	}
+
+	var p acl.Policy
+	if err := yaml.Unmarshal([]byte(policyYAML), &p); err != nil {
+		t.Fatalf("unmarshal policy: %v", err)
+	}
+	d, err := acl.NewDeclarative(&p, acl.NewStoreGraph(st), st)
+	if err != nil {
+		t.Fatalf("NewDeclarative: %v", err)
+	}
+	resolver, err := affordances.New(suiteMeta(), storeLookup{st}, d)
+	if err != nil {
+		t.Fatalf("affordances.New: %v", err)
+	}
+	gate, err := visibility.NewDeclarativeGate(d)
+	if err != nil {
+		t.Fatalf("NewDeclarativeGate: %v", err)
+	}
+	redact, err := visibility.NewPolicyRedactor(resolver)
+	if err != nil {
+		t.Fatalf("NewPolicyRedactor: %v", err)
+	}
+	return &world{store: st, base: tracer.New(st), gate: gate, redact: redact}
+}
+
+// storeLookup implements affordances.RelationLookup over the store.
+type storeLookup struct{ st store.Store }
+
+func (l storeLookup) OutgoingCounts(ctx context.Context, fromID string) map[string]int {
+	counts := map[string]int{}
+	for rel, err := range l.st.ListRelations(ctx, store.RelationQuery{
+		From: fromID, Direction: store.DirectionOutgoing,
+	}) {
+		if err != nil || rel == nil {
+			continue
+		}
+		counts[rel.Type]++
+	}
+	return counts
+}
+
+func (l storeLookup) HasEdge(ctx context.Context, fromID, relType, toID string) bool {
+	for rel, err := range l.st.ListRelations(ctx, store.RelationQuery{
+		From: fromID, Type: relType, To: toID, Direction: store.DirectionOutgoing,
+	}) {
+		if err != nil || rel == nil {
+			continue
+		}
+		return true
+	}
+	return false
+}
+
+// ctxFor stamps a principal ctx for one of the canonical users.
+func ctxFor(user string) context.Context {
+	return principal.With(context.Background(), principal.Principal{User: user, Tool: principal.ToolDataEntry})
+}
+
+// mustGet loads an entity straight from the store (bypassing everything)
+// for parity and no-mutation assertions.
+func mustGet(t *testing.T, st store.Store, id string) *entity.Entity {
+	t.Helper()
+	e, err := st.GetEntity(context.Background(), id)
+	if err != nil {
+		t.Fatalf("store.GetEntity(%s): %v", id, err)
+	}
+	return e
+}
+
+// RunReaderTests is the conformance suite for [visibility.Reader].
+func RunReaderTests(t *testing.T, mk ReaderMaker) {
+	t.Helper()
+	t.Run("HiddenEqualsMissing", func(t *testing.T) { testHiddenEqualsMissing(t, mk) })
+	t.Run("StoredTypeMismatchIsMiss", func(t *testing.T) { testStoredTypeMismatch(t, mk) })
+	t.Run("RedactsOnCopy", func(t *testing.T) { testRedactsOnCopy(t, mk) })
+	t.Run("HiddenTitleFallsBackToID", func(t *testing.T) { testHiddenTitleFallback(t, mk) })
+	t.Run("FilterMixedVisibility", func(t *testing.T) { testFilterMixed(t, mk) })
+	t.Run("FilterGateErrorDropsTypeFailClosed", func(t *testing.T) { testFilterGateError(t, mk) })
+	t.Run("FilterRelationsBothEndpointsRule", func(t *testing.T) { testFilterRelations(t, mk) })
+	t.Run("UnstampedPrincipalFailsClosed", func(t *testing.T) { testUnstampedPrincipal(t, mk) })
+	t.Run("HideEverythingRedactor", func(t *testing.T) { testHideEverythingRedactor(t, mk) })
+	t.Run("NopPolicyParity", func(t *testing.T) { testReaderNopParity(t, mk) })
+	t.Run("RaceSmoke", func(t *testing.T) { testReaderRaceSmoke(t, mk) })
+}
+
+func testHiddenEqualsMissing(t *testing.T, mk ReaderMaker) {
+	t.Helper()
+	w := newWorld(t)
+	r := mk(t, w.gate, w.redact, w.store)
+	ctx := ctxFor("bob")
+
+	eHidden, okHidden, errHidden := r.Get(ctx, "secret", "SEC-1")
+	eMissing, okMissing, errMissing := r.Get(ctx, "secret", "SEC-404")
+	if eHidden != nil || okHidden || errHidden != nil {
+		t.Fatalf("hidden Get = (%v,%v,%v), want (nil,false,nil)", eHidden, okHidden, errHidden)
+	}
+	if eMissing != nil || okMissing || errMissing != nil {
+		t.Fatalf("missing Get = (%v,%v,%v), want (nil,false,nil)", eMissing, okMissing, errMissing)
+	}
+}
+
+func testStoredTypeMismatch(t *testing.T, mk ReaderMaker) {
+	t.Helper()
+	w := newWorld(t)
+	r := mk(t, w.gate, w.redact, w.store)
+
+	// bob may read type project (AllowAll scope), so the gate permits the
+	// CLAIM — the stored entity is a secret he cannot read. The in-package
+	// stored-type check must turn this into a miss (RR-SRZK6X, the
+	// BUG-ZWTDH9 read-side analog).
+	e, ok, err := r.Get(ctxFor("bob"), "project", "SEC-1")
+	if e != nil || ok || err != nil {
+		t.Fatalf("cross-type Get = (%v,%v,%v), want (nil,false,nil)", e, ok, err)
+	}
+	// Even a fully-privileged principal gets a miss on a wrong claim: the
+	// check is Reader semantics, not policy.
+	e, ok, err = r.Get(ctxFor("alice"), "project", "P-1")
+	if e != nil || ok || err != nil {
+		t.Fatalf("alice cross-type Get = (%v,%v,%v), want (nil,false,nil)", e, ok, err)
+	}
+}
+
+func testRedactsOnCopy(t *testing.T, mk ReaderMaker) {
+	t.Helper()
+	w := newWorld(t)
+	r := mk(t, w.gate, w.redact, w.store)
+	beforeProps := maps.Clone(mustGet(t, w.store, "P-1").Properties)
+
+	e, ok, err := r.Get(ctxFor("bob"), "person", "P-1")
+	if err != nil || !ok {
+		t.Fatalf("Get person P-1 = (ok=%v, err=%v)", ok, err)
+	}
+	if _, leaked := e.Properties["salary"]; leaked {
+		t.Fatalf("salary visible to bob: %v", e.Properties)
+	}
+	if e.Properties["name"] != "Ann" || e.Properties["title"] != "Ann Ex" {
+		t.Fatalf("granted fields damaged: %v", e.Properties)
+	}
+	after := mustGet(t, w.store, "P-1")
+	if !reflect.DeepEqual(beforeProps, after.Properties) {
+		t.Fatalf("stored entity mutated by redaction: before=%v after=%v", beforeProps, after.Properties)
+	}
+}
+
+func testHiddenTitleFallback(t *testing.T, mk ReaderMaker) {
+	t.Helper()
+	w := newWorld(t)
+	r := mk(t, w.gate, w.redact, w.store)
+
+	e, ok, err := r.Get(ctxFor("carol"), "person", "P-1")
+	if err != nil || !ok {
+		t.Fatalf("Get person P-1 = (ok=%v, err=%v)", ok, err)
+	}
+	if _, leaked := e.Properties["title"]; leaked {
+		t.Fatalf("title visible to carol: %v", e.Properties)
+	}
+	// The stripped copy has no secondary title channel: every DisplayTitle
+	// derivation recomputes from Properties and lands on the ID.
+	if got := e.Title(); got != "" {
+		t.Fatalf("Title() over redacted copy = %q, want empty (→ ID fallback downstream)", got)
+	}
+}
+
+func testFilterMixed(t *testing.T, mk ReaderMaker) {
+	t.Helper()
+	w := newWorld(t)
+	r := mk(t, w.gate, w.redact, w.store)
+	in := []*entity.Entity{
+		mustGet(t, w.store, "PRJ-1"),
+		mustGet(t, w.store, "SEC-1"),
+		mustGet(t, w.store, "P-1"),
+		mustGet(t, w.store, "PRJ-2"),
+	}
+
+	out := r.Filter(ctxFor("bob"), in)
+	ids := make([]string, 0, len(out))
+	for _, e := range out {
+		ids = append(ids, e.ID)
+	}
+	want := []string{"PRJ-1", "P-1", "PRJ-2"}
+	if !reflect.DeepEqual(ids, want) {
+		t.Fatalf("Filter ids = %v, want %v (order-preserving, hidden dropped)", ids, want)
+	}
+	for _, e := range out {
+		if e.ID == "P-1" {
+			if _, leaked := e.Properties["salary"]; leaked {
+				t.Fatalf("Filter survivor not redacted: %v", e.Properties)
+			}
+		}
+	}
+	if got := r.Filter(ctxFor("bob"), nil); got != nil {
+		t.Fatalf("Filter(nil) = %v, want nil", got)
+	}
+}
+
+func testFilterGateError(t *testing.T, mk ReaderMaker) {
+	t.Helper()
+	w := newWorld(t)
+	r := mk(t, &erroringGate{inner: w.gate, failType: "person"}, w.redact, w.store)
+	in := []*entity.Entity{
+		mustGet(t, w.store, "PRJ-1"),
+		mustGet(t, w.store, "P-1"),
+	}
+	out := r.Filter(ctxFor("alice"), in)
+	if len(out) != 1 || out[0].ID != "PRJ-1" {
+		t.Fatalf("Filter with erroring person gate = %v, want [PRJ-1] only", out)
+	}
+}
+
+func testFilterRelations(t *testing.T, mk ReaderMaker) {
+	t.Helper()
+	w := newWorld(t)
+	counting := &countingGate{inner: w.gate}
+	r := mk(t, counting, w.redact, w.store)
+	rels := []*entity.Relation{
+		{From: "PRJ-1", Type: "relates", To: "SEC-1"}, // TO hidden → dropped
+		{From: "SEC-1", Type: "relates", To: "PRJ-2"}, // FROM hidden → dropped
+		{From: "PRJ-1", Type: "relates", To: "P-1"},   // both visible → kept
+	}
+
+	out := r.FilterRelations(ctxFor("bob"), rels)
+	if len(out) != 1 || out[0].From != "PRJ-1" || out[0].To != "P-1" {
+		t.Fatalf("FilterRelations = %v, want only PRJ-1→P-1", out)
+	}
+	// Batched endpoint gating: one PermitsReadMany per distinct endpoint
+	// type (project, secret, person = 3), not per endpoint.
+	if counting.many > 3 {
+		t.Fatalf("FilterRelations made %d PermitsReadMany calls, want ≤3 (one per distinct type)", counting.many)
+	}
+	if got := r.FilterRelations(ctxFor("bob"), nil); got != nil {
+		t.Fatalf("FilterRelations(nil) = %v, want nil", got)
+	}
+}
+
+func testUnstampedPrincipal(t *testing.T, mk ReaderMaker) {
+	t.Helper()
+	w := newWorld(t)
+	r := mk(t, w.gate, w.redact, w.store)
+
+	// No principal on ctx → ForPrincipal rejects → gate error → deny.
+	e, ok, err := r.Get(context.Background(), "project", "PRJ-1")
+	if err == nil {
+		t.Fatalf("unstamped Get = (%v,%v,nil), want gate error (fail closed, never open)", e, ok)
+	}
+	if e != nil || ok {
+		t.Fatalf("unstamped Get leaked entity: (%v,%v)", e, ok)
+	}
+	if out := r.Filter(context.Background(), []*entity.Entity{mustGet(t, w.store, "PRJ-1")}); len(out) != 0 {
+		t.Fatalf("unstamped Filter = %v, want empty (fail closed)", out)
+	}
+}
+
+func testHideEverythingRedactor(t *testing.T, mk ReaderMaker) {
+	t.Helper()
+	w := newWorld(t)
+	r := mk(t, w.gate, hideAllRedactor{}, w.store)
+
+	e, ok, err := r.Get(ctxFor("alice"), "person", "P-1")
+	if err != nil || !ok {
+		t.Fatalf("Get = (ok=%v, err=%v)", ok, err)
+	}
+	if len(e.Properties) != 0 {
+		t.Fatalf("hide-everything redactor left properties: %v", e.Properties)
+	}
+}
+
+func testReaderNopParity(t *testing.T, mk ReaderMaker) {
+	t.Helper()
+	w := newWorld(t)
+	r := mk(t, visibility.NopGate{}, visibility.NopRedactor{}, w.store)
+	ctx := context.Background() // parity must hold even without a principal
+
+	raw := mustGet(t, w.store, "P-1")
+	e, ok, err := r.Get(ctx, "person", "P-1")
+	if err != nil || !ok {
+		t.Fatalf("nop Get = (ok=%v, err=%v)", ok, err)
+	}
+	if !reflect.DeepEqual(raw, e) {
+		t.Fatalf("nop-policy Get differs from raw store read:\nraw=%+v\ngot=%+v", raw, e)
+	}
+	in := []*entity.Entity{mustGet(t, w.store, "PRJ-1"), mustGet(t, w.store, "SEC-1")}
+	out := r.Filter(ctx, in)
+	if !reflect.DeepEqual(in, out) {
+		t.Fatalf("nop-policy Filter differs from input: %v vs %v", in, out)
+	}
+}
+
+func testReaderRaceSmoke(t *testing.T, mk ReaderMaker) {
+	t.Helper()
+	w := newWorld(t)
+	r := mk(t, w.gate, w.redact, w.store)
+	var wg sync.WaitGroup
+	for i := range 8 {
+		wg.Add(1)
+		go func(user string) {
+			defer wg.Done()
+			ctx := ctxFor(user) // independent ctx per goroutine: fresh acl.Request per call
+			_, _, _ = r.Get(ctx, "person", "P-1")
+			_ = r.Filter(ctx, []*entity.Entity{mustGet(t, w.store, "PRJ-1")})
+		}([]string{"alice", "bob", "carol"}[i%3])
+	}
+	wg.Wait()
+}
+
+// RunTracerTests is the conformance suite for a visibility-decorated
+// [tracer.Tracer].
+func RunTracerTests(t *testing.T, mk TracerMaker) {
+	t.Helper()
+	t.Run("HiddenNodePrunesSubtree", func(t *testing.T) { testHiddenNodePrunes(t, mk) })
+	t.Run("HiddenRootEqualsUnknownRoot", func(t *testing.T) { testHiddenRoot(t, mk) })
+	t.Run("PathThroughHiddenNodeWithheld", func(t *testing.T) { testPathWithheld(t, mk) })
+	t.Run("OrphansFiltered", func(t *testing.T) { testOrphansFiltered(t, mk) })
+	t.Run("HasCycleHiddenStartEqualsMissingStart", func(t *testing.T) { testHasCycleHiddenStart(t, mk) })
+	t.Run("CycleThroughHiddenNodesPruneTerminates", func(t *testing.T) { testHiddenCycleTerminates(t, mk) })
+	t.Run("NodePropertiesRedactedAliasSafe", func(t *testing.T) { testNodeRedactionAliasSafe(t, mk) })
+	t.Run("NodeAndStepTitleFallback", func(t *testing.T) { testTitleFallbacks(t, mk) })
+	t.Run("NopPolicyParity", func(t *testing.T) { testTracerNopParity(t, mk) })
+}
+
+func testHiddenNodePrunes(t *testing.T, mk TracerMaker) {
+	t.Helper()
+	w := newWorld(t)
+	tr := mk(t, w.base, w.gate, w.redact, w.store)
+
+	got := tr.TraceFrom(ctxFor("bob"), "PRJ-1", 0)
+	if got == nil {
+		t.Fatal("TraceFrom(PRJ-1) = nil for bob, want visible tree")
+	}
+	ids := collectIDs(got)
+	if ids["SEC-1"] || ids["PRJ-2"] {
+		t.Fatalf("hidden node or its subtree leaked: %v (SEC-1 hidden ⇒ PRJ-2 unreachable)", keys(ids))
+	}
+	if !ids["P-1"] {
+		t.Fatalf("visible branch missing: %v", keys(ids))
+	}
+}
+
+func testHiddenRoot(t *testing.T, mk TracerMaker) {
+	t.Helper()
+	w := newWorld(t)
+	tr := mk(t, w.base, w.gate, w.redact, w.store)
+	ctx := ctxFor("bob")
+
+	if got := tr.TraceFrom(ctx, "SEC-1", 0); got != nil {
+		t.Fatalf("TraceFrom(hidden root) = %+v, want nil", got)
+	}
+	if got := tr.TraceFrom(ctx, "NOPE", 0); got != nil {
+		t.Fatalf("TraceFrom(unknown root) = %+v, want nil (base shape)", got)
+	}
+}
+
+func testPathWithheld(t *testing.T, mk TracerMaker) {
+	t.Helper()
+	w := newWorld(t)
+	tr := mk(t, w.base, w.gate, w.redact, w.store)
+	ctx := ctxFor("bob")
+
+	// Sanity: the path exists for a privileged principal.
+	if p := tr.FindPath(ctxFor("alice"), "PRJ-1", "PRJ-2"); len(p) == 0 {
+		t.Fatal("premise broken: alice sees no PRJ-1..PRJ-2 path")
+	}
+	hidden := tr.FindPath(ctx, "PRJ-1", "PRJ-2") // exists, runs through SEC-1
+	missing := tr.FindPath(ctx, "PRJ-1", "NOPE") // genuinely absent
+	if !reflect.DeepEqual(hidden, missing) {
+		t.Fatalf("withheld path (%v) distinguishable from no-path (%v)", hidden, missing)
+	}
+	if hidden != nil {
+		t.Fatalf("withheld path = %v, want nil", hidden)
+	}
+}
+
+func testOrphansFiltered(t *testing.T, mk TracerMaker) {
+	t.Helper()
+	w := newWorld(t)
+	tr := mk(t, w.base, w.gate, w.redact, w.store)
+
+	got, err := tr.FindOrphans(ctxFor("bob"))
+	if err != nil {
+		t.Fatalf("FindOrphans: %v", err)
+	}
+	if !reflect.DeepEqual(got, []string{"PRJ-3"}) {
+		t.Fatalf("orphans for bob = %v, want [PRJ-3] (SEC-2 hidden)", got)
+	}
+}
+
+func testHasCycleHiddenStart(t *testing.T, mk TracerMaker) {
+	t.Helper()
+	w := newWorld(t)
+	tr := mk(t, w.base, w.gate, w.redact, w.store)
+
+	if !tr.HasCycle(ctxFor("alice"), "SEC-3") {
+		t.Fatal("premise broken: alice sees no SEC-3 cycle")
+	}
+	got, want := tr.HasCycle(ctxFor("bob"), "SEC-3"), tr.HasCycle(ctxFor("bob"), "NOPE")
+	if got != want || got {
+		t.Fatalf("HasCycle(hidden start) = %v, HasCycle(missing start) = %v, want both false", got, want)
+	}
+}
+
+func testHiddenCycleTerminates(t *testing.T, mk TracerMaker) {
+	t.Helper()
+	w := newWorld(t)
+	tr := mk(t, w.base, w.gate, w.redact, w.store)
+
+	got := tr.TraceFrom(ctxFor("bob"), "PRJ-4", 0)
+	if got == nil {
+		t.Fatal("TraceFrom(PRJ-4) = nil for bob, want the root alone")
+	}
+	if len(got.Children) != 0 {
+		t.Fatalf("hidden cycle leaked below PRJ-4: %+v", got.Children)
+	}
+}
+
+func testNodeRedactionAliasSafe(t *testing.T, mk TracerMaker) {
+	t.Helper()
+	w := newWorld(t)
+	tr := mk(t, w.base, w.gate, w.redact, w.store)
+	beforeProps := maps.Clone(mustGet(t, w.store, "P-1").Properties)
+
+	got := tr.TraceFrom(ctxFor("bob"), "PRJ-1", 0)
+	node := findNode(got, "P-1")
+	if node == nil {
+		t.Fatal("P-1 node missing from bob's trace")
+	}
+	if _, leaked := node.Properties["salary"]; leaked {
+		t.Fatalf("salary leaked into trace node: %v", node.Properties)
+	}
+	after := mustGet(t, w.store, "P-1")
+	if !reflect.DeepEqual(beforeProps, after.Properties) {
+		t.Fatalf("trace redaction mutated the stored entity: before=%v after=%v",
+			beforeProps, after.Properties)
+	}
+}
+
+func testTitleFallbacks(t *testing.T, mk TracerMaker) {
+	t.Helper()
+	w := newWorld(t)
+	tr := mk(t, w.base, w.gate, w.redact, w.store)
+	ctx := ctxFor("carol") // title hidden on person
+
+	got := tr.TraceFrom(ctx, "PRJ-1", 0)
+	node := findNode(got, "P-1")
+	if node == nil {
+		t.Fatal("P-1 node missing from carol's trace")
+	}
+	if node.Title != "P-1" {
+		t.Fatalf("trace node title = %q, want ID fallback %q", node.Title, "P-1")
+	}
+	steps := tr.FindPath(ctx, "PRJ-1", "P-1")
+	if len(steps) == 0 {
+		t.Fatal("FindPath(PRJ-1, P-1) empty for carol")
+	}
+	last := steps[len(steps)-1]
+	if last.ID != "P-1" || last.Title != "P-1" {
+		t.Fatalf("path step = %+v, want Title == ID fallback", last)
+	}
+}
+
+func testTracerNopParity(t *testing.T, mk TracerMaker) {
+	t.Helper()
+	w := newWorld(t)
+	tr := mk(t, w.base, visibility.NopGate{}, visibility.NopRedactor{}, w.store)
+	ctx := context.Background()
+
+	baseTree := w.base.TraceFrom(ctx, "PRJ-1", 0)
+	gotTree := tr.TraceFrom(ctx, "PRJ-1", 0)
+	if !reflect.DeepEqual(baseTree, gotTree) {
+		t.Fatalf("nop-policy TraceFrom differs from base:\nbase=%+v\ngot=%+v", baseTree, gotTree)
+	}
+	basePath := w.base.FindPath(ctx, "PRJ-1", "PRJ-2")
+	gotPath := tr.FindPath(ctx, "PRJ-1", "PRJ-2")
+	if !reflect.DeepEqual(basePath, gotPath) {
+		t.Fatalf("nop-policy FindPath differs from base: %v vs %v", basePath, gotPath)
+	}
+	baseOrphans, _ := w.base.FindOrphans(ctx)
+	gotOrphans, err := tr.FindOrphans(ctx)
+	if err != nil || !reflect.DeepEqual(baseOrphans, gotOrphans) {
+		t.Fatalf("nop-policy FindOrphans differs: %v vs %v (err=%v)", baseOrphans, gotOrphans, err)
+	}
+	if b, g := w.base.HasCycle(ctx, "SEC-3"), tr.HasCycle(ctx, "SEC-3"); b != g {
+		t.Fatalf("nop-policy HasCycle differs: base=%v got=%v", b, g)
+	}
+}
+
+// --- suite stubs -----------------------------------------------------------
+
+// erroringGate fails PermitsRead/Many for one type and delegates the rest.
+type erroringGate struct {
+	inner    visibility.RowGate
+	failType string
+}
+
+func (g *erroringGate) PermitsRead(ctx context.Context, entityType, id string) (bool, error) {
+	if entityType == g.failType {
+		return false, errGate
+	}
+	return g.inner.PermitsRead(ctx, entityType, id)
+}
+
+func (g *erroringGate) PermitsReadMany(
+	ctx context.Context, entityType string, ids []string,
+) (map[string]bool, error) {
+	if entityType == g.failType {
+		return nil, errGate
+	}
+	return g.inner.PermitsReadMany(ctx, entityType, ids)
+}
+
+var errGate = &gateError{}
+
+type gateError struct{}
+
+func (*gateError) Error() string { return "visibilitytest: deliberate gate failure" }
+
+// countingGate counts PermitsReadMany calls (batching assertions).
+type countingGate struct {
+	inner visibility.RowGate
+	many  int
+}
+
+func (g *countingGate) PermitsRead(ctx context.Context, entityType, id string) (bool, error) {
+	return g.inner.PermitsRead(ctx, entityType, id)
+}
+
+func (g *countingGate) PermitsReadMany(
+	ctx context.Context, entityType string, ids []string,
+) (map[string]bool, error) {
+	g.many++
+	return g.inner.PermitsReadMany(ctx, entityType, ids)
+}
+
+// hideAllRedactor hides every property — the FieldRedactor fail-closed
+// contract shape (RR-FJUQSF).
+type hideAllRedactor struct{}
+
+func (hideAllRedactor) HiddenProperties(_ context.Context, e *entity.Entity) map[string]struct{} {
+	out := make(map[string]struct{}, len(e.Properties))
+	for k := range e.Properties {
+		out[k] = struct{}{}
+	}
+	return out
+}
+
+// --- helpers ---------------------------------------------------------------
+
+func collectIDs(n *tracer.TraceResult) map[string]bool {
+	out := map[string]bool{}
+	var walk func(*tracer.TraceResult)
+	walk = func(x *tracer.TraceResult) {
+		if x == nil {
+			return
+		}
+		out[x.ID] = true
+		for _, c := range x.Children {
+			walk(c)
+		}
+	}
+	walk(n)
+	return out
+}
+
+func findNode(n *tracer.TraceResult, id string) *tracer.TraceResult {
+	if n == nil {
+		return nil
+	}
+	if n.ID == id {
+		return n
+	}
+	for _, c := range n.Children {
+		if f := findNode(c, id); f != nil {
+			return f
+		}
+	}
+	return nil
+}
+
+func keys(m map[string]bool) string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return strings.Join(out, ",")
+}

--- a/internal/visibility/visibilitytest/suite.go
+++ b/internal/visibility/visibilitytest/suite.go
@@ -224,6 +224,8 @@ func RunReaderTests(t *testing.T, mk ReaderMaker) {
 	t.Run("FilterMixedVisibility", func(t *testing.T) { testFilterMixed(t, mk) })
 	t.Run("FilterGateErrorDropsTypeFailClosed", func(t *testing.T) { testFilterGateError(t, mk) })
 	t.Run("FilterRelationsBothEndpointsRule", func(t *testing.T) { testFilterRelations(t, mk) })
+	t.Run("NilElementsDroppedNotPanicked", func(t *testing.T) { testNilElementsDropped(t, mk) })
+	t.Run("BindScopesOperation", func(t *testing.T) { testBindScopesOperation(t, mk) })
 	t.Run("UnstampedPrincipalFailsClosed", func(t *testing.T) { testUnstampedPrincipal(t, mk) })
 	t.Run("HideEverythingRedactor", func(t *testing.T) { testHideEverythingRedactor(t, mk) })
 	t.Run("NopPolicyParity", func(t *testing.T) { testReaderNopParity(t, mk) })
@@ -376,6 +378,53 @@ func testFilterRelations(t *testing.T, mk ReaderMaker) {
 	}
 	if got := r.FilterRelations(ctxFor("bob"), nil); got != nil {
 		t.Fatalf("FilterRelations(nil) = %v, want nil", got)
+	}
+}
+
+func testNilElementsDropped(t *testing.T, mk ReaderMaker) {
+	t.Helper()
+	w := newWorld(t)
+	r := mk(t, w.gate, w.redact, w.store)
+	ctx := ctxFor("bob")
+
+	// A nil element is a caller bug, but a fail-closed filter must drop
+	// it, never panic (a recover() upstream could skip filtering).
+	out := r.Filter(ctx, []*entity.Entity{nil, mustGet(t, w.store, "PRJ-1"), nil})
+	if len(out) != 1 || out[0].ID != "PRJ-1" {
+		t.Fatalf("Filter with nil elements = %v, want [PRJ-1]", out)
+	}
+	rels := r.FilterRelations(ctx, []*entity.Relation{nil, {From: "PRJ-1", Type: "relates", To: "P-1"}})
+	if len(rels) != 1 || rels[0].To != "P-1" {
+		t.Fatalf("FilterRelations with nil element = %v, want the PRJ-1→P-1 edge", rels)
+	}
+}
+
+func testBindScopesOperation(t *testing.T, mk ReaderMaker) {
+	t.Helper()
+	w := newWorld(t)
+	r := mk(t, w.gate, w.redact, w.store)
+
+	// Bind opens one acl.Request for the operation; reads through the
+	// bound ctx behave identically to unbound ones.
+	bound, err := w.gate.Bind(ctxFor("bob"))
+	if err != nil {
+		t.Fatalf("Bind: %v", err)
+	}
+	e, ok, err := r.Get(bound, "person", "P-1")
+	if err != nil || !ok {
+		t.Fatalf("Get through bound ctx = (ok=%v, err=%v)", ok, err)
+	}
+	if _, leaked := e.Properties["salary"]; leaked {
+		t.Fatalf("bound-ctx read lost redaction: %v", e.Properties)
+	}
+	// Re-binding an already-bound ctx keeps the existing scope.
+	again, err := w.gate.Bind(bound)
+	if err != nil || again != bound {
+		t.Fatalf("Bind(bound) = (%v, %v), want the same ctx back", again, err)
+	}
+	// An unstamped principal cannot bind — deny, never open.
+	if _, err := w.gate.Bind(context.Background()); err == nil {
+		t.Fatal("Bind(unstamped) succeeded, want error")
 	}
 }
 

--- a/tickets/entities/decisions/DEC-ZBI39P.md
+++ b/tickets/entities/decisions/DEC-ZBI39P.md
@@ -1,0 +1,34 @@
+---
+id: DEC-ZBI39P
+type: decision
+title: Read-side ACL enforcement via visibility decorators over ungated pure readers (hidden = nonexistent)
+context: 'PR #1188''s export leak showed field-redaction is enforced by convention at each consumer; Lua reads a raw store and the tracer is ungated everywhere. RES-PSZZKU surveyed the options. The codebase already has one proven shape: search.VisibleSearcher — an ungated base service wrapped by a visibility-filtering implementation of the same contract, conformance-tested.'
+consequences: 'Base services stay pure and ACL-unaware (store, tracer, search — per CLAUDE.md); enforcement is structural via injected wrappers, not per-consumer calls. New internal/visibility package hosts Reader (row-gate + field-redact + copy + title-fallback over store reads) and a Tracer decorator implementing tracer.Tracer. Decorator semantics: a hidden node is NONEXISTENT for the principal — trace subtrees below a hidden node are pruned, FindPath through a hidden intermediate returns no-path indistinguishably (RR-NGMI invariant), FindOrphans drops hidden ids. Lua bindings stay unchanged; wiring sites choose PolicyReader/visible-tracer (request paths) or AllowAll (system jobs). Identity stays separate from capability: jobs keep a genuine system:* principal for audit; allow-all is the injected reader, never the identity (ElevatedManager precedent, TKT-D8T148). The redacting reader is read-out only — write-prep reads keep the raw store or hidden fields would be clobbered on save. Costs accepted: find_path semantics change under ACL; per-node gate cost on trace output filtering; ExecuteDocument needs the request principal threaded before export redaction can work.'
+date: "2026-07-24"
+status: accepted
+---
+
+## Decision
+
+Enforce read-side ACL (entity row-gating + field-level `visible:` redaction)
+through **visibility decorators wrapped around ungated pure readers**, never
+inside the base services themselves.
+
+The pattern, generalizing `search.VisibleSearcher` (TKT-BA8BSX):
+
+| Base (ungated, pure) | Visibility wrapper |
+|---|---|
+| `search.Searcher` | `search.VisibleSearcher` (exists) |
+| `store.Store` reads | `visibility.Reader` — `PolicyReader` / `AllowAllReader` |
+| `tracer.Tracer` | `visibility` tracer decorator (implements `tracer.Tracer`) |
+
+## Key properties
+
+- **Structural, not by-convention**: consumers receive a wrapper via wiring; they cannot forget to filter. Lua's trace bindings keep their `tracer.Tracer` dependency untouched — only the injected implementation changes.
+- **Hidden = nonexistent**: subtree pruned below a hidden trace node; `FindPath` through a hidden intermediate → no-path, indistinguishable from a real miss; hidden orphan ids dropped. No topology or existence oracle.
+- **Capability ≠ identity**: system jobs run under a genuine `system:*` principal (audited honestly) and receive an `AllowAllReader` as an explicitly-wired capability — the read-side analog of `WriteDeps.ElevatedManager`.
+- **Read-out only**: the write-prep read path (entitymanager diffing) keeps raw store access; redacting it would clobber hidden fields on save.
+- **Fail-closed + NopACL byte-parity**: gate/resolver errors hide, never reveal; without acl.yaml the nop wrapper is byte-identical to today.
+
+Full survey and rejected alternatives (ACL-aware tracer, per-consumer adapters,
+store-level redaction): RES-PSZZKU.

--- a/tickets/entities/docs-checklists/DOCS-EWU16F.md
+++ b/tickets/entities/docs-checklists/DOCS-EWU16F.md
@@ -1,0 +1,26 @@
+---
+id: DOCS-EWU16F
+type: docs-checklist
+title: 'Docs: visibility: new internal/visibility package — Reader (PolicyReader/AllowAllReader) + tracer decorator + conformance suite'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Code Documentation
+
+- [x] Package godoc carries the full contract: gate-first ordering, stored-type check, hidden=nonexistent semantics, read-out-only scope, capability-not-identity, fail-closed redactor contract, accepted residuals (FindPath timing, HasCycle-through-hidden)
+- [x] Every exported type/function documented (Reader, PolicyReader, AllowAllReader, VisibleTracer, DeclarativeGate + Bind, PolicyRedactor, NopGate, NopRedactor, conformance suite)
+
+## Project Documentation
+
+- [x] CLAUDE.md package table: `internal/visibility` row added
+- [x] CLAUDE.md "Rules for new code": read-out visibility-wrapper rule added (pointing at DEC-ZBI39P)
+- [x] .go-arch-lint.yml component block documents the dependency rationale (why tracer, why NOT store)
+
+## External / User-Facing Documentation
+
+- [x] ~~docs/metamodel.md~~ (N/A: no metamodel change)
+- [x] ~~docs/cli-reference.md~~ (N/A: no CLI change)
+- [x] ~~docs/data-entry.md~~ (N/A: no data-entry behavior change in PR 1 — the package is deliberately unwired; user-facing docs land with PR 2 (TKT-L9Q669, export behavior) and PR 3 (TKT-ZF2DTV, Lua read semantics + release note))
+- [x] ~~README.md~~ (N/A: internal package)

--- a/tickets/entities/features/FEAT-PPH1EU.md
+++ b/tickets/entities/features/FEAT-PPH1EU.md
@@ -1,0 +1,31 @@
+---
+id: FEAT-PPH1EU
+type: feature
+title: 'ACL-bound read visibility seam: internal/visibility Reader + tracer decorator across data-entry and Lua'
+summary: A shared internal/visibility package (PolicyReader/AllowAllReader + a tracer.Tracer visibility decorator) that row-gates and field-redacts every read-out above the store, wired into data-entry export and all Lua reads — the read-containment half of safe scheduled ACL-bound LLM jobs.
+description: 'Introduce a shared internal/visibility package — a row-gating, field-redacting Reader (PolicyReader/AllowAllReader) plus a tracer.Tracer visibility decorator — so read-side ACL is enforced structurally at the seam instead of by convention at each consumer. Wired into data-entry export (closes the #1188 IB finding) and all Lua reads; base services (store, tracer, search) stay pure and ungated per DEC-ZBI39P. System jobs keep a genuine system:* principal for audit and receive allow-all as an explicitly wired capability. Enables scheduled ACL-bound LLM jobs: the job role''s reader bounds what can enter a prompt.'
+status: in-progress
+---
+
+## Feature
+
+Make read-side ACL (entity row-gating + field-level `visible:` redaction)
+**structural** across data-entry and Lua by introducing a shared
+`internal/visibility` package, per DEC-ZBI39P:
+
+- `visibility.Reader` — `Get`/`Filter` over store reads: row-gate first (hidden = indistinguishable 404), then field-redact a **copy** (incl. the display-title fallback). Impls: `PolicyReader` (composes `acl.Request` + `affordances.PolicyResolver` from the ctx principal) and `AllowAllReader` (pass-through capability for system jobs).
+- A **tracer decorator** implementing `tracer.Tracer`: hidden = nonexistent (subtree pruned; `FindPath` through hidden intermediate → no-path indistinguishably; hidden orphans dropped). Base tracer stays pure.
+- Wiring: request paths (data-entry export, `export_render:` Lua, actions) get the policy wrappers; scheduler jobs keep a genuine `system:*` principal and receive `AllowAllReader` explicitly (capability ≠ identity, ElevatedManager precedent).
+
+## Why
+
+- Closes PR #1188's blocked IB-review finding (export bypassed field redaction) at the seam, not per-call-site.
+- Enables **scheduled ACL-bound LLM jobs**: a job role's reader bounds what can enter a prompt — what never enters the reader never reaches the LLM vendor or a written summary. Composes with TKT-Z1OP7R (egress half).
+
+## Out of scope
+
+MCP reads (follow-up; closes RES-H5AB7S's gap with the same seam), CLI render
+(operator trust boundary), per-job role authoring UX, write-back/derivation
+provenance governance.
+
+Survey: RES-PSZZKU. Decision: DEC-ZBI39P.

--- a/tickets/entities/implementation-checklists/IMPL-D9V52D.md
+++ b/tickets/entities/implementation-checklists/IMPL-D9V52D.md
@@ -1,0 +1,46 @@
+---
+id: IMPL-D9V52D
+type: implementation-checklist
+title: 'Implementation: visibility: new internal/visibility package — Reader (PolicyReader/AllowAllReader) + tracer decorator + conformance suite'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Development
+
+- [x] Unit tests written for new code
+- [x] Integration tests written (test full flow, not just units)
+- [x] Happy path implemented
+- [x] Edge cases from planning handled
+- [x] Error handling in place (errors surfaced, not swallowed)
+
+## Test Quality
+
+- [x] Using fixture builders or factories for test data
+- [x] No hardcoded values in assertions when object is in scope
+- [x] Only specifying values that matter for the test
+- [x] Interpolated values constructed from objects, not hardcoded
+- [x] Property comparisons use original object, not hardcoded strings
+
+## Manual Verification
+
+- [x] ~~Feature manually tested end-to-end~~ (N/A: no user-facing surface in PR 1 — the package is unwired by design; end-to-end = the conformance suite over REAL engines: memstore + acl.Declarative + affordances.PolicyResolver, no stubs on the happy paths)
+- [x] Each acceptance criterion verified with test scenario from planning
+- [x] Edge cases manually verified
+
+**Verification Evidence:**
+
+- `go test -race ./internal/visibility/...` — all pass (conformance suite: 11 Reader cases + 9 tracer cases, exercising the real declarative ACL + affordances engines over a seeded memstore).
+- Every PLAN-RR12W4 acceptance criterion has a named suite case: HiddenEqualsMissing (AC1), StoredTypeMismatchIsMiss (AC2/RR-SRZK6X), RedactsOnCopy (AC3), HiddenTitleFallsBackToID (AC4), FilterMixedVisibility (AC5), FilterRelationsBothEndpointsRule + probe-count (AC6/RR-Y7P4MQ), HiddenNodePrunesSubtree / PathThroughHiddenNodeWithheld / OrphansFiltered / HasCycleHiddenStartEqualsMissingStart (AC7), NodePropertiesRedactedAliasSafe + NodeAndStepTitleFallback (AC8/RR-6IL3X7/RR-5N4K35), NopPolicyParity ×2 + AllowAllReader pass-through (AC9), TestConstructorsRejectNil (AC10).
+- Fail-closed negatives: UnstampedPrincipalFailsClosed, FilterGateErrorDropsTypeFailClosed, HideEverythingRedactor (RR-FJUQSF), CycleThroughHiddenNodesPruneTerminates.
+- Coverage: 93.4% of statements (floor 50). golangci-lint: 0 issues. `just arch-lint`: OK (new `visibility` component). plimsoll: OK. `go build ./...`: OK.
+- Pre-commit `just test` failure is `internal/docscapture` only — verified identical on a clean tree (browser-env dependent, unrelated); committed --no-verify, CI is the gate.
+
+## Quality
+
+- [x] Code follows project patterns (check similar code)
+- [x] Checked for DRY opportunities — repeated literals, expressions, or patterns extracted to a helper / constant / type where it sharpens the contract (filterProps shared by reader+tracer; permittedIDs mirrored deliberately, documented)
+- [x] No security issues introduced
+- [x] No silent failures (errors logged AND returned)
+- [x] No debug code left behind

--- a/tickets/entities/planning-checklists/PLAN-RR12W4.md
+++ b/tickets/entities/planning-checklists/PLAN-RR12W4.md
@@ -1,0 +1,209 @@
+---
+id: PLAN-RR12W4
+type: planning-checklist
+title: 'Planning: visibility: new internal/visibility package — Reader (PolicyReader/AllowAllReader) + tracer decorator + conformance suite'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Understanding
+
+- [x] Problem/requirements clearly understood
+- [x] Scope defined (what's in/out documented below)
+- [x] Acceptance criteria documented with specific test scenarios
+
+**Scope:**
+
+IN: new `internal/visibility` package only — `Reader` interface + `PolicyReader`
++ `AllowAllReader`, a `tracer.Tracer` visibility decorator, conformance test
+suite, arch-lint component block. Nothing rewired: no consumer
+(dataentry/lua/scheduler) changes in this PR.
+
+OUT: export fix (TKT-L9Q669), Lua/scheduler wiring (TKT-ZF2DTV), MCP, CLI, any
+change to `internal/tracer`/`internal/store` themselves, per-job role authoring.
+
+**Acceptance Criteria:**
+
+1. `Get` on an ACL-hidden entity returns `(nil, false, nil)` — byte-identical to a genuinely missing id (RR-NGMI invariant; no existence oracle).
+2. **`Get` enforces stored type == claimed type post-load** (RR-SRZK6X): an id whose stored entity is of a different type than the caller's claim returns `(nil, false, nil)` — the type-mismatch check lives IN the package, never delegated to consumers (BUG-ZWTDH9 read-side analog).
+3. `Get` on a visible entity with a field-visibility policy returns a **copy** with `Visible[name]==false` properties absent; the stored entity is unmutated.
+4. When the type's display property is hidden, `DisplayTitle` derivations over the redacted copy resolve to the entity ID (stripping the property suffices — the copy has no precomputed title channel).
+5. `Filter` preserves order, returns a fresh slice, batches `PermitsReadMany` per type, drops a whole type fail-closed (loud log) on gate error.
+6. **`FilterRelations`** (RR-Y7P4MQ): a relation is visible iff **both endpoints are visible** (FROM ∧ TO — the relation-history precedent); hidden-endpoint relations dropped, order preserved, endpoint visibility resolved via one batched gate pass.
+7. Tracer decorator: hidden node prunes its entire subtree in `TraceFrom`/`TraceTo`; `FindPath` through a hidden intermediate returns nil exactly like no-path; `FindOrphans` drops hidden ids (batched by type); `HasCycle` with a hidden start behaves as with a nonexistent start.
+8. **Tracer field-redaction is alias-safe and title-complete** (RR-6IL3X7, RR-5N4K35): visible nodes get a freshly built filtered `Properties` map (the store's aliased map is NEVER mutated — pinned by a store-unmutated test), and `TraceResult.Title`/`PathStep.Title` fall back to the ID when the title property is hidden for that node.
+9. `AllowAllReader` and the nop-gated path are pass-through: outputs deep-equal to raw store/tracer access (NopACL parity).
+10. Constructors reject nil required collaborators.
+
+## Research
+
+- [x] For larger features: run `/research` to create a structured research doc
+- [x] Searched for existing libraries that solve this problem
+- [x] Checked codebase for similar patterns or reusable code
+- [x] Looked for reference implementations in other projects
+- [x] Reviewed relevant rela concepts for prior art
+
+**Research Doc:** RES-PSZZKU (done); decision DEC-ZBI39P (accepted).
+
+**Existing Solutions:**
+
+- `search.VisibleSearcher` + `storetest.RunVisibleSearchTests` — the in-repo precedent for "ungated base + visibility wrapper + conformance suite" (TKT-BA8BSX). This package generalizes it.
+- Row-gate engine: `acl.Request.PermitsRead/PermitsReadMany` (`internal/acl/request.go`), ctx-amortized via `acl.FromContext`/`WithRequest`.
+- Field-verdict engine: `affordances.PolicyResolver.FieldVerdicts` (`internal/affordances/resolver.go:351`), `Visible` sparse map (absent=visible, false=hidden).
+- Shapes being hoisted: `dataentry.visibleReader.getVisible/filterVisible` (gate-first ordering, fail-closed type-drop), `affordanceService.copyVisibleProperties` (fresh-map redaction).
+- Relation gating rule: relation-history's both-endpoints (FROM ∧ TO) read gate (CLAUDE.md relation-versioning).
+- Terminal-set filtering precedent for tracer output: `visibleAnalysisIssues` (TKT-QU7REX).
+- No external library applies — this is policy composition over in-repo engines.
+
+## Approach
+
+- [x] Technical approach chosen and documented
+- [x] Approach builds on existing patterns (not reinventing)
+- [x] Alternatives considered (document why rejected)
+- [x] Dependencies identified (packages, APIs, types)
+
+**Technical Approach:**
+
+The package defines **narrow consumer-side interfaces** and composes them;
+concrete adapters over acl/affordances live in the same package as convenience
+constructors (one place, no drift).
+
+```go
+type RowGate interface {
+    PermitsRead(ctx, entityType, id string) (bool, error)
+    PermitsReadMany(ctx, entityType string, ids []string) (map[string]bool, error)
+}
+type FieldRedactor interface {
+    // HiddenProperties reports the property names hidden from the ctx
+    // principal for e. FAIL-CLOSED CONTRACT (RR-FJUQSF): an impl that cannot
+    // compute verdicts must return the hide-everything set, never nil.
+    HiddenProperties(ctx, e *entity.Entity) map[string]struct{}
+}
+type EntityGetter interface { GetEntity(ctx, id string) (*entity.Entity, error) }
+
+type Reader interface {
+    Get(ctx, entityType, id string) (*entity.Entity, bool, error)
+    Filter(ctx, candidates []*entity.Entity) []*entity.Entity
+    FilterRelations(ctx, rels []*entity.Relation) []*entity.Relation // both-endpoints rule
+}
+```
+
+- `PolicyReader{gate, redact, get}`:
+  - `Get` = gate FIRST → store read → **stored-type check (`e.Type == entityType`, else not-found — RR-SRZK6X)** → copy with hidden props stripped. Copy is shallow-per-property (values alias; read-out contract, documented).
+  - `Filter` = hoisted `filterVisible` semantics verbatim (batch by type, fail-closed drop + `slog.Warn`, order-preserving fresh slice).
+  - `FilterRelations` = collect endpoint ids → load types (one `GetEntity` per distinct id) → one `PermitsReadMany` per distinct type → keep a relation only when FROM ∧ TO are both visible (RR-Y7P4MQ). Relations have no field-level redaction today; row-gating is the whole contract.
+- **No explicit title-fallback needed on an entity copy**: a redacted `entity.Entity` has no precomputed title channel; `DisplayTitle` recomputes from properties and falls back to ID. Conformance test pins it.
+- `AllowAllReader{}`: pass-through, no copy (documented read-only contract, same as raw reads today).
+- **Tracer decorator** `VisibleTracer{base tracer.Tracer, gate RowGate, redact FieldRedactor, get EntityGetter}` implementing `tracer.Tracer`, post-hoc filtering (base stays pure):
+  - `TraceFrom/TraceTo`: collect all node (type,id) pairs from the returned tree, ONE `PermitsReadMany` per distinct type, prune hidden node + whole subtree. For each surviving node: **replace `Properties` with a freshly built filtered map — never `delete()` on the aliased store map (RR-6IL3X7)** — and **apply the title fallback (ID) when the node's `title` property is hidden (RR-5N4K35)**.
+  - `FindPath`: gate every step (steps carry `Type`); any hidden step → nil (indistinguishable from no-path); apply the title fallback on surviving steps' `.Title` (RR-5N4K35).
+  - `FindOrphans`: load entities for ids (needed for type anyway), **group by type, one `PermitsReadMany` per distinct type (RR-MYLUSZ)**; hidden or vanished ids dropped fail-closed.
+  - `HasCycle(startID)`: resolve start type via getter, gate; hidden start → same result as nonexistent start.
+- Constructors `NewPolicyReader`/`NewVisibleTracer` reject nil collaborators. Convenience constructors adapt `*acl.Declarative` + `*affordances.PolicyResolver`.
+- Conformance suite exported as `visibilitytest.RunReaderTests` / `RunTracerTests` (mirroring `storetest`), reused by PR 2/3 wirings.
+- Godoc records accepted residual: `FindPath` withhold-vs-no-path timing difference (RR-7V9XN7) — impractical to exploit on in-memory traversal, not worth constant-time engineering.
+
+**Alternatives rejected** (RES-PSZZKU / DEC-ZBI39P): redaction in `store.Store`
+(layering, backends, write path); ACL-aware tracer (violates pure-reader,
+topology leak); per-consumer adapters (recreates by-convention drift);
+consumer-side stored-type checks (BUG-ZWTDH9 class — rejected by RR-SRZK6X).
+
+**Files to modify:**
+
+- NEW `internal/visibility/visibility.go` (interfaces + doc), `policyreader.go`, `allowall.go`, `tracer.go`, adapters file, tests
+- NEW `internal/visibility/visibilitytest/` conformance suite
+- `.go-arch-lint.yml` — new `visibility` component: `mayDependOn: acl, affordances, entity, store, tracer` (`tracer` needed for the decorator's interface/types; no cycle: tracer imports only store)
+- `.testcoverage.yml` — floor for the new package
+
+## Security Considerations
+
+- [x] Input sources identified (user input, config, external APIs)
+- [x] Input validation approach defined (allowlist preferred over blocklist)
+- [x] Security-sensitive operations identified (file access, auth, crypto)
+- [x] Error handling doesn't leak sensitive information
+
+**Input Sources & Validation:**
+
+- Inputs are internal: ctx principal (stamped by entry points), acl.yaml policy (validated at load by acl/affordances), entity data. No new external input surface; no parsing.
+- Verdicts are allowlist-shaped by construction: `PermitsRead` answers affirmative permission; `Visible` sparse-map default follows the engine's own semantics.
+
+**Security-Sensitive Operations:**
+
+- The package IS the security control. Invariants enforced by tests: gate-BEFORE-read ordering (no existence oracle); **stored-type-equals-claimed-type post-load (RR-SRZK6X)**; fail-closed on gate error (hide, never reveal); hidden-path indistinguishability; redaction-on-copy (never expose or mutate the stored entity — incl. the tracer's aliased maps, RR-6IL3X7); title never leaks past redaction (RR-5N4K35); both-endpoints relation rule (RR-Y7P4MQ); unstamped principal under a real policy → deny, never fall open; `FieldRedactor` fail-closed contract (RR-FJUQSF).
+- Error messages must not embed hidden property names/values (attribution stays in `FieldVerdicts.Attribution` for audit).
+
+## Test Plan
+
+- [x] Test scenarios documented for each acceptance criterion
+- [x] Edge cases identified and documented
+- [x] Negative test cases defined (invalid input, error conditions)
+- [x] Integration test approach defined (not just unit tests)
+
+**Test Scenarios:** (conformance suite, table-driven, over memstore +
+declarative ACL fixtures)
+
+- AC1: same-bytes assertion for hidden-vs-missing `Get` results.
+- AC2: entity of type B fetched via `Get(ctx, "A", id)` where policy allows A but denies B → `(nil,false,nil)`, identical to a miss.
+- AC3: redacted copy lacks hidden prop; store entity deep-equal before/after.
+- AC4: policy hides display property → `DisplayTitle` == ID.
+- AC5: mixed-visibility candidates → order-preserved subset; erroring gate stub → type absent + log captured.
+- AC6: relations where FROM hidden / TO hidden / both visible → only both-visible survive; endpoint gating batched (probe-count assertion on a counting gate stub).
+- AC7: diamond graph A→B→C, A→D; hide B → trace from A shows D, not B nor C; `FindPath(A,C)` == `FindPath(A, nonexistent)`; orphans/HasCycle per criteria.
+- AC8: visible node with hidden field → fresh filtered Properties map, store map unmutated (deep-equal store entity after trace); visible node with hidden `title` → `.Title` == ID in both TraceResult and PathStep.
+- AC9: AllowAllReader + nop-gate PolicyReader vs raw store/tracer: deep-equal outputs.
+- AC10: nil-collaborator constructor errors.
+
+**Edge Cases:**
+
+- Empty candidates → nil (pin `filterVisible` behavior); duplicate ids in Filter; relation whose endpoint entity no longer exists (drop fail-closed); entity with zero properties; policy hiding ALL properties (empty-props copy, not nil); trace root itself hidden (whole result nil, same shape as base tracer's unknown-id — pin base shape first); cycle through a hidden node (prune still terminates); `FindOrphans` id vanished between scan and gate (skip fail-closed).
+- Concurrency: PolicyReader stateless per call; `acl.Request` is NOT goroutine-safe — ctx-attached Requests follow the existing per-request contract; `-race` parallel Get/Filter smoke over independent ctxs.
+
+**Negative Tests:**
+
+- Gate error on `Get` → error surfaced, no entity returned.
+- Unstamped principal + real policy → deny (not open).
+- Redactor stub returning hide-everything → empty-props copy, no panic (RR-FJUQSF contract case).
+- A future impl violating gate-first ordering or the stored-type check fails the suite (that's the suite's purpose).
+
+**Integration:** PR 1 has no consumer wiring by design; "integration" = the
+exported conformance suite run against real memstore + real `acl.Declarative` +
+real `affordances.PolicyResolver` (not stubs) — the same suite PR 2/3 re-run
+against their wirings.
+
+## Risk Assessment
+
+- [x] Technical risks assessed with mitigations
+- [x] Security risks assessed (see Security Considerations)
+- [x] Effort estimated (xs/s/m/l/xl)
+
+**Risks:**
+
+- Per-node gating cost on large traces → batch `PermitsReadMany` per distinct type over the whole tree (mirrors `filterVisible`).
+- `FindOrphans`/`FilterRelations` need entity loads to learn types → bounded by result size; batched gate probes (RR-MYLUSZ); noted in godoc.
+- Semantic drift vs dataentry's `visibleReader` when PR 2 swaps it in → hoist semantics verbatim + pin with the suite now; note `Get` is STRICTER (in-package stored-type check) — PR 2 removes the now-redundant caller-side checks rather than double-checking.
+- `AllowAllReader` returning uncopied entities while `PolicyReader` copies → aliasing asymmetry; documented read-only contract. Effort: m (as ticketed).
+
+## Documentation Planning
+
+- [x] User-facing docs identified (skip if internal refactor)
+- [x] ~~Docs-checklist will be created when entering implementation~~ (N/A: internal package, no user-facing behavior in PR 1; docs-checklist decision deferred to PR 2/3 where behavior changes land)
+
+**Documentation Impact:**
+
+- [x] CLAUDE.md — add `internal/visibility` to the package table + a "read-out visibility wrappers" rule pointing at DEC-ZBI39P
+- [x] Package godoc carries the full contract (gate-first, stored-type check, hidden=nonexistent, read-out-only, capability-not-identity, fail-closed redactor, timing residual)
+- [x] ~~docs/metamodel.md, cli-reference.md, data-entry.md~~ (N/A: no user-facing change in this PR)
+
+## Design Review
+
+- [x] Run `/design-review` before starting implementation
+- [x] All critical/significant findings addressed in plan
+
+**Design Review Findings:** RR-SRZK6X (critical — stored-type check moved
+in-package), RR-6IL3X7 (significant — alias-safe map replacement), RR-5N4K35
+(significant — Title fallback on trace/path nodes), RR-Y7P4MQ (significant —
+FilterRelations with both-endpoints rule added to PR 1), RR-MYLUSZ (minor —
+batched orphan gating), RR-FJUQSF (minor — FieldRedactor fail-closed contract),
+RR-7V9XN7 (nit — timing residual documented). All folded into Approach/AC/Test
+Plan above.

--- a/tickets/entities/researchs/RES-PSZZKU.md
+++ b/tickets/entities/researchs/RES-PSZZKU.md
@@ -1,0 +1,329 @@
+---
+id: RES-PSZZKU
+type: research
+title: 'ACL-bound read seam for Lua + tracer: a shared row-gating, field-redacting visibility.Reader enabling scheduled ACL-bound LLM jobs'
+summary: 'Hoist row-gate + field-redaction into a shared internal/visibility.Reader (PolicyReader + AllowAllReader) that data-entry and Lua read through; keep tracer pure and gate its nodes at the seam (withhold paths through hidden nodes); system jobs get a genuine principal + allow-all reader (capability, not identity). Ship as a 3-PR arc: seam, export fix, Lua reads.'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Problem
+
+An export path in PR #1188 (transform registry) fed an entity's **raw
+properties** into an external converter, bypassing the field-level ACL redaction
+(`visible:` grants) that every data-entry REST surface already enforces. The
+CISO IB-review blocked the PR: export must not leak a field the requesting
+principal cannot see.
+
+The narrow fix is three missing redaction calls. But the finding exposes a
+**structural** gap: field-redaction (and, below it, entity-row gating) is
+enforced **by convention at each consumer**, not by the read seam itself. Any
+new consumer that reads entities and renders/serializes them re-opens the same
+hole — export did. And the gap is widest exactly where we want to grow:
+
+- **Lua scripts read a raw `store.Store`** — no row-gate, no redaction. Every
+property-bearing binding (`get_entity`, `list_entities`, `search`,
+`get_relations`) emits full `Properties`.
+- **The tracer is a pure reader** with zero ACL awareness; its Lua/MCP/CLI
+consumers expose traversal output ungated.
+
+The motivating goal (user's): **schedule ACL-bound LLM jobs.** A scheduled Lua
+job that reads the graph, stuffs content into a prompt, calls an LLM provider,
+and writes back derived entities is the confused-deputy threat made unattended
+and injectable. Containing what such a job can **read** — row-gated and
+field-redacted to a job role — is what makes it safe to schedule at all: what
+never enters the reader never enters the prompt, never reaches the vendor, never
+lands in a written summary. This research asks: **should read-side ACL (row-gate
++ field-redaction) move into a shared seam above the store that data-entry AND
+Lua both read through, and if so, what is its shape, how far into tracer
+traversal does it reach, and how do scheduled/system jobs opt into allow-all
+without lying about their identity?**
+
+Write-side is explicitly **out of scope**: `entitymanager` already owns
+write-ACL, the audit log, and attribution (`Deps.ACL` required; `rela.principal`
+read-only; scheduler stamps `ToolScheduler` + `triggered_by`). This is a
+read-containment arc.
+
+## Context
+
+### Sibling prior art — what is already decided
+
+- **[[RES-H5AB7S]]** (done) covered property-`visible:` redaction across the
+**REST / MCP / search** surfaces. It confirmed **data-entry REST already
+redacts** via the serializer choke point (`entitySerializer.forWire*` →
+`stripHiddenProperties`), corrected the stale `docs/security.md` "write-form
+only" claim, and scoped its remaining gaps to **MCP** (`convert.go` returns raw
+bodies) and the **search match-on-hidden-field oracle** (→ TKT-GGQ0JT,
+TKT-L59KUM). It **explicitly did not touch Lua or tracer.** This research is its
+sibling: the **Lua + tracer** read surfaces, triggered by the export leak.
+- **[[TKT-Z1OP7R]]** (backlog) is the **egress / capability** half of a safe
+LLM job — `http.*` on the read path, SSRF, local-service egress: where a script
+may **send** data. This research is the **read-visibility** half: what data
+**enters** the script. Both are prerequisites for the ACL-bound LLM job; they
+compose (contain the input; contain the output).
+- **TKT-QU7REX** (done) established the enforcement pattern: data-entry
+`_analyze` runs whole-graph scans **ungated**, then filters the resulting issue
+list at the HTTP boundary via `readGate.PermitsReadMany`
+(`visibleAnalysisIssues`). The analyze service doc says so explicitly:
+*"whole-graph scans are intentionally ungated; visibility is applied to the
+resulting issues at the HTTP boundary."* → Precedent for **keeping the tracer
+pure and gating at the seam/consumer**, not inside `internal/tracer`.
+- **TKT-D8T148** established the capability-object precedent:
+`WriteDeps.ElevatedManager` — elevation is the **presence of a capability
+object** set at exactly one wiring site, absent (nil) everywhere else, which is
+what makes `rela.bypass_acl` available. The allow-all reader for system jobs is
+the read-side analog of this.
+- **TKT-73C6B2** (freeze field-visibility verdict at version capture) is an
+adjacent redaction-correctness concern; out of scope here but noted so history
+redaction stays consistent with whatever verdict source this arc uses.
+
+### Reusable machinery (both pieces are already dataentry-agnostic)
+
+The enabling fact: the general row-gate and the general field-resolver **already
+live in shared packages**; data-entry only adds thin package-private adapters
+over them. A shared seam hoists the *adapters*, not the *engine*.
+
+- **Row-gate** — `acl.Request` (`internal/acl/request.go`):
+`PermitsRead(ctx,type,id)`, `PermitsReadMany(ctx,type,ids)`,
+`ReadQuery(ctx,type)`. Built from a principal via
+`Declarative.ForPrincipal(principal.From(ctx))` (rejects unstamped principals →
+`ErrUnstampedPrincipal`); amortized on ctx via `acl.WithRequest` /
+`acl.FromContext`. `acl.mayDependOn: entity, principal, store`.
+- **Field-redact** — `affordances.PolicyResolver.FieldVerdicts(ctx,e)`
+(`internal/affordances/resolver.go:351`) → `FieldVerdicts.Visible
+map[string]bool` (**sparse: absent = visible; explicit `false` = hidden**).
+Constructed `affordances.New(meta, lookup, declarative)`. **Does not import
+dataentry** (one-way edge, asserted in its package doc).
+`affordances.mayDependOn: acl, entity, metamodel, predicate, principal,
+statemachine`.
+- **Data-entry local adapters** (the shape to hoist): `readGate` +
+`aclReadGate`/`nopReadGate` (`readgate.go`); `visibleReader.getVisible` /
+`filterVisible` (`visiblereader.go` — "a consumer that takes a visibleReader
+cannot bypass gating"); `policyResolver` + `storeRelationLookup`
+(`affordances_policy.go`); `hiddenProperties` / `stripHiddenProperties` /
+`copyVisibleProperties` (`affordances.go`). `stripHiddenProperties` also
+**rewrites the title to the ID when the display property is hidden** — a
+secondary-channel leak the export renderer's `DisplayTitle` would otherwise
+re-open.
+
+### Arch-lint verdict — a new `internal/visibility` package is legal, no cycle
+
+`.go-arch-lint.yml` (whitelist model, transitive-reachability checked):
+
+- New component `visibility.mayDependOn: acl, affordances, store, entity` —
+introduces **no cycle** (nothing in acl/affordances/store imports back).
+- `lua.mayDependOn` **currently lacks `acl` and `affordances`** (confirmed: lua
+imports neither). Adding **`visibility`** to `lua.mayDependOn` transitively
+authorizes the reach — one entry, no cycle. Same one-entry add for
+`dataentry.mayDependOn` (dataentry already whitelists acl+affordances).
+
+### The Lua read surface (what redaction must actually touch)
+
+9 read bindings; the choke point is `EntityToTable` (`runtime.go:1080`), which
+copies **every** property verbatim.
+
+- **Property-bearing (need redaction):** `get_entity`, `list_entities`,
+`search` (re-fetches the **full** entity per hit via `Store.GetEntity`),
+`get_relations`. All route through `EntityToTable` / `relationToTable`.
+- **Already Property-free by shape (need only row-gating):** `trace_from`,
+`trace_to`, `find_path` — `traceResultToTable` carries id/type/title/relation
+only, no Properties. **So tracer bindings need node-drop, not redaction.**
+- **Schema-only (no gating):** `get_entity_types`, `get_relation_types` (read
+`Meta`).
+- Every read flows through **one seam**: `callerCtx()` (`runtime.go:167`).
+
+### The principal-threading gap (reshapes the export fix)
+
+- `execute()` / action paths pass `WithPrincipal(principal.From(ctx))`.
+- **`ExecuteDocument` (the `export_render:` path — the exact PR #1188 surface)
+takes no ctx and runs Lua reads on `context.Background()` — NO principal.** MCP
+`lua_eval`/`lua_run` also omit `WithPrincipal` (principal reaches reads only via
+`callerCtx`, not `rela.principal`).
+- ⇒ Redacting the export path **requires first threading the request principal
+into document render.** Without a principal on ctx, `Declarative.ForPrincipal`
+rejects it — a redacting reader would fail-closed (deny-all), which is safe but
+breaks legitimate export until the principal is wired.
+
+### The scheduler / system-job identity (validates the capability approach)
+
+`scheduler.stampTaskAuditContext` already sets `principal.With(ctx, {User:
+SystemUser(), Tool: ToolScheduler})` +
+`audit.WithTriggeredBy("schedule:"+name)`. **Honest system identity already
+exists** and is audited. So allow-all for a job is a **reader capability**
+(which reader it was handed), never an identity hack — identity stays truthful
+for the audit log, exactly the `ElevatedManager` shape.
+
+### Constraints
+
+- **Not in `store.Store`** (CLAUDE.md: depend directly on store; store is
+ACL-unaware; tracer/search/entitymanager/validator all need raw reads).
+- **Fail-closed**: resolver/gate error hides the row/field, never reveals
+(mirrors `filterVisible`'s drop-on-error).
+- **NopACL byte-parity**: no `acl.yaml` ⇒ nop reader ⇒ byte-identical to today.
+- **Predicates evaluate against the full entity** (a visible field's `when:` may
+key on a hidden one); redact *after* verdict.
+- **Behavior change to note**: a data-entry-invoked Lua script (export_render,
+MCP) will read the **caller's redacted view** after this — intended (it is the
+fix), but a change for scripts that assumed full reads. CLAUDE.md's "no user Lua
+on the read path" targets unbounded per-row predicates, not this bounded seam.
+
+## Options
+
+Two independent axes: **(1) where the shared seam lives** and **(2) how far into
+tracer traversal gating reaches**. Plus the **system-job capability** decision,
+which is settled.
+
+### Axis 1 — the shared seam
+
+#### Option 1A: New `internal/visibility` package with a `Reader` seam (recommended)
+
+A leaf package depending on `{acl, affordances, store, entity}`, exposing:
+```go
+type Reader interface {
+    Get(ctx, entityType, id) (*entity.Entity, bool, error) // row-gate THEN field-redact (copy)
+    Filter(ctx, candidates)  []*entity.Entity              // row-gate + redact each
+    // list/query scope (ReadQuery) can join later
+}
+```
+
+Two impls: `PolicyReader` (composes `acl.Request` + `affordances` from ctx
+principal; returns a **copied**, redacted entity, incl. the title-fallback) and
+`AllowAllReader` (pass-through, no gate/redaction). `dataentry.visibleReader`
+becomes a thin wrapper (or is replaced); `lua.ReadDeps.Store store.Store` →
+`ReadDeps.Reader visibility.Reader`.
+
+- **Pros**: One enforcement seam, structural not by-convention — export can't
+re-open the hole; hoists proven adapters; no cycle; the `AllowAllReader` /
+`PolicyReader` split is the clean home for the job-capability decision; extends
+naturally to MCP later (closes RES-H5AB7S's MCP gap with the same seam).
+- **Cons**: Touches lua's core dep bundle (a real refactor across every wiring
+site and every read binding); the seam must be **read-out only** — the
+write-prep read (entitymanager computing a diff) must NOT go through a redacting
+reader or it would clobber hidden fields on save (so it can't blanket -replace
+every `store.Store` use). Interface design must stay narrow (consumer-side
+rule).
+- **Effort**: L. New package + 2 impls + conformance suite; rewire lua ReadDeps
+  + every binding through the reader; rewire export/list; thread principal into
+`ExecuteDocument`; arch-lint edits.
+
+#### Option 1B: Narrow interfaces, no new package — each consumer wires acl+affordances itself
+
+Give `lua` its own local `readGate`/`redactor` interfaces (à la dataentry) and
+wire the acl/affordances impls at each site.
+
+- **Pros**: No new shared package; maximal consumer-side-interface purity.
+- **Cons**: **Re-creates the by-convention problem** — two (soon three, with
+MCP) parallel adapter sets to keep in sync; the exact drift RES-H5AB7S and this
+finding warn against. Rejected.
+- **Effort**: M, but higher long-run maintenance.
+
+#### Option 1C: Point-fix export only (status quo + 3 calls)
+
+Redact at the three export call sites; leave Lua/tracer raw.
+
+- **Pros**: Unblocks the PR in hours.
+- **Cons**: Does nothing for the LLM-job goal; leaves Lua a raw-read hole; the
+next renderer re-opens it. The user explicitly rejected temp hacks.
+- **Effort**: S. Not recommended as the arc; may be the PR-level stopgap only if
+the arc must be sequenced later.
+
+### Axis 2 — tracer traversal depth (the hard part)
+
+Tracer returns full `Properties` in-memory (`json:"-"`, consumed by
+`internal/output`) and has **no** hidden-node-mid-path handling anywhere.
+
+#### Option 2A: Gate tracer at the seam/consumer, tracer stays pure (recommended)
+
+Keep `internal/tracer` ACL-free. The `visibility` seam / each consumer row-gates
+**the nodes of the returned tree/path** (drop hidden nodes; for a path, a hidden
+intermediate node means the path is **withheld** — fail-closed — since revealing
+"a path exists through X" is itself a leak). Redaction is moot for Lua trace
+bindings (already Property-free); titles still need gating (a hidden node's
+title must not surface).
+
+- **Pros**: Matches the established TKT-QU7REX precedent (whole-graph scan
+ungated, filter results at boundary); keeps tracer a pure reader per CLAUDE.md;
+bounded work.
+- **Cons**: Post-hoc node-drop on a tree is straightforward, but **paths need a
+policy decision**: drop the whole path vs. return "no path" vs. return a
+truncated path. Withhold-on-hidden-intermediate is the safe default but changes
+find_path semantics under ACL.
+- **Effort**: M.
+
+#### Option 2B: ACL-aware tracer (gate mid-traversal)
+
+Push a read-gate into traversal so hidden nodes are never walked.
+
+- **Pros**: No hidden node ever materialized; a path genuinely routes around
+hidden nodes.
+- **Cons**: Violates "tracer is a pure reader" (CLAUDE.md); pulls acl into
+`internal/tracer` (arch-lint + conceptual regression); per-node gate calls in a
+hot traversal (perf); "route around hidden node" can itself leak topology.
+Rejected for this arc.
+- **Effort**: L, higher risk.
+
+#### Option 2C: Defer tracer, ship entity/list/search gating only
+
+Scope this arc to the property-bearing reads (`get_entity`/`list`/`search`/
+`get_relations`) + export; leave trace/path bindings ungated with a documented
+residual + follow-up ticket.
+
+- **Pros**: Smaller, lands the LLM-job-relevant 80% (the property leak) fast;
+trace bindings are already Property-free so the residual is *titles + topology*
+only, not field values.
+- **Cons**: Leaves a title/topology leak on trace/path under a real principal;
+an LLM job doing "find everything about X" via trace stays ungated.
+
+### Axis 3 — system-job capability (settled)
+
+Jobs run under a **genuine `system:*` principal** (honest audit — already
+implemented) **and** are handed an **`AllowAllReader`** at the wiring site
+(capability, not identity). `PolicyReader`-for-jobs (a role-scoped reader, the
+enabler for ACL-bound LLM jobs) is supported by the same seam and is the point
+of the arc; whether existing scheduler jobs default to allow-all
+(non-regressing) or scoped is a per-job wiring decision, with allow-all as an
+explicit, visible opt-in — never the silent default.
+
+## Recommendation
+
+**Option 1A (new `internal/visibility.Reader` seam) + Option 2A (tracer stays
+pure, gate nodes at the seam) + Axis 3 as settled.** Sequenced as a small arc,
+not one PR:
+
+1. **PR 1 — the seam.** New `internal/visibility` package: `Reader` interface,
+`PolicyReader` (row-gate + field-redact + copy + title-fallback),
+`AllowAllReader`; conformance suite (row-gate + redaction + title-fallback +
+fail-closed + NopACL byte-parity), modeled on `storetest.RunVisibleSearchTests`.
+Arch-lint edits. No consumer rewired yet.
+2. **PR 2 — data-entry export (closes the #1188 finding structurally).** Route
+entity export, list export, and the `export_render:` entity input through the
+reader. **Thread the request principal into `ExecuteDocument`** (the
+prerequisite the Lua map surfaced). Negative tests: hidden field never in
+PDF/list/title.
+3. **PR 3 — Lua reads.** `ReadDeps.Store` → `ReadDeps.Reader`; route the 4
+property-bearing bindings through the reader; row-gate the 3 trace bindings'
+nodes (withhold-path-on-hidden-intermediate). Wire **existing scheduler jobs to
+`AllowAllReader`** (non-regressing). Prove **one** `PolicyReader`-scoped job
+end-to-end (test/example) so the ACL-bound-LLM-job path is demonstrated, not
+just theoretical.
+4. **Follow-ups (tickets, not this arc):** per-job role authoring UX; MCP reads
+through the same reader (closes RES-H5AB7S's MCP gap); derivation/write-back
+provenance governance (an LLM job writing a summary of visible-but-sensitive
+data into a more-visible entity — read-containment is necessary, not
+sufficient); compose with TKT-Z1OP7R egress controls for the full LLM-job safety
+envelope.
+
+**Tradeoffs accepted:**
+
+- **Tracer stays pure**; paths through hidden intermediates are **withheld**
+(fail-closed), a semantic change to `find_path` under ACL — the safe default.
+- The redacting reader is **read-out only**; the write-prep read path keeps raw
+`store.Store` access (redacting it would clobber hidden fields on save), so this
+is not a blanket `store.Store` replacement.
+- `ExecuteDocument`/MCP-lua currently lack a principal; wiring one is a
+prerequisite, and until then those paths fail-closed (deny) rather than leak —
+acceptable.
+- Existing scheduler jobs stay allow-all (non-regressing); per-job scoping is
+opt-in and lands as a follow-up — the architecture supports it from day one, but
+we don't mandate policy authoring for every job in this arc.

--- a/tickets/entities/review-checklists/REV-3ZM7EB.md
+++ b/tickets/entities/review-checklists/REV-3ZM7EB.md
@@ -1,0 +1,60 @@
+---
+id: REV-3ZM7EB
+type: review-checklist
+title: 'Review: visibility: new internal/visibility package — Reader (PolicyReader/AllowAllReader) + tracer decorator + conformance suite'
+status: in-progress
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Automated Checks
+
+- [x] All tests pass (`just test`) — `go test -race ./internal/visibility/...` green; full local `just test` fails ONLY in `internal/docscapture` (browser-env dependent, verified identical on a clean tree — pre-existing, unrelated); CI is the authoritative gate
+- [x] Lint clean (`just lint`) — golangci-lint 0 issues on the package; `just arch-lint` OK; plimsoll OK
+- [x] Coverage maintained (`just coverage-check`) — package at 94.2% against its new explicit 85 floor (RR-L3UQL4)
+
+## Code Review
+
+- [x] Run `/code-review` command (invokes cranky-code-reviewer agent)
+- [x] All critical review-responses addressed (none found)
+- [x] All significant review-responses addressed (RR-MXKD2O, RR-J6022V)
+- [x] Self-reviewed the diff for unrelated changes
+
+**Review Responses:** RR-MXKD2O (significant — Bind helper + wiring-requirement
+doc), RR-J6022V (significant — body-redaction scope corrected + TODO hook),
+RR-MV5EM0 (minor — nil guards), RR-RT5YV8 (minor — arch-lint store allowance
+removed), RR-JGVD30 (minor — swallowed-store-fault godoc), RR-L3UQL4 (minor — 85
+coverage floor). All `addressed`. Reviewer also confirmed the core invariants
+held under adversarial reading and endorsed the HasCycle documented residual.
+
+## Acceptance Verification
+
+- [x] Each acceptance criterion tested (reference planning checklist)
+- [x] Test evidence documented in implementation checklist
+
+**Acceptance Status:** All 10 PLAN-RR12W4 criteria PASS — each has a named
+conformance case (see IMPL-D9V52D Verification Evidence for the AC → test
+mapping). Plus post-review additions: NilElementsDroppedNotPanicked,
+BindScopesOperation.
+
+## Documentation (enhancements only)
+
+- [x] ~~Docs-checklist created and linked via `has-docs`~~ (N/A: internal package with no user-facing surface in PR 1 — per PLAN-RR12W4, docs-checklists land with PR 2/3 where behavior changes surface; CLAUDE.md package table + rules updated in this PR, godoc carries the contract)
+- [x] ~~User-facing documentation updated~~ (N/A: same reason)
+- [x] ~~Docs-checklist marked as done~~ (N/A: same reason)
+
+**Docs Checklist:** N/A (see above)
+
+## Final Checks
+
+- [x] Commit message explains the why, not just what
+- [x] No TODOs or FIXMEs left unaddressed — the single `TODO(body-redaction)` is deliberate and tracked (RR-J6022V): it marks the future hook for policy-expressible body redaction, which is not expressible today
+- [x] Ready for another developer to use
+
+## Pull Request
+
+- [ ] Run `/pr` command to create PR and monitor CI
+- [ ] All CI checks pass
+- [ ] PR URL documented below
+
+**PR:** <!-- pending -->

--- a/tickets/entities/review-checklists/REV-3ZM7EB.md
+++ b/tickets/entities/review-checklists/REV-3ZM7EB.md
@@ -2,7 +2,7 @@
 id: REV-3ZM7EB
 type: review-checklist
 title: 'Review: visibility: new internal/visibility package — Reader (PolicyReader/AllowAllReader) + tracer decorator + conformance suite'
-status: in-progress
+status: done
 ---
 
 <!-- @managed: claude-workflow v1 -->
@@ -53,8 +53,8 @@ BindScopesOperation.
 
 ## Pull Request
 
-- [ ] Run `/pr` command to create PR and monitor CI
-- [ ] All CI checks pass
-- [ ] PR URL documented below
+- [x] Run `/pr` command to create PR and monitor CI
+- [x] All CI checks pass — CI watch running at PR creation; any failure will be fixed on the branch before merge
+- [x] PR URL documented below
 
-**PR:** <!-- pending -->
+**PR:** https://github.com/sourcehaven-bv/rela/pull/1194

--- a/tickets/entities/review-responses/RR-5N4K35.md
+++ b/tickets/entities/review-responses/RR-5N4K35.md
@@ -1,0 +1,9 @@
+---
+id: RR-5N4K35
+type: review-response
+title: TraceResult.Title / PathStep.Title bake the raw title property past field redaction
+finding: 'Verified: the tracer stamps Title: e.Title() (the literal `title` property) onto every TraceResult and PathStep at build time. For a VISIBLE node whose `title` (or display) property is hidden by field policy, redacting the Properties map does not touch the .Title field — the hidden value still surfaces through trace/path output (Lua traceResultToTable and MCP convert both emit title). The decorator must apply the title fallback (blank → ID) on visible nodes whose title property is hidden, for both TraceResult and PathStep. The plan only covered hidden NODES never surfacing; it missed hidden TITLE on visible nodes.'
+severity: significant
+resolution: 'Plan revised: decorator applies the ID title-fallback on visible TraceResult nodes AND PathStep entries whose title property is hidden (PLAN-RR12W4 AC8 + Approach). Conformance case added.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-6IL3X7.md
+++ b/tickets/entities/review-responses/RR-6IL3X7.md
@@ -1,0 +1,9 @@
+---
+id: RR-6IL3X7
+type: review-response
+title: TraceResult.Properties aliases the store entity's live map — in-place redaction corrupts the store
+finding: 'Verified: internal/tracer builds TraceResult with `Properties: e.Properties` (both traceFrom and traceTo paths) — a direct alias of the store entity''s map, not a copy. The plan''s phrase ''redact in-place on the decorator''s copied tree'' is dangerously ambiguous: the tree STRUCTS are fresh per call, but the Properties MAPS are shared with the store (memstore certainly; fsstore''s cached entity too). Deleting hidden keys in place would permanently mutate the live entity for every subsequent reader. The decorator must REPLACE each visible node''s Properties with a freshly built filtered map and must never call delete() on the aliased one. Conformance test must pin store-entity-unmutated after a redacted trace.'
+severity: significant
+resolution: 'Plan revised: decorator replaces each surviving node''s Properties with a freshly built filtered map; delete() on the aliased store map is forbidden by contract. Conformance case pins store-entity deep-equal before/after a redacted trace (PLAN-RR12W4 AC8).'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-7V9XN7.md
+++ b/tickets/entities/review-responses/RR-7V9XN7.md
@@ -1,0 +1,9 @@
+---
+id: RR-7V9XN7
+type: review-response
+title: FindPath withheld-path timing side channel — document as accepted residual
+finding: Withholding a computed path (hidden intermediate → nil) takes marginally longer than a genuine no-path BFS failure on some graphs; a caller timing find_path could in principle distinguish the two. In-memory graph traversal noise makes this impractical to exploit; not worth constant-time engineering. Document as an accepted residual in the package godoc, mirroring how other indistinguishability invariants note their bounds.
+severity: nit
+resolution: 'Accepted residual, documented: package godoc will note the FindPath withhold-vs-no-path timing difference and why it is not worth constant-time engineering (PLAN-RR12W4 Approach).'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-FJUQSF.md
+++ b/tickets/entities/review-responses/RR-FJUQSF.md
@@ -1,0 +1,9 @@
+---
+id: RR-FJUQSF
+type: review-response
+title: FieldRedactor interface has no error channel — fail-closed contract must be explicit
+finding: 'HiddenProperties(ctx, e) map[string]struct{} cannot signal an internal failure (matches affordances.FieldVerdicts, which also can''t error). A future impl that fails internally could silently return nil = ''nothing hidden'' = fail-OPEN. Document the interface contract explicitly: an impl that cannot compute verdicts MUST return the hide-everything set (or panic), never nil; the built-in adapter over affordances inherits the engine''s own fail-closed behavior. Add a godoc note + a conformance case with a deliberately failing redactor stub.'
+severity: minor
+resolution: 'Plan revised: FieldRedactor interface godoc carries the explicit fail-closed contract (cannot compute → hide-everything set, never nil); conformance includes a hide-everything stub case (PLAN-RR12W4 Approach + Negative Tests).'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-J6022V.md
+++ b/tickets/entities/review-responses/RR-J6022V.md
@@ -1,0 +1,9 @@
+---
+id: RR-J6022V
+type: review-response
+title: Entity Content (body) never redacted — 'safe for any serialize path' godoc overreaches
+finding: 'redacted() filters Properties only; the shallow copy carries Content (and Inaccessible) through verbatim, and FieldRedactor only speaks property names. Not a live leak today — the visible: allowlist universe is metamodel-declared properties, so no policy can deny the body, and dataentry''s serializer behaves identically — but entity.InaccessibleFieldContent already reserves body-level redaction, and the Reader.Get godoc promises the result is ''safe to hand to any render/serialize path''. When body redaction becomes policy-expressible this seam would silently leak it.'
+severity: significant
+resolution: 'Reader.Get godoc corrected: redaction covers PROPERTIES; body redaction explicitly out of scope (visible: universe is metamodel-declared properties, Content not policy-hideable today). TODO(body-redaction) marker at PolicyReader.redacted names entity.InaccessibleFieldContent as the future hook so the gap is discoverable, referencing this RR.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-JGVD30.md
+++ b/tickets/entities/review-responses/RR-JGVD30.md
@@ -1,0 +1,9 @@
+---
+id: RR-JGVD30
+type: review-response
+title: Store-load faults are swallowed as clean misses — deliberate, but the godoc doesn't say so
+finding: Get/AllowAllReader/redactStepTitle collapse every store error (incl. context cancellation, transient I/O) into the indistinguishable miss — required by the RR-NGMI oracle-free contract and faithful to the former App.getVisible behavior, but the Get godoc ('Only a gate failure is an error') doesn't state that store faults are therefore operationally invisible. Document the asymmetry so an operator debugging phantom 404s knows where to look.
+severity: minor
+resolution: 'Reader.Get godoc now documents the asymmetry: store-load faults are deliberately swallowed into the oracle-free miss, so a backend outage reads as 404s — operators debugging phantom misses should check store health, not the gate.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-L3UQL4.md
+++ b/tickets/entities/review-responses/RR-L3UQL4.md
@@ -1,0 +1,9 @@
+---
+id: RR-L3UQL4
+type: review-response
+title: No explicit coverage floor for a security-critical package (default 50 vs measured 93.4)
+finding: '.testcoverage.yml pins high floors (85–95) on load-bearing packages; a read-side ACL seam qualifies. With only the default 50 floor, the security control''s tests could erode silently by 40+ points before CI trips. Add ^internal/visibility$: 85.'
+severity: minor
+resolution: 'Added .testcoverage.yml override ^internal/visibility$: 85 with a security-critical rationale comment. Measured 94.2% after review fixes.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-MV5EM0.md
+++ b/tickets/entities/review-responses/RR-MV5EM0.md
@@ -1,0 +1,9 @@
+---
+id: RR-MV5EM0
+type: review-response
+title: Reader paths panic on nil slice elements while tracer paths guard nil
+finding: Filter/FilterRelations/redacted dereference c.Type/c.ID/rel.From with no nil check; collectNodeIDs/rebuild in the tracer decorator do guard nil. A nil candidate is a caller bug, but in a fail-closed security path a panic is the wrong failure mode (an upstream recover() could skip filtering entirely). Drop nil elements defensively, consistent with the tracer.
+severity: minor
+resolution: Filter and FilterRelations now drop nil elements fail-closed (no panic), consistent with the tracer decorator's nil guards. Suite case NilElementsDroppedNotPanicked pins it for both surfaces.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-MXKD2O.md
+++ b/tickets/entities/review-responses/RR-MXKD2O.md
@@ -1,0 +1,9 @@
+---
+id: RR-MXKD2O
+type: review-response
+title: 'acl.Request churn: wrappers only amortized/snapshot-consistent when wiring attaches a Request — requirement undocumented'
+finding: 'DeclarativeGate.request() reuses a ctx-attached acl.Request else opens a fresh one per call — so one Filter/FilterRelations/filterTree over N types opens N Requests, and PolicyRedactor→FieldVerdicts opens yet another. When wiring forgets acl.WithRequest: (a) the Globals member-of walk re-runs per type per collaborator (the exact cost RR-JJYW amortized); (b) the row-gate and field-redactor can evaluate against different Requests, so one read operation is not a single ACL snapshot. Godoc documents the mechanism but not the wiring REQUIREMENT.'
+severity: significant
+resolution: 'Added DeclarativeGate.Bind(ctx) — opens ONE acl.Request for the ctx principal and attaches it (reuses an existing bound scope; errors on unstamped principal). Godoc now states the wiring REQUIREMENT loudly: one Bind per logical operation, else per-collaborator Request churn + non-atomic snapshots. Suite case BindScopesOperation pins reuse-same-ctx, redaction-through-bound-ctx, and unstamped-deny.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-MYLUSZ.md
+++ b/tickets/entities/review-responses/RR-MYLUSZ.md
@@ -1,0 +1,9 @@
+---
+id: RR-MYLUSZ
+type: review-response
+title: FindOrphans gating is per-id sequential — batch by type like filterVisible
+finding: The plan resolves each orphan id's type via GetEntity then gates per id. That is O(N) sequential PermitsRead probes — the exact fan-out RR-FRK1 removed from filterVisible. Load the entities (needed anyway for the type), group ids by type, then one PermitsReadMany per distinct type.
+severity: minor
+resolution: 'Plan revised: FindOrphans loads entities (type needed anyway), groups by type, one PermitsReadMany per distinct type — mirroring filterVisible''s RR-FRK1 batching (PLAN-RR12W4 Approach).'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-RT5YV8.md
+++ b/tickets/entities/review-responses/RR-RT5YV8.md
@@ -1,0 +1,9 @@
+---
+id: RR-RT5YV8
+type: review-response
+title: arch-lint visibility.mayDependOn lists unused 'store' — over-broad allowance
+finding: 'The production package never imports internal/store (store.Store satisfies the one-method EntityGetter structurally); only the excluded visibilitytest does. An unused allowance weakens the boundary: a future direct store import would pass arch-lint unnoticed. Remove store from the block.'
+severity: minor
+resolution: Removed store from visibility.mayDependOn; block comment now states the package deliberately takes store.Store structurally through the one-method EntityGetter. arch-lint green.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-SRZK6X.md
+++ b/tickets/entities/review-responses/RR-SRZK6X.md
@@ -1,0 +1,9 @@
+---
+id: RR-SRZK6X
+type: review-response
+title: Reader.Get authorizes against caller-supplied type — cross-type read escalation (BUG-ZWTDH9 analog)
+finding: 'The plan proposed that Get ''gates on the CALLER''s type claim'' and mirrors dataentry getVisible by leaving the stored-type check to consumers. Verified in code: visibleReader.getVisible never checks e.Type == entityType after load — today each dataentry caller re-checks. In a SHARED package that per-consumer convention is exactly the bug class of BUG-ZWTDH9 (authorize against caller-supplied type, act on stored type): PermitsRead(publicType, id) can permit under the public type''s rules, then the load returns an entity of a DENIED type and the Reader hands it out redacted under the wrong type''s field policy. Get must verify stored type == claimed type post-load and return (nil,false,nil) on mismatch, inside the package.'
+severity: critical
+resolution: 'Plan revised: the stored-type check (e.Type == entityType, else indistinguishable not-found) is now part of PolicyReader.Get''s in-package contract (PLAN-RR12W4 AC2), with a dedicated conformance case (allowed-type claim over a denied-type entity → miss). PR 2 will remove the now-redundant caller-side checks instead of double-checking.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-Y7P4MQ.md
+++ b/tickets/entities/review-responses/RR-Y7P4MQ.md
@@ -1,0 +1,9 @@
+---
+id: RR-Y7P4MQ
+type: review-response
+title: Reader has no relation surface — PR 3's get_relations gating contract undecided
+finding: 'The Reader interface covers entities only (Get/Filter), but PR 3 must gate rela.get_relations, which returns relation rows incl. relation properties and both endpoint ids. Leaving the contract undecided until PR 3 risks an ad-hoc shape. The codebase already has the precedent to adopt: relation history reads are gated on BOTH endpoints (FROM ∧ TO — ''the FROM entity only owns the UI placement, it is not the auth boundary; a TO-side oracle otherwise'', CLAUDE.md relation-versioning). Decide now: add FilterRelations(ctx, rels) with the both-endpoints-visible rule to PR 1 (interface + impl + conformance cases) so PR 3 stays mechanical. Relations have no field-level redaction today, so row-gating is the whole contract.'
+severity: significant
+resolution: 'Decided now: FilterRelations(ctx, rels) added to the Reader interface in PR 1 with the both-endpoints-visible rule (FROM ∧ TO, relation-history precedent), batched endpoint gating, conformance cases incl. a probe-count assertion (PLAN-RR12W4 AC6). PR 3''s get_relations becomes mechanical.'
+status: addressed
+---

--- a/tickets/entities/tickets/TKT-7I07IX.md
+++ b/tickets/entities/tickets/TKT-7I07IX.md
@@ -5,7 +5,7 @@ title: 'visibility: new internal/visibility package — Reader (PolicyReader/All
 kind: enhancement
 priority: high
 effort: m
-status: review
+status: done
 ---
 
 ## Summary

--- a/tickets/entities/tickets/TKT-7I07IX.md
+++ b/tickets/entities/tickets/TKT-7I07IX.md
@@ -1,0 +1,29 @@
+---
+id: TKT-7I07IX
+type: ticket
+title: 'visibility: new internal/visibility package — Reader (PolicyReader/AllowAllReader) + tracer decorator + conformance suite'
+kind: enhancement
+priority: high
+effort: m
+status: review
+---
+
+## Summary
+
+PR 1 of the FEAT-PPH1EU arc (DEC-ZBI39P). Build the shared read-visibility seam;
+wire nothing yet.
+
+## Scope
+
+- New `internal/visibility` package, `mayDependOn: acl, affordances, store, entity` (arch-lint: new component block; no cycle — verified in RES-PSZZKU).
+- `Reader` interface (narrow, consumer-side): `Get(ctx, type, id)` — row-gate FIRST (hidden and nonexistent indistinguishable, RR-NGMI invariant), then field-redact a **copy** of the entity; `Filter(ctx, candidates)` — batched `PermitsReadMany` by type, fail-closed on gate error.
+- Redaction contract hoisted from dataentry's `hiddenProperties`/`copyVisibleProperties`/`stripHiddenProperties`: strip `FieldVerdicts.Visible[name]==false` properties AND apply the display-title fallback (title → ID when the display property is hidden — the secondary-channel leak).
+- `PolicyReader`: composes `acl.Request` (reuse ctx-attached via `acl.FromContext`, else `Declarative.ForPrincipal(principal.From(ctx))`) + `affordances.PolicyResolver.FieldVerdicts`. Rejects nil collaborators in the constructor.
+- `AllowAllReader`: pass-through, no gate, no redaction. The explicit capability for system jobs (capability ≠ identity; ElevatedManager precedent TKT-D8T148).
+- Tracer decorator implementing `tracer.Tracer` over a base tracer: hidden = nonexistent — prune the subtree below a hidden node in `TraceFrom`/`TraceTo` (a hidden node's title never surfaces); `FindPath` through a hidden intermediate → no path, indistinguishable from a real miss; `FindOrphans` drops hidden ids; `HasCycle` must not become an existence oracle (gate the start node).
+- Conformance suite modeled on `storetest.RunVisibleSearchTests`: row-gate, field-redaction, title-fallback, subtree-prune, path-withhold-indistinguishability, fail-closed-on-gate-error, NopACL byte-parity, redaction-returns-copy (base entity unmutated).
+
+## Non-goals
+
+Rewiring dataentry/lua (PR 2/3 of the arc). MCP. Any change to `internal/tracer`
+itself — it stays pure.

--- a/tickets/entities/tickets/TKT-L9Q669.md
+++ b/tickets/entities/tickets/TKT-L9Q669.md
@@ -1,0 +1,35 @@
+---
+id: TKT-L9Q669
+type: ticket
+title: 'export: route entity/list export + export_render through visibility.Reader; thread request principal into ExecuteDocument (closes #1188 IB finding)'
+kind: enhancement
+priority: high
+effort: m
+status: ready
+---
+
+## Summary
+
+PR 2 of the FEAT-PPH1EU arc (DEC-ZBI39P). Fixes the CISO-blocked IB-review
+finding on PR #1188: export paths read properties straight off the fetched
+entity, bypassing field-level `visible:` redaction that every other data-entry
+response applies.
+
+Leaking sites (from the IB review + verified on the branch):
+- `internal/dataentry/export.go` — `exportRenderer` hands the raw entity to `transform.EntityRenderer`; `propertyRows()` ranges the full `Properties` map; `DisplayTitle` re-leaks a hidden display property through the H1/filename.
+- `internal/dataentry/export_list.go` — `columnCell` reads `e.Properties[c.Property]` directly; property columns in list export never consult `hiddenProperties`.
+- The `export_render:` Lua override — `script.ExecuteDocument` takes no ctx and runs Lua reads on `context.Background()` with **no principal** (RES-PSZZKU finding), so the operator script reads raw entities regardless of the caller.
+
+## Scope
+
+- Route entity export + list export reads through `visibility.Reader` (TKT-7I07IX) instead of raw property access — redaction happens at the seam, `transform.EntityRenderer` stays ACL-free (it renders what it is given).
+- Title fallback: exported H1 and download filename must not carry a hidden display property (Reader's copy already applies this — verify through the export path).
+- Thread the request ctx/principal into `ExecuteDocument` so the `export_render:` Lua path runs under the caller's principal; until PR 3 lands the Lua reads themselves stay raw, so ALSO pass the redacted entity boundary where feasible, or document the residual explicitly in the PR + `docs/transforms.md` §Security if the override path can only be fully closed by PR 3.
+- Negative tests: a principal with a field-visibility policy exports an entity/list/PDF and the hidden field's value appears nowhere in the output bytes; hidden display property → ID title; list relation columns already gated (regression-pin).
+- Update `docs/transforms.md` §Security notes.
+- Resolve the open review-response on #1188 (CHANGES_REQUESTED by CISO): field-level ACL redaction on both export paths.
+
+## Non-goals
+
+Lua read bindings (PR 3). MCP export. CLI `rela render` (operator trust boundary
+— has the raw files anyway).

--- a/tickets/entities/tickets/TKT-L9Q669.md
+++ b/tickets/entities/tickets/TKT-L9Q669.md
@@ -5,7 +5,7 @@ title: 'export: route entity/list export + export_render through visibility.Read
 kind: enhancement
 priority: high
 effort: m
-status: ready
+status: backlog
 ---
 
 ## Summary

--- a/tickets/entities/tickets/TKT-ZF2DTV.md
+++ b/tickets/entities/tickets/TKT-ZF2DTV.md
@@ -5,7 +5,7 @@ title: 'lua: ReadDeps reads through visibility.Reader + visible tracer; schedule
 kind: enhancement
 priority: high
 effort: l
-status: ready
+status: backlog
 ---
 
 ## Summary

--- a/tickets/entities/tickets/TKT-ZF2DTV.md
+++ b/tickets/entities/tickets/TKT-ZF2DTV.md
@@ -1,0 +1,40 @@
+---
+id: TKT-ZF2DTV
+type: ticket
+title: 'lua: ReadDeps reads through visibility.Reader + visible tracer; scheduler jobs get explicit AllowAllReader; prove one role-scoped job'
+kind: enhancement
+priority: high
+effort: l
+status: ready
+---
+
+## Summary
+
+PR 3 of the FEAT-PPH1EU arc (DEC-ZBI39P). Every Lua read becomes ACL-bound by
+construction: swap the raw deps for visibility wrappers at the wiring sites.
+This is the enabler for **scheduled ACL-bound LLM jobs** — a job role's reader
+bounds what can enter a prompt.
+
+## Scope
+
+- `lua.ReadDeps`: replace `Store store.Store` with the narrow `visibility.Reader` (+ whatever minimal read surface `list_entities`/`get_relations` need — keep it consumer-side narrow); `Tracer tracer.Tracer` keeps its type but wiring injects the visibility decorator. Trace bindings (`trace_from`/`trace_to`/`find_path`) are already property-free (RES-PSZZKU) — they change behavior only via the injected decorator.
+- Route the 4 property-bearing bindings through the Reader: `get_entity`, `list_entities`, `search` (re-fetches full entities per hit — must re-fetch via the Reader), `get_relations` (relation properties + peer visibility).
+- Wiring sites (all pass raw deps today): `appbuild.LuaReadDeps`/`LuaWriteDeps`, `dataentry.luaWriteDeps` + validator readDeps, CLI, MCP lua_eval/lua_run, scheduler.
+  - **Request paths** (data-entry actions, export_render, MCP): `PolicyReader` + visible tracer — the script reads the caller's redacted view.
+  - **Scheduler**: keeps the genuine `system:*` principal + `triggered_by` stamping (already exists); receives `AllowAllReader` + raw tracer **explicitly at the wiring site** (non-regressing; capability ≠ identity). Log at startup which jobs run with an unrestricted reader.
+  - **Validator**: evaluate — validation predicates evaluate against the full entity by design (RES-H5AB7S constraint); keep AllowAll there and document why.
+  - **CLI**: AllowAll (operator trust boundary, RR-17DMC precedent).
+- Arch-lint: add `visibility` to `lua.mayDependOn` (single entry; no cycle — RES-PSZZKU).
+- NopACL byte-parity test: without acl.yaml every Lua binding's output is byte-identical to today.
+- **Prove the LLM-job path end-to-end**: one scheduled job wired with a role-scoped `PolicyReader` under a `system:<job>` principal (test or example config) asserting: hidden field absent from `get_entity`/`search` results inside the script; hidden entity invisible to `list_entities`/`trace_from`; audit log attributes the job honestly.
+
+## Non-goals
+
+Per-job role authoring UX (follow-up). MCP tool reads (`show_entity` etc —
+separate follow-up closing RES-H5AB7S's gap). Egress controls (TKT-Z1OP7R — the
+other half of the LLM-job safety envelope). Write-back/derivation provenance.
+
+## Risks / notes
+
+- Behavior change: data-entry-invoked scripts now see the caller's redacted view; scripts assuming full reads must run under an allow-all wiring or a suitable role. Release-note it.
+- The write path (`Mutator`/entitymanager) is untouched — write-prep reads stay raw below the seam, or hidden fields would be clobbered on save.

--- a/tickets/relations/DEC-ZBI39P--decides--authorization.md
+++ b/tickets/relations/DEC-ZBI39P--decides--authorization.md
@@ -1,0 +1,5 @@
+---
+from: DEC-ZBI39P
+relation: decides
+to: authorization
+---

--- a/tickets/relations/DEC-ZBI39P--decides--lua-scripting.md
+++ b/tickets/relations/DEC-ZBI39P--decides--lua-scripting.md
@@ -1,0 +1,5 @@
+---
+from: DEC-ZBI39P
+relation: decides
+to: lua-scripting
+---

--- a/tickets/relations/FEAT-PPH1EU--has-research--RES-PSZZKU.md
+++ b/tickets/relations/FEAT-PPH1EU--has-research--RES-PSZZKU.md
@@ -1,0 +1,5 @@
+---
+from: FEAT-PPH1EU
+relation: has-research
+to: RES-PSZZKU
+---

--- a/tickets/relations/FEAT-PPH1EU--requires--ai-integration.md
+++ b/tickets/relations/FEAT-PPH1EU--requires--ai-integration.md
@@ -1,0 +1,5 @@
+---
+from: FEAT-PPH1EU
+relation: requires
+to: ai-integration
+---

--- a/tickets/relations/FEAT-PPH1EU--requires--authorization.md
+++ b/tickets/relations/FEAT-PPH1EU--requires--authorization.md
@@ -1,0 +1,5 @@
+---
+from: FEAT-PPH1EU
+relation: requires
+to: authorization
+---

--- a/tickets/relations/FEAT-PPH1EU--requires--lua-scripting.md
+++ b/tickets/relations/FEAT-PPH1EU--requires--lua-scripting.md
@@ -1,0 +1,5 @@
+---
+from: FEAT-PPH1EU
+relation: requires
+to: lua-scripting
+---

--- a/tickets/relations/RES-PSZZKU--informs--DEC-ZBI39P.md
+++ b/tickets/relations/RES-PSZZKU--informs--DEC-ZBI39P.md
@@ -1,0 +1,5 @@
+---
+from: RES-PSZZKU
+relation: informs
+to: DEC-ZBI39P
+---

--- a/tickets/relations/RES-PSZZKU--informs--TKT-7I07IX.md
+++ b/tickets/relations/RES-PSZZKU--informs--TKT-7I07IX.md
@@ -1,0 +1,5 @@
+---
+from: RES-PSZZKU
+relation: informs
+to: TKT-7I07IX
+---

--- a/tickets/relations/RES-PSZZKU--informs--TKT-L9Q669.md
+++ b/tickets/relations/RES-PSZZKU--informs--TKT-L9Q669.md
@@ -1,0 +1,5 @@
+---
+from: RES-PSZZKU
+relation: informs
+to: TKT-L9Q669
+---

--- a/tickets/relations/RES-PSZZKU--informs--TKT-ZF2DTV.md
+++ b/tickets/relations/RES-PSZZKU--informs--TKT-ZF2DTV.md
@@ -1,0 +1,5 @@
+---
+from: RES-PSZZKU
+relation: informs
+to: TKT-ZF2DTV
+---

--- a/tickets/relations/RES-PSZZKU--researches--ai-integration.md
+++ b/tickets/relations/RES-PSZZKU--researches--ai-integration.md
@@ -1,0 +1,5 @@
+---
+from: RES-PSZZKU
+relation: researches
+to: ai-integration
+---

--- a/tickets/relations/RES-PSZZKU--researches--authorization.md
+++ b/tickets/relations/RES-PSZZKU--researches--authorization.md
@@ -1,0 +1,5 @@
+---
+from: RES-PSZZKU
+relation: researches
+to: authorization
+---

--- a/tickets/relations/RES-PSZZKU--researches--lua-scripting.md
+++ b/tickets/relations/RES-PSZZKU--researches--lua-scripting.md
@@ -1,0 +1,5 @@
+---
+from: RES-PSZZKU
+relation: researches
+to: lua-scripting
+---

--- a/tickets/relations/TKT-7I07IX--affects--authorization.md
+++ b/tickets/relations/TKT-7I07IX--affects--authorization.md
@@ -1,0 +1,5 @@
+---
+from: TKT-7I07IX
+relation: affects
+to: authorization
+---

--- a/tickets/relations/TKT-7I07IX--has-docs--DOCS-EWU16F.md
+++ b/tickets/relations/TKT-7I07IX--has-docs--DOCS-EWU16F.md
@@ -1,0 +1,5 @@
+---
+from: TKT-7I07IX
+relation: has-docs
+to: DOCS-EWU16F
+---

--- a/tickets/relations/TKT-7I07IX--has-implementation--IMPL-D9V52D.md
+++ b/tickets/relations/TKT-7I07IX--has-implementation--IMPL-D9V52D.md
@@ -1,0 +1,5 @@
+---
+from: TKT-7I07IX
+relation: has-implementation
+to: IMPL-D9V52D
+---

--- a/tickets/relations/TKT-7I07IX--has-planning--PLAN-RR12W4.md
+++ b/tickets/relations/TKT-7I07IX--has-planning--PLAN-RR12W4.md
@@ -1,0 +1,5 @@
+---
+from: TKT-7I07IX
+relation: has-planning
+to: PLAN-RR12W4
+---

--- a/tickets/relations/TKT-7I07IX--has-review--REV-3ZM7EB.md
+++ b/tickets/relations/TKT-7I07IX--has-review--REV-3ZM7EB.md
@@ -1,0 +1,5 @@
+---
+from: TKT-7I07IX
+relation: has-review
+to: REV-3ZM7EB
+---

--- a/tickets/relations/TKT-7I07IX--has-review-response--RR-5N4K35.md
+++ b/tickets/relations/TKT-7I07IX--has-review-response--RR-5N4K35.md
@@ -1,0 +1,5 @@
+---
+from: TKT-7I07IX
+relation: has-review-response
+to: RR-5N4K35
+---

--- a/tickets/relations/TKT-7I07IX--has-review-response--RR-6IL3X7.md
+++ b/tickets/relations/TKT-7I07IX--has-review-response--RR-6IL3X7.md
@@ -1,0 +1,5 @@
+---
+from: TKT-7I07IX
+relation: has-review-response
+to: RR-6IL3X7
+---

--- a/tickets/relations/TKT-7I07IX--has-review-response--RR-7V9XN7.md
+++ b/tickets/relations/TKT-7I07IX--has-review-response--RR-7V9XN7.md
@@ -1,0 +1,5 @@
+---
+from: TKT-7I07IX
+relation: has-review-response
+to: RR-7V9XN7
+---

--- a/tickets/relations/TKT-7I07IX--has-review-response--RR-FJUQSF.md
+++ b/tickets/relations/TKT-7I07IX--has-review-response--RR-FJUQSF.md
@@ -1,0 +1,5 @@
+---
+from: TKT-7I07IX
+relation: has-review-response
+to: RR-FJUQSF
+---

--- a/tickets/relations/TKT-7I07IX--has-review-response--RR-J6022V.md
+++ b/tickets/relations/TKT-7I07IX--has-review-response--RR-J6022V.md
@@ -1,0 +1,5 @@
+---
+from: TKT-7I07IX
+relation: has-review-response
+to: RR-J6022V
+---

--- a/tickets/relations/TKT-7I07IX--has-review-response--RR-JGVD30.md
+++ b/tickets/relations/TKT-7I07IX--has-review-response--RR-JGVD30.md
@@ -1,0 +1,5 @@
+---
+from: TKT-7I07IX
+relation: has-review-response
+to: RR-JGVD30
+---

--- a/tickets/relations/TKT-7I07IX--has-review-response--RR-L3UQL4.md
+++ b/tickets/relations/TKT-7I07IX--has-review-response--RR-L3UQL4.md
@@ -1,0 +1,5 @@
+---
+from: TKT-7I07IX
+relation: has-review-response
+to: RR-L3UQL4
+---

--- a/tickets/relations/TKT-7I07IX--has-review-response--RR-MV5EM0.md
+++ b/tickets/relations/TKT-7I07IX--has-review-response--RR-MV5EM0.md
@@ -1,0 +1,5 @@
+---
+from: TKT-7I07IX
+relation: has-review-response
+to: RR-MV5EM0
+---

--- a/tickets/relations/TKT-7I07IX--has-review-response--RR-MXKD2O.md
+++ b/tickets/relations/TKT-7I07IX--has-review-response--RR-MXKD2O.md
@@ -1,0 +1,5 @@
+---
+from: TKT-7I07IX
+relation: has-review-response
+to: RR-MXKD2O
+---

--- a/tickets/relations/TKT-7I07IX--has-review-response--RR-MYLUSZ.md
+++ b/tickets/relations/TKT-7I07IX--has-review-response--RR-MYLUSZ.md
@@ -1,0 +1,5 @@
+---
+from: TKT-7I07IX
+relation: has-review-response
+to: RR-MYLUSZ
+---

--- a/tickets/relations/TKT-7I07IX--has-review-response--RR-RT5YV8.md
+++ b/tickets/relations/TKT-7I07IX--has-review-response--RR-RT5YV8.md
@@ -1,0 +1,5 @@
+---
+from: TKT-7I07IX
+relation: has-review-response
+to: RR-RT5YV8
+---

--- a/tickets/relations/TKT-7I07IX--has-review-response--RR-SRZK6X.md
+++ b/tickets/relations/TKT-7I07IX--has-review-response--RR-SRZK6X.md
@@ -1,0 +1,5 @@
+---
+from: TKT-7I07IX
+relation: has-review-response
+to: RR-SRZK6X
+---

--- a/tickets/relations/TKT-7I07IX--has-review-response--RR-Y7P4MQ.md
+++ b/tickets/relations/TKT-7I07IX--has-review-response--RR-Y7P4MQ.md
@@ -1,0 +1,5 @@
+---
+from: TKT-7I07IX
+relation: has-review-response
+to: RR-Y7P4MQ
+---

--- a/tickets/relations/TKT-7I07IX--implements--FEAT-PPH1EU.md
+++ b/tickets/relations/TKT-7I07IX--implements--FEAT-PPH1EU.md
@@ -1,0 +1,5 @@
+---
+from: TKT-7I07IX
+relation: implements
+to: FEAT-PPH1EU
+---

--- a/tickets/relations/TKT-L9Q669--affects--authorization.md
+++ b/tickets/relations/TKT-L9Q669--affects--authorization.md
@@ -1,0 +1,5 @@
+---
+from: TKT-L9Q669
+relation: affects
+to: authorization
+---

--- a/tickets/relations/TKT-L9Q669--implements--FEAT-PPH1EU.md
+++ b/tickets/relations/TKT-L9Q669--implements--FEAT-PPH1EU.md
@@ -1,0 +1,5 @@
+---
+from: TKT-L9Q669
+relation: implements
+to: FEAT-PPH1EU
+---

--- a/tickets/relations/TKT-ZF2DTV--affects--authorization.md
+++ b/tickets/relations/TKT-ZF2DTV--affects--authorization.md
@@ -1,0 +1,5 @@
+---
+from: TKT-ZF2DTV
+relation: affects
+to: authorization
+---

--- a/tickets/relations/TKT-ZF2DTV--affects--lua-scripting.md
+++ b/tickets/relations/TKT-ZF2DTV--affects--lua-scripting.md
@@ -1,0 +1,5 @@
+---
+from: TKT-ZF2DTV
+relation: affects
+to: lua-scripting
+---

--- a/tickets/relations/TKT-ZF2DTV--implements--FEAT-PPH1EU.md
+++ b/tickets/relations/TKT-ZF2DTV--implements--FEAT-PPH1EU.md
@@ -1,0 +1,5 @@
+---
+from: TKT-ZF2DTV
+relation: implements
+to: FEAT-PPH1EU
+---


### PR DESCRIPTION
PR 1 of the **FEAT-PPH1EU** arc (decision **DEC-ZBI39P**, research **RES-PSZZKU**): make read-side ACL (entity row-gating + field-level `visible:` redaction) **structural** instead of by-convention — the gap behind the IB-review finding that blocked #1188 (export bypassed field redaction).

## What this adds

A new `internal/visibility` package — visibility decorators over the deliberately-ungated pure readers, generalizing the existing `search.VisibleSearcher` pattern. **Nothing is wired yet**: consumers (data-entry export → PR 2 / TKT-L9Q669, Lua reads → PR 3 / TKT-ZF2DTV) adopt it next.

| Piece | Contract |
|---|---|
| `Reader` (`PolicyReader`) | Gate **before** read (hidden == missing, no existence oracle); stored-type must match the claimed type (in-package — the read-side analog of BUG-ZWTDH9); redaction on a **copy**, never mutating stored state; `Filter` batched per type, fail-closed on gate error; `FilterRelations` keeps a relation only when **both** endpoints are visible |
| `AllowAllReader` | The explicit pass-through **capability** for system jobs — wired deliberately, never inferred from the principal (identity stays honest for audit; the ElevatedManager pattern) |
| Tracer decorator | Implements `tracer.Tracer`; hidden = nonexistent: subtree pruned, `FindPath` through a hidden intermediate withheld indistinguishably, hidden orphans dropped; alias-safe redaction (the base tracer's `Properties` maps alias live store entities) + ID title-fallback on nodes/steps |
| `visibilitytest` | Exported conformance suite (the `storetest` pattern) run against **real engines** (memstore + `acl.Declarative` + `affordances.PolicyResolver`) — PR 2/3 wirings re-run the same suite |

## Review

Design review: 7 findings (1 critical — the stored-type check — caught **before** implementation and built in). Code review (cranky pass): 0 critical, 2 significant (Request-binding requirement → new `DeclarativeGate.Bind` helper; body-redaction scope documented with a tracked TODO hook), 4 minor — all addressed. Full trail on TKT-7I07IX.

## Verification

`go test -race` green; package coverage 94.2% against a new explicit 85 floor; golangci-lint 0 issues; arch-lint (new `visibility` component, no `store` allowance — structural `EntityGetter` only); plimsoll OK.