### PR TITLE
fix(dataentry): redact visible:-hidden properties in the ICS feed

### DIFF
--- a/docs-project/entities/guides/GUIDE-data-entry.md
+++ b/docs-project/entities/guides/GUIDE-data-entry.md
@@ -3117,7 +3117,21 @@ property, or **timed** (a UTC `DTSTART` with a time-of-day) when it is a
 
 Point your calendar app at
 `http://<host>:<port>/api/v1/_feeds/<name>.ics`. The endpoint applies the
-server's ACL: a feed only ever exposes entities the request's principal may read.
+server's ACL in both dimensions: an entity the request's principal may not read
+is absent from the feed, and a property hidden from them by a `visible:` grant is
+omitted from the event it would otherwise appear in.
+
+Field redaction applies to what the event **renders**, not to which entities the
+feed selects. A `where:` clause is evaluated against the unredacted entity on
+purpose — otherwise a hidden property would read as empty inside the filter, and
+the same feed would contain different events for different readers. Which
+entities a feed selects is an operator-authored decision; what their fields say
+is the reader's business.
+
+One consequence worth knowing: if a feed is anchored on a date property that a
+reader may not see, entities have no usable date for them and drop out of that
+reader's calendar entirely. That is deliberate — an event whose date you may not
+read is not one you should be shown.
 
 On a plain localhost server there is no authentication — the feed is readable by
 anything that can reach the port, which is appropriate for a single-user local

--- a/docs/data-entry.md
+++ b/docs/data-entry.md
@@ -3111,7 +3111,21 @@ property, or **timed** (a UTC `DTSTART` with a time-of-day) when it is a
 
 Point your calendar app at
 `http://<host>:<port>/api/v1/_feeds/<name>.ics`. The endpoint applies the
-server's ACL: a feed only ever exposes entities the request's principal may read.
+server's ACL in both dimensions: an entity the request's principal may not read
+is absent from the feed, and a property hidden from them by a `visible:` grant is
+omitted from the event it would otherwise appear in.
+
+Field redaction applies to what the event **renders**, not to which entities the
+feed selects. A `where:` clause is evaluated against the unredacted entity on
+purpose — otherwise a hidden property would read as empty inside the filter, and
+the same feed would contain different events for different readers. Which
+entities a feed selects is an operator-authored decision; what their fields say
+is the reader's business.
+
+One consequence worth knowing: if a feed is anchored on a date property that a
+reader may not see, entities have no usable date for them and drop out of that
+reader's calendar entirely. That is deliberate — an event whose date you may not
+read is not one you should be shown.
 
 On a plain localhost server there is no authentication — the feed is readable by
 anything that can reach the port, which is appropriate for a single-user local

