### PR TITLE
fix(release): install bubblewrap in the release test gate (BUG-2J30F3)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,11 @@ permissions:
 jobs:
   test:
     name: Test
-    runs-on: ubuntu-latest
+    # Must match ci.yml's test job. 26.04, not ubuntu-latest: the command
+    # sandbox needs unprivileged user namespaces, which 24.04 restricts via
+    # AppArmor (apparmor_restrict_unprivileged_userns=1, seen as bwrap
+    # "Failed RTM_NEWADDR: Operation not permitted").
+    runs-on: ubuntu-26.04
     steps:
       - uses: actions/checkout@v7
 
@@ -24,6 +28,17 @@ jobs:
         uses: actions/setup-go@v7
         with:
           go-version: "1.26"
+
+      # External commands (attachment scan/transform, view export) run confined
+      # and FAIL CLOSED when no sandbox is available, so the runner needs
+      # bubblewrap or every command-running test fails. Without this the release
+      # gate fails on commits that pass CI, blocking the release — which is what
+      # left v26.7.1 a tag with no GitHub release.
+      - name: Install bubblewrap (command sandbox)
+        run: sudo apt-get update && sudo apt-get install -y bubblewrap
+
+      - name: Verify the sandbox actually works on this runner
+        run: bwrap --unshare-all --ro-bind / / /bin/true
 
       - name: Run tests
         run: go test -v -race ./...

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -126,6 +126,12 @@ the Actions tab.
   (govulncheck). If either fails, `release` is skipped and no assets are
   produced — this is correct gating, not a bug. Bump deps / fix the vuln
   and re-tag.
+- **Release-runner drift from CI.** The `test` job in `release.yml` is a
+  *second* copy of CI's test gate, so it can rot independently. It must
+  keep matching `ci.yml`'s: `ubuntu-26.04` plus the bubblewrap install.
+  External commands fail closed with no sandbox, so a runner without
+  `bwrap` fails ~35 attachment/cmdexec/transform/export tests — on a commit
+  that passed CI. This is what left `v26.7.1` a tag with no release.
 
 ## Verifying a release
 

--- a/tickets/entities/automated-measures/release-test-gate-sandbox-parity.md
+++ b/tickets/entities/automated-measures/release-test-gate-sandbox-parity.md
@@ -1,0 +1,9 @@
+---
+id: release-test-gate-sandbox-parity
+type: automated-measure
+title: 'Measure: release test gate installs and verifies bubblewrap like CI'
+description: 'Control for BUG-2J30F3. The test job in release.yml now pins ubuntu-26.04 and installs bubblewrap, mirroring ci.yml. It keeps CI''s `bwrap --unshare-all --ro-bind / / /bin/true` verification step so a runner without a working sandbox fails hard and visibly, instead of every confined-command test failing closed with an exec-not-found error that reads like a code defect. Scope is honest: this is a configuration mirror, not a test pin. The two gates remain duplicated and only the release one runs on tag push, so a future divergence is still possible — the structural control (a workflow_call gate shared by both workflows) is deferred.'
+kind: ci
+location: '.github/workflows/release.yml (test job: runs-on ubuntu-26.04; Install bubblewrap; Verify the sandbox actually works on this runner)'
+status: active
+---

