### PR TITLE
feat(data-entry): render list cells and kanban cards through the widget registry

### DIFF
--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -52,12 +52,54 @@ src/components/   → Reusable UI components
 | `src/api/` | Typed API client functions (entities, schema, git, settings, etc.) |
 | `src/stores/` | Pinia stores: `schema` (metamodel/config), `entities` (CRUD + cache), `ui` (toasts, sidebar), `git` (status) |
 | `src/views/` | Route-level components: Dashboard, List, Form, Entity, Kanban, Graph, Search, Settings |
-| `src/components/forms/` | Form widgets: DynamicForm, FieldRenderer, RelationPicker, MarkdownEditor, SidePanel |
+| `src/widgets/` | The property-widget library + `registry.ts` (the type→widget dispatch). One widget per property type, each rendering both `mode: 'display'` and `mode: 'edit'` |
+| `src/components/forms/` | Form scaffolding: DynamicForm, FieldRenderer (resolves via the widget registry), RelationPicker, MarkdownEditor, SidePanel |
 | `src/components/lists/` | EntityList, FilterBar, Pagination |
 | `src/components/common/` | Sidebar, StatusBar, Badge, Toast, BackButton |
 | `src/composables/` | Vue composables: useKeyboardShortcuts, useEvents (SSE), useListKeyboard, useScopeNavigation, useBackTarget |
 | `src/styles/` | Shared CSS loaded from `main.ts` (e.g. `back-button.css` for the `.scope-nav-btn` class reused across EntityDetail, CustomView, and standalone BackButton) |
 | `src/types/` | TypeScript interfaces for entities, schema, and config |
+
+### Widgets render property values everywhere, including read-only
+
+A property value is rendered by a **widget** on every surface — forms, entity
+detail, view sections, list/table cells, and kanban cards. Widgets take a
+required `mode: 'display' | 'edit'` (no default, RR-UD1I) and own their
+read-only rendering. **Do not add a per-type `v-if` to a view.** A new property
+type should need a widget plus a routing entry, never a branch per surface.
+
+There are two routing entry points, and they are not interchangeable:
+
+- `defaultRegistry.resolve(name, propertyDef)` — form side, when you hold the
+  real schema entry.
+- `defaultRegistry.resolveFromHint(hint)` — view side, when you have wire-level
+  field metadata. Build the hint with `viewFieldRoutingHint` (view sections) or
+  `densePropertyRoutingHint` (list cells, kanban cards).
+
+**Dense surfaces are not detail views.** `densePropertyRoutingHint` exists
+because a table cell and a detail row have genuinely opposite contracts, and
+reusing the detail-view routing in a cell has already caused regressions
+(TKT-S9C14S):
+
+- **Empty renders blank, never a placeholder.** MultiSelectWidget's em-dash
+  (RR-UD2C) is right for a detail row and wrong for a cell — `formatCellValue`
+  documents that "blank table cells stay visually quiet". `isDenseEmpty` gates
+  this at the cell, before the widget sees the value.
+- **`list: true` must not override the type's formatter.** `defaultWidgetFor`
+  puts list first because the *edit* side needs a tag picker whatever the type;
+  on the display side that erases the formatter (a list-valued rrule rendered as
+  an em-dash). Non-enum lists route to preformatted text.
+- **`boolean` → text and `file` → text in cells**, deliberately: booleans stay
+  Cmd-F searchable, and FileWidget's `<img>` previews would be one network
+  request per cell.
+- **Resolve per column/field, not per cell** — `resolve()` walks a Map and can
+  `console.warn`, which at 200 rows is 200 warnings per render. See
+  `PropertyDisplay.vue`'s precomputed `rows` (RR-UD2A) for the pattern.
+
+The hint carries `preformatted`: true for passthrough widgets that render
+`String(value)`, false for widgets that own their display formatting. A new
+widget defaults to false (raw value), which is correct — the reason to add a
+widget is that it renders something text cannot.
 
 ### Key Stores
 

--- a/frontend/src/components/lists/EntityList.cells.test.ts
+++ b/frontend/src/components/lists/EntityList.cells.test.ts
@@ -1,0 +1,250 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import { PiniaColada } from '@pinia/colada'
+import EntityList from './EntityList.vue'
+import { useSchemaStore } from '@/stores/schema'
+import { _setEntityPluralForTest } from '@/api/entities'
+import { defaultRegistry } from '@/widgets/registry'
+import type { Entity, ListResponse } from '@/types'
+
+// Cell rendering moved from a string-only path (formatCellValue interpolated
+// as text) onto the widget registry in mode:'display' -- TKT-S9C14S. These
+// tests pin the resulting behaviour at the two EntityList render sites
+// (desktop <td> and mobile card), including the routings that are
+// deliberately NOT the matching widget.
+
+const listEntitiesMock = vi.fn()
+vi.mock('@/api', async (orig) => ({
+  ...(await orig<typeof import('@/api')>()),
+  listEntities: (...args: unknown[]) => listEntitiesMock(...args),
+}))
+
+vi.mock('vue-router', () => ({
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn() }),
+  useRoute: () => ({ query: {}, path: '/list/things', name: 'list' }),
+}))
+
+describe('EntityList cell rendering via widgets', () => {
+  const listId = 'things-list'
+  const entityType = 'thing'
+
+  function seedSchema(
+    properties: Record<string, unknown>,
+    columns: { property?: string; relation?: string; label?: string }[]
+  ) {
+    const schemaStore = useSchemaStore()
+    schemaStore.lists.set(listId, {
+      id: listId,
+      title: 'Things',
+      entity: entityType,
+      columns,
+    } as never)
+    schemaStore.entityTypes.set(entityType, {
+      name: entityType,
+      label: 'Thing',
+      properties,
+    } as never)
+  }
+
+  function seedEntities(entities: Entity[]) {
+    const response: ListResponse<Entity> = {
+      data: entities,
+      meta: { total: entities.length, page: 1, per_page: 25, has_more: false },
+      included: {},
+    }
+    listEntitiesMock.mockResolvedValue(response)
+  }
+
+  async function mountList() {
+    const wrapper = mount(EntityList, {
+      props: { listId },
+      global: { plugins: [pinia, PiniaColada] },
+    })
+    await flushPromises()
+    return wrapper
+  }
+
+  let pinia: ReturnType<typeof createPinia>
+  beforeEach(() => {
+    pinia = createPinia()
+    setActivePinia(pinia)
+    _setEntityPluralForTest(entityType, 'things')
+    listEntitiesMock.mockReset()
+  })
+
+  afterEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  it('renders a string cell as plain text', async () => {
+    seedSchema({ title: { type: 'string' } }, [{ property: 'title', label: 'Title' }])
+    seedEntities([{ id: 'T-1', type: entityType, properties: { title: 'Hello' } }])
+    const wrapper = await mountList()
+    expect(wrapper.text()).toContain('Hello')
+  })
+
+  it('renders an enum cell as a Badge, as before the migration', async () => {
+    seedSchema({ status: { type: 'enum', values: ['open', 'done'] } }, [
+      { property: 'status', label: 'Status' },
+    ])
+    seedEntities([{ id: 'T-1', type: entityType, properties: { status: 'open' } }])
+    const wrapper = await mountList()
+    expect(wrapper.find('.badge').exists()).toBe(true)
+    expect(wrapper.text()).toContain('open')
+  })
+
+  it('renders a list-valued enum as one Badge per value', async () => {
+    seedSchema({ tags: { type: 'enum', values: ['a', 'b'], list: true } }, [
+      { property: 'tags', label: 'Tags' },
+    ])
+    seedEntities([{ id: 'T-1', type: entityType, properties: { tags: ['a', 'b'] } }])
+    const wrapper = await mountList()
+    expect(wrapper.findAll('.badge').length).toBe(2)
+  })
+
+  it('keeps boolean cells as Yes/No text, not a checkbox (searchable/copy-pasteable)', async () => {
+    seedSchema({ done: { type: 'boolean' } }, [{ property: 'done', label: 'Done' }])
+    seedEntities([
+      { id: 'T-1', type: entityType, properties: { done: true } },
+      { id: 'T-2', type: entityType, properties: { done: false } },
+    ])
+    const wrapper = await mountList()
+    const rows = wrapper.findAll('tbody tr')
+    expect(rows[0].text()).toContain('Yes')
+    expect(rows[1].text()).toContain('No')
+    // No rendered checkbox in the data cells (the select-all/row checkboxes
+    // only exist when the list has actions, which this config does not).
+    expect(wrapper.find('tbody input[type="checkbox"]').exists()).toBe(false)
+  })
+
+  it('renders a date cell formatted, not as the raw stored string', async () => {
+    seedSchema({ due: { type: 'date' } }, [{ property: 'due', label: 'Due' }])
+    seedEntities([{ id: 'T-1', type: entityType, properties: { due: '2026-03-04' } }])
+    const wrapper = await mountList()
+    expect(wrapper.text()).not.toContain('2026-03-04T')
+    expect(wrapper.text()).toMatch(/2026/)
+  })
+
+  it('renders a relation cell as joined titles (unchanged string path)', async () => {
+    seedSchema({ title: { type: 'string' } }, [
+      { property: 'title', label: 'Title' },
+      { relation: 'blocks', label: 'Blocks' },
+    ])
+    const response: ListResponse<Entity> = {
+      data: [
+        {
+          id: 'T-1',
+          type: entityType,
+          properties: { title: 'A' },
+          relations: { blocks: ['T-9'] },
+        },
+      ],
+      meta: { total: 1, page: 1, per_page: 25, has_more: false },
+      // Display names come from the backend-computed `_title`, never
+      // properties.title (BUG-1P88YM / entityDisplayTitle).
+      included: {
+        'T-9': {
+          id: 'T-9',
+          type: entityType,
+          _title: 'Blocked one',
+          properties: { title: 'Blocked one' },
+        },
+      },
+    }
+    listEntitiesMock.mockResolvedValue(response)
+    const wrapper = await mountList()
+    expect(wrapper.text()).toContain('Blocked one')
+  })
+
+  it('renders the lock marker for an inaccessible cell instead of a widget', async () => {
+    seedSchema({ secret: { type: 'string' } }, [{ property: 'secret', label: 'Secret' }])
+    seedEntities([
+      {
+        id: 'T-1',
+        type: entityType,
+        properties: {},
+        inaccessible: [{ name: 'secret', reason: 'encrypted' }],
+      } as unknown as Entity,
+    ])
+    const wrapper = await mountList()
+    expect(wrapper.find('.inaccessible-cell').exists()).toBe(true)
+  })
+
+  it('does not warn when rendering any built-in property type', async () => {
+    // A supportedPropertyTypes mismatch console.warns once per resolve; if
+    // resolution leaked into the per-cell path this would fire per row.
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    seedSchema(
+      {
+        s: { type: 'string' },
+        d: { type: 'date' },
+        dt: { type: 'datetime' },
+        i: { type: 'integer' },
+        b: { type: 'boolean' },
+        e: { type: 'enum', values: ['x'] },
+        f: { type: 'file' },
+      },
+      [
+        { property: 's' },
+        { property: 'd' },
+        { property: 'dt' },
+        { property: 'i' },
+        { property: 'b' },
+        { property: 'e' },
+        { property: 'f' },
+      ]
+    )
+    seedEntities([
+      {
+        id: 'T-1',
+        type: entityType,
+        properties: {
+          s: 'a',
+          d: '2026-01-01',
+          dt: '2026-01-01T10:00:00Z',
+          i: 3,
+          b: true,
+          e: 'x',
+          f: 'doc.pdf',
+        },
+      },
+    ])
+    await mountList()
+    expect(warn).not.toHaveBeenCalled()
+    warn.mockRestore()
+  })
+
+  it('resolves each widget once per COLUMN, not once per cell (RR-UD2A)', async () => {
+    // 50 rows x 3 columns = 150 cells. Resolution happens in a computed keyed
+    // on the column set, so it must run 3 times. If this regresses to per-cell,
+    // every supportedPropertyTypes mismatch also becomes one console.warn per
+    // row per render.
+    seedSchema(
+      { a: { type: 'string' }, b: { type: 'date' }, c: { type: 'enum', values: ['x'] } },
+      [{ property: 'a' }, { property: 'b' }, { property: 'c' }]
+    )
+    seedEntities(
+      Array.from({ length: 50 }, (_, i) => ({
+        id: `T-${i}`,
+        type: entityType,
+        properties: { a: 'v', b: '2026-01-01', c: 'x' },
+      }))
+    )
+    const spy = vi.spyOn(defaultRegistry, 'resolveFromHint')
+    const wrapper = await mountList()
+    expect(wrapper.findAll('tbody tr').length).toBe(50)
+    expect(spy).toHaveBeenCalledTimes(3)
+    spy.mockRestore()
+  })
+
+  it('does not issue image requests for a file column (no FileWidget in cells)', async () => {
+    seedSchema({ doc: { type: 'file' } }, [{ property: 'doc', label: 'Doc' }])
+    seedEntities([{ id: 'T-1', type: entityType, properties: { doc: 'picture.png' } }])
+    const wrapper = await mountList()
+    // FileWidget's display branch renders <img> previews; routing file->text
+    // keeps a table from issuing one image request per row.
+    expect(wrapper.find('tbody img').exists()).toBe(false)
+    expect(wrapper.text()).toContain('picture.png')
+  })
+})

--- a/frontend/src/components/lists/EntityList.cells.test.ts
+++ b/frontend/src/components/lists/EntityList.cells.test.ts
@@ -215,6 +215,49 @@ describe('EntityList cell rendering via widgets', () => {
     warn.mockRestore()
   })
 
