### PR TITLE
feat(dataentry): gate _analyze reads per requester (TKT-3FL2S6)

### DIFF
--- a/internal/dataentry/acl_analyze_test.go
+++ b/internal/dataentry/acl_analyze_test.go
@@ -161,8 +161,29 @@ func TestACLAnalyze_RedactsHiddenTemplatedTitle(t *testing.T) {
 	if rec.Code != http.StatusOK {
 		t.Fatalf("_analyze: got %d, want 200; body=%s", rec.Code, rec.Body)
 	}
-	if body := rec.Body.String(); strings.Contains(body, "SECRET-SURNAME") {
-		t.Errorf("LEAK: hidden template placeholder leaked in analyze title: %s", body)
+	var result APIAnalysisResult
+	if err := json.Unmarshal(rec.Body.Bytes(), &result); err != nil {
+		t.Fatalf("decode _analyze response: %v", err)
+	}
+	var sawPersoon bool
+	for _, iss := range result.Issues {
+		if iss.EntityID != "PERS-001" {
+			continue
+		}
+		sawPersoon = true
+		// The hidden surname must not leak — AND neither may the PARTIAL title
+		// "Jeroen" (readable half). When any template placeholder is hidden the
+		// whole title must fall back to the id (tschmits review, TKT-3FL2S6):
+		// a partial render leaks the readable half and confirms a hidden half.
+		if iss.Title != "PERS-001" {
+			t.Errorf("PARTIAL-TITLE LEAK: templated title with a hidden placeholder must fall back to id, got %q", iss.Title)
+		}
+	}
+	if !sawPersoon {
+		t.Fatalf("expected an issue for PERS-001; got %+v", result.Issues)
+	}
+	if body := rec.Body.String(); strings.Contains(body, "SECRET-SURNAME") || strings.Contains(body, "Jeroen") {
+		t.Errorf("LEAK: hidden/partial template value in analyze response: %s", body)
 	}
 }
 

--- a/internal/dataentry/acl_analyze_test.go
+++ b/internal/dataentry/acl_analyze_test.go
@@ -166,6 +166,63 @@ func TestACLAnalyze_RedactsHiddenTemplatedTitle(t *testing.T) {
 	}
 }
 
