### PR TITLE
docs(acl-map): TKT-CAN9GM next slice + mark map --principal shipped

### DIFF
--- a/tickets/entities/features/FEAT-RCQ6SJ.md
+++ b/tickets/entities/features/FEAT-RCQ6SJ.md
@@ -45,13 +45,15 @@ interfaces (`ListEntities`, a `ForPrincipal`-style resolver, policy accessors) �
 
 ## Use-cases covered (from RES-8TX9KF)
 
-| UC | What v1 delivers |
-|----|------------------|
-| UC1 onboarding | `map --principal` — per-principal verb grid, spot a stray write grant |
-| UC2 offboarding | `map --principal` — complete reachable set, `everyone`-only = cut off |
-| UC3 sensitive spot-check | `who-can read <entity>` — readers + the path each took |
-| UC6 blast-radius | `map --principal` before/after diff — count of newly-reachable entities |
-| UC7 (partial) | surfaces everyone-readable types etc.; full heuristics are a separate aclaudit ticket |
+| UC | What v1 delivers | Status |
+|----|------------------|--------|
+| UC1 onboarding | `map --principal` — per-principal verb grid, spot a stray write grant | ✅ TKT-B1YE7 |
+| UC2 offboarding | `map --principal` — complete reachable set, `everyone`-only = cut off | ✅ TKT-B1YE7 |
+| UC3 sensitive spot-check | `who-can read <entity>` — readers + the path each took | ✅ TKT-9089I6 |
+| UC6 blast-radius | `map --principal` before/after diff — count of newly-reachable entities | ✅ TKT-B1YE7 (diff = external) |
+| `can` spot-check | `can <P> <verb> <E>` — scriptable yes/no + exit code | TKT-CAN9GM |
+| whole-graph `map` | `map` (no `--principal`) — full inventory, reverse index | TKT-CAN9GM |
+| UC7 (partial) | surfaces everyone-readable types etc.; full heuristics are a separate aclaudit ticket | later |
 
 ## Acceptance criteria
 

--- a/tickets/entities/researchs/RES-8TX9KF.md
+++ b/tickets/entities/researchs/RES-8TX9KF.md
@@ -2,9 +2,37 @@
 id: RES-8TX9KF
 type: research
 title: 'Effective-access map: enumerate who can access what, with provenance and drift detection'
-summary: 'ACL effective-access map: enumerate who-can-access-what with all-routes provenance, filtering, drift. UC3 (who-can) SHIPPED in TKT-9089I6.'
+summary: 'ACL effective-access map: enumerate who-can-access-what with all-routes provenance, filtering, drift. UC3 (who-can) + UC1/UC2 (map --principal) SHIPPED.'
 status: done
 ---
+
+## Implementation notes — UC1/UC2 (`map --principal`) SHIPPED (TKT-B1YE7, PR #1218, merged 2026-07-26)
+
+Second slice — `rela acl map --principal <P>` — is in `develop`
+(`internal/aclmap/mapprincipal.go` + `acl` empty-entity probe support). The
+inverse of who-can: fix the principal, show everything reachable by type. What
+this slice taught us (refines the design above):
+
+- **Baseline must be computed entity-independently, NOT discovered inside the
+  entity loop.** Type-level grants (global/group/asserted/everyone) apply to
+  every entity of a type, so the per-type baseline is computed once via an
+  **empty-entity probe** — `AccessRoutes(verb, type, "")`. Discovering baselines
+  inside the entity loop meant a type with ZERO entities hid a real global grant
+  and reported `EveryoneOnly=true` — the exact UC2 offboarding false all-clear
+  (CRITICAL, caught in code review, fixed + regression test). The entity loop now
+  only collects local/inherited **exceptions**.
+- **The baseline/exception split is itself a correctness surface, not just
+  presentation.** A conformance test that only checks the boolean grant is blind
+  to misclassifying an entity-specific grant as a type-wide baseline (or vice
+  versa) — the split must be asserted (`assertClassification`: an entity-specific
+  grant's same-type sibling is denied). `isTypeLevel` switches over the full
+  closed `SourceKind` enum (3 type-level, 4 entity-level) with a panic-guard on
+  the baseline probe.
+- **This is the scale mechanism.** O(E) per principal, but the output is O(types)
+  baseline rows + O(exceptions) — never a row per entity. The reverse index
+  (RR-K72ML0) is still deferred; a single principal's O(E) is acceptable, but
+  whole-graph `map` (all principals) is O(P·E) and IS where the index becomes
+  load-bearing — see TKT-CAN9GM.
 
 ## Implementation notes — UC3 (`who-can`) SHIPPED (TKT-9089I6, PR #1141, merged 2026-07-16)
 
@@ -55,8 +83,9 @@ cache); bounded by `depthCap=5`, fine for single-entity `who-can`. A reverse
 principal→entity index is the optimization the `map` command will need
 (RR-K72ML0, deferred).
 
