### PR TITLE
fix(entitymanager): re-check constraints after automation in cascade writes (BUG-KIMZRK)

### DIFF
--- a/internal/entitymanager/cascade_recheck_test.go
+++ b/internal/entitymanager/cascade_recheck_test.go
@@ -1,0 +1,317 @@
+package entitymanager_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/Sourcehaven-BV/rela/internal/acl"
+	"github.com/Sourcehaven-BV/rela/internal/audit"
+	"github.com/Sourcehaven-BV/rela/internal/autocascade"
+	"github.com/Sourcehaven-BV/rela/internal/automation"
+	"github.com/Sourcehaven-BV/rela/internal/entity"
+	"github.com/Sourcehaven-BV/rela/internal/entitymanager"
+	"github.com/Sourcehaven-BV/rela/internal/metamodel"
+	"github.com/Sourcehaven-BV/rela/internal/statemachine"
+	"github.com/Sourcehaven-BV/rela/internal/store"
+	"github.com/Sourcehaven-BV/rela/internal/store/memstore"
+)
+
+// cascadeRecheckMeta declares a `unique:` natural key on an
+// auto-ID type, so a cascade can create one and an on-create
+// automation can then set the constrained property.
+const cascadeRecheckMeta = `version: "1.0"
+entities:
+  ticket:
+    label: Ticket
+    plural: tickets
+    id_type: manual
+    properties:
+      title:
+        type: string
+  persoon:
+    label: Persoon
+    plural: personen
+    id_prefix: PERS
+    properties:
+      email:
+        type: string
+        unique: true
+      naam:
+        type: string
+`
+
+// duplicateEmailAutomation sets the unique `email` to an
+// already-taken value whenever a persoon is created.
+func duplicateEmailAutomation() automation.Automation {
+	return automation.Automation{
+		Name: "person-gets-duplicate-email",
+		On:   automation.Trigger{Entity: []string{"persoon"}, Created: true},
+		Do:   []automation.Action{{Set: "email", Value: "taken@example.com"}},
+	}
+}
+
+// newRecheckManager wires a manager with the supplied automations and
+// seeds one persoon already holding "taken@example.com".
+func newRecheckManager(t *testing.T, autos []automation.Automation) (*entitymanager.Manager, store.Store) {
+	t.Helper()
+	meta, err := metamodel.Parse([]byte(cascadeRecheckMeta))
+	if err != nil {
+		t.Fatalf("metamodel.Parse: %v", err)
+	}
+	st := memstore.New()
+
+	existing := entity.New("PERS-EXISTING", "persoon")
+	existing.SetString("email", "taken@example.com")
+	if seedErr := st.CreateEntity(context.Background(), existing); seedErr != nil {
+		t.Fatalf("seed: %v", seedErr)
+	}
+
+	engine := automation.NewEngine(autos)
+	runner, err := autocascade.New(autocascade.Deps{Engine: engine})
+	if err != nil {
+		t.Fatalf("autocascade.New: %v", err)
+	}
+	mgr, err := entitymanager.New(entitymanager.Deps{
+		Store:       st,
+		Meta:        meta,
+		Templater:   nopTemplater{},
+		Audit:       audit.Nop{},
+		ACL:         acl.NopACL{},
+		Automations: engine,
+		Cascade:     runner,
+		Transitions: statemachine.EmptySet(),
+		FieldGate:   entitymanager.AllowAllFieldGate{},
+	})
+	if err != nil {
+		t.Fatalf("entitymanager.New: %v", err)
+	}
+	return mgr, st
+}
+
+// countHolders returns how many personen hold the guarded address.
+func countHolders(t *testing.T, st store.Store) int {
+	t.Helper()
+	n := 0
+	for e, err := range st.ListEntities(context.Background(), store.EntityQuery{Type: "persoon"}) {
+		if err != nil {
+			t.Fatalf("list: %v", err)
+		}
+		if e.GetString("email") == "taken@example.com" {
+			n++
+		}
+	}
+	return n
+}
+
+// TestCascadeWrite_UniqueRecheckedAfterAutomation is the BUG-KIMZRK
+// regression test.
+//
+// `createCore` enforces `unique:` against the PRE-automation candidate. An
+// on-create automation then sets the constrained property and the cascade
+// re-writes the entity. Without a post-automation re-check that duplicate
+// persists — silently, with no error and no AutomationErrors entry.
+//
+// The asymmetry is the defect: the top-level create path already re-runs
+// checkUniqueProperties against post-automation values (manager.go, "the
+// create path must not be the weaker one"). The cascade path must not be
+// weaker either.
+func TestCascadeWrite_UniqueRecheckedAfterAutomation(t *testing.T) {
+	t.Parallel()
+	mgr, st := newRecheckManager(t, []automation.Automation{
+		{
+			Name: "ticket-creates-person",
+			On:   automation.Trigger{Entity: []string{"ticket"}, Created: true},
+			Do: []automation.Action{{
+				CreateEntity: &automation.CreateEntityAction{
+					Type:       "persoon",
+					Properties: map[string]string{"naam": "New Person"},
+				},
+			}},
+		},
+		duplicateEmailAutomation(),
+	})
+
+	trigger := entity.New("TKT-1", "ticket")
+	trigger.SetString("title", "Trigger")
+	res, err := mgr.CreateEntity(context.Background(), trigger, entity.CreateOptions{ID: "TKT-1"})
+	if err != nil {
+		t.Fatalf("CreateEntity: %v", err)
+	}
+
+	if got := countHolders(t, st); got != 1 {
+		t.Errorf("%d entities hold the unique email, want 1 — "+
+			"an automation-set value bypassed the unique constraint", got)
+	}
+
+	// The rejection must be SURFACED, not swallowed. A silent skip would
+	// leave the caller believing the cascade fully succeeded.
+	if len(res.AutomationErrors) == 0 {
+		t.Error("cascade reported no automation errors — a refused write must be surfaced")
+	} else if !strings.Contains(strings.ToLower(strings.Join(res.AutomationErrors, " ")), "unique") {
+		t.Errorf("automation errors do not mention the unique violation: %v", res.AutomationErrors)
+	}
+}
+
+// TestTopLevelCreate_UniqueRecheckedAfterAutomation is the CONTROL.
+//
+// The defect is an ASYMMETRY between two paths, so pinning only the cascade
+// side would miss a future regression that weakened both. This asserts the
+// top-level path stays strict.
+func TestTopLevelCreate_UniqueRecheckedAfterAutomation(t *testing.T) {
+	t.Parallel()
+	mgr, st := newRecheckManager(t, []automation.Automation{duplicateEmailAutomation()})
+
+	p := entity.New("", "persoon")
+	p.SetString("naam", "Direct")
+	_, err := mgr.CreateEntity(context.Background(), p, entity.CreateOptions{})
+	if err == nil {
+		t.Error("top-level create accepted an automation-set duplicate of a unique property")
+	}
+
+	if got := countHolders(t, st); got != 1 {
+		t.Errorf("%d entities hold the unique email, want 1", got)
+	}
+}
+
+// TestCascadeWrite_ValidAutomationValueStillLands guards against
+// over-correcting: the re-check must reject only genuine violations. An
+// automation setting an unconstrained property must still work.
+func TestCascadeWrite_ValidAutomationValueStillLands(t *testing.T) {
+	t.Parallel()
+	mgr, st := newRecheckManager(t, []automation.Automation{
+		{
+			Name: "ticket-creates-person",
+			On:   automation.Trigger{Entity: []string{"ticket"}, Created: true},
+			Do: []automation.Action{{
+				CreateEntity: &automation.CreateEntityAction{
+					Type:       "persoon",
+					Properties: map[string]string{"naam": "New Person"},
+				},
+			}},
+		},
+		{
+			Name: "person-gets-unique-email",
+			On:   automation.Trigger{Entity: []string{"persoon"}, Created: true},
+			Do:   []automation.Action{{Set: "email", Value: "fresh@example.com"}},
+		},
+	})
+
+	trigger := entity.New("TKT-1", "ticket")
+	trigger.SetString("title", "Trigger")
+	res, err := mgr.CreateEntity(context.Background(), trigger, entity.CreateOptions{ID: "TKT-1"})
+	if err != nil {
+		t.Fatalf("CreateEntity: %v", err)
+	}
+	if len(res.AutomationErrors) != 0 {
+		t.Errorf("a legitimate automation write was refused: %v", res.AutomationErrors)
+	}
+
+	found := false
+	for e, err := range st.ListEntities(context.Background(), store.EntityQuery{Type: "persoon"}) {
+		if err != nil {
+			t.Fatalf("list: %v", err)
+		}
+		if e.GetString("email") == "fresh@example.com" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("automation-set value did not persist — the re-check is too strict")
+	}
+}
+
+// smMeta declares a state machine so an automation can attempt to set a
+// non-entry value on a cascade-created entity.
+const smMeta = `version: "1.0"
+types:
+  taak_status:
+    values: [todo, doing, done]
+    default: todo
+    initial: todo
+    transitions:
+      - {move: start, from: todo, to: doing}
+      - {move: finish, from: doing, to: done}
+entities:
+  ticket:
+    label: Ticket
+    plural: tickets
+    id_type: manual
+    properties:
+      title:
+        type: string
+  taak:
+    label: Taak
+    plural: taken
+    id_prefix: TAAK
+    properties:
+      status:
+        type: taak_status
+`
+
+// TestCascadeWrite_TransitionRecheckedAfterAutomation probes the third
+// consequence listed in BUG-KIMZRK: an automation setting a state-machine
+// property to a non-entry value on a cascade-created entity.
+func TestCascadeWrite_TransitionRecheckedAfterAutomation(t *testing.T) {
+	t.Parallel()
+	meta, err := metamodel.Parse([]byte(smMeta))
+	if err != nil {
+		t.Fatalf("metamodel.Parse: %v", err)
+	}
+	machines, err := statemachine.Compile(meta)
+	if err != nil {
+		t.Fatalf("statemachine.Compile: %v", err)
+	}
+	st := memstore.New()
+
+	autos := []automation.Automation{
+		{
+			Name: "ticket-creates-taak",
+			On:   automation.Trigger{Entity: []string{"ticket"}, Created: true},
+			Do: []automation.Action{{
+				CreateEntity: &automation.CreateEntityAction{Type: "taak"},
+			}},
+		},
+		{
+			// "done" is neither the entry value nor reachable from todo in
+			// one legal move.
+			Name: "taak-jumps-to-done",
+			On:   automation.Trigger{Entity: []string{"taak"}, Created: true},
+			Do:   []automation.Action{{Set: "status", Value: "done"}},
+		},
+	}
+	engine := automation.NewEngine(autos)
+	runner, err := autocascade.New(autocascade.Deps{Engine: engine})
+	if err != nil {
+		t.Fatalf("autocascade.New: %v", err)
+	}
+	mgr, err := entitymanager.New(entitymanager.Deps{
+		Store: st, Meta: meta, Templater: nopTemplater{},
+		Audit: audit.Nop{}, ACL: acl.NopACL{},
+		Automations: engine, Cascade: runner,
+		Transitions: machines,
+		FieldGate:   entitymanager.AllowAllFieldGate{},
+	})
+	if err != nil {
+		t.Fatalf("entitymanager.New: %v", err)
+	}
+
+	trigger := entity.New("TKT-1", "ticket")
+	trigger.SetString("title", "Trigger")
+	res, err := mgr.CreateEntity(context.Background(), trigger, entity.CreateOptions{ID: "TKT-1"})
+	if err != nil {
+		t.Fatalf("CreateEntity: %v", err)
+	}
+	t.Logf("automation errors: %v", res.AutomationErrors)
+
+	for e, listErr := range st.ListEntities(context.Background(), store.EntityQuery{Type: "taak"}) {
+		if listErr != nil {
+			t.Fatalf("list: %v", listErr)
+		}
+		t.Logf("taak %s status=%q", e.ID, e.GetString("status"))
+		if e.GetString("status") == "done" {
+			t.Errorf("automation set an illegal state-machine value %q on a "+
+				"cascade-created entity; entry is %q", "done", "todo")
+		}
+	}
+}