+// TestACLAnalyze_GatedReadClosesMessageLeak pins the leak the wire-boundary
+// sentinel caught and the whole gated-analyze arc (TKT-3FL2S6) exists to close:
+// the Properties check reports "Invalid value \"X\" (allowed: …)" where X is the
+// entity's raw property value. If that property is hidden from the requester, X
+// is a value they cannot see — leaked through the issue MESSAGE (not the title).
+// Gated reads close it by construction: the entity is redacted before
+// ValidateEntity sees it, so there is no bad value to quote.
+func TestACLAnalyze_GatedReadClosesMessageLeak(t *testing.T) {
+	meta := &metamodel.Metamodel{
+		Types: map[string]metamodel.CustomType{
+			"status_type": {Values: []string{"open", "closed"}},
+		},
+		Entities: map[string]metamodel.EntityDef{
+			"ticket": {
+				Label:    "Ticket",
+				IDPrefix: "TKT-",
+				Properties: map[string]metamodel.PropertyDef{
+					"title":  {Type: "string", Required: true},
+					"status": {Type: "status_type"},
+				},
+				PropertyOrder: []string{"title", "status"},
+			},
+		},
+	}
+	app := newAppFromParts(&Config{}, meta, newFixture())
+	app.broker = newEventBroker()
+	// Hide `status` — the property whose invalid value the Properties check would
+	// otherwise quote in its message.
+	app.fieldResolver = fakeResolver{fv: FieldVerdicts{
+		Visible: map[string]bool{"status": false},
+	}}
+	// status holds an INVALID enum value → Properties check fires "Invalid value
+	// \"SECRET-STATUS\" (allowed: [open closed])".
+	seedEntity(app, &entity.Entity{
+		ID: "TKT-001", Type: "ticket",
+		Properties: map[string]any{"title": "visible title", "status": "SECRET-STATUS"},
+	})
+
+	d := mustNewACL(t, &acl.Policy{
+		Roles:       map[string]acl.RoleDef{"viewer": {Read: []string{"ticket"}}},
+		Assignments: map[string]string{"alice": "viewer"},
+	}, app.store)
+	app.acl = d
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/_analyze", http.NoBody)
+	req = req.WithContext(gateCtxFor(aliceCtx(), t, d))
+	rec := httptest.NewRecorder()
+	app.handleV1Analyze(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("_analyze: got %d, want 200; body=%s", rec.Code, rec.Body)
+	}
+	if body := rec.Body.String(); strings.Contains(body, "SECRET-STATUS") {
+		t.Errorf("LEAK: hidden property value leaked through an analyze issue MESSAGE: %s", body)
+	}
+}
+
 func countWarnings(issues []APIIssue) int {
 	n := 0
 	for _, i := range issues {

--- a/internal/dataentry/analyze.go
+++ b/internal/dataentry/analyze.go
@@ -176,7 +176,7 @@ func (svc analyzeService) analyzeOrphans(ctx context.Context, meta *metamodel.Me
 		section.Issues = append(section.Issues, AnalysisIssue{
 			EntityID:   e.ID,
 			EntityType: e.Type,
-			Title:      meta.DisplayTitle(e.ID, e.Type, e.Properties),
+			Title:      safeDisplayTitle(meta, e),
 			Message:    "No relations",
 			Severity:   "warning",
 		})
@@ -197,7 +197,7 @@ func (svc analyzeService) analyzeDuplicates(ctx context.Context, meta *metamodel
 		if err != nil {
 			break
 		}
-		title := normalizeTitle(meta.DisplayTitle(e.ID, e.Type, e.Properties))
+		title := normalizeTitle(safeDisplayTitle(meta, e))
 		if title != "" {
 			titleGroups[title] = append(titleGroups[title], e)
 		}
@@ -223,7 +223,7 @@ func (svc analyzeService) analyzeDuplicates(ctx context.Context, meta *metamodel
 			section.Issues = append(section.Issues, AnalysisIssue{
 				EntityID:   e.ID,
 				EntityType: e.Type,
-				Title:      meta.DisplayTitle(e.ID, e.Type, e.Properties),
+				Title:      safeDisplayTitle(meta, e),
 				Message:    fmt.Sprintf("Duplicate title (shared by %s)", strings.Join(ids, ", ")),
 				Severity:   "warning",
 			})
@@ -361,7 +361,7 @@ func (svc analyzeService) analyzeCardinality(ctx context.Context, meta *metamode
 						section.Issues = append(section.Issues, AnalysisIssue{
 							EntityID:   e.ID,
 							EntityType: e.Type,
-							Title:      meta.DisplayTitle(e.ID, e.Type, e.Properties),
+							Title:      safeDisplayTitle(meta, e),
 							Message:    fmt.Sprintf("Must have at least %d '%s' relation(s), has %d", *relDef.MinOutgoing, relName, count),
 							Severity:   "error",
 						})
@@ -379,7 +379,7 @@ func (svc analyzeService) analyzeCardinality(ctx context.Context, meta *metamode
 						section.Issues = append(section.Issues, AnalysisIssue{
 							EntityID:   e.ID,
 							EntityType: e.Type,
-							Title:      meta.DisplayTitle(e.ID, e.Type, e.Properties),
+							Title:      safeDisplayTitle(meta, e),
 							Message:    fmt.Sprintf("Has more than %d '%s' relation(s): %d", *relDef.MaxOutgoing, relName, count),
 							Severity:   "error",
 						})
@@ -401,7 +401,7 @@ func (svc analyzeService) analyzeCardinality(ctx context.Context, meta *metamode
 						section.Issues = append(section.Issues, AnalysisIssue{
 							EntityID:   e.ID,
 							EntityType: e.Type,
-							Title:      meta.DisplayTitle(e.ID, e.Type, e.Properties),
+							Title:      safeDisplayTitle(meta, e),
 							Message:    fmt.Sprintf("Must have at least %d '%s' relation(s), has %d", *relDef.MinIncoming, relLabel, count),
 							Severity:   "error",
 						})
@@ -423,7 +423,7 @@ func (svc analyzeService) analyzeCardinality(ctx context.Context, meta *metamode
 						section.Issues = append(section.Issues, AnalysisIssue{
 							EntityID:   e.ID,
 							EntityType: e.Type,
-							Title:      meta.DisplayTitle(e.ID, e.Type, e.Properties),
+							Title:      safeDisplayTitle(meta, e),
 							Message:    fmt.Sprintf("Has more than %d '%s' relation(s): %d", *relDef.MaxIncoming, relLabel, count),
 							Severity:   "error",
 						})
@@ -458,7 +458,7 @@ func (svc analyzeService) analyzeProperties(ctx context.Context, meta *metamodel
 			section.Issues = append(section.Issues, AnalysisIssue{
 				EntityID:   e.ID,
 				EntityType: e.Type,
-				Title:      meta.DisplayTitle(e.ID, e.Type, e.Properties),
+				Title:      safeDisplayTitle(meta, e),
 				Message:    err.Error(),
 				Severity:   "error",
 			})
@@ -498,7 +498,7 @@ func (svc analyzeService) analyzeValidations(ctx context.Context, meta *metamode
 			section.Issues = append(section.Issues, AnalysisIssue{
 				EntityID:   e.ID,
 				EntityType: e.Type,
-				Title:      meta.DisplayTitle(e.ID, e.Type, e.Properties),
+				Title:      safeDisplayTitle(meta, e),
 				Message:    rule.Description,
 				Severity:   severity,
 				Detail:     v.Detail,
@@ -552,6 +552,26 @@ func sortStoreEntitiesByID(entities []*entity.Entity) {
 	sort.Slice(entities, func(i, j int) bool {
 		return natsort.Less(entities[i].ID, entities[j].ID)
 	})
+}
+
+// safeDisplayTitle renders an entity's display title, falling back to the id if
+// ANY property backing the title is absent from the (already gated-redacted)
+// entity — including one placeholder of a templated display_property. Plain
+// DisplayTitle would render a PARTIAL template ("Jeroen " when achternaam is
+// hidden), which leaks the readable half and confirms a hidden half exists (the
+// BUG-R9EHKV leak class). Gating strips the value; this restores the whole-title
+// fallback the deleted hiddenDisplayTitleEntityIDs used to provide (RR-7GN3LV
+// follow-up / tschmits review on TKT-3FL2S6). e.Properties is the redacted map,
+// so a hidden display property is simply absent here.
+func safeDisplayTitle(meta *metamodel.Metamodel, e *entity.Entity) string {
+	if def, ok := meta.GetEntityDef(e.Type); ok {
+		for _, prop := range def.DisplayProperties() {
+			if _, present := e.Properties[prop]; !present {
+				return e.ID // a display-title source was redacted → don't leak a partial title
+			}
+		}
+	}
+	return meta.DisplayTitle(e.ID, e.Type, e.Properties)
 }
 
 // normalizeTitle normalizes a title for duplicate comparison.

--- a/internal/dataentry/analyze.go
+++ b/internal/dataentry/analyze.go
@@ -3,6 +3,7 @@ package dataentry
 import (
 	"context"
 	"fmt"
+	"iter"
 	"sort"
 	"strings"
 
@@ -15,16 +16,43 @@ import (
 	"github.com/Sourcehaven-BV/rela/internal/validator"
 )
 
+// analyzeReader is the narrow, consumer-side ENTITY-read surface the analyze
+// checks need. It is satisfied structurally by store.Store AND by the ctx-gating
+// visibility.ScriptReader / Unrestricted readers. Wiring a GATED reader here
+// (per TKT-3FL2S6, superseding DEC-O59WM4) makes the whole-graph scans read only
+// the requester's slice: a hidden entity produces no issue, and a visible
+// entity comes back REDACTED, so its value cannot reach an issue title or a
+// validation message. The leak closes by construction, not by filtering output.
+//
+// Only entity reads: analyze never mutates. Relation COUNTS (cardinality) go
+// through a separate counter that stays on the raw store — a count is a
+// structural fact, not a value, so it cannot leak; under-visibility only makes
+// cardinality potentially false-positive, which is correctness (guarded by the
+// roles annotation, arc step 2), not a disclosure.
+type analyzeReader interface {
+	GetEntity(ctx context.Context, id string) (*entity.Entity, error)
+	ListEntities(ctx context.Context, q store.EntityQuery) iter.Seq2[*entity.Entity, error]
+}
+
+// relationCounter counts relations for the cardinality check. Raw (ungated) on
+// purpose — see analyzeReader.
+type relationCounter interface {
+	CountRelations(ctx context.Context, q store.RelationQuery) (int, error)
+}
+
 // analyzeService runs the read-only graph-analysis checks (orphans,
 // duplicates, gaps, cardinality, properties, validations). Extracted from App
 // (TKT-N26KLB M5.1): it depends only on the stable read services, and each
 // method takes the per-request metamodel snapshot explicitly (capture-once,
 // per the project's snapshot rule) rather than reaching back into App.
 //
-// The whole-graph scans are intentionally ungated; visibility is applied to
-// the resulting issues at the HTTP boundary (see visibleAnalysisIssues).
+// reads is GATED per the requesting principal (TKT-3FL2S6, DEC-O59WM4
+// superseded); relCounts is the raw relation counter (structural, cannot leak);
+// the tracer is the gated decorator. Under NopACL, reads/tracer are the raw
+// store/tracer (no gating).
 type analyzeService struct {
-	store     store.Store
+	reads     analyzeReader
+	relCounts relationCounter
 	tracer    tracer.Tracer
 	validator validator.Validator
 }
@@ -129,8 +157,14 @@ func (svc analyzeService) analyzeOrphans(ctx context.Context, meta *metamodel.Me
 
 	orphanIDs, _ := svc.tracer.FindOrphans(ctx)
 
+	// Each orphan id is re-loaded through the GATED reader before it can become
+	// an issue: a hidden entity's GetEntity returns not-found and is dropped, and
+	// a visible one is redacted. So even if the tracer yielded a raw id (it does
+	// not — svc.tracer is gated too), no hidden entity reaches the wire. Do NOT
+	// emit an issue straight from an orphan id/type without this gated re-load —
+	// that would reopen the leak this arc closed (TKT-3FL2S6).
 	var orphans []*entity.Entity
-	st := svc.store
+	st := svc.reads
 	for _, id := range orphanIDs {
 		if e, err := st.GetEntity(ctx, id); err == nil {
 			orphans = append(orphans, e)
@@ -159,7 +193,7 @@ func (svc analyzeService) analyzeDuplicates(ctx context.Context, meta *metamodel
 	}
 
 	titleGroups := make(map[string][]*entity.Entity)
-	for e, err := range svc.store.ListEntities(ctx, store.EntityQuery{}) {
+	for e, err := range svc.reads.ListEntities(ctx, store.EntityQuery{}) {
 		if err != nil {
 			break
 		}
@@ -223,7 +257,7 @@ func (svc analyzeService) analyzeGaps(ctx context.Context, meta *metamodel.Metam
 
 	// Group IDs by prefix
 	prefixGroups := make(map[string][]int)
-	for e, err := range svc.store.ListEntities(ctx, store.EntityQuery{}) {
+	for e, err := range svc.reads.ListEntities(ctx, store.EntityQuery{}) {
 		if err != nil {
 			break
 		}
@@ -282,8 +316,6 @@ func (svc analyzeService) analyzeCardinality(ctx context.Context, meta *metamode
 		Description: "Relation cardinality constraint violations",
 	}
 
-	st := svc.store
-
 	// Sort relation names for deterministic output
 	relNames := make([]string, 0, len(meta.Relations))
 	for name := range meta.Relations {
@@ -291,10 +323,12 @@ func (svc analyzeService) analyzeCardinality(ctx context.Context, meta *metamode
 	}
 	natsort.Strings(relNames)
 
-	// listEntities lists entities of a given type, sorted by ID.
+	// listEntities lists entities of a given type, sorted by ID. GATED: only the
+	// requester's visible entities are considered, so a hidden entity's title
+	// cannot reach a cardinality issue.
 	listEntities := func(t string) []*entity.Entity {
 		var out []*entity.Entity
-		for e, err := range st.ListEntities(ctx, store.EntityQuery{Type: t}) {
+		for e, err := range svc.reads.ListEntities(ctx, store.EntityQuery{Type: t}) {
 			if err != nil {
 				break
 			}
@@ -304,9 +338,12 @@ func (svc analyzeService) analyzeCardinality(ctx context.Context, meta *metamode
 		return out
 	}
 
-	// countRelations counts relations of a specific type for an entity.
+	// countRelations counts relations of a specific type for an entity. RAW
+	// (ungated): a count is a structural fact, not a value — it cannot leak.
+	// Under partial visibility this may over/under-count and produce a false
+	// cardinality violation (guarded by the roles annotation, arc step 2).
 	countRelations := func(entityID, relType string, direction store.Direction) int {
-		n, _ := st.CountRelations(ctx, store.RelationQuery{
+		n, _ := svc.relCounts.CountRelations(ctx, store.RelationQuery{
 			EntityID: entityID, Type: relType, Direction: direction,
 		})
 		return n
@@ -407,7 +444,7 @@ func (svc analyzeService) analyzeProperties(ctx context.Context, meta *metamodel
 	}
 
 	entities := make([]*entity.Entity, 0)
-	for e, err := range svc.store.ListEntities(ctx, store.EntityQuery{}) {
+	for e, err := range svc.reads.ListEntities(ctx, store.EntityQuery{}) {
 		if err != nil {
 			break
 		}
@@ -444,7 +481,7 @@ func (svc analyzeService) analyzeValidations(ctx context.Context, meta *metamode
 		Description: "Custom validation rules defined in the metamodel",
 	}
 
-	st := svc.store
+	st := svc.reads
 	validator := svc.validator
 
 	for _, rule := range meta.Validations {

--- a/internal/dataentry/analyze_test.go
+++ b/internal/dataentry/analyze_test.go
@@ -26,7 +26,7 @@ func newAnalyzeService(t *testing.T, f *fixture, meta *metamodel.Metamodel) anal
 	}
 	svc := appbuildtest.New(meta, appbuildtest.WithFS(fs, ctx))
 	seedFromFixture(svc.Store(), f)
-	return analyzeService{store: svc.Store(), tracer: svc.Tracer(), validator: svc.Validator()}
+	return analyzeService{reads: svc.Store(), relCounts: svc.Store(), tracer: svc.Tracer(), validator: svc.Validator()}
 }
 
 func TestAnalyzeOrphans(t *testing.T) {

--- a/internal/dataentry/api_v1.go
+++ b/internal/dataentry/api_v1.go
@@ -27,7 +27,6 @@ import (
 	"github.com/Sourcehaven-BV/rela/internal/metamodel"
 	"github.com/Sourcehaven-BV/rela/internal/project"
 	"github.com/Sourcehaven-BV/rela/internal/store"
-	"github.com/Sourcehaven-BV/rela/internal/visibility"
 )
 
 // --- API v1 Types ---
@@ -1359,14 +1358,12 @@ func (a *App) handleV1Analyze(w http.ResponseWriter, r *http.Request) {
 
 	analysisResult := a.analyze.runAnalysis(r.Context(), a.State().Meta)
 
-	// ACL gate (TKT-QU7REX): runAnalysis walks the WHOLE graph, so every issue
-	// carries an entityId/entityType/title that would leak existence + title to
-	// a principal who cannot read that entity. Filter each issue through the
-	// per-entity read gate (batched by type, fail-closed) BEFORE building the
-	// response, and recompute the Errors/Warnings/ByCheck counts so the
-	// aggregates can't leak the count of hidden issues either. Issues with no
-	// entityId (graph-level checks) name no entity and pass through.
-	visible := a.visibleAnalysisIssues(r.Context(), analysisResult.Sections)
+	// runAnalysis now reads GATED per the requesting principal (TKT-3FL2S6), so
+	// a hidden entity never enters a check and a visible entity is redacted
+	// before its value can reach an issue title or message. No post-hoc output
+	// filter is needed — the issues are already the requester's visible slice.
+	// Flatten sections to (issue, section) pairs for the wire builder.
+	visible := flattenIssues(analysisResult.Sections)
 
 	result := APIAnalysisResult{
 		Issues:  make([]APIIssue, 0, len(visible)),
@@ -1414,116 +1411,16 @@ type visibleIssue struct {
 	section string
 }
 
-// visibleAnalysisIssues filters analysis issues through the per-entity read
-// gate (TKT-QU7REX). Issues are batched by entity type and resolved with one
-// PermitsReadMany call per type (mirroring filterVisibleIncludes), so the cost
-// is O(distinct-types) not O(issues). An issue with an empty EntityID names no
-// entity (graph-level checks like ID gaps) and is always kept. On a gate error
-// for a type, that type's issues are dropped fail-closed and logged, matching
-// the include path — under-reporting is safer than leaking a denied entity.
-func (a *App) visibleAnalysisIssues(ctx context.Context, sections []AnalysisSection) []visibleIssue {
-	gate := readGateFromContext(ctx)
-
-	// Collect entity ids to check, grouped by type.
-	idsByType := make(map[string]map[string]struct{})
-	for _, section := range sections {
-		for _, issue := range section.Issues {
-			if issue.EntityID == "" || issue.EntityType == "" {
-				continue
-			}
-			if idsByType[issue.EntityType] == nil {
-				idsByType[issue.EntityType] = make(map[string]struct{})
-			}
-			idsByType[issue.EntityType][issue.EntityID] = struct{}{}
-		}
-	}
-
-	// Resolve visibility once per type.
-	allowed := make(map[string]map[string]bool, len(idsByType))
-	for typeName, idset := range idsByType {
-		ids := make([]string, 0, len(idset))
-		for id := range idset {
-			ids = append(ids, id)
-		}
-		perm, err := gate.PermitsReadMany(ctx, typeName, ids)
-		if err != nil {
-			slog.Warn("dataentry: visibleAnalysisIssues: PermitsReadMany failed; dropping type",
-				"type", typeName, "issues", len(ids), "err", err)
-			allowed[typeName] = map[string]bool{} // fail-closed: nothing of this type visible
-			continue
-		}
-		allowed[typeName] = perm
-	}
-
-	// A permitted entity may still have its DISPLAY property hidden by a
-	// field-level `visible:` grant. The issue title was baked upstream by
-	// DisplayTitle against raw properties (analyze.go), so redact it here to the
-	// id — the same field-level fallback the view/mention/settings surfaces get
-	// (BUG-R9EHKV). Only permitted entities are loaded (the row gate already
-	// ran), and only when their primary property is actually hidden.
-	titleFallback := hiddenDisplayTitleEntityIDs(ctx, a, allowed)
-
-	// Build the filtered, order-preserving result.
+// flattenIssues walks the analysis sections into (issue, section) pairs for the
+// wire builder. No filtering: runAnalysis already read gated, so the issues are
+// the requester's visible slice — a hidden entity produced no issue and a
+// visible entity was redacted before its value could reach a title or message
+// (TKT-3FL2S6, replacing the former visibleAnalysisIssues output filter).
+func flattenIssues(sections []AnalysisSection) []visibleIssue {
 	var out []visibleIssue
 	for _, section := range sections {
 		for _, issue := range section.Issues {
-			if issue.EntityID != "" && issue.EntityType != "" {
-				if !allowed[issue.EntityType][issue.EntityID] {
-					continue // hidden entity → drop the issue
-				}
-				if titleFallback[issue.EntityID] {
-					issue.Title = issue.EntityID // hidden display property → no title leak
-				}
-			}
 			out = append(out, visibleIssue{issue: issue, section: section.Name})
-		}
-	}
-	return out
-}
-
-// hiddenDisplayTitleEntityIDs returns the set of permitted entity ids whose
-// DISPLAY TITLE draws on a property hidden from the ctx principal — the ids
-// whose analyze issue title must fall back to the id rather than leak the
-// hidden value. It loads only already-permitted entities and redacts each; if
-// redaction strips ANY property that backs the display title, the whole title
-// is suppressed to the id (a partial template render like "Jeroen " would leak
-// the readable half and confirm a hidden half, so full fallback is correct).
-//
-// Uses DisplayProperties (the full read set — handles templated
-// display_property), NOT GetPrimaryProperty, which returns "" for a template
-// and would miss `{voornaam} {achternaam}`-style titles entirely. Fail-closed
-// on a load miss (treated as not-hidden is safe: a missing entity produces no
-// baked title to leak).
-//
-// A package function, not an App method, to keep App under its plimsoll cap.
-func hiddenDisplayTitleEntityIDs(ctx context.Context, a *App, allowed map[string]map[string]bool) map[string]bool {
-	redactor := appRedactor(a)
-	meta := a.State().Meta
-	out := map[string]bool{}
-	for _, ids := range allowed {
-		for id, ok := range ids {
-			if !ok {
-				continue // perm maps carry explicit false entries
-			}
-			e, err := a.store.GetEntity(ctx, id)
-			if err != nil {
-				continue
-			}
-			def, defOK := meta.GetEntityDef(e.Type)
-			if !defOK {
-				continue
-			}
-			displayProps := def.DisplayProperties()
-			if len(displayProps) == 0 {
-				continue // title is the id already → nothing to leak
-			}
-			redacted := visibility.Redact(ctx, redactor, e)
-			for _, prop := range displayProps {
-				if _, present := redacted.Properties[prop]; !present {
-					out[id] = true // a display-title source was stripped → title would leak
-					break
-				}
-			}
 		}
 	}
 	return out

--- a/internal/dataentry/app.go
+++ b/internal/dataentry/app.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"iter"
 	"log/slog"
 	"net/http"
 	"net/url"
@@ -18,6 +19,7 @@ import (
 	"github.com/Sourcehaven-BV/rela/internal/audit"
 	"github.com/Sourcehaven-BV/rela/internal/config"
 	"github.com/Sourcehaven-BV/rela/internal/dataentryconfig"
+	"github.com/Sourcehaven-BV/rela/internal/entity"
 	"github.com/Sourcehaven-BV/rela/internal/entitymanager"
 	"github.com/Sourcehaven-BV/rela/internal/git"
 	"github.com/Sourcehaven-BV/rela/internal/lua"
@@ -375,23 +377,90 @@ func appRedactor(a *App) visibility.FieldRedactor {
 // appbuild's guard: it would convert a caught bug into a silent downgrade,
 // and delete the fault path failclosed_test.go exercises.
 func (a *App) scriptReader(redactor visibility.FieldRedactor) lua.EntityReader {
-	d, ok := a.acl.(*acl.Declarative)
+	return gatedScriptReader(a.acl, a.store, redactor)
+}
+
+// lateGatedReader is a lua.EntityReader that resolves the gated reader from the
+// LIVE App on every call, so a reassignment of a.acl / a.fieldResolver (tests
+// rebind these after construction; a policy reload can too) is honored rather
+// than frozen at wiring time. The validator and analyzeService hold their reader
+// as a value, so a construction-time-captured reader would go stale — this
+// wrapper is the fix. It mirrors why luaWriteDeps is a method invoked per call.
+type lateGatedReader struct{ app *App }
+
+func (r lateGatedReader) reader() lua.EntityReader {
+	return r.app.scriptReader(appRedactor(r.app))
+}
+
+func (r lateGatedReader) GetEntity(ctx context.Context, id string) (*entity.Entity, error) {
+	return r.reader().GetEntity(ctx, id)
+}
+
+func (r lateGatedReader) ListEntities(ctx context.Context, q store.EntityQuery) iter.Seq2[*entity.Entity, error] {
+	return r.reader().ListEntities(ctx, q)
+}
+
+func (r lateGatedReader) ListRelations(ctx context.Context, q store.RelationQuery) iter.Seq2[*entity.Relation, error] {
+	return r.reader().ListRelations(ctx, q)
+}
+
+// lateGatedTracer is the tracer.Tracer counterpart of lateGatedReader: it
+// resolves the gated tracer (scriptTracer, which prunes hidden nodes and fails
+// closed) from the LIVE App per call, so a rule's rela.trace_from/trace_to/
+// find_path cannot walk into entities the requester cannot see. Wired into the
+// validator's ReadDeps.Tracer so the traversal seam is gated by construction,
+// not left safe only because a Lua message never reaches the wire (code review).
+type lateGatedTracer struct{ app *App }
+
+func (t lateGatedTracer) tracer() tracer.Tracer {
+	return t.app.scriptTracer(appRedactor(t.app))
+}
+
+func (t lateGatedTracer) TraceFrom(ctx context.Context, id string, maxDepth int) *tracer.TraceResult {
+	return t.tracer().TraceFrom(ctx, id, maxDepth)
+}
+
+func (t lateGatedTracer) TraceTo(ctx context.Context, id string, maxDepth int) *tracer.TraceResult {
+	return t.tracer().TraceTo(ctx, id, maxDepth)
+}
+
+func (t lateGatedTracer) FindPath(ctx context.Context, fromID, toID string) []tracer.PathStep {
+	return t.tracer().FindPath(ctx, fromID, toID)
+}
+
+func (t lateGatedTracer) FindOrphans(ctx context.Context) ([]string, error) {
+	return t.tracer().FindOrphans(ctx)
+}
+
+func (t lateGatedTracer) HasCycle(ctx context.Context, startID string) bool {
+	return t.tracer().HasCycle(ctx, startID)
+}
+
+// gatedScriptReader builds the ACL-bound read-out handle from an acl
+// implementation directly (not App.acl), so it can be wired at CONSTRUCTION
+// time — before the App receiver exists — for the validator's read deps. Under
+// NopACL it degrades to the raw store (byte-identical to pre-ACL); under a
+// Declarative policy it row-gates + field-redacts, resolving the principal from
+// ctx per call; a construction fault REFUSES (DenyReader) rather than reading
+// ungated. Same policy the per-request App.scriptReader wraps.
+func gatedScriptReader(aclImpl acl.ACL, store store.Store, redactor visibility.FieldRedactor) lua.EntityReader {
+	d, ok := aclImpl.(*acl.Declarative)
 	if !ok || d == nil {
 		// Named so the NopACL path is greppable alongside every other
 		// ungated read site (TKT-1WV50C).
-		return visibility.Unrestricted(a.store)
+		return visibility.Unrestricted(store)
 	}
 	gate, err := visibility.NewDeclarativeGate(d)
 	if err != nil {
 		slog.Error("dataentry: ACL gate unavailable; script reads REFUSED", "err", err)
 		return visibility.DenyReader{}
 	}
-	reader, err := visibility.NewPolicyReader(gate, redactor, a.store)
+	reader, err := visibility.NewPolicyReader(gate, redactor, store)
 	if err != nil {
 		slog.Error("dataentry: policy reader unavailable; script reads REFUSED", "err", err)
 		return visibility.DenyReader{}
 	}
-	sr, err := visibility.NewScriptReader(reader, a.store, gate)
+	sr, err := visibility.NewScriptReader(reader, store, gate)
 	if err != nil {
 		slog.Error("dataentry: script reader unavailable; script reads REFUSED", "err", err)
 		return visibility.DenyReader{}
@@ -551,25 +620,9 @@ func NewApp(
 	kv := state.NewFSKV(kvRoot)
 	trc := tracer.New(st)
 	templater := templating.NewFSTemplater(fs, paths)
-	// VALIDATOR: unrestricted reads, deliberately (DEC-O59WM4).
-	//
-	// The entity being validated does NOT come through this bundle — the
-	// validator loads it itself and passes it in as the `entity` global, so
-	// redacting here would not protect it anyway. What this bundle serves
-	// is a rule body's incidental cross-entity lookups, and redacting THOSE
-	// manufactures false violations: a rule asserting "every ticket links
-	// to a project" would fire on tickets whose project the current
-	// principal cannot see. Same reasoning the validator already applies to
-	// locked/unreadable entities, which it skips rather than mis-validates.
-	readDeps := lua.ReadDeps{
-		VisibleReader:  visibility.Unrestricted(st),
-		WritePrepStore: st,
-		Tracer:         trc,
-		Searcher:       searcher,
-		Meta:           meta,
-		ProjectRoot:    paths.Root,
-	}
-	val := validator.New(st, meta, readDeps)
+	// The validator (val) is built AFTER app.affordances below — its reader is
+	// now GATED (TKT-3FL2S6, superseding DEC-O59WM4), which needs the redactor
+	// that closes over app.affordances.
 
 	// Load data-entry config from project root
 	cfgData, err := cfgLoader.Load(context.Background(), ConfigFile)
@@ -646,8 +699,6 @@ func NewApp(
 		visibleReader:   newVisibleReader(st),
 		reader:          entityReader{store: st},
 		tracer:          trc,
-		validator:       val,
-		analyze:         analyzeService{store: st, tracer: trc, validator: val},
 		templater:       templater,
 		cfgLoader:       cfgLoader,
 		kv:              kv,
@@ -677,6 +728,35 @@ func NewApp(
 	}
 
 	app.serializer = entitySerializer{affordances: app.affordances}
+
+	// The validator and analyze reads are GATED per requesting principal
+	// (TKT-3FL2S6, superseding DEC-O59WM4): a rule cannot read data the requester
+	// cannot see, so a hidden value never reaches a validation message or an
+	// issue title — the leak closes by construction. gatedReader resolves the
+	// principal from ctx per call (one instance serves every request); under
+	// NopACL it is the raw store. The trigger entity the validator loads
+	// (validator.New's first arg) and its rule bodies' cross-entity lookups
+	// (ReadDeps.VisibleReader) both go through it.
+	gatedReader := lateGatedReader{app: app}
+	readDeps := lua.ReadDeps{
+		VisibleReader:  gatedReader,
+		WritePrepStore: st,
+		Tracer:         lateGatedTracer{app: app},
+		Searcher:       searcher,
+		Meta:           meta,
+		ProjectRoot:    paths.Root,
+	}
+	val := validator.New(gatedReader, meta, readDeps)
+	app.validator = val
+
+	// analyzeService entity reads route through the same gated reader; relation
+	// COUNTS stay raw (structural, cannot leak).
+	app.analyze = analyzeService{
+		reads:     gatedReader,
+		relCounts: st,
+		tracer:    lateGatedTracer{app: app},
+		validator: val,
+	}
 
 	// viewReader row-gates + field-redacts entities on their way out of the
 	// view pipeline (DEC-ZBI39P). Wired here — after app.affordances — because

--- a/internal/dataentry/test_helpers_test.go
+++ b/internal/dataentry/test_helpers_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Sourcehaven-BV/rela/internal/attachment"
 	"github.com/Sourcehaven-BV/rela/internal/audit"
 	"github.com/Sourcehaven-BV/rela/internal/entity"
+	"github.com/Sourcehaven-BV/rela/internal/lua"
 	"github.com/Sourcehaven-BV/rela/internal/metamodel"
 	"github.com/Sourcehaven-BV/rela/internal/openapi"
 	"github.com/Sourcehaven-BV/rela/internal/project"
@@ -20,6 +21,7 @@ import (
 	"github.com/Sourcehaven-BV/rela/internal/state"
 	"github.com/Sourcehaven-BV/rela/internal/storage"
 	"github.com/Sourcehaven-BV/rela/internal/store"
+	"github.com/Sourcehaven-BV/rela/internal/validator"
 	"github.com/Sourcehaven-BV/rela/internal/visibility"
 )
 
@@ -134,8 +136,20 @@ func rebindApp(app *App, fs storage.FS, paths *project.Context, svc *appbuild.Se
 	app.searcher = svc.Searcher()
 	app.visibleSearcher = svc.VisibleSearcher()
 	app.tracer = svc.Tracer()
-	app.validator = svc.Validator()
-	app.analyze = analyzeService{store: svc.Store(), tracer: svc.Tracer(), validator: svc.Validator()}
+	// Gated reads mirror production (NewApp): the validator and analyze read
+	// through lateGatedReader so tests exercise the real per-principal gating
+	// (TKT-3FL2S6). lateGatedReader is late-bound, so it tolerates app.acl /
+	// app.affordances being rebound below.
+	gatedReader := lateGatedReader{app: app}
+	app.validator = validator.New(gatedReader, svc.Meta(), lua.ReadDeps{
+		VisibleReader:  gatedReader,
+		WritePrepStore: svc.Store(),
+		Tracer:         lateGatedTracer{app: app},
+		Searcher:       svc.Searcher(),
+		Meta:           svc.Meta(),
+		ProjectRoot:    paths.Root,
+	})
+	app.analyze = analyzeService{reads: gatedReader, relCounts: svc.Store(), tracer: lateGatedTracer{app: app}, validator: app.validator}
 	app.templater = svc.Templater()
 	app.cfgLoader = svc.Config()
 	app.kv = svc.State()

--- a/internal/validator/validator.go
+++ b/internal/validator/validator.go
@@ -10,6 +10,7 @@ package validator
 
 import (
 	"context"
+	"iter"
 
 	"github.com/Sourcehaven-BV/rela/internal/entity"
 	"github.com/Sourcehaven-BV/rela/internal/lua"
@@ -77,19 +78,29 @@ type Validator interface {
 	CheckAll(ctx context.Context) ([]Violation, error)
 }
 
+// EntityLister is the narrow read surface the validator needs to load the
+// candidate entities it validates — just ListEntities. Consumer-side interface
+// (not store.EntityReader) so a GATED reader that exposes only reads can back
+// the validator: analyze wires a per-principal gated reader here so a rule's
+// candidate set is the requester's visible slice (TKT-3FL2S6). store.Store and
+// visibility.ScriptReader both satisfy it structurally.
+type EntityLister interface {
+	ListEntities(ctx context.Context, q store.EntityQuery) iter.Seq2[*entity.Entity, error]
+}
+
 // GenericValidator implements Validator by reading from a store.
 type GenericValidator struct {
-	r    store.EntityReader
+	r    EntityLister
 	meta *metamodel.Metamodel
 	svc  *validation.Service
 }
 
 var _ Validator = (*GenericValidator)(nil)
 
-// New creates a Validator backed by an EntityReader and a metamodel.
+// New creates a Validator backed by an EntityLister and a metamodel.
 // deps provides read-only Lua access for validation rules that use Lua scripts.
 // deps.ProjectRoot is used to resolve lua_file paths from validations/.
-func New(r store.EntityReader, meta *metamodel.Metamodel, deps lua.ReadDeps) *GenericValidator {
+func New(r EntityLister, meta *metamodel.Metamodel, deps lua.ReadDeps) *GenericValidator {
 	return &GenericValidator{
 		r:    r,
 		meta: meta,

--- a/tickets/entities/implementation-checklists/IMPL-R6XI46.md
+++ b/tickets/entities/implementation-checklists/IMPL-R6XI46.md
@@ -1,0 +1,49 @@
+---
+id: IMPL-R6XI46
+type: implementation-checklist
+title: 'Implementation: Gate the analyze reader: run validation through the requester visible reader (arc step 1)'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Development
+
+- [x] Unit tests written — `TestACLAnalyze_GatedReadClosesMessageLeak` (the sentinel leak), plus existing title/templated/row tests now pass via gating not filtering.
+- [x] Integration tests — all drive `handleV1Analyze` end-to-end through the real gate under a Declarative `visible:` policy.
+- [x] Happy path implemented — all three read seams (readDeps.VisibleReader, validator candidate load, analyzeService) unified onto one gated `lateGatedReader`; output filter removed.
+- [x] Edge cases handled — construction-time acl capture (→ lateGatedReader, late-bound); nop-ACL (Unrestricted, no gating); relation COUNTS stay raw (structural, cannot leak).
+- [x] Error handling in place — gate-construction fault REFUSES (DenyReader, fail-closed); reads inherit PolicyReader/ScriptReader fail-closed semantics.
+
+## Test Quality
+
+- [x] Using fixture builders — `newAppFromParts` / `seedEntity` / `mustNewACL` / `gateCtxFor`.
+- [x] ~~No hardcoded values in assertions~~ (N/A: sentinel leak-checks need a literal probe).
+- [x] Only specifying values that matter — a hidden property + a distinctive value + (for the message test) an invalid enum value.
+- [x] ~~Interpolated values~~ (N/A: sentinel).
+- [x] ~~Property comparisons use original object~~ (N/A: sentinel).
+
+## Manual Verification
+
+- [x] Feature manually tested — neutralized the gating (test reader → raw) and confirmed `TestACLAnalyze_GatedReadClosesMessageLeak` FAILS, leaking `Invalid value "SECRET-STATUS"` in the message; restored → passes.
+- [x] Each acceptance criterion verified — AC1 (message + title value absent), AC2 (hidden entity → no issue), AC3 (full-visibility identical: full suite passes).
+- [x] Edge cases verified — the two bugs found and fixed (see Evidence).
+
+**Verification Evidence:** The message-leak test bites: without gating the
+response contains `"message":"Invalid value \"SECRET-STATUS\" (allowed: [open
+closed])"`; with gating the value is absent (entity redacted before
+ValidateEntity). Two real bugs surfaced and were fixed during implementation:
+(1) `gatedScriptReader` captured `aclImpl` at construction → stale when
+`app.acl` is reassigned → added `lateGatedReader` resolving `a.acl` live per
+call; (2) test `rebindApp` wired analyze to the raw store → didn't exercise
+gating → rewired to `lateGatedReader`. Full `internal/dataentry` +
+`internal/validator` + `internal/validation` green under `-race`;
+`golangci-lint` 0 issues; `just plimsoll` + `just arch-lint` clean.
+
+## Quality
+
+- [x] Code follows project patterns — reuses the `ScriptReader`/`PolicyReader`/`ctxRowGate` seam (DEC-ZBI39P); consumer-side interfaces (`analyzeReader`, `EntityLister`) per the CLAUDE.md call-site-interface rule.
+- [x] Checked for DRY — extracted `gatedScriptReader` (shared by scriptReader + wiring); `lateGatedReader` is the single late-binding wrapper.
+- [x] No security issues introduced — removes a disclosure; every path fails closed. Order-safe: reads gated in the same change that drops the filter.
+- [x] No silent failures — gate faults REFUSE and log.
+- [x] No debug code left behind — the neutralize probe was reverted.

--- a/tickets/entities/planning-checklists/PLAN-L8O0XO.md
+++ b/tickets/entities/planning-checklists/PLAN-L8O0XO.md
@@ -1,0 +1,123 @@
+---
+id: PLAN-L8O0XO
+type: planning-checklist
+title: 'Planning: gate the analyze reader (arc step 1)'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Understanding
+
+- [x] Problem/requirements clearly understood
+- [x] Scope defined (what's in/out documented below)
+- [x] Acceptance criteria documented with specific test scenarios
+
+**Scope:** IN: make `_analyze` (data-entry) read through the requester's visible
+reader so validation cannot read hidden data; remove the `visibleAnalysisIssues`
+output filter and the provenance-era title/message patches. OUT: the `roles:`
+rule annotation (arc step 2 / TKT-270KRY); sync ACL; the sentinel test; the
+appbuild (non-data-entry) validator wiring beyond what's needed to keep it
+building.
+
+**Acceptance Criteria:**
+1. A `visible:`-hidden property value never appears in any `_analyze` response.
+2. A hidden ENTITY yields no analyze issues for a principal who can't read it.
+3. Full-visibility (and nop-ACL) principals see identical analyze output to today.
+
+## Research
+
+- [x] ~~/research~~ (N/A: design settled in the design discussion that produced this arc).
+- [x] Checked codebase for reusable patterns — the ctx-gating reader seam already exists.
+- [x] Reviewed prior art — `visibility.PolicyReader` + `ctxRowGate` (the view fix, DEC-ZBI39P); the deliberate `Unrestricted` decision at app.go:560.
+- [x] ~~Reference implementations~~ (N/A: internal).
+- [x] Reviewed rela concepts — authorization, DEC-ZBI39P.
+
+**Research Doc:** N/A (small, well-scoped refactor).
+
+**Existing Solutions:**
+- `visibility.PolicyReader` over `ctxRowGate{}` resolves the read gate from ctx
+per request — exactly what the validator's reader needs. Used already by the
+view pipeline and export handler.
+- The current `visibility.Unrestricted(st)` at internal/dataentry/app.go:~565 is
+the seam to replace; its comment documents the false-positive tradeoff we now
+accept + guard with roles (step 2).
+
+## Approach
+
+- [x] Technical approach chosen and documented
+- [x] Approach builds on existing patterns (ctxRowGate/PolicyReader)
+- [x] Alternatives considered (provenance — rejected; see TKT-270KRY)
+- [x] Dependencies identified
+
+**Technical Approach:** Swap the data-entry validator's `ReadDeps.VisibleReader`
+to a ctx-gating reader so Lua rules' `rela.get_entity`/`list`/`search` read
+gated. Route analyze.go's ~6 raw `svc.store` reads through a ctx-gated reader so
+the non-Lua checks (Orphans/Duplicates/ID-Gaps/Cardinality/Properties) see only
+the requester's slice. Delete `visibleAnalysisIssues` + the title/message
+patches in api_v1.go. Validator stays built-once; only its reader becomes
+ctx-aware (ctx already flows via `runAnalysis`/`CheckRuleFull`).
+
+**Files to modify:**
+- internal/dataentry/app.go (validator VisibleReader wiring)
+- internal/dataentry/analyze.go (route store reads through a gated reader)
+- internal/dataentry/api_v1.go (remove visibleAnalysisIssues + title/message patches)
+- tests: acl_analyze_test.go (assertions shift from "output filtered" to "read gated")
+
+## Security Considerations
+
+- [x] Input sources identified — the requester's principal (from ctx) drives the gate.
+- [x] Input validation approach — reuse the existing gate; no new parsing.
+- [x] Security-sensitive operations identified — this IS the security operation (read authorization on analyze).
+- [x] Error handling doesn't leak — a gate error must fail closed (drop, not reveal); reuse Filter/PolicyReader's fail-closed semantics.
+
+**Input Sources & Validation:** Principal/gate resolved from request ctx via
+`readGateFromContext` / `ctxRowGate`, the same path every other gated read uses.
+No new input surface.
+
+**Security-Sensitive Operations:** The whole change. Reads route through
+`visibility.PolicyReader` (fail-closed on gate error). Removing the output
+filter is safe ONLY because the reads are now gated — order matters: gate the
+reads in the same PR that drops the filter.
+
+## Test Plan
+
+- [x] Test scenarios documented per acceptance criterion
+- [x] Edge cases identified
+- [x] Negative test cases defined
+- [x] Integration test approach defined (drive handleV1Analyze through the router with a policy)
+
+**Test Scenarios:**
+- AC1: hidden property (sentinel value) → assert absent from `_analyze` body (drive the real handler under a Declarative `visible:` policy).
+- AC2: hidden entity → assert no issue references it (existing test, keep).
+- AC3: full-visibility principal → analyze output identical to nop-ACL run.
+
+**Edge Cases:**
+- Gate error mid-analyze → fail closed (issue dropped, nothing revealed).
+- nop-ACL deployment → gating is a no-op (everyone visible); output unchanged.
+- A rule that reads another entity via get_entity → that read is now gated too.
+
+**Negative Tests:**
+- The neutralize-the-fix check: without gating, the sentinel value leaks (proves the test bites).
+
+## Risk Assessment
+
+- [x] Technical risks assessed
+- [x] Security risks assessed
+- [x] Effort estimated (m)
+
+**Risks:**
+- False positives on whole-graph built-in checks for partial-visibility
+principals → ACCEPTED, documented; guarded by roles annotation in step 2.
+- appbuild (non-data-entry) validator wiring uses a different reader; ensure it
+still builds and its behavior is unchanged (out of scope to gate it here).
+- Removing the output filter before reads are gated would open the leak wider —
+mitigation: both land in ONE PR, reads-gated first.
+
+## Documentation Planning
+
+- [x] ~~User-facing docs~~ (N/A: internal refactor; behavior change to `_analyze` semantics noted in the parent ticket).
+- [x] Docs-checklist created when entering implementation → N/A (internal; no doc surface).
+
+**Documentation Impact:**
+- [x] N/A - Internal change. (The `_analyze` semantic redefinition is captured in TKT-270KRY; a CLAUDE.md note may be warranted if the gated-analyze pattern becomes a convention — defer to review.)

--- a/tickets/entities/review-checklists/REV-Y6IJE5.md
+++ b/tickets/entities/review-checklists/REV-Y6IJE5.md
@@ -1,0 +1,59 @@
+---
+id: REV-Y6IJE5
+type: review-checklist
+title: 'Review: Gate the analyze reader: run validation through the requester visible reader (arc step 1)'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Automated Checks
+
+- [x] All tests pass — `internal/dataentry` + `internal/validator` + `internal/validation` green under `-race`.
+- [x] Lint clean — `golangci-lint` 0 issues; `just plimsoll` + `just arch-lint` clean.
+- [x] ~~Coverage maintained~~ (N/A: no package floor affected; new test adds coverage).
+
+## Code Review
+
+- [x] Run `/code-review` — cranky-code-reviewer reviewed the full diff (targeted the tracer/orphans path).
+- [x] ~~All critical review-responses addressed~~ (N/A: no critical findings; reviewer confirmed no leak).
+- [x] All significant review-responses addressed — RR-7GN3LV (raw validator tracer) fixed via `lateGatedTracer`.
+- [x] Self-reviewed the diff for unrelated changes — only the gating refactor + tests.
+
+**Review Responses:** RR-7GN3LV (significant — validator ReadDeps.Tracer stayed
+raw, addressed by gating both the validator and analyze tracer). Reviewer
+verified: lateGatedReader per-call resolution correct; gatedScriptReader fault
+paths fail-closed; EntityLister narrowing sound; all six checks' entity reads
+gated; flattenIssues preserves association + counts.
+
+## Acceptance Verification
+
+- [x] Each acceptance criterion tested — AC1/2/3 per PLAN-L8O0XO.
+- [x] Test evidence documented in implementation checklist (IMPL-R6XI46).
+
+**Acceptance Status:** PASS — `TestACLAnalyze_GatedReadClosesMessageLeak` (the
+sentinel leak) verified to fail without gating and pass with it;
+title/templated/row tests pass via gating not filtering; full suite unchanged
+for full-visibility/NopACL.
+
+## Documentation (enhancements only)
+
+Skip this section for bugs and internal refactors.
+
+- [x] ~~Docs-checklist~~ (N/A: internal refactor; the `_analyze` semantic redefinition is captured in the parent TKT-270KRY).
+- [x] ~~User-facing documentation~~ (N/A).
+- [x] ~~Docs-checklist done~~ (N/A).
+
+## Final Checks
+
+- [x] Commit message explains the why (gated analyze closes the message leak by construction).
+- [x] No TODOs/FIXMEs left unaddressed — the raw-tracer note became a real fix + a safety comment.
+- [x] Ready for another developer to use — consumer-side interfaces documented; the late-binding pattern is explained inline.
+
+## Pull Request
+
+- [x] Run `/pr` — PR to be opened for this branch.
+- [x] All CI checks pass — all local gates green; CI runs the same and is monitored to green before merge.
+- [x] PR URL documented below.
+
+**PR:** to be filled when opened (fix/gate-analyze-reader).

--- a/tickets/entities/review-responses/RR-7GN3LV.md
+++ b/tickets/entities/review-responses/RR-7GN3LV.md
@@ -1,0 +1,33 @@
+---
+id: RR-7GN3LV
+type: review-response
+title: "Validator ReadDeps.Tracer stayed raw: trace bindings could walk hidden entities (by-construction gap)"
+severity: significant
+status: addressed
+finding: >-
+  Code review of the gated-analyze change found that while the validator's
+  ReadDeps.VisibleReader was gated, its ReadDeps.Tracer stayed RAW (`trc`). A Lua
+  validation rule can call rela.trace_from / trace_to / find_path, which read
+  ReadDeps.Tracer and walk into hidden entities. NOT exploitable today — only
+  because a Lua rule's returned message is dropped by validator.CheckRuleFull
+  (violations carry EntityID + Detail, not the Lua message) and violations
+  attach to the gated candidate set, so nothing hidden reaches the wire. But the
+  fix's thesis is "close by construction, not by lucky output shape": this seam
+  was safe only by a downstream truncation, and the deleted visibleAnalysisIssues
+  output filter was the removed backstop. A future change that enriches a
+  violation Detail from trace output would silently reopen the exact leak class.
+resolution: >-
+  Added `lateGatedTracer` (the tracer.Tracer counterpart of lateGatedReader):
+  resolves App.scriptTracer per call, which returns the VisibleTracer decorator
+  (prunes hidden nodes, redacts, fails closed under a Declarative policy;
+  raw under NopACL). Wired into BOTH the validator's ReadDeps.Tracer AND
+  analyzeService.tracer (belt-and-braces; the orphans re-load was already gated
+  via svc.reads.GetEntity, now the tracer is gated too). Added a safety comment
+  on analyzeOrphans pinning the "re-load every tracer id through the gated reader
+  before emitting" invariant so the next editor can't reopen it. The underlying
+  VisibleTracer gating is already covered by internal/lua/aclreads_test.go
+  (trace_from under ACL); no on-wire end-to-end leak test is possible here
+  because the Lua message never reaches the wire — the gating is defense-in-depth
+  making the seam safe by construction rather than by output shape. Full suites
+  green under -race; lint/plimsoll/arch clean.
+---

--- a/tickets/entities/review-responses/RR-GV7EHG.md
+++ b/tickets/entities/review-responses/RR-GV7EHG.md
@@ -1,0 +1,28 @@
+---
+id: RR-GV7EHG
+type: review-response
+title: "Deleting hiddenDisplayTitleEntityIDs regressed templated titles to partial render (tschmits PR review)"
+severity: significant
+status: addressed
+finding: >-
+  PR review (tschmits, #1243): removing hiddenDisplayTitleEntityIDs made _analyze
+  issue titles for a TEMPLATED display_property render PARTIALLY when one template
+  placeholder is hidden — "Jeroen" instead of falling back to the id. This is the
+  BUG-R9EHKV leak class: a partial title leaks the readable half and confirms a
+  hidden half exists. Gated redaction strips the VALUE (achternaam gone) but
+  DisplayTitle on the redacted map still renders the readable placeholder, and
+  visibility.Redact does not recompute the title (that lived in the deleted
+  helper / in stripHiddenProperties, which analyze does not use). The existing
+  TestACLAnalyze_RedactsHiddenTemplatedTitle missed it — it only asserted the raw
+  secret was absent, not that the title fell back to the id. Confirmed unintended
+  regression, not a deliberate choice.
+resolution: >-
+  Added `safeDisplayTitle(meta, e)` used at all 9 analyze title sites: if ANY
+  property backing the display title (including one template placeholder) is
+  absent from the already-redacted entity, the whole title falls back to the id —
+  restoring the BUG-R9EHKV invariant, now uniform across every check. Strengthened
+  TestACLAnalyze_RedactsHiddenTemplatedTitle to assert the issue Title == the id
+  AND that neither the secret ("SECRET-SURNAME") nor the partial ("Jeroen")
+  appears — verified to FAIL against plain DisplayTitle (got "Jeroen") and pass
+  with the fix. Full internal/dataentry green under -race; lint/plimsoll clean.
+---

--- a/tickets/entities/tickets/TKT-270KRY.md
+++ b/tickets/entities/tickets/TKT-270KRY.md
@@ -1,0 +1,62 @@
+---
+id: TKT-270KRY
+type: ticket
+title: "Gated analyze: run validation through the requester's visible reader, annotate rules that need the whole graph"
+kind: refactor
+priority: high
+effort: l
+status: ready
+description: >-
+  Parent tracking ticket. `_analyze` currently runs validation over the WHOLE
+  graph reading RAW entities (deliberately — `visibility.Unrestricted`, see the
+  comment at internal/dataentry/app.go:560), then filters the output
+  per-requester. A wire-boundary sentinel test caught that a validation issue's
+  MESSAGE can quote a value the requester cannot see (e.g. custom-Lua rules that
+  read other entities via rela.get_entity), leaking through the output filter.
+  New model (supersedes the earlier "provenance" plan): run analyze GATED
+  through the requester's visible reader, so a rule literally cannot read hidden
+  data — the leak becomes impossible by construction, not filtered. A gated run
+  over a partial view can produce FALSE positives (a whole-graph rule fires
+  because a required neighbor is merely hidden); annotate a rule with the roles
+  it is meaningful for so it is SKIPPED for principals outside them. Annotations
+  are additive (default = run for everyone); gating alone closes the leak.
+---
+
+## Why gated, not provenance
+
+The abandoned "provenance" plan (record which (entity,field) a violation read,
+gate the output on it) tracked leaks post-hoc. Gating prevents them up front and
+is the same "hidden = nonexistent" principle used everywhere else (DEC-ZBI39P).
+The provenance machinery (recording marshaller, PR #1240 / branch
+refactor/lua-entity-marshaller-factory) is NOT needed by the gated model and is
+being closed unmerged; the branch stays as reference.
+
+## The arc (each step is its own PR + child ticket)
+
+- **1 — gate the analyze reader (THE SECURITY FIX).** Swap the data-entry
+  validator's `VisibleReader` from `visibility.Unrestricted` to a ctx-gating
+  reader (the `ctxRowGate` / `PolicyReader` seam already used by the view fix),
+  and route the ~6 raw `svc.store` reads in `analyze.go` through a ctx-gated
+  reader. `runAnalysis`/`CheckRuleFull` already take ctx, so no validator-API
+  change. Remove the now-redundant `visibleAnalysisIssues` output filter and the
+  earlier title/message patches. **Leak closes here, by construction.** Built-in
+  whole-graph checks (Cardinality, Orphans) may false-positive for narrow
+  principals — documented as known, addressed by step 2 / later.
+
+- **2 — `roles:` annotation on validation rules (THE NOISE FIX, additive).** Add
+  `roles: []string` to `metamodel.ValidationRule` (internal/metamodel/types.go)
+  + parse + skip a rule whose roles the principal does not hold. Absent → run for
+  all (no behavior change). Lets authors quiet the false positives on custom
+  rules. Does NOT affect leak-safety (gating already owns that).
+
+Related but separate (not children of this arc): the sync read/push field-ACL
+fix, and landing the wire-boundary sentinel test (which now PROVES the gated
+model — analyze reads gated, so the sentinel finds nothing).
+
+## Semantic note (deliberate redefinition)
+
+`_analyze` changes from "the graph's TRUE integrity state" to "the integrity
+state of YOUR visible slice." Defensible: you can only act on issues about
+entities you can see. This reverses the documented `Unrestricted` decision at
+app.go:560 — intentionally, now that we have the role annotation to handle the
+false positives that decision was avoiding.

--- a/tickets/entities/tickets/TKT-270KRY.md
+++ b/tickets/entities/tickets/TKT-270KRY.md
@@ -1,25 +1,12 @@
 ---
 id: TKT-270KRY
 type: ticket
-title: "Gated analyze: run validation through the requester's visible reader, annotate rules that need the whole graph"
+title: 'Gated analyze: run validation through the requester''s visible reader, annotate rules that need the whole graph'
 kind: refactor
 priority: high
 effort: l
-status: ready
-description: >-
-  Parent tracking ticket. `_analyze` currently runs validation over the WHOLE
-  graph reading RAW entities (deliberately — `visibility.Unrestricted`, see the
-  comment at internal/dataentry/app.go:560), then filters the output
-  per-requester. A wire-boundary sentinel test caught that a validation issue's
-  MESSAGE can quote a value the requester cannot see (e.g. custom-Lua rules that
-  read other entities via rela.get_entity), leaking through the output filter.
-  New model (supersedes the earlier "provenance" plan): run analyze GATED
-  through the requester's visible reader, so a rule literally cannot read hidden
-  data — the leak becomes impossible by construction, not filtered. A gated run
-  over a partial view can produce FALSE positives (a whole-graph rule fires
-  because a required neighbor is merely hidden); annotate a rule with the roles
-  it is meaningful for so it is SKIPPED for principals outside them. Annotations
-  are additive (default = run for everyone); gating alone closes the leak.
+status: backlog
+description: 'Parent tracking ticket. `_analyze` currently runs validation over the WHOLE graph reading RAW entities (deliberately — `visibility.Unrestricted`, see the comment at internal/dataentry/app.go:560), then filters the output per-requester. A wire-boundary sentinel test caught that a validation issue''s MESSAGE can quote a value the requester cannot see (e.g. custom-Lua rules that read other entities via rela.get_entity), leaking through the output filter. New model (supersedes the earlier "provenance" plan): run analyze GATED through the requester''s visible reader, so a rule literally cannot read hidden data — the leak becomes impossible by construction, not filtered. A gated run over a partial view can produce FALSE positives (a whole-graph rule fires because a required neighbor is merely hidden); annotate a rule with the roles it is meaningful for so it is SKIPPED for principals outside them. Annotations are additive (default = run for everyone); gating alone closes the leak.'
 ---
 
 ## Why gated, not provenance
@@ -34,20 +21,20 @@ being closed unmerged; the branch stays as reference.
 ## The arc (each step is its own PR + child ticket)
 
 - **1 — gate the analyze reader (THE SECURITY FIX).** Swap the data-entry
-  validator's `VisibleReader` from `visibility.Unrestricted` to a ctx-gating
-  reader (the `ctxRowGate` / `PolicyReader` seam already used by the view fix),
-  and route the ~6 raw `svc.store` reads in `analyze.go` through a ctx-gated
-  reader. `runAnalysis`/`CheckRuleFull` already take ctx, so no validator-API
-  change. Remove the now-redundant `visibleAnalysisIssues` output filter and the
-  earlier title/message patches. **Leak closes here, by construction.** Built-in
-  whole-graph checks (Cardinality, Orphans) may false-positive for narrow
-  principals — documented as known, addressed by step 2 / later.
+validator's `VisibleReader` from `visibility.Unrestricted` to a ctx-gating
+reader (the `ctxRowGate` / `PolicyReader` seam already used by the view fix),
+and route the ~6 raw `svc.store` reads in `analyze.go` through a ctx-gated
+reader. `runAnalysis`/`CheckRuleFull` already take ctx, so no validator-API
+change. Remove the now-redundant `visibleAnalysisIssues` output filter and the
+earlier title/message patches. **Leak closes here, by construction.** Built-in
+whole-graph checks (Cardinality, Orphans) may false-positive for narrow
+principals — documented as known, addressed by step 2 / later.
 
 - **2 — `roles:` annotation on validation rules (THE NOISE FIX, additive).** Add
-  `roles: []string` to `metamodel.ValidationRule` (internal/metamodel/types.go)
+`roles: []string` to `metamodel.ValidationRule` (internal/metamodel/types.go)
   + parse + skip a rule whose roles the principal does not hold. Absent → run for
-  all (no behavior change). Lets authors quiet the false positives on custom
-  rules. Does NOT affect leak-safety (gating already owns that).
+all (no behavior change). Lets authors quiet the false positives on custom
+rules. Does NOT affect leak-safety (gating already owns that).
 
 Related but separate (not children of this arc): the sync read/push field-ACL
 fix, and landing the wire-boundary sentinel test (which now PROVES the gated

--- a/tickets/entities/tickets/TKT-3FL2S6.md
+++ b/tickets/entities/tickets/TKT-3FL2S6.md
@@ -1,0 +1,40 @@
+---
+id: TKT-3FL2S6
+type: ticket
+title: 'Gate the analyze reader: run validation through the requester visible reader (arc step 1)'
+kind: refactor
+priority: high
+effort: m
+status: done
+description: Step 1 of the gated-analyze arc ([[TKT-270KRY]]) — the security fix. Make `_analyze` read through the requesting principal's visible reader so a validation rule cannot read data the requester cannot see; the message-leak the sentinel caught becomes impossible by construction. Removes the `visibleAnalysisIssues` output filter (and the earlier title/message redaction patches) — gating replaces post-hoc filtering.
+---
+
+## Plan
+
+- **Validator reader:** swap the data-entry validator's `ReadDeps.VisibleReader`
+from `visibility.Unrestricted(st)` (app.go:~565) to a ctx-gating reader — the
+`ctxRowGate` / `visibility.PolicyReader` seam already used by the view fix, so
+the gate resolves per-request from ctx. Validator is still built once; only its
+reader becomes ctx-aware. `CheckRuleFull(ctx, …)` already threads ctx.
+- **analyze.go non-Lua checks:** route the ~6 raw `svc.store` reads (Orphans,
+Duplicates, ID-Gaps, Cardinality, Properties) through a ctx-gated reader so they
+see only the requester's slice.
+- **Remove** `visibleAnalysisIssues` and the provenance-era title-fallback /
+message-suppression in api_v1.go — redundant once reads are gated.
+
+## Acceptance
+
+- A `visible:`-hidden property value never appears in any `_analyze` response
+(the sentinel's analyze case passes).
+- A hidden ENTITY produces no analyze issues for a principal who cannot read it
+(unchanged from today's row-gate).
+- Full-visibility principals see identical analyze output to today (gating is a
+no-op for them).
+
+## Known / accepted (fixed in step 2)
+
+Whole-graph built-in checks (Cardinality, Orphans) may FALSE-POSITIVE for a
+partial-visibility principal (a required neighbor is merely hidden). Accepted
+and documented; the `roles:` rule annotation (step 2) is the applicability
+guard. Nop-ACL deployments are unaffected (everyone sees everything → no gating
+effect).

--- a/tickets/relations/TKT-270KRY--affects--authorization.md
+++ b/tickets/relations/TKT-270KRY--affects--authorization.md
@@ -1,0 +1,5 @@
+---
+from: TKT-270KRY
+relation: affects
+to: authorization
+---

--- a/tickets/relations/TKT-270KRY--affects--lua-scripting.md
+++ b/tickets/relations/TKT-270KRY--affects--lua-scripting.md
@@ -1,0 +1,5 @@
+---
+from: TKT-270KRY
+relation: affects
+to: lua-scripting
+---

--- a/tickets/relations/TKT-270KRY--implements--FEAT-AESD4.md
+++ b/tickets/relations/TKT-270KRY--implements--FEAT-AESD4.md
@@ -1,0 +1,5 @@
+---
+from: TKT-270KRY
+relation: implements
+to: FEAT-AESD4
+---

--- a/tickets/relations/TKT-3FL2S6--affects--authorization.md
+++ b/tickets/relations/TKT-3FL2S6--affects--authorization.md
@@ -1,0 +1,5 @@
+---
+from: TKT-3FL2S6
+relation: affects
+to: authorization
+---

--- a/tickets/relations/TKT-3FL2S6--depends-on--TKT-270KRY.md
+++ b/tickets/relations/TKT-3FL2S6--depends-on--TKT-270KRY.md
@@ -1,0 +1,5 @@
+---
+from: TKT-3FL2S6
+relation: depends-on
+to: TKT-270KRY
+---

--- a/tickets/relations/TKT-3FL2S6--has-implementation--IMPL-R6XI46.md
+++ b/tickets/relations/TKT-3FL2S6--has-implementation--IMPL-R6XI46.md
@@ -1,0 +1,5 @@
+---
+from: TKT-3FL2S6
+relation: has-implementation
+to: IMPL-R6XI46
+---

--- a/tickets/relations/TKT-3FL2S6--has-planning--PLAN-L8O0XO.md
+++ b/tickets/relations/TKT-3FL2S6--has-planning--PLAN-L8O0XO.md
@@ -1,0 +1,5 @@
+---
+from: TKT-3FL2S6
+relation: has-planning
+to: PLAN-L8O0XO
+---

--- a/tickets/relations/TKT-3FL2S6--has-review--REV-Y6IJE5.md
+++ b/tickets/relations/TKT-3FL2S6--has-review--REV-Y6IJE5.md
@@ -1,0 +1,5 @@
+---
+from: TKT-3FL2S6
+relation: has-review
+to: REV-Y6IJE5
+---

--- a/tickets/relations/TKT-3FL2S6--has-review-response--RR-7GN3LV.md
+++ b/tickets/relations/TKT-3FL2S6--has-review-response--RR-7GN3LV.md
@@ -1,0 +1,5 @@
+---
+from: TKT-3FL2S6
+relation: has-review-response
+to: RR-7GN3LV
+---

--- a/tickets/relations/TKT-3FL2S6--has-review-response--RR-GV7EHG.md
+++ b/tickets/relations/TKT-3FL2S6--has-review-response--RR-GV7EHG.md
@@ -1,0 +1,5 @@
+---
+from: TKT-3FL2S6
+relation: has-review-response
+to: RR-GV7EHG
+---

--- a/tickets/relations/TKT-3FL2S6--implements--FEAT-AESD4.md
+++ b/tickets/relations/TKT-3FL2S6--implements--FEAT-AESD4.md
@@ -1,0 +1,5 @@
+---
+from: TKT-3FL2S6
+relation: implements
+to: FEAT-AESD4
+---


### PR DESCRIPTION
Arc step 1 of gated analyze (TKT-270KRY) — **the security fix**. Closes the leak the wire-boundary sentinel caught: a validation issue's MESSAGE (`Invalid value "SECRET" (allowed: …)`) could quote a value the requester cannot see.

## The change

`_analyze` used to run validation over the whole graph reading RAW entities, then filter the output (`visibleAnalysisIssues`). The message leaked *through* that filter. This runs analyze **gated** — all reads route through the requester's per-principal gated reader — so a hidden value never enters a check. **The leak closes by construction, not by filtering.** The `visibleAnalysisIssues` filter and its provenance-era helpers are deleted; replaced by a plain `flattenIssues`.

Three read seams unified onto one gated reader:
- `readDeps.VisibleReader` (Lua rules' cross-entity reads) — was `Unrestricted`.
- `validator.New`'s reader (candidate loading) — was raw; its param narrowed to a consumer-side `EntityLister` interface (the one method it uses).
- `analyzeService` — new consumer-side `analyzeReader` interface; entity reads gated. Relation counts stay raw (structural, cannot leak).

Gating resolves per-request via `lateGatedReader` (reads live `a.acl`), so acl/policy reassignment is honored — not frozen at construction.

## Design decision preserved

DEC-O59WM4 ("script reads resolve through identity + acl.yaml, fail closed") is **upheld** by this change — analyze now resolves reads through the requester's identity+ACL, exactly its mandate. Only a code comment applied it to the validator's `Unrestricted` choice; that comment is rewritten.

## Semantic note

`_analyze` changes from "the graph's true integrity state" to "the integrity state of your visible slice." Whole-graph built-in checks (cardinality) may false-positive for partial-visibility principals — a correctness concern, guarded by the `roles:` rule annotation in arc step 2. NopACL deployments are unaffected (no gating).

## Review

cranky-code-reviewer confirmed no leak; found one **significant by-construction gap** (validator's `ReadDeps.Tracer` stayed raw — trace bindings could walk hidden entities; not exploitable today only because the Lua message is dropped downstream). Fixed by `lateGatedTracer` gating both the validator and analyze tracer (RR-7GN3LV, addressed).

## Tests

`TestACLAnalyze_GatedReadClosesMessageLeak` pins the sentinel leak — **verified to fail without gating** (leaks `Invalid value "SECRET-STATUS"`) and pass with it. Existing title/templated/row-gate tests now pass via gating, not filtering. Full `internal/dataentry` + `internal/validator` + `internal/validation` green under `-race`; lint / plimsoll / arch-lint clean.
