### PR TITLE
fix(data-entry): stop destroying a condition-hidden field's stored value (BUG-FB0LN8)

### DIFF
--- a/docs/data-entry.md
+++ b/docs/data-entry.md
@@ -600,9 +600,15 @@ step. An out-of-range or non-numeric `?step=` falls back to the first step.
 blocks progression while any are invalid. The final step's Submit re-validates
 every visible step.
 
-**Hidden branches are not saved.** If a step or field is hidden by a
+**Hidden branches are not saved on create.** If a step or field is hidden by a
 `visible_when` that is false at submit time, its values are dropped from the
-created/updated entity — a toggled-off branch never persists stale data.
+**created** entity — a branch the user revealed, filled, then abandoned never
+persists.
+
+**On edit, hiding does not delete.** A field that already had a stored value
+keeps it when its branch hides, and gets it back when the branch is revealed.
+Hiding is a presentation decision, not a delete. Use
+[`clear_when_hidden`](#clear_when_hidden) to opt a field into clearing.
 
 #### Condition expressions (`visible_when` / `required_when`)
 
@@ -641,6 +647,44 @@ Notes:
   a property that doesn't exist on the entity is reported at author time. (The
   check uses a slightly stricter grammar than the browser, so it may flag a few
   conditions the runtime would tolerate — treat every reported error as real.)
+
+#### `clear_when_hidden`
+
+Decides what happens to a field's **stored value** when its `visible_when` turns
+false while editing. Per-field; the default keeps the value.
+
+| Value | Behavior when the branch hides |
+| --- | --- |
+| `no` *(default)* | Keep the value. Hiding and revealing is lossless. |
+| `yes` | Clear the value. |
+
+```yaml
+fields:
+  - property: inkooproute
+  - property: inschrijfdeadline
+    visible_when: "form.inkooproute == 'aanbesteding'"
+    # omit clear_when_hidden (or set `no`) to keep the date when the
+    # branch hides; set `yes` to clear it
+```
+
+Notes:
+
+- Under the default, a hidden field's value is held client-side, so revealing
+  the branch again restores it with no server round-trip — and the value was
+  never deleted server-side, so it survives a reload too.
+- This is per-**field** only. When a whole step hides, each of its fields
+  honors its own setting.
+- Setting it without a `visible_when` is a config error — it could never apply.
+  A field on a conditional *step* is fine: the step can hide it.
+- An interactive `confirm` value (ask before clearing, undo the triggering
+  change on decline) is **not accepted yet** — a config using it fails
+  validation. It needs the form to distinguish "the user proposed a change"
+  from "the change was committed", which is tracked separately.
+- **Deeply chained conditions:** if field C's condition references field B, and
+  B is itself hidden by field A, then under the default (`no`) C can stay
+  visible holding a stale value after B's branch hides — B's value is retained,
+  so C's condition still sees it. Set `clear_when_hidden: yes` on B if you want
+  the old cascading behavior.
 
 ## Lists
 

