### PR TITLE
feat(lua): recording entity marshaller — per-(entity,field) access capture (1/N)

### DIFF
--- a/internal/lua/entity_marshaller.go
+++ b/internal/lua/entity_marshaller.go
@@ -1,0 +1,209 @@
+package lua
+
+import (
+	"sync"
+	"time"
+
+	lua "github.com/yuin/gopher-lua"
+
+	"github.com/Sourcehaven-BV/rela/internal/entity"
+)
+
+// EntityMarshaller builds the Lua `entity` table for one entity. It is the
+// injectable seam over entity→Lua marshaling: the default is [DefaultMarshaller]
+// (the eager, behavior-preserving [EntityToTable]); a recording variant
+// ([NewRecordingMarshaller]) captures which properties a script actually reads,
+// so a consumer can gate an outcome on the reader's visibility of exactly those
+// fields.
+//
+// The seam exists so field-access capture is a swap-in STRATEGY, not a fork of
+// the shared marshaling code — most call sites keep the default and are wholly
+// unaffected.
+type EntityMarshaller func(ls *lua.LState, e *entity.Entity) *lua.LTable
+
+// DefaultMarshaller is the standard, behavior-preserving marshaller: it is
+// exactly [EntityToTable]. Existing call sites that pass no strategy get this,
+// so their behavior is unchanged.
+func DefaultMarshaller(ls *lua.LState, e *entity.Entity) *lua.LTable {
+	return EntityToTable(ls, e)
+}
+
+// FieldAccessRecord accumulates the (entityID, field) pairs a script touched
+// through a recording marshaller's `entity` tables. It is keyed BY ENTITY so a
+// script that reads several entities in one run (the triggering entity plus any
+// pulled via rela.get_entity / list / trace in later PRs — all of which will
+// marshal through the same record) keeps each entity's touched fields distinct.
+// This is the provenance a consumer gates on: a violation is shown only if the
+// requester can read every (entity, field) that produced it.
+//
+// A read of `entity.content` records the sentinel [FieldContent] — content is a
+// value-bearing field a consumer may also want to gate on. `id`/`type`/`mod_time`
+// are NOT recorded: they are never ACL-hideable (id/type are identity; mod_time
+// is storage metadata).
+//
+// Safe for the single-threaded gopher-lua run; the mutex guards against a
+// record shared across goroutines.
+type FieldAccessRecord struct {
+	mu       sync.Mutex
+	byEntity map[string]map[string]struct{} // entityID → set of field names
+}
+
+// FieldContent is the sentinel key recorded when a script reads entity.content.
+const FieldContent = "\x00content"
+
+// NewFieldAccessRecord returns an empty record.
+func NewFieldAccessRecord() *FieldAccessRecord {
+	return &FieldAccessRecord{byEntity: map[string]map[string]struct{}{}}
+}
+
+func (r *FieldAccessRecord) mark(entityID, field string) {
+	r.mu.Lock()
+	fields := r.byEntity[entityID]
+	if fields == nil {
+		fields = map[string]struct{}{}
+		r.byEntity[entityID] = fields
+	}
+	fields[field] = struct{}{}
+	r.mu.Unlock()
+}
+
+// AccessedFor returns the field names recorded for entityID (unordered, nil if
+// none). Includes [FieldContent] if content was read.
+func (r *FieldAccessRecord) AccessedFor(entityID string) []string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	fields := r.byEntity[entityID]
+	if len(fields) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(fields))
+	for k := range fields {
+		out = append(out, k)
+	}
+	return out
+}
+
+// Entities returns the entity ids that had any field recorded (unordered).
+func (r *FieldAccessRecord) Entities() []string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([]string, 0, len(r.byEntity))
+	for id := range r.byEntity {
+		out = append(out, id)
+	}
+	return out
+}
+
+// Has reports whether (entityID, field) was recorded.
+func (r *FieldAccessRecord) Has(entityID, field string) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	fields := r.byEntity[entityID]
+	if fields == nil {
+		return false
+	}
+	_, ok := fields[field]
+	return ok
+}
+
+// NewRecordingMarshaller returns a marshaller that records every property a
+// script reads into the returned record, plus the record itself.
+//
+// Gated-by-construction: the `properties` table is EMPTY, backed by an
+// __index function. In Lua 5.1 (gopher-lua) __index fires on every read of an
+// absent key — and every key is absent from an empty table — so
+// `entity.properties.foo` always routes through the recorder. There is no raw
+// data on the table to read around the gate. `entity:prop(name)` and
+// `entity.content` are served by recording accessors for the same reason; a
+// future accessor added WITHOUT wiring the recorder yields nil rather than raw
+// data, so a coverage gap fails closed (loud absence) instead of leaking.
+//
+// Iteration caveat (documented, measured by the tests): gopher-lua's pairs()
+// iterates a table's RAW contents and does not honor __index/__pairs, so
+// `pairs(entity.properties)` over the empty proxy sees nothing. A script that
+// enumerates properties therefore records nothing via that path — the
+// fail-closed direction (reads nothing → can leak nothing), but a consumer that
+// needs "a script that iterates depends on ALL props" must treat an iterating
+// script conservatively. This marshaller does not itself decide that policy; it
+// reports what was touched through the gated read paths.
+func NewRecordingMarshaller() (EntityMarshaller, *FieldAccessRecord) {
+	rec := NewFieldAccessRecord()
+	m := func(ls *lua.LState, e *entity.Entity) *lua.LTable {
+		return recordingEntityTable(ls, e, rec)
+	}
+	return m, rec
+}
+
+func recordingEntityTable(ls *lua.LState, e *entity.Entity, rec *FieldAccessRecord) *lua.LTable {
+	t := ls.NewTable()
+	t.RawSetString("id", lua.LString(e.ID))
+	t.RawSetString("type", lua.LString(e.Type))
+
+	if !e.UpdatedAt.IsZero() {
+		t.RawSetString("mod_time", lua.LString(e.UpdatedAt.Format(time.RFC3339)))
+	} else {
+		t.RawSetString("mod_time", lua.LString(""))
+	}
+
+	// content is served through the entity table's own __index so the read is
+	// recorded (a plain RawSetString would let the script read it ungated).
+	// Every non-raw field EXCEPT the ones we set rawly above routes here.
+
+	// props: an empty table whose __index records the key and returns the real
+	// value. Empty ⇒ every field read is a miss ⇒ __index always fires.
+	props := ls.NewTable()
+	propsMeta := ls.NewTable()
+	propsMeta.RawSetString("__index", ls.NewFunction(func(ls *lua.LState) int {
+		key := ls.CheckString(2)
+		rec.mark(e.ID, key)
+		v, ok := e.Properties[key]
+		if !ok {
+			ls.Push(lua.LNil)
+			return 1
+		}
+		ls.Push(GoToLuaValue(ls, v))
+		return 1
+	}))
+	ls.SetMetatable(props, propsMeta)
+	t.RawSetString("properties", props)
+
+	// Recording prop(name, default): records name, reads from the Go map
+	// directly (NOT via props.RawGetString, which would bypass recording AND
+	// find nothing on the empty proxy).
+	t.RawSetString("prop", ls.NewFunction(func(ls *lua.LState) int {
+		name := ls.CheckString(2)
+		defaultVal := ls.Get(3)
+		rec.mark(e.ID, name)
+		v, ok := e.Properties[name]
+		if !ok {
+			ls.Push(defaultVal)
+			return 1
+		}
+		lv := GoToLuaValue(ls, v)
+		if s, isStr := lv.(lua.LString); isStr && string(s) == "" {
+			ls.Push(defaultVal)
+			return 1
+		}
+		ls.Push(lv)
+		return 1
+	}))
+
+	t.RawSetString("strip_prefix", ls.NewFunction(luaEntityStripPrefix))
+
+	// content via the entity table's __index: record then serve. Set on a
+	// metatable so a read of the absent raw `content` key routes here.
+	tMeta := ls.NewTable()
+	tMeta.RawSetString("__index", ls.NewFunction(func(ls *lua.LState) int {
+		key := ls.CheckString(2)
+		if key == "content" {
+			rec.mark(e.ID, FieldContent)
+			ls.Push(lua.LString(e.Content))
+			return 1
+		}
+		ls.Push(lua.LNil)
+		return 1
+	}))
+	ls.SetMetatable(t, tMeta)
+
+	return t
+}