--- a/tickets/entities/bugs/BUG-2J30F3.md
+++ b/tickets/entities/bugs/BUG-2J30F3.md
@@ -1,0 +1,67 @@
+---
+id: BUG-2J30F3
+type: bug
+title: Release test gate lacks bubblewrap so releases fail on commits that pass CI
+description: The test job in release.yml runs on ubuntu-latest without bubblewrap while ci.yml uses ubuntu-26.04 with it installed. Confined commands fail closed with no sandbox so 35 attachment/cmdexec/transform/export tests fail on a commit that passed CI. This gated the Release workflow and left v26.7.1 a tag with no release object.
+priority: high
+why1: The Release workflow test gate failed on the exact commit that had just passed CI on develop, so release, desktop and homebrew were skipped and v26.7.1 got a tag with no release object.
+why2: The runner had no bwrap binary, and confined external commands fail closed, so every attachment/cmdexec/transform/export test errored.
+why3: release.yml's test job ran on ubuntu-latest with no bubblewrap install step, while ci.yml's runs on ubuntu-26.04 and both installs and verifies it.
+why4: release.yml duplicates CI's test gate rather than reusing it, so the sandbox requirements added to ci.yml were never mirrored into release.yml.
+why5: Nothing enforces that the two gates stay equivalent, and the release gate only executes on a tag push — so drift stays invisible until a release is cut and cannot be caught at PR time.
+prevention: The release test gate now pins ubuntu-26.04, installs bubblewrap, and keeps ci.yml's `bwrap --unshare-all --ro-bind / / /bin/true` verification step so an absent sandbox is a hard failure rather than a silent mass-skip. docs/releasing.md documents runner drift from CI as a named release failure mode. The structural fix — a workflow_call reusable gate shared by both workflows, which would make this drift impossible — is deliberately deferred as a larger refactor.
+status: review
+---
+
+## Summary
+
+The `test` job in `.github/workflows/release.yml` is a second, independent copy
+of CI's test gate, and it had drifted from `.github/workflows/ci.yml`:
+
+|                | `ci.yml` test        | `release.yml` test (before) |
+| -------------- | -------------------- | --------------------------- |
+| Runner         | `ubuntu-26.04`       | `ubuntu-latest` (24.04)     |
+| bubblewrap     | installed + verified | **not installed**           |
+
+External commands (attachment scan/transform, view export) run confined via
+`internal/cmdexec` and **fail closed** when no sandbox is available. With no
+`bwrap` on the runner, every command-running test fails.
+
+## Impact
+
+`v26.7.1` was tagged successfully by `Tag Release`, but the `Release` workflow's
+`test` gate failed, so `release` / `desktop` / `homebrew` were all skipped.
+
+The result is the inverse of the `v0.8` / `v0.12` failure mode the release docs
+warn about: not an empty published release, but **a tag with no release object
+at all**. Consumers see no `v26.7.1` on the releases page and no assets.
+
+35 tests failed, all from the one cause:
+
+```
+sandbox_test.go:71: transform: cmdexec: start "bwrap":
+    exec: "bwrap": executable file not found in $PATH
+```
+
+Spanning `internal/attachment`, `internal/cli`, `internal/cmdexec`,
+`internal/dataentry` (export 500s — export shells out through `cmdexec`), and
+`internal/transform`. The identical commit passed CI on `develop` minutes
+earlier, which is the signature of runner drift rather than a code defect.
+
+## Fix
+
+Bring the release test gate back in line with CI: pin `ubuntu-26.04`, install
+bubblewrap, and keep the `bwrap --unshare-all --ro-bind / / /bin/true`
+verification step so an absent sandbox is a hard failure rather than a silent
+mass-skip.
+
+`docs/releasing.md` gains this as a named entry under "Why a release can
+silently produce no assets", since that list is where the release failure modes
+are enumerated.
+
+## Note on the duplicated gate
+
+The deeper issue is that the release test gate is a copy of CI's rather than a
+reuse of it. A `workflow_call` reusable workflow shared by both would make this
+class of drift impossible. Not done here — that is a larger refactor of both
+workflows and this needed to unblock the release.

--- a/tickets/entities/bugs/BUG-2J30F3.md
+++ b/tickets/entities/bugs/BUG-2J30F3.md
@@ -10,7 +10,7 @@ why3: release.yml's test job ran on ubuntu-latest with no bubblewrap install ste
 why4: release.yml duplicates CI's test gate rather than reusing it, so the sandbox requirements added to ci.yml were never mirrored into release.yml.
 why5: Nothing enforces that the two gates stay equivalent, and the release gate only executes on a tag push — so drift stays invisible until a release is cut and cannot be caught at PR time.
 prevention: The release test gate now pins ubuntu-26.04, installs bubblewrap, and keeps ci.yml's `bwrap --unshare-all --ro-bind / / /bin/true` verification step so an absent sandbox is a hard failure rather than a silent mass-skip. docs/releasing.md documents runner drift from CI as a named release failure mode. The structural fix — a workflow_call reusable gate shared by both workflows, which would make this drift impossible — is deliberately deferred as a larger refactor.
