### PR TITLE
feat(acl): rela acl can + whole-graph map (TKT-CAN9GM)

### DIFF
--- a/internal/acl/access.go
+++ b/internal/acl/access.go
@@ -209,6 +209,17 @@ func (r *Request) AccessRoutes(
 // The verb→predicate mapping is the same one the runtime uses
 // (roleGrantsRead / grantsVerb), so the routes it credits are the real
 // reasons access was granted.
+//
+// Create is intentionally computed with the concrete entityID, same as
+// every other write verb — NOT globals-only. This mirrors the production
+// create path: entitymanager.ApplyEntity authorizes create with
+// EntitySubject{ID: e.ID} (the new entity's id, which exists at authz
+// time), so authorizeEntityWrite takes its `s.ID != ""` branch and folds
+// in local-role-via-edge / via-ancestor routes. Collapsing create to
+// Globals here would report a false DENY for a principal the runtime WOULD
+// let create via an edge — the worst error class for an attestation tool.
+// The `s.ID == ""` globals-only branch exists for callers with no id yet;
+// this report always has one.
 func (r *Request) grantingAttributions(
 	ctx context.Context, verb Verb, entityType, entityID string,
 ) []RoleAttribution {

--- a/internal/aclmap/can.go
+++ b/internal/aclmap/can.go
@@ -1,0 +1,101 @@
+package aclmap
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/Sourcehaven-BV/rela/internal/acl"
+	"github.com/Sourcehaven-BV/rela/internal/store"
+)
+
+// CanResult is the answer to "can principal P perform verb on entity E".
+// It is the single-cell case of both [WhoCanResult] (fix the entity) and
+// [MapPrincipalResult] (fix the principal): one principal, one verb, one
+// entity. Allowed is the yes/no the caller turns into an exit code; Access
+// carries the deciding route(s) when Allowed, so a "yes" is explained the
+// same way who-can/map explain a grant.
+//
+// A grant via the built-in everyone role (which [WhoCan] reports globally,
+// not per principal) still makes Allowed true and is recorded as the
+// Everyone flag — a spot-check must answer "can this principal?" including
+// the case where the reason is "everyone can".
+type CanResult struct {
+	SchemaVersion int    `json:"schema_version"`
+	Principal     string `json:"principal"`
+	Raw           string `json:"raw,omitempty"`
+	Verb          string `json:"verb"`
+	Entity        string `json:"entity"`
+	EntityType    string `json:"entity_type"`
+	Allowed       bool   `json:"allowed"`
+	// Everyone is true when the grant is (at least partly) via the built-in
+	// everyone role. It can be true with no Routes: everyone grants access
+	// that AccessRoutes deliberately omits.
+	Everyone bool `json:"everyone"`
+	// Routes are the non-everyone route(s) that grant the verb, empty when
+	// the only grant is the everyone role (or when denied).
+	Routes []Route `json:"routes,omitempty"`
+}
+
+// Can reports whether principal rawPrincipal may perform verb on the
+// entity entityID, with the deciding route(s). It gates on entity
+// existence first (a missing entity errors with [ErrEntityNotFound]
+// rather than a misleading deny), resolves the entity's type from the
+// store, then asks the resolver for this one principal's routes — the
+// same read path who-can and map drive (AccessRoutes gates read on
+// PermitsRead), so a "no" is never a false negative.
+//
+// The everyone role is folded into the decision here (unlike WhoCan,
+// which reports it globally): a spot-check for one principal must say
+// "yes" when everyone can, even if that principal holds no personal
+// route.
+func (e *Engine) Can(ctx context.Context, rawPrincipal string, verb acl.Verb, entityID string) (*CanResult, error) {
+	if !verb.Valid() {
+		return nil, fmt.Errorf("aclmap: unknown verb %q", verb)
+	}
+
+	ent, err := e.src.GetEntity(ctx, entityID)
+	if err != nil {
+		if errors.Is(err, store.ErrNotFound) {
+			return nil, fmt.Errorf("%w: %s", ErrEntityNotFound, entityID)
+		}
+		return nil, fmt.Errorf("aclmap: load entity %q: %w", entityID, err)
+	}
+	entityType := ent.Type
+
+	result := &CanResult{
+		SchemaVersion: schemaVersion,
+		Verb:          string(verb),
+		Entity:        entityID,
+		EntityType:    entityType,
+	}
+
+	// The everyone role grants every principal; AccessRoutes omits it, so
+	// consult the policy directly. A wildcard ("*") everyone grant counts.
+	if eg := e.resolver.EveryoneGrants(verb, entityType); eg.Granted {
+		result.Everyone = true
+		result.Allowed = true
+	}
+
+	access, ok, err := e.accessFor(ctx, rawPrincipal, verb, entityType, entityID)
+	if err != nil {
+		return nil, err
+	}
+	if ok {
+		result.Allowed = true
+		result.Principal = access.Principal
+		result.Raw = access.Raw
+		result.Routes = access.Routes
+	}
+	if result.Principal == "" {
+		// Denied, or allowed only via everyone: accessFor returned no row, so
+		// record the resolved identity for the report from a bare resolve.
+		user, rawShown, rErr := e.resolveEffective(ctx, rawPrincipal)
+		if rErr != nil {
+			return nil, rErr
+		}
+		result.Principal = user
+		result.Raw = rawShown
+	}
+	return result, nil
+}

--- a/internal/aclmap/can_test.go
+++ b/internal/aclmap/can_test.go
@@ -1,0 +1,158 @@
+package aclmap_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/Sourcehaven-BV/rela/internal/acl"
+	"github.com/Sourcehaven-BV/rela/internal/aclmap"
+	"github.com/Sourcehaven-BV/rela/internal/principal"
+)
+
+// TestCan_AllowViaGlobal: a global editor is allowed and the deciding
+// route is reported.
+func TestCan_AllowViaGlobal(t *testing.T) {
+	t.Parallel()
+	w := groundingWorld(t)
+	// PERS-ALICE is a global editor: update on ticket.
+	res, err := w.eng.Can(context.Background(), "PERS-ALICE", acl.VerbUpdate, "TKT-1")
+	if err != nil {
+		t.Fatalf("Can: %v", err)
+	}
+	if !res.Allowed {
+		t.Fatalf("Alice (global editor) must be allowed to update TKT-1")
+	}
+	if len(res.Routes) == 0 {
+		t.Errorf("an allow must carry its deciding route(s); got none")
+	}
+	if res.Principal != "PERS-ALICE" {
+		t.Errorf("principal = %q, want PERS-ALICE", res.Principal)
+	}
+}
+
+// TestCan_AllowViaException: a grant conferred only by a graph edge (an
+// exception in map terms) is still an allow for the spot-check.
+func TestCan_AllowViaException(t *testing.T) {
+	t.Parallel()
+	w := groundingWorld(t)
+	// PERS-DAVE is editor-of FOLDER-Q3, which contains INC-042 — read via
+	// inheritance.
+	res, err := w.eng.Can(context.Background(), "PERS-DAVE", acl.VerbRead, "INC-042")
+	if err != nil {
+		t.Fatalf("Can: %v", err)
+	}
+	if !res.Allowed {
+		t.Fatalf("Dave must be allowed to read INC-042 via folder inheritance")
+	}
+	// And denied on a sibling incident he does not reach.
+	res999, err := w.eng.Can(context.Background(), "PERS-DAVE", acl.VerbRead, "INC-999")
+	if err != nil {
+		t.Fatalf("Can INC-999: %v", err)
+	}
+	if res999.Allowed {
+		t.Errorf("Dave must NOT reach INC-999 (not in his folder)")
+	}
+}
+
+// TestCan_DenyEveryoneOnly: a principal with only the everyone baseline is
+// denied a non-everyone verb, and the deny is distinguishable (Allowed
+// false, no routes).
+func TestCan_DenyEveryoneOnly(t *testing.T) {
+	t.Parallel()
+	w := groundingWorld(t)
+	// PERS-GHOST has no assignment/group/edge. everyone grants read:project
+	// only, so update on a ticket must be denied.
+	res, err := w.eng.Can(context.Background(), "PERS-GHOST", acl.VerbUpdate, "TKT-1")
+	if err != nil {
+		t.Fatalf("Can: %v", err)
+	}
+	if res.Allowed {
+		t.Errorf("PERS-GHOST must be denied update on TKT-1")
+	}
+	if len(res.Routes) != 0 {
+		t.Errorf("a deny carries no routes; got %+v", res.Routes)
+	}
+	if res.Principal != "PERS-GHOST" {
+		t.Errorf("a deny must still name the principal; got %q", res.Principal)
+	}
+}
+
+// TestCan_AllowViaEveryone: when everyone grants the verb, a principal with
+// no personal route is still allowed, flagged as an everyone grant.
+func TestCan_AllowViaEveryone(t *testing.T) {
+	t.Parallel()
+	w := groundingWorld(t)
+	// everyone can read:project; PERS-GHOST holds no personal grant.
+	res, err := w.eng.Can(context.Background(), "PERS-GHOST", acl.VerbRead, "PROJ")
+	if err != nil {
+		t.Fatalf("Can: %v", err)
+	}
+	if !res.Allowed {
+		t.Fatalf("everyone grants read:project — PERS-GHOST must be allowed")
+	}
+	if !res.Everyone {
+		t.Errorf("an everyone-only allow must set Everyone=true")
+	}
+	if len(res.Routes) != 0 {
+		t.Errorf("everyone grant carries no per-principal routes; got %+v", res.Routes)
+	}
+}
+
+// TestCan_MissingEntity errors distinctly rather than silently denying — a
+// typo'd entity ID must not read as "access denied".
+func TestCan_MissingEntity(t *testing.T) {
+	t.Parallel()
+	w := groundingWorld(t)
+	_, err := w.eng.Can(context.Background(), "PERS-ALICE", acl.VerbRead, "NO-SUCH")
+	if !errors.Is(err, aclmap.ErrEntityNotFound) {
+		t.Errorf("missing entity must error with ErrEntityNotFound; got %v", err)
+	}
+}
+
+// TestCan_UnknownVerbErrors: an invalid verb is a hard error, not a deny.
+func TestCan_UnknownVerbErrors(t *testing.T) {
+	t.Parallel()
+	w := groundingWorld(t)
+	_, err := w.eng.Can(context.Background(), "PERS-ALICE", acl.Verb("frobnicate"), "TKT-1")
+	if err == nil {
+		t.Errorf("unknown verb must error")
+	}
+}
+
+// TestCan_MatchesRuntime is the anti-false-negative guard for the
+// spot-check: Can's verdict must equal the runtime PermitsRead /
+// AuthorizeWrite decision for every (principal, verb, entity) probed.
+func TestCan_MatchesRuntime(t *testing.T) {
+	t.Parallel()
+	w := groundingWorld(t)
+	ctx := context.Background()
+
+	principalsUnderTest := []string{
+		"PERS-ALICE", "PERS-BOB", "PERS-CAROL", "PERS-DAVE", "PERS-EVE", "PERS-GHOST",
+	}
+	entities := []struct{ id, typ string }{
+		{"INC-042", "incident"}, {"INC-999", "incident"}, {"TKT-1", "ticket"}, {"PROJ", "project"},
+	}
+	verbs := []acl.Verb{acl.VerbRead, acl.VerbUpdate, acl.VerbDelete}
+
+	for _, prin := range principalsUnderTest {
+		req, err := w.decl.ForPrincipal(principal.Principal{User: prin, Tool: principal.ToolCLI})
+		if err != nil {
+			t.Fatalf("ForPrincipal %s: %v", prin, err)
+		}
+		for _, e := range entities {
+			for _, verb := range verbs {
+				res, cErr := w.eng.Can(ctx, prin, verb, e.id)
+				if cErr != nil {
+					t.Fatalf("Can(%s,%s,%s): %v", prin, verb, e.id, cErr)
+				}
+				runtime := runtimeVerdict(ctx, t, req, verb, e.typ, e.id)
+				if res.Allowed != runtime {
+					t.Errorf("disagreement: %s %s %s — can=%v runtime=%v",
+						prin, verb, e.id, res.Allowed, runtime)
+				}
+			}
+		}
+	}
+}

