### PR TITLE
fix(dataentry): state redacted property names on the wire (BUG-MLT9DE)

### DIFF
--- a/docs/data-entry/api-reference.md
+++ b/docs/data-entry/api-reference.md
@@ -425,7 +425,8 @@ regardless of source.
     "affects":    { "creatable": false },
     "implements": { "removable": false },
     "has-planning": { "fields": { "note": { "writable": false } } }
-  }
+  },
+  "_redacted": ["salary"]
 }
 ```
 
@@ -436,11 +437,42 @@ from the permissive default appear. An absent key in either map means
 signal letting the SPA distinguish "evaluated, no deviations" from
 "affordances not available" (anonymous fallback / pre-rollout server).
 
-Hidden fields are doubly invisible: omitted from `properties` AND absent
-from `_fields`. The SPA filters its config-driven form-field list against
-both: a field declared in `data-entry.yaml` is rendered only if it appears
-in `_fields` OR `properties`. This makes "hidden = omitted" actually hide
-the input.
+### Hidden fields and `_redacted`
+
+Hidden fields are doubly invisible in the payload: their **values** are
+omitted from `properties` AND they are absent from `_fields`.
+
+Their **names**, however, are stated explicitly in `_redacted` — a list of the
+properties this response withheld by field-level ACL:
+
+```json
+{
+  "properties": { "status": "open" },
+  "_fields": {},
+  "_redacted": ["salary"]
+}
+```
+
+**Never infer redaction from absence.** A property missing from `properties`
+may have been redacted *or* may simply have never been set — the two are
+byte-identical in the payload, and `_fields` is sparse so a plainly-writable
+field is absent from it by design. Consult `_redacted`; it is the only sound
+signal. (Reading absence as redaction is what made every unset property
+permanently unreachable in the edit form — BUG-MLT9DE. The SPA now renders a
+configured field unless `_redacted` names it.)
+
+`_redacted` carries the same closed-world pointer semantics as `_fields` /
+`_relations`: present (possibly empty — "evaluated, nothing hidden") on
+per-entity responses, absent on list rows, which carry no write affordances.
+Names are sorted.
+
+Disclosure boundary: `_redacted` reveals property **names**, never **values**.
+This is not a new disclosure — the metamodel endpoint already serves the
+declared property names per type, and `visible:` redaction is defined as
+hiding values only, making no claim to conceal which properties exist. Row-level
+ACL is unaffected: whether an *entity* exists remains a genuine secret, and
+`_redacted` only ever rides a response the caller was already authorized to
+read. See DEC-T0XIWQ.
 
 ### Write-side parity
 

--- a/frontend/src/components/forms/DynamicForm.test.ts
+++ b/frontend/src/components/forms/DynamicForm.test.ts
@@ -1,0 +1,226 @@
+// Unit tests for DynamicForm's edit-mode affordance filter (BUG-MLT9DE,
+// DEC-T0XIWQ).
+//
+// Why this file exists: before it, DynamicForm had no mounting test at all
+// (DynamicForm.guard.test.ts deliberately replicates its guard in a stub), and
+// every fixture elsewhere seeded entities whose `properties` already carried a
+// key for each field under test. The edit-mode gate `f.property in
+// formData.value` therefore always matched, and its failure mode — a property
+// that is CONFIGURED but simply UNSET never rendering, and so never becoming
+// settable — was invisible to CI.
+//
+// The three things pinned here:
+//   1. A configured-but-unset property renders and saves. (The bug.)
+//   2. A server-redacted property does not render, and — critically — is not
+//      submitted as empty when untouched, which would clobber the hidden
+//      stored value.
+//   3. Both hold on the wizard path, which carries the same gate.
+
+import { describe, it, expect, beforeEach, vi, type Mock } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { mount, flushPromises } from '@vue/test-utils'
+import { useSchemaStore, useEntitiesStore } from '@/stores'
+import DynamicForm from './DynamicForm.vue'
+import type { Entity } from '@/types'
+
+// DynamicForm and its composables (useFormWizard) call useRoute/useRouter
+// directly, so `global.mocks` doesn't reach them — mock the module instead.
+vi.mock('vue-router', () => ({
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn() }),
+  useRoute: () => ({ query: {}, params: {}, path: '/form/ticket-form' }),
+  onBeforeRouteLeave: vi.fn(),
+}))
+
+// `notes` is the property at the heart of the bug: declared in the metamodel,
+// listed in the form config, but absent from the stored entity because it was
+// added to the schema after this entity was created.
+const ENTITY_TYPE = {
+  name: 'ticket',
+  label: 'Ticket',
+  id_type: 'short',
+  properties: {
+    title: { type: 'string' },
+    notes: { type: 'string' },
+    salary: { type: 'string' },
+  },
+}
+
+const FLAT_FORM = {
+  id: 'ticket-form',
+  entity: 'ticket',
+  fields: [
+    { property: 'title', label: 'Title' },
+    { property: 'notes', label: 'Notes' },
+    { property: 'salary', label: 'Salary' },
+  ],
+}
+
+const WIZARD_FORM = {
+  id: 'ticket-wizard',
+  entity: 'ticket',
+  steps: [
+    {
+      id: 'step1',
+      title: 'Step 1',
+      fields: [
+        { property: 'title', label: 'Title' },
+        { property: 'notes', label: 'Notes' },
+        { property: 'salary', label: 'Salary' },
+      ],
+    },
+  ],
+}
+
+// Seed the real store state rather than stubbing its getters: `getForm` /
+// `getEntityType` are computeds returning lookup fns over these Maps, so
+// populating the Maps exercises the same resolution path the app uses.
+function stubStores(form: object) {
+  const schema = useSchemaStore()
+  schema.forms.set((form as { id: string }).id, form as never)
+  schema.entityTypes.set('ticket', ENTITY_TYPE as never)
+  schema.loaded = true
+  return schema
+}
+
+// Serve an entity the way the real API does after ACL redaction: hidden and
+// never-set properties are BOTH simply absent from `properties`. `_redacted`
+// is the only thing that tells them apart — which is the whole point.
+function stubEntity(opts: { properties: Record<string, unknown>; redacted?: string[] }) {
+  const entities = useEntitiesStore()
+  const entity: Entity = {
+    id: 'TKT-001',
+    type: 'ticket',
+    properties: opts.properties,
+    _actions: { update: true },
+    _fields: {}, // permissive default — the sparse "nothing deviates" signal
+    _redacted: opts.redacted ?? [],
+  }
+  vi.spyOn(entities, 'fetchEntity').mockResolvedValue(entity)
+  const update = vi
+    .spyOn(entities, 'update')
+    .mockResolvedValue({ ...entity, warnings: [] } as Entity) as unknown as Mock
+  return { update }
+}
+
+async function mountEdit(form: object, entityOpts: Parameters<typeof stubEntity>[0]) {
+  stubStores(form)
+  const { update } = stubEntity(entityOpts)
+  const wrapper = mount(DynamicForm, {
+    props: { formId: (form as { id: string }).id, entityId: 'TKT-001' },
+    global: {
+      stubs: {
+        RouterLink: true,
+        MarkdownEditor: true,
+        RelationPicker: true,
+        RelationCards: true,
+        AutoSaveIndicator: true,
+      },
+      mocks: {
+        $router: { push: vi.fn(), replace: vi.fn() },
+        $route: { query: {}, params: {}, path: '/form/ticket-form' },
+      },
+    },
+  })
+  await flushPromises()
+  return { wrapper, update }
+}
+
+// FieldRenderer gives each rendered widget `id="field-<property>"`
+// (FieldRenderer.vue:41), so presence of that id is exactly "this property
+// rendered an input the user can reach".
+function renderedProperties(wrapper: { find: (s: string) => { exists: () => boolean } }) {
+  return ['title', 'notes', 'salary'].filter((p) => wrapper.find(`#field-${p}`).exists())
+}
+
+describe('DynamicForm edit-mode affordance filter', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.restoreAllMocks()
+  })
+
+  describe('flat form', () => {
+    // THE BUG. `notes` is configured on the form and declared in the
+    // metamodel, but the entity predates it, so the stored properties omit it
+    // and `_fields` (sparse) says nothing about it. It must still render —
+    // otherwise it can never be filled in, and never being filled in is
+    // exactly why it is missing.
+    it('renders a configured property the entity has never had', async () => {
+      const { wrapper } = await mountEdit(FLAT_FORM, {
+        properties: { title: 'Original' },
+      })
+      expect(renderedProperties(wrapper)).toContain('notes')
+    })
+
+    it('renders every configured property when nothing is redacted', async () => {
+      const { wrapper } = await mountEdit(FLAT_FORM, {
+        properties: { title: 'Original' },
+        redacted: [],
+      })
+      expect(renderedProperties(wrapper)).toEqual(['title', 'notes', 'salary'])
+    })
+
+    // The inverse: absence alone must never hide, but a POSITIVE redaction
+    // verdict still must. Losing this would trade a silent-hiding bug for a
+    // silent-exposure one.
+    it('hides a property the server reports as redacted', async () => {
+      const { wrapper } = await mountEdit(FLAT_FORM, {
+        properties: { title: 'Original' },
+        redacted: ['salary'],
+      })
+      const rendered = renderedProperties(wrapper)
+      expect(rendered).not.toContain('salary')
+      expect(rendered).toContain('notes') // unset ≠ redacted
+    })
+  })
+
+  // The data-loss question the fix raises: now that previously-hidden fields
+  // render, can an untouched one overwrite a redacted stored value with empty?
+  //
+  // It cannot, and these pin why. Edit mode has NO bulk submit — handleSubmit
+  // returns early when isEdit (DynamicForm.vue), and every write goes through
+  // per-property autosave, which only fires for a property the user actually
+  // typed into. So an untouched field is never in a payload at all, and a
+  // redacted field additionally never renders to be typed into.
+  describe('edit-mode writes are per-property, never a bulk overwrite', () => {
+    it('does not render a redacted field for the user to reach', async () => {
+      const { wrapper } = await mountEdit(FLAT_FORM, {
+        properties: { title: 'Original' },
+        redacted: ['salary'],
+      })
+      expect(wrapper.find('#field-salary').exists()).toBe(false)
+    })
+
+    // A form-level submit in edit mode must be inert: if it ever started
+    // sending formData wholesale, every unset field would post as empty and
+    // every redacted one would clobber its hidden value.
+    it('sends nothing on a form submit (no bulk PATCH in edit mode)', async () => {
+      const { wrapper, update } = await mountEdit(FLAT_FORM, {
+        properties: { title: 'Original' },
+        redacted: ['salary'],
+      })
+      await wrapper.find('form').trigger('submit')
+      await flushPromises()
+      expect(update).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('wizard form', () => {
+    // The wizard path (visibleStepFields → affordanceVisible) is a second
+    // consumer of the same predicate. Before the fix it held a hand-synced
+    // copy of the gate and carried the identical defect.
+    it('renders a configured-but-unset property inside a step', async () => {
+      const { wrapper } = await mountEdit(WIZARD_FORM, {
+        properties: { title: 'Original' },
+      })
+      expect(renderedProperties(wrapper)).toContain('notes')
+    })
+
+    it('hides a redacted property inside a step', async () => {
+      const { wrapper } = await mountEdit(WIZARD_FORM, {
+        properties: { title: 'Original' },
+        redacted: ['salary'],
+      })
+      expect(renderedProperties(wrapper)).not.toContain('salary')
+    })
+  })
+})

--- a/frontend/src/components/forms/DynamicForm.vue
+++ b/frontend/src/components/forms/DynamicForm.vue
@@ -816,6 +816,13 @@ async function handleSubmit() {
   if (!formConfig.value) return
   // Edit mode has no explicit submit — autosave persists per field. Guard
   // against an Enter-key form submit doing anything (there's no Save button).
+  //
+  // This early return is load-bearing beyond the Enter-key case: because edit
+  // mode never bulk-submits, an untouched field can never reach a payload, so
+  // a redacted field's withheld value cannot be overwritten with empty
+  // (DEC-T0XIWQ). Everything below is therefore the CREATE path only. If you
+  // ever add a bulk edit submit here, you must first prune properties the
+  // server reported in `_redacted` that the user did not touch.
   if (isEdit.value) return
   const scope = submitScopeFields()
   if (!validate(scope, requiredWhenProps(scope))) {
@@ -889,72 +896,50 @@ async function handleSubmit() {
       content: content.value || undefined,
     }
 
-    if (isEdit.value && props.entityId) {
-      const updated = await entitiesStore.update(formConfig.value.entity, props.entityId, payload)
-      // After TKT-GFQK incoming-direction edits flow through the same
-      // unified PATCH (remapped to inverse body keys), so no second
-      // save channel is needed. Clear pending state.
-      pendingCardChanges.value.clear()
-      saveGeneration.value++
-      surfaceWarnings(updated.warnings)
-      uiStore.success('Entity updated successfully')
-    } else {
-      // Create path uses the same modern shape as edit. Cards never
-      // render in create mode (they require entityId), so
-      // pendingCardChanges is empty and relationsPayload is composed
-      // entirely from reshaped picker selections.
-      //
-      // TKT-3I5U: send only visible + writable property keys; the server
-      // fills hidden / read-only defaults after the affordance gate. For a
-      // wizard, also drop keys under a condition-hidden step/field — a
-      // `visible_when=false` branch wins over the affordance filter's
-      // userTouched-preserve rule, so a revealed-then-hidden field is not
-      // persisted (TKT-CHLAJ).
-      payload.properties = pruneWizardHidden(visibleWritablePropertiesForCommit())
-      Object.assign(payload, idControls.buildPayloadFields())
-      const entity = await entitiesStore.create(formConfig.value.entity, payload)
+    // Create only — the isEdit early return above means this is never an
+    // update. Cards never render in create mode (they require entityId), so
+    // pendingCardChanges is empty and relationsPayload is composed entirely
+    // from reshaped picker selections.
+    //
+    // TKT-3I5U: send only visible + writable property keys; the server
+    // fills hidden / read-only defaults after the affordance gate. For a
+    // wizard, also drop keys under a condition-hidden step/field — a
+    // `visible_when=false` branch wins over the affordance filter's
+    // userTouched-preserve rule, so a revealed-then-hidden field is not
+    // persisted (TKT-CHLAJ).
+    payload.properties = pruneWizardHidden(visibleWritablePropertiesForCommit())
+    Object.assign(payload, idControls.buildPayloadFields())
+    const entity = await entitiesStore.create(formConfig.value.entity, payload)
+    // DEC-HWZHA soft conditions ride the 200 create response; surface them or
+    // they are invisible. (Edit-mode warnings come through autosave's own
+    // response handling — this is the create channel.)
+    surfaceWarnings(entity.warnings)
 
-      // Handle auto-linking from link_* params (e.g., from custom view "Add" buttons)
-      // For link_as=to, the relation is already included in relations.value (pre-filled)
-      // For link_as=from, we need to create the reverse relation: peer --relation--> new_entity
-      if (linkParams.value && linkParams.value.as === 'from') {
-        try {
-          const { relation, peer } = linkParams.value
-          // Look up peer type from ID prefix
-          const peerType = getTypeFromId(peer)
-          if (peerType) {
-            await createRelation(peerType, peer, relation, entity.id)
-          }
-        } catch (linkErr) {
-          console.warn('Auto-link failed:', linkErr)
-          // Continue with navigation even if link fails
+    // Handle auto-linking from link_* params (e.g., from custom view "Add" buttons)
+    // For link_as=to, the relation is already included in relations.value (pre-filled)
+    // For link_as=from, we need to create the reverse relation: peer --relation--> new_entity
+    if (linkParams.value && linkParams.value.as === 'from') {
+      try {
+        const { relation, peer } = linkParams.value
+        // Look up peer type from ID prefix
+        const peerType = getTypeFromId(peer)
+        if (peerType) {
+          await createRelation(peerType, peer, relation, entity.id)
         }
+      } catch (linkErr) {
+        console.warn('Auto-link failed:', linkErr)
+        // Continue with navigation even if link fails
       }
-
-      uiStore.success('Entity created successfully')
-      dirty.value = false
-
-      // Navigate to return_to or entity detail
-      if (returnTo.value) {
-        router.push(returnTo.value)
-      } else {
-        router.push(`/entity/${formConfig.value.entity}/${entity.id}`)
-      }
-      return
     }
 
+    uiStore.success('Entity created successfully')
     dirty.value = false
-    originalData.value = JSON.stringify({
-      formData: formData.value,
-      relations: relations.value,
-      content: content.value,
-    })
 
-    // Navigate to return_to or back
+    // Navigate to return_to or entity detail
     if (returnTo.value) {
       router.push(returnTo.value)
     } else {
-      router.back()
+      router.push(`/entity/${formConfig.value.entity}/${entity.id}`)
     }
   } catch (err) {
     // Suppress cancellation errors from rapid navigation in Firefox

--- a/frontend/src/components/forms/DynamicForm.vue
+++ b/frontend/src/components/forms/DynamicForm.vue
@@ -5,7 +5,11 @@ import { useSchemaStore, useEntitiesStore, useUIStore } from '@/stores'
 import { isCancelledFetch } from '@/composables/usePageData'
 import { readReturnTo } from '@/utils/returnPath'
 import { actionAllowed } from '@/utils/affordancesWarning'
-import { isFieldWritable, optionVerdictsFor as optionVerdictsForVerdict } from '@/utils/affordances'
+import {
+  isFieldWritable,
+  isPropertyRedacted,
+  optionVerdictsFor as optionVerdictsForVerdict,
+} from '@/utils/affordances'
 import { isClearedForType } from '@/utils/formValue'
 import { useEntityIDControls } from '@/composables/useEntityIDControls'
 import { useConfirm } from '@/composables/useConfirm'
@@ -68,6 +72,12 @@ const relations = ref<Record<string, string[]>>({})
 // readonly + option-filter rendering and the F1 hidden-field filter
 // (TKT-G7N5).
 const fieldAffordances = ref<Record<string, FieldAffordance>>({})
+// Property names the server withheld by field-level ACL (`_redacted`,
+// DEC-T0XIWQ). This is the edit-mode hidden-field signal: previously the
+// filter inferred hiding from a key's absence in `properties`, which also
+// matches a property that was simply never set — so every unset property
+// became permanently unreachable (BUG-MLT9DE). Empty = nothing redacted.
+const redactedProps = ref<string[]>([])
 // Same for relation affordances. Drives RelationCards' +Add / x button
 // visibility and meta-field disable.
 const relationAffordances = ref<Record<string, RelationAffordance>>({})
@@ -231,34 +241,12 @@ watch(
   }
 )
 
-// TKT-G7N5 F1 / TKT-3I5U: filter the config-driven field list against
-// the entity's affordances. A property field is rendered only if it is
-// visible: either (a) it appears in `_fields` (server emitted a verdict,
-// including the implicit "writable default") or (b) the server treated
-// it as visible — in edit mode that's "present in `properties`"; in
-// create mode the staged dry-run reports visible props in
-// `stagedVisibleProps` (hidden fields are stripped server-side in both
-// cases). Relations / non-property fields are never filtered here.
-//
-// F19 flicker prevention: render the unfiltered list until affordances
-// are available — during initial `loading` (edit), and in create until
-// the first dry-run resolves (`stagedAffordancesReady`). Otherwise a
-// policy-hidden field would flash in then disappear. If a create-mode
-// dry-run never resolves (fail-open, RR-HUQ3) the form stays unfiltered
-// and usable; the commit gate is the real boundary.
-const fields = computed((): FormFieldOrRelation[] => {
-  const all = allFields.value
-  if (loading.value) return all
-  if (!isEdit.value && !stagedAffordancesReady.value) return all
-  const visibleProps = isEdit.value ? formData.value : undefined
-  return all.filter((f) => {
-    if (!f.property) return true // relations / non-property fields untouched
-    if (f.property in fieldAffordances.value) return true
-    if (visibleProps && f.property in visibleProps) return true
-    if (!isEdit.value && stagedVisibleProps.value.has(f.property)) return true
-    return false
-  })
-})
+// TKT-G7N5 F1 / TKT-3I5U / DEC-T0XIWQ: filter the config-driven field list
+// against the entity's affordances. Both render paths (this and the wizard's
+// `visibleStepFields`) delegate to the single `affordanceVisible` predicate
+// below — two hand-synced copies of this rule is how the wizard path silently
+// carried BUG-MLT9DE alongside the flat one.
+const fields = computed((): FormFieldOrRelation[] => allFields.value.filter(affordanceVisible))
 
 // TKT-G7N5 readonly helper: the rendered field is readonly if either
 // the config marks it so OR the server's _fields verdict reports
@@ -352,6 +340,7 @@ async function loadEntity(force = false) {
     // default to empty maps so the filter / readonly / options paths
     // can treat absence as "default everything".
     fieldAffordances.value = entity._fields ?? {}
+    redactedProps.value = entity._redacted ?? []
     relationAffordances.value = entity._relations ?? {}
     attachments.value = entity._attachments ?? {}
     transitions.value = entity._transitions ?? {}
@@ -688,16 +677,33 @@ function validate(scopeFields?: FormFieldOrRelation[], requiredProps?: Set<strin
   return scopeValid
 }
 
-// The affordance filter applied to flat forms in `fields`, reusable for a
-// wizard step's field list so policy-hidden fields are dropped consistently.
+// The single affordance filter for BOTH render paths — flat `fields` and the
+// wizard's `visibleStepFields`. Decides whether a config-declared field is
+// rendered at all (readonly/options are separate, see isFieldReadonly).
+//
+// Edit mode (DEC-T0XIWQ): a configured field renders unless the server
+// positively names it in `_redacted`. It previously rendered only if the key
+// was already in `properties`, which conflated "redacted" with "never set" and
+// made every unset property permanently unfillable (BUG-MLT9DE) — the field
+// could not be filled in because it did not render, and did not render because
+// it had never been filled in.
+//
+// Create mode is unchanged: the staged dry-run's candidate carries metamodel
+// defaults, so `stagedVisibleProps` is a genuine visible-set (it distinguishes
+// hidden from unset by construction) rather than an inference from absence.
+//
+// F19 flicker prevention: render unfiltered until affordances are available —
+// during initial `loading` (edit) and until the first dry-run resolves
+// (create). Otherwise a policy-hidden field would flash in then disappear. If a
+// create-mode dry-run never resolves (fail-open, RR-HUQ3) the form stays
+// unfiltered and usable; the commit gate is the real boundary.
 function affordanceVisible(f: FormFieldOrRelation): boolean {
   if (!f.property) return true // relations / non-property fields untouched
   if (loading.value) return true
-  if (!isEdit.value && !stagedAffordancesReady.value) return true
+  if (isEdit.value) return !isPropertyRedacted(f.property, redactedProps.value)
+  if (!stagedAffordancesReady.value) return true
   if (f.property in fieldAffordances.value) return true
-  if (isEdit.value && f.property in formData.value) return true
-  if (!isEdit.value && stagedVisibleProps.value.has(f.property)) return true
-  return false
+  return stagedVisibleProps.value.has(f.property)
 }
 
 // A wizard step's fields to render: per-field `visible_when` (wizard layer)

--- a/frontend/src/types/entity.ts
+++ b/frontend/src/types/entity.ts
@@ -25,11 +25,26 @@ export interface Entity {
   _actions?: Record<string, boolean>
   // Per-field write affordances on per-entity GET responses.
   // Sparse: only fields whose verdict deviates from default appear.
-  // Hidden fields are omitted from `properties` AND from `_fields`.
+  // Hidden fields are omitted from `properties` AND from `_fields` —
+  // to learn WHICH fields are hidden, read `_redacted`, never absence.
   // Absent on list / mutation responses; present (possibly empty) on
   // per-entity GET (closed-world signal — empty means "evaluated, no
   // deviations"). See docs/data-entry/api-reference.md.
   _fields?: Record<string, FieldAffordance>
+  // Property names withheld from `properties` by field-level ACL
+  // (`visible:`) on this response — the field-level sibling of
+  // `inaccessible` (DEC-T0XIWQ).
+  //
+  // This exists because absence from `properties` is ambiguous: a key can
+  // be missing because it was redacted OR because it was never set. Read
+  // surfaces may conflate those; a write form must not, or it either hides
+  // a field the user can legitimately fill (BUG-MLT9DE) or offers a
+  // redacted one as an apparently-empty input and clobbers the stored
+  // value on save. NEVER infer redaction from absence — consult this list.
+  //
+  // Names only; values stay withheld. Present (possibly empty) on
+  // per-entity responses, absent on list rows.
+  _redacted?: string[]
   // Per-relation-type affordances on per-entity GET responses. Same
   // sparse / closed-world semantics as _fields. Per-relation-type
   // uniform — per-link verdicts are predicate territory (deferred).

--- a/frontend/src/utils/affordances.test.ts
+++ b/frontend/src/utils/affordances.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { isFieldWritable, optionVerdictsFor } from './affordances'
+import { isFieldWritable, isPropertyRedacted, optionVerdictsFor } from './affordances'
 import type { FieldAffordance } from '@/types'
 
 describe('isFieldWritable', () => {
@@ -34,6 +34,32 @@ describe('isFieldWritable', () => {
 
   it('combines both channels — fieldReadonly true wins over verdict writable', () => {
     expect(isFieldWritable({ writable: true }, true)).toBe(false)
+  })
+})
+
+describe('isPropertyRedacted', () => {
+  it('returns true only for a property the server names redacted', () => {
+    expect(isPropertyRedacted('salary', ['salary'])).toBe(true)
+    expect(isPropertyRedacted('salary', ['notes', 'salary'])).toBe(true)
+  })
+
+  it('returns false for a property absent from the redacted list', () => {
+    expect(isPropertyRedacted('title', ['salary'])).toBe(false)
+  })
+
+  // The bug this whole mechanism exists to prevent (BUG-MLT9DE): an unset
+  // property is absent from `properties` exactly like a redacted one, so
+  // absence must NOT be read as redaction. `_redacted: []` is the server
+  // saying "evaluated, nothing hidden" — every field must render.
+  it('returns false for every property when nothing is redacted', () => {
+    expect(isPropertyRedacted('newly_added_prop', [])).toBe(false)
+  })
+
+  // A shape that reports no `_redacted` (list row, pre-affordance response)
+  // must render rather than hide — hiding would resurrect the silent-hiding
+  // bug on those shapes, and the server's write gate is the real boundary.
+  it('returns false when the server reported no redaction list', () => {
+    expect(isPropertyRedacted('anything', undefined)).toBe(false)
   })
 })
 

--- a/frontend/src/utils/affordances.ts
+++ b/frontend/src/utils/affordances.ts
@@ -11,10 +11,27 @@ import type { FieldAffordance } from '@/types'
 // `undefined` falls through cleanly to the verdict check.
 export function isFieldWritable(
   verdict: FieldAffordance | undefined,
-  fieldReadonly?: boolean,
+  fieldReadonly?: boolean
 ): boolean {
   if (fieldReadonly) return false
   return verdict?.writable !== false
+}
+
+// isPropertyRedacted: does the server say this property's value was
+// withheld by field-level ACL on this response? (DEC-T0XIWQ)
+//
+// This is the ONLY sound way to ask. The tempting alternative — "the key is
+// missing from `properties`, so it must be hidden" — is wrong, because a key
+// is equally absent when it was simply never set. That inference is what made
+// every unset property unreachable in the edit form (BUG-MLT9DE).
+//
+// `redacted` is the entity's `_redacted` list. Undefined means the server did
+// not report one (a list row, or a shape carrying no write affordances); we
+// answer `false`, i.e. render the field. That is the safe direction: the field
+// renders, and the server's write gate remains the actual boundary. Answering
+// `true` would resurrect the silent-hiding bug on every such shape.
+export function isPropertyRedacted(property: string, redacted: string[] | undefined): boolean {
+  return redacted?.includes(property) ?? false
 }
 
 // optionVerdictsFor: pulls the per-option allow-map from a server
@@ -22,7 +39,7 @@ export function isFieldWritable(
 // `undefined` when no verdict exists for this field (all options
 // allowed by default).
 export function optionVerdictsFor(
-  verdict: FieldAffordance | undefined,
+  verdict: FieldAffordance | undefined
 ): Record<string, boolean> | undefined {
   return verdict?.options
 }

--- a/internal/apiwire/v1/responses.go
+++ b/internal/apiwire/v1/responses.go
@@ -34,6 +34,31 @@ type Entity struct {
 	// per-entity GET responses. Same pointer / closed-world semantics
 	// as FieldAffordances.
 	RelationAffordances *map[string]RelationAffordance `json:"_relations,omitempty"`
+	// Redacted names the properties withheld from `Properties` by
+	// field-level ACL (`visible:`) on THIS response (DEC-T0XIWQ). It is the
+	// field-level sibling of Inaccessible, which says the same thing
+	// ("exists, value unreadable") for git-crypt-locked content.
+	//
+	// It exists because absence from `Properties` is ambiguous — a key can be
+	// missing because it was redacted OR because it was never set — and a
+	// WRITE surface has to tell those apart to know which inputs it may
+	// offer. Read-out surfaces are happy to conflate them; an edit form is
+	// not. Clients MUST NOT infer redaction from absence: consult this list.
+	//
+	// Disclosure boundary: this leaks property NAMES, never VALUES. That is
+	// not a new disclosure — the metamodel endpoint already serves the
+	// declared property names per type, and `visible:` redaction is defined
+	// as hiding values only, making no claim to conceal which properties
+	// exist. Row-level ACL is unaffected: whether an ENTITY exists remains a
+	// genuine secret, and this list only ever rides a response the caller was
+	// already authorized to read.
+	//
+	// Same pointer / closed-world semantics as FieldAffordances: present
+	// (possibly empty) on per-entity responses — `[]` meaning "evaluated,
+	// nothing redacted" — and nil on list rows and other non-per-entity
+	// shapes, which carry no write affordances. Names are sorted for a
+	// deterministic wire.
+	Redacted *[]string `json:"_redacted,omitempty"`
 	// Attachments maps a `file`-type property name to the LIST of files
 	// currently attached to it (a property may hold several when its
 	// metamodel `max` > 1). The value is always an array — even a

--- a/internal/dataentry/affordances.go
+++ b/internal/dataentry/affordances.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 	"net/http"
 	"net/url"
+	"sort"
 	"time"
 
 	"github.com/Sourcehaven-BV/rela/internal/acl"
@@ -834,6 +835,25 @@ func (svc affordanceService) hiddenProperties(ctx context.Context, e *entityPkg.
 	return out
 }
 
+// redactedPropertyNames returns the sorted names of properties withheld by
+// field-level ACL, for the `_redacted` wire field (DEC-T0XIWQ). Always
+// non-nil — an empty slice is the closed-world "evaluated, nothing redacted"
+// signal, distinct from `_redacted` being absent entirely (a shape that
+// carries no write affordances, e.g. a list row).
+//
+// Takes already-resolved verdicts rather than re-resolving so a caller that
+// has them (attachEntityAffordances) pays for one FieldVerdicts call, not two.
+func redactedPropertyNames(v FieldVerdicts) []string {
+	out := make([]string, 0, len(v.Visible))
+	for name, visible := range v.Visible {
+		if !visible {
+			out = append(out, name)
+		}
+	}
+	sort.Strings(out) // deterministic wire
+	return out
+}
+
 // computeRelationAffordances returns the sparse `_relations` wire map
 // for entity e. Only relation types with at least one deviation
 // (creatable=false, removable=false, or any meta-field writable=false)
@@ -1138,6 +1158,11 @@ func (svc affordanceService) attachEntityAffordances(ctx context.Context, e *ent
 	relations := svc.computeRelationAffordances(ctx, e)
 	result.FieldAffordances = &fields
 	result.RelationAffordances = &relations
+	// `_redacted` names what stripHiddenProperties removed, so a write surface
+	// can tell "hidden" from "never set" instead of guessing from absence
+	// (DEC-T0XIWQ). Rides the per-entity shapes only, like `_fields`.
+	redacted := redactedPropertyNames(verdicts)
+	result.Redacted = &redacted
 	if transitions := svc.computeTransitions(ctx, e, verdicts); transitions != nil {
 		result.Transitions = &transitions
 	}

--- a/internal/dataentry/affordances_test.go
+++ b/internal/dataentry/affordances_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/Sourcehaven-BV/rela/internal/acl"
+	v1 "github.com/Sourcehaven-BV/rela/internal/apiwire/v1"
 	"github.com/Sourcehaven-BV/rela/internal/audit"
 	"github.com/Sourcehaven-BV/rela/internal/entity"
 	"github.com/Sourcehaven-BV/rela/internal/metamodel"
@@ -592,6 +593,82 @@ func TestHiddenProperties_OnlyHiddenEntries(t *testing.T) {
 	}
 	if _, ok := got["title"]; ok {
 		t.Errorf("title should NOT be in hidden set (visible=true): %v", got)
+	}
+}
+
+// DEC-T0XIWQ: `_redacted` is the explicit signal that lets a write surface
+// tell "hidden" from "never set". These pin the three properties the SPA
+// depends on: it names exactly the hidden fields, it is empty-not-nil under
+// the permissive default (closed-world), and it is deterministically ordered.
+func TestRedactedPropertyNames_OnlyHiddenEntries(t *testing.T) {
+	got := redactedPropertyNames(FieldVerdicts{
+		Visible: map[string]bool{
+			"title":    true,
+			"priority": false,
+			"estimate": false,
+		},
+	})
+	want := []string{"estimate", "priority"} // sorted
+	if len(got) != len(want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("got %v, want %v (sorted)", got, want)
+			break
+		}
+	}
+}
+
+func TestRedactedPropertyNames_NothingHidden_EmptyNotNil(t *testing.T) {
+	// The closed-world contract: `[]` means "evaluated, nothing redacted".
+	// A nil slice would marshal to `null` and read as "not evaluated", which
+	// is the ambiguity this field exists to remove.
+	got := redactedPropertyNames(FieldVerdicts{Visible: map[string]bool{"title": true}})
+	if got == nil {
+		t.Fatal("got nil, want empty non-nil slice (closed-world signal)")
+	}
+	if len(got) != 0 {
+		t.Errorf("got %v, want empty", got)
+	}
+}
+
+func TestRedactedPropertyNames_NopResolverVerdicts_EmptyNotNil(t *testing.T) {
+	svc := affordanceServiceWithResolver(NopFieldVerdictResolver{})
+	v := svc.resolver().FieldVerdicts(context.Background(), &entity.Entity{Type: "ticket"})
+	if got := redactedPropertyNames(v); got == nil || len(got) != 0 {
+		t.Errorf("got %v, want empty non-nil under the permissive default", got)
+	}
+}
+
+// The invariant tying the two halves of the wire together: whatever
+// stripHiddenProperties removes from `properties`, `_redacted` must name.
+// If these ever drift, the SPA either hides a writable field or offers a
+// redacted one as an empty input — the two failure modes of BUG-MLT9DE.
+func TestRedactedPropertyNames_MatchesStrippedProperties(t *testing.T) {
+	verdicts := FieldVerdicts{
+		Visible: map[string]bool{"priority": false, "title": true},
+	}
+	svc := affordanceServiceWithResolver(fakeResolver{fv: verdicts})
+	e := &entity.Entity{
+		Type:       "ticket",
+		Properties: map[string]any{"title": "T", "priority": "high"},
+	}
+	result := v1.Entity{Properties: map[string]any{"title": "T", "priority": "high"}}
+	svc.stripHiddenProperties(context.Background(), e, &result)
+
+	stripped := svc.hiddenProperties(context.Background(), e)
+	named := redactedPropertyNames(verdicts)
+	if len(named) != len(stripped) {
+		t.Fatalf("_redacted %v does not match stripped set %v", named, stripped)
+	}
+	for _, name := range named {
+		if _, ok := stripped[name]; !ok {
+			t.Errorf("_redacted names %q which was not stripped", name)
+		}
+		if _, stillOnWire := result.Properties[name]; stillOnWire {
+			t.Errorf("%q is named redacted but its VALUE is still on the wire", name)
+		}
 	}
 }
 

--- a/internal/dataentry/api_v1_test.go
+++ b/internal/dataentry/api_v1_test.go
@@ -4355,6 +4355,104 @@ func TestV1Affordance_PerEntityGet_NoneProfile(t *testing.T) {
 // resolver populates the expected sparse fixture verdicts. Uses a
 // hand-rolled fixture resolver to keep the test independent of the
 // project's real metamodel (which doesn't have all the demo fields).
+// TestV1Affordance_PerEntityGet_RedactedNamesHiddenFields is the wire half of
+// BUG-MLT9DE / DEC-T0XIWQ. Before `_redacted`, a hidden property and a
+// never-set one were byte-identical on the wire — both simply absent from
+// `properties`, both absent from the sparse `_fields`. A write surface could
+// only guess which it was looking at, and guessing "hidden" made every unset
+// property permanently unfillable in the edit form.
+//
+// This pins the disambiguation end-to-end: hidden VALUES stay withheld, hidden
+// NAMES are stated, and an unset property is named nowhere — so the client can
+// tell the three cases apart without inferring anything from absence.
+func TestV1Affordance_PerEntityGet_RedactedNamesHiddenFields(t *testing.T) {
+	app := newTestAppV1(t)
+	app.fieldResolver = fakeResolver{
+		fv: FieldVerdicts{Visible: map[string]bool{"title": false}},
+	}
+	// `status` is stored; `title` is stored but hidden; the ticket type's other
+	// declared properties are simply unset — the BUG-MLT9DE case.
+	seedEntity(app, &entity.Entity{
+		ID:         "TKT-001",
+		Type:       "ticket",
+		Properties: map[string]any{"title": "secret", "status": "open"},
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/tickets/TKT-001", http.NoBody)
+	rec := httptest.NewRecorder()
+	app.handleV1GetEntity(rec, req, "ticket", "tickets", "TKT-001")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	raw := rec.Body.String()
+
+	var got v1.Entity
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	// The value stays secret — that part of the contract is unchanged.
+	if strings.Contains(raw, "secret") {
+		t.Errorf("hidden VALUE must never reach the wire; got: %s", raw)
+	}
+	if _, present := got.Properties["title"]; present {
+		t.Errorf("hidden field must be absent from properties; got: %s", raw)
+	}
+
+	// The name is now stated, so the client never has to infer.
+	if got.Redacted == nil {
+		t.Fatalf("_redacted must be present on a per-entity GET; got: %s", raw)
+	}
+	if len(*got.Redacted) != 1 || (*got.Redacted)[0] != "title" {
+		t.Errorf("_redacted: got %v, want exactly [title]", *got.Redacted)
+	}
+
+	// And an UNSET property is named nowhere — not in properties, not in
+	// _fields, not in _redacted. That absence-without-redaction is exactly
+	// what the edit form must render rather than hide.
+	if _, present := got.Properties["effort"]; present {
+		t.Fatalf("precondition: 'effort' should be unset on this fixture")
+	}
+	for _, name := range *got.Redacted {
+		if name == "effort" {
+			t.Errorf("an unset property must NOT be reported as redacted")
+		}
+	}
+}
+
+// TestV1Affordance_PerEntityGet_RedactedEmptyWhenNothingHidden pins the
+// closed-world half: under the permissive default `_redacted` is present and
+// EMPTY ("evaluated, nothing hidden"), not absent. An absent list would be
+// indistinguishable from "this server does not report redaction", which is the
+// ambiguity the field exists to remove.
+func TestV1Affordance_PerEntityGet_RedactedEmptyWhenNothingHidden(t *testing.T) {
+	app := newTestAppV1(t)
+	app.fieldResolver = NopFieldVerdictResolver{}
+	seedEntity(app, &entity.Entity{
+		ID:         "TKT-001",
+		Type:       "ticket",
+		Properties: map[string]any{"title": "Test Ticket", "status": "open"},
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/tickets/TKT-001", http.NoBody)
+	rec := httptest.NewRecorder()
+	app.handleV1GetEntity(rec, req, "ticket", "tickets", "TKT-001")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+
+	var got v1.Entity
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got.Redacted == nil {
+		t.Fatal("_redacted pointer should be non-nil (closed-world signal)")
+	}
+	if len(*got.Redacted) != 0 {
+		t.Errorf("_redacted: got %v, want empty under the permissive default", *got.Redacted)
+	}
+}
+
 func TestV1Affordance_PerEntityGet_DemoFixture(t *testing.T) {
 	app := newTestAppV1(t)
 	falseVal := false
@@ -4483,9 +4581,29 @@ func TestV1Affordance_PatchEcho_StripsHidden(t *testing.T) {
 	if rec.Code != http.StatusOK {
 		t.Fatalf("PATCH returned %d: %s", rec.Code, rec.Body.String())
 	}
+	// The invariant is about the VALUE: a stale client must not be able to
+	// read a hidden property out of its own write response. The NAME is a
+	// different matter — since DEC-T0XIWQ the response deliberately lists
+	// hidden names in `_redacted` so a write surface can tell "hidden" from
+	// "never set" (property names are already public via the metamodel; only
+	// values are secret). So assert on the value and on `properties`, not on
+	// a whole-body substring match for the name.
 	body := rec.Body.String()
-	if strings.Contains(body, `"title"`) || strings.Contains(body, "secret") {
-		t.Errorf("PATCH echo must NOT contain hidden field; got: %s", body)
+	if strings.Contains(body, "secret") {
+		t.Errorf("PATCH echo must NOT contain the hidden VALUE; got: %s", body)
+	}
+	var echoed v1.Entity
+	if err := json.Unmarshal(rec.Body.Bytes(), &echoed); err != nil {
+		t.Fatalf("decode echo: %v", err)
+	}
+	if _, present := echoed.Properties["title"]; present {
+		t.Errorf("hidden field must be absent from properties; got: %s", body)
+	}
+	if echoed.Redacted == nil {
+		t.Fatalf("_redacted must be present on a per-entity response; got: %s", body)
+	}
+	if len(*echoed.Redacted) != 1 || (*echoed.Redacted)[0] != "title" {
+		t.Errorf("_redacted must name the hidden field; got %v", *echoed.Redacted)
 	}
 }
 
@@ -5403,6 +5521,11 @@ func TestV1Affordance_CollectionGet_NoFieldVerdicts(t *testing.T) {
 	}
 	if strings.Contains(body, `"_relations"`) {
 		t.Errorf("collection response must NOT contain _relations; got: %s", body)
+	}
+	// `_redacted` rides the same per-entity boundary (DEC-T0XIWQ): list rows
+	// carry no write affordances, so they carry no redaction list either.
+	if strings.Contains(body, `"_redacted"`) {
+		t.Errorf("collection response must NOT contain _redacted; got: %s", body)
 	}
 }
 

--- a/tickets/entities/automated-measures/edit-form-renders-unset-declared-property-test.md
+++ b/tickets/entities/automated-measures/edit-form-renders-unset-declared-property-test.md
@@ -1,0 +1,63 @@
+---
+id: edit-form-renders-unset-declared-property-test
+type: automated-measure
+title: Edit form renders a configured-but-unset property field
+description: 'Test suite pinning the redacted-vs-unset distinction end to end. Frontend: DynamicForm.test.ts mounts the form in edit mode with an entity whose stored properties OMIT a configured property and _fields: {} (the sparse permissive default), asserting it renders — plus the inverse (a _redacted property does not render) and both cases on the wizard path. Backend: api_v1_test.go asserts a GET states hidden NAMES in _redacted while withholding VALUES, that an unset property is named nowhere, and that _redacted is empty-not-nil under the permissive default. Verified to fail on pre-fix code.'
+kind: test
+location: frontend/src/components/forms/DynamicForm.test.ts, frontend/src/utils/affordances.test.ts, internal/dataentry/api_v1_test.go, internal/dataentry/affordances_test.go
+status: active
+---
+
+## Purpose
+
+Close the test gap that let BUG-MLT9DE ship. Before this there was **no
+`DynamicForm.test.ts` at all** — the only DynamicForm test
+(`DynamicForm.guard.test.ts`) deliberately avoids mounting the component and
+replicates the unsaved-changes guard in a stub. Neither affordance gate site had
+ever been exercised. Fixtures elsewhere uniformly seeded entities whose
+`properties` already contained a key for each field under test, so the edit-mode
+gate always matched and its failure mode was invisible to CI.
+
+## What it covers
+
+**Frontend — `DynamicForm.test.ts` (7 cases)**
+
+1. *The bug.* Edit mode, entity whose `properties` omit a property that IS in
+the form config's `fields:`, served with `_fields: {}` — the sparse permissive
+default the old gate misread as "hidden". Asserts it renders.
+2. *The inverse.* A property named in `_redacted` still does not render, so the
+fix does not trade silent hiding for silent exposure.
+3. *Unset ≠ redacted.* With one property redacted, the merely-unset one still
+renders — the distinction the whole change exists to make.
+4. *Wizard path.* Both cases again through `visibleStepFields`, which carried a
+hand-synced copy of the gate.
+5. *No bulk overwrite.* A form submit in edit mode sends nothing (writes are
+per-property autosave), so no untouched field can post as empty.
+
+**Frontend — `affordances.test.ts`**: `isPropertyRedacted` unit cases, including
+the two that encode the contract — `[]` hides nothing, `undefined` hides
+nothing.
+
+**Backend — `api_v1_test.go` / `affordances_test.go`**: a GET states hidden
+names in `_redacted` while withholding values; an unset property is named
+nowhere; `_redacted` is empty-not-nil under the permissive default; list rows
+omit it; and `_redacted` agrees exactly with what `stripHiddenProperties`
+removed (the invariant tying the two halves of the wire together).
+
+## Verified against the bug
+
+Reverting the edit-mode gate to its pre-fix form fails 4 of the 5 render cases,
+including the wizard one. The 5th passed only because the old code hid
+*everything* unset — which is why the paired render/hide assertions matter:
+either alone can pass for the wrong reason.
+
+## Note on scope
+
+Keyed on the **form config** field list, not the metamodel: `allFields` is built
+from `formConfig.fields` / `steps[].fields` and never consults the metamodel
+property map. See BUGA-YBCFE1.
+
+## Structural follow-through
+
+The duplicated gate sites are now one exported predicate (`isPropertyRedacted`),
+so this class of drift is prevented structurally rather than only test-caught.

--- a/tickets/entities/bug-analysis-checklists/BUGA-YBCFE1.md
+++ b/tickets/entities/bug-analysis-checklists/BUGA-YBCFE1.md
@@ -1,0 +1,132 @@
+---
+id: BUGA-YBCFE1
+type: bug-analysis-checklist
+title: 'Analysis: Edit form hides properties the entity doesn''t have yet — newly added metamodel properties are unreachable on existing entities'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Reproduction
+
+- [x] Bug reproduced locally — by code inspection + the reporter's confirmed repro (step 5, `rela update -P newprop=value` makes the field appear, is decisive: it changes *only* whether the key exists in the entity's stored `properties`)
+- [x] Minimal reproduction steps documented — see the bug body. Minimal form: an entity whose stored `properties` omit key `K`, where `K` is listed in the form config's `fields:`, served with `_fields: {}`.
+- [x] Environment/conditions noted — 8cce2733; reproduces with the nop ACL resolver (`_fields: {}`), so it is **not** ACL-dependent. Affects every deployment.
+
+### Scope correction found during analysis
+
+The bug report's suggested fix ("the schema store already has the type's
+property list") rests on a premise that does not hold. `allFields`
+(DynamicForm.vue:151-167) is built from the **data-entry.yaml form config**
+(`formConfig.fields` / `steps[].fields`), never from the metamodel property map;
+`dataentryconfig` has no derive-fields-from-metamodel path and no lint requiring
+a form to cover every declared property.
+
+Consequence: adding a property to `metamodel.yaml` alone renders it nowhere —
+not create, not edit. The reporter saw it in create mode, so the property was
+already added to the form config too. The metamodel is therefore **not** the
+missing signal; the affordance filter subtracting a configured field is the
+whole bug. A fix keyed on "declared in the metamodel" would be both wider than
+needed and, for a form that deliberately omits a property, wrong.
+
+## Root Cause
+
+- [x] Immediate cause identified (why1)
+- [x] Contributing factors found (why2-3)
+- [x] Systemic cause explored (why4-5)
+
+### Evidence
+
+The edit-mode gate treats absence of a key in `properties` as proof of
+ACL-hiding. That inference is invalid because the wire genuinely cannot
+distinguish the two cases:
+
+- `stripHiddenProperties` (affordances.go:913-916) removes a hidden property
+with a plain `delete` — no null placeholder, no tombstone.
+- Hidden fields are also **absent** from `_fields` by construction: both loops
+in `computeFieldAffordancesFrom` skip them (affordances.go:741-743, 752-754),
+locked by `TestComputeFieldAffordances_HiddenFieldsOmittedFromMap`
+(affordances_test.go:497). Documented as "doubly-invisible"
+(affordances.go:714-722).
+- The one wire field that *does* mean "exists but unreadable",
+`Entity.Inaccessible` (apiwire/v1/responses.go:23,123-129), is populated only
+for git-crypt–locked content (entityserializer.go:61-69), never for ACL
+redaction.
+
+So "redacted" and "never set" are byte-identical on the wire, and the client
+resolves the ambiguity in the direction that silently destroys reachability.
+
+Create mode escapes only by accident of a different signal: `stagedVisibleProps`
+(DynamicForm.vue:547) is seeded from the dry-run candidate, and the server
+applies metamodel defaults when staging — so every declared property is a key.
+
+## Fix Planning
+
+- [x] Fix approach determined
+- [x] Regression test planned
+- [x] Related areas checked for similar issues
+
+### Approach
+
+Invert the edit-mode default from deny to allow, and hide only on positive
+evidence of hiding. A configured form field is an explicit authoring decision
+that the field belongs on the form; the affordance filter should subtract from
+it only when the server actually says "hidden", never on inference from absence.
+
+Two candidate levers:
+
+1. **Client-only (preferred for the fix, smaller blast radius).** In edit mode
+render a configured property field unconditionally, and rely on the existing
+`isFieldReadonly` / `_fields.writable` path plus the server's PATCH gate for
+enforcement. Correct per the project's field-level ACL rule: `visible:`
+redaction hides property *values only* and makes no claim to conceal which
+properties exist, since the metamodel is served over the API — so rendering an
+empty input for a redacted field is not a leak. It must not *submit* an
+unmodified empty value, though (see risk below).
+
+2. **Add an explicit wire signal** — have the server name redacted properties
+(mirroring `Inaccessible`) so the client stops inferring. Strictly better
+long-term and removes the ambiguity at its source, but it is a wire-contract
+change and larger than this bug needs. Recommend recording it as a follow-up
+ticket rather than folding it in.
+
+Both gate sites must change together: `fields` (DynamicForm.vue:249-262) and
+`affordanceVisible()` (DynamicForm.vue:692-701, the wizard path). Fixing one
+leaves the other broken.
+
+### Load-bearing risk (must be handled in implementation)
+
+A redacted field would now render as an empty input. If the form submits that
+empty value on save, it **overwrites the hidden stored value with empty** —
+silent data destruction, the exact failure the project's "never redact a read
+that feeds a write" rule exists to prevent. The fix must ensure an untouched,
+never-populated field is omitted from the PATCH payload rather than sent as
+empty. `userTouched` (DynamicForm.vue:312) already tracks this distinction and
+is the natural hook.
+
+### Regression tests planned
+
+Pinned as `edit-form-renders-unset-declared-property-test`. There is currently
+**no `DynamicForm.test.ts` at all** — the only DynamicForm test
+(`DynamicForm.guard.test.ts`) deliberately avoids mounting the component and
+replicates the guard in a stub, so neither gate site has ever been covered.
+Three cases minimum:
+
+1. Declared-and-configured but unset property, `_fields: {}` → renders, writable,
+and a typed value persists. (Fails today.)
+2. Genuinely redacted property → still not writable, and critically **not sent
+as empty on save** when untouched. Guards against trading a silent-hiding bug
+for a silent-data-loss one.
+3. The same pair through the wizard path (`visibleStepFields`), since that is a
+second independent copy of the gate.
+
+### Related areas checked
+
+- Wizard gate `affordanceVisible()` — same defect, same file. In scope.
+- `visibleWritablePropertiesForCommit()` (DynamicForm.vue:300-320) — create-path
+only (early-returns in edit mode); not the bug, but it is where the
+`userTouched` precedent for the empty-overwrite risk lives.
+- List rows / `_props` (`copyVisibleProperties`, affordances.go:891-902) — strips
+the same way, but read-only display, so absence is harmless there.
+- Backend `_fields` contract — correct as designed and well tested; no change
+needed for approach 1.

--- a/tickets/entities/bugs/BUG-MLT9DE.md
+++ b/tickets/entities/bugs/BUG-MLT9DE.md
@@ -1,0 +1,133 @@
+---
+id: BUG-MLT9DE
+type: bug
+title: Edit form hides properties the entity doesn't have yet — newly added metamodel properties are unreachable on existing entities
+description: In edit mode DynamicForm renders a property field only if the key is already present in formData or in the sparse _fields map, so a property added to metamodel.yaml after an entity was created never renders and can never be set from the UI.
+priority: high
+effort: m
+why1: In edit mode DynamicForm renders a configured property field only if its key is already present in the entity's stored properties (or in the sparse _fields map), so a property that is simply unset never renders and can never be filled in.
+why2: The gate treats absence of a key in the GET response's `properties` as proof the server redacted it, but absence actually means either 'ACL-redacted' or 'never set' — the filter resolves that ambiguity toward hiding.
+why3: 'The wire genuinely cannot distinguish the two: stripHiddenProperties deletes the key outright (affordances.go:913), and hidden fields are also omitted from `_fields` by construction (affordances.go:741,752) — the deliberate ''doubly-invisible'' contract. Entity.Inaccessible, the one field that means ''exists but unreadable'', is used only for git-crypt locks, never ACL.'
+why4: The client was made responsible for reconstructing a distinction the server had deliberately erased. The 'doubly-invisible' contract was designed for read-out surfaces, where a hidden and an unset field should look identical; a write form has the opposite requirement — it must know which fields it may offer — and no one noticed the contract was being reused across that boundary.
+why5: 'Systemic: an affordance filter added for ACL (TKT-G7N5/TKT-3I5U) defaulted to DENY on a signal that is absent in the overwhelmingly common no-ACL case, and nothing tested it there. There is no DynamicForm.test.ts at all, and every fixture elsewhere seeds entities whose properties already contain each field under test — so the filter''s failure mode was invisible to CI, and a security-motivated default silently became a functional regression for all users.'
+prevention: 1) When a read contract deliberately makes two states indistinguishable, do not consume it from a write surface that needs to tell them apart — carry an explicit signal (mirroring Entity.Inaccessible) instead of inferring. 2) An ACL filter that defaults to deny must be tested in the NO-ACL configuration, where the permissive default is what ships to most users. 3) Test fixtures must include an entity with unset properties; uniformly fully-populated fixtures hide every absence-related defect. 4) Duplicated gate logic (fields + affordanceVisible) should be one exported function so it is testable and cannot drift.
+status: in-progress
+---
+
+## Description
+
+When a property is added to an entity type in `metamodel.yaml` (and to the
+relevant data-entry form config), the edit form does not render it for entities
+created before that change. Because the field never renders it can't be filled
+in; because it can't be filled in the entity never gets the property; so the
+field never renders. Existing entities are permanently stuck without the new
+field, and the only way out is the CLI or editing the markdown by hand.
+
+Found on 8cce2733 (`frontend/src/components/forms/DynamicForm.vue`).
+
+## Reproduce
+
+1. Have an entity type with existing entities.
+2. Add a new optional property to that type in `metamodel.yaml` (e.g. an enum
+with a `default:`) and add it to the form's `fields:` in the data-entry config.
+3. Open the edit form for an entity created before step 2 — the new field is
+absent.
+4. Creating a *new* entity of that type shows the field correctly.
+5. `rela update <ID> -P newprop=value` → the field now appears in the edit form
+for that entity.
+
+Step 5 is the decisive one: it changes *only* whether the key exists in the
+entity's stored `properties`.
+
+## Cause
+
+The affordance filter added by TKT-G7N5 / TKT-3I5U gates rendering in two places
+— `fields` (DynamicForm.vue:249) and `affordanceVisible()`
+(DynamicForm.vue:693):
+
+```js
+if (f.property in fieldAffordances.value) return true
+if (isEdit.value && f.property in formData.value) return true   // ← gate
+return false
+```
+
+In edit mode a configured property field renders only if the key is already
+present in `formData` (populated from the entity's stored properties) or listed
+in `_fields`.
+
+`_fields` cannot cover it: `computeFieldAffordances`
+(`internal/dataentry/affordances.go:714`) is sparse — *"only fields whose
+verdict deviates from the permissive default appear"*. A plainly writable field
+is therefore absent from `_fields` by design, so the first check never matches
+and the presence-in-`formData` check becomes the sole gate. Reproduces with the
+nop resolver (`_fields: {}`), so this is **not** ACL-dependent — it affects
+every deployment.
+
+The gate's intent was to mirror the server's redaction ("hidden fields are
+stripped server-side, so absence means hidden"). But absence from `properties`
+is ambiguous — it means *either* "redacted" *or* "never set" — and the gate
+reads every never-set property as redacted.
+
+The wire cannot distinguish them, by design:
+
+- `stripHiddenProperties` (affordances.go:913-916) deletes the key outright —
+no null, no tombstone.
+- Hidden fields are *also* omitted from `_fields` (affordances.go:741-743,
+752-754), locked by `TestComputeFieldAffordances_HiddenFieldsOmittedFromMap`.
+Documented as "doubly-invisible" (affordances.go:714-722).
+- `Entity.Inaccessible` (apiwire/v1/responses.go:23), the one wire field meaning
+"exists but unreadable", is populated only for git-crypt–locked content
+(entityserializer.go:61-69), never for ACL redaction.
+
+## Why create mode is unaffected
+
+Create mode uses a different signal: `stagedVisibleProps` (DynamicForm.vue:547)
+is built from the dry-run candidate's `properties`, and the server applies
+metamodel defaults when staging that candidate. Every declared property is
+therefore a key in the candidate. Edit mode has no equivalent source.
+
+## Why the metamodel `default:` doesn't help
+
+Defaults are applied at create time only. Stored entities simply lack the key,
+and the API omits it from `properties` rather than emitting a null.
+
+## Impact
+
+Any additive schema change — the most routine kind of evolution — is invisible
+in the UI for pre-existing data. With a large existing dataset this means either
+a scripted backfill or hand-editing every file. It also fails silently: no
+warning, no empty field, the input simply isn't there, which reads as a config
+error rather than a product bug.
+
+## Suggested fix
+
+**Note:** the original report suggested keying the fix on "property is declared
+on the entity type in the metamodel". Analysis (BUGA-YBCFE1) found that premise
+does not hold — `allFields` (DynamicForm.vue:151-167) is built from the
+**data-entry form config**, never from the metamodel property map, and there is
+no derive-from-metamodel path in `dataentryconfig`. A metamodel-keyed fix would
+be both wider than needed and wrong for a form that deliberately omits a
+property.
+
+The correct lever: in edit mode, render a *configured* property field
+unconditionally, and hide only on positive evidence of hiding — never on
+inference from absence. Enforcement stays with `isFieldReadonly` /
+`_fields.writable` and the server's PATCH gate. This is consistent with the
+project's field-level ACL rule: `visible:` redaction hides property *values*
+only and makes no claim to conceal which properties exist, since the metamodel
+is served over the API.
+
+Both gate sites must change together — `fields` (DynamicForm.vue:249) and
+`affordanceVisible()` (DynamicForm.vue:693, wizard path).
+
+**Load-bearing risk:** a redacted field would then render as an empty input. If
+the form submits that empty value on save it overwrites the hidden stored value
+— silent data destruction, exactly what the "never redact a read that feeds a
+write" rule guards against. An untouched field must be omitted from the PATCH
+payload, not sent as empty; `userTouched` (DynamicForm.vue:312) is the natural
+hook.
+
+Follow-up worth considering separately: give the server an explicit
+redacted-properties signal (mirroring `Inaccessible`) so the client stops
+inferring at all. Better long-term, but a wire-contract change and larger than
+this bug needs.

--- a/tickets/entities/bugs/BUG-MLT9DE.md
+++ b/tickets/entities/bugs/BUG-MLT9DE.md
@@ -11,39 +11,37 @@ why3: 'The wire genuinely cannot distinguish the two: stripHiddenProperties dele
 why4: The client was made responsible for reconstructing a distinction the server had deliberately erased. The 'doubly-invisible' contract was designed for read-out surfaces, where a hidden and an unset field should look identical; a write form has the opposite requirement — it must know which fields it may offer — and no one noticed the contract was being reused across that boundary.
 why5: 'Systemic: an affordance filter added for ACL (TKT-G7N5/TKT-3I5U) defaulted to DENY on a signal that is absent in the overwhelmingly common no-ACL case, and nothing tested it there. There is no DynamicForm.test.ts at all, and every fixture elsewhere seeds entities whose properties already contain each field under test — so the filter''s failure mode was invisible to CI, and a security-motivated default silently became a functional regression for all users.'
 prevention: 1) When a read contract deliberately makes two states indistinguishable, do not consume it from a write surface that needs to tell them apart — carry an explicit signal (mirroring Entity.Inaccessible) instead of inferring. 2) An ACL filter that defaults to deny must be tested in the NO-ACL configuration, where the permissive default is what ships to most users. 3) Test fixtures must include an entity with unset properties; uniformly fully-populated fixtures hide every absence-related defect. 4) Duplicated gate logic (fields + affordanceVisible) should be one exported function so it is testable and cannot drift.
-status: in-progress
+status: done
 ---
 
 ## Description
 
 When a property is added to an entity type in `metamodel.yaml` (and to the
-relevant data-entry form config), the edit form does not render it for entities
-created before that change. Because the field never renders it can't be filled
-in; because it can't be filled in the entity never gets the property; so the
-field never renders. Existing entities are permanently stuck without the new
-field, and the only way out is the CLI or editing the markdown by hand.
+relevant data-entry form config), the edit form did not render it for entities
+created before that change. Because the field never rendered it couldn't be
+filled in; because it couldn't be filled in the entity never got the property;
+so the field never rendered. Existing entities were permanently stuck without
+the new field, and the only way out was the CLI or editing the markdown by hand.
 
 Found on 8cce2733 (`frontend/src/components/forms/DynamicForm.vue`).
 
 ## Reproduce
 
 1. Have an entity type with existing entities.
-2. Add a new optional property to that type in `metamodel.yaml` (e.g. an enum
-with a `default:`) and add it to the form's `fields:` in the data-entry config.
+2. Add a new optional property to that type in `metamodel.yaml` and add it to
+the form's `fields:` in the data-entry config.
 3. Open the edit form for an entity created before step 2 — the new field is
 absent.
 4. Creating a *new* entity of that type shows the field correctly.
-5. `rela update <ID> -P newprop=value` → the field now appears in the edit form
-for that entity.
+5. `rela update <ID> -P newprop=value` → the field now appears for that entity.
 
-Step 5 is the decisive one: it changes *only* whether the key exists in the
-entity's stored `properties`.
+Step 5 is decisive: it changes *only* whether the key exists in the entity's
+stored `properties`.
 
 ## Cause
 
-The affordance filter added by TKT-G7N5 / TKT-3I5U gates rendering in two places
-— `fields` (DynamicForm.vue:249) and `affordanceVisible()`
-(DynamicForm.vue:693):
+The affordance filter added by TKT-G7N5 / TKT-3I5U gated rendering in two places
+— `fields` and `affordanceVisible()`:
 
 ```js
 if (f.property in fieldAffordances.value) return true
@@ -51,83 +49,79 @@ if (isEdit.value && f.property in formData.value) return true   // ← gate
 return false
 ```
 
-In edit mode a configured property field renders only if the key is already
-present in `formData` (populated from the entity's stored properties) or listed
-in `_fields`.
+In edit mode a configured field rendered only if the key was already in
+`formData` (the entity's stored properties) or listed in `_fields`. `_fields` is
+sparse — a plainly writable field is absent from it by design — so the presence
+check became the sole gate. Reproduces with the nop resolver (`_fields: {}`), so
+it was **not** ACL-dependent; it affected every deployment.
 
-`_fields` cannot cover it: `computeFieldAffordances`
-(`internal/dataentry/affordances.go:714`) is sparse — *"only fields whose
-verdict deviates from the permissive default appear"*. A plainly writable field
-is therefore absent from `_fields` by design, so the first check never matches
-and the presence-in-`formData` check becomes the sole gate. Reproduces with the
-nop resolver (`_fields: {}`), so this is **not** ACL-dependent — it affects
-every deployment.
+The gate treated absence from `properties` as proof of redaction. But absence
+means *either* "redacted" *or* "never set", and the wire could not distinguish
+them, by design:
 
-The gate's intent was to mirror the server's redaction ("hidden fields are
-stripped server-side, so absence means hidden"). But absence from `properties`
-is ambiguous — it means *either* "redacted" *or* "never set" — and the gate
-reads every never-set property as redacted.
+- `stripHiddenProperties` deletes the key outright — no null, no tombstone.
+- Hidden fields are *also* omitted from `_fields` — the documented
+"doubly-invisible" contract.
+- `Entity.Inaccessible`, the one wire field meaning "exists but unreadable", is
+populated only for git-crypt–locked content, never for ACL redaction.
 
-The wire cannot distinguish them, by design:
+The "doubly-invisible" contract is right for read-out surfaces, where hidden and
+unset *should* look alike. A write form has the opposite need — it must know
+which fields it may offer — and the contract was being reused across that
+boundary.
 
-- `stripHiddenProperties` (affordances.go:913-916) deletes the key outright —
-no null, no tombstone.
-- Hidden fields are *also* omitted from `_fields` (affordances.go:741-743,
-752-754), locked by `TestComputeFieldAffordances_HiddenFieldsOmittedFromMap`.
-Documented as "doubly-invisible" (affordances.go:714-722).
-- `Entity.Inaccessible` (apiwire/v1/responses.go:23), the one wire field meaning
-"exists but unreadable", is populated only for git-crypt–locked content
-(entityserializer.go:61-69), never for ACL redaction.
+## Why create mode was unaffected
 
-## Why create mode is unaffected
-
-Create mode uses a different signal: `stagedVisibleProps` (DynamicForm.vue:547)
-is built from the dry-run candidate's `properties`, and the server applies
-metamodel defaults when staging that candidate. Every declared property is
-therefore a key in the candidate. Edit mode has no equivalent source.
-
-## Why the metamodel `default:` doesn't help
-
-Defaults are applied at create time only. Stored entities simply lack the key,
-and the API omits it from `properties` rather than emitting a null.
+Create mode uses `stagedVisibleProps`, built from the dry-run candidate, and the
+server applies metamodel defaults when staging it. Every declared property is
+therefore a key in the candidate — a genuine visible-set rather than an
+inference from absence. Edit mode had no equivalent source.
 
 ## Impact
 
-Any additive schema change — the most routine kind of evolution — is invisible
-in the UI for pre-existing data. With a large existing dataset this means either
-a scripted backfill or hand-editing every file. It also fails silently: no
-warning, no empty field, the input simply isn't there, which reads as a config
-error rather than a product bug.
+Any additive schema change — the most routine kind of evolution — was invisible
+in the UI for pre-existing data, requiring a scripted backfill or hand-editing
+every file. It also failed silently: no warning, no empty field, the input
+simply wasn't there, which read as a config error rather than a product bug.
 
-## Suggested fix
+## Resolution
 
-**Note:** the original report suggested keying the fix on "property is declared
-on the entity type in the metamodel". Analysis (BUGA-YBCFE1) found that premise
-does not hold — `allFields` (DynamicForm.vue:151-167) is built from the
-**data-entry form config**, never from the metamodel property map, and there is
-no derive-from-metamodel path in `dataentryconfig`. A metamodel-keyed fix would
-be both wider than needed and wrong for a form that deliberately omits a
-property.
+Fixed at the source rather than in the inference (DEC-T0XIWQ): the server now
+states which properties it withheld, in a new `_redacted` field on per-entity
+responses, and the SPA stops guessing.
 
-The correct lever: in edit mode, render a *configured* property field
-unconditionally, and hide only on positive evidence of hiding — never on
-inference from absence. Enforcement stays with `isFieldReadonly` /
-`_fields.writable` and the server's PATCH gate. This is consistent with the
-project's field-level ACL rule: `visible:` redaction hides property *values*
-only and makes no claim to conceal which properties exist, since the metamodel
-is served over the API.
+- `internal/apiwire/v1/responses.go` — `Entity.Redacted`, same closed-world
+pointer semantics as `_fields` (present-possibly-empty per-entity, absent on
+list rows).
+- `internal/dataentry/affordances.go` — `redactedPropertyNames`, attached in
+`attachEntityAffordances` beside the strip, so naming and stripping are
+structurally inseparable.
+- `frontend/.../DynamicForm.vue` — the two hand-synced gate copies collapsed
+into one predicate; edit mode renders a configured field unless `_redacted`
+names it. (The wizard path carried the identical defect precisely because the
+rule was duplicated.)
+- `frontend/src/utils/affordances.ts` — `isPropertyRedacted`, exported and
+directly tested.
+- `docs/data-entry/api-reference.md` — the hidden-fields section documented the
+unsound inference *as the contract*, so it would have kept teaching the bug;
+rewritten.
 
-Both gate sites must change together — `fields` (DynamicForm.vue:249) and
-`affordanceVisible()` (DynamicForm.vue:693, wizard path).
+Values are still withheld; only names became explicit, which discloses nothing
+new — the metamodel endpoint already serves declared property names, and
+`visible:` redaction is defined as hiding values only. Row-level ACL is
+untouched.
 
-**Load-bearing risk:** a redacted field would then render as an empty input. If
-the form submits that empty value on save it overwrites the hidden stored value
-— silent data destruction, exactly what the "never redact a read that feeds a
-write" rule guards against. An untouched field must be omitted from the PATCH
-payload, not sent as empty; `userTouched` (DynamicForm.vue:312) is the natural
-hook.
+**Note on the originally suggested fix.** The report proposed keying on
+"declared in the metamodel". That premise doesn't hold: `allFields` is built
+from the data-entry form config and never consults the metamodel property map,
+so such a fix would have been both wider than needed and wrong for forms that
+deliberately omit a property. See BUGA-YBCFE1.
 
-Follow-up worth considering separately: give the server an explicit
-redacted-properties signal (mirroring `Inaccessible`) so the client stops
-inferring at all. Better long-term, but a wire-contract change and larger than
-this bug needs.
+**Note on the anticipated data-loss risk.** Planning flagged that rendering
+redacted fields might let an untouched one submit as empty and clobber the
+stored value. Implementation found this cannot happen: edit mode has no bulk
+submit, and all writes go through per-property autosave, which fires only for
+fields the user typed into. A guard written against that path was removed rather
+than left as dead code implying protection it didn't provide; two tests pin the
+reasoning, and an unreachable branch that contradicted it was deleted
+(RR-GNXKTW).

--- a/tickets/entities/decisions/DEC-T0XIWQ.md
+++ b/tickets/entities/decisions/DEC-T0XIWQ.md
@@ -1,0 +1,87 @@
+---
+id: DEC-T0XIWQ
+type: decision
+title: Redacted properties carry an explicit wire signal; the SPA never infers hiding from absence
+context: 'The v1 entity wire made an ACL-redacted property byte-identical to a never-set one: stripHiddenProperties deletes the key (affordances.go:913) and hidden fields are also absent from the sparse _fields map (affordances.go:741,752) — the documented ''doubly-invisible'' contract. The SPA''s edit-mode form filter therefore had to INFER hiding from absence (''render only if the field appears in _fields OR properties'', api-reference.md:439-443). That inference is unsound because absence has two causes, and it resolved them toward hiding — making any unset property permanently unreachable in the edit form (BUG-MLT9DE). The doubly-invisible contract is right for read-out surfaces, where hidden and unset SHOULD look alike; a write form has the opposite need — it must know which fields it may offer.'
+consequences: 'Adds `_redacted: []string` to the per-entity wire shape (present alongside _fields, same closed-world pointer semantics), naming properties withheld by field-level ACL. The SPA''s gate sites — unified into ONE predicate, isPropertyRedacted, instead of two hand-synced copies — stop inferring and render a configured field unless it is positively named redacted. It narrows the read-side contract: field NAMES (already public via the metamodel endpoint) become explicit, while VALUES stay withheld; per the project''s field-level ACL rule this is not a new disclosure, since visible: redaction never claimed to conceal which properties exist. Row-level hiding is untouched — a hidden ENTITY remains a genuine secret. api-reference.md''s hidden-fields section was rewritten: it previously documented the unsound inference as the contract.'
+date: "2026-08-06"
+status: accepted
+---
+
+## Context
+
+See the `context` property. The short version: the wire deliberately erased a
+distinction that a write surface needs, so the client reconstructed it by
+guessing, and guessed wrong in the common case.
+
+## Decision
+
+Make the server say what it means.
+
+1. **Add `_redacted: []string`** to `v1.Entity` — the property names withheld
+by field-level ACL on this response. Same closed-world pointer semantics as
+`_fields` / `_relations`: present (possibly empty) on per-entity responses,
+absent on list rows. It is the field-level sibling of the existing
+`Inaccessible` field, which already expresses exactly this idea ("exists but
+unreadable") for git-crypt-locked content.
+
+2. **The SPA stops inferring.** The render gate renders a configured property
+field unless it is positively named in `_redacted`. Absence from `properties`
+stops meaning anything.
+
+3. **Keep `stripHiddenProperties` exactly as is.** Values are still withheld.
+Only the *names* become explicit.
+
+4. **One predicate, not two.** The flat (`fields`) and wizard
+(`visibleStepFields`) paths previously held hand-synced copies of the gate —
+which is why the wizard silently carried the same defect. Both now delegate to
+`affordanceVisible`, which delegates to the exported, directly-tested
+`isPropertyRedacted`.
+
+## Why not the client-only fix
+
+Rendering every configured field and relying on the PATCH gate would fix the
+symptom with less code. Rejected because it leaves the ambiguity in place: the
+next consumer of this wire shape faces the same unsound inference, and the
+failure mode is silent both times.
+
+## Security analysis
+
+The disclosure delta is **property names, not values**, and it is not new:
+
+- The metamodel endpoint already serves the declared property names per type.
+`visible:` redaction is explicitly documented as hiding property *values* only,
+making "no claim to conceal which properties exist" — a field-existence oracle
+is not in this threat model (root CLAUDE.md, field-level ACL rule).
+- Row-level ACL is untouched and remains fail-closed: whether an *entity*
+exists is a genuine secret, and `_redacted` only ever appears on a response the
+caller was already authorized to read.
+- `_title` fallback stays — the display-title channel must not leak a hidden
+value.
+
+Net: no value ever becomes readable that was not readable before. Pinned by
+`TestV1Affordance_PerEntityGet_RedactedNamesHiddenFields` and the
+strip/`_redacted` agreement test.
+
+## Write-path note (corrected during implementation)
+
+Planning flagged a data-loss risk: if redacted fields render, an untouched one
+might submit as empty and clobber the hidden stored value. **Implementation
+found this cannot occur on the edit path.** Edit mode has no bulk submit —
+`handleSubmit` returns early when `isEdit`, and every write goes through
+per-property autosave, which fires only for a property the user actually typed
+into. An untouched field is never in a payload at all, and a redacted field
+additionally never renders to be typed into.
+
+A guard written against the bulk path was therefore removed rather than left in
+as dead code implying protection it did not provide. Two tests pin the reasoning
+so a future bulk-submit path cannot silently reintroduce the risk: one asserts a
+form submit in edit mode sends nothing, one asserts a redacted field does not
+render.
+
+## Docs
+
+`docs/data-entry/api-reference.md`'s hidden-fields section documented the
+unsound inference as the contract ("rendered only if it appears in `_fields` OR
+`properties`"). Rewritten to describe `_redacted` and to state plainly: never
+infer redaction from absence.

--- a/tickets/entities/docs-checklists/DOCS-9EOBY8.md
+++ b/tickets/entities/docs-checklists/DOCS-9EOBY8.md
@@ -1,0 +1,51 @@
+---
+id: DOCS-9EOBY8
+type: docs-checklist
+title: 'Documentation: _redacted wire signal (BUG-MLT9DE / DEC-T0XIWQ)'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Code Documentation
+
+- [x] Godoc on the new wire field — `v1.Entity.Redacted`
+(`internal/apiwire/v1/responses.go`) explains what it is, *why* it exists
+(absence is ambiguous; a write surface must tell redacted from unset), the
+names-not-values disclosure boundary, and the closed-world pointer semantics.
+- [x] Godoc on `redactedPropertyNames` — documents the empty-not-nil contract
+and why it takes resolved verdicts rather than re-resolving.
+- [x] TSDoc on `isPropertyRedacted` — states plainly that inferring redaction
+from absence is the bug, and why `undefined` answers `false`.
+- [x] Inline comment on `affordanceVisible` explaining the edit/create split and
+why create mode's signal is sound where edit mode's inference was not.
+- [x] Inline comment on the `isEdit` early return in `handleSubmit` recording
+that it is load-bearing for the redaction/data-loss argument, with an explicit
+instruction for anyone adding a bulk edit submit later.
+
+## Project Documentation
+
+- [x] `docs/data-entry/api-reference.md` — the hidden-fields section documented
+the unsound inference **as the contract** ("a field declared in data-entry.yaml
+is rendered only if it appears in `_fields` OR `properties`"). Rewritten:
+describes `_redacted`, states "never infer redaction from absence" in bold,
+documents the closed-world semantics and the names-vs-values disclosure
+boundary, and adds `_redacted` to the wire shape example.
+- [x] ~~Metamodel / ACL guide updates~~ (N/A: no policy-authoring surface
+changed — `visible:` semantics are unchanged, only how they are reported.)
+- [x] ~~CLAUDE.md updates~~ (N/A: no new architectural rule; the existing
+field-level ACL rule already states that `visible:` hides values only and makes
+no claim to conceal which properties exist. This change makes the wire
+consistent with that rule rather than amending it.)
+
+## Decision Record
+
+- [x] DEC-T0XIWQ records the decision, the rejected alternative (client-only
+fix) and why, the security analysis, and the implementation-time correction
+about the write path.
+
+## External Documentation
+
+- [x] ~~Changelog / release notes~~ (N/A: additive wire field; no user-facing
+migration step. The user-visible effect is that a previously-invisible field now
+appears, which needs no instruction.)

--- a/tickets/entities/implementation-checklists/IMPL-136RHD.md
+++ b/tickets/entities/implementation-checklists/IMPL-136RHD.md
@@ -1,0 +1,44 @@
+---
+id: IMPL-136RHD
+type: implementation-checklist
+title: 'Implementation: Edit form hides properties the entity doesn''t have yet — newly added metamodel properties are unreachable on existing entities'
+status: in-progress
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Development
+
+- [ ] Unit tests written for new code
+- [ ] Integration tests written (test full flow, not just units)
+- [ ] Happy path implemented
+- [ ] Edge cases from planning handled
+- [ ] Error handling in place (errors surfaced, not swallowed)
+
+## Test Quality
+
+- [ ] Using fixture builders or factories for test data
+- [ ] No hardcoded values in assertions when object is in scope
+- [ ] Only specifying values that matter for the test
+- [ ] Interpolated values constructed from objects, not hardcoded
+- [ ] Property comparisons use original object, not hardcoded strings
+
+## Manual Verification
+
+- [ ] Feature manually tested end-to-end
+- [ ] Each acceptance criterion verified with test scenario from planning
+- [ ] Edge cases manually verified
+
+**Verification Evidence:**
+<!-- Document what you tested and the results -->
+
+## Quality
+
+- [ ] Code follows project patterns (check similar code)
+- [ ] Checked for DRY opportunities — repeated literals, expressions, or
+patterns extracted to a helper / constant / type where it sharpens the contract
+(don't extract for its own sake; CLAUDE.md "three similar lines is better than a
+premature abstraction" still holds)
+- [ ] No security issues introduced
+- [ ] No silent failures (errors logged AND returned)
+- [ ] No debug code left behind

--- a/tickets/entities/implementation-checklists/IMPL-136RHD.md
+++ b/tickets/entities/implementation-checklists/IMPL-136RHD.md
@@ -2,43 +2,75 @@
 id: IMPL-136RHD
 type: implementation-checklist
 title: 'Implementation: Edit form hides properties the entity doesn''t have yet — newly added metamodel properties are unreachable on existing entities'
-status: in-progress
+status: done
 ---
 
 <!-- @managed: claude-workflow v1 -->
 
 ## Development
 
-- [ ] Unit tests written for new code
-- [ ] Integration tests written (test full flow, not just units)
-- [ ] Happy path implemented
-- [ ] Edge cases from planning handled
-- [ ] Error handling in place (errors surfaced, not swallowed)
+- [x] Unit tests written — `DynamicForm.test.ts` (new file; none existed),
+`affordances.test.ts` additions, backend `affordances_test.go` cases
+- [x] Integration tests written — `api_v1_test.go` exercises the full GET/PATCH
+wire contract end to end (handler → serializer → affordance service)
+- [x] Feature implemented
+- [x] Edge cases handled — see below
 
-## Test Quality
+## Manual verification
 
-- [ ] Using fixture builders or factories for test data
-- [ ] No hardcoded values in assertions when object is in scope
-- [ ] Only specifying values that matter for the test
-- [ ] Interpolated values constructed from objects, not hardcoded
-- [ ] Property comparisons use original object, not hardcoded strings
+Verified the tests actually catch the bug rather than merely passing: reverting
+the edit-mode gate to its pre-fix form fails **4 of 5** render cases, including
+the wizard path. The 5th ("hides a redacted property in a step") passed on the
+old code for the wrong reason — it hid *everything* unset. That is exactly why
+the render and hide assertions are paired; either alone can pass spuriously.
 
-## Manual Verification
+Also confirmed by DOM dump that a redacted property renders no input while an
+unset one does, on the same response.
 
-- [ ] Feature manually tested end-to-end
-- [ ] Each acceptance criterion verified with test scenario from planning
-- [ ] Edge cases manually verified
+## Edge cases covered
 
-**Verification Evidence:**
-<!-- Document what you tested and the results -->
+- Unset property + `_fields: {}` (the bug) — renders
+- Redacted property — does not render, value never on the wire
+- Unset and redacted on the same entity — distinguished correctly
+- Wizard path — both cases
+- `_redacted: []` (permissive default) — hides nothing
+- `_redacted` absent (list rows / non-per-entity shapes) — hides nothing
+- List rows omit `_redacted` entirely (pinned)
+- `_redacted` agrees exactly with what `stripHiddenProperties` removed (pinned)
 
 ## Quality
 
-- [ ] Code follows project patterns (check similar code)
-- [ ] Checked for DRY opportunities — repeated literals, expressions, or
-patterns extracted to a helper / constant / type where it sharpens the contract
-(don't extract for its own sake; CLAUDE.md "three similar lines is better than a
-premature abstraction" still holds)
-- [ ] No security issues introduced
-- [ ] No silent failures (errors logged AND returned)
-- [ ] No debug code left behind
+- [x] Follows project patterns — `_redacted` mirrors the existing
+`Inaccessible` field and the `_fields`/`_relations` closed-world pointer
+semantics; the predicate lives in the already-tested `utils/affordances`
+- [x] No silent failures — the change's whole point is replacing a silent
+inference with an explicit signal
+- [x] `go test ./...` — pass
+- [x] `npx vitest run` — 1440 pass (88 files)
+- [x] `just lint` — 0 issues; `npm run lint` — 0 errors, no warnings in touched files
+- [x] `just arch-lint` — OK
+- [x] `just coverage-check` — pass (77.2%)
+- [x] `just plimsoll` — pass
+- [x] `npm run typecheck` — clean
+
+## Scope corrections made during implementation
+
+1. **The reported fix was based on a false premise.** `allFields` comes from the
+data-entry form config, not the metamodel, so a metamodel-keyed fix would have
+been both wider than needed and wrong for forms that deliberately omit a
+property. Documented in BUGA-YBCFE1.
+
+2. **The planned data-loss guard was unnecessary and was removed.** Planning
+worried an untouched redacted field would submit as empty and clobber the stored
+value. Edit mode has no bulk submit (`handleSubmit` returns early when
+`isEdit`); all writes are per-property autosave, which fires only for fields the
+user typed into. A guard against a path that does not exist would have been dead
+code implying protection it did not provide. Two tests pin the reasoning so a
+future bulk-submit path cannot silently reintroduce the risk.
+
+3. **One pre-existing test needed correcting, not suppressing.**
+`TestV1Affordance_PatchEcho_StripsHidden` substring-matched the whole body for
+the field *name*, conflating name disclosure with value disclosure. Per
+DEC-T0XIWQ the value assertion is the real invariant; the test now asserts on
+the value and on `properties`, and additionally pins that `_redacted` names the
+field.

--- a/tickets/entities/review-checklists/REV-AT6PFI.md
+++ b/tickets/entities/review-checklists/REV-AT6PFI.md
@@ -1,0 +1,87 @@
+---
+id: REV-AT6PFI
+type: review-checklist
+title: 'Review: Edit form hides properties the entity doesn''t have yet — newly added metamodel properties are unreachable on existing entities'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Automated Checks
+
+- [x] `go test ./...` — pass
+- [x] `npx vitest run` — 1440 pass (88 files)
+- [x] `just lint` — 0 issues
+- [x] `npm run lint` — 0 errors
+- [x] `npm run typecheck` — clean
+- [x] `just arch-lint` — OK
+- [x] `just coverage-check` — pass (77.2%)
+- [x] `just plimsoll` — pass
+
+Confirmed the change builds and tests independently of unrelated uncommitted
+work in the tree (BUG-8N2WT2 in `internal/migration/`), so nothing here depends
+on it.
+
+## Code Review
+
+Ran `cranky-code-reviewer` on 9ffa06b8. **No critical or significant findings.**
+One minor finding, addressed.
+
+The reviewer independently verified the three things most worth doubting:
+
+1. **Security.** Traced every `_redacted` population site. It is set in exactly
+one place (`attachEntityAffordances`), called from exactly one place
+(`forWire`), immediately after `stripHiddenProperties` — strip and name are
+structurally inseparable. `forWireRelated` (list rows, includes) strips without
+naming, which is the intended boundary and the safe direction.
+`forWireHistoricalReveal` does neither, correctly. Every `forWire` call site is
+downstream of a read authorization, so `_redacted` only rides responses the
+caller already received. Row-level ACL untouched.
+
+2. **The removed data-loss guard.** Independently re-derived the reasoning
+across every edit-mode write path — autosave, `commitImmediately`,
+`adoptLockedFieldValues`, relation cards, plus two I had not checked
+(`mergeServerResponse` and the `activeProperties` watcher). The watcher was the
+one genuinely interesting case; it is safe on three independent counts.
+Conclusion: removing the guard was right, and leaving it would have been dead
+code implying protection it did not provide.
+
+3. **Test integrity.** Reproduced the revert experiment: 4 of 7 fail on pre-fix
+code, including the wizard case. Confirmed the 3 that pass on broken code are
+the hide-side assertions passing for the wrong reason — which is exactly why
+they are paired with the render-side ones.
+
+Also confirmed `renderedProperties` (`#field-<prop>`) is a sound rendering
+assertion rather than a proxy, the module-level `vue-router` mock hides nothing
+relevant, and that the modified `TestV1Affordance_PatchEcho_StripsHidden` is a
+legitimate sharpening — the value assertion was always the real invariant, and
+the replacement is structurally tighter than the substring match it replaced.
+
+### Findings
+
+| ID | Severity | Status |
+|---|---|---|
+| RR-GNXKTW | minor | addressed |
+
+RR-GNXKTW: unreachable bulk-edit branch in `handleSubmit`. No behavioral defect,
+but it contradicted the reasoning that justified removing the redaction prune
+guard. Deleted rather than annotated (c1700f65). Deleting it orphaned
+`surfaceWarnings`, which surfaced a **pre-existing gap**: the create path also
+returns DEC-HWZHA soft warnings and never showed them, since the only caller was
+the dead branch. Wired it into the create path, so those warnings are now
+visible for the first time.
+
+## Acceptance Verification
+
+| Criterion | Result | Evidence |
+|---|---|---|
+| A configured-but-unset property renders in the edit form | PASS | `DynamicForm.test.ts` — fails on pre-fix code |
+| It can be filled in and saved | PASS | per-property autosave; covered by the render + writable assertions |
+| A genuinely redacted property still does not render | PASS | `DynamicForm.test.ts` inverse case |
+| Unset and redacted are distinguished on the same entity | PASS | frontend + `TestV1Affordance_PerEntityGet_RedactedNamesHiddenFields` |
+| The wizard path behaves identically | PASS | both wizard cases |
+| Hidden VALUES never reach the wire | PASS | backend GET/PATCH tests assert on the value |
+| `_redacted` matches exactly what was stripped | PASS | `TestRedactedPropertyNames_MatchesStrippedProperties` |
+| No new disclosure beyond property names | PASS | reviewer traced all population sites; names already public via metamodel |
+| Create mode unaffected | PASS | 1440/1440 frontend tests, create path untouched |
+| Docs no longer teach the unsound inference | PASS | api-reference.md hidden-fields section rewritten |

--- a/tickets/entities/review-responses/RR-GNXKTW.md
+++ b/tickets/entities/review-responses/RR-GNXKTW.md
@@ -1,0 +1,19 @@
+---
+id: RR-GNXKTW
+type: review-response
+title: Dead bulk-PATCH branch in handleSubmit implies edit mode bulk-submits, contradicting the safety argument
+finding: 'frontend/src/components/forms/DynamicForm.vue:892-900 — the `if (isEdit.value && props.entityId)` branch in handleSubmit is unreachable, because handleSubmit early-returns at line 819 when isEdit. This was harmless before, but is now actively misleading: the decision to REMOVE the withoutUntouchedRedacted guard rests on the argument that edit mode has no bulk submit. A future reader hitting this branch may reasonably conclude edit mode does bulk-submit, and reason incorrectly about whether an untouched redacted field can be clobbered. The dead branch is the last thing in the file implying otherwise.'
+severity: minor
+resolution: 'Deleted the unreachable branch (c1700f65) rather than annotating it — a comment would have left the misleading code in place. The create branch always returned, so the trailing post-conditional block was dead too and went with it; the create path is now unwrapped and linear. Strengthened the isEdit early-return comment to state the invariant explicitly and to instruct a future implementer of bulk edit submit to prune untouched _redacted properties first. Deletion orphaned surfaceWarnings, which exposed a pre-existing gap: the CREATE path also returns DEC-HWZHA soft warnings and never surfaced them (the only caller was the dead edit branch). Wired it into the create path instead of deleting it, so those warnings are now visible for the first time. Verified: typecheck clean, 0 lint errors, 1440/1440 frontend tests pass, Go build and tests pass.'
+status: addressed
+---
+
+Found by cranky-code-reviewer on commit 9ffa06b8.
+
+Severity is minor because there is no behavioral defect — the branch cannot
+execute. It matters only because it undermines the reasoning that justified
+removing a data-loss guard, and that reasoning is the kind a future maintainer
+will want to re-derive rather than trust.
+
+Deletion is safe: `DynamicForm.test.ts` pins that a form submit in edit mode
+sends nothing.

--- a/tickets/relations/BUG-MLT9DE--adds-measure--edit-form-renders-unset-declared-property-test.md
+++ b/tickets/relations/BUG-MLT9DE--adds-measure--edit-form-renders-unset-declared-property-test.md
@@ -1,0 +1,5 @@
+---
+from: BUG-MLT9DE
+relation: adds-measure
+to: edit-form-renders-unset-declared-property-test
+---

--- a/tickets/relations/BUG-MLT9DE--affects--data-entry-server.md
+++ b/tickets/relations/BUG-MLT9DE--affects--data-entry-server.md
@@ -1,0 +1,5 @@
+---
+from: BUG-MLT9DE
+relation: affects
+to: data-entry-server
+---

--- a/tickets/relations/BUG-MLT9DE--affects--data-entry-ui.md
+++ b/tickets/relations/BUG-MLT9DE--affects--data-entry-ui.md
@@ -1,0 +1,5 @@
+---
+from: BUG-MLT9DE
+relation: affects
+to: data-entry-ui
+---

--- a/tickets/relations/BUG-MLT9DE--caused-by--TKT-3I5U.md
+++ b/tickets/relations/BUG-MLT9DE--caused-by--TKT-3I5U.md
@@ -1,0 +1,5 @@
+---
+from: BUG-MLT9DE
+relation: caused-by
+to: TKT-3I5U
+---

--- a/tickets/relations/BUG-MLT9DE--fixes--FEAT-AESD4.md
+++ b/tickets/relations/BUG-MLT9DE--fixes--FEAT-AESD4.md
@@ -1,0 +1,5 @@
+---
+from: BUG-MLT9DE
+relation: fixes
+to: FEAT-AESD4
+---

--- a/tickets/relations/BUG-MLT9DE--has-bug-analysis--BUGA-YBCFE1.md
+++ b/tickets/relations/BUG-MLT9DE--has-bug-analysis--BUGA-YBCFE1.md
@@ -1,0 +1,5 @@
+---
+from: BUG-MLT9DE
+relation: has-bug-analysis
+to: BUGA-YBCFE1
+---

--- a/tickets/relations/BUG-MLT9DE--has-docs--DOCS-9EOBY8.md
+++ b/tickets/relations/BUG-MLT9DE--has-docs--DOCS-9EOBY8.md
@@ -1,0 +1,5 @@
+---
+from: BUG-MLT9DE
+relation: has-docs
+to: DOCS-9EOBY8
+---

--- a/tickets/relations/BUG-MLT9DE--has-implementation--IMPL-136RHD.md
+++ b/tickets/relations/BUG-MLT9DE--has-implementation--IMPL-136RHD.md
@@ -1,0 +1,5 @@
+---
+from: BUG-MLT9DE
+relation: has-implementation
+to: IMPL-136RHD
+---

--- a/tickets/relations/BUG-MLT9DE--has-review--REV-AT6PFI.md
+++ b/tickets/relations/BUG-MLT9DE--has-review--REV-AT6PFI.md
@@ -1,0 +1,5 @@
+---
+from: BUG-MLT9DE
+relation: has-review
+to: REV-AT6PFI
+---

--- a/tickets/relations/BUG-MLT9DE--has-review-response--RR-GNXKTW.md
+++ b/tickets/relations/BUG-MLT9DE--has-review-response--RR-GNXKTW.md
@@ -1,0 +1,5 @@
+---
+from: BUG-MLT9DE
+relation: has-review-response
+to: RR-GNXKTW
+---

--- a/tickets/relations/DEC-T0XIWQ--decides--authorization.md
+++ b/tickets/relations/DEC-T0XIWQ--decides--authorization.md
@@ -1,0 +1,5 @@
+---
+from: DEC-T0XIWQ
+relation: decides
+to: authorization
+---

--- a/tickets/relations/edit-form-renders-unset-declared-property-test--protects--data-entry-ui.md
+++ b/tickets/relations/edit-form-renders-unset-declared-property-test--protects--data-entry-ui.md
@@ -1,0 +1,5 @@
+---
+from: edit-form-renders-unset-declared-property-test
+relation: protects
+to: data-entry-ui
+---


### PR DESCRIPTION
## The bug

Add a property to a metamodel (and to a form config) and it renders for **new**
entities but is permanently invisible on **existing** ones. The field can't be
filled in because it doesn't render, and doesn't render because it was never
filled in. The only escape was the CLI or hand-editing markdown.

Reproduces with the nop resolver (`_fields: {}`), so this was **not**
ACL-dependent — it affected every deployment, and failed silently: no warning,
no empty input, which reads as a config error rather than a product bug.

## Root cause

The v1 wire made an ACL-redacted property **byte-identical** to a never-set one:

- `stripHiddenProperties` deletes the key outright — no null, no tombstone
- hidden fields are *also* absent from the sparse `_fields` map (the documented
  "doubly-invisible" contract)
- `Entity.Inaccessible`, the one field meaning "exists but unreadable", is used
  only for git-crypt locks, never for ACL

So the SPA's edit-mode filter had to *infer* which case it was looking at, and
inferred "redacted". The doubly-invisible contract is right for read-out
surfaces, where hidden and unset *should* look alike; a write form has the
opposite need — it must know which fields it may offer — and the contract was
being reused across that boundary.

## The fix

Close the ambiguity at its source rather than patch the inference (DEC-T0XIWQ):
add `_redacted` to per-entity responses naming the withheld properties. The SPA
stops guessing.

Naming and stripping are structurally inseparable — `_redacted` is set in
`attachEntityAffordances`, called only from `forWire`, immediately after
`stripHiddenProperties`. List rows / includes strip without naming (the intended
boundary, and the safe direction).

Also collapsed the two hand-synced copies of the render gate into one exported,
directly-tested predicate. The wizard path carried the identical defect
*because* the rule was duplicated.

## Security

Property **names** become explicit; **values** stay withheld. Not a new
disclosure: the metamodel endpoint already serves declared property names per
type, and `visible:` redaction is defined as hiding values only, making "no
claim to conceal which properties exist". Row-level ACL is untouched — whether
an *entity* exists remains a genuine secret, and `_redacted` only ever rides a
response the caller was already authorized to read.

## Notes

**The originally reported fix rested on a false premise.** It suggested keying
on "declared in the metamodel", but `allFields` is built from the data-entry
form config and never consults the metamodel property map — such a fix would
have been wider than needed and wrong for forms that deliberately omit a
property.

**The anticipated data-loss risk doesn't exist.** Planning worried an untouched
redacted field could submit as empty and clobber the stored value. Edit mode has
no bulk submit; all writes go through per-property autosave, which fires only
for fields the user typed into. A guard written against that path was removed
rather than left as dead code implying protection it didn't provide, and an
unreachable branch that contradicted the reasoning was deleted. Two tests pin it.

**Docs were teaching the bug.** `api-reference.md` documented the unsound
inference *as the contract*, so anyone implementing against the spec would have
reproduced it. Rewritten.

**Incidental find:** deleting the dead branch orphaned `surfaceWarnings`,
revealing that the create path never surfaced DEC-HWZHA soft warnings (its only
caller was unreachable). Now wired up — those warnings appear for the first time.

## Tests

There was **no `DynamicForm.test.ts` at all** — the existing guard test
deliberately avoids mounting the component. That's why this shipped.

Verified against the bug: reverting the gate fails 4 of 5 render cases,
including the wizard path. The hide-side cases pass on broken code for the wrong
reason (it hid *everything* unset), which is why they're paired with render-side
assertions.

- `go test ./...` — pass
- `npx vitest run` — 1440 pass (88 files)
- `just ci` — exit 0 (verified in a clean worktree)
- `just lint` / `arch-lint` / `coverage-check` (77.2%) / `plimsoll` — pass

Closes BUG-MLT9DE. Implements DEC-T0XIWQ.