### PR TITLE
docs(acl): scope field-level visible: to value redaction, not field-existence

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,8 +54,14 @@
   (`Reader`, the tracer decorator) injected at the wiring site — never
   by per-consumer redaction calls, and never inside `store`/`tracer`/
   `search` themselves (DEC-ZBI39P; the `search.VisibleSearcher`
-  pattern generalized). Hidden = nonexistent (pruned subtrees,
-  withheld paths, indistinguishable 404s). A system job that may read
+  pattern generalized). **Row-level**: a hidden entity is nonexistent —
+  pruned subtrees, withheld paths, a denied GET indistinguishable from a
+  real 404 (whether an entity *exists* is a genuine secret). **Field-level**
+  (`visible:`): redaction hides property **values only** — it makes no claim
+  to conceal *which* properties exist, since the metamodel (declared property
+  names per type) is served over the API. A "field-existence oracle" is not a
+  threat this guards against; code need not contort to hide field names, only
+  their values. A system job that may read
   everything gets an `AllowAllReader` capability at wiring while
   keeping its genuine `system:*` principal for audit — allow-all is
   never inferred from identity. Write-prep reads (entitymanager


### PR DESCRIPTION
Narrows the read-side ACL rule in CLAUDE.md to match what field-level `visible:` redaction actually protects.

The rule previously lumped field-level redaction under the same "Hidden = nonexistent … indistinguishable" banner as row-level gating. But field *names* are public — the metamodel (declared properties per type) is served over the API — so there is no "field-existence oracle" to defend, only the field **values**. The old wording implied code should conceal which fields exist, which isn't a real threat and invites contortions.

This edit splits the two:
- **Row-level** — a hidden *entity* is nonexistent (pruned subtrees, withheld paths, indistinguishable 404s). Kept as-is; whether an entity exists is a genuine secret.
- **Field-level** (`visible:`) — redaction hides property **values only**; no claim to conceal which properties exist.

No code or package-doc change: the `internal/visibility` godoc (RR-NGMI, "no existence oracle") only ever asserts oracle-freedom for *entity existence*, so it was already consistent with this narrower framing.

Tickets-PR: #1214