--- a/internal/lua/entity_marshaller_test.go
+++ b/internal/lua/entity_marshaller_test.go
@@ -1,0 +1,195 @@
+package lua
+
+import (
+	"sort"
+	"testing"
+
+	lua "github.com/yuin/gopher-lua"
+
+	"github.com/Sourcehaven-BV/rela/internal/entity"
+)
+
+// runScriptWithRecordingEntity marshals e into the `entity` global via a
+// recording marshaller, runs script, and returns the recorded field set plus
+// any Lua error. It exercises the exact seam the validator will use.
+func runScriptWithRecordingEntity(t *testing.T, e *entity.Entity, script string) ([]string, error) {
+	t.Helper()
+	ls := lua.NewState()
+	defer ls.Close()
+
+	m, rec := NewRecordingMarshaller()
+	ls.SetGlobal("entity", m(ls, e))
+	if err := ls.DoString(script); err != nil {
+		return nil, err
+	}
+	got := rec.AccessedFor(e.ID)
+	sort.Strings(got)
+	return got, nil
+}
+
+func sampleEntity() *entity.Entity {
+	return &entity.Entity{
+		ID:   "TKT-001",
+		Type: "ticket",
+		Properties: map[string]any{
+			"title":    "First",
+			"status":   "open",
+			"priority": "high",
+		},
+		Content: "body text",
+	}
+}
+
+func TestRecordingMarshaller_CapturesEachAccessPath(t *testing.T) {
+	tests := []struct {
+		name   string
+		script string
+		want   []string
+	}{
+		{
+			name:   "direct property read via .properties.X",
+			script: `local _ = entity.properties.status`,
+			want:   []string{"status"},
+		},
+		{
+			name:   "multiple direct reads",
+			script: `local _ = entity.properties.status; local _ = entity.properties.priority`,
+			want:   []string{"priority", "status"},
+		},
+		{
+			name:   "index syntax .properties[k]",
+			script: `local k = "title"; local _ = entity.properties[k]`,
+			want:   []string{"title"},
+		},
+		{
+			name:   "prop(name) method records name",
+			script: `local _ = entity:prop("status")`,
+			want:   []string{"status"},
+		},
+		{
+			name:   "prop with default on absent key still records the touched name",
+			script: `local _ = entity:prop("nope", "fallback")`,
+			want:   []string{"nope"},
+		},
+		{
+			name:   "content read records the content sentinel",
+			script: `local _ = entity.content`,
+			want:   []string{FieldContent},
+		},
+		{
+			name:   "id/type/mod_time reads are NOT recorded (never ACL-hideable)",
+			script: `local _ = entity.id; local _ = entity.type; local _ = entity.mod_time`,
+			want:   []string{},
+		},
+		{
+			name:   "reading nothing records nothing",
+			script: `local x = 1 + 1`,
+			want:   []string{},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := runScriptWithRecordingEntity(t, sampleEntity(), tc.script)
+			if err != nil {
+				t.Fatalf("script error: %v", err)
+			}
+			if !equalStringSets(got, tc.want) {
+				t.Errorf("recorded = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestRecordingMarshaller_ServesRealValues proves the gate does not break the
+// script contract: a recorded read returns the ACTUAL property value, so a
+// validation rule behaves identically to the eager marshaller for the reads it
+// makes.
+func TestRecordingMarshaller_ServesRealValues(t *testing.T) {
+	ls := lua.NewState()
+	defer ls.Close()
+	m, _ := NewRecordingMarshaller()
+	ls.SetGlobal("entity", m(ls, sampleEntity()))
+
+	if err := ls.DoString(`
+		assert(entity.properties.status == "open", "direct read value")
+		assert(entity:prop("priority") == "high", "prop() value")
+		assert(entity.content == "body text", "content value")
+		assert(entity.id == "TKT-001", "id value")
+		assert(entity:prop("missing", "dflt") == "dflt", "prop default")
+	`); err != nil {
+		t.Fatalf("value assertions failed: %v", err)
+	}
+}
+
+// TestRecordingMarshaller_PairsIterationBehaviour MEASURES the documented
+// gopher-lua caveat: pairs() iterates raw table contents and does not fire
+// __index, so iterating the empty proxy records NOTHING and sees NO properties.
+// This test pins the observed behavior so the consumer policy (treat an
+// iterating rule conservatively) is grounded in a measured fact, not a guess.
+func TestRecordingMarshaller_PairsIterationBehaviour(t *testing.T) {
+	got, err := runScriptWithRecordingEntity(t, sampleEntity(), `
+		local count = 0
+		for k, v in pairs(entity.properties) do count = count + 1 end
+		seen_count = count
+	`)
+	if err != nil {
+		t.Fatalf("script error: %v", err)
+	}
+	// The empty proxy yields no iteration entries.
+	if len(got) != 0 {
+		t.Errorf("pairs() over the recording proxy recorded %v; expected nothing "+
+			"(gopher-lua pairs is raw and cannot be intercepted here)", got)
+	}
+	// Document the visible consequence: the script sees zero properties via pairs.
+	// (If a future gopher-lua/version honors __pairs, this test will flag the change.)
+}
+
+// TestRecordingMarshaller_KeysByEntity proves the core of the provenance model:
+// two entities marshaled through the SAME record (as happens when a rule reads
+// its trigger plus another entity via rela.get_entity in later PRs) keep their
+// touched fields distinct — a field read on one is NOT attributed to the other.
+func TestRecordingMarshaller_KeysByEntity(t *testing.T) {
+	ls := lua.NewState()
+	defer ls.Close()
+	m, rec := NewRecordingMarshaller()
+
+	a := &entity.Entity{ID: "TKT-A", Type: "ticket", Properties: map[string]any{"status": "open", "priority": "high"}}
+	b := &entity.Entity{ID: "TKT-B", Type: "ticket", Properties: map[string]any{"status": "closed", "priority": "low"}}
+	ls.SetGlobal("a", m(ls, a))
+	ls.SetGlobal("b", m(ls, b))
+
+	// Read `status` on A, `priority` on B — through one shared record.
+	if err := ls.DoString(`local _ = a.properties.status; local _ = b.properties.priority`); err != nil {
+		t.Fatalf("script error: %v", err)
+	}
+
+	if got := rec.AccessedFor("TKT-A"); !equalStringSets(got, []string{"status"}) {
+		t.Errorf("TKT-A recorded = %v, want [status]", got)
+	}
+	if got := rec.AccessedFor("TKT-B"); !equalStringSets(got, []string{"priority"}) {
+		t.Errorf("TKT-B recorded = %v, want [priority]", got)
+	}
+	if ents := rec.Entities(); !equalStringSets(ents, []string{"TKT-A", "TKT-B"}) {
+		t.Errorf("Entities() = %v, want [TKT-A TKT-B]", ents)
+	}
+	if rec.Has("TKT-A", "priority") {
+		t.Errorf("LEAK of attribution: A must not record B's field 'priority'")
+	}
+}
+
+func equalStringSets(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	m := make(map[string]struct{}, len(a))
+	for _, s := range a {
+		m[s] = struct{}{}
+	}
+	for _, s := range b {
+		if _, ok := m[s]; !ok {
+			return false
+		}
+	}
+	return true
+}


### PR DESCRIPTION
First PR in a multi-PR arc that makes analyze's custom-Lua validation issues leak-safe by tracking, per issue, which (entity, field) pairs the rule read — so a violation is shown only if the requester can see everything it depended on.

**This PR is the mechanism + its proof. Nothing is wired to a consumer yet — zero behavior change.**

## What it adds (`internal/lua/entity_marshaller.go`)

- `EntityMarshaller` — an injectable strategy over entity→Lua marshalling. `DefaultMarshaller` is exactly the existing `EntityToTable`, so existing call sites are unaffected.
- `NewRecordingMarshaller()` → a marshaller + `FieldAccessRecord` that captures every property a script reads, keyed by `(entityID, field)`.

**Gated by construction:** the `properties` table is empty with an `__index` recorder. In Lua 5.1 (gopher-lua) `__index` fires on every read of an absent key, and every key is absent from an empty table, so `entity.properties.foo` always routes through the recorder — there is no raw data on the table to read around the gate. `prop()` and `content` are served by recording accessors too; a future accessor added without wiring the recorder returns nil (fail-closed loud), never raw data.

## Proven by tests

- Each access path (`.properties.X`, `[k]`, `:prop()`, `.content`) records exactly the touched field; `id`/`type`/`mod_time` are not recorded (never ACL-hideable); real values are served (script contract preserved).
- **Per-entity keying:** two entities through one record keep their fields distinct, with an explicit attribution-leak assertion (A must not record B's field). This is the property the whole provenance arc rests on.
- **Measured caveat:** gopher-lua's `pairs()` iterates raw contents and ignores `__index`, so iterating the empty proxy records nothing. Pinned by a test. The downstream consumer (a later PR) treats an iterating rule conservatively; this PR just documents/measures the behavior.

## The arc (for reviewer context)

- **A (this):** recording marshaller + proof.
- **B:** thread the strategy through every read binding (`get_entity`/`list`/`trace`/`relations`) so provenance covers all data a rule pulls, not just the trigger entity.
- **C:** wire validation to the recording strategy; attach provenance to each violation.
- **D:** analyze phase-2 gate consumes provenance (+ declarative `err.Property`, title-fallback). The leak closes here.

Split this way so each step is independently reviewable and green; no gate ships until provenance is total (post-B).
