### PR TITLE
feat(lua): elevated reads on rela.bypass_acl's admin handle (TKT-ACSBSA)

### DIFF
--- a/docs-project/entities/guides/GUIDE-acl-security.md
+++ b/docs-project/entities/guides/GUIDE-acl-security.md
@@ -578,6 +578,16 @@ A project with **no** `acl.yaml` is unaffected: that is a deliberate
 "no access control" configuration, not a fault, and scripts there read
 the full graph exactly as they always have.
 
+**When an automation legitimately needs more than its caller can see**,
+the sanctioned route is `rela.bypass_acl` — not widening the policy. Its
+`admin` handle carries `get_entity`, `list_entities` and `get_relations`
+alongside the write methods, all reading raw. That keeps the privilege
+scoped to a closure and visible at the call site, and it leaves an
+`acl-bypass-read` audit row, where relaxing a role in `acl.yaml` would
+widen access for every read on every path with nothing in the log to
+show for it. It requires operator opt-in (`allow_acl_bypass: true` on
+the action) — see the Lua scripting guide.
+
 ## Property-level redaction (`visible:`)
 
 Entity-level filtering decides whether you see an entity at all. The

--- a/docs-project/entities/guides/GUIDE-lua-scripting.md
+++ b/docs-project/entities/guides/GUIDE-lua-scripting.md
@@ -402,8 +402,15 @@ end)
 
 Note the two reads differ deliberately in what a `nil` means:
 `rela.get_entity` returns `nil` for "missing **or** hidden" (it stays
-oracle-free), while `admin.get_entity` returns `nil` only when the entity
-genuinely does not exist.
+oracle-free), while `admin.get_entity` returns `nil` only for a genuine
+miss. A store failure (backend down, driver error) **raises** rather than
+returning `nil` — otherwise the uniqueness check above would read a
+transient outage as "no duplicate" and admit one, silently violating the
+invariant it exists to enforce. All three `admin` read methods raise on
+store errors.
+
+Mistyped filter options raise too: `admin.get_relations({from = 12345})` is
+an error, not an unfiltered whole-graph dump.
 
 **Operator opt-in is required.** `rela.bypass_acl` only exists when the
 automation action sets `allow_acl_bypass: true` in `metamodel.yaml` (an

--- a/docs-project/entities/guides/GUIDE-lua-scripting.md
+++ b/docs-project/entities/guides/GUIDE-lua-scripting.md
@@ -345,20 +345,20 @@ local ok, e, warnings = pcall(rela.update_entity, "TKT-001", {title = ""})
 -- ok=true, e is the entity, warnings is the validation findings.
 ```
 
-### Elevated writes — `rela.bypass_acl`
+### Elevated access — `rela.bypass_acl`
 
-By default an automation script's writes are **ACL-checked against the
-triggering principal** (the user whose action fired the automation). That is
-correct for most automations. But some scripts enforce a *system invariant* on
-behalf of a user who isn't authorized to make the write directly — e.g.
-stamping `submitter --created-by--> ticket` on ticket create so the submitter
-(and only they) can later read their own ticket, without the submitter being
-able to write `person` relations themselves.
+By default an automation script's reads **and** writes are **ACL-checked
+against the triggering principal** (the user whose action fired the
+automation). That is correct for most automations. But some scripts enforce a
+*system invariant* on behalf of a user who isn't authorized to act directly —
+e.g. stamping `submitter --created-by--> ticket` on ticket create so the
+submitter (and only they) can later read their own ticket, without the
+submitter being able to write `person` relations themselves.
 
 For those, `rela.bypass_acl(fn)` runs `fn` with a single argument `admin`: a
-write handle whose mutations **skip the ACL deny**. Elevation is scoped to the
-closure and carried by the `admin` object — the ordinary `rela.*` write
-bindings are never elevated.
+handle whose reads and writes **skip the ACL**. Elevation is scoped to the
+closure and carried by the `admin` object — the ordinary `rela.*` bindings are
+never elevated.
 
 ```lua
 -- on ticket create: stamp the submitter as author, server-side, unforgeable
@@ -369,7 +369,41 @@ end)
 -- back to normal (gated) authority here
 ```
 
-`admin` exposes `create_relation`, `delete_relation`, `delete_entity`.
+`admin` exposes:
+
+| Method | Purpose |
+|--------|---------|
+| `admin.create_relation(from, type, to)` | Link, skipping the ACL deny |
+| `admin.delete_relation(from, type, to)` | Unlink, skipping the ACL deny |
+| `admin.delete_entity(id, cascade?)` | Remove, skipping the ACL deny |
+| `admin.get_entity(id)` | Read **raw** — full properties, no redaction |
+| `admin.list_entities(type)` | Every entity of `type`, ungated |
+| `admin.get_relations(opts?)` | Every matching edge, not peer-gated |
+
+**Elevated reads return raw data.** `admin.get_entity` returns the entity with
+all properties, including ones the triggering user cannot see; `list_entities`
+returns rows the gated `rela.list_entities` would drop; `get_relations` returns
+edges even when neither endpoint is visible to the caller. A half-elevated read
+would be a confusing contract — the closure is the boundary.
+
+Use them when an automation genuinely needs a whole-graph view, e.g. checking a
+uniqueness invariant across entities the submitter cannot see:
+
+```lua
+rela.bypass_acl(function(admin)
+  for _, t in ipairs(admin.list_entities("ticket")) do
+    if t.properties.external_ref == entity.properties.external_ref
+       and t.id ~= entity.id then
+      error("duplicate external_ref: " .. t.id)
+    end
+  end
+end)
+```
+
+Note the two reads differ deliberately in what a `nil` means:
+`rela.get_entity` returns `nil` for "missing **or** hidden" (it stays
+oracle-free), while `admin.get_entity` returns `nil` only when the entity
+genuinely does not exist.
 
 **Operator opt-in is required.** `rela.bypass_acl` only exists when the
 automation action sets `allow_acl_bypass: true` in `metamodel.yaml` (an
@@ -390,13 +424,27 @@ automations:
 - **Audited, not anonymous.** Every elevated write records an `acl-bypass`
   audit row carrying the **real** triggering principal (not a system user) plus
   `acl_bypass=true`, so "who caused this elevated write" is always answerable.
+- **Elevated reads are audited too.** A closure that used any of the `admin`
+  read methods emits one `acl-bypass-read` row naming the principal, the
+  automation, and which bindings were used. It is **one row per closure**, not
+  per read — a single `admin.list_entities` can span the graph — and it
+  deliberately records **no subject and no entity data**, since logging the
+  read set would copy the very data the ACL protects into the audit log. The
+  row is written even when the closure then raises, so failing is not a way to
+  erase the evidence. Isolate them with `op == "acl-bypass-read"`.
 - **No leak into nested cascades.** A cascade that an elevated write triggers
   runs with normal (gated) ACL authority — elevation does not propagate to
   descendant writes.
 - **Closure-scoped.** After `fn` returns, `admin` is invalidated; stashing it in
-  a global and calling it later raises.
+  a global and calling it later raises — for reads as well as writes, so
+  elevation cannot become a durable ungated handle.
 - **Cannot forge identity.** `rela.principal` is read-only and the write
   attribution derives from the request context, never from the script.
+- **Fails loudly, never silently degraded.** If a deployment grants elevated
+  writes but no elevated read capability, the `admin` read methods **raise**
+  rather than falling back to the caller's gated view. A closure that looked
+  elevated but silently returned a partial graph would be worse than one that
+  refuses.
 
 ### Schema Functions
 

--- a/docs/acl-security.md
+++ b/docs/acl-security.md
@@ -572,6 +572,16 @@ A project with **no** `acl.yaml` is unaffected: that is a deliberate
 "no access control" configuration, not a fault, and scripts there read
 the full graph exactly as they always have.
 
+**When an automation legitimately needs more than its caller can see**,
+the sanctioned route is `rela.bypass_acl` — not widening the policy. Its
+`admin` handle carries `get_entity`, `list_entities` and `get_relations`
+alongside the write methods, all reading raw. That keeps the privilege
+scoped to a closure and visible at the call site, and it leaves an
+`acl-bypass-read` audit row, where relaxing a role in `acl.yaml` would
+widen access for every read on every path with nothing in the log to
+show for it. It requires operator opt-in (`allow_acl_bypass: true` on
+the action) — see the Lua scripting guide.
+
 ## Property-level redaction (`visible:`)
 
 Entity-level filtering decides whether you see an entity at all. The

--- a/docs/lua-scripting.md
+++ b/docs/lua-scripting.md
@@ -396,8 +396,15 @@ end)
 
 Note the two reads differ deliberately in what a `nil` means:
 `rela.get_entity` returns `nil` for "missing **or** hidden" (it stays
-oracle-free), while `admin.get_entity` returns `nil` only when the entity
-genuinely does not exist.
+oracle-free), while `admin.get_entity` returns `nil` only for a genuine
+miss. A store failure (backend down, driver error) **raises** rather than
+returning `nil` — otherwise the uniqueness check above would read a
+transient outage as "no duplicate" and admit one, silently violating the
+invariant it exists to enforce. All three `admin` read methods raise on
+store errors.
+
+Mistyped filter options raise too: `admin.get_relations({from = 12345})` is
+an error, not an unfiltered whole-graph dump.
 
 **Operator opt-in is required.** `rela.bypass_acl` only exists when the
 automation action sets `allow_acl_bypass: true` in `metamodel.yaml` (an

--- a/docs/lua-scripting.md
+++ b/docs/lua-scripting.md
@@ -339,20 +339,20 @@ local ok, e, warnings = pcall(rela.update_entity, "TKT-001", {title = ""})
 -- ok=true, e is the entity, warnings is the validation findings.
 ```
 
-### Elevated writes — `rela.bypass_acl`
+### Elevated access — `rela.bypass_acl`
 
-By default an automation script's writes are **ACL-checked against the
-triggering principal** (the user whose action fired the automation). That is
-correct for most automations. But some scripts enforce a *system invariant* on
-behalf of a user who isn't authorized to make the write directly — e.g.
-stamping `submitter --created-by--> ticket` on ticket create so the submitter
-(and only they) can later read their own ticket, without the submitter being
-able to write `person` relations themselves.
+By default an automation script's reads **and** writes are **ACL-checked
+against the triggering principal** (the user whose action fired the
+automation). That is correct for most automations. But some scripts enforce a
+*system invariant* on behalf of a user who isn't authorized to act directly —
+e.g. stamping `submitter --created-by--> ticket` on ticket create so the
+submitter (and only they) can later read their own ticket, without the
+submitter being able to write `person` relations themselves.
 
 For those, `rela.bypass_acl(fn)` runs `fn` with a single argument `admin`: a
-write handle whose mutations **skip the ACL deny**. Elevation is scoped to the
-closure and carried by the `admin` object — the ordinary `rela.*` write
-bindings are never elevated.
+handle whose reads and writes **skip the ACL**. Elevation is scoped to the
+closure and carried by the `admin` object — the ordinary `rela.*` bindings are
+never elevated.
 
 ```lua
 -- on ticket create: stamp the submitter as author, server-side, unforgeable
@@ -363,7 +363,41 @@ end)
 -- back to normal (gated) authority here
 ```
 
