### PR TITLE
fix(acl): fail closed when the data-entry script read gate cannot be built (rela#1198)

### DIFF
--- a/docs-project/entities/guides/GUIDE-acl-security.md
+++ b/docs-project/entities/guides/GUIDE-acl-security.md
@@ -561,6 +561,22 @@ The `attachACLRequest` middleware:
   was a fail-open path — every read became AllowAll because the
   read handlers couldn't tell "no ACL" from "ACL but no
   principal."
+- **Refuses script reads when the read gate cannot be built.** If an
+  `acl.yaml` is configured but the visibility decorator fails to
+  construct, script runtimes (data-entry actions, `export_render`,
+  and the IdP webhook) receive a refusing reader rather than the raw
+  store: every read returns `read gate unavailable; refusing to read
+  ungated`, logged at ERROR at the wiring site. Degrading to ungated
+  reads would be an unbounded silent disclosure on the unattended
+  paths, where nobody is watching a warning. Note the asymmetry with
+  traversals: `trace_from`, `trace_to` and `find_path` cannot report
+  an error, so a refused traversal looks like an empty result to the
+  script — correlate with the ERROR log by timestamp when a script
+  reports an unexpectedly empty graph.
+
+A project with **no** `acl.yaml` is unaffected: that is a deliberate
+"no access control" configuration, not a fault, and scripts there read
+the full graph exactly as they always have.
 
 ## Property-level redaction (`visible:`)
 

--- a/docs/acl-security.md
+++ b/docs/acl-security.md
@@ -555,6 +555,22 @@ The `attachACLRequest` middleware:
   was a fail-open path — every read became AllowAll because the
   read handlers couldn't tell "no ACL" from "ACL but no
   principal."
+- **Refuses script reads when the read gate cannot be built.** If an
+  `acl.yaml` is configured but the visibility decorator fails to
+  construct, script runtimes (data-entry actions, `export_render`,
+  and the IdP webhook) receive a refusing reader rather than the raw
+  store: every read returns `read gate unavailable; refusing to read
+  ungated`, logged at ERROR at the wiring site. Degrading to ungated
+  reads would be an unbounded silent disclosure on the unattended
+  paths, where nobody is watching a warning. Note the asymmetry with
+  traversals: `trace_from`, `trace_to` and `find_path` cannot report
+  an error, so a refused traversal looks like an empty result to the
+  script — correlate with the ERROR log by timestamp when a script
+  reports an unexpectedly empty graph.
+
+A project with **no** `acl.yaml` is unaffected: that is a deliberate
+"no access control" configuration, not a fault, and scripts there read
+the full graph exactly as they always have.
 
 ## Property-level redaction (`visible:`)
 

--- a/internal/appbuild/appbuild.go
+++ b/internal/appbuild/appbuild.go
@@ -225,9 +225,10 @@ func (s *Services) LuaReadDeps() lua.ReadDeps {
 //
 // Falls back to unrestricted reads when no Declarative ACL is configured —
 // that is the NopACL path, byte-identical to pre-ACL behavior, not a
-// bypass. A construction failure is also unrestricted-with-a-warning
-// rather than silent denial: failing every script closed on a wiring error
-// would be a louder outage than the ACL is worth here, and it is logged.
+// bypass. A construction failure does NOT: it REFUSES, via
+// [visibility.DenyReader] / [visibility.DenyTracer] (RR-GKCZO5). See
+// [scriptEntityReader] for why an unattended path must not degrade to the
+// raw store.
 func (s *Services) luaReadDepsFor(redactor visibility.FieldRedactor) lua.ReadDeps {
 	deps := s.LuaReadDeps()
 	// WritePrepStore stays RAW on purpose — see lua.ReadDeps.WritePrepStore.

--- a/internal/dataentry/app.go
+++ b/internal/dataentry/app.go
@@ -322,9 +322,35 @@ func (a *App) luaWriteDeps() lua.WriteDeps {
 
 // scriptReader returns the ACL-bound read-out handle for script runtimes,
 // or the raw store when no Declarative policy is configured (the NopACL
-// path — byte-identical to pre-ACL behavior). A construction fault
-// degrades to the raw store with a warning rather than breaking every
-// script; a genuine DENY is still a deny.
+// path — byte-identical to pre-ACL behavior, not a bypass).
+//
+// When a policy IS configured but the gate cannot be built, this REFUSES
+// (returns [visibility.DenyReader]) rather than degrading to the raw store
+// — matching appbuild's unattended-path wiring (RR-GKCZO5, rela#1198).
+//
+// This wiring was fail-open on the theory that its callers are interactive,
+// so a broken gate would surface as an immediate, human-visible outage.
+// That does not hold: of the three consumers of [App.luaWriteDeps] —
+// actions.go (interactive), document.go/export_render, and webhook.go — the
+// IdP webhook is unattended machine-to-machine, running as `webhook:<event>`
+// with nobody watching the log. An unattended job quietly reverting to
+// full-graph reads is an unbounded silent disclosure into whatever it sends
+// onward — the exact failure DenyReader exists to stop.
+//
+// Failing closed costs the interactive callers nothing they were promised:
+// [visibility.ErrReaderUnavailable] is a loud, immediate, diagnosable error,
+// which is what the fail-open argument actually wanted — just without the
+// ungated read. A genuine DENY remains a deny, distinct from this error.
+//
+// DELIBERATE DIVERGENCE from appbuild: that seam substitutes
+// [visibility.NopRedactor] for a nil redactor, because its callers
+// (scheduler, cascades) legitimately have no affordance resolver and row
+// gating alone is the best available there (RR-7408F5). Data-entry always
+// has one, so a nil redactor here is a WIRING BUG, not a capability gap —
+// silently swapping in NopRedactor would drop field-level redaction on a
+// path that is supposed to enforce it. Do not "align" these by copying
+// appbuild's guard: it would convert a caught bug into a silent downgrade,
+// and delete the fault path failclosed_test.go exercises.
 func (a *App) scriptReader(redactor visibility.FieldRedactor) lua.EntityReader {
 	d, ok := a.acl.(*acl.Declarative)
 	if !ok || d == nil {
@@ -332,18 +358,18 @@ func (a *App) scriptReader(redactor visibility.FieldRedactor) lua.EntityReader {
 	}
 	gate, err := visibility.NewDeclarativeGate(d)
 	if err != nil {
-		slog.Warn("dataentry: ACL gate unavailable; script reads stay unrestricted", "err", err)
-		return a.store
+		slog.Error("dataentry: ACL gate unavailable; script reads REFUSED", "err", err)
+		return visibility.DenyReader{}
 	}
 	reader, err := visibility.NewPolicyReader(gate, redactor, a.store)
 	if err != nil {
-		slog.Warn("dataentry: policy reader unavailable; script reads stay unrestricted", "err", err)
-		return a.store
+		slog.Error("dataentry: policy reader unavailable; script reads REFUSED", "err", err)
+		return visibility.DenyReader{}
 	}
 	sr, err := visibility.NewScriptReader(reader, a.store, gate)
 	if err != nil {
-		slog.Warn("dataentry: script reader unavailable; script reads stay unrestricted", "err", err)
-		return a.store
+		slog.Error("dataentry: script reader unavailable; script reads REFUSED", "err", err)
+		return visibility.DenyReader{}
 	}
 	return sr
 }
@@ -351,6 +377,10 @@ func (a *App) scriptReader(redactor visibility.FieldRedactor) lua.EntityReader {
 // scriptTracer wraps the tracer in the visibility decorator when a
 // Declarative policy is configured. Trace bindings are unchanged either
 // way — pruning happens inside the decorator.
+//
+// Construction faults REFUSE ([visibility.DenyTracer]) for the same reason
+// as [App.scriptReader]: traversal is a read, and an unattended caller must
+// not silently walk the whole graph.
 func (a *App) scriptTracer(redactor visibility.FieldRedactor) tracer.Tracer {
 	d, ok := a.acl.(*acl.Declarative)
 	if !ok || d == nil {
@@ -358,13 +388,13 @@ func (a *App) scriptTracer(redactor visibility.FieldRedactor) tracer.Tracer {
 	}
 	gate, err := visibility.NewDeclarativeGate(d)
 	if err != nil {
-		slog.Warn("dataentry: ACL gate unavailable; traversal stays unrestricted", "err", err)
-		return a.tracer
+		slog.Error("dataentry: ACL gate unavailable; traversal REFUSED", "err", err)
+		return visibility.DenyTracer{}
 	}
 	vt, err := visibility.NewVisibleTracer(a.tracer, gate, redactor, a.store)
 	if err != nil {
-		slog.Warn("dataentry: visible tracer unavailable; traversal stays unrestricted", "err", err)
-		return a.tracer
+		slog.Error("dataentry: visible tracer unavailable; traversal REFUSED", "err", err)
+		return visibility.DenyTracer{}
 	}
 	return vt
 }

--- a/internal/dataentry/failclosed_test.go
+++ b/internal/dataentry/failclosed_test.go
@@ -1,0 +1,147 @@
+package dataentry
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/Sourcehaven-BV/rela/internal/acl"
+	"github.com/Sourcehaven-BV/rela/internal/entity"
+	"github.com/Sourcehaven-BV/rela/internal/store"
+	"github.com/Sourcehaven-BV/rela/internal/visibility"
+)
+
+// rela#1198 / TKT-EIWW4M: when an ACL policy IS configured but the gate
+// cannot be constructed, the script read seam must REFUSE, not fall back to
+// the raw ungated store.
+//
+// Why this is worth pinning even though the fault is currently unreachable
+// through App.luaWriteDeps (the redactor there is a non-nil struct literal
+// and a.store is nil-rejected in NewApp): the fail-open branch was dead code
+// that would silently reactivate the moment any of the three constructors
+// grew a new error condition, or a.store/the redactor became nilable. The
+// exposure is latent, and a latent ungated read on the IdP-webhook path —
+// unattended, machine-to-machine, nobody reading the log — is exactly what
+// DenyReader exists to prevent. Pinning the CHOICE, not just the current
+// reachability, is the point.
+//
+// These tests drive scriptReader/scriptTracer directly with a nil redactor,
+// which is a real fault path in NewPolicyReader/NewVisibleTracer (both
+// reject a nil redact). No production code is weakened to make them run.
+
+// configuredACLApp returns an App with a real Declarative policy installed.
+// A policy must be present or the NopACL early-return short-circuits before
+// any fault branch is reachable.
+func configuredACLApp(t *testing.T) *App {
+	t.Helper()
+	app := newTestAppV1(t)
+	seedEntity(app, &entity.Entity{ID: "TKT-001", Type: "ticket",
+		Properties: map[string]any{"title": "Readable"}})
+	d := mustNewACL(t, &acl.Policy{
+		Roles:       map[string]acl.RoleDef{"viewer": {Read: []string{"ticket"}}},
+		Assignments: map[string]string{"alice": "viewer"},
+	}, app.store)
+	app.acl = d
+	return app
+}
+
+// TestScriptReader_FailsClosedOnGateFault pins that a construction fault
+// yields DenyReader rather than the raw store. If this regresses, an
+// unattended webhook script silently reads the entire graph.
+func TestScriptReader_FailsClosedOnGateFault(t *testing.T) {
+	app := configuredACLApp(t)
+
+	// nil redactor => NewPolicyReader errors => the fault branch runs.
+	reader := app.scriptReader(nil)
+
+	if reader == nil {
+		t.Fatal("scriptReader returned nil")
+	}
+	if _, isRaw := reader.(store.Store); isRaw {
+		t.Fatalf("FAIL-OPEN: scriptReader degraded to the raw store (%T) on a "+
+			"gate construction fault — an unattended script would read the "+
+			"whole graph ungated (rela#1198)", reader)
+	}
+	if _, ok := reader.(visibility.DenyReader); !ok {
+		t.Fatalf("expected visibility.DenyReader on a construction fault, got %T", reader)
+	}
+
+	// And it must actually refuse, with the diagnosable error rather than a
+	// not-found that reads as "no such entity".
+	got, err := reader.GetEntity(context.Background(), "TKT-001")
+	if err == nil {
+		t.Fatalf("DenyReader.GetEntity returned no error (entity=%v)", got)
+	}
+	if !errors.Is(err, visibility.ErrReaderUnavailable) {
+		t.Errorf("want ErrReaderUnavailable, got %v", err)
+	}
+	if got != nil {
+		t.Errorf("DenyReader leaked an entity: %v", got)
+	}
+}
+
+// TestScriptTracer_FailsClosedOnGateFault is the traversal counterpart.
+// Traversal is a read: an ungated trace walks the whole graph.
+func TestScriptTracer_FailsClosedOnGateFault(t *testing.T) {
+	app := configuredACLApp(t)
+
+	tr := app.scriptTracer(nil)
+
+	if tr == nil {
+		t.Fatal("scriptTracer returned nil")
+	}
+	if tr == app.tracer {
+		t.Fatal("FAIL-OPEN: scriptTracer degraded to the bare tracer on a " +
+			"construction fault — hidden nodes would leak into traversals (rela#1198)")
+	}
+	if _, ok := tr.(visibility.DenyTracer); !ok {
+		t.Fatalf("expected visibility.DenyTracer on a construction fault, got %T", tr)
+	}
+
+	ctx := context.Background()
+	if res := tr.TraceFrom(ctx, "TKT-001", 2); res != nil {
+		t.Errorf("DenyTracer.TraceFrom leaked a result: %v", res)
+	}
+	if res := tr.TraceTo(ctx, "TKT-001", 2); res != nil {
+		t.Errorf("DenyTracer.TraceTo leaked a result: %v", res)
+	}
+	if p := tr.FindPath(ctx, "TKT-001", "TKT-001"); p != nil {
+		t.Errorf("DenyTracer.FindPath leaked a path: %v", p)
+	}
+
+	// FindOrphans is the only traversal that CAN report failure (no script
+	// can reach it, but the wiring must still not silently claim an empty
+	// graph to a Go caller).
+	if _, err := tr.FindOrphans(ctx); !errors.Is(err, visibility.ErrReaderUnavailable) {
+		t.Errorf("FindOrphans: want ErrReaderUnavailable, got %v", err)
+	}
+}
+
+// TestScriptReadSeam_PolicylessProjectStaysUnrestricted pins the other side
+// of the contract. Absence of a policy is a documented intentional state
+// ("no access control desired"), NOT a fault — it must keep returning the
+// raw store, byte-identical to pre-ACL behavior. Failing closed here would
+// break every policy-less deployment's scripts.
+func TestScriptReadSeam_PolicylessProjectStaysUnrestricted(t *testing.T) {
+	app := newTestAppV1(t)
+	seedEntity(app, &entity.Entity{ID: "TKT-001", Type: "ticket",
+		Properties: map[string]any{"title": "Readable"}})
+	app.acl = acl.NopACL{}
+
+	reader := app.scriptReader(nil)
+	if _, isDeny := reader.(visibility.DenyReader); isDeny {
+		t.Error("policy-less project got DenyReader — absence of acl.yaml is " +
+			"an intentional state, not a construction fault")
+	}
+	if any(reader) != any(app.store) {
+		t.Errorf("policy-less scriptReader should be the raw store, got %T", reader)
+	}
+
+	tr := app.scriptTracer(nil)
+	if _, isDeny := tr.(visibility.DenyTracer); isDeny {
+		t.Error("policy-less project got DenyTracer")
+	}
+	if tr != app.tracer {
+		t.Errorf("policy-less scriptTracer should be the bare tracer, got %T", tr)
+	}
+}

--- a/internal/visibility/denyreader.go
+++ b/internal/visibility/denyreader.go
@@ -62,8 +62,20 @@ func (DenyReader) ListRelations(
 // traverse the whole graph.
 //
 // tracer.Tracer's methods return no error, so refusal is expressed as the
-// empty result each method already uses for "nothing found" — the failure
-// itself is surfaced by the loud log at the wiring site.
+// empty result each method already uses for "nothing found".
+//
+// CAVEAT — refusal is INVISIBLE to a script. The three traversals bound to
+// Lua (rela.trace_from, rela.trace_to, rela.find_path) are exactly the three
+// that cannot report failure, and a nil result is the same value a script
+// gets for a nonexistent ID. FindOrphans does return an error, but no script
+// can call it. So the `slog.Error` at the WIRING SITE is the only signal
+// that a traversal was refused rather than genuinely empty — correlate by
+// timestamp when a script reports an unexpectedly empty graph.
+//
+// This is accepted deliberately: seeing less than the truth is the safe
+// direction, and the alternative (traversing ungated) is the disclosure this
+// type exists to prevent. Surfacing it properly needs an error-returning
+// traversal on tracer.Tracer — an interface change, tracked separately.
 type DenyTracer struct{}
 
 // TraceFrom implements [tracer.Tracer]: always empty.

--- a/tickets/entities/docs-checklists/DOCS-L6F4H8.md
+++ b/tickets/entities/docs-checklists/DOCS-L6F4H8.md
@@ -1,0 +1,24 @@
+---
+id: DOCS-L6F4H8
+type: docs-checklist
+title: 'Docs: fail-closed data-entry script read wiring'
+status: done
+---
+
+## Code docs
+
+- [x] `App.scriptReader` godoc rewritten — states the real justification (the unattended IdP webhook consumer), names all three consumers, and documents the deliberate divergence from appbuild's nil-redactor guard with an explicit warning against "aligning" them.
+- [x] `App.scriptTracer` godoc cross-references the reader's rationale.
+- [x] `appbuild.luaReadDepsFor` godoc corrected — it described the pre-RR-GKCZO5 fail-open behavior while the code 30 lines below failed closed (RR-DZ7H2S).
+- [x] `visibility.DenyTracer` godoc corrected — it cited `FindOrphans` as the diagnostic surface, but no script can reach it; the caveat is now stated honestly (RR-R38TA9).
+
+## Project docs
+
+- [x] `docs-project/entities/guides/GUIDE-acl-security.md` — added a bullet to "ACL fail-loud and middleware scope" covering what happens when the read gate cannot be built, including the traversal asymmetry (refused traces look empty to a script) and the explicit note that policy-less projects are unaffected.
+- [x] Regenerated derived docs via `just docs` (`docs/acl-security.md`); source-of-truth edited, not the generated copy.
+
+## External docs
+
+- [x] ~~API/OpenAPI docs~~ (N/A: no HTTP surface change — this is internal wiring)
+- [x] ~~Migration notes~~ (N/A: no operator action required; the change only alters behavior on a fault that is currently unreachable)
+- [x] Issue #1198 to be answered with both premise corrections stated explicitly.

--- a/tickets/entities/implementation-checklists/IMPL-OZELQR.md
+++ b/tickets/entities/implementation-checklists/IMPL-OZELQR.md
@@ -1,0 +1,30 @@
+---
+id: IMPL-OZELQR
+type: implementation-checklist
+title: 'Implementation: fail-closed data-entry script read wiring'
+status: done
+---
+
+## Development
+
+- [x] `App.scriptReader` returns `visibility.DenyReader{}` on all three construction faults, logged at `slog.Error`.
+- [x] `App.scriptTracer` returns `visibility.DenyTracer{}` on both faults.
+- [x] NopACL early-return preserved unchanged in both.
+- [x] Godoc rewritten to state the real justification (the unattended webhook consumer) and the deliberate divergence from appbuild's nil-redactor guard.
+
+## Quality
+
+- [x] `go build ./...` clean.
+- [x] `just lint` — 0 issues (fixed one `unparam` on the test helper).
+- [x] `just arch-lint` — no warnings.
+- [x] `just plimsoll` — no new god-object violations.
+- [x] Tests: dataentry, visibility, appbuild, lua, scheduler all pass.
+- [x] Mutation-tested: reverting to fail-open (and separately breaking the NopACL early-return) makes each test fail with an actionable message.
+- [x] ~~Frontend changes~~ (N/A: Go wiring only)
+
+## Notes
+
+`internal/docscapture` fails locally because `frontend/dist/` is not built in
+this checkout. Verified byte-identical failure with the branch stashed (tree ==
+develop), so it is a pre-existing local-environment gap, not a regression. CI
+builds the frontend.

--- a/tickets/entities/planning-checklists/PLAN-Q907M4.md
+++ b/tickets/entities/planning-checklists/PLAN-Q907M4.md
@@ -1,0 +1,34 @@
+---
+id: PLAN-Q907M4
+type: planning-checklist
+title: 'Planning: fail-closed data-entry script read wiring'
+status: done
+---
+
+## Understanding
+
+- [x] Problem understood — rela#1198 (IB review, CONTROL-5-15): `scriptReader`/`scriptTracer` fall back to the raw ungated store on a gate construction fault.
+- [x] Issue claims verified against code rather than accepted. Two of three premises were refuted (MCP not served by this wiring; branches unreachable), and the genuine justification (the unattended IdP webhook) was identified independently.
+- [x] Scope clear — wiring change only; `DenyReader`/`DenyTracer` already exist.
+
+## Research
+
+- [x] ~~Library search~~ (N/A: no new dependency; the fail-closed machinery is already in-tree from RR-GKCZO5)
+- [x] Existing pattern reused — `appbuild.scriptEntityReader`/`scriptTracer` are the direct precedent.
+- [x] All consumers of `App.luaWriteDeps` enumerated (actions, export_render, webhook).
+
+## Approach
+
+- [x] Chosen: make all three consumers fail closed rather than splitting per-consumer policy. An interactive caller receiving `ErrReaderUnavailable` gets the loud, immediate outage the fail-open argument actually wanted, without the ungated read.
+- [x] NopACL path explicitly preserved — absence of `acl.yaml` is an intentional state, not a fault.
+
+## Security
+
+- [x] Input trust — no new input surface; this narrows an existing read path.
+- [x] Failure direction — fail-closed on fault; deny remains distinct from unavailable.
+- [x] Considered the counter-risk (breaking policy-less deployments) and pinned it with a dedicated test.
+
+## Test plan
+
+- [x] Fail-closed reader, fail-closed tracer, policy-less-stays-unrestricted.
+- [x] Each test to be mutation-verified rather than merely passing.

--- a/tickets/entities/review-checklists/REV-TXKHHZ.md
+++ b/tickets/entities/review-checklists/REV-TXKHHZ.md
@@ -1,0 +1,30 @@
+---
+id: REV-TXKHHZ
+type: review-checklist
+title: 'Review: fail-closed data-entry script read wiring'
+status: done
+---
+
+## Automated checks
+
+- [x] `go build ./...` clean
+- [x] `just lint` — 0 issues
+- [x] `just arch-lint` — no warnings
+- [x] `just plimsoll` — pass
+- [x] Affected suites pass (dataentry, visibility, appbuild, lua, scheduler)
+
+## Code review
+
+- [x] `/code-review` run via cranky-code-reviewer.
+- [x] Findings triaged, and two were **rejected after verification** rather than applied blindly:
+  - "there are two consumers, not three" — refuted: `app.go:628` passes `app.luaWriteDeps` as a closure into `newDocumentService`, so `export_render` is a third consumer. The reviewer's grep missed the closure form.
+  - "the `store.Store` assertion is unreachable dead weight" — refuted by probe: the assertion exists to catch the *fail-open* case (raw store returned), and it fires exactly then, as the mutation run confirmed.
+- [x] Accepted findings addressed: RR-8JNKWC (critical), RR-DZ7H2S, RR-R38TA9.
+- [x] No open critical or significant review responses.
+
+## Verification
+
+- [x] Security property mutation-tested, not merely asserted.
+- [x] Policy-less regression risk explicitly pinned.
+- [x] Local `docscapture` failures investigated to root cause (`frontend/dist/` absent) and proven pre-existing via a stashed-tree control, rather than assumed environmental.
+- [x] PR opened: https://github.com/sourcehaven-bv/rela/pull/1204

--- a/tickets/entities/review-responses/RR-8JNKWC.md
+++ b/tickets/entities/review-responses/RR-8JNKWC.md
@@ -1,0 +1,9 @@
+---
+id: RR-8JNKWC
+type: review-response
+title: dataentry/appbuild diverge on nil-redactor handling while claiming to match
+finding: 'The new scriptReader godoc claims it matches appbuild''s unattended-path wiring, but appbuild.go:257-259/289-291 substitutes visibility.NopRedactor{} for a nil redactor while dataentry returns DenyReader. Two seams documented as identical behave oppositely on the same input. Load-bearing for the tests: a future ''alignment'' refactor copying appbuild''s guard into dataentry would delete the only fault path failclosed_test.go exercises, and the tests would fail with no indication why.'
+severity: critical
+resolution: 'Resolved deliberately rather than by alignment. dataentry keeps the strict behavior and the godoc now documents the divergence as intentional with its rationale: appbuild''s callers (scheduler, cascades) legitimately have no affordance resolver, so NopRedactor is the best available there (RR-7408F5); data-entry always has one, so a nil redactor is a wiring bug, not a capability gap. Silently swapping in NopRedactor there would drop field-level redaction on a path required to enforce it. The comment explicitly warns against copying appbuild''s guard.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-DZ7H2S.md
+++ b/tickets/entities/review-responses/RR-DZ7H2S.md
@@ -1,0 +1,9 @@
+---
+id: RR-DZ7H2S
+type: review-response
+title: appbuild godoc documented fail-open while its code fails closed
+finding: internal/appbuild/appbuild.go luaReadDepsFor's godoc said 'A construction failure is also unrestricted-with-a-warning rather than silent denial' — but the code 30 lines below returns visibility.DenyReader{} and logs slog.Error. The comment documented pre-RR-GKCZO5 behavior and was never updated. Since rela#1198 is an ISO CONTROL-5-15 finding, an auditor reading the file cited as the fail-closed exemplar would find prose asserting the opposite.
+severity: significant
+resolution: Rewrote the paragraph to state that a construction failure REFUSES via DenyReader/DenyTracer (RR-GKCZO5), pointing at scriptEntityReader for the rationale. The NopACL sentence, which was and remains accurate, is preserved.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-R38TA9.md
+++ b/tickets/entities/review-responses/RR-R38TA9.md
@@ -1,0 +1,9 @@
+---
+id: RR-R38TA9
+type: review-response
+title: DenyTracer godoc cited FindOrphans as the diagnostic surface, but no script can call it
+finding: 'DenyTracer''s godoc reassured that FindOrphans ''CAN report failure rather than looking like an empty graph''. Verified against internal/lua/runtime.go:697-699: the only script-bound traversals are trace_from, trace_to and find_path — all three silent-nil. FindOrphans is unreachable from Lua. So the scripting surface is 100% silent, and luaTraceFrom maps nil to LNil, the identical value returned for a nonexistent ID: a script cannot distinguish ''gate broken, refusing'' from ''no such entity''.'
+severity: significant
+resolution: Added an explicit CAVEAT paragraph to DenyTracer stating that refusal is invisible to scripts, that the three Lua-bound traversals are exactly the three that cannot report failure, and that the wiring-site slog.Error is the only signal (correlate by timestamp). Documented the tradeoff as deliberate — seeing less than the truth is the safe direction — and noted that surfacing it properly requires an error-returning traversal on tracer.Tracer, an interface change tracked separately.
+status: addressed
+---

--- a/tickets/entities/tickets/TKT-EIWW4M.md
+++ b/tickets/entities/tickets/TKT-EIWW4M.md
@@ -1,0 +1,100 @@
+---
+id: TKT-EIWW4M
+type: ticket
+title: 'acl: fail-closed script read wiring in data-entry (rela#1198)'
+kind: enhancement
+priority: medium
+effort: s
+status: done
+---
+
+## Summary
+
+Closes rela#1198 (IB review, CONTROL-5-15). `dataentry.App.scriptReader` /
+`scriptTracer` degrade to the **raw ungated store** on an ACL-gate construction
+fault, with only a `slog.Warn`. The equivalent helpers in `appbuild` make the
+opposite choice on identical error branches — `slog.Error` +
+`visibility.DenyReader{}` / `DenyTracer{}` (RR-GKCZO5).
+
+## Premise corrections (verified against develop @ dd0fe649)
+
+The issue's two headline claims are **wrong**. Both were checked in code and
+independently re-verified before planning.
+
+### Correction 1: MCP is NOT served by this wiring
+
+The issue's strongest argument is that MCP is "een machine-naar-LLM-kanaal, geen
+mens die de warn-log direct ziet". That argument points at code that does not
+exist.
+
+- MCP builds its own services: `appbuild.Discover(..., WithACL(acl.NopACL{}))`
+(`internal/cli/mcp_wiring.go:43`) and passes `svc.LuaWriteDeps()` — the
+**unrestricted** accessor (`appbuild.go:310`, doc: "UNRESTRICTED reads") — into
+`mcp.Deps` (`mcp_wiring.go:66`).
+- `internal/mcp` never imports `internal/dataentry`; no entry point wires
+both into one process (`cmd/rela-server`, `cmd/rela-desktop` construct
+`dataentry.NewApp` and never import `internal/mcp`).
+
+So MCP reads unrestricted **by deliberate, documented design** — the local stdio
+transport means the filesystem is already the trust boundary
+(`mcp_wiring.go:34-41`) — not via a fail-open fallback. Changing `dataentry`
+would not alter MCP behavior by one byte. Whether NopACL-for-MCP is right is a
+separate question, out of scope here.
+
+### Correction 2: the fail-open branches are currently UNREACHABLE
+
+All three `scriptReader` error branches are dead code at this call site:
+
+| Constructor | Only errors when | Reachable? |
+|---|---|---|
+| `NewDeclarativeGate` | `d == nil` | No — guarded by the `!ok \|\| d == nil` early return above it |
+| `NewPolicyReader` | gate/redact/get nil | No — gate is a non-pointer struct value; redactor is a struct literal; `a.store` is nil-rejected in `NewApp` |
+| `NewScriptReader` | reader/raw nil | No — both non-nil per above |
+
+This is therefore **latent exposure, not a live leak**. It activates on a future
+refactor (a nilable store/redactor, or a new error condition in any of the three
+constructors) — exactly the kind of silent activation that is cheap to prevent
+now and expensive to detect later.
+
+## What IS real: the webhook path
+
+The issue's conclusion is right for a reason it did not identify.
+`App.luaWriteDeps` has exactly three consumers:
+
+- `actions.go:94` — interactive HTTP action (human at the UI)
+- `document.go:268` — `export_render`
+- **`webhook.go:181` — the IdP webhook: unattended machine-to-machine**
+
+The webhook runs as a real stamped principal (`User: "webhook:"+claims.Event`,
+`Tool: ToolWebhookReceiver`) with **no human in the loop** — its own godoc says
+"not a human at the UI". The "an operator sees the outage immediately" rationale
+that justifies fail-open for interactive requests does **not** hold here. That
+is the genuine asymmetry, and it is sufficient on its own.
+
+## Approach
+
+Make all three consumers fail closed, matching `appbuild`. The
+`DenyReader`/`DenyTracer` machinery already exists and is already the precedent
+— this is a wiring change, not new infrastructure.
+
+Rationale for not splitting per-consumer: an interactive caller getting
+`ErrReaderUnavailable` is a loud, immediate, diagnosable outage — which is the
+*stated goal* of the fail-open argument, achieved without the ungated read.
+There is no case where returning the raw store is preferable to a clear error,
+so the added complexity of a per-consumer policy buys nothing.
+
+## Acceptance criteria
+
+- `scriptReader` returns `visibility.DenyReader{}`, `scriptTracer` returns
+`visibility.DenyTracer{}`, on any construction fault; logged at `slog.Error`,
+wording matched to `appbuild`.
+- NopACL path (`d == nil`) still returns the raw store — unchanged.
+- A genuine DENY remains a deny, distinct from `ErrReaderUnavailable`.
+- Tests pin fail-closed for the reader and tracer, and pin that the
+policy-less path stays unrestricted.
+- Issue #1198 answered with both premise corrections stated explicitly.
+
+## Non-goals
+
+MCP's `NopACL` wiring (deliberate; separate decision). `export_render`
+output-side redaction. Field-level redaction on scheduled jobs (RR-7408F5).

--- a/tickets/relations/TKT-EIWW4M--affects--authorization.md
+++ b/tickets/relations/TKT-EIWW4M--affects--authorization.md
@@ -1,0 +1,5 @@
+---
+from: TKT-EIWW4M
+relation: affects
+to: authorization
+---

--- a/tickets/relations/TKT-EIWW4M--has-docs--DOCS-L6F4H8.md
+++ b/tickets/relations/TKT-EIWW4M--has-docs--DOCS-L6F4H8.md
@@ -1,0 +1,5 @@
+---
+from: TKT-EIWW4M
+relation: has-docs
+to: DOCS-L6F4H8
+---

--- a/tickets/relations/TKT-EIWW4M--has-implementation--IMPL-OZELQR.md
+++ b/tickets/relations/TKT-EIWW4M--has-implementation--IMPL-OZELQR.md
@@ -1,0 +1,5 @@
+---
+from: TKT-EIWW4M
+relation: has-implementation
+to: IMPL-OZELQR
+---

--- a/tickets/relations/TKT-EIWW4M--has-planning--PLAN-Q907M4.md
+++ b/tickets/relations/TKT-EIWW4M--has-planning--PLAN-Q907M4.md
@@ -1,0 +1,5 @@
+---
+from: TKT-EIWW4M
+relation: has-planning
+to: PLAN-Q907M4
+---

--- a/tickets/relations/TKT-EIWW4M--has-review--REV-TXKHHZ.md
+++ b/tickets/relations/TKT-EIWW4M--has-review--REV-TXKHHZ.md
@@ -1,0 +1,5 @@
+---
+from: TKT-EIWW4M
+relation: has-review
+to: REV-TXKHHZ
+---

--- a/tickets/relations/TKT-EIWW4M--has-review-response--RR-8JNKWC.md
+++ b/tickets/relations/TKT-EIWW4M--has-review-response--RR-8JNKWC.md
@@ -1,0 +1,5 @@
+---
+from: TKT-EIWW4M
+relation: has-review-response
+to: RR-8JNKWC
+---

--- a/tickets/relations/TKT-EIWW4M--has-review-response--RR-DZ7H2S.md
+++ b/tickets/relations/TKT-EIWW4M--has-review-response--RR-DZ7H2S.md
@@ -1,0 +1,5 @@
+---
+from: TKT-EIWW4M
+relation: has-review-response
+to: RR-DZ7H2S
+---

--- a/tickets/relations/TKT-EIWW4M--has-review-response--RR-R38TA9.md
+++ b/tickets/relations/TKT-EIWW4M--has-review-response--RR-R38TA9.md
@@ -1,0 +1,5 @@
+---
+from: TKT-EIWW4M
+relation: has-review-response
+to: RR-R38TA9
+---

--- a/tickets/relations/TKT-EIWW4M--implements--FEAT-PPH1EU.md
+++ b/tickets/relations/TKT-EIWW4M--implements--FEAT-PPH1EU.md
@@ -1,0 +1,5 @@
+---
+from: TKT-EIWW4M
+relation: implements
+to: FEAT-PPH1EU
+---


### PR DESCRIPTION
Closes #1198.

`dataentry.App.scriptReader`/`scriptTracer` degraded to the **raw ungated store** on an ACL-gate construction fault, with only a `slog.Warn`. They now return `visibility.DenyReader{}`/`DenyTracer{}` and log at `slog.Error`, matching the wiring `appbuild` already uses for unattended paths (RR-GKCZO5).

## Two premise corrections

The issue's headline claims did not survive checking. Both were verified in code and independently re-verified.

**MCP is not served by this wiring.** The issue's strongest argument is that MCP is a machine-to-LLM channel with nobody reading the warning. But MCP builds its own services — `appbuild.Discover(..., WithACL(acl.NopACL{}))` (`internal/cli/mcp_wiring.go:43`) — and passes the *unrestricted* `svc.LuaWriteDeps()`. `internal/mcp` never imports `internal/dataentry`, and no entry point wires both into one process. MCP reads unrestricted by deliberate, documented design (local stdio ⇒ the filesystem is already the trust boundary), not via a fail-open fallback. This PR does not change MCP behavior by one byte; whether NopACL-for-MCP is right is a separate question.

**The fail-open branches were unreachable.** `NewDeclarativeGate` only errors on `d == nil` (already guarded by the early return); `NewPolicyReader`/`NewScriptReader` only on nil args, and the gate is a non-pointer struct, the redactor a struct literal, and `a.store` nil-rejected in `NewApp`. So this is latent-exposure hardening, not a live leak — the branch would silently reactivate the moment a constructor grew a new error condition.

## What is real

`App.luaWriteDeps` has three consumers: `actions.go` (interactive), `document.go`/`export_render`, and **`webhook.go` — the IdP webhook, unattended machine-to-machine**, running as `webhook:<event>` with no human in the loop. The "an operator sees the outage immediately" rationale that justified fail-open does not hold there. That alone justifies the change.

Failing closed costs interactive callers nothing they were promised: `ErrReaderUnavailable` is a loud, immediate, diagnosable error — what the fail-open argument actually wanted, minus the ungated read.

## Review findings addressed

- **RR-8JNKWC** (critical) — `appbuild` substitutes `NopRedactor` for a nil redactor while this code refuses, so two seams documented as identical behaved oppositely. Resolved deliberately: data-entry always *has* an affordance resolver, so a nil redactor is a wiring bug, not a capability gap; silently swapping in `NopRedactor` would drop field-level redaction on a path required to enforce it. The godoc now documents the divergence and warns against "aligning" them.
- **RR-DZ7H2S** (significant) — `appbuild`'s own godoc still described the pre-RR-GKCZO5 fail-open behavior, contradicting the code 30 lines below it. Since that file is the cited fail-closed exemplar for an ISO CONTROL-5-15 finding, corrected here.
- **RR-R38TA9** (significant) — `DenyTracer`'s godoc cited `FindOrphans` as the diagnostic surface, but the only Lua-bound traversals (`trace_from`/`trace_to`/`find_path`) are exactly the three that cannot report failure, and `nil` is indistinguishable from "no such entity". Documented the caveat honestly rather than papering over it.

## Tests

`internal/dataentry/failclosed_test.go` pins fail-closed for the reader and tracer, and pins that a **policy-less project stays unrestricted** — absence of `acl.yaml` is an intentional state, and failing closed there would break every such deployment.

All three tests were mutation-tested: reverting the production code to fail-open (and separately breaking the NopACL early-return) makes each fail with an actionable message.

`go build`, `just lint` (0 issues), `just arch-lint`, `just plimsoll`, and the dataentry/visibility/appbuild/lua/scheduler suites all pass. Note: `internal/docscapture` fails locally because `frontend/dist/` is not built in this checkout — verified identical with the branch stashed (tree == develop), so unrelated to this change.