-**Still open (this feature):** `map` (UC1/UC2), `can`, full hop-chains, drift
-(UC8), assertions (UC4/UC5), reverse index, web view — see FEAT-RCQ6SJ.
+**Still open (this feature):** `can` + whole-graph `map` (TKT-CAN9GM), full
+hop-chains, drift (UC8), assertions (UC4/UC5), reverse index, web view — see
+FEAT-RCQ6SJ.
 
 ## Context
 

--- a/tickets/entities/tickets/TKT-CAN9GM.md
+++ b/tickets/entities/tickets/TKT-CAN9GM.md
@@ -1,0 +1,120 @@
+---
+id: TKT-CAN9GM
+type: ticket
+title: rela acl can <P> <verb> <E> + whole-graph map (no --principal) — spot-check & full inventory (UC6/UC7)
+kind: enhancement
+priority: medium
+effort: m
+status: backlog
+---
+
+# `rela acl can` + whole-graph `rela acl map`
+
+Third slice of **[[FEAT-RCQ6SJ]]** (ACL effective-access map), building on the
+shipped UC3 engine (`internal/aclmap`, [[TKT-9089I6]]) and the per-principal
+`map` (`MapPrincipal`, [[TKT-B1YE7]]). Delivers the two remaining v1 inventory
+surfaces from [[RES-8TX9KF]] Option A:
+
+- **`rela acl can <principal> <verb> <entity>`** — a scriptable yes/no
+  spot-check with a non-zero exit on deny. Nearly free: one `AccessRoutes`
+  call, no enumeration.
+- **`rela acl map` (no `--principal`)** — the *whole-graph* inventory: every
+  principal's effective access, aggregated by type with per-entity exceptions.
+  This is the slice that finally makes the **reverse principal→entity index**
+  ([[RR-K72ML0]], deferred through the last two slices) load-bearing, because it
+  is genuinely O(P·E).
+
+## Commands
+
+```
+rela acl can <principal> <verb> <entity>   [--format text|json]
+rela acl map [--verb read|create|update|delete] [--type <T>] [--format text|json]
+```
+
+`can` is a leaf spot-check (fixes principal AND entity AND verb → one boolean +
+deciding route(s)). Whole-graph `map` is `MapPrincipal` fanned across the
+enumerated principal universe — the same per-type-baseline / per-entity-exception
+shape, grouped per principal.
+
+## Why `can` is trivial and `map` is not
+
+**`can`** reuses `accessFor` verbatim: resolve the principal, call
+`AccessRoutes(verb, type, entityID)`, print allow + the route(s) or deny + "no
+grant", set exit code. Read fidelity carries over (gated on `PermitsRead`). No
+new engine machinery; it is the single-cell case of both existing commands.
+
+**Whole-graph `map`** is where cost bites. `who-can` fixed the entity (O(P));
+`map --principal` fixed the principal (O(E), member-of walk amortized per
+`Request`). Whole-graph fixes neither: O(P) principals × O(E) entities, each an
+`AccessRoutes` call. The per-type **baseline computed once per (principal, type)
+via the empty-entity probe** already collapses the common case to O(P·T); the
+O(P·E) term is only the *exception* scan — entities reachable via a
+role-relation or inheritance edge. So the reverse index is scoped as: **index
+role-relation + inheritance edge sources so the exception scan visits only
+entities that CAN carry an exception, not the whole entity space.**
+
+## Cost — the reverse-index question ([[RR-K72ML0]], now due)
+
+Confirm during planning:
+1. Baseline stays O(P·T) — the empty-entity probe is per (principal, type), not
+   per entity. Already true in `MapPrincipal`; whole-graph just loops it.
+2. The exception scan is bounded by the set of entities that are a role-relation
+   target or have an ancestor carrying a local grant — NOT every entity. Build a
+   reverse index (edge-target → nothing-to-scan-otherwise) so a graph with
+   thousands of baseline-only entities does O(edges), not O(P·E).
+3. If the index is more than a slice's worth of work, whole-graph `map` MAY ship
+   behind a documented "walks all entities" note and the index split to a
+   follow-up — decide in planning, do not silently ship the O(P·E) loop as if it
+   scaled.
+
+## Acceptance criteria
+
+### `can`
+- [ ] `rela acl can <P> <verb> <E>` prints allow + the deciding route(s), or
+  deny + "no grant", and sets a **non-zero exit code on deny** (scriptable).
+- [ ] Read decided by the runtime read path (reuse `AccessRoutes` /
+  `accessFor`); a missing entity errors distinctly (not a silent deny).
+- [ ] `--format json` emits the versioned schema (a single-principal,
+  single-entity `PrincipalAccess`-shaped object + a boolean).
+- [ ] `principal_property` resolution + data-entry-transport caveat carried over
+  in `--help`.
+
+### Whole-graph `map`
+- [ ] `rela acl map` (no `--principal`) lists every enumerated principal's
+  effective access, per-type baseline + per-entity exceptions, each grant with
+  all-routes provenance — same shape as `map --principal`, grouped by principal.
+- [ ] `--verb` / `--type` filters apply across all principals.
+- [ ] The `everyone` baseline is surfaced once (global), never repeated per
+  principal.
+- [ ] A **headline summary** (principal count, total grant-source count) reads
+  the whole-graph posture at a glance.
+- [ ] `--format json` reuses the versioned schema; deterministic ordering across
+  principals AND within each principal.
+
+### Correctness / cost
+- [ ] Read-vs-runtime conformance holds for BOTH surfaces (a test asserts `can`
+  ⟺ `PermitsRead`/`AuthorizeWrite`, and whole-graph `map` = the union of
+  per-principal `MapPrincipal` runs).
+- [ ] The exception scan visits only edge-reachable entities (a test with many
+  baseline-only entities asserts the scan does not touch them) — OR the
+  documented "walks all entities" fallback is in place with the index split to a
+  named follow-up ticket.
+- [ ] `just arch-lint`, `just plimsoll`, coverage floors.
+
+## Tests
+- [ ] `can` allow: a principal with a direct/group/edge grant → exit 0 + route.
+- [ ] `can` deny: a principal with only the `everyone` baseline for a
+  non-everyone verb → non-zero exit + "no grant".
+- [ ] `can` missing entity → distinct error, not a deny.
+- [ ] Whole-graph `map` = union of `map --principal` over the enumerated set
+  (conformance).
+- [ ] Whole-graph `map` with a baseline-only-heavy graph exercises the exception
+  scan bound (cost guard).
+- [ ] `--verb` / `--type` filters on whole-graph output.
+
+## Explicitly deferred (later slices)
+- Full hop-by-hop provenance chains (the `Source` restructure).
+- Drift detection (UC8) — reuses this JSON as the snapshot format.
+- Conformance assertions `rela acl verify` (UC4/UC5).
+- Graph-aware heuristics folded into `rela acl audit` (UC7 full).
+- Data-entry web view.

