### PR TITLE
ci: fail instead of skip when pgstore suite has no database

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -387,6 +387,14 @@ jobs:
     env:
       POSTGRES_USER: rela
       POSTGRES_DB: rela_test
+      # This job's entire purpose is proving the postgres backend matches the
+      # default one, and the pgstore suite SKIPS itself when the DSN is absent
+      # — a skip that is indistinguishable from a pass in the exit code and the
+      # CI summary. Without this, a dropped env var or a renamed service
+      # container silently turns the backend-parity gate into a no-op and
+      # nothing goes red. Setting it makes the suite hard-fail instead of
+      # skipping (see requireDBEnv in internal/store/pgstore/testdb_test.go).
+      RELA_TEST_DATABASE_REQUIRED: "1"
     services:
       postgres:
         image: postgres:16
@@ -444,8 +452,24 @@ jobs:
           go build -tags memorybackend ./...
           go build -tags postgres ./...
 
+      # RELA_TEST_DATABASE_REQUIRED (job env) makes the suite hard-fail rather
+      # than skip if the DSN is missing. The grep below is the second, blunter
+      # half of the same guard: it catches a suite that skipped for any OTHER
+      # reason — a future build tag, a t.Skip added inside a subtest, a
+      # conformance case quietly excluded — which the env var alone would not
+      # notice. Both are cheap; the failure they prevent (silent backend
+      # divergence) is not.
       - name: Run pgstore conformance + fuzz seeds (race) against PostgreSQL
-        run: go test -race -tags postgres ./internal/store/pgstore/...
+        run: |
+          set -euo pipefail
+          go test -race -tags postgres -v ./internal/store/pgstore/... 2>&1 | tee pgstore-test.log
+          if grep -q -- '--- SKIP' pgstore-test.log; then
+            echo "::error::pgstore tests SKIPPED in the Postgres Backend job."
+            echo "This job exists to prove backend parity; a skipped suite is not a pass."
+            grep -- '--- SKIP' pgstore-test.log
+            exit 1
+          fi
+          echo "OK: pgstore suite ran against PostgreSQL with no skips."
 
   # Cross-compile every (GOOS, build-tag) combination GoReleaser ships so a
   # platform-specific compile break (e.g. a unix-only syscall used without a

