### PR TITLE
sec: enable gosec G704, annotate operator-configured HTTP destinations

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -129,9 +129,13 @@ linters:
         # belongs in FEAT-ESLP (data-entry server hardening). Deferring
         # these so the v2 migration doesn't block on threat-model decisions;
         # track the work under that feature instead.
+        #
+        # G704 (SSRF) is ENABLED: its two findings were reviewed and are
+        # operator-configured destinations (.rela/ai.yaml base_url; the
+        # `rela sync --remote` flag), annotated with narrow nolint
+        # directives naming the trust boundary at each call site.
         - G702  # command injection via taint analysis
         - G703  # path traversal via taint analysis
-        - G704  # SSRF via taint analysis
         - G705  # XSS via taint analysis
         - G706  # log injection via taint analysis
       config:

--- a/internal/ai/openai.go
+++ b/internal/ai/openai.go
@@ -175,6 +175,19 @@ func (p *openAICompatProvider) executeRequest(
 ) (*http.Response, []byte, time.Time, error) {
 	start := time.Now()
 
+	// The destination is operator configuration, not attacker input: the
+	// only source of BaseURL is .rela/ai.yaml (gitignored, per-user), read
+	// from local disk by ai.LoadConfig and reachable only via
+	// lua.LoadContextOptions -> ai.LoadProvider. Pointing rela at a
+	// self-hosted or alternative OpenAI-compatible endpoint (ollama, LM
+	// Studio, a corporate gateway) is the feature, so a host allowlist would
+	// break the documented use case. Nothing below the config file can steer
+	// it: ai.ChatRequest/EmbedRequest carry no URL, and the Lua ai.* bindings
+	// accept only messages/model/temperature/max_tokens — a script (even an
+	// untrusted one) cannot override the endpoint per call. Config.Validate
+	// already constrains the value to http/https with no credentials, query,
+	// or fragment, and redirect-following is disabled above.
+	//nolint:gosec // G704: destination comes from operator-owned .rela/ai.yaml, not from request/script input.
 	resp, doErr := p.httpClient.Do(httpReq)
 	if doErr != nil {
 		netErr := wrapNetworkError(doErr, apiKey)

--- a/internal/cli/sync/client.go
+++ b/internal/cli/sync/client.go
@@ -314,6 +314,17 @@ func relationSegments(from, relType, to string) []string {
 }
 
 func (c *Client) do(req *http.Request) (*http.Response, error) {
+	// The destination is operator configuration, not attacker input: the base
+	// URL is the `rela sync push/pull --remote` flag (env RELA_REMOTE), supplied
+	// by whoever invokes the CLI, and NewClient requires it to be absolute.
+	// Choosing which rela-server to sync against is the entire point of the
+	// command, so a host allowlist would defeat it. Remote-controlled data never
+	// reaches the destination: the path is built from JoinPath over segments this
+	// package derives from local record ids, so a hostile server's manifest can
+	// influence the path (escaped exactly once by JoinPath) but never the
+	// scheme/host. The trust boundary is the operator's shell, the same one that
+	// already grants full local filesystem access.
+	//nolint:gosec // G704: destination comes from the operator's --remote/RELA_REMOTE, not from request input.
 	resp, err := c.http.Do(req)
 	if err != nil {
 		// Never include req.URL with credentials — newRequest keeps the token in

--- a/tickets/entities/implementation-checklists/IMPL-ZRW35Z.md
+++ b/tickets/entities/implementation-checklists/IMPL-ZRW35Z.md
@@ -1,0 +1,49 @@
+---
+id: IMPL-ZRW35Z
+type: implementation-checklist
+title: 'Implementation: Enable gosec G704 (SSRF) and annotate operator-configured HTTP destinations'
+status: done
+---
+
+## Development
+
+- [x] ~~Unit tests written for new code~~ (N/A: no behaviour change — two
+annotations and a lint-config edit)
+- [x] ~~Integration tests written~~ (N/A: no behaviour change)
+- [x] Happy path implemented
+- [x] Edge cases from planning handled — the server-response-feeds-request-path
+sub-angle was checked explicitly, see evidence
+- [x] Error handling in place (errors surfaced, not swallowed)
+
+## Test Quality
+
+- [x] Using fixture builders or factories for test data
+- [x] No hardcoded values in assertions when object is in scope
+- [x] Only specifying values that matter for the test
+- [x] Interpolated values constructed from objects, not hardcoded
+- [x] Property comparisons use original object, not hardcoded strings
+
+## Manual Verification
+
+- [x] Feature manually tested end-to-end
+- [x] Each acceptance criterion verified with test scenario from planning
+- [x] Edge cases manually verified
+
+**Verification Evidence:**
+
+Both trust boundaries were traced to their source rather than asserted:
+
+- The AI endpoint's provenance was followed from `.rela/ai.yaml` through
+`LoadConfig` / `LoadProvider` to its single non-test call site, and the negative
+("Lua cannot override it") was confirmed at two layers — the request type has no
+URL field, and the Lua binding parses no URL key.
+- One sub-angle checked because a *remote* server's manifest response feeds back
+into subsequent request paths: `newRequest` builds paths via `url.URL.JoinPath`
+over segments derived from record ids, joining onto the base and escaping each
+segment exactly once. A hostile server can influence the *path* but never the
+scheme or host, so it cannot redirect requests to a new destination.
+Cross-origin redirects are not followed.
+
+Static checks: `golangci-lint run ./...` with G704 enabled reports 0 issues;
+`go build ./...` and `go test ./internal/ai/... ./internal/cli/...` pass,
+re-verified after rebasing onto current `develop`.

--- a/tickets/entities/review-checklists/REV-9OT5Z2.md
+++ b/tickets/entities/review-checklists/REV-9OT5Z2.md
@@ -1,0 +1,70 @@
+---
+id: REV-9OT5Z2
+type: review-checklist
+title: 'Review: Enable gosec G704 (SSRF) and annotate operator-configured HTTP destinations'
+status: done
+---
+
+## Automated Checks
+
+- [x] All tests pass — `go test ./internal/ai/... ./internal/cli/...` green
+- [x] Lint clean — `golangci-lint run ./...` 0 issues with G704 enabled
+- [x] ~~Coverage maintained~~ (N/A: no behaviour change, so no new code to cover)
+
+## Code Review
+
+- [x] Run `/code-review`
+- [x] All critical review-responses addressed (none raised)
+- [x] All significant review-responses addressed (none raised)
+- [x] Self-reviewed the diff for unrelated changes
+
+**Review Responses:** none
+
+This PR annotates rather than changes, so the review question is whether each
+annotation names a boundary that actually holds. Both do, and both were verified
+by tracing provenance to the source rather than by inspection of the sink. The
+strongest evidence is the two-layer negative on the AI endpoint: an override
+cannot exist even in principle, because the request type has no URL field.
+
+The hostile-remote-server angle is the non-obvious one and was checked rather
+than dismissed: a malicious server influences path segments only, never scheme or
+host.
+
+## Acceptance Verification
+
+- [x] Each acceptance criterion tested — see the evidence block in IMPL-ZRW35Z
+- [x] Test evidence documented in implementation checklist
+
+**Acceptance Status:**
+
+- G704 enabled repo-wide — PASS (removed from `gosec.excludes`)
+- Both findings resolved with narrow, per-site annotations — PASS
+- AI endpoint provenance is local config, not request data — PASS (traced end to
+end; confirmed negative at two layers for Lua)
+- Sync remote is operator-supplied via flag/env — PASS
+- Hostile remote server cannot redirect the destination — PASS (`JoinPath`
+influences path only; cross-origin redirects not followed)
+- No security control weakened — PASS (`Validate` constraints and redirect
+refusal both retained)
+
+## Documentation (enhancements only)
+
+- [x] ~~Docs-checklist created and linked~~ (N/A: internal security-lint work,
+`kind=refactor`, no user-facing behaviour change)
+- [x] ~~User-facing documentation updated~~ (N/A: no user-facing change)
+- [x] ~~Docs-checklist marked as done~~ (N/A: no docs-checklist)
+
+## Final Checks
+
+- [x] Commit message explains the why, not just what
+- [x] No TODOs or FIXMEs left unaddressed
+- [x] Ready for another developer to use
+
+## Pull Request
+
+- [x] Run `/pr` command to create PR and monitor CI
+- [x] All CI checks pass — full matrix green; the `Rela Tickets` gate is resolved
+by this done-transition
+- [x] PR URL documented below
+
+**PR:** https://github.com/sourcehaven-bv/rela/pull/1250

--- a/tickets/entities/tickets/TKT-NOPHKW.md
+++ b/tickets/entities/tickets/TKT-NOPHKW.md
@@ -1,0 +1,46 @@
+---
+id: TKT-NOPHKW
+type: ticket
+title: 'Enable gosec G704 (SSRF) and annotate operator-configured HTTP destinations'
+kind: refactor
+priority: medium
+effort: s
+status: done
+---
+
+## Description
+
+`G704` was in the `gosec.excludes` block in `.golangci.yml`, so SSRF taint
+analysis never ran. Enabling it surfaced two findings. Both are operator
+configuration rather than SSRF, so no code behaviour changes — but each needed
+its trust boundary traced end to end rather than assumed.
+
+**`internal/ai/openai.go`** — the destination derives solely from
+`Config.BaseURL`: `.rela/ai.yaml` (gitignored, per-user) → `ai.LoadConfig`
+(plain `os.ReadFile` from local disk) → `ai.LoadProvider`. `LoadProvider` has
+exactly one non-test call site (`internal/lua/context.go`), and the `.rela` dir
+comes from `deps.ProjectRoot`, never from a request. Pointing rela at ollama /
+LM Studio / a corporate gateway is the documented feature
+(`docs/lua-scripting.md`), so a host allowlist would break the intended use case.
+
+Lua cannot override the AI endpoint, confirmed negative at two independent
+layers: `ai.ChatRequest` carries only `Messages`, `Model`, `Temperature`,
+`MaxTokens` — no URL field on the request type, so no per-call override exists
+even in principle — and the Lua binding `parseChatRequest` reads only
+`messages`, `role`/`content`, `model`, `temperature`, `max_tokens` (same for the
+embed path). So even fully untrusted Lua cannot steer the destination.
+
+**`internal/cli/sync/client.go`** — base URL comes from the `rela sync
+push/pull --remote` flag (env `RELA_REMOTE`), through `buildSyncEngine` →
+`syncclient.NewClient`, which requires an absolute URL. The trust boundary is the
+operator's shell — the same one that already grants full local filesystem access.
+
+## Solution
+
+- Annotate both sites with a narrow `//nolint:gosec` naming the specific trust
+boundary, matching this repo's existing suppression style (as in
+`internal/canonical/canonical.go`).
+- Remove `G704` from the `gosec.excludes` block.
+- No security control weakened: no allowlist removed, and the existing
+`Config.Validate` constraints (http/https only, no credentials, query string or
+fragment) and the client's refusal to follow redirects both remain.

--- a/tickets/relations/TKT-NOPHKW--affects--ai-integration.md
+++ b/tickets/relations/TKT-NOPHKW--affects--ai-integration.md
@@ -1,0 +1,5 @@
+---
+from: TKT-NOPHKW
+relation: affects
+to: ai-integration
+---

--- a/tickets/relations/TKT-NOPHKW--affects--ci-pipeline.md
+++ b/tickets/relations/TKT-NOPHKW--affects--ci-pipeline.md
@@ -1,0 +1,5 @@
+---
+from: TKT-NOPHKW
+relation: affects
+to: ci-pipeline
+---

--- a/tickets/relations/TKT-NOPHKW--affects--cli-flags.md
+++ b/tickets/relations/TKT-NOPHKW--affects--cli-flags.md
@@ -1,0 +1,5 @@
+---
+from: TKT-NOPHKW
+relation: affects
+to: cli-flags
+---

--- a/tickets/relations/TKT-NOPHKW--has-implementation--IMPL-ZRW35Z.md
+++ b/tickets/relations/TKT-NOPHKW--has-implementation--IMPL-ZRW35Z.md
@@ -1,0 +1,5 @@
+---
+from: TKT-NOPHKW
+relation: has-implementation
+to: IMPL-ZRW35Z
+---

--- a/tickets/relations/TKT-NOPHKW--has-review--REV-9OT5Z2.md
+++ b/tickets/relations/TKT-NOPHKW--has-review--REV-9OT5Z2.md
@@ -1,0 +1,5 @@
+---
+from: TKT-NOPHKW
+relation: has-review
+to: REV-9OT5Z2
+---

--- a/tickets/relations/TKT-NOPHKW--implements--FEAT-GE1YY.md
+++ b/tickets/relations/TKT-NOPHKW--implements--FEAT-GE1YY.md
@@ -1,0 +1,5 @@
+---
+from: TKT-NOPHKW
+relation: implements
+to: FEAT-GE1YY
+---


### PR DESCRIPTION
Enables the gosec `G704` (SSRF) taint check. Both findings are operator configuration, not SSRF — no code behaviour changes.

## `internal/ai/openai.go`

The destination derives solely from `Config.BaseURL`, traced end to end: `.rela/ai.yaml` (gitignored, per-user) → `ai.LoadConfig` (plain `os.ReadFile` from local disk) → `ai.LoadProvider`. `LoadProvider` has exactly one non-test call site (`internal/lua/context.go`), and the `.rela` dir comes from `deps.ProjectRoot`, never from a request.

Pointing rela at ollama / LM Studio / a corporate gateway is the documented feature (`docs/lua-scripting.md`), so a host allowlist would break the intended use case.

**Lua cannot override the AI endpoint — confirmed negative at two independent layers:**

- `ai.ChatRequest` carries only `Messages`, `Model`, `Temperature`, `MaxTokens`. There is no URL field on the request type, so no per-call override exists even in principle.
- The Lua binding `parseChatRequest` reads only `messages`, `role`/`content`, `model`, `temperature`, `max_tokens`. Same for the embed path.

So even fully untrusted Lua cannot steer the destination. Changing it requires editing a local file, which already implies filesystem write access to the project. `Config.Validate` additionally constrains the value to http/https with no credentials, query string, or fragment, and redirect-following is disabled in the client.

## `internal/cli/sync/client.go`

Base URL comes from the `rela sync push/pull --remote` flag (env `RELA_REMOTE`), through `buildSyncEngine` → `syncclient.NewClient`, which requires an absolute URL. The trust boundary is the operator's shell — the same one that already grants full local filesystem access.

One sub-angle checked, since a *remote* server's manifest response feeds back into subsequent request paths: `newRequest` builds paths via `url.URL.JoinPath` over segments derived from record ids, joining onto the base and escaping each segment exactly once. A hostile server can influence the *path* but never the scheme or host, so it cannot redirect requests to a new destination. Cross-origin redirects are not followed.

## Notes

- Both sites carry a narrow `//nolint:gosec` naming the specific trust boundary, matching this repo's existing suppression style (as in `internal/canonical/canonical.go`).
- No security control was weakened — no allowlist removed; the existing `Validate` constraints and redirect refusal remain.
- `G704` removed from the `gosec.excludes` block in `.golangci.yml`.
- `golangci-lint run ./...` (G704 enabled) → 0 issues; `go build ./...` and `go test ./internal/ai/... ./internal/cli/...` pass, re-verified after rebasing onto current `develop`.