### PR TITLE
fix(frontend): nest DocumentsPanel inside .sections for consistent spacing

### DIFF
--- a/frontend/src/components/entity/EntityDetail.vue
+++ b/frontend/src/components/entity/EntityDetail.vue
@@ -1183,10 +1183,13 @@ watch(
             </table>
           </div>
         </section>
-      </div>
 
-      <!-- External documents (renders only when configured for this type). -->
-      <DocumentsPanel :entity-type="entityType" :entity-id="entityId" />
+        <!-- External documents (renders only when configured for this type).
+             Nested here (not a sibling of .sections) so it picks up the
+             container's flex `gap` for free instead of duplicating that
+             spacing via its own margin. -->
+        <DocumentsPanel :entity-type="entityType" :entity-id="entityId" />
+      </div>
 
       <CommandModal ref="commandModalRef" :entity-id="entityId" />
     </template>

--- a/tickets/entities/automated-measures/documentspanel-sections-nesting-test.md
+++ b/tickets/entities/automated-measures/documentspanel-sections-nesting-test.md
@@ -1,0 +1,9 @@
+---
+id: documentspanel-sections-nesting-test
+type: automated-measure
+title: Frontend test asserting DocumentsPanel nests inside .sections
+description: No test currently asserts DocumentsPanel is a child of div.sections in EntityDetail.vue; a future refactor could silently move it back out to a sibling position and lose the flex gap again with no red test to catch it. Add a frontend component test (or Playwright DOM assertion) that asserts DocumentsPanel renders as a descendant of .sections.
+kind: test
+location: frontend/src/components/entity/EntityDetail.vue (test not yet added)
+status: proposed
+---

--- a/tickets/entities/bugs/BUG-YKJSZM.md
+++ b/tickets/entities/bugs/BUG-YKJSZM.md
@@ -1,0 +1,40 @@
+---
+id: BUG-YKJSZM
+type: bug
+title: DocumentsPanel rendered as sibling of .sections missing 32px gap
+description: 'DocumentsPanel rendered as a sibling of div.sections in EntityDetail.vue instead of one of its flex children; it never picked up .sections gap: 32px and nothing else supplied that spacing either; there was no gap between the last section and the Documents panel.'
+priority: low
+effort: xs
+why1: DocumentsPanel was placed after the closing </div> of .sections rather than before it; it fell outside the flex container that provides the 32px gap between sections.
+why2: EntityDetail.vue was structured with .sections as a flex container relying on gap for inter-child spacing; DocumentsPanel was appended as a template sibling rather than a child when it was added to the page.
+why3: No margin or gap was added for DocumentsPanel at the point it was introduced since the author relied on visual review rather than checking which flex container the gap actually applied to.
+why4: There is no test or lint rule asserting DOM nesting/spacing invariants for EntityDetail.vue so a layout regression like this is only caught by manual visual inspection.
+why5: Layout spacing in this component is implicit (derived from DOM nesting under a flex gap) rather than an explicit named spacing token or utility applied uniformly; correctness depends on remembering which elements must nest inside which container.
+prevention: Nest new entity-detail sections inside .sections so they share the flex gap by construction; consider a visual regression test on EntityDetail.vue if this class of spacing bug recurs.
+status: done
+---
+
+## Problem
+
+`DocumentsPanel` was rendered as a sibling of `div.sections` in
+`EntityDetail.vue`, after that div's closing tag, instead of as one of its flex
+children. `.sections` supplies `gap: 32px` between its children; nothing else in
+the template supplied equivalent spacing for `DocumentsPanel`, so there was no
+gap between the last relation section and the Documents panel on an entity
+detail page with a configured document.
+
+## Fix
+
+Moved `<DocumentsPanel>` inside `div.sections`, right after the `v-for` rendered
+`<section>` elements, so it is covered by the existing flex `gap` instead of
+duplicating that spacing via a new margin.
+
+Verified `entry` is `computed(() => viewData.value?.entry || null)`, so `entry`
+truthy already implies `viewData` truthy — nesting inside `v-if="viewData"`
+introduces no behavioral divergence from the previous unconditional-sibling
+placement.
+
+Manually verified in a local rela-server build: 32px gap now renders between the
+last relation section and the Documents panel.
+
+Fixed in PR #1242.

--- a/tickets/entities/review-checklists/REV-K95PBS.md
+++ b/tickets/entities/review-checklists/REV-K95PBS.md
@@ -1,0 +1,25 @@
+---
+id: REV-K95PBS
+type: review-checklist
+title: 'Review: DocumentsPanel rendered as sibling of .sections missing 32px gap'
+status: done
+---
+
+## Automated Checks
+
+- [x] `just ci` passes end-to-end (all checks green after this checklist was added)
+- [x] `just arch-lint` passes (no backend code touched)
+
+## Manual Review
+
+- [x] Change reviewed: single-line move of `<DocumentsPanel>` from a sibling
+of `div.sections` to its last child, so it picks up the existing flex `gap:
+32px` instead of needing a new margin.
+- [x] Confirmed no behavioral divergence from nesting inside `v-if="viewData"`
+(`entry` truthy already implies `viewData` truthy).
+- [x] ~~Automated frontend test~~ (N/A: layout-only change, no existing test
+covers `.sections`/`DocumentsPanel` DOM structure; manually verified 32px gap
+renders correctly in a local rela-server build)
+
+**Summary:** Trivial, low-risk CSS/DOM-structure fix. Manually verified the gap
+renders as expected; no behavior change beyond spacing.

--- a/tickets/relations/BUG-YKJSZM--adds-measure--documentspanel-sections-nesting-test.md
+++ b/tickets/relations/BUG-YKJSZM--adds-measure--documentspanel-sections-nesting-test.md
@@ -1,0 +1,5 @@
+---
+from: BUG-YKJSZM
+relation: adds-measure
+to: documentspanel-sections-nesting-test
+---

--- a/tickets/relations/BUG-YKJSZM--affects--data-entry-ui.md
+++ b/tickets/relations/BUG-YKJSZM--affects--data-entry-ui.md
@@ -1,0 +1,5 @@
+---
+from: BUG-YKJSZM
+relation: affects
+to: data-entry-ui
+---

--- a/tickets/relations/BUG-YKJSZM--fixes--FEAT-023.md
+++ b/tickets/relations/BUG-YKJSZM--fixes--FEAT-023.md
@@ -1,0 +1,5 @@
+---
+from: BUG-YKJSZM
+relation: fixes
+to: FEAT-023
+---

--- a/tickets/relations/BUG-YKJSZM--has-review--REV-K95PBS.md
+++ b/tickets/relations/BUG-YKJSZM--has-review--REV-K95PBS.md
@@ -1,0 +1,5 @@
+---
+from: BUG-YKJSZM
+relation: has-review
+to: REV-K95PBS
+---


### PR DESCRIPTION
## Summary
- `DocumentsPanel` rendered as a sibling of `div.sections` instead of one of its flex children, so it never picked up `.sections`' `gap: 32px` — nothing else supplied that spacing either, leaving no gap between the last section and the Documents panel.
- Moved `<DocumentsPanel>` inside `div.sections`, right after the `v-for`-rendered `<section>` elements, so it's covered by the existing flex `gap` instead of duplicating that spacing via a new margin.
- Verified `entry` is `computed(() => viewData.value?.entry || null)`, so `entry` truthy already implies `viewData` truthy — nesting inside `v-if="viewData"` introduces no behavioral divergence from the previous unconditional-sibling placement.

## Test plan
- [x] Manually verified in a local rela-server build: 32px gap now renders between the last relation section and the Documents panel on an entity detail page with a configured document.
- [ ] Frontend unit/e2e suite (not run as part of this change — layout-only, no test currently covers `.sections`/`DocumentsPanel` DOM structure)