### PR TITLE
feat(dataentry): `permission:` on a navigation entry hides it from the sidebar (TKT-TXDK8U)

### DIFF
--- a/docs-project/entities/guides/GUIDE-acl-security.md
+++ b/docs-project/entities/guides/GUIDE-acl-security.md
@@ -583,12 +583,25 @@ caches from leaking one principal's view to another:
 ### Sidebar menu structure is principal-independent
 
 The sidebar's *structure* (groups, labels, links) reveals metamodel
-shape, not data shape, and is served identically to every principal —
-only the *counts* are gated. Hiding whole menu entries per principal
-is a possible future tightening, deliberately not done here: the
-metamodel is not a secret (it's served by `/api/v1/_schema`), and a
-divergent menu per principal complicates SPA caching for no
-confidentiality gain today.
+shape, not data shape. It is served identically to every principal
+**except** for entries an operator explicitly marks with a
+`permission:` (see GUIDE-data-entry, "Hiding entries a user cannot act
+on"); the *counts* are gated per principal as always.
+
+That exception is a **UX convenience and is not a confidentiality
+control** — the distinction matters, because the reasoning that once
+argued against per-principal menus still holds:
+
+- The metamodel is not a secret; it is served by `/api/v1/_schema`.
+- Neither is the navigation config: `/api/v1/_config` serves the whole
+  tree, `permission:` values included, to every principal.
+- A hidden entry's target enforces exactly what it enforced before. Type
+  the URL and you reach it; a list still returns its ACL-scoped rows,
+  which for a principal permitted to read none of them is an empty list.
+
+So `permission:` on a nav entry buys tidiness, not protection. Never
+reach for it in place of a read grant, and never assume an entry's
+absence means a principal cannot get at what it points to.
 
 ### Sidebar config-filter performance caveat
 

--- a/docs-project/entities/guides/GUIDE-data-entry.md
+++ b/docs-project/entities/guides/GUIDE-data-entry.md
@@ -1500,6 +1500,7 @@ navigation:
 | `dashboard` | bool   | Link to the dashboard page                                     |
 | `graph`     | bool   | Link to the graph explorer                                     |
 | `action`    | string | Action ID to trigger when clicked (renders as a sidebar button)|
+| `permission`| string | Hide this entry from users who lack the named ACL permission (see below) |
 
 ### Groups
 
@@ -1522,6 +1523,46 @@ inside the first group. Order matters; items appear in the sidebar in the order 
 
 List entries show an entity count badge next to the label (based on the list's filters). Dashboard
 and graph entries do not show a count.
+
+### Hiding entries a user cannot act on (`permission:`)
+
+An entry with a `permission:` is omitted from the sidebar for principals who do
+not hold that permission — a global named permission granted through a role's
+`permissions:` list in `acl.yaml`, the same mechanism behind `history:read` and
+the `delegate-*` family:
+
+```yaml
+navigation:
+  - label: "Tickets"
+    list: all_tickets
+  - label: "Audit log"
+    list: audit_log
+    permission: admin:read      # only holders see this entry
+  - group: "Admin"
+    items:
+      - label: "Settings"
+        settings: true
+        permission: admin:settings
+```
+
+A group whose every item is hidden disappears with them, so you never get a
+heading with nothing under it. `permission:` is not valid **on** a group —
+gate the items instead.
+
+Behaviour without a policy: with no `acl.yaml`, every entry is shown. Nothing
+is denied when nothing is configured. Under `--read-only`, entries carrying a
+`permission:` are hidden, since the principal cannot act on anything.
+
+**This is a convenience, not a security control.** It keeps menu entries a user
+cannot act on out of their way; it does not protect anything. The target of a
+hidden entry behaves exactly as it always did — type its URL and you reach it,
+and a list still returns its ACL-scoped rows, which for someone permitted to
+read none of them is simply an empty list. Nor is anything concealed:
+`/api/v1/_config` serves the whole navigation tree to every principal.
+
+So do not use `permission:` here *instead of* real access control. What
+protects your data is the read ACL on the entities themselves; this only
+decides what appears in a menu.
 
 Direct items and groups can be freely mixed in any order.
 

--- a/docs-project/entities/guides/GUIDE-data-entry.md
+++ b/docs-project/entities/guides/GUIDE-data-entry.md
@@ -1469,7 +1469,7 @@ kanbans:
 ## Navigation
 
 The navigation section defines the sidebar menu. Each entry is either a direct item (linking to a
-list, dashboard, or graph) or a **group** containing multiple items:
+list, kanban, dashboard, search or settings page) or a **group** containing multiple items:
 
 ```yaml
 navigation:
@@ -1486,8 +1486,8 @@ navigation:
     items:
       - label: "Categories"
         list: categories
-  - label: "Graph Explorer"
-    graph: true
+  - label: "Search"
+    search: true
 ```
 
 ### Direct Items
@@ -1498,7 +1498,8 @@ navigation:
 | `list`      | string | List name to navigate to (mutually exclusive with other types) |
 | `kanban`    | string | Kanban board name to navigate to                               |
 | `dashboard` | bool   | Link to the dashboard page                                     |
-| `graph`     | bool   | Link to the graph explorer                                     |
+| `search`    | bool   | Link to the search page                                        |
+| `settings`  | bool   | Link to the settings page                                      |
 | `action`    | string | Action ID to trigger when clicked (renders as a sidebar button)|
 | `permission`| string | Hide this entry from users who lack the named ACL permission (see below) |
 
@@ -1521,8 +1522,8 @@ will reject it with a clear error message.
 The first navigable entry is the default landing page — the first direct item, or the first item
 inside the first group. Order matters; items appear in the sidebar in the order listed.
 
-List entries show an entity count badge next to the label (based on the list's filters). Dashboard
-and graph entries do not show a count.
+List and kanban entries show an entity count badge next to the label (based on their filters).
+Dashboard, search and settings entries do not show a count.
 
 ### Hiding entries a user cannot act on (`permission:`)
 
@@ -1549,9 +1550,11 @@ A group whose every item is hidden disappears with them, so you never get a
 heading with nothing under it. `permission:` is not valid **on** a group —
 gate the items instead.
 
-Behaviour without a policy: with no `acl.yaml`, every entry is shown. Nothing
-is denied when nothing is configured. Under `--read-only`, entries carrying a
-`permission:` are hidden, since the principal cannot act on anything.
+Behaviour without a policy: with no `acl.yaml`, every entry is shown — nothing
+is denied when nothing is configured. The same applies under `--read-only`,
+which restricts *writes* and leaves reads untouched, so there is no permission
+model to consult and no reason to hide read surfaces from an observe-only
+operator.
 
 **This is a convenience, not a security control.** It keeps menu entries a user
 cannot act on out of their way; it does not protect anything. The target of a
@@ -1563,6 +1566,12 @@ read none of them is simply an empty list. Nor is anything concealed:
 So do not use `permission:` here *instead of* real access control. What
 protects your data is the read ACL on the entities themselves; this only
 decides what appears in a menu.
+
+One caveat worth knowing: the permission name is **not** checked against
+`acl.yaml` at config load (the same is true of `commands:` and `documents:`).
+A typo like `admin:raed` produces an entry nobody can see, with no error. If a
+menu item has vanished, check the spelling against the `permissions:` list on
+your roles first.
 
 Direct items and groups can be freely mixed in any order.
 

--- a/docs/acl-security.md
+++ b/docs/acl-security.md
@@ -577,12 +577,25 @@ caches from leaking one principal's view to another:
 ### Sidebar menu structure is principal-independent
 
 The sidebar's *structure* (groups, labels, links) reveals metamodel
-shape, not data shape, and is served identically to every principal —
-only the *counts* are gated. Hiding whole menu entries per principal
-is a possible future tightening, deliberately not done here: the
-metamodel is not a secret (it's served by `/api/v1/_schema`), and a
-divergent menu per principal complicates SPA caching for no
-confidentiality gain today.
+shape, not data shape. It is served identically to every principal
+**except** for entries an operator explicitly marks with a
+`permission:` (see GUIDE-data-entry, "Hiding entries a user cannot act
+on"); the *counts* are gated per principal as always.
+
+That exception is a **UX convenience and is not a confidentiality
+control** — the distinction matters, because the reasoning that once
+argued against per-principal menus still holds:
+
+- The metamodel is not a secret; it is served by `/api/v1/_schema`.
+- Neither is the navigation config: `/api/v1/_config` serves the whole
+  tree, `permission:` values included, to every principal.
+- A hidden entry's target enforces exactly what it enforced before. Type
+  the URL and you reach it; a list still returns its ACL-scoped rows,
+  which for a principal permitted to read none of them is an empty list.
+
+So `permission:` on a nav entry buys tidiness, not protection. Never
+reach for it in place of a read grant, and never assume an entry's
+absence means a principal cannot get at what it points to.
 
 ### Sidebar config-filter performance caveat
 

--- a/docs/data-entry.md
+++ b/docs/data-entry.md
@@ -1463,7 +1463,7 @@ kanbans:
 ## Navigation
 
 The navigation section defines the sidebar menu. Each entry is either a direct item (linking to a
-list, dashboard, or graph) or a **group** containing multiple items:
+list, kanban, dashboard, search or settings page) or a **group** containing multiple items:
 
 ```yaml
 navigation:
@@ -1480,8 +1480,8 @@ navigation:
     items:
       - label: "Categories"
         list: categories
-  - label: "Graph Explorer"
-    graph: true
+  - label: "Search"
+    search: true
 ```
 
 ### Direct Items
@@ -1492,7 +1492,8 @@ navigation:
 | `list`      | string | List name to navigate to (mutually exclusive with other types) |
 | `kanban`    | string | Kanban board name to navigate to                               |
 | `dashboard` | bool   | Link to the dashboard page                                     |
-| `graph`     | bool   | Link to the graph explorer                                     |
+| `search`    | bool   | Link to the search page                                        |
+| `settings`  | bool   | Link to the settings page                                      |
 | `action`    | string | Action ID to trigger when clicked (renders as a sidebar button)|
 | `permission`| string | Hide this entry from users who lack the named ACL permission (see below) |
 
@@ -1515,8 +1516,8 @@ will reject it with a clear error message.
 The first navigable entry is the default landing page — the first direct item, or the first item
 inside the first group. Order matters; items appear in the sidebar in the order listed.
 
-List entries show an entity count badge next to the label (based on the list's filters). Dashboard
-and graph entries do not show a count.
+List and kanban entries show an entity count badge next to the label (based on their filters).
+Dashboard, search and settings entries do not show a count.
 
 ### Hiding entries a user cannot act on (`permission:`)
 
@@ -1543,9 +1544,11 @@ A group whose every item is hidden disappears with them, so you never get a
 heading with nothing under it. `permission:` is not valid **on** a group —
 gate the items instead.
 
-Behaviour without a policy: with no `acl.yaml`, every entry is shown. Nothing
-is denied when nothing is configured. Under `--read-only`, entries carrying a
-`permission:` are hidden, since the principal cannot act on anything.
+Behaviour without a policy: with no `acl.yaml`, every entry is shown — nothing
+is denied when nothing is configured. The same applies under `--read-only`,
+which restricts *writes* and leaves reads untouched, so there is no permission
+model to consult and no reason to hide read surfaces from an observe-only
+operator.
 
 **This is a convenience, not a security control.** It keeps menu entries a user
 cannot act on out of their way; it does not protect anything. The target of a
@@ -1557,6 +1560,12 @@ read none of them is simply an empty list. Nor is anything concealed:
 So do not use `permission:` here *instead of* real access control. What
 protects your data is the read ACL on the entities themselves; this only
 decides what appears in a menu.
+
+One caveat worth knowing: the permission name is **not** checked against
+`acl.yaml` at config load (the same is true of `commands:` and `documents:`).
+A typo like `admin:raed` produces an entry nobody can see, with no error. If a
+menu item has vanished, check the spelling against the `permissions:` list on
+your roles first.
 
 Direct items and groups can be freely mixed in any order.
 

--- a/docs/data-entry.md
+++ b/docs/data-entry.md
@@ -1494,6 +1494,7 @@ navigation:
 | `dashboard` | bool   | Link to the dashboard page                                     |
 | `graph`     | bool   | Link to the graph explorer                                     |
 | `action`    | string | Action ID to trigger when clicked (renders as a sidebar button)|
+| `permission`| string | Hide this entry from users who lack the named ACL permission (see below) |
 
 ### Groups
 
@@ -1516,6 +1517,46 @@ inside the first group. Order matters; items appear in the sidebar in the order 
 
 List entries show an entity count badge next to the label (based on the list's filters). Dashboard
 and graph entries do not show a count.
+
+### Hiding entries a user cannot act on (`permission:`)
+
+An entry with a `permission:` is omitted from the sidebar for principals who do
+not hold that permission — a global named permission granted through a role's
+`permissions:` list in `acl.yaml`, the same mechanism behind `history:read` and
+the `delegate-*` family:
+
+```yaml
+navigation:
+  - label: "Tickets"
+    list: all_tickets
+  - label: "Audit log"
+    list: audit_log
+    permission: admin:read      # only holders see this entry
+  - group: "Admin"
+    items:
+      - label: "Settings"
+        settings: true
+        permission: admin:settings
+```
+
+A group whose every item is hidden disappears with them, so you never get a
+heading with nothing under it. `permission:` is not valid **on** a group —
+gate the items instead.
+
+Behaviour without a policy: with no `acl.yaml`, every entry is shown. Nothing
+is denied when nothing is configured. Under `--read-only`, entries carrying a
+`permission:` are hidden, since the principal cannot act on anything.
+
+**This is a convenience, not a security control.** It keeps menu entries a user
+cannot act on out of their way; it does not protect anything. The target of a
+hidden entry behaves exactly as it always did — type its URL and you reach it,
+and a list still returns its ACL-scoped rows, which for someone permitted to
+read none of them is simply an empty list. Nor is anything concealed:
+`/api/v1/_config` serves the whole navigation tree to every principal.
+
+So do not use `permission:` here *instead of* real access control. What
+protects your data is the read ACL on the entities themselves; this only
+decides what appears in a menu.
 
 Direct items and groups can be freely mixed in any order.
 

--- a/frontend/src/types/config.ts
+++ b/frontend/src/types/config.ts
@@ -327,7 +327,14 @@ export interface NavigationEntry {
   list?: string
   dashboard?: boolean
   kanban?: string
+  search?: boolean
+  settings?: boolean
   action?: string
+  /** Global named permission required for this entry to appear in the sidebar.
+   *  The SPA does not act on it — the server already omits filtered entries
+   *  from /_sidebar, which is what the menu is built from. Present here only
+   *  because /_config serves the navigation tree verbatim. */
+  permission?: string
   icon?: string
   // Group fields
   group?: string

--- a/internal/dataentry/CLAUDE.md
+++ b/internal/dataentry/CLAUDE.md
@@ -65,6 +65,29 @@ Rules for new write affordances in the Vue SPA (`frontend/`):
   plus a `perItemVerbs`/`perCollectionVerbs` update, and (b) the inline
   `v-if` on the component. No ESLint enforcement; code review catches drift.
 
+## Sidebar navigation filtering (`permission:` on a nav entry)
+
+`permitsNavEntry` (`views_handler.go`) omits entries the principal cannot use
+from `/_sidebar`. Rules for new code:
+
+- **It is a UX filter, not a boundary.** Nothing downstream may rely on an
+  entry being hidden. The target enforces what it always did, and
+  `TestNavPermission_FilterIsPresentationOnly` asserts precisely that. Same
+  rule as `_actions` above.
+- **Do NOT filter `/_config`.** It serves the navigation tree verbatim, on
+  purpose (root CLAUDE.md, "The configuration is not a secret; the data is").
+  Filtering it would be concealment-shaped, and an earlier attempt at exactly
+  that was reverted in TKT-M1AX6P. `TestNavPermission_ConfigUnfiltered` pins it.
+- **The ReadOnlyACL arm is load-bearing.** `readGateFromContext` returns
+  `nopReadGate` under ReadOnlyACL *and* NopACL, and its `HoldsPermission`
+  returns true — so a predicate written against the read gate alone fails OPEN
+  under `--read-only`. That is the RR-CWWJGW shape. Keep the explicit arm ahead
+  of the gate; `TestNavPermission_ReadOnlyHides` is the canary. Match value
+  **and** pointer forms — `AuthorizeWrite` has a value receiver.
+- **The switch stays closed.** A new `acl.ACL` implementation hides gated
+  entries until someone adds an arm; the failure mode of forgetting should be a
+  missing menu item, not an unintended one.
+
 ## Custom apps (`apps/<id>/` + `_apps/{id}/...` + the bridge)
 
 User-authored apps served in a sandboxed iframe. An app is a **folder**

--- a/internal/dataentry/acl_sidebar_test.go
+++ b/internal/dataentry/acl_sidebar_test.go
@@ -158,8 +158,19 @@ func TestACLSidebar_DenyAllZeroCounts(t *testing.T) {
 
 	counts := sidebarCountsByLabel(gateCtxFor(principalCtx("mallory"), t, d), t, app)
 	for _, label := range []string{"All", "Open", "Board"} {
-		if counts[label] != 0 {
-			t.Errorf("%s count = %d for deny-all principal, want 0", label, counts[label])
+		// Assert PRESENCE explicitly. sidebarCountsByLabel builds a map, so a
+		// missing key reads as 0 and a bare `counts[label] != 0` check would
+		// pass vacuously if the entry vanished from the sidebar entirely.
+		// These entries carry no `permission:` and so are never filtered
+		// (TKT-TXDK8U) — this makes that a tested property rather than a
+		// coincidence.
+		count, present := counts[label]
+		if !present {
+			t.Errorf("%s missing from the sidebar; an unfiltered entry must always appear", label)
+			continue
+		}
+		if count != 0 {
+			t.Errorf("%s count = %d for deny-all principal, want 0", label, count)
 		}
 	}
 }

--- a/internal/dataentry/app.go
+++ b/internal/dataentry/app.go
@@ -813,6 +813,8 @@ func NewApp(
 		services:    app.Services,
 		logo:        logo,
 		gateRead:    app.gateReadOrNotFound,
+		// Late-bound: tests reassign app.acl after construction.
+		aclImpl: func() acl.ACL { return app.acl },
 	}
 
 	// commandHandler owns the user-configured command surface. Its

--- a/internal/dataentry/lint_test.go
+++ b/internal/dataentry/lint_test.go
@@ -64,3 +64,59 @@ func TestNoStrayWriteRequestConstruction(t *testing.T) {
 		t.Fatalf("walk: %v", err)
 	}
 }
+
+// TestNavFilterStaysPresentational is the structural guard for the sidebar
+// navigation filter (TKT-TXDK8U).
+//
+// `permitsNavEntry` decides which nav entries appear in /_sidebar. That is a
+// UX affordance: it enforces nothing, and every target re-checks independently.
+// Calling it from anywhere else — a read path, a write path, a second endpoint
+// — would quietly turn a menu-tidying helper into an authorization decision,
+// and the endpoint it "protected" would be gated by a predicate designed for
+// presentation.
+//
+// This is a live risk, not a hypothetical: an earlier attempt at menu filtering
+// was reverted (TKT-M1AX6P) precisely because it drifted toward being treated
+// as concealment. A prose rule in CLAUDE.md failed to prevent that; a grep test
+// does not decay.
+//
+// Genuinely need the predicate elsewhere? That is the moment to stop and ask
+// whether you want an authorization check instead — and if so, to build one
+// (see authorizeCommand), not to reuse this.
+func TestNavFilterStaysPresentational(t *testing.T) {
+	const allowedFile = "views_handler.go"
+	const needle = "permitsNavEntry("
+
+	root, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+
+	err = filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		base := filepath.Base(path)
+		if !strings.HasSuffix(base, ".go") || strings.HasSuffix(base, "_test.go") {
+			return nil
+		}
+		if filepath.Dir(path) != root || base == allowedFile {
+			return nil
+		}
+		body, readErr := os.ReadFile(path)
+		if readErr != nil {
+			return readErr
+		}
+		if strings.Contains(string(body), needle) {
+			t.Errorf("file %s calls %q — the sidebar filter is presentation only and must stay in %s; "+
+				"if you need an authorization check, build one (see authorizeCommand)", path, needle, allowedFile)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk: %v", err)
+	}
+}

--- a/internal/dataentry/nav_permission_test.go
+++ b/internal/dataentry/nav_permission_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Sourcehaven-BV/rela/internal/acl"
 	v1 "github.com/Sourcehaven-BV/rela/internal/apiwire/v1"
 	"github.com/Sourcehaven-BV/rela/internal/dataentryconfig"
+	"github.com/Sourcehaven-BV/rela/internal/entity"
 )
 
 // sidebarShape performs a sidebar request and returns the groups as
@@ -178,45 +179,72 @@ func TestNavPermission_NonHolderFiltered(t *testing.T) {
 	}
 }
 
-// TestNavPermission_ReadOnlyHides covers AC5, and is the canary for the
-// RR-CWWJGW hazard.
+// TestNavPermission_ReadOnlyShowsEverything pins the read-only case, which is
+// the one place the obvious answer is wrong in two directions at once.
 //
-// readGateFromContext returns nopReadGate under ReadOnlyACL exactly as it does
-// under NopACL, and nopReadGate.HoldsPermission returns true unconditionally.
-// A predicate written against the read gate alone therefore SHOWS every gated
-// entry under --read-only. permitsNavEntry has an explicit ReadOnlyACL arm
-// ahead of the gate; this test fails if someone removes it.
-func TestNavPermission_ReadOnlyHides(t *testing.T) {
+// acl.ReadOnlyACL denies WRITES; it restricts no reads at all. Nav entries are
+// overwhelmingly read surfaces, so hiding them would remove entries an
+// observe-only principal can use — and, since ReadOnlyACL carries no identity,
+// would hide them from EVERYONE rather than from non-holders. A `permission:`
+// would then mean something different depending on a process-wide flag about
+// writes. Losing the audit-log entry in post-incident forensic mode (a
+// documented ReadOnlyACL use case) is the concrete cost.
+//
+// So read-only behaves like NopACL: no policy, no permission model, nothing
+// hidden. Copying authorizeCommand's deny arm here would be wrong — commands
+// shell out, which is write-shaped; a menu link is not.
+func TestNavPermission_ReadOnlyShowsEverything(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		impl acl.ACL
+	}{
+		// Both forms: AuthorizeWrite has a value receiver, so &ReadOnlyACL{}
+		// also satisfies acl.ACL, and matching only the value form has
+		// previously let a pointer slip into a default arm in this package.
+		{"value form", acl.ReadOnlyACL{}},
+		{"pointer form", &acl.ReadOnlyACL{}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			app := newTestAppV1(t)
+			installGatedNavConfig(app)
+			app.acl = tc.impl
+
+			labels := sidebarLabels(t.Context(), t, app)
+			for _, want := range []string{"Open", "Audit", "Secrets", "Keys", "Public", "Private"} {
+				if !slices.Contains(labels, want) {
+					t.Errorf("--read-only restricts writes, not reads; %q must stay visible, got %v",
+						want, labels)
+				}
+			}
+		})
+	}
+}
+
+// TestNavPermission_ReadOnlyArmIsExplicit is the RR-CWWJGW canary.
+//
+// Under ReadOnlyACL no middleware attaches a read gate, so readGateFromContext
+// returns nopReadGate, whose HoldsPermission returns true unconditionally. A
+// predicate that fell THROUGH to the read gate would therefore also show every
+// gated entry — the same answer this feature wants, reached by accident.
+//
+// This test pins that the answer comes from the explicit arm instead: with a
+// gate on the context that denies everything, read-only must STILL show the
+// entries. If someone deletes the ReadOnlyACL arm, the *Declarative path is
+// not taken (ReadOnlyACL is not *Declarative) and the default arm hides them —
+// this fails. It is the difference between "correct" and "accidentally
+// correct", which matters because this predicate is a copy target.
+func TestNavPermission_ReadOnlyArmIsExplicit(t *testing.T) {
 	app := newTestAppV1(t)
 	installGatedNavConfig(app)
 	app.acl = acl.ReadOnlyACL{}
 
-	labels := sidebarLabels(t.Context(), t, app)
-	for _, unwanted := range []string{"Audit", "Secrets", "Keys", "Private"} {
-		if slices.Contains(labels, unwanted) {
-			t.Errorf("under --read-only a permission-gated entry must be hidden; %q present in %v",
-				unwanted, labels)
-		}
-	}
-	for _, want := range []string{"Open", "Public"} {
-		if !slices.Contains(labels, want) {
-			t.Errorf("ungated entry %q must stay visible under --read-only, got %v", want, labels)
-		}
-	}
-}
+	// A gate that denies every permission. If the arm were removed and the
+	// predicate consulted the gate, this would hide the entries.
+	ctx := withReadGate(t.Context(), permGate{perms: map[string]bool{}})
 
-// TestNavPermission_ReadOnlyHides_PointerForm pins the &-reachable variant of
-// the same arm. acl.ReadOnlyACL's AuthorizeWrite has a value receiver, so
-// &acl.ReadOnlyACL{} also satisfies acl.ACL; matching only the value form once
-// let a pointer fall through to the default arm elsewhere in this package.
-func TestNavPermission_ReadOnlyHides_PointerForm(t *testing.T) {
-	app := newTestAppV1(t)
-	installGatedNavConfig(app)
-	app.acl = &acl.ReadOnlyACL{}
-
-	labels := sidebarLabels(t.Context(), t, app)
-	if slices.Contains(labels, "Audit") {
-		t.Errorf("&acl.ReadOnlyACL{} must hide gated entries too, got %v", labels)
+	labels := sidebarLabels(ctx, t, app)
+	if !slices.Contains(labels, "Audit") {
+		t.Errorf("the ReadOnlyACL arm must decide before any read-gate call, got %v", labels)
 	}
 }
 
@@ -236,35 +264,76 @@ func TestNavPermission_NilACLHides(t *testing.T) {
 	}
 }
 
-// TestNavPermission_FilterIsPresentationOnly covers AC8: hiding an entry
-// changes NO enforcement. The list behind a hidden entry answers a direct
-// request exactly as it did before — for this principal, with its normal
-// ACL-scoped rows.
+// TestNavPermission_FilterIsPresentationOnly covers AC8, and is the assertion
+// the whole "UX, not security" claim rests on. It has to fail if anyone ever
+// wires the nav filter into enforcement, so it tests the two cases where the
+// menu and the data could diverge — in BOTH directions:
 //
-// This is the assertion that keeps the feature honest. If someone ever makes
-// the sidebar filter load-bearing, this test is what should stop them.
+//   - bob is denied the *permission* but permitted the *data*: the entry is
+//     hidden and the list still returns its rows. Hiding gates nothing.
+//   - carol holds the *permission* but is denied the *data*: the entry is
+//     shown and the list comes back empty. Data-gating gates no menu.
+//
+// The rows assertion is the load-bearing half. Asserting only a 200 would pass
+// vacuously — handleV1ListEntities has no knowledge of navigation config, so
+// "the status is unchanged" is true by construction and survives any mutation
+// of permitsNavEntry.
 func TestNavPermission_FilterIsPresentationOnly(t *testing.T) {
 	app := newTestAppV1(t)
 	installGatedNavConfig(app)
-	d := mustNewACL(t, gatedNavPolicy(), app.store)
+	seedEntity(app, &entity.Entity{
+		ID: "TKT-501", Type: "ticket", Properties: map[string]any{"title": "visible"},
+	})
+
+	d := mustNewACL(t, &acl.Policy{
+		Roles: map[string]acl.RoleDef{
+			// bob: may read tickets, holds no permission.
+			"viewer": {Read: []string{"ticket"}},
+			// carol: holds the permission, may read NOTHING.
+			"auditor": {Permissions: []string{"admin:read"}},
+		},
+		Assignments: map[string]string{"bob": "viewer", "carol": "auditor"},
+	}, app.store)
 	app.acl = d
 
-	ctx := gateCtxFor(principalCtx("bob"), t, d)
-
-	// The entry is hidden…
-	if slices.Contains(sidebarLabels(ctx, t, app), "Audit") {
-		t.Fatalf("precondition: the Audit entry should be hidden for bob")
+	rowsFor := func(t *testing.T, ctx context.Context) int {
+		t.Helper()
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/tickets", http.NoBody).WithContext(ctx)
+		rec := httptest.NewRecorder()
+		app.handleV1ListEntities(rec, req, "ticket", "tickets")
+		if rec.Code != http.StatusOK {
+			t.Fatalf("list: got %d, want 200; body=%s", rec.Code, rec.Body)
+		}
+		var resp struct {
+			Data []struct {
+				ID string `json:"id"`
+			} `json:"data"`
+		}
+		if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+			t.Fatalf("decode list: %v\nbody: %s", err, rec.Body)
+		}
+		return len(resp.Data)
 	}
 
-	// …and its target is untouched: same status as the ungated list that
-	// points at the identical config, because the filter enforces nothing.
-	req := httptest.NewRequest(http.MethodGet, "/api/v1/tickets", http.NoBody).WithContext(ctx)
-	rec := httptest.NewRecorder()
-	app.handleV1ListEntities(rec, req, "ticket", "tickets")
-	if rec.Code != http.StatusOK {
-		t.Errorf("hiding a nav entry must not change its target's behavior: got %d, want 200; body=%s",
-			rec.Code, rec.Body)
-	}
+	t.Run("entry hidden, data still readable", func(t *testing.T) {
+		ctx := gateCtxFor(principalCtx("bob"), t, d)
+		if slices.Contains(sidebarLabels(ctx, t, app), "Audit") {
+			t.Fatalf("precondition: the Audit entry should be hidden for bob")
+		}
+		if n := rowsFor(t, ctx); n == 0 {
+			t.Errorf("hiding a nav entry must not gate its target's data; got %d rows, want >0", n)
+		}
+	})
+
+	t.Run("entry shown, data still gated", func(t *testing.T) {
+		ctx := gateCtxFor(principalCtx("carol"), t, d)
+		if !slices.Contains(sidebarLabels(ctx, t, app), "Audit") {
+			t.Fatalf("precondition: carol holds admin:read, so the Audit entry should be shown")
+		}
+		if n := rowsFor(t, ctx); n != 0 {
+			t.Errorf("showing a nav entry must not grant its target's data; got %d rows, want 0", n)
+		}
+	})
 }
 
 // TestNavPermission_ConfigUnfiltered covers AC9: /_config keeps serving the

--- a/internal/dataentry/nav_permission_test.go
+++ b/internal/dataentry/nav_permission_test.go
@@ -1,0 +1,299 @@
+package dataentry
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"slices"
+	"testing"
+
+	"github.com/Sourcehaven-BV/rela/internal/acl"
+	v1 "github.com/Sourcehaven-BV/rela/internal/apiwire/v1"
+	"github.com/Sourcehaven-BV/rela/internal/dataentryconfig"
+)
+
+// sidebarShape performs a sidebar request and returns the groups as
+// (groupLabel, itemLabels) pairs.
+//
+// A sibling of sidebarCountsByLabel, which records only items carrying a
+// non-nil Count and so cannot express "this entry is absent" — the property
+// every test here turns on. It also surfaces group structure, needed to assert
+// that an emptied group is dropped rather than rendered as a bare heading.
+func sidebarShape(ctx context.Context, t *testing.T, app *App) []struct {
+	Group string
+	Items []string
+} {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/_sidebar", http.NoBody).WithContext(ctx)
+	rec := httptest.NewRecorder()
+	app.views.handleV1Sidebar(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET _sidebar: %d %s", rec.Code, rec.Body)
+	}
+	var resp v1.SidebarResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode sidebar: %v\nbody: %s", err, rec.Body)
+	}
+	out := make([]struct {
+		Group string
+		Items []string
+	}, 0, len(resp.Navigation))
+	for _, g := range resp.Navigation {
+		labels := make([]string, 0, len(g.Items))
+		for _, it := range g.Items {
+			labels = append(labels, it.Label)
+		}
+		out = append(out, struct {
+			Group string
+			Items []string
+		}{Group: g.Group, Items: labels})
+	}
+	return out
+}
+
+// sidebarLabels flattens sidebarShape to the set of visible item labels.
+func sidebarLabels(ctx context.Context, t *testing.T, app *App) []string {
+	t.Helper()
+	var labels []string
+	for _, g := range sidebarShape(ctx, t, app) {
+		labels = append(labels, g.Items...)
+	}
+	return labels
+}
+
+// installGatedNavConfig publishes a navigation tree mixing gated and ungated
+// entries, including a group that is entirely gated (so the empty-group drop
+// is observable) and one that is only partly gated.
+func installGatedNavConfig(app *App) {
+	cur := app.State()
+	next := *cur
+	cfg := *cur.Cfg
+	cfg.Lists = map[string]dataentryconfig.List{
+		"all-tickets": {EntityType: "ticket", Title: "All"},
+	}
+	cfg.Navigation = []dataentryconfig.NavigationEntry{
+		{Label: "Open", List: "all-tickets"},
+		{Label: "Audit", List: "all-tickets", Permission: "admin:read"},
+		{Group: "Admin", Items: []dataentryconfig.NavigationEntry{
+			{Label: "Secrets", List: "all-tickets", Permission: "admin:read"},
+			{Label: "Keys", List: "all-tickets", Permission: "admin:read"},
+		}},
+		{Group: "Mixed", Items: []dataentryconfig.NavigationEntry{
+			{Label: "Public", List: "all-tickets"},
+			{Label: "Private", List: "all-tickets", Permission: "admin:read"},
+		}},
+	}
+	next.Cfg = &cfg
+	app.schema.Publish(&next)
+}
+
+// gatedNavPolicy grants admin:read to alice only.
+func gatedNavPolicy() *acl.Policy {
+	return &acl.Policy{
+		Roles: map[string]acl.RoleDef{
+			"admin":  {Read: []string{"ticket"}, Permissions: []string{"admin:read"}},
+			"viewer": {Read: []string{"ticket"}},
+		},
+		Assignments: map[string]string{"alice": "admin", "bob": "viewer"},
+	}
+}
+
+// TestNavPermission_NopACLShowsEverything pins the no-policy case (AC2): with
+// no acl.yaml, an entry carrying a `permission:` is still shown.
+//
+// No policy configured means no restrictions — the same posture nopReadGate
+// takes for reads. This is what keeps a single-user instance's menu whole even
+// if its config carries permissions.
+func TestNavPermission_NopACLShowsEverything(t *testing.T) {
+	app := newTestAppV1(t)
+	installGatedNavConfig(app)
+	app.acl = acl.NopACL{}
+
+	labels := sidebarLabels(t.Context(), t, app)
+	for _, want := range []string{"Open", "Audit", "Secrets", "Keys", "Public", "Private"} {
+		if !slices.Contains(labels, want) {
+			t.Errorf("under NopACL every entry must be shown; %q missing from %v", want, labels)
+		}
+	}
+}
+
+// TestNavPermission_HolderSeesEverything covers AC3: a principal holding the
+// permission sees the gated entries.
+func TestNavPermission_HolderSeesEverything(t *testing.T) {
+	app := newTestAppV1(t)
+	installGatedNavConfig(app)
+	d := mustNewACL(t, gatedNavPolicy(), app.store)
+	app.acl = d
+
+	labels := sidebarLabels(gateCtxFor(aliceCtx(), t, d), t, app)
+	for _, want := range []string{"Open", "Audit", "Secrets", "Keys", "Public", "Private"} {
+		if !slices.Contains(labels, want) {
+			t.Errorf("alice holds admin:read; %q missing from %v", want, labels)
+		}
+	}
+}
+
+// TestNavPermission_NonHolderFiltered covers AC4, AC6 and AC7 together, since
+// they are three properties of one response: gated entries are absent, the
+// fully-gated group is dropped entirely, and the partly-gated group survives
+// with only its permitted item.
+func TestNavPermission_NonHolderFiltered(t *testing.T) {
+	app := newTestAppV1(t)
+	installGatedNavConfig(app)
+	d := mustNewACL(t, gatedNavPolicy(), app.store)
+	app.acl = d
+
+	shape := sidebarShape(gateCtxFor(principalCtx("bob"), t, d), t, app)
+
+	var groups []string
+	var labels []string
+	for _, g := range shape {
+		groups = append(groups, g.Group)
+		labels = append(labels, g.Items...)
+		if len(g.Items) == 0 {
+			t.Errorf("group %q rendered with no items; emptied groups must be dropped", g.Group)
+		}
+	}
+
+	// AC4: gated entries absent.
+	for _, unwanted := range []string{"Audit", "Secrets", "Keys", "Private"} {
+		if slices.Contains(labels, unwanted) {
+			t.Errorf("bob lacks admin:read but %q is present in %v", unwanted, labels)
+		}
+	}
+	// Ungated entries untouched.
+	for _, want := range []string{"Open", "Public"} {
+		if !slices.Contains(labels, want) {
+			t.Errorf("ungated entry %q must stay visible, got %v", want, labels)
+		}
+	}
+	// AC6: the wholly-gated group is gone.
+	if slices.Contains(groups, "Admin") {
+		t.Errorf("group %q had all items filtered and must be dropped, got groups %v", "Admin", groups)
+	}
+	// AC7: the partly-gated group survives with its permitted item.
+	if !slices.Contains(groups, "Mixed") {
+		t.Errorf("group %q keeps a permitted item and must survive, got groups %v", "Mixed", groups)
+	}
+}
+
+// TestNavPermission_ReadOnlyHides covers AC5, and is the canary for the
+// RR-CWWJGW hazard.
+//
+// readGateFromContext returns nopReadGate under ReadOnlyACL exactly as it does
+// under NopACL, and nopReadGate.HoldsPermission returns true unconditionally.
+// A predicate written against the read gate alone therefore SHOWS every gated
+// entry under --read-only. permitsNavEntry has an explicit ReadOnlyACL arm
+// ahead of the gate; this test fails if someone removes it.
+func TestNavPermission_ReadOnlyHides(t *testing.T) {
+	app := newTestAppV1(t)
+	installGatedNavConfig(app)
+	app.acl = acl.ReadOnlyACL{}
+
+	labels := sidebarLabels(t.Context(), t, app)
+	for _, unwanted := range []string{"Audit", "Secrets", "Keys", "Private"} {
+		if slices.Contains(labels, unwanted) {
+			t.Errorf("under --read-only a permission-gated entry must be hidden; %q present in %v",
+				unwanted, labels)
+		}
+	}
+	for _, want := range []string{"Open", "Public"} {
+		if !slices.Contains(labels, want) {
+			t.Errorf("ungated entry %q must stay visible under --read-only, got %v", want, labels)
+		}
+	}
+}
+
+// TestNavPermission_ReadOnlyHides_PointerForm pins the &-reachable variant of
+// the same arm. acl.ReadOnlyACL's AuthorizeWrite has a value receiver, so
+// &acl.ReadOnlyACL{} also satisfies acl.ACL; matching only the value form once
+// let a pointer fall through to the default arm elsewhere in this package.
+func TestNavPermission_ReadOnlyHides_PointerForm(t *testing.T) {
+	app := newTestAppV1(t)
+	installGatedNavConfig(app)
+	app.acl = &acl.ReadOnlyACL{}
+
+	labels := sidebarLabels(t.Context(), t, app)
+	if slices.Contains(labels, "Audit") {
+		t.Errorf("&acl.ReadOnlyACL{} must hide gated entries too, got %v", labels)
+	}
+}
+
+// TestNavPermission_NilACLHides pins the wiring-bug case: a handler
+// constructed without an ACL closure must hide gated entries, not show them.
+func TestNavPermission_NilACLHides(t *testing.T) {
+	app := newTestAppV1(t)
+	installGatedNavConfig(app)
+	app.views.aclImpl = nil
+
+	labels := sidebarLabels(t.Context(), t, app)
+	if slices.Contains(labels, "Audit") {
+		t.Errorf("a missing ACL wiring must fail closed for gated entries, got %v", labels)
+	}
+	if !slices.Contains(labels, "Open") {
+		t.Errorf("ungated entries are unaffected by ACL wiring, got %v", labels)
+	}
+}
+
+// TestNavPermission_FilterIsPresentationOnly covers AC8: hiding an entry
+// changes NO enforcement. The list behind a hidden entry answers a direct
+// request exactly as it did before — for this principal, with its normal
+// ACL-scoped rows.
+//
+// This is the assertion that keeps the feature honest. If someone ever makes
+// the sidebar filter load-bearing, this test is what should stop them.
+func TestNavPermission_FilterIsPresentationOnly(t *testing.T) {
+	app := newTestAppV1(t)
+	installGatedNavConfig(app)
+	d := mustNewACL(t, gatedNavPolicy(), app.store)
+	app.acl = d
+
+	ctx := gateCtxFor(principalCtx("bob"), t, d)
+
+	// The entry is hidden…
+	if slices.Contains(sidebarLabels(ctx, t, app), "Audit") {
+		t.Fatalf("precondition: the Audit entry should be hidden for bob")
+	}
+
+	// …and its target is untouched: same status as the ungated list that
+	// points at the identical config, because the filter enforces nothing.
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/tickets", http.NoBody).WithContext(ctx)
+	rec := httptest.NewRecorder()
+	app.handleV1ListEntities(rec, req, "ticket", "tickets")
+	if rec.Code != http.StatusOK {
+		t.Errorf("hiding a nav entry must not change its target's behavior: got %d, want 200; body=%s",
+			rec.Code, rec.Body)
+	}
+}
+
+// TestNavPermission_ConfigUnfiltered covers AC9: /_config keeps serving the
+// whole navigation tree to every principal.
+//
+// Deliberate. Which entries are configured is not a secret — data-entry.yaml
+// is an operator-authored file in the repo (root CLAUDE.md, "The configuration
+// is not a secret; the data is"). Only the *menu* is filtered, and only so a
+// user isn't offered something they cannot act on.
+func TestNavPermission_ConfigUnfiltered(t *testing.T) {
+	app := newTestAppV1(t)
+	installGatedNavConfig(app)
+	d := mustNewACL(t, gatedNavPolicy(), app.store)
+	app.acl = d
+
+	bodyFor := func(t *testing.T, ctx context.Context) string {
+		t.Helper()
+		rec := httptest.NewRecorder()
+		app.handleV1Config(rec, httptest.NewRequest(http.MethodGet, "/api/v1/_config", http.NoBody).
+			WithContext(ctx))
+		if rec.Code != http.StatusOK {
+			t.Fatalf("_config: got %d, want 200; body=%s", rec.Code, rec.Body)
+		}
+		return rec.Body.String()
+	}
+
+	alice := bodyFor(t, gateCtxFor(aliceCtx(), t, d))
+	bob := bodyFor(t, gateCtxFor(principalCtx("bob"), t, d))
+	if alice != bob {
+		t.Errorf("_config must be principal-independent:\n alice=%s\n bob=%s", alice, bob)
+	}
+}

--- a/internal/dataentry/test_helpers_test.go
+++ b/internal/dataentry/test_helpers_test.go
@@ -198,6 +198,8 @@ func rebindApp(app *App, fs storage.FS, paths *project.Context, svc *appbuild.Se
 		services:    app.Services,
 		logo:        app.logo,
 		gateRead:    app.gateReadOrNotFound,
+		// Late-bound, as in NewApp: tests reassign app.acl after construction.
+		aclImpl: func() acl.ACL { return app.acl },
 	}
 	// commandHandler holds closures over App methods, which read the fields
 	// rebound above — so it stays valid after this rebind. (Rebuilt rather than

--- a/internal/dataentry/views_handler.go
+++ b/internal/dataentry/views_handler.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/Sourcehaven-BV/rela/internal/acl"
 	v1 "github.com/Sourcehaven-BV/rela/internal/apiwire/v1"
 	"github.com/Sourcehaven-BV/rela/internal/dataentryconfig"
 	entityPkg "github.com/Sourcehaven-BV/rela/internal/entity"
@@ -46,6 +47,21 @@ type viewsHandler struct {
 	// gateRead is App.gateReadOrNotFound: ACL-gates an entity read,
 	// writing the uniform 404 on denial (hidden = nonexistent).
 	gateRead func(w http.ResponseWriter, r *http.Request, typeName, entityID string) bool
+	// aclImpl resolves the active ACL for permitsNavEntry's sidebar filter.
+	// A closure, not a captured value, for the same reason commandHandler
+	// holds one: tests reassign app.acl AFTER construction, so a captured
+	// value would go stale and the filter would consult the wrong policy.
+	aclImpl func() acl.ACL
+}
+
+// currentACL resolves the active ACL, or nil when the handler was constructed
+// without the closure. Callers must treat nil as "hide" (see permitsNavEntry)
+// — a wiring omission has to fail closed, not panic and not show.
+func (h *viewsHandler) currentACL() acl.ACL {
+	if h.aclImpl == nil {
+		return nil
+	}
+	return h.aclImpl()
 }
 
 // redactor is the field-redaction seam for this surface, mirroring
@@ -186,8 +202,12 @@ func (h *viewsHandler) handleV1Sidebar(w http.ResponseWriter, r *http.Request) {
 		h:           h,
 	}
 
-	// Build navigation with counts
+	// Build navigation with counts. Entries the principal cannot use are
+	// omitted (permitsNavEntry) — a UX filter, not a boundary; see its doc.
+	// The ACL is resolved ONCE here rather than per entry, matching
+	// resolveCommands.
 	navigation := make([]v1.SidebarGroup, 0)
+	aclImpl := h.currentACL()
 
 	for _, entry := range s.Cfg.Navigation {
 		if entry.IsGroup() {
@@ -197,12 +217,25 @@ func (h *viewsHandler) handleV1Sidebar(w http.ResponseWriter, r *http.Request) {
 				Items:     make([]v1.SidebarItem, 0),
 			}
 			for _, item := range entry.Items {
+				if !permitsNavEntry(r.Context(), aclImpl, item) {
+					continue
+				}
 				sidebarItem := h.navEntryToSidebarItem(r.Context(), item, counts)
 				group.Items = append(group.Items, sidebarItem)
+			}
+			// A group whose every item was filtered out is dropped rather than
+			// rendered as a bare heading: an empty labeled group reads as a
+			// rendering bug, and it outlines what the principal cannot reach
+			// without being useful to them.
+			if len(group.Items) == 0 {
+				continue
 			}
 			navigation = append(navigation, group)
 		} else {
 			// Top-level item without group
+			if !permitsNavEntry(r.Context(), aclImpl, entry) {
+				continue
+			}
 			item := h.navEntryToSidebarItem(r.Context(), entry, counts)
 			navigation = append(navigation, v1.SidebarGroup{
 				Items: []v1.SidebarItem{item},
@@ -312,6 +345,67 @@ func (c *sidebarCounts) countWithFilters(
 		entities = append(entities, e)
 	}
 	return len(applyFilters(entities, filters))
+}
+
+// permitsNavEntry reports whether a navigation entry should appear in this
+// principal's sidebar (TKT-TXDK8U).
+//
+// This is a UX filter and NOTHING ELSE. Hiding an entry changes no
+// enforcement: its target is reachable by typing the URL and behaves exactly
+// as it did before — a list still returns its ACL-scoped rows, which for a
+// principal who may read none of them is simply an empty list. Nor does it
+// conceal configuration: `/api/v1/_config` keeps serving the whole navigation
+// tree to every principal, deliberately (root CLAUDE.md, "The configuration is
+// not a secret; the data is"). The goal is only to keep entries a user cannot
+// act on out of their menu.
+//
+// Policy, keyed on the configured ACL implementation, mirroring
+// authorizeCommand (DEC-EIHQSU):
+//
+//   - No `permission:` → show. The overwhelmingly common case, short-circuited
+//     before any ACL work so an unconfigured menu costs nothing.
+//   - [acl.ReadOnlyACL] → hide. Checked FIRST and independently of the read
+//     gate, because readGateFromContext hands back nopReadGate under read-only
+//     exactly as it does under NopACL, and nopReadGate.HoldsPermission returns
+//     true — so a guard written against the read gate alone fails OPEN here.
+//     That is the RR-CWWJGW shape; here it would only show an unusable entry,
+//     but the predicate gets copied and the next copy may not be cosmetic.
+//   - [acl.NopACL] → show. No policy configured ⇒ no restrictions, matching
+//     the read gate's allow-all posture. The only arm that grants by default.
+//   - [*acl.Declarative] → the principal must hold the permission.
+//   - anything else → hide.
+//
+// The switch is closed by construction: an ACL implementation nobody taught
+// this function about hides gated entries rather than showing them. Both value
+// and pointer forms of the nop/read-only types are matched, because their
+// AuthorizeWrite has a value receiver — matching only the value form would
+// drop a `&acl.ReadOnlyACL{}` into the default arm.
+func permitsNavEntry(ctx context.Context, aclImpl acl.ACL, entry dataentryconfig.NavigationEntry) bool {
+	if entry.Permission == "" {
+		return true
+	}
+	// A nil ACL means the handler was wired without one. Hide, for the same
+	// fail-closed reason authorizeCommand denies.
+	if aclImpl == nil {
+		return false
+	}
+
+	switch a := aclImpl.(type) {
+	case acl.NopACL, *acl.NopACL:
+		return true
+
+	case acl.ReadOnlyACL, *acl.ReadOnlyACL:
+		return false
+
+	case *acl.Declarative:
+		if a == nil {
+			return false // misconfigured policy must not fail open
+		}
+		return readGateFromContext(ctx).HoldsPermission(ctx, entry.Permission)
+
+	default:
+		return false
+	}
 }
 
 // navEntryToSidebarItem converts a navigation entry to a sidebar item with count.

--- a/internal/dataentry/views_handler.go
+++ b/internal/dataentry/views_handler.go
@@ -364,16 +364,35 @@ func (c *sidebarCounts) countWithFilters(
 //
 //   - No `permission:` → show. The overwhelmingly common case, short-circuited
 //     before any ACL work so an unconfigured menu costs nothing.
-//   - [acl.ReadOnlyACL] → hide. Checked FIRST and independently of the read
-//     gate, because readGateFromContext hands back nopReadGate under read-only
-//     exactly as it does under NopACL, and nopReadGate.HoldsPermission returns
-//     true — so a guard written against the read gate alone fails OPEN here.
-//     That is the RR-CWWJGW shape; here it would only show an unusable entry,
-//     but the predicate gets copied and the next copy may not be cosmetic.
-//   - [acl.NopACL] → show. No policy configured ⇒ no restrictions, matching
-//     the read gate's allow-all posture. The only arm that grants by default.
+//   - [acl.NopACL] and [acl.ReadOnlyACL] → show. NEITHER carries a policy, so
+//     there is no permission model to consult and no principal who could be
+//     shown to hold anything: "no policy configured ⇒ no restrictions", the
+//     same posture the read gate takes. See the read-only note below.
 //   - [*acl.Declarative] → the principal must hold the permission.
 //   - anything else → hide.
+//
+// Read-only deserves its own paragraph, because the obvious arm is wrong in
+// two different ways and this predicate is a copy target.
+//
+// It is tempting to mirror authorizeCommand, which denies everything under
+// ReadOnlyACL. That is right for commands — they SHELL OUT, a write-shaped act
+// — but [acl.ReadOnlyACL] only implements AuthorizeWrite; it restricts no
+// reads whatsoever. Nav entries are overwhelmingly read surfaces (list, kanban,
+// dashboard, search), and hiding them would remove entries an observe-only
+// principal can use perfectly well. It would also hide them from EVERYONE,
+// since ReadOnlyACL has no identity to check — so `permission:` would silently
+// change meaning from "hide from non-holders" to "hide from all" based on a
+// process-wide flag about writes. An operator in post-incident forensic mode
+// (a documented ReadOnlyACL use case) would lose exactly the audit-log entry
+// they came for.
+//
+// The hazard the deny arm was reaching for is real but belongs elsewhere: under
+// ReadOnlyACL no middleware attaches a read gate, so readGateFromContext hands
+// back nopReadGate, whose HoldsPermission returns true unconditionally
+// (RR-CWWJGW). Falling THROUGH to the gate would therefore show gated entries
+// while looking like it had checked something. The explicit arm above is what
+// prevents that: the answer is the same, but it is reached deliberately rather
+// than by an accident that would keep working if the gate's behavior changed.
 //
 // The switch is closed by construction: an ACL implementation nobody taught
 // this function about hides gated entries rather than showing them. Both value
@@ -391,11 +410,11 @@ func permitsNavEntry(ctx context.Context, aclImpl acl.ACL, entry dataentryconfig
 	}
 
 	switch a := aclImpl.(type) {
-	case acl.NopACL, *acl.NopACL:
+	// Grouped deliberately: both mean "no policy is configured", so neither
+	// can answer whether a principal holds a permission. See the read-only
+	// paragraph above before splitting these apart.
+	case acl.NopACL, *acl.NopACL, acl.ReadOnlyACL, *acl.ReadOnlyACL:
 		return true
-
-	case acl.ReadOnlyACL, *acl.ReadOnlyACL:
-		return false
 
 	case *acl.Declarative:
 		if a == nil {

--- a/internal/dataentryconfig/config.go
+++ b/internal/dataentryconfig/config.go
@@ -440,6 +440,27 @@ type NavigationEntry struct {
 	Settings  bool   `yaml:"settings,omitempty" json:"settings,omitempty"`
 	Action    string `yaml:"action,omitempty" json:"action,omitempty"`
 
+	// Permission optionally hides this entry from the sidebar for principals
+	// who do not hold the named global ACL permission (TKT-TXDK8U). Empty —
+	// the overwhelmingly common case — means the entry is always shown.
+	//
+	// This is a UX filter, NOT an access control. The entry's target enforces
+	// (or does not enforce) exactly what it did before: a hidden list is still
+	// reachable by typing its URL, and still returns its normal ACL-scoped
+	// rows, which for a principal who may read none of them is an empty list.
+	// The point is to keep menu entries a user cannot act on out of their way,
+	// not to conceal that they are configured — `/api/v1/_config` still serves
+	// the whole navigation tree to everyone (see "The configuration is not a
+	// secret; the data is" in the root CLAUDE.md).
+	//
+	// Behavior with no `acl.yaml`: shown. No policy configured means no
+	// restrictions, matching the read gate's allow-all posture. Under
+	// `--read-only`: hidden, since the principal cannot act on anything.
+	//
+	// Not valid on a group entry — a group is a container, not a destination;
+	// groups disappear on their own when every child is filtered out.
+	Permission string `yaml:"permission,omitempty" json:"permission,omitempty"`
+
 	// Group fields
 	Group     string            `yaml:"group,omitempty" json:"group,omitempty"`
 	Collapsed bool              `yaml:"collapsed,omitempty" json:"collapsed,omitempty"`

--- a/internal/dataentryconfig/config.go
+++ b/internal/dataentryconfig/config.go
@@ -454,8 +454,11 @@ type NavigationEntry struct {
 	// secret; the data is" in the root CLAUDE.md).
 	//
 	// Behavior with no `acl.yaml`: shown. No policy configured means no
-	// restrictions, matching the read gate's allow-all posture. Under
-	// `--read-only`: hidden, since the principal cannot act on anything.
+	// restrictions, matching the read gate's allow-all posture. Same under
+	// `--read-only`, which restricts writes only and so has no permission
+	// model to consult — hiding there would remove read surfaces an
+	// observe-only principal can use, and would hide them from everyone
+	// rather than from non-holders.
 	//
 	// Not valid on a group entry — a group is a container, not a destination;
 	// groups disappear on their own when every child is filtered out.

--- a/internal/dataentryconfig/validate.go
+++ b/internal/dataentryconfig/validate.go
@@ -217,6 +217,15 @@ func validateNavEntry(nav NavigationEntry, cfg *Config) []string {
 	}
 
 	if nav.IsGroup() {
+		// A group is a container, not a destination — there is nothing for a
+		// permission to gate, and a gated group would be ambiguous with the
+		// empty-group rule (a group disappears on its own once every child is
+		// filtered out). Rejecting is clearer than silently ignoring it.
+		if nav.Permission != "" {
+			errs = append(errs, fmt.Sprintf(
+				"navigation: group %q cannot have a permission (set it on the items instead; "+
+					"a group is hidden automatically when all its items are)", nav.Group))
+		}
 		for _, child := range nav.Items {
 			errs = append(errs, validateNavEntry(child, cfg)...)
 		}

--- a/internal/dataentryconfig/validate_test.go
+++ b/internal/dataentryconfig/validate_test.go
@@ -1885,6 +1885,73 @@ func TestValidateNavigation_KnownAction(t *testing.T) {
 	}
 }
 
+// TestValidateNavigation_Permission covers `permission:` on a navigation entry
+// (TKT-TXDK8U). It is valid on any direct item and rejected on a group: a group
+// is a container with no destination, and it already disappears on its own once
+// every child is filtered out.
+func TestValidateNavigation_Permission(t *testing.T) {
+	meta := testMetamodel()
+
+	cases := []struct {
+		name    string
+		nav     []NavigationEntry
+		wantErr string // substring; "" means expect success
+	}{
+		{
+			name:    "permission on a list entry is valid",
+			nav:     []NavigationEntry{{Label: "Audit", List: "tickets", Permission: "admin:read"}},
+			wantErr: "",
+		},
+		{
+			// Kinds with no config object behind them can be gated too — that
+			// is the main reason the field lives on the entry.
+			name:    "permission on a settings entry is valid",
+			nav:     []NavigationEntry{{Label: "Settings", Settings: true, Permission: "admin:settings"}},
+			wantErr: "",
+		},
+		{
+			name: "permission on a group is an error",
+			nav: []NavigationEntry{
+				{Group: "Admin", Permission: "admin:read", Items: []NavigationEntry{
+					{Label: "Audit", List: "tickets"},
+				}},
+			},
+			wantErr: `group "Admin" cannot have a permission`,
+		},
+		{
+			name: "permission on an item inside a group is valid",
+			nav: []NavigationEntry{
+				{Group: "Admin", Items: []NavigationEntry{
+					{Label: "Audit", List: "tickets", Permission: "admin:read"},
+				}},
+			},
+			wantErr: "",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := &Config{
+				Lists:      map[string]List{"tickets": {EntityType: "ticket"}},
+				Navigation: tc.nav,
+			}
+			err := ValidateConfig([]byte(`version: "1.0"`), cfg, meta)
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Errorf("expected success, got error: %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("expected error containing %q, got nil", tc.wantErr)
+			}
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Errorf("expected error to contain %q, got: %s", tc.wantErr, err.Error())
+			}
+		})
+	}
+}
+
 func TestValidateEntityViews_Valid(t *testing.T) {
 	meta := testMetamodel()
 	cfg := &Config{

--- a/tickets/entities/docs-checklists/DOCS-VNBHJQ.md
+++ b/tickets/entities/docs-checklists/DOCS-VNBHJQ.md
@@ -1,0 +1,53 @@
+---
+id: DOCS-VNBHJQ
+type: docs-checklist
+title: 'Docs: Permission-based navigation filtering'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Code Documentation
+
+- [x] Exported types and functions have godoc
+- [x] Non-obvious decisions explain *why*, not just *what*
+
+`permitsNavEntry` carries the reasoning that matters: why each ACL arm behaves
+as it does, and a dedicated paragraph on read-only explaining why the obvious
+answer (copy `authorizeCommand`'s deny) is wrong in two directions — the arm was
+wrong in the first commit, so the comment now argues the case rather than
+asserting it.
+
+## Project Documentation
+
+**Remember `docs/*.md` are GENERATED** from `docs-project/entities/`. Edit the
+source guide, run `just docs`, diff. (Learned the hard way in TKT-M1AX6P, where
+`just docs` silently reverted ~172 lines of hand-edited output.)
+
+- [x] `GUIDE-data-entry.md` → `docs/data-entry.md`
+  - `permission:` in the navigation field table
+  - New "Hiding entries a user cannot act on" section: the YAML, the
+empty-group rule, the no-policy/read-only behaviour, and an explicit "this is a
+convenience, not a security control" paragraph
+  - The unvalidated-permission-name gotcha (RR-2KZEXF) with the debugging hint
+  - **Fixed a stale table** documenting a `graph:` nav field that does not
+exist, while the real `search:`/`settings:` were undocumented (RR-ABO495); also
+the example and the counts paragraph
+- [x] `GUIDE-acl-security.md` → `docs/acl-security.md`
+  - Rewrote § "Sidebar menu structure is principal-independent" so it no longer
+contradicts the code: the exception is named, and the three reasons the original
+decision gave are restated as *still true* (metamodel not secret, config not
+secret, target enforces independently) rather than overturned
+- [x] `internal/dataentry/CLAUDE.md` — new section: the filter is presentation
+only; do not filter `/_config`; the ReadOnlyACL arm is load-bearing; the switch
+stays closed
+
+## Verification
+
+- [x] `just docs && git diff --stat docs/` — regenerated output matches the
+committed files; nothing hand-edited survives only in generated form
+- [x] `just lint-md` — 0 issues
+
+## External Documentation
+
+- [x] ~~Changelog / release notes~~ (N/A: none maintained in-tree)

--- a/tickets/entities/implementation-checklists/IMPL-6LZROW.md
+++ b/tickets/entities/implementation-checklists/IMPL-6LZROW.md
@@ -1,0 +1,87 @@
+---
+id: IMPL-6LZROW
+type: implementation-checklist
+title: 'Implementation: Permission-based navigation filtering (UX: hide menu entries a user cannot use)'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Development
+
+- [x] Unit tests written for new code
+- [x] Integration tests written (test full flow, not just units)
+- [x] Happy path implemented
+- [x] Edge cases from planning handled
+- [x] Error handling in place (errors surfaced, not swallowed)
+
+Changes:
+
+- `dataentryconfig/config.go` — `NavigationEntry.Permission`.
+- `dataentryconfig/validate.go` — reject `permission:` on a group entry.
+- `dataentry/views_handler.go` — `permitsNavEntry` (closed switch mirroring
+`authorizeCommand`), `viewsHandler.aclImpl` + `currentACL`, filtering and the
+empty-group drop in `handleV1Sidebar`.
+- `dataentry/app.go` + `test_helpers_test.go` — wire the late-bound `aclImpl`
+closure at both construction sites.
+- `frontend/src/types/config.ts` — `permission?` (plus the `search?`/`settings?`
+fields that were already missing from the TS mirror).
+
+## Test Quality
+
+- [x] Using fixture builders or factories for test data
+- [x] No hardcoded values in assertions when object is in scope
+- [x] Only specifying values that matter for the test
+- [x] Interpolated values constructed from objects, not hardcoded
+- [x] Property comparisons use original object, not hardcoded strings
+
+`sidebarShape` is a new helper because the existing `sidebarCountsByLabel`
+records only items with a non-nil `Count` — it literally cannot express "this
+entry is absent", which is the property every test here turns on.
+
+## Manual Verification
+
+- [x] Feature manually tested end-to-end
+- [x] Each acceptance criterion verified with test scenario from planning
+- [x] Edge cases manually verified
+
+**Verification Evidence:**
+
+Live `rela-server` against `prototypes/data-entry/project` with a gated `Admin
+Only` nav entry (`permission: admin:read`) granted to alice only:
+
+| Check | Result |
+|---|---|
+| alice (holder) sidebar | `Admin Only` present |
+| bob (non-holder) sidebar | absent; all ungated entries intact |
+| bob → `/api/v1/tickets` (the hidden entry's target) | **200** — filtering enforces nothing |
+| `/_config` alice vs bob | byte-identical (md5) |
+| bob's `/_config` | still lists the gated entry |
+| No `acl.yaml` at all | entry shown; browser-verified in the sidebar with its count |
+
+The 200 and the identical `/_config` are the two that matter: they demonstrate
+this is presentation, not a boundary, and that nothing is concealed.
+
+## Quality
+
+- [x] Code follows project patterns (check similar code)
+- [x] Checked for DRY opportunities
+- [x] No security issues introduced
+- [x] No silent failures (errors logged AND returned)
+- [x] No debug code left behind
+
+Notes:
+
+- **A test caught a real wiring gap.** `test_helpers_test.go` builds its own
+`viewsHandler` under a comment claiming it "mirrors production wiring"; it did
+not pass `aclImpl`, so gated entries were hidden from *everyone* (the
+fail-closed nil arm). Fixed at the helper so the comment stays true, rather than
+working around it in the tests.
+- **`TestMdCorpusRoundTrip` (in `internal/lua`) failed on my own planning
+document**, not on code: a wrapped line began `403.`, which the markdown parser
+reads as an ordered-list item, so render(parse(x)) != x. Reworded. Worth knowing
+that every `tickets/**` file is parser-validated by the test suite.
+- `just lint` flagged British spelling twice (`behaviour`) — Go code is
+US-spelling-linted; the prose docs are not.
+- Docs were edited in `docs-project/entities/guides/` and regenerated, per the
+generated-file trap hit in TKT-M1AX6P.

--- a/tickets/entities/planning-checklists/PLAN-UQ4MFO.md
+++ b/tickets/entities/planning-checklists/PLAN-UQ4MFO.md
@@ -62,6 +62,17 @@ the entry is absent from every group.
 hidden.** This is the arm that the read gate alone gets wrong (see Security).
 *Test:* asserts hidden, and is the canary for the RR-CWWJGW hazard.
 
+   **REVISED DURING REVIEW (RR-XYO03L): read-only now SHOWS gated entries.**
+   The rationale above was wrong and I had not checked it against
+   `acl.ReadOnlyACL`'s contract: it implements only `AuthorizeWrite` and
+   restricts no reads, while nav entries are overwhelmingly read surfaces. It
+   also carries no identity, so hiding removed entries from *everyone* rather
+   than from non-holders. Read-only is structurally the same case as NopACL —
+   no policy, so no permission model — and is grouped with it. The explicit arm
+   remains, because falling through to the read gate would reach the same
+   answer by accident (RR-CWWJGW); `TestNavPermission_ReadOnlyArmIsExplicit`
+   pins the difference.
+
 6. **A group whose every item is hidden is dropped**, not rendered as a bare
 heading. *Test:* two-item group, both gated, both denied ⇒ group absent.
 
@@ -154,7 +165,9 @@ closed switch:
   - `entry.Permission == ""` → **true** (the common case, short-circuited first);
   - `aclImpl == nil` → false (wiring bug fails closed);
   - `acl.NopACL` / `*acl.NopACL` → **true** (no policy ⇒ no restrictions, AC2);
-  - `acl.ReadOnlyACL` / `*acl.ReadOnlyACL` → **hide** (AC5). Read-only means the
+  - `acl.ReadOnlyACL` / `*acl.ReadOnlyACL` → **show**, grouped with NopACL
+(revised during review — see AC5). Originally specified as **hide**, on the
+reasoning below, which was wrong: read-only means the
 principal can't act; a permission-gated entry is exactly the thing to hide.
 *This arm must be explicit and precede any read-gate use* — see Security;
   - `*acl.Declarative` → `readGateFromContext(ctx).HoldsPermission(...)`;
@@ -304,8 +317,8 @@ independently, and the NopACL/read-only behaviour
 principal-independent" with the new behaviour
 - [x] `internal/dataentry/CLAUDE.md` — nav filtering is an affordance; the
 ReadOnlyACL arm is load-bearing; do not filter `/_config`
-- [ ] Root `CLAUDE.md` — N/A (the config-is-not-secret rule already covers the
-framing)
+- [x] ~~Root `CLAUDE.md`~~ (N/A: the config-is-not-secret rule added in
+TKT-M1AX6P already covers the framing)
 
 ## Design Review
 

--- a/tickets/entities/planning-checklists/PLAN-UQ4MFO.md
+++ b/tickets/entities/planning-checklists/PLAN-UQ4MFO.md
@@ -1,0 +1,320 @@
+---
+id: PLAN-UQ4MFO
+type: planning-checklist
+title: 'Planning: Permission-based navigation filtering (UX: hide menu entries a user cannot use)'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Understanding
+
+- [x] Problem/requirements clearly understood
+- [x] Scope defined (what's in/out documented below)
+- [x] Acceptance criteria documented with specific test scenarios
+
+**Scope:**
+
+IN scope:
+
+1. Optional `permission:` on `NavigationEntry`.
+2. `/api/v1/_sidebar` omits entries whose `permission:` the principal lacks.
+3. A group left empty by that filtering is dropped entirely.
+4. Docs: `docs-project/.../GUIDE-data-entry.md` (nav table + the field) and
+`GUIDE-acl-security.md` (reconcile § "Sidebar menu structure is
+principal-independent" with the new behaviour).
+
+OUT of scope — each with a reason, because each was actively considered:
+
+- **`permission:` on `List`/`Kanban`/`Action`.** Discussed with the user and
+deferred. For lists/kanbans the ACL already does the real work — rows are scoped
+by `scopedSortedEntities`, so a denied user gets an empty list rather than a
+refusal. A `permission:` there would govern only whether you may *look at the
+page* while the data is governed by something else: two mechanisms on one
+screen, and an invitation for someone to later mistake the label for a boundary.
+For `Action` it is a genuine capability gate, but that belongs with the missing
+enforcement (TKT-X06LA2), not here.
+- **Filtering `/_config`.** Concealment-shaped and explicitly unwanted; the SPA
+builds the menu from `SidebarData`, so `/_sidebar` alone achieves the UX goal.
+- **Count-based hiding** ("hide a list whose count is 0"). Ruled out by the
+user: counts are a separate problem (TKT-LP90MA).
+- **Any change to counts or their staleness.** Same reason.
+- **Gating `handleV1Action`.** TKT-X06LA2.
+
+**Acceptance Criteria:**
+
+1. **A nav entry with no `permission:` is always shown.** The overwhelmingly
+common case must be untouched. *Test:* existing sidebar tests stay green
+unmodified — `TestV1SidebarWithNavigation`, `TestACLSidebar_*`.
+
+2. **Under NopACL (no `acl.yaml`), an entry with `permission:` is shown.**
+No policy configured ⇒ no restrictions, matching `nopReadGate`'s allow-all
+posture. *Test:* explicit case with a `permission:` entry and no ACL wired; also
+keeps `TestACLSidebar_NopACLFullCounts` green.
+
+3. **Under a configured policy, a holder sees the entry.** *Test:* alice holds
+`admin:read`, sees the gated entry.
+
+4. **Under a configured policy, a non-holder does not.** *Test:* bob lacks it,
+the entry is absent from every group.
+
+5. **Under `--read-only` (`ReadOnlyACL`), an entry with `permission:` is
+hidden.** This is the arm that the read gate alone gets wrong (see Security).
+*Test:* asserts hidden, and is the canary for the RR-CWWJGW hazard.
+
+6. **A group whose every item is hidden is dropped**, not rendered as a bare
+heading. *Test:* two-item group, both gated, both denied ⇒ group absent.
+
+7. **A group that keeps at least one item is retained with only the survivors.**
+*Test:* mixed group ⇒ group present, exactly the permitted items.
+
+8. **Filtering is presentation only.** A hidden entry's target still behaves
+exactly as before by direct URL. *Test:* asserts a denied principal's
+`/list/:id` still returns its normal (ACL-scoped, possibly empty) response — the
+filter changed no enforcement.
+
+9. **`/_config` is unchanged** — still serves `navigation` in full to every
+principal. *Test:* asserts config identical for holder and non-holder.
+
+10. **Config validation rejects a `permission:` on a group entry** (a group is
+a container, not a destination). *Test:* validation table case.
+
+## Research
+
+- [x] For larger features: run `/research` to create a structured research doc
+- [x] Searched for existing libraries that solve this problem
+- [x] Checked codebase for similar patterns or reusable code
+- [x] Looked for reference implementations in other projects
+- [x] Reviewed relevant rela concepts for prior art
+
+**Research Doc:** N/A — the mechanism is established in-tree; the open question
+was a config-design decision, resolved with the user.
+
+**Existing Solutions:**
+
+- **`resolveCommands` / `authorizeCommand`** (`internal/dataentry/commands.go:130`,
+`:84`) is the pattern to mirror: "return only what this principal can use, the
+endpoint re-checks". Its doc comment states the invariant explicitly — *"This is
+presentation only — `authorizeCommand` is re-consulted at exec time, which is
+the actual boundary."* Three properties to copy:
+  - a **closed switch** over the `acl.ACL` implementation (`commands.go:72-83`)
+so a new implementation denies until an arm is added;
+  - **both value and pointer forms matched** — `AuthorizeWrite` has a value
+receiver, and matching only the value form once let `&acl.ReadOnlyACL{}` fall
+into the granting default arm: a `--read-only` bypass reachable by one `&`;
+  - the ACL implementation read **once** outside the loop (`commands.go:145`).
+- **`_actions` on entity/list responses** is the same shape one level down, and
+`internal/dataentry/CLAUDE.md` already carries the rule: "Don't trust `_actions`
+for authorization. The write endpoint must re-authorize."
+- **`readGate.HoldsPermission`** (`readgate.go:52`) is the predicate itself,
+already used by the history path (`history_handler.go:124`).
+
+**Why `ReadQuery` is NOT the mechanism** (checked, and it is a trap):
+`readquery.go:49-51` returns `DenyAll` only when *no role in the entire policy*
+grants read on the type. A principal holding no conferring edges gets a `Query`
+that yields zero rows — not `DenyAll`. So `DenyAll` is **policy-shaped, not
+principal-shaped** and cannot answer "can this user use this entry".
+`TestACLSidebar_DenyAllZeroCounts` demonstrates exactly this: count 0 via
+`Query`, not via `DenyAll`.
+
+**Pre-existing issues noted, not fixed here:**
+
+- `handleV1Action` has no per-principal gate at all → TKT-X06LA2 (filed).
+- The sidebar is fetched once on mount and never refreshed → TKT-LP90MA (filed).
+- `sidebarCountsByLabel` (`acl_sidebar_test.go:85`) only records items with a
+non-nil `Count`, so it cannot distinguish "hidden" from "present with no count".
+This ticket needs a sibling helper that returns labels/hrefs.
+- `TestACLSidebar_DenyAllZeroCounts` asserts `counts[label] == 0`, which would
+pass *vacuously* if the entry disappeared (missing key ⇒ zero value). It is not
+affected by this change (those entries carry no `permission:`), but it should be
+tightened to assert presence while it is being read anyway.
+
+## Approach
+
+- [x] Technical approach chosen and documented
+- [x] Approach builds on existing patterns (not reinventing)
+- [x] Alternatives considered (document why rejected)
+- [x] Dependencies identified (packages, APIs, types)
+
+**Technical Approach:**
+
+*Config* (`internal/dataentryconfig`)
+
+- `NavigationEntry` (`config.go:433`): add `Permission string`
+(`yaml:"permission,omitempty"`), matching the field name commands and documents
+already use.
+- `validateNavEntry` (`validate.go:195`): reject `permission:` on a **group**
+entry — a group is a container with no destination, and gating it would be
+ambiguous with the empty-group drop. Groups vanish when all their children do.
+
+*Sidebar* (`internal/dataentry/views_handler.go`)
+
+- Add `permitsNavEntry(ctx, aclImpl, entry) bool`, mirroring `authorizeCommand`'s
+closed switch:
+  - `entry.Permission == ""` → **true** (the common case, short-circuited first);
+  - `aclImpl == nil` → false (wiring bug fails closed);
+  - `acl.NopACL` / `*acl.NopACL` → **true** (no policy ⇒ no restrictions, AC2);
+  - `acl.ReadOnlyACL` / `*acl.ReadOnlyACL` → **hide** (AC5). Read-only means the
+principal can't act; a permission-gated entry is exactly the thing to hide.
+*This arm must be explicit and precede any read-gate use* — see Security;
+  - `*acl.Declarative` → `readGateFromContext(ctx).HoldsPermission(...)`;
+  - `default:` → false.
+- `handleV1Sidebar` (`:192-211`): skip filtered items; after building a group's
+items, `continue` if empty. Read the ACL implementation **once** before the
+loop, as `resolveCommands` does.
+
+*Docs* — both are GENERATED; edit `docs-project/entities/guides/*.md` then `just
+docs` and diff.
+
+**Files to modify:**
+
+- `internal/dataentryconfig/config.go`, `validate.go` (+ `validate_test.go`)
+- `internal/dataentry/views_handler.go` (+ `api_v1_test.go`, `acl_sidebar_test.go`)
+- `docs-project/entities/guides/GUIDE-data-entry.md`, `GUIDE-acl-security.md`
+- `frontend/src/types/config.ts` — add `permission?` to the TS `NavigationEntry`
+for parity (the SPA reads `SidebarData`, so it needs no behaviour change)
+
+**Alternatives considered:**
+
+- *`permission:` on `List`/`Kanban`/`Action`* — see Scope. Deferred, not
+rejected on difficulty; the door is left open below.
+- *Derive from the target, with override* — the eventual shape if `List` ever
+gains a real `permission:`. Adding it now would mean deriving from a field that
+does not exist.
+- *Reuse `ReadQuery`/`DenyAll`* — rejected; policy-shaped, see Research.
+- *Hide on zero count* — ruled out by the user (TKT-LP90MA).
+- *Filter `/_config` too* — concealment-shaped; explicitly unwanted.
+
+**Future: derive from target.** If `List`/`Kanban`/`Action` later gain
+`permission:` (TKT-X06LA2 proposes it for `Action`), the natural evolution is
+derive-from-target with an explicit entry-level override. The entry-level field
+added here is forward-compatible with that: it becomes the override.
+
+## Security Considerations
+
+- [x] Input sources identified (user input, config, external APIs)
+- [x] Input validation approach defined (allowlist preferred over blocklist)
+- [x] Security-sensitive operations identified (file access, auth, crypto)
+- [x] Error handling doesn't leak sensitive information
+
+**This feature is NOT a security control, and the code must not read as one.** A
+hidden entry stays reachable by direct URL and its target behaves exactly as
+before. The user's framing is the correct one: *guessing the URL gets you empty
+stuff — no problem*, because lists are already row-scoped by the ACL.
+
+Consequences for the implementation:
+
+- **No concealment language** in code, docs, or tests. No test asserting a
+config name is unenumerable. `/_config` keeps serving navigation in full. (Root
+`CLAUDE.md`: "The configuration is not a secret; the data is." An earlier
+attempt at this in TKT-M1AX6P was reverted for exactly this reason.)
+- **`docs/acl-security.md` must be updated**, or it will contradict the code:
+it currently records per-principal menu hiding as "deliberately not done". The
+decision becomes "done for UX, explicitly not for confidentiality".
+
+**The one real hazard: `ReadOnlyACL` fails OPEN through the read gate.**
+`readGateFromContext` returns `nopReadGate` under **both** NopACL *and*
+ReadOnlyACL (`readgate.go`), and `nopReadGate.HoldsPermission` returns `true`
+unconditionally (`readgate.go:135`). So a predicate that consults only the read
+gate would *show* every gated entry under `--read-only`. That combination was
+live bug RR-CWWJGW, which is why `authorizeCommand` carries an explicit
+ReadOnlyACL arm ahead of the gate. `permitsNavEntry` must do the same. AC5 is
+the canary.
+
+This is cosmetic here (a shown-but-unusable entry, not an escalation) — but the
+same predicate shape gets copied, and the next copy may not be cosmetic.
+
+**Input Sources & Validation:**
+
+| Input | Source | Validation | On invalid |
+|---|---|---|---|
+| `permission:` on a nav entry | config author | non-empty string; rejected on a group entry | config error |
+| principal | request context | existing ACL middleware | unchanged |
+
+Not cross-checked against `acl.yaml` — matching the existing precedent for
+command and document permissions, where the policy is not available at
+config-validation time. A typo'd permission hides the entry (fail-closed under a
+configured policy), which is the safe direction and visible immediately.
+
+## Test Plan
+
+- [x] Test scenarios documented for each acceptance criterion
+- [x] Edge cases identified and documented
+- [x] Negative test cases defined (invalid input, error conditions)
+- [x] Integration test approach defined (not just unit tests)
+
+**Test Scenarios:** as listed per AC. Layers:
+
+- `internal/dataentryconfig/validate_test.go` — AC10.
+- `internal/dataentry/acl_sidebar_test.go` — AC2-7, reusing `sidebarPolicy()`,
+`installSidebarConfig`, `mustNewACL`, `gateCtxFor`, `aliceCtx`, `principalCtx`.
+Needs a **new helper returning labels/hrefs**, since `sidebarCountsByLabel`
+drops items with a nil count and so cannot express absence.
+- `internal/dataentry/api_v1_test.go` — AC1 (existing tests unmodified), AC9.
+
+**Edge Cases:**
+
+- Entry with `permission:` **and** no ACL wired → shown (AC2).
+- `--read-only` → hidden (AC5); explicitly not delegated to the read gate.
+- Group with `permission:` → config error (AC10).
+- Group emptied by filtering → dropped (AC6); group partially filtered →
+retained with survivors (AC7).
+- **Every** top-level entry filtered out → `navigation: []`. Confirm the SPA
+renders an empty sidebar rather than erroring.
+- A `permission:` naming a permission no role grants → entry hidden under a
+configured policy, shown under NopACL. Consistent, and the typo is visible.
+- Nav entry pointing at a nonexistent list/kanban → unchanged behaviour
+(item with nil count); filtering is orthogonal.
+
+**Negative Tests:**
+
+- Non-holder: entry absent from `/_sidebar`, **and** the target endpoint
+unchanged by direct request (AC8) — the assertion that keeps this honest as
+presentation-only.
+
+## Risk Assessment
+
+- [x] Technical risks assessed with mitigations
+- [x] Security risks assessed (see Security Considerations)
+- [x] Effort estimated (xs/s/m/l/xl)
+
+**Risks:**
+
+| Risk | Severity | Mitigation |
+|---|---|---|
+| ReadOnlyACL fails open via the read gate (RR-CWWJGW shape) | Medium | Explicit ReadOnlyACL arm before any gate call; AC5 pins it |
+| The filter is later mistaken for a boundary | Medium | Endpoints unchanged and AC8 asserts it; no concealment language anywhere; `internal/dataentry/CLAUDE.md` gains a line |
+| `acl-security.md` left contradicting the code | Medium | In scope; update the source guide, `just docs`, diff |
+| Existing sidebar tests silently weakened (the vacuous-pass problem in `TestACLSidebar_DenyAllZeroCounts`) | Low-Med | New absence-asserting helper; tighten that test while in the file |
+| Editing generated `docs/*.md` instead of the source | Low | Known trap (hit in TKT-M1AX6P); `just docs && git diff --stat docs/` is the check |
+
+**Effort:** m
+
+## Documentation Planning
+
+- [x] User-facing docs identified (skip if internal refactor)
+- [x] Docs-checklist will be created when entering implementation
+
+**Documentation Impact:**
+
+- [x] `GUIDE-data-entry.md` — `permission:` in the navigation field table; a
+short subsection stating it is a UX filter, that the target still enforces
+independently, and the NopACL/read-only behaviour
+- [x] `GUIDE-acl-security.md` — reconcile § "Sidebar menu structure is
+principal-independent" with the new behaviour
+- [x] `internal/dataentry/CLAUDE.md` — nav filtering is an affordance; the
+ReadOnlyACL arm is load-bearing; do not filter `/_config`
+- [ ] Root `CLAUDE.md` — N/A (the config-is-not-secret rule already covers the
+framing)
+
+## Design Review
+
+- [x] Run `/design-review` before starting implementation
+- [x] All critical/significant findings addressed in plan
+
+**Design Review Findings:** No separate `/design-review` run. The design's two
+load-bearing questions were resolved with the user directly (gate source; NopACL
+and empty-group behaviour), and the survey that informed them was an explicit
+code exploration rather than a guess. The one hazard a design review would look
+for — the ReadOnlyACL fail-open — is identified above with its mitigation and a
+dedicated AC.

--- a/tickets/entities/review-checklists/REV-LN3QJM.md
+++ b/tickets/entities/review-checklists/REV-LN3QJM.md
@@ -2,55 +2,102 @@
 id: REV-LN3QJM
 type: review-checklist
 title: 'Review: Permission-based navigation filtering (UX: hide menu entries a user cannot use)'
-status: in-progress
+status: done
 ---
 
 <!-- @managed: claude-workflow v1 -->
 
 ## Automated Checks
 
-- [ ] All tests pass (`just test`)
-- [ ] Lint clean (`just lint`)
-- [ ] Coverage maintained (`just coverage-check`)
+- [x] `go test ./...` — all pass
+- [x] `just lint` — 0 issues
+- [x] `just lint-md` — 0 issues
+- [x] `just arch-lint` — no warnings
+- [x] `just plimsoll` — no warnings
+- [x] `just coverage-check` — PASS, total 77.2%
+- [x] frontend `npm run test:run` — 1429 passed
+- [x] frontend `npm run typecheck` — clean
 
 ## Code Review
 
-- [ ] Run `/code-review` command (invokes cranky-code-reviewer agent)
-- [ ] All critical review-responses addressed
-- [ ] All significant review-responses addressed
-- [ ] Self-reviewed the diff for unrelated changes
+Run with the cranky-code-reviewer agent, asked explicitly to attack the "UX not
+security" framing. **The framing held** — the reviewer patched `handleV1Config`
+to filter navigation per principal and confirmed
+`TestNavPermission_ConfigUnfiltered` fails loudly, i.e. that guard is real.
 
-**Review Responses:** <!-- List IDs of review-response entities created, e.g.,
-RR-xxxx -->
+Two findings landed, both mutation-verified by the reviewer:
+
+| ID | Severity | Status |
+|----|----------|--------|
+| RR-XYO03L | critical | addressed — ReadOnlyACL arm hid entries a read-only principal can use |
+| RR-KCM8R0 | significant | addressed — the presentation-only guard test was theatre |
+| RR-2KZEXF | significant | **deferred** → TKT-E5EM3N (permission names unvalidated) |
+| RR-ABO495 | nit | addressed — docs table documented a nonexistent `graph:` field |
+
+No open critical or significant responses.
+
+**RR-XYO03L is the one that mattered.** I copied `authorizeCommand`'s
+ReadOnlyACL deny arm without checking whether its reasoning transferred. It
+doesn't: `authorizeCommand` gates shell execution (write-shaped, correctly
+denied under `--read-only`), while this gates menu links to *read* surfaces, and
+`acl.ReadOnlyACL` only implements `AuthorizeWrite`. My godoc asserted "the
+principal cannot act on anything", which is simply false. And since
+`ReadOnlyACL` carries no identity, the arm hid gated entries from *everyone* —
+`permission:` changed meaning based on a process-wide flag about writes. The
+audit-log entry my own docs use as the example disappeared in exactly the
+forensic mode `ReadOnlyACL` documents as a use case.
+
+Fixed by grouping ReadOnlyACL with NopACL (neither carries a policy, so neither
+has a permission model) while keeping the arm explicit, because RR-CWWJGW is
+real: falling through to the read gate would reach the same answer *by
+accident*. `TestNavPermission_ReadOnlyArmIsExplicit` pins that distinction.
+
+**RR-KCM8R0** is a lesson worth keeping: the test I described in the plan as
+"the assertion that keeps this honest" asserted that two unconnected subsystems
+are unconnected, and could not fail from any change to the feature.
+
+## Mutation testing
+
+Every guard on this branch was verified by breaking the code and confirming the
+right test fails:
+
+| Mutation | Expected to fail | Result |
+|---|---|---|
+| `permitsNavEntry` → always `true` | NonHolderFiltered, NilACLHides, FilterIsPresentationOnly | all three failed ✓ |
+| Remove the ReadOnlyACL arm | ReadOnlyShowsEverything (both forms), ReadOnlyArmIsExplicit | all failed ✓ |
+| (reviewer) filter `handleV1Config` | ConfigUnfiltered | failed ✓ |
+
+Restored and green after each.
 
 ## Acceptance Verification
 
-- [ ] Each acceptance criterion tested (reference planning checklist)
-- [ ] Test evidence documented in implementation checklist
+Verified against a live `rela-server` on `prototypes/data-entry/project` with a
+gated `Admin Only` entry granted to alice only.
 
-**Acceptance Status:**
-<!-- For each acceptance criterion, state PASS/FAIL with evidence -->
+| AC | Result | Evidence |
+|----|--------|----------|
+| 1 | PASS | Every pre-existing sidebar test green, unmodified |
+| 2 | PASS | No `acl.yaml` → entry shown (browser-verified in the sidebar) |
+| 3 | PASS | alice (holder) → present |
+| 4 | PASS | bob (non-holder) → absent, ungated entries intact |
+| 5 | **CHANGED** | `--read-only` now **shows** gated entries — see RR-XYO03L; verified live |
+| 6 | PASS | Fully-gated group dropped, not rendered as a bare heading |
+| 7 | PASS | Partly-gated group retained with only its permitted item |
+| 8 | PASS | bob's `/api/v1/tickets` returns **rows**, not just 200 (rewritten per RR-KCM8R0) |
+| 9 | PASS | `/_config` byte-identical (md5) for alice and bob; still lists the gated entry |
+| 10 | PASS | `permission:` on a group is a config error |
 
-## Documentation (enhancements only)
+AC5's expected outcome was inverted by the review. The plan asserted a rationale
+I had not checked against `acl.ReadOnlyACL`'s actual contract.
 
-Skip this section for bugs and internal refactors.
+## Structural guard added
 
-- [ ] Docs-checklist created and linked via `has-docs`
-- [ ] User-facing documentation updated
-- [ ] Docs-checklist marked as done
+`TestNavFilterStaysPresentational` (a grep test, following the `translateVerb`
+precedent in `lint_test.go`) forbids calling `permitsNavEntry` outside
+`views_handler.go`. Suggested by the reviewer, and worth it: a prose rule in
+CLAUDE.md already failed to prevent this exact drift once, in TKT-M1AX6P.
 
-**Docs Checklist:** <!-- e.g., DOCS-xxxx -->
+## Follow-ups filed
 
-## Final Checks
-
-- [ ] Commit message explains the why, not just what
-- [ ] No TODOs or FIXMEs left unaddressed
-- [ ] Ready for another developer to use
-
-## Pull Request
-
-- [ ] Run `/pr` command to create PR and monitor CI
-- [ ] All CI checks pass
-- [ ] PR URL documented below
-
-**PR:** <!-- e.g., https://github.com/org/repo/pull/123 -->
+- **TKT-E5EM3N** — warn on `permission:` values no role grants, across
+commands/documents/navigation (from RR-2KZEXF)

--- a/tickets/entities/review-checklists/REV-LN3QJM.md
+++ b/tickets/entities/review-checklists/REV-LN3QJM.md
@@ -1,0 +1,56 @@
+---
+id: REV-LN3QJM
+type: review-checklist
+title: 'Review: Permission-based navigation filtering (UX: hide menu entries a user cannot use)'
+status: in-progress
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Automated Checks
+
+- [ ] All tests pass (`just test`)
+- [ ] Lint clean (`just lint`)
+- [ ] Coverage maintained (`just coverage-check`)
+
+## Code Review
+
+- [ ] Run `/code-review` command (invokes cranky-code-reviewer agent)
+- [ ] All critical review-responses addressed
+- [ ] All significant review-responses addressed
+- [ ] Self-reviewed the diff for unrelated changes
+
+**Review Responses:** <!-- List IDs of review-response entities created, e.g.,
+RR-xxxx -->
+
+## Acceptance Verification
+
+- [ ] Each acceptance criterion tested (reference planning checklist)
+- [ ] Test evidence documented in implementation checklist
+
+**Acceptance Status:**
+<!-- For each acceptance criterion, state PASS/FAIL with evidence -->
+
+## Documentation (enhancements only)
+
+Skip this section for bugs and internal refactors.
+
+- [ ] Docs-checklist created and linked via `has-docs`
+- [ ] User-facing documentation updated
+- [ ] Docs-checklist marked as done
+
+**Docs Checklist:** <!-- e.g., DOCS-xxxx -->
+
+## Final Checks
+
+- [ ] Commit message explains the why, not just what
+- [ ] No TODOs or FIXMEs left unaddressed
+- [ ] Ready for another developer to use
+
+## Pull Request
+
+- [ ] Run `/pr` command to create PR and monitor CI
+- [ ] All CI checks pass
+- [ ] PR URL documented below
+
+**PR:** <!-- e.g., https://github.com/org/repo/pull/123 -->

--- a/tickets/entities/review-responses/RR-2KZEXF.md
+++ b/tickets/entities/review-responses/RR-2KZEXF.md
@@ -1,0 +1,14 @@
+---
+id: RR-2KZEXF
+type: review-response
+title: 'permission: values are never validated against acl.yaml'
+finding: 'validateNavEntry checks list:/kanban:/action: references against the config but accepts any non-empty string as a permission:. A typo like admin:raed yields an entry permanently invisible to everyone, with no error and no warning — and since the failure mode is a silently missing menu item, nobody notices until a user complains.'
+severity: significant
+reason: |-
+    Real, but not fixable within this ticket's boundary. internal/dataentryconfig does not see acl.yaml at all — the same reason command permissions (config.go, viewCommandPermissionWarnings) and document permissions are equally unvalidated today. Fixing it means plumbing the policy into config validation, which is a change to the validation architecture affecting three features, not one. Doing it here would be scope creep into shared machinery on a UX ticket.
+
+    Mitigated where it costs nothing: the docs now name this explicitly, tell the reader the failure mode (an entry nobody can see, no error), and point at the roles' permissions: list as the first thing to check when a menu item has vanished. That converts a silent puzzle into a documented gotcha.
+
+    Worth its own ticket covering all three consumers together — a warning listing unknown permission names, in the shape of the existing viewCommandPermissionWarnings precedent.
+status: deferred
+---

--- a/tickets/entities/review-responses/RR-ABO495.md
+++ b/tickets/entities/review-responses/RR-ABO495.md
@@ -1,0 +1,9 @@
+---
+id: RR-ABO495
+type: review-response
+title: 'Navigation docs table documented a nonexistent graph: field'
+finding: 'The navigation field table documented `graph: bool` ("Link to the graph explorer"), which does not exist on NavigationEntry, while the real `search:` and `settings:` fields were undocumented. A YAML example also used `graph: true`, and the counts paragraph referred to "graph entries". Pre-existing, but in the table this ticket edits.'
+severity: nit
+resolution: 'Replaced the graph row with the real search/settings rows, changed the example entry to `search: true`, and reworded the intro and counts paragraphs to name the kinds that actually exist. Fixed in the SOURCE guide (docs-project/entities/guides/) and regenerated — docs/*.md are generated output.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-KCM8R0.md
+++ b/tickets/entities/review-responses/RR-KCM8R0.md
@@ -1,0 +1,9 @@
+---
+id: RR-KCM8R0
+type: review-response
+title: TestNavPermission_FilterIsPresentationOnly was theatre
+finding: 'The test guarding the feature''s central claim couldn''t fail from a change to the feature. It asserted handleV1ListEntities returns 200 for bob — but bob''s role grants Read on ticket, so that 200 holds for unrelated reasons, and handleV1ListEntities has no knowledge of navigation config at all (no import, no lookup, no shared state). It asserted that two unconnected subsystems are unconnected. The reviewer mutation-tested it: with permitsNavEntry hardwired to return true, only the precondition line failed (a duplicate of NonHolderFiltered), never the advertised assertion. It also never checked the response body, so it would not have noticed the target silently returning zero rows.'
+severity: significant
+resolution: 'Rewritten to test the two cases where menu and data could actually diverge, in both directions: (a) bob is denied the permission but permitted the data — entry hidden, list returns rows (hiding gates nothing); (b) carol holds the permission but is denied the data — entry shown, list returns empty (data-gating gates no menu). The rows assertion is the load-bearing half. Mutation-verified: with the filter disabled, TestNavPermission_FilterIsPresentationOnly now fails on the assertion rather than the precondition. Also added TestNavFilterStaysPresentational, a grep test forbidding permitsNavEntry calls outside views_handler.go — the reviewer''s suggestion, following the translateVerb precedent in lint_test.go. Worth it because a prose rule already failed to prevent exactly this drift once (TKT-M1AX6P).'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-XYO03L.md
+++ b/tickets/entities/review-responses/RR-XYO03L.md
@@ -1,0 +1,9 @@
+---
+id: RR-XYO03L
+type: review-response
+title: ReadOnlyACL arm hid entries a read-only principal can fully use
+finding: 'permitsNavEntry copied authorizeCommand''s ReadOnlyACL deny arm without its justification. authorizeCommand gates shell execution — a write-shaped act, correctly denied under --read-only. permitsNavEntry gates menu links to READ surfaces (list, kanban, dashboard, search), and acl.ReadOnlyACL only implements AuthorizeWrite; it restricts no reads at all. So my stated rationale ("the principal cannot act on anything") was simply false. Worse, ReadOnlyACL carries no identity, so the arm hid gated entries from EVERYONE — `permission:` silently changed meaning from "hide from non-holders" to "hide from all" based on a process-wide flag about writes. The concrete cost: the audit-log entry my own docs use as the example vanishes in post-incident forensic mode, a documented ReadOnlyACL use case.'
+severity: critical
+resolution: 'Grouped ReadOnlyACL with NopACL and made both SHOW. The reviewer''s framing is right: neither carries a policy, so neither has a permission model to consult — read-only is structurally the same case as no-ACL, not its opposite. The arm stays explicit rather than falling through, because the RR-CWWJGW hazard is real (readGateFromContext returns nopReadGate under read-only, whose HoldsPermission returns true, so falling through would reach the same answer by accident). The godoc now says that plainly instead of asserting a false rationale, and a new test TestNavPermission_ReadOnlyArmIsExplicit pins it by attaching a deny-everything gate: if the arm is removed, the default arm hides the entries and the test fails. Mutation-verified both directions.'
+status: addressed
+---

--- a/tickets/entities/tickets/TKT-E5EM3N.md
+++ b/tickets/entities/tickets/TKT-E5EM3N.md
@@ -1,0 +1,61 @@
+---
+id: TKT-E5EM3N
+type: ticket
+title: 'Warn on permission: values no role grants (commands, documents, navigation)'
+kind: enhancement
+priority: low
+effort: s
+status: backlog
+---
+
+## Problem
+
+Three config surfaces accept a `permission:` naming a global ACL permission:
+
+- `commands:` (`CommandConfig.Permission`)
+- `documents:` (`DocumentConfig.Permission`, TKT-M1AX6P)
+- `navigation:` (`NavigationEntry.Permission`, TKT-TXDK8U)
+
+None of them is checked against `acl.yaml`. Any non-empty string is accepted, so
+a typo (`admin:raed` for `admin:read`) is silently inert.
+
+The failure modes are quiet and differ per surface:
+
+- a **command** the user can never execute,
+- a **document** that always 403s,
+- a **nav entry** nobody can see.
+
+The nav case is the worst of the three: a missing menu item gives no error, no
+log line, and nothing to search for. Nobody notices until a user asks where
+something went.
+
+## Why it isn't already done
+
+`internal/dataentryconfig` never sees `acl.yaml` — `ValidateConfig(data, cfg,
+meta)` takes the metamodel, not the policy. Each of the three features
+individually decided this was out of scope rather than plumb the policy in. That
+is the right call three times over and the wrong outcome once.
+
+## Proposal
+
+Plumb the parsed policy (or just the set of permission names any role grants)
+into config validation and emit a **warning** — not a hard error — listing
+`permission:` values no role grants, naming the surface and key.
+
+A warning rather than an error because:
+
+- `acl.yaml` is optional; with no policy, every `permission:` is inert by
+design and must not fail the boot.
+- Config and policy are edited independently, sometimes by different people;
+a transient mismatch during a rollout should not take the server down.
+
+`viewCommandPermissionWarnings` (`internal/dataentryconfig/validate.go`) is the
+existing precedent for a config warning of exactly this shape — reuse it.
+
+Cover all three surfaces in one pass; fixing one and leaving two is how this
+stays confusing.
+
+## Origin
+
+RR-2KZEXF, from the code review of TKT-TXDK8U. Documented as a gotcha in the
+data-entry guide meanwhile.

--- a/tickets/entities/tickets/TKT-LP90MA.md
+++ b/tickets/entities/tickets/TKT-LP90MA.md
@@ -1,0 +1,38 @@
+---
+id: TKT-LP90MA
+type: ticket
+title: Sidebar counts are fetched once on mount and never refresh
+kind: enhancement
+priority: low
+effort: s
+status: backlog
+---
+
+## Problem
+
+`Sidebar.vue` calls `loadSidebar()` in `onMounted` and never again — there is no
+watcher on route changes and no `entity:changed` SSE subscription (contrast
+`DocumentView.vue` / `DocumentsPanel.vue`, which both re-render on that event).
+
+So the per-list and per-kanban counts shown in the menu are a snapshot from page
+load. Create ten tickets and "Open Tickets" still shows the old number until a
+full browser reload. The counts are correct when fetched — they run through the
+ACL read scope (`sidebarCounts`, TKT-VMD8) — just stale.
+
+## Notes for whoever picks this up
+
+- `handleV1Sidebar` recomputes every count per request
+(`countWithFilters`, `views_handler.go`), and with `filters:` configured it
+loads the visible set into memory. A naive "refetch on every `entity:changed`"
+would run that on every write in the system, for every connected client. See the
+performance caveat in `docs/acl-security.md` § "Sidebar config-filter
+performance caveat" (RR-REQW) — debounce, or refetch on navigation rather than
+on the event stream.
+- `countWithFilters` degrades backend errors to `0` with a `slog.Warn`. A
+refresh that silently rewrites a count to 0 on a transient error is worse than a
+stale count; consider distinguishing error from empty first.
+
+## Origin
+
+Noticed while surveying the sidebar for TKT-TXDK8U (nav filtering). Explicitly
+split out by the user as a separate problem — TKT-TXDK8U does not touch counts.

--- a/tickets/entities/tickets/TKT-TXDK8U.md
+++ b/tickets/entities/tickets/TKT-TXDK8U.md
@@ -5,7 +5,7 @@ title: 'Permission-based navigation filtering (UX: hide menu entries a user cann
 kind: enhancement
 priority: medium
 effort: m
-status: in-progress
+status: review
 ---
 
 ## Goal

--- a/tickets/entities/tickets/TKT-TXDK8U.md
+++ b/tickets/entities/tickets/TKT-TXDK8U.md
@@ -5,7 +5,7 @@ title: 'Permission-based navigation filtering (UX: hide menu entries a user cann
 kind: enhancement
 priority: medium
 effort: m
-status: review
+status: done
 ---
 
 ## Goal

--- a/tickets/entities/tickets/TKT-TXDK8U.md
+++ b/tickets/entities/tickets/TKT-TXDK8U.md
@@ -1,0 +1,85 @@
+---
+id: TKT-TXDK8U
+type: ticket
+title: 'Permission-based navigation filtering (UX: hide menu entries a user cannot use)'
+kind: enhancement
+priority: medium
+effort: m
+status: in-progress
+---
+
+## Goal
+
+Hide navigation entries a principal cannot use, **for UX reasons** — a menu full
+of links that error is a bad menu. Not a security measure: see the framing
+section below, which is the part most likely to be got wrong.
+
+## Framing (read before implementing)
+
+`docs/acl-security.md` § "Sidebar menu structure is principal-independent"
+records the current behaviour and rejects per-principal hiding *as a
+confidentiality tightening*:
+
+> the metamodel is not a secret (it's served by `/api/v1/_schema`), and a
+> divergent menu per principal complicates SPA caching for no confidentiality
+> gain today
+
+This ticket does **not** overturn that reasoning — it accepts it and adds a
+different justification. Concretely that means:
+
+- The endpoints keep enforcing independently. A hidden entry stays reachable
+by direct URL and returns the same 403/404 it does today. Nothing about the
+filter is load-bearing for authorization (same rule as `_actions` in
+`internal/dataentry/CLAUDE.md`).
+- Do **not** describe this as concealment in code, docs, or tests, and do not
+add tests asserting that a config name is unenumerable. Config is not a secret
+(root `CLAUDE.md`, "The configuration is not a secret; the data is").
+- `docs/acl-security.md` must be updated so the two sections don't contradict
+each other — the decision changes from "deliberately not done" to "done for UX,
+explicitly not for confidentiality".
+
+A first pass at this shipped and was reverted in TKT-M1AX6P precisely because it
+was justified as concealment. The behaviour is wanted; the rationale has to be
+right.
+
+## Open design questions
+
+1. **What is a nav entry gated on?** Only `commands:` and `documents:` have a
+`permission:` field today (`config.go:611`, `:667`). Lists, kanbans and actions
+have none, so most nav kinds have nothing to derive visibility from. Options:
+   - add `permission:` to the nav entry itself (uniform, explicit, but
+duplicates the target's own gate and can drift from it);
+   - derive it from the target where one exists and add `permission:` to
+`List`/`Kanban`/`Action` where it doesn't (no duplication, more surface);
+   - both — derive by default, allow an explicit override on the entry.
+2. **Beyond permissions?** A list whose ACL-scoped count is 0 for this
+principal is arguably also a useless entry. That is a different (and more
+expensive) predicate — the count already runs through the ACL read scope
+(`sidebarCounts`), so it is available, but hiding on it makes the menu flicker
+as data changes. Probably out of scope; decide explicitly.
+3. **Empty groups.** A group whose every item is hidden should be dropped, or
+it renders as a bare heading. (The reverted implementation did this.)
+4. **`/_config` too, or just `/_sidebar`?** The SPA reads `SidebarData` for
+the menu, so `/_sidebar` alone is enough for the UX goal. Filtering `/_config`
+as well would be concealment-shaped and is explicitly not wanted.
+5. **SPA caching.** The cost the existing decision names. `/api/` responses are
+already `no-store` + `Vary` on the principal header (`docs/acl-security.md` §
+"Caching: per-principal responses"), so this is about the SPA's own client-side
+reuse of the sidebar payload, not HTTP caches. Confirm the SPA doesn't cache the
+sidebar across identity changes.
+
+## Prior art in-tree
+
+- The reverted implementation is in git history on `feat/standalone-documents`
+(`hidesNavEntry` in `internal/dataentry/views_handler.go`, removed in the revert
+commit) — including the empty-group drop and a per-request predicate. Worth
+reading, but re-derive the design rather than restoring it wholesale.
+- `resolveCommands` (`internal/dataentry/commands.go`) is the established
+pattern for "return only what this principal can use, endpoint re-checks".
+- `_actions` on entity/list responses is the same shape at the item level.
+
+## Origin
+
+Requested by the user during TKT-M1AX6P review cleanup, after the
+security-justified version was reverted. Wanted for navigation generally, not
+just `document:` entries.

--- a/tickets/entities/tickets/TKT-X06LA2.md
+++ b/tickets/entities/tickets/TKT-X06LA2.md
@@ -1,0 +1,82 @@
+---
+id: TKT-X06LA2
+type: ticket
+title: Actions have no per-principal authorization gate (handleV1Action + webhook)
+kind: enhancement
+priority: high
+effort: m
+status: backlog
+---
+
+## Problem
+
+`handleV1Action` (`internal/dataentry/actions.go:45`) runs a configured action —
+a Lua script, or a declarative `set:` mutation — with **no per-principal
+authorization check at all**. The handler validates the method, the id shape,
+and looks up the config; then it takes `writeMu` and calls
+`engine().ExecuteAction`. There is no `readGateFromContext`, no
+`acl.WriteRequest`, no `authorizeCommand` equivalent.
+
+Contrast `commands:`, which has `Permission` on the config
+(`dataentryconfig/config.go:606`) and a real gate in `authorizeCommand`
+(`internal/dataentry/commands.go:84-120`), re-consulted at exec time. `Action`
+has no authorization field whatsoever (`dataentryconfig/config.go:100-108`).
+
+## Impact
+
+The enforcement that does exist is indirect and downstream: the script's writes
+go through `EntityManager` and its reads through the ACL-bound `scriptReader`,
+so under a restrictive policy the *effects* are largely denied. But:
+
+- The action always **starts**, always burns the 5s `actionTimeout`, and always
+holds `writeMu` — a denied principal can serialize every writer in the process
+by POSTing in a loop.
+- A `set:` action's mutation and any script side effect that isn't an entity
+write are not covered by that downstream gating.
+- Under `--read-only` the action still executes; only its writes fail.
+
+There is a **second entry point**: `dispatchWebhookAction`
+(`internal/dataentry/webhook.go:153-183`) runs actions under a synthetic
+`principal.Principal{User: "webhook:" + claims.Event}`, gated only by webhook
+token validation. Any fix has to cover both.
+
+## Proposal
+
+Add `Permission string` to `Action` and gate `handleV1Action` on it, mirroring
+`authorizeCommand`:
+
+- **Closed switch over the `acl.ACL` implementation**, so a new implementation
+denies until someone adds an arm (`commands.go:72-83`).
+- **Match both value and pointer forms** — `AuthorizeWrite` has a value
+receiver, and matching only the value form once dropped `&acl.ReadOnlyACL{}`
+into the granting default arm: a silent `--read-only` bypass reachable by one
+`&`.
+- **`ReadOnlyACL` denies every action, in every context.**
+- **Do not key off the read gate alone.** `readGateFromContext` returns
+`nopReadGate` under *both* NopACL and ReadOnlyACL, and
+`nopReadGate.HoldsPermission` returns `true` — that combination was live bug
+RR-CWWJGW. The ReadOnlyACL arm must be independent and come first.
+- Decide the fail-open/fail-closed posture for an action with no `permission:`
+under a configured policy. Commands fail **closed** there
+(`commands.go:112-114`) on the grounds that a command shells out; an action runs
+Lua with write access, so the same argument applies — but it is a breaking
+change for existing configs and needs a deliberate call.
+- Cover `dispatchWebhookAction` too, or document explicitly why the webhook
+principal is exempt.
+
+## Relationship to TKT-TXDK8U
+
+TKT-TXDK8U (nav filtering) hides an `action:` entry the user cannot use, keyed
+on a `permission:` declared **on the nav entry**. That is presentation only and
+does not close this hole: the menu hides the button, but `POST
+/api/v1/_action/{id}` still executes for anyone who posts to it.
+
+If this ticket adds `Action.Permission`, TKT-TXDK8U's nav-entry `permission:`
+could later derive from it rather than being restated — see the "future: derive
+from target" note there.
+
+## Origin
+
+Found by the code-review survey while planning TKT-TXDK8U. Split out at the
+user's direction: a missing authorization gate is a security fix, not a tail on
+a UX ticket.

--- a/tickets/relations/TKT-E5EM3N--affects--data-entry-ui.md
+++ b/tickets/relations/TKT-E5EM3N--affects--data-entry-ui.md
@@ -1,0 +1,5 @@
+---
+from: TKT-E5EM3N
+relation: affects
+to: data-entry-ui
+---

--- a/tickets/relations/TKT-E5EM3N--implements--FEAT-AESD4.md
+++ b/tickets/relations/TKT-E5EM3N--implements--FEAT-AESD4.md
@@ -1,0 +1,5 @@
+---
+from: TKT-E5EM3N
+relation: implements
+to: FEAT-AESD4
+---

--- a/tickets/relations/TKT-LP90MA--affects--data-entry-ui.md
+++ b/tickets/relations/TKT-LP90MA--affects--data-entry-ui.md
@@ -1,0 +1,5 @@
+---
+from: TKT-LP90MA
+relation: affects
+to: data-entry-ui
+---

--- a/tickets/relations/TKT-LP90MA--implements--FEAT-AESD4.md
+++ b/tickets/relations/TKT-LP90MA--implements--FEAT-AESD4.md
@@ -1,0 +1,5 @@
+---
+from: TKT-LP90MA
+relation: implements
+to: FEAT-AESD4
+---

--- a/tickets/relations/TKT-TXDK8U--affects--data-entry-ui.md
+++ b/tickets/relations/TKT-TXDK8U--affects--data-entry-ui.md
@@ -1,0 +1,5 @@
+---
+from: TKT-TXDK8U
+relation: affects
+to: data-entry-ui
+---

--- a/tickets/relations/TKT-TXDK8U--has-docs--DOCS-VNBHJQ.md
+++ b/tickets/relations/TKT-TXDK8U--has-docs--DOCS-VNBHJQ.md
@@ -1,0 +1,5 @@
+---
+from: TKT-TXDK8U
+relation: has-docs
+to: DOCS-VNBHJQ
+---

--- a/tickets/relations/TKT-TXDK8U--has-implementation--IMPL-6LZROW.md
+++ b/tickets/relations/TKT-TXDK8U--has-implementation--IMPL-6LZROW.md
@@ -1,0 +1,5 @@
+---
+from: TKT-TXDK8U
+relation: has-implementation
+to: IMPL-6LZROW
+---

--- a/tickets/relations/TKT-TXDK8U--has-planning--PLAN-UQ4MFO.md
+++ b/tickets/relations/TKT-TXDK8U--has-planning--PLAN-UQ4MFO.md
@@ -1,0 +1,5 @@
+---
+from: TKT-TXDK8U
+relation: has-planning
+to: PLAN-UQ4MFO
+---

--- a/tickets/relations/TKT-TXDK8U--has-review--REV-LN3QJM.md
+++ b/tickets/relations/TKT-TXDK8U--has-review--REV-LN3QJM.md
@@ -1,0 +1,5 @@
+---
+from: TKT-TXDK8U
+relation: has-review
+to: REV-LN3QJM
+---

--- a/tickets/relations/TKT-TXDK8U--has-review-response--RR-2KZEXF.md
+++ b/tickets/relations/TKT-TXDK8U--has-review-response--RR-2KZEXF.md
@@ -1,0 +1,5 @@
+---
+from: TKT-TXDK8U
+relation: has-review-response
+to: RR-2KZEXF
+---

--- a/tickets/relations/TKT-TXDK8U--has-review-response--RR-ABO495.md
+++ b/tickets/relations/TKT-TXDK8U--has-review-response--RR-ABO495.md
@@ -1,0 +1,5 @@
+---
+from: TKT-TXDK8U
+relation: has-review-response
+to: RR-ABO495
+---

--- a/tickets/relations/TKT-TXDK8U--has-review-response--RR-KCM8R0.md
+++ b/tickets/relations/TKT-TXDK8U--has-review-response--RR-KCM8R0.md
@@ -1,0 +1,5 @@
+---
+from: TKT-TXDK8U
+relation: has-review-response
+to: RR-KCM8R0
+---

--- a/tickets/relations/TKT-TXDK8U--has-review-response--RR-XYO03L.md
+++ b/tickets/relations/TKT-TXDK8U--has-review-response--RR-XYO03L.md
@@ -1,0 +1,5 @@
+---
+from: TKT-TXDK8U
+relation: has-review-response
+to: RR-XYO03L
+---

--- a/tickets/relations/TKT-TXDK8U--implements--FEAT-AESD4.md
+++ b/tickets/relations/TKT-TXDK8U--implements--FEAT-AESD4.md
@@ -1,0 +1,5 @@
+---
+from: TKT-TXDK8U
+relation: implements
+to: FEAT-AESD4
+---

--- a/tickets/relations/TKT-X06LA2--affects--data-entry-ui.md
+++ b/tickets/relations/TKT-X06LA2--affects--data-entry-ui.md
@@ -1,0 +1,5 @@
+---
+from: TKT-X06LA2
+relation: affects
+to: data-entry-ui
+---

--- a/tickets/relations/TKT-X06LA2--implements--FEAT-AESD4.md
+++ b/tickets/relations/TKT-X06LA2--implements--FEAT-AESD4.md
@@ -1,0 +1,5 @@
+---
+from: TKT-X06LA2
+relation: implements
+to: FEAT-AESD4
+---


### PR DESCRIPTION
## What

An optional `permission:` on a `navigation:` entry hides it from `/_sidebar` for principals who don't hold that global ACL permission. A group whose every item is hidden disappears with them.

```yaml
navigation:
  - label: "Tickets"
    list: all_tickets
  - label: "Audit log"
    list: audit_log
    permission: admin:read      # only holders see this entry
```

A menu full of links that error is a bad menu.

## This is UX, not a security control

Stated up front because a previous attempt at menu filtering was **reverted** (TKT-M1AX6P) for being justified as concealment:

- `/api/v1/_config` still serves the whole navigation tree, `permission:` values included, to every principal.
- A hidden entry's target enforces exactly what it did before. Type the URL and you reach it; a list still returns its ACL-scoped rows, which for someone permitted to read none of them is an empty list.
- Two tests guard this, and both were mutation-verified to actually fail when broken: `TestNavPermission_FilterIsPresentationOnly` (hidden entry → rows still returned; shown entry → rows still withheld) and `TestNavPermission_ConfigUnfiltered`.
- `TestNavFilterStaysPresentational` is a grep test forbidding `permitsNavEntry` outside `views_handler.go`, following the `translateVerb` precedent. A prose rule already failed to prevent this drift once.

`docs/acl-security.md` § "Sidebar menu structure is principal-independent" is updated rather than contradicted: the three reasons it gave are restated as still true, with the exception named.

## Why the field is on the nav entry

Only `commands:` and `documents:` have a `permission:` today; `List`/`Kanban`/`Action` have none. For lists the ACL already does the real work, so a `permission:` there would govern only whether you may *look at* the page while the data is governed by something else — two mechanisms on one screen. `Action` is a genuine capability gate but has **no enforcement at all** today, which is filed separately as TKT-X06LA2. The entry-level field is forward-compatible with deriving from the target later.

## Read-only

`permitsNavEntry` mirrors `authorizeCommand`'s closed switch, but **not** its ReadOnlyACL arm. The first commit copied that deny and it was wrong: `acl.ReadOnlyACL` implements only `AuthorizeWrite` and restricts no reads, while nav entries are overwhelmingly read surfaces — and since it carries no identity, hiding removed entries from *everyone*, making `permission:` mean something different based on a process-wide flag about writes. An operator in forensic mode lost exactly the audit-log entry they came for.

Read-only now groups with NopACL (neither carries a policy, so neither has a permission model). The arm stays **explicit** because RR-CWWJGW is real — `nopReadGate.HoldsPermission` returns true, so falling through would reach the same answer by accident. `TestNavPermission_ReadOnlyArmIsExplicit` pins that distinction.

## Verification

Live-tested against `prototypes/data-entry/project`: holder sees the entry, non-holder doesn't, non-holder's `/api/v1/tickets` still returns 200, `/_config` byte-identical (md5) for both, and `--read-only` shows gated entries. Full suite, lint, markdown-lint, arch-lint, plimsoll, coverage (77.2%), frontend tests and typecheck all pass.

Strict no-op for configs with no `permission:` anywhere — every pre-existing sidebar test is green, unmodified.

## Follow-ups filed

- **TKT-X06LA2** (high) — actions have no per-principal authorization gate at all
- **TKT-E5EM3N** — warn on `permission:` values no role grants (all three surfaces)
- **TKT-LP90MA** — sidebar counts never refresh after mount

## Note for reviewers

`docs/*.md` are generated from `docs-project/entities/`; edits here are in the source guides. Also fixes a stale nav table documenting a `graph:` field that doesn't exist while omitting the real `search:`/`settings:`.