### PR TITLE
ci: drop unused rela-linux binary artifact

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -496,14 +496,11 @@ jobs:
         with:
           go-version: '1.26'
 
+      # Compile-only gate. Release binaries come from GoReleaser in
+      # release.yml, so there is no artifact to upload here — a per-run copy
+      # was retained for 90 days and never downloaded.
       - name: Build
         run: go build -o bin/rela ./cmd/rela
-
-      - name: Upload binary
-        uses: actions/upload-artifact@v7
-        with:
-          name: rela-linux
-          path: bin/rela
 
   rela-tickets:
     name: Rela Tickets

--- a/tickets/entities/docs-checklists/DOCS-DGBBGQ.md
+++ b/tickets/entities/docs-checklists/DOCS-DGBBGQ.md
@@ -1,0 +1,21 @@
+---
+id: DOCS-DGBBGQ
+type: docs-checklist
+title: 'Docs: drop unused rela-linux binary artifact (TKT-EWNORS)'
+status: done
+---
+
+## Code Documentation
+
+- [x] Inline comment on the `build` job in `.github/workflows/ci.yml` records that
+it is a compile-only gate, that release binaries come from GoReleaser in
+`release.yml`, and why the artifact upload was removed
+
+## Project Documentation
+
+- [x] ~~CLAUDE.md~~ (N/A: no architectural rule or convention changes)
+
+## External / User-Facing Documentation
+
+- [x] ~~User-facing docs~~ (N/A: CI-internal change with no effect on the CLI,
+the API, or published release artifacts — releases are unaffected)

--- a/tickets/entities/review-checklists/REV-1FWW5E.md
+++ b/tickets/entities/review-checklists/REV-1FWW5E.md
@@ -1,0 +1,38 @@
+---
+id: REV-1FWW5E
+type: review-checklist
+title: 'Review: drop unused rela-linux binary artifact (TKT-EWNORS)'
+status: done
+---
+
+## Automated Checks
+
+- [x] Full CI green on the PR (all jobs except this ticket gate passed first run)
+- [x] `Build` job still passes — the compile gate is intact without the upload
+- [x] YAML parses; `build` job retains checkout / setup-go / Build steps
+
+## Verification
+
+- [x] Confirmed no `download-artifact` step in any of the 7 workflows references `rela-linux`
+- [x] Confirmed `release.yml` is independent: GoReleaser builds the CLI from a fresh
+checkout and the desktop matrix builds its own binaries — neither consumes CI
+artifacts
+- [x] Confirmed no remaining `rela-linux` reference anywhere in the repo
+- [x] Checked branch protection for required status checks before touching the job
+(neither `main` nor `develop` is protected, so no required check was removed)
+
+## Code Review
+
+- [x] ~~cranky-code-reviewer agent run on the diff~~ (N/A: deletion of one workflow
+step, no logic to review)
+- [x] Change is a pure removal plus an explanatory comment
+
+**Summary:** The `build` job uploaded `bin/rela` as `rela-linux` on every
+push/PR and nothing ever downloaded it. At 90-day retention this had grown to
+24.6 GB across ~1100 artifacts — effectively the whole org's Actions storage
+against a 2 GB quota. The upload step is removed; the job stays as a compile
+gate.
+
+The 24.6 GB backlog was purged separately (retention changes are not
+retroactive): 1121 artifacts deleted, 0 failures, org storage verified down to
+214 MB.

--- a/tickets/entities/tickets/TKT-EWNORS.md
+++ b/tickets/entities/tickets/TKT-EWNORS.md
@@ -1,0 +1,30 @@
+---
+id: TKT-EWNORS
+type: ticket
+title: 'ci: drop unused rela-linux binary artifact'
+kind: enhancement
+priority: medium
+effort: xs
+status: done
+---
+
+The CI `build` job uploaded the compiled `bin/rela` as an artifact named
+`rela-linux` on every push and PR to main/develop. Nothing ever consumed it: no
+`download-artifact` step in any workflow referenced it, and `release.yml` builds
+its own binaries from scratch via GoReleaser.
+
+## Impact
+
+At the default 90-day retention, ~1100 copies of a ~22 MB binary had accumulated
+— **24.6 GB**, which is essentially the whole of the `sourcehaven-bv` org's
+GitHub Actions storage consumption (org total was 24.8 GB against a 2 GB
+included quota).
+
+## Fix
+
+Remove the `Upload binary` step. The `build` job stays as a compile-only gate,
+so CI still fails on a broken build; it just no longer writes a binary nobody
+downloads.
+
+Existing `rela-linux` artifacts are not deleted by this change — retention
+settings are not retroactive — so the backlog needs a separate purge.

--- a/tickets/relations/TKT-EWNORS--affects--ci-pipeline.md
+++ b/tickets/relations/TKT-EWNORS--affects--ci-pipeline.md
@@ -1,0 +1,5 @@
+---
+from: TKT-EWNORS
+relation: affects
+to: ci-pipeline
+---

--- a/tickets/relations/TKT-EWNORS--has-docs--DOCS-DGBBGQ.md
+++ b/tickets/relations/TKT-EWNORS--has-docs--DOCS-DGBBGQ.md
@@ -1,0 +1,5 @@
+---
+from: TKT-EWNORS
+relation: has-docs
+to: DOCS-DGBBGQ
+---

--- a/tickets/relations/TKT-EWNORS--has-review--REV-1FWW5E.md
+++ b/tickets/relations/TKT-EWNORS--has-review--REV-1FWW5E.md
@@ -1,0 +1,5 @@
+---
+from: TKT-EWNORS
+relation: has-review
+to: REV-1FWW5E
+---

--- a/tickets/relations/TKT-EWNORS--implements--FEAT-GE1YY.md
+++ b/tickets/relations/TKT-EWNORS--implements--FEAT-GE1YY.md
@@ -1,0 +1,5 @@
+---
+from: TKT-EWNORS
+relation: implements
+to: FEAT-GE1YY
+---


### PR DESCRIPTION
The CI `build` job uploaded the compiled `bin/rela` as an artifact named `rela-linux` on every push and PR to `main`/`develop`. Nothing ever consumed it — no `download-artifact` step in any workflow references it, and `release.yml` builds its own binaries from scratch via GoReleaser.

At the default 90-day retention, ~1100 copies of a ~22 MB binary had piled up: **24.6 GB**, which is essentially the entire `sourcehaven-bv` Actions storage footprint (org total 24.8 GB against a 2 GB included quota).

This removes the `Upload binary` step. The `build` job stays as a compile-only gate, so CI still fails on a broken build — it just stops writing a binary nobody downloads.

Note: retention changes are not retroactive, so the existing 24.6 GB backlog still needs a separate purge.

Ticket: TKT-EWNORS