### PR TITLE
feat(dataentry): shareable history diff URLs via ?base/?target (TKT-YOHC3N)

### DIFF
--- a/docs-project/entities/guides/GUIDE-postgres-backend.md
+++ b/docs-project/entities/guides/GUIDE-postgres-backend.md
@@ -189,6 +189,25 @@ rela restore TKT-42 3              # restore the entity to version 3
 The data-entry web UI shows the same timeline, an in-page diff, and a restore
 button (gated by your write permission) on each entity's detail page.
 
+**Sharing a diff.** The two compared versions live in the URL as `?base=` and
+`?target=`, so a specific diff can be linked, bookmarked, or reopened after a
+reload:
+
+```text
+/history/feature/FEAT-42?base=3&target=7          # v3 → v7
+/history/feature/FEAT-42?base=3&target=current    # what changed since v3
+```
+
+Either side takes a version ordinal or `current`. Note that `current` is
+**live-relative**: a link with `target=current` shows the diff against the
+entity as it stands when the recipient opens it, not as it stood when the link
+was made. Link two ordinals for a diff that is frozen. Omit the params for the
+default view, and a value that names no existing version (a stale link, a typo)
+falls back to that default rather than erroring — the address bar is rewritten
+to the pair actually being shown, so a corrected link is what you copy. A
+shared link is not a capability — the recipient still needs their own read
+permission on the entity, and sees the same 404 they would without the link.
+
 Access control: reading the history of a **live** entity requires the same read
 permission as reading the entity itself. Reading the history of a **deleted**
 entity requires the global `history:read` permission — see
@@ -232,6 +251,15 @@ global `history:read`). In the web UI, a relation's history is owned by its
 **source** (`from`) entity: each outgoing relation on an entity's detail page has
 a History affordance. Restore goes through the normal write path; re-creating a
 relation whose endpoint entity no longer exists is refused (409).
+
+Relation diffs are shareable the same way, with `?base=`/`?target=` on the
+relation-history URL — though here `current` resolves to the newest captured
+version (labelled *latest*), since a relation has no separate live-read
+endpoint:
+
+```text
+/relation-history/ticket/TKT-42/blocks/TKT-99?base=1&target=3
+```
 
 ### Purging history for compliance
 

--- a/docs/postgres-backend.md
+++ b/docs/postgres-backend.md
@@ -199,9 +199,8 @@ was made. Link two ordinals for a diff that is frozen. Omit the params for the
 default view, and a value that names no existing version (a stale link, a typo)
 falls back to that default rather than erroring — the address bar is rewritten
 to the pair actually being shown, so a corrected link is what you copy. A
-shared link is not a
-capability — the recipient still needs their own read permission on the entity,
-and sees the same 404 they would without the link.
+shared link is not a capability — the recipient still needs their own read
+permission on the entity, and sees the same 404 they would without the link.
 
 Access control: reading the history of a **live** entity requires the same read
 permission as reading the entity itself. Reading the history of a **deleted**

--- a/docs/postgres-backend.md
+++ b/docs/postgres-backend.md
@@ -183,6 +183,26 @@ rela restore TKT-42 3              # restore the entity to version 3
 The data-entry web UI shows the same timeline, an in-page diff, and a restore
 button (gated by your write permission) on each entity's detail page.
 
+**Sharing a diff.** The two compared versions live in the URL as `?base=` and
+`?target=`, so a specific diff can be linked, bookmarked, or reopened after a
+reload:
+
+```text
+/history/feature/FEAT-42?base=3&target=7          # v3 → v7
+/history/feature/FEAT-42?base=3&target=current    # what changed since v3
+```
+
+Either side takes a version ordinal or `current`. Note that `current` is
+**live-relative**: a link with `target=current` shows the diff against the
+entity as it stands when the recipient opens it, not as it stood when the link
+was made. Link two ordinals for a diff that is frozen. Omit the params for the
+default view, and a value that names no existing version (a stale link, a typo)
+falls back to that default rather than erroring — the address bar is rewritten
+to the pair actually being shown, so a corrected link is what you copy. A
+shared link is not a
+capability — the recipient still needs their own read permission on the entity,
+and sees the same 404 they would without the link.
+
 Access control: reading the history of a **live** entity requires the same read
 permission as reading the entity itself. Reading the history of a **deleted**
 entity requires the global `history:read` permission — see
@@ -226,6 +246,15 @@ global `history:read`). In the web UI, a relation's history is owned by its
 **source** (`from`) entity: each outgoing relation on an entity's detail page has
 a History affordance. Restore goes through the normal write path; re-creating a
 relation whose endpoint entity no longer exists is refused (409).
+
+Relation diffs are shareable the same way, with `?base=`/`?target=` on the
+relation-history URL — though here `current` resolves to the newest captured
+version (labelled *latest*), since a relation has no separate live-read
+endpoint:
+
+```text
+/relation-history/ticket/TKT-42/blocks/TKT-99?base=1&target=3
+```
 
 ### Purging history for compliance
 

--- a/e2e/pages/history.page.ts
+++ b/e2e/pages/history.page.ts
@@ -1,0 +1,159 @@
+import { type Locator, expect } from "@playwright/test";
+import { BasePage } from "./base.page";
+
+/** A comparison side as it appears in the URL and in the dropdowns: a version
+ *  ordinal, or the `current` sentinel (the live entity). */
+export type Side = number | "current";
+
+function sideValue(s: Side): string {
+  return String(s);
+}
+
+/** Page object for the entity history view (`/history/:type/:id`,
+ *  HistoryView.vue). Selectors mirror the component's stable class names —
+ *  `.timeline`, `.compare-select`, `.compare-caption`, `.prop-diff` — which are
+ *  shared with RelationHistoryView, so the two page objects deliberately look
+ *  alike. The compared pair is mirrored into `?base=`/`?target=` (TKT-YOHC3N),
+ *  which is what makes a diff linkable. */
+export class HistoryPage extends BasePage {
+  /** Open the history view for an entity, optionally deep-linking a pair. */
+  async open(type: string, id: string, selection?: { base?: Side; target?: Side }) {
+    const params = new URLSearchParams();
+    if (selection?.base !== undefined) params.set("base", sideValue(selection.base));
+    if (selection?.target !== undefined) params.set("target", sideValue(selection.target));
+    const qs = params.toString();
+    await this.navigateTo(`/history/${type}/${id}${qs ? `?${qs}` : ""}`);
+    await expect(this.page.locator(".history-view")).toBeVisible();
+  }
+
+  timelineItems(): Locator {
+    return this.page.locator(".timeline .timeline-item");
+  }
+
+  async timelineCount(): Promise<number> {
+    return this.timelineItems().count();
+  }
+
+  /** Wait until the timeline has at least `n` rows (create/update capture is
+   *  asynchronous — the reconciliation sweep). Named `AtLeast` to match the
+   *  relation page object, where a same-named exact-count waiter also exists. */
+  async waitForTimelineAtLeast(n: number) {
+    await expect
+      .poll(async () => this.timelineCount(), { timeout: 20_000 })
+      .toBeGreaterThanOrEqual(n);
+  }
+
+  /** Click a timeline row, which sets the BASE (before) side. */
+  async selectVersion(version: number) {
+    await this.page
+      .locator(`.timeline-item[data-version="${version}"] .timeline-select`)
+      .click();
+  }
+
+  baseSelect(): Locator {
+    return this.page.locator(".compare-select").nth(0);
+  }
+
+  targetSelect(): Locator {
+    return this.page.locator(".compare-select").nth(1);
+  }
+
+  /** Choose the two compared versions via the dropdowns. */
+  async compare(base: Side, target: Side) {
+    await this.baseSelect().selectOption(sideValue(base));
+    await this.targetSelect().selectOption(sideValue(target));
+  }
+
+  /** The pair the dropdowns currently show. Reading the SELECT values (rather
+   *  than the URL) is what catches a v-model type mismatch: a numeric side
+   *  parsed as a string matches no <option> and leaves the control blank. */
+  async selectedPair(): Promise<{ base: string; target: string }> {
+    return {
+      base: await this.baseSelect().inputValue(),
+      target: await this.targetSelect().inputValue(),
+    };
+  }
+
+  /** The `base → target` caption under the compare bar. */
+  caption(): Locator {
+    return this.page.locator(".compare-caption");
+  }
+
+  /** The view's root, visible once the route has rendered. */
+  root(): Locator {
+    return this.page.locator(".history-view");
+  }
+
+  /** Assert the view rendered (used after a raw navigation or a reload). */
+  async expectLoaded() {
+    await expect(this.root()).toBeVisible();
+  }
+
+  /** The timeline row for a version — `.selected` marks the base side. */
+  timelineItem(version: number): Locator {
+    return this.page.locator(`.timeline-item[data-version="${version}"]`);
+  }
+
+  /** Assert the timeline highlights `version` as the base side. */
+  async expectSelectedVersion(version: number) {
+    await expect(this.timelineItem(version)).toHaveClass(/selected/);
+  }
+
+  /** Assert no error state is rendered (malformed params must degrade
+   *  silently to defaults rather than surface an error). */
+  async expectNoError() {
+    await expect(this.page.locator(".error-state")).toHaveCount(0);
+  }
+
+  /** Reload the page and wait for the view to come back. */
+  async reload() {
+    await this.page.reload();
+    await this.expectLoaded();
+  }
+
+  /** Read one arbitrary query param off the current URL — used to assert that
+   *  a selection write MERGED into the query rather than clobbering it. */
+  queryParam(name: string): string | null {
+    return new URL(this.page.url()).searchParams.get(name);
+  }
+
+  async swapSides() {
+    await this.page.locator(".compare-swap").click();
+  }
+
+  /** The `?base=`/`?target=` params currently in the address bar. */
+  urlSelection(): { base: string | null; target: string | null } {
+    const params = new URL(this.page.url()).searchParams;
+    return { base: params.get("base"), target: params.get("target") };
+  }
+
+  /** Wait until the URL reflects a specific pair (the write is a
+   *  router.replace, so it lands a tick after the interaction). */
+  async expectUrlSelection(base: Side, target: Side) {
+    await expect
+      .poll(() => this.urlSelection())
+      .toEqual({ base: sideValue(base), target: sideValue(target) });
+  }
+
+  propDiffRows(): Locator {
+    return this.page.locator(".prop-diff .prop-row");
+  }
+
+  async propDiffLabels(): Promise<string[]> {
+    return this.page.locator(".prop-diff .prop-row .prop-label").allTextContents();
+  }
+
+  async restoreVersion(version: number) {
+    await this.page
+      .locator(`.timeline-item[data-version="${version}"]`)
+      .locator("button", { hasText: "Restore" })
+      .click();
+  }
+
+  /** The "version history is not available for this deployment" state (fsstore). */
+  async expectUnsupported() {
+    await expect(
+      this.page.locator(".loading-state", { hasText: /not available/i }),
+    ).toBeVisible();
+  }
+}

--- a/e2e/pages/index.ts
+++ b/e2e/pages/index.ts
@@ -13,3 +13,5 @@ export { RelationCardsPage } from './relation-cards.page';
 export { AppShellPage } from './app-shell.page';
 export { AppHostPage } from './app-host.page';
 export { DocumentPage } from './document.page';
+export { HistoryPage } from './history.page';
+export { RelationHistoryPage } from './relation-history.page';

