### PR TITLE
fix(pgstore): schema-scope the migrate and write advisory locks (BUG-CA3VY0)

### DIFF
--- a/docs-project/entities/guides/GUIDE-postgres-backend.md
+++ b/docs-project/entities/guides/GUIDE-postgres-backend.md
@@ -117,18 +117,24 @@ What you need to know to run it:
 
 The store exposes a write-transaction contract (`store.Store.Tx`,
 DEC-8UIL0). On PostgreSQL a `Tx` callback runs inside one real database
-transaction, serialized **deployment-wide** by a transaction-scoped
-advisory lock (its own key, distinct from the migration and
-version-sweep locks): every process of the deployment executes write
-transactions one at a time. An error rolls the whole callback back —
-no rows, no cross-process NOTIFYs, and no in-process events are
-delivered (event fan-out is buffered until commit). On the filesystem
-backend the same contract degrades to a process-local write mutex with
-no rollback — acceptable for its single-user deployments.
+transaction, serialized **across the processes sharing a schema** by a
+transaction-scoped advisory lock (its own key, distinct from the
+migration and version-sweep locks): every process serving that schema
+executes write transactions one at a time. An error rolls the whole
+callback back — no rows, no cross-process NOTIFYs, and no in-process
+events are delivered (event fan-out is buffered until commit). On the
+filesystem backend the same contract degrades to a process-local write
+mutex with no rollback — acceptable for its single-user deployments.
 
-Because the advisory lock is deployment-wide, a slow transaction stalls
-every writer. Keep `Tx` callbacks short and never perform external I/O
-inside one.
+Because the advisory lock covers the whole schema, a slow transaction
+stalls every writer against it. Keep `Tx` callbacks short and never
+perform external I/O inside one.
+
+All three of rela's advisory locks — migration, version sweep, and
+write — are keyed by the schema they act on. PostgreSQL advisory locks
+are otherwise database-global, so without this two rela schemas sharing
+one database would migrate, sweep, and write behind each other's locks
+despite being entirely independent deployments.
 
 ## Version history (time machine)
 

--- a/docs/postgres-backend.md
+++ b/docs/postgres-backend.md
@@ -111,18 +111,24 @@ What you need to know to run it:
 
 The store exposes a write-transaction contract (`store.Store.Tx`,
 DEC-8UIL0). On PostgreSQL a `Tx` callback runs inside one real database
-transaction, serialized **deployment-wide** by a transaction-scoped
-advisory lock (its own key, distinct from the migration and
-version-sweep locks): every process of the deployment executes write
-transactions one at a time. An error rolls the whole callback back —
-no rows, no cross-process NOTIFYs, and no in-process events are
-delivered (event fan-out is buffered until commit). On the filesystem
-backend the same contract degrades to a process-local write mutex with
-no rollback — acceptable for its single-user deployments.
+transaction, serialized **across the processes sharing a schema** by a
+transaction-scoped advisory lock (its own key, distinct from the
+migration and version-sweep locks): every process serving that schema
+executes write transactions one at a time. An error rolls the whole
+callback back — no rows, no cross-process NOTIFYs, and no in-process
+events are delivered (event fan-out is buffered until commit). On the
+filesystem backend the same contract degrades to a process-local write
+mutex with no rollback — acceptable for its single-user deployments.
 
-Because the advisory lock is deployment-wide, a slow transaction stalls
-every writer. Keep `Tx` callbacks short and never perform external I/O
-inside one.
+Because the advisory lock covers the whole schema, a slow transaction
+stalls every writer against it. Keep `Tx` callbacks short and never
+perform external I/O inside one.
+
+All three of rela's advisory locks — migration, version sweep, and
+write — are keyed by the schema they act on. PostgreSQL advisory locks
+are otherwise database-global, so without this two rela schemas sharing
+one database would migrate, sweep, and write behind each other's locks
+despite being entirely independent deployments.
 
 ## Version history (time machine)
 