-status: review
+status: done
 ---
 
 ## Summary

--- a/tickets/entities/implementation-checklists/IMPL-099MO1.md
+++ b/tickets/entities/implementation-checklists/IMPL-099MO1.md
@@ -1,0 +1,52 @@
+---
+id: IMPL-099MO1
+type: implementation-checklist
+title: 'Implementation: Release test gate lacks bubblewrap so releases fail on commits that pass CI'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Development
+
+- [x] ~~Unit tests written for new code~~ (N/A: CI workflow configuration change, no Go code — the control is the workflow definition itself, see `release-test-gate-sandbox-parity`)
+- [x] ~~Integration tests written~~ (N/A: the release gate only executes on a tag push and cannot be exercised from a PR — this is why4/why5 of the bug, recorded rather than papered over)
+- [x] Happy path implemented — `release.yml` test job pins `ubuntu-26.04` and installs bubblewrap, mirroring `ci.yml`
+- [x] Edge cases handled — kept CI's `bwrap --unshare-all --ro-bind / / /bin/true` verification step so a runner where the sandbox is present but non-functional (the AppArmor `apparmor_restrict_unprivileged_userns` case the `ubuntu-26.04` pin exists for) fails loudly rather than mass-skipping
+- [x] Error handling in place — the verify step makes an absent/broken sandbox a hard named failure instead of 35 confusing `exec: "bwrap": executable file not found` errors that read like a code defect
+
+## Test Quality
+
+- [x] ~~Using fixture builders~~ (N/A: no test code added)
+- [x] ~~No hardcoded values in assertions~~ (N/A: no test code added)
+- [x] ~~Only specifying values that matter~~ (N/A: no test code added)
+- [x] ~~Interpolated values constructed from objects~~ (N/A: no test code added)
+- [x] ~~Property comparisons use original object~~ (N/A: no test code added)
+
+## Manual Verification
+
+- [x] Feature manually tested end-to-end — root cause confirmed from the failed run's logs before changing anything; `release.yml` re-parsed with a YAML loader after the edit to confirm the job structure (`runs-on: ubuntu-26.04` plus the 5 steps in order)
+- [x] Each acceptance criterion verified — the release `test` job now matches `ci.yml`'s runner and sandbox setup step-for-step
+- [x] Edge cases verified — audited the other release jobs (`security`, `release`, `desktop`, `homebrew`); none run sandboxed tests, so `ubuntu-latest` stays correct for them and the change is scoped to the one job that needed it
+
+**Verification Evidence:** Failed run 30433648340 on tag `v26.7.1`: `Test`
+failed, so `Release` / `Desktop` / `Update Homebrew Cask` were all skipped and
+no release object was created. 35 tests failed across `internal/attachment`,
+`internal/cli`, `internal/cmdexec`, `internal/dataentry` and
+`internal/transform`; every one traces to
+`cmdexec: start "bwrap": exec: "bwrap": executable file not found in $PATH`
+(the `internal/dataentry` export failures are 500s downstream of the same
+sandbox, since export shells out through `cmdexec`). The identical commit
+`ba0c1fd7` passed `CI` on `develop` minutes earlier — the signature of runner
+drift, not a code defect. Diffing the two workflows confirmed `ci.yml` installs
+and verifies bubblewrap on `ubuntu-26.04` while `release.yml` did neither on
+`ubuntu-latest`. Full verification is the next release run, since the gate is
+only reachable from a tag push.
+
+## Quality
+
+- [x] Code follows project patterns — copied `ci.yml`'s runner pin, install step and verify step verbatim, including the comment explaining why `ubuntu-26.04` rather than `ubuntu-latest`
+- [x] Checked for DRY opportunities — the real DRY fix is a `workflow_call` gate shared by both workflows, which would make this class of drift structurally impossible. Deliberately **not** done here: it is a refactor of both workflows and the immediate need was to unblock the release. Recorded in the bug's `prevention` and in the measure's description rather than silently dropped
+- [x] No security issues introduced — the added steps are static `apt-get` / `bwrap` invocations with no `github.event.*` interpolation, so no workflow-injection surface. Installing bubblewrap *strengthens* the gate: it makes the negative sandbox tests (asserting egress and out-of-allowlist reads are blocked) actually run instead of failing closed
+- [x] No silent failures — the verify step is the explicit guard against the silent case
+- [x] No debug code left behind

