### PR TITLE
feat(acl): fixed scheduler identity + migrate a read grant into an existing acl.yaml (TKT-76JP2A)

### DIFF
--- a/docs-project/entities/guides/GUIDE-scheduled-tasks.md
+++ b/docs-project/entities/guides/GUIDE-scheduled-tasks.md
@@ -77,8 +77,9 @@ tasks:
 ### Identity and what a task can read (`run_as`)
 
 A scheduled task runs under an **identity**, and that identity decides what
-its script may read. By default every task runs as the scheduler's system
-user. `run_as` gives a task its own identity instead:
+its script may read. By default every task runs as `system:scheduler`, a
+fixed identity that does not depend on which OS account started the
+scheduler. `run_as` gives a task its own identity instead:
 
 ```yaml
 tasks:
@@ -105,6 +106,34 @@ With that pairing, `rela.get_entity` / `list_entities` / `search` /
 the `reporting` role may see. Anything else is invisible to the script —
 which is what bounds the data an AI-assisted or outbound-reporting job can
 possibly include.
+
+#### If your project has an `acl.yaml`, grant the scheduler
+
+The default identity is subject to the same rule as any other: it reads
+only what a role grants it. A project that has an `acl.yaml` but never
+assigns `system:scheduler` a role has tasks that read **nothing** — and
+because a gated read is indistinguishable from missing data, they fail
+silently rather than erroring.
+
+`rela migrate` adds the grant for you:
+
+```yaml
+# acl.yaml
+roles:
+  scheduler-system:
+    read: ["*"]
+assignments:
+  system:scheduler: scheduler-system
+```
+
+Narrow `read:` to the types your jobs actually need, or give each job its
+own `run_as` identity with a tighter role — the migration writes a
+permissive default so existing jobs keep working, not because wide access
+is recommended.
+
+Projects with **no** `acl.yaml` need do nothing: with no policy there is no
+access control, and scheduled tasks read the whole graph as they always
+have.
 
 Notes:
 
@@ -389,5 +418,10 @@ the audit log for scheduler-driven changes:
 ```bash
 cat .rela/audit/*.jsonl | jq 'select(.triggered_by == "schedule:traceability-report")'
 ```
+
+`principal.user` is the task's identity: `system:scheduler` by default, or
+its `run_as` value. Earlier versions recorded the OS account that started
+the scheduler, so records written before the upgrade carry that instead —
+worth knowing when reading back across the change.
 
 See [audit-log.md](audit-log.md) for the full record schema.

--- a/docs/scheduled-tasks.md
+++ b/docs/scheduled-tasks.md
@@ -71,8 +71,9 @@ tasks:
 ### Identity and what a task can read (`run_as`)
 
 A scheduled task runs under an **identity**, and that identity decides what
-its script may read. By default every task runs as the scheduler's system
-user. `run_as` gives a task its own identity instead:
+its script may read. By default every task runs as `system:scheduler`, a
+fixed identity that does not depend on which OS account started the
+scheduler. `run_as` gives a task its own identity instead:
 
 ```yaml
 tasks:
@@ -99,6 +100,34 @@ With that pairing, `rela.get_entity` / `list_entities` / `search` /
 the `reporting` role may see. Anything else is invisible to the script —
 which is what bounds the data an AI-assisted or outbound-reporting job can
 possibly include.
+
+#### If your project has an `acl.yaml`, grant the scheduler
+
+The default identity is subject to the same rule as any other: it reads
+only what a role grants it. A project that has an `acl.yaml` but never
+assigns `system:scheduler` a role has tasks that read **nothing** — and
+because a gated read is indistinguishable from missing data, they fail
+silently rather than erroring.
+
+`rela migrate` adds the grant for you:
+
+```yaml
+# acl.yaml
+roles:
+  scheduler-system:
+    read: ["*"]
+assignments:
+  system:scheduler: scheduler-system
+```
+
+Narrow `read:` to the types your jobs actually need, or give each job its
+own `run_as` identity with a tighter role — the migration writes a
+permissive default so existing jobs keep working, not because wide access
+is recommended.
+
+Projects with **no** `acl.yaml` need do nothing: with no policy there is no
+access control, and scheduled tasks read the whole graph as they always
+have.
 
 Notes:
 
@@ -383,5 +412,10 @@ the audit log for scheduler-driven changes:
 ```bash
 cat .rela/audit/*.jsonl | jq 'select(.triggered_by == "schedule:traceability-report")'
 ```
+
+`principal.user` is the task's identity: `system:scheduler` by default, or
+its `run_as` value. Earlier versions recorded the OS account that started
+the scheduler, so records written before the upgrade carry that instead —
+worth knowing when reading back across the change.
 
 See [audit-log.md](audit-log.md) for the full record schema.

--- a/internal/migration/acl_scheduler_grant.go
+++ b/internal/migration/acl_scheduler_grant.go
@@ -1,0 +1,132 @@
+package migration
+
+import (
+	"gopkg.in/yaml.v3"
+)
+
+func init() {
+	Register(&ACLSchedulerGrantMigration{})
+}
+
+// Grant shape written into acl.yaml. The role name is deliberately
+// specific enough not to collide with an operator's own naming.
+const (
+	schedulerRoleName = "scheduler-system"
+	// schedulerPrincipal must stay in lockstep with
+	// principal.UserScheduler. It is duplicated as a literal rather than
+	// imported because internal/migration deliberately depends on nothing
+	// but yaml — see the package doc. The pairing is pinned by a test.
+	schedulerPrincipal = "system:scheduler"
+)
+
+// ACLSchedulerGrantMigration grants the scheduler's fixed system identity
+// read access in an existing acl.yaml.
+//
+// Why this exists: since scheduled Lua reads became ACL-bound (TKT-ZF2DTV,
+// DEC-O59WM4), a task's script sees only what its identity may see. A
+// project that has an acl.yaml but never assigned the scheduler a role
+// therefore has tasks that read NOTHING — silently, because a gated read
+// returns "not found" rather than an error. This migration restores them.
+//
+// It only ever edits an acl.yaml that already exists. A project without one
+// runs on NopACL, where scheduled tasks already read the full graph and have
+// nothing to repair; creating a policy there would flip every OTHER principal
+// (humans, CLI, MCP) to deny-by-default, breaking far more than it fixed
+// (RR-SVQ5HE). The migrate runner's skip-on-missing behavior gives that for
+// free.
+//
+// The grant is read-only. Writes continue through entitymanager's own ACL.
+type ACLSchedulerGrantMigration struct{}
+
+func (m *ACLSchedulerGrantMigration) Name() string {
+	return "acl-scheduler-grant"
+}
+
+func (m *ACLSchedulerGrantMigration) Description() string {
+	return "Grant the scheduler identity read access in acl.yaml " +
+		"(without it, scheduled tasks silently read nothing)"
+}
+
+func (m *ACLSchedulerGrantMigration) FileTypes() []FileType {
+	return []FileType{FileTypeACL}
+}
+
+// Detect reports whether acl.yaml lacks an assignment for the scheduler
+// principal. An operator who has already assigned it a role — of any name,
+// scoped however they like — is left alone.
+func (m *ACLSchedulerGrantMigration) Detect(doc *yaml.Node) bool {
+	root := GetDocumentRoot(doc)
+	if root == nil || root.Kind != yaml.MappingNode {
+		return false
+	}
+	assignments := GetMapValue(root, "assignments")
+	if assignments == nil || assignments.Kind != yaml.MappingNode {
+		// No assignments block at all: the scheduler is certainly unassigned.
+		return true
+	}
+	return GetMapValue(assignments, schedulerPrincipal) == nil
+}
+
+// Apply adds the scheduler role (if absent) and the assignment binding the
+// scheduler principal to it. Existing keys are never overwritten: if the
+// operator already defines a role by this name, we bind to theirs rather
+// than replacing it.
+func (m *ACLSchedulerGrantMigration) Apply(doc *yaml.Node) error {
+	root := GetDocumentRoot(doc)
+	if root == nil || root.Kind != yaml.MappingNode {
+		return nil
+	}
+
+	m.ensureRole(root)
+	m.ensureAssignment(root)
+	return nil
+}
+
+// ensureRole adds `scheduler-system: {read: ["*"]}` under `roles:` unless a
+// role of that name is already defined.
+//
+// read: ["*"] restores exactly the pre-TKT-ZF2DTV behavior, where scheduled
+// tasks read the whole graph. Narrowing it is the operator's call, and
+// `run_as` exists so a job can be given a tighter identity instead.
+func (m *ACLSchedulerGrantMigration) ensureRole(root *yaml.Node) {
+	roles := GetMapValue(root, "roles")
+	if roles == nil || roles.Kind != yaml.MappingNode {
+		roles = &yaml.Node{Kind: yaml.MappingNode}
+		// Roles are conventionally declared before assignments; when neither
+		// exists this appends, which is also fine.
+		InsertMapKeyAfter(root, "", "roles", roles)
+	}
+	if GetMapValue(roles, schedulerRoleName) != nil {
+		return // operator already defines this role — bind to theirs
+	}
+
+	wildcard := &yaml.Node{Kind: yaml.SequenceNode, Content: []*yaml.Node{
+		{Kind: yaml.ScalarNode, Value: "*", Style: yaml.DoubleQuotedStyle},
+	}}
+	roleDef := &yaml.Node{Kind: yaml.MappingNode, Content: []*yaml.Node{
+		{Kind: yaml.ScalarNode, Value: "read"},
+		wildcard,
+	}}
+	roleKey := &yaml.Node{
+		Kind:        yaml.ScalarNode,
+		Value:       schedulerRoleName,
+		HeadComment: "Added by migration: lets scheduled tasks read. Narrow or\nremove this once each job has a run_as identity of its own.",
+	}
+	roles.Content = append(roles.Content, roleKey, roleDef)
+}
+
+// ensureAssignment binds the scheduler principal to the role.
+func (m *ACLSchedulerGrantMigration) ensureAssignment(root *yaml.Node) {
+	assignments := GetMapValue(root, "assignments")
+	if assignments == nil || assignments.Kind != yaml.MappingNode {
+		assignments = &yaml.Node{Kind: yaml.MappingNode}
+		InsertMapKeyAfter(root, "roles", "assignments", assignments)
+	}
+	if GetMapValue(assignments, schedulerPrincipal) != nil {
+		return
+	}
+	assignments.Content = append(assignments.Content,
+		&yaml.Node{Kind: yaml.ScalarNode, Value: schedulerPrincipal},
+		&yaml.Node{Kind: yaml.ScalarNode, Value: schedulerRoleName},
+	)
+}

--- a/internal/migration/acl_scheduler_grant.go
+++ b/internal/migration/acl_scheduler_grant.go
@@ -1,6 +1,8 @@
 package migration
 
 import (
+	"fmt"
+
 	"gopkg.in/yaml.v3"
 )
 
@@ -12,11 +14,14 @@ func init() {
 // specific enough not to collide with an operator's own naming.
 const (
 	schedulerRoleName = "scheduler-system"
-	// schedulerPrincipal must stay in lockstep with
+	// SchedulerPrincipal must stay in lockstep with
 	// principal.UserScheduler. It is duplicated as a literal rather than
-	// imported because internal/migration deliberately depends on nothing
-	// but yaml — see the package doc. The pairing is pinned by a test.
-	schedulerPrincipal = "system:scheduler"
+	// imported because arch-lint restricts internal/migration to
+	// [storage] — importing internal/principal fails `just arch-lint`.
+	//
+	// Exported so a test can assert the equality directly, independent of
+	// whether Apply happens to work on any given input.
+	SchedulerPrincipal = "system:scheduler"
 )
 
 // ACLSchedulerGrantMigration grants the scheduler's fixed system identity
@@ -51,26 +56,35 @@ func (m *ACLSchedulerGrantMigration) FileTypes() []FileType {
 	return []FileType{FileTypeACL}
 }
 
-// Detect reports whether acl.yaml lacks an assignment for the scheduler
-// principal. An operator who has already assigned it a role — of any name,
-// scoped however they like — is left alone.
+// Detect reports whether the scheduler still lacks a usable read grant.
+//
+// The predicate is "is the scheduler granted read?", NOT merely "does an
+// assignment key exist". A bare key check would go quiet on a grant that
+// names an undefined role, or one whose role grants no read — both of
+// which leave tasks reading nothing while reporting the migration done.
+// Apply asserts this same predicate as its postcondition.
+//
+// An operator who has already granted the scheduler read — under any role
+// name, scoped however they like, via `assignments` or
+// `asserted_role_assignments` — is left alone.
 func (m *ACLSchedulerGrantMigration) Detect(doc *yaml.Node) bool {
 	root := GetDocumentRoot(doc)
 	if root == nil || root.Kind != yaml.MappingNode {
 		return false
 	}
-	assignments := GetMapValue(root, "assignments")
-	if assignments == nil || assignments.Kind != yaml.MappingNode {
-		// No assignments block at all: the scheduler is certainly unassigned.
-		return true
-	}
-	return GetMapValue(assignments, schedulerPrincipal) == nil
+	return !schedulerCanRead(root)
 }
 
 // Apply adds the scheduler role (if absent) and the assignment binding the
 // scheduler principal to it. Existing keys are never overwritten: if the
 // operator already defines a role by this name, we bind to theirs rather
 // than replacing it.
+//
+// Apply verifies its own postcondition. Every failure mode this migration
+// has had produced a file that parsed, validated, and granted nothing —
+// so "wrote something" is not evidence of success. Returning an error here
+// stops the runner BEFORE it writes (runner.go), leaving the operator's
+// file untouched and the failure loud.
 func (m *ACLSchedulerGrantMigration) Apply(doc *yaml.Node) error {
 	root := GetDocumentRoot(doc)
 	if root == nil || root.Kind != yaml.MappingNode {
@@ -79,7 +93,58 @@ func (m *ACLSchedulerGrantMigration) Apply(doc *yaml.Node) error {
 
 	m.ensureRole(root)
 	m.ensureAssignment(root)
+
+	if !schedulerCanRead(root) {
+		return fmt.Errorf(
+			"acl-scheduler-grant: after applying, %q still has no role granting read; "+
+				"acl.yaml was left unchanged — grant it manually",
+			SchedulerPrincipal)
+	}
 	return nil
+}
+
+// schedulerCanRead reports whether the policy grants the scheduler
+// principal read via a role that actually exists and lists read targets.
+//
+// Both assignment maps are consulted: `assignments` (principal → one role)
+// and `asserted_role_assignments` (principal → role or list of roles). An
+// operator who scoped the scheduler through the asserted map has already
+// thought about this, and must not have a wildcard grant added on top.
+func schedulerCanRead(root *yaml.Node) bool {
+	roles := GetMapValue(root, "roles")
+	if roles == nil || roles.Kind != yaml.MappingNode {
+		return false
+	}
+	grantsRead := func(roleName string) bool {
+		return hasReadTargets(GetMapValue(roles, roleName))
+	}
+
+	assignments := GetMapValue(root, "assignments")
+	if assignments != nil && assignments.Kind == yaml.MappingNode {
+		assigned := GetMapValue(assignments, SchedulerPrincipal)
+		if assigned != nil && grantsRead(assigned.Value) {
+			return true
+		}
+	}
+
+	asserted := GetMapValue(root, "asserted_role_assignments")
+	if asserted == nil || asserted.Kind != yaml.MappingNode {
+		return false
+	}
+	entry := GetMapValue(asserted, SchedulerPrincipal)
+	if entry == nil {
+		return false
+	}
+	// RoleList is scalar-or-sequence.
+	if entry.Kind == yaml.SequenceNode {
+		for _, r := range entry.Content {
+			if grantsRead(r.Value) {
+				return true
+			}
+		}
+		return false
+	}
+	return grantsRead(entry.Value)
 }
 
 // ensureRole adds `scheduler-system: {read: ["*"]}` under `roles:` unless a
@@ -89,20 +154,21 @@ func (m *ACLSchedulerGrantMigration) Apply(doc *yaml.Node) error {
 // tasks read the whole graph. Narrowing it is the operator's call, and
 // `run_as` exists so a job can be given a tighter identity instead.
 func (m *ACLSchedulerGrantMigration) ensureRole(root *yaml.Node) {
-	roles := GetMapValue(root, "roles")
-	if roles == nil || roles.Kind != yaml.MappingNode {
-		roles = &yaml.Node{Kind: yaml.MappingNode}
-		// Roles are conventionally declared before assignments; when neither
-		// exists this appends, which is also fine.
-		InsertMapKeyAfter(root, "", "roles", roles)
+	// EnsureMapping, not InsertMapKeyAfter: `roles:` with nothing under it
+	// is a null scalar, and inserting over an existing key no-ops.
+	roles := EnsureMapping(root, "", "roles")
+	if roles == nil {
+		return
 	}
 	if GetMapValue(roles, schedulerRoleName) != nil {
-		return // operator already defines this role — bind to theirs
+		// The operator defines a role by this name. Keep their definition,
+		// but make sure it grants read — binding to a role that grants
+		// nothing just relocates the bug this migration exists to fix.
+		m.ensureRoleGrantsRead(root, schedulerRoleName)
+		return
 	}
 
-	wildcard := &yaml.Node{Kind: yaml.SequenceNode, Content: []*yaml.Node{
-		{Kind: yaml.ScalarNode, Value: "*", Style: yaml.DoubleQuotedStyle},
-	}}
+	wildcard := wildcardRead()
 	roleDef := &yaml.Node{Kind: yaml.MappingNode, Content: []*yaml.Node{
 		{Kind: yaml.ScalarNode, Value: "read"},
 		wildcard,
@@ -115,18 +181,62 @@ func (m *ACLSchedulerGrantMigration) ensureRole(root *yaml.Node) {
 	roles.Content = append(roles.Content, roleKey, roleDef)
 }
 
-// ensureAssignment binds the scheduler principal to the role.
+// wildcardRead builds the `read: ["*"]` value node.
+func wildcardRead() *yaml.Node {
+	return &yaml.Node{Kind: yaml.SequenceNode, Content: []*yaml.Node{
+		{Kind: yaml.ScalarNode, Value: "*", Style: yaml.DoubleQuotedStyle},
+	}}
+}
+
+// ensureAssignment binds the scheduler principal to a role that grants read.
+//
+// When an assignment already exists it is KEPT — repointing an operator's
+// deliberate choice would be presumptuous — but the role it names is
+// repaired if it grants nothing, since an assignment to a dead or undefined
+// role reads exactly like no assignment at all.
 func (m *ACLSchedulerGrantMigration) ensureAssignment(root *yaml.Node) {
-	assignments := GetMapValue(root, "assignments")
-	if assignments == nil || assignments.Kind != yaml.MappingNode {
-		assignments = &yaml.Node{Kind: yaml.MappingNode}
-		InsertMapKeyAfter(root, "roles", "assignments", assignments)
+	assignments := EnsureMapping(root, "roles", "assignments")
+	if assignments == nil {
+		return
 	}
-	if GetMapValue(assignments, schedulerPrincipal) != nil {
+	if existing := GetMapValue(assignments, SchedulerPrincipal); existing != nil {
+		m.ensureRoleGrantsRead(root, existing.Value)
 		return
 	}
 	assignments.Content = append(assignments.Content,
-		&yaml.Node{Kind: yaml.ScalarNode, Value: schedulerPrincipal},
+		&yaml.Node{Kind: yaml.ScalarNode, Value: SchedulerPrincipal},
 		&yaml.Node{Kind: yaml.ScalarNode, Value: schedulerRoleName},
 	)
+}
+
+// ensureRoleGrantsRead gives `roleName` a read list if it has none —
+// covering both an undefined role (a dangling assignment) and one defined
+// but empty. Roles that already grant read are untouched.
+func (m *ACLSchedulerGrantMigration) ensureRoleGrantsRead(root *yaml.Node, roleName string) {
+	if roleName == "" {
+		return
+	}
+	roles := EnsureMapping(root, "", "roles")
+	if roles == nil {
+		return
+	}
+	def := EnsureMapping(roles, "", roleName)
+	if def == nil {
+		return
+	}
+	if hasReadTargets(def) {
+		return
+	}
+	SetMapNode(def, "read", wildcardRead())
+}
+
+// hasReadTargets reports whether a role definition lists at least one read
+// target. An empty or missing `read:` grants nothing, which is
+// indistinguishable from having no role at all.
+func hasReadTargets(roleDef *yaml.Node) bool {
+	if roleDef == nil || roleDef.Kind != yaml.MappingNode {
+		return false
+	}
+	read := GetMapValue(roleDef, "read")
+	return read != nil && read.Kind == yaml.SequenceNode && len(read.Content) > 0
 }

--- a/internal/migration/acl_scheduler_grant_test.go
+++ b/internal/migration/acl_scheduler_grant_test.go
@@ -1,0 +1,251 @@
+package migration_test
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/Sourcehaven-BV/rela/internal/acl"
+	"github.com/Sourcehaven-BV/rela/internal/migration"
+	"github.com/Sourcehaven-BV/rela/internal/principal"
+)
+
+// TKT-76JP2A / RR-1USMEZ: scheduled tasks resolve reads against a fixed
+// system identity. A project with an acl.yaml that never assigns that
+// identity a role has tasks reading nothing; this migration repairs it.
+
+func parseDoc(t *testing.T, src string) *yaml.Node {
+	t.Helper()
+	var doc yaml.Node
+	if err := yaml.Unmarshal([]byte(src), &doc); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	return &doc
+}
+
+func TestACLSchedulerGrant_Detect(t *testing.T) {
+	tests := []struct {
+		name string
+		src  string
+		want bool
+	}{
+		{
+			name: "no assignments block",
+			src:  "roles:\n  viewer:\n    read: [ticket]\n",
+			want: true,
+		},
+		{
+			name: "assignments without the scheduler",
+			src:  "roles:\n  viewer:\n    read: [ticket]\nassignments:\n  alice: viewer\n",
+			want: true,
+		},
+		{
+			name: "scheduler already assigned",
+			src:  "assignments:\n  system:scheduler: scheduler-system\n",
+			want: false,
+		},
+		{
+			name: "scheduler assigned to an operator's own role",
+			src:  "assignments:\n  system:scheduler: my-custom-role\n",
+			want: false,
+		},
+		{
+			name: "empty document",
+			src:  "",
+			want: false,
+		},
+	}
+
+	m := &migration.ACLSchedulerGrantMigration{}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := m.Detect(parseDoc(t, tc.src)); got != tc.want {
+				t.Errorf("Detect() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestACLSchedulerGrant_ApplyIsIdempotent pins the package convention:
+// after Apply, Detect must be false and a second Apply must not duplicate.
+func TestACLSchedulerGrant_ApplyIsIdempotent(t *testing.T) {
+	m := &migration.ACLSchedulerGrantMigration{}
+	doc := parseDoc(t, "roles:\n  viewer:\n    read: [ticket]\nassignments:\n  alice: viewer\n")
+
+	if err := m.Apply(doc); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if m.Detect(doc) {
+		t.Error("Detect still true after Apply")
+	}
+
+	first, marshalErr := yaml.Marshal(doc)
+	if marshalErr != nil {
+		t.Fatalf("marshal: %v", marshalErr)
+	}
+	if applyErr := m.Apply(doc); applyErr != nil {
+		t.Fatalf("second Apply: %v", applyErr)
+	}
+	second, marshalErr := yaml.Marshal(doc)
+	if marshalErr != nil {
+		t.Fatalf("marshal: %v", marshalErr)
+	}
+	if !bytes.Equal(first, second) {
+		t.Errorf("second Apply changed the document:\n--- first ---\n%s\n--- second ---\n%s", first, second)
+	}
+}
+
+// TestACLSchedulerGrant_PreservesComments is the whole point of the
+// yaml.Node approach — an operator's policy file keeps its comments and
+// its existing entries.
+func TestACLSchedulerGrant_PreservesComments(t *testing.T) {
+	src := `# Our access policy - keep in sync with the handbook.
+roles:
+  # Analysts get read-only access.
+  viewer:
+    read: [ticket]
+assignments:
+  alice: viewer
+`
+	m := &migration.ACLSchedulerGrantMigration{}
+	doc := parseDoc(t, src)
+	if err := m.Apply(doc); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	out, err := yaml.Marshal(doc)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	got := string(out)
+
+	for _, want := range []string{
+		"# Our access policy - keep in sync with the handbook.",
+		"# Analysts get read-only access.",
+		"alice: viewer",
+		"scheduler-system",
+		"system:scheduler",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("output missing %q:\n%s", want, got)
+		}
+	}
+}
+
+// TestACLSchedulerGrant_ProducesLoadablePolicy is the guard against
+// shipping a file that blocks boot: appbuild hard-fails on a malformed or
+// invalid acl.yaml, so a migration that generated one would be worse than
+// the bug it fixes.
+func TestACLSchedulerGrant_ProducesLoadablePolicy(t *testing.T) {
+	sources := map[string]string{
+		"with existing roles": "roles:\n  viewer:\n    read: [ticket]\nassignments:\n  alice: viewer\n",
+		"assignments only":    "assignments:\n  alice: viewer\n",
+		"roles only":          "roles:\n  viewer:\n    read: [ticket]\n",
+	}
+
+	m := &migration.ACLSchedulerGrantMigration{}
+	for name, src := range sources {
+		t.Run(name, func(t *testing.T) {
+			doc := parseDoc(t, src)
+			if err := m.Apply(doc); err != nil {
+				t.Fatalf("Apply: %v", err)
+			}
+			out, err := yaml.Marshal(doc)
+			if err != nil {
+				t.Fatalf("marshal: %v", err)
+			}
+
+			var policy acl.Policy
+			if err := yaml.Unmarshal(out, &policy); err != nil {
+				t.Fatalf("migrated policy does not parse: %v\n%s", err, out)
+			}
+			if err := policy.Validate(); err != nil {
+				t.Fatalf("migrated policy fails Validate (would block boot): %v\n%s", err, out)
+			}
+
+			// The grant must actually bind the principal the scheduler uses.
+			role, ok := policy.Assignments[principal.UserScheduler]
+			if !ok {
+				t.Fatalf("no assignment for %q:\n%s", principal.UserScheduler, out)
+			}
+			def, ok := policy.Roles[role]
+			if !ok {
+				t.Fatalf("assignment names role %q which is not defined:\n%s", role, out)
+			}
+			if len(def.Read) == 0 {
+				t.Errorf("role %q grants no read:\n%s", role, out)
+			}
+			// Read-only: a privilege grant must not smuggle in write verbs.
+			if len(def.Update) != 0 || len(def.Delete) != 0 || len(def.Create) != 0 {
+				t.Errorf("scheduler role grants write verbs (create=%v update=%v delete=%v)",
+					def.Create, def.Update, def.Delete)
+			}
+		})
+	}
+}
+
+// TestACLSchedulerGrant_RespectsOperatorRole: if the operator already
+// defines a role by our name, bind to theirs rather than overwriting it.
+func TestACLSchedulerGrant_RespectsOperatorRole(t *testing.T) {
+	src := "roles:\n  scheduler-system:\n    read: [ticket]\nassignments:\n  alice: viewer\n"
+	m := &migration.ACLSchedulerGrantMigration{}
+	doc := parseDoc(t, src)
+	if err := m.Apply(doc); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	out, err := yaml.Marshal(doc)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	var policy acl.Policy
+	if err := yaml.Unmarshal(out, &policy); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	// Their narrower definition survives; we did not widen it to "*".
+	got := policy.Roles["scheduler-system"].Read
+	if len(got) != 1 || got[0] != "ticket" {
+		t.Errorf("operator's role was overwritten: read = %v, want [ticket]", got)
+	}
+	if policy.Assignments[principal.UserScheduler] != "scheduler-system" {
+		t.Errorf("assignment = %q, want scheduler-system", policy.Assignments[principal.UserScheduler])
+	}
+}
+
+// TestACLSchedulerGrant_PrincipalMatchesRuntime pins the literal in this
+// package against the constant the scheduler actually stamps. internal/
+// migration deliberately imports nothing but yaml, so the value is
+// duplicated — this test is what keeps the copy honest. If it fails, the
+// migration is writing a grant for a principal nothing runs as.
+func TestACLSchedulerGrant_PrincipalMatchesRuntime(t *testing.T) {
+	m := &migration.ACLSchedulerGrantMigration{}
+	doc := parseDoc(t, "assignments:\n  alice: viewer\n")
+	if err := m.Apply(doc); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	out, err := yaml.Marshal(doc)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var policy acl.Policy
+	if err := yaml.Unmarshal(out, &policy); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if _, ok := policy.Assignments[principal.UserScheduler]; !ok {
+		t.Fatalf("migration grants no role to principal.UserScheduler (%q); "+
+			"the literal in acl_scheduler_grant.go has drifted:\n%s",
+			principal.UserScheduler, out)
+	}
+}
+
+// TestACLSchedulerGrant_Registered pins the wiring: an unregistered
+// migration silently never runs.
+func TestACLSchedulerGrant_Registered(t *testing.T) {
+	for _, m := range migration.ForFileType(migration.FileTypeACL) {
+		if m.Name() == "acl-scheduler-grant" {
+			return
+		}
+	}
+	t.Fatal("acl-scheduler-grant is not registered for FileTypeACL")
+}

--- a/internal/migration/acl_scheduler_grant_test.go
+++ b/internal/migration/acl_scheduler_grant_test.go
@@ -43,17 +43,53 @@ func TestACLSchedulerGrant_Detect(t *testing.T) {
 		},
 		{
 			name: "scheduler already assigned",
-			src:  "assignments:\n  system:scheduler: scheduler-system\n",
+			src: "roles:\n  scheduler-system:\n    read: [\"*\"]\n" +
+				"assignments:\n  system:scheduler: scheduler-system\n",
 			want: false,
 		},
 		{
 			name: "scheduler assigned to an operator's own role",
-			src:  "assignments:\n  system:scheduler: my-custom-role\n",
+			src: "roles:\n  my-custom-role:\n    read: [ticket]\n" +
+				"assignments:\n  system:scheduler: my-custom-role\n",
 			want: false,
 		},
 		{
 			name: "empty document",
 			src:  "",
+			want: false,
+		},
+		// The shapes that previously produced a silent false success.
+		{
+			name: "roles present but null",
+			src:  "roles:\nassignments:\n  alice: viewer\n",
+			want: true,
+		},
+		{
+			name: "assignments present but null",
+			src:  "roles:\n  viewer:\n    read: [ticket]\nassignments:\n",
+			want: true,
+		},
+		{
+			name: "assignment names a role that is not defined",
+			src:  "roles:\n  viewer:\n    read: [ticket]\nassignments:\n  system:scheduler: ghost\n",
+			want: true,
+		},
+		{
+			name: "assigned role grants no read",
+			src: "roles:\n  writer:\n    create: [ticket]\n" +
+				"assignments:\n  system:scheduler: writer\n",
+			want: true,
+		},
+		{
+			name: "granted via asserted_role_assignments (scalar)",
+			src: "roles:\n  reporting:\n    read: [ticket]\n" +
+				"asserted_role_assignments:\n  system:scheduler: reporting\n",
+			want: false,
+		},
+		{
+			name: "granted via asserted_role_assignments (list)",
+			src: "roles:\n  reporting:\n    read: [ticket]\n" +
+				"asserted_role_assignments:\n  system:scheduler: [other, reporting]\n",
 			want: false,
 		},
 	}
@@ -70,15 +106,33 @@ func TestACLSchedulerGrant_Detect(t *testing.T) {
 
 // TestACLSchedulerGrant_ApplyIsIdempotent pins the package convention:
 // after Apply, Detect must be false and a second Apply must not duplicate.
+// Runs over the awkward shapes too: idempotency is precisely the property
+// that broke on a null `assignments:` (Detect stayed true forever, so every
+// `rela migrate` re-applied and re-wrote the file).
 func TestACLSchedulerGrant_ApplyIsIdempotent(t *testing.T) {
-	m := &migration.ACLSchedulerGrantMigration{}
-	doc := parseDoc(t, "roles:\n  viewer:\n    read: [ticket]\nassignments:\n  alice: viewer\n")
+	sources := map[string]string{
+		"well formed":      "roles:\n  viewer:\n    read: [ticket]\nassignments:\n  alice: viewer\n",
+		"roles null":       "roles:\nassignments:\n  alice: viewer\n",
+		"assignments null": "roles:\n  viewer:\n    read: [ticket]\nassignments:\n",
+		"both null":        "roles:\nassignments:\n",
+	}
+	for name, src := range sources {
+		t.Run(name, func(t *testing.T) {
+			m := &migration.ACLSchedulerGrantMigration{}
+			doc := parseDoc(t, src)
+			applyIdempotently(t, m, doc)
+		})
+	}
+}
 
+func applyIdempotently(t *testing.T, m *migration.ACLSchedulerGrantMigration, doc *yaml.Node) {
+	t.Helper()
 	if err := m.Apply(doc); err != nil {
 		t.Fatalf("Apply: %v", err)
 	}
 	if m.Detect(doc) {
-		t.Error("Detect still true after Apply")
+		out, _ := yaml.Marshal(doc)
+		t.Errorf("Detect still true after Apply — migration never converges:\n%s", out)
 	}
 
 	first, marshalErr := yaml.Marshal(doc)
@@ -142,6 +196,15 @@ func TestACLSchedulerGrant_ProducesLoadablePolicy(t *testing.T) {
 		"with existing roles": "roles:\n  viewer:\n    read: [ticket]\nassignments:\n  alice: viewer\n",
 		"assignments only":    "assignments:\n  alice: viewer\n",
 		"roles only":          "roles:\n  viewer:\n    read: [ticket]\n",
+		// `key:` with nothing under it parses as a NULL SCALAR, not an
+		// empty mapping. Both of these previously yielded a file that
+		// parsed and validated while granting nothing.
+		"roles null":          "roles:\nassignments:\n  alice: viewer\n",
+		"assignments null":    "roles:\n  viewer:\n    read: [ticket]\nassignments:\n",
+		"both null":           "roles:\nassignments:\n",
+		"dangling assignment": "roles:\n  viewer:\n    read: [ticket]\nassignments:\n  system:scheduler: ghost\n",
+		"assigned role grants no read": "roles:\n  writer:\n    create: [ticket]\n" +
+			"assignments:\n  system:scheduler: writer\n",
 	}
 
 	m := &migration.ACLSchedulerGrantMigration{}
@@ -176,9 +239,12 @@ func TestACLSchedulerGrant_ProducesLoadablePolicy(t *testing.T) {
 			if len(def.Read) == 0 {
 				t.Errorf("role %q grants no read:\n%s", role, out)
 			}
-			// Read-only: a privilege grant must not smuggle in write verbs.
-			if len(def.Update) != 0 || len(def.Delete) != 0 || len(def.Create) != 0 {
-				t.Errorf("scheduler role grants write verbs (create=%v update=%v delete=%v)",
+			// A role WE mint must be read-only — the migration must never
+			// hand the scheduler write verbs it did not already have. A
+			// role the operator wrote is theirs; we only ensure it reads.
+			writes := len(def.Update) + len(def.Delete) + len(def.Create)
+			if role == "scheduler-system" && writes != 0 {
+				t.Errorf("migration-created role grants write verbs (create=%v update=%v delete=%v)",
 					def.Create, def.Update, def.Delete)
 			}
 		})
@@ -219,8 +285,38 @@ func TestACLSchedulerGrant_RespectsOperatorRole(t *testing.T) {
 // duplicated — this test is what keeps the copy honest. If it fails, the
 // migration is writing a grant for a principal nothing runs as.
 func TestACLSchedulerGrant_PrincipalMatchesRuntime(t *testing.T) {
+	// Direct and unconditional: this holds regardless of whether Apply
+	// works on any particular input, so a structural bug elsewhere cannot
+	// masquerade as "the literal is fine".
+	if migration.SchedulerPrincipal != principal.UserScheduler {
+		t.Fatalf("migration.SchedulerPrincipal = %q but principal.UserScheduler = %q; "+
+			"the migration would grant a principal nothing runs as",
+			migration.SchedulerPrincipal, principal.UserScheduler)
+	}
+}
+
+// TestACLSchedulerGrant_RespectsAssertedRoleGrant: an operator who scoped
+// the scheduler through asserted_role_assignments has already thought about
+// this. Do not pile a read:["*"] role on top of their narrower grant.
+func TestACLSchedulerGrant_RespectsAssertedRoleGrant(t *testing.T) {
+	src := "roles:\n  reporting:\n    read: [ticket]\n" +
+		"asserted_role_assignments:\n  system:scheduler: reporting\n"
 	m := &migration.ACLSchedulerGrantMigration{}
-	doc := parseDoc(t, "assignments:\n  alice: viewer\n")
+	doc := parseDoc(t, src)
+
+	if m.Detect(doc) {
+		t.Fatal("Detect true despite an existing asserted read grant — would widen the operator's scope")
+	}
+}
+
+// TestACLSchedulerGrant_RepairsDeadRole: a role that exists but grants no
+// read must be given one, not silently bound to. Binding to an empty role
+// just relocates the bug.
+func TestACLSchedulerGrant_RepairsDeadRole(t *testing.T) {
+	src := "roles:\n  scheduler-system: {}\nassignments:\n  alice: viewer\n"
+	m := &migration.ACLSchedulerGrantMigration{}
+	doc := parseDoc(t, src)
+
 	if err := m.Apply(doc); err != nil {
 		t.Fatalf("Apply: %v", err)
 	}
@@ -232,10 +328,33 @@ func TestACLSchedulerGrant_PrincipalMatchesRuntime(t *testing.T) {
 	if err := yaml.Unmarshal(out, &policy); err != nil {
 		t.Fatalf("unmarshal: %v", err)
 	}
-	if _, ok := policy.Assignments[principal.UserScheduler]; !ok {
-		t.Fatalf("migration grants no role to principal.UserScheduler (%q); "+
-			"the literal in acl_scheduler_grant.go has drifted:\n%s",
-			principal.UserScheduler, out)
+	if got := policy.Roles["scheduler-system"].Read; len(got) == 0 {
+		t.Errorf("dead role left without read:\n%s", out)
+	}
+}
+
+// TestACLSchedulerGrant_ApplyFailsLoudlyWhenItCannotGrant exercises the
+// postcondition. Every bug this migration has had produced a file that
+// parsed and validated while granting nothing, so Apply must verify its
+// own result rather than trust that it wrote something.
+//
+// The input is a malformed policy the repair cannot fix: the scheduler's
+// assignment value is a nested mapping, not a role name. Returning an
+// error stops the runner before it writes, so the operator's file survives
+// (see TestMigrate_MalformedACLDoesNotClobber for the on-disk half).
+func TestACLSchedulerGrant_ApplyFailsLoudlyWhenItCannotGrant(t *testing.T) {
+	src := "roles:\n  viewer:\n    read: [ticket]\n" +
+		"assignments:\n  system:scheduler:\n    nested: yes\n"
+	m := &migration.ACLSchedulerGrantMigration{}
+	doc := parseDoc(t, src)
+
+	err := m.Apply(doc)
+	if err == nil {
+		out, _ := yaml.Marshal(doc)
+		t.Fatalf("Apply reported success but granted nothing:\n%s", out)
+	}
+	if !strings.Contains(err.Error(), migration.SchedulerPrincipal) {
+		t.Errorf("error should name the principal, got: %v", err)
 	}
 }
 

--- a/internal/migration/migration.go
+++ b/internal/migration/migration.go
@@ -38,6 +38,7 @@ type FileType string
 const (
 	FileTypeMetamodel FileType = "metamodel"  // metamodel.yaml
 	FileTypeDataEntry FileType = "data-entry" // data-entry.yaml
+	FileTypeACL       FileType = "acl"        // acl.yaml
 )
 
 // Migration defines the interface for schema migrations.

--- a/internal/migration/yaml_util.go
+++ b/internal/migration/yaml_util.go
@@ -52,6 +52,23 @@ func SetMapValue(node *yaml.Node, key, value string) {
 	node.Content = append(node.Content, keyNode, valueNode)
 }
 
+// SetMapNode sets `key` to an arbitrary value node, replacing any existing
+// value. [SetMapValue] is the scalar-only equivalent; this one accepts a
+// composite (sequence/mapping) value.
+func SetMapNode(node *yaml.Node, key string, value *yaml.Node) {
+	if node == nil || node.Kind != yaml.MappingNode {
+		return
+	}
+	for i := 0; i < len(node.Content)-1; i += 2 {
+		if node.Content[i].Value == key {
+			node.Content[i+1] = value
+			return
+		}
+	}
+	node.Content = append(node.Content,
+		&yaml.Node{Kind: yaml.ScalarNode, Value: key}, value)
+}
+
 // RenameMapKey renames a key in a mapping node.
 // Returns true if the key was found and renamed.
 func RenameMapKey(node *yaml.Node, oldKey, newKey string) bool {
@@ -211,6 +228,45 @@ func InsertMapKeyAfter(node *yaml.Node, anchor, key string, value *yaml.Node) {
 	}
 	// Anchor not found — append at end.
 	node.Content = append(node.Content, keyNode, value)
+}
+
+// EnsureMapping returns the mapping node stored under `key`, creating or
+// repairing it as needed so the caller always gets a usable mapping.
+//
+// It exists because `key:` with nothing under it parses as a NULL SCALAR,
+// not an empty mapping — a shape YAML accepts and operators write all the
+// time (a commented-out block, a half-finished file). Reaching for
+// [InsertMapKeyAfter] there silently does nothing: the key already exists,
+// so the insert no-ops and the freshly-built mapping is dropped. The
+// migration then reports success having changed nothing.
+//
+// Three cases:
+//   - key absent            → append `key: {}` after `anchor` and return it
+//   - key holds a mapping   → return it untouched
+//   - key holds null/scalar → convert THAT node in place to an empty
+//     mapping (preserving position and comments) and return it
+//
+// Returns nil only if `node` is not a mapping.
+func EnsureMapping(node *yaml.Node, anchor, key string) *yaml.Node {
+	if node == nil || node.Kind != yaml.MappingNode {
+		return nil
+	}
+	if existing := GetMapValue(node, key); existing != nil {
+		if existing.Kind == yaml.MappingNode {
+			return existing
+		}
+		// Null or wrong kind: repair in place so the node keeps its
+		// position in the document and any attached comments.
+		existing.Kind = yaml.MappingNode
+		existing.Tag = "!!map"
+		existing.Value = ""
+		existing.Style = 0
+		existing.Content = nil
+		return existing
+	}
+	created := &yaml.Node{Kind: yaml.MappingNode, Tag: "!!map"}
+	InsertMapKeyAfter(node, anchor, key, created)
+	return created
 }
 
 // DeleteMapKey removes a key-value pair from a mapping node by key name.

--- a/internal/principal/principal.go
+++ b/internal/principal/principal.go
@@ -256,6 +256,27 @@ const (
 	ToolWebhookReceiver = "webhook-receiver"
 )
 
+// UserScheduler is the default [Principal.User] for scheduled tasks that
+// declare no `run_as` — a FIXED identity, deliberately not the OS user.
+//
+// The scheduler used to default to [SystemUser] ($USER). That made a job's
+// read scope depend on which OS account happened to run `rela scheduler`,
+// so the assignment an operator needed in acl.yaml differed per host and
+// could not be written down in advance. Worse, a systemd unit typically has
+// no $USER, so SystemUser() returned "unknown" — which [acl.Declarative]
+// rejects as an unstamped principal, failing the task outright rather than
+// merely scoping it.
+//
+// A fixed principal makes the scheduler's identity a documented, grantable
+// constant:
+//
+//	assignments:
+//	  system:scheduler: <a-role-with-read>
+//
+// It grants nothing by itself (DEC-O59WM4) — privileges still come only
+// from acl.yaml. `run_as` continues to override it per task.
+const UserScheduler = "system:scheduler"
+
 // principalKey is the unexported context.WithValue key so no other
 // package can collide with it or read/write the value outside this
 // package's API.

--- a/internal/projectsetup/migrate.go
+++ b/internal/projectsetup/migrate.go
@@ -151,5 +151,19 @@ func getMigrateFiles(ctx *project.Context) []MigrateFile {
 			Name:     dataentryconfig.ConfigFile,
 			FileType: migration.FileTypeDataEntry,
 		},
+		{
+			// Only migrated when it already exists — the callers' skip-on-
+			// missing guard is load-bearing here. A project with no acl.yaml
+			// runs on NopACL and must stay that way; creating one would flip
+			// every principal to deny-by-default (RR-SVQ5HE).
+			Path:     filepath.Join(ctx.Root, aclConfigFile),
+			Name:     aclConfigFile,
+			FileType: migration.FileTypeACL,
+		},
 	}
 }
+
+// aclConfigFile is the policy filename. Declared here because the migrate
+// file list is the only place in projectsetup that needs it; appbuild and
+// the acl CLI commands each join the same literal against the project root.
+const aclConfigFile = "acl.yaml"

--- a/internal/projectsetup/migrate_acl_test.go
+++ b/internal/projectsetup/migrate_acl_test.go
@@ -1,0 +1,167 @@
+package projectsetup_test
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/Sourcehaven-BV/rela/internal/acl"
+	"github.com/Sourcehaven-BV/rela/internal/principal"
+	"github.com/Sourcehaven-BV/rela/internal/projectsetup"
+	"github.com/Sourcehaven-BV/rela/internal/storage"
+)
+
+// TKT-76JP2A: acl.yaml joins the migrated file set. These tests drive the
+// real runner over a real temp project, because the unit tests on the
+// migration itself cannot catch a file that is never handed to it.
+
+const aclTestMetamodel = `entities:
+  ticket:
+    id_type: sequential
+    properties:
+      title:
+        type: string
+`
+
+// newACLProject writes a minimal project. When aclYAML is empty, no
+// acl.yaml is created — the "policy-less project" case.
+func newACLProject(t *testing.T, aclYAML string) string {
+	t.Helper()
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "metamodel.yaml"), []byte(aclTestMetamodel), 0o600); err != nil {
+		t.Fatalf("write metamodel: %v", err)
+	}
+	if aclYAML != "" {
+		if err := os.WriteFile(filepath.Join(dir, "acl.yaml"), []byte(aclYAML), 0o600); err != nil {
+			t.Fatalf("write acl.yaml: %v", err)
+		}
+	}
+	return dir
+}
+
+// TestMigrate_GrantsSchedulerInExistingACL is the end-to-end repair: an
+// operator's policy that never mentioned the scheduler gains the grant.
+func TestMigrate_GrantsSchedulerInExistingACL(t *testing.T) {
+	dir := newACLProject(t, "# my policy\nroles:\n  viewer:\n    read: [ticket]\nassignments:\n  alice: viewer\n")
+	fs := storage.NewSafeFS(storage.NewOsFS())
+
+	if _, err := projectsetup.MigrateWithFS(dir, fs); err != nil {
+		t.Fatalf("MigrateWithFS: %v", err)
+	}
+
+	raw, err := os.ReadFile(filepath.Join(dir, "acl.yaml"))
+	if err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	got := string(raw)
+	if !strings.Contains(got, "# my policy") {
+		t.Errorf("operator's comment was lost:\n%s", got)
+	}
+
+	var policy acl.Policy
+	if err := yaml.Unmarshal(raw, &policy); err != nil {
+		t.Fatalf("migrated acl.yaml does not parse: %v\n%s", err, got)
+	}
+	if err := policy.Validate(); err != nil {
+		t.Fatalf("migrated acl.yaml fails Validate: %v\n%s", err, got)
+	}
+	if _, ok := policy.Assignments[principal.UserScheduler]; !ok {
+		t.Errorf("no grant for %q:\n%s", principal.UserScheduler, got)
+	}
+	if policy.Assignments["alice"] != "viewer" {
+		t.Errorf("existing assignment lost:\n%s", got)
+	}
+}
+
+// TestMigrate_LeavesPolicylessProjectAlone is AC3 and the guard on
+// RR-SVQ5HE: a project with no acl.yaml runs on NopACL, where scheduled
+// tasks already read fine. Creating a policy would flip every principal
+// (humans, CLI, MCP) to deny-by-default. It must stay absent.
+func TestMigrate_LeavesPolicylessProjectAlone(t *testing.T) {
+	dir := newACLProject(t, "")
+	fs := storage.NewSafeFS(storage.NewOsFS())
+
+	if _, err := projectsetup.MigrateWithFS(dir, fs); err != nil {
+		t.Fatalf("MigrateWithFS: %v", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(dir, "acl.yaml")); !os.IsNotExist(err) {
+		raw, _ := os.ReadFile(filepath.Join(dir, "acl.yaml"))
+		t.Fatalf("migration CREATED acl.yaml in a policy-less project "+
+			"(this denies reads to every principal); content:\n%s", raw)
+	}
+}
+
+// TestMigrate_ACLIsIdempotent: running migrate twice must not double up.
+func TestMigrate_ACLIsIdempotent(t *testing.T) {
+	dir := newACLProject(t, "roles:\n  viewer:\n    read: [ticket]\nassignments:\n  alice: viewer\n")
+	fs := storage.NewSafeFS(storage.NewOsFS())
+	path := filepath.Join(dir, "acl.yaml")
+
+	if _, err := projectsetup.MigrateWithFS(dir, fs); err != nil {
+		t.Fatalf("first migrate: %v", err)
+	}
+	first, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+
+	if _, migrateErr := projectsetup.MigrateWithFS(dir, fs); migrateErr != nil {
+		t.Fatalf("second migrate: %v", migrateErr)
+	}
+	second, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+
+	if !bytes.Equal(first, second) {
+		t.Errorf("second migrate changed the file:\n--- first ---\n%s\n--- second ---\n%s", first, second)
+	}
+}
+
+// TestDetectMigrations_ReportsACLGrant pins that `rela migrate --check`
+// surfaces this before it is applied.
+func TestDetectMigrations_ReportsACLGrant(t *testing.T) {
+	dir := newACLProject(t, "roles:\n  viewer:\n    read: [ticket]\nassignments:\n  alice: viewer\n")
+	fs := storage.NewSafeFS(storage.NewOsFS())
+
+	detections, err := projectsetup.DetectMigrationsWithFS(dir, fs)
+	if err != nil {
+		t.Fatalf("DetectMigrationsWithFS: %v", err)
+	}
+	for _, d := range detections {
+		if d.File.Name != "acl.yaml" {
+			continue
+		}
+		for _, m := range d.Migrations {
+			if m.Migration.Name() == "acl-scheduler-grant" {
+				return
+			}
+		}
+	}
+	t.Errorf("acl-scheduler-grant not reported by --check; detections=%+v", detections)
+}
+
+// TestMigrate_MalformedACLDoesNotClobber: a broken policy must fail the
+// migration and leave the operator's bytes on disk untouched.
+func TestMigrate_MalformedACLDoesNotClobber(t *testing.T) {
+	const broken = "roles:\n  viewer:\n    read: [ticket\nassignments:\n"
+	dir := newACLProject(t, broken)
+	fs := storage.NewSafeFS(storage.NewOsFS())
+
+	if _, err := projectsetup.MigrateWithFS(dir, fs); err == nil {
+		t.Error("malformed acl.yaml migrated without error")
+	}
+
+	raw, err := os.ReadFile(filepath.Join(dir, "acl.yaml"))
+	if err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	if string(raw) != broken {
+		t.Errorf("malformed file was rewritten:\n--- want ---\n%s\n--- got ---\n%s", broken, raw)
+	}
+}

--- a/internal/scheduler/config.go
+++ b/internal/scheduler/config.go
@@ -31,11 +31,11 @@ type TaskConfig struct {
 	// acl.yaml: assignments map this principal to roles, exactly like a
 	// human user. Naming a principal here grants nothing by itself.
 	//
-	// Empty (the default) means [principal.SystemUser], i.e. every task
-	// shares the scheduler's identity. Set it to give a job its own
-	// identity — which both narrows what it can read (via a scoped role)
-	// and makes the audit log name the specific job rather than a generic
-	// scheduler.
+	// Empty (the default) means [principal.UserScheduler] — the fixed
+	// "system:scheduler" identity every task shares. Set it to give a job
+	// its own identity, which both narrows what it can read (via a scoped
+	// role) and makes the audit log name the specific job rather than a
+	// generic scheduler.
 	//
 	// A task whose principal has no read grants reads nothing: privileges
 	// are granted in acl.yaml, never inferred from task config.

--- a/internal/scheduler/principal_test.go
+++ b/internal/scheduler/principal_test.go
@@ -20,8 +20,10 @@ func TestStampTaskAuditContext(t *testing.T) {
 	if p.Tool != principal.ToolScheduler {
 		t.Errorf("Principal.Tool = %q, want %q", p.Tool, principal.ToolScheduler)
 	}
-	if p.User != "alice" {
-		t.Errorf("Principal.User = %q, want 'alice'", p.User)
+	// The identity is the fixed system principal, NOT $USER — even though
+	// $USER is set here. See runas_test.go for why.
+	if p.User != principal.UserScheduler {
+		t.Errorf("Principal.User = %q, want %q", p.User, principal.UserScheduler)
 	}
 
 	if got := audit.TriggeredByFrom(stamped); got != "schedule:nightly-rollup" {

--- a/internal/scheduler/runas_test.go
+++ b/internal/scheduler/runas_test.go
@@ -31,14 +31,42 @@ func TestStampTaskAuditContext_RunAsOverridesIdentity(t *testing.T) {
 	}
 }
 
-func TestStampTaskAuditContext_EmptyRunAsKeepsSystemUser(t *testing.T) {
+// TestStampTaskAuditContext_EmptyRunAsIsFixedIdentity pins the default
+// identity to a FIXED constant rather than the OS user (RR-1USMEZ).
+//
+// The scheduler used to default to principal.SystemUser() ($USER). That
+// made the acl.yaml assignment an operator needed depend on which account
+// ran `rela scheduler`, so the grant could not be written down in advance
+// — it differed per host, and a migration could not compute it.
+//
+// $USER is deliberately set to a decoy here: if the default ever reverts
+// to the OS user, this fails.
+func TestStampTaskAuditContext_EmptyRunAsIsFixedIdentity(t *testing.T) {
 	t.Setenv("USER", "operator")
 
 	ctx := stampTaskAuditContext(context.Background(), "nightly", "")
 
-	// Non-regressing: tasks without run_as keep today's shared scheduler
-	// identity, so existing deployments behave exactly as before.
-	if got, want := principal.From(ctx).User, principal.SystemUser(); got != want {
-		t.Errorf("Principal.User = %q, want the default system user %q", got, want)
+	if got := principal.From(ctx).User; got != principal.UserScheduler {
+		t.Errorf("Principal.User = %q, want the fixed %q (not $USER)", got, principal.UserScheduler)
+	}
+}
+
+// TestStampTaskAuditContext_NoUserEnvStillStamped covers the deployment
+// that motivated the fixed identity: a systemd unit typically has no
+// $USER, so SystemUser() returned the literal "unknown" — which
+// acl.Declarative.ForPrincipal REJECTS as an unstamped principal
+// (ErrUnstampedPrincipal). Scheduled tasks then failed outright rather
+// than merely being scoped. The fixed identity is never "unknown".
+func TestStampTaskAuditContext_NoUserEnvStillStamped(t *testing.T) {
+	t.Setenv("USER", "")
+
+	ctx := stampTaskAuditContext(context.Background(), "nightly", "")
+
+	p := principal.From(ctx)
+	if p.User != principal.UserScheduler {
+		t.Errorf("Principal.User = %q, want %q", p.User, principal.UserScheduler)
+	}
+	if p.User == "unknown" || p.User == "" {
+		t.Error("principal is unstamped; acl.ForPrincipal would reject it")
 	}
 }

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -92,16 +92,20 @@ func StartBackground(
 //
 // The stamped principal is ALSO what the script's reads resolve against
 // (DEC-O59WM4) — the scheduler's identity is the one thing that decides
-// what a job can see, via acl.yaml. runAs overrides the default system
-// user, giving a job its own identity for both audit and read scope; empty
-// keeps today's shared scheduler identity.
+// what a job can see, via acl.yaml. runAs overrides the default, giving a
+// job its own identity for both audit and read scope.
+//
+// The default is the FIXED [principal.UserScheduler], not the OS user: a
+// grantable constant an operator can write into acl.yaml once, rather than
+// a per-host value that is "unknown" under systemd (which acl rejects as
+// unstamped). See that constant's godoc.
 //
 // Extracted so the stamping logic can be unit-tested without booting
 // the script engine.
 func stampTaskAuditContext(ctx context.Context, taskName, runAs string) context.Context {
 	user := runAs
 	if user == "" {
-		user = principal.SystemUser()
+		user = principal.UserScheduler
 	}
 	out := principal.With(ctx, principal.Principal{
 		User: user,

--- a/internal/scheduler/schedulerid_acl_test.go
+++ b/internal/scheduler/schedulerid_acl_test.go
@@ -1,0 +1,142 @@
+package scheduler_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/Sourcehaven-BV/rela/internal/acl"
+	"github.com/Sourcehaven-BV/rela/internal/entity"
+	"github.com/Sourcehaven-BV/rela/internal/principal"
+	"github.com/Sourcehaven-BV/rela/internal/store"
+	"github.com/Sourcehaven-BV/rela/internal/store/memstore"
+	"github.com/Sourcehaven-BV/rela/internal/visibility"
+)
+
+// RR-1USMEZ: the scheduler's default identity must be a FIXED, grantable
+// principal. These tests assert the property that makes the acl.yaml grant
+// possible at all — that an operator can write one assignment line, ahead
+// of time, without knowing which OS account will run the scheduler.
+//
+// They go through the real acl.Declarative + visibility stack over a
+// memstore, so they fail if either the identity or the gate regresses.
+
+// schedulerReader wires the ACL-bound read handle a scheduled task gets,
+// under the given policy.
+func schedulerReader(t *testing.T, policyYAML string) *visibility.ScriptReader {
+	t.Helper()
+	ctx := context.Background()
+	st := memstore.New()
+	if err := st.CreateEntity(ctx, &entity.Entity{
+		ID: "TKT-1", Type: "ticket", Properties: map[string]any{"title": "Nightly"},
+	}); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	var policy acl.Policy
+	if err := yaml.Unmarshal([]byte(policyYAML), &policy); err != nil {
+		t.Fatalf("unmarshal policy: %v", err)
+	}
+	d, err := acl.NewDeclarative(&policy, acl.NewStoreGraph(st), st)
+	if err != nil {
+		t.Fatalf("NewDeclarative: %v", err)
+	}
+	gate, err := visibility.NewDeclarativeGate(d)
+	if err != nil {
+		t.Fatalf("NewDeclarativeGate: %v", err)
+	}
+	reader, err := visibility.NewPolicyReader(gate, visibility.NopRedactor{}, st)
+	if err != nil {
+		t.Fatalf("NewPolicyReader: %v", err)
+	}
+	sr, err := visibility.NewScriptReader(reader, st, gate)
+	if err != nil {
+		t.Fatalf("NewScriptReader: %v", err)
+	}
+	return sr
+}
+
+// schedulerCtx is the context a task with no `run_as` runs under.
+func schedulerCtx() context.Context {
+	return principal.With(context.Background(), principal.Principal{
+		User: principal.UserScheduler,
+		Tool: principal.ToolScheduler,
+	})
+}
+
+// TestSchedulerIdentity_GrantedPrincipalReads is the payoff: an operator
+// grants the documented constant, and scheduled tasks read again. This is
+// the assignment a migration can safely write, because the key is fixed.
+func TestSchedulerIdentity_GrantedPrincipalReads(t *testing.T) {
+	const granted = `
+roles:
+  scheduler-system:
+    read: ["*"]
+assignments:
+  system:scheduler: scheduler-system
+`
+	sr := schedulerReader(t, granted)
+
+	got, err := sr.GetEntity(schedulerCtx(), "TKT-1")
+	if err != nil {
+		t.Fatalf("granted scheduler read failed: %v", err)
+	}
+	if got.ID != "TKT-1" {
+		t.Errorf("read %q, want TKT-1", got.ID)
+	}
+}
+
+// TestSchedulerIdentity_UngrantedPrincipalReadsNothing pins the other half:
+// the identity grants nothing by itself (DEC-O59WM4). A policy that never
+// assigns the scheduler a role leaves its tasks reading nothing — the
+// regression this arc exists to make visible and fixable.
+func TestSchedulerIdentity_UngrantedPrincipalReadsNothing(t *testing.T) {
+	const ungranted = `
+roles:
+  viewer:
+    read: [ticket]
+assignments:
+  alice: viewer
+`
+	sr := schedulerReader(t, ungranted)
+
+	_, err := sr.GetEntity(schedulerCtx(), "TKT-1")
+	if !errors.Is(err, store.ErrNotFound) {
+		t.Errorf("ungranted scheduler read err = %v, want ErrNotFound", err)
+	}
+}
+
+// TestSchedulerIdentity_IsAcceptedByACL guards the systemd failure mode.
+// The old default was principal.SystemUser(), which returns the literal
+// "unknown" when $USER is unset — and acl rejects that as an unstamped
+// principal, so tasks failed outright rather than being scoped. The fixed
+// identity must always be a principal acl will open a Request for.
+func TestSchedulerIdentity_IsAcceptedByACL(t *testing.T) {
+	t.Setenv("USER", "") // systemd-style: no $USER
+
+	var policy acl.Policy
+	if err := yaml.Unmarshal([]byte("roles:\n  r:\n    read: [ticket]\n"), &policy); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	st := memstore.New()
+	d, err := acl.NewDeclarative(&policy, acl.NewStoreGraph(st), st)
+	if err != nil {
+		t.Fatalf("NewDeclarative: %v", err)
+	}
+
+	if _, err := d.ForPrincipal(principal.Principal{
+		User: principal.UserScheduler, Tool: principal.ToolScheduler,
+	}); err != nil {
+		t.Errorf("acl rejected the scheduler identity: %v", err)
+	}
+
+	// Contrast: the value the OLD default produced under systemd.
+	if _, err := d.ForPrincipal(principal.Principal{
+		User: principal.SystemUser(), Tool: principal.ToolScheduler,
+	}); err == nil {
+		t.Error("expected the old $USER-derived 'unknown' principal to be rejected; " +
+			"if this now passes, the unstamped guard changed and this test's premise is stale")
+	}
+}

--- a/tickets/entities/docs-checklists/DOCS-8608HC.md
+++ b/tickets/entities/docs-checklists/DOCS-8608HC.md
@@ -1,0 +1,52 @@
+---
+id: DOCS-8608HC
+type: docs-checklist
+title: 'Docs: fixed scheduler identity + acl.yaml scheduler grant migration'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Code Documentation
+
+- [x] Godoc on new exported symbols — `principal.UserScheduler`, `migration.FileTypeACL`, `migration.SchedulerPrincipal`, `migration.EnsureMapping`, `migration.SetMapNode`, `ACLSchedulerGrantMigration`
+- [x] Non-obvious decisions explained at the point of the code
+
+Notably: `EnsureMapping`'s godoc states *why* it exists (null scalar vs empty
+mapping, and the `InsertMapKeyAfter` no-op that made it a silent footgun), since
+that is the trap the next migration author would otherwise step in.
+`SchedulerPrincipal` records why the literal is duplicated rather than imported
+(arch-lint restricts `internal/migration` to `[storage]`).
+
+## Project Documentation
+
+- [x] User-facing docs updated
+- [x] Generated docs regenerated from source entities
+
+`docs-project/entities/guides/GUIDE-scheduled-tasks.md` (SOURCE — `docs/*.md`
+are generated and carry a "do not edit directly" banner):
+
+1. The `run_as` section now names the actual default identity (`system:scheduler`,
+fixed, independent of the OS account) instead of the vague "the scheduler's
+system user".
+2. New subsection "If your project has an `acl.yaml`, grant the scheduler" —
+states the silent-failure symptom, shows the grant, points at `rela migrate`,
+and tells operators to narrow it. Explicitly says policy-less projects need do
+nothing.
+3. Audit-log section notes that `principal.user` is now the task identity and
+that pre-upgrade records carry the OS account.
+
+Regenerated via `just docs`; the pre-push docs-freshness gate passes.
+
+- [x] ~~README~~ (N/A: no new top-level capability)
+- [x] ~~CLAUDE.md~~ (N/A: no new architectural rule — this follows the existing migration pattern)
+
+## External Documentation
+
+- [x] ~~API docs~~ (N/A: no HTTP API surface changed)
+- [x] Migration notes — the migration's `Description()` is the operator-visible
+string and names the symptom, not just the mechanic: "Grant the scheduler
+identity read access in acl.yaml (without it, scheduled tasks silently read
+nothing)"
+- [x] Breaking change documented — audit attribution for scheduled writes
+changes from the OS account to `system:scheduler`

--- a/tickets/entities/implementation-checklists/IMPL-UC0AQW.md
+++ b/tickets/entities/implementation-checklists/IMPL-UC0AQW.md
@@ -1,0 +1,63 @@
+---
+id: IMPL-UC0AQW
+type: implementation-checklist
+title: 'Implementation: acl: migrate a scheduler read grant into an existing acl.yaml (new FileTypeACL)'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Development
+
+- [x] Code implements the planned approach
+- [x] Follows existing patterns (yaml.Node transform migration registered via `init()`, matching `short_id_default.go`)
+- [x] No unplanned scope added
+- [x] Edge cases handled
+
+**Delivered:**
+
+1. `principal.UserScheduler = "system:scheduler"` — fixed default identity for tasks with no `run_as`, replacing `principal.SystemUser()` (`$USER`).
+2. `migration.FileTypeACL` + `acl-scheduler-grant` migration, wired into `projectsetup.getMigrateFiles`.
+3. `migration.EnsureMapping` / `SetMapNode` in `yaml_util.go` — shared helpers, added while fixing RR-KG2FCX.
+4. Docs: `docs-project/entities/guides/GUIDE-scheduled-tasks.md` (source) → regenerated `docs/scheduled-tasks.md`.
+
+**Deliberately out of scope:** creating `acl.yaml` when absent (RR-SVQ5HE).
+
+## Quality
+
+- [x] `just lint` — 0 issues
+- [x] `just arch-lint` — OK, no warnings
+- [x] `just plimsoll` — clean
+- [x] Tests written and passing
+- [x] Coverage within floors (migration 84.1%, projectsetup 72.0%, scheduler 78.0%, principal 97.1%; default floor 50)
+- [x] `just docs` regenerated; pre-push docs check passes
+
+Only failing tests in the tree are the five `internal/docscapture` browser
+tests, verified failing identically on a clean `develop` checkout (they need
+Chrome + a built SPA).
+
+## Verification
+
+- [x] Behavior verified against acceptance criteria
+- [x] Mutation-tested rather than assumed
+
+**Mutation testing** (production code mutated, not fixtures — the failure mode
+from earlier in this arc):
+
+| Mutation | Result |
+|---|---|
+| Scheduler default reverted to `SystemUser()` | 3 tests fail |
+| `acl.yaml` unwired from migrate file list | 2 tests fail |
+| `EnsureMapping` stops repairing null in place | 6 subtests fail |
+| `Detect` reverted to bare key-existence check | 5 tests fail |
+| Dead-role repair removed | 2 tests fail |
+| `Apply` postcondition removed | 1 test fails |
+
+The postcondition was initially UNGUARDED — the first mutation run passed clean,
+and a test was added specifically for it.
+
+**Probes run before implementing** (recorded because they overturned the
+ticket's premise):
+
+- `scriptEntityReader(st, nil, nil).GetEntity` succeeds → policy-less projects have no regression.
+- `stampTaskAuditContext(ctx, "nightly", "")` → `"deploy-bot"` (i.e. `$USER`), and `"unknown"` when `$USER` is unset.

--- a/tickets/entities/planning-checklists/PLAN-G7L1X0.md
+++ b/tickets/entities/planning-checklists/PLAN-G7L1X0.md
@@ -1,0 +1,165 @@
+---
+id: PLAN-G7L1X0
+type: planning-checklist
+title: 'Planning: acl: migrate a scheduler read grant into acl.yaml (new FileTypeACL + runner create-path + operator notice)'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Understanding
+
+- [x] Problem/requirements clearly understood
+- [x] Scope defined (what's in/out documented below)
+- [x] Acceptance criteria documented with specific test scenarios
+
+**Premise correction (verified before planning):** reads ALREADY fail closed —
+`acl.readQuery` returns `DenyAll` when no role confers read
+(`readquery.go:49-50`). So this ticket **repairs a regression we shipped in
+TKT-ZF2DTV**, it does not harden a default. Any deployment that has an
+`acl.yaml` and runs scheduled tasks has had those tasks silently reading nothing
+since it merged.
+
+**Scope correction (RR-SVQ5HE, accepted 2026-07-25):** the create-when-absent
+path is **dropped**. Verified by probe that `scriptEntityReader` returns the raw
+store when no policy exists (`appbuild.go:254`, `if d == nil { return st }`) —
+so a project without `acl.yaml` has **no regression to repair**, while creating
+one would flip *every* principal to deny-by-default. Net-harmful; removed.
+
+**Scope:**
+
+IN: `migration.FileTypeACL`; a migration adding a scheduler read grant to an
+**existing** `acl.yaml`; wiring that file type into the migrate file list; an
+operator-visible description naming the symptom; tests.
+
+OUT: **creating `acl.yaml` when absent** (RR-SVQ5HE); per-job role authoring UX;
+changing `run_as` semantics; the data-entry fail-open fallback (rela#1198); the
+NopACL branches (`d == nil` → raw store is correct parity, not a bypass).
+
+**Acceptance Criteria:**
+
+1. An `acl.yaml` lacking a scheduler assignment gets the grant added; the rest of the file — comments and formatting included — is preserved.
+2. An `acl.yaml` that already has the assignment is left untouched (`Detect` false, idempotent).
+3. A project with **no** `acl.yaml` is left alone — no file created, no error, no notice. It is already correct.
+4. A malformed `acl.yaml` fails the migration without clobbering the file.
+5. The migrated policy passes `acl.Policy.Validate` / `LoadPolicy` — a broken generated file would block boot (`appbuild.go:551`).
+6. Post-migration, a scheduled task under `system:scheduler` reads again; a task under an unassigned `run_as` still reads nothing.
+
+## Research
+
+- [x] Full survey of the migration framework, runner, callers, acl.yaml loading and validation taken before planning
+- [x] Existing patterns identified and will be followed
+- [x] Reference implementation read end-to-end (`short_id_default.go`)
+
+**Survey findings that shape the work:**
+
+1. **Migrations are `yaml.Node` transforms registered via `init()`** — one new file in `internal/migration/` with `Register(&…{})`. `Detect`/`Apply` take the *document* node; every migration starts with `GetDocumentRoot`. `InsertMapKeyAfter` is the only helper accepting a composite value node, which is what a `roles:`/`read:` subtree needs.
+2. **Skip-on-missing is now exactly right.** `projectsetup/migrate.go:64` and `:106` `continue` when `fs.Stat` fails. With AC3 dropped this is the *desired* behavior, not a blocker — a missing `acl.yaml` must stay missing. No change needed there; adding the file to `getMigrateFiles` is sufficient and safe.
+3. **`Description()` is the only operator-visible per-migration string** (printed at `cli/migrate.go:39`, `:71`). `migration.Result`/`MigrateFileResult` carry no notice field. Since the change is now narrow and non-destructive, `Description()` alone is adequate — no new plumbing.
+4. **`Policy.Validate` enforces `update ⊆ read` / `delete ⊆ read`** (`policy.go:576-593`) — satisfied here since the grant is read-only, but a policy that violates it hard-fails `LoadPolicy` and blocks boot, so it must be test-pinned.
+5. Exact shapes: `roles:` is `map[string]RoleDef`; `assignments:` is `map[string]string` (principal → **one** role name, scalar); `RoleDef.Read` is `[]string` with `"*"` wildcard.
+6. No production code has ever written `acl.yaml`, and `rela init` doesn't scaffold one. This migration edits only files an operator authored deliberately.
+
+## Approach
+
+- [x] Technical approach chosen and documented
+- [x] Approach builds on existing patterns (not reinventing)
+- [x] Alternatives considered (document why rejected)
+- [x] Dependencies identified
+
+**The grant** (read-only, so `Validate` passes):
+
+```yaml
+roles:
+  scheduler-system:
+    read: ["*"]
+assignments:
+  system:scheduler: scheduler-system
+```
+
+`read: ["*"]` restores the pre-TKT-ZF2DTV behavior exactly — scheduled tasks
+previously read the whole graph. Narrowing per-deployment is the operator's job,
+and `run_as` exists for that.
+
+**Migration** — new `internal/migration/acl_scheduler_grant.go`, registered via
+`init()`, `FileTypes: []FileType{FileTypeACL}`. `Detect` → true when
+`assignments` lacks a `system:scheduler` key. `Apply` → upsert the role and the
+assignment via `GetMapValue`/`InsertMapKeyAfter`, creating the
+`roles:`/`assignments:` mappings when absent *within an existing file*.
+Idempotent by construction (AC2).
+
+**Wiring** — add `FileTypeACL` to `migration.FileType` and an entry to
+`projectsetup.getMigrateFiles`. The existing skip-on-missing loop then gives AC3
+for free.
+
+**Operator notice** — `Description()` names the symptom, since it is the string
+that reaches the operator: *"add a scheduler read grant to acl.yaml — scheduled
+tasks read nothing without it"*.
+
+**Alternatives rejected:** creating the file when absent (RR-SVQ5HE — breaks
+every principal, repairs nothing); adding a create-path to `migration.Apply`
+(would let every migration conjure files; the package's contract is
+read-transform-write); writing the grant from `appbuild` at boot (silently
+mutating a security policy at runtime is worse than an explicit `rela migrate`).
+
+**Files:** `internal/migration/{migration.go (FileTypeACL),
+acl_scheduler_grant.go (new), acl_scheduler_grant_test.go (new)}`;
+`internal/projectsetup/migrate.go` (file list only);
+`docs-project/entities/guides/` for the operator note.
+
+## Security Considerations
+
+- [x] Input sources identified — operator-run command against project-local files; no external input
+- [x] Validation approach — migrated policy must pass `Policy.Validate`, pinned by a `LoadPolicy` round-trip test
+- [x] Security-sensitive operations identified
+- [x] Error handling doesn't leak
+
+- **The dominant risk was the create-path; it has been removed** (RR-SVQ5HE). What remains only edits files an operator wrote deliberately, and only widens one system identity's reads back to what they were before the regression.
+- **The grant is a privilege grant** and must therefore be minimal in kind: `read: ["*"]` with **no write verbs**. A scheduled task's writes keep going through entitymanager's own ACL.
+- **A malformed existing file fails without clobbering** (AC4) — the runner's encode/write runs only after a successful parse.
+- **A generated file that fails `Validate` would block boot** — pinned by test (AC5).
+- No secret material is read or written.
+
+## Test Plan
+
+- [x] Scenarios per AC; [x] edge cases; [x] negative tests; [x] integration approach
+
+Following the package's established style (inline YAML string literals, no
+fixtures dir):
+
+- **Detect table**: no assignments block / assignments without the key / key already present (false) / empty file.
+- **Apply table**: assert on the mutated node tree, then re-assert `Detect(&doc) == false` for idempotence (the package's own convention).
+- **Comment preservation**: `yaml.Marshal(&doc)` + `strings.Contains` on a comment and on the new keys — the `id_prefix_rename_test.go` pattern.
+- **Validity**: feed migrated YAML to `acl.LoadPolicy` and assert it parses and validates (AC5 — the check that prevents shipping a boot-blocking file).
+- **Runner integration**: real temp file via `storage.NewOsFS()`, `Apply`, read back, `strings.Contains`.
+- **Absent file** (AC3): `projectsetup.MigrateWithFS` on a project with no `acl.yaml` → no file created, no error.
+- **Negative**: malformed YAML → error, original bytes unchanged on disk.
+- **End-to-end** (AC6): scheduled task with the grant reads; with an unassigned `run_as`, reads nothing.
+
+## Risk Assessment
+
+- [x] Risks + mitigations; [x] security risks; [x] effort (s — reduced from m after RR-SVQ5HE)
+
+- **Widening `system:scheduler` to `read: ["*"]`** — restores prior behavior exactly; the alternative (guessing a narrower set) would silently break working jobs.
+- **Generated file blocks boot** if it fails `Validate` — mitigated by the `LoadPolicy` round-trip test.
+- **An operator who deliberately removed the scheduler assignment** would have it re-added by `Detect`. Acceptable: `run_as` is the supported way to scope a task, and the migration runs once.
+- No changes to `internal/migration`'s contract or to the runner; `projectsetup` gains one list entry.
+
+## Documentation Planning
+
+- [x] User-facing docs identified
+- [x] Docs-checklist will be created at review
+
+**Impact:** `docs-project/entities/guides/` scheduled-tasks guide (why a
+policy-configured project needs the grant, beside the existing `run_as` section;
+and that policy-less projects need do nothing) → regenerates
+`docs/scheduled-tasks.md`. Note: `docs/*.md` are GENERATED — edit the source
+entities.
+
+## Design Review
+
+- [x] Run `/design-review` before starting implementation
+- [x] All critical/significant findings addressed in plan
+
+**Design Review Findings:** RR-SVQ5HE (critical, addressed — create-path
+dropped)

--- a/tickets/entities/review-checklists/REV-LY0JXC.md
+++ b/tickets/entities/review-checklists/REV-LY0JXC.md
@@ -1,0 +1,76 @@
+---
+id: REV-LY0JXC
+type: review-checklist
+title: 'Review: acl: migrate a scheduler read grant into an existing acl.yaml (new FileTypeACL)'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Automated Checks
+
+- [x] `just lint` — 0 issues
+- [x] `just arch-lint` — OK, no warnings
+- [x] `just plimsoll` — clean
+- [x] Tests pass
+- [x] Coverage within floors
+- [x] `just docs` regenerated and committed
+
+The five `internal/docscapture` browser tests fail in this environment; verified
+failing identically on a clean `develop` checkout (they need Chrome + a built
+SPA), so they are pre-existing and unrelated.
+
+## Code Review
+
+- [x] `/code-review` run (cranky-code-reviewer)
+- [x] All critical findings addressed
+- [x] All significant findings addressed
+
+**Findings:**
+
+| ID | Severity | Status |
+|---|---|---|
+| RR-KG2FCX | critical | addressed |
+| RR-2ZIGX3 | significant | addressed |
+
+The reviewer drove the real `Detect`/`Apply` through the real `acl.Policy`
+loader rather than reading the code, and found two shapes where the migration
+reported success while granting nothing (`roles:` / `assignments:` present but
+null). Both were reproduced locally before fixing and re-verified after.
+
+Two earlier design-review findings (RR-SVQ5HE, RR-1USMEZ) were raised and
+resolved during planning — both reversed decisions in the original ticket, and
+both were confirmed by probe rather than argument.
+
+## Verification
+
+- [x] Acceptance criteria met
+- [x] Manual verification performed
+- [x] No regressions introduced
+
+**Mutation testing** — every fix is independently guarded:
+
+| Mutation | Tests failing |
+|---|---|
+| Scheduler default reverted to `SystemUser()` | 3 |
+| `acl.yaml` unwired from migrate file list | 2 |
+| `EnsureMapping` stops repairing null in place | 6 subtests |
+| `Detect` reverted to bare key-existence | 5 |
+| Dead-role repair removed | 2 |
+| `Apply` postcondition removed | 1 |
+
+The postcondition mutation initially SURVIVED — the guard was added only after
+that run showed the test suite could not detect its removal.
+
+## PR
+
+- [x] PR created: https://github.com/sourcehaven-bv/rela/pull/1203
+- [x] CI monitored
+
+## Sign-off
+
+- [x] Ready to merge
+
+Behaviour change flagged for release notes: scheduled writes now record
+`principal.user: "system:scheduler"` instead of the OS account that started the
+scheduler. Documented in the scheduled-tasks guide.

--- a/tickets/entities/review-responses/RR-1USMEZ.md
+++ b/tickets/entities/review-responses/RR-1USMEZ.md
@@ -1,0 +1,88 @@
+---
+id: RR-1USMEZ
+type: review-response
+title: The grant target 'system:scheduler' is not the principal scheduled tasks actually run as
+finding: |-
+    The ticket (and my plan) specified writing `assignments: {system:scheduler: scheduler-system}`. That principal DOES NOT EXIST at runtime, so the migration as specified would be a silent no-op: it would appear to repair the regression while changing nothing.
+
+    Verified by probe on internal/scheduler.stampTaskAuditContext:
+
+        run_as EMPTY  -> Principal.User = "deploy-bot"   (i.e. $USER)
+        run_as SET    -> Principal.User = "system:digest"
+
+    scheduler.go:102-105 is explicit:
+
+        user := runAs
+        if user == "" {
+            user = principal.SystemUser()
+        }
+
+    and principal.SystemUser() (principal.go:299) returns `strings.TrimSpace(os.Getenv("USER"))`, or "unknown" when unset.
+
+    So the identity a scheduled task resolves reads against is:
+    - the value of `run_as` when set — operator-chosen, arbitrary, unknowable to a migration; or
+    - the OS username of whatever account runs `rela scheduler` — host-dependent, also unknowable at migration time, and DIFFERENT on each deployment (root / rela / deploy-bot / a developer's own login).
+
+    There is no fixed system principal to grant to. A static migration fundamentally cannot compute the right assignment key. Worse, guessing "unknown" (the $USER-unset fallback) would grant read:[*] to a catch-all identity that any misconfigured process could land on — a security regression, not a fix.
+
+    This also means the regression is WIDER than the ticket describes: on a deployment with an acl.yaml, the scheduler runs as $USER, so whether jobs still work is decided by whether that OS username happens to be assigned a role — which is accidental.
+
+    Recommendation: a YAML migration is the wrong instrument. See the resolution for the alternatives.
+severity: critical
+resolution: |-
+    User decision (2026-07-25): give the scheduler a REAL FIXED IDENTITY first, then the migration becomes correct.
+
+    The scheduler default changes from principal.SystemUser() ($USER, host-dependent) to a stable literal system principal. Once the default identity is fixed and knowable, a static migration CAN grant it — which restores the original ticket design on a sound footing.
+
+    Sequencing: the identity change is a prerequisite, so it lands first (this ticket, or a split). The acl.yaml grant migration follows once there is a fixed principal to grant to. Rejected alternatives: aclaudit-only detection (reports the symptom, leaves the broken default in place); docs-only (leaves a silent failure mode).
+
+    Note the identity change alters audit-log attribution for scheduled writes on every existing deployment (from the OS username to the system principal), which needs calling out in the changelog and docs.
+status: addressed
+---
+
+## Evidence
+
+`internal/scheduler/scheduler.go:101-111`:
+
+```go
+func stampTaskAuditContext(ctx context.Context, taskName, runAs string) context.Context {
+	user := runAs
+	if user == "" {
+		user = principal.SystemUser()   // <- $USER, not "system:scheduler"
+	}
+	out := principal.With(ctx, principal.Principal{
+		User: user,
+		Tool: principal.ToolScheduler,
+	})
+```
+
+`internal/principal/principal.go:299`:
+
+```go
+func SystemUser() string {
+	u := strings.TrimSpace(os.Getenv("USER"))
+	if u == "" {
+		return "unknown"
+	}
+	return u
+}
+```
+
+Probe output:
+
+```text
+run_as EMPTY  -> Principal.User = "deploy-bot" (Tool="scheduler")
+run_as SET     -> Principal.User = "system:digest"
+```
+
+## Why a migration can't fix this
+
+The assignment key is either operator-chosen (`run_as`) or host-dependent
+(`$USER`). Both are unknown to a static YAML transform. Granting
+`system:scheduler` writes a grant that matches no principal; granting `unknown`
+creates a catch-all privilege.
+
+The one durable, migration-visible fact is `Principal.Tool == "scheduler"`
+(`principal.ToolScheduler`) — but `acl.Policy.Assignments` is keyed on **User**,
+not Tool, so today's policy language cannot express "any task run by the
+scheduler."

--- a/tickets/entities/review-responses/RR-2ZIGX3.md
+++ b/tickets/entities/review-responses/RR-2ZIGX3.md
@@ -1,0 +1,21 @@
+---
+id: RR-2ZIGX3
+type: review-response
+title: Detect checked assignment existence, not whether the scheduler could actually read
+finding: |-
+    Detect's predicate was `does an assignments key for the scheduler exist`. That goes quiet on three states where the scheduler still reads nothing:
+
+    1. The assignment names an UNDEFINED role (the dangling case produced by the null-roles bug).
+    2. The assigned role EXISTS but grants no read (`scheduler-system: {}`, or a write-only role). The old ensureRole guard was `GetMapValue(roles, name) != nil` — mere existence, not usefulness — so it deferred to an operator role that granted nothing, relocating the bug rather than fixing it. The original RespectsOperatorRole test happened to use `read: [ticket]`, the one variant where deferring is correct.
+    3. asserted_role_assignments was never consulted, so an operator who had ALREADY scoped the scheduler there got a redundant read:["*"] role piled on top of their deliberately narrower grant — a silent widening. The Detect godoc claimed such operators were "left alone", which was false for that path.
+severity: significant
+resolution: |-
+    Detect now asks the real question via a shared schedulerCanRead(root) predicate: is the scheduler bound to a role that EXISTS and lists at least one read target? It consults both assignments (principal->role) and asserted_role_assignments (principal->RoleList, scalar-or-sequence).
+
+    ensureRole/ensureAssignment now repair a dead role instead of binding to it, while KEEPING the operator's role name and definition (only adding a read list where there was none). An existing operator assignment is never repointed.
+
+    Apply asserts schedulerCanRead as a POSTCONDITION and returns an error when unmet — the runner then stops before writing, so a policy it cannot fix leaves the operator's file untouched with a loud, actionable error instead of a silent false success.
+
+    Mutation-tested: reverting Detect to the bare key check fails 5 tests; removing the dead-role repair fails 2; removing the postcondition fails 1 (a test was added specifically for it, since the postcondition was initially unguarded).
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-KG2FCX.md
+++ b/tickets/entities/review-responses/RR-KG2FCX.md
@@ -1,0 +1,23 @@
+---
+id: RR-KG2FCX
+type: review-response
+title: 'Null roles:/assignments: blocks made the migration a silent no-op'
+finding: |-
+    `key:` with nothing under it parses as a NULL SCALAR, not an empty mapping. Both ensureRole and ensureAssignment detected the wrong Kind, built a replacement mapping, and handed it to InsertMapKeyAfter — which no-ops when the key already exists (yaml_util.go:193-197). The freshly-built mapping was dropped.
+
+    Two distinct failures, both reproduced before fixing:
+
+    1. `roles:` null -> the assignment was written naming a role that was never defined. Detect (which only checked assignment-key existence) then returned FALSE, so the migration reported success and never retried. Policy.Validate does not reject a dangling role reference, so nothing downstream caught it. Operator sees success; tasks still read nothing.
+
+    2. `assignments:` null -> the role was added but NO assignment was ever written, and Detect stayed TRUE forever. Every subsequent `rela migrate` re-detected, re-applied and re-wrote the file — a migration that never converges and never fixes anything.
+
+    This is not an exotic input: it is what a commented-out block or half-written policy produces, and acl.Policy accepts it.
+severity: critical
+resolution: |-
+    Root-caused to InsertMapKeyAfter being the wrong tool for "replace a non-mapping value". Added a shared migration.EnsureMapping(node, anchor, key) helper in yaml_util.go that returns the existing mapping, repairs a null/scalar value IN PLACE (preserving document position and comments), or appends a new one. Both call sites now use it, and the helper is available to every future migration in the package — the footgun was generic, not specific to this migration.
+
+    Also added migration.SetMapNode for composite values (SetMapValue is scalar-only).
+
+    Guarded by mutation testing: reverting EnsureMapping to the old semantics fails 6 subtests. Test fixtures gained `roles null`, `assignments null` and `both null` cases in both ProducesLoadablePolicy and ApplyIsIdempotent (idempotency being precisely the property that broke).
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-SVQ5HE.md
+++ b/tickets/entities/review-responses/RR-SVQ5HE.md
@@ -1,0 +1,61 @@
+---
+id: RR-SVQ5HE
+type: review-response
+title: Creating acl.yaml where none exists causes a total access outage and repairs nothing
+finding: |-
+    AC3 (create acl.yaml when absent) is a net-harmful operation, verified by probe rather than inference.
+
+    1. A project WITHOUT acl.yaml HAS NO REGRESSION TO REPAIR. appbuild.scriptEntityReader:254 reads `if d == nil { return st }` — with no policy, aclDeclarative is nil and the scheduler receives the RAW STORE. Probe (scriptEntityReader(st, nil, nil).GetEntity) returns the entity successfully. Scheduled tasks in a policy-less project read everything today and always have. TKT-ZF2DTV broke only projects that HAVE an acl.yaml.
+
+    2. Creating the file flips the entire project to deny-by-default FOR EVERY PRINCIPAL. acl.readQuery:49-50 returns DenyAll whenever no role confers read on a type — this is keyed on the ROLE SET, not on who is asking. The generated file would assign only system:scheduler, so every human data-entry user, every CLI caller and every MCP agent loses all reads at once. internal/cli/acl_whocan.go:52 states the current contract to the operator verbatim: "No acl.yaml found; every principal has full access (no policy)."
+
+    3. Absence is a DOCUMENTED intentional state, not an oversight. appbuild.loadACLPolicy's godoc: "(nil, nil) when the file is genuinely missing ... no policy declared, no access control desired". `rela init` deliberately does not scaffold one, and no production code has ever written acl.yaml.
+
+    So the create-path takes projects that are working correctly, breaks them totally, and delivers no fix in exchange. The blast radius is every principal, and the trigger is an operator running an unrelated routine `rela migrate`.
+
+    Recommendation: drop AC3. Scope the migration to projects that already HAVE an acl.yaml (where the regression is real and the grant is a genuine repair). For policy-less projects, emit nothing — they are already correct.
+severity: critical
+resolution: 'Accepted by user (2026-07-25): the create-path is dropped. The migration now applies only to projects that already have an acl.yaml. AC3 removed from PLAN-G7L1X0; scope narrowed accordingly (no FileTypeACL create-path in the runner, no projectsetup seeding, no change to the fs.Stat skip-on-missing behavior — that skip is now CORRECT for this migration, since a missing acl.yaml should be left missing). Docs will instead tell operators of policy-less projects that they need do nothing.'
+status: addressed
+---
+
+## Finding
+
+The user chose "also create it when absent" **before** two facts were
+established: (a) the premise correction that reads already fail closed, and (b)
+the blast radius below. Both were discovered during planning survey.
+
+## Evidence
+
+**No-policy projects have no regression** — `internal/appbuild/appbuild.go:254`:
+
+```go
+func scriptEntityReader(st store.Store, d *acl.Declarative, ...) lua.EntityReader {
+	if d == nil {
+		return st   // raw store — NopACL parity
+	}
+```
+
+Probe result:
+
+```text
+NO-POLICY project: scheduled read OK -> TKT-1 (One)
+--- PASS
+```
+
+**Creating a policy denies everyone** — `internal/acl/readquery.go:49-50`:
+
+```go
+if len(conferring) == 0 {
+    return ReadQueryResult{DenyAll: true}
+}
+```
+
+`DenyAll` is reached on the role set, not the identity. A file granting only
+`system:scheduler` denies every other principal.
+
+## Recommendation
+
+Drop AC3; keep AC1/AC2/AC4/AC5/AC6. The migration then only touches projects
+with an existing `acl.yaml`, where the grant repairs a real shipped regression
+and the file's presence already means the operator opted into access control.

--- a/tickets/entities/tickets/TKT-76JP2A.md
+++ b/tickets/entities/tickets/TKT-76JP2A.md
@@ -1,57 +1,104 @@
 ---
 id: TKT-76JP2A
 type: ticket
-title: 'acl: migrate a scheduler read grant into acl.yaml (new FileTypeACL + runner create-path + operator notice)'
+title: 'acl: fixed scheduler identity + migrate a read grant into an existing acl.yaml'
 kind: enhancement
 priority: high
 effort: m
-status: backlog
+status: review
 ---
 
 ## Summary
 
 Split out of TKT-ZF2DTV (DEC-O59WM4). That ticket made Lua reads resolve against
-the acting identity; scheduled tasks resolve against `system:scheduler` (or
-their `run_as`). What it deliberately did NOT do is make reads **fail closed**,
-because doing so safely requires writing an explicit grant into existing
-deployments first.
+the acting identity; scheduled tasks resolve against the scheduler's identity
+(or their `run_as`).
 
-## The problem this closes
+Two defects were found while planning this, both verified against the merged
+code rather than assumed. They changed the shape of the work substantially.
 
-Today a deployment WITH an `acl.yaml` has no assignment for `system:scheduler`.
-Scheduled scripts still read everything only because the read path is permissive
-where no grant exists. That is fail-open, and it means the ACL-bound-LLM-job
-story ("a job role bounds what enters a prompt") isn't actually enforced yet —
-it's honoured by convention.
+## Correction 1: reads already fail closed
 
-Writing the grant explicitly lets the runtime flip to **fail closed**: an
-identity with no grants reads nothing, and the scheduler's reach becomes visible
-in the one place privileges live (inspectable via `rela acl who-can` and the
-effective-access map).
+The ticket was written assuming reads were fail-open where no grant existed,
+and that this ticket would flip them closed. **That was wrong.**
 
-## Scope
+- `acl.readQuery` returns `DenyAll` when no role confers read
+  (`internal/acl/readquery.go:49-50`).
+- Probe: an unassigned scheduler principal gets `store.ErrNotFound` for an
+  entity that exists.
 
-- New `migration.FileTypeACL` alongside `FileTypeMetamodel` / `FileTypeDataEntry`.
-- A migration writing the scheduler grant:
-  ```yaml
-  roles:
-    scheduler-system:
-      read: ["*"]
-  assignments:
-    system:scheduler: scheduler-system
-  ```
-- **Runner create-path.** `migration.Apply`/`Detect` currently read-then-mutate an existing file (`runner.go:98`, `:161`) and error on a missing one — they have no way to CREATE. Extend them, or add a sibling entry point, so a project without `acl.yaml` gets one.
-- **Operator notice (load-bearing).** Creating `acl.yaml` flips a project from `NopACL` (everything permitted for everyone) to declarative (deny-by-default for EVERY principal) — consequential far beyond the scheduler. This must be surfaced loudly, never silent. Consider a dry-run listing before writing.
-- **Then** flip script reads to fail closed and drop the permissive fallbacks in `appbuild.scriptEntityReader` / `dataentry.App.scriptReader` (they currently degrade to the raw store with a warning on construction failure — revisit whether that stays once grants are explicit).
-- Tests: migration on a project WITH an existing acl.yaml (grant added, file otherwise preserved — comments/formatting intact per the yaml.Node contract); WITHOUT one (created + notice emitted); malformed existing acl.yaml (fail, don't clobber); a scheduled task reading nothing when its identity has no grant.
+So this is **breaking-change repair, not hardening**. Any deployment with an
+`acl.yaml` that runs scheduled tasks has had those tasks silently reading
+nothing since TKT-ZF2DTV merged — silently, because a gated read is
+indistinguishable from missing data.
+
+## Correction 2: there was no fixed identity to grant to (RR-1USMEZ)
+
+The original plan was to write `assignments: {system:scheduler: ...}`. That
+principal **did not exist**. `stampTaskAuditContext` defaulted to
+`principal.SystemUser()` = `$USER`:
+
+```text
+run_as EMPTY  -> Principal.User = "deploy-bot"   ($USER)
+run_as SET    -> Principal.User = "system:digest"
+```
+
+The read identity was therefore either operator-chosen (`run_as`) or the OS
+account running `rela scheduler` — both unknowable to a static migration. Worse,
+a systemd unit typically has no `$USER`, so `SystemUser()` returned the literal
+`"unknown"`, which `acl.Declarative.ForPrincipal` **rejects** as an unstamped
+principal: those tasks failed outright rather than being scoped.
+
+A migration writing `system:scheduler` would have been a silent no-op.
+
+## What shipped
+
+1. **`principal.UserScheduler = "system:scheduler"`** — a fixed default identity
+   for tasks with no `run_as`, replacing `SystemUser()`. Makes the scheduler's
+   identity a documented, grantable constant instead of a per-host accident.
+2. **`migration.FileTypeACL` + `acl-scheduler-grant`** — adds the role and
+   assignment to an **existing** `acl.yaml`, preserving comments and formatting.
+3. **Docs** — the `run_as` section now states the default identity, tells
+   operators of policy-configured projects to grant it, and notes the audit
+   attribution change (scheduled writes now record `system:scheduler` rather
+   than the OS account).
+
+## Deliberately NOT done: creating `acl.yaml` (RR-SVQ5HE)
+
+The original instruction was to create the file when absent. Dropped after
+verifying it would be net-harmful:
+
+- A project with no `acl.yaml` **has no regression**. `scriptEntityReader`
+  returns the raw store when no policy exists (`appbuild.go:254`), confirmed by
+  probe — scheduled tasks there read everything and always have.
+- Creating a policy flips the project to deny-by-default **for every
+  principal**, since `readQuery` keys on the role set, not the identity. The
+  generated file grants only the scheduler, so every human, CLI and MCP caller
+  loses all reads at once.
+
+The migrate runner's skip-on-missing behavior enforces this, pinned by
+`TestMigrate_LeavesPolicylessProjectAlone`.
+
+## Review findings addressed
+
+- **RR-KG2FCX** (critical) — `roles:`/`assignments:` with nothing under them
+  parse as a null scalar, and `InsertMapKeyAfter` no-ops on an existing key, so
+  the migration reported success while granting nothing. Fixed with a shared
+  `EnsureMapping` helper that repairs a null value in place.
+- **RR-2ZIGX3** (significant) — `Detect` checked assignment-key existence rather
+  than whether the scheduler could actually read, going quiet on dangling and
+  read-less roles, and never consulting `asserted_role_assignments`. `Apply` now
+  verifies its own postcondition and errors instead of writing a file that
+  grants nothing.
 
 ## Non-goals
 
 Per-job role authoring UX. Changing what `run_as` means (it selects an identity;
-privileges stay in acl.yaml).
+privileges stay in `acl.yaml`). The data-entry fail-open fallback (rela#1198).
 
 ## References
 
-- `internal/migration/{migration.go:40 (FileType), runner.go:98,161}`
-- `internal/appbuild/appbuild.go` (scriptEntityReader), `internal/dataentry/app.go` (scriptReader)
-- DEC-O59WM4, TKT-ZF2DTV, PLAN-C3G1VO AC10
+- `internal/principal/principal.go` (`UserScheduler`)
+- `internal/migration/{acl_scheduler_grant.go, yaml_util.go}`
+- `internal/acl/readquery.go:49-50`
+- DEC-O59WM4, TKT-ZF2DTV

--- a/tickets/entities/tickets/TKT-76JP2A.md
+++ b/tickets/entities/tickets/TKT-76JP2A.md
@@ -5,7 +5,7 @@ title: 'acl: fixed scheduler identity + migrate a read grant into an existing ac
 kind: enhancement
 priority: high
 effort: m
-status: review
+status: done
 ---
 
 ## Summary

--- a/tickets/relations/TKT-76JP2A--has-docs--DOCS-8608HC.md
+++ b/tickets/relations/TKT-76JP2A--has-docs--DOCS-8608HC.md
@@ -1,0 +1,5 @@
+---
+from: TKT-76JP2A
+relation: has-docs
+to: DOCS-8608HC
+---

--- a/tickets/relations/TKT-76JP2A--has-implementation--IMPL-UC0AQW.md
+++ b/tickets/relations/TKT-76JP2A--has-implementation--IMPL-UC0AQW.md
@@ -1,0 +1,5 @@
+---
+from: TKT-76JP2A
+relation: has-implementation
+to: IMPL-UC0AQW
+---

--- a/tickets/relations/TKT-76JP2A--has-planning--PLAN-G7L1X0.md
+++ b/tickets/relations/TKT-76JP2A--has-planning--PLAN-G7L1X0.md
@@ -1,0 +1,5 @@
+---
+from: TKT-76JP2A
+relation: has-planning
+to: PLAN-G7L1X0
+---

--- a/tickets/relations/TKT-76JP2A--has-review--REV-LY0JXC.md
+++ b/tickets/relations/TKT-76JP2A--has-review--REV-LY0JXC.md
@@ -1,0 +1,5 @@
+---
+from: TKT-76JP2A
+relation: has-review
+to: REV-LY0JXC
+---

--- a/tickets/relations/TKT-76JP2A--has-review-response--RR-1USMEZ.md
+++ b/tickets/relations/TKT-76JP2A--has-review-response--RR-1USMEZ.md
@@ -1,0 +1,5 @@
+---
+from: TKT-76JP2A
+relation: has-review-response
+to: RR-1USMEZ
+---

--- a/tickets/relations/TKT-76JP2A--has-review-response--RR-2ZIGX3.md
+++ b/tickets/relations/TKT-76JP2A--has-review-response--RR-2ZIGX3.md
@@ -1,0 +1,5 @@
+---
+from: TKT-76JP2A
+relation: has-review-response
+to: RR-2ZIGX3
+---

--- a/tickets/relations/TKT-76JP2A--has-review-response--RR-KG2FCX.md
+++ b/tickets/relations/TKT-76JP2A--has-review-response--RR-KG2FCX.md
@@ -1,0 +1,5 @@
+---
+from: TKT-76JP2A
+relation: has-review-response
+to: RR-KG2FCX
+---

--- a/tickets/relations/TKT-76JP2A--has-review-response--RR-SVQ5HE.md
+++ b/tickets/relations/TKT-76JP2A--has-review-response--RR-SVQ5HE.md
@@ -1,0 +1,5 @@
+---
+from: TKT-76JP2A
+relation: has-review-response
+to: RR-SVQ5HE
+---


### PR DESCRIPTION
Scheduled tasks in any deployment with an `acl.yaml` have been silently reading **nothing** since #1197 made script reads ACL-bound. This repairs that. Two things had to change, because the obvious fix would not have worked.

## The scheduler had no grantable identity

The plan was to migrate `assignments: {system:scheduler: ...}` into `acl.yaml`. That principal did not exist. `stampTaskAuditContext` defaulted to `principal.SystemUser()`, i.e. `$USER`:

```text
run_as EMPTY  -> Principal.User = "deploy-bot"   ($USER)
run_as SET    -> Principal.User = "system:digest"
```

So a job's read scope depended on which OS account ran `rela scheduler` — unknowable to a static migration, and different per host. Worse, a systemd unit typically has no `$USER`, so `SystemUser()` returned the literal `"unknown"`, which `acl.Declarative.ForPrincipal` **rejects** as an unstamped principal: those tasks failed outright rather than being scoped.

A migration granting `system:scheduler` would have been a silent no-op. So commit 1 makes it real: `principal.UserScheduler`, a fixed default identity. It grants nothing by itself (DEC-O59WM4) — privileges still come only from `acl.yaml`, and `run_as` still overrides per task.

## The migration

New `migration.FileTypeACL` plus an `acl-scheduler-grant` migration that adds the role and assignment to an **existing** `acl.yaml`, preserving comments and formatting.

## It deliberately does NOT create `acl.yaml`

The original instruction was to create the file when absent. That turned out to be net-harmful and was dropped:

- A project with no `acl.yaml` **has no regression**. `scriptEntityReader` returns the raw store when no policy exists (`appbuild.go:254`) — verified by probe. Those tasks read everything and always have.
- Creating a policy flips the project to deny-by-default **for every principal**, because `readQuery` keys on the role set, not the identity. A file granting only the scheduler would strip reads from every human, CLI and MCP caller at once. `rela acl who-can` states the current contract plainly: *"No acl.yaml found; every principal has full access (no policy)."*

Pinned by `TestMigrate_LeavesPolicylessProjectAlone`.

## Review fixes (commit 3)

Code review caught the migration reporting success while granting nothing:

- **`key:` with nothing under it is a null scalar, not an empty mapping**, and `InsertMapKeyAfter` no-ops on an existing key — so a null `roles:` produced a *dangling* assignment naming an undefined role (and `Detect` then went quiet forever), while a null `assignments:` wrote no assignment at all and never converged. Fixed with a shared `EnsureMapping` helper in `yaml_util.go`, since that footgun is generic to every migration in the package.
- **`Detect` now asks whether the scheduler can actually read** — role exists *and* lists targets — instead of whether an assignment key exists. It also consults `asserted_role_assignments`, so an operator who already scoped the scheduler narrowly does not get a `read: ["*"]` role piled on top.
- **`Apply` verifies its own postcondition** and errors rather than writing a file that grants nothing. The runner stops before writing, so the operator's bytes survive.

## Behaviour change worth flagging

Scheduled writes now record `principal.user: "system:scheduler"` instead of the OS account. Documented in the scheduled-tasks guide next to `run_as`.

## Testing

- Unit + end-to-end through the real `acl.Declarative` + visibility stack: granted scheduler reads, ungranted reads nothing, and the identity is accepted where `"unknown"` was rejected.
- Migration covers null/dangling/read-less/asserted-role shapes, comment preservation, idempotence, and a `LoadPolicy` round-trip so a generated file can never block boot.
- **Mutation-tested**: reverting the scheduler default fails 3 tests; unwiring `acl.yaml` from the migrate list fails 2; reverting `EnsureMapping` fails 6 subtests; reverting `Detect` fails 5; removing the dead-role repair fails 2; removing the postcondition fails 1.

`just lint`, `just arch-lint`, `just plimsoll` clean. The only failing tests in the tree are the five `internal/docscapture` browser tests, which fail identically on a clean `develop` checkout (they need Chrome + a built SPA).

Closes TKT-76JP2A.