-`admin` exposes `create_relation`, `delete_relation`, `delete_entity`.
+`admin` exposes:
+
+| Method | Purpose |
+|--------|---------|
+| `admin.create_relation(from, type, to)` | Link, skipping the ACL deny |
+| `admin.delete_relation(from, type, to)` | Unlink, skipping the ACL deny |
+| `admin.delete_entity(id, cascade?)` | Remove, skipping the ACL deny |
+| `admin.get_entity(id)` | Read **raw** — full properties, no redaction |
+| `admin.list_entities(type)` | Every entity of `type`, ungated |
+| `admin.get_relations(opts?)` | Every matching edge, not peer-gated |
+
+**Elevated reads return raw data.** `admin.get_entity` returns the entity with
+all properties, including ones the triggering user cannot see; `list_entities`
+returns rows the gated `rela.list_entities` would drop; `get_relations` returns
+edges even when neither endpoint is visible to the caller. A half-elevated read
+would be a confusing contract — the closure is the boundary.
+
+Use them when an automation genuinely needs a whole-graph view, e.g. checking a
+uniqueness invariant across entities the submitter cannot see:
+
+```lua
+rela.bypass_acl(function(admin)
+  for _, t in ipairs(admin.list_entities("ticket")) do
+    if t.properties.external_ref == entity.properties.external_ref
+       and t.id ~= entity.id then
+      error("duplicate external_ref: " .. t.id)
+    end
+  end
+end)
+```
+
+Note the two reads differ deliberately in what a `nil` means:
+`rela.get_entity` returns `nil` for "missing **or** hidden" (it stays
+oracle-free), while `admin.get_entity` returns `nil` only when the entity
+genuinely does not exist.
 
 **Operator opt-in is required.** `rela.bypass_acl` only exists when the
 automation action sets `allow_acl_bypass: true` in `metamodel.yaml` (an
@@ -384,13 +418,27 @@ automations:
 - **Audited, not anonymous.** Every elevated write records an `acl-bypass`
   audit row carrying the **real** triggering principal (not a system user) plus
   `acl_bypass=true`, so "who caused this elevated write" is always answerable.
+- **Elevated reads are audited too.** A closure that used any of the `admin`
+  read methods emits one `acl-bypass-read` row naming the principal, the
+  automation, and which bindings were used. It is **one row per closure**, not
+  per read — a single `admin.list_entities` can span the graph — and it
+  deliberately records **no subject and no entity data**, since logging the
+  read set would copy the very data the ACL protects into the audit log. The
+  row is written even when the closure then raises, so failing is not a way to
+  erase the evidence. Isolate them with `op == "acl-bypass-read"`.
 - **No leak into nested cascades.** A cascade that an elevated write triggers
   runs with normal (gated) ACL authority — elevation does not propagate to
   descendant writes.
 - **Closure-scoped.** After `fn` returns, `admin` is invalidated; stashing it in
-  a global and calling it later raises.
+  a global and calling it later raises — for reads as well as writes, so
+  elevation cannot become a durable ungated handle.
 - **Cannot forge identity.** `rela.principal` is read-only and the write
   attribution derives from the request context, never from the script.
+- **Fails loudly, never silently degraded.** If a deployment grants elevated
+  writes but no elevated read capability, the `admin` read methods **raise**
+  rather than falling back to the caller's gated view. A closure that looked
+  elevated but silently returned a partial graph would be worse than one that
+  refuses.
 
 ### Schema Functions
 

--- a/internal/appbuild/appbuild.go
+++ b/internal/appbuild/appbuild.go
@@ -854,7 +854,7 @@ func assemble(
 		ACL:                     resolvedACL,
 		Automations:             autoEngine,
 		Cascade:                 cascadeRunner,
-		ScriptRunner:            script.NewLuaScriptRunner(cfg.ScriptEngine, readDeps),
+		ScriptRunner:            cascadeScriptRunner(cfg.ScriptEngine, readDeps, st, cfg.Audit),
 		VersionRecorder:         versionRecorderFor(versions),
 		RelationVersionRecorder: relationVersionRecorderFor(versions),
 		Transitions:             tw.Enforcer,

--- a/internal/appbuild/appbuildtest/fixture.go
+++ b/internal/appbuild/appbuildtest/fixture.go
@@ -175,14 +175,23 @@ func New(meta *metamodel.Metamodel, opts ...Option) *appbuild.Services {
 		panic(fmt.Sprintf("appbuildtest.New: compile transitions: %v", err))
 	}
 	mgr, err := entitymanager.New(entitymanager.Deps{
-		Store:           st,
-		Meta:            meta,
-		Templater:       templater,
-		Audit:           auditSink,
-		ACL:             aclImpl,
-		Automations:     autoEngine,
-		Cascade:         cascadeRunner,
-		ScriptRunner:    script.NewLuaScriptRunner(scriptEngine, readDeps),
+		Store:       st,
+		Meta:        meta,
+		Templater:   templater,
+		Audit:       auditSink,
+		ACL:         aclImpl,
+		Automations: autoEngine,
+		Cascade:     cascadeRunner,
+		// Mirrors the production wiring in appbuild.assemble: elevated reads
+		// are granted here so an integration test exercises the same
+		// capability set a real deployment has (TKT-ACSBSA). Still inert
+		// without an allow_acl_bypass action + an ElevatedProvider Mutator.
+		ScriptRunner: script.NewLuaScriptRunnerWithElevatedReads(
+			scriptEngine, readDeps, script.ReadElevation{
+				Reader:   visibility.Unrestricted(st),
+				Recorder: appbuild.NewElevationAuditor(auditSink),
+			},
+		),
 		Transitions:     tw.Enforcer,
 		TransitionGuard: tw.Guard,
 		TransitionGraph: tw.Graph,

--- a/internal/appbuild/elevatedreads.go
+++ b/internal/appbuild/elevatedreads.go
@@ -1,0 +1,49 @@
+package appbuild
+
+import (
+	"github.com/Sourcehaven-BV/rela/internal/audit"
+	"github.com/Sourcehaven-BV/rela/internal/lua"
+	"github.com/Sourcehaven-BV/rela/internal/script"
+	"github.com/Sourcehaven-BV/rela/internal/store"
+	"github.com/Sourcehaven-BV/rela/internal/visibility"
+)
+
+// cascadeScriptRunner builds the automation-cascade script runner, granting
+// bypass_acl closures a RAW read handle (admin.get_entity et al.) plus the
+// audit sink that records its use (TKT-ACSBSA).
+//
+// The capability is inert until an action is allow_acl_bypass AND the
+// cascade Mutator offers ElevatedProvider — the same two keys that gate
+// elevated writes. The reader is deliberately the same raw store
+// readDeps.WritePrepStore holds, named through visibility.Unrestricted so
+// this ungated path shows up in the grep that enumerates them (TKT-1WV50C).
+func cascadeScriptRunner(
+	engine *script.Engine, readDeps lua.ReadDeps, st store.Store, sink audit.Audit,
+) *script.LuaScriptRunner {
+	return script.NewLuaScriptRunnerWithElevatedReads(engine, readDeps, script.ReadElevation{
+		Reader:   visibility.Unrestricted(st),
+		Recorder: NewElevationAuditor(sink),
+	})
+}
+
+// NewElevationAuditor returns the elevated-read audit recorder over sink, or
+// a genuinely nil interface when no sink is wired (which the lua side reads
+// as "recording disabled").
+//
+// Exported so appbuildtest can build the SAME elevation bundle production
+// does — a fixture that granted elevated reads without the audit trace would
+// let a test pass while the wiring it stands in for has the audit gap.
+//
+// This wrapper exists for ONE reason: the nil conversion. audit's
+// constructor returns *audit.ElevationRecorder, and assigning a nil one
+// straight into lua's interface-typed ElevationRecorder field yields a TYPED
+// nil, which is != nil — lua's `ElevationRecorder == nil` guard would pass
+// and the first elevated read would nil-deref, killing the process on a path
+// that is supposed to degrade quietly. Returning the INTERFACE type here
+// makes the nil a real nil. Same trap as RR-5QQL1Z.
+func NewElevationAuditor(sink audit.Audit) lua.ElevationRecorder {
+	if sink == nil {
+		return nil
+	}
+	return audit.NewElevationRecorder(sink)
+}

--- a/internal/appbuild/elevatedreads_test.go
+++ b/internal/appbuild/elevatedreads_test.go
@@ -1,0 +1,51 @@
+package appbuild
+
+import (
+	"testing"
+
+	"github.com/Sourcehaven-BV/rela/internal/audit"
+	"github.com/Sourcehaven-BV/rela/internal/lua"
+)
+
+// TestNewElevationAuditor_NilSinkYieldsNilInterface is the whole reason this
+// wrapper exists (TKT-ACSBSA).
+//
+// audit.NewElevationRecorder returns a CONCRETE pointer, so `return nil`
+// from it lands in lua's interface-typed ElevationRecorder field as a TYPED
+// nil — which is != nil, so the `ElevationRecorder == nil` guard passes and
+// the first elevated read nil-derefs. That kills the process on the path
+// that is supposed to degrade quietly (no audit sink configured). Verified
+// as a real failure mode in RR-5QQL1Z, not reasoned about.
+//
+// The assertion goes through lua.WriteDeps — the actual field the value
+// lands in — rather than checking the return value directly. That detail IS
+// the test: `NewElevationAuditor(nil) != nil` is false even for a
+// concrete-pointer signature (a nil *T compares equal to nil), so a direct
+// check silently passes against the very mutation it should catch. Boxing
+// into the interface first is what makes the typed nil observable, and it is
+// what production does.
+func TestNewElevationAuditor_NilSinkYieldsNilInterface(t *testing.T) {
+	t.Parallel()
+
+	deps := lua.WriteDeps{ElevationRecorder: NewElevationAuditor(nil)}
+
+	// Exactly the guard Runtime.recordElevatedReads performs.
+	if deps.ElevationRecorder != nil {
+		t.Errorf("ElevationRecorder = %#v after wiring a nil sink, want nil -- "+
+			"a typed nil passes lua's `ElevationRecorder == nil` guard and "+
+			"nil-derefs on the first elevated read", deps.ElevationRecorder)
+	}
+}
+
+// TestNewElevationAuditor_RealSinkIsWired is the other half: a real sink
+// must produce a usable recorder, or elevated reads would go untraced while
+// the nil-handling above looked correct.
+func TestNewElevationAuditor_RealSinkIsWired(t *testing.T) {
+	t.Parallel()
+
+	deps := lua.WriteDeps{ElevationRecorder: NewElevationAuditor(&audit.Memory{})}
+	if deps.ElevationRecorder == nil {
+		t.Error("a real audit sink produced no recorder -- elevated reads would " +
+			"happen with no trace")
+	}
+}

--- a/internal/audit/audit.go
+++ b/internal/audit/audit.go
@@ -46,6 +46,28 @@ const (
 	// `op == "acl-bypass"`.
 	OpACLBypass = "acl-bypass"
 
+	// OpACLBypassRead records that an elevated automation closure
+	// (rela.bypass_acl) performed at least one RAW READ — TKT-ACSBSA.
+	//
+	// Separate from OpACLBypass because the two answer different questions
+	// and have different blast radii: a bypass WRITE changed the graph and
+	// names its subject; a bypass READ changed nothing but may have
+	// disclosed anything. Folding reads into "acl-bypass" would silently
+	// change what every existing `op == "acl-bypass"` query means.
+	//
+	// Emitted ONCE PER CLOSURE, not per read: one admin.list_entities can
+	// traverse the entire graph, so a per-row record would be an unbounded
+	// synchronous write on a read path. Subject is deliberately EMPTY and no
+	// entity data is recorded — the read set is unbounded, and logging it
+	// would copy ACL-protected content into the audit log, a wider
+	// disclosure than the read itself. Summary carries acl_bypass_read=true
+	// plus the admin bindings used. The Principal is the REAL triggering
+	// identity; TriggeredBy carries automation:<name>. Isolate elevated
+	// reads with `op == "acl-bypass-read"`.
+	//
+	//nolint:gosec // G101 false positive: an audit op name, not a credential.
+	OpACLBypassRead = "acl-bypass-read"
+
 	// OpPurgeVersion records an operator hard-delete of version snapshot rows
 	// (TKT-BW6UUL) — the deliberate, irreversible exception to append-only
 	// history, for compliance redaction. Subject names the entity/relation whose

--- a/internal/audit/elevatedread.go
+++ b/internal/audit/elevatedread.go
@@ -1,0 +1,64 @@
+package audit
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/Sourcehaven-BV/rela/internal/principal"
+)
+
+// ElevationRecorder records that an elevated automation closure
+// (rela.bypass_acl) performed at least one RAW READ — TKT-ACSBSA.
+//
+// Why it exists: elevated WRITES are recorded by entitymanager as
+// [OpACLBypass]. Elevated reads never reach entitymanager — they go straight
+// to the store — so without this, an operator querying the audit log for
+// elevation saw every elevated write and was silently blind to every
+// elevated read. A reviewer could reasonably conclude no elevated access to
+// a sensitive entity had occurred when in fact it had.
+//
+// It lives in this package rather than at the wiring site because the
+// attribution it performs ([principal.From] on the ctx) is audit's concern,
+// and the wiring package (appbuild) deliberately does not depend on
+// principal. It satisfies lua.ElevationRecorder structurally, so lua keeps
+// its consumer-side interface and this package does not depend on lua.
+type ElevationRecorder struct{ sink Audit }
+
+// NewElevationRecorder returns a recorder over sink, or nil when sink is
+// nil.
+//
+// CAUTION at wiring sites: this returns a CONCRETE pointer, so a nil result
+// assigned into an interface-typed field becomes a TYPED nil (!= nil) and
+// defeats the consumer's nil guard. Wiring sites must convert through a
+// helper that returns the interface type — see appbuild.NewElevationAuditor.
+func NewElevationRecorder(sink Audit) *ElevationRecorder {
+	if sink == nil {
+		return nil
+	}
+	return &ElevationRecorder{sink: sink}
+}
+
+// RecordElevatedRead emits one audit row per bypass_acl closure that used
+// its read elevation. Satisfies lua.ElevationRecorder.
+//
+// The row deliberately carries NO subject and NO entity data: the read set
+// is unbounded (one admin.list_entities can span the graph), and recording
+// the content would copy the very data the ACL was protecting into the
+// audit log — a wider disclosure than the read being recorded. What it does
+// record is the SHAPE of the access — who, under which automation, using
+// which bindings — which is what a forensic query needs in order to decide
+// whether to look further.
+//
+// Principal is the REAL triggering identity, not a system user, matching
+// the elevated-write row: "who caused this" stays answerable, like ruid
+// under sudo.
+func (r *ElevationRecorder) RecordElevatedRead(ctx context.Context, bindings []string) {
+	r.sink.Record(Record{
+		Time:        time.Now().UTC(),
+		Op:          OpACLBypassRead,
+		Principal:   principal.From(ctx),
+		TriggeredBy: TriggeredByFrom(ctx),
+		Summary:     "acl_bypass_read=true bindings=" + strings.Join(bindings, ","),
+	})
+}

--- a/internal/audit/elevatedread_test.go
+++ b/internal/audit/elevatedread_test.go
@@ -1,0 +1,73 @@
+package audit_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/Sourcehaven-BV/rela/internal/audit"
+	"github.com/Sourcehaven-BV/rela/internal/principal"
+)
+
+// TKT-ACSBSA: the row that records "a bypass_acl closure read raw data",
+// closing the gap where elevated WRITES were audited (OpACLBypass) and
+// elevated READS left no trace at all.
+
+// TestElevationRecorder_RecordsShapeNotContent pins what the row carries.
+//
+// It must identify WHO read raw data under WHICH automation using WHICH
+// bindings, and must NOT carry entity data or a subject: the read set is
+// unbounded (one admin.list_entities can span the graph), and logging it
+// would copy ACL-protected content into the audit log — a wider disclosure
+// than the read being recorded.
+func TestElevationRecorder_RecordsShapeNotContent(t *testing.T) {
+	t.Parallel()
+	sink := &audit.Memory{}
+	rec := audit.NewElevationRecorder(sink)
+
+	ctx := principal.With(context.Background(), principal.Principal{
+		User: "alice", Tool: principal.ToolDataEntry,
+	})
+	rec.RecordElevatedRead(ctx, []string{"get_entity", "list_entities"})
+
+	records := sink.Records()
+	if len(records) != 1 {
+		t.Fatalf("got %d audit records, want 1", len(records))
+	}
+	got := records[0]
+
+	if got.Op != audit.OpACLBypassRead {
+		t.Errorf("Op = %q, want %q -- elevated reads must be isolable separately "+
+			"from elevated writes, which answer a different question and have a "+
+			"different blast radius", got.Op, audit.OpACLBypassRead)
+	}
+	// The REAL triggering identity, not a system user: "who caused this"
+	// stays answerable, like ruid under sudo.
+	if got.Principal.User != "alice" {
+		t.Errorf("Principal.User = %q, want %q -- the elevated read must be "+
+			"attributed to the real triggering identity", got.Principal.User, "alice")
+	}
+	if got.Subject != nil {
+		t.Errorf("Subject = %+v, want nil -- the read set is unbounded, so naming "+
+			"a subject would be either wrong or a disclosure", got.Subject)
+	}
+	for _, want := range []string{"acl_bypass_read=true", "get_entity", "list_entities"} {
+		if !strings.Contains(got.Summary, want) {
+			t.Errorf("Summary = %q, want it to contain %q", got.Summary, want)
+		}
+	}
+	if got.Time.IsZero() {
+		t.Error("Time is zero -- an audit row with no timestamp is not forensic")
+	}
+}
+
+// TestElevationRecorder_NilSink pins that no sink yields no recorder. The
+// nil must be converted to a genuine nil INTERFACE by the wiring site — see
+// appbuild.NewElevationAuditor and its test, which covers the typed-nil trap
+// this constructor deliberately leaves to the caller.
+func TestElevationRecorder_NilSink(t *testing.T) {
+	t.Parallel()
+	if got := audit.NewElevationRecorder(nil); got != nil {
+		t.Errorf("NewElevationRecorder(nil) = %#v, want nil", got)
+	}
+}

--- a/internal/lua/acl_bypass_reads_test.go
+++ b/internal/lua/acl_bypass_reads_test.go
@@ -3,6 +3,7 @@ package lua
 import (
 	"bytes"
 	"context"
+	"errors"
 	"iter"
 	"slices"
 	"strings"
@@ -91,6 +92,56 @@ func (g gatedReader) ListRelations(ctx context.Context, q store.RelationQuery) i
 			}
 		}
 	}
+}
+
+// failingElevatedReader yields one good row and then an error, to exercise
+// the mid-iteration failure path. The panic after the failing yield is the
+// point: if s.RaiseError did NOT unwind the range loop, the iterator would be
+// resumed and the panic would fire.
+type failingElevatedReader struct{ raw store.Store }
+
+func (f failingElevatedReader) GetEntity(ctx context.Context, id string) (*entity.Entity, error) {
+	return f.raw.GetEntity(ctx, id)
+}
+
+func (f failingElevatedReader) ListEntities(
+	context.Context, store.EntityQuery,
+) iter.Seq2[*entity.Entity, error] {
+	return func(yield func(*entity.Entity, error) bool) {
+		if !yield(&entity.Entity{ID: "A", Type: "ticket"}, nil) {
+			return
+		}
+		yield(nil, errors.New("synthetic store failure"))
+		panic("iterator resumed after RaiseError -- the longjmp did not unwind " +
+			"the range loop, so the binding is leaking an in-flight iterator")
+	}
+}
+
+func (f failingElevatedReader) ListRelations(
+	context.Context, store.RelationQuery,
+) iter.Seq2[*entity.Relation, error] {
+	return func(func(*entity.Relation, error) bool) {}
+}
+
+// brokenElevatedReader fails every GetEntity with an INFRASTRUCTURE error
+// (not a miss), to pin that such errors surface rather than masquerading as
+// "does not exist".
+type brokenElevatedReader struct{}
+
+func (brokenElevatedReader) GetEntity(context.Context, string) (*entity.Entity, error) {
+	return nil, errors.New("connection refused: database is down")
+}
+
+func (brokenElevatedReader) ListEntities(
+	context.Context, store.EntityQuery,
+) iter.Seq2[*entity.Entity, error] {
+	return func(func(*entity.Entity, error) bool) {}
+}
+
+func (brokenElevatedReader) ListRelations(
+	context.Context, store.RelationQuery,
+) iter.Seq2[*entity.Relation, error] {
+	return func(func(*entity.Relation, error) bool) {}
 }
 
 // recordingElevationRecorder captures the post-closure audit
