### PR TITLE
fix(ui): preserve authored line breaks in ConfirmModal messages

### DIFF
--- a/frontend/src/components/ui/ConfirmModal.test.ts
+++ b/frontend/src/components/ui/ConfirmModal.test.ts
@@ -69,6 +69,17 @@ describe('ConfirmModal', () => {
       expect(document.querySelector('.modal p')).toBeNull()
     })
 
+    // A caller that lists items ("these fields will be cleared: …") separates
+    // them with newlines. Default `white-space` collapses those to spaces and
+    // the list renders as one run-on paragraph, which is unreadable exactly
+    // when the message matters most.
+    it('marks the message so authored line breaks survive', () => {
+      factory({ open: true, title: 'T', message: 'line one\nline two' })
+      const p = document.querySelector('.modal p')
+      expect(p?.classList.contains('modal-message')).toBe(true)
+      expect(p?.textContent).toBe('line one\nline two')
+    })
+
     it('uses default labels', () => {
       factory()
       const b = buttons()

--- a/frontend/src/components/ui/ConfirmModal.vue
+++ b/frontend/src/components/ui/ConfirmModal.vue
@@ -98,7 +98,7 @@ function handleKeydown(e: KeyboardEvent) {
     >
       <div class="modal">
         <h3 :id="titleId">{{ title }}</h3>
-        <p v-if="$slots.default || message">
+        <p v-if="$slots.default || message" class="modal-message">
           <slot>{{ message }}</slot>
         </p>
         <div class="modal-actions">
@@ -123,3 +123,13 @@ function handleKeydown(e: KeyboardEvent) {
     </div>
   </Teleport>
 </template>
+
+<style scoped>
+/* Preserve authored line breaks so a caller can present a list (e.g. "these
+   fields will be cleared") without it collapsing into one run-on paragraph.
+   `pre-line` keeps newlines but still wraps long lines and collapses the
+   incidental indentation of a template literal. */
+.modal-message {
+  white-space: pre-line;
+}
+</style>


### PR DESCRIPTION
## Problem

`ConfirmModal` renders `message` as text in a `<p>`, so default `white-space` collapses newlines to spaces.

A caller listing items ("these fields will be cleared: …") got one run-on paragraph — unreadable exactly when the message matters most, since the whole point of such a dialog is that the user can see what they are about to lose.

Observed:

> This change hides fields that have a saved value. Continuing will clear: • Contract value: € 2.400.000 • Award criteria: EMVI — 60% kwaliteit / 40% prijs • Framework agreement: true Choose Cancel to keep the current values.

## Fix

`white-space: pre-line` on the message paragraph. Keeps authored newlines while still wrapping long lines and collapsing a template literal's incidental indentation.

Fixed in the shared component rather than per-caller, so any caller can present a list.

## Notes

Adds the test the message paragraph was missing. Independent of the other BUG-FB0LN8 PRs.

---

Tickets-PR: #1296