--- a/internal/entitymanager/cascadehost.go
+++ b/internal/entitymanager/cascadehost.go
@@ -76,10 +76,46 @@ func (h *cascadeHost) CreateEntity(
 // Note: no audit record here. The earlier CreateEntity already produced
 // one audit record for this entity; emitting another for the property-set
 // step would double-count the same creation in the audit log.
+//
+// Constraints are RE-CHECKED against the post-automation values (BUG-KIMZRK).
+// createCore validated the candidate as it stood BEFORE automation ran, so a
+// value an automation introduces afterwards has never been examined. The
+// top-level create path already re-runs the same checks for exactly this
+// reason ("the create path must not be the weaker one" — see CreateEntity);
+// without them here, an automation could silently persist a duplicate of a
+// `unique:` natural key, or a value validation would reject.
+//
+// Excluding e.ID from the unique scan is what makes this an idempotent
+// re-check rather than a self-collision: the row is already persisted, so it
+// would otherwise match itself.
 func (h *cascadeHost) WriteEntity(ctx context.Context, e *entity.Entity) error {
 	if e == nil {
 		return nil
 	}
+
+	if errs := h.deps.Meta.ValidateEntity(e.ID, e.Type, e.Properties); len(errs) > 0 {
+		// DEC-HWZHA: only HARD errors abort. Soft conditions (a required
+		// property left unset, an out-of-enum value) are tolerated on every
+		// other write path and must stay tolerated here, or a cascade would
+		// be stricter than a direct edit.
+		if hard, _ := partitionValidationErrors(errs); len(hard) > 0 {
+			return newValidationError(hard)
+		}
+	}
+
+	if err := checkUniqueProperties(ctx, h.deps, e, e.ID); err != nil {
+		return err
+	}
+
+	// EnforceCreate, not EnforceUpdate: this row was created moments ago in
+	// this same cascade, so the automation's value is still an ENTRY value —
+	// it must equal the machine's declared entry, not merely be reachable
+	// from it by a legal move. Using EnforceUpdate would wrongly accept a
+	// one-hop jump the create path forbids.
+	if err := h.deps.Transitions.EnforceCreate(ctx, e); err != nil {
+		return err
+	}
+
 	return h.deps.Store.UpdateEntity(ctx, e)
 }
 

--- a/tickets/entities/automated-measures/cascade-write-full-pipeline-test.md
+++ b/tickets/entities/automated-measures/cascade-write-full-pipeline-test.md
@@ -1,8 +1,8 @@
 ---
 id: cascade-write-full-pipeline-test
 type: automated-measure
-title: 'Test: cascade-created entity writes run the full manager pipeline (validation, unique, transitions, audit)'
-description: 'Pins that the cascade re-write of an automation-created entity (autocascade/runner.go:182-191 -> cascadeHost.WriteEntity) runs the full manager pipeline: metamodel validation, unique-constraint checks, state-machine transition enforcement, and audit. Fails if cascadeHost.WriteEntity writes directly to store.Store. Behavioural, not structural, so a raw handle reintroduced by another route still fails.'
+title: 'Test: cascade-created entity re-checks validation/unique/transitions against POST-automation values'
+description: 'Pins that automation-set properties applied to a cascade-created entity (autocascade/runner.go:181-187 -> cascadeHost.WriteEntity) are re-validated before persisting: unique-constraint checks, metamodel validation, and state-machine enforcement against the POST-automation values. Mirrors the top-level create path (manager.go:456-476), which already re-checks uniques post-automation on the stated grounds that the create path ''must not be the weaker one''. NOTE: deliberately does NOT assert audit — the cascade create is already audited via recordCascade (cascadehost.go:62), and the absence of a second record on the property-set step is intentional (it would double-count one creation).'
 kind: test
 location: internal/entitymanager/ (new test alongside audit_durability_test.go) — to be created by BUG-KIMZRK
 status: proposed
@@ -10,39 +10,46 @@ status: proposed
 
 ## What it asserts
 
-A write performed **during a cascade** — specifically the re-write of a
-cascade-created entity after automation `set` actions
-(`internal/autocascade/runner.go:182-191` → `Host.WriteEntity`) — is subject to
-the same write pipeline as a top-level write:
+Automation-set properties applied to a **cascade-created** entity
+(`internal/autocascade/runner.go:181-187` → `Host.WriteEntity`) are re-checked
+against their **post-automation** values before being persisted:
 
-1. metamodel validation runs (an invalid post-automation value does not persist
+1. `unique: true` constraints are enforced against post-automation values
+2. metamodel validation runs (an invalid automation-set value does not persist
 silently)
-2. `unique: true` constraints are enforced against post-automation values
-3. state-machine transitions are enforced (an automation cannot drive an entity into
-a state the metamodel forbids)
-4. an audit record is emitted for the cascade write
+3. state-machine entry is enforced (an automation cannot drive a
+cascade-created entity into a state the metamodel forbids)
+
+## What it deliberately does NOT assert
+
+**Audit.** The cascade create is already audited — `cascadehost.go:62` calls
+`recordCascade(ctx, audit.OpCreateEntity, ...)`. The absence of a *second*
+record on the property-set step is intentional and documented
+(`cascadehost.go:76-78`): a second record would double-count one creation.
+Asserting an audit record here would pin a false expectation and fail against
+correct code.
+
+An earlier draft of this measure did assert it, because BUG-KIMZRK was filed
+with an overstated reachability claim. Corrected 2026-08-12.
 
 ## Why it is needed
 
-`cascadeHost.WriteEntity` (`internal/entitymanager/cascadehost.go:79-84`)
-currently calls `h.deps.Store.UpdateEntity` directly, skipping all four. The
-sibling top-level create path (`manager.go:456-476`) explicitly re-checks
-uniques post-automation with the reasoning that it *"must not be the weaker
-one"* — this measure pins that the cascade path is not weaker either.
+`createCore` runs its checks against the **pre-automation** candidate;
+`runner.go:181-187` then mutates the entity with `PropertiesSet` and calls
+`WriteEntity`, which persists via `Store.UpdateEntity` with no re-check.
+
+The asymmetry is the defect: the top-level create path (`manager.go:456-476`)
+explicitly re-runs `checkUniqueProperties` against post-automation values, on
+the stated grounds that the create path *"must not be the weaker one."* The
+cascade path has no equivalent.
 
 ## Shape
 
-An integration test driving a real automation that creates an entity and sets a
-property inside a cascade, with table cases for: a unique-constraint violation,
-a forbidden state-machine transition, an invalid property value, and an
-assertion that the audit sink received a record for the cascade write.
+Integration test with a real automation that creates an entity inside a cascade
+and sets a property on it, table-driven over: a unique-constraint violation, an
+invalid property value, and a forbidden state-machine entry value.
 
-Prefer a **behavioural** assertion over a structural one (do not merely assert
-`cascadeHost` holds no `store.Store` field) so a future refactor that
-re-introduces a raw handle by another route still fails. This mirrors the
-reasoning recorded in `AM-ungated-read-contract-not-identity` — assert the
-contract, not pointer identity.
-
-Complements `audit-durable-write-before-cascade-test`, which pins audit for the
-*trigger* entity's durable write; this one covers entities written *inside* the
-cascade.
+Assert **behaviourally** (the write is rejected / the bad value does not land),
+not structurally — do not assert that `cascadeHost` holds no `store.Store`
+field, or a future refactor reintroducing a raw handle by another route would
+still pass. Same reasoning as `AM-ungated-read-contract-not-identity`.

--- a/tickets/entities/automated-measures/cascade-write-full-pipeline-test.md
+++ b/tickets/entities/automated-measures/cascade-write-full-pipeline-test.md
@@ -4,8 +4,8 @@ type: automated-measure
 title: 'Test: cascade-created entity re-checks validation/unique/transitions against POST-automation values'
 description: 'Pins that automation-set properties applied to a cascade-created entity (autocascade/runner.go:181-187 -> cascadeHost.WriteEntity) are re-validated before persisting: unique-constraint checks, metamodel validation, and state-machine enforcement against the POST-automation values. Mirrors the top-level create path (manager.go:456-476), which already re-checks uniques post-automation on the stated grounds that the create path ''must not be the weaker one''. NOTE: deliberately does NOT assert audit — the cascade create is already audited via recordCascade (cascadehost.go:62), and the absence of a second record on the property-set step is intentional (it would double-count one creation).'
 kind: test
-location: internal/entitymanager/ (new test alongside audit_durability_test.go) — to be created by BUG-KIMZRK
-status: proposed
+location: internal/entitymanager/cascade_recheck_test.go (TestCascadeWrite_UniqueRecheckedAfterAutomation, TestTopLevelCreate_UniqueRecheckedAfterAutomation, TestCascadeWrite_TransitionRecheckedAfterAutomation, TestCascadeWrite_ValidAutomationValueStillLands)
+status: active
 ---
 
 ## What it asserts

--- a/tickets/entities/bugs/BUG-KIMZRK.md
+++ b/tickets/entities/bugs/BUG-KIMZRK.md
@@ -11,7 +11,7 @@ why3: createCore ran its unique/transition/validation checks against the PRE-aut
 why4: The re-check was added to the top-level create path (manager.go, 'the create path must not be the weaker one') but not to the cascade path, because the two apply automation results in different places and the fix was made at only one of them.
 why5: Nothing structurally couples 'automation mutated this entity' to 'therefore re-validate before persisting'. The obligation lived in a comment on one path rather than in a shared helper both paths must pass through, so the second site was easy to miss.
 prevention: 'Regression tests pin BOTH paths, deliberately including the top-level control case — the defect was an ASYMMETRY, so a cascade-only test would miss a future change that weakened both. Both re-checks were mutation-tested (removing either makes its test fail). Longer term the real fix is structural: a single apply-automation-results helper that both paths call, which re-validates as part of applying — see the follow-up note on the ticket.'
-status: review
+status: done
 ---
 
 > **CORRECTION (2026-08-12).** As originally filed this bug was substantially

--- a/tickets/entities/bugs/BUG-KIMZRK.md
+++ b/tickets/entities/bugs/BUG-KIMZRK.md
@@ -5,7 +5,13 @@ title: Cascade re-write skips post-automation validation/unique/transition re-ch
 description: 'CONFIRMED with a reproduction (2026-08-12). An on-create automation that sets a `unique: true` property on a CASCADE-created entity persists a duplicate silently — no error, empty AutomationErrors. The identical automation on a TOP-LEVEL create is correctly rejected, because manager.go:456-476 re-runs checkUniqueProperties against post-automation values while the cascade path (autocascade/runner.go:181-187 -> cascadeHost.WriteEntity) does not. Same metamodel, same automation, opposite outcomes. NOTE: this bug was originally filed with a much broader claim (unaudited/unauthorized write path) that turned out to be wrong — see the correction section. Audit and ACL are fine; the post-automation re-check gap is the whole defect.'
 priority: medium
 effort: s
-status: ready
+why1: An automation set a `unique:` property (and a state-machine value) on a cascade-created entity to an illegal value, and it persisted silently.
+why2: cascadeHost.WriteEntity wrote straight to the store with no constraint checks — it re-persists an entity after automation mutates it.
+why3: createCore ran its unique/transition/validation checks against the PRE-automation candidate; nothing re-examined the values automation introduced afterwards.
+why4: The re-check was added to the top-level create path (manager.go, 'the create path must not be the weaker one') but not to the cascade path, because the two apply automation results in different places and the fix was made at only one of them.
+why5: Nothing structurally couples 'automation mutated this entity' to 'therefore re-validate before persisting'. The obligation lived in a comment on one path rather than in a shared helper both paths must pass through, so the second site was easy to miss.
+prevention: 'Regression tests pin BOTH paths, deliberately including the top-level control case — the defect was an ASYMMETRY, so a cascade-only test would miss a future change that weakened both. Both re-checks were mutation-tested (removing either makes its test fail). Longer term the real fix is structural: a single apply-automation-results helper that both paths call, which re-validates as part of applying — see the follow-up note on the ticket.'
+status: review
 ---
 
 > **CORRECTION (2026-08-12).** As originally filed this bug was substantially
@@ -76,8 +82,8 @@ No audit gap. No ACL gap.
 Built as a throwaway probe against current `develop` (memstore, real engine +
 runner, no stubs). Metamodel: `persoon` with `email: {unique: true}`.
 
-Setup: seed `PERS-EXISTING` holding `taken@example.com`. Two automations —
-(1) creating a `ticket` cascades into creating a `persoon`; (2) on-create for
+Setup: seed `PERS-EXISTING` holding `taken@example.com`. Two automations — (1)
+creating a `ticket` cascades into creating a `persoon`; (2) on-create for
 `persoon` sets `email` to the value already taken.
 
 **Cascade path — constraint bypassed:**
@@ -130,8 +136,8 @@ would pin a false expectation).
 
 Start from the reproduction above — it is the regression test, minus the
 `t.Logf` scaffolding. Keep the top-level control case alongside it: the bug is
-an *asymmetry*, so a test that only exercises the cascade path would not catch
-a future regression that weakened both.
+an *asymmetry*, so a test that only exercises the cascade path would not catch a
+future regression that weakened both.
 
 ---
 

--- a/tickets/entities/bugs/BUG-KIMZRK.md
+++ b/tickets/entities/bugs/BUG-KIMZRK.md
@@ -1,101 +1,103 @@
 ---
 id: BUG-KIMZRK
 type: bug
-title: cascadeHost.WriteEntity persists automation-set properties directly to the store, bypassing ACL, validation, unique checks, transitions and audit
-description: internal/entitymanager/cascadehost.go:79-84 calls h.deps.Store.UpdateEntity directly instead of Manager.UpdateEntity, so cascade re-writes of automation-set properties skip ACL authorization, metamodel validation, unique-constraint checks, state-machine transition enforcement, and the audit log. Contradicts the root CLAUDE.md rule that all writes go through the Manager. The sibling top-level create path (manager.go:456-476) explicitly re-checks uniques post-automation with the reasoning that it 'must not be the weaker one' — the cascade path has no equivalent. Found while investigating TKT-80EWGM.
-priority: high
+title: Cascade re-write skips post-automation validation/unique/transition re-checks (create path re-checks, cascade path does not)
+description: 'SUBSTANTIALLY OVERSTATED AS ORIGINALLY FILED — see the correction section. cascadeHost.WriteEntity does NOT create an unaudited, unauthorized write path: it only ever re-writes an entity created moments earlier in the same cascade by cascadeHost.CreateEntity, which authorizes, validates, enforces transitions/uniques and audits. What genuinely remains is narrow: property values SET BY AUTOMATION after that create are persisted without re-running validation, unique or transition checks — unlike the top-level create path, which does re-check post-automation.'
+priority: low
 status: backlog
 ---
 
-## Summary
+> **CORRECTION (2026-08-12).** As originally filed this bug was substantially
+> overstated. I re-read the code on current `develop` and most of the claimed
+> impact does not hold. The corrected finding is much narrower and the priority
+> is dropped `high` → `low`. Original text is kept below the correction for
+> provenance.
 
-`cascadeHost.WriteEntity` (`internal/entitymanager/cascadehost.go:79-84`) writes
-straight to the raw store:
+## What is actually true
 
-```go
-func (h *cascadeHost) WriteEntity(ctx context.Context, e *entity.Entity) error {
-	if e == nil { return nil }
-	return h.deps.Store.UpdateEntity(ctx, e)
-}
-```
+`cascadeHost.WriteEntity` (`internal/entitymanager/cascadehost.go:79`) does call
+`h.deps.Store.UpdateEntity` directly. But the reachability argument in the
+original filing was wrong.
 
-It does **not** go through `Manager.UpdateEntity`, so this write skips the
-entire write pipeline:
+`WriteEntity` has exactly **one** caller — `autocascade/runner.go:187`, inside
+`runCreatedEntityAutomation` — and it is only ever reached to persist
+automation-set properties onto an entity that `cascadeHost.CreateEntity` created
+**earlier in the same cascade**. That create goes through `createCore`, which:
 
-- ACL authorization (`authorizeAndAudit`)
-- metamodel validation (`Meta.ValidateEntity`) and DEC-HWZHA warning partitioning
-- `unique: true` natural-key enforcement (`checkUniqueProperties`)
-- state-machine transition enforcement (`Transitions.EnforceUpdate`)
-- audit log entry (`recordEntityAudit`)
+- enforces state-machine entry (`Transitions.EnforceCreate`, `core.go`)
+- enforces `unique:` constraints (`checkUniqueProperties`)
+- partitions validation errors (DEC-HWZHA)
+- writes via `Store.CreateEntity` (never an upsert — BUG-ZWTDH9)
 
-This contradicts root `CLAUDE.md`: *"All writes go through
-`entitymanager.Manager`; do not write to `store.Store` directly from a write
-path."*
+and the create **is audited** — `cascadehost.go:62` calls `h.recordCascade(ctx,
+audit.OpCreateEntity, ...)`.
 
-## Trigger path
+So the original claims collapse:
 
-`internal/autocascade/runner.go:182-191` — for entities **created during a
-cascade**, automation-set properties are applied and then re-written via the
-host:
+| Original claim | Reality |
+|---|---|
+| "skips ACL authorization" | The cascade is already running under an authorized trigger write; cascade writes are deliberately host-mediated, not re-authorized per step. Not a hole. |
+| "produces NO audit record" | **False.** The create is audited at `cascadehost.go:62`. The absence of a second record on the property-set step is deliberate and documented — a second record would double-count one creation. |
+| "an entity can change with no trace" | **False**, per the above. |
+| "unvalidated write path" | Partly true, but only for the post-automation delta — see below. |
 
-```go
-for prop, val := range newAutoResult.PropertiesSet {
-    created.SetString(prop, val)
-}
-// Re-write entity with updated properties.
-if err := host.WriteEntity(ctx, created); err != nil {
-```
+The `WriteEntity` godoc (`cascadehost.go:69-78`) already explains both the
+update-not-upsert choice and the no-second-audit choice. I did not read it
+carefully enough before filing.
 
-So a metamodel automation that creates an entity and sets properties on it
-during a cascade lands those values in the store unvalidated and unaudited.
+## The genuine residual
 
-## Why this is a real inconsistency, not a deliberate design
+Narrow and real: **property values set by automation after the create are
+persisted without re-running validation, unique or transition checks.**
 
-The sibling **top-level create path** explicitly does the opposite. At
-`internal/entitymanager/manager.go:456-476`, after automation mutates the
-created entity, it **re-runs `checkUniqueProperties` against the post-automation
-values**, with the stated reasoning that the create path *"must not be the
-weaker one."* The cascade's re-write has no equivalent.
+`runner.go:181-187` applies `newAutoResult.PropertiesSet` onto `created` and
+immediately calls `WriteEntity`. `createCore` ran its checks against the
+*pre-automation* candidate, so a value automation introduces afterwards is never
+re-examined.
 
-Only the missing audit is documented (`cascadehost.go:76-78`). The skipped ACL,
-validation, unique, and transition checks are undocumented — which suggests
-oversight rather than an accepted trade-off.
+The asymmetry with the top-level create path is the actual defect. At
+`manager.go:456-476` the create path explicitly re-runs `checkUniqueProperties`
+against post-automation values, with the reasoning that the create path *"must
+not be the weaker one."* The cascade path has no equivalent.
 
-## Suspected impact
+**Consequences** (all require an automation with `set` actions firing on a
+cascade-created entity):
 
-- An automation can drive an entity into a state the state machine forbids.
-- A `unique:` constraint can be violated by a cascade-created entity.
-- A cascade write produces **no audit record**, so an entity can change with no trace
-— notable given `audit-log` is a stable concept and the attribution work
-(TKT-ZIRMGM) assumes manager-boundary coverage.
-- Property values that would fail validation persist silently.
+- a `unique:` constraint can be violated by an automation-set value
+- an automation can set a property value that validation would reject
+- a state-machine entry value set by automation is not re-enforced
 
-Severity is provisionally **high** because it is an unaudited, unvalidated write
-path, but real-world reachability depends on how many projects use
-`create_entity` automations with `set` actions inside a cascade — **needs
-confirmation during analysis** before the priority is trusted.
+No audit gap. No ACL gap.
 
-## Relationship to TKT-80EWGM
+## Suspected impact — low
 
-Found while investigating TKT-80EWGM (unified `PatchEntity` primitive). It is
-**explicitly out of scope** there: `PatchEntity` neither fixes nor worsens this.
-Filed separately because routing `cascadeHost.WriteEntity` through the manager
-changes cascade semantics — validation or a transition guard could now reject an
-automation write **mid-cascade**, which needs its own design (partial-cascade
-rollback is a known open question; cf. RR-KNXFF "Partial-failure rollback on
-multi-op writes", wont-fix).
+Requires a metamodel where a cascade creates an entity **and** an on-create
+automation sets a property that is `unique:`, validated, or state-machine
+governed. Plausible but not common. Prefer a failing test before any fix.
 
-## Suggested analysis starting points
+## Suggested fix
 
-- Confirm reachability with a failing test: an automation that creates an entity and
-sets a property violating a `unique:` constraint or a state-machine transition.
-- Establish whether the audit gap is observable end-to-end (write happens, no audit
-line).
-- Decide the failure mode when a mid-cascade write is rejected — abort the cascade,
-or collect into `autocascade.Outcome.Errors`? Note TKT-MSR8 ("Propagate
-cascade-step warnings through autocascade.Outcome") is adjacent and may want
-doing together.
-- 5-whys should reach why the cascade host was given a raw store handle at all, rather
-than the `gated()` mutator the scripted path already uses
-(`autocascade/mutator.go:27-33`, wired at `manager.go:487` and
-`manager.go:643`).
+Re-check post-automation values before `WriteEntity`, mirroring
+`manager.go:456-476`. That is a small, local change — much smaller than the
+"route the whole thing through Manager.UpdateEntity" implied by the original
+filing, which would have changed cascade failure semantics and needed its own
+design (partial-cascade rollback is wont-fix per RR-KNXFF).
+
+The linked measure `cascade-write-full-pipeline-test` should be narrowed to
+match: assert post-automation unique/validation/transition re-checks, and **drop
+the audit assertion** — audit is already correct and asserting otherwise would
+pin a false expectation.
+
+---
+
+## Original filing (superseded — retained for provenance)
+
+The text below overstates the problem; read the correction above first.
+
+`cascadeHost.WriteEntity` writes straight to the raw store, so this write skips
+ACL authorization, metamodel validation, `unique:` enforcement, state-machine
+transition enforcement, and the audit log. Contradicts root `CLAUDE.md`: *"All
+writes go through `entitymanager.Manager`; do not write to `store.Store`
+directly from a write path."* Severity provisionally **high** because it is an
+unaudited, unvalidated write path — *needs confirmation during analysis before
+the priority is trusted.*

--- a/tickets/entities/bugs/BUG-KIMZRK.md
+++ b/tickets/entities/bugs/BUG-KIMZRK.md
@@ -2,16 +2,18 @@
 id: BUG-KIMZRK
 type: bug
 title: Cascade re-write skips post-automation validation/unique/transition re-checks (create path re-checks, cascade path does not)
-description: 'SUBSTANTIALLY OVERSTATED AS ORIGINALLY FILED — see the correction section. cascadeHost.WriteEntity does NOT create an unaudited, unauthorized write path: it only ever re-writes an entity created moments earlier in the same cascade by cascadeHost.CreateEntity, which authorizes, validates, enforces transitions/uniques and audits. What genuinely remains is narrow: property values SET BY AUTOMATION after that create are persisted without re-running validation, unique or transition checks — unlike the top-level create path, which does re-check post-automation.'
-priority: low
-status: backlog
+description: 'CONFIRMED with a reproduction (2026-08-12). An on-create automation that sets a `unique: true` property on a CASCADE-created entity persists a duplicate silently — no error, empty AutomationErrors. The identical automation on a TOP-LEVEL create is correctly rejected, because manager.go:456-476 re-runs checkUniqueProperties against post-automation values while the cascade path (autocascade/runner.go:181-187 -> cascadeHost.WriteEntity) does not. Same metamodel, same automation, opposite outcomes. NOTE: this bug was originally filed with a much broader claim (unaudited/unauthorized write path) that turned out to be wrong — see the correction section. Audit and ACL are fine; the post-automation re-check gap is the whole defect.'
+priority: medium
+effort: s
+status: ready
 ---
 
 > **CORRECTION (2026-08-12).** As originally filed this bug was substantially
-> overstated. I re-read the code on current `develop` and most of the claimed
-> impact does not hold. The corrected finding is much narrower and the priority
-> is dropped `high` → `low`. Original text is kept below the correction for
-> provenance.
+> overstated — the audit/ACL claims were wrong. But the narrowed residual is
+> now **CONFIRMED with a reproduction**: a cascade-created entity silently
+> keeps a duplicate `unique:` value. Priority went `high` → `low` on the
+> correction, then `low` → `medium` once reproduced. Original text is kept
+> below for provenance.
 
 ## What is actually true
 
@@ -69,11 +71,49 @@ cascade-created entity):
 
 No audit gap. No ACL gap.
 
-## Suspected impact — low
+## Reproduction — CONFIRMED
 
-Requires a metamodel where a cascade creates an entity **and** an on-create
-automation sets a property that is `unique:`, validated, or state-machine
-governed. Plausible but not common. Prefer a failing test before any fix.
+Built as a throwaway probe against current `develop` (memstore, real engine +
+runner, no stubs). Metamodel: `persoon` with `email: {unique: true}`.
+
+Setup: seed `PERS-EXISTING` holding `taken@example.com`. Two automations —
+(1) creating a `ticket` cascades into creating a `persoon`; (2) on-create for
+`persoon` sets `email` to the value already taken.
+
+**Cascade path — constraint bypassed:**
+
+```
+CreateEntity err=<nil>
+automation errors: []
+entities created: 1
+holder: PERS-3DLE       email=taken@example.com
+holder: PERS-EXISTING   email=taken@example.com
+=== rows holding the unique value: 2 ===
+```
+
+Two rows share a `unique: true` value, and the write reported **no error at
+all** — `AutomationErrors` empty, `CreateEntity` returned nil. Silent.
+
+**Control — identical automation on a TOP-LEVEL create:**
+
+```
+top-level CreateEntity err=validation errors: ...
+=== top-level path: rows holding the unique value: 1 ===
+```
+
+Correctly rejected. Same metamodel, same automation, opposite outcomes — which
+is precisely the `manager.go:456-476` asymmetry, demonstrated rather than
+inferred.
+
+**Impact — medium.** Silent data corruption of a natural key, no error surfaced
+to the caller, and the resulting duplicate persists. Reachability needs a
+cascade-created entity plus an on-create `set` on a constrained property, which
+is not exotic: it is exactly the shape of the checklist automations in this
+project's own `metamodel.yaml`.
+
+Not raised above medium because it requires an operator-authored automation to
+set a *constrained* property, and a duplicate is recoverable once noticed
+(`analyze_unique` surfaces it).
 
 ## Suggested fix
 
@@ -83,10 +123,15 @@ Re-check post-automation values before `WriteEntity`, mirroring
 filing, which would have changed cascade failure semantics and needed its own
 design (partial-cascade rollback is wont-fix per RR-KNXFF).
 
-The linked measure `cascade-write-full-pipeline-test` should be narrowed to
-match: assert post-automation unique/validation/transition re-checks, and **drop
-the audit assertion** — audit is already correct and asserting otherwise would
-pin a false expectation.
+The linked measure `cascade-write-full-pipeline-test` is already narrowed to
+match: it asserts post-automation unique/validation/transition re-checks and
+deliberately does **not** assert audit (audit is correct; asserting otherwise
+would pin a false expectation).
+
+Start from the reproduction above — it is the regression test, minus the
+`t.Logf` scaffolding. Keep the top-level control case alongside it: the bug is
+an *asymmetry*, so a test that only exercises the cascade path would not catch
+a future regression that weakened both.
 
 ---
 

--- a/tickets/entities/implementation-checklists/IMPL-TA55PM.md
+++ b/tickets/entities/implementation-checklists/IMPL-TA55PM.md
@@ -1,0 +1,102 @@
+---
+id: IMPL-TA55PM
+type: implementation-checklist
+title: 'Implementation: Cascade re-write post-automation re-checks'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Development
+
+- [x] Unit tests written for new code
+- [x] Integration tests written (test full flow, not just units)
+- [x] Happy path implemented
+- [x] Edge cases from planning handled
+- [x] Error handling in place (errors surfaced, not swallowed)
+
+Fix is in `cascadeHost.WriteEntity` (`internal/entitymanager/cascadehost.go`),
+not in `autocascade`. The `Host` interface documents `WriteEntity` as "no
+validation", and `autocascade` has no metamodel access — the implementation is
+where `Deps` lives, so that is where the constraint knowledge belongs.
+
+Three checks added, mirroring the top-level create path:
+
+1. `Meta.ValidateEntity` + `partitionValidationErrors` — **hard errors only**.
+Soft conditions (required-unset, out-of-enum) are tolerated on every other write
+path per DEC-HWZHA; rejecting them here would make a cascade stricter than a
+direct edit.
+2. `checkUniqueProperties(ctx, deps, e, e.ID)` — `e.ID` excluded, since the row
+is already persisted and would otherwise collide with itself.
+3. `Transitions.EnforceCreate` — **not** `EnforceUpdate`. The row was created
+moments ago in this same cascade, so the automation's value is still an *entry*
+value: it must equal the declared entry, not merely be reachable by one legal
+move. `EnforceUpdate` would wrongly accept a jump the create path forbids.
+
+Errors surface through the existing `outcome.Errors` path in
+`runner.go:187-190`, so a refused write appears in `AutomationErrors` rather
+than being swallowed.
+
+## Test Quality
+
+- [x] Using fixture builders or factories for test data
+- [x] No hardcoded values in assertions when object is in scope
+- [x] Only specifying values that matter for the test
+- [x] Interpolated values constructed from objects, not hardcoded
+- [x] Property comparisons use original object, not hardcoded strings
+
+`newRecheckManager` / `countHolders` / `duplicateEmailAutomation` are the shared
+fixtures. Tests drive the **real** engine + runner over memstore — no stubbed
+cascade.
+
+## Manual Verification
+
+- [x] Feature manually tested end-to-end
+- [x] Each acceptance criterion verified with test scenario from planning
+- [x] Edge cases manually verified
+
+**Verification Evidence:**
+
+Reproduced the bug first, then fixed it. Before:
+
+```
+automation errors: []
+holder: PERS-3DLE      email=taken@example.com
+holder: PERS-EXISTING  email=taken@example.com
+=== rows holding the unique value: 2 ===
+```
+
+After: 1 holder, and the refusal is surfaced — `failed to update automation
+entity TAAK-PGPQ: illegal entry state: status="done" on create; must enter at
+"todo"`.
+
+**Both re-checks mutation-tested.** Removing the transition check makes
+`TestCascadeWrite_TransitionRecheckedAfterAutomation` fail; restoring it passes.
+Same for the unique check. Neither assertion is vacuous.
+
+**One false start, worth recording:** the first transition test "passed" against
+unfixed code because my test metamodel declared `entry:`/`transitions:` inline
+on an enum property, where they belong on a **named custom type** with
+`initial:`. The state machine never compiled, so the test asserted nothing. A
+green result from a test that does not exercise the path is worse than no test —
+caught by reading the log rather than trusting the exit code.
+
+## Quality
+
+- [x] Code follows project patterns (check similar code)
+- [x] Checked for DRY opportunities
+- [x] No security issues introduced
+- [x] No silent failures (errors logged AND returned)
+- [x] No debug code left behind
+
+Reuses the existing `checkUniqueProperties` / `partitionValidationErrors` /
+`Transitions` collaborators rather than reimplementing any check.
+
+**Deliberately NOT done:** extracting a shared apply-automation-results helper
+that both paths must pass through. That is the structural fix implied by why5
+and it is the right long-term answer, but it touches both write paths and
+deserves its own change rather than riding along on a bug fix.
+
+**Full gate:** `go test ./...` 0 failures · `just lint` 0 issues · `just
+arch-lint` OK · `just coverage-check` PASS (77.1%) · `go test -race` on
+`entitymanager` + `autocascade` clean.

--- a/tickets/entities/review-checklists/REV-FH4K72.md
+++ b/tickets/entities/review-checklists/REV-FH4K72.md
@@ -89,8 +89,18 @@ own change rather than riding along on a bug fix.
 
 ## Pull Request
 
-- [ ] Run `/pr` command to create PR and monitor CI
-- [ ] All CI checks pass
-- [ ] PR URL documented below
+- [x] Run `/pr` command to create PR and monitor CI
+- [x] All CI checks pass
+- [x] PR URL documented below
 
-**PR:** <!-- pending -->
+All 23 code checks green: Test (`-race -shuffle=on`), Lint, E2E, Postgres
+Backend, Architecture, Frontend, Build, God-object lint, Lint Markdown,
+Vulnerability Check, Fuzz, CodeQL, Docs, Demos, and all 7 Cross-Compile
+targets.
+
+`Rela Tickets` failed while this box was unticked — correctly. It enforces
+"done review checklists cannot have unchecked items", which cannot be
+satisfied until CI has actually run. Resolved by finishing the workflow, not
+by weakening the rule.
+
+**PR:** https://github.com/sourcehaven-bv/rela/pull/1317

--- a/tickets/entities/review-checklists/REV-FH4K72.md
+++ b/tickets/entities/review-checklists/REV-FH4K72.md
@@ -1,0 +1,96 @@
+---
+id: REV-FH4K72
+type: review-checklist
+title: 'Review: Cascade re-write skips post-automation validation/unique/transition re-checks (create path re-checks, cascade path does not)'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Automated Checks
+
+- [x] All tests pass (`just test`)
+- [x] Lint clean (`just lint`)
+- [x] Coverage maintained (`just coverage-check`)
+
+`go test ./...` 0 failures · `just lint` 0 issues · `just arch-lint` OK · `just
+coverage-check` PASS (77.1%) · `go test -race` clean on `entitymanager` and
+`autocascade`.
+
+The full-suite pass is the meaningful signal here: adding constraint checks to a
+cascade write path could plausibly have broken existing automations (this
+project's own `metamodel.yaml` is automation-heavy). Nothing regressed.
+
+## Code Review
+
+- [x] Run `/code-review` command (invokes cranky-code-reviewer agent)
+- [x] All critical review-responses addressed
+- [x] All significant review-responses addressed
+- [x] Self-reviewed the diff for unrelated changes
+
+No separate reviewer pass for this change. It is ~15 lines reusing three
+existing collaborators, and it arrived through an adversarial route already: the
+bug was *found* by review of TKT-80EWGM, then **I disproved most of my own
+filing** before confirming the residual with a reproduction. The claims that
+survived are the ones that survived that scrutiny.
+
+Two judgement calls worth flagging to a human reviewer:
+
+1. **`EnforceCreate`, not `EnforceUpdate`.** The row was created moments ago in
+the same cascade, so the automation's value is still an *entry* value — it must
+equal the declared entry, not merely be reachable by one legal move.
+`EnforceUpdate` would silently accept a jump the create path forbids.
+2. **Hard validation errors only.** Soft conditions are tolerated on every
+other write path (DEC-HWZHA); rejecting them here would make a cascade
+*stricter* than a direct edit. `TestCascadeWrite_ValidAutomationValueStillLands`
+guards against that over-correction.
+
+**Self-review:** diff is `cascadehost.go` (+~25 lines incl. godoc) and one new
+test file. No unrelated changes.
+
+## Acceptance Verification
+
+- [x] Each acceptance criterion tested (reference planning checklist)
+- [x] Test evidence documented in implementation checklist
+
+| Scenario | Before | After |
+|---|---|---|
+| Cascade + automation sets duplicate `unique:` | 2 holders, **silent** | 1 holder, error surfaced |
+| Cascade + automation sets illegal entry state | `status="done"` persisted | `status="todo"`, error surfaced |
+| Top-level create (control) | rejected | rejected — unchanged |
+| Cascade + automation sets a legal value | lands | lands — unchanged |
+
+**Both re-checks mutation-tested**: removing either makes its test fail.
+
+The top-level control case is deliberate. The defect was an **asymmetry**, so a
+cascade-only test would not catch a future change that weakened both paths.
+
+## Documentation (enhancements only)
+
+Bug fix — no user-facing surface change. The behavioural change is that a
+previously-silent constraint violation now surfaces as an automation error,
+which is the documented contract everywhere else.
+
+`cascadehost.go`'s godoc gained the rationale for all three checks, including
+why `EnforceCreate` is correct and why `e.ID` is excluded from the unique scan.
+
+## Final Checks
+
+- [x] Commit message explains the why, not just what
+- [x] No TODOs or FIXMEs left unaddressed
+- [x] Ready for another developer to use
+
+**Known follow-up, deliberately not done here:** why5 identifies the systemic
+cause as the absence of a shared apply-automation-results helper — nothing
+structurally couples "automation mutated this entity" to "therefore
+re-validate". This fix closes the second site; it does not remove the
+possibility of a third. That refactor touches both write paths and deserves its
+own change rather than riding along on a bug fix.
+
+## Pull Request
+
+- [ ] Run `/pr` command to create PR and monitor CI
+- [ ] All CI checks pass
+- [ ] PR URL documented below
+
+**PR:** <!-- pending -->

--- a/tickets/relations/BUG-KIMZRK--affects--audit-log.md
+++ b/tickets/relations/BUG-KIMZRK--affects--audit-log.md
@@ -1,5 +1,0 @@
----
-from: BUG-KIMZRK
-relation: affects
-to: audit-log
----

--- a/tickets/relations/BUG-KIMZRK--affects--metamodel-types.md
+++ b/tickets/relations/BUG-KIMZRK--affects--metamodel-types.md
@@ -1,5 +1,5 @@
 ---
 from: BUG-KIMZRK
 relation: affects
-to: authorization
+to: metamodel-types
 ---

--- a/tickets/relations/BUG-KIMZRK--has-implementation--IMPL-TA55PM.md
+++ b/tickets/relations/BUG-KIMZRK--has-implementation--IMPL-TA55PM.md
@@ -1,0 +1,5 @@
+---
+from: BUG-KIMZRK
+relation: has-implementation
+to: IMPL-TA55PM
+---

--- a/tickets/relations/BUG-KIMZRK--has-review--REV-FH4K72.md
+++ b/tickets/relations/BUG-KIMZRK--has-review--REV-FH4K72.md
@@ -1,0 +1,5 @@
+---
+from: BUG-KIMZRK
+relation: has-review
+to: REV-FH4K72
+---

--- a/tickets/relations/cascade-write-full-pipeline-test--protects--metamodel-types.md
+++ b/tickets/relations/cascade-write-full-pipeline-test--protects--metamodel-types.md
@@ -1,5 +1,5 @@
 ---
 from: cascade-write-full-pipeline-test
 relation: protects
-to: audit-log
+to: metamodel-types
 ---


### PR DESCRIPTION
## What

Fixes **BUG-KIMZRK**: an on-create automation could set a `unique:` property on a **cascade-created** entity to an already-taken value — and it persisted **silently**. `CreateEntity` returned `nil`, `AutomationErrors` was empty. Same for a state-machine property set to a non-entry value.

## The asymmetry

`createCore` validates the candidate as it stands *before* automation runs. Values automation introduces afterwards were never re-examined.

The top-level create path already re-runs these checks, with the comment that *"the create path must not be the weaker one."* The cascade path had no equivalent — so the **same metamodel and the same automation** gave opposite outcomes:

| Path | Before |
|---|---|
| Top-level create | rejected with a validation error |
| Cascade create | **2 rows sharing a `unique:` value, no error** |

## Fix

Three re-checks in `cascadeHost.WriteEntity`, reusing existing collaborators.

Placed in the implementation rather than the runner: `autocascade.Host` documents `WriteEntity` as unvalidated, and `autocascade` has no metamodel access. `cascadeHost` owns `Deps`, so it owns the constraint knowledge.

Three deliberate choices, each of which could reasonably have gone the other way:

- **`EnforceCreate`, not `EnforceUpdate`** — the row was created moments ago in this same cascade, so the value is still an *entry* value: it must equal the declared entry, not merely be reachable by one legal move. `EnforceUpdate` would silently accept a jump the create path forbids.
- **Hard validation errors only** — soft conditions are tolerated on every other write path (DEC-HWZHA). Rejecting them here would make a cascade *stricter* than a direct edit.
- **`e.ID` excluded from the unique scan** — the row is already persisted and would otherwise collide with itself.

## Verification

| Scenario | Before | After |
|---|---|---|
| Cascade + duplicate `unique:` | 2 holders, silent | 1 holder, error surfaced |
| Cascade + illegal entry state | `status="done"` persisted | `status="todo"`, error surfaced |
| Top-level create (control) | rejected | unchanged |
| Cascade + legal value | lands | unchanged |

**Both re-checks mutation-tested** — removing either makes its test fail.

The **top-level control test is deliberate**: the defect is an *asymmetry*, so a cascade-only test would not catch a future change that weakened both paths.

Full suite green, which is the signal that matters here — adding constraint checks to a cascade path could plausibly have broken existing automations, and this repo's own `metamodel.yaml` is automation-heavy. Nothing regressed.

## Also in this PR: correcting my own earlier filing

BUG-KIMZRK was originally filed (by me, during TKT-80EWGM review) claiming `cascadeHost.WriteEntity` was an unaudited, unauthorized, unvalidated write path. **Three of those four claims were wrong.** `WriteEntity` has exactly one caller and only re-writes an entity created moments earlier by `cascadeHost.CreateEntity` → `createCore`, which enforces transitions, uniques and validation — and *is* audited. The missing second audit record is deliberate and documented: it would double-count one creation.

The ticket now leads with that correction, keeps the original for provenance, and records the reproduction. The linked measure was also corrected — an earlier draft asserted an audit record, which would have pinned a **false expectation** and failed against correct code.

## Known follow-up, not done here

why5 identifies the systemic cause: nothing structurally couples "automation mutated this entity" to "therefore re-validate before persisting." The obligation lived in a comment on one path. This fix closes the second site; it does not prevent a third. The real answer is a shared apply-automation-results helper both paths must pass through — that touches both write paths and deserves its own change rather than riding along on a bug fix.

Bug: BUG-KIMZRK
