### PR TITLE
chore(tickets): re-verify versioning follow-up tickets against develop

### DIFF
--- a/tickets/entities/tickets/TKT-73C6B2.md
+++ b/tickets/entities/tickets/TKT-73C6B2.md
@@ -38,3 +38,24 @@ and removes the whole 'verdict context mismatch' class.
 - Interacts with the entity_versions capture path (entitymanager version hook + sweep) and the store VersionSnapshot shape.
 - Consider whether to store the full resolved verdict, or the (relations + roles) inputs, or a per-field visible/hidden bitmap.
 - The relation-set-as-of question overlaps with relation history (TKT-VFJKMB).
+
+## Re-verification (2026-07-25, against develop dd0fe649)
+
+Premise STILL VALID — and now SHARPER. TKT-9E57 ("predicate-backed _fields
+resolver", done) made the field-visibility resolver genuinely conditional-grant
+capable: `internal/affordances/resolver.go:629-654` evaluates a `When` predicate
+per grant via `prog.Eval`, and the bindings resolve `has_edge`/`count_relations`
+against the LIVE store (`internal/dataentry/affordances_policy.go:96-106`). For a
+deleted entity the live store returns no edges, so a conditional `visible:` grant
+flips at read time — exactly the under-redaction this ticket describes, now a live
+policy capability rather than a hypothetical. History is still redacted at read
+time against the live ACL (`internal/dataentry/history_handler.go:194-208` →
+`entityserializer.go:117` → `affordances.go:895` stripHiddenProperties); the
+capture path stores no frozen verdict (`store.go` VersionSnapshot carries only
+content/properties/schema-projection). This ticket's fix is unimplemented and its
+value went UP with TKT-9E57.
+
+Coupled with TKT-B1F5Q1: both say "build the capture-time freeze with a shared
+design" — 73C6B2 is the entity-side freeze, B1F5Q1 adds relation-side `visible:`
+which needs the same freeze if relation grants are conditional. Design them
+together.

--- a/tickets/entities/tickets/TKT-B1F5Q1.md
+++ b/tickets/entities/tickets/TKT-B1F5Q1.md
@@ -57,3 +57,33 @@ hole.
 
 Confirmed as a gap in the TKT-92JL8P follow-up review — "acl does not allow
 field level stuff [for relations], seems like a gap we need to address."
+
+## Re-verification (2026-07-25, against develop dd0fe649)
+
+Premise STILL VALID — relations still have no read-time field-visibility
+redaction. Intervening ACL work (TKT-9E57 predicate-backed resolver, TKT-ZF2DTV
+ACL-bound script reads) strengthened the ENTITY side but added nothing for
+relations:
+
+- The policy schema still cannot express a relation `visible:` grant:
+  `internal/acl/policy.go:271-277` `RelationGrant` has only
+  `Relation`/`Create`/`Remove`/`Fields`/`When` — no `Visible`.
+- The live relation GET still emits properties raw:
+  `internal/dataentry/api_v1.go:893,918,1043` all do `rel["meta"] =
+  edge.Properties` with no stripping. `stripHiddenProperties` exists only for
+  entities (`affordances.go:895`, called from `entityserializer.go:117,142`).
+- `RelationVerdict.Fields` gates WRITES only (`affordances.go:226-229`;
+  consumers are the write-path validators `validateRelationMetaWrite` +
+  `_actions` emission) — never a read-side redaction.
+
+CORRECTION to the Problem section: the claim "`entity.Relation.Inaccessible` …
+never populated (zero writers)" is now imprecise. `fsstore/markdown.go:349`
+(`buildInaccessibleRelation`) DOES write it — but only for git-crypt-encrypted
+relation files (reason `git-crypt`), a filesystem-encryption stand-in, NOT wired
+from any ACL verdict. So the substantive gap (no ACL-driven per-field relation
+redaction) is intact; only the "zero writers" phrasing is stale. Fix direction
+step 2 should say "populate from the ACL verdict" (distinct from the existing
+git-crypt writer).
+
+Still coupled to TKT-73C6B2 — see its re-verification note; design the
+capture-time freeze once and cover both.

--- a/tickets/entities/tickets/TKT-SCXHUL.md
+++ b/tickets/entities/tickets/TKT-SCXHUL.md
@@ -37,3 +37,22 @@ Deliver as its own follow-up PR (per the TKT-92JL8P review discussion).
 ## Origin
 
 TKT-92JL8P follow-up — "add e2e as follow up pr."
+
+## Re-verification (2026-07-25, against develop dd0fe649)
+
+STILL VALID, scope UNCHANGED. Target surfaces exist and have zero e2e coverage:
+
+- `frontend/src/views/RelationHistoryView.vue` present; per-relation History
+  affordance present (`RelationCards.vue:511-516` History button;
+  `:167-176` `openRelationHistory`, outgoing-only).
+- No relation-history e2e anywhere in `e2e/` (grep for
+  relation-history/_relation_history/RelationHistory → zero). `relation-cards.spec.ts`
+  covers cards generally, not history. Entity history HAS e2e — this is the gap.
+
+Lifetime UI is OUT OF SCOPE (deliberately). TKT-HGE4KW shipped the
+deleted-relation LIFETIMES feature entirely backend + CLI — no frontend files
+changed. `frontend/src/api/history.ts` has no `listRelationLifetimes`/`record_id`
+and `RelationHistoryView.vue` has no lifetime picker. So there is nothing
+lifetime-related for this e2e to cover. Building the lifetime picker/affordance in
+the frontend (a `_lifetimes` client + a lifetime selector in RelationHistoryView)
+is a SEPARATE ticket that must land first; only then should an e2e cover it.


### PR DESCRIPTION
Doc-only ticket maintenance (`chore/*`, all three stay `backlog`). Re-verified the three deferred versioning follow-ups against current develop after the intervening ACL/versioning work (TKT-9E57, TKT-ZF2DTV, TKT-L9Q669) landed.

- **TKT-73C6B2** (freeze visibility verdict): STILL VALID, now sharper — TKT-9E57 made the field-visibility resolver conditional-grant capable (`resolver.go:629-654` evaluates `When` against the live store), so the deleted-entity under-redaction this ticket targets is now a live policy capability. Value went up; noted the coupling with B1F5Q1.
- **TKT-B1F5Q1** (relation field-level ACL redaction): STILL VALID. Corrected the stale "`Relation.Inaccessible` has zero writers" claim (`fsstore/markdown.go:349` writes it for git-crypt, not ACL) and pinned the current evidence (`RelationGrant` has no `Visible`; live GET emits `rel["meta"]` raw).
- **TKT-SCXHUL** (relation-history e2e): STILL VALID, scope unchanged. Marked lifetime UI explicitly out of scope — TKT-HGE4KW shipped backend/CLI only, no frontend lifetime surface exists yet.

No status changes; `rela validate` passes.