### PR TITLE
feat(export): per-list render override (lists.<id>.export_render) — TKT-95XU13

### DIFF
--- a/docs-project/entities/guides/GUIDE-data-entry.md
+++ b/docs-project/entities/guides/GUIDE-data-entry.md
@@ -705,6 +705,7 @@ lists:
 | `edit_form`       | string | Form name for the row edit action                           |
 | `page_size`       | int    | Rows per page (default: 25)                                 |
 | `actions`         | list   | Action IDs available as keyboard shortcuts on selected rows |
+| `export_render`   | string | Lua script under `scripts/` that renders this list for export instead of the built-in column table (see View Export & Transforms) |
 
 #### Header and footer info regions
 

--- a/docs-project/entities/guides/GUIDE-lua-scripting.md
+++ b/docs-project/entities/guides/GUIDE-lua-scripting.md
@@ -769,6 +769,27 @@ script runs in a specialized mode with extra context exposed:
 | `rela.document.id`       | The key under `documents:` in `data-entry.yaml` |
 | `rela.document.entry_id` | The ID of the entity being rendered |
 
+**List renders** (a `lists.<id>.export_render` view export, see
+[Transforms](../../../docs/transforms.md#custom-per-list-rendering)) run in the
+same document mode — `rela.mode` is `"document"` there too — with the row set
+added and `entry_id` **absent**, since a list has no entry entity:
+
+| Variable                    | Meaning |
+|-----------------------------|---------|
+| `rela.document.list_id`     | The key under `lists:` being exported |
+| `rela.document.entity_type` | The list's entity type |
+| `rela.document.rows()`      | Iterator over the resolved rows |
+| `rela.document.row(i)`      | One row by 1-based index, or `nil` |
+| `rela.document.count`       | Rows this render can see |
+| `rela.document.total`       | Rows before the export cap |
+| `rela.document.truncated`   | Whether the cap applied |
+| `rela.document.query`       | Read-only `{q, filters, sort}` |
+
+Branch on `rela.document.list_id` (or `rows`) to tell the two apart. The rows
+are handed in already resolved and gated; don't re-derive them with
+`rela.list_entities`, or the export stops matching the list the user was
+looking at.
+
 The script's stdout is captured and used as the rendered document's
 markdown (which is then converted to HTML). Use `print()` to produce
 output.

--- a/docs/data-entry.md
+++ b/docs/data-entry.md
@@ -699,7 +699,7 @@ lists:
 | `edit_form`       | string | Form name for the row edit action                           |
 | `page_size`       | int    | Rows per page (default: 25)                                 |
 | `actions`         | list   | Action IDs available as keyboard shortcuts on selected rows |
-| `export_render`   | string | Lua script under `scripts/` that renders this list for export instead of the built-in column table ([Transforms](transforms.md#custom-per-list-rendering)) |
+| `export_render`   | string | Lua script under `scripts/` that renders this list for export instead of the built-in column table (see View Export & Transforms) |
 
 #### Header and footer info regions
 

--- a/docs/data-entry.md
+++ b/docs/data-entry.md
@@ -699,6 +699,7 @@ lists:
 | `edit_form`       | string | Form name for the row edit action                           |
 | `page_size`       | int    | Rows per page (default: 25)                                 |
 | `actions`         | list   | Action IDs available as keyboard shortcuts on selected rows |
+| `export_render`   | string | Lua script under `scripts/` that renders this list for export instead of the built-in column table ([Transforms](transforms.md#custom-per-list-rendering)) |
 
 #### Header and footer info regions
 

--- a/docs/lua-scripting.md
+++ b/docs/lua-scripting.md
@@ -763,13 +763,9 @@ script runs in a specialized mode with extra context exposed:
 | `rela.document.id`       | The key under `documents:` in `data-entry.yaml` |
 | `rela.document.entry_id` | The ID of the entity being rendered |
 
-The script's stdout is captured and used as the rendered document's
-markdown (which is then converted to HTML). Use `print()` to produce
-output.
-
 **List renders** (a `lists.<id>.export_render` view export, see
-[Transforms](transforms.md#custom-per-list-rendering)) run in the same
-document mode — `rela.mode` is `"document"` there too — with the row set
+[Transforms](../../../docs/transforms.md#custom-per-list-rendering)) run in the
+same document mode — `rela.mode` is `"document"` there too — with the row set
 added and `entry_id` **absent**, since a list has no entry entity:
 
 | Variable                    | Meaning |
@@ -783,10 +779,14 @@ added and `entry_id` **absent**, since a list has no entry entity:
 | `rela.document.truncated`   | Whether the cap applied |
 | `rela.document.query`       | Read-only `{q, filters, sort}` |
 
-Branch on `rela.document.list_id` (or `rows`) to tell the two apart. The
-rows are handed in already resolved and gated; don't re-derive them with
+Branch on `rela.document.list_id` (or `rows`) to tell the two apart. The rows
+are handed in already resolved and gated; don't re-derive them with
 `rela.list_entities`, or the export stops matching the list the user was
 looking at.
+
+The script's stdout is captured and used as the rendered document's
+markdown (which is then converted to HTML). Use `print()` to produce
+output.
 
 ```lua
 -- scripts/docs/release_notes.lua

--- a/docs/lua-scripting.md
+++ b/docs/lua-scripting.md
@@ -767,6 +767,27 @@ The script's stdout is captured and used as the rendered document's
 markdown (which is then converted to HTML). Use `print()` to produce
 output.
 
+**List renders** (a `lists.<id>.export_render` view export, see
+[Transforms](transforms.md#custom-per-list-rendering)) run in the same
+document mode — `rela.mode` is `"document"` there too — with the row set
+added and `entry_id` **absent**, since a list has no entry entity:
+
+| Variable                    | Meaning |
+|-----------------------------|---------|
+| `rela.document.list_id`     | The key under `lists:` being exported |
+| `rela.document.entity_type` | The list's entity type |
+| `rela.document.rows()`      | Iterator over the resolved rows |
+| `rela.document.row(i)`      | One row by 1-based index, or `nil` |
+| `rela.document.count`       | Rows this render can see |
+| `rela.document.total`       | Rows before the export cap |
+| `rela.document.truncated`   | Whether the cap applied |
+| `rela.document.query`       | Read-only `{q, filters, sort}` |
+
+Branch on `rela.document.list_id` (or `rows`) to tell the two apart. The
+rows are handed in already resolved and gated; don't re-derive them with
+`rela.list_entities`, or the export stops matching the list the user was
+looking at.
+
 ```lua
 -- scripts/docs/release_notes.lua
 local entry = rela.get_entity(rela.document.entry_id)

--- a/docs/transforms.md
+++ b/docs/transforms.md
@@ -103,6 +103,72 @@ only for an entity the caller is allowed to read — export resolves the entity
 through the ACL gate first, so a denied caller gets a 404 and the script never
 runs.
 
+### Custom per-list rendering
+
+List export has the same escape hatch, configured on the **list** rather than
+the entity type — so two lists of the same type can export differently, and the
+list that owns the columns and filters also owns its export:
+
+```yaml
+lists:
+  tickets:
+    entity_type: ticket
+    columns: [...]
+    export_render: docs/ticket_report.lua
+```
+
+Now "Export as PDF/ODT" on the **tickets** list renders through
+`ticket_report.lua` instead of the built-in column table. The script receives
+the rows the server already resolved, plus the resolved query as read-only
+context:
+
+```lua
+print("# " .. rela.document.list_id .. " report")
+if rela.document.query.filters.status then
+  print("_status: " .. rela.document.query.filters.status .. "_")
+end
+print()
+
+for _, row in rela.document.rows() do
+  print("## " .. row.properties.title)
+  print(row.content or "")
+end
+
+if rela.document.truncated then
+  print(("\n_Showing %d of %d._"):format(rela.document.count, rela.document.total))
+end
+```
+
+What a list render sees on `rela.document`:
+
+| Field | Meaning |
+|---|---|
+| `list_id`, `entity_type` | which list, over which type |
+| `rows()` | iterator over the rows — `for _, row in rela.document.rows() do` |
+| `row(i)` | one row by 1-based index, or nil |
+| `count` | rows this render can see (post-cap) |
+| `total`, `truncated` | rows before the cap, and whether it applied |
+| `query.q`, `query.filters`, `query.sort` | the resolved request, read-only |
+| `entry_id` | **absent** — a list render has no entry entity |
+
+Two contracts worth knowing:
+
+- **Render the rows you are given.** `rela.document.rows()` is exactly the
+  ACL-scoped, filtered, sorted, capped set the on-screen list resolved. Building
+  your own set with `rela.list_entities` would silently ignore the filters the
+  user actually had applied and escape the row cap, so an export would stop
+  matching the view it came from. Narrowing, grouping, or sorting the given rows
+  in Lua is fine — that is the intended way to shape the output.
+- **Rows are materialized lazily**, one at a time, so a large export stays flat
+  in memory. Each call to `rows()` starts a fresh walk, so you may iterate more
+  than once (to total, then to emit); each walk re-materializes, which costs CPU
+  rather than memory. Use `count` and `row(i)` when you only need a length or
+  one row.
+
+A list with no `export_render` keeps the built-in column table. As with entity
+export, the override is config-selected — a request may choose a transform
+*name*, never a renderer.
+
 ## Security
 
 ### The threat
@@ -189,6 +255,11 @@ untrusted content through the Linux tier.
   - `rela.update_entity`'s read-before-write is deliberately **not**
     redacted — reading a redacted copy there would erase the caller's hidden
     properties on save. Writes remain gated by the ACL as before.
+  - A **list** override (`lists.<id>.export_render`) receives its rows from
+    the server, already row-gated and field-redacted by the same read the
+    on-screen list uses — the script never queries for them. That is why an
+    export always matches the view it came from, and why the row cap still
+    bounds it.
 
 ### Other notes
 
@@ -206,8 +277,6 @@ untrusted content through the Linux tier.
 ## Not yet supported (v1 limits)
 
 - Format chaining (e.g. markdown → HTML → PDF) — each transform is a single step.
-- A render override for LIST export — `export_render` applies to entity export
-  only; list export always emits the column table.
 - Asynchronous export for slow converters (LaTeX / LibreOffice) — exports run
   synchronously within the request.
 - A per-view configurable row cap for list export.

--- a/internal/dataentry/api_v1.go
+++ b/internal/dataentry/api_v1.go
@@ -1696,33 +1696,39 @@ func applyV1Filters(
 	return filtered, nil
 }
 
-// applyV1Sorting applies `sort=` query params to the entity slice. Pure data
-// transform — a free function, not App behavior (TKT-N26KLB M5.5).
-func applyV1Sorting(entities []*entityPkg.Entity, query map[string][]string) []*entityPkg.Entity {
-	sortParam := ""
-	if vals, ok := query["sort"]; ok && len(vals) > 0 {
-		sortParam = vals[0]
-	}
+// parseSortParam parses the `sort=` query param into ordered sort specs:
+// "-created,title" means descending created, then ascending title. Returns nil
+// when no sort was requested.
+//
+// Shared by every consumer of the grammar — the list pipeline that APPLIES the
+// sort and the export context that REPORTS it — so the two cannot drift into
+// describing different orderings.
+func parseSortParam(query map[string][]string) []filter.SortSpec {
+	sortParam := queryGet(query, "sort")
 	if sortParam == "" {
-		return entities
+		return nil
 	}
-
-	// Parse sort param: "-created,title" means descending created, ascending title
-	sortSpecs := make([]filter.SortSpec, 0)
+	var specs []filter.SortSpec
 	for part := range strings.SplitSeq(sortParam, ",") {
 		part = strings.TrimSpace(part)
 		if part == "" {
 			continue
 		}
 		spec := filter.SortSpec{Direction: "asc"}
-		if strings.HasPrefix(part, "-") {
+		if after, found := strings.CutPrefix(part, "-"); found {
 			spec.Direction = "desc"
-			part = part[1:]
+			part = after
 		}
 		spec.Property = part
-		sortSpecs = append(sortSpecs, spec)
+		specs = append(specs, spec)
 	}
+	return specs
+}
 
+// applyV1Sorting applies `sort=` query params to the entity slice. Pure data
+// transform — a free function, not App behavior (TKT-N26KLB M5.5).
+func applyV1Sorting(entities []*entityPkg.Entity, query map[string][]string) []*entityPkg.Entity {
+	sortSpecs := parseSortParam(query)
 	if len(sortSpecs) == 0 {
 		return entities
 	}

--- a/internal/dataentry/app.go
+++ b/internal/dataentry/app.go
@@ -572,6 +572,10 @@ func NewApp(
 		}
 	}
 
+	if err := checkExportRenderScripts(cfg, paths.Root); err != nil {
+		return nil, err
+	}
+
 	entCount, _ := st.CountEntities(context.Background(), store.EntityQuery{})
 	relCount, _ := st.CountRelations(context.Background(), store.RelationQuery{})
 	slog.Info("loaded project", "entities", entCount, "relations", relCount)
@@ -770,6 +774,34 @@ func NewApp(
 	}
 
 	return app, nil
+}
+
+// checkExportRenderScripts verifies every configured export render override
+// resolves to a real script under scripts/, for the same reason and by the
+// same mechanism as the documents:/actions: checks in NewApp — an operator
+// should learn about a typo'd path at boot, not on someone's first export.
+//
+// Both override kinds are checked. The per-type one (views.<type>.export_render)
+// went unverified until the per-list one was added, which was an oversight
+// rather than a decision.
+func checkExportRenderScripts(cfg Config, root string) error {
+	for id, list := range cfg.Lists {
+		if list.ExportRender == "" {
+			continue
+		}
+		if err := script.CheckDocumentScriptExists(root, list.ExportRender); err != nil {
+			return fmt.Errorf("invalid %s: list %q: export_render: %w", ConfigFile, id, err)
+		}
+	}
+	for id, view := range cfg.Views {
+		if view.ExportRender == "" {
+			continue
+		}
+		if err := script.CheckDocumentScriptExists(root, view.ExportRender); err != nil {
+			return fmt.Errorf("invalid %s: view %q: export_render: %w", ConfigFile, id, err)
+		}
+	}
+	return nil
 }
 
 // NavItem is an enriched navigation entry that includes the entity type for client-side matching.

--- a/internal/dataentry/document.go
+++ b/internal/dataentry/document.go
@@ -54,6 +54,8 @@ func isFormRoute(path string) bool {
 type documentScriptEngine interface {
 	ExecuteDocument(ctx context.Context, path string, deps lua.WriteDeps, stdout io.Writer,
 		documentID, entryID string, timeout time.Duration) error
+	ExecuteListDocument(ctx context.Context, path string, deps lua.WriteDeps, stdout io.Writer,
+		documentID string, lrc lua.ListRenderContext, timeout time.Duration) error
 }
 
 // documentDeps yields the lua.WriteDeps the script engine needs. The App
@@ -204,6 +206,53 @@ func (s *documentService) RenderMarkdown(
 		return s.renderScript(ctx, entryID, cfg)
 	}
 	return s.renderCommand(ctx, entryID, cfg)
+}
+
+// RenderListMarkdown renders a LIST export override (`lists.<id>.export_render`)
+// to markdown, for the same reason RenderMarkdown exists on the entity side:
+// view export feeds the markdown to a format transform rather than converting
+// it to HTML.
+//
+// Script-only. A `command:` renderer has no meaning here — its placeholders are
+// {id}/{id_lower} of an entry entity, and a list has none — so a Command config
+// is a wiring error rather than a supported branch.
+//
+// It deliberately does NOT hash, cache, or singleflight, and none of those are
+// oversights to be "optimized" back in later:
+//   - computeDocumentHash loads ONE entity by id; a list has no entry entity,
+//     so there is nothing for it to hash.
+//   - The disk cache is keyed on that entry hash and holds HTML; list export
+//     produces per-request markdown.
+//   - A correct singleflight key would need the full resolved query AND the
+//     caller's ACL scope, because two principals' row sets legitimately differ.
+//     Getting that key wrong collapses two callers onto one render — a
+//     cross-principal leak, the RR-2QSGLU hazard with more to lose. Not
+//     deduping is the safe default.
+//
+// Callers MUST have resolved the rows through the ACL read path before calling
+// this — it makes no ACL decision of its own.
+func (s *documentService) RenderListMarkdown(
+	ctx context.Context, cfg documentRenderConfig, lrc lua.ListRenderContext,
+) (string, error) {
+	if cfg.Command != "" {
+		return "", errors.New("list export render must be a script, not a command")
+	}
+	if s.scriptEngine == nil || s.luaDeps == nil {
+		return "", errors.New("script rendering not available (engine or deps not wired)")
+	}
+	var buf bytes.Buffer
+	if err := s.scriptEngine.ExecuteListDocument(ctx, cfg.Script, s.luaDeps(), &buf,
+		cfg.ConfigID, lrc, cfg.Timeout); err != nil {
+		// Same shaping as renderScript: attach the output captured before the
+		// script threw, then bubble up unchanged so the HTTP layer can branch
+		// via errors.As.
+		var se *lua.ScriptError
+		if errors.As(err, &se) {
+			return "", se.AttachCapturedOutput(buf.Bytes())
+		}
+		return "", fmt.Errorf("list script render: %w", err)
+	}
+	return buf.String(), nil
 }
 
 // doRender performs the actual rendering work. Dispatches on Script vs.

--- a/internal/dataentry/document.go
+++ b/internal/dataentry/document.go
@@ -213,9 +213,10 @@ func (s *documentService) RenderMarkdown(
 // view export feeds the markdown to a format transform rather than converting
 // it to HTML.
 //
-// Script-only. A `command:` renderer has no meaning here — its placeholders are
-// {id}/{id_lower} of an entry entity, and a list has none — so a Command config
-// is a wiring error rather than a supported branch.
+// Script-only: a `command:` renderer's placeholders are {id}/{id_lower} of an
+// entry entity and a list has none. No caller sets Command today; the guard
+// below is a fail-closed assertion so a future one gets an error instead of a
+// silently entry-less substitution.
 //
 // It deliberately does NOT hash, cache, or singleflight, and none of those are
 // oversights to be "optimized" back in later:

--- a/internal/dataentry/document_script_test.go
+++ b/internal/dataentry/document_script_test.go
@@ -47,11 +47,57 @@ type fakeScriptCall struct {
 	documentID string
 	entryID    string
 	timeout    time.Duration
+
+	// List-render fields, populated only by ExecuteListDocument.
+	listID  string
+	query   lua.ListQuery
+	rowIDs  []string // the provider drained once, in order
+	rowIDs2 []string // drained a SECOND time, to pin the walk-twice contract
 }
 
 func (f *fakeScriptEngine) ExecuteDocument(_ context.Context, path string, _ lua.WriteDeps, stdout io.Writer,
 	documentID, entryID string, timeout time.Duration) error {
 	call := fakeScriptCall{path: path, documentID: documentID, entryID: entryID, timeout: timeout}
+	f.mu.Lock()
+	f.calls = append(f.calls, call)
+	f.mu.Unlock()
+
+	if f.delay > 0 {
+		time.Sleep(f.delay)
+	}
+	if f.err != nil {
+		return f.err
+	}
+	if f.stdout != nil {
+		_, _ = io.WriteString(stdout, f.stdout(call))
+	}
+	return nil
+}
+
+// ExecuteListDocument records a list render. It DRAINS the row provider
+// (twice) rather than ignoring it, so tests can assert which rows reached the
+// script — and that a second walk restarts — without standing up a real Lua
+// runtime. The production binding materializes rows the same way.
+func (f *fakeScriptEngine) ExecuteListDocument(_ context.Context, path string, _ lua.WriteDeps,
+	stdout io.Writer, documentID string, lrc lua.ListRenderContext, timeout time.Duration) error {
+	drain := func() []string {
+		if lrc.Rows == nil {
+			return nil
+		}
+		ids := make([]string, 0, lrc.Rows.Len())
+		for i := range lrc.Rows.Len() {
+			if e := lrc.Rows.At(i); e != nil {
+				ids = append(ids, e.ID)
+			}
+		}
+		return ids
+	}
+
+	call := fakeScriptCall{
+		path: path, documentID: documentID, timeout: timeout,
+		listID: lrc.ListID, query: lrc.Query,
+		rowIDs: drain(), rowIDs2: drain(),
+	}
 	f.mu.Lock()
 	f.calls = append(f.calls, call)
 	f.mu.Unlock()

--- a/internal/dataentry/export_list.go
+++ b/internal/dataentry/export_list.go
@@ -42,11 +42,11 @@ func (h *exportHandler) handleV1ExportList(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	// Resolve the effective list ONCE, and use it for both the columns and
-	// the render override — see resolveEffectiveList for why these must not
-	// be looked up independently.
+	// Resolve the effective list ONCE and derive both the columns and the
+	// render override from it — see resolveEffectiveList for why these must
+	// not be looked up independently.
 	effListID, effList, haveList := h.resolveEffectiveList(query.Get("list"), typeName)
-	columns := h.exportListColumns(query.Get("list"), typeName)
+	columns := listColumnsOf(effList, haveList)
 
 	// The WHOLE ACL-scoped, filtered, sorted set — pre-pagination. Reuses the
 	// exact read path the list view uses, so export can't widen past the view.
@@ -158,41 +158,36 @@ func (r entitySliceRows) At(i int) *entityPkg.Entity {
 // for changing what it contains.
 func buildListQuery(in listRenderInput) lua.ListQuery {
 	q := lua.ListQuery{
-		ListID:     in.listID,
 		EntityType: in.typeName,
 		Q:          queryGet(in.query, "q"),
 		Total:      in.total,
-		Rendered:   len(in.entities),
-		Truncated:  in.truncated,
 	}
 
-	// filter[<key>]=<value> → {key: value}. First value wins, matching how
-	// the list pipeline itself reads these.
+	// filter[<key>]=<value> → {key: value}, parsed with the SAME helper the
+	// filter pipeline uses. Rolling our own TrimPrefix/TrimSuffix here would
+	// reintroduce RR-6RF60V: `filter[status][ne]` would key the table on
+	// "status][ne" instead of "status", so a script would see a filter name
+	// that never matches what was actually filtered on. The operator segment
+	// is intentionally dropped — this context reports WHICH properties were
+	// filtered, and the last value wins, matching applyV1Filters.
 	for k, vals := range in.query {
-		key, ok := strings.CutPrefix(k, "filter[")
-		if !ok || !strings.HasSuffix(key, "]") || len(vals) == 0 {
+		if !strings.HasPrefix(k, "filter[") || len(vals) == 0 {
+			continue
+		}
+		key, _, ok := parseRelationFilterKey(k)
+		if !ok {
 			continue
 		}
 		if q.Filters == nil {
 			q.Filters = map[string]string{}
 		}
-		q.Filters[strings.TrimSuffix(key, "]")] = vals[0]
+		q.Filters[key] = vals[len(vals)-1]
 	}
 
-	// sort=-created,title — same grammar applyV1Sorting parses.
-	for part := range strings.SplitSeq(queryGet(in.query, "sort"), ",") {
-		part = strings.TrimSpace(part)
-		if part == "" {
-			continue
-		}
-		spec := lua.ListSortSpec{Direction: "asc"}
-		if after, found := strings.CutPrefix(part, "-"); found {
-			spec.Direction = "desc"
-			part = after
-		}
-		spec.Property = part
-		q.Sort = append(q.Sort, spec)
-	}
+	// sort=-created,title, parsed by the same helper applyV1Sorting uses, so
+	// the sort reported to a script cannot drift from the sort applied.
+	// ListSortSpec aliases filter.SortSpec, so these pass straight through.
+	q.Sort = parseSortParam(in.query)
 	return q
 }
 
@@ -208,7 +203,7 @@ func buildListQuery(in listRenderInput) lua.ListQuery {
 // that is plainly configured.
 //
 // Note what this does NOT test: `len(Columns) > 0`. That predicate lives in
-// exportListColumns, where it belongs — it is a statement about whether a list
+// listColumnsOf, where it belongs — it is a statement about whether a list
 // can supply columns, not about which list this export is. A list configured
 // with `export_render:` and no `columns:` is perfectly valid (the script
 // renders whatever it likes), and folding the column check in here would make
@@ -233,16 +228,15 @@ func (h *exportHandler) resolveEffectiveList(
 	return "", dataentryconfig.List{}, false
 }
 
-// exportListColumns returns the columns for the export: the effective list's
+// listColumnsOf returns the columns for the export: the effective list's
 // columns when it has any, else a minimal [id, title] pair so an export always
 // produces a sensible table even when no list is configured.
 //
-// The two-step (effective list, then column check) preserves the original
-// behavior exactly for every configuration that has columns anywhere, while
-// keeping list identity and column availability as the separate questions they
-// are — see resolveEffectiveList.
-func (h *exportHandler) exportListColumns(listID, typeName string) []dataentryconfig.ListColumn {
-	if _, l, ok := h.resolveEffectiveList(listID, typeName); ok && len(l.Columns) > 0 {
+// Takes the ALREADY-resolved list rather than resolving one itself, so a
+// single request resolves exactly once and the columns can never come from a
+// different list than the render override — see resolveEffectiveList.
+func listColumnsOf(l dataentryconfig.List, haveList bool) []dataentryconfig.ListColumn {
+	if haveList && len(l.Columns) > 0 {
 		return l.Columns
 	}
 	return []dataentryconfig.ListColumn{

--- a/internal/dataentry/export_list.go
+++ b/internal/dataentry/export_list.go
@@ -73,35 +73,36 @@ func (h *exportHandler) handleV1ExportList(w http.ResponseWriter, r *http.Reques
 	// field-redaction pass, and the cap. That ordering is load-bearing: a
 	// render override can only ever be handed rows that already survived
 	// every gate, and never more of them than the cap allows.
-	renderer := h.listExportRenderer(
-		listRenderInput{
-			listID: effListID, list: effList, haveList: haveList,
-			typeName: typeName, entities: entities, columns: columns,
-			total: total, truncated: truncated, query: query,
+	//
+	// haveList needs no test of its own: resolveEffectiveList returns a zero
+	// List when it finds none, and a zero List has no ExportRender.
+	renderer := h.listTableRenderer(entities, columns, total, truncated)
+	if effList.ExportRender != "" {
+		renderer = h.listOverrideRenderer(listOverride{
+			listID: effListID, script: effList.ExportRender, typeName: typeName,
+			rows: entities, total: total, query: query,
 		})
+	}
 	h.convertAndWrite(w, r, reg, name, renderer, typeName+"-list", "type", typeName)
 }
 
-// listRenderInput bundles what listExportRenderer needs to choose and build a
-// renderer. A struct rather than nine positional parameters — several are the
-// same type and would be trivially transposable at the call site.
-type listRenderInput struct {
-	listID    string
-	list      dataentryconfig.List
-	haveList  bool
-	typeName  string
-	entities  []*entityPkg.Entity
-	columns   []dataentryconfig.ListColumn
-	total     int
-	truncated bool
-	query     map[string][]string
+// listOverride is what rendering a list THROUGH A SCRIPT needs: which list,
+// which script, and the resolved read it renders. Deliberately not a bundle of
+// everything the handler happens to hold — the built-in table path takes its
+// own arguments, so neither branch carries fields the other needs.
+type listOverride struct {
+	listID   string
+	script   string
+	typeName string
+	rows     []*entityPkg.Entity
+	total    int // pre-cap count; len(rows) is what the script can reach
+	query    map[string][]string
 }
 
-// listExportRenderer picks the markdown renderer for a list export. When the
-// effective list configures an `export_render:` Lua script, the export routes
-// through that script — the per-list render OVERRIDE — so exporting that list
-// automatically uses the operator's document instead of the built-in column
-// table. Otherwise the built-in [exportHandler.listTableRenderer] is used.
+// listOverrideRenderer builds the markdown renderer for a list export that
+// configures an `export_render:` Lua script — the per-list render OVERRIDE —
+// so exporting that list uses the operator's document instead of the built-in
+// column table.
 //
 // The rows were already resolved through the ACL read path, field-redacted,
 // and capped by the caller, so the override sees exactly the ROWS the
@@ -121,14 +122,10 @@ type listRenderInput struct {
 // caller may not read resolves to an empty set and renders an empty document,
 // which is what the built-in table does too. A 404 would leak the difference
 // between "no rows" and "no access".
-func (h *exportHandler) listExportRenderer(in listRenderInput) transform.Renderer {
-	if !in.haveList || in.list.ExportRender == "" {
-		return h.listTableRenderer(in.entities, in.columns, in.total, in.truncated)
-	}
-
+func (h *exportHandler) listOverrideRenderer(in listOverride) transform.Renderer {
 	lrc := lua.ListRenderContext{
 		ListID: in.listID,
-		Rows:   entitySliceRows(in.entities),
+		Rows:   entitySliceRows(in.rows),
 		Query:  buildListQuery(in),
 	}
 	// ConfigID is synthetic and namespaced: the "list:" infix keeps it from
@@ -142,7 +139,7 @@ func (h *exportHandler) listExportRenderer(in listRenderInput) transform.Rendere
 	// RenderListMarkdown neither caches nor shells out, so the ConfigID's only
 	// consumers are a Lua string and an error message. If a list render ever
 	// gains a disk cache, this needs the guard.
-	cfg := documentRenderConfig{ConfigID: "export:list:" + in.listID, Script: in.list.ExportRender}
+	cfg := documentRenderConfig{ConfigID: "export:list:" + in.listID, Script: in.script}
 
 	return transform.RendererFunc(func(ctx context.Context) ([]byte, error) {
 		md, err := h.documents.RenderListMarkdown(ctx, cfg, lrc)
@@ -173,7 +170,7 @@ func (r entitySliceRows) At(i int) *entityPkg.Entity {
 // and how the cap applied. Only what the caller already supplied is echoed
 // back — this is context for titling and annotating an export, not a channel
 // for changing what it contains.
-func buildListQuery(in listRenderInput) lua.ListQuery {
+func buildListQuery(in listOverride) lua.ListQuery {
 	q := lua.ListQuery{
 		EntityType: in.typeName,
 		Q:          queryGet(in.query, "q"),

--- a/internal/dataentry/export_list.go
+++ b/internal/dataentry/export_list.go
@@ -104,9 +104,18 @@ type listRenderInput struct {
 // table. Otherwise the built-in [exportHandler.listTableRenderer] is used.
 //
 // The rows were already resolved through the ACL read path, field-redacted,
-// and capped by the caller, so the override renders exactly the set the
-// on-screen view showed. The script is a fixed config value, never request
-// input: a request may choose a transform NAME, never a renderer.
+// and capped by the caller, so the override sees exactly the ROWS the
+// on-screen view resolved, with the same property redaction. The script is a
+// fixed config value, never request input: a request may choose a transform
+// NAME, never a renderer.
+//
+// It does NOT see only what the on-screen table showed. A row reaches the
+// script as a full entity table, so a script can render the entity BODY, which
+// the column table never displays. That is intended — a report override wants
+// bodies, and the entity export path already exposes them — but note that
+// `visibility.Redact` currently leaves `Content` verbatim (the body-redaction
+// TODO in internal/visibility/policyreader.go). When body redaction lands, this
+// is one of the paths that must route through it.
 //
 // Unlike the entity path there is no failure mode to report here — a list the
 // caller may not read resolves to an empty set and renders an empty document,
@@ -125,6 +134,14 @@ func (h *exportHandler) listExportRenderer(in listRenderInput) transform.Rendere
 	// ConfigID is synthetic and namespaced: the "list:" infix keeps it from
 	// colliding with the entity path's "export:<type>" for a list whose id
 	// happens to equal an entity type name.
+	//
+	// No isSafePathSegment guard here, unlike the entity path (see
+	// exportRenderer): that one validates because an entity id is REQUEST
+	// input that reaches a document cache filename. This id is neither — it
+	// is a key that matched cfg.Lists, so it is operator-authored config, and
+	// RenderListMarkdown neither caches nor shells out, so the ConfigID's only
+	// consumers are a Lua string and an error message. If a list render ever
+	// gains a disk cache, this needs the guard.
 	cfg := documentRenderConfig{ConfigID: "export:list:" + in.listID, Script: in.list.ExportRender}
 
 	return transform.RendererFunc(func(ctx context.Context) ([]byte, error) {

--- a/internal/dataentry/export_list.go
+++ b/internal/dataentry/export_list.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/Sourcehaven-BV/rela/internal/dataentryconfig"
 	entityPkg "github.com/Sourcehaven-BV/rela/internal/entity"
+	"github.com/Sourcehaven-BV/rela/internal/lua"
 	"github.com/Sourcehaven-BV/rela/internal/metamodel"
 	"github.com/Sourcehaven-BV/rela/internal/transform"
 	"github.com/Sourcehaven-BV/rela/internal/visibility"
@@ -41,6 +42,10 @@ func (h *exportHandler) handleV1ExportList(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
+	// Resolve the effective list ONCE, and use it for both the columns and
+	// the render override — see resolveEffectiveList for why these must not
+	// be looked up independently.
+	effListID, effList, haveList := h.resolveEffectiveList(query.Get("list"), typeName)
 	columns := h.exportListColumns(query.Get("list"), typeName)
 
 	// The WHOLE ACL-scoped, filtered, sorted set — pre-pagination. Reuses the
@@ -64,25 +69,181 @@ func (h *exportHandler) handleV1ExportList(w http.ResponseWriter, r *http.Reques
 		truncated = true
 	}
 
-	renderer := h.listTableRenderer(entities, columns, total, truncated)
+	// Override selection happens HERE — after the ACL-scoped read, the
+	// field-redaction pass, and the cap. That ordering is load-bearing: a
+	// render override can only ever be handed rows that already survived
+	// every gate, and never more of them than the cap allows.
+	renderer := h.listExportRenderer(
+		listRenderInput{
+			listID: effListID, list: effList, haveList: haveList,
+			typeName: typeName, entities: entities, columns: columns,
+			total: total, truncated: truncated, query: query,
+		})
 	h.convertAndWrite(w, r, reg, name, renderer, typeName+"-list", "type", typeName)
 }
 
-// exportListColumns returns the columns for the export. It prefers the named
-// list's columns, falls back to the type's default list, and finally to a
-// minimal [id, title] pair so an export always produces a sensible table even
-// when no list is configured.
-func (h *exportHandler) exportListColumns(listID, typeName string) []dataentryconfig.ListColumn {
+// listRenderInput bundles what listExportRenderer needs to choose and build a
+// renderer. A struct rather than nine positional parameters — several are the
+// same type and would be trivially transposable at the call site.
+type listRenderInput struct {
+	listID    string
+	list      dataentryconfig.List
+	haveList  bool
+	typeName  string
+	entities  []*entityPkg.Entity
+	columns   []dataentryconfig.ListColumn
+	total     int
+	truncated bool
+	query     map[string][]string
+}
+
+// listExportRenderer picks the markdown renderer for a list export. When the
+// effective list configures an `export_render:` Lua script, the export routes
+// through that script — the per-list render OVERRIDE — so exporting that list
+// automatically uses the operator's document instead of the built-in column
+// table. Otherwise the built-in [exportHandler.listTableRenderer] is used.
+//
+// The rows were already resolved through the ACL read path, field-redacted,
+// and capped by the caller, so the override renders exactly the set the
+// on-screen view showed. The script is a fixed config value, never request
+// input: a request may choose a transform NAME, never a renderer.
+//
+// Unlike the entity path there is no failure mode to report here — a list the
+// caller may not read resolves to an empty set and renders an empty document,
+// which is what the built-in table does too. A 404 would leak the difference
+// between "no rows" and "no access".
+func (h *exportHandler) listExportRenderer(in listRenderInput) transform.Renderer {
+	if !in.haveList || in.list.ExportRender == "" {
+		return h.listTableRenderer(in.entities, in.columns, in.total, in.truncated)
+	}
+
+	lrc := lua.ListRenderContext{
+		ListID: in.listID,
+		Rows:   entitySliceRows(in.entities),
+		Query:  buildListQuery(in),
+	}
+	// ConfigID is synthetic and namespaced: the "list:" infix keeps it from
+	// colliding with the entity path's "export:<type>" for a list whose id
+	// happens to equal an entity type name.
+	cfg := documentRenderConfig{ConfigID: "export:list:" + in.listID, Script: in.list.ExportRender}
+
+	return transform.RendererFunc(func(ctx context.Context) ([]byte, error) {
+		md, err := h.documents.RenderListMarkdown(ctx, cfg, lrc)
+		if err != nil {
+			return nil, err
+		}
+		return []byte(md), nil
+	})
+}
+
+// entitySliceRows adapts an already-resolved entity slice to lua.ListRows.
+// The laziness that matters is on the Lua side — one entity TABLE is
+// materialized at a time — so a plain indexed slice is exactly the right
+// backing store here.
+type entitySliceRows []*entityPkg.Entity
+
+func (r entitySliceRows) Len() int { return len(r) }
+
+func (r entitySliceRows) At(i int) *entityPkg.Entity {
+	if i < 0 || i >= len(r) {
+		return nil
+	}
+	return r[i]
+}
+
+// buildListQuery flattens the request into the read-only context a render
+// override sees: which list, over which type, under which filters and sort,
+// and how the cap applied. Only what the caller already supplied is echoed
+// back — this is context for titling and annotating an export, not a channel
+// for changing what it contains.
+func buildListQuery(in listRenderInput) lua.ListQuery {
+	q := lua.ListQuery{
+		ListID:     in.listID,
+		EntityType: in.typeName,
+		Q:          queryGet(in.query, "q"),
+		Total:      in.total,
+		Rendered:   len(in.entities),
+		Truncated:  in.truncated,
+	}
+
+	// filter[<key>]=<value> → {key: value}. First value wins, matching how
+	// the list pipeline itself reads these.
+	for k, vals := range in.query {
+		key, ok := strings.CutPrefix(k, "filter[")
+		if !ok || !strings.HasSuffix(key, "]") || len(vals) == 0 {
+			continue
+		}
+		if q.Filters == nil {
+			q.Filters = map[string]string{}
+		}
+		q.Filters[strings.TrimSuffix(key, "]")] = vals[0]
+	}
+
+	// sort=-created,title — same grammar applyV1Sorting parses.
+	for part := range strings.SplitSeq(queryGet(in.query, "sort"), ",") {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+		spec := lua.ListSortSpec{Direction: "asc"}
+		if after, found := strings.CutPrefix(part, "-"); found {
+			spec.Direction = "desc"
+			part = after
+		}
+		spec.Property = part
+		q.Sort = append(q.Sort, spec)
+	}
+	return q
+}
+
+// resolveEffectiveList returns the list configuration governing this export:
+// the named ?list= when it exists and matches the type, else the type's
+// default list from navigation, else ok=false.
+//
+// BOTH the column set and the render override MUST resolve through this. They
+// used to be one lookup because columns were the only thing a list
+// contributed; now that a list can also carry an `export_render:` script,
+// resolving them independently would let an export take its columns from one
+// list and its override from another — or, worse, silently skip an override
+// that is plainly configured.
+//
+// Note what this does NOT test: `len(Columns) > 0`. That predicate lives in
+// exportListColumns, where it belongs — it is a statement about whether a list
+// can supply columns, not about which list this export is. A list configured
+// with `export_render:` and no `columns:` is perfectly valid (the script
+// renders whatever it likes), and folding the column check in here would make
+// its override silently not apply.
+func (h *exportHandler) resolveEffectiveList(
+	listID, typeName string,
+) (string, dataentryconfig.List, bool) {
 	cfg := h.cfg()
 	if listID != "" {
-		if l, ok := cfg.Lists[listID]; ok && l.EntityType == typeName && len(l.Columns) > 0 {
-			return l.Columns
+		if l, ok := cfg.Lists[listID]; ok && l.EntityType == typeName {
+			return listID, l, true
 		}
 	}
 	if def := h.findListForType(typeName); def != "" {
-		if l, ok := cfg.Lists[def]; ok && len(l.Columns) > 0 {
-			return l.Columns
+		// The EntityType re-check is belt-and-braces: findListForType only
+		// returns lists of this type, but it makes the contract total, so a
+		// future navigation change cannot hand back a mismatched list.
+		if l, ok := cfg.Lists[def]; ok && l.EntityType == typeName {
+			return def, l, true
 		}
+	}
+	return "", dataentryconfig.List{}, false
+}
+
+// exportListColumns returns the columns for the export: the effective list's
+// columns when it has any, else a minimal [id, title] pair so an export always
+// produces a sensible table even when no list is configured.
+//
+// The two-step (effective list, then column check) preserves the original
+// behavior exactly for every configuration that has columns anywhere, while
+// keeping list identity and column availability as the separate questions they
+// are — see resolveEffectiveList.
+func (h *exportHandler) exportListColumns(listID, typeName string) []dataentryconfig.ListColumn {
+	if _, l, ok := h.resolveEffectiveList(listID, typeName); ok && len(l.Columns) > 0 {
+		return l.Columns
 	}
 	return []dataentryconfig.ListColumn{
 		{Property: "id", Label: "ID"},

--- a/internal/dataentry/export_list_render_test.go
+++ b/internal/dataentry/export_list_render_test.go
@@ -303,11 +303,15 @@ func TestExport_List_RenderOverride_RowsWalkableTwice(t *testing.T) {
 		t.Fatalf("want 1 call, got %d", len(fake.calls))
 	}
 	call := fake.calls[0]
-	if len(call.rowIDs) != 3 {
-		t.Fatalf("first walk saw %d rows, want 3", len(call.rowIDs))
+	want := "TKT-1,TKT-2,TKT-3"
+	if got := strings.Join(call.rowIDs, ","); got != want {
+		t.Errorf("provider yielded %q, want %q (in list order)", got, want)
 	}
-	if strings.Join(call.rowIDs, ",") != strings.Join(call.rowIDs2, ",") {
-		t.Errorf("second walk differed: %v vs %v", call.rowIDs, call.rowIDs2)
+	// The provider is re-readable — a precondition for the Lua cursor's
+	// walk-twice contract, which is itself pinned against a real runtime by
+	// TestListDocumentMode_IteratorWalkableTwice in internal/lua.
+	if got := strings.Join(call.rowIDs2, ","); got != want {
+		t.Errorf("second read yielded %q, want %q", got, want)
 	}
 }
 
@@ -362,6 +366,48 @@ func TestExport_List_RenderOverride_FilterOperatorKey(t *testing.T) {
 	}
 	if _, bad := filters["status][ne"]; bad {
 		t.Errorf("operator segment swallowed into the key: %v", filters)
+	}
+}
+
+// TestExport_List_RenderOverride_ConfigIDDistinctFromEntityPath pins the
+// PROPERTY the "list:" infix exists for: a list whose id equals an entity type
+// name must not produce the same config identity as that type's entity-export
+// override. Asserting the literal string alone would pass even if the infix
+// were dropped.
+func TestExport_List_RenderOverride_ConfigIDDistinctFromEntityPath(t *testing.T) {
+	requireCp(t)
+	app := newExportApp(t)
+	seedExportTickets(app, "TKT-1")
+
+	// A list literally named "ticket" — the same string as the entity type,
+	// whose entity-export ConfigID is "export:ticket".
+	s := app.State()
+	cfg := *s.Cfg
+	cfg.Lists = map[string]dataentryconfig.List{
+		"ticket": {EntityType: "ticket", ExportRender: "docs/fancy_list.lua"},
+	}
+	cfg.Navigation = []dataentryconfig.NavigationEntry{{List: "ticket"}}
+	app.schema.Publish(&Schema{
+		Cfg: &cfg, Meta: s.Meta, StyleMap: s.StyleMap,
+		StyledTypes: s.StyledTypes, OpenAPIGen: s.OpenAPIGen,
+	})
+	fake := &fakeScriptEngine{stdout: func(fakeScriptCall) string { return "ok\n" }}
+	app.documents = newDocumentService(app.store, app.kv, "/", fake,
+		func() lua.WriteDeps { return lua.WriteDeps{} })
+	var err error
+	if app.export, err = newExportHandler(app); err != nil {
+		t.Fatalf("newExportHandler: %v", err)
+	}
+	ctx := adminListCtx(t, app)
+
+	exportListURL(ctx, app, "transform=copy&list=ticket")
+
+	if len(fake.calls) != 1 {
+		t.Fatalf("want 1 call, got %d", len(fake.calls))
+	}
+	got := fake.calls[0].documentID
+	if entityPathID := "export:" + "ticket"; got == entityPathID {
+		t.Errorf("list ConfigID %q collides with the entity path's %q", got, entityPathID)
 	}
 }
 

--- a/internal/dataentry/export_list_render_test.go
+++ b/internal/dataentry/export_list_render_test.go
@@ -275,11 +275,10 @@ func TestExport_List_RenderOverride_TruncationReachesScript(t *testing.T) {
 	if call.query.Total != 5 {
 		t.Errorf("Total = %d, want 5 (pre-cap count)", call.query.Total)
 	}
-	if call.query.Rendered != 2 {
-		t.Errorf("Rendered = %d, want 2", call.query.Rendered)
-	}
-	if !call.query.Truncated {
-		t.Error("Truncated = false, want true")
+	// Truncation is derived at render time from Total vs the row count, so
+	// assert the two inputs the script's `truncated` is computed from.
+	if got := call.query.Total > len(call.rowIDs); !got {
+		t.Error("Total <= rows, so the script would see truncated=false")
 	}
 	// The built-in truncation notice must NOT appear — the script owns its
 	// own notice when it overrides.
@@ -327,8 +326,8 @@ func TestExport_List_RenderOverride_QueryContext(t *testing.T) {
 		t.Fatalf("want 1 call, got %d", len(fake.calls))
 	}
 	q := fake.calls[0].query
-	if q.ListID != "tickets" || q.EntityType != "ticket" {
-		t.Errorf("list identity wrong: %+v", q)
+	if fake.calls[0].listID != "tickets" || q.EntityType != "ticket" {
+		t.Errorf("list identity wrong: listID=%q %+v", fake.calls[0].listID, q)
 	}
 	if q.Q != "urgent" {
 		t.Errorf("Q = %q, want %q", q.Q, "urgent")
@@ -338,6 +337,31 @@ func TestExport_List_RenderOverride_QueryContext(t *testing.T) {
 	}
 	if len(q.Sort) != 1 || q.Sort[0].Property != "title" || q.Sort[0].Direction != "desc" {
 		t.Errorf("Sort = %+v, want one {title desc}", q.Sort)
+	}
+}
+
+// TestExport_List_RenderOverride_FilterOperatorKey pins that an operator
+// segment is parsed, not swallowed into the property name (the RR-6RF60V bug
+// class). A naive TrimPrefix/TrimSuffix keys this table on "status][ne", so a
+// script would report a filter name that never matches what was filtered on.
+func TestExport_List_RenderOverride_FilterOperatorKey(t *testing.T) {
+	requireCp(t)
+	app := newExportApp(t)
+	seedExportTickets(app, "TKT-1")
+	fake := withListRenderOverride(t, app, func(fakeScriptCall) string { return "ok\n" })
+	ctx := adminListCtx(t, app)
+
+	exportListURL(ctx, app, "transform=copy&list=tickets&filter[status][ne]=done")
+
+	if len(fake.calls) != 1 {
+		t.Fatalf("want 1 call, got %d", len(fake.calls))
+	}
+	filters := fake.calls[0].query.Filters
+	if got, ok := filters["status"]; !ok || got != "done" {
+		t.Errorf("Filters = %v, want the operator segment parsed off to key %q", filters, "status")
+	}
+	if _, bad := filters["status][ne"]; bad {
+		t.Errorf("operator segment swallowed into the key: %v", filters)
 	}
 }
 

--- a/internal/dataentry/export_list_render_test.go
+++ b/internal/dataentry/export_list_render_test.go
@@ -1,0 +1,365 @@
+package dataentry
+
+import (
+	"context"
+	"maps"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/Sourcehaven-BV/rela/internal/acl"
+	"github.com/Sourcehaven-BV/rela/internal/dataentryconfig"
+	"github.com/Sourcehaven-BV/rela/internal/entity"
+	"github.com/Sourcehaven-BV/rela/internal/lua"
+)
+
+// withListRenderOverride configures a per-LIST export_render override on the
+// fixture's "tickets" list and swaps app.documents for a fake-script-engine
+// documentService, so the override tests exercise the render path without a
+// real Lua runtime. Mirrors withRenderOverride (the per-type equivalent),
+// including the step that is easy to forget: rebuilding app.export so the
+// handler picks up both the republished config and the swapped document
+// service.
+func withListRenderOverride(
+	t *testing.T, app *App, output func(c fakeScriptCall) string,
+) *fakeScriptEngine {
+	t.Helper()
+	const listID = "tickets"
+	s := app.State()
+	cfg := *s.Cfg
+	lists := make(map[string]dataentryconfig.List, len(cfg.Lists))
+	maps.Copy(lists, cfg.Lists)
+	l := lists[listID]
+	l.ExportRender = "docs/fancy_list.lua"
+	lists[listID] = l
+	cfg.Lists = lists
+	app.schema.Publish(&Schema{
+		Cfg: &cfg, Meta: s.Meta, StyleMap: s.StyleMap,
+		StyledTypes: s.StyledTypes, OpenAPIGen: s.OpenAPIGen,
+	})
+
+	fake := &fakeScriptEngine{stdout: output}
+	deps := func() lua.WriteDeps { return lua.WriteDeps{} }
+	app.documents = newDocumentService(app.store, app.kv, "/", fake, deps)
+	var err error
+	if app.export, err = newExportHandler(app); err != nil {
+		t.Fatalf("newExportHandler: %v", err)
+	}
+	return fake
+}
+
+// exportListURL drives a list export against an arbitrary query string, so
+// tests can exercise the no-`list=` fallback and filter/sort context.
+func exportListURL(ctx context.Context, app *App, rawQuery string) *httptest.ResponseRecorder {
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/tickets/_export?"+rawQuery, http.NoBody)
+	req = req.WithContext(ctx)
+	rec := httptest.NewRecorder()
+	app.export.handleV1ExportList(rec, req, "ticket")
+	return rec
+}
+
+// adminListCtx seeds an admin ACL that can read everything and returns a
+// gated context for alice.
+func adminListCtx(t *testing.T, app *App) context.Context {
+	t.Helper()
+	d := mustNewACL(t, &acl.Policy{
+		Roles:       map[string]acl.RoleDef{"admin": {Read: []string{"ticket", "feature"}}},
+		Assignments: map[string]string{"alice": "admin"},
+	}, app.store)
+	app.acl = d
+	return gateCtxFor(aliceCtx(), t, d)
+}
+
+func seedExportTickets(app *App, ids ...string) {
+	for _, id := range ids {
+		seedEntity(app, &entity.Entity{ID: id, Type: "ticket",
+			Properties: map[string]any{"title": "Title " + id, "status": "open"}})
+	}
+}
+
+// TestExport_List_RenderOverride is the core contract: the configured script
+// replaces the built-in column table entirely.
+func TestExport_List_RenderOverride(t *testing.T) {
+	requireCp(t)
+	app := newExportApp(t)
+	seedExportTickets(app, "TKT-1", "TKT-2")
+	fake := withListRenderOverride(t, app, func(c fakeScriptCall) string {
+		return "# Fancy " + c.listID + " (" + strings.Join(c.rowIDs, ",") + ")\n"
+	})
+	ctx := adminListCtx(t, app)
+
+	rec := exportListURL(ctx, app, "transform=copy&list=tickets")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body)
+	}
+	body := rec.Body.String()
+
+	if !strings.Contains(body, "# Fancy tickets (TKT-1,TKT-2)") {
+		t.Errorf("override output missing:\n%s", body)
+	}
+	// The negative half: the built-in table must be fully replaced, not
+	// prepended or appended to.
+	if strings.Contains(body, "| Title | Status |") {
+		t.Errorf("built-in column table leaked into an overridden export:\n%s", body)
+	}
+	if fake.callCount() != 1 {
+		t.Errorf("want exactly 1 script call, got %d", fake.callCount())
+	}
+}
+
+// TestExport_List_NoOverrideUsesBuiltin guards the regression direction: a
+// list without export_render keeps the column table, and no script runs.
+func TestExport_List_NoOverrideUsesBuiltin(t *testing.T) {
+	requireCp(t)
+	app := newExportApp(t)
+	seedExportTickets(app, "TKT-1")
+
+	// Override configured on a DIFFERENT list, so the tickets export must
+	// not pick it up.
+	s := app.State()
+	cfg := *s.Cfg
+	lists := map[string]dataentryconfig.List{}
+	maps.Copy(lists, cfg.Lists)
+	lists["other"] = dataentryconfig.List{
+		EntityType:   "feature",
+		Columns:      []dataentryconfig.ListColumn{{Property: "title"}},
+		ExportRender: "docs/other.lua",
+	}
+	cfg.Lists = lists
+	app.schema.Publish(&Schema{
+		Cfg: &cfg, Meta: s.Meta, StyleMap: s.StyleMap,
+		StyledTypes: s.StyledTypes, OpenAPIGen: s.OpenAPIGen,
+	})
+	fake := &fakeScriptEngine{stdout: func(fakeScriptCall) string { return "SHOULD NOT RUN" }}
+	app.documents = newDocumentService(app.store, app.kv, "/", fake,
+		func() lua.WriteDeps { return lua.WriteDeps{} })
+	var err error
+	if app.export, err = newExportHandler(app); err != nil {
+		t.Fatalf("newExportHandler: %v", err)
+	}
+	ctx := adminListCtx(t, app)
+
+	body := exportListURL(ctx, app, "transform=copy&list=tickets").Body.String()
+	if !strings.Contains(body, "| Title | Status | Implements |") {
+		t.Errorf("built-in header row missing:\n%s", body)
+	}
+	if strings.Contains(body, "SHOULD NOT RUN") {
+		t.Errorf("unrelated list's override ran:\n%s", body)
+	}
+	if fake.callCount() != 0 {
+		t.Errorf("no script should have run, got %d calls", fake.callCount())
+	}
+}
+
+// TestExport_List_RenderOverride_EffectiveListFallback is the regression test
+// for resolving the override independently of the columns: a request with no
+// ?list= must still find the type's default list AND its override.
+func TestExport_List_RenderOverride_EffectiveListFallback(t *testing.T) {
+	requireCp(t)
+	app := newExportApp(t)
+	seedExportTickets(app, "TKT-1")
+	withListRenderOverride(t, app, func(c fakeScriptCall) string {
+		return "# Fallback " + c.listID + "\n"
+	})
+	ctx := adminListCtx(t, app)
+
+	// No list= param at all — the type's default list comes from navigation.
+	body := exportListURL(ctx, app, "transform=copy").Body.String()
+	if !strings.Contains(body, "# Fallback tickets") {
+		t.Errorf("override did not apply without an explicit list= param:\n%s", body)
+	}
+	if strings.Contains(body, "| Title | Status |") {
+		t.Errorf("built-in table rendered instead of the override:\n%s", body)
+	}
+}
+
+// TestExport_List_RenderOverride_ColumnlessList pins that a list carrying an
+// override but no columns still gets its override. The columns predicate is a
+// columns concern; folding it into list identity would silently skip this.
+func TestExport_List_RenderOverride_ColumnlessList(t *testing.T) {
+	requireCp(t)
+	app := newExportApp(t)
+	seedExportTickets(app, "TKT-1")
+
+	s := app.State()
+	cfg := *s.Cfg
+	cfg.Lists = map[string]dataentryconfig.List{
+		"tickets": {EntityType: "ticket", ExportRender: "docs/fancy_list.lua"},
+	}
+	app.schema.Publish(&Schema{
+		Cfg: &cfg, Meta: s.Meta, StyleMap: s.StyleMap,
+		StyledTypes: s.StyledTypes, OpenAPIGen: s.OpenAPIGen,
+	})
+	fake := &fakeScriptEngine{stdout: func(c fakeScriptCall) string { return "# Columnless " + c.listID + "\n" }}
+	app.documents = newDocumentService(app.store, app.kv, "/", fake,
+		func() lua.WriteDeps { return lua.WriteDeps{} })
+	var err error
+	if app.export, err = newExportHandler(app); err != nil {
+		t.Fatalf("newExportHandler: %v", err)
+	}
+	ctx := adminListCtx(t, app)
+
+	body := exportListURL(ctx, app, "transform=copy&list=tickets").Body.String()
+	if !strings.Contains(body, "# Columnless tickets") {
+		t.Errorf("override on a columns-less list did not apply:\n%s", body)
+	}
+}
+
+// TestExport_List_RenderOverride_DeniedSeesNoRows asserts the override sits
+// downstream of the ACL read. A denied caller yields an EMPTY row set and a
+// 200 — deliberately not a 404, which is what the built-in table does too;
+// diverging would leak "no access" vs "no rows".
+func TestExport_List_RenderOverride_DeniedSeesNoRows(t *testing.T) {
+	requireCp(t)
+	app := newExportApp(t)
+	seedEntity(app, &entity.Entity{ID: "TKT-1", Type: "ticket",
+		Properties: map[string]any{"title": "Top Secret"}})
+	fake := withListRenderOverride(t, app, func(c fakeScriptCall) string {
+		return "rows=" + strings.Join(c.rowIDs, ",") + "\n"
+	})
+
+	// alice may read features, not tickets.
+	d := mustNewACL(t, &acl.Policy{
+		Roles:       map[string]acl.RoleDef{"viewer": {Read: []string{"feature"}}},
+		Assignments: map[string]string{"alice": "viewer"},
+	}, app.store)
+	app.acl = d
+	ctx := gateCtxFor(aliceCtx(), t, d)
+
+	rec := exportListURL(ctx, app, "transform=copy&list=tickets")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (empty set, not 404)", rec.Code)
+	}
+	if strings.Contains(rec.Body.String(), "Top Secret") {
+		t.Errorf("denied export leaked entity content: %s", rec.Body)
+	}
+	if len(fake.calls) != 1 {
+		t.Fatalf("want 1 call, got %d", len(fake.calls))
+	}
+	if got := fake.calls[0].rowIDs; len(got) != 0 {
+		t.Errorf("denied caller's script saw rows %v, want none", got)
+	}
+	if got := fake.calls[0].query.Total; got != 0 {
+		t.Errorf("Total = %d, want 0 for a denied caller", got)
+	}
+}
+
+// TestExport_List_RenderOverride_TruncationReachesScript asserts the cap
+// bookkeeping reaches the script so an override can render its own notice.
+func TestExport_List_RenderOverride_TruncationReachesScript(t *testing.T) {
+	requireCp(t)
+	app := newExportApp(t)
+	seedExportTickets(app, "TKT-1", "TKT-2", "TKT-3", "TKT-4", "TKT-5")
+
+	orig := listExportCap
+	t.Cleanup(func() { listExportCap = orig })
+	listExportCap = 2
+
+	fake := withListRenderOverride(t, app, func(fakeScriptCall) string {
+		return "rendered\n"
+	})
+	ctx := adminListCtx(t, app)
+
+	rec := exportListURL(ctx, app, "transform=copy&list=tickets")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body)
+	}
+	if len(fake.calls) != 1 {
+		t.Fatalf("want 1 call, got %d", len(fake.calls))
+	}
+	call := fake.calls[0]
+	if len(call.rowIDs) != 2 {
+		t.Errorf("script saw %d rows, want 2 (the cap)", len(call.rowIDs))
+	}
+	if call.query.Total != 5 {
+		t.Errorf("Total = %d, want 5 (pre-cap count)", call.query.Total)
+	}
+	if call.query.Rendered != 2 {
+		t.Errorf("Rendered = %d, want 2", call.query.Rendered)
+	}
+	if !call.query.Truncated {
+		t.Error("Truncated = false, want true")
+	}
+	// The built-in truncation notice must NOT appear — the script owns its
+	// own notice when it overrides.
+	if strings.Contains(rec.Body.String(), "truncated") {
+		t.Errorf("built-in truncation notice leaked into an override:\n%s", rec.Body)
+	}
+}
+
+// TestExport_List_RenderOverride_RowsWalkableTwice pins the iterator contract
+// at the provider level: a script that walks once to total and again to emit
+// must see the full set both times.
+func TestExport_List_RenderOverride_RowsWalkableTwice(t *testing.T) {
+	requireCp(t)
+	app := newExportApp(t)
+	seedExportTickets(app, "TKT-1", "TKT-2", "TKT-3")
+	fake := withListRenderOverride(t, app, func(fakeScriptCall) string { return "ok\n" })
+	ctx := adminListCtx(t, app)
+
+	exportListURL(ctx, app, "transform=copy&list=tickets")
+
+	if len(fake.calls) != 1 {
+		t.Fatalf("want 1 call, got %d", len(fake.calls))
+	}
+	call := fake.calls[0]
+	if len(call.rowIDs) != 3 {
+		t.Fatalf("first walk saw %d rows, want 3", len(call.rowIDs))
+	}
+	if strings.Join(call.rowIDs, ",") != strings.Join(call.rowIDs2, ",") {
+		t.Errorf("second walk differed: %v vs %v", call.rowIDs, call.rowIDs2)
+	}
+}
+
+// TestExport_List_RenderOverride_QueryContext asserts the resolved filters and
+// sort reach the script, so an override can title and annotate the export.
+func TestExport_List_RenderOverride_QueryContext(t *testing.T) {
+	requireCp(t)
+	app := newExportApp(t)
+	seedExportTickets(app, "TKT-1")
+	fake := withListRenderOverride(t, app, func(fakeScriptCall) string { return "ok\n" })
+	ctx := adminListCtx(t, app)
+
+	exportListURL(ctx, app, "transform=copy&list=tickets&filter[status]=open&sort=-title&q=urgent")
+
+	if len(fake.calls) != 1 {
+		t.Fatalf("want 1 call, got %d", len(fake.calls))
+	}
+	q := fake.calls[0].query
+	if q.ListID != "tickets" || q.EntityType != "ticket" {
+		t.Errorf("list identity wrong: %+v", q)
+	}
+	if q.Q != "urgent" {
+		t.Errorf("Q = %q, want %q", q.Q, "urgent")
+	}
+	if q.Filters["status"] != "open" {
+		t.Errorf("Filters = %v, want status=open", q.Filters)
+	}
+	if len(q.Sort) != 1 || q.Sort[0].Property != "title" || q.Sort[0].Direction != "desc" {
+		t.Errorf("Sort = %+v, want one {title desc}", q.Sort)
+	}
+}
+
+// TestExport_List_RenderOverride_ConfigIDNamespaced pins the synthetic config
+// identity, whose "list:" infix keeps a list id from colliding with an entity
+// type name on the entity export path.
+func TestExport_List_RenderOverride_ConfigIDNamespaced(t *testing.T) {
+	requireCp(t)
+	app := newExportApp(t)
+	seedExportTickets(app, "TKT-1")
+	fake := withListRenderOverride(t, app, func(fakeScriptCall) string { return "ok\n" })
+	ctx := adminListCtx(t, app)
+
+	exportListURL(ctx, app, "transform=copy&list=tickets")
+
+	if len(fake.calls) != 1 {
+		t.Fatalf("want 1 call, got %d", len(fake.calls))
+	}
+	if got, want := fake.calls[0].documentID, "export:list:tickets"; got != want {
+		t.Errorf("documentID = %q, want %q", got, want)
+	}
+	if got, want := fake.calls[0].path, "docs/fancy_list.lua"; got != want {
+		t.Errorf("script path = %q, want %q", got, want)
+	}
+}

--- a/internal/dataentryconfig/config.go
+++ b/internal/dataentryconfig/config.go
@@ -235,6 +235,21 @@ type List struct {
 	DetailView     string          `yaml:"detail_view" json:"detail_view,omitempty"`
 	PageSize       int             `yaml:"page_size" json:"page_size,omitempty"`
 	Actions        []string        `yaml:"actions,omitempty" json:"actions,omitempty"`
+
+	// ExportRender is an optional Lua script (relative path under scripts/,
+	// e.g. "docs/ticket_report.lua") that renders THIS LIST for export. When
+	// set, "Export as PDF/ODT" on the list routes through the script instead
+	// of the built-in column table, so an operator fully controls the
+	// exported document (grouped sections, summaries, a cover header —
+	// anything a table cannot express).
+	//
+	// The script runs in list-document mode and receives the rows the server
+	// already resolved: rela.document.rows()/row(i)/count, plus the resolved
+	// query as read-only context. It must NOT derive its own row set — the
+	// handler resolved exactly the ACL-scoped, filtered, sorted, capped set
+	// the user is looking at, and re-querying would both diverge from that
+	// view and escape the row cap. Empty → built-in column table.
+	ExportRender string `yaml:"export_render,omitempty" json:"export_render,omitempty"`
 }
 
 // ListColumn defines a column in a list view.

--- a/internal/dataentryconfig/validate.go
+++ b/internal/dataentryconfig/validate.go
@@ -452,6 +452,30 @@ func validateEntityViews(cfg *Config, meta *metamodel.Metamodel) []string {
 	return errs
 }
 
+// validateExportRenderShape validates an `export_render:` script path's shape.
+// Shape only — whether the file exists on disk is checked at app construction,
+// which is where the project root is known (see dataentry.NewApp).
+//
+// Shared by the list and view overrides so the two cannot fail differently:
+// before this, a typo'd list path failed here while the identical typo on a
+// view fell through to a generic loader error at boot. kind/id name the owner
+// for the message ("list"/"view").
+func validateExportRenderShape(kind, id, path string) []string {
+	if path == "" {
+		return nil
+	}
+	var errs []string
+	if !strings.HasSuffix(path, ".lua") {
+		errs = append(errs, fmt.Sprintf(
+			"%s %q: export_render must be a .lua script path, got %q", kind, id, path))
+	}
+	if !filepath.IsLocal(path) {
+		errs = append(errs, fmt.Sprintf(
+			"%s %q: export_render must be a local path under scripts/, got %q", kind, id, path))
+	}
+	return errs
+}
+
 // validateLists validates list definitions.
 //
 //nolint:gocognit // linear validation dispatcher: one independent config-vs-metamodel check per branch; splitting would scatter the rule set without lowering real complexity.
@@ -465,21 +489,7 @@ func validateLists(cfg *Config, meta *metamodel.Metamodel) []string {
 			continue
 		}
 
-		// Validate the export render override. Shape only — whether the file
-		// exists on disk is checked at app construction, which is where the
-		// project root is known (see dataentry.NewApp).
-		if list.ExportRender != "" {
-			if !strings.HasSuffix(list.ExportRender, ".lua") {
-				errs = append(errs, fmt.Sprintf(
-					"list %q: export_render must be a .lua script path, got %q",
-					listID, list.ExportRender))
-			}
-			if !filepath.IsLocal(list.ExportRender) {
-				errs = append(errs, fmt.Sprintf(
-					"list %q: export_render must be a local path under scripts/, got %q",
-					listID, list.ExportRender))
-			}
-		}
+		errs = append(errs, validateExportRenderShape("list", listID, list.ExportRender)...)
 
 		// Validate columns
 		for i, c := range list.Columns {
@@ -762,6 +772,11 @@ func validateViews(cfg *Config, meta *metamodel.Metamodel) []string {
 	}
 
 	for viewID, view := range cfg.Views {
+		// Before the entry-type check, which continues on failure: a bad
+		// export_render path is worth reporting even on a view whose entry
+		// type is also wrong.
+		errs = append(errs, validateExportRenderShape("view", viewID, view.ExportRender)...)
+
 		// Validate entry type
 		entDef, ok := meta.GetEntityDef(view.Entry.Type)
 		if !ok {

--- a/internal/dataentryconfig/validate.go
+++ b/internal/dataentryconfig/validate.go
@@ -465,6 +465,22 @@ func validateLists(cfg *Config, meta *metamodel.Metamodel) []string {
 			continue
 		}
 
+		// Validate the export render override. Shape only — whether the file
+		// exists on disk is checked at app construction, which is where the
+		// project root is known (see dataentry.NewApp).
+		if list.ExportRender != "" {
+			if !strings.HasSuffix(list.ExportRender, ".lua") {
+				errs = append(errs, fmt.Sprintf(
+					"list %q: export_render must be a .lua script path, got %q",
+					listID, list.ExportRender))
+			}
+			if !filepath.IsLocal(list.ExportRender) {
+				errs = append(errs, fmt.Sprintf(
+					"list %q: export_render must be a local path under scripts/, got %q",
+					listID, list.ExportRender))
+			}
+		}
+
 		// Validate columns
 		for i, c := range list.Columns {
 			if c.Relation != "" {

--- a/internal/dataentryconfig/validate_test.go
+++ b/internal/dataentryconfig/validate_test.go
@@ -602,6 +602,77 @@ func TestValidateConfig_UnknownListEntityType(t *testing.T) {
 	}
 }
 
+// TestValidateConfig_ListExportRenderShape covers the shape half of
+// export_render validation. Existence on disk is checked at app construction,
+// where the project root is known.
+func TestValidateConfig_ListExportRenderShape(t *testing.T) {
+	tests := []struct {
+		name    string
+		script  string
+		wantErr string
+	}{
+		{
+			name:    "non-lua extension rejected",
+			script:  "docs/report.sh",
+			wantErr: `list "test": export_render must be a .lua script path`,
+		},
+		{
+			name:    "traversal rejected",
+			script:  "../../etc/evil.lua",
+			wantErr: `list "test": export_render must be a local path`,
+		},
+		{
+			name:   "valid script accepted",
+			script: "docs/report.lua",
+		},
+		{
+			name:   "empty means built-in table",
+			script: "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			meta := testMetamodel()
+			cfg := &Config{
+				Lists: map[string]List{
+					"test": {EntityType: "ticket", ExportRender: tc.script},
+				},
+			}
+
+			err := ValidateConfig([]byte(`version: "1.0"`), cfg, meta)
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("expected error for export_render %q", tc.script)
+			}
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Errorf("want error containing %q, got: %v", tc.wantErr, err)
+			}
+		})
+	}
+}
+
+// TestValidateConfig_ListExportRenderWithoutColumns pins that a list carrying
+// only an export_render (no columns) is valid — the script renders whatever it
+// likes, so requiring columns would be wrong.
+func TestValidateConfig_ListExportRenderWithoutColumns(t *testing.T) {
+	meta := testMetamodel()
+	cfg := &Config{
+		Lists: map[string]List{
+			"test": {EntityType: "ticket", ExportRender: "docs/report.lua"},
+		},
+	}
+
+	if err := ValidateConfig([]byte(`version: "1.0"`), cfg, meta); err != nil {
+		t.Fatalf("a columns-less list with export_render must be valid, got: %v", err)
+	}
+}
+
 func TestValidateConfig_UnknownListColumnProperty(t *testing.T) {
 	meta := testMetamodel()
 	cfg := &Config{

--- a/internal/lua/listmode.go
+++ b/internal/lua/listmode.go
@@ -1,6 +1,9 @@
 package lua
 
-import "github.com/Sourcehaven-BV/rela/internal/entity"
+import (
+	"github.com/Sourcehaven-BV/rela/internal/entity"
+	"github.com/Sourcehaven-BV/rela/internal/filter"
+)
 
 // ListRows supplies the rows a list-document render displays.
 //
@@ -24,29 +27,28 @@ type ListRows interface {
 	At(i int) *entity.Entity
 }
 
-// ListSortSpec is one resolved sort criterion, in priority order.
-type ListSortSpec struct {
-	Property  string
-	Direction string
-}
+// ListSortSpec is one resolved sort criterion, in priority order. Aliased to
+// the shared sort type rather than redeclared, following the same move
+// filter.SortSpec already makes — one sort shape across metamodel, filter,
+// and here, so a caller can pass parsed specs straight through.
+type ListSortSpec = filter.SortSpec
 
-// ListQuery is the read-only request context a list render receives: which
-// list, over which entity type, under which filters and sort, and how the
-// row cap applied. Plain data — a script may read it to title and annotate
-// the export, but it is exposed through a frozen Lua table so it cannot be
-// used as a back-channel to mutate the handler's state.
+// ListQuery is the read-only request context a list render receives: the
+// entity type, the filters and sort that produced the rows, and how many rows
+// existed before the export cap. Plain data — a script may read it to title
+// and annotate the export, but it is exposed through a frozen Lua table so it
+// cannot be used as a back-channel to mutate the handler's state.
 //
-// Total is the row count BEFORE the cap; Rendered is what the script can
-// actually see (== ListRows.Len()). They differ exactly when Truncated.
+// Total is the row count BEFORE the cap. How many the script can actually see
+// is ListRows.Len(), and whether the cap applied is Total > that — both
+// derived at render time rather than stored, so the three can never disagree.
+// The list's identity lives on [ListRenderContext], not here.
 type ListQuery struct {
-	ListID     string
 	EntityType string
 	Q          string
 	Filters    map[string]string
 	Sort       []ListSortSpec
 	Total      int
-	Rendered   int
-	Truncated  bool
 }
 
 // ListRenderContext bundles everything a list-document render needs beyond

--- a/internal/lua/listmode.go
+++ b/internal/lua/listmode.go
@@ -1,0 +1,60 @@
+package lua
+
+import "github.com/Sourcehaven-BV/rela/internal/entity"
+
+// ListRows supplies the rows a list-document render displays.
+//
+// Defined here at the consumer (per CLAUDE.md "interfaces at the call site")
+// so the lua package never learns about data-entry: the wiring site passes an
+// adapter over a slice it has already resolved. Two methods because the
+// bindings need both a cheap length (rela.document.count, without draining)
+// and indexed access (row(i) / the rows() iterator).
+//
+// The rows are ALREADY resolved, ACL-scoped, filtered, sorted, and capped by
+// the caller. The lua package performs no query of its own for them — that
+// is the whole point of the seam. A list render must show what the on-screen
+// view showed; re-deriving the set here would let the export drift from the
+// view and escape the caller's row cap.
+//
+// At is called once per materialization, and a script may walk the set more
+// than once, so implementations must be repeatable for the same index and
+// must return nil when i is out of range.
+type ListRows interface {
+	Len() int
+	At(i int) *entity.Entity
+}
+
+// ListSortSpec is one resolved sort criterion, in priority order.
+type ListSortSpec struct {
+	Property  string
+	Direction string
+}
+
+// ListQuery is the read-only request context a list render receives: which
+// list, over which entity type, under which filters and sort, and how the
+// row cap applied. Plain data — a script may read it to title and annotate
+// the export, but it is exposed through a frozen Lua table so it cannot be
+// used as a back-channel to mutate the handler's state.
+//
+// Total is the row count BEFORE the cap; Rendered is what the script can
+// actually see (== ListRows.Len()). They differ exactly when Truncated.
+type ListQuery struct {
+	ListID     string
+	EntityType string
+	Q          string
+	Filters    map[string]string
+	Sort       []ListSortSpec
+	Total      int
+	Rendered   int
+	Truncated  bool
+}
+
+// ListRenderContext bundles everything a list-document render needs beyond
+// the script path itself. Bundled rather than passed as three more
+// parameters so [WithListDocumentMode] stays a two-argument option and
+// script.Engine.ExecuteListDocument keeps a readable signature.
+type ListRenderContext struct {
+	ListID string
+	Rows   ListRows
+	Query  ListQuery
+}

--- a/internal/lua/listmode.go
+++ b/internal/lua/listmode.go
@@ -22,6 +22,13 @@ import (
 // At is called once per materialization, and a script may walk the set more
 // than once, so implementations must be repeatable for the same index and
 // must return nil when i is out of range.
+//
+// Rows reach the script through EntityToTable, which includes the entity
+// BODY. Property-level `visible:` redaction is already applied by the caller,
+// but visibility.Redact does not currently redact Content (the body-redaction
+// TODO in internal/visibility). When it does, this is one of the paths that
+// must route through it — a render override is a read-out surface like any
+// other.
 type ListRows interface {
 	Len() int
 	At(i int) *entity.Entity
@@ -39,9 +46,11 @@ type ListSortSpec = filter.SortSpec
 // and annotate the export, but it is exposed through a frozen Lua table so it
 // cannot be used as a back-channel to mutate the handler's state.
 //
-// Total is the row count BEFORE the cap. How many the script can actually see
-// is ListRows.Len(), and whether the cap applied is Total > that — both
-// derived at render time rather than stored, so the three can never disagree.
+// Total is the row count BEFORE the cap; how many the script can actually see
+// is ListRows.Len(), and whether the cap applied is derived from the two at
+// render time rather than stored. Total is the one value a caller supplies
+// independently, so the render clamps it up to the row count — a Total that
+// under-reports the rows it ships with cannot produce an incoherent view.
 // The list's identity lives on [ListRenderContext], not here.
 type ListQuery struct {
 	EntityType string

--- a/internal/lua/listmode_test.go
+++ b/internal/lua/listmode_test.go
@@ -34,13 +34,11 @@ func testListContext() ListRenderContext {
 		ListID: "tickets",
 		Rows:   testRows(),
 		Query: ListQuery{
-			ListID:     "tickets",
 			EntityType: "ticket",
 			Q:          "urgent",
 			Filters:    map[string]string{"status": "open"},
 			Sort:       []ListSortSpec{{Property: "title", Direction: "asc"}},
 			Total:      3,
-			Rendered:   3,
 		},
 	}
 }
@@ -219,8 +217,6 @@ func TestListDocumentMode_Truncation(t *testing.T) {
 	lrc := testListContext()
 	lrc.Rows = testRows()[:2]
 	lrc.Query.Total = 57
-	lrc.Query.Rendered = 2
-	lrc.Query.Truncated = true
 
 	got := runListDoc(t, lrc, `
 print(("showing %d of %d, truncated=%s"):format(

--- a/internal/lua/listmode_test.go
+++ b/internal/lua/listmode_test.go
@@ -227,3 +227,101 @@ print(("showing %d of %d, truncated=%s"):format(
 		t.Errorf("truncation bookkeeping wrong:\n%s", got)
 	}
 }
+
+// TestListDocumentMode_EdgeCases covers the boundaries a render override can
+// hit in practice: nothing to render, a script that ignores the rows, a script
+// that drains an iterator and then walks again, and the exact-cap case where
+// truncated must stay false.
+func TestListDocumentMode_EdgeCases(t *testing.T) {
+	cases := []struct {
+		name string
+		lrc  ListRenderContext
+		src  string
+		want string
+	}{
+		{
+			name: "empty row set",
+			lrc: ListRenderContext{ListID: "l", Rows: sliceRows{},
+				Query: ListQuery{EntityType: "ticket", Total: 0}},
+			src: `local n=0
+for _ in rela.document.rows() do n=n+1 end
+print(("count=%d n=%d trunc=%s"):format(rela.document.count, n, tostring(rela.document.truncated)))`,
+			want: "count=0 n=0 trunc=false",
+		},
+		{
+			name: "script never iterates",
+			lrc:  testListContext(),
+			src:  `print("ignored rows entirely")`,
+			want: "ignored rows entirely",
+		},
+		{
+			name: "iterate past end then re-walk",
+			lrc:  testListContext(),
+			src: `local it = rela.document.rows()
+for i=1,10 do it() end
+local n=0
+for _ in rela.document.rows() do n=n+1 end
+print("after-exhaust n=" .. n)`,
+			want: "after-exhaust n=3",
+		},
+		{
+			name: "total equals len - no truncation at boundary",
+			lrc: ListRenderContext{ListID: "l", Rows: testRows(),
+				Query: ListQuery{EntityType: "ticket", Total: 3}},
+			src:  `print("trunc=" .. tostring(rela.document.truncated))`,
+			want: "trunc=false",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ws := newMockWorkspace(t)
+			var buf bytes.Buffer
+			r := NewReader(ws.readDeps(t.TempDir()), &buf, WithListDocumentMode("d", tc.lrc))
+			defer r.Close()
+			if err := r.RunString(tc.src); err != nil {
+				t.Fatalf("run: %v (out=%s)", err, buf.String())
+			}
+			if !strings.Contains(buf.String(), tc.want) {
+				t.Errorf("want %q, got:\n%s", tc.want, buf.String())
+			}
+		})
+	}
+}
+
+// TestListDocumentMode_TotalClamped pins that an under-reported Total cannot
+// produce an incoherent view: a caller passing Total=0 alongside 3 rows must
+// still see total >= count, and truncated=false.
+func TestListDocumentMode_TotalClamped(t *testing.T) {
+	t.Parallel()
+
+	lrc := testListContext()
+	lrc.Query.Total = 0 // inconsistent with the 3 rows supplied
+
+	got := runListDoc(t, lrc, `
+print(("count=%d total=%d trunc=%s"):format(
+  rela.document.count, rela.document.total, tostring(rela.document.truncated)))
+`)
+	if !strings.Contains(got, "count=3 total=3 trunc=false") {
+		t.Errorf("under-reported Total not clamped:\n%s", got)
+	}
+}
+
+// TestListDocumentMode_EmptyQIsEmptyString pins that query.q is always a
+// string. It was previously omitted when empty, so `"Search: " .. query.q`
+// worked on a filtered export and hard-errored on every unfiltered one.
+func TestListDocumentMode_EmptyQIsEmptyString(t *testing.T) {
+	t.Parallel()
+
+	lrc := testListContext()
+	lrc.Query.Q = ""
+
+	got := runListDoc(t, lrc, `
+print("type=" .. type(rela.document.query.q))
+print("concat=[" .. rela.document.query.q .. "]")
+`)
+	for _, want := range []string{"type=string", "concat=[]"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("missing %q in output:\n%s", want, got)
+		}
+	}
+}

--- a/internal/lua/listmode_test.go
+++ b/internal/lua/listmode_test.go
@@ -1,0 +1,233 @@
+package lua
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/Sourcehaven-BV/rela/internal/entity"
+)
+
+// sliceRows is a test ListRows over a fixed slice. Mirrors the adapter the
+// data-entry export handler supplies in production.
+type sliceRows []*entity.Entity
+
+func (s sliceRows) Len() int { return len(s) }
+
+func (s sliceRows) At(i int) *entity.Entity {
+	if i < 0 || i >= len(s) {
+		return nil
+	}
+	return s[i]
+}
+
+func testRows() sliceRows {
+	return sliceRows{
+		{ID: "TKT-1", Type: "ticket", Properties: map[string]any{"title": "First"}},
+		{ID: "TKT-2", Type: "ticket", Properties: map[string]any{"title": "Second"}},
+		{ID: "TKT-3", Type: "ticket", Properties: map[string]any{"title": "Third"}},
+	}
+}
+
+func testListContext() ListRenderContext {
+	return ListRenderContext{
+		ListID: "tickets",
+		Rows:   testRows(),
+		Query: ListQuery{
+			ListID:     "tickets",
+			EntityType: "ticket",
+			Q:          "urgent",
+			Filters:    map[string]string{"status": "open"},
+			Sort:       []ListSortSpec{{Property: "title", Direction: "asc"}},
+			Total:      3,
+			Rendered:   3,
+		},
+	}
+}
+
+// runListDoc runs src in a list-document runtime and returns captured stdout.
+func runListDoc(t *testing.T, lrc ListRenderContext, src string) string {
+	t.Helper()
+	ws := newMockWorkspace(t)
+	var buf bytes.Buffer
+	r := NewReader(ws.readDeps(t.TempDir()), &buf,
+		WithListDocumentMode("export:list:tickets", lrc))
+	defer r.Close()
+
+	if err := r.RunString(src); err != nil {
+		t.Fatalf("run: %v\ncaptured: %s", err, buf.String())
+	}
+	return buf.String()
+}
+
+// TestListDocumentMode_Surface pins the rela.document fields a list render
+// sees, including the two that differ from an entity render.
+func TestListDocumentMode_Surface(t *testing.T) {
+	t.Parallel()
+
+	got := runListDoc(t, testListContext(), `
+print("mode=" .. rela.mode)
+print("list_id=" .. rela.document.list_id)
+print("entity_type=" .. rela.document.entity_type)
+print("id=" .. rela.document.id)
+print("count=" .. rela.document.count)
+print("total=" .. rela.document.total)
+print("truncated=" .. tostring(rela.document.truncated))
+print("q=" .. rela.document.query.q)
+print("status=" .. rela.document.query.filters.status)
+print("sort=" .. rela.document.query.sort[1].property .. ":" .. rela.document.query.sort[1].direction)
+`)
+
+	for _, want := range []string{
+		// mode stays "document": a list render reuses document mode
+		// wholesale rather than introducing a third mode.
+		"mode=document",
+		"list_id=tickets",
+		"entity_type=ticket",
+		"id=export:list:tickets",
+		"count=3",
+		"total=3",
+		"truncated=false",
+		"q=urgent",
+		"status=open",
+		"sort=title:asc",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("missing %q in output:\n%s", want, got)
+		}
+	}
+}
+
+// TestListDocumentMode_EntryIDAbsent is the regression test for the
+// empty-string footgun: entry_id must be Lua nil in list mode so the
+// idiomatic truthiness guard takes the correct branch and `or default`
+// yields the default.
+func TestListDocumentMode_EntryIDAbsent(t *testing.T) {
+	t.Parallel()
+
+	got := runListDoc(t, testListContext(), `
+print("type=" .. type(rela.document.entry_id))
+print("guard=" .. tostring(rela.document.entry_id ~= nil))
+print("default=" .. (rela.document.entry_id or "fallback"))
+`)
+
+	for _, want := range []string{"type=nil", "guard=false", "default=fallback"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("missing %q in output:\n%s", want, got)
+		}
+	}
+}
+
+// TestDocumentMode_EntryIDStillPresent guards the other direction: making
+// entry_id conditional must not change an ENTITY render.
+func TestDocumentMode_EntryIDStillPresent(t *testing.T) {
+	t.Parallel()
+
+	ws := newMockWorkspace(t)
+	var buf bytes.Buffer
+	r := NewReader(ws.readDeps(t.TempDir()), &buf, WithDocumentMode("book_card", "TKT-9"))
+	defer r.Close()
+
+	if err := r.RunString(`print("entry=" .. rela.document.entry_id)`); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if !strings.Contains(buf.String(), "entry=TKT-9") {
+		t.Errorf("entity-mode entry_id changed: %s", buf.String())
+	}
+	// And a list render's row bindings must NOT appear on an entity render.
+	buf.Reset()
+	if err := r.RunString(`print("rows=" .. type(rela.document.rows))`); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if !strings.Contains(buf.String(), "rows=nil") {
+		t.Errorf("entity render exposed list row bindings: %s", buf.String())
+	}
+}
+
+// TestListDocumentMode_RowAccess covers row(i) bounds and 1-based indexing.
+func TestListDocumentMode_RowAccess(t *testing.T) {
+	t.Parallel()
+
+	got := runListDoc(t, testListContext(), `
+print("first=" .. rela.document.row(1).id)
+print("title=" .. rela.document.row(1).properties.title)
+print("last=" .. rela.document.row(3).id)
+print("over=" .. type(rela.document.row(4)))
+print("zero=" .. type(rela.document.row(0)))
+`)
+
+	for _, want := range []string{
+		"first=TKT-1", "title=First", "last=TKT-3", "over=nil", "zero=nil",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("missing %q in output:\n%s", want, got)
+		}
+	}
+}
+
+// TestListDocumentMode_IteratorWalkableTwice pins the contract that each
+// rows() call mints a fresh cursor. A script that walks once to compute a
+// total and again to emit must see the full set both times.
+func TestListDocumentMode_IteratorWalkableTwice(t *testing.T) {
+	t.Parallel()
+
+	got := runListDoc(t, testListContext(), `
+local function walk()
+  local ids = {}
+  for _, row in rela.document.rows() do
+    ids[#ids+1] = row.id
+  end
+  return table.concat(ids, ",")
+end
+print("first=" .. walk())
+print("second=" .. walk())
+`)
+
+	if !strings.Contains(got, "first=TKT-1,TKT-2,TKT-3") {
+		t.Errorf("first walk wrong:\n%s", got)
+	}
+	if !strings.Contains(got, "second=TKT-1,TKT-2,TKT-3") {
+		t.Errorf("second walk did not restart — rows() must mint a fresh cursor:\n%s", got)
+	}
+}
+
+// TestListDocumentMode_QueryFrozen asserts the read-only context is enforced
+// rather than conventional.
+func TestListDocumentMode_QueryFrozen(t *testing.T) {
+	t.Parallel()
+
+	got := runListDoc(t, testListContext(), `
+local ok, err = pcall(function() rela.document.query.q = "tampered" end)
+print("ok=" .. tostring(ok))
+print("q=" .. rela.document.query.q)
+local ok2 = pcall(function() rela.document.query.filters.status = "closed" end)
+print("filters_ok=" .. tostring(ok2))
+`)
+
+	for _, want := range []string{"ok=false", "q=urgent", "filters_ok=false"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("missing %q in output:\n%s", want, got)
+		}
+	}
+}
+
+// TestListDocumentMode_Truncation asserts the cap bookkeeping reaches the
+// script, so an override can render its own "showing N of M" notice.
+func TestListDocumentMode_Truncation(t *testing.T) {
+	t.Parallel()
+
+	lrc := testListContext()
+	lrc.Rows = testRows()[:2]
+	lrc.Query.Total = 57
+	lrc.Query.Rendered = 2
+	lrc.Query.Truncated = true
+
+	got := runListDoc(t, lrc, `
+print(("showing %d of %d, truncated=%s"):format(
+  rela.document.count, rela.document.total, tostring(rela.document.truncated)))
+`)
+
+	if !strings.Contains(got, "showing 2 of 57, truncated=true") {
+		t.Errorf("truncation bookkeeping wrong:\n%s", got)
+	}
+}

--- a/internal/lua/runtime.go
+++ b/internal/lua/runtime.go
@@ -906,9 +906,12 @@ func registerListDocumentFields(ls *lua.LState, docTable *lua.LTable, lrc ListRe
 
 	ls.SetField(docTable, "list_id", lua.LString(lrc.ListID))
 	ls.SetField(docTable, "entity_type", lua.LString(q.EntityType))
+	// count/total/truncated all derive from the two facts the caller supplied
+	// (the row set and the pre-cap count), so a script can never observe them
+	// disagreeing with each other.
 	ls.SetField(docTable, "count", lua.LNumber(rows.Len()))
 	ls.SetField(docTable, "total", lua.LNumber(q.Total))
-	ls.SetField(docTable, "truncated", lua.LBool(q.Truncated))
+	ls.SetField(docTable, "truncated", lua.LBool(q.Total > rows.Len()))
 
 	// The resolved request context, frozen so "read-only" is enforced
 	// rather than conventional (same treatment rela.principal gets).
@@ -928,7 +931,7 @@ func registerListDocumentFields(ls *lua.LState, docTable *lua.LTable, lrc ListRe
 		ls.SetField(spec, "direction", lua.LString(s.Direction))
 		sort.RawSetInt(i+1, freezeTable(ls, spec))
 	}
-	ls.SetField(queryTable, "sort", sort)
+	ls.SetField(queryTable, "sort", freezeTable(ls, sort))
 	ls.SetField(docTable, "query", freezeTable(ls, queryTable))
 
 	// row(i) -> entity table | nil. 1-based, per Lua convention.

--- a/internal/lua/runtime.go
+++ b/internal/lua/runtime.go
@@ -90,9 +90,18 @@ type Runtime struct {
 	isDocument    bool              // document mode: rela.document populated, rela.output becomes a warning
 	documentID    string            // data-entry.yaml documents: key, exposed as rela.document.id
 	documentEntry string            // ID of the entity being rendered, exposed as rela.document.entry_id
-	aiProvider    ai.Provider       // nil means AI is not configured
-	cache         cacheStore        // nil means rela.cache.* is not registered
-	scriptPath    string            // set by RunFile; empty for RunString/inline
+
+	// listRender is set (non-nil Rows) only for a LIST document render — the
+	// lists: export_render override. It rides on document mode rather than
+	// introducing a third mode: a list render wants document mode's stdout
+	// capture and its rela.output warning verbatim, and a parallel mode
+	// would have to be OR-ed into every one of those guards forever.
+	// Entity renders leave this zero, so rela.document carries no row
+	// bindings there.
+	listRender ListRenderContext
+	aiProvider ai.Provider // nil means AI is not configured
+	cache      cacheStore  // nil means rela.cache.* is not registered
+	scriptPath string      // set by RunFile; empty for RunString/inline
 
 	// principal is the identity this runtime runs as, exposed read-only as
 	// rela.principal (TKT-5U6NRR). Set by [WithPrincipal] from the caller's
@@ -213,6 +222,28 @@ func WithDocumentMode(documentID, entryID string) Option {
 		r.isDocument = true
 		r.documentID = documentID
 		r.documentEntry = entryID
+	}
+}
+
+// WithListDocumentMode marks the runtime as rendering a LIST export (the
+// `lists.<id>.export_render` override). It sets document mode, so stdout
+// capture and the rela.output warning behave exactly as for an entity
+// render, and additionally populates the row/query bindings on
+// rela.document.
+//
+// It is a SEPARATE constructor from [WithDocumentMode] rather than extra
+// optional arguments on it: a caller holding only WithDocumentMode cannot
+// conjure a row provider, which keeps the typed-seam property that the
+// script.Engine methods are the only way to enter either mode.
+//
+// entryID is deliberately not a parameter — a list render has no entry
+// entity, and rela.document.entry_id stays absent (Lua nil) rather than
+// empty-string. See registerContextBindings for why.
+func WithListDocumentMode(documentID string, lrc ListRenderContext) Option {
+	return func(r *Runtime) {
+		r.isDocument = true
+		r.documentID = documentID
+		r.listRender = lrc
 	}
 }
 
@@ -821,17 +852,118 @@ func (r *Runtime) registerContextBindings(rela *lua.LTable) {
 	// rela.url submodule — typed URL builders for the SPA's routes.
 	r.registerURLModule(rela)
 
-	// Document-mode context: rela.mode + rela.document.{id, entry_id}.
-	// Only populated when WithDocumentMode was applied. In every other
-	// context rela.mode and rela.document are absent (Lua nil), so a
-	// script that branches on them sees nil outside document renders.
+	// Document-mode context: rela.mode + rela.document.*.
+	// Only populated when WithDocumentMode or WithListDocumentMode was
+	// applied. In every other context rela.mode and rela.document are
+	// absent (Lua nil), so a script that branches on them sees nil outside
+	// document renders.
 	if r.isDocument {
 		r.L.SetField(rela, "mode", lua.LString("document"))
 		docTable := r.L.NewTable()
 		r.L.SetField(docTable, "id", lua.LString(r.documentID))
-		r.L.SetField(docTable, "entry_id", lua.LString(r.documentEntry))
+
+		// entry_id is set ONLY when there is a real entry entity. An entity
+		// render always has one (the caller path-validates it before we get
+		// here), so this is byte-identical to the previous unconditional
+		// set; a LIST render has none and must see Lua nil, never "".
+		// Empty-string would be the worse lie: it is truthy in Lua, so the
+		// idiomatic `if rela.document.entry_id then rela.get_entity(...)`
+		// guard would pass and then raise ("entity ID cannot be empty"),
+		// and `entry_id or default` would yield "" instead of the default.
+		if r.documentEntry != "" {
+			r.L.SetField(docTable, "entry_id", lua.LString(r.documentEntry))
+		}
+
+		// List-render bindings. Kept as closures over the provider rather
+		// than *Runtime methods on purpose: Runtime is pinned at the
+		// plimsoll load line (max-methods=120), and these would push it
+		// over. They are also genuinely per-render state, not runtime
+		// behavior.
+		if r.listRender.Rows != nil {
+			registerListDocumentFields(r.L, docTable, r.listRender)
+		}
+
 		r.L.SetField(rela, "document", docTable)
 	}
+}
+
+// registerListDocumentFields populates the LIST-render half of
+// rela.document: the query context plus the lazy row accessors.
+//
+// A plain function taking *lua.LState, NOT a *Runtime method: Runtime sits
+// exactly on its plimsoll load line (max-methods=120, already justified up
+// to there by TKT-ZF2DTV), so adding a method here fails CI. It needs
+// nothing from the Runtime beyond the state and the render context anyway.
+//
+// Rows are materialized ONE AT A TIME. A 5000-row export therefore holds a
+// single Lua entity table at a time rather than 5000 (each of which is a
+// table plus a properties sub-table plus two closures). That is what makes
+// the caller's existing row cap the only bound needed here — no second,
+// separately-tuned cap for the script path.
+func registerListDocumentFields(ls *lua.LState, docTable *lua.LTable, lrc ListRenderContext) {
+	rows := lrc.Rows
+	q := lrc.Query
+
+	ls.SetField(docTable, "list_id", lua.LString(lrc.ListID))
+	ls.SetField(docTable, "entity_type", lua.LString(q.EntityType))
+	ls.SetField(docTable, "count", lua.LNumber(rows.Len()))
+	ls.SetField(docTable, "total", lua.LNumber(q.Total))
+	ls.SetField(docTable, "truncated", lua.LBool(q.Truncated))
+
+	// The resolved request context, frozen so "read-only" is enforced
+	// rather than conventional (same treatment rela.principal gets).
+	queryTable := ls.NewTable()
+	if q.Q != "" {
+		ls.SetField(queryTable, "q", lua.LString(q.Q))
+	}
+	filters := ls.NewTable()
+	for k, v := range q.Filters {
+		ls.SetField(filters, k, lua.LString(v))
+	}
+	ls.SetField(queryTable, "filters", freezeTable(ls, filters))
+	sort := ls.NewTable()
+	for i, s := range q.Sort {
+		spec := ls.NewTable()
+		ls.SetField(spec, "property", lua.LString(s.Property))
+		ls.SetField(spec, "direction", lua.LString(s.Direction))
+		sort.RawSetInt(i+1, freezeTable(ls, spec))
+	}
+	ls.SetField(queryTable, "sort", sort)
+	ls.SetField(docTable, "query", freezeTable(ls, queryTable))
+
+	// row(i) -> entity table | nil. 1-based, per Lua convention.
+	ls.SetField(docTable, "row", ls.NewFunction(func(s *lua.LState) int {
+		i := s.CheckInt(1)
+		e := rows.At(i - 1)
+		if e == nil {
+			s.Push(lua.LNil)
+			return 1
+		}
+		s.Push(EntityToTable(s, e))
+		return 1
+	}))
+
+	// rows() -> stateful iterator, for `for _, row in rela.document.rows() do`.
+	// Each CALL to rows() mints a fresh cursor, so a script may walk the set
+	// more than once; each walk re-materializes its tables. That is the
+	// deliberate trade for flat memory — CPU, not RAM. Do not memoize the
+	// materialized tables here; that would reintroduce exactly the O(n)
+	// retention the laziness exists to avoid.
+	ls.SetField(docTable, "rows", ls.NewFunction(func(s *lua.LState) int {
+		i := 0
+		s.Push(s.NewFunction(func(inner *lua.LState) int {
+			if i >= rows.Len() {
+				inner.Push(lua.LNil)
+				return 1
+			}
+			e := rows.At(i)
+			i++
+			inner.Push(lua.LNumber(i))
+			inner.Push(EntityToTable(inner, e))
+			return 2
+		}))
+		return 1
+	}))
 }
 
 // reader returns the read-out handle, raising when it is absent.

--- a/internal/lua/runtime.go
+++ b/internal/lua/runtime.go
@@ -890,10 +890,12 @@ func (r *Runtime) registerContextBindings(rela *lua.LTable) {
 // registerListDocumentFields populates the LIST-render half of
 // rela.document: the query context plus the lazy row accessors.
 //
-// A plain function taking *lua.LState, NOT a *Runtime method: Runtime sits
-// exactly on its plimsoll load line (max-methods=120, already justified up
-// to there by TKT-ZF2DTV), so adding a method here fails CI. It needs
-// nothing from the Runtime beyond the state and the render context anyway.
+// A plain function rather than a *Runtime method because it needs nothing
+// from the Runtime — the LState and the render context are the whole input.
+// (It also keeps Runtime off its plimsoll load line, which sits at exactly
+// max-methods=120. That is a consequence, not the reason: the fix for a full
+// Runtime is to take fields OFF it — see TKT-N0IKN9 — not to route new
+// methods around the counter.)
 //
 // Rows are materialized ONE AT A TIME. A 5000-row export therefore holds a
 // single Lua entity table at a time rather than 5000 (each of which is a
@@ -906,19 +908,29 @@ func registerListDocumentFields(ls *lua.LState, docTable *lua.LTable, lrc ListRe
 
 	ls.SetField(docTable, "list_id", lua.LString(lrc.ListID))
 	ls.SetField(docTable, "entity_type", lua.LString(q.EntityType))
-	// count/total/truncated all derive from the two facts the caller supplied
-	// (the row set and the pre-cap count), so a script can never observe them
-	// disagreeing with each other.
-	ls.SetField(docTable, "count", lua.LNumber(rows.Len()))
-	ls.SetField(docTable, "total", lua.LNumber(q.Total))
-	ls.SetField(docTable, "truncated", lua.LBool(q.Total > rows.Len()))
+	// count is ground truth (the rows the script can actually reach); total is
+	// the caller's pre-cap count, and truncated is derived from the two rather
+	// than stored, so those three can't drift apart.
+	//
+	// A caller that under-reports Total would still be incoherent, so clamp:
+	// total can never be less than the rows we are about to hand over. That
+	// makes "total >= count" an invariant of what the script sees rather than
+	// a promise about what every caller passes.
+	count := rows.Len()
+	total := max(q.Total, count)
+	ls.SetField(docTable, "count", lua.LNumber(count))
+	ls.SetField(docTable, "total", lua.LNumber(total))
+	ls.SetField(docTable, "truncated", lua.LBool(total > count))
 
 	// The resolved request context, frozen so "read-only" is enforced
 	// rather than conventional (same treatment rela.principal gets).
 	queryTable := ls.NewTable()
-	if q.Q != "" {
-		ls.SetField(queryTable, "q", lua.LString(q.Q))
-	}
+	// Always set, even when empty. Unlike entry_id — where absence is
+	// semantically right because a list HAS no entry entity — "no search
+	// term" is a representable value, so the empty string is the honest
+	// answer. Omitting it made `"Search: " .. rela.document.query.q` work on
+	// every filtered export and hard-error on every unfiltered one.
+	ls.SetField(queryTable, "q", lua.LString(q.Q))
 	filters := ls.NewTable()
 	for k, v := range q.Filters {
 		ls.SetField(filters, k, lua.LString(v))

--- a/internal/script/executor.go
+++ b/internal/script/executor.go
@@ -104,43 +104,13 @@ func (e *Engine) ExecuteDocument(
 	entryID string,
 	timeout time.Duration,
 ) error {
-	scriptCode, err := loadScript(deps.ProjectRoot, path)
-	if err != nil {
-		return err
-	}
-
 	// ctx + principal are threaded like execute()/ExecuteAction: the script
 	// runs under the CALLER's identity (rela.principal reflects the request
 	// principal, reads cancel with the request). Before TKT-L9Q669 this
 	// path ran on context.Background() with no principal — an export_render
 	// or document script could never be attributed or ACL-bound.
-	opts := []lua.Option{
-		lua.WithDocumentMode(documentID, entryID),
-		lua.WithCache(e.cache),
-		lua.WithContext(ctx),
-		lua.WithPrincipal(principal.From(ctx)),
-	}
-	if timeout > 0 {
-		opts = append(opts, lua.WithTimeout(timeout))
-	}
-
-	runtime, err := NewWriterRuntime(deps, path, stdout, opts...)
-	if err != nil {
-		return err
-	}
-	defer runtime.Close()
-
-	// RunFileContent (not RunString) so gopher-lua receives the script
-	// path as the chunkname — that lands in the message handler's frame
-	// captures and lets ScriptError.Source populate from the right file.
-	// Doubles as the rela.cache.* namespace, so SetScriptPath is no
-	// longer needed alongside it.
-	//nolint:contextcheck // ctx threaded via WithContext above, same as execute()
-	if runErr := runtime.RunFileContent(path, []byte(scriptCode), nil); runErr != nil {
-		return wrapScriptError(lua.SurfaceDocument, scriptsDir, path, entryID,
-			runtime.ErrorFrames(), nil, runErr, deps.ProjectRoot)
-	}
-	return nil
+	return e.runDocumentScript(ctx, path, deps, stdout,
+		lua.WithDocumentMode(documentID, entryID), entryID, timeout)
 }
 
 // wrapScriptError builds a *lua.ScriptError from a runtime failure.

--- a/internal/script/list_document.go
+++ b/internal/script/list_document.go
@@ -50,6 +50,11 @@ func (e *Engine) ExecuteListDocument(
 // public methods each supply exactly one mode, so no caller can forge
 // WithOutputDir or WithActionMode. subject fills the error envelope's subject
 // slot (an entity id, or a list id where there is no entry entity).
+//
+// INVARIANT: this stays unexported and never grows a variadic option tail.
+// Both are what make the seam structural rather than conventional — an
+// exported version, or one taking ...lua.Option, hands every caller exactly
+// the option injection ExecuteDocument/ExecuteAction exist to prevent.
 func (e *Engine) runDocumentScript(
 	ctx context.Context,
 	path string,

--- a/internal/script/list_document.go
+++ b/internal/script/list_document.go
@@ -33,16 +33,42 @@ func (e *Engine) ExecuteListDocument(
 	lrc lua.ListRenderContext,
 	timeout time.Duration,
 ) error {
+	// The list id stands in for the entity id in the error envelope's subject
+	// slot: a list render has no entry entity, and "which list" is the useful
+	// thing to see in a failure.
+	return e.runDocumentScript(ctx, path, deps, stdout,
+		lua.WithListDocumentMode(documentID, lrc), lrc.ListID, timeout)
+}
+
+// runDocumentScript is the shared body behind the document-mode entry points
+// (ExecuteDocument, ExecuteListDocument): load the script, build the standard
+// opt set, run it with the file path as chunkname, and shape any failure into
+// a *lua.ScriptError.
+//
+// modeOpt is what distinguishes the callers, and keeping it a PARAMETER rather
+// than exposing variadic lua.Option is what preserves the typed seam: the
+// public methods each supply exactly one mode, so no caller can forge
+// WithOutputDir or WithActionMode. subject fills the error envelope's subject
+// slot (an entity id, or a list id where there is no entry entity).
+func (e *Engine) runDocumentScript(
+	ctx context.Context,
+	path string,
+	deps lua.WriteDeps,
+	stdout io.Writer,
+	modeOpt lua.Option,
+	subject string,
+	timeout time.Duration,
+) error {
 	scriptCode, err := loadScript(deps.ProjectRoot, path)
 	if err != nil {
 		return err
 	}
 
-	// ctx + principal threaded exactly as ExecuteDocument does: the render
-	// runs under the CALLER's identity, so its reads are ACL-bound
-	// (TKT-ZF2DTV) and it cancels with the request.
+	// ctx + principal are threaded so the render runs under the CALLER's
+	// identity: its reads are ACL-bound (TKT-ZF2DTV) and it cancels with the
+	// request.
 	opts := []lua.Option{
-		lua.WithListDocumentMode(documentID, lrc),
+		modeOpt,
 		lua.WithCache(e.cache),
 		lua.WithContext(ctx),
 		lua.WithPrincipal(principal.From(ctx)),
@@ -58,13 +84,11 @@ func (e *Engine) ExecuteListDocument(
 	defer runtime.Close()
 
 	// RunFileContent (not RunString) so gopher-lua receives the script path
-	// as the chunkname — see ExecuteDocument for the full rationale.
-	//nolint:contextcheck // ctx threaded via WithContext above, same as ExecuteDocument
+	// as the chunkname — that lands in the message handler's frame captures
+	// and lets ScriptError.Source populate from the right file.
+	//nolint:contextcheck // ctx threaded via WithContext above
 	if runErr := runtime.RunFileContent(path, []byte(scriptCode), nil); runErr != nil {
-		// The list id stands in for the entity id in the error envelope's
-		// subject slot: a list render has no entry entity, and "which list"
-		// is the useful thing to see in a failure.
-		return wrapScriptError(lua.SurfaceDocument, scriptsDir, path, lrc.ListID,
+		return wrapScriptError(lua.SurfaceDocument, scriptsDir, path, subject,
 			runtime.ErrorFrames(), nil, runErr, deps.ProjectRoot)
 	}
 	return nil

--- a/internal/script/list_document.go
+++ b/internal/script/list_document.go
@@ -1,0 +1,71 @@
+package script
+
+import (
+	"context"
+	"io"
+	"time"
+
+	"github.com/Sourcehaven-BV/rela/internal/lua"
+	"github.com/Sourcehaven-BV/rela/internal/principal"
+)
+
+// ExecuteListDocument loads and runs a Lua script in LIST document-rendering
+// mode — the `lists.<id>.export_render` override. The script's captured
+// stdout is the rendered markdown, which the data-entry layer feeds to a
+// format transform.
+//
+// documentID is the synthetic config identity ("export:list:<listID>");
+// lrc carries the list id, the lazy row provider, and the read-only resolved
+// query context. The rows are the ones the CALLER already resolved through
+// the ACL read path, filtered, sorted, and capped — the script renders those
+// and does not derive its own set. That keeps an export showing exactly what
+// the on-screen view showed, and keeps the caller's row cap meaningful.
+//
+// Like [Engine.ExecuteDocument] and [Engine.ExecuteAction] this is a typed
+// seam — intentionally NOT taking variadic lua.Option — so callers cannot
+// inject arbitrary opts (e.g. forge WithOutputDir or WithActionMode).
+func (e *Engine) ExecuteListDocument(
+	ctx context.Context,
+	path string,
+	deps lua.WriteDeps,
+	stdout io.Writer,
+	documentID string,
+	lrc lua.ListRenderContext,
+	timeout time.Duration,
+) error {
+	scriptCode, err := loadScript(deps.ProjectRoot, path)
+	if err != nil {
+		return err
+	}
+
+	// ctx + principal threaded exactly as ExecuteDocument does: the render
+	// runs under the CALLER's identity, so its reads are ACL-bound
+	// (TKT-ZF2DTV) and it cancels with the request.
+	opts := []lua.Option{
+		lua.WithListDocumentMode(documentID, lrc),
+		lua.WithCache(e.cache),
+		lua.WithContext(ctx),
+		lua.WithPrincipal(principal.From(ctx)),
+	}
+	if timeout > 0 {
+		opts = append(opts, lua.WithTimeout(timeout))
+	}
+
+	runtime, err := NewWriterRuntime(deps, path, stdout, opts...)
+	if err != nil {
+		return err
+	}
+	defer runtime.Close()
+
+	// RunFileContent (not RunString) so gopher-lua receives the script path
+	// as the chunkname — see ExecuteDocument for the full rationale.
+	//nolint:contextcheck // ctx threaded via WithContext above, same as ExecuteDocument
+	if runErr := runtime.RunFileContent(path, []byte(scriptCode), nil); runErr != nil {
+		// The list id stands in for the entity id in the error envelope's
+		// subject slot: a list render has no entry entity, and "which list"
+		// is the useful thing to see in a failure.
+		return wrapScriptError(lua.SurfaceDocument, scriptsDir, path, lrc.ListID,
+			runtime.ErrorFrames(), nil, runErr, deps.ProjectRoot)
+	}
+	return nil
+}

--- a/internal/script/list_document_test.go
+++ b/internal/script/list_document_test.go
@@ -32,7 +32,7 @@ func listCtx() lua.ListRenderContext {
 			{ID: "TKT-2", Type: "ticket", Properties: map[string]any{"title": "Second"}},
 		},
 		Query: lua.ListQuery{
-			ListID: "tickets", EntityType: "ticket", Total: 2, Rendered: 2,
+			EntityType: "ticket", Total: 2,
 		},
 	}
 }

--- a/internal/script/list_document_test.go
+++ b/internal/script/list_document_test.go
@@ -1,0 +1,118 @@
+package script
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/Sourcehaven-BV/rela/internal/entity"
+	"github.com/Sourcehaven-BV/rela/internal/lua"
+	"github.com/Sourcehaven-BV/rela/internal/principal"
+)
+
+// testRows is a ListRows over a fixed slice, mirroring the adapter the
+// data-entry export handler supplies.
+type testRows []*entity.Entity
+
+func (r testRows) Len() int { return len(r) }
+
+func (r testRows) At(i int) *entity.Entity {
+	if i < 0 || i >= len(r) {
+		return nil
+	}
+	return r[i]
+}
+
+func listCtx() lua.ListRenderContext {
+	return lua.ListRenderContext{
+		ListID: "tickets",
+		Rows: testRows{
+			{ID: "TKT-1", Type: "ticket", Properties: map[string]any{"title": "First"}},
+			{ID: "TKT-2", Type: "ticket", Properties: map[string]any{"title": "Second"}},
+		},
+		Query: lua.ListQuery{
+			ListID: "tickets", EntityType: "ticket", Total: 2, Rendered: 2,
+		},
+	}
+}
+
+// TestExecuteListDocument_CapturesStdout is the core contract: the script
+// renders the rows it was handed and its print() output is the markdown.
+func TestExecuteListDocument_CapturesStdout(t *testing.T) {
+	root := writeDocScript(t, "list.lua", `print("# " .. rela.document.list_id)
+for _, row in rela.document.rows() do
+  print("- " .. row.properties.title)
+end`)
+
+	var stdout bytes.Buffer
+	engine := NewEngine()
+	err := engine.ExecuteListDocument(t.Context(), "list.lua", testWriteDeps(root), &stdout,
+		"export:list:tickets", listCtx(), 0)
+	if err != nil {
+		t.Fatalf("ExecuteListDocument failed: %v", err)
+	}
+
+	want := "# tickets\n- First\n- Second\n"
+	if got := stdout.String(); got != want {
+		t.Errorf("stdout mismatch:\n got: %q\nwant: %q", got, want)
+	}
+}
+
+// TestExecuteListDocument_PrincipalThreaded mirrors the entity path: the
+// render runs under the caller's identity, which is what binds the script's
+// own reads to the caller's ACL (TKT-ZF2DTV).
+func TestExecuteListDocument_PrincipalThreaded(t *testing.T) {
+	root := writeDocScript(t, "who.lua", `print(rela.principal.user .. "/" .. rela.principal.tool)`)
+
+	ctx := principal.With(t.Context(), principal.Principal{User: "alice", Tool: principal.ToolDataEntry})
+	var stdout bytes.Buffer
+	engine := NewEngine()
+	err := engine.ExecuteListDocument(ctx, "who.lua", testWriteDeps(root), &stdout,
+		"export:list:tickets", listCtx(), 0)
+	if err != nil {
+		t.Fatalf("ExecuteListDocument failed: %v", err)
+	}
+	if got, want := stdout.String(), "alice/"+principal.ToolDataEntry+"\n"; got != want {
+		t.Errorf("principal not threaded:\n got: %q\nwant: %q", got, want)
+	}
+}
+
+// TestExecuteListDocument_ScriptErrorSurfaced verifies a Lua failure comes
+// back as a *lua.ScriptError naming the list, so the HTTP layer can branch
+// via errors.As exactly as it does for entity renders.
+func TestExecuteListDocument_ScriptErrorSurfaced(t *testing.T) {
+	root := writeDocScript(t, "boom.lua", `error("kaboom")`)
+
+	var stdout bytes.Buffer
+	engine := NewEngine()
+	err := engine.ExecuteListDocument(t.Context(), "boom.lua", testWriteDeps(root), &stdout,
+		"export:list:tickets", listCtx(), 0)
+	if err == nil {
+		t.Fatal("expected an error from a failing script")
+	}
+	var se *lua.ScriptError
+	if !errors.As(err, &se) {
+		t.Fatalf("want *lua.ScriptError, got %T: %v", err, err)
+	}
+	if !strings.Contains(err.Error(), "kaboom") {
+		t.Errorf("error should carry the Lua message: %v", err)
+	}
+}
+
+// TestExecuteListDocument_BadPath pins that path validation runs before any
+// execution — the same loadScript guard ExecuteDocument uses.
+func TestExecuteListDocument_BadPath(t *testing.T) {
+	root := writeDocScript(t, "ok.lua", `print("hi")`)
+
+	var stdout bytes.Buffer
+	engine := NewEngine()
+	err := engine.ExecuteListDocument(t.Context(), "../escape.lua", testWriteDeps(root), &stdout,
+		"export:list:tickets", listCtx(), 0)
+	if err == nil {
+		t.Fatal("expected traversal path to be rejected")
+	}
+	if stdout.Len() != 0 {
+		t.Errorf("nothing should have been rendered, got %q", stdout.String())
+	}
+}

--- a/tickets/entities/docs-checklists/DOCS-KGF71J.md
+++ b/tickets/entities/docs-checklists/DOCS-KGF71J.md
@@ -1,0 +1,44 @@
+---
+id: DOCS-KGF71J
+type: docs-checklist
+title: 'Docs: export: per-list render override (lists.<id>.export_render)'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Code Documentation
+
+- [x] Godoc on every new exported symbol — `lua.ListRows`, `ListQuery`,
+`ListSortSpec`, `ListRenderContext`, `WithListDocumentMode`,
+`Engine.ExecuteListDocument`
+- [x] Load-bearing rationale documented at the seams: why rows are handed in
+rather than re-queried, why `entry_id` is absent rather than empty, why
+`resolveEffectiveList` omits the column predicate, why `runDocumentScript` stays
+unexported and never takes a variadic option tail
+- [x] Known residual documented where an implementer will find it — the
+`Content` body pass-through is noted on both the `ListRows` seam and
+`listOverrideRenderer`, pointing at the body-redaction TODO in
+`internal/visibility/policyreader.go`
+
+## Project Documentation
+
+- [x] `docs/transforms.md` — removed the "Not yet supported (v1 limits)" bullet
+that said list export always emits the column table; added a "Custom per-list
+rendering" section mirroring the per-entity one (YAML + Lua example, the full
+`rela.document` field table, and the two non-obvious contracts: render the rows
+you are given, and rows are lazy so each walk re-materializes)
+- [x] `docs/transforms.md` §Access control — extended the `export_render:`
+bullet to cover `lists.<id>.export_render`, stating that a list override's rows
+are server-supplied and already gated
+- [x] `docs/lua-scripting.md` — added the list-render fields to the document-mode
+reference, noting `rela.mode` stays `"document"` and `entry_id` is absent
+- [x] `docs/data-entry.md` — added `export_render` to the List Fields table
+
+## External Documentation
+
+- [x] ~~API reference update~~ (N/A: no new endpoint or wire-format change —
+the existing `GET /api/v1/{plural}/_export` gains no parameter; the override is
+config-selected, never request-selected)
+- [x] ~~Migration notes~~ (N/A: purely additive config key; a list with no
+`export_render` keeps the built-in table byte-for-byte)

--- a/tickets/entities/implementation-checklists/IMPL-35TQGI.md
+++ b/tickets/entities/implementation-checklists/IMPL-35TQGI.md
@@ -1,0 +1,68 @@
+---
+id: IMPL-35TQGI
+type: implementation-checklist
+title: 'Implementation: export: per-list render override (lists.<id>.export_render)'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Development
+
+- [x] `internal/lua/listmode.go` — `ListRows` consumer-side interface (Len/At),
+`ListQuery`, `ListSortSpec` (alias for `filter.SortSpec`), `ListRenderContext`
+- [x] `internal/lua/runtime.go` — `WithListDocumentMode`;
+`registerListDocumentFields` (a free function, not a `*Runtime` method);
+`entry_id` made conditional so entity mode is byte-identical
+- [x] `internal/script/list_document.go` — `ExecuteListDocument` typed seam +
+`runDocumentScript` shared body, now also backing `ExecuteDocument`
+- [x] `internal/dataentry/document.go` — `RenderListMarkdown`;
+`documentScriptEngine` grew to 2 methods
+- [x] `internal/dataentry/export_list.go` — `resolveEffectiveList`,
+`listColumnsOf`, `listOverrideRenderer`, `entitySliceRows`, `buildListQuery`
+- [x] `internal/dataentryconfig/` — `List.ExportRender` + shared
+`validateExportRenderShape`
+- [x] `internal/dataentry/app.go` — `checkExportRenderScripts` (lists **and**
+views; the views half closes a pre-existing gap)
+
+## Quality Checks
+
+- [x] `go test ./...` — exit 0
+- [x] `just lint` — 0 issues
+- [x] `just arch-lint` — OK; neither `lua` nor `script` gained a `dataentry` edge
+- [x] `just plimsoll` — OK; `Runtime` stayed at its pinned max-methods=120 (the
+first cut added a method and failed CI, so the helper became a free function
+rather than bumping a pin TKT-ZF2DTV had just justified)
+- [x] `just coverage-check` — floors PASS
+- [x] `-race` on the export path — clean
+
+## Verification Evidence
+
+**End-to-end with a real Lua runtime** (not just the fake engine): a script on
+disk rendering three real rows produced `entry_id is nil`, all three rows via
+`rows()`, and "second walk saw 3" — the iterator restart contract holding in
+practice.
+
+**AC → test mapping**
+
+| Acceptance criterion | Test |
+|---|---|
+| Override replaces the built-in table | `TestExport_List_RenderOverride` (asserts script output present **and** table header absent) |
+| No override → table unchanged, script never runs | `TestExport_List_NoOverrideUsesBuiltin` |
+| Override applies without an explicit `list=` | `TestExport_List_RenderOverride_EffectiveListFallback` |
+| Columnless list still gets its override | `TestExport_List_RenderOverride_ColumnlessList` |
+| Denied caller → 200, zero rows, no leak | `TestExport_List_RenderOverride_DeniedSeesNoRows` |
+| Cap bookkeeping reaches the script | `TestExport_List_RenderOverride_TruncationReachesScript` |
+| Filters/sort reach the script | `TestExport_List_RenderOverride_QueryContext` |
+| Operator segment parsed, not swallowed | `TestExport_List_RenderOverride_FilterOperatorKey` |
+| ConfigID cannot collide with the entity path | `TestExport_List_RenderOverride_ConfigIDDistinctFromEntityPath` |
+| Lua surface: mode/list_id/count/total/query | `TestListDocumentMode_Surface` |
+| `entry_id` absent in list mode | `TestListDocumentMode_EntryIDAbsent` |
+| Entity mode unchanged (regression) | `TestDocumentMode_EntryIDStillPresent` |
+| Iterator restarts per `rows()` call | `TestListDocumentMode_IteratorWalkableTwice` |
+| Read-only context enforced | `TestListDocumentMode_QueryFrozen` |
+| `total` clamped when under-reported | `TestListDocumentMode_TotalClamped` |
+| Empty `q` is a string, not nil | `TestListDocumentMode_EmptyQIsEmptyString` |
+| Edge cases (empty set, never-iterate, exhaust-then-rewalk, exact cap) | `TestListDocumentMode_EdgeCases` |
+| Script seam: stdout, principal, error shaping, path validation | `TestExecuteListDocument_*` (4) |
+| Config shape + boot-time existence | `TestValidateConfig_ListExportRender*` |

--- a/tickets/entities/review-checklists/REV-OJOCKJ.md
+++ b/tickets/entities/review-checklists/REV-OJOCKJ.md
@@ -1,0 +1,73 @@
+---
+id: REV-OJOCKJ
+type: review-checklist
+title: 'Review: export: per-list render override (lists.<id>.export_render)'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Automated Checks
+
+- [x] All tests pass (`just test`) — full sweep green (`go test ./...` exit 0) after rebase onto develop @ dd0fe649
+- [x] Lint clean (`just lint`) — golangci-lint 0 issues; `just arch-lint` OK (no new `lua`/`script` → `dataentry` edge); `just plimsoll` OK (`Runtime` held at max-methods=120, not bumped)
+- [x] Coverage maintained (`just coverage-check`) — package floor 50% PASS, total 65% PASS (76.3%)
+
+## Code Review
+
+- [x] Run `/code-review` command (invokes cranky-code-reviewer agent)
+- [x] All critical review-responses addressed (none)
+- [x] All significant review-responses addressed (RR-DXDTSB, RR-ECUOIT, RR-YI4LGQ)
+- [x] Self-reviewed the diff for unrelated changes
+
+**Reviews run:** cranky-code-reviewer + go-architect, in parallel, plus a
+4-agent `/simplify` pass (reuse / simplification / efficiency / altitude) before
+them.
+
+**Findings addressed:**
+
+- **RR-DXDTSB** (significant, from the reuse pass) — `buildListQuery` parsed
+`filter[...]` keys with `TrimPrefix`/`TrimSuffix`, the exact pre-RR-6RF60V
+shape: `filter[status][ne]` keyed the script's table on `"status][ne"`. Now
+routed through the existing `parseRelationFilterKey`. Pinned by
+`TestExport_List_RenderOverride_FilterOperatorKey`, verified by reverting the
+fix and watching it fail.
+- **RR-ECUOIT** (significant, cranky) — `rela.document.query.q` was omitted when
+empty, so `"Search: " .. query.q` worked on a filtered export and hard-errored
+on every unfiltered one. Reproduced (`cannot perform concat operation between
+string and nil`), then fixed to always set the field.
+- **RR-YI4LGQ** (significant, architect) — `listOverrideRenderer`'s godoc claimed
+the override "renders exactly the set the on-screen view showed"; rows in fact
+arrive as full entity tables including the **body**, which the column table
+never shows, and `visibility.Redact` does not redact `Content` yet. Comment
+corrected; both it and the `ListRows` seam godoc now point at the body-redaction
+TODO.
+- **Minor/nit, addressed:** sort grammar duplicated from `applyV1Sorting`
+(extracted `parseSortParam`, aliased `ListSortSpec = filter.SortSpec`);
+`ListQuery.Rendered` dead + `.Truncated`/`.ListID` redundant (removed, with
+`total` clamped up to the row count so an under-reporting caller can't produce
+an incoherent view); `resolveEffectiveList` called twice per export; `sort`
+table left unfrozen; `validateExportRenderShape` not shared with views;
+`registerListDocumentFields` godoc led with the plimsoll cap rather than the
+real reason; `runDocumentScript` seam invariant unstated.
+
+**Findings rejected, with reasons:**
+
+- Cranky claimed list renders run with **no timeout**. Verified false —
+`newRuntime` initializes `timeout: DefaultTimeout` and `WithTimeout` is only
+appended when non-zero, so `Timeout: 0` inherits 30s. Confirmed empirically: an
+infinite-loop script terminates at 30.0s. No change made.
+- Two agents called the `cfg.Command` guard in `RenderListMarkdown` unreachable
+dead code. Unreachable today, but kept as a fail-closed assertion against an
+entry-less `{id}` substitution; comment trimmed to say so.
+
+## Acceptance Verification
+
+- [x] Each acceptance criterion tested (reference planning checklist)
+- [x] Test evidence documented in implementation checklist
+
+**Acceptance Status:** all PASS — see IMPL checklist for the AC → test mapping.
+
+## Documentation (enhancements only)
+
+- [x] Docs checklist completed — see the linked docs-checklist.

--- a/tickets/entities/review-responses/RR-DXDTSB.md
+++ b/tickets/entities/review-responses/RR-DXDTSB.md
@@ -1,0 +1,9 @@
+---
+id: RR-DXDTSB
+type: review-response
+title: buildListQuery re-derives the pre-RR-6RF60V filter-key bug (filter[status][ne] keys on "status][ne")
+finding: 'buildListQuery parsed filter[...] query keys with a naive CutPrefix/TrimSuffix pair. That is the exact shape RR-6RF60V already fixed elsewhere: an operator segment is swallowed into the property name, so filter[status][ne]=done keys the script''s rela.document.query.filters table on "status][ne" instead of "status". A render override would therefore report a filter name that never matches what the pipeline actually filtered on.'
+severity: significant
+resolution: Routed through the existing parseRelationFilterKey helper (internal/dataentry/api_v1.go), which uses the same ][-split logic as applyV1Filters and was written to fix precisely this bug. The operator segment is intentionally dropped (this context reports WHICH properties were filtered) and last-value-wins now matches applyV1Filters. Pinned by TestExport_List_RenderOverride_FilterOperatorKey, whose sensitivity was verified by temporarily reverting the fix and confirming the test fails with map[status][ne:done].
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-ECUOIT.md
+++ b/tickets/entities/review-responses/RR-ECUOIT.md
@@ -1,0 +1,9 @@
+---
+id: RR-ECUOIT
+type: review-response
+title: rela.document.query.q omitted when empty makes string concatenation hard-error on unfiltered exports
+finding: 'registerListDocumentFields set query.q only when non-empty, so the field was Lua nil on any export without a search term. A script doing the idiomatic `"Search: " .. rela.document.query.q` therefore worked on every filtered export and hard-errored on every unfiltered one — the most likely real-world break in the feature. Reproduced: "cannot perform concat operation between string and nil".'
+severity: significant
+resolution: 'query.q is now always set, empty string included. The omission had over-applied the entry_id reasoning: absence is right for entry_id because a list genuinely HAS no entry entity, but "no search term" is a representable value, so the empty string is the honest answer. Pinned by TestListDocumentMode_EmptyQIsEmptyString, which asserts both type(q) == "string" and that concatenation succeeds.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-YI4LGQ.md
+++ b/tickets/entities/review-responses/RR-YI4LGQ.md
@@ -1,0 +1,9 @@
+---
+id: RR-YI4LGQ
+type: review-response
+title: 'listOverrideRenderer godoc asserted a false invariant: the override widens the list surface to include entity bodies'
+finding: The doc comment claimed the override "renders exactly the set the on-screen view showed". Rows reach the script via EntityToTable, which includes Content, and visibility.Redact does not redact Content (the body-redaction TODO in internal/visibility/policyreader.go). The built-in column table never renders bodies, so choosing an override widens the field surface for the same request. Not a new ACL hole — row-gating and property redaction are intact, and the entity export path already exposes bodies — but the comment asserted an invariant that is not true, which is the kind of comment that suppresses the search when body redaction is later implemented.
+severity: significant
+resolution: Kept the behavior (a report override legitimately wants bodies, and blocking them here would diverge from the entity export path) and corrected the claim. listOverrideRenderer now states that the override sees the same ROWS with the same property redaction but NOT only what the table showed, and both it and the lua.ListRows seam godoc point at the body-redaction TODO so whoever implements it finds this path.
+status: addressed
+---

--- a/tickets/entities/tickets/TKT-95XU13.md
+++ b/tickets/entities/tickets/TKT-95XU13.md
@@ -1,0 +1,95 @@
+---
+id: TKT-95XU13
+type: ticket
+title: 'export: per-list render override (lists.<id>.export_render) — script receives handler-resolved rows lazily'
+kind: enhancement
+priority: medium
+effort: m
+status: done
+---
+
+## Summary
+
+Closes the v1 limit recorded in `docs/transforms.md`: *"A render override for
+LIST export — `export_render` applies to entity export only; list export always
+emits the column table."* Anticipated by FEAT-5IUVGX ("List export: table in v1,
+Lua override for fancier").
+
+```yaml
+lists:
+  tickets:
+    entity_type: ticket
+    columns: [...]
+    export_render: docs/ticket_report.lua
+```
+
+## Design decisions
+
+1. **Keyed on the list, not the entity type.** Two lists of the same type can
+export differently, and the list already owns the columns/filters/sort the
+export derives from.
+
+2. **The script renders handler-resolved rows; it never re-queries.** The
+handler has already resolved the exact ACL-scoped, filtered, sorted, capped set.
+Note the ACL argument does *not* apply here — TKT-ZF2DTV landed, so a script's
+own reads are ACL-bound anyway. The real reasons are narrower: a re-query would
+ignore the user's active filters and escape `listExportCap`, so the export would
+stop matching the view it came from.
+
+3. **The resolved query is read-only context** (`q`, `filters`, `sort`), frozen
+via `freezeTable`, so a script can title and annotate an export. No re-query
+seam; parameter rewriting would be additive and needs its own decision.
+
+4. **Rows are lazy, not a prebuilt array.** `rows()` mints a fresh cursor per
+call and materializes one `EntityToTable` at a time. A prebuilt array would
+allocate a table + properties sub-table + 2 closures per row for the whole set
+before the script's first line, and would have forced a second, separately-tuned
+cap. Walking twice re-materializes — CPU, not memory.
+
+5. **List mode rides on document mode** (`isDocument = true`), rather than a
+third mode: a list render wants document mode's stdout capture and `rela.output`
+guard verbatim, and a parallel mode would need OR-ing into every such guard
+forever. `rela.mode` stays `"document"`; scripts discriminate on
+`rela.document.list_id`.
+
+6. **`rela.document.entry_id` is absent (Lua nil) in list mode**, not
+empty-string — `""` is truthy in Lua, so the idiomatic guard would pass and then
+raise, and `entry_id or default` would yield `""`.
+
+7. **A denied caller gets 200 with an empty row set, not a 404** — matching the
+non-override list export, since an empty list is indistinguishable from no
+access.
+
+## Load-bearing implementation notes
+
+- **`resolveEffectiveList` deliberately drops the `len(Columns) > 0` predicate**
+the original `exportListColumns` had. That is a *columns* concern; folding it
+into list identity would make a list with `export_render` and no `columns`
+silently not get its override. Behavior change: naming a columnless list now
+falls back to `[id,title]` instead of borrowing the type-default list's columns.
+- **Override selection happens AFTER** `scopedEntities` → `visReader.Filter` →
+cap. That ordering is the guarantee that a script can only ever be handed gated,
+capped rows.
+- **`registerListDocumentFields` is a free function**, not a `*Runtime` method:
+it needs nothing from the Runtime. (It also keeps `Runtime` off its plimsoll
+line at max-methods=120 — a consequence, not the reason.)
+- **`runDocumentScript`** backs both `ExecuteDocument` and
+`ExecuteListDocument`. It stays unexported and takes the mode as a single
+`lua.Option` parameter, never a variadic tail — that is what keeps the typed
+seam structural rather than conventional.
+
+## Riding along
+
+- **Fixed a pre-existing gap**: `views.<type>.export_render` was never
+existence-checked at boot. Now both override kinds are, via
+`checkExportRenderScripts`, and both share `validateExportRenderShape`.
+
+## Known residual
+
+Rows reach the script through `EntityToTable`, which includes the entity
+**body**. Property-level `visible:` redaction is applied, but
+`visibility.Redact` does not yet redact `Content` (the body-redaction TODO in
+`internal/visibility/policyreader.go`). This matches the entity export path,
+which already exposes bodies — but the list export surface is newly widened, and
+both the seam godoc and `listOverrideRenderer` now point at that TODO so whoever
+implements body redaction finds this path.

--- a/tickets/relations/TKT-95XU13--affects--data-entry-server.md
+++ b/tickets/relations/TKT-95XU13--affects--data-entry-server.md
@@ -1,0 +1,5 @@
+---
+from: TKT-95XU13
+relation: affects
+to: data-entry-server
+---

--- a/tickets/relations/TKT-95XU13--affects--lua-scripting.md
+++ b/tickets/relations/TKT-95XU13--affects--lua-scripting.md
@@ -1,0 +1,5 @@
+---
+from: TKT-95XU13
+relation: affects
+to: lua-scripting
+---

--- a/tickets/relations/TKT-95XU13--has-docs--DOCS-KGF71J.md
+++ b/tickets/relations/TKT-95XU13--has-docs--DOCS-KGF71J.md
@@ -1,0 +1,5 @@
+---
+from: TKT-95XU13
+relation: has-docs
+to: DOCS-KGF71J
+---

--- a/tickets/relations/TKT-95XU13--has-implementation--IMPL-35TQGI.md
+++ b/tickets/relations/TKT-95XU13--has-implementation--IMPL-35TQGI.md
@@ -1,0 +1,5 @@
+---
+from: TKT-95XU13
+relation: has-implementation
+to: IMPL-35TQGI
+---

--- a/tickets/relations/TKT-95XU13--has-review--REV-OJOCKJ.md
+++ b/tickets/relations/TKT-95XU13--has-review--REV-OJOCKJ.md
@@ -1,0 +1,5 @@
+---
+from: TKT-95XU13
+relation: has-review
+to: REV-OJOCKJ
+---

--- a/tickets/relations/TKT-95XU13--has-review-response--RR-DXDTSB.md
+++ b/tickets/relations/TKT-95XU13--has-review-response--RR-DXDTSB.md
@@ -1,0 +1,5 @@
+---
+from: TKT-95XU13
+relation: has-review-response
+to: RR-DXDTSB
+---

--- a/tickets/relations/TKT-95XU13--has-review-response--RR-ECUOIT.md
+++ b/tickets/relations/TKT-95XU13--has-review-response--RR-ECUOIT.md
@@ -1,0 +1,5 @@
+---
+from: TKT-95XU13
+relation: has-review-response
+to: RR-ECUOIT
+---

--- a/tickets/relations/TKT-95XU13--has-review-response--RR-YI4LGQ.md
+++ b/tickets/relations/TKT-95XU13--has-review-response--RR-YI4LGQ.md
@@ -1,0 +1,5 @@
+---
+from: TKT-95XU13
+relation: has-review-response
+to: RR-YI4LGQ
+---

--- a/tickets/relations/TKT-95XU13--implements--FEAT-5IUVGX.md
+++ b/tickets/relations/TKT-95XU13--implements--FEAT-5IUVGX.md
@@ -1,0 +1,5 @@
+---
+from: TKT-95XU13
+relation: implements
+to: FEAT-5IUVGX
+---


### PR DESCRIPTION
Closes the v1 limit in `docs/transforms.md`: *"A render override for LIST export — `export_render` applies to entity export only."* A list may now name a Lua script that renders it instead of the built-in column table, mirroring `views.<type>.export_render`.

```yaml
lists:
  tickets:
    entity_type: ticket
    columns: [...]
    export_render: docs/ticket_report.lua
```

```lua
print("# " .. rela.document.list_id .. " report")
for _, row in rela.document.rows() do
  print("## " .. row.properties.title)
end
if rela.document.truncated then
  print(("\n_Showing %d of %d._"):format(rela.document.count, rela.document.total))
end
```

Ticket: **TKT-95XU13** (done, validate-clean) · implements **FEAT-5IUVGX**, which scoped this as "List export: table in v1, Lua override for fancier".

## Design decisions

- **The script renders handler-resolved rows; it never re-queries.** The ACL argument does *not* apply (TKT-ZF2DTV landed, so a script's own reads are ACL-bound anyway). The real reasons are narrower: a re-query would ignore the user's active filters and escape `listExportCap`, so the export would stop matching the view it came from.
- **Rows are lazy** — `rows()` mints a fresh cursor per call and materializes one `EntityToTable` at a time, so memory stays flat and the existing cap stays the only bound. Walking twice re-materializes (CPU, not memory).
- **List mode rides on document mode** rather than adding a third: it wants document mode's stdout capture and `rela.output` guard verbatim. `rela.mode` stays `"document"`; scripts discriminate on `rela.document.list_id`.
- **`entry_id` is absent (Lua nil)**, not empty-string — `""` is truthy in Lua, so the idiomatic guard would pass and then raise.
- **A denied caller gets 200 with an empty set, not a 404** — matching the non-override path, since an empty list is indistinguishable from no access.

## Reviewer notes

Two behavior changes worth a look:

1. **`resolveEffectiveList` drops the `len(Columns) > 0` predicate** when deciding *which list* an export belongs to. That is a columns concern; keeping it would make a list with `export_render` and no `columns` silently not get its override. Side effect: naming a columnless list now falls back to `[id,title]` rather than borrowing the type-default list's columns.
2. **`views.<type>.export_render` is now existence-checked at boot** — it never was, which the list work made conspicuous.

**Known residual:** rows reach the script via `EntityToTable`, which includes the entity **body**. Property redaction is applied, but `visibility.Redact` does not redact `Content` yet. This matches the entity export path, which already exposes bodies — flagged in the godoc at both the seam and the renderer so body-redaction work finds this path.

## Review trail

A 4-agent `/simplify` pass, then cranky-code-reviewer + go-architect. Three significant findings, all fixed:

- **RR-DXDTSB** — `buildListQuery` re-derived the pre-RR-6RF60V filter-key bug: `filter[status][ne]` keyed the script's table on `"status][ne"`. Now uses the existing `parseRelationFilterKey`; the regression test's sensitivity was verified by reverting the fix.
- **RR-ECUOIT** — `query.q` was omitted when empty, so `"Search: " .. q` worked on filtered exports and hard-errored on unfiltered ones.
- **RR-YI4LGQ** — the renderer godoc asserted an invariant that wasn't true (the body case above).

One finding rejected after checking: a claim that list renders run without a timeout. `Timeout: 0` inherits `lua.DefaultTimeout`; an infinite-loop script terminates at 30.0s.

## Verification

`just ci` green locally. Also verified end-to-end with a **real Lua runtime** (not just the fake engine): a script on disk rendered three real rows, `entry_id is nil`, and the second `rows()` walk saw all three.

Coverage floors PASS. `arch-lint` clean — neither `lua` nor `script` gained a `dataentry` edge. `plimsoll` clean — `Runtime` held at its pinned `max-methods=120` rather than bumping a pin TKT-ZF2DTV had just justified.