### PR TITLE
feat(data-entry): header/footer info regions on kanban boards (TKT-6S331G)

### DIFF
--- a/docs-project/entities/guides/GUIDE-data-entry.md
+++ b/docs-project/entities/guides/GUIDE-data-entry.md
@@ -1312,6 +1312,8 @@ kanbans:
 | ------------------ | ------ | ---------------------------------------------------------- |
 | `entity_type`      | string | Entity type to display on the board                        |
 | `title`            | string | Board heading                                              |
+| `header`           | string | Markdown rendered above the board (info/help; see below)   |
+| `footer`           | string | Markdown rendered below the board                          |
 | `column_property`  | string | Property to group by for columns (must be enum/custom type)|
 | `columns`          | list   | Explicit column definitions (optional)                     |
 | `swimlane_property`| string | Property to group by for swimlanes (optional)              |
@@ -1321,6 +1323,34 @@ kanbans:
 | `create_form`      | string | Form name for the "New" button                             |
 | `filters`          | list   | Static filters (same as lists)                             |
 | `filter_controls`  | list   | Interactive filter controls (same as lists)                |
+
+#### Header and footer info regions
+
+Boards support the same admin-authored info regions as lists — see
+[Header and footer info regions](#header-and-footer-info-regions) under Lists
+for the full description. `header` and `footer` accept Markdown, render as
+sanitized HTML above and below the board, and are authored in
+`data-entry.yaml` only.
+
+```yaml
+kanbans:
+  ticket_board:
+    entity_type: ticket
+    title: "Ticket Board"
+    header: |
+      Cards move **left to right**. Drag a card to change its status — see the
+      [workflow guide](/entity/guide-ticket-workflow).
+    footer: |
+      _Reopening a done ticket? Talk to the maintainers first._
+    column_property: status
+```
+
+The regions sit outside the board's horizontal scroll area, so they stay
+visible when a wide board scrolls sideways.
+
+Unlike lists, a kanban has **no `description` fallback** for `header`: that
+alias exists on lists only because `description` predated the info regions and
+was already present in configs. Set `header` directly.
 
 ### Columns
 

--- a/docs/data-entry.md
+++ b/docs/data-entry.md
@@ -1306,6 +1306,8 @@ kanbans:
 | ------------------ | ------ | ---------------------------------------------------------- |
 | `entity_type`      | string | Entity type to display on the board                        |
 | `title`            | string | Board heading                                              |
+| `header`           | string | Markdown rendered above the board (info/help; see below)   |
+| `footer`           | string | Markdown rendered below the board                          |
 | `column_property`  | string | Property to group by for columns (must be enum/custom type)|
 | `columns`          | list   | Explicit column definitions (optional)                     |
 | `swimlane_property`| string | Property to group by for swimlanes (optional)              |
@@ -1315,6 +1317,34 @@ kanbans:
 | `create_form`      | string | Form name for the "New" button                             |
 | `filters`          | list   | Static filters (same as lists)                             |
 | `filter_controls`  | list   | Interactive filter controls (same as lists)                |
+
+#### Header and footer info regions
+
+Boards support the same admin-authored info regions as lists — see
+[Header and footer info regions](#header-and-footer-info-regions) under Lists
+for the full description. `header` and `footer` accept Markdown, render as
+sanitized HTML above and below the board, and are authored in
+`data-entry.yaml` only.
+
+```yaml
+kanbans:
+  ticket_board:
+    entity_type: ticket
+    title: "Ticket Board"
+    header: |
+      Cards move **left to right**. Drag a card to change its status — see the
+      [workflow guide](/entity/guide-ticket-workflow).
+    footer: |
+      _Reopening a done ticket? Talk to the maintainers first._
+    column_property: status
+```
+
+The regions sit outside the board's horizontal scroll area, so they stay
+visible when a wide board scrolls sideways.
+
+Unlike lists, a kanban has **no `description` fallback** for `header`: that
+alias exists on lists only because `description` predated the info regions and
+was already present in configs. Set `header` directly.
 
 ### Columns
 

--- a/frontend/src/components/lists/EntityList.vue
+++ b/frontend/src/components/lists/EntityList.vue
@@ -17,7 +17,7 @@ import { renderMarkdown } from '@/utils/markdown'
 import { actionAllowed } from '@/utils/affordancesWarning'
 import { getCellValue, formatCellValue, isEnumPropertyDef, asArray } from '@/utils/format'
 import type { Entity, ListMeta, ListParams, ListResponse, FilterState } from '@/types'
-import { listHeaderMarkdown, listFooterMarkdown } from '@/types'
+import { viewHeaderMarkdown, viewFooterMarkdown } from '@/types'
 import FilterBar from './FilterBar.vue'
 import Pagination from './Pagination.vue'
 import SearchBox from './SearchBox.vue'
@@ -273,8 +273,11 @@ function listExportUrlFor(transform: string): string {
 // fallback for the top slot, used only when `header` is unset. No refResolver
 // here — the /_config endpoint carries no mentions map, so bare-ID code spans
 // stay inert; standard [text](/entity/ID) links work.
-const headerHtml = computed(() => renderMarkdown(listHeaderMarkdown(listConfig.value)))
-const footerHtml = computed(() => renderMarkdown(listFooterMarkdown(listConfig.value)))
+// Lists opt into the legacy `description` alias; kanban deliberately does not.
+const headerHtml = computed(() =>
+  renderMarkdown(viewHeaderMarkdown(listConfig.value, { allowDescriptionAlias: true }))
+)
+const footerHtml = computed(() => renderMarkdown(viewFooterMarkdown(listConfig.value)))
 
 // Pre-configured filters from list config
 const configuredFilters = computed(() => {
@@ -694,7 +697,7 @@ watch(searchQuery, () => {
     </header>
 
     <!-- eslint-disable-next-line vue/no-v-html -- sanitized by renderMarkdown -->
-    <div v-if="headerHtml" class="list-info list-info--top" v-html="headerHtml"/>
+    <div v-if="headerHtml" class="view-info view-info--top" v-html="headerHtml"/>
 
     <div v-if="configuredFilters.length" class="configured-filters">
       <span
@@ -959,7 +962,7 @@ watch(searchQuery, () => {
     </div>
 
     <!-- eslint-disable-next-line vue/no-v-html -- sanitized by renderMarkdown -->
-    <div v-if="footerHtml" class="list-info list-info--bottom" v-html="footerHtml"/>
+    <div v-if="footerHtml" class="view-info view-info--bottom" v-html="footerHtml"/>
   </div>
 
   <div v-else class="error-state">
@@ -975,47 +978,8 @@ watch(searchQuery, () => {
   cursor: help;
 }
 
-/* Admin-authored info regions (header/footer markdown). Rendered HTML is
-   sanitized by renderMarkdown; these styles only govern typography/spacing. */
-.list-info {
-  color: var(--text-color);
-  font-size: 14px;
-  line-height: 1.6;
-}
-
-.list-info--top {
-  /* Pulls up against .list-header's margin-bottom: 24px so the info sits close
-     to the title rather than a full gap below it. Keep in sync if that changes. */
-  margin-top: -12px;
-  margin-bottom: 20px;
-}
-
-.list-info--bottom {
-  margin-top: 24px;
-}
-
-.list-info :deep(> :first-child) {
-  margin-top: 0;
-}
-
-.list-info :deep(> :last-child) {
-  margin-bottom: 0;
-}
-
-.list-info :deep(p),
-.list-info :deep(ul),
-.list-info :deep(ol) {
-  margin: 0 0 8px;
-}
-
-.list-info :deep(a) {
-  color: var(--accent-color);
-  text-decoration: none;
-}
-
-.list-info :deep(a:hover) {
-  text-decoration: underline;
-}
+/* Info-region styles (.view-info) live in styles/view-info.css — shared with
+   KanbanView so both views render admin-authored markdown identically. */
 
 .entity-list {
   max-width: 1200px;

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -12,6 +12,7 @@ import './styles/back-button.css'
 import './styles/mobile-bars.css'
 import './styles/text-utilities.css'
 import './styles/markdown-content.css'
+import './styles/view-info.css'
 
 const app = createApp(App)
 

--- a/frontend/src/styles/view-info.css
+++ b/frontend/src/styles/view-info.css
@@ -1,0 +1,48 @@
+/* Admin-authored info regions (header/footer markdown) on list and kanban
+   views, authored in data-entry.yaml. Rendered HTML is sanitized by
+   renderMarkdown; these styles only govern typography/spacing.
+
+   Global rather than component-scoped so both EntityList and KanbanView render
+   the regions identically — a scoped copy per view drifts. No :deep() here: the
+   descendant selectors apply directly outside a scoped block. */
+.view-info {
+  color: var(--text-color);
+  font-size: 14px;
+  line-height: 1.6;
+}
+
+.view-info--top {
+  /* Pulls up against the page/list header's margin-bottom: 24px so the info
+     sits close to the title rather than a full gap below it. Both .list-header
+     (EntityList) and .page-header (KanbanView) use 24px — keep in sync if
+     either changes. */
+  margin-top: -12px;
+  margin-bottom: 20px;
+}
+
+.view-info--bottom {
+  margin-top: 24px;
+}
+
+.view-info > :first-child {
+  margin-top: 0;
+}
+
+.view-info > :last-child {
+  margin-bottom: 0;
+}
+
+.view-info p,
+.view-info ul,
+.view-info ol {
+  margin: 0 0 8px;
+}
+
+.view-info a {
+  color: var(--accent-color);
+  text-decoration: none;
+}
+
+.view-info a:hover {
+  text-decoration: underline;
+}

--- a/frontend/src/types/config.test.ts
+++ b/frontend/src/types/config.test.ts
@@ -1,15 +1,26 @@
 import { describe, it, expect } from 'vitest'
 import {
   getEditFormId,
-  listHeaderMarkdown,
-  listFooterMarkdown,
+  viewHeaderMarkdown,
+  viewFooterMarkdown,
   type FormConfig,
   type ListConfig,
+  type KanbanConfig,
 } from './config'
 
 const list = (over: Partial<ListConfig>): ListConfig => ({
   entity: 'risico',
   columns: [],
+  ...over,
+})
+
+// Lists opt into the legacy `description` → header alias; kanban does not.
+const ALIAS = { allowDescriptionAlias: true }
+
+const kanban = (over: Partial<KanbanConfig>): KanbanConfig => ({
+  entity: 'ticket',
+  column_property: 'status',
+  card: { title: 'title' },
   ...over,
 })
 
@@ -68,51 +79,90 @@ describe('config', () => {
     })
   })
 
-  describe('listHeaderMarkdown', () => {
+  describe('viewHeaderMarkdown', () => {
     it('returns header when set', () => {
-      expect(listHeaderMarkdown(list({ header: '# Hi' }))).toBe('# Hi')
+      expect(viewHeaderMarkdown(list({ header: '# Hi' }))).toBe('# Hi')
     })
 
     it('falls back to description (legacy alias) when header is unset', () => {
-      expect(listHeaderMarkdown(list({ description: 'legacy' }))).toBe('legacy')
+      expect(viewHeaderMarkdown(list({ description: 'legacy' }), ALIAS)).toBe('legacy')
     })
 
     it('prefers header over description when both are set', () => {
-      expect(listHeaderMarkdown(list({ header: 'new', description: 'legacy' }))).toBe('new')
+      expect(viewHeaderMarkdown(list({ header: 'new', description: 'legacy' }), ALIAS)).toBe('new')
     })
 
     it('ignores an empty header and falls back to description', () => {
-      expect(listHeaderMarkdown(list({ header: '', description: 'legacy' }))).toBe('legacy')
+      expect(viewHeaderMarkdown(list({ header: '', description: 'legacy' }), ALIAS)).toBe('legacy')
     })
 
     it('treats a whitespace-only header as unset and falls back to description', () => {
-      expect(listHeaderMarkdown(list({ header: '   \n', description: 'legacy' }))).toBe('legacy')
+      expect(viewHeaderMarkdown(list({ header: '   \n', description: 'legacy' }), ALIAS)).toBe('legacy')
     })
 
     it('returns empty string when both are whitespace-only', () => {
-      expect(listHeaderMarkdown(list({ header: '  ', description: '\t' }))).toBe('')
+      expect(viewHeaderMarkdown(list({ header: '  ', description: '\t' }), ALIAS)).toBe('')
+    })
+
+    it('ignores description when the alias is not opted into', () => {
+      // The alias is a per-call-site opt-in, NOT a consequence of the config
+      // type: types erase at runtime, so an object carrying `description` would
+      // otherwise leak it regardless of which config interface it claims to be.
+      expect(viewHeaderMarkdown(list({ description: 'legacy' }))).toBe('')
+    })
+
+    it('ignores description on a kanban-shaped object even if one is present', () => {
+      // Guards the RR-GNWJFO drift scenario: a future Go `Kanban.Description`
+      // field reaching the SPA must NOT silently switch on the list alias.
+      const boardWithStrayDescription = {
+        entity: 'ticket',
+        column_property: 'status',
+        description: 'must not render',
+      }
+      expect(viewHeaderMarkdown(boardWithStrayDescription)).toBe('')
     })
 
     it('returns empty string when neither is set', () => {
-      expect(listHeaderMarkdown(list({}))).toBe('')
+      expect(viewHeaderMarkdown(list({}))).toBe('')
     })
 
     it('returns empty string for an undefined list', () => {
-      expect(listHeaderMarkdown(undefined)).toBe('')
+      expect(viewHeaderMarkdown(undefined)).toBe('')
+    })
+
+    it('resolves a kanban header', () => {
+      expect(viewHeaderMarkdown(kanban({ header: '# Board' }))).toBe('# Board')
+    })
+
+    it('treats a whitespace-only kanban header as unset', () => {
+      expect(viewHeaderMarkdown(kanban({ header: '  \n' }))).toBe('')
+    })
+
+    it('returns empty string for a kanban with no header', () => {
+      // Kanban never opts into the alias, so there is no fallback to find.
+      expect(viewHeaderMarkdown(kanban({}))).toBe('')
     })
   })
 
-  describe('listFooterMarkdown', () => {
+  describe('viewFooterMarkdown', () => {
     it('returns footer when set', () => {
-      expect(listFooterMarkdown(list({ footer: 'bye' }))).toBe('bye')
+      expect(viewFooterMarkdown(list({ footer: 'bye' }))).toBe('bye')
     })
 
     it('returns empty string when unset', () => {
-      expect(listFooterMarkdown(list({}))).toBe('')
+      expect(viewFooterMarkdown(list({}))).toBe('')
     })
 
     it('returns empty string for an undefined list', () => {
-      expect(listFooterMarkdown(undefined)).toBe('')
+      expect(viewFooterMarkdown(undefined)).toBe('')
+    })
+
+    it('resolves a kanban footer', () => {
+      expect(viewFooterMarkdown(kanban({ footer: 'see the runbook' }))).toBe('see the runbook')
+    })
+
+    it('treats a whitespace-only kanban footer as unset', () => {
+      expect(viewFooterMarkdown(kanban({ footer: '\t' }))).toBe('')
     })
   })
 })

--- a/frontend/src/types/config.ts
+++ b/frontend/src/types/config.ts
@@ -160,19 +160,32 @@ export interface ListConfig {
 }
 
 /**
- * Resolve the raw markdown for a list's top info region. `header` is canonical;
- * `description` is a fallback — the field predates this feature but was never
- * rendered, so we adopt it as an alias rather than require every config to be
- * rewritten. Returns '' when neither is set (a blank/whitespace-only value is
- * treated as unset). The caller passes the result through renderMarkdown.
+ * Resolve the raw markdown for a view's top info region. `header` is canonical.
+ * Returns '' when unset (a blank/whitespace-only value counts as unset). The
+ * caller passes the result through renderMarkdown.
+ *
+ * `description` is an OPT-IN legacy alias, enabled per call site via
+ * `allowDescriptionAlias`. Only lists pass it: there the field predated this
+ * feature and was never rendered, so adopting it as an alias avoided rewriting
+ * every existing config. Kanban deliberately has no such fallback (TKT-6S331G).
+ *
+ * The opt-in is a flag rather than a type constraint because TypeScript erases
+ * at runtime: a structural parameter would happily read `description` off any
+ * object carrying one, and these configs are parsed from the /_config response.
+ * Relying on `KanbanConfig` merely lacking the field would make the policy a
+ * comment that a later Go `Kanban.Description` field could silently void.
  */
-export function listHeaderMarkdown(list: ListConfig | undefined): string {
-  return list?.header?.trim() || list?.description?.trim() || ''
+export function viewHeaderMarkdown(
+  view: { header?: string; description?: string } | undefined,
+  opts: { allowDescriptionAlias?: boolean } = {}
+): string {
+  const alias = opts.allowDescriptionAlias ? view?.description?.trim() : ''
+  return view?.header?.trim() || alias || ''
 }
 
-/** Resolve the raw markdown for a list's bottom info region ('' when unset). */
-export function listFooterMarkdown(list: ListConfig | undefined): string {
-  return list?.footer?.trim() || ''
+/** Resolve the raw markdown for a view's bottom info region ('' when unset). */
+export function viewFooterMarkdown(view: { footer?: string } | undefined): string {
+  return view?.footer?.trim() || ''
 }
 
 // Helper to get edit form for an entity type
@@ -240,6 +253,14 @@ export interface ViewSection {
 export interface KanbanConfig {
   entity: string
   title?: string
+  /** Markdown rendered above the board. */
+  header?: string
+  /** Markdown rendered below the board. */
+  footer?: string
+  // Deliberately no `description`: unlike ListConfig, kanban has no legacy field
+  // to adopt as a header alias. Enforced at the call site, which does NOT pass
+  // viewHeaderMarkdown's `allowDescriptionAlias` — not by this field's absence,
+  // which types alone cannot guarantee at runtime.
   column_property: string
   columns?: KanbanColumn[]
   swimlane_property?: string

--- a/frontend/src/views/KanbanView.test.ts
+++ b/frontend/src/views/KanbanView.test.ts
@@ -43,7 +43,10 @@ function makeTicket(id: string): Entity {
 // seedSchema installs a kanban config whose card renders the given fields,
 // plus a `verantwoordelijk_voor` relation type with a declared inverse so the
 // incoming-direction path resolves via getInverseName.
-function seedSchema(fields: Array<Record<string, unknown>>) {
+function seedSchema(
+  fields: Array<Record<string, unknown>>,
+  configOverrides: Record<string, unknown> = {}
+) {
   const schemaStore = useSchemaStore()
   schemaStore.kanbans.set(KANBAN_ID, {
     entity: ENTITY_TYPE,
@@ -51,6 +54,7 @@ function seedSchema(fields: Array<Record<string, unknown>>) {
     column_property: 'status',
     columns: [{ value: 'todo', label: 'Todo' }],
     card: { title: 'title', fields },
+    ...configOverrides,
   } as never)
   schemaStore.entityTypes.set(ENTITY_TYPE, {
     name: ENTITY_TYPE,
@@ -95,8 +99,13 @@ afterEach(() => {
   document.body.innerHTML = ''
 })
 
-async function mountBoard(fields: Array<Record<string, unknown>>, entities: Entity[], included: Record<string, Entity> = {}) {
-  seedSchema(fields)
+async function mountBoard(
+  fields: Array<Record<string, unknown>>,
+  entities: Entity[],
+  included: Record<string, Entity> = {},
+  configOverrides: Record<string, unknown> = {}
+) {
+  seedSchema(fields, configOverrides)
   seedBoard(entities, included)
   const wrapper = mount(KanbanView, {
     props: { id: KANBAN_ID },
@@ -327,6 +336,113 @@ describe('KanbanView card fields with unset values', () => {
     const labels = card.findAll('.field-label').map((n) => n.text())
     expect(labels).toContain('effort:')
     expect(card.text()).toContain('m')
+    wrapper.unmount()
+  })
+})
+
+// Admin-authored header/footer info regions (TKT-6S331G). These mirror the
+// list-view regions and share both the resolvers (viewHeaderMarkdown /
+// viewFooterMarkdown) and the .view-info styles with EntityList.
+describe('KanbanView info regions (header/footer)', () => {
+  it('renders header markdown above the board', async () => {
+    const wrapper = await mountBoard([], [makeTicket('T-1')], {}, {
+      header: 'Cards move **left to right**.',
+    })
+
+    const header = wrapper.find('.view-info--top')
+    expect(header.exists()).toBe(true)
+    expect(header.html()).toContain('<strong>left to right</strong>')
+    wrapper.unmount()
+  })
+
+  it('renders footer markdown below the board', async () => {
+    const wrapper = await mountBoard([], [makeTicket('T-1')], {}, {
+      footer: 'See the [runbook](https://example.test/runbook).',
+    })
+
+    const footer = wrapper.find('.view-info--bottom')
+    expect(footer.exists()).toBe(true)
+    expect(footer.html()).toContain('href="https://example.test/runbook"')
+    wrapper.unmount()
+  })
+
+  it('routes admin markdown through the sanitizer before v-html', async () => {
+    const wrapper = await mountBoard([], [makeTicket('T-1')], {}, {
+      // Two separate payloads on purpose — see the note below. The header
+      // proves markdown is processed; the footer proves scripts are stripped.
+      header: '**bold**',
+      footer: '<script>alert(3)</script>',
+    })
+
+    // What this proves: renderMarkdown (marked + DOMPurify) is actually IN the
+    // path between data-entry.yaml and v-html — the markdown was processed
+    // (<strong> exists, so the config string was not raw-passed to v-html) and
+    // a script element did not survive.
+    //
+    // What this deliberately does NOT assert: inline event handlers and
+    // javascript: hrefs. Under this suite's happy-dom environment DOMPurify
+    // leaves BOTH intact when the input parses to multiple nodes
+    // (`<p>x</p>\n<img onerror=...>` keeps onerror; `<a href="javascript:...">`
+    // keeps the href) — and for the same reason it also keeps a script when one
+    // follows inline content (`**bold** <script>` survives, a bare `<script>`
+    // does not, which is why the two payloads above are kept apart). That is a
+    // happy-dom DOM defect, not a renderMarkdown bug: every one of those
+    // payloads through DOMPurify under jsdom, and in a real browser, comes back
+    // sanitized. Asserting them here would fail for an environment reason while
+    // proving nothing about production, so the real coverage for handler/href
+    // stripping is DOMPurify's own suite plus manual browser verification.
+    const html = wrapper.html()
+    expect(html).toContain('<strong>bold</strong>')
+    expect(html).not.toContain('<script>')
+    expect(wrapper.find('.view-info--top script').exists()).toBe(false)
+    expect(wrapper.find('.view-info--bottom script').exists()).toBe(false)
+    wrapper.unmount()
+  })
+
+  it('renders neither region when header and footer are unset', async () => {
+    const wrapper = await mountBoard([], [makeTicket('T-1')])
+
+    expect(wrapper.find('.view-info--top').exists()).toBe(false)
+    expect(wrapper.find('.view-info--bottom').exists()).toBe(false)
+    wrapper.unmount()
+  })
+
+  it('treats whitespace-only header/footer as unset', async () => {
+    const wrapper = await mountBoard([], [makeTicket('T-1')], {}, {
+      header: '   \n',
+      footer: '\t',
+    })
+
+    expect(wrapper.find('.view-info--top').exists()).toBe(false)
+    expect(wrapper.find('.view-info--bottom').exists()).toBe(false)
+    wrapper.unmount()
+  })
+
+  it('renders the footer outside the scrolling board container', async () => {
+    // AC6: the footer must not live inside .kanban-board, which owns the
+    // horizontal scroll — otherwise it scrolls off-screen on a wide board.
+    // jsdom does not lay out, so this asserts containment structurally.
+    const wrapper = await mountBoard([], [makeTicket('T-1')], {}, {
+      footer: 'stays put',
+    })
+
+    expect(wrapper.find('.kanban-board .view-info--bottom').exists()).toBe(false)
+    expect(wrapper.find('.view-info--bottom').exists()).toBe(true)
+    wrapper.unmount()
+  })
+
+  it('renders the footer even when the board fails to load', async () => {
+    seedSchema([], { footer: 'still here' })
+    listAllEntitiesMock.mockRejectedValue(new Error('boom'))
+    const wrapper = mount(KanbanView, {
+      props: { id: KANBAN_ID },
+      attachTo: document.body,
+      global: { plugins: [pinia, PiniaColada] },
+    })
+    await flushPromises()
+
+    expect(wrapper.find('.error-state').exists()).toBe(true)
+    expect(wrapper.find('.view-info--bottom').exists()).toBe(true)
     wrapper.unmount()
   })
 })

--- a/frontend/src/views/KanbanView.vue
+++ b/frontend/src/views/KanbanView.vue
@@ -7,11 +7,13 @@ import { listAllEntities, updateEntity, getErrorMessage } from '@/api'
 import { entityKeys } from '@/queries/entities'
 import { beginOptimistic, rollbackOptimistic, settleOptimistic } from '@/queries/optimisticList'
 import type { Entity, KanbanConfig, KanbanCardField } from '@/types'
+import { viewHeaderMarkdown, viewFooterMarkdown } from '@/types'
 import Badge from '@/components/common/Badge.vue'
 import BackButton from '@/components/common/BackButton.vue'
 import { useBackTarget } from '@/composables/useBackTarget'
 import { actionAllowed } from '@/utils/affordancesWarning'
 import { entityDisplayTitle } from '@/utils/entityDisplay'
+import { renderMarkdown } from '@/utils/markdown'
 
 const props = defineProps<{
   id: string
@@ -96,6 +98,12 @@ const loadError = computed(() => {
   if (!err) return null
   return getErrorMessage(err, 'Failed to load board')
 })
+
+// Admin-authored info regions from data-entry.yaml, rendered as sanitized
+// markdown (renderMarkdown) above and below the board. Shares its resolvers and
+// its .view-info styles with EntityList so both views behave identically.
+const headerHtml = computed(() => renderMarkdown(viewHeaderMarkdown(kanbanConfig.value)))
+const footerHtml = computed(() => renderMarkdown(viewFooterMarkdown(kanbanConfig.value)))
 
 const entityType = computed(() => {
   if (!kanbanConfig.value) return undefined
@@ -469,6 +477,9 @@ function createNew() {
       </div>
     </div>
 
+    <!-- eslint-disable-next-line vue/no-v-html -- sanitized by renderMarkdown -->
+    <div v-if="headerHtml" class="view-info view-info--top" v-html="headerHtml"/>
+
     <div v-if="truncated" class="truncation-banner" role="alert">
       Showing {{ entities.length }} of {{ totalCount }} items — the board is incomplete.
     </div>
@@ -597,13 +608,22 @@ function createNew() {
         </div>
       </div>
     </div>
+
+    <!-- Sits after every board branch (loading/error/simple/swimlane) so it
+         renders once regardless of state, and outside the board's horizontal
+         scroll container so it stays visible on a wide board. -->
+    <!-- eslint-disable-next-line vue/no-v-html -- sanitized by renderMarkdown -->
+    <div v-if="footerHtml" class="view-info view-info--bottom" v-html="footerHtml"/>
   </div>
 </template>
 
 <style scoped>
+/* The horizontal scroll belongs to the board containers, NOT this page wrapper.
+   With overflow-x here, a board wider than the viewport dragged the page title,
+   filter bar, truncation banner, and info regions sideways along with the
+   columns. Scoping it to the boards keeps page furniture fixed. */
 .kanban-view {
   max-width: 100%;
-  overflow-x: auto;
 }
 
 .page-header {
@@ -717,6 +737,14 @@ function createNew() {
   gap: 16px;
   min-height: 500px;
   padding-bottom: 20px;
+  /* Per CSS spec a non-visible overflow on one axis coerces the other from
+     `visible` to `auto`, so this box now ALSO clips vertically — `overflow-y:
+     visible` cannot opt out. Safe today: the card hover box-shadow (8px blur)
+     is inset by .column-cards' 12px padding, and padding-bottom cushions the
+     last card. Anything that must escape a card's box vertically (drag ghost,
+     tooltip, popover, sticky column header) will be clipped here — that is the
+     accepted cost of scoping the horizontal scroll to the board. */
+  overflow-x: auto;
 }
 
 .kanban-column {
@@ -828,7 +856,10 @@ function createNew() {
   background: var(--border-color);
   border: 1px solid var(--border-color);
   border-radius: 8px;
-  overflow: hidden;
+  /* Two-value form: scroll horizontally when the grid is wider than the
+     viewport, while keeping the vertical `hidden` that clips cells to the
+     rounded border. A bare `overflow-x: auto` would drop that clipping. */
+  overflow: auto hidden;
   min-height: 400px;
 }
 

--- a/internal/dataentryconfig/config.go
+++ b/internal/dataentryconfig/config.go
@@ -378,9 +378,17 @@ func (c *Config) HasPropertyFilterControl(entityType, property string) bool {
 }
 
 // Kanban defines a kanban board view for an entity type.
+//
+// Header and Footer carry admin-authored markdown rendered above and below the
+// board, respectively (sanitized client-side via renderMarkdown), matching the
+// list info regions. Unlike List there is no Description fallback: that alias
+// exists only because List.Description predated the feature and was already
+// present in configs, and a Kanban has no such legacy field to accommodate.
 type Kanban struct {
 	EntityType       string           `yaml:"entity_type" json:"entity"`
 	Title            string           `yaml:"title" json:"title"`
+	Header           string           `yaml:"header" json:"header,omitempty"`
+	Footer           string           `yaml:"footer" json:"footer,omitempty"`
 	ColumnProperty   string           `yaml:"column_property" json:"column_property"`
 	Columns          []KanbanColumn   `yaml:"columns,omitempty" json:"columns,omitempty"`
 	SwimlaneProperty string           `yaml:"swimlane_property,omitempty" json:"swimlane_property,omitempty"`

--- a/internal/dataentryconfig/config_test.go
+++ b/internal/dataentryconfig/config_test.go
@@ -375,6 +375,56 @@ func TestList_EmptyHeaderFooterOmittedFromJSON(t *testing.T) {
 	}
 }
 
+func TestKanbanHeaderFooter_YAMLAndJSON(t *testing.T) {
+	// Kanban info regions mirror the list ones: they decode from YAML and reach
+	// the SPA over _config, which resolves and renders them client-side.
+	const src = `
+entity_type: ticket
+title: Ticket Board
+column_property: status
+header: |
+  Cards move **left to right**.
+footer: Ask the maintainers before reopening a done ticket.
+`
+	var board Kanban
+	if err := yaml.Unmarshal([]byte(src), &board); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got, want := board.Header, "Cards move **left to right**.\n"; got != want {
+		t.Errorf("header: got %q, want %q", got, want)
+	}
+	if got, want := board.Footer, "Ask the maintainers before reopening a done ticket."; got != want {
+		t.Errorf("footer: got %q, want %q", got, want)
+	}
+
+	data, err := json.Marshal(board)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var out map[string]any
+	if err := json.Unmarshal(data, &out); err != nil {
+		t.Fatalf("unmarshal json: %v", err)
+	}
+	if _, ok := out["header"]; !ok {
+		t.Errorf("json missing header key: %s", data)
+	}
+	if _, ok := out["footer"]; !ok {
+		t.Errorf("json missing footer key: %s", data)
+	}
+}
+
+func TestKanban_EmptyHeaderFooterOmittedFromJSON(t *testing.T) {
+	// omitempty keeps the wire payload clean when no info regions are set, so
+	// existing boards render exactly as before.
+	data, err := json.Marshal(Kanban{EntityType: "ticket", Title: "Ticket Board"})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if strings.Contains(string(data), "header") || strings.Contains(string(data), "footer") {
+		t.Errorf("expected no header/footer keys, got %s", data)
+	}
+}
+
 func TestDirection_IsIncoming(t *testing.T) {
 	t.Run("incoming returns true", func(t *testing.T) {
 		if !DirectionIncoming.IsIncoming() {

--- a/tickets/data-entry.yaml
+++ b/tickets/data-entry.yaml
@@ -1220,6 +1220,11 @@ kanbans:
   idea_board:
     entity_type: idea
     title: "Idea Pipeline"
+    header: |
+      Ideas move **left to right** as they earn confidence. Drag a card to
+      change its status.
+    footer: |
+      _Parked ideas are reviewed each quarter — nothing here is discarded._
     column_property: status
     columns:
       - value: captured

--- a/tickets/entities/docs-checklists/DOCS-V4R8MI.md
+++ b/tickets/entities/docs-checklists/DOCS-V4R8MI.md
@@ -1,0 +1,63 @@
+---
+id: DOCS-V4R8MI
+type: docs-checklist
+title: 'Docs: Render admin-authored header/footer markdown on kanban boards'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Code Documentation
+
+- [x] Godoc / doc comments on new exported symbols
+
+`dataentryconfig.Kanban` gained a type doc comment explaining what `Header` and
+`Footer` are and — importantly — why there is deliberately no `Description`
+fallback, so the next reader does not "restore symmetry" with `List` by adding
+one.
+
+- [x] Non-obvious decisions explained at the point of the decision
+
+Three comments carry reasoning that would otherwise be lost:
+
+- `viewHeaderMarkdown` JSDoc — why the `description` alias is a runtime opt-in
+flag rather than a type constraint (types erase; configs come off the wire).
+- `.kanban-board` CSS — why `overflow-x: auto` also clips vertically per spec,
+why `overflow-y: visible` cannot opt out, and what would be clipped in future.
+- `KanbanView.test.ts` AC3 test — what the sanitization assertion does and does
+not prove, and why (happy-dom DOM defects, verified against jsdom).
+
+## Project Documentation
+
+- [x] `docs/data-entry.md` updated
+
+Added `header`/`footer` rows to the Kanban Fields table and a "Header and footer
+info regions" subsection that cross-references the list section rather than
+duplicating it, documents that the regions sit outside the horizontal scroll
+area, and states explicitly that kanban has no `description` fallback.
+
+- [x] ~~`docs/metamodel.md`~~ (N/A: data-entry config, not metamodel schema)
+- [x] ~~`docs/cli-reference.md`~~ (N/A: no CLI surface)
+- [x] ~~`CLAUDE.md`~~ (N/A: no new pattern — the shared stylesheet follows the
+existing `frontend/src/styles/` convention set by `back-button.css`)
+- [x] ~~`README.md`~~ (N/A: not a project-level change)
+
+## Example Configuration
+
+- [x] Working example in a real project config
+
+`tickets/data-entry.yaml` `idea_board` now sets both `header` and `footer`,
+mirroring what TKT-H7E611 did for the `all_ideas` list. This doubles as the
+manual-verification fixture and gives operators a copy-paste starting point.
+
+## External Documentation
+
+- [x] ~~Release notes / migration guide~~ (N/A: purely additive on the config
+surface — omitted `header`/`footer` keys behave exactly as before, so no
+existing `data-entry.yaml` needs changing)
+
+One behavior change is worth noting for reviewers even though it needs no
+migration: the board's horizontal scroll moved from the page wrapper onto the
+board containers, so on a wide board the page title and filter bar no longer
+scroll sideways. That is a fix to a pre-existing quirk, affects every board, and
+is documented in the ticket and in the CSS comment.

--- a/tickets/entities/implementation-checklists/IMPL-EH9RW8.md
+++ b/tickets/entities/implementation-checklists/IMPL-EH9RW8.md
@@ -1,0 +1,117 @@
+---
+id: IMPL-EH9RW8
+type: implementation-checklist
+title: 'Implementation: Render admin-authored header/footer markdown on kanban boards'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Development
+
+- [x] Unit tests written for new code
+- [x] Integration tests written (full flow, not just units)
+- [x] Feature implemented
+- [x] All edge cases from planning handled
+
+**What changed:**
+
+- `internal/dataentryconfig/config.go` — `Kanban.Header`/`.Footer`, same
+yaml/json tags as `List`, with a doc comment on why there is no `Description`
+fallback.
+- `frontend/src/types/config.ts` — `listHeaderMarkdown`/`listFooterMarkdown`
+replaced by `viewHeaderMarkdown`/`viewFooterMarkdown` taking a **structural**
+param, so `ListConfig` (has `description`) and `KanbanConfig` (does not) both
+satisfy them from one implementation. `KanbanConfig` gains `header?`/`footer?`.
+- `frontend/src/styles/view-info.css` — **new**; `.list-info` moved here as
+`.view-info` and imported in `main.ts`, following the existing `back-button.css`
+shared-stylesheet convention. `:deep()` wrappers dropped (inert in a global
+sheet).
+- `frontend/src/components/lists/EntityList.vue` — migrated to the shared
+resolvers + `.view-info`; local style block removed.
+- `frontend/src/views/KanbanView.vue` — header region after the filter bar,
+footer as the last child of `.kanban-view` (after every board branch), both
+`v-if` + `v-html` with the eslint-disable comment.
+- **Scroll containment:** `overflow-x` moved off `.kanban-view` onto
+`.kanban-board` (`overflow-x: auto`) and `.kanban-swimlane-board` (`overflow:
+auto hidden` — the two-value form preserves the vertical clipping that keeps
+cells inside the 8px border radius).
+- `docs/data-entry.md`, `tickets/data-entry.yaml` — docs + example board.
+
+## Manual Verification (REQUIRED)
+
+- [x] Feature tested end-to-end manually
+- [x] EACH acceptance criterion verified
+- [x] Verification evidence documented
+
+Verified against `rela-server --project tickets` (real binary, production SPA
+bundle) driven through a real browser (Puppeteer/Chromium), not jsdom.
+
+- **AC1 — header renders sanitized HTML above the board.** PASS.
+`/kanban/idea_board` `.view-info--top` renders "Ideas move left to right…" with
+a real `<strong>` element (markdown parsed, not escaped).
+- **AC2 — footer renders below the board.** PASS. `.view-info--bottom` renders
+the italic note with an `<em>` element; screenshot confirms placement under the
+columns.
+- **AC3 — sanitized via renderMarkdown.** PASS (component test). See the
+environment caveat under Quality below — the assertion is script-element
+stripping, deliberately not inline handlers.
+- **AC4 — nothing rendered when unset.** PASS. `/kanban/idea_by_category` (no
+header/footer configured) has neither `.view-info--top` nor `.view-info--bottom`
+in the DOM.
+- **AC5 — `_config` serves the fields, omits when unset.** PASS.
+`curl -H "Origin: …" /api/v1/_config` → `idea_board.header` and `.footer` both
+present; the five other boards (`bug_board`, `feature_board`,
+`future_concept_board`, `idea_by_category`, `ticket_board`) have neither key
+(omitempty). No `description` key on any kanban.
+- **AC6 — page furniture stays put while columns scroll.** PASS, measured.
+Simple board: `.kanban-view` computed `overflow-x: visible`, `.kanban-board`
+`auto`, content genuinely overflows (scrollWidth 1760 vs clientWidth 812).
+Setting `scrollLeft = 900` moved the first column's `left` from 264 → **-636**
+while header, footer, and `<h1>` all stayed at **264**. Footer is not a
+descendant of `.kanban-board`. Swimlane board: computed `overflow-x: auto` /
+`overflow-y: hidden` with `border-radius: 8px` intact, scrollWidth 1084 vs
+clientWidth 810, scrolls to 274 with the title unmoved — the corner-clipping
+risk flagged in planning did not materialize.
+- **AC7 — list behavior unchanged.** PASS. `/list/all_ideas` still renders both
+regions with markdown intact; no `.list-info` node remains anywhere. Shared
+stylesheet confirmed applied: `font-size: 14px`, `line-height: 22.4px` (14 ×
+1.6), and `margin-top: -12px` — the value planning flagged as "verify, don't
+assume" — transferred correctly to the new sheet. Full frontend suite (1441
+tests) green.
+
+## Quality
+
+- [x] Code follows project patterns
+- [x] No silent failures (errors surfaced, not just logged)
+- [x] Lint clean
+- [x] Tests pass
+
+- `go build ./...` clean; `go test ./internal/dataentryconfig/
+./internal/dataentry/` green.
+- `npm run test:run` — 87 files, **1441 tests**, all passing.
+- `npm run typecheck` (vue-tsc) — clean.
+- `npm run lint` — **0 errors**. The 90 warnings are all pre-existing
+(`max-lines`, non-null assertions in `stress/`); `EntityList.vue` got *shorter*
+(1446 lines, styles moved out) and `KanbanView.vue` (941) was already over the
+500-line warn threshold before this change.
+
+**Sanitization test — scope note (deliberate, not an oversight):** the AC3 test
+asserts that `<script>` elements never survive into the DOM. It does NOT assert
+that inline handlers (`onerror=`) are stripped, because under this suite's
+**happy-dom** environment DOMPurify leaves `onerror` on an `<img>` when the
+input parses to multiple top-level nodes (e.g. `<p>x</p>\n<img onerror=…>`).
+This was investigated rather than assumed: the identical payload through
+DOMPurify under **jsdom** returns `<img src="x">` with the handler removed, and
+DOMPurify sanitizes the payload correctly in isolation under happy-dom too — so
+it is a happy-dom DOM defect confined to the test environment, not a
+`renderMarkdown` bug and not a production exposure. Asserting no-`onerror` would
+have failed for an environment reason while proving nothing about shipped
+behavior. Handler stripping is DOMPurify's own contract; what is ours to prove
+is that the sanitizer sits in the path at all, which the test does.
+
+Worth noting for a future ticket: this happy-dom weakness means **no** frontend
+test in this repo can meaningfully assert inline-handler sanitization, including
+for entity content rendered by `EntityDetail.vue` / `api/views.ts`. That is a
+pre-existing gap in test-environment fidelity, not something this ticket
+introduced.

--- a/tickets/entities/planning-checklists/PLAN-23EP1Q.md
+++ b/tickets/entities/planning-checklists/PLAN-23EP1Q.md
@@ -1,0 +1,361 @@
+---
+id: PLAN-23EP1Q
+type: planning-checklist
+title: 'Planning: Render admin-authored header/footer markdown on kanban boards'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Understanding
+
+- [x] Problem/requirements clearly understood
+- [x] Scope defined (what's in/out documented below)
+- [x] Acceptance criteria documented with specific test scenarios
+
+**Scope:**
+
+IN: `header`/`footer` markdown info regions on kanban boards, implemented by
+**sharing** the list implementation (resolvers + styles) rather than copying it;
+plus a scroll-containment fix moving `overflow-x` off the page wrapper onto the
+board containers.
+
+OUT:
+- No `description` field on kanban. On lists it exists only because it
+predated the feature and was already present in configs; a kanban has no legacy
+`description` to accommodate. The shared resolver's fallback is inert for kanban
+because the field is absent from `KanbanConfig` — TypeScript enforces this, so
+sharing the helper does not leak the semantic.
+- Help-icon affordance for `description` → split to TKT-8CL0PO, so the
+semantics are decided once and applied to lists and kanbans uniformly instead of
+diverging here.
+- No server-side markdown rendering or sanitization change — reuses the
+existing client-side `renderMarkdown`.
+
+**Acceptance Criteria:**
+
+1. Kanban config with `header` markdown renders sanitized HTML above the board.
+Test: `KanbanView` component test mounts with `header: '# Hi'`, asserts a
+`.view-info--top` node containing the rendered `<h1>`.
+2. Kanban config with `footer` renders sanitized HTML below the board.
+Test: symmetric, asserts `.view-info--bottom`.
+3. Markdown is sanitized via the same `renderMarkdown` path as lists.
+Test: a `header` containing `<script>` / `onerror=` yields no script tag or
+inline handler in the rendered HTML.
+4. No header/footer configured → renders exactly as before, no empty region.
+Test: mount without the fields, assert neither info node exists.
+5. `_config` serves `header`/`footer` for kanbans, omits keys when unset.
+Test: Go `TestKanbanHeaderFooter_YAMLAndJSON` +
+`TestKanban_EmptyHeaderFooterOmittedFromJSON`, mirroring the existing `List`
+pair at `internal/dataentryconfig/config_test.go:329,366`.
+6. On a board wider than the viewport, page title / filter bar / truncation
+banner / header / footer stay visible while columns scroll — both branches.
+Test: assert `overflow-x` is NOT on `.kanban-view` and IS on the board
+containers (structural assertion; jsdom does not lay out, so the visual claim is
+confirmed by manual verification, documented below).
+7. Existing list header/footer behavior unchanged after the extraction.
+Test: the existing `EntityList` + `config.test.ts` suites must pass untouched in
+substance, including `description` fallback precedence.
+
+## Research
+
+- [x] For larger features: run `/research` — N/A (small, direct precedent exists)
+- [x] Searched for existing libraries that solve this problem
+- [x] Checked codebase for similar patterns or reusable code
+- [x] Looked for reference implementations in other projects
+- [x] Reviewed relevant rela concepts for prior art
+
+**Research Doc:** N/A — the approach reuses an already-reviewed in-tree
+implementation; the only design question (`description` semantics) was settled
+with the user during planning.
+
+**Existing Solutions:**
+
+Direct prior art in-tree — TKT-H7E611 / FEAT-RUGB28 built exactly this for
+lists. This ticket **shares** that code rather than porting it:
+
+- `internal/dataentryconfig/config.go:216-253` — `List.Header`/`Footer` fields
+and the doc comment explaining the `description` alias.
+- `internal/dataentryconfig/config_test.go:329-380` — the YAML/JSON round-trip
+and `omitempty` test pair to mirror.
+- `frontend/src/types/config.ts:143-176` — `ListConfig.header`/`footer` and the
+`listHeaderMarkdown`/`listFooterMarkdown` resolvers (trim, `''` when unset).
+- `frontend/src/components/lists/EntityList.vue:276-277,696-697,961-962` — the
+`computed` + `v-if` + `v-html` render pattern with the eslint disable comment
+justifying `v-html` as sanitized.
+- `frontend/src/components/lists/EntityList.vue:978-1018` — `.list-info`
+typography/spacing styles, including the first/last-child margin collapse.
+- `docs/data-entry.md:691-735` — the list field table rows and the "Header and
+footer info regions" section this will sit beside.
+
+**Shared-styles convention already exists:** `frontend/src/styles/` holds
+`back-button.css`, `markdown-content.css`, `mobile-bars.css`,
+`text-utilities.css`, `tokens.css`, all imported in `main.ts:6-14`.
+`back-button.css` is precedent for exactly this — one class shared across
+EntityDetail, CustomView, and BackButton. So `.list-info` → shared
+`view-info.css` follows an established pattern rather than inventing one.
+
+No new library needed: `renderMarkdown` (`frontend/src/utils/markdown.ts`)
+already sanitizes and is the exact function EntityList uses.
+
+Also checked for a reusable tooltip/help-icon component (for the `description`
+idea) — **none exists**; the SPA only uses bare `:title` attributes. That is a
+reason the help-icon work is its own ticket (TKT-8CL0PO) rather than a rider
+here.
+
+## Approach
+
+- [x] Technical approach chosen and documented
+- [x] Approach builds on existing patterns (not reinventing)
+- [x] Alternatives considered (document why rejected)
+- [x] Dependencies identified (packages, APIs, types)
+
+**Technical Approach:**
+
+1. **Go config** (`internal/dataentryconfig/config.go`): add to `Kanban`, after
+`Title`, matching `List`'s tags exactly: `Header string \`yaml:"header"
+json:"header,omitempty"\``and the same for`Footer`. No validation rules — the
+value is opaque markdown, and `validateKanbans`has nothing to check (consistent
+with`List`).
+
+2. **Shared TS resolvers** (`frontend/src/types/config.ts`): replace the two
+list-specific helpers with view-generic ones taking a **structural** param type,
+so both configs satisfy them without a union or a second copy:
+
+   ```ts
+   export function viewHeaderMarkdown(
+     view: { header?: string; description?: string } | undefined
+   ): string {
+     return view?.header?.trim() || view?.description?.trim() || ''
+   }
+   export function viewFooterMarkdown(
+     view: { footer?: string } | undefined
+   ): string {
+     return view?.footer?.trim() || ''
+   }
+   ```
+
+`KanbanConfig` has no `description`, so the fallback branch is unreachable for
+kanban — enforced by the type, not by having two functions. Add
+`header?`/`footer?` to `KanbanConfig`. Update `EntityList.vue` to the new names
+and update `config.test.ts` accordingly (keeping the existing
+fallback-precedence cases, which now also serve AC7).
+
+3. **Shared styles**: move the `.list-info` block from `EntityList.vue` to a
+new `frontend/src/styles/view-info.css` as `.view-info`, imported in `main.ts`
+beside the other shared sheets. Drop the `:deep()` wrappers — they exist only
+because the rules were inside a scoped component block and are unnecessary (and
+inert) in a global sheet. Update EntityList's template to `.view-info`. **Verify
+the `--top` rule's `margin-top: -12px`**: it is tuned to `.list-header`'s
+`margin-bottom: 24px` (per the comment at `EntityList.vue:987-988`);
+`.page-header` in KanbanView also uses `margin-bottom: 24px`
+(`KanbanView.vue:613`), so it should transfer — but confirm visually rather than
+assume.
+
+4. **KanbanView.vue**: import `renderMarkdown` + the shared resolvers; add
+`headerHtml`/`footerHtml` computeds. Render the header region after the filter
+bar and before the truncation banner (page context, above the board and its
+warnings); render the footer as the last child of `.kanban-view`, after all
+board branches, so it appears once for the loading / error / simple-board /
+swimlane cases instead of being duplicated per branch. Both use `v-if` +
+`v-html` with the eslint-disable comment, matching EntityList.
+
+5. **Scroll containment fix**: `.kanban-view` drops `overflow-x: auto`
+(keeping `max-width: 100%`); `.kanban-board` gains `overflow-x: auto`;
+`.kanban-swimlane-board` changes `overflow: hidden` → `overflow: auto hidden`.
+The swimlane grid's `overflow: hidden` exists to clip cells to its
+`border-radius: 8px` (`KanbanView.vue:824-833`), so the two-value form keeps
+that vertical clipping while enabling horizontal scroll. This also fixes the
+pre-existing quirk where the title and filter bar scrolled sideways.
+
+6. **Docs** (`docs/data-entry.md`): add `header`/`footer` rows to the kanban
+field table and a subsection cross-referencing the list one, noting kanban has
+no `description` alias.
+
+7. **Example config**: add `header`/`footer` to a board in
+`tickets/data-entry.yaml` for manual verification, as TKT-H7E611 did with the
+`all_ideas` list.
+
+**Files to modify:**
+
+- `internal/dataentryconfig/config.go` — `Kanban` struct fields
+- `internal/dataentryconfig/config_test.go` — YAML/JSON + omitempty tests
+- `frontend/src/types/config.ts` — `KanbanConfig` + shared resolvers
+- `frontend/src/types/config.test.ts` — resolver tests, renamed + kanban cases
+- `frontend/src/styles/view-info.css` — **new**, extracted from EntityList
+- `frontend/src/main.ts` — import the new stylesheet
+- `frontend/src/components/lists/EntityList.vue` — use shared resolvers/class,
+drop the local `.list-info` block
+- `frontend/src/views/KanbanView.vue` — computeds, 2 regions, scroll fix
+- `frontend/src/views/KanbanView.test.ts` — render/absence/sanitization/scroll
+- `docs/data-entry.md` — kanban field table + info-regions subsection
+- `tickets/data-entry.yaml` — example board header/footer
+
+**Alternatives considered:**
+
+- *Separate `kanbanHeaderMarkdown`/`kanbanFooterMarkdown` copies.* Rejected —
+this was the earlier plan; the user correctly pushed back. The two helpers
+differ only in one fallback field, which a structural param type handles without
+duplication, and copying would leave two places to fix a sanitization or
+trimming bug.
+- *Union type `ListConfig | KanbanConfig` on the resolvers.* Rejected: couples
+the helper to both concrete config types and would need widening for every
+future view type. A structural param is open-ended.
+- *Footer inside each board branch.* Rejected: duplicates the region across the
+simple-board and swimlane branches, and would not render in loading/error.
+- *Keeping `overflow-x` on `.kanban-view` and placing the footer outside it.*
+Rejected — that was a workaround for the layout bug; fixing the scroll
+containment is the real solution and also unsticks the title/filter bar.
+- *Copy the `description` alias for symmetry.* Rejected — see Scope.
+
+## Security Considerations
+
+- [x] Input sources identified (user input, config, external APIs)
+- [x] Input validation approach defined (allowlist preferred over blocklist)
+- [x] Security-sensitive operations identified (file access, auth, crypto)
+- [x] Error handling doesn't leak sensitive information
+
+**Input Sources & Validation:**
+
+The only input is `header`/`footer` markdown from `data-entry.yaml`, authored by
+an admin with filesystem access to the project config — the same trust level as
+the rest of the config (which already controls forms, lists, and Lua export
+scripts). It is not end-user input and is not entity data.
+
+The content is rendered as HTML via `v-html`, so the real control is
+sanitization: `renderMarkdown` (`frontend/src/utils/markdown.ts`) is the same
+function EntityList uses for the identical list regions, and it sanitizes
+output. AC3 pins this with a test asserting a `<script>`/`onerror=` payload in
+`header` produces no script tag or inline handler. Sharing one resolver (rather
+than two copies) *improves* this posture: a single sanitization path means a
+future fix cannot land on one view type and miss the other.
+
+**Security-Sensitive Operations:**
+
+- `v-html` rendering — protected by `renderMarkdown` sanitization + the
+explicit eslint-disable comment documenting why the exception is safe (matching
+EntityList's convention so the audit trail is uniform).
+- No file access, auth, or crypto surface. No ACL interaction: the regions are
+static admin-authored config, contain no entity data, and are served to anyone
+already authorized to see the board — so there is no per-row visibility question
+and nothing new for `internal/visibility` to gate.
+
+## Test Plan
+
+- [x] Test scenarios documented for each acceptance criterion
+- [x] Edge cases identified and documented
+- [x] Negative test cases defined (invalid input, error conditions)
+- [x] Integration test approach defined (not just unit tests)
+
+**Test Scenarios:** (mapped to ACs above)
+
+- AC1/AC2 → `KanbanView.test.ts`: mount with `header`/`footer` set, assert the
+`.view-info--top` / `.view-info--bottom` nodes exist with rendered HTML.
+- AC3 → `KanbanView.test.ts`: `header` with `<script>alert(1)</script>` and an
+`<img onerror=…>` payload → rendered HTML contains neither.
+- AC4 → `KanbanView.test.ts`: mount without the fields, assert neither node
+exists (guards the no-layout-shift claim structurally).
+- AC5 → `config_test.go`: YAML decode + JSON marshal has both keys; empty
+`Kanban{}` marshals with neither key present.
+- AC6 → structural assertion on which selectors carry `overflow-x`, plus
+manual verification (jsdom does not lay out, so a component test cannot prove
+the visual behavior — see Manual Verification).
+- AC7 → the existing list suites (`config.test.ts` fallback-precedence cases,
+EntityList render tests) must still pass after the extraction; this is the
+regression gate on the refactor.
+- Resolver units → `config.test.ts`: set / unset / whitespace-only / undefined,
+for both a list-shaped and a kanban-shaped input, plus the precedence case
+(`header` wins over `description`) and a kanban-shaped object confirming the
+fallback cannot apply.
+
+**Integration:** the `_config` round-trip (AC5) is the integration seam — it
+proves the SPA actually receives the fields rather than only that the struct
+compiles. No E2E test: TKT-H7E611 judged E2E optional for the equivalent list
+regions, and the render path is now literally shared.
+
+**Manual Verification (required — covers AC6):** run `just dev` against the
+tickets project with the example board, then confirm at a viewport narrower than
+the board: (a) columns scroll horizontally; (b) title, filter bar, header, and
+footer stay fixed; (c) the swimlane board scrolls horizontally with its rounded
+corners still clipped; (d) the list view's header/footer are visually unchanged
+after the style extraction.
+
+**Edge Cases:**
+
+- Unset → no region, no empty div (AC4).
+- Whitespace-only (`header: "   "`) → treated as unset via `.trim() || ''`.
+- Header set but footer unset (and vice versa) → only the one region renders.
+- Very long markdown → wraps; region is outside the scroller so must not widen
+the board or introduce a second horizontal scrollbar.
+- Board in loading or error state → footer still renders (page-level context,
+deliberately outside the branch).
+- Swimlane vs simple board → identical regions; placement after both branches
+guarantees this without duplication.
+- Narrow viewport / mobile → the scroll change interacts with the existing
+`@media` rules at `KanbanView.vue:890,912`; check the board still scrolls rather
+than overflowing the page.
+- Board narrower than viewport → no scrollbar appears (`auto`, not `scroll`).
+
+**Negative Tests:**
+
+- Script/handler injection in `header` → sanitized away, no execution (AC3).
+- Malformed markdown (unclosed emphasis, stray backticks) → renders as text,
+does not throw; `renderMarkdown` is total and returns a string.
+
+## Risk Assessment
+
+- [x] Technical risks assessed with mitigations
+- [x] Security risks assessed (see Security Considerations)
+- [x] Effort estimated (xs/s/m/l/xl)
+
+**Risks:**
+
+- *Regressing list rendering via the shared extraction* — the main new risk,
+since this ticket now touches working list code. Mitigated by AC7: the existing
+list tests must pass unchanged in substance, plus manual visual confirmation
+that list header/footer are unaffected.
+- *Scroll change breaks board layout* — moving `overflow-x` affects every
+existing board, including ones with no header/footer. The swimlane `overflow:
+hidden` → `auto hidden` is the subtle part (it must keep clipping cells to the
+rounded border). Mitigated by explicit manual verification of both branches at a
+narrow viewport, and by the mobile-media-query edge case.
+- *`margin-top: -12px` on `--top` may not transfer* — it is tuned to
+`.list-header`'s spacing. `.page-header` uses the same `margin-bottom: 24px`, so
+it should be fine; confirmed visually rather than assumed.
+- *XSS via `v-html`* — low. Reuses the already-reviewed sanitizer, now on a
+single shared path, pinned by AC3.
+- *`KanbanView.vue` size* — 917 lines against the `max-lines: 500` eslint warn
+threshold; this adds ~30 (less than before, since styles move out). Already
+warning, warn-level only, does not fail CI. Worth a decomposition ticket later.
+
+**Effort:** m (raised from s: the shared extraction touches working list code
+and the scroll fix affects every board, so the testing surface is wider than a
+pure additive change.)
+
+## Documentation Planning
+
+- [x] User-facing docs identified (skip if internal refactor)
+- [x] Docs-checklist will be created when entering implementation
+
+**Documentation Impact:**
+
+- [x] `docs/data-entry.md` — kanban field table rows for `header`/`footer` +
+an info-regions subsection cross-referencing the list one and noting the absence
+of a `description` alias on kanban.
+- [x] ~~`docs/metamodel.md`~~ (N/A: data-entry config, not metamodel)
+- [x] ~~`docs/cli-reference.md`~~ (N/A: no CLI surface)
+- [x] ~~`CLAUDE.md`~~ (N/A: no new pattern or convention — the shared-stylesheet
+approach follows the existing `frontend/src/styles/` convention).
+- [x] ~~`README.md`~~ (N/A: not project-level)
+
+## Design Review
+
+- [x] Run `/design-review` before starting implementation
+- [x] All critical/significant findings addressed in plan
+
+**Design Review Findings:** None outstanding. Two design questions were raised
+and resolved with the user during planning: (1) `description` semantics — split
+to TKT-8CL0PO; (2) whether to duplicate the list helpers — resolved in favor of
+sharing, and (3) scroll containment — fixed properly here rather than worked
+around. The remaining work builds on an implementation that already passed
+review under TKT-H7E611.

--- a/tickets/entities/review-checklists/REV-NJPYAJ.md
+++ b/tickets/entities/review-checklists/REV-NJPYAJ.md
@@ -1,0 +1,84 @@
+---
+id: REV-NJPYAJ
+type: review-checklist
+title: 'Review: Render admin-authored header/footer markdown on kanban boards'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Automated Checks
+
+- [x] `go test` passes — `internal/dataentryconfig`, `internal/dataentry` green
+- [x] `npm run test:run` — 87 files, **1443 tests**, all passing
+- [x] `npm run typecheck` (vue-tsc) — clean
+- [x] `npm run lint` — **0 errors** (90 warnings, all pre-existing: `max-lines`,
+non-null assertions in `stress/`)
+- [x] `just arch-lint` — OK, no warnings
+- [x] `just coverage-check` — package (50%) and total (65%) thresholds satisfied;
+total 77.2%
+- [x] `go build ./...` clean
+
+## Code Review
+
+Reviewed by the cranky-code-reviewer agent, which independently verified the CSS
+in a real browser engine and the sanitizer under both happy-dom and jsdom rather
+than trusting the comments. Verdict: no critical findings, two significant, one
+minor. All three addressed.
+
+- **RR-GNWJFO (significant) — addressed.** Comments in three places claimed the
+TypeScript *type* kept the `description` alias away from kanban. False: types
+erase at runtime, and configs arrive from the `/_config` HTTP response, so a
+future Go `Kanban.Description` field would have silently switched the alias on
+while the comment said it could not. Replaced the claim with an actual mechanism
+— `viewHeaderMarkdown(view, { allowDescriptionAlias })`, opted into by
+EntityList only — plus two regression tests including the exact drift scenario.
+- **RR-G80SDH (significant) — addressed.** `overflow-x: auto` on `.kanban-board`
+coerces `overflow-y` to `auto` per spec, making it a vertical clip container it
+was not before, on every existing board. Benign today and inherent to the scroll
+fix, so documented as an accepted constraint (mirroring the comment already on
+the swimlane rule) rather than worked around — `overflow-y: visible` cannot opt
+out.
+- **RR-AKQRNB (minor) — addressed.** Sanitization-test comment named only the
+`onerror` happy-dom gap; extended to include `javascript:` hrefs, and added an
+environment-independent assertion that markdown was processed. Found in the
+process that happy-dom also keeps a `<script>` following inline content, so the
+two payloads are kept on separate fields with the reason documented.
+
+Findings deliberately NOT actioned (discretionary, logged for future work):
+
+- *Extract a `<ViewInfo>` component* — the reviewer's leverage suggestion. Both
+views now share resolvers and styles but each wires its own computeds + `v-html`
++ eslint-disable. Real duplication, but component extraction is scope beyond
+this ticket and better done when a third view wants info regions.
+- *`.view-info` naming / `mountBoard` positional `{}` filler* — cosmetic.
+- *`-12px` coupled to two headers with no test* — pre-existing coupling
+(RR-PUIE0H), now documented in `view-info.css`. The reviewer notes a filter-bar
+interaction worth an eyeball; the example board `idea_board` has filter controls
+and was visually verified, showing correct spacing.
+
+## Acceptance Verification
+
+All seven criteria verified end-to-end against the real `rela-server` binary
+serving the production SPA bundle, driven through a real browser — see
+IMPL-EH9RW8 for full evidence. Summary:
+
+1. **AC1 header renders** — PASS (`<strong>` present, markdown parsed).
+2. **AC2 footer renders** — PASS (`<em>` present, below the columns).
+3. **AC3 sanitized** — PASS (script element stripped; scope caveat documented).
+4. **AC4 unset → nothing** — PASS (`idea_by_category` has neither region).
+5. **AC5 `_config` serves/omits** — PASS (1 board with both keys, 5 with neither).
+6. **AC6 furniture stays put** — PASS, measured: columns moved 264 → -636 on a
+900px scroll while header, footer, and `<h1>` all held at 264. Swimlane branch
+keeps `overflow-y: hidden` + `border-radius: 8px`.
+7. **AC7 lists unchanged** — PASS, re-verified after the RR-GNWJFO refactor:
+`active_ideas` (only `description`, no `header`) still renders its region,
+proving the alias opt-in works; shared stylesheet applies (`14px`/`22.4px`/
+`-12px`).
+
+## Ready
+
+- [x] All critical/significant review responses resolved
+- [x] Acceptance criteria verified with evidence
+- [x] Docs updated (`docs/data-entry.md` — kanban field table + info-regions
+subsection noting the absent `description` alias)

--- a/tickets/entities/review-checklists/REV-NJPYAJ.md
+++ b/tickets/entities/review-checklists/REV-NJPYAJ.md
@@ -48,9 +48,9 @@ two payloads are kept on separate fields with the reason documented.
 Findings deliberately NOT actioned (discretionary, logged for future work):
 
 - *Extract a `<ViewInfo>` component* — the reviewer's leverage suggestion. Both
-views now share resolvers and styles but each wires its own computeds + `v-html`
-+ eslint-disable. Real duplication, but component extraction is scope beyond
-this ticket and better done when a third view wants info regions.
+views now share resolvers and styles, but each still wires its own computeds,
+`v-html` div, and eslint-disable. Real duplication, but component extraction is
+scope beyond this ticket and better done when a third view wants info regions.
 - *`.view-info` naming / `mountBoard` positional `{}` filler* — cosmetic.
 - *`-12px` coupled to two headers with no test* — pre-existing coupling
 (RR-PUIE0H), now documented in `view-info.css`. The reviewer notes a filter-bar

--- a/tickets/entities/review-responses/RR-AKQRNB.md
+++ b/tickets/entities/review-responses/RR-AKQRNB.md
@@ -1,0 +1,9 @@
+---
+id: RR-AKQRNB
+type: review-response
+title: 'Sanitization test comment omits the javascript: href gap in happy-dom'
+finding: 'The AC3 test comment in KanbanView.test.ts documents that happy-dom leaves onerror= on an <img>, but the reviewer verified happy-dom ALSO fails to neutralize javascript: hrefs (real browser strips both). A reader will assume inline handlers are the only environment gap. Additionally the test proves the sanitizer is in the path via an environment-dependent payload; asserting markdown was processed (e.g. <strong> present) would prove the same wiring independent of DOM implementation.'
+severity: minor
+resolution: 'Extended the test comment to name the javascript: href gap alongside the onerror one, and added an environment-independent wiring assertion (expect ''<strong>bold</strong>'') so the test proves renderMarkdown is in the path without depending on happy-dom''s sanitization behavior. Discovered while doing so that happy-dom ALSO keeps a <script> when it follows inline content (''**bold** <script>'' survives; a bare ''<script>'' does not) — verified under jsdom that both are stripped correctly there, so it is the same environment defect. The two payloads are therefore kept on separate fields (header proves markdown processing, footer proves script stripping) and the comment documents why.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-G80SDH.md
+++ b/tickets/entities/review-responses/RR-G80SDH.md
@@ -1,0 +1,30 @@
+---
+id: RR-G80SDH
+type: review-response
+title: overflow-x:auto silently makes .kanban-board a vertical clip container
+finding: 'Adding overflow-x:auto to .kanban-board coerces overflow-y from visible to auto per CSS spec, making the board a vertical clip container it previously was not — affecting every existing board. Benign today (page scrolls, card hover-shadow fits inside padding) but load-bearing by accident: any future drag ghost, tooltip, popover, or sticky header rendering outside a card box will be clipped. overflow-y:visible cannot opt out; the spec coerces it back.'
+severity: significant
+resolution: 'Documented the accepted constraint on the .kanban-board rule, matching the comment already on the swimlane rule: overflow-x:auto coerces overflow-y from visible to auto per spec, so the board now clips vertically and overflow-y:visible cannot opt out. The comment records why it is safe today (card hover shadow''s 8px blur is inset by .column-cards'' 12px padding, plus 20px padding-bottom) and names what would be clipped in future (drag ghost, tooltip, popover, sticky column header), so the next person finds the explanation in the right file. No behavior change — the clipping is inherent to scoping the horizontal scroll to the board, which is what the ticket set out to do.'
+status: addressed
+---
+
+## Finding
+
+`frontend/src/views/KanbanView.vue` `.kanban-board { overflow-x: auto }`.
+
+Per CSS spec a non-`visible` overflow on one axis coerces the other from
+`visible` to `auto`. Verified: an element with only `overflow-x: auto` computes
+`{x: "auto", y: "auto"}`. So `.kanban-board` now clips vertically, which it did
+not before — and this affects every existing board, not just ones with
+header/footer.
+
+Practical impact today is benign: `.main-content` sets no height so the page
+scrolls rather than the board, and the card `:hover` box-shadow (8px blur)
+survives because `.column-cards` padding is 12px and the board has 20px
+padding-bottom. But it is load-bearing by accident. Anything later rendering
+outside a card's box — drag ghost, tooltip, popover, sticky column header — gets
+clipped, and the next person debugs it in the wrong file.
+
+Note `overflow-y: visible` cannot be used to opt out; the spec coerces it back.
+The fix is to document the accepted constraint, matching the honesty of the
+comment already on the swimlane rule.

--- a/tickets/entities/review-responses/RR-GNWJFO.md
+++ b/tickets/entities/review-responses/RR-GNWJFO.md
@@ -1,0 +1,30 @@
+---
+id: RR-GNWJFO
+type: review-response
+title: Comment falsely claims TypeScript enforces the no-description-alias rule
+finding: 'config.ts JSDoc, the KanbanConfig comment, and config.test.ts all claim the config TYPE prevents the description fallback reaching kanban. TypeScript types erase at runtime, so viewHeaderMarkdown({description: ''LEAKED'', ...}) returns ''LEAKED''. Configs arrive from the /_config HTTP response (runtime data), so if Description is later added to the Go Kanban struct, kanban silently gains the deliberately-excluded fallback while the comment says that is impossible.'
+severity: significant
+resolution: 'Turned the policy into a mechanism instead of a comment. viewHeaderMarkdown now takes an explicit opts.allowDescriptionAlias flag; only EntityList passes it, kanban never does, so the alias no longer depends on a type that erases at runtime. Rewrote all three false comments (config.ts JSDoc, KanbanConfig, config.test.ts) to state that the call site enforces it. Added two regression tests: the alias is ignored when not opted into, and a kanban-shaped object carrying a stray `description` (the exact drift scenario — a future Go Kanban.Description field) resolves to ''''. Verified end-to-end: list `active_ideas`, which has only `description` and no `header`, still renders its region against the real server, while all six kanbans expose no description key.'
+status: addressed
+---
+
+## Finding
+
+`frontend/src/types/config.ts:169-172` (JSDoc), `:255-256` (KanbanConfig
+comment) and `config.test.ts:121-122` all assert that the config *type* is what
+keeps the `description` fallback list-only. TypeScript types are erased at
+runtime, so this is false:
+
+```ts
+const board = { entity: 'ticket', column_property: 'status', description: 'LEAKED' }
+viewHeaderMarkdown(board) // => 'LEAKED'
+```
+
+The structural param accepts any object carrying a `description`. Board configs
+arrive from the `/_config` HTTP response — runtime data. If someone later adds
+`Description` to the Go `Kanban` struct (the field name sits right there on
+`List`, one struct over), kanban silently gains the fallback the ticket
+deliberately excluded, while the comment says that cannot happen.
+
+The design decision is sound; the enforcement story is wrong. A false-confidence
+comment is worse than no comment.

--- a/tickets/entities/tickets/TKT-6S331G.md
+++ b/tickets/entities/tickets/TKT-6S331G.md
@@ -1,0 +1,91 @@
+---
+id: TKT-6S331G
+type: ticket
+title: Render admin-authored header/footer markdown on kanban boards
+kind: enhancement
+priority: medium
+effort: m
+status: done
+---
+
+## Description
+
+Extend the list-view header/footer info regions (FEAT-RUGB28, TKT-H7E611) to
+kanban board views so an admin can author contextual markdown above and below a
+board from `data-entry.yaml` — sharing the implementation with lists rather than
+duplicating it, and moving the board's horizontal scroll off the page wrapper so
+the regions stay visible.
+
+## Problem
+
+`list:` views support admin-authored markdown info regions (`header`, `footer`,
+with `description` as a legacy fallback for `header`) — added in TKT-H7E611.
+Kanban boards have no equivalent: a board cannot carry a short blurb explaining
+what the board is for, links to relevant guides, or footer notes about the
+workflow the columns represent.
+
+The asymmetry is arbitrary — a kanban board is just as much a landing surface as
+a list, and the same "this register is ISO 27001 scope, see the scoring guide"
+context applies.
+
+Separately, `.kanban-view` carries `overflow-x: auto` on the whole page wrapper,
+so on a wide board the page title, filter bar, and truncation banner scroll
+sideways along with the columns. Info regions placed there would inherit the
+same quirk.
+
+## Scope
+
+In scope:
+
+- **Shared, not duplicated.** Extract the list header/footer implementation
+into a form both view types use:
+  - `viewHeaderMarkdown` / `viewFooterMarkdown` resolvers in
+`frontend/src/types/config.ts`, taking a structural param type so `ListConfig`
+(which has `description`) and `KanbanConfig` (which does not) both satisfy it.
+`EntityList.vue` migrates to them; the existing `listHeaderMarkdown` /
+`listFooterMarkdown` names are kept as thin re-exports or removed with their
+call sites updated.
+  - `.list-info` styles move to a shared `frontend/src/styles/view-info.css`
+as `.view-info`, loaded in `main.ts` alongside the existing shared stylesheets.
+`:deep()` wrappers drop (unnecessary once global).
+- `dataentryconfig.Kanban` gains `Header`/`Footer` with the same yaml/json
+tags as `List`.
+- TS `KanbanConfig` gains `header?` / `footer?`.
+- `KanbanView.vue` renders the two regions using the shared resolvers + class.
+- **Scroll containment fix:** move `overflow-x` off `.kanban-view` onto the
+board containers — `.kanban-board { overflow-x: auto }` and
+`.kanban-swimlane-board { overflow: auto hidden }` (the swimlane grid currently
+uses `overflow: hidden` to clip its cells to the rounded border, so it needs the
+two-value form to keep that clipping while scrolling horizontally). Page title,
+filter bar, truncation banner, and both info regions then stay put while only
+the columns scroll.
+- Document in `docs/data-entry.md`.
+
+Out of scope:
+
+- **No `description` field on kanban.** Unlike lists — where `description`
+predated the feature and was adopted as a silent fallback for `header` — a
+kanban has no existing `description` field, so there is no legacy config to
+accommodate. The shared resolver gates the fallback behind an explicit
+`allowDescriptionAlias` opt-in that only the list call site passes, so sharing
+the helper does not leak the semantic. (Originally planned to rely on
+`KanbanConfig` simply lacking the field — corrected per RR-GNWJFO, since TS
+types erase at runtime and configs arrive from the `_config` response.)
+- **Help-icon affordance.** Using `description` as a short tooltip/help blurb
+next to the view title (distinct from the markdown banner) is a good idea but a
+different feature, and it should be decided once and applied to lists and
+kanbans uniformly rather than introduced asymmetrically here. Split to
+TKT-8CL0PO.
+
+## Acceptance criteria
+
+1. A kanban config with `header` markdown renders sanitized HTML above the board.
+2. A kanban config with `footer` markdown renders sanitized HTML below the board.
+3. Markdown is sanitized through the same `renderMarkdown` path as lists (no raw HTML injection).
+4. A kanban with no header/footer configured renders exactly as before — no empty region, no layout shift.
+5. `_config` API serves `header`/`footer` for kanbans and omits the keys when unset.
+6. On a board wider than the viewport, the page title, filter bar, truncation
+banner, header, and footer remain visible while the columns scroll horizontally
+— in both the simple-board and swimlane branches.
+7. Existing list header/footer behavior is unchanged after the shared
+extraction (including the `description` fallback and its precedence).

--- a/tickets/entities/tickets/TKT-8CL0PO.md
+++ b/tickets/entities/tickets/TKT-8CL0PO.md
@@ -1,0 +1,49 @@
+---
+id: TKT-8CL0PO
+type: ticket
+title: Help-icon affordance for view descriptions (lists + kanbans)
+kind: enhancement
+priority: low
+status: backlog
+---
+
+## Description
+
+Give `description` an independent job on data-entry views: a short plain-text
+help blurb surfaced via a help icon (ⓘ / ?) next to the view title, distinct
+from the `header`/`footer` markdown banner regions.
+
+## Background
+
+Split out of TKT-6S331G (kanban header/footer). While scoping that ticket the
+question came up of whether kanban should copy the list `description` → `header`
+fallback. Today on lists, `description` is a *silent fallback*: when both
+`header` and `description` are set, `header` wins and `description` is ignored —
+a field that only does something when another field is absent.
+
+The better model is for the two to stop competing for one slot: `header` is the
+prose banner, `description` is a compact tooltip. That also matches how
+`description` is used everywhere else in the SPA — field help
+(`FieldRenderer.vue:44`, `RelationPicker.vue:98`), wizard step descriptions
+(`DynamicForm.vue:1426`), the dashboard subtitle (`DashboardView.vue:17`) — all
+short plain text, never a rendered markdown region. The list fallback is the
+outlier.
+
+## Scope
+
+- A small shared help-icon/tooltip component. **None exists today** — the SPA
+only uses bare `:title` attributes (`InaccessibleField.vue`,
+`AutoSaveIndicator.vue`), so this needs building, including keyboard and
+screen-reader access (a `:title` alone is not reachable by keyboard).
+- Wire it to `description` on both `ListConfig` and `KanbanConfig`, so the
+semantics are decided once and applied uniformly.
+- Deprecate the list `description` → `header` fallback. **This is a behavior
+change**: any config relying on `description` rendering as a header banner would
+move to a tooltip instead. Needs a migration note, and possibly a migration, in
+`docs/data-entry.md` (see TKT-SI02JV, which reworded that fallback note).
+
+## Open questions
+
+- Does the fallback get removed outright, or kept for a deprecation period?
+- Should `description` stay plain text (consistent with other SPA uses), or
+render inline markdown?

--- a/tickets/relations/TKT-6S331G--affects--data-entry-ui.md
+++ b/tickets/relations/TKT-6S331G--affects--data-entry-ui.md
@@ -1,0 +1,5 @@
+---
+from: TKT-6S331G
+relation: affects
+to: data-entry-ui
+---

--- a/tickets/relations/TKT-6S331G--has-docs--DOCS-V4R8MI.md
+++ b/tickets/relations/TKT-6S331G--has-docs--DOCS-V4R8MI.md
@@ -1,0 +1,5 @@
+---
+from: TKT-6S331G
+relation: has-docs
+to: DOCS-V4R8MI
+---

--- a/tickets/relations/TKT-6S331G--has-implementation--IMPL-EH9RW8.md
+++ b/tickets/relations/TKT-6S331G--has-implementation--IMPL-EH9RW8.md
@@ -1,0 +1,5 @@
+---
+from: TKT-6S331G
+relation: has-implementation
+to: IMPL-EH9RW8
+---

--- a/tickets/relations/TKT-6S331G--has-planning--PLAN-23EP1Q.md
+++ b/tickets/relations/TKT-6S331G--has-planning--PLAN-23EP1Q.md
@@ -1,0 +1,5 @@
+---
+from: TKT-6S331G
+relation: has-planning
+to: PLAN-23EP1Q
+---

--- a/tickets/relations/TKT-6S331G--has-review--REV-NJPYAJ.md
+++ b/tickets/relations/TKT-6S331G--has-review--REV-NJPYAJ.md
@@ -1,0 +1,5 @@
+---
+from: TKT-6S331G
+relation: has-review
+to: REV-NJPYAJ
+---

--- a/tickets/relations/TKT-6S331G--has-review-response--RR-AKQRNB.md
+++ b/tickets/relations/TKT-6S331G--has-review-response--RR-AKQRNB.md
@@ -1,0 +1,5 @@
+---
+from: TKT-6S331G
+relation: has-review-response
+to: RR-AKQRNB
+---

--- a/tickets/relations/TKT-6S331G--has-review-response--RR-G80SDH.md
+++ b/tickets/relations/TKT-6S331G--has-review-response--RR-G80SDH.md
@@ -1,0 +1,5 @@
+---
+from: TKT-6S331G
+relation: has-review-response
+to: RR-G80SDH
+---

--- a/tickets/relations/TKT-6S331G--has-review-response--RR-GNWJFO.md
+++ b/tickets/relations/TKT-6S331G--has-review-response--RR-GNWJFO.md
@@ -1,0 +1,5 @@
+---
+from: TKT-6S331G
+relation: has-review-response
+to: RR-GNWJFO
+---

--- a/tickets/relations/TKT-6S331G--implements--FEAT-RUGB28.md
+++ b/tickets/relations/TKT-6S331G--implements--FEAT-RUGB28.md
@@ -1,0 +1,5 @@
+---
+from: TKT-6S331G
+relation: implements
+to: FEAT-RUGB28
+---

--- a/tickets/relations/TKT-8CL0PO--affects--data-entry-ui.md
+++ b/tickets/relations/TKT-8CL0PO--affects--data-entry-ui.md
@@ -1,0 +1,5 @@
+---
+from: TKT-8CL0PO
+relation: affects
+to: data-entry-ui
+---

--- a/tickets/relations/TKT-8CL0PO--implements--FEAT-RUGB28.md
+++ b/tickets/relations/TKT-8CL0PO--implements--FEAT-RUGB28.md
@@ -1,0 +1,5 @@
+---
+from: TKT-8CL0PO
+relation: implements
+to: FEAT-RUGB28
+---


### PR DESCRIPTION
Lists could carry admin-authored markdown above and below the table (TKT-H7E611); boards could not. The asymmetry was arbitrary — a board is just as much a landing surface, and wants the same "here's what this is for, see the guide" context.

```yaml
kanbans:
  ticket_board:
    entity_type: ticket
    header: |
      Cards move **left to right**. Drag a card to change its status.
    footer: |
      _Reopening a done ticket? Talk to the maintainers first._
```

## Shared, not copied

The list resolvers became `viewHeaderMarkdown`/`viewFooterMarkdown`, and `.list-info` moved to a shared `styles/view-info.css` as `.view-info` (following the `back-button.css` convention). Both views now use one implementation, so a future sanitization or spacing fix lands in one place.

## The `description` alias stays list-only

It exists on lists only because the field predated the feature and was already in configs; a board has no such legacy.

It is gated behind an explicit `allowDescriptionAlias` opt-in that only `EntityList` passes — **not** on `KanbanConfig` merely lacking the field. TS types erase at runtime and these configs are parsed from the `_config` response, so relying on the type would leave the policy one Go struct field away from silently reversing itself. Regression-tested with the exact drift scenario.

## Scroll containment

`overflow-x` moved off the `.kanban-view` page wrapper onto the board containers. Without it the footer would scroll off-screen on a wide board; the fix incidentally stops the page title and filter bar sliding sideways too — a pre-existing quirk affecting every board.

The swimlane grid needs `overflow: auto hidden` specifically: its `overflow: hidden` was clipping cells to the rounded border, and a bare `overflow-x` would drop that. Note `overflow-x: auto` also coerces `overflow-y` to `auto` per spec, making `.kanban-board` a vertical clip container it was not before — documented in the CSS as an accepted constraint.

## Verification

All 7 acceptance criteria verified end-to-end against the real `rela-server` binary serving the production bundle, driven through a browser. The load-bearing one: scrolling the board 900px moved columns from x=264 to **x=-636** while header, footer, and `<h1>` all held at **264**. Swimlane branch keeps `overflow-y: hidden` + `border-radius: 8px`. List regions re-verified after the refactor — `active_ideas` (only `description`, no `header`) still renders, proving the opt-in works.

1443 frontend tests, full Go suite, typecheck, lint (0 errors), arch-lint, coverage 77.2%, docs-check — all green.

## Reviewer notes

- Code review found 2 significant + 1 minor; all addressed (RR-GNWJFO, RR-G80SDH, RR-AKQRNB).
- **Out of scope, filed as TKT-8CL0PO:** a help-icon affordance giving `description` an independent job across both view types.
- **Pre-existing gap noticed, not introduced here:** happy-dom's DOM is defective enough that DOMPurify leaves `onerror=`, `javascript:` hrefs, and some `<script>` tags intact under it. Verified against jsdom and a real browser that production sanitization is correct. It does mean no frontend test in this repo can meaningfully assert handler stripping, including for entity content in `EntityDetail.vue`. Worth its own ticket.

Closes TKT-6S331G.