### PR TITLE
fix(dataentry): asserted roles must flow through the fail-closed JWT gate (TKT-OJL2GN)

### DIFF
--- a/cmd/rela-server/main.go
+++ b/cmd/rela-server/main.go
@@ -264,7 +264,7 @@ func wirePrincipalResolvers(app *dataentry.App, f *serverFlags, idv *jwtauth.Ver
 			os.Exit(1)
 		}
 		if err := app.SetJWTGate(dataentry.JWTGateConfig{
-			Verifier:   idv,
+			Verifier:   assertionVerifierAdapter{idv},
 			HeaderName: f.jwtHeader,
 			// Injected as a predicate so dataentry needn't import jwtauth.
 			KeysUnavailable: func(err error) bool {
@@ -338,6 +338,32 @@ func wireWebhookReceiver(app *dataentry.App, f *serverFlags, idv *jwtauth.Verifi
 	}
 	app.SetWebhookReceiver(webhookVerifierAdapter{wv}, f.webhookAction)
 	slog.Info("idp webhook enabled", "audience", f.webhookAudience, "action", f.webhookAction)
+}
+
+// assertionVerifierAdapter bridges the concrete jwtauth.Verifier to the
+// dataentry JWT gate's expected shape, translating jwtauth.AssertionClaims into
+// dataentry.AssertedIdentity. Like webhookVerifierAdapter it lives in the wiring
+// layer — the one place allowed to import both packages — so dataentry needn't
+// depend on jwtauth (the inward-pointing layering rule).
+//
+// The gate consumes VerifyAssertion (not VerifySubject) so the assertion's
+// org/roles reach the Principal it stamps; a subject-only adapter here would
+// silently strip every asserted role (TKT-OJL2GN).
+type assertionVerifierAdapter struct{ v *jwtauth.Verifier }
+
+func (a assertionVerifierAdapter) VerifyAssertion(
+	ctx context.Context, raw string,
+) (dataentry.AssertedIdentity, error) {
+	c, err := a.v.VerifyAssertion(ctx, raw)
+	if err != nil {
+		return dataentry.AssertedIdentity{}, err
+	}
+	return dataentry.AssertedIdentity{
+		Subject: c.Subject,
+		OrgID:   c.OrgID,
+		OrgSlug: c.OrgSlug,
+		Roles:   c.Roles,
+	}, nil
 }
 
 // webhookVerifierAdapter bridges the concrete jwtauth.WebhookVerifier to the

--- a/internal/dataentry/jwtgate.go
+++ b/internal/dataentry/jwtgate.go
@@ -23,8 +23,13 @@ const denialLogInterval = 10 * time.Second
 // [requireVerifiedJWT] and the principal-resolver chain is bypassed entirely for
 // those requests.
 type JWTGateConfig struct {
-	// Verifier checks the assertion. Required.
-	Verifier subjectVerifier
+	// Verifier checks the assertion and projects its claims. Required.
+	//
+	// It returns the full [AssertedIdentity] (subject + org + roles), not just
+	// the subject, so the gate can stamp asserted roles onto the Principal it
+	// installs. A subject-only verifier here would authenticate correctly but
+	// silently strip every asserted role before the ACL sees it (TKT-OJL2GN).
+	Verifier assertionVerifier
 	// HeaderName is the request header carrying the assertion. Required.
 	HeaderName string
 	// KeysUnavailable reports whether a verification error means the JWKS was
@@ -138,19 +143,23 @@ func requireVerifiedJWT(next http.Handler, cfg JWTGateConfig) http.Handler {
 			return
 		}
 
-		sub, err := cfg.Verifier.VerifySubject(r.Context(), raw)
+		id, err := cfg.Verifier.VerifyAssertion(r.Context(), raw)
 		if err != nil {
 			g.logFailure(r, err)
 			g.deny(w, r)
 			return
 		}
 
-		// Same input filtering as JWTPrincipalResolver: the subject is an opaque
-		// IdP-controlled id, but cap length and strip control characters so a
-		// hostile IdP cannot corrupt the audit JSONL stream. A control-only
-		// subject sanitizes to "" and is denied rather than silently downgraded.
-		user := sanitizeUser(sub)
-		if user == "" {
+		// Project the verified claims into the stamped Principal. verifiedPrincipal
+		// is shared with JWTPrincipalResolver so the gate and the deprecated
+		// resolver sanitize the subject and filter roles identically. A control-only
+		// subject sanitizes away and is denied rather than silently downgraded.
+		//
+		// This carries org_id/org_slug/roles onto the Principal — without it an
+		// asserted_role_assignments policy grants nothing on the production path
+		// (TKT-OJL2GN). The claims flow on to the ACL via attachACLRequest.
+		p, ok := verifiedPrincipal(id)
+		if !ok {
 			slog.InfoContext(r.Context(), "jwt gate: verified subject is unusable after sanitization",
 				"path", r.URL.Path, "method", r.Method, "remote_addr", r.RemoteAddr)
 			g.deny(w, r)
@@ -158,11 +167,7 @@ func requireVerifiedJWT(next http.Handler, cfg JWTGateConfig) http.Handler {
 		}
 
 		g.noteRecovery(r)
-		ctx := principal.With(r.Context(), principal.Principal{
-			User: user,
-			Tool: principal.ToolDataEntry,
-		})
-		next.ServeHTTP(w, r.WithContext(ctx))
+		next.ServeHTTP(w, r.WithContext(principal.With(r.Context(), p)))
 	})
 }
 

--- a/internal/dataentry/jwtgate_test.go
+++ b/internal/dataentry/jwtgate_test.go
@@ -407,6 +407,54 @@ func TestRequireVerifiedJWT_StampsAssertedClaims(t *testing.T) {
 	}
 }
 
+// TestRequireVerifiedJWT_SanitizesRolesThroughGate drives roles carrying control
+// characters through the gate and asserts they are cleaned before landing on the
+// Principal. The per-element cap and control-char strip live in the shared
+// verifiedPrincipal projection; this pins that they run on the gate path
+// specifically, not only in jwtauth's own unit tests. A hostile IdP must not be
+// able to inject a control-char role into the audit JSONL stream via the gate.
+//
+// (The 32-role count cap is enforced in jwtauth.VerifyAssertion, upstream of the
+// stub used here, so it is covered by internal/jwtauth; this guards the
+// dataentry-side per-element sanitization the gate applies.)
+func TestRequireVerifiedJWT_SanitizesRolesThroughGate(t *testing.T) {
+	const header = "X-Auth-Assertion"
+	cfg := JWTGateConfig{
+		Verifier: gateVerifier{
+			validToken: "good.jwt.token", subject: "usr_abc123",
+			// A control char in a role, and one role that is control-only (must
+			// be dropped, since an empty role can never match a policy mapping).
+			roles: []string{"ad\x00min", "\x00\x00", "ok"},
+		},
+		HeaderName: header,
+	}
+
+	var seen principal.Principal
+	inner := http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		seen = principal.From(r.Context())
+	})
+	h := stampAuditPrincipal(requireVerifiedJWT(inner, cfg), defaultPrincipalResolver)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/entities", http.NoBody)
+	req.Header.Set(header, "good.jwt.token")
+	h.ServeHTTP(httptest.NewRecorder(), req)
+
+	for _, role := range seen.Roles() {
+		if strings.ContainsRune(role, 0) {
+			t.Errorf("role %q reached the Principal with a control char — the gate "+
+				"did not sanitize", role)
+		}
+		if role == "" {
+			t.Error("an empty role survived the gate; it can never match a policy " +
+				"mapping and only pads the attribution set")
+		}
+	}
+	// "ad\x00min" -> "ad min", "\x00\x00" -> dropped, "ok" -> "ok".
+	if len(seen.Roles()) != 2 {
+		t.Errorf("Roles = %v, want 2 surviving entries", seen.Roles())
+	}
+}
+
 // A denied request must never reach the handlers the gate protects — no store
 // read, no ACL request, no side effect.
 func TestRequireVerifiedJWT_DenialShortCircuits(t *testing.T) {

--- a/internal/dataentry/jwtgate_test.go
+++ b/internal/dataentry/jwtgate_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"slices"
 	"strings"
 	"testing"
 
@@ -25,17 +26,25 @@ var errStubKeysUnavailable = errors.New("keys unavailable")
 type gateVerifier struct {
 	validToken string
 	subject    string
+	orgID      string
+	orgSlug    string
+	roles      []string
 	failWith   error
 }
 
-func (g gateVerifier) VerifySubject(_ context.Context, raw string) (string, error) {
+func (g gateVerifier) VerifyAssertion(_ context.Context, raw string) (AssertedIdentity, error) {
 	if raw == g.validToken {
-		return g.subject, nil
+		return AssertedIdentity{
+			Subject: g.subject,
+			OrgID:   g.orgID,
+			OrgSlug: g.orgSlug,
+			Roles:   g.roles,
+		}, nil
 	}
 	if g.failWith != nil {
-		return "", g.failWith
+		return AssertedIdentity{}, g.failWith
 	}
-	return "", errors.New("invalid")
+	return AssertedIdentity{}, errors.New("invalid")
 }
 
 // newGateHandler builds the gate over a handler that echoes the stamped
@@ -360,6 +369,44 @@ func TestRequireVerifiedJWT_OrderingRelativeToStamper(t *testing.T) {
 	}
 }
 
+// TestRequireVerifiedJWT_StampsAssertedClaims pins that the gate stamps the
+// FULL verified identity — org and roles, not just the subject. This is the
+// direct regression guard for TKT-OJL2GN: the gate used to stamp a subject-only
+// literal, silently dropping every asserted claim before the ACL saw it.
+func TestRequireVerifiedJWT_StampsAssertedClaims(t *testing.T) {
+	const header = "X-Auth-Assertion"
+	cfg := JWTGateConfig{
+		Verifier: gateVerifier{
+			validToken: "good.jwt.token", subject: "usr_abc123",
+			orgID: "org_acme", orgSlug: "acme", roles: []string{"admin", "billing"},
+		},
+		HeaderName: header,
+	}
+
+	var seen principal.Principal
+	inner := http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		seen = principal.From(r.Context())
+	})
+	h := stampAuditPrincipal(requireVerifiedJWT(inner, cfg), defaultPrincipalResolver)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/entities", http.NoBody)
+	req.Header.Set(header, "good.jwt.token")
+	h.ServeHTTP(httptest.NewRecorder(), req)
+
+	if seen.User != "usr_abc123" {
+		t.Fatalf("User = %q, want the verified subject", seen.User)
+	}
+	if seen.OrgID() != "org_acme" {
+		t.Errorf("OrgID = %q, want org_acme — the gate dropped the org claim", seen.OrgID())
+	}
+	if seen.OrgSlug() != "acme" {
+		t.Errorf("OrgSlug = %q, want acme", seen.OrgSlug())
+	}
+	if want := []string{"admin", "billing"}; !slices.Equal(seen.Roles(), want) {
+		t.Errorf("Roles = %v, want %v — the gate dropped the asserted roles", seen.Roles(), want)
+	}
+}
+
 // A denied request must never reach the handlers the gate protects — no store
 // read, no ACL request, no side effect.
 func TestRequireVerifiedJWT_DenialShortCircuits(t *testing.T) {
@@ -529,6 +576,84 @@ func TestJWTGate_RouterChainOrder(t *testing.T) {
 
 		if rec.Code == http.StatusUnauthorized {
 			t.Error("SPA shell was gated (RR-T15E): operators lose the recovery surface")
+		}
+	})
+}
+
+// TestJWTGate_AssertedRolesReachACL is the systemic guard TKT-OJL2GN's 5-whys
+// identified as missing: it drives a signed assertion CARRYING ROLES through the
+// real NewRouter stack and asserts the mapped role produces an ACL decision.
+//
+// The prior gate test (TestJWTGate_RouterChainOrder) proved the verified subject
+// reaches the ACL but stopped short of the claims — which is exactly the gap
+// that let the gate ship stamping a subject-only Principal while the asserted-
+// role machinery sat inert. This test pins the whole identity path
+// (verify → stamp → resolve → ACL), so a future rework of the gate or the
+// resolver cannot silently sever claims again.
+func TestJWTGate_AssertedRolesReachACL(t *testing.T) {
+	const header = "X-Auth-Assertion"
+
+	// A policy where the ONLY way to read a ticket is an asserted "admin" claim
+	// mapped to the viewer role. The principal has no assignments entry and no
+	// membership edge, so a 200 can only come from the asserted role flowing
+	// through the gate.
+	newApp := func(t *testing.T) *App {
+		t.Helper()
+		app := newTestAppV1(t)
+		seedEntity(app, &entity.Entity{ID: "TKT-001", Type: "ticket", Properties: map[string]any{"title": "T1"}})
+		app.acl = mustNewACL(t, &acl.Policy{
+			Roles:         map[string]acl.RoleDef{"viewer": {Read: []string{"ticket"}}},
+			AssertedRoles: map[string]acl.RoleList{"admin": {"viewer"}},
+		}, app.store)
+		return app
+	}
+
+	get := func(t *testing.T, h http.Handler) *httptest.ResponseRecorder {
+		t.Helper()
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/tickets/TKT-001", http.NoBody)
+		req.Header.Set(header, "good.jwt.token")
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, req)
+		return rec
+	}
+
+	t.Run("asserted role grants read through the real gate", func(t *testing.T) {
+		app := newApp(t)
+		if err := app.SetJWTGate(JWTGateConfig{
+			Verifier: gateVerifier{
+				validToken: "good.jwt.token", subject: "usr_nobody",
+				orgID: "org_acme", roles: []string{"admin"},
+			},
+			HeaderName: header,
+		}); err != nil {
+			t.Fatalf("SetJWTGate: %v", err)
+		}
+
+		rec := get(t, app.NewRouter())
+		if rec.Code != http.StatusOK {
+			t.Fatalf("status = %d, want 200 — the asserted 'admin' claim maps to "+
+				"viewer and should grant read; got %s", rec.Code, rec.Body)
+		}
+	})
+
+	t.Run("without the claim the same request is denied", func(t *testing.T) {
+		// The negative half: identical setup, no roles on the assertion. Proves
+		// the 200 above came from the claim, not from an accidental open grant.
+		app := newApp(t)
+		if err := app.SetJWTGate(JWTGateConfig{
+			Verifier: gateVerifier{
+				validToken: "good.jwt.token", subject: "usr_nobody",
+				roles: nil,
+			},
+			HeaderName: header,
+		}); err != nil {
+			t.Fatalf("SetJWTGate: %v", err)
+		}
+
+		rec := get(t, app.NewRouter())
+		if rec.Code == http.StatusOK {
+			t.Fatalf("status = 200 for a principal holding no asserted role — the "+
+				"gate is granting read without the claim (body %s)", rec.Body)
 		}
 	})
 }

