### PR TITLE
refactor(appbuild): explicit DSN option instead of ambient env read (TKT-1J5KEV)

### DIFF
--- a/cmd/rela-server/main.go
+++ b/cmd/rela-server/main.go
@@ -117,9 +117,11 @@ func parseFlags() *serverFlags {
 	flag.StringVar(&f.webhookAction, "webhook-action", envOr("RELA_WEBHOOK_ACTION", ""),
 		"Name of the action a verified IdP webhook dispatches to (e.g. idp-sync). The action "+
 			"receives event/user_id/org_id as params and provisions the user.")
-	// Note: there is no --database-url flag. The postgres build reads the DSN
-	// from $RELA_DATABASE_URL only, so the credential never lands in process
-	// listings or shell history. See appbuild.Config.DatabaseURL.
+	// Note: there is no --database-url flag, and must not be. The postgres
+	// build takes the DSN from $RELA_DATABASE_URL (or, for an embedding
+	// caller, appbuild.WithDatabaseURL) — never from argv, so the credential
+	// cannot land in process listings or shell history.
+	// See appbuild.Config.DatabaseURL.
 	flag.Parse()
 	if os.Getenv("RELA_READ_ONLY") == "1" {
 		f.readOnly = true

--- a/internal/appbuild/appbuild.go
+++ b/internal/appbuild/appbuild.go
@@ -512,6 +512,12 @@ type Option func(*options)
 
 type options struct {
 	acl acl.ACL
+
+	// databaseURL, when non-empty, supplies the DSN that [Discover] would
+	// otherwise read from the environment. Consumed by [Discover] only:
+	// [New] takes the DSN from [Config.DatabaseURL], because a caller
+	// building a Config already decides where the data lives.
+	databaseURL string
 }
 
 // WithACL overrides the auto-loaded ACL with the supplied
@@ -526,6 +532,45 @@ type options struct {
 // path directly.
 func WithACL(a acl.ACL) Option {
 	return func(o *options) { o.acl = a }
+}
+
+// WithDatabaseURL supplies the PostgreSQL DSN explicitly, instead of letting
+// [Discover] read it from $RELA_DATABASE_URL. The option always wins over the
+// environment, so a caller that knows where a project's data lives never has to
+// mutate process state to say so.
+//
+// This exists so that *which database a project uses* is an argument rather than
+// an ambient property. Two [Services] can then be constructed in one process
+// against different databases — impossible via the environment, which is global
+// and shared. `rela-desktop` already builds a fresh bundle per project switch,
+// and a future multi-tenant server resolves a DSN per tenant.
+//
+// The invariant this must not break: a DSN carries a password, so it must never
+// reach a command line. Passing one here in Go code is fine — sourcing it from a
+// flag is not. See [Config.DatabaseURL].
+//
+// Ignored by the FS and memory builds, which have no DSN.
+func WithDatabaseURL(dsn string) Option {
+	return func(o *options) { o.databaseURL = dsn }
+}
+
+// resolveDatabaseURL decides which DSN [Discover] hands to [New]: an explicit
+// [WithDatabaseURL] wins, otherwise $RELA_DATABASE_URL. getenv is injected so
+// the precedence is testable without mutating process environment — which is
+// itself the ambient-state problem this seam removes.
+//
+// Split out of Discover because on the FS and memory builds the resolved DSN is
+// never consumed, so a test could not otherwise distinguish "option honored"
+// from "option ignored" without a live PostgreSQL.
+func resolveDatabaseURL(opts []Option, getenv func(string) string) string {
+	var o options
+	for _, opt := range opts {
+		opt(&o)
+	}
+	if o.databaseURL != "" {
+		return o.databaseURL
+	}
+	return getenv("RELA_DATABASE_URL")
 }
 
 // loadACLPolicy reads `acl.yaml` from projectRoot and returns the
@@ -645,12 +690,20 @@ type Config struct {
 	ScriptEngine *script.Engine
 	Audit        audit.Audit
 
-	// DatabaseURL is the PostgreSQL connection string, sourced from the
-	// RELA_DATABASE_URL environment variable (see [Discover]). It is
-	// deliberately env-only — never a command-line flag — so the
-	// credential-bearing DSN does not leak into process listings or shell
-	// history. Consumed only by the postgres build; empty (and ignored) in
-	// the FS/memory builds.
+	// DatabaseURL is the PostgreSQL connection string. The caller decides
+	// where it comes from: [Discover] takes it from [WithDatabaseURL] or, as a
+	// fallback, $RELA_DATABASE_URL; a caller building a Config directly (e.g.
+	// rela-desktop, or a per-tenant lookup) simply sets it.
+	//
+	// The invariant is that a DSN must **never reach a command line** — it
+	// carries a password, and a flag would put it in `ps` output and shell
+	// history. That is why no binary exposes a --database-url flag. It is NOT
+	// an invariant that the value come from the environment; passing it in Go
+	// code is fine and is what makes two differently-backed Services
+	// constructible in one process.
+	//
+	// Consumed only by the postgres build; empty (and ignored) in the
+	// FS/memory builds.
 	DatabaseURL string
 }
 
@@ -678,11 +731,13 @@ func (c Config) validate() error {
 // engine; production callers pass [script.NewEngine].
 //
 // Discover constructs a production [audit.Filesystem] under
-// .rela/audit/ and resolves the database URL (postgres build) from the
-// RELA_DATABASE_URL environment variable — env-only, so the credential
-// never appears on a command line. The entry point caller is responsible
-// for stamping [principal.Principal] onto the request context (this varies
-// per binary — cli, mcp, scheduler, data-entry server).
+// .rela/audit/ and resolves the database URL (postgres build) from
+// [WithDatabaseURL] when supplied, falling back to the RELA_DATABASE_URL
+// environment variable. Neither source is a command-line flag, which is the
+// property that matters: a DSN carries a password and must not land in `ps`
+// output or shell history. The entry point caller is responsible for stamping
+// [principal.Principal] onto the request context (this varies per binary — cli,
+// mcp, scheduler, data-entry server).
 func Discover(startDir string, scriptEngine *script.Engine, opts ...Option) (*Services, error) {
 	fs := storage.NewSafeFS(storage.NewOsFS())
 	paths, err := project.Discover(startDir, fs)
@@ -693,12 +748,13 @@ func Discover(startDir string, scriptEngine *script.Engine, opts ...Option) (*Se
 	if auditErr != nil {
 		return nil, fmt.Errorf("build audit sink: %w", auditErr)
 	}
+
 	return New(Config{
 		FS:           fs,
 		Paths:        paths,
 		ScriptEngine: scriptEngine,
 		Audit:        auditSink,
-		DatabaseURL:  os.Getenv("RELA_DATABASE_URL"),
+		DatabaseURL:  resolveDatabaseURL(opts, os.Getenv),
 	}, opts...)
 }
 

--- a/internal/appbuild/databaseurl_internal_test.go
+++ b/internal/appbuild/databaseurl_internal_test.go
@@ -1,0 +1,103 @@
+package appbuild
+
+import "testing"
+
+// The DSN is consumed only by the postgres recipe, so on the FS and memory
+// builds an end-to-end assertion cannot tell "option honored" from "option
+// ignored" — a test written against Discover alone passes even when the option
+// is dropped on the floor. (RES-S8CH9C records the same trap for the advisory
+// lock keys: the obvious regression test passed against deliberately broken
+// code.) These assert the resolution rule directly instead, with getenv
+// injected so precedence is observable without mutating process environment.
+func TestResolveDatabaseURL(t *testing.T) {
+	const (
+		fromOption = "postgres://option/db"
+		fromEnv    = "postgres://environment/db"
+	)
+
+	env := func(v string) func(string) string {
+		return func(key string) string {
+			if key != "RELA_DATABASE_URL" {
+				return ""
+			}
+			return v
+		}
+	}
+
+	for _, tc := range []struct {
+		name   string
+		opts   []Option
+		getenv func(string) string
+		want   string
+	}{
+		{
+			// The property the seam exists for: a caller that knows where the
+			// data lives is not overridden by process-global state.
+			name:   "explicit option beats a set environment",
+			opts:   []Option{WithDatabaseURL(fromOption)},
+			getenv: env(fromEnv),
+			want:   fromOption,
+		},
+		{
+			// Every existing call site passes no option and must keep working.
+			name:   "no option falls back to the environment",
+			getenv: env(fromEnv),
+			want:   fromEnv,
+		},
+		{
+			name:   "option applies when the environment is unset",
+			opts:   []Option{WithDatabaseURL(fromOption)},
+			getenv: env(""),
+			want:   fromOption,
+		},
+		{
+			name:   "neither source set yields empty",
+			getenv: env(""),
+			want:   "",
+		},
+		{
+			// An empty option must not shadow a usable environment value —
+			// otherwise WithDatabaseURL(someUnsetVar) would silently break a
+			// deployment that relies on the env.
+			name:   "empty option does not suppress the environment",
+			opts:   []Option{WithDatabaseURL("")},
+			getenv: env(fromEnv),
+			want:   fromEnv,
+		},
+		{
+			name:   "last option wins",
+			opts:   []Option{WithDatabaseURL("postgres://first/db"), WithDatabaseURL(fromOption)},
+			getenv: env(fromEnv),
+			want:   fromOption,
+		},
+		{
+			// WithDatabaseURL must not disturb unrelated options.
+			name:   "coexists with other options",
+			opts:   []Option{WithACL(nil), WithDatabaseURL(fromOption)},
+			getenv: env(fromEnv),
+			want:   fromOption,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := resolveDatabaseURL(tc.opts, tc.getenv); got != tc.want {
+				t.Errorf("resolveDatabaseURL() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestResolveDatabaseURL_ReadsOnlyItsOwnVariable guards against a future
+// refactor widening the ambient surface this ticket set out to narrow.
+func TestResolveDatabaseURL_ReadsOnlyItsOwnVariable(t *testing.T) {
+	var asked []string
+	getenv := func(key string) string {
+		asked = append(asked, key)
+		return ""
+	}
+
+	resolveDatabaseURL(nil, getenv)
+
+	if len(asked) != 1 || asked[0] != "RELA_DATABASE_URL" {
+		t.Errorf("read environment %v, want exactly [RELA_DATABASE_URL]", asked)
+	}
+}

--- a/internal/cli/kong.go
+++ b/internal/cli/kong.go
@@ -164,9 +164,10 @@ func runKong() int {
 	var bundles *cliBundles
 	if requiresProject(ktx.Command()) {
 		var err error
-		// The postgres build reads its DSN from $RELA_DATABASE_URL inside
-		// Discover (env-only — no flag — so the credential never lands on a
-		// command line). The filesystem build ignores it.
+		// The postgres build resolves its DSN inside Discover, from
+		// $RELA_DATABASE_URL unless a caller supplies appbuild.WithDatabaseURL.
+		// Neither is a flag, so the credential never lands on a command line.
+		// The filesystem build ignores it.
 		svc, err = appbuild.Discover(projectPath, script.NewEngine())
 		if err != nil {
 			fmt.Fprintln(os.Stderr, relaerrors.WrapDiscoverError(err))

--- a/tickets/entities/researchs/RES-D54281.md
+++ b/tickets/entities/researchs/RES-D54281.md
@@ -1,0 +1,290 @@
+---
+id: RES-D54281
+type: research
+title: 'Multi-tenant SaaS rela: one operator config, N tenant orgs (schema-per-tenant, org_id -> DSN)'
+summary: 'SaaS shape: ONE operator-authored config (metamodel/acl/templates/scripts) served to N tenants whose only difference is content. Storage: schema-per-tenant, apartment-style shared pool with SET search_path. Tenant resolution: verified org_id -> DSN via a rela-owned map (NOT a JWT claim, NOT Pratique). Requires: shared NOTIFY channel (decouples live updates from per-tenant connections), sweep keeps a dedicated conn, appbuild split into shared-config + per-tenant-store, scheduler iterates tenants. Provisioning: eager IdP webhook + lazy first-request backstop, single-flighted, 202+poll. Erasure: DROP SCHEMA CASCADE + documented backup-retention SLA + an audit-log decision. Supersedes RES-S8CH9C, which scoped a DIFFERENT problem (N different projects + switcher).'
+status: done
+---
+
+## Problem
+
+An operator authors one rela config — metamodel, `acl.yaml`, `data-entry.yaml`,
+templates, scripts, actions — and wants to ship it as a **SaaS to many tenant
+orgs**. Every tenant runs the *same application*; only the **content** differs,
+because each is its own org. Tenants map to Pratique orgs via the verified
+`org_id` claim. Hard requirement: **no cross-tenant data leaks**.
+
+Process-per-tenant is explicitly rejected as the target — this is about making
+rela work as a multi-tenant SaaS in one process (or a fleet), not about
+sidestepping it with OS isolation.
+
+**This is a different problem from RES-S8CH9C** and supersedes it. That document
+scoped *N different projects* (ticketing + ISMS) in one process with a switcher,
+and its costs were dominated by per-project config divergence. Here the config
+is **uniform by definition**, which deletes most of that cost. See "What uniform
+config deletes" below.
+
+## Context
+
+### Already built (do not rebuild)
+
+| Piece | State |
+|---|---|
+| ES256 JWT verification vs JWKS, `aud`/`iss` pinned, fail-closed | `internal/jwtauth/verifier.go` |
+| `org_id` / `org_slug` / `roles` on `Principal`, forge-proof (unexported + `principal.Verified` sole constructor) | `principal.go:68-76,84` |
+| Claims reaching ACL on the **production** path | Shipped, TKT-OJL2GN — `jwtgate.go:146` calls `VerifyAssertion` |
+| `asserted_role_assignments` (IdP claim → rela role) | `acl/policy.go:112`, resolver `resolver.go:57-65` — grants without a graph walk |
+| All four advisory locks schema-scoped (migrate/write/sweep/purge) | Shipped — R1, #1217 + BUG-CA3VY0 |
+| Schema-scoped NOTIFY channel | `feed.go:42,65-74` |
+| N isolated schemas on one DB, per-schema pools | `pgstore/testdb_test.go:88-116` — already routine in the test harness |
+| IdP webhook carrying `org_id`, self-authenticating (separate `aud`) | `dataentry/webhook.go:174`, `verifier.go:238-249` |
+| Attachment bytes in the DB | `pgstore/attachment.go:57` — a schema holds ALL tenant data |
+| Search in-DB (`pg_trgm` + tsvector) | `pgstore/open.go:43-46` — no index files |
+
+**`pgstore` has no schema config field at all.** Schema is purely the
+connection's `search_path` (`current_schema()` derives the channel and all lock
+keys). Schema-per-tenant needs **zero pgstore changes**.
+
+### What uniform config deletes
+
+RES-S8CH9C's cost model assumed per-project config. Under one shared config:
+
+- `metamodel.yaml`, `acl.yaml`, `data-entry.yaml` — **one copy, loaded once**. No
+per-tenant divergence, no per-tenant reload, no restart coupling between
+tenants.
+- `templates/`, `scripts/`, `actions/`, `apps/`, `custom.css` — **one root**. The
+per-request disk reads (`fstemplater.go:27`, `executor.go:249`, `action.go:170`,
+`apps.go:94`, `custom.go:169`) are **no longer a tenant boundary** — they read
+the operator's single project root. Their `projectRoot string` threading stops
+being a leak risk and becomes a pure caching question.
+- `.rela/secrets.yaml`, `.rela/ai.yaml` — the **operator's**, not the tenant's.
+Shared. (Re-read per Lua runtime at `lua/context.go:21-41`; a perf fix, not a
+correctness one.)
+- `script.Engine`'s process-wide Lua cache (`executor.go:29-45`) — sharing is now
+**correct**, not contamination, since the scripts are identical.
+- `cmdexec` process-global confinement (`sandbox_options.go:78`) — fine; it is the
+operator's uniform policy.
+
+**What remains tenant-scoped is exactly the data**: entities, relations,
+attachments, search, versions, audit — all in Postgres under the postgres build.
+
+### The gap
+
+`docs/acl-security.md:288` and `principal.go:100-103` state it: `org_id` is
+**recorded, not enforced**. A principal in org A holding a role sees everything
+that role grants in *every* org, and `TestAssertedRoles_OrgIsNotEvaluated` pins
+the absence. `internal/acl` is **union semantics with no deny primitive**
+(`declarative.go:24-33`), so "deny unless org matches" cannot be expressed as a
+role rule — enforcement must be a separate mechanism.
+
+**In this design it is not an ACL rule at all.** Isolation comes from the
+tenant's store handle: a request resolved to tenant T can only reach schema T,
+so a cross-tenant read is "relation does not exist", not a missing `WHERE`. The
+ACL keeps doing what it already does *within* a tenant.
+
+## Options
+
+### Option 1: Process-per-tenant
+- **Approach**: One rela process + one DB per tenant, proxy routes on `org`.
+- **Pros**: Leak-proof by construction; zero rela changes; matches the existing
+fleet pattern (openvwr = VM pair + own DB + own pgBackRest stanza + own restore
+drill; rela already deploys per-instance as "atlas").
+- **Cons**: Not SaaS — per-tenant provisioning is an ops event, cost scales
+linearly, no path to self-serve signup. **Explicitly rejected by the operator.**
+- **Effort**: none
+
+### Option 2: Tenant column on every table
+- **Approach**: `tenant_id` on entities/relations/attachments/versions.
+- **Cons**: `entities.id` is a bare `TEXT PRIMARY KEY` (`0001_init.sql:31`); a
+tenant column makes every PK/FK composite and propagates to ~20 indexes across 6
+migrations, plus `AND tenant_id = $n` on every query. **Miss one and it is a
+silent cross-tenant leak with no compile error.** `rela_seq`/`version_seq`
+interleave across tenants, muddying the change-feed watermark. The write
+advisory lock is schema-wide (`tx.go:71`), so **all tenants' writes serialize**.
+- **Effort**: large, and permanently leak-prone. **Rejected.**
+
+### Option 3: Schema-per-tenant, apartment-style (CHOSEN)
+- **Approach**: One shared config; per-tenant store handle resolved from verified
+`org_id` through a rela-owned `org_id → DSN` map; shared pool with `SET
+search_path` per checkout.
+- **Pros**: Isolation from Postgres itself, not from correct code. Zero pgstore
+changes. Promotes an existing, exercised test pattern. `(tenant) → DSN`
+preserves DB-per-tenant and cluster-sharding as pure config changes. Clean GDPR
+erasure (`DROP SCHEMA CASCADE`).
+- **Cons**: Needs the refactors below (sweep connection discipline, shared NOTIFY
+channel, appbuild split, scheduler). Migrations run N times with mixed-version
+states. Schema names become a trust boundary needing strict validation
+(`^[a-z][a-z0-9_]{0,30}$`).
+- **Effort**: large but incremental; every step stands alone.
+
+## Recommendation
+
+**Option 3, built incrementally.** Design decisions below.
+
+### Storage and connection model
+
+Pool-per-tenant is the naive form and hits a ceiling fast: untuned pgx pool
+(`max(4, numCPU)`) + a dedicated LISTEN connection + the sweep ≈ **17
+connections/tenant**, so ~20 tenants against `max_connections=100`.
+
+**Apartment-style**: one shared pool, `SET search_path` per checkout. Two things
+in the current code fight it and must be handled:
+
+1. **The version sweep must keep a dedicated connection per tenant.** It takes a
+*session-scoped* `pg_try_advisory_lock` and deliberately runs its whole tick on
+one acquired connection — issuing inserts via the pool would "silently void the
+single-writer guarantee" (`sweep.go` doc, `:162-167`). Rotating `search_path` on
+a shared pool breaks that assumption.
+2. **LISTEN/NOTIFY needs a dedicated session per channel**, and channels are
+per-schema (`rela_changed_<schema>`). So live updates cost one connection per
+tenant *regardless of pooling* — this, not the pool, is the real ceiling.
+
+### Single shared NOTIFY channel (prerequisite, not optional)
+
+Collapse `rela_changed_<schema>` to **one channel with the schema in the
+payload**: `feed.go:65-74` stops resolving per-schema names, the payload gains a
+schema field, `listener.go` filters instead of subscribing per-tenant. This
+takes live updates from **one connection per tenant to one per process** and
+removes the ceiling without new infrastructure.
+
+**Redis pub/sub is the right answer later, not now.** Its genuine win is
+**cross-cluster** fan-out: once tenants shard across DB clusters, Postgres
+NOTIFY cannot fan out beyond its own cluster. But it adds an operational
+dependency and message-loss semantics that must be reconciled against the
+existing `seq > watermark` catch-up (`listener.go:213-285`), which is
+per-schema-sequence and does not trivially port. Shared channel now; revisit
+Redis when sharding.
+
+### Tenant → DSN map: owned by rela, NOT Pratique
+
+**Decided (2026-08-13, with the user).** Pratique is the authority on org
+*identity*; rela owns the map from org to *storage*.
+
+- Pratique mints `org_id` (already does) and posts `org.created` to the existing
+IdP webhook. The interface between the two systems is **exactly one stable
+string**.
+- rela owns `org_id → DSN` in its own store, plus provisioning.
+
+Rationale — the decisive argument is **coupling**: storage topology in an
+identity token would mean Pratique knows about database clusters, and every
+rebalance or tier-promotion becomes a Pratique deployment. It would also break
+`jwtauth`'s deliberate provider-agnosticism ("any proxy that injects a signed
+JWT — oauth2-proxy, Pomerium, Keycloak, Pratique — works"), since rela would
+depend on a Pratique-specific claim.
+
+A secondary, **weaker** argument is credential hygiene: a DSN is a durable
+credential and a JWT is signed-not-encrypted, so it would land in proxy access
+logs and rela's own JWT failure logs. Note this is **server-side only** —
+Pratique injects the assertion proxy-side as `Authorization: Bearer` and strips
+inbound `Authorization` (`proxy.go:323`); **the browser never holds the JWT**.
+So this is a handling-hygiene point within the trust boundary, not an
+interception risk. It supports the decision; it does not carry it.
+
+Deployment of the map is a **rela scaling decision**: same cluster for small
+deployments, its own small boringly-hosted cluster at scale (it cannot live
+inside the thing it shards — recursion). The **lookup must be a single seam**:
+one interface, one cache with explicit invalidation. Keep that true and "where
+the map lives" stays a config change.
+
+**Feature request to Pratique — only this**: org enumeration or `org.created`
+event replay, as the reconciliation backstop for missed webhooks. That is a
+legitimate IdP feature; storage topology is not.
+
+### Sharding: cluster == N tenants
+
+`(tenant) → DSN` resolving to a different **host** composes with
+schema-per-tenant (shard to a cluster, then schema within it).
+
+**Pick N from blast radius, not resource headroom.** Cluster-sharding is not
+primarily a vertical-scaling escape — connections and CPU are fixed by the
+shared channel plus pooling. A cluster is the unit of **failover, `pg_upgrade`,
+and a bad migration**: 500 tenants on one cluster means one bad afternoon
+affects 500 tenants. Also supports **pooled tiers** — most tenants share, a
+tenant that outgrows or contractually requires isolation gets promoted to its
+own database.
+
+### Provisioning: eager webhook + lazy backstop
+
+- **Eager**: Pratique `org.created` → webhook → create schema + `pgstore.Migrate`.
+Fast first request; failures are loud and early where retry is easy.
+- **Lazy**: verified-but-unknown org on a request → provision on the spot. Makes a
+missed webhook self-healing.
+- **Both.** Eager is the fast path, lazy is the backstop.
+- **Single-flight the lazy path.** `pgstore.Migrate` is already concurrent-start
+safe (one tx under `pg_advisory_xact_lock(key, hashtext(current_schema()))`,
+`migrate.go:63-67`), so a herd serializes rather than corrupts — but put a
+single-flight in front so nine requests wait on one instead of queuing.
+- **Return `202` + a status the SPA polls**; do not hold an HTTP request open
+across schema creation. Holding it turns a slow migration into a timeout with a
+half-created tenant.
+
+**Write down the trust assumption**: verified-org-never-seen is an
+*authorization* decision, not just a trigger. Pratique guarantees `org_id` is
+always present on the verified path and an orgless session never receives an
+assertion at all — so unknown means new, not malicious. That is a property of
+**this IdP with `aud` pinned**, and it stops holding the day a second issuer
+exists. Anyone who can mint an assertion can create schemas.
+
+### Scheduler
+
+No blocker; mechanical. One loop **iterating tenants** (not N loops), stamping
+`principal.Verified` with the tenant's org instead of the current plain literal
+(`scheduler.go:110`), resolving a per-tenant store handle per task.
+`WorkspaceProvider` is already narrow (4 methods) and `ScheduledLuaWriteDeps()`
+is explicitly identity-agnostic and safe to rebuild per task (DEC-O59WM4). It
+builds its own `script.Engine` — correct to share here, since config is uniform.
+
+### GDPR erasure
+
+`DROP SCHEMA CASCADE` erases entities, relations, attachments (bytes are in the
+DB), search, and version history in one statement. Two residues to decide now:
+
+1. **pgBackRest PITR backups** retain a dropped schema for the retention window.
+Standard answer: retention expiry *is* the erasure SLA — document "erased within
+N days", not "immediately".
+2. **The audit log** is filesystem JSONL (`appbuild.go:692`), shared across
+tenants here, recording entity ids/types/principals. `DROP SCHEMA` does not
+touch it. Not a *leak* (tenants have no disk access — it is operator-oriented),
+but it **is retained personal data outside the erasure boundary**. Existing
+`history-purge` tooling is per-entity and CLI-only, so it does not cover this.
+Decide: per-tenant sink, tenant field + retention policy, or documented
+exclusion. `audit.Audit` is a one-method interface, so a per-tenant or DB-backed
+sink is a drop-in; the only hardcoding is one `filepath.Join`.
+
+### The main refactor
+
+**`appbuild.Services` bundles config and store as one unit** (one `Services` =
+one metamodel + one store, `appbuild.go:70-102`). This model needs them split:
+**shared config, per-tenant store**. That split is the spine of the work.
+
+Ordering note: `attachACLRequest` opens exactly one `acl.Request` per request
+(`router.go:307`) and it already holds the verified principal — the natural
+place to also carry the resolved tenant scope. Do **not** put per-request tenant
+logic on `App`, which is at its plimsoll line (`max-methods=90`,
+ratchet-down-only).
+
+### Known fail-open traps to respect
+
+- Zero-value `ReadQueryResult` **aliases `AllowAll`**; two sites fail loud on it
+deliberately (`api_v1.go:303`, `request.go:142`). Any new verdict type inherits
+this.
+- `nopReadGate.HoldsPermission` returns `true` unconditionally
+(`readgate.go:135`) — under `NopACL` a gate-only predicate **fails open**
+(RR-CWWJGW).
+- Rebuilding a `Principal` with a plain composite literal **silently drops org and
+roles** — live scar at `router.go:380-382`.
+- Non-HTTP entry points (`scheduler.go:110`, `cli/kong.go:158`,
+`mcp/server.go:148`) build principals from **plain literals** and have no org.
+Decide deliberately what a CLI/MCP write means in a SaaS deployment.
+
+### First ticket
+
+**R2 — make the DSN an explicit parameter.** `appbuild.Discover` still reads
+`os.Getenv("RELA_DATABASE_URL")` ambiently (`appbuild.go:701`);
+`Config.DatabaseURL` is already per-instance, so only `Discover` is ambient — 7
+shallow call sites (`cmd/rela-server`, `cmd/rela-docs`, `internal/docscapture`,
+`internal/cli/{mcp_wiring,flow,kong,validate}`). Every tier above resolves to "a
+DSN per tenant"; the ambient read is the single thing keeping tenant count an
+architecture question instead of an ops one. Justifies itself independently
+(ambient env reads are untestable and surprising in a second context). Keep the
+credential out of argv (`main.go:120-122`).

--- a/tickets/entities/researchs/RES-S8CH9C.md
+++ b/tickets/entities/researchs/RES-S8CH9C.md
@@ -2,8 +2,8 @@
 id: RES-S8CH9C
 type: research
 title: 'Multi-app rela-server: serving several projects (ticketing, ISMS, …) from one process with a switcher'
-summary: 'Multi-app rela-server as a horizon, reached by independently-justified refactorings. Storage: schema-per-project (DSN is the seam preserving DB-per-tenant and (tenant,project)->shard). Cross-project is a federation feature that must work ACROSS INSTALLS, so it is not a storage-layout tradeoff. Tenancy: control-plane-as-rela-project + wire the existing VerifyAssertion claims. R1 (schema-qualify advisory locks) is a latent bug to fix first.'
-status: done
+summary: 'SUPERSEDED by RES-D54281 for the SaaS case. This doc scoped a DIFFERENT problem: N DIFFERENT projects (ticketing + ISMS) in one process with a switcher, where per-project config divergence dominated the cost. RES-D54281 scopes multi-tenant SaaS — ONE operator config, N tenants differing only in content — which deletes most of that cost. Still-valid and reused by RES-D54281: schema-per-project over a tenant column, the (tenant)->DSN invariant, the connection-ceiling analysis, and R2 (explicit DSN) as the next thing to bank. Now STALE here: R6 shipped (TKT-OJL2GN — the gate calls VerifyAssertion, so org/roles DO reach the ACL); R1 shipped.'
+status: superseded
 ---
 
 ## Problem
@@ -213,32 +213,32 @@ Ordered by independence. Each is justified without committing to multi-tenancy �
 that is the point.
 
 **R1 — Schema-qualify the advisory lock keys. ✅ DONE.** All three of pgstore's
-advisory locks used unqualified compile-time constants, but PG advisory locks are
-**database-wide**, so two schemas on one database contended on all three.
+advisory locks used unqualified compile-time constants, but PG advisory locks
+are **database-wide**, so two schemas on one database contended on all three.
 Severity varied sharply, which is why the fix arrived in two parts:
 
 - **Version sweep** — the severe one. Non-blocking `pg_try_advisory_lock` plus a
-  silent `return nil` on failure meant the losing schema's version capture was
-  **dropped with no error, warning or metric**. Fixed independently by **#1217
-  (TKT-SCXHUL)**, which surfaced it when parallel postgres e2e workers starved
-  each other. Uses the two-key form
-  `pg_try_advisory_lock(key, hashtext(current_schema()))`.
+silent `return nil` on failure meant the losing schema's version capture was
+**dropped with no error, warning or metric**. Fixed independently by **#1217
+(TKT-SCXHUL)**, which surfaced it when parallel postgres e2e workers starved
+each other. Uses the two-key form `pg_try_advisory_lock(key,
+hashtext(current_schema()))`.
 - **Migrate + write Tx** — blocking rather than lossy, so nothing forced them
-  into view. Fixed under **BUG-CA3VY0**, adopting #1217's idiom rather than a
-  competing mechanism.
+into view. Fixed under **BUG-CA3VY0**, adopting #1217's idiom rather than a
+competing mechanism.
 
 Two things worth carrying forward from doing this:
 
 1. **The low-severity instances of a defect outlive the high-severity one.** The
-   sweep variant got fixed because it lost data visibly; the identical root cause
-   in migrate and write survived that pass. When fixing a class of bug, grep for
-   the class, not the symptom.
+sweep variant got fixed because it lost data visibly; the identical root cause
+in migrate and write survived that pass. When fixing a class of bug, grep for
+the class, not the symptom.
 2. **A regression test for lock scoping is easy to write and useless.** Holding
-   the *scoped* key and asserting the other schema proceeds passes even against
-   the un-fixed code — Postgres treats one-key and two-key advisory locks as
-   disjoint spaces, so the bare-key regression takes a lock nobody holds. The
-   first draft of the tests did exactly this and passed against a deliberately
-   broken build. Only a fail-before check caught it.
+the *scoped* key and asserting the other schema proceeds passes even against the
+un-fixed code — Postgres treats one-key and two-key advisory locks as disjoint
+spaces, so the bare-key regression takes a lock nobody holds. The first draft of
+the tests did exactly this and passed against a deliberately broken build. Only
+a fail-before check caught it.
 
 This was **not** a multi-tenancy prerequisite — it was a latent bug in the
 current single-project design, since the conformance harness already runs many

--- a/tickets/entities/tickets/TKT-1J5KEV.md
+++ b/tickets/entities/tickets/TKT-1J5KEV.md
@@ -1,0 +1,149 @@
+---
+id: TKT-1J5KEV
+type: ticket
+title: 'appbuild: make the database DSN an explicit parameter instead of an ambient env read'
+kind: refactor
+priority: medium
+effort: s
+status: backlog
+---
+
+## Description
+
+`appbuild.Discover` reads `os.Getenv("RELA_DATABASE_URL")` directly
+(`internal/appbuild/appbuild.go:701`). Make the DSN an explicit input so that
+*where a project's data lives* is decided by the caller, not by process
+environment.
+
+`Config.DatabaseURL` is **already** a per-`Config` field
+(`appbuild.go:648-654`), and `appbuild.New` is already fine — it takes the DSN
+from the caller. **Only `Discover` is ambient.** This is a small, contained
+change.
+
+### Why (stands on its own)
+
+An ambient env read is the classic testability problem: a test that wants to
+point `Discover` at a specific database has to mutate process environment, which
+is global and order-dependent under `t.Parallel()`. It is also
+surprise-in-a-second-context — the value silently changes meaning when a second
+project is constructed in one process, which `rela-desktop` already does on
+every project switch (`cmd/rela-desktop/main.go:125-205`).
+
+### Why it also matters later
+
+Multi-tenant SaaS (RES-D54281) resolves every tenant to a DSN — `search_path` on
+one cluster today, a different host once tenants shard across clusters. That
+whole range stays reachable **only** while a single lookup decides where data
+lives. The ambient read is the one thing keeping tenant count an architecture
+question instead of an ops one. RES-S8CH9C named this "the seam that preserves
+every storage option at zero cost now"; the sibling refactor R1 (schema-scoped
+advisory locks) shipped on the same principle and paid for itself as a plain bug
+fix.
+
+**This ticket does not build multi-tenancy.** It removes one ambient read.
+
+## Scope
+
+**In scope**
+
+- Add an option (e.g. `appbuild.WithDatabaseURL(dsn string)`) so callers pass the
+DSN explicitly. Follow the existing `Option` pattern used by `WithACL`
+(`appbuild.go:518-522`).
+- Keep `Discover`'s env read as the **default** when no option is supplied, so
+every current caller keeps working unchanged.
+- Prefer the explicit option over the env var when both are present, and make
+that precedence a test.
+- Update the `Discover` and `Config.DatabaseURL` doc comments — they currently
+assert env-only sourcing as a security property (see the constraint below).
+
+**Out of scope**
+
+- Any tenant resolution, `org_id` mapping, or per-tenant store handles.
+- Splitting `appbuild.Services` into shared-config + per-tenant-store (the main
+refactor in RES-D54281; this ticket is a prerequisite, not that work).
+- Changing `pgstore` — it already takes a DSN and nothing else
+(`pgstore.Open(ctx, dsn)`), which is why this seam works.
+
+## Call sites
+
+Six non-test callers of `appbuild.Discover`, all shallow — each simply gets the
+option threaded through or keeps the env default:
+
+| Site | Note |
+|---|---|
+| `cmd/rela-server/main.go:149` | via `discoverProject`, already passes `discoverOptions(f)...` |
+| `cmd/rela-docs/main.go:69` | |
+| `internal/docscapture/server.go:81` | |
+| `internal/cli/mcp_wiring.go:43` | already passes `WithACL(acl.NopACL{})` |
+| `internal/cli/kong.go:170` | |
+| `internal/cli/flow.go:43` | |
+| `internal/cli/validate.go:83` | |
+
+(`rela-desktop` calls `appbuild.New` directly with an explicit `Config`, so it
+is already correct and needs no change.)
+
+## Load-bearing constraint: keep the credential out of argv
+
+**Do not add a `--database-url` flag.** There is deliberately none today
+(`cmd/rela-server/main.go:120-122`, and the `Config.DatabaseURL` godoc at
+`appbuild.go:648-653`): a DSN carries a password, and a flag would put it in
+`ps` output and shell history. The rule is *not a flag*, not *env-only* — an
+option passed in Go code by a caller that got the DSN from env, a config file,
+or a tenant lookup is fine and is the point of this change.
+
+The godoc currently phrases the guarantee as "sourced from the RELA_DATABASE_URL
+environment variable... deliberately env-only". Reword to state the actual
+invariant (never on a command line) so the next reader does not think the env
+read itself is the security property and re-inline it.
+
+## Acceptance criteria
+
+1. `appbuild.Discover` no longer reads `os.Getenv` when a DSN option is supplied.
+2. With no option supplied, `Discover` behaves exactly as today (env read),
+and every existing call site compiles and behaves unchanged.
+3. An explicit DSN option takes precedence over a set `RELA_DATABASE_URL`, pinned
+by a test.
+4. A test constructs two `Services` in one process against two different DSNs
+without touching process environment. This is the property the whole ticket
+exists for.
+5. No `--database-url` flag is added to any binary; `rela-server --help` is
+unchanged.
+6. Godoc on `Discover` and `Config.DatabaseURL` states the invariant as
+"never on a command line" rather than "env-only".
+7. `just arch-lint` and `just ci` pass.
+
+## Do not consolidate the call sites
+
+Considered and **rejected** (2026-08-13). The four `internal/cli` sites look like
+duplication but differ in ways a shared helper would have to re-expose:
+
+- `kong.go:170` is conditional on `requiresProject(ktx.Command())`, owns
+  `defer svc.Close()`, and its error path prints `relaerrors.WrapDiscoverError`
+  and returns an exit code.
+- `flow.go:43` starts from a directory derived from a **script path**, not the
+  project flag, and deliberately replaces the error with
+  `"no project found for script %s"`.
+- `validate.go:83` runs *after* an early return on `result.MetamodelError`, so it
+  cannot be hoisted to a common point.
+- `mcp_wiring.go:43` passes `WithACL(acl.NopACL{})` behind a documented
+  trust-boundary justification.
+
+A helper covering all four would take a start dir, an options slice, and an
+error-wrapping strategy — i.e. it would be `appbuild.Discover` with a layer on
+top, and it would bury the `NopACL` opt-out that is currently explicit. It would
+also change control flow and user-facing error strings in four commands, turning
+a mechanically behaviour-preserving refactor into one needing regression review.
+
+**Do** clean up while touching these lines: `flow.go:43` and `validate.go:83`
+carry an identical `//nolint:contextcheck` comment, and `kong.go:167-169` has a
+comment asserting the env-only rule that this ticket rewords (see the argv
+constraint above). Comment fixes only — no structural change.
+
+## Notes
+
+- The postgres recipe already validates a non-empty DSN in its own `openBackend`
+(`appbuild_postgres.go:48-51`); `Config.validate()` deliberately only nil-checks
+the four build-agnostic fields (`appbuild.go:660-674`). Keep that split — do not
+move DSN validation into `validate()`, since FS/memory builds ignore the field.
+- `MigrateDSN` / `StatusDSN` (`pgstore/open.go:80-98`) and the `db` commands read
+the env directly and are **not** part of this ticket.

--- a/tickets/relations/RES-D54281--informs--TKT-1J5KEV.md
+++ b/tickets/relations/RES-D54281--informs--TKT-1J5KEV.md
@@ -1,0 +1,5 @@
+---
+from: RES-D54281
+relation: informs
+to: TKT-1J5KEV
+---

--- a/tickets/relations/RES-D54281--researches--authorization.md
+++ b/tickets/relations/RES-D54281--researches--authorization.md
@@ -1,0 +1,5 @@
+---
+from: RES-D54281
+relation: researches
+to: authorization
+---

--- a/tickets/relations/RES-D54281--researches--data-entry-server.md
+++ b/tickets/relations/RES-D54281--researches--data-entry-server.md
@@ -1,0 +1,5 @@
+---
+from: RES-D54281
+relation: researches
+to: data-entry-server
+---

--- a/tickets/relations/RES-D54281--researches--store-backends.md
+++ b/tickets/relations/RES-D54281--researches--store-backends.md
@@ -1,0 +1,5 @@
+---
+from: RES-D54281
+relation: researches
+to: store-backends
+---

--- a/tickets/relations/TKT-1J5KEV--affects--store-backends.md
+++ b/tickets/relations/TKT-1J5KEV--affects--store-backends.md
@@ -1,0 +1,5 @@
+---
+from: TKT-1J5KEV
+relation: affects
+to: store-backends
+---

--- a/tickets/relations/TKT-1J5KEV--implements--FEAT-CO4YP.md
+++ b/tickets/relations/TKT-1J5KEV--implements--FEAT-CO4YP.md
@@ -1,0 +1,5 @@
+---
+from: TKT-1J5KEV
+relation: implements
+to: FEAT-CO4YP
+---


### PR DESCRIPTION
Makes the PostgreSQL DSN an explicit input to `appbuild.Discover` instead of an
ambient `os.Getenv` read. Small, behaviour-preserving, and the first step of the
multi-tenant SaaS work (RES-D54281) — but it stands on its own.

Ticket: TKT-1J5KEV. Design: RES-D54281.

## Why

An ambient env read is the classic testability problem: pointing `Discover` at a
specific database means mutating process environment, which is global and
order-dependent under `t.Parallel()`. It is also surprise-in-a-second-context —
the value silently changes meaning when a second project is built in one
process, which `rela-desktop` already does on every project switch.

`Config.DatabaseURL` was **already** a per-`Config` field and `appbuild.New` was
already correct. Only `Discover` was ambient.

## What changed

- New `appbuild.WithDatabaseURL(dsn)`, following the existing `WithACL` option
  pattern. The option wins; `$RELA_DATABASE_URL` remains the fallback, so all
  six existing call sites are untouched and behave exactly as before.
- Resolution extracted to `resolveDatabaseURL(opts, getenv)` — see testing note.
- Godoc reworded on `Discover` and `Config.DatabaseURL`.

## The security invariant was stated wrong, and is now stated right

The old godoc asserted the DSN is "deliberately env-only" as a security
property. It isn't. The actual invariant is that a password-bearing DSN must
**never reach a command line** (`ps` output, shell history) — which is why no
binary exposes `--database-url`, and that stays true here. Passing a DSN in Go
code is fine and is precisely what makes two differently-backed `Services`
constructible in one process.

Left as-is, the next reader would treat the env read itself as load-bearing and
re-inline it. Same reasoning applied to the stale comments in
`cmd/rela-server/main.go` and `internal/cli/kong.go`.

## Testing note: the obvious test was useless

The DSN is consumed only by the postgres recipe, so on the FS build it is inert
— an end-to-end test against `Discover` **passes even when the option is dropped
on the floor**. My first pass did exactly that. This is the trap RES-S8CH9C
recorded for the advisory-lock keys ("only a fail-before check caught it").

Fixed by extracting `resolveDatabaseURL` with `getenv` injected, so precedence
is directly assertable without mutating process environment — which is itself
the ambient-state problem being removed. Verified by reverting the logic and
confirming failure, for two distinct breakages:

- dropping option-honouring → 4 subtests fail
- letting an empty option shadow the env → 1 subtest fails

That last case is a plausible real bug: `WithDatabaseURL(someUnsetVar)` must not
silently kill a deployment that relies on the environment.

## Deliberately NOT done

**The four `internal/cli` call sites are not consolidated.** They look like
duplication but differ in ways a shared helper would have to re-expose:
`kong.go` is conditional and owns `defer svc.Close()` plus an exit code;
`flow.go` starts from a script path and rewrites the error; `validate.go` runs
after an early return; `mcp_wiring.go` passes `WithACL(NopACL{})` behind a
documented trust-boundary justification. A helper covering all four would be
`Discover` plus a layer, and would bury that opt-out — while changing control
flow and user-facing error strings in four commands inside a refactor whose
value is being provably behaviour-preserving. Rationale recorded in the ticket.

Also out of scope: tenant resolution, `org_id` mapping, splitting
`appbuild.Services`. `MigrateDSN`/`StatusDSN` and the `db` commands still read
the env directly, deliberately.

## Verification

- `go build ./...` and `go build -tags postgres ./...`
- full `go test ./...` passes
- `just arch-lint` clean, `golangci-lint` clean
- coverage 77.1%, floors pass
- no `--database-url` flag anywhere (only comments asserting its absence)

Also included: RES-D54281 (the multi-tenant SaaS design this unblocks) and
RES-S8CH9C marked `superseded` — it scoped a different problem (N *different*
projects with a switcher), and two of its recommendations have since shipped.