### PR TITLE
Unified targeted-write primitive: entitymanager.PatchEntity (TKT-80EWGM)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,14 +67,26 @@
   never inferred from identity. Write-prep reads (entitymanager
   diffing) keep raw store access: a redacted read-modify-write would
   clobber hidden fields.
-- **Never redact a read that feeds a write.** Read-out and write-prep are
-  different handles on purpose (`lua.ReadDeps.VisibleReader` vs
-  `WritePrepStore`). A read-modify-write that loads a *redacted* entity
-  drops the caller's hidden properties from the clone and **erases them on
-  save** — silent data destruction. If you find yourself "tidying" two
-  store handles into one, that is the bug: `luaUpdateEntity` and anything
-  like it must keep the raw handle. Pinned by
-  `TestScriptReads_UpdatePreservesHiddenProperties`.
+- **Partial writes go through `entitymanager.Manager.PatchEntity`, never
+  read-modify-write.** Name the properties you are changing in an
+  `entity.Patch` (`Properties` upserts, `MetaUnset` removes, `Content` is a
+  `*string` tri-state) and the manager merges them against the raw stored
+  entity internally. Properties you do not name are preserved — **forgetting
+  one is a no-op, not an erasure.**
+
+  The alternative — `GetEntity` → clone → merge → `UpdateEntity` — requires
+  holding the *whole* entity, so anything you failed to carry across is
+  destroyed on save. That is unrecoverable when the read was redacted: a
+  caller who cannot see a property cannot carry it, and silently deletes it.
+  This used to be guarded by prose and a raw `lua.ReadDeps.WritePrepStore`
+  handle; TKT-80EWGM removed both, so the mistake is now unavailable rather
+  than merely discouraged. Pinned by `TestPatchEntity_PreservesUnnamedProperties`
+  and `TestScriptReads_UpdatePreservesHiddenProperties`.
+
+  `UpdateEntity` still exists for callers that legitimately own the whole
+  entity (a form save that renders every field). `ApplyEntity` is the
+  whole-record replace the sync channel needs. If you are writing a *subset*,
+  you want `PatchEntity`.
 - **The configuration is not a secret; the data is.** `metamodel.yaml`,
   `data-entry.yaml`, `acl.yaml`, `schedules.yaml`, `scripts/`, `actions/`,
   `templates/` are operator-authored files that live in the repo — routinely a

--- a/docs-project/entities/guides/GUIDE-cli-reference.md
+++ b/docs-project/entities/guides/GUIDE-cli-reference.md
@@ -283,26 +283,52 @@ rela update <id> [flags]
 
 **Flags:**
 
-| Flag                | Description     |
-| ------------------- | --------------- |
-| `-t, --title`       | New title       |
-| `-s, --status`      | New status      |
-| `-p, --priority`    | New priority    |
-| `-d, --description` | New description |
+| Flag                | Description                                             |
+| ------------------- | ------------------------------------------------------- |
+| `-t, --title`       | New title                                               |
+| `-s, --status`      | New status                                              |
+| `-p, --priority`    | New priority                                            |
+| `-d, --description` | New description                                         |
+| `-P, --property`    | Set a property (`key=value`, repeatable)                |
+| `-U, --unset`       | Remove a property entirely (repeatable)                 |
+| `-b, --body`        | Replace the markdown body                               |
+| `-B, --body-file`   | Read the body from a file (`-` for stdin)               |
+| `--clear-body`      | Remove the markdown body                                |
+| `--strict`          | Exit 1 if soft validation warnings are surfaced         |
 
 At least one flag is required.
+
+**Updates are targeted.** Only the properties you name are changed;
+everything else on the entity is left exactly as it was. There is no need
+to re-supply fields you are not editing, and no risk of blanking them by
+omission.
+
+**`-P key=` and `-U key` are different.** `-P key=` _sets the property to
+the empty string_ (the key remains, with an empty value). `-U key` _removes
+the property altogether_. Use `-U` when you mean "this no longer applies";
+use `-P key=` when you mean "this is known to be blank".
 
 **Examples:**
 
 ```bash
-# Update status
+# Update status — every other property is untouched
 rela update REQ-001 --status accepted
 
 # Update multiple fields
 rela update DEC-042 --title "Revised title" --status proposed
 
-# Update description
-rela update SOL-001 --description "Detailed implementation notes"
+# Set an arbitrary property
+rela update REQ-001 -P owner=alice
+
+# Set a property to the empty string (key kept)
+rela update REQ-001 -P owner=
+
+# Remove a property entirely (key gone)
+rela update REQ-001 -U owner
+
+# Replace the body, then clear it
+rela update REQ-001 --body "New notes"
+rela update REQ-001 --clear-body
 ```
 
 ---

--- a/docs-project/entities/guides/GUIDE-cli-reference.md
+++ b/docs-project/entities/guides/GUIDE-cli-reference.md
@@ -308,6 +308,10 @@ the empty string_ (the key remains, with an empty value). `-U key` _removes
 the property altogether_. Use `-U` when you mean "this no longer applies";
 use `-P key=` when you mean "this is known to be blank".
 
+`-B/--body-file` is honored even when the file is empty — naming a source is
+an explicit instruction. Use `--clear-body` when you mean to clear the body,
+and note the two cannot be combined.
+
 **Examples:**
 
 ```bash

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -277,26 +277,52 @@ rela update <id> [flags]
 
 **Flags:**
 
-| Flag                | Description     |
-| ------------------- | --------------- |
-| `-t, --title`       | New title       |
-| `-s, --status`      | New status      |
-| `-p, --priority`    | New priority    |
-| `-d, --description` | New description |
+| Flag                | Description                                             |
+| ------------------- | ------------------------------------------------------- |
+| `-t, --title`       | New title                                               |
+| `-s, --status`      | New status                                              |
+| `-p, --priority`    | New priority                                            |
+| `-d, --description` | New description                                         |
+| `-P, --property`    | Set a property (`key=value`, repeatable)                |
+| `-U, --unset`       | Remove a property entirely (repeatable)                 |
+| `-b, --body`        | Replace the markdown body                               |
+| `-B, --body-file`   | Read the body from a file (`-` for stdin)               |
+| `--clear-body`      | Remove the markdown body                                |
+| `--strict`          | Exit 1 if soft validation warnings are surfaced         |
 
 At least one flag is required.
+
+**Updates are targeted.** Only the properties you name are changed;
+everything else on the entity is left exactly as it was. There is no need
+to re-supply fields you are not editing, and no risk of blanking them by
+omission.
+
+**`-P key=` and `-U key` are different.** `-P key=` _sets the property to
+the empty string_ (the key remains, with an empty value). `-U key` _removes
+the property altogether_. Use `-U` when you mean "this no longer applies";
+use `-P key=` when you mean "this is known to be blank".
 
 **Examples:**
 
 ```bash
-# Update status
+# Update status — every other property is untouched
 rela update REQ-001 --status accepted
 
 # Update multiple fields
 rela update DEC-042 --title "Revised title" --status proposed
 
-# Update description
-rela update SOL-001 --description "Detailed implementation notes"
+# Set an arbitrary property
+rela update REQ-001 -P owner=alice
+
+# Set a property to the empty string (key kept)
+rela update REQ-001 -P owner=
+
+# Remove a property entirely (key gone)
+rela update REQ-001 -U owner
+
+# Replace the body, then clear it
+rela update REQ-001 --body "New notes"
+rela update REQ-001 --clear-body
 ```
 
 ---

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -302,6 +302,10 @@ the empty string_ (the key remains, with an empty value). `-U key` _removes
 the property altogether_. Use `-U` when you mean "this no longer applies";
 use `-P key=` when you mean "this is known to be blank".
 
+`-B/--body-file` is honored even when the file is empty — naming a source is
+an explicit instruction. Use `--clear-body` when you mean to clear the body,
+and note the two cannot be combined.
+
 **Examples:**
 
 ```bash

--- a/internal/analysis/analysis_test.go
+++ b/internal/analysis/analysis_test.go
@@ -47,10 +47,9 @@ func newServiceWith(t *testing.T, meta *metamodel.Metamodel, seed func(store.Sto
 		Meta:   meta,
 		Tracer: tr,
 		LuaReadDeps: lua.ReadDeps{
-			VisibleReader:  st,
-			WritePrepStore: st,
-			Tracer:         tr,
-			Meta:           meta,
+			VisibleReader: st,
+			Tracer:        tr,
+			Meta:          meta,
 		},
 	})
 	if err != nil {

--- a/internal/appbuild/appbuild.go
+++ b/internal/appbuild/appbuild.go
@@ -197,12 +197,11 @@ func (s *Services) LuaReadDeps() lua.ReadDeps {
 		root = s.paths.Root
 	}
 	return lua.ReadDeps{
-		VisibleReader:  visibility.Unrestricted(s.store),
-		WritePrepStore: s.store,
-		Tracer:         s.tracer,
-		Searcher:       s.searcher,
-		Meta:           s.meta,
-		ProjectRoot:    root,
+		VisibleReader: visibility.Unrestricted(s.store),
+		Tracer:        s.tracer,
+		Searcher:      s.searcher,
+		Meta:          s.meta,
+		ProjectRoot:   root,
 	}
 }
 