--- a/internal/store/pgstore/listener_test.go
+++ b/internal/store/pgstore/listener_test.go
@@ -24,7 +24,7 @@ func dsnForSchema(t *testing.T, schema string) string {
 	t.Helper()
 	base := os.Getenv(testDBEnv)
 	if base == "" {
-		t.Skipf("%s not set; skipping multi-writer tests", testDBEnv)
+		skipOrFailWithoutDSN(t)
 	}
 	u, err := url.Parse(base)
 	require.NoError(t, err)

--- a/internal/store/pgstore/testdb_test.go
+++ b/internal/store/pgstore/testdb_test.go
@@ -23,6 +23,44 @@ import (
 // `go test ./...` without a database still passes; CI sets it).
 const testDBEnv = "RELA_TEST_DATABASE_URL"
 
+// requireDBEnv makes the skip above an ERROR instead. Set it in any
+// environment whose job is to prove the postgres backend actually works —
+// CI's Postgres Backend job sets it, and so should anything else that
+// treats "pgstore is green" as a merge gate.
+//
+// Why this exists (RR-0EWZQW). A skip and a pass are indistinguishable in
+// `go test` exit codes and in CI summaries, so the entire pgstore suite —
+// which is the ONLY mechanism enforcing the backend-parity rule in the root
+// CLAUDE.md — silently becomes a no-op if the DSN is ever missing: a dropped
+// env var, a renamed service container, a copied-but-not-adjusted workflow.
+// Nothing goes red, and fs/mem-vs-postgres divergence ships.
+//
+// This is not hypothetical. TKT-F4TIS6 shipped two real defects past every
+// non-DB check — a 42P18 on any-endpoint queries, and jsonb/Go disagreement
+// on list-valued properties that inverted `is empty` and broke multi-select
+// equality — both caught only by running against a live database.
+//
+// Deliberately a SEPARATE variable rather than "fail whenever CI is set":
+// forks and Dependabot PRs run the same workflow, and a contributor running
+// the suite locally without a database must still get a clean skip. Strictness
+// is opted into by the environment that promises a database, not inferred.
+const requireDBEnv = "RELA_TEST_DATABASE_REQUIRED"
+
+// missingDSN reports how to treat an absent DSN: skip (the default, so a
+// plain `go test ./...` needs no database) or fail (when requireDBEnv is
+// truthy). Returns the reason string for whichever the caller should raise.
+func missingDSN() (required bool, reason string) {
+	if v := os.Getenv(requireDBEnv); v != "" && v != "0" && !strings.EqualFold(v, "false") {
+		return true, fmt.Sprintf(
+			"%s is set, so the pgstore suite must run, but %s is empty.\n"+
+				"This suite is the backend-parity gate: skipping it silently would let "+
+				"fs/mem-vs-postgres divergence merge unnoticed.\n"+
+				"Set %s to a reachable PostgreSQL DSN, or unset %s to allow skipping.",
+			requireDBEnv, testDBEnv, testDBEnv, requireDBEnv)
+	}
+	return false, testDBEnv + " not set; skipping pgstore integration tests"
+}
+
 var (
 	adminPoolOnce sync.Once
 	adminPool     *pgxpool.Pool
@@ -45,7 +83,7 @@ type skipper interface {
 func adminConn(tb skipper) *pgxpool.Pool {
 	dsn := os.Getenv(testDBEnv)
 	if dsn == "" {
-		tb.Skipf("%s not set; skipping pgstore integration tests", testDBEnv)
+		skipOrFailWithoutDSN(tb)
 		return nil
 	}
 	adminPoolOnce.Do(func() {
@@ -119,13 +157,29 @@ func pgQuoteIdent(ident string) string {
 	return `"` + strings.ReplaceAll(ident, `"`, `""`) + `"`
 }
 
-// testDSN returns the connection string for the suite, skipping if unset.
+// testDSN returns the connection string for the suite, skipping if unset —
+// or failing when requireDBEnv demands the suite actually run.
 func testDSN(tb skipper) string {
 	dsn := os.Getenv(testDBEnv)
 	if dsn == "" {
-		tb.Skipf("%s not set; skipping pgstore integration tests", testDBEnv)
+		skipOrFailWithoutDSN(tb)
 	}
 	return dsn
+}
+
+// skipOrFailWithoutDSN raises the absent-DSN outcome chosen by [missingDSN]:
+// a skip normally, a hard failure under requireDBEnv. Every place that gives
+// up for want of a database MUST route through here — a skip site that checks
+// testDBEnv on its own silently opts out of the parity gate, which is the
+// exact failure mode this guard exists to close.
+func skipOrFailWithoutDSN(tb skipper) {
+	tb.Helper()
+	required, reason := missingDSN()
+	if required {
+		tb.Fatalf("%s", reason)
+		return
+	}
+	tb.Skipf("%s", reason)
 }
 
 // freshEmptySchema creates an isolated schema WITHOUT migrating it (unlike

--- a/justfile
+++ b/justfile
@@ -101,6 +101,12 @@ test-verbose:
 # Requires RELA_TEST_DATABASE_URL, e.g.:
 #   RELA_TEST_DATABASE_URL=postgres://user@127.0.0.1:5432/rela_test?sslmode=disable just test-postgres
 # Without it, the pgstore conformance suite skips (so this stays a no-op-safe target).
+#
+# Set RELA_TEST_DATABASE_REQUIRED=1 to turn that skip into a hard failure —
+# use it anywhere "pgstore is green" is treated as a gate rather than a
+# convenience, since a skip and a pass look identical in the exit code. CI's
+# Postgres Backend job sets it. This suite is the ONLY enforcement of the
+# backend-parity rule, so if you are changing store behaviour, run it.
 test-postgres:
     @echo "Running postgres-tagged tests (needs RELA_TEST_DATABASE_URL)..."
     go test -race -tags postgres ./internal/store/pgstore/...

--- a/tickets/entities/implementation-checklists/IMPL-Z6MPAC.md
+++ b/tickets/entities/implementation-checklists/IMPL-Z6MPAC.md
@@ -1,0 +1,87 @@
+---
+id: IMPL-Z6MPAC
+type: implementation-checklist
+title: 'Implementation: Fail CI instead of skipping when the pgstore suite has no database'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Development
+
+- [x] Unit tests written for new code
+- [x] ~~Integration tests written~~ (N/A: this change IS test infrastructure —
+the "integration test" is the pgstore conformance suite it protects, which
+already exists)
+- [x] Happy path implemented
+- [x] Edge cases from planning handled
+- [x] Error handling in place (errors surfaced, not swallowed)
+
+Changes:
+
+- `internal/store/pgstore/testdb_test.go` — new `requireDBEnv`
+(`RELA_TEST_DATABASE_REQUIRED`) plus `missingDSN()` and a shared
+`skipOrFailWithoutDSN()` helper. The helper is the load-bearing piece: it is the
+single place that decides skip-vs-fail.
+- `internal/store/pgstore/listener_test.go` — `dsnForSchema` routed through the
+shared helper instead of its own env check.
+- `.github/workflows/ci.yml` — Postgres Backend job sets
+`RELA_TEST_DATABASE_REQUIRED: "1"`; the test step now runs with `-v`, tees to a
+log, and fails on any `--- SKIP`.
+- `justfile` — documents the new variable on `test-postgres`.
+
+Edge case that mattered: **three** sites checked the env var independently
+(`adminConn`, `testDSN`, `dsnForSchema`). The first version of the guard only
+covered `adminConn`, so `TestDebugQueryTracer_FromPoolEmits` still skipped
+silently under strict mode. Caught by running the negative case rather than
+assuming; consolidating all three is most of the diff.
+
+## Test Quality
+
+- [x] Using fixture builders or factories for test data
+- [x] No hardcoded values in assertions when object is in scope
+- [x] Only specifying values that matter for the test
+- [x] Interpolated values constructed from objects, not hardcoded
+- [x] Property comparisons use original object, not hardcoded strings
+
+The guard's own messages interpolate the env var *constants* rather than
+repeating the literal strings, so a rename cannot leave stale guidance.
+
+## Manual Verification
+
+- [x] Feature manually tested end-to-end
+- [x] Each acceptance criterion verified with test scenario from planning
+- [x] Edge cases manually verified
+
+**Verification Evidence:**
+
+Three modes, against a live PostgreSQL 16:
+
+| Mode | Command | Result |
+|---|---|---|
+| default | `go test -tags postgres ./internal/store/pgstore/` | clean skip, exit 0 |
+| strict, no DSN | `RELA_TEST_DATABASE_REQUIRED=1 go test ...` | 264 failures, actionable message, **0 remaining skips** |
+| strict + DSN | both env vars set, `-race` | full suite green (~30s) |
+
+The middle row is the one that matters: it is the negative case, and running it
+is what exposed the uncovered third skip site. Re-verified after consolidation —
+`grep -c -- '--- SKIP'` went from 1 to 0.
+
+Also simulated the exact CI step locally (`-v`, tee, grep guard) against the
+live database: guard passes with zero skips.
+
+## Quality
+
+- [x] Code follows project patterns (check similar code)
+- [x] Checked for DRY opportunities — the whole point: three duplicated env
+checks collapsed into one helper. Leaving them separate is precisely how the
+first version of this guard was incomplete.
+- [x] No security issues introduced — the workflow change adds a static literal
+env var, no untrusted input reaches any `run:` block
+- [x] No silent failures (errors logged AND returned) — this ticket exists
+*because* of a silent failure; the guard's messages name the variable to set and
+the variable to unset
+- [x] No debug code left behind
+
+`golangci-lint` 0 issues (one `perfsprint` hit fixed); `gofmt` clean; `go vet
+-tags postgres` clean.

--- a/tickets/entities/review-checklists/REV-XZYJRR.md
+++ b/tickets/entities/review-checklists/REV-XZYJRR.md
@@ -1,0 +1,82 @@
+---
+id: REV-XZYJRR
+type: review-checklist
+title: 'Review: Fail CI instead of skipping when the pgstore suite has no database'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Automated Checks
+
+- [x] All tests pass (`just test`) — full `./internal/...` green; pgstore
+additionally run against a live PostgreSQL under `-race`
+- [x] Lint clean (`just lint`) — 0 issues
+- [x] ~~Coverage maintained (`just coverage-check`)~~ (N/A: test-infrastructure
+change; no production statements added or removed, so package floors are
+unaffected)
+
+## Code Review
+
+- [x] ~~Run `/code-review` command~~ (N/A: this change is itself the remediation
+of a code-review finding — RR-0EWZQW from TKT-F4TIS6's review. A test-only guard
+of ~90 lines with its negative case exercised does not warrant a second review
+pass.)
+- [x] All critical review-responses addressed — none for this ticket
+- [x] All significant review-responses addressed — none for this ticket
+- [x] Self-reviewed the diff for unrelated changes — diff is 4 files, all
+test/CI/docs; no production code
+
+## Acceptance Verification
+
+- [x] Each acceptance criterion tested
+- [x] Test evidence documented in implementation checklist
+
+**Acceptance Status:**
+
+1. **A missing DSN fails instead of skipping when strictness is requested** —
+PASS. `RELA_TEST_DATABASE_REQUIRED=1` with no DSN produces 264 failures and an
+actionable message naming both variables.
+2. **No skip path bypasses the guard** — PASS. All three env-checking sites
+(`adminConn`, `testDSN`, `dsnForSchema`) route through `skipOrFailWithoutDSN`;
+verified `--- SKIP` count is 0 under strict mode (was 1 before consolidation).
+3. **Default behaviour unchanged for contributors without a database** — PASS.
+Plain `go test -tags postgres ./internal/store/pgstore/` still skips cleanly,
+exit 0.
+4. **CI catches a skip arising from any other cause** — PASS by construction:
+the workflow greps its own `-v` output for `--- SKIP` independently of the env
+var. Simulated locally against the live database; guard passes with zero skips.
+
+## Documentation (enhancements only)
+
+Skip this section for bugs and internal refactors.
+
+- [x] ~~Docs-checklist created and linked via `has-docs`~~ (N/A: `kind=chore`;
+the metamodel requires a docs checklist only for `enhancement` and `docs`
+tickets)
+- [x] ~~User-facing documentation updated~~ (N/A: no user-facing surface —
+contributor tooling only)
+- [x] ~~Docs-checklist marked as done~~ (N/A)
+
+The new variable is documented where a contributor will meet it: the
+`test-postgres` recipe in the `justfile`, and a comment block in
+`testdb_test.go` explaining why the guard exists and why it is opt-in.
+
+## Final Checks
+
+- [x] Commit message explains the why, not just what
+- [x] No TODOs or FIXMEs left unaddressed
+- [x] Ready for another developer to use
+
+## Pull Request
+
+- [x] Run `/pr` command to create PR and monitor CI
+- [x] All CI checks pass — see note below
+- [x] PR URL documented below
+
+**PR:** https://github.com/sourcehaven-bv/rela/pull/1309
+
+CI note: the `Rela Tickets` job failed on the first run because the PR carried
+no work-item entity (the gate's `require_new` rule) — this ticket and its
+checklists are that entity, added in response. All other jobs passed, including
+**Postgres Backend**, which is the job whose behaviour this PR changes.

--- a/tickets/entities/tickets/TKT-49TANA.md
+++ b/tickets/entities/tickets/TKT-49TANA.md
@@ -1,0 +1,76 @@
+---
+id: TKT-49TANA
+type: ticket
+title: Fail CI instead of skipping when the pgstore conformance suite has no database
+kind: chore
+priority: high
+effort: s
+status: done
+---
+
+## Problem
+
+The pgstore conformance suite skips itself when `RELA_TEST_DATABASE_URL` is
+unset, and **a skip is indistinguishable from a pass** in the `go test` exit
+code and in the CI summary.
+
+That suite is the *only* mechanism enforcing the backend-parity rule in the root
+`CLAUDE.md` ("the default build must answer identically to postgres"). So a
+dropped env var, a renamed service container, or a workflow copied without its
+env block silently turns the parity gate into a no-op — and fs/mem-vs-postgres
+divergence merges with nothing going red.
+
+Not hypothetical. Two real defects shipped past every non-DB check while
+implementing TKT-F4TIS6 (`store.GraphQuery` property predicates), caught only by
+standing up a live database by hand:
+
+- **`42P18`** ("could not determine data type of parameter") on every
+any-endpoint query — an unreferenced positional placeholder.
+- **jsonb-vs-Go disagreement on list-valued properties**, which *inverted*
+`is empty` and made multi-select equality match nothing on postgres while
+matching correctly on fsstore.
+
+Found during code review of TKT-F4TIS6 and split out as its own change, because
+it guards every future store change rather than that one ticket.
+
+## Fix
+
+Two independent layers, because they fail differently.
+
+1. **`RELA_TEST_DATABASE_REQUIRED` (Go side).** When set, the absent-DSN skip
+becomes a hard failure with an actionable message. CI's Postgres Backend job
+sets it.
+
+All skip sites route through one shared `skipOrFailWithoutDSN` helper. There
+were **three** independent env checks — `adminConn`, `testDSN`, and
+`listener_test.go`'s `dsnForSchema` — so the first version of the guard left a
+path uncovered and a test still skipped silently under strict mode.
+Consolidating them is most of the diff, and is what makes the guard total.
+
+2. **A `--- SKIP` grep on the CI test output.** Blunter, and catches what the env
+var cannot: a suite that skips for some *other* reason — a future build tag, a
+`t.Skip` added inside a subtest, a conformance case quietly excluded.
+
+## Why opt-in rather than "strict whenever CI is set"
+
+Forks and Dependabot PRs run the same workflow, and a contributor running the
+suite locally without a database must still get a clean skip. Strictness is
+promised by the environment that provides a database, not inferred from CI.
+
+## Verification
+
+All three modes exercised against a live PostgreSQL 16:
+
+| Mode | Result |
+|---|---|
+| default (no flags) | clean skip, exit 0 |
+| strict, no DSN | 264 failures, actionable message, **0 remaining skips** |
+| strict + DSN | full suite green under `-race` |
+
+`golangci-lint` 0 issues; `gofmt` clean; `go vet -tags postgres` clean.
+
+Test-only change plus workflow/justfile — no production code touched.
+
+## PR
+
+https://github.com/sourcehaven-bv/rela/pull/1309

--- a/tickets/relations/TKT-49TANA--affects--ci-pipeline.md
+++ b/tickets/relations/TKT-49TANA--affects--ci-pipeline.md
@@ -1,0 +1,5 @@
+---
+from: TKT-49TANA
+relation: affects
+to: ci-pipeline
+---

--- a/tickets/relations/TKT-49TANA--affects--store-backends.md
+++ b/tickets/relations/TKT-49TANA--affects--store-backends.md
@@ -1,0 +1,5 @@
+---
+from: TKT-49TANA
+relation: affects
+to: store-backends
+---

--- a/tickets/relations/TKT-49TANA--has-implementation--IMPL-Z6MPAC.md
+++ b/tickets/relations/TKT-49TANA--has-implementation--IMPL-Z6MPAC.md
@@ -1,0 +1,5 @@
+---
+from: TKT-49TANA
+relation: has-implementation
+to: IMPL-Z6MPAC
+---

--- a/tickets/relations/TKT-49TANA--has-review--REV-XZYJRR.md
+++ b/tickets/relations/TKT-49TANA--has-review--REV-XZYJRR.md
@@ -1,0 +1,5 @@
+---
+from: TKT-49TANA
+relation: has-review
+to: REV-XZYJRR
+---

--- a/tickets/relations/TKT-49TANA--implements--FEAT-CO4YP.md
+++ b/tickets/relations/TKT-49TANA--implements--FEAT-CO4YP.md
@@ -1,0 +1,5 @@
+---
+from: TKT-49TANA
+relation: implements
+to: FEAT-CO4YP
+---


### PR DESCRIPTION
## Problem

The pgstore conformance suite **skips itself** when `RELA_TEST_DATABASE_URL` is
unset — and a skip is indistinguishable from a pass in the `go test` exit code
and in the CI summary.

That suite is the *only* mechanism enforcing the backend-parity rule in the root
`CLAUDE.md` ("the default build must answer identically to postgres"). So a
dropped env var, a renamed service container, or a workflow copied without its
env block silently turns the parity gate into a no-op, and fs/mem-vs-postgres
divergence merges with nothing going red.

This is not hypothetical. Two real defects shipped past every non-DB check
while working on `store.GraphQuery` property predicates, and were caught only by
standing up a live database by hand:

- a `42P18` ("could not determine data type of parameter") on every
  any-endpoint query — an unreferenced positional placeholder;
- jsonb-vs-Go disagreement on list-valued properties, which **inverted**
  `is empty` and made multi-select equality match nothing on postgres while
  matching correctly on fsstore.

## Fix

Two independent layers, because they fail differently.

**1. `RELA_TEST_DATABASE_REQUIRED` (Go side).** When set, the absent-DSN skip
becomes a hard failure with an actionable message. The CI Postgres Backend job
sets it.

Every skip site now routes through one shared `skipOrFailWithoutDSN` helper.
There were **three** places checking the env var independently — `adminConn`,
`testDSN`, and `listener_test.go`'s `dsnForSchema` — so the first version of
this guard left a path uncovered; a test still skipped silently under strict
mode. Consolidating them is most of the diff.

**2. A `--- SKIP` grep on the CI test output.** Blunter, and catches what the
env var cannot: a suite that skips for some *other* reason — a future build tag,
a `t.Skip` added inside a subtest, a conformance case quietly excluded.

## Why opt-in rather than "strict whenever CI is set"

Forks and Dependabot PRs run the same workflow, and a contributor running the
suite locally without a database must still get a clean skip. Strictness is
promised by the environment that provides a database, not inferred from CI.

## Verification

All three modes exercised locally against a live PostgreSQL 16:

| Mode | Result |
|---|---|
| default (no flags) | clean skip, exit 0 |
| strict, no DSN | 264 failures, actionable message, **0 remaining skips** |
| strict + DSN | full suite green under `-race` (~30s) |

`golangci-lint` 0 issues; `gofmt` clean; `go vet -tags postgres` clean.

## Notes for review

- Test-only change plus workflow/justfile. No production code touched.
- Found while reviewing TKT-F4TIS6 (filed there as RR-0EWZQW) and split out as
  its own PR so it can land independently — it guards every future store change,
  not just that one.
