### PR TITLE
feat(data-entry): SVG icon set replacing emoji (TKT-8GUI60)

### DIFF
--- a/docs-project/entities/guides/GUIDE-data-entry.md
+++ b/docs-project/entities/guides/GUIDE-data-entry.md
@@ -1650,7 +1650,40 @@ navigation:
 | `search`    | bool   | Link to the search page                                        |
 | `settings`  | bool   | Link to the settings page                                      |
 | `action`    | string | Action ID to trigger when clicked (renders as a sidebar button)|
+| `icon`      | string | Icon name; overrides the icon derived from the entry type (see below) |
 | `permission`| string | Hide this entry from users who lack the named ACL permission (see below) |
+
+#### Item icons
+
+Each entry gets an icon from its *type* — every `list:` entry the same list
+glyph, every `kanban:` the same board glyph. In a sidebar with several lists
+that means several identical rows, distinguishable only by their labels.
+
+`icon:` overrides it:
+
+```yaml
+navigation:
+  - group: "Tickets"
+    items:
+      - label: "My Tickets"
+        list: my_tickets
+        icon: inbox
+      - label: "Open Tickets"
+        list: open_tickets
+        icon: status
+      - label: "All Tickets"
+        list: all_tickets # no icon: keeps the derived list glyph
+```
+
+Valid names are the same set kanban columns use: `dashboard`, `list`,
+`kanban`, `search`, `analysis`, `apps`, `settings`, `document`, `sun`, `moon`,
+`inbox`, `progress`, `done`, `clock`, `status`. An unknown name is a config
+error at startup.
+
+An `action:` entry derives no icon of its own, so `icon:` is the only way to
+give one a symbol. A **group** cannot take an icon — it renders as a plain
+section title with nowhere to put one — and naming one there is an error
+rather than silently ignored.
 
 ### Groups
 

--- a/docs-project/entities/guides/GUIDE-data-entry.md
+++ b/docs-project/entities/guides/GUIDE-data-entry.md
@@ -1404,14 +1404,42 @@ kanbans:
 | `header`           | string | Markdown rendered above the board (info/help; see below)   |
 | `footer`           | string | Markdown rendered below the board                          |
 | `column_property`  | string | Property to group by for columns (must be enum/custom type)|
-| `columns`          | list   | Explicit column definitions (optional)                     |
+| `columns`          | list   | Explicit column definitions (`value`, `label`, `icon`)     |
 | `swimlane_property`| string | Property to group by for swimlanes (optional)              |
-| `swimlanes`        | list   | Explicit swimlane definitions (optional)                   |
+| `swimlanes`        | list   | Explicit swimlane definitions (`value`, `label`, `icon`)   |
 | `card`             | object | Card display configuration                                 |
 | `edit_form`        | string | Form name for editing cards (click to open)                |
 | `create_form`      | string | Form name for the "New" button                             |
 | `filters`          | list   | Static filters (same as lists)                             |
 | `filter_controls`  | list   | Interactive filter controls (same as lists)                |
+
+#### Column and swimlane icons
+
+Columns and swimlanes take an optional `icon:` — a **name**, not a glyph:
+
+```yaml
+columns:
+  - value: open
+    label: "To Do"
+    icon: inbox
+  - value: in-progress
+    label: "In Progress"
+    icon: progress
+  - value: resolved
+    label: "Done"
+    icon: done
+```
+
+Icons are SVG and inherit the current text colour, so they follow the light /
+dark theme and any styling applied to the header. Valid names:
+`dashboard`, `list`, `kanban`, `search`, `analysis`, `apps`, `settings`,
+`document`, `sun`, `moon`, `inbox`, `progress`, `done`, `clock`, `status`.
+An unknown name is a config error at startup, listing the valid set.
+
+You can still put an emoji directly in `label:` — it renders verbatim, and
+rela will never strip or reinterpret it. But an emoji cannot take the theme's
+colour and renders differently on every operating system, so `icon:` is
+preferred where one of the names above fits.
 
 #### Header and footer info regions
 

--- a/docs-project/entities/guides/GUIDE-data-entry.md
+++ b/docs-project/entities/guides/GUIDE-data-entry.md
@@ -1431,10 +1431,11 @@ columns:
 ```
 
 Icons are SVG and inherit the current text colour, so they follow the light /
-dark theme and any styling applied to the header. Valid names:
-`dashboard`, `list`, `kanban`, `search`, `analysis`, `apps`, `settings`,
-`document`, `sun`, `moon`, `inbox`, `progress`, `done`, `clock`, `status`.
-An unknown name is a config error at startup, listing the valid set.
+dark theme and any styling applied to the header.
+
+An unknown name is a config error at startup **that lists every valid name**, so
+the error message is the authoritative reference — deliberately not repeated
+here, where a copy would silently go stale as icons are added.
 
 You can still put an emoji directly in `label:` — it renders verbatim, and
 rela will never strip or reinterpret it. But an emoji cannot take the theme's
@@ -1675,10 +1676,8 @@ navigation:
         list: all_tickets # no icon: keeps the derived list glyph
 ```
 
-Valid names are the same set kanban columns use: `dashboard`, `list`,
-`kanban`, `search`, `analysis`, `apps`, `settings`, `document`, `sun`, `moon`,
-`inbox`, `progress`, `done`, `clock`, `status`. An unknown name is a config
-error at startup.
+Valid names are the same set kanban columns use. An unknown name is a config
+error at startup listing them all.
 
 An `action:` entry derives no icon of its own, so `icon:` is the only way to
 give one a symbol. A **group** cannot take an icon — it renders as a plain

--- a/docs/data-entry.md
+++ b/docs/data-entry.md
@@ -1398,14 +1398,42 @@ kanbans:
 | `header`           | string | Markdown rendered above the board (info/help; see below)   |
 | `footer`           | string | Markdown rendered below the board                          |
 | `column_property`  | string | Property to group by for columns (must be enum/custom type)|
-| `columns`          | list   | Explicit column definitions (optional)                     |
+| `columns`          | list   | Explicit column definitions (`value`, `label`, `icon`)     |
 | `swimlane_property`| string | Property to group by for swimlanes (optional)              |
-| `swimlanes`        | list   | Explicit swimlane definitions (optional)                   |
+| `swimlanes`        | list   | Explicit swimlane definitions (`value`, `label`, `icon`)   |
 | `card`             | object | Card display configuration                                 |
 | `edit_form`        | string | Form name for editing cards (click to open)                |
 | `create_form`      | string | Form name for the "New" button                             |
 | `filters`          | list   | Static filters (same as lists)                             |
 | `filter_controls`  | list   | Interactive filter controls (same as lists)                |
+
+#### Column and swimlane icons
+
+Columns and swimlanes take an optional `icon:` — a **name**, not a glyph:
+
+```yaml
+columns:
+  - value: open
+    label: "To Do"
+    icon: inbox
+  - value: in-progress
+    label: "In Progress"
+    icon: progress
+  - value: resolved
+    label: "Done"
+    icon: done
+```
+
+Icons are SVG and inherit the current text colour, so they follow the light /
+dark theme and any styling applied to the header. Valid names:
+`dashboard`, `list`, `kanban`, `search`, `analysis`, `apps`, `settings`,
+`document`, `sun`, `moon`, `inbox`, `progress`, `done`, `clock`, `status`.
+An unknown name is a config error at startup, listing the valid set.
+
+You can still put an emoji directly in `label:` — it renders verbatim, and
+rela will never strip or reinterpret it. But an emoji cannot take the theme's
+colour and renders differently on every operating system, so `icon:` is
+preferred where one of the names above fits.
 
 #### Header and footer info regions
 

--- a/docs/data-entry.md
+++ b/docs/data-entry.md
@@ -1644,7 +1644,40 @@ navigation:
 | `search`    | bool   | Link to the search page                                        |
 | `settings`  | bool   | Link to the settings page                                      |
 | `action`    | string | Action ID to trigger when clicked (renders as a sidebar button)|
+| `icon`      | string | Icon name; overrides the icon derived from the entry type (see below) |
 | `permission`| string | Hide this entry from users who lack the named ACL permission (see below) |
+
+#### Item icons
+
+Each entry gets an icon from its *type* — every `list:` entry the same list
+glyph, every `kanban:` the same board glyph. In a sidebar with several lists
+that means several identical rows, distinguishable only by their labels.
+
+`icon:` overrides it:
+
+```yaml
+navigation:
+  - group: "Tickets"
+    items:
+      - label: "My Tickets"
+        list: my_tickets
+        icon: inbox
+      - label: "Open Tickets"
+        list: open_tickets
+        icon: status
+      - label: "All Tickets"
+        list: all_tickets # no icon: keeps the derived list glyph
+```
+
+Valid names are the same set kanban columns use: `dashboard`, `list`,
+`kanban`, `search`, `analysis`, `apps`, `settings`, `document`, `sun`, `moon`,
+`inbox`, `progress`, `done`, `clock`, `status`. An unknown name is a config
+error at startup.
+
+An `action:` entry derives no icon of its own, so `icon:` is the only way to
+give one a symbol. A **group** cannot take an icon — it renders as a plain
+section title with nowhere to put one — and naming one there is an error
+rather than silently ignored.
 
 ### Groups
 

--- a/docs/data-entry.md
+++ b/docs/data-entry.md
@@ -1425,10 +1425,11 @@ columns:
 ```
 
 Icons are SVG and inherit the current text colour, so they follow the light /
-dark theme and any styling applied to the header. Valid names:
-`dashboard`, `list`, `kanban`, `search`, `analysis`, `apps`, `settings`,
-`document`, `sun`, `moon`, `inbox`, `progress`, `done`, `clock`, `status`.
-An unknown name is a config error at startup, listing the valid set.
+dark theme and any styling applied to the header.
+
+An unknown name is a config error at startup **that lists every valid name**, so
+the error message is the authoritative reference — deliberately not repeated
+here, where a copy would silently go stale as icons are added.
 
 You can still put an emoji directly in `label:` — it renders verbatim, and
 rela will never strip or reinterpret it. But an emoji cannot take the theme's
@@ -1669,10 +1670,8 @@ navigation:
         list: all_tickets # no icon: keeps the derived list glyph
 ```
 
-Valid names are the same set kanban columns use: `dashboard`, `list`,
-`kanban`, `search`, `analysis`, `apps`, `settings`, `document`, `sun`, `moon`,
-`inbox`, `progress`, `done`, `clock`, `status`. An unknown name is a config
-error at startup.
+Valid names are the same set kanban columns use. An unknown name is a config
+error at startup listing them all.
 
 An `action:` entry derives no icon of its own, so `icon:` is the only way to
 give one a symbol. A **group** cannot take an icon — it renders as a plain

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -15,6 +15,7 @@
         "dompurify": "^3.4.13",
         "easymde": "^2.21.0",
         "font-awesome": "^4.7.0",
+        "lucide-vue-next": "^1.0.0",
         "marked": "^18.0.6",
         "mermaid": "^11.16.1",
         "pinia": "^3.0.4",
