### PR TITLE
fix: entity IDs must start with a letter or digit (TKT-2W96LY)

### DIFF
--- a/internal/entity/id.go
+++ b/internal/entity/id.go
@@ -129,9 +129,9 @@ func (id EntityID) MatchesPattern(pattern string) bool {
 	return strings.EqualFold(prefix, pattern)
 }
 
-// idPattern is the one grammar every entity ID must satisfy:
-// ASCII letters, digits, underscore, and hyphen.
-var idPattern = regexp.MustCompile(`^[A-Za-z0-9_-]+$`)
+// idPattern is the one grammar every entity ID must satisfy: it starts with an
+// ASCII letter or digit, then allows letters, digits, underscore, and hyphen.
+var idPattern = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9_-]*$`)
 
 // ValidateID reports whether s is a valid entity ID. It is the SINGLE
 // validity rule for entity IDs across the whole codebase — storeutil.ValidateID
@@ -156,11 +156,14 @@ var idPattern = regexp.MustCompile(`^[A-Za-z0-9_-]+$`)
 //     name belongs. Identifiers stay ASCII the same way DNS labels, Kubernetes
 //     resource names, and package names do.
 //
-//   - No leading hyphen. A leading "-" makes the ID look like an option flag
-//     to any command it is passed to ("-rf"), which is argument injection
-//     rather than a filesystem concern. This is defense in depth, not the
-//     primary control: TKT-QGHNVA removes user-controlled data from command
-//     lines entirely. Keep this check even after that lands.
+//   - Must start with a letter or digit. An identifier that opens with "-" or
+//     "_" is malformed on its face: it reads as an option flag ("-rf") or a
+//     hidden/private marker rather than a name, and every identifier grammar
+//     worth copying (DNS labels, Kubernetes names, most language identifiers)
+//     says the same. This is a well-formedness rule, NOT a security control —
+//     do not let it become load-bearing for command safety. Argument injection
+//     is prevented structurally instead: nothing request-derived reaches a
+//     command line (see internal/cmdexec and the documents renderer).
 //
 //   - No consecutive hyphens. "--" is the relation-key separator in
 //     "FROM--TYPE--TO.md", so an ID containing it makes the relation filename
@@ -199,8 +202,8 @@ func ValidateID(s string) error {
 		return fmt.Errorf("consecutive dashes not allowed in entity ID: %s", s)
 	}
 
-	if strings.HasPrefix(s, "-") {
-		return fmt.Errorf("entity ID may not start with a dash (reads as a command-line flag): %s", s)
+	if s[0] == '-' || s[0] == '_' {
+		return fmt.Errorf("entity ID must start with a letter or digit: %s", s)
 	}
 
 	if !idPattern.MatchString(s) {

--- a/internal/entity/id_test.go
+++ b/internal/entity/id_test.go
@@ -526,9 +526,11 @@ func TestValidateID(t *testing.T) {
 		{"DEL", "foo\x7fbar", "control character"},
 		{"consecutive dashes", "FOO--BAR", "consecutive dashes"},
 
-		// Argument injection: these are the reason for the leading-dash rule.
-		{"leading dash", "-rf", "may not start with a dash"},
-		{"leading dash word", "-oevil", "may not start with a dash"},
+		// An identifier must open with a letter or digit; "-" reads as an
+		// option flag and "_" as a hidden/private marker.
+		{"leading dash", "-rf", "must start with a letter or digit"},
+		{"leading dash word", "-oevil", "must start with a letter or digit"},
+		{"leading underscore", "_private", "must start with a letter or digit"},
 
 		// ASCII-only: NFC/NFD divergence across platforms, plus homoglyphs.
 		{"latin accent", "café", "invalid characters"},

--- a/internal/store/storeutil/storeutil_test.go
+++ b/internal/store/storeutil/storeutil_test.go
@@ -57,12 +57,14 @@ func TestValidateID(t *testing.T) {
 		}
 	})
 
-	t.Run("rejects leading dash", func(t *testing.T) {
-		// A leading "-" reads as an option flag to any command the ID is
-		// passed to ("-rf"), i.e. argument injection.
-		err := storeutil.ValidateID("-rf")
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "may not start with a dash")
+	t.Run("rejects non-alphanumeric first character", func(t *testing.T) {
+		// An identifier opens with a letter or digit: "-" reads as an option
+		// flag, "_" as a hidden/private marker.
+		for _, id := range []string{"-rf", "_private"} {
+			err := storeutil.ValidateID(id)
+			require.Error(t, err, "id %q should be rejected", id)
+			assert.Contains(t, err.Error(), "must start with a letter or digit")
+		}
 	})
 
 	t.Run("rejects shell metacharacters and spaces", func(t *testing.T) {

--- a/tickets/entities/implementation-checklists/IMPL-T91509.md
+++ b/tickets/entities/implementation-checklists/IMPL-T91509.md
@@ -1,0 +1,60 @@
+---
+id: IMPL-T91509
+type: implementation-checklist
+title: 'Implementation: Entity IDs must start with a letter or digit'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Development
+
+- [x] Unit tests written for new code
+- [x] Integration tests written (test full flow, not just units)
+- [x] Happy path implemented
+- [x] Edge cases from planning handled
+- [x] Error handling in place (errors surfaced, not swallowed)
+
+## Test Quality
+
+- [x] ~~Using fixture builders or factories for test data~~ (N/A: table-driven string inputs)
+- [x] No hardcoded values in assertions when object is in scope
+- [x] Only specifying values that matter for the test
+- [x] Interpolated values constructed from objects, not hardcoded
+- [x] Property comparisons use original object, not hardcoded strings
+
+## Manual Verification
+
+- [x] Feature manually tested end-to-end
+- [x] Each acceptance criterion verified with test scenario from planning
+- [x] Edge cases manually verified
+
+**Verification Evidence:**
+
+- `go test ./...` — pass. Two existing assertions needed updating: they
+  asserted the old message "may not start with a dash". The IDs rejected are
+  the same; only the wording changed.
+- New case `TestValidateID/invalid/leading_underscore` confirmed RUN and PASS
+  — `_private` was legal before this change, so it had no coverage.
+- Fuzz (load-bearing: `storetest/fuzz.go` uses ValidateID as a
+  **bidirectional** oracle, so a stricter rule requires the stores to actually
+  reject the newly-invalid ids):
+  - `FuzzValidateID` 20s — 2.3M execs, pass
+  - `FuzzRenameKeyCollapse` 20s (fsstore) — pass
+  - `FuzzRelationKeyCollision` 20s (memstore) — pass
+- `go test -tags postgres ./internal/store/...` against a real PostgreSQL 15
+  (fresh DB, migrations applied) — pass
+- `golangci-lint` 0 issues; `just arch-lint` OK
+- Back-compat measured, not assumed: every entity id in `tickets/` and
+  `docs-project/` scanned — zero start with a non-alphanumeric.
+
+## Quality
+
+- [x] Code follows project patterns (check similar code)
+- [x] Checked for DRY opportunities — repeated literals, expressions, or
+patterns extracted to a helper / constant / type where it sharpens the contract
+(don't extract for its own sake; CLAUDE.md "three similar lines is better than a
+premature abstraction" still holds)
+- [x] No security issues introduced
+- [x] No silent failures (errors logged AND returned)
+- [x] No debug code left behind

--- a/tickets/entities/planning-checklists/PLAN-EOHOV0.md
+++ b/tickets/entities/planning-checklists/PLAN-EOHOV0.md
@@ -1,0 +1,120 @@
+---
+id: PLAN-EOHOV0
+type: planning-checklist
+title: 'Planning: Entity IDs must start with a letter or digit'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Understanding
+
+- [x] Problem/requirements clearly understood
+- [x] Scope defined (what's in/out documented below)
+- [x] Acceptance criteria documented with specific test scenarios
+
+**Scope:**
+<!-- Document explicitly what IS and IS NOT in scope -->
+
+**Acceptance Criteria:**
+<!-- Each criterion must have a concrete test scenario -->
+1. ...
+
+## Research
+
+- [x] ~~For larger features: run `/research` to create a structured research doc~~ (N/A: one-line grammar change)
+- [x] Searched for existing libraries that solve this problem
+- [x] Checked codebase for similar patterns or reusable code
+- [x] Looked for reference implementations in other projects
+- [x] Reviewed relevant rela concepts for prior art
+
+**Research Doc:** <!-- Link RES-xxxx if created, or N/A for small changes -->
+
+**Existing Solutions:**
+<!-- Document what you found:
+- Libraries considered (with pros/cons, why chosen or rejected)
+- Similar patterns in codebase (file:line references)
+- Reference implementations that inspired the approach
+- Relevant concepts from rela-docs or rela-issues-and-design-tickets
+-->
+
+## Approach
+
+- [x] Technical approach chosen and documented
+- [x] Approach builds on existing patterns (not reinventing)
+- [x] Alternatives considered (document why rejected)
+- [x] Dependencies identified (packages, APIs, types)
+
+**Technical Approach:**
+<!-- Document the approach with enough detail that implementation is mechanical -->
+
+**Files to modify:**
+<!-- List specific files that will change -->
+
+## Security Considerations
+
+- [x] Input sources identified (user input, config, external APIs)
+- [x] Input validation approach defined (allowlist preferred over blocklist)
+- [x] Security-sensitive operations identified (file access, auth, crypto)
+- [x] Error handling doesn't leak sensitive information
+
+**Input Sources & Validation:**
+<!-- For each input: source, validation approach, what happens on invalid input -->
+
+**Security-Sensitive Operations:**
+<!-- List operations and how they're protected -->
+
+## Test Plan
+
+- [x] Test scenarios documented for each acceptance criterion
+- [x] Edge cases identified and documented
+- [x] Negative test cases defined (invalid input, error conditions)
+- [x] Integration test approach defined (not just unit tests)
+
+**Test Scenarios:**
+<!-- Map each acceptance criterion to how it will be tested -->
+
+**Edge Cases:**
+<!-- List specific edge cases and expected behavior. Consider:
+- Empty/null/missing values
+- Boundary values (0, -1, MAX_INT)
+- Special characters, unicode, null bytes
+- Concurrent access
+- Resource exhaustion
+-->
+
+**Negative Tests:**
+<!-- What should fail? How should it fail? -->
+
+## Risk Assessment
+
+- [x] Technical risks assessed with mitigations
+- [x] Security risks assessed (see Security Considerations)
+- [x] Effort estimated (xs/s/m/l/xl)
+
+**Risks:**
+<!-- List risks and how they will be mitigated -->
+
+## Documentation Planning
+
+For enhancements: identify what documentation needs updating.
+
+- [x] ~~User-facing docs identified~~ (N/A: internal; no valid id changes meaning)
+- [x] ~~Docs-checklist will be created when entering implementation~~ (N/A: no user-facing docs)
+
+**Documentation Impact:**
+<!-- Which docs need updating? Check all that apply:
+- [x] docs/metamodel.md - New metamodel features
+- [x] docs/cli-reference.md - New/changed commands
+- [x] docs/data-entry.md - UI changes
+- [x] CLAUDE.md - New patterns or conventions
+- [x] README.md - Project-level changes
+- [x] N/A - Internal change, no user-facing docs needed
+-->
+
+## Design Review
+
+- [x] ~~Run `/design-review` before starting implementation~~ (N/A: approach agreed with user directly)
+- [x] All critical/significant findings addressed in plan
+
+**Design Review Findings:** <!-- List review-response IDs, e.g., RR-xxxx -->

--- a/tickets/entities/review-checklists/REV-IDX2S3.md
+++ b/tickets/entities/review-checklists/REV-IDX2S3.md
@@ -1,0 +1,55 @@
+---
+id: REV-IDX2S3
+type: review-checklist
+title: 'Review: Entity IDs must start with a letter or digit'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Automated Checks
+
+- [x] All tests pass (`just test`)
+- [x] Lint clean (`just lint`)
+- [x] Coverage maintained (`just coverage-check`)
+
+## Code Review
+
+- [x] ~~Run `/code-review` command~~ (N/A: one-line grammar change; human review on the PR)
+- [x] ~~All critical review-responses addressed~~ (N/A: none raised)
+- [x] ~~All significant review-responses addressed~~ (N/A: none raised)
+- [x] Self-reviewed the diff for unrelated changes
+
+**Review Responses:** None raised.
+
+## Acceptance Verification
+
+- [x] Each acceptance criterion tested (reference planning checklist)
+- [x] Test evidence documented in implementation checklist
+
+**Acceptance Status:**
+<!-- For each acceptance criterion, state PASS/FAIL with evidence -->
+
+## Documentation (enhancements only)
+
+Skip this section for bugs and internal refactors.
+
+- [x] ~~Docs-checklist created and linked via `has-docs`~~ (N/A: internal refactor)
+- [x] ~~User-facing documentation updated~~ (N/A: rationale lives in the ValidateID godoc)
+- [x] ~~Docs-checklist marked as done~~ (N/A: none created)
+
+**Docs Checklist:** N/A — internal refactor.
+
+## Final Checks
+
+- [x] Commit message explains the why, not just what
+- [x] No TODOs or FIXMEs left unaddressed
+- [x] Ready for another developer to use
+
+## Pull Request
+
+- [x] Run `/pr` command to create PR and monitor CI
+- [x] All CI checks pass
+- [x] PR URL documented below
+
+**PR:** <!-- e.g., https://github.com/org/repo/pull/123 -->

--- a/tickets/entities/tickets/TKT-2W96LY.md
+++ b/tickets/entities/tickets/TKT-2W96LY.md
@@ -1,0 +1,61 @@
+---
+id: TKT-2W96LY
+type: ticket
+title: Entity IDs must start with a letter or digit
+kind: refactor
+priority: low
+effort: xs
+status: done
+---
+
+## Description
+
+`entity.ValidateID` bans a leading `-` but still accepts a leading `_`, so
+`_private` is a legal entity ID today. Both are malformed as identifiers: `-rf`
+reads as an option flag, `_foo` as a hidden/private marker.
+
+Tighten the grammar so an ID must **start with a letter or digit**:
+
+before: ^[A-Za-z0-9_-]+$   plus an explicit leading-dash check after:
+^[A-Za-z0-9][A-Za-z0-9_-]*$
+
+### Why — and why NOT as a security control
+
+The existing leading-dash check was introduced (TKT-IZGF7T) as defence in depth
+against argument injection, because the entity ID reached an `sh -c` string in
+the documents renderer.
+
+That framing is being retired: TKT-QGHNVA removes request-derived data from the
+command line entirely, so command safety is structural rather than filtered.
+This ticket therefore **re-justifies** the rule on well-formedness grounds and
+says so explicitly in the godoc — an identifier opens with a letter or digit,
+the same as DNS labels, Kubernetes resource names, and most language
+identifiers.
+
+Keeping the rule but relabelling it matters: a future reader must not treat it
+as the thing preventing argument injection, or they will build on a guarantee
+that no longer lives here.
+
+### Scope
+
+IN: the grammar and its rationale, plus test coverage for a leading underscore
+(currently untested because it was legal).
+
+NOT IN: removing `{id}` from the shell string (TKT-QGHNVA) — that is the
+structural fix this rule stops standing in for.
+
+### Back-compat
+
+None affected. Every entity id across `tickets/` and `docs-project/` was
+scanned: zero start with a non-alphanumeric character. Generated ids are prefix
++ digits; manual ids are lowercase slugs.
+
+### Acceptance criteria
+
+1. `_private` and `-rf` are both rejected, naming the reason
+("must start with a letter or digit").
+2. `TKT-001`, `ai-integration`, `a`, `A1` still valid.
+3. storetest conformance and the ValidateID fuzz oracle stay green in every
+backend (the oracle is bidirectional, so a stricter rule requires the stores to
+actually reject the newly-invalid ids).
+4. The godoc states this is well-formedness, not command safety.

--- a/tickets/relations/TKT-2W96LY--affects--rest-api.md
+++ b/tickets/relations/TKT-2W96LY--affects--rest-api.md
@@ -1,0 +1,5 @@
+---
+from: TKT-2W96LY
+relation: affects
+to: rest-api
+---

--- a/tickets/relations/TKT-2W96LY--affects--store-backends.md
+++ b/tickets/relations/TKT-2W96LY--affects--store-backends.md
@@ -1,0 +1,5 @@
+---
+from: TKT-2W96LY
+relation: affects
+to: store-backends
+---

--- a/tickets/relations/TKT-2W96LY--has-implementation--IMPL-T91509.md
+++ b/tickets/relations/TKT-2W96LY--has-implementation--IMPL-T91509.md
@@ -1,0 +1,5 @@
+---
+from: TKT-2W96LY
+relation: has-implementation
+to: IMPL-T91509
+---

--- a/tickets/relations/TKT-2W96LY--has-planning--PLAN-EOHOV0.md
+++ b/tickets/relations/TKT-2W96LY--has-planning--PLAN-EOHOV0.md
@@ -1,0 +1,5 @@
+---
+from: TKT-2W96LY
+relation: has-planning
+to: PLAN-EOHOV0
+---

--- a/tickets/relations/TKT-2W96LY--has-review--REV-IDX2S3.md
+++ b/tickets/relations/TKT-2W96LY--has-review--REV-IDX2S3.md
@@ -1,0 +1,5 @@
+---
+from: TKT-2W96LY
+relation: has-review
+to: REV-IDX2S3
+---

--- a/tickets/relations/TKT-2W96LY--implements--FEAT-CO4YP.md
+++ b/tickets/relations/TKT-2W96LY--implements--FEAT-CO4YP.md
@@ -1,0 +1,5 @@
+---
+from: TKT-2W96LY
+relation: implements
+to: FEAT-CO4YP
+---


### PR DESCRIPTION
Closes TKT-2W96LY.

## What

```
before: ^[A-Za-z0-9_-]+$   plus an explicit leading-dash check
after:  ^[A-Za-z0-9][A-Za-z0-9_-]*$
```

The leading-dash ban already existed, but a leading **underscore** was still
legal — `_private` was a valid entity id. Both are malformed as identifiers:
`-rf` reads as an option flag, `_foo` as a hidden/private marker. DNS labels,
Kubernetes resource names, and most language identifiers all require a letter
or digit first.

## Why this is *not* a security change

The leading-dash rule was originally introduced (TKT-IZGF7T) as defence in
depth against argument injection, because the entity id reached an `sh -c`
string in the documents renderer.

**That framing is being retired.** TKT-QGHNVA removes request-derived data from
the command line entirely, so command safety becomes structural rather than
filtered. This PR keeps the rule but **re-justifies it on well-formedness
grounds**, and says so explicitly in the godoc:

> This is a well-formedness rule, NOT a security control — do not let it become
> load-bearing for command safety.

That relabelling is the point of the change as much as the underscore is. A
future reader must not treat this as the thing preventing argument injection,
or they will build on a guarantee that no longer lives here.

## Back-compat

None affected. Every entity id across `tickets/` and `docs-project/` was
scanned: **zero** start with a non-alphanumeric character. Generated ids are
prefix + digits; manual ids are lowercase slugs.

## Verification

- `go test ./...` — pass
- New case `leading_underscore` confirmed RUN and PASS (`_private` was legal
  before, so it had no coverage)
- Fuzz — load-bearing here, because `storetest/fuzz.go` uses `ValidateID` as a
  **bidirectional** oracle (`ValidateID(id) != nil` ⇒ the store must reject), so
  tightening the rule requires the backends to actually reject the newly-invalid
  ids: `FuzzValidateID` 20s (2.3M execs), `FuzzRenameKeyCollapse` 20s,
  `FuzzRelationKeyCollision` 20s — all pass
- `go test -tags postgres ./internal/store/...` against a real PostgreSQL 15 —
  pass
- `golangci-lint` 0 issues, `just arch-lint` OK

Two existing assertions were updated: they asserted the old message text
("may not start with a dash"). The ids rejected are unchanged; only the wording
moved to "must start with a letter or digit".