--- a/tickets/entities/review-checklists/REV-V0EO3S.md
+++ b/tickets/entities/review-checklists/REV-V0EO3S.md
@@ -1,0 +1,60 @@
+---
+id: REV-V0EO3S
+type: review-checklist
+title: 'Review: Release test gate lacks bubblewrap so releases fail on commits that pass CI'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Automated Checks
+
+- [x] All tests pass — pre-commit hook ran format, lint and tests: all green
+- [x] Lint clean — golangci-lint reported `0 issues.` via the pre-commit hook
+- [x] ~~Coverage maintained~~ (N/A: no Go code changed — the diff is one workflow file and one docs file)
+
+## Code Review
+
+- [x] ~~Run `/code-review`~~ (N/A: no application code — a 17-line CI workflow change, reviewed directly against `ci.yml` as the reference implementation)
+- [x] No critical review-responses raised
+- [x] No significant review-responses raised
+- [x] Self-reviewed the diff for unrelated changes — `git diff origin/develop` outside `tickets/` is exactly 2 files, +22/-1: the `release.yml` test job and one docs section. No stray edits
+
+**Review Responses:** none — no findings warranted a review-response entity.
+
+## Acceptance Verification
+
+- [x] Each acceptance criterion tested — the release `test` job now matches `ci.yml`'s runner (`ubuntu-26.04`) and both sandbox steps, confirmed by re-parsing the workflow YAML and by direct diff against `ci.yml`
+- [x] Test evidence documented in implementation checklist — see IMPL-099MO1 "Verification Evidence"
+
+**Acceptance Status:**
+
+- AC1 — release test gate runs on the same runner as CI: **PASS** (`runs-on: ubuntu-26.04`).
+- AC2 — bubblewrap installed before tests run: **PASS** (install step precedes `Run tests`).
+- AC3 — a broken/absent sandbox fails loudly rather than silently: **PASS** (`bwrap --unshare-all --ro-bind / / /bin/true` verify step retained from CI).
+- AC4 — no other release job regressed: **PASS** (`security`, `release`, `desktop`, `homebrew` untouched; none run sandboxed tests, so `ubuntu-latest` remains correct for them).
+- AC5 — the tag builds and publishes assets: **PENDING** — only verifiable by the next release run, since this gate is reachable only from a tag push.
+
+## Documentation (enhancements only)
+
+Skipped: this is a bug fix, not an enhancement. `docs/releasing.md` was still
+updated, since that file enumerates release failure modes and this is a new
+named one ("Release-runner drift from CI").
+
+- [x] ~~Docs-checklist created and linked~~ (N/A: bug fix, not an enhancement)
+- [x] ~~User-facing documentation updated~~ (N/A: no user-facing behaviour change — `docs/releasing.md` is a maintainer runbook and was updated)
+- [x] ~~Docs-checklist marked as done~~ (N/A: no docs-checklist)
+
+## Final Checks
+
+- [x] Commit message explains the why, not just what — names the CI parity requirement and the v26.7.1 consequence, not just "install bubblewrap"
+- [x] No TODOs or FIXMEs left unaddressed — the deferred `workflow_call` refactor is recorded in the bug's `prevention` and the measure's description, not left as an inline TODO
+- [x] Ready for another developer to use — both added steps carry comments explaining why they exist and that they must track `ci.yml`
+
+## Pull Request
+
+- [x] PR created against `develop`
+- [ ] All CI checks pass — see PR
+- [x] PR URL documented below
+
+**PR:** see the `fix/release-test-sandbox` PR linked on BUG-2J30F3.

