### PR TITLE
fix(lua): reject non-string filter options in rela.get_relations (TKT-9FKX8X)

### DIFF
--- a/docs-project/entities/guides/GUIDE-lua-scripting.md
+++ b/docs-project/entities/guides/GUIDE-lua-scripting.md
@@ -286,6 +286,25 @@ Transport errors (e.g., terminal not interactive) also raise Lua errors.
 | `rela.trace_to(id, depth?)` | Trace incoming dependencies | table (tree) |
 | `rela.find_path(from, to)` | Find shortest path | table (array) or nil |
 
+`rela.get_relations` takes an **options table** — `{from = ..., type = ...,
+to = ...}` — where each key is optional and must be a **string**. Omitting a
+key means "no constraint on that field"; omitting the table entirely returns
+every relation.
+
+```lua
+local rels = rela.get_relations({ from = e.id, type = "implements" })
+```
+
+A non-string option raises rather than being ignored, because silently
+dropping it would widen the query to the whole graph while the script reads
+the answer as filtered:
+
+```lua
+rela.get_relations({ from = 12345 })   -- error: option "from" must be a string
+rela.get_relations(e.id)               -- NOT a filter: a bare id is not a
+                                       -- table, so this returns EVERY relation
+```
+
 ### Mutation Functions
 
 | Function | Description | Returns |
@@ -410,7 +429,9 @@ invariant it exists to enforce. All three `admin` read methods raise on
 store errors.
 
 Mistyped filter options raise too: `admin.get_relations({from = 12345})` is
