### PR TITLE
feat(acl): explicit `visible: false` tombstone in _fields

### DIFF
--- a/docs/data-entry/api-reference.md
+++ b/docs/data-entry/api-reference.md
@@ -419,7 +419,8 @@ regardless of source.
   "properties": { /* hidden fields are OMITTED entirely */ },
   "_fields": {
     "kind": { "writable": false },
-    "status": { "options": { "done": false } }
+    "status": { "options": { "done": false } },
+    "salary": { "visible": false }
   },
   "_relations": {
     "affects":    { "creatable": false },
@@ -436,11 +437,31 @@ from the permissive default appear. An absent key in either map means
 signal letting the SPA distinguish "evaluated, no deviations" from
 "affordances not available" (anonymous fallback / pre-rollout server).
 
-Hidden fields are doubly invisible: omitted from `properties` AND absent
-from `_fields`. The SPA filters its config-driven form-field list against
-both: a field declared in `data-entry.yaml` is rendered only if it appears
-in `_fields` OR `properties`. This makes "hidden = omitted" actually hide
-the input.
+A hidden field's **value** is omitted from `properties`, and the field
+carries an explicit `{"visible": false}` **tombstone** in `_fields`
+(BUG-FB0LN8). The SPA renders a read-only "redacted" affordance for a
+tombstoned field, and renders a normal input for any other property its
+entity type declares.
+
+The tombstone exists because absence is ambiguous. A key missing from
+`properties` may be redacted, never set, or deleted by the client itself —
+and a client forced to infer intent from absence gets it wrong. It used to:
+the form treated "absent" as "hidden", so once a conditional field's value
+was cleared the input could never be rendered again, silently destroying
+user data with no recovery path.
+
+The tombstone discloses only the field **name**. That is not a secret:
+`GET /api/v1/_schema` already serves every declared property of every type,
+unfiltered, to any authenticated caller. Field-level `visible:` redaction
+protects **values**, and makes no claim to conceal which properties exist.
+(Row-level ACL is different — whether an entity *exists* is a genuine
+secret, and a hidden entity 404s indistinguishably.)
+
+**Exception — read-only per-row surfaces.** `v1.ViewEntity._fields` on
+cards / list rows keeps the stricter closed-world shape: hidden fields are
+absent from both `_props` and `_fields`. A read-only row never decides
+whether to render an input, so it has no use for the disambiguation and
+does not pay its disclosure.
 
 ### Write-side parity
 
@@ -612,7 +633,13 @@ sparse semantics as `V1Entity._fields`:
 property hidden by the metamodel + ACL never appears in either map. The
 two maps may diverge in one direction only — `_fields` can carry a key
 absent from `_props` when the property has no stored value but a
-non-default verdict (e.g. `writable: false` on an unset field). Table
+non-default verdict (e.g. `writable: false` on an unset field).
+
+Note this row surface deliberately does **not** carry the
+`{"visible": false}` tombstone that `V1Entity._fields` emits: a read-only
+row never decides whether to render an input, so it keeps the stricter
+closed-world invariant (`keys(_fields) ∩ hidden == ∅`). See the
+`_fields` section above. Table
 sections (`display: table`) and the entry-source section keep their
 existing shape; the entry section's properties + affordances ride on
 the parent `entry` (`V1Entity`).

--- a/frontend/src/types/entity.ts
+++ b/frontend/src/types/entity.ts
@@ -25,7 +25,10 @@ export interface Entity {
   _actions?: Record<string, boolean>
   // Per-field write affordances on per-entity GET responses.
   // Sparse: only fields whose verdict deviates from default appear.
-  // Hidden fields are omitted from `properties` AND from `_fields`.
+  // A hidden field's VALUE is omitted from `properties`, and the field
+  // carries a `{visible: false}` tombstone here so a client can tell
+  // "redacted" from "unset" (BUG-FB0LN8). Read-only per-row surfaces
+  // (view sections) omit hidden fields from both maps instead.
   // Absent on list / mutation responses; present (possibly empty) on
   // per-entity GET (closed-world signal — empty means "evaluated, no
   // deviations"). See docs/data-entry/api-reference.md.
@@ -59,11 +62,23 @@ export interface Entity {
 }
 
 // FieldAffordance carries per-field write / option affordances on
-// the wire. Sparse: `writable` undefined means default (writable);
-// `options` lists only the false entries (allowed options are
-// implicit via the metamodel).
+// the wire. Sparse: `writable` / `visible` undefined means the
+// permissive default (writable, visible); `options` lists only the
+// false entries (allowed options are implicit via the metamodel).
+//
+// `visible: false` is an explicit redaction tombstone (BUG-FB0LN8): the
+// field is declared by the metamodel but its VALUE is withheld by
+// field-level ACL, so it is also absent from `properties`. Render it
+// read-only/redacted — never as an empty input, which would invite a
+// write the server rejects. Do NOT infer redaction from a key's mere
+// absence: absence is ambiguous (redacted, never set, or locally
+// cleared), and guessing is what caused BUG-FB0LN8.
+//
+// A hidden field carries ONLY this tombstone; writability and option
+// verdicts are suppressed server-side for values the caller can't read.
 export interface FieldAffordance {
   writable?: boolean
+  visible?: boolean
   options?: Record<string, boolean>
 }
 

--- a/frontend/src/utils/affordances.test.ts
+++ b/frontend/src/utils/affordances.test.ts
@@ -35,6 +35,22 @@ describe('isFieldWritable', () => {
   it('combines both channels — fieldReadonly true wins over verdict writable', () => {
     expect(isFieldWritable({ writable: true }, true)).toBe(false)
   })
+
+  // BUG-FB0LN8: a redaction tombstone carries ONLY `visible: false` — the
+  // server suppresses `writable` for a value the caller cannot read. Checking
+  // `writable !== false` alone would call a redacted field writable and render
+  // an empty, editable widget whose every write the server 403s.
+  it('is never writable when the field is redacted', () => {
+    expect(isFieldWritable({ visible: false })).toBe(false)
+  })
+
+  it('stays non-writable for a redacted field even if writable is explicitly true', () => {
+    expect(isFieldWritable({ visible: false, writable: true })).toBe(false)
+  })
+
+  it('is unaffected by an explicit visible: true', () => {
+    expect(isFieldWritable({ visible: true })).toBe(true)
+  })
 })
 
 describe('optionVerdictsFor', () => {

--- a/frontend/src/utils/affordances.ts
+++ b/frontend/src/utils/affordances.ts
@@ -1,19 +1,25 @@
 import type { FieldAffordance } from '@/types'
 
-// isFieldWritable: the rendered field is writable unless EITHER the
-// static config marks it readonly OR the server's `_fields` verdict
-// reports `writable === false`. Both signals are honored — the server
-// verdict is authoritative on the wire, but a form config can still
-// pin a field readonly for static reasons (e.g. ID display).
+// isFieldWritable: the rendered field is writable unless the static
+// config marks it readonly, the server's `_fields` verdict reports
+// `writable === false`, or the field is redacted (`visible === false`).
+// All three signals are honored — the server verdict is authoritative
+// on the wire, but a form config can still pin a field readonly for
+// static reasons (e.g. ID display).
 //
-// `fieldReadonly` is optional so view-side hosts (SectionEditForm)
-// that have no static-readonly concept can omit it; passing
-// `undefined` falls through cleanly to the verdict check.
+// The `visible === false` case matters because a redaction tombstone
+// carries ONLY that verdict: the server suppresses `writable` for a
+// value the caller cannot read (BUG-FB0LN8), so `writable !== false`
+// alone would report a redacted field as writable and render an empty,
+// editable widget whose every write the server 403s. Checking it here
+// rather than per-consumer is deliberate — the gap this closes was one
+// consumer compensating while another did not.
 export function isFieldWritable(
   verdict: FieldAffordance | undefined,
   fieldReadonly?: boolean,
 ): boolean {
   if (fieldReadonly) return false
+  if (verdict?.visible === false) return false
   return verdict?.writable !== false
 }
 

--- a/internal/apiwire/v1/responses.go
+++ b/internal/apiwire/v1/responses.go
@@ -23,8 +23,12 @@ type Entity struct {
 	Inaccessible []InaccessibleField `json:"inaccessible,omitempty"`
 	// FieldAffordances carries per-field write affordances on per-entity
 	// GET responses. Sparse: only fields whose verdict deviates from the
-	// permissive default appear. Hidden fields are omitted from
-	// `Properties` AND from this map entirely. Pointer semantics
+	// permissive default appear. A hidden field's VALUE is omitted from
+	// `Properties`, and the field carries a `{visible: false}` tombstone
+	// here so a client can tell "redacted" from "unset" (BUG-FB0LN8).
+	// Read-only per-row surfaces (ViewEntity) omit hidden fields from
+	// both maps instead — see computeVisibleFieldAffordances.
+	// Pointer semantics
 	// distinguish "absent on the wire" (nil pointer; list / mutation
 	// responses) from "present and empty" (`{}`; per-entity GET with no
 	// deviations under nop resolver — closed-world signal matching the
@@ -66,12 +70,23 @@ type Entity struct {
 }
 
 // FieldAffordance describes per-field write / option affordances on
-// the wire. Sparse: `Writable` is nil when the default (writable)
-// holds; `Options` lists only the false entries (allowed options are
-// implicit via the metamodel). See the closed-world contract in
-// docs/data-entry/api-reference.md.
+// the wire. Sparse: `Writable` and `Visible` are nil when their
+// permissive defaults (writable, visible) hold; `Options` lists only
+// the false entries (allowed options are implicit via the metamodel).
+// See the closed-world contract in docs/data-entry/api-reference.md.
+//
+// `Visible: false` is an explicit redaction tombstone (BUG-FB0LN8):
+// the field is declared by the metamodel but its VALUE is withheld by
+// field-level ACL, so it is also absent from the entity's Properties.
+// Without the tombstone a redacted field is byte-identical on the wire
+// to one that is merely unset, and clients are forced to infer intent
+// from absence — an ambiguous sentinel that cost us silent data loss.
+// Field-level redaction hides values only and makes no claim to
+// conceal which properties exist (the metamodel is served in full via
+// /api/v1/_schema), so naming the redacted field discloses nothing new.
 type FieldAffordance struct {
 	Writable *bool           `json:"writable,omitempty"`
+	Visible  *bool           `json:"visible,omitempty"`
 	Options  map[string]bool `json:"options,omitempty"`
 }
 

--- a/internal/dataentry/affordances.go
+++ b/internal/dataentry/affordances.go
@@ -211,8 +211,11 @@ type FieldVerdicts struct {
 	Writable map[string]bool
 
 	// Visible maps fieldName → visible. Absence = visible. False means
-	// the property is omitted from the wire `properties` map AND from
-	// `_fields`; the SPA's filter never sees the key.
+	// the property's VALUE is omitted from the wire `properties` map; on
+	// per-entity responses the field also gets a `{visible: false}`
+	// tombstone in `_fields` so the client can distinguish "redacted"
+	// from "unset" (BUG-FB0LN8). Read-only per-row surfaces omit it from
+	// both maps — see computeVisibleFieldAffordances.
 	Visible map[string]bool
 
 	// Options maps fieldName → optionValue → allowed. Absence of the
@@ -713,9 +716,17 @@ func (svc affordanceService) validateRelationMetaWrite(
 
 // computeFieldAffordances returns the sparse `_fields` wire map for
 // entity e: only fields whose verdict deviates from the permissive
-// default appear. Hidden fields (Visible[name] == false) are absent
-// from the returned map AND must be omitted from the entity's
-// Properties by the caller — they are doubly-invisible to the client.
+// default appear. Hidden fields (Visible[name] == false) appear as an
+// explicit `{visible: false}` tombstone and must still be omitted from
+// the entity's Properties by the caller — the VALUE is withheld, the
+// field's existence is not (BUG-FB0LN8).
+//
+// The tombstone exists because absence is ambiguous: a key missing from
+// `properties` may be redacted, never set, or deleted. Clients that had
+// to guess got it wrong in a way that silently destroyed user data. It
+// discloses only the field NAME, which /api/v1/_schema already serves
+// in full to any authenticated caller; field-level redaction protects
+// values, not the shape of the metamodel.
 //
 // Empty input verdicts yield an empty (non-nil) map so the wire shape
 // is consistent: `_fields: {}` under the nop resolver, sparse entries
@@ -726,19 +737,54 @@ func (svc affordanceService) computeFieldAffordances(
 	return computeFieldAffordancesFrom(svc.resolver().FieldVerdicts(ctx, e))
 }
 
+// computeVisibleFieldAffordances is computeFieldAffordances without the
+// `{visible: false}` tombstones — hidden fields are absent from the map
+// entirely, the pre-BUG-FB0LN8 closed-world shape.
+//
+// This is for READ-ONLY per-row surfaces (cards/list rows in
+// v1.ViewEntity._fields, TKT-IHC7D), which preserve RR-FD1B's stricter
+// invariant: keys(_props) ∩ hidden == ∅ AND keys(_fields) ∩ hidden == ∅.
+// The tombstone earns its disclosure on the EDIT path, where a client
+// must tell "redacted" from "unset" to decide whether to render an input.
+// A read-only row makes no such decision, so it gets no tombstone.
+func (svc affordanceService) computeVisibleFieldAffordances(
+	ctx context.Context, e *entityPkg.Entity,
+) map[string]v1.FieldAffordance {
+	v := svc.resolver().FieldVerdicts(ctx, e)
+	out := computeFieldAffordancesFrom(v)
+	for name := range out {
+		if v.isHidden(name) {
+			delete(out, name)
+		}
+	}
+	return out
+}
+
 // computeFieldAffordancesFrom is computeFieldAffordances given an
 // already-resolved verdict set, so callers that need the verdicts for more
 // than one thing (e.g. _fields + _attachments) resolve them once.
 func computeFieldAffordancesFrom(v FieldVerdicts) map[string]v1.FieldAffordance {
 	out := make(map[string]v1.FieldAffordance)
 
+	// visible=false tombstones. A hidden field carries ONLY this verdict:
+	// writability and option filters are meaningless for a value the
+	// caller cannot read, and emitting them would leak policy detail
+	// beyond the field's existence.
+	for name := range v.Visible {
+		if !v.isHidden(name) {
+			continue // sparse: default is visible
+		}
+		f := false
+		out[name] = v1.FieldAffordance{Visible: &f}
+	}
+
 	// writable=false entries
 	for name, writable := range v.Writable {
 		if writable {
 			continue // sparse: default is writable
 		}
-		if !v.Visible[name] && v.isHidden(name) {
-			continue // hidden takes precedence; skip from _fields entirely
+		if v.isHidden(name) {
+			continue // hidden takes precedence; the tombstone above is the whole verdict
 		}
 		entry := out[name]
 		f := false

--- a/internal/dataentry/affordances_test.go
+++ b/internal/dataentry/affordances_test.go
@@ -494,7 +494,13 @@ func TestComputeFieldAffordances_SparseWritable(t *testing.T) {
 	}
 }
 
-func TestComputeFieldAffordances_HiddenFieldsOmittedFromMap(t *testing.T) {
+// BUG-FB0LN8: a hidden field appears in _fields as an explicit
+// `{visible: false}` tombstone, carrying NOTHING else. The value stays
+// omitted from `properties` (that is the redaction); the tombstone only
+// disambiguates "redacted" from "unset" so clients stop inferring intent
+// from absence. Writability and option filters are suppressed — they are
+// meaningless for an unreadable value and would leak policy detail.
+func TestComputeFieldAffordances_HiddenFieldsCarryVisibleTombstoneOnly(t *testing.T) {
 	svc := affordanceServiceWithResolver(fakeResolver{
 		fv: FieldVerdicts{
 			Writable: map[string]bool{"priority": false}, // also marked read-only
@@ -503,8 +509,70 @@ func TestComputeFieldAffordances_HiddenFieldsOmittedFromMap(t *testing.T) {
 		},
 	})
 	got := svc.computeFieldAffordances(context.Background(), &entity.Entity{Type: "ticket"})
+	entry, ok := got["priority"]
+	if !ok {
+		t.Fatalf("hidden field must appear as a tombstone; got %+v", got)
+	}
+	if entry.Visible == nil || *entry.Visible {
+		t.Errorf("priority.Visible: got %v, want pointer-to-false", entry.Visible)
+	}
+	if entry.Writable != nil {
+		t.Errorf("hidden field must not carry a writable verdict; got %v", *entry.Writable)
+	}
+	if len(entry.Options) != 0 {
+		t.Errorf("hidden field must not carry option verdicts; got %v", entry.Options)
+	}
+}
+
+// The read-only per-row surface (cards/list rows) keeps RR-FD1B's stricter
+// closed-world invariant: hidden fields are absent from _fields entirely.
+// The tombstone earns its disclosure only on the edit path, where a client
+// must distinguish "redacted" from "unset" to decide whether to render an
+// input; a read-only row makes no such decision.
+func TestComputeVisibleFieldAffordances_NoTombstonesOnReadOnlyRows(t *testing.T) {
+	svc := affordanceServiceWithResolver(fakeResolver{
+		fv: FieldVerdicts{
+			Writable: map[string]bool{"kind": false},
+			Visible:  map[string]bool{"priority": false},
+		},
+	})
+	e := &entity.Entity{Type: "ticket"}
+	got := svc.computeVisibleFieldAffordances(context.Background(), e)
 	if _, ok := got["priority"]; ok {
-		t.Errorf("hidden field must NOT appear in _fields (closed-world); got %+v", got)
+		t.Errorf("hidden field must be wholly absent from a read-only row; got %+v", got)
+	}
+	// Non-hidden verdicts still ride along.
+	if kind, ok := got["kind"]; !ok {
+		t.Errorf("kind should keep its writable verdict; got %+v", got)
+	} else if kind.Writable == nil || *kind.Writable {
+		t.Errorf("kind.Writable: got %v, want pointer-to-false", kind.Writable)
+	}
+	// ...while the edit-path surface DOES tombstone the same field.
+	edit := svc.computeFieldAffordances(context.Background(), e)
+	if _, ok := edit["priority"]; !ok {
+		t.Errorf("edit-path _fields must tombstone the hidden field; got %+v", edit)
+	}
+}
+
+// A visible field is never given a tombstone — `visible` stays nil so the
+// sparse wire shape is unchanged for the overwhelmingly common case.
+func TestComputeFieldAffordances_VisibleFieldsHaveNoTombstone(t *testing.T) {
+	svc := affordanceServiceWithResolver(fakeResolver{
+		fv: FieldVerdicts{
+			Writable: map[string]bool{"kind": false},
+			Visible:  map[string]bool{"kind": true, "title": true},
+		},
+	})
+	got := svc.computeFieldAffordances(context.Background(), &entity.Entity{Type: "ticket"})
+	if _, ok := got["title"]; ok {
+		t.Errorf("visible+writable field must stay absent (sparse); got %+v", got)
+	}
+	kind, ok := got["kind"]
+	if !ok {
+		t.Fatalf("kind should be present for its writable verdict")
+	}
+	if kind.Visible != nil {
+		t.Errorf("visible field must not carry a visible verdict; got %v", *kind.Visible)
 	}
 }
 

--- a/internal/dataentry/api_v1_test.go
+++ b/internal/dataentry/api_v1_test.go
@@ -4413,8 +4413,12 @@ func TestV1Affordance_PerEntityGet_DemoFixture(t *testing.T) {
 		t.Fatal("FieldAffordances nil")
 	}
 	fa := *got.FieldAffordances
-	if _, ok := fa["priority"]; ok {
-		t.Errorf("priority must be absent from _fields (hidden): %v", fa)
+	// BUG-FB0LN8: a hidden field carries an explicit {visible:false}
+	// tombstone. Its VALUE is still withheld (asserted on Properties above).
+	if prio, ok := fa["priority"]; !ok {
+		t.Errorf("priority must appear in _fields as a tombstone (hidden): %v", fa)
+	} else if prio.Visible == nil || *prio.Visible {
+		t.Errorf("priority.Visible: got %v, want pointer-to-false", prio.Visible)
 	}
 	if _, ok := fa["title"]; ok {
 		t.Errorf("title must be absent from _fields (default writable): %v", fa)
@@ -4484,8 +4488,27 @@ func TestV1Affordance_PatchEcho_StripsHidden(t *testing.T) {
 		t.Fatalf("PATCH returned %d: %s", rec.Code, rec.Body.String())
 	}
 	body := rec.Body.String()
-	if strings.Contains(body, `"title"`) || strings.Contains(body, "secret") {
-		t.Errorf("PATCH echo must NOT contain hidden field; got: %s", body)
+	// The hidden field's VALUE must never appear anywhere in the echo.
+	if strings.Contains(body, "secret") {
+		t.Errorf("PATCH echo must NOT contain the hidden field's value; got: %s", body)
+	}
+	var echo v1.Entity
+	if err := json.Unmarshal(rec.Body.Bytes(), &echo); err != nil {
+		t.Fatalf("unmarshal echo: %v", err)
+	}
+	if _, ok := echo.Properties["title"]; ok {
+		t.Errorf("PATCH echo properties must omit the hidden field; got: %s", body)
+	}
+	// BUG-FB0LN8: the field's existence is disclosed via the tombstone, so
+	// a client can tell "redacted" from "unset" without guessing.
+	if echo.FieldAffordances == nil {
+		t.Fatal("PATCH echo missing _fields")
+	}
+	title, ok := (*echo.FieldAffordances)["title"]
+	if !ok {
+		t.Errorf("PATCH echo _fields must carry the hidden field's tombstone; got: %s", body)
+	} else if title.Visible == nil || *title.Visible {
+		t.Errorf("title.Visible: got %v, want pointer-to-false", title.Visible)
 	}
 }
 
@@ -4978,10 +5001,15 @@ func TestHandleV1DryRunCreate_Affordances(t *testing.T) {
 		if err := json.Unmarshal(rec.Body.Bytes(), &v); err != nil {
 			t.Fatalf("decode: %v; body=%s", err, body)
 		}
-		if v.FieldAffordances != nil {
-			if _, present := (*v.FieldAffordances)["status"]; present {
-				t.Errorf("hidden field must be absent from _fields; got %s", body)
-			}
+		// BUG-FB0LN8: hidden fields carry a {visible:false} tombstone in
+		// _fields; only the VALUE is withheld (asserted on Properties below).
+		if v.FieldAffordances == nil {
+			t.Fatalf("_fields missing; got %s", body)
+		}
+		if status, present := (*v.FieldAffordances)["status"]; !present {
+			t.Errorf("hidden field must appear in _fields as a tombstone; got %s", body)
+		} else if status.Visible == nil || *status.Visible {
+			t.Errorf("status.Visible: got %v, want pointer-to-false", status.Visible)
 		}
 		if _, present := v.Properties["status"]; present {
 			t.Errorf("hidden field must be stripped from properties; got %s", body)

--- a/internal/dataentry/sections.go
+++ b/internal/dataentry/sections.go
@@ -169,7 +169,7 @@ func (h *viewsHandler) buildSectionEntityData(
 		Type:          e.Type,
 		EditFormID:    h.editFormForType(e.Type),
 		Props:         h.affordances.copyVisibleProperties(ctx, e),
-		FieldVerdicts: h.affordances.computeFieldAffordances(ctx, e),
+		FieldVerdicts: h.affordances.computeVisibleFieldAffordances(ctx, e),
 	}
 	for _, f := range secFields {
 		values := propertyToStrings(e.Properties[f.Property])


### PR DESCRIPTION
> **This is the PR in this stack that wants real review** — it changes an ACL-adjacent wire format.

## Problem

A field-level-redacted property was omitted from **both** `properties` and `_fields`, making it byte-identical on the wire to one that is merely unset. Clients had to infer intent from absence, and absence is genuinely ambiguous: redacted, never set, or deleted by the client itself.

That ambiguity already cost us. A form treated "absent" as "hidden", so once a conditional field's value was cleared the input could never be rendered again — silent, unrecoverable data loss (BUG-FB0LN8, fixed in a separate PR that stacks on this one). This removes the ambiguous sentinel rather than working around it.

## The disclosure argument

The tombstone discloses only the field **name**. That is not a secret:

- `/api/v1/_schema` (`handleV1Schema`) iterates `s.Meta.Entities` and emits every declared property with **no principal check and no ACL filtering** — verified, not assumed.
- The project treats field-level `visible:` as protecting **values**, with no claim to conceal which properties exist (root `CLAUDE.md`: *"A 'field-existence oracle' is not a threat this guards against"*).

**Row-level ACL is untouched.** Whether an entity *exists* remains a real secret; hidden entities still 404 indistinguishably.

## Design points

- **A hidden field carries ONLY the tombstone.** Writable and option verdicts are suppressed — meaningless for a value the caller cannot read, and emitting them would leak policy detail beyond the field's existence.
- **Read-only per-row surfaces keep the stricter closed-world shape** via `computeVisibleFieldAffordances` (RR-FD1B). A card/list row never decides whether to render an input, so it has no use for the disambiguation and does not pay its disclosure.
- **`isFieldWritable` returns false for a tombstone**, in the *shared* helper rather than per-consumer. One consumer compensating while another did not is what caused the original bug; fixing it centrally makes every current and future consumer correct by default.

## Value secrecy

Unchanged. Hidden properties are still stripped on every serializer path (`forWire`, `forWireRelated`, includes, search, dry-run, transitions, attachments). The tombstone and `stripHiddenProperties` derive from the **same** `Visible` map via the same accessor, so they cannot disagree.

Tests tightened to assert the **value** never appears anywhere in the response, rather than matching on the key (which the tombstone would now trip).

## Review focus

1. Is the "field names are not secret" premise right for your threat model?
2. Is suppressing writable/options for hidden fields the correct call?
3. Is the read-only-row exception drawn in the right place?

---

Tickets-PR: #1292
