### PR TITLE
test(dataentry): fix stale identity assertion blocking all open PRs

### DIFF
--- a/internal/dataentry/failclosed_test.go
+++ b/internal/dataentry/failclosed_test.go
@@ -133,8 +133,18 @@ func TestScriptReadSeam_PolicylessProjectStaysUnrestricted(t *testing.T) {
 		t.Error("policy-less project got DenyReader — absence of acl.yaml is " +
 			"an intentional state, not a construction fault")
 	}
-	if any(reader) != any(app.store) {
-		t.Errorf("policy-less scriptReader should be the raw store, got %T", reader)
+	// The ungated path is spelled visibility.Unrestricted (TKT-1WV50C), not a
+	// bare a.store, so pin the CONTRACT — no gate, no redaction — rather than
+	// pointer identity with the store. Reads must pass straight through.
+	if _, isUngated := reader.(*visibility.UnrestrictedReader); !isUngated {
+		t.Errorf("policy-less scriptReader should be the ungated reader, got %T", reader)
+	}
+	got, err := reader.GetEntity(context.Background(), "TKT-001")
+	if err != nil {
+		t.Fatalf("policy-less read failed: %v", err)
+	}
+	if got == nil || got.ID != "TKT-001" {
+		t.Errorf("policy-less read did not pass through to the store, got %v", got)
 	}
 
 	tr := app.scriptTracer(nil)

--- a/tickets/entities/automated-measures/AM-ungated-read-contract-not-identity.md
+++ b/tickets/entities/automated-measures/AM-ungated-read-contract-not-identity.md
@@ -1,0 +1,9 @@
+---
+id: AM-ungated-read-contract-not-identity
+type: automated-measure
+title: Seam test asserts the ungated read contract, not store pointer identity
+description: 'TestScriptReadSeam_PolicylessProjectStaysUnrestricted pins the policy-less script read path by asserting the reader is a *visibility.UnrestrictedReader AND that a read passes through to the store, instead of comparing pointer identity with app.store. Identity assertions break on any behaviour-preserving rename of the ungated wrapper (as #1208/TKT-1WV50C did), reddening CI on every open PR while the security contract is in fact intact. Asserting the observable contract keeps the fail-open regression covered without coupling to which object the wiring returns.'
+kind: test
+location: internal/dataentry/failclosed_test.go (TestScriptReadSeam_PolicylessProjectStaysUnrestricted)
+status: active
+---

--- a/tickets/entities/bugs/BUG-UJ5THN.md
+++ b/tickets/entities/bugs/BUG-UJ5THN.md
@@ -1,0 +1,49 @@
+---
+id: BUG-UJ5THN
+type: bug
+title: Stale identity assertion in policy-less script-read seam test reddens CI on every open PR
+description: TestScriptReadSeam_PolicylessProjectStaysUnrestricted fails on develop at HEAD, turning the Test job red on all 9 approved dependabot PRs (#1219-#1227) and every other open PR. Production behaviour is correct; only the test assertion is stale.
+priority: high
+effort: xs
+why1: The test asserted pointer identity between the policy-less script reader and app.store (any(reader) != any(app.store)), which no longer holds.
+why2: 'PR #1208 (TKT-1WV50C) changed App.scriptReader''s policy-less branch from `return a.store` to `return visibility.Unrestricted(a.store)`, so the reader is now a *visibility.UnrestrictedReader wrapper rather than the store itself.'
+why3: The test pinned an implementation detail (which object is returned) instead of the contract it exists to protect (policy-less means no gate and no redaction), so a deliberate, behaviour-preserving refactor broke it.
+why4: '#1208 was a rename/legibility refactor whose author updated the production wiring and the visibility package''s own tests, but did not run or notice the dataentry package''s fail-closed test that depended on the old return identity.'
+why5: Tests that assert on object identity rather than observable behaviour create hidden coupling to refactorable internals; nothing in review or tooling flags an identity assertion as the fragile form when the safer contract assertion is available.
+prevention: Assert the ungated contract (type is *visibility.UnrestrictedReader plus a read that passes through to the store) rather than pointer identity with the store. More generally, when a seam test exists to pin a security contract, assert the observable behaviour of that contract so a legibility refactor of the wiring cannot redden CI while behaviour is unchanged.
+status: done
+---
+
+## Symptom
+
+`go test ./internal/dataentry/` fails on `develop` at HEAD:
+
+```
+failclosed_test.go:137: policy-less scriptReader should be the raw store, got *visibility.UnrestrictedReader
+--- FAIL: TestScriptReadSeam_PolicylessProjectStaysUnrestricted (0.00s)
+```
+
+Because the `Test` job runs on every PR, this single failure blocked all 9
+approved dependabot PRs plus the open feature/docs PRs.
+
+## Root cause
+
+#1208 (TKT-1WV50C) named the ungated read path:
+
+```go
+-	return a.store
++	return visibility.Unrestricted(a.store)
+```
+
+The test's identity assertion (`any(reader) != any(app.store)`) predates that
+change. The `scriptTracer` half still returns `a.tracer` directly, so its
+identity assertion remains valid and is left untouched.
+
+## Fix
+
+Pin the contract instead of the identity: assert the reader is a
+`*visibility.UnrestrictedReader` and that a read passes straight through to the
+store. This keeps the test meaningful against the current wiring rather than
+re-coupling it to the detail #1208 deliberately replaced.
+
+Fixed in PR #1228.

--- a/tickets/entities/implementation-checklists/IMPL-Z4WAXX.md
+++ b/tickets/entities/implementation-checklists/IMPL-Z4WAXX.md
@@ -1,0 +1,23 @@
+---
+id: IMPL-Z4WAXX
+type: implementation-checklist
+title: 'Implementation: Fix stale identity assertion in policy-less script-read seam test'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Development
+
+- [x] Reproduced the failure locally on `develop` at HEAD (`3974fecb`)
+- [x] Traced the cause to #1208 (TKT-1WV50C) changing `a.store` → `visibility.Unrestricted(a.store)`
+- [x] Replaced the pointer-identity assertion with a contract assertion (`*visibility.UnrestrictedReader` + pass-through read)
+- [x] Confirmed the `scriptTracer` half still returns `a.tracer`, so its identity assertion is correct and left untouched
+
+## Quality
+
+- [x] Target tests pass (`go test ./internal/dataentry/ -run 'TestScriptRead|TestScriptTracer'`)
+- [x] Full suite green (`go test ./internal/...`, no failures)
+- [x] Lint clean (`golangci-lint run internal/dataentry/...` — 0 issues)
+- [x] `go build ./...` clean
+- [x] ~~New user-facing behavior~~ (N/A: test-only change, production wiring untouched)

--- a/tickets/entities/review-checklists/REV-1TZYIH.md
+++ b/tickets/entities/review-checklists/REV-1TZYIH.md
@@ -1,0 +1,33 @@
+---
+id: REV-1TZYIH
+type: review-checklist
+title: 'Review: Fix stale identity assertion in policy-less script-read seam test'
+status: done
+---
+
+## Automated Checks
+
+- [x] `Test` job green on PR #1228 (the job this bug reddened)
+- [x] `Lint`, `Frontend`, `Fuzz`, `Postgres Backend`, `Architecture`, `God-object lint`, CodeQL all pass
+- [x] All cross-compile targets pass
+
+## Code Review
+
+- [x] Change is test-only; no production wiring touched (verified via `git diff --stat`)
+- [x] Security contract preserved — the test still fails if the policy-less path returns a gated or deny reader
+- [x] Assertion now pins observable behaviour (type + pass-through read) rather than pointer identity
+- [x] ~~cranky-code-reviewer agent run~~ (N/A: 8-line single-assertion test fix with a documented root cause)
+
+## Verification
+
+- [x] Root cause confirmed by bisecting to #1208's `return a.store` → `visibility.Unrestricted(a.store)` change
+- [x] Prevention recorded as AM-ungated-read-contract-not-identity
+
+**PR:** https://github.com/sourcehaven-bv/rela/pull/1228
+
+**Summary:** `TestScriptReadSeam_PolicylessProjectStaysUnrestricted` asserted
+pointer identity with `app.store`, which #1208 invalidated by naming the ungated
+path `visibility.Unrestricted`. Production behaviour was correct throughout —
+only the assertion was stale, and it reddened the shared `Test` job on every
+open PR including all 9 approved dependabot bumps. Fixed by asserting the
+ungated contract instead of the identity.

--- a/tickets/relations/BUG-UJ5THN--adds-measure--AM-ungated-read-contract-not-identity.md
+++ b/tickets/relations/BUG-UJ5THN--adds-measure--AM-ungated-read-contract-not-identity.md
@@ -1,0 +1,5 @@
+---
+from: BUG-UJ5THN
+relation: adds-measure
+to: AM-ungated-read-contract-not-identity
+---

--- a/tickets/relations/BUG-UJ5THN--affects--authorization.md
+++ b/tickets/relations/BUG-UJ5THN--affects--authorization.md
@@ -1,0 +1,5 @@
+---
+from: BUG-UJ5THN
+relation: affects
+to: authorization
+---

--- a/tickets/relations/BUG-UJ5THN--affects--ci-pipeline.md
+++ b/tickets/relations/BUG-UJ5THN--affects--ci-pipeline.md
@@ -1,0 +1,5 @@
+---
+from: BUG-UJ5THN
+relation: affects
+to: ci-pipeline
+---

--- a/tickets/relations/BUG-UJ5THN--fixes--FEAT-AESD4.md
+++ b/tickets/relations/BUG-UJ5THN--fixes--FEAT-AESD4.md
@@ -1,0 +1,5 @@
+---
+from: BUG-UJ5THN
+relation: fixes
+to: FEAT-AESD4
+---

--- a/tickets/relations/BUG-UJ5THN--has-implementation--IMPL-Z4WAXX.md
+++ b/tickets/relations/BUG-UJ5THN--has-implementation--IMPL-Z4WAXX.md
@@ -1,0 +1,5 @@
+---
+from: BUG-UJ5THN
+relation: has-implementation
+to: IMPL-Z4WAXX
+---

--- a/tickets/relations/BUG-UJ5THN--has-review--REV-1TZYIH.md
+++ b/tickets/relations/BUG-UJ5THN--has-review--REV-1TZYIH.md
@@ -1,0 +1,5 @@
+---
+from: BUG-UJ5THN
+relation: has-review
+to: REV-1TZYIH
+---


### PR DESCRIPTION
`TestScriptReadSeam_PolicylessProjectStaysUnrestricted` fails on `develop` at HEAD, so the `Test` job is red on **all 9 approved dependabot PRs** (#1219–#1227) and the rest.

## Cause

#1208 (TKT-1WV50C) changed the policy-less branch of `App.scriptReader`:

```go
-	return a.store
+	return visibility.Unrestricted(a.store)
```

The test still asserted pointer identity with the raw store (`any(reader) != any(app.store)`), which no longer holds now that the ungated path is a named `*visibility.UnrestrictedReader` wrapper. Production behavior is correct and unchanged — only the assertion was stale.

## Fix

Pin the **contract** the test exists to protect (policy-less ⇒ no gate, no redaction) rather than pointer identity: assert the reader is `*visibility.UnrestrictedReader` and that a read actually passes through to the store. That keeps the test meaningful against the current wiring instead of re-coupling it to an implementation detail #1208 deliberately replaced.

The `scriptTracer` half still returns `a.tracer` directly, so its identity assertion is left as-is.

Verified: `go test ./internal/...` fully green, `golangci-lint run internal/dataentry/...` clean.