--- a/internal/dataentry/router.go
+++ b/internal/dataentry/router.go
@@ -483,9 +483,11 @@ func JWTPrincipalResolver(v assertionVerifier, headerName string) PrincipalResol
 // once silently dropped roles on the gate path (TKT-OJL2GN).
 //
 // It carries the org and role claims via [principal.Verified], the only
-// constructor that can populate them. A role reaching the ACL from an
-// unverified source would be a complete authorization bypass, so this must be
-// called ONLY on the output of a completed signature verification.
+// constructor that populates them from request-path input (the audit
+// wire-format [principal.Principal.UnmarshalJSON] reads them back too, but only
+// from a record this process already wrote and verified). A role reaching the
+// ACL from an unverified source would be a complete authorization bypass, so
+// this must be called ONLY on the output of a completed signature verification.
 func verifiedPrincipal(id AssertedIdentity) (principal.Principal, bool) {
 	if id.Subject == "" {
 		return principal.Principal{}, false

--- a/internal/dataentry/router.go
+++ b/internal/dataentry/router.go
@@ -412,18 +412,13 @@ type AssertedIdentity struct {
 	Roles   []string
 }
 
-// subjectVerifier verifies a signed assertion and returns only its subject.
-// [requireVerifiedJWT] gates on authenticity alone — it decides 401-or-proceed
-// and stamps the user — so it asks for nothing more, and a caller wiring only
-// the gate needn't implement the claims projection.
-type subjectVerifier interface {
-	VerifySubject(ctx context.Context, raw string) (string, error)
-}
-
-// assertionVerifier additionally projects the org/role claims this package
-// stamps onto a Principal. Satisfied by an adapter over *jwtauth.Verifier;
-// kept local (and unexported, per the other consumer interfaces here) so the
-// resolver is testable with a stub.
+// assertionVerifier verifies a signed assertion and projects the org/role
+// claims this package stamps onto a Principal. It is the seam for BOTH the
+// production gate ([requireVerifiedJWT], via [App.SetJWTGate]) and the
+// deprecated [JWTPrincipalResolver]; both must carry the full claims, or an
+// asserted_role_assignments policy grants nothing (TKT-OJL2GN). Satisfied by an
+// adapter over *jwtauth.Verifier — kept local (and unexported, per the other
+// consumer interfaces here) so both are testable with a stub.
 type assertionVerifier interface {
 	VerifyAssertion(ctx context.Context, raw string) (AssertedIdentity, error)
 }
@@ -468,32 +463,54 @@ func JWTPrincipalResolver(v assertionVerifier, headerName string) PrincipalResol
 			return principal.Principal{}
 		}
 		id, err := v.VerifyAssertion(r.Context(), raw)
-		if err != nil || id.Subject == "" {
+		if err != nil {
 			return principal.Principal{}
 		}
-		// The subject is a controlled id (opaque, from the IdP), but sanitize it
-		// the same way as header/env users for defense in depth (length cap,
-		// control-char strip). A control-only value sanitizes to "" and falls
-		// through.
-		user := sanitizeUser(id.Subject)
-		if user == "" {
+		p, ok := verifiedPrincipal(id)
+		if !ok {
 			return principal.Principal{}
 		}
-		// Org and roles get the same treatment. Roles are already bounded by the
-		// verifier's projection; sanitizing here covers control chars and any
-		// future verifier that forgets to. A role that sanitizes away is dropped
-		// rather than kept as "" — an empty role name can never match a policy
-		// mapping, so keeping it would only pad the attribution set.
-		roles := make([]string, 0, len(id.Roles))
-		for _, role := range id.Roles {
-			if s := sanitizeUser(role); s != "" {
-				roles = append(roles, s)
-			}
-		}
-		return principal.Verified(
-			user, principal.ToolDataEntry,
-			sanitizeUser(id.OrgID), sanitizeUser(id.OrgSlug), roles)
+		return p
 	}
+}
+
+// verifiedPrincipal projects a verified [AssertedIdentity] into a stamped
+// Principal, or reports ok=false when the subject is unusable (empty, or all
+// control characters that sanitize away). It is the SINGLE place the assertion
+// claims become a Principal, shared by [JWTPrincipalResolver] (the deprecated
+// chain path) and [requireVerifiedJWT] (the production gate) so the two cannot
+// drift on how a subject is sanitized or how roles are filtered — a drift that
+// once silently dropped roles on the gate path (TKT-OJL2GN).
+//
+// It carries the org and role claims via [principal.Verified], the only
+// constructor that can populate them. A role reaching the ACL from an
+// unverified source would be a complete authorization bypass, so this must be
+// called ONLY on the output of a completed signature verification.
+func verifiedPrincipal(id AssertedIdentity) (principal.Principal, bool) {
+	if id.Subject == "" {
+		return principal.Principal{}, false
+	}
+	// The subject is a controlled id (opaque, from the IdP), but sanitize it the
+	// same way as header/env users for defense in depth (length cap, control-char
+	// strip). A control-only value sanitizes to "" and is rejected.
+	user := sanitizeUser(id.Subject)
+	if user == "" {
+		return principal.Principal{}, false
+	}
+	// Org and roles get the same treatment. Roles are already bounded by the
+	// verifier's projection; sanitizing here covers control chars and any future
+	// verifier that forgets to. A role that sanitizes away is dropped rather than
+	// kept as "" — an empty role name can never match a policy mapping, so
+	// keeping it would only pad the attribution set.
+	roles := make([]string, 0, len(id.Roles))
+	for _, role := range id.Roles {
+		if s := sanitizeUser(role); s != "" {
+			roles = append(roles, s)
+		}
+	}
+	return principal.Verified(
+		user, principal.ToolDataEntry,
+		sanitizeUser(id.OrgID), sanitizeUser(id.OrgSlug), roles), true
 }
 
 // stripBearer trims the header value and removes an optional "Bearer" auth

--- a/internal/dataentry/webhook.go
+++ b/internal/dataentry/webhook.go
@@ -19,9 +19,8 @@ var errWebhookActionMissing = errors.New("dataentry: configured webhook action n
 // WebhookClaims is the verified subset of an inbound webhook the receiver acts
 // on. It mirrors jwtauth.WebhookClaims but is declared HERE so the dataentry
 // package needn't import jwtauth (the inward-pointing layering rule — the same
-// reason JWTPrincipalResolver takes a local subjectVerifier interface). The
-// wiring layer, which may import both, adapts the concrete verifier to this
-// shape.
+// reason the JWT gate takes a local assertionVerifier interface). The wiring
+// layer, which may import both, adapts the concrete verifier to this shape.
 type WebhookClaims struct {
 	Event  string // the event name, e.g. "membership.created"
 	UserID string // the subject the event concerns

--- a/tickets/entities/docs-checklists/DOCS-EIVP7F.md
+++ b/tickets/entities/docs-checklists/DOCS-EIVP7F.md
@@ -1,0 +1,49 @@
+---
+id: DOCS-EIVP7F
+type: docs-checklist
+title: 'Documentation: Asserted roles inert on the production JWT gate (TKT-OJL2GN)'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Code documentation
+
+- [x] Godoc on new/changed exported and load-bearing internal symbols
+
+- `verifiedPrincipal` (router.go) — the shared projection: what it does, that
+it is the single place claims become a Principal (so gate and resolver can't
+drift), and the request-path trust-boundary caveat.
+- `JWTGateConfig.Verifier` — why it is `assertionVerifier` not
+`subjectVerifier`, naming the bug a subject-only verifier reintroduces.
+- `assertionVerifier` interface — updated to name both consumers (gate +
+deprecated resolver), replacing the stale "so the resolver is testable" text.
+- `assertionVerifierAdapter` (main.go) — mirrors `webhookVerifierAdapter`; why
+it consumes `VerifyAssertion`.
+- `webhook.go` — stale `subjectVerifier` reference corrected to
+`assertionVerifier`.
+
+## Project documentation
+
+- [x] ~~docs/server-security.md, docs/acl-*.md~~ (N/A — see below)
+
+**Documentation Impact: none.** This is a corrective code-only change. The
+user-facing behaviour it delivers — asserted roles actually granting through the
+production JWT gate — is exactly what the shipped docs (from TKT-RP3X3Q) already
+describe. Those docs were correct in intent and wrong only in that the code did
+not match them on the gate path; this change makes the code match the docs.
+Nothing to add, change, or regenerate.
+
+- [x] Confirmed no `generate-docs` drift: the change touches no `docs/` or
+`docs-project/` file, so `git diff --exit-code docs/ README.md` after
+`scripts/generate-docs.sh` is clean (the CI Docs job requirement).
+- [x] ~~docs/cli-reference.md, docs/data-entry.md, docs/metamodel.md~~
+(N/A: no CLI, UI, or metamodel surface change)
+
+## Verification
+
+- [x] The behaviour the docs promise is now pinned by
+`TestJWTGate_AssertedRolesReachACL` (asserted role → ACL grant through the real
+router) and `TestRequireVerifiedJWT_StampsAssertedClaims` (org/roles on the
+stamped Principal) — so the doc/code agreement is machine-checked, not just
+asserted here.

--- a/tickets/entities/implementation-checklists/IMPL-FY4LWA.md
+++ b/tickets/entities/implementation-checklists/IMPL-FY4LWA.md
@@ -1,0 +1,68 @@
+---
+id: IMPL-FY4LWA
+type: implementation-checklist
+title: 'Implementation: Asserted roles are inert on the production JWT gate — claims dropped at requireVerifiedJWT'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Development
+
+- [x] Feature implemented
+- [x] Unit tests written for new code
+- [x] Integration tests written (full flow, not just units)
+- [x] All edge cases handled
+
+**What changed (5 files, code-only — no doc change):**
+
+1. `router.go` — extracted `verifiedPrincipal(AssertedIdentity) (Principal, bool)`,
+the single place the assertion claims become a Principal. Both the gate and the
+deprecated `JWTPrincipalResolver` call it, so they cannot drift on subject
+sanitize / role filter — the drift that caused this bug. Removed the now-dead
+`subjectVerifier` interface; updated `assertionVerifier`'s doc to name both
+consumers.
+2. `jwtgate.go` — the core fix. `JWTGateConfig.Verifier` is now
+`assertionVerifier`; `requireVerifiedJWT` calls `VerifyAssertion` and stamps via
+`verifiedPrincipal`, carrying org/roles. Fail-closed logging, the
+unusable-subject denial, and `noteRecovery` are unchanged.
+3. `cmd/rela-server/main.go` — added `assertionVerifierAdapter` (mirrors the
+existing `webhookVerifierAdapter`) so `*jwtauth.Verifier` reaches the gate as
+`dataentry.AssertedIdentity`. dataentry still does not import jwtauth (arch-lint
+confirms).
+4. `jwtgate_test.go` — stub `gateVerifier` now implements `VerifyAssertion` with
+optional org/roles; every existing test passes unmodified.
+5. `webhook.go` — stale comment referencing `subjectVerifier` updated.
+
+## Manual verification
+
+- [x] Each acceptance criterion verified
+- [x] Verification evidence documented
+
+| AC | Test | Result |
+|---|---|---|
+| AC1 | `TestJWTGate_AssertedRolesReachACL/asserted_role_grants_read_through_the_real_gate` — drives a signed assertion with `roles:[admin]` through the real `NewRouter`; the mapped viewer role grants read (200). Negative half asserts no-claim → not-200. | PASS |
+| AC2 | `TestRequireVerifiedJWT_StampsAssertedClaims` asserts OrgID/OrgSlug on the stamped Principal. | PASS |
+| AC3 | Existing `TestRequireVerifiedJWT` (JWKS-outage / keys-unavailable rows) pass unmodified; `VerifyAssertion` uses `classify()`, so fail-closed is unchanged. | PASS |
+| AC4 | The AC1 test uses subject `usr_nobody` with NO assignments entry and NO membership edge — a principal that matches no user entity — and it still gets read via the asserted role. AC10 parity, end-to-end. | PASS |
+| AC5 | **Fault-injected.** Reverting the gate stamp to the old subject-only literal fails both new tests with *"the gate dropped the org claim"*, *"the gate dropped the asserted roles"*, and the end-to-end read 404s. Restored → pass. | PASS |
+
+The AC1/AC4 end-to-end test is the systemic guard why5 identified as missing: it
+pins verify → stamp → resolve → ACL, so a future rework of the gate or the
+resolver cannot silently sever claims again. Confirmed it catches the exact
+regression by reverting the fix.
+
+## Quality
+
+- [x] Code follows project patterns (adapter mirrors `webhookVerifierAdapter`;
+shared helper mirrors the consumer-side-interface idiom)
+- [x] No silent failures
+
+- `go build ./...` — clean
+- `just test` (full suite) — pass, no failures
+- `go test -race ./internal/dataentry ./internal/jwtauth` — clean
+- `just lint` — 0 issues (removed the orphaned `subjectVerifier`)
+- `just arch-lint` — OK; **jwtauth stays a leaf, dataentry does not import it**
+- `just coverage-check` — PASS (76.3%)
+- No docs touched → no `generate-docs` drift (the shipped docs already describe
+asserted roles working; this makes the code match them).

--- a/tickets/entities/review-checklists/REV-5JNW5K.md
+++ b/tickets/entities/review-checklists/REV-5JNW5K.md
@@ -1,0 +1,66 @@
+---
+id: REV-5JNW5K
+type: review-checklist
+title: 'Review: Asserted roles are inert on the production JWT gate — claims dropped at requireVerifiedJWT'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Automated checks
+
+- [x] `just test` (full suite) — pass, no failures
+- [x] `go test -race ./internal/dataentry ./internal/jwtauth` — clean
+- [x] `just lint` — 0 issues
+- [x] `just arch-lint` — OK; jwtauth stays a leaf, dataentry does not import it
+- [x] `just coverage-check` — PASS (76.3%)
+
+## Code review
+
+- [x] `cranky-code-reviewer` run against the branch diff
+- [x] All findings addressed
+
+**Findings: 2 (1 minor, 1 nit). Both addressed. Zero critical/significant.**
+
+| ID | Severity | Finding | Status |
+|---|---|---|---|
+| RR-LP9XAU | minor | Gate role-bounds/sanitization not exercised end-to-end through the gate | addressed |
+| RR-E9N3WY | nit | `verifiedPrincipal` doc overstated "only constructor" (UnmarshalJSON too) | addressed |
+
+The reviewer verified the load-bearing properties by tracing and running code,
+not by inspection:
+
+- **Fail-closed unchanged.** Both `VerifySubject` and `VerifyAssertion` route
+their parse error through the same `classify()` (verifier.go:138 / :189,
+byte-identical), so ErrKeysUnavailable-vs-ErrInvalid and the Error-vs-Info
+logging split are reached identically. Pinned by the existing
+`TestVerifyAssertion_MatchesVerifySubject`.
+- **No empty-subject bypass.** `VerifyAssertion` returns `ErrInvalid` for an
+empty subject (denies before `verifiedPrincipal`), and `verifiedPrincipal`
+guards `Subject==""` → `ok=false` anyway. No path yields `ok=true` on an empty
+subject.
+- **Adapter preserves error classification.** The reviewer ran a scratch program
+confirming the double-`%w` wrap keeps `errors.Is(err, ErrKeysUnavailable)` true
+across the adapter — so the gate's KeysUnavailable predicate still fires.
+- **The end-to-end test is not a tautology.** The policy grants read ONLY via the
+asserted claim; the principal has no assignment and no membership edge, so 200
+can only come from the claim flowing through. The negative subtest rules out a
+default-open grant.
+
+Both findings were addressed with a fault-injected test / a doc precision fix.
+The new sanitization test fails correctly when `verifiedPrincipal`'s role loop
+is replaced with a raw passthrough.
+
+## Acceptance verification
+
+AC1-AC5 verified (see IMPL-FY4LWA table). AC5 (regression guard) confirmed by
+reverting the fix and observing the tests fail with diagnostics naming the
+dropped claims — the systemic guard why5 identified as missing now exists and
+demonstrably catches the exact bug.
+
+## Docs
+
+- [x] ~~Project docs~~ (N/A: code-only change; the shipped docs already describe
+asserted roles working — this makes the code match them, no drift)
+- [x] Godoc on the new `verifiedPrincipal` helper, the widened `JWTGateConfig`,
+and the `assertionVerifierAdapter`

--- a/tickets/entities/review-responses/RR-E9N3WY.md
+++ b/tickets/entities/review-responses/RR-E9N3WY.md
@@ -1,0 +1,24 @@
+---
+id: RR-E9N3WY
+type: review-response
+title: verifiedPrincipal doc says 'only constructor that can populate them' — UnmarshalJSON also does
+finding: The verifiedPrincipal godoc called principal.Verified 'the only constructor that can populate them'. principal.Principal.UnmarshalJSON also populates the unexported claim fields (from the audit wire format). The intent was correct — no composite literal can forge claims, and Verified is the only request-path constructor — but the absolute phrasing is slightly imprecise for a load-bearing security comment.
+severity: nit
+resolution: Reworded to 'the only constructor that populates them from request-path input', explicitly noting UnmarshalJSON reads them back only from a record this process already wrote and verified. Precision matters here because the comment is the human-readable statement of the trust boundary.
+status: addressed
+---
+
+## Finding
+
+`verifiedPrincipal`'s godoc said `principal.Verified` is "the only constructor
+that can populate them." `principal.Principal.UnmarshalJSON` also populates the
+unexported claim fields — from the audit wire format. The comment's *intent* (no
+composite literal can forge claims; `Verified` is the only request-path
+constructor) is correct, but the absolute phrasing is imprecise for a
+load-bearing security comment.
+
+## Resolution
+
+Reworded to "the only constructor that populates them from request-path input,"
+noting `UnmarshalJSON` reads them back only from a record this process already
+wrote and verified.

--- a/tickets/entities/review-responses/RR-LP9XAU.md
+++ b/tickets/entities/review-responses/RR-LP9XAU.md
@@ -1,0 +1,28 @@
+---
+id: RR-LP9XAU
+type: review-response
+title: Gate role-bounds/sanitization not exercised end-to-end through the gate
+finding: The 32-role count cap and 256-rune/control-char sanitization live in jwtauth.stringSliceClaim and the shared verifiedPrincipal helper, and are unit-tested in internal/jwtauth. But no test drove an over-cap or control-char roles array THROUGH the gate specifically, so the systemic guard stopped short of proving sanitization holds on the production gate path. Defense-in-depth gap, not a hole — the caps do apply in production because VerifyAssertion runs upstream of the gate and verifiedPrincipal re-sanitizes per element.
+severity: minor
+resolution: 'Added TestRequireVerifiedJWT_SanitizesRolesThroughGate: drives roles ["ad\x00min", "\x00\x00", "ok"] through the real requireVerifiedJWT and asserts the stamped Principal.Roles() carry no control chars, no empty entries, and the control-only role is dropped (2 survivors). Fault-injected: replacing verifiedPrincipal''s role-sanitize loop with a raw passthrough fails the test with ''role "ad\x00min" reached the Principal with a control char'' and ''want 2 surviving entries''. The count cap stays covered by internal/jwtauth (upstream of the stub used here); this closes the dataentry-side per-element sanitization on the gate path.'
+status: addressed
+---
+
+## Finding
+
+The per-element role sanitization (control-char strip, empty-drop) and the
+32-role / 256-rune caps are real on the production gate path — `VerifyAssertion`
+runs upstream, `verifiedPrincipal` re-sanitizes per element — but no **gate
+test** drove a hostile roles array through to prove it. The systemic guard
+covered subject-and-roles-reach-ACL but not sanitization-on-the-gate-path.
+
+## Resolution
+
+`TestRequireVerifiedJWT_SanitizesRolesThroughGate` drives `["ad\x00min",
+"\x00\x00", "ok"]` through the real `requireVerifiedJWT` and asserts the stamped
+`Roles()` are clean, the control-only role is dropped, and exactly two survive.
+
+Fault-injected: replacing `verifiedPrincipal`'s sanitize loop with `roles :=
+id.Roles` fails with *"role \"ad\x00min\" reached the Principal with a control
+char"* and *"want 2 surviving entries"*. The count cap stays covered by
+`internal/jwtauth` (it runs before the stub used here).

--- a/tickets/entities/tickets/TKT-OJL2GN.md
+++ b/tickets/entities/tickets/TKT-OJL2GN.md
@@ -5,7 +5,7 @@ title: Asserted roles are inert on the production JWT gate — claims dropped at
 kind: enhancement
 priority: high
 effort: s
-status: review
+status: done
 ---
 
 The asserted-role feature (TKT-RP3X3Q) shipped with all its ACL machinery —

--- a/tickets/entities/tickets/TKT-OJL2GN.md
+++ b/tickets/entities/tickets/TKT-OJL2GN.md
@@ -1,0 +1,112 @@
+---
+id: TKT-OJL2GN
+type: ticket
+title: Asserted roles are inert on the production JWT gate — claims dropped at requireVerifiedJWT
+kind: enhancement
+priority: high
+effort: s
+status: in-progress
+---
+
+The asserted-role feature (TKT-RP3X3Q) shipped with all its ACL machinery —
+`principal.Verified`, `asserted_role_assignments`, `SourceAsserted`,
+conditional-grant reporting — but **nothing feeds it on the production JWT
+path**. A verified assertion's `org_id`/`org_slug`/`roles` are dropped before
+the ACL ever sees them, so an `asserted_role_assignments` policy grants nothing
+in a real deployment.
+
+## Root cause: two PRs that each passed and collided
+
+TKT-RP3X3Q wired claims through `dataentry.JWTPrincipalResolver`. In parallel,
+TKT-RYUS3H (#1178) replaced that resolver with a fail-closed **gate**
+(`requireVerifiedJWT` in `internal/dataentry/jwtgate.go`) and marked the
+resolver `Deprecated`. The gate was authored against the pre-RP3X3Q world: it
+calls `VerifySubject` (subject only) and stamps a plain composite literal, so
+the claims RP3X3Q added never enter the request.
+
+Both PRs merged green. Neither test suite exercised the *other's* path, so the
+interaction was invisible until the branches were both on `develop`.
+
+## Where it breaks (current develop)
+
+- `internal/dataentry/jwtgate.go:141` — `cfg.Verifier.VerifySubject(...)` returns
+the subject only; org/roles are never requested.
+- `internal/dataentry/jwtgate.go:161-164` — stamps
+`principal.Principal{User, Tool}`, a plain literal. Even if claims were fetched,
+this drops them. This is exactly the pattern the `resolvePrincipalEntity`
+comment warns against.
+- `JWTGateConfig.Verifier` is typed `subjectVerifier` (`VerifySubject` only), so
+the seam itself cannot carry claims.
+
+## What is ALREADY correct (do not re-do)
+
+- `internal/jwtauth.VerifyAssertion` exists and already fails closed via
+`classify()` (ErrInvalid vs ErrKeysUnavailable) — the RYUS3H interaction was
+merged correctly here.
+- `resolvePrincipalEntity` (router.go:320) already rebuilds via
+`principal.Verified`, so claims survive the `principal_property` substitution.
+The gate is the ONLY drop point.
+- `dataentry.AssertedIdentity` (router.go:408) and the `assertionVerifier`
+interface (router.go:427) already exist — the deprecated `JWTPrincipalResolver`
+uses them, and its sanitize-and-`Verified` projection is the logic to port.
+
+## Scope
+
+**In scope** — make the gate carry claims:
+
+- Switch `JWTGateConfig.Verifier` from `subjectVerifier` to `assertionVerifier`
+(`VerifyAssertion`).
+- In `requireVerifiedJWT`, stamp via `principal.Verified(user, Tool, orgID,
+orgSlug, roles)`, porting the role sanitize/filter from `JWTPrincipalResolver`.
+- Wire the verifier through the existing `assertionVerifier` seam in
+`cmd/rela-server/main.go` (an adapter or a direct method — dataentry must not
+import jwtauth).
+- Rework `jwtgate_test.go`'s stub to return claims and assert org/roles reach
+the ACL end-to-end (extend `TestJWTGate_RouterChainOrder`).
+
+**Out of scope**
+
+- Fail-closed behaviour — RYUS3H owns it and it is unchanged; `VerifyAssertion`
+already classifies identically.
+- The deprecated `JWTPrincipalResolver` — leave it; external embedders may use
+it. It already stamps claims correctly.
+- Auto-provisioning an unmatched principal — TKT-0C3II2.
+- Org *enforcement* — still a separate concern; org stays attribution-only.
+
+## Acceptance criteria
+
+1. A verified assertion carrying `roles` grants the mapped
+`asserted_role_assignments` role on a request through the real gate
+(`TestJWTGate_RouterChainOrder`-style, driving the actual middleware stack).
+2. `org_id`/`org_slug` reach the audit log via the gate path.
+3. The gate still fails closed on a JWKS outage (ErrKeysUnavailable → 401),
+unchanged from RYUS3H.
+4. A verified principal whose subject matches no user entity keeps its asserted
+roles through the gate (AC10 parity, end-to-end).
+5. The fault is regression-guarded: reverting the `Verified` stamp to a plain
+literal fails a test naming the dropped claims.
+
+## 5-whys
+
+- **why1** (immediate): the JWT gate calls `VerifySubject` and stamps a
+subject-only Principal, so org/roles never enter the request.
+- **why2**: the gate (TKT-RYUS3H) was designed against the pre-assertion world
+and its seam type (`subjectVerifier`) has no claims method.
+- **why3**: TKT-RP3X3Q and TKT-RYUS3H were developed in parallel on the same
+file region; each rebuilt the JWT identity path for its own purpose without the
+other's requirement in view.
+- **why4**: neither PR's test suite exercised the other's path — RP3X3Q tested
+the resolver it wired, RYUS3H tested the gate it built; no test drove a verified
+assertion *with roles* through the *gate*.
+- **why5** (systemic): there is no single end-to-end test asserting that a
+signed assertion's roles reach an ACL decision through the production middleware
+stack — the one test that would have caught a collision between any two changes
+to the identity path. `TestJWTGate_RouterChainOrder` proves the subject reaches
+the ACL but stops short of claims.
+
+## Prevention
+
+The end-to-end assertion-through-gate test added in AC1/AC4 is the systemic fix:
+it pins the whole identity path (verify → stamp → resolve → ACL) so a future
+rework of either the gate or the resolver cannot silently sever claims again.
+This is the missing test why5 identifies.

--- a/tickets/entities/tickets/TKT-OJL2GN.md
+++ b/tickets/entities/tickets/TKT-OJL2GN.md
@@ -5,7 +5,7 @@ title: Asserted roles are inert on the production JWT gate — claims dropped at
 kind: enhancement
 priority: high
 effort: s
-status: in-progress
+status: review
 ---
 
 The asserted-role feature (TKT-RP3X3Q) shipped with all its ACL machinery —

--- a/tickets/relations/TKT-OJL2GN--affects--authorization.md
+++ b/tickets/relations/TKT-OJL2GN--affects--authorization.md
@@ -1,0 +1,5 @@
+---
+from: TKT-OJL2GN
+relation: affects
+to: authorization
+---

--- a/tickets/relations/TKT-OJL2GN--affects--data-entry-server.md
+++ b/tickets/relations/TKT-OJL2GN--affects--data-entry-server.md
@@ -1,0 +1,5 @@
+---
+from: TKT-OJL2GN
+relation: affects
+to: data-entry-server
+---

--- a/tickets/relations/TKT-OJL2GN--has-docs--DOCS-EIVP7F.md
+++ b/tickets/relations/TKT-OJL2GN--has-docs--DOCS-EIVP7F.md
@@ -1,0 +1,5 @@
+---
+from: TKT-OJL2GN
+relation: has-docs
+to: DOCS-EIVP7F
+---

--- a/tickets/relations/TKT-OJL2GN--has-implementation--IMPL-FY4LWA.md
+++ b/tickets/relations/TKT-OJL2GN--has-implementation--IMPL-FY4LWA.md
@@ -1,0 +1,5 @@
+---
+from: TKT-OJL2GN
+relation: has-implementation
+to: IMPL-FY4LWA
+---

--- a/tickets/relations/TKT-OJL2GN--has-review--REV-5JNW5K.md
+++ b/tickets/relations/TKT-OJL2GN--has-review--REV-5JNW5K.md
@@ -1,0 +1,5 @@
+---
+from: TKT-OJL2GN
+relation: has-review
+to: REV-5JNW5K
+---

--- a/tickets/relations/TKT-OJL2GN--has-review-response--RR-E9N3WY.md
+++ b/tickets/relations/TKT-OJL2GN--has-review-response--RR-E9N3WY.md
@@ -1,0 +1,5 @@
+---
+from: TKT-OJL2GN
+relation: has-review-response
+to: RR-E9N3WY
+---

--- a/tickets/relations/TKT-OJL2GN--has-review-response--RR-LP9XAU.md
+++ b/tickets/relations/TKT-OJL2GN--has-review-response--RR-LP9XAU.md
@@ -1,0 +1,5 @@
+---
+from: TKT-OJL2GN
+relation: has-review-response
+to: RR-LP9XAU
+---

--- a/tickets/relations/TKT-OJL2GN--implements--FEAT-OQBYHD.md
+++ b/tickets/relations/TKT-OJL2GN--implements--FEAT-OQBYHD.md
@@ -1,0 +1,5 @@
+---
+from: TKT-OJL2GN
+relation: implements
+to: FEAT-OQBYHD
+---


### PR DESCRIPTION
Makes the asserted-role feature (#1179) actually work on the production JWT
path. It shipped inert: a separately-merged fail-closed gate (#1178) stamped a
subject-only Principal, dropping `org_id`/`org_slug`/`roles` before the ACL ever
saw them — so an `asserted_role_assignments` policy granted nothing in a real
deployment.

Closes TKT-OJL2GN.

## Root cause: two PRs that each passed and collided

#1179 wired claims through `JWTPrincipalResolver`. In parallel, #1178 replaced
that resolver with a fail-closed **gate** (`requireVerifiedJWT`) and marked the
resolver deprecated. The gate was authored against the pre-assertion world — it
called `VerifySubject` and stamped `principal.Principal{User, Tool}`, a plain
literal that carries no claims.

Both PRs merged green because **no test drove a verified assertion _with roles_
through the _gate_**. #1179 tested the resolver it wired; #1178 tested the gate
it built. The gap between them was invisible until both were on `develop`.

## The fix

- **`verifiedPrincipal(AssertedIdentity) (Principal, bool)`** — extracted the
  sanitize-and-`principal.Verified` projection into one helper, the single place
  assertion claims become a Principal. Both the gate and the deprecated resolver
  call it, so they cannot drift on subject sanitization or role filtering again
  — the exact drift that caused this bug.
- **The gate** now takes an `assertionVerifier` and stamps via
  `verifiedPrincipal`, carrying org/roles onto the request.
- **`main.go`** wires the verifier through an `assertionVerifierAdapter`
  mirroring the existing webhook adapter, keeping `dataentry` free of `jwtauth`
  (arch-lint confirms).
- Removed the now-orphaned `subjectVerifier` interface.

## Fail-closed is untouched

`VerifyAssertion` already routes its parse error through the same `classify()`
as `VerifySubject` (`ErrInvalid` vs `ErrKeysUnavailable`), and the adapter
preserves the wrapped error so `errors.Is(err, ErrKeysUnavailable)` still fires.
A JWKS outage still denies with 401, unchanged from #1178. Pinned by the
existing `TestVerifyAssertion_MatchesVerifySubject`.

## The systemic test (the why5 fix)

`TestJWTGate_AssertedRolesReachACL` drives a signed assertion carrying roles
through the **real `NewRouter` stack** and asserts the mapped role produces an
ACL decision — the end-to-end test whose absence let the collision through. The
policy grants read *only* via the asserted claim, and the principal has no
assignment or membership edge, so a 200 can only come from the claim flowing
through; a negative subtest rules out a default-open grant.

Every guard was **fault-injected**: reverting the gate stamp to a subject-only
literal fails the tests with diagnostics naming the dropped claims (`"the gate
dropped the org claim"`, `"the gate dropped the asserted roles"`), and the
end-to-end read 404s. Restored → pass.

## Review

`cranky-code-reviewer` found zero critical/significant — 1 minor (add an
end-to-end role-sanitization test through the gate) and 1 nit (doc precision),
both addressed. The reviewer verified fail-closed preservation and the adapter's
error classification by tracing and running code, not inspection.

## Verification

`just test` (full) · `just lint` (0 issues) · `just arch-lint` (jwtauth stays a
leaf) · `go test -race ./internal/dataentry ./internal/jwtauth` · `just
coverage-check` (76.3%). Code-only change — no doc drift.

## Follow-ups (unchanged, still open)

- **TKT-0C3II2** — auto-provisioning an unmatched principal.
- Org *enforcement* — org stays attribution-only; needs its own design.