--- a/tickets/relations/TKT-CAN9GM--affects--authorization.md
+++ b/tickets/relations/TKT-CAN9GM--affects--authorization.md
@@ -1,0 +1,5 @@
+---
+from: TKT-CAN9GM
+relation: affects
+to: authorization
+---

--- a/tickets/relations/TKT-CAN9GM--implements--FEAT-RCQ6SJ.md
+++ b/tickets/relations/TKT-CAN9GM--implements--FEAT-RCQ6SJ.md
@@ -1,0 +1,5 @@
+---
+from: TKT-CAN9GM
+relation: implements
+to: FEAT-RCQ6SJ
+---


### PR DESCRIPTION
Tickets-only. Drafts **TKT-CAN9GM** (`rela acl can` + whole-graph `rela acl map`) as the third slice of FEAT-RCQ6SJ, and marks the shipped `map --principal` (TKT-B1YE7) / `who-can` (TKT-9089I6) slices in RES-8TX9KF + FEAT-RCQ6SJ.

- New ticket + `implements`/`affects` relations.
- Research gains a UC1/UC2 implementation-notes block (entity-independent baseline probe; baseline/exception split as a correctness surface).
- Feature use-case table shows per-ticket ✅ status.

Validated with CI's exact gate: `rela validate --check cardinality --check properties --check validations` — all pass.