### PR TITLE
refactor(dataentry): move Lua action + webhook dispatch onto writeHandler (TKT-6NDSH9)

### DIFF
--- a/internal/dataentry/actions.go
+++ b/internal/dataentry/actions.go
@@ -42,7 +42,7 @@ type v1ActionRequest struct {
 // Action scripts may mutate the workspace, so we serialize them via
 // writeMu for the duration of script execution. Concurrent reloads,
 // other mutations, and other action scripts wait for writeMu.
-func (a *App) handleV1Action(w http.ResponseWriter, r *http.Request) {
+func (h *writeHandler) handleV1Action(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
 		w.Header().Set("Allow", "POST")
 		writeV1Error(w, r, http.StatusMethodNotAllowed, "method_not_allowed", "Method not allowed", "")
@@ -56,7 +56,7 @@ func (a *App) handleV1Action(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	s := a.State()
+	s := h.schema()
 	action, ok := s.Cfg.Actions[id]
 	if !ok {
 		writeV1Error(w, r, http.StatusNotFound, "action_not_found", "Action not found", "")
@@ -77,27 +77,27 @@ func (a *App) handleV1Action(w http.ResponseWriter, r *http.Request) {
 
 	// Serialize action script execution against other mutations and
 	// against workspace reloads via writeMu.
-	a.writeMu.Lock()
-	defer a.writeMu.Unlock()
+	h.writeMu.Lock()
+	defer h.writeMu.Unlock()
 
 	// Resolve entity if provided in the request.
 	var ent *entity.Entity
 	if req.EntityID != "" {
-		if e, err := a.store.GetEntity(r.Context(), req.EntityID); err == nil {
+		if e, err := h.store.GetEntity(r.Context(), req.EntityID); err == nil {
 			ent = e
 		}
 	}
 
-	// Reuse the App's long-lived engine so rela.cache state persists
+	// Reuse App's long-lived engine so rela.cache state persists
 	// across action invocations. Constructing a fresh engine per
 	// request would reset the cache each time and defeat memoization.
-	resp, err := a.scriptEngine.ExecuteAction(r.Context(), action.Script, a.luaWriteDeps(),
+	resp, err := h.engine().ExecuteAction(r.Context(), action.Script, h.luaDeps(),
 		ent, action.Params, actionTimeout, correlationID)
 	if err != nil {
 		slog.Warn("action failed", "action", id, "correlation", correlationID, "error", err)
 		var se *lua.ScriptError
 		if errors.As(err, &se) {
-			writeV1ScriptError(w, se, a.allowFullScriptDetail(r), correlationID)
+			writeV1ScriptError(w, se, h.fullScriptDetail(r), correlationID)
 			return
 		}
 		// Non-Lua failure (script-not-found, contract failure from

--- a/internal/dataentry/actions_test.go
+++ b/internal/dataentry/actions_test.go
@@ -19,7 +19,7 @@ import (
 // call; since App.mu was deleted this is now just a direct call, but
 // keeping the helper avoids touching every test body in this file.
 func callAction(app *App, req *http.Request, rec *httptest.ResponseRecorder) {
-	app.handleV1Action(rec, req)
+	app.write.handleV1Action(rec, req)
 }
 
 // newActionTestApp builds a test App with a real project root containing

--- a/internal/dataentry/api_v1.go
+++ b/internal/dataentry/api_v1.go
@@ -108,7 +108,7 @@ func (a *App) registerAPIV1Routes(mux *http.ServeMux) {
 	mux.HandleFunc("/api/v1/_transforms", a.export.handleV1Transforms)
 	mux.HandleFunc("/api/v1/_templates/", a.handleV1Templates)
 	mux.HandleFunc("/api/v1/_views/", a.handleV1Views)
-	mux.HandleFunc("/api/v1/_action/", a.handleV1Action)
+	mux.HandleFunc("/api/v1/_action/", a.write.handleV1Action)
 	mux.HandleFunc("/api/v1/_apps/", a.handleV1App)
 
 	// Dynamic entity routes are handled by a catch-all

--- a/internal/dataentry/app.go
+++ b/internal/dataentry/app.go
@@ -80,9 +80,12 @@ const userPaletteFile = "palette.yaml"
 // commandHandler (154 → 143); the attachment cluster (12 methods) moved to
 // attachmentHandler / package functions (143 → 131); the write nucleus —
 // entity/relation CRUD, clone, conflict-resolve, and the modern relations
-// reconciler (18 methods) — moved to writeHandler (131 → 114).
+// reconciler (18 methods) — moved to writeHandler (131 → 114); the Lua
+// action handler joined it (115 → 114, from a base that had absorbed the
+// DEC-O59WM4 script-read helpers), completing the write surface: every
+// writeMu write path now lives on or routes through writeHandler.
 //
-//plimsoll:max-methods=115
+//plimsoll:max-methods=114
 type App struct {
 	// Primitives — immutable after NewApp.
 	fs    storage.FS
@@ -755,6 +758,9 @@ func NewApp(
 		denyAfford:         app.denyAffordance,
 		computeETag:        app.computeEntityETag,
 		currentEdgesByPeer: app.currentEdgesByPeer,
+		engine:             func() *script.Engine { return app.scriptEngine },
+		luaDeps:            app.luaWriteDeps,
+		fullScriptDetail:   app.allowFullScriptDetail,
 		paths:              paths,
 		writeMu:            &app.writeMu,
 	}

--- a/internal/dataentry/test_helpers_test.go
+++ b/internal/dataentry/test_helpers_test.go
@@ -220,6 +220,9 @@ func rebindApp(app *App, fs storage.FS, paths *project.Context, svc *appbuild.Se
 		denyAfford:         app.denyAffordance,
 		computeETag:        app.computeEntityETag,
 		currentEdgesByPeer: app.currentEdgesByPeer,
+		engine:             func() *script.Engine { return app.scriptEngine },
+		luaDeps:            app.luaWriteDeps,
+		fullScriptDetail:   app.allowFullScriptDetail,
 		paths:              paths,
 		writeMu:            &app.writeMu,
 	}

--- a/internal/dataentry/webhook.go
+++ b/internal/dataentry/webhook.go
@@ -86,12 +86,12 @@ func (a *App) registerWebhookRoutes(mux *http.ServeMux) {
 		return
 	}
 	// The handler lives on the receiver; the App only supplies the dispatch
-	// closure (which needs App internals: scriptEngine, State, writeMu). This
+	// closure (which routes through the writeHandler: engine, schema, writeMu). This
 	// keeps the HTTP-flow logic off the (already large) App type.
 	rec := a.webhook
 	mux.HandleFunc("POST /webhooks/idp", func(w http.ResponseWriter, r *http.Request) {
 		rec.handle(w, r, func(ctx context.Context, claims WebhookClaims) error {
-			return dispatchWebhookAction(ctx, a, rec.actionID, claims)
+			return dispatchWebhookAction(ctx, a.write, rec.actionID, claims)
 		})
 	})
 }
@@ -149,10 +149,10 @@ func (rec *webhookReceiver) handle(
 // dispatchWebhookAction runs the provisioning action with the webhook's claims as
 // params, under the webhook-receiver principal. Serialized against other
 // mutations via writeMu (the action upserts an entity), matching handleV1Action.
-// A free function (not an App method) to keep the App type's method count down;
-// it still needs App internals, so it takes *App explicitly.
-func dispatchWebhookAction(ctx context.Context, a *App, actionID string, claims WebhookClaims) error {
-	s := a.State()
+// A free function taking the writeHandler explicitly (it is dispatch wiring,
+// not a route handler).
+func dispatchWebhookAction(ctx context.Context, h *writeHandler, actionID string, claims WebhookClaims) error {
+	s := h.schema()
 	action, ok := s.Cfg.Actions[actionID]
 	if !ok {
 		// Misconfiguration: the configured action id doesn't exist. Fail loud in
@@ -175,10 +175,10 @@ func dispatchWebhookAction(ctx context.Context, a *App, actionID string, claims 
 		"org_id":  claims.OrgID,
 	}
 
-	a.writeMu.Lock()
-	defer a.writeMu.Unlock()
+	h.writeMu.Lock()
+	defer h.writeMu.Unlock()
 
-	_, err := a.scriptEngine.ExecuteAction(ctx, action.Script, a.luaWriteDeps(),
+	_, err := h.engine().ExecuteAction(ctx, action.Script, h.luaDeps(),
 		nil, params, webhookActionTimeout, newCorrelationID())
 	return err
 }

--- a/internal/dataentry/webhook_test.go
+++ b/internal/dataentry/webhook_test.go
@@ -47,7 +47,7 @@ func postWebhook(app *App, body string) *httptest.ResponseRecorder {
 	// in registerWebhookRoutes.
 	r := app.webhook
 	r.handle(rec, req, func(ctx context.Context, claims WebhookClaims) error {
-		return dispatchWebhookAction(ctx, app, r.actionID, claims)
+		return dispatchWebhookAction(ctx, app.write, r.actionID, claims)
 	})
 	return rec
 }

--- a/internal/dataentry/write_handler.go
+++ b/internal/dataentry/write_handler.go
@@ -17,16 +17,19 @@ import (
 	"github.com/Sourcehaven-BV/rela/internal/conflict"
 	entityPkg "github.com/Sourcehaven-BV/rela/internal/entity"
 	"github.com/Sourcehaven-BV/rela/internal/entitymanager"
+	"github.com/Sourcehaven-BV/rela/internal/lua"
 	"github.com/Sourcehaven-BV/rela/internal/metamodel"
 	"github.com/Sourcehaven-BV/rela/internal/principal"
 	"github.com/Sourcehaven-BV/rela/internal/project"
+	"github.com/Sourcehaven-BV/rela/internal/script"
 	"github.com/Sourcehaven-BV/rela/internal/store"
 )
 
 // writeHandler owns the data-entry write nucleus: the entity/relation CRUD
 // endpoints (create/dry-run-create/update/delete entity, create/update/delete
-// relation), clone, conflict-resolve, and the modern relations reconciler they
-// share. Extracted from App (TKT-R68TV8 M5.4) to shrink the god object.
+// relation), clone, conflict-resolve, the modern relations reconciler they
+// share, and the Lua action surface (interactive actions + webhook dispatch).
+// Extracted from App (TKT-R68TV8 M5.4) to shrink the god object.
 //
 // This is a PURE STRUCTURAL extraction: the handlers move verbatim and the
 // concurrency model is untouched.
@@ -40,10 +43,11 @@ import (
 // audit, one ETag definition).
 //
 // writeMu is a POINTER to App's mutation mutex: every handler here serializes
-// against App's residual write paths (Lua actions, webhook) and the extracted
-// sync/attachment handlers, exactly as before. (The DEC-8UIL0 arc later
-// replaces this mutex with the store's Tx contract; that is deliberately NOT
-// part of this refactor.)
+// against the extracted sync/attachment handlers, exactly as before. With the
+// action surface moved in, writeHandler covers the complete data-entry write
+// surface — no App method takes writeMu directly anymore. (The DEC-8UIL0 arc
+// later replaces this mutex with the store's Tx contract; that is deliberately
+// NOT part of this refactor.)
 type writeHandler struct {
 	schema      func() *Schema
 	store       store.Store
@@ -53,6 +57,16 @@ type writeHandler struct {
 	affordances affordanceService
 	acl         func() acl.ACL
 	audit       func() audit.Audit
+
+	// The Lua action surface (interactive actions + webhook dispatch) —
+	// scripts may mutate the workspace, so they run under writeMu. All three
+	// are live closures over App: the engine so fixtures that build App
+	// piecemeal see late-set fields, luaDeps because the bundle is derived
+	// per call from swappable collaborators, fullScriptDetail because the
+	// security layer is wired after construction (SetSecurityConfig).
+	engine           func() *script.Engine
+	luaDeps          func() lua.WriteDeps
+	fullScriptDetail func(r *http.Request) bool
 
 	// Shared App helpers (also used by the read path — stay on App).
 	gateRead   func(w http.ResponseWriter, r *http.Request, typeName, entityID string) bool

--- a/tickets/entities/review-checklists/REV-E3PPDY.md
+++ b/tickets/entities/review-checklists/REV-E3PPDY.md
@@ -1,0 +1,31 @@
+---
+id: REV-E3PPDY
+type: review-checklist
+title: 'Review: Move Lua action + webhook dispatch onto writeHandler'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Automated Checks
+
+- [x] All tests pass (`go test -race ./...` — full suite)
+- [x] Lint clean (`golangci-lint run ./internal/dataentry/...`) — 0 issues
+- [x] `gofmt` clean
+- [x] `just plimsoll` passes — `App` directive ratcheted 115 → 114
+- [x] `just arch-lint` passes
+- [x] Builds across default / `postgres` / `memorybackend` tags
+
+## Manual Review
+
+- [x] `/code-review` run (cranky-code-reviewer, word-diff vs develop originals) — **zero findings**
+- [x] Substitution fidelity exact — bodies byte-identical modulo receiver/field renames, each resolving to the same underlying value; lock scope, timeouts, params, correlation-id sites unchanged
+- [x] Liveness verified — `luaDeps`/`fullScriptDetail` are method values reading swappable App fields live (post-`rebindApp` store/affordances, post-construction `SetSecurityConfig`); `engine` closure reads `app.scriptEngine` live (never reassigned)
+- [x] Webhook principal stamping (`webhook:<event>`, `ToolWebhookReceiver`) outside the diff hunks — untouched
+- [x] `writeMu` single instance; `actions.go`/`webhook.go` confirmed as the last two direct App takers — non-test `writeMu.Lock` sites now exist only on handler structs; no double-lock (both entry points top-level)
+- [x] Wiring parity `NewApp` vs `rebindApp`; no stale doc claims actions/webhook live on App
+
+**Review Responses:** none — zero findings. One non-blocking pre-existing
+observation recorded on the ticket: store-wrapping tests mutate `app.store` in
+place without rebuilding extracted handlers (inert for this path; same
+pre-existing pattern as attachmentHandler).

--- a/tickets/entities/tickets/TKT-6NDSH9.md
+++ b/tickets/entities/tickets/TKT-6NDSH9.md
@@ -1,0 +1,43 @@
+---
+id: TKT-6NDSH9
+type: ticket
+title: Move Lua action + webhook dispatch onto writeHandler (complete the write surface)
+kind: refactor
+priority: medium
+effort: s
+status: done
+---
+
+Sub-ticket of the [[TKT-R68TV8]] `dataentry.App` decomposition arc (M5.4 tail).
+Follows [[TKT-HKY8RJ]] (write nucleus).
+
+## What
+
+Moved the last two direct `writeMu` takers off `App` onto `writeHandler`:
+
+- `handleV1Action` (actions.go) — receiver change in place; the interactive
+Lua action endpoint (`POST /api/v1/_action/{id}`).
+- `dispatchWebhookAction` (webhook.go) — the free dispatch function retargeted
+from `*App` to `*writeHandler`; `SetWebhookReceiver` / `registerWebhookRoutes`
+stay on `App` (public wiring + routing), the dispatch closure passes `a.write`.
+
+Three new `writeHandler` collaborators, all LIVE closures over App (wired
+identically in `NewApp` and `rebindApp`): `engine` (`app.scriptEngine`),
+`luaDeps` (`app.luaWriteDeps` — the bundle is derived per call from swappable
+collaborators), `fullScriptDetail` (`app.allowFullScriptDetail` — the security
+layer is wired after construction via `SetSecurityConfig`).
+
+- **`App`: 115 → 114 methods** (base had absorbed develop's DEC-O59WM4
+script-read helpers); `//plimsoll:max-methods` ratcheted 115 → 114.
+- **This completes the write surface**: every data-entry write path now lives
+on `writeHandler` or holds a pointer to the shared mutex (sync/attachment
+handlers) — no `App` method takes `writeMu` directly anymore. The [[DEC-8UIL0]]
+Tx arc now has a single obvious seam.
+- PURE STRUCTURAL: bodies verbatim, lock scope unchanged, webhook principal
+stamping (`webhook:<event>`) and correlation-id behavior unchanged.
+
+## Verification
+
+- `go test -race ./...` (full suite)
+- Builds across default / `postgres` / `memorybackend`
+- `just plimsoll`, `just arch-lint`, `golangci-lint` (0 issues), `gofmt`

--- a/tickets/entities/tickets/TKT-R68TV8.md
+++ b/tickets/entities/tickets/TKT-R68TV8.md
@@ -10,6 +10,8 @@ status: backlog
 
 > **Sweep note (2026-07-20): M5.2 sub-tickets confirmed landed (sync_handler.go, command_handler.go, attachment_handler.go all exist). Epic remains open: App still has 132 receiver methods (goal <40), //plimsoll:max-methods=131 directive still present in app.go, and the M5.4 write nucleus is not carved (writeMu still a field on App, taken directly in api_v1.go write handlers).**
 
+> **Update (2026-07-25): M5.4 write nucleus carved — [[TKT-HKY8RJ]] / PR #1191 merged, then [[TKT-6NDSH9]] moved the Lua action + webhook dispatch in as well. App at 114 methods, directive 114. The write surface is COMPLETE on writeHandler: no App method takes writeMu directly anymore. writeMu itself remains App-owned and pointer-shared; deleting it outright stays the [[DEC-8UIL0]] Tx arc, which now has a single obvious seam.**
+
 **Epic / parent ticket** for the remainder of the `dataentry.App` decomposition.
 Each shippable step is its own sub-ticket (moved to `done` with its PR); this
 parent stays in `backlog` until the whole arc lands — App under the 40-method
@@ -35,6 +37,11 @@ functions (143 → 131). PR #1149.
 - **M5.4 — write nucleus.** Carve the entity/relation/attachment write handlers
 behind one shared `writeMu`; drive `App` under 40 and delete the
 `//plimsoll:max-methods` directive in `internal/dataentry/app.go`.
+  - [x] [[TKT-HKY8RJ]] — write nucleus (entity/relation CRUD + dry-run, clone,
+conflict-resolve, relations reconciler; 18 methods) → `writeHandler` (131 →
+114). PR #1191.
+  - [x] [[TKT-6NDSH9]] — Lua action handler + webhook dispatch → `writeHandler`
+(115 → 114 after develop drift), completing the write surface.
   - **Open question — settled.** Researched in [[RES-Z1SJ5]], decided in
 [[DEC-8UIL0]]: write serialization becomes a `Tx` contract on `store.Store` (fs
 = mutex, postgres = native transactions + advisory lock), implemented as its

--- a/tickets/relations/TKT-6NDSH9--affects--ci-pipeline.md
+++ b/tickets/relations/TKT-6NDSH9--affects--ci-pipeline.md
@@ -1,0 +1,5 @@
+---
+from: TKT-6NDSH9
+relation: affects
+to: ci-pipeline
+---

--- a/tickets/relations/TKT-6NDSH9--depends-on--TKT-HKY8RJ.md
+++ b/tickets/relations/TKT-6NDSH9--depends-on--TKT-HKY8RJ.md
@@ -1,0 +1,5 @@
+---
+from: TKT-6NDSH9
+relation: depends-on
+to: TKT-HKY8RJ
+---

--- a/tickets/relations/TKT-6NDSH9--has-review--REV-E3PPDY.md
+++ b/tickets/relations/TKT-6NDSH9--has-review--REV-E3PPDY.md
@@ -1,0 +1,5 @@
+---
+from: TKT-6NDSH9
+relation: has-review
+to: REV-E3PPDY
+---

--- a/tickets/relations/TKT-6NDSH9--implements--FEAT-GE1YY.md
+++ b/tickets/relations/TKT-6NDSH9--implements--FEAT-GE1YY.md
@@ -1,0 +1,5 @@
+---
+from: TKT-6NDSH9
+relation: implements
+to: FEAT-GE1YY
+---


### PR DESCRIPTION
Sub-ticket of the TKT-R68TV8 `dataentry.App` decomposition arc (M5.4 tail). Follows #1191 (write nucleus).

## What

Moves the last two direct `writeMu` takers off `App` onto `writeHandler`:

- `handleV1Action` (actions.go) — receiver change in place; the interactive Lua action endpoint.
- `dispatchWebhookAction` (webhook.go) — the free dispatch function retargeted from `*App` to `*writeHandler`; `SetWebhookReceiver`/`registerWebhookRoutes` stay on App (public wiring + routing), the dispatch closure now passes `a.write`.

Three new `writeHandler` collaborators, all live closures over App, wired identically in `NewApp` and `rebindApp`: `engine` (`app.scriptEngine`), `luaDeps` (`app.luaWriteDeps` — bundle derived per call from swappable collaborators), `fullScriptDetail` (`app.allowFullScriptDetail` — security layer is wired post-construction via `SetSecurityConfig`).

**`App`: 115 → 114 methods** (base had absorbed develop's DEC-O59WM4 script-read helpers); `//plimsoll:max-methods` ratcheted 115 → 114.

**This completes the write surface**: every data-entry write path now lives on `writeHandler` or holds a pointer to the shared mutex (sync/attachment handlers) — no `App` method takes `writeMu` directly anymore. The DEC-8UIL0 Tx arc now has a single obvious seam.

## Design

Pure structural: bodies verbatim, lock scope unchanged, webhook principal stamping (`webhook:<event>`) and correlation-id behavior unchanged.

## Verification

- `go test -race ./...` (full suite), `just plimsoll`, `just arch-lint`, `golangci-lint` 0 issues, `gofmt`
- Builds across default / `postgres` / `memorybackend` tags
- cranky-code-reviewer word-diff vs develop originals: **zero findings** — substitution fidelity exact, closure liveness verified (post-rebind store/affordances, post-construction security), single-mutex discipline confirmed with App no longer a direct taker (REV-E3PPDY)

Companion tickets: TKT-6NDSH9 (done) + REV-E3PPDY; epic TKT-R68TV8 ledger updated.