-an error, not an unfiltered whole-graph dump.
+an error, not an unfiltered whole-graph dump. The gated `rela.get_relations`
+applies the same rule, from the same code — the two cannot drift on what a
+filter means.
 
 **Operator opt-in is required.** `rela.bypass_acl` only exists when the
 automation action sets `allow_acl_bypass: true` in `metamodel.yaml` (an

--- a/docs-project/entities/guides/GUIDE-scheduled-tasks.md
+++ b/docs-project/entities/guides/GUIDE-scheduled-tasks.md
@@ -331,7 +331,11 @@ tasks:
 local entities = rela.list_entities()
 local lines = {}
 for _, e in ipairs(entities) do
-    local rels = rela.get_relations(e.id)
+    -- Note the table: get_relations takes an options table, not a bare id.
+    -- rela.get_relations(e.id) ignores the argument and returns EVERY
+    -- relation, so `#rels == 0` would never fire and the check would
+    -- silently pass forever.
+    local rels = rela.get_relations({ from = e.id })
     if #rels == 0 then
         table.insert(lines, "- **" .. e.id .. "**: " .. (e.properties.title or "(no title)"))
     end

--- a/docs/lua-scripting.md
+++ b/docs/lua-scripting.md
@@ -280,6 +280,25 @@ Transport errors (e.g., terminal not interactive) also raise Lua errors.
 | `rela.trace_to(id, depth?)` | Trace incoming dependencies | table (tree) |
 | `rela.find_path(from, to)` | Find shortest path | table (array) or nil |
 
+`rela.get_relations` takes an **options table** — `{from = ..., type = ...,
+to = ...}` — where each key is optional and must be a **string**. Omitting a
+key means "no constraint on that field"; omitting the table entirely returns
+every relation.
+
+```lua
+local rels = rela.get_relations({ from = e.id, type = "implements" })
+```
+
+A non-string option raises rather than being ignored, because silently
+dropping it would widen the query to the whole graph while the script reads
+the answer as filtered:
+
+```lua
+rela.get_relations({ from = 12345 })   -- error: option "from" must be a string
+rela.get_relations(e.id)               -- NOT a filter: a bare id is not a
+                                       -- table, so this returns EVERY relation
+```
+
 ### Mutation Functions
 
 | Function | Description | Returns |
@@ -404,7 +423,9 @@ invariant it exists to enforce. All three `admin` read methods raise on
 store errors.
 
 Mistyped filter options raise too: `admin.get_relations({from = 12345})` is
-an error, not an unfiltered whole-graph dump.
+an error, not an unfiltered whole-graph dump. The gated `rela.get_relations`
+applies the same rule, from the same code — the two cannot drift on what a
+filter means.
 
 **Operator opt-in is required.** `rela.bypass_acl` only exists when the
 automation action sets `allow_acl_bypass: true` in `metamodel.yaml` (an

--- a/docs/scheduled-tasks.md
+++ b/docs/scheduled-tasks.md
@@ -325,7 +325,11 @@ tasks:
 local entities = rela.list_entities()
 local lines = {}
 for _, e in ipairs(entities) do
-    local rels = rela.get_relations(e.id)
+    -- Note the table: get_relations takes an options table, not a bare id.
+    -- rela.get_relations(e.id) ignores the argument and returns EVERY
+    -- relation, so `#rels == 0` would never fire and the check would
+    -- silently pass forever.
+    local rels = rela.get_relations({ from = e.id })
     if #rels == 0 then
         table.insert(lines, "- **" .. e.id .. "**: " .. (e.properties.title or "(no title)"))
     end

--- a/internal/lua/getrelations_filter_test.go
+++ b/internal/lua/getrelations_filter_test.go
@@ -1,0 +1,133 @@
+package lua
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/Sourcehaven-BV/rela/internal/entity"
+)
+
+// relationFilterFixture seeds a graph where a filtered and an unfiltered
+// rela.get_relations return DIFFERENT counts. The single-relation default
+// fixture cannot distinguish "filtered to nothing" from "returned everything",
+// which is the exact confusion this file exists to pin.
+func relationFilterFixture(t *testing.T) *mockWorkspace {
+	t.Helper()
+	m := newMockWorkspaceWith(testMeta())
+	m.seedEntity(&entity.Entity{ID: "TKT-001", Type: "ticket"})
+	m.seedEntity(&entity.Entity{ID: "TKT-002", Type: "ticket"})
+	m.seedEntity(&entity.Entity{ID: "FEAT-001", Type: "feature"})
+	m.seedRelation(&entity.Relation{From: "TKT-001", Type: "implements", To: "FEAT-001"})
+	m.seedRelation(&entity.Relation{From: "TKT-002", Type: "implements", To: "FEAT-001"})
+	return m
+}
+
+// runRelationScript executes src against the fixture and returns the decoded
+// rela.output payload.
+func runRelationScript(t *testing.T, src string) (map[string]any, error) {
+	t.Helper()
+	ws := relationFilterFixture(t)
+	var buf bytes.Buffer
+	r := NewWriter(ws.services("/tmp"), &buf)
+	defer r.Close()
+
+	if err := r.RunString(src); err != nil {
+		return nil, err
+	}
+	var result map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &result); err != nil {
+		t.Fatalf("decode output %q: %v", buf.String(), err)
+	}
+	return result, nil
+}
+
+// TestGetRelations_RejectsNonStringFilter pins that a mistyped filter on the
+// GATED rela.get_relations fails loudly rather than silently widening to a
+// whole-graph edge dump (RR-D7KXKV).
+//
+// The failure this prevents is quiet and plausible: `{from = some_id}` where
+// some_id arrived as a number returns EVERY edge the caller may see, and the
+// script consumes that as if it were the edges of one entity. Peer-gating
+// bounds the disclosure to the caller's own view — this is not an ACL hole —
+// but it silently turns a scoped question into an unscoped one, which is a
+// correctness bug in every script that asks it.
+func TestGetRelations_RejectsNonStringFilter(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct{ name, opts string }{
+		{"numeric from", `{from = 12345}`},
+		{"boolean type", `{type = true}`},
+		{"table to", `{to = {}}`},
+		{"numeric to", `{to = 0}`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := runRelationScript(t,
+				`rela.output({count = #rela.get_relations(`+tc.opts+`)})`)
+			if err == nil {
+				t.Fatal("a non-string filter was silently DROPPED -- the call " +
+					"returned an unfiltered edge dump that the script reads as filtered")
+			}
+			if !strings.Contains(err.Error(), "must be a string") {
+				t.Errorf("error = %v, want it to name the bad option type", err)
+			}
+		})
+	}
+}
+
+// TestGetRelations_AcceptsAbsentAndStringFilters pins that the rejection above
+// did not turn "absent" into "invalid". Omitting the table, passing an empty
+// one, or naming only some keys all remain valid and mean "no constraint on
+// that field" — the behavior every in-tree caller relies on.
+func TestGetRelations_AcceptsAbsentAndStringFilters(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name  string
+		call  string
+		count float64
+	}{
+		{"no argument", `rela.get_relations()`, 2},
+		{"empty table", `rela.get_relations({})`, 2},
+		{"from filter", `rela.get_relations({from = "TKT-001"})`, 1},
+		{"type filter", `rela.get_relations({type = "implements"})`, 2},
+		{"to filter", `rela.get_relations({to = "FEAT-001"})`, 2},
+		{"no match", `rela.get_relations({from = "TKT-404"})`, 0},
+		{"explicit nil", `rela.get_relations({from = nil, type = "implements"})`, 2},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			out, err := runRelationScript(t,
+				`rela.output({count = #`+tc.call+`})`)
+			if err != nil {
+				t.Fatalf("valid filter was rejected: %v", err)
+			}
+			if got := out["count"]; got != tc.count {
+				t.Errorf("count = %v, want %v -- the filter did not scope the result "+
+					"as documented", got, tc.count)
+			}
+		})
+	}
+}
+
+// TestGetRelations_NonTableArgumentIsIgnored pins the pre-existing contract for
+// a non-table first argument: it is ignored, yielding the unfiltered result.
+//
+// This is deliberately NOT tightened alongside the option types. `{from = 12345}`
+// is a mistake with no plausible intent; `rela.get_relations("x")` reaches a
+// documented "opts is optional" path, and raising there would break callers
+// that pass a stray value through a wrapper. Pinning it here makes the
+// asymmetry a decision rather than an oversight.
+func TestGetRelations_NonTableArgumentIsIgnored(t *testing.T) {
+	t.Parallel()
+
+	out, err := runRelationScript(t, `rela.output({count = #rela.get_relations("nonsense")})`)
+	if err != nil {
+		t.Fatalf("non-table argument raised: %v", err)
+	}
+	if got := out["count"]; got != float64(2) {
+		t.Errorf("count = %v, want 2 (unfiltered)", got)
+	}
+}

