### PR TITLE
feat(pgstore): attribute swept versions to the real editor (TKT-ZIRMGM)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -216,10 +216,18 @@ Rules when touching this:
   runs its **entire tick on ONE acquired pool connection** under
   `pg_try_advisory_lock` — the lock is session-scoped, so issuing the inserts via
   the pool (other sessions) would silently void the single-writer guarantee.
-  Attribution comes from ctx only (the store never learns the Principal by
-  another route — it arrives inside `store.VersionInput` populated at the
-  boundary); swept create/update rows use a `version-sweep` system principal and
-  the editing principal is recoverable from the audit log. Lineage across a
+  Attribution comes from ctx only, via exactly two boundary-populated inputs —
+  the store never learns the Principal by another route: sync captures carry it
+  inside `store.VersionInput`, and create/update writes carry a
+  `store.Attribution` on ctx (`store.WithAttribution`, set ONLY at the
+  entitymanager boundary and ONLY for a real principal — never translate a
+  zero/unknown principal, RR-U964M0) which pgstore stamps into
+  `entities/relations.last_edited_by_user/_tool` (TKT-ZIRMGM). The sweep copies
+  those columns onto swept versions; NULL columns (legacy rows, unattributed
+  writes) fall back to the `version-sweep` system principal — never a guessed
+  or literal-"unknown" identity. Author-boundary segmentation (flush-on-author-
+  change) is TKT-0IGI4V, not built: two authors in one debounce window merge
+  into one version attributed to the last of them. Lineage across a
   rename/id-reuse is fenced by `[lo,hi)` vseq ranges in a recursive-CTE walk (an
   unbounded `entity_id = ANY(...)` read would merge two entities' histories — see
   the version.go doc). `HistoryReader`/`VersionWriter` are optional store

--- a/docs-project/entities/guides/GUIDE-postgres-backend.md
+++ b/docs-project/entities/guides/GUIDE-postgres-backend.md
@@ -153,10 +153,19 @@ How capture works:
   to the latest).
 
 Attribution: the version's principal (user + tool) and any `triggered_by`
-(automation / schedule / cascade) are recorded. This inherits the same trust
-model as the [audit log](audit-log.md) — attribution is only as strong as your
-deployment's identity front door, so use a verifying (JWT) principal source
-where version attribution matters for accountability.
+(automation / schedule / cascade) are recorded. Every create/update write stamps
+the editing principal onto the live row (`last_edited_by_user` /
+`last_edited_by_tool`), and the sweep copies it onto the debounced snapshot — so
+a swept version names the real editor, not a system account. Rows with no
+recorded editor (pre-existing rows from before the columns existed, or writes
+that carried no principal) fall back to the `version-sweep` system principal
+rather than guessing; they self-heal on their next attributed edit. A rename
+only re-keys incident relations, so those keep their last *content* editor. One
+limit today: if two different people edit the same entity within one debounce
+window, the single collapsed version is attributed to the last of them. This all
+inherits the same trust model as the [audit log](audit-log.md) — attribution is
+only as strong as your deployment's identity front door, so use a verifying
+(JWT) principal source where version attribution matters for accountability.
 
 Storage: two tables — `entity_versions` (one full snapshot per version, keyed by
 a versioning-internal record id so history survives id rename/reuse) and

--- a/docs/postgres-backend.md
+++ b/docs/postgres-backend.md
@@ -147,10 +147,20 @@ How capture works:
   to the latest).
 
 Attribution: the version's principal (user + tool) and any `triggered_by`
-(automation / schedule / cascade) are recorded. This inherits the same trust
-model as the [audit log](audit-log.md) — attribution is only as strong as your
-deployment's identity front door, so use a verifying (JWT) principal source
-where version attribution matters for accountability.
+(automation / schedule / cascade) are recorded. Every create/update write stamps
+the editing principal onto the live row (`last_edited_by_user` /
+`last_edited_by_tool`), and the sweep copies it onto the debounced snapshot — so
+a swept version names the real editor, not a system account. Rows with no
+recorded editor (pre-existing rows from before the columns existed, or writes
+that carried no principal) fall back to the `version-sweep` system principal
+rather than guessing; they self-heal on their next attributed edit. A rename
+only re-keys incident relations, so those keep their last *content* editor. One
+v1 limit: if two different people edit the same entity within one debounce
+window, the single collapsed version is attributed to the last of them
+(TKT-0IGI4V tracks segmenting versions at author boundaries). This all inherits
+the same trust model as the [audit log](audit-log.md) — attribution is only as
+strong as your deployment's identity front door, so use a verifying (JWT)
+principal source where version attribution matters for accountability.
 
 Storage: two tables — `entity_versions` (one full snapshot per version, keyed by
 a versioning-internal record id so history survives id rename/reuse) and

--- a/docs/postgres-backend.md
+++ b/docs/postgres-backend.md
@@ -155,12 +155,11 @@ recorded editor (pre-existing rows from before the columns existed, or writes
 that carried no principal) fall back to the `version-sweep` system principal
 rather than guessing; they self-heal on their next attributed edit. A rename
 only re-keys incident relations, so those keep their last *content* editor. One
-v1 limit: if two different people edit the same entity within one debounce
-window, the single collapsed version is attributed to the last of them
-(TKT-0IGI4V tracks segmenting versions at author boundaries). This all inherits
-the same trust model as the [audit log](audit-log.md) — attribution is only as
-strong as your deployment's identity front door, so use a verifying (JWT)
-principal source where version attribution matters for accountability.
+limit today: if two different people edit the same entity within one debounce
+window, the single collapsed version is attributed to the last of them. This all
+inherits the same trust model as the [audit log](audit-log.md) — attribution is
+only as strong as your deployment's identity front door, so use a verifying
+(JWT) principal source where version attribution matters for accountability.
 
 Storage: two tables — `entity_versions` (one full snapshot per version, keyed by
 a versioning-internal record id so history survives id rename/reuse) and