--- a/tickets/entities/review-checklists/REV-V0EO3S.md
+++ b/tickets/entities/review-checklists/REV-V0EO3S.md
@@ -54,7 +54,7 @@ named one ("Release-runner drift from CI").
 ## Pull Request
 
 - [x] PR created against `develop`
-- [ ] All CI checks pass — see PR
+- [x] All CI checks pass — full matrix green on the PR; the `Rela Tickets` gate is resolved by this done-transition
 - [x] PR URL documented below
 
 **PR:** see the `fix/release-test-sandbox` PR linked on BUG-2J30F3.

--- a/tickets/relations/BUG-2J30F3--adds-measure--release-test-gate-sandbox-parity.md
+++ b/tickets/relations/BUG-2J30F3--adds-measure--release-test-gate-sandbox-parity.md
@@ -1,0 +1,5 @@
+---
+from: BUG-2J30F3
+relation: adds-measure
+to: release-test-gate-sandbox-parity
+---

--- a/tickets/relations/BUG-2J30F3--affects--ci-pipeline.md
+++ b/tickets/relations/BUG-2J30F3--affects--ci-pipeline.md
@@ -1,0 +1,5 @@
+---
+from: BUG-2J30F3
+relation: affects
+to: ci-pipeline
+---

--- a/tickets/relations/BUG-2J30F3--fixes--FEAT-S31FF7.md
+++ b/tickets/relations/BUG-2J30F3--fixes--FEAT-S31FF7.md
@@ -1,0 +1,5 @@
+---
+from: BUG-2J30F3
+relation: fixes
+to: FEAT-S31FF7
+---

--- a/tickets/relations/BUG-2J30F3--has-implementation--IMPL-099MO1.md
+++ b/tickets/relations/BUG-2J30F3--has-implementation--IMPL-099MO1.md
@@ -1,0 +1,5 @@
+---
+from: BUG-2J30F3
+relation: has-implementation
+to: IMPL-099MO1
+---

--- a/tickets/relations/BUG-2J30F3--has-review--REV-V0EO3S.md
+++ b/tickets/relations/BUG-2J30F3--has-review--REV-V0EO3S.md
@@ -1,0 +1,5 @@
+---
+from: BUG-2J30F3
+relation: has-review
+to: REV-V0EO3S
+---


### PR DESCRIPTION
The `test` job in `release.yml` is a second copy of CI's test gate, and it had drifted:

|            | `ci.yml` test        | `release.yml` test (before) |
| ---------- | -------------------- | --------------------------- |
| Runner     | `ubuntu-26.04`       | `ubuntu-latest` (24.04)     |
| bubblewrap | installed + verified | **not installed**           |

Confined external commands fail closed with no sandbox, so a runner without
`bwrap` fails ~35 tests across `internal/attachment`, `internal/cli`,
`internal/cmdexec`, `internal/dataentry` and `internal/transform` — on a commit
that passed CI.

That is what happened to **v26.7.1**: the tag was cut, the `test` gate failed,
`release`/`desktop`/`homebrew` were skipped, and the tag has **no release
object and no assets**. The inverse of the `v0.8`/`v0.12` footgun the release
docs warn about.

```
sandbox_test.go:71: transform: cmdexec: start "bwrap":
    exec: "bwrap": executable file not found in $PATH
```

## Change

Bring the release test gate back in line with CI: pin `ubuntu-26.04`, install
bubblewrap, keep the `bwrap --unshare-all --ro-bind / / /bin/true` verify step
so an absent sandbox fails loudly instead of mass-skipping.

`docs/releasing.md` gains this as a named entry under "Why a release can
silently produce no assets".

## Note

The structural fix is a `workflow_call` gate shared by both workflows, making
this drift impossible. Deliberately not done here — it is a refactor of both
workflows and this needed to unblock the release. Recorded in BUG-2J30F3's
`prevention` and in the `release-test-gate-sandbox-parity` measure.

Note this gate only runs on a tag push, so CI here cannot prove the fix; the
next release run is the real verification.