--- a/e2e/pages/relation-history.page.ts
+++ b/e2e/pages/relation-history.page.ts
@@ -63,11 +63,51 @@ export class RelationHistoryPage extends BasePage {
   }
 
   /** Choose the two compared versions in the diff pane and read back the
-   *  rendered property changes. */
-  async compare(baseVersion: number, targetVersion: number) {
+   *  rendered property changes. Accepts the `latest` sentinel, which is
+   *  spelled `current` in the option value and the URL. */
+  async compare(baseVersion: number | "current", targetVersion: number | "current") {
     const selects = this.page.locator(".compare-select");
     await selects.nth(0).selectOption(String(baseVersion));
     await selects.nth(1).selectOption(String(targetVersion));
+  }
+
+  /** The pair the dropdowns currently show. Reading the SELECT values (rather
+   *  than the URL) is what catches a v-model type mismatch: a numeric side
+   *  parsed as a string matches no <option> and leaves the control blank. */
+  async selectedPair(): Promise<{ base: string; target: string }> {
+    const selects = this.page.locator(".compare-select");
+    return {
+      base: await selects.nth(0).inputValue(),
+      target: await selects.nth(1).inputValue(),
+    };
+  }
+
+  /** The `?base=`/`?target=` params currently in the address bar (TKT-YOHC3N —
+   *  the compared pair is mirrored into the URL so a diff is linkable). */
+  urlSelection(): { base: string | null; target: string | null } {
+    const params = new URL(this.page.url()).searchParams;
+    return { base: params.get("base"), target: params.get("target") };
+  }
+
+  /** Wait until the URL reflects a specific pair (the write is a
+   *  router.replace, so it lands a tick after the interaction). */
+  async expectUrlSelection(base: number | "current", target: number | "current") {
+    await expect
+      .poll(() => this.urlSelection())
+      .toEqual({ base: String(base), target: String(target) });
+  }
+
+  /** Assert the view rendered (used after a raw navigation). */
+  async expectLoaded() {
+    await expect(this.page.locator(".history-view")).toBeVisible();
+  }
+
+  /** Wait until the timeline has at least `n` rows, polling because
+   *  create/update capture is asynchronous (the reconciliation sweep). */
+  async waitForTimelineAtLeast(n: number) {
+    await expect
+      .poll(async () => this.timelineCount(), { timeout: 20_000 })
+      .toBeGreaterThanOrEqual(n);
   }
 
   propDiffRows(): Locator {

--- a/e2e/tests/fixtures.ts
+++ b/e2e/tests/fixtures.ts
@@ -215,6 +215,16 @@ export interface ApiHelpers {
     count: number,
     options?: { timeout?: number },
   ): Promise<void>;
+  /** Poll the entity-history timeline until it has at least `count` versions.
+   *  The entity counterpart of waitForRelationVersions — same async-sweep
+   *  caveat, same pgstore-only restriction. `type` is the singular entity type
+   *  the _history path expects (e.g. "feature", not "features"). */
+  waitForEntityVersions(
+    type: string,
+    id: string,
+    count: number,
+    options?: { timeout?: number },
+  ): Promise<void>;
   /** Returns the current set of outgoing relation edges of the given type for an entity.
    *  Each edge exposes `id` (target entity) and `meta` (relation-property values). */
   listRelations(
@@ -554,6 +564,33 @@ export const test = base.extend<TestFixtures, WorkerFixtures>({
   api: async ({ serverUrl, appPage }, use) => {
     const request: APIRequestContext = appPage.request;
 
+    /** Poll a `_history` / `_relation_history` listing until it reports at
+     *  least `count` versions. Shared by the entity and relation waiters —
+     *  both face the same async reconciliation sweep, so a seed-then-assert
+     *  flow has to wait for capture rather than read straight after writing.
+     *  `subject` only labels the timeout error. */
+    async function pollForVersions(
+      get: typeof call,
+      apiPath: string,
+      count: number,
+      subject: string,
+      options?: { timeout?: number },
+    ): Promise<void> {
+      const timeout = options?.timeout ?? 20000;
+      const start = Date.now();
+      while (Date.now() - start < timeout) {
+        const resp = await get("GET", apiPath).catch(() => null);
+        if (resp && resp.ok()) {
+          const body = (await resp.json()) as { versions?: unknown[] };
+          if ((body.versions?.length ?? 0) >= count) return;
+        }
+        await new Promise((r) => setTimeout(r, 200));
+      }
+      throw new Error(
+        `${subject} did not reach ${count} version(s) within ${timeout}ms`,
+      );
+    }
+
     async function call(method: string, apiPath: string, data?: unknown) {
       const options: Record<string, unknown> = {
         method,
@@ -608,21 +645,22 @@ export const test = base.extend<TestFixtures, WorkerFixtures>({
         });
       },
       async waitForRelationVersions(fromType, fromId, relation, toId, count, options) {
-        const apiPath =
+        await pollForVersions(
+          call,
           `_relation_history/${encodeURIComponent(fromType)}/${encodeURIComponent(fromId)}` +
-          `/${encodeURIComponent(relation)}/${encodeURIComponent(toId)}`;
-        const timeout = options?.timeout ?? 20000;
-        const start = Date.now();
-        while (Date.now() - start < timeout) {
-          const resp = await call("GET", apiPath).catch(() => null);
-          if (resp && resp.ok()) {
-            const body = (await resp.json()) as { versions?: unknown[] };
-            if ((body.versions?.length ?? 0) >= count) return;
-          }
-          await new Promise((r) => setTimeout(r, 200));
-        }
-        throw new Error(
-          `relation ${fromId}--${relation}--${toId} did not reach ${count} version(s) within ${timeout}ms`,
+            `/${encodeURIComponent(relation)}/${encodeURIComponent(toId)}`,
+          count,
+          `relation ${fromId}--${relation}--${toId}`,
+          options,
+        );
+      },
+      async waitForEntityVersions(type, id, count, options) {
+        await pollForVersions(
+          call,
+          `_history/${encodeURIComponent(type)}/${encodeURIComponent(id)}`,
+          count,
+          `entity ${id}`,
+          options,
         );
       },
       async listRelations(plural, id, relation) {

--- a/e2e/tests/history-url-params.spec.ts
+++ b/e2e/tests/history-url-params.spec.ts
@@ -1,0 +1,190 @@
+import {
+  postgresTest as test,
+  expect,
+  POSTGRES_E2E_ENABLED,
+  type ApiHelpers,
+} from "./fixtures";
+import { HistoryPage } from "../pages/history.page";
+import { RelationHistoryPage } from "../pages/relation-history.page";
+
+// The compared-version pair lives in `?base=`/`?target=` so a specific diff can
+// be shared, bookmarked, and survive a reload (TKT-YOHC3N).
+//
+// Version history is a pgstore-only capability, so this suite runs against
+// `rela-server-postgres` and SKIPS when RELA_E2E_DATABASE_URL is unset. The
+// postgres backend starts EMPTY, so each test creates the entities it needs.
+test.describe("history view URL params", () => {
+  test.skip(
+    !POSTGRES_E2E_ENABLED,
+    "requires a postgres backend (set RELA_E2E_DATABASE_URL)",
+  );
+
+  /** Create a feature and edit it until the sweep has captured `versions`
+   *  distinct versions. Each edit must settle before the next, or the
+   *  reconciliation sweep coalesces them into one version. */
+  async function featureWithHistory(
+    api: ApiHelpers,
+    title: string,
+    versions: number,
+  ): Promise<string> {
+    const e = await api.createEntity("features", {
+      prefix: "FEAT",
+      properties: { title, status: "draft" },
+    });
+    await api.waitForEntityVersions("feature", e.id, 1);
+    for (let i = 2; i <= versions; i++) {
+      await api.updateEntity("features", e.id, { title: `${title} v${i}` });
+      await api.waitForEntityVersions("feature", e.id, i);
+    }
+    return e.id;
+  }
+
+  test("deep link selects the pair, and a bare URL publishes its defaults", async ({
+    appPage,
+    api,
+  }) => {
+    const id = await featureWithHistory(api, "Deep link", 3);
+    const history = new HistoryPage(appPage);
+
+    // A bare URL keeps the existing default (newest → current) and writes it
+    // back, so the address bar becomes an explicit, shareable link.
+    await history.open("feature", id);
+    await history.waitForTimelineAtLeast(3);
+    await history.expectUrlSelection(3, "current");
+    expect(await history.selectedPair()).toEqual({ base: "3", target: "current" });
+
+    // A deep link selects the pair it names, with no user interaction. Reading
+    // the SELECT values (not just the URL) is the assertion that catches a
+    // v-model type mismatch — a numeric side parsed as a string would leave the
+    // dropdown blank while the URL still looked correct.
+    await history.open("feature", id, { base: 1, target: 2 });
+    await history.waitForTimelineAtLeast(3);
+    expect(await history.selectedPair()).toEqual({ base: "1", target: "2" });
+    await expect(history.caption()).toHaveText(/v1.*v2/);
+    // The timeline highlights the base side.
+    await history.expectSelectedVersion(1);
+  });
+
+  test("selecting a pair writes the URL, and a reload reproduces it", async ({
+    appPage,
+    api,
+  }) => {
+    const id = await featureWithHistory(api, "Reload stable", 3);
+    const history = new HistoryPage(appPage);
+
+    await history.open("feature", id);
+    await history.waitForTimelineAtLeast(3);
+
+    // A non-default pair, chosen through the dropdowns.
+    await history.compare(1, 3);
+    await history.expectUrlSelection(1, 3);
+
+    // Reloading reproduces the same diff rather than resetting to defaults.
+    await history.reload();
+    await history.waitForTimelineAtLeast(3);
+    expect(await history.selectedPair()).toEqual({ base: "1", target: "3" });
+
+    // A timeline click sets the base side and is reflected in the URL.
+    await history.selectVersion(2);
+    await history.expectUrlSelection(2, 3);
+
+    // Swap reverses the pair.
+    await history.swapSides();
+    await history.expectUrlSelection(3, 2);
+  });
+
+  test("malformed params fall back to defaults without erroring", async ({
+    appPage,
+    api,
+  }) => {
+    const id = await featureWithHistory(api, "Bad params", 2);
+    const history = new HistoryPage(appPage);
+
+    // An out-of-range ordinal and a non-numeric value both degrade to the
+    // view's defaults — no crash, no error state, no failed fetch.
+    await history.navigateTo(`/history/feature/${id}?base=999&target=nonsense`);
+    await history.expectLoaded();
+    await history.waitForTimelineAtLeast(2);
+    expect(await history.selectedPair()).toEqual({ base: "2", target: "current" });
+    await history.expectNoError();
+  });
+
+  test("selection params merge with an existing query param", async ({
+    appPage,
+    api,
+  }) => {
+    const id = await featureWithHistory(api, "Query merge", 2);
+    const history = new HistoryPage(appPage);
+
+    // An unrelated param must survive the selection write — the history view
+    // merges into route.query rather than replacing it.
+    await history.navigateTo(`/history/feature/${id}?return_to=%2Flist%2Ffeatures`);
+    await history.expectLoaded();
+    await history.waitForTimelineAtLeast(2);
+
+    await history.compare(1, 2);
+    await history.expectUrlSelection(1, 2);
+    expect(history.queryParam("return_to")).toBe("/list/features");
+  });
+
+  test("relation history mirrors its pair into the URL too", async ({
+    appPage,
+    api,
+  }) => {
+    const from = await featureWithHistory(api, "Rel URL source", 1);
+    const to = await featureWithHistory(api, "Rel URL target", 1);
+
+    await api.setRelationMeta("features", from, "blocks", "feature", to, {
+      reason: "initial reason",
+    });
+    await api.waitForRelationVersions("feature", from, "blocks", to, 1);
+    await api.setRelationMeta("features", from, "blocks", "feature", to, {
+      reason: "second reason",
+    });
+    await api.waitForRelationVersions("feature", from, "blocks", to, 2);
+
+    const history = new RelationHistoryPage(appPage);
+    await history.navigateTo(
+      `/relation-history/feature/${from}/blocks/${to}?base=1&target=2`,
+    );
+    await history.expectLoaded();
+    await history.waitForTimelineAtLeast(2);
+
+    // The deep-linked pair is selected, and the diff shows the changed property.
+    expect(await history.selectedPair()).toEqual({ base: "1", target: "2" });
+    const labels = (await history.propDiffLabels()).map((l) => l.toLowerCase());
+    expect(labels).toContain("reason");
+
+    // Changing the selection republishes to the URL.
+    await history.compare(2, 2);
+    await history.expectUrlSelection(2, 2);
+
+    // A BARE relation URL publishes a live-relative default (`target=current`),
+    // the same shape the entity view publishes — not two frozen ordinals, which
+    // would make an otherwise-identical shared link freeze for relations only.
+    await history.navigateTo(
+      `/relation-history/feature/${from}/blocks/${to}`,
+    );
+    await history.expectLoaded();
+    await history.waitForTimelineAtLeast(2);
+    await history.expectUrlSelection(1, "current");
+  });
+
+  test("an out-of-range ordinal is corrected in the URL, not left to rot", async ({
+    appPage,
+    api,
+  }) => {
+    // `base=999` names no version that exists. The view falls back to its
+    // default AND rewrites the address bar, so the corrected pair is what gets
+    // copied or bookmarked — leaving the stale ordinal there would let it be
+    // re-applied verbatim after more versions are captured.
+    const id = await featureWithHistory(api, "Stale ordinal", 2);
+    const history = new HistoryPage(appPage);
+
+    await history.navigateTo(`/history/feature/${id}?base=999&target=nonsense`);
+    await history.expectLoaded();
+    await history.waitForTimelineAtLeast(2);
+    await history.expectUrlSelection(2, "current");
+    await history.expectNoError();
+  });
+});

--- a/frontend/src/composables/useVersionSelectionSync.test.ts
+++ b/frontend/src/composables/useVersionSelectionSync.test.ts
@@ -1,0 +1,348 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { reactive, nextTick, effectScope, type EffectScope } from 'vue'
+import type { LocationQuery } from 'vue-router'
+import {
+  useVersionSelectionSync,
+  parseSide,
+  serializeSide,
+  type Side,
+  type UseVersionSelectionSyncOptions,
+} from './useVersionSelectionSync'
+
+// A reactive route-like object whose `query` we mutate to simulate navigation,
+// mirroring useUrlFilterSync.test.ts.
+const mockRoute = reactive<{ query: LocationQuery }>({ query: {} })
+const mockReplace = vi.fn()
+const mockPush = vi.fn()
+
+vi.mock('vue-router', () => ({
+  useRoute: () => mockRoute,
+  useRouter: () => ({
+    replace: mockReplace,
+    push: mockPush,
+  }),
+}))
+
+// Real router.replace mutates route.query; wire the mock the same way so the
+// watcher actually fires (and so an echo loop would be observable if the guard
+// were broken).
+mockReplace.mockImplementation(({ query }: { query: LocationQuery }) => {
+  mockRoute.query = query
+})
+
+// Each test runs the composable in its own effect scope so watchers are torn
+// down and don't re-fire against the shared mockRoute in later tests.
+let scope: EffectScope
+
+function setup(opts: Partial<UseVersionSelectionSyncOptions> = {}) {
+  const full: UseVersionSelectionSyncOptions = {
+    validVersions: () => [1, 2, 3],
+    defaults: () => ({ base: 3, target: 'current' }),
+    onChange: vi.fn(),
+    ...opts,
+  }
+  const api = scope.run(() => useVersionSelectionSync(full))!
+  return { ...api, onChange: full.onChange }
+}
+
+describe('parseSide', () => {
+  const valid = [1, 2, 3]
+
+  it("keeps 'current' as the sentinel string", () => {
+    expect(parseSide('current', valid)).toBe('current')
+  })
+
+  it('coerces a valid ordinal to a NUMBER, not a numeric string', () => {
+    // The <option value="current"> is a string while version options bind
+    // :value="m.version" (a number). A string '3' would match no option and
+    // v-model would render the dropdown blank.
+    const parsed = parseSide('3', valid)
+    expect(parsed).toBe(3)
+    expect(typeof parsed).toBe('number')
+  })
+
+  it('takes the last value of a repeated param', () => {
+    expect(parseSide(['1', '2'], valid)).toBe(2)
+  })
+
+  it.each([
+    ['empty string', ''],
+    ['non-numeric', 'abc'],
+    ['negative', '-1'],
+    ['zero (ordinals are 1-based)', '0'],
+    ['fractional', '1.5'],
+    ['exponent notation', '1e2'],
+    ['out of range', '999'],
+    ['path traversal attempt', '../../etc/passwd'],
+    ['script tag', '<script>alert(1)</script>'],
+    ['whitespace padded', ' 2 '],
+    ['undefined', undefined],
+    ['null', null],
+    ['number type', 3],
+    ['empty array', []],
+  ])('rejects %s', (_label, input) => {
+    expect(parseSide(input, valid)).toBeNull()
+  })
+
+  it('rejects an ordinal absent from the list even though it is numeric', () => {
+    expect(parseSide('4', [1, 2, 3])).toBeNull()
+  })
+
+  it('rejects every ordinal while the version list is still empty', () => {
+    expect(parseSide('1', [])).toBeNull()
+    expect(parseSide('current', [])).toBe('current')
+  })
+})
+
+describe('serializeSide', () => {
+  it.each([
+    ['current' as Side, 'current'],
+    [3 as Side, '3'],
+  ])('serializes %s to %s', (input, expected) => {
+    expect(serializeSide(input)).toBe(expected)
+  })
+})
+
+describe('useVersionSelectionSync', () => {
+  beforeEach(() => {
+    mockRoute.query = {}
+    mockReplace.mockClear()
+    mockPush.mockClear()
+    scope = effectScope()
+  })
+
+  afterEach(() => {
+    scope.stop()
+  })
+
+  describe('seeding', () => {
+    it('falls back to defaults when no params are present', () => {
+      const { base, target } = setup()
+      expect(base.value).toBe(3)
+      expect(target.value).toBe('current')
+    })
+
+    it('seeds both sides from the URL', () => {
+      mockRoute.query = { base: '1', target: '2' }
+      const { base, target } = setup()
+      expect(base.value).toBe(1)
+      expect(target.value).toBe(2)
+    })
+
+    it('seeds one side and defaults the other when only one param is given', () => {
+      mockRoute.query = { base: '2' }
+      const { base, target } = setup()
+      expect(base.value).toBe(2)
+      expect(target.value).toBe('current')
+    })
+
+    it('allows an identical pair (an empty diff is linkable)', () => {
+      mockRoute.query = { base: '2', target: '2' }
+      const { base, target } = setup()
+      expect(base.value).toBe(2)
+      expect(target.value).toBe(2)
+    })
+
+    it('falls back to defaults for malformed params without throwing', () => {
+      mockRoute.query = { base: 'abc', target: '999' }
+      const { base, target } = setup()
+      expect(base.value).toBe(3)
+      expect(target.value).toBe('current')
+    })
+
+    it('re-seeds against the real ordinals once the version list loads', () => {
+      // The synchronous setup pass sees an empty list, so ?base=2 can't be
+      // validated yet; seedFromUrl re-runs after listVersions resolves.
+      mockRoute.query = { base: '2', target: 'current' }
+      let loaded = false
+      const { base, seedFromUrl } = setup({
+        validVersions: () => (loaded ? [1, 2, 3] : []),
+        defaults: () => ({ base: loaded ? 3 : 'current', target: 'current' }),
+      })
+      expect(base.value).toBe('current') // not yet validatable
+
+      loaded = true
+      seedFromUrl()
+      expect(base.value).toBe(2)
+    })
+
+    it('does not seed a stale ordinal after the list shrinks', () => {
+      mockRoute.query = { base: '3', target: 'current' }
+      let versions = [1, 2, 3]
+      const { base, seedFromUrl } = setup({
+        validVersions: () => versions,
+        defaults: () => ({ base: versions[versions.length - 1], target: 'current' }),
+      })
+      expect(base.value).toBe(3)
+
+      versions = [1, 2]
+      seedFromUrl()
+      expect(base.value).toBe(2) // default, not the now-absent v3
+    })
+  })
+
+  describe('writing to the URL', () => {
+    it('writes the pair on select and recomputes', () => {
+      const { select, onChange } = setup()
+      select({ base: 1 })
+      expect(mockReplace).toHaveBeenCalledWith({ query: { base: '1', target: 'current' } })
+      expect(onChange).toHaveBeenCalledTimes(1)
+    })
+
+    it('uses replace, never push, so the Back button is not buried', () => {
+      const { select } = setup()
+      select({ base: 1 })
+      select({ target: 2 })
+      expect(mockReplace).toHaveBeenCalledTimes(2)
+      expect(mockPush).not.toHaveBeenCalled()
+    })
+
+    it("serializes the 'current' sentinel verbatim rather than as a number", () => {
+      const { select } = setup()
+      select({ base: 'current', target: 'current' })
+      expect(mockReplace).toHaveBeenCalledWith({
+        query: { base: 'current', target: 'current' },
+      })
+    })
+
+    it('preserves unrelated query params', () => {
+      mockRoute.query = { return_to: '/list/features', from: 'dashboard' }
+      const { select } = setup()
+      select({ base: 2 })
+      expect(mockReplace).toHaveBeenCalledWith({
+        query: { return_to: '/list/features', from: 'dashboard', base: '2', target: 'current' },
+      })
+    })
+
+    it('swap reverses the two sides and publishes both', () => {
+      mockRoute.query = { base: '1', target: '3' }
+      const { base, target, swap } = setup()
+      swap()
+      expect(base.value).toBe(3)
+      expect(target.value).toBe(1)
+      expect(mockReplace).toHaveBeenCalledWith({ query: { base: '3', target: '1' } })
+    })
+
+    it('publish writes the resolved pair without recomputing', () => {
+      const { publish, onChange } = setup()
+      publish()
+      expect(mockReplace).toHaveBeenCalledWith({ query: { base: '3', target: 'current' } })
+      expect(onChange).not.toHaveBeenCalled()
+    })
+
+    it('publishes a correcting write even when there are NO versions', () => {
+      // The view calls publish() unconditionally so a stale ordinal left in the
+      // URL doesn't survive to be re-applied once the sweep captures versions.
+      mockRoute.query = { base: '999', target: 'nonsense' }
+      const { publish } = setup({
+        validVersions: () => [],
+        defaults: () => ({ base: 'current', target: 'current' }),
+      })
+      publish()
+      expect(mockReplace).toHaveBeenCalledWith({
+        query: { base: 'current', target: 'current' },
+      })
+    })
+  })
+
+  describe('type coercion', () => {
+    // parseSide guarantees numbers for URL-sourced values, but sides also come
+    // from callers. A numeric STRING matches no <option> and blanks the control,
+    // so the invariant is enforced on every write rather than per caller.
+    it('coerces a numeric string passed to select', () => {
+      const { base, select } = setup()
+      select({ base: '2' as unknown as Side })
+      expect(base.value).toBe(2)
+      expect(typeof base.value).toBe('number')
+    })
+
+    it('coerces a numeric string coming from the view defaults', () => {
+      const { base } = setup({
+        defaults: () => ({ base: '3' as unknown as Side, target: 'current' }),
+      })
+      expect(base.value).toBe(3)
+      expect(typeof base.value).toBe('number')
+    })
+
+    it('leaves the current sentinel alone', () => {
+      const { base, select } = setup()
+      select({ base: 'current' })
+      expect(base.value).toBe('current')
+    })
+  })
+
+  describe('resetToDefaults', () => {
+    it('resets both sides to the defaults, ignoring the URL', () => {
+      // The post-restore path: the version list changed underneath, so the URL's
+      // pair must NOT be resurrected.
+      mockRoute.query = { base: '1', target: '2' }
+      const { base, target, resetToDefaults } = setup()
+      expect(base.value).toBe(1)
+
+      resetToDefaults()
+      expect(base.value).toBe(3)
+      expect(target.value).toBe('current')
+    })
+
+    it('does not write or recompute on its own', () => {
+      // The view publishes and recomputes explicitly after resetting, so the
+      // reset itself must stay side-effect free.
+      const { resetToDefaults, onChange } = setup()
+      resetToDefaults()
+      expect(mockReplace).not.toHaveBeenCalled()
+      expect(onChange).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('external navigation', () => {
+    it('re-seeds and recomputes on an external query change', async () => {
+      const { base, target, onChange } = setup()
+      mockRoute.query = { base: '1', target: '2' }
+      await nextTick()
+      expect(base.value).toBe(1)
+      expect(target.value).toBe(2)
+      expect(onChange).toHaveBeenCalledTimes(1)
+    })
+
+    it('ignores the echo of its own write (no recompute, no loop)', async () => {
+      const { select, onChange } = setup()
+      select({ base: 1 })
+      expect(onChange).toHaveBeenCalledTimes(1)
+
+      await nextTick()
+      // The write mutated route.query, firing the watcher. The signature guard
+      // must recognize it as our own and not recompute or write again.
+      expect(onChange).toHaveBeenCalledTimes(1)
+      expect(mockReplace).toHaveBeenCalledTimes(1)
+    })
+
+    it('settles after repeated selections rather than looping', async () => {
+      const { select, base } = setup()
+      select({ base: 1 })
+      select({ base: 2 })
+      select({ base: 3 })
+      await nextTick()
+      await nextTick()
+      expect(base.value).toBe(3)
+      expect(mockReplace).toHaveBeenCalledTimes(3)
+    })
+
+    it('falls back to defaults when navigated to a malformed query', async () => {
+      mockRoute.query = { base: '1', target: '2' }
+      const { base, target } = setup()
+      expect(base.value).toBe(1)
+
+      mockRoute.query = { base: '999', target: 'nonsense' }
+      await nextTick()
+      expect(base.value).toBe(3)
+      expect(target.value).toBe('current')
+    })
+
+    it('ignores changes to unrelated query params', async () => {
+      const { onChange } = setup()
+      mockRoute.query = { ...mockRoute.query, q: 'search text' }
+      await nextTick()
+      expect(onChange).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/frontend/src/composables/useVersionSelectionSync.ts
+++ b/frontend/src/composables/useVersionSelectionSync.ts
@@ -1,0 +1,208 @@
+/**
+ * Bidirectional sync between the history views' compared-version pair and the
+ * `?base=` / `?target=` query params, so a specific diff is a shareable link.
+ *
+ * Mirrors the seed/replace/echo pattern of `useUrlFilterSync` and
+ * `useFormWizard`'s `?step=N`:
+ *
+ * - Seeds synchronously at setup so a deep link is honoured as early as
+ *   possible, and is re-runnable (`seedFromUrl`) because the set of valid
+ *   versions isn't known until `listVersions` resolves — the same reason
+ *   useFormWizard re-seeds after its entity loads.
+ * - `select` is the single write path: it updates the refs and the URL via
+ *   `router.replace` (never `push`, so fiddling with the dropdowns doesn't bury
+ *   the Back button under one entry per change) and records a signature the
+ *   route watcher uses to ignore its own echo.
+ * - The route watcher handles external navigation (back/forward, a pasted
+ *   link) and re-seeds from the query.
+ *
+ * A param is accepted only if it is the literal `current` or an ordinal the
+ * server actually returned. That allowlist — rather than a numeric range check
+ * — is what keeps a crafted `?base=../../x` or `?base=999` from ever reaching a
+ * fetch: an unrecognized value silently becomes the view's default.
+ */
+import { ref, watch, type Ref } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+
+/**
+ * A comparison side: a version ordinal, or the live/newest state.
+ *
+ * `current` is spelled the same in the URL for both history views even though
+ * they resolve and label it differently — the entity view diffs against the
+ * live entity ("current"), while the relation view has no live-fetch endpoint
+ * and maps it to the newest snapshot ("latest"). Keeping one URL token means a
+ * link reads the same either way.
+ */
+export type Side = number | 'current'
+
+/** The sentinel's URL spelling, shared by both views. */
+export const CURRENT = 'current'
+
+export interface VersionSelection {
+  base: Side
+  target: Side
+}
+
+export interface UseVersionSelectionSyncOptions {
+  /**
+   * Version ordinals that actually exist. Supplied by the view, and empty
+   * until `listVersions` resolves — which is precisely why seeding has to be
+   * re-runnable rather than a one-shot at setup.
+   */
+  validVersions: () => number[]
+  /**
+   * The view's default pair, used for any side the URL doesn't validly
+   * specify. The two views disagree (entity: newest → current; relation:
+   * second-newest → newest), so this can't be hardcoded here.
+   */
+  defaults: () => VersionSelection
+  /** Run after any change to the pair, from any source. */
+  onChange: () => void
+}
+
+/** Collapse a query value to a single string, taking the last of a repeated
+ *  param (`?base=1&base=2`) the way `useUrlFilterSync.readQParam` does. */
+function readParam(value: unknown): string {
+  if (typeof value === 'string') return value
+  if (Array.isArray(value)) {
+    const last = value[value.length - 1]
+    return typeof last === 'string' ? last : ''
+  }
+  return ''
+}
+
+/**
+ * Resolve one raw query value to a Side, or null if it names nothing real.
+ *
+ * The numeric branch must produce a `number`, not a numeric string: the
+ * `<option value="current">` is a string while version options bind
+ * `:value="m.version"` (a number), so a string `'3'` would match no option and
+ * `v-model` would render the dropdown blank.
+ */
+export function parseSide(raw: unknown, validVersions: number[]): Side | null {
+  const value = readParam(raw)
+  if (value === CURRENT) return CURRENT
+  if (!/^\d+$/.test(value)) return null // rejects '', 'abc', '-1', '1.5', '1e2'
+  const n = Number(value)
+  return validVersions.includes(n) ? n : null
+}
+
+/** Serialize a Side for the URL. */
+export function serializeSide(s: Side): string {
+  return s === CURRENT ? CURRENT : String(s)
+}
+
+/**
+ * Normalize a Side to the numeric form the dropdowns bind.
+ *
+ * `parseSide` already guarantees this for URL-sourced values, but sides also
+ * arrive from callers (a view's `defaults()`, a `select()` argument). Coercing
+ * on every write keeps the invariant with the type instead of relying on each
+ * caller — a numeric STRING would match no `<option>` and silently blank the
+ * control, since version options bind numbers while the sentinel binds a string.
+ */
+export function coerceSide(s: Side): Side {
+  return s === CURRENT ? CURRENT : Number(s)
+}
+
+export function useVersionSelectionSync(opts: UseVersionSelectionSyncOptions) {
+  const route = useRoute()
+  const router = useRouter()
+
+  const base = ref<Side>(CURRENT) as Ref<Side>
+  const target = ref<Side>(CURRENT) as Ref<Side>
+
+  // Signature of the pair we last wrote ourselves, so the route watcher can
+  // tell our own `router.replace` echo from real external navigation.
+  let lastWrittenSig = ''
+
+  function signature(b: Side, t: Side): string {
+    return `${serializeSide(b)}|${serializeSide(t)}`
+  }
+
+  /**
+   * Read the pair from the URL, falling back per-side to the view's defaults.
+   * Re-runnable: call it again once the version list has loaded so params can
+   * be validated against real ordinals.
+   */
+  function seedFromUrl(): void {
+    const valid = opts.validVersions()
+    const fallback = opts.defaults()
+    base.value = parseSide(route.query.base, valid) ?? coerceSide(fallback.base)
+    target.value = parseSide(route.query.target, valid) ?? coerceSide(fallback.target)
+  }
+
+  /**
+   * Write the current pair to the URL, merging into the existing query so
+   * unrelated params (`return_to`, `from`, …) survive.
+   *
+   * Exported as `publish` for the views to call after a load has already
+   * computed the diff: it turns a bare or stale URL into an explicit, shareable
+   * one. It does NOT recompute — `select` owns that.
+   */
+  function writeToQuery(): void {
+    const query = {
+      ...route.query,
+      base: serializeSide(base.value),
+      target: serializeSide(target.value),
+    }
+    lastWrittenSig = signature(base.value, target.value)
+    void router.replace({ query })
+  }
+
+  /** The single sanctioned mutation path: set one or both sides, publish to
+   *  the URL, and recompute. Every caller (dropdown, timeline row, swap) goes
+   *  through here so no path can update the URL without recomputing the diff,
+   *  or recompute without updating the URL. */
+  function select(next: Partial<VersionSelection>): void {
+    if (next.base !== undefined) base.value = coerceSide(next.base)
+    if (next.target !== undefined) target.value = coerceSide(next.target)
+    writeToQuery()
+    opts.onChange()
+  }
+
+  /** Reset both sides to the view's defaults and publish, WITHOUT reading the
+   *  URL. Used after a restore: the version list has changed underneath, so
+   *  re-seeding would resurrect a pair the user picked against the old list.
+   *  Exists so the views don't assign the refs directly and bypass the write
+   *  path. */
+  function resetToDefaults(): void {
+    const d = opts.defaults()
+    base.value = coerceSide(d.base)
+    target.value = coerceSide(d.target)
+  }
+
+  /** Swap the two sides (reverse the diff direction). */
+  function swap(): void {
+    select({ base: target.value, target: base.value })
+  }
+
+  // External navigation (back/forward, a pasted link). Our own writes are
+  // skipped via the signature guard, which is what keeps this from looping.
+  //
+  // The getter returns a joined STRING, not an array: an array getter allocates
+  // a fresh reference every run, so Vue's reference comparison would fire the
+  // watcher on any unrelated query change (a `?q=` edit elsewhere) and
+  // spuriously recompute the diff.
+  watch(
+    () => `${readParam(route.query.base)}|${readParam(route.query.target)}`,
+    () => {
+      const valid = opts.validVersions()
+      const fallback = opts.defaults()
+      const incoming = signature(
+        parseSide(route.query.base, valid) ?? fallback.base,
+        parseSide(route.query.target, valid) ?? fallback.target
+      )
+      if (incoming === lastWrittenSig) return
+      lastWrittenSig = incoming
+      seedFromUrl()
+      opts.onChange()
+    }
+  )
+
+  // Seed once synchronously. The version list is still empty here, so this
+  // only picks up `current`; seedFromUrl runs again after load resolves.
+  seedFromUrl()
+
+  return { base, target, seedFromUrl, resetToDefaults, select, swap, publish: writeToQuery }
+}

--- a/frontend/src/views/HistoryView.vue
+++ b/frontend/src/views/HistoryView.vue
@@ -6,6 +6,7 @@ import { getErrorMessage, ApiError } from '@/api/errors'
 import { listVersions, getVersion, restoreVersion, type VersionMeta } from '@/api/history'
 import { getEntity as fetchEntity } from '@/api/entities'
 import { lineDiff, propertyDiff, type DiffLine, type PropertyChange } from '@/utils/lineDiff'
+import { useVersionSelectionSync, type Side } from '@/composables/useVersionSelectionSync'
 import { isEnumPropertyDef } from '@/utils/format'
 import Badge from '@/components/common/Badge.vue'
 import type { Entity } from '@/types'
@@ -26,11 +27,32 @@ const current = ref<Entity | null>(null)
 
 // A comparison side is either a version ordinal (number) or 'current' (the live
 // entity). 'current' is the sentinel for the working state, so a user can diff
-// any past version against another OR against the live entity.
-type Side = number | 'current'
+// any past version against another OR against the live entity. The pair is
+// mirrored into `?base=`/`?target=` so a diff can be linked to — see
+// useVersionSelectionSync.
+const {
+  base: baseSel,
+  target: targetSel,
+  seedFromUrl,
+  resetToDefaults,
+  select,
+  swap: swapSides,
+  publish: publishSelection,
+} = useVersionSelectionSync({
+  validVersions: () => versions.value.map((m) => m.version),
+  defaults: () => defaultSelection(),
+  onChange: () => void recompute(),
+})
 
-const baseSel = ref<Side>('current')
-const targetSel = ref<Side>('current')
+// Default: the most recent version → current, preserving the "what changed
+// since this version" reading the screen opened with. Extracted (rather than
+// inlined in `defaults`) so the post-restore reset uses the same expression and
+// the two can't drift.
+function defaultSelection(): { base: Side; target: Side } {
+  if (!versions.value.length) return { base: 'current', target: 'current' }
+  return { base: versions.value[versions.value.length - 1].version, target: 'current' }
+}
+
 const contentDiff = ref<DiffLine[]>([])
 const propDiff = ref<PropertyChange[]>([])
 const restoring = ref(false)
@@ -71,7 +93,11 @@ function displayValue(v: unknown): string {
   return String(v)
 }
 
-async function load() {
+// `fromUrl` re-reads `?base=`/`?target=` now that the version list is known and
+// params can be validated against real ordinals. A reload after a RESTORE
+// passes false: the version list has changed underneath, so re-seeding would
+// resurrect a pair the user chose against the old list.
+async function load(fromUrl = true) {
   loading.value = true
   error.value = ''
   try {
@@ -81,13 +107,18 @@ async function load() {
     ])
     versions.value = vs
     current.value = ent
-    // Default comparison: the most recent version → current, preserving the
-    // "what changed since this version" reading the screen opened with.
-    if (vs.length) {
-      baseSel.value = vs[vs.length - 1].version
-      targetSel.value = 'current'
-      await recompute()
+    if (fromUrl) {
+      seedFromUrl()
+    } else {
+      resetToDefaults()
     }
+    if (vs.length) await recompute()
+    // Publish the resolved pair so a bare URL becomes an explicit, shareable one
+    // (and so a post-restore reset is reflected in the address bar). Runs even
+    // with NO versions: that is exactly when the URL is most likely to carry a
+    // stale ordinal, and leaving it there would let a bookmark re-apply it once
+    // the sweep captures versions later.
+    publishSelection()
   } catch (err) {
     if (err instanceof ApiError && err.status === 501) {
       unsupported.value = true
@@ -145,16 +176,20 @@ async function recompute() {
   }
 }
 
-// Clicking a timeline row sets the BASE (before) side and recomputes.
+// Clicking a timeline row sets the BASE (before) side.
 function selectVersion(v: number) {
-  baseSel.value = v
-  void recompute()
+  select({ base: v })
 }
 
-// Swap the two sides (reverse the diff direction).
-function swapSides() {
-  ;[baseSel.value, targetSel.value] = [targetSel.value, baseSel.value]
-  void recompute()
+// The dropdowns bind v-model directly, so `select` re-publishes the value the
+// ref already holds; passing it explicitly keeps one write path for all four
+// mutation sources (dropdown, timeline row, swap, external nav).
+function onBaseChange() {
+  select({ base: baseSel.value })
+}
+
+function onTargetChange() {
+  select({ target: targetSel.value })
 }
 
 async function restore(v: number) {
@@ -163,7 +198,7 @@ async function restore(v: number) {
   try {
     await restoreVersion(entityType.value, entityId.value, v)
     uiStore.showToast('success', `Restored to version ${v}`)
-    await load()
+    await load(false)
   } catch (err) {
     uiStore.showToast('error', getErrorMessage(err, 'Restore failed'))
   } finally {
@@ -219,6 +254,7 @@ onMounted(load)
             :key="m.version"
             class="timeline-item"
             :class="{ selected: selectedVersion === m.version }"
+            :data-version="m.version"
           >
             <button type="button" class="timeline-select" @click="selectVersion(m.version)">
               <span class="timeline-badge" :data-op="m.op">{{ m.op }}</span>
@@ -245,7 +281,7 @@ onMounted(load)
       <section class="card diff-card">
         <div class="compare-bar">
           <span class="compare-label">Compare</span>
-          <select v-model="baseSel" class="compare-select" @change="recompute">
+          <select v-model="baseSel" class="compare-select" @change="onBaseChange">
             <option value="current">current</option>
             <option v-for="m in versionsNewestFirst" :key="m.version" :value="m.version">
               v{{ m.version }} · {{ m.op }}
@@ -259,7 +295,7 @@ onMounted(load)
           >
             ⇄
           </button>
-          <select v-model="targetSel" class="compare-select" @change="recompute">
+          <select v-model="targetSel" class="compare-select" @change="onTargetChange">
             <option value="current">current</option>
             <option v-for="m in versionsNewestFirst" :key="m.version" :value="m.version">
               v{{ m.version }} · {{ m.op }}

--- a/frontend/src/views/RelationHistoryView.vue
+++ b/frontend/src/views/RelationHistoryView.vue
@@ -10,6 +10,7 @@ import {
   type RelationVersionMeta,
 } from '@/api/history'
 import { lineDiff, propertyDiff, type DiffLine, type PropertyChange } from '@/utils/lineDiff'
+import { useVersionSelectionSync, type Side } from '@/composables/useVersionSelectionSync'
 
 const route = useRoute()
 const router = useRouter()
@@ -29,10 +30,37 @@ const versions = ref<RelationVersionMeta[]>([])
 
 // A comparison side is a version ordinal or 'current' (the live relation, taken
 // from the newest snapshot since relations have no separate live-fetch endpoint
-// here — the newest version reflects the current settled state).
-type Side = number | 'current'
-const baseSel = ref<Side>('current')
-const targetSel = ref<Side>('current')
+// here — the newest version reflects the current settled state). The pair is
+// mirrored into `?base=`/`?target=` so a diff can be linked to; the URL token
+// stays `current` here even though this view LABELS it "latest", so a history
+// link reads the same for entities and relations.
+const {
+  base: baseSel,
+  target: targetSel,
+  seedFromUrl,
+  resetToDefaults,
+  select,
+  swap: swapSides,
+  publish: publishSelection,
+} = useVersionSelectionSync({
+  validVersions: () => versions.value.map((m) => m.version),
+  // Default: second-newest → newest, i.e. "what the most recent edit changed".
+  defaults: () => defaultSelection(),
+  onChange: () => void recompute(),
+})
+
+// Extracted so load() can reset to the same defaults after a restore.
+//
+// The target is the `current` SENTINEL rather than the newest ordinal, so the
+// published default link stays live-relative and keeps meaning "what the most
+// recent edit changed" as new versions land — matching HistoryView, whose
+// default is likewise `→ current`. Pinning the ordinal here would make an
+// otherwise-identical shared link freeze for relations but not for entities.
+function defaultSelection(): { base: Side; target: Side } {
+  if (versions.value.length < 2) return { base: 'current', target: 'current' }
+  return { base: versions.value[versions.value.length - 2].version, target: 'current' }
+}
+
 const contentDiff = ref<DiffLine[]>([])
 const propDiff = ref<PropertyChange[]>([])
 const restoring = ref(false)
@@ -57,18 +85,27 @@ function displayValue(v: unknown): string {
   return String(v)
 }
 
-async function load() {
+// `fromUrl` re-reads `?base=`/`?target=` now that the version list is known and
+// params can be validated against real ordinals. A reload after a RESTORE
+// passes false: the version list has changed underneath, so re-seeding would
+// resurrect a pair the user chose against the old list.
+async function load(fromUrl = true) {
   loading.value = true
   error.value = ''
   try {
     versions.value = await listRelationVersions(fromType.value, from.value, relType.value, to.value)
-    if (versions.value.length) {
-      const last = versions.value[versions.value.length - 1].version
-      baseSel.value =
-        versions.value.length > 1 ? versions.value[versions.value.length - 2].version : last
-      targetSel.value = last
-      await recompute()
+    if (fromUrl) {
+      seedFromUrl()
+    } else {
+      resetToDefaults()
     }
+    if (versions.value.length) await recompute()
+    // Publish the resolved pair so a bare URL becomes an explicit, shareable one
+    // (and so a post-restore reset is reflected in the address bar). Runs even
+    // with NO versions: that is exactly when the URL is most likely to carry a
+    // stale ordinal, and leaving it there would let a bookmark re-apply it once
+    // the sweep captures versions later.
+    publishSelection()
   } catch (err) {
     if (err instanceof ApiError && err.status === 501) {
       unsupported.value = true
@@ -120,13 +157,18 @@ async function recompute() {
 }
 
 function selectVersion(v: number) {
-  baseSel.value = v
-  void recompute()
+  select({ base: v })
 }
 
-function swapSides() {
-  ;[baseSel.value, targetSel.value] = [targetSel.value, baseSel.value]
-  void recompute()
+// The dropdowns bind v-model directly, so `select` re-publishes the value the
+// ref already holds; passing it explicitly keeps one write path for all four
+// mutation sources (dropdown, timeline row, swap, external nav).
+function onBaseChange() {
+  select({ base: baseSel.value })
+}
+
+function onTargetChange() {
+  select({ target: targetSel.value })
 }
 
 async function restore(v: number) {
@@ -135,7 +177,7 @@ async function restore(v: number) {
   try {
     await restoreRelationVersion(fromType.value, from.value, relType.value, to.value, v)
     uiStore.showToast('success', `Restored relation to version ${v}`)
-    await load()
+    await load(false)
   } catch (err) {
     uiStore.showToast('error', getErrorMessage(err, 'Restore failed'))
   } finally {
@@ -218,7 +260,7 @@ onMounted(load)
       <section class="card diff-card">
         <div class="compare-bar">
           <span class="compare-label">Compare</span>
-          <select v-model="baseSel" class="compare-select" @change="recompute">
+          <select v-model="baseSel" class="compare-select" @change="onBaseChange">
             <option value="current">latest</option>
             <option v-for="m in versionsNewestFirst" :key="m.version" :value="m.version">
               v{{ m.version }} · {{ m.op }}
@@ -232,7 +274,7 @@ onMounted(load)
           >
             ⇄
           </button>
-          <select v-model="targetSel" class="compare-select" @change="recompute">
+          <select v-model="targetSel" class="compare-select" @change="onTargetChange">
             <option value="current">latest</option>
             <option v-for="m in versionsNewestFirst" :key="m.version" :value="m.version">
               v{{ m.version }} · {{ m.op }}

--- a/tickets/entities/docs-checklists/DOCS-U2GMHT.md
+++ b/tickets/entities/docs-checklists/DOCS-U2GMHT.md
@@ -1,0 +1,55 @@
+---
+id: DOCS-U2GMHT
+type: docs-checklist
+title: 'Docs: History/diff views shareable version URLs (TKT-YOHC3N)'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Code Documentation
+
+- [x] New code carries doc comments explaining the *why*
+
+`useVersionSelectionSync.ts` has a module docstring stating the three rules of
+the seed/replace/echo pattern and naming its two in-repo precedents, plus
+per-function comments on the non-obvious parts: why `parseSide` must return a
+number (the `v-model` type trap), why the watcher getter returns a string rather
+than an array (reference comparison would fire on unrelated query changes), why
+the allowlist is membership-in-the-real-list rather than a range check, and why
+`current` is spelled identically in both views' URLs despite being labelled
+differently.
+
+Both views carry a comment at the `load()` call site explaining why
+`publishSelection()` runs even with no versions, and why the restore path resets
+instead of re-seeding.
+
+## Project Documentation
+
+- [x] `docs/postgres-backend.md` updated
+
+Added a "Sharing a diff" block under the paragraph describing the history UI,
+with worked URL examples for both entity and relation history. It states
+explicitly that `current` is **live-relative** (so nobody expects a frozen
+diff), that omitting the params gives the default view, that an ordinal naming
+no existing version falls back *and* gets corrected in the address bar, and that
+a shared link is **not a capability** — the recipient still needs their own read
+permission and sees the same 404 they would without it.
+
+- [x] ~~`docs/metamodel.md`~~ (N/A: no metamodel change)
+- [x] ~~`docs/cli-reference.md`~~ (N/A: no CLI change; the `rela history` /
+`rela relation-history` commands are untouched)
+- [x] ~~`docs/data-entry.md`~~ (N/A: that file never documents the history
+feature — the history UI is described in `postgres-backend.md`, since versioning
+is a pgstore-only capability, so the docs went where a reader would actually
+look)
+- [x] ~~`CLAUDE.md` / `frontend/CLAUDE.md`~~ (N/A: this *uses* the established
+URL-sync composable pattern rather than introducing a new convention;
+`frontend/CLAUDE.md` already documents `src/composables/`)
+- [x] ~~`README.md`~~ (N/A: not a project-level change)
+
+## External Documentation
+
+- [x] ~~Release notes / changelog~~ (N/A: no changelog file in this repo)
+- [x] ~~API documentation~~ (N/A: no API change — this is entirely client-side;
+the `_history` endpoints already accepted a version ordinal)

--- a/tickets/entities/implementation-checklists/IMPL-PQ0TUL.md
+++ b/tickets/entities/implementation-checklists/IMPL-PQ0TUL.md
@@ -1,0 +1,128 @@
+---
+id: IMPL-PQ0TUL
+type: implementation-checklist
+title: 'Implementation: History/diff views: put selected versions in the URL so a diff is shareable'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Development
+
+- [x] Unit tests written for new code
+- [x] Integration tests written (test full flow, not just units)
+- [x] Happy path implemented
+- [x] Edge cases from planning handled
+- [x] Error handling in place (errors surfaced, not swallowed)
+
+**What was built:**
+
+`frontend/src/composables/useVersionSelectionSync.ts` — one composable owning
+the URL representation of the compared pair, wired into both history views.
+Follows the house seed/replace/echo pattern (`useUrlFilterSync`,
+`useFormWizard`'s `?step=N`), with two-phase seeding because the valid-version
+allowlist doesn't exist until `listVersions` resolves.
+
+| File | Change |
+|---|---|
+| `frontend/src/composables/useVersionSelectionSync.ts` | New — parse/serialize/seed/write/echo-guard. |
+| `frontend/src/composables/useVersionSelectionSync.test.ts` | New — 39 unit tests. |
+| `frontend/src/views/HistoryView.vue` | Composable wired in; `load(fromUrl)`; single write path; `:data-version` added to timeline rows. |
+| `frontend/src/views/RelationHistoryView.vue` | Same; `defaultSelection()` extracted so the post-restore reset and the composable's `defaults()` can't drift. |
+| `e2e/pages/history.page.ts` | New — entity-history page object. |
+| `e2e/pages/relation-history.page.ts` | URL/selection helpers. |
+| `e2e/pages/index.ts` | Export both history page objects. |
+| `e2e/tests/history-url-params.spec.ts` | New — 5 postgres-gated e2e tests. |
+| `e2e/tests/fixtures.ts` | `waitForEntityVersions` added; polling loop shared with the relation waiter via `pollForVersions`. |
+| `docs/postgres-backend.md` | Shareable-diff URLs documented for entities and relations. |
+
+**Deviations from plan:** none material. Docs landed in
+`docs/postgres-backend.md` rather than `docs/data-entry.md` — that's where the
+history feature is actually documented (`data-entry.md` never mentions it), so
+the new text sits directly under the paragraph describing the history UI.
+
+## Test Quality
+
+- [x] Using fixture builders or factories for test data
+- [x] No hardcoded values in assertions when object is in scope
+- [x] Only specifying values that matter for the test
+- [x] Interpolated values constructed from objects, not hardcoded
+- [x] Property comparisons use original object, not hardcoded strings
+
+E2E entity ids come from the server-assigned `e.id` (features use sequential
+ids, so a literal `FEAT-001` would be fragile) via a `featureWithHistory(api,
+title, versions)` helper that also waits out the async capture sweep. Unit tests
+are `it.each`-tabulated for the 14 malformed-input cases.
+
+## Manual Verification
+
+- [x] Feature manually tested end-to-end
+- [x] Each acceptance criterion verified with test scenario from planning
+- [x] Edge cases manually verified
+
+**Verification Evidence:**
+
+Executed against a real PostgreSQL backend (`rela-server-postgres` built from
+this branch, `RELA_E2E_DATABASE_URL` + the CI sweep intervals), not mocks.
+
+| AC | Result | Evidence |
+|---|---|---|
+| 1 deep link | PASS | e2e "deep link selects the pair…" — `?base=1&target=2` yields select values `1`/`2`, caption `v1 → v2`, timeline row 1 `.selected`, no interaction. |
+| 2 writes URL | PASS | e2e asserts URL after dropdown change, timeline click (`base=2`), and swap (`3`/`2`); unit tests assert the `router.replace` payload. |
+| 3 reload | PASS | e2e picks `1`/`3`, reloads, pair survives. |
+| 4 `current` round-trips | PASS | Unit: parses to the sentinel, serializes back unchanged, never coerced to a number. e2e: bare URL publishes `target=current`. |
+| 5 bare URL = today's defaults | PASS | e2e: bare URL → `base=3&target=current` (newest→current) and the URL gains explicit params. |
+| 6 bad params degrade | PASS | e2e `?base=999&target=nonsense` → defaults, no `.error-state`. Unit: 14 cases incl. `abc`, `-1`, `0`, `1.5`, `1e2`, `999`, `../../etc/passwd`, `<script>`, arrays, empty. |
+| 7 no history spam | PASS | Unit asserts `replace` called, `push` never. |
+| 8 restore resets | PASS | `load(false)` on the restore path; pre-existing relation-history restore e2e still passes. |
+
+Plus an unplanned AC: selection writes **merge** into the query — e2e asserts a
+`?return_to=/list/features` survives a selection change.
+
+**Mutation-tested the tests.** Rather than trust green, I injected the exact
+regression the plan flagged as highest-risk (numeric side returned as a *string*
+— the `v-model` type trap) and confirmed both layers fail: 8 unit tests red, and
+the e2e deep-link test red on the timeline-highlight assertion. Then reverted
+and re-confirmed green. The tests detect the failure they were written for
+rather than passing vacuously.
+
+**Full suites:** frontend unit `1423 passed (87 files)`; e2e `238 passed`
+(includes the 2 pre-existing relation-history tests and the whole wizard suite —
+the closest sibling of this URL-sync pattern — so no regression). `npm run
+typecheck` clean in both projects; `npm run lint` 0 errors in both;
+`markdownlint` clean on the changed doc; prettier clean on all changed files
+(the repo's 123 pre-existing format warnings are untouched and none are mine).
+
+## Quality
+
+- [x] Code follows project patterns (check similar code)
+- [x] Checked for DRY opportunities
+- [x] No security issues introduced
+- [x] No silent failures (errors logged AND returned)
+- [x] No debug code left behind
+
+**DRY:** the composable exists precisely so the ~40 lines of sync logic aren't
+duplicated across two already-near-duplicate views. Two further extractions
+during implementation: `defaultSelection()` in the relation view (the default
+pair is needed both by `defaults()` and by the post-restore reset — inlining it
+twice would let them drift), and `pollForVersions` in `fixtures.ts` (the new
+entity waiter would otherwise have been a verbatim copy of the relation one).
+
+**Security:** the allowlist is the load-bearing control — a side is accepted
+only if it is `current` or an ordinal the *server returned*, so a crafted value
+never reaches `getVersion()` or the DOM. Explicitly unit-tested with traversal
+and script-tag payloads. No new authorization surface: the params only choose
+among versions the caller could already read, and the read gate (entity
+visibility; relations gated on both endpoints) is untouched server-side.
+
+**Two defects found and fixed during implementation**, both caught by tests
+rather than review:
+
+1. *Spurious recompute on unrelated navigation.* The route watcher's getter
+returned a fresh array `[base, target]` each run, so Vue's reference comparison
+fired it on any query change — a `?q=` edit elsewhere would re-diff. Fixed by
+watching a joined string; the failing unit test ("ignores changes to unrelated
+query params") now pins it.
+2. *Wrong route segment in the new e2e spec* — used the plural (`features`)
+where the SPA route takes the singular (`feature`), producing "Entity not
+found". Caught by actually running the suite against postgres.

--- a/tickets/entities/planning-checklists/PLAN-MWQHUZ.md
+++ b/tickets/entities/planning-checklists/PLAN-MWQHUZ.md
@@ -1,0 +1,414 @@
+---
+id: PLAN-MWQHUZ
+type: planning-checklist
+title: 'Planning: History/diff views: put selected versions in the URL so a diff is shareable'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Understanding
+
+- [x] Problem/requirements clearly understood
+- [x] Scope defined (what's in/out documented below)
+- [x] Acceptance criteria documented with specific test scenarios
+
+The two history views keep the compared version pair in local refs (`baseSel` /
+`targetSel`, `type Side = number | 'current'`) and never touch the URL. A user
+looking at an interesting diff has no way to hand that diff to a colleague,
+bookmark it, or get it back after a reload.
+
+**User decisions (asked 2026-07-27):**
+
+1. **Query params, not path params.** `?base=&target=` on the existing routes.
+Path segments would need new route patterns plus an optional-segment scheme on
+both routes, for no user-visible gain, and would sit awkwardly beside the
+existing `return_to` / `from` query conventions.
+2. **`current` stays live-relative.** A shared `?base=3&target=current` link
+means "what changed since v3", evaluated against the entity as it is when the
+recipient opens it — the same reading the sender had on screen. No
+resolve-on-copy, no pinning, no copy-link button.
+
+**Scope:**
+
+IN:
+
+- `HistoryView.vue` (entity) and `RelationHistoryView.vue` (relation): seed
+`baseSel`/`targetSel` from `?base=` / `?target=`, write them back on every
+selection change, and react to external navigation (back/forward, deep link).
+- A shared composable for the parse/serialize/echo-guard logic, since the two
+views would otherwise carry an identical copy.
+- Validation of the incoming params against the loaded version list.
+- `:data-version` on the entity view's timeline rows (currently only the
+relation view has it) so an e2e page object can address rows.
+- Unit tests for the composable; e2e assertions for deep-link + reload.
+
+OUT:
+
+- A "Copy link" affordance or any pinning of `current` to an ordinal (decision 2).
+- Path-param routes (decision 1).
+- Any backend change. This is entirely frontend; the `_history` endpoints
+already accept a version ordinal and need nothing new.
+- Making `goBack()` round-trip `return_to` (a real gap noted during research,
+but pre-existing and unrelated — separate ticket if wanted).
+- Unifying the two near-duplicate views. Tempting, but a much larger refactor
+than this ticket, and doing it here would bury the URL change.
+
+**Acceptance Criteria:**
+
+1. **Deep link selects the pair.** Opening
+`/history/<type>/<id>?base=2&target=5` renders the v2 → v5 diff, with both
+dropdowns showing those versions and the timeline highlighting v2 — without the
+user touching a control. *Test:* e2e navigates directly to the URL, asserts
+`.compare-select` values and the `.compare-caption` text.
+2. **Selection writes the URL.** Changing either dropdown, clicking a timeline
+row, or hitting swap updates `?base=`/`?target=` to match. *Test:* unit test on
+the composable asserts `router.replace` payload; e2e asserts `page.url()` after
+a `selectOption`.
+3. **Reload is stable.** Reloading any history URL reproduces the same diff
+rather than resetting to defaults. *Test:* e2e picks a non-default pair,
+reloads, asserts the pair survived.
+4. **`current` round-trips.** `?target=current` is preserved verbatim as the
+sentinel (not coerced to a number), and the diff is against the live entity.
+*Test:* unit test for parse/serialize of the sentinel; e2e asserts the caption
+reads `current` (entity view) / `latest` (relation view).
+5. **No params = today's behaviour.** A bare `/history/<type>/<id>` still opens
+on the existing defaults (entity: newest → current; relation: second-newest →
+newest) and writes those defaults to the URL once loaded. *Test:* e2e opens the
+bare URL, asserts the default caption.
+6. **Bad params degrade to defaults, silently and safely.** `?base=999`,
+`?base=abc`, `?base=-1`, `?base[]=1&base[]=2`, `?base=3` on an entity with 2
+versions — all fall back to the default pair. No crash, no error toast, no
+failed fetch. *Test:* unit tests, one case per malformed input.
+7. **No history spam.** Changing selections uses `router.replace`, so the
+browser Back button leaves the history view rather than stepping back through
+every dropdown fiddle. *Test:* unit test asserts `replace` (not `push`) is
+called.
+8. **Restore still works.** After a restore the version list grows; the view
+re-seeds to fresh defaults and the URL follows. *Test:* covered by extending the
+existing relation-history e2e restore test.
+
+## Research
+
+- [x] For larger features: run `/research` to create a structured research doc
+- [x] Searched for existing libraries that solve this problem
+- [x] Checked codebase for similar patterns or reusable code
+- [x] Looked for reference implementations in other projects
+- [x] Reviewed relevant rela concepts for prior art
+
+**Research Doc:** N/A — small, well-bounded frontend change with three existing
+in-repo precedents. A `/research` doc would restate what the codebase survey
+below already settled.
+
+**Existing Solutions:**
+
+No library needed. `vue-router` already provides everything (`route.query` +
+`router.replace`), and the repo has a documented house pattern for exactly this
+— **seed / replace / echo-guard**:
+
+- `frontend/src/composables/useUrlFilterSync.ts:1-120` — the canonical
+implementation, used by `EntityList.vue:178`. Its header comment (`:1-22`)
+states the three rules: seed synchronously at setup so the first fetch already
+sees URL state; route all writes through one function that uses `router.replace`
+and records a signature; a `watch(() => route.query)` that skips its own echo by
+comparing that signature.
+- `frontend/src/composables/useFormWizard.ts:182-224` — **the closest analogue,
+and the one to copy.** It syncs a single scalar `?step=N`, with a scalar
+`lastWritten` echo guard (`:205-212`), a `clamp()` for out-of-range values
+(`:184-188`), and — critically — a re-runnable `seedFromUrl()` (`:197-203`)
+because *the valid range isn't known until async data lands*. That is exactly
+our situation: `?base=7` can't be validated until `listVersions` resolves. Its
+own comment even says it mirrors `useUrlFilterSync`'s pattern.
+- `frontend/src/components/entity/DocumentsPanel.vue:69-83` — lightest variant
+(`?doc=`), seeds via `watch(..., {immediate:true})`, guards with a plain
+equality check. Its `:79-81` comment documents the replace-over-push rationale.
+- `frontend/src/views/SearchView.vue:130-142` — an **older hand-rolled variant
+with no echo guard that also clobbers the whole query object**. Explicitly not
+the model to follow; noted so a reviewer doesn't point at it as precedent.
+
+Also relevant: `frontend/src/composables/useScopeNavigation.ts` and
+`useBackTarget.ts:34-49` already read `from` / `q` / `return_to` off
+`route.query` on entity pages. Our writes must **merge** into `route.query`
+rather than replace it, or we'd break `return_to` round-tripping for anyone who
+later wires it through to the history view.
+
+Prior art in the graph: `FEAT-5UYW8F` (pgstore content versioning) and
+`TKT-SCXHUL` (relation-history e2e) — this ticket is a UX follow-up on that
+feature, not new capability.
+
+## Approach
+
+- [x] Technical approach chosen and documented
+- [x] Approach builds on existing patterns (not reinventing)
+- [x] Alternatives considered (document why rejected)
+- [x] Dependencies identified (packages, APIs, types)
+
+**Technical Approach:**
+
+Add one composable, `useVersionSelectionSync`, and wire it into both views. It
+owns the `Side` type's URL representation and nothing else — the views keep
+owning fetching, diffing, and restore.
+
+```ts
+// frontend/src/composables/useVersionSelectionSync.ts
+export type Side = number | 'current'
+
+export interface UseVersionSelectionSyncOptions {
+  // Ordinals that actually exist, supplied by the view once listVersions
+  // resolves. Empty until then, which is why seeding must be re-runnable.
+  validVersions: () => number[]
+  // The view's default pair — the two views disagree (entity: newest→current,
+  // relation: second-newest→newest), so the composable must not hardcode one.
+  defaults: () => { base: Side; target: Side }
+}
+```
+
+Returned surface: `base`, `target` (refs the views bind with `v-model`),
+`seedFromUrl()`, `write(base, target)`, and `onExternalChange(cb)` — or, more
+simply, the composable owns the refs and the view passes a `recompute` callback
+to run whenever the pair changes from any source. I'll settle the exact shape
+during implementation; the constraint is that **every** mutation path (dropdown,
+timeline click, swap, external nav) converges on one write function and one
+recompute, so no path can update the URL without recomputing the diff or vice
+versa.
+
+Parse rules (the fiddly part, and the source of most of the edge cases):
+
+- `'current'` → the sentinel string, preserved as-is. Note the type asymmetry
+this guards: the `<option value="current">` is a **string** while version
+options bind `:value="m.version"` (a **number**). Parsing `?base=3` to the
+string `"3"` would make `v-model` silently fail to match any option — the
+dropdown would render blank. So a numeric param must be coerced with `Number()`,
+not left as a string.
+- A string of digits → `Number()`, then accepted **only if present in
+`validVersions()`**. This is an allowlist against the real version list, not a
+range check — it rejects `999`, `-1`, `0`, `1.5`, and `abc` in one step.
+- An array (`?base=1&base=2`, which vue-router surfaces as `string[]`) → take
+the last element, matching `useUrlFilterSync`'s `readQParam` (`:41-48`).
+- Anything else, or a value not in the allowlist → fall back to that side's
+default.
+
+Seeding is **two-phase**, following `useFormWizard`:
+
+1. Synchronously at setup, so a deep link is honoured before first paint where
+possible. At this point `validVersions()` is empty, so this pass only captures
+the raw intent.
+2. Re-run inside `load()` immediately after `listVersions` resolves and the
+defaults are computed, now with a populated allowlist. This is the pass that
+actually decides the pair.
+
+Then write the resolved pair back (`router.replace`), so a bare URL becomes an
+explicit shareable one and AC5 holds.
+
+The echo guard is a scalar signature (`` `${base}|${target}` ``) compared in the
+`watch(() => [route.query.base, route.query.target]) ` handler, exactly as
+`useFormWizard:205-223 ` does.
+
+Two details that must not be missed:
+
+- **`load() ` runs on mount and again after a restore** (`HistoryView.vue:166 `).
+Re-seeding from the URL after a restore would resurrect a stale pair against a
+changed version list, so the post-restore path must reset to fresh defaults
+rather than re-read the URL (AC8). Cleanest way: give `load() ` a `seedFromUrl:
+boolean ` parameter — `true ` from `onMounted `, `false ` from `restore `.
+- **The relation view's `sideState ` maps `'current' ` to the newest snapshot**
+(`RelationHistoryView.vue:88 `), and labels it `latest ` (`:45 `) where the
+entity view says `current ` (`HistoryView.vue:44 `). The URL token stays
+`current ` in both for consistency; only the display label differs. Worth a
+code comment, since it looks like an inconsistency otherwise.
+
+**Files to modify:**
+
+| File | Change |
+|---|---|
+| `frontend/src/composables/useVersionSelectionSync.ts ` | **New.** Parse/serialize/seed/write/echo-guard. |
+| `frontend/src/composables/useVersionSelectionSync.test.ts ` | **New.** Unit tests (model: `useUrlFilterSync.test.ts `). |
+| `frontend/src/views/HistoryView.vue ` | Replace local `baseSel `/`targetSel ` with the composable; `load(seedFromUrl) `; route every mutation through the write path; add `:data-version ` to `.timeline-item ` (`:217-222 `). |
+| `frontend/src/views/RelationHistoryView.vue ` | Same, minus `:data-version ` (already present at `:193 `). |
+| `e2e/pages/history.page.ts ` | **New.** Entity-history page object (only the relation one exists). |
+| `e2e/pages/relation-history.page.ts ` | Add URL/deep-link helpers. |
+| `e2e/pages/index.ts ` | Export the new page object. |
+| `e2e/tests/history-url-params.spec.ts ` | **New.** Deep-link + reload + URL-write, postgres-gated. |
+| `docs/data-entry.md ` | Document the shareable-diff URL params. |
+
+**Alternatives considered:**
+
+- **Path params** — rejected by the user (decision 1); would need new route
+patterns and an optional-segment scheme for zero gain.
+- **A single combined param** (`?diff=3..current `, git-style) — compact and
+rather elegant, but it invents a parse format where two plain params need none,
+and it doesn't compose with `buildQueryWithFilters `-style merging. Rejected as
+cleverness.
+- **Inline the sync in both views** (no composable) — ~40 near-identical lines
+duplicated across two files that are *already* near-duplicates of each other.
+`npm run dupes ` (jscpd) would likely flag it, and the two copies would drift.
+- **Resolve `current ` to an ordinal on load** so links are always frozen —
+rejected by the user (decision 2); also changes what the existing dropdown
+means.
+
+**Dependencies:** none new. `vue `, `vue-router `, existing `@/api/history `.
+
+## Security Considerations
+
+- [x] Input sources identified (user input, config, external APIs)
+- [x] Input validation approach defined (allowlist preferred over blocklist)
+- [x] Security-sensitive operations identified (file access, auth, crypto)
+- [x] Error handling doesn't leak sensitive information
+
+**Input Sources & Validation:**
+
+One new untrusted input: the `base ` / `target ` query params, fully
+attacker-controlled since the whole point is that these URLs get shared.
+
+| Input | Validation | On invalid |
+|---|---|---|
+| `?base= `, `?target= ` | Allowlist: the literal `current `, or a number present in the version list returned by the server. `string[] ` → last element. | Silent fallback to that side's default. No toast, no error state. |
+
+The allowlist is the important property: the param is **never** interpolated
+into a request path before being matched against a server-supplied ordinal. A
+crafted `?base=../../foo ` or `?base=<script> ` fails the `validVersions() `
+membership test and is discarded, so it never reaches `getVersion(type, id, s)
+` and never reaches the DOM. Validating against the real list rather than a
+numeric range also means a user can't probe for versions outside their lineage.
+
+**Security-Sensitive Operations:**
+
+- **No new authorization surface.** The params choose *among versions the server
+already returned to this user* via `listVersions `. Read gating stays entirely
+server-side: entity history through the visibility read path, relation history
+gated on **both** endpoints (FROM ∧ TO) per the root `CLAUDE.md `. A shared
+link is not a capability — a recipient without read access gets the same 404/403
+they'd get without the link. Worth stating plainly because "shareable link" is
+exactly the phrase that tends to smuggle in an authorization assumption; here it
+does not.
+- **No leakage through the URL itself.** `base `/`target ` are small integers or
+the word `current ` — no content, no principal, no property values. A history
+URL pasted into a chat reveals the entity id and type, which the existing
+`/history/:type/:id ` route already did.
+- **Error handling unchanged.** Bad params produce a default view, not a
+message; nothing echoes the raw param back into the page (no reflected-XSS
+vector, and Vue escapes text interpolation regardless).
+- Unchanged: 501 → "not available for this deployment", which leaks only the
+build flavour, as today.
+
+## Test Plan
+
+- [x] Test scenarios documented for each acceptance criterion
+- [x] Edge cases identified and documented
+- [x] Negative test cases defined (invalid input, error conditions)
+- [x] Integration test approach defined (not just unit tests)
+
+**Test Scenarios:**
+
+| AC | Level | Test |
+|---|---|---|
+| 1 deep link | e2e + unit | Navigate to `?base=2&target=5 `; assert both `.compare-select ` values, the `.compare-caption `, and the highlighted timeline row. Unit: seeding with a populated allowlist yields the pair. |
+| 2 writes URL | unit + e2e | Unit: assert `router.replace ` called with the merged query. e2e: `selectOption ` then assert `page.url() `. |
+| 3 reload | e2e | Select a non-default pair, `page.reload() `, assert the pair survived. |
+| 4 `current ` | unit + e2e | Unit: `'current' ` parses to the sentinel and serializes back unchanged (and is **not** coerced to a number). e2e: caption reads `current ` / `latest `. |
+| 5 bare URL | e2e | Open bare URL; assert default caption; assert the URL gains explicit params after load. |
+| 6 bad params | unit | One case per malformed input (table below). |
+| 7 no spam | unit | Assert `replace ` called, `push ` not called. |
+| 8 restore | e2e | Extend the existing relation-history restore test: after restore the URL reflects fresh defaults, not the pre-restore pair. |
+
+Unit tests follow `useUrlFilterSync.test.ts:1-46 `: mock `vue-router ` with a
+`reactive({query}) ` route and a `mockReplace ` that writes back into
+`mockRoute.query ` (so the watcher genuinely fires), and run the composable in
+a per-test `effectScope() ` so watchers are torn down.
+
+E2E lives in `e2e/tests/ `, uses the `postgresTest ` fixture, and **skips
+unless `RELA_E2E_DATABASE_URL ` is set** — history is pgstore-only, exactly as
+`e2e/tests/relation-history.spec.ts:19-22 ` does.
+
+**Edge Cases:**
+
+| Case | Expected |
+|---|---|
+| `?base= ` (empty) | Default for that side. |
+| `?base=abc ` | Default. |
+| `?base=-1 `, `?base=0 ` | Default (not in allowlist; ordinals are 1-based). |
+| `?base=1.5 ` | Default. |
+| `?base=999 ` (beyond the list) | Default — **no fetch attempted**. |
+| `?base=3 ` where the entity has 2 versions | Default. Same path as above; called out because it's the realistic case — a link shared before a lineage was purged or from a different entity. |
+| `?base=1&base=2 ` (array) | Last wins (`2 `), matching `readQParam `. |
+| Only one param supplied | That side seeds, the other takes its default. |
+| `?base=2&target=2 ` | Allowed — an empty diff is a legitimate thing to link to. |
+| Entity with **zero** versions | Existing "No versions recorded yet." state; params ignored; no write to the URL (nothing meaningful to write). |
+| `?base=current&target=current ` | Allowed; empty diff. |
+| Rapid dropdown changes | Existing `recomputeSeq ` guard (`HistoryView.vue:124-135 `) still drops stale results; the URL reflects the last selection. Must verify the guard survives the refactor. |
+| Back/forward between two pairs | Watcher re-seeds and recomputes; echo guard prevents a write loop. |
+| Restore while a non-default pair is selected | Fresh defaults (AC8), not a stale pair against a changed list. |
+| Params present but the deployment returns 501 | Unsupported state, params ignored — no crash. |
+
+**Negative Tests:**
+
+Every malformed input above must fall back **silently**: no thrown error, no
+`uiStore.showToast('error', ...) `, no request issued with an invalid ordinal.
+A test asserts `getVersion ` is never called with an out-of-list value — that's
+the assertion that actually pins the allowlist behaviour rather than just its
+symptom.
+
+Also negative-tested: the write path must not clobber unrelated query params
+(assert an existing `?return_to=x ` survives a selection change).
+
+## Risk Assessment
+
+- [x] Technical risks assessed with mitigations
+- [x] Security risks assessed (see Security Considerations)
+- [x] Effort estimated (xs/s/m/l/xl)
+
+**Risks:**
+
+| Risk | Likelihood | Mitigation |
+|---|---|---|
+| **Infinite loop** — write → watcher → write. The classic failure of this pattern. | Medium | Scalar signature echo guard, copied from `useFormWizard:205-223 `; explicit unit test asserting `replace ` is called once per selection change. |
+| **`v-model ` type mismatch** — parsing `"3" ` as a string leaves the dropdown blank because options bind numbers. Would look like "deep links just don't work". | Medium | Coerce with `Number() `; unit test asserts `typeof base === 'number' `; e2e asserts the visible select value, which is what would actually catch it. |
+| **Re-seed after restore resurrects a stale pair.** | Medium | `load(seedFromUrl: boolean) `; AC8 e2e test. |
+| **Regressing the `recomputeSeq ` stale-diff guard** while rerouting mutation paths. | Low-Medium | Keep the guard untouched; every path still funnels into the existing `recompute() `. |
+| **Two views drift** — one gets the fix properly, the other approximately. | Medium | Shared composable rather than two copies; run both view's e2e. |
+| Query-param collision with `return_to ` / `from `. | Low | Merge into `route.query ` (never replace it); explicit negative test. |
+| Router file is excluded from v8 coverage (`router/index.ts:1 `) | Low | No router change needed under decision 1 — this risk is now moot, noted for the record. |
+| Frontend coverage floor | Low | New composable ships with its own unit tests; `FEAT-wzwp ` ratchet applies. |
+
+**Effort:** `s ` — one small composable, two view edits, a page object, and
+tests. The estimate holds mainly because the pattern is already established
+three times over in this codebase; the genuine work is the edge-case handling
+around the async allowlist, not the sync itself.
+
+## Documentation Planning
+
+- [x] User-facing docs identified (skip if internal refactor)
+- [x] Docs-checklist will be created when entering implementation
+
+**Documentation Impact:**
+
+- [x] `docs/data-entry.md ` — document that history/diff views accept
+`?base= ` / `?target= ` and that such links are shareable, including the
+live-relative meaning of `current ` (decision 2) so nobody expects a frozen
+diff.
+- [ ] ~~`docs/metamodel.md `~~ (N/A: no metamodel change)
+- [ ] ~~`docs/cli-reference.md `~~ (N/A: no CLI change)
+- [ ] ~~`CLAUDE.md `~~ (N/A: uses the existing URL-sync pattern rather than
+introducing one; `frontend/CLAUDE.md ` already covers composables)
+- [ ] ~~`README.md `~~ (N/A: not project-level)
+
+## Design Review
+
+- [x] ~~Run `/design-review` before starting implementation~~ (N/A: the plan was
+      presented to the user and explicitly approved ("looks good; continue")
+      before any code was written, and the two decisions that actually shaped
+      the design — query-vs-path params, and whether `current` pins — were put
+      to the user directly rather than inferred. For an `s`-sized change that
+      reuses an established in-repo pattern with three precedents, a separate
+      design-review pass would have re-litigated settled ground.)
+- [x] ~~All critical/significant findings addressed in plan~~ (N/A: no design
+      review run — see above)
+
+**Design Review Findings:** None — skipped, see above. The design was instead
+scrutinized at code-review time by `cranky-code-reviewer`, which independently
+re-implemented the control flow to attack the echo guard and found no critical
+issues; its four findings are recorded as RR-XM367L, RR-L4M1WK, RR-1QWV9S and
+RR-W7L33A, all addressed. Notably RR-XM367L was a genuine *design* defect (the
+two views' default pairs diverging in meaning) that a design review might have
+caught earlier — worth remembering next time a change touches two parallel
+views.

--- a/tickets/entities/review-checklists/REV-FTHW8Q.md
+++ b/tickets/entities/review-checklists/REV-FTHW8Q.md
@@ -1,0 +1,93 @@
+---
+id: REV-FTHW8Q
+type: review-checklist
+title: 'Review: History/diff views: put selected versions in the URL so a diff is shareable'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Automated Checks
+
+- [x] Frontend unit tests pass — `1429 passed (87 files)`
+- [x] E2E tests pass — `239 passed` against real PostgreSQL
+- [x] Typecheck clean — `vue-tsc` (frontend) and `tsc` (e2e)
+- [x] Lint clean — 0 errors in both projects
+- [x] Markdown lint clean on the changed doc
+- [x] Prettier clean on all changed files
+- [x] ~~`just test` / `just coverage-check` (Go)~~ (N/A: no Go source changed —
+the only Go-adjacent edit is the e2e TypeScript fixture)
+
+Verified against a `rela-server-postgres` binary built from this branch, with
+the CI sweep intervals — not mocks. The e2e run includes the whole wizard suite
+(`?step=N`, the closest sibling of this URL-sync pattern) and the two
+pre-existing relation-history tests, so regression coverage is real.
+
+## Code Review
+
+- [x] `cranky-code-reviewer` invoked
+- [x] Findings recorded as `review-response` entities
+- [x] All critical/significant findings addressed
+
+The reviewer independently re-implemented both views' control flow and attacked
+the interleavings the plan flagged as risky — external nav between
+`seedFromUrl()` and `publish()`, a slow load's publish racing a newer nav, rapid
+selects, back-button restores. It found **no critical issues** and confirmed the
+echo guard, the `recomputeSeq` interaction, and the array-getter fix are sound.
+
+| ID | Severity | Finding | Status |
+|---|---|---|---|
+| RR-XM367L | significant | Relation bare URL published two frozen ordinals while the entity view published a live-relative link | addressed |
+| RR-L4M1WK | significant | Empty version history left bogus params in the URL unvalidated | addressed |
+| RR-1QWV9S | significant | `select()` did no type coercion — the `Side` invariant rested on a template binding | addressed |
+| RR-W7L33A | minor | `publish()` passthrough; duplicated defaults in `HistoryView`; colliding e2e waiter names | addressed |
+
+**Review summary.** RR-XM367L was the one users would actually have hit: the
+headline feature is "share this diff", and it silently meant two different
+things depending on which history you were looking at. The relation view's
+default published `?base=2&target=3` (frozen) where the entity view published
+`?base=3&target=current` (live) — so an otherwise-identical link would stop
+meaning "the most recent edit" as soon as a new version landed, for relations
+only. Fixed by returning the sentinel from `defaultSelection()`; the plumbing
+(`sideState` resolving `current` to the newest version) already existed.
+
+RR-1QWV9S is the kind of finding worth taking seriously even though nothing was
+broken: the mutation test I ran proved the *current* wiring correct, not the
+*next* caller. `coerceSide` now enforces the invariant on every write into the
+refs, so the guarantee lives with the type rather than in a Vue template two
+files away.
+
+Fixes added 6 unit tests (39 → 45) and 1 e2e test (5 → 6 in this spec), each
+pinning a specific fixed behaviour rather than restating the change.
+
+## Acceptance Verification
+
+Each criterion from PLAN-MWQHUZ, verified against a real postgres backend:
+
+| AC | Verdict | Evidence |
+|---|---|---|
+| 1 Deep link selects the pair | PASS | `?base=1&target=2` → select values `1`/`2`, caption `v1 → v2`, timeline row 1 highlighted, no interaction |
+| 2 Selection writes the URL | PASS | Asserted after dropdown change, timeline click, and swap; unit tests assert the `replace` payload |
+| 3 Reload is stable | PASS | Non-default pair `1`/`3` survives `page.reload()` |
+| 4 `current` round-trips | PASS | Parses to the sentinel, serializes unchanged, never coerced to a number |
+| 5 No params = today's behaviour | PASS | Bare URL → `base=3&target=current`, then published explicitly |
+| 6 Bad params degrade silently | PASS | e2e `?base=999&target=nonsense` → defaults, no error state; 14 unit cases incl. traversal and script-tag payloads |
+| 7 No history spam | PASS | `replace` called, `push` never |
+| 8 Restore resets | PASS | `load(false)` → `resetToDefaults()`; pre-existing restore e2e still green |
+
+Two criteria emerged during the work and are also covered: selection writes
+**merge** into the query (a `?return_to=` survives), and a stale ordinal is
+**corrected** in the address bar rather than left to rot.
+
+## Documentation
+
+- [x] `docs/postgres-backend.md` — shareable-diff URLs documented for both
+entity and relation history, including the live-relative meaning of `current`
+and the fact that a shared link is not a capability (the recipient still needs
+their own read permission)
+- [x] Doc claim corrected during review — the fallback sentence now states that
+the address bar is rewritten, which is what RR-L4M1WK made true
+
+Placed in `postgres-backend.md` rather than `data-entry.md` because that is
+where the history feature is actually documented; the new text sits directly
+under the paragraph describing the history UI.

--- a/tickets/entities/review-responses/RR-1QWV9S.md
+++ b/tickets/entities/review-responses/RR-1QWV9S.md
@@ -1,0 +1,37 @@
+---
+id: RR-1QWV9S
+type: review-response
+title: select() performs no type coercion — the Side numeric invariant is enforced only by a template binding
+finding: 'parseSide() goes to deliberate trouble to return a number rather than a numeric string (useVersionSelectionSync.ts:76-87), because the <option value="current"> is a string while version options bind :value="m.version" (a number), so a string ''3'' matches no option and v-model blanks the dropdown. But select() (:140-145) writes next.base straight into the ref with no validation: select({base: ''2''}) leaves base.value === ''2'', serializes to a plausible-looking URL, and blanks the control. Today this is safe only because onBaseChange passes baseSel.value, which v-model already populated as a number — i.e. the type discipline lives in a Vue template rather than in the composable that owns the type. A leaked string IS repaired by the next seedFromUrl(), so the damage is a blanked dropdown until reload, not permanent.'
+severity: significant
+resolution: 'Fixed. Added an exported coerceSide(s) helper and applied it on every write into the refs: select(), the new resetToDefaults(), and the defaults fallback inside seedFromUrl(). The numeric invariant now lives with the type in the composable rather than depending on each caller (previously it held only because v-model happened to supply numbers from :value="m.version"). Three unit tests pin the contract: a numeric string passed to select() coerces to a number, a numeric string coming from a view''s defaults() coerces, and the ''current'' sentinel is left untouched. parseSide is unchanged — it already guaranteed this for URL-sourced values.'
+status: addressed
+---
+
+## Finding
+
+The composable owns the `Side` type and its numeric invariant, but only
+`parseSide` enforces it. `select()` is an unguarded write.
+
+```ts
+select({ base: '2' as unknown as Side })  // base.value === '2', dropdown blanks
+```
+
+## Why it matters
+
+The mutation test I ran proves the *current* wiring is correct. It does not
+prove the *next* caller will be. The invariant should live with the type, not in
+a template binding two files away.
+
+## Fix
+
+Coerce in `select()`, three lines:
+
+```ts
+function coerce(s: Side): Side {
+  return s === CURRENT ? CURRENT : Number(s)
+}
+```
+
+Plus a unit test pinning the contract (the existing e2e assertion only catches
+the current wiring).

--- a/tickets/entities/review-responses/RR-L4M1WK.md
+++ b/tickets/entities/review-responses/RR-L4M1WK.md
@@ -1,0 +1,26 @@
+---
+id: RR-L4M1WK
+type: review-response
+title: Empty version history leaves bogus ?base/?target params in the URL unvalidated
+finding: 'Both views gate the entire seed/recompute/publish block on `if (versions.length)` (HistoryView.vue:105, RelationHistoryView.vue:94). Opening /history/feature/FEAT-1?base=999&target=nonsense on an entity with no captured versions leaves those params in the address bar permanently — publishSelection() is never called. The refs correctly fall back to defaults so nothing breaks visually, but the promise that a bogus URL becomes an explicit correct one lapses exactly where the URL is most wrong. Bookmark trap: the user bookmarks it, the sweep later captures versions, and the stale params then get evaluated against a real list. docs/postgres-backend.md also makes the unconditional claim that a value naming no existing version falls back to the default — true of the view, not of the URL.'
+severity: significant
+resolution: 'Fixed in both views. The `if (versions.length)` gate now wraps only the recompute (there is nothing to diff with no versions); seeding and publishSelection() run unconditionally, so a stale or bogus param is always rewritten to the pair actually being shown. Comment at both call sites explains that the empty case is precisely when the URL is most likely wrong. Covered two ways: a unit test asserting publish() emits {base:''current'',target:''current''} when validVersions() is empty and the URL says ?base=999&target=nonsense, and an e2e test asserting an out-of-range ordinal is corrected to the default in the address bar. The docs sentence in docs/postgres-backend.md was also corrected — it now states that the address bar is rewritten to the pair being shown, so the corrected link is what gets copied.'
+status: addressed
+---
+
+## Finding
+
+`if (versions.value.length)` wraps seed + recompute + publish. With zero
+versions, `publishSelection()` never runs, so malformed params survive in the
+address bar indefinitely.
+
+## Impact
+
+Mostly cosmetic today (the refs fall back correctly, the view renders "No
+versions recorded yet."), but it is a bookmark trap: version capture is
+asynchronous, so an entity with no versions *now* may have them later, at which
+point the stale params are evaluated for real.
+
+The documentation in `docs/postgres-backend.md` states the fallback guarantee
+unconditionally, which is accurate for the rendered view and inaccurate for the
+URL.

--- a/tickets/entities/review-responses/RR-W7L33A.md
+++ b/tickets/entities/review-responses/RR-W7L33A.md
@@ -1,0 +1,25 @@
+---
+id: RR-W7L33A
+type: review-response
+title: 'Minor cleanups: publish() is a passthrough, HistoryView duplicates its defaults inline, e2e waiter names collide'
+finding: 'Three small consistency issues. (a) publish() (useVersionSelectionSync.ts:155-157) is a one-line passthrough to writeToQuery() whose docstring implies it does something extra ("without recomputing") — writeToQuery never recomputed. (b) HistoryView.vue:109-110 repeats the default pair inline in the restore branch, duplicating the expression already in defaults() at :45-46; the sibling RelationHistoryView extracted defaultSelection() precisely to avoid this. Both views'' restore branches also poke the refs directly, bypassing the composable''s write path — a resetToDefaults() on the composable would close that. (c) e2e naming: relation-history.page.ts now has both waitForTimeline (exact count) and waitForTimelineAtLeast (poll), while history.page.ts names its POLL waitForTimeline — so the same method name means different things on the two page objects.'
+severity: minor
+resolution: All three fixed. (a) publish() removed; the composable now exports writeToQuery directly as `publish`, with the 'does not recompute — select owns that' note folded into writeToQuery's own docstring, so there is no passthrough to check. (b) HistoryView gained defaultSelection(), mirroring the sibling view, so the default pair exists once; both views' restore branches now call the new resetToDefaults() on the composable instead of assigning refs directly, closing the last write path that bypassed it. Two unit tests cover resetToDefaults (ignores the URL; is side-effect free). (c) history.page.ts's poll waiter renamed waitForTimeline → waitForTimelineAtLeast to match the relation page object's semantics, with a comment noting why; all call sites updated.
+status: addressed
+---
+
+## Finding
+
+Three unrelated minor issues, grouped because each is a small consistency fix.
+
+1. **`publish()` adds nothing** over `writeToQuery()` and its docstring implies
+otherwise, forcing the reader to check.
+2. **`HistoryView` duplicates its default pair** inline in the restore branch,
+while the sibling view extracted `defaultSelection()` for exactly this reason.
+Both restore branches also assign refs directly, bypassing the composable's own
+write path.
+3. **E2E waiter names collide across page objects** — `waitForTimeline` means
+"exact count" on one and "at least" on the other.
+
+None of these can produce a wrong result today; they're all "someone picks the
+wrong one later" risks.

--- a/tickets/entities/review-responses/RR-XM367L.md
+++ b/tickets/entities/review-responses/RR-XM367L.md
@@ -1,0 +1,33 @@
+---
+id: RR-XM367L
+type: review-response
+title: Relation view's bare URL publishes two frozen ordinals while the entity view publishes a live-relative link
+finding: 'RelationHistoryView.defaultSelection() returns {base: secondNewest, target: newest} — two concrete ordinals. HistoryView returns {base: newest, target: ''current''}. So opening a bare URL and copying the address bar yields a live-relative link for entities and a frozen one for relations. The relation default''s own stated intent ("what the most recent edit changed", RelationHistoryView.vue:46) is live-relative by nature, so it stops meaning that the moment a new version lands. sideState() already resolves ''current'' to the newest version (RelationHistoryView.vue:123), so the plumbing exists. Also causes a single-version relation history to publish ?base=1&target=1 (v1 diffed against itself).'
+severity: significant
+resolution: 'Fixed. RelationHistoryView.defaultSelection() now returns {base: secondNewest, target: ''current''} — the sentinel, not the newest ordinal — so a bare relation URL publishes ?base=N&target=current, matching the entity view''s live-relative shape. sideState() already resolved ''current'' to the newest version, so no other plumbing changed. The <2-versions case now returns {current, current} instead of publishing ?base=1&target=1 (v1 against itself). Comment added at the function explaining why the sentinel is load-bearing here. Covered by a new e2e assertion: after loading a bare relation-history URL, expectUrlSelection(1, ''current'').'
+status: addressed
+---
+
+## Finding
+
+The headline feature is "share this diff", and it silently means two different
+things depending on which history view produced the link.
+
+| View | Bare URL publishes |
+|---|---|
+| Entity | `?base=3&target=current` (live-relative) |
+| Relation | `?base=2&target=3` (frozen) |
+
+The user's decision was that `current` stays live-relative. The entity view
+honours it; the relation view does not, because `defaultSelection()`
+(`RelationHistoryView.vue:52-59`) reaches for an ordinal where the sentinel is
+the honest answer.
+
+This is NOT the `current`-vs-`latest` labelling difference, which is deliberate
+and documented — it's the default pair itself diverging.
+
+## Impact
+
+A relation link shared as "the most recent edit" stops meaning that as soon as a
+fourth version is captured, silently. A single-version relation history
+publishes `?base=1&target=1` — v1 diffed against itself.

--- a/tickets/entities/tickets/TKT-YOHC3N.md
+++ b/tickets/entities/tickets/TKT-YOHC3N.md
@@ -1,0 +1,33 @@
+---
+id: TKT-YOHC3N
+type: ticket
+title: 'History/diff views: put selected versions in the URL so a diff is shareable'
+kind: enhancement
+priority: medium
+effort: s
+status: done
+---
+
+## Problem
+
+`HistoryView.vue` and `RelationHistoryView.vue` keep the compared versions in
+local refs (`baseSel` / `targetSel`, typed `number | 'current'`). Nothing is
+read from or written to the URL, so:
+
+- A user cannot share a link to a specific diff ("look at v3 → v7").
+- Reloading `/history/features/FEAT-1` silently resets to the default pair.
+- Browser back/forward does not move between compared versions.
+
+Every other stateful surface in the SPA already mirrors its state into the URL
+(`useUrlFilterSync`, `useFormWizard`'s `?step=N`, `DocumentsPanel`'s `?doc=`),
+so the history views are the outlier.
+
+## Scope
+
+Sync the two selected sides to the URL for **both** history views, following the
+established seed / `router.replace` / echo-guard pattern.
+
+## Origin
+
+User request: "history / diff view should use query/path params for the versions
+so a user can share a link to a specific diff".

--- a/tickets/relations/TKT-YOHC3N--affects--data-entry-ui.md
+++ b/tickets/relations/TKT-YOHC3N--affects--data-entry-ui.md
@@ -1,0 +1,5 @@
+---
+from: TKT-YOHC3N
+relation: affects
+to: data-entry-ui
+---

--- a/tickets/relations/TKT-YOHC3N--has-docs--DOCS-U2GMHT.md
+++ b/tickets/relations/TKT-YOHC3N--has-docs--DOCS-U2GMHT.md
@@ -1,0 +1,5 @@
+---
+from: TKT-YOHC3N
+relation: has-docs
+to: DOCS-U2GMHT
+---

--- a/tickets/relations/TKT-YOHC3N--has-implementation--IMPL-PQ0TUL.md
+++ b/tickets/relations/TKT-YOHC3N--has-implementation--IMPL-PQ0TUL.md
@@ -1,0 +1,5 @@
+---
+from: TKT-YOHC3N
+relation: has-implementation
+to: IMPL-PQ0TUL
+---

--- a/tickets/relations/TKT-YOHC3N--has-planning--PLAN-MWQHUZ.md
+++ b/tickets/relations/TKT-YOHC3N--has-planning--PLAN-MWQHUZ.md
@@ -1,0 +1,5 @@
+---
+from: TKT-YOHC3N
+relation: has-planning
+to: PLAN-MWQHUZ
+---

--- a/tickets/relations/TKT-YOHC3N--has-review--REV-FTHW8Q.md
+++ b/tickets/relations/TKT-YOHC3N--has-review--REV-FTHW8Q.md
@@ -1,0 +1,5 @@
+---
+from: TKT-YOHC3N
+relation: has-review
+to: REV-FTHW8Q
+---

--- a/tickets/relations/TKT-YOHC3N--has-review-response--RR-1QWV9S.md
+++ b/tickets/relations/TKT-YOHC3N--has-review-response--RR-1QWV9S.md
@@ -1,0 +1,5 @@
+---
+from: TKT-YOHC3N
+relation: has-review-response
+to: RR-1QWV9S
+---

--- a/tickets/relations/TKT-YOHC3N--has-review-response--RR-L4M1WK.md
+++ b/tickets/relations/TKT-YOHC3N--has-review-response--RR-L4M1WK.md
@@ -1,0 +1,5 @@
+---
+from: TKT-YOHC3N
+relation: has-review-response
+to: RR-L4M1WK
+---

--- a/tickets/relations/TKT-YOHC3N--has-review-response--RR-W7L33A.md
+++ b/tickets/relations/TKT-YOHC3N--has-review-response--RR-W7L33A.md
@@ -1,0 +1,5 @@
+---
+from: TKT-YOHC3N
+relation: has-review-response
+to: RR-W7L33A
+---

--- a/tickets/relations/TKT-YOHC3N--has-review-response--RR-XM367L.md
+++ b/tickets/relations/TKT-YOHC3N--has-review-response--RR-XM367L.md
@@ -1,0 +1,5 @@
+---
+from: TKT-YOHC3N
+relation: has-review-response
+to: RR-XM367L
+---

--- a/tickets/relations/TKT-YOHC3N--implements--FEAT-5UYW8F.md
+++ b/tickets/relations/TKT-YOHC3N--implements--FEAT-5UYW8F.md
@@ -1,0 +1,5 @@
+---
+from: TKT-YOHC3N
+relation: implements
+to: FEAT-5UYW8F
+---


### PR DESCRIPTION
## What

The entity and relation history views held the compared version pair in local
component state, so a specific diff could not be linked, bookmarked, or restored
after a reload. They were the only stateful surface in the SPA not mirrored into
the URL.

The pair now lives in `?base=` / `?target=`:

```text
/history/feature/FEAT-42?base=3&target=7          # v3 → v7
/history/feature/FEAT-42?base=3&target=current    # what changed since v3
/relation-history/ticket/TKT-42/blocks/TKT-99?base=1&target=3
```

Two product decisions, both made explicitly by the requester:

1. **Query params, not path params** — additive, no router change, composes with
   the existing `return_to` / `from` conventions.
2. **`current` stays live-relative** — a shared `?target=current` link means
   "what changed since v3", evaluated when the recipient opens it. Link two
   ordinals for a frozen diff.

## How

One composable, `useVersionSelectionSync`, wired into both views, following the
house seed/replace/echo pattern (`useUrlFilterSync`, `useFormWizard`'s
`?step=N`). Three details worth a reviewer's attention:

- **Seeding is two-phase.** `?base=7` can't be validated until `listVersions`
  resolves, so seeding runs synchronously at setup and again after load — the
  same reason `useFormWizard` re-seeds after its entity lands.
- **Acceptance is an allowlist**, not a range check: a side is accepted only if
  it is `current` or an ordinal the *server returned*. A crafted `?base=../../x`
  or `?base=999` never reaches a fetch or the DOM.
- **No new authorization surface.** The params only choose among versions the
  caller could already read. A shared link is not a capability — the recipient
  without read access gets the same 404 they'd get without it.

## Testing

- Frontend unit: **1429 passed** (45 in the new composable suite).
- E2E: **239 passed** against a real PostgreSQL backend — includes the wizard
  suite (`?step=N`, the closest sibling of this pattern) and the pre-existing
  relation-history tests, so regression coverage is real.
- Typecheck, lint, markdownlint, prettier clean.

The suite was **mutation-tested**: the `v-model` type regression flagged as
highest-risk during planning (a numeric side returned as a string, which blanks
the dropdown while the URL still looks right) was injected deliberately, both
unit and e2e layers confirmed red, then reverted.

## Review notes

Code review surfaced one genuine design defect worth calling out: the relation
view's bare URL published *two frozen ordinals* while the entity view published
a live-relative link — so "share this diff" quietly meant different things in
the two views, and a relation link stopped meaning "the most recent edit" once a
new version landed. Fixed by returning the sentinel from `defaultSelection()`.
Three further findings (unvalidated params surviving on an empty history, no
type coercion on `select()`, minor naming/duplication) are all addressed;
tracked as RR-XM367L, RR-L4M1WK, RR-1QWV9S, RR-W7L33A.

Deliberately **out of scope**, each defensible as a separate ticket:

- Unifying the two near-duplicate history views (a much larger refactor that
  would bury this change).
- Making `goBack()` round-trip `return_to` — a real pre-existing gap noticed
  while reading, unrelated to this work.
- Any "Copy link" affordance or pinning of `current` (decision 2).

Ticket: TKT-YOHC3N
