### PR TITLE
fix(forms): date inputs render blank over stored values

### DIFF
--- a/frontend/src/widgets/DateWidget.vue
+++ b/frontend/src/widgets/DateWidget.vue
@@ -25,6 +25,21 @@ const displayValue = computed(() => {
   return formatDate(stringValue.value) ?? stringValue.value
 })
 
+// `<input type="date">` accepts ONLY `YYYY-MM-DD` and silently renders blank
+// for anything else — including the RFC3339 timestamps the API returns for
+// `date` properties (`2026-09-15T00:00:00Z`). Binding the raw string therefore
+// showed an empty input over a stored value, which reads as "my data is gone".
+// Narrow to the date part; pass through anything already in the right shape,
+// and leave un-parseable input alone so the user's in-progress typing is never
+// swallowed.
+const inputValue = computed(() => {
+  const raw = stringValue.value
+  if (!raw) return ''
+  if (/^\d{4}-\d{2}-\d{2}$/.test(raw)) return raw
+  const match = /^(\d{4}-\d{2}-\d{2})T/.exec(raw)
+  return match ? match[1] : raw
+})
+
 function onInput(event: Event) {
   emit('update:modelValue', (event.target as HTMLInputElement).value)
 }
@@ -37,7 +52,7 @@ function onInput(event: Event) {
     :id="id"
     type="date"
     :class="{ 'is-error': !!error }"
-    :value="stringValue"
+    :value="inputValue"
     :placeholder="placeholder"
     :disabled="disabled"
     @input="onInput"

--- a/frontend/src/widgets/widgets.test.ts
+++ b/frontend/src/widgets/widgets.test.ts
@@ -117,6 +117,41 @@ describe('DateWidget', () => {
     await input.setValue('2026-06-01')
     expect(w.emitted('update:modelValue')?.[0]).toEqual(['2026-06-01'])
   })
+
+  // The API returns RFC3339 for `date` properties (`2026-09-15T00:00:00Z`),
+  // but `<input type="date">` accepts ONLY `YYYY-MM-DD` and silently renders
+  // blank otherwise — so the form showed an empty input over a stored value,
+  // which reads as "my data is gone". The old test only ever passed an
+  // already-normalized date, which is how this slipped through.
+  it('narrows an RFC3339 timestamp to the date part so the input is populated', () => {
+    const w = mount(DateWidget, {
+      props: { modelValue: '2026-09-15T00:00:00Z', mode: 'edit' as const, propertyName: '' },
+    })
+    expect((w.find('input[type="date"]').element as HTMLInputElement).value).toBe('2026-09-15')
+  })
+
+  it('narrows a timestamp with an offset too', () => {
+    const w = mount(DateWidget, {
+      props: { modelValue: '2026-09-15T13:45:00+02:00', mode: 'edit' as const, propertyName: '' },
+    })
+    expect((w.find('input[type="date"]').element as HTMLInputElement).value).toBe('2026-09-15')
+  })
+
+  it('passes an un-parseable value through rather than swallowing it', () => {
+    // The browser will reject it for display, but we must not silently rewrite
+    // whatever the user or a hand-edited file put there.
+    const w = mount(DateWidget, {
+      props: { modelValue: 'not-a-date', mode: 'edit' as const, propertyName: '' },
+    })
+    expect(w.find('input[type="date"]').exists()).toBe(true)
+  })
+
+  it('renders empty for no value', () => {
+    const w = mount(DateWidget, {
+      props: { modelValue: '', mode: 'edit' as const, propertyName: '' },
+    })
+    expect((w.find('input[type="date"]').element as HTMLInputElement).value).toBe('')
+  })
 })
 
 describe('DatetimeWidget', () => {


### PR DESCRIPTION
## Problem

`<input type="date">` accepts **only** `YYYY-MM-DD` and silently renders blank for anything else — including the RFC3339 timestamps the API returns for `date` properties (`2026-09-15T00:00:00Z`).

`DateWidget` bound the raw stored string, so **every date field showed EMPTY over a perfectly good stored value**, on a plain page load with no interaction at all.

Especially misleading in context: an empty date box is exactly what "my data was destroyed" looks like.

## Fix

Narrow an RFC3339 timestamp to its date part before binding. Values already in `YYYY-MM-DD` pass through; un-parseable input is left alone so a user's in-progress typing is never swallowed.

`DatetimeWidget` already did this (`utcISOToLocalInput`) — `DateWidget` was the outlier.

## Why it wasn't caught

The existing unit test only ever passed an already-normalized `YYYY-MM-DD`. Four new cases: RFC3339, offset timestamps, un-parseable passthrough, empty.

## Notes

Pre-existing bug, found while building a demo for BUG-FB0LN8. Independent of that work — no shared code.

---

Tickets-PR: #1296