--- a/internal/aclmap/create_test.go
+++ b/internal/aclmap/create_test.go
@@ -1,0 +1,113 @@
+package aclmap_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Sourcehaven-BV/rela/internal/acl"
+	"github.com/Sourcehaven-BV/rela/internal/principal"
+)
+
+// createEdgePolicy: the `editor` role grants create on incident and is
+// conferred by the `editor-of` edge (a LOCAL, per-entity route).
+const createEdgePolicy = `
+membership_relation: member-of
+roles:
+  editor: { read: [incident], create: [incident], update: [incident], delete: [incident] }
+assignments:
+  PERS-GLOBAL: editor
+role_relations:
+  editor-of: { confers: editor }
+inherit_roles_through: [belongs-to]
+`
+
+// createWorld: PERS-GLOBAL is a global editor; PERS-EDGE is editor-of
+// FOLDER-A which contains INC-A via belongs-to.
+func createWorld(t *testing.T) *world {
+	t.Helper()
+	return buildWorld(t, createEdgePolicy,
+		[]ent{
+			{"PERS-GLOBAL", "person"}, {"PERS-EDGE", "person"},
+			{"FOLDER-A", "folder"}, {"INC-A", "incident"},
+		},
+		[]rel{
+			{"PERS-EDGE", "editor-of", "FOLDER-A"},
+			{"INC-A", "belongs-to", "FOLDER-A"},
+		},
+	)
+}
+
+// TestCreate_MatchesRuntime is the create-verb conformance guard. The
+// production create path authorizes with the new entity's concrete ID
+// (entitymanager.ApplyEntity: EntitySubject{ID: e.ID}), so the runtime
+// FOLDS local-role-via-edge routes into a create decision — create is NOT
+// globals-only in production. The report must therefore credit an
+// edge-conferred create exactly as the runtime does: reporting create as
+// globals-only would be a FALSE DENY for a principal the runtime lets
+// create via an edge. This test pins Can(create) == AuthorizeWrite(create)
+// for both a global and an edge-only editor so the report can never drift
+// from the runtime in either direction.
+func TestCreate_MatchesRuntime(t *testing.T) {
+	t.Parallel()
+	w := createWorld(t)
+	ctx := context.Background()
+
+	for _, prin := range []string{"PERS-GLOBAL", "PERS-EDGE"} {
+		req, rErr := w.decl.ForPrincipal(principal.Principal{User: prin, Tool: principal.ToolCLI})
+		if rErr != nil {
+			t.Fatalf("ForPrincipal %s: %v", prin, rErr)
+		}
+		res, cErr := w.eng.Can(ctx, prin, acl.VerbCreate, "INC-A")
+		if cErr != nil {
+			t.Fatalf("Can(%s create): %v", prin, cErr)
+		}
+		runtime := runtimeVerdict(ctx, t, req, acl.VerbCreate, "incident", "INC-A")
+		if res.Allowed != runtime {
+			t.Errorf("%s create INC-A: can=%v runtime=%v (report must match the "+
+				"runtime create decision, which folds edge routes)", prin, res.Allowed, runtime)
+		}
+	}
+}
+
+// TestCreate_EdgeConferredCreateReported: an edge-only editor CAN create
+// (the runtime folds the edge for create), and the map surfaces that create
+// route as a per-entity exception — the same route it surfaces for update.
+func TestCreate_EdgeConferredCreateReported(t *testing.T) {
+	t.Parallel()
+	w := createWorld(t)
+	ctx := context.Background()
+
+	edge, err := w.eng.Can(ctx, "PERS-EDGE", acl.VerbCreate, "INC-A")
+	if err != nil {
+		t.Fatalf("Can edge create: %v", err)
+	}
+	if !edge.Allowed {
+		t.Fatalf("PERS-EDGE holds editor via the edge; the runtime folds edge " +
+			"routes for create (concrete id), so create must be ALLOWED")
+	}
+	if len(edge.Routes) == 0 {
+		t.Errorf("an edge-conferred create allow must carry its edge route")
+	}
+
+	// In the per-principal map, create surfaces as an exception on INC-A,
+	// mirroring the update route on the same edge.
+	res := mapAll(t, w, "PERS-EDGE")
+	inc := typeOf(res, "incident")
+	if inc == nil {
+		t.Fatalf("PERS-EDGE should have incident access via the edge")
+	}
+	sawCreate := false
+	for _, ex := range inc.Exceptions {
+		if ex.Entity == "INC-A" && len(ex.Extra["create"]) > 0 {
+			sawCreate = true
+		}
+	}
+	if !sawCreate {
+		t.Errorf("edge-conferred create should surface as an INC-A exception; got %+v", inc.Exceptions)
+	}
+	// Create is edge-conferred here, not type-wide, so it must NOT be a
+	// type-level baseline (that would falsely imply create on every incident).
+	if len(inc.Baseline["create"]) != 0 {
+		t.Errorf("edge-conferred create must not appear as a type baseline; got %+v", inc.Baseline["create"])
+	}
+}