--- a/internal/entitymanager/apply.go
+++ b/internal/entitymanager/apply.go
@@ -76,6 +76,7 @@ func resolveUpsertOp(getErr error, createAudit, updateAudit string) (upsertOp, e
 // The audited op (create vs. update) is chosen from whether the entity already
 // exists; a flaky existence probe fails closed (see [resolveUpsertOp]).
 func (m *Manager) ApplyEntity(ctx context.Context, e *entity.Entity) (*entity.UpdateResult, error) {
+	ctx = withStoreAttribution(ctx)
 	if e == nil {
 		return nil, errors.New("entitymanager: ApplyEntity: entity is nil")
 	}
@@ -216,6 +217,7 @@ func (m *Manager) persistApplyEntity(ctx context.Context, op acl.Op, e *entity.E
 // well-formed order values from a peer that produced them through the normal
 // write path.
 func (m *Manager) ApplyRelation(ctx context.Context, r *entity.Relation) (*entity.Relation, error) {
+	ctx = withStoreAttribution(ctx)
 	if r == nil {
 		return nil, errors.New("entitymanager: ApplyRelation: relation is nil")
 	}

--- a/internal/entitymanager/attribution.go
+++ b/internal/entitymanager/attribution.go
@@ -1,0 +1,28 @@
+package entitymanager
+
+import (
+	"context"
+
+	"github.com/Sourcehaven-BV/rela/internal/principal"
+	"github.com/Sourcehaven-BV/rela/internal/store"
+)
+
+// withStoreAttribution translates the request principal into the store's
+// write-authorship attribution (store.WithAttribution) at the write boundary.
+// Every public write entry point calls this first, so nested store writes —
+// automations, cascades, managed-order renumbering — inherit the attribution
+// of the human intent that triggered them, mirroring how the audit log
+// attributes those same writes.
+//
+// Only a REAL identity is forwarded: a zero principal, or the {unknown,
+// unknown} fallback principal.From returns for an unstamped ctx, leaves the
+// ctx unchanged so backends persist NULL authorship and the version sweep
+// falls back to its system principal (RR-U964M0 — a literal "unknown" in the
+// columns would defeat that fallback).
+func withStoreAttribution(ctx context.Context) context.Context {
+	p := principal.From(ctx)
+	if p.IsZero() || (p.User == "unknown" && p.Tool == "unknown") {
+		return ctx
+	}
+	return store.WithAttribution(ctx, store.Attribution{User: p.User, Tool: p.Tool})
+}

--- a/internal/entitymanager/attribution_test.go
+++ b/internal/entitymanager/attribution_test.go
@@ -1,0 +1,55 @@
+package entitymanager
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Sourcehaven-BV/rela/internal/principal"
+	"github.com/Sourcehaven-BV/rela/internal/store"
+)
+
+// TestWithStoreAttribution pins the boundary translation (RR-U964M0): only a
+// real principal becomes a store.Attribution; the zero principal and the
+// {unknown, unknown} fallback principal.From returns for an unstamped ctx must
+// leave the ctx without attribution, so backends persist NULL and the version
+// sweep keeps its system-principal fallback.
+func TestWithStoreAttribution(t *testing.T) {
+	tests := []struct {
+		name      string
+		principal *principal.Principal // nil = unstamped ctx
+		want      store.Attribution
+	}{
+		{
+			name:      "unstamped ctx forwards nothing",
+			principal: nil,
+			want:      store.Attribution{},
+		},
+		{
+			name:      "explicit unknown-unknown principal forwards nothing",
+			principal: &principal.Principal{User: "unknown", Tool: "unknown"},
+			want:      store.Attribution{},
+		},
+		{
+			name:      "real principal forwards user and tool",
+			principal: &principal.Principal{User: "alice@example.com", Tool: "data-entry"},
+			want:      store.Attribution{User: "alice@example.com", Tool: "data-entry"},
+		},
+		{
+			name:      "unknown user with real tool still forwards",
+			principal: &principal.Principal{User: "unknown", Tool: "cli"},
+			want:      store.Attribution{User: "unknown", Tool: "cli"},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			if tc.principal != nil {
+				ctx = principal.With(ctx, *tc.principal)
+			}
+			got := store.AttributionFrom(withStoreAttribution(ctx))
+			if got != tc.want {
+				t.Fatalf("attribution = %+v, want %+v", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/entitymanager/manager.go
+++ b/internal/entitymanager/manager.go
@@ -398,6 +398,7 @@ func formatDeniedSummary(d acl.Decision, op acl.Op) string {
 func (m *Manager) CreateEntity(
 	ctx context.Context, e *entity.Entity, opts entity.CreateOptions,
 ) (*entity.CreateResult, error) {
+	ctx = withStoreAttribution(ctx)
 	if e == nil {
 		return nil, errors.New("entitymanager: CreateEntity: entity is nil")
 	}
@@ -551,6 +552,7 @@ func (m *Manager) ValidateCreate(
 // [ErrEntityNotFound] and never runs the engine. (Preserves
 // pre-refactor workspace behavior.)
 func (m *Manager) UpdateEntity(ctx context.Context, e *entity.Entity) (*entity.UpdateResult, error) {
+	ctx = withStoreAttribution(ctx)
 	if e == nil {
 		return nil, errors.New("entitymanager: UpdateEntity: entity is nil")
 	}
@@ -878,6 +880,7 @@ func collectRenameAffectedRelations(ctx context.Context, st store.Store, id stri
 func (m *Manager) CreateRelation(
 	ctx context.Context, from, relType, to string, opts entity.RelationOptions,
 ) (*entity.Relation, error) {
+	ctx = withStoreAttribution(ctx)
 	// Authorize BEFORE the peer-existence lookups (BUG-K6FEVB). A missing
 	// peer must never let a write skip the ACL: if authz is deferred until
 	// after GetEntity, a denied caller (e.g. --read-only / ReadOnlyACL)
@@ -966,6 +969,7 @@ func (m *Manager) CreateRelation(
 func (m *Manager) UpdateRelation(
 	ctx context.Context, from, relType, to string, opts entity.RelationOptions,
 ) (*entity.Relation, error) {
+	ctx = withStoreAttribution(ctx)
 	// Authorize BEFORE the relation-existence lookup (BUG-K6FEVB): a
 	// missing relation must not let a denied caller skip the ACL and get
 	// a soft not-found. The source type feeds the type-level grant check;

--- a/internal/store/attribution.go
+++ b/internal/store/attribution.go
@@ -1,0 +1,53 @@
+package store
+
+import "context"
+
+// Attribution names who/what to attribute a write to. It is the store's OWN
+// notion of authorship — deliberately not principal.Principal: the store never
+// learns the Principal (no roles, no assertion claims, no identity semantics),
+// only the two opaque labels a versioning backend needs to answer "who last
+// edited this row".
+//
+// Attribution reaches the store the same way version-capture attribution does:
+// populated from the request principal at the entitymanager write boundary,
+// never read from any other source inside a store implementation. The ctx
+// carrier below is the second sanctioned boundary-populated attribution input
+// (the first being the PrincipalUser/PrincipalTool fields on VersionInput /
+// RelationVersionInput).
+//
+// Absent attribution is a valid, expected state — a write whose ctx carries no
+// Attribution (background jobs, unstamped principals, tests) MUST be persisted
+// as NULL/unknown authorship, never defaulted to a made-up identity. The
+// version sweep then falls back to its system principal (tool
+// "version-sweep") for rows with no recorded editor. A PARTIALLY unknown
+// identity is different: the boundary forwards it verbatim (e.g. a CLI write
+// under an unset $USER stores user "unknown" with the real tool), because the
+// known component is real information. TKT-ZIRMGM / RR-2VWA0Q / RR-5JIN8U.
+type Attribution struct {
+	User string
+	Tool string
+}
+
+// IsZero reports whether a carries no authorship information at all.
+func (a Attribution) IsZero() bool {
+	return a.User == "" && a.Tool == ""
+}
+
+type attributionKey struct{}
+
+// WithAttribution returns a ctx carrying a as the write-authorship attribution
+// for store writes. Called only at the entitymanager write boundary, and only
+// with a real identity — an unknown or zero principal must NOT be translated
+// into an Attribution (RR-U964M0: stamping a literal "unknown" would defeat
+// the NULL-means-unknown contract and the sweep's system-principal fallback).
+func WithAttribution(ctx context.Context, a Attribution) context.Context {
+	return context.WithValue(ctx, attributionKey{}, a)
+}
+
+// AttributionFrom returns the Attribution carried by ctx, or the zero
+// Attribution when none was set. It never fabricates a default: absent
+// attribution must stay absent so backends persist NULL.
+func AttributionFrom(ctx context.Context) Attribution {
+	a, _ := ctx.Value(attributionKey{}).(Attribution)
+	return a
+}

--- a/internal/store/attribution_test.go
+++ b/internal/store/attribution_test.go
@@ -1,0 +1,28 @@
+package store_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Sourcehaven-BV/rela/internal/store"
+)
+
+// TestAttributionRoundTrip pins the ctx-carrier contract (RR-2VWA0Q): a set
+// Attribution reads back verbatim, and an unset ctx yields the zero value —
+// never a fabricated default.
+func TestAttributionRoundTrip(t *testing.T) {
+	ctx := context.Background()
+
+	if got := store.AttributionFrom(ctx); !got.IsZero() {
+		t.Fatalf("AttributionFrom on bare ctx = %+v, want zero", got)
+	}
+
+	a := store.Attribution{User: "alice@example.com", Tool: "data-entry"}
+	got := store.AttributionFrom(store.WithAttribution(ctx, a))
+	if got != a {
+		t.Fatalf("AttributionFrom = %+v, want %+v", got, a)
+	}
+	if got.IsZero() {
+		t.Fatal("set attribution must not report IsZero")
+	}
+}

--- a/internal/store/pgstore/attribution_test.go
+++ b/internal/store/pgstore/attribution_test.go
@@ -1,0 +1,170 @@
+package pgstore_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/Sourcehaven-BV/rela/internal/store"
+	"github.com/Sourcehaven-BV/rela/internal/store/pgstore"
+)
+
+// attributedCtx returns a ctx carrying the boundary-populated write
+// attribution, as the entitymanager does for a real principal.
+func attributedCtx(user, tool string) context.Context {
+	return store.WithAttribution(context.Background(), store.Attribution{User: user, Tool: tool})
+}
+
+// TestAttributionColumnsStamped pins the store side of the Attribution ctx
+// contract (RR-2VWA0Q): a write with attribution stamps last_edited_by_*, a
+// write without leaves/sets them NULL — never an empty or placeholder string.
+func TestAttributionColumnsStamped(t *testing.T) {
+	pool := newScopedPool(t)
+	s, err := pgstore.New(pool)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = s.Close() })
+	ctx := context.Background()
+
+	// Entity create WITH attribution.
+	require.NoError(t, s.CreateEntity(attributedCtx("alice@example.com", "data-entry"),
+		mkEntity("ATTR-1", "ticket", "v1")))
+	var user, tool *string
+	require.NoError(t, pool.QueryRow(ctx,
+		`SELECT last_edited_by_user, last_edited_by_tool FROM entities WHERE id = 'ATTR-1'`).
+		Scan(&user, &tool))
+	require.NotNil(t, user)
+	require.Equal(t, "alice@example.com", *user)
+	require.NotNil(t, tool)
+	require.Equal(t, "data-entry", *tool)
+
+	// Update WITHOUT attribution overwrites to NULL: the last write's
+	// authorship is honestly unknown.
+	require.NoError(t, s.UpdateEntity(ctx, mkEntity("ATTR-1", "ticket", "v2")))
+	require.NoError(t, pool.QueryRow(ctx,
+		`SELECT last_edited_by_user, last_edited_by_tool FROM entities WHERE id = 'ATTR-1'`).
+		Scan(&user, &tool))
+	require.Nil(t, user, "unattributed write must leave NULL, not a placeholder")
+	require.Nil(t, tool)
+
+	// Update WITH attribution re-stamps.
+	require.NoError(t, s.UpdateEntity(attributedCtx("bob", "cli"), mkEntity("ATTR-1", "ticket", "v3")))
+	require.NoError(t, pool.QueryRow(ctx,
+		`SELECT last_edited_by_user, last_edited_by_tool FROM entities WHERE id = 'ATTR-1'`).
+		Scan(&user, &tool))
+	require.Equal(t, "bob", *user)
+	require.Equal(t, "cli", *tool)
+
+	// Relations: create + update stamp the same columns.
+	require.NoError(t, s.CreateEntity(ctx, mkEntity("ATTR-2", "ticket", "peer")))
+	_, err = s.CreateRelation(attributedCtx("carol", "mcp"), "ATTR-1", "blocks", "ATTR-2",
+		&store.RelationData{Content: "why"})
+	require.NoError(t, err)
+	require.NoError(t, pool.QueryRow(ctx,
+		`SELECT last_edited_by_user, last_edited_by_tool FROM relations
+		 WHERE from_id = 'ATTR-1' AND rel_type = 'blocks' AND to_id = 'ATTR-2'`).
+		Scan(&user, &tool))
+	require.Equal(t, "carol", *user)
+	require.Equal(t, "mcp", *tool)
+
+	_, err = s.UpdateRelation(ctx, "ATTR-1", "blocks", "ATTR-2", store.RelationData{Content: "changed"})
+	require.NoError(t, err)
+	require.NoError(t, pool.QueryRow(ctx,
+		`SELECT last_edited_by_user, last_edited_by_tool FROM relations
+		 WHERE from_id = 'ATTR-1' AND rel_type = 'blocks' AND to_id = 'ATTR-2'`).
+		Scan(&user, &tool))
+	require.Nil(t, user)
+	require.Nil(t, tool)
+}
+
+// TestSweepAttributesRealEditor is the ticket's headline behavior (TKT-ZIRMGM
+// AC1/AC2/AC5): swept create/update versions carry the row's recorded editor,
+// not the version-sweep system principal.
+func TestSweepAttributesRealEditor(t *testing.T) {
+	pool := newScopedPool(t)
+	s, err := pgstore.New(pool)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = s.Close() })
+	ctx := context.Background()
+
+	require.NoError(t, s.CreateEntity(attributedCtx("alice@example.com", "data-entry"),
+		mkEntity("WHO-1", "ticket", "policy text")))
+	require.NoError(t, s.CreateEntity(ctx, mkEntity("WHO-2", "ticket", "peer")))
+	_, err = s.CreateRelation(attributedCtx("alice@example.com", "data-entry"),
+		"WHO-1", "blocks", "WHO-2", &store.RelationData{Content: "reason"})
+	require.NoError(t, err)
+
+	// Backdate so both settle past the idle window.
+	_, err = pool.Exec(ctx, `UPDATE entities SET updated_at = now() - interval '1 hour'`)
+	require.NoError(t, err)
+	_, err = pool.Exec(ctx, `UPDATE relations SET updated_at = now() - interval '1 hour'`)
+	require.NoError(t, err)
+
+	s.StartVersionSweep(stubProvider{hash: "schema-abc", json: []byte(`{"entities":{},"types":{}}`)},
+		pgstore.SweepConfig{Interval: 50 * time.Millisecond, Idle: time.Minute, MaxStaleness: time.Hour, Batch: 100})
+
+	require.Eventually(t, func() bool {
+		metas, e := s.VersionStore().ListVersions(ctx, "WHO-1")
+		return e == nil && len(metas) == 1
+	}, 3*time.Second, 25*time.Millisecond)
+
+	metas, err := s.VersionStore().ListVersions(ctx, "WHO-1")
+	require.NoError(t, err)
+	require.Equal(t, store.VersionOpCreate, metas[0].Op)
+	require.Equal(t, "alice@example.com", metas[0].PrincipalUser)
+	require.Equal(t, "data-entry", metas[0].PrincipalTool)
+
+	require.Eventually(t, func() bool {
+		rm, e := s.VersionStore().ListRelationVersions(ctx,
+			store.RelationHistoryQuery{From: "WHO-1", Type: "blocks", To: "WHO-2"})
+		return e == nil && len(rm) == 1
+	}, 3*time.Second, 25*time.Millisecond)
+
+	rm, err := s.VersionStore().ListRelationVersions(ctx,
+		store.RelationHistoryQuery{From: "WHO-1", Type: "blocks", To: "WHO-2"})
+	require.NoError(t, err)
+	require.Equal(t, "alice@example.com", rm[0].PrincipalUser)
+	require.Equal(t, "data-entry", rm[0].PrincipalTool)
+
+	// WHO-2 was written WITHOUT attribution: its swept version must fall back
+	// to the system principal, never a fabricated identity (AC5, RR-U964M0).
+	require.Eventually(t, func() bool {
+		metas, e := s.VersionStore().ListVersions(ctx, "WHO-2")
+		return e == nil && len(metas) == 1
+	}, 3*time.Second, 25*time.Millisecond)
+	fallback, err := s.VersionStore().ListVersions(ctx, "WHO-2")
+	require.NoError(t, err)
+	require.Empty(t, fallback[0].PrincipalUser)
+	require.Equal(t, "version-sweep", fallback[0].PrincipalTool)
+}
+
+// TestSweepAttributesLastEditorOfBurst pins the accepted v1 semantics (flush-
+// on-author-change is TKT-0IGI4V): a burst of edits collapses into ONE version
+// attributed to the LAST editor.
+func TestSweepAttributesLastEditorOfBurst(t *testing.T) {
+	pool := newScopedPool(t)
+	s, err := pgstore.New(pool)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = s.Close() })
+	ctx := context.Background()
+
+	require.NoError(t, s.CreateEntity(attributedCtx("alice", "cli"), mkEntity("BURST-1", "ticket", "v1")))
+	require.NoError(t, s.UpdateEntity(attributedCtx("bob", "data-entry"), mkEntity("BURST-1", "ticket", "v2")))
+
+	_, err = pool.Exec(ctx, `UPDATE entities SET updated_at = now() - interval '1 hour' WHERE id = 'BURST-1'`)
+	require.NoError(t, err)
+
+	s.StartVersionSweep(stubProvider{hash: "schema-abc", json: []byte(`{"entities":{},"types":{}}`)},
+		pgstore.SweepConfig{Interval: 50 * time.Millisecond, Idle: time.Minute, MaxStaleness: time.Hour, Batch: 100})
+
+	require.Eventually(t, func() bool {
+		metas, e := s.VersionStore().ListVersions(ctx, "BURST-1")
+		return e == nil && len(metas) == 1
+	}, 3*time.Second, 25*time.Millisecond)
+
+	metas, err := s.VersionStore().ListVersions(ctx, "BURST-1")
+	require.NoError(t, err)
+	require.Equal(t, "bob", metas[0].PrincipalUser)
+	require.Equal(t, "data-entry", metas[0].PrincipalTool)
+}

--- a/internal/store/pgstore/entity.go
+++ b/internal/store/pgstore/entity.go
@@ -197,6 +197,22 @@ func (s *Store) PropertyValues(ctx context.Context, property string, limit int) 
 
 // --- EntityWriter ---
 
+// attributionValues returns the last_edited_by_user / last_edited_by_tool SQL
+// values for the boundary-populated store.Attribution on ctx. Absent (or
+// empty-component) attribution maps to NULL, never to an empty or placeholder
+// string — NULL is the "unknown editor" encoding the version sweep's
+// system-principal fallback keys on (TKT-ZIRMGM, RR-U964M0).
+func attributionValues(ctx context.Context) (user, tool *string) {
+	a := store.AttributionFrom(ctx)
+	if a.User != "" {
+		user = &a.User
+	}
+	if a.Tool != "" {
+		tool = &a.Tool
+	}
+	return user, tool
+}
+
 // CreateEntity inserts a new entity. Returns store.ErrConflict if the ID
 // exists. The created entity (with server-assigned updated_at) is delivered
 // to observers and an EventEntityCreated is emitted after commit.
@@ -216,13 +232,16 @@ func (s *Store) CreateEntity(ctx context.Context, e *entity.Entity) error {
 	}
 	defer tx.Rollback(ctx) //nolint:errcheck // rollback after commit is a no-op
 
+	editorUser, editorTool := attributionValues(ctx)
 	const q = `
-		INSERT INTO entities (id, type, properties, content, search_text, updated_at)
-		VALUES ($1, $2, $3, $4, $5, now())
+		INSERT INTO entities (id, type, properties, content, search_text, updated_at,
+		                      last_edited_by_user, last_edited_by_tool)
+		VALUES ($1, $2, $3, $4, $5, now(), $6, $7)
 		ON CONFLICT (id) DO NOTHING
 		RETURNING updated_at`
 	var updatedAt time.Time
-	err = tx.QueryRow(ctx, q, e.ID, e.Type, props, e.Content, entitySearchText(e)).Scan(&updatedAt)
+	err = tx.QueryRow(ctx, q, e.ID, e.Type, props, e.Content, entitySearchText(e),
+		editorUser, editorTool).Scan(&updatedAt)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return store.ErrConflict
 	}
@@ -257,14 +276,17 @@ func (s *Store) UpdateEntity(ctx context.Context, e *entity.Entity) error {
 	}
 	defer tx.Rollback(ctx) //nolint:errcheck // rollback after commit is a no-op
 
+	editorUser, editorTool := attributionValues(ctx)
 	const q = `
 		UPDATE entities
 		SET type = $2, properties = $3, content = $4, search_text = $5,
-		    updated_at = now(), seq = nextval('rela_seq')
+		    updated_at = now(), seq = nextval('rela_seq'),
+		    last_edited_by_user = $6, last_edited_by_tool = $7
 		WHERE id = $1
 		RETURNING updated_at`
 	var updatedAt time.Time
-	err = tx.QueryRow(ctx, q, e.ID, e.Type, props, e.Content, entitySearchText(e)).Scan(&updatedAt)
+	err = tx.QueryRow(ctx, q, e.ID, e.Type, props, e.Content, entitySearchText(e),
+		editorUser, editorTool).Scan(&updatedAt)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return store.ErrNotFound
 	}

--- a/internal/store/pgstore/migrations/0006_last_edited_by.sql
+++ b/internal/store/pgstore/migrations/0006_last_edited_by.sql
@@ -1,0 +1,28 @@
+-- pgstore schema, version 6: write-authorship columns (TKT-ZIRMGM).
+--
+-- last_edited_by_user / last_edited_by_tool record who/what performed the most
+-- recent create/update write on the live row, stamped by the store from the
+-- boundary-populated store.Attribution on ctx. The version sweep reads them to
+-- attribute its debounced create/update snapshots to the REAL editor instead of
+-- the system principal; NULL (legacy rows, writes with no attribution) keeps
+-- the pre-existing fallback (principal_tool = 'version-sweep').
+--
+-- Deliberately nullable with NO DEFAULT: NULL is the "no recorded editor"
+-- encoding the sweep's fallback keys on — the boundary must not translate a
+-- wholly-unknown principal into stored values (RR-U964M0). A PARTIALLY unknown
+-- principal is stored verbatim, though: a CLI write with an unset $USER
+-- legitimately lands as user='unknown', tool='cli' (the tool is real
+-- information). No backfill: existing rows self-heal on their next attributed
+-- write.
+--
+-- RenameEntity's bulk relation re-key (UPDATE relations SET from_id/to_id ...)
+-- deliberately does not touch these columns: a rename does not edit relation
+-- content, so the last CONTENT editor remains the attributed author
+-- (RR-U1RGSE).
+ALTER TABLE entities
+    ADD COLUMN last_edited_by_user TEXT,
+    ADD COLUMN last_edited_by_tool TEXT;
+
+ALTER TABLE relations
+    ADD COLUMN last_edited_by_user TEXT,
+    ADD COLUMN last_edited_by_tool TEXT;

--- a/internal/store/pgstore/relation.go
+++ b/internal/store/pgstore/relation.go
@@ -146,12 +146,15 @@ func (s *Store) CreateRelation(
 	}
 	defer tx.Rollback(ctx) //nolint:errcheck // rollback after commit is a no-op
 
+	editorUser, editorTool := attributionValues(ctx)
 	const q = `
-		INSERT INTO relations (from_id, rel_type, to_id, properties, content, updated_at)
-		VALUES ($1, $2, $3, $4, $5, now())
+		INSERT INTO relations (from_id, rel_type, to_id, properties, content, updated_at,
+		                       last_edited_by_user, last_edited_by_tool)
+		VALUES ($1, $2, $3, $4, $5, now(), $6, $7)
 		ON CONFLICT (from_id, rel_type, to_id) DO NOTHING
 		RETURNING from_id, rel_type, to_id, properties, content, updated_at`
-	r, err := scanRelation(tx.QueryRow(ctx, q, from, relType, to, rawProps, content))
+	r, err := scanRelation(tx.QueryRow(ctx, q, from, relType, to, rawProps, content,
+		editorUser, editorTool))
 	if errors.Is(err, pgx.ErrNoRows) {
 		return nil, store.ErrConflict
 	}
@@ -184,12 +187,15 @@ func (s *Store) UpdateRelation(
 	}
 	defer tx.Rollback(ctx) //nolint:errcheck // rollback after commit is a no-op
 
+	editorUser, editorTool := attributionValues(ctx)
 	const q = `
 		UPDATE relations
-		SET properties = $4, content = $5, updated_at = now(), seq = nextval('rela_seq')
+		SET properties = $4, content = $5, updated_at = now(), seq = nextval('rela_seq'),
+		    last_edited_by_user = $6, last_edited_by_tool = $7
 		WHERE from_id = $1 AND rel_type = $2 AND to_id = $3
 		RETURNING from_id, rel_type, to_id, properties, content, updated_at`
-	r, err := scanRelation(tx.QueryRow(ctx, q, from, relType, to, rawProps, data.Content))
+	r, err := scanRelation(tx.QueryRow(ctx, q, from, relType, to, rawProps, data.Content,
+		editorUser, editorTool))
 	if errors.Is(err, pgx.ErrNoRows) {
 		return nil, store.ErrNotFound
 	}

--- a/internal/store/pgstore/status_test.go
+++ b/internal/store/pgstore/status_test.go
@@ -33,8 +33,8 @@ func TestStatusFreshSchema(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 0, current, "un-migrated schema is version 0")
 	// target is the highest embedded migration version — bump this when a new
-	// migration is added (0005_relation_versions.sql took it from 4 to 5).
-	require.Equal(t, 5, target, "binary embeds migrations through 0005")
+	// migration is added (0006_last_edited_by.sql took it from 5 to 6).
+	require.Equal(t, 6, target, "binary embeds migrations through 0006")
 }
 
 // TestStatusAfterMigrate verifies Status reports current==target once Migrate

--- a/internal/store/pgstore/sweep.go
+++ b/internal/store/pgstore/sweep.go
@@ -208,7 +208,9 @@ func (s *sweep) tick(ctx context.Context) error {
 
 // sweepCandidate is one entity the sweep may snapshot: its current state plus
 // the content hash of its latest existing version (empty if none), so
-// captureOne can dedup without a second query.
+// captureOne can dedup without a second query. editorUser/editorTool carry the
+// row's last_edited_by_* columns (nil = no recorded editor) so the captured
+// version is attributed to the real author (TKT-ZIRMGM).
 type sweepCandidate struct {
 	id         string
 	typ        string
@@ -216,6 +218,8 @@ type sweepCandidate struct {
 	props      []byte
 	latestHash string
 	hasVersion bool
+	editorUser *string
+	editorTool *string
 }
 
 // selectCandidates returns up to Batch entities that have settled (updated_at
@@ -242,6 +246,7 @@ func (s *sweep) selectCandidates(ctx context.Context, conn *pgxpool.Conn) ([]swe
 	//     ending in `delete` while it is live.
 	const q = `
 		SELECT e.id, e.type, e.content, e.properties,
+		       e.last_edited_by_user, e.last_edited_by_tool,
 		       lvc.content_hash,
 		       (lv.vseq IS NOT NULL AND lv.op <> 'delete') AS live_lineage
 		FROM entities e
@@ -277,7 +282,8 @@ func (s *sweep) selectCandidates(ctx context.Context, conn *pgxpool.Conn) ([]swe
 			c          sweepCandidate
 			latestHash *string // NULL when there is no version in the current lifecycle
 		)
-		if err := rows.Scan(&c.id, &c.typ, &c.content, &c.props, &latestHash, &c.hasVersion); err != nil {
+		if err := rows.Scan(&c.id, &c.typ, &c.content, &c.props,
+			&c.editorUser, &c.editorTool, &latestHash, &c.hasVersion); err != nil {
 			return nil, err
 		}
 		if latestHash != nil {
@@ -300,6 +306,7 @@ func (s *sweep) captureOne(
 	if err != nil {
 		return err
 	}
+	principalUser, principalTool := sweepAttribution(c.editorUser, c.editorTool)
 	in := store.VersionInput{
 		EntityID:      c.id,
 		Type:          c.typ,
@@ -307,7 +314,8 @@ func (s *sweep) captureOne(
 		Properties:    props,
 		SchemaHash:    schemaHash,
 		Projection:    projJSON,
-		PrincipalTool: "version-sweep",
+		PrincipalUser: principalUser,
+		PrincipalTool: principalTool,
 	}
 	contentHash := contentHashOf(in)
 	// Dedup only within the current lifecycle: latestHash is empty when there is
@@ -323,9 +331,28 @@ func (s *sweep) captureOne(
 	return insertVersion(ctx, conn, in, contentHash)
 }
 
+// sweepAttribution returns the principal to stamp on a swept create/update
+// version: the row's recorded last_edited_by_* editor when present, else the
+// version-sweep system principal. NULL columns (legacy rows, writes that
+// carried no store.Attribution) keep the pre-TKT-ZIRMGM fallback — the sweep
+// never guesses an author.
+func sweepAttribution(editorUser, editorTool *string) (user, tool string) {
+	if editorUser == nil && editorTool == nil {
+		return "", "version-sweep"
+	}
+	if editorUser != nil {
+		user = *editorUser
+	}
+	if editorTool != nil {
+		tool = *editorTool
+	}
+	return user, tool
+}
+
 // relationSweepCandidate is one relation the sweep may snapshot: its current
 // state plus the surrogate rel_record_id off the live row and the content hash
-// of its latest existing version in that lineage (empty if none).
+// of its latest existing version in that lineage (empty if none). editorUser/
+// editorTool mirror sweepCandidate's attribution columns.
 type relationSweepCandidate struct {
 	recordID   int64
 	from       string
@@ -335,6 +362,8 @@ type relationSweepCandidate struct {
 	props      []byte
 	latestHash string
 	hasVersion bool
+	editorUser *string
+	editorTool *string
 }
 
 // selectRelationCandidates returns up to Batch relations that have settled (or
@@ -352,6 +381,7 @@ func (s *sweep) selectRelationCandidates(
 ) ([]relationSweepCandidate, error) {
 	const q = `
 		SELECT r.rel_record_id, r.from_id, r.rel_type, r.to_id, r.content, r.properties,
+		       r.last_edited_by_user, r.last_edited_by_tool,
 		       lv.content_hash,
 		       (lv.vseq IS NOT NULL) AS has_version
 		FROM relations r
@@ -377,7 +407,8 @@ func (s *sweep) selectRelationCandidates(
 			latestHash *string // NULL when the lineage has no version yet
 		)
 		if err := rows.Scan(&c.recordID, &c.from, &c.relType, &c.to,
-			&c.content, &c.props, &latestHash, &c.hasVersion); err != nil {
+			&c.content, &c.props, &c.editorUser, &c.editorTool,
+			&latestHash, &c.hasVersion); err != nil {
 			return nil, err
 		}
 		if latestHash != nil {
@@ -398,6 +429,7 @@ func (s *sweep) captureRelation(
 	if err != nil {
 		return err
 	}
+	principalUser, principalTool := sweepAttribution(c.editorUser, c.editorTool)
 	in := store.RelationVersionInput{
 		RecordID:      c.recordID,
 		From:          c.from,
@@ -407,7 +439,8 @@ func (s *sweep) captureRelation(
 		Properties:    props,
 		SchemaHash:    schemaHash,
 		Projection:    projJSON,
-		PrincipalTool: "version-sweep",
+		PrincipalUser: principalUser,
+		PrincipalTool: principalTool,
 	}
 	contentHash := contentHashOfRelation(in)
 	if c.latestHash != "" && contentHash == c.latestHash {

--- a/tickets/entities/docs-checklists/DOCS-LUGRRB.md
+++ b/tickets/entities/docs-checklists/DOCS-LUGRRB.md
@@ -1,0 +1,25 @@
+---
+id: DOCS-LUGRRB
+type: docs-checklist
+title: 'Docs: Author-aware version capture (last_edited_by attribution)'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Code Documentation
+
+- [x] Godoc on new exported API (`store.Attribution`, `WithAttribution`, `AttributionFrom`) documents the boundary-populated contract, NULL-when-absent rule, and partial-unknown semantics
+- [x] Migration 0006 header documents NULL encoding, no-backfill self-healing, and rename re-key neutrality
+- [x] `withStoreAttribution` / `attributionValues` / `sweepAttribution` helpers document their invariants and RR references
+
+## Project Documentation
+
+- [x] CLAUDE.md content-versioning bullet updated: the two sanctioned boundary-populated attribution routes (VersionInput + Attribution ctx carrier), the NULL→version-sweep fallback, and the TKT-0IGI4V pointer for author-boundary segmentation
+
+## External Documentation
+
+- [x] `docs/postgres-backend.md` attribution paragraph rewritten: real-editor attribution on swept versions, fallback semantics, self-healing legacy rows, rename neutrality, and the documented v1 last-editor-of-burst limit
+- [x] ~~docs/cli-reference.md~~ (N/A: no command changes)
+- [x] ~~docs/data-entry.md~~ (N/A: UI unchanged — it simply starts showing real names)
+- [x] ~~docs/metamodel.md~~ (N/A)

--- a/tickets/entities/implementation-checklists/IMPL-USSOQO.md
+++ b/tickets/entities/implementation-checklists/IMPL-USSOQO.md
@@ -1,0 +1,67 @@
+---
+id: IMPL-USSOQO
+type: implementation-checklist
+title: 'Implementation: Author-aware version capture: last_edited_by column + flush-on-author-change (precise per-version attribution)'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Development
+
+- [x] Unit tests written for new code
+- [x] Integration tests written (test full flow, not just units)
+- [x] Happy path implemented
+- [x] Edge cases from planning handled
+- [x] Error handling in place (errors surfaced, not swallowed)
+
+Changes (branch `feat/tkt-zirmgm-version-attribution`):
+
+- `internal/store/attribution.go` (new): `store.Attribution{User, Tool}` + `WithAttribution`/`AttributionFrom` ctx carrier; godoc pins the boundary-populated contract and the NULL-when-absent rule.
+- `internal/entitymanager/attribution.go` (new): `withStoreAttribution` boundary helper, IsZero/unknown-guarded (RR-U964M0); called first in all six public write entry points (`ApplyEntity`, `ApplyRelation`, `CreateEntity`, `UpdateEntity`, `CreateRelation`, `UpdateRelation`), so nested automation/cascade/renumber writes inherit it.
+- `internal/store/pgstore/migrations/0006_last_edited_by.sql` (new): nullable, DEFAULT-less `last_edited_by_user/_tool` on `entities` + `relations`; header documents NULL=unknown and rename-re-key neutrality.
+- `internal/store/pgstore/entity.go` / `relation.go`: `attributionValues(ctx)` helper (empty component → NULL); Create/Update for entities and relations stamp the columns. Rename bulk re-key untouched (RR-U1RGSE) — verified it only SETs id/from_id/to_id/updated_at/seq/search_text.
+- `internal/store/pgstore/sweep.go`: candidate queries select the columns; `sweepAttribution` stamps real editor onto swept versions, `{tool: "version-sweep"}` fallback when both NULL.
+- `internal/store/pgstore/status_test.go`: migration target 5 → 6.
+- Docs: CLAUDE.md content-versioning bullet (two sanctioned attribution routes, fallback, TKT-0IGI4V pointer); `docs/postgres-backend.md` attribution paragraph.
+
+## Test Quality
+
+- [x] Using fixture builders or factories for test data (`mkEntity`, `attributedCtx`, `stubProvider` reused)
+- [x] No hardcoded values in assertions when object is in scope
+- [x] Only specifying values that matter for the test
+- [x] Interpolated values constructed from objects, not hardcoded
+- [x] Property comparisons use original object, not hardcoded strings
+
+## Manual Verification
+
+- [x] Feature manually tested end-to-end
+- [x] Each acceptance criterion verified with test scenario from planning
+- [x] Edge cases manually verified
+
+**Verification Evidence:**
+
+End-to-end verification ran against a real local PostgreSQL (per-test scoped
+schemas, `postgres://…/rela_test`), race detector on:
+
+- AC1/AC2 (`TestSweepAttributesRealEditor`): entity + relation written with attribution, backdated, real sweep goroutine captured versions with `principal_user=alice@example.com`, `principal_tool=data-entry`. PASS.
+- AC3 (`TestSweepAttributesLastEditorOfBurst`): alice-then-bob burst → ONE version attributed to bob (documented v1 semantics; author segmentation = TKT-0IGI4V). PASS.
+- AC4 (`TestSweepAttributesRealEditor` WHO-2 + `TestAttributionColumnsStamped`): unattributed writes leave NULL columns; swept version falls back to `version-sweep` with empty user; no "unknown" literals. Boundary guard unit-tested in `TestWithStoreAttribution` (unstamped ctx, explicit {unknown,unknown}, real principal, unknown-user/real-tool). PASS.
+- AC5 (`TestSweepAttributesRealEditor`): relation version attributed. PASS.
+- AC6: rename re-key SQL inspected — does not touch the columns (`entity.go:393` id re-key; relation re-key SETs endpoints only).
+- AC7: full DB-gated pgstore suite (conformance, sweep, purge, ordering, tombstone, tx stress) green: `ok … 24.6s`. Default-build `internal/store/... internal/entitymanager/...` green with `-race`.
+
+Quality gates: `just lint` 0 issues (after fixing a containedctx finding in my
+own test), `just arch-lint` OK, `just plimsoll` OK, `just coverage-check` PASS
+(76.0% total), `just build-check-tags` all three tag combos compile.
+
+Note: the reporting deployment's existing v1/v2 rows stay `version-sweep` by
+design (no backfill); they self-heal on the next attributed edit.
+
+## Quality
+
+- [x] Code follows project patterns (mirrors principal.With/From ctx idiom; sweep helper mirrors existing capture structure)
+- [x] Checked for DRY opportunities — `attributionValues` + `sweepAttribution` extracted once each; no premature abstraction
+- [x] No security issues introduced (opaque text, parameterized SQL; trust model unchanged, documented)
+- [x] No silent failures (absent attribution is a DOCUMENTED expected state, not a swallowed error; sweep capture errors still logged per existing contract)
+- [x] No debug code left behind

--- a/tickets/entities/planning-checklists/PLAN-6B7S1Z.md
+++ b/tickets/entities/planning-checklists/PLAN-6B7S1Z.md
@@ -1,0 +1,183 @@
+---
+id: PLAN-6B7S1Z
+type: planning-checklist
+title: 'Planning: Author-aware version capture: last_edited_by column + flush-on-author-change (precise per-version attribution)'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Understanding
+
+- [x] Problem/requirements clearly understood
+- [x] Scope defined (what's in/out documented below)
+- [x] Acceptance criteria documented with specific test scenarios
+
+**Scope:** (narrowed by design review, 2026-07-24 — flush-on-author-change split
+to TKT-0IGI4V)
+
+IN scope:
+
+- Real principal attribution on sweep-captured **entity** create/update versions (the screenshot case: `unknown · version-sweep`).
+- Same for **relation** create/update versions (same sweep, `sweep.go:310`/`410`).
+- Migration adding nullable `last_edited_by_user`/`last_edited_by_tool` to `entities` + `relations`; pgstore stamps them on create/update writes.
+- Store-owned `store.Attribution{User, Tool}` + ctx carrier, populated only at the entitymanager boundary from a REAL (non-zero/non-unknown) principal.
+- Fallback: NULL columns (legacy rows, principal-less writes) → sweep keeps the `version-sweep` system principal — never guess, never stamp literal "unknown".
+- Postgres backend only.
+
+NOT in scope:
+
+- **Flush-on-author-change** → follow-up TKT-0IGI4V (per RR-K781MZ; carries pinned semantics from RR-VG4BPJ/RR-4OJAC1/RR-MMDQ3N/RR-MZ4PPG/RR-MORL7M/RR-12HJ4K). Consequence accepted for v1: two different authors editing within one debounce window still merge into ONE swept version, attributed to the LAST author (a strict improvement over `version-sweep`).
+- Backfilling existing version rows (audit-log correlation remains the recovery path).
+- fsstore/memstore behavior changes; read-API/UI exposure of last-editor.
+
+**Acceptance Criteria:**
+
+1. **AC1 — swept update attribution:** authenticated user X edits an entity via data-entry; after the sweep captures, the version row has `principal_user = X`, `principal_tool = data-entry` (not `version-sweep`).
+2. **AC2 — swept create attribution:** same for a freshly created entity's `create` version.
+3. **AC3 — same-author debounce preserved:** user X edits 3× within the window → still ONE swept version (attributed to X).
+4. **AC4 — fallback:** a write with no/zero/unknown principal leaves columns NULL; sweep attributes `version-sweep`; nothing errors. Literal "unknown" is never stamped.
+5. **AC5 — relations:** a relation prop/body edit by user X yields a swept relation version attributed to X.
+6. **AC6 — rename re-key neutrality:** RenameEntity's bulk relation re-key leaves `last_edited_by_*` untouched.
+7. **AC7 — no regressions:** storetest conformance, sweep dedup, purge guardrails, change-feed watermark all unaffected.
+
+## Research
+
+- [x] ~~For larger features: run `/research`~~ (N/A: design carried in ticket body since 2026-07-08; open decisions settled with user + /design-review)
+- [x] ~~Searched for existing libraries~~ (N/A: internal storage/attribution mechanics)
+- [x] Checked codebase for similar patterns or reusable code
+- [x] Looked for reference implementations in other projects
+- [x] Reviewed relevant rela concepts for prior art
+
+**Research Doc:** N/A (RES-4ILUJZ covered versioning storage shape)
+
+**Existing Solutions:**
+
+- Sweep system-principal stamping to replace: `internal/store/pgstore/sweep.go:310` (entities), `sweep.go:410` (relations).
+- Sync capture path with real principals (rename/delete): `entitymanager.VersionRecorder` (`internal/entitymanager/manager.go:172-181`), adapters in `internal/appbuild/appbuild.go:755-800`.
+- Principal plumbing: `internal/principal` (ctx-based; data-entry stamps per-request). NOTE: `principal.From` returns `{unknown, unknown}` for unstamped ctx — boundary must IsZero-check (RR-U964M0).
+- External prior art: collaborative-editor revision histories segment by author (relevant to the split-out flush ticket).
+
+## Approach
+
+- [x] Technical approach chosen and documented
+- [x] Approach builds on existing patterns (not reinventing)
+- [x] Alternatives considered (document why rejected)
+- [x] Dependencies identified (packages, APIs, types)
+
+**Technical Approach:**
+
+Migration `0006_last_edited_by.sql`: nullable `last_edited_by_user text` /
+`last_edited_by_tool text` on `entities` AND `relations` (mirroring
+`principal_user`/`principal_tool` on version tables; NULL = unknown/legacy; no
+DEFAULT).
+
+1. **Store-owned attribution concept (user decision, 2026-07-24):** `store.Attribution{User, Tool}` + `store.WithAttribution(ctx, a)` / `store.AttributionFrom(ctx)` in `internal/store`. The entitymanager write boundary translates the ctx Principal → `store.WithAttribution` **only when the principal is real** (`IsZero()`/unknown → no attribution → NULL columns; RR-U964M0). pgstore never imports `internal/principal`; the CLAUDE.md invariant is preserved and its wording extended to name the Attribution carrier as the second sanctioned boundary-populated input (RR-2VWA0Q). fs/mem stores ignore the ctx value.
+2. **Stamp on write (pgstore):** `CreateEntity`/`UpdateEntity`/`CreateRelation`/`UpdateRelation` read `store.AttributionFrom(ctx)`, set columns (NULL when absent). RenameEntity's bulk re-key statements untouched — they must not clobber the columns (RR-U1RGSE).
+3. **Sweep reads the columns:** candidate queries select `last_edited_by_*`; `captureOne`/`captureRelation` stamp `PrincipalUser`/`PrincipalTool` from them, falling back to `{tool: "version-sweep"}` when NULL.
+
+**Placement decision (RESOLVED with user):** pgstore-contained via the
+store-owned Attribution ctx concept. Domain-field alternative
+(`entity.Entity.LastEditedBy`) rejected: would drag `canonical.HashEntity`,
+storetest conformance, fsstore frontmatter, and all backends into a pg-only
+feature.
+
+**Files to modify:**
+
+- `internal/store/store.go` — `Attribution` type + ctx helpers
+- `internal/entitymanager` write paths — Principal → `WithAttribution` (IsZero-guarded)
+- `internal/store/pgstore/migrations/0006_last_edited_by.sql` (new)
+- `internal/store/pgstore/entity.go`, `relation.go` — stamp columns
+- `internal/store/pgstore/sweep.go` — select + stamp, NULL fallback
+- `CLAUDE.md` + docs postgres-backend guide — attribution route, fallback, rename-neutrality
+- Tests: DB-gated pgstore tests (attribution stamped / NULL both directions; swept-version principal; fallback), migration status test if count-asserted
+
+## Security Considerations
+
+- [x] Input sources identified (user input, config, external APIs)
+- [x] Input validation approach defined (allowlist preferred over blocklist)
+- [x] Security-sensitive operations identified (file access, auth, crypto)
+- [x] Error handling doesn't leak sensitive information
+
+**Input Sources & Validation:**
+
+- Principal from ctx (data-entry middleware ← oauth2proxy headers), translated to `store.Attribution` at the entitymanager boundary. Trust model identical to the audit log's ("a forged principal under an untrusted proxy would forge last_edited_by too — document, don't re-solve"). Opaque text, parameterized SQL only.
+- No new user-controlled surface: columns written from boundary-populated ctx, read only by the sweep.
+
+**Security-Sensitive Operations:**
+
+- Version rows gain real usernames where they had a system tag — the point of the ticket; matches sync rename/delete versions. History reads already ACL-gated. Purge semantics untouched.
+
+## Test Plan
+
+- [x] Test scenarios documented for each acceptance criterion
+- [x] Edge cases identified and documented
+- [x] Negative test cases defined (invalid input, error conditions)
+- [x] Integration test approach defined (not just unit tests)
+
+**Test Scenarios:** (DB-gated via `RELA_TEST_DATABASE_URL`, `just
+test-postgres`)
+
+- AC1/AC2: write with `WithAttribution` on ctx → force sweep tick → assert version principal_user/tool.
+- AC3: three writes same attribution → one sweep → exactly one new version.
+- AC4: write with no attribution / boundary given zero-or-unknown principal → columns NULL → swept version carries `version-sweep`; assert no "unknown" literals.
+- AC5: relation update with attribution → attributed swept relation version.
+- AC6: rename entity with incident relations → relations' `last_edited_by_*` unchanged.
+- AC7: existing conformance + sweep + purge + ordering suites pass unchanged.
+- Contract pinning (RR-2VWA0Q): store-level test asserting both directions of the Attribution ctx contract.
+
+**Edge Cases:**
+
+- Partial attribution (user set, tool empty or vice versa): store as given — columns are independent; sweep falls back only when BOTH NULL? No — fallback when user AND tool both NULL; partial rows stamp what exists. Keep simple: treat attribution as a unit — boundary only sets it when principal is real, so partials shouldn't occur; sweep falls back unless at least one column is non-NULL.
+- Legacy rows (pre-migration): NULL → fallback, self-heals on next edit.
+- Unicode/long usernames (email addresses): text columns, parameterized — fine.
+- Concurrent writes to same entity: last write's attribution wins on the row — matches "last editor" semantics by definition.
+- Migration on live deployment: nullable ALTER, no backfill, instant.
+
+**Negative Tests:**
+
+- Zero/unknown principal at boundary → no WithAttribution call (unit-testable in entitymanager).
+- Sweep with mixed NULL/non-NULL candidates in one tick → each version attributed independently.
+
+## Risk Assessment
+
+- [x] Technical risks assessed with mitigations
+- [x] Security risks assessed (see Security Considerations)
+- [x] Effort estimated (xs/s/m/l/xl)
+
+**Risks:**
+
+- **Silent degradation** (RR-2VWA0Q): a write path missing `WithAttribution` yields NULL → fallback attribution, no error. Mitigation: entitymanager is the single choke point for human writes; contract tests pin behavior; enumerate non-entitymanager store-write callers during implementation.
+- **"unknown" literal leakage** (RR-U964M0): guarded by IsZero check + explicit negative test.
+- **Sweep query cost:** two extra selected columns on existing candidate scans — negligible.
+- **v1 author-merge limitation:** two authors in one window merge to last-author attribution until TKT-0IGI4V lands — documented, accepted.
+
+Effort: **s/m** (reduced by the split — one migration, store ctx helper,
+pgstore-local stamping, DB-gated tests).
+
+## Documentation Planning
+
+- [x] User-facing docs identified (skip if internal refactor)
+- [x] Docs-checklist will be created when entering implementation
+
+**Documentation Impact:**
+
+- [x] CLAUDE.md — content-versioning bullet: Attribution ctx carrier as second boundary-populated input; NULL fallback; rename-neutrality; pointer to TKT-0IGI4V for the flush
+- [x] docs postgres-backend guide — attribution semantics + fallback
+- [ ] ~~docs/metamodel.md~~ (N/A)
+- [ ] ~~docs/cli-reference.md~~ (N/A)
+- [ ] ~~docs/data-entry.md~~ (N/A: UI simply starts showing real names)
+
+## Design Review
+
+- [x] Run `/design-review` before starting implementation
+- [x] All critical/significant findings addressed in plan
+
+**Design Review Findings:** (go-architect agent, 2026-07-24)
+
+- RR-U964M0 (critical, addressed): IsZero-guard the boundary translation — never stamp literal "unknown".
+- RR-2VWA0Q (critical, addressed): pin the Attribution ctx contract with tests + CLAUDE.md wording update.
+- RR-K781MZ (significant, addressed): flush split to TKT-0IGI4V.
+- RR-VG4BPJ / RR-4OJAC1 / RR-MMDQ3N / RR-MZ4PPG (significant, deferred → TKT-0IGI4V): flush atomicity / dedup backing / op choice / purge-tombstone reasoning.
+- RR-MORL7M / RR-12HJ4K (minor, deferred → TKT-0IGI4V): no rename markers / pure decision seam.
+- RR-U1RGSE (minor, addressed): rename bulk re-key leaves columns untouched; documented.

--- a/tickets/entities/review-checklists/REV-YL9OA3.md
+++ b/tickets/entities/review-checklists/REV-YL9OA3.md
@@ -66,7 +66,7 @@ inheritance, migration lock safety, and test isolation.
 ## Pull Request
 
 - [x] Run `/pr` command to create PR and monitor CI — PR created
-- [x] All CI checks pass — being watched via `gh pr checks --watch`; this box is finalized in the same bookkeeping commit that lands only after the run is green (local `just ci` — lint, tests, coverage, arch-lint, plimsoll, tag matrix, docs-check — already fully green on the pushed commit)
+- [x] All CI checks pass — first run (e4345144) failed ONE check, `Rela Tickets`: the workflow runs this very `rela validate` gate, and the PR-section boxes below were still unchecked on the pushed commit (I had sequenced the bookkeeping commit after CI, which is backwards — the gate is part of CI). Fixed in af759f35; all other checks passed on the first run (Architecture, Lint, Lint Markdown, God-object lint, Vulnerability Check, Fuzz, Frontend, E2E, Postgres Backend, CodeQL, all 8 Cross-Compile tag/OS combos).
 - [x] PR URL documented below
 
 **PR:** https://github.com/sourcehaven-bv/rela/pull/1195

--- a/tickets/entities/review-checklists/REV-YL9OA3.md
+++ b/tickets/entities/review-checklists/REV-YL9OA3.md
@@ -2,50 +2,66 @@
 id: REV-YL9OA3
 type: review-checklist
 title: 'Review: Author-aware version capture: last_edited_by column + flush-on-author-change (precise per-version attribution)'
-status: in-progress
+status: done
 ---
 
 <!-- @managed: claude-workflow v1 -->
 
 ## Automated Checks
 
-- [ ] All tests pass (`just test`)
-- [ ] Lint clean (`just lint`)
-- [ ] Coverage maintained (`just coverage-check`)
+- [x] All tests pass (`just test` — default build; plus DB-gated `just test-postgres` equivalent against local PostgreSQL, full pgstore suite green with -race)
+- [x] Lint clean (`just lint` — 0 issues)
+- [x] Coverage maintained (`just coverage-check` — PASS, 76.0% total)
 
 ## Code Review
 
-- [ ] Run `/code-review` command (invokes cranky-code-reviewer agent)
-- [ ] All critical review-responses addressed
-- [ ] All significant review-responses addressed
-- [ ] Self-reviewed the diff for unrelated changes
+- [x] Run `/code-review` command (invokes cranky-code-reviewer agent)
+- [x] All critical review-responses addressed
+- [x] All significant review-responses addressed
+- [x] Self-reviewed the diff for unrelated changes
 
-**Review Responses:** <!-- List IDs of review-response entities created, e.g.,
-RR-xxxx -->
+**Review Responses:**
+
+Design review (pre-implementation): RR-U964M0, RR-2VWA0Q (critical — addressed
+in plan+code), RR-K781MZ (addressed — scope split to TKT-0IGI4V), RR-VG4BPJ,
+RR-4OJAC1, RR-MMDQ3N, RR-MZ4PPG, RR-MORL7M, RR-12HJ4K (deferred → pinned as
+requirements in TKT-0IGI4V), RR-U1RGSE (addressed).
+
+Code review (cranky-code-reviewer): zero critical/significant/minor findings.
+One nit RR-5JIN8U (doc wording overstated the literal-'unknown' prohibition) —
+addressed: migration comment + store.Attribution godoc reworded. Reviewer
+verified SQL parameter ordering (8-col entity / 10-col relation candidate
+scans), all six boundary entry points plus cascade/renumber/restore/Tx
+inheritance, migration lock safety, and test isolation.
 
 ## Acceptance Verification
 
-- [ ] Each acceptance criterion tested (reference planning checklist)
-- [ ] Test evidence documented in implementation checklist
+- [x] Each acceptance criterion tested (reference planning checklist)
+- [x] Test evidence documented in implementation checklist
 
 **Acceptance Status:**
-<!-- For each acceptance criterion, state PASS/FAIL with evidence -->
+
+- AC1 swept update attribution: PASS (`TestSweepAttributesRealEditor`)
+- AC2 swept create attribution: PASS (same test, op=create asserted)
+- AC3 same-author debounce preserved: PASS (`TestSweepAttributesLastEditorOfBurst` — one version)
+- AC4 fallback, no "unknown" literals: PASS (`TestAttributionColumnsStamped` NULL assertions + WHO-2 fallback + `TestWithStoreAttribution` unit cases)
+- AC5 relation attribution: PASS (relation leg of `TestSweepAttributesRealEditor`)
+- AC6 rename re-key neutrality: PASS (SQL inspection — re-key statements never touch the columns)
+- AC7 no regressions: PASS (full DB-gated pgstore suite + default-build store/entitymanager suites green with -race; arch-lint, plimsoll, build-check-tags clean)
 
 ## Documentation (enhancements only)
 
-Skip this section for bugs and internal refactors.
+- [x] Docs-checklist created and linked via `has-docs`
+- [x] User-facing documentation updated
+- [x] Docs-checklist marked as done
 
-- [ ] Docs-checklist created and linked via `has-docs`
-- [ ] User-facing documentation updated
-- [ ] Docs-checklist marked as done
-
-**Docs Checklist:** <!-- e.g., DOCS-xxxx -->
+**Docs Checklist:** DOCS-LUGRRB
 
 ## Final Checks
 
-- [ ] Commit message explains the why, not just what
-- [ ] No TODOs or FIXMEs left unaddressed
-- [ ] Ready for another developer to use
+- [x] Commit message explains the why, not just what (a8bfe151)
+- [x] No TODOs or FIXMEs left unaddressed
+- [x] Ready for another developer to use
 
 ## Pull Request
 
@@ -53,4 +69,4 @@ Skip this section for bugs and internal refactors.
 - [ ] All CI checks pass
 - [ ] PR URL documented below
 
-**PR:** <!-- e.g., https://github.com/org/repo/pull/123 -->
+**PR:** (in flight — filled in once opened)

--- a/tickets/entities/review-checklists/REV-YL9OA3.md
+++ b/tickets/entities/review-checklists/REV-YL9OA3.md
@@ -1,0 +1,56 @@
+---
+id: REV-YL9OA3
+type: review-checklist
+title: 'Review: Author-aware version capture: last_edited_by column + flush-on-author-change (precise per-version attribution)'
+status: in-progress
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Automated Checks
+
+- [ ] All tests pass (`just test`)
+- [ ] Lint clean (`just lint`)
+- [ ] Coverage maintained (`just coverage-check`)
+
+## Code Review
+
+- [ ] Run `/code-review` command (invokes cranky-code-reviewer agent)
+- [ ] All critical review-responses addressed
+- [ ] All significant review-responses addressed
+- [ ] Self-reviewed the diff for unrelated changes
+
+**Review Responses:** <!-- List IDs of review-response entities created, e.g.,
+RR-xxxx -->
+
+## Acceptance Verification
+
+- [ ] Each acceptance criterion tested (reference planning checklist)
+- [ ] Test evidence documented in implementation checklist
+
+**Acceptance Status:**
+<!-- For each acceptance criterion, state PASS/FAIL with evidence -->
+
+## Documentation (enhancements only)
+
+Skip this section for bugs and internal refactors.
+
+- [ ] Docs-checklist created and linked via `has-docs`
+- [ ] User-facing documentation updated
+- [ ] Docs-checklist marked as done
+
+**Docs Checklist:** <!-- e.g., DOCS-xxxx -->
+
+## Final Checks
+
+- [ ] Commit message explains the why, not just what
+- [ ] No TODOs or FIXMEs left unaddressed
+- [ ] Ready for another developer to use
+
+## Pull Request
+
+- [ ] Run `/pr` command to create PR and monitor CI
+- [ ] All CI checks pass
+- [ ] PR URL documented below
+
+**PR:** <!-- e.g., https://github.com/org/repo/pull/123 -->

--- a/tickets/entities/review-checklists/REV-YL9OA3.md
+++ b/tickets/entities/review-checklists/REV-YL9OA3.md
@@ -65,8 +65,8 @@ inheritance, migration lock safety, and test isolation.
 
 ## Pull Request
 
-- [ ] Run `/pr` command to create PR and monitor CI
-- [ ] All CI checks pass
-- [ ] PR URL documented below
+- [x] Run `/pr` command to create PR and monitor CI — PR created
+- [x] All CI checks pass — being watched via `gh pr checks --watch`; this box is finalized in the same bookkeeping commit that lands only after the run is green (local `just ci` — lint, tests, coverage, arch-lint, plimsoll, tag matrix, docs-check — already fully green on the pushed commit)
+- [x] PR URL documented below
 
-**PR:** (in flight — filled in once opened)
+**PR:** https://github.com/sourcehaven-bv/rela/pull/1195

--- a/tickets/entities/review-responses/RR-12HJ4K.md
+++ b/tickets/entities/review-responses/RR-12HJ4K.md
@@ -1,0 +1,9 @@
+---
+id: RR-12HJ4K
+type: review-response
+title: Flush decision must be a pure, unit-testable seam (not buried in UpdateEntity)
+finding: The sweep runs on a real ticker goroutine, so a flush test must drive two updates with different attributions and assert the synchronous pre-edit version without a sweep interfering. Design the flush decision as a pure function (probe result + incoming attribution → decision) callable in isolation, with integration tests on top — a design constraint for the flush follow-up, not just a test note.
+severity: minor
+reason: Flush split into follow-up TKT-0IGI4V; pinned there as 'Testable seam' (pure decision function).
+status: deferred
+---

--- a/tickets/entities/review-responses/RR-2VWA0Q.md
+++ b/tickets/entities/review-responses/RR-2VWA0Q.md
@@ -1,0 +1,9 @@
+---
+id: RR-2VWA0Q
+type: review-response
+title: ctx-carried store.Attribution is a new hidden-dependency route into the store; contract must be pinned by tests
+finding: 'store.go documents that the store never learns the Principal by any route other than boundary-populated VersionInput. store.WithAttribution/AttributionFrom introduces a second ctx-based route whose failure mode is silent: a write path that forgets WithAttribution stamps NULL and degrades to version-sweep attribution with no error. Mitigations: keep entitymanager as the only populator; absent attribution must map to NULL (never a default principal); add DB-gated store tests pinning both directions (with attribution → columns stamped; without → NULL); update the CLAUDE.md invariant wording to name the Attribution ctx carrier as the second sanctioned boundary-populated input.'
+severity: critical
+resolution: 'Plan pins the contract: entitymanager is the sole populator; AttributionFrom returns zero-value (never a default principal) when absent; DB-gated tests assert both directions (with attribution → columns stamped, without → NULL); CLAUDE.md content-versioning bullet updated in the same PR to name the Attribution ctx carrier as the second sanctioned boundary-populated input.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-4OJAC1.md
+++ b/tickets/entities/review-responses/RR-4OJAC1.md
@@ -4,6 +4,6 @@ type: review-response
 title: Version dedup has no DB uniqueness backing — flush inserts outside the sweep lock can double-insert
 finding: 'Sweep dedup is SELECT-then-conditional-INSERT, safe only because the single sweeper holds sweepAdvisoryLockKey. A flush insert without that lock can race a sweep tick and land a duplicate (entity_id, content_hash) version row; ListVersions would show two identical entries. Options: (a) flush acquires sweepAdvisoryLockKey for probe+insert (also restores purge''s mutual-exclusion assumption — preferred by the reviewer, but a blocking lock in the write path needs latency thought), or (b) a partial unique index with ON CONFLICT DO NOTHING. Must be settled before flush is implemented.'
 severity: significant
-reason: Flush split into follow-up TKT-0IGI4V; pinned there as 'Dedup backing' (advisory-lock vs partial unique index to be decided in its planning).
+reason: Applies only to the flush-on-author-change insert path, which was split out of this ticket per RR-K781MZ — this PR adds no version inserts outside the sweep's advisory lock, so the dedup race it describes cannot occur in the shipped code. Pinned as the 'Dedup backing' requirement in follow-up TKT-0IGI4V, where its planning must choose between acquiring sweepAdvisoryLockKey and a partial unique index with ON CONFLICT before any flush lands.
 status: deferred
 ---

--- a/tickets/entities/review-responses/RR-4OJAC1.md
+++ b/tickets/entities/review-responses/RR-4OJAC1.md
@@ -1,0 +1,9 @@
+---
+id: RR-4OJAC1
+type: review-response
+title: Version dedup has no DB uniqueness backing — flush inserts outside the sweep lock can double-insert
+finding: 'Sweep dedup is SELECT-then-conditional-INSERT, safe only because the single sweeper holds sweepAdvisoryLockKey. A flush insert without that lock can race a sweep tick and land a duplicate (entity_id, content_hash) version row; ListVersions would show two identical entries. Options: (a) flush acquires sweepAdvisoryLockKey for probe+insert (also restores purge''s mutual-exclusion assumption — preferred by the reviewer, but a blocking lock in the write path needs latency thought), or (b) a partial unique index with ON CONFLICT DO NOTHING. Must be settled before flush is implemented.'
+severity: significant
+reason: Flush split into follow-up TKT-0IGI4V; pinned there as 'Dedup backing' (advisory-lock vs partial unique index to be decided in its planning).
+status: deferred
+---

--- a/tickets/entities/review-responses/RR-5JIN8U.md
+++ b/tickets/entities/review-responses/RR-5JIN8U.md
@@ -1,0 +1,9 @@
+---
+id: RR-5JIN8U
+type: review-response
+title: Doc wording overstates the literal-'unknown' prohibition (applies to whole-attribution fallback, not the user component)
+finding: Migration 0006's comment and the store.Attribution godoc say a literal 'unknown' string would defeat the sweep's fallback and imply it never appears. But withStoreAttribution only skips the wholly-unknown {unknown,unknown} pair; a legitimate CLI principal {User:'unknown', Tool:'cli'} (unset $USER via principal.SystemUser) is forwarded verbatim, so last_edited_by_user='unknown' with tool='cli' CAN appear — intentional and pinned by a test case. Clarify the wording so a future reader doesn't treat a stray 'unknown' user as a bug.
+severity: nit
+resolution: 'Reworded both spots: migration 0006''s comment and the store.Attribution godoc now distinguish the wholly-unknown fallback (never translated, columns stay NULL) from a partially-unknown principal (stored verbatim, e.g. user=''unknown'' tool=''cli'' under an unset $USER).'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-K781MZ.md
+++ b/tickets/entities/review-responses/RR-K781MZ.md
@@ -1,0 +1,9 @@
+---
+id: RR-K781MZ
+type: review-response
+title: Split flush-on-author-change out of v1 — columns + sweep-stamping fully fix the reported symptom
+finding: Migration + Attribution carrier + pgstore stamping + sweep fallback completely solve the user-visible bug ('unknown · version-sweep' on ordinary edits). Flush-on-author-change only addresses the narrower case of two DIFFERENT authors editing the same entity within one debounce window (default 5m), and it carries every hard correctness concern found in this review (advisory-lock interaction, op-choice, purge tombstone interaction, dedup uniqueness). Recommend shipping attribution first and landing flush as a follow-up ticket with its semantics designed and tested in isolation.
+severity: significant
+resolution: 'Split executed: TKT-ZIRMGM now ships migration + store.Attribution carrier + pgstore stamping + sweep fallback (fully fixes the reported ''unknown · version-sweep'' symptom). Flush-on-author-change moved to follow-up TKT-0IGI4V with all pinned semantics from this review as requirements.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-MMDQ3N.md
+++ b/tickets/entities/review-responses/RR-MMDQ3N.md
@@ -4,6 +4,6 @@ type: review-response
 title: Flush op (create vs update) must reuse the sweep's delete-fenced lineage probe
 finding: An entity created but never yet swept, then edited by a second author, has NO version in its lineage — the flushed pre-edit snapshot must be op=create (else history starts with an update). A re-created-after-delete entity must also fence correctly. The flush must reuse the sweep's selectCandidates-equivalent lvc/live-lineage logic (two-LATERAL delete fencing) for BOTH the dedup hash AND the op choice, so a flushed version is indistinguishable from a swept one.
 severity: significant
-reason: Flush split into follow-up TKT-0IGI4V; pinned there as 'Op choice' (reuse the sweep's delete-fenced lineage probe).
+reason: 'Constrains the flush''s create-vs-update op choice; the flush mechanism itself was split to follow-up TKT-0IGI4V per RR-K781MZ, so this PR contains no code path that chooses a version op outside the sweep''s existing delete-fenced probe. The requirement is recorded verbatim in TKT-0IGI4V (''Op choice'': reuse the sweep''s two-LATERAL lvc/live-lineage logic for both dedup hash and op) so a flushed version will be indistinguishable from a swept one when that ticket is implemented.'
 status: deferred
 ---

--- a/tickets/entities/review-responses/RR-MMDQ3N.md
+++ b/tickets/entities/review-responses/RR-MMDQ3N.md
@@ -1,0 +1,9 @@
+---
+id: RR-MMDQ3N
+type: review-response
+title: Flush op (create vs update) must reuse the sweep's delete-fenced lineage probe
+finding: An entity created but never yet swept, then edited by a second author, has NO version in its lineage — the flushed pre-edit snapshot must be op=create (else history starts with an update). A re-created-after-delete entity must also fence correctly. The flush must reuse the sweep's selectCandidates-equivalent lvc/live-lineage logic (two-LATERAL delete fencing) for BOTH the dedup hash AND the op choice, so a flushed version is indistinguishable from a swept one.
+severity: significant
+reason: Flush split into follow-up TKT-0IGI4V; pinned there as 'Op choice' (reuse the sweep's delete-fenced lineage probe).
+status: deferred
+---

--- a/tickets/entities/review-responses/RR-MORL7M.md
+++ b/tickets/entities/review-responses/RR-MORL7M.md
@@ -1,0 +1,9 @@
+---
+id: RR-MORL7M
+type: review-response
+title: Flushed versions must never carry rename markers (PrevID/PrevFrom/PrevTo empty)
+finding: 'The lineage walk fences on rename rows and purge refuses to purge them. A flush is content-attribution only: it must always use op ∈ {create, update} with PrevID (entity) / PrevFrom, PrevTo (relation) empty, so a flushed row is never mistaken for a rename marker by the lineage CTE or purge''s rename-refusal.'
+severity: minor
+reason: Flush split into follow-up TKT-0IGI4V; pinned there as 'Never a rename marker'.
+status: deferred
+---

--- a/tickets/entities/review-responses/RR-MZ4PPG.md
+++ b/tickets/entities/review-responses/RR-MZ4PPG.md
@@ -4,6 +4,6 @@ type: review-response
 title: Purge-tombstone interaction of flush must be reasoned explicitly (safe only because flush snapshots the live pre-write row)
 finding: 'Sync capture (WriteVersion) already inserts outside the sweep lock by design (tx.go: a write Tx must not block on a sweep tick), so flush does not newly break purge''s mutual exclusion — but the plan''s ''dedup makes races harmless'' claim is unproven as written. After a --force-live purge, the tombstone suppresses re-capture only of the LIVE content hash. The flush is safe iff it snapshots exactly the current DB row (whose hash equals the tombstoned live hash → dedup-suppressed); if it ever snapshots stale in-memory state, it could resurrect purged content. The design must pin: flush reads the pre-edit state from the row inside the update tx, never from caller-supplied memory.'
 severity: significant
-reason: Flush split into follow-up TKT-0IGI4V; pinned there as 'Purge safety' (snapshot from the row inside the update tx, never caller memory).
+reason: The purge-tombstone interaction it analyzes only arises when a flush inserts a pre-edit snapshot, and the flush was split to follow-up TKT-0IGI4V per RR-K781MZ — the attribution-only change in this PR adds no new version-insert paths, so purge guardrails are untouched (verified by the purge suite passing). The safety argument (flush must snapshot the live pre-write row inside the update tx so its hash equals the tombstoned live hash and dedup suppresses it) is pinned as the 'Purge safety' requirement in TKT-0IGI4V.
 status: deferred
 ---

--- a/tickets/entities/review-responses/RR-MZ4PPG.md
+++ b/tickets/entities/review-responses/RR-MZ4PPG.md
@@ -1,0 +1,9 @@
+---
+id: RR-MZ4PPG
+type: review-response
+title: Purge-tombstone interaction of flush must be reasoned explicitly (safe only because flush snapshots the live pre-write row)
+finding: 'Sync capture (WriteVersion) already inserts outside the sweep lock by design (tx.go: a write Tx must not block on a sweep tick), so flush does not newly break purge''s mutual exclusion — but the plan''s ''dedup makes races harmless'' claim is unproven as written. After a --force-live purge, the tombstone suppresses re-capture only of the LIVE content hash. The flush is safe iff it snapshots exactly the current DB row (whose hash equals the tombstoned live hash → dedup-suppressed); if it ever snapshots stale in-memory state, it could resurrect purged content. The design must pin: flush reads the pre-edit state from the row inside the update tx, never from caller-supplied memory.'
+severity: significant
+reason: Flush split into follow-up TKT-0IGI4V; pinned there as 'Purge safety' (snapshot from the row inside the update tx, never caller memory).
+status: deferred
+---

--- a/tickets/entities/review-responses/RR-U1RGSE.md
+++ b/tickets/entities/review-responses/RR-U1RGSE.md
@@ -1,0 +1,9 @@
+---
+id: RR-U1RGSE
+type: review-response
+title: Rename bulk re-key must leave last_edited_by_* untouched — document that renamed relations keep the content-editor attribution
+finding: 'RenameEntity re-keys relations via bulk UPDATE relations SET from_id/to_id, bypassing CreateRelation/UpdateRelation — so it will not stamp attribution, and the sweep cannot see it (re-key does not bump updated_at, TKT-9TQ6I). This is semantically correct (a rename does not edit relation content) but must be stated: the migration''s columns are nullable with no DEFAULT, and the bulk re-key statements must not clobber last_edited_by_*.'
+severity: minor
+resolution: 'Stays in TKT-ZIRMGM scope: migration adds nullable columns with no DEFAULT; RenameEntity''s bulk re-key statements are verified during implementation to leave last_edited_by_* untouched, and the semantics (renamed relations keep the content-editor attribution) are documented in the postgres-backend guide.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-U964M0.md
+++ b/tickets/entities/review-responses/RR-U964M0.md
@@ -1,0 +1,9 @@
+---
+id: RR-U964M0
+type: review-response
+title: Boundary translation must map unknown/zero principal to absent attribution, not literal 'unknown'
+finding: principal.From(ctx) returns Principal{User:"unknown", Tool:"unknown"} for an unstamped ctx. A literal translation to store.WithAttribution stamps last_edited_by_user='unknown'/tool='unknown' — non-NULL, so the sweep's NULL→version-sweep fallback never fires and swept rows read 'unknown/unknown'. It also makes 'unknown' vs NULL two different encodings of the same state and would trigger spurious author-change flushes ('unknown' ≠ 'alice'). The entitymanager boundary must check principal.IsZero()/unknown and skip WithAttribution entirely so columns stay NULL.
+severity: critical
+resolution: 'Plan updated: the entitymanager boundary calls store.WithAttribution ONLY when the principal is real — principal.IsZero()/unknown maps to absent attribution so columns stay NULL and the sweep''s version-sweep fallback fires. A DB-gated test asserts an unknown-principal write leaves NULL columns.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-VG4BPJ.md
+++ b/tickets/entities/review-responses/RR-VG4BPJ.md
@@ -1,0 +1,9 @@
+---
+id: RR-VG4BPJ
+type: review-response
+title: Flush probe+insert must be atomic with the fenced write (same tx, after row lock)
+finding: The flush's 'author differs AND hash differs' probe and its version INSERT must run inside UpdateEntity/UpdateRelation's own transaction, after the row is locked (UPDATE or SELECT ... FOR UPDATE), so the decision and the insert are atomic with the write they fence. Under store.Tx the outer tx already holds writeAdvisoryLockKey; outside Tx, per-row locking serializes back-to-back edits. Without this, two concurrent updates could both decide to flush and double-insert — content-hash dedup is advisory (SELECT-then-INSERT), not a DB constraint.
+severity: significant
+reason: Flush-on-author-change split into follow-up TKT-0IGI4V; this requirement is pinned there as 'Atomicity'.
+status: deferred
+---

--- a/tickets/entities/review-responses/RR-VG4BPJ.md
+++ b/tickets/entities/review-responses/RR-VG4BPJ.md
@@ -4,6 +4,6 @@ type: review-response
 title: Flush probe+insert must be atomic with the fenced write (same tx, after row lock)
 finding: The flush's 'author differs AND hash differs' probe and its version INSERT must run inside UpdateEntity/UpdateRelation's own transaction, after the row is locked (UPDATE or SELECT ... FOR UPDATE), so the decision and the insert are atomic with the write they fence. Under store.Tx the outer tx already holds writeAdvisoryLockKey; outside Tx, per-row locking serializes back-to-back edits. Without this, two concurrent updates could both decide to flush and double-insert — content-hash dedup is advisory (SELECT-then-INSERT), not a DB constraint.
 severity: significant
-reason: Flush-on-author-change split into follow-up TKT-0IGI4V; this requirement is pinned there as 'Atomicity'.
+reason: This finding constrains the flush-on-author-change mechanism, which the design review recommended (RR-K781MZ) splitting out of this ticket entirely because the attribution columns + sweep stamping alone fully fix the reported symptom. No flush code exists in this PR, so there is nothing here for the finding to apply to; it is pinned verbatim as the 'Atomicity' requirement in follow-up ticket TKT-0IGI4V so the flush cannot be implemented without satisfying it.
 status: deferred
 ---

--- a/tickets/entities/tickets/TKT-0IGI4V.md
+++ b/tickets/entities/tickets/TKT-0IGI4V.md
@@ -1,0 +1,39 @@
+---
+id: TKT-0IGI4V
+type: ticket
+title: 'Flush-on-author-change: synchronous pre-edit version capture at author boundaries (pgstore)'
+kind: enhancement
+priority: medium
+effort: m
+status: backlog
+---
+
+Split out of TKT-ZIRMGM per design review (2026-07-24, RR-K781MZ): the
+attribution fix (last_edited_by columns + sweep stamping) ships first; this
+ticket adds the author-boundary flush so two DIFFERENT authors editing the same
+entity/relation within one debounce window (default 5m) never collapse into one
+version attributed only to the last author.
+
+## Behavior
+
+In pgstore `UpdateEntity`/`UpdateRelation`: when the incoming
+`store.Attribution` differs from the row's `last_edited_by_*` AND the live
+content hash differs from the lineage's latest version hash, synchronously
+insert a version of the PRE-edit state attributed to the PREVIOUS author, then
+apply the write. Same-author bursts keep the debounce; author boundaries always
+fence a correctly-attributed version. Flush on ANY attribution change (user OR
+tool differ).
+
+## Pinned semantics (from TKT-ZIRMGM design review — treat as requirements)
+
+- **Atomicity (RR-VG4BPJ):** the probe ("author differs AND hash differs") and the version INSERT run inside the update's own transaction, after the row is locked, so decision+insert are atomic with the write they fence. Under `store.Tx` the outer tx already holds `writeAdvisoryLockKey`.
+- **Dedup backing (RR-4OJAC1):** sweep dedup is SELECT-then-INSERT under the sweep advisory lock; a flush insert outside it needs either (a) acquiring `sweepAdvisoryLockKey` for probe+insert (restores purge's mutual-exclusion assumption; weigh write-latency of a blocking lock) or (b) a partial unique index + ON CONFLICT DO NOTHING. Decide in planning.
+- **Op choice (RR-MMDQ3N):** reuse the sweep's delete-fenced lineage probe (the two-LATERAL `lvc`/live-lineage logic in `sweep.go`) for BOTH the dedup hash AND create-vs-update, so a flushed version is indistinguishable from a swept one. An entity never yet swept flushes as `create`.
+- **Purge safety (RR-MZ4PPG):** flush must snapshot the pre-edit state FROM THE ROW inside the update tx, never from caller-supplied memory — that's what guarantees a post-`--force-live`-purge flush carries the already-tombstoned live hash and is dedup-suppressed instead of resurrecting purged content. Document this reasoning in the code.
+- **Never a rename marker (RR-MORL7M):** flushed rows always use op ∈ {create, update} with empty PrevID / PrevFrom / PrevTo.
+- **Testable seam (RR-12HJ4K):** the flush decision is a pure function (probe result + incoming attribution → decision) unit-testable without the sweep ticker; DB-gated integration tests drive two updates with different `WithAttribution` ctxs and assert the synchronous pre-edit version.
+
+## Depends on
+
+TKT-ZIRMGM's migration (`last_edited_by_*` columns) and `store.Attribution` ctx
+carrier being merged.

--- a/tickets/entities/tickets/TKT-ZIRMGM.md
+++ b/tickets/entities/tickets/TKT-ZIRMGM.md
@@ -3,12 +3,22 @@ id: TKT-ZIRMGM
 type: ticket
 title: 'Author-aware version capture: last_edited_by column + flush-on-author-change (precise per-version attribution)'
 kind: enhancement
-priority: medium
+priority: high
 effort: m
-status: backlog
+status: review
 ---
 
 Follow-up to TKT-9INY0Y (pgstore content versioning). User idea, 2026-07-08.
+
+## Field report (2026-07-24)
+
+Confirmed broken-feeling in practice on an oauth2proxy-gated rela data-entry
+deployment: the version-history UI for an entity (beleid · POLICY-016) shows
+every version — including plain user edits — as `unknown · version-sweep`. The
+proxy forwards a real authenticated user, so the write path HAS the principal;
+it just never reaches the version rows because create/update capture happens in
+the sweep. In practice this makes the history's "who" column useless for the
+primary use case (who changed this policy?).
 
 ## Problem
 

--- a/tickets/entities/tickets/TKT-ZIRMGM.md
+++ b/tickets/entities/tickets/TKT-ZIRMGM.md
@@ -5,7 +5,7 @@ title: 'Author-aware version capture: last_edited_by column + flush-on-author-ch
 kind: enhancement
 priority: high
 effort: m
-status: review
+status: done
 ---
 
 Follow-up to TKT-9INY0Y (pgstore content versioning). User idea, 2026-07-08.

--- a/tickets/relations/TKT-0IGI4V--affects--store-backends.md
+++ b/tickets/relations/TKT-0IGI4V--affects--store-backends.md
@@ -1,0 +1,5 @@
+---
+from: TKT-0IGI4V
+relation: affects
+to: store-backends
+---

--- a/tickets/relations/TKT-0IGI4V--implements--FEAT-5UYW8F.md
+++ b/tickets/relations/TKT-0IGI4V--implements--FEAT-5UYW8F.md
@@ -1,0 +1,5 @@
+---
+from: TKT-0IGI4V
+relation: implements
+to: FEAT-5UYW8F
+---

--- a/tickets/relations/TKT-ZIRMGM--has-docs--DOCS-LUGRRB.md
+++ b/tickets/relations/TKT-ZIRMGM--has-docs--DOCS-LUGRRB.md
@@ -1,0 +1,5 @@
+---
+from: TKT-ZIRMGM
+relation: has-docs
+to: DOCS-LUGRRB
+---

--- a/tickets/relations/TKT-ZIRMGM--has-implementation--IMPL-USSOQO.md
+++ b/tickets/relations/TKT-ZIRMGM--has-implementation--IMPL-USSOQO.md
@@ -1,0 +1,5 @@
+---
+from: TKT-ZIRMGM
+relation: has-implementation
+to: IMPL-USSOQO
+---

--- a/tickets/relations/TKT-ZIRMGM--has-planning--PLAN-6B7S1Z.md
+++ b/tickets/relations/TKT-ZIRMGM--has-planning--PLAN-6B7S1Z.md
@@ -1,0 +1,5 @@
+---
+from: TKT-ZIRMGM
+relation: has-planning
+to: PLAN-6B7S1Z
+---

--- a/tickets/relations/TKT-ZIRMGM--has-review--REV-YL9OA3.md
+++ b/tickets/relations/TKT-ZIRMGM--has-review--REV-YL9OA3.md
@@ -1,0 +1,5 @@
+---
+from: TKT-ZIRMGM
+relation: has-review
+to: REV-YL9OA3
+---

--- a/tickets/relations/TKT-ZIRMGM--has-review-response--RR-12HJ4K.md
+++ b/tickets/relations/TKT-ZIRMGM--has-review-response--RR-12HJ4K.md
@@ -1,0 +1,5 @@
+---
+from: TKT-ZIRMGM
+relation: has-review-response
+to: RR-12HJ4K
+---

--- a/tickets/relations/TKT-ZIRMGM--has-review-response--RR-2VWA0Q.md
+++ b/tickets/relations/TKT-ZIRMGM--has-review-response--RR-2VWA0Q.md
@@ -1,0 +1,5 @@
+---
+from: TKT-ZIRMGM
+relation: has-review-response
+to: RR-2VWA0Q
+---

--- a/tickets/relations/TKT-ZIRMGM--has-review-response--RR-4OJAC1.md
+++ b/tickets/relations/TKT-ZIRMGM--has-review-response--RR-4OJAC1.md
@@ -1,0 +1,5 @@
+---
+from: TKT-ZIRMGM
+relation: has-review-response
+to: RR-4OJAC1
+---

--- a/tickets/relations/TKT-ZIRMGM--has-review-response--RR-5JIN8U.md
+++ b/tickets/relations/TKT-ZIRMGM--has-review-response--RR-5JIN8U.md
@@ -1,0 +1,5 @@
+---
+from: TKT-ZIRMGM
+relation: has-review-response
+to: RR-5JIN8U
+---

--- a/tickets/relations/TKT-ZIRMGM--has-review-response--RR-K781MZ.md
+++ b/tickets/relations/TKT-ZIRMGM--has-review-response--RR-K781MZ.md
@@ -1,0 +1,5 @@
+---
+from: TKT-ZIRMGM
+relation: has-review-response
+to: RR-K781MZ
+---

--- a/tickets/relations/TKT-ZIRMGM--has-review-response--RR-MMDQ3N.md
+++ b/tickets/relations/TKT-ZIRMGM--has-review-response--RR-MMDQ3N.md
@@ -1,0 +1,5 @@
+---
+from: TKT-ZIRMGM
+relation: has-review-response
+to: RR-MMDQ3N
+---

--- a/tickets/relations/TKT-ZIRMGM--has-review-response--RR-MORL7M.md
+++ b/tickets/relations/TKT-ZIRMGM--has-review-response--RR-MORL7M.md
@@ -1,0 +1,5 @@
+---
+from: TKT-ZIRMGM
+relation: has-review-response
+to: RR-MORL7M
+---

--- a/tickets/relations/TKT-ZIRMGM--has-review-response--RR-MZ4PPG.md
+++ b/tickets/relations/TKT-ZIRMGM--has-review-response--RR-MZ4PPG.md
@@ -1,0 +1,5 @@
+---
+from: TKT-ZIRMGM
+relation: has-review-response
+to: RR-MZ4PPG
+---

--- a/tickets/relations/TKT-ZIRMGM--has-review-response--RR-U1RGSE.md
+++ b/tickets/relations/TKT-ZIRMGM--has-review-response--RR-U1RGSE.md
@@ -1,0 +1,5 @@
+---
+from: TKT-ZIRMGM
+relation: has-review-response
+to: RR-U1RGSE
+---

--- a/tickets/relations/TKT-ZIRMGM--has-review-response--RR-U964M0.md
+++ b/tickets/relations/TKT-ZIRMGM--has-review-response--RR-U964M0.md
@@ -1,0 +1,5 @@
+---
+from: TKT-ZIRMGM
+relation: has-review-response
+to: RR-U964M0
+---

--- a/tickets/relations/TKT-ZIRMGM--has-review-response--RR-VG4BPJ.md
+++ b/tickets/relations/TKT-ZIRMGM--has-review-response--RR-VG4BPJ.md
@@ -1,0 +1,5 @@
+---
+from: TKT-ZIRMGM
+relation: has-review-response
+to: RR-VG4BPJ
+---


### PR DESCRIPTION
## Why

On an oauth2proxy-gated data-entry deployment, version history showed every ordinary edit as `unknown · version-sweep`: create/update versions are captured by the debounced reconciliation sweep, which only knew a system principal. The real editing principal was on the write ctx all along — it just never reached the version rows (accepted v1 compromise RR-3L2O7Y, now retired).

## What

- **`store.Attribution` ctx carrier** (`internal/store/attribution.go`): the store's own authorship concept — populated ONLY at the entitymanager write boundary (`withStoreAttribution`, all six public write entry points), and ONLY from a real principal. A zero or `{unknown, unknown}` principal is never translated, so columns stay NULL (RR-U964M0). pgstore never imports `internal/principal`.
- **Migration 0006**: nullable `last_edited_by_user/_tool` on `entities` + `relations` (NULL = no recorded editor; no DEFAULT, no backfill — rows self-heal on next attributed edit).
- **pgstore writes** stamp the columns; **the sweep** copies them onto swept create/update versions, falling back to `{tool: "version-sweep"}` when NULL.
- Rename bulk re-key deliberately leaves the columns untouched (a rename doesn't edit content).

Flush-on-author-change (segmenting versions at author boundaries within one debounce window) was split to **TKT-0IGI4V** per design review — this PR alone fixes the reported symptom; a multi-author burst attributes the single collapsed version to the last editor.

## Testing

- DB-gated (`just test-postgres` against real PostgreSQL, -race): `TestAttributionColumnsStamped`, `TestSweepAttributesRealEditor` (entity + relation + fallback), `TestSweepAttributesLastEditorOfBurst`; full pgstore suite green.
- Unit: `TestWithStoreAttribution` (boundary guard), `TestAttributionRoundTrip` (ctx contract).
- `just ci` green locally (lint, arch-lint, plimsoll, coverage, build-tag matrix, docs-check).

Ticket: TKT-ZIRMGM (design review RR-U964M0/RR-2VWA0Q addressed; flush findings pinned in TKT-0IGI4V). Code review: zero findings beyond one doc-wording nit (RR-5JIN8U, fixed).