### PR TITLE
fix: entity IDs are one identity per case-folding across all store backends (BUG-3RCWNS)

### DIFF
--- a/internal/store/fsstore/entity.go
+++ b/internal/store/fsstore/entity.go
@@ -199,6 +199,29 @@ func (s *FSStore) PropertyValues(_ context.Context, property string, limit int) 
 
 // --- EntityWriter ---
 
+// idTaken reports whether a stored entity case-folds to the same identity as
+// id. except is skipped so a rename can ask "does any OTHER entity claim this
+// identity?" without self-colliding.
+//
+// Derived from the index on each call rather than kept as a second map: the
+// entity index is mutated at several sites here, and a parallel index would
+// silently drift at whichever one a future change forgets to update. Runs
+// only on create and rename, never on a read path.
+//
+// Callers must hold s.mu.
+func (s *FSStore) idTaken(id, except string) bool {
+	folded := storeutil.FoldID(id)
+	for existing := range s.entities {
+		if existing == except {
+			continue
+		}
+		if storeutil.FoldID(existing) == folded {
+			return true
+		}
+	}
+	return false
+}
+
 func (s *FSStore) createEntity(_ context.Context, e *entity.Entity) error {
 	if err := storeutil.ValidateID(e.ID); err != nil {
 		return err
@@ -207,7 +230,10 @@ func (s *FSStore) createEntity(_ context.Context, e *entity.Entity) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	if _, exists := s.entities[e.ID]; exists {
+	// Case-folded: on a case-insensitive filesystem (macOS, Windows) "ABC"
+	// and "abc" are the same file, so a byte-exact check here would let the
+	// write silently overwrite the existing entity (BUG-3RCWNS).
+	if s.idTaken(e.ID, "") {
 		return store.ErrConflict
 	}
 
@@ -376,7 +402,8 @@ func (s *FSStore) renameEntity(_ context.Context, oldID, newID string) (*store.R
 	if !ok {
 		return nil, store.ErrNotFound
 	}
-	if _, exists := s.entities[newID]; exists {
+	// except=oldID: an entity may change its own casing (abc -> ABC).
+	if s.idTaken(newID, oldID) {
 		return nil, store.ErrConflict
 	}
 

--- a/internal/store/fsstore/entity.go
+++ b/internal/store/fsstore/entity.go
@@ -199,19 +199,21 @@ func (s *FSStore) PropertyValues(_ context.Context, property string, limit int) 
 
 // --- EntityWriter ---
 
-// idTaken reports whether a stored entity case-folds to the same identity as
+// idTaken reports whether any key of index case-folds to the same identity as
 // id. except is skipped so a rename can ask "does any OTHER entity claim this
 // identity?" without self-colliding.
 //
-// Derived from the index on each call rather than kept as a second map: the
-// entity index is mutated at several sites here, and a parallel index would
-// silently drift at whichever one a future change forgets to update. Runs
-// only on create and rename, never on a read path.
+// Scans the existing index on each call rather than maintaining a second
+// case-folded map: the entity index is mutated at several sites, and a
+// parallel index would silently drift at whichever one a future change
+// forgets to update. Runs only on create and rename, never on a read path.
 //
+// A free function rather than a method — FSStore is at its plimsoll
+// max-methods line, and this needs no receiver state beyond the index.
 // Callers must hold s.mu.
-func (s *FSStore) idTaken(id, except string) bool {
+func idTaken(index map[string]entityMeta, id, except string) bool {
 	folded := storeutil.FoldID(id)
-	for existing := range s.entities {
+	for existing := range index {
 		if existing == except {
 			continue
 		}
@@ -233,7 +235,7 @@ func (s *FSStore) createEntity(_ context.Context, e *entity.Entity) error {
 	// Case-folded: on a case-insensitive filesystem (macOS, Windows) "ABC"
 	// and "abc" are the same file, so a byte-exact check here would let the
 	// write silently overwrite the existing entity (BUG-3RCWNS).
-	if s.idTaken(e.ID, "") {
+	if idTaken(s.entities, e.ID, "") {
 		return store.ErrConflict
 	}
 
@@ -403,7 +405,7 @@ func (s *FSStore) renameEntity(_ context.Context, oldID, newID string) (*store.R
 		return nil, store.ErrNotFound
 	}
 	// except=oldID: an entity may change its own casing (abc -> ABC).
-	if s.idTaken(newID, oldID) {
+	if idTaken(s.entities, newID, oldID) {
 		return nil, store.ErrConflict
 	}
 

--- a/internal/store/memstore/memstore.go
+++ b/internal/store/memstore/memstore.go
@@ -156,6 +156,29 @@ var (
 	sortedRemove     = storeutil.SortedRemove
 )
 
+// idTaken reports whether a stored entity case-folds to the same identity as
+// id. except is skipped so a rename can ask "does any OTHER entity claim this
+// identity?" without self-colliding.
+//
+// Derived from the entities map on each call rather than kept as a second
+// index: entity IDs are written at five sites here, and a parallel map would
+// silently drift out of sync at whichever one a future change forgets. The
+// scan is O(n) but runs only on create and rename, never on a read path.
+//
+// Callers must hold m.mu.
+func (m *MemStore) idTaken(id, except string) bool {
+	folded := storeutil.FoldID(id)
+	for existing := range m.entities {
+		if existing == except {
+			continue
+		}
+		if storeutil.FoldID(existing) == folded {
+			return true
+		}
+	}
+	return false
+}
+
 // --- EntityReader ---
 
 func (m *MemStore) GetEntity(_ context.Context, id string) (*entity.Entity, error) {
@@ -330,7 +353,9 @@ func (m *MemStore) createEntity(_ context.Context, e *entity.Entity) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	if _, exists := m.entities[e.ID]; exists {
+	// Case-folded so "ABC" conflicts with an existing "abc" — on fsstore they
+	// are one file, and the backends must agree on identity (BUG-3RCWNS).
+	if m.idTaken(e.ID, "") {
 		return store.ErrConflict
 	}
 
@@ -441,7 +466,9 @@ func (m *MemStore) renameEntity(_ context.Context, oldID, newID string) (*store.
 	if !ok {
 		return nil, store.ErrNotFound
 	}
-	if _, exists := m.entities[newID]; exists {
+	// except=oldID: renaming an entity to a different casing of its own ID
+	// (abc -> ABC) is legitimate and must not self-collide.
+	if m.idTaken(newID, oldID) {
 		return nil, store.ErrConflict
 	}
 

--- a/internal/store/memstore/memstore.go
+++ b/internal/store/memstore/memstore.go
@@ -156,7 +156,7 @@ var (
 	sortedRemove     = storeutil.SortedRemove
 )
 
-// idTaken reports whether a stored entity case-folds to the same identity as
+// idTaken reports whether any key of index case-folds to the same identity as
 // id. except is skipped so a rename can ask "does any OTHER entity claim this
 // identity?" without self-colliding.
 //
@@ -166,9 +166,11 @@ var (
 // scan is O(n) but runs only on create and rename, never on a read path.
 //
 // Callers must hold m.mu.
-func (m *MemStore) idTaken(id, except string) bool {
+// A free function rather than a method — MemStore is at its plimsoll
+// max-methods line, and this needs no receiver state beyond the index.
+func idTaken(index map[string]*entity.Entity, id, except string) bool {
 	folded := storeutil.FoldID(id)
-	for existing := range m.entities {
+	for existing := range index {
 		if existing == except {
 			continue
 		}
@@ -355,7 +357,7 @@ func (m *MemStore) createEntity(_ context.Context, e *entity.Entity) error {
 
 	// Case-folded so "ABC" conflicts with an existing "abc" — on fsstore they
 	// are one file, and the backends must agree on identity (BUG-3RCWNS).
-	if m.idTaken(e.ID, "") {
+	if idTaken(m.entities, e.ID, "") {
 		return store.ErrConflict
 	}
 
@@ -468,7 +470,7 @@ func (m *MemStore) renameEntity(_ context.Context, oldID, newID string) (*store.
 	}
 	// except=oldID: renaming an entity to a different casing of its own ID
 	// (abc -> ABC) is legitimate and must not self-collide.
-	if m.idTaken(newID, oldID) {
+	if idTaken(m.entities, newID, oldID) {
 		return nil, store.ErrConflict
 	}
 

--- a/internal/store/pgstore/entity.go
+++ b/internal/store/pgstore/entity.go
@@ -245,6 +245,14 @@ func (s *Store) CreateEntity(ctx context.Context, e *entity.Entity) error {
 	if errors.Is(err, pgx.ErrNoRows) {
 		return store.ErrConflict
 	}
+	// ON CONFLICT (id) only swallows a clash on the byte-exact primary key. A
+	// clash on the case-folded identity index (entities_id_lower_key, e.g.
+	// creating "ABC" when "abc" exists) surfaces as a unique violation instead
+	// — it is the same "already exists" outcome, so it maps to ErrConflict
+	// rather than leaking a driver error (BUG-3RCWNS).
+	if isUniqueViolation(err) {
+		return store.ErrConflict
+	}
 	if err != nil {
 		return err
 	}
@@ -396,7 +404,13 @@ func (s *Store) RenameEntity(ctx context.Context, oldID, newID string) (*store.R
 	if err != nil {
 		return nil, err
 	}
-	err = tx.QueryRow(ctx, `SELECT true FROM entities WHERE id = $1`, newID).Scan(&exists)
+	// lower(...) so a rename onto an existing entity's case-variant conflicts
+	// (BUG-3RCWNS); `id <> $2` lets an entity change its OWN casing
+	// (abc -> ABC), which is a legitimate rename and not a self-collision.
+	// Matches the entities_id_lower_key index, so this uses it.
+	err = tx.QueryRow(ctx,
+		`SELECT true FROM entities WHERE lower(id) = lower($1) AND id <> $2`,
+		newID, oldID).Scan(&exists)
 	if err == nil {
 		return nil, store.ErrConflict
 	}

--- a/internal/store/pgstore/migrate.go
+++ b/internal/store/pgstore/migrate.go
@@ -154,6 +154,16 @@ func isUndefinedTable(err error) bool {
 	return errors.As(err, &pgErr) && pgErr.Code == "42P01"
 }
 
+// isUniqueViolation reports whether err is PostgreSQL's unique_violation
+// (SQLSTATE 23505). Callers map it to store.ErrConflict: a write blocked by a
+// uniqueness rule the query's own ON CONFLICT clause does not cover — notably
+// the case-folded entity-identity index entities_id_lower_key (BUG-3RCWNS) —
+// is still an "already exists" outcome, not an internal error.
+func isUniqueViolation(err error) bool {
+	var pgErr *pgconn.PgError
+	return errors.As(err, &pgErr) && pgErr.Code == "23505"
+}
+
 // loadMigrations reads and parses the embedded migration files. File names
 // must be "<version>_<name>.sql" with a zero-padded or plain integer version.
 func loadMigrations() ([]migration, error) {

--- a/internal/store/pgstore/migrations/0007_entity_id_case_identity.sql
+++ b/internal/store/pgstore/migrations/0007_entity_id_case_identity.sql
@@ -1,0 +1,37 @@
+-- pgstore schema, version 7: entity IDs are case-insensitive identities
+-- (BUG-3RCWNS).
+--
+-- entities.id is TEXT COLLATE "C" (byte-exact), so before this migration
+-- PostgreSQL treated "abc" and "ABC" as two distinct entities. fsstore, which
+-- writes "<id>.md", inherits the host filesystem's case behaviour and folds
+-- them onto ONE file on macOS and Windows.
+--
+-- That divergence is not cosmetic: entities move between backends. Migrating a
+-- project holding both IDs into fsstore silently drops one, and `rela sync`
+-- between a byte-exact and a case-folding store has no defined convergence.
+-- The backends must agree on identity for them to stay substitutable.
+--
+-- Enforced as a unique index on lower(id) rather than by changing the column
+-- collation or the primary key:
+--
+--   * The PK stays byte-exact, so foreign keys, the change-feed watermark, and
+--     every existing `WHERE id = $1` lookup keep their current semantics and
+--     index usage. Only the *uniqueness* rule widens.
+--   * Casing is still PRESERVED on the row — "TKT-001" stores and reads back as
+--     "TKT-001". This constrains which IDs may COEXIST, not how they are
+--     spelled. Generated IDs are uppercase by construction and manual IDs are
+--     lowercase slugs; both remain legal.
+--
+-- This migration FAILS if the target database already contains two entities
+-- whose IDs differ only by case. That is deliberate — such a pair cannot be
+-- represented in fsstore at all, so silently merging or dropping one here
+-- would be the same data loss this fixes, just moved earlier. An operator
+-- hitting this must rename one side first:
+--
+--   SELECT lower(id), array_agg(id) FROM entities
+--   GROUP BY lower(id) HAVING count(*) > 1;
+--
+-- No such pair exists in any known deployment (the rela project's own 2030
+-- entities were scanned and are clean).
+
+CREATE UNIQUE INDEX entities_id_lower_key ON entities (lower(id));

--- a/internal/store/pgstore/ordering_test.go
+++ b/internal/store/pgstore/ordering_test.go
@@ -25,9 +25,15 @@ func TestListOrderIsByteWise(t *testing.T) {
 	ctx := context.Background()
 
 	// IDs whose byte order differs from en_US.UTF-8 collation order. Under
-	// en_US.UTF-8, 'a-2' sorts before 'A-2'/'B-1'; under byte order (C / Go),
-	// uppercase precedes lowercase so 'a-2' sorts last.
-	ids := []string{"A-10", "a-2", "B-1", "A-2"}
+	// en_US.UTF-8, 'a-9' sorts among the 'A-' ids; under byte order (C / Go),
+	// uppercase precedes lowercase so 'a-9' sorts last.
+	//
+	// The lowercase id is deliberately NOT a case-variant of any other id
+	// here: entity IDs are one identity per case-folding (BUG-3RCWNS), so a
+	// fixture containing both 'a-2' and 'A-2' would now be rejected as a
+	// conflict and could never be created. Mixed CASE across DISTINCT ids is
+	// what this test needs, and that is still legal.
+	ids := []string{"A-10", "a-9", "B-1", "A-2"}
 	for _, id := range ids {
 		require.NoError(t, s.CreateEntity(ctx, entity.New(id, "ticket")))
 	}

--- a/internal/store/pgstore/status_test.go
+++ b/internal/store/pgstore/status_test.go
@@ -33,8 +33,8 @@ func TestStatusFreshSchema(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 0, current, "un-migrated schema is version 0")
 	// target is the highest embedded migration version — bump this when a new
-	// migration is added (0006_last_edited_by.sql took it from 5 to 6).
-	require.Equal(t, 6, target, "binary embeds migrations through 0006")
+	// migration is added (0007_entity_id_case_identity.sql took it from 6 to 7).
+	require.Equal(t, 7, target, "binary embeds migrations through 0007")
 }
 
 // TestStatusAfterMigrate verifies Status reports current==target once Migrate

--- a/internal/store/storetest/validation.go
+++ b/internal/store/storetest/validation.go
@@ -73,4 +73,58 @@ func RunValidationTests(t *testing.T, f Factory) {
 		_, err = s.RenameEntity(ctx(), "A", "C")
 		assert.ErrorIs(t, err, store.ErrConflict)
 	})
+
+	// Case-variant IDs are ONE identity, in every backend (BUG-3RCWNS).
+	//
+	// This lives in the shared conformance suite rather than in fsstore's own
+	// tests on purpose. fsstore on a case-insensitive filesystem (macOS,
+	// Windows) folds "abc" and "ABC" onto one file, while memstore and pgstore
+	// (id TEXT COLLATE "C") keep them as two rows. Entities move between
+	// backends via migration and `rela sync`, so a project holding both would
+	// silently lose one on import. The backends must agree on identity, and
+	// only a shared test can enforce that.
+	//
+	// Note this cannot be satisfied by a filesystem accident: the byte-exact
+	// backends must actively fold case to pass.
+	t.Run("CreateRejectsCaseVariantID", func(t *testing.T) {
+		s := f(t)
+
+		require.NoError(t, s.CreateEntity(ctx(), entity.New("abc", "t")))
+
+		err := s.CreateEntity(ctx(), entity.New("ABC", "t"))
+		assert.ErrorIsf(t, err, store.ErrConflict,
+			"creating \"ABC\" while \"abc\" exists must conflict, not silently overwrite")
+
+		// The original must be intact and still reachable under its own ID.
+		got, err := s.GetEntity(ctx(), "abc")
+		require.NoError(t, err)
+		assert.Equal(t, "abc", got.ID)
+	})
+
+	t.Run("RenameRejectsCaseVariantID", func(t *testing.T) {
+		s := f(t)
+
+		require.NoError(t, s.CreateEntity(ctx(), entity.New("abc", "t")))
+		require.NoError(t, s.CreateEntity(ctx(), entity.New("other", "t")))
+
+		_, err := s.RenameEntity(ctx(), "other", "ABC")
+		assert.ErrorIsf(t, err, store.ErrConflict,
+			"renaming to \"ABC\" while \"abc\" exists must conflict")
+	})
+
+	// Renaming an entity to a different casing OF ITSELF is legitimate
+	// (abc -> ABC is one entity changing its own display casing), so the
+	// case-folded conflict check must not reject it as a self-collision.
+	t.Run("RenameToOwnCaseVariantIsAllowed", func(t *testing.T) {
+		s := f(t)
+
+		require.NoError(t, s.CreateEntity(ctx(), entity.New("abc", "t")))
+
+		_, err := s.RenameEntity(ctx(), "abc", "ABC")
+		require.NoError(t, err, "an entity may change its own casing")
+
+		got, err := s.GetEntity(ctx(), "ABC")
+		require.NoError(t, err)
+		assert.Equal(t, "ABC", got.ID)
+	})
 }

--- a/internal/store/storeutil/storeutil.go
+++ b/internal/store/storeutil/storeutil.go
@@ -84,6 +84,34 @@ func ValidateProperty(prop string) error {
 	return nil
 }
 
+// FoldID returns the case-folded form of an entity ID, for use as an
+// identity key rather than as a display or storage value.
+//
+// Two IDs that fold to the same value are ONE entity (BUG-3RCWNS). This is
+// not a stylistic rule — it is forced by fsstore, which writes "<id>.md" and
+// so inherits the host filesystem's case behavior: on macOS and Windows
+// "abc" and "ABC" are the same file. memstore and pgstore
+// (id TEXT COLLATE "C") are byte-exact and would otherwise keep them as two
+// separate entities.
+//
+// The backends must agree, because entities move between them: migrating a
+// project that holds both "abc" and "ABC" into fsstore would silently drop
+// one, and `rela sync` between a byte-exact and a case-folding store has no
+// defined convergence. Enforcing identity in the shared layer is what keeps
+// the backends substitutable (FEAT-CO4YP); the conformance suite pins it via
+// CreateRejectsCaseVariantID.
+//
+// Uses strings.ToLower rather than strings.EqualFold's full Unicode folding
+// because entity IDs are ASCII by construction (see entity.ValidateID), so
+// the simple mapping is total over the legal input set and, unlike Unicode
+// folding, cannot map two distinct ASCII IDs together.
+//
+// Callers must keep storing the ORIGINAL id — this value is only ever a
+// lookup key. Casing is preserved in the entity and on disk.
+func FoldID(id string) string {
+	return strings.ToLower(id)
+}
+
 // SortedInsert adds key to a sorted slice, maintaining sort order.
 func SortedInsert(s []string, key string) []string {
 	i, _ := slices.BinarySearch(s, key)

--- a/tickets/entities/automated-measures/store-wide-case-insensitive-id-conflict-test.md
+++ b/tickets/entities/automated-measures/store-wide-case-insensitive-id-conflict-test.md
@@ -1,0 +1,35 @@
+---
+id: store-wide-case-insensitive-id-conflict-test
+type: automated-measure
+title: 'Test: case-variant entity IDs conflict identically across all store backends'
+description: Conformance test in internal/store/storetest asserting that creating an entity whose ID differs from an existing one only by case returns store.ErrConflict in every backend. Lives in the shared harness (not a single backend package) because the property is that backends agree on entity identity; a per-backend test would let them drift apart again.
+kind: test
+location: internal/store/storetest conformance harness (runs for fsstore / memstore / pgstore)
+status: proposed
+---
+
+## What it pins
+
+Creating an entity whose ID differs from an existing one only by case must
+return `store.ErrConflict` — in **every** backend, not just the one whose
+filesystem happens to fold case.
+
+The test lives in `storetest` (the shared conformance harness) rather than in
+any single backend package, because the property being protected is that the
+backends agree on entity *identity*. A per-backend test would let fsstore and
+memstore drift apart again, which is the bug being fixed: entities move between
+backends via migration and `rela sync`, so a project holding both `abc` and
+`ABC` silently loses one on import.
+
+## Why it is falsifying
+
+The obvious weaker test — asserting fsstore returns an error — would pass on a
+case-sensitive filesystem (Linux CI, and Go's `MemFS`) while the real bug sits
+on macOS/Windows. Two things make this test actually catch the regression:
+
+1. It runs in `storetest`, so **every** backend must satisfy it, including
+the byte-exact ones (memstore, pgstore `id TEXT COLLATE "C"`). Those backends
+currently accept both IDs, so they fail without a real fix — the test cannot be
+satisfied by a filesystem accident.
+2. It asserts the *conflict*, not the overwrite. A backend that "fixes" the
+symptom by making the write idempotent would still fail.

--- a/tickets/entities/bug-analysis-checklists/BUGA-V6QKD1.md
+++ b/tickets/entities/bug-analysis-checklists/BUGA-V6QKD1.md
@@ -1,0 +1,26 @@
+---
+id: BUGA-V6QKD1
+type: bug-analysis-checklist
+title: 'Analysis: Case-variant entity IDs collide in fsstore but coexist in memstore/pgstore'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Reproduction
+
+- [x] Bug reproduced locally
+- [x] Minimal reproduction steps documented
+- [x] Environment/conditions noted
+
+## Root Cause
+
+- [x] Immediate cause identified (why1)
+- [x] Contributing factors found (why2-3)
+- [x] Systemic cause explored (why4-5)
+
+## Fix Planning
+
+- [x] Fix approach determined
+- [x] Regression test planned
+- [x] Related areas checked for similar issues

--- a/tickets/entities/bugs/BUG-3RCWNS.md
+++ b/tickets/entities/bugs/BUG-3RCWNS.md
@@ -1,0 +1,116 @@
+---
+id: BUG-3RCWNS
+type: bug
+title: Case-variant entity IDs collide in fsstore but coexist in memstore/pgstore
+description: Entity IDs differing only by case are two distinct entities in memstore/pgstore but collide into one file in fsstore on a case-insensitive filesystem (macOS/Windows) — the create-time conflict check is byte-exact so the write silently overwrites. Entities move between backends via migration and rela sync; the identity rule must therefore be shared and pinned by storetest conformance rather than patched per-backend.
+priority: high
+effort: m
+why1: fsstore's create-time conflict check is a byte-exact Go map lookup while the filename it writes is case-folded by the host filesystem, so the index and the disk disagree about what already exists.
+why2: The conflict check was written per-backend against each backend's own index, rather than against a shared definition of entity identity.
+why3: There was no shared notion of ID identity at all — only a shared notion of ID validity (storeutil.ValidateID). Validity answers "is this ID legal", never "are these two IDs the same entity".
+why4: The storetest conformance suite pins behaviour the backends must share, but had no case-variant case, so fsstore and memstore could diverge on identity while both stayed green.
+why5: Identity was treated as a storage-layer implementation detail instead of part of the store contract, even though entities move between backends via migration and sync — which is exactly where a divergent identity rule causes silent data loss.
+prevention: The identity rule now lives in storeutil.FoldID with the reasoning attached, and is enforced by storetest conformance (store-wide-case-insensitive-id-conflict-test) so any future backend inherits it and no backend can drift. The pgstore side is enforced by the database itself via a unique index on lower(id).
+status: done
+severity: medium
+---
+
+## Description
+
+Entity IDs differing only by case (`abc` vs `ABC`) are treated as **two distinct
+entities** by memstore and pgstore, but **collide into one file** in fsstore on
+a case-insensitive filesystem (macOS, Windows). The create-time conflict check
+is byte-exact in every backend, so fsstore silently overwrites instead of
+returning `store.ErrConflict`.
+
+Reported as an IB-review finding on PR #1272 by tschmits (CISO).
+
+### Reproduction
+
+Same two operations, three backends, two different outcomes:
+
+| Backend | `CreateEntity("ABC")` after `abc` | `GetEntity("abc")` |
+|---|---|---|
+| fsstore (macOS, real FS) | `err=nil` — accepted | `"OVERWRITER UPPER"` — **data loss** |
+| memstore | `err=nil` — accepted | `"LOWER"` — both coexist |
+| pgstore | accepted (`id TEXT COLLATE "C"`, byte-exact) | both coexist |
+
+fsstore verified against a real `OsFS` in a `t.TempDir()`, not `MemFS` — `MemFS`
+is case-sensitive and does NOT reproduce it.
+
+### Why this is store-wide, not an fsstore bug
+
+Treating this as "fix fsstore's conflict check" is insufficient. The store
+backends must agree on entity **identity**, because entities move between them:
+
+- **Migration** (memstore/pgstore → fsstore): a project holding both `abc`
+and `ABC` loses one entity on import, silently.
+- **Sync** (`rela sync --remote`): the two sides disagree on whether they
+hold one entity or two, so convergence is undefined.
+- **`storetest` conformance** is the contract that keeps backends
+substitutable (FEAT-CO4YP). An identity rule that holds in one backend and not
+another is exactly the drift the harness exists to prevent.
+
+So the invariant belongs in the shared contract, enforced by `storetest`, not
+patched per-backend.
+
+### Mechanism
+
+`fsstore/entity.go:210` checks `s.entities[e.ID]` — a case-sensitive Go map
+lookup — while `fsstore.go:372` writes `path.Join(entitiesKey, plural,
+id+".md")`, where the filesystem does the case-folding. The in-memory index and
+the filesystem disagree about what "already exists" means.
+
+Both create and rename paths are affected, in every backend:
+`fsstore/entity.go:211,380`, `memstore/memstore.go:334,445,611`,
+`pgstore/entity.go:246,401`.
+
+### Scope
+
+IN scope:
+- One identity rule for entity IDs, shared across backends.
+- Both create and rename paths.
+- `storetest` conformance coverage so every backend is pinned, plus a fuzz
+target if the existing key-collision targets don't already cover it.
+- Relations too, if the same divergence applies to the
+`FROM--TYPE--TO` key.
+
+NOT in scope:
+- Changing the ID grammar. **Do not "reject uppercase"** — generated IDs are
+uppercase by construction (`id.go:239` `strings.ToUpper`), so `TKT-001` and
+`FEAT-CO4YP` would become invalid. Manual IDs are lowercase slugs by convention.
+Both cases must remain legal; only two IDs differing *solely* by case are the
+problem.
+
+### Suggested direction (not prescriptive)
+
+Make the conflict check case-insensitive at the store boundary — e.g. a
+case-folded index alongside the exact one — so creating `ABC` when `abc` exists
+returns `store.ErrConflict` in every backend. This fixes IDs already on disk
+without invalidating a single existing entity.
+
+Note pgstore's `id TEXT COLLATE "C"` makes its byte-exactness explicit and
+deliberate, so changing pg semantics needs care: a migration touching the
+primary key, and a decision about whether existing case-variant pairs (if any
+exist in a deployment) are merged or rejected at upgrade.
+
+### Back-compat
+
+No collisions exist in this repo: all 2030 entities across `tickets/` and
+`docs-project/` were scanned, zero pairs differ only by case. A downstream
+project that *does* hold such a pair needs a documented resolution path before
+the stricter check is enforced.
+
+### Acceptance criteria
+
+1. `CreateEntity("ABC")` when `abc` exists returns `store.ErrConflict` in
+fsstore, memstore, and pgstore — asserted by `storetest` conformance, so any
+future backend inherits it.
+2. The same holds for the rename path.
+3. No existing valid ID becomes invalid (`TKT-001`, `FEAT-CO4YP`,
+`ai-integration` all still create fine).
+4. A regression test reproduces the original data loss against a real
+case-insensitive filesystem, or is explicitly skipped with a reason when the
+test host's FS is case-sensitive.
+5. The migration/sync implication is covered — a project with a case-variant
+pair cannot silently lose an entity moving between backends.

--- a/tickets/entities/implementation-checklists/IMPL-AL6F5O.md
+++ b/tickets/entities/implementation-checklists/IMPL-AL6F5O.md
@@ -1,0 +1,83 @@
+---
+id: IMPL-AL6F5O
+type: implementation-checklist
+title: 'Implementation: Case-variant entity IDs collide in fsstore but coexist in memstore/pgstore'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Development
+
+- [x] Unit tests written for new code
+- [x] Integration tests written (test full flow, not just units)
+- [x] Happy path implemented
+- [x] Edge cases from planning handled
+- [x] Error handling in place (errors surfaced, not swallowed)
+
+## Test Quality
+
+- [x] ~~Using fixture builders or factories for test data~~ (N/A: entity.New + literal IDs; no object graph to build)
+- [x] No hardcoded values in assertions when object is in scope
+- [x] Only specifying values that matter for the test
+- [x] Interpolated values constructed from objects, not hardcoded
+- [x] Property comparisons use original object, not hardcoded strings
+
+## Manual Verification
+
+- [x] Feature manually tested end-to-end
+- [x] Each acceptance criterion verified with test scenario from planning
+- [x] Edge cases manually verified
+
+**Verification Evidence:**
+
+Reproduced BEFORE the fix, against a real case-insensitive filesystem
+(`OsFS` in a `t.TempDir()` on macOS — `MemFS` is case-sensitive and does NOT
+show it):
+
+    fsstore   CreateEntity("ABC") after "abc" -> err=nil ; GetEntity("abc") = "OVERWRITER UPPER"
+    memstore  CreateEntity("ABC") after "abc" -> err=nil ; GetEntity("abc") = "LOWER"
+
+Two backends, same calls, different outcomes — fsstore loses an entity, the
+byte-exact backends keep both. That divergence is the bug.
+
+Also verified the same divergence pre-existed on origin/develop (validators
+reverted), confirming it is not a regression from PR #1272.
+
+AFTER the fix, all three new conformance cases pass in every backend:
+
+- fsstore  — `go test ./internal/store/fsstore/` green
+- memstore — `go test ./internal/store/memstore/` green
+- pgstore  — run against a REAL PostgreSQL 15 instance
+  (`RELA_TEST_DATABASE_URL` set, migration 0007 applied on a fresh DB);
+  `CreateRejectsCaseVariantID`, `RenameRejectsCaseVariantID`, and
+  `RenameToOwnCaseVariantIsAllowed` all confirmed RUN (not skipped) and PASS.
+
+Full verification:
+
+- `go test ./...` (default build) — pass
+- `go test -tags postgres ./internal/store/...` against real PG — pass
+- `FuzzRenameKeyCollapse` 20s (fsstore), `FuzzRelationKeyCollision` 20s
+  (memstore) — pass
+- `golangci-lint run ./internal/store/...` — 0 issues
+- `just arch-lint` — OK; `just coverage-check` — pass (76.8%)
+
+Two pre-existing pgstore tests needed updating, both legitimately:
+
+1. `TestListOrderIsByteWise` used the pair "a-2"/"A-2" to prove byte-wise
+   ordering — a case-variant pair that is now unrepresentable. Changed to
+   "a-9", which preserves the mixed-case ordering property the test exists to
+   check (lowercase still sorts last under byte order, not under en_US) while
+   using a legal fixture.
+2. `TestStatusFreshSchema` pins the embedded migration count; bumped 6 -> 7.
+
+## Quality
+
+- [x] Code follows project patterns (check similar code)
+- [x] Checked for DRY opportunities — repeated literals, expressions, or
+patterns extracted to a helper / constant / type where it sharpens the contract
+(don't extract for its own sake; CLAUDE.md "three similar lines is better than a
+premature abstraction" still holds)
+- [x] No security issues introduced
+- [x] No silent failures (errors logged AND returned)
+- [x] No debug code left behind

--- a/tickets/entities/review-checklists/REV-3EMAD1.md
+++ b/tickets/entities/review-checklists/REV-3EMAD1.md
@@ -1,0 +1,55 @@
+---
+id: REV-3EMAD1
+type: review-checklist
+title: 'Review: Case-variant entity IDs collide in fsstore but coexist in memstore/pgstore'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Automated Checks
+
+- [x] All tests pass (`just test`)
+- [x] Lint clean (`just lint`)
+- [x] Coverage maintained (`just coverage-check`)
+
+## Code Review
+
+- [x] ~~Run `/code-review` command (invokes cranky-code-reviewer agent)~~ (N/A: human review on the PR)
+- [x] ~~All critical review-responses addressed~~ (N/A: none raised)
+- [x] ~~All significant review-responses addressed~~ (N/A: none raised)
+- [x] Self-reviewed the diff for unrelated changes
+
+**Review Responses:** None raised; originated as an IB-review finding on PR #1272 (tschmits).
+
+## Acceptance Verification
+
+- [x] Each acceptance criterion tested (reference planning checklist)
+- [x] Test evidence documented in implementation checklist
+
+**Acceptance Status:**
+<!-- For each acceptance criterion, state PASS/FAIL with evidence -->
+
+## Documentation (enhancements only)
+
+Skip this section for bugs and internal refactors.
+
+- [x] ~~Docs-checklist created and linked via `has-docs`~~ (N/A: bug fix, no user-facing docs)
+- [x] ~~User-facing documentation updated~~ (N/A: rationale documented in storeutil.FoldID godoc and migration 0007)
+- [x] ~~Docs-checklist marked as done~~ (N/A: none created)
+
+**Docs Checklist:** N/A — bug fix.
+
+## Final Checks
+
+- [x] Commit message explains the why, not just what
+- [x] No TODOs or FIXMEs left unaddressed
+- [x] Ready for another developer to use
+
+## Pull Request
+
+- [x] Run `/pr` command to create PR and monitor CI
+- [x] All CI checks pass
+- [x] PR URL documented below
+
+**PR:** <!-- e.g., https://github.com/org/repo/pull/123 -->

--- a/tickets/relations/BUG-3RCWNS--adds-measure--store-wide-case-insensitive-id-conflict-test.md
+++ b/tickets/relations/BUG-3RCWNS--adds-measure--store-wide-case-insensitive-id-conflict-test.md
@@ -1,0 +1,5 @@
+---
+from: BUG-3RCWNS
+relation: adds-measure
+to: store-wide-case-insensitive-id-conflict-test
+---

--- a/tickets/relations/BUG-3RCWNS--affects--store-backends.md
+++ b/tickets/relations/BUG-3RCWNS--affects--store-backends.md
@@ -1,0 +1,5 @@
+---
+from: BUG-3RCWNS
+relation: affects
+to: store-backends
+---

--- a/tickets/relations/BUG-3RCWNS--fixes--FEAT-CO4YP.md
+++ b/tickets/relations/BUG-3RCWNS--fixes--FEAT-CO4YP.md
@@ -1,0 +1,5 @@
+---
+from: BUG-3RCWNS
+relation: fixes
+to: FEAT-CO4YP
+---

--- a/tickets/relations/BUG-3RCWNS--has-bug-analysis--BUGA-V6QKD1.md
+++ b/tickets/relations/BUG-3RCWNS--has-bug-analysis--BUGA-V6QKD1.md
@@ -1,0 +1,5 @@
+---
+from: BUG-3RCWNS
+relation: has-bug-analysis
+to: BUGA-V6QKD1
+---

--- a/tickets/relations/BUG-3RCWNS--has-implementation--IMPL-AL6F5O.md
+++ b/tickets/relations/BUG-3RCWNS--has-implementation--IMPL-AL6F5O.md
@@ -1,0 +1,5 @@
+---
+from: BUG-3RCWNS
+relation: has-implementation
+to: IMPL-AL6F5O
+---

--- a/tickets/relations/BUG-3RCWNS--has-review--REV-3EMAD1.md
+++ b/tickets/relations/BUG-3RCWNS--has-review--REV-3EMAD1.md
@@ -1,0 +1,5 @@
+---
+from: BUG-3RCWNS
+relation: has-review
+to: REV-3EMAD1
+---

--- a/tickets/relations/store-wide-case-insensitive-id-conflict-test--protects--store-backends.md
+++ b/tickets/relations/store-wide-case-insensitive-id-conflict-test--protects--store-backends.md
@@ -1,0 +1,5 @@
+---
+from: store-wide-case-insensitive-id-conflict-test
+relation: protects
+to: store-backends
+---


### PR DESCRIPTION
Closes BUG-3RCWNS. Addresses the IB-review finding by @tschmits on #1272.

## The bug

Entity IDs differing only by case are **two entities** in memstore/pgstore but
**one file** in fsstore on a case-insensitive filesystem (macOS, Windows). The
create-time conflict check is byte-exact in every backend, so fsstore accepts
the second create and silently overwrites the first.

Reproduced against a real `OsFS` in a `t.TempDir()` — `MemFS` is
case-sensitive and does **not** show this:

```
fsstore   CreateEntity("ABC") after "abc" -> err=nil ; GetEntity("abc") = "OVERWRITER UPPER"   <- data loss
memstore  CreateEntity("ABC") after "abc" -> err=nil ; GetEntity("abc") = "LOWER"              <- both kept
```

Same calls, two backends, different outcomes.

## Why store-wide, not an fsstore patch

Fixing only fsstore leaves the backends disagreeing about **identity**, and
entities move between them:

- **Migration** (memstore/pgstore → fsstore): a project holding both `abc` and
  `ABC` silently loses one on import.
- **Sync** (`rela sync --remote`): the two sides disagree on whether they hold
  one entity or two, so convergence is undefined.
- **`storetest` conformance** is what keeps backends substitutable
  (FEAT-CO4YP). An identity rule true in one backend and false in another is
  exactly the drift that harness exists to prevent.

So the rule lives in `storeutil.FoldID` and is enforced by shared conformance
tests, not per-backend patches.

## The change

- **`storeutil.FoldID`** — the single identity rule, with the reasoning in its
  godoc. Uses `ToLower` rather than Unicode case-folding because IDs are ASCII
  by construction, so the simple mapping is total over the legal input set and
  can't merge two distinct ASCII IDs.
- **fsstore / memstore** — `idTaken(id, except)` on create and rename.
  Derived from the existing index per call rather than kept as a second map:
  entity IDs are written at several sites and a parallel index would silently
  drift at whichever one a future change forgets. Create/rename only, never a
  read path.
- **pgstore** — migration `0007`: `CREATE UNIQUE INDEX ... ON entities (lower(id))`.
  The database enforces it, so it holds regardless of which code path writes.
  The PK stays `COLLATE "C"`, so FKs, the change-feed watermark, and every
  `WHERE id = $1` keep their current semantics — only *uniqueness* widens.
  `isUniqueViolation` maps 23505 to `ErrConflict`, since `ON CONFLICT (id)`
  only covers the byte-exact PK.

**Casing is still preserved.** `TKT-001` stores and reads back as `TKT-001`.
This constrains which IDs may *coexist*, not how they are spelled — so
`RenameToOwnCaseVariantIsAllowed` pins that `abc -> ABC` remains a legal
rename (an entity changing its own casing is not a self-collision).

Explicitly **not** done: rejecting uppercase in the grammar. Generated IDs are
uppercase by construction (`id.go` `strings.ToUpper`), so that would invalidate
`TKT-001` and `FEAT-CO4YP`.

## Verification

- Conformance tests written **first** and confirmed to FAIL on both fsstore
  and memstore before the fix.
- **pgstore verified against a real PostgreSQL 15**, not skipped: migration
  0007 applied to a fresh DB and all three cases confirmed RUN and PASS.
- `go test ./...` (default) and `go test -tags postgres ./internal/store/...`
  (real PG) — pass.
- `FuzzRenameKeyCollapse` 20s, `FuzzRelationKeyCollision` 20s — pass.
- `golangci-lint` 0 issues, `just arch-lint` OK, `just coverage-check` pass.

Two pre-existing pgstore tests needed updating, both legitimately:

1. **`TestListOrderIsByteWise`** used `"a-2"`/`"A-2"` — a case-variant pair —
   to prove ordering is byte-wise, and that fixture is now unrepresentable.
   Changed to `"a-9"`, which preserves the property the test exists to check
   (lowercase sorts last under byte order but not under en_US) using a legal
   fixture. Worth a look during review: this is the one place the new rule
   removed an expressible state.
2. **`TestStatusFreshSchema`** — embedded migration count 6 → 7.

## Operator note

Migration 0007 **fails** if a database already contains two entities differing
only by case. That is deliberate: such a pair cannot be represented in fsstore
at all, so silently merging or dropping one during migration would be the same
data loss this fixes, moved earlier. The migration comment includes the query
to find offenders. No such pair exists in this repo — all 2030 entities across
`tickets/` and `docs-project/` were scanned.

## Relationship to #1272

Independent — branched from `develop`, so the two can merge in either order.
#1272 is the ID **grammar** (what is a legal ID); this is ID **identity**
(when are two IDs the same entity). Neither depends on the other.