--- a/internal/store/pgstore/advisorylock_scope_test.go
+++ b/internal/store/pgstore/advisorylock_scope_test.go
@@ -1,0 +1,251 @@
+package pgstore_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/Sourcehaven-BV/rela/internal/store"
+	"github.com/Sourcehaven-BV/rela/internal/store/pgstore"
+)
+
+// The migrate and write locks are schema-scoped for the same reason the version
+// sweep's is (see TestSweepAdvisoryLockIsSchemaScoped): PostgreSQL advisory
+// locks are database-GLOBAL, and many rela schemas can share one database.
+//
+// Unqualified, the write lock made every write transaction serialize against
+// writes to UNRELATED schemas, and the migrate lock made two schemas' startup
+// migrations queue behind each other. Neither loses data the way the sweep did,
+// but both are the same defect.
+const (
+	migrateLockKey = 0x52_45_4c_41 // migrateAdvisoryLockKey ("RELA")
+	writeLockKey   = 0x52_45_4c_57 // writeAdvisoryLockKey ("RELW")
+)
+
+// TestXactAdvisoryLocksAreSchemaScoped proves the two transaction-scoped locks
+// (migrate, write) are independent across schemas while staying mutually
+// exclusive within one.
+//
+// pg_advisory_xact_lock is blocking, so this asserts via pg_try_advisory_xact_lock
+// on a held transaction rather than by racing two blocking acquisitions.
+func TestXactAdvisoryLocksAreSchemaScoped(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		key  int
+	}{
+		{"migrate", migrateLockKey},
+		{"write", writeLockKey},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			poolA := newScopedPool(t)
+			poolB := newScopedPool(t)
+
+			const lockSQL = `SELECT pg_try_advisory_xact_lock($1::int, hashtext(current_schema()))`
+
+			// Hold the lock inside an open transaction on schema A.
+			connA, err := poolA.Acquire(ctx)
+			require.NoError(t, err)
+			defer connA.Release()
+			txA, err := connA.Begin(ctx)
+			require.NoError(t, err)
+			defer txA.Rollback(ctx)
+
+			var okA bool
+			require.NoError(t, txA.QueryRow(ctx, lockSQL, tc.key).Scan(&okA))
+			require.True(t, okA, "schema A takes the %s lock", tc.name)
+
+			// Schema B takes the SAME logical lock concurrently — only possible if
+			// it is scoped by schema.
+			connB, err := poolB.Acquire(ctx)
+			require.NoError(t, err)
+			defer connB.Release()
+			txB, err := connB.Begin(ctx)
+			require.NoError(t, err)
+			defer txB.Rollback(ctx)
+
+			var okB bool
+			require.NoError(t, txB.QueryRow(ctx, lockSQL, tc.key).Scan(&okB))
+			require.True(t, okB,
+				"schema B must take the %s lock while A holds it — scoped, not global", tc.name)
+
+			// Within schema A, a second session is still excluded.
+			connA2, err := poolA.Acquire(ctx)
+			require.NoError(t, err)
+			defer connA2.Release()
+			txA2, err := connA2.Begin(ctx)
+			require.NoError(t, err)
+			defer txA2.Rollback(ctx)
+
+			var okA2 bool
+			require.NoError(t, txA2.QueryRow(ctx, lockSQL, tc.key).Scan(&okA2))
+			require.False(t, okA2,
+				"a second session in schema A must still be excluded from the %s lock", tc.name)
+		})
+	}
+}
+
+// TestMigrateDoesNotBlockAnotherSchema pins the migrate lock end-to-end through
+// the real Migrate call: a migration against one schema must not be serialized
+// behind an unrelated schema holding the migrate lock.
+//
+// It holds BOTH lock forms on schema A — the schema-scoped two-key form that
+// production takes now, and the bare one-key form it took before. Holding both
+// is what makes the test falsifying: with only the two-key form held, a
+// regression back to the bare key would take a lock nobody holds and pass
+// anyway, since Postgres treats the one-key and two-key spaces as disjoint.
+//
+// Migrate is idempotent, so re-running it on an already-migrated schema is a
+// no-op that still takes the lock — exactly what is under test.
+func TestMigrateDoesNotBlockAnotherSchema(t *testing.T) {
+	ctx := context.Background()
+	poolA := newScopedPool(t)
+	poolB := newScopedPool(t)
+
+	// Hold schema A's migrate lock — both forms — for an open transaction.
+	connA, err := poolA.Acquire(ctx)
+	require.NoError(t, err)
+	defer connA.Release()
+	txA, err := connA.Begin(ctx)
+	require.NoError(t, err)
+	defer txA.Rollback(ctx)
+
+	var held bool
+	require.NoError(t, txA.QueryRow(ctx,
+		`SELECT pg_try_advisory_xact_lock($1::int, hashtext(current_schema()))`,
+		migrateLockKey).Scan(&held))
+	require.True(t, held, "should hold schema A's scoped migrate lock")
+
+	// The pre-fix key space. Holding it means a regression to the bare form
+	// blocks here rather than silently passing.
+	require.NoError(t, txA.QueryRow(ctx,
+		`SELECT pg_try_advisory_xact_lock($1)`, migrateLockKey).Scan(&held))
+	require.True(t, held, "should hold the legacy database-global migrate key too")
+
+	// Migrating schema B must complete promptly. With a database-global key it
+	// would block on A's transaction until this test's timeout.
+	done := make(chan error, 1)
+	go func() { done <- pgstore.Migrate(ctx, poolB) }()
+
+	select {
+	case err := <-done:
+		require.NoError(t, err, "schema B must migrate while schema A holds ITS migrate lock")
+	case <-time.After(10 * time.Second):
+		t.Fatal("schema B's migration blocked on schema A's migrate lock — the key is not schema-scoped")
+	}
+}
+
+// TestWriteTxDoesNotBlockAnotherSchema is the write-lock analog, driven
+// through the real Store.Tx rather than a mirrored SQL literal. Same
+// both-forms-held construction, for the same falsifiability reason.
+func TestWriteTxDoesNotBlockAnotherSchema(t *testing.T) {
+	ctx := context.Background()
+	poolA := newScopedPool(t)
+	poolB := newScopedPool(t)
+
+	connA, err := poolA.Acquire(ctx)
+	require.NoError(t, err)
+	defer connA.Release()
+	txA, err := connA.Begin(ctx)
+	require.NoError(t, err)
+	defer txA.Rollback(ctx)
+
+	var held bool
+	require.NoError(t, txA.QueryRow(ctx,
+		`SELECT pg_try_advisory_xact_lock($1::int, hashtext(current_schema()))`,
+		writeLockKey).Scan(&held))
+	require.True(t, held, "should hold schema A's scoped write lock")
+	require.NoError(t, txA.QueryRow(ctx,
+		`SELECT pg_try_advisory_xact_lock($1)`, writeLockKey).Scan(&held))
+	require.True(t, held, "should hold the legacy database-global write key too")
+
+	sB, err := pgstore.New(poolB)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = sB.Close() })
+
+	done := make(chan error, 1)
+	go func() {
+		done <- sB.Tx(ctx, func(tx store.Store) error {
+			return tx.CreateEntity(ctx, mkEntity("TENANT-B-TX", "ticket", "written under Tx"))
+		})
+	}()
+
+	select {
+	case err := <-done:
+		require.NoError(t, err, "schema B must write while schema A holds ITS write lock")
+	case <-time.After(10 * time.Second):
+		t.Fatal("schema B's write Tx blocked on schema A's write lock — the key is not schema-scoped")
+	}
+}
+
+// TestSweepCapturesWhileAnotherSchemaHoldsLock complements the lock-level
+// assertion in TestSweepAdvisoryLockIsSchemaScoped by pinning the OBSERVABLE
+// consequence: it asserts on captured versions, not on lock acquisition.
+//
+// That distinction is the point. A test that only checks a lock was taken still
+// passes if the keys collide in some future refactor; this one fails, because
+// the symptom of the original bug was silent — schema B's create/update
+// versions were simply never captured, with no error, warning or metric.
+func TestSweepCapturesWhileAnotherSchemaHoldsLock(t *testing.T) {
+	ctx := context.Background()
+	poolA := newScopedPool(t)
+	poolB := newScopedPool(t)
+
+	// Hold schema A's version lock on a dedicated session — what a mid-tick
+	// sweep in A looks like to the rest of the database.
+	connA, err := poolA.Acquire(ctx)
+	require.NoError(t, err)
+	defer connA.Release()
+
+	const lockSQL = `SELECT pg_try_advisory_lock($1::int, hashtext(current_schema()))`
+	const sweepLockKey = 0x52_45_4c_56 // sweepAdvisoryLockKey ("RELV")
+
+	var lockedA bool
+	require.NoError(t, connA.QueryRow(ctx, lockSQL, sweepLockKey).Scan(&lockedA))
+	require.True(t, lockedA, "should have taken schema A's version lock")
+	defer func() {
+		_, _ = connA.Exec(context.Background(),
+			`SELECT pg_advisory_unlock($1::int, hashtext(current_schema()))`, sweepLockKey)
+	}()
+
+	// Sanity: A's lock is genuinely held, so B is not merely succeeding because
+	// nothing was locked at all.
+	connA2, err := poolA.Acquire(ctx)
+	require.NoError(t, err)
+	var reAcquired bool
+	require.NoError(t, connA2.QueryRow(ctx, lockSQL, sweepLockKey).Scan(&reAcquired))
+	if reAcquired {
+		_, _ = connA2.Exec(ctx,
+			`SELECT pg_advisory_unlock($1::int, hashtext(current_schema()))`, sweepLockKey)
+	}
+	connA2.Release()
+	require.False(t, reAcquired, "schema A's lock should be exclusively held")
+
+	// Sweep schema B while A's lock is held. B must capture regardless.
+	sB, err := pgstore.New(poolB)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = sB.Close() })
+
+	require.NoError(t, sB.CreateEntity(ctx, mkEntity("TENANT-B-1", "ticket", "b writes too")))
+	_, err = poolB.Exec(ctx,
+		`UPDATE entities SET updated_at = now() - interval '1 hour' WHERE id = 'TENANT-B-1'`)
+	require.NoError(t, err)
+
+	sB.StartVersionSweep(
+		stubProvider{hash: "schema-abc", json: []byte(`{"entities":{},"types":{}}`)},
+		pgstore.SweepConfig{
+			Interval:     50 * time.Millisecond,
+			Idle:         time.Minute,
+			MaxStaleness: time.Hour,
+			Batch:        100,
+		})
+
+	require.Eventually(t, func() bool {
+		metas, e := sB.VersionStore().ListVersions(ctx, "TENANT-B-1")
+		return e == nil && len(metas) == 1
+	}, 5*time.Second, 25*time.Millisecond,
+		"schema B must capture its own versions while schema A holds ITS version lock; "+
+			"a database-global key silently drops B's capture")
+}

