### PR TITLE
ci: widen ticket gate to all work-item entities

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -525,32 +525,68 @@ jobs:
         if: steps.gate.outputs.applies == 'true'
         run: go build -o bin/rela ./cmd/rela
 
-      - name: Check for new or modified bug/feature/ticket entity
+      - name: Check for new or modified work-item entity
         if: steps.gate.outputs.require_new == 'true'
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PR_BODY: ${{ github.event.pull_request.body }}
         run: |
           set -euo pipefail
 
           # Get list of added or modified entity files in this PR
           # A = Added (new tickets), M = Modified (continuation work on existing tickets)
+          #
+          # Any work-item entity counts, not just bugs/features/tickets: flipping a
+          # review-response to `addressed` or closing out a doc-task is exactly the
+          # ticket hygiene this gate wants, and failing it for touching the "wrong"
+          # entity subdirectory taught people to bolt a no-op ticket edit onto the PR.
+          # Reference material (concepts, decisions, ideas, guides) is deliberately
+          # NOT here — editing a concept is not evidence of tracked work.
           CHANGED_ENTITIES=$(git diff --name-only --diff-filter=AM "${BASE_SHA}"...HEAD -- \
             'tickets/entities/bugs/*.md' \
             'tickets/entities/features/*.md' \
-            'tickets/entities/tickets/*.md' || true)
+            'tickets/entities/tickets/*.md' \
+            'tickets/entities/researchs/*.md' \
+            'tickets/entities/review-responses/*.md' \
+            'tickets/entities/doc-tasks/*.md' \
+            'tickets/entities/bug-analysis-checklists/*.md' \
+            'tickets/entities/implementation-checklists/*.md' \
+            'tickets/entities/planning-checklists/*.md' \
+            'tickets/entities/review-checklists/*.md' \
+            'tickets/entities/docs-checklists/*.md' || true)
+
+          # A code-only PR may carry its tickets on a companion branch (so the code
+          # PR is reviewable as code, and the ticket PR merges when the work actually
+          # reaches a terminal state). Such a PR declares the companion explicitly.
+          TICKETS_PR=""
+          if [[ -n "${PR_BODY:-}" ]]; then
+            TICKETS_PR=$(printf '%s' "$PR_BODY" \
+              | grep -oiE 'Tickets-PR:[[:space:]]*#?[0-9]+' \
+              | head -1 | grep -oE '[0-9]+' || true)
+          fi
+
+          if [[ -z "$CHANGED_ENTITIES" && -n "$TICKETS_PR" ]]; then
+            echo "No work-item entity in this PR, but it declares its tickets live in #${TICKETS_PR}."
+            echo "Ticket state is gated on that PR; this one is code-only."
+            exit 0
+          fi
 
           if [[ -z "$CHANGED_ENTITIES" ]]; then
             echo ""
-            echo "ERROR: PR must include a new or modified bug, feature, or ticket entity in tickets/entities/"
+            echo "ERROR: PR must include a new or modified work-item entity in tickets/entities/"
             echo ""
             echo "Create one with:"
             echo "  rela create bug --project tickets -P title='Title'"
             echo "  rela create feature --project tickets -P title='Title'"
             echo "  rela create ticket --project tickets -P title='Title'"
+            echo ""
+            echo "Or, if this PR is code-only and its tickets live on a companion"
+            echo "branch, add a line to the PR body:"
+            echo "  Tickets-PR: #1234"
             exit 1
           fi
 
-          echo "Found ticket entities:"
+          echo "Found work-item entities:"
           echo "$CHANGED_ENTITIES"
 
       - name: Run rela validate

