### PR TITLE
tickets: RR-UGKOI5 addressed (bounded export pool shipped in v1)

### DIFF
--- a/tickets/entities/doc-tasks/DOC-WWNE41.md
+++ b/tickets/entities/doc-tasks/DOC-WWNE41.md
@@ -1,0 +1,23 @@
+---
+id: DOC-WWNE41
+type: doc-task
+title: Fold docs/transforms.md into the docs-project generation pipeline
+description: docs/transforms.md was hand-authored during TKT-JF5JI8 because the docs/*.md files are generated from docs-project/entities/ and no source entity existed. Create a GUIDE-transforms entity (or fold the content into GUIDE-export) in docs-project/ so `just docs` owns the file, then remove the standalone hand-maintained copy. Noted as an accepted N/A in DOCS-FIY2UG.
+priority: low
+status: backlog
+---
+
+## Task
+
+`docs/transforms.md` (view-export / transform registry reference: registering
+transforms, CLI `rela render`, data-entry entity+list export, `export_render`
+override, security notes, v1 limits) is currently a standalone hand-maintained
+file, unlike the rest of `docs/*.md`, which `scripts/generate-docs.sh` (`just
+docs`) generates from `docs-project/entities/`.
+
+Steps:
+
+1. Create `GUIDE-transforms` in `docs-project/entities/guides/` carrying the transforms.md content (or fold it into `GUIDE-export` if one page is preferred), with the proper `path:` so generation emits `docs/transforms.md`.
+2. Wire concept/feature relations in docs-project (export feature, data-entry, metamodel).
+3. Run `just docs` and verify the generated file replaces the hand-authored one 1:1.
+4. Remove any now-stale hand-edits; from then on edits go through docs-project.

--- a/tickets/entities/guides/GUIDE-transforms.md
+++ b/tickets/entities/guides/GUIDE-transforms.md
@@ -1,0 +1,14 @@
+---
+id: GUIDE-transforms
+type: guide
+title: Transforms & View Export
+summary: 'Reference for the transform registry and view export: registering transforms, CLI render, data-entry entity/list export, export_render override, security model.'
+audience: intermediate
+path: transforms.md
+status: draft
+---
+
+Placeholder for the docs-project source of `docs/transforms.md`. Today the file
+is hand-authored (see DOC-WWNE41); this entity tracks the guide that the
+docs-project generation pipeline should own. Becomes `published` once `just
+docs` generates the page from a docs-project entity.

--- a/tickets/entities/review-responses/RR-UGKOI5.md
+++ b/tickets/entities/review-responses/RR-UGKOI5.md
@@ -4,6 +4,7 @@ type: review-response
 title: No global export concurrency limit in v1
 finding: Many simultaneous exports each spawn a subprocess + temp dir. Per-call timeout and output cap exist, but there is no global concurrency limit, so a burst could spawn many converters at once.
 severity: minor
+resolution: 'Implemented in v1 after all: transform.Engine wraps cmdexec with a bounded worker pool (WithMaxConcurrent, default 4) shared across requests — exports past the bound queue rather than pile on. The engine is constructed once per handler (pinned by TestExport_EngineIsSharedAcrossRequests), so the cap is a real global bound. Landed with the cmdexec confinement work and the engine-lifecycle simplification in PR #1188.'
 reason: v1 targets fast converters (pandoc) and the per-call timeout+cap bound each invocation; a global semaphore is a straightforward v2 addition alongside the async job model for slow converters. Documented as a known bound in the plan risks.
-status: deferred
+status: addressed
 ---

--- a/tickets/relations/DOC-WWNE41--affects--data-entry-ui.md
+++ b/tickets/relations/DOC-WWNE41--affects--data-entry-ui.md
@@ -1,0 +1,5 @@
+---
+from: DOC-WWNE41
+relation: affects
+to: data-entry-ui
+---

--- a/tickets/relations/DOC-WWNE41--affects--views.md
+++ b/tickets/relations/DOC-WWNE41--affects--views.md
@@ -1,0 +1,5 @@
+---
+from: DOC-WWNE41
+relation: affects
+to: views
+---

--- a/tickets/relations/DOC-WWNE41--triggered-by--TKT-JF5JI8.md
+++ b/tickets/relations/DOC-WWNE41--triggered-by--TKT-JF5JI8.md
@@ -1,0 +1,5 @@
+---
+from: DOC-WWNE41
+relation: triggered-by
+to: TKT-JF5JI8
+---

--- a/tickets/relations/DOC-WWNE41--updates--GUIDE-transforms.md
+++ b/tickets/relations/DOC-WWNE41--updates--GUIDE-transforms.md
@@ -1,0 +1,5 @@
+---
+from: DOC-WWNE41
+relation: updates
+to: GUIDE-transforms
+---


### PR DESCRIPTION
The deferred concurrency-limit finding was actually implemented in PR #1188: transform.Engine wraps cmdexec with a shared bounded worker pool (WithMaxConcurrent, default 4). Flip the review-response to addressed with resolution.