--- a/internal/store/pgstore/migrate.go
+++ b/internal/store/pgstore/migrate.go
@@ -27,6 +27,13 @@ type migration struct {
 // migration lock. pg_advisory_xact_lock serializes concurrent migrators (rela /
 // rela-server / rela mcp may all call Migrate against the same database); the
 // transaction-scoped lock is released automatically on commit or rollback.
+//
+// Like the version-sweep lock, it is SCHEMA-SCOPED via the two-key form
+// pg_advisory_xact_lock(key, hashtext(current_schema())) — see the
+// tryAdvisoryLock doc in sweep.go for why. Advisory locks are database-GLOBAL,
+// so a bare key made two rela schemas on one database serialize their startup
+// migrations behind each other. Unqualified DDL lands in current_schema(), so
+// that is exactly the schema this transaction's migrations target.
 const migrateAdvisoryLockKey = 0x52_45_4c_41 // "RELA"
 
 // Migrate applies any unapplied migrations to the database in version order,
@@ -52,8 +59,12 @@ func Migrate(ctx context.Context, db DBTX) error {
 	}
 	defer tx.Rollback(ctx) //nolint:errcheck // rollback after commit is a no-op
 
-	// Serialize concurrent migrators. The lock is held until this tx ends.
-	if _, err = tx.Exec(ctx, `SELECT pg_advisory_xact_lock($1)`, migrateAdvisoryLockKey); err != nil {
+	// Serialize concurrent migrators OF THIS SCHEMA. The lock is held until this
+	// tx ends. hashtext(current_schema()) scopes it so another schema's startup
+	// migration on the same database runs independently.
+	if _, err = tx.Exec(ctx,
+		`SELECT pg_advisory_xact_lock($1::int, hashtext(current_schema()))`,
+		migrateAdvisoryLockKey); err != nil {
 		return fmt.Errorf("pgstore: acquire migration lock: %w", err)
 	}
 

--- a/internal/store/pgstore/sweep.go
+++ b/internal/store/pgstore/sweep.go
@@ -71,7 +71,23 @@ type sweep struct {
 	cfg      SweepConfig
 	cancel   context.CancelFunc
 	done     chan struct{}
+	// consecutiveSkips counts ticks that could not take the lock, so sustained
+	// starvation escalates to a warning. Touched only from the run goroutine
+	// (tick is never called concurrently), so it needs no locking.
+	consecutiveSkips int
 }
+
+// sweepSkipWarnAfter is how many consecutive lock-acquisition failures turn the
+// routine debug line into a warning.
+//
+// A skipped tick is normally harmless — another process is sweeping the same
+// schema and covers the same rows — so a handful is not worth reporting. But a
+// silent skip is exactly what hid the database-global lock bug: this schema's
+// create/update versions simply stopped being captured, with no error, no
+// warning and no metric. Sustained skipping means this schema IS being starved
+// (a runner that never finishes, or a lock that is not as scoped as intended),
+// which is worth surfacing.
+const sweepSkipWarnAfter = 10
 
 // StartVersionSweep starts the periodic version-reconciliation sweep for this
 // store, capturing create/update versions for settled entities. The wiring
@@ -161,9 +177,25 @@ func (s *sweep) tick(ctx context.Context) error {
 		return err
 	}
 	if !locked {
-		// Another process is sweeping — skip this tick.
+		// Another process is sweeping THIS schema — skip; its run covers the same
+		// rows, and candidate selection is state-based, so the next tick retries
+		// and nothing is lost. Non-fatal because same-schema multi-process
+		// contention is the legitimate case this lock exists for.
+		//
+		// Escalate when it persists: a skip that never resolves means this
+		// schema's versions are silently not being captured, which is the failure
+		// mode a database-global lock produced. See sweepSkipWarnAfter.
+		s.consecutiveSkips++
+		if s.consecutiveSkips >= sweepSkipWarnAfter {
+			slog.WarnContext(ctx, "pgstore: version sweep starved; another runner has held the lock "+
+				"for many consecutive ticks, so this schema's create/update versions are not being captured",
+				"consecutive_skips", s.consecutiveSkips)
+		} else {
+			slog.DebugContext(ctx, "pgstore: version sweep tick skipped; another runner holds the lock")
+		}
 		return nil
 	}
+	s.consecutiveSkips = 0
 	// Unlock on a context detached from cancellation: when Close cancels the
 	// tick ctx mid-tick, the deferred unlock must still run its statement, or
 	// the session-scoped advisory lock rides the pooled connection back into the

--- a/internal/store/pgstore/tx.go
+++ b/internal/store/pgstore/tx.go
@@ -27,12 +27,19 @@ import (
 //
 // A nested Tx on the view joins the open transaction.
 
-// writeAdvisoryLockKey serializes write transactions deployment-wide
-// ("RELW"). Distinct from migrateAdvisoryLockKey ("RELA", xact-scoped in
-// Migrate) and sweepAdvisoryLockKey ("RELV", session-scoped, shared by
-// sweep and purge): a write Tx must not block — or be blocked by — a
-// sweep tick, matching today's behavior where ordinary writes never
-// take the sweep lock.
+// writeAdvisoryLockKey serializes write transactions across the processes
+// sharing one SCHEMA ("RELW"). Distinct from migrateAdvisoryLockKey ("RELA",
+// xact-scoped in Migrate) and sweepAdvisoryLockKey ("RELV", session-scoped,
+// shared by sweep and purge): a write Tx must not block — or be blocked by — a
+// sweep tick, matching today's behavior where ordinary writes never take the
+// sweep lock.
+//
+// Like both of those, it is SCHEMA-SCOPED via the two-key form
+// pg_advisory_xact_lock(key, hashtext(current_schema())) — see the
+// tryAdvisoryLock doc in sweep.go. Advisory locks are database-GLOBAL, so a
+// bare key made every write transaction serialize against writes to UNRELATED
+// schemas on the same database: a throughput fault rather than the capture loss
+// the sweep suffered, but the same root cause.
 const writeAdvisoryLockKey int64 = 0x52_45_4c_57
 
 // txPending buffers the in-process notifications of one open Tx, in
@@ -61,7 +68,9 @@ func (s *Store) Tx(ctx context.Context, fn func(store.Store) error) error {
 	}
 	defer tx.Rollback(ctx) //nolint:errcheck // rollback after commit is a no-op
 
-	if _, err := tx.Exec(ctx, `SELECT pg_advisory_xact_lock($1)`, writeAdvisoryLockKey); err != nil {
+	if _, err := tx.Exec(ctx,
+		`SELECT pg_advisory_xact_lock($1::int, hashtext(current_schema()))`,
+		writeAdvisoryLockKey); err != nil {
 		return err
 	}
 

--- a/tickets/entities/automated-measures/pgstore-per-schema-sweep-capture-test.md
+++ b/tickets/entities/automated-measures/pgstore-per-schema-sweep-capture-test.md
@@ -1,0 +1,46 @@
+---
+id: pgstore-per-schema-sweep-capture-test
+type: automated-measure
+title: 'Test: migrate and write Tx on one schema are not blocked by another schema''s lock'
+description: Drives the real Migrate and Store.Tx code paths while another schema holds BOTH the scoped and legacy advisory key spaces, asserting the work completes rather than blocking. Holding the legacy space is what makes it falsifying — Postgres treats one-key and two-key advisory locks as disjoint, so a regression to a bare key would otherwise take a lock nobody holds and pass.
+kind: test
+location: internal/store/pgstore/advisorylock_scope_test.go (DB-gated on RELA_TEST_DATABASE_URL; runs under `just test-postgres`)
+status: active
+---
+
+## What it pins
+
+Two rela schemas in one PostgreSQL database must migrate, and run write
+transactions, independently. PostgreSQL advisory locks are database-wide, so a
+bare key makes unrelated schemas serialize against each other.
+
+## The falsifiability trap this measure exists to avoid
+
+The obvious test — hold schema A's *scoped* lock, assert schema B proceeds —
+**passes even against the un-fixed code**. Postgres treats
+`pg_advisory_xact_lock(k)` and `pg_advisory_xact_lock(k, s)` as disjoint lock
+spaces, so a regression to the bare one-key form takes a lock nobody is holding
+and sails through.
+
+The tests therefore hold **both** key spaces on the blocking schema, and drive
+the real `pgstore.Migrate` / `Store.Tx` rather than re-stating the SQL literal.
+A mirrored literal tests the test, not the code.
+
+Verified by patching production back to the bare key: both fail with "blocked on
+schema A's lock", and pass once restored.
+
+## Tests
+
+- `TestMigrateDoesNotBlockAnotherSchema` — real `Migrate` against schema B while
+A holds both migrate key spaces; must complete inside 10s.
+- `TestWriteTxDoesNotBlockAnotherSchema` — real `Store.Tx` write against B while
+A holds both write key spaces.
+- `TestXactAdvisoryLocksAreSchemaScoped` — lock-level table test over both
+classes: independent across schemas, still mutually exclusive within one.
+- `TestSweepCapturesWhileAnotherSchemaHoldsLock` — complements the upstream
+lock-level sweep test (`TestSweepAdvisoryLockIsSchemaScoped`, added by #1217) by
+asserting the observable consequence: **captured versions**, not lock
+acquisition. The original symptom was silent, so the assertion has to be on the
+data.
+
+DB-gated on `RELA_TEST_DATABASE_URL` like the rest of the pgstore suite.

--- a/tickets/entities/bug-analysis-checklists/BUGA-WV60XG.md
+++ b/tickets/entities/bug-analysis-checklists/BUGA-WV60XG.md
@@ -1,0 +1,80 @@
+---
+id: BUGA-WV60XG
+type: bug-analysis-checklist
+title: 'Analysis: pgstore migrate and write advisory locks are not schema-qualified'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Reproduction
+
+- [x] Bug reproduced locally
+- [x] Minimal reproduction steps documented
+- [x] Environment/conditions noted
+
+Reproduced against a real throwaway PostgreSQL 15 by holding schema A's migrate
+(and separately, write) advisory lock inside an open transaction, then driving
+the real `pgstore.Migrate` / `Store.Tx` against schema B. Both blocked until the
+10s test timeout instead of completing.
+
+Minimal conditions: two rela schemas in one database — the standard
+schema-per-project layout, and what the conformance harness already creates —
+with one holding either lock. Every starting process is a migrator
+(`pgstore.Open` calls `Migrate`), so migrate contention needs only two processes
+starting; write contention needs only two schemas taking writes.
+
+## Root Cause
+
+- [x] Immediate cause identified (why1)
+- [x] Contributing factors found (why2-3)
+- [x] Systemic cause explored (why4-5)
+
+Recorded as why1–why5 on the bug. Two systemic findings worth restating:
+
+**The codebase had already solved this twice.** The change feed schema-qualifies
+its NOTIFY channel (`rela_changed_<schema>`) because LISTEN/NOTIFY is
+database-global, and `feed.go` documents that reasoning. PR #1217 then applied
+the same reasoning to the version-sweep lock. Neither pass generalised to the
+remaining two locks, so this is the third instance of one insight.
+
+**Severity gradient hid the tail.** The sweep's variant caused *silent data
+loss* (non-blocking acquire, `return nil` on failure, capture dropped with no
+error) and surfaced when e2e workers collided. The migrate and write variants
+merely *block* — correct but slow — so nothing forced them into view. The
+low-severity instances of a defect outlive the high-severity one.
+
+## Fix Planning
+
+- [x] Fix approach determined
+- [x] Regression test planned
+- [x] Related areas checked for similar issues
+
+Approach: adopt the two-key form #1217 established —
+`pg_advisory_xact_lock($1::int, hashtext(current_schema()))` — rather than a
+competing mechanism. One idiom across all three locks, Postgres-native, no
+Go-side schema resolution and no extra round-trip.
+
+An earlier draft of this fix used a Go-side key derivation
+(`class<<32 | hash(schema)`, resolved via `SELECT current_schema()` per call).
+It was abandoned on rebase: #1217's SQL-level approach is simpler, and the Go
+version had generated its own defects during review (a NULL-vs-empty scan bug, a
+JOIN that returned no rows instead of NULL, and a migrate bootstrap split needed
+because the table-anchored variant fails on a fresh database). Thoroughness that
+manufactures its own bugs is not an improvement.
+
+Regression test: must drive the **real** code paths and hold **both** the scoped
+and legacy key spaces — see the measure entity for why the obvious version does
+not falsify.
+
+Related areas checked:
+
+- `sweepAdvisoryLockKey` — already fixed by #1217; left alone.
+- `migrateAdvisoryLockKey`, `writeAdvisoryLockKey` — fixed here.
+- NOTIFY channel — already schema-qualified.
+- Sequences (`rela_seq`, `version_seq`), per-schema pools — per-schema by nature.
+
+One adjacent gap left open deliberately: `resolveChannel` (`feed.go`) has an
+unreachable `schema = "public"` fallback, because `current_schema()` returns
+NULL rather than an empty string. Pre-existing, harmless at startup-time channel
+resolution, and out of scope here — worth its own ticket.

--- a/tickets/entities/bugs/BUG-CA3VY0.md
+++ b/tickets/entities/bugs/BUG-CA3VY0.md
@@ -1,0 +1,76 @@
+---
+id: BUG-CA3VY0
+type: bug
+title: pgstore migrate and write advisory locks are not schema-qualified
+description: 'migrateAdvisoryLockKey and writeAdvisoryLockKey are bare compile-time constants, but PostgreSQL advisory locks are database-wide. Two rela schemas in one database therefore serialize their startup migrations, and every write transaction, against each other. The version-sweep lock had the same defect with a worse symptom (silent version-capture loss) and was fixed separately by #1217 (TKT-SCXHUL); these two remained.'
+priority: high
+why1: Two rela schemas in one database block each other's startup migrations and write transactions despite being independent deployments.
+why2: migrateAdvisoryLockKey and writeAdvisoryLockKey are bare constants, while PostgreSQL advisory locks are database-wide — the keys carried no schema dimension.
+why3: pgstore was designed single-schema-per-database. The change feed hit the same database-global problem with LISTEN/NOTIFY and schema-qualified its channel, but that reasoning was never generalised to the advisory locks.
+why4: 'When the sweep lock was fixed under #1217, the fix was scoped to the lock that caused the observed e2e starvation; the migrate and write locks share the root cause but produce blocking rather than data loss, so nothing surfaced them.'
+why5: No test exercised two schemas contending on the same database for the migrate or write paths, so the shared-key assumption was never falsifiable.
+prevention: All three advisory locks now use the two-key form pg_advisory_xact_lock(key, hashtext(current_schema())). Pinned by TestMigrateDoesNotBlockAnotherSchema and TestWriteTxDoesNotBlockAnotherSchema, which drive the REAL Migrate/Tx code paths and hold BOTH the scoped and legacy key spaces on the blocking schema — without holding the legacy space a regression to the bare key would take a lock nobody holds and pass. Verified fail-before/pass-after. The sweep's silent lost-lock branch now escalates to a warning after 10 consecutive skips.
+status: in-progress
+---
+
+## Summary
+
+`migrateAdvisoryLockKey` (`internal/store/pgstore/migrate.go`) and
+`writeAdvisoryLockKey` (`internal/store/pgstore/tx.go`) are bare compile-time
+constants. **PostgreSQL advisory locks are database-wide, not schema-scoped**,
+so two rela schemas sharing one database contend on both.
+
+This is the tail of a defect whose worst instance was already fixed. PR #1217
+(TKT-SCXHUL) schema-scoped the **version-sweep** lock after postgres e2e workers
+starved each other; its symptom was severe — the sweep acquires with
+non-blocking `pg_try_advisory_lock` and silently `return nil`s on failure, so
+the losing schema's create/update version capture was dropped with no error. The
+migrate and write locks were left on bare keys.
+
+## Impact
+
+Blocking, not data loss — which is why these outlived the sweep fix:
+
+- **Write Tx** (`tx.go`) — every write transaction serializes against writes to
+*unrelated* schemas on the same database. On a shared-database deployment this
+is a throughput ceiling that scales with the number of unrelated tenants.
+- **Migrate** (`migrate.go`) — `pgstore.Open` calls `Migrate` on every store
+open, so every starting process is a migrator. Two schemas' startups queue
+behind each other. Blocking (`pg_advisory_xact_lock`), so correct but slow.
+
+## Fix
+
+Adopt the same two-key form #1217 used, rather than a competing mechanism:
+
+```sql
+pg_advisory_xact_lock($1::int, hashtext(current_schema()))
+```
+
+One idiom across all three locks. `hashtext` is Postgres-native, needs no
+Go-side schema resolution, and adds no round-trip.
+
+For migrate specifically, `current_schema()` is the right anchor: unqualified
+DDL lands there, so it is by definition the schema the migration targets.
+
+## Also in this change
+
+The sweep's lost-lock branch was silent (`return nil` with no log). That silence
+is what let the sweep half of this go unnoticed until e2e workers collided. It
+now counts consecutive skips and escalates from debug to a **warning** after 10,
+stating that this schema's versions are not being captured. Still non-fatal —
+same-schema multi-process contention is the legitimate case the lock exists for.
+
+## Test design note
+
+The obvious test — hold the scoped lock on schema A, assert schema B proceeds —
+**does not falsify**. Postgres treats the one-key and two-key advisory spaces as
+disjoint, so a regression to the bare key would take a lock nobody holds and
+pass. The tests therefore hold **both** key spaces on schema A, and drive the
+real `Migrate` / `Store.Tx` code paths rather than mirroring the SQL literal.
+Confirmed by patching production back to the bare key: both tests fail with
+"blocked on schema A's lock", and pass once restored.
+
+## Origin
+
+Found while researching multi-app rela-server (RES-S8CH9C), where
+schema-per-project makes this systematic. Independent of that work.

--- a/tickets/entities/bugs/BUG-CA3VY0.md
+++ b/tickets/entities/bugs/BUG-CA3VY0.md
@@ -10,7 +10,7 @@ why3: pgstore was designed single-schema-per-database. The change feed hit the s
 why4: 'When the sweep lock was fixed under #1217, the fix was scoped to the lock that caused the observed e2e starvation; the migrate and write locks share the root cause but produce blocking rather than data loss, so nothing surfaced them.'
 why5: No test exercised two schemas contending on the same database for the migrate or write paths, so the shared-key assumption was never falsifiable.
 prevention: All three advisory locks now use the two-key form pg_advisory_xact_lock(key, hashtext(current_schema())). Pinned by TestMigrateDoesNotBlockAnotherSchema and TestWriteTxDoesNotBlockAnotherSchema, which drive the REAL Migrate/Tx code paths and hold BOTH the scoped and legacy key spaces on the blocking schema — without holding the legacy space a regression to the bare key would take a lock nobody holds and pass. Verified fail-before/pass-after. The sweep's silent lost-lock branch now escalates to a warning after 10 consecutive skips.
-status: in-progress
+status: done
 ---
 
 ## Summary

--- a/tickets/entities/implementation-checklists/IMPL-CXK5UB.md
+++ b/tickets/entities/implementation-checklists/IMPL-CXK5UB.md
@@ -1,0 +1,95 @@
+---
+id: IMPL-CXK5UB
+type: implementation-checklist
+title: 'Implementation: pgstore migrate and write advisory locks are not schema-qualified'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Development
+
+- [x] Unit tests written for new code
+- [x] Integration tests written (test full flow, not just units)
+- [x] Happy path implemented
+- [x] Edge cases from planning handled
+- [x] Error handling in place (errors surfaced, not swallowed)
+
+`TestXactAdvisoryLocksAreSchemaScoped` is the lock-level pin (both classes,
+independent across schemas, still exclusive within one).
+`TestMigrateDoesNotBlockAnotherSchema` and `TestWriteTxDoesNotBlockAnotherSchema`
+are the integration-level pins — real `Migrate` / `Store.Tx`, real database, real
+contention.
+
+## Test Quality
+
+- [x] Using fixture builders or factories for test data
+- [x] No hardcoded values in assertions when object is in scope
+- [x] Only specifying values that matter for the test
+- [x] Interpolated values constructed from objects, not hardcoded
+- [x] Property comparisons use original object, not hardcoded strings
+
+Reuses `newScopedPool` / `stubProvider` / `mkEntity`. The two lock-key constants
+are restated in the test file because they are unexported; the tests that matter
+drive production code rather than the literal.
+
+## Manual Verification
+
+- [x] Feature manually tested end-to-end
+- [x] Each acceptance criterion verified with test scenario from planning
+- [x] Edge cases manually verified
+
+**Verification Evidence:**
+
+Ran against a real throwaway PostgreSQL 15 instance (not a mock).
+
+**Both regression tests verified to fail before the fix.** Production was
+patched back to the bare one-key form:
+
+```text
+--- FAIL: TestMigrateDoesNotBlockAnotherSchema (10.51s)
+    schema B's migration blocked on schema A's migrate lock — the key is not schema-scoped
+--- FAIL: TestWriteTxDoesNotBlockAnotherSchema (10.17s)
+    schema B's write Tx blocked on schema A's write lock — the key is not schema-scoped
+```
+
+Both pass after restoring (0.07s each).
+
+Worth recording: the **first** version of these tests passed against the patched
+code — a false negative. Holding only the scoped key space proves nothing,
+because Postgres treats one-key and two-key advisory locks as disjoint, so the
+bare-key regression grabbed a lock nobody held. Fixed by holding both spaces.
+The fail-before check is what caught it; without it the measure would have been
+decorative.
+
+Full suite green: pgstore against real Postgres (`ok ... 19.5s`, conformance
+harness + fuzz + tx stress), full default `go test ./...`, both build tags,
+`just arch-lint`, `just docs-check`, `just coverage-check` (76.3%), markdown lint.
+
+## Quality
+
+- [x] Code follows project patterns (check similar code)
+- [x] Checked for DRY opportunities — repeated literals, expressions, or
+patterns extracted to a helper / constant / type where it sharpens the contract
+(don't extract for its own sake; CLAUDE.md "three similar lines is better than a
+premature abstraction" still holds)
+- [x] No security issues introduced
+- [x] No silent failures (errors logged AND returned)
+- [x] No debug code left behind
+
+Follows the pattern #1217 set for the sweep lock, deliberately: three locks with
+one idiom beats two mechanisms doing the same job. An earlier draft introduced a
+Go-side `advisorylock.go` deriving keys as `class<<32 | hash(schema)`; it was
+dropped on rebase in favour of matching upstream. That is recorded in the bug
+and the analysis checklist, since the reasoning matters more than the diff.
+
+DRY: no helper extracted. Three call sites share a SQL idiom, not code, and
+`hashtext(current_schema())` inline at each lock site is clearer than a
+constructed string — the surrounding doc comments carry the rationale.
+
+No silent failures: the sweep's lost-lock branch, previously a bare `return nil`,
+now counts consecutive skips and warns after 10 that this schema's versions are
+not being captured. Deliberately still non-fatal.
+
+Debug/simulation code: the temporary bare-key patch used for fail-before
+verification was confirmed removed by grep, and the full suite re-run after.

--- a/tickets/entities/researchs/RES-S8CH9C.md
+++ b/tickets/entities/researchs/RES-S8CH9C.md
@@ -1,0 +1,347 @@
+---
+id: RES-S8CH9C
+type: research
+title: 'Multi-app rela-server: serving several projects (ticketing, ISMS, …) from one process with a switcher'
+summary: 'Multi-app rela-server as a horizon, reached by independently-justified refactorings. Storage: schema-per-project (DSN is the seam preserving DB-per-tenant and (tenant,project)->shard). Cross-project is a federation feature that must work ACROSS INSTALLS, so it is not a storage-layout tradeoff. Tenancy: control-plane-as-rela-project + wire the existing VerifyAssertion claims. R1 (schema-qualify advisory locks) is a latent bug to fix first.'
+status: done
+---
+
+## Problem
+
+One `rela-server` process serves exactly one project. Running a ticketing system
+*and* an ISMS means two processes, two ports, two URLs, no shared chrome. The
+target is one server, one URL, a pulldown to switch.
+
+**This document is written as a horizon, not a project plan.** The intent is to
+drive smaller refactorings that each stand on their own merit while making the
+eventual setup easier. Nothing here should be built as a big-bang feature.
+
+## The horizon
+
+One process (or a fleet), N projects, a switcher listing what the signed-in
+principal's org may open. Storage sharded as far as demand requires, with the
+resident set of live projects bounded independently of total tenant count.
+
+**The load-bearing invariant that gets us there:**
+
+> As long as a single lookup — `(tenant, project) → DSN` — is the *only* thing
+> that knows where a project's data lives, tenant count is an operations
+> question, not an architecture one.
+
+That lookup resolves to a `search_path` on one instance today, a different host
+later, and a mix per deployment. `pgstore.Open(ctx, dsn)` already takes a DSN
+and nothing else — it cannot tell the difference. **The project registry and the
+shard map are the same object.** Keeping that true is the design constraint
+worth enforcing: the moment anything else hardcodes a DSN or assumes one
+instance, sharding stops being a config change.
+
+The corollary for process cost: at high tenant counts you never hold N live
+`Services` (each = bleve index, backfilled entities, Lua caches, watcher, SSE
+broker, scheduler goroutine). You lazy-load with LRU eviction via
+`Services.Close()` — the mechanism `rela-desktop` already exercises on every
+project switch. Sharding bounds storage; eviction bounds process memory. Same
+insight, two resources.
+
+## Where the codebase already is
+
+**The plumbing is largely done; the isolation is not.** The
+workspace-decomposition arc removed the `internal/workspace` singleton;
+`appbuild.go:1002` says so outright — "workspace was a process-singleton;
+appbuild is constructed per project on a long-running desktop".
+
+- `appbuild.Services`: per-project bundle, 22 accessors, all instance fields,
+zero package-level state, `sync.Once`-guarded `Close()` (`appbuild.go:982`).
+- `dataentry.NewApp(...)` takes the bundle explicitly; `project.Context` is a
+pure value type.
+- **`rela-desktop` already runs N projects in one long-lived process**
+(`cmd/rela-desktop/main.go:126-221`): build new `Services` + `App` + router,
+cancel old scheduler, swap under RWMutex, `Close()` previous *outside* the lock.
+Serial not concurrent, but the lifecycle discipline is exactly right.
+- Already per-instance, no collision: `acl.yaml` + `Declarative`
+(`appbuild.go:542`); `acl.Request` amortized per-HTTP-request
+(`router.go:196-293`); bleve per-`Services`, in-memory (`appbuild_fs.go:47`);
+audit sinks per project dir (`appbuild.go:689`); scheduler + watchers per
+`Services`; NOTIFY channels already schema-scoped (`feed.go:65-74`).
+- **`VerifyAssertion` already extracts `Subject`/`Email`/`OrgID`/`OrgSlug`/
+`Roles`** (`verifier.go:186-204`), bounded against hostile input.
+`principal.Verified(...)` already exists as the compile-enforced constructor
+(`orgID` unexported, no setter). Both are built and tested — just unwired.
+- The IdP webhook already carries `org_id` into a Lua action that provisions
+entities (`webhook.go:175`). Org membership is *already* designed to land in a
+rela graph.
+
+## Cross-project is federation, not a storage-layout question
+
+**Decided (2026-07-26): cross-project linking must work ACROSS INSTALLS**, not
+merely across projects inside one database. That settles a question this
+document previously got wrong.
+
+An earlier draft listed "no cross-project queries" as a *downside* of
+schema-per-project, implying a tenant column would have bought them via a SQL
+join. That framing is void: a join only ever worked inside a single database, so
+it was never a solution to federation across separate deployments.
+Schema-per-project therefore forecloses **nothing that was actually available**,
+and the storage choice below is unconstrained by this requirement.
+
+Cross-project support is its own feature with its own design — stable
+cross-install entity references, a resolution protocol, auth between installs,
+and partial-availability semantics when a remote install is unreachable or a
+reference dangles. Nearest prior art in-tree is the machine-to-machine sync API
+(`/api/sync/`, `a.sync.registerSyncRoutes` at `router.go:95`). It should be
+researched separately; it is explicitly NOT a byproduct of table layout, and it
+must not be used to justify a storage decision in either direction.
+
+## Storage: schema-per-project
+
+Chosen over a tenant column on every table.
+
+**Why the column option is worse than it looks.** `entities.id` is a bare `TEXT
+COLLATE "C" PRIMARY KEY` (`0001_init.sql:31`). A tenant column makes that
+composite and propagates: every PK/FK (`relations` `(from_id,rel_type,to_id)`,
+`attachments`, `entity_versions`, `relation_versions`), ~20 indexes across 6
+migrations including two GIN indexes on `search_text` (which don't take a
+leading scalar efficiently), and every query in `pgstore` gains `AND project_id
+= $n`. **Miss one and it's a silent cross-tenant leak with no compile-time
+error.** Plus `rela_seq`/`version_seq` would interleave across tenants, muddying
+the change-feed watermark.
+
+Schema-per-project gets isolation from Postgres itself — wrong-schema access is
+"relation does not exist", not a missing WHERE. Indexes, sequences, manual IDs
+and collation-sensitive keyset pagination all keep working byte-for-byte. And
+`testdb_test.go:84-115` already runs N migrated isolated schemas on one database
+with per-schema pools: this is promoting the test harness, not new design.
+
+**Honest downsides:** migrations run N times with mixed-version partial-failure
+states; DDL sprawl across catalogs; project IDs become schema names so they are
+a trust boundary needing strict validation (`^[a-z][a-z0-9_]{0,30}$`). Note that
+in-database cross-project joins are NOT on this list — see the federation
+section above.
+
+**The connection ceiling — measured, and the reason it is NOT terminal.**
+`pgstore.Open` (`open.go:24-66`) builds a pool per call with **no `MaxConns`
+override** (pgx defaults to `max(4, numCPU)`) plus a **dedicated listener
+connection outside the pool** (`open.go:52`), plus a sweep goroutine acquiring
+from the pool. On a 16-core box that is ~17 connections/project; against a
+typical `max_connections=100`, ~20 projects.
+
+That ceiling is an artifact of **one pool per project**, not of schemas.
+Schema-per-project preserves the option of one shared pool with `SET
+search_path` per checkout, which raises it substantially. Not free — it fights
+pgx's model and interacts badly with the sweep's session-scoped advisory lock
+(`sweep.go` warns that issuing inserts via the pool would "silently void the
+single-writer guarantee"). Not early work, but the option exists.
+
+**DB-per-tenant** (considered, not chosen now): wins on blast radius (per-tenant
+dump/restore, `DROP DATABASE` for GDPR erasure, per-tenant tuning and
+credentials), and makes the advisory-lock and NOTIFY-channel qualification
+redundant rather than load-bearing. But a pooled connection is **bound to one
+database** — you cannot share a pool across databases, so it permanently
+forecloses the one optimization that raises the ceiling. PgBouncer is the usual
+escape and is a poor fit here: it conflicts with `LISTEN/NOTIFY` (needs session
+pooling) and with session-scoped advisory locks. Right answer only when a
+*compliance* requirement demands physical separation — a business input, not a
+technical one.
+
+**Sharding at high counts** — `(tenant, project) → DSN` returning a host instead
+of a `search_path`. Composes with schema-per-project (shard to an instance, then
+schema within it), so the connection ceiling becomes per-shard and scales
+horizontally. Genuinely hard parts are not the routing: the map becomes critical
+infrastructure needing caching/invalidation (and cannot live in a sharded rela
+project without recursion — an argument for a small, boringly-hosted control
+plane); **rebalancing** is a real project (stop writes, drain the change feed,
+dump/restore, update map — subtle with the sweep's lock in flight); fleet
+migrations gain partial-failure states; per-shard failure becomes partial outage
+needing honest degradation in the switcher.
+
+## Multi-tenancy: control-plane-as-rela-project
+
+Nothing in identity or ACL can currently express "user X may access project A
+but not B". `principal.Principal` (`principal.go:68-76`) has no project field,
+and the org claim is explicitly non-enforcing — `principal.go:100-103`:
+"ATTRIBUTION ONLY... a principal in org A holding a role sees every entity that
+role grants, in EVERY org... Enforcement is deliberately deferred; see
+**TKT-RP3X3Q**." Confirmed: `OrgID()` has one non-test caller outside its
+package (`router.go:320`), zero ACL evaluation sites. The production gate calls
+`VerifySubject` (`jwtgate.go:141`), **discarding org/roles before they reach
+ctx**; the path that populated them (`JWTPrincipalResolver`) is deprecated and
+unwired.
+
+**Proposal: make the registry itself a rela project** (`_control`):
+
+```yaml
+entities:
+  org:    { properties: [name, idp_org_id] }
+  app:    { properties: [slug, project_path, dsn, description] }
+  person: { properties: [email, idp_subject] }
+relations:
+  org--has-app-->app
+  person--member-of-->org
+  person--granted-->app     # optional per-user override
+```
+
+The data-entry UI becomes the admin console — no new CRUD screens; validation,
+audit, versioning, MCP tools and Lua automations all apply. The IdP webhook
+already fits (`membership.created` → Lua action → create person, link
+`member-of`). ACL on the control plane is just its own `acl.yaml` — no second
+authorization system.
+
+**Do not hardcode org→principal.** `VerifyAssertion` already carries it;
+hardcoding strands the second customer.
+
+**Bootstrap** (the real objection — the control plane can't authorize access to
+itself using itself): its own `acl.yaml` uses `asserted_role_assignments`
+(`policy.go:100`) against an IdP claim, so the IdP is the root of trust and
+there is no recursion. That path is already per-policy hence per-project, and is
+dead in production *only* because the gate strips roles — so wiring
+`VerifyAssertion` lights up an existing designed path rather than inventing one.
+
+**Still Go work regardless of being metamodel-based:** wire the gate to
+`VerifyAssertion` (respecting the deliberate identity-source exclusivity in
+`main.go:199-231` — do not reintroduce an auth-downgrade path); project
+selection *before* `attachACLRequest`; the switcher's list as a new
+cross-project authorization decision with no existing home; a cache with
+invalidation (note `acl.yaml` has no reload/watcher today).
+
+**Keep per-project identity per-project.** `principal_property` resolution
+(`router.go:306-323`) resolves against *the project's own graph*, so the same
+email is a different `PERS-…` per project. Org membership lives in the control
+plane; a globally-cached principal would be wrong.
+
+## Refactorings that stand on their own merit
+
+Ordered by independence. Each is justified without committing to multi-tenancy —
+that is the point.
+
+**R1 — Schema-qualify the advisory lock keys. ✅ DONE.** All three of pgstore's
+advisory locks used unqualified compile-time constants, but PG advisory locks are
+**database-wide**, so two schemas on one database contended on all three.
+Severity varied sharply, which is why the fix arrived in two parts:
+
+- **Version sweep** — the severe one. Non-blocking `pg_try_advisory_lock` plus a
+  silent `return nil` on failure meant the losing schema's version capture was
+  **dropped with no error, warning or metric**. Fixed independently by **#1217
+  (TKT-SCXHUL)**, which surfaced it when parallel postgres e2e workers starved
+  each other. Uses the two-key form
+  `pg_try_advisory_lock(key, hashtext(current_schema()))`.
+- **Migrate + write Tx** — blocking rather than lossy, so nothing forced them
+  into view. Fixed under **BUG-CA3VY0**, adopting #1217's idiom rather than a
+  competing mechanism.
+
+Two things worth carrying forward from doing this:
+
+1. **The low-severity instances of a defect outlive the high-severity one.** The
+   sweep variant got fixed because it lost data visibly; the identical root cause
+   in migrate and write survived that pass. When fixing a class of bug, grep for
+   the class, not the symptom.
+2. **A regression test for lock scoping is easy to write and useless.** Holding
+   the *scoped* key and asserting the other schema proceeds passes even against
+   the un-fixed code — Postgres treats one-key and two-key advisory locks as
+   disjoint spaces, so the bare-key regression takes a lock nobody holds. The
+   first draft of the tests did exactly this and passed against a deliberately
+   broken build. Only a fail-before check caught it.
+
+This was **not** a multi-tenancy prerequisite — it was a latent bug in the
+current single-project design, since the conformance harness already runs many
+schemas per database. It just happens to also be a precondition for
+schema-per-project.
+
+**R2 — Make the DSN an explicit parameter rather than an ambient env read.**
+`appbuild.Discover` hardcodes `os.Getenv("RELA_DATABASE_URL")`
+(`appbuild.go:698`); `Config.DatabaseURL` is *already* a per-`Config` field, so
+`New` is fine and only `Discover` is ambient. **7 call sites** reach `Discover`
+(`cmd/rela-server`, `cmd/rela-docs`, `internal/docscapture`,
+`internal/cli/{mcp_wiring,flow,kong,validate}`) — broad but shallow. Merit on
+its own: ambient env reads are the classic testability and
+surprise-in-a-second-context problem. **This is the seam that preserves every
+storage option** (schema / DB-per-tenant / shard) at zero cost now. Keep the
+credential out of argv — config file or env, never a flag (`main.go:120-122`).
+
+**R3 — Adopt desktop's teardown ordering in the server.** `rela-server`
+deliberately never calls `svc.Close()` (`main.go:375-378`, "the daemon-lifetime
+case"), while desktop does it properly. Merit on its own: makes the server's
+lifecycle testable and correct under reload. Prerequisite for any registry that
+adds/removes projects, and for LRU eviction later.
+
+**R4 — Make per-project failure non-fatal.** `discoverProject`
+(`main.go:144-153`) `os.Exit(1)`s. With N projects one bad project must not kill
+the server. Merit on its own: better single-project diagnostics too.
+
+**R5 — Route the frontend's API base through one place.** `api/client.ts:13`
+axios `baseURL` is nearly the single chokepoint, but ~8 sites bypass it: raw
+`fetch` in `api/settings.ts:74,82,95,103` and `api/theme.ts:24,40,59,92`;
+builders in `api/attachments.ts:11`, `api/transforms.ts:35,53`; `EventSource`
+(`useEvents.ts:95`); iframe src (`AppHostView.vue:21`); plus legacy non-`/v1`
+paths (`HelpModal.vue:37`, `CommandModal.vue`). Merit on its own: consistent
+interceptors, error handling, and testability.
+
+**R6 — Wire the gate to `VerifyAssertion`.** Stops discarding verified claims.
+Merit on its own: roles become available to `asserted_role_assignments`, which
+is a documented, built, currently-dead feature. Respect the identity-exclusivity
+rationale in `main.go:199-231`.
+
+**R7 — Project-prefix-aware app CSP.** `appCSP(base)` is path-scoped
+(`internal/dataentry/CLAUDE.md`); a prefix must flow into that base or the
+iframe sandbox boundary silently loosens. **Security-load-bearing** — needs
+review, not mechanical care. Only meaningful alongside prefix routing, so it is
+the one item genuinely coupled to the feature.
+
+**R8 (separate research, not a refactoring) — cross-install federation.** See
+the federation section above. Independent of everything else here.
+
+## Routing seam (when the time comes)
+
+`App.NewRouter()` (`router.go:58`) builds a fresh `ServeMux` with absolute path
+literals; `api_v1.go:133` strips a hardcoded `/api/v1/`; security middleware
+assumes `/api/` at position 0 (`middleware_security.go:208,246,269`;
+`router.go:167`). Cleanest: leave it untouched and wrap —
+`outer.Handle("/p/{id}/", http.StripPrefix("/p/"+id, app.NewRouter()))` — so
+internal literals and the middleware chain consistently see the stripped path.
+Pin with the probe table in `router_walk_test.go`. Caveat: `spaHandler`
+(`router.go:592-608`) serves an `index.html` referencing `/assets/*`, which 404s
+under a prefix unless Vite `base` matches or assets mount unprefixed.
+
+Frontend switch cost is **bimodal**: a hard-navigation switch
+(`window.location.assign('/p/<id>/')`) skips *all* cache invalidation, route
+changes and `/:project` threading — a reload wipes the three project-unaware
+caches (Pinia `schema`/`entities`, the Colada cache at `queries/entities.ts:41`)
+and module globals (`registerEntityPlurals`, the `eventSource` singleton) for
+free, as chunk-reload recovery already does (`main.ts:58`). In-place switching
+is several days more and carries two bug traps: the `loadPromise` in-flight
+dedupe race (`schema.ts:59`) and that module-global plural registry.
+
+There is **no frontend auth layer at all** — session is server-side same-origin
+cookies, so a path prefix gets per-project cookie scoping free; a header scheme
+would not. No top header bar exists; the sidebar header (`Sidebar.vue:146-156`)
+already shows project logo + name and is the natural switcher home — but the
+file is at 519 lines against a 500-line lint warning, so extract
+`ProjectSwitcher.vue`.
+
+## Recommendation
+
+**Treat this as a horizon and bank R1–R6 opportunistically.** Each is
+independently justified; together they mean the eventual feature is assembly
+rather than surgery.
+
+**R1 is done** (#1217 for the sweep lock, BUG-CA3VY0 for migrate + write) — it
+was a latent bug in the current design, not a multi-tenancy concern, which is
+exactly why it was the right thing to do first: it paid for itself regardless of
+whether multi-app is ever built. **R2 (per-project DSN) is the next one to
+bank** — it is the seam that keeps schema-per-project, DB-per-tenant and
+`(tenant, project) → shard` all reachable, and its own justification (an ambient
+env read is untestable and surprising in a second context) stands without any of
+them.
+
+When the feature is built, phase on trust model:
+- **Trusted users, all projects visible** (one team running its own ticketing +
+ISMS): prefix routing + hard-navigation switch + per-project DSN. Per-project
+`acl.yaml` already works; the missing tenancy dimension is not needed. Days.
+- **Users who must NOT see some projects**: the control plane + R6 + an
+enforcement site. Until that exists, **separate processes behind a reverse proxy
+is the honest answer** — process isolation provides the guarantee the in-process
+model cannot yet make. A switcher listing projects a user cannot open is worse
+than no switcher; one listing projects they *should not see* is an incident.
+
+Accepted tradeoffs: logical not physical isolation in-process (a project's
+expensive export shares CPU/memory); memory linear in *resident* projects (fine
+for ~10, then lazy-load + LRU via `Services.Close()`). Cross-install federation
+is deferred to its own design and does not constrain this one.

--- a/tickets/entities/review-checklists/REV-S577SC.md
+++ b/tickets/entities/review-checklists/REV-S577SC.md
@@ -2,7 +2,7 @@
 id: REV-S577SC
 type: review-checklist
 title: 'Review: pgstore migrate and write advisory locks are not schema-qualified'
-status: in-progress
+status: done
 ---
 
 <!-- @managed: claude-workflow v1 -->
@@ -98,11 +98,35 @@ which this change makes false. Corrected in the **source**
 
 ## Pull Request
 
-- [ ] Run `/pr` command to create PR and monitor CI
-- [ ] All CI checks pass
-- [ ] PR URL documented below
+- [x] Run `/pr` command to create PR and monitor CI
+- [x] All CI checks pass
+- [x] PR URL documented below
 
 Branch `fix/pgstore-schema-scoped-advisory-locks`, rebuilt on current `develop`
-(a2b78c0c) after #1217 landed the sweep half of this defect.
+(a2b78c0c) after #1217 landed the sweep half of this defect. Local `just ci`
+green (exit 0) before push.
 
-**PR:** not created yet
+Remote CI: every job green including **Postgres Backend** (which runs this
+change's new tests against a real database), Test, Fuzz, Architecture, Frontend,
+CodeQL, God-object lint, Lint Markdown, Vulnerability Check, and all six
+cross-compile targets.
+
+One job — **Rela Tickets** — failed on the first run, for the reason recorded
+below rather than a defect in the change.
+
+### The `done`-before-PR ordering
+
+The `/pr` workflow gates on the bug being `status=done` before the PR opens, and
+CI enforces the same rule. But this checklist's own final section requires a PR
+URL and green CI, neither of which can exist before the PR does. The gate is
+circular for any ticket that reaches it honestly.
+
+Resolved by opening the PR first, letting CI substantively validate the change,
+then closing this checklist and transitioning the bug — the only order in which
+every box above is true when ticked. The first `Rela Tickets` run therefore
+failed by construction; it passes on re-run now that the graph is complete.
+
+Flagged to the user rather than silently reinterpreted. If the intended order is
+the reverse, the fix is to treat the PR section as N/A at transition time.
+
+**PR:** https://github.com/sourcehaven-bv/rela/pull/1253

--- a/tickets/entities/review-checklists/REV-S577SC.md
+++ b/tickets/entities/review-checklists/REV-S577SC.md
@@ -1,0 +1,108 @@
+---
+id: REV-S577SC
+type: review-checklist
+title: 'Review: pgstore migrate and write advisory locks are not schema-qualified'
+status: in-progress
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Automated Checks
+
+- [x] All tests pass (`just test`)
+- [x] Lint clean (`just lint`)
+- [x] Coverage maintained (`just coverage-check`)
+
+Full default-build `go test ./...` green; both build tags compile; pgstore suite
+green against a real PostgreSQL 15 (`ok ... 19.5s`, including the storetest
+conformance harness, fuzz corpus and tx stress tests). `just arch-lint` OK.
+`just docs-check` OK (generated docs regenerated from `docs-project/`).
+`just coverage-check`: 76.3%, package and total floors satisfied.
+golangci-lint clean for this change — the only remaining findings in the package
+are three pre-existing issues in `graphquery_explain_test.go` (govet shadow,
+misspell, whitespace), confirmed not mine via `git diff`. Markdown lint clean.
+
+## Code Review
+
+- [x] Run `/code-review` command (invokes cranky-code-reviewer agent)
+- [x] All critical review-responses addressed
+- [x] All significant review-responses addressed
+- [x] Self-reviewed the diff for unrelated changes
+
+The review ran against the **earlier** Go-side implementation of this fix and
+found 6 issues (1 critical, 2 significant, 2 minor, 1 nit). Five of them were
+defects *in that mechanism* — a NULL-vs-empty scan, a `current_schema()` /
+table-schema divergence, a hash too narrow, a debug-only starvation log, and
+tautological key-derivation tests.
+
+That mechanism was then **abandoned** on rebase in favour of #1217's SQL-level
+`hashtext(current_schema())` form, which is simpler and never had any of those
+problems. The corresponding review-responses were deleted rather than marked
+addressed: keeping critiques of code that no longer exists would misrepresent
+the change. Their substance is preserved where it still applies — the starvation
+warning was kept, and the "assert on captured versions, not lock acquisition"
+insight now drives the sweep test.
+
+**RR-NAOG9H (significant) survives and is addressed**: the rolling-deploy window
+where old and new binaries compute different keys. Assessment updated for the
+new mechanism; note #1217 already shifted the sweep lock's key space the same
+way, so this is the second and last such transition.
+
+Self-review: the diff is 3 production files (`migrate.go`, `tx.go`, `sweep.go`),
+1 new test file, 1 docs source + its generated output, and the ticket graph.
+`purge.go`, `export_test.go` and `tx_stress_test.go` were reverted to develop —
+the earlier draft had touched them only because of the abandoned mechanism.
+
+**Review Responses:** RR-NAOG9H (significant, addressed). Six others deleted as
+obsolete — see above.
+
+## Acceptance Verification
+
+- [x] Each acceptance criterion tested (reference planning checklist)
+- [x] Test evidence documented in implementation checklist
+
+**Acceptance Status:**
+
+- Two schemas migrate independently — **PASS**.
+  `TestMigrateDoesNotBlockAnotherSchema`, verified to FAIL against the bare key.
+- Two schemas write independently — **PASS**.
+  `TestWriteTxDoesNotBlockAnotherSchema`, verified to FAIL against the bare key.
+- Locks still mutually exclusive *within* a schema — **PASS**.
+  `TestXactAdvisoryLocksAreSchemaScoped` asserts the negative case too.
+- Sweep behaviour unchanged and still correct — **PASS**. Upstream's
+  `TestSweepAdvisoryLockIsSchemaScoped` plus
+  `TestSweepCapturesWhileAnotherSchemaHoldsLock`, which asserts captured versions.
+- pgstore conformance suite still passes — **PASS**.
+
+## Documentation (enhancements only)
+
+Skip this section for bugs and internal refactors.
+
+- [x] ~~Docs-checklist created and linked via `has-docs`~~ (N/A: bug fix, not an
+  enhancement)
+- [x] User-facing documentation updated
+- [x] ~~Docs-checklist marked as done~~ (N/A: bug fix, not an enhancement)
+
+The postgres guide claimed write transactions were serialized "deployment-wide",
+which this change makes false. Corrected in the **source**
+(`docs-project/entities/guides/GUIDE-postgres-backend.md`) and regenerated —
+`docs/` is auto-generated and CI enforces it matches.
+
+**Docs Checklist:** N/A
+
+## Final Checks
+
+- [x] Commit message explains the why, not just what
+- [x] No TODOs or FIXMEs left unaddressed
+- [x] Ready for another developer to use
+
+## Pull Request
+
+- [ ] Run `/pr` command to create PR and monitor CI
+- [ ] All CI checks pass
+- [ ] PR URL documented below
+
+Branch `fix/pgstore-schema-scoped-advisory-locks`, rebuilt on current `develop`
+(a2b78c0c) after #1217 landed the sweep half of this defect.
+
+**PR:** not created yet

--- a/tickets/entities/review-responses/RR-NAOG9H.md
+++ b/tickets/entities/review-responses/RR-NAOG9H.md
@@ -1,0 +1,31 @@
+---
+id: RR-NAOG9H
+type: review-response
+title: 'Rolling deploy: old and new binaries use different migrate/write lock keys'
+finding: Changing a lock-key derivation means that during a rolling deploy, old and new processes on the SAME schema compute DIFFERENT keys and are therefore not mutually excluded. pgstore.Open calls Migrate on every store open, so every starting process is a migrator, and migrations are not individually idempotent (bare CREATE TABLE, ALTER TABLE DROP CONSTRAINT).
+severity: significant
+resolution: 'Documented rather than redesigned, and the exposure is smaller than first assessed. The write lock is belt-and-braces over work that is already transactional with row-level locking, so a brief mixed window degrades isolation rather than correctness. For migrate, the whole thing runs in ONE transaction and PostgreSQL''s own catalog locks serialize concurrent DDL, so the loser rolls back atomically — a failed startup needing a restart, never a corrupted schema — and only on a release that changes lock keys AND adds a migration together. This branch adds no migration. Note the same one-time window already occurred for the sweep lock in #1217, so this is the second and last such transition.'
+status: addressed
+---
+
+Assessed per lock rather than treating "different keys during deploy" as one
+issue:
+
+- **Write Tx** — not a correctness problem. `Tx` serialization sits over work
+that is already transactional with row-level locking; briefly losing
+cross-process serialization degrades isolation, not committed rows.
+- **Migrate** — the sharper one, and the reason for the docs note. Loud and
+atomic: one transaction, catalog locks serialize the DDL, loser rolls back.
+
+Rejected a dual-key transition scheme (taking both old and new keys during a
+deprecation release) as over-engineering for a failure mode that is loud, atomic
+and self-correcting.
+
+**Why no docs note in the end.** The first draft of this fix added an upgrade
+paragraph to the postgres guide. It was dropped when the change was rebased onto
+#1217: that PR had already shifted the sweep lock's key space without an upgrade
+note, so a note attached only to the migrate/write transition would imply the
+sweep transition was safer than it was. The realistic exposure — a startup that
+fails loudly and succeeds on retry, only when a release changes keys and adds a
+migration together — does not warrant permanent guide text. Recorded here
+instead, where it is discoverable from the bug.

--- a/tickets/relations/BUG-CA3VY0--adds-measure--pgstore-per-schema-sweep-capture-test.md
+++ b/tickets/relations/BUG-CA3VY0--adds-measure--pgstore-per-schema-sweep-capture-test.md
@@ -1,0 +1,5 @@
+---
+from: BUG-CA3VY0
+relation: adds-measure
+to: pgstore-per-schema-sweep-capture-test
+---

--- a/tickets/relations/BUG-CA3VY0--affects--store-backends.md
+++ b/tickets/relations/BUG-CA3VY0--affects--store-backends.md
@@ -1,0 +1,5 @@
+---
+from: BUG-CA3VY0
+relation: affects
+to: store-backends
+---

--- a/tickets/relations/BUG-CA3VY0--fixes--FEAT-5UYW8F.md
+++ b/tickets/relations/BUG-CA3VY0--fixes--FEAT-5UYW8F.md
@@ -1,0 +1,5 @@
+---
+from: BUG-CA3VY0
+relation: fixes
+to: FEAT-5UYW8F
+---

--- a/tickets/relations/BUG-CA3VY0--has-bug-analysis--BUGA-WV60XG.md
+++ b/tickets/relations/BUG-CA3VY0--has-bug-analysis--BUGA-WV60XG.md
@@ -1,0 +1,5 @@
+---
+from: BUG-CA3VY0
+relation: has-bug-analysis
+to: BUGA-WV60XG
+---

--- a/tickets/relations/BUG-CA3VY0--has-implementation--IMPL-CXK5UB.md
+++ b/tickets/relations/BUG-CA3VY0--has-implementation--IMPL-CXK5UB.md
@@ -1,0 +1,5 @@
+---
+from: BUG-CA3VY0
+relation: has-implementation
+to: IMPL-CXK5UB
+---

--- a/tickets/relations/BUG-CA3VY0--has-review--REV-S577SC.md
+++ b/tickets/relations/BUG-CA3VY0--has-review--REV-S577SC.md
@@ -1,0 +1,5 @@
+---
+from: BUG-CA3VY0
+relation: has-review
+to: REV-S577SC
+---

--- a/tickets/relations/BUG-CA3VY0--has-review-response--RR-NAOG9H.md
+++ b/tickets/relations/BUG-CA3VY0--has-review-response--RR-NAOG9H.md
@@ -1,0 +1,5 @@
+---
+from: BUG-CA3VY0
+relation: has-review-response
+to: RR-NAOG9H
+---

--- a/tickets/relations/RES-S8CH9C--researches--authorization.md
+++ b/tickets/relations/RES-S8CH9C--researches--authorization.md
@@ -1,0 +1,5 @@
+---
+from: RES-S8CH9C
+relation: researches
+to: authorization
+---

--- a/tickets/relations/RES-S8CH9C--researches--data-entry-server.md
+++ b/tickets/relations/RES-S8CH9C--researches--data-entry-server.md
@@ -1,0 +1,5 @@
+---
+from: RES-S8CH9C
+relation: researches
+to: data-entry-server
+---

--- a/tickets/relations/RES-S8CH9C--researches--workspace.md
+++ b/tickets/relations/RES-S8CH9C--researches--workspace.md
@@ -1,0 +1,5 @@
+---
+from: RES-S8CH9C
+relation: researches
+to: workspace
+---


### PR DESCRIPTION
## Problem

PostgreSQL advisory locks are **database-wide**. pgstore's migrate and write-Tx
locks use bare compile-time keys, so two rela schemas sharing one database
serialize their startup migrations, and every write transaction, against each
other despite being independent deployments.

This is the tail of a defect whose worst instance is already fixed. #1217
(TKT-SCXHUL) schema-scoped the **version-sweep** lock after parallel postgres
e2e workers starved each other — there the symptom was severe (non-blocking
acquire + silent `return nil` meant the losing schema's version capture was
dropped with no error). The migrate and write locks share the root cause but
merely *block*, so nothing forced them into view.

## Fix

Adopt #1217's idiom rather than a competing mechanism:

```sql
pg_advisory_xact_lock($1::int, hashtext(current_schema()))
```

One form across all three locks. Postgres-native, no Go-side schema resolution,
no extra round-trip. For migrate, `current_schema()` is the correct anchor:
unqualified DDL lands there, so it is by definition the schema being migrated.

## Also here

The sweep's lost-lock branch was a bare `return nil`. That silence is what let
the sweep half go unnoticed until e2e collided. It now counts consecutive skips
and escalates from debug to a **warning** after 10, stating that this schema's
versions are not being captured. Still non-fatal — same-schema multi-process
contention is the legitimate case the lock exists for.

## Test design note

The obvious test — hold schema A's *scoped* lock, assert B proceeds — **does not
falsify**. Postgres treats one-key and two-key advisory locks as disjoint
spaces, so a regression to the bare key takes a lock nobody holds and passes.
The first draft of these tests did exactly that and passed against a
deliberately broken build.

The tests therefore hold **both** key spaces on the blocking schema and drive
the real `Migrate` / `Store.Tx` rather than mirroring the SQL literal. Verified
fail-before / pass-after against a real PostgreSQL 15:

```
--- FAIL: TestMigrateDoesNotBlockAnotherSchema (10.51s)
    schema B's migration blocked on schema A's migrate lock — the key is not schema-scoped
--- FAIL: TestWriteTxDoesNotBlockAnotherSchema (10.17s)
    schema B's write Tx blocked on schema A's write lock — the key is not schema-scoped
```

## Upgrade note

Like #1217 before it, this shifts a lock's key space, so during a rolling deploy
old and new processes on one schema are briefly not mutually excluded. The write
lock sits over work that is already transactional with row-level locking, so
that window degrades isolation rather than correctness. For migrate the whole
thing runs in one transaction and PostgreSQL's catalog locks serialize the DDL —
the loser rolls back atomically, so the worst case is a startup that fails
loudly and succeeds on retry, and only on a release that changes keys *and* adds
a migration. This one adds no migration.

## Verification

`just ci` green. pgstore suite against real PostgreSQL 15 (conformance harness,
fuzz corpus, tx stress). Both build tags. arch-lint, docs-check, coverage 76.3%,
markdown lint.

Closes BUG-CA3VY0.