@@ -459,6 +510,163 @@ func TestElevatedRead_DeniedReadIsNotAudited(t *testing.T) {
 	if len(rec.calls) != 0 {
 		t.Errorf("a DENIED elevated read was audited as though data was disclosed: %v",
 			rec.calls)
+	}
+}
+
+// TestElevatedRead_StoreErrorMidIterationUnwindsCleanly pins two properties
+// of the failure path that are easy to get wrong together.
+//
+// The elevated list bindings call s.RaiseError from INSIDE a range-over-func
+// loop -- unlike the gated bindings, which `break` on an iterator error. That
+// is a longjmp out of a running iterator, so this pins that (a) the range loop
+// really unwinds rather than resuming the iterator (the fixture panics if it
+// is resumed), (b) the store error reaches the script instead of being
+// silently swallowed into a short result -- a truncated list that looked
+// complete would be worse than an error -- and (c) the audit defer still
+// fires, so a read that partially succeeded before failing is still recorded.
+func TestElevatedRead_StoreErrorMidIterationUnwindsCleanly(t *testing.T) {
+	t.Parallel()
+	ws := newMockWorkspace(t)
+	rec := &recordingElevationRecorder{}
+	deps := ws.services("/tmp")
+	deps.VisibleReader = gatedReader{raw: ws.store}
+	deps.ElevatedManager = &recordingMutator{}
+	deps.ElevatedReader = failingElevatedReader{raw: ws.store}
+	deps.ElevationRecorder = rec
+	var buf bytes.Buffer
+	r := NewWriter(deps, &buf)
+	defer r.Close()
+
+	err := r.RunString(`rela.bypass_acl(function(admin) admin.list_entities("ticket") end)`)
+	if err == nil {
+		t.Fatal("a store failure mid-iteration was swallowed -- the script got a " +
+			"TRUNCATED list it would read as complete")
+	}
+	if !strings.Contains(err.Error(), "synthetic store failure") {
+		t.Errorf("error = %v, want it to carry the underlying store failure", err)
+	}
+	if len(rec.calls) != 1 {
+		t.Errorf("got %d audit records, want 1 -- the read partially succeeded "+
+			"before failing, so it must still be recorded", len(rec.calls))
+	}
+}
+
+// TestElevatedRead_StoreErrorIsNotMaskedAsMissing pins that only a genuine
+// MISS yields nil (RR: significant).
+//
+// Masking an infrastructure error as nil breaks the documented contract
+// ("admin.get_entity returns nil only when the entity genuinely does not
+// exist") and silently breaks the motivating use case: the guide's own
+// example is a cross-entity uniqueness check, and a nil returned during a
+// transient outage reads as "no duplicate" — so the invariant the elevated
+// read exists to ENFORCE gets violated, quietly, on exactly the occasions
+// the system is already unhealthy.
+func TestElevatedRead_StoreErrorIsNotMaskedAsMissing(t *testing.T) {
+	t.Parallel()
+	ws := newMockWorkspace(t)
+	deps := ws.services("/tmp")
+	deps.VisibleReader = gatedReader{raw: ws.store}
+	deps.ElevatedManager = &recordingMutator{}
+	deps.ElevatedReader = brokenElevatedReader{}
+	var buf bytes.Buffer
+	r := NewWriter(deps, &buf)
+	defer r.Close()
+
+	err := r.RunString(`rela.bypass_acl(function(admin) admin.get_entity("TKT-001") end)`)
+	if err == nil {
+		t.Fatal("a store OUTAGE was reported to the script as nil (not-found) -- " +
+			"a uniqueness check would read that as 'no duplicate' and admit one")
+	}
+	if !strings.Contains(err.Error(), "connection refused") {
+		t.Errorf("error = %v, want it to carry the underlying store failure", err)
+	}
+}
+
+// TestElevatedRead_MissStillReturnsNil is the other half: a genuine miss must
+// stay nil, or every "does this exist?" script breaks.
+func TestElevatedRead_MissStillReturnsNil(t *testing.T) {
+	t.Parallel()
+	r := elevatedReadFixture(t, true)
+	if err := r.RunString(`rela.bypass_acl(function(admin)
+		if admin.get_entity("NOPE-404") ~= nil then
+			error("a missing entity did not come back as nil")
+		end
+	end)`); err != nil {
+		t.Fatalf("a genuine miss raised instead of returning nil: %v", err)
+	}
+}
+
+// TestElevatedRead_DeniedByArgValidationIsNotAudited pins that the audit row
+// means what it says (RR: significant).
+//
+// The empty-argument checks raise BEFORE the reader is ever called, so no
+// data was disclosed. Recording one anyway would make the audit log overstate
+// what happened — the same principle
+// TestElevatedRead_DeniedReadIsNotAudited pins for the nil-reader denial,
+// which is why the mark happens at the store call rather than in readGuard.
+func TestElevatedRead_DeniedByArgValidationIsNotAudited(t *testing.T) {
+	t.Parallel()
+	r, rec := elevatedReadFixtureWithRecorder(t, true)
+
+	// pcall so the raises do not abort the closure; the point is what got
+	// recorded, not that they raised (covered separately).
+	if err := r.RunString(`rela.bypass_acl(function(admin)
+		pcall(function() admin.get_entity("") end)
+		pcall(function() admin.list_entities("") end)
+	end)`); err != nil {
+		t.Fatalf("script: %v", err)
+	}
+
+	if len(rec.calls) != 0 {
+		t.Errorf("got %d audit records (%v), want 0 -- these calls were rejected "+
+			"by argument validation and never reached the store, so recording "+
+			"them claims a disclosure that did not happen", len(rec.calls), rec.calls)
+	}
+}
+
+// TestElevatedRead_GetRelationsRejectsNonStringFilter pins that a mistyped
+// filter fails loudly instead of becoming a whole-graph scan (RR: minor).
+//
+// `{from = 12345}` — an id that came back as a number, or a typo'd key —
+// previously dropped the constraint silently and returned EVERY edge, which
+// the script would read as a filtered result. On the gated path an
+// over-broad query is still peer-gated by the reader; here nothing gates it.
+func TestElevatedRead_GetRelationsRejectsNonStringFilter(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct{ name, opts string }{
+		{"numeric from", `{from = 12345}`},
+		{"boolean type", `{type = true}`},
+		{"table to", `{to = {}}`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			r := elevatedReadFixture(t, true)
+			err := r.RunString(
+				`rela.bypass_acl(function(admin) admin.get_relations(` + tc.opts + `) end)`)
+			if err == nil {
+				t.Fatal("a non-string filter was silently DROPPED -- the call returned " +
+					"an unfiltered whole-graph edge dump that the script reads as filtered")
+			}
+			if !strings.Contains(err.Error(), "must be a string") {
+				t.Errorf("error = %v, want it to name the bad option type", err)
+			}
+		})
+	}
+}
+
+// TestElevatedRead_GetRelationsAcceptsAbsentFilters pins that omitting the
+// options (or individual keys) still means "no constraint" — the rejection
+// above must not have turned absent into invalid.
+func TestElevatedRead_GetRelationsAcceptsAbsentFilters(t *testing.T) {
+	t.Parallel()
+	r := elevatedReadFixture(t, true)
+	if err := r.RunString(`rela.bypass_acl(function(admin)
+		admin.get_relations()
+		admin.get_relations({})
+		admin.get_relations({from = "TKT-001"})
+	end)`); err != nil {
+		t.Fatalf("absent or partial filters were rejected: %v", err)
 	}
 }
 