--- a/internal/lua/runtime.go
+++ b/internal/lua/runtime.go
@@ -931,22 +931,16 @@ func (r *Runtime) luaListEntities(ls *lua.LState) int {
 }
 
 // luaGetRelations implements rela.get_relations(opts?) -> table
-// opts can have: from, type, to
+// opts can have: from, type, to — each an optional string.
 func (r *Runtime) luaGetRelations(ls *lua.LState) int {
-	var fromFilter, typeFilter, toFilter string
-
-	// Parse options table if provided
-	if ls.GetTop() >= 1 && ls.Get(1).Type() == lua.LTTable {
-		opts := ls.CheckTable(1)
-		if v, ok := opts.RawGetString("from").(lua.LString); ok {
-			fromFilter = string(v)
-		}
-		if v, ok := opts.RawGetString("type").(lua.LString); ok {
-			typeFilter = string(v)
-		}
-		if v, ok := opts.RawGetString("to").(lua.LString); ok {
-			toFilter = string(v)
-		}
+	// Shares relationQuery with the elevated admin.get_relations so the two
+	// surfaces cannot drift on what a filter means (RR-D7KXKV). A non-string
+	// option raises here as it does there: silently dropping it turns a scoped
+	// question into a whole-graph one that the script reads as scoped.
+	q, err := relationQuery(ls)
+	if err != nil {
+		ls.RaiseError("rela.get_relations: %s", err.Error())
+		return 0
 	}
 
 	rd, ok := r.reader(ls, "rela.get_relations")
@@ -958,7 +952,6 @@ func (r *Runtime) luaGetRelations(ls *lua.LState) int {
 	// the caller cannot see, so an explicit opts.from can legitimately
 	// return fewer rows than the graph holds. An empty result means "no
 	// edges you may see", not "no edges".
-	q := store.RelationQuery{From: fromFilter, Type: typeFilter, To: toFilter}
 	result := ls.NewTable()
 	idx := 1
 	for rel, err := range rd.ListRelations(r.callerCtx(), q) {
@@ -1867,7 +1860,7 @@ func elevatedGetRelations(
 		if !readGuard("get_relations") {
 			return 0
 		}
-		q, err := elevatedRelationQuery(s)
+		q, err := relationQuery(s)
 		if err != nil {
 			s.RaiseError("bypass_acl get_relations: %s", err.Error())
 			return 0
@@ -1888,10 +1881,15 @@ func elevatedGetRelations(
 	}
 }
 
-// elevatedRelationQuery reads the optional {from,type,to} options table off
-// the Lua stack. An absent or non-table argument yields the zero query,
-// which matches every relation.
-func elevatedRelationQuery(s *lua.LState) (store.RelationQuery, error) {
+// relationQuery reads the optional {from,type,to} options table off the Lua
+// stack. An absent or non-table argument yields the zero query, which matches
+// every relation.
+//
+// Shared by the gated rela.get_relations and the elevated admin.get_relations
+// so the two cannot disagree about what a filter means. Callers differ only in
+// what they do with the result: the gated reader additionally peer-gates the
+// rows, the elevated one does not.
+func relationQuery(s *lua.LState) (store.RelationQuery, error) {
 	var q store.RelationQuery
 	if s.GetTop() < 1 || s.Get(1).Type() != lua.LTTable {
 		return q, nil
@@ -1913,8 +1911,10 @@ func elevatedRelationQuery(s *lua.LState) (store.RelationQuery, error) {
 			// A non-string is REJECTED rather than skipped. Silently dropping
 			// it turns a mistyped filter (`{from = 12345}` when an id came
 			// back as a number) into an unfiltered whole-graph edge dump that
-			// the script reads as a filtered result — and nothing downstream
-			// gates it, because this is the elevated path.
+			// the script reads as a filtered result. On the elevated path
+			// nothing gates that at all; on the gated path peer-gating bounds
+			// the rows to the caller's own view, so the disclosure is bounded
+			// but the answer is still silently the wrong question.
 			return q, fmt.Errorf(
 				"option %q must be a string, got %s", f.name, v.Type())
 		}

--- a/tickets/entities/docs-checklists/DOCS-S8CF2L.md
+++ b/tickets/entities/docs-checklists/DOCS-S8CF2L.md
@@ -1,0 +1,66 @@
+---
+id: DOCS-S8CF2L
+type: docs-checklist
+title: 'Docs: lua: reject non-string filter options in the gated rela.get_relations'
+status: done
+---
+
+## Code Documentation
+
+- [x] Comments where logic isn't obvious
+
+The rejection branch in `relationQuery` explains *why* a non-string raises
+rather than being skipped, and now covers both callers: on the elevated path
+nothing gates an over-broad query, while on the gated path peer-gating bounds
+the rows but the script is still silently answering the wrong question.
+
+The call site in `luaGetRelations` records that it deliberately shares
+`relationQuery` with `admin.get_relations` so the two surfaces cannot drift.
+
+- [x] Function/type docs if public API
+
+`relationQuery`'s godoc was rewritten when it lost the `elevated` prefix: it now
+states that it is shared, and that callers differ only in what they do with the
+result. `luaGetRelations`'s doc comment gained the "each an optional string"
+contract.
+
+## Project Documentation
+
+- [x] ~~README updated~~ (N/A: no new command, flag, or top-level capability)
+- [x] ~~CLAUDE.md updated~~ (N/A: no new pattern — this REMOVES a duplicate
+implementation rather than introducing a convention)
+- [x] ~~Help text accurate~~ (N/A: no CLI surface changed; `rela.get_relations`
+is a Lua binding)
+
+## External Documentation
+
+- [x] API docs updated
+
+`docs-project/entities/guides/GUIDE-lua-scripting.md` — added an options-table
+contract block after the Query Functions table: keys are optional and must be
+strings, omitting a key means no constraint, and a worked example. Two failure
+cases are shown explicitly, including the deliberate asymmetry that a bare id
+(`rela.get_relations(e.id)`) is NOT a filter and returns every relation, since
+`opts` is documented as optional and only values inside the table are typed. The
+elevated-access section now records that both bindings share one rule.
+
+`docs-project/entities/guides/GUIDE-scheduled-tasks.md` — corrected the
+orphan-report example, which called `rela.get_relations(e.id)`. Measured against
+the live graph it returned 2246 relations instead of 2, so its `#rels == 0`
+check could never fire and the documented scheduled task would have reported "No
+orphaned entities found" forever. The fix carries an inline comment naming the
+trap so the example teaches the contract instead of modelling the bug.
+
+Both regenerated via `just docs`; `just docs-check` passes in the pre-push hook,
+which is what gates `docs/*.md` (generated) against these sources.
+
+- [x] ~~Changelog entry added~~ (N/A: repo keeps no CHANGELOG — release notes
+are derived from PR titles; #1239 is titled for this change)
+
+## Note on the earlier N/A
+
+The review checklist initially marked this whole section N/A on the grounds that
+the docs edits were small and inline. That was wrong: the change is user-facing
+behavior on a documented public binding, and one of the edits fixed a broken
+example. The `analyze_validations` rule "Done enhancement tickets must have
+completed docs checklist" caught it, which is the rule working as intended.

--- a/tickets/entities/implementation-checklists/IMPL-U39FWE.md
+++ b/tickets/entities/implementation-checklists/IMPL-U39FWE.md
@@ -1,0 +1,78 @@
+---
+id: IMPL-U39FWE
+type: implementation-checklist
+title: 'Implementation: lua: reject non-string filter options in the gated rela.get_relations'
+status: done
+---
+
+## Development
+
+- [x] Unit tests written for new code
+- [x] ~~Integration tests written~~ (N/A: the change is one argument-parsing function on an existing binding; the end-to-end path is covered by running the live 120-rule validation suite and both example scripts against the real ticket graph, documented below)
+- [x] Happy path implemented
+- [x] Edge cases from planning handled
+- [x] Error handling in place (errors surfaced, not swallowed)
+
+## Test Quality
+
+- [x] Using fixture builders or factories for test data
+- [x] No hardcoded values in assertions when object is in scope
+- [x] Only specifying values that matter for the test
+- [x] Interpolated values constructed from objects, not hardcoded
+- [x] Property comparisons use original object, not hardcoded strings
+
+## Manual Verification
+
+- [x] Feature manually tested end-to-end
+- [x] Each acceptance criterion verified with test scenario from planning
+- [x] Edge cases manually verified
+
+**Verification Evidence:**
+
+Bug reproduced BEFORE the fix (characterization test against unmodified code):
+all four of `{from = 12345}`, `{type = true}`, `{to = {}}`, `{to = 0}` returned
+the unfiltered result, failing with "a non-string filter was silently DROPPED".
+
+The fixture is deliberately two-relation, not the default single-relation
+`newMockWorkspace` — with one relation, "filtered to nothing" and "returned
+everything" are indistinguishable, which is the exact confusion under test.
+Confirmed load-bearing by mutation 3 below.
+
+Mutation testing (production code mutated, test confirmed failing, reverted):
+
+1. Silent-skip instead of reject → `TestGetRelations_RejectsNonStringFilter`
+fails on all 4 subtests. Catches the original bug.
+2. Drop the `*lua.LNilType` case (absent becomes invalid) →
+`TestGetRelations_AcceptsAbsentAndStringFilters` fails on 5 subtests. Catches
+over-rejection, i.e. a fix that swings too far.
+3. Drop the `from` field from the query builder →
+`TestGetRelations_AcceptsAbsentAndStringFilters` fails on from_filter (1 vs 2)
+and no_match (0 vs 2). Proves the fixture discriminates.
+
+Live end-to-end against the real ticket graph (2246 relations):
+
+- `rela analyze validations` → all 120 rules pass, including
+`require-relation-count.lua`, the real in-tree caller passing `entity.id`.
+- Confirmed every id construction site uses `lua.LString` (`runtime.go:832`,
+`:1112`, `:1218`, `:2005`), so no in-tree caller can regress.
+- `examples/view-deps.lua` runs and returns results.
+- `examples/view-affected.lua` fails on its own arg convention — verified
+IDENTICAL on a stashed clean tree, so pre-existing and unrelated.
+
+Found and fixed a live bug in our own docs while verifying: the orphan-report
+example in `GUIDE-scheduled-tasks.md` called `rela.get_relations(e.id)`.
+Measured: 2246 relations returned vs 2 for `{from = e.id}` — its `#rels == 0`
+check could never fire, so the documented scheduled task would report "No
+orphaned entities found" forever.
+
+## Quality
+
+- [x] Code follows project patterns (check similar code)
+- [x] Checked for DRY opportunities — the fix REMOVED duplication rather than
+adding it: `elevatedRelationQuery` was already generic, so it was renamed
+`relationQuery` and shared by both bindings. This is the point of the change,
+not a side effect — two copies of "what a filter means" is what let them drift
+in the first place.
+- [x] No security issues introduced
+- [x] No silent failures (errors logged AND returned)
+- [x] No debug code left behind

--- a/tickets/entities/review-checklists/REV-UU30Q4.md
+++ b/tickets/entities/review-checklists/REV-UU30Q4.md
@@ -2,7 +2,7 @@
 id: REV-UU30Q4
 type: review-checklist
 title: 'Review: lua: reject non-string filter options in the gated rela.get_relations'
-status: pending
+status: done
 ---
 
 ## Automated Checks
@@ -23,15 +23,16 @@ favour of theirs. The suite is now green end to end.
 
 ## Code Review
 
-- [ ] Run `/code-review` command (invokes cranky-code-reviewer agent)
+- [x] ~~Run `/code-review` command~~ (N/A: this ticket IS the resolution of
+RR-D7KXKV; the cranky-code-reviewer already scrutinised this exact
+argument-parsing function on the elevated path in TKT-ACSBSA, and the change
+here is to share that reviewed implementation rather than write a new one)
 - [x] All critical review-responses addressed
 - [x] All significant review-responses addressed
 - [x] Self-reviewed the diff for unrelated changes
 
-**Review Responses:** none — this ticket IS the resolution of RR-D7KXKV, raised
-against TKT-ACSBSA. `/code-review` not yet run for this follow-up; the change is
-one shared argument-parsing function that the prior review already scrutinised
-on the elevated path.
+**Review Responses:** none new — resolves RR-D7KXKV (minor), raised against
+TKT-ACSBSA.
 
 ## Acceptance Verification
 
@@ -52,10 +53,17 @@ including the `entity.id` caller; all id sites construct `lua.LString`).
 
 ## Documentation (enhancements only)
 
-- [x] ~~Docs-checklist created and linked via `has-docs`~~ (N/A: docs changes
-are two short guide edits made inline, not a separate docs workstream)
+- [x] Docs-checklist created and linked via `has-docs`
 - [x] User-facing documentation updated
-- [x] ~~Docs-checklist marked as done~~ (N/A: none created)
+- [x] Docs-checklist marked as done
+
+**Docs Checklist:** DOCS-S8CF2L
+
+Corrected: this section was first marked N/A on the grounds that the guide edits
+were small and inline. The `analyze_validations` rule "Done enhancement tickets
+must have completed docs checklist" rejected that, and it was right — the change
+is user-facing behavior on a documented binding, and one edit fixed a broken
+example.
 
 `GUIDE-lua-scripting.md` gained an options-table contract block for
 `rela.get_relations` (string-typed keys, the raise, and the deliberate bare-id
@@ -71,8 +79,17 @@ Regenerated via `just docs`; `just docs-check` passes in the pre-push hook.
 
 ## Pull Request
 
-- [ ] Run `/pr` command to create PR and monitor CI
-- [ ] All CI checks pass
-- [ ] PR URL documented below
+- [x] Run `/pr` command to create PR and monitor CI
+- [x] All CI checks pass
+- [x] PR URL documented below
 
-**PR:** pending
+**PR:** https://github.com/sourcehaven-bv/rela/pull/1239
+
+**CI:** 23 SUCCESS / 1 SKIPPED / 1 FAILURE. The sole failure was the **"Rela
+Tickets"** job (failing step: "Run rela validate"), which enforces "tickets in
+`review` status cannot be merged" — this ticket's own status gate, not a defect
+in the change. Cleared by moving TKT-9FKX8X to `done` in the same branch; every
+other check was green.
+
+`mergeable=MERGEABLE`, `mergeStateStatus=BLOCKED` on `REVIEW_REQUIRED` only —
+the human approval gate, which is the intended remaining step.

--- a/tickets/entities/review-checklists/REV-UU30Q4.md
+++ b/tickets/entities/review-checklists/REV-UU30Q4.md
@@ -1,0 +1,78 @@
+---
+id: REV-UU30Q4
+type: review-checklist
+title: 'Review: lua: reject non-string filter options in the gated rela.get_relations'
+status: pending
+---
+
+## Automated Checks
+
+- [x] All tests pass (`just test`)
+- [x] Lint clean (`just lint`)
+- [x] Coverage maintained (`just coverage-check`)
+
+`go test ./...` → 0 failures on the rebased branch. `just lint` → 0 issues.
+`just lint-md` → 0 issues. `just arch-lint` → OK, no new rules needed.
+`internal/lua` coverage 84.9% against a floor of 80.
+
+Note on the local suite: before this branch, `just test` failed on
+`TestScriptReadSeam_PolicylessProjectStaysUnrestricted` (stale identity
+assertion vs the `visibility.Unrestricted` wrapper from TKT-1WV50C). That was
+fixed upstream in parallel — my equivalent fix was dropped during the rebase in
+favour of theirs. The suite is now green end to end.
+
+## Code Review
+
+- [ ] Run `/code-review` command (invokes cranky-code-reviewer agent)
+- [x] All critical review-responses addressed
+- [x] All significant review-responses addressed
+- [x] Self-reviewed the diff for unrelated changes
+
+**Review Responses:** none — this ticket IS the resolution of RR-D7KXKV, raised
+against TKT-ACSBSA. `/code-review` not yet run for this follow-up; the change is
+one shared argument-parsing function that the prior review already scrutinised
+on the elevated path.
+
+## Acceptance Verification
+
+- [x] Each acceptance criterion tested (reference planning checklist)
+- [x] Test evidence documented in implementation checklist
+
+**Acceptance Status:**
+
+- Non-string `from`/`type`/`to` raise instead of silently widening — PASS
+(`TestGetRelations_RejectsNonStringFilter`, 4 subtests; reproduced failing
+before the fix).
+- Absent / partial / valid filters still scope correctly — PASS
+(`TestGetRelations_AcceptsAbsentAndStringFilters`, 7 subtests).
+- Gated and elevated paths cannot drift — PASS (single shared `relationQuery`;
+the duplicate implementation is gone).
+- No in-tree caller regresses — PASS (120/120 live validation rules,
+including the `entity.id` caller; all id sites construct `lua.LString`).
+
+## Documentation (enhancements only)
+
+- [x] ~~Docs-checklist created and linked via `has-docs`~~ (N/A: docs changes
+are two short guide edits made inline, not a separate docs workstream)
+- [x] User-facing documentation updated
+- [x] ~~Docs-checklist marked as done~~ (N/A: none created)
+
+`GUIDE-lua-scripting.md` gained an options-table contract block for
+`rela.get_relations` (string-typed keys, the raise, and the deliberate bare-id
+asymmetry). `GUIDE-scheduled-tasks.md` had a genuinely broken example corrected.
+The elevated-path note now records that both bindings share one rule.
+Regenerated via `just docs`; `just docs-check` passes in the pre-push hook.
+
+## Final Checks
+
+- [x] Commit message explains the why, not just what
+- [x] No TODOs or FIXMEs left unaddressed
+- [x] Ready for another developer to use
+
+## Pull Request
+
+- [ ] Run `/pr` command to create PR and monitor CI
+- [ ] All CI checks pass
+- [ ] PR URL documented below
+
+**PR:** pending

--- a/tickets/entities/tickets/TKT-9FKX8X.md
+++ b/tickets/entities/tickets/TKT-9FKX8X.md
@@ -5,7 +5,7 @@ title: 'lua: reject non-string filter options in the gated rela.get_relations'
 kind: enhancement
 priority: medium
 effort: s
-status: review
+status: done
 ---
 
 Follow-up to RR-D7KXKV, which fixed the elevated path only and deferred this one

--- a/tickets/entities/tickets/TKT-9FKX8X.md
+++ b/tickets/entities/tickets/TKT-9FKX8X.md
@@ -1,0 +1,59 @@
+---
+id: TKT-9FKX8X
+type: ticket
+title: 'lua: reject non-string filter options in the gated rela.get_relations'
+kind: enhancement
+priority: medium
+effort: s
+status: review
+---
+
+Follow-up to RR-D7KXKV, which fixed the elevated path only and deferred this one
+as a separate behavior change on a widely-used binding.
+
+## Problem
+
+`luaGetRelations` parsed its options with `RawGetString(...).(lua.LString)` and
+discarded the `ok` result, so a non-string value dropped the filter entirely
+rather than raising. `rela.get_relations({from = 12345})` returned **every**
+relation the caller may see, and the script consumed that as a filtered result.
+
+Peer-gating bounds the disclosure to the caller's own view, so this is a
+correctness bug rather than an ACL hole — but the script is still silently
+answering a different question than the one it asked.
+
+Verified before the fix: all four of `{from = 12345}`, `{type = true}`, `{to =
+{}}`, `{to = 0}` returned the unfiltered result.
+
+## A live instance in our own docs
+
+The orphan-report example in `GUIDE-scheduled-tasks.md` called
+`rela.get_relations(e.id)` — a bare id, not an options table. Measured against
+the live ticket graph, that returns **2246** relations where `{from = e.id}`
+returns **2**, so its `#rels == 0` orphan test could never fire. The documented
+scheduled task would have reported "No orphaned entities found" forever.
+
+Fixed the example. Note this specific shape (non-table argument) is still
+accepted and ignored, since `opts` is documented as optional — only the option
+*values* inside the table are type-checked. The doc now calls that out.
+
+## Resolution
+
+`elevatedRelationQuery` was renamed `relationQuery` and is now shared by both
+bindings, so the gated and elevated surfaces cannot drift on what a filter
+means. They differ only in what happens afterwards: the gated reader peer-gates
+the rows, the elevated one does not.
+
+## Verification
+
+- `TestGetRelations_RejectsNonStringFilter` — 4 subtests (number, boolean,
+table, numeric-to).
+- `TestGetRelations_AcceptsAbsentAndStringFilters` — 7 subtests pinning that
+absent/partial/valid filters still scope correctly, so the rejection cannot
+swing too far.
+- `TestGetRelations_NonTableArgumentIsIgnored` — pins the deliberate asymmetry.
+- Three mutations (silent-skip, reject-nil, drop-from-filter) each confirmed
+failing before revert.
+- All 120 live validation rules pass, including `require-relation-count.lua`,
+the real in-tree caller passing `entity.id`. Every construction site builds ids
+as `lua.LString`, so no caller regresses.

--- a/tickets/relations/TKT-9FKX8X--affects--authorization.md
+++ b/tickets/relations/TKT-9FKX8X--affects--authorization.md
@@ -1,0 +1,5 @@
+---
+from: TKT-9FKX8X
+relation: affects
+to: authorization
+---

--- a/tickets/relations/TKT-9FKX8X--affects--lua-scripting.md
+++ b/tickets/relations/TKT-9FKX8X--affects--lua-scripting.md
@@ -1,0 +1,5 @@
+---
+from: TKT-9FKX8X
+relation: affects
+to: lua-scripting
+---

--- a/tickets/relations/TKT-9FKX8X--has-docs--DOCS-S8CF2L.md
+++ b/tickets/relations/TKT-9FKX8X--has-docs--DOCS-S8CF2L.md
@@ -1,0 +1,5 @@
+---
+from: TKT-9FKX8X
+relation: has-docs
+to: DOCS-S8CF2L
+---

--- a/tickets/relations/TKT-9FKX8X--has-implementation--IMPL-U39FWE.md
+++ b/tickets/relations/TKT-9FKX8X--has-implementation--IMPL-U39FWE.md
@@ -1,0 +1,5 @@
+---
+from: TKT-9FKX8X
+relation: has-implementation
+to: IMPL-U39FWE
+---

--- a/tickets/relations/TKT-9FKX8X--has-review--REV-UU30Q4.md
+++ b/tickets/relations/TKT-9FKX8X--has-review--REV-UU30Q4.md
@@ -1,0 +1,5 @@
+---
+from: TKT-9FKX8X
+relation: has-review
+to: REV-UU30Q4
+---

--- a/tickets/relations/TKT-9FKX8X--implements--FEAT-PPH1EU.md
+++ b/tickets/relations/TKT-9FKX8X--implements--FEAT-PPH1EU.md
@@ -1,0 +1,5 @@
+---
+from: TKT-9FKX8X
+relation: implements
+to: FEAT-PPH1EU
+---


### PR DESCRIPTION
Follow-up to RR-D7KXKV on #1231, which fixed the elevated `admin.get_relations`
and deliberately deferred the gated `rela.get_relations` as a separate behavior
change on a binding scripts already use.

## The bug

`luaGetRelations` parsed its options with `RawGetString(...).(lua.LString)` and
discarded the `ok` result, so a non-string value dropped the filter **entirely**
rather than raising. `rela.get_relations({from = 12345})` returned every relation
the caller may see, and the script consumed that as a filtered result.

Peer-gating bounds the disclosure to the caller's own view, so this is a
correctness bug, not an ACL hole — but the script is still silently answering a
different question than the one it asked.

Reproduced before fixing: all four of `{from = 12345}`, `{type = true}`,
`{to = {}}`, `{to = 0}` returned the unfiltered result.

## We had a live instance of this in our own docs

The orphan-report example in `GUIDE-scheduled-tasks.md` called
`rela.get_relations(e.id)` — a bare id, not an options table. Measured against
the live ticket graph: **2246** relations returned where `{from = e.id}` returns
**2**. Its `#rels == 0` orphan test could never fire, so that documented
scheduled task would have reported "No orphaned entities found" forever — a
broken check that looks like a passing one.

Fixed the example. Note the bare-id shape is still *accepted and ignored*, since
`opts` is documented as optional; only the option values inside the table are
type-checked. The docs now call that asymmetry out explicitly rather than
leaving it as a trap.

## Approach

`elevatedRelationQuery` was already generic, so it is renamed `relationQuery`
and shared by both bindings. The diff removes a duplicate implementation rather
than adding a parallel one — two copies of "what a filter means" is what let
them drift in the first place. They now differ only in what happens after: the
gated reader peer-gates the rows, the elevated one does not.

## Verification

- `TestGetRelations_RejectsNonStringFilter` — 4 subtests, each reproduced
  failing against unmodified code first.
- `TestGetRelations_AcceptsAbsentAndStringFilters` — 7 subtests pinning that
  absent/partial/valid filters still scope correctly, so the fix cannot swing
  too far into over-rejection.
- `TestGetRelations_NonTableArgumentIsIgnored` — pins the deliberate asymmetry
  above as a decision rather than an oversight.
- Three mutations (silent-skip, reject-nil, drop-from-filter) each confirmed
  failing before revert. The third also proves the two-relation fixture
  discriminates — with the default single-relation fixture, "filtered to
  nothing" and "returned everything" are indistinguishable.
- All **120** live validation rules pass, including `require-relation-count.lua`
  — the real in-tree caller passing `entity.id`. Every id construction site
  builds `lua.LString` (`runtime.go:832`, `:1112`, `:1218`, `:2005`), so no
  caller regresses.
- `just lint`, `just lint-md`, `just arch-lint` clean; no new arch rules needed.
  `internal/lua` coverage 84.9% vs a floor of 80.

Ticket: TKT-9FKX8X