--- a/internal/dataentry/feed_handler.go
+++ b/internal/dataentry/feed_handler.go
@@ -52,7 +52,7 @@ func (a *App) handleV1Feed(w http.ResponseWriter, r *http.Request) {
 	link := func(entityType, id string) string {
 		return base + "/entity/" + entityType + "/" + id
 	}
-	provider, err := newDeclarativeFeed(name, cfg, s.Meta, feedEntitySource{app: a}, link)
+	provider, err := newDeclarativeFeed(name, cfg, s.Meta, feedEntitySource{app: a}, link, appRedactor(a))
 	if err != nil {
 		writeV1Error(w, r, http.StatusInternalServerError, "feed_error", "Feed misconfigured", "")
 		return

--- a/internal/dataentry/feed_provider.go
+++ b/internal/dataentry/feed_provider.go
@@ -13,6 +13,7 @@ import (
 	"github.com/Sourcehaven-BV/rela/internal/entity"
 	"github.com/Sourcehaven-BV/rela/internal/filter"
 	"github.com/Sourcehaven-BV/rela/internal/metamodel"
+	"github.com/Sourcehaven-BV/rela/internal/visibility"
 )
 
 // feedProvider is the internal, transport-independent view of a calendar feed:
@@ -59,11 +60,14 @@ type deepLinker func(entityType, id string) string
 // entities' properties to calendar events (all-day or timed, per the source
 // date property's type).
 type declarativeFeed struct {
-	cfg    dataentryconfig.Feed
-	meta   *metamodel.Metamodel
-	src    entitySource
-	link   deepLinker
-	feedID string // the config key; used as the default calendar name
+	cfg  dataentryconfig.Feed
+	meta *metamodel.Metamodel
+	src  entitySource
+	link deepLinker
+	// redactor applies field-level `visible:` ACL to rendered values. Nil means
+	// no redaction (the memory/test wiring); production always supplies one.
+	redactor visibility.FieldRedactor
+	feedID   string // the config key; used as the default calendar name
 }
 
 // newDeclarativeFeed builds a provider for one configured feed. It pre-parses
@@ -71,6 +75,7 @@ type declarativeFeed struct {
 // entity is read (config validation catches this earlier still).
 func newDeclarativeFeed(
 	feedID string, cfg dataentryconfig.Feed, meta *metamodel.Metamodel, src entitySource, link deepLinker,
+	redactor visibility.FieldRedactor,
 ) (*declarativeFeed, error) {
 	// Validate sources reference known types up front so List/Get can assume it.
 	for i, s := range cfg.Sources {
@@ -81,7 +86,9 @@ func newDeclarativeFeed(
 			return nil, fmt.Errorf("feed %q: source[%d]: %w", feedID, i, err)
 		}
 	}
-	return &declarativeFeed{cfg: cfg, meta: meta, src: src, link: link, feedID: feedID}, nil
+	return &declarativeFeed{
+		cfg: cfg, meta: meta, src: src, link: link, redactor: redactor, feedID: feedID,
+	}, nil
 }
 
 // calendarName is the feed's display name: the configured meta.name, or the
@@ -132,7 +139,7 @@ func (d *declarativeFeed) List(ctx context.Context, opts feedListOpts) ([]calfee
 			if !since.IsZero() && !e.UpdatedAt.After(since) {
 				continue
 			}
-			ev, ok, err := d.mapEntity(e, s, entDef, filters)
+			ev, ok, err := d.mapEntity(ctx, e, s, entDef, filters)
 			if err != nil {
 				return nil, "", err
 			}
@@ -179,7 +186,7 @@ func (d *declarativeFeed) Get(ctx context.Context, uid string) (calfeed.Event, b
 			return calfeed.Event{}, false, err
 		}
 		entDef, _ := d.meta.GetEntityDef(entityType)
-		ev, mapped, err := d.mapEntity(e, s, entDef, filters)
+		ev, mapped, err := d.mapEntity(ctx, e, s, entDef, filters)
 		if err != nil {
 			return calfeed.Event{}, false, err
 		}
@@ -188,13 +195,59 @@ func (d *declarativeFeed) Get(ctx context.Context, uid string) (calfeed.Event, b
 	return calfeed.Event{}, false, nil
 }
 
+// redactFeedEntity returns a copy of e with `visible:`-hidden properties
+// removed, or e unchanged when nothing is hidden.
+//
+// A COPY, never a mutation: the entity comes from the shared store snapshot, so
+// deleting properties in place would redact it for every other reader in the
+// process.
+//
+// The DATE property is deliberately not special-cased. If an operator hides the
+// property a feed is anchored on, the entity has no usable date and drops out of
+// the calendar — which is the correct outcome: an event whose date the reader
+// may not see is not an event they should be shown. That it also removes the
+// entity from the feed is a disclosure the row-level ACL already governs (a
+// reader who cannot see the row never got here at all).
+func redactFeedEntity(
+	ctx context.Context, r visibility.FieldRedactor, e *entity.Entity,
+) *entity.Entity {
+	if r == nil || e == nil {
+		return e
+	}
+	hidden := r.HiddenProperties(ctx, e)
+	if len(hidden) == 0 {
+		return e
+	}
+	clone := *e
+	clone.Properties = make(map[string]any, len(e.Properties))
+	for k, v := range e.Properties {
+		if _, hide := hidden[k]; hide {
+			continue
+		}
+		clone.Properties[k] = v
+	}
+	return &clone
+}
+
 // mapEntity applies a source's filter to one entity and, if it matches and has
 // a date value, maps its properties to a calendar event. ok=false means the
 // entity is filtered out or has no usable date (it is silently skipped, not an
 // error — a task with no due date is simply not on the calendar).
 func (d *declarativeFeed) mapEntity(
+	ctx context.Context,
 	e *entity.Entity, s dataentryconfig.FeedSource, entDef *metamodel.EntityDef, filters []*filter.Filter,
 ) (calfeed.Event, bool, error) {
+	// The FILTER runs against the raw entity, deliberately, and redaction is
+	// applied only afterwards to the values that get rendered.
+	//
+	// Order matters. Redacting first would make a `visible:`-hidden property
+	// read as empty inside `where:`, so feed MEMBERSHIP would vary by principal:
+	// the same feed would contain different events for different readers, and an
+	// entity would silently drop out of the calendar because a field the reader
+	// cannot see was filtered on. Which entities a feed selects is an
+	// operator-authored decision (row visibility is the ACL's job, and
+	// `src.listType` has already applied it); what their FIELDS say is the
+	// reader's business.
 	matched, err := filter.MatchAll(entityRecord(e), filters, entDef, d.meta)
 	if err != nil {
 		return calfeed.Event{}, false, err
@@ -202,6 +255,7 @@ func (d *declarativeFeed) mapEntity(
 	if !matched {
 		return calfeed.Event{}, false, nil
 	}
+	e = redactFeedEntity(ctx, d.redactor, e)
 
 	dateStr := e.GetString(s.Date)
 	if dateStr == "" {

--- a/internal/dataentry/feed_provider_test.go
+++ b/internal/dataentry/feed_provider_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/Sourcehaven-BV/rela/internal/dataentryconfig"
 	"github.com/Sourcehaven-BV/rela/internal/entity"
 	"github.com/Sourcehaven-BV/rela/internal/metamodel"
+	"github.com/Sourcehaven-BV/rela/internal/visibility"
 )
 
 // compile-time: declarativeFeed satisfies feedProvider.
@@ -70,7 +71,16 @@ func testLinker(t, id string) string { return "/entity/" + t + "/" + id }
 
 func newTestFeed(t *testing.T, cfg dataentryconfig.Feed, src entitySource) *declarativeFeed {
 	t.Helper()
-	d, err := newDeclarativeFeed("cal", cfg, feedTestMeta(), src, testLinker)
+	// nil redactor: these tests exercise mapping and filtering with no ACL
+	// policy, which is the no-policy parity case (nothing hidden).
+	return newTestFeedWithRedactor(t, cfg, src, nil)
+}
+
+func newTestFeedWithRedactor(
+	t *testing.T, cfg dataentryconfig.Feed, src entitySource, r visibility.FieldRedactor,
+) *declarativeFeed {
+	t.Helper()
+	d, err := newDeclarativeFeed("cal", cfg, feedTestMeta(), src, testLinker, r)
 	if err != nil {
 		t.Fatalf("newDeclarativeFeed: %v", err)
 	}
@@ -464,5 +474,107 @@ func TestSplitFeedUID(t *testing.T) {
 		if !ok || typ != tc.typ || id != tc.id {
 			t.Errorf("round-trip feedUID(%q,%q) = (%q,%q,%v)", tc.typ, tc.id, typ, id, ok)
 		}
+	}
+}
+
+// feedFakeRedactor hides a fixed set of property names.
+type feedFakeRedactor struct{ hide []string }
+
+func (f feedFakeRedactor) HiddenProperties(context.Context, *entity.Entity) map[string]struct{} {
+	out := map[string]struct{}{}
+	for _, h := range f.hide {
+		out[h] = struct{}{}
+	}
+	return out
+}
+
+// TestDeclarativeFeed_RedactsHiddenProperties pins that field-level `visible:`
+// ACL reaches the ICS feed.
+//
+// listType gates ROWS — an entity the principal cannot read never reaches the
+// mapper. It does not touch FIELDS, and docs/acl-security.md commits to
+// redaction on "every HTTP read shape". The feed was one that skipped it: a
+// source mapping `description: notes` served that property verbatim to a
+// principal whose role redacts it.
+func TestDeclarativeFeed_RedactsHiddenProperties(t *testing.T) {
+	cfg := dataentryconfig.Feed{Sources: []dataentryconfig.FeedSource{{
+		EntityType: "task", Date: "due", Summary: "title", Description: "notes",
+	}}}
+	task := mkTask("TSK-1", "Buy milk", "todo", "2026-08-12", time.Now())
+	task.Properties["notes"] = "classified"
+	src := fakeSource{byType: map[string][]*entity.Entity{"task": {task}}}
+
+	// Precondition: with nothing hidden the value IS rendered, so the assertion
+	// below cannot pass for an unrelated reason.
+	open, _, err := newTestFeed(t, cfg, src).List(t.Context(), feedListOpts{})
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(open) != 1 || open[0].Description != "classified" {
+		t.Fatalf("precondition: description not rendered at all: %+v", open)
+	}
+
+	d := newTestFeedWithRedactor(t, cfg, src, feedFakeRedactor{hide: []string{"notes"}})
+	got, _, err := d.List(t.Context(), feedListOpts{})
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("want 1 event, got %d", len(got))
+	}
+	if got[0].Description != "" {
+		t.Errorf("a `visible:`-hidden property reached the feed: %q", got[0].Description)
+	}
+	if got[0].Summary != "Buy milk" {
+		t.Errorf("a visible property was dropped: %q", got[0].Summary)
+	}
+}
+
+// TestDeclarativeFeed_RedactionDoesNotChangeMembership pins the ORDER: the
+// `where:` filter runs against the raw entity, before redaction.
+//
+// Redacting first would make a hidden property read as empty inside the filter,
+// so the same feed would contain different EVENTS for different readers — an
+// entity silently dropping off the calendar because a field the reader cannot
+// see was filtered on. Which entities a feed selects is operator-authored; what
+// their fields say is the reader's business.
+func TestDeclarativeFeed_RedactionDoesNotChangeMembership(t *testing.T) {
+	cfg := dataentryconfig.Feed{Sources: []dataentryconfig.FeedSource{{
+		EntityType: "task", Date: "due", Summary: "title",
+		Where: []string{"status = todo"},
+	}}}
+	src := fakeSource{byType: map[string][]*entity.Entity{"task": {
+		mkTask("TSK-1", "Buy milk", "todo", "2026-08-12", time.Now()),
+	}}}
+
+	// `status` is the filtered property AND hidden from this reader.
+	d := newTestFeedWithRedactor(t, cfg, src, feedFakeRedactor{hide: []string{"status"}})
+	got, _, err := d.List(t.Context(), feedListOpts{})
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("hiding the filtered property changed feed membership: got %d events, want 1", len(got))
+	}
+}
+
+// TestDeclarativeFeed_RedactionCopies pins that redaction never mutates the
+// shared store entity. The snapshot is process-wide, so an in-place delete would
+// redact for every other reader — including write-prep reads, where a missing
+// property is an ERASURE.
+func TestDeclarativeFeed_RedactionCopies(t *testing.T) {
+	task := mkTask("TSK-1", "Buy milk", "todo", "2026-08-12", time.Now())
+	task.Properties["notes"] = "classified"
+	cfg := dataentryconfig.Feed{Sources: []dataentryconfig.FeedSource{{
+		EntityType: "task", Date: "due", Summary: "title", Description: "notes",
+	}}}
+	src := fakeSource{byType: map[string][]*entity.Entity{"task": {task}}}
+
+	d := newTestFeedWithRedactor(t, cfg, src, feedFakeRedactor{hide: []string{"notes"}})
+	if _, _, err := d.List(t.Context(), feedListOpts{}); err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if task.Properties["notes"] != "classified" {
+		t.Error("redaction mutated the shared store entity")
 	}
 }

--- a/tickets/entities/automated-measures/AM-feed-field-redaction.md
+++ b/tickets/entities/automated-measures/AM-feed-field-redaction.md
@@ -1,0 +1,9 @@
+---
+id: AM-feed-field-redaction
+type: automated-measure
+title: The ICS feed omits visible:-hidden properties, and redaction runs after the filter
+description: TestDeclarativeFeed_RedactsHiddenProperties asserts a hidden property never reaches a rendered event. TestDeclarativeFeed_RedactionDoesNotChangeMembership pins the ORDER by hiding the property the where: clause filters on and asserting the event still appears - moving redaction before the filter drops it, so feed membership would vary per principal. TestDeclarativeFeed_RedactionCopies asserts the shared store entity is not mutated. All three verified to fail against the fix being removed.
+kind: test
+location: internal/dataentry/feed_provider_test.go
+status: active
+---

--- a/tickets/entities/bugs/BUG-E9DYW5.md
+++ b/tickets/entities/bugs/BUG-E9DYW5.md
@@ -1,0 +1,63 @@
+---
+id: BUG-E9DYW5
+type: bug
+title: 'ICS feed serves `visible:`-redacted properties verbatim'
+description: A property hidden from a principal by a `visible:` ACL grant was served verbatim in the ICS feed, while every other HTTP read shape omits it. Row-level gating was unaffected; only field-level redaction was missing. Found during the CalDAV security review (PR #1308), which fixed the same gap on its own read path.
+priority: high
+why1: The ICS feed's mapEntity reads properties straight off the raw entity (e.GetString), so a property a role's `visible:` grant hides is rendered into the event.
+why2: Field-level redaction is applied by the data-entry serializer, and the feed does not go through it — it builds a calfeed.Event directly from the entity.
+why3: The feed was built as a projection of entities to a calendar model, and row-level gating (feedEntitySource.listType) was the visible ACL concern; field-level redaction is a second, orthogonal cut that was not considered at the seam.
+why4: Redaction is enforced per-read-shape rather than structurally, so every NEW read shape has to remember it. docs/acl-security.md asserts it applies to 'every HTTP read shape', which reads as a guarantee rather than a convention to re-implement.
+why5: There is no type-level barrier between 'raw store entity' and 'entity safe to render outward'. Both are *entity.Entity, so a new read path compiles and works while silently skipping redaction.
+prevention: Redaction now runs at the single mapping chokepoint in each feed path, pinned by tests that fail if the call is removed (including an ordering test for filter-before-redact). The durable fix is a distinct type for 'redacted, safe to render' so a raw entity cannot reach a serializer by accident — tracked separately.
+status: done
+---
+
+## Symptom
+
+A property hidden from a principal by a `visible:` ACL grant is served verbatim
+in the ICS feed (`/api/v1/_feeds/<name>.ics`), while every other HTTP read shape
+omits it.
+
+A feed source mapping `description: notes` renders `notes` into the event
+DESCRIPTION for any principal who passes the **row** gate, regardless of whether
+their role may read that field.
+
+## Scope
+
+Row-level gating was never affected: `feedEntitySource.listType` resolves the
+`ReadQuery` verdict fail-closed, so an entity the principal cannot read is
+absent from the feed. Only **field-level** redaction was missing.
+
+Found during a security review of the CalDAV work (PR #1308), which inherited
+the same gap from this code and fixed it on its own read path. This ticket is
+the pre-existing feed half.
+
+## Fix
+
+`mapEntity` now applies the `visible:` redactor before reading any property into
+the event.
+
+**Ordering is load-bearing.** Redaction runs AFTER the `where:` filter, never
+before. Redacting first would make a hidden property read as empty inside the
+filter, so feed *membership* would vary per principal — the same feed would
+contain different events for different readers, and an entity would silently
+drop off the calendar because a field the reader cannot see was filtered on.
+Which entities a feed selects is an operator-authored decision; what their
+fields say is the reader's business.
+
+One accepted consequence: if a feed is anchored on a date property the reader
+may not see, entities have no usable date for them and leave that reader's
+calendar entirely. Deliberate — an event whose date you may not read is not one
+you should be shown.
+
+## Verification
+
+Three tests, each verified to FAIL against the fix being removed:
+
+- a hidden property does not reach the rendered event
+- hiding the **filtered** property does not change feed membership (pins the
+ordering: moving redaction before the filter drops the event)
+- redaction copies rather than mutating the shared store entity, which would
+redact it for every other reader in the process — including write-prep reads,
+where a missing property is an erasure

--- a/tickets/entities/implementation-checklists/IMPL-E9DYW5.md
+++ b/tickets/entities/implementation-checklists/IMPL-E9DYW5.md
@@ -1,0 +1,41 @@
+---
+id: IMPL-E9DYW5
+type: implementation-checklist
+title: 'Implementation: ICS feed field redaction'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Development
+
+- [x] Unit tests written for new code
+- [x] ~~Integration tests~~ (N/A: the change is one call at the mapping
+chokepoint; the three unit tests drive the real `declarativeFeed.List` path)
+- [x] Happy path implemented
+- [x] Edge cases from planning handled — the filter/redaction ORDER, and the
+date-property case where redaction removes the event entirely
+- [x] Error handling in place
+
+## Test Quality
+
+- [x] Using fixture builders for test data (`mkTask`, `fakeSource`)
+- [x] No hardcoded values in assertions when the object is in scope
+- [x] Only specifying values that matter for the test
+- [x] Each test verified to FAIL against the fix being removed, including an
+ordering sabotage (redact-before-filter) for the membership test
+
+## Quality
+
+- [x] Code follows project patterns — mirrors `affordanceService.copyVisibleProperties`
+- [x] Checked for DRY opportunities
+- [x] No security issues introduced
+- [x] No silent failures
+- [x] No debug code left behind
+
+## Automated checks
+
+- `go test ./internal/dataentry/` — PASS (one pre-existing unrelated failure,
+`TestBuiltCSSIsLayered`, from stale frontend build artifacts on develop)
+- `golangci-lint run ./...` — 0 issues
+- `just arch-lint` / `just plimsoll` — OK

--- a/tickets/entities/tickets/TKT-KUAV99.md
+++ b/tickets/entities/tickets/TKT-KUAV99.md
@@ -1,0 +1,104 @@
+---
+id: TKT-KUAV99
+type: ticket
+title: 'Make field-level redaction structural: a distinct type for render-safe entities'
+kind: refactor
+priority: medium
+effort: l
+status: backlog
+---
+
+## Problem
+
+`docs/acl-security.md` asserts that `visible:` redaction is applied "on
+**every** HTTP read shape". That is a guarantee in prose and a **convention** in
+code: each read path calls a redaction helper itself, and nothing stops a new
+one from skipping it.
+
+Two paths did skip it, independently, and neither was caught by review:
+
+- **CalDAV** (PR #1308) — `renderObject` read `e.GetString(...)` off the raw
+entity. Found by security review.
+- **The ICS feed** (BUG-E9DYW5, PR #1314) — `mapEntity` did the same. Found only
+because CalDAV inherited the pattern from it.
+
+Both compiled, passed review, and served hidden property values.
+
+## Root cause
+
+There is no type-level distinction between "raw entity from the store" and
+"entity safe to render outward". Both are `*entity.Entity`, so:
+
+```go
+e, _, _ := src.getEntity(ctx, typ, id)   // row-gated, NOT field-redacted
+ev.Summary = e.GetString("title")        // compiles; may leak
+```
+
+This is precisely the bug class `visibleReader` was built to close, one level
+down. Its own doc comment states the principle:
+
+> the read gate already exists but is applied by *convention* — a handler can
+> reach `a.store.GetEntity` directly and forget to gate. That "gate by
+> convention" is the read-ACL bug class (TKT-N26KLB, #1010). A type that holds
+> the store privately and exposes only gated reads makes the gating
+> **structural**.
+
+`visibleReader` made ROW gating structural and returns `*entity.Entity` — so
+FIELD redaction remained conventional. The fix is the same move applied to
+fields.
+
+## Current state: four mechanisms, one contract
+
+The same "omit hidden properties" rule is implemented four times over:
+
+| Site | Shape |
+|---|---|
+| `affordanceService.stripHiddenProperties` | mutates a `v1.Entity` in place |
+| `affordanceService.copyVisibleProperties` | returns a fresh property map |
+| `redactEntityFields` (CalDAV) | returns a copied `*entity.Entity` |
+| `redactFeedEntity` (ICS feed) | returns a copied `*entity.Entity` |
+
+The last two are near-duplicates added while fixing the two leaks — evidence the
+missing abstraction is being re-derived per site rather than reused.
+
+## Proposal (shape to be settled in planning)
+
+A `visibility.RedactedEntity` (or similar) that:
+
+- **cannot be constructed** except by passing a raw entity through the redactor
+- exposes only read accessors (`GetString`, `Content`, …), never the raw
+`Properties` map
+- is what `visibleReader` returns from its read-out methods, so a consumer
+taking the gated reader gets field redaction by construction
+
+Then a render path that wants a property has no way to reach an unredacted one,
+and the four mechanisms above collapse to one.
+
+## Open questions for planning
+
+- **Write-prep reads must NOT be redacted.** `entitymanager` diffing needs the
+raw entity — a redacted read-modify-write would clobber hidden fields, which is
+exactly the erasure `PatchEntity` exists to prevent. The type must not reach
+that path, or must be explicitly convertible with a named, greppable escape
+hatch.
+- **The body (`Content`) has no `visible:` vocabulary.** CalDAV clears it when a
+property named `body` is hidden, which is a heuristic. Decide whether the type
+models body visibility properly or preserves that heuristic.
+- **Filter/sort inputs stay raw.** The ICS feed evaluates `where:` against the
+unredacted entity on purpose — redacting first would make feed *membership* vary
+per principal. Any type must leave that path a raw entity.
+- **Scope.** `visibleReader`'s own doc notes some ungated reads were deliberately
+not migrated (BUG-ZM7SBI). This ticket should not silently widen that.
+
+## Acceptance criteria
+
+1. A render path cannot obtain an unredacted property value without a named,
+greppable escape hatch.
+2. The four existing redaction mechanisms collapse to one implementation.
+3. Write-prep reads still receive raw entities;
+`TestPatchEntity_PreservesUnnamedProperties` and
+`TestScriptReads_UpdatePreservesHiddenProperties` still pass.
+4. Feed membership is still decided on unredacted values
+(`TestDeclarativeFeed_RedactionDoesNotChangeMembership` still passes).
+5. A new read path that forgets redaction fails to COMPILE, and a test
+demonstrates that (e.g. a compile-fail fixture or a lint rule).

--- a/tickets/relations/BUG-E9DYW5--adds-measure--AM-feed-field-redaction.md
+++ b/tickets/relations/BUG-E9DYW5--adds-measure--AM-feed-field-redaction.md
@@ -1,0 +1,5 @@
+---
+from: BUG-E9DYW5
+type: adds-measure
+to: AM-feed-field-redaction
+---

--- a/tickets/relations/BUG-E9DYW5--affects--authorization.md
+++ b/tickets/relations/BUG-E9DYW5--affects--authorization.md
@@ -1,0 +1,5 @@
+---
+from: BUG-E9DYW5
+relation: affects
+to: authorization
+---

--- a/tickets/relations/BUG-E9DYW5--fixes--FEAT-OT4361.md
+++ b/tickets/relations/BUG-E9DYW5--fixes--FEAT-OT4361.md
@@ -1,0 +1,5 @@
+---
+from: BUG-E9DYW5
+relation: fixes
+to: FEAT-OT4361
+---

--- a/tickets/relations/BUG-E9DYW5--has-implementation--IMPL-E9DYW5.md
+++ b/tickets/relations/BUG-E9DYW5--has-implementation--IMPL-E9DYW5.md
@@ -1,0 +1,5 @@
+---
+from: BUG-E9DYW5
+type: has-implementation
+to: IMPL-E9DYW5
+---

--- a/tickets/relations/TKT-KUAV99--affects--authorization.md
+++ b/tickets/relations/TKT-KUAV99--affects--authorization.md
@@ -1,0 +1,5 @@
+---
+from: TKT-KUAV99
+relation: affects
+to: authorization
+---

--- a/tickets/relations/TKT-KUAV99--implements--FEAT-PPH1EU.md
+++ b/tickets/relations/TKT-KUAV99--implements--FEAT-PPH1EU.md
@@ -1,0 +1,5 @@
+---
+from: TKT-KUAV99
+relation: implements
+to: FEAT-PPH1EU
+---


### PR DESCRIPTION
A property hidden from a principal by a `visible:` ACL grant was served
**verbatim** in the ICS feed (`/api/v1/_feeds/<name>.ics`), while every other
HTTP read shape omits it.

`docs/acl-security.md` states redaction is applied "on **every** HTTP read
shape". The feed was one that skipped it: `mapEntity` builds a `calfeed.Event`
straight from the raw entity, so a source mapping `description: notes` rendered
that property for any principal who passed the **row** gate — regardless of
whether their role may read the field.

Row-level gating was never affected. `feedEntitySource.listType` resolves the
`ReadQuery` verdict fail-closed, so an entity the principal cannot read is absent
from the feed. Only field-level redaction was missing.

## Ordering is the load-bearing part

Redaction runs **after** the `where:` filter, never before.

Redacting first would make a hidden property read as empty inside the filter, so
feed **membership** would vary per principal: the same feed would contain
different events for different readers, and an entity would silently drop off the
calendar because a field the reader cannot see was filtered on. Which entities a
feed selects is an operator-authored decision; what their fields say is the
reader's business.

One accepted consequence, documented in the guide: if a feed is anchored on a
date property the reader may not see, entities have no usable date for them and
leave that reader's calendar entirely. Deliberate — an event whose date you may
not read is not one you should be shown.

## Tests

Three, each verified to FAIL against the fix being removed:

- a hidden property does not reach the rendered event
- hiding the **filtered** property does not change feed membership (the ordering
  pin — moving redaction before the filter drops the event)
- redaction copies rather than mutating the shared store entity, which would
  redact it for every other reader in the process, including write-prep reads
  where a missing property is an erasure

## Provenance

Found during a security review of the CalDAV work (#1308), which inherited this
gap from the feed code and fixed it on its own read path. This is the
pre-existing half, split out as its own PR so the fix to shipped behaviour is
reviewable on its own.

Note `TestBuiltCSSIsLayered` fails on `develop` already (stale frontend build
artifacts from #1307) and is unrelated to this change.

Closes BUG-E9DYW5.