--- a/tickets/entities/docs-checklists/DOCS-B76AT8.md
+++ b/tickets/entities/docs-checklists/DOCS-B76AT8.md
@@ -1,0 +1,34 @@
+---
+id: DOCS-B76AT8
+type: docs-checklist
+title: 'Docs: Ticket gate rejects code-only and non-bug-entity PRs'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Code Documentation
+
+- [x] Comments where logic isn't obvious — the widened glob list carries a
+      comment explaining why work-item entities count and why reference
+      material (concepts, decisions, ideas) deliberately does not, so the
+      next person does not "tidy" the exclusion away
+- [x] ~~Function/type docs if public API~~ (N/A: shell step in a workflow
+      file, no Go API surface)
+
+## Project Documentation
+
+- [x] ~~README updated~~ (N/A: README does not document CI gate internals)
+- [x] ~~CLAUDE.md updated~~ (N/A: no new code pattern — this is a policy
+      widening of an existing gate, not a convention contributors write
+      code against)
+- [x] ~~Help text accurate~~ (N/A: no CLI change). The equivalent
+      contributor-facing text is the step's own error output, which now
+      documents the `Tickets-PR:` trailer alongside the `rela create`
+      suggestions.
+
+## External Documentation
+
+- [x] ~~Changelog entry added~~ (N/A: internal CI policy, not a shipped
+      user-visible change)
+- [x] ~~API docs updated~~ (N/A: no API change)