--- a/internal/lua/acl_bypass_reads_test.go
+++ b/internal/lua/acl_bypass_reads_test.go
@@ -1,0 +1,488 @@
+package lua
+
+import (
+	"bytes"
+	"context"
+	"iter"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/Sourcehaven-BV/rela/internal/entity"
+	"github.com/Sourcehaven-BV/rela/internal/store"
+)
+
+// TKT-ACSBSA: admin.get_entity / list_entities / get_relations inside a
+// rela.bypass_acl closure read RAW — past the gate the surrounding rela.*
+// bindings enforce.
+//
+// The pivot of every test here is that the runtime's VisibleReader is a
+// GATED stub while ElevatedReader is the raw store. If elevated reads ever
+// route through VisibleReader (the plausible "tidy up, they're both
+// readers" refactor), these fail — that is what they exist to catch.
+
+// gatedReader is a deliberately hostile VisibleReader: it hides SECRET-1
+// entirely and strips the "classified" property off everything else. Its
+// job is to be OBSERVABLY different from the raw store so a test can tell
+// which reader a binding used.
+type gatedReader struct{ raw store.Store }
+
+// GetEntity reports a hidden entity as store.ErrNotFound, matching
+// visibility.ScriptReader: a denial is indistinguishable from a genuine
+// miss, so the gated path leaks no existence oracle. Returning (nil, nil)
+// would violate the EntityReader contract and nil-deref the binding.
+func (g gatedReader) GetEntity(ctx context.Context, id string) (*entity.Entity, error) {
+	e, err := g.raw.GetEntity(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	red := g.redact(e)
+	if red == nil {
+		return nil, store.ErrNotFound
+	}
+	return red, nil
+}
+
+// redact returns a copy without the "classified" property, or nil for a
+// hidden entity. Copying (not mutating) matters: the store hands out its
+// own copies, but a future store that didn't would see its data corrupted
+// by a reader, and this stub should not model that bug.
+func (g gatedReader) redact(e *entity.Entity) *entity.Entity {
+	if e.ID == "SECRET-1" {
+		return nil
+	}
+	c := e.Clone()
+	delete(c.Properties, "classified")
+	return c
+}
+
+func (g gatedReader) ListEntities(ctx context.Context, q store.EntityQuery) iter.Seq2[*entity.Entity, error] {
+	return func(yield func(*entity.Entity, error) bool) {
+		for e, err := range g.raw.ListEntities(ctx, q) {
+			if err != nil {
+				if !yield(nil, err) {
+					return
+				}
+				continue
+			}
+			if red := g.redact(e); red != nil && !yield(red, nil) {
+				return
+			}
+		}
+	}
+}
+
+// ListRelations drops any edge touching SECRET-1 — the peer-gating the real
+// visibility reader does (RR-7GDT1Y).
+func (g gatedReader) ListRelations(ctx context.Context, q store.RelationQuery) iter.Seq2[*entity.Relation, error] {
+	return func(yield func(*entity.Relation, error) bool) {
+		for rel, err := range g.raw.ListRelations(ctx, q) {
+			if err != nil {
+				if !yield(nil, err) {
+					return
+				}
+				continue
+			}
+			if rel.From == "SECRET-1" || rel.To == "SECRET-1" {
+				continue
+			}
+			if !yield(rel, nil) {
+				return
+			}
+		}
+	}
+}
+
+// recordingElevationRecorder captures the post-closure audit
+// notifications, one entry per call.
+type recordingElevationRecorder struct{ calls [][]string }
+
+func (r *recordingElevationRecorder) RecordElevatedRead(_ context.Context, bindings []string) {
+	// Copy: the binding owns the slice and is free to reuse it.
+	r.calls = append(r.calls, append([]string(nil), bindings...))
+}
+
+// elevatedReadFixture builds a writer runtime whose gated view hides
+// SECRET-1 and the "classified" property, while the elevated handle (when
+// granted) reads the raw store.
+//
+// grantReads=false models a wiring site that gave write elevation but no
+// read elevation — the nil-ElevatedReader deny path.
+func elevatedReadFixture(t *testing.T, grantReads bool) *Runtime {
+	t.Helper()
+	r, _ := elevatedReadFixtureWithRecorder(t, grantReads)
+	return r
+}
+
+// elevatedReadFixtureWithRecorder is elevatedReadFixture plus the audit
+// recorder, returned so a test can inspect what was recorded.
+func elevatedReadFixtureWithRecorder(
+	t *testing.T, grantReads bool,
+) (*Runtime, *recordingElevationRecorder) {
+	t.Helper()
+	ws := newMockWorkspace(t)
+	ws.seedEntity(&entity.Entity{
+		ID:   "SECRET-1",
+		Type: "ticket",
+		Properties: map[string]any{
+			"title":      "Hidden Ticket",
+			"status":     "open",
+			"classified": "top-secret",
+		},
+	})
+	ws.seedRelation(&entity.Relation{From: "SECRET-1", Type: "implements", To: "FEAT-001"})
+
+	rec := &recordingElevationRecorder{}
+	deps := ws.services("/tmp")
+	deps.VisibleReader = gatedReader{raw: ws.store}
+	deps.ElevatedManager = &recordingMutator{}
+	deps.ElevationRecorder = rec
+	if grantReads {
+		deps.ElevatedReader = ws.store
+	}
+	var buf bytes.Buffer
+	r := NewWriter(deps, &buf)
+	t.Cleanup(r.Close)
+	return r, rec
+}
+
+// TestElevatedRead_SeesWhatTheGatedReaderHides is the core contract: the
+// same two reads, one inside the closure and one outside, disagree — and
+// they disagree in the direction that proves elevation happened.
+func TestElevatedRead_SeesWhatTheGatedReaderHides(t *testing.T) {
+	t.Parallel()
+	r := elevatedReadFixture(t, true)
+
+	script := `
+		-- Outside: gated. SECRET-1 is invisible and "classified" is stripped.
+		if rela.get_entity("SECRET-1") ~= nil then
+			error("gated read saw SECRET-1 -- the fixture is not actually gating")
+		end
+		local vis = rela.get_entity("TKT-001")
+		if vis.properties.classified ~= nil then
+			error("gated read kept the classified property")
+		end
+
+		-- Inside: raw.
+		rela.bypass_acl(function(admin)
+			local hidden = admin.get_entity("SECRET-1")
+			if hidden == nil then
+				error("elevated get_entity could not see the hidden entity")
+			end
+			if hidden.properties.classified ~= "top-secret" then
+				error("elevated get_entity redacted the classified property: got "
+					.. tostring(hidden.properties.classified))
+			end
+		end)
+	`
+	if err := r.RunString(script); err != nil {
+		t.Fatalf("elevated read script: %v", err)
+	}
+}
+
+// TestElevatedRead_ListEntitiesIsUngated pins the list surface: the gated
+// binding drops the hidden row, the elevated one keeps it.
+func TestElevatedRead_ListEntitiesIsUngated(t *testing.T) {
+	t.Parallel()
+	r := elevatedReadFixture(t, true)
+
+	// Counting rather than comparing IDs: what must hold is that elevation
+	// returns strictly MORE, and by exactly the hidden row.
+	script := `
+		local gated = #rela.list_entities("ticket")
+		local elevated
+		rela.bypass_acl(function(admin)
+			elevated = #admin.list_entities("ticket")
+		end)
+		if elevated ~= gated + 1 then
+			error("elevated list_entities returned " .. elevated ..
+				" but gated returned " .. gated .. " -- expected exactly one more (SECRET-1)")
+		end
+	`
+	if err := r.RunString(script); err != nil {
+		t.Fatalf("elevated list script: %v", err)
+	}
+}
+
+// TestElevatedRead_GetRelationsIsNotPeerGated pins that an edge to a hidden
+// endpoint survives elevation. This is the surface most likely to be
+// quietly re-gated, because the gated binding's peer-drop looks like a
+// safety property worth keeping everywhere.
+func TestElevatedRead_GetRelationsIsNotPeerGated(t *testing.T) {
+	t.Parallel()
+	r := elevatedReadFixture(t, true)
+
+	script := `
+		local function has_secret_edge(rels)
+			for _, rel in ipairs(rels) do
+				if rel.from == "SECRET-1" then return true end
+			end
+			return false
+		end
+
+		if has_secret_edge(rela.get_relations({to = "FEAT-001"})) then
+			error("gated get_relations returned the SECRET-1 edge -- fixture is not gating")
+		end
+		rela.bypass_acl(function(admin)
+			if not has_secret_edge(admin.get_relations({to = "FEAT-001"})) then
+				error("elevated get_relations dropped the edge from the hidden entity")
+			end
+		end)
+	`
+	if err := r.RunString(script); err != nil {
+		t.Fatalf("elevated relations script: %v", err)
+	}
+}
+
+// TestElevatedRead_HandleInvalidatedAfterClosure pins that the read methods
+// obey the SAME liveness guard as the write methods. A read that survives
+// the closure would be a durable ungated capability — precisely what the
+// object-capability design exists to prevent.
+func TestElevatedRead_HandleInvalidatedAfterClosure(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name string
+		call string
+	}{
+		{"get_entity", `stashed.get_entity("SECRET-1")`},
+		{"list_entities", `stashed.list_entities("ticket")`},
+		{"get_relations", `stashed.get_relations({})`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			r := elevatedReadFixture(t, true)
+			script := `
+				local stashed
+				rela.bypass_acl(function(admin) stashed = admin end)
+			` + tc.call
+
+			err := r.RunString(script)
+			if err == nil {
+				t.Fatal("an escaped admin handle performed an elevated READ after the " +
+					"closure returned -- elevation leaked past its dynamic extent")
+			}
+			if !strings.Contains(err.Error(), "invalidated") {
+				t.Errorf("error = %v, want it to mention the handle is invalidated", err)
+			}
+		})
+	}
+}
+
+// TestElevatedRead_DeniesWhenNoReaderWired pins the nil-ElevatedReader
+// contract: RAISE, never silently fall back to the gated VisibleReader.
+//
+// A fallback would be the worst outcome available — the closure would look
+// elevated, return a partial graph, and the script would treat it as
+// complete. Failing loudly is the only safe behavior for a capability that
+// is supposed to be total.
+func TestElevatedRead_DeniesWhenNoReaderWired(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name string
+		call string
+	}{
+		{"get_entity", `admin.get_entity("TKT-001")`},
+		{"list_entities", `admin.list_entities("ticket")`},
+		{"get_relations", `admin.get_relations({})`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			r := elevatedReadFixture(t, false) // write elevation only
+			err := r.RunString(`rela.bypass_acl(function(admin) ` + tc.call + ` end)`)
+			if err == nil {
+				t.Fatal("an elevated read succeeded with NO elevated reader wired -- " +
+					"it must have fallen back to the gated reader, which makes a " +
+					"non-elevated result look elevated")
+			}
+			if !strings.Contains(err.Error(), "no elevated reader is configured") {
+				t.Errorf("error = %v, want the 'no elevated reader is configured' raise", err)
+			}
+		})
+	}
+}
+
+// TestElevatedRead_WriteElevationStillWorksWithoutReadElevation pins that
+// the two capabilities are independent: withholding reads must not break
+// the pre-existing TKT-D8T148 write surface.
+func TestElevatedRead_WriteElevationStillWorksWithoutReadElevation(t *testing.T) {
+	t.Parallel()
+	r := elevatedReadFixture(t, false)
+	err := r.RunString(`rela.bypass_acl(function(admin)
+		admin.create_relation("alice", "created-by", "TKT-001")
+	end)`)
+	if err != nil {
+		t.Fatalf("elevated WRITE broke when read elevation was withheld: %v", err)
+	}
+}
+
+// TestElevatedRead_RejectsEmptyArguments pins argument validation, so a
+// typo'd id reaches a clear Lua error rather than an empty-string store
+// query whose result the script would misread as "not found".
+func TestElevatedRead_RejectsEmptyArguments(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name string
+		call string
+	}{
+		{"get_entity", `admin.get_entity("")`},
+		{"list_entities", `admin.list_entities("")`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			r := elevatedReadFixture(t, true)
+			if err := r.RunString(`rela.bypass_acl(function(admin) ` + tc.call + ` end)`); err == nil {
+				t.Error("an empty argument was accepted; want a raise")
+			}
+		})
+	}
+}
+
+// TestElevatedRead_AbsentWithoutBypassBinding pins the outer gate: no
+// allow_acl_bypass action means no rela.bypass_acl, so an ElevatedReader
+// sitting in the deps grants a script nothing. Elevation needs BOTH keys.
+func TestElevatedRead_AbsentWithoutBypassBinding(t *testing.T) {
+	t.Parallel()
+	ws := newMockWorkspace(t)
+	deps := ws.services("/tmp")
+	deps.VisibleReader = gatedReader{raw: ws.store}
+	deps.ElevatedReader = ws.store // read capability present...
+	deps.ElevatedManager = nil     // ...but no elevated Mutator: no binding.
+	var buf bytes.Buffer
+	r := NewWriter(deps, &buf)
+	defer r.Close()
+
+	if err := r.RunString(`if rela.bypass_acl ~= nil then error("bypass_acl present") end`); err != nil {
+		t.Errorf("an ElevatedReader alone registered rela.bypass_acl (%v) -- read "+
+			"elevation must not be a second, independent key to the closure", err)
+	}
+}
+
+// TestElevatedRead_AuditsOncePerClosure pins the audit contract
+// (TKT-ACSBSA): one record per closure that read, naming the distinct
+// bindings used — NOT one per read.
+//
+// The per-read alternative is what makes this worth a test: a single
+// admin.list_entities can traverse the whole graph, so per-row recording
+// would put an unbounded synchronous write on a read path.
+func TestElevatedRead_AuditsOncePerClosure(t *testing.T) {
+	t.Parallel()
+	r, rec := elevatedReadFixtureWithRecorder(t, true)
+
+	// Two distinct bindings, and one of them called repeatedly.
+	script := `
+		rela.bypass_acl(function(admin)
+			admin.get_entity("SECRET-1")
+			admin.get_entity("TKT-001")
+			admin.get_entity("TKT-002")
+			admin.list_entities("ticket")
+		end)
+	`
+	if err := r.RunString(script); err != nil {
+		t.Fatalf("script: %v", err)
+	}
+
+	if len(rec.calls) != 1 {
+		t.Fatalf("got %d audit records, want exactly 1 per closure "+
+			"(4 reads happened; per-read recording would be unbounded)", len(rec.calls))
+	}
+	want := []string{"get_entity", "list_entities"}
+	if !slices.Equal(rec.calls[0], want) {
+		t.Errorf("recorded bindings = %v, want %v (distinct, first-use order; "+
+			"get_entity was called 3x and must appear once)", rec.calls[0], want)
+	}
+}
+
+// TestElevatedRead_AuditsEvenWhenClosureRaises is the anti-tampering
+// property: a closure that reads raw data and THEN fails must still leave
+// the trace.
+//
+// Recording only on the success path would let a script read everything and
+// erase the evidence by raising — the shape an attacker would choose, and
+// an easy mistake to make since the natural place for the call is after the
+// PCall succeeds.
+func TestElevatedRead_AuditsEvenWhenClosureRaises(t *testing.T) {
+	t.Parallel()
+	r, rec := elevatedReadFixtureWithRecorder(t, true)
+
+	err := r.RunString(`
+		rela.bypass_acl(function(admin)
+			admin.get_entity("SECRET-1")
+			error("boom")
+		end)
+	`)
+	if err == nil {
+		t.Fatal("expected the raise to propagate out of bypass_acl")
+	}
+	if len(rec.calls) != 1 {
+		t.Fatalf("got %d audit records, want 1 -- a closure that read raw data and "+
+			"then raised left NO trace, so failing is a way to erase the evidence",
+			len(rec.calls))
+	}
+}
+
+// TestElevatedRead_NoAuditWithoutReads pins the quiet case: a bypass_acl
+// closure that only WRITES must not emit a read record. Those writes are
+// already covered by entitymanager's OpACLBypass rows, and an empty
+// read-record would add noise that makes the real ones harder to spot.
+func TestElevatedRead_NoAuditWithoutReads(t *testing.T) {
+	t.Parallel()
+	r, rec := elevatedReadFixtureWithRecorder(t, true)
+
+	err := r.RunString(`rela.bypass_acl(function(admin)
+		admin.create_relation("alice", "created-by", "TKT-001")
+	end)`)
+	if err != nil {
+		t.Fatalf("script: %v", err)
+	}
+	if len(rec.calls) != 0 {
+		t.Errorf("a write-only closure emitted %d read audit records, want 0: %v",
+			len(rec.calls), rec.calls)
+	}
+}
+
+// TestElevatedRead_DeniedReadIsNotAudited pins that a REFUSED read (no
+// elevated reader wired) emits no record. The record means "raw data was
+// disclosed"; emitting one when nothing was read would make the audit log
+// overstate what happened, which erodes trust in every other row.
+func TestElevatedRead_DeniedReadIsNotAudited(t *testing.T) {
+	t.Parallel()
+	r, rec := elevatedReadFixtureWithRecorder(t, false)
+
+	if err := r.RunString(
+		`rela.bypass_acl(function(admin) admin.get_entity("TKT-001") end)`,
+	); err == nil {
+		t.Fatal("expected the denied read to raise")
+	}
+	if len(rec.calls) != 0 {
+		t.Errorf("a DENIED elevated read was audited as though data was disclosed: %v",
+			rec.calls)
+	}
+}
+
+// TestElevatedRead_NilRecorderIsNotFatal pins that a missing audit sink
+// degrades quietly. Unlike a missing ElevatedReader (which denies), a
+// deployment may legitimately run without an audit sink, and refusing to
+// run automations over that would be a worse failure than an unrecorded
+// read.
+func TestElevatedRead_NilRecorderIsNotFatal(t *testing.T) {
+	t.Parallel()
+	ws := newMockWorkspace(t)
+	deps := ws.services("/tmp")
+	deps.VisibleReader = gatedReader{raw: ws.store}
+	deps.ElevatedManager = &recordingMutator{}
+	deps.ElevatedReader = ws.store
+	deps.ElevationRecorder = nil // no sink wired
+	var buf bytes.Buffer
+	r := NewWriter(deps, &buf)
+	defer r.Close()
+
+	if err := r.RunString(
+		`rela.bypass_acl(function(admin) admin.get_entity("TKT-001") end)`,
+	); err != nil {
+		t.Errorf("an elevated read failed because no audit sink was wired: %v -- "+
+			"recording is best-effort, not a precondition", err)
+	}
+}