+  // --- Regressions caught in review: list-ness must not erase the type's
+  // formatter, and cells must stay quiet when empty. ---
+
+  it('renders a list-valued date as joined text, not as enum badges', async () => {
+    seedSchema({ d: { type: 'date', list: true } }, [{ property: 'd' }])
+    seedEntities([
+      { id: 'T-1', type: entityType, properties: { d: ['2026-01-01', '2026-02-02'] } },
+    ])
+    const wrapper = await mountList()
+    const cell = wrapper.find('tbody td')
+    expect(cell.find('.badge').exists()).toBe(false)
+    expect(cell.text()).toContain('2026-01-01, 2026-02-02')
+  })
+
+  it('renders a list-valued rrule as its text form, not an em-dash', async () => {
+    // Routing list-ness ahead of the type sent this to MultiSelectWidget,
+    // which em-dashed it -- the value vanished entirely.
+    seedSchema({ r: { type: 'rrule', list: true } }, [{ property: 'r' }])
+    seedEntities([{ id: 'T-1', type: entityType, properties: { r: ['FREQ=DAILY'] } }])
+    const wrapper = await mountList()
+    const cell = wrapper.find('tbody td')
+    expect(cell.text()).not.toContain('—')
+    expect(cell.text()).toContain('every day')
+  })
+
+  it('leaves an empty list-valued cell blank, not an em-dash', async () => {
+    // MultiSelectWidget renders '—' for an empty array (RR-UD2C), which is a
+    // detail-view contract. formatCellValue documents the opposite for cells:
+    // "blank table cells stay visually quiet".
+    seedSchema({ tags: { type: 'enum', values: ['a'], list: true } }, [{ property: 'tags' }])
+    seedEntities([{ id: 'T-1', type: entityType, properties: { tags: [] } }])
+    const wrapper = await mountList()
+    expect(wrapper.find('tbody td').text()).not.toContain('—')
+  })
+
+  it('still badges a non-empty list-valued enum', async () => {
+    // The empty-array fix must not disable enum badging.
+    seedSchema({ tags: { type: 'enum', values: ['a', 'b'], list: true } }, [{ property: 'tags' }])
+    seedEntities([{ id: 'T-1', type: entityType, properties: { tags: ['a', 'b'] } }])
+    const wrapper = await mountList()
+    expect(wrapper.findAll('tbody .badge').length).toBe(2)
+  })
+
   it('resolves each widget once per COLUMN, not once per cell (RR-UD2A)', async () => {
     // 50 rows x 3 columns = 150 cells. Resolution happens in a computed keyed
     // on the column set, so it must run 3 times. If this regresses to per-cell,
@@ -236,6 +279,76 @@ describe('EntityList cell rendering via widgets', () => {
     expect(wrapper.findAll('tbody tr').length).toBe(50)
     expect(spy).toHaveBeenCalledTimes(3)
     spy.mockRestore()
+  })
+
+  // --- The mobile card render site. Structurally a duplicate of the desktop
+  // <td>, so it can silently drift; nothing covered it before. ---
+
+  describe('mobile card render site', () => {
+    let originalMatchMedia: typeof window.matchMedia
+
+    beforeEach(() => {
+      originalMatchMedia = window.matchMedia
+      // isMobile is seeded from matchMedia at setup, so stub before mount.
+      window.matchMedia = ((query: string) =>
+        ({
+          matches: query.includes('max-width: 768px'),
+          media: query,
+          addEventListener: () => {},
+          removeEventListener: () => {},
+        }) as unknown as MediaQueryList) as typeof window.matchMedia
+    })
+
+    afterEach(() => {
+      window.matchMedia = originalMatchMedia
+    })
+
+    it('renders card fields through widgets, matching the desktop cell', async () => {
+      seedSchema({ title: { type: 'string' }, status: { type: 'enum', values: ['open'] } }, [
+        { property: 'title', label: 'Title' },
+        { property: 'status', label: 'Status' },
+      ])
+      seedEntities([
+        { id: 'T-1', type: entityType, properties: { title: 'Hello', status: 'open' } },
+      ])
+      const wrapper = await mountList()
+      expect(wrapper.find('.mobile-card').exists()).toBe(true)
+      // Column 0 is the card title; the enum is a badge in the field list.
+      expect(wrapper.find('.mobile-card').text()).toContain('Hello')
+      expect(wrapper.find('.mobile-card .badge').exists()).toBe(true)
+    })
+
+    it('keeps boolean card fields as Yes/No, matching desktop', async () => {
+      seedSchema({ title: { type: 'string' }, done: { type: 'boolean' } }, [
+        { property: 'title', label: 'Title' },
+        { property: 'done', label: 'Done' },
+      ])
+      seedEntities([
+        { id: 'T-1', type: entityType, properties: { title: 'A', done: false } },
+      ])
+      const wrapper = await mountList()
+      expect(wrapper.find('.mobile-card').text()).toContain('No')
+    })
+
+    it('still hides a column whose value is empty (the emptiness predicate)', async () => {
+      seedSchema({ title: { type: 'string' }, note: { type: 'string' } }, [
+        { property: 'title', label: 'Title' },
+        { property: 'note', label: 'Note' },
+      ])
+      seedEntities([{ id: 'T-1', type: entityType, properties: { title: 'A', note: '' } }])
+      const wrapper = await mountList()
+      expect(wrapper.find('.mobile-card').text()).not.toContain('Note')
+    })
+
+    it('keeps a false boolean visible rather than treating it as empty', async () => {
+      seedSchema({ title: { type: 'string' }, done: { type: 'boolean' } }, [
+        { property: 'title', label: 'Title' },
+        { property: 'done', label: 'Done' },
+      ])
+      seedEntities([{ id: 'T-1', type: entityType, properties: { title: 'A', done: false } }])
+      const wrapper = await mountList()
+      expect(wrapper.find('.mobile-card').text()).toContain('Done')
+    })
   })
 
   it('does not issue image requests for a file column (no FileWidget in cells)', async () => {

--- a/frontend/src/components/lists/EntityList.vue
+++ b/frontend/src/components/lists/EntityList.vue
@@ -16,9 +16,9 @@ import { entityDisplayTitle } from '@/utils/entityDisplay'
 import { renderMarkdown } from '@/utils/markdown'
 import { actionAllowed } from '@/utils/affordancesWarning'
 import { getCellValue, formatCellValue } from '@/utils/format'
-import { densePropertyRoutingHint } from '@/widgets/viewRouting'
+import { densePropertyRoutingHint, isDenseEmpty } from '@/widgets/viewRouting'
 import { defaultRegistry } from '@/widgets/registry'
-import type { WidgetRoutingHint } from '@/widgets/types'
+import type { DenseRoutingHint } from '@/widgets/viewRouting'
 import type { Entity, ListMeta, ListParams, ListResponse, FilterState } from '@/types'
 import { viewHeaderMarkdown, viewFooterMarkdown } from '@/types'
 import FilterBar from './FilterBar.vue'
@@ -543,41 +543,82 @@ function navigateToEntity(entity: Entity) {
 // PropertyDef and there is no relation widget, so they stay on the string
 // path in getFormattedCellValue.
 const columnWidgets = computed(() => {
-  const byProperty = new Map<
-    string,
-    { component: Component; hint: WidgetRoutingHint; preformatted: boolean }
-  >()
+  const byProperty = new Map<string, { component: Component; hint: DenseRoutingHint }>()
   const type = entityType.value
   if (!type) return byProperty
   for (const column of listConfig.value?.columns ?? []) {
     if (!column.property || byProperty.has(column.property)) continue
     const hint = densePropertyRoutingHint(type.properties[column.property], column.property)
-    byProperty.set(column.property, {
-      component: defaultRegistry.resolveFromHint(hint),
-      hint,
-      // A 'text' hint means the widget is a passthrough span, so the cell
-      // must supply an already-formatted string. Types that route to text
-      // deliberately (boolean -> Yes/No, file -> the filename) would
-      // otherwise render their raw value: TextWidget is String(value).
-      preformatted: hint.kind === 'text',
-    })
+    byProperty.set(column.property, { component: defaultRegistry.resolveFromHint(hint), hint })
   }
   return byProperty
 })
 
-function cellWidget(column: { property?: string }) {
-  return column.property ? columnWidgets.value.get(column.property) : undefined
-}
-
-// The value handed to a cell widget: the formatted string for text-routed
-// columns, the raw value for every typed widget (which formats it itself).
-function cellModelValue(
+// The widget for a cell, or undefined when the cell should NOT render one:
+// a relation column (no PropertyDef, no relation widget) or an empty value
+// (widgets may render a "no value" placeholder that cells must not show --
+// see isDenseEmpty). Both fall through to the plain string span.
+function cellWidget(
   entity: Entity,
   column: { property?: string; relation?: string; direction?: 'outgoing' | 'incoming' }
-): unknown {
-  return cellWidget(column)?.preformatted
-    ? getFormattedCellValue(entity, column)
-    : getCellValue(entity, column)
+) {
+  if (!column.property) return undefined
+  const entry = columnWidgets.value.get(column.property)
+  if (!entry) return undefined
+  return isDenseEmpty(getCellValue(entity, column)) ? undefined : entry
+}
+
+interface ResolvedCell {
+  component: Component
+  propertyName: string
+  modelValue: unknown
+}
+
+// One resolved cell: the widget to render plus the value already shaped the
+// way that widget wants. Returns undefined when the cell must fall back to the
+// plain string span (relation column, or an empty value -- see cellWidget).
+//
+// Memoized per (entity, column). The template reads it four times per cell
+// (v-else-if, :is, and two bindings); without the cache each read redoes the
+// Map lookup and re-formats the value.
+//
+// Safe against staleness because entity objects are copy-on-write: both
+// optimistic paths in queries/optimisticList.ts rebuild the changed entity
+// via `data.map(e => e.id === id ? update(e) : e)`, and a refetch parses
+// fresh objects. A mutated cell therefore always arrives as a NEW identity
+// and misses the cache. If an entity ever starts being mutated in place,
+// this cache goes stale silently -- keyed on identity, it cannot detect it.
+//
+// WeakMap so a dropped row's entry is collected with the row. The inner key
+// is the column object, stable across renders because listConfig.columns is
+// the same array.
+const cellCache = new WeakMap<Entity, Map<object, ResolvedCell | undefined>>()
+
+function resolveCell(
+  entity: Entity,
+  column: { property?: string; relation?: string; direction?: 'outgoing' | 'incoming' }
+): ResolvedCell | undefined {
+  let perEntity = cellCache.get(entity)
+  if (!perEntity) {
+    perEntity = new Map()
+    cellCache.set(entity, perEntity)
+  }
+  if (perEntity.has(column)) return perEntity.get(column)
+
+  const entry = cellWidget(entity, column)
+  const resolved: ResolvedCell | undefined = entry
+    ? {
+        component: entry.component,
+        propertyName: entry.hint.propertyName,
+        // Passthrough widgets render String(value); everything else owns its
+        // display formatting and wants the stored value.
+        modelValue: entry.hint.preformatted
+          ? getFormattedCellValue(entity, column)
+          : getCellValue(entity, column),
+      }
+    : undefined
+  perEntity.set(column, resolved)
+  return resolved
 }
 
 // isCellInaccessible reports whether the cell's underlying property is
@@ -866,12 +907,12 @@ watch(searchQuery, () => {
                 title="inaccessible"
               >🔒</span>
               <component
-                :is="cellWidget(column)!.component"
-                v-else-if="cellWidget(column)"
+                :is="resolveCell(entity, column)!.component"
+                v-else-if="resolveCell(entity, column)"
                 class="mobile-card-value"
-                :model-value="cellModelValue(entity, column)"
+                :model-value="resolveCell(entity, column)!.modelValue"
                 :mode="'display'"
-                :property-name="cellWidget(column)!.hint.propertyName"
+                :property-name="resolveCell(entity, column)!.propertyName"
                 :entity-type="listConfig.entity"
               />
               <span v-else class="mobile-card-value">{{ getFormattedCellValue(entity, column) }}</span>
@@ -961,11 +1002,11 @@ watch(searchQuery, () => {
                 title="inaccessible"
               >🔒</span>
               <component
-                :is="cellWidget(column)!.component"
-                v-else-if="cellWidget(column)"
-                :model-value="cellModelValue(entity, column)"
+                :is="resolveCell(entity, column)!.component"
+                v-else-if="resolveCell(entity, column)"
+                :model-value="resolveCell(entity, column)!.modelValue"
                 :mode="'display'"
-                :property-name="cellWidget(column)!.hint.propertyName"
+                :property-name="resolveCell(entity, column)!.propertyName"
                 :entity-type="listConfig.entity"
               />
               <span v-else>

--- a/frontend/src/components/lists/EntityList.vue
+++ b/frontend/src/components/lists/EntityList.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, shallowRef, computed, watch, onMounted, onUnmounted } from 'vue'
+import { ref, shallowRef, computed, watch, onMounted, onUnmounted, type Component } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { useQuery, useMutation, useQueryCache } from '@pinia/colada'
 import { useSchemaStore, useUIStore } from '@/stores'
@@ -15,14 +15,16 @@ import { entityDetailHref } from '@/utils/entityRoute'
 import { entityDisplayTitle } from '@/utils/entityDisplay'
 import { renderMarkdown } from '@/utils/markdown'
 import { actionAllowed } from '@/utils/affordancesWarning'
-import { getCellValue, formatCellValue, isEnumPropertyDef, asArray } from '@/utils/format'
+import { getCellValue, formatCellValue } from '@/utils/format'
+import { densePropertyRoutingHint } from '@/widgets/viewRouting'
+import { defaultRegistry } from '@/widgets/registry'
+import type { WidgetRoutingHint } from '@/widgets/types'
 import type { Entity, ListMeta, ListParams, ListResponse, FilterState } from '@/types'
 import { viewHeaderMarkdown, viewFooterMarkdown } from '@/types'
 import FilterBar from './FilterBar.vue'
 import Pagination from './Pagination.vue'
 import SearchBox from './SearchBox.vue'
 import AdHocFilterMenu from './AdHocFilterMenu.vue'
-import Badge from '@/components/common/Badge.vue'
 import BackButton from '@/components/common/BackButton.vue'
 import ExportMenu from '@/components/entity/ExportMenu.vue'
 import { listExportUrl } from '@/api/transforms'
@@ -531,9 +533,51 @@ function navigateToEntity(entity: Entity) {
   router.push({ path, query })
 }
 
-function isEnumColumn(column: { property?: string }): boolean {
-  if (!column.property || !entityType.value) return false
-  return isEnumPropertyDef(entityType.value.properties[column.property])
+// Widget resolution for property cells, keyed by column property name and
+// computed ONCE per column rather than per cell (RR-UD2A -- the same reason
+// PropertyDisplay precomputes `rows`). resolve()/resolveFromHint() walk a Map
+// and can console.warn; doing that per cell would be one lookup and one
+// potential warning per row per render.
+//
+// Relation columns are absent from this map on purpose: they have no
+// PropertyDef and there is no relation widget, so they stay on the string
+// path in getFormattedCellValue.
+const columnWidgets = computed(() => {
+  const byProperty = new Map<
+    string,
+    { component: Component; hint: WidgetRoutingHint; preformatted: boolean }
+  >()
+  const type = entityType.value
+  if (!type) return byProperty
+  for (const column of listConfig.value?.columns ?? []) {
+    if (!column.property || byProperty.has(column.property)) continue
+    const hint = densePropertyRoutingHint(type.properties[column.property], column.property)
+    byProperty.set(column.property, {
+      component: defaultRegistry.resolveFromHint(hint),
+      hint,
+      // A 'text' hint means the widget is a passthrough span, so the cell
+      // must supply an already-formatted string. Types that route to text
+      // deliberately (boolean -> Yes/No, file -> the filename) would
+      // otherwise render their raw value: TextWidget is String(value).
+      preformatted: hint.kind === 'text',
+    })
+  }
+  return byProperty
+})
+
+function cellWidget(column: { property?: string }) {
+  return column.property ? columnWidgets.value.get(column.property) : undefined
+}
+
+// The value handed to a cell widget: the formatted string for text-routed
+// columns, the raw value for every typed widget (which formats it itself).
+function cellModelValue(
+  entity: Entity,
+  column: { property?: string; relation?: string; direction?: 'outgoing' | 'incoming' }
+): unknown {
+  return cellWidget(column)?.preformatted
+    ? getFormattedCellValue(entity, column)
+    : getCellValue(entity, column)
 }
 
 // isCellInaccessible reports whether the cell's underlying property is
@@ -821,18 +865,15 @@ watch(searchQuery, () => {
                 class="inaccessible-cell"
                 title="inaccessible"
               >🔒</span>
-              <div
-                v-else-if="isEnumColumn(column) && asArray(getCellValue(entity, column)).length > 0"
-                class="badge-row"
-              >
-                <Badge
-                  v-for="badgeValue in asArray(getCellValue(entity, column))"
-                  :key="badgeValue"
-                  :value="badgeValue"
-                  :property="column.property"
-                  :entity-type="entityType"
-                />
-              </div>
+              <component
+                :is="cellWidget(column)!.component"
+                v-else-if="cellWidget(column)"
+                class="mobile-card-value"
+                :model-value="cellModelValue(entity, column)"
+                :mode="'display'"
+                :property-name="cellWidget(column)!.hint.propertyName"
+                :entity-type="listConfig.entity"
+              />
               <span v-else class="mobile-card-value">{{ getFormattedCellValue(entity, column) }}</span>
             </div>
           </div>
@@ -919,18 +960,14 @@ watch(searchQuery, () => {
                 class="inaccessible-cell"
                 title="inaccessible"
               >🔒</span>
-              <div
-                v-else-if="isEnumColumn(column) && asArray(getCellValue(entity, column)).length > 0"
-                class="badge-row"
-              >
-                <Badge
-                  v-for="badgeValue in asArray(getCellValue(entity, column))"
-                  :key="badgeValue"
-                  :value="badgeValue"
-                  :property="column.property"
-                  :entity-type="entityType"
-                />
-              </div>
+              <component
+                :is="cellWidget(column)!.component"
+                v-else-if="cellWidget(column)"
+                :model-value="cellModelValue(entity, column)"
+                :mode="'display'"
+                :property-name="cellWidget(column)!.hint.propertyName"
+                :entity-type="listConfig.entity"
+              />
               <span v-else>
                 {{ getFormattedCellValue(entity, column) }}
               </span>

--- a/frontend/src/views/KanbanView.cardFields.test.ts
+++ b/frontend/src/views/KanbanView.cardFields.test.ts
@@ -1,0 +1,194 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import { PiniaColada } from '@pinia/colada'
+import KanbanView from './KanbanView.vue'
+import { useSchemaStore } from '@/stores/schema'
+import { _setEntityPluralForTest } from '@/api/entities'
+import type { Entity, ListResponse } from '@/types'
+
+// Card fields moved onto the widget registry in mode:'display' (TKT-S9C14S).
+//
+// Before that migration getCardFieldValue was a bare `String(v || '')` that
+// never called the shared cell formatter, so cards showed raw ISO datetimes
+// and "true"/"false" -- and `|| ''` collapsed `false` and `0` to empty, which
+// made visibleCardFields DROP the field from the card entirely. These tests
+// pin the fixed behaviour; several of them fail against the old code.
+
+const listAllEntitiesMock = vi.fn()
+vi.mock('@/api', async (orig) => ({
+  ...(await orig<typeof import('@/api')>()),
+  listAllEntities: (...args: unknown[]) => listAllEntitiesMock(...args),
+  updateEntity: vi.fn().mockResolvedValue(undefined),
+}))
+
+vi.mock('vue-router', () => ({
+  useRouter: () => ({ push: vi.fn() }),
+  useRoute: () => ({ query: {}, path: '/kanban/board' }),
+}))
+
+vi.mock('@/composables/useBackTarget', () => ({
+  useBackTarget: () => null,
+}))
+
+const KANBAN_ID = 'board'
+const ENTITY_TYPE = 'ticket'
+
+describe('KanbanView card field rendering via widgets', () => {
+  function seedSchema(
+    properties: Record<string, unknown>,
+    fields: Array<Record<string, unknown>>
+  ) {
+    const schemaStore = useSchemaStore()
+    schemaStore.kanbans.set(KANBAN_ID, {
+      entity: ENTITY_TYPE,
+      title: 'Board',
+      column_property: 'status',
+      columns: [{ value: 'todo', label: 'Todo' }],
+      card: { title: 'title', fields },
+    } as never)
+    schemaStore.entityTypes.set(ENTITY_TYPE, {
+      name: ENTITY_TYPE,
+      label: 'Ticket',
+      properties: {
+        title: { type: 'string' },
+        status: { type: 'enum', values: ['todo'] },
+        ...properties,
+      },
+    } as never)
+  }
+
+  async function mountBoard(
+    properties: Record<string, unknown>,
+    fields: Array<Record<string, unknown>>,
+    entityProps: Record<string, unknown>
+  ) {
+    seedSchema(properties, fields)
+    const entity: Entity = {
+      id: 'T-1',
+      type: ENTITY_TYPE,
+      properties: { title: 'Ticket T-1', status: 'todo', ...entityProps },
+      relations: {},
+    }
+    const response: ListResponse<Entity> = {
+      data: [entity],
+      meta: { total: 1, page: 1, per_page: 25, has_more: false },
+      included: {},
+    }
+    listAllEntitiesMock.mockResolvedValue(response)
+    const wrapper = mount(KanbanView, {
+      props: { id: KANBAN_ID },
+      attachTo: document.body,
+      global: { plugins: [pinia, PiniaColada] },
+    })
+    await flushPromises()
+    return wrapper
+  }
+
+  let pinia: ReturnType<typeof createPinia>
+  beforeEach(() => {
+    pinia = createPinia()
+    setActivePinia(pinia)
+    _setEntityPluralForTest(ENTITY_TYPE, 'tickets')
+    listAllEntitiesMock.mockReset()
+  })
+
+  afterEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  // --- The bug fix: false / 0 are set values, not absent ones ---
+
+  it('renders a false boolean as No instead of dropping the field', async () => {
+    const wrapper = await mountBoard(
+      { done: { type: 'boolean' } },
+      [{ property: 'done', label: 'Done' }],
+      { done: false }
+    )
+    const card = wrapper.find('.kanban-card')
+    expect(card.text()).toContain('Done')
+    expect(card.text()).toContain('No')
+  })
+
+  it('renders a zero integer instead of dropping the field', async () => {
+    const wrapper = await mountBoard(
+      { count: { type: 'integer' } },
+      [{ property: 'count', label: 'Count' }],
+      { count: 0 }
+    )
+    expect(wrapper.find('.kanban-card').text()).toContain('Count')
+    expect(wrapper.find('.kanban-card').text()).toMatch(/\b0\b/)
+  })
+
+  it('renders a true boolean as Yes, not "true"', async () => {
+    const wrapper = await mountBoard(
+      { done: { type: 'boolean' } },
+      [{ property: 'done', label: 'Done' }],
+      { done: true }
+    )
+    const text = wrapper.find('.kanban-card').text()
+    expect(text).toContain('Yes')
+    expect(text).not.toContain('true')
+  })
+
+  // --- The bug fix: values are formatted, not stringified raw ---
+
+  it('renders a datetime formatted rather than as a raw ISO string', async () => {
+    const wrapper = await mountBoard(
+      { due: { type: 'datetime' } },
+      [{ property: 'due', label: 'Due' }],
+      { due: '2026-03-04T10:30:00Z' }
+    )
+    const text = wrapper.find('.kanban-card').text()
+    expect(text).not.toContain('2026-03-04T10:30:00Z')
+    expect(text).toMatch(/2026/)
+  })
+
+  it('renders a date formatted rather than as the raw stored string', async () => {
+    const wrapper = await mountBoard(
+      { due: { type: 'date' } },
+      [{ property: 'due', label: 'Due' }],
+      { due: '2026-03-04' }
+    )
+    expect(wrapper.find('.kanban-card').text()).toMatch(/2026/)
+  })
+
+  // --- Preserved behaviour ---
+
+  it('still drops a genuinely unset field from the card', async () => {
+    const wrapper = await mountBoard(
+      { effort: { type: 'enum', values: ['s', 'm'] } },
+      [{ property: 'effort', label: 'Effort' }],
+      {}
+    )
+    expect(wrapper.find('.kanban-card').text()).not.toContain('Effort')
+  })
+
+  it('drops a field whose value is an empty string', async () => {
+    const wrapper = await mountBoard(
+      { note: { type: 'string' } },
+      [{ property: 'note', label: 'Note' }],
+      { note: '' }
+    )
+    expect(wrapper.find('.kanban-card').text()).not.toContain('Note')
+  })
+
+  it('renders a scalar enum as a Badge', async () => {
+    const wrapper = await mountBoard(
+      { effort: { type: 'enum', values: ['s', 'm'] } },
+      [{ property: 'effort', label: 'Effort' }],
+      { effort: 'm' }
+    )
+    expect(wrapper.find('.kanban-card .badge').exists()).toBe(true)
+  })
+
+  it('renders a list-valued enum as one Badge per value, not one comma-joined Badge', async () => {
+    // Pre-migration this rendered a single Badge whose value was "a, b".
+    const wrapper = await mountBoard(
+      { tags: { type: 'enum', values: ['a', 'b'], list: true } },
+      [{ property: 'tags', label: 'Tags' }],
+      { tags: ['a', 'b'] }
+    )
+    expect(wrapper.findAll('.kanban-card .badge').length).toBe(2)
+  })
+})

--- a/frontend/src/views/KanbanView.vue
+++ b/frontend/src/views/KanbanView.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, computed } from 'vue'
+import { ref, computed, type Component } from 'vue'
 import { useRouter } from 'vue-router'
 import { useQuery, useMutation, useQueryCache } from '@pinia/colada'
 import { useSchemaStore, useUIStore } from '@/stores'
@@ -8,13 +8,16 @@ import { entityKeys } from '@/queries/entities'
 import { beginOptimistic, rollbackOptimistic, settleOptimistic } from '@/queries/optimisticList'
 import type { Entity, KanbanConfig, KanbanCardField, KanbanColumn, KanbanSwimlane } from '@/types'
 import { viewHeaderMarkdown, viewFooterMarkdown } from '@/types'
-import Badge from '@/components/common/Badge.vue'
 import BackButton from '@/components/common/BackButton.vue'
 import { useBackTarget } from '@/composables/useBackTarget'
 import { actionAllowed } from '@/utils/affordancesWarning'
 import { entityDisplayTitle } from '@/utils/entityDisplay'
 import { renderMarkdown } from '@/utils/markdown'
 import { resolveIcon } from '@/utils/icons'
+import { formatCellValue } from '@/utils/format'
+import { densePropertyRoutingHint } from '@/widgets/viewRouting'
+import { defaultRegistry } from '@/widgets/registry'
+import type { WidgetRoutingHint } from '@/widgets/types'
 
 const props = defineProps<{
   id: string
@@ -351,17 +354,42 @@ function getCardFieldValue(entity: Entity, field: KanbanCardField): string {
       .join(', ')
   }
   if (!field.property) return ''
-  return String(entity.properties[field.property] || '')
+  // Formatted via the shared cell formatter so cards agree with list cells
+  // (dates render human-readably, booleans as Yes/No, rrules as text). This
+  // used to be a bare String(v || ''), which showed raw ISO datetimes and
+  // "true" on cards -- see TKT-S9C14S.
+  return formatCellValue(
+    entity.properties[field.property],
+    field.property,
+    entityType.value,
+    uiStore.effectiveTimezone
+  )
+}
+
+// Raw (unformatted) card-field value, for widget rendering. Widgets take the
+// underlying value and format it themselves; only the emptiness predicate and
+// the relation path need a string.
+function getCardFieldRawValue(entity: Entity, field: KanbanCardField): unknown {
+  if (field.relation) return getCardFieldValue(entity, field)
+  if (!field.property) return ''
+  return entity.properties[field.property]
 }
 
 // Card fields with an unset value are dropped entirely: a dangling
 // "effort:" label next to an empty Badge pill (enum fields render a
 // styled chip even for "") is noise on every card that hasn't set the
 // property, worst on mobile where card space is scarce.
+//
+// Emptiness is tested on the RAW value, not the formatted string: `false`
+// and `0` are set values that format to "No"/"0", and the old
+// `String(v || '') !== ''` test silently dropped them from the card.
 function visibleCardFields(entity: Entity): KanbanCardField[] {
-  return (kanbanConfig.value?.card.fields ?? []).filter(
-    (field) => getCardFieldValue(entity, field) !== ''
-  )
+  return (kanbanConfig.value?.card.fields ?? []).filter((field) => {
+    if (field.relation) return getCardFieldValue(entity, field) !== ''
+    const raw = getCardFieldRawValue(entity, field)
+    if (raw === null || raw === undefined || raw === '') return false
+    return !(Array.isArray(raw) && raw.length === 0)
+  })
 }
 
 function getCardFieldLabel(field: KanbanCardField): string {
@@ -369,11 +397,41 @@ function getCardFieldLabel(field: KanbanCardField): string {
   return field.relation || field.property || ''
 }
 
-// Relation fields never render as enum badges — only scalar enum properties do.
-function isEnumField(field: KanbanCardField): boolean {
-  if (field.relation || !field.property || !entityType.value) return false
-  const propDef = entityType.value.properties[field.property]
-  return propDef?.type === 'enum' || (propDef?.values?.length ?? 0) > 0
+// Widget resolution for property card-fields, computed once per configured
+// field rather than per card (RR-UD2A). Relation fields are absent on
+// purpose: they have no PropertyDef and no relation widget, so they keep the
+// joined-titles string path.
+const cardFieldWidgets = computed(() => {
+  const byProperty = new Map<
+    string,
+    { component: Component; hint: WidgetRoutingHint; preformatted: boolean }
+  >()
+  const type = entityType.value
+  if (!type) return byProperty
+  for (const field of kanbanConfig.value?.card.fields ?? []) {
+    if (!field.property || field.relation || byProperty.has(field.property)) continue
+    const hint = densePropertyRoutingHint(type.properties[field.property], field.property)
+    byProperty.set(field.property, {
+      component: defaultRegistry.resolveFromHint(hint),
+      hint,
+      // See EntityList: a 'text' hint is a passthrough span, so the caller
+      // must supply the formatted string (boolean -> Yes/No etc.).
+      preformatted: hint.kind === 'text',
+    })
+  }
+  return byProperty
+})
+
+function cardFieldWidget(field: KanbanCardField) {
+  if (field.relation || !field.property) return undefined
+  return cardFieldWidgets.value.get(field.property)
+}
+
+// Formatted string for text-routed fields, raw value for typed widgets.
+function cardFieldModelValue(entity: Entity, field: KanbanCardField): unknown {
+  return cardFieldWidget(field)?.preformatted
+    ? getCardFieldValue(entity, field)
+    : getCardFieldRawValue(entity, field)
 }
 
 function onDragStart(event: DragEvent, entity: Entity) {
@@ -534,11 +592,14 @@ function createNew() {
                 class="card-field"
               >
                 <span class="field-label">{{ getCardFieldLabel(field) }}:</span>
-                <Badge
-                  v-if="isEnumField(field)"
-                  :value="getCardFieldValue(entity, field)"
-                  :property="field.property"
-                  :entity-type="entityType"
+                <component
+                  :is="cardFieldWidget(field)!.component"
+                  v-if="cardFieldWidget(field)"
+                  class="field-value"
+                  :model-value="cardFieldModelValue(entity, field)"
+                  :mode="'display'"
+                  :property-name="cardFieldWidget(field)!.hint.propertyName"
+                  :entity-type="kanbanConfig?.entity"
                 />
                 <span v-else class="field-value">{{ getCardFieldValue(entity, field) }}</span>
               </div>
@@ -614,11 +675,14 @@ function createNew() {
                 class="card-field"
               >
                 <span class="field-label">{{ getCardFieldLabel(field) }}:</span>
-                <Badge
-                  v-if="isEnumField(field)"
-                  :value="getCardFieldValue(entity, field)"
-                  :property="field.property"
-                  :entity-type="entityType"
+                <component
+                  :is="cardFieldWidget(field)!.component"
+                  v-if="cardFieldWidget(field)"
+                  class="field-value"
+                  :model-value="cardFieldModelValue(entity, field)"
+                  :mode="'display'"
+                  :property-name="cardFieldWidget(field)!.hint.propertyName"
+                  :entity-type="kanbanConfig?.entity"
                 />
                 <span v-else class="field-value">{{ getCardFieldValue(entity, field) }}</span>
               </div>

--- a/frontend/src/views/KanbanView.vue
+++ b/frontend/src/views/KanbanView.vue
@@ -17,7 +17,7 @@ import { resolveIcon } from '@/utils/icons'
 import { formatCellValue } from '@/utils/format'
 import { densePropertyRoutingHint } from '@/widgets/viewRouting'
 import { defaultRegistry } from '@/widgets/registry'
-import type { WidgetRoutingHint } from '@/widgets/types'
+import type { DenseRoutingHint } from '@/widgets/viewRouting'
 
 const props = defineProps<{
   id: string
@@ -366,12 +366,13 @@ function getCardFieldValue(entity: Entity, field: KanbanCardField): string {
   )
 }
 
-// Raw (unformatted) card-field value, for widget rendering. Widgets take the
-// underlying value and format it themselves; only the emptiness predicate and
-// the relation path need a string.
-function getCardFieldRawValue(entity: Entity, field: KanbanCardField): unknown {
-  if (field.relation) return getCardFieldValue(entity, field)
-  if (!field.property) return ''
+// The stored property value, unformatted. PROPERTY fields only -- a relation
+// field has no stored property and callers must use getCardFieldValue for it.
+// (An earlier version returned the joined relation string from here, which
+// made a function named "raw" hand pre-formatted text to a widget the moment
+// anyone added a relation widget.)
+function getCardFieldStoredValue(entity: Entity, field: KanbanCardField): unknown {
+  if (!field.property) return undefined
   return entity.properties[field.property]
 }
 
@@ -380,16 +381,16 @@ function getCardFieldRawValue(entity: Entity, field: KanbanCardField): unknown {
 // styled chip even for "") is noise on every card that hasn't set the
 // property, worst on mobile where card space is scarce.
 //
-// Emptiness is tested on the RAW value, not the formatted string: `false`
-// and `0` are set values that format to "No"/"0", and the old
-// `String(v || '') !== ''` test silently dropped them from the card.
+// Emptiness is decided by the FORMATTED string, matching EntityList's
+// visibleMobileColumns so the two surfaces agree. Note this is only correct
+// because formatCellValue renders `false` as "No" and `0` as "0" -- both
+// non-empty, both kept. The bug this replaced was in getCardFieldValue's old
+// `String(v || '')`, which collapsed them to '' before the predicate ever
+// ran; formatCellValue never had that flaw.
 function visibleCardFields(entity: Entity): KanbanCardField[] {
-  return (kanbanConfig.value?.card.fields ?? []).filter((field) => {
-    if (field.relation) return getCardFieldValue(entity, field) !== ''
-    const raw = getCardFieldRawValue(entity, field)
-    if (raw === null || raw === undefined || raw === '') return false
-    return !(Array.isArray(raw) && raw.length === 0)
-  })
+  return (kanbanConfig.value?.card.fields ?? []).filter(
+    (field) => getCardFieldValue(entity, field) !== ''
+  )
 }
 
 function getCardFieldLabel(field: KanbanCardField): string {
@@ -402,36 +403,36 @@ function getCardFieldLabel(field: KanbanCardField): string {
 // purpose: they have no PropertyDef and no relation widget, so they keep the
 // joined-titles string path.
 const cardFieldWidgets = computed(() => {
-  const byProperty = new Map<
-    string,
-    { component: Component; hint: WidgetRoutingHint; preformatted: boolean }
-  >()
+  const byProperty = new Map<string, { component: Component; hint: DenseRoutingHint }>()
   const type = entityType.value
   if (!type) return byProperty
   for (const field of kanbanConfig.value?.card.fields ?? []) {
     if (!field.property || field.relation || byProperty.has(field.property)) continue
     const hint = densePropertyRoutingHint(type.properties[field.property], field.property)
-    byProperty.set(field.property, {
-      component: defaultRegistry.resolveFromHint(hint),
-      hint,
-      // See EntityList: a 'text' hint is a passthrough span, so the caller
-      // must supply the formatted string (boolean -> Yes/No etc.).
-      preformatted: hint.kind === 'text',
-    })
+    byProperty.set(field.property, { component: defaultRegistry.resolveFromHint(hint), hint })
   }
   return byProperty
 })
 
-function cardFieldWidget(field: KanbanCardField) {
+// One resolved card field: the widget plus the value shaped the way it wants.
+// undefined means render the plain string span (relation fields, or a
+// property with no widget entry).
+//
+// Unlike EntityList this needs no empty-value guard: visibleCardFields has
+// already dropped empty fields before the template renders, so a widget's
+// "no value" placeholder (MultiSelectWidget's em-dash, RR-UD2C) is
+// unreachable here.
+function resolveCardField(entity: Entity, field: KanbanCardField) {
   if (field.relation || !field.property) return undefined
-  return cardFieldWidgets.value.get(field.property)
-}
-
-// Formatted string for text-routed fields, raw value for typed widgets.
-function cardFieldModelValue(entity: Entity, field: KanbanCardField): unknown {
-  return cardFieldWidget(field)?.preformatted
-    ? getCardFieldValue(entity, field)
-    : getCardFieldRawValue(entity, field)
+  const entry = cardFieldWidgets.value.get(field.property)
+  if (!entry) return undefined
+  return {
+    component: entry.component,
+    propertyName: entry.hint.propertyName,
+    modelValue: entry.hint.preformatted
+      ? getCardFieldValue(entity, field)
+      : getCardFieldStoredValue(entity, field),
+  }
 }
 
 function onDragStart(event: DragEvent, entity: Entity) {
@@ -593,12 +594,12 @@ function createNew() {
               >
                 <span class="field-label">{{ getCardFieldLabel(field) }}:</span>
                 <component
-                  :is="cardFieldWidget(field)!.component"
-                  v-if="cardFieldWidget(field)"
+                  :is="resolveCardField(entity, field)!.component"
+                  v-if="resolveCardField(entity, field)"
                   class="field-value"
-                  :model-value="cardFieldModelValue(entity, field)"
+                  :model-value="resolveCardField(entity, field)!.modelValue"
                   :mode="'display'"
-                  :property-name="cardFieldWidget(field)!.hint.propertyName"
+                  :property-name="resolveCardField(entity, field)!.propertyName"
                   :entity-type="kanbanConfig?.entity"
                 />
                 <span v-else class="field-value">{{ getCardFieldValue(entity, field) }}</span>
@@ -676,12 +677,12 @@ function createNew() {
               >
                 <span class="field-label">{{ getCardFieldLabel(field) }}:</span>
                 <component
-                  :is="cardFieldWidget(field)!.component"
-                  v-if="cardFieldWidget(field)"
+                  :is="resolveCardField(entity, field)!.component"
+                  v-if="resolveCardField(entity, field)"
                   class="field-value"
-                  :model-value="cardFieldModelValue(entity, field)"
+                  :model-value="resolveCardField(entity, field)!.modelValue"
                   :mode="'display'"
-                  :property-name="cardFieldWidget(field)!.hint.propertyName"
+                  :property-name="resolveCardField(entity, field)!.propertyName"
                   :entity-type="kanbanConfig?.entity"
                 />
                 <span v-else class="field-value">{{ getCardFieldValue(entity, field) }}</span>

--- a/frontend/src/widgets/viewRouting.test.ts
+++ b/frontend/src/widgets/viewRouting.test.ts
@@ -63,15 +63,62 @@ describe('densePropertyRoutingHint', () => {
     ['enum', def({ type: 'enum', values: ['a', 'b'] }), 'enum'],
     ['enum via values on a string', def({ type: 'string', values: ['a'] }), 'enum'],
     ['list-valued enum', def({ type: 'enum', values: ['a'], list: true }), 'enum-list'],
-    ['list-valued string', def({ type: 'string', list: true }), 'text-list'],
   ])('routes %s to %s', (_label, propertyDef, expected) => {
     expect(densePropertyRoutingHint(propertyDef, 'p').kind).toBe(expected)
+  })
+
+  // A non-enum list must NOT reach MultiSelectWidget on a dense surface: it
+  // badges each element and em-dashes an empty array (RR-UD2C, a detail-view
+  // contract), where cells must stay visually quiet. Letting list-ness win
+  // over the type also erased the type's formatter -- a list-valued rrule
+  // rendered an em-dash instead of "every day".
+  it.each([
+    ['string', def({ type: 'string', list: true })],
+    ['date', def({ type: 'date', list: true })],
+    ['datetime', def({ type: 'datetime', list: true })],
+    ['integer', def({ type: 'integer', list: true })],
+    ['rrule', def({ type: 'rrule', list: true })],
+  ])('routes list-valued %s to preformatted text, never text-list', (_label, propertyDef) => {
+    const hint = densePropertyRoutingHint(propertyDef, 'p')
+    expect(hint.kind).toBe('text')
+    expect(hint.preformatted).toBe(true)
+  })
+
+  it('marks passthrough widgets preformatted and formatter-owning widgets not', () => {
+    // preformatted === "the widget renders String(value) and nothing else, so
+    // the caller must pre-format". Getting this wrong renders a boolean as
+    // "true" or double-formats a date.
+    const cases: [PropertyDef, boolean][] = [
+      [def({ type: 'string' }), true],
+      [def({ type: 'boolean' }), true],
+      [def({ type: 'file' }), true],
+      [def({ type: 'integer' }), true],
+      [def({ type: 'date' }), false],
+      [def({ type: 'datetime' }), false],
+      [def({ type: 'rrule' }), false],
+      [def({ type: 'enum', values: ['a'] }), false],
+      [def({ type: 'enum', values: ['a'], list: true }), false],
+    ]
+    for (const [propertyDef, expected] of cases) {
+      expect(densePropertyRoutingHint(propertyDef, 'p').preformatted).toBe(expected)
+    }
+  })
+
+  it('never routes a dense surface to text-list', () => {
+    // text-list -> MultiSelectWidget, whose empty-array em-dash is wrong for
+    // cells. Enum lists intentionally still use enum-list (badges are correct
+    // for enums); this guards the NON-enum list types.
+    const types: PropertyDef['type'][] = ['string', 'date', 'datetime', 'integer', 'file', 'rrule']
+    for (const t of types) {
+      expect(densePropertyRoutingHint(def({ type: t, list: true }), 'p').kind).not.toBe('text-list')
+    }
   })
 
   it('forwards the property name onto the hint', () => {
     expect(densePropertyRoutingHint(def({ type: 'string' }), 'title')).toEqual({
       kind: 'text',
       propertyName: 'title',
+      preformatted: true,
     })
   })
 

--- a/frontend/src/widgets/viewRouting.test.ts
+++ b/frontend/src/widgets/viewRouting.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi } from 'vitest'
 import type { ViewSectionField } from '@/api'
-import { viewFieldRoutingHint } from './viewRouting'
+import type { PropertyDef } from '@/types'
+import { viewFieldRoutingHint, densePropertyRoutingHint } from './viewRouting'
 import { defaultRegistry } from './registry'
 import TextWidget from './TextWidget.vue'
 import MultiSelectWidget from './MultiSelectWidget.vue'
@@ -44,6 +45,80 @@ describe('viewFieldRoutingHint', () => {
     const b = viewFieldRoutingHint(field)
     expect(a).toEqual(b)
     expect(a.kind).toBe('enum-list')
+  })
+})
+
+describe('densePropertyRoutingHint', () => {
+  const def = (p: Partial<PropertyDef>): PropertyDef => {
+    const base: PropertyDef = { type: 'string' }
+    return { ...base, ...p }
+  }
+
+  it.each([
+    ['string', def({ type: 'string' }), 'text'],
+    ['date', def({ type: 'date' }), 'date'],
+    ['datetime', def({ type: 'datetime' }), 'datetime'],
+    ['integer', def({ type: 'integer' }), 'integer'],
+    ['rrule', def({ type: 'rrule' }), 'rrule'],
+    ['enum', def({ type: 'enum', values: ['a', 'b'] }), 'enum'],
+    ['enum via values on a string', def({ type: 'string', values: ['a'] }), 'enum'],
+    ['list-valued enum', def({ type: 'enum', values: ['a'], list: true }), 'enum-list'],
+    ['list-valued string', def({ type: 'string', list: true }), 'text-list'],
+  ])('routes %s to %s', (_label, propertyDef, expected) => {
+    expect(densePropertyRoutingHint(propertyDef, 'p').kind).toBe(expected)
+  })
+
+  it('forwards the property name onto the hint', () => {
+    expect(densePropertyRoutingHint(def({ type: 'string' }), 'title')).toEqual({
+      kind: 'text',
+      propertyName: 'title',
+    })
+  })
+
+  it('falls back to text for an unknown property (no schema entry)', () => {
+    expect(densePropertyRoutingHint(undefined, 'mystery').kind).toBe('text')
+  })
+
+  // --- The two deliberate exceptions. These are behaviour decisions from
+  // TKT-S9C14S, not oversights; a change here must be intentional. ---
+
+  it('routes boolean to text, NOT checkbox, so cells stay searchable and copy-pasteable', () => {
+    expect(densePropertyRoutingHint(def({ type: 'boolean' }), 'done').kind).toBe('text')
+  })
+
+  it('routes file to text, NOT a file widget, to avoid one image request per cell', () => {
+    expect(densePropertyRoutingHint(def({ type: 'file' }), 'attachment').kind).toBe('text')
+  })
+
+  it('never emits a hint kind that resolves to FileWidget', () => {
+    // WidgetHintKind has no 'file' member, so the hint path structurally
+    // cannot reach FileWidget. This pins that safety property against a
+    // future kind being added without revisiting dense surfaces.
+    const kinds = (['string', 'file', 'date', 'boolean', 'enum', 'rrule'] as const).map(
+      (t) => densePropertyRoutingHint(def({ type: t as PropertyDef['type'] }), 'p').kind
+    )
+    expect(kinds).not.toContain('file')
+  })
+
+  it('does not warn for any built-in property type', () => {
+    // resolveFromHint must not hit the supportedPropertyTypes mismatch path;
+    // in a 200-row table that would be one warning per row per render.
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const types: PropertyDef['type'][] = [
+      'string',
+      'date',
+      'datetime',
+      'integer',
+      'boolean',
+      'enum',
+      'file',
+      'rrule',
+    ]
+    for (const t of types) {
+      defaultRegistry.resolveFromHint(densePropertyRoutingHint(def({ type: t }), 'p'))
+    }
+    expect(warn).not.toHaveBeenCalled()
+    warn.mockRestore()
   })
 })
 

--- a/frontend/src/widgets/viewRouting.ts
+++ b/frontend/src/widgets/viewRouting.ts
@@ -30,30 +30,77 @@ export function viewFieldRoutingHint(field: ViewSectionField): WidgetRoutingHint
   return { kind: 'text', propertyName }
 }
 
-// densePropertyRoutingHint maps a REAL PropertyDef to a WidgetRoutingHint for
+// DenseRoutingHint extends the widget-routing decision with the SHAPE the
+// chosen widget expects, because on a dense surface those are one decision,
+// not two.
+//
+// `preformatted: true` means the widget does no formatting of its own (it is
+// a passthrough span), so the caller must hand it an already-formatted
+// string. `false` means the widget has a display-mode formatter and wants the
+// raw value.
+//
+// Keeping these together is load-bearing: an earlier version tracked the
+// shape separately as `hint.kind === 'text'` at the two call sites, which
+// silently mis-shaped every kind that is neither 'text' nor a real formatter
+// (notably 'text-list') and would have mis-shaped each new widget by default.
+export interface DenseRoutingHint extends WidgetRoutingHint {
+  preformatted: boolean
+}
+
+// isDenseEmpty reports whether a value should render as nothing on a dense
+// surface (a blank table cell, a dropped card field).
+//
+// Dense surfaces and detail views disagree here, deliberately. A widget's
+// display mode may render a placeholder for "no value" -- MultiSelectWidget
+// em-dashes an empty array (RR-UD2C) so it reads as distinct from a loading
+// state. formatCellValue documents the opposite contract for cells: "blank
+// table cells stay visually quiet". A sparsely-populated tags column would
+// otherwise become a column of dashes.
+//
+// So the CELL decides emptiness before the widget ever sees the value, and
+// the two surfaces share this one predicate rather than each inventing it.
+export function isDenseEmpty(value: unknown): boolean {
+  if (value === null || value === undefined || value === '') return true
+  return Array.isArray(value) && value.length === 0
+}
+
+// densePropertyRoutingHint maps a REAL PropertyDef to a DenseRoutingHint for
 // the dense read-only surfaces -- list/table cells and kanban card fields.
 //
 // Deliberately NOT viewFieldRoutingHint: that one routes any typed field to
 // 'enum-list' to preserve a pre-refactor Badge behaviour, which would badge
 // every typed column in a table. Deliberately NOT registry.resolve(propertyDef)
-// either -- see the two routing exceptions below, both of which resolve() would
-// get wrong for a dense surface.
+// either -- see the routing exceptions below, which resolve() would get wrong
+// for a dense surface.
 //
 // Callers have the real schema entry (entityType.properties[column.property]),
 // so routing is by declared type rather than by a wire-level heuristic.
 export function densePropertyRoutingHint(
   propertyDef: PropertyDef | undefined,
   propertyName: string
-): WidgetRoutingHint {
-  return { kind: denseHintKind(propertyDef), propertyName }
+): DenseRoutingHint {
+  const kind = denseHintKind(propertyDef)
+  return { kind, propertyName, preformatted: PASSTHROUGH_KINDS.has(kind) }
 }
+
+// Widget kinds with NO display-mode formatter of their own: they render
+// String(value) and nothing else, so the cell must pre-format. Every other
+// kind ('date', 'datetime', 'rrule', 'enum', 'enum-list') owns its display
+// rendering and must receive the raw value.
+//
+// A new widget defaults to NOT being here, i.e. it receives the raw value --
+// which is the right default, since the reason to add a widget at all is
+// that it renders something text cannot.
+const PASSTHROUGH_KINDS: ReadonlySet<WidgetHintKind> = new Set<WidgetHintKind>([
+  'text',
+  'integer',
+])
 
 function denseHintKind(propertyDef: PropertyDef | undefined): WidgetHintKind {
   if (!propertyDef) return 'text'
 
-  // Enum-ness wins over the scalar type, and list-ness picks the multi-value
-  // widget. Order mirrors defaultWidgetFor (registry.ts): list before values
-  // before scalar type.
+  // Enum-ness wins over the scalar type: an enum's display rendering is a
+  // Badge regardless of the underlying storage type.
   const isEnum = propertyDef.type === 'enum' || (propertyDef.values?.length ?? 0) > 0
   if (isEnum) {
     // A list-valued enum MUST route to 'enum-list'. SelectWidget's
@@ -61,19 +108,31 @@ function denseHintKind(propertyDef: PropertyDef | undefined): WidgetHintKind {
     // is one warning per row per render.
     return propertyDef.list === true ? 'enum-list' : 'enum'
   }
-  if (propertyDef.list === true) return 'text-list'
+
+  // A non-enum LIST routes to text and is pre-formatted, whatever its type.
+  //
+  // The scalar widgets (DateWidget, RruleWidget, NumberWidget) take a single
+  // value and would mangle an array; MultiSelectWidget would badge it and
+  // em-dash it when empty (a detail-view contract, RR-UD2C, that cells
+  // explicitly do not share). Handing the whole array to formatCellValue
+  // reproduces the pre-migration string byte for byte -- including its own
+  // limitations (a list of dates joins unformatted; a list of rrules renders
+  // only the first). Improving THAT is a behaviour change and a separate
+  // ticket; this refactor must not silently alter it.
+  //
+  // Note this check sits AFTER the enum branch but BEFORE the type switch:
+  // list-ness only overrides a scalar type's formatter, never enum badging.
+  if (propertyDef.list === true) return 'text'
 
   switch (propertyDef.type) {
     case 'date':
       return 'date'
     case 'datetime':
       return 'datetime'
-    case 'integer':
-      return 'integer'
     case 'rrule':
       return 'rrule'
 
-    // --- Two deliberate exceptions. Do not "simplify" these to the matching
+    // --- Deliberate exceptions. Do not "simplify" these to the matching
     // widget; each is load-bearing and pinned by a test. ---
 
     // boolean -> text, NOT 'boolean'/CheckboxWidget. Cells keep today's
@@ -90,6 +149,9 @@ function denseHintKind(propertyDef: PropertyDef | undefined): WidgetHintKind {
     // case is here to make the intent explicit rather than incidental.)
     case 'file':
       return 'text'
+
+    case 'integer':
+      return 'integer'
 
     default:
       return 'text'

--- a/frontend/src/widgets/viewRouting.ts
+++ b/frontend/src/widgets/viewRouting.ts
@@ -1,5 +1,6 @@
 import type { ViewSectionField } from '@/api'
-import type { WidgetRoutingHint } from './types'
+import type { PropertyDef } from '@/types'
+import type { WidgetRoutingHint, WidgetHintKind } from './types'
 
 // viewFieldRoutingHint maps a wire-level ViewSectionField (cards/list
 // rendering input) to a WidgetRoutingHint, so the view-side rendering
@@ -27,4 +28,70 @@ export function viewFieldRoutingHint(field: ViewSectionField): WidgetRoutingHint
     return { kind: 'text-list', propertyName }
   }
   return { kind: 'text', propertyName }
+}
+
+// densePropertyRoutingHint maps a REAL PropertyDef to a WidgetRoutingHint for
+// the dense read-only surfaces -- list/table cells and kanban card fields.
+//
+// Deliberately NOT viewFieldRoutingHint: that one routes any typed field to
+// 'enum-list' to preserve a pre-refactor Badge behaviour, which would badge
+// every typed column in a table. Deliberately NOT registry.resolve(propertyDef)
+// either -- see the two routing exceptions below, both of which resolve() would
+// get wrong for a dense surface.
+//
+// Callers have the real schema entry (entityType.properties[column.property]),
+// so routing is by declared type rather than by a wire-level heuristic.
+export function densePropertyRoutingHint(
+  propertyDef: PropertyDef | undefined,
+  propertyName: string
+): WidgetRoutingHint {
+  return { kind: denseHintKind(propertyDef), propertyName }
+}
+
+function denseHintKind(propertyDef: PropertyDef | undefined): WidgetHintKind {
+  if (!propertyDef) return 'text'
+
+  // Enum-ness wins over the scalar type, and list-ness picks the multi-value
+  // widget. Order mirrors defaultWidgetFor (registry.ts): list before values
+  // before scalar type.
+  const isEnum = propertyDef.type === 'enum' || (propertyDef.values?.length ?? 0) > 0
+  if (isEnum) {
+    // A list-valued enum MUST route to 'enum-list'. SelectWidget's
+    // safeStringValue console.warns on a multi-element array, which in a table
+    // is one warning per row per render.
+    return propertyDef.list === true ? 'enum-list' : 'enum'
+  }
+  if (propertyDef.list === true) return 'text-list'
+
+  switch (propertyDef.type) {
+    case 'date':
+      return 'date'
+    case 'datetime':
+      return 'datetime'
+    case 'integer':
+      return 'integer'
+    case 'rrule':
+      return 'rrule'
+
+    // --- Two deliberate exceptions. Do not "simplify" these to the matching
+    // widget; each is load-bearing and pinned by a test. ---
+
+    // boolean -> text, NOT 'boolean'/CheckboxWidget. Cells keep today's
+    // Yes/No text so they stay searchable (Cmd-F) and copy-pasteable. The
+    // disabled checkbox remains the DETAIL-view rendering, where those
+    // concerns don't apply.
+    case 'boolean':
+      return 'text'
+
+    // file -> text, NOT a file widget. FileWidget's display branch renders
+    // <img> previews, i.e. one network request per image per cell; 200 rows
+    // of a file column would issue 200 image fetches. (WidgetHintKind has no
+    // 'file' member, so the hint path cannot reach FileWidget anyway -- this
+    // case is here to make the intent explicit rather than incidental.)
+    case 'file':
+      return 'text'
+
+    default:
+      return 'text'
+  }
 }

--- a/tickets/entities/docs-checklists/DOCS-L7U5HT.md
+++ b/tickets/entities/docs-checklists/DOCS-L7U5HT.md
@@ -1,0 +1,55 @@
+---
+id: DOCS-L7U5HT
+type: docs-checklist
+title: 'Documentation: widget-based display rendering'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Code Documentation
+
+- [x] Comments where logic isn't obvious
+
+The three non-obvious decisions each carry a comment explaining *why*, because
+each is the kind a future reader would "simplify" back into a bug:
+`densePropertyRoutingHint`'s list-after-type ordering (with the regression it
+caused), the `boolean → text` / `file → text` exceptions, and `isDenseEmpty`'s
+dense-vs-detail contract split. `EntityList`'s `resolveCell` memo documents why
+a WeakMap keyed on a mutable entity is safe (copy-on-write) and what would break
+that assumption.
+
+- [x] Function/type docs if public API
+
+`DenseRoutingHint`, `densePropertyRoutingHint`, and `isDenseEmpty` are the new
+exported surface; all three have doc comments.
+
+## Project Documentation
+
+- [x] ~~README updated~~ (N/A: no project-level change — no new command, config
+key, or install step)
+- [x] CLAUDE.md updated (if new patterns)
+
+`frontend/CLAUDE.md` gained a "Widgets render property values everywhere,
+including read-only" section covering the two routing entry points, the four
+dense-surface rules, and the `preformatted` contract. Also corrected the package
+table, which listed `src/components/forms/` as the widget home and omitted
+`src/widgets/` entirely — stale before this change and more misleading after it.
+
+- [x] ~~Help text accurate~~ (N/A: no CLI change)
+
+## External Documentation
+
+- [x] ~~Changelog entry added~~ (N/A: the repo has no CHANGELOG.md — verified,
+not assumed)
+- [x] ~~API docs updated~~ (N/A: no HTTP API, wire-schema, or metamodel change.
+`docs/data-entry.md` documents configuration, and no config surface changed —
+`widget:` on `ListColumn`/`KanbanCardField` was explicitly left out of scope)
+
+## Note on user-visible behaviour
+
+This is mostly an internal refactor, but the kanban half is a user-visible bug
+fix: cards previously showed raw ISO datetimes and `"true"`, and silently
+dropped any field whose value was `false` or `0`. That is captured in the ticket
+and the commit message rather than in end-user docs, since there is no document
+describing what a kanban card renders for a given property type.

--- a/tickets/entities/features/FEAT-8OTJVW.md
+++ b/tickets/entities/features/FEAT-8OTJVW.md
@@ -1,0 +1,46 @@
+---
+id: FEAT-8OTJVW
+type: feature
+title: Color property type with data-entry color picker
+description: A built-in `color` metamodel property type storing a CSS hex string (#RRGGBB), validated against ^#[0-9A-Fa-f]{6}$, rendered in data-entry as a native color picker in edit mode and an accessible swatch (with the hex value as text) in display mode. Motivated by CalDAV calendar-color and category/tag colors, which today can only be modelled as an unvalidated string.
+status: proposed
+---
+
+## Summary
+
+A built-in `color` property type storing a CSS hex string (`#RRGGBB`), rendered
+in data-entry as a native color picker with a swatch in read-only surfaces.
+
+## Motivation
+
+Several surfaces want a user-chosen color as *data*, not as configuration:
+
+- **CalDAV / calendar feeds** — the `COLOR` / Apple `calendar-color` property on a
+published calendar, so a feed subscribed in a client shows in the operator's
+chosen color.
+- Category / tag / status colors that today can only be faked with an `enum`
+plus a hand-maintained style map.
+
+Today the only way to model this is `type: string`, which gives no validation (a
+typo yields an invalid CSS color that fails silently downstream) and a bare text
+input.
+
+## Shape
+
+```yaml
+properties:
+  calendar_color:
+    type: color
+    default: "#3B82F6"
+```
+
+Stored verbatim in YAML frontmatter as a string; validated against
+`^#[0-9A-Fa-f]{6}$`. No alpha channel — `#RRGGBB` only, keeping every consumer
+(CSS, CalDAV, the picker element) on one representation.
+
+## Out of scope
+
+- Alpha (`#RRGGBBAA`), named CSS colors, `rgb()`/`hsl()` notation.
+- A curated palette / theme-aware swatch set — that is an `enum` with a style
+map, a different feature.
+- Consuming the color in the calendar feed — a separate ticket depends on this.

--- a/tickets/entities/implementation-checklists/IMPL-L7TKL6.md
+++ b/tickets/entities/implementation-checklists/IMPL-L7TKL6.md
@@ -1,0 +1,71 @@
+---
+id: IMPL-L7TKL6
+type: implementation-checklist
+title: 'Implementation: Render list cells and kanban card fields through the widget registry'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Development
+
+- [x] Code implemented per the planning-checklist approach
+- [x] Follows existing patterns (`PropertyDisplay.vue`'s precomputed-rows +
+`<component :is>` + sibling ACL `v-if`)
+- [x] No unrelated changes in the diff
+- [x] Commit messages explain the why
+
+Commits: `277b9371` (migration), `1c0841c6` (review fixes).
+
+## Quality Checks
+
+- [x] `npm run test:run` — 103 files, 1649 tests pass (was 1616 before; +33)
+- [x] `npm run typecheck` — clean
+- [x] `npm run lint` — 0 errors. Remaining warnings are pre-existing
+`max-lines` on `EntityList.vue` / `KanbanView.vue`, both already well over 500
+lines before this change.
+- [x] `npm run build` — succeeds
+- [x] ~~`just coverage-check`~~ (N/A: Go package-floor thresholds only; the
+frontend has no coverage enforcement — `frontend/CLAUDE.md` and the root
+Coverage section both state unit tests run plain)
+
+## Acceptance Criteria Evidence
+
+1. **Per-type rendering matches the pre-migration string** — PASS. Verified by
+rendering each case through a mounted `EntityList` and comparing against
+`formatCellValue` directly: list-date `"2026-01-01, 2026-02-02"`, list-rrule
+`"every day"`, empty-enum-list `""`, bool-false `"No"`, int-zero `"0"`,
+scalar-date `"Mar 4, 2026"`, empty-string-list `""` — all identical. The one
+intended difference is a non-empty enum list, which badges (two `.badge`
+elements) instead of joining, as it already did.
+2. **No console warnings on any built-in type** — PASS.
+`EntityList.cells.test.ts` renders all eight types and asserts `console.warn` is
+never called.
+3. **Resolution once per column** — PASS. 50 rows × 3 columns produces exactly
+3 `resolveFromHint` calls (spy assertion).
+4. **Relation / ACL / emptiness unchanged** — PASS. Relation cell renders joined
+titles; inaccessible cell renders the lock and never reaches a widget; mobile
+hides an empty column and keeps a `false` boolean.
+
+## Bug fix verification
+
+The kanban fix was verified negatively: reverting `getCardFieldValue` and
+`visibleCardFields` to their previous form makes exactly the three bug-fix tests
+fail (`false` dropped, `0` dropped, `true` rendered instead of `Yes`), and
+restoring the fix makes them pass. A test that would also pass against the old
+code would prove nothing.
+
+## Edge cases covered
+
+`null`/`undefined`/`''`/`[]`, `false`, `0`, list-valued variants of every scalar
+type, a property with no schema entry, and both deliberate routings (boolean →
+text, file → text) pinned so a future "simplification" to `resolve(propertyDef)`
+fails loudly.
+
+## Known gaps
+
+- Schema/data mismatch on a scalar-declared enum holding an array still warns
+per row and truncates to the first element (RR-XEC2RD, deferred — pre-existing
+in `SelectWidget`, shared with detail views).
+- The four render sites still duplicate their structure; no shared cell
+component was extracted. All four are now covered by tests.

--- a/tickets/entities/planning-checklists/PLAN-TFDIO6.md
+++ b/tickets/entities/planning-checklists/PLAN-TFDIO6.md
@@ -1,0 +1,199 @@
+---
+id: PLAN-TFDIO6
+type: planning-checklist
+title: 'Planning: Render list cells and kanban card fields through the widget registry'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Understanding
+
+- [x] Problem/requirements clearly understood
+- [x] Scope defined (what's in/out documented below)
+- [x] Acceptance criteria documented with specific test scenarios
+
+**Scope:**
+
+IN: list/table cells (`EntityList.vue`, desktop `<td>` + mobile card) and kanban
+card fields (`KanbanView.vue`, simple + swimlane boards) render read-only values
+through the widget registry in `mode: 'display'`, with `text` as the universal
+fallback. A schema-driven hint builder for dense surfaces.
+
+OUT: inline-edit (TKT-IHCY7/HOIX1/GUPMK cover that); a `widget:` config key on
+`ListColumn`/`KanbanCardField` (needs a backend validator counterpart —
+follow-up); relation widgets; any new property type.
+
+**Acceptance Criteria:**
+
+1. Every built-in property type renders in a cell and a card, identical to the
+pre-migration string output — except enums, which keep badging.
+2. No console warnings on any built-in type at any row count.
+3. Widget resolution happens once per column, not per cell.
+4. Relation cells, ACL-locked cells, and the emptiness predicates are unchanged.
+
+## Research
+
+- [x] ~~Run `/research`~~ (N/A: no unknowns — the target pattern already exists in-tree)
+- [x] Searched for existing libraries that solve this problem
+- [x] Checked codebase for similar patterns or reusable code
+- [x] Looked for reference implementations in other projects
+- [x] Reviewed relevant rela concepts for prior art
+
+**Research Doc:** N/A — the approach was determined by existing code, not by a
+survey.
+
+**Existing Solutions:**
+
+No library involved; this is internal wiring. The decisive prior art is in-tree:
+
+- `components/common/PropertyDisplay.vue:52-107` — the exact pattern to copy
+(precomputed `rows` computed + `<component :is>` with an explicit
+`:mode="'display'"`). `EntityDetail.vue` `fieldRowsFor` is a second instance.
+- `widgets/registry.ts:92` `resolveFromHint` and `widgets/types.ts:69-93`
+`WidgetRoutingHint` already exist for exactly this case, with a documented
+rationale (RR-UD2B: view-side callers must not synthesise a fake `PropertyDef`).
+- So this ticket is an unfinished migration, not new machinery. FEAT-72NR1 claims
+five increments but only three tickets existed, all inline-edit; these two
+surfaces were the gap.
+
+## Approach
+
+- [x] Technical approach chosen and documented
+- [x] Approach builds on existing patterns (not reinventing)
+- [x] Alternatives considered (document why rejected)
+- [x] Dependencies identified (packages, APIs, types)
+
+**Technical Approach:**
+
+Add `densePropertyRoutingHint(propertyDef, name) -> DenseRoutingHint` to
+`widgets/viewRouting.ts`. Each surface builds a `computed` Map of property →
+`{component, hint}` (once per column/field), and the template renders
+`<component :is>` with the ACL check as a sibling `v-if`.
+
+The hint carries `preformatted`, so routing owns both *which widget* and *what
+shape it wants*. Passthrough widgets (text, integer) get the formatted string;
+widgets with their own display formatter (date, datetime, rrule, enum) get the
+raw value.
+
+**Alternatives rejected:**
+
+- *Reuse `viewFieldRoutingHint`* — maps any truthy `propType` to `enum-list`,
+which is bug-compatibility with pre-refactor Badge behaviour, not a type
+mapping. Would badge every typed column in a table.
+- *Use `registry.resolve(propertyDef)`* — routes `file` to FileWidget (an
+`<img>` request per cell) and lets list-valued enums reach SelectWidget, which
+`console.warn`s per row.
+- *Extract a shared cell component* — would prevent future drift across the four
+render sites, but widens the diff; noted in the ticket as optional.
+
+**Files to modify:** `widgets/viewRouting.ts`,
+`components/lists/EntityList.vue`, `views/KanbanView.vue` (+ the three test
+files).
+
+## Security Considerations
+
+- [x] Input sources identified (user input, config, external APIs)
+- [x] Input validation approach defined (allowlist preferred over blocklist)
+- [x] Security-sensitive operations identified (file access, auth, crypto)
+- [x] Error handling doesn't leak sensitive information
+
+**Input Sources & Validation:**
+
+- *Entity property values* (server, ultimately user-authored): rendered as text
+by every widget on this path — interpolated, never `v-html`. No new sink.
+- *`data-entry.yaml` column/field config* (operator-authored): selects a
+property name only; it cannot name a widget on this path (no `widget:` key on
+`ListColumn`/`KanbanCardField`), so config cannot reach an arbitrary component.
+Resolution is an allowlist: a closed `WidgetHintKind` union → a fixed registry
+map.
+- *Unknown property* (no schema entry): falls back to `text`, never throws.
+
+**Security-Sensitive Operations:**
+
+Read-side ACL is the one that matters. `isCellInaccessible` stays a **sibling**
+`v-if` outside the widget, mirroring `PropertyDisplay`'s `InaccessibleField`, so
+a locked property's value never enters `resolveCell` and never reaches a widget.
+Verified in review that there is no third path. Pinned by a test.
+
+No file access, auth, or crypto in this change.
+
+## Test Plan
+
+- [x] Test scenarios documented for each acceptance criterion
+- [x] Edge cases identified and documented
+- [x] Negative test cases defined (invalid input, error conditions)
+- [x] Integration test approach defined (not just unit tests)
+
+**Test Scenarios:**
+
+1. AC1 → per-type mount tests at both EntityList sites and both kanban sites.
+2. AC2 → a test rendering all built-in types asserting `console.warn` is unused.
+3. AC3 → 50 rows × 3 columns asserts exactly 3 `resolveFromHint` calls.
+4. AC4 → relation cell shows joined titles; inaccessible cell shows the lock;
+empty column stays hidden on mobile.
+
+Unit tests for the hint builder; component-mount integration tests for
+rendering.
+
+**Edge Cases:**
+
+- Empty/null/missing: `null`, `undefined`, `''`, `[]` — must render blank, not a
+placeholder (cells and detail views have opposite contracts here).
+- `false` and `0` — set values, must render `No`/`0` and must NOT be dropped by
+the emptiness predicates.
+- List-valued variants of every scalar type — must not lose the type's formatter.
+- Unparseable values (a `date` holding `'garbage'`).
+- A property with no schema entry (`id` pseudo-column).
+- Schema/data mismatch: scalar-declared enum holding an array.
+
+**Negative Tests:**
+
+- `file` must never resolve to FileWidget (no image requests from a table).
+- `boolean` must never resolve to a checkbox in a cell.
+- No hint may resolve to `text-list` on a dense surface.
+Each fails loudly if someone "simplifies" the routing to `resolve(propertyDef)`.
+
+## Risk Assessment
+
+- [x] Technical risks assessed with mitigations
+- [x] Security risks assessed (see Security Considerations)
+- [x] Effort estimated (xs/s/m/l/xl)
+
+**Risks:**
+
+- *Four render sites, no shared component* → they can drift. Mitigated by
+covering all four with tests (the mobile site had none before).
+- *Widget contracts differ between detail and dense surfaces* — this was the
+real risk and it materialised: MultiSelectWidget's em-dash and list-first
+routing both leaked a detail-view contract into cells. Caught in review, fixed,
+and pinned.
+- *Dense mounting cost* — investigated up front: no widget has a lifecycle hook,
+listener, observer, dynamic import, or fetch. Only FileWidget's `<img>` previews
+are a genuine hazard, handled by routing `file` to text.
+
+**Effort:** m
+
+## Documentation Planning
+
+- [x] User-facing docs identified (skip if internal refactor)
+- [x] ~~Docs-checklist created~~ (N/A: no user-facing behaviour to document)
+
+**Documentation Impact:**
+
+- [x] N/A — internal refactor. Rendering is unchanged for every existing config;
+the one behaviour change (kanban cards gaining formatting, and `false`/`0` no
+longer vanishing) is a bug fix, not a documented feature. No metamodel, CLI, or
+config surface changes.
+
+## Design Review
+
+- [x] ~~Run `/design-review` before implementation~~ (N/A: design settled in
+conversation with the requester, who chose the sequencing, the boolean
+rendering, and the caching approach before implementation began)
+- [x] All critical/significant findings addressed in plan
+
+**Design Review Findings:** N/A — `/code-review` ran after implementation and
+produced RR-L5I3L1, RR-IPTBC7, RR-GHU9TE, RR-UTZM9Q, RR-2UAM9F, RR-01JKVJ,
+RR-XEC2RD. Two criticals and two significants fixed; one significant deferred
+with reason.

--- a/tickets/entities/review-checklists/REV-QC4ZQI.md
+++ b/tickets/entities/review-checklists/REV-QC4ZQI.md
@@ -77,7 +77,9 @@ findings).
 - [x] All CI checks pass
 - [x] PR URL documented below
 
-**PR:** see the `has-pr` note below.
+**PR:** https://github.com/sourcehaven-bv/rela/pull/1313 — 24/24 checks green
+(1 skipped: `auto-merge`, label-gated). No CI fixes were needed. Blocked only on
+`REVIEW_REQUIRED`, i.e. human approval.
 
 Ordering note: the workflow requires the ticket to be `done` and validating
 clean *before* the PR is opened (a ticket left in `review` fails the

--- a/tickets/entities/review-checklists/REV-QC4ZQI.md
+++ b/tickets/entities/review-checklists/REV-QC4ZQI.md
@@ -2,7 +2,7 @@
 id: REV-QC4ZQI
 type: review-checklist
 title: 'Review: Render list cells and kanban card fields through the widget registry'
-status: in-progress
+status: done
 ---
 
 <!-- @managed: claude-workflow v1 -->
@@ -51,14 +51,19 @@ pre-migration `formatCellValue` output.
 
 ## Documentation (enhancements only)
 
-- [x] ~~Docs-checklist created~~ (N/A: internal refactor — rendering is
-unchanged for every existing config, and the one behaviour change is a bug fix,
-not a documented feature)
-- [x] ~~User-facing documentation updated~~ (N/A: no metamodel, CLI, or config
-surface change)
-- [x] ~~Docs-checklist marked done~~ (N/A: none created)
+- [x] Docs-checklist created and linked via `has-docs`
+- [x] User-facing documentation updated
+- [x] Docs-checklist marked as done
 
-**Docs Checklist:** N/A
+**Docs Checklist:** DOCS-L7U5HT
+
+Initially recorded as N/A on the grounds that this is an internal refactor. The
+metamodel disagreed — `has-docs` is required for `kind: enhancement`, and the
+gate was right: `frontend/CLAUDE.md` documented `src/components/forms/` as the
+widget home and never mentioned `src/widgets/`, which this change makes more
+misleading. Updated the package table and added a section on the display-side
+widget contract (the dense-vs-detail rules that caused the two critical review
+findings).
 
 ## Final Checks
 
@@ -68,8 +73,14 @@ surface change)
 
 ## Pull Request
 
-- [ ] Run `/pr` command to create PR and monitor CI
-- [ ] All CI checks pass
-- [ ] PR URL documented below
+- [x] Run `/pr` command to create PR and monitor CI
+- [x] All CI checks pass
+- [x] PR URL documented below
 
-**PR:** not yet created — branch `feat/widget-display-cells` is ready.
+**PR:** see the `has-pr` note below.
+
+Ordering note: the workflow requires the ticket to be `done` and validating
+clean *before* the PR is opened (a ticket left in `review` fails the
+`CI: Tickets in 'review' status cannot be merged` gate on its own PR). So these
+items are checked as the PR is created rather than after it merges, and the URL
+is recorded on the ticket once `gh pr create` returns.

--- a/tickets/entities/review-checklists/REV-QC4ZQI.md
+++ b/tickets/entities/review-checklists/REV-QC4ZQI.md
@@ -1,0 +1,75 @@
+---
+id: REV-QC4ZQI
+type: review-checklist
+title: 'Review: Render list cells and kanban card fields through the widget registry'
+status: in-progress
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Automated Checks
+
+- [x] All tests pass — `npm run test:run`: 103 files, 1649 tests
+- [x] Lint clean — `npm run lint`: 0 errors (remaining warnings are pre-existing
+`max-lines` on two files already over the limit before this change)
+- [x] ~~Coverage maintained~~ (N/A: `just coverage-check` enforces Go package
+floors only; the frontend has no coverage enforcement)
+
+## Code Review
+
+- [x] Run `/code-review` command (invokes cranky-code-reviewer agent)
+- [x] All critical review-responses addressed
+- [x] All significant review-responses addressed (one deferred with reason)
+- [x] Self-reviewed the diff for unrelated changes
+
+**Review Responses:**
+
+| ID | Severity | Status | Summary |
+|---|---|---|---|
+| RR-L5I3L1 | critical | addressed | `list: true` erased the type's display formatter |
+| RR-IPTBC7 | critical | addressed | Empty list cells rendered an em-dash placeholder |
+| RR-GHU9TE | significant | addressed | `preformatted` derived at the call site |
+| RR-UTZM9Q | significant | addressed | `getCardFieldRawValue` returned formatted text |
+| RR-XEC2RD | significant | **deferred** | Scalar-enum/array mismatch warns per row |
+| RR-2UAM9F | minor | addressed | Mobile card render site had no coverage |
+| RR-01JKVJ | minor | addressed | The two emptiness predicates diverged |
+
+RR-XEC2RD is deferred because it is not introduced by this change and not
+fixable in the routing layer: `SelectWidget` itself warns and truncates, and
+`PropertyDisplay` resolves the same widget from the same schema, so detail views
+have identical exposure today. Fixing it means changing a widget shared with
+forms — a separate ticket rather than a silent scope widening.
+
+## Acceptance Verification
+
+- [x] Each acceptance criterion tested (reference planning checklist)
+- [x] Test evidence documented in implementation checklist
+
+**Acceptance Status:** all four PASS — see IMPL-L7TKL6 for per-criterion
+evidence, including a value-by-value comparison of the new rendering against the
+pre-migration `formatCellValue` output.
+
+## Documentation (enhancements only)
+
+- [x] ~~Docs-checklist created~~ (N/A: internal refactor — rendering is
+unchanged for every existing config, and the one behaviour change is a bug fix,
+not a documented feature)
+- [x] ~~User-facing documentation updated~~ (N/A: no metamodel, CLI, or config
+surface change)
+- [x] ~~Docs-checklist marked done~~ (N/A: none created)
+
+**Docs Checklist:** N/A
+
+## Final Checks
+
+- [x] Commit message explains the why, not just what
+- [x] No TODOs or FIXMEs left unaddressed
+- [x] Ready for another developer to use
+
+## Pull Request
+
+- [ ] Run `/pr` command to create PR and monitor CI
+- [ ] All CI checks pass
+- [ ] PR URL documented below
+
+**PR:** not yet created — branch `feat/widget-display-cells` is ready.

--- a/tickets/entities/review-responses/RR-01JKVJ.md
+++ b/tickets/entities/review-responses/RR-01JKVJ.md
@@ -1,0 +1,9 @@
+---
+id: RR-01JKVJ
+type: review-response
+title: visibleMobileColumns and visibleCardFields used different emptiness tests
+finding: 'EntityList tested the formatted string; KanbanView was rewritten to test the raw value. Reviewer tabled twelve values and found they agree on false, 0, empty string, empty array, whitespace and NaN, diverging only on an unparseable date (mobile drops it, raw keeps it). Separately, the raw test did not predict what the widget renders: ['''',''''] passes a non-empty-array test but MultiSelectWidget renders two empty badges, producing the dangling ''Tags:'' label the predicate exists to prevent.'
+severity: minor
+resolution: Reverted visibleCardFields to the formatted test, matching EntityList. Verified independently that formatCellValue renders false as 'No' and 0 as '0' - both non-empty, both kept - so the raw rewrite was never needed. The kanban bug was entirely in getCardFieldValue's old String(v || ''), which collapsed them before the predicate ran.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-2UAM9F.md
+++ b/tickets/entities/review-responses/RR-2UAM9F.md
@@ -1,0 +1,9 @@
+---
+id: RR-2UAM9F
+type: review-response
+title: Mobile card render site had no test coverage
+finding: Every EntityList test asserted on `tbody`, so the isMobile branch (a full second render site, structurally duplicating the desktop cell) was entirely unexercised. It can drift from desktop silently.
+severity: minor
+resolution: 'Added a ''mobile card render site'' describe block that stubs window.matchMedia before mount to drive isMobile, covering: widget rendering matching desktop, boolean showing Yes/No, the emptiness predicate still hiding empty columns, and a false boolean staying visible.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-GHU9TE.md
+++ b/tickets/entities/review-responses/RR-GHU9TE.md
@@ -1,0 +1,9 @@
+---
+id: RR-GHU9TE
+type: review-response
+title: preformatted was a two-source-of-truth flag derived at the call site
+finding: Both call sites derived the value shape as `hint.kind === 'text'`. That encodes 'TextWidget does no formatting', but the real property is 'this widget has no display-mode formatter', which is true of text, integer, and text-list, and will be true of the forthcoming ColorWidget. It was already wrong for text-list, and each new widget would default to being mis-shaped.
+severity: significant
+resolution: Introduced DenseRoutingHint extending WidgetRoutingHint with preformatted, computed inside densePropertyRoutingHint from a PASSTHROUGH_KINDS set. Routing now owns both which widget and what shape it wants; call sites just read hint.preformatted. A new widget defaults to receiving the raw value, which is the correct default since the reason to add a widget is that it renders something text cannot.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-IPTBC7.md
+++ b/tickets/entities/review-responses/RR-IPTBC7.md
@@ -1,0 +1,9 @@
+---
+id: RR-IPTBC7
+type: review-response
+title: Empty list-valued cells rendered an em-dash placeholder
+finding: 'MultiSelectWidget renders an em-dash for an empty array (RR-UD2C) so ''no value'' reads as distinct from a loading state. That is a DETAIL-view contract. formatCellValue documents the opposite for cells: ''Cells render empty for null/undefined (vs - in formatValue) so blank table cells stay visually quiet; do not delegate this branch to formatValue.'' A sparsely-populated list column became a column of dashes. It also interacted with the mobile predicate: desktop dashed while mobile dropped the column, so the same data rendered two ways by viewport.'
+severity: critical
+resolution: Added isDenseEmpty(value) to widgets/viewRouting.ts, shared by both surfaces. The CELL decides emptiness before the widget sees the value, so a widget placeholder can never reach a dense surface. MultiSelectWidget is unchanged - its em-dash is correct for detail views and other consumers depend on it.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-L5I3L1.md
+++ b/tickets/entities/review-responses/RR-L5I3L1.md
@@ -1,0 +1,9 @@
+---
+id: RR-L5I3L1
+type: review-response
+title: 'list: true erased the type''s display formatter in cells'
+finding: 'densePropertyRoutingHint checked propertyDef.list before the type switch (mirroring defaultWidgetFor, which is the EDIT-side dispatcher). On the display side this erased the type''s formatter: a date + list:true column rendered ISO strings as grey enum badges, and a list-valued rrule rendered an em-dash (the value vanished entirely, because MultiSelectWidget does not unwrap a single-element array the way formatCellValue does). Both are regressions against the string path being replaced.'
+severity: critical
+resolution: Moved the list check after the enum branch but before the type switch, routing every non-enum list to preformatted text so formatCellValue reproduces the pre-migration string byte for byte. Enum lists still route to enum-list and badge. Pinned by an it.each over all five list-valued types plus end-to-end render tests for the date and rrule cases.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-UTZM9Q.md
+++ b/tickets/entities/review-responses/RR-UTZM9Q.md
@@ -1,0 +1,9 @@
+---
+id: RR-UTZM9Q
+type: review-response
+title: getCardFieldRawValue returned formatted text for relation fields
+finding: A function named 'raw' returned the joined relation string ('A, B') for relation fields. It was harmless only because cardFieldWidget independently returns undefined for relations, so the value never reached a widget - two guards agreeing by luck. Adding a relation widget later would silently feed it pre-joined text.
+severity: significant
+resolution: Renamed to getCardFieldStoredValue and dropped the relation branch; it now handles property fields only and returns undefined otherwise. Callers use getCardFieldValue for relations explicitly.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-XEC2RD.md
+++ b/tickets/entities/review-responses/RR-XEC2RD.md
@@ -1,0 +1,9 @@
+---
+id: RR-XEC2RD
+type: review-response
+title: Schema/data mismatch on a scalar enum warns once per row per render
+finding: A property declared scalar enum whose stored value is an array (legacy data, hand-edited markdown, an un-backfilled metamodel change) routes to SelectWidget, whose safeStringValue console.warns per instance and renders only the first element - so 'b' is silently dropped where the old string path joined both. Routing is decided per column from the SCHEMA, but this failure is per row from the DATA, so the hint cannot prevent it.
+severity: significant
+reason: 'Not introduced by this change and not fixable in the routing layer. The pre-existing detail-view path has the identical exposure: PropertyDisplay resolves the same SelectWidget from the same schema, so any surface rendering a scalar-declared enum holding an array already warns and truncates. Fixing it means either making SelectWidget''s warn non-per-render or having it render all elements, both of which change a widget shared with forms and detail views - out of scope for a display-path migration. Filed as a follow-up rather than silently widened into this PR.'
+status: deferred
+---

--- a/tickets/entities/tickets/TKT-28FRME.md
+++ b/tickets/entities/tickets/TKT-28FRME.md
@@ -1,0 +1,113 @@
+---
+id: TKT-28FRME
+type: ticket
+title: Add color property type (#RRGGBB) with data-entry picker widget
+kind: enhancement
+priority: medium
+effort: m
+status: backlog
+---
+
+## Goal
+
+A new built-in property type `color` whose value is a CSS hex string `#RRGGBB`,
+usable anywhere a scalar property is usable, with a real color picker in
+data-entry instead of a text box.
+
+**Depends on TKT-S9C14S** (widget-based display rendering in list cells and
+kanban cards). Landing that first means the swatch is a single widget
+registration instead of a per-surface special case in four render sites.
+
+## Value representation
+
+- Canonical form: `#RRGGBB`, seven characters, leading `#`.
+- Validation regex: `^#[0-9A-Fa-f]{6}$`.
+- Stored verbatim as a YAML string. No new Go representation, so
+`internal/canonical` needs no change.
+- No alpha, no named colors, no `rgb()`. One representation keeps CSS, the
+`<input type="color">` element, and CalDAV's `calendar-color` in agreement.
+
+Case is **preserved, not normalized**. Normalizing on write would rewrite the
+operator's file on an unrelated save; validation is case-insensitive so both
+`#3b82f6` and `#3B82F6` are accepted.
+
+## Backend touch points
+
+| File | Change |
+|---|---|
+| `internal/metamodel/types.go:404-413` | add `PropertyTypeColor = "color"` |
+| `internal/metamodel/types.go:475-481` | add to `IsBuiltinType` |
+| `internal/metamodel/validation.go:225` | new `case` in `validatePropertyValue` + `ParseColorValue` helper |
+| `internal/metamodel/loader.go:409` | add to the display_property **deny** list (decided: a hex string is a poor entity label) |
+| `internal/metamodel/schema_output.go:117` | `ResolveWidgetFromType` -> `color` |
+| `internal/dataentryconfig/config.go:23` | `WidgetColor` constant |
+| `internal/openapi/schemas.go:81` | JSON Schema: `string` + pattern |
+| `internal/predicatefns/env.go:28` | `ScalarType` -> `StringType` |
+| `internal/affordances/bindings.go:188` | `coerceScalar` — must stay in lockstep with `ScalarType` (RR-4189H) |
+| `internal/filter/match.go:71,153` | match dispatch + allowed operators (`=`/`!=` only) |
+| `internal/filter/sort.go:38,332` | string comparator |
+| `internal/templating/fsloader.go:283` | default value |
+| `docs/metamodel.md:588` | property-type table + dedicated section |
+
+Confirmed **non**-touch points: `internal/markdown`, `internal/search`,
+`internal/store` (all backends), `internal/validator` — none carry
+per-property-type logic.
+
+## Frontend touch points
+
+With TKT-S9C14S landed, this is four files:
+
+| File | Change |
+|---|---|
+| `frontend/src/types/schema.ts:22` | add `'color'` to the `PropertyDef['type']` union — the tripwire that surfaces everything else |
+| `frontend/src/widgets/ColorWidget.vue` | new; implements both `mode: 'display'` and `mode: 'edit'` |
+| `frontend/src/widgets/registry.ts:18-28` | `defaultWidgetFor` — add before the `text` fallback |
+| `frontend/src/widgets/registry.ts:103-119` | register in `buildDefaultRegistry` |
+| `frontend/src/widgets/types.ts:76-85` | add a `'color'` member to `WidgetHintKind` |
+| `frontend/src/widgets/registry.ts:33-43` | add the `color` entry to `hintKindToWidgetName` |
+| `frontend/src/widgets/viewRouting.ts` | route `type: 'color'` in the schema-driven hint builder added by TKT-S9C14S |
+
+`utils/format.ts`, `EntityList.vue` and `KanbanView.vue` need **no change** —
+that was only true after the refactor; before it, each needed its own swatch
+branch.
+
+## Widget behaviour
+
+- **Edit mode**: `<input type="color">` (native picker) paired with a text input
+accepting a typed hex, kept in sync. The native picker alone is unusable for
+someone pasting a brand hex.
+- **Display mode**: a swatch plus the hex value as text.
+- **Empty value**: a neutral outlined chip reading `—`, not a black square
+(`background: ''` collapses to transparent).
+- The swatch needs a `1px` low-alpha `currentColor` border, or `#FFFFFF` is
+invisible on light backgrounds and `#111827` vanishes in dark mode.
+
+## Accessibility
+
+A swatch must never be color-alone: render the hex value as text beside it, and
+mark the swatch `aria-hidden="true"` (decorative once the text is present). A
+color-blind or screen-reader user gets the same information.
+
+## Testing
+
+- `internal/metamodel` table test for `validatePropertyValue`: valid, missing
+`#`, wrong length, non-hex chars, empty, non-string; both cases accepted.
+- Loader test: `type: color` accepted as a property; **rejected** as a
+`display_property`.
+- `frontend/src/widgets/registry.test.ts:19-36` — add the `it.each` mapping row
+(mandatory, else the dispatch is untested).
+- `frontend/src/widgets/widgets.test.ts` — mount `ColorWidget` in both modes,
+assert `update:modelValue`, assert the display branch does not render in edit
+mode (RR-UD2D).
+- Hint-builder test: `type: 'color'` routes to the color widget.
+- E2E: set a color on an entity via the picker, reload, value persists.
+
+## Validation error convention
+
+Per `internal/dataentry/CLAUDE.md` lines 14-30 the data-entry write path is
+write-then-warn: an invalid color returns 200 with a `{code, path, detail}`
+warning, not a 400.
+
+## Follow-on
+
+The CalDAV/calendar-feed ticket consumes this property; not in scope here.

--- a/tickets/entities/tickets/TKT-S9C14S.md
+++ b/tickets/entities/tickets/TKT-S9C14S.md
@@ -5,7 +5,7 @@ title: Render list cells and kanban card fields through the widget registry
 kind: enhancement
 priority: high
 effort: m
-status: review
+status: done
 ---
 
 ## Goal

--- a/tickets/entities/tickets/TKT-S9C14S.md
+++ b/tickets/entities/tickets/TKT-S9C14S.md
@@ -1,0 +1,158 @@
+---
+id: TKT-S9C14S
+type: ticket
+title: Render list cells and kanban card fields through the widget registry
+kind: enhancement
+priority: high
+effort: m
+status: review
+---
+
+## Goal
+
+Finish the display-side widget migration. `PropertyDisplay` and `EntityDetail`
+already resolve read-only rendering through the widget registry; list/table
+cells and kanban card fields were left behind on a string-only path. Move them
+onto the same seam, with `text` as the universal fallback.
+
+This is the missing display-side increment of FEAT-72NR1. The three existing
+tickets under that feature (TKT-IHCY7, TKT-HOIX1, TKT-GUPMK) are all inline-edit
+work and none covers these two surfaces.
+
+## Why now
+
+`formatCellValue` returns a `string`, so a cell can only ever be text. Any
+property type whose useful rendering is not text — a color swatch, a progress
+bar, a rating, an image thumbnail — is unrepresentable. Adding a per-type branch
+per surface is what the widget registry already exists to avoid; TKT-28FRME
+(color property type) is blocked behind this and is the immediate motivating
+consumer.
+
+## Approach
+
+Follow the `PropertyDisplay.vue:52-107` model exactly:
+
+1. A precomputed `computed` resolving the widget **per column / per card
+field**, not per cell (`PropertyDisplay`'s `rows`, cited RR-UD2A).
+2. `<component :is>` with an explicit `:mode="'display'"` literal — `mode` is
+required and deliberately has no default (RR-UD1I).
+3. The ACL branch stays a **sibling** `v-if` outside the widget; no widget
+models lock state.
+
+### Widget resolution: a new schema-driven hint builder
+
+Add a `propertyDef -> WidgetHintKind` builder in `widgets/viewRouting.ts`
+alongside the existing `viewFieldRoutingHint`. Do **not** reuse either existing
+path:
+
+- `viewFieldRoutingHint` maps any truthy `propType` to `enum-list`, which is
+documented as bug-compatibility with pre-refactor Badge behaviour, not a correct
+type mapping. Adopting it in tables would badge every typed column.
+- Bare `registry.resolve(propertyDef)` routes `file` to `FileWidget`, whose
+display branch renders `<img>` previews — one network request per image per
+cell. It also lets a list-valued enum reach `SelectWidget`, whose
+`safeStringValue` `console.warn`s on multi-element arrays: one warning per row
+per render.
+
+The new builder is schema-driven (list views have the real `PropertyDef` via
+`entityType.properties[column.property]`), routes list-valued enums to
+`enum-list`, and inherits the safety property that `WidgetHintKind` has no
+`'file'` member — a file column cannot reach `FileWidget` through a hint.
+
+### Per-type routing decisions
+
+| Type | Cell/card routing | Rationale |
+|---|---|---|
+| boolean | `text` (`Yes`/`No`) | **Not** `checkbox`. Preserves today's appearance and keeps cells text-searchable and copy-pasteable. The checkbox stays the detail-view rendering. |
+| enum (scalar) | `enum` | single Badge, as today |
+| enum (list) | `enum-list` | multi-select's Badge loop; also fixes kanban, which today renders one Badge of a comma-joined string |
+| file | `text` | never `FileWidget` in a dense context |
+| date / datetime / integer / rrule / string | matching widget | |
+| relation | unchanged string path | no `PropertyDef`, no relation widget in the registry |
+
+## Behaviour changes (intentional, not silent)
+
+**Kanban gains formatting it never had.** `getCardFieldValue`
+(`KanbanView.vue:336-355`) is bare `String(v || '')` and never called
+`formatCellValue`, so cards today show datetimes as raw ISO strings, booleans as
+`"true"`, rrules as `"FREQ=DAILY"`. The `|| ''` also collapses `0` and `false`
+to empty, which makes `visibleCardFields` **drop the field from the card
+entirely** — a `false` boolean silently vanishes. The migration fixes all of
+this; it is a bug fix riding along, and both the ticket and the PR should say
+so.
+
+List cells are otherwise visually unchanged.
+
+## Must not break
+
+- **String-emptiness predicates.** `visibleMobileColumns`
+(`EntityList.vue:365-368`) and `visibleCardFields` (`KanbanView.vue:360-362`)
+use `formatted !== ''` to decide whether a field appears at all. These are
+*filters*, not render paths. Keep them on a string source or convert to a
+value-level emptiness check. If they break, mobile cards show dangling labels
+with no values.
+- `formatValue` stays — `RruleWidget:20` depends on it.
+- `formatCellValue` stays for the emptiness predicate. Note that after this
+change it is no longer a rendering path.
+
+## Four render sites
+
+No shared cell component exists, so the same change lands in four places; miss
+one and they drift:
+
+- `EntityList.vue:913` — desktop `<td>`
+- `EntityList.vue:812` — mobile card (structural duplicate)
+- `KanbanView.vue:530` — simple board
+- `KanbanView.vue:610` — swimlane board
+
+Extracting a shared cell component is optional but would prevent the next drift.
+
+## Performance
+
+Widgets are safe to mount densely: none of `TextWidget`, `NumberWidget`,
+`DateWidget`, `CheckboxWidget`, `SelectWidget`, `MultiSelectWidget`,
+`RruleWidget`, `FileWidget` has a lifecycle hook, event listener, observer,
+dynamic import, or fetch. The only dependencies are `useStringValue` (one
+computed) and `useSchemaStore()` (a Pinia singleton lookup).
+
+Two real notes:
+
+- **`FileWidget` is the exception** — its display branch renders `<img>`
+previews, i.e. a network request per image per cell. Handled by routing `file`
+to `text` above.
+- **No rrule cache.** Vue's `computed` already is the cache: `RruleWidget`'s
+`displayValue` depends only on `stringValue`, so it re-parses on dependency
+change, not per render. Stable `:key`s are required so instances are reused. The
+residual cost is identical RRULE strings across rows each parsing once on first
+render — sub-millisecond `toText()` calls. Profile before optimising; if it
+shows up, a bounded (~200-entry, oldest-out) cache belongs in the widget's
+module scope, **not** in `format.ts` — a pure leaf formatter should not carry
+hidden mutable state.
+
+Fix while here: the enum branch calls `getCellValue` twice per cell per render
+(`EntityList.vue:922,924`); precomputing rows removes it.
+
+## Config surface (optional, can defer)
+
+Neither `ListColumn` (`types/config.ts:256-264`) nor `KanbanCardField`
+(`:330-335`) has `widget?: string`, so authored per-column widget overrides are
+not possible. `FormField.widget` (`:99`) is the naming precedent. Adding it
+needs a backend config-validator counterpart — reasonable to split into a
+follow-up.
+
+Unrelated latent bug found nearby: `ListColumn.width` is declared but never read
+anywhere, so authored column widths are silently ignored.
+
+## Testing
+
+- Unit-test the new hint builder per property type, including the two
+deliberate routings (boolean → text, file → text) so a future "simplification"
+to `resolve(propertyDef)` fails loudly.
+- `EntityList` mount test: enum column still badges, boolean still shows
+`Yes`/`No`, relation column still shows joined titles, inaccessible cell still
+shows the lock.
+- `KanbanView` test pinning the fixed behaviour: `false` renders as `No` and the
+field is **not** dropped; a datetime renders formatted, not as raw ISO.
+- Mobile-card test that an empty column is still hidden (the emptiness
+predicate).
+- `npm run test:run`, `npm run typecheck`, `npm run lint`.

--- a/tickets/relations/FEAT-8OTJVW--requires--metamodel-types.md
+++ b/tickets/relations/FEAT-8OTJVW--requires--metamodel-types.md
@@ -1,0 +1,5 @@
+---
+from: FEAT-8OTJVW
+relation: requires
+to: metamodel-types
+---

--- a/tickets/relations/TKT-28FRME--affects--metamodel-types.md
+++ b/tickets/relations/TKT-28FRME--affects--metamodel-types.md
@@ -1,0 +1,5 @@
+---
+from: TKT-28FRME
+relation: affects
+to: metamodel-types
+---

--- a/tickets/relations/TKT-28FRME--depends-on--TKT-S9C14S.md
+++ b/tickets/relations/TKT-28FRME--depends-on--TKT-S9C14S.md
@@ -1,0 +1,5 @@
+---
+from: TKT-28FRME
+relation: depends-on
+to: TKT-S9C14S
+---

--- a/tickets/relations/TKT-28FRME--implements--FEAT-8OTJVW.md
+++ b/tickets/relations/TKT-28FRME--implements--FEAT-8OTJVW.md
@@ -1,0 +1,5 @@
+---
+from: TKT-28FRME
+relation: implements
+to: FEAT-8OTJVW
+---

--- a/tickets/relations/TKT-S9C14S--affects--data-entry-ui.md
+++ b/tickets/relations/TKT-S9C14S--affects--data-entry-ui.md
@@ -1,0 +1,5 @@
+---
+from: TKT-S9C14S
+relation: affects
+to: data-entry-ui
+---

--- a/tickets/relations/TKT-S9C14S--has-docs--DOCS-L7U5HT.md
+++ b/tickets/relations/TKT-S9C14S--has-docs--DOCS-L7U5HT.md
@@ -1,0 +1,5 @@
+---
+from: TKT-S9C14S
+relation: has-docs
+to: DOCS-L7U5HT
+---

--- a/tickets/relations/TKT-S9C14S--has-implementation--IMPL-L7TKL6.md
+++ b/tickets/relations/TKT-S9C14S--has-implementation--IMPL-L7TKL6.md
@@ -1,0 +1,5 @@
+---
+from: TKT-S9C14S
+relation: has-implementation
+to: IMPL-L7TKL6
+---

--- a/tickets/relations/TKT-S9C14S--has-planning--PLAN-TFDIO6.md
+++ b/tickets/relations/TKT-S9C14S--has-planning--PLAN-TFDIO6.md
@@ -1,0 +1,5 @@
+---
+from: TKT-S9C14S
+relation: has-planning
+to: PLAN-TFDIO6
+---

--- a/tickets/relations/TKT-S9C14S--has-review--REV-QC4ZQI.md
+++ b/tickets/relations/TKT-S9C14S--has-review--REV-QC4ZQI.md
@@ -1,0 +1,5 @@
+---
+from: TKT-S9C14S
+relation: has-review
+to: REV-QC4ZQI
+---

--- a/tickets/relations/TKT-S9C14S--has-review-response--RR-01JKVJ.md
+++ b/tickets/relations/TKT-S9C14S--has-review-response--RR-01JKVJ.md
@@ -1,0 +1,5 @@
+---
+from: TKT-S9C14S
+relation: has-review-response
+to: RR-01JKVJ
+---

--- a/tickets/relations/TKT-S9C14S--has-review-response--RR-2UAM9F.md
+++ b/tickets/relations/TKT-S9C14S--has-review-response--RR-2UAM9F.md
@@ -1,0 +1,5 @@
+---
+from: TKT-S9C14S
+relation: has-review-response
+to: RR-2UAM9F
+---

--- a/tickets/relations/TKT-S9C14S--has-review-response--RR-GHU9TE.md
+++ b/tickets/relations/TKT-S9C14S--has-review-response--RR-GHU9TE.md
@@ -1,0 +1,5 @@
+---
+from: TKT-S9C14S
+relation: has-review-response
+to: RR-GHU9TE
+---

--- a/tickets/relations/TKT-S9C14S--has-review-response--RR-IPTBC7.md
+++ b/tickets/relations/TKT-S9C14S--has-review-response--RR-IPTBC7.md
@@ -1,0 +1,5 @@
+---
+from: TKT-S9C14S
+relation: has-review-response
+to: RR-IPTBC7
+---

--- a/tickets/relations/TKT-S9C14S--has-review-response--RR-L5I3L1.md
+++ b/tickets/relations/TKT-S9C14S--has-review-response--RR-L5I3L1.md
@@ -1,0 +1,5 @@
+---
+from: TKT-S9C14S
+relation: has-review-response
+to: RR-L5I3L1
+---

--- a/tickets/relations/TKT-S9C14S--has-review-response--RR-UTZM9Q.md
+++ b/tickets/relations/TKT-S9C14S--has-review-response--RR-UTZM9Q.md
@@ -1,0 +1,5 @@
+---
+from: TKT-S9C14S
+relation: has-review-response
+to: RR-UTZM9Q
+---

--- a/tickets/relations/TKT-S9C14S--has-review-response--RR-XEC2RD.md
+++ b/tickets/relations/TKT-S9C14S--has-review-response--RR-XEC2RD.md
@@ -1,0 +1,5 @@
+---
+from: TKT-S9C14S
+relation: has-review-response
+to: RR-XEC2RD
+---

--- a/tickets/relations/TKT-S9C14S--implements--FEAT-72NR1.md
+++ b/tickets/relations/TKT-S9C14S--implements--FEAT-72NR1.md
@@ -1,0 +1,5 @@
+---
+from: TKT-S9C14S
+relation: implements
+to: FEAT-72NR1
+---


### PR DESCRIPTION
Finishes the display-side widget migration (TKT-S9C14S). `PropertyDisplay` and
`EntityDetail` already resolved read-only rendering through the widget registry;
list/table cells and kanban card fields were still on a string-only path.

## Why

`formatCellValue` returns a `string`, so a cell could only ever be text. Any
property type whose useful rendering is not text — a colour swatch, a progress
bar, a thumbnail — was unrepresentable, and each would have needed a per-type
branch in four separate render sites. TKT-28FRME (colour property type) is
blocked behind this and is the motivating consumer.

This is the missing display-side increment of FEAT-72NR1; the three existing
tickets under that feature are all inline-edit work.

## Kanban bug fix (user-visible)

`getCardFieldValue` never called the shared formatter, so cards showed raw ISO
datetimes and `"true"`, and `String(v || '')` collapsed `false` and `0` to `''`
— which made `visibleCardFields` **drop those fields from the card entirely**.

| | before | after |
|---|---|---|
| `done: false` | field absent | `Done: No` |
| `effort: 0` | field absent | `Effort: 0` |
| `starts_at` | `2026-03-04T09:30:00Z` | `4 mrt 2026, 10:30` |
| `repeats` | `FREQ=DAILY` | `every day` |
| list-valued enum | one badge `"a,b"` | one badge per value |

Verified by building both revisions against the same fixture. Genuinely-unset
fields are still dropped.

## Design

`densePropertyRoutingHint` (`widgets/viewRouting.ts`) maps a real `PropertyDef`
to a widget for dense surfaces. Deliberately **not** the two existing paths:
`viewFieldRoutingHint` routes any typed field to `enum-list` (bug-compatibility
with pre-refactor Badge behaviour) and would badge every typed column;
`registry.resolve(propertyDef)` routes `file` to FileWidget, whose display
branch renders `<img>` previews — one network request per cell.

Dense surfaces and detail views have genuinely opposite contracts, which is the
root of the two critical findings the review caught:

- **Empty renders blank, never a placeholder.** MultiSelectWidget's em-dash
  (RR-UD2C) is right for a detail row; `formatCellValue` documents that cells
  "stay visually quiet".
- **`list: true` must not override the type's formatter.** `defaultWidgetFor`
  puts list first because the *edit* side needs a tag picker whatever the type.
  On the display side that erased the formatter — a list-valued rrule rendered
  as an em-dash, i.e. the value vanished.
- **`boolean` → text, `file` → text** in cells: booleans stay Cmd-F searchable
  and copy-pasteable; the checkbox remains the detail-view rendering.
- **Resolve per column, not per cell** — pinned by a test asserting 50 rows x 3
  columns produces exactly 3 resolutions.

## Testing

1649 tests (+33). Includes the mobile card render site, which had no coverage at
all despite being a structural duplicate of the desktop cell. The three kanban
bug-fix tests were verified to fail against the pre-fix code.

## Review

`/code-review` produced 7 findings: 2 critical and 2 significant fixed, 2 minor
fixed, 1 significant deferred (RR-XEC2RD — a scalar-declared enum holding an
array warns per row; pre-existing in `SelectWidget` and shared with detail
views, so out of scope for a display-path migration).

## Not in scope

`widget:` on `ListColumn` / `KanbanCardField` (needs a backend validator
counterpart), relation widgets, and extracting a shared cell component for the
four render sites.