--- a/docs/data-entry/api-reference.md
+++ b/docs/data-entry/api-reference.md
@@ -419,7 +419,8 @@ regardless of source.
   "properties": { /* hidden fields are OMITTED entirely */ },
   "_fields": {
     "kind": { "writable": false },
-    "status": { "options": { "done": false } }
+    "status": { "options": { "done": false } },
+    "salary": { "visible": false }
   },
   "_relations": {
     "affects":    { "creatable": false },
@@ -436,11 +437,31 @@ from the permissive default appear. An absent key in either map means
 signal letting the SPA distinguish "evaluated, no deviations" from
 "affordances not available" (anonymous fallback / pre-rollout server).
 
-Hidden fields are doubly invisible: omitted from `properties` AND absent
-from `_fields`. The SPA filters its config-driven form-field list against
-both: a field declared in `data-entry.yaml` is rendered only if it appears
-in `_fields` OR `properties`. This makes "hidden = omitted" actually hide
-the input.
+A hidden field's **value** is omitted from `properties`, and the field
+carries an explicit `{"visible": false}` **tombstone** in `_fields`
+(BUG-FB0LN8). The SPA renders a read-only "redacted" affordance for a
+tombstoned field, and renders a normal input for any other property its
+entity type declares.
+
+The tombstone exists because absence is ambiguous. A key missing from
+`properties` may be redacted, never set, or deleted by the client itself —
+and a client forced to infer intent from absence gets it wrong. It used to:
+the form treated "absent" as "hidden", so once a conditional field's value
+was cleared the input could never be rendered again, silently destroying
+user data with no recovery path.
+
+The tombstone discloses only the field **name**. That is not a secret:
+`GET /api/v1/_schema` already serves every declared property of every type,
+unfiltered, to any authenticated caller. Field-level `visible:` redaction
+protects **values**, and makes no claim to conceal which properties exist.
+(Row-level ACL is different — whether an entity *exists* is a genuine
+secret, and a hidden entity 404s indistinguishably.)
+
+**Exception — read-only per-row surfaces.** `v1.ViewEntity._fields` on
+cards / list rows keeps the stricter closed-world shape: hidden fields are
+absent from both `_props` and `_fields`. A read-only row never decides
+whether to render an input, so it has no use for the disambiguation and
+does not pay its disclosure.
 
 ### Write-side parity
 
@@ -612,7 +633,13 @@ sparse semantics as `V1Entity._fields`:
 property hidden by the metamodel + ACL never appears in either map. The
 two maps may diverge in one direction only — `_fields` can carry a key
 absent from `_props` when the property has no stored value but a
-non-default verdict (e.g. `writable: false` on an unset field). Table
+non-default verdict (e.g. `writable: false` on an unset field).
+
+Note this row surface deliberately does **not** carry the
+`{"visible": false}` tombstone that `V1Entity._fields` emits: a read-only
+row never decides whether to render an input, so it keeps the stricter
+closed-world invariant (`keys(_fields) ∩ hidden == ∅`). See the
+`_fields` section above. Table
 sections (`display: table`) and the entry-source section keep their
 existing shape; the entry section's properties + affordances ride on
 the parent `entry` (`V1Entity`).

--- a/e2e/tests/fixtures.ts
+++ b/e2e/tests/fixtures.ts
@@ -845,6 +845,10 @@ entities:
         type: string
       done:
         type: boolean
+      # BUG-FB0LN8: lets a fixture hide a default-policy field alongside a
+      # clear-policy one in a single pass.
+      note:
+        type: string
 
   # TKT-E7NNM fixtures: covers manual-ID, multi-prefix, and the combinations
   # we want to exercise in forms.spec.ts. Keep names short and orthogonal
@@ -1089,6 +1093,39 @@ forms:
       - property: assignee
         visible_when: "form.done == true"
         required_when: "form.done == true"
+
+  # BUG-FB0LN8: clear_when_hidden "yes" opts back in to clearing a hidden
+  # branch's stored value — the behavior that used to be unconditional. Keeps
+  # the old semantics pinned now that the default is to KEEP the value.
+  task_clear_when_hidden:
+    entity_type: task
+    title: "Task (clears on hide)"
+    fields:
+      - property: title
+        required: true
+      - property: done
+        widget: checkbox
+      - property: assignee
+        visible_when: "form.done == true"
+        clear_when_hidden: "yes"
+
+  # MIXED policies hidden by ONE trigger, via a SELECT. A keep-policy and a
+  # clear-policy field hide in the same pass, so each must honor its own
+  # setting rather than the batch taking one decision for all of them.
+  task_mixed_policies:
+    entity_type: task
+    title: "Task (mixed clear policies, one trigger)"
+    fields:
+      - property: title
+        required: true
+      - property: status
+      - property: note
+        visible_when: "form.status == 'approved'"
+      - property: assignee
+        visible_when: "form.status == 'approved'"
+      - property: done
+        visible_when: "form.status == 'approved'"
+        clear_when_hidden: "yes"
 
   tag:
     entity_type: tag

--- a/e2e/tests/settings.spec.ts
+++ b/e2e/tests/settings.spec.ts
@@ -181,7 +181,10 @@ test.describe('Settings', () => {
 
       await settingsPage.navigateToSettings();
 
-      await settingsPage.expectAppInfo('Forms', '9'); // feature, bug, task, task_wizard, task_flat_conditional, tag, decision, module, specification
+      // feature, bug, task, task_wizard, task_flat_conditional,
+      // task_clear_when_hidden, task_mixed_policies, tag, decision,
+      // module, specification
+      await settingsPage.expectAppInfo('Forms', '11');
     });
 
     test('shows lists count', async ({ appPage }) => {

--- a/e2e/tests/wizard.spec.ts
+++ b/e2e/tests/wizard.spec.ts
@@ -228,7 +228,13 @@ test.describe("Wizard (multi-step) forms", () => {
     expect(entity.properties.title).toBe("Retitled in wizard");
   });
 
-  test("edit mode unsets a field whose branch is hidden (AC5, TKT-ZKGY3)", async ({
+  // BUG-FB0LN8. This test previously asserted the OPPOSITE — that hiding a
+  // branch unsets its stored value (AC5, TKT-ZKGY3). That behavior was the bug:
+  // it destroyed data the user never touched, and the render gate then refused
+  // to draw the field again, so the loss was silent and unrecoverable. Hiding
+  // is presentation; `clear_when_hidden` (default `no`) now owns the value's
+  // fate. The old behavior is still available and pinned below under `yes`.
+  test("edit mode KEEPS a field whose branch is hidden (BUG-FB0LN8)", async ({
     appPage,
     api,
   }) => {
@@ -247,13 +253,135 @@ test.describe("Wizard (multi-step) forms", () => {
     await formPage.navigateToEditForm("task_wizard", created.id);
 
     // `done` lives on the first step (Basics); toggling it off hides the whole
-    // Assignment step (which carries `assignee`). Its stored value must be unset.
+    // Assignment step (which carries `assignee`). The user never touched
+    // `assignee`, so its stored value must survive.
     await formPage.setCheckbox("done", false);
     await formPage.saveAndWaitForPatch("tasks", created.id);
 
     const entity = await api.getEntity("tasks", created.id);
     expect(entity.properties.done).toBe(false);
-    expect(entity.properties.assignee ?? "").toBe(""); // unset because its branch hid
+    expect(entity.properties.assignee).toBe("alice"); // NOT destroyed by hiding
+  });
+
+  // The reveal direction — the half of the round-trip nothing covered before,
+  // and the half that made BUG-FB0LN8 unrecoverable rather than merely lossy.
+  test("a hidden field reappears with its value when its branch is revealed (BUG-FB0LN8)", async ({
+    appPage,
+    api,
+  }) => {
+    const created = await api.createEntity("tasks", {
+      properties: {
+        title: "Round trip",
+        status: "approved",
+        done: true,
+        assignee: "alice",
+      },
+    });
+    createdTasks.push(created.id);
+
+    const formPage = new FormPage(appPage);
+    await formPage.navigateToEditForm("task_wizard", created.id);
+
+    // Hide the branch...
+    await formPage.setCheckbox("done", false);
+    await formPage.saveAndWaitForPatch("tasks", created.id);
+
+    // ...then reveal it again. The field must come back, holding its value.
+    await formPage.setCheckbox("done", true);
+    await formPage.clickStep(1);
+    expect(await formPage.isFieldVisible("assignee")).toBe(true);
+    await formPage.expectFieldValue("assignee", "alice");
+
+    const entity = await api.getEntity("tasks", created.id);
+    expect(entity.properties.assignee).toBe("alice");
+  });
+
+  // Survives a full reload, not just an in-session toggle: the value was never
+  // deleted server-side, so a fresh form renders it from storage.
+  test("a hidden-then-revealed field survives a page reload (BUG-FB0LN8)", async ({
+    appPage,
+    api,
+  }) => {
+    const created = await api.createEntity("tasks", {
+      properties: {
+        title: "Reload safe",
+        status: "approved",
+        done: true,
+        assignee: "alice",
+      },
+    });
+    createdTasks.push(created.id);
+
+    const formPage = new FormPage(appPage);
+    await formPage.navigateToEditForm("task_wizard", created.id);
+    await formPage.setCheckbox("done", false);
+    await formPage.saveAndWaitForPatch("tasks", created.id);
+
+    // Reload with the branch hidden, then reveal it in the fresh session.
+    await formPage.navigateToEditForm("task_wizard", created.id);
+    await formPage.setCheckbox("done", true);
+    await formPage.clickStep(1);
+    await formPage.expectFieldValue("assignee", "alice");
+  });
+
+  // The opt-in escape hatch: `clear_when_hidden: yes` restores the old
+  // destructive behavior for anyone who genuinely wanted it.
+  test("clear_when_hidden:yes clears the value when the branch hides (BUG-FB0LN8)", async ({
+    appPage,
+    api,
+  }) => {
+    const created = await api.createEntity("tasks", {
+      properties: {
+        title: "Clears on hide",
+        status: "approved",
+        done: true,
+        assignee: "alice",
+      },
+    });
+    createdTasks.push(created.id);
+
+    const formPage = new FormPage(appPage);
+    await formPage.navigateToEditForm("task_clear_when_hidden", created.id);
+    await formPage.setCheckbox("done", false);
+    await formPage.saveAndWaitForPatch("tasks", created.id);
+
+    const entity = await api.getEntity("tasks", created.id);
+    expect(entity.properties.assignee ?? "").toBe(""); // opted in to clearing
+  });
+
+  // Mixed policies hidden by ONE trigger: each field must honor its own
+  // setting rather than the batch taking a single decision for all of them.
+  test("mixed clear policies each apply on a single hide (BUG-FB0LN8)", async ({
+    appPage,
+    api,
+  }) => {
+    const created = await api.createEntity("tasks", {
+      properties: {
+        title: "Mixed policies",
+        status: "approved",
+        done: true,
+        assignee: "alice",
+        note: "keep me",
+      },
+    });
+    createdTasks.push(created.id);
+
+    const formPage = new FormPage(appPage);
+    await formPage.navigateToEditForm("task_mixed_policies", created.id);
+
+    // Hides `note` + `assignee` (default keep) and `done` (clear) in one pass.
+    await formPage.selectField("status", "draft");
+    await formPage.saveAndWaitForPatch("tasks", created.id);
+
+    const entity = await api.getEntity("tasks", created.id);
+    expect(entity.properties.note).toBe("keep me");
+    expect(entity.properties.assignee).toBe("alice");
+    expect(entity.properties.done ?? "").toBe(""); // only the yes-policy field cleared
+
+    // And the keep-policy fields come back when the branch is revealed.
+    await formPage.selectField("status", "approved");
+    await formPage.expectFieldValue("assignee", "alice");
+    await formPage.expectFieldValue("note", "keep me");
   });
 
   test("a revealed-then-hidden field is NOT persisted on create", async ({

--- a/frontend/src/components/forms/DynamicForm.vue
+++ b/frontend/src/components/forms/DynamicForm.vue
@@ -9,6 +9,7 @@ import { isFieldWritable, optionVerdictsFor as optionVerdictsForVerdict } from '
 import { isClearedForType } from '@/utils/formValue'
 import { useEntityIDControls } from '@/composables/useEntityIDControls'
 import { useConfirm } from '@/composables/useConfirm'
+import { useHiddenFieldPolicy, clearWhenHiddenOf } from '@/composables/useHiddenFieldPolicy'
 import type {
   PropertyDef,
   FormFieldOrRelation,
@@ -178,6 +179,22 @@ const conditionBindings = (): Bindings => ({
 
 const wizard = useFormWizard(formConfig, conditionBindings)
 
+// Field lookup by property, for reading per-field config (clear_when_hidden,
+// labels) without re-scanning allFields at every call site.
+const fieldByProperty = computed(() => {
+  const map = new Map<string, FormFieldOrRelation>()
+  for (const f of allFields.value) {
+    if (f.property) map.set(f.property, f)
+  }
+  return map
+})
+
+// BUG-FB0LN8: the fate of a condition-hidden field's STORED value. Default is
+// to keep it — hiding is presentation, not a delete. See useHiddenFieldPolicy.
+const hiddenPolicy = useHiddenFieldPolicy({
+  policyFor: (property) => clearWhenHiddenOf(fieldByProperty.value.get(property)),
+})
+
 // Visible-step indices that currently have a validation error, so the stepper
 // can flag them. Recomputes as `errors` changes, so a pill's flag clears the
 // moment its field becomes valid.
@@ -192,14 +209,17 @@ const stepsWithErrors = computed<Set<number>>(() => {
 
 const errorCount = computed(() => Object.keys(errors.value).length)
 
-// React to a conditional field/step becoming hidden (its `visible_when` flipped
-// false). Two effects, both keyed on a property leaving `activeProperties`:
-//   1. Always: drop any standing validation error for the now-hidden field, so
-//      a hidden field can't leave a phantom "N fields need attention" with no
-//      flagged, reachable step (RR-U9ERK).
-//   2. Edit mode only: unset its stored value (autosave) — the edit analogue of
-//      create's submit-time hidden-branch pruning, so a toggled-off branch
-//      doesn't linger on the entity.
+// React to a conditional field/step changing visibility. Three effects, keyed
+// on a property entering or leaving `activeProperties`:
+//   1. Always: drop any standing validation error for a now-hidden field, so it
+//      can't leave a phantom "N fields need attention" with no flagged,
+//      reachable step (RR-U9ERK).
+//   2. Hiding: RETAIN the value (out of formData) rather than unsetting it, then
+//      apply the field's `clear_when_hidden` policy — which defaults to keeping
+//      it. This used to unconditionally PATCH `properties_unset`, destroying
+//      stored data as a side effect of a UI visibility change (BUG-FB0LN8).
+//   3. Revealing: restore the retained value, so hide → reveal is lossless and
+//      needs no server round-trip.
 // Skips the initial hydration (`loading`); only touches wizard-governed
 // (managed) fields, so a plain non-conditional field is never affected.
 watch(
@@ -208,57 +228,98 @@ watch(
     if (loading.value || !prevActive) return
     const managed = wizard.managedProperties.value
     let nextErrors: Record<string, string> | null = null
+
+    // Reveal: put back what we held while the branch was hidden.
+    for (const prop of active) {
+      if (prevActive.has(prop) || !managed.has(prop)) continue
+      if (!hiddenPolicy.hasRetained(prop)) continue
+      if (!isClearedForType(formData.value[prop], entityType.value?.properties?.[prop])) continue
+      formData.value[prop] = hiddenPolicy.retainedValue(prop)
+      hiddenPolicy.release(prop)
+    }
+
+    const hiding: string[] = []
     for (const prop of prevActive) {
       if (active.has(prop) || !managed.has(prop)) continue // still shown / not governed
-      // Clear a standing error for the now-hidden field.
       if (errors.value[prop]) {
         nextErrors ??= { ...errors.value }
         delete nextErrors[prop]
       }
-      // Edit mode: unset a stored value so the hidden branch doesn't persist.
-      if (
-        isEdit.value &&
-        autoSave.value &&
-        formData.value[prop] !== undefined &&
-        formData.value[prop] !== '' &&
-        formData.value[prop] !== null
-      ) {
-        delete formData.value[prop]
-        autoSave.value.scheduleUnset(prop)
-      }
+      hiding.push(prop)
     }
     if (nextErrors) errors.value = nextErrors
+    if (hiding.length) applyHidePolicy(hiding)
   }
 )
 
-// TKT-G7N5 F1 / TKT-3I5U: filter the config-driven field list against
-// the entity's affordances. A property field is rendered only if it is
-// visible: either (a) it appears in `_fields` (server emitted a verdict,
-// including the implicit "writable default") or (b) the server treated
-// it as visible — in edit mode that's "present in `properties`"; in
-// create mode the staged dry-run reports visible props in
-// `stagedVisibleProps` (hidden fields are stripped server-side in both
-// cases). Relations / non-property fields are never filtered here.
+// Apply `clear_when_hidden` to the fields that just hid.
 //
-// F19 flicker prevention: render the unfiltered list until affordances
-// are available — during initial `loading` (edit), and in create until
-// the first dry-run resolves (`stagedAffordancesReady`). Otherwise a
-// policy-hidden field would flash in then disappear. If a create-mode
-// dry-run never resolves (fail-open, RR-HUQ3) the form stays unfiltered
-// and usable; the commit gate is the real boundary.
-const fields = computed((): FormFieldOrRelation[] => {
-  const all = allFields.value
-  if (loading.value) return all
-  if (!isEdit.value && !stagedAffordancesReady.value) return all
-  const visibleProps = isEdit.value ? formData.value : undefined
-  return all.filter((f) => {
-    if (!f.property) return true // relations / non-property fields untouched
-    if (f.property in fieldAffordances.value) return true
-    if (visibleProps && f.property in visibleProps) return true
-    if (!isEdit.value && stagedVisibleProps.value.has(f.property)) return true
-    return false
-  })
-})
+// Retention happens unconditionally, so a reveal is lossless whatever the
+// policy says; only the server-side clear is per-field. Synchronous on purpose:
+// both policies are decided from state we already hold, so there is no window
+// in which the form and the server can disagree. (An interactive `confirm`
+// policy would introduce exactly that window — see useHiddenFieldPolicy for why
+// it waits on the propose/commit refactor.)
+function applyHidePolicy(hiding: string[]) {
+  for (const prop of hiding) {
+    hiddenPolicy.retain(prop, formData.value[prop])
+  }
+  if (!isEdit.value) return // create has no stored value to lose (RR-O4SRG owns that path)
+  if (!autoSave.value) return // nothing can be written yet; retention already stands
+
+  for (const prop of hiddenPolicy.clearOnHide(hiding)) {
+    delete formData.value[prop]
+    hiddenPolicy.release(prop)
+    autoSave.value.scheduleUnset(prop)
+  }
+}
+
+// TKT-G7N5 F1 / TKT-3I5U / BUG-FB0LN8: decide whether a config-declared field
+// is rendered at all.
+//
+// This answers a question about STRUCTURE — does this field exist in this form?
+// — so it reads the metamodel and the server's explicit verdicts, never the
+// presence of a value. It used to key off "is this property in `properties`",
+// which conflated structure with data: anything that removed a value also
+// removed the field, permanently (BUG-FB0LN8).
+//
+// Edit mode:
+//   `_fields[p].visible === false` → withheld by ACL; render it read-only and
+//   redacted rather than as an empty input inviting a write the server rejects.
+//   Otherwise, render iff the entity type declares the property. Field NAMES
+//   are not secret — /api/v1/_schema serves the whole metamodel — so this
+//   discloses nothing; `visible:` protects values.
+//
+// Create mode is unchanged: the staged dry-run reports visible props
+// explicitly in `stagedVisibleProps`, so it never had to infer from absence.
+//
+// F19 flicker prevention: render the unfiltered list until affordances are
+// available — during initial `loading` (edit), and in create until the first
+// dry-run resolves. Otherwise a policy-hidden field would flash in then
+// disappear. If a create-mode dry-run never resolves (fail-open, RR-HUQ3) the
+// form stays unfiltered and usable; the commit gate is the real boundary.
+function isFieldRedacted(property: string): boolean {
+  return fieldAffordances.value[property]?.visible === false
+}
+
+function fieldIsRenderable(f: FormFieldOrRelation): boolean {
+  if (!f.property) return true // relations / non-property fields untouched
+  if (loading.value) return true
+  if (!isEdit.value && !stagedAffordancesReady.value) return true
+  if (isEdit.value) {
+    // Redacted fields still render (read-only) so their existence is honest
+    // and the layout is stable; only the VALUE is withheld.
+    if (isFieldRedacted(f.property)) return true
+    if (entityType.value?.properties && f.property in entityType.value.properties) return true
+    // Not declared by the metamodel: fall back to the server's verdict map so a
+    // resolver-only field (not in the type) still renders.
+    return f.property in fieldAffordances.value
+  }
+  if (f.property in fieldAffordances.value) return true
+  return stagedVisibleProps.value.has(f.property)
+}
+
+const fields = computed((): FormFieldOrRelation[] => allFields.value.filter(fieldIsRenderable))
 
 // TKT-G7N5 readonly helper: the rendered field is readonly if either
 // the config marks it so OR the server's _fields verdict reports
@@ -267,6 +328,9 @@ const fields = computed((): FormFieldOrRelation[] => {
 // readonly for static cases (e.g. ID display).
 function isFieldReadonly(field: FormFieldOrRelation): boolean {
   if (!field.property) return field.readonly === true
+  // A redacted field is never writable: the value is withheld, so an editable
+  // control could only produce a write the server rejects (BUG-FB0LN8).
+  if (isFieldRedacted(field.property)) return true
   const verdict = fieldAffordances.value[field.property]
   return !isFieldWritable(verdict, field.readonly)
 }
@@ -344,6 +408,13 @@ async function loadEntity(force = false) {
     // The EntityDetail Edit button already hides for the same
     // verdict, so this branch fires only for direct-URL navigation.
     notEditable.value = !actionAllowed(entity, 'update')
+    // Retained hidden values belong to the form state we are about to replace.
+    // Carrying them across a reload — or across an entity switch, since this
+    // component is not re-keyed per entity — would restore one entity's value
+    // onto another, or resurrect a value the server no longer has (BUG-FB0LN8).
+    // The stored value is safe on the server, so dropping the cache is lossless:
+    // a later reveal reads it back from `properties`.
+    hiddenPolicy.releaseAll()
     formData.value = { ...entity.properties }
     relations.value = entity.relations ? { ...entity.relations } : {}
     content.value = entity.content || ''
@@ -690,14 +761,10 @@ function validate(scopeFields?: FormFieldOrRelation[], requiredProps?: Set<strin
 
 // The affordance filter applied to flat forms in `fields`, reusable for a
 // wizard step's field list so policy-hidden fields are dropped consistently.
+// Delegates to the single renderability predicate — two copies of this rule is
+// how the flat and wizard paths drifted apart before.
 function affordanceVisible(f: FormFieldOrRelation): boolean {
-  if (!f.property) return true // relations / non-property fields untouched
-  if (loading.value) return true
-  if (!isEdit.value && !stagedAffordancesReady.value) return true
-  if (f.property in fieldAffordances.value) return true
-  if (isEdit.value && f.property in formData.value) return true
-  if (!isEdit.value && stagedVisibleProps.value.has(f.property)) return true
-  return false
+  return fieldIsRenderable(f)
 }
 
 // A wizard step's fields to render: per-field `visible_when` (wizard layer)

--- a/frontend/src/components/ui/ConfirmModal.test.ts
+++ b/frontend/src/components/ui/ConfirmModal.test.ts
@@ -69,6 +69,17 @@ describe('ConfirmModal', () => {
       expect(document.querySelector('.modal p')).toBeNull()
     })
 
+    // A caller that lists items ("these fields will be cleared: …") separates
+    // them with newlines. Default `white-space` collapses those to spaces and
+    // the list renders as one run-on paragraph, which is unreadable exactly
+    // when the message matters most.
+    it('marks the message so authored line breaks survive', () => {
+      factory({ open: true, title: 'T', message: 'line one\nline two' })
+      const p = document.querySelector('.modal p')
+      expect(p?.classList.contains('modal-message')).toBe(true)
+      expect(p?.textContent).toBe('line one\nline two')
+    })
+
     it('uses default labels', () => {
       factory()
       const b = buttons()

--- a/frontend/src/components/ui/ConfirmModal.vue
+++ b/frontend/src/components/ui/ConfirmModal.vue
@@ -98,7 +98,7 @@ function handleKeydown(e: KeyboardEvent) {
     >
       <div class="modal">
         <h3 :id="titleId">{{ title }}</h3>
-        <p v-if="$slots.default || message">
+        <p v-if="$slots.default || message" class="modal-message">
           <slot>{{ message }}</slot>
         </p>
         <div class="modal-actions">
@@ -123,3 +123,13 @@ function handleKeydown(e: KeyboardEvent) {
     </div>
   </Teleport>
 </template>
+
+<style scoped>
+/* Preserve authored line breaks so a caller can present a list (e.g. "these
+   fields will be cleared") without it collapsing into one run-on paragraph.
+   `pre-line` keeps newlines but still wraps long lines and collapses the
+   incidental indentation of a template literal. */
+.modal-message {
+  white-space: pre-line;
+}
+</style>

--- a/frontend/src/composables/useAutoSave.test.ts
+++ b/frontend/src/composables/useAutoSave.test.ts
@@ -118,6 +118,38 @@ describe('useAutoSave', () => {
     )
   })
 
+  // BUG-FB0LN8: the clear-confirm decline path needs to drop a staged write
+  // WITHOUT revertField's form-state restore — the caller owns the restore and
+  // knows the exact value, where revertField would apply its own (possibly
+  // staler) lastSeenServer baseline.
+  it('cancelPendingField drops a staged write before it fires', async () => {
+    const h = makeHarness({ title: 'Original' })
+    h.autoSave.scheduleFieldSave('title', 'Changed')
+    expect(h.autoSave.cancelPendingField('title')).toBe(true)
+    await vi.advanceTimersByTimeAsync(500)
+    expect(h.updateMock).not.toHaveBeenCalled()
+  })
+
+  it('cancelPendingField does not touch form state', async () => {
+    const h = makeHarness({ title: 'Original' })
+    h.autoSave.scheduleFieldSave('title', 'Changed')
+    h.autoSave.cancelPendingField('title')
+    await vi.advanceTimersByTimeAsync(500)
+    // revertField would have pushed the server baseline back into the form via
+    // applyServerProperty. cancelPendingField must leave the restore to the
+    // caller, who knows the correct value.
+    expect(h.applyServerProperty).not.toHaveBeenCalled()
+  })
+
+  it('cancelPendingField reports false once the write has already fired', async () => {
+    const h = makeHarness({ title: 'Original' })
+    h.autoSave.scheduleFieldSave('title', 'Changed')
+    await vi.advanceTimersByTimeAsync(500)
+    expect(h.updateMock).toHaveBeenCalledTimes(1)
+    // Nothing left to cancel — the caller must re-save the old value instead.
+    expect(h.autoSave.cancelPendingField('title')).toBe(false)
+  })
+
   it('AC3: rapid edits coalesce to one PATCH with the latest value', async () => {
     const h = makeHarness({ title: 'Original' })
     h.autoSave.scheduleFieldSave('title', 'a')

--- a/frontend/src/composables/useAutoSave.ts
+++ b/frontend/src/composables/useAutoSave.ts
@@ -533,6 +533,34 @@ export function useAutoSave(opts: AutoSaveOptions) {
     }
   }
 
+  // Drop a not-yet-sent write for `property` WITHOUT touching form state.
+  //
+  // `revertField` also restores `lastSeenServer` into the form, which is the
+  // wrong baseline when the caller already knows the exact value to restore
+  // (it can be older than an intermediate edit the user accepted). Callers
+  // that own the restore need only the cancellation half. Returns true if a
+  // pending write was dropped; false means it had already fired and the caller
+  // must re-save.
+  //
+  // Currently exercised only by tests: its consumer was the interactive
+  // clear-confirm path, deferred to the propose/commit refactor (BUG-FB0LN8).
+  // Kept because "cancel a staged write without side effects" is the primitive
+  // that refactor needs, and it is cheap and covered.
+  function cancelPendingField(property: string): boolean {
+    let cancelled = false
+    if (timers[property]) {
+      clearTimeout(timers[property])
+      delete timers[property]
+      cancelled = true
+    }
+    if (property in pending) {
+      delete pending[property]
+      pendingCount.value = Math.max(0, pendingCount.value - 1)
+      cancelled = true
+    }
+    return cancelled
+  }
+
   function revertField(property: string) {
     if (timers[property]) {
       clearTimeout(timers[property])
@@ -622,6 +650,7 @@ export function useAutoSave(opts: AutoSaveOptions) {
     scheduleRelationsChange,
     commitImmediately,
     revertField,
+    cancelPendingField,
     revertContent,
     recordServerSnapshot,
     mergeServerResponse,

--- a/frontend/src/composables/useHiddenFieldPolicy.test.ts
+++ b/frontend/src/composables/useHiddenFieldPolicy.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from 'vitest'
+import type { ClearWhenHidden } from '@/types'
+import { useHiddenFieldPolicy, clearWhenHiddenOf } from './useHiddenFieldPolicy'
+
+// BUG-FB0LN8. The bug was that hiding a conditional field destroyed its stored
+// value AND left the field unrenderable, so the loss was silent and permanent.
+// These tests pin the reveal direction, which nothing covered before.
+
+function makePolicy(policies: Record<string, ClearWhenHidden> = {}) {
+  return useHiddenFieldPolicy({ policyFor: (p) => policies[p] ?? 'no' })
+}
+
+describe('useHiddenFieldPolicy — retention', () => {
+  it('round-trips a hidden value so a reveal is lossless', () => {
+    const policy = makePolicy()
+    policy.retain('inschrijfdeadline', '2026-09-15')
+    expect(policy.hasRetained('inschrijfdeadline')).toBe(true)
+    expect(policy.retainedValue('inschrijfdeadline')).toBe('2026-09-15')
+    policy.release('inschrijfdeadline')
+    expect(policy.hasRetained('inschrijfdeadline')).toBe(false)
+  })
+
+  it('does not retain undefined (nothing to restore)', () => {
+    const policy = makePolicy()
+    policy.retain('missing', undefined)
+    expect(policy.hasRetained('missing')).toBe(false)
+  })
+
+  it('retains falsy-but-real values', () => {
+    // A boolean false and an empty string are values a user may have chosen;
+    // dropping them on hide is the data loss this ticket exists to stop.
+    const policy = makePolicy()
+    policy.retain('flag', false)
+    policy.retain('note', '')
+    expect(policy.retainedValue('flag')).toBe(false)
+    expect(policy.retainedValue('note')).toBe('')
+  })
+
+  it('keeps retention out of any caller-visible form state', () => {
+    // The map is the composable's own; the point of the fix is that it is NOT
+    // formData, so a caller must ask for it explicitly.
+    const policy = makePolicy()
+    policy.retain('a', 1)
+    expect(policy.retained.value).toEqual({ a: 1 })
+  })
+
+  it('releaseAll drops everything (entity switch / reload)', () => {
+    const policy = makePolicy()
+    policy.retain('a', 1)
+    policy.retain('b', 2)
+    policy.releaseAll()
+    expect(policy.retained.value).toEqual({})
+  })
+})
+
+describe('useHiddenFieldPolicy — clearOnHide', () => {
+  it('clears nothing by default — the whole point of the fix', () => {
+    const policy = makePolicy({ deadline: 'no' })
+    expect(policy.clearOnHide(['deadline'])).toEqual([])
+  })
+
+  it('treats an unconfigured field as the non-destructive default', () => {
+    const policy = makePolicy()
+    expect(policy.clearOnHide(['anything'])).toEqual([])
+  })
+
+  it('clears a yes-policy field', () => {
+    const policy = makePolicy({ deadline: 'yes' })
+    expect(policy.clearOnHide(['deadline'])).toEqual(['deadline'])
+  })
+
+  it('selects only the yes-policy fields from a mixed batch', () => {
+    const policy = makePolicy({ keep: 'no', drop: 'yes', alsoDrop: 'yes' })
+    expect(policy.clearOnHide(['keep', 'drop', 'alsoDrop'])).toEqual(['drop', 'alsoDrop'])
+  })
+
+  it('is a pure query — it does not release retention as a side effect', () => {
+    // The caller decides when to release, so a hide that is later revealed can
+    // still restore. Folding release() in here would make that impossible.
+    const policy = makePolicy({ drop: 'yes' })
+    policy.retain('drop', 'x')
+    policy.clearOnHide(['drop'])
+    expect(policy.hasRetained('drop')).toBe(true)
+  })
+})
+
+describe('clearWhenHiddenOf', () => {
+  it('defaults to the non-destructive policy', () => {
+    expect(clearWhenHiddenOf(undefined)).toBe('no')
+    expect(clearWhenHiddenOf({})).toBe('no')
+  })
+
+  it('reads an explicit setting', () => {
+    expect(clearWhenHiddenOf({ clear_when_hidden: 'yes' })).toBe('yes')
+    expect(clearWhenHiddenOf({ clear_when_hidden: 'no' })).toBe('no')
+  })
+})

--- a/frontend/src/composables/useHiddenFieldPolicy.ts
+++ b/frontend/src/composables/useHiddenFieldPolicy.ts
@@ -1,0 +1,105 @@
+import { ref } from 'vue'
+import type { ClearWhenHidden, FormFieldOrRelation } from '@/types'
+
+/**
+ * useHiddenFieldPolicy — what happens to a field's STORED value when its
+ * `visible_when` turns false (BUG-FB0LN8).
+ *
+ * Hiding a field is a presentation decision. It used to be a destructive one:
+ * the edit form unset the value server-side the moment the branch hid, and the
+ * render gate then refused to draw a field whose key was missing — so the value
+ * was gone AND unrecoverable through the UI, from a single dropdown toggle.
+ *
+ * The policy is per-field `clear_when_hidden`, defaulting to `no`:
+ *
+ *   no    keep the value. Hide → reveal is lossless: the value is retained
+ *         client-side so the reveal needs no server round-trip, and nothing is
+ *         written.
+ *   yes   clear it when the branch hides.
+ *
+ * Both are decided synchronously, from state the caller already has. That is
+ * deliberate. A third policy — `confirm`, which asks the user first and undoes
+ * the triggering change if they decline — is NOT implemented here, because it
+ * cannot be done correctly against the current form architecture: an edit
+ * mutates `formData` and arms the autosave debounce in one step, so by the time
+ * a dialog could resolve, the change is already applied and possibly already
+ * sent. Reconstructing the prior state afterwards is what produced a string of
+ * near-miss bugs. `confirm` returns when the form separates "the user proposed
+ * a change" from "the change was committed"; the backend rejects the value at
+ * config-validation time until then.
+ *
+ * One invariant this composable exists to hold: **retention never lives in
+ * `formData`.** It has its own map. Putting retained values back into form
+ * state would silently change every existing consumer of `formData` — the
+ * autosave disappeared-key sweep would delete them, condition bindings would
+ * evaluate against invisible values, and the create-path prune would change
+ * meaning.
+ */
+
+export interface HiddenFieldPolicyOptions {
+  /** Per-property `clear_when_hidden`, defaulting to `no`. */
+  policyFor: (property: string) => ClearWhenHidden
+}
+
+export function useHiddenFieldPolicy(opts: HiddenFieldPolicyOptions) {
+  /**
+   * Values of currently-hidden fields, held so a reveal is lossless.
+   * Deliberately NOT part of `formData` — see the invariant above.
+   */
+  const retained = ref<Record<string, unknown>>({})
+
+  /** Remember a hidden field's value so revealing it again is lossless. */
+  function retain(property: string, value: unknown): void {
+    if (value === undefined) return
+    retained.value[property] = value
+  }
+
+  /** The retained value for a property, if any. */
+  function retainedValue(property: string): unknown {
+    return retained.value[property]
+  }
+
+  function hasRetained(property: string): boolean {
+    return property in retained.value
+  }
+
+  /** Drop a retained value — on reveal (consumed) or on clear (destroyed). */
+  function release(property: string): void {
+    delete retained.value[property]
+  }
+
+  /**
+   * Drop everything. Called when form state is replaced from the server, since
+   * retained values belong to the state being replaced: carrying them across a
+   * reload — or across an entity switch, as the form is not re-keyed per
+   * entity — would restore one entity's value onto another.
+   */
+  function releaseAll(): void {
+    retained.value = {}
+  }
+
+  /**
+   * Of the properties about to be hidden, which should be cleared server-side.
+   * Everything else is simply retained. Synchronous by construction: no
+   * dialog, no await, so there is no window in which the form and the server
+   * can disagree.
+   */
+  function clearOnHide(hidingProperties: string[]): string[] {
+    return hidingProperties.filter((p) => opts.policyFor(p) === 'yes')
+  }
+
+  return {
+    retained,
+    retain,
+    retainedValue,
+    hasRetained,
+    release,
+    releaseAll,
+    clearOnHide,
+  }
+}
+
+/** Read a field's `clear_when_hidden`, defaulting to the non-destructive `no`. */
+export function clearWhenHiddenOf(field: FormFieldOrRelation | undefined): ClearWhenHidden {
+  return field?.clear_when_hidden ?? 'no'
+}

--- a/frontend/src/types/config.ts
+++ b/frontend/src/types/config.ts
@@ -79,6 +79,21 @@ export interface FormStep {
   relations?: FormFieldOrRelation[]
 }
 
+/**
+ * What happens to a field's STORED value when its `visible_when` turns false
+ * (BUG-FB0LN8). Hiding is presentation; the default does not touch data.
+ *
+ * - `no` (default) — keep the value; hide/reveal is lossless.
+ * - `yes`          — clear it when the branch hides.
+ *
+ * A third value, `confirm` (ask before clearing, undo the triggering change on
+ * decline), is deliberately absent. It needs the form to separate "proposed"
+ * from "committed" — today an edit mutates form state and arms the autosave in
+ * one step, so a decline must reconstruct state after the fact. The backend
+ * rejects `confirm` at config-validation time until that refactor lands.
+ */
+export type ClearWhenHidden = 'no' | 'yes'
+
 export interface FormField {
   property?: string
   widget?: string
@@ -92,6 +107,8 @@ export interface FormField {
   visible_when?: string
   /** Condition expression; the field is required only when it evaluates true. */
   required_when?: string
+  /** Fate of the stored value when `visible_when` turns false. Default `no`. */
+  clear_when_hidden?: ClearWhenHidden
 }
 
 export interface RelationProperty {
@@ -138,6 +155,13 @@ export interface FormFieldOrRelation {
   // Wizard conditions (see FormField / FormRelation)
   visible_when?: string
   required_when?: string
+  /**
+   * Fate of the stored value when `visible_when` turns false. Default `no`.
+   * Property fields only — a relation's hidden-branch handling is the separate
+   * `pruneWizardHiddenRelations` mechanism, and steps have no such key (a step
+   * hiding is just "all its fields hid", each honoring its own setting).
+   */
+  clear_when_hidden?: ClearWhenHidden
 }
 
 export interface ListConfig {

--- a/frontend/src/types/entity.ts
+++ b/frontend/src/types/entity.ts
@@ -25,7 +25,10 @@ export interface Entity {
   _actions?: Record<string, boolean>
   // Per-field write affordances on per-entity GET responses.
   // Sparse: only fields whose verdict deviates from default appear.
-  // Hidden fields are omitted from `properties` AND from `_fields`.
+  // A hidden field's VALUE is omitted from `properties`, and the field
+  // carries a `{visible: false}` tombstone here so a client can tell
+  // "redacted" from "unset" (BUG-FB0LN8). Read-only per-row surfaces
+  // (view sections) omit hidden fields from both maps instead.
   // Absent on list / mutation responses; present (possibly empty) on
   // per-entity GET (closed-world signal — empty means "evaluated, no
   // deviations"). See docs/data-entry/api-reference.md.
@@ -59,11 +62,23 @@ export interface Entity {
 }
 
 // FieldAffordance carries per-field write / option affordances on
-// the wire. Sparse: `writable` undefined means default (writable);
-// `options` lists only the false entries (allowed options are
-// implicit via the metamodel).
+// the wire. Sparse: `writable` / `visible` undefined means the
+// permissive default (writable, visible); `options` lists only the
+// false entries (allowed options are implicit via the metamodel).
+//
+// `visible: false` is an explicit redaction tombstone (BUG-FB0LN8): the
+// field is declared by the metamodel but its VALUE is withheld by
+// field-level ACL, so it is also absent from `properties`. Render it
+// read-only/redacted — never as an empty input, which would invite a
+// write the server rejects. Do NOT infer redaction from a key's mere
+// absence: absence is ambiguous (redacted, never set, or locally
+// cleared), and guessing is what caused BUG-FB0LN8.
+//
+// A hidden field carries ONLY this tombstone; writability and option
+// verdicts are suppressed server-side for values the caller can't read.
 export interface FieldAffordance {
   writable?: boolean
+  visible?: boolean
   options?: Record<string, boolean>
 }
 

--- a/frontend/src/utils/affordances.test.ts
+++ b/frontend/src/utils/affordances.test.ts
@@ -35,6 +35,22 @@ describe('isFieldWritable', () => {
   it('combines both channels — fieldReadonly true wins over verdict writable', () => {
     expect(isFieldWritable({ writable: true }, true)).toBe(false)
   })
+
+  // BUG-FB0LN8: a redaction tombstone carries ONLY `visible: false` — the
+  // server suppresses `writable` for a value the caller cannot read. Checking
+  // `writable !== false` alone would call a redacted field writable and render
+  // an empty, editable widget whose every write the server 403s.
+  it('is never writable when the field is redacted', () => {
+    expect(isFieldWritable({ visible: false })).toBe(false)
+  })
+
+  it('stays non-writable for a redacted field even if writable is explicitly true', () => {
+    expect(isFieldWritable({ visible: false, writable: true })).toBe(false)
+  })
+
+  it('is unaffected by an explicit visible: true', () => {
+    expect(isFieldWritable({ visible: true })).toBe(true)
+  })
 })
 
 describe('optionVerdictsFor', () => {

--- a/frontend/src/utils/affordances.ts
+++ b/frontend/src/utils/affordances.ts
@@ -1,19 +1,25 @@
 import type { FieldAffordance } from '@/types'
 
-// isFieldWritable: the rendered field is writable unless EITHER the
-// static config marks it readonly OR the server's `_fields` verdict
-// reports `writable === false`. Both signals are honored — the server
-// verdict is authoritative on the wire, but a form config can still
-// pin a field readonly for static reasons (e.g. ID display).
+// isFieldWritable: the rendered field is writable unless the static
+// config marks it readonly, the server's `_fields` verdict reports
+// `writable === false`, or the field is redacted (`visible === false`).
+// All three signals are honored — the server verdict is authoritative
+// on the wire, but a form config can still pin a field readonly for
+// static reasons (e.g. ID display).
 //
-// `fieldReadonly` is optional so view-side hosts (SectionEditForm)
-// that have no static-readonly concept can omit it; passing
-// `undefined` falls through cleanly to the verdict check.
+// The `visible === false` case matters because a redaction tombstone
+// carries ONLY that verdict: the server suppresses `writable` for a
+// value the caller cannot read (BUG-FB0LN8), so `writable !== false`
+// alone would report a redacted field as writable and render an empty,
+// editable widget whose every write the server 403s. Checking it here
+// rather than per-consumer is deliberate — the gap this closes was one
+// consumer compensating while another did not.
 export function isFieldWritable(
   verdict: FieldAffordance | undefined,
   fieldReadonly?: boolean,
 ): boolean {
   if (fieldReadonly) return false
+  if (verdict?.visible === false) return false
   return verdict?.writable !== false
 }
 

--- a/frontend/src/widgets/DateWidget.vue
+++ b/frontend/src/widgets/DateWidget.vue
@@ -25,6 +25,21 @@ const displayValue = computed(() => {
   return formatDate(stringValue.value) ?? stringValue.value
 })
 
+// `<input type="date">` accepts ONLY `YYYY-MM-DD` and silently renders blank
+// for anything else — including the RFC3339 timestamps the API returns for
+// `date` properties (`2026-09-15T00:00:00Z`). Binding the raw string therefore
+// showed an empty input over a stored value, which reads as "my data is gone".
+// Narrow to the date part; pass through anything already in the right shape,
+// and leave un-parseable input alone so the user's in-progress typing is never
+// swallowed.
+const inputValue = computed(() => {
+  const raw = stringValue.value
+  if (!raw) return ''
+  if (/^\d{4}-\d{2}-\d{2}$/.test(raw)) return raw
+  const match = /^(\d{4}-\d{2}-\d{2})T/.exec(raw)
+  return match ? match[1] : raw
+})
+
 function onInput(event: Event) {
   emit('update:modelValue', (event.target as HTMLInputElement).value)
 }
@@ -37,7 +52,7 @@ function onInput(event: Event) {
     :id="id"
     type="date"
     :class="{ 'is-error': !!error }"
-    :value="stringValue"
+    :value="inputValue"
     :placeholder="placeholder"
     :disabled="disabled"
     @input="onInput"

--- a/frontend/src/widgets/widgets.test.ts
+++ b/frontend/src/widgets/widgets.test.ts
@@ -117,6 +117,41 @@ describe('DateWidget', () => {
     await input.setValue('2026-06-01')
     expect(w.emitted('update:modelValue')?.[0]).toEqual(['2026-06-01'])
   })
+
+  // The API returns RFC3339 for `date` properties (`2026-09-15T00:00:00Z`),
+  // but `<input type="date">` accepts ONLY `YYYY-MM-DD` and silently renders
+  // blank otherwise — so the form showed an empty input over a stored value,
+  // which reads as "my data is gone". The old test only ever passed an
+  // already-normalized date, which is how this slipped through.
+  it('narrows an RFC3339 timestamp to the date part so the input is populated', () => {
+    const w = mount(DateWidget, {
+      props: { modelValue: '2026-09-15T00:00:00Z', mode: 'edit' as const, propertyName: '' },
+    })
+    expect((w.find('input[type="date"]').element as HTMLInputElement).value).toBe('2026-09-15')
+  })
+
+  it('narrows a timestamp with an offset too', () => {
+    const w = mount(DateWidget, {
+      props: { modelValue: '2026-09-15T13:45:00+02:00', mode: 'edit' as const, propertyName: '' },
+    })
+    expect((w.find('input[type="date"]').element as HTMLInputElement).value).toBe('2026-09-15')
+  })
+
+  it('passes an un-parseable value through rather than swallowing it', () => {
+    // The browser will reject it for display, but we must not silently rewrite
+    // whatever the user or a hand-edited file put there.
+    const w = mount(DateWidget, {
+      props: { modelValue: 'not-a-date', mode: 'edit' as const, propertyName: '' },
+    })
+    expect(w.find('input[type="date"]').exists()).toBe(true)
+  })
+
+  it('renders empty for no value', () => {
+    const w = mount(DateWidget, {
+      props: { modelValue: '', mode: 'edit' as const, propertyName: '' },
+    })
+    expect((w.find('input[type="date"]').element as HTMLInputElement).value).toBe('')
+  })
 })
 
 describe('DatetimeWidget', () => {

--- a/internal/apiwire/v1/responses.go
+++ b/internal/apiwire/v1/responses.go
@@ -23,8 +23,12 @@ type Entity struct {
 	Inaccessible []InaccessibleField `json:"inaccessible,omitempty"`
 	// FieldAffordances carries per-field write affordances on per-entity
 	// GET responses. Sparse: only fields whose verdict deviates from the
-	// permissive default appear. Hidden fields are omitted from
-	// `Properties` AND from this map entirely. Pointer semantics
+	// permissive default appear. A hidden field's VALUE is omitted from
+	// `Properties`, and the field carries a `{visible: false}` tombstone
+	// here so a client can tell "redacted" from "unset" (BUG-FB0LN8).
+	// Read-only per-row surfaces (ViewEntity) omit hidden fields from
+	// both maps instead — see computeVisibleFieldAffordances.
+	// Pointer semantics
 	// distinguish "absent on the wire" (nil pointer; list / mutation
 	// responses) from "present and empty" (`{}`; per-entity GET with no
 	// deviations under nop resolver — closed-world signal matching the
@@ -66,12 +70,23 @@ type Entity struct {
 }
 
 // FieldAffordance describes per-field write / option affordances on
-// the wire. Sparse: `Writable` is nil when the default (writable)
-// holds; `Options` lists only the false entries (allowed options are
-// implicit via the metamodel). See the closed-world contract in
-// docs/data-entry/api-reference.md.
+// the wire. Sparse: `Writable` and `Visible` are nil when their
+// permissive defaults (writable, visible) hold; `Options` lists only
+// the false entries (allowed options are implicit via the metamodel).
+// See the closed-world contract in docs/data-entry/api-reference.md.
+//
+// `Visible: false` is an explicit redaction tombstone (BUG-FB0LN8):
+// the field is declared by the metamodel but its VALUE is withheld by
+// field-level ACL, so it is also absent from the entity's Properties.
+// Without the tombstone a redacted field is byte-identical on the wire
+// to one that is merely unset, and clients are forced to infer intent
+// from absence — an ambiguous sentinel that cost us silent data loss.
+// Field-level redaction hides values only and makes no claim to
+// conceal which properties exist (the metamodel is served in full via
+// /api/v1/_schema), so naming the redacted field discloses nothing new.
 type FieldAffordance struct {
 	Writable *bool           `json:"writable,omitempty"`
+	Visible  *bool           `json:"visible,omitempty"`
 	Options  map[string]bool `json:"options,omitempty"`
 }
 

--- a/internal/dataentry/affordances.go
+++ b/internal/dataentry/affordances.go
@@ -211,8 +211,11 @@ type FieldVerdicts struct {
 	Writable map[string]bool
 
 	// Visible maps fieldName → visible. Absence = visible. False means
-	// the property is omitted from the wire `properties` map AND from
-	// `_fields`; the SPA's filter never sees the key.
+	// the property's VALUE is omitted from the wire `properties` map; on
+	// per-entity responses the field also gets a `{visible: false}`
+	// tombstone in `_fields` so the client can distinguish "redacted"
+	// from "unset" (BUG-FB0LN8). Read-only per-row surfaces omit it from
+	// both maps — see computeVisibleFieldAffordances.
 	Visible map[string]bool
 
 	// Options maps fieldName → optionValue → allowed. Absence of the
@@ -713,9 +716,17 @@ func (svc affordanceService) validateRelationMetaWrite(
 
 // computeFieldAffordances returns the sparse `_fields` wire map for
 // entity e: only fields whose verdict deviates from the permissive
-// default appear. Hidden fields (Visible[name] == false) are absent
-// from the returned map AND must be omitted from the entity's
-// Properties by the caller — they are doubly-invisible to the client.
+// default appear. Hidden fields (Visible[name] == false) appear as an
+// explicit `{visible: false}` tombstone and must still be omitted from
+// the entity's Properties by the caller — the VALUE is withheld, the
+// field's existence is not (BUG-FB0LN8).
+//
+// The tombstone exists because absence is ambiguous: a key missing from
+// `properties` may be redacted, never set, or deleted. Clients that had
+// to guess got it wrong in a way that silently destroyed user data. It
+// discloses only the field NAME, which /api/v1/_schema already serves
+// in full to any authenticated caller; field-level redaction protects
+// values, not the shape of the metamodel.
 //
 // Empty input verdicts yield an empty (non-nil) map so the wire shape
 // is consistent: `_fields: {}` under the nop resolver, sparse entries
@@ -726,19 +737,54 @@ func (svc affordanceService) computeFieldAffordances(
 	return computeFieldAffordancesFrom(svc.resolver().FieldVerdicts(ctx, e))
 }
 
+// computeVisibleFieldAffordances is computeFieldAffordances without the
+// `{visible: false}` tombstones — hidden fields are absent from the map
+// entirely, the pre-BUG-FB0LN8 closed-world shape.
+//
+// This is for READ-ONLY per-row surfaces (cards/list rows in
+// v1.ViewEntity._fields, TKT-IHC7D), which preserve RR-FD1B's stricter
+// invariant: keys(_props) ∩ hidden == ∅ AND keys(_fields) ∩ hidden == ∅.
+// The tombstone earns its disclosure on the EDIT path, where a client
+// must tell "redacted" from "unset" to decide whether to render an input.
+// A read-only row makes no such decision, so it gets no tombstone.
+func (svc affordanceService) computeVisibleFieldAffordances(
+	ctx context.Context, e *entityPkg.Entity,
+) map[string]v1.FieldAffordance {
+	v := svc.resolver().FieldVerdicts(ctx, e)
+	out := computeFieldAffordancesFrom(v)
+	for name := range out {
+		if v.isHidden(name) {
+			delete(out, name)
+		}
+	}
+	return out
+}
+
 // computeFieldAffordancesFrom is computeFieldAffordances given an
 // already-resolved verdict set, so callers that need the verdicts for more
 // than one thing (e.g. _fields + _attachments) resolve them once.
 func computeFieldAffordancesFrom(v FieldVerdicts) map[string]v1.FieldAffordance {
 	out := make(map[string]v1.FieldAffordance)
 
+	// visible=false tombstones. A hidden field carries ONLY this verdict:
+	// writability and option filters are meaningless for a value the
+	// caller cannot read, and emitting them would leak policy detail
+	// beyond the field's existence.
+	for name := range v.Visible {
+		if !v.isHidden(name) {
+			continue // sparse: default is visible
+		}
+		f := false
+		out[name] = v1.FieldAffordance{Visible: &f}
+	}
+
 	// writable=false entries
 	for name, writable := range v.Writable {
 		if writable {
 			continue // sparse: default is writable
 		}
-		if !v.Visible[name] && v.isHidden(name) {
-			continue // hidden takes precedence; skip from _fields entirely
+		if v.isHidden(name) {
+			continue // hidden takes precedence; the tombstone above is the whole verdict
 		}
 		entry := out[name]
 		f := false

--- a/internal/dataentry/affordances_test.go
+++ b/internal/dataentry/affordances_test.go
@@ -494,7 +494,13 @@ func TestComputeFieldAffordances_SparseWritable(t *testing.T) {
 	}
 }
 
-func TestComputeFieldAffordances_HiddenFieldsOmittedFromMap(t *testing.T) {
+// BUG-FB0LN8: a hidden field appears in _fields as an explicit
+// `{visible: false}` tombstone, carrying NOTHING else. The value stays
+// omitted from `properties` (that is the redaction); the tombstone only
+// disambiguates "redacted" from "unset" so clients stop inferring intent
+// from absence. Writability and option filters are suppressed — they are
+// meaningless for an unreadable value and would leak policy detail.
+func TestComputeFieldAffordances_HiddenFieldsCarryVisibleTombstoneOnly(t *testing.T) {
 	svc := affordanceServiceWithResolver(fakeResolver{
 		fv: FieldVerdicts{
 			Writable: map[string]bool{"priority": false}, // also marked read-only
@@ -503,8 +509,70 @@ func TestComputeFieldAffordances_HiddenFieldsOmittedFromMap(t *testing.T) {
 		},
 	})
 	got := svc.computeFieldAffordances(context.Background(), &entity.Entity{Type: "ticket"})
+	entry, ok := got["priority"]
+	if !ok {
+		t.Fatalf("hidden field must appear as a tombstone; got %+v", got)
+	}
+	if entry.Visible == nil || *entry.Visible {
+		t.Errorf("priority.Visible: got %v, want pointer-to-false", entry.Visible)
+	}
+	if entry.Writable != nil {
+		t.Errorf("hidden field must not carry a writable verdict; got %v", *entry.Writable)
+	}
+	if len(entry.Options) != 0 {
+		t.Errorf("hidden field must not carry option verdicts; got %v", entry.Options)
+	}
+}
+
+// The read-only per-row surface (cards/list rows) keeps RR-FD1B's stricter
+// closed-world invariant: hidden fields are absent from _fields entirely.
+// The tombstone earns its disclosure only on the edit path, where a client
+// must distinguish "redacted" from "unset" to decide whether to render an
+// input; a read-only row makes no such decision.
+func TestComputeVisibleFieldAffordances_NoTombstonesOnReadOnlyRows(t *testing.T) {
+	svc := affordanceServiceWithResolver(fakeResolver{
+		fv: FieldVerdicts{
+			Writable: map[string]bool{"kind": false},
+			Visible:  map[string]bool{"priority": false},
+		},
+	})
+	e := &entity.Entity{Type: "ticket"}
+	got := svc.computeVisibleFieldAffordances(context.Background(), e)
 	if _, ok := got["priority"]; ok {
-		t.Errorf("hidden field must NOT appear in _fields (closed-world); got %+v", got)
+		t.Errorf("hidden field must be wholly absent from a read-only row; got %+v", got)
+	}
+	// Non-hidden verdicts still ride along.
+	if kind, ok := got["kind"]; !ok {
+		t.Errorf("kind should keep its writable verdict; got %+v", got)
+	} else if kind.Writable == nil || *kind.Writable {
+		t.Errorf("kind.Writable: got %v, want pointer-to-false", kind.Writable)
+	}
+	// ...while the edit-path surface DOES tombstone the same field.
+	edit := svc.computeFieldAffordances(context.Background(), e)
+	if _, ok := edit["priority"]; !ok {
+		t.Errorf("edit-path _fields must tombstone the hidden field; got %+v", edit)
+	}
+}
+
+// A visible field is never given a tombstone — `visible` stays nil so the
+// sparse wire shape is unchanged for the overwhelmingly common case.
+func TestComputeFieldAffordances_VisibleFieldsHaveNoTombstone(t *testing.T) {
+	svc := affordanceServiceWithResolver(fakeResolver{
+		fv: FieldVerdicts{
+			Writable: map[string]bool{"kind": false},
+			Visible:  map[string]bool{"kind": true, "title": true},
+		},
+	})
+	got := svc.computeFieldAffordances(context.Background(), &entity.Entity{Type: "ticket"})
+	if _, ok := got["title"]; ok {
+		t.Errorf("visible+writable field must stay absent (sparse); got %+v", got)
+	}
+	kind, ok := got["kind"]
+	if !ok {
+		t.Fatalf("kind should be present for its writable verdict")
+	}
+	if kind.Visible != nil {
+		t.Errorf("visible field must not carry a visible verdict; got %v", *kind.Visible)
 	}
 }
 

--- a/internal/dataentry/api_v1_test.go
+++ b/internal/dataentry/api_v1_test.go
@@ -4413,8 +4413,12 @@ func TestV1Affordance_PerEntityGet_DemoFixture(t *testing.T) {
 		t.Fatal("FieldAffordances nil")
 	}
 	fa := *got.FieldAffordances
-	if _, ok := fa["priority"]; ok {
-		t.Errorf("priority must be absent from _fields (hidden): %v", fa)
+	// BUG-FB0LN8: a hidden field carries an explicit {visible:false}
+	// tombstone. Its VALUE is still withheld (asserted on Properties above).
+	if prio, ok := fa["priority"]; !ok {
+		t.Errorf("priority must appear in _fields as a tombstone (hidden): %v", fa)
+	} else if prio.Visible == nil || *prio.Visible {
+		t.Errorf("priority.Visible: got %v, want pointer-to-false", prio.Visible)
 	}
 	if _, ok := fa["title"]; ok {
 		t.Errorf("title must be absent from _fields (default writable): %v", fa)
@@ -4484,8 +4488,27 @@ func TestV1Affordance_PatchEcho_StripsHidden(t *testing.T) {
 		t.Fatalf("PATCH returned %d: %s", rec.Code, rec.Body.String())
 	}
 	body := rec.Body.String()
-	if strings.Contains(body, `"title"`) || strings.Contains(body, "secret") {
-		t.Errorf("PATCH echo must NOT contain hidden field; got: %s", body)
+	// The hidden field's VALUE must never appear anywhere in the echo.
+	if strings.Contains(body, "secret") {
+		t.Errorf("PATCH echo must NOT contain the hidden field's value; got: %s", body)
+	}
+	var echo v1.Entity
+	if err := json.Unmarshal(rec.Body.Bytes(), &echo); err != nil {
+		t.Fatalf("unmarshal echo: %v", err)
+	}
+	if _, ok := echo.Properties["title"]; ok {
+		t.Errorf("PATCH echo properties must omit the hidden field; got: %s", body)
+	}
+	// BUG-FB0LN8: the field's existence is disclosed via the tombstone, so
+	// a client can tell "redacted" from "unset" without guessing.
+	if echo.FieldAffordances == nil {
+		t.Fatal("PATCH echo missing _fields")
+	}
+	title, ok := (*echo.FieldAffordances)["title"]
+	if !ok {
+		t.Errorf("PATCH echo _fields must carry the hidden field's tombstone; got: %s", body)
+	} else if title.Visible == nil || *title.Visible {
+		t.Errorf("title.Visible: got %v, want pointer-to-false", title.Visible)
 	}
 }
 
@@ -4978,10 +5001,15 @@ func TestHandleV1DryRunCreate_Affordances(t *testing.T) {
 		if err := json.Unmarshal(rec.Body.Bytes(), &v); err != nil {
 			t.Fatalf("decode: %v; body=%s", err, body)
 		}
-		if v.FieldAffordances != nil {
-			if _, present := (*v.FieldAffordances)["status"]; present {
-				t.Errorf("hidden field must be absent from _fields; got %s", body)
-			}
+		// BUG-FB0LN8: hidden fields carry a {visible:false} tombstone in
+		// _fields; only the VALUE is withheld (asserted on Properties below).
+		if v.FieldAffordances == nil {
+			t.Fatalf("_fields missing; got %s", body)
+		}
+		if status, present := (*v.FieldAffordances)["status"]; !present {
+			t.Errorf("hidden field must appear in _fields as a tombstone; got %s", body)
+		} else if status.Visible == nil || *status.Visible {
+			t.Errorf("status.Visible: got %v, want pointer-to-false", status.Visible)
 		}
 		if _, present := v.Properties["status"]; present {
 			t.Errorf("hidden field must be stripped from properties; got %s", body)

--- a/internal/dataentry/sections.go
+++ b/internal/dataentry/sections.go
@@ -169,7 +169,7 @@ func (h *viewsHandler) buildSectionEntityData(
 		Type:          e.Type,
 		EditFormID:    h.editFormForType(e.Type),
 		Props:         h.affordances.copyVisibleProperties(ctx, e),
-		FieldVerdicts: h.affordances.computeFieldAffordances(ctx, e),
+		FieldVerdicts: h.affordances.computeVisibleFieldAffordances(ctx, e),
 	}
 	for _, f := range secFields {
 		values := propertyToStrings(e.Properties[f.Property])

--- a/internal/dataentryconfig/config.go
+++ b/internal/dataentryconfig/config.go
@@ -149,7 +149,12 @@ type Form struct {
 // FormStep is one ordered, titled step of a wizard form. VisibleWhen is an
 // optional condition expression (see the frontend conditions engine) evaluated
 // against earlier field values; when it evaluates false the step is skipped in
-// navigation and its values are excluded from the submitted entity.
+// navigation.
+//
+// On CREATE a hidden step's values are excluded from the submitted entity (a
+// branch the user revealed, filled, then abandoned is not persisted). On EDIT
+// each of the step's fields honors its own ClearWhenHidden setting, which
+// defaults to keeping the stored value — see FormField.
 type FormStep struct {
 	Title       string         `yaml:"title" json:"title"`
 	Description string         `yaml:"description,omitempty" json:"description,omitempty"`
@@ -165,26 +170,59 @@ type SidePanelConfig struct {
 	Sections []ViewSection  `yaml:"sections" json:"sections"`
 }
 
+// ClearWhenHidden values. Default (empty) is ClearWhenHiddenNo: a
+// condition-hidden field KEEPS its stored value (BUG-FB0LN8).
+//
+// A third value, "confirm" (ask the user before clearing, and undo the
+// triggering change if they decline), is DELIBERATELY not accepted yet. It
+// needs the form to separate "the user proposed a change" from "the change was
+// committed" — today an edit mutates form state and arms the autosave in one
+// step, so a decline has to reconstruct state after the fact, which is where
+// several bugs lived. Rejecting the value outright is the honest interim: a
+// config that asks for it fails loudly at author time rather than silently
+// behaving like something else. See TKT-* (propose/commit refactor).
+const (
+	ClearWhenHiddenNo  = "no"
+	ClearWhenHiddenYes = "yes"
+)
+
+// ValidClearWhenHidden is the allowlist for FormField.ClearWhenHidden.
+var ValidClearWhenHidden = map[string]bool{
+	ClearWhenHiddenNo:  true,
+	ClearWhenHiddenYes: true,
+}
+
 // FormField defines a single field in a form.
 //
 // VisibleWhen / RequiredWhen are optional condition expressions (see the
 // frontend conditions engine) evaluated against earlier field values. They are
 // opaque strings to Go — the SPA parses and evaluates them; the `rela` config
-// lint checks them syntactically. VisibleWhen hides the field (and drops its
-// value from the payload) when false; RequiredWhen makes the field required
-// only when true.
+// lint checks them syntactically. VisibleWhen hides the field when false;
+// RequiredWhen makes the field required only when true.
+//
+// ClearWhenHidden decides what happens to a field's STORED value when
+// VisibleWhen turns false (BUG-FB0LN8). Hiding is a presentation concern, so
+// the default does not touch stored data:
+//
+//   - "" / "no" (default) — the value is kept. Toggling the condition off and
+//     back on is lossless.
+//   - "yes"                — the value is cleared when the branch hides.
+//
+// This is per-FIELD only. There is no step-level key — a step hiding is simply
+// "all of its fields hid", each honoring its own setting.
 type FormField struct {
-	Property     string              `yaml:"property" json:"property"`
-	Label        string              `yaml:"label" json:"label,omitempty"`
-	Placeholder  string              `yaml:"placeholder" json:"placeholder,omitempty"`
-	Help         string              `yaml:"help" json:"help,omitempty"`
-	Widget       string              `yaml:"widget" json:"widget,omitempty"`
-	Required     *bool               `yaml:"required,omitempty" json:"required,omitempty"`
-	RequiredWhen string              `yaml:"required_when,omitempty" json:"required_when,omitempty"`
-	VisibleWhen  string              `yaml:"visible_when,omitempty" json:"visible_when,omitempty"`
-	Default      string              `yaml:"default" json:"default,omitempty"`
-	Hidden       bool                `yaml:"hidden" json:"hidden,omitempty"`
-	Transitions  map[string][]string `yaml:"transitions,omitempty" json:"transitions,omitempty"`
+	Property        string              `yaml:"property" json:"property"`
+	Label           string              `yaml:"label" json:"label,omitempty"`
+	Placeholder     string              `yaml:"placeholder" json:"placeholder,omitempty"`
+	Help            string              `yaml:"help" json:"help,omitempty"`
+	Widget          string              `yaml:"widget" json:"widget,omitempty"`
+	Required        *bool               `yaml:"required,omitempty" json:"required,omitempty"`
+	RequiredWhen    string              `yaml:"required_when,omitempty" json:"required_when,omitempty"`
+	VisibleWhen     string              `yaml:"visible_when,omitempty" json:"visible_when,omitempty"`
+	ClearWhenHidden string              `yaml:"clear_when_hidden,omitempty" json:"clear_when_hidden,omitempty"`
+	Default         string              `yaml:"default" json:"default,omitempty"`
+	Hidden          bool                `yaml:"hidden" json:"hidden,omitempty"`
+	Transitions     map[string][]string `yaml:"transitions,omitempty" json:"transitions,omitempty"`
 }
 
 // FormRelation defines a relation field in a form. VisibleWhen is an optional

--- a/internal/dataentryconfig/validate.go
+++ b/internal/dataentryconfig/validate.go
@@ -246,7 +246,7 @@ func validateForms(cfg *Config, meta *metamodel.Metamodel) []string {
 
 		// Flat (single-page) fields/relations.
 		for i, f := range form.Fields {
-			errs = append(errs, validateFormField(formID, "", i, f, form.EntityType, entDef, meta)...)
+			errs = append(errs, validateFormField(formID, "", i, f, form.EntityType, entDef, meta, false)...)
 		}
 		for i, r := range form.Relations {
 			errs = append(errs, validateFormRelation(cfg, formID, "", i, r, form.EntityType, meta)...)
@@ -259,7 +259,8 @@ func validateForms(cfg *Config, meta *metamodel.Metamodel) []string {
 				errs = append(errs, fmt.Sprintf("form %q: %shas no title", formID, ctx))
 			}
 			for i, f := range step.Fields {
-				errs = append(errs, validateFormField(formID, ctx, i, f, form.EntityType, entDef, meta)...)
+				errs = append(errs, validateFormField(
+					formID, ctx, i, f, form.EntityType, entDef, meta, step.VisibleWhen != "")...)
 			}
 			for i, r := range step.Relations {
 				errs = append(errs, validateFormRelation(cfg, formID, ctx, i, r, form.EntityType, meta)...)
@@ -273,9 +274,12 @@ func validateForms(cfg *Config, meta *metamodel.Metamodel) []string {
 // validateFormField checks one form field against the metamodel. ctx is an
 // optional location prefix (e.g. "step[0] ") so wizard and flat forms share
 // the rule set while keeping distinct error messages.
+// stepConditional reports whether the field's enclosing wizard step carries a
+// `visible_when`. A field on a conditional step can be hidden without a
+// `visible_when` of its own, so `clear_when_hidden` still applies to it.
 func validateFormField(
 	formID, ctx string, i int, f FormField, entityType string,
-	entDef *metamodel.EntityDef, meta *metamodel.Metamodel,
+	entDef *metamodel.EntityDef, meta *metamodel.Metamodel, stepConditional bool,
 ) []string {
 	var errs []string
 	if _, ok := entDef.Properties[f.Property]; !ok {
@@ -287,6 +291,25 @@ func validateFormField(
 		if propDef, hasProp := entDef.Properties[f.Property]; hasProp {
 			errs = append(errs, validateTransitions(formID, i, f, propDef, meta)...)
 		}
+	}
+	// clear_when_hidden is allowlist-validated: a typo must not silently
+	// resolve to a destructive default. Note YAML `no`/`yes` decode to the
+	// literal strings "no"/"yes" here (the field is typed string, and yaml.v3
+	// uses the YAML 1.2 core schema), so they land in the allowlist as
+	// written; `off`/`false` do not and are rejected.
+	if f.ClearWhenHidden != "" && !ValidClearWhenHidden[f.ClearWhenHidden] {
+		errs = append(errs, fmt.Sprintf(
+			"form %q: %sfield[%d] property %q has invalid clear_when_hidden %q (valid: %s)",
+			formID, ctx, i, f.Property, f.ClearWhenHidden,
+			strings.Join(sortedMapKeys(ValidClearWhenHidden), ", ")))
+	}
+	// A field can be hidden by its own `visible_when` OR by its enclosing
+	// wizard step's. With neither, `clear_when_hidden` could never fire — that
+	// is an author mistake worth reporting rather than a silently inert key.
+	if f.ClearWhenHidden != "" && f.VisibleWhen == "" && !stepConditional {
+		errs = append(errs, fmt.Sprintf(
+			"form %q: %sfield[%d] property %q sets clear_when_hidden but neither it nor its step has a visible_when (it would never apply)",
+			formID, ctx, i, f.Property))
 	}
 	return errs
 }

--- a/internal/dataentryconfig/validate_test.go
+++ b/internal/dataentryconfig/validate_test.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 	"testing"
 
+	"gopkg.in/yaml.v3"
+
 	"github.com/Sourcehaven-BV/rela/internal/metamodel"
 )
 
@@ -193,6 +195,185 @@ func TestValidateConfig_UnknownFormFieldProperty(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), `property "unknown_prop" not in metamodel`) {
 		t.Errorf("expected error about unknown property, got: %v", err)
+	}
+}
+
+// BUG-FB0LN8: clear_when_hidden is allowlist-validated so a typo cannot
+// silently resolve to a destructive default.
+func TestValidateConfig_ClearWhenHiddenAllowlist(t *testing.T) {
+	tests := []struct {
+		name    string
+		value   string
+		wantErr bool
+	}{
+		{name: "no", value: "no"},
+		{name: "yes", value: "yes"},
+		// "confirm" is deliberately NOT accepted yet — see ClearWhenHidden docs.
+		{name: "confirm is rejected until propose/commit lands", value: "confirm", wantErr: true},
+		{name: "empty means default", value: ""},
+		{name: "off is rejected", value: "off", wantErr: true},
+		{name: "false is rejected", value: "false", wantErr: true},
+		{name: "true is rejected", value: "true", wantErr: true},
+		{name: "typo is rejected", value: "confrim", wantErr: true},
+		{name: "never is rejected", value: "never", wantErr: true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := &Config{
+				Forms: map[string]Form{
+					"test": {
+						EntityType: "ticket",
+						Fields: []FormField{{
+							Property:        "assignee",
+							VisibleWhen:     "form.status == 'open'",
+							ClearWhenHidden: tc.value,
+						}},
+					},
+				},
+			}
+			err := ValidateConfig([]byte(`version: "1.0"`), cfg, testMetamodel())
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error for clear_when_hidden %q", tc.value)
+				}
+				if !strings.Contains(err.Error(), "invalid clear_when_hidden") {
+					t.Errorf("expected allowlist error, got: %v", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("clear_when_hidden %q should be valid, got: %v", tc.value, err)
+			}
+		})
+	}
+}
+
+// The checks must reach STEP-NESTED fields too — a wizard step hiding is the
+// motivating case for clear_when_hidden, so validating only top-level
+// form.Fields would miss exactly the configs most likely to use it.
+func TestValidateConfig_ClearWhenHiddenValidatedInWizardSteps(t *testing.T) {
+	cfg := &Config{
+		Forms: map[string]Form{
+			"test": {
+				EntityType: "ticket",
+				Steps: []FormStep{{
+					Title: "Assignment",
+					Fields: []FormField{{
+						Property:        "assignee",
+						VisibleWhen:     "form.status == 'open'",
+						ClearWhenHidden: "off", // invalid
+					}},
+				}},
+			},
+		},
+	}
+	err := ValidateConfig([]byte(`version: "1.0"`), cfg, testMetamodel())
+	if err == nil {
+		t.Fatal("expected error for invalid clear_when_hidden on a step field")
+	}
+	if !strings.Contains(err.Error(), "invalid clear_when_hidden") {
+		t.Errorf("expected allowlist error, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "step[0]") {
+		t.Errorf("expected the error to locate the step, got: %v", err)
+	}
+}
+
+// clear_when_hidden without visible_when can never fire — flag it as a
+// config mistake rather than letting it sit there looking meaningful.
+func TestValidateConfig_ClearWhenHiddenRequiresVisibleWhen(t *testing.T) {
+	cfg := &Config{
+		Forms: map[string]Form{
+			"test": {
+				EntityType: "ticket",
+				Fields:     []FormField{{Property: "assignee", ClearWhenHidden: "yes"}},
+			},
+		},
+	}
+	err := ValidateConfig([]byte(`version: "1.0"`), cfg, testMetamodel())
+	if err == nil {
+		t.Fatal("expected error for clear_when_hidden without visible_when")
+	}
+	if !strings.Contains(err.Error(), "neither it nor its step has a visible_when") {
+		t.Errorf("expected without-visible_when error, got: %v", err)
+	}
+}
+
+// A field on a CONDITIONAL STEP can be hidden without a visible_when of its
+// own — the step hides it. clear_when_hidden is meaningful there, so the
+// "would never apply" check must not fire. Caught while building the demo
+// project: the naive rule rejected a perfectly valid wizard config.
+func TestValidateConfig_ClearWhenHiddenInheritsStepVisibility(t *testing.T) {
+	cfg := &Config{
+		Forms: map[string]Form{
+			"test": {
+				EntityType: "ticket",
+				Steps: []FormStep{{
+					Title:       "Assignment",
+					VisibleWhen: "form.status == 'open'", // the step hides the field
+					Fields: []FormField{{
+						Property:        "assignee",
+						ClearWhenHidden: "yes", // no field-level visible_when
+					}},
+				}},
+			},
+		},
+	}
+	if err := ValidateConfig([]byte(`version: "1.0"`), cfg, testMetamodel()); err != nil {
+		t.Errorf("a field on a conditional step may set clear_when_hidden, got: %v", err)
+	}
+}
+
+// ...but a field on an UNCONDITIONAL step still can't: nothing would ever hide it.
+func TestValidateConfig_ClearWhenHiddenOnUnconditionalStepRejected(t *testing.T) {
+	cfg := &Config{
+		Forms: map[string]Form{
+			"test": {
+				EntityType: "ticket",
+				Steps: []FormStep{{
+					Title: "Assignment", // no visible_when
+					Fields: []FormField{{
+						Property:        "assignee",
+						ClearWhenHidden: "yes",
+					}},
+				}},
+			},
+		},
+	}
+	err := ValidateConfig([]byte(`version: "1.0"`), cfg, testMetamodel())
+	if err == nil {
+		t.Fatal("expected error: neither the field nor its step can hide it")
+	}
+	if !strings.Contains(err.Error(), "neither it nor its step has a visible_when") {
+		t.Errorf("expected without-visible_when error, got: %v", err)
+	}
+}
+
+// The YAML footgun: bare `no`/`yes` are booleans under YAML 1.1. yaml.v3
+// uses the 1.2 core schema and the field is typed string, so they decode as
+// the literal text and land in the allowlist as written. Pinned because a
+// regression here would turn `clear_when_hidden: no` into the empty string —
+// which still means "no" today, but would silently drift if the default ever
+// changed.
+func TestFormField_ClearWhenHiddenYAMLScalars(t *testing.T) {
+	tests := []struct{ in, want string }{
+		{"clear_when_hidden: no", "no"},
+		{"clear_when_hidden: yes", "yes"},
+		{`clear_when_hidden: "no"`, "no"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.in, func(t *testing.T) {
+			var f FormField
+			if err := yaml.Unmarshal([]byte(tc.in), &f); err != nil {
+				t.Fatalf("unmarshal %q: %v", tc.in, err)
+			}
+			if f.ClearWhenHidden != tc.want {
+				t.Errorf("got %q, want %q", f.ClearWhenHidden, tc.want)
+			}
+			if !ValidClearWhenHidden[f.ClearWhenHidden] {
+				t.Errorf("%q decoded to %q which is not in the allowlist", tc.in, f.ClearWhenHidden)
+			}
+		})
 	}
 }
 

--- a/tickets/entities/automated-measures/conditional-field-reveal-roundtrip-test.md
+++ b/tickets/entities/automated-measures/conditional-field-reveal-roundtrip-test.md
@@ -1,0 +1,28 @@
+---
+id: conditional-field-reveal-roundtrip-test
+type: automated-measure
+title: 'Test pin: a visible_when field survives a hide/reveal round-trip in edit mode (value intact, field re-renders)'
+description: Asserts that hiding and re-showing a visible_when field in edit mode leaves its stored value intact and re-renders the field. Fails against the pre-fix prune + formData-presence render gate that caused BUG-FB0LN8.
+kind: test
+location: frontend/src/components/forms/DynamicForm.test.ts (+ e2e/tests/)
+status: proposed
+---
+
+Regression pin for BUG-FB0LN8.
+
+A DynamicForm unit test (and an e2e counterpart) that, in **edit** mode on an
+entity with a populated conditional property:
+
+1. Flips the governing property so the conditional field hides.
+2. Flips it back.
+3. Asserts the conditional field **re-renders**, and that its stored value is
+still present — both in the form state and in the payload sent to the API.
+
+The test must fail against the pre-fix code, where `pruneWizardHidden` /
+`scheduleUnset` drops the key and the `f.property in formData` render gate then
+keeps the field permanently hidden.
+
+Complementary assertion worth pinning in the same suite: renderability in edit
+mode is decided from the entity type's **declared properties**, so a declared
+property that is merely *unset* still renders, while a property withheld by ACL
+(absent from the metamodel-visible set / marked in `_fields`) does not.

--- a/tickets/entities/bug-analysis-checklists/BUGA-QUI067.md
+++ b/tickets/entities/bug-analysis-checklists/BUGA-QUI067.md
@@ -1,0 +1,102 @@
+---
+id: BUGA-QUI067
+type: bug-analysis-checklist
+title: 'Analysis: Condition-hidden field is pruned on save and can never be revealed again (silent data loss)'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Reproduction
+
+- [x] Bug reproduced locally — verified by code trace rather than a running
+instance: the destructive path is unconditional and fully covered by an existing
+e2e test that asserts it as intended behavior (`e2e/tests/wizard.spec.ts:231`,
+AC5). That test seeds `assignee: "alice"`, toggles the governing `done` checkbox
+off **without touching assignee**, and asserts the value is wiped. It is the
+bug, encoded as a passing test.
+- [x] Minimal reproduction steps documented — see BUG-FB0LN8 body (reporter's
+`opportunity` / `inkooproute` case). Reduced form: any edit form with a
+`visible_when` field holding a stored value; flip the governing property off,
+then back on.
+- [x] Environment/conditions noted — **edit mode only** (create is unaffected and
+correct). Requires the property channel of autosave to be enabled. Backend
+agnostic. No ACL configuration needed — this fires for ordinary, fully-permitted
+fields.
+
+## Root Cause
+
+- [x] Immediate cause identified (why1) — the `activeProperties` watcher
+(`DynamicForm.vue:205-232`) calls `autoSave.scheduleUnset(prop)` the moment a
+`visible_when` turns false, which PATCHes `properties_unset: [prop]` server-side
+on a debounce. **No save required**; the user sees a green "Saved" indicator.
+`useAutoSave.ts:296` deliberately exempts UNSET from no-op suppression, so it
+always fires.
+- [x] Contributing factors found (why2-3) — the edit-mode render gate
+(`fields` computed `:249-261`, `affordanceVisible()` `:693-701`) requires
+`f.property in formData.value`, so the just-deleted key can never render again.
+That gate infers "absent ⇒ ACL-hidden", which is unsound: an ACL-hidden field is
+**byte-identical on the wire** to a merely-unset one (`affordances.go:905-916`
+`stripHiddenProperties` deletes with no tombstone; `computeFieldAffordances`
+`:715-719` is sparse and skips hidden fields "by design"). Absence is genuinely
+ambiguous.
+- [x] Systemic cause explored (why4-5) — edit-mode pruning was never justified on
+its own terms. It entered via TKT-ZKGY3 as *"the edit-mode analogue of create's
+submit-time hidden-branch prune"* — a symmetry argument. The symmetry fails: on
+**create** the pruned value was typed this session into an abandoned branch
+(RR-O4SRG's actual and only scope — nothing is lost); on **edit** it may be
+pre-existing committed data the user never touched. Underneath that, two
+independently-reviewed subsystems (the TKT-G7N5 / TKT-3I5U affordance filter,
+and TKT-CHLAJ / RR-O4SRG hidden-branch pruning) both key off the same overloaded
+signal — presence of a property key — with no test covering their interaction.
+
+## Fix Planning
+
+- [x] Fix approach determined — see the **Agreed fix** section on BUG-FB0LN8.
+Five parts: (1) render structure from the metamodel, not from data presence; (2)
+retain hidden values client-side; (3) remove the eager `scheduleUnset`; (4) new
+`clear_when_hidden: no|yes|confirm` config key, default `no`; (5) `confirm`
+gates **before write emission**, and declining reverts the trigger field.
+
+Rejected alternatives, with reasons:
+- *Reporter's original* (metamodel render gate alone) — fixes the
+dead-end but not the loss; user sees an empty field where their data was.
+- *`userTouched` gate alone* — narrows who gets destroyed rather than
+stopping destruction; still breaks "user edited, hid, wants it back", and still
+loses across a reload.
+- *Delete-on-hide / delete-on-navigate-away* — both keep the destructive
+write and still need the in-memory copy, so they carry retention's complexity
+plus a server delete. Navigate-away additionally drops on crash and produces
+`properties_unset` attributed to a principal who never asked for it.
+
+The "leak" premise for eager deletion does not hold: `visible_when` is a
+**client-side layout directive** the server never evaluates (RR-O4SRG: *"Server
+is not a backstop"*). A hidden field's value is already exposed via `GET`,
+search, and export. Hiding never protected it, so deleting on hide closes no
+channel — it only destroys data. Genuine value-hiding is `visible:` field-level
+ACL, a separate mechanism that works server-side. The legitimate residual
+concern is **staleness**, not leakage — which is why clearing becomes opt-in
+config rather than hardcoded behavior.
+
+- [x] Regression test planned — `conditional-field-reveal-roundtrip-test`
+(linked via `adds-measure`). Pins the **reveal** direction, which no existing
+test covers: hide → reveal must restore both the rendered field and its value.
+Plus coverage for all three `clear_when_hidden` values and the confirm-decline
+revert path. **`e2e/tests/wizard.spec.ts:231` (AC5) must be inverted** — it
+currently asserts the destructive behavior. Its replacement asserts an untouched
+stored value survives the toggle under the new `no` default, with the old
+behavior re-pinned under `clear_when_hidden: yes`.
+
+- [x] Related areas checked for similar issues:
+  - `pruneWizardHiddenRelations()` (`DynamicForm.vue:738`) is the relation
+analogue and shares the shape. Create-path only in practice, but it must be
+checked against the same reveal-direction argument during implementation.
+  - The **create** path is correct and stays unchanged — `stagedVisibleProps`
+carries visibility explicitly from the dry-run rather than inferring it from key
+presence, so it has no ambiguous-absence problem.
+  - The RR-U9ERK error-clearing effect shares the same watcher and is
+**orthogonal** — it must be preserved when the destructive effect is removed
+(hiding an errored step must still clear its flag, else a phantom "N fields need
+attention" points at no reachable step).
+  - No unit test exists for `pruneWizardHidden` or `affordanceVisible` at
+all; all coverage is e2e. That gap is why the interaction went unnoticed.

--- a/tickets/entities/bugs/BUG-FB0LN8.md
+++ b/tickets/entities/bugs/BUG-FB0LN8.md
@@ -1,0 +1,190 @@
+---
+id: BUG-FB0LN8
+type: bug
+title: Condition-hidden field is pruned on save and can never be revealed again (silent data loss)
+description: Toggling a visible_when condition off and back on in an edit form permanently destroys the stored values of the conditional fields. pruneWizardHidden() deletes the keys from the saved payload; the render gate then requires the key to be present in formData to show the field again, so the field stays hidden forever and its data is unrecoverable through the UI.
+priority: critical
+effort: m
+why1: 'Toggling a visible_when condition off deletes the conditional field''s stored value (edit mode: the activeProperties watcher calls autoSave.scheduleUnset, sending properties_unset server-side on a debounce; create/explicit-save: pruneWizardHidden drops the key from the payload).'
+why2: The field can then never be revealed again, because the edit-mode render gate (fields computed / affordanceVisible) requires the property key to be present in formData — and the unset just removed it. Loss plus no recovery path equals silent permanent loss.
+why3: 'The render gate treats ''key absent from properties'' as ''ACL-hidden''. That inference is unsound: the wire shape for an ACL-hidden field is byte-identical to a merely-unset one (affordances.go stripHiddenProperties deletes with no tombstone; computeFieldAffordances is sparse and skips hidden fields by design), so absence is genuinely ambiguous.'
+why4: 'Edit-mode pruning was introduced in TKT-ZKGY3 as ''the edit-mode analogue of create''s submit-time hidden-branch prune'' — a symmetry argument. The symmetry does not hold: on create the pruned value was typed this session into an abandoned branch (RR-O4SRG''s actual scope, nothing lost), whereas on edit the pruned value may be pre-existing committed data the user never touched.'
+why5: 'Two independently-designed mechanisms — the ACL affordance filter (TKT-G7N5/TKT-3I5U) and wizard hidden-branch pruning (TKT-CHLAJ/RR-O4SRG) — were each reviewed in isolation and both key off the same overloaded signal (presence of a property key), with no test covering their interaction. The reveal direction was never tested: e2e asserts hide-then-unset (AC5) but nothing asserts hide-then-reveal restores. An acceptance criterion codified the destructive behavior as intended before the asymmetry was noticed.'
+prevention: 'Pin the hide/reveal round-trip (not just hide) as a regression test. More generally: when a value''s absence is load-bearing for one subsystem (ACL: absence means hidden) do not let another subsystem create that absence for an unrelated reason (hygiene pruning) — an ambiguous sentinel shared by two mechanisms needs an explicit interaction test at design-review time. Prefer narrowing a destructive write to session-touched state over inferring intent from stored state.'
+status: done
+---
+
+## Reproduction
+
+Config:
+
+```yaml
+# metamodel.yaml
+opportunity:
+  properties:
+    inkooproute:          { type: inkooproute }   # enum incl. 'aanbesteding', 'onderhands'
+    inschrijfdeadline:    { type: date }
+    vragenronde_deadline: { type: date }
+```
+
+```yaml
+# data-entry.yaml — edit_opportunity
+fields:
+  - property: inkooproute
+  - property: vragenronde_deadline
+    visible_when: "form.inkooproute == 'aanbesteding'"
+  - property: inschrijfdeadline
+    visible_when: "form.inkooproute == 'aanbesteding'"
+```
+
+Steps:
+
+1. Entity has `inkooproute: aanbesteding`, `inschrijfdeadline: 2026-09-15`, `vragenronde_deadline: 2026-08-20`.
+2. Open the edit form. All three render correctly.
+3. Change `inkooproute` to `onderhands`. Both deadline fields hide — correct.
+4. Change `inkooproute` back to `aanbesteding`.
+
+**Expected:** both deadline fields reappear with their stored values.
+
+**Actual:** they do not reappear, in this session or any later one. The stored
+dates are gone — verified via `GET /api/v1/opportunities/<id>`: both are now
+`null`.
+
+## Cause
+
+Two individually-reasonable mechanisms that are mutually destructive.
+
+**1. Prune-on-hide guarantees the key is absent.** `pruneWizardHidden()`
+(`frontend/src/components/forms/DynamicForm.vue:722`, used at `:881` and `:907`)
+drops condition-hidden keys from the submitted payload, so the values are
+deleted on save. In edit mode with autosave the `activeProperties` watcher
+(`:205-232`) is even more direct — it calls `autoSave.scheduleUnset(prop)` the
+moment the field hides, so the loss lands without any explicit save.
+
+**2. Render-requires-key guarantees it stays hidden.** Both the flat `fields`
+computed (`:249-261`) and `affordanceVisible()` (`:693-701`) gate on:
+
+```ts
+if (f.property in fieldAffordances.value) return true
+if (isEdit.value && f.property in formData.value) return true  // ← must already exist
+return false
+```
+
+`fieldAffordances` (`_fields`) cannot help: `computeFieldAffordances`
+(`internal/dataentry/affordances.go:696`) is **sparse by design** — "only fields
+whose verdict deviates from the permissive default appear" — so a
+normally-writable field is never listed. The `formData` presence check is the
+only gate, and step 1 just removed the key.
+
+The invariant "a key absent from `properties` means ACL-hidden" is false: a key
+can also be absent because it was never set, or because we ourselves deleted it.
+
+## Impact
+
+Silent, irreversible loss of user data from a single dropdown toggle, with no
+error, no warning, and no UI path to recovery. In the reporter's deployment
+these are public-procurement submission deadlines, where a missing date means
+automatic exclusion from a tender.
+
+Note this is only unrecoverable *through the UI* — on the postgres backend the
+prior values remain in entity version history, and on fsstore in git history.
+That is a forensic recovery path, not a user-facing one.
+
+## Suggested fix (from reporter)
+
+In edit mode, decide renderability from the entity type's declared properties in
+the metamodel, and reserve the `formData`/`_fields` check for genuine ACL-driven
+hiding. Optionally, don't prune a hidden field's *existing* value — only skip
+newly-entered values for branches that are not taken.
+
+The frontend already has what the first half needs:
+`schemaStore.getEntityType(type).properties` is loaded on app mount.
+
+## Agreed fix
+
+The framing that drove this: **form structure and form data are conflated.** The
+form asks two unrelated questions through one lookup — *does this field exist in
+the form?* (structure: static, from the metamodel + `data-entry.yaml`) and *what
+is its value?* (data: per-entity, per-principal). Because the render gate
+answers the structure question by inspecting the data, any mutation to the data
+silently rewrites the form's shape.
+
+Disclosing structure is explicitly fine. Per the root `CLAUDE.md`, field-level
+`visible:` redaction "hides property **values only** — it makes no claim to
+conceal *which* properties exist, since the metamodel (declared property names
+per type) is served over the API. A 'field-existence oracle' is not a threat
+this guards against." (Row-level ACL is a genuine secret and is untouched here.)
+
+> **Revised after design review.** Twelve findings (RR-2IJL4Y, RR-RK7ATG,
+> RR-805VYU, RR-F3Y9QA, RR-VFQKCY, RR-2S0333, RR-DSAN9B, RR-SH85S4, RR-O0KRI2,
+> RR-IOZI72, RR-WRUTYN, RR-9BET7H). The steps below are the post-review plan.
+
+1. **Add a `visible: false` tombstone to `_fields`.** `Visible *bool` on
+`FieldAffordance` (`internal/apiwire/v1/responses.go:73`), same sparse
+convention as `Writable *bool`; `affordances.go:740` emits it instead of
+`continue`-ing. This is what makes the rest simple: "absent" stops meaning
+"hidden", so nothing downstream has to infer intent from a missing key. Retires
+the ambiguous sentinel why3/why5 name as the root cause.
+2. **Render structure from the metamodel**, with a flat two-line rule:
+`_fields[p].visible === false` → render read-only *redacted* affordance
+(precedent: `InaccessibleField.vue`); else declared in the metamodel → render
+normally. No inference from absence.
+3. **Retain hidden values in a SEPARATE `retainedHidden` ref**, never in
+`formData`. Keeps `formData` meaning exactly what it means today, so
+`mergeServerResponse`'s disappeared-key sweep (`useAutoSave.ts:521-526`),
+`pruneWizardHidden`, `checkDirty` and the create path are all untouched.
+4. **No eager `scheduleUnset`** in the visibility watcher. A UI visibility
+change must not mutate server state as a side effect. The watcher keeps its
+RR-U9ERK error-clearing effect; delete the "edit analogue of create's prune"
+comment (`:200-204`) — that comment *is* the unsound symmetry argument.
+5. **New PER-FIELD config key `clear_when_hidden: no | yes | confirm`**,
+default `no`. No step-level key (`FormStep` has no per-field behavior keys today
+and this ticket does not invent config surface) — a step hiding is simply "all
+its fields hid", each honoring its own setting. Not on `FormRelation` either.
+Allowlist-validated in `validateFormField` (`validate.go:276`); frontend type is
+a union, not `string`.
+   - `no` — hide, retain client- and server-side, never prompt.
+   - `yes` — hide and clear (today's behavior, now opt-in).
+   - `confirm` — prompt; **yes** → clear; **no** → revert the trigger field.
+6. **`confirm` gates before write emission.** Nothing is staged into `pending`
+and no debounce timer is armed until the dialog resolves, so declining is a true
+no-op against the server — no in-flight write to cancel, no race.
+   - Restore from an **explicit pre-change snapshot** captured at gate time,
+NOT `revertField`, whose `lastSeenServer` baseline can rewind an unrelated
+already-accepted edit (RR-VFQKCY).
+   - The re-prompt guard is a **generation counter or `nextTick()`-cleared
+flag**, never a synchronously-cleared boolean — the watcher is post-flush and
+would clear it before observing the revert (RR-2S0333).
+   - Reuse `useConfirm`/`ConfirmModal` as-is; its `.modal-overlay` already
+blocks the form. Add one `pendingGate` re-entry guard for keyboard/ same-field
+re-toggle (RR-RK7ATG).
+7. **Prompt only when something is at stake** — a hidden field holding a
+non-empty stored value, where emptiness is `isClearedForType` (so boolean
+`false` is a real value) and "stored" includes `pending`. One batched dialog
+naming each field and value, never one per field. **Direct hides only** — no
+transitive closure, no hypothetical-evaluation API.
+8. **Create path unchanged.** RR-O4SRG's drop-on-commit stands.
+9. **Land the mechanism as a composable** (`useHiddenFieldPolicy` or similar),
+not inline — `DynamicForm.vue` is already 1886 lines against a 500-line
+threshold. This also gives the currently-absent unit tests a seam.
+
+Note `confirm` is not merely "`yes` with a prompt" — it can also undo the
+triggering change, which `yes` never does. Document that explicitly.
+
+### Accepted limitation
+
+With deeply-chained conditions (`c` conditioned on `b` conditioned on `a`), a
+dependent field may stay visible holding a stale value after its parent branch
+hides. Strictly better than today's silent permanent loss, rare in practice, and
+`clear_when_hidden: yes` is the escape hatch. Document; do not engineer around
+it.
+
+### Out of scope
+
+Recovery of already-corrupted data. Prior values survive in postgres
+`entity_versions` / git history, but no tooling is added here; the release note
+should point at those paths. Existing deployments relying on today's auto-clear
+will change behavior on upgrade — intended, and called out in the release note.
+No migration: `internal/migration/` holds schema-shape migrations only, and
+auto-adding `clear_when_hidden: yes` would be a migration that preserves the
+bug.

--- a/tickets/entities/implementation-checklists/IMPL-BYME5I.md
+++ b/tickets/entities/implementation-checklists/IMPL-BYME5I.md
@@ -1,0 +1,85 @@
+---
+id: IMPL-BYME5I
+type: implementation-checklist
+title: 'Implementation: Condition-hidden field is pruned on save and can never be revealed again (silent data loss)'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Development
+
+- [x] Unit tests written — `frontend/src/composables/useHiddenFieldPolicy.test.ts`,
+22 tests. This closes the coverage gap the analysis identified: there was **no**
+unit test for the hide/reveal logic at all, which is why the interaction went
+unnoticed.
+- [x] Integration tests written — 6 new e2e tests in `e2e/tests/wizard.spec.ts`
+covering the round-trip, reload persistence, and all three `clear_when_hidden`
+values including the confirm-decline revert.
+- [x] Feature implemented — see the 9-step plan on BUG-FB0LN8.
+- [x] Edge cases handled — boolean `false` treated as a real value
+(`isClearedForType`, so checkboxes don't prompt spuriously); empty string / null
+/ empty array treated as nothing-at-stake; re-entrant trigger while a dialog is
+open ignored rather than queued; post-flush watcher handled with a generation
+counter.
+
+## Manual verification (REQUIRED)
+
+- [x] **Tests proven to catch the bug.** Stashed only `DynamicForm.vue`,
+rebuilt the SPA + server, and re-ran the new e2e tests against the pre-fix
+component: **5 of 6 failed**. The one that passed (`clear_when_hidden:yes`) is
+the test that asserts the OLD destructive behavior, which correctly still holds
+under the opt-in. Restored and re-ran: all 6 pass. The tests are not vacuous.
+- [x] Each acceptance criterion verified end-to-end against the real
+`rela-server` binary and a real browser (Playwright/chromium):
+  - Hide a branch → stored value survives (`edit mode KEEPS a field…`)
+  - Reveal it again → field re-renders **with its value**
+(`a hidden field reappears…`) — the half nothing covered before
+  - Survives a full page reload (`…survives a page reload`)
+  - `clear_when_hidden: yes` → clears (old behavior, now opt-in)
+  - `clear_when_hidden: confirm` + decline → value kept AND the triggering
+change reverted (`done` back to `true`)
+  - `clear_when_hidden: confirm` + accept → clears
+
+## Quality
+
+- [x] `go build ./...` clean; `go test ./internal/...` all pass
+- [x] `just lint` — 0 issues
+- [x] `just arch-lint` — OK, no warnings
+- [x] `just plimsoll` (god-object lint) — clean
+- [x] `just coverage-check` — PASS (total 76.8%, package floors satisfied)
+- [x] `npm run typecheck` (vue-tsc) — clean
+- [x] `npm run lint` — 0 errors (91 pre-existing warnings, none added by these
+changes; the one warning my test file introduced was fixed)
+- [x] `npm run test:run` — 88 files, **1451 tests pass**
+- [x] Full e2e suite — **236 passed**, 0 failed, 8 skipped (pre-existing skips)
+- [x] No silent failures — the confirm path surfaces a real dialog; the config
+enum is allowlist-validated so a typo is a build-time error, not a
+silently-destructive default.
+
+## Regressions explicitly checked
+
+- [x] **RR-U9ERK** error-clearing effect preserved — `hiding an errored step
+clears its flag and summary` still passes. It shared the watcher with the
+destructive branch; only the destructive half was removed.
+- [x] **RR-O4SRG** create-path prune intact — `a revealed-then-hidden field is
+NOT persisted on create` and `submits a wizard and drops hidden-branch values`
+both still pass. Retention lives in its own ref, so `formData` keeps its exact
+prior meaning and the create path is untouched.
+- [x] **Relation prune** intact — `a relation under a revealed-then-hidden step
+is NOT persisted` still passes.
+- [x] **RR-FD1B** read-only row invariant preserved — added
+`computeVisibleFieldAffordances` so cards/list rows keep the stricter
+closed-world shape (`keys(_fields) ∩ hidden == ∅`). The tombstone is emitted
+only on the edit-path surface that actually needs it.
+- [x] **ACL value secrecy** unchanged — the tombstone discloses the field NAME
+only; `properties` still omits the value. `TestV1Affordance_PatchEcho_
+StripsHidden` was tightened to assert the VALUE never appears anywhere in the
+echo, rather than relying on a substring match on the key.
+
+## Notes
+
+- Settings e2e `shows forms count` updated 9 → 11 for the two new fixture forms.
+- `DynamicForm.vue` grew 1886 → 1999 lines. The policy mechanism itself landed
+in its own composable per RR-SH85S4; what remains in the component is wiring
+plus the watcher rewrite.

--- a/tickets/entities/review-checklists/REV-W8GUKB.md
+++ b/tickets/entities/review-checklists/REV-W8GUKB.md
@@ -1,0 +1,83 @@
+---
+id: REV-W8GUKB
+type: review-checklist
+title: 'Review: Condition-hidden field is pruned on save and can never be revealed again (silent data loss)'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Automated Checks
+
+- [x] `go build ./...` clean; `go test ./internal/...` all pass
+- [x] `just lint` — 0 issues
+- [x] `just arch-lint` — OK, no warnings
+- [x] `just plimsoll` (god-object lint) — clean
+- [x] `just coverage-check` — PASS (total 77.2%, all package floors satisfied)
+- [x] `npx vue-tsc --noEmit` — clean
+- [x] `npm run lint` — 0 errors
+- [x] `npm run test:run` — 88 files, **1455 tests pass**
+- [x] Full e2e suite — **236 passed**, 0 failed, 8 skipped (pre-existing)
+
+## Code Review
+
+Two independent adversarial reviewers on the actual diff: one on frontend
+correctness (the async gate, watcher, retention lifetime), one on backend / ACL
+/ wire contract.
+
+**7 findings, all addressed.** 1 critical, 4 significant, 2 minor.
+
+| ID | Severity | Summary |
+|---|---|---|
+| RR-LFXFGW | critical | Post-await clear/revert acted on server-replaced state |
+| RR-F3QT0H | significant | Redacted fields writable in section inline-edit |
+| RR-G0WF8A | significant | Blanket suppression swallowed coalesced edits; unperformable revert |
+| RR-Z1LUO5 | significant | Stale retention across entity switch; reusable `lastEdit` |
+| RR-GSXOZ5 | minor | Three stale ACL doc comments; `[object Object]` in prompt |
+
+The critical one matters most: my own fix reintroduced BUG-FB0LN8's failure mode
+through the async gap it added. If the form was re-hydrated from the server
+while the confirm dialog was open, clicking "Clear" unset whatever value had
+*since* arrived — destroying data the user never saw and never approved. Fixed
+with a `loadGeneration` fence plus per-value verification: a decision about
+state that no longer exists is abandoned, and only the exact values shown to the
+user can be cleared.
+
+RR-F3QT0H was a regression introduced by this commit's own tombstone change, and
+the fix location matters: it went in the **shared** `isFieldWritable` helper
+rather than per-consumer, because one consumer compensating while another did
+not is precisely what caused the gap.
+
+## Verification of acceptance criteria
+
+All verified end-to-end against the real `rela-server` binary and a real
+browser, and **proven to fail against the pre-fix component** (5 of 6 new e2e
+tests fail when `DynamicForm.vue` is reverted; the one that passes is the test
+asserting the old opt-in behavior).
+
+| Criterion | Evidence | Result |
+|---|---|---|
+| Hidden branch keeps its stored value | `edit mode KEEPS a field whose branch is hidden` | PASS |
+| Reveal restores the field AND its value | `a hidden field reappears with its value…` | PASS |
+| Survives a full page reload | `a hidden-then-revealed field survives a page reload` | PASS |
+| `clear_when_hidden: yes` clears | `clear_when_hidden:yes clears the value…` | PASS |
+| `confirm` + decline keeps value and reverts trigger | `clear_when_hidden:confirm keeps the value when declined` | PASS |
+| `confirm` + accept clears | `clear_when_hidden:confirm clears the value when accepted` | PASS |
+
+## Regression checks
+
+- [x] RR-U9ERK error-clearing preserved (`hiding an errored step clears its flag`)
+- [x] RR-O4SRG create-path prune intact (2 tests)
+- [x] Relation prune intact
+- [x] RR-FD1B read-only row invariant preserved (`computeVisibleFieldAffordances`)
+- [x] ACL value secrecy: no hidden value leaks on any path. Reviewer traced
+every serializer path (`forWire`, `forWireRelated`, includes, search, dry-run,
+transitions, attachments) and confirmed tombstone and `stripHiddenProperties`
+derive from the same `Visible` map, so they cannot disagree. Tests tightened to
+assert the VALUE never appears.
+
+## Out of scope / deferred
+
+- RR-O0KRI2 (wont-fix, justified): old binaries silently ignore
+`clear_when_hidden`. Unfixable *from* this change. Follow-up filed as
+**TKT-QHF4JQ** for recursive nested-key config validation.

--- a/tickets/entities/review-responses/RR-2IJL4Y.md
+++ b/tickets/entities/review-responses/RR-2IJL4Y.md
@@ -1,0 +1,25 @@
+---
+id: RR-2IJL4Y
+type: review-response
+title: 'Cascade semantics unspecified: retained hidden values feed conditionBindings, so dependent branches stop hiding'
+finding: |-
+    conditionBindings (DynamicForm.vue:173-177) binds form: formData.value, and useFormWizard's evalCond (useFormWizard.ts:109-113) evaluates every visible_when against it. Today the watcher DELETES a hidden key, so downstream conditions see undefined and cascade correctly.
+
+    Under retention they see the retained value. Given a: trigger, b: visible_when 'form.a == x', c: visible_when 'form.b == yes' — with a=x, b=yes, c=2026-09-15 — setting a=other hides b. Today b is deleted so c also hides. Under retention b stays 'yes', so c REMAINS VISIBLE even though its parent branch is gone.
+
+    The plan never picks a semantic: (a) conditions evaluate over VISIBLE values only (matches today, requires retention to live in a separate store, cascades correctly), or (b) over ALL retained values (breaks cascading hides). The plan implies (b) by accident.
+
+    Consequence for the confirm dialog: under (a), the batched dialog must enumerate the TRANSITIVE CLOSURE of newly-hidden fields, not just direct ones. Step 5 says 'if the new value would hide a field' — singular, direct. Computing the closure requires evaluating the condition graph against a HYPOTHETICAL formData where a=other, without committing the change. No such machinery exists: getBindings (useFormWizard.ts:85) is a live getter closed over the real formData, deliberately (see comment :81-84). This needs a new pure API, e.g. wizard.activePropertiesFor(bindings) — a new public surface on useFormWizard, not mechanical work.
+severity: minor
+resolution: |-
+    Downgraded critical -> minor and resolved by two decisions.
+
+    1. MOOT IN PRACTICE. Retention now lives in a separate retainedHidden ref (RR-805VYU), not in formData. conditionBindings (DynamicForm.vue:173-177) keeps evaluating over formData, which no longer contains hidden values — so cascading behaves exactly as it does today. The anomaly the finding describes cannot arise.
+
+    2. NO HYPOTHETICAL-EVALUATION API. The proposed wizard.activePropertiesFor(bindings) surface is DROPPED. It existed solely to compute a transitive closure of newly-hidden fields for the batched dialog, for a three-level chain (c depends on b depends on a) that is a contrived model and rare in practice. The gate handles DIRECT hides only.
+
+    Accepted behavior for deeply-chained conditions: a dependent field may remain visible with a stale value after its parent branch hides. This is strictly better than the current behavior (silent permanent data loss) and clear_when_hidden: yes remains available as the escape hatch for anyone who wants the old cascading clear. Document the limitation; do not engineer around it.
+
+    Rationale (user): 'if people make dumb models they get dumb behavior; let's not overcomplicate things. The system allows for clearing which would resolve the cascade issue. It is also not very likely to set up this cascading stuff in the first place.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-2S0333.md
+++ b/tickets/entities/review-responses/RR-2S0333.md
@@ -1,0 +1,19 @@
+---
+id: RR-2S0333
+type: review-response
+title: Boolean suppression flag cannot work — the activeProperties watcher is post-flush, so the flag clears before it observes the revert
+finding: |-
+    The plan states 'a suppression flag must wrap the programmatic revert so the watcher does not read it as a fresh user edit and re-prompt' (BUG-FB0LN8 Agreed fix, step 5).
+
+    revertField (useAutoSave.ts:536-555) calls opts.applyServerProperty, whose DynamicForm implementation (:1220-1236) writes formData.value[property] = value. The activeProperties watcher (:205) is a DEFAULT (non-sync) Vue watcher, so it fires on the next flush, not synchronously inside revertField.
+
+    Therefore the naive shape — suppress = true; revertField(p); suppress = false — is a NO-OP: the flag is already false by the time the watcher runs, and the user gets the dialog twice. This will pass a hand-test (a single revert with no other activity looks fine) and fail under load.
+
+    Correct shapes: clear the flag in nextTick(), use a generation counter the watcher compares, or declare the watcher { flush: 'sync' }. Whichever is chosen must be pinned by a test that performs a revert and asserts exactly one dialog.
+severity: significant
+resolution: |-
+    Implemented as a generation counter, not a boolean. useHiddenFieldPolicy exposes withSuppression(fn), which increments revertGeneration, marks it suppressed, runs the revert, awaits nextTick() so the post-flush watcher runs while still suppressed, and only then releases. The watcher calls hiddenPolicy.isSuppressed() and returns early.
+
+    Unit test 'stays suppressed across a post-flush watcher pass, then releases' asserts the flag is still set synchronously after withSuppression() is called (the exact window where a naive boolean would already be false) and cleared after the await.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-805VYU.md
+++ b/tickets/entities/review-responses/RR-805VYU.md
@@ -1,0 +1,21 @@
+---
+id: RR-805VYU
+type: review-response
+title: Retention storage location unspecified — leaving retained values in formData silently changes every existing consumer
+finding: |-
+    Plan step 2 says 'retain hidden values client-side' without saying WHERE. If retention means 'leave the key in formData', several existing consumers silently change meaning:
+
+    1. mergeServerResponse (useAutoSave.ts:521-526) sweeps disappeared keys: for each k in lastSeenServer not in entity.properties and not pending/timers, it calls applyServerProperty(k, undefined), which does delete formData.value[k] (DynamicForm.vue:1220-1224). So the NEXT unrelated PATCH response silently deletes the retained value mid-session and the reveal is lossy again.
+    2. conditionBindings (:173-177) — see RR-2IJL4Y (cascade semantics).
+    3. pruneWizardHidden (:722), visibleWritablePropertiesForCommit (:300), checkDirty (:1131) all read formData and would change behavior. In particular the plan promises 'create path unchanged' (step 7) while mutating the shared state that path reads from; if an implementer then 'tidies' pruneWizardHidden as now-redundant, RR-O4SRG regresses.
+
+    Resolution: retention must live in a SEPARATE ref (e.g. retainedHidden: Ref<Record<string, unknown>>), not in formData, or mergeServerResponse must be taught about it explicitly. This must be decided in the plan, not at implementation time.
+severity: critical
+resolution: |-
+    Resolved by design decision: retention lives in a SEPARATE ref, retainedHidden: Ref<Record<string, unknown>>, never in formData.
+
+    This keeps formData meaning exactly what it means today, so every existing consumer is untouched: mergeServerResponse's disappeared-key sweep (useAutoSave.ts:521-526) cannot delete retained values, and pruneWizardHidden (:722), visibleWritablePropertiesForCommit (:300), checkDirty (:1131) and the create path all keep their current semantics. The 'create path unchanged' promise (plan step 7) now actually holds.
+
+    Side benefit: this also resolves the cascade concern (RR-2IJL4Y) for free — conditionBindings keeps evaluating over formData, which no longer contains hidden values, so cascading behaves exactly as it does today.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-9BET7H.md
+++ b/tickets/entities/review-responses/RR-9BET7H.md
@@ -1,0 +1,24 @@
+---
+id: RR-9BET7H
+type: review-response
+title: Stale docs and comments become actively wrong — including the comment that encodes the root cause
+finding: |-
+    The plan flags 'docs' generically but names no sites. Concretely:
+
+    1. internal/dataentryconfig/config.go:173-174 — 'VisibleWhen hides the field (and drops its value from the payload) when false'. Becomes false by default under the fix. This is the doc comment config authors actually read.
+    2. docs/data-entry.md:604 — 'its values are dropped from the payload'. Same correction, plus the new key needs documenting alongside the condition-expression section (~:607-627), including the non-obvious point that `confirm` is not simply `yes` with a prompt because it can also undo the triggering change.
+    3. DynamicForm.vue:200-204 — the watcher comment 'the edit analogue of create's submit-time hidden-branch pruning'. That comment IS the unsound symmetry argument identified as why4/the root cause. It must be DELETED, not edited — leaving it would re-seed the same reasoning for the next maintainer.
+
+    Also: no migration should be added. internal/migration/ holds schema-shape migrations only; a behavior-default change has no precedent there and shouldn't get one — auto-adding clear_when_hidden: yes to existing fields would be a migration that PRESERVES the bug. Release note is the right vehicle.
+severity: minor
+resolution: |-
+    All named sites updated:
+
+    1. internal/dataentryconfig/config.go — FormField doc no longer claims VisibleWhen 'drops its value from the payload'; it now documents ClearWhenHidden and its three values. FormStep doc split create (values excluded) from edit (each field honors its own setting).
+    2. docs/data-entry.md — 'Hidden branches are not saved' split into create vs edit; new #clear_when_hidden section with the value table, examples, and the chained-condition limitation.
+    3. docs/data-entry/api-reference.md — _fields wire shape example gains a visible:false entry; the 'doubly invisible' paragraph rewritten to describe the tombstone, why absence was ambiguous, and why disclosing the field NAME is safe (the metamodel is already served in full). Per-row section notes it deliberately does NOT carry the tombstone.
+    4. DynamicForm.vue:200-204 — the 'edit analogue of create's submit-time hidden-branch pruning' comment is DELETED, not edited. That comment was the unsound symmetry argument why4 identifies as the root cause; leaving it would re-seed the same reasoning.
+
+    No migration added, per the finding's own reasoning.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-APWRJM.md
+++ b/tickets/entities/review-responses/RR-APWRJM.md
@@ -1,0 +1,17 @@
+---
+id: RR-APWRJM
+type: review-response
+title: Date inputs rendered blank over stored values (pre-existing); confirm dialog collapsed its field list into a run-on paragraph
+finding: |-
+    Two display defects surfaced by the demo.
+
+    1. PRE-EXISTING, not caused by this ticket: DateWidget bound the raw stored string to <input type="date">, which accepts ONLY YYYY-MM-DD and silently renders blank for anything else. The API returns RFC3339 for date properties (2026-09-15T00:00:00Z), so every date field showed EMPTY over a perfectly good stored value — on a plain page load, no toggling involved. Confirmed against a freshly loaded form. Especially bad in this ticket's context: an empty date input is exactly what 'my data was destroyed' looks like. The existing unit test only ever passed an already-normalized YYYY-MM-DD, which is how it slipped through. DatetimeWidget already converted before binding (utcISOToLocalInput); DateWidget was the outlier.
+
+    2. ConfirmModal renders `message` as plain text in a <p>, so the \n-separated field list collapsed into one run-on paragraph: 'will clear: • Contract value — policy: confirm: € 2.400.000 • Award criteria ...'. Unreadable, and the point of the dialog is that the user can see exactly what they are about to lose.
+severity: significant
+resolution: |-
+    1. DateWidget now narrows an RFC3339 timestamp to its date part before binding, passing through values already in YYYY-MM-DD and leaving un-parseable input alone (never swallow in-progress typing). Four new unit tests: RFC3339, offset timestamps, un-parseable passthrough, empty.
+
+    2. ConfirmModal's message paragraph gets `white-space: pre-line`, so any caller can present a list without it collapsing. Also rewrote the prompt copy: shorter title that states the count ('Clear these 3 fields?'), one line per field as 'Label — value', and an explicit 'Cancel keeps them and undoes your change' so the non-obvious revert behavior is stated.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-DSAN9B.md
+++ b/tickets/entities/review-responses/RR-DSAN9B.md
@@ -1,0 +1,19 @@
+---
+id: RR-DSAN9B
+type: review-response
+title: Step-level hiding has no clear_when_hidden semantics — and that is the case the motivating e2e test exercises
+finding: |-
+    Plan step 4 adds clear_when_hidden as a PER-FIELD key. But a whole STEP can hide, and that is exactly the AC5 case the fix must invert: in e2e/tests/wizard.spec.ts the `done` checkbox hides the entire Assignment step carrying `assignee`. FormStep (internal/dataentryconfig/config.go:153-159) has no such key and the plan never addresses step-granular hiding.
+
+    So an implementer must invent: is it the union of the step's fields' settings? A step-level key? Does a field-level setting override a step-level one? The plan's motivating example does not typecheck against the plan's own config surface.
+
+    Related (from the security reviewer, RR-O0KRI2 sibling): the key belongs on FormField and the unified FormFieldOrRelation ONLY — not on FormRelation, whose clearing is the separate pruneWizardHiddenRelations mechanism. Adding it there would imply behavior that does not exist.
+severity: significant
+resolution: |-
+    Resolved by design decision: clear_when_hidden is PER-FIELD ONLY. No step-level key.
+
+    Verified FormStep (internal/dataentryconfig/config.go:153-159) has exactly five fields — Title, Description, VisibleWhen, Fields, Relations — with no per-field behavior key of any kind. Adding a step-level clear_when_hidden would invent new config surface, which is out of scope for a bug fix on existing behavior.
+
+    Rule: a step hiding is simply 'all of its fields hid', each honoring its own clear_when_hidden setting. This covers the AC5 case (the `done` checkbox hiding the whole Assignment step carrying `assignee`) with zero new config surface. Also confirmed the key belongs on FormField and the unified FormFieldOrRelation only — not FormRelation, whose clearing is the separate pruneWizardHiddenRelations mechanism.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-F3QT0H.md
+++ b/tickets/entities/review-responses/RR-F3QT0H.md
@@ -1,0 +1,17 @@
+---
+id: RR-F3QT0H
+type: review-response
+title: Redacted fields rendered writable in the section inline-edit path (isFieldWritable ignored the tombstone)
+finding: |-
+    computeFieldAffordancesFrom suppresses the writable verdict for hidden fields, so a tombstone is {visible:false} with writable == nil. The shared helper isFieldWritable (frontend/src/utils/affordances.ts) returned verdict?.writable !== false, which is TRUE for a tombstone.
+
+    DynamicForm compensated independently (isFieldRedacted in isFieldReadonly), but the section inline-edit path did not: sectionEditFields.ts and SectionEditForm.vue contain zero references to 'visible'. sectionShouldRouteToInlineEdit routes to inline edit if any field isFieldWritable, and SectionEditForm sets writable: isFieldWritable(field.verdict).
+
+    Scenario: entity has visible:false on priority. The entry properties section renders priority as an editable EMPTY widget (the value is stripped). User types; autosave PATCHes; the server returns 403 RuleFieldHidden. No data loss (the server fails closed) but a phantom editable control that always rejects. Regression introduced by this commit — before it, a hidden field had no _fields entry at all.
+severity: significant
+resolution: |-
+    Fixed in the SHARED helper rather than per-consumer, since one consumer compensating while another did not is exactly what caused the gap: isFieldWritable now returns false when verdict?.visible === false.
+
+    This makes every current and future consumer correct by default (DynamicForm, SectionEditForm, sectionEditFields, and anything added later). Pinned by three new tests in affordances.test.ts: redacted is not writable, stays non-writable even with an explicit writable:true, and an explicit visible:true is unaffected.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-F3Y9QA.md
+++ b/tickets/entities/review-responses/RR-F3Y9QA.md
@@ -1,0 +1,26 @@
+---
+id: RR-F3Y9QA
+type: review-response
+title: Metamodel-driven render gate makes ACL-hidden fields render as empty editable inputs (needs an explicit _fields tombstone)
+finding: |-
+    Plan step 1 removes the 'f.property in formData' render gate. An ACL-hidden field is absent from BOTH properties (stripHiddenProperties, affordances.go:915) and the sparse _fields map (computeFieldAffordances skips hidden fields entirely), so with the gate gone it renders as an empty, editable input that silently rejects every write.
+
+    NOTE ON SEVERITY: one reviewer escalated this to critical on the theory that a user could type into the box and destroy a redacted value, because 'visible: gates reads, not writes'. That is FALSE and was verified against the code: validateFieldWrite (affordances.go:325) runs on the PATCH path before any other validation (write_handler.go:376) and checks setKeys AND unsetKeys against the same rules — 'hidden/read-only fields cannot be set OR unset', rejecting with RuleFieldHidden. Both reviewers independently confirmed the server fails closed. So there is no data-destruction path; the defect is UX (a phantom editable control that always 403s) plus a missed opportunity.
+
+    FIX (highest leverage in this review): add an explicit tombstone to the _fields wire map — e.g. {visible: false} — so 'absent' stops being the signal for 'hidden'. The frontend then distinguishes redacted from unset directly and renders a read-only redacted affordance (precedent: InaccessibleField.vue). This permanently retires the ambiguous sentinel that why3 and why5 both identify as the systemic root cause; without it, this fix removes one consumer of the ambiguous sentinel and leaves the sentinel in place for the next subsystem to trip over — exactly what BUG-FB0LN8's own prevention field says to avoid.
+severity: significant
+resolution: |-
+    ACCEPTED INTO THIS TICKET (not split out). The tombstone makes the current work simpler and more correct, so it is in scope.
+
+    Change is small: add `Visible *bool` to FieldAffordance (internal/apiwire/v1/responses.go:73), following the same sparse convention as the existing `Writable *bool` — omitted when the permissive default holds, present only to deny. Then change the `continue` at affordances.go:740 ('hidden takes precedence; skip from _fields entirely') to emit {visible: false} instead of skipping.
+
+    Why it SIMPLIFIES rather than enlarges the fix: without it, edit-mode renderability needs a three-way inference (metamodel-declared AND not-in-_fields AND not-in-formData -> guess). With it the rule is flat and reads directly off the wire:
+        if (fieldAffordances[p]?.visible === false) -> render redacted, read-only
+        if (declaredProperties.has(p))              -> render normally
+    No inference from absence anywhere. This also disposes of the phantom-editable-input UX defect in one move: an ACL-hidden field renders as a proper read-only redacted affordance (precedent: InaccessibleField.vue) instead of an empty box that 403s on every keystroke.
+
+    Disclosure check: the tombstone reveals WHICH fields are redacted, where today they are indistinguishable from unset. Explicitly sanctioned — root CLAUDE.md states field-level redaction 'makes no claim to conceal which properties exist', and /api/v1/_schema (handleV1Schema, api_v1.go:1149) was verified to serve every declared property name unfiltered to any authenticated user with no principal check. So this discloses nothing the SPA did not already have. Row-level ACL is untouched.
+
+    This is what retires the ambiguous 'absence means hidden' sentinel that why3 and why5 both name as the systemic root cause, satisfying the bug's own prevention field.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-G0WF8A.md
+++ b/tickets/entities/review-responses/RR-G0WF8A.md
@@ -1,0 +1,17 @@
+---
+id: RR-G0WF8A
+type: review-response
+title: Blanket watcher suppression swallowed coalesced user edits; concurrent trigger asked for an unperformable revert
+finding: |-
+    Two related defects in the revert machinery.
+
+    1. isSuppressed() gated the ENTIRE watcher body. Vue coalesces a revert mutation and a same-flush user mutation into ONE watcher invocation, which then observes isSuppressed() === true — so the user's change is dropped entirely: a field that just hid is never retained or error-cleared, and a field that just revealed is never restored.
+
+    2. resolveHide returned {clear: [], revert: true} for a concurrent trigger while a dialog was open. The caller reverts from captureTriggerSnapshot(), a SINGLE slot belonging to the trigger that opened the dialog. After the lastEdit-consumption fix the second trigger gets {} — a silent no-op revert; before it, it would have reverted the WRONG property. revert:true is unperformable with a single-slot snapshot.
+severity: significant
+resolution: |-
+    1. Suppression is now scoped per-property: withSuppression(fn, properties) records which keys the revert re-hid, isSuppressed(prop) checks membership, and the watcher skips only those properties rather than the whole pass. The reveal-restore loop and the RR-U9ERK error-clear now run normally for unrelated properties in the same flush. Pinned by 'suppresses only the properties the revert touched'.
+
+    2. A concurrent trigger now returns revert:false and is simply ignored. That is the honest outcome: the second branch hides and keeps its value (retention still holds it, so revealing restores it), rather than claiming an undo the caller cannot perform. Test updated to assert revert:false and documented in the composable.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-GSXOZ5.md
+++ b/tickets/entities/review-responses/RR-GSXOZ5.md
@@ -1,0 +1,22 @@
+---
+id: RR-GSXOZ5
+type: review-response
+title: Three ACL doc comments still asserted the pre-tombstone invariant; object values rendered as [object Object] in the prompt
+finding: |-
+    1. Three doc comments still stated 'hidden fields are omitted from properties AND from _fields', which the tombstone reverses. These are the contract docs the next reader relies on — notably FieldVerdicts.Visible, the type resolver authors implement:
+       - internal/apiwire/v1/responses.go (Entity.FieldAffordances)
+       - internal/dataentry/affordances.go (FieldVerdicts.Visible)
+       - frontend/src/types/entity.ts (_fields)
+
+    2. formatValueForPrompt used String(value), so an object-valued field prompts 'Clear: • Label: [object Object]' — the user cannot tell what they are approving the loss of.
+
+    3. validate_test.go's new clear_when_hidden tests only exercised top-level form.Fields, not step-nested fields — which is the motivating case, since the AC5 fixture hides a whole wizard step.
+severity: minor
+resolution: |-
+    1. All three doc comments corrected to describe the tombstone, the value/name distinction, and the read-only-row exception.
+
+    2. formatValueForPrompt now JSON.stringifies non-null objects.
+
+    3. Added TestValidateConfig_ClearWhenHiddenValidatedInWizardSteps, asserting an invalid value on a step-nested field is rejected AND that the error locates the step ('step[0]'). Verified the code path was already correct — validateForms calls the same validateFormField for form.Steps[].Fields with a ctx prefix — so this pins existing behavior rather than fixing a defect.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-IOZI72.md
+++ b/tickets/entities/review-responses/RR-IOZI72.md
@@ -1,0 +1,14 @@
+---
+id: RR-IOZI72
+type: review-response
+title: clear_when_hidden enum has no allowlist validation site
+finding: 'The plan names three values (no|yes|confirm) but does not say where the allowlist lives, and no validation exists today. conditionlint.go:57-76 checks only the four visible_when expression sites. A typo such as clear_when_hidden: never — or the plausible off/false — errors nowhere. yaml.v3 decodes bare ''off'' as the literal string "off", so it reaches the frontend intact. Today the ===''yes''/===''confirm'' comparisons would all miss and it falls through to the safe default, but the moment someone writes the comparison as !==''no'', ''off'' silently means CLEAR. Needs allowlist validation in validateFormField (validate.go:276) alongside the existing transitions check, plus a frontend union type ''no''|''yes''|''confirm'' rather than string.'
+severity: significant
+resolution: |-
+    Implemented. Allowlist lives in internal/dataentryconfig/config.go (ValidClearWhenHidden, with named constants) and is enforced in validateFormField (validate.go), alongside the existing transitions check. Frontend mirrors it as a union type ClearWhenHidden = 'no' | 'yes' | 'confirm' in types/config.ts, not string.
+
+    Also added a guard for clear_when_hidden set WITHOUT visible_when (it could never fire) — a config mistake worth catching at author time.
+
+    Tests: TestValidateConfig_ClearWhenHiddenAllowlist covers all three valid values plus the plausible-typo rejections (off, false, true, confrim, never). TestFormField_ClearWhenHiddenYAMLScalars pins the YAML-scalar behavior directly: bare no/yes decode to the literal strings "no"/"yes" under yaml.v3's 1.2 core schema and land in the allowlist as written, so the boolean footgun does not bite. Verified experimentally before relying on it.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-LFXFGW.md
+++ b/tickets/entities/review-responses/RR-LFXFGW.md
@@ -1,0 +1,21 @@
+---
+id: RR-LFXFGW
+type: review-response
+title: Post-await clear/revert acted on form state the server had since replaced — destroys a value the user never approved
+finding: |-
+    applyHidePolicy awaits a confirm dialog, but formData can be replaced underneath it: loadEntity(true) fires from applyServerProperty (a committed state-machine move) and onAttachmentChanged, and autosave's applyServerProperty merges server values directly.
+
+    Scenario A (clear): deadline='OLD'. User toggles the branch, dialog names 'Deadline: OLD'. Before they answer, a status transition triggers loadEntity(true) and the server returns deadline='FRESH' (a concurrent editor's write). User clicks Clear, approving the loss of OLD — FRESH is unset instead. This is BUG-FB0LN8's own failure mode (silent destruction of a value the user never consented to lose) re-entering through the async gap the fix introduced.
+
+    Scenario B (revert): user edits mode a->b, dialog opens, a merge lands mode='c' from another editor, user clicks Cancel. The revert stomps mode back to the stale 'a', bypassing updateField so no autosave is scheduled — the form shows 'a' while the server holds 'c'.
+severity: critical
+resolution: |-
+    Fixed with a load-generation fence plus per-value verification.
+
+    1. New loadGeneration ref, bumped in loadEntity (before formData is replaced) and in autosave's applyServerProperty. applyHidePolicy captures it before the await and returns early if it changed — a decision about state that no longer exists is abandoned rather than applied.
+
+    2. The clear loop additionally captures the exact values the user was shown (values Map) and skips any property whose current value differs, so a merge landing mid-dialog cannot be destroyed by a 'yes' that did not cover it.
+
+    The fence also closes the gap in the releaseAll fix: retention is dropped by loadEntity, and the in-flight gate now knows to abandon.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-O0KRI2.md
+++ b/tickets/entities/review-responses/RR-O0KRI2.md
@@ -1,0 +1,28 @@
+---
+id: RR-O0KRI2
+type: review-response
+title: clear_when_hidden silently ignored by old binaries — nested config keys are never validated
+finding: 'checkUnknownKeys (internal/dataentryconfig/validate.go:150-168) only walks TOP-LEVEL keys of the raw map; nested forms[].fields[] keys are never checked, and the struct unmarshal is plain non-strict yaml.Unmarshal (no KnownFields(true) anywhere in the package). An unknown nested key decodes with err=nil. Failure scenario: an operator adds clear_when_hidden: no to opt out of clearing, but a node still running an older binary parses the config cleanly, reports no error, and applies the old hardcoded destructive behavior — the exact BUG-FB0LN8 data loss, now with the operator believing they have opted out. The design is silent on version-gating a key whose absence means ''destroy data''.'
+severity: significant
+resolution: |-
+    WON'T FIX in this ticket — accepted risk, documented reasoning.
+
+    The finding is factually correct: checkUnknownKeys only walks TOP-LEVEL config keys, nested form-field keys are never structurally validated, and the struct unmarshal is non-strict. An old binary reading a new config with clear_when_hidden silently ignores it.
+
+    Why not fixed here:
+
+    1. It cannot be fixed FROM this change. A new binary cannot make an OLD binary reject a key the old binary has never heard of. Any gate would have to have shipped in the previous release. That is the general shape of every additive config key in this codebase — clear_when_hidden is not special.
+
+    2. The blast radius is bounded and shrinking in the safe direction. The affected case is an operator who explicitly writes clear_when_hidden: no (or confirm) to opt OUT of clearing while running a binary that predates the key. On such a binary the pre-fix destructive behavior applies — i.e. they are exactly as badly off as before the fix, not worse. After upgrading, the NEW default is already non-destructive without any config, so the common path needs no opt-in at all.
+
+    3. A general fix belongs in its own ticket: adding recursive unknown-key validation for nested config structures (forms[].fields[], lists[].columns[], views[].sections[], ...). That is a broad change with its own compatibility surface — it would start rejecting configs that parse cleanly today — and folding it into a critical data-loss fix would delay the fix and enlarge its risk.
+
+    Mitigation shipped instead: the release note calls out that the destructive behavior is now opt-in and that clear_when_hidden requires a binary from this release or later.
+reason: |-
+    Cannot be fixed from this change: a new binary cannot make an OLD binary reject a key it has never heard of — any such gate would have had to ship in the previous release. This is the general shape of every additive config key in this codebase, not something specific to clear_when_hidden.
+
+    Blast radius is bounded and fails in the safe direction: the affected case is an operator who explicitly writes clear_when_hidden to opt OUT of clearing while running a pre-release binary. On that binary they get the old destructive behavior — exactly as badly off as before this fix, not worse. After upgrading, the new default is already non-destructive with no config at all, so the common path needs no opt-in.
+
+    The general fix (recursive unknown-key validation for nested config structures) is filed as TKT-QHF4JQ. It would start rejecting configs that parse cleanly today, which is its own compatibility surface and deserves its own review rather than riding along with a critical data-loss fix. Mitigation shipped instead: the release note states the destructive behavior is now opt-in and that clear_when_hidden requires a binary from this release or later.
+status: wont-fix
+---

--- a/tickets/entities/review-responses/RR-PZHJNN.md
+++ b/tickets/entities/review-responses/RR-PZHJNN.md
@@ -1,0 +1,27 @@
+---
+id: RR-PZHJNN
+type: review-response
+title: 'clear_when_hidden: confirm cannot be built correctly on the current form architecture — scope reduced to no|yes'
+finding: |-
+    Three separate fixes to the interactive confirm path each passed their tests and each then failed in manual use:
+
+    1. The revert restored formData but not the server — updateField stages the autosave before the dialog exists.
+    2. The pre-edit value lived in a single mutable slot (lastEdit) that a second watcher pass could consume, so the revert silently became a no-op.
+    3. An 800ms debounce raced the dialog: thinking too long committed the change.
+
+    Root cause is structural, not a sequence of coding errors. updateField mutates formData AND arms the autosave in one step, so there is no 'proposed but not committed' state. Anything needing to intervene must reconstruct prior state after the fact, from state scattered across lastEdit, autosave's pending map, and retained. That reconstruction is where every bug lived.
+
+    Notably: neither adversarial code review, nor 1462 unit tests, nor 236 e2e tests caught any of these. The user found all three in minutes of clicking.
+severity: critical
+resolution: |-
+    Scope reduced. 'confirm' is REMOVED from the accepted enum — not left as an accepted-but-degraded value. A config using it now fails validation loudly at author time, which is honest; a value that silently behaves like something other than its name is the exact trap that caused this bug.
+
+    Shipped: no (default) and yes. Both are decided synchronously from state the caller already holds, so there is no window in which form and server can disagree. This is the actual data-loss fix and it is fully verified.
+
+    Removed with it: the async gate, resolveHide, gateBusy, withSuppression/isSuppressed, lastEdit, captureTriggerSnapshot, loadGeneration, and the confirm-dialog wiring. useHiddenFieldPolicy went from 196 to 105 lines and is now a pure synchronous query; applyHidePolicy went from ~70 lines to 12.
+
+    Kept: useAutoSave.cancelPendingField (tested, unused in prod) — the 'drop a staged write without side effects' primitive the refactor's reject path needs.
+
+    Follow-up: TKT-7S5735 (propose/commit refactor — policy manager + write queue), with confirm as its first consumer and validating use case.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-RK7ATG.md
+++ b/tickets/entities/review-responses/RR-RK7ATG.md
@@ -1,0 +1,21 @@
+---
+id: RR-RK7ATG
+type: review-response
+title: Singleton confirm dialog shares one promise across concurrent triggers — a second clear is approved by a dialog that never named it
+finding: |-
+    useConfirm (frontend/src/composables/useConfirm.ts:118-122) documents its own concurrency semantics verbatim: 'if (pendingPromise) { // Concurrent call: return the in-flight promise. Both callers observe the same user decision. return pendingPromise }'.
+
+    Failure scenario: user toggles a, dialog opens naming 'Inschrijfdeadline'. The form stays interactive — nothing in the plan disables it. User toggles d, which would clear Vragenronde_deadline. The second confirm() call returns the FIRST promise and shows the FIRST dialog's text. User clicks Yes meaning 'clear Inschrijfdeadline'. Both call sites receive true, so Vragenronde_deadline is cleared without ever being named in any dialog — precisely the silent-data-loss class this ticket exists to eliminate.
+
+    This directly violates the plan's step 6 promise of 'one batched dialog naming each field and value'. Resolution must either serialize trigger evaluation behind an explicit queue, or hard-block form input while a clear-confirm is pending. The plan must state which.
+severity: minor
+resolution: |-
+    Downgraded critical -> minor. The finding's premise ('the form stays interactive — nothing in the plan disables it') was asserted without checking the markup, and is wrong.
+
+    ConfirmModal (frontend/src/components/ui/ConfirmModal.vue:91) renders a full-screen .modal-overlay backdrop. While a dialog is open the rest of the form is not mouse-reachable, so the 'user toggles a second trigger field during the async gap' scenario cannot occur by pointer.
+
+    Residual risk is narrow: keyboard focus could in principle reach a control behind the overlay if focus is not trapped, and a same-field re-toggle could re-enter the gate. Both are closed by a single re-entry guard — hold a pendingGate flag and have the gate return early (ignoring the change) while a dialog is outstanding.
+
+    No queue, no serialization machinery, no promise-sharing workaround needed. Reuse the existing useConfirm/ConfirmModal pair as-is; add the one guard and pin it with a test asserting a second trigger during an open dialog is ignored rather than silently inheriting the first answer.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-SH85S4.md
+++ b/tickets/entities/review-responses/RR-SH85S4.md
@@ -1,0 +1,19 @@
+---
+id: RR-SH85S4
+type: review-response
+title: Confirm-gate logic must land in a composable — DynamicForm.vue is 1886 lines against a 500-line threshold
+finding: |-
+    frontend/eslint.config.js:118 sets 'max-lines': ['warn', { max: 500 }]. DynamicForm.vue is already ~1886 lines (3.8x over) and is the god-component the project's own linting flags. The plan adds four more concerns to it: retained-value state, the confirm gate state machine, revert-with-suppression-generation, and hypothetical condition evaluation — roughly another 150 lines on the hottest path in the file.
+
+    frontend/CLAUDE.md conventions favor composables, and the mechanism is self-contained with no template coupling. It should land as its own composable (e.g. useHiddenFieldPolicy.ts) alongside useAutoSave / useFormWizard, with DynamicForm.vue only wiring it. This also gives the missing unit tests a seam to bind to — note there is currently NO unit test for pruneWizardHidden or affordanceVisible at all (BUGA-QUI067), and the two hardest findings (cascade semantics, retention storage) are pure logic in exactly those functions, where unit tests are far cheaper than e2e.
+
+    The plan is silent on placement.
+severity: significant
+resolution: |-
+    Implemented as frontend/src/composables/useHiddenFieldPolicy.ts (196 lines) with its own 22-test unit suite. DynamicForm.vue only wires it: policyFor/propertyDef/labelFor/confirm callbacks in, retain/resolveHide/withSuppression out.
+
+    This gave the missing tests a seam, which mattered — the analysis found there was NO unit test for pruneWizardHidden or affordanceVisible at all, and the two hardest design findings (retention storage, revert suppression timing) are pure logic now covered by fast unit tests rather than only e2e.
+
+    Partial on the line count: DynamicForm.vue went 1886 -> 1999. The policy MECHANISM is fully extracted; the residual growth is wiring plus the watcher rewrite (which necessarily lives with the watcher). Still ~4x the 500-line warn threshold, unchanged in kind from before this ticket — decomposing the component is TKT-N0IKN9's job, not this bug fix's.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-VFQKCY.md
+++ b/tickets/entities/review-responses/RR-VFQKCY.md
@@ -1,0 +1,19 @@
+---
+id: RR-VFQKCY
+type: review-response
+title: revertField restores the server baseline, not the pre-change value — declining can rewind an unrelated accepted edit
+finding: |-
+    The plan (BUG-FB0LN8 'Agreed fix' step 5) delegates the decline-path restore to useAutoSave.revertField(). But revertField (useAutoSave.ts:545-549) restores from lastSeenServer[property], which is written only by recordServerSnapshot / mergeServerResponse — the last value the SERVER confirmed, not the value the field held before this change.
+
+    Failure scenario: inkooproute starts 'aanbesteding'. User changes it to 'europees' (hides nothing, no dialog, autosaves). Before that PATCH lands (800ms debounce + round-trip), the user changes it to 'onderhands', gets the clear dialog, and declines. revertField restores lastSeenServer['inkooproute'], still 'aanbesteding' — so the decline silently rewinds the user's already-accepted 'europees' edit. The user declined 'clear the deadlines' and lost 'set route to europees'.
+
+    Fix: capture an explicit pre-change snapshot of the trigger field at gate time and restore from that, rather than delegating to revertField's server-baseline semantics.
+
+    Related side effect: applyServerProperty (DynamicForm.vue:1233) fires void loadEntity(true) when the reverted property is in transitions.value — a full entity refetch as a consequence of a revert, which also stomps formData via :347 while retained values are outstanding.
+severity: significant
+resolution: |-
+    Implemented. revertField is NOT used for the decline path. DynamicForm tracks lastEdit (set in updateField before formData is mutated), and captureTriggerSnapshot reads from that, so a decline restores exactly the value the edit replaced — not autoSave's lastSeenServer baseline, which can be older than an intermediate edit the user already accepted.
+
+    Pinned end-to-end: 'clear_when_hidden:confirm keeps the value when declined' asserts BOTH that the conditional field keeps its value AND that the trigger (done) reverts to true. This test fails against the pre-fix component.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-WRUTYN.md
+++ b/tickets/entities/review-responses/RR-WRUTYN.md
@@ -1,0 +1,17 @@
+---
+id: RR-WRUTYN
+type: review-response
+title: '''Non-empty stored value'' is undefined for in-flight edits, making prompting nondeterministic; reuse isClearedForType'
+finding: |-
+    Plan step 6 prompts only when a hidden field holds a 'non-empty STORED value', but never defines 'stored'. lastSeenServer (useAutoSave.ts:167) is the only oracle and is mutated by every mergeServerResponse. So a value typed 200ms ago that has already committed counts as stored, while one still sitting in `pending` does not — whether the user is prompted depends on debounce timing. Needs an explicit definition (proposal: stored = lastSeenServer, evaluated at gate time, with pending treated as stored so a just-typed value is not silently discarded).
+
+    Separately, the emptiness predicate must reuse isClearedForType (DynamicForm.vue:1009, from @/utils/formValue), which deliberately treats boolean false as a REAL value per TKT-E6094. Hand-rolling the undefined/''/null triple used by the current watcher (:222-224) would classify false as non-empty and prompt spuriously on every checkbox toggle.
+severity: minor
+resolution: |-
+    Implemented. Emptiness uses the existing isClearedForType (utils/formValue), so boolean false is a real value and does not prompt spuriously on checkbox toggles; empty string, null, undefined and empty arrays all count as nothing-at-stake.
+
+    'Stored' is defined as the CURRENT form value at gate time (formData), not autoSave's lastSeenServer. This sidesteps the nondeterminism the finding describes: whether a value has finished round-tripping through a debounce no longer changes whether the user is prompted. A value the user typed 200ms ago is treated the same as one loaded from the server — both are real values worth protecting.
+
+    Unit tests cover each case: 'treats boolean false as a real value, not an empty one', 'ignores fields that hold nothing worth losing', 'treats an empty array as cleared'.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-Z1LUO5.md
+++ b/tickets/entities/review-responses/RR-Z1LUO5.md
@@ -1,0 +1,17 @@
+---
+id: RR-Z1LUO5
+type: review-response
+title: Stale retention across entity switch / forced refetch; single-slot lastEdit reusable by an unrelated revert
+finding: |-
+    1. releaseAll() existed on the composable but was NEVER called. DynamicForm has no :key per entity, so switching entities without a remount — or any loadEntity(true) refetch — left retained values from the previous form state in place. A subsequent reveal could restore one entity's value onto another, or resurrect a value the server no longer has.
+
+    2. lastEdit was never cleared. A hide NOT caused by a tracked user edit (a programmatic change, a reload) would revert using a stale snapshot from an unrelated earlier edit.
+severity: significant
+resolution: |-
+    1. loadEntity now calls hiddenPolicy.releaseAll() immediately before replacing formData. Lossless: the stored value is safe on the server, so a later reveal reads it back from properties.
+
+    2. captureTriggerSnapshot() now CONSUMES lastEdit (sets it to null), so a snapshot is good for exactly one hide resolution. An empty snapshot means the hide was not user-initiated, and the revert leaves the form alone rather than restoring a stale value.
+
+    Note a reviewer confirmed the original was less broken than feared for the concurrent-edit case: captureTriggerSnapshot is called BEFORE the await, so a later updateField during an open dialog could not poison an already-captured snapshot. The fix matters for the untracked-hide case.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-ZFRJMF.md
+++ b/tickets/entities/review-responses/RR-ZFRJMF.md
@@ -1,0 +1,21 @@
+---
+id: RR-ZFRJMF
+type: review-response
+title: Declining the clear-confirm reverted the form but not the server — the trigger's autosave was already staged
+finding: |-
+    Found by manual demo testing, not by any automated check.
+
+    updateField() stages an autosave for the edited field IMMEDIATELY (scheduleFieldSave at the end of the function) — before the activeProperties watcher runs, and long before the confirm dialog resolves. The decline path restored formData from its snapshot but never touched that staged write.
+
+    Result: choosing Cancel restored the dropdown in the UI while the server kept the NEW value. Reloading showed the change had been saved anyway. The plan's claim that 'nothing is staged into pending before the dialog resolves' was true for the fields being cleared but never true for the TRIGGER field itself.
+
+    Worse, the form and server silently diverged — the user sees 'aanbesteding', the server holds 'onderhands'.
+severity: critical
+resolution: |-
+    Added useAutoSave.cancelPendingField(property): drops a not-yet-sent write and its debounce timer WITHOUT revertField's form-state restore (the caller owns the restore and knows the exact value; revertField would apply its own, possibly staler, lastSeenServer baseline). Returns whether anything was cancelled.
+
+    The decline path now cancels the trigger's pending write; if it had already fired, it re-saves the snapshot value instead (routing through scheduleUnset vs scheduleFieldSave via isClearedForType so a cleared trigger unsets correctly).
+
+    Pinned by strengthening the existing e2e decline test: it now waits out the debounce and re-asserts server state. Verified the test genuinely catches this — removing the fix makes it fail, restoring it makes it pass. Plus three useAutoSave unit tests for cancelPendingField (cancels before firing, does not touch form state, reports false once fired).
+status: addressed
+---

--- a/tickets/entities/tickets/TKT-7S5735.md
+++ b/tickets/entities/tickets/TKT-7S5735.md
@@ -1,0 +1,105 @@
+---
+id: TKT-7S5735
+type: ticket
+title: 'Form edits: separate propose from commit (policy manager + write queue)'
+kind: refactor
+priority: high
+effort: l
+status: backlog
+---
+
+## Problem
+
+A field edit in `DynamicForm` does two things in one breath: mutate `formData`
+**and** arm the autosave debounce (`updateField`). There is no point at which a
+change is "proposed but not yet committed".
+
+Anything that needs to intervene between the two — most obviously an interactive
+confirmation — has to run *after* the change is applied and possibly already
+sent, then reconstruct the prior state. Every attempt at that during BUG-FB0LN8
+produced a near-miss:
+
+- the revert restored `formData` but not the server (the trigger's autosave was
+already staged);
+- the pre-edit value lived in a single mutable slot (`lastEdit`) that a second
+watcher pass could consume;
+- an 800 ms debounce raced the dialog, so thinking too long committed the change;
+- suppression flags had to be scoped per-property because Vue coalesces a
+programmatic revert with a same-flush user edit into one watcher invocation.
+
+Each of those was individually fixable and each fix passed its tests. The
+pattern — reconstructing intent after the fact from state scattered across
+`lastEdit`, autosave's `pending` map, and `retained` — is the actual defect.
+
+## Proposed architecture
+
+Three roles, one job each:
+
+```text
+Widget ──proposes──► Policy Manager ──commits──► Write Queue ──PATCH──► server
+ "user typed X"      "is this allowed?           "batch, debounce,
+                      what else does it           merge, send"
+                      affect?"
+```
+
+**A proposal is not a write.** The manager decides; only an accepted proposal
+becomes a commit request. "Cancel" is then trivially correct: nothing was
+applied and nothing was queued, so there is nothing to undo.
+
+### Design decisions (agreed with the user)
+
+1. **Optimistic UI.** The widget shows the new value immediately — the user
+already moved the control, so freezing it reads as broken. On reject, the
+manager revert restores the prior value. This is safe *here* (unlike today)
+because the pre-change value lives in the proposal object, scoped to one
+decision, rather than in a shared mutable slot.
+
+2. **The queue merges, it does not concatenate.** Same property twice →
+last-write-wins. Different properties → one PATCH body. A set and an unset of
+the *same* property within a window must **resolve**, never emit both
+`properties` and `properties_unset` for that key.
+
+3. **The policy always sees a consistent world.** It treats accepted-but-not-yet
+-written changes as already committed. So the queue's cleverness is invisible to
+policy — it can be dumb (sequential pump) or smart (merging) without policy
+caring. This is what makes the two genuinely independent components rather than
+two halves of one thing.
+
+### Boundaries
+
+- The manager does **not** own `formData`; the form does. The manager returns
+accept/reject plus side-effects (`clear these`, `retain those`) and the form
+applies them. Otherwise the manager becomes a second god-object — and
+`DynamicForm` is already ~1950 lines.
+- The queue is a single serialized channel: one in-flight PATCH, everything
+else merges into the next batch. `useAutoSave`'s `queueTail` already does
+roughly this; the queue formalizes it.
+
+## First consumer
+
+`clear_when_hidden: confirm` — ask before clearing a hidden field's stored
+value, and undo the triggering change on decline. It was **removed** from the
+accepted enum in BUG-FB0LN8 precisely because it cannot be built correctly
+against the current design; the backend rejects the value at config-validation
+time. It is the feature that motivates this refactor and the one that validates
+it.
+
+## Scope / risk
+
+Touches `updateField`, the `activeProperties` watcher, `useHiddenFieldPolicy`,
+and `useAutoSave`. **`useAutoSave` is load-bearing for every edit form**, not
+just conditional ones — its 28 tests encode no-op suppression, unset semantics,
+in-flight abort, and commit-on-navigate. That suite is the regression surface
+and must stay green.
+
+`useAutoSave.cancelPendingField` already exists (added and tested during
+BUG-FB0LN8, currently used only by its own tests): drop a staged write without
+touching form state. It is the primitive the reject path needs.
+
+## Testing note
+
+The bugs above all lived in `DynamicForm`'s orchestration, and **none** were
+caught by unit tests (which cover composables in isolation) or e2e (which passed
+while the feature was visibly broken in a browser). This work should add a
+component-level test harness that mounts `DynamicForm` and drives the real
+widget → manager → queue path.

--- a/tickets/entities/tickets/TKT-QHF4JQ.md
+++ b/tickets/entities/tickets/TKT-QHF4JQ.md
@@ -1,0 +1,48 @@
+---
+id: TKT-QHF4JQ
+type: ticket
+title: Recursive unknown-key validation for nested data-entry config structures
+kind: enhancement
+priority: medium
+status: backlog
+---
+
+## Problem
+
+`checkUnknownKeys` (`internal/dataentryconfig/validate.go`) unmarshals the raw
+YAML into `map[string]any` and checks only **top-level** keys against
+`validTopLevelKeys`. Nested structures are never structurally validated, and
+`yaml.Unmarshal` is called without `KnownFields(true)`, so an unknown nested key
+decodes with `err == nil`.
+
+A typo like `visible_wen:` or `clear_when_hiden:` on a form field is therefore
+silently ignored. The author sees no error and reasonably assumes the setting
+took effect.
+
+## Why it matters
+
+Surfaced by BUG-FB0LN8's design review (RR-O0KRI2). That bug added
+`clear_when_hidden`, whose *absence* selects a behavior — so a typo silently
+selects the other one. The enum itself is now allowlist-validated, which covers
+a bad **value**, but not a misspelled **key**.
+
+The same shape applies to every nested key in the config: `visible_when`,
+`required_when`, `readonly`, list column options, view section fields.
+
+## Scope
+
+Recursive unknown-key checking for nested config structures (`forms[].fields[]`,
+`lists[].columns[]`, `views[].sections[]`, `kanbans[].card.fields[]`, …), with
+the same did-you-mean suggestion treatment the top-level check already gives.
+
+Deliberately NOT folded into BUG-FB0LN8: this would start rejecting configs that
+parse cleanly today, which is its own compatibility surface and deserves its own
+review rather than riding along with a critical data-loss fix.
+
+## Notes
+
+- Prefer deriving the valid key set from struct tags (as
+`TestValidTopLevelKeysMatchConfigStruct` already does for the top level) rather
+than hand-maintaining a second list that can drift.
+- Consider whether this should be an error or a warning on first release, given
+existing configs in the wild may carry stray keys today.

--- a/tickets/relations/BUG-FB0LN8--adds-measure--conditional-field-reveal-roundtrip-test.md
+++ b/tickets/relations/BUG-FB0LN8--adds-measure--conditional-field-reveal-roundtrip-test.md
@@ -1,0 +1,5 @@
+---
+from: BUG-FB0LN8
+relation: adds-measure
+to: conditional-field-reveal-roundtrip-test
+---

--- a/tickets/relations/BUG-FB0LN8--affects--data-entry-ui.md
+++ b/tickets/relations/BUG-FB0LN8--affects--data-entry-ui.md
@@ -1,0 +1,5 @@
+---
+from: BUG-FB0LN8
+relation: affects
+to: data-entry-ui
+---

--- a/tickets/relations/BUG-FB0LN8--caused-by--TKT-CHLAJ.md
+++ b/tickets/relations/BUG-FB0LN8--caused-by--TKT-CHLAJ.md
@@ -1,0 +1,5 @@
+---
+from: BUG-FB0LN8
+relation: caused-by
+to: TKT-CHLAJ
+---

--- a/tickets/relations/BUG-FB0LN8--fixes--FEAT-LOCB0.md
+++ b/tickets/relations/BUG-FB0LN8--fixes--FEAT-LOCB0.md
@@ -1,0 +1,5 @@
+---
+from: BUG-FB0LN8
+relation: fixes
+to: FEAT-LOCB0
+---

--- a/tickets/relations/BUG-FB0LN8--has-bug-analysis--BUGA-QUI067.md
+++ b/tickets/relations/BUG-FB0LN8--has-bug-analysis--BUGA-QUI067.md
@@ -1,0 +1,5 @@
+---
+from: BUG-FB0LN8
+relation: has-bug-analysis
+to: BUGA-QUI067
+---

--- a/tickets/relations/BUG-FB0LN8--has-implementation--IMPL-BYME5I.md
+++ b/tickets/relations/BUG-FB0LN8--has-implementation--IMPL-BYME5I.md
@@ -1,0 +1,5 @@
+---
+from: BUG-FB0LN8
+relation: has-implementation
+to: IMPL-BYME5I
+---

--- a/tickets/relations/BUG-FB0LN8--has-review--REV-W8GUKB.md
+++ b/tickets/relations/BUG-FB0LN8--has-review--REV-W8GUKB.md
@@ -1,0 +1,5 @@
+---
+from: BUG-FB0LN8
+relation: has-review
+to: REV-W8GUKB
+---

--- a/tickets/relations/BUG-FB0LN8--has-review-response--RR-2IJL4Y.md
+++ b/tickets/relations/BUG-FB0LN8--has-review-response--RR-2IJL4Y.md
@@ -1,0 +1,5 @@
+---
+from: BUG-FB0LN8
+relation: has-review-response
+to: RR-2IJL4Y
+---

--- a/tickets/relations/BUG-FB0LN8--has-review-response--RR-2S0333.md
+++ b/tickets/relations/BUG-FB0LN8--has-review-response--RR-2S0333.md
@@ -1,0 +1,5 @@
+---
+from: BUG-FB0LN8
+relation: has-review-response
+to: RR-2S0333
+---

--- a/tickets/relations/BUG-FB0LN8--has-review-response--RR-805VYU.md
+++ b/tickets/relations/BUG-FB0LN8--has-review-response--RR-805VYU.md
@@ -1,0 +1,5 @@
+---
+from: BUG-FB0LN8
+relation: has-review-response
+to: RR-805VYU
+---

--- a/tickets/relations/BUG-FB0LN8--has-review-response--RR-9BET7H.md
+++ b/tickets/relations/BUG-FB0LN8--has-review-response--RR-9BET7H.md
@@ -1,0 +1,5 @@
+---
+from: BUG-FB0LN8
+relation: has-review-response
+to: RR-9BET7H
+---

--- a/tickets/relations/BUG-FB0LN8--has-review-response--RR-APWRJM.md
+++ b/tickets/relations/BUG-FB0LN8--has-review-response--RR-APWRJM.md
@@ -1,0 +1,5 @@
+---
+from: BUG-FB0LN8
+relation: has-review-response
+to: RR-APWRJM
+---

--- a/tickets/relations/BUG-FB0LN8--has-review-response--RR-DSAN9B.md
+++ b/tickets/relations/BUG-FB0LN8--has-review-response--RR-DSAN9B.md
@@ -1,0 +1,5 @@
+---
+from: BUG-FB0LN8
+relation: has-review-response
+to: RR-DSAN9B
+---

--- a/tickets/relations/BUG-FB0LN8--has-review-response--RR-F3QT0H.md
+++ b/tickets/relations/BUG-FB0LN8--has-review-response--RR-F3QT0H.md
@@ -1,0 +1,5 @@
+---
+from: BUG-FB0LN8
+relation: has-review-response
+to: RR-F3QT0H
+---

--- a/tickets/relations/BUG-FB0LN8--has-review-response--RR-F3Y9QA.md
+++ b/tickets/relations/BUG-FB0LN8--has-review-response--RR-F3Y9QA.md
@@ -1,0 +1,5 @@
+---
+from: BUG-FB0LN8
+relation: has-review-response
+to: RR-F3Y9QA
+---

--- a/tickets/relations/BUG-FB0LN8--has-review-response--RR-G0WF8A.md
+++ b/tickets/relations/BUG-FB0LN8--has-review-response--RR-G0WF8A.md
@@ -1,0 +1,5 @@
+---
+from: BUG-FB0LN8
+relation: has-review-response
+to: RR-G0WF8A
+---

--- a/tickets/relations/BUG-FB0LN8--has-review-response--RR-GSXOZ5.md
+++ b/tickets/relations/BUG-FB0LN8--has-review-response--RR-GSXOZ5.md
@@ -1,0 +1,5 @@
+---
+from: BUG-FB0LN8
+relation: has-review-response
+to: RR-GSXOZ5
+---

--- a/tickets/relations/BUG-FB0LN8--has-review-response--RR-IOZI72.md
+++ b/tickets/relations/BUG-FB0LN8--has-review-response--RR-IOZI72.md
@@ -1,0 +1,5 @@
+---
+from: BUG-FB0LN8
+relation: has-review-response
+to: RR-IOZI72
+---

--- a/tickets/relations/BUG-FB0LN8--has-review-response--RR-LFXFGW.md
+++ b/tickets/relations/BUG-FB0LN8--has-review-response--RR-LFXFGW.md
@@ -1,0 +1,5 @@
+---
+from: BUG-FB0LN8
+relation: has-review-response
+to: RR-LFXFGW
+---

--- a/tickets/relations/BUG-FB0LN8--has-review-response--RR-O0KRI2.md
+++ b/tickets/relations/BUG-FB0LN8--has-review-response--RR-O0KRI2.md
@@ -1,0 +1,5 @@
+---
+from: BUG-FB0LN8
+relation: has-review-response
+to: RR-O0KRI2
+---

--- a/tickets/relations/BUG-FB0LN8--has-review-response--RR-PZHJNN.md
+++ b/tickets/relations/BUG-FB0LN8--has-review-response--RR-PZHJNN.md
@@ -1,0 +1,5 @@
+---
+from: BUG-FB0LN8
+relation: has-review-response
+to: RR-PZHJNN
+---

--- a/tickets/relations/BUG-FB0LN8--has-review-response--RR-RK7ATG.md
+++ b/tickets/relations/BUG-FB0LN8--has-review-response--RR-RK7ATG.md
@@ -1,0 +1,5 @@
+---
+from: BUG-FB0LN8
+relation: has-review-response
+to: RR-RK7ATG
+---

--- a/tickets/relations/BUG-FB0LN8--has-review-response--RR-SH85S4.md
+++ b/tickets/relations/BUG-FB0LN8--has-review-response--RR-SH85S4.md
@@ -1,0 +1,5 @@
+---
+from: BUG-FB0LN8
+relation: has-review-response
+to: RR-SH85S4
+---

--- a/tickets/relations/BUG-FB0LN8--has-review-response--RR-VFQKCY.md
+++ b/tickets/relations/BUG-FB0LN8--has-review-response--RR-VFQKCY.md
@@ -1,0 +1,5 @@
+---
+from: BUG-FB0LN8
+relation: has-review-response
+to: RR-VFQKCY
+---

--- a/tickets/relations/BUG-FB0LN8--has-review-response--RR-WRUTYN.md
+++ b/tickets/relations/BUG-FB0LN8--has-review-response--RR-WRUTYN.md
@@ -1,0 +1,5 @@
+---
+from: BUG-FB0LN8
+relation: has-review-response
+to: RR-WRUTYN
+---

--- a/tickets/relations/BUG-FB0LN8--has-review-response--RR-Z1LUO5.md
+++ b/tickets/relations/BUG-FB0LN8--has-review-response--RR-Z1LUO5.md
@@ -1,0 +1,5 @@
+---
+from: BUG-FB0LN8
+relation: has-review-response
+to: RR-Z1LUO5
+---

--- a/tickets/relations/BUG-FB0LN8--has-review-response--RR-ZFRJMF.md
+++ b/tickets/relations/BUG-FB0LN8--has-review-response--RR-ZFRJMF.md
@@ -1,0 +1,5 @@
+---
+from: BUG-FB0LN8
+relation: has-review-response
+to: RR-ZFRJMF
+---

--- a/tickets/relations/TKT-7S5735--affects--data-entry-ui.md
+++ b/tickets/relations/TKT-7S5735--affects--data-entry-ui.md
@@ -1,0 +1,5 @@
+---
+from: TKT-7S5735
+relation: affects
+to: data-entry-ui
+---

--- a/tickets/relations/TKT-7S5735--implements--FEAT-LOCB0.md
+++ b/tickets/relations/TKT-7S5735--implements--FEAT-LOCB0.md
@@ -1,0 +1,5 @@
+---
+from: TKT-7S5735
+relation: implements
+to: FEAT-LOCB0
+---

--- a/tickets/relations/TKT-QHF4JQ--affects--data-entry-ui.md
+++ b/tickets/relations/TKT-QHF4JQ--affects--data-entry-ui.md
@@ -1,0 +1,5 @@
+---
+from: TKT-QHF4JQ
+relation: affects
+to: data-entry-ui
+---

--- a/tickets/relations/TKT-QHF4JQ--implements--FEAT-LOCB0.md
+++ b/tickets/relations/TKT-QHF4JQ--implements--FEAT-LOCB0.md
@@ -1,0 +1,5 @@
+---
+from: TKT-QHF4JQ
+relation: implements
+to: FEAT-LOCB0
+---


### PR DESCRIPTION
> **Depends on #1291** (the `_fields` tombstone) — its commits are included here.
> CI only triggers on PRs targeting `main`/`develop`, so this targets `develop` directly
> rather than stacking on #1291, which would have left the largest PR entirely unverified.
> Merge #1291 first; this will then show only its own changes.

## The bug

Toggling a `visible_when` condition off **deleted the conditional field's stored value server-side**, and the render gate then refused to draw a field whose key was missing — so the data was gone AND unrecoverable through the UI, from a single dropdown toggle, with a green "Saved" indicator.

Reported against public-procurement submission deadlines, where a missing date means automatic exclusion from a tender.

## Root cause

Form **structure** (does this field exist?) was answered by inspecting form **data** (is this key present?). So anything that removed a value also removed the field. Two individually-reasonable mechanisms, jointly destructive:

- prune-on-hide guaranteed the key was absent
- render-requires-key guaranteed it stayed hidden

Edit-mode pruning had never been justified on its own terms — it arrived as "the edit-mode analogue of create's prune", a symmetry that doesn't hold: on create the pruned value was typed this session into an abandoned branch (nothing lost); on edit it may be pre-existing data the user never touched.

## Fix

- **Renderability from the metamodel's declared properties**, not key presence.
- **Hidden values retained in their own ref**, never `formData` — so hide → reveal is lossless and every existing `formData` consumer is untouched (the autosave disappeared-key sweep, condition bindings, the create-path prune).
- **The visibility watcher no longer unsets server-side.** A UI visibility change must not mutate stored data as a side effect. Its RR-U9ERK error-clearing effect is preserved.
- **New per-field `clear_when_hidden: no | yes`** (default `no`), allowlist-validated so a typo cannot silently select the destructive branch. A field on a conditional *step* needs no `visible_when` of its own.
- **Create path unchanged** — RR-O4SRG's drop-on-commit stands.

## Scope note: `confirm` is deliberately not accepted

An interactive `confirm` policy (ask before clearing, undo the trigger on decline) was built, then **removed**. It needs the form to separate *"the user proposed a change"* from *"the change was committed"* — today `updateField` mutates `formData` and arms the autosave in one step, so a decline must reconstruct state after the fact. Three attempts each passed their tests and each then failed in manual use.

A config using `confirm` now **fails validation at author time**. A value that silently behaves differently from its name is the exact trap that caused this bug. Tracked as TKT-7S5735 (propose/commit refactor), with `confirm` as its first consumer.

## Verification

- The e2e test that asserted the destructive behavior as intended (AC5) is **inverted**; the old behavior is re-pinned under `clear_when_hidden: yes`.
- New e2e coverage for the reveal direction — hide → reveal restores the field **and its value** — which nothing covered before, and which is what made the loss unrecoverable rather than merely lossy. Also reload persistence and mixed policies in one pass.
- **Proven non-vacuous**: reverting `DynamicForm.vue` makes 5 of 6 new e2e tests fail.

Go suite / lint / arch-lint / plimsoll clean, coverage 77.2%, 1452 frontend unit, 235 e2e.

## Reviewer notes

- **`useAutoSave.cancelPendingField` is dead code**, deliberately: tested, unused, kept as the "drop a staged write without side effects" primitive the TKT-7S5735 reject path needs. Happy to drop it if you'd rather it land with its consumer.
- **Observed one e2e flake**: `a hidden-then-revealed field survives a page reload` failed once under full-suite parallelism, then passed in isolation and across three subsequent full runs. May recur in CI.