--- a/internal/lua/deps.go
+++ b/internal/lua/deps.go
@@ -110,4 +110,63 @@ type WriteDeps struct {
 	// rela.bypass_acl(fn). Nil on every other runtime, so rela.bypass_acl is
 	// absent and a script cannot elevate.
 	ElevatedManager Mutator
+
+	// ElevatedReader, when non-nil, is the RAW read handle backing the
+	// admin.get_entity / list_entities / get_relations methods of the
+	// bypass_acl closure (TKT-ACSBSA). Reads through it are unredacted and
+	// ungated — the closure is the boundary, so a half-elevated read would
+	// be a confusing contract.
+	//
+	// SEPARATE from WritePrepStore on purpose, even though production wires
+	// both from the same raw store. WritePrepStore is present on EVERY
+	// writer runtime (update_entity's read-before-write needs it); routing
+	// elevated reads through it would hand every writer runtime an ungated
+	// read path and dissolve the two-key gate that makes elevation
+	// opt-in. This field is set at the same site, under the same two
+	// conditions, as ElevatedManager.
+	//
+	// Nil is a DENY, not a fallback: admin.get_entity raises rather than
+	// silently reading through the gated VisibleReader. Elevation that
+	// quietly degrades to the caller's view is worse than a loud failure —
+	// the script would see a partial graph and treat it as complete.
+	ElevatedReader EntityReader
+
+	// ElevationRecorder, when non-nil, is notified once per bypass_acl
+	// closure that performed at least one elevated READ (TKT-ACSBSA).
+	//
+	// Elevated WRITES are already audited inside entitymanager
+	// (audit.OpACLBypass). Reads never reach entitymanager — they go
+	// straight to the store — so without this an operator querying the
+	// audit log for elevation sees every elevated write and is silently
+	// blind to every elevated read. That asymmetry is the gap this closes.
+	//
+	// ONCE PER CLOSURE, not per read: a single admin.list_entities can
+	// traverse the whole graph, and a per-row audit record would put an
+	// unbounded synchronous write on a read path. The forensic question an
+	// operator actually asks is "which elevated scopes read raw data", and
+	// the closure is the unit of elevation.
+	//
+	// Nil disables recording. Unlike ElevatedReader, nil here is NOT a deny:
+	// a wiring site may legitimately have no audit sink (CLI, tests), and
+	// refusing to run automations because of that would be a worse failure
+	// than an unrecorded read.
+	ElevationRecorder ElevationRecorder
+}
+
+// ElevationRecorder receives a notification when a rela.bypass_acl closure
+// used its elevated READ capability. Defined here at the consumer per
+// CLAUDE.md "interfaces at the call site" — one method, which is all the
+// binding needs; the wiring site adapts it onto the audit sink.
+type ElevationRecorder interface {
+	// RecordElevatedRead is called at most once per closure, after it
+	// returns, when at least one elevated read occurred. bindings names the
+	// distinct admin read methods used (e.g. "get_entity,list_entities") so
+	// the record says what kind of access happened without recording the
+	// data itself.
+	//
+	// Implementations must not block: this runs on the script's goroutine
+	// inside the cascade. Errors are the implementation's to handle — the
+	// binding has no way to surface them and a failed audit write must not
+	// fail the automation.
+	RecordElevatedRead(ctx context.Context, bindings []string)
 }

--- a/internal/lua/runtime.go
+++ b/internal/lua/runtime.go
@@ -1694,9 +1694,16 @@ func (r *Runtime) newElevatedHandle(
 		}
 		return true
 	}