@@ -231,7 +230,6 @@ func (s *Services) LuaReadDeps() lua.ReadDeps {
 // raw store.
 func (s *Services) luaReadDepsFor(redactor visibility.FieldRedactor) lua.ReadDeps {
 	deps := s.LuaReadDeps()
-	// WritePrepStore stays RAW on purpose — see lua.ReadDeps.WritePrepStore.
 	deps.VisibleReader = scriptEntityReader(s.store, s.aclDeclarative, redactor)
 	deps.Tracer = scriptTracer(s.tracer, s.store, s.aclDeclarative, redactor)
 	return deps
@@ -828,12 +826,11 @@ func assemble(
 	// deliberately NOT a config default; it is TKT-ACSBSA (an admin-handle
 	// extension), so a cascade that needs more must ask for it in the open.
 	readDeps := lua.ReadDeps{
-		VisibleReader:  scriptEntityReader(st, aclDeclarative, nil),
-		WritePrepStore: st,
-		Tracer:         scriptTracer(tr, st, aclDeclarative, nil),
-		Searcher:       searcher,
-		Meta:           base.meta,
-		ProjectRoot:    cfg.Paths.Root,
+		VisibleReader: scriptEntityReader(st, aclDeclarative, nil),
+		Tracer:        scriptTracer(tr, st, aclDeclarative, nil),
+		Searcher:      searcher,
+		Meta:          base.meta,
+		ProjectRoot:   cfg.Paths.Root,
 	}
 
 	tw, err := CompileTransitions(base.meta, st, resolvedACL)

--- a/internal/appbuild/appbuild.go
+++ b/internal/appbuild/appbuild.go
@@ -858,6 +858,7 @@ func assemble(
 		VersionRecorder:         versionRecorderFor(versions),
 		RelationVersionRecorder: relationVersionRecorderFor(versions),
 		Transitions:             tw.Enforcer,
+		FieldGate:               entitymanager.AllowAllFieldGate{},
 		TransitionGuard:         tw.Guard,
 		TransitionGraph:         tw.Graph,
 	})

--- a/internal/appbuild/appbuild_test.go
+++ b/internal/appbuild/appbuild_test.go
@@ -107,7 +107,7 @@ func TestDiscover_LuaDepsDerivable(t *testing.T) {
 	defer svc.Close()
 
 	read := svc.LuaReadDeps()
-	if read.VisibleReader == nil || read.WritePrepStore == nil || read.Tracer == nil || read.Meta == nil {
+	if read.VisibleReader == nil || read.Tracer == nil || read.Meta == nil {
 		t.Errorf("LuaReadDeps incomplete: %+v", read)
 	}
 	// The nil check above no longer proves the reader is wired to a store:

--- a/internal/appbuild/appbuildtest/fixture.go
+++ b/internal/appbuild/appbuildtest/fixture.go
@@ -193,6 +193,7 @@ func New(meta *metamodel.Metamodel, opts ...Option) *appbuild.Services {
 			},
 		),
 		Transitions:     tw.Enforcer,
+		FieldGate:       entitymanager.AllowAllFieldGate{},
 		TransitionGuard: tw.Guard,
 		TransitionGraph: tw.Graph,
 	})

--- a/internal/appbuild/appbuildtest/fixture.go
+++ b/internal/appbuild/appbuildtest/fixture.go
@@ -306,12 +306,11 @@ func buildReadDeps(st store.Store, tr tracer.Tracer, searcher search.Searcher,
 	// Test fixture: unrestricted reads (no ACL wiring here). Production
 	// identity-bearing paths use Services.luaReadDepsFor instead.
 	return lua.ReadDeps{
-		VisibleReader:  visibility.Unrestricted(st),
-		WritePrepStore: st,
-		Tracer:         tr,
-		Searcher:       searcher,
-		Meta:           meta,
-		ProjectRoot:    root,
+		VisibleReader: visibility.Unrestricted(st),
+		Tracer:        tr,
+		Searcher:      searcher,
+		Meta:          meta,
+		ProjectRoot:   root,
 	}
 }
 

--- a/internal/appbuild/elevatedreads.go
+++ b/internal/appbuild/elevatedreads.go
@@ -14,9 +14,10 @@ import (
 //
 // The capability is inert until an action is allow_acl_bypass AND the
 // cascade Mutator offers ElevatedProvider — the same two keys that gate
-// elevated writes. The reader is deliberately the same raw store
-// readDeps.WritePrepStore holds, named through visibility.Unrestricted so
-// this ungated path shows up in the grep that enumerates them (TKT-1WV50C).
+// elevated writes. The reader is the raw store, named through
+// visibility.Unrestricted so this ungated path shows up in the grep that
+// enumerates them (TKT-1WV50C). Since TKT-80EWGM this is the ONLY raw read
+// a script runtime can reach — the always-present write-prep handle is gone.
 func cascadeScriptRunner(
 	engine *script.Engine, readDeps lua.ReadDeps, st store.Store, sink audit.Audit,
 ) *script.LuaScriptRunner {

--- a/internal/appbuild/luawiring_test.go
+++ b/internal/appbuild/luawiring_test.go
@@ -110,11 +110,20 @@ func TestScheduledLuaWriteDeps_WritePrepStaysRaw(t *testing.T) {
 	defer svc.Close()
 
 	deps := svc.ScheduledLuaWriteDeps()
-	if deps.WritePrepStore == nil {
-		t.Fatal("WritePrepStore is nil — rela.update_entity would fail")
+	if deps.VisibleReader == nil {
+		t.Fatal("VisibleReader is nil — scheduled script reads would deny outright")
 	}
-	if deps.VisibleReader == lua.EntityReader(deps.WritePrepStore) {
-		t.Error("VisibleReader and WritePrepStore are the same handle under a configured " +
-			"policy — either reads are ungated, or update_entity would erase hidden properties")
+	// Pre-TKT-80EWGM this asserted VisibleReader != WritePrepStore, because a
+	// second RAW handle rode along on every writer runtime for
+	// update_entity's read-before-write. That handle is gone: the binding
+	// patches through the manager now. The surviving invariants are that
+	// reads are gated, and that the only remaining ungated path stays
+	// opt-in.
+	if deps.VisibleReader == lua.EntityReader(st) {
+		t.Error("VisibleReader IS the raw store under a configured policy — reads are ungated")
+	}
+	if deps.ElevatedReader != nil {
+		t.Error("ElevatedReader is set on a scheduled runtime — " +
+			"the ungated read path must remain opt-in to allow_acl_bypass")
 	}
 }

--- a/internal/attachment/attachment_test.go
+++ b/internal/attachment/attachment_test.go
@@ -96,6 +96,7 @@ func setupAttachmentService(t *testing.T) attachmentFixture {
 		Audit:       audit.Nop{},
 		ACL:         acl.NopACL{},
 		Transitions: statemachine.EmptySet(),
+		FieldGate:   entitymanager.AllowAllFieldGate{},
 	})
 	if err != nil {
 		t.Fatalf("entitymanager.New: %v", err)

--- a/internal/autocascade/mutator.go
+++ b/internal/autocascade/mutator.go
@@ -27,6 +27,10 @@ import (
 type Mutator interface {
 	CreateEntity(ctx context.Context, e *entity.Entity, opts entity.CreateOptions) (*entity.CreateResult, error)
 	UpdateEntity(ctx context.Context, e *entity.Entity) (*entity.UpdateResult, error)
+	// PatchEntity applies a targeted set of property changes, preserving
+	// everything the patch does not name (TKT-80EWGM). Script runtimes use
+	// this for partial writes so they need no raw store handle.
+	PatchEntity(ctx context.Context, id string, p entity.Patch) (*entity.UpdateResult, error)
 	DeleteEntity(ctx context.Context, id string, cascade bool) (*entity.DeleteResult, error)
 	CreateRelation(ctx context.Context, from, relType, to string, opts entity.RelationOptions) (*entity.Relation, error)
 	DeleteRelation(ctx context.Context, from, relType, to string) error

--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -7,6 +7,9 @@ import (
 	"io"
 	"os"
 	"strings"
+
+	"github.com/Sourcehaven-BV/rela/internal/entity"
+	"github.com/Sourcehaven-BV/rela/internal/entitymanager"
 )
 
 // UpdateCmd updates an existing entity.
@@ -22,60 +25,66 @@ type UpdateCmd struct {
 	Priority    string   `short:"p" help:"New priority."`
 	Description string   `short:"d" help:"New description."`
 	Property    []string `short:"P" help:"Set a property (format: key=value, can be repeated)."`
-	Body        string   `short:"b" help:"Markdown body content for the entity."`
-	BodyFile    string   `name:"body-file" short:"B" help:"Read body content from file (use - for stdin)."`
-	Strict      bool     `help:"Exit with status 1 if soft validation warnings are surfaced."`
+	// Unset removes a property outright. Distinct from `-P key=`, which
+	// sets the EMPTY STRING and always has — changing that silently would
+	// break existing scripts, so removal gets its own flag.
+	Unset     []string `short:"U" help:"Remove a property entirely (can be repeated). Differs from -P key=, which sets an empty value."`
+	Body      string   `short:"b" help:"Markdown body content for the entity."`
+	BodyFile  string   `name:"body-file" short:"B" help:"Read body content from file (use - for stdin)."`
+	ClearBody bool     `name:"clear-body" help:"Remove the entity's markdown body."`
+	Strict    bool     `help:"Exit with status 1 if soft validation warnings are surfaced."`
 }
 
 // Run dispatches `rela update <id>`.
 func (c *UpdateCmd) Run(ctx context.Context, svc *writeServices) error {
-	entity, err := svc.Store.GetEntity(ctx, c.ID)
-	if err != nil {
-		return &entityNotFoundError{ID: c.ID}
-	}
+	// A targeted patch: name only the flags the operator passed. Properties
+	// that go unmentioned are preserved by the manager, so `rela update` can
+	// no longer clobber state it never read (TKT-80EWGM).
+	patch := entity.Patch{Properties: map[string]any{}}
 
-	changed := false
 	for _, prop := range c.Property {
 		key, value, parseErr := parsePropertyFlag(prop)
 		if parseErr != nil {
 			return parseErr
 		}
-		entity.SetString(key, value)
-		changed = true
+		patch.Properties[key] = value
 	}
+	patch.MetaUnset = append(patch.MetaUnset, c.Unset...)
 
-	if c.Title != "" {
-		entity.SetString("title", c.Title)
-		changed = true
-	}
-	if c.Status != "" {
-		entity.SetString("status", c.Status)
-		changed = true
-	}
-	if c.Priority != "" {
-		entity.SetString("priority", c.Priority)
-		changed = true
-	}
-	if c.Description != "" {
-		entity.SetString("description", c.Description)
-		changed = true
+	for key, value := range map[string]string{
+		"title":       c.Title,
+		"status":      c.Status,
+		"priority":    c.Priority,
+		"description": c.Description,
+	} {
+		if value != "" {
+			patch.Properties[key] = value
+		}
 	}
 
 	bodyContent, err := c.getBodyContent()
 	if err != nil {
 		return err
 	}
-	if bodyContent != "" {
-		entity.Content = bodyContent
-		changed = true
+	switch {
+	case c.ClearBody && bodyContent != "":
+		return errors.New("--clear-body cannot be combined with -b/--body or -B/--body-file")
+	case c.ClearBody:
+		empty := ""
+		patch.Content = &empty
+	case bodyContent != "":
+		patch.Content = &bodyContent
 	}
 
-	if !changed {
+	if patch.IsEmpty() {
 		return errors.New("no updates specified")
 	}
 
-	result, err := svc.EntityManager.UpdateEntity(ctx, entity)
+	result, err := svc.EntityManager.PatchEntity(ctx, c.ID, patch)
 	if err != nil {
+		if errors.Is(err, entitymanager.ErrEntityNotFound) {
+			return &entityNotFoundError{ID: c.ID}
+		}
 		return err
 	}
 

--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -62,16 +62,26 @@ func (c *UpdateCmd) Run(ctx context.Context, svc *writeServices) error {
 		}
 	}
 
+	// Check the FLAGS, not the resolved content: `--clear-body -B empty.md`
+	// is just as contradictory as `--clear-body -b text`, and testing the
+	// content would let the empty-file case through silently.
+	if c.ClearBody && (c.Body != "" || c.BodyFile != "") {
+		return errors.New("--clear-body cannot be combined with -b/--body or -B/--body-file")
+	}
+
 	bodyContent, err := c.getBodyContent()
 	if err != nil {
 		return err
 	}
 	switch {
-	case c.ClearBody && bodyContent != "":
-		return errors.New("--clear-body cannot be combined with -b/--body or -B/--body-file")
 	case c.ClearBody:
-		empty := ""
-		patch.Content = &empty
+		patch.Content = new("")
+	case c.BodyFile != "":
+		// An explicitly-supplied file wins even when it is empty or all
+		// whitespace: the operator named a source, so honor it rather than
+		// silently degrading to "no updates specified". Use --clear-body to
+		// clear deliberately.
+		patch.Content = &bodyContent
 	case bodyContent != "":
 		patch.Content = &bodyContent
 	}

--- a/internal/cli/update_test.go
+++ b/internal/cli/update_test.go
@@ -2,6 +2,8 @@ package cli
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"reflect"
 	"testing"
 
@@ -121,19 +123,60 @@ func TestUpdateCmd_BuildsTargetedPatch(t *testing.T) {
 // TestUpdateCmd_ClearBodyConflictsWithBody pins the guard: the two ways
 // of specifying a body are mutually exclusive, and the conflict is a
 // loud error rather than a silent precedence rule.
+//
+// The check is on the FLAGS, not the resolved content — otherwise
+// `--clear-body -B empty.md` would slip through, since an empty file
+// resolves to "" and would look like "no body was supplied".
 func TestUpdateCmd_ClearBodyConflictsWithBody(t *testing.T) {
-	cmd := UpdateCmd{ID: "TASK-1", ClearBody: true, Body: "text"}
-	p := &capturingPatcher{}
-
-	err := cmd.Run(context.Background(), &writeServices{
-		readServices:  readServices{},
-		EntityManager: p,
-	})
-	if err == nil {
-		t.Fatal("expected an error when --clear-body is combined with -b")
+	for _, tc := range []struct {
+		name string
+		cmd  UpdateCmd
+	}{
+		{"with --body", UpdateCmd{ID: "TASK-1", ClearBody: true, Body: "text"}},
+		{"with --body-file", UpdateCmd{ID: "TASK-1", ClearBody: true, BodyFile: "notes.md"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			p := &capturingPatcher{}
+			err := tc.cmd.Run(context.Background(), &writeServices{
+				readServices:  readServices{},
+				EntityManager: p,
+			})
+			if err == nil {
+				t.Fatal("expected an error when --clear-body is combined with a body source")
+			}
+			if p.called != 0 {
+				t.Error("a conflicting invocation must not reach the write path")
+			}
+		})
 	}
-	if p.called != 0 {
-		t.Error("a conflicting invocation must not reach the write path")
+}
+
+// TestUpdateCmd_EmptyBodyFileIsHonored pins that naming an empty file is
+// treated as an explicit instruction, not as "no updates specified". The
+// operator pointed at a source; degrading that to an error about supplying
+// nothing would be baffling.
+func TestUpdateCmd_EmptyBodyFileIsHonored(t *testing.T) {
+	captureOut(t)
+	dir := t.TempDir()
+	path := filepath.Join(dir, "empty.md")
+	if err := os.WriteFile(path, []byte("   \n"), 0o600); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+
+	p := &capturingPatcher{}
+	err := (&UpdateCmd{ID: "TASK-1", BodyFile: path}).Run(
+		context.Background(), &writeServices{
+			readServices:  readServices{},
+			EntityManager: p,
+		})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if p.gotPatch.Content == nil {
+		t.Fatal("Content = nil; an explicitly named body file must be honored")
+	}
+	if *p.gotPatch.Content != "" {
+		t.Errorf("Content = %q, want empty", *p.gotPatch.Content)
 	}
 }
 

--- a/internal/cli/update_test.go
+++ b/internal/cli/update_test.go
@@ -1,8 +1,12 @@
 package cli
 
 import (
+	"context"
 	"reflect"
 	"testing"
+
+	"github.com/Sourcehaven-BV/rela/internal/entity"
+	"github.com/Sourcehaven-BV/rela/internal/entitymanager/entitymanagertest"
 )
 
 // update_test.go covers only CLI-level concerns. The property flag
@@ -19,4 +23,156 @@ func TestUpdateCmd_PropertyFlagExists(t *testing.T) {
 	if got := f.Tag.Get("short"); got != "P" {
 		t.Errorf("Property field short tag = %q, want %q", got, "P")
 	}
+}
+
+// capturingPatcher records the patch the command built, so these tests
+// assert on the WIRE SHAPE the CLI produces rather than on storage.
+//
+// PanicOnUse supplies the rest of the interface: any write path other
+// than PatchEntity is a test failure, loudly.
+type capturingPatcher struct {
+	entitymanagertest.PanicOnUse
+	gotID    string
+	gotPatch entity.Patch
+	called   int
+}
+
+func (c *capturingPatcher) PatchEntity(
+	_ context.Context, id string, p entity.Patch,
+) (*entity.UpdateResult, error) {
+	c.called++
+	c.gotID, c.gotPatch = id, p
+	return &entity.UpdateResult{Entity: entity.New(id, "task")}, nil
+}
+
+// TestUpdateCmd_BuildsTargetedPatch pins the flag → patch translation,
+// including the two capabilities `rela update` gained in TKT-80EWGM
+// (remove a property, clear the body) and the one it deliberately did
+// NOT change (-P key= still sets the empty string).
+func TestUpdateCmd_BuildsTargetedPatch(t *testing.T) {
+	tests := []struct {
+		name       string
+		cmd        UpdateCmd
+		wantProps  map[string]any
+		wantUnset  []string
+		wantBody   *string
+		wantNoBody bool
+	}{
+		{
+			name:       "named property only — nothing else is touched",
+			cmd:        UpdateCmd{ID: "TASK-1", Title: "Renamed"},
+			wantProps:  map[string]any{"title": "Renamed"},
+			wantNoBody: true,
+		},
+		{
+			name:       "unset removes a property",
+			cmd:        UpdateCmd{ID: "TASK-1", Unset: []string{"due"}},
+			wantProps:  map[string]any{},
+			wantUnset:  []string{"due"},
+			wantNoBody: true,
+		},
+		{
+			name:       "-P key= sets an EMPTY STRING, it does not remove",
+			cmd:        UpdateCmd{ID: "TASK-1", Property: []string{"notes="}},
+			wantProps:  map[string]any{"notes": ""},
+			wantNoBody: true,
+		},
+		{
+			name:      "clear-body sends a pointer to empty",
+			cmd:       UpdateCmd{ID: "TASK-1", ClearBody: true},
+			wantProps: map[string]any{},
+			wantBody:  new(""),
+		},
+		{
+			name:      "body sets a pointer to the content",
+			cmd:       UpdateCmd{ID: "TASK-1", Body: "hello"},
+			wantProps: map[string]any{},
+			wantBody:  new("hello"),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := buildPatch(t, tc.cmd)
+
+			if len(got.Properties) != len(tc.wantProps) {
+				t.Errorf("Properties = %v, want %v", got.Properties, tc.wantProps)
+			}
+			for k, want := range tc.wantProps {
+				if got.Properties[k] != want {
+					t.Errorf("Properties[%q] = %v, want %v", k, got.Properties[k], want)
+				}
+			}
+			if len(got.MetaUnset) != len(tc.wantUnset) {
+				t.Errorf("MetaUnset = %v, want %v", got.MetaUnset, tc.wantUnset)
+			}
+			switch {
+			case tc.wantNoBody && got.Content != nil:
+				t.Errorf("Content = %q, want nil (body untouched)", *got.Content)
+			case tc.wantBody != nil && got.Content == nil:
+				t.Errorf("Content = nil, want %q", *tc.wantBody)
+			case tc.wantBody != nil && *got.Content != *tc.wantBody:
+				t.Errorf("Content = %q, want %q", *got.Content, *tc.wantBody)
+			}
+		})
+	}
+}
+
+// TestUpdateCmd_ClearBodyConflictsWithBody pins the guard: the two ways
+// of specifying a body are mutually exclusive, and the conflict is a
+// loud error rather than a silent precedence rule.
+func TestUpdateCmd_ClearBodyConflictsWithBody(t *testing.T) {
+	cmd := UpdateCmd{ID: "TASK-1", ClearBody: true, Body: "text"}
+	p := &capturingPatcher{}
+
+	err := cmd.Run(context.Background(), &writeServices{
+		readServices:  readServices{},
+		EntityManager: p,
+	})
+	if err == nil {
+		t.Fatal("expected an error when --clear-body is combined with -b")
+	}
+	if p.called != 0 {
+		t.Error("a conflicting invocation must not reach the write path")
+	}
+}
+
+// TestUpdateCmd_NoUpdatesSpecified pins that an empty patch is refused
+// rather than dispatched as a no-op write.
+func TestUpdateCmd_NoUpdatesSpecified(t *testing.T) {
+	p := &capturingPatcher{}
+
+	err := (&UpdateCmd{ID: "TASK-1"}).Run(context.Background(), &writeServices{
+		readServices:  readServices{},
+		EntityManager: p,
+	})
+	if err == nil {
+		t.Fatal("expected an error when no update flags were supplied")
+	}
+	if p.called != 0 {
+		t.Error("an empty patch must not reach the write path")
+	}
+}
+
+// buildPatch runs the command against a capturing fake and returns the
+// patch it produced. captureOut is required because Run writes progress
+// through the package-level output writer, which is nil by default in
+// tests (and is a mutable global, so these tests are not parallel).
+func buildPatch(t *testing.T, cmd UpdateCmd) entity.Patch {
+	t.Helper()
+	captureOut(t)
+	p := &capturingPatcher{}
+	if err := cmd.Run(context.Background(), &writeServices{
+		readServices:  readServices{},
+		EntityManager: p,
+	}); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if p.called != 1 {
+		t.Fatalf("PatchEntity called %d times, want 1", p.called)
+	}
+	if p.gotID != cmd.ID {
+		t.Errorf("patched id = %q, want %q", p.gotID, cmd.ID)
+	}
+	return p.gotPatch
 }

--- a/internal/dataentry/app.go
+++ b/internal/dataentry/app.go
@@ -316,18 +316,18 @@ func (a *App) Meta() *metamodel.Metamodel { return a.State().Meta }
 // script, an export_render override, or an MCP-invoked script sees exactly
 // the caller's view — hidden entities absent, hidden properties redacted.
 // Identity resolves per call from the ctx, so one bundle serves every
-// request. WritePrepStore stays RAW so update_entity's read-before-write
-// cannot erase hidden properties (see lua.ReadDeps.WritePrepStore).
+// request. Note there is no raw read handle here at all: update_entity
+// patches through the manager, which does its own write-prep read
+// (TKT-80EWGM), so a redacted read can no longer feed a write.
 func (a *App) luaWriteDeps() lua.WriteDeps {
 	redactor := appRedactor(a)
 	return lua.WriteDeps{
 		ReadDeps: lua.ReadDeps{
-			VisibleReader:  a.scriptReader(redactor),
-			WritePrepStore: a.store,
-			Tracer:         a.scriptTracer(redactor),
-			Searcher:       a.searcher,
-			Meta:           a.Meta(),
-			ProjectRoot:    a.paths.Root,
+			VisibleReader: a.scriptReader(redactor),
+			Tracer:        a.scriptTracer(redactor),
+			Searcher:      a.searcher,
+			Meta:          a.Meta(),
+			ProjectRoot:   a.paths.Root,
 		},
 		EntityManager: a.entityManager,
 	}
@@ -741,12 +741,11 @@ func NewApp(
 	// (ReadDeps.VisibleReader) both go through it.
 	gatedReader := lateGatedReader{app: app}
 	readDeps := lua.ReadDeps{
-		VisibleReader:  gatedReader,
-		WritePrepStore: st,
-		Tracer:         lateGatedTracer{app: app},
-		Searcher:       searcher,
-		Meta:           meta,
-		ProjectRoot:    paths.Root,
+		VisibleReader: gatedReader,
+		Tracer:        lateGatedTracer{app: app},
+		Searcher:      searcher,
+		Meta:          meta,
+		ProjectRoot:   paths.Root,
 	}
 	val := validator.New(gatedReader, meta, readDeps)
 	app.validator = val

--- a/internal/dataentry/document_script_test.go
+++ b/internal/dataentry/document_script_test.go
@@ -428,10 +428,9 @@ print(got)
 	deps := func() lua.WriteDeps {
 		return lua.WriteDeps{
 			ReadDeps: lua.ReadDeps{
-				VisibleReader:  st,
-				WritePrepStore: st,
-				Tracer:         tracer.New(st),
-				ProjectRoot:    projectRoot,
+				VisibleReader: st,
+				Tracer:        tracer.New(st),
+				ProjectRoot:   projectRoot,
 			},
 			EntityManager: entitymanagertest.PanicOnUse{},
 		}

--- a/internal/dataentry/luawiring_test.go
+++ b/internal/dataentry/luawiring_test.go
@@ -98,17 +98,23 @@ rela.output("nodes=" .. table.concat(walk(rela.trace_from("TKT-001", 2), {}), ",
 	}
 }
 
-// TestLuaWiring_WritePrepStoreStaysRaw pins the other half of the split at
-// the wiring level: the App must hand scripts a RAW write-prep handle, or
-// rela.update_entity would erase hidden properties on save.
-func TestLuaWiring_WritePrepStoreStaysRaw(t *testing.T) {
+// TestLuaWiring_NoRawReadHandleOnWriterDeps replaces the old
+// WritePrepStoreStaysRaw guard. That test asserted the App handed scripts a
+// RAW second store handle, because rela.update_entity read through it before
+// saving. Since TKT-80EWGM the binding patches through the manager instead,
+// so the correct invariant INVERTED: an ordinary writer runtime must carry
+// NO ungated read path at all.
+//
+// The property the old test protected — script reads are ACL-bound — is
+// still asserted here. What is gone is the hazard it was guarding: there is
+// no longer a second handle that could be pointed at the wrong reader.
+// Elevated reads remain available, but only via the explicitly opt-in
+// ElevatedReader (nil here, as this is not a bypass_acl runtime).
+func TestLuaWiring_NoRawReadHandleOnWriterDeps(t *testing.T) {
 	app := newTestAppV1(t)
 	seedEntity(app, &entity.Entity{ID: "TKT-001", Type: "ticket",
 		Properties: map[string]any{"title": "T"}})
 
-	// With a Declarative ACL configured, the two handles must DIFFER: reads
-	// gated, write-prep raw. (Without a policy both are the raw store — the
-	// NopACL path — which is why this test configures one.)
 	d := mustNewACL(t, &acl.Policy{
 		Roles:       map[string]acl.RoleDef{"viewer": {Read: []string{"ticket"}}},
 		Assignments: map[string]string{"alice": "viewer"},
@@ -116,15 +122,17 @@ func TestLuaWiring_WritePrepStoreStaysRaw(t *testing.T) {
 	app.acl = d
 
 	deps := app.luaWriteDeps()
-	if deps.WritePrepStore == nil {
-		t.Fatal("WritePrepStore is nil — rela.update_entity would fail")
-	}
-	if deps.WritePrepStore != app.store {
-		t.Errorf("WritePrepStore is not the raw store (%T) — a redacted "+
-			"read-before-write erases hidden properties on save", deps.WritePrepStore)
+	if deps.VisibleReader == nil {
+		t.Fatal("VisibleReader is nil — script reads would deny outright")
 	}
 	if deps.VisibleReader == lua.EntityReader(app.store) {
 		t.Error("VisibleReader IS the raw store under a configured policy — " +
 			"script reads are not ACL-bound")
+	}
+	// The elevated (raw) read path must stay opt-in: absent unless the
+	// runtime was built for an allow_acl_bypass action.
+	if deps.ElevatedReader != nil {
+		t.Error("ElevatedReader is set on an ordinary writer runtime — " +
+			"the ungated read path must remain opt-in")
 	}
 }

--- a/internal/dataentry/test_helpers_test.go
+++ b/internal/dataentry/test_helpers_test.go
@@ -142,12 +142,11 @@ func rebindApp(app *App, fs storage.FS, paths *project.Context, svc *appbuild.Se
 	// app.affordances being rebound below.
 	gatedReader := lateGatedReader{app: app}
 	app.validator = validator.New(gatedReader, svc.Meta(), lua.ReadDeps{
-		VisibleReader:  gatedReader,
-		WritePrepStore: svc.Store(),
-		Tracer:         lateGatedTracer{app: app},
-		Searcher:       svc.Searcher(),
-		Meta:           svc.Meta(),
-		ProjectRoot:    paths.Root,
+		VisibleReader: gatedReader,
+		Tracer:        lateGatedTracer{app: app},
+		Searcher:      svc.Searcher(),
+		Meta:          svc.Meta(),
+		ProjectRoot:   paths.Root,
 	})
 	app.analyze = analyzeService{reads: gatedReader, relCounts: svc.Store(), tracer: lateGatedTracer{app: app}, validator: app.validator}
 	app.templater = svc.Templater()

--- a/internal/docs/runtime.go
+++ b/internal/docs/runtime.go
@@ -157,10 +157,9 @@ func Build(ctx context.Context, src string, opts Options) (string, error) {
 	// build just seeded itself, and runs at the operator trust boundary
 	// (whoever builds the docs already has the project). No ACL applies.
 	readDeps := rlua.ReadDeps{
-		VisibleReader:  visibility.Unrestricted(st),
-		WritePrepStore: st,
-		Tracer:         dr.tracer,
-		Meta:           opts.Meta,
+		VisibleReader: visibility.Unrestricted(st),
+		Tracer:        dr.tracer,
+		Meta:          opts.Meta,
 	}
 	rt := rlua.NewReader(readDeps, dr.out, rlua.WithContext(ctx), rlua.WithTimeout(buildTimeout))
 	defer rt.Close()

--- a/internal/entity/writeapi.go
+++ b/internal/entity/writeapi.go
@@ -1,5 +1,7 @@
 package entity
 
+import "maps"
+
 // This file holds the shared write-API vocabulary used by every
 // caller that mutates the graph: options, result envelopes, and the
 // soft-validation Warning struct. The types live in `entity` rather
@@ -110,4 +112,67 @@ type RelationOptions struct {
 	Properties map[string]any
 	MetaUnset  []string
 	Content    *string
+}
+
+// Patch describes a TARGETED entity write: apply exactly these
+// property changes and leave everything else alone. It is the entity-side
+// analog of [RelationOptions] on the update path, and deliberately shares
+// its vocabulary (Properties merges, MetaUnset removes, Content is a
+// pointer tri-state).
+//
+// The contract that makes it worth having: **properties not named are
+// preserved as-is, regardless of whether the caller could read them.** A
+// caller who can see 3 of an entity's 10 properties can patch those 3
+// without touching the other 7 — so forgetting a property yields a no-op,
+// not an erasure. Contrast a whole-entity save, where every property the
+// caller failed to supply is silently destroyed.
+//
+// Semantics:
+//
+//   - Properties MERGES into the stored entity's properties. An empty or
+//     nil map changes nothing; it does NOT clear existing keys.
+//   - MetaUnset removes the named keys and is applied AFTER the merge, so
+//     a patch naming the same key in both ends with it removed. Unsetting
+//     an absent key is a no-op, not an error.
+//   - Content non-nil replaces the body with *Content (including the empty
+//     string, which clears it); nil leaves the body untouched.
+//
+// The pointer-vs-string distinction on Content is the only way to express
+// "leave the body alone" vs "set the body to empty" — same rationale as
+// [RelationOptions.Content].
+type Patch struct {
+	Properties map[string]any
+	MetaUnset  []string
+	Content    *string
+}
+
+// IsEmpty reports whether the patch would change nothing: no property
+// upserts, no unsets, and no body replacement. Callers that treat a
+// no-op patch specially (skipping the write entirely) can check this
+// before dispatching.
+func (p Patch) IsEmpty() bool {
+	return len(p.Properties) == 0 && len(p.MetaUnset) == 0 && p.Content == nil
+}
+
+// Apply merges the patch into e, mutating it in place. Order is
+// upserts-then-unset (see [Patch]); the body is replaced only when
+// Content is non-nil.
+//
+// Values are assigned directly rather than through [Entity.SetString] so
+// non-string property types (lists, numbers, bools) survive the round trip
+// with their declared shape intact.
+func (p Patch) Apply(e *Entity) {
+	if e == nil {
+		return
+	}
+	if len(p.Properties) > 0 && e.Properties == nil {
+		e.Properties = make(map[string]any, len(p.Properties))
+	}
+	maps.Copy(e.Properties, p.Properties)
+	for _, k := range p.MetaUnset {
+		delete(e.Properties, k)
+	}
+	if p.Content != nil {
+		e.Content = *p.Content
+	}
 }

--- a/internal/entitymanager/CLAUDE.md
+++ b/internal/entitymanager/CLAUDE.md
@@ -6,6 +6,56 @@ and consults the ACL. All entity/relation writes go through here — do not
 write directly to `store.Store` from a write path, or the audit record
 won't be emitted.
 
+## Which write method
+
+| Situation | Method |
+|---|---|
+| Changing a SUBSET of properties | `PatchEntity` |
+| Caller legitimately owns the whole entity (form save rendering every field) | `UpdateEntity` |
+| Whole-record replace from a trusted replica (sync channel) | `ApplyEntity` |
+
+**Default to `PatchEntity`.** It takes an `entity.Patch` (`Properties`
+upserts, `MetaUnset` removes, `Content` is a `*string` tri-state), does its
+own write-prep read, and merges against the raw stored entity. Properties
+the patch does not name are preserved regardless of whether the caller
+could read them — so a caller holding a redacted view cannot erase what it
+cannot see. `UpdateEntity` gives you no such protection: it saves exactly
+the entity you hand it, so every property you failed to carry across is
+gone.
+
+`UpdateEntity` and `PatchEntity` share `updateCore`, so they cannot drift
+on validation, automation, transitions, unique checks, audit, or cascade.
+Attribution and authorization deliberately stay in the entry points —
+`updateCore` has no ACL check, mirroring `createCore`. Do not move them in:
+`PatchEntity` must authorize early (it needs the stored type for the ACL
+subject), so an authorize inside the core would double-authorize and emit
+two `denied-write` rows for one denial.
+
+### PatchEntity ordering is load-bearing
+
+```text
+read (raw) → IsLocked guard → authorize → field gate → merge → updateCore
+```
+
+- The **read comes first** because `acl.EntitySubject` needs the entity's
+  real type and the caller supplied only an id. Same shape, and the same
+  accepted existence disclosure, as `DeleteEntity`.
+- The **field gate runs strictly after authorization**. Field verdicts are
+  value-dependent, so consulting them for an unauthorized caller would leak
+  both entity existence and stored property values through the
+  allow-vs-deny difference. (Naming the *rule* in a denial is fine — config
+  is not a secret. The leak is about data.)
+- `Deps.FieldGate` is **required**, with `AllowAllFieldGate{}` as the named
+  opt-out for operator-trust-boundary surfaces like the CLI. A nil gate is
+  rejected at `New` rather than silently permitting everything.
+- The gate constrains **caller-authored** changes only. Automation-derived
+  properties are system writes and are deliberately not gated, or a user who
+  cannot author `status` could never trigger an automation that sets it.
+- **Elevation is total**: `bypass_acl` skips the field gate as well as the
+  row ACL, and `recordACLBypass` still fires. A half-elevated handle that
+  silently drops some property writes is the confusing contract the
+  elevated-read seam exists to avoid.
+
 ## Audit log
 
 Every successful entity/relation create/update/delete/rename is audited as
@@ -13,8 +63,12 @@ a JSONL record under `.rela/audit/YYYY-MM-DD.jsonl`. See `docs/audit-log.md`
 for the user-facing reference. Rules for new code:
 
 - **New write paths inherit audit automatically.** Any code calling
-  `Manager.{Create,Update,Delete,Rename}{Entity,Relation}` produces a
-  record without further wiring. Do not bypass Manager.
+  `Manager.{Create,Update,Patch,Delete,Rename}{Entity,Relation}` produces a
+  record without further wiring. Do not bypass Manager. Note this is a
+  property of the shared pipeline, not of the method name: `PatchEntity`
+  audits because it routes through `updateCore`. A new entry point that
+  reimplements the pipeline instead of calling the shared core would NOT
+  inherit audit — that is the thing to check in review.
 - **New entry-point binaries stamp Principal at startup**, once:
   `ctx = principal.With(ctx, principal.Principal{User: principal.SystemUser(), Tool: principal.ToolXxx})`.
   Use a `principal.ToolCLI`/`ToolMCP`/`ToolDataEntry`/`ToolScheduler`/

--- a/internal/entitymanager/acl_bypass_test.go
+++ b/internal/entitymanager/acl_bypass_test.go
@@ -134,6 +134,7 @@ func TestManager_Elevated_DoesNotLeakIntoNestedCascade(t *testing.T) {
 		Audit:        audit.Nop{},
 		ACL:          acl.ReadOnlyACL{}, // deny-all, so a gated write is refused
 		Transitions:  statemachine.EmptySet(),
+		FieldGate:    entitymanager.AllowAllFieldGate{},
 		Automations:  engine,
 		Cascade:      runner,
 		ScriptRunner: scripts,

--- a/internal/entitymanager/acl_test.go
+++ b/internal/entitymanager/acl_test.go
@@ -31,6 +31,7 @@ func newManagerWithACL(
 		Audit:       sink,
 		ACL:         aclImpl,
 		Transitions: statemachine.EmptySet(),
+		FieldGate:   entitymanager.AllowAllFieldGate{},
 	})
 	if err != nil {
 		t.Fatalf("entitymanager.New: %v", err)
@@ -51,6 +52,7 @@ func seedEntity(t *testing.T, store *countingStore, entityType, title string) {
 		Audit:       audit.Nop{},
 		ACL:         acl.NopACL{},
 		Transitions: statemachine.EmptySet(),
+		FieldGate:   entitymanager.AllowAllFieldGate{},
 	})
 	if err != nil {
 		t.Fatalf("seedEntity: New: %v", err)
@@ -72,6 +74,7 @@ func seedRelation(t *testing.T, store *countingStore, from, relType, to string) 
 		Audit:       audit.Nop{},
 		ACL:         acl.NopACL{},
 		Transitions: statemachine.EmptySet(),
+		FieldGate:   entitymanager.AllowAllFieldGate{},
 	})
 	if err != nil {
 		t.Fatalf("seedRelation: New: %v", err)
@@ -373,7 +376,8 @@ role_relations:
 	// We rebuild the Manager with the real ACL once the data is in.
 	store := &countingStore{Store: memstore.New()}
 	seedMgr, err := entitymanager.New(entitymanager.Deps{
-		Store: store, Meta: meta, Templater: nopTemplater{},
+		FieldGate: entitymanager.AllowAllFieldGate{},
+		Store:     store, Meta: meta, Templater: nopTemplater{},
 		Audit: audit.Nop{}, ACL: acl.NopACL{}, Transitions: statemachine.EmptySet(),
 	})
 	if err != nil {
@@ -421,7 +425,8 @@ role_relations:
 		t.Fatalf("NewDeclarative: %v", err)
 	}
 	mgr, err := entitymanager.New(entitymanager.Deps{
-		Store: store, Meta: meta, Templater: nopTemplater{},
+		FieldGate: entitymanager.AllowAllFieldGate{},
+		Store:     store, Meta: meta, Templater: nopTemplater{},
 		Audit: sink, ACL: declarative, Transitions: statemachine.EmptySet(),
 	})
 	if err != nil {
@@ -536,7 +541,8 @@ assignments:
 
 	store := &countingStore{Store: memstore.New()}
 	seedMgr, err := entitymanager.New(entitymanager.Deps{
-		Store: store, Meta: meta, Templater: nopTemplater{},
+		FieldGate: entitymanager.AllowAllFieldGate{},
+		Store:     store, Meta: meta, Templater: nopTemplater{},
 		Audit: audit.Nop{}, ACL: acl.NopACL{}, Transitions: statemachine.EmptySet(),
 	})
 	if err != nil {
@@ -571,7 +577,8 @@ assignments:
 		t.Fatalf("NewDeclarative: %v", err)
 	}
 	mgr, err := entitymanager.New(entitymanager.Deps{
-		Store: store, Meta: meta, Templater: nopTemplater{},
+		FieldGate: entitymanager.AllowAllFieldGate{},
+		Store:     store, Meta: meta, Templater: nopTemplater{},
 		Audit: sink, ACL: declarative, Transitions: statemachine.EmptySet(),
 	})
 	if err != nil {

--- a/internal/entitymanager/apply_conflict_test.go
+++ b/internal/entitymanager/apply_conflict_test.go
@@ -66,7 +66,8 @@ func TestApplyEntity_CreateConflict_RejectsAndDoesNotClobber(t *testing.T) {
 
 	st := &raceCreateStore{Store: inner}
 	mgr, err := entitymanager.New(entitymanager.Deps{
-		Store: st, Meta: meta, Templater: nopTemplater{}, Audit: audit.Nop{}, ACL: acl.NopACL{}, Transitions: statemachine.EmptySet(),
+		FieldGate: entitymanager.AllowAllFieldGate{},
+		Store:     st, Meta: meta, Templater: nopTemplater{}, Audit: audit.Nop{}, ACL: acl.NopACL{}, Transitions: statemachine.EmptySet(),
 	})
 	if err != nil {
 		t.Fatalf("entitymanager.New: %v", err)
@@ -114,7 +115,8 @@ func TestApplyEntity_SameTypeCreateConflict_NoClobber(t *testing.T) {
 
 	st := &raceCreateStore{Store: inner}
 	mgr, err := entitymanager.New(entitymanager.Deps{
-		Store: st, Meta: meta, Templater: nopTemplater{}, Audit: audit.Nop{}, ACL: acl.NopACL{}, Transitions: statemachine.EmptySet(),
+		FieldGate: entitymanager.AllowAllFieldGate{},
+		Store:     st, Meta: meta, Templater: nopTemplater{}, Audit: audit.Nop{}, ACL: acl.NopACL{}, Transitions: statemachine.EmptySet(),
 	})
 	if err != nil {
 		t.Fatalf("entitymanager.New: %v", err)
@@ -172,7 +174,8 @@ func TestApplyEntity_UpdateVanished_RejectsWithoutCreating(t *testing.T) {
 		stored: &entity.Entity{ID: "NOTE-1", Type: "note", Properties: map[string]any{"title": "v1"}},
 	}
 	mgr, err := entitymanager.New(entitymanager.Deps{
-		Store: st, Meta: meta, Templater: nopTemplater{}, Audit: audit.Nop{}, ACL: acl.NopACL{}, Transitions: statemachine.EmptySet(),
+		FieldGate: entitymanager.AllowAllFieldGate{},
+		Store:     st, Meta: meta, Templater: nopTemplater{}, Audit: audit.Nop{}, ACL: acl.NopACL{}, Transitions: statemachine.EmptySet(),
 	})
 	if err != nil {
 		t.Fatalf("entitymanager.New: %v", err)

--- a/internal/entitymanager/apply_test.go
+++ b/internal/entitymanager/apply_test.go
@@ -24,6 +24,7 @@ func newApplyManager(t *testing.T, st store.Store, sink audit.Audit) *entitymana
 		Audit:       sink,
 		ACL:         acl.NopACL{},
 		Transitions: statemachine.EmptySet(),
+		FieldGate:   entitymanager.AllowAllFieldGate{},
 	})
 	if err != nil {
 		t.Fatalf("entitymanager.New: %v", err)
@@ -404,7 +405,8 @@ func TestApplyRelation_EndpointProbeFailsClosed(t *testing.T) {
 func seedViaManager(t *testing.T, st store.Store, id, typ string) {
 	t.Helper()
 	mgr, err := entitymanager.New(entitymanager.Deps{
-		Store: st, Meta: parseMeta(t), Templater: nopTemplater{}, Audit: audit.Nop{}, ACL: acl.NopACL{}, Transitions: statemachine.EmptySet(),
+		FieldGate: entitymanager.AllowAllFieldGate{},
+		Store:     st, Meta: parseMeta(t), Templater: nopTemplater{}, Audit: audit.Nop{}, ACL: acl.NopACL{}, Transitions: statemachine.EmptySet(),
 	})
 	if err != nil {
 		t.Fatalf("seedViaManager: %v", err)
@@ -422,7 +424,8 @@ func seedViaManager(t *testing.T, st store.Store, id, typ string) {
 func TestApplyEntity_ACLDenied(t *testing.T) {
 	st := memstore.New()
 	mgr, err := entitymanager.New(entitymanager.Deps{
-		Store: st, Meta: parseMeta(t), Templater: nopTemplater{}, Audit: audit.Nop{}, ACL: acl.ReadOnlyACL{}, Transitions: statemachine.EmptySet(),
+		FieldGate: entitymanager.AllowAllFieldGate{},
+		Store:     st, Meta: parseMeta(t), Templater: nopTemplater{}, Audit: audit.Nop{}, ACL: acl.ReadOnlyACL{}, Transitions: statemachine.EmptySet(),
 	})
 	if err != nil {
 		t.Fatalf("New: %v", err)

--- a/internal/entitymanager/apply_type_confusion_test.go
+++ b/internal/entitymanager/apply_type_confusion_test.go
@@ -64,7 +64,8 @@ func TestApplyEntity_RejectsTypeChangeOnUpdate(t *testing.T) {
 
 	// Seed a secret via a NopACL manager (seeding bypasses authz).
 	seedMgr, err := entitymanager.New(entitymanager.Deps{
-		Store: st, Meta: meta, Templater: nopTemplater{}, Audit: audit.Nop{}, ACL: acl.NopACL{}, Transitions: statemachine.EmptySet(),
+		FieldGate: entitymanager.AllowAllFieldGate{},
+		Store:     st, Meta: meta, Templater: nopTemplater{}, Audit: audit.Nop{}, ACL: acl.NopACL{}, Transitions: statemachine.EmptySet(),
 	})
 	if err != nil {
 		t.Fatalf("seed New: %v", err)
@@ -93,7 +94,8 @@ assignments:
 	}
 	sink := audit.NewMemory()
 	mgr, err := entitymanager.New(entitymanager.Deps{
-		Store: st, Meta: meta, Templater: nopTemplater{}, Audit: sink, ACL: declarative, Transitions: statemachine.EmptySet(),
+		FieldGate: entitymanager.AllowAllFieldGate{},
+		Store:     st, Meta: meta, Templater: nopTemplater{}, Audit: sink, ACL: declarative, Transitions: statemachine.EmptySet(),
 	})
 	if err != nil {
 		t.Fatalf("New: %v", err)
@@ -148,7 +150,8 @@ func TestApplyEntity_SameTypeUpdateStillWorks(t *testing.T) {
 	meta := typeConfusionMeta(t)
 
 	seedMgr, err := entitymanager.New(entitymanager.Deps{
-		Store: st, Meta: meta, Templater: nopTemplater{}, Audit: audit.Nop{}, ACL: acl.NopACL{}, Transitions: statemachine.EmptySet(),
+		FieldGate: entitymanager.AllowAllFieldGate{},
+		Store:     st, Meta: meta, Templater: nopTemplater{}, Audit: audit.Nop{}, ACL: acl.NopACL{}, Transitions: statemachine.EmptySet(),
 	})
 	if err != nil {
 		t.Fatalf("seed New: %v", err)
@@ -175,7 +178,8 @@ assignments:
 		t.Fatalf("NewDeclarative: %v", err)
 	}
 	mgr, err := entitymanager.New(entitymanager.Deps{
-		Store: st, Meta: meta, Templater: nopTemplater{}, Audit: audit.Nop{}, ACL: declarative, Transitions: statemachine.EmptySet(),
+		FieldGate: entitymanager.AllowAllFieldGate{},
+		Store:     st, Meta: meta, Templater: nopTemplater{}, Audit: audit.Nop{}, ACL: declarative, Transitions: statemachine.EmptySet(),
 	})
 	if err != nil {
 		t.Fatalf("New: %v", err)

--- a/internal/entitymanager/audit_durability_test.go
+++ b/internal/entitymanager/audit_durability_test.go
@@ -40,6 +40,7 @@ func newManagerWithStoreAndAudit(
 		Audit:       sink,
 		ACL:         acl.NopACL{},
 		Transitions: statemachine.EmptySet(),
+		FieldGate:   entitymanager.AllowAllFieldGate{},
 	}
 	if automations != nil {
 		engine := automation.NewEngine(automations)

--- a/internal/entitymanager/audit_test.go
+++ b/internal/entitymanager/audit_test.go
@@ -31,6 +31,7 @@ func newManagerWithAudit(
 		Audit:       sink,
 		ACL:         acl.NopACL{},
 		Transitions: statemachine.EmptySet(),
+		FieldGate:   entitymanager.AllowAllFieldGate{},
 	}
 	if automations != nil {
 		engine := automation.NewEngine(automations)

--- a/internal/entitymanager/bench_test.go
+++ b/internal/entitymanager/bench_test.go
@@ -34,6 +34,7 @@ func BenchmarkValidateCreate(b *testing.B) {
 		Audit:       audit.Nop{},
 		ACL:         acl.NopACL{},
 		Transitions: statemachine.EmptySet(),
+		FieldGate:   entitymanager.AllowAllFieldGate{},
 	})
 	if err != nil {
 		b.Fatal(err)
@@ -80,6 +81,7 @@ func TestValidateCreate_AllocCeiling(t *testing.T) {
 		Audit:       audit.Nop{},
 		ACL:         acl.NopACL{},
 		Transitions: statemachine.EmptySet(),
+		FieldGate:   entitymanager.AllowAllFieldGate{},
 	})
 	if err != nil {
 		t.Fatal(err)

--- a/internal/entitymanager/collect_errors_test.go
+++ b/internal/entitymanager/collect_errors_test.go
@@ -62,6 +62,7 @@ func newManagerOver(t *testing.T, st store.Store) *entitymanager.Manager {
 		Audit:       audit.Nop{},
 		ACL:         acl.NopACL{},
 		Transitions: statemachine.EmptySet(),
+		FieldGate:   entitymanager.AllowAllFieldGate{},
 	})
 	if err != nil {
 		t.Fatalf("entitymanager.New: %v", err)

--- a/internal/entitymanager/create_conflict_test.go
+++ b/internal/entitymanager/create_conflict_test.go
@@ -42,6 +42,7 @@ func newManagerOverStore(t *testing.T, st store.Store) *entitymanager.Manager {
 		Audit:       audit.Nop{},
 		ACL:         acl.NopACL{},
 		Transitions: statemachine.EmptySet(),
+		FieldGate:   entitymanager.AllowAllFieldGate{},
 	})
 	if err != nil {
 		t.Fatalf("entitymanager.New: %v", err)

--- a/internal/entitymanager/entitymanager.go
+++ b/internal/entitymanager/entitymanager.go
@@ -43,6 +43,12 @@ type EntityManager interface {
 	// The caller passes the modified entity; the manager detects changes.
 	UpdateEntity(ctx context.Context, e *entity.Entity) (*entity.UpdateResult, error)
 
+	// PatchEntity applies a targeted set of property changes, preserving
+	// everything the patch does not name. Prefer this over UpdateEntity for
+	// any partial write: the caller never holds the whole entity, so it
+	// cannot erase properties it could not read (TKT-80EWGM).
+	PatchEntity(ctx context.Context, id string, p entity.Patch) (*entity.UpdateResult, error)
+
 	// DeleteEntity removes an entity and optionally cascades to its relations.
 	DeleteEntity(ctx context.Context, id string, cascade bool) (*entity.DeleteResult, error)
 

--- a/internal/entitymanager/entitymanagertest/panic.go
+++ b/internal/entitymanager/entitymanagertest/panic.go
@@ -35,6 +35,11 @@ func (PanicOnUse) UpdateEntity(context.Context,
 	panic("entitymanagertest.PanicOnUse.UpdateEntity: not expected in this test")
 }
 
+func (PanicOnUse) PatchEntity(context.Context, string,
+	entity.Patch) (*entity.UpdateResult, error) {
+	panic("entitymanagertest.PanicOnUse.PatchEntity: not expected in this test")
+}
+
 func (PanicOnUse) DeleteEntity(context.Context, string,
 	bool) (*entity.DeleteResult, error) {
 	panic("entitymanagertest.PanicOnUse.DeleteEntity: not expected in this test")

--- a/internal/entitymanager/errors.go
+++ b/internal/entitymanager/errors.go
@@ -20,6 +20,34 @@ var ErrEntityNotFound = errors.New("entity not found")
 // ErrRelationNotFound is returned when a relation lookup fails.
 var ErrRelationNotFound = errors.New("relation not found")
 
+// entityNotFoundError wraps [ErrEntityNotFound] with the id and exposes a
+// structural EntityNotFound() marker, so consumers that cannot import this
+// package (the Lua bindings hold only a narrow consumer-side Mutator
+// interface) can distinguish "missing entity" from any other hard error
+// WITHOUT matching on the error text.
+//
+// Text matching is unsafe here: several hard errors embed caller-supplied
+// values — an illegal state-machine transition formats the attempted value
+// with %q — so a caller setting a property to the literal "entity not
+// found" would have its transition rejection misreported as a 404.
+//
+// errors.Is(err, ErrEntityNotFound) keeps working: Unwrap returns the
+// sentinel.
+type entityNotFoundError struct{ id string }
+
+func (e entityNotFoundError) Error() string {
+	return fmt.Sprintf("%s: %s", ErrEntityNotFound.Error(), e.id)
+}
+
+func (e entityNotFoundError) Unwrap() error { return ErrEntityNotFound }
+
+// EntityNotFound marks this as the entity-does-not-exist condition. See
+// the lua package's NotFoundError for the consumer-side contract.
+func (e entityNotFoundError) EntityNotFound() bool { return true }
+
+// newEntityNotFound builds the not-found error for a given id.
+func newEntityNotFound(id string) error { return entityNotFoundError{id: id} }
+
 // ErrEntityVanishedOnUpdate is returned by the sync apply path when an
 // update-intent write finds its target row gone at write time: the existence
 // probe observed the entity, but the durable UpdateEntity hit

--- a/internal/entitymanager/manager.go
+++ b/internal/entitymanager/manager.go
@@ -562,6 +562,44 @@ func (m *Manager) UpdateEntity(ctx context.Context, e *entity.Entity) (*entity.U
 	}); err != nil {
 		return nil, err
 	}
+	// Hard-validate BEFORE the existence probe. Order is load-bearing and
+	// predates the updateCore extraction: an invalid entity reports its
+	// validation error even when the id does not exist. PatchEntity cannot
+	// share this half (it has no candidate entity until after the read), so
+	// the pre-check lives here rather than in updateCore, which re-runs the
+	// same partition on the merged result.
+	preErrs := m.deps.Meta.ValidateEntity(e.ID, e.Type, e.Properties)
+	if hard, _ := partitionValidationErrors(preErrs); len(hard) > 0 {
+		return nil, newValidationError(hard)
+	}
+
+	oldEntity, getErr := m.deps.Store.GetEntity(ctx, e.ID)
+	if getErr != nil {
+		return nil, fmt.Errorf("%w: %s", ErrEntityNotFound, e.ID)
+	}
+
+	return m.updateCore(ctx, e, oldEntity)
+}
+
+// updateCore is the shared post-authorization update pipeline: validate,
+// run on-update automation, enforce transitions and unique constraints,
+// persist, audit, and dispatch the cascade.
+//
+// Method on Manager (not a free function over [Deps] like [createCore])
+// because the cascade needs m.gated() to stop elevation propagating into
+// descendants. It deliberately contains **no ACL check and no attribution**
+// — both belong to the entry points ([UpdateEntity], [PatchEntity]), which
+// authorize with the subject shape appropriate to how they learned the
+// entity type. Putting authorize here would double-authorize PatchEntity
+// (which must authorize early, before it can merge) and emit two
+// denied-write audit rows for one denial.
+//
+// oldEntity is passed in rather than re-read: both callers already hold it
+// (UpdateEntity to prove existence, PatchEntity as the merge base), so
+// threading it through keeps the write path at one read.
+func (m *Manager) updateCore(
+	ctx context.Context, e, oldEntity *entity.Entity,
+) (*entity.UpdateResult, error) {
 	// DEC-HWZHA: partition validation errors once. Hard errors abort;
 	// soft conditions populate Result.Warnings. If automation runs and
 	// mutates properties, we recompute warnings against the post-
@@ -570,11 +608,6 @@ func (m *Manager) UpdateEntity(ctx context.Context, e *entity.Entity) (*entity.U
 	hard, soft := partitionValidationErrors(preErrs)
 	if len(hard) > 0 {
 		return nil, newValidationError(hard)
-	}
-
-	oldEntity, getErr := m.deps.Store.GetEntity(ctx, e.ID)
-	if getErr != nil {
-		return nil, fmt.Errorf("%w: %s", ErrEntityNotFound, e.ID)
 	}
 
 	result := &entity.UpdateResult{Entity: e, Warnings: soft}

--- a/internal/entitymanager/manager.go
+++ b/internal/entitymanager/manager.go
@@ -202,6 +202,57 @@ type Deps struct {
 	// `when:` precondition. May be nil when no precondition needs the graph;
 	// a `when:` that queries the graph then evaluates against an empty graph.
 	TransitionGraph statemachine.GraphLookup
+
+	// FieldGate decides whether the ctx principal may author the specific
+	// property changes in a [Manager.PatchEntity] call. Required — pass
+	// [AllowAllFieldGate] to opt out explicitly.
+	//
+	// It is a CAPABILITY injected at the wiring site, never inferred from
+	// identity (the write-side analog of the read-side AllowAllReader,
+	// DEC-ZBI39P). Operator-trust-boundary entry points (CLI) wire
+	// AllowAllFieldGate because they have full access by design;
+	// request-scoped surfaces wire a policy-backed implementation.
+	//
+	// Required rather than optional-nil on purpose: a silently-nil authz
+	// gate is the "forgotten wiring must not become an ACL bypass" failure
+	// (RR-X9NVHI), and it matches how ACL and Audit are already handled.
+	FieldGate FieldWriteGate
+}
+
+// FieldWriteGate answers whether the ctx principal may write the named
+// properties of e. Defined here at the call site (CLAUDE.md consumer-side
+// interfaces) so entitymanager needs no dependency on the affordance
+// resolver that backs it in production.
+//
+// set holds the properties being upserted (key → new value); unset holds
+// the ones being removed. An implementation returns a non-nil error to
+// refuse the write; the error surfaces to the caller unwrapped, so it
+// should carry whatever structured denial detail the surface needs.
+//
+// **Scope: caller-authored changes only.** Automation-derived properties
+// ([automation.Result.PropertiesSet]) are system writes and are
+// deliberately NOT passed through this gate. The gate enforces parity with
+// what the affordance resolver would surface to this principal on a read —
+// and automation is the system acting, not the principal. Gating it would
+// mean a user who cannot author `status` could never trigger an automation
+// that sets `status`, breaking ordinary workflow automations (RR-00ERM9).
+type FieldWriteGate interface {
+	CheckFieldWrite(ctx context.Context, e *entity.Entity, set map[string]any, unset []string) error
+}
+
+// AllowAllFieldGate permits every field write. It is the explicit opt-out
+// for surfaces that sit on the operator trust boundary (the CLI, where the
+// caller already has full filesystem access to the data) and for tests.
+//
+// Named and passed deliberately, exactly like [acl.NopACL] — never the
+// result of leaving [Deps.FieldGate] nil.
+type AllowAllFieldGate struct{}
+
+// CheckFieldWrite implements [FieldWriteGate] by allowing everything.
+func (AllowAllFieldGate) CheckFieldWrite(
+	context.Context, *entity.Entity, map[string]any, []string,
+) error {
+	return nil
 }
 
 // TransitionEnforcer is the narrow contract the Manager needs from the
@@ -236,6 +287,10 @@ func New(d Deps) (*Manager, error) {
 	if d.Transitions == nil {
 		return nil, errors.New(
 			"entitymanager: New: Transitions is required (use statemachine.Compile; an empty set is a no-op)")
+	}
+	if d.FieldGate == nil {
+		return nil, errors.New(
+			"entitymanager: New: FieldGate is required (use entitymanager.AllowAllFieldGate{} to opt out)")
 	}
 	if (d.Automations == nil) != (d.Cascade == nil) {
 		return nil, errors.New(
@@ -579,6 +634,83 @@ func (m *Manager) UpdateEntity(ctx context.Context, e *entity.Entity) (*entity.U
 	}
 
 	return m.updateCore(ctx, e, oldEntity)
+}
+
+// PatchEntity applies a TARGETED set of property changes to one entity:
+// properties the patch does not name are preserved as-is, regardless of
+// whether the caller could read them. See [entity.Patch] for the
+// merge semantics (upserts, then unsets, then the body tri-state).
+//
+// This is the safe alternative to read-modify-write. A caller doing
+// GetEntity → merge → UpdateEntity must hold the WHOLE entity, so any
+// property it failed to carry across is destroyed on save — and a caller
+// reading through a redacting reader cannot carry across what it cannot
+// see. PatchEntity owns the read internally and merges against the RAW
+// stored entity, so that failure mode is unreachable: forgetting a
+// property is a no-op, not an erasure.
+//
+// **Ordering is load-bearing** (RR-32XA5V):
+//
+//	read → locked-check → authorize → field gate → merge → updateCore
+//
+// The read comes first because the ACL subject needs the entity's real
+// type and the caller supplied only an id — the same shape, and the same
+// accepted existence disclosure, as [Manager.DeleteEntity]. The field gate
+// runs strictly AFTER authorization: field verdicts are value-dependent,
+// so consulting them for an unauthorized caller would turn allow-vs-deny
+// into an oracle for stored property values and for entity existence.
+//
+// An elevated Manager (rela.bypass_acl) skips the field gate as well as
+// the row ACL. Elevation is total by design — a half-elevated handle that
+// silently drops some property writes is the confusing contract
+// lua.WriteDeps.ElevatedManager exists to avoid — and the bypass is still
+// recorded by authorizeAndAudit (RR-BA1NIV).
+func (m *Manager) PatchEntity(
+	ctx context.Context, id string, p entity.Patch,
+) (*entity.UpdateResult, error) {
+	ctx = withStoreAttribution(ctx)
+	if id == "" {
+		return nil, errors.New("entitymanager: PatchEntity: id is empty")
+	}
+
+	// RAW read, deliberately ungated: this is write-prep, and the merge
+	// base must be the complete stored entity or hidden properties would
+	// be dropped from the clone and erased on save. Consolidating this
+	// read here is the point of the primitive — consumers no longer hold
+	// a raw store handle of their own.
+	stored, getErr := m.deps.Store.GetEntity(ctx, id)
+	if getErr != nil {
+		return nil, fmt.Errorf("%w: %s", ErrEntityNotFound, id)
+	}
+
+	// A locked (git-crypt) entity reads as a shell whose real property
+	// values are unavailable, so merging onto it and saving would persist
+	// the shell OVER the encrypted content — the same erasure this
+	// primitive exists to prevent, via encryption instead of redaction
+	// (RR-0QWLRC). Matches ApplyEntity's guard.
+	if stored.IsLocked() {
+		return nil, fmt.Errorf("entitymanager: PatchEntity: entity %s has inaccessible fields", id)
+	}
+
+	if err := m.authorizeAndAudit(ctx, acl.WriteRequest{
+		Op:      acl.OpUpdate,
+		Subject: acl.EntitySubject{Type: stored.Type, ID: id},
+	}); err != nil {
+		return nil, err
+	}
+
+	// Field-level gate, after the row-level decision. Skipped under
+	// elevation for the same reason the row ACL is (see the doc comment).
+	if !m.bypassACL {
+		if err := m.deps.FieldGate.CheckFieldWrite(ctx, stored, p.Properties, p.MetaUnset); err != nil {
+			return nil, err
+		}
+	}
+
+	updated := stored.Clone()
+	p.Apply(updated)
+
+	return m.updateCore(ctx, updated, stored)
 }
 
 // updateCore is the shared post-authorization update pipeline: validate,

--- a/internal/entitymanager/manager.go
+++ b/internal/entitymanager/manager.go
@@ -211,7 +211,8 @@ type Deps struct {
 	// identity (the write-side analog of the read-side AllowAllReader,
 	// DEC-ZBI39P). Operator-trust-boundary entry points (CLI) wire
 	// AllowAllFieldGate because they have full access by design;
-	// request-scoped surfaces wire a policy-backed implementation.
+	// request-scoped surfaces are where a policy-backed implementation
+	// belongs — none is wired yet (TKT-0XL8MF); see [FieldWriteGate].
 	//
 	// Required rather than optional-nil on purpose: a silently-nil authz
 	// gate is the "forgotten wiring must not become an ACL bypass" failure
@@ -223,6 +224,14 @@ type Deps struct {
 // properties of e. Defined here at the call site (CLAUDE.md consumer-side
 // interfaces) so entitymanager needs no dependency on the affordance
 // resolver that backs it in production.
+//
+// **STATUS: no production surface wires a real implementation yet.** Every
+// current wiring site passes [AllowAllFieldGate], so this gate is inert
+// outside tests — field-level write authz is enforced only by
+// internal/dataentry's own validateFieldWrite on its HTTP path, exactly as
+// before. The seam exists so the policy-backed implementation is a wiring
+// change rather than a rewrite; see TKT-0XL8MF. Do not assume a write
+// reaching PatchEntity has been field-gated.
 //
 // set holds the properties being upserted (key → new value); unset holds
 // the ones being removed. An implementation returns a non-nil error to
@@ -680,7 +689,10 @@ func (m *Manager) PatchEntity(
 	// a raw store handle of their own.
 	stored, getErr := m.deps.Store.GetEntity(ctx, id)
 	if getErr != nil {
-		return nil, fmt.Errorf("%w: %s", ErrEntityNotFound, id)
+		// Structural, not textual: consumers holding a narrow write
+		// interface (the Lua bindings) must be able to tell this apart
+		// from other hard errors without matching on the message.
+		return nil, newEntityNotFound(id)
 	}
 
 	// A locked (git-crypt) entity reads as a shell whose real property
@@ -727,8 +739,10 @@ func (m *Manager) PatchEntity(
 // denied-write audit rows for one denial.
 //
 // oldEntity is passed in rather than re-read: both callers already hold it
-// (UpdateEntity to prove existence, PatchEntity as the merge base), so
-// threading it through keeps the write path at one read.
+// (UpdateEntity to prove existence, PatchEntity as the merge base), so the
+// manager itself reads the row once per write. Callers may still read
+// separately for their own reasons — internal/mcp does, to validate
+// property names against the entity type before dispatching.
 func (m *Manager) updateCore(
 	ctx context.Context, e, oldEntity *entity.Entity,
 ) (*entity.UpdateResult, error) {

--- a/internal/entitymanager/manager_delete_test.go
+++ b/internal/entitymanager/manager_delete_test.go
@@ -40,6 +40,7 @@ func TestDeleteEntity_PropagatesStoreError(t *testing.T) {
 		Audit:       audit.Nop{},
 		ACL:         acl.NopACL{},
 		Transitions: statemachine.EmptySet(),
+		FieldGate:   entitymanager.AllowAllFieldGate{},
 	}
 	mgr, err := entitymanager.New(deps)
 	if err != nil {
@@ -79,6 +80,7 @@ func TestDeleteEntity_CascadeAuditsReportedRelations(t *testing.T) {
 		Audit:       mem,
 		ACL:         acl.NopACL{},
 		Transitions: statemachine.EmptySet(),
+		FieldGate:   entitymanager.AllowAllFieldGate{},
 	}
 	mgr, err := entitymanager.New(deps)
 	if err != nil {

--- a/internal/entitymanager/manager_test.go
+++ b/internal/entitymanager/manager_test.go
@@ -164,6 +164,7 @@ func newManager(t *testing.T, automations []automation.Automation) (*entitymanag
 		Audit:       audit.Nop{},
 		ACL:         acl.NopACL{},
 		Transitions: machines,
+		FieldGate:   entitymanager.AllowAllFieldGate{},
 	}
 	if automations != nil {
 		engine := automation.NewEngine(automations)
@@ -210,6 +211,7 @@ func createDec(t *testing.T, mgr *entitymanager.Manager, title string) *entity.E
 func TestNew_RejectsNilStore(t *testing.T) {
 	t.Parallel()
 	_, err := entitymanager.New(entitymanager.Deps{
+		FieldGate: entitymanager.AllowAllFieldGate{},
 		Meta:      parseMeta(t),
 		Templater: nopTemplater{},
 	})
@@ -221,6 +223,7 @@ func TestNew_RejectsNilStore(t *testing.T) {
 func TestNew_RejectsNilMeta(t *testing.T) {
 	t.Parallel()
 	_, err := entitymanager.New(entitymanager.Deps{
+		FieldGate: entitymanager.AllowAllFieldGate{},
 		Store:     memstore.New(),
 		Templater: nopTemplater{},
 	})
@@ -232,8 +235,9 @@ func TestNew_RejectsNilMeta(t *testing.T) {
 func TestNew_RejectsNilTemplater(t *testing.T) {
 	t.Parallel()
 	_, err := entitymanager.New(entitymanager.Deps{
-		Store: memstore.New(),
-		Meta:  parseMeta(t),
+		FieldGate: entitymanager.AllowAllFieldGate{},
+		Store:     memstore.New(),
+		Meta:      parseMeta(t),
 	})
 	if err == nil || !strings.Contains(err.Error(), "Templater") {
 		t.Fatalf("expected Templater-required error, got %v", err)
@@ -243,6 +247,7 @@ func TestNew_RejectsNilTemplater(t *testing.T) {
 func TestNew_RejectsNilAudit(t *testing.T) {
 	t.Parallel()
 	_, err := entitymanager.New(entitymanager.Deps{
+		FieldGate: entitymanager.AllowAllFieldGate{},
 		Store:     memstore.New(),
 		Meta:      parseMeta(t),
 		Templater: nopTemplater{},
@@ -255,6 +260,7 @@ func TestNew_RejectsNilAudit(t *testing.T) {
 func TestNew_RejectsNilACL(t *testing.T) {
 	t.Parallel()
 	_, err := entitymanager.New(entitymanager.Deps{
+		FieldGate: entitymanager.AllowAllFieldGate{},
 		Store:     memstore.New(),
 		Meta:      parseMeta(t),
 		Templater: nopTemplater{},
@@ -268,6 +274,7 @@ func TestNew_RejectsNilACL(t *testing.T) {
 func TestNew_RejectsNilTransitions(t *testing.T) {
 	t.Parallel()
 	_, err := entitymanager.New(entitymanager.Deps{
+		FieldGate: entitymanager.AllowAllFieldGate{},
 		Store:     memstore.New(),
 		Meta:      parseMeta(t),
 		Templater: nopTemplater{},
@@ -289,6 +296,7 @@ func TestNew_RejectsAutomationsWithoutCascade(t *testing.T) {
 		Audit:       audit.Nop{},
 		ACL:         acl.NopACL{},
 		Transitions: statemachine.EmptySet(),
+		FieldGate:   entitymanager.AllowAllFieldGate{},
 		Automations: engine,
 	})
 	if err == nil || !strings.Contains(err.Error(), "Automations and Cascade") {
@@ -305,6 +313,7 @@ func TestNew_AllowsNoAutomation(t *testing.T) {
 		Audit:       audit.Nop{},
 		ACL:         acl.NopACL{},
 		Transitions: statemachine.EmptySet(),
+		FieldGate:   entitymanager.AllowAllFieldGate{},
 	}); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -630,6 +639,7 @@ func TestCreate_PassesManagerAsMutator(t *testing.T) {
 		Audit:        audit.Nop{},
 		ACL:          acl.NopACL{},
 		Transitions:  statemachine.EmptySet(),
+		FieldGate:    entitymanager.AllowAllFieldGate{},
 		Automations:  engine,
 		Cascade:      runner,
 		ScriptRunner: scripts,
@@ -948,6 +958,7 @@ func TestCreate_PropagatesNonConflictStoreError(t *testing.T) {
 		Audit:       audit.Nop{},
 		ACL:         acl.NopACL{},
 		Transitions: statemachine.EmptySet(),
+		FieldGate:   entitymanager.AllowAllFieldGate{},
 	})
 	if err != nil {
 		t.Fatalf("New: %v", err)
@@ -1004,6 +1015,7 @@ func TestCreate_SoftValidationProducesWarning(t *testing.T) {
 		Audit:       audit.Nop{},
 		ACL:         acl.NopACL{},
 		Transitions: statemachine.EmptySet(),
+		FieldGate:   entitymanager.AllowAllFieldGate{},
 	})
 	if err != nil {
 		t.Fatalf("New: %v", err)
@@ -1064,6 +1076,7 @@ func TestUpdate_SoftValidationProducesWarning(t *testing.T) {
 		Audit:       audit.Nop{},
 		ACL:         acl.NopACL{},
 		Transitions: statemachine.EmptySet(),
+		FieldGate:   entitymanager.AllowAllFieldGate{},
 	})
 	if err != nil {
 		t.Fatalf("New: %v", err)

--- a/internal/entitymanager/orderable_test.go
+++ b/internal/entitymanager/orderable_test.go
@@ -77,6 +77,7 @@ func newOrderableManagerWithAudit(t *testing.T, mode string) (*entitymanager.Man
 		Audit:       mem,
 		ACL:         acl.NopACL{},
 		Transitions: statemachine.EmptySet(),
+		FieldGate:   entitymanager.AllowAllFieldGate{},
 	}
 	mgr, err := entitymanager.New(deps)
 	if err != nil {

--- a/internal/entitymanager/patch_test.go
+++ b/internal/entitymanager/patch_test.go
@@ -326,18 +326,57 @@ func TestPatchEntity_NonStringValuesSurvive(t *testing.T) {
 
 // TestPatchEntity_NilPropertiesEntity covers an entity stored with no
 // property map at all — Clone allocates one, so the patch must still work.
+//
+// The unset-only sub-case is the subtle one: Apply only allocates a map
+// when Properties is non-empty, so a MetaUnset-only patch runs delete()
+// against a possibly-nil map. That is a no-op in Go rather than a panic,
+// but the invariant is load-bearing (both MCP and CLI can emit unset-only
+// patches) and worth pinning rather than leaving to language trivia.
 func TestPatchEntity_NilPropertiesEntity(t *testing.T) {
 	t.Parallel()
-	mgr, st := newPatchManager(t, nil)
-	seedTask(t, st, "TASK-1", nil, "")
 
-	if _, err := mgr.PatchEntity(context.Background(), "TASK-1", entity.Patch{
-		Properties: map[string]any{"title": "set-on-nil-map"},
-	}); err != nil {
-		t.Fatalf("PatchEntity: %v", err)
-	}
-	if got := mustGet(t, st, "TASK-1").Properties["title"]; got != "set-on-nil-map" {
-		t.Errorf("title = %v, want it set", got)
+	t.Run("set on a nil property map", func(t *testing.T) {
+		t.Parallel()
+		mgr, st := newPatchManager(t, nil)
+		seedTask(t, st, "TASK-1", nil, "")
+
+		if _, err := mgr.PatchEntity(context.Background(), "TASK-1", entity.Patch{
+			Properties: map[string]any{"title": "set-on-nil-map"},
+		}); err != nil {
+			t.Fatalf("PatchEntity: %v", err)
+		}
+		if got := mustGet(t, st, "TASK-1").Properties["title"]; got != "set-on-nil-map" {
+			t.Errorf("title = %v, want it set", got)
+		}
+	})
+
+	t.Run("unset-only against a nil property map does not panic", func(t *testing.T) {
+		t.Parallel()
+		mgr, st := newPatchManager(t, nil)
+		seedTask(t, st, "TASK-2", nil, "body")
+
+		if _, err := mgr.PatchEntity(context.Background(), "TASK-2", entity.Patch{
+			MetaUnset: []string{"never-existed"},
+		}); err != nil {
+			t.Fatalf("PatchEntity: %v", err)
+		}
+		if got := mustGet(t, st, "TASK-2").Content; got != "body" {
+			t.Errorf("body = %q, want it untouched", got)
+		}
+	})
+}
+
+// TestPatch_ApplyOnNilMap pins the same invariant at the unit level, on
+// the value type itself, so a future change of property container fails
+// here rather than only through the manager.
+func TestPatch_ApplyOnNilMap(t *testing.T) {
+	t.Parallel()
+
+	e := &entity.Entity{ID: "X-1", Type: "task"} // Properties is nil
+	entity.Patch{MetaUnset: []string{"nope"}}.Apply(e)
+
+	if len(e.Properties) != 0 {
+		t.Errorf("Properties = %v, want empty", e.Properties)
 	}
 }
 

--- a/internal/entitymanager/patch_test.go
+++ b/internal/entitymanager/patch_test.go
@@ -1,0 +1,680 @@
+package entitymanager_test
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/Sourcehaven-BV/rela/internal/acl"
+	"github.com/Sourcehaven-BV/rela/internal/audit"
+	"github.com/Sourcehaven-BV/rela/internal/autocascade"
+	"github.com/Sourcehaven-BV/rela/internal/automation"
+	"github.com/Sourcehaven-BV/rela/internal/entity"
+	"github.com/Sourcehaven-BV/rela/internal/entitymanager"
+	"github.com/Sourcehaven-BV/rela/internal/metamodel"
+	"github.com/Sourcehaven-BV/rela/internal/statemachine"
+	"github.com/Sourcehaven-BV/rela/internal/store"
+	"github.com/Sourcehaven-BV/rela/internal/store/memstore"
+)
+
+// patchMetamodelYAML mirrors the CalDAV/VTODO shape that motivated the
+// primitive: a task carrying a handful of properties, only some of which
+// any given partial writer knows how to express.
+const patchMetamodelYAML = `version: "1.0"
+entities:
+  task:
+    label: Task
+    plural: tasks
+    id_type: manual
+    properties:
+      title:
+        type: string
+      status:
+        type: string
+      due:
+        type: string
+      salary:
+        type: string
+      notes:
+        type: string
+`
+
+func newPatchManager(t *testing.T, gate entitymanager.FieldWriteGate) (*entitymanager.Manager, store.Store) {
+	t.Helper()
+	meta, err := metamodel.Parse([]byte(patchMetamodelYAML))
+	if err != nil {
+		t.Fatalf("metamodel.Parse: %v", err)
+	}
+	st := memstore.New()
+	if gate == nil {
+		gate = entitymanager.AllowAllFieldGate{}
+	}
+	mgr, err := entitymanager.New(entitymanager.Deps{
+		Store:       st,
+		Meta:        meta,
+		Templater:   nopTemplater{},
+		Audit:       audit.Nop{},
+		ACL:         acl.NopACL{},
+		Transitions: statemachine.EmptySet(),
+		FieldGate:   gate,
+	})
+	if err != nil {
+		t.Fatalf("entitymanager.New: %v", err)
+	}
+	return mgr, st
+}
+
+// seedTask writes a task directly to the store so the fixture is
+// independent of the write path under test.
+func seedTask(t *testing.T, st store.Store, id string, props map[string]any, body string) {
+	t.Helper()
+	e := entity.New(id, "task")
+	e.Properties = props
+	e.Content = body
+	if err := st.CreateEntity(context.Background(), e); err != nil {
+		t.Fatalf("seed %s: %v", id, err)
+	}
+}
+
+func mustGet(t *testing.T, st store.Store, id string) *entity.Entity {
+	t.Helper()
+	got, err := st.GetEntity(context.Background(), id)
+	if err != nil {
+		t.Fatalf("GetEntity %s: %v", id, err)
+	}
+	return got
+}
+
+// TestPatchEntity_PreservesUnnamedProperties is the INVERSE test — the one
+// that would have caught this bug class at its origin (TKT-80EWGM AC2).
+//
+// A caller that can only see a subset of an entity's properties patches
+// exactly one of them. Every property it did not name must survive
+// byte-identical, INCLUDING the ones it could never have read. Under the
+// old GetEntity→merge→UpdateEntity idiom a redacted-read caller silently
+// erased those; with a patch, forgetting is a no-op.
+func TestPatchEntity_PreservesUnnamedProperties(t *testing.T) {
+	t.Parallel()
+	mgr, st := newPatchManager(t, nil)
+
+	seedTask(t, st, "TASK-1", map[string]any{
+		"title":  "Original",
+		"status": "todo",
+		"due":    "2026-01-01",
+		"salary": "secret-value",
+		"notes":  "hidden-notes",
+	}, "original body")
+
+	newTitle := "Updated"
+	if _, err := mgr.PatchEntity(context.Background(), "TASK-1", entity.Patch{
+		Properties: map[string]any{"title": newTitle},
+	}); err != nil {
+		t.Fatalf("PatchEntity: %v", err)
+	}
+
+	got := mustGet(t, st, "TASK-1")
+	if got.Properties["title"] != newTitle {
+		t.Errorf("title = %v, want %q", got.Properties["title"], newTitle)
+	}
+	// The whole point: everything unnamed is untouched.
+	for k, want := range map[string]string{
+		"status": "todo",
+		"due":    "2026-01-01",
+		"salary": "secret-value",
+		"notes":  "hidden-notes",
+	} {
+		if got.Properties[k] != want {
+			t.Errorf("property %q = %v, want %q (unnamed properties must survive)", k, got.Properties[k], want)
+		}
+	}
+	if got.Content != "original body" {
+		t.Errorf("body = %q, want it untouched", got.Content)
+	}
+}
+
+// TestPatchEntity_SetUnsetAbsent pins the three distinct behaviors that
+// make a patch a patch: set changes, unset removes, absent preserves.
+func TestPatchEntity_SetUnsetAbsent(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		patch    entity.Patch
+		wantDue  any
+		wantHave bool
+	}{
+		{
+			name:     "set overwrites",
+			patch:    entity.Patch{Properties: map[string]any{"due": "2027-12-31"}},
+			wantDue:  "2027-12-31",
+			wantHave: true,
+		},
+		{
+			name:     "unset removes",
+			patch:    entity.Patch{MetaUnset: []string{"due"}},
+			wantHave: false,
+		},
+		{
+			name:     "absent preserves",
+			patch:    entity.Patch{Properties: map[string]any{"title": "other"}},
+			wantDue:  "2026-01-01",
+			wantHave: true,
+		},
+		{
+			name: "set and unset same key ends cleared",
+			patch: entity.Patch{
+				Properties: map[string]any{"due": "2027-12-31"},
+				MetaUnset:  []string{"due"},
+			},
+			wantHave: false,
+		},
+		{
+			name:     "unset absent key is a no-op not an error",
+			patch:    entity.Patch{MetaUnset: []string{"notes"}},
+			wantDue:  "2026-01-01",
+			wantHave: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			mgr, st := newPatchManager(t, nil)
+			seedTask(t, st, "TASK-1", map[string]any{
+				"title": "Original",
+				"due":   "2026-01-01",
+			}, "")
+
+			if _, err := mgr.PatchEntity(context.Background(), "TASK-1", tc.patch); err != nil {
+				t.Fatalf("PatchEntity: %v", err)
+			}
+
+			got := mustGet(t, st, "TASK-1")
+			val, have := got.Properties["due"]
+			if have != tc.wantHave {
+				t.Fatalf("due present = %v, want %v (props=%v)", have, tc.wantHave, got.Properties)
+			}
+			if tc.wantHave && val != tc.wantDue {
+				t.Errorf("due = %v, want %v", val, tc.wantDue)
+			}
+		})
+	}
+}
+
+// TestPatchEntity_BodyTriState pins the pointer semantics: nil leaves the
+// body alone, empty-string clears it, non-empty replaces it. Without the
+// pointer there is no way to say "don't touch the body".
+func TestPatchEntity_BodyTriState(t *testing.T) {
+	t.Parallel()
+	empty := ""
+	replacement := "new body"
+
+	tests := []struct {
+		name    string
+		content *string
+		want    string
+	}{
+		{name: "nil leaves body untouched", content: nil, want: "original body"},
+		{name: "empty string clears body", content: &empty, want: ""},
+		{name: "non-empty replaces body", content: &replacement, want: "new body"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			mgr, st := newPatchManager(t, nil)
+			seedTask(t, st, "TASK-1", map[string]any{"title": "T"}, "original body")
+
+			if _, err := mgr.PatchEntity(context.Background(), "TASK-1", entity.Patch{
+				Content: tc.content,
+			}); err != nil {
+				t.Fatalf("PatchEntity: %v", err)
+			}
+
+			if got := mustGet(t, st, "TASK-1").Content; got != tc.want {
+				t.Errorf("body = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestPatchEntity_RemindersVTODOShape is the CalDAV fixture this ticket
+// unblocks: Apple Reminders PUTs only the fields VTODO models and drops
+// everything else. Applied as a whole-entity save that would erase the
+// rest; as a patch it must not.
+func TestPatchEntity_RemindersVTODOShape(t *testing.T) {
+	t.Parallel()
+	mgr, st := newPatchManager(t, nil)
+
+	seedTask(t, st, "TASK-1", map[string]any{
+		"title":  "Renew passport",
+		"status": "todo",
+		"due":    "2026-06-30",
+		"salary": "not-in-vtodo",
+		"notes":  "also-not-in-vtodo",
+	}, "detail body")
+
+	// Exactly what Reminders sends: SUMMARY, STATUS, DUE. Nothing else.
+	if _, err := mgr.PatchEntity(context.Background(), "TASK-1", entity.Patch{
+		Properties: map[string]any{
+			"title":  "Renew passport",
+			"status": "doing",
+			"due":    "2026-07-15",
+		},
+	}); err != nil {
+		t.Fatalf("PatchEntity: %v", err)
+	}
+
+	got := mustGet(t, st, "TASK-1")
+	if got.Properties["status"] != "doing" || got.Properties["due"] != "2026-07-15" {
+		t.Errorf("VTODO fields not applied: %v", got.Properties)
+	}
+	if got.Properties["salary"] != "not-in-vtodo" || got.Properties["notes"] != "also-not-in-vtodo" {
+		t.Errorf("properties VTODO cannot express were erased: %v", got.Properties)
+	}
+	if got.Content != "detail body" {
+		t.Errorf("body = %q, want untouched (VTODO sent no DESCRIPTION)", got.Content)
+	}
+}
+
+// TestPatchEntity_NotFound pins the uniform not-found error.
+func TestPatchEntity_NotFound(t *testing.T) {
+	t.Parallel()
+	mgr, _ := newPatchManager(t, nil)
+
+	_, err := mgr.PatchEntity(context.Background(), "TASK-404", entity.Patch{
+		Properties: map[string]any{"title": "x"},
+	})
+	if !errors.Is(err, entitymanager.ErrEntityNotFound) {
+		t.Fatalf("err = %v, want ErrEntityNotFound", err)
+	}
+}
+
+// TestPatchEntity_EmptyID rejects an empty id rather than reading one.
+func TestPatchEntity_EmptyID(t *testing.T) {
+	t.Parallel()
+	mgr, _ := newPatchManager(t, nil)
+
+	if _, err := mgr.PatchEntity(context.Background(), "", entity.Patch{}); err == nil {
+		t.Fatal("expected an error for an empty id")
+	}
+}
+
+// TestPatchEntity_NonStringValuesSurvive pins that patching does not
+// stringify property values — SetString would have.
+func TestPatchEntity_NonStringValuesSurvive(t *testing.T) {
+	t.Parallel()
+	mgr, st := newPatchManager(t, nil)
+	seedTask(t, st, "TASK-1", map[string]any{"title": "T"}, "")
+
+	if _, err := mgr.PatchEntity(context.Background(), "TASK-1", entity.Patch{
+		Properties: map[string]any{"notes": []any{"a", "b"}},
+	}); err != nil {
+		t.Fatalf("PatchEntity: %v", err)
+	}
+
+	got := mustGet(t, st, "TASK-1")
+	list, ok := got.Properties["notes"].([]any)
+	if !ok {
+		t.Fatalf("notes = %T, want []any (value was stringified)", got.Properties["notes"])
+	}
+	if len(list) != 2 {
+		t.Errorf("notes = %v, want 2 elements", list)
+	}
+}
+
+// TestPatchEntity_NilPropertiesEntity covers an entity stored with no
+// property map at all — Clone allocates one, so the patch must still work.
+func TestPatchEntity_NilPropertiesEntity(t *testing.T) {
+	t.Parallel()
+	mgr, st := newPatchManager(t, nil)
+	seedTask(t, st, "TASK-1", nil, "")
+
+	if _, err := mgr.PatchEntity(context.Background(), "TASK-1", entity.Patch{
+		Properties: map[string]any{"title": "set-on-nil-map"},
+	}); err != nil {
+		t.Fatalf("PatchEntity: %v", err)
+	}
+	if got := mustGet(t, st, "TASK-1").Properties["title"]; got != "set-on-nil-map" {
+		t.Errorf("title = %v, want it set", got)
+	}
+}
+
+// --- Field-write gate ---
+
+// recordingGate refuses writes touching any denied property and records
+// what it was asked about, so tests can assert BOTH the decision and that
+// the gate was consulted at all.
+type recordingGate struct {
+	denied  map[string]bool
+	calls   int
+	lastSet map[string]any
+	lastUn  []string
+}
+
+func (g *recordingGate) CheckFieldWrite(
+	_ context.Context, _ *entity.Entity, set map[string]any, unset []string,
+) error {
+	g.calls++
+	g.lastSet, g.lastUn = set, unset
+	for k := range set {
+		if g.denied[k] {
+			return errors.New("field write denied: " + k)
+		}
+	}
+	for _, k := range unset {
+		if g.denied[k] {
+			return errors.New("field unset denied: " + k)
+		}
+	}
+	return nil
+}
+
+// TestPatchEntity_FieldGateDeniesSetAndUnset pins parity: a property the
+// caller may not author cannot be set OR unset. Unset parity matters —
+// erasing a value you cannot see is still writing it.
+func TestPatchEntity_FieldGateDeniesSetAndUnset(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name  string
+		patch entity.Patch
+	}{
+		{"set denied property", entity.Patch{Properties: map[string]any{"salary": "999"}}},
+		{"unset denied property", entity.Patch{MetaUnset: []string{"salary"}}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			gate := &recordingGate{denied: map[string]bool{"salary": true}}
+			mgr, st := newPatchManager(t, gate)
+			seedTask(t, st, "TASK-1", map[string]any{"title": "T", "salary": "original"}, "")
+
+			if _, err := mgr.PatchEntity(context.Background(), "TASK-1", tc.patch); err == nil {
+				t.Fatal("expected the field gate to refuse the write")
+			}
+			if got := mustGet(t, st, "TASK-1").Properties["salary"]; got != "original" {
+				t.Errorf("salary = %v, want %q — a refused write must not persist", got, "original")
+			}
+		})
+	}
+}
+
+// TestPatchEntity_FieldGateAllowsUngatedProperty proves the gate is a
+// filter, not a blanket block, and that it sees the real diff.
+func TestPatchEntity_FieldGateAllowsUngatedProperty(t *testing.T) {
+	t.Parallel()
+	gate := &recordingGate{denied: map[string]bool{"salary": true}}
+	mgr, st := newPatchManager(t, gate)
+	seedTask(t, st, "TASK-1", map[string]any{"title": "T", "salary": "original"}, "")
+
+	if _, err := mgr.PatchEntity(context.Background(), "TASK-1", entity.Patch{
+		Properties: map[string]any{"title": "allowed"},
+		MetaUnset:  []string{"notes"},
+	}); err != nil {
+		t.Fatalf("PatchEntity: %v", err)
+	}
+
+	if gate.calls != 1 {
+		t.Errorf("gate consulted %d times, want exactly 1", gate.calls)
+	}
+	if _, ok := gate.lastSet["title"]; !ok {
+		t.Errorf("gate saw set=%v, want it to include the upserted key", gate.lastSet)
+	}
+	if len(gate.lastUn) != 1 || gate.lastUn[0] != "notes" {
+		t.Errorf("gate saw unset=%v, want [notes]", gate.lastUn)
+	}
+	// The gated property was never named, so it is untouched.
+	if got := mustGet(t, st, "TASK-1").Properties["salary"]; got != "original" {
+		t.Errorf("salary = %v, want it preserved", got)
+	}
+}
+
+// TestPatchEntity_RunsFullPipeline pins AC1: a patch is a first-class
+// write, not a store poke. Automation must fire and audit must be emitted
+// — PatchEntity is NOT in the {Create,Update,Delete,Rename} set that
+// internal/entitymanager/CLAUDE.md says inherits audit mechanically, so
+// this is verified rather than assumed.
+func TestPatchEntity_RunsFullPipeline(t *testing.T) {
+	t.Parallel()
+
+	meta, err := metamodel.Parse([]byte(patchMetamodelYAML))
+	if err != nil {
+		t.Fatalf("metamodel.Parse: %v", err)
+	}
+	st := memstore.New()
+	sink := audit.NewMemory()
+	auto := automation.Automation{
+		Name: "stamp-notes-on-status-change",
+		On:   automation.Trigger{Entity: []string{"task"}, Property: "status"},
+		Do:   []automation.Action{{Set: "notes", Value: "touched-by-automation"}},
+	}
+	engine := automation.NewEngine([]automation.Automation{auto})
+	runner, err := autocascade.New(autocascade.Deps{Engine: engine})
+	if err != nil {
+		t.Fatalf("autocascade.New: %v", err)
+	}
+	mgr, err := entitymanager.New(entitymanager.Deps{
+		Store:       st,
+		Meta:        meta,
+		Templater:   nopTemplater{},
+		Audit:       sink,
+		ACL:         acl.NopACL{},
+		Automations: engine,
+		Cascade:     runner,
+		Transitions: statemachine.EmptySet(),
+		FieldGate:   entitymanager.AllowAllFieldGate{},
+	})
+	if err != nil {
+		t.Fatalf("entitymanager.New: %v", err)
+	}
+
+	seedTask(t, st, "TASK-1", map[string]any{"title": "T", "status": "todo"}, "")
+
+	if _, err := mgr.PatchEntity(context.Background(), "TASK-1", entity.Patch{
+		Properties: map[string]any{"status": "doing"},
+	}); err != nil {
+		t.Fatalf("PatchEntity: %v", err)
+	}
+
+	got := mustGet(t, st, "TASK-1")
+	if got.Properties["notes"] != "touched-by-automation" {
+		t.Errorf("automation did not fire on the patch path: %v", got.Properties)
+	}
+	if len(sink.Records()) == 0 {
+		t.Error("no audit record emitted for a patch — audit must not depend on the method name")
+	}
+}
+
+// TestPatchEntity_AutomationNotFieldGated pins RR-00ERM9. The gate
+// constrains what a PRINCIPAL may author, not what the SYSTEM derives.
+// If automation output were gated, a user who cannot author `notes` could
+// never trigger an automation that sets it — breaking ordinary workflow
+// automations. This test is what stops a future "consistency" change from
+// silently doing that.
+func TestPatchEntity_AutomationNotFieldGated(t *testing.T) {
+	t.Parallel()
+
+	meta, err := metamodel.Parse([]byte(patchMetamodelYAML))
+	if err != nil {
+		t.Fatalf("metamodel.Parse: %v", err)
+	}
+	st := memstore.New()
+	// The caller may NOT author `notes` …
+	gate := &recordingGate{denied: map[string]bool{"notes": true}}
+	// … but an automation sets exactly that property.
+	auto := automation.Automation{
+		Name: "stamp-notes-on-status-change",
+		On:   automation.Trigger{Entity: []string{"task"}, Property: "status"},
+		Do:   []automation.Action{{Set: "notes", Value: "set-by-automation"}},
+	}
+	engine := automation.NewEngine([]automation.Automation{auto})
+	runner, err := autocascade.New(autocascade.Deps{Engine: engine})
+	if err != nil {
+		t.Fatalf("autocascade.New: %v", err)
+	}
+	mgr, err := entitymanager.New(entitymanager.Deps{
+		Store:       st,
+		Meta:        meta,
+		Templater:   nopTemplater{},
+		Audit:       audit.Nop{},
+		ACL:         acl.NopACL{},
+		Automations: engine,
+		Cascade:     runner,
+		Transitions: statemachine.EmptySet(),
+		FieldGate:   gate,
+	})
+	if err != nil {
+		t.Fatalf("entitymanager.New: %v", err)
+	}
+
+	seedTask(t, st, "TASK-1", map[string]any{"title": "T", "status": "todo"}, "")
+
+	// Patching `status` is allowed; the automation's write to the denied
+	// `notes` must not be blocked by the caller's field gate.
+	if _, err := mgr.PatchEntity(context.Background(), "TASK-1", entity.Patch{
+		Properties: map[string]any{"status": "doing"},
+	}); err != nil {
+		t.Fatalf("PatchEntity: %v — automation output must not be field-gated", err)
+	}
+	if got := mustGet(t, st, "TASK-1").Properties["notes"]; got != "set-by-automation" {
+		t.Errorf("notes = %v, want the automation's value to land", got)
+	}
+}
+
+// denyWritesACL refuses every write, standing in for a caller with no
+// write authority on the entity.
+type denyWritesACL struct{}
+
+func (denyWritesACL) AuthorizeWrite(context.Context, acl.WriteRequest) acl.Decision {
+	return acl.Decision{Allow: false, RuleKind: "read-only", RuleID: "test-deny-all"}
+}
+
+// TestPatchEntity_GateRunsAfterAuthorize is the SECURITY regression net
+// for RR-32XA5V. The field gate must not be consulted for a caller who is
+// not authorized to write the entity at all.
+//
+// Field verdicts are value-dependent, so if the gate ran first an
+// unauthorized caller could distinguish "entity absent" from "entity
+// present but this field is denied" from "present and allowed" — turning a
+// refused write into an oracle for entity existence AND for stored
+// property values. Both are data, and data is secret.
+//
+// The assertion is deliberately behavioral rather than positional: the
+// gate must record ZERO calls, and the denial must be the ACL's.
+func TestPatchEntity_GateRunsAfterAuthorize(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name   string
+		id     string
+		exists bool
+	}{
+		{name: "existing entity", id: "TASK-1", exists: true},
+		{name: "nonexistent entity", id: "TASK-404"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			meta, err := metamodel.Parse([]byte(patchMetamodelYAML))
+			if err != nil {
+				t.Fatalf("metamodel.Parse: %v", err)
+			}
+			st := memstore.New()
+			gate := &recordingGate{denied: map[string]bool{"salary": true}}
+			mgr, err := entitymanager.New(entitymanager.Deps{
+				Store:       st,
+				Meta:        meta,
+				Templater:   nopTemplater{},
+				Audit:       audit.Nop{},
+				ACL:         denyWritesACL{},
+				Transitions: statemachine.EmptySet(),
+				FieldGate:   gate,
+			})
+			if err != nil {
+				t.Fatalf("entitymanager.New: %v", err)
+			}
+			if tc.exists {
+				seedTask(t, st, tc.id, map[string]any{"title": "T", "salary": "secret"}, "")
+			}
+
+			// Patch a property the gate WOULD refuse. The ACL must win.
+			_, patchErr := mgr.PatchEntity(context.Background(), tc.id, entity.Patch{
+				Properties: map[string]any{"salary": "999"},
+			})
+			if patchErr == nil {
+				t.Fatal("expected the write to be refused")
+			}
+			if gate.calls != 0 {
+				t.Errorf("field gate was consulted %d times for an unauthorized caller; "+
+					"it must run strictly after authorization (RR-32XA5V)", gate.calls)
+			}
+			if strings.Contains(patchErr.Error(), "denied: salary") {
+				t.Errorf("error leaked a field-level verdict to an unauthorized caller: %v", patchErr)
+			}
+		})
+	}
+}
+
+// TestPatchEntity_ElevationSkipsFieldGate pins RR-BA1NIV: elevation is
+// TOTAL. A half-elevated handle that can write any entity but silently
+// drops some property writes is the confusing contract the elevated-read
+// seam exists to avoid, and the operator holding bypass_acl can read
+// acl.yaml anyway — the gate conceals nothing from them.
+func TestPatchEntity_ElevationSkipsFieldGate(t *testing.T) {
+	t.Parallel()
+	gate := &recordingGate{denied: map[string]bool{"salary": true}}
+	mgr, st := newPatchManager(t, gate)
+	seedTask(t, st, "TASK-1", map[string]any{"title": "T", "salary": "original"}, "")
+
+	// Assert, don't skip: if the elevated handle ever stops exposing
+	// PatchEntity this must fail loudly rather than quietly not running.
+	elevated, ok := mgr.Elevated().(interface {
+		PatchEntity(context.Context, string, entity.Patch) (*entity.UpdateResult, error)
+	})
+	if !ok {
+		t.Fatalf("elevated mutator (%T) does not expose PatchEntity", mgr.Elevated())
+	}
+
+	if _, err := elevated.PatchEntity(context.Background(), "TASK-1", entity.Patch{
+		Properties: map[string]any{"salary": "999"},
+	}); err != nil {
+		t.Fatalf("elevated PatchEntity: %v", err)
+	}
+	if gate.calls != 0 {
+		t.Errorf("field gate consulted %d times under elevation, want 0 (elevation is total)", gate.calls)
+	}
+	if got := mustGet(t, st, "TASK-1").Properties["salary"]; got != "999" {
+		t.Errorf("salary = %v, want the elevated write to land", got)
+	}
+}
+
+// TestPatchEntity_LockedEntityRefused pins RR-0QWLRC. A git-crypt-locked
+// entity reads as a shell; merging onto it and saving would write the
+// cleartext shell over the ciphertext — the same erasure this primitive
+// exists to prevent, arriving via encryption instead of redaction.
+func TestPatchEntity_LockedEntityRefused(t *testing.T) {
+	t.Parallel()
+	mgr, st := newPatchManager(t, nil)
+
+	locked := entity.New("TASK-LOCKED", "task")
+	locked.Properties = map[string]any{"title": "Locked"}
+	locked.Inaccessible = []entity.InaccessibleField{
+		{Name: "salary", Reason: entity.InaccessibleReasonGitCrypt},
+	}
+	if err := st.CreateEntity(context.Background(), locked); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	_, err := mgr.PatchEntity(context.Background(), "TASK-LOCKED", entity.Patch{
+		Properties: map[string]any{"title": "Overwritten"},
+	})
+	if err == nil {
+		t.Fatal("expected PatchEntity to refuse a locked entity")
+	}
+	if !strings.Contains(err.Error(), "inaccessible") {
+		t.Errorf("err = %v, want it to name the inaccessible fields", err)
+	}
+	if got := mustGet(t, st, "TASK-LOCKED").Properties["title"]; got != "Locked" {
+		t.Errorf("title = %v, want the locked entity untouched", got)
+	}
+}

--- a/internal/entitymanager/relation_version_hook_test.go
+++ b/internal/entitymanager/relation_version_hook_test.go
@@ -36,6 +36,7 @@ func newRelationVersionManager(t *testing.T) (*entitymanager.Manager, *fakeRelat
 		Audit:                   audit.Nop{},
 		ACL:                     acl.NopACL{},
 		Transitions:             statemachine.EmptySet(),
+		FieldGate:               entitymanager.AllowAllFieldGate{},
 		RelationVersionRecorder: rec,
 	})
 	if err != nil {

--- a/internal/entitymanager/rename_acl_test.go
+++ b/internal/entitymanager/rename_acl_test.go
@@ -59,6 +59,7 @@ func TestRename_FailsClosedOnNonNotFoundFetchError(t *testing.T) {
 		Audit:       audit.Nop{},
 		ACL:         acl.ReadOnlyACL{},
 		Transitions: statemachine.EmptySet(),
+		FieldGate:   entitymanager.AllowAllFieldGate{},
 	}
 	mgr, err := entitymanager.New(deps)
 	if err != nil {

--- a/internal/entitymanager/transition_test.go
+++ b/internal/entitymanager/transition_test.go
@@ -67,6 +67,7 @@ func newTransitionManager(t *testing.T, guard statemachine.Guard) *entitymanager
 		Audit:           audit.Nop{},
 		ACL:             acl.NopACL{},
 		Transitions:     machines,
+		FieldGate:       entitymanager.AllowAllFieldGate{},
 		TransitionGuard: guard,
 	})
 	if err != nil {
@@ -196,6 +197,7 @@ func TestTransition_IllegalEntry_DoesNotPersist(t *testing.T) {
 		Audit:           audit.Nop{},
 		ACL:             acl.NopACL{},
 		Transitions:     machines,
+		FieldGate:       entitymanager.AllowAllFieldGate{},
 		TransitionGuard: allowAllGuard{},
 	})
 	if err != nil {

--- a/internal/entitymanager/unique_test.go
+++ b/internal/entitymanager/unique_test.go
@@ -54,6 +54,7 @@ func newUniqueManager(t *testing.T) *entitymanager.Manager {
 		Audit:       audit.Nop{},
 		ACL:         acl.NopACL{},
 		Transitions: statemachine.EmptySet(),
+		FieldGate:   entitymanager.AllowAllFieldGate{},
 	})
 	if err != nil {
 		t.Fatalf("entitymanager.New: %v", err)
@@ -82,6 +83,7 @@ func newUniqueManagerWithAutomation(t *testing.T, autos []automation.Automation)
 		Audit:       audit.Nop{},
 		ACL:         acl.NopACL{},
 		Transitions: statemachine.EmptySet(),
+		FieldGate:   entitymanager.AllowAllFieldGate{},
 		Automations: engine,
 		Cascade:     runner,
 	})

--- a/internal/entitymanager/version_hook_test.go
+++ b/internal/entitymanager/version_hook_test.go
@@ -34,6 +34,7 @@ func newVersionManager(t *testing.T) (*entitymanager.Manager, *fakeRecorder) {
 		Audit:           audit.Nop{},
 		ACL:             acl.NopACL{},
 		Transitions:     statemachine.EmptySet(),
+		FieldGate:       entitymanager.AllowAllFieldGate{},
 		VersionRecorder: rec,
 	})
 	if err != nil {

--- a/internal/lua/acl_bypass_test.go
+++ b/internal/lua/acl_bypass_test.go
@@ -22,6 +22,9 @@ func (r *recordingMutator) CreateEntity(context.Context, *entity.Entity, entity.
 func (r *recordingMutator) UpdateEntity(context.Context, *entity.Entity) (*entity.UpdateResult, error) {
 	return &entity.UpdateResult{}, nil
 }
+func (r *recordingMutator) PatchEntity(context.Context, string, entity.Patch) (*entity.UpdateResult, error) {
+	return &entity.UpdateResult{}, nil
+}
 func (r *recordingMutator) DeleteEntity(context.Context, string, bool) (*entity.DeleteResult, error) {
 	return &entity.DeleteResult{}, nil
 }

--- a/internal/lua/aclreads_test.go
+++ b/internal/lua/aclreads_test.go
@@ -3,6 +3,7 @@ package lua_test
 import (
 	"context"
 	"errors"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -116,10 +117,9 @@ func newACLWorld(t *testing.T) (store.Store, lua.WriteDeps) {
 		ReadDeps: lua.ReadDeps{
 			VisibleReader: scriptReader,
 			// RAW on purpose — the read-before-write handle. See AC6.
-			WritePrepStore: st,
-			Tracer:         visTracer,
-			Meta:           aclWorldMeta(),
-			ProjectRoot:    t.TempDir(),
+			Tracer:      visTracer,
+			Meta:        aclWorldMeta(),
+			ProjectRoot: t.TempDir(),
 		},
 		EntityManager: entitymanagertest.PanicOnUse{},
 	}
@@ -238,15 +238,21 @@ rela.output("nodes=" .. table.concat(walk(rela.trace_from("TKT-1", 2), {}), ",")
 // data-destruction guard, and the single most important test in this
 // ticket.
 //
-// rela.update_entity does GetEntity → Clone → merge → save. If that read
-// went through the REDACTING reader, the clone would lack the caller's
-// hidden properties and the save would ERASE them. The write-prep handle
-// is raw precisely to prevent that.
+// The hazard: a read-modify-write whose READ is redacted produces a clone
+// missing the caller's hidden properties, and the save then ERASES them.
 //
-// This test runs the REAL binding end-to-end and asserts on the PERSISTED
-// entity, so it fails if anyone points luaUpdateEntity at VisibleReader —
-// which an earlier version of this test, asserting only on the deps
-// handles, did not (RR-KYWIMZ).
+// Since TKT-80EWGM the binding no longer performs that read at all — it
+// builds an entity.Patch naming only what the script supplied and hands it
+// to PatchEntity, which merges against the raw stored entity internally.
+// The invariant this test pins is therefore now structural rather than
+// conventional: there is no store handle on the binding to point at the
+// wrong reader.
+//
+// The test is kept (and still asserts on the PERSISTED entity) because it
+// is the end-to-end proof of the property that matters — a caller who
+// cannot READ `salary` cannot ERASE it either — independent of which
+// mechanism currently provides it. An earlier version asserting only on
+// the deps handles would not have caught a regression here (RR-KYWIMZ).
 func TestScriptReads_UpdatePreservesHiddenProperties(t *testing.T) {
 	st, deps := newACLWorld(t)
 	deps.EntityManager = &storeMutator{st: st}
@@ -277,6 +283,26 @@ func (m *storeMutator) UpdateEntity(ctx context.Context, e *entity.Entity) (*ent
 		return nil, err
 	}
 	return &entity.UpdateResult{Entity: e}, nil
+}
+
+// PatchEntity mirrors the real manager: read the STORED entity, merge the
+// patch onto it, save. The read is the raw store, which is exactly what
+// entitymanager.PatchEntity does internally — so the AC6 test still
+// exercises a genuine read-merge-save round trip and would still catch a
+// redacted write-prep read.
+func (m *storeMutator) PatchEntity(
+	ctx context.Context, id string, p entity.Patch,
+) (*entity.UpdateResult, error) {
+	stored, err := m.st.GetEntity(ctx, id)
+	if err != nil {
+		return nil, fmt.Errorf("entity not found: %s", id)
+	}
+	updated := stored.Clone()
+	p.Apply(updated)
+	if err := m.st.UpdateEntity(ctx, updated); err != nil {
+		return nil, err
+	}
+	return &entity.UpdateResult{Entity: updated}, nil
 }
 
 func (m *storeMutator) CreateEntity(
@@ -343,11 +369,10 @@ func TestScriptReads_NilReaderDenies(t *testing.T) {
 	}
 	deps := lua.WriteDeps{
 		ReadDeps: lua.ReadDeps{
-			VisibleReader:  nil, // the wiring omission under test
-			WritePrepStore: st,  // present, and must NOT be used as a fallback
-			Tracer:         tracer.New(st),
-			Meta:           aclWorldMeta(),
-			ProjectRoot:    t.TempDir(),
+			VisibleReader: nil, // the wiring omission under test
+			Tracer:        tracer.New(st),
+			Meta:          aclWorldMeta(),
+			ProjectRoot:   t.TempDir(),
 		},
 		EntityManager: entitymanagertest.PanicOnUse{},
 	}

--- a/internal/lua/deps.go
+++ b/internal/lua/deps.go
@@ -2,6 +2,7 @@ package lua
 
 import (
 	"context"
+	"errors"
 	"iter"
 
 	"github.com/Sourcehaven-BV/rela/internal/entity"
@@ -97,6 +98,32 @@ type Mutator interface {
 	DeleteEntity(ctx context.Context, id string, cascade bool) (*entity.DeleteResult, error)
 	CreateRelation(ctx context.Context, from, relType, to string, opts entity.RelationOptions) (*entity.Relation, error)
 	DeleteRelation(ctx context.Context, from, relType, to string) error
+}
+
+// NotFoundError is an OPTIONAL capability a [Mutator]'s returned error may
+// implement to say "the target entity does not exist". Declared here at the
+// consumer so lua needs no dependency on internal/entitymanager (same
+// rationale as [Mutator] itself); the production error type satisfies it.
+//
+// Why this exists rather than a string match: several hard errors embed
+// caller-supplied values. An illegal state-machine transition formats the
+// attempted value with %q, so `strings.Contains(err.Error(), "entity not
+// found")` misreports a *rejected transition* as a *missing entity* when a
+// script sets a property to that literal text — and a script branching on
+// that message could try to recreate a row that still exists. Structural
+// beats textual.
+type NotFoundError interface {
+	error
+	// EntityNotFound reports that the write failed because the target
+	// entity does not exist, as opposed to any other hard error.
+	EntityNotFound() bool
+}
+
+// isEntityNotFound reports whether err (or anything it wraps) declares
+// itself an entity-not-found condition.
+func isEntityNotFound(err error) bool {
+	var nfe NotFoundError
+	return errors.As(err, &nfe) && nfe.EntityNotFound()
 }
 
 // WriteDeps is the capability bundle required to run a read-write Lua runtime.

--- a/internal/lua/deps.go
+++ b/internal/lua/deps.go
@@ -43,22 +43,19 @@ type ReadDeps struct {
 	// scripts can see.
 	//
 	// A nil VisibleReader DENIES (the binding raises); it never falls back
-	// to WritePrepStore. A forgotten wiring must not become an ACL bypass
+	// to a raw handle. A forgotten wiring must not become an ACL bypass
 	// (RR-X9NVHI).
-	VisibleReader EntityReader
-
-	// WritePrepStore is the RAW, ungated store handle, used by exactly one
-	// binding: rela.update_entity's read-before-write.
 	//
-	// DO NOT route read-outs through this, and DO NOT "tidy" it away by
-	// pointing update_entity at VisibleReader. update_entity does
-	// GetEntity → Clone → merge → save, so reading a REDACTED entity there
-	// would drop the caller's hidden properties from the clone and ERASE
-	// THEM ON SAVE — silent data destruction. This is the read-out /
-	// write-prep boundary DEC-ZBI39P calls out; the two fields are separate
-	// so the wrong choice is visible at the call site. Nil on reader
-	// runtimes (NewReader), which have no write bindings.
-	WritePrepStore store.Store
+	// There is deliberately NO second, raw store field beside this one.
+	// rela.update_entity used to need one for its read-before-write — and
+	// that field was a standing hazard, since pointing it at VisibleReader
+	// by mistake made the save erase whatever the caller could not see.
+	// The binding now builds an [entity.Patch] and lets the manager merge
+	// against the raw stored entity internally (TKT-80EWGM), so no Lua
+	// binding holds an ungated read path and the mistake is unavailable.
+	// Elevated reads are the sole exception and stay explicitly opt-in via
+	// [WriteDeps.ElevatedReader].
+	VisibleReader EntityReader
 
 	// Tracer is the graph-traversal surface. Wiring injects either the
 	// plain tracer or a visibility decorator over it; the trace bindings
@@ -85,13 +82,18 @@ type ReadDeps struct {
 // site supplies an implementation (the production one being the
 // project's EntityManager).
 //
-// Five methods — RenameEntity and UpdateRelation are intentionally
+// Six methods — RenameEntity and UpdateRelation are intentionally
 // absent because no Lua binding invokes them. Narrowed from the
 // wider EntityManager interface in TKT-IF37 to drop lua's transitive
 // dependency on internal/entitymanager.
+//
+// PatchEntity is what rela.update_entity is built on: the binding names
+// the properties the script touched and nothing else, so it needs no raw
+// store handle of its own to read-modify-write through (TKT-80EWGM).
 type Mutator interface {
 	CreateEntity(ctx context.Context, e *entity.Entity, opts entity.CreateOptions) (*entity.CreateResult, error)
 	UpdateEntity(ctx context.Context, e *entity.Entity) (*entity.UpdateResult, error)
+	PatchEntity(ctx context.Context, id string, p entity.Patch) (*entity.UpdateResult, error)
 	DeleteEntity(ctx context.Context, id string, cascade bool) (*entity.DeleteResult, error)
 	CreateRelation(ctx context.Context, from, relType, to string, opts entity.RelationOptions) (*entity.Relation, error)
 	DeleteRelation(ctx context.Context, from, relType, to string) error
@@ -117,13 +119,12 @@ type WriteDeps struct {
 	// ungated — the closure is the boundary, so a half-elevated read would
 	// be a confusing contract.
 	//
-	// SEPARATE from WritePrepStore on purpose, even though production wires
-	// both from the same raw store. WritePrepStore is present on EVERY
-	// writer runtime (update_entity's read-before-write needs it); routing
-	// elevated reads through it would hand every writer runtime an ungated
-	// read path and dissolve the two-key gate that makes elevation
-	// opt-in. This field is set at the same site, under the same two
-	// conditions, as ElevatedManager.
+	// This is now the ONLY raw read handle a writer runtime can carry, and
+	// it is opt-in: set at the same site, under the same two conditions, as
+	// ElevatedManager. Previously a second raw field (WritePrepStore) was
+	// present on EVERY writer runtime for update_entity's read-before-write;
+	// removing it (TKT-80EWGM) means an ungated read path now exists only
+	// where elevation was explicitly requested.
 	//
 	// Nil is a DENY, not a fallback: admin.get_entity raises rather than
 	// silently reading through the gated VisibleReader. Elevation that

--- a/internal/lua/runtime.go
+++ b/internal/lua/runtime.go
@@ -1749,9 +1749,10 @@ func (r *Runtime) luaUpdateEntity(ls *lua.LState) int {
 	result, err := r.deps.EntityManager.PatchEntity(ctx, id, patch)
 	if err != nil {
 		// Preserve the pre-TKT-80EWGM message for a missing entity: scripts
-		// match on it. lua cannot import entitymanager for its sentinel
-		// (consumer-side interface), so the check is on the wrapped text.
-		if strings.Contains(err.Error(), "entity not found") {
+		// match on it. The check is STRUCTURAL (see [NotFoundError]) — a
+		// text match would misreport an illegal-transition rejection, whose
+		// message embeds the caller's own property value, as a 404.
+		if isEntityNotFound(err) {
 			ls.RaiseError("entity not found: %s", id)
 			return 0
 		}

--- a/internal/lua/runtime.go
+++ b/internal/lua/runtime.go
@@ -15,7 +15,6 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
-	"maps"
 	"math"
 	"os"
 	"path/filepath"
@@ -1729,40 +1728,33 @@ func (r *Runtime) luaUpdateEntity(ls *lua.LState) int {
 	}
 
 	ctx := r.callerCtx()
-	if r.deps.WritePrepStore == nil {
-		ls.RaiseError("rela.update_entity: no write-prep store is configured for this runtime")
-		return 0
-	}
-	// WritePrepStore, NOT VisibleReader — deliberately raw. The clone below
-	// becomes the SAVED entity, so reading a redacted copy here would drop
-	// the caller's hidden properties and erase them on save. See the field's
-	// godoc in deps.go; the guard test pins this.
-	existing, err := r.deps.WritePrepStore.GetEntity(ctx, id)
-	if err != nil {
-		ls.RaiseError("entity not found: %s", id)
-		return 0
-	}
 
-	// Clone for update
-	updated := existing.Clone()
+	// A TARGETED write: name only what the script actually supplied and let
+	// the manager merge it against the raw stored entity. The binding holds
+	// no store handle at all, so the read-before-write that used to erase a
+	// caller's hidden properties is now unreachable from here (TKT-80EWGM).
+	var patch entity.Patch
 
 	// Merge properties if provided
 	if ls.GetTop() >= 2 && ls.Get(2).Type() == lua.LTTable {
-		propsTable := ls.CheckTable(2)
-		newProps := luaTableToGoMap(propsTable)
-		if updated.Properties == nil {
-			updated.Properties = make(map[string]any)
-		}
-		maps.Copy(updated.Properties, newProps)
+		patch.Properties = luaTableToGoMap(ls.CheckTable(2))
 	}
 
 	// Update content if provided (nil means not provided, empty string clears content)
 	if ls.GetTop() >= 3 && ls.Get(3).Type() != lua.LTNil {
-		updated.Content = ls.CheckString(3)
+		content := ls.CheckString(3)
+		patch.Content = &content
 	}
 
-	result, err := r.deps.EntityManager.UpdateEntity(ctx, updated)
+	result, err := r.deps.EntityManager.PatchEntity(ctx, id, patch)
 	if err != nil {
+		// Preserve the pre-TKT-80EWGM message for a missing entity: scripts
+		// match on it. lua cannot import entitymanager for its sentinel
+		// (consumer-side interface), so the check is on the wrapped text.
+		if strings.Contains(err.Error(), "entity not found") {
+			ls.RaiseError("entity not found: %s", id)
+			return 0
+		}
 		ls.RaiseError("update entity error: %s", err.Error())
 		return 0
 	}

--- a/internal/lua/runtime_test.go
+++ b/internal/lua/runtime_test.go
@@ -201,7 +201,9 @@ func (m *mockManager) PatchEntity(
 ) (*entity.UpdateResult, error) {
 	stored, err := m.ws.store.GetEntity(ctx, id)
 	if err != nil {
-		return nil, fmt.Errorf("entity not found: %s", id)
+		// Structural marker, matching the production manager — the binding
+		// detects not-found via the interface, not the message.
+		return nil, fakeNotFoundError{id: id}
 	}
 	updated := stored.Clone()
 	p.Apply(updated)
@@ -210,6 +212,13 @@ func (m *mockManager) PatchEntity(
 	}
 	return &entity.UpdateResult{Entity: updated}, nil
 }
+
+// fakeNotFoundError mirrors the production entity-not-found error's structural
+// marker so the fake exercises the same detection path as production.
+type fakeNotFoundError struct{ id string }
+
+func (e fakeNotFoundError) Error() string        { return "entity not found: " + e.id }
+func (e fakeNotFoundError) EntityNotFound() bool { return true }
 
 func (m *mockManager) DeleteEntity(
 	ctx context.Context, id string, cascade bool,
@@ -3029,5 +3038,79 @@ func TestRunValidationString_StripsShebang(t *testing.T) {
 	}
 	if num != 42 {
 		t.Errorf("got %v, want 42", num)
+	}
+}
+
+// misreportingMutator returns a NON-404 hard error whose text embeds a
+// caller-supplied value — the exact shape internal/statemachine produces
+// for an illegal transition (`%s %q→%q is not a declared transition`).
+type misreportingMutator struct {
+	Mutator
+	err error
+}
+
+func (m misreportingMutator) PatchEntity(
+	context.Context, string, entity.Patch,
+) (*entity.UpdateResult, error) {
+	return nil, m.err
+}
+
+// TestUpdateEntity_NonNotFoundErrorIsNotMisreported is a regression test
+// for a bug found in code review.
+//
+// rela.update_entity briefly detected "entity not found" with
+// strings.Contains over the whole error text. That is unsafe: several hard
+// errors interpolate CALLER-SUPPLIED values, so a script setting a property
+// to the literal string "entity not found" had its illegal-transition
+// rejection reported as a missing entity. A script branching on that
+// message could then try to recreate a row that still exists.
+//
+// Detection is structural now (lua.NotFoundError). This pins that a
+// non-404 error carrying the magic substring is reported as itself.
+func TestUpdateEntity_NonNotFoundErrorIsNotMisreported(t *testing.T) {
+	t.Parallel()
+	ws := newMockWorkspace(t)
+	deps := ws.services(t.TempDir())
+
+	// Verbatim shape of statemachine's illegal-transition error, with the
+	// caller's own value ("entity not found") interpolated via %q.
+	deps.EntityManager = misreportingMutator{
+		err: fmt.Errorf(
+			"illegal transition: status %q→%q is not a declared transition",
+			"todo", "entity not found",
+		),
+	}
+
+	r := NewWriter(deps, io.Discard)
+	defer r.Close()
+
+	err := r.RunString(`rela.update_entity("TKT-001", {status = "entity not found"})`)
+	if err == nil {
+		t.Fatal("expected the illegal-transition error to surface")
+	}
+	if !strings.Contains(err.Error(), "not a declared transition") {
+		t.Errorf("the real error was lost; got: %v", err)
+	}
+	// The specific regression: it must NOT be dressed up as a 404.
+	if strings.HasPrefix(strings.TrimSpace(err.Error()), "entity not found:") {
+		t.Errorf("non-404 error misreported as entity-not-found: %v", err)
+	}
+}
+
+// TestUpdateEntity_NotFoundStillReported pins the other half: a genuine
+// missing entity keeps its original script-facing message, which existing
+// scripts match on.
+func TestUpdateEntity_NotFoundStillReported(t *testing.T) {
+	t.Parallel()
+	ws := newMockWorkspace(t)
+	r := NewWriter(ws.services(t.TempDir()), io.Discard)
+	defer r.Close()
+
+	err := r.RunString(`rela.update_entity("NOPE-999", {title = "x"})`)
+	if err == nil {
+		t.Fatal("expected an error for a missing entity")
+	}
+	if !strings.Contains(err.Error(), "entity not found: NOPE-999") {
+		t.Errorf("missing-entity message changed; got: %v", err)
 	}
 }

--- a/internal/lua/runtime_test.go
+++ b/internal/lua/runtime_test.go
@@ -111,12 +111,11 @@ func (m *mockWorkspace) seedRelation(r *entity.Relation) {
 func (m *mockWorkspace) services(projectRoot string) WriteDeps {
 	return WriteDeps{
 		ReadDeps: ReadDeps{
-			VisibleReader:  m.store,
-			WritePrepStore: m.store,
-			Tracer:         tracer.New(m.store),
-			Searcher:       &mockSearcher{ws: m},
-			Meta:           m.meta,
-			ProjectRoot:    projectRoot,
+			VisibleReader: m.store,
+			Tracer:        tracer.New(m.store),
+			Searcher:      &mockSearcher{ws: m},
+			Meta:          m.meta,
+			ProjectRoot:   projectRoot,
 		},
 		EntityManager: &mockManager{ws: m},
 	}
@@ -191,6 +190,25 @@ func (m *mockManager) UpdateEntity(
 		return nil, err
 	}
 	return &entity.UpdateResult{Entity: e}, nil
+}
+
+// PatchEntity mirrors the real manager's targeted-write semantics
+// (read the STORED entity, merge, unset, then save) so binding tests
+// exercise the same preserve-what-you-did-not-name behavior they do
+// in production rather than a permissive stub.
+func (m *mockManager) PatchEntity(
+	ctx context.Context, id string, p entity.Patch,
+) (*entity.UpdateResult, error) {
+	stored, err := m.ws.store.GetEntity(ctx, id)
+	if err != nil {
+		return nil, fmt.Errorf("entity not found: %s", id)
+	}
+	updated := stored.Clone()
+	p.Apply(updated)
+	if err := m.ws.store.UpdateEntity(ctx, updated); err != nil {
+		return nil, err
+	}
+	return &entity.UpdateResult{Entity: updated}, nil
 }
 
 func (m *mockManager) DeleteEntity(
@@ -2446,12 +2464,14 @@ func (s *ctxSpySearcher) Search(ctx context.Context, q search.Query) iter.Seq2[s
 func spiedDeps(realDeps WriteDeps, rec *ctxRecorder) WriteDeps {
 	return WriteDeps{
 		ReadDeps: ReadDeps{
-			VisibleReader:  &ctxSpyStore{Store: realDeps.WritePrepStore, rec: rec},
-			WritePrepStore: realDeps.WritePrepStore,
-			Tracer:         &ctxSpyTracer{inner: realDeps.Tracer, rec: rec},
-			Searcher:       &ctxSpySearcher{inner: realDeps.Searcher, rec: rec},
-			Meta:           realDeps.Meta,
-			ProjectRoot:    realDeps.ProjectRoot,
+			// The fixture's VisibleReader is backed by the mock store, so it
+			// satisfies store.Store; assert rather than carry a second raw
+			// handle just for the spy.
+			VisibleReader: &ctxSpyStore{Store: realDeps.VisibleReader.(store.Store), rec: rec},
+			Tracer:        &ctxSpyTracer{inner: realDeps.Tracer, rec: rec},
+			Searcher:      &ctxSpySearcher{inner: realDeps.Searcher, rec: rec},
+			Meta:          realDeps.Meta,
+			ProjectRoot:   realDeps.ProjectRoot,
 		},
 		EntityManager: realDeps.EntityManager,
 	}

--- a/internal/mcp/tools_entity.go
+++ b/internal/mcp/tools_entity.go
@@ -4,6 +4,7 @@ package mcp
 import (
 	"context"
 	"fmt"
+	"slices"
 	"strings"
 
 	"github.com/mark3labs/mcp-go/mcp"
@@ -214,19 +215,30 @@ func (s *Server) handleUpdateEntity(
 		return errResult, nil
 	}
 
-	// Apply property updates: nil deletes, anything else sets/overwrites.
+	// Translate the wire shape into a targeted patch: MCP's in-band nil
+	// sentinel means "delete", anything else upserts. Everything not named
+	// is preserved by PatchEntity, so this tool can no longer clobber a
+	// property it did not mention (TKT-80EWGM).
+	patch := entity.Patch{Properties: make(map[string]any, len(properties))}
 	for k, v := range properties {
 		if v == nil {
-			delete(e.Properties, k)
+			patch.MetaUnset = append(patch.MetaUnset, k)
 			continue
 		}
-		e.Properties[k] = v
+		patch.Properties[k] = v
 	}
+	// Deletion order does not affect the result, but a stable slice keeps
+	// audit summaries and test expectations deterministic.
+	slices.Sort(patch.MetaUnset)
+	// Deliberately NOT a pointer-to-"": MCP has no sentinel for "clear the
+	// body", and inventing one here would silently change the tool's
+	// contract. An empty content string means "leave the body alone", as
+	// the `content == ""` guard above already implies.
 	if content != "" {
-		e.Content = content
+		patch.Content = &content
 	}
 
-	updateResult, updateErr := s.deps.EntityManager.UpdateEntity(ctx, e)
+	updateResult, updateErr := s.deps.EntityManager.PatchEntity(ctx, id, patch)
 	if updateErr != nil {
 		return mcp.NewToolResultError(updateErr.Error()), nil
 	}

--- a/internal/script/elevation_test.go
+++ b/internal/script/elevation_test.go
@@ -147,15 +147,20 @@ func TestRun_ElevationRequiresBothKeys(t *testing.T) {
 
 // TestRun_NoElevatedReaderWhenNoneSupplied pins that Run hands over only
 // what the WIRING SITE gave it. A runner built without a reader must not
-// synthesize one from readDeps — WritePrepStore is a raw store sitting
-// right there, and reaching for it would grant read elevation at every
-// wiring site rather than the ones that opted in.
+// synthesize one from readDeps.
+//
+// The specific temptation this guarded against is now gone: readDeps used
+// to carry an always-present raw WritePrepStore that a future refactor
+// could have reached for, granting read elevation at every wiring site
+// rather than the ones that opted in. TKT-80EWGM removed that field, so
+// there is no raw handle in readDeps left to synthesize from. The
+// assertion is kept because the RULE — elevation comes from the wiring
+// site, never from ambient deps — outlives the particular field.
 func TestRun_NoElevatedReaderWhenNoneSupplied(t *testing.T) {
 	t.Parallel()
 	exec := &depsCapturingExecutor{}
-	// NewLuaScriptRunner is the no-read-elevation constructor. WritePrepStore
-	// is deliberately populated: the temptation this test guards against.
-	r := NewLuaScriptRunner(exec, lua.ReadDeps{WritePrepStore: nil})
+	// NewLuaScriptRunner is the no-read-elevation constructor.
+	r := NewLuaScriptRunner(exec, lua.ReadDeps{})
 
 	err := r.Run(context.Background(), autocascade.ScriptAction{
 		Code:           "print('x')",

--- a/internal/script/executor_test.go
+++ b/internal/script/executor_test.go
@@ -20,10 +20,9 @@ func testWriteDeps(projectRoot string) lua.WriteDeps {
 	st := memstore.New()
 	return lua.WriteDeps{
 		ReadDeps: lua.ReadDeps{
-			VisibleReader:  st,
-			WritePrepStore: st,
-			Tracer:         tracer.New(st),
-			ProjectRoot:    projectRoot,
+			VisibleReader: st,
+			Tracer:        tracer.New(st),
+			ProjectRoot:   projectRoot,
 		},
 		EntityManager: entitymanagertest.PanicOnUse{},
 	}

--- a/internal/store/storetest/entity.go
+++ b/internal/store/storetest/entity.go
@@ -38,10 +38,11 @@ func RunEntityTests(t *testing.T, f Factory) {
 	// structs directly rather than serializing through markdown, so a
 	// markdown-only assertion would not cover it (RR-KBWJPV).
 	//
-	// A redacted entity should never reach a write path at all — that is
-	// what lua.ReadDeps.WritePrepStore keeps separate — but the whole
-	// design rests on that separation, so it is worth one cheap assertion
-	// that a slip does not persist someone's per-principal view.
+	// A redacted entity should never reach a write path at all — write-prep
+	// reads go through entitymanager.PatchEntity, which merges against the
+	// raw stored entity — but the whole design rests on that separation, so
+	// it is worth one cheap assertion that a slip does not persist someone's
+	// per-principal view.
 	t.Run("RedactedNotPersisted", func(t *testing.T) {
 		s := f(t)
 		e := entity.New("FEAT-002", "feature")

--- a/internal/validation/lua_test.go
+++ b/internal/validation/lua_test.go
@@ -73,11 +73,10 @@ func newMockWorkspace() *mockWorkspace {
 // services returns lua.ReadDeps for the validation runtime.
 func (m *mockWorkspace) services(projectRoot string) lua.ReadDeps {
 	return lua.ReadDeps{
-		VisibleReader:  m.store,
-		WritePrepStore: m.store,
-		Tracer:         tracer.New(m.store),
-		Meta:           m.meta,
-		ProjectRoot:    projectRoot,
+		VisibleReader: m.store,
+		Tracer:        tracer.New(m.store),
+		Meta:          m.meta,
+		ProjectRoot:   projectRoot,
 	}
 }
 

--- a/tickets/entities/automated-measures/cascade-write-full-pipeline-test.md
+++ b/tickets/entities/automated-measures/cascade-write-full-pipeline-test.md
@@ -1,0 +1,48 @@
+---
+id: cascade-write-full-pipeline-test
+type: automated-measure
+title: 'Test: cascade-created entity writes run the full manager pipeline (validation, unique, transitions, audit)'
+description: 'Pins that the cascade re-write of an automation-created entity (autocascade/runner.go:182-191 -> cascadeHost.WriteEntity) runs the full manager pipeline: metamodel validation, unique-constraint checks, state-machine transition enforcement, and audit. Fails if cascadeHost.WriteEntity writes directly to store.Store. Behavioural, not structural, so a raw handle reintroduced by another route still fails.'
+kind: test
+location: internal/entitymanager/ (new test alongside audit_durability_test.go) — to be created by BUG-KIMZRK
+status: proposed
+---
+
+## What it asserts
+
+A write performed **during a cascade** — specifically the re-write of a
+cascade-created entity after automation `set` actions
+(`internal/autocascade/runner.go:182-191` → `Host.WriteEntity`) — is subject to
+the same write pipeline as a top-level write:
+
+1. metamodel validation runs (an invalid post-automation value does not persist
+silently)
+2. `unique: true` constraints are enforced against post-automation values
+3. state-machine transitions are enforced (an automation cannot drive an entity into
+a state the metamodel forbids)
+4. an audit record is emitted for the cascade write
+
+## Why it is needed
+
+`cascadeHost.WriteEntity` (`internal/entitymanager/cascadehost.go:79-84`)
+currently calls `h.deps.Store.UpdateEntity` directly, skipping all four. The
+sibling top-level create path (`manager.go:456-476`) explicitly re-checks
+uniques post-automation with the reasoning that it *"must not be the weaker
+one"* — this measure pins that the cascade path is not weaker either.
+
+## Shape
+
+An integration test driving a real automation that creates an entity and sets a
+property inside a cascade, with table cases for: a unique-constraint violation,
+a forbidden state-machine transition, an invalid property value, and an
+assertion that the audit sink received a record for the cascade write.
+
+Prefer a **behavioural** assertion over a structural one (do not merely assert
+`cascadeHost` holds no `store.Store` field) so a future refactor that
+re-introduces a raw handle by another route still fails. This mirrors the
+reasoning recorded in `AM-ungated-read-contract-not-identity` — assert the
+contract, not pointer identity.
+
+Complements `audit-durable-write-before-cascade-test`, which pins audit for the
+*trigger* entity's durable write; this one covers entities written *inside* the
+cascade.

--- a/tickets/entities/bugs/BUG-KIMZRK.md
+++ b/tickets/entities/bugs/BUG-KIMZRK.md
@@ -1,0 +1,101 @@
+---
+id: BUG-KIMZRK
+type: bug
+title: cascadeHost.WriteEntity persists automation-set properties directly to the store, bypassing ACL, validation, unique checks, transitions and audit
+description: internal/entitymanager/cascadehost.go:79-84 calls h.deps.Store.UpdateEntity directly instead of Manager.UpdateEntity, so cascade re-writes of automation-set properties skip ACL authorization, metamodel validation, unique-constraint checks, state-machine transition enforcement, and the audit log. Contradicts the root CLAUDE.md rule that all writes go through the Manager. The sibling top-level create path (manager.go:456-476) explicitly re-checks uniques post-automation with the reasoning that it 'must not be the weaker one' — the cascade path has no equivalent. Found while investigating TKT-80EWGM.
+priority: high
+status: backlog
+---
+
+## Summary
+
+`cascadeHost.WriteEntity` (`internal/entitymanager/cascadehost.go:79-84`) writes
+straight to the raw store:
+
+```go
+func (h *cascadeHost) WriteEntity(ctx context.Context, e *entity.Entity) error {
+	if e == nil { return nil }
+	return h.deps.Store.UpdateEntity(ctx, e)
+}
+```
+
+It does **not** go through `Manager.UpdateEntity`, so this write skips the
+entire write pipeline:
+
+- ACL authorization (`authorizeAndAudit`)
+- metamodel validation (`Meta.ValidateEntity`) and DEC-HWZHA warning partitioning
+- `unique: true` natural-key enforcement (`checkUniqueProperties`)
+- state-machine transition enforcement (`Transitions.EnforceUpdate`)
+- audit log entry (`recordEntityAudit`)
+
+This contradicts root `CLAUDE.md`: *"All writes go through
+`entitymanager.Manager`; do not write to `store.Store` directly from a write
+path."*
+
+## Trigger path
+
+`internal/autocascade/runner.go:182-191` — for entities **created during a
+cascade**, automation-set properties are applied and then re-written via the
+host:
+
+```go
+for prop, val := range newAutoResult.PropertiesSet {
+    created.SetString(prop, val)
+}
+// Re-write entity with updated properties.
+if err := host.WriteEntity(ctx, created); err != nil {
+```
+
+So a metamodel automation that creates an entity and sets properties on it
+during a cascade lands those values in the store unvalidated and unaudited.
+
+## Why this is a real inconsistency, not a deliberate design
+
+The sibling **top-level create path** explicitly does the opposite. At
+`internal/entitymanager/manager.go:456-476`, after automation mutates the
+created entity, it **re-runs `checkUniqueProperties` against the post-automation
+values**, with the stated reasoning that the create path *"must not be the
+weaker one."* The cascade's re-write has no equivalent.
+
+Only the missing audit is documented (`cascadehost.go:76-78`). The skipped ACL,
+validation, unique, and transition checks are undocumented — which suggests
+oversight rather than an accepted trade-off.
+
+## Suspected impact
+
+- An automation can drive an entity into a state the state machine forbids.
+- A `unique:` constraint can be violated by a cascade-created entity.
+- A cascade write produces **no audit record**, so an entity can change with no trace
+— notable given `audit-log` is a stable concept and the attribution work
+(TKT-ZIRMGM) assumes manager-boundary coverage.
+- Property values that would fail validation persist silently.
+
+Severity is provisionally **high** because it is an unaudited, unvalidated write
+path, but real-world reachability depends on how many projects use
+`create_entity` automations with `set` actions inside a cascade — **needs
+confirmation during analysis** before the priority is trusted.
+
+## Relationship to TKT-80EWGM
+
+Found while investigating TKT-80EWGM (unified `PatchEntity` primitive). It is
+**explicitly out of scope** there: `PatchEntity` neither fixes nor worsens this.
+Filed separately because routing `cascadeHost.WriteEntity` through the manager
+changes cascade semantics — validation or a transition guard could now reject an
+automation write **mid-cascade**, which needs its own design (partial-cascade
+rollback is a known open question; cf. RR-KNXFF "Partial-failure rollback on
+multi-op writes", wont-fix).
+
+## Suggested analysis starting points
+
+- Confirm reachability with a failing test: an automation that creates an entity and
+sets a property violating a `unique:` constraint or a state-machine transition.
+- Establish whether the audit gap is observable end-to-end (write happens, no audit
+line).
+- Decide the failure mode when a mid-cascade write is rejected — abort the cascade,
+or collect into `autocascade.Outcome.Errors`? Note TKT-MSR8 ("Propagate
+cascade-step warnings through autocascade.Outcome") is adjacent and may want
+doing together.
+- 5-whys should reach why the cascade host was given a raw store handle at all, rather
+than the `gated()` mutator the scripted path already uses
+(`autocascade/mutator.go:27-33`, wired at `manager.go:487` and
+`manager.go:643`).

--- a/tickets/entities/implementation-checklists/IMPL-T8S8LU.md
+++ b/tickets/entities/implementation-checklists/IMPL-T8S8LU.md
@@ -1,0 +1,140 @@
+---
+id: IMPL-T8S8LU
+type: implementation-checklist
+title: 'Implementation: Unified targeted-write primitive: entitymanager.PatchEntity replaces four hand-rolled property merges'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+Landed as 5 commits on `tkt-80ewgm-patch-entity`, sequenced so the risky
+refactor is isolated and reviewable on its own:
+
+| Commit | What |
+|---|---|
+| `29964269` | extract `updateCore` (behaviour-preserving, standalone) |
+| `08c15888` | `entity.Patch` + `Manager.PatchEntity` + `FieldWriteGate` |
+| `a3ef1817` | lua migration; **delete `ReadDeps.WritePrepStore`** |
+| `8619cf72` | mcp + cli migrations |
+| `c575a947` | docs: root CLAUDE.md rule, entitymanager CLAUDE.md, cli-reference |
+
+## Development
+
+- [x] Unit tests written for new code
+- [x] Integration tests written (test full flow, not just units)
+- [x] Happy path implemented
+- [x] Edge cases from planning handled
+- [x] Error handling in place (errors surfaced, not swallowed)
+
+New tests in `internal/entitymanager/patch_test.go` (13 funcs / 20 cases) plus
+`internal/cli/update_test.go` (flag→patch translation). Integration coverage
+runs through real `Deps` with automation + cascade + audit wired, not stubs.
+
+**Two deviations from plan, both deliberate:**
+
+1. **`entity.EntityPatch` → `entity.Patch`.** revive flagged the stutter
+(`entity.EntityPatch`). Renamed before it reached any consumer.
+2. **The field gate is wired as `AllowAllFieldGate` everywhere, not
+policy-backed.** The real resolver lives behind
+`dataentry.newFieldVerdictResolver`, and `appbuild` may not import
+`internal/affordances` under arch-lint (`.go-arch-lint.yml:410-434`). Wiring it
+properly means moving resolver construction out of `dataentry` — more than this
+ticket scoped. **This preserves today's exact behaviour** (no path outside
+dataentry gates fields today), and the seam is now in place, so it becomes a
+wiring change rather than a rewrite. Flagged as a follow-up, not silently
+dropped.
+
+## Test Quality
+
+- [x] Using fixture builders or factories for test data
+- [x] No hardcoded values in assertions when object is in scope
+- [x] Only specifying values that matter for the test
+- [x] Interpolated values constructed from objects, not hardcoded
+- [x] Property comparisons use original object, not hardcoded strings
+
+`newPatchManager(t, gate)` / `seedTask` / `mustGet` are the fixture helpers;
+`recordingGate` records what it was asked so tests assert the gate was
+*consulted*, not merely that a write succeeded.
+
+**Mutation-tested the audit assertion** rather than trusting it: disabling
+`recordEntityAudit` makes `TestPatchEntity_RunsFullPipeline` fail with "no audit
+record emitted"; restoring it passes. The assertion is real, not vacuous. This
+mattered because `internal/entitymanager/CLAUDE.md` warns audit is inherited by
+method *name* — `PatchEntity` is not in that set, so it had to be verified
+rather than assumed.
+
+## Manual Verification
+
+- [x] Feature manually tested end-to-end
+- [x] Each acceptance criterion verified with test scenario from planning
+- [x] Edge cases manually verified
+
+**Verification Evidence:**
+
+Built `cmd/rela` and drove a real fs-backed project (`/tmp/clitest`), not a test
+harness:
+
+| # | Command | Result |
+|---|---|---|
+| 1 | `update TASK-1 -t Renamed` | title changed; `due` + `notes` + body untouched |
+| 2 | `update TASK-1 -U due` | `due` key gone; `title` + `notes` survive |
+| 3 | `update TASK-1 -P due=2026-12-31` | re-set; others survive |
+| 4 | `update TASK-1 --clear-body` | body empty, frontmatter intact |
+| 5 | `update TASK-1 -P notes=` | `notes: ""` — **old semantics preserved** |
+| 6 | `update TASK-1 --clear-body -b x` | exit 1, "cannot be combined" |
+
+Case 5 is the backward-compat one: `-P key=` still sets the empty string rather
+than removing, so existing scripts are unaffected; removal is the new `-U`.
+
+*(Note during verification: I initially read a hand-created `entities/task/`
+directory and concluded the writes were failing. The store uses the plural
+`entities/tasks/`. The writes had been correct all along — corrected by locating
+the real file rather than by changing code.)*
+
+**AC verification:**
+
+| AC | Status | Evidence |
+|---|---|---|
+| 1 pipeline fires | PASS | `TestPatchEntity_RunsFullPipeline` + mutation test |
+| 2 inverse test | PASS | `TestPatchEntity_PreservesUnnamedProperties` |
+| 3 set/unset/absent | PASS | `TestPatchEntity_SetUnsetAbsent` (5 cases) |
+| 4 body tri-state | PASS | `TestPatchEntity_BodyTriState` (3 cases) |
+| 5 `WritePrepStore` deleted | PASS | 0 refs; `luaUpdateEntity` holds 0 store refs |
+| 6 mcp/cli unchanged | PASS | existing suites green; nil-delete + `-P key=` pinned |
+| 7 CLI gate is no-op | PASS | manual case 1–5; `AllowAllFieldGate` wired |
+| 8 CI gates | PASS | see below |
+| 9 locked refused | PASS | `TestPatchEntity_LockedEntityRefused` |
+| 10 elevation total | PASS | `TestPatchEntity_ElevationSkipsFieldGate` |
+| 11 automation ungated | PASS | `TestPatchEntity_AutomationNotFieldGated` |
+| RR-32XA5V ordering | PASS | `TestPatchEntity_GateRunsAfterAuthorize` (2 cases) |
+
+**Gates:** `go test ./...` 0 failures · `just lint` 0 issues · `just arch-lint`
+OK · `just lint-md` 0 issues · `just coverage-check` PASS (77.0%, up from 76.9%)
+· `go test -race` on all five touched packages clean.
+
+arch-lint passing **confirms the design bet**: declaring `FieldWriteGate` as a
+consumer-side interface inside `entitymanager` needed no `.go-arch-lint.yml`
+change, exactly as planned.
+
+## Quality
+
+- [x] Code follows project patterns (check similar code)
+- [x] Checked for DRY opportunities
+- [x] No security issues introduced
+- [x] No silent failures (errors logged AND returned)
+- [x] No debug code left behind
+
+Patterns followed rather than invented: `updateCore` mirrors `createCore`
+(free-standing shared core, no ACL/attribution); `entity.Patch` mirrors
+`entity.RelationOptions` field-for-field (`Properties`/`MetaUnset`/`Content
+*string`); `AllowAllFieldGate` mirrors `acl.NopACL{}` as a named opt-out;
+`PatchEntity`'s read-then-authorize mirrors `DeleteEntity`.
+
+DRY: `entity.Patch.Apply` is the single merge implementation — the four
+divergent hand-rolled merges are gone. The two lua/mcp test fakes implement real
+read-merge-save semantics rather than permissive stubs, so binding tests still
+exercise the property that matters.
+
+Security: the ordering test is the regression net for RR-32XA5V; the guard tests
+deleted from `dataentry`/`appbuild` were **replaced** with equivalents pinning
+the inverted invariant (no raw handle, elevation opt-in), not dropped.

--- a/tickets/entities/planning-checklists/PLAN-9FGKSD.md
+++ b/tickets/entities/planning-checklists/PLAN-9FGKSD.md
@@ -1,0 +1,351 @@
+---
+id: PLAN-9FGKSD
+type: planning-checklist
+title: 'Planning: Unified targeted-write primitive: entitymanager.PatchEntity replaces four hand-rolled property merges'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+> **Revised after design review (7 findings, all addressed).** The ordering in
+> §3 and the scope of the `IsLocked` guard changed materially. See "Design
+> Review" at the bottom.
+
+## Understanding
+
+- [x] Problem/requirements clearly understood
+- [x] Scope defined (what's in/out documented below)
+- [x] Acceptance criteria documented with specific test scenarios
+
+**Problem:** four writers hand-roll the same read-modify-write with four
+incompatible clear/body dialects (table in TKT-80EWGM). No shared helper exists:
+`internal/entity` has `GetString`/`SetString`/`Clone` and nothing else. Each new
+writer reinvents it and must independently rediscover the read-out/write-prep
+boundary (DEC-ZBI39P), guarded today by prose in four places.
+
+**Scope:**
+
+IN:
+- `PatchEntity` on `*Manager` + `entity.EntityPatch`.
+- Extract `updateCore` so `UpdateEntity` and `PatchEntity` share one pipeline.
+- Field-write gate as a **required** injected `Deps` capability.
+- **`IsLocked()` git-crypt guard** — moved IN by RR-0QWLRC.
+- Migrate `internal/lua` `luaUpdateEntity`, `internal/mcp` `update_entity`,
+`internal/cli` `update`.
+- Delete `lua.ReadDeps.WritePrepStore`.
+
+OUT (and why):
+- **Relations** — separate question; `MetaUnset` already exists there.
+- **If-Match / optimistic concurrency** — dataentry-local; CalDAV ETag plumbing
+belongs with CalDAV. `PatchEntity` is documented last-write-wins **per
+property**, already better than today's per-entity.
+- **Read-side ACL semantics** — unchanged.
+- **`cascadeHost.WriteEntity` manager bypass** — BUG-KIMZRK.
+- **`restoreOntoLive`**, **`syncHandler.putEntity`** — deliberate whole-entity
+replaces; correct for restore / sync contract.
+- **dataentry PATCH migration** — reference semantics, already correct.
+- **Adding clear-content to MCP** — RR-S3U18Q: preserve current behaviour.
+
+**Acceptance Criteria:** the 8 on TKT-80EWGM, plus three added by review: AC9
+locked-entity patch is refused; AC10 elevated (`bypass_acl`) patch bypasses the
+field gate **and** emits the bypass audit record; AC11 automation may set a
+property the caller could not author.
+
+## Research
+
+- [x] For larger features: run `/research` to create a structured research doc
+- [x] Searched for existing libraries that solve this problem
+- [x] Checked codebase for similar patterns or reusable code
+- [x] Looked for reference implementations in other projects
+- [x] Reviewed relevant rela concepts for prior art
+
+**Research Doc:** N/A — internal consolidation of four existing in-tree
+implementations, not a survey of unfamiliar approaches. Every open question was
+answered by in-tree precedent, which is what a research doc would have gone
+looking for.
+
+**Existing Solutions (all in-tree prior art):**
+
+- **`createCore`** (`core.go:88`) — *the* structural precedent. Free function
+over `Deps`, deliberately not a method, containing **no ACL and no
+attribution**. `updateCore` mirrors it exactly.
+- **`buildCandidateEntity`** (`core.go:~130`) — precedent for splitting "compute
+candidate" from "persist", so dry-run cannot drift from the real path.
+- **`DeleteEntity`** (`manager.go:663-673`) — the read-then-authorize shape
+`PatchEntity` must adopt, with the tradeoff already documented.
+- **dataentry PATCH** (`write_handler.go:406-430`) — reference merge semantics
+incl. the unset-after-upsert ordering rule (`:411-415`); and its gate ordering
+(`:322` then `:376`) is the model for §3.
+- **`entity.RelationOptions`** (`writeapi.go:99-111`) — naming precedent:
+`MetaUnset []string`, `Content *string`, with the tri-state rationale.
+- **`ApplyEntity`** (`apply.go:85-91`) — the `IsLocked` guard precedent.
+- **`lua.WriteDeps.EntityManager`** (`lua/deps.go:94`) — consumer-side interface
+pattern; no arch-lint edge.
+- **`internal/affordances`** — already exposes
+`PolicyResolver.FieldVerdicts(ctx, *entity.Entity)` and does not import
+dataentry. Home for shared gate logic.
+
+## Approach
+
+- [x] Technical approach chosen and documented
+- [x] Approach builds on existing patterns (not reinventing)
+- [x] Alternatives considered (document why rejected)
+- [x] Dependencies identified (packages, APIs, types)
+
+### 1. Extract `updateCore` (standalone commit, no behaviour change)
+
+Boundary is explicit (RR-U01ILQ), mirroring `createCore`:
+
+| Stays in entry points | Moves into `updateCore` |
+|---|---|
+| `withStoreAttribution` (`manager.go:556`) | validate(pre) + partition (`:566-571`) |
+| nil / id guards | automation + re-validate (`:580-604`) |
+| `authorizeAndAudit` (`:559`) | transitions (`:606-616`) |
+| raw `GetEntity` | unique (`:618-623`) |
+| `IsLocked` guard | store write (`:625-630`) |
+| `FieldGate` | audit (`:632-635`) |
+| | cascade (`:641-655`) |
+
+```go
+func updateCore(ctx context.Context, deps Deps, e, oldEntity *entity.Entity, ...) (*entity.UpdateResult, error)
+```
+
+`oldEntity` is **passed in**, not re-read (RR-GM92KZ) — both entry points
+already hold it, so the extraction *reduces* reads from two to one on the patch
+path. Keeping authorize out prevents `PatchEntity` double-authorizing (which
+would emit two denied-write audit rows on a deny) and stops `updateCore`
+becoming a second public write surface.
+
+Load-bearing ordering comments (audit-before-cascade at `:632`,
+re-validate-after-automation, exclude-self on unique) carry over **verbatim**.
+
+### 2. `PatchEntity`
+
+```go
+// internal/entity/writeapi.go — beside RelationOptions
+type EntityPatch struct {
+    Properties map[string]any // upserts
+    Unset      []string       // removals, applied AFTER upserts
+    Content    *string        // nil = leave body untouched
+}
+
+// internal/entitymanager
+func (m *Manager) PatchEntity(ctx context.Context, id string, p EntityPatch) (*entity.UpdateResult, error)
+```
+
+`writeapi.go` is the verified-correct home: its own doc says these types live in
+`entity` "because they're consumed by code that has no reason to import the
+entitymanager package — autocascade scripts, dataentry handlers, mcp tools, lua
+bindings, cli helpers." No cycle: `entity` imports only `metamodel`.
+
+### 3. Ordering (REVISED — RR-32XA5V, RR-0V0TVB, RR-0QWLRC)
+
+```
+withStoreAttribution(ctx)
+  → raw GetEntity(id)                     // ungated: write-prep, the whole point.
+                                          //   Also needed to learn Type for the ACL subject.
+  → IsLocked() guard                      // apply.go:85 precedent
+  → authorizeAndAudit(OpUpdate, {stored.Type, id})
+  → FieldGate.CheckFieldWrite(...)        // AFTER authorize
+  → Clone() → apply Properties → delete Unset → set Content if non-nil
+  → updateCore(ctx, deps, e, oldEntity)
+```
+
+**Why the gate moved after authorize.** The original plan had it before, which
+is an oracle. dataentry gates first deliberately (`write_handler.go:318-324`:
+*"A 400 / 412 / 422 here would be an existence oracle"*, RR-FGUZ) and runs
+`validateFieldWrite` only at `:376`. Two things leak under the wrong order —
+**existence** (not-found vs denied) and **content** (field verdicts are
+value-dependent, so allow-vs-deny on a fixed patch reveals stored values). Both
+are "data", which is secret. Note the *policy* being named in the denial is
+**not** a leak — config is public per root CLAUDE.md, so
+`AffordanceDenialError.Attribution` may keep naming the rule.
+
+**Why authorize can't move earlier.** `acl.EntitySubject` needs `Type`, and
+`PatchEntity` receives only an ID — so it must read first. This is exactly
+`DeleteEntity`'s documented shape. Rejected: taking `type` as a parameter, which
+would let a caller assert a type disagreeing with the stored row (the class
+`ApplyEntity` guards with `ErrTypeImmutable`).
+
+### 4. Field-write gate
+
+Narrow consumer-side interface declared **in `entitymanager`**
+(`TemplateLoader`/`TransitionEnforcer` pattern) — so **no `.go-arch-lint.yml`
+change is needed**:
+
+```go
+// The gate constrains CALLER-AUTHORED changes only. Automation-derived
+// properties (automation.Result.PropertiesSet) are system writes and are
+// deliberately NOT gated: the gate enforces affordance parity with what the
+// resolver would surface on GET for this principal, and automation is the
+// system acting, not the principal. (RR-00ERM9)
+type FieldWriteGate interface {
+    CheckFieldWrite(ctx context.Context, e *entity.Entity, set map[string]any, unset []string) error
+}
+```
+
+**Required** in `Deps`, rejected-if-nil in `New()`, with an exported
+`entitymanager.AllowAllFieldGate{}` mirroring `acl.NopACL{}`. Cost is ~2
+production sites and ~48 test sites — realistic, and matches the house pattern
+(`Audit`/`ACL` are already required with named no-ops). A silently-nil gate is
+the "forgotten wiring must not become an ACL bypass" failure RR-X9NVHI names.
+
+**Elevation is total** (RR-BA1NIV): `bypassACL` bypasses the field gate too. An
+operator writing `rela.bypass_acl(...)` can already read `acl.yaml` in full —
+config is not secret — so a gate blocking them conceals nothing and is merely a
+silent obstacle, i.e. the "half-elevated contract" `lua/deps.go:126-133`
+rejects. `recordACLBypass` still fires: audit is attribution, not secrecy.
+
+### 5. Migrations
+
+- **lua** (`runtime.go:1724`) → `PatchEntity`; deletes `ReadDeps.WritePrepStore`.
+- **mcp** (`tools_entity.go:218`) → in-band `nil` becomes `Unset`. Empty content
+maps to `Content: nil` (**preserve** today's inability to clear the body,
+RR-S3U18Q). Also removes a latent un-cloned-mutation hazard (`:200` mutates the
+store-returned entity in place; safe today only by backend accident).
+- **cli** (`update.go:38`) → gains clear-property and clear-content; wires
+`AllowAllFieldGate{}` (operator trust boundary, full access by design).
+
+**Alternatives rejected:** delegate-to-`UpdateEntity` (no seam for the gate,
+double read); reimplement `UpdateEntity` via `PatchEntity` (breaks its
+documented in-place-mutation contract, and `ApplyEntity` needs whole-entity
+replace); add `PatchEntity` to the `EntityManager` interface (documented
+"transitional… slated for removal"; breaks every fake); import `affordances`
+directly (needs an arch-lint change the interface approach avoids); partial-body
+edits (whole-body `*string` matches every precedent).
+
+**Files to modify:** `internal/entity/writeapi.go`;
+`internal/entitymanager/{core,manager}.go` + `entitymanagertest/`;
+`internal/affordances/`; `internal/dataentry/affordances.go`;
+`internal/lua/{deps,runtime}.go`; `internal/mcp/tools_entity.go`;
+`internal/cli/update.go`; wiring in `internal/appbuild/*`,
+`internal/dataentry/app.go`, `internal/docs/runtime.go`, `internal/script/*`;
+root `CLAUDE.md` + `internal/entitymanager/CLAUDE.md`; `docs/cli-reference.md`.
+
+## Security Considerations
+
+- [x] Input sources identified (user input, config, external APIs)
+- [x] Input validation approach defined (allowlist preferred over blocklist)
+- [x] Security-sensitive operations identified (file access, auth, crypto)
+- [x] Error handling doesn't leak sensitive information
+
+| Input | Validation | On invalid |
+|---|---|---|
+| `id` | store ID validation; miss → `ErrEntityNotFound` | uniform not-found |
+| `Properties` keys | `declaredProperties` **allowlist**; unknown → `RuleFieldHidden` | preserves the F8 side-channel closure |
+| `Properties` values | `Meta.ValidateEntity`, DEC-HWZHA hard/soft split | hard aborts; soft warns |
+| `Unset` keys | same allowlist + gate | denial |
+| `Content` | unchanged | — |
+
+1. **Raw write-prep read** — deliberate; consolidating four raw reads into one
+auditable location is the improvement.
+2. **Ordering is the security-critical part** — see §3. Existence and
+value-dependent content must not leak before authorize. Config/policy naming is
+explicitly fine (config is not secret).
+3. **`IsLocked` guard** — without it, patching a git-crypt-locked entity writes
+the cleartext shell over encrypted content: the ticket's own erasure class, via
+encryption instead of redaction.
+4. **Audit** — `PatchEntity` is NOT in the `{Create,Update,Delete,Rename}` set
+that `internal/entitymanager/CLAUDE.md` says inherits audit mechanically, so
+audit must come from the shared `updateCore`. Verify, don't assume.
+5. **Elevation** — total, and audited via `recordACLBypass`.
+
+## Test Plan
+
+- [x] Test scenarios documented for each acceptance criterion
+- [x] Edge cases identified and documented
+- [x] Negative test cases defined (invalid input, error conditions)
+- [x] Integration test approach defined (not just unit tests)
+
+| AC | Scenario |
+|---|---|
+| 1 | Integration w/ real `Deps`: automation fired, unique enforced, transition enforced, audit emitted, cascade ran. |
+| 2 | **Inverse test** — redacted-read caller patches ONE visible prop; every hidden prop byte-identical after. |
+| 3 | Table {visible,hidden} × {set,unset,absent}. |
+| 4 | Body tri-state: `nil` / `""` / `"x"`. |
+| 5 | `WritePrepStore` gone; `luaUpdateEntity` holds no `store.Store`. |
+| 6 | MCP nil-delete + MCP **cannot-clear-body** + CLI regressions all green. |
+| 7 | CLI patches a hidden property successfully (`AllowAllFieldGate`). |
+| 8 | `just arch-lint lint test coverage-check`. |
+| **9** | Patching a locked entity is refused; stored bytes byte-identical. |
+| **10** | Elevated patch of a gated field succeeds AND emits the bypass audit record. |
+| **11** | Principal who cannot author `status` triggers an automation that sets `status` → succeeds. |
+
+**Ordering tests (from RR-32XA5V) — the security regression net:** a principal
+with **no write authority** patches (a) a nonexistent id and (b) an existing
+entity whose field policy would deny — assert **both** return the same
+authorization failure, and that neither returns `AffordanceDenialError`. This is
+what pins the gate behind authorize.
+
+**Integration approach:** AC1/AC2 run end-to-end **through the cascade path**
+(autocascade → LuaScriptRunner → patch), preserving the coverage RR-J4518A
+demanded — that finding exists precisely because the original test only used a
+directly-constructed runtime.
+
+**Edge Cases:** empty patch (no-op; document whether it bumps `UpdatedAt`); key
+in both `Properties` and `Unset` → cleared; unset absent key → no-op; unset
+undeclared key → `unknown_property_unset_key` warning; nil `Properties` +
+non-empty `Unset`; entity not found → `ErrEntityNotFound`; `Clone()` always
+allocates a non-nil map so nil-Properties entities patch fine; non-string values
+assigned directly (not via `SetString`) to preserve `any` typing; unsetting a
+**required** property succeeds with a warning (DEC-HWZHA, verified:
+`metamodel/validation.go:92-100` → `entitymanager/validation.go:22-27`, code
+`required_property_unset`); concurrent patches are last-write-wins per property.
+
+**Negative:** hidden set → denied; hidden unset → denied (parity); read-only
+same-value → still denied (strictness deliberate); undeclared →
+`RuleFieldHidden` not "unknown field"; illegal transition → transition error;
+unique violation → unique error; `New()` with nil `FieldGate` → constructor
+error.
+
+## Risk Assessment
+
+- [x] Technical risks assessed with mitigations
+- [x] Security risks assessed (see Security Considerations)
+- [x] Effort estimated (xs/s/m/l/xl)
+
+| Risk | Mitigation |
+|---|---|
+| `updateCore` extraction regresses the hottest write path | Standalone behaviour-preserving commit, suite green before `PatchEntity` exists; verbatim ordering comments. |
+| Required `Deps.FieldGate` breaks ~50 construction sites | Compiler finds all; `AllowAllFieldGate{}` fixture first. ~2 production + ~48 test, measured. |
+| Gate extraction changes dataentry denial behaviour (rule names are a wire contract) | dataentry delegates rather than being rewritten; existing affordance tests are the net. |
+| `WritePrepStore` deletion touches many wiring sites | Compiler-guided; **replace** the two identity guard tests with new-invariant equivalents, don't delete. |
+| Getting the gate/authorize order wrong again | Explicit ordering tests above; the order is now documented with its rationale in `PatchEntity`'s godoc. |
+| Scope creep toward BUG-KIMZRK | Out of scope; changes cascade failure semantics, needs its own design. |
+
+**Effort:** l — confirmed, slightly up after review (IsLocked guard, 3 extra
+ACs, ordering tests).
+
+## Documentation Planning
+
+- [x] User-facing docs identified (skip if internal refactor)
+- [x] Docs-checklist will be created when entering implementation
+
+- [x] root `CLAUDE.md` — **the point of the ticket**: replace "Never redact a read
+that feeds a write" with "use `PatchEntity`". The prose guards a footgun this
+removes.
+- [x] `internal/entitymanager/CLAUDE.md` — document `PatchEntity`; note it is NOT
+in the auto-audit `{Create,Update,Delete,Rename}` set.
+- [x] `docs/cli-reference.md` — CLI gains clear-property/clear-content.
+- [x] Lua API docs — decide whether to expose unset on `rela.update_entity`.
+- [x] ~~`docs/metamodel.md`, `docs/data-entry.md`~~ (N/A: no metamodel change;
+dataentry behaviour is unchanged — it is the reference semantics, not a
+migration target)
+
+## Design Review
+
+- [x] Run `/design-review` before starting implementation
+- [x] All critical/significant findings addressed in plan
+
+**Design Review Findings:** 7, all `addressed`.
+
+| ID | Sev | Outcome |
+|---|---|---|
+| RR-32XA5V | critical | Gate moved after authorize. Rationale narrowed: existence + value-dependent content leak (real); policy-naming leak (withdrawn — config is public). |
+| RR-0V0TVB | significant | Adopt `DeleteEntity` read-then-authorize shape; documented, not accidental. |
+| RR-BA1NIV | significant | Elevation is **total**; `recordACLBypass` still fires. |
+| RR-00ERM9 | significant | Automation ungated — status quo, now written into the godoc + pinned (AC11). |
+| RR-0QWLRC | significant | `IsLocked` guard moved INTO scope (AC9). |
+| RR-GM92KZ | minor | `oldEntity` passed into `updateCore`; no `store.Tx`. |
+| RR-U01ILQ | minor | Extraction boundary specified; standalone first commit. |
+| RR-S3U18Q | minor | MCP: preserve cannot-clear-body; un-cloned mutation fixed by construction. |

--- a/tickets/entities/review-checklists/REV-O8TSAY.md
+++ b/tickets/entities/review-checklists/REV-O8TSAY.md
@@ -123,8 +123,23 @@ so nobody builds on protection that is not yet there.
 
 ## Pull Request
 
-- [ ] Run `/pr` command to create PR and monitor CI
-- [ ] All CI checks pass
-- [ ] PR URL documented below
+- [x] Run `/pr` command to create PR and monitor CI
+- [x] All CI checks pass
+- [x] PR URL documented below
 
-**PR:** <!-- pending -->
+All 21 code checks green: Test (`-race -shuffle=on`), Lint, E2E, Postgres
+Backend, Architecture, Frontend, Build, God-object lint, Lint Markdown,
+Vulnerability Check, Fuzz, CodeQL (go / actions / js-ts), and all 7
+Cross-Compile targets including both postgres variants.
+
+The `Rela Tickets` check failed while this box was unticked — correctly. It
+enforces "done review checklists cannot have unchecked items", which cannot
+be satisfied until CI has actually run. Resolved by finishing the workflow
+(tick once green, move the ticket to `done`), not by weakening the rule.
+
+`Docs` regenerates from `docs-project/` and fails on any diff. Verified
+locally by running `./scripts/generate-docs.sh` — the generator reproduces
+the cli-reference edit byte-for-byte, because the source entity was edited
+alongside the generated file.
+
+**PR:** https://github.com/sourcehaven-bv/rela/pull/1306

--- a/tickets/entities/review-checklists/REV-O8TSAY.md
+++ b/tickets/entities/review-checklists/REV-O8TSAY.md
@@ -1,0 +1,130 @@
+---
+id: REV-O8TSAY
+type: review-checklist
+title: 'Review: Unified targeted-write primitive: entitymanager.PatchEntity replaces four hand-rolled property merges'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Automated Checks
+
+- [x] All tests pass (`just test`)
+- [x] Lint clean (`just lint`)
+- [x] Coverage maintained (`just coverage-check`)
+
+`go test ./...` 0 failures · `just lint` 0 issues · `just arch-lint` OK · `just
+lint-md` 0 issues · `just coverage-check` PASS (77.0%, up from the 76.9%
+baseline) · `go test -race` clean on `lua`, `cli`, `entitymanager`.
+
+## Code Review
+
+- [x] Run `/code-review` command (invokes cranky-code-reviewer agent)
+- [x] All critical review-responses addressed
+- [x] All significant review-responses addressed
+- [x] Self-reviewed the diff for unrelated changes
+
+**Review Responses:** RR-7YXR83, RR-JZBP5E, RR-MU0TLH, RR-OFWA2Q, RR-E812RW,
+RR-TEA3NA
+
+| ID | Sev | Status |
+|---|---|---|
+| RR-7YXR83 | significant | addressed — structural not-found detection |
+| RR-JZBP5E | significant | addressed — nil-map invariant pinned |
+| RR-MU0TLH | minor | addressed — inert-gate disclosure in godoc |
+| RR-OFWA2Q | minor | addressed — CLI body-flag handling |
+| RR-E812RW | nit | addressed — corrected overstated godoc |
+| RR-TEA3NA | minor | **deferred** with reasoning (MCP pre-read) |
+
+Zero critical. No open critical/significant.
+
+**The one real defect was mine.** `luaUpdateEntity` detected a missing entity
+via `strings.Contains(err.Error(), "entity not found")`. Several hard errors
+interpolate caller-supplied values — `statemachine` formats an illegal
+transition as `%s %q→%q is not a declared transition` — so a script setting a
+property to the literal `"entity not found"` had its transition rejection
+reported as a 404, and a script branching on that message could try to recreate
+a row that still exists. The reviewer confirmed with a runnable repro against
+the real manager.
+
+Fixed structurally: `entitymanager` returns an error exposing `EntityNotFound()
+bool`; `lua` matches it through a consumer-side `NotFoundError` interface with
+`errors.As`. `errors.Is(err, ErrEntityNotFound)` still works via `Unwrap`, so
+the 14 existing sentinel users are unaffected.
+
+Two candidate fixes were rejected after checking rather than assuming: moving
+the sentinel into `internal/entity` (14 files across many packages), and
+duplicating the sentinel in `lua` — I verified two separately-constructed
+`errors.New` values with identical text do **not** match under `errors.Is`, so
+that would have silently never fired.
+
+**Regression test verified against the old implementation:**
+`TestUpdateEntity_NonNotFoundErrorIsNotMisreported` FAILS with the string match,
+PASSES with the structural check.
+
+**Self-review:** every touched file traces to the ticket. The 30-odd peripheral
+test diffs are one-line `FieldGate:` additions and `WritePrepStore:` removals
+(plus gofmt realignment); confirmed by diffing `analysis`, `attachment`, `docs`,
+`validation` for stray edits. No scope creep.
+
+## Acceptance Verification
+
+- [x] Each acceptance criterion tested (reference planning checklist)
+- [x] Test evidence documented in implementation checklist
+
+**Acceptance Status:** all 11 ACs plus the RR-32XA5V ordering test PASS — full
+table with per-AC evidence in IMPL-T8S8LU. Highlights:
+
+- **AC2 (the inverse test)** PASS — `TestPatchEntity_PreservesUnnamedProperties`.
+The test that would have caught this bug class at its origin.
+- **AC5 (success criterion)** PASS — `WritePrepStore` deleted; 0 references,
+`luaUpdateEntity` holds 0 store references.
+- **AC1** PASS — and the audit half was **mutation-tested**: disabling
+`recordEntityAudit` makes it fail, restoring it passes. Necessary because
+`entitymanager/CLAUDE.md` warns audit is inherited by method *name*, and
+`PatchEntity` is not in that set.
+- **AC7** PASS — verified against the real `cmd/rela` binary on an
+fs-backed project, not a harness.
+
+## Documentation (enhancements only)
+
+Internal refactor with one user-visible CLI capability change, so docs were
+updated inline rather than via a separate docs-checklist:
+
+- [x] `CLAUDE.md` — the defensive "never redact a read that feeds a write"
+prose replaced by the positive `PatchEntity` rule. This was the point of the
+ticket.
+- [x] `internal/entitymanager/CLAUDE.md` — which-write-method table plus the
+load-bearing `PatchEntity` ordering rationale.
+- [x] `docs/cli-reference.md` **and its `docs-project/` source** — `-U/--unset`,
+`--clear-body`, the `-P key=` vs `-U` distinction, `-B` empty-file semantics.
+Also filled in `-P`/`-b`/`-B`, previously undocumented.
+
+**Docs Checklist:** N/A — refactor; the user-facing surface is the three CLI
+flags, documented above. `just lint-md` clean; generated file and source
+verified byte-identical in the changed section.
+
+## Final Checks
+
+- [x] Commit message explains the why, not just what
+- [x] No TODOs or FIXMEs left unaddressed
+- [x] Ready for another developer to use
+
+Six commits, each explaining the reasoning and citing the review-response it
+answers. Deliberately sequenced so the risky `updateCore` extraction is a
+standalone behaviour-preserving commit reviewable on its own.
+
+**Known limitation, disclosed not hidden:** `FieldWriteGate` is wired as
+`AllowAllFieldGate` at every production site, so it is inert outside tests. This
+preserves today's exact behaviour (nothing outside dataentry ever field-gated
+writes) and the seam makes the real wiring a config change rather than a
+rewrite. Stated in the `FieldWriteGate` godoc itself — not only in TKT-0XL8MF —
+so nobody builds on protection that is not yet there.
+
+## Pull Request
+
+- [ ] Run `/pr` command to create PR and monitor CI
+- [ ] All CI checks pass
+- [ ] PR URL documented below
+
+**PR:** <!-- pending -->

--- a/tickets/entities/review-responses/RR-00ERM9.md
+++ b/tickets/entities/review-responses/RR-00ERM9.md
@@ -1,0 +1,36 @@
+---
+id: RR-00ERM9
+type: review-response
+title: Automation-set properties bypass the field gate — correct, but the plan leaves it as an open question
+finding: 'The plan raises but does not answer whether automation-set properties should be field-gated. They are not, and should not be — but leaving it open invites the next reviewer to ''re-litigate'' or, worse, ''fix'' it. Confirmed: manager.go:589-592 applies autoResult.PropertiesSet via e.SetString AFTER the caller''s diff, so a gate that ran on the caller''s set/unset never sees them. This is correct: the field gate implements affordance PARITY (write_handler.go:373 calls it ''reject writes that conflict with what the resolver would have surfaced on GET'') — it constrains what a PRINCIPAL may author, not what the SYSTEM may derive. Verdicts are principal-scoped, so gating automation output would mean a user who cannot author `status` could never trigger an automation that sets `status`, breaking every workflow automation in the project''s own metamodel.yaml. The precedent is exact: dataentry runs validateFieldWrite at write_handler.go:376 then hands off to UpdateEntity at write_handler.go:436, where automation freely sets whatever it likes — so automation already bypasses the field gate in the ONLY path that has one. The plan preserves the status quo; it just needs to say so in the godoc.'
+severity: significant
+resolution: |-
+    ACCEPTED. Status quo preserved (automation-set properties are NOT field-gated), but the semantics move from 'unanswered plan question' to written contract on the FieldWriteGate godoc: 'The field gate constrains caller-authored property changes only. Automation-derived properties (automation.Result.PropertiesSet) are system writes and are deliberately NOT gated — the gate enforces affordance parity with what the resolver would surface on GET for this principal, and automation is the system acting, not the principal.'
+
+    Pinned by a test: a principal who may not author `status` triggers an automation that sets `status`; assert the write succeeds and status is set. Without that test a future 'consistency' change silently breaks every status-transition automation in the project's own metamodel.yaml.
+status: addressed
+---
+
+## Resolution
+
+Write the semantics into `FieldWriteGate`'s godoc, not just the plan:
+
+> The field gate constrains **caller-authored** property changes only.
+> Automation-derived properties (`automation.Result.PropertiesSet`) are system
+> writes and are deliberately **not** gated — the gate enforces affordance
+> parity with what the resolver would surface on GET for this principal, and
+> automation is the system acting, not the principal.
+
+Add a test pinning it: a principal who may not author `status` triggers an
+automation that sets `status`; assert the write succeeds and `status` is set.
+Without that test, a future "consistency" change silently breaks every
+status-transition automation.
+
+## Evidence
+
+- `internal/entitymanager/manager.go:589-592` — automation applies after the
+caller's diff.
+- `internal/dataentry/write_handler.go:373` — the gate's stated purpose is
+affordance parity with GET.
+- `internal/dataentry/write_handler.go:376` then `:436` — gate, then
+`UpdateEntity`, inside which automation is ungated. Status quo confirmed.

--- a/tickets/entities/review-responses/RR-0QWLRC.md
+++ b/tickets/entities/review-responses/RR-0QWLRC.md
@@ -1,0 +1,39 @@
+---
+id: RR-0QWLRC
+type: review-response
+title: PatchEntity omits the IsLocked (git-crypt) guard that ApplyEntity has
+finding: 'The plan lists IsLocked as an out-of-scope ''noted gap'', but PatchEntity is precisely the shape the guard exists for. ApplyEntity guards it at apply.go:85-91; dataentry guards it at write_handler.go:335. PatchEntity does a raw read-modify-write: it reads the stored entity, clones it, merges, and writes it back. If the entity is locked (git-crypt encrypted, entity.Inaccessible non-empty, entity.IsLocked() at entity.go:111), the read yields a shell whose real property values are unavailable — and writing that shell back persists the cleartext shell OVER the encrypted content. That is the same data-destruction class the whole ticket exists to prevent, just via encryption rather than redaction. UpdateEntity not having the guard is not a licence to omit it: UpdateEntity receives a caller-constructed entity, whereas PatchEntity owns the read, so it is the correct place to enforce it. Add the guard and pin it with a test.'
+severity: significant
+resolution: |-
+    ACCEPTED — moved from out-of-scope to IN scope. PatchEntity adds an IsLocked() guard immediately after the raw GetEntity and before authorize, reusing ApplyEntity's error (apply.go:85-91) for consistency.
+
+    The reviewer's argument is decisive: a locked (git-crypt) entity reads as a shell whose real property values are unavailable, so a read-modify-write persists that cleartext shell OVER the encrypted content. That is the same erasure class the ticket exists to prevent — via encryption rather than redaction. Because PatchEntity owns the read internally (the whole point of the design), consumers can no longer perform this check themselves, making PatchEntity the only correct place for it.
+
+    Test: patching a locked entity returns the lock error and leaves the stored bytes byte-identical.
+status: addressed
+---
+
+## Why this matters more than the plan assumed
+
+The ticket's core thesis is *"forgetting a property yields a no-op, not an
+erasure."* A locked entity is the encrypted analogue of a redacted one: the read
+returns something that is **not** the full stored state. Writing it back is
+exactly the read-modify-write erasure the primitive is supposed to make
+impossible.
+
+Since `PatchEntity` owns the read internally (that is the whole design), it is
+the natural and only correct place for the guard — consumers can no longer
+perform the check themselves because they no longer hold the entity.
+
+## Evidence
+
+- `internal/entitymanager/apply.go:85-91` — `ApplyEntity`'s guard.
+- `internal/dataentry/write_handler.go:335` — dataentry's guard.
+- `internal/entity/entity.go:111` — `IsLocked()`; `Inaccessible` field at
+`entity.go:57`.
+
+## Resolution
+
+Add the `IsLocked()` check immediately after the raw `GetEntity`, before
+authorize. Reuse `ApplyEntity`'s error for consistency. Test: patching a locked
+entity returns the lock error and leaves the stored bytes untouched.

--- a/tickets/entities/review-responses/RR-0V0TVB.md
+++ b/tickets/entities/review-responses/RR-0V0TVB.md
@@ -1,0 +1,45 @@
+---
+id: RR-0V0TVB
+type: review-response
+title: PatchEntity cannot authorize before reading — needs the entity type for the ACL subject (DeleteEntity shape)
+finding: 'The plan implicitly assumes PatchEntity can follow UpdateEntity''s authorize-first shape. It cannot. acl.WriteRequest.Subject is acl.EntitySubject{Type, ID} (manager.go:561-563); UpdateEntity gets Type free because the caller hands it a whole *entity.Entity, but PatchEntity(ctx, id string, p EntityPatch) has only an ID. It must read first to learn the type. This is exactly DeleteEntity''s shape (manager.go:663-673), which documents the accepted tradeoff: ''ACL check happens after the lookup so the request carries the real entity type; a deny on a non-existent entity would be more confusing than the ErrEntityNotFound returned above.'' So PatchEntity inherits DeleteEntity''s already-accepted existence disclosure — defensible for the same reason, but it must be a stated, deliberate inheritance rather than an accident, and it constrains where the field gate can sit (strictly between authorize and mutation).'
+severity: significant
+resolution: |-
+    ACCEPTED. PatchEntity adopts the DeleteEntity shape (manager.go:663-673): raw GetEntity first to learn the real entity type, then authorize with acl.EntitySubject{Type: stored.Type, ID: id}. Documented in PatchEntity's godoc citing DeleteEntity's existing rationale, so the existence disclosure is an explicit, precedented inheritance rather than an accident.
+
+    Rejected alternative (recorded so it is not revisited): taking `type` as a PatchEntity parameter to enable authorize-before-read. That would let a caller assert a type disagreeing with the stored row — the exact class ApplyEntity guards with ErrTypeImmutable (apply.go:105-110). Reading the real type is safer.
+
+    This finding is what fixes the position of the field gate in RR-32XA5V: the gate sits strictly between authorize and mutation, since authorize cannot move earlier.
+status: addressed
+---
+
+## Evidence
+
+`internal/entitymanager/manager.go:663-673` (`DeleteEntity`):
+
+```go
+current, err := m.deps.Store.GetEntity(ctx, id)
+if err != nil {
+    return nil, fmt.Errorf("%w: %s", ErrEntityNotFound, id)
+}
+// ACL check happens after the lookup so the request carries the
+// real entity type; a deny on a non-existent entity would be more
+// confusing than the ErrEntityNotFound returned above.
+if aclErr := m.authorizeAndAudit(ctx, acl.WriteRequest{
+    Op:      acl.OpDelete,
+    Subject: acl.EntitySubject{Type: current.Type, ID: id},
+}); aclErr != nil {
+```
+
+## Resolution
+
+Adopt the `DeleteEntity` ordering explicitly and document it in `PatchEntity`'s
+godoc, citing the same rationale. The existence disclosure is pre-existing and
+accepted for ID-addressed write ops; what must NOT happen is the additional
+field-policy disclosure from RR-32XA5V, which is why the gate sits after
+authorize rather than before it.
+
+An alternative — taking `type` as a `PatchEntity` parameter so it could
+authorize first — is rejected: it would let a caller assert a type that
+disagrees with the stored row, which is the exact class `ApplyEntity` guards
+with `ErrTypeImmutable` (`apply.go:105-110`). Reading the real type is safer.

--- a/tickets/entities/review-responses/RR-32XA5V.md
+++ b/tickets/entities/review-responses/RR-32XA5V.md
@@ -1,0 +1,57 @@
+---
+id: RR-32XA5V
+type: review-response
+title: Field gate runs before ACL authorize — creates an existence + field-policy oracle
+finding: 'The plan places FieldGate.CheckFieldWrite after computing the set/unset diff but BEFORE authorizeAndAudit. This inverts the project''s settled ordering. dataentry does the opposite deliberately: gateRead is the FIRST thing in the update handler (write_handler.go:322) with the comment ''runs BEFORE getEntity (RR-NGMI timing) AND before body parse / If-Match / IsLocked so the only observable for "this id exists but you can''t see it" is the same 404 as "this id doesn''t exist" (RR-FGUZ). A 400 / 412 / 422 here would be an existence oracle.'' validateFieldWrite only runs at write_handler.go:376, after the gate, the read, IsLocked and If-Match. Under the plan''s order an unauthorized caller gets three distinguishable outcomes: ErrEntityNotFound (absent), AffordanceDenialError (exists, field denied), or ACL forbidden (exists, field allowed). Worse, AffordanceDenialError carries Rule/Path/Reason/Attribution (affordances.go:339-361) so it names the denying rule/role, and FieldVerdicts are value-dependent (verdicts differ by the entity''s own property values), so the allow-vs-deny difference leaks entity CONTENT to a principal with no write authority at all. Correct order: authorize first, field-gate second.'
+severity: critical
+resolution: |-
+    ACCEPTED, with the rationale NARROWED. Order corrected to: raw GetEntity -> IsLocked guard -> authorizeAndAudit -> FieldGate -> apply diff -> updateCore.
+
+    Rationale narrowed per the project's config-is-public posture (root CLAUDE.md: 'The configuration is not a secret; the data is'). The original finding cited AffordanceDenialError.Attribution naming the denying rule/role as a leak — that part is WITHDRAWN. acl.yaml is operator-authored, lives in a routinely-public repo, and CLAUDE.md explicitly says a 403 naming the missing permission is the right answer for a config-declared capability. Naming the rule is a feature, not a leak.
+
+    What SURVIVES, and is why the reorder is still required: (1) EXISTENCE — not-found vs denied distinguishes whether an entity id exists, and entity existence is explicitly secret (row-level rule, DEC-ZBI39P: 'a hidden entity is nonexistent'). (2) CONTENT — field verdicts are value-dependent (they evaluate predicates against the entity's own property values), so an allow-vs-deny difference on a fixed patch reveals stored property values to a caller with no write authority. Both are in the 'data is secret' half of the posture, not the config half.
+
+    So the defect is real and the fix is unchanged; only the justification is trimmed to the two claims that hold.
+status: addressed
+---
+
+## Evidence
+
+`internal/dataentry/write_handler.go:318-324`:
+
+```go
+// before body parse / If-Match / IsLocked so the only observable
+// for "this id exists but you can't see it" is the same 404 as
+// "this id doesn't exist" (RR-FGUZ). A 400 / 412 / 422 here would
+// be an existence oracle.
+if !h.gateRead(w, r, typeName, entityID) {
+    return
+}
+```
+
+`internal/dataentry/write_handler.go:370-379` — the field gate runs much later:
+
+```go
+// Affordance parity (TKT-G7N5): reject writes that conflict with
+// what the resolver would have surfaced on GET.
+if denial := h.affordances.validateFieldWrite(
+    r.Context(), entity, req.Properties, req.PropertiesUnset,
+); denial != nil {
+```
+
+The delete handler repeats the pattern (`write_handler.go:488-491`) noting
+RR-3532: gateRead before AuthorizeWrite *"so a hidden target 404s, not
+403-with-rule_id"*.
+
+## Resolution
+
+Reorder. See RR (finding 2) for the constraint that `PatchEntity` must read
+before authorizing in order to learn the entity type for the ACL subject — the
+resulting order is:
+
+```
+GetEntity (raw) → IsLocked guard → authorizeAndAudit → FieldGate → apply diff → updateCore
+```
+
+The set/unset diff does not depend on the ACL decision, so nothing forced the
+plan's original order.

--- a/tickets/entities/review-responses/RR-7YXR83.md
+++ b/tickets/entities/review-responses/RR-7YXR83.md
@@ -1,0 +1,14 @@
+---
+id: RR-7YXR83
+type: review-response
+title: Lua misreports arbitrary hard errors as "entity not found" via strings.Contains
+finding: 'luaUpdateEntity (runtime.go:1754) detected a missing entity with strings.Contains(err.Error(), "entity not found") over the WHOLE error text. Several non-404 hard errors embed caller-supplied values: internal/statemachine/enforce.go:94 formats ''%w: %s %q→%q is not a declared transition'' with the value the caller supplied. Reviewer confirmed with a runnable repro against the real manager — error text ''illegal transition: status "in-review"→"entity not found" is not a declared transition'' contains the magic substring. FAILURE: a script calls rela.update_entity("TASK-1", {status = "entity not found"}) on an entity that EXISTS; the write is correctly refused as an illegal transition, but the script sees ''entity not found: TASK-1'' and may take a compensating action such as recreating a row that is still there. mapTransitionError output and ACL denial text are the same class of hazard. The comment''s premise was also wrong: PatchEntity returns fmt.Errorf("%w: %s", ErrEntityNotFound, id), so the sentinel DOES survive errors.Is — internal/cli/update.go:83 already uses the correct idiom in this same changeset.'
+severity: significant
+resolution: |-
+    Replaced text matching with a STRUCTURAL marker. entitymanager gained an unexported entityNotFoundError type exposing EntityNotFound() bool and Unwrap() to ErrEntityNotFound; lua declares a consumer-side NotFoundError interface plus isEntityNotFound() using errors.As. PatchEntity returns newEntityNotFound(id).
+
+    errors.Is(err, ErrEntityNotFound) keeps working via Unwrap, so the 14 existing sentinel users are unaffected. Chose the interface over moving the sentinel into internal/entity (would have touched 14 files across many packages) and over duplicating the sentinel in lua — I verified two separately-constructed errors.New values with identical text do NOT match under errors.Is, so that approach would have silently never fired.
+
+    Regression test TestUpdateEntity_NonNotFoundErrorIsNotMisreported reproduces the reviewer's exact scenario and was verified to FAIL against the old string-matching implementation and PASS against the fix. TestUpdateEntity_NotFoundStillReported pins that a genuine 404 keeps its original script-facing message.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-BA1NIV.md
+++ b/tickets/entities/review-responses/RR-BA1NIV.md
@@ -1,0 +1,45 @@
+---
+id: RR-BA1NIV
+type: review-response
+title: 'bypassACL vs field gate: plan asserts a half-elevation the codebase explicitly rejects'
+finding: 'The plan proposes (without argument) that bypassACL does NOT bypass the field gate. The codebase points the other way. bypassACL is the elevated write handle for rela.bypass_acl (manager.go:66-76) and authorizeAndAudit returns nil immediately on that path (manager.go:266-269). The companion READ elevation is total: appbuild/elevatedreads.go:22-25 grants visibility.Unrestricted, and lua/deps.go:126-133 explains why partial elevation is wrong — ''Reads through it are unredacted and ungated — the closure is the boundary, so a half-elevated read would be a confusing contract... Elevation that quietly degrades to the caller''s view is worse than a loud failure.'' The field gate is field-level ACL derived from the same principal-scoped resolver. A bypass_acl closure that can write any entity but silently cannot set a read-only-for-this-principal field is precisely the half-elevated contract that comment rejects, and it is undiagnosable: the author asked for elevation and got most of it. Either bypass the field gate too (consistent, audited via the existing recordACLBypass at manager.go:267), or keep the proposal and document why field policy is categorically different from row policy — pinned by a test. The plan currently offers neither.'
+severity: significant
+resolution: |-
+    RESOLVED: elevation is TOTAL — bypassACL bypasses the field gate too, with recordACLBypass still firing.
+
+    Decided in light of the project's config-is-public posture (root CLAUDE.md: 'The configuration is not a secret; the data is'). An operator authoring rela.bypass_acl(...) can already read acl.yaml in full, so a field gate that blocks them conceals nothing from them — they know precisely which field is gated and by which rule. It is not a confidentiality boundary in that context, only a silent obstacle to route around. That is exactly the 'half-elevated contract' lua/deps.go:126-133 rejects: 'Elevation that quietly degrades to the caller's view is worse than a loud failure.'
+
+    This also restores symmetry with the read side, where elevation grants visibility.Unrestricted (appbuild/elevatedreads.go:22-25) with no partial variant.
+
+    UNCHANGED: recordACLBypass (manager.go:267) must still fire for the field-gate bypass. Audit is about attribution, not secrecy — it is orthogonal to the config-is-public argument and survives it. Pin with a test asserting an elevated patch of a gated field (a) succeeds and (b) emits the bypass audit record.
+status: addressed
+---
+
+## Evidence
+
+`internal/lua/deps.go:126-133` — the elevation contract:
+
+> Reads through it are unredacted and ungated — the closure is the boundary, so
+> a half-elevated read would be a confusing contract... Elevation that quietly
+> degrades to the caller's view is worse than a loud failure.
+
+`internal/entitymanager/manager.go:266-269` — `authorizeAndAudit` short-circuits
+on the bypass path, recording via `recordACLBypass`.
+
+`internal/appbuild/elevatedreads.go:22-25` — the read side grants
+`visibility.Unrestricted`, i.e. total.
+
+## Recommendation
+
+Prefer **bypassing the field gate too**, for symmetry with the read side, with
+the bypass recorded through the existing `recordACLBypass` channel so it stays
+auditable. `rela.bypass_acl` is already an explicitly-requested, audited,
+closure-scoped capability; making it total is the honest contract.
+
+If the opposite is chosen, the plan must state *why* field policy differs from
+row policy and pin it with a test, so the next reader does not "fix" the
+inconsistency.
+
+Note `elevated()`/`gated()` copy `m.deps` wholesale (`manager.go:82-107`), so
+the gate is carried automatically either way — the decision is purely about
+whether `PatchEntity` consults `m.bypassACL` before calling it.

--- a/tickets/entities/review-responses/RR-E812RW.md
+++ b/tickets/entities/review-responses/RR-E812RW.md
@@ -1,0 +1,9 @@
+---
+id: RR-E812RW
+type: review-response
+title: updateCore godoc overstated "one read" as an end-to-end property
+finding: The updateCore doc comment claimed threading oldEntity through 'keeps the write path at one read'. True inside the manager, false end-to-end for the MCP path, which still does its own GetEntity to obtain e.Type for validatePropertyNames before dispatching. Comments that claim a global property from a local vantage point age badly — and this one is adjacent to a ticket whose stated goal was consolidating duplicated reads.
+severity: nit
+resolution: 'Reworded to claim only what is true from where it sits: ''the manager itself reads the row once per write'', with an explicit note that callers may still read separately for their own reasons and naming internal/mcp as the case in point.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-GM92KZ.md
+++ b/tickets/entities/review-responses/RR-GM92KZ.md
@@ -1,0 +1,34 @@
+---
+id: RR-GM92KZ
+type: review-response
+title: 'Double GetEntity: pass oldEntity into updateCore instead of re-reading'
+finding: 'As planned, PatchEntity does its own GetEntity and then updateCore does a SECOND GetEntity for oldEntity (manager.go:573) — two reads of the same row per patch. Not a new race (the existing lua pattern runtime.go:1740 GetEntity -> :1747 Clone -> :1766 UpdateEntity has the same read-modify-write gap) and not corruption: the second read only feeds oldEntity for automation and EnforceUpdate, so a concurrent write between the two reads makes automation diff against a NEWER old-state than the patch was computed from. Impossible on fsstore/memstore (in-process single-writer by design); reachable on pgstore multi-writer. Wrapping the pipeline in store.Tx is NOT the fix — the cascade runs arbitrary Lua, and CLAUDE.md/store.go:204-211 forbid slow external I/O inside a Tx callback. The clean fix is to have updateCore accept the already-fetched oldEntity as a parameter rather than re-reading it. UpdateEntity fetches it at manager.go:573 and PatchEntity fetches it too, so threading it through makes the extraction REDUCE reads rather than double them, and narrows the window without a transaction.'
+severity: minor
+resolution: |-
+    ACCEPTED. updateCore takes the already-fetched oldEntity as a parameter instead of re-reading it. Both entry points already hold it at the call point: UpdateEntity reads it at manager.go:573, and PatchEntity must read it anyway to learn the entity type for the ACL subject (RR-0V0TVB) and to compute the merge base. Net effect: one read per write on both paths, down from two on the patch path — the extraction reduces reads rather than doubling them.
+
+    Explicitly NOT doing: wrapping in store.Tx. All three backends implement it (fsstore/tx.go:31, memstore/tx.go:22, pgstore/tx.go:60), but the cascade dispatches arbitrary Lua and both root CLAUDE.md and store.go:204-211 forbid slow external I/O inside a Tx callback. Optimistic concurrency stays out of scope per the ticket; PatchEntity is documented as last-write-wins per property, which is still strictly better than today's whole-entity last-write-wins.
+status: addressed
+---
+
+## Resolution
+
+Signature becomes roughly:
+
+```go
+func updateCore(ctx context.Context, deps Deps, e, oldEntity *entity.Entity, ...) (*entity.UpdateResult, error)
+```
+
+Both entry points already hold `oldEntity` at the point they would call it:
+
+- `UpdateEntity` — reads it at `manager.go:573`
+- `PatchEntity` — must read it anyway to learn the type for the ACL subject
+(RR-0V0TVB) and to compute the merge base
+
+Net effect: one read per write on both paths, down from two on the patch path.
+
+Explicitly **not** doing: wrapping in `store.Tx`. All three backends implement
+it (`fsstore/tx.go:31`, `memstore/tx.go:22`, `pgstore/tx.go:60`), but the
+cascade dispatches arbitrary Lua, and root `CLAUDE.md` plus
+`internal/store/store.go:204-211` forbid slow external I/O inside a `Tx`
+callback. Optimistic concurrency remains out of scope per the ticket.

--- a/tickets/entities/review-responses/RR-JZBP5E.md
+++ b/tickets/entities/review-responses/RR-JZBP5E.md
@@ -1,0 +1,9 @@
+---
+id: RR-JZBP5E
+type: review-response
+title: Patch.Apply's nil-map + MetaUnset invariant is load-bearing but untested
+finding: Patch.Apply (writeapi.go:186-193) allocates a Properties map only when len(p.Properties) > 0, so a MetaUnset-only patch runs delete() against a possibly-nil map. That is a no-op in Go rather than a panic, so the code is CORRECT — but the invariant ('unset-only patches on a nil-property entity are silently fine') is load-bearing, since both MCP and CLI can emit unset-only patches, and it was covered by no test. It held by a Go language property nobody had written down; a future refactor to a non-map property container would break it with no failing test. The guard also reads as if Properties == nil were the hazard being handled, obscuring what the real invariant is.
+severity: significant
+resolution: Added two tests at different levels. TestPatch_ApplyOnNilMap pins it on the value type directly, so a change of property container fails there rather than only through the manager. TestPatchEntity_NilPropertiesEntity gained an 'unset-only against a nil property map does not panic' subtest exercising the full manager path. The existing set-on-nil-map case was kept as a sibling subtest.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-MU0TLH.md
+++ b/tickets/entities/review-responses/RR-MU0TLH.md
@@ -1,0 +1,9 @@
+---
+id: RR-MU0TLH
+type: review-response
+title: FieldWriteGate is inert in production but its godoc reads as if it were live
+finding: internal/appbuild/appbuild.go is the sole production wiring site and hardcodes AllowAllFieldGate{}, so the gate is unreachable outside tests. This WAS honestly disclosed (TKT-0XL8MF filed, IMPL-T8S8LU states it plainly) — but the Deps.FieldGate godoc said request-scoped surfaces 'wire a policy-backed implementation' in the PRESENT tense, which is aspirational. An inert gate that looks live is how people come to build on protection that was never real. The disclosure belongs where a reader will encounter it, not only in a ticket.
+severity: minor
+resolution: 'Added an explicit STATUS paragraph to the FieldWriteGate godoc: ''no production surface wires a real implementation yet... Do not assume a write reaching PatchEntity has been field-gated'', pointing at TKT-0XL8MF. Corrected the Deps.FieldGate godoc from the aspirational present tense to ''where a policy-backed implementation belongs — none is wired yet''. Introducing a required-but-inert authz seam remains the right call (it forces the wiring decision at every future call site), but it now says so.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-OFWA2Q.md
+++ b/tickets/entities/review-responses/RR-OFWA2Q.md
@@ -1,0 +1,9 @@
+---
+id: RR-OFWA2Q
+type: review-response
+title: -B with an empty file silently became "no updates specified"; --clear-body conflict checked content not flags
+finding: Two adjacent CLI warts. (1) getBodyContent TrimSpaces, so `-B empty.md` (or whitespace-only) yielded "", left patch.Content nil, and with no other flags produced 'no updates specified' despite the operator explicitly naming a file. Pre-existing behaviour (old code gated `changed` on bodyContent != ""), so not a regression — but adding --clear-body made it MORE confusing, since `-B empty.md` and `--clear-body` now differ for no reason a user can infer. (2) The mutual-exclusion guard tested the RESOLVED content (`c.ClearBody && bodyContent != ""`), so `--clear-body -B empty.md` slipped through silently instead of erroring.
+severity: minor
+resolution: '(1) An explicitly named body file is now honored even when empty or whitespace-only: naming a source is an explicit instruction, and silently degrading it to an error about supplying nothing is baffling. Clearing deliberately is what --clear-body is for. (2) The conflict check now tests the FLAGS (c.Body != "" || c.BodyFile != "") rather than resolved content, so the empty-file combination is caught. Both pinned: TestUpdateCmd_EmptyBodyFileIsHonored and a table-driven TestUpdateCmd_ClearBodyConflictsWithBody covering --body and --body-file. Documented in cli-reference (and its docs-project source).'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-S3U18Q.md
+++ b/tickets/entities/review-responses/RR-S3U18Q.md
@@ -1,0 +1,30 @@
+---
+id: RR-S3U18Q
+type: review-response
+title: 'MCP migration traps: pre-existing un-cloned mutation, and MCP cannot express clear-content'
+finding: 'Two things about the MCP migration the plan did not anticipate. (1) internal/mcp/tools_entity.go:200 does `e, getErr := st.GetEntity(ctx, id)` then mutates e.Properties IN PLACE at :222-228 with no Clone(). This is safe today only by backend accident — memstore clones on read (memstore.go:194) and fsstore re-parses from disk (fsstore/entity.go:28) — but it is not guaranteed by the store contract. Migrating to PatchEntity removes the hazard by construction since PatchEntity owns the read and the clone; this is a genuine benefit of the migration worth stating rather than leaving as an accident that happens to work. (2) MCP currently CANNOT express ''clear content'': the guard at tools_entity.go:209 short-circuits when len(properties)==0 && content=="", and content is only assigned when non-empty (:227-229). The migration must not silently change that — EntityPatch.Content is a *string tri-state, so a naive mapping of MCP''s empty content to a non-nil pointer would newly allow (or newly force) body clearing. Decide deliberately and pin whichever semantics is chosen.'
+severity: minor
+resolution: |-
+    RESOLVED both parts.
+
+    (1) Un-cloned mutation at tools_entity.go:200/:222-228 is fixed by construction — PatchEntity owns the read and the clone. Note it in the commit message as a fixed latent hazard rather than an incidental refactor.
+
+    (2) Clear-content: PRESERVE current behaviour. Map MCP's empty content to Content: nil (leave untouched), never to a pointer-to-empty-string. Chosen as the lowest-risk option: MCP is slated for replacement by a remote-oriented server, so spending a wire-shape decision on the current client-side implementation is not worthwhile. Keeps AC6's 'behave unchanged' promise strictly intact. Pin with a regression test — AC6 covers MCP nil-deletes but not this adjacent case.
+status: addressed
+---
+
+## Resolution
+
+1. **Un-cloned mutation** — no action needed beyond the migration itself, but
+note it in the commit message as a fixed latent hazard rather than an incidental
+refactor. Evidence: `tools_entity.go:200` then `:222-228`;
+`memstore/memstore.go:194` returns `e.Clone()`; `fsstore/entity.go:28`
+re-parses.
+
+2. **Clear-content** — preserve today's behaviour by mapping MCP's empty content
+to `Content: nil` (leave untouched), NOT to a pointer-to-empty-string. If
+exposing clear-content to MCP is desired, that is a deliberate capability
+addition needing its own wire-shape decision (MCP uses in-band `nil` for
+properties; content has no equivalent sentinel today). Pin the chosen behaviour
+with a regression test either way — AC6 already requires MCP nil-deletes to
+behave unchanged, and this is the adjacent case it does not currently cover.

--- a/tickets/entities/review-responses/RR-TEA3NA.md
+++ b/tickets/entities/review-responses/RR-TEA3NA.md
@@ -1,0 +1,16 @@
+---
+id: RR-TEA3NA
+type: review-response
+title: MCP still does a pre-read that PatchEntity repeats
+finding: 'internal/mcp/tools_entity.go:198-215 still calls st.GetEntity(ctx, id) solely to obtain e.Type for validatePropertyNames, then PatchEntity does its own raw read. Two reads where one might do, and the window between them is racy: if the entity is deleted in between, the caller gets PatchEntity''s ErrEntityNotFound rather than the handler''s ''entity not found: ''+id — different text for the same condition on the same code path. Not a correctness bug (the second read is authoritative; the first feeds only an advisory NAME check), but it is exactly the duplicated read this ticket set out to consolidate.'
+severity: minor
+reason: |-
+    DEFERRED, not dismissed — removing it is a behaviour change needing its own decision, and doing it here would exceed the ticket's stated scope.
+
+    The pre-read exists so validatePropertyNames can reject unknown property names with a good message BEFORE dispatching. Eliminating it means one of: (a) dropping early name validation and letting the manager's metamodel validation own it — changes MCP's error text and its 400-vs-warning shape, which AC6 explicitly promised to leave unchanged; (b) having PatchEntity surface the resolved type so the caller can validate after the fact — widens the primitive's return contract for one consumer's convenience; (c) moving name validation into the manager — a real improvement but a cross-cutting change affecting every writer.
+
+    The divergent error text on the racy path is the only user-visible symptom, and both outcomes are a truthful 'not found'. Note MCP is slated for replacement by a remote-oriented server, which is when (c) becomes worth doing properly.
+
+    Mitigated meanwhile: the misleading 'one read' claim in updateCore's godoc was corrected (RR-E812RW) so the duplication is documented rather than contradicted.
+status: deferred
+---

--- a/tickets/entities/review-responses/RR-U01ILQ.md
+++ b/tickets/entities/review-responses/RR-U01ILQ.md
@@ -1,0 +1,48 @@
+---
+id: RR-U01ILQ
+type: review-response
+title: 'updateCore extraction boundary unspecified: attribution and authorize must stay in the entry points'
+finding: 'The plan says ''extract updateCore'' without specifying the split point, which is the one detail that decides whether the extraction is safe. withStoreAttribution(ctx) (manager.go:556) and authorizeAndAudit (manager.go:559) must stay in the ENTRY POINTS, not move into updateCore. If they move: PatchEntity would double-authorize (it must authorize early to get the type per RR-0V0TVB), which is harmless functionally but emits TWO denied-write audit rows on a deny, corrupting the forensic count — and updateCore would silently become a second public write surface with its own ACL check, which is exactly the kind of parallel write path the root CLAUDE.md forbids. The correct boundary mirrors createCore, which is a free function over Deps (core.go:88-90) containing no ACL and no attribution — both live in Manager.CreateEntity. Extractable body is manager.go:566 (preErrs := ...) through :653.'
+severity: minor
+resolution: |-
+    ACCEPTED. Extraction boundary now specified explicitly in the plan, mirroring createCore (core.go:88-90), which contains no ACL and no attribution.
+
+    STAYS in the entry points (UpdateEntity / PatchEntity): withStoreAttribution (manager.go:556), nil/id guards, authorizeAndAudit (:559), the raw GetEntity, the IsLocked guard (RR-0QWLRC), and the FieldGate call (RR-32XA5V).
+
+    MOVES into updateCore: validate(pre) + partitionValidationErrors (:566-571), automation + re-validate (:580-604), transitions (:606-616), unique (:618-623), store write (:625-630), audit (:632-635), cascade (:641-655).
+
+    Rationale for keeping authorize out: PatchEntity must authorize early (it needs the type from the read, RR-0V0TVB), so an authorize inside updateCore would double-authorize — harmless functionally but emitting TWO denied-write audit rows on a deny, corrupting the forensic count — and would make updateCore a de-facto second public write surface with its own ACL check.
+
+    Sequencing: the extraction lands as a standalone behaviour-preserving commit with the full suite green BEFORE PatchEntity is added. Load-bearing ordering comments (audit-before-cascade at :632, re-validate-after-automation, exclude-self on unique) are carried verbatim, not paraphrased.
+status: addressed
+---
+
+## Precedent
+
+`internal/entitymanager/core.go:84-90` — `createCore`'s godoc explains the
+shape:
+
+> Free function over [Deps] (not a method on Manager) so cascadeHost can call it
+> directly without constructing a half-initialized Manager view.
+
+It contains no ACL check and no attribution; `Manager.CreateEntity` owns both.
+`updateCore` must match.
+
+## Boundary
+
+| Stays in entry point (`UpdateEntity` / `PatchEntity`) | Moves to `updateCore` |
+|---|---|
+| `withStoreAttribution(ctx)` (`manager.go:556`) | validate(pre) + `partitionValidationErrors` (`:566-571`) |
+| nil/id guards | automation + re-validate (`:580-604`) |
+| `authorizeAndAudit` (`:559`) | transitions (`:606-616`) |
+| the raw `GetEntity` (now passed in, RR-GM92KZ) | unique (`:618-623`) |
+| `IsLocked` guard (RR-0QWLRC) | store write (`:625-630`) |
+| `FieldGate` (RR-32XA5V) | audit (`:632-635`) |
+| | cascade (`:641-655`) |
+
+## Sequencing
+
+Do the extraction as a **standalone, behaviour-preserving commit** with the full
+suite green before `PatchEntity` is added. The ordering comments in `manager.go`
+(audit-before-cascade at `:632`, re-validate-after-automation, exclude-self on
+unique) are load-bearing — carry them verbatim rather than paraphrasing.

--- a/tickets/entities/tickets/TKT-0XL8MF.md
+++ b/tickets/entities/tickets/TKT-0XL8MF.md
@@ -1,0 +1,68 @@
+---
+id: TKT-0XL8MF
+type: ticket
+title: 'Wire a policy-backed FieldWriteGate: move affordance-resolver construction out of dataentry so appbuild can supply it'
+kind: enhancement
+priority: medium
+effort: m
+status: backlog
+---
+
+Follow-up to TKT-80EWGM, which introduced `entitymanager.FieldWriteGate` as a
+required injected capability but wires `AllowAllFieldGate{}` at **every** site.
+
+## Why it was deferred
+
+The real implementation would adapt `affordances.PolicyResolver.FieldVerdicts` —
+the same logic `dataentry.affordanceService.validateFieldWrite`
+(`affordances.go:326`) already uses. But the resolver is constructed inside
+`internal/dataentry` (`affordances_stub.go:75`), and `appbuild` may not import
+`internal/affordances` under arch-lint (`.go-arch-lint.yml:410-434`). Supplying
+a policy-backed gate means moving resolver construction to a package both
+`appbuild` and `dataentry` may depend on.
+
+That is a wiring/layering change with its own design, so TKT-80EWGM stopped at
+the seam rather than widening its own scope.
+
+## Important: this is not a regression
+
+`AllowAllFieldGate` **preserves today's exact behaviour**. Field-level write
+gating has only ever existed on the dataentry HTTP path, which still calls
+`validateFieldWrite` directly and is unchanged. MCP, CLI and Lua were never
+field-gated. Nothing got weaker; the seam simply is not yet load-bearing.
+
+## What to do
+
+1. Move (or re-home) affordance-resolver construction so a non-dataentry
+wiring site can build one — likely a small constructor in
+`internal/affordances`, with `dataentry` keeping only its wire-shape adapter.
+2. Implement `FieldWriteGate` over `FieldVerdicts`, preserving the denial
+classification verbatim — **rule names are a wire contract**
+(`affordances.go:264-272`), and the unknown-field→`RuleFieldHidden` mapping
+closes the F8 side channel.
+3. Wire it in `appbuild` for request-scoped surfaces. **CLI keeps
+`AllowAllFieldGate`** — the operator has full filesystem access to the data, so
+gating there buys nothing (settled in TKT-80EWGM).
+4. Consider migrating dataentry's PATCH onto `PatchEntity` at the same time, so
+the gate has exactly one implementation and one call site.
+
+## Constraints inherited from TKT-80EWGM (do not re-litigate)
+
+- **The gate runs AFTER `authorizeAndAudit`, never before** (RR-32XA5V). Field
+verdicts are value-dependent, so consulting them for an unauthorized caller
+leaks entity existence and stored values. Pinned by
+`TestPatchEntity_GateRunsAfterAuthorize`.
+- **Elevation is total** — `bypassACL` skips the field gate too (RR-BA1NIV).
+Pinned by `TestPatchEntity_ElevationSkipsFieldGate`.
+- **Automation output is not gated** (RR-00ERM9) — the gate constrains
+caller-authored changes only. Pinned by
+`TestPatchEntity_AutomationNotFieldGated`.
+
+## Acceptance
+
+- A request-scoped caller cannot set or unset a property their policy hides,
+via MCP or Lua, not just via the dataentry HTTP path.
+- CLI can still patch any property.
+- dataentry denial responses (rule names, status codes) are byte-identical to
+today — existing affordance tests are the regression net.
+- The three constraint tests above still pass unmodified.

--- a/tickets/entities/tickets/TKT-80EWGM.md
+++ b/tickets/entities/tickets/TKT-80EWGM.md
@@ -5,7 +5,7 @@ title: 'Unified targeted-write primitive: entitymanager.PatchEntity replaces fou
 kind: refactor
 priority: medium
 effort: l
-status: review
+status: done
 ---
 
 Add a single targeted/partial entity-write primitive on `entitymanager.Manager`

--- a/tickets/entities/tickets/TKT-80EWGM.md
+++ b/tickets/entities/tickets/TKT-80EWGM.md
@@ -5,7 +5,7 @@ title: 'Unified targeted-write primitive: entitymanager.PatchEntity replaces fou
 kind: refactor
 priority: medium
 effort: l
-status: in-progress
+status: review
 ---
 
 Add a single targeted/partial entity-write primitive on `entitymanager.Manager`

--- a/tickets/entities/tickets/TKT-80EWGM.md
+++ b/tickets/entities/tickets/TKT-80EWGM.md
@@ -1,0 +1,203 @@
+---
+id: TKT-80EWGM
+type: ticket
+title: 'Unified targeted-write primitive: entitymanager.PatchEntity replaces four hand-rolled property merges'
+kind: refactor
+priority: medium
+effort: l
+status: in-progress
+---
+
+Add a single targeted/partial entity-write primitive on `entitymanager.Manager`
+and migrate the hand-rolled read-modify-write merges (Lua, MCP, CLI) onto it.
+One merge implementation, one clear/unset semantic, one body tri-state —
+reducing implementation and maintenance burden for both existing writers and new
+ones (CalDAV/VTODO inbound sync being the next). Deletes
+`lua.ReadDeps.WritePrepStore`.
+
+## Problem
+
+There is **no shared partial-write helper anywhere in the codebase**.
+`internal/entity` exposes only `GetString` / `SetString` / `Clone` — no merge,
+no unset. Every write path hand-rolls its own read-modify-write, and the
+resulting dialects are mutually incompatible:
+
+| Path | file:line | Clear a property? | Clear content? |
+|---|---|---|---|
+| dataentry PATCH | `write_handler.go:406-428` | yes — out-of-band `properties_unset []string` | yes — `*string` tri-state |
+| MCP `update_entity` | `tools_entity.go:218-226` | yes — in-band `nil` sentinel | **no** |
+| Lua `rela.update_entity` | `runtime.go:1743-1758` | **no** | yes (`""` clears) |
+| CLI `update` | `update.go:38-62` | **no** (`-P key=` sets empty string) | **no** |
+
+Four writers, four semantics, for one conceptual operation. The closest thing to
+a shared concept is the `(setKeys map[string]any, unsetKeys []string)` pair in
+`affordances.validateFieldWrite` — but that **validates**, it does not apply.
+
+Each new writer must reinvent the merge and independently rediscover the
+read-out / write-prep boundary (DEC-ZBI39P). The boundary is currently enforced
+by convention and prose in four places (`lua/deps.go` field godoc, root
+`CLAUDE.md`, `lua/runtime.go:1736-1739` inline, and
+`TestScriptReads_UpdatePreservesHiddenProperties`). That volume of defensive
+documentation is the smell: the codebase guards a sharp edge with warnings
+rather than removing it.
+
+**The key inversion this buys: forgetting a property yields a no-op, not an
+erasure.**
+
+## Findings from investigation (2026-08-09)
+
+Recorded because they narrow the scope from the originating brief:
+
+- **No live data loss exists today.** Every read-before-write already uses a raw,
+ungated handle: MCP `deps.Store`, CLI `svc.Store`, Lua `WritePrepStore`,
+dataentry `entityReader.getEntity` (godoc: *"deliberately UNGATED — ACL scoping
+is applied elsewhere"*). This ticket is justified by **semantic divergence and
+maintenance burden**, not by an imminent bug.
+- **`visibleReader.getVisible` returns UNREDACTED entities** — it row-gates only
+(`visiblereader.go:57-65`). Field redaction happens in `toV1` on the wire
+struct, on a freshly-built map with no aliasing back to the stored entity
+(`entityserializer.go:154`, `affordances.go:933`). So the dataentry PATCH path
+is safe even against a hypothetical "tidy onto getVisible".
+- **`automation` `set` actions are NOT a consumer.** `engine.go:250` only records intent
+into `Result.PropertiesSet`; the entitymanager applies it to the **in-flight**
+entity (`manager.go:590`). There is no read-modify-write there to migrate.
+- **dataentry PATCH is already effectively this primitive**, just private and
+HTTP-shaped. It is the reference semantics to generalize, not a site to fix.
+
+## Scope
+
+Build the primitive; migrate the three hand-rolled merges. Unification is the
+goal — **not** retrofitting authorization.
+
+- **CLI** has full access by design; the field-write gate must be a **no-op** there.
+- **MCP** is client-side/local today (operator trust boundary). It will be reworked when
+it moves to a remote MCP; migrating now means the gate is already a **wiring
+choice** at that point rather than a rewrite.
+
+### 1. The primitive
+
+Shape is a proposal; naming and exact home are the implementer's call.
+
+```go
+// in or near internal/entitymanager
+type PropertyPatch struct {
+    Set   map[string]any  // properties to write
+    Clear []string        // properties to explicitly remove
+    Body  *string         // nil = leave body untouched
+}
+
+func (m *Manager) PatchEntity(ctx context.Context, id string, p PropertyPatch) (*entity.UpdateResult, error)
+```
+
+Requirements:
+
+1. **Goes through `entitymanager.Manager`** — automations, validation, transitions,
+unique checks, and audit must all fire. Not a store-level primitive.
+2. **Merge happens against the raw entity, internally.** Callers never hold a raw store
+handle to do it themselves — that is the entire point.
+3. **A redacted-read caller is safe by construction.** A caller who can see 3 of 10
+properties can patch those 3 without touching the other 7.
+4. **Explicit clear is distinct from absent.** `Clear: ["due"]` removes it; omitting
+`due` from both leaves it untouched.
+5. **`Set` and `Clear` ordering follows dataentry's documented precedent**
+(`write_handler.go:410-413`): unset applied **after** upserts, so a patch that
+both sets and clears the same key ends cleared.
+
+### 2. Field-write gate as an injected capability
+
+Whether a caller may `Set`/`Clear` a property they cannot read is **already
+answered in-tree**: `affordances.validateFieldWrite` (`affordances.go:319`)
+enforces *"hidden/read-only fields cannot be set OR unset."* That answer stands
+— do not re-litigate it.
+
+The gap is that this validator lives in `internal/dataentry`; MCP and CLI never
+call it. Supply it to `PatchEntity` as a **wiring-site capability**, mirroring
+how read-side allow-all works (`AllowAllReader`, DEC-ZBI39P): never inferred
+from identity, always injected. CLI and other operator-trust-boundary paths wire
+a permissive/no-op gate; request-scoped paths wire the real resolver.
+
+### 3. Migrations
+
+- `internal/lua` `luaUpdateEntity` (`runtime.go:1724`) — canonical case. **Deletes
+`lua.ReadDeps.WritePrepStore`**, its only consumer. Removes the footgun field
+and the prose guarding it.
+- `internal/mcp` `update_entity` (`tools_entity.go:190`) — in-band `nil` maps to `Clear`.
+- `internal/cli` `update` (`update.go:31`) — gains clear-a-property and clear-content,
+which it currently cannot do at all.
+
+Callers keep their own wire shapes; only the merge is shared.
+
+## Explicitly out of scope
+
+- **Relations.** Entity properties only.
+- **Optimistic concurrency / `If-Match`.** Belongs with the CalDAV work.
+- **Any change to read-side ACL semantics.** This changes how writes *merge*, not who may
+read what.
+- **`cascadeHost.WriteEntity` bypassing the manager** — a real write-path hole, filed
+separately. `PatchEntity` neither fixes nor worsens it.
+- **`restoreOntoLive`** (`history_restore.go:102`) — a deliberate whole-entity replace;
+correct semantics for a restore.
+- **`syncHandler.putEntity`** — whole-record replace is the sync contract, guarded by a
+mandatory If-Match precondition.
+- **dataentry PATCH migration.** Optional follow-up; it is the reference semantics and
+already correct. Migrating it is a simplification, not a fix.
+
+## Acceptance criteria
+
+1. `PatchEntity` exists on `Manager`; automations, validation, transitions, unique
+checks, and audit all fire (asserted, not assumed).
+2. A caller holding a **redacted** read patches one visible property; **every hidden
+property is byte-identical afterwards.** This is the inverse test that would
+have caught this class originally.
+3. `Set` / `Clear` / absent are three distinct behaviours, table-driven over
+visible × hidden.
+4. Body tri-state: `nil` leaves untouched, `""` clears, non-empty replaces.
+5. `lua.ReadDeps.WritePrepStore` is **deleted**; `luaUpdateEntity` compiles without a raw
+store handle.
+6. MCP and CLI merges are gone, replaced by `PatchEntity` calls; existing MCP nil-deletes
+and CLI updates behave unchanged (regression-pinned).
+7. CLI's field-write gate is a no-op — an operator can patch any property.
+8. `just arch-lint`, `just lint`, `just test`, `just coverage-check` all pass.
+
+## Testing
+
+- Port `TestScriptReads_UpdatePreservesHiddenProperties`
+(`internal/lua/aclreads_test.go:250`) to the new API; keep the original green
+until its call site is migrated.
+- Add the **inverse** test (AC2) — redacted-read caller patches one visible property,
+assert all hidden properties survive byte-identical.
+- Table-driven: property visible/hidden × set/clear/absent.
+- Preserve the RR-J4518A end-to-end coverage: the hidden-property-preservation test must
+still run **through the cascade path** (autocascade → LuaScriptRunner → update),
+not only against a directly-constructed runtime.
+- Replace the `WritePrepStore`-identity guard tests
+(`internal/dataentry/luawiring_test.go:104`,
+`internal/appbuild/luawiring_test.go:116`) with equivalents that pin the new
+invariant — do not simply delete them.
+- Include a fixture mirroring a real Apple Reminders VTODO PUT (partial property set:
+`SUMMARY`, `STATUS`, `COMPLETED`, `PERCENT-COMPLETE`, `DUE`; entity has hidden
+properties) — the exact CalDAV shape this unblocks.
+
+## Open questions for planning
+
+1. Does `PatchEntity` live on `Manager`, or as a narrow consumer-side interface each of
+Lua/MCP/CLI/CalDAV declares? Root `CLAUDE.md` favours call-site interfaces; the
+manager is where writes must land. Likely both: method on `Manager`, narrow
+interface at each consumer.
+2. Should `UpdateEntity` be reimplemented in terms of `PatchEntity`? **Suggest no** —
+`UpdateEntity` has a documented in-place-mutation contract
+(`manager.go:545-549`) that automation depends on, and `ApplyEntity` genuinely
+needs whole-entity replace. Let them coexist.
+3. Body handling — whole-body replace sufficient? **Suggest yes**, `*string` tri-state
+matching dataentry's existing `req.Content`.
+
+## Why now
+
+CalDAV/VTODO inbound sync (Phase 2 of the calendar-feed arc, after TKT-RDM9M5)
+adds a new writer. A CalDAV `PUT` from Apple Reminders carries a *partial* view
+— verified empirically 2026-08-09: it sends `SUMMARY`, `STATUS`, `COMPLETED`,
+`PERCENT-COMPLETE`, `DUE` and drops everything it does not model. Applying that
+as a whole-entity save would erase every rela property VTODO has no slot for.
+
+Building this inside the CalDAV PR would shape it around one caller. It has
+standalone value and deserves its own design.

--- a/tickets/relations/BUG-KIMZRK--adds-measure--cascade-write-full-pipeline-test.md
+++ b/tickets/relations/BUG-KIMZRK--adds-measure--cascade-write-full-pipeline-test.md
@@ -1,0 +1,5 @@
+---
+from: BUG-KIMZRK
+relation: adds-measure
+to: cascade-write-full-pipeline-test
+---

--- a/tickets/relations/BUG-KIMZRK--affects--audit-log.md
+++ b/tickets/relations/BUG-KIMZRK--affects--audit-log.md
@@ -1,0 +1,5 @@
+---
+from: BUG-KIMZRK
+relation: affects
+to: audit-log
+---

--- a/tickets/relations/BUG-KIMZRK--affects--authorization.md
+++ b/tickets/relations/BUG-KIMZRK--affects--authorization.md
@@ -1,0 +1,5 @@
+---
+from: BUG-KIMZRK
+relation: affects
+to: authorization
+---

--- a/tickets/relations/BUG-KIMZRK--fixes--FEAT-013.md
+++ b/tickets/relations/BUG-KIMZRK--fixes--FEAT-013.md
@@ -1,0 +1,5 @@
+---
+from: BUG-KIMZRK
+relation: fixes
+to: FEAT-013
+---

--- a/tickets/relations/TKT-0XL8MF--affects--authorization.md
+++ b/tickets/relations/TKT-0XL8MF--affects--authorization.md
@@ -1,0 +1,5 @@
+---
+from: TKT-0XL8MF
+relation: affects
+to: authorization
+---

--- a/tickets/relations/TKT-0XL8MF--depends-on--TKT-80EWGM.md
+++ b/tickets/relations/TKT-0XL8MF--depends-on--TKT-80EWGM.md
@@ -1,0 +1,5 @@
+---
+from: TKT-0XL8MF
+relation: depends-on
+to: TKT-80EWGM
+---

--- a/tickets/relations/TKT-0XL8MF--implements--FEAT-AESD4.md
+++ b/tickets/relations/TKT-0XL8MF--implements--FEAT-AESD4.md
@@ -1,0 +1,5 @@
+---
+from: TKT-0XL8MF
+relation: implements
+to: FEAT-AESD4
+---

--- a/tickets/relations/TKT-80EWGM--affects--authorization.md
+++ b/tickets/relations/TKT-80EWGM--affects--authorization.md
@@ -1,0 +1,5 @@
+---
+from: TKT-80EWGM
+relation: affects
+to: authorization
+---

--- a/tickets/relations/TKT-80EWGM--affects--lua-scripting.md
+++ b/tickets/relations/TKT-80EWGM--affects--lua-scripting.md
@@ -1,0 +1,5 @@
+---
+from: TKT-80EWGM
+relation: affects
+to: lua-scripting
+---

--- a/tickets/relations/TKT-80EWGM--affects--mcp-api.md
+++ b/tickets/relations/TKT-80EWGM--affects--mcp-api.md
@@ -1,0 +1,5 @@
+---
+from: TKT-80EWGM
+relation: affects
+to: mcp-api
+---

--- a/tickets/relations/TKT-80EWGM--has-implementation--IMPL-T8S8LU.md
+++ b/tickets/relations/TKT-80EWGM--has-implementation--IMPL-T8S8LU.md
@@ -1,0 +1,5 @@
+---
+from: TKT-80EWGM
+relation: has-implementation
+to: IMPL-T8S8LU
+---

--- a/tickets/relations/TKT-80EWGM--has-planning--PLAN-9FGKSD.md
+++ b/tickets/relations/TKT-80EWGM--has-planning--PLAN-9FGKSD.md
@@ -1,0 +1,5 @@
+---
+from: TKT-80EWGM
+relation: has-planning
+to: PLAN-9FGKSD
+---

--- a/tickets/relations/TKT-80EWGM--has-review--REV-O8TSAY.md
+++ b/tickets/relations/TKT-80EWGM--has-review--REV-O8TSAY.md
@@ -1,0 +1,5 @@
+---
+from: TKT-80EWGM
+relation: has-review
+to: REV-O8TSAY
+---

--- a/tickets/relations/TKT-80EWGM--has-review-response--RR-00ERM9.md
+++ b/tickets/relations/TKT-80EWGM--has-review-response--RR-00ERM9.md
@@ -1,0 +1,5 @@
+---
+from: TKT-80EWGM
+relation: has-review-response
+to: RR-00ERM9
+---

--- a/tickets/relations/TKT-80EWGM--has-review-response--RR-0QWLRC.md
+++ b/tickets/relations/TKT-80EWGM--has-review-response--RR-0QWLRC.md
@@ -1,0 +1,5 @@
+---
+from: TKT-80EWGM
+relation: has-review-response
+to: RR-0QWLRC
+---

--- a/tickets/relations/TKT-80EWGM--has-review-response--RR-0V0TVB.md
+++ b/tickets/relations/TKT-80EWGM--has-review-response--RR-0V0TVB.md
@@ -1,0 +1,5 @@
+---
+from: TKT-80EWGM
+relation: has-review-response
+to: RR-0V0TVB
+---

--- a/tickets/relations/TKT-80EWGM--has-review-response--RR-32XA5V.md
+++ b/tickets/relations/TKT-80EWGM--has-review-response--RR-32XA5V.md
@@ -1,0 +1,5 @@
+---
+from: TKT-80EWGM
+relation: has-review-response
+to: RR-32XA5V
+---

--- a/tickets/relations/TKT-80EWGM--has-review-response--RR-7YXR83.md
+++ b/tickets/relations/TKT-80EWGM--has-review-response--RR-7YXR83.md
@@ -1,0 +1,5 @@
+---
+from: TKT-80EWGM
+relation: has-review-response
+to: RR-7YXR83
+---

--- a/tickets/relations/TKT-80EWGM--has-review-response--RR-BA1NIV.md
+++ b/tickets/relations/TKT-80EWGM--has-review-response--RR-BA1NIV.md
@@ -1,0 +1,5 @@
+---
+from: TKT-80EWGM
+relation: has-review-response
+to: RR-BA1NIV
+---

--- a/tickets/relations/TKT-80EWGM--has-review-response--RR-E812RW.md
+++ b/tickets/relations/TKT-80EWGM--has-review-response--RR-E812RW.md
@@ -1,0 +1,5 @@
+---
+from: TKT-80EWGM
+relation: has-review-response
+to: RR-E812RW
+---

--- a/tickets/relations/TKT-80EWGM--has-review-response--RR-GM92KZ.md
+++ b/tickets/relations/TKT-80EWGM--has-review-response--RR-GM92KZ.md
@@ -1,0 +1,5 @@
+---
+from: TKT-80EWGM
+relation: has-review-response
+to: RR-GM92KZ
+---

--- a/tickets/relations/TKT-80EWGM--has-review-response--RR-JZBP5E.md
+++ b/tickets/relations/TKT-80EWGM--has-review-response--RR-JZBP5E.md
@@ -1,0 +1,5 @@
+---
+from: TKT-80EWGM
+relation: has-review-response
+to: RR-JZBP5E
+---

--- a/tickets/relations/TKT-80EWGM--has-review-response--RR-MU0TLH.md
+++ b/tickets/relations/TKT-80EWGM--has-review-response--RR-MU0TLH.md
@@ -1,0 +1,5 @@
+---
+from: TKT-80EWGM
+relation: has-review-response
+to: RR-MU0TLH
+---

--- a/tickets/relations/TKT-80EWGM--has-review-response--RR-OFWA2Q.md
+++ b/tickets/relations/TKT-80EWGM--has-review-response--RR-OFWA2Q.md
@@ -1,0 +1,5 @@
+---
+from: TKT-80EWGM
+relation: has-review-response
+to: RR-OFWA2Q
+---

--- a/tickets/relations/TKT-80EWGM--has-review-response--RR-S3U18Q.md
+++ b/tickets/relations/TKT-80EWGM--has-review-response--RR-S3U18Q.md
@@ -1,0 +1,5 @@
+---
+from: TKT-80EWGM
+relation: has-review-response
+to: RR-S3U18Q
+---

--- a/tickets/relations/TKT-80EWGM--has-review-response--RR-TEA3NA.md
+++ b/tickets/relations/TKT-80EWGM--has-review-response--RR-TEA3NA.md
@@ -1,0 +1,5 @@
+---
+from: TKT-80EWGM
+relation: has-review-response
+to: RR-TEA3NA
+---

--- a/tickets/relations/TKT-80EWGM--has-review-response--RR-U01ILQ.md
+++ b/tickets/relations/TKT-80EWGM--has-review-response--RR-U01ILQ.md
@@ -1,0 +1,5 @@
+---
+from: TKT-80EWGM
+relation: has-review-response
+to: RR-U01ILQ
+---

--- a/tickets/relations/TKT-80EWGM--implements--FEAT-B9VS.md
+++ b/tickets/relations/TKT-80EWGM--implements--FEAT-B9VS.md
@@ -1,0 +1,5 @@
+---
+from: TKT-80EWGM
+relation: implements
+to: FEAT-B9VS
+---

--- a/tickets/relations/cascade-write-full-pipeline-test--protects--audit-log.md
+++ b/tickets/relations/cascade-write-full-pipeline-test--protects--audit-log.md
@@ -1,0 +1,5 @@
+---
+from: cascade-write-full-pipeline-test
+relation: protects
+to: audit-log
+---


### PR DESCRIPTION
## What

Adds `entitymanager.Manager.PatchEntity` — a targeted partial-write primitive — and migrates Lua, MCP and CLI onto it. **Deletes `lua.ReadDeps.WritePrepStore`.**

The contract: *apply exactly these property changes; properties not named are preserved, regardless of whether the caller could read them.* **Forgetting a property is now a no-op, not an erasure.**

## Why

There was no shared partial-write helper anywhere. `internal/entity` had `GetString`/`SetString`/`Clone` and nothing else, so every writer hand-rolled its own read-modify-write — and the four dialects were mutually incompatible:

| Path | Clear a property? | Clear body? |
|---|---|---|
| dataentry PATCH | yes — out-of-band `properties_unset` | yes — `*string` |
| MCP | yes — in-band `nil` | **no** |
| Lua | **no** | yes (`""`) |
| CLI | **no** | **no** |

Each new writer had to reinvent the merge *and* independently rediscover the read-out/write-prep boundary (DEC-ZBI39P) — a rule previously enforced by prose in four places. That volume of defensive documentation was the smell: the codebase was guarding a sharp edge with warnings instead of removing it.

`WritePrepStore` was that edge. Pointing it at `VisibleReader` made a save erase whatever the caller could not see. It is now gone, so the mistake is unavailable rather than merely discouraged.

Unblocks CalDAV/VTODO inbound sync, where Apple Reminders PUTs a partial view and a whole-entity save would erase every property VTODO cannot express.

## Honest scoping

**No live data loss existed.** Every read-before-write already used a raw handle. This is justified by *semantic divergence and maintenance burden*, not an imminent bug. Two premises in the original brief turned out wrong and are recorded in the ticket: data-entry PATCH was already safe by design, and `automation` `set` actions were never a consumer.

**`FieldWriteGate` is inert in production.** Every wiring site passes `AllowAllFieldGate`, preserving today's exact behaviour. The policy-backed implementation needs affordance-resolver construction moved out of `dataentry` (arch-lint forbids `appbuild → affordances`) — that is TKT-0XL8MF. Stated in the `FieldWriteGate` godoc itself, not only in a ticket, so nobody builds on protection that is not yet there.

## Commits

Sequenced so the risky refactor is reviewable alone:

1. `entitymanager: extract updateCore` — behaviour-preserving, standalone
2. `add PatchEntity primitive` — `entity.Patch`, `FieldWriteGate`
3. `lua: patch through the manager` — deletes `WritePrepStore`
4. `mcp, cli: migrate` — CLI gains `-U/--unset`, `--clear-body`
5. `docs` — replaces the defensive rule with the positive one
6. `fix: structural not-found detection` — code-review fix

## Design review found 7 issues; code review found 1 more

The critical one was mine: I had placed the field gate **before** the ACL authorize. Field verdicts are value-dependent, so that leaks entity existence and stored values to an unauthorized caller. Corrected to `read → IsLocked → authorize → gate → merge`, pinned by `TestPatchEntity_GateRunsAfterAuthorize`.

Code review then caught a real bug in my Lua migration: detecting "entity not found" with `strings.Contains` over the error text. `statemachine` interpolates caller-supplied values (`%s %q→%q is not a declared transition`), so a script setting a property to the literal `"entity not found"` had its transition rejection reported as a 404 — and a script branching on that could recreate a row that still exists. Now structural via an `EntityNotFound() bool` marker. **The regression test was verified to fail against the old implementation.**

Also settled during review: elevation is **total** (`bypass_acl` skips the field gate too — a half-elevated handle is the contract `lua/deps.go` explicitly rejects); automation output is deliberately **not** gated; locked git-crypt entities are refused.

## Verification

- All 11 ACs pass, plus the ordering regression test
- **Audit assertion mutation-tested** — disabling `recordEntityAudit` makes it fail. Necessary because audit is inherited by method *name*, and `PatchEntity` is not in that set
- **CLI verified against the real binary** on an fs-backed project, all six cases including backward-compat (`-P key=` still sets empty string; removal is the new `-U`)
- `go test -race -shuffle=on ./...` clean — matching CI exactly
- `postgres` and `memorybackend` tagged builds compile and vet
- lint, arch-lint, lint-md clean; coverage 76.9% → 77.0%

arch-lint passing confirms the design bet: declaring `FieldWriteGate` as a consumer-side interface needed no `.go-arch-lint.yml` change.

## Follow-ups filed

- **BUG-KIMZRK** — `cascadeHost.WriteEntity` bypasses the manager entirely (no ACL/validation/unique/transitions/audit). Found during design review; untouched here.
- **TKT-0XL8MF** — wire the policy-backed `FieldWriteGate`.
- **RR-TEA3NA** — MCP's redundant pre-read, deferred with three rejected options recorded.

Ticket: TKT-80EWGM
