### PR TITLE
tickets: clarify purge verification in REV-1FWW5E

### DIFF
--- a/tickets/entities/review-checklists/REV-1FWW5E.md
+++ b/tickets/entities/review-checklists/REV-1FWW5E.md
@@ -34,5 +34,22 @@ against a 2 GB quota. The upload step is removed; the job stays as a compile
 gate.
 
 The 24.6 GB backlog was purged separately (retention changes are not
-retroactive): 1121 artifacts deleted, 0 failures, org storage verified down to
-214 MB.
+retroactive): 1121 artifacts deleted, 0 failures. Live (unexpired) storage
+verified down to ~214 MB, all of it `coverage-report` plus a few small
+sarif/fuzz artifacts.
+
+Two clarifications on that figure, prompted by review (IB-review #1244):
+
+- **Expired rows still list.** The artifacts API returns already-expired
+  artifacts with `"expired": true`; ~1143 such `rela-linux` rows (~17.4 GB
+  nominal) remain enumerable. They are a disjoint set from the 1121 deleted
+  (zero id overlap) — GitHub had already expired them at their 90-day mark, so
+  they were never mine to delete and hold no billable storage. Any count of
+  remaining `rela-linux` must filter on `expired == false`, or it double-counts
+  bytes that no longer exist. The 1121 deletions were re-verified: all return
+  404 individually and none appear in a fresh full listing.
+- **Two stragglers, since removed.** Two runs on `develop` (`b98deaa6`,
+  `4333c858`, both pushed 16:03–16:04 UTC) started before this PR merged and so
+  still ran the old workflow, uploading 45 MB after the purge. Both were
+  deleted. `develop` no longer contains the upload step, so no further
+  `rela-linux` artifacts can be produced.


### PR DESCRIPTION
Follow-up to #1244, addressing the IB-review finding on the purge claim.

The review reported ~1145 `rela-linux` artifacts (~17.45 GB) still present, contradicting the checklist. Both figures were right about different things:

- **Expired rows still enumerate.** The artifacts API returns expired artifacts with `"expired": true`. ~1143 such `rela-linux` rows remain listable, but they are a *disjoint* set from the 1121 I deleted (zero id overlap) — GitHub expired them at their own 90-day mark. They hold no billable storage. A count that does not filter `expired == false` double-counts bytes that no longer exist.
- **The 1121 deletions are real** — re-verified: each returns 404 individually, and none appear in a fresh full listing.
- **The finding did surface something real.** Two runs on `develop` started before #1244 merged, so they ran the old workflow and uploaded 45 MB *after* the purge. Both have now been deleted.

Live storage is 213.5 MB, all `coverage-report` plus a few small sarif/fuzz artifacts. `develop` no longer contains the upload step, so no new `rela-linux` artifacts can be produced.

This PR only corrects the wording in the checklist so the record matches what was actually verified.