--- a/tickets/entities/review-checklists/REV-XBQ5DR.md
+++ b/tickets/entities/review-checklists/REV-XBQ5DR.md
@@ -1,0 +1,79 @@
+---
+id: REV-XBQ5DR
+type: review-checklist
+title: 'Review: Ticket gate rejects code-only and non-bug-entity PRs'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Automated Checks
+
+- [x] All tests pass (`just test`) — run by the pre-commit hook on 822fceb
+- [x] Lint clean (`just lint`) — 0 issues, pre-commit hook
+- [x] ~~Coverage maintained (`just coverage-check`)~~ (N/A: no Go code
+      changed; the diff is a workflow YAML file plus ticket entities)
+
+## Code Review
+
+- [x] ~~Run `/code-review` command~~ (N/A: no application code — the change
+      is a CI workflow step, reviewed directly against the GitHub Actions
+      script-injection guidance; see the trailer-parsing evidence below)
+- [x] All critical review-responses addressed — none raised
+- [x] All significant review-responses addressed — none raised
+- [x] Self-reviewed the diff for unrelated changes — the branch carries only
+      `.github/workflows/ci.yml` plus this ticket's entities. Pre-existing
+      unrelated edits in the working tree (`e2e/tests/fixtures.ts`,
+      `scripts/reachability.sh`, `reachability*.out`) were left unstaged.
+
+**Review Responses:** none
+
+## Acceptance Verification
+
+- [x] Each acceptance criterion tested
+- [x] Test evidence documented below
+
+**Acceptance Status:**
+
+- **Widened allowlist accepts ticket-hygiene PRs** — PASS. Replayed the new
+  glob set against `origin/tickets/rr-ugkoi5-addressed` (PR #1209) from its
+  real merge-base: matches `review-responses/RR-UGKOI5.md` and
+  `doc-tasks/DOC-WWNE41.md`. Previously matched nothing.
+- **Code-only PR can pass via companion trailer** — PASS. Replayed against
+  `origin/fix/views-acl-field-redaction` (PR #1212): still matches no
+  work-item entity, so it takes the `Tickets-PR:` branch.
+- **Existing ticket PRs still match** — PASS. `origin/tickets/acl-shielding-bugs`
+  (PR #1214) matches 7 entities, a superset of what the old three globs found.
+- **Trailer parsing is correct and injection-safe** — PASS. Table-tested
+  plain / no-hash / lowercase / mid-prose / absent / empty, plus
+  `'...; rm -rf /'`, `'$(whoami)'` and backtick payloads. The body is bound
+  via `env:` and never interpolated into the script; only `[0-9]+` is ever
+  extracted, so command substitutions yield empty.
+- **Gate does not become a merge loophole** — PASS. The
+  `Ticket done-before-merge check` step is unchanged and still globs only
+  `bugs/` + `tickets/`, so terminal-status enforcement is intact.
+- **Workflow still parses** — PASS. `yaml.safe_load` on `ci.yml` succeeds.
+
+## Documentation (enhancements only)
+
+- [x] Docs-checklist created and linked via `has-docs`
+- [x] ~~User-facing documentation updated~~ (N/A: internal CI policy with no
+      user-facing surface; the contributor-facing contract is the error
+      message the step prints, updated to document the `Tickets-PR:` trailer)
+- [x] Docs-checklist marked as done
+
+**Docs Checklist:** DOCS-B76AT8
+
+## Final Checks
+
+- [x] Commit message explains the why, not just what
+- [x] No TODOs or FIXMEs left unaddressed
+- [x] Ready for another developer to use
+
+## Pull Request
+
+- [x] Run `/pr` command to create PR and monitor CI
+- [x] All CI checks pass
+- [x] PR URL documented below
+
+**PR:** https://github.com/sourcehaven-bv/rela/pull/1215

--- a/tickets/entities/review-checklists/REV-XBQ5DR.md
+++ b/tickets/entities/review-checklists/REV-XBQ5DR.md
@@ -76,4 +76,4 @@ status: done
 - [x] All CI checks pass
 - [x] PR URL documented below
 
-**PR:** https://github.com/sourcehaven-bv/rela/pull/1215
+**PR:** https://github.com/sourcehaven-bv/rela/pull/1216

--- a/tickets/entities/tickets/TKT-IVQKQ3.md
+++ b/tickets/entities/tickets/TKT-IVQKQ3.md
@@ -1,0 +1,56 @@
+---
+id: TKT-IVQKQ3
+type: ticket
+title: Ticket gate rejects code-only and non-bug-entity PRs
+kind: enhancement
+priority: medium
+effort: s
+description: 'The "Rela Tickets" CI gate required a changed file under one of three entity directories (bugs/features/tickets), which rejected two legitimate PR shapes: a ticket-hygiene PR touching only review-responses or doc-tasks, and a code-only PR whose tickets were deliberately split onto a companion branch.'
+status: done
+---
+
+## Description
+
+The `Check for new or modified bug/feature/ticket entity` step in `ci.yml`
+globbed exactly three of the fifteen directories under `tickets/entities/`:
+`bugs/`, `features/`, `tickets/`. Anything else counted as "no ticket".
+
+Two real PRs failed on this without doing anything wrong:
+
+- **#1209** flips `RR-UGKOI5` from `deferred` to `addressed` and closes out
+  `DOC-WWNE41`. Both are work-item entities and this is precisely the ticket
+  hygiene the gate wants — it failed for touching the "wrong" subdirectory.
+- **#1212** is the `_views` ACL redaction fix, deliberately kept code-only so
+  it is reviewable as code, with its tickets on companion branch #1214. The
+  gate structurally cannot pass for a clean code/ticket split.
+
+The failure mode this creates is worse than the gap: the cheapest way to get
+green is to bolt a no-op edit onto an unrelated ticket, which is exactly the
+stale-ticket problem the gate exists to prevent.
+
+## Fix
+
+Widen the allowlist to every *work-item* entity type — bugs, features,
+tickets, research, review-responses, doc-tasks and the five checklist types.
+Reference material (`concepts/`, `decisions/`, `ideas/`, `future-concepts/`,
+`automated-measures/`) stays out: editing a concept is not evidence of
+tracked work.
+
+For the code-only split, a PR may declare its companion in the body:
+
+```text
+Tickets-PR: #1214
+```
+
+Ticket state is then gated on that PR, which carries the entities and must
+itself pass the done-before-merge check before it can merge.
+
+## Scope
+
+The `Ticket done-before-merge check` step is **unchanged** — it still scans
+only `bugs/` and `tickets/` and still requires a terminal status. Widening
+what counts as *referencing* the ticket graph does not widen what counts as
+*finishing* the work, so no unfinished bug becomes mergeable as a result.
+
+The PR body is read via an `env:` binding and only `[0-9]+` is ever extracted
+from it, so the trailer is not a script-injection surface.

--- a/tickets/relations/TKT-IVQKQ3--affects--ci-pipeline.md
+++ b/tickets/relations/TKT-IVQKQ3--affects--ci-pipeline.md
@@ -1,0 +1,5 @@
+---
+from: TKT-IVQKQ3
+relation: affects
+to: ci-pipeline
+---

--- a/tickets/relations/TKT-IVQKQ3--has-docs--DOCS-B76AT8.md
+++ b/tickets/relations/TKT-IVQKQ3--has-docs--DOCS-B76AT8.md
@@ -1,0 +1,5 @@
+---
+from: TKT-IVQKQ3
+relation: has-docs
+to: DOCS-B76AT8
+---

--- a/tickets/relations/TKT-IVQKQ3--has-review--REV-XBQ5DR.md
+++ b/tickets/relations/TKT-IVQKQ3--has-review--REV-XBQ5DR.md
@@ -1,0 +1,5 @@
+---
+from: TKT-IVQKQ3
+relation: has-review
+to: REV-XBQ5DR
+---

--- a/tickets/relations/TKT-IVQKQ3--implements--FEAT-GE1YY.md
+++ b/tickets/relations/TKT-IVQKQ3--implements--FEAT-GE1YY.md
@@ -1,0 +1,5 @@
+---
+from: TKT-IVQKQ3
+relation: implements
+to: FEAT-GE1YY
+---


### PR DESCRIPTION
## Problem

The `Rela Tickets` gate required a changed file under one of three directories (`bugs/`, `features/`, `tickets/`) out of the fifteen under `tickets/entities/`. Two open PRs fail it without doing anything wrong:

- **#1209** flips `RR-UGKOI5` `deferred` → `addressed` and closes `DOC-WWNE41`. Both are work-item entities, and this is exactly the ticket hygiene the gate wants — it fails for touching the "wrong" subdirectory.
- **#1212** (the `_views` ACL redaction fix) is deliberately code-only so it reviews as code, with its tickets on companion branch #1214. A clean code/ticket split structurally cannot pass.

The incentive this creates is worse than the gap: the cheapest way to green is to bolt a no-op edit onto an unrelated ticket — which is the stale-ticket problem the gate exists to prevent (cf. TKT-QXHFJZ).

## Fix

Widen the allowlist to every **work-item** entity type: bugs, features, tickets, research, review-responses, doc-tasks, and the five checklist types. Reference material (`concepts/`, `decisions/`, `ideas/`, `future-concepts/`, `automated-measures/`) stays out — editing a concept is not evidence of tracked work.

For the code-only split, a PR may declare its companion in the body:

```
Tickets-PR: #1214
```

Ticket state is then gated on that PR, which carries the entities and must pass the done-before-merge check itself.

## What this does NOT change

The `Ticket done-before-merge check` step is untouched — still globs only `bugs/` + `tickets/`, still requires a terminal status. Widening what counts as *referencing* the ticket graph does not widen what counts as *finishing* the work. No unfinished bug becomes mergeable.

Note this PR does **not** try to make #1214 green: that one fails `rela validate` because `BUG-R9EHKV` is `in-progress` and `BUG-9QL9XV` is in `review`, which is the gate correctly reporting the bugs aren't done.

## Verification

Replayed the new glob set against all three branches from their real merge-bases:

| PR | Old | New |
| -- | --- | --- |
| #1209 | no match | `RR-UGKOI5.md`, `DOC-WWNE41.md` |
| #1212 | no match | no match → takes the `Tickets-PR:` branch |
| #1214 | 2 entities | 7 entities (superset) |

Trailer parsing table-tested: plain / no-hash / lowercase / mid-prose / absent / empty, plus `'; rm -rf /'`, `$(whoami)` and backtick payloads. The body is bound via `env:` and never interpolated into the script, and only `[0-9]+` is extracted, so substitutions yield empty. `yaml.safe_load` on `ci.yml` passes.

TKT-IVQKQ3