### PR TITLE
fix(test): repair develop Test job — policy-less scriptReader vs visibility.Unrestricted (TKT-U8G4Q0)

### DIFF
--- a/internal/dataentry/failclosed_test.go
+++ b/internal/dataentry/failclosed_test.go
@@ -120,8 +120,11 @@ func TestScriptTracer_FailsClosedOnGateFault(t *testing.T) {
 // TestScriptReadSeam_PolicylessProjectStaysUnrestricted pins the other side
 // of the contract. Absence of a policy is a documented intentional state
 // ("no access control desired"), NOT a fault — it must keep returning the
-// raw store, byte-identical to pre-ACL behavior. Failing closed here would
-// break every policy-less deployment's scripts.
+// ungated read handle over the raw store, byte-identical to pre-ACL
+// behavior. Since TKT-1WV50C that handle is the NAMED wrapper
+// [visibility.Unrestricted], so every ungated read site is greppable —
+// not the bare store value. Failing closed here would break every
+// policy-less deployment's scripts.
 func TestScriptReadSeam_PolicylessProjectStaysUnrestricted(t *testing.T) {
 	app := newTestAppV1(t)
 	seedEntity(app, &entity.Entity{ID: "TKT-001", Type: "ticket",
@@ -133,8 +136,9 @@ func TestScriptReadSeam_PolicylessProjectStaysUnrestricted(t *testing.T) {
 		t.Error("policy-less project got DenyReader — absence of acl.yaml is " +
 			"an intentional state, not a construction fault")
 	}
-	if any(reader) != any(app.store) {
-		t.Errorf("policy-less scriptReader should be the raw store, got %T", reader)
+	if _, ok := reader.(*visibility.UnrestrictedReader); !ok {
+		t.Errorf("policy-less scriptReader should be the named Unrestricted handle "+
+			"over the raw store (TKT-1WV50C), got %T", reader)
 	}
 
 	tr := app.scriptTracer(nil)

--- a/tickets/entities/review-checklists/REV-T815YX.md
+++ b/tickets/entities/review-checklists/REV-T815YX.md
@@ -1,0 +1,24 @@
+---
+id: REV-T815YX
+type: review-checklist
+title: 'Review: fix policy-less scriptReader test (TKT-U8G4Q0)'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Automated Checks
+
+- [x] All tests pass (`go test -race ./internal/dataentry/` — full package)
+- [x] Lint clean (`golangci-lint run ./internal/dataentry/`) — 0 issues
+- [x] `gofmt` clean
+- [x] ~~`just plimsoll`~~ (N/A: test-only change, no type surface touched)
+
+## Manual Review
+
+- [x] Root cause identified as a semantic conflict (#1204 test vs #1208 named-handle refactor), not a regression — both sides' intent preserved
+- [x] New assertion pins the TKT-1WV50C contract (`*visibility.UnrestrictedReader`), keeps the DenyReader fail-closed assertion, and the scriptTracer side untouched
+- [x] Pass-through equivalence of the wrapper is already pinned by `internal/visibility/unrestricted_test.go` — no behavioral coverage lost
+- [x] ~~`/code-review` agent run~~ (N/A: 8-line test-only diff, reviewed inline)
+
+**Review Responses:** none.

--- a/tickets/entities/tickets/TKT-U8G4Q0.md
+++ b/tickets/entities/tickets/TKT-U8G4Q0.md
@@ -1,0 +1,33 @@
+---
+id: TKT-U8G4Q0
+type: ticket
+title: 'Fix develop CI: policy-less scriptReader test vs visibility.Unrestricted (semantic conflict PR #1204 × #1208)'
+kind: test
+priority: high
+effort: xs
+status: done
+---
+
+Develop's Test job has been red since #1216/#1217/#1218 merged on top of the
+#1204 × #1208 pair. Root cause is a **semantic conflict**, not a bad change:
+
+- **#1204** (`fix(acl): fail closed when the data-entry script read gate
+cannot be built`) added `TestScriptReadSeam_PolicylessProjectStaysUnrestricted`
+with the assertion `any(reader) != any(app.store)` — "policy-less scriptReader
+should be the raw store".
+- **#1208** (`refactor(visibility): name the ungated read path`, TKT-1WV50C)
+deliberately changed `App.scriptReader`'s NopACL branch to return
+`visibility.Unrestricted(a.store)` — a named, greppable ungated read handle. Its
+branch predates #1204's merge, so neither PR's CI saw the combination.
+
+## Fix
+
+Update the test to pin the CURRENT intended contract: the policy-less path must
+return `*visibility.UnrestrictedReader` (and still never `DenyReader`). Behavior
+is unchanged — the wrapper is pass-through by design (pinned by
+`internal/visibility/unrestricted_test.go`).
+
+## Verification
+
+- `go test -race ./internal/dataentry/` — full package green
+- `golangci-lint run ./internal/dataentry/` — 0 issues

--- a/tickets/relations/TKT-U8G4Q0--affects--ci-pipeline.md
+++ b/tickets/relations/TKT-U8G4Q0--affects--ci-pipeline.md
@@ -1,0 +1,5 @@
+---
+from: TKT-U8G4Q0
+relation: affects
+to: ci-pipeline
+---

--- a/tickets/relations/TKT-U8G4Q0--has-review--REV-T815YX.md
+++ b/tickets/relations/TKT-U8G4Q0--has-review--REV-T815YX.md
@@ -1,0 +1,5 @@
+---
+from: TKT-U8G4Q0
+relation: has-review
+to: REV-T815YX
+---

--- a/tickets/relations/TKT-U8G4Q0--implements--FEAT-GE1YY.md
+++ b/tickets/relations/TKT-U8G4Q0--implements--FEAT-GE1YY.md
@@ -1,0 +1,5 @@
+---
+from: TKT-U8G4Q0
+relation: implements
+to: FEAT-GE1YY
+---


### PR DESCRIPTION
## Summary

Develop's **Test job has been red** since the last three merges. Root cause is a semantic conflict between two individually-green PRs:

- #1204 added `TestScriptReadSeam_PolicylessProjectStaysUnrestricted`, asserting the policy-less `scriptReader` **is the raw store value** (`any(reader) != any(app.store)`).
- #1208 (TKT-1WV50C) then intentionally changed that same path to return the **named** `visibility.Unrestricted(...)` handle so every ungated read site is greppable. Its branch predates #1204's merge, so neither PR's CI ever saw the combination.

This updates the test to pin the current intended contract: the policy-less path returns `*visibility.UnrestrictedReader` (and still never `DenyReader`). No production code changes; the wrapper's pass-through equivalence is already pinned by `internal/visibility/unrestricted_test.go`.

## Verification

- `go test -race ./internal/dataentry/` — full package green (was failing exactly on this test)
- `golangci-lint run ./internal/dataentry/` — 0 issues

Companion ticket: TKT-U8G4Q0 (done, review checklist REV-T815YX).