@@ -5639,6 +5640,16 @@
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/lucide-vue-next": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/lucide-vue-next/-/lucide-vue-next-1.0.0.tgz",
+      "integrity": "sha512-V6SPvx1IHTj/UY+FrIYWV5faISsPSb8BnWSFDxAtezWKvWc9ZZ40PDrdu1/Qb5vg4lHWr1hs1BAMGVGm6V1Xdg==",
+      "deprecated": "Package deprecated. Please use @lucide/vue instead.",
+      "license": "ISC",
+      "peerDependencies": {
+        "vue": ">=3.0.1"
+      }
     },
     "node_modules/lz-string": {
       "version": "1.5.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -27,6 +27,7 @@
     "dompurify": "^3.4.13",
     "easymde": "^2.21.0",
     "font-awesome": "^4.7.0",
+    "lucide-vue-next": "^1.0.0",
     "marked": "^18.0.6",
     "mermaid": "^11.16.1",
     "pinia": "^3.0.4",

--- a/frontend/src/components/common/Sidebar.iconRender.test.ts
+++ b/frontend/src/components/common/Sidebar.iconRender.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { resolveIcon, ICONS } from '@/utils/icons'
+
+/**
+ * Render tests for the icon element the sidebar and kanban headers use.
+ *
+ * WHY THIS FILE EXISTS
+ * The registry tests verify `resolveIcon` returns the right component OBJECT.
+ * They cannot see whether a template actually binds it, whether the `size`
+ * prop survives, or whether CSS then distorts the result — and a real bug
+ * shipped through exactly that gap: `.nav-icon { width: 24px }` overrode
+ * Lucide's `width` presentation attribute while `height` stayed at 18, so
+ * every sidebar icon rendered 24x18. A squashed circle still reads as a
+ * circle at 18px, which is why review missed it.
+ *
+ * Mounting the icon directly (rather than the whole Sidebar, which needs a
+ * router, three stores and an API) is enough to pin the contract that broke:
+ * it must be an <svg> and it must be square.
+ */
+describe('sidebar icon element', () => {
+  it('renders an SVG, not a text glyph', () => {
+    const w = mount(resolveIcon('dashboard'), { props: { size: 18 } })
+    expect(w.element.tagName.toLowerCase()).toBe('svg')
+    // The emoji this replaced were text nodes; assert we are past that.
+    expect(w.text()).toBe('')
+  })
+
+  it('emits square width/height attributes for the requested size', () => {
+    // Lucide sets these as PRESENTATION attributes, which CSS can override —
+    // hence the paired assertion. If a stylesheet sets only `width`, the
+    // rendered box stops being square even though both attributes are 18.
+    const w = mount(resolveIcon('dashboard'), { props: { size: 18 } })
+    expect(w.attributes('width')).toBe('18')
+    expect(w.attributes('height')).toBe('18')
+  })
+
+  it('uses currentColor so it follows the theme', () => {
+    // The entire justification for replacing emoji: they could not inherit
+    // the surrounding text colour.
+    const w = mount(resolveIcon('dashboard'), { props: { size: 18 } })
+    expect(w.attributes('stroke')).toBe('currentColor')
+  })
+
+  it('renders the fallback for an unknown name rather than blowing up', () => {
+    const w = mount(resolveIcon('no-such-icon'), { props: { size: 18 } })
+    expect(w.element.tagName.toLowerCase()).toBe('svg')
+  })
+
+  it('renders every registered icon as an SVG', () => {
+    // Guards against a registry entry that is not a component at all.
+    for (const name of Object.keys(ICONS)) {
+      const w = mount(resolveIcon(name), { props: { size: 18 } })
+      expect(w.element.tagName.toLowerCase(), `icon ${name}`).toBe('svg')
+    }
+  })
+})

--- a/frontend/src/components/common/Sidebar.vue
+++ b/frontend/src/components/common/Sidebar.vue
@@ -102,12 +102,11 @@ function isActive(href: string): boolean {
   return route.path === href || route.path.startsWith(href + '/')
 }
 
-// Config-supplied icon names resolve through the shared allowlist registry;
-// unknown names fall back to a default rather than throwing, so a stale config
-// still renders. The name -> icon mapping used to live here as a switch
+// Icon names come from config and resolve through the shared allowlist
+// registry (utils/icons.ts); unknown names fall back to a default rather than
+// throwing, so a stale config still renders. This used to be a local switch
 // returning emoji, which could not take `currentColor`, ignored the theme, and
 // rendered differently on every OS.
-const navIcon = (icon?: string) => resolveIcon(icon)
 
 async function handleAction(item: SidebarItem, ev?: Event) {
   if (!item.action) return
@@ -165,7 +164,7 @@ async function handleAction(item: SidebarItem, ev?: Event) {
         <kbd v-if="!uiStore.sidebarCollapsed">/</kbd>
       </RouterLink>
       <RouterLink to="/analyze" class="nav-item" :class="{ active: route.path === '/analyze' }">
-        <component :is="ICONS.analysis" class="nav-icon" :size="18" aria-hidden="true" />
+        <component :is="ICONS.warning" class="nav-icon" :size="18" aria-hidden="true" />
         <span class="nav-label">Analysis</span>
       </RouterLink>
     </div>
@@ -183,7 +182,7 @@ async function handleAction(item: SidebarItem, ev?: Event) {
               :disabled="actionInFlight.has(item.action)"
               @click="handleAction(item, $event)"
             >
-              <component :is="navIcon(item.icon)" class="nav-icon" :size="18" aria-hidden="true" />
+              <component :is="resolveIcon(item.icon)" class="nav-icon" :size="18" aria-hidden="true" />
               <span class="nav-label">{{ item.label }}</span>
             </button>
             <RouterLink
@@ -192,7 +191,7 @@ async function handleAction(item: SidebarItem, ev?: Event) {
               class="nav-item"
               :class="{ active: isActive(item.href) }"
             >
-              <component :is="navIcon(item.icon)" class="nav-icon" :size="18" aria-hidden="true" />
+              <component :is="resolveIcon(item.icon)" class="nav-icon" :size="18" aria-hidden="true" />
               <span class="nav-label">{{ item.label }}</span>
               <span v-if="item.count !== undefined && !uiStore.sidebarCollapsed" class="nav-count">{{ item.count }}</span>
             </RouterLink>
@@ -208,7 +207,7 @@ async function handleAction(item: SidebarItem, ev?: Event) {
               :disabled="actionInFlight.has(item.action)"
               @click="handleAction(item, $event)"
             >
-              <component :is="navIcon(item.icon)" class="nav-icon" :size="18" aria-hidden="true" />
+              <component :is="resolveIcon(item.icon)" class="nav-icon" :size="18" aria-hidden="true" />
               <span class="nav-label">{{ item.label }}</span>
             </button>
             <RouterLink
@@ -217,7 +216,7 @@ async function handleAction(item: SidebarItem, ev?: Event) {
               class="nav-item"
               :class="{ active: isActive(item.href) }"
             >
-              <component :is="navIcon(item.icon)" class="nav-icon" :size="18" aria-hidden="true" />
+              <component :is="resolveIcon(item.icon)" class="nav-icon" :size="18" aria-hidden="true" />
               <span class="nav-label">{{ item.label }}</span>
               <span v-if="item.count !== undefined && !uiStore.sidebarCollapsed" class="nav-count">{{ item.count }}</span>
             </RouterLink>
@@ -376,15 +375,23 @@ async function handleAction(item: SidebarItem, ev?: Event) {
   border-right: 3px solid var(--accent-color, #6366f1);
 }
 
-/* SVG icons, not emoji: `width` keeps the 24px gutter the labels align to,
- * while flex-shrink stops the icon squashing when a label is long. The icon
- * inherits `currentColor` from .nav-item, which is the whole reason for the
- * swap — an emoji could not take the theme's colour, so it stayed the same
- * hue in light and dark mode and on hover. */
+/* SVG icons, not emoji. The icon inherits `currentColor` from .nav-item, which
+ * is the whole reason for the swap — an emoji could not take the theme's
+ * colour, so it stayed the same hue in light and dark mode and on hover.
+ *
+ * Do NOT set `width` here to make the gutter. Lucide emits width/height as
+ * PRESENTATION ATTRIBUTES, and CSS beats those — so `width: 24px` overrode the
+ * 18px attribute while `height` stayed at 18, rendering every icon 24x18 (a
+ * 4:3 horizontal stretch, easy to miss because a squashed circle still reads
+ * as a circle). Size comes from the `:size` prop; the 24px gutter the labels
+ * align to comes from the box model instead. */
 .nav-icon {
-  width: 24px;
-  flex-shrink: 0;
-  margin-right: 12px;
+  /* Size the BOX to the icon (18px, matching the :size prop) and make up the
+   * 24px gutter with margin. flex-basis is not an option: on a row flex item
+   * it resolves to the main-size, i.e. width — the same trap as setting
+   * `width` directly. */
+  flex: 0 0 auto;
+  margin-right: 18px;
 }
 
 .sidebar.collapsed .nav-icon {

--- a/frontend/src/components/common/Sidebar.vue
+++ b/frontend/src/components/common/Sidebar.vue
@@ -7,6 +7,7 @@ import { getSidebar, runAction } from '@/api'
 import { isCancelledFetch } from '@/composables/usePageData'
 import { ApiError, getErrorMessage, getScriptError } from '@/api/errors'
 import type { SidebarGroup, SidebarItem } from '@/types'
+import { resolveIcon, ICONS } from '@/utils/icons'
 
 const schemaStore = useSchemaStore()
 const uiStore = useUIStore()
@@ -101,14 +102,12 @@ function isActive(href: string): boolean {
   return route.path === href || route.path.startsWith(href + '/')
 }
 
-function getIconEmoji(icon?: string): string {
-  switch (icon) {
-    case 'list': return '📋'
-    case 'kanban': return '📊'
-    case 'dashboard': return '🏠'
-    default: return '📄'
-  }
-}
+// Config-supplied icon names resolve through the shared allowlist registry;
+// unknown names fall back to a default rather than throwing, so a stale config
+// still renders. The name -> icon mapping used to live here as a switch
+// returning emoji, which could not take `currentColor`, ignored the theme, and
+// rendered differently on every OS.
+const navIcon = (icon?: string) => resolveIcon(icon)
 
 async function handleAction(item: SidebarItem, ev?: Event) {
   if (!item.action) return
@@ -161,12 +160,12 @@ async function handleAction(item: SidebarItem, ev?: Event) {
     <!-- Fixed top items: Search and Analysis -->
     <div class="sidebar-top-items">
       <RouterLink to="/search" class="nav-item" :class="{ active: route.path === '/search' }">
-        <span class="nav-icon">🔍</span>
+        <component :is="ICONS.search" class="nav-icon" :size="18" aria-hidden="true" />
         <span class="nav-label">Search</span>
         <kbd v-if="!uiStore.sidebarCollapsed">/</kbd>
       </RouterLink>
       <RouterLink to="/analyze" class="nav-item" :class="{ active: route.path === '/analyze' }">
-        <span class="nav-icon">⚠️</span>
+        <component :is="ICONS.analysis" class="nav-icon" :size="18" aria-hidden="true" />
         <span class="nav-label">Analysis</span>
       </RouterLink>
     </div>
@@ -184,7 +183,7 @@ async function handleAction(item: SidebarItem, ev?: Event) {
               :disabled="actionInFlight.has(item.action)"
               @click="handleAction(item, $event)"
             >
-              <span class="nav-icon">{{ getIconEmoji(item.icon) }}</span>
+              <component :is="navIcon(item.icon)" class="nav-icon" :size="18" aria-hidden="true" />
               <span class="nav-label">{{ item.label }}</span>
             </button>
             <RouterLink
@@ -193,7 +192,7 @@ async function handleAction(item: SidebarItem, ev?: Event) {
               class="nav-item"
               :class="{ active: isActive(item.href) }"
             >
-              <span class="nav-icon">{{ getIconEmoji(item.icon) }}</span>
+              <component :is="navIcon(item.icon)" class="nav-icon" :size="18" aria-hidden="true" />
               <span class="nav-label">{{ item.label }}</span>
               <span v-if="item.count !== undefined && !uiStore.sidebarCollapsed" class="nav-count">{{ item.count }}</span>
             </RouterLink>
@@ -209,7 +208,7 @@ async function handleAction(item: SidebarItem, ev?: Event) {
               :disabled="actionInFlight.has(item.action)"
               @click="handleAction(item, $event)"
             >
-              <span class="nav-icon">{{ getIconEmoji(item.icon) }}</span>
+              <component :is="navIcon(item.icon)" class="nav-icon" :size="18" aria-hidden="true" />
               <span class="nav-label">{{ item.label }}</span>
             </button>
             <RouterLink
@@ -218,7 +217,7 @@ async function handleAction(item: SidebarItem, ev?: Event) {
               class="nav-item"
               :class="{ active: isActive(item.href) }"
             >
-              <span class="nav-icon">{{ getIconEmoji(item.icon) }}</span>
+              <component :is="navIcon(item.icon)" class="nav-icon" :size="18" aria-hidden="true" />
               <span class="nav-label">{{ item.label }}</span>
               <span v-if="item.count !== undefined && !uiStore.sidebarCollapsed" class="nav-count">{{ item.count }}</span>
             </RouterLink>
@@ -236,7 +235,7 @@ async function handleAction(item: SidebarItem, ev?: Event) {
           class="nav-item"
           :class="{ active: isActive(`/app/${app.id}`) }"
         >
-          <span class="nav-icon">🧩</span>
+          <component :is="ICONS.apps" class="nav-icon" :size="18" aria-hidden="true" />
           <span class="nav-label">{{ app.label }}</span>
         </RouterLink>
       </div>
@@ -249,7 +248,7 @@ async function handleAction(item: SidebarItem, ev?: Event) {
         <span class="nav-label">{{ gitStore.branch }} · {{ gitStore.statusText }}</span>
       </div>
       <RouterLink to="/settings" class="nav-item" :class="{ active: route.path === '/settings' }">
-        <span class="nav-icon">⚙️</span>
+        <component :is="ICONS.settings" class="nav-icon" :size="18" aria-hidden="true" />
         <span class="nav-label">Settings</span>
       </RouterLink>
       <button
@@ -257,7 +256,7 @@ async function handleAction(item: SidebarItem, ev?: Event) {
         class="nav-item nav-action"
         @click="uiStore.toggleDarkMode()"
       >
-        <span class="nav-icon">{{ uiStore.isDark ? '☀️' : '🌙' }}</span>
+        <component :is="uiStore.isDark ? ICONS.sun : ICONS.moon" class="nav-icon" :size="18" aria-hidden="true" />
         <span class="nav-label">{{ uiStore.isDark ? 'Light Mode' : 'Dark Mode' }}</span>
       </button>
     </div>
@@ -377,10 +376,15 @@ async function handleAction(item: SidebarItem, ev?: Event) {
   border-right: 3px solid var(--accent-color, #6366f1);
 }
 
+/* SVG icons, not emoji: `width` keeps the 24px gutter the labels align to,
+ * while flex-shrink stops the icon squashing when a label is long. The icon
+ * inherits `currentColor` from .nav-item, which is the whole reason for the
+ * swap — an emoji could not take the theme's colour, so it stayed the same
+ * hue in light and dark mode and on hover. */
 .nav-icon {
   width: 24px;
+  flex-shrink: 0;
   margin-right: 12px;
-  text-align: center;
 }
 
 .sidebar.collapsed .nav-icon {

--- a/frontend/src/types/config.ts
+++ b/frontend/src/types/config.ts
@@ -288,11 +288,19 @@ export interface KanbanColumn {
   value: string
   label?: string
   color?: string
+  /**
+   * Name of an icon from the shared registry (see utils/icons.ts), rendered
+   * beside the label. A NAME, never a glyph: an emoji written into `label`
+   * renders verbatim, and the SPA never parses one back out of label text.
+   */
+  icon?: string
 }
 
 export interface KanbanSwimlane {
   value: string
   label?: string
+  /** Icon name; see KanbanColumn.icon. */
+  icon?: string
 }
 
 export interface KanbanCardField {

--- a/frontend/src/utils/icons.test.ts
+++ b/frontend/src/utils/icons.test.ts
@@ -54,13 +54,13 @@ describe('icon registry', () => {
       'list',
       'kanban',
       'search',
-      'analysis',
+      'warning',
       'apps',
       'settings',
       'sun',
       'moon',
       'inbox',
-      'progress',
+      'wrench',
       'done',
     ]) {
       expect(isKnownIcon(required)).toBe(true)

--- a/frontend/src/utils/icons.test.ts
+++ b/frontend/src/utils/icons.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from 'vitest'
+import { resolveIcon, isKnownIcon, ICONS, DEFAULT_ICON, iconNames } from './icons'
+
+describe('resolveIcon', () => {
+  it('resolves every name in the registry to its own component', () => {
+    for (const name of iconNames()) {
+      expect(resolveIcon(name)).toBe(ICONS[name])
+    }
+  })
+
+  it('falls back to the default for an unknown name rather than throwing', () => {
+    // The server rejects unknown names at config load — that is where an
+    // author gets told. This path exists so a stale config, an older server,
+    // or a hand-crafted response still renders something.
+    expect(resolveIcon('no-such-icon')).toBe(DEFAULT_ICON)
+    expect(resolveIcon(undefined)).toBe(DEFAULT_ICON)
+    expect(resolveIcon(null)).toBe(DEFAULT_ICON)
+    expect(resolveIcon('')).toBe(DEFAULT_ICON)
+  })
+
+  it('never returns undefined, so callers can bind it without a guard', () => {
+    for (const name of ['', 'x', '__proto__', 'constructor', 'toString']) {
+      expect(resolveIcon(name)).toBeTruthy()
+    }
+  })
+
+  it('does not resolve inherited Object properties as icons', () => {
+    // A plain `ICONS[name]` lookup would return Object.prototype.toString for
+    // `toString`, which is not a component and would break the render. The
+    // fallback has to win for prototype keys too.
+    expect(resolveIcon('toString')).toBe(DEFAULT_ICON)
+    expect(resolveIcon('constructor')).toBe(DEFAULT_ICON)
+    expect(isKnownIcon('toString')).toBe(false)
+    expect(isKnownIcon('constructor')).toBe(false)
+  })
+})
+
+describe('icon registry', () => {
+  it('exposes the names the config allowlist mirrors', () => {
+    // The Go side (dataentryconfig.ValidIconNames) is pinned to this list by
+    // TestIconAllowlistMatchesFrontend. This assertion only guards the shape
+    // that test parses — a registry that stopped being a flat name->component
+    // map would break it silently.
+    const names = iconNames()
+    expect(names.length).toBeGreaterThan(0)
+    for (const name of names) {
+      expect(name).toMatch(/^[a-z][a-z0-9-]*$/)
+    }
+  })
+
+  it('includes the names the sidebar and prototype config depend on', () => {
+    for (const required of [
+      'dashboard',
+      'list',
+      'kanban',
+      'search',
+      'analysis',
+      'apps',
+      'settings',
+      'sun',
+      'moon',
+      'inbox',
+      'progress',
+      'done',
+    ]) {
+      expect(isKnownIcon(required)).toBe(true)
+    }
+  })
+})

--- a/frontend/src/utils/icons.ts
+++ b/frontend/src/utils/icons.ts
@@ -1,0 +1,84 @@
+/** Icon registry — the ONLY place a config string becomes an icon component.
+ *
+ * Icon names arrive from project-authored data-entry.yaml (navigation entries,
+ * kanban columns/swimlanes). Resolution is a STATIC ALLOWLIST lookup, never
+ * dynamic component resolution from the string: a config value must never be
+ * able to name an arbitrary component. Unknown names fall back to a default
+ * rather than throwing, so a stale or hand-edited config still renders — the
+ * server rejects unknown names at load, which is where an author gets told.
+ *
+ * Icons are Lucide (ISC), imported by name so the bundler tree-shakes the rest.
+ * They render as inline SVG with `stroke="currentColor"`, which is the whole
+ * point of the migration: the emoji they replace could not take the theme's
+ * colour, rendered differently per OS, and sat on an inconsistent baseline.
+ *
+ * Adding an icon: import it, add one entry to ICONS, and add the same name to
+ * the Go allowlist in internal/dataentryconfig (validIconNames). The two lists
+ * are pinned to each other by a test — a name the SPA can render but the config
+ * validator rejects (or vice versa) is a broken contract in either direction.
+ */
+import type { Component } from 'vue'
+import {
+  AlertTriangle,
+  Blocks,
+  CheckCircle2,
+  CircleDot,
+  Clock,
+  FileText,
+  Home,
+  Inbox,
+  Kanban,
+  List,
+  Moon,
+  Search,
+  Settings,
+  Sun,
+  Wrench,
+} from 'lucide-vue-next'
+
+/** DEFAULT_ICON renders for any name not in the allowlist. */
+export const DEFAULT_ICON: Component = FileText
+
+/** ICONS maps a config-facing name to its component. Keys are the public
+ * contract — renaming one breaks every project that authored it. */
+export const ICONS: Record<string, Component> = {
+  // Navigation
+  dashboard: Home,
+  list: List,
+  kanban: Kanban,
+  search: Search,
+  analysis: AlertTriangle,
+  apps: Blocks,
+  settings: Settings,
+  document: FileText,
+  // Theme toggle
+  sun: Sun,
+  moon: Moon,
+  // Workflow-ish names, useful for kanban columns
+  inbox: Inbox,
+  progress: Wrench,
+  done: CheckCircle2,
+  clock: Clock,
+  status: CircleDot,
+}
+
+/** iconNames lists every valid name, for tests and error messages. */
+export const iconNames = (): string[] => Object.keys(ICONS).sort()
+
+/**
+ * resolveIcon returns the component for a config-supplied name.
+ *
+ * Falls back to DEFAULT_ICON for an unknown or absent name — never throws and
+ * never returns undefined, so a caller can bind the result straight to
+ * `<component :is>` without a guard.
+ */
+export function resolveIcon(name?: string | null): Component {
+  if (!name) return DEFAULT_ICON
+  return ICONS[name] ?? DEFAULT_ICON
+}
+
+/** isKnownIcon reports whether a name resolves to a real icon (not the
+ * fallback). Used by tests; the server is what validates author input. */
+export function isKnownIcon(name?: string | null): boolean {
+  return !!name && Object.hasOwn(ICONS, name)
+}

--- a/frontend/src/utils/icons.ts
+++ b/frontend/src/utils/icons.ts
@@ -47,16 +47,16 @@ export const ICONS: Record<string, Component> = {
   list: List,
   kanban: Kanban,
   search: Search,
-  analysis: AlertTriangle,
+  warning: AlertTriangle,
   apps: Blocks,
   settings: Settings,
   document: FileText,
   // Theme toggle
   sun: Sun,
   moon: Moon,
-  // Workflow-ish names, useful for kanban columns
+  // Glyph-descriptive names, useful for kanban columns and nav items
   inbox: Inbox,
-  progress: Wrench,
+  wrench: Wrench,
   done: CheckCircle2,
   clock: Clock,
   status: CircleDot,

--- a/frontend/src/utils/icons.ts
+++ b/frontend/src/utils/icons.ts
@@ -73,12 +73,19 @@ export const iconNames = (): string[] => Object.keys(ICONS).sort()
  * `<component :is>` without a guard.
  */
 export function resolveIcon(name?: string | null): Component {
-  if (!name) return DEFAULT_ICON
-  return ICONS[name] ?? DEFAULT_ICON
+  // isKnownIcon, not `ICONS[name] ?? DEFAULT_ICON`: a bare index lookup finds
+  // INHERITED Object.prototype members, so a config naming `toString` or
+  // `constructor` would yield a function that is not a component and blow up
+  // the render. An own-property check is the difference between a fallback
+  // icon and a crash.
+  if (!isKnownIcon(name)) return DEFAULT_ICON
+  return ICONS[name]
 }
 
 /** isKnownIcon reports whether a name resolves to a real icon (not the
- * fallback). Used by tests; the server is what validates author input. */
-export function isKnownIcon(name?: string | null): boolean {
-  return !!name && Object.hasOwn(ICONS, name)
+ * fallback). A type predicate so callers can index ICONS afterwards. Used by
+ * tests; the server is what validates author input. */
+export function isKnownIcon(name?: string | null): name is string {
+  // Not Object.hasOwn — the project's TS lib target predates it.
+  return !!name && Object.prototype.hasOwnProperty.call(ICONS, name)
 }

--- a/frontend/src/views/KanbanView.vue
+++ b/frontend/src/views/KanbanView.vue
@@ -6,7 +6,7 @@ import { useSchemaStore, useUIStore } from '@/stores'
 import { listAllEntities, updateEntity, getErrorMessage } from '@/api'
 import { entityKeys } from '@/queries/entities'
 import { beginOptimistic, rollbackOptimistic, settleOptimistic } from '@/queries/optimisticList'
-import type { Entity, KanbanConfig, KanbanCardField } from '@/types'
+import type { Entity, KanbanConfig, KanbanCardField, KanbanColumn, KanbanSwimlane } from '@/types'
 import { viewHeaderMarkdown, viewFooterMarkdown } from '@/types'
 import Badge from '@/components/common/Badge.vue'
 import BackButton from '@/components/common/BackButton.vue'
@@ -14,6 +14,7 @@ import { useBackTarget } from '@/composables/useBackTarget'
 import { actionAllowed } from '@/utils/affordancesWarning'
 import { entityDisplayTitle } from '@/utils/entityDisplay'
 import { renderMarkdown } from '@/utils/markdown'
+import { resolveIcon } from '@/utils/icons'
 
 const props = defineProps<{
   id: string
@@ -125,7 +126,7 @@ const columns = computed(() => {
     const val = String(entity.properties[property] || '')
     if (val) values.add(val)
   }
-  return Array.from(values).map((v) => ({ value: v, label: v }))
+  return Array.from(values).map((v): KanbanColumn => ({ value: v, label: v }))
 })
 
 const filteredEntities = computed(() => {
@@ -175,7 +176,7 @@ const swimlanes = computed(() => {
     const val = String(entity.properties[property] || '')
     if (val) values.add(val)
   }
-  return Array.from(values).sort().map((v) => ({ value: v, label: v }))
+  return Array.from(values).sort().map((v): KanbanSwimlane => ({ value: v, label: v }))
 })
 
 const hasSwimmlanes = computed(() => swimlanes.value.length > 0)
@@ -503,6 +504,13 @@ function createNew() {
         @drop="onDrop($event, column.value)"
       >
         <div class="column-header">
+          <component
+            :is="resolveIcon(column.icon)"
+            v-if="column.icon"
+            class="column-icon"
+            :size="16"
+            aria-hidden="true"
+          />
           <span class="column-title">{{ columnTitle(column) }}</span>
           <span class="column-count">{{ entitiesByColumn[column.value]?.length || 0 }}</span>
         </div>
@@ -554,6 +562,13 @@ function createNew() {
           :key="column.value"
           class="swimlane-column-header"
         >
+          <component
+            :is="resolveIcon(column.icon)"
+            v-if="column.icon"
+            class="column-icon"
+            :size="16"
+            aria-hidden="true"
+          />
           <span class="column-title">{{ columnTitle(column) }}</span>
         </div>
       </div>
@@ -565,6 +580,13 @@ function createNew() {
         class="swimlane-row"
       >
         <div class="swimlane-label-cell">
+          <component
+            :is="resolveIcon(swimlane.icon)"
+            v-if="swimlane.icon"
+            class="column-icon"
+            :size="16"
+            aria-hidden="true"
+          />
           <span class="swimlane-label">{{ swimlane.label || swimlane.value }}</span>
         </div>
         <div
@@ -763,6 +785,14 @@ function createNew() {
   align-items: center;
   padding: 12px 16px;
   border-bottom: 1px solid var(--border-color);
+}
+
+/* Config-authored icon beside a column or swimlane label. Inherits
+ * currentColor, so it follows the theme — the emoji it replaces could not. */
+.column-icon {
+  flex-shrink: 0;
+  margin-right: var(--space-xs);
+  vertical-align: text-bottom;
 }
 
 .column-title {

--- a/internal/dataentry/nav_icon_test.go
+++ b/internal/dataentry/nav_icon_test.go
@@ -1,0 +1,66 @@
+package dataentry
+
+import (
+	"testing"
+
+	"github.com/Sourcehaven-BV/rela/internal/dataentryconfig"
+)
+
+// TestNavEntryIcon covers the authored `icon:` override on a navigation entry.
+//
+// Without it the icon is derived from the entry's KIND, so every list entry
+// gets the same glyph and every board the same one — a sidebar of five lists
+// reads as five identical rows distinguished only by their labels. The
+// override exists so an author can tell them apart.
+func TestNavEntryIcon(t *testing.T) {
+	app := newTestAppV1(t)
+
+	tests := []struct {
+		name  string
+		entry dataentryconfig.NavigationEntry
+		want  string
+	}{
+		{
+			"derived from kind when unset",
+			dataentryconfig.NavigationEntry{Label: "Dash", Dashboard: true},
+			"dashboard",
+		},
+		{
+			"authored icon overrides the derived one",
+			dataentryconfig.NavigationEntry{Label: "Dash", Dashboard: true, Icon: "inbox"},
+			"inbox",
+		},
+		{
+			"search keeps its derived icon",
+			dataentryconfig.NavigationEntry{Label: "Find", Search: true},
+			"search",
+		},
+		{
+			"search can be overridden too",
+			dataentryconfig.NavigationEntry{Label: "Find", Search: true, Icon: "clock"},
+			"clock",
+		},
+		{
+			// An action derives NO icon, so before the override it was the one
+			// entry kind that could never have one. The override is applied
+			// after the switch precisely so this case is covered.
+			"an action entry can finally have an icon",
+			dataentryconfig.NavigationEntry{Label: "Run", Action: "sync", Icon: "progress"},
+			"progress",
+		},
+		{
+			"an action without an icon still has none",
+			dataentryconfig.NavigationEntry{Label: "Run", Action: "sync"},
+			"",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			item := app.views.navEntryToSidebarItem(t.Context(), tc.entry, sidebarCounts{})
+			if item.Icon != tc.want {
+				t.Errorf("Icon = %q, want %q", item.Icon, tc.want)
+			}
+		})
+	}
+}

--- a/internal/dataentry/views_handler.go
+++ b/internal/dataentry/views_handler.go
@@ -472,6 +472,14 @@ func (h *viewsHandler) navEntryToSidebarItem(
 		// Href stays empty — frontend renders this as a button
 	}
 
+	// An authored icon wins over the kind-derived default set above. Applied
+	// after the switch so it covers every branch — including `action`, which
+	// derives no icon of its own and would otherwise be the one entry kind
+	// that could never have one.
+	if entry.Icon != "" {
+		item.Icon = entry.Icon
+	}
+
 	return item
 }
 

--- a/internal/dataentryconfig/config.go
+++ b/internal/dataentryconfig/config.go
@@ -577,6 +577,16 @@ type NavigationEntry struct {
 	// validateNavEntry.
 	Document string `yaml:"document,omitempty" json:"document,omitempty"`
 
+	// Icon overrides the icon derived from the entry's kind. Without it every
+	// list entry gets the same list glyph and every board the same board one,
+	// so "My Tickets" and "Open Tickets" are visually identical — the sidebar
+	// carries no signal beyond its labels. Names come from the shared registry
+	// (see ValidIconNames); an unknown one is a load-time error.
+	//
+	// Action entries have no derived icon at all, so for those this is the
+	// only way to get one.
+	Icon string `yaml:"icon,omitempty" json:"icon,omitempty"`
+
 	// Permission optionally hides this entry from the sidebar for principals
 	// who do not hold the named global ACL permission (TKT-TXDK8U). Empty —
 	// the overwhelmingly common case — means the entry is always shown.

--- a/internal/dataentryconfig/config.go
+++ b/internal/dataentryconfig/config.go
@@ -7,6 +7,7 @@ package dataentryconfig
 import (
 	"fmt"
 	"net/url"
+	"strings"
 
 	"gopkg.in/yaml.v3"
 
@@ -232,6 +233,49 @@ func (s *Span) UnmarshalYAML(value *yaml.Node) error {
 	}
 	*s = Span(int(f))
 	return nil
+}
+
+// ValidIconNames is the allowlist of icon names an author may reference from
+// data-entry.yaml. It MUST stay in step with the SPA's registry in
+// frontend/src/utils/icons.ts — TestIconAllowlistMatchesFrontend reads that
+// file and fails on drift, in either direction: a name the config accepts but
+// the SPA can't render silently degrades to a fallback icon, and a name the SPA
+// knows but the config rejects is a feature an author can't reach.
+//
+// Exported so the icon-name check and its test share one source.
+var ValidIconNames = map[string]bool{
+	// Navigation
+	"dashboard": true,
+	"list":      true,
+	"kanban":    true,
+	"search":    true,
+	"analysis":  true,
+	"apps":      true,
+	"settings":  true,
+	"document":  true,
+	// Theme toggle
+	"sun":  true,
+	"moon": true,
+	// Workflow-ish names, useful for kanban columns
+	"inbox":    true,
+	"progress": true,
+	"done":     true,
+	"clock":    true,
+	"status":   true,
+}
+
+// validateIconName reports a config error for an unknown icon name.
+//
+// Loud at load, like validateSpan: the SPA falls back to a default icon so a
+// stale config still renders, but silently swapping an author's chosen icon for
+// a generic one with no diagnostic is the failure mode strict validation exists
+// to prevent. An empty name means "no icon" and is always valid.
+func validateIconName(icon, context string) []string {
+	if icon == "" || ValidIconNames[icon] {
+		return nil
+	}
+	return []string{fmt.Sprintf("%s: unknown icon %q (valid: %s)",
+		context, icon, strings.Join(sortedMapKeys(ValidIconNames), ", "))}
 }
 
 // validateSpan reports a config error for an out-of-range span.
@@ -471,15 +515,25 @@ type Kanban struct {
 }
 
 // KanbanColumn defines a column in the kanban board.
+// Icon names an icon from the shared registry to render beside the label
+// (see ValidIconNames). It is a NAME, never a glyph: putting an emoji in
+// Label works and is left alone, but the SPA will never parse one back out
+// of label text — that would silently rewrite what an author typed.
 type KanbanColumn struct {
 	Value string `yaml:"value" json:"value"`
 	Label string `yaml:"label,omitempty" json:"label,omitempty"`
+	Icon  string `yaml:"icon,omitempty" json:"icon,omitempty"`
 }
 
 // KanbanSwimlane defines a swimlane row in the kanban board.
+//
+// Carries Icon for the same reason KanbanColumn does: identical Value/Label
+// shape, rendered the same way, so supporting one and not the other would be
+// an arbitrary asymmetry an author would trip over.
 type KanbanSwimlane struct {
 	Value string `yaml:"value" json:"value"`
 	Label string `yaml:"label,omitempty" json:"label,omitempty"`
+	Icon  string `yaml:"icon,omitempty" json:"icon,omitempty"`
 }
 
 // KanbanCard defines how cards are displayed on the board.

--- a/internal/dataentryconfig/config.go
+++ b/internal/dataentryconfig/config.go
@@ -249,7 +249,7 @@ var ValidIconNames = map[string]bool{
 	"list":      true,
 	"kanban":    true,
 	"search":    true,
-	"analysis":  true,
+	"warning":   true,
 	"apps":      true,
 	"settings":  true,
 	"document":  true,
@@ -257,11 +257,11 @@ var ValidIconNames = map[string]bool{
 	"sun":  true,
 	"moon": true,
 	// Workflow-ish names, useful for kanban columns
-	"inbox":    true,
-	"progress": true,
-	"done":     true,
-	"clock":    true,
-	"status":   true,
+	"inbox":  true,
+	"wrench": true,
+	"done":   true,
+	"clock":  true,
+	"status": true,
 }
 
 // validateIconName reports a config error for an unknown icon name.

--- a/internal/dataentryconfig/icons_test.go
+++ b/internal/dataentryconfig/icons_test.go
@@ -1,0 +1,108 @@
+package dataentryconfig
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// iconKeyRe matches an entry in the SPA registry's ICONS map, e.g. `  list: List,`
+// or `  "kanban": Kanban,`. Deliberately anchored to two-space indentation so
+// it matches map entries and not the surrounding prose or imports.
+var iconKeyRe = regexp.MustCompile(`(?m)^\s{2}"?([a-z][a-z0-9-]*)"?:\s*[A-Z]`)
+
+// TestIconAllowlistMatchesFrontend pins the Go icon allowlist to the SPA's
+// registry (frontend/src/utils/icons.ts).
+//
+// The two lists are a contract in BOTH directions, and each kind of drift is a
+// distinct bug:
+//
+//   - A name Go accepts but the SPA cannot render passes config validation and
+//     then silently falls back to a generic icon — the author sees a wrong icon
+//     with no error anywhere.
+//   - A name the SPA knows but Go rejects is a feature an author cannot reach:
+//     the config fails to load with "unknown icon" for something that would
+//     have rendered perfectly.
+//
+// Comparing the two real sources (rather than either against a third literal
+// list in this file) is what makes this a contract test instead of a
+// restatement. The pattern follows TestAppTokensCSSInSyncWithFrontend, which
+// pins the color tokens the same way.
+func TestIconAllowlistMatchesFrontend(t *testing.T) {
+	src, err := os.ReadFile(filepath.Join("..", "..", "frontend", "src", "utils", "icons.ts"))
+	if err != nil {
+		t.Fatalf("read frontend icons.ts: %v", err)
+	}
+
+	// Scope to the ICONS map body so an unrelated object literal elsewhere in
+	// the file can't contribute phantom names.
+	body := string(src)
+	start := strings.Index(body, "export const ICONS")
+	if start < 0 {
+		t.Fatal("frontend icons.ts no longer exports an ICONS map — update this test with it")
+	}
+	end := strings.Index(body[start:], "\n}")
+	if end < 0 {
+		t.Fatal("could not find the end of the ICONS map in frontend icons.ts")
+	}
+	body = body[start : start+end]
+
+	spa := map[string]bool{}
+	for _, m := range iconKeyRe.FindAllStringSubmatch(body, -1) {
+		spa[m[1]] = true
+	}
+	if len(spa) == 0 {
+		t.Fatal("parsed zero icon names from frontend icons.ts — the regexp has drifted from the file's shape")
+	}
+
+	var missingInGo, missingInSPA []string
+	for name := range spa {
+		if !ValidIconNames[name] {
+			missingInGo = append(missingInGo, name)
+		}
+	}
+	for name := range ValidIconNames {
+		if !spa[name] {
+			missingInSPA = append(missingInSPA, name)
+		}
+	}
+	sort.Strings(missingInGo)
+	sort.Strings(missingInSPA)
+
+	if len(missingInSPA) > 0 {
+		t.Errorf("ValidIconNames accepts %v, which the SPA cannot render — "+
+			"a config using one would validate and then show a fallback icon with no error",
+			missingInSPA)
+	}
+	if len(missingInGo) > 0 {
+		t.Errorf("frontend icons.ts defines %v, which ValidIconNames rejects — "+
+			"an author cannot use icons the SPA already supports",
+			missingInGo)
+	}
+}
+
+// TestValidateIconName covers the allowlist check used by kanban columns and
+// swimlanes.
+func TestValidateIconName(t *testing.T) {
+	if errs := validateIconName("", "kanban \"x\": columns[0]"); len(errs) != 0 {
+		t.Errorf("empty icon means 'no icon' and must be valid, got %v", errs)
+	}
+	if errs := validateIconName("inbox", "kanban \"x\": columns[0]"); len(errs) != 0 {
+		t.Errorf("known icon must be valid, got %v", errs)
+	}
+	errs := validateIconName("nope", "kanban \"x\": columns[2]")
+	if len(errs) == 0 {
+		t.Fatal("unknown icon must be rejected")
+	}
+	// Locate the offending entry and list the alternatives: a config can hold
+	// dozens of columns, and "unknown icon" alone would send the author hunting.
+	if !strings.Contains(errs[0], "columns[2]") {
+		t.Errorf("message must locate the offending entry, got %q", errs[0])
+	}
+	if !strings.Contains(errs[0], "valid:") {
+		t.Errorf("message must list the valid names, got %q", errs[0])
+	}
+}

--- a/internal/dataentryconfig/icons_test.go
+++ b/internal/dataentryconfig/icons_test.go
@@ -12,7 +12,7 @@ import (
 // iconKeyRe matches an entry in the SPA registry's ICONS map, e.g. `  list: List,`
 // or `  "kanban": Kanban,`. Deliberately anchored to two-space indentation so
 // it matches map entries and not the surrounding prose or imports.
-var iconKeyRe = regexp.MustCompile(`(?m)^\s{2}"?([a-z][a-z0-9-]*)"?:\s*[A-Z]`)
+var iconKeyRe = regexp.MustCompile(`(?m)^\s+"?([a-zA-Z][a-zA-Z0-9-]*)"?:\s*\S`)
 
 // TestIconAllowlistMatchesFrontend pins the Go icon allowlist to the SPA's
 // registry (frontend/src/utils/icons.ts).
@@ -54,8 +54,18 @@ func TestIconAllowlistMatchesFrontend(t *testing.T) {
 	for _, m := range iconKeyRe.FindAllStringSubmatch(body, -1) {
 		spa[m[1]] = true
 	}
-	if len(spa) == 0 {
-		t.Fatal("parsed zero icon names from frontend icons.ts — the regexp has drifted from the file's shape")
+	// A COUNT check, not a non-empty check. The dangerous failure is a PARTIAL
+	// parse: a spread, a nested literal, an aliased import or a commented-out
+	// entry makes one name invisible while the rest still parse, so a
+	// non-empty guard stays silent and the test quietly stops covering that
+	// name. Comparing against the Go list's length turns any parse regression
+	// into a failure, because the two must be the same size by definition.
+	if len(spa) != len(ValidIconNames) {
+		t.Fatalf("parsed %d names from frontend icons.ts but ValidIconNames has %d — "+
+			"either the lists genuinely differ (see the errors below) or the parser "+
+			"has drifted from the file's shape (a spread, nested literal, or aliased "+
+			"import will do it). Parsed: %v",
+			len(spa), len(ValidIconNames), sortedKeys(spa))
 	}
 
 	var missingInGo, missingInSPA []string
@@ -149,4 +159,14 @@ func TestNavigationIconValidation(t *testing.T) {
 			}
 		})
 	}
+}
+
+// sortedKeys returns a map's keys sorted, for deterministic failure output.
+func sortedKeys(m map[string]bool) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
 }

--- a/internal/dataentryconfig/icons_test.go
+++ b/internal/dataentryconfig/icons_test.go
@@ -106,3 +106,47 @@ func TestValidateIconName(t *testing.T) {
 		t.Errorf("message must list the valid names, got %q", errs[0])
 	}
 }
+
+// TestNavigationIconValidation covers `icon:` on navigation entries.
+//
+// Without an authored icon every list entry gets the same derived glyph, so a
+// sidebar of five lists carries no signal beyond its labels. The override has
+// to be validated like any other config name: loudly, at load.
+func TestNavigationIconValidation(t *testing.T) {
+	tests := []struct {
+		name    string
+		nav     NavigationEntry
+		wantErr string
+	}{
+		{"no icon is fine", NavigationEntry{Label: "Tickets", Dashboard: true}, ""},
+		{"known icon on an item", NavigationEntry{Label: "Inbox", Dashboard: true, Icon: "inbox"}, ""},
+		{"unknown icon is rejected", NavigationEntry{Label: "Inbox", Dashboard: true, Icon: "nope"}, "unknown icon"},
+		{
+			"icon on a group is rejected",
+			NavigationEntry{Group: "Tickets", Icon: "inbox"},
+			"cannot have an icon",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			errs := validateNavEntry(tc.nav, &Config{})
+			if tc.wantErr == "" {
+				for _, e := range errs {
+					if strings.Contains(e, "icon") {
+						t.Errorf("unexpected icon error: %s", e)
+					}
+				}
+				return
+			}
+			found := false
+			for _, e := range errs {
+				if strings.Contains(e, tc.wantErr) {
+					found = true
+				}
+			}
+			if !found {
+				t.Errorf("want an error containing %q, got %v", tc.wantErr, errs)
+			}
+		})
+	}
+}

--- a/internal/dataentryconfig/validate.go
+++ b/internal/dataentryconfig/validate.go
@@ -1104,6 +1104,19 @@ func validateKanbans(cfg *Config, meta *metamodel.Metamodel) []string {
 			}
 		}
 
+		// Icon names are checked unconditionally — deliberately NOT inside the
+		// enum guards above, which only run when column_property resolves to an
+		// enum. A bad icon name is wrong regardless, and burying it behind an
+		// unrelated error would surface it only after the first one was fixed.
+		for i, col := range kanban.Columns {
+			errs = append(errs, validateIconName(col.Icon,
+				fmt.Sprintf("kanban %q: columns[%d]", kanbanID, i))...)
+		}
+		for i, lane := range kanban.Swimlanes {
+			errs = append(errs, validateIconName(lane.Icon,
+				fmt.Sprintf("kanban %q: swimlanes[%d]", kanbanID, i))...)
+		}
+
 		// Validate swimlane_property if specified
 		if kanban.SwimlaneProperty != "" { //nolint:nestif // nested guards each check a distinct optional field of the kanban config.
 			propDef, ok := entDef.Properties[kanban.SwimlaneProperty]

--- a/internal/dataentryconfig/validate.go
+++ b/internal/dataentryconfig/validate.go
@@ -195,6 +195,14 @@ func validateNavigation(cfg *Config) []string {
 func validateNavEntry(nav NavigationEntry, cfg *Config) []string {
 	var errs []string
 
+	// The name itself is checked for groups too, so a typo is reported even on
+	// an entry that will also be rejected for having an icon at all.
+	label := nav.Label
+	if label == "" {
+		label = nav.Group
+	}
+	errs = append(errs, validateIconName(nav.Icon, fmt.Sprintf("navigation %q", label))...)
+
 	if nav.List != "" {
 		if _, ok := cfg.Lists[nav.List]; !ok {
 			errs = append(errs, fmt.Sprintf(
@@ -238,6 +246,13 @@ func validateNavEntry(nav NavigationEntry, cfg *Config) []string {
 		// permission to gate, and a gated group would be ambiguous with the
 		// empty-group rule (a group disappears on its own once every child is
 		// filtered out). Rejecting is clearer than silently ignoring it.
+		// Same reasoning as permission: a group renders as a bare section
+		// title with no icon slot, so an icon here would be silently dropped.
+		if nav.Icon != "" {
+			errs = append(errs, fmt.Sprintf(
+				"navigation: group %q cannot have an icon (a group renders as a section "+
+					"title; set icon on its items instead)", nav.Group))
+		}
 		if nav.Permission != "" {
 			errs = append(errs, fmt.Sprintf(
 				"navigation: group %q cannot have a permission (set it on the items instead; "+

--- a/prototypes/data-entry/project/data-entry.yaml
+++ b/prototypes/data-entry/project/data-entry.yaml
@@ -600,7 +600,7 @@ kanbans:
         icon: inbox
       - value: in-progress
         label: "In Progress"
-        icon: progress
+        icon: wrench
       - value: resolved
         label: "Done"
         icon: done

--- a/prototypes/data-entry/project/data-entry.yaml
+++ b/prototypes/data-entry/project/data-entry.yaml
@@ -590,12 +590,20 @@ kanbans:
     title: "Ticket Board"
     column_property: status
     columns:
+      # `icon:` names an icon from the shared registry; the label stays plain
+      # text. Emoji used to live inside the label string, which meant they
+      # ignored the theme, rendered differently per OS, and could not be
+      # styled — and the SPA had no way to tell an intentional emoji in a
+      # label apart from one meant as an icon.
       - value: open
-        label: "\U0001F4E5 To Do"
+        label: "To Do"
+        icon: inbox
       - value: in-progress
-        label: "\U0001F527 In Progress"
+        label: "In Progress"
+        icon: progress
       - value: resolved
-        label: "✅ Done"
+        label: "Done"
+        icon: done
     card:
       title: title
       fields:

--- a/prototypes/data-entry/project/data-entry.yaml
+++ b/prototypes/data-entry/project/data-entry.yaml
@@ -640,10 +640,15 @@ navigation:
     document: status_review
   - group: "Tickets"
     items:
+      # Without `icon:` all three lists get the same derived glyph, so the
+      # sidebar reads as three identical rows distinguished only by their
+      # labels. An authored icon gives each one a shape you can aim for.
       - label: "My Tickets"
         list: my_tickets
+        icon: inbox
       - label: "Open Tickets"
         list: open_tickets
+        icon: status
       - label: "All Tickets"
         list: all_tickets
       - label: "Ticket Board"

--- a/prototypes/data-entry/project/entities/tickets/TKT-003.md
+++ b/prototypes/data-entry/project/entities/tickets/TKT-003.md
@@ -1,11 +1,11 @@
 ---
 id: TKT-003
-priority: critical
-reporter: bob
-assignee: alice
-status: open
-title: Database migration for user schema
 type: ticket
+title: Database migration for user schema
+status: in-progress
+priority: critical
+assignee: alice
+reporter: bob
 ---
 
 ## Issue Description

--- a/tickets/entities/docs-checklists/DOCS-9ARY8L.md
+++ b/tickets/entities/docs-checklists/DOCS-9ARY8L.md
@@ -1,0 +1,54 @@
+---
+id: DOCS-9ARY8L
+type: docs-checklist
+title: 'Docs: icon: on navigation, kanban columns and swimlanes'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Code Documentation
+
+- [x] Godoc/comments on new exported symbols
+- [x] Non-obvious decisions explained with WHY, not WHAT
+
+`utils/icons.ts` documents why resolution is a static allowlist and why
+`resolveIcon` needs an own-property check (a bare index finds inherited
+`Object.prototype` members and would crash the render).
+
+`ValidIconNames` documents that it mirrors the SPA registry and which test pins
+it. `NavigationEntry.Icon` explains what the derived default is and why an
+override exists. The `.nav-icon` CSS carries a warning that `width` and
+`flex-basis` both reproduce the 24x18 stretch bug — the mechanism that caught me
+twice.
+
+## Project Documentation
+
+- [x] ~~frontend/CLAUDE.md~~ (N/A: no new frontend convention. The icon
+registry is a single documented module, not a pattern other code must follow.)
+- [x] ~~CLAUDE.md (root)~~ (N/A)
+
+## External / User-Facing Documentation
+
+- [x] `docs/data-entry.md` — **required**, two new public config keys.
+
+Authored in `docs-project/entities/guides/GUIDE-data-entry.md` (the generated
+file is not the source — a lesson from #1282's CI failure).
+
+Two sections: "Column and swimlane icons" under Kanbans, and "Item icons" under
+Navigation. Both explain that `icon:` takes a NAME not a glyph, that an emoji
+left in a label renders verbatim, and that a group cannot take one.
+
+**The valid-name list is deliberately NOT restated in prose.** It was, twice,
+and the rename in RR-OX9WFS made both copies wrong within the hour. The startup
+error interpolates the live allowlist, so it is the authoritative reference; the
+docs now say so and explain why the omission is intentional.
+
+## Verification
+
+- [x] Documentation matches the implemented behaviour
+- [x] Examples in docs actually work
+
+The worked YAML examples are the ones now in the prototype project, so they are
+exercised by the running demo rather than only existing in prose. `just
+docs-check` (the CI gate) and `markdownlint-cli2` both pass.

--- a/tickets/entities/implementation-checklists/IMPL-DJ9Y71.md
+++ b/tickets/entities/implementation-checklists/IMPL-DJ9Y71.md
@@ -1,0 +1,99 @@
+---
+id: IMPL-DJ9Y71
+type: implementation-checklist
+title: 'Implementation: Replace emoji with an SVG icon set; add icon: to kanban columns and swimlanes'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Development
+
+- [x] Unit tests written for new code
+- [x] Integration tests written (test full flow, not just units)
+- [x] Happy path implemented
+- [x] Edge cases from planning handled
+- [x] Error handling in place (errors surfaced, not swallowed)
+
+Commit `37b4ed46`. `lucide-vue-next` (ISC); `utils/icons.ts` as the single
+config-string→component boundary; `ValidIconNames` + `validateIconName` Go-side;
+`Icon` on `KanbanColumn` and `KanbanSwimlane`; sidebar and kanban rendering;
+prototype YAML migrated; docs authored in `docs-project/`.
+
+## Test Quality
+
+- [x] Using fixture builders or factories for test data
+- [x] No hardcoded values in assertions when object is in scope
+- [x] Only specifying values that matter for the test
+- [x] Interpolated values constructed from objects, not hardcoded
+- [x] Property comparisons use original object, not hardcoded strings
+
+`TestIconAllowlistMatchesFrontend` compares the two REAL sources rather than
+either against a third literal list in the test — that is what makes it a
+contract test instead of a restatement.
+
+## Manual Verification
+
+- [x] Feature manually tested end-to-end
+- [x] Each acceptance criterion verified with test scenario from planning
+- [x] Edge cases manually verified
+
+**Verification Evidence:**
+
+**AC 1 — self-hosted.** Lucide imported by name; the build produces no runtime
+fetch for icon assets.
+
+**AC 2 — all nine sidebar emoji gone.** Counted before (9, via a unicode-range
+grep) and after (0). That includes the five outside the old `getIconEmoji`
+switch, which RR-09N4MN flagged as easy to miss.
+
+**AC 3 — icons follow the theme.** Verified in-browser, and this took two
+attempts: toggling `.dark` on `<html>` directly did NOT change the tokens, so my
+first measurement wrongly suggested icons ignored the theme. Using the real UI
+toggle showed the truth — in light mode the kanban icon stroke is
+`rgb(25,25,25)`, exactly matching its label's colour; in dark it is
+`rgb(236,233,224)`. The icon inherits `currentColor`, which is the entire
+justification for the swap.
+
+Worth noting the sidebar icons legitimately do NOT change colour: the sidebar is
+deep navy in both themes by design (PR 1's `tokens.css`), so its icons correctly
+hold one colour.
+
+**AC 4 — kanban icon field.** 15 icons render as real `<svg>` elements (12 nav
++ 3 column). Confirmed by tag name, not by eye.
+
+**AC 5 — prototype migrated.** Emoji moved out of `label:` into `icon:` for all
+three columns; server loads with no config error.
+
+**AC 6 — unknown name.** `validateIconName` rejects with an indexed message
+listing the valid set; `resolveIcon` falls back without throwing.
+
+**AC 7 — emoji in a label renders verbatim.** No parsing of label text exists,
+by design.
+
+**AC 8 — no regression.** Frontend 1499/1499 (93 files), Go tests ok,
+`golangci-lint` 0 issues, ESLint 0 errors, typecheck clean, `just docs-check`
+passes.
+
+**A real bug the tests caught.** `resolveIcon` originally used `ICONS[name] ??
+DEFAULT_ICON`. A bare index finds INHERITED `Object.prototype` members, so a
+config naming `toString` or `constructor` would have returned a function that is
+not a component and crashed the render. The test I wrote for prototype keys
+failed on first run; fixed with an own-property check.
+
+## Quality
+
+- [x] Code follows project patterns (check similar code)
+- [x] Checked for DRY opportunities
+- [x] No security issues introduced
+- [x] No silent failures (errors logged AND returned)
+- [x] No debug code left behind
+
+Follows `TestAppTokensCSSInSyncWithFrontend` for the cross-language pin, and the
+`span:` precedent from PR 2 for the config-surface shape (one optional field,
+loud load-time validation, frontend fallback as defence-in-depth).
+
+Security: icon names select a component, so the lookup is an allowlist by
+construction — no dynamic resolution from a config string, and the own-property
+check closes the prototype-chain hole. Icons are bundled, so no new network
+surface.

--- a/tickets/entities/planning-checklists/PLAN-C1OV20.md
+++ b/tickets/entities/planning-checklists/PLAN-C1OV20.md
@@ -1,0 +1,120 @@
+---
+id: PLAN-C1OV20
+type: planning-checklist
+title: 'Planning: Replace emoji with an SVG icon set; add icon: to kanban columns and swimlanes'
+status: in-progress
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Understanding
+
+- [ ] Problem/requirements clearly understood
+- [ ] Scope defined (what's in/out documented below)
+- [ ] Acceptance criteria documented with specific test scenarios
+
+**Scope:**
+<!-- Document explicitly what IS and IS NOT in scope -->
+
+**Acceptance Criteria:**
+<!-- Each criterion must have a concrete test scenario -->
+1. ...
+
+## Research
+
+- [ ] For larger features: run `/research` to create a structured research doc
+- [ ] Searched for existing libraries that solve this problem
+- [ ] Checked codebase for similar patterns or reusable code
+- [ ] Looked for reference implementations in other projects
+- [ ] Reviewed relevant rela concepts for prior art
+
+**Research Doc:** <!-- Link RES-xxxx if created, or N/A for small changes -->
+
+**Existing Solutions:**
+<!-- Document what you found:
+- Libraries considered (with pros/cons, why chosen or rejected)
+- Similar patterns in codebase (file:line references)
+- Reference implementations that inspired the approach
+- Relevant concepts from rela-docs or rela-issues-and-design-tickets
+-->
+
+## Approach
+
+- [ ] Technical approach chosen and documented
+- [ ] Approach builds on existing patterns (not reinventing)
+- [ ] Alternatives considered (document why rejected)
+- [ ] Dependencies identified (packages, APIs, types)
+
+**Technical Approach:**
+<!-- Document the approach with enough detail that implementation is mechanical -->
+
+**Files to modify:**
+<!-- List specific files that will change -->
+
+## Security Considerations
+
+- [ ] Input sources identified (user input, config, external APIs)
+- [ ] Input validation approach defined (allowlist preferred over blocklist)
+- [ ] Security-sensitive operations identified (file access, auth, crypto)
+- [ ] Error handling doesn't leak sensitive information
+
+**Input Sources & Validation:**
+<!-- For each input: source, validation approach, what happens on invalid input -->
+
+**Security-Sensitive Operations:**
+<!-- List operations and how they're protected -->
+
+## Test Plan
+
+- [ ] Test scenarios documented for each acceptance criterion
+- [ ] Edge cases identified and documented
+- [ ] Negative test cases defined (invalid input, error conditions)
+- [ ] Integration test approach defined (not just unit tests)
+
+**Test Scenarios:**
+<!-- Map each acceptance criterion to how it will be tested -->
+
+**Edge Cases:**
+<!-- List specific edge cases and expected behavior. Consider:
+- Empty/null/missing values
+- Boundary values (0, -1, MAX_INT)
+- Special characters, unicode, null bytes
+- Concurrent access
+- Resource exhaustion
+-->
+
+**Negative Tests:**
+<!-- What should fail? How should it fail? -->
+
+## Risk Assessment
+
+- [ ] Technical risks assessed with mitigations
+- [ ] Security risks assessed (see Security Considerations)
+- [ ] Effort estimated (xs/s/m/l/xl)
+
+**Risks:**
+<!-- List risks and how they will be mitigated -->
+
+## Documentation Planning
+
+For enhancements: identify what documentation needs updating.
+
+- [ ] User-facing docs identified (skip if internal refactor)
+- [ ] Docs-checklist will be created when entering implementation
+
+**Documentation Impact:**
+<!-- Which docs need updating? Check all that apply:
+- [ ] docs/metamodel.md - New metamodel features
+- [ ] docs/cli-reference.md - New/changed commands
+- [ ] docs/data-entry.md - UI changes
+- [ ] CLAUDE.md - New patterns or conventions
+- [ ] README.md - Project-level changes
+- [ ] N/A - Internal change, no user-facing docs needed
+-->
+
+## Design Review
+
+- [ ] Run `/design-review` before starting implementation
+- [ ] All critical/significant findings addressed in plan
+
+**Design Review Findings:** <!-- List review-response IDs, e.g., RR-xxxx -->

--- a/tickets/entities/planning-checklists/PLAN-C1OV20.md
+++ b/tickets/entities/planning-checklists/PLAN-C1OV20.md
@@ -2,119 +2,125 @@
 id: PLAN-C1OV20
 type: planning-checklist
 title: 'Planning: Replace emoji with an SVG icon set; add icon: to kanban columns and swimlanes'
-status: in-progress
+status: done
 ---
 
 <!-- @managed: claude-workflow v1 -->
 
+> **Split note.** PR 3 of 3 from TKT-5V8704's design review (FEAT-OJ8L0H).
+> Full research and the five design-review findings live in PLAN-J86M7L;
+> RR-GWVGDX (critical) and RR-09N4MN govern this ticket.
+
 ## Understanding
 
-- [ ] Problem/requirements clearly understood
-- [ ] Scope defined (what's in/out documented below)
-- [ ] Acceptance criteria documented with specific test scenarios
+- [x] Problem/requirements clearly understood
+- [x] Scope defined (what's in/out documented below)
+- [x] Acceptance criteria documented with specific test scenarios
 
-**Scope:**
-<!-- Document explicitly what IS and IS NOT in scope -->
-
-**Acceptance Criteria:**
-<!-- Each criterion must have a concrete test scenario -->
-1. ...
+**Scope:** replace emoji with a real SVG icon set in the sidebar, and give
+kanban columns/swimlanes a proper `icon:` field. OUT: tokens (PR 1), layout (PR
+2), label humanization, and the emoji in other components (EntityList,
+CommandModal, InaccessibleField, StatusBar) — those are separate surfaces the
+ticket doesn't cover.
 
 ## Research
 
-- [ ] For larger features: run `/research` to create a structured research doc
-- [ ] Searched for existing libraries that solve this problem
-- [ ] Checked codebase for similar patterns or reusable code
-- [ ] Looked for reference implementations in other projects
-- [ ] Reviewed relevant rela concepts for prior art
+- [x] ~~Run `/research`~~ (N/A: library choice is narrow and documented below)
+- [x] Searched for existing libraries that solve this problem
+- [x] Checked codebase for similar patterns or reusable code
+- [x] Looked for reference implementations in other projects
+- [x] Reviewed relevant rela concepts for prior art
 
-**Research Doc:** <!-- Link RES-xxxx if created, or N/A for small changes -->
+**Library:** Lucide (`lucide-vue-next` 1.0.0, ISC) — tree-shakeable named
+imports, self-hosted (mandatory: the SPA is embedded in a Go binary and must not
+fetch icons at runtime), `currentColor` by default.
 
-**Existing Solutions:**
-<!-- Document what you found:
-- Libraries considered (with pros/cons, why chosen or rejected)
-- Similar patterns in codebase (file:line references)
-- Reference implementations that inspired the approach
-- Relevant concepts from rela-docs or rela-issues-and-design-tickets
--->
+**font-awesome 4.7 rejected** even though it is already a dependency: it is
+present only because EasyMDE's toolbar needs it, and v4 is an icon *font* — no
+tree-shaking, ships the whole webfont, no per-path `currentColor`.
+
+**Prior art:** `TestAppTokensCSSInSyncWithFrontend` pins a Go copy of a frontend
+file; the icon allowlist test follows that pattern.
 
 ## Approach
 
-- [ ] Technical approach chosen and documented
-- [ ] Approach builds on existing patterns (not reinventing)
-- [ ] Alternatives considered (document why rejected)
-- [ ] Dependencies identified (packages, APIs, types)
+- [x] Technical approach chosen and documented
+- [x] Approach builds on existing patterns (not reinventing)
+- [x] Alternatives considered (document why rejected)
+- [x] Dependencies identified (packages, APIs, types)
 
-**Technical Approach:**
-<!-- Document the approach with enough detail that implementation is mechanical -->
+`utils/icons.ts` is the single boundary a config string crosses to become a
+component — a static allowlist, never dynamic resolution. `ValidIconNames`
+mirrors it Go-side so an unknown name fails at config load.
 
-**Files to modify:**
-<!-- List specific files that will change -->
+**Rejected:** parsing emoji out of user `label:` text to convert existing
+configs automatically. That is a lossy heuristic over user data and silently
+rewrites what an author typed (RR-GWVGDX). Authors migrate explicitly; an emoji
+left in a label keeps rendering verbatim.
 
 ## Security Considerations
 
-- [ ] Input sources identified (user input, config, external APIs)
-- [ ] Input validation approach defined (allowlist preferred over blocklist)
-- [ ] Security-sensitive operations identified (file access, auth, crypto)
-- [ ] Error handling doesn't leak sensitive information
+- [x] Input sources identified (user input, config, external APIs)
+- [x] Input validation approach defined (allowlist preferred over blocklist)
+- [x] Security-sensitive operations identified (file access, auth, crypto)
+- [x] Error handling doesn't leak sensitive information
 
-**Input Sources & Validation:**
-<!-- For each input: source, validation approach, what happens on invalid input -->
-
-**Security-Sensitive Operations:**
-<!-- List operations and how they're protected -->
+Icon names come from project-authored YAML and select a **component**, so the
+lookup is an allowlist by construction. `resolveIcon` uses an own-property check
+rather than a bare index: `ICONS['toString']` would otherwise return an
+inherited function, which is not a component and would crash the render. A test
+covers `toString`/`constructor`. No new network surface — icons are bundled, not
+fetched.
 
 ## Test Plan
 
-- [ ] Test scenarios documented for each acceptance criterion
-- [ ] Edge cases identified and documented
-- [ ] Negative test cases defined (invalid input, error conditions)
-- [ ] Integration test approach defined (not just unit tests)
+- [x] Test scenarios documented for each acceptance criterion
+- [x] Edge cases identified and documented
+- [x] Negative test cases defined (invalid input, error conditions)
+- [x] Integration test approach defined (not just unit tests)
 
-**Test Scenarios:**
-<!-- Map each acceptance criterion to how it will be tested -->
+1. *Allowlist drift* — `TestIconAllowlistMatchesFrontend` parses the real
+`icons.ts` and compares both directions.
+2. *Unknown name* — `validateIconName` rejects with an indexed message listing
+valid names; `resolveIcon` falls back without throwing.
+3. *Prototype pollution* — `toString`, `constructor` resolve to the default.
+4. *Rendered output* — browser check that icons are `<svg>`, not text.
+5. *Theme* — icon stroke matches its label colour in both themes.
+6. *Regression* — full frontend + Go suites, lint, typecheck, docs-check.
 
-**Edge Cases:**
-<!-- List specific edge cases and expected behavior. Consider:
-- Empty/null/missing values
-- Boundary values (0, -1, MAX_INT)
-- Special characters, unicode, null bytes
-- Concurrent access
-- Resource exhaustion
--->
-
-**Negative Tests:**
-<!-- What should fail? How should it fail? -->
+**Edge cases:** empty icon (means "no icon", valid); an emoji left in a label
+(renders verbatim, never stripped); a column with no icon (renders label only).
 
 ## Risk Assessment
 
-- [ ] Technical risks assessed with mitigations
-- [ ] Security risks assessed (see Security Considerations)
-- [ ] Effort estimated (xs/s/m/l/xl)
+- [x] Technical risks assessed with mitigations
+- [x] Security risks assessed (see Security Considerations)
+- [x] Effort estimated (xs/s/m/l/xl)
 
-**Risks:**
-<!-- List risks and how they will be mitigated -->
+- *New runtime dependency.* Mitigated: ISC, tree-shaken, self-hosted; bundle
+delta checked via the build.
+- *Two allowlists drifting apart.* Mitigated by the cross-language test.
+- *Config surface is permanent.* `icon:` is one optional string following the
+same shape as the `span:` key added in PR 2.
+
+**Effort:** m
 
 ## Documentation Planning
 
-For enhancements: identify what documentation needs updating.
+- [x] User-facing docs identified (skip if internal refactor)
+- [x] Docs-checklist will be created when entering implementation
 
-- [ ] User-facing docs identified (skip if internal refactor)
-- [ ] Docs-checklist will be created when entering implementation
-
-**Documentation Impact:**
-<!-- Which docs need updating? Check all that apply:
-- [ ] docs/metamodel.md - New metamodel features
-- [ ] docs/cli-reference.md - New/changed commands
-- [ ] docs/data-entry.md - UI changes
-- [ ] CLAUDE.md - New patterns or conventions
-- [ ] README.md - Project-level changes
-- [ ] N/A - Internal change, no user-facing docs needed
--->
+- [x] `docs/data-entry.md` — **required**, this adds a public config key.
+Authored in `docs-project/entities/guides/GUIDE-data-entry.md` (the generated
+file is not the source — a lesson from PR 2's CI failure).
 
 ## Design Review
 
-- [ ] Run `/design-review` before starting implementation
-- [ ] All critical/significant findings addressed in plan
+- [x] Run `/design-review` before starting implementation
+- [x] All critical/significant findings addressed in plan
 
-**Design Review Findings:** <!-- List review-response IDs, e.g., RR-xxxx -->
+**Design Review Findings:** inherited from TKT-5V8704's review. RR-GWVGDX
+(critical) established that kanban emoji live in user-authored label strings and
+must not be parsed out — this ticket's `icon:` field is that finding's
+resolution. RR-09N4MN identified the five sidebar emoji outside the
+`getIconEmoji` map that a naive swap would have missed.

--- a/tickets/entities/review-checklists/REV-ZRFXAZ.md
+++ b/tickets/entities/review-checklists/REV-ZRFXAZ.md
@@ -1,56 +1,98 @@
 ---
 id: REV-ZRFXAZ
 type: review-checklist
-title: 'Review: Replace emoji with an SVG icon set; add icon: to kanban columns and swimlanes'
-status: in-progress
+title: 'Review: Replace emoji with an SVG icon set; add icon: to navigation, kanban columns and swimlanes'
+status: done
 ---
 
 <!-- @managed: claude-workflow v1 -->
 
 ## Automated Checks
 
-- [ ] All tests pass (`just test`)
-- [ ] Lint clean (`just lint`)
-- [ ] Coverage maintained (`just coverage-check`)
+- [x] All tests pass (`just test`)
+- [x] Lint clean (`just lint`)
+- [x] Coverage maintained (`just coverage-check`)
+
+Go tests ok (`dataentryconfig`, `dataentry`); `golangci-lint` **0 issues**;
+frontend **1504/1504** (94 files); `vue-tsc` clean; ESLint 0 errors; `just
+docs-check` and `markdownlint-cli2` pass.
 
 ## Code Review
 
-- [ ] Run `/code-review` command (invokes cranky-code-reviewer agent)
-- [ ] All critical review-responses addressed
-- [ ] All significant review-responses addressed
-- [ ] Self-reviewed the diff for unrelated changes
+- [x] Run `/code-review` command (invokes cranky-code-reviewer agent)
+- [x] All critical review-responses addressed
+- [x] All significant review-responses addressed
+- [x] Self-reviewed the diff for unrelated changes
 
-**Review Responses:** <!-- List IDs of review-response entities created, e.g.,
-RR-xxxx -->
+**Review Responses:** RR-5ESHXG (critical, addressed), RR-NV753I (significant,
+addressed), RR-OX9WFS (significant, addressed), RR-GTOQCF (minor, addressed),
+RR-VESDBZ (minor, wont-fix with reasoning).
+
+The review earned its keep twice over.
+
+**RR-5ESHXG** is the one that matters: every sidebar icon rendered **24×18**, a
+4:3 horizontal stretch, in a PR whose entire purpose was visual consistency.
+Lucide emits width/height as *presentation attributes*, which CSS overrides — so
+my `width: 24px` beat the 18px width while height stayed 18. It survived because
+a squashed circle still reads as a circle at 18px, and jsdom does not lay out
+SVG so no test could see it. The reviewer measured it in real Chrome.
+
+**RR-NV753I** found that the drift test I was proud of could silently stop
+covering a name: its guard only fired on a *total* parse failure, never a
+partial one, so a spread / nested literal / commented-out entry made a name
+invisible while the test kept passing.
 
 ## Acceptance Verification
 
-- [ ] Each acceptance criterion tested (reference planning checklist)
-- [ ] Test evidence documented in implementation checklist
+- [x] Each acceptance criterion tested (reference planning checklist)
+- [x] Test evidence documented in implementation checklist
 
-**Acceptance Status:**
-<!-- For each acceptance criterion, state PASS/FAIL with evidence -->
+**Acceptance Status:** all 11 PASS — per-criterion evidence in IMPL-DJ9Y71.
+Post-review additions:
+
+- **AC 3 (icons follow the theme)** — now also verified *square*: nav 18×18,
+kanban 16×16, measured in Chrome. Was 24×18 before the fix.
+- **AC 10 (allowlist pinned both ways)** — the test is now
+**mutation-tested**: a nested literal fails with "parsed 16 names but
+ValidIconNames has 15", a commented-out entry with "parsed 14". Both were silent
+passes before.
 
 ## Documentation (enhancements only)
 
-Skip this section for bugs and internal refactors.
-
-- [ ] Docs-checklist created and linked via `has-docs`
-- [ ] User-facing documentation updated
-- [ ] Docs-checklist marked as done
-
-**Docs Checklist:** <!-- e.g., DOCS-xxxx -->
+- [x] Docs-checklist created and linked via `has-docs` — DOCS-9ARY8L
+- [x] User-facing documentation updated
+- [x] Docs-checklist marked as done
 
 ## Final Checks
 
-- [ ] Commit message explains the why, not just what
-- [ ] No TODOs or FIXMEs left unaddressed
-- [ ] Ready for another developer to use
+- [x] Commit message explains the why, not just what
+- [x] No TODOs or FIXMEs left unaddressed
+- [x] Ready for another developer to use
+
+Three things I'd want a reader to know, all recorded at their site in code:
+
+1. Never set `width` or `flex-basis` on a Lucide icon — both reproduce the
+stretch. Size via `:size`, space via `margin`.
+2. `go run` embeds the SPA at compile time, so a config-only edit live-reloads
+but a Go type change needs a restart. I measured a stale build twice while
+chasing the stretch; comparing the served asset hash to the on-disk one is the
+quick tell.
+3. The reviewer's suggestion to *generate* one allowlist from the other is the
+right end state and would delete the parser entirely. Deliberately not done here
+— it is a build-pipeline change, not an icon change. Worth a follow-up.
 
 ## Pull Request
 
-- [ ] Run `/pr` command to create PR and monitor CI
-- [ ] All CI checks pass
-- [ ] PR URL documented below
+- [x] Run `/pr` command to create PR and monitor CI
+- [x] ~~All CI checks pass~~ (BLOCKED, not skipped: this PR targets
+      #1282's branch, and ci.yml only triggers on PRs to main/develop, so
+      CI cannot run until #1282 merges and this retargets. The full
+      pipeline was run locally instead — see Automated Checks above.)
+- [x] PR URL documented below
 
-**PR:** <!-- e.g., https://github.com/org/repo/pull/123 -->
+**PR:** https://github.com/sourcehaven-bv/rela/pull/1285
+
+Stacked on #1282, so it targets `feat/field-span-layout-TKT-5V8704` rather than
+`develop` — **CI will not run until #1282 merges and this retargets**, the same
+constraint #1282 had against #1281. The full CI pipeline was run locally in the
+meantime (race tests, golangci-lint, the frontend job sequence, docs-check).

--- a/tickets/entities/review-checklists/REV-ZRFXAZ.md
+++ b/tickets/entities/review-checklists/REV-ZRFXAZ.md
@@ -1,0 +1,56 @@
+---
+id: REV-ZRFXAZ
+type: review-checklist
+title: 'Review: Replace emoji with an SVG icon set; add icon: to kanban columns and swimlanes'
+status: in-progress
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Automated Checks
+
+- [ ] All tests pass (`just test`)
+- [ ] Lint clean (`just lint`)
+- [ ] Coverage maintained (`just coverage-check`)
+
+## Code Review
+
+- [ ] Run `/code-review` command (invokes cranky-code-reviewer agent)
+- [ ] All critical review-responses addressed
+- [ ] All significant review-responses addressed
+- [ ] Self-reviewed the diff for unrelated changes
+
+**Review Responses:** <!-- List IDs of review-response entities created, e.g.,
+RR-xxxx -->
+
+## Acceptance Verification
+
+- [ ] Each acceptance criterion tested (reference planning checklist)
+- [ ] Test evidence documented in implementation checklist
+
+**Acceptance Status:**
+<!-- For each acceptance criterion, state PASS/FAIL with evidence -->
+
+## Documentation (enhancements only)
+
+Skip this section for bugs and internal refactors.
+
+- [ ] Docs-checklist created and linked via `has-docs`
+- [ ] User-facing documentation updated
+- [ ] Docs-checklist marked as done
+
+**Docs Checklist:** <!-- e.g., DOCS-xxxx -->
+
+## Final Checks
+
+- [ ] Commit message explains the why, not just what
+- [ ] No TODOs or FIXMEs left unaddressed
+- [ ] Ready for another developer to use
+
+## Pull Request
+
+- [ ] Run `/pr` command to create PR and monitor CI
+- [ ] All CI checks pass
+- [ ] PR URL documented below
+
+**PR:** <!-- e.g., https://github.com/org/repo/pull/123 -->

--- a/tickets/entities/review-checklists/REV-ZRFXAZ.md
+++ b/tickets/entities/review-checklists/REV-ZRFXAZ.md
@@ -84,15 +84,18 @@ right end state and would delete the parser entirely. Deliberately not done here
 ## Pull Request
 
 - [x] Run `/pr` command to create PR and monitor CI
-- [x] ~~All CI checks pass~~ (BLOCKED, not skipped: this PR targets
-      #1282's branch, and ci.yml only triggers on PRs to main/develop, so
-      CI cannot run until #1282 merges and this retargets. The full
-      pipeline was run locally instead — see Automated Checks above.)
+- [x] All CI checks pass
 - [x] PR URL documented below
 
 **PR:** https://github.com/sourcehaven-bv/rela/pull/1285
 
-Stacked on #1282, so it targets `feat/field-span-layout-TKT-5V8704` rather than
-`develop` — **CI will not run until #1282 merges and this retargets**, the same
-constraint #1282 had against #1281. The full CI pipeline was run locally in the
-meantime (race tests, golangci-lint, the frontend job sequence, docs-check).
+#1282 has since merged, so this retargeted to `develop` and CI ran for the
+first time: **all checks green** (Test, Frontend, Lint, Architecture, Build,
+E2E, Fuzz, Postgres, Docs, Rela Tickets, CodeQL, all six cross-compiles).
+
+Getting there needed a rebase: #1282 was squash-merged, so `develop` held its
+work as one commit while this branch still carried the originals — same
+changes, different SHAs, hence conflicts. Replaying only this PR's own six
+commits onto `develop` resolved it with no manual conflict resolution.
+Re-verified afterwards: frontend 1542/1542, Go tests ok, golangci-lint 0
+issues, docs-check passes.

--- a/tickets/entities/review-responses/RR-5ESHXG.md
+++ b/tickets/entities/review-responses/RR-5ESHXG.md
@@ -1,0 +1,26 @@
+---
+id: RR-5ESHXG
+type: review-response
+title: Every sidebar icon rendered 24x18 — CSS width beat Lucide's presentation attribute
+finding: |-
+    Lucide emits width/height as PRESENTATION attributes (Icon.js: width: size, height: size). CSS beats presentation attributes, so `.nav-icon { width: 24px }` overrode the 18px width while nothing overrode height=18. Every icon in the sidebar rendered 24x18 — a 4:3 horizontal stretch.
+
+    Measured in real Chrome by the reviewer and independently confirmed: attrW=18, renderedW=24, renderedH=18, in both expanded and collapsed states.
+
+    This is the single thing the ticket set out to fix — visual consistency — shipping with every glyph distorted. Two reasons it survived: a squashed circle still reads as a circle at 18px, and jsdom does not lay out SVG, so no test could observe it. The comment I wrote at that rule asserted width 'keeps the 24px gutter the labels align to' — the intent was right, the mechanism wrong, and the comment made it look considered.
+
+    Also note the diff deleted `text-align: center`, the OLD centering mechanism, without replacing it for the new one.
+severity: critical
+resolution: |-
+    Fixed in bdb197f1. The icon box is now sized by its :size prop and the 24px label gutter comes from margin instead, so sizing and spacing are separate concerns.
+
+    Took two attempts: my first fix used `flex: 0 0 24px`, which on a ROW flex item resolves flex-basis to the main size — i.e. the width — so it reproduced the exact bug. Verified 18x18 in Chrome afterwards rather than assuming.
+
+    Also added Sidebar.iconRender.test.ts, which is the real remedy: it mounts the icon and asserts it is an <svg> with SQUARE width/height and stroke=currentColor. The registry tests only proved resolveIcon returned the right component object; nothing checked that a template rendered it correctly, which is the gap this shipped through.
+
+    A diagnostic note for the next person: chasing this I twice measured a stale build, because `go run` embeds the SPA at compile time and a surviving process kept serving the old asset hash. Comparing the served CSS hash against the on-disk one is the quick way to tell.
+status: addressed
+---
+
+Found by the cranky-code-reviewer in real Chrome, which is exactly where the
+suite could not look. Fixed in `bdb197f1`.

--- a/tickets/entities/review-responses/RR-GTOQCF.md
+++ b/tickets/entities/review-responses/RR-GTOQCF.md
@@ -1,0 +1,17 @@
+---
+id: RR-GTOQCF
+type: review-response
+title: Docs restated the valid icon names as an unpinned fourth copy
+finding: |-
+    I pinned the Go and SPA allowlists to each other in both directions, then wrote the same 15 names into prose twice (once in the kanban section, once in navigation) with nothing checking them — and the docs source makes copies four and five.
+
+    Add an icon and the docs are wrong. That matters more than usual here because docs are the only place an author DISCOVERS these names; the startup error message is the only other source.
+
+    The rename in RR-OX9WFS proved the point immediately: two of the names in those prose lists went stale the moment I changed them.
+severity: minor
+resolution: |-
+    Fixed in bdb197f1. Both prose lists are gone, replaced by a pointer to the startup error message — which already interpolates sortedMapKeys(ValidIconNames), so it cannot go stale. The docs now say so explicitly, framing the omission as deliberate rather than an oversight the next person should 'helpfully' fill in.
+
+    This also removes the last place the rename would have left a wrong answer.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-NV753I.md
+++ b/tickets/entities/review-responses/RR-NV753I.md
@@ -1,0 +1,27 @@
+---
+id: RR-NV753I
+type: review-response
+title: Allowlist drift test could silently stop covering a name (partial-parse false negative)
+finding: |-
+    TestIconAllowlistMatchesFrontend parsed icons.ts with a regexp guarded only by `len(spa) == 0`. That guard fires only when EVERY entry fails to parse — a global reformat. It cannot fire on a PARTIAL parse, which is what every realistic single-entry edit produces.
+
+    The reviewer ran the exact regexp against realistic shapes and demonstrated five silent-drift cases: an aliased import (`Home as homeIcon`), a spread (`...navIcons`), a nested object literal, a commented-out entry, and a camelCase name. In each the new name is invisible to the parser, so if both sides are correct and consistent the test PASSES while having quietly stopped covering that name.
+
+    The nested-literal case is worst: `strings.Index(body[start:], "\n}")` stops at the first column-0 brace, truncating the parse mid-map so everything after it is invisible forever.
+
+    And the aliased-import case produces a FALSE POSITIVE with a misleading message — it blames the SPA for a name that renders fine.
+
+    This is the failure mode I asked the reviewer to look for, and it was worse than I expected.
+severity: significant
+resolution: |-
+    Fixed in bdb197f1 with two changes.
+
+    The guard now asserts a COUNT against the Go list rather than non-emptiness. The two lists must be the same size by definition, so any parse regression — partial or total — becomes a failure. The message names the likely causes (spread, nested literal, aliased import) and prints what was parsed, so the next person isn't left guessing whether the lists differ or the parser broke.
+
+    The regexp also matches key-only now (dropped the [A-Z] value anchor), so an aliased import no longer misattributes blame to the SPA side.
+
+    Mutation-tested rather than assumed: adding a nested object literal fails with 'parsed 16 names but ValidIconNames has 15', and commenting out an entry fails with 'parsed 14'. Both were silent passes before.
+
+    Not taken: the reviewer's suggestion to generate one side from the other (an icons.json or go:generate). It is the right end state — it deletes the parser entirely — but it is a build-pipeline change that does not belong in a PR about icons. Worth a follow-up ticket; the hardened test closes the actual hole in the meantime.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-OX9WFS.md
+++ b/tickets/entities/review-responses/RR-OX9WFS.md
@@ -1,0 +1,22 @@
+---
+id: RR-OX9WFS
+type: review-response
+title: Two icon names described a use site, not the glyph — frozen traps once authored
+finding: |-
+    icons.ts's own docstring says 'Keys are the public contract — renaming one breaks every project that authored it.' Two of the fifteen then violated that:
+
+    - `analysis` rendered AlertTriangle. An author writing `icon: analysis` on a column labelled 'Analysis' gets a hazard sign.
+    - `progress` rendered Wrench, which reads as tooling rather than motion. The prototype used it for 'In Progress' and the column looked like maintenance.
+
+    Both were named for where I happened to use them rather than what they show. Once projects author them neither can be fixed without a migration.
+
+    (`status: CircleDot` and `apps: Blocks` have a milder version of the same smell but are defensible.)
+severity: significant
+resolution: |-
+    Fixed in bdb197f1: `analysis` -> `warning`, `progress` -> `wrench`. Both now describe the glyph, so an author choosing one gets what they expect.
+
+    Done now precisely because it is still free: the only consumer is prototypes/, so this is a rename rather than a migration. After the first real project authors these it would be a breaking change.
+
+    Updated all five sites: the SPA registry, the Go allowlist, the Sidebar's hardcoded Analysis nav item, the prototype YAML, and my own test (which failed on the rename — correctly).
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-VESDBZ.md
+++ b/tickets/entities/review-responses/RR-VESDBZ.md
@@ -1,0 +1,19 @@
+---
+id: RR-VESDBZ
+type: review-response
+title: Kanban's v-if="column.icon" makes the fallback unreachable, so surfaces disagree on bad input
+finding: |-
+    KanbanView guards the icon element with `v-if="column.icon"`. A truthy-but-unknown name therefore renders the generic FileText fallback, while an EMPTY name renders nothing. Sidebar has no guard, so it always renders a fallback.
+
+    So the two surfaces behave differently for the same bad input, and the reviewer argues the kanban fallback is arguably worse than nothing: an author who typo'd sees a document glyph beside 'Done' rather than the absence that would prompt a config check.
+severity: minor
+reason: |-
+    The divergence is real but correct, because the two surfaces have genuinely different defaults.
+
+    A nav entry ALWAYS has an icon (derived from its kind), so rendering a fallback there preserves the layout — dropping it would shift every label left. A kanban column has NO icon by default, so `v-if` is what makes an unset icon render nothing rather than a stray document glyph beside every column header in every unmigrated project. Removing the guard would put a FileText next to every column of every board that has never heard of icons.
+
+    The reviewer's sharper point — that a typo showing a generic glyph is worse than showing nothing — is fair, but the server rejects unknown names at load, so this is only reachable via a hand-crafted API response or a config that predates the name. In that state a visible-but-wrong icon and no icon are about equally diagnostic, and neither is silent.
+
+    Not worth adding an isKnownIcon() call to the template to unify behaviour for a state the validator already prevents. Recording the reasoning so it reads as a decision rather than an oversight.
+status: wont-fix
+---

--- a/tickets/entities/tickets/TKT-8GUI60.md
+++ b/tickets/entities/tickets/TKT-8GUI60.md
@@ -5,7 +5,7 @@ title: 'Replace emoji with an SVG icon set; add icon: to kanban columns and swim
 kind: enhancement
 priority: medium
 effort: m
-status: backlog
+status: planning
 ---
 
 ## Description

--- a/tickets/entities/tickets/TKT-8GUI60.md
+++ b/tickets/entities/tickets/TKT-8GUI60.md
@@ -5,7 +5,7 @@ title: 'Replace emoji with an SVG icon set; add icon: to kanban columns and swim
 kind: enhancement
 priority: medium
 effort: m
-status: planning
+status: review
 ---
 
 ## Description

--- a/tickets/entities/tickets/TKT-8GUI60.md
+++ b/tickets/entities/tickets/TKT-8GUI60.md
@@ -1,17 +1,16 @@
 ---
 id: TKT-8GUI60
 type: ticket
-title: 'Replace emoji with an SVG icon set; add icon: to kanban columns and swimlanes'
+title: 'Replace emoji with an SVG icon set; add icon: to navigation, kanban columns and swimlanes'
 kind: enhancement
 priority: medium
 effort: m
-status: review
+status: done
 ---
 
 ## Description
 
-**PR 3 of 3** splitting TKT-5V8704 (see FEAT-OJ8L0H). Shares no files with the
-layout PR, so it can land independently of PR 2.
+**PR 3 of 3** splitting TKT-5V8704 (see FEAT-OJ8L0H).
 
 Emoji cannot take `currentColor`, ignore the theme toggle, render differently
 per OS, and sit on an inconsistent baseline — all while sitting directly beside
@@ -24,27 +23,25 @@ real SVG icons (search, trash, chevrons).
 | **Lucide** (`lucide-vue-next` 1.0.0) | 1,500+ | ISC | Feather fork, actively maintained, one outline path per icon. Official Vue 3 package. |
 | Heroicons (`@heroicons/vue` 2.2.0) | ~292 | MIT | Smallest set — risk of gaps. |
 | Phosphor | 7,700+ | MIT | Most variety/weights; larger surface than needed. |
-| font-awesome 4.7 (already a dep) | — | — | **Rejected**: present only because EasyMDE's toolbar requires it (`MarkdownEditor.vue:10`, `relaEditor.ts:24`). v4 is an icon *font* — no tree-shaking, ships the whole webfont, no per-path `currentColor`. Reusing it entrenches a legacy dep. |
+| font-awesome 4.7 (already a dep) | — | — | **Rejected**: present only because EasyMDE's toolbar requires it. v4 is an icon *font* — no tree-shaking, ships the whole webfont, no per-path `currentColor`. Reusing it entrenches a legacy dep. |
 
-**Recommended: Lucide** — tree-shakeable named imports, self-hosted (no runtime
+**Chosen: Lucide** — tree-shakeable named imports, self-hosted (no runtime
 fetch, mandatory since the SPA is embedded in a Go binary), `currentColor` by
 default so it themes for free.
 
-### Sidebar (from RR-09N4MN)
+### Sidebar glyphs (from RR-09N4MN)
 
-`Sidebar.vue:101` already has the right shape — a `getIconEmoji` allowlist
-switch over `list`/`kanban`/`dashboard` with a default fallback. The work is
-changing the return type from string to component, **not** designing a new
-validation surface.
+`Sidebar.vue` had a `getIconEmoji` allowlist switch over
+`list`/`kanban`/`dashboard` with a default fallback — the right shape already.
+The work is changing the return type from string to component.
 
-Do not miss the emoji **outside** that map: `Sidebar.vue` lines 161, 166, 236,
-249, 257 (search, analysis, apps, settings, and the theme-toggle sun/moon).
+Do not miss the emoji **outside** that map: search, analysis, apps, settings,
+and the theme-toggle sun/moon. Nine glyphs total.
 
 ### Kanban (from RR-GWVGDX — the critical finding)
 
-Kanban has **no icon field at all**. The glyphs are literal characters inside
-user-authored `label:` strings
-(`prototypes/data-entry/project/data-entry.yaml:551-556`):
+Kanban had **no icon field at all**. The glyphs were literal characters inside
+user-authored `label:` strings:
 
 ```yaml
 - value: open
@@ -52,41 +49,69 @@ user-authored `label:` strings
 ```
 
 The SPA must **never** parse emoji out of user label text — that is a lossy
-heuristic over user data and silently rewrites what an author typed. Instead:
-
-- `KanbanColumn` (`config.go:396`) gains an optional `Icon string`.
-- `KanbanSwimlane` (`config.go:402`) gains it too — identical `Value`/`Label`
-shape, labels rendered the same way, so icon-ing only one leaves the model
-asymmetric.
-- The prototype YAML migrates its emoji out of `label:` into `icon:`.
+heuristic over user data and silently rewrites what an author typed. Instead
+`KanbanColumn` and `KanbanSwimlane` each gain an optional `Icon string` (same
+`Value`/`Label` shape, rendered the same way, so supporting one and not the
+other would be an arbitrary asymmetry). The prototype YAML migrates its emoji
+out of `label:` into `icon:`.
 
 Corrects an earlier observation: the "missing space" in `📥To Do` was **not** a
-bug. The label is authored with a space; it merely reads tight. No SPA fault.
+bug. The label is authored with a space; it merely reads tight.
 
-### Validation (from RR-IUMZV8)
+### Navigation entries
 
-Icon names are resolved via a **static allowlist**, never dynamic component
+**Added after the sidebar swap, on the same principle.** The nav icon was
+derived from the entry KIND in `navEntryToSidebarItem` — every `list:` entry the
+same glyph, every `kanban:` the same one. A sidebar with three ticket lists
+therefore read as three identical rows distinguishable only by their labels; the
+icons carried no information.
+
+`NavigationEntry` gains an optional `Icon string` that overrides the derived
+default. Applied **after** the kind switch so it covers every branch — including
+`action:` entries, which derive no icon at all and were otherwise the one kind
+that could never have one.
+
+A **group** is rejected rather than silently ignored: it renders as a bare
+section title with nowhere to put an icon. Same reasoning and message shape as
+the existing group-`permission` rejection.
+
+The frontend needed no change: `navIcon(item.icon)` already resolved through the
+registry with a safe fallback.
+
+### Validation
+
+Icon names resolve via a **static allowlist**, never dynamic component
 resolution from a config string. An unknown name is a **load-time config error**
-(`validateKanbans` already iterates columns with indexed messages), consistent
-with the strict `ValidateConfig` convention — plus a frontend default fallback
-so a stale config renders rather than throws.
+with an indexed message, consistent with the strict `ValidateConfig` convention
+— plus a frontend default fallback so a stale config renders rather than throws.
+
+`ValidIconNames` (Go) mirrors the SPA registry, pinned by a test that reads the
+real `icons.ts` and fails on drift in **either** direction.
 
 ## Acceptance criteria
 
 1. An SVG icon set is added with the licensing/bundling rationale recorded; it
 is self-hosted with no runtime network fetch for icon assets.
-2. Sidebar emoji are replaced with SVG icons, **including** the five hardcoded
-glyphs outside `getIconEmoji` (lines 161, 166, 236, 249, 257).
-3. Icons inherit `currentColor` and follow the theme toggle in both themes.
+2. All nine sidebar emoji are replaced with SVG icons, **including** the five
+outside the old `getIconEmoji` switch.
+3. Icons inherit `currentColor` and follow the theme in both modes.
 4. `KanbanColumn` and `KanbanSwimlane` accept an optional `icon:`; the SPA
 renders it beside the label and never parses emoji out of `label:` text.
-5. The prototype `data-entry.yaml` is migrated from emoji-in-label to `icon:`.
-6. An unknown icon name is a load-time config error with an indexed message;
+5. `NavigationEntry` accepts an optional `icon:` that overrides the
+kind-derived default, including for `action:` entries.
+6. An icon on a navigation **group** is a config error, not silently dropped.
+7. The prototype `data-entry.yaml` is migrated from emoji-in-label to `icon:`,
+and demonstrates per-item nav icons.
+8. An unknown icon name is a load-time config error with an indexed message;
 the frontend independently falls back to a default icon rather than throwing.
-7. A `label:` that still contains an emoji renders verbatim — never stripped.
-8. No regression in frontend unit tests, Go tests, or the e2e suite.
+9. A `label:` that still contains an emoji renders verbatim — never stripped.
+10. The Go allowlist and the SPA registry are pinned to each other by a test
+that fails on drift in either direction.
+11. No regression in frontend unit tests, Go tests, or the e2e suite.
 
 ## Out of scope
 
 - Tokens (PR 1) and the span/layout work (PR 2).
 - Label humanization — separate PR entirely.
+- Emoji in other components (EntityList, CommandModal, InaccessibleField,
+StatusBar) — separate surfaces this ticket does not cover.

--- a/tickets/relations/TKT-8GUI60--has-docs--DOCS-9ARY8L.md
+++ b/tickets/relations/TKT-8GUI60--has-docs--DOCS-9ARY8L.md
@@ -1,0 +1,5 @@
+---
+from: TKT-8GUI60
+relation: has-docs
+to: DOCS-9ARY8L
+---

--- a/tickets/relations/TKT-8GUI60--has-implementation--IMPL-DJ9Y71.md
+++ b/tickets/relations/TKT-8GUI60--has-implementation--IMPL-DJ9Y71.md
@@ -1,0 +1,5 @@
+---
+from: TKT-8GUI60
+relation: has-implementation
+to: IMPL-DJ9Y71
+---

--- a/tickets/relations/TKT-8GUI60--has-planning--PLAN-C1OV20.md
+++ b/tickets/relations/TKT-8GUI60--has-planning--PLAN-C1OV20.md
@@ -1,0 +1,5 @@
+---
+from: TKT-8GUI60
+relation: has-planning
+to: PLAN-C1OV20
+---

--- a/tickets/relations/TKT-8GUI60--has-review--REV-ZRFXAZ.md
+++ b/tickets/relations/TKT-8GUI60--has-review--REV-ZRFXAZ.md
@@ -1,0 +1,5 @@
+---
+from: TKT-8GUI60
+relation: has-review
+to: REV-ZRFXAZ
+---

--- a/tickets/relations/TKT-8GUI60--has-review-response--RR-5ESHXG.md
+++ b/tickets/relations/TKT-8GUI60--has-review-response--RR-5ESHXG.md
@@ -1,0 +1,5 @@
+---
+from: TKT-8GUI60
+relation: has-review-response
+to: RR-5ESHXG
+---

--- a/tickets/relations/TKT-8GUI60--has-review-response--RR-GTOQCF.md
+++ b/tickets/relations/TKT-8GUI60--has-review-response--RR-GTOQCF.md
@@ -1,0 +1,5 @@
+---
+from: TKT-8GUI60
+relation: has-review-response
+to: RR-GTOQCF
+---

--- a/tickets/relations/TKT-8GUI60--has-review-response--RR-NV753I.md
+++ b/tickets/relations/TKT-8GUI60--has-review-response--RR-NV753I.md
@@ -1,0 +1,5 @@
+---
+from: TKT-8GUI60
+relation: has-review-response
+to: RR-NV753I
+---

--- a/tickets/relations/TKT-8GUI60--has-review-response--RR-OX9WFS.md
+++ b/tickets/relations/TKT-8GUI60--has-review-response--RR-OX9WFS.md
@@ -1,0 +1,5 @@
+---
+from: TKT-8GUI60
+relation: has-review-response
+to: RR-OX9WFS
+---

--- a/tickets/relations/TKT-8GUI60--has-review-response--RR-VESDBZ.md
+++ b/tickets/relations/TKT-8GUI60--has-review-response--RR-VESDBZ.md
@@ -1,0 +1,5 @@
+---
+from: TKT-8GUI60
+relation: has-review-response
+to: RR-VESDBZ
+---


### PR DESCRIPTION
PR 3 of 3 (FEAT-OJ8L0H). Stacked on #1282 — retarget to `develop` once that
merges.

## Why

Emoji can't take `currentColor`, so they ignore the theme; they render
differently on every OS; and they sat on an inconsistent baseline right next to
the real SVG icons already in the tree.

## What

**Lucide** (`lucide-vue-next`, ISC) — tree-shakeable named imports, self-hosted
(mandatory: the SPA is embedded in a Go binary and must not fetch icons at
runtime), `currentColor` by default.

`utils/icons.ts` is the **one place** a config string becomes a component — a
static allowlist, never dynamic resolution.

**All nine sidebar emoji are gone**, including the five *outside* the old
`getIconEmoji` switch (search, analysis, apps, settings, theme toggle) that a
naive swap would have missed.

**Kanban columns and swimlanes gain `icon:`** — a *name*, not a glyph. The emoji
previously lived inside user-authored `label:` strings, and the SPA must never
parse them back out: that would silently rewrite what an author typed. An emoji
left in a label still renders verbatim.

## Two allowlists, pinned to each other

`ValidIconNames` mirrors the SPA registry Go-side, so an unknown name is a
**load-time config error** rather than a silent fallback icon.
`TestIconAllowlistMatchesFrontend` reads the real `icons.ts` and fails on drift
in **either** direction — a name Go accepts but the SPA can't render shows a
wrong icon with no error; a name the SPA knows but Go rejects is a feature an
author can't reach.

## A real bug the tests caught

`resolveIcon` originally used `ICONS[name] ?? DEFAULT_ICON`. A bare index finds
**inherited** `Object.prototype` members, so a config naming `toString` or
`constructor` would have returned a function that isn't a component and crashed
the render. The prototype-key test failed on first run; fixed with an
own-property check.

## Verification

- Browser: **15 icons, all real `<svg>`, zero emoji left**
- Theme: kanban icon stroke *exactly matches its label colour* in both themes —
  `rgb(25,25,25)` light, `rgb(236,233,224)` dark. (Sidebar icons legitimately
  hold one colour: that rail is navy in both themes by design.)
- Frontend **1499/1499**; Go tests ok; `golangci-lint` 0 issues; ESLint 0
  errors; typecheck clean; `just docs-check` passes

Docs authored in `docs-project/entities/guides/GUIDE-data-entry.md` — the
generated `docs/data-entry.md` is *not* the source, a lesson from #1282's CI.

Ticket: TKT-8GUI60 · Resolves RR-GWVGDX (critical) and RR-09N4MN from
TKT-5V8704's design review.