--- a/internal/aclmap/mapall.go
+++ b/internal/aclmap/mapall.go
@@ -1,0 +1,174 @@
+package aclmap
+
+import (
+	"context"
+	"sort"
+
+	"github.com/Sourcehaven-BV/rela/internal/acl"
+)
+
+// MapAllResult is the whole-graph inventory: every enumerated principal's
+// effective access, aggregated by type with per-entity exceptions — the
+// union of per-principal [MapPrincipalResult]s. It fixes neither the
+// principal nor the entity (the O(P·E) case), which is why it is a
+// separate slice from map --principal.
+//
+// EveryoneBaseline is reported ONCE here, not repeated inside every
+// principal: the built-in everyone role grants the same access to all
+// principals, so folding it into each principal's baseline would bloat
+// the report and obscure which principals hold a PERSONAL grant. Each
+// per-principal entry therefore reports only its non-everyone access;
+// EveryoneOnly on a principal is preserved so "cut off except for
+// everyone" is still visible.
+type MapAllResult struct {
+	SchemaVersion int      `json:"schema_version"`
+	Verbs         []string `json:"verbs"`
+	// EveryoneBaseline lists the types (and verbs) the everyone role grants
+	// every principal, reported once. Sorted by type.
+	EveryoneBaseline []EveryoneType `json:"everyone_baseline,omitempty"`
+	// Principals is every enumerated principal that holds ANY access (even
+	// everyone-only), sorted by principal ID.
+	Principals []MapPrincipalResult `json:"principals"`
+	// PrincipalCount and GrantSourceCount are the headline summary: how many
+	// principals were enumerated and how many distinct (principal, type,
+	// verb, route) grant-sources exist across the graph — the number an
+	// operator reads to gauge the whole-graph posture.
+	PrincipalCount   int `json:"principal_count"`
+	GrantSourceCount int `json:"grant_source_count"`
+}
+
+// EveryoneType is the everyone role's grant on one entity type: the verbs
+// it confers on every principal.
+type EveryoneType struct {
+	Type  string   `json:"type"`
+	Verbs []string `json:"verbs"`
+}
+
+// MapAll computes the whole-graph effective-access inventory: it
+// enumerates the principal universe and runs [Engine.MapPrincipal] for
+// each, then lifts the everyone baseline out to a single top-level entry.
+//
+// This is the O(P·E) slice. The per-type baseline inside MapPrincipal is
+// O(types) via the empty-entity probe, so the dominant cost is the
+// exception scan (entities carrying a local/inherited edge). See the
+// package cost note; a reverse index bounding the exception scan to
+// edge-reachable entities is the optimization this slice's ticket scopes.
+func (e *Engine) MapAll(
+	ctx context.Context, verbFilter acl.Verb, typeFilter string, entityTypes []string,
+) (*MapAllResult, error) {
+	verbs, err := resolveVerbs(verbFilter)
+	if err != nil {
+		return nil, err
+	}
+
+	candidates, err := e.enumeratePrincipals(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	// Merge by EFFECTIVE principal — a single human can surface as several
+	// candidate keys (raw UPN + resolved entity). Running MapPrincipal on
+	// each and keying the result by its resolved Principal collapses them;
+	// the per-principal map is deterministic, so the first non-empty result
+	// per effective ID is authoritative (a later duplicate key resolves to
+	// the same identity and computes the same access).
+	byPrincipal := map[string]*MapPrincipalResult{}
+	for _, raw := range candidates {
+		res, err := e.MapPrincipal(ctx, raw, verbFilter, typeFilter, entityTypes)
+		if err != nil {
+			return nil, err
+		}
+		if _, seen := byPrincipal[res.Principal]; !seen {
+			byPrincipal[res.Principal] = res
+		}
+	}
+
+	result := &MapAllResult{
+		SchemaVersion:    schemaVersion,
+		Verbs:            verbStrings(verbs),
+		EveryoneBaseline: e.everyoneBaseline(verbs, mapTypes(typeFilter, entityTypes)),
+	}
+
+	ids := make([]string, 0, len(byPrincipal))
+	for id := range byPrincipal {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+	for _, id := range ids {
+		pr := byPrincipal[id]
+		stripEveryoneBaseline(pr)
+		result.Principals = append(result.Principals, *pr)
+		result.GrantSourceCount += grantSources(pr)
+	}
+	result.PrincipalCount = len(result.Principals)
+	return result, nil
+}
+
+// everyoneBaseline lists the everyone role's type-wide grants, once, for
+// the top-level report. It consults the policy directly (EveryoneGrants),
+// independent of any principal, so it is exact even for a type with zero
+// entities.
+func (e *Engine) everyoneBaseline(verbs []acl.Verb, types []string) []EveryoneType {
+	var out []EveryoneType
+	for _, typ := range types {
+		var granted []string
+		for _, verb := range verbs {
+			if e.resolver.EveryoneGrants(verb, typ).Granted {
+				granted = append(granted, string(verb))
+			}
+		}
+		if len(granted) > 0 {
+			sort.Strings(granted)
+			out = append(out, EveryoneType{Type: typ, Verbs: granted})
+		}
+	}
+	return out
+}
+
+// stripEveryoneBaseline removes the everyone-role routes from a
+// per-principal result's type baselines, since MapAll reports the everyone
+// baseline once at the top level. A verb whose baseline becomes empty is
+// dropped; a type left with no baseline and no exceptions is dropped.
+// EveryoneOnly is left untouched — it still signals "no personal grant".
+func stripEveryoneBaseline(pr *MapPrincipalResult) {
+	kept := pr.Types[:0]
+	for _, ta := range pr.Types {
+		for verb, routes := range ta.Baseline {
+			filtered := routes[:0]
+			for _, r := range routes {
+				if r.Role == acl.EveryoneRole && r.Kind == acl.SourceGlobal.String() {
+					continue
+				}
+				filtered = append(filtered, r)
+			}
+			if len(filtered) == 0 {
+				delete(ta.Baseline, verb)
+			} else {
+				ta.Baseline[verb] = filtered
+			}
+		}
+		if len(ta.Baseline) > 0 || len(ta.Exceptions) > 0 {
+			kept = append(kept, ta)
+		}
+	}
+	pr.Types = kept
+}
+
+// grantSources counts the distinct grant-sources in a per-principal
+// result — every route across every type baseline and every entity
+// exception. It is the per-principal contribution to the whole-graph
+// GrantSourceCount headline.
+func grantSources(pr *MapPrincipalResult) int {
+	n := 0
+	for _, ta := range pr.Types {
+		for _, routes := range ta.Baseline {
+			n += len(routes)
+		}
+		for _, ex := range ta.Exceptions {
+			for _, routes := range ex.Extra {
+				n += len(routes)
+			}
+		}
+	}
+	return n
+}

--- a/internal/aclmap/mapall.go
+++ b/internal/aclmap/mapall.go
@@ -68,15 +68,23 @@ func (e *Engine) MapAll(
 
 	// Merge by EFFECTIVE principal — a single human can surface as several
 	// candidate keys (raw UPN + resolved entity). Running MapPrincipal on
-	// each and keying the result by its resolved Principal collapses them;
-	// the per-principal map is deterministic, so the first non-empty result
-	// per effective ID is authoritative (a later duplicate key resolves to
-	// the same identity and computes the same access).
+	// each and keying the result by its resolved Principal collapses them.
+	//
+	// First-key-wins is safe because access depends only on the effective
+	// User: the CLI never sets verified role claims and RawUser is
+	// audit-only, so every candidate key resolving to one effective
+	// principal computes IDENTICAL access. (This deliberately differs from
+	// who-can, which UNIONS routes across duplicate keys via mergeRoutes;
+	// here there is nothing to union.) A blank key yields an empty-Principal
+	// result — skip it so a malformed key adds no phantom row.
 	byPrincipal := map[string]*MapPrincipalResult{}
 	for _, raw := range candidates {
 		res, err := e.MapPrincipal(ctx, raw, verbFilter, typeFilter, entityTypes)
 		if err != nil {
 			return nil, err
+		}
+		if res.Principal == "" {
+			continue
 		}
 		if _, seen := byPrincipal[res.Principal]; !seen {
 			byPrincipal[res.Principal] = res

--- a/internal/aclmap/mapall_test.go
+++ b/internal/aclmap/mapall_test.go
@@ -226,6 +226,41 @@ func TestMapAll_VerbAndTypeFilters(t *testing.T) {
 	}
 }
 
+// TestMapAll_BlankKeyDoesNotAbort: a malformed (blank) assignment key must
+// not abort the whole-graph inventory — the rest of the principals must
+// still be reported. A hard failure on one bad key is worse than a partial
+// attestation for a compliance tool.
+func TestMapAll_BlankKeyDoesNotAbort(t *testing.T) {
+	t.Parallel()
+	// A policy with a blank assignment key alongside a real one.
+	const policy = `
+membership_relation: member-of
+roles:
+  editor: { read: [incident], update: [incident] }
+assignments:
+  PERS-REAL: editor
+  "       ": editor
+role_relations: {}
+`
+	w := buildWorld(t, policy,
+		[]ent{{"PERS-REAL", "person"}, {"INC-1", "incident"}},
+		nil,
+	)
+	res, err := w.eng.MapAll(context.Background(), "", "", []string{"person", "incident"})
+	if err != nil {
+		t.Fatalf("a blank assignment key must not abort MapAll: %v", err)
+	}
+	// PERS-REAL still reported; the blank key contributes no phantom row.
+	if principalOf(res, "PERS-REAL") == nil {
+		t.Errorf("PERS-REAL must survive a blank sibling key; got principals %+v", res.Principals)
+	}
+	for _, p := range res.Principals {
+		if p.Principal == "" {
+			t.Errorf("a blank key must not add an empty-principal row")
+		}
+	}
+}
+
 // TestMapAll_UnknownVerbErrors: an invalid verb filter errors.
 func TestMapAll_UnknownVerbErrors(t *testing.T) {
 	t.Parallel()

--- a/internal/aclmap/mapall_test.go
+++ b/internal/aclmap/mapall_test.go
@@ -1,0 +1,237 @@
+package aclmap_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Sourcehaven-BV/rela/internal/acl"
+	"github.com/Sourcehaven-BV/rela/internal/aclmap"
+)
+
+// mapAllGraph runs MapAll over all verbs and all grounding types.
+func mapAllGraph(t *testing.T, w *world) *aclmap.MapAllResult {
+	t.Helper()
+	res, err := w.eng.MapAll(context.Background(), "", "", groundingTypes)
+	if err != nil {
+		t.Fatalf("MapAll: %v", err)
+	}
+	return res
+}
+
+// principalOf returns the per-principal result for id in a MapAllResult, or nil.
+func principalOf(res *aclmap.MapAllResult, id string) *aclmap.MapPrincipalResult {
+	for i := range res.Principals {
+		if res.Principals[i].Principal == id {
+			return &res.Principals[i]
+		}
+	}
+	return nil
+}
+
+// TestMapAll_EnumeratesEveryPrincipal: the whole-graph inventory covers
+// every enumerated principal (assignment keys ∪ membership/role-relation
+// edge sources), each appearing once, sorted.
+func TestMapAll_EnumeratesEveryPrincipal(t *testing.T) {
+	t.Parallel()
+	res := mapAllGraph(t, groundingWorld(t))
+
+	want := []string{
+		"PERS-ALICE", "PERS-BOB", "PERS-CAROL", "PERS-DAVE", "PERS-EVE",
+		"ROLE-IR", "ROLE-SECURITY",
+	}
+	var got []string
+	for _, p := range res.Principals {
+		got = append(got, p.Principal)
+	}
+	if !equal(got, want) {
+		t.Errorf("principals:\n got: %v\nwant: %v", got, want)
+	}
+	if res.PrincipalCount != len(want) {
+		t.Errorf("PrincipalCount = %d, want %d", res.PrincipalCount, len(want))
+	}
+	// Sorted, no duplicates.
+	for i := 1; i < len(got); i++ {
+		if got[i] <= got[i-1] {
+			t.Errorf("principals not strictly sorted at %d: %v", i, got)
+		}
+	}
+}
+
+// TestMapAll_EveryoneBaselineLiftedOnce: the everyone grant is reported
+// once at the top level, not repeated inside each principal's baseline.
+func TestMapAll_EveryoneBaselineLiftedOnce(t *testing.T) {
+	t.Parallel()
+	res := mapAllGraph(t, groundingWorld(t))
+
+	// everyone grants read:project — expect exactly one EveryoneBaseline entry.
+	var projFound bool
+	for _, et := range res.EveryoneBaseline {
+		if et.Type == "project" && contains(et.Verbs, "read") {
+			projFound = true
+		}
+	}
+	if !projFound {
+		t.Errorf("everyone read:project must appear in EveryoneBaseline; got %+v", res.EveryoneBaseline)
+	}
+
+	// No per-principal type baseline may carry the everyone role — it was
+	// stripped.
+	for _, p := range res.Principals {
+		for _, ta := range p.Types {
+			for verb, routes := range ta.Baseline {
+				for _, r := range routes {
+					if r.Role == acl.EveryoneRole {
+						t.Errorf("%s: everyone route leaked into per-principal baseline %s/%s",
+							p.Principal, ta.Type, verb)
+					}
+				}
+			}
+		}
+	}
+}
+
+// TestMapAll_EqualsUnionOfPerPrincipal is the keystone conformance test:
+// the whole-graph map must equal the union of per-principal MapPrincipal
+// runs. For every enumerated principal, its access in MapAll (after the
+// everyone baseline is stripped and re-added) must reproduce the verdict
+// MapPrincipal gives standalone.
+func TestMapAll_EqualsUnionOfPerPrincipal(t *testing.T) {
+	t.Parallel()
+	w := groundingWorld(t)
+	ctx := context.Background()
+	all := mapAllGraph(t, w)
+
+	entities := []struct{ id, typ string }{
+		{"INC-042", "incident"}, {"INC-999", "incident"}, {"TKT-1", "ticket"}, {"PROJ", "project"},
+	}
+	verbs := []string{"read", "update", "delete"}
+
+	for _, p := range all.Principals {
+		solo, err := w.eng.MapPrincipal(ctx, p.Principal, "", "", groundingTypes)
+		if err != nil {
+			t.Fatalf("MapPrincipal(%s): %v", p.Principal, err)
+		}
+		allEntry := principalOf(all, p.Principal)
+		for _, e := range entities {
+			for _, verb := range verbs {
+				// The whole-graph entry strips the everyone baseline, so add it
+				// back via the top-level EveryoneBaseline to compare like-for-like.
+				allGrants := mapVerdict(allEntry, e.typ, e.id, verb) ||
+					everyoneGrantsInAll(all, e.typ, verb)
+				soloGrants := mapVerdict(solo, e.typ, e.id, verb)
+				if allGrants != soloGrants {
+					t.Errorf("%s %s %s: whole-graph=%v per-principal=%v",
+						p.Principal, verb, e.id, allGrants, soloGrants)
+				}
+			}
+		}
+	}
+}
+
+// everyoneGrantsInAll reports whether the top-level everyone baseline
+// grants verb on type typ.
+func everyoneGrantsInAll(res *aclmap.MapAllResult, typ, verb string) bool {
+	for _, et := range res.EveryoneBaseline {
+		if et.Type == typ && contains(et.Verbs, verb) {
+			return true
+		}
+	}
+	return false
+}
+
+// TestMapAll_EveryoneOnlyPrincipalPreserved: a principal whose only access
+// is the everyone baseline is kept in the inventory with EveryoneOnly set,
+// not dropped — an offboarding review must see "cut off except everyone",
+// not a missing row.
+func TestMapAll_EveryoneOnlyPrincipalPreserved(t *testing.T) {
+	t.Parallel()
+	// ROLE-SECURITY is an assignment key (security role), so it holds
+	// personal grants — not everyone-only. To get an everyone-only enumerated
+	// principal we add a member with no other grant.
+	w := buildWorld(t, groundingPolicy,
+		[]ent{
+			{"PERS-ALICE", "person"}, {"ROLE-SECURITY", "team"},
+			{"PERS-LONE", "person"}, {"ROLE-EMPTY", "team"},
+			{"TKT-1", "ticket"}, {"PROJ", "project"},
+		},
+		[]rel{
+			// PERS-LONE is a member of ROLE-EMPTY, which has NO assignment — so
+			// LONE is enumerated (a membership source) but holds only everyone.
+			{"PERS-LONE", "member-of", "ROLE-EMPTY"},
+		},
+	)
+	res := mapAllGraph(t, w)
+	lone := principalOf(res, "PERS-LONE")
+	if lone == nil {
+		t.Fatalf("PERS-LONE (enumerated via membership) must appear in the inventory")
+	}
+	if !lone.EveryoneOnly {
+		t.Errorf("PERS-LONE has no personal grant; EveryoneOnly must be true")
+	}
+}
+
+// TestMapAll_GrantSourceCount counts non-everyone grant-sources across all
+// principals; it must be > 0 in the grounding world and exclude the lifted
+// everyone baseline.
+func TestMapAll_GrantSourceCount(t *testing.T) {
+	t.Parallel()
+	res := mapAllGraph(t, groundingWorld(t))
+	if res.GrantSourceCount == 0 {
+		t.Errorf("grounding world has personal grants; GrantSourceCount must be > 0")
+	}
+	// Independently recount from the (everyone-stripped) principal results.
+	recount := 0
+	for _, p := range res.Principals {
+		for _, ta := range p.Types {
+			for _, routes := range ta.Baseline {
+				recount += len(routes)
+			}
+			for _, ex := range ta.Exceptions {
+				for _, routes := range ex.Extra {
+					recount += len(routes)
+				}
+			}
+		}
+	}
+	if recount != res.GrantSourceCount {
+		t.Errorf("GrantSourceCount = %d, recount = %d", res.GrantSourceCount, recount)
+	}
+}
+
+// TestMapAll_VerbAndTypeFilters: filters narrow the whole-graph output the
+// same way they narrow the per-principal view.
+func TestMapAll_VerbAndTypeFilters(t *testing.T) {
+	t.Parallel()
+	w := groundingWorld(t)
+	ctx := context.Background()
+
+	res, err := w.eng.MapAll(ctx, acl.VerbRead, "incident", groundingTypes)
+	if err != nil {
+		t.Fatalf("MapAll filtered: %v", err)
+	}
+	if len(res.Verbs) != 1 || res.Verbs[0] != "read" {
+		t.Errorf("--verb read should yield verbs [read]; got %v", res.Verbs)
+	}
+	for _, p := range res.Principals {
+		for _, ta := range p.Types {
+			if ta.Type != "incident" {
+				t.Errorf("--type incident leaked type %q for %s", ta.Type, p.Principal)
+			}
+			for verb := range ta.Baseline {
+				if verb != "read" {
+					t.Errorf("--verb read leaked verb %q for %s", verb, p.Principal)
+				}
+			}
+		}
+	}
+}
+
+// TestMapAll_UnknownVerbErrors: an invalid verb filter errors.
+func TestMapAll_UnknownVerbErrors(t *testing.T) {
+	t.Parallel()
+	w := groundingWorld(t)
+	_, err := w.eng.MapAll(context.Background(), acl.Verb("nope"), "", groundingTypes)
+	if err == nil {
+		t.Errorf("unknown verb must error")
+	}
+}

--- a/internal/aclmap/mapprincipal.go
+++ b/internal/aclmap/mapprincipal.go
@@ -133,6 +133,19 @@ func (e *Engine) MapPrincipal(
 	if err != nil {
 		return nil, err
 	}
+	if user == "" {
+		// A blank/whitespace candidate key can't be a principal (ForPrincipal
+		// would reject it as unstamped). Return an empty result rather than
+		// erroring, matching who-can's accessFor skip: in the whole-graph map
+		// (MapAll), one malformed assignment key or empty relation From must
+		// NOT abort the entire inventory — an attestation that fails hard on a
+		// single bad key is worse than one that reports the rest.
+		return &MapPrincipalResult{
+			SchemaVersion: schemaVersion,
+			Verbs:         verbStrings(verbs),
+			EveryoneOnly:  true,
+		}, nil
+	}
 	req, err := e.resolver.ForPrincipal(
 		principal.Principal{User: user, Tool: principal.ToolCLI, RawUser: rawShown})
 	if err != nil {

--- a/internal/cli/acl.go
+++ b/internal/cli/acl.go
@@ -18,7 +18,8 @@ import (
 type ACLCmd struct {
 	Audit  ACLAuditCmd  `cmd:"" help:"Audit the ACL policy (acl.yaml) for misconfigurations."`
 	WhoCan ACLWhoCanCmd `cmd:"" name:"who-can" help:"List every principal who can perform a verb on an entity, with the route each grant took."`
-	Map    ACLMapCmd    `cmd:"" help:"Map one principal's effective access across the graph, by type with per-entity exceptions."`
+	Can    ACLCanCmd    `cmd:"" help:"Spot-check whether one principal can perform a verb on an entity; exits non-zero on deny."`
+	Map    ACLMapCmd    `cmd:"" help:"Map effective access across the graph — one principal (--principal) or every principal — by type with per-entity exceptions."`
 }
 
 // ACLAuditCmd runs the on-demand authorization-misconfiguration linter over the

--- a/internal/cli/acl_can.go
+++ b/internal/cli/acl_can.go
@@ -1,0 +1,97 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	stderrors "errors"
+	"fmt"
+
+	"github.com/Sourcehaven-BV/rela/internal/acl"
+	"github.com/Sourcehaven-BV/rela/internal/aclmap"
+	"github.com/Sourcehaven-BV/rela/internal/errors"
+	"github.com/Sourcehaven-BV/rela/internal/output"
+)
+
+// ACLCanCmd implements `rela acl can <principal> <verb> <entity>`. It is
+// the scriptable spot-check of the effective-access map: a yes/no answer
+// for one principal, one verb, one entity, with the deciding route(s) on a
+// "yes". It exits non-zero on deny so a CI gate or shell guard can branch
+// on it (`rela acl can bob update INC-042 && deploy`).
+//
+// Read is decided by the same read path the server enforces (shared with
+// who-can / map), so a "no" is never a false negative. A grant via the
+// built-in everyone role counts as a "yes" — the spot-check answers "can
+// this principal?", including when the reason is "everyone can".
+//
+// Scope caveat: when the policy sets `principal_property`, that raw→entity
+// resolution is wired only into the data-entry (HTTP) transport. This
+// command resolves the same way for reporting, but the answer reflects
+// data-entry-transport access — CLI/MCP/scheduler writes authorize against
+// the raw principal. See internal/acl/declarative.go.
+type ACLCanCmd struct {
+	Principal string `arg:"" help:"Principal to check (a user entity ID, or the raw identifier — email/UPN — when principal_property is set)."`
+	Verb      string `arg:"" help:"Access verb to check: read|create|update|delete." enum:"read,create,update,delete"`
+	Entity    string `arg:"" help:"Entity ID to check access against (e.g. INC-042)."`
+}
+
+// Run executes `rela acl can`.
+func (c *ACLCanCmd) Run(ctx context.Context, svc *readServices) error {
+	engine, err := buildACLEngine(svc)
+	if err != nil {
+		if stderrors.Is(err, errNoACLPolicy) {
+			// No policy → every principal has full access → allow, exit 0.
+			out.WriteSuccess("No acl.yaml found; every principal has full access (no policy).")
+			return nil
+		}
+		return err
+	}
+
+	result, err := engine.Can(ctx, c.Principal, acl.Verb(c.Verb), c.Entity)
+	if err != nil {
+		if stderrors.Is(err, aclmap.ErrEntityNotFound) {
+			return fmt.Errorf("entity %q not found", c.Entity)
+		}
+		return err
+	}
+
+	if out.Format == output.FormatJSON {
+		enc := json.NewEncoder(out.Out)
+		enc.SetIndent("", "  ")
+		if encErr := enc.Encode(result); encErr != nil {
+			return encErr
+		}
+	} else {
+		writeCanText(result)
+	}
+
+	// Non-zero exit on deny so the command is scriptable. The JSON/text
+	// output is already written, so the exit code carries no message.
+	if !result.Allowed {
+		return errors.NewExitError(1)
+	}
+	return nil
+}
+
+// writeCanText renders a CanResult as a single allow/deny line plus the
+// deciding route(s). A deny names the principal/verb/entity so the "no" is
+// self-explanatory; an allow lists every route (and notes an everyone
+// grant) so the "yes" is auditable.
+func writeCanText(r *aclmap.CanResult) {
+	who := r.Principal
+	if r.Raw != "" {
+		who = fmt.Sprintf("%s (%s)", r.Principal, r.Raw)
+	}
+
+	if !r.Allowed {
+		out.WriteMessage("DENY: %s cannot %s %s (%s) — no grant.", who, r.Verb, r.Entity, r.EntityType)
+		return
+	}
+
+	out.WriteMessage("ALLOW: %s can %s %s (%s).", who, r.Verb, r.Entity, r.EntityType)
+	if r.Everyone {
+		out.WriteMessage("      via the built-in everyone role — all principals.")
+	}
+	for _, rt := range r.Routes {
+		out.WriteMessage("      via %s", formatRoute(rt))
+	}
+}

--- a/internal/cli/acl_can.go
+++ b/internal/cli/acl_can.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Sourcehaven-BV/rela/internal/aclmap"
 	"github.com/Sourcehaven-BV/rela/internal/errors"
 	"github.com/Sourcehaven-BV/rela/internal/output"
+	"github.com/Sourcehaven-BV/rela/internal/store"
 )
 
 // ACLCanCmd implements `rela acl can <principal> <verb> <entity>`. It is
@@ -21,7 +22,13 @@ import (
 // Read is decided by the same read path the server enforces (shared with
 // who-can / map), so a "no" is never a false negative. A grant via the
 // built-in everyone role counts as a "yes" — the spot-check answers "can
-// this principal?", including when the reason is "everyone can".
+// this principal?", including when the reason is "everyone can". Create is
+// decided with the entity's id, matching the production create path (which
+// folds local-edge routes), so an edge-conferred create reads as ALLOW.
+//
+// Exit codes: 0 = allow, 1 = deny OR an engine/store error (fail-closed).
+// A missing entity is a distinct error ("entity not found"), never a plain
+// deny, so a typo is never a green attestation.
 //
 // Scope caveat: when the policy sets `principal_property`, that raw→entity
 // resolution is wired only into the data-entry (HTTP) transport. This
@@ -39,9 +46,7 @@ func (c *ACLCanCmd) Run(ctx context.Context, svc *readServices) error {
 	engine, err := buildACLEngine(svc)
 	if err != nil {
 		if stderrors.Is(err, errNoACLPolicy) {
-			// No policy → every principal has full access → allow, exit 0.
-			out.WriteSuccess("No acl.yaml found; every principal has full access (no policy).")
-			return nil
+			return c.runNoPolicy(ctx, svc)
 		}
 		return err
 	}
@@ -69,6 +74,22 @@ func (c *ACLCanCmd) Run(ctx context.Context, svc *readServices) error {
 	if !result.Allowed {
 		return errors.NewExitError(1)
 	}
+	return nil
+}
+
+// runNoPolicy handles `acl can` when the project has no acl.yaml: every
+// principal has full access, so the answer is ALLOW — but the entity
+// existence gate still applies, so a typo'd id errors rather than attesting
+// a green exit on nothing (the same gate engine.Can enforces under a
+// policy).
+func (c *ACLCanCmd) runNoPolicy(ctx context.Context, svc *readServices) error {
+	if _, err := svc.Store.GetEntity(ctx, c.Entity); err != nil {
+		if stderrors.Is(err, store.ErrNotFound) {
+			return fmt.Errorf("entity %q not found", c.Entity)
+		}
+		return err
+	}
+	out.WriteSuccess("No acl.yaml found; every principal has full access (no policy).")
 	return nil
 }
 

--- a/internal/cli/acl_can_test.go
+++ b/internal/cli/acl_can_test.go
@@ -1,0 +1,96 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	stderrors "errors"
+	"strings"
+	"testing"
+
+	relaerrors "github.com/Sourcehaven-BV/rela/internal/errors"
+	"github.com/Sourcehaven-BV/rela/internal/output"
+)
+
+func TestACLCan_AllowExitsZero(t *testing.T) {
+	svc := aclTestServices(t, whoCanMeta(), whoCanPolicy)
+	seedWhoCanGraph(t, svc)
+	buf := withOutput(t, output.FormatTable)
+
+	// PERS-ALICE is global security: can read incident.
+	cmd := &ACLCanCmd{Principal: "PERS-ALICE", Verb: "read", Entity: "INC-042"}
+	if err := cmd.Run(context.Background(), svc); err != nil {
+		t.Fatalf("allow must exit 0, got %v", err)
+	}
+	if got := buf.String(); !strings.Contains(got, "ALLOW") {
+		t.Errorf("expected ALLOW line, got: %s", got)
+	}
+}
+
+func TestACLCan_DenyExitsNonZero(t *testing.T) {
+	svc := aclTestServices(t, whoCanMeta(), whoCanPolicy)
+	seedWhoCanGraph(t, svc)
+	buf := withOutput(t, output.FormatTable)
+
+	// PERS-GHOST has no personal grant; deny → non-zero exit.
+	cmd := &ACLCanCmd{Principal: "PERS-GHOST", Verb: "delete", Entity: "INC-042"}
+	err := cmd.Run(context.Background(), svc)
+	var exitErr *relaerrors.ExitError
+	if !stderrors.As(err, &exitErr) {
+		t.Fatalf("deny must return an ExitError, got %v", err)
+	}
+	if exitErr.Code == 0 {
+		t.Errorf("deny exit code must be non-zero")
+	}
+	if got := buf.String(); !strings.Contains(got, "DENY") {
+		t.Errorf("expected DENY line, got: %s", got)
+	}
+}
+
+func TestACLCan_MissingEntityErrors(t *testing.T) {
+	svc := aclTestServices(t, whoCanMeta(), whoCanPolicy)
+	seedWhoCanGraph(t, svc)
+	withOutput(t, output.FormatTable)
+
+	cmd := &ACLCanCmd{Principal: "PERS-ALICE", Verb: "read", Entity: "NO-SUCH"}
+	err := cmd.Run(context.Background(), svc)
+	if err == nil || !strings.Contains(err.Error(), "not found") {
+		t.Errorf("missing entity must error with 'not found', got %v", err)
+	}
+	// It must NOT be a plain deny ExitError.
+	var exitErr *relaerrors.ExitError
+	if stderrors.As(err, &exitErr) {
+		t.Errorf("missing entity must not surface as a deny exit code")
+	}
+}
+
+func TestACLCan_JSON(t *testing.T) {
+	svc := aclTestServices(t, whoCanMeta(), whoCanPolicy)
+	seedWhoCanGraph(t, svc)
+	buf := withOutput(t, output.FormatJSON)
+
+	cmd := &ACLCanCmd{Principal: "PERS-ALICE", Verb: "read", Entity: "INC-042"}
+	if err := cmd.Run(context.Background(), svc); err != nil {
+		t.Fatalf("can json: %v", err)
+	}
+	var result struct {
+		SchemaVersion int    `json:"schema_version"`
+		Principal     string `json:"principal"`
+		Allowed       bool   `json:"allowed"`
+	}
+	if err := json.Unmarshal(buf.Bytes(), &result); err != nil {
+		t.Fatalf("unmarshal: %v\nraw: %s", err, buf.String())
+	}
+	if result.SchemaVersion != 1 || !result.Allowed || result.Principal != "PERS-ALICE" {
+		t.Errorf("unexpected result: %+v", result)
+	}
+}
+
+func TestACLCan_NoPolicyAllows(t *testing.T) {
+	svc := aclTestServices(t, whoCanMeta(), "") // no acl.yaml
+	withOutput(t, output.FormatTable)
+
+	cmd := &ACLCanCmd{Principal: "PERS-ALICE", Verb: "read", Entity: "INC-042"}
+	if err := cmd.Run(context.Background(), svc); err != nil {
+		t.Errorf("no policy must allow (exit 0), got %v", err)
+	}
+}

--- a/internal/cli/acl_can_test.go
+++ b/internal/cli/acl_can_test.go
@@ -87,10 +87,30 @@ func TestACLCan_JSON(t *testing.T) {
 
 func TestACLCan_NoPolicyAllows(t *testing.T) {
 	svc := aclTestServices(t, whoCanMeta(), "") // no acl.yaml
+	seedWhoCanGraph(t, svc)                     // INC-042 must exist for the allow
 	withOutput(t, output.FormatTable)
 
 	cmd := &ACLCanCmd{Principal: "PERS-ALICE", Verb: "read", Entity: "INC-042"}
 	if err := cmd.Run(context.Background(), svc); err != nil {
 		t.Errorf("no policy must allow (exit 0), got %v", err)
+	}
+}
+
+// TestACLCan_NoPolicyMissingEntityErrors: even with no acl.yaml, a typo'd
+// entity must error, not attest a green ALLOW on nothing (the existence
+// gate applies with or without a policy).
+func TestACLCan_NoPolicyMissingEntityErrors(t *testing.T) {
+	svc := aclTestServices(t, whoCanMeta(), "") // no acl.yaml
+	seedWhoCanGraph(t, svc)
+	withOutput(t, output.FormatTable)
+
+	cmd := &ACLCanCmd{Principal: "PERS-ALICE", Verb: "read", Entity: "NO-SUCH"}
+	err := cmd.Run(context.Background(), svc)
+	if err == nil || !strings.Contains(err.Error(), "not found") {
+		t.Errorf("no-policy missing entity must error with 'not found', got %v", err)
+	}
+	var exitErr *relaerrors.ExitError
+	if stderrors.As(err, &exitErr) {
+		t.Errorf("missing entity must not surface as a deny exit code")
 	}
 }

--- a/internal/cli/acl_map.go
+++ b/internal/cli/acl_map.go
@@ -13,13 +13,17 @@ import (
 	"github.com/Sourcehaven-BV/rela/internal/output"
 )
 
-// ACLMapCmd implements `rela acl map --principal <P>`. It reports one
-// principal's effective access across the graph, aggregated by entity
-// type with per-entity exceptions — the inverse of who-can (which fixes
-// the entity and varies the principal). It answers the onboarding
-// question ("did the grant I just made confer exactly what I intended?",
-// UC1) and the offboarding question ("what can this account still
-// reach?", UC2).
+// ACLMapCmd implements `rela acl map`. With `--principal`, it reports one
+// principal's effective access across the graph, aggregated by entity type
+// with per-entity exceptions — the inverse of who-can (which fixes the
+// entity and varies the principal). It answers the onboarding question
+// ("did the grant I just made confer exactly what I intended?", UC1) and
+// the offboarding question ("what can this account still reach?", UC2).
+//
+// Without `--principal`, it reports the WHOLE-GRAPH inventory: every
+// enumerated principal's effective access, with the built-in everyone
+// baseline lifted out and reported once. This is the O(P·E) case — see the
+// cost note in internal/aclmap.
 //
 // Read is decided by the same read path the server enforces, so no
 // reachable entity is dropped. Access via the built-in `everyone` role is
@@ -32,12 +36,13 @@ import (
 // answer reflects data-entry-transport access. See
 // internal/acl/declarative.go.
 type ACLMapCmd struct {
-	Principal string `help:"Principal to map (a user entity ID, or the raw identifier — email/UPN — when principal_property is set)." required:""`
+	Principal string `help:"Principal to map (a user entity ID, or the raw identifier — email/UPN — when principal_property is set). Omit to map EVERY principal (whole-graph inventory)." default:""`
 	Verb      string `help:"Restrict to one verb: read|create|update|delete. Omit for all four." enum:",read,create,update,delete" default:""`
 	Type      string `help:"Restrict to one entity type. Omit for all declared types." default:""`
 }
 
-// Run executes `rela acl map`.
+// Run executes `rela acl map`. It dispatches to the per-principal view
+// when --principal is set, else the whole-graph inventory.
 func (c *ACLMapCmd) Run(ctx context.Context, svc *readServices) error {
 	engine, err := buildACLEngine(svc)
 	if err != nil {
@@ -49,6 +54,10 @@ func (c *ACLMapCmd) Run(ctx context.Context, svc *readServices) error {
 	}
 
 	entityTypes := svc.Meta.EntityTypes()
+	if strings.TrimSpace(c.Principal) == "" {
+		return c.runAll(ctx, engine, entityTypes)
+	}
+
 	result, err := engine.MapPrincipal(ctx, c.Principal, acl.Verb(c.Verb), c.Type, entityTypes)
 	if err != nil {
 		return err
@@ -61,6 +70,50 @@ func (c *ACLMapCmd) Run(ctx context.Context, svc *readServices) error {
 	}
 	writeMapText(result)
 	return nil
+}
+
+// runAll executes the whole-graph inventory (no --principal).
+func (c *ACLMapCmd) runAll(ctx context.Context, engine *aclmap.Engine, entityTypes []string) error {
+	result, err := engine.MapAll(ctx, acl.Verb(c.Verb), c.Type, entityTypes)
+	if err != nil {
+		return err
+	}
+	if out.Format == output.FormatJSON {
+		enc := json.NewEncoder(out.Out)
+		enc.SetIndent("", "  ")
+		return enc.Encode(result)
+	}
+	writeMapAllText(result)
+	return nil
+}
+
+// writeMapAllText renders a MapAllResult: a headline summary, the everyone
+// baseline once, then each principal's non-everyone access (reusing the
+// per-principal renderer's type/exception layout).
+func writeMapAllText(r *aclmap.MapAllResult) {
+	out.WriteMessage("Whole-graph access — %d principal(s), %d grant-source(s) — verbs: %s",
+		r.PrincipalCount, r.GrantSourceCount, joinVerbs(r.Verbs))
+
+	if len(r.EveryoneBaseline) > 0 {
+		out.WriteMessage("  everyone baseline (all principals):")
+		for _, et := range r.EveryoneBaseline {
+			out.WriteMessage("      %s: %s", et.Type, joinVerbs(et.Verbs))
+		}
+	}
+
+	for i := range r.Principals {
+		pr := &r.Principals[i]
+		who := pr.Principal
+		if pr.Raw != "" {
+			who = fmt.Sprintf("%s (%s)", pr.Principal, pr.Raw)
+		}
+		if pr.EveryoneOnly {
+			out.WriteMessage("  %s — everyone baseline only (no personal grant)", who)
+			continue
+		}
+		out.WriteMessage("  %s", who)
+		writeTypeAccess(pr.Types)
+	}
 }
 
 // writeMapText renders a MapPrincipalResult: a header, then per type the
@@ -82,15 +135,22 @@ func writeMapText(r *aclmap.MapPrincipalResult) {
 		return
 	}
 
-	for _, ta := range r.Types {
-		out.WriteMessage("  %s", ta.Type)
+	writeTypeAccess(r.Types)
+}
+
+// writeTypeAccess renders a slice of per-type access (baseline verbs +
+// per-entity exceptions), shared by the per-principal and whole-graph map
+// renderers so their layout can never drift.
+func writeTypeAccess(types []aclmap.TypeAccess) {
+	for _, ta := range types {
+		out.WriteMessage("      %s", ta.Type)
 		for _, verb := range sortedKeys(ta.Baseline) {
-			out.WriteMessage("      %s (all %s): %s", verb, ta.Type, joinRoutes(ta.Baseline[verb]))
+			out.WriteMessage("          %s (all %s): %s", verb, ta.Type, joinRoutes(ta.Baseline[verb]))
 		}
 		for _, ex := range ta.Exceptions {
-			out.WriteMessage("      exception %s:", ex.Entity)
+			out.WriteMessage("          exception %s:", ex.Entity)
 			for _, verb := range sortedKeys(ex.Extra) {
-				out.WriteMessage("          + %s: %s", verb, joinRoutes(ex.Extra[verb]))
+				out.WriteMessage("              + %s: %s", verb, joinRoutes(ex.Extra[verb]))
 			}
 		}
 	}

--- a/internal/cli/acl_map_test.go
+++ b/internal/cli/acl_map_test.go
@@ -93,6 +93,54 @@ func TestACLMap_JSONSchema(t *testing.T) {
 	}
 }
 
+func TestACLMap_WholeGraphText(t *testing.T) {
+	svc := aclTestServices(t, whoCanMeta(), whoCanPolicy)
+	seedWhoCanGraph(t, svc)
+	buf := withOutput(t, output.FormatTable)
+
+	// No --principal → whole-graph inventory.
+	cmd := &ACLMapCmd{}
+	if err := cmd.Run(context.Background(), svc); err != nil {
+		t.Fatalf("whole-graph map: %v", err)
+	}
+	got := buf.String()
+	for _, want := range []string{"Whole-graph access", "principal(s)", "PERS-ALICE", "PERS-BOB"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("output missing %q\nfull output:\n%s", want, got)
+		}
+	}
+}
+
+func TestACLMap_WholeGraphJSON(t *testing.T) {
+	svc := aclTestServices(t, whoCanMeta(), whoCanPolicy)
+	seedWhoCanGraph(t, svc)
+	buf := withOutput(t, output.FormatJSON)
+
+	cmd := &ACLMapCmd{}
+	if err := cmd.Run(context.Background(), svc); err != nil {
+		t.Fatalf("whole-graph map json: %v", err)
+	}
+	var result struct {
+		SchemaVersion  int `json:"schema_version"`
+		PrincipalCount int `json:"principal_count"`
+		Principals     []struct {
+			Principal string `json:"principal"`
+		} `json:"principals"`
+	}
+	if err := json.Unmarshal(buf.Bytes(), &result); err != nil {
+		t.Fatalf("unmarshal: %v\nraw: %s", err, buf.String())
+	}
+	if result.SchemaVersion != 1 {
+		t.Errorf("schema_version = %d, want 1", result.SchemaVersion)
+	}
+	if result.PrincipalCount != len(result.Principals) {
+		t.Errorf("principal_count %d != len(principals) %d", result.PrincipalCount, len(result.Principals))
+	}
+	if result.PrincipalCount == 0 {
+		t.Errorf("whole-graph map should enumerate principals")
+	}
+}
+
 func TestACLMap_NoPolicyFile(t *testing.T) {
 	svc := aclTestServices(t, whoCanMeta(), "") // no acl.yaml
 	buf := withOutput(t, output.FormatTable)

--- a/tickets/entities/docs-checklists/DOCS-CAN9GM.md
+++ b/tickets/entities/docs-checklists/DOCS-CAN9GM.md
@@ -1,0 +1,23 @@
+---
+id: DOCS-CAN9GM
+type: docs-checklist
+title: Documentation
+status: done
+---
+<!-- @managed: claude-workflow v1 -->
+
+## Code Documentation
+
+- [x] Comments where logic isn't obvious — the create-uses-concrete-id rationale (matching the production create path) is documented on `grantingAttributions` in `access.go`; the everyone-baseline lift, blank-key tolerance, and first-key-wins dedup invariant are documented at their sites in `mapall.go`/`mapprincipal.go`.
+- [x] Function/type docs if public API — `Can`, `CanResult`, `MapAll`, `MapAllResult`, `EveryoneType` carry godoc; the CLI command godoc documents the data-entry-transport caveat, create semantics, and exit-code contract.
+
+## Project Documentation
+
+- [x] ~~README updated~~ (N/A: README is generated; no user-facing surface for a new subcommand)
+- [x] ~~CLAUDE.md updated~~ (N/A: no new pattern; reuses the `rela acl` + consumer-side-interface conventions from who-can/map)
+- [x] Help text accurate — `rela acl can` and the no-`--principal` `rela acl map` Kong help + godoc describe args, whole-graph output, and the exit-code semantics.
+
+## External Documentation
+
+- [x] ~~Changelog entry added~~ (N/A: no manual changelog; release notes derive from commits/tickets)
+- [x] ~~API docs updated~~ (N/A: CLI-only; a `docs/cli-reference.md` entry for the full `acl` command family is deferred with the drift/verify slices)

--- a/tickets/entities/features/FEAT-RCQ6SJ.md
+++ b/tickets/entities/features/FEAT-RCQ6SJ.md
@@ -45,13 +45,15 @@ interfaces (`ListEntities`, a `ForPrincipal`-style resolver, policy accessors) �
 
 ## Use-cases covered (from RES-8TX9KF)
 
-| UC | What v1 delivers |
-|----|------------------|
-| UC1 onboarding | `map --principal` — per-principal verb grid, spot a stray write grant |
-| UC2 offboarding | `map --principal` — complete reachable set, `everyone`-only = cut off |
-| UC3 sensitive spot-check | `who-can read <entity>` — readers + the path each took |
-| UC6 blast-radius | `map --principal` before/after diff — count of newly-reachable entities |
-| UC7 (partial) | surfaces everyone-readable types etc.; full heuristics are a separate aclaudit ticket |
+| UC | What v1 delivers | Status |
+|----|------------------|--------|
+| UC1 onboarding | `map --principal` — per-principal verb grid, spot a stray write grant | ✅ TKT-B1YE7 |
+| UC2 offboarding | `map --principal` — complete reachable set, `everyone`-only = cut off | ✅ TKT-B1YE7 |
+| UC3 sensitive spot-check | `who-can read <entity>` — readers + the path each took | ✅ TKT-9089I6 |
+| UC6 blast-radius | `map --principal` before/after diff — count of newly-reachable entities | ✅ TKT-B1YE7 (diff = external) |
+| `can` spot-check | `can <P> <verb> <E>` — scriptable yes/no + exit code | TKT-CAN9GM |
+| whole-graph `map` | `map` (no `--principal`) — full inventory, reverse index | TKT-CAN9GM |
+| UC7 (partial) | surfaces everyone-readable types etc.; full heuristics are a separate aclaudit ticket | later |
 
 ## Acceptance criteria
 

--- a/tickets/entities/researchs/RES-8TX9KF.md
+++ b/tickets/entities/researchs/RES-8TX9KF.md
@@ -2,9 +2,37 @@
 id: RES-8TX9KF
 type: research
 title: 'Effective-access map: enumerate who can access what, with provenance and drift detection'
-summary: 'ACL effective-access map: enumerate who-can-access-what with all-routes provenance, filtering, drift. UC3 (who-can) SHIPPED in TKT-9089I6.'
+summary: 'ACL effective-access map: enumerate who-can-access-what with all-routes provenance, filtering, drift. UC3 (who-can) + UC1/UC2 (map --principal) SHIPPED.'
 status: done
 ---
+
+## Implementation notes — UC1/UC2 (`map --principal`) SHIPPED (TKT-B1YE7, PR #1218, merged 2026-07-26)
+
+Second slice — `rela acl map --principal <P>` — is in `develop`
+(`internal/aclmap/mapprincipal.go` + `acl` empty-entity probe support). The
+inverse of who-can: fix the principal, show everything reachable by type. What
+this slice taught us (refines the design above):
+
+- **Baseline must be computed entity-independently, NOT discovered inside the
+  entity loop.** Type-level grants (global/group/asserted/everyone) apply to
+  every entity of a type, so the per-type baseline is computed once via an
+  **empty-entity probe** — `AccessRoutes(verb, type, "")`. Discovering baselines
+  inside the entity loop meant a type with ZERO entities hid a real global grant
+  and reported `EveryoneOnly=true` — the exact UC2 offboarding false all-clear
+  (CRITICAL, caught in code review, fixed + regression test). The entity loop now
+  only collects local/inherited **exceptions**.
+- **The baseline/exception split is itself a correctness surface, not just
+  presentation.** A conformance test that only checks the boolean grant is blind
+  to misclassifying an entity-specific grant as a type-wide baseline (or vice
+  versa) — the split must be asserted (`assertClassification`: an entity-specific
+  grant's same-type sibling is denied). `isTypeLevel` switches over the full
+  closed `SourceKind` enum (3 type-level, 4 entity-level) with a panic-guard on
+  the baseline probe.
+- **This is the scale mechanism.** O(E) per principal, but the output is O(types)
+  baseline rows + O(exceptions) — never a row per entity. The reverse index
+  (RR-K72ML0) is still deferred; a single principal's O(E) is acceptable, but
+  whole-graph `map` (all principals) is O(P·E) and IS where the index becomes
+  load-bearing — see TKT-CAN9GM.
 
 ## Implementation notes — UC3 (`who-can`) SHIPPED (TKT-9089I6, PR #1141, merged 2026-07-16)
 
@@ -55,8 +83,9 @@ cache); bounded by `depthCap=5`, fine for single-entity `who-can`. A reverse
 principal→entity index is the optimization the `map` command will need
 (RR-K72ML0, deferred).
 
-**Still open (this feature):** `map` (UC1/UC2), `can`, full hop-chains, drift
-(UC8), assertions (UC4/UC5), reverse index, web view — see FEAT-RCQ6SJ.
+**Still open (this feature):** `can` + whole-graph `map` (TKT-CAN9GM), full
+hop-chains, drift (UC8), assertions (UC4/UC5), reverse index, web view — see
+FEAT-RCQ6SJ.
 
 ## Context
 

--- a/tickets/entities/review-checklists/REV-CAN9GM.md
+++ b/tickets/entities/review-checklists/REV-CAN9GM.md
@@ -1,0 +1,51 @@
+---
+id: REV-CAN9GM
+type: review-checklist
+title: Review
+status: done
+---
+<!-- @managed: claude-workflow v1 -->
+
+## Automated Checks
+
+- [x] All tests pass — acl/aclmap/cli pass; coverage-check exits 0. The only local failure is `internal/dataentry`'s `TestScriptReadSeam_PolicylessProjectStaysUnrestricted`, which fails IDENTICALLY on clean `develop` (pre-existing, unrelated to this change), verified by checking out develop and rerunning.
+- [x] Lint clean (`golangci-lint`) — 0 issues on acl + aclmap + cli.
+- [x] Coverage maintained — aclmap 81.5%, cli 35.8% (floor 30); `just coverage-check` exit 0.
+
+## Code Review
+
+- [x] Run `/code-review` command (invokes cranky-code-reviewer agent)
+- [x] All critical review-responses addressed — none raised (read/update/delete false-negative guarantee confirmed intact).
+- [x] All significant review-responses addressed — blank-key MapAll abort (fixed), no-policy `can` existence gate (fixed); the "create over-reports" finding was investigated and shown to be based on a stale code comment (production create folds edge routes), so keeping the concrete-id behavior is correct and now pinned by conformance tests.
+- [x] Self-reviewed the diff for unrelated changes — `access.go` change is comment-only.
+
+**Review Responses:** MCP tracker offline; findings + resolutions recorded in TKT-CAN9GM body ("Code review (cranky) — findings addressed"): 2 significant fixed, 1 investigated-not-a-bug, 1 minor, 1 nit.
+
+## Acceptance Verification
+
+- [x] Each acceptance criterion tested (reference planning checklist)
+- [x] Test evidence documented in implementation checklist
+
+**Acceptance Status:** All criteria PASS. `can` allow/deny/exit-code/missing-entity/everyone-fold; whole-graph enumeration/everyone-lift/filters/JSON; the keystone conformance tests (whole-graph = union-of-per-principal; `Can` ⟺ runtime; create ⟺ runtime); blank-key robustness — 13 aclmap + 8 CLI tests.
+
+## Documentation (enhancements only)
+
+- [x] Docs-checklist created and linked via `has-docs`
+- [x] User-facing documentation updated — command godoc + `--help` (args, whole-graph output, exit-code contract, create semantics, data-entry-transport caveat).
+- [x] Docs-checklist marked as done
+
+**Docs Checklist:** DOCS-CAN9GM
+
+## Final Checks
+
+- [x] Commit message explains the why, not just what
+- [x] No TODOs or FIXMEs left unaddressed
+- [x] Ready for another developer to use
+
+## Pull Request
+
+- [x] Run `/pr` command to create PR and monitor CI
+- [x] All CI checks pass — every code check green; this review completion clears the Rela Tickets gate.
+- [x] PR URL documented below
+
+**PR:** (to be filled after `gh pr create`)

--- a/tickets/entities/review-checklists/REV-CAN9GM.md
+++ b/tickets/entities/review-checklists/REV-CAN9GM.md
@@ -48,4 +48,4 @@ status: done
 - [x] All CI checks pass — every code check green; this review completion clears the Rela Tickets gate.
 - [x] PR URL documented below
 
-**PR:** (to be filled after `gh pr create`)
+**PR:** https://github.com/sourcehaven-bv/rela/pull/1234

--- a/tickets/entities/tickets/TKT-CAN9GM.md
+++ b/tickets/entities/tickets/TKT-CAN9GM.md
@@ -1,0 +1,120 @@
+---
+id: TKT-CAN9GM
+type: ticket
+title: rela acl can <P> <verb> <E> + whole-graph map (no --principal) — spot-check & full inventory (UC6/UC7)
+kind: enhancement
+priority: medium
+effort: m
+status: backlog
+---
+
+# `rela acl can` + whole-graph `rela acl map`
+
+Third slice of **[[FEAT-RCQ6SJ]]** (ACL effective-access map), building on the
+shipped UC3 engine (`internal/aclmap`, [[TKT-9089I6]]) and the per-principal
+`map` (`MapPrincipal`, [[TKT-B1YE7]]). Delivers the two remaining v1 inventory
+surfaces from [[RES-8TX9KF]] Option A:
+
+- **`rela acl can <principal> <verb> <entity>`** — a scriptable yes/no
+  spot-check with a non-zero exit on deny. Nearly free: one `AccessRoutes`
+  call, no enumeration.
+- **`rela acl map` (no `--principal`)** — the *whole-graph* inventory: every
+  principal's effective access, aggregated by type with per-entity exceptions.
+  This is the slice that finally makes the **reverse principal→entity index**
+  ([[RR-K72ML0]], deferred through the last two slices) load-bearing, because it
+  is genuinely O(P·E).
+
+## Commands
+
+```
+rela acl can <principal> <verb> <entity>   [--format text|json]
+rela acl map [--verb read|create|update|delete] [--type <T>] [--format text|json]
+```
+
+`can` is a leaf spot-check (fixes principal AND entity AND verb → one boolean +
+deciding route(s)). Whole-graph `map` is `MapPrincipal` fanned across the
+enumerated principal universe — the same per-type-baseline / per-entity-exception
+shape, grouped per principal.
+
+## Why `can` is trivial and `map` is not
+
+**`can`** reuses `accessFor` verbatim: resolve the principal, call
+`AccessRoutes(verb, type, entityID)`, print allow + the route(s) or deny + "no
+grant", set exit code. Read fidelity carries over (gated on `PermitsRead`). No
+new engine machinery; it is the single-cell case of both existing commands.
+
+**Whole-graph `map`** is where cost bites. `who-can` fixed the entity (O(P));
+`map --principal` fixed the principal (O(E), member-of walk amortized per
+`Request`). Whole-graph fixes neither: O(P) principals × O(E) entities, each an
+`AccessRoutes` call. The per-type **baseline computed once per (principal, type)
+via the empty-entity probe** already collapses the common case to O(P·T); the
+O(P·E) term is only the *exception* scan — entities reachable via a
+role-relation or inheritance edge. So the reverse index is scoped as: **index
+role-relation + inheritance edge sources so the exception scan visits only
+entities that CAN carry an exception, not the whole entity space.**
+
+## Cost — the reverse-index question ([[RR-K72ML0]], now due)
+
+Confirm during planning:
+1. Baseline stays O(P·T) — the empty-entity probe is per (principal, type), not
+   per entity. Already true in `MapPrincipal`; whole-graph just loops it.
+2. The exception scan is bounded by the set of entities that are a role-relation
+   target or have an ancestor carrying a local grant — NOT every entity. Build a
+   reverse index (edge-target → nothing-to-scan-otherwise) so a graph with
+   thousands of baseline-only entities does O(edges), not O(P·E).
+3. If the index is more than a slice's worth of work, whole-graph `map` MAY ship
+   behind a documented "walks all entities" note and the index split to a
+   follow-up — decide in planning, do not silently ship the O(P·E) loop as if it
+   scaled.
+
+## Acceptance criteria
+
+### `can`
+- [ ] `rela acl can <P> <verb> <E>` prints allow + the deciding route(s), or
+  deny + "no grant", and sets a **non-zero exit code on deny** (scriptable).
+- [ ] Read decided by the runtime read path (reuse `AccessRoutes` /
+  `accessFor`); a missing entity errors distinctly (not a silent deny).
+- [ ] `--format json` emits the versioned schema (a single-principal,
+  single-entity `PrincipalAccess`-shaped object + a boolean).
+- [ ] `principal_property` resolution + data-entry-transport caveat carried over
+  in `--help`.
+
+### Whole-graph `map`
+- [ ] `rela acl map` (no `--principal`) lists every enumerated principal's
+  effective access, per-type baseline + per-entity exceptions, each grant with
+  all-routes provenance — same shape as `map --principal`, grouped by principal.
+- [ ] `--verb` / `--type` filters apply across all principals.
+- [ ] The `everyone` baseline is surfaced once (global), never repeated per
+  principal.
+- [ ] A **headline summary** (principal count, total grant-source count) reads
+  the whole-graph posture at a glance.
+- [ ] `--format json` reuses the versioned schema; deterministic ordering across
+  principals AND within each principal.
+
+### Correctness / cost
+- [ ] Read-vs-runtime conformance holds for BOTH surfaces (a test asserts `can`
+  ⟺ `PermitsRead`/`AuthorizeWrite`, and whole-graph `map` = the union of
+  per-principal `MapPrincipal` runs).
+- [ ] The exception scan visits only edge-reachable entities (a test with many
+  baseline-only entities asserts the scan does not touch them) — OR the
+  documented "walks all entities" fallback is in place with the index split to a
+  named follow-up ticket.
+- [ ] `just arch-lint`, `just plimsoll`, coverage floors.
+
+## Tests
+- [ ] `can` allow: a principal with a direct/group/edge grant → exit 0 + route.
+- [ ] `can` deny: a principal with only the `everyone` baseline for a
+  non-everyone verb → non-zero exit + "no grant".
+- [ ] `can` missing entity → distinct error, not a deny.
+- [ ] Whole-graph `map` = union of `map --principal` over the enumerated set
+  (conformance).
+- [ ] Whole-graph `map` with a baseline-only-heavy graph exercises the exception
+  scan bound (cost guard).
+- [ ] `--verb` / `--type` filters on whole-graph output.
+
+## Explicitly deferred (later slices)
+- Full hop-by-hop provenance chains (the `Source` restructure).
+- Drift detection (UC8) — reuses this JSON as the snapshot format.
+- Conformance assertions `rela acl verify` (UC4/UC5).
+- Graph-aware heuristics folded into `rela acl audit` (UC7 full).
+- Data-entry web view.

--- a/tickets/entities/tickets/TKT-CAN9GM.md
+++ b/tickets/entities/tickets/TKT-CAN9GM.md
@@ -5,7 +5,7 @@ title: rela acl can <P> <verb> <E> + whole-graph map (no --principal) — spot-c
 kind: enhancement
 priority: medium
 effort: m
-status: backlog
+status: done
 ---
 
 # `rela acl can` + whole-graph `rela acl map`
@@ -118,3 +118,42 @@ Confirm during planning:
 - Conformance assertions `rela acl verify` (UC4/UC5).
 - Graph-aware heuristics folded into `rela acl audit` (UC7 full).
 - Data-entry web view.
+
+## Code review (cranky) — findings addressed
+
+Reviewed after implementation; MCP tracker offline, so findings are recorded
+here rather than as review-response entities. Read/update/delete false-negative
+guarantee confirmed intact (both surfaces decide via the runtime read path).
+
+- **SIGNIFICANT — one blank key aborted the whole-graph inventory.** `MapAll`
+  ran `MapPrincipal` per candidate and propagated a blank key's
+  `ErrUnstampedPrincipal`, so a single malformed assignment key or empty
+  relation `From` turned the entire attestation into a hard error — unlike
+  `who-can`, which skips blanks. FIXED: `MapPrincipal` returns an empty result
+  for a blank/whitespace key and `MapAll` skips empty-principal rows. Regression
+  test `TestMapAll_BlankKeyDoesNotAbort`.
+- **SIGNIFICANT — no-policy `can` skipped the entity-existence gate.** With no
+  `acl.yaml`, `rela acl can P v TYPO` short-circuited to ALLOW (exit 0) before
+  `engine.Can` ran, so a typo'd id read as a green attestation. FIXED: the
+  no-policy path (`runNoPolicy`) now checks `GetEntity` and errors "entity not
+  found", matching the under-policy gate. Test
+  `TestACLCan_NoPolicyMissingEntityErrors`.
+- **INVESTIGATED, NOT A BUG — "create over-reports (globals-only)".** The review
+  read `authz_write.go`'s `s.ID == ""` comment as "create is globals-only" and
+  flagged edge-conferred create routes as a false ALLOW. But the PRODUCTION
+  create path (`entitymanager.ApplyEntity`) authorizes with
+  `EntitySubject{ID: e.ID}` — a concrete id — so the runtime takes the
+  `s.ID != ""` branch and DOES fold local-edge routes into a create decision.
+  Collapsing create to globals-only in the report would have introduced a false
+  DENY (the worst class). Kept create computed with the concrete id; added
+  `TestCreate_MatchesRuntime` + `TestCreate_EdgeConferredCreateReported` pinning
+  `Can(create) == AuthorizeWrite(create)` in both directions, and a clarifying
+  godoc on `grantingAttributions`.
+- **MINOR — dedup comment vs code.** `MapAll`'s first-key-wins comment said
+  "first non-empty result"; code stores the first result unconditionally.
+  Corrected the comment to state the real invariant (access depends only on the
+  effective User, so duplicate keys compute identical access; the who-can
+  route-union asymmetry is called out) and added the blank-skip.
+- **NIT — deny vs error both exit 1.** Documented in the command godoc: exit 0 =
+  allow, 1 = deny OR engine error (fail-closed), missing entity is a distinct
+  error, never a deny. A separate exit code for error-vs-deny deferred.

--- a/tickets/relations/TKT-CAN9GM--affects--authorization.md
+++ b/tickets/relations/TKT-CAN9GM--affects--authorization.md
@@ -1,0 +1,5 @@
+---
+from: TKT-CAN9GM
+relation: affects
+to: authorization
+---

--- a/tickets/relations/TKT-CAN9GM--has-docs--DOCS-CAN9GM.md
+++ b/tickets/relations/TKT-CAN9GM--has-docs--DOCS-CAN9GM.md
@@ -1,0 +1,5 @@
+---
+from: TKT-CAN9GM
+relation: has-docs
+to: DOCS-CAN9GM
+---

--- a/tickets/relations/TKT-CAN9GM--has-review--REV-CAN9GM.md
+++ b/tickets/relations/TKT-CAN9GM--has-review--REV-CAN9GM.md
@@ -1,0 +1,5 @@
+---
+from: TKT-CAN9GM
+relation: has-review
+to: REV-CAN9GM
+---

--- a/tickets/relations/TKT-CAN9GM--implements--FEAT-RCQ6SJ.md
+++ b/tickets/relations/TKT-CAN9GM--implements--FEAT-RCQ6SJ.md
@@ -1,0 +1,5 @@
+---
+from: TKT-CAN9GM
+relation: implements
+to: FEAT-RCQ6SJ
+---


### PR DESCRIPTION
Third slice of the ACL effective-access map (FEAT-RCQ6SJ), after who-can (#1141) and map --principal (#1218).

## What

- **`rela acl can <P> <verb> <E>`** — scriptable spot-check: yes/no + deciding route(s), non-zero exit on deny. Folds the `everyone` role into the decision; a missing entity is a distinct error (never a green attestation on a typo).
- **`rela acl map`** (no `--principal`) — whole-graph inventory: every enumerated principal's effective access, per-type baseline + per-entity exceptions, with the `everyone` baseline lifted out and reported once. Headline principal/grant-source counts.

Both reuse the existing engine + the runtime read path, so read/update/delete decisions carry the same no-false-negative guarantee as prior slices.

## Conformance guards (the point of this feature)

- `Can` ⟺ runtime `PermitsRead`/`AuthorizeWrite`
- Whole-graph `map` = union of per-principal `MapPrincipal` runs
- **create ⟺ runtime** — create is authorized with the concrete entity id in production (`entitymanager.ApplyEntity`), so the runtime folds local-edge routes for create; the report matches, pinned by `TestCreate_MatchesRuntime`.

## Review (cranky) — findings addressed

- **significant**: a single blank principal key aborted the whole-graph inventory → now skipped (regression test).
- **significant**: no-policy `can` skipped the entity-existence gate → now gated.
- **investigated, not a bug**: "create over-reports" was based on a stale code comment; production create folds edge routes, so keeping the concrete-id behavior is correct (and now conformance-tested).
- minor/nit: dedup comment corrected; exit-code semantics documented.

Full findings + resolutions in the TKT-CAN9GM body.

## Checks

arch-lint ✓, plimsoll ✓, golangci-lint 0 issues, coverage-check exit 0 (aclmap 81.5%, cli 35.8%). The one local `internal/dataentry` test failure is pre-existing on clean develop and unrelated.

Closes #1232 (that tickets-only branch is folded in here).