-	// readGuard adds the wired-reader check to the liveness check, and marks
-	// the binding as used. Both checks are required before any elevated read
-	// touches the store.
+	// readGuard adds the wired-reader check to the liveness check. Both are
+	// required before any elevated read touches the store.
+	//
+	// It deliberately does NOT mark the binding as used. Marking here would
+	// audit a read that never reached the store — the argument-validation
+	// raises (empty id, empty type) fire AFTER this guard, so a closure doing
+	// only `pcall(admin.get_entity, "")` would produce an `acl-bypass-read`
+	// row claiming a disclosure that never happened. Each method calls
+	// reads.mark immediately before its er.* call instead, so the audit row
+	// means what it says.
 	readGuard := func(name string) bool {
 		if !guard(name) {
 			return false
@@ -1705,11 +1712,6 @@ func (r *Runtime) newElevatedHandle(
 			ls.RaiseError("rela.bypass_acl: %s: no elevated reader is configured for this runtime", name)
 			return false
 		}
-		// Marked BEFORE the read, not after: a read that panics or raises
-		// mid-iteration still happened, and partial data may already have
-		// reached the script. Recording only completed reads would leave the
-		// noisiest failure cases untraced.
-		reads.mark(name)
 		return true
 	}
 	ls.SetField(t, "create_relation", ls.NewFunction(func(s *lua.LState) int {
@@ -1749,7 +1751,7 @@ func (r *Runtime) newElevatedHandle(
 		s.Push(lua.LTrue)
 		return 1
 	}))
-	registerElevatedReads(ls, t, er, readGuard, r.callerCtx)
+	registerElevatedReads(ls, t, er, readGuard, r.callerCtx, reads)
 	return t
 }
 
@@ -1765,11 +1767,11 @@ func (r *Runtime) newElevatedHandle(
 // small and it keeps the two read paths physically separate.
 func registerElevatedReads(
 	ls *lua.LState, t *lua.LTable, er EntityReader, readGuard func(string) bool,
-	ctxFn func() context.Context,
+	ctxFn func() context.Context, reads *readUsage,
 ) {
-	ls.SetField(t, "get_entity", ls.NewFunction(elevatedGetEntity(er, readGuard, ctxFn)))
-	ls.SetField(t, "list_entities", ls.NewFunction(elevatedListEntities(er, readGuard, ctxFn)))
-	ls.SetField(t, "get_relations", ls.NewFunction(elevatedGetRelations(er, readGuard, ctxFn)))
+	ls.SetField(t, "get_entity", ls.NewFunction(elevatedGetEntity(er, readGuard, ctxFn, reads)))
+	ls.SetField(t, "list_entities", ls.NewFunction(elevatedListEntities(er, readGuard, ctxFn, reads)))
+	ls.SetField(t, "get_relations", ls.NewFunction(elevatedGetRelations(er, readGuard, ctxFn, reads)))
 }
 
 // elevatedGetEntity builds admin.get_entity(id) -> table|nil.
@@ -1780,6 +1782,7 @@ func registerElevatedReads(
 // deliberately ambiguous "missing or hidden" that keeps it oracle-free.
 func elevatedGetEntity(
 	er EntityReader, readGuard func(string) bool, ctxFn func() context.Context,
+	reads *readUsage,
 ) func(*lua.LState) int {
 	return func(s *lua.LState) int {
 		if !readGuard("get_entity") {
@@ -1790,10 +1793,23 @@ func elevatedGetEntity(
 			s.RaiseError("bypass_acl get_entity: entity ID cannot be empty")
 			return 0
 		}
+		reads.mark("get_entity")
 		e, err := er.GetEntity(ctxFn(), id)
 		if err != nil {
-			s.Push(lua.LNil)
-			return 1
+			// Only a genuine MISS is nil. Any other error (store down, driver
+			// failure) RAISES — masking it as nil would make the documented
+			// contract ("nil means it does not exist") false, and would break
+			// the motivating use case: a uniqueness check that reads nil on a
+			// transient outage concludes "no duplicate" and lets the invariant
+			// the elevated read exists to enforce be violated. The two list
+			// bindings already raise on iteration errors; this keeps the three
+			// consistent.
+			if errors.Is(err, store.ErrNotFound) {
+				s.Push(lua.LNil)
+				return 1
+			}
+			s.RaiseError("bypass_acl get_entity error: %s", err.Error())
+			return 0
 		}
 		s.Push(EntityToTable(s, e))
 		return 1
@@ -1809,6 +1825,7 @@ func elevatedGetEntity(
 // (TKT-YWDGZD tracks paging for both).
 func elevatedListEntities(
 	er EntityReader, readGuard func(string) bool, ctxFn func() context.Context,
+	reads *readUsage,
 ) func(*lua.LState) int {
 	return func(s *lua.LState) int {
 		if !readGuard("list_entities") {
@@ -1819,6 +1836,7 @@ func elevatedListEntities(
 			s.RaiseError("bypass_acl list_entities: entity type cannot be empty")
 			return 0
 		}
+		reads.mark("list_entities")
 		result := s.NewTable()
 		idx := 1
 		for e, err := range er.ListEntities(ctxFn(), store.EntityQuery{Type: entityType}) {
@@ -1843,12 +1861,18 @@ func elevatedListEntities(
 // elevated view incomplete.
 func elevatedGetRelations(
 	er EntityReader, readGuard func(string) bool, ctxFn func() context.Context,
+	reads *readUsage,
 ) func(*lua.LState) int {
 	return func(s *lua.LState) int {
 		if !readGuard("get_relations") {
 			return 0
 		}
-		q := elevatedRelationQuery(s)
+		q, err := elevatedRelationQuery(s)
+		if err != nil {
+			s.RaiseError("bypass_acl get_relations: %s", err.Error())
+			return 0
+		}
+		reads.mark("get_relations")
 		result := s.NewTable()
 		idx := 1
 		for rel, err := range er.ListRelations(ctxFn(), q) {
@@ -1867,22 +1891,35 @@ func elevatedGetRelations(
 // elevatedRelationQuery reads the optional {from,type,to} options table off
 // the Lua stack. An absent or non-table argument yields the zero query,
 // which matches every relation.
-func elevatedRelationQuery(s *lua.LState) store.RelationQuery {
+func elevatedRelationQuery(s *lua.LState) (store.RelationQuery, error) {
 	var q store.RelationQuery
 	if s.GetTop() < 1 || s.Get(1).Type() != lua.LTTable {
-		return q
+		return q, nil
 	}
 	opts := s.CheckTable(1)
-	if v, ok := opts.RawGetString("from").(lua.LString); ok {
-		q.From = string(v)
+	fields := []struct {
+		name string
+		dst  *string
+	}{
+		{"from", &q.From}, {"type", &q.Type}, {"to", &q.To},
 	}
-	if v, ok := opts.RawGetString("type").(lua.LString); ok {
-		q.Type = string(v)
+	for _, f := range fields {
+		switch v := opts.RawGetString(f.name).(type) {
+		case *lua.LNilType:
+			// Absent: no constraint on this field.
+		case lua.LString:
+			*f.dst = string(v)
+		default:
+			// A non-string is REJECTED rather than skipped. Silently dropping
+			// it turns a mistyped filter (`{from = 12345}` when an id came
+			// back as a number) into an unfiltered whole-graph edge dump that
+			// the script reads as a filtered result — and nothing downstream
+			// gates it, because this is the elevated path.
+			return q, fmt.Errorf(
+				"option %q must be a string, got %s", f.name, v.Type())
+		}
 	}
-	if v, ok := opts.RawGetString("to").(lua.LString); ok {
-		q.To = string(v)
-	}
-	return q
+	return q, nil
 }
 
 // luaDeleteEntity implements rela.delete_entity(id, cascade?) -> boolean

--- a/internal/lua/runtime.go
+++ b/internal/lua/runtime.go
@@ -19,6 +19,7 @@ import (
 	"math"
 	"os"
 	"path/filepath"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -1600,11 +1601,22 @@ func (r *Runtime) luaBypassACL(ls *lua.LState) int {
 	// live gates every admin.* call; set false after fn returns so a captured
 	// handle is dead outside the closure's dynamic extent.
 	live := true
-	admin := r.newElevatedHandle(ls, r.deps.ElevatedManager, &live)
+	// reads accumulates the distinct elevated read bindings this closure
+	// used, for the single post-closure audit record (TKT-ACSBSA).
+	reads := &readUsage{}
+	admin := r.newElevatedHandle(ls, r.deps.ElevatedManager, r.deps.ElevatedReader, &live, reads)
 
 	// Invalidate on every exit path (normal return or Lua error). pcall keeps
 	// the runtime alive so we can flip `live` before re-raising.
-	defer func() { live = false }()
+	//
+	// The audit record rides the SAME defer, so a closure that reads raw data
+	// and then raises still leaves a trace. Recording only on the success
+	// path would let a script read everything and erase the evidence by
+	// failing — the exact shape an attacker would choose.
+	defer func() {
+		live = false
+		recordElevatedReads(r.callerCtx(), r.deps.ElevationRecorder, reads)
+	}()
 
 	ls.Push(fn)
 	ls.Push(admin)
@@ -1620,23 +1632,84 @@ func (r *Runtime) luaBypassACL(ls *lua.LState) int {
 }
 
 // newElevatedHandle builds the `admin` table passed to a rela.bypass_acl
-// closure. Its methods route to the elevated Mutator `em` and check `*live`
-// first, so they raise once the closure has returned. No reads, no principal,
-// no nested bypass.
+// closure. Its methods route to the elevated Mutator `em` (writes) and the
+// elevated EntityReader `er` (reads), and check `*live` first, so they raise
+// once the closure has returned. No principal, no nested bypass.
 //
-// v1 surface: create_relation, delete_relation, delete_entity — the
+// Write surface: create_relation, delete_relation, delete_entity — the
 // link/unlink + remove operations the system-invariant use cases (e.g.
 // authorship stamping via created-by) need. create_entity / update_entity are a
 // deliberate follow-up: they marshal a full entity table and aren't required by
 // the motivating case; gating elevated *entity* creation is a larger surface
 // best added with its own tests.
-func (r *Runtime) newElevatedHandle(ls *lua.LState, em Mutator, live *bool) *lua.LTable {
+//
+// Read surface (TKT-ACSBSA): get_entity, list_entities, get_relations —
+// mirroring the gated rela.* bindings one-for-one so a script can lift a read
+// into the closure without rewriting it. Reads are RAW: full properties, no
+// row gate, no redaction. A half-elevated read is a confusing contract and the
+// closure is already the boundary.
+//
+// A nil `er` leaves the three read methods present but RAISING, not absent.
+// Absence would make `if admin.get_entity then` silently take the
+// no-elevation branch on a misconfigured deployment; raising names the
+// missing capability. Writes behave the same way via the outer nil check on
+// ElevatedManager.
+// readUsage accumulates which elevated read bindings a bypass_acl closure
+// actually used, so the post-closure audit record can name them. Order is
+// first-use, and each binding appears once — the record answers "what kind
+// of raw access happened", not "how many times".
+//
+// Not safe for concurrent use, and does not need to be: a Lua state is
+// single-goroutine, and one readUsage is scoped to one closure.
+type readUsage struct{ names []string }
+
+// mark records a use of binding `name`, ignoring repeats.
+func (u *readUsage) mark(name string) {
+	if slices.Contains(u.names, name) {
+		return
+	}
+	u.names = append(u.names, name)
+}
+
+// recordElevatedReads emits the single post-closure audit notification when
+// the closure used its read elevation. Silent when no recorder is wired or
+// when the closure performed no elevated reads — a bypass_acl block that
+// only writes is already covered by entitymanager's OpACLBypass rows, and
+// an empty record would just add noise to the log.
+func recordElevatedReads(ctx context.Context, rec ElevationRecorder, u *readUsage) {
+	if rec == nil || len(u.names) == 0 {
+		return
+	}
+	rec.RecordElevatedRead(ctx, u.names)
+}
+
+func (r *Runtime) newElevatedHandle(
+	ls *lua.LState, em Mutator, er EntityReader, live *bool, reads *readUsage,
+) *lua.LTable {
 	t := ls.NewTable()
 	guard := func(name string) bool {
 		if !*live {
 			ls.RaiseError("rela.bypass_acl: handle %q used outside its closure (invalidated)", name)
 			return false
 		}
+		return true
+	}
+	// readGuard adds the wired-reader check to the liveness check, and marks
+	// the binding as used. Both checks are required before any elevated read
+	// touches the store.
+	readGuard := func(name string) bool {
+		if !guard(name) {
+			return false
+		}
+		if er == nil {
+			ls.RaiseError("rela.bypass_acl: %s: no elevated reader is configured for this runtime", name)
+			return false
+		}
+		// Marked BEFORE the read, not after: a read that panics or raises
+		// mid-iteration still happened, and partial data may already have
+		// reached the script. Recording only completed reads would leave the
+		// noisiest failure cases untraced.
+		reads.mark(name)
 		return true
 	}
 	ls.SetField(t, "create_relation", ls.NewFunction(func(s *lua.LState) int {
@@ -1676,7 +1749,140 @@ func (r *Runtime) newElevatedHandle(ls *lua.LState, em Mutator, live *bool) *lua
 		s.Push(lua.LTrue)
 		return 1
 	}))
+	registerElevatedReads(ls, t, er, readGuard, r.callerCtx)
 	return t
+}
+
+// registerElevatedReads adds the three raw read methods to the `admin` table
+// (TKT-ACSBSA). Split out of newElevatedHandle to keep each function within
+// the length limit; `readGuard` carries both the liveness and wired-reader
+// checks so neither can be forgotten at an individual method.
+//
+// Deliberately NOT sharing code with the gated luaGetEntity / luaListEntities
+// / luaGetRelations bindings: those funnel through r.reader() (which resolves
+// VisibleReader), and a shared helper parameterized by reader would be one
+// edit away from letting a gated binding read raw. The duplication here is
+// small and it keeps the two read paths physically separate.
+func registerElevatedReads(
+	ls *lua.LState, t *lua.LTable, er EntityReader, readGuard func(string) bool,
+	ctxFn func() context.Context,
+) {
+	ls.SetField(t, "get_entity", ls.NewFunction(elevatedGetEntity(er, readGuard, ctxFn)))
+	ls.SetField(t, "list_entities", ls.NewFunction(elevatedListEntities(er, readGuard, ctxFn)))
+	ls.SetField(t, "get_relations", ls.NewFunction(elevatedGetRelations(er, readGuard, ctxFn)))
+}
+
+// elevatedGetEntity builds admin.get_entity(id) -> table|nil.
+//
+// Returns nil on a miss, matching rela.get_entity. The two nils mean
+// different things, though: under elevation a nil means the entity
+// genuinely does not exist, where the gated binding's nil is the
+// deliberately ambiguous "missing or hidden" that keeps it oracle-free.
+func elevatedGetEntity(
+	er EntityReader, readGuard func(string) bool, ctxFn func() context.Context,
+) func(*lua.LState) int {
+	return func(s *lua.LState) int {
+		if !readGuard("get_entity") {
+			return 0
+		}
+		id := s.CheckString(1)
+		if id == "" {
+			s.RaiseError("bypass_acl get_entity: entity ID cannot be empty")
+			return 0
+		}
+		e, err := er.GetEntity(ctxFn(), id)
+		if err != nil {
+			s.Push(lua.LNil)
+			return 1
+		}
+		s.Push(EntityToTable(s, e))
+		return 1
+	}
+}
+
+// elevatedListEntities builds admin.list_entities(type) -> table.
+//
+// No filter-expression argument: rela.list_entities' filter is a
+// convenience over an already-gated set, and adding an expression parser to
+// the elevated path widens it for no gain — a script can filter the
+// returned table in Lua. Unbounded, like its gated counterpart
+// (TKT-YWDGZD tracks paging for both).
+func elevatedListEntities(
+	er EntityReader, readGuard func(string) bool, ctxFn func() context.Context,
+) func(*lua.LState) int {
+	return func(s *lua.LState) int {
+		if !readGuard("list_entities") {
+			return 0
+		}
+		entityType := s.CheckString(1)
+		if entityType == "" {
+			s.RaiseError("bypass_acl list_entities: entity type cannot be empty")
+			return 0
+		}
+		result := s.NewTable()
+		idx := 1
+		for e, err := range er.ListEntities(ctxFn(), store.EntityQuery{Type: entityType}) {
+			if err != nil {
+				s.RaiseError("bypass_acl list_entities error: %s", err.Error())
+				return 0
+			}
+			result.RawSetInt(idx, EntityToTable(s, e))
+			idx++
+		}
+		s.Push(result)
+		return 1
+	}
+}
+
+// elevatedGetRelations builds admin.get_relations(opts?) -> table, with
+// opts.{from,type,to}.
+//
+// NOT peer-gated (unlike rela.get_relations): an edge is returned even when
+// neither endpoint would be visible to the caller. Re-adding the peer drop
+// here would look like a safety improvement and would silently make the
+// elevated view incomplete.
+func elevatedGetRelations(
+	er EntityReader, readGuard func(string) bool, ctxFn func() context.Context,
+) func(*lua.LState) int {
+	return func(s *lua.LState) int {
+		if !readGuard("get_relations") {
+			return 0
+		}
+		q := elevatedRelationQuery(s)
+		result := s.NewTable()
+		idx := 1
+		for rel, err := range er.ListRelations(ctxFn(), q) {
+			if err != nil {
+				s.RaiseError("bypass_acl get_relations error: %s", err.Error())
+				return 0
+			}
+			result.RawSetInt(idx, relationToTable(s, rel))
+			idx++
+		}
+		s.Push(result)
+		return 1
+	}
+}
+
+// elevatedRelationQuery reads the optional {from,type,to} options table off
+// the Lua stack. An absent or non-table argument yields the zero query,
+// which matches every relation.
+func elevatedRelationQuery(s *lua.LState) store.RelationQuery {
+	var q store.RelationQuery
+	if s.GetTop() < 1 || s.Get(1).Type() != lua.LTTable {
+		return q
+	}
+	opts := s.CheckTable(1)
+	if v, ok := opts.RawGetString("from").(lua.LString); ok {
+		q.From = string(v)
+	}
+	if v, ok := opts.RawGetString("type").(lua.LString); ok {
+		q.Type = string(v)
+	}
+	if v, ok := opts.RawGetString("to").(lua.LString); ok {
+		q.To = string(v)
+	}
+	return q
 }
 
 // luaDeleteEntity implements rela.delete_entity(id, cascade?) -> boolean

--- a/internal/script/elevation_test.go
+++ b/internal/script/elevation_test.go
@@ -1,0 +1,177 @@
+package script
+
+import (
+	"context"
+	"errors"
+	"iter"
+	"testing"
+
+	"github.com/Sourcehaven-BV/rela/internal/autocascade"
+	"github.com/Sourcehaven-BV/rela/internal/entity"
+	"github.com/Sourcehaven-BV/rela/internal/lua"
+	"github.com/Sourcehaven-BV/rela/internal/store"
+)
+
+// The TKT-D8T148 / TKT-ACSBSA two-key gate lives HERE, in Run: elevation is
+// granted only when the action is allow_acl_bypass AND the per-cascade
+// Mutator offers ElevatedProvider. internal/lua cannot test this — it
+// receives WriteDeps already assembled. These tests inspect the deps this
+// package hands the executor.
+
+// depsCapturingExecutor records the lua.WriteDeps it was called with, which
+// is exactly the elevation decision this package makes.
+type depsCapturingExecutor struct{ got lua.WriteDeps }
+
+func (d *depsCapturingExecutor) ExecuteCode(
+	_ context.Context, _ string, deps lua.WriteDeps, _, _ *entity.Entity,
+) error {
+	d.got = deps
+	return nil
+}
+
+func (d *depsCapturingExecutor) ExecuteFile(
+	_ context.Context, _ string, deps lua.WriteDeps, _, _ *entity.Entity,
+) error {
+	d.got = deps
+	return nil
+}
+
+// elevatingMutator offers the optional ElevatedProvider capability.
+type elevatingMutator struct{ autocascade.Mutator }
+
+func (e elevatingMutator) Elevated() autocascade.Mutator { return e }
+
+// plainMutator does NOT offer ElevatedProvider — a Mutator that declines to
+// grant elevation, which no flag can override.
+type plainMutator struct{ autocascade.Mutator }
+
+// errStubRead is returned by every stubReader method. The stub is never
+// called by these tests — they assert which reader is HANDED OVER, not what
+// it returns — so a sentinel error is the honest zero behavior; returning a
+// nil entity with a nil error would model a contract no real reader has.
+var errStubRead = errors.New("stubReader: not expected to be called")
+
+// stubReader is a non-nil lua.EntityReader standing in for the raw store.
+type stubReader struct{}
+
+func (stubReader) GetEntity(context.Context, string) (*entity.Entity, error) {
+	return nil, errStubRead
+}
+func (stubReader) ListEntities(context.Context, store.EntityQuery) iter.Seq2[*entity.Entity, error] {
+	return func(func(*entity.Entity, error) bool) {}
+}
+func (stubReader) ListRelations(
+	context.Context, store.RelationQuery,
+) iter.Seq2[*entity.Relation, error] {
+	return func(func(*entity.Relation, error) bool) {}
+}
+
+// stubRecorder is a non-nil lua.ElevationRecorder. Like stubReader it is
+// never invoked; these tests assert what is handed over.
+type stubRecorder struct{}
+
+func (stubRecorder) RecordElevatedRead(context.Context, []string) {}
+
+// TestRun_ElevationRequiresBothKeys is the table that pins the gate. Read
+// and write elevation are asserted TOGETHER because they must turn on and
+// off as one — a row where one is granted and the other is not would mean
+// the two capabilities had drifted apart.
+func TestRun_ElevationRequiresBothKeys(t *testing.T) {
+	t.Parallel()
+
+	elevation := ReadElevation{Reader: stubReader{}, Recorder: stubRecorder{}}
+	for _, tc := range []struct {
+		name        string
+		allowBypass bool
+		mutator     autocascade.Mutator
+		wantGranted bool
+	}{
+		{
+			name:        "both keys: elevation granted",
+			allowBypass: true,
+			mutator:     elevatingMutator{},
+			wantGranted: true,
+		},
+		{
+			// Operator opt-in alone is not enough: a Mutator that does not
+			// offer the capability cannot be forced to grant it.
+			name:        "flag set but mutator declines: denied",
+			allowBypass: true,
+			mutator:     plainMutator{},
+		},
+		{
+			// The mirror image, and the more dangerous direction: a Mutator
+			// that CAN elevate must not do so for an ordinary action.
+			name:    "mutator can elevate but flag unset: denied",
+			mutator: elevatingMutator{},
+		},
+		{
+			name:    "neither key: denied",
+			mutator: plainMutator{},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			exec := &depsCapturingExecutor{}
+			r := NewLuaScriptRunnerWithElevatedReads(exec, lua.ReadDeps{}, elevation)
+
+			err := r.Run(context.Background(), autocascade.ScriptAction{
+				Code:           "print('x')",
+				AllowACLBypass: tc.allowBypass,
+			}, tc.mutator)
+			if err != nil {
+				t.Fatalf("Run: %v", err)
+			}
+
+			gotWrite := exec.got.ElevatedManager != nil
+			gotRead := exec.got.ElevatedReader != nil
+			if gotWrite != tc.wantGranted {
+				t.Errorf("elevated WRITE granted = %v, want %v", gotWrite, tc.wantGranted)
+			}
+			if gotRead != tc.wantGranted {
+				t.Errorf("elevated READ granted = %v, want %v -- read elevation must "+
+					"turn on and off with the same two keys as write elevation, never "+
+					"on its own", gotRead, tc.wantGranted)
+			}
+			// The recorder must accompany the reader on every row. Granting
+			// the capability without the audit trace is the exact gap
+			// TKT-ACSBSA closes, and it would be invisible in behavior.
+			if gotRec := exec.got.ElevationRecorder != nil; gotRec != tc.wantGranted {
+				t.Errorf("elevation RECORDER passed = %v, want %v -- the audit sink "+
+					"must travel with the elevated reader, or elevated reads happen "+
+					"untraced", gotRec, tc.wantGranted)
+			}
+		})
+	}
+}
+
+// TestRun_NoElevatedReaderWhenNoneSupplied pins that Run hands over only
+// what the WIRING SITE gave it. A runner built without a reader must not
+// synthesize one from readDeps — WritePrepStore is a raw store sitting
+// right there, and reaching for it would grant read elevation at every
+// wiring site rather than the ones that opted in.
+func TestRun_NoElevatedReaderWhenNoneSupplied(t *testing.T) {
+	t.Parallel()
+	exec := &depsCapturingExecutor{}
+	// NewLuaScriptRunner is the no-read-elevation constructor. WritePrepStore
+	// is deliberately populated: the temptation this test guards against.
+	r := NewLuaScriptRunner(exec, lua.ReadDeps{WritePrepStore: nil})
+
+	err := r.Run(context.Background(), autocascade.ScriptAction{
+		Code:           "print('x')",
+		AllowACLBypass: true,
+	}, elevatingMutator{})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	if exec.got.ElevatedReader != nil {
+		t.Error("read elevation was granted by a runner that was never given a " +
+			"reader -- the capability must come from the wiring site, not be " +
+			"synthesized from the read deps")
+	}
+	// Write elevation is unaffected: the two are independent capabilities.
+	if exec.got.ElevatedManager == nil {
+		t.Error("withholding read elevation also disabled WRITE elevation")
+	}
+}

--- a/internal/script/luascriptrunner.go
+++ b/internal/script/luascriptrunner.go
@@ -88,7 +88,11 @@ type ReadElevation struct {
 // is nil, which is the right behavior for misconfigured deployments.
 //
 // Use [NewLuaScriptRunnerWithElevatedReads] to additionally grant the
-// bypass_acl closure a raw read handle.
+// bypass_acl closure a raw read handle. Since TKT-ACSBSA both production
+// wiring sites (appbuild.assemble, appbuildtest) use that one, so this
+// constructor has no production callers today — it is kept because
+// "no read elevation" is a real configuration a wiring site may want, and
+// the tests that pin the withheld-capability behavior need it.
 func NewLuaScriptRunner(exec Executor, readDeps lua.ReadDeps) *LuaScriptRunner {
 	return NewLuaScriptRunnerWithElevatedReads(exec, readDeps, ReadElevation{})
 }

--- a/internal/script/luascriptrunner.go
+++ b/internal/script/luascriptrunner.go
@@ -44,17 +44,74 @@ type Executor interface {
 type LuaScriptRunner struct {
 	exec     Executor
 	readDeps lua.ReadDeps
+
+	// elevatedReader is the raw read capability handed to a bypass_acl
+	// closure (TKT-ACSBSA). Nil means this wiring scope grants no read
+	// elevation: admin.get_entity et al. raise rather than degrading to the
+	// caller's gated view.
+	elevatedReader lua.EntityReader
+
+	// elevationRecorder receives the post-closure notification when elevated
+	// reads occurred. Travels WITH elevatedReader — granting the capability
+	// without the trace is what the audit gap looked like before TKT-ACSBSA.
+	elevationRecorder lua.ElevationRecorder
+}
+
+// ReadElevation is the read-side capability a wiring site grants to
+// rela.bypass_acl closures (TKT-ACSBSA): the raw reader plus the audit sink
+// that records its use.
+//
+// The two are one struct because they must be decided together. A Reader
+// without a Recorder is ungated access that leaves no trace — the audit
+// asymmetry the ticket exists to close — so the pairing is visible at every
+// wiring site rather than being two independent arguments one of which is
+// easy to forget.
+type ReadElevation struct {
+	// Reader must be UNGATED — the point of elevation is to see past the
+	// acting principal's view. A gated reader here produces a closure that
+	// looks elevated and silently is not, which is the one failure mode
+	// worse than no elevation at all. Wiring sites name it through
+	// visibility.Unrestricted so `grep -rn visibility.Unrestricted`
+	// enumerates this path with every other ungated read (TKT-1WV50C).
+	Reader lua.EntityReader
+
+	// Recorder is notified once per closure that used Reader. Nil is
+	// permitted (a deployment may genuinely have no audit sink) but is a
+	// deliberate choice, not a default — see the field godoc on
+	// lua.WriteDeps.ElevationRecorder.
+	Recorder lua.ElevationRecorder
 }
 
 // NewLuaScriptRunner returns a LuaScriptRunner bound to exec and the
-// static read deps. Returns nil if exec is nil — Runner records each
-// scripted action as an error when ScriptRunner is nil, which is the
-// right behavior for misconfigured deployments.
+// static read deps, granting NO read elevation. Returns nil if exec is
+// nil — Runner records each scripted action as an error when ScriptRunner
+// is nil, which is the right behavior for misconfigured deployments.
+//
+// Use [NewLuaScriptRunnerWithElevatedReads] to additionally grant the
+// bypass_acl closure a raw read handle.
 func NewLuaScriptRunner(exec Executor, readDeps lua.ReadDeps) *LuaScriptRunner {
+	return NewLuaScriptRunnerWithElevatedReads(exec, readDeps, ReadElevation{})
+}
+
+// NewLuaScriptRunnerWithElevatedReads is [NewLuaScriptRunner] plus the read
+// capability backing admin.get_entity / list_entities / get_relations inside
+// a rela.bypass_acl closure (TKT-ACSBSA).
+//
+// The capability is inert until BOTH TKT-D8T148 keys turn: the action must
+// be allow_acl_bypass and the per-cascade Mutator must offer
+// ElevatedProvider. Passing an elevation here grants nothing on its own.
+func NewLuaScriptRunnerWithElevatedReads(
+	exec Executor, readDeps lua.ReadDeps, elevation ReadElevation,
+) *LuaScriptRunner {
 	if exec == nil {
 		return nil
 	}
-	return &LuaScriptRunner{exec: exec, readDeps: readDeps}
+	return &LuaScriptRunner{
+		exec:              exec,
+		readDeps:          readDeps,
+		elevatedReader:    elevation.Reader,
+		elevationRecorder: elevation.Recorder,
+	}
 }
 
 // Run dispatches the action to the underlying executor. The mutator
@@ -91,6 +148,17 @@ func (l *LuaScriptRunner) Run(ctx context.Context, action autocascade.ScriptActi
 	if action.AllowACLBypass {
 		if ep, ok := m.(autocascade.ElevatedProvider); ok {
 			deps.ElevatedManager = ep.Elevated()
+			// TKT-ACSBSA: the elevated READ handle is set under the SAME two
+			// keys, inside the same branch — never on its own, so read
+			// elevation cannot outlive or precede write elevation.
+			//
+			// elevatedReader is supplied by the wiring site (nil when that site
+			// chose not to grant read elevation), exactly as the elevated WRITE
+			// handle comes from the caller's Mutator rather than being minted
+			// here. This package does not construct the capability; it only
+			// decides when to hand over one it was given.
+			deps.ElevatedReader = l.elevatedReader
+			deps.ElevationRecorder = l.elevationRecorder
 		}
 	}
 	var err error

--- a/tickets/entities/docs-checklists/DOCS-P7CJLR.md
+++ b/tickets/entities/docs-checklists/DOCS-P7CJLR.md
@@ -1,0 +1,66 @@
+---
+id: DOCS-P7CJLR
+type: docs-checklist
+title: 'Docs: lua: elevated reads on rela.bypass_acl''s admin handle'
+status: done
+---
+
+## Code Documentation
+
+- [x] Godoc on every new exported symbol (`lua.ElevationRecorder`,
+`script.ReadElevation`, `script.NewLuaScriptRunnerWithElevatedReads`,
+`audit.ElevationRecorder`, `audit.NewElevationRecorder`,
+`audit.OpACLBypassRead`, `appbuild.NewElevationAuditor`)
+- [x] Godoc explains the *why*, not just the *what* — each of the
+load-bearing decisions carries its rationale at the declaration site:
+  - `WriteDeps.ElevatedReader`: why it is SEPARATE from `WritePrepStore`
+(which exists on every writer runtime, so reusing it would dissolve the two-key
+gate)
+  - `WriteDeps.ElevationRecorder`: why once-per-closure and not per-read
+  - `newElevatedHandle`: why a nil reader leaves the methods PRESENT and
+RAISING rather than absent
+  - `registerElevatedReads`: why it deliberately does NOT share code with
+the gated bindings
+  - `appbuild.NewElevationAuditor`: the typed-nil-in-interface trap
+- [x] Comments explain non-obvious decisions (the `defer` that records the
+audit row on the raise path; marking the binding used BEFORE the read)
+
+## Project Documentation
+
+- [x] `docs-project/entities/guides/GUIDE-lua-scripting.md` — retitled the
+section "Elevated writes" → "Elevated access"; added the three read methods to
+the `admin` method table; documented that elevated reads return raw data; added
+a worked example (cross-entity uniqueness invariant); documented the deliberate
+difference in what `nil` means between `rela.get_entity` (missing OR hidden —
+oracle-free) and `admin.get_entity` (genuinely absent); extended the
+safety-properties list with the audit row, closure-scoping for reads, and the
+fail-loud-not-degraded contract.
+- [x] `docs-project/entities/guides/GUIDE-acl-security.md` — added the
+sanctioned escape hatch to the script-reads section: when an automation needs
+more than its caller can see, use `rela.bypass_acl` rather than widening a role
+in `acl.yaml` (scoped to a closure, visible at the call site, leaves an
+`acl-bypass-read` row — where a widened role would grant access on every path
+with nothing in the log).
+- [x] Generated docs regenerated via `just docs`; `docs/lua-scripting.md`
+and `docs/acl-security.md` updated and committed. Edited the SOURCES in
+`docs-project/`, not the generated output.
+- [x] `just lint-md` passes (245 files, 0 issues)
+- [x] The pre-push docs gate (`git diff --exit-code docs/ README.md`)
+confirms generated output is in sync.
+
+## External Documentation
+
+- [x] ~~API reference updated~~ (N/A: no HTTP API surface changed — this is
+a Lua binding on an operator-gated automation path)
+- [x] ~~Migration guide~~ (N/A: purely additive. Existing `bypass_acl`
+closures keep working unchanged; the new methods appear on a handle that only
+exists when an operator has already set `allow_acl_bypass: true`)
+- [x] ~~CHANGELOG~~ (N/A: this project does not maintain one)
+
+## Operator-facing notes
+
+- [x] The new audit op `acl-bypass-read` is documented in
+`internal/audit/audit.go` (wire-contract constant block, alongside `acl-bypass`)
+AND in the ACL/Lua guides, including the deliberate choice to record NO subject
+and NO entity data, and why folding it into the existing `acl-bypass` op would
+have silently changed what every existing `op == "acl-bypass"` query means.

--- a/tickets/entities/implementation-checklists/IMPL-PG7L2C.md
+++ b/tickets/entities/implementation-checklists/IMPL-PG7L2C.md
@@ -1,0 +1,83 @@
+---
+id: IMPL-PG7L2C
+type: implementation-checklist
+title: 'Implementation: lua: extend rela.bypass_acl''s admin handle with read methods (elevated reads, closure-scoped)'
+status: done
+---
+
+## Development
+
+- [x] Unit tests written for new code
+- [x] Integration tests written (test full flow, not just units)
+- [x] Happy path implemented
+- [x] Edge cases from planning handled
+- [x] Error handling in place (errors surfaced, not swallowed)
+
+## Test Quality
+
+- [x] Using fixture builders or factories for test data
+- [x] No hardcoded values in assertions when object is in scope
+- [x] Only specifying values that matter for the test
+- [x] Interpolated values constructed from objects, not hardcoded
+- [x] Property comparisons use original object, not hardcoded strings
+
+## Manual Verification
+
+- [x] ~~Feature manually tested end-to-end~~ (N/A: the capability is inert
+without an `allow_acl_bypass` automation action + an `ElevatedProvider` Mutator;
+the two-key gate is exercised by the automated tests at both layers)
+- [x] Each acceptance criterion verified with test scenario from planning
+- [x] Edge cases manually verified
+
+**Verification Evidence:**
+
+Verified by **mutation testing** — each mutation applied to production code,
+confirmed the intended test fails, then reverted:
+
+| Mutation | Caught by |
+|----------|-----------|
+| Route elevated reads through `VisibleReader` (the plausible "they're both readers" tidy-up) | 5 tests |
+| Drop the liveness guard from the read methods | `TestElevatedRead_HandleInvalidatedAfterClosure` |
+| Fall back to the gated reader when `ElevatedReader` is nil | `TestElevatedRead_DeniesWhenNoReaderWired` |
+| Grant the reader outside the two-key branch | 3 deny rows of `TestRun_ElevationRequiresBothKeys` |
+| Record the audit row only on the success path | `TestElevatedRead_AuditsEvenWhenClosureRaises` |
+| Remove per-closure dedup (record per read) | `TestElevatedRead_AuditsOncePerClosure` |
+| Emit a record when no reads happened | 2 tests |
+| Return concrete `*ElevationRecorder` instead of the interface (typed-nil trap) | `TestNewElevationAuditor_NilSinkYieldsNilInterface` |
+
+The typed-nil mutation initially **survived** — the first version of that test
+compared the return value directly, and `nil *T != nil` is false, so it passed
+against the very defect it targeted. Rewritten to assert through the
+`lua.WriteDeps` field the value actually lands in; it now fails correctly.
+
+Full suite green except `TestScriptReadSeam_PolicylessProjectStaysUnrestricted`,
+which fails identically on a pristine `develop` worktree (pre-existing, fixed by
+PR #1228). Race detector clean on all touched packages. `just lint`, `just
+arch-lint`, `just plimsoll`, `just lint-md`, coverage floors: all pass.
+
+## Quality
+
+- [x] Code follows project patterns (check similar code)
+- [x] Checked for DRY opportunities — the elevated read bindings deliberately
+do NOT share code with the gated `luaGetEntity`/`luaListEntities`/
+`luaGetRelations`: those funnel through `r.reader()` (which resolves
+`VisibleReader`), and a shared helper parameterized by reader would be one edit
+away from letting a gated binding read raw. Extracted `elevatedRelationQuery`
+(shared option-table parsing) and `readUsage.mark` where it did sharpen the
+contract.
+- [x] No security issues introduced
+- [x] No silent failures (errors logged AND returned)
+- [x] No debug code left behind
+
+## Architecture notes
+
+- `plimsoll` flagged `Runtime` at 125/120 methods. Resolved by making the four
+new read builders + `recordElevatedReads` **package functions** taking a
+`ctxFn`, rather than raising the directive — the guidance says prefer splitting
+the type.
+- `arch-lint` rejected `appbuild → principal`. The audit adapter moved to
+`internal/audit` (which already depends on `principal` and owns the record
+shape); it satisfies `lua.ElevationRecorder` structurally, so `audit` gains no
+dependency on `lua`. **No arch-lint rule additions were needed.**
+- `visibility.Unrestricted` names the new ungated path, so
+`grep -rn "visibility.Unrestricted"` still enumerates every one (TKT-1WV50C).

--- a/tickets/entities/review-checklists/REV-WPVK8E.md
+++ b/tickets/entities/review-checklists/REV-WPVK8E.md
@@ -1,0 +1,83 @@
+---
+id: REV-WPVK8E
+type: review-checklist
+title: 'Review: lua: extend rela.bypass_acl''s admin handle with read methods (elevated reads, closure-scoped)'
+status: done
+---
+
+## Automated Checks
+
+- [x] `just lint` — 0 issues
+- [x] `just arch-lint` — OK, no warnings. **No rule additions were needed**:
+the `appbuild → principal` violation was fixed by moving the audit adapter to
+`internal/audit` (which already owns `principal` and the record shape) rather
+than widening the allow-list.
+- [x] `just plimsoll` — passes. `Runtime` hit 125/120 methods; resolved by
+making the read builders + `recordElevatedReads` **package functions**, not by
+raising the directive.
+- [x] `just lint-md` — 245 files, 0 issues
+- [x] `just docs` — generated output regenerated and committed; the pre-push
+gate (`git diff --exit-code docs/ README.md`) confirms sync
+- [x] Race detector clean on all touched packages
+- [x] Coverage floors satisfied (package 50% / total 65%)
+
+## Code Review
+
+- [x] `/code-review` run (cranky-code-reviewer) against commit `31813351`
+- [x] All findings triaged and recorded as review-response entities
+- [x] **All 3 findings addressed** (2 significant, 1 minor) — see
+[[RR-FDV0GO]], [[RR-B89X8H]], [[RR-D7KXKV]]
+- [x] No open critical or significant findings remain
+
+### What the review confirmed
+
+The reviewer independently verified the security core empirically rather than by
+reading — worth recording because these were the properties I was least able to
+prove to myself:
+
+- **Coroutine escape is blocked.** A coroutine that yields the `admin` handle
+out and calls it from the main thread raises "used outside its closure".
+gopher-lua's `switchToParentThread` unwinds via panic, so the `defer` fires and
+`live=false` lands before the handle escapes.
+- **Nested-bypass revival is blocked** — a stale handle stays dead inside a
+second closure.
+- **`readUsage`'s single-goroutine assumption is sound** — no
+goroutine/errgroup/WaitGroup anywhere in `lua`, `autocascade`, `script`, or
+`automation`; coroutines share one OS thread.
+- **Mid-iteration `RaiseError` is safe** — the iterator body does not resume,
+deferred cleanup runs exactly once, the error reaches the script.
+- **A Go panic (not a Lua raise) still audits** — `PCall` recovers, the
+`defer` runs.
+- **The audit row cannot be suppressed by failing, nor duplicated.**
+- **The typed-nil test is genuinely load-bearing**, including its choice to
+assert through `lua.WriteDeps` rather than the return value.
+
+## Verification
+
+- [x] Every fix mutation-verified: reverting each one fails its own
+regression test (`StoreErrorIsNotMaskedAsMissing`,
+`DeniedByArgValidationIsNotAudited`, `GetRelationsRejectsNonStringFilter`)
+- [x] Both directions pinned, so no fix could swing too far —
+`MissStillReturnsNil` guards the error-raising fix from breaking existence
+checks; `GetRelationsAcceptsAbsentFilters` guards the type-check from rejecting
+legitimately absent options
+- [x] Full suite green **except**
+`TestScriptReadSeam_PolicylessProjectStaysUnrestricted`, which fails identically
+on a pristine `develop` worktree — pre-existing, fixed by PR **#1180/#1228**
+(verified by checking out a clean worktree at `3974fecb`, not assumed)
+
+## Notes
+
+- `NewLuaScriptRunner` now has zero production callers (both wiring sites use
+the elevated-reads constructor). Kept deliberately — "no read elevation" is a
+real configuration, and the withheld-capability tests need it. Noted in its
+godoc so the next reader is not puzzled.
+- The identical non-string-filter shape in the **gated** `luaGetRelations`
+was left as-is: tightening it is a breaking change on a binding scripts already
+use, and the risk there is bounded by peer-gating. Follow-up territory, not a
+drive-by change inside this ticket.
+
+## PR
+
+Branch `feat/tkt-acsbsa-elevated-reads`. PR to be opened once **#1228** lands
+and clears the pre-existing `develop` failure.

--- a/tickets/entities/review-responses/RR-B89X8H.md
+++ b/tickets/entities/review-responses/RR-B89X8H.md
@@ -1,0 +1,18 @@
+---
+id: RR-B89X8H
+type: review-response
+title: admin.get_entity masked infrastructure errors as "does not exist"
+finding: 'elevatedGetEntity pushed lua.LNil on ANY error from er.GetEntity, so a store outage was indistinguishable from a genuine miss. Verified: a reader returning "connection refused: database is down" gave the script nil and no error. Two compounding problems. (1) The docs added in the same commit promise "admin.get_entity returns nil only when the entity genuinely does not exist" — false under any store error, and the whole point of contrasting it with the oracle-free gated nil is that the elevated nil is supposed to be informative. (2) The documented use case is a correctness invariant: the guide''s own example is a cross-entity uniqueness check, so under a transient outage the check reads nil, concludes "no duplicate", and silently violates the invariant the elevated read exists to enforce — precisely when the system is already unhealthy. The sibling list_entities/get_relations already raised on iteration errors, making get_entity the inconsistent one.'
+severity: significant
+resolution: get_entity now returns nil ONLY for store.ErrNotFound and raises on every other error, making the three read methods consistent. Corrected the false claim in GUIDE-lua-scripting.md and regenerated docs. Added TestElevatedRead_StoreErrorIsNotMaskedAsMissing plus TestElevatedRead_MissStillReturnsNil (so the fix cannot swing the other way and break existence checks); mutation-verified.
+status: addressed
+---
+
+Raised by the cranky-code-reviewer against commit `31813351`.
+
+The most consequential of the three findings: it made my own documentation
+false, and the failure mode is silent corruption of a correctness invariant
+rather than a visible error. The gated `rela.get_entity` mirrors this
+nil-on-error shape, but there it is defensible — the gated nil is *deliberately*
+ambiguous to stay oracle-free. The elevated nil carries the opposite contract,
+so the same code shape has the opposite meaning.

--- a/tickets/entities/review-responses/RR-D7KXKV.md
+++ b/tickets/entities/review-responses/RR-D7KXKV.md
@@ -1,0 +1,17 @@
+---
+id: RR-D7KXKV
+type: review-response
+title: Mistyped get_relations filter silently became a full ungated scan
+finding: 'elevatedRelationQuery used RawGetString(...).(lua.LString) with the ok result discarded into a silent skip, so a non-string value dropped the filter entirely. Verified: admin.get_relations({from = 12345}) returned ALL relations rather than zero. Triggered by `from = entity.id` where the id came back as a number, or by a typo''d key. This mirrors the gated luaGetRelations so it is not a regression, but the blast radius differs: on the gated path an over-broad result is still peer-gated by the reader, whereas on the elevated path nothing gates it — the script receives a whole-graph edge dump and treats it as filtered. Also internally inconsistent, since the two list methods validate their arguments and this one did not.'
+severity: minor
+resolution: 'elevatedRelationQuery now returns an error and rejects any non-string, non-nil from/type/to, naming the offending option and its actual type. Absent keys and an absent options table still mean "no constraint". Added TestElevatedRead_GetRelationsRejectsNonStringFilter (3 subtests: number, boolean, table) and TestElevatedRead_GetRelationsAcceptsAbsentFilters so the rejection cannot swing too far; mutation-verified. The gated luaGetRelations was left as-is — changing it is a behavior change on a widely-used binding and belongs in its own ticket.'
+status: addressed
+---
+
+Raised by the cranky-code-reviewer against commit `31813351`.
+
+Fixed on the elevated path only. The identical shape in the gated
+`luaGetRelations` (`runtime.go:938-950`) is left alone deliberately: tightening
+it would be a breaking behavior change on a binding scripts already use, and the
+risk there is bounded by the peer-gating the reader applies afterwards. Worth a
+follow-up ticket, not a drive-by change inside this one.

--- a/tickets/entities/review-responses/RR-FDV0GO.md
+++ b/tickets/entities/review-responses/RR-FDV0GO.md
@@ -1,0 +1,18 @@
+---
+id: RR-FDV0GO
+type: review-response
+title: Elevated-read audit row claims reads that never touched the store
+finding: 'readGuard marked the binding as used before each method''s argument validation ran. The empty-string checks (empty id for get_entity, empty type for list_entities) raise BEFORE the reader is called, so a closure doing only `pcall(function() admin.get_entity("") end)` produced an acl-bypass-read audit row claiming a disclosure that never happened. Verified empirically: audit calls = [[get_entity list_entities]] with zero store contact. This contradicted TestElevatedRead_DeniedReadIsNotAudited, whose own comment states the principle — the test only covered the nil-reader denial, so the argument-validation denial slipped through the same hole the test was written to close.'
+severity: significant
+resolution: Removed reads.mark from readGuard; each of the three methods now calls reads.mark immediately before its er.* call, so the mark happens where disclosure actually occurs. readGuard's godoc now explains why it deliberately does NOT mark. Added TestElevatedRead_DeniedByArgValidationIsNotAudited; mutation-verified by restoring the mark to readGuard, which fails the new test.
+status: addressed
+---
+
+Raised by the cranky-code-reviewer against commit `31813351`.
+
+The `readGuard` comment justified early marking with "a read that panics or
+raises mid-iteration still happened" — true for `list_entities`, but argument
+validation happens *before* any store contact, so the justification did not
+cover that case. Marking at the store call preserves the mid-iteration property
+(the mark still precedes the `er.*` call, so a partial read that then fails is
+still recorded) while dropping the false-positive.

--- a/tickets/entities/tickets/TKT-ACSBSA.md
+++ b/tickets/entities/tickets/TKT-ACSBSA.md
@@ -5,7 +5,7 @@ title: 'lua: extend rela.bypass_acl''s admin handle with read methods (elevated 
 kind: enhancement
 priority: medium
 effort: m
-status: backlog
+status: done
 ---
 
 ## Summary

--- a/tickets/relations/TKT-ACSBSA--has-docs--DOCS-P7CJLR.md
+++ b/tickets/relations/TKT-ACSBSA--has-docs--DOCS-P7CJLR.md
@@ -1,0 +1,5 @@
+---
+from: TKT-ACSBSA
+relation: has-docs
+to: DOCS-P7CJLR
+---

--- a/tickets/relations/TKT-ACSBSA--has-implementation--IMPL-PG7L2C.md
+++ b/tickets/relations/TKT-ACSBSA--has-implementation--IMPL-PG7L2C.md
@@ -1,0 +1,5 @@
+---
+from: TKT-ACSBSA
+relation: has-implementation
+to: IMPL-PG7L2C
+---

--- a/tickets/relations/TKT-ACSBSA--has-review--REV-WPVK8E.md
+++ b/tickets/relations/TKT-ACSBSA--has-review--REV-WPVK8E.md
@@ -1,0 +1,5 @@
+---
+from: TKT-ACSBSA
+relation: has-review
+to: REV-WPVK8E
+---

--- a/tickets/relations/TKT-ACSBSA--has-review-response--RR-B89X8H.md
+++ b/tickets/relations/TKT-ACSBSA--has-review-response--RR-B89X8H.md
@@ -1,0 +1,5 @@
+---
+from: TKT-ACSBSA
+relation: has-review-response
+to: RR-B89X8H
+---

--- a/tickets/relations/TKT-ACSBSA--has-review-response--RR-D7KXKV.md
+++ b/tickets/relations/TKT-ACSBSA--has-review-response--RR-D7KXKV.md
@@ -1,0 +1,5 @@
+---
+from: TKT-ACSBSA
+relation: has-review-response
+to: RR-D7KXKV
+---

--- a/tickets/relations/TKT-ACSBSA--has-review-response--RR-FDV0GO.md
+++ b/tickets/relations/TKT-ACSBSA--has-review-response--RR-FDV0GO.md
@@ -1,0 +1,5 @@
+---
+from: TKT-ACSBSA
+relation: has-review-response
+to: RR-FDV0GO
+---


### PR DESCRIPTION
Closes TKT-ACSBSA. Follow-up to TKT-ZF2DTV / DEC-O59WM4.

## Why

TKT-ZF2DTV bound Lua automation reads to the triggering principal — but left no
sanctioned way for an automation that legitimately needs to see more. Without
one, the pressure is to widen a role in `acl.yaml`, which grants access on every
path with nothing in the audit log to show for it.

This extends the **existing** closure-scoped `admin` handle (TKT-D8T148) rather
than adding a second escalation mechanism, so elevation stays legible at the
call site.

```lua
rela.bypass_acl(function(admin)
  for _, t in ipairs(admin.list_entities("ticket")) do   -- raw, ungated
    if t.properties.external_ref == entity.properties.external_ref
       and t.id ~= entity.id then
      error("duplicate external_ref: " .. t.id)
    end
  end
end)
-- admin is dead here; rela.* stays scoped to the caller
```

## What

- `admin.get_entity` / `list_entities` / `get_relations`, reading raw, under the
  same liveness guard as the write methods.
- `WriteDeps.ElevatedReader` — deliberately **separate** from `WritePrepStore`.
  That field is a raw store present on *every* writer runtime; routing elevated
  reads through it would have dissolved the two-key gate.
- A nil reader **denies** (raises) rather than degrading to the gated view. A
  closure that looks elevated but silently returns a partial graph is worse than
  one that refuses.

## The ticket's open question: should elevated reads be audited?

Yes — and it's built. New `acl-bypass-read` audit op, **one row per closure**
(a single `list_entities` can span the graph, so per-read would be an unbounded
synchronous write on a read path), carrying **no subject and no entity data**
(logging the read set would copy ACL-protected content *into* the audit log).

Emitted from a `defer`, so a closure that reads raw and *then* raises still
leaves the trace — otherwise failing would be a way to erase the evidence.

Kept as a separate op from `acl-bypass`: folding reads in would silently change
what every existing `op == "acl-bypass"` query means.

## Review

`/code-review` found **3 issues, all fixed** in the second commit — each
reproduced empirically first, then mutation-verified after the fix
(RR-FDV0GO, RR-B89X8H, RR-D7KXKV):

1. **significant** — the audit row claimed reads that never touched the store
   (argument validation raises *after* the guard marked the binding used). Now
   marked at the store call.
2. **significant** — `admin.get_entity` masked infrastructure errors as
   "does not exist", making my own docs false and silently breaking the
   documented uniqueness-check use case under a transient outage. Now raises on
   anything that isn't `ErrNotFound`.
3. **minor** — a mistyped filter (`{from = 12345}`) silently became a full
   ungated scan. Now rejected. The identical shape in the *gated*
   `luaGetRelations` is left alone deliberately — tightening it is a breaking
   change on a widely-used binding and belongs in its own ticket.

The reviewer also independently verified, empirically, that coroutine escape is
blocked, nested-bypass revival is blocked, `readUsage`'s single-goroutine
assumption holds, mid-iteration `RaiseError` unwinds cleanly, and a Go panic
still audits.

## Checks

`lint`, `arch-lint`, `plimsoll`, `lint-md`, race detector, coverage floors — all
pass. Two gates flagged real problems and both were fixed by restructuring
rather than by relaxing the rule: `Runtime` went over its method cap (read
builders became package functions), and `appbuild → principal` was rejected (the
audit adapter moved to `internal/audit`, which already owns `principal`).

> [!NOTE]
> CI will show `TestScriptReadSeam_PolicylessProjectStaysUnrestricted` failing.
> That is **pre-existing on `develop`** — verified against a pristine worktree at
> `3974fecb`, not assumed — and is what #1228 fixes. This branch goes green once
> that lands.