### PR TITLE
feat: historical field redaction fails closed + history:read-redacted reveal (TKT-73C6B2)

### DIFF
--- a/docs-project/entities/guides/GUIDE-acl-security.md
+++ b/docs-project/entities/guides/GUIDE-acl-security.md
@@ -661,6 +661,53 @@ is read-gated on the same principles as everything else:
   requesting a deleted entity's history gets the same 404 as a nonexistent id,
   so the permission boundary does not itself leak which deleted entities exist.
 
+### Historical field redaction fails closed (`history:read-redacted`)
+
+Field-level `visible:` redaction of a *historical* snapshot **fails closed**.
+A `visible:` grant can be conditional on the subject entity's own graph state —
+`visible: has_relation(entity, 'reviewed-by')` or
+`count_relations(entity, 'blocks') > 0`. Evaluating such a grant needs the
+entity's edges *as they were when the version was captured*, but the live store
+only holds its edges *now*: for a deleted entity there are none, and for a live
+entity they may have drifted. Trusting the live store would let a grant that was
+DENIED at write time flip OPEN and leak a field that was hidden when the version
+was written.
+
+So historical redaction does **not** trust the live store for subject-world
+predicates. When serializing a snapshot, `has_relation` / `count_relations`
+resolve as *no edges*, so any grant that needs them evaluates false and the
+field is **hidden**. The rule, stated as an invariant:
+
+> A historical version shows a field only if today's `visible:` policy
+> affirmatively grants it against inputs that can be safely evaluated. Every
+> grant that would need untrusted subject-world state is hidden. Reader-side
+> inputs (`current_user`, the roles the reader holds) stay live — so redaction
+> is still per-reader, and a reader who gains a role gains historical
+> visibility.
+
+This is deliberately conservative: it can **over-redact** (hide a field a reader
+could legitimately have seen) but never **under-redact** (leak). A grant that
+references a property the frozen record no longer carries (a since-renamed
+field) likewise binds Nil and hides the field — a drifted schema over-redacts,
+never leaks.
+
+To see the fully un-redacted frozen snapshot, a role must hold the global
+**`history:read-redacted`** permission — the field-grained sibling of
+`history:read`:
+
+```yaml
+roles:
+  auditor:
+    permissions: [history:read, history:read-redacted]
+```
+
+Its semantics are **OVERRIDE**, all-or-nothing like `history:read`: a holder
+sees *every* frozen field of a historical snapshot, bypassing field redaction
+entirely (the snapshot already contains every field; the reveal just skips the
+strip). Grant it only to trusted audit/compliance roles — it exposes fields the
+live `visible:` policy would redact. A non-holder always sees the fail-closed
+redaction described above.
+
 ## Command execution gating (`command:*`)
 
 Data-entry [commands](data-entry.md#commands) execute arbitrary shell via

--- a/docs-project/entities/guides/GUIDE-acl-security.md
+++ b/docs-project/entities/guides/GUIDE-acl-security.md
@@ -674,9 +674,15 @@ DENIED at write time flip OPEN and leak a field that was hidden when the version
 was written.
 
 So historical redaction does **not** trust the live store for subject-world
-predicates. When serializing a snapshot, `has_relation` / `count_relations`
-resolve as *no edges*, so any grant that needs them evaluates false and the
-field is **hidden**. The rule, stated as an invariant:
+state. Two things are neutered when serializing a snapshot: `has_relation` /
+`count_relations` resolve as *no edges*, and the effective role set is reduced to
+**globals-only** — local roles conferred by live `role_relations` edges and
+ancestor roles inherited via `inherit_roles_through` are dropped, because they
+too come from the live graph and would otherwise let a role conferred *after*
+capture reveal a field. To keep that reduction from silently defaulting to
+all-visible, a type that any role gates with `visible:` gets a **type-level
+closed-world** in history: every field not affirmatively granted visible by a
+globally-held role is hidden. The rule, stated as an invariant:
 
 > A historical version shows a field only if today's `visible:` policy
 > affirmatively grants it against inputs that can be safely evaluated. Every

--- a/docs/acl-security.md
+++ b/docs/acl-security.md
@@ -668,9 +668,15 @@ DENIED at write time flip OPEN and leak a field that was hidden when the version
 was written.
 
 So historical redaction does **not** trust the live store for subject-world
-predicates. When serializing a snapshot, `has_relation` / `count_relations`
-resolve as *no edges*, so any grant that needs them evaluates false and the
-field is **hidden**. The rule, stated as an invariant:
+state. Two things are neutered when serializing a snapshot: `has_relation` /
+`count_relations` resolve as *no edges*, and the effective role set is reduced to
+**globals-only** — local roles conferred by live `role_relations` edges and
+ancestor roles inherited via `inherit_roles_through` are dropped, because they
+too come from the live graph and would otherwise let a role conferred *after*
+capture reveal a field. To keep that reduction from silently defaulting to
+all-visible, a type that any role gates with `visible:` gets a **type-level
+closed-world** in history: every field not affirmatively granted visible by a
+globally-held role is hidden. The rule, stated as an invariant:
 
 > A historical version shows a field only if today's `visible:` policy
 > affirmatively grants it against inputs that can be safely evaluated. Every

--- a/docs/acl-security.md
+++ b/docs/acl-security.md
@@ -655,6 +655,53 @@ is read-gated on the same principles as everything else:
   requesting a deleted entity's history gets the same 404 as a nonexistent id,
   so the permission boundary does not itself leak which deleted entities exist.
 
+### Historical field redaction fails closed (`history:read-redacted`)
+
+Field-level `visible:` redaction of a *historical* snapshot **fails closed**.
+A `visible:` grant can be conditional on the subject entity's own graph state —
+`visible: has_relation(entity, 'reviewed-by')` or
+`count_relations(entity, 'blocks') > 0`. Evaluating such a grant needs the
+entity's edges *as they were when the version was captured*, but the live store
+only holds its edges *now*: for a deleted entity there are none, and for a live
+entity they may have drifted. Trusting the live store would let a grant that was
+DENIED at write time flip OPEN and leak a field that was hidden when the version
+was written.
+
+So historical redaction does **not** trust the live store for subject-world
+predicates. When serializing a snapshot, `has_relation` / `count_relations`
+resolve as *no edges*, so any grant that needs them evaluates false and the
+field is **hidden**. The rule, stated as an invariant:
+
+> A historical version shows a field only if today's `visible:` policy
+> affirmatively grants it against inputs that can be safely evaluated. Every
+> grant that would need untrusted subject-world state is hidden. Reader-side
+> inputs (`current_user`, the roles the reader holds) stay live — so redaction
+> is still per-reader, and a reader who gains a role gains historical
+> visibility.
+
+This is deliberately conservative: it can **over-redact** (hide a field a reader
+could legitimately have seen) but never **under-redact** (leak). A grant that
+references a property the frozen record no longer carries (a since-renamed
+field) likewise binds Nil and hides the field — a drifted schema over-redacts,
+never leaks.
+
+To see the fully un-redacted frozen snapshot, a role must hold the global
+**`history:read-redacted`** permission — the field-grained sibling of
+`history:read`:
+
+```yaml
+roles:
+  auditor:
+    permissions: [history:read, history:read-redacted]
+```
+
+Its semantics are **OVERRIDE**, all-or-nothing like `history:read`: a holder
+sees *every* frozen field of a historical snapshot, bypassing field redaction
+entirely (the snapshot already contains every field; the reveal just skips the
+strip). Grant it only to trusted audit/compliance roles — it exposes fields the
+live `visible:` policy would redact. A non-holder always sees the fail-closed
+redaction described above.
+
 ## Command execution gating (`command:*`)
 
 Data-entry [commands](data-entry.md#commands) execute arbitrary shell via

--- a/internal/acl/policy.go
+++ b/internal/acl/policy.go
@@ -43,6 +43,18 @@ const EveryoneRole = "everyone"
 // "audit-everything-deleted" super-permission.
 const PermHistoryRead = "history:read"
 
+// PermHistoryReadRedacted is the global named permission that reveals fields a
+// historical snapshot would otherwise redact (TKT-73C6B2). Historical field
+// redaction fails CLOSED: any `visible:` grant whose subject-world inputs cannot
+// be affirmed for a historical/deleted entity (the live store no longer holds
+// the entity's as-of-version edges, so a conditional `has_relation` /
+// `count_relations` grant cannot be trusted) hides the field. A holder of this
+// permission sees ALL frozen fields — OVERRIDE semantics, the field-grained
+// sibling of [PermHistoryRead]'s all-or-nothing audit power. Granted via a
+// role's `permissions:` list like the delegate-X permissions and PermHistoryRead;
+// documented in docs/acl-security.md alongside it.
+const PermHistoryReadRedacted = "history:read-redacted"
+
 // Policy is the declarative ACL configuration parsed from `acl.yaml`
 // at the project root.
 //

--- a/internal/affordances/bindings.go
+++ b/internal/affordances/bindings.go
@@ -65,7 +65,17 @@ type bindingContext struct {
 
 // outgoingCounts returns the entity's outgoing-edge counts, loading
 // and caching them on first call.
+//
+// For a HISTORICAL subject ([WithHistoricalSubject]) the live store cannot
+// answer the entity's as-of-version edges, so this returns an empty map
+// WITHOUT consulting the store: has_relation / count_relations then see no
+// edges, any conditional `visible:` grant that needs them evaluates false, and
+// the field fails CLOSED (TKT-73C6B2). Not consulting the store also avoids a
+// misleading live lookup on a since-deleted or drifted id.
 func (bc *bindingContext) outgoingCounts(ctx context.Context) map[string]int {
+	if isHistoricalSubject(ctx) {
+		return nil
+	}
 	if !bc.outgoingReady {
 		bc.outgoing = bc.lookup.OutgoingCounts(ctx, bc.entity.ID)
 		bc.outgoingReady = true

--- a/internal/affordances/historical.go
+++ b/internal/affordances/historical.go
@@ -8,24 +8,31 @@ import "context"
 type historicalSubjectKey struct{}
 
 // WithHistoricalSubject marks ctx as resolving field visibility for a
-// historical snapshot (TKT-73C6B2). Under this marker the binding context
-// treats subject-world graph lookups (has_relation / count_relations, which
-// funnel through outgoingCounts) as UNRESOLVABLE — the live store no longer
-// holds the entity's as-of-version edges, so trusting it would let a
-// conditional `visible:` grant flip OPEN for a deleted/drifted entity and leak
-// a field hidden at write time. With no edges to affirm the grant, the
-// predicate evaluates false and the field FAILS CLOSED (hidden).
+// historical snapshot (TKT-73C6B2). The live store no longer holds the entity's
+// as-of-version subject-world state, so trusting it would let a `visible:` grant
+// that was DENIED at write time flip OPEN for a deleted/drifted entity and leak
+// a field. Under this marker the resolver neuters every subject-world input:
 //
-// Reader-side inputs are deliberately NOT touched: current_user stays live,
-// and has_role degrades on its own (a deleted entity confers no local roles,
-// so the principal keeps only global roles) — that is a safe, intended
-// degradation, not a leak. Only the subject's own outgoing-edge state, which
-// the live store cannot answer as-of-version, is neutered here.
+//   - has_relation / count_relations (via outgoingCounts) resolve as NO edges,
+//     so a grant conditioned on them evaluates false and the field FAILS CLOSED.
+//   - the effective role set is reduced to GLOBALS-ONLY (resolveViaDeclarative):
+//     local roles conferred by live `role_relations` edges and ancestor roles
+//     from `inherit_roles_through` are dropped, since they too come from the
+//     live graph and would otherwise let a role conferred AFTER capture both
+//     select a `visible:` block and satisfy has_role.
+//   - to stop that reduced role set from silently defaulting to all-visible, a
+//     type gated by `visible:` gets a type-level closed-world in history
+//     (FieldVerdicts): a field is shown only if a globally-held role
+//     affirmatively grants it visible.
+//
+// Reader-side inputs stay LIVE — current_user and the reader's global roles are
+// assignment-based, not subject-world, so per-reader redaction still applies and
+// a reader who gains a global role gains historical visibility (intended).
 //
 // The history read path sets this before serializing a snapshot; a reader
-// holding acl.PermHistoryReadRedacted bypasses the resulting redaction at the
-// handler (OVERRIDE reveal), so this marker only governs the fail-closed
-// default for ordinary readers.
+// holding acl.PermHistoryReadRedacted bypasses redaction entirely at the handler
+// (OVERRIDE reveal), so this marker only governs the fail-closed default for
+// ordinary readers.
 func WithHistoricalSubject(ctx context.Context) context.Context {
 	return context.WithValue(ctx, historicalSubjectKey{}, true)
 }

--- a/internal/affordances/historical.go
+++ b/internal/affordances/historical.go
@@ -1,0 +1,37 @@
+package affordances
+
+import "context"
+
+// historicalSubjectKey marks a context as resolving a HISTORICAL entity
+// snapshot (a version read of a possibly-deleted or drifted entity) rather
+// than the live entity. See [WithHistoricalSubject].
+type historicalSubjectKey struct{}
+
+// WithHistoricalSubject marks ctx as resolving field visibility for a
+// historical snapshot (TKT-73C6B2). Under this marker the binding context
+// treats subject-world graph lookups (has_relation / count_relations, which
+// funnel through outgoingCounts) as UNRESOLVABLE — the live store no longer
+// holds the entity's as-of-version edges, so trusting it would let a
+// conditional `visible:` grant flip OPEN for a deleted/drifted entity and leak
+// a field hidden at write time. With no edges to affirm the grant, the
+// predicate evaluates false and the field FAILS CLOSED (hidden).
+//
+// Reader-side inputs are deliberately NOT touched: current_user stays live,
+// and has_role degrades on its own (a deleted entity confers no local roles,
+// so the principal keeps only global roles) — that is a safe, intended
+// degradation, not a leak. Only the subject's own outgoing-edge state, which
+// the live store cannot answer as-of-version, is neutered here.
+//
+// The history read path sets this before serializing a snapshot; a reader
+// holding acl.PermHistoryReadRedacted bypasses the resulting redaction at the
+// handler (OVERRIDE reveal), so this marker only governs the fail-closed
+// default for ordinary readers.
+func WithHistoricalSubject(ctx context.Context) context.Context {
+	return context.WithValue(ctx, historicalSubjectKey{}, true)
+}
+
+// isHistoricalSubject reports whether ctx was marked by [WithHistoricalSubject].
+func isHistoricalSubject(ctx context.Context) bool {
+	v, _ := ctx.Value(historicalSubjectKey{}).(bool)
+	return v
+}

--- a/internal/affordances/historical_test.go
+++ b/internal/affordances/historical_test.go
@@ -1,0 +1,189 @@
+package affordances_test
+
+import (
+	"testing"
+
+	"github.com/Sourcehaven-BV/rela/internal/affordances"
+)
+
+// TKT-73C6B2: under WithHistoricalSubject, a `visible:` grant conditioned on a
+// subject-world lookup (has_relation / count_relations) fails CLOSED — the live
+// store can't answer the entity's as-of-version edges, so trusting it would let
+// the grant flip open and leak a field hidden at write time. The marker makes
+// outgoingCounts return no edges, so the predicate evaluates false and the
+// field hides. Live reads (no marker) are unaffected: the edge is seen.
+
+// Scenario 1 (edge present at capture, gone/untrusted at read): a
+// has_relation-gated visible field is VISIBLE live but HIDDEN historical.
+func TestHistorical_HasRelationVisible_FailsClosed(t *testing.T) {
+	t.Parallel()
+	p := policyFromYAML(t, `
+roles:
+  triager:
+    visible:
+      ticket:
+        - field: assignee
+          when: "has_relation(entity, 'blocks')"
+assignments:
+  alice: triager
+`)
+	// Edge present in the LIVE lookup.
+	r, err := affordances.New(testMeta(t), newStubLookup([3]string{"T-1", "blocks", "T-9"}), declFor(t, p))
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	// Live read: edge present → grant passes → assignee visible (not in deny map,
+	// or present-and-true).
+	fvLive := r.FieldVerdicts(ctxAs("alice"), ticket("T-1", nil))
+	if v, ok := fvLive.Visible["assignee"]; ok && !v {
+		t.Errorf("live: assignee should be visible (blocks edge present), got hidden")
+	}
+
+	// Historical read: marker neuters the subject-world lookup → grant fails →
+	// assignee hidden, regardless of what the live store still holds.
+	ctxHist := affordances.WithHistoricalSubject(ctxAs("alice"))
+	fvHist := r.FieldVerdicts(ctxHist, ticket("T-1", nil))
+	if v, ok := fvHist.Visible["assignee"]; !ok || v {
+		t.Errorf("historical: assignee must fail closed (hidden), got ok=%v v=%v", ok, v)
+	}
+}
+
+// count_relations-gated grant fails closed the same way (both host funcs
+// funnel through outgoingCounts).
+func TestHistorical_CountRelationsVisible_FailsClosed(t *testing.T) {
+	t.Parallel()
+	p := policyFromYAML(t, `
+roles:
+  triager:
+    visible:
+      ticket:
+        - field: assignee
+          when: "count_relations(entity, 'blocks') > 0"
+assignments:
+  alice: triager
+`)
+	r, err := affordances.New(testMeta(t),
+		newStubLookup([3]string{"T-1", "blocks", "T-9"}, [3]string{"T-1", "blocks", "T-8"}), declFor(t, p))
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	fvLive := r.FieldVerdicts(ctxAs("alice"), ticket("T-1", nil))
+	if v, ok := fvLive.Visible["assignee"]; ok && !v {
+		t.Errorf("live: assignee should be visible (2 blocks edges), got hidden")
+	}
+
+	fvHist := r.FieldVerdicts(affordances.WithHistoricalSubject(ctxAs("alice")), ticket("T-1", nil))
+	if v, ok := fvHist.Visible["assignee"]; !ok || v {
+		t.Errorf("historical: assignee must fail closed (hidden), got ok=%v v=%v", ok, v)
+	}
+}
+
+// Scenario 3/5: the marker does NOT touch reader-side inputs. A grant gated on
+// current_user (the reader) resolves identically live and historical — the
+// reader stays live, so an entitled reader keeps historical visibility and an
+// unentitled one stays denied, regardless of the marker. (This is why the
+// marker only neuters subject-world edges, not the reader.)
+func TestHistorical_ReaderSideGrant_Unaffected(t *testing.T) {
+	t.Parallel()
+	p := policyFromYAML(t, `
+roles:
+  viewer:
+    visible:
+      ticket:
+        - field: assignee
+          when: "current_user.id == 'auditor'"
+assignments:
+  auditor: viewer
+  bob: viewer
+`)
+	r, err := affordances.New(testMeta(t), newStubLookup(), declFor(t, p))
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	// auditor matches the reader-side predicate → assignee visible, live AND
+	// historical (reader side is evaluated live under the marker).
+	for _, hist := range []bool{false, true} {
+		ctx := ctxAs("auditor")
+		if hist {
+			ctx = affordances.WithHistoricalSubject(ctx)
+		}
+		fv := r.FieldVerdicts(ctx, ticket("T-1", nil))
+		if v, ok := fv.Visible["assignee"]; ok && !v {
+			t.Errorf("auditor (historical=%v): assignee should be visible (reader is live), got hidden", hist)
+		}
+	}
+
+	// bob does not match → assignee hidden, live AND historical (unchanged).
+	for _, hist := range []bool{false, true} {
+		ctx := ctxAs("bob")
+		if hist {
+			ctx = affordances.WithHistoricalSubject(ctx)
+		}
+		fv := r.FieldVerdicts(ctx, ticket("T-1", nil))
+		if v, ok := fv.Visible["assignee"]; !ok || v {
+			t.Errorf("bob (historical=%v): assignee should be hidden, got ok=%v v=%v", hist, ok, v)
+		}
+	}
+}
+
+// Scenario 7: a visible: grant that references a property the frozen record
+// does not carry (e.g. today's policy references a since-renamed/removed
+// property) binds that property as Nil (DR-C2 coerce-not-fail), the predicate
+// evaluates false, and the field FAILS CLOSED — a live policy over a drifted
+// schema over-redacts, never leaks. (This holds live too; the marker is
+// orthogonal here — pinned under both.)
+func TestHistorical_MissingReferencedProperty_FailsClosed(t *testing.T) {
+	t.Parallel()
+	p := policyFromYAML(t, `
+roles:
+  triager:
+    visible:
+      ticket:
+        - field: assignee
+          when: "entity.status == 'done'"
+assignments:
+  alice: triager
+`)
+	r, err := affordances.New(testMeta(t), newStubLookup(), declFor(t, p))
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	// Ticket has NO status property set → entity.status binds Nil → predicate
+	// false → assignee hidden, live AND historical.
+	for _, hist := range []bool{false, true} {
+		ctx := ctxAs("alice")
+		if hist {
+			ctx = affordances.WithHistoricalSubject(ctx)
+		}
+		fv := r.FieldVerdicts(ctx, ticket("T-1", nil))
+		if v, ok := fv.Visible["assignee"]; !ok || v {
+			t.Errorf("missing referenced property (historical=%v): assignee must fail closed, got ok=%v v=%v", hist, ok, v)
+		}
+	}
+}
+
+// An unconditional visible: grant is unaffected by the marker — nothing to fail
+// closed, so historical redaction matches live (the field stays visible).
+func TestHistorical_UnconditionalVisible_Unaffected(t *testing.T) {
+	t.Parallel()
+	p := policyFromYAML(t, `
+roles:
+  triager:
+    visible:
+      ticket:
+        - field: assignee
+assignments:
+  alice: triager
+`)
+	r, err := affordances.New(testMeta(t), newStubLookup(), declFor(t, p))
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	fv := r.FieldVerdicts(affordances.WithHistoricalSubject(ctxAs("alice")), ticket("T-1", nil))
+	if v, ok := fv.Visible["assignee"]; ok && !v {
+		t.Errorf("historical: unconditional visible grant should keep assignee visible, got hidden")
+	}
+}

--- a/internal/affordances/historical_test.go
+++ b/internal/affordances/historical_test.go
@@ -129,6 +129,73 @@ assignments:
 	}
 }
 
+// RR (role-resolution leak): under the historical marker, a type that ANY role
+// gates with `visible:` gets a TYPE-LEVEL closed-world, so a reader who resolves
+// to FEWER roles historically (e.g. a local role dropped because it was
+// conferred by a now-untrusted live edge) fails closed to hidden instead of
+// defaulting to all-visible. Here alice holds NO global role, so the historical
+// role set is empty — every field must be hidden, not shown.
+func TestHistorical_TypeLevelClosedWorld_EmptyRoleSet(t *testing.T) {
+	t.Parallel()
+	p := policyFromYAML(t, `
+roles:
+  owner:
+    visible:
+      ticket:
+        - field: title
+assignments:
+  bob: owner
+`)
+	r, err := affordances.New(testMeta(t), newStubLookup(), declFor(t, p))
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	// alice has no role at all. LIVE read: no role declares a visible: block for
+	// her → closed-world never opts in → all fields visible (protected by the
+	// row gate live, not field redaction).
+	fvLive := r.FieldVerdicts(ctxAs("alice"), ticket("T-1", nil))
+	if v, ok := fvLive.Visible["priority"]; ok && !v {
+		t.Errorf("live, no role: priority should default visible, got hidden")
+	}
+
+	// HISTORICAL read: ticket has a visible: block (declared by owner), so the
+	// type-level closed-world opts in even though alice holds no role → every
+	// field in the universe is hidden.
+	fvHist := r.FieldVerdicts(affordances.WithHistoricalSubject(ctxAs("alice")), ticket("T-1", nil))
+	if v, ok := fvHist.Visible["priority"]; !ok || v {
+		t.Errorf("historical, no role: priority must fail closed (hidden), got ok=%v v=%v", ok, v)
+	}
+	if v, ok := fvHist.Visible["title"]; !ok || v {
+		t.Errorf("historical, no role: title must fail closed (hidden), got ok=%v v=%v", ok, v)
+	}
+}
+
+// The historical marker is INERT for a type no role gates with `visible:` —
+// there is nothing to fail closed, so redaction matches live (all visible). This
+// guards against the type-level closed-world over-firing on unredacted types.
+func TestHistorical_NoVisiblePolicyForType_MarkerInert(t *testing.T) {
+	t.Parallel()
+	p := policyFromYAML(t, `
+roles:
+  triager:
+    fields:
+      ticket:
+        - field: status
+assignments:
+  alice: triager
+`)
+	r, err := affordances.New(testMeta(t), newStubLookup(), declFor(t, p))
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	// No visible: block anywhere → historical marker changes nothing.
+	fv := r.FieldVerdicts(affordances.WithHistoricalSubject(ctxAs("alice")), ticket("T-1", nil))
+	if v, ok := fv.Visible["priority"]; ok && !v {
+		t.Errorf("no visible policy: historical marker must be inert, priority hidden unexpectedly")
+	}
+}
+
 // Scenario 7: a visible: grant that references a property the frozen record
 // does not carry (e.g. today's policy references a since-renamed/removed
 // property) binds that property as Nil (DR-C2 coerce-not-fail), the predicate

--- a/internal/affordances/resolver.go
+++ b/internal/affordances/resolver.go
@@ -70,6 +70,13 @@ type PolicyResolver struct {
 
 	// grants is indexed by (role, entityType) → compiled grant blocks.
 	grants map[grantKey]*compiledGrants
+
+	// typesWithVisible records entity types for which ANY role declares a
+	// `visible:` block. Under the historical marker ([WithHistoricalSubject])
+	// such a type gets a type-level closed-world so a reader whose live roles
+	// were reduced to globals-only (see resolveViaDeclarative) fails closed
+	// rather than defaulting to all-visible (TKT-73C6B2).
+	typesWithVisible map[string]bool
 }
 
 type grantKey struct {
@@ -130,12 +137,13 @@ func New(
 	}
 	policy := declarative.Policy()
 	r := &PolicyResolver{
-		policy:      policy,
-		meta:        meta,
-		lookup:      lookup,
-		declarative: declarative,
-		envs:        map[string]*predicate.Env{},
-		grants:      map[grantKey]*compiledGrants{},
+		policy:           policy,
+		meta:             meta,
+		lookup:           lookup,
+		declarative:      declarative,
+		envs:             map[string]*predicate.Env{},
+		grants:           map[grantKey]*compiledGrants{},
+		typesWithVisible: map[string]bool{},
 	}
 	if policy == nil {
 		return r, nil
@@ -224,6 +232,7 @@ func (r *PolicyResolver) compileRole(roleName string, role acl.RoleDef) []error 
 	for et, grants := range role.Visible {
 		g := get(et)
 		g.declaredVisible = true
+		r.typesWithVisible[et] = true
 		errs = append(errs, r.compileFieldBlock(roleName, et, "visible", grants, &g.visible)...)
 	}
 	for et, grants := range role.Options {
@@ -353,28 +362,44 @@ func (r *PolicyResolver) FieldVerdicts(ctx context.Context, e *entity.Entity) Fi
 	if e == nil || r.policy == nil {
 		return out
 	}
-	bc, roles := r.bindingFor(ctx, e)
-	if bc == nil {
-		return out
-	}
 
 	writable := newDimension()
 	visible := newDimension()
 	options := newOptionDimension()
 
-	for _, role := range roles {
-		g := r.grants[grantKey{role, e.Type}]
-		if g == nil {
-			continue
-		}
-		if g.declaredFields {
-			r.applyFieldGrants(ctx, bc, role, "read-only", g.fields, writable)
-		}
-		if g.declaredVisible {
-			r.applyFieldGrants(ctx, bc, role, "hidden", g.visible, visible)
-		}
-		if g.declaredOptions {
-			r.applyOptionGrants(ctx, bc, role, g.options, options)
+	// Historical type-level closed-world (TKT-73C6B2): when serializing a
+	// snapshot of a type that ANY role gates with `visible:`, force the visible
+	// dimension to opt in up front. Ordinarily the `visible:` closed-world is
+	// role-scoped — it bites only for roles the reader holds that declare a
+	// block, so a reader with no such role sees all fields and is protected only
+	// by the row-level read gate. For history that is not enough: the reader's
+	// live roles are reduced to globals-only (resolveViaDeclarative), which can
+	// drop the very role that declared the block, and the reduced set would
+	// otherwise default to all-visible — leaking a field that was redacted at
+	// write time. Opting in here means every field not affirmatively granted
+	// visible by a globally-held role is hidden. Deliberately stricter than a
+	// live read; a holder of acl.PermHistoryReadRedacted bypasses redaction
+	// entirely at the handler.
+	if isHistoricalSubject(ctx) && r.typesWithVisible[e.Type] {
+		visible.optIn("hidden")
+	}
+
+	bc, roles := r.bindingFor(ctx, e)
+	if bc != nil {
+		for _, role := range roles {
+			g := r.grants[grantKey{role, e.Type}]
+			if g == nil {
+				continue
+			}
+			if g.declaredFields {
+				r.applyFieldGrants(ctx, bc, role, "read-only", g.fields, writable)
+			}
+			if g.declaredVisible {
+				r.applyFieldGrants(ctx, bc, role, "hidden", g.visible, visible)
+			}
+			if g.declaredOptions {
+				r.applyOptionGrants(ctx, bc, role, g.options, options)
+			}
 		}
 	}
 
@@ -603,7 +628,24 @@ func (r *PolicyResolver) resolveViaDeclarative(
 	for _, a := range gr.Attributions {
 		global[a.Role] = true
 	}
-	attrs := req.ForEntity(ctx, e.Type, e.ID)
+	// For a HISTORICAL subject ([WithHistoricalSubject]) the effective role set
+	// is GLOBALS-ONLY: local roles (conferred by live `role_relations` edges)
+	// and ancestor-conferred roles (via `inherit_roles_through` containment) are
+	// resolved by ForEntity against the LIVE graph, which no longer describes
+	// the entity as-of-version. Trusting them would let a role newly conferred
+	// after capture flip a `visible:` grant OPEN in an old snapshot — both by
+	// SELECTING which roles' grant blocks apply and by feeding has_role. Globals
+	// are assignment-based (reader-side), so they are the safe tier. Dropping to
+	// globals-only can leave a reader with FEWER roles than live; the type-level
+	// historical closed-world in [PolicyResolver.FieldVerdicts] compensates so
+	// the reduced role set fails closed rather than defaulting to all-visible
+	// (TKT-73C6B2 / RR — the role-resolution leak).
+	var attrs []acl.RoleAttribution
+	if isHistoricalSubject(ctx) {
+		attrs = gr.Attributions
+	} else {
+		attrs = req.ForEntity(ctx, e.Type, e.ID)
+	}
 	seen := make(map[string]bool, len(attrs))
 	roles = make([]string, 0, len(attrs))
 	for _, a := range attrs {

--- a/internal/affordances/resolver_test.go
+++ b/internal/affordances/resolver_test.go
@@ -94,10 +94,8 @@ func declFor(t *testing.T, p *acl.Policy) *acl.Declarative {
 }
 
 // ctxAs builds a request context for the named principal. user varies
-// across the table even where current tests happen to use one value;
-// keeping it explicit documents which principal each case exercises.
-//
-//nolint:unparam // user is intentionally explicit per-test
+// across the table (e.g. the TKT-73C6B2 historical tests exercise
+// "auditor"/"bob"), documenting which principal each case exercises.
 func ctxAs(user string) context.Context {
 	return principal.With(context.Background(),
 		principal.Principal{User: user, Tool: principal.ToolDataEntry})

--- a/internal/dataentry/affordances_policy_test.go
+++ b/internal/dataentry/affordances_policy_test.go
@@ -53,6 +53,7 @@ func patchAs(t *testing.T, app *App, user, id, body string) (status int, respBod
 	return rec.Code, rec.Body.String()
 }
 
+//nolint:unparam // user is intentionally explicit per-test (documents the principal each case exercises)
 func getAs(t *testing.T, app *App, user, id string) v1.Entity {
 	t.Helper()
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/tickets/"+id, http.NoBody)

--- a/internal/dataentry/entityserializer.go
+++ b/internal/dataentry/entityserializer.go
@@ -119,6 +119,22 @@ func (s entitySerializer) forWire(
 	return result
 }
 
+// forWireHistoricalReveal renders a historical snapshot for an audit reader
+// holding acl.PermHistoryReadRedacted (TKT-73C6B2): it SKIPS
+// stripHiddenProperties entirely, emitting every frozen field — OVERRIDE
+// semantics, the field-grained sibling of acl.PermHistoryRead's all-or-nothing
+// audit power. This is the ONLY serializer path that intentionally does not
+// strip; every ordinary read path (forWire / forWireRelated) strips. Callers
+// MUST gate this on the permission (the history handler does) — it is not a
+// general-purpose entry point. No `_fields` / `_relations` affordance maps: a
+// historical snapshot is read-only, and those maps describe live-edit
+// affordances that don't apply to a past version.
+func (s entitySerializer) forWireHistoricalReveal(
+	ctx context.Context, e *entityPkg.Entity, meta *metamodel.Metamodel, plural string,
+) v1.Entity {
+	return s.toV1(ctx, e, nil, nil, nil, meta, plural)
+}
+
 // forWireRelated renders an entity that is NOT the per-entity response root —
 // list rows, `?include=*` peers, search-result include map. Strips hidden
 // properties but omits the `_fields` / `_relations` maps (those ride on

--- a/internal/dataentry/entityserializer.go
+++ b/internal/dataentry/entityserializer.go
@@ -126,9 +126,13 @@ func (s entitySerializer) forWire(
 // audit power. This is the ONLY serializer path that intentionally does not
 // strip; every ordinary read path (forWire / forWireRelated) strips. Callers
 // MUST gate this on the permission (the history handler does) — it is not a
-// general-purpose entry point. No `_fields` / `_relations` affordance maps: a
-// historical snapshot is read-only, and those maps describe live-edit
-// affordances that don't apply to a past version.
+// general-purpose entry point. It omits the `_fields` / `_relations` affordance
+// maps (those ride only on forWire, the per-entity live shape). It does carry
+// the base `_actions` map from toV1 — computed against the LIVE graph, so on a
+// snapshot it is at best advisory and, for a deleted entity, describes write
+// affordances that no longer apply; it is a boolean UI hint, not a data leak,
+// and the server re-authorizes every write regardless. The ordinary
+// (non-reveal) history path shares that same toV1-`_actions` property.
 func (s entitySerializer) forWireHistoricalReveal(
 	ctx context.Context, e *entityPkg.Entity, meta *metamodel.Metamodel, plural string,
 ) v1.Entity {

--- a/internal/dataentry/history_handler.go
+++ b/internal/dataentry/history_handler.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 
 	"github.com/Sourcehaven-BV/rela/internal/acl"
+	"github.com/Sourcehaven-BV/rela/internal/affordances"
+	v1 "github.com/Sourcehaven-BV/rela/internal/apiwire/v1"
 	entityPkg "github.com/Sourcehaven-BV/rela/internal/entity"
 	"github.com/Sourcehaven-BV/rela/internal/store"
 )
@@ -191,12 +193,24 @@ func serveHistoryVersion(a *App,
 	// serializer so field-level redaction (stripHiddenProperties) applies — a
 	// raw snapshot would leak `visible:`-denied properties (RR-YDMJV7).
 	//
-	// KNOWN LIMITATION (RR-TPATBK): redaction runs against the LIVE ACL context
-	// (relations, roles), not the context as-of the version. For unconditional
-	// per-type `visible:` grants this is exactly correct; for relation- or
-	// property-CONDITIONED grants a deleted entity's snapshot may under-redact.
-	// The sound fix is to freeze the visibility verdict at capture time (like
-	// the stored schema projection) — tracked as a follow-up.
+	// Historical redaction FAILS CLOSED (TKT-73C6B2). Two reader tiers:
+	//
+	//   - Ordinary reader: the ctx is marked historical-subject, so a conditional
+	//     `visible:` grant whose subject-world inputs (has_relation /
+	//     count_relations) can't be affirmed for this possibly-deleted/drifted
+	//     entity evaluates false and HIDES the field. The live store no longer
+	//     holds the entity's as-of-version edges, so trusting it would let such a
+	//     grant flip OPEN and leak a field hidden at write time (the old
+	//     RR-TPATBK under-redaction). Reader-side inputs stay live (per-reader
+	//     redaction is intended).
+	//
+	//   - Holder of acl.PermHistoryReadRedacted (audit super-user): bypass the
+	//     strip entirely via forWireHistoricalReveal — sees ALL frozen fields
+	//     (OVERRIDE semantics, sibling of PermHistoryRead). Skipping only the
+	//     historical marker would NOT be enough: the ordinary live strip would
+	//     still run and hide fields the live policy redacts, which is not the
+	//     all-or-nothing reveal this permission grants.
+	ctx := r.Context()
 	snapEntity := entityPkg.New(entityID, snap.Type)
 	snapEntity.Content = snap.Content
 	snapEntity.Properties = cloneProps(snap.Properties) // N1: don't alias the snapshot map
@@ -205,7 +219,12 @@ func serveHistoryVersion(a *App,
 	if def, ok := meta.GetEntityDef(snap.Type); ok {
 		plural = def.GetPlural(snap.Type)
 	}
-	wire := a.serializer.forWire(r.Context(), snapEntity, nil, meta, plural)
+	var wire v1.Entity
+	if readGateFromContext(ctx).HoldsPermission(ctx, acl.PermHistoryReadRedacted) {
+		wire = a.serializer.forWireHistoricalReveal(ctx, snapEntity, meta, plural)
+	} else {
+		wire = a.serializer.forWire(affordances.WithHistoricalSubject(ctx), snapEntity, nil, meta, plural)
+	}
 
 	writeV1JSON(w, http.StatusOK, map[string]any{
 		"id":         entityID,

--- a/internal/dataentry/history_handler_test.go
+++ b/internal/dataentry/history_handler_test.go
@@ -40,9 +40,14 @@ func (h historyStore) GetVersion(_ context.Context, id string, version int) (*st
 	return &s, nil
 }
 
-func snapshot(version int, typ, content string, props map[string]any) store.VersionSnapshot {
+// snapshot builds a version-1 create snapshot. Version is fixed at 1 (every
+// caller uses a single-version timeline); typ stays an explicit parameter to
+// document each case's entity type and keep the cross-type test readable.
+//
+//nolint:unparam // typ is intentionally explicit per-test
+func snapshot(typ, content string, props map[string]any) store.VersionSnapshot {
 	return store.VersionSnapshot{
-		VersionMeta: store.VersionMeta{Version: version, Op: store.VersionOpCreate, Type: typ},
+		VersionMeta: store.VersionMeta{Version: 1, Op: store.VersionOpCreate, Type: typ},
 		Content:     content,
 		Properties:  props,
 		Projection:  []byte(`{}`),
@@ -129,7 +134,7 @@ func TestHandleV1History_CrossTypeIs404(t *testing.T) {
 	app := newAppFromParts(nil, testMeta(), f)
 	app.versions = historyStore{
 		versions: map[string][]store.VersionSnapshot{
-			"TKT-SECRET": {snapshot(1, "ticket", "body", map[string]any{"title": "secret ticket"})},
+			"TKT-SECRET": {snapshot("ticket", "body", map[string]any{"title": "secret ticket"})},
 		},
 	}
 

--- a/internal/dataentry/history_redaction_test.go
+++ b/internal/dataentry/history_redaction_test.go
@@ -1,0 +1,160 @@
+package dataentry
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Sourcehaven-BV/rela/internal/acl"
+	v1 "github.com/Sourcehaven-BV/rela/internal/apiwire/v1"
+	"github.com/Sourcehaven-BV/rela/internal/entity"
+	"github.com/Sourcehaven-BV/rela/internal/principal"
+	"github.com/Sourcehaven-BV/rela/internal/search"
+	"github.com/Sourcehaven-BV/rela/internal/store"
+)
+
+// permGate is a readGate that grants a configurable SET of named permissions
+// (unlike fakeGate's single bool), so the two history permissions
+// (history:read and history:read-redacted) can be granted independently. Reads
+// are permitted (the live entity path), matching an authorized reader.
+type permGate struct {
+	perms map[string]bool
+}
+
+func (g permGate) PermitsRead(context.Context, string, string) (bool, error) { return true, nil }
+
+func (g permGate) PermitsReadMany(_ context.Context, _ string, ids []string) (map[string]bool, error) {
+	m := make(map[string]bool, len(ids))
+	for _, id := range ids {
+		m[id] = true
+	}
+	return m, nil
+}
+
+func (g permGate) ReadQuery(context.Context, string) acl.ReadQueryResult {
+	return acl.ReadQueryResult{AllowAll: true}
+}
+
+func (g permGate) SearchScope(context.Context, []string) map[string]search.TypeScope {
+	return map[string]search.TypeScope{search.WildcardType: {AllowAll: true}}
+}
+
+func (g permGate) HoldsPermission(_ context.Context, perm string) bool { return g.perms[perm] }
+
+// getHistoryVersion drives serveHistoryVersion via handleV1History for version 1
+// of id, under the given principal and read gate.
+func getHistoryVersion(app *App, user, typeName, id string, gate readGate) *httptest.ResponseRecorder {
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/_history/"+typeName+"/"+id+"/1", http.NoBody)
+	ctx := principal.With(req.Context(),
+		principal.Principal{User: user, Tool: principal.ToolDataEntry})
+	ctx = withReadGate(ctx, gate)
+	req = req.WithContext(ctx)
+	rec := httptest.NewRecorder()
+	handleV1History(app, rec, req)
+	return rec
+}
+
+func decodeHistoryEntity(t *testing.T, rec *httptest.ResponseRecorder) v1.Entity {
+	t.Helper()
+	if rec.Code != http.StatusOK {
+		t.Fatalf("history version: got %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	var resp struct {
+		Entity v1.Entity `json:"entity"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode history version: %v", err)
+	}
+	return resp.Entity
+}
+
+// TKT-73C6B2 — the conditional-visible policy shared by the redaction tests:
+// `priority` is visible only when the entity has an outgoing `depends_on` edge (a
+// subject-world condition). Live, with the edge present, it shows; in history
+// the marker neuters the lookup so it fails closed.
+const historyRedactionACL = `
+roles:
+  triager:
+    read:
+      - ticket
+    visible:
+      ticket:
+        - field: title
+        - field: status
+        - field: priority
+          when: "has_relation(entity, 'depends_on')"
+assignments:
+  alice: triager
+`
+
+// Scenario 1/2 (fail closed): a has_relation-gated visible field that is shown
+// on the LIVE entity (edge present) is HIDDEN in the historical snapshot — the
+// marker neuters the subject-world lookup so the grant can't be affirmed. This
+// holds even though the live store STILL has the edge, which is exactly the
+// leak the design prevents (a deleted/drifted entity would have no edge, and we
+// must not trust the live store either way).
+func TestHistoryRedaction_SubjectConditional_FailsClosed(t *testing.T) {
+	app := buildPolicyApp(t, historyRedactionACL, nil)
+	seedEntity(app, &entity.Entity{
+		ID:         "TKT-001",
+		Type:       "ticket",
+		Properties: map[string]any{"title": "t", "priority": "high", "status": "open"},
+	})
+	// Live edge present → the grant passes on a LIVE read.
+	if _, err := app.store.CreateRelation(context.Background(),
+		"TKT-001", "depends_on", "TKT-002", nil); err != nil {
+		t.Fatalf("CreateRelation: %v", err)
+	}
+	app.versions = historyStore{
+		versions: map[string][]store.VersionSnapshot{
+			"TKT-001": {snapshot(1, "ticket", "body",
+				map[string]any{"title": "t", "priority": "high", "status": "open"})},
+		},
+	}
+
+	// Sanity: LIVE read shows priority (edge present, grant passes).
+	live := getAs(t, app, "alice", "TKT-001")
+	if _, ok := live.Properties["priority"]; !ok {
+		t.Fatalf("live read should expose priority (depends_on edge present); props=%v", live.Properties)
+	}
+
+	// Historical read (no reveal permission): priority must be stripped.
+	gate := permGate{perms: map[string]bool{acl.PermHistoryRead: true}}
+	hist := decodeHistoryEntity(t, getHistoryVersion(app, "alice", "ticket", "TKT-001", gate))
+	if _, ok := hist.Properties["priority"]; ok {
+		t.Errorf("historical read must fail closed: priority should be stripped, got %v", hist.Properties["priority"])
+	}
+	// Non-conditional fields remain.
+	if _, ok := hist.Properties["title"]; !ok {
+		t.Errorf("historical read stripped a non-hidden field (title); props=%v", hist.Properties)
+	}
+}
+
+// Scenario 2/4 (reveal): a holder of history:read-redacted sees the frozen
+// field the ordinary reader has redacted — OVERRIDE semantics.
+func TestHistoryRedaction_RevealPermission_ShowsFrozenField(t *testing.T) {
+	app := buildPolicyApp(t, historyRedactionACL, nil)
+	seedEntity(app, &entity.Entity{
+		ID:         "TKT-001",
+		Type:       "ticket",
+		Properties: map[string]any{"title": "t", "priority": "high", "status": "open"},
+	})
+	app.versions = historyStore{
+		versions: map[string][]store.VersionSnapshot{
+			"TKT-001": {snapshot(1, "ticket", "body",
+				map[string]any{"title": "t", "priority": "high", "status": "open"})},
+		},
+	}
+
+	// With history:read-redacted the marker is skipped → priority revealed.
+	gate := permGate{perms: map[string]bool{
+		acl.PermHistoryRead:         true,
+		acl.PermHistoryReadRedacted: true,
+	}}
+	hist := decodeHistoryEntity(t, getHistoryVersion(app, "alice", "ticket", "TKT-001", gate))
+	if got, ok := hist.Properties["priority"]; !ok || got != "high" {
+		t.Errorf("reveal: priority should be present=high, got ok=%v v=%v", ok, got)
+	}
+}

--- a/internal/dataentry/history_redaction_test.go
+++ b/internal/dataentry/history_redaction_test.go
@@ -109,7 +109,7 @@ func TestHistoryRedaction_SubjectConditional_FailsClosed(t *testing.T) {
 	}
 	app.versions = historyStore{
 		versions: map[string][]store.VersionSnapshot{
-			"TKT-001": {snapshot(1, "ticket", "body",
+			"TKT-001": {snapshot("ticket", "body",
 				map[string]any{"title": "t", "priority": "high", "status": "open"})},
 		},
 	}
@@ -132,6 +132,64 @@ func TestHistoryRedaction_SubjectConditional_FailsClosed(t *testing.T) {
 	}
 }
 
+// C1 regression (RR — the role-resolution leak): a `visible:` grant on a role
+// conferred by a LIVE role-relation edge (`role_relations`) must ALSO fail
+// closed in history. The subject-world neutering has to reach role resolution,
+// not just has_relation/count_relations — otherwise a role newly conferred
+// after capture (a reassignment) selects a `visible:` block that reveals a
+// field hidden when the version was written. Globals-only under the historical
+// marker is the fix.
+func TestHistoryRedaction_LocalRoleConferred_FailsClosed(t *testing.T) {
+	const aclYAML = `
+roles:
+  owner:
+    read:
+      - ticket
+    visible:
+      ticket:
+        - field: title
+        - field: status
+        - field: priority
+role_relations:
+  owns:
+    confers: owner
+`
+	app := buildPolicyApp(t, aclYAML, nil)
+	seedEntity(app, &entity.Entity{
+		ID:         "TKT-001",
+		Type:       "ticket",
+		Properties: map[string]any{"title": "t", "priority": "high", "status": "open"},
+	})
+	// Live edge alice --owns--> TKT-001 confers `owner` on alice for this entity.
+	if _, err := app.store.CreateRelation(context.Background(),
+		"alice", "owns", "TKT-001", nil); err != nil {
+		t.Fatalf("CreateRelation: %v", err)
+	}
+	app.versions = historyStore{
+		versions: map[string][]store.VersionSnapshot{
+			"TKT-001": {snapshot("ticket", "body",
+				map[string]any{"title": "t", "priority": "high", "status": "open"})},
+		},
+	}
+
+	// Sanity: LIVE read confers owner via the edge → priority visible.
+	live := getAs(t, app, "alice", "TKT-001")
+	if _, ok := live.Properties["priority"]; !ok {
+		t.Fatalf("live read should confer owner and expose priority; props=%v", live.Properties)
+	}
+
+	// Historical read (no reveal permission): the owner role is conferred by a
+	// LIVE edge, but historical resolution is globals-only → alice holds no
+	// role that grants `priority` → it must be stripped. Before the C1 fix this
+	// leaked (owner selected against the live edge).
+	gate := permGate{perms: map[string]bool{acl.PermHistoryRead: true}}
+	hist := decodeHistoryEntity(t, getHistoryVersion(app, "alice", "ticket", "TKT-001", gate))
+	if _, ok := hist.Properties["priority"]; ok {
+		t.Errorf("historical read must fail closed on local-role-conferred visibility: priority should be stripped, got %v",
+			hist.Properties["priority"])
+	}
+}
+
 // Scenario 2/4 (reveal): a holder of history:read-redacted sees the frozen
 // field the ordinary reader has redacted — OVERRIDE semantics.
 func TestHistoryRedaction_RevealPermission_ShowsFrozenField(t *testing.T) {
@@ -143,7 +201,7 @@ func TestHistoryRedaction_RevealPermission_ShowsFrozenField(t *testing.T) {
 	})
 	app.versions = historyStore{
 		versions: map[string][]store.VersionSnapshot{
-			"TKT-001": {snapshot(1, "ticket", "body",
+			"TKT-001": {snapshot("ticket", "body",
 				map[string]any{"title": "t", "priority": "high", "status": "open"})},
 		},
 	}

--- a/internal/dataentry/relation_history_handler.go
+++ b/internal/dataentry/relation_history_handler.go
@@ -265,6 +265,13 @@ func serveRelationHistoryVersion(
 		writeGateError(w, r, err)
 		return
 	}
+	// Relation meta is emitted RAW: relations have no field-level `visible:`
+	// redaction today (TKT-B1F5Q1). When B1F5Q1 adds a relation strip step, it
+	// MUST wrap this snapshot's ctx in affordances.WithHistoricalSubject (unless
+	// the reader holds acl.PermHistoryReadRedacted) so relation history inherits
+	// the same deny-by-default fail-closed rule the entity path uses
+	// (serveHistoryVersion, TKT-73C6B2). There is nothing to gate until then —
+	// no `visible:` grant is evaluated on this path.
 	row := map[string]any{
 		"from": snap.From, "type": snap.Type, "to": snap.To,
 		"content": snap.Content, "meta": snap.Properties,

--- a/tickets/entities/docs-checklists/DOCS-73C6B2.md
+++ b/tickets/entities/docs-checklists/DOCS-73C6B2.md
@@ -1,0 +1,26 @@
+---
+id: DOCS-73C6B2
+type: docs-checklist
+title: 'Docs: historical redaction fails closed'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Code Documentation
+
+- [x] Godoc on `acl.PermHistoryReadRedacted`, `affordances.WithHistoricalSubject` (describes the complete neutering: outgoingCounts, globals-only role resolution, type-level closed-world), `PolicyResolver.typesWithVisible`, `forWireHistoricalReveal`, and the `serveHistoryVersion` two-tier branch
+- [x] ~~CLAUDE.md pattern update~~ (N/A: reuses existing ACL/serializer patterns; no new cross-cutting rule)
+
+## Project Documentation
+
+- [x] `docs/acl-security.md` (via docs-project GUIDE-acl-security source, regenerated): new "Historical field redaction fails closed (`history:read-redacted`)" subsection — the invariant, the deny-by-default rule, globals-only + type-level closed-world, and OVERRIDE reveal semantics
+- [x] Relation-history seam documented in `relation_history_handler.go` for TKT-B1F5Q1 to inherit the rule
+
+## External Documentation
+
+- [x] ~~README / external docs~~ (N/A: security-hardening guide is the operator-facing surface, updated above)
+
+**Docs verified:** acl-security.md regenerated with no unintended drift; the
+documented invariant matches the implemented fail-closed behavior including the
+role-resolution path (RR-73CA).

--- a/tickets/entities/implementation-checklists/IMPL-73C6B2.md
+++ b/tickets/entities/implementation-checklists/IMPL-73C6B2.md
@@ -1,0 +1,25 @@
+---
+id: IMPL-73C6B2
+type: implementation-checklist
+title: 'Implementation: historical redaction fails closed'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Development
+
+- [x] `acl.PermHistoryReadRedacted = "history:read-redacted"` constant beside PermHistoryRead; free-form permission (no registry) — grantable via a role's `permissions:` list
+- [x] `affordances.WithHistoricalSubject(ctx)` marker + `isHistoricalSubject`; `bindings.outgoingCounts` returns no edges under the marker so has_relation/count_relations fail closed
+- [x] Role resolution under the marker is globals-only (resolveViaDeclarative skips ForEntity's live local/ancestor probes); FieldVerdicts applies a type-level closed-world (typesWithVisible) so a reduced role set fails closed, not all-visible (RR-73CA)
+- [x] `serveHistoryVersion`: ordinary reader → historical marker + forWire (fail closed); `history:read-redacted` holder → `forWireHistoricalReveal` (skips strip, OVERRIDE reveal)
+- [x] `forWireHistoricalReveal` serializer path (toV1 without stripHiddenProperties), gated by the handler on the reveal permission
+- [x] Relation history handler: comment marking the seam so TKT-B1F5Q1 wires the same fail-closed rule when it adds relation `visible:`
+- [x] Docs: `history:read-redacted` section in GUIDE-acl-security (regenerated to docs/acl-security.md)
+
+## Quality
+
+- [x] `just lint` clean; `just arch-lint` clean (no new package boundary)
+- [x] `just coverage-check` PASS (76.8% total)
+- [x] Default + `-tags postgres` builds green (bleve/pgx separation intact)
+- [x] Full default suite green; touched packages + DB-gated pgstore suite green under postgres tag

--- a/tickets/entities/review-checklists/REV-73C6B2.md
+++ b/tickets/entities/review-checklists/REV-73C6B2.md
@@ -1,0 +1,53 @@
+---
+id: REV-73C6B2
+type: review-checklist
+title: 'Review: historical redaction fails closed'
+status: in-progress
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Automated Checks
+
+- [x] `just lint` clean; `just arch-lint` clean
+- [x] `just coverage-check` PASS (76.9% total)
+- [x] Default + `-tags postgres` builds green; full default suite green; touched packages + DB-gated pgstore suite green under postgres tag
+
+## Code Review
+
+- [x] Run `/code-review` command (cranky-code-reviewer)
+- [x] All critical review-responses addressed (RR-73CA — role-resolution leak: globals-only historical role resolution + type-level closed-world)
+- [x] All significant review-responses addressed (RR-73CB docs over-promise; RR-73CC missing role-relation negative test)
+- [x] Minor/nit addressed or dispositioned (RR-73CD _actions comment fixed; RR-73CE bool-payload wont-fix with reason)
+- [x] Self-reviewed the diff for unrelated changes
+
+**Review Responses:** RR-73CA (critical, addressed), RR-73CB (significant, addressed), RR-73CC (significant, addressed), RR-73CD (minor, addressed), RR-73CE (nit, wont-fix)
+
+## Acceptance Verification
+
+- [x] Subject-conditional (has_relation/count_relations) grant fails closed in history — PASS (TestHistoryRedaction_SubjectConditional_FailsClosed, TestHistorical_HasRelationVisible/CountRelations)
+- [x] Local/ancestor-role-conferred visibility fails closed in history — PASS (TestHistoryRedaction_LocalRoleConferred_FailsClosed, TestHistorical_TypeLevelClosedWorld_EmptyRoleSet)
+- [x] Reader-side inputs stay live; per-reader + reader-promoted correct — PASS (TestHistorical_ReaderSideGrant_Unaffected)
+- [x] `history:read-redacted` holder sees all frozen fields (OVERRIDE) — PASS (TestHistoryRedaction_RevealPermission_ShowsFrozenField)
+- [x] Since-removed referenced property fails closed — PASS (TestHistorical_MissingReferencedProperty_FailsClosed)
+- [x] Marker inert for a type with no visible: policy — PASS (TestHistorical_NoVisiblePolicyForType_MarkerInert)
+- [x] ~~Relation-history scenario 6~~ (N/A: deferred to TKT-B1F5Q1; seam comment left in relation_history_handler.go)
+
+## Documentation (enhancements only)
+
+- [x] `history:read-redacted` documented in GUIDE-acl-security (regenerated to docs/acl-security.md); code comments describe the complete neutering
+- [x] ~~Docs-checklist~~ (N/A: doc source updated inline; no separate external-docs surface)
+
+## Final Checks
+
+- [x] Commit message explains the why
+- [x] No TODOs/FIXMEs left
+- [x] Ready for another developer to use
+
+## Pull Request
+
+- [ ] Run `/pr` command to create PR and monitor CI
+- [ ] All CI checks pass (monitored post-creation)
+- [ ] PR URL documented below
+
+**PR:** (filled after creation)

--- a/tickets/entities/review-checklists/REV-73C6B2.md
+++ b/tickets/entities/review-checklists/REV-73C6B2.md
@@ -2,7 +2,7 @@
 id: REV-73C6B2
 type: review-checklist
 title: 'Review: historical redaction fails closed'
-status: in-progress
+status: done
 ---
 
 <!-- @managed: claude-workflow v1 -->
@@ -46,8 +46,8 @@ status: in-progress
 
 ## Pull Request
 
-- [ ] Run `/pr` command to create PR and monitor CI
-- [ ] All CI checks pass (monitored post-creation)
-- [ ] PR URL documented below
+- [x] Run `/pr` command to create PR and monitor CI
+- [x] All CI checks pass (monitored post-creation)
+- [x] PR URL documented below
 
 **PR:** (filled after creation)

--- a/tickets/entities/review-checklists/REV-73C6B2.md
+++ b/tickets/entities/review-checklists/REV-73C6B2.md
@@ -50,4 +50,4 @@ status: done
 - [x] All CI checks pass (monitored post-creation)
 - [x] PR URL documented below
 
-**PR:** (filled after creation)
+**PR:** https://github.com/sourcehaven-bv/rela/pull/1236

--- a/tickets/entities/review-responses/RR-73CA.md
+++ b/tickets/entities/review-responses/RR-73CA.md
@@ -1,0 +1,9 @@
+---
+id: RR-73CA
+type: review-response
+title: Fail-closed was incomplete — local/ancestor-conferred visible grants still resolved against the live graph
+finding: 'The historical marker neutered only outgoingCounts (has_relation / count_relations). But bindingFor → resolveViaDeclarative → req.ForEntity walks the LIVE graph (role_relations HasEdge + inherit_roles_through ancestors) to build the effective role set, which both SELECTS which roles'' visible: blocks apply and feeds has_role. For a drifted-but-live entity, a role newly conferred after capture (e.g. a reassignment) selects an unconditional visible: grant that reveals a field hidden when the version was written — a leak, not requiring anyone to write has_role. Every historical test used NullGraph or a policy with zero role_relations, so the leaking path was structurally untestable.'
+severity: critical
+resolution: 'Under the historical marker, resolveViaDeclarative resolves GLOBALS-ONLY (skips ForEntity, uses req.Globals attributions). Because the visible: closed-world is role-scoped, dropping to globals-only could leave a reader with zero roles and default to all-visible — so FieldVerdicts now applies a TYPE-LEVEL closed-world under the marker for any type a role gates with visible: (new typesWithVisible set): a field shows only if a globally-held role affirmatively grants it. Regression tests: TestHistoryRedaction_LocalRoleConferred_FailsClosed (dataentry, real StoreGraph + live owns edge), TestHistorical_TypeLevelClosedWorld_EmptyRoleSet + TestHistorical_NoVisiblePolicyForType_MarkerInert (affordances).'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-73CB.md
+++ b/tickets/entities/review-responses/RR-73CB.md
@@ -1,0 +1,9 @@
+---
+id: RR-73CB
+type: review-response
+title: Docs and comments over-promised the fail-closed guarantee
+finding: 'The commit deleted the honest RR-TPATBK "known limitation" note and replaced it with docs/comments asserting "every grant that would need untrusted subject-world state is hidden" — which was false while the role-resolution path (RR-73CA) still leaked. The WithHistoricalSubject doc also claimed has_role "degrades to globals-only safely for a deleted entity", true only for deleted (no edges), not drifted-but-live entities.'
+severity: significant
+resolution: 'With RR-73CA fixed the guarantee is now true. Updated docs/acl-security.md (via docs-project source, regenerated) and the WithHistoricalSubject / FieldVerdicts / historical.go comments to describe the COMPLETE neutering: outgoingCounts, globals-only role resolution, and the type-level closed-world — with the stated invariant matching the implementation.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-73CC.md
+++ b/tickets/entities/review-responses/RR-73CC.md
@@ -1,0 +1,9 @@
+---
+id: RR-73CC
+type: review-response
+title: No negative test for the role-relation-conferred visibility path
+finding: 'Independent of the fix: there was no test where a visible: grant belongs to a role conferred by a role_relation edge (or inherit_roles_through), the edge is live, and the historical read is asserted to hide the field. Without it the fail-closed guarantee for that path could silently regress — the genuinely-absent scenario in the acceptance list (distinct from the deferred relation-history scenario 6).'
+severity: significant
+resolution: 'Added TestHistoryRedaction_LocalRoleConferred_FailsClosed using the buildPolicyApp harness (real acl.NewStoreGraph) with a role_relations: {owns: {confers: owner}} policy and a live alice--owns-->TKT-001 edge: live read exposes the field, historical read hides it. Plus affordances-level TestHistorical_TypeLevelClosedWorld_EmptyRoleSet pins the empty-role-set fail-closed and TestHistorical_NoVisiblePolicyForType_MarkerInert pins non-over-firing.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-73CD.md
+++ b/tickets/entities/review-responses/RR-73CD.md
@@ -1,0 +1,9 @@
+---
+id: RR-73CD
+type: review-response
+title: Reveal path comment claimed read-only but toV1 still emits _actions
+finding: 'forWireHistoricalReveal → toV1 still calls computeActions against the live, unmarked ctx, so _actions is computed against a graph that (for a deleted entity) no longer describes it. The comment claimed the snapshot is read-only with no affordance maps. Not a data leak (booleans, reveal holder is an auditor, server re-authorizes writes), but the comment was inaccurate. The ordinary non-reveal path has the same toV1-_actions property.'
+severity: minor
+resolution: 'Corrected the forWireHistoricalReveal doc to state it carries the base _actions map from toV1 (advisory-only on a snapshot, a UI hint the server re-authorizes), and that the non-reveal history path shares that property. Left _actions emitting rather than restructuring the shared toV1 — proportionate to a minor cosmetic/accuracy finding.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-73CE.md
+++ b/tickets/entities/review-responses/RR-73CE.md
@@ -1,0 +1,9 @@
+---
+id: RR-73CE
+type: review-response
+title: historicalSubjectKey stores a redundant true payload
+finding: 'context.WithValue(ctx, historicalSubjectKey{}, true) with a bool read works, but the true payload is redundant — presence of the key is the signal. A struct{} marker or != nil check would make it impossible to accidentally store false and read it as not-historical. Cosmetic; current form is correct.'
+severity: nit
+reason: 'Kept as-is. The bool payload is the conventional, readable form and isHistoricalSubject reads it via a comma-ok bool assertion (absent key → false). WithHistoricalSubject is the ONLY writer and always stores true, so the theoretical store-false footgun cannot occur. Not worth a churn.'
+status: wont-fix
+---

--- a/tickets/entities/tickets/TKT-73C6B2.md
+++ b/tickets/entities/tickets/TKT-73C6B2.md
@@ -5,7 +5,7 @@ title: Historical field redaction fails closed — deny-by-default with a histor
 kind: enhancement
 priority: medium
 effort: m
-status: review
+status: done
 ---
 
 Follow-up to TKT-9INY0Y / review finding RR-TPATBK. Design superseded 2026-07-27

--- a/tickets/entities/tickets/TKT-73C6B2.md
+++ b/tickets/entities/tickets/TKT-73C6B2.md
@@ -5,7 +5,7 @@ title: Historical field redaction fails closed — deny-by-default with a histor
 kind: enhancement
 priority: medium
 effort: m
-status: planning
+status: review
 ---
 
 Follow-up to TKT-9INY0Y / review finding RR-TPATBK. Design superseded 2026-07-27
@@ -128,6 +128,14 @@ visible:
 - New permission constant `PermHistoryReadRedacted = "history:read-redacted"`
   beside PermHistoryRead; documented in docs/acl-security.md alongside it.
 - No entity_versions / schema_versions schema change. No capture-path change.
+- FUTURE (RR-73CA/L1): the sounder long-term design is to FREEZE the
+  subject-world (edge/role state) at capture time — like the schema projection
+  — so both edge and role predicates answer as-of-version instead of being
+  blinded. That removes the over-redaction this deny-by-default accepts, and
+  removes the need to enumerate every subject-world input to neuter (the
+  enumeration that originally missed role resolution). Deliberately out of scope
+  here (larger capture-path lift); deny-by-default is the security-complete
+  stopgap.
 
 ## Re-verification (2026-07-25, against develop dd0fe649)
 

--- a/tickets/entities/tickets/TKT-73C6B2.md
+++ b/tickets/entities/tickets/TKT-73C6B2.md
@@ -1,61 +1,145 @@
 ---
 id: TKT-73C6B2
 type: ticket
-title: Freeze field-visibility verdict at version capture so historical redaction is context-correct
+title: Historical field redaction fails closed — deny-by-default with a history:read-redacted reveal permission
 kind: enhancement
 priority: medium
-effort: l
-status: backlog
+effort: m
+status: planning
 ---
 
-Follow-up to TKT-9INY0Y / review finding RR-TPATBK.
+Follow-up to TKT-9INY0Y / review finding RR-TPATBK. Design superseded 2026-07-27
+(see Design decision) — the original "freeze the visibility verdict/inputs at
+capture" framing is REPLACED by deny-by-default + an audit reveal permission.
 
 ## Problem
 
 serveHistoryVersion redacts a historical snapshot by reconstructing an
-*entity.Entity (content + properties only) and running it through the dataentry
-serializer (forWire -> stripHiddenProperties -> FieldVerdicts). But
-FieldVerdicts resolves field visibility against the LIVE ACL context:
-- relation-dependent grants (visible: has_edge(...)) evaluate against the live store's relations — empty for a deleted entity → grant flips;
-- roles come from ForEntity against the live ACL graph — for a deleted entity only 'everyone' resolves → role-scoped hidden fields un-hide.
+*entity.Entity and running it through the dataentry serializer (forWire ->
+stripHiddenProperties -> FieldVerdicts). FieldVerdicts resolves field visibility
+against the LIVE ACL context, which no longer matches the moment the version was
+captured:
+
+- relation-dependent grants (`visible: has_relation(...)` / `count_relations(...)`)
+  evaluate against the LIVE store's outgoing edges — empty/changed for a
+  deleted or drifted entity → a grant that was DENIED at write time flips OPEN.
+- the subject-side half of role grants (`has_role(...)`) resolves via `ForEntity`
+  against the live ACL graph — for a deleted entity only `everyone` resolves, so
+  the entity confers no roles and role-gated fields mis-evaluate.
 
 So a field correctly hidden at write time can UNDER-REDACT (leak) in the
-snapshot the moment the policy uses a CONDITIONAL visible: grant. Unconditional
-per-type visible: grants redact correctly today; this ships v1 with that
-documented boundary (docs/acl-security.md + a code comment at
-serveHistoryVersion).
+snapshot the moment the policy uses a CONDITIONAL `visible:` grant. TKT-9E57
+(predicate-backed `_fields` resolver, done) made conditional grants a live
+capability, so this is a real leak, not a hypothetical.
 
-## Fix
+The three inputs to a field verdict, and how history must treat each:
 
-Freeze the field-visibility verdict (or the inputs needed to recompute it) at
-version-capture time and redact the snapshot against THAT — exactly the pattern
-VersionSnapshot.Projection already uses to render against the
-schema-as-of-version. This makes historical redaction correct-by-construction
-and removes the whole 'verdict context mismatch' class.
+| Input | Example binding | History treatment |
+|---|---|---|
+| ACL policy (`visible:` rules) | the `when:` predicate itself | LIVE — today's policy |
+| Reader | `current_user`, roles the reader holds | LIVE — the reader as they are now |
+| Subject-world | entity's own edges / roles it confers (`has_relation`, subject half of `has_role`) | CANNOT be reconstructed for deleted/drifted entities |
+
+The reader-side (Scenario 3/5) is already correct: reader roles are live and
+that IS the intended stance (a promoted reader gains historical visibility). The
+BUG is purely the subject-world: the live store can no longer answer
+"what edges did this entity have at version V", and a conditional grant that
+consults it fails OPEN.
+
+## Design decision (2026-07-27)
+
+Do NOT freeze subject-world inputs at capture. That approach ("replay the world
+as-of-V") is only as safe as our fidelity in capturing every input a predicate
+could touch — a subtle capture bug leaks — and was rejected as too magical.
+
+Instead, **fail closed**: any historical field the current policy cannot
+AFFIRMATIVELY grant `visible` to (including every conditional grant whose
+subject-world inputs cannot be trusted for a historical/deleted entity) is
+HIDDEN by default. Security becomes structural — unknown ⇒ hidden — not
+reconstructed.
+
+Revealing those fields requires a new global named permission
+**`history:read-redacted`**, the field-grained sibling of the existing
+`history:read` (PermHistoryRead, internal/acl/policy.go:44) audit
+super-permission. Semantics are **OVERRIDE** (all-or-nothing, exactly like
+`history:read`): a holder sees ALL frozen historical fields, skipping the strip
+step entirely. Supplement semantics ("only un-hide fields that failed for the
+right reason") were rejected as the same magic we deleted. Granted via a role's
+`permissions:` list like the delegate-X permissions.
+
+The frozen content already CONTAINS every field (`VersionSnapshot.Properties`
+holds the full record; redaction is a serialization-time strip), so the reveal
+is purely "skip the strip for this reader" — NO capture-schema change, no new
+table, no frozen-edge-set.
+
+## Invariant
+
+> Reading version V shows a field to a normal reader only if TODAY's ACL policy
+> affirmatively grants it `visible` against the inputs that can be safely
+> evaluated; every grant that would need untrusted subject-world state fails
+> CLOSED (hidden). A holder of `history:read-redacted` sees all frozen fields.
+
+- Policy → live.  Reader → live.  Subject-world → NOT reconstructed → fail closed.
+
+## Acceptance criteria (scenarios → tests)
+
+Policy under test (conditional field grants):
+
+```yaml
+visible:
+  - field: bonus_note
+    when: not has_relation("reviewed-by")   # subject-side
+  - field: salary
+    when: has_role("hr")                     # reader-side (routed through subject)
+```
+
+1. **Subject edge gone** — V3 captured with a `reviewed-by` edge (bonus_note
+   hidden). Edge later removed. Reading V3 as a normal reader: `bonus_note`
+   HIDDEN (fail closed — the subject-world grant cannot be affirmed). No leak.
+2. **Deleted entity** — entity hard-deleted; normal reader requests V5: every
+   subject-conditional field HIDDEN (fail closed). Reader with
+   `history:read-redacted`: all fields shown.
+3. **Reader-side role, two readers** — V2, `salary` grant `has_role("hr")`. HR
+   reader: salary VISIBLE (live reader role). Plain viewer: HIDDEN. Same version,
+   per-reader — reader side stays live and correct.
+4. **Mixed / over-redaction is acceptable** — `salary` visibility routed through
+   a since-removed subject edge. Normal reader (even one who legitimately held
+   the role via that edge): HIDDEN (fail closed — we do NOT reconstruct the edge;
+   over-redaction is the safe failure). `history:read-redacted` reader: shown.
+5. **Reader promoted after capture** — reader gains `hr` after V1 captured;
+   reading V1 now shows `salary` (reader roles are live — intended). Demotion
+   symmetrically re-hides. (Confirmed acceptable.)
+6. **Relation history (TKT-B1F5Q1)** — same rule for relation `visible:`:
+   relation history fails closed, same `history:read-redacted` reveal.
+7. **Since-removed property** — today's policy references `entity.department`
+   but V's record predates the rename (had `dept`). Frozen record binds
+   `department` as Nil (DR-C2), predicate fails → field HIDDEN (fail closed).
+   Pinned as a test — live policy over a drifted schema over-redacts, never
+   leaks.
 
 ## Notes
 
-- Interacts with the entity_versions capture path (entitymanager version hook + sweep) and the store VersionSnapshot shape.
-- Consider whether to store the full resolved verdict, or the (relations + roles) inputs, or a per-field visible/hidden bitmap.
-- The relation-set-as-of question overlaps with relation history (TKT-VFJKMB).
+- Touch points: serveHistoryVersion redaction (internal/dataentry/history_handler.go
+  ~194-208 → entityserializer.go:117 → affordances.go:895 stripHiddenProperties);
+  the resolver's fail-closed behavior (internal/affordances/resolver.go passes()
+  already fails closed on predicate error — the work is ensuring subject-world
+  bindings for a historical/deleted entity route to that fail-closed path rather
+  than to a live-store lookup that silently returns "no edges" → grant flips).
+- New permission constant `PermHistoryReadRedacted = "history:read-redacted"`
+  beside PermHistoryRead; documented in docs/acl-security.md alongside it.
+- No entity_versions / schema_versions schema change. No capture-path change.
 
 ## Re-verification (2026-07-25, against develop dd0fe649)
 
 Premise STILL VALID — and now SHARPER. TKT-9E57 ("predicate-backed _fields
 resolver", done) made the field-visibility resolver genuinely conditional-grant
 capable: `internal/affordances/resolver.go:629-654` evaluates a `When` predicate
-per grant via `prog.Eval`, and the bindings resolve `has_edge`/`count_relations`
+per grant via `prog.Eval`, and the bindings resolve `has_relation`/`count_relations`
 against the LIVE store (`internal/dataentry/affordances_policy.go:96-106`). For a
 deleted entity the live store returns no edges, so a conditional `visible:` grant
-flips at read time — exactly the under-redaction this ticket describes, now a live
-policy capability rather than a hypothetical. History is still redacted at read
-time against the live ACL (`internal/dataentry/history_handler.go:194-208` →
-`entityserializer.go:117` → `affordances.go:895` stripHiddenProperties); the
-capture path stores no frozen verdict (`store.go` VersionSnapshot carries only
-content/properties/schema-projection). This ticket's fix is unimplemented and its
-value went UP with TKT-9E57.
+flips at read time. History is still redacted at read time against the live ACL
+(`internal/dataentry/history_handler.go:194-208`); the capture path stores no
+frozen verdict.
 
-Coupled with TKT-B1F5Q1: both say "build the capture-time freeze with a shared
-design" — 73C6B2 is the entity-side freeze, B1F5Q1 adds relation-side `visible:`
-which needs the same freeze if relation grants are conditional. Design them
-together.
+Coupled with TKT-B1F5Q1 — the relation-side `visible:` — which inherits this
+same deny-by-default + reveal rule. Design them together.

--- a/tickets/entities/tickets/TKT-B1F5Q1.md
+++ b/tickets/entities/tickets/TKT-B1F5Q1.md
@@ -47,11 +47,14 @@ TKT-92JL8P (RR-BZNL0S) at the same time.
 
 ## Interaction with TKT-73C6B2
 
-Freezing the visibility verdict at capture time (TKT-73C6B2) is the entity-side
-correctness fix for CONDITIONAL grants. If relation `visible:` grants can also
-be conditional, the same freeze applies — build these two with a shared design
-so relation history doesn't reintroduce the conditional-grant under-redaction
-hole.
+TKT-73C6B2 makes historical field redaction **fail closed** (deny-by-default;
+any grant whose subject-world inputs cannot be affirmed for a historical/deleted
+entity is hidden, revealed only by the `history:read-redacted` audit permission).
+Its earlier "freeze the visibility verdict at capture" framing was superseded
+2026-07-27 (too magical). Relation `visible:` grants inherit the SAME rule for
+free: relation history fails closed, same reveal permission. Build 73C6B2's
+deny-by-default machinery generically enough that relations plug in — do NOT
+build a relation-specific redaction path.
 
 ## Origin
 

--- a/tickets/relations/TKT-73C6B2--has-docs--DOCS-73C6B2.md
+++ b/tickets/relations/TKT-73C6B2--has-docs--DOCS-73C6B2.md
@@ -1,0 +1,5 @@
+---
+from: TKT-73C6B2
+relation: has-docs
+to: DOCS-73C6B2
+---

--- a/tickets/relations/TKT-73C6B2--has-implementation--IMPL-73C6B2.md
+++ b/tickets/relations/TKT-73C6B2--has-implementation--IMPL-73C6B2.md
@@ -1,0 +1,5 @@
+---
+from: TKT-73C6B2
+relation: has-implementation
+to: IMPL-73C6B2
+---

--- a/tickets/relations/TKT-73C6B2--has-review--REV-73C6B2.md
+++ b/tickets/relations/TKT-73C6B2--has-review--REV-73C6B2.md
@@ -1,0 +1,5 @@
+---
+from: TKT-73C6B2
+relation: has-review
+to: REV-73C6B2
+---

--- a/tickets/relations/TKT-73C6B2--has-review-response--RR-73CA.md
+++ b/tickets/relations/TKT-73C6B2--has-review-response--RR-73CA.md
@@ -1,0 +1,5 @@
+---
+from: TKT-73C6B2
+relation: has-review-response
+to: RR-73CA
+---

--- a/tickets/relations/TKT-73C6B2--has-review-response--RR-73CB.md
+++ b/tickets/relations/TKT-73C6B2--has-review-response--RR-73CB.md
@@ -1,0 +1,5 @@
+---
+from: TKT-73C6B2
+relation: has-review-response
+to: RR-73CB
+---

--- a/tickets/relations/TKT-73C6B2--has-review-response--RR-73CC.md
+++ b/tickets/relations/TKT-73C6B2--has-review-response--RR-73CC.md
@@ -1,0 +1,5 @@
+---
+from: TKT-73C6B2
+relation: has-review-response
+to: RR-73CC
+---

--- a/tickets/relations/TKT-73C6B2--has-review-response--RR-73CD.md
+++ b/tickets/relations/TKT-73C6B2--has-review-response--RR-73CD.md
@@ -1,0 +1,5 @@
+---
+from: TKT-73C6B2
+relation: has-review-response
+to: RR-73CD
+---

--- a/tickets/relations/TKT-73C6B2--has-review-response--RR-73CE.md
+++ b/tickets/relations/TKT-73C6B2--has-review-response--RR-73CE.md
@@ -1,0 +1,5 @@
+---
+from: TKT-73C6B2
+relation: has-review-response
+to: RR-73CE
+---


### PR DESCRIPTION
## Summary

Historical field-visibility redaction now **fails closed** (TKT-73C6B2). A `visible:` grant can be conditional on the subject entity's own graph state (`has_relation` / `count_relations`) or on a role conferred by a live `role_relations` / `inherit_roles_through` edge. History previously evaluated these against the **live** store, so for a deleted/drifted entity a grant DENIED at write time could flip OPEN and leak a field hidden when the version was written.

Under `WithHistoricalSubject` the resolver now neuters every subject-world input:
- `has_relation` / `count_relations` resolve as no edges (via `outgoingCounts`).
- the effective role set is reduced to **globals-only** (skips `ForEntity`'s live local/ancestor probes).
- a type gated by `visible:` gets a **type-level closed-world** so the reduced role set fails closed instead of defaulting to all-visible.

Reader-side inputs (`current_user`, the reader's global roles) stay **live** — per-reader redaction, reader-promoted-gains-visibility is intended.

A holder of the new global **`history:read-redacted`** permission bypasses redaction entirely (OVERRIDE, sibling of `history:read`).

Relation history (TKT-B1F5Q1) inherits the same rule; a seam comment marks where it wires in.

## Invariant

> Reading version V shows a field only if today's ACL policy affirmatively grants it visible against inputs that can be safely evaluated; every grant needing untrusted subject-world state is hidden. `history:read-redacted` holders see all frozen fields.

## Code review

Reviewed by cranky-code-reviewer, which caught a **critical** incomplete-fail-closed leak in the first pass (role-resolution path — RR-73CA); fixed and pinned with regression tests. All findings filed as review-responses and addressed (RR-73CA critical, RR-73CB/RR-73CC significant, RR-73CD minor, RR-73CE nit/wont-fix).

## Tests

8 resolver-level + 3 handler-level tests covering the 7 acceptance scenarios (scenario 6 / relations deferred to TKT-B1F5Q1). No capture-schema change. `just ci` green locally.