### PR TITLE
feat(acl): client attenuation — restrict a client below its acting user (TKT-IAC8TX)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,6 +48,28 @@
   Never substitute a no-op or sentinel implementation silently — that
   defers the failure to a downstream symptom that is much harder to
   diagnose.
+- **Restrictions compile at LOAD time; the evaluator has no denial
+  primitive.** Client attenuation (`client_baselines` / `scope_grants`,
+  TKT-IAC8TX) restricts a client below the user it acts as, but it does so
+  by compiling into plain allowlists when `acl.yaml` loads — `redact:
+  {person: [salary]}` becomes "person's permitted fields, minus salary".
+  `decideFromAttrs`, `readQuery`, `grantsPermission` and `FieldVerdicts`
+  keep seeing allowlists, so DEC-RG878's additive union semantics are
+  intact. **Do not add a runtime deny.** `ReadQuery` compiles to a
+  `store.GraphQuery` pushed into SQL, so a runtime denial would have to
+  become a SQL predicate in every backend, and every evaluation path plus
+  all of `internal/aclmap` would need re-deriving.
+
+  The clamp point is `Request.roleFor` — every evaluation path resolves
+  role names through it, so reaching into `policy.Roles[...]` directly
+  from a new path silently bypasses the ceiling. A guard test
+  (`ceilingguard_test.go`) scans the package and fails on that; it uses an
+  exemption list, so a new file must be clean or explicitly exempted.
+
+  A ceiling only ever NARROWS (`effective = user_grants ∩ (baseline ∪
+  scopes)`), so a bug fails toward less access — except in the compilation
+  step, which is why that has direct unit tests rather than only
+  end-to-end ones.
 - **Read-out paths go through visibility wrappers, base readers stay
   ungated.** Read-side ACL (entity row-gating + field-level `visible:`
   redaction) is enforced by `internal/visibility` decorators

--- a/cmd/rela-server/main.go
+++ b/cmd/rela-server/main.go
@@ -349,6 +349,11 @@ func wireWebhookReceiver(app *dataentry.App, f *serverFlags, idv *jwtauth.Verifi
 // The gate consumes VerifyAssertion (not VerifySubject) so the assertion's
 // org/roles reach the Principal it stamps; a subject-only adapter here would
 // silently strip every asserted role (TKT-OJL2GN).
+//
+// The same applies to principal_type/scope (TKT-IAC8TX), with the failure
+// running the other way: dropping a role removes access, dropping a
+// principal_type removes the CEILING and hands a restricted client its acting
+// user's full grants. Every claim this adapter forgets is a silent widening.
 type assertionVerifierAdapter struct{ v *jwtauth.Verifier }
 
 func (a assertionVerifierAdapter) VerifyAssertion(
@@ -359,10 +364,12 @@ func (a assertionVerifierAdapter) VerifyAssertion(
 		return dataentry.AssertedIdentity{}, err
 	}
 	return dataentry.AssertedIdentity{
-		Subject: c.Subject,
-		OrgID:   c.OrgID,
-		OrgSlug: c.OrgSlug,
-		Roles:   c.Roles,
+		Subject:       c.Subject,
+		OrgID:         c.OrgID,
+		OrgSlug:       c.OrgSlug,
+		Roles:         c.Roles,
+		PrincipalType: c.PrincipalType,
+		Scopes:        c.Scopes,
 	}, nil
 }
 

--- a/docs-project/entities/guides/GUIDE-acl-overview.md
+++ b/docs-project/entities/guides/GUIDE-acl-overview.md
@@ -303,6 +303,184 @@ The resolver's decisions:
 - **A drive-by anonymous request:** `Deny`. `ErrUnstampedPrincipal`
   surfaces; the request never reaches `AuthorizeWrite`.
 
+## Restricting a client below its user
+
+Everything above answers "what may this *person* do". Client attenuation
+answers a different question: **what may this person do *through this
+client*.**
+
+The case is any external tool acting on a person's behalf — an MCP
+server, a CI script, an integration, a personal access token pasted into
+something you did not write — where you want a *guarantee* about what it
+can reach, independent of how much the person driving it can reach.
+
+Concretely: an HR user connects an MCP server. It acts with their
+identity, so by default it can read `person.salary`, and it can delete
+things, because they can. Client attenuation lets an operator say: this
+client sees less, and can destroy less, than the person driving it.
+
+The guarantee is what matters. Trusting the tool to behave, or the
+person to only ask it for safe things, is not one — a ceiling holds
+regardless of what the tool does or is told to do.
+
+```yaml
+client_baselines:
+  apps:
+    applies_to: [app]          # matches the verified principal_type claim
+    deny_write: ["*"]          # read-only
+    redact:
+      person: [salary, bsn]    # hidden even though the user may see them
+
+scope_grants:
+  rela.tickets.write:          # matches a value in the `scope` claim
+    update: [ticket]           # hands one capability back
+```
+
+The whole model is one line:
+
+```text
+effective = user_grants ∩ (baseline ∪ matched scope_grants)
+```
+
+Read as a diagram — what the client actually gets is the overlap, and
+nothing outside the user's own circle is reachable at all:
+
+```mermaid
+graph LR
+    subgraph U["What the USER may do"]
+        direction TB
+        UO["person.salary · delete ticket<br/>(user-only: the ceiling removes these)"]
+        E["EFFECTIVE<br/>read ticket · read person.name<br/>update ticket via scope"]
+    end
+    subgraph C["What the CEILING permits<br/>baseline ∪ scopes"]
+        direction TB
+        CO["types the user was never granted<br/>(named by the ceiling, but the user<br/>lacks them — so still denied)"]
+    end
+    E -.->|"the overlap IS the answer"| C
+
+    style E fill:#c8e6c9,stroke:#388e3c,stroke-width:2px
+    style UO fill:#ffe0b2,stroke:#e65100
+    style CO fill:#eceff1,stroke:#90a4ae,stroke-dasharray: 4 3
+```
+
+`CO` is the half that trips people up: a ceiling naming a capability
+does not confer it. Listing `read: [audit-record]` in a baseline grants
+nothing to a user who was never granted audit-records — the ceiling is
+an upper bound, never a source.
+
+Two consequences follow, and both matter:
+
+- **A ceiling never grants.** The intersection with the acting user's
+  own grants means a token cannot exceed its user, whatever it claims.
+  A read-only user presenting a write scope still cannot write.
+- **More scopes never means less access.** Scopes union, so adding one
+  can only widen — within the ceiling. A client is never broken by
+  gaining a scope.
+
+### Selecting a baseline
+
+`applies_to` lists the `principal_type` values a baseline covers.
+**The sets must be disjoint** — overlap is a startup error — so exactly
+one baseline matches any request. There is deliberately no precedence
+rule to learn, and no way for a more specific baseline to silently
+widen a narrower one.
+
+A `principal_type` that matches no baseline is **unrestricted**. That
+is what makes an interactive `user` token, a `--principal-header`
+deployment and a proxy that models no principal type all work with no
+special-casing. `rela acl audit` reports a baseline that covers
+nothing, since that is a policy gap rather than a runtime error.
+
+### Two spellings, per type
+
+Each axis takes either an allowlist or a denylist — never both for the
+same axis (or, for fields, the same type); declaring both is a load
+error rather than a merge rule to memorize.
+
+| Allowlist — fail-closed | Denylist — low-effort |
+|---|---|
+| `read: [ticket, person]` | `deny_read: [audit-record]` |
+| `update: [ticket]` | `deny_update: ["*"]` |
+| `visible: {person: [name]}` | `redact: {person: [salary]}` |
+| `permissions: [history:read]` | `deny_permissions: [history:read]` |
+
+The difference is what happens to a property **added to the metamodel
+later**:
+
+- `visible:` is **closed-world**. It names the complete permitted set,
+  so a new property is hidden from the client automatically. Nobody has
+  to remember to redact it.
+- `redact:` is **open-world**. It hides only what it names, so a new
+  property stays visible.
+
+Pick `visible:` for a type whose safe set is small and whose sensitive
+set is open-ended; pick `redact:` for a type with two sensitive columns
+and many harmless ones.
+
+`deny_write: ["*"]` is shorthand for denying create, update and delete —
+"read-only client" should not take three lines.
+
+**An omitted axis is inherited**: the block does not narrow it. A
+baseline that only hides two fields stays two lines long instead of
+restating the schema.
+
+### Scopes re-open
+
+A scope grant lists what it hands back, in the allow spellings only. A
+deny inside a `scope_grants` block is a load error: a scope exists to
+re-open, and "re-open nothing" is what omitting it already says.
+
+`rela acl audit` flags a scope that re-opens something no baseline
+closes. That check earns its place because the symptom is invisible —
+the capability *is* present, so the scope looks like it works, right up
+until someone writes a second one that genuinely depended on a baseline
+closing something first.
+
+**A baseline denial is a default, not a floor.** Any scope naming a
+capability re-opens it, including one the baseline explicitly denied;
+there is no way to mark a denial un-carve-out-able. That is safe because
+the floor is the acting *user* — everything is still intersected with
+their own grants, so no scope reaches past what they hold. But read a
+baseline denial as "off unless a scope turns it on". If a capability
+must never reach a client class, do not write a scope grant naming it.
+
+### What it does not do
+
+- **`principal_type` and `scope` come only from a verified assertion.**
+  The same trust boundary as asserted roles, enforced by the type
+  system. See GUIDE-acl-security.
+- **stdio MCP is not covered.** It has no authentication at all, so
+  there is no verified claim to key on. This makes the *policy*
+  expressible; wiring `internal/mcp` through the read gate is
+  TKT-G3PPD.
+- **`Tool` is not a selector.** rela stamps it (`mcp`, `cli`,
+  `data-entry`), but the entry-point binary asserts it rather than an
+  IdP signing it. Mixing a spoofable key with signed claims in one
+  mechanism invites leaning on the weak one.
+- **Relation *meta* fields are not attenuated.** A ceiling's `visible:` /
+  `redact:` cover entity properties. Per-relation meta-field visibility
+  is a separate grant vocabulary (`relations:` on a role), and a client
+  ceiling has no equivalent — so a restricted client sees the same
+  relation meta a role grants it. Row-level `deny_read` still applies to
+  both endpoints, so a hidden entity's edges stay hidden.
+
+To see what a client actually gets, ask:
+
+```console
+$ rela acl map --principal alice --as app --scope rela.tickets.write
+Effective access for alice — verbs: read, create, update, delete
+  as client type "app" with scopes rela.tickets.write — the client_baselines ceiling is applied below.
+      person
+          read (all person): role hr [global]
+      ticket
+          read (all ticket): role hr [global]
+          update (all ticket): role hr [global]
+```
+
+Alice's own `hr` role also grants `create` and `delete` on tickets and
+`update` on people. They are absent here because the `apps` baseline
+denies writes and only `rela.tickets.write` was handed back.
+
 ## How to read a deny
 
 A `403` from a write looks like this on the wire:

--- a/docs-project/entities/guides/GUIDE-acl-security.md
+++ b/docs-project/entities/guides/GUIDE-acl-security.md
@@ -298,9 +298,16 @@ tenant a request *came from*; it does not constrain what that request
 could reach.
 
 This is a deliberate scope decision, not an oversight — ACL evaluation
-is additive (any role granting the verb allows it, and no rule can
-subtract), so a cross-cutting "deny unless org matches" needs its own
-design rather than a field check bolted onto the resolver. A test
+is additive (any role granting the verb allows it), so a cross-cutting
+"deny unless org matches" needs its own design rather than a field check
+bolted onto the resolver.
+
+Client attenuation is not a counter-example. It narrows, but it does so
+by compiling restrictions into plain allowlists at LOAD time, keyed on a
+claim whose value set the operator enumerates. Org enforcement cannot
+work that way: the comparison is between a claim and a property of the
+entity being evaluated, which is a per-row predicate — the thing the
+read path deliberately does not have. A test
 (`TestAssertedRoles_OrgIsNotEvaluated`) pins the absence of enforcement
 so it cannot be mistaken for an omission, and fails the day a partial
 org check is added.
@@ -310,6 +317,65 @@ containment edges plus `inherit_roles_through` scope roles to a subtree
 positively, and read-filtering follows for free. That works only if no
 role grants a broad wildcard read — a global `read: ["*"]` defeats any
 org scoping, in this design or any other.
+
+## Client attenuation (`client_baselines` / `scope_grants`)
+
+Client attenuation restricts a client BELOW the user it acts as (see
+GUIDE-acl-overview for the mechanics). Four properties are load-bearing.
+
+**Same trust boundary as asserted roles, and for the same reason.**
+`principal_type` and `scope` live in unexported fields on
+`principal.Principal`, populated only through `principal.Verified` /
+`VerifiedFrom` after signature verification. Never introduce a header
+trusted as a `principal_type` source.
+
+The direction of harm is inverted from a role, which is worth stating
+explicitly because it is easy to reason about backwards: forging a role
+*adds* access, while forging a `principal_type` selects a ceiling and
+therefore *removes* it. The dangerous manipulation here is not injecting
+a claim but **dropping** one — a principal whose `principal_type` is
+lost matches no baseline and is unrestricted. That is why every re-stamp
+of a Principal must carry the claims forward, and why the audit log
+records them.
+
+**A ceiling only ever narrows.** `effective = user_grants ∩ (baseline ∪
+scopes)`. Nothing an operator writes in `client_baselines` or
+`scope_grants` can grant capability the acting user lacks, so a mistake
+in one of these blocks fails toward *less* access. The one exception to
+that comfort is a ceiling that silently matches nothing — see the audit
+rules below.
+
+**This does not contradict the additive model.** Restrictions are
+compiled at LOAD time into ordinary allowlists: `redact: {person:
+[salary]}` becomes "the permitted field set for person, minus salary",
+and the runtime evaluator sees a plain allowlist exactly as before. No
+denial primitive exists at evaluation time, and none should be added —
+`ReadQuery` compiles to a `store.GraphQuery` pushed down into SQL, so a
+runtime deny would have to become a SQL predicate in every backend.
+
+**An inert ceiling is the failure mode to watch.** A wrong *grant*
+denies something and someone reports it. A wrong *restriction* just
+fails to restrict, and nobody files a bug about access they still have.
+`rela acl audit` therefore reports:
+
+- `A11-inert-client-baseline` — a baseline that narrows nothing.
+- `A13-baseline-matches-nothing` — an empty `applies_to`.
+- `A12-scope-reopens-nothing` — a scope re-opening what no baseline
+  closed (it appears to work, which is exactly the trap).
+- `B8` / `B9` — a ceiling naming an entity type or field the metamodel
+  does not declare. A typo in a *denial* is worse than in a grant: it
+  silently fails to protect.
+
+Run `rela acl map --principal <user> --as <type>` to see what a client
+actually gets, rather than inferring it from the policy file.
+
+### Not a substitute for gating the client itself
+
+stdio MCP has no authentication, so no verified claim exists to key a
+baseline on, and its read path does not yet route through the ACL read
+gate at all (TKT-G3PPD). Client attenuation makes the *policy*
+expressible; it does not by itself restrict a locally-launched
+`rela mcp`.
 
 ## Fail-loud on malformed `acl.yaml`
 

--- a/docs/acl-overview.md
+++ b/docs/acl-overview.md
@@ -297,6 +297,184 @@ The resolver's decisions:
 - **A drive-by anonymous request:** `Deny`. `ErrUnstampedPrincipal`
   surfaces; the request never reaches `AuthorizeWrite`.
 
+## Restricting a client below its user
+
+Everything above answers "what may this *person* do". Client attenuation
+answers a different question: **what may this person do *through this
+client*.**
+
+The case is any external tool acting on a person's behalf — an MCP
+server, a CI script, an integration, a personal access token pasted into
+something you did not write — where you want a *guarantee* about what it
+can reach, independent of how much the person driving it can reach.
+
+Concretely: an HR user connects an MCP server. It acts with their
+identity, so by default it can read `person.salary`, and it can delete
+things, because they can. Client attenuation lets an operator say: this
+client sees less, and can destroy less, than the person driving it.
+
+The guarantee is what matters. Trusting the tool to behave, or the
+person to only ask it for safe things, is not one — a ceiling holds
+regardless of what the tool does or is told to do.
+
+```yaml
+client_baselines:
+  apps:
+    applies_to: [app]          # matches the verified principal_type claim
+    deny_write: ["*"]          # read-only
+    redact:
+      person: [salary, bsn]    # hidden even though the user may see them
+
+scope_grants:
+  rela.tickets.write:          # matches a value in the `scope` claim
+    update: [ticket]           # hands one capability back
+```
+
+The whole model is one line:
+
+```text
+effective = user_grants ∩ (baseline ∪ matched scope_grants)
+```
+
+Read as a diagram — what the client actually gets is the overlap, and
+nothing outside the user's own circle is reachable at all:
+
+```mermaid
+graph LR
+    subgraph U["What the USER may do"]
+        direction TB
+        UO["person.salary · delete ticket<br/>(user-only: the ceiling removes these)"]
+        E["EFFECTIVE<br/>read ticket · read person.name<br/>update ticket via scope"]
+    end
+    subgraph C["What the CEILING permits<br/>baseline ∪ scopes"]
+        direction TB
+        CO["types the user was never granted<br/>(named by the ceiling, but the user<br/>lacks them — so still denied)"]
+    end
+    E -.->|"the overlap IS the answer"| C
+
+    style E fill:#c8e6c9,stroke:#388e3c,stroke-width:2px
+    style UO fill:#ffe0b2,stroke:#e65100
+    style CO fill:#eceff1,stroke:#90a4ae,stroke-dasharray: 4 3
+```
+
+`CO` is the half that trips people up: a ceiling naming a capability
+does not confer it. Listing `read: [audit-record]` in a baseline grants
+nothing to a user who was never granted audit-records — the ceiling is
+an upper bound, never a source.
+
+Two consequences follow, and both matter:
+
+- **A ceiling never grants.** The intersection with the acting user's
+  own grants means a token cannot exceed its user, whatever it claims.
+  A read-only user presenting a write scope still cannot write.
+- **More scopes never means less access.** Scopes union, so adding one
+  can only widen — within the ceiling. A client is never broken by
+  gaining a scope.
+
+### Selecting a baseline
+
+`applies_to` lists the `principal_type` values a baseline covers.
+**The sets must be disjoint** — overlap is a startup error — so exactly
+one baseline matches any request. There is deliberately no precedence
+rule to learn, and no way for a more specific baseline to silently
+widen a narrower one.
+
+A `principal_type` that matches no baseline is **unrestricted**. That
+is what makes an interactive `user` token, a `--principal-header`
+deployment and a proxy that models no principal type all work with no
+special-casing. `rela acl audit` reports a baseline that covers
+nothing, since that is a policy gap rather than a runtime error.
+
+### Two spellings, per type
+
+Each axis takes either an allowlist or a denylist — never both for the
+same axis (or, for fields, the same type); declaring both is a load
+error rather than a merge rule to memorize.
+
+| Allowlist — fail-closed | Denylist — low-effort |
+|---|---|
+| `read: [ticket, person]` | `deny_read: [audit-record]` |
+| `update: [ticket]` | `deny_update: ["*"]` |
+| `visible: {person: [name]}` | `redact: {person: [salary]}` |
+| `permissions: [history:read]` | `deny_permissions: [history:read]` |
+
+The difference is what happens to a property **added to the metamodel
+later**:
+
+- `visible:` is **closed-world**. It names the complete permitted set,
+  so a new property is hidden from the client automatically. Nobody has
+  to remember to redact it.
+- `redact:` is **open-world**. It hides only what it names, so a new
+  property stays visible.
+
+Pick `visible:` for a type whose safe set is small and whose sensitive
+set is open-ended; pick `redact:` for a type with two sensitive columns
+and many harmless ones.
+
+`deny_write: ["*"]` is shorthand for denying create, update and delete —
+"read-only client" should not take three lines.
+
+**An omitted axis is inherited**: the block does not narrow it. A
+baseline that only hides two fields stays two lines long instead of
+restating the schema.
+
+### Scopes re-open
+
+A scope grant lists what it hands back, in the allow spellings only. A
+deny inside a `scope_grants` block is a load error: a scope exists to
+re-open, and "re-open nothing" is what omitting it already says.
+
+`rela acl audit` flags a scope that re-opens something no baseline
+closes. That check earns its place because the symptom is invisible —
+the capability *is* present, so the scope looks like it works, right up
+until someone writes a second one that genuinely depended on a baseline
+closing something first.
+
+**A baseline denial is a default, not a floor.** Any scope naming a
+capability re-opens it, including one the baseline explicitly denied;
+there is no way to mark a denial un-carve-out-able. That is safe because
+the floor is the acting *user* — everything is still intersected with
+their own grants, so no scope reaches past what they hold. But read a
+baseline denial as "off unless a scope turns it on". If a capability
+must never reach a client class, do not write a scope grant naming it.
+
+### What it does not do
+
+- **`principal_type` and `scope` come only from a verified assertion.**
+  The same trust boundary as asserted roles, enforced by the type
+  system. See GUIDE-acl-security.
+- **stdio MCP is not covered.** It has no authentication at all, so
+  there is no verified claim to key on. This makes the *policy*
+  expressible; wiring `internal/mcp` through the read gate is
+  TKT-G3PPD.
+- **`Tool` is not a selector.** rela stamps it (`mcp`, `cli`,
+  `data-entry`), but the entry-point binary asserts it rather than an
+  IdP signing it. Mixing a spoofable key with signed claims in one
+  mechanism invites leaning on the weak one.
+- **Relation *meta* fields are not attenuated.** A ceiling's `visible:` /
+  `redact:` cover entity properties. Per-relation meta-field visibility
+  is a separate grant vocabulary (`relations:` on a role), and a client
+  ceiling has no equivalent — so a restricted client sees the same
+  relation meta a role grants it. Row-level `deny_read` still applies to
+  both endpoints, so a hidden entity's edges stay hidden.
+
+To see what a client actually gets, ask:
+
+```console
+$ rela acl map --principal alice --as app --scope rela.tickets.write
+Effective access for alice — verbs: read, create, update, delete
+  as client type "app" with scopes rela.tickets.write — the client_baselines ceiling is applied below.
+      person
+          read (all person): role hr [global]
+      ticket
+          read (all ticket): role hr [global]
+          update (all ticket): role hr [global]
+```
+
+Alice's own `hr` role also grants `create` and `delete` on tickets and
+`update` on people. They are absent here because the `apps` baseline
+denies writes and only `rela.tickets.write` was handed back.
+
 ## How to read a deny
 
 A `403` from a write looks like this on the wire:

--- a/docs/acl-security.md
+++ b/docs/acl-security.md
@@ -292,9 +292,16 @@ tenant a request *came from*; it does not constrain what that request
 could reach.
 
 This is a deliberate scope decision, not an oversight — ACL evaluation
-is additive (any role granting the verb allows it, and no rule can
-subtract), so a cross-cutting "deny unless org matches" needs its own
-design rather than a field check bolted onto the resolver. A test
+is additive (any role granting the verb allows it), so a cross-cutting
+"deny unless org matches" needs its own design rather than a field check
+bolted onto the resolver.
+
+Client attenuation is not a counter-example. It narrows, but it does so
+by compiling restrictions into plain allowlists at LOAD time, keyed on a
+claim whose value set the operator enumerates. Org enforcement cannot
+work that way: the comparison is between a claim and a property of the
+entity being evaluated, which is a per-row predicate — the thing the
+read path deliberately does not have. A test
 (`TestAssertedRoles_OrgIsNotEvaluated`) pins the absence of enforcement
 so it cannot be mistaken for an omission, and fails the day a partial
 org check is added.
@@ -304,6 +311,65 @@ containment edges plus `inherit_roles_through` scope roles to a subtree
 positively, and read-filtering follows for free. That works only if no
 role grants a broad wildcard read — a global `read: ["*"]` defeats any
 org scoping, in this design or any other.
+
+## Client attenuation (`client_baselines` / `scope_grants`)
+
+Client attenuation restricts a client BELOW the user it acts as (see
+GUIDE-acl-overview for the mechanics). Four properties are load-bearing.
+
+**Same trust boundary as asserted roles, and for the same reason.**
+`principal_type` and `scope` live in unexported fields on
+`principal.Principal`, populated only through `principal.Verified` /
+`VerifiedFrom` after signature verification. Never introduce a header
+trusted as a `principal_type` source.
+
+The direction of harm is inverted from a role, which is worth stating
+explicitly because it is easy to reason about backwards: forging a role
+*adds* access, while forging a `principal_type` selects a ceiling and
+therefore *removes* it. The dangerous manipulation here is not injecting
+a claim but **dropping** one — a principal whose `principal_type` is
+lost matches no baseline and is unrestricted. That is why every re-stamp
+of a Principal must carry the claims forward, and why the audit log
+records them.
+
+**A ceiling only ever narrows.** `effective = user_grants ∩ (baseline ∪
+scopes)`. Nothing an operator writes in `client_baselines` or
+`scope_grants` can grant capability the acting user lacks, so a mistake
+in one of these blocks fails toward *less* access. The one exception to
+that comfort is a ceiling that silently matches nothing — see the audit
+rules below.
+
+**This does not contradict the additive model.** Restrictions are
+compiled at LOAD time into ordinary allowlists: `redact: {person:
+[salary]}` becomes "the permitted field set for person, minus salary",
+and the runtime evaluator sees a plain allowlist exactly as before. No
+denial primitive exists at evaluation time, and none should be added —
+`ReadQuery` compiles to a `store.GraphQuery` pushed down into SQL, so a
+runtime deny would have to become a SQL predicate in every backend.
+
+**An inert ceiling is the failure mode to watch.** A wrong *grant*
+denies something and someone reports it. A wrong *restriction* just
+fails to restrict, and nobody files a bug about access they still have.
+`rela acl audit` therefore reports:
+
+- `A11-inert-client-baseline` — a baseline that narrows nothing.
+- `A13-baseline-matches-nothing` — an empty `applies_to`.
+- `A12-scope-reopens-nothing` — a scope re-opening what no baseline
+  closed (it appears to work, which is exactly the trap).
+- `B8` / `B9` — a ceiling naming an entity type or field the metamodel
+  does not declare. A typo in a *denial* is worse than in a grant: it
+  silently fails to protect.
+
+Run `rela acl map --principal <user> --as <type>` to see what a client
+actually gets, rather than inferring it from the policy file.
+
+### Not a substitute for gating the client itself
+
+stdio MCP has no authentication, so no verified claim exists to key a
+baseline on, and its read path does not yet route through the ACL read
+gate at all (TKT-G3PPD). Client attenuation makes the *policy*
+expressible; it does not by itself restrict a locally-launched
+`rela mcp`.
 
 ## Fail-loud on malformed `acl.yaml`
 

--- a/internal/acl/access.go
+++ b/internal/acl/access.go
@@ -225,12 +225,25 @@ func (r *Request) grantingAttributions(
 ) []RoleAttribution {
 	attrs := r.ForEntity(ctx, entityType, entityID)
 	op, isWrite := verb.op()
+
+	// An attestation tool must report EFFECTIVE access, so the client ceiling
+	// applies here exactly as it does at runtime. Reporting the un-attenuated
+	// role set would tell an operator a restricted client can do something it
+	// cannot — the worst error class for a tool whose whole job is answering
+	// "who can do what".
+	if isWrite && !r.ceiling.permitsVerb(op, entityType) {
+		return nil
+	}
+	if !isWrite && !r.ceiling.permitsRead(entityType) {
+		return nil
+	}
+
 	var out []RoleAttribution
 	for _, a := range attrs {
 		if a.Role == EveryoneRole {
 			continue
 		}
-		role, ok := r.d.policy.Roles[a.Role]
+		role, ok := r.roleFor(a.Role)
 		if !ok {
 			continue
 		}

--- a/internal/acl/authz_write.go
+++ b/internal/acl/authz_write.go
@@ -74,8 +74,29 @@ func (r *Request) authorizeRelationWrite(ctx context.Context, op Op, s RelationS
 // the resolver considered (AC7). The wire 403 path
 // ([ForbiddenError.Error]) ignores Attributions — only audit reads it.
 func (r *Request) decideFromAttrs(attrs []RoleAttribution, op Op, target, denyFmt string) Decision {
+	// The client ceiling is checked before any role, because it can only
+	// remove: if it denies this verb on this type, no role can grant it. The
+	// deny names the ceiling rather than a role, so an operator reading the
+	// audit log can tell "your policy grants nothing" apart from "your policy
+	// grants it, but this client is attenuated" — two very different fixes.
+	//
+	// It also closes the wildcard gap: a role holding `update: ["*"]` under a
+	// `deny_update: [person]` ceiling keeps its wildcard through roleFor (a
+	// plain list cannot spell "all except person"), so the denial must be
+	// applied here.
+	if !r.ceiling.permitsVerb(op, target) {
+		return Decision{
+			Allow:    false,
+			RuleKind: "client-ceiling",
+			RuleID:   r.ceiling.name,
+			Reason: fmt.Sprintf(
+				"client baseline %q does not permit %s on %q for principal type %q",
+				r.ceiling.name, op, target, r.principal.PrincipalType()),
+			Attributions: attrs,
+		}
+	}
 	for _, a := range attrs {
-		role, ok := r.d.policy.Roles[a.Role]
+		role, ok := r.roleFor(a.Role)
 		if !ok {
 			continue
 		}

--- a/internal/acl/ceiling.go
+++ b/internal/acl/ceiling.go
@@ -1,0 +1,474 @@
+package acl
+
+import (
+	"errors"
+	"fmt"
+	"slices"
+	"sort"
+	"strings"
+)
+
+// Client attenuation (TKT-IAC8TX) restricts a non-interactive client BELOW the
+// user it acts as.
+//
+// The invariant, and the reason this is safe:
+//
+//	effective = user_grants ∩ (baseline ∪ matched scope_grants)
+//
+// Two properties fall out, and both are load-bearing:
+//
+//  1. A ceiling NEVER grants. Intersection with the acting user's own grants
+//     means a token cannot exceed its user whatever it claims — a read-only
+//     user holding a write-scoped token still cannot write.
+//  2. Scopes widen only WITHIN the ceiling. `baseline ∪ scopes` is a union, so
+//     more scopes means more capability (matching OAuth everywhere else), but
+//     still clamped by (1).
+//
+// # Why this compiles at load time
+//
+// A restriction block is static config, so it is fully resolvable when the
+// policy loads: `redact: {person: [salary]}` becomes "the allowed field set for
+// person, minus salary" against the metamodel. The compiled result is an
+// ordinary allowlist, which means the RUNTIME EVALUATOR NEVER LEARNS THE WORD
+// "DENY" — decideFromAttrs, readQuery, grantsPermission and FieldVerdicts keep
+// seeing the same plain allowlists they always did, and DEC-RG878's additive
+// union semantics are untouched.
+//
+// That is not an implementation detail, it is the design. A runtime denial
+// primitive would have to be re-derived in every evaluation path, INCLUDING
+// readQuery — which compiles to a store.GraphQuery pushed down into SQL, so a
+// deny would have to become a SQL predicate. Do not reintroduce one.
+//
+// # Selection has no combination rule
+//
+// [ClientBaseline.AppliesTo] sets must be DISJOINT ([Policy.Validate] rejects
+// overlap), so exactly one baseline matches any principal_type. There is
+// deliberately no baseline-vs-baseline precedence to specify, document, or get
+// wrong. A principal_type matching no baseline is unrestricted.
+
+// ClientBaseline is the ceiling applied to a client of a given principal_type.
+// It is keyed by NAME in `acl.yaml` (so it can be talked about in diagnostics
+// and `rela acl map --as`), and selects on the verified `principal_type` claim
+// via AppliesTo.
+type ClientBaseline struct {
+	// Description is optional operator-facing prose. Documentation only,
+	// mirroring [Policy.Description] and [RoleDef.Description].
+	Description string `yaml:"description,omitempty"`
+
+	// AppliesTo lists the verified principal_type values this baseline covers
+	// (e.g. [app, pat, service]). Must be disjoint across all baselines —
+	// overlap is a load error, not a precedence puzzle. An empty AppliesTo
+	// matches nothing and is flagged by `rela acl audit` as dead config.
+	AppliesTo []string `yaml:"applies_to"`
+
+	Restriction `yaml:",inline"`
+}
+
+// ScopeGrant re-opens capability a baseline closed. It is keyed by the verified
+// scope string in `acl.yaml`. Every scope on the token that names a grant
+// contributes; the results union. Since a union of re-openings is still bounded
+// by the acting user's grants, a scope can never escalate.
+//
+// Only the ALLOW spellings are meaningful on a scope grant: a scope exists to
+// re-open, and a "deny" on a re-opener would be a second, redundant way to
+// spell "leave it closed". [Policy.Validate] rejects the deny spellings here so
+// the asymmetry is explicit rather than silently ignored.
+//
+// # A baseline denial is a default, not a floor
+//
+// Any scope grant naming a capability re-opens it, including one the baseline
+// explicitly denied — a scope-granted exception is checked ahead of the denial
+// (see [verbCeiling.except]). There is deliberately no way to mark a baseline
+// denial un-carve-out-able.
+//
+// That is safe because the floor is the ACTING USER, not the baseline:
+// everything here is still intersected with the user's own grants, so no scope
+// can reach past what the user holds. But an operator should read a baseline
+// denial as "off unless a scope turns it on", not as a hard minimum. If a
+// capability must never reach a client class at all, do not write a scope grant
+// that names it.
+type ScopeGrant struct {
+	Description string `yaml:"description,omitempty"`
+
+	Restriction `yaml:",inline"`
+}
+
+// Restriction is the shared body of a [ClientBaseline] and a [ScopeGrant]: what
+// an axis permits, in either an allowlist or a denylist spelling.
+//
+// Per axis, per entity type, an operator picks ONE spelling:
+//
+//	allowlist (fail-closed)              denylist (low-effort)
+//	read:    [ticket, person]            deny_read:    [audit-record]
+//	create/update/delete: [ticket]       deny_create/update/delete: ["*"]
+//	visible: {person: [name, email]}     redact:       {person: [salary]}
+//	permissions: [history:read]          deny_permissions: [history:read]
+//
+// Declaring both spellings for the same axis (or, for fields, the same TYPE) in
+// one block is a load error — a merge rule there would be a coin-flip an
+// operator has to memorize.
+//
+// An OMITTED axis is INHERITED: the block does not narrow it. That is what lets
+// a baseline that only hides two fields stay two lines long, instead of
+// restating the whole schema.
+type Restriction struct {
+	Read   []string `yaml:"read,omitempty"`
+	Create []string `yaml:"create,omitempty"`
+	Update []string `yaml:"update,omitempty"`
+	Delete []string `yaml:"delete,omitempty"`
+
+	DenyRead   []string `yaml:"deny_read,omitempty"`
+	DenyCreate []string `yaml:"deny_create,omitempty"`
+	DenyUpdate []string `yaml:"deny_update,omitempty"`
+	DenyDelete []string `yaml:"deny_delete,omitempty"`
+
+	// DenyWrite is shorthand expanding at load to deny_create + deny_update +
+	// deny_delete. "read-only client" is the single most common ceiling and
+	// should be one line, not three. There is deliberately NO allowlist `write:`
+	// counterpart: an allowlist names types, and "the types I may write" is
+	// already spelled per-verb.
+	DenyWrite []string `yaml:"deny_write,omitempty"`
+
+	// Visible is the closed-world allowlist form: naming a type here asserts a
+	// COMPLETE field list for it, so anything unnamed — including a property
+	// added to the metamodel later — is redacted. This is where the fail-closed
+	// property comes from, and it reuses the existing per-role `visible:`
+	// semantics rather than inventing a parallel one.
+	Visible map[string][]string `yaml:"visible,omitempty"`
+
+	// Redact is the open-world denylist form: only the named fields are hidden,
+	// everything else passes through, including fields added later. Cheaper to
+	// write, weaker guarantee — the right pick when a type has two sensitive
+	// columns and an open-ended set of harmless ones.
+	Redact map[string][]string `yaml:"redact,omitempty"`
+
+	Permissions     []string `yaml:"permissions,omitempty"`
+	DenyPermissions []string `yaml:"deny_permissions,omitempty"`
+}
+
+// Narrows reports whether the block restricts anything at all. Exported for
+// `rela acl audit`, which flags a baseline that narrows nothing: it reads like
+// protection, enforces none, and — unlike a wrong grant — produces no symptom
+// anyone would report.
+func (r Restriction) Narrows() bool {
+	return len(r.Read) > 0 || len(r.Create) > 0 || len(r.Update) > 0 ||
+		len(r.Delete) > 0 || len(r.DenyRead) > 0 || len(r.DenyCreate) > 0 ||
+		len(r.DenyUpdate) > 0 || len(r.DenyDelete) > 0 || len(r.DenyWrite) > 0 ||
+		len(r.Visible) > 0 || len(r.Redact) > 0 ||
+		len(r.Permissions) > 0 || len(r.DenyPermissions) > 0
+}
+
+// denySpellings reports which deny-form axes are set, for the [ScopeGrant]
+// rejection. Returns names in a stable order so the error message is
+// deterministic.
+func (r Restriction) denySpellings() []string {
+	var out []string
+	for _, c := range []struct {
+		name string
+		set  bool
+	}{
+		{"deny_read", len(r.DenyRead) > 0},
+		{"deny_create", len(r.DenyCreate) > 0},
+		{"deny_update", len(r.DenyUpdate) > 0},
+		{"deny_delete", len(r.DenyDelete) > 0},
+		{"deny_write", len(r.DenyWrite) > 0},
+		{"redact", len(r.Redact) > 0},
+		{"deny_permissions", len(r.DenyPermissions) > 0},
+	} {
+		if c.set {
+			out = append(out, c.name)
+		}
+	}
+	return out
+}
+
+// validate checks a restriction block. label names the containing block for the
+// error message ("client_baselines.apps"). Split into three passes so each
+// stays independently readable — they answer different questions.
+func (r Restriction) validate(label string) error {
+	if err := r.validateSpellings(label); err != nil {
+		return err
+	}
+	return r.validateNoBlanks(label)
+}
+
+// validateSpellings enforces one spelling per axis (and, for fields, per type).
+func (r Restriction) validateSpellings(label string) error {
+	for _, c := range []struct {
+		allow, deny       string
+		allowSet, denySet bool
+	}{
+		{"read", "deny_read", len(r.Read) > 0, len(r.DenyRead) > 0},
+		{"create", "deny_create", len(r.Create) > 0, len(r.DenyCreate) > 0},
+		{"update", "deny_update", len(r.Update) > 0, len(r.DenyUpdate) > 0},
+		{"delete", "deny_delete", len(r.Delete) > 0, len(r.DenyDelete) > 0},
+		{"permissions", "deny_permissions", len(r.Permissions) > 0, len(r.DenyPermissions) > 0},
+	} {
+		if c.allowSet && c.denySet {
+			return fmt.Errorf(
+				"%s: declares both %q and %q — pick one spelling per axis "+
+					"(an allowlist states what is permitted; a denylist states what is removed)",
+				label, c.allow, c.deny)
+		}
+	}
+
+	// deny_write is shorthand for the three write verbs, so it collides with
+	// each of them in either spelling. Checked separately because the collision
+	// is one-to-many.
+	if len(r.DenyWrite) > 0 {
+		for _, c := range []struct {
+			name string
+			set  bool
+		}{
+			{"create", len(r.Create) > 0}, {"deny_create", len(r.DenyCreate) > 0},
+			{"update", len(r.Update) > 0}, {"deny_update", len(r.DenyUpdate) > 0},
+			{"delete", len(r.Delete) > 0}, {"deny_delete", len(r.DenyDelete) > 0},
+		} {
+			if c.set {
+				return fmt.Errorf(
+					"%s: declares both \"deny_write\" and %q — deny_write already "+
+						"covers create, update and delete", label, c.name)
+			}
+		}
+	}
+
+	// Fields collide per TYPE, not per axis: `visible` on person and `redact`
+	// on ticket is a legitimate mix (each type picks its own posture).
+	for t := range r.Visible {
+		if _, both := r.Redact[t]; both {
+			return fmt.Errorf(
+				"%s: declares both \"visible\" and \"redact\" for type %q — "+
+					"pick one spelling per type", label, t)
+		}
+	}
+	return nil
+}
+
+// validateNoBlanks rejects empty/whitespace entries. A blank type, field or
+// permission name can never match anything, so it is silently inert — the
+// failure mode an operator is least likely to notice.
+func (r Restriction) validateNoBlanks(label string) error {
+	for _, c := range []struct {
+		field string
+		vals  []string
+	}{
+		{"read", r.Read}, {"create", r.Create}, {"update", r.Update}, {"delete", r.Delete},
+		{"deny_read", r.DenyRead}, {"deny_create", r.DenyCreate},
+		{"deny_update", r.DenyUpdate}, {"deny_delete", r.DenyDelete},
+		{"deny_write", r.DenyWrite},
+		{"permissions", r.Permissions}, {"deny_permissions", r.DenyPermissions},
+	} {
+		for i, v := range c.vals {
+			if isBlank(v) {
+				return fmt.Errorf("%s.%s[%d]: must not be empty or whitespace", label, c.field, i)
+			}
+		}
+	}
+	for _, m := range []struct {
+		field string
+		vals  map[string][]string
+	}{{"visible", r.Visible}, {"redact", r.Redact}} {
+		for t, fields := range m.vals {
+			if isBlank(t) {
+				return fmt.Errorf("%s.%s: entity type key must not be empty or whitespace", label, m.field)
+			}
+			for i, f := range fields {
+				if isBlank(f) {
+					return fmt.Errorf("%s.%s.%s[%d]: field must not be empty or whitespace",
+						label, m.field, t, i)
+				}
+			}
+		}
+	}
+	return nil
+}
+
+// validateClientAttenuation checks the baseline/scope blocks. Split out of
+// [Policy.Validate] to keep that function's cognitive complexity in bounds,
+// matching validateUnmatchedPrincipal.
+func (p *Policy) validateClientAttenuation() error {
+	// A principal_type may be claimed by at most ONE baseline. This is what
+	// buys the "no combination rule" property; without it we would need a
+	// precedence order, and a more-specific baseline could silently WIDEN a
+	// narrower one.
+	claimedBy := map[string]string{}
+	for _, name := range sortedBaselineNames(p.ClientBaselines) {
+		b := p.ClientBaselines[name]
+		if isBlank(name) {
+			return errors.New("client_baselines: name key must not be empty or whitespace")
+		}
+		if err := b.validate("client_baselines." + name); err != nil {
+			return err
+		}
+		for i, t := range b.AppliesTo {
+			if isBlank(t) {
+				return fmt.Errorf(
+					"client_baselines.%s.applies_to[%d]: principal type must not be empty or whitespace",
+					name, i)
+			}
+			t = strings.TrimSpace(t)
+			if prev, dup := claimedBy[t]; dup {
+				return fmt.Errorf(
+					"client_baselines: principal type %q is claimed by both %q and %q — "+
+						"applies_to sets must be disjoint so exactly one baseline matches",
+					t, prev, name)
+			}
+			claimedBy[t] = name
+		}
+	}
+
+	for _, name := range sortedScopeNames(p.ScopeGrants) {
+		g := p.ScopeGrants[name]
+		if isBlank(name) {
+			return errors.New("scope_grants: scope key must not be empty or whitespace")
+		}
+		if err := g.validate("scope_grants." + name); err != nil {
+			return err
+		}
+		// A scope re-opens; a deny on it would mean "re-open nothing", which is
+		// what omitting the scope already says. Rejecting rather than ignoring
+		// keeps an operator from believing a scope tightens something.
+		if deny := g.denySpellings(); len(deny) > 0 {
+			return fmt.Errorf(
+				"scope_grants.%s: declares %s — a scope grant may only RE-OPEN "+
+					"capability a baseline closed, never remove it; express removals "+
+					"in the client_baselines block instead",
+				name, strings.Join(quoteAll(deny), ", "))
+		}
+	}
+
+	// Only now that every collision has been rejected is it safe to rewrite the
+	// deny_write shorthand — see [Restriction.expanded].
+	p.expandClientAttenuation()
+	return nil
+}
+
+// expandClientAttenuation applies [Restriction.expanded] to every block. Called
+// at the tail of validation, never before it.
+func (p *Policy) expandClientAttenuation() {
+	for name, b := range p.ClientBaselines {
+		b.Restriction = b.expanded()
+		p.ClientBaselines[name] = b
+	}
+	for name, g := range p.ScopeGrants {
+		g.Restriction = g.expanded()
+		p.ScopeGrants[name] = g
+	}
+}
+
+// normalizeClientAttenuation trims whitespace from every lookup key and value
+// so a padded `acl.yaml` entry cannot load clean yet stay permanently
+// unmatchable (the RR-IK355A trap on asserted_role_assignments). Runs before
+// validation, so the blank checks see the normalized form.
+func (p *Policy) normalizeClientAttenuation() {
+	if len(p.ClientBaselines) > 0 {
+		out := make(map[string]ClientBaseline, len(p.ClientBaselines))
+		for name, b := range p.ClientBaselines {
+			b.AppliesTo = trimAll(b.AppliesTo)
+			b.Restriction = b.normalized()
+			out[strings.TrimSpace(name)] = b
+		}
+		p.ClientBaselines = out
+	}
+	if len(p.ScopeGrants) > 0 {
+		out := make(map[string]ScopeGrant, len(p.ScopeGrants))
+		for name, g := range p.ScopeGrants {
+			g.Restriction = g.normalized()
+			out[strings.TrimSpace(name)] = g
+		}
+		p.ScopeGrants = out
+	}
+}
+
+// normalized returns r with every type name, field name and permission trimmed.
+//
+// It deliberately does NOT expand deny_write — that is [Restriction.expanded],
+// and the ordering matters: expanding before validation would rewrite
+// deny_write into the three per-verb lists, and the "deny_write alongside
+// deny_update" collision check would then find deny_write already gone and pass
+// a policy whose deny_update was silently discarded.
+func (r Restriction) normalized() Restriction {
+	r.Read, r.Create, r.Update, r.Delete =
+		trimAll(r.Read), trimAll(r.Create), trimAll(r.Update), trimAll(r.Delete)
+	r.DenyRead, r.DenyCreate, r.DenyUpdate, r.DenyDelete =
+		trimAll(r.DenyRead), trimAll(r.DenyCreate), trimAll(r.DenyUpdate), trimAll(r.DenyDelete)
+	r.DenyWrite = trimAll(r.DenyWrite)
+	r.Permissions, r.DenyPermissions = trimAll(r.Permissions), trimAll(r.DenyPermissions)
+	r.Visible, r.Redact = trimFieldMap(r.Visible), trimFieldMap(r.Redact)
+	return r
+}
+
+// expanded rewrites the deny_write shorthand into the three write verbs, so
+// every downstream consumer sees one canonical shape instead of re-deriving the
+// shorthand. Runs AFTER validation has confirmed deny_write does not collide
+// with a per-verb spelling, so these assignments cannot clobber operator input.
+func (r Restriction) expanded() Restriction {
+	if len(r.DenyWrite) == 0 {
+		return r
+	}
+	w := r.DenyWrite
+	// Each verb gets its OWN backing array: a later in-place edit of one
+	// (a compiler step filtering wildcards, say) must not silently mutate the
+	// other two.
+	r.DenyCreate = slices.Clone(w)
+	r.DenyUpdate = slices.Clone(w)
+	r.DenyDelete = slices.Clone(w)
+	r.DenyWrite = nil
+	return r
+}
+
+// trimAll trims every element, PRESERVING the nil-vs-empty distinction: an
+// absent key decodes to nil ("axis omitted → inherit") while `read: []` decodes
+// to a non-nil empty slice ("permit nothing"). Collapsing the latter to nil
+// would silently turn a hard lockout into no restriction at all — the fail-open
+// direction.
+func trimAll(in []string) []string {
+	if in == nil {
+		return nil
+	}
+	out := make([]string, 0, len(in))
+	for _, v := range in {
+		out = append(out, strings.TrimSpace(v))
+	}
+	return out
+}
+
+func trimFieldMap(in map[string][]string) map[string][]string {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make(map[string][]string, len(in))
+	for t, fields := range in {
+		out[strings.TrimSpace(t)] = trimAll(fields)
+	}
+	return out
+}
+
+func quoteAll(in []string) []string {
+	out := make([]string, 0, len(in))
+	for _, v := range in {
+		out = append(out, fmt.Sprintf("%q", v))
+	}
+	return out
+}
+
+// sortedBaselineNames / sortedScopeNames give deterministic iteration so a
+// policy with two conflicting entries always reports the SAME pair, rather than
+// whichever the map happened to yield first.
+func sortedBaselineNames(m map[string]ClientBaseline) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func sortedScopeNames(m map[string]ScopeGrant) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/internal/acl/ceiling_test.go
+++ b/internal/acl/ceiling_test.go
@@ -1,0 +1,458 @@
+package acl_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/Sourcehaven-BV/rela/internal/acl"
+)
+
+// loadCeilingPolicy parses an acl.yaml body and returns the validation error.
+// Uses LoadPolicyBytes so the tests exercise the real load path (normalization
+// runs before validation, exactly as in production).
+func loadCeilingPolicy(t *testing.T, body string) (*acl.Policy, error) {
+	t.Helper()
+	return acl.LoadPolicyBytes([]byte(body))
+}
+
+// TestClientBaselines_DisjointAppliesTo pins AC2. Overlap is the invariant that
+// buys "exactly one baseline matches", which is what lets the design have no
+// precedence rule at all. If this ever becomes a warning instead of an error,
+// the no-combination-rule property is gone and a more-specific baseline can
+// silently widen a narrower one.
+func TestClientBaselines_DisjointAppliesTo(t *testing.T) {
+	t.Parallel()
+	_, err := loadCeilingPolicy(t, `
+roles:
+  reader:
+    read: ["*"]
+client_baselines:
+  apps:
+    applies_to: [app, pat]
+    deny_write: ["*"]
+  automation:
+    applies_to: [pat, service]
+    deny_write: ["*"]
+`)
+	if err == nil {
+		t.Fatal("overlapping applies_to loaded clean; want a startup error")
+	}
+	// The message must name BOTH blocks — an operator staring at four baselines
+	// needs to know which pair collided, not just that one did.
+	for _, want := range []string{"pat", "apps", "automation", "disjoint"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error %q does not mention %q", err, want)
+		}
+	}
+}
+
+// TestClientBaselines_DisjointErrorIsDeterministic guards against a map-order
+// flake: with three-way overlap the reported pair must be stable, or the same
+// broken policy produces different errors on different runs and an operator
+// chasing one collision sees another.
+func TestClientBaselines_DisjointErrorIsDeterministic(t *testing.T) {
+	t.Parallel()
+	const body = `
+client_baselines:
+  zeta:
+    applies_to: [app]
+    deny_write: ["*"]
+  alpha:
+    applies_to: [app]
+    deny_write: ["*"]
+  mid:
+    applies_to: [app]
+    deny_write: ["*"]
+`
+	var first string
+	for i := range 20 {
+		_, err := loadCeilingPolicy(t, body)
+		if err == nil {
+			t.Fatal("overlapping applies_to loaded clean")
+		}
+		if i == 0 {
+			first = err.Error()
+			continue
+		}
+		if err.Error() != first {
+			t.Fatalf("non-deterministic error:\n run 0: %s\n run %d: %s", first, i, err)
+		}
+	}
+}
+
+// TestRestriction_OneSpellingPerAxis pins AC5. Declaring both an allowlist and
+// a denylist for one axis has no defensible merge semantics — whatever we chose
+// would be a coin-flip an operator has to memorize — so it must fail loud.
+func TestRestriction_OneSpellingPerAxis(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		body string
+		want []string
+	}{
+		{
+			name: "read and deny_read",
+			body: `
+client_baselines:
+  apps:
+    applies_to: [app]
+    read: [ticket]
+    deny_read: [person]
+`,
+			want: []string{"read", "deny_read"},
+		},
+		{
+			name: "visible and redact on the same type",
+			body: `
+client_baselines:
+  apps:
+    applies_to: [app]
+    visible:
+      person: [name]
+    redact:
+      person: [salary]
+`,
+			want: []string{"visible", "redact", "person"},
+		},
+		{
+			name: "deny_write and deny_update overlap",
+			body: `
+client_baselines:
+  apps:
+    applies_to: [app]
+    deny_write: ["*"]
+    deny_update: [ticket]
+`,
+			want: []string{"deny_write", "deny_update"},
+		},
+		{
+			name: "deny_write and allowlist create",
+			body: `
+client_baselines:
+  apps:
+    applies_to: [app]
+    deny_write: ["*"]
+    create: [ticket]
+`,
+			want: []string{"deny_write", "create"},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := loadCeilingPolicy(t, tc.body)
+			if err == nil {
+				t.Fatal("conflicting spellings loaded clean; want a load error")
+			}
+			for _, w := range tc.want {
+				if !strings.Contains(err.Error(), w) {
+					t.Errorf("error %q does not mention %q", err, w)
+				}
+			}
+		})
+	}
+}
+
+// TestRestriction_VisibleAndRedactOnDifferentTypes is the counterpart to the
+// same-type rejection above: mixing postures ACROSS types is legitimate and
+// must keep working. A type with two sensitive columns wants redact; a type
+// whose safe set is small wants visible. Rejecting this would force one posture
+// on the whole schema.
+func TestRestriction_VisibleAndRedactOnDifferentTypes(t *testing.T) {
+	t.Parallel()
+	p, err := loadCeilingPolicy(t, `
+client_baselines:
+  apps:
+    applies_to: [app]
+    visible:
+      ticket: [title, status]
+    redact:
+      person: [salary]
+`)
+	if err != nil {
+		t.Fatalf("mixing visible and redact across types should load: %v", err)
+	}
+	b := p.ClientBaselines["apps"]
+	if got := b.Visible["ticket"]; len(got) != 2 {
+		t.Errorf("visible[ticket] = %v, want 2 fields", got)
+	}
+	if got := b.Redact["person"]; len(got) != 1 {
+		t.Errorf("redact[person] = %v, want 1 field", got)
+	}
+}
+
+// TestDenyWrite_ExpandsToThreeVerbs pins AC6. deny_write exists so the most
+// common ceiling ("read-only client") is one line; the expansion happens at
+// load so every downstream consumer sees one canonical shape rather than
+// re-deriving the shorthand.
+func TestDenyWrite_ExpandsToThreeVerbs(t *testing.T) {
+	t.Parallel()
+	p, err := loadCeilingPolicy(t, `
+client_baselines:
+  apps:
+    applies_to: [app]
+    deny_write: ["*"]
+`)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	b := p.ClientBaselines["apps"]
+	for name, got := range map[string][]string{
+		"deny_create": b.DenyCreate,
+		"deny_update": b.DenyUpdate,
+		"deny_delete": b.DenyDelete,
+	} {
+		if len(got) != 1 || got[0] != "*" {
+			t.Errorf("%s = %v, want [*]", name, got)
+		}
+	}
+	if len(b.DenyWrite) != 0 {
+		t.Errorf("DenyWrite = %v, want cleared after expansion", b.DenyWrite)
+	}
+}
+
+// TestDenyWrite_ExpansionRunsAfterValidation is a regression test for an
+// ordering bug found while writing these tests: normalization originally
+// expanded deny_write into the three per-verb lists BEFORE validation, so the
+// "deny_write alongside deny_update" collision check found deny_write already
+// gone, passed the policy, and silently discarded the operator's deny_update.
+//
+// Silently narrowing differently from what was written is the worst outcome
+// available to a ceiling: it neither fails loud nor does what the file says.
+func TestDenyWrite_ExpansionRunsAfterValidation(t *testing.T) {
+	t.Parallel()
+	_, err := loadCeilingPolicy(t, `
+client_baselines:
+  apps:
+    applies_to: [app]
+    deny_write: ["*"]
+    deny_update: [ticket]
+`)
+	if err == nil {
+		t.Fatal("deny_write + deny_update loaded clean — the collision check ran " +
+			"after expansion and the deny_update was silently discarded")
+	}
+}
+
+// TestDenyWrite_ExpansionDoesNotAliasBackingArray guards a subtle aliasing bug:
+// if the three verb slices shared one backing array, a later in-place edit of
+// one (say, a compiler step filtering wildcards) would silently mutate the
+// others. The clone is cheap; the bug would be near-invisible.
+func TestDenyWrite_ExpansionDoesNotAliasBackingArray(t *testing.T) {
+	t.Parallel()
+	p, err := loadCeilingPolicy(t, `
+client_baselines:
+  apps:
+    applies_to: [app]
+    deny_write: [ticket]
+`)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	b := p.ClientBaselines["apps"]
+	b.DenyCreate[0] = "mutated"
+	if b.DenyUpdate[0] != "ticket" || b.DenyDelete[0] != "ticket" {
+		t.Errorf("deny_write expansion shares a backing array: update=%v delete=%v",
+			b.DenyUpdate, b.DenyDelete)
+	}
+}
+
+// TestScopeGrants_RejectDenySpellings pins the re-open-only asymmetry. A scope
+// exists to widen within a ceiling; "deny" on a re-opener means "re-open
+// nothing", which omitting the scope already says. Rejecting rather than
+// ignoring stops an operator believing a scope tightens something.
+func TestScopeGrants_RejectDenySpellings(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name, field, body string
+	}{
+		{
+			name:  "deny_read",
+			field: "deny_read",
+			body: `
+scope_grants:
+  rela.read:
+    deny_read: [person]
+`,
+		},
+		{
+			name:  "redact",
+			field: "redact",
+			body: `
+scope_grants:
+  rela.read:
+    redact:
+      person: [salary]
+`,
+		},
+		{
+			// deny_write survives to validation unexpanded (expansion runs only
+			// after every collision check passes), so the error names it directly.
+			name:  "deny_write",
+			field: "deny_write",
+			body: `
+scope_grants:
+  rela.read:
+    deny_write: ["*"]
+`,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := loadCeilingPolicy(t, tc.body)
+			if err == nil {
+				t.Fatalf("scope_grants with %s loaded clean; want a load error", tc.field)
+			}
+			if !strings.Contains(err.Error(), tc.field) {
+				t.Errorf("error %q does not name the offending field %q", err, tc.field)
+			}
+		})
+	}
+}
+
+// TestScopeGrants_AllowSpellingsLoad confirms the positive path still works —
+// the rejection above must not have been implemented as "reject everything".
+func TestScopeGrants_AllowSpellingsLoad(t *testing.T) {
+	t.Parallel()
+	p, err := loadCeilingPolicy(t, `
+scope_grants:
+  rela.people.read:
+    read: [person]
+    visible:
+      person: [name, email]
+  rela.tickets.write:
+    update: [ticket]
+`)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if got := p.ScopeGrants["rela.people.read"].Read; len(got) != 1 || got[0] != "person" {
+		t.Errorf("read = %v, want [person]", got)
+	}
+	if got := p.ScopeGrants["rela.tickets.write"].Update; len(got) != 1 || got[0] != "ticket" {
+		t.Errorf("update = %v, want [ticket]", got)
+	}
+}
+
+// TestCeiling_WhitespacePaddedKeysAreMatchable is the RR-IK355A trap, ported.
+// A padded key that loads clean but can never match any real claim value is the
+// worst failure mode available here: it looks like protection and is inert.
+// Normalization must make the padded form equivalent to the bare one.
+func TestCeiling_WhitespacePaddedKeysAreMatchable(t *testing.T) {
+	t.Parallel()
+	p, err := loadCeilingPolicy(t, `
+client_baselines:
+  "  apps  ":
+    applies_to: ["  app  "]
+    deny_write: ["  ticket  "]
+scope_grants:
+  "  rela.read  ":
+    read: ["  person  "]
+`)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if _, ok := p.ClientBaselines["apps"]; !ok {
+		t.Errorf("baseline key not trimmed; got keys %v", keysOf(p.ClientBaselines))
+	}
+	if got := p.ClientBaselines["apps"].AppliesTo; len(got) != 1 || got[0] != "app" {
+		t.Errorf("applies_to = %q, want [app]", got)
+	}
+	if got := p.ClientBaselines["apps"].DenyCreate; len(got) != 1 || got[0] != "ticket" {
+		t.Errorf("deny_create = %q, want [ticket] (trimmed + expanded)", got)
+	}
+	if _, ok := p.ScopeGrants["rela.read"]; !ok {
+		t.Errorf("scope key not trimmed")
+	}
+	if got := p.ScopeGrants["rela.read"].Read; len(got) != 1 || got[0] != "person" {
+		t.Errorf("scope read = %q, want [person]", got)
+	}
+}
+
+// TestCeiling_BlankKeysRejected: a blank key can never match a claim, so the
+// mapping is silently inert — same reasoning as the asserted_role_assignments
+// guard. Fail loud instead.
+func TestCeiling_BlankKeysRejected(t *testing.T) {
+	t.Parallel()
+	tests := []struct{ name, body string }{
+		{"blank baseline name", `
+client_baselines:
+  "   ":
+    applies_to: [app]
+    deny_write: ["*"]
+`},
+		{"blank applies_to entry", `
+client_baselines:
+  apps:
+    applies_to: ["  "]
+    deny_write: ["*"]
+`},
+		{"blank scope key", `
+scope_grants:
+  "   ":
+    read: [person]
+`},
+		{"blank type in visible", `
+client_baselines:
+  apps:
+    applies_to: [app]
+    visible:
+      "  ": [name]
+`},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if _, err := loadCeilingPolicy(t, tc.body); err == nil {
+				t.Fatal("blank key loaded clean; want a load error")
+			}
+		})
+	}
+}
+
+// TestCeiling_AbsentIsUnrestricted pins AC3 at the policy layer: a policy with
+// no attenuation config must parse to empty maps, not to some implicit
+// everything-denied default. The ceiling is opt-in; every existing deployment
+// must be byte-for-byte unaffected.
+func TestCeiling_AbsentIsUnrestricted(t *testing.T) {
+	t.Parallel()
+	p, err := loadCeilingPolicy(t, `
+roles:
+  reader:
+    read: ["*"]
+assignments:
+  alice: reader
+`)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if len(p.ClientBaselines) != 0 {
+		t.Errorf("ClientBaselines = %v, want empty", p.ClientBaselines)
+	}
+	if len(p.ScopeGrants) != 0 {
+		t.Errorf("ScopeGrants = %v, want empty", p.ScopeGrants)
+	}
+}
+
+// TestCeiling_UnknownKeyStillWarnsNotFails confirms the new keys joined the
+// allowlist without turning the loader strict: acl.yaml is tolerant by design
+// (operators iterate on it) and a typo must not brick the server.
+func TestCeiling_UnknownKeyStillWarnsNotFails(t *testing.T) {
+	t.Parallel()
+	if _, err := loadCeilingPolicy(t, `
+client_baseline:
+  apps:
+    applies_to: [app]
+`); err != nil {
+		t.Fatalf("a typo'd top-level key must warn, not fail: %v", err)
+	}
+}
+
+func keysOf[V any](m map[string]V) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}

--- a/internal/acl/ceilingcompile.go
+++ b/internal/acl/ceilingcompile.go
@@ -1,0 +1,429 @@
+package acl
+
+import (
+	"slices"
+	"strings"
+)
+
+// compiledCeiling is the resolved, per-request ceiling: what a client of a
+// given principal_type, carrying a given scope set, may do — BEFORE
+// intersecting with the acting user's own grants.
+//
+// # Why this is a matcher, not an expanded set
+//
+// The obvious implementation is to expand every wildcard against the metamodel
+// at load ("read: [*] minus person" → the literal list of every other type) and
+// store the result. This does NOT do that, for two reasons:
+//
+//  1. Expansion is the one step that can fail OPEN. Getting the type universe
+//     wrong — stale metamodel, a type added later, a subtly wrong set
+//     difference — silently produces a ceiling that permits more than written.
+//     A matcher has no universe to get wrong: `deny_read: [person]` is checked
+//     by asking "is this type person?", which cannot over-permit.
+//  2. The verb predicates ([grantsVerb], [roleGrantsRead]) already match
+//     wildcards rather than expanding them, so an expanded set would have to be
+//     re-collapsed to interoperate. Matching composes directly.
+//
+// Fields are absent here on purpose: the closed-world `visible:` universe is
+// resolved at EVALUATION time by internal/affordances against the entity's
+// declared properties (its declaredFields), so the field axis of a ceiling is
+// applied there in the same vocabulary, not compiled here.
+type compiledCeiling struct {
+	// name identifies the matched baseline, for diagnostics and attribution.
+	// Empty when no baseline matched (i.e. the principal is unrestricted).
+	name string
+
+	// active is false when no baseline matched. Distinguished from a
+	// zero-valued ceiling because "no baseline" (unrestricted) and "a baseline
+	// that permits nothing" are opposite outcomes and must not be confused.
+	active bool
+
+	// baseline is the matched block, kept so the field axis
+	// ([Request.FieldCeilingFor]) reads the SAME resolution the verb axis was
+	// compiled from rather than re-deriving it per call. One source of truth,
+	// and no map walk on every field verdict in a list response.
+	baseline ClientBaseline
+
+	read, create, update, del verbCeiling
+	permissions               permissionCeiling
+}
+
+// verbCeiling decides whether one verb is permitted on one entity type.
+// Exactly one of allow/deny is populated, mirroring the one-spelling-per-axis
+// rule enforced at load.
+type verbCeiling struct {
+	// allow, when non-nil, is the closed allowlist: only these types (or "*").
+	// A non-nil EMPTY slice means "nothing permitted" — distinct from nil,
+	// which means the axis was omitted and is therefore inherited.
+	allow []string
+	// deny lists types removed from whatever the user holds. "*" removes all.
+	deny []string
+	// except lists types a scope grant carved back OUT of deny. It exists
+	// because `deny_write: ["*"]` — the "read-only client" one-liner, and the
+	// single most common ceiling — cannot be widened by subtraction: removing
+	// "ticket" from ["*"] leaves ["*"], which still denies everything. So a
+	// re-opened type is recorded here and checked ahead of the wildcard.
+	except []string
+}
+
+// permits reports whether the ceiling admits target. An omitted axis (both nil)
+// inherits — it does not narrow.
+func (v verbCeiling) permits(target string) bool {
+	// A scope-granted exception wins over the denial it was carved from. This
+	// is checked FIRST so it can override a `deny: ["*"]` wildcard.
+	if slices.Contains(v.except, target) {
+		return true
+	}
+	if v.allow != nil {
+		return matchesTypeList(v.allow, target)
+	}
+	if len(v.deny) > 0 {
+		return !matchesTypeList(v.deny, target)
+	}
+	return true
+}
+
+// narrows reports whether this axis constrains anything at all.
+func (v verbCeiling) narrows() bool { return v.allow != nil || len(v.deny) > 0 }
+
+// permissionCeiling decides whether one named permission is withheld.
+type permissionCeiling struct {
+	allow  []string // non-nil: only these permissions survive
+	deny   []string // these permissions are withheld
+	except []string // scope-granted carve-outs; see [verbCeiling.except]
+}
+
+func (p permissionCeiling) permits(name string) bool {
+	if slices.Contains(p.except, name) {
+		return true
+	}
+	if p.allow != nil {
+		return slices.Contains(p.allow, name) || slices.Contains(p.allow, "*")
+	}
+	if len(p.deny) > 0 {
+		return !slices.Contains(p.deny, name) && !slices.Contains(p.deny, "*")
+	}
+	return true
+}
+
+func (p permissionCeiling) narrows() bool { return p.allow != nil || len(p.deny) > 0 }
+
+// matchesTypeList reports whether target is covered by list, honoring the "*"
+// wildcard the verb predicates already use.
+func matchesTypeList(list []string, target string) bool {
+	for _, t := range list {
+		if t == "*" || t == target {
+			return true
+		}
+	}
+	return false
+}
+
+// ceilingFor resolves the ceiling for a principal: the baseline matching its
+// principal_type, widened by every scope grant its scope claim names.
+//
+// Returns an inactive ceiling when no baseline matches — an unrecognized (or
+// absent) principal_type is UNRESTRICTED, which is what makes an interactive
+// `user` token, a `--principal-header` deployment and a provider that models no
+// principal type all work without special-casing. The audit surfaces a
+// principal_type no baseline covers, since that is a policy gap rather than a
+// runtime error.
+func (p *Policy) ceilingFor(principalType string, scopes []string) compiledCeiling {
+	name, baseline, ok := p.baselineFor(principalType)
+	if !ok {
+		return compiledCeiling{}
+	}
+
+	c := compiledCeiling{
+		name:     name,
+		active:   true,
+		baseline: baseline,
+		read:     verbCeiling{allow: nilIfUnset(baseline.Read), deny: baseline.DenyRead},
+		create:   verbCeiling{allow: nilIfUnset(baseline.Create), deny: baseline.DenyCreate},
+		update:   verbCeiling{allow: nilIfUnset(baseline.Update), deny: baseline.DenyUpdate},
+		del:      verbCeiling{allow: nilIfUnset(baseline.Delete), deny: baseline.DenyDelete},
+		permissions: permissionCeiling{
+			allow: nilIfUnset(baseline.Permissions),
+			deny:  baseline.DenyPermissions,
+		},
+	}
+
+	// Every scope the token carries that names a grant re-opens its listed
+	// capability. Scopes UNION: more scopes means more capability, which is how
+	// OAuth scopes behave everywhere else. This cannot escalate, because the
+	// result is still intersected with the acting user's own grants downstream.
+	//
+	// An unknown scope contributes nothing — matching the Assignments guard,
+	// and meaning an IdP cannot invent capability by minting a scope name the
+	// operator never wrote.
+	for _, scope := range scopes {
+		g, found := p.ScopeGrants[strings.TrimSpace(scope)]
+		if !found {
+			continue
+		}
+		c.read.reopen(g.Read)
+		c.create.reopen(g.Create)
+		c.update.reopen(g.Update)
+		c.del.reopen(g.Delete)
+		c.permissions.reopen(g.Permissions)
+	}
+	return c
+}
+
+// baselineFor finds the single baseline covering principalType. Load-time
+// validation guarantees applies_to sets are disjoint, so the first match is the
+// only match and iteration order cannot change the answer.
+func (p *Policy) baselineFor(principalType string) (string, ClientBaseline, bool) {
+	principalType = strings.TrimSpace(principalType)
+	if principalType == "" || len(p.ClientBaselines) == 0 {
+		return "", ClientBaseline{}, false
+	}
+	for _, name := range sortedBaselineNames(p.ClientBaselines) {
+		b := p.ClientBaselines[name]
+		if slices.Contains(b.AppliesTo, principalType) {
+			return name, b, true
+		}
+	}
+	return "", ClientBaseline{}, false
+}
+
+// reopen widens a verb axis by the types a scope grant names.
+//
+// The two spellings widen differently, and both directions are "permit more":
+//
+//   - allowlist: append the types, so they now pass the closed list.
+//   - denylist: record them as exceptions, so they stop being blocked.
+//
+// Exceptions rather than list-subtraction because the most common denial is
+// `deny_write: ["*"]`, and subtracting "ticket" from ["*"] leaves ["*"] — the
+// scope would silently fail to re-open anything. See [verbCeiling.except].
+//
+// A scope naming a type on an axis that is already unrestricted (both nil) is a
+// no-op: there is nothing to widen.
+func (v *verbCeiling) reopen(types []string) {
+	if len(types) == 0 {
+		return
+	}
+	if v.allow != nil {
+		v.allow = append(slices.Clone(v.allow), types...)
+	}
+	if len(v.deny) > 0 {
+		v.except = append(slices.Clone(v.except), types...)
+	}
+}
+
+// reopen widens the permission axis, mirroring [verbCeiling.reopen].
+func (p *permissionCeiling) reopen(names []string) {
+	if len(names) == 0 {
+		return
+	}
+	if p.allow != nil {
+		p.allow = append(slices.Clone(p.allow), names...)
+	}
+	if len(p.deny) > 0 {
+		p.except = append(slices.Clone(p.except), names...)
+	}
+}
+
+// nilIfUnset preserves the load-time distinction between an omitted axis (nil →
+// inherit) and an explicitly empty one (non-nil empty → permit nothing). YAML
+// decodes `read: []` to an empty non-nil slice and an absent key to nil, so the
+// distinction survives to here for free — but it is load-bearing enough to name.
+func nilIfUnset(v []string) []string {
+	if v == nil {
+		return nil
+	}
+	return slices.Clone(v)
+}
+
+// clamp returns role narrowed to what this ceiling permits, or false when the
+// ceiling leaves the role with nothing at all.
+//
+// This is THE clamp point. Every evaluation path in this package resolves a
+// role name to a RoleDef and then asks a predicate of it; narrowing the RoleDef
+// here means read gating, write authorization, permission checks and the
+// affordance resolver all inherit the ceiling without a single call site
+// knowing it exists.
+//
+// The result is a plain RoleDef holding plain allowlists — the runtime never
+// learns the word "deny". See the commentary in ceiling.go for why that is the
+// design and not an accident.
+func (c compiledCeiling) clamp(role RoleDef) RoleDef {
+	if !c.active {
+		return role
+	}
+	role.Read = filterTypes(role.Read, c.read)
+	role.Create = filterTypes(role.Create, c.create)
+	role.Update = filterTypes(role.Update, c.update)
+	role.Delete = filterTypes(role.Delete, c.del)
+	role.Permissions = filterPermissions(role.Permissions, c.permissions)
+	return role
+}
+
+// filterTypes intersects a role's type list with a verb ceiling.
+//
+// The wildcard case is the subtle one. A role granting `["*"]` under a ceiling
+// of `allow: [ticket]` must become `[ticket]`, NOT stay `["*"]` — otherwise the
+// ceiling would be silently ignored, which is the fail-open direction. So when
+// the role holds a wildcard and the ceiling has a closed allowlist, the
+// ceiling's list becomes the result: it is by construction a subset of "every
+// type".
+//
+// A wildcard under a pure DENY ceiling is different: a plain list cannot spell
+// "everything except person", and expanding it would reintroduce exactly the
+// metamodel-universe fail-open risk this design avoids. So the wildcard is
+// preserved and the denial re-checked at match time via
+// [compiledCeiling.permitsVerb] / [compiledCeiling.permitsRead].
+func filterTypes(roleTypes []string, v verbCeiling) []string {
+	if !v.narrows() || len(roleTypes) == 0 {
+		return roleTypes
+	}
+	if v.allow != nil && slices.Contains(roleTypes, "*") {
+		// "everything" ∩ "exactly these" = "exactly these".
+		return slices.Clone(v.allow)
+	}
+	out := make([]string, 0, len(roleTypes))
+	for _, t := range roleTypes {
+		if t == "*" {
+			// Wildcard under a pure denial: keep it. The denial is enforced by
+			// permitsVerb, which every predicate consults after the role lists
+			// have been checked — a plain list cannot express "all except X".
+			out = append(out, t)
+			continue
+		}
+		if v.permits(t) {
+			out = append(out, t)
+		}
+	}
+	return out
+}
+
+// filterPermissions intersects a role's permission list with the ceiling.
+func filterPermissions(rolePerms []string, p permissionCeiling) []string {
+	if !p.narrows() || len(rolePerms) == 0 {
+		return rolePerms
+	}
+	if p.allow != nil && slices.Contains(rolePerms, "*") {
+		return slices.Clone(p.allow)
+	}
+	out := make([]string, 0, len(rolePerms))
+	for _, name := range rolePerms {
+		if name == "*" {
+			out = append(out, name)
+			continue
+		}
+		if p.permits(name) {
+			out = append(out, name)
+		}
+	}
+	return out
+}
+
+// permitsVerb re-checks a resolved verb against the ceiling, closing the
+// wildcard gap [filterTypes] leaves open: a role holding `["*"]` under a
+// `deny_read: [person]` ceiling keeps its wildcard (a list cannot spell "all
+// except person"), so the denial must be applied at match time instead.
+//
+// Callers apply this AFTER the ordinary role predicates say yes. It can only
+// turn a yes into a no.
+func (c compiledCeiling) permitsVerb(op Op, target string) bool {
+	if !c.active {
+		return true
+	}
+	switch op {
+	case OpCreate:
+		return c.create.permits(target)
+	case OpUpdate, OpRename:
+		return c.update.permits(target)
+	case OpDelete:
+		return c.del.permits(target)
+	default:
+		return true
+	}
+}
+
+// permitsRead re-checks a read against the ceiling, for the same wildcard
+// reason as [compiledCeiling.permitsVerb].
+func (c compiledCeiling) permitsRead(target string) bool {
+	if !c.active {
+		return true
+	}
+	return c.read.permits(target)
+}
+
+// permitsPermission re-checks a named permission against the ceiling.
+func (c compiledCeiling) permitsPermission(name string) bool {
+	if !c.active {
+		return true
+	}
+	return c.permissions.permits(name)
+}
+
+// FieldCeiling is the field-visibility half of a client ceiling, for one entity
+// type. It is the only part of client attenuation that crosses out of this
+// package: the closed-world `visible:` universe is resolved against an entity's
+// declared properties, which lives in internal/affordances, so the field axis
+// is applied there rather than compiled here.
+//
+// Exactly one of Visible / Redact is meaningful, mirroring the
+// one-spelling-per-type rule enforced at load:
+//
+//   - Visible non-nil → CLOSED WORLD. Only these fields survive; everything
+//     else on the type is hidden, including properties added later. This is
+//     where the fail-closed property comes from.
+//   - Redact non-empty → open world. Only these fields are hidden.
+//   - Both empty → the ceiling does not constrain this type's fields.
+type FieldCeiling struct {
+	Baseline string
+	Visible  []string
+	Redact   []string
+}
+
+// Constrains reports whether this ceiling hides anything for the type.
+func (f FieldCeiling) Constrains() bool {
+	return f.Visible != nil || len(f.Redact) > 0
+}
+
+// FieldCeilingFor returns the field ceiling this request's principal is subject
+// to for entityType. A zero value (Constrains() == false) means unrestricted —
+// either no baseline matched, or the baseline says nothing about this type.
+//
+// Scope grants re-open fields the same way they re-open verbs: a scope naming
+// fields under `visible:` ADDS them to the closed world, and one naming fields
+// already hidden by `redact:` removes them from the denial.
+func (r *Request) FieldCeilingFor(entityType string) FieldCeiling {
+	if !r.ceiling.active {
+		return FieldCeiling{}
+	}
+	// Read the baseline resolved at construction rather than re-deriving it.
+	// Re-deriving would be a second lookup keyed off the same principal, and
+	// the point of computing the ceiling once is that there is nothing to
+	// invalidate — two derivations is two things that can drift.
+	baseline := r.ceiling.baseline
+
+	out := FieldCeiling{Baseline: r.ceiling.name}
+	if v, declared := baseline.Visible[entityType]; declared {
+		out.Visible = slices.Clone(v)
+	}
+	out.Redact = slices.Clone(baseline.Redact[entityType])
+
+	for _, scope := range r.principal.Scopes() {
+		g, found := r.d.policy.ScopeGrants[strings.TrimSpace(scope)]
+		if !found {
+			continue
+		}
+		reopened := g.Visible[entityType]
+		if len(reopened) == 0 {
+			continue
+		}
+		if out.Visible != nil {
+			out.Visible = append(out.Visible, reopened...)
+		}
+		if len(out.Redact) > 0 {
+			out.Redact = slices.DeleteFunc(out.Redact, func(f string) bool {
+				return slices.Contains(reopened, f)
+			})
+		}
+	}
+	return out
+}

--- a/internal/acl/ceilingcompile_test.go
+++ b/internal/acl/ceilingcompile_test.go
@@ -1,0 +1,513 @@
+package acl
+
+import (
+	"slices"
+	"testing"
+)
+
+// These tests are IN-PACKAGE on purpose. The compiler is the one step in client
+// attenuation that can fail OPEN — every other layer, if buggy, denies too much
+// (annoying, visible, safe). A wrong intersection here permits more than the
+// operator wrote, silently. So it is tested directly rather than only through
+// the end-to-end behavior, where an over-permissive result could be masked by
+// the user's own grants happening to be narrow.
+
+func mustPolicy(t *testing.T, body string) *Policy {
+	t.Helper()
+	p, err := LoadPolicyBytes([]byte(body))
+	if err != nil {
+		t.Fatalf("load policy: %v", err)
+	}
+	return p
+}
+
+// TestCeilingFor_NoBaselineIsInactive pins AC3 at the compiler. An unrecognized
+// or absent principal_type must yield an INACTIVE ceiling, not an empty one:
+// "no baseline matched" (unrestricted) and "a baseline permitting nothing" are
+// opposite outcomes, and conflating them would either lock out every
+// interactive user or silently unrestrict every client.
+func TestCeilingFor_NoBaselineIsInactive(t *testing.T) {
+	t.Parallel()
+	p := mustPolicy(t, `
+client_baselines:
+  apps:
+    applies_to: [app]
+    deny_write: ["*"]
+`)
+	for _, pt := range []string{"", "user", "unknown-from-another-idp"} {
+		c := p.ceilingFor(pt, nil)
+		if c.active {
+			t.Errorf("principal_type %q produced an ACTIVE ceiling; want unrestricted", pt)
+		}
+		// An inactive ceiling must be transparent to every predicate.
+		transparent := c.permitsRead("person") &&
+			c.permitsVerb(OpUpdate, "person") &&
+			c.permitsPermission("history:read")
+		if !transparent {
+			t.Errorf("principal_type %q: inactive ceiling denied something", pt)
+		}
+		role := RoleDef{Read: []string{"*"}, Update: []string{"person"}}
+		if got := c.clamp(role); !slices.Equal(got.Update, role.Update) {
+			t.Errorf("principal_type %q: inactive ceiling clamped a role: %+v", pt, got)
+		}
+	}
+}
+
+// TestClamp_NeverGrants is the core safety property (AC7): a ceiling may only
+// ever REMOVE. Whatever the baseline or scopes say, the clamped role can never
+// hold a type the original role did not.
+func TestClamp_NeverGrants(t *testing.T) {
+	t.Parallel()
+	p := mustPolicy(t, `
+client_baselines:
+  apps:
+    applies_to: [app]
+    read: [ticket, person, audit-record]
+    update: [ticket, person]
+    permissions: [history:read, export:bulk]
+`)
+	c := p.ceilingFor("app", nil)
+
+	// A deliberately narrow role: the ceiling names far more than it holds.
+	role := RoleDef{Read: []string{"ticket"}, Update: nil, Permissions: nil}
+	got := c.clamp(role)
+
+	if !slices.Equal(got.Read, []string{"ticket"}) {
+		t.Errorf("Read = %v, want [ticket] — the ceiling must not add person/audit-record", got.Read)
+	}
+	if len(got.Update) != 0 {
+		t.Errorf("Update = %v, want empty — the ceiling must not grant a verb the role lacks", got.Update)
+	}
+	if len(got.Permissions) != 0 {
+		t.Errorf("Permissions = %v, want empty — the ceiling must not grant permissions", got.Permissions)
+	}
+}
+
+// TestClamp_WildcardMeetsAllowlist is the fail-open case that matters most. A
+// role granting "*" under a closed allowlist must collapse to that allowlist —
+// if the wildcard survived, the ceiling would be silently ignored and the
+// client would keep everything.
+func TestClamp_WildcardMeetsAllowlist(t *testing.T) {
+	t.Parallel()
+	p := mustPolicy(t, `
+client_baselines:
+  apps:
+    applies_to: [app]
+    read: [ticket]
+    update: [ticket]
+    permissions: [history:read]
+`)
+	c := p.ceilingFor("app", nil)
+	got := c.clamp(RoleDef{
+		Read:        []string{"*"},
+		Update:      []string{"*"},
+		Permissions: []string{"*"},
+	})
+
+	if slices.Contains(got.Read, "*") {
+		t.Errorf("Read kept the wildcard (%v) — the ceiling was silently ignored", got.Read)
+	}
+	if !slices.Equal(got.Read, []string{"ticket"}) {
+		t.Errorf("Read = %v, want [ticket]", got.Read)
+	}
+	if !slices.Equal(got.Update, []string{"ticket"}) {
+		t.Errorf("Update = %v, want [ticket]", got.Update)
+	}
+	if !slices.Equal(got.Permissions, []string{"history:read"}) {
+		t.Errorf("Permissions = %v, want [history:read]", got.Permissions)
+	}
+}
+
+// TestClamp_WildcardMeetsDenial covers the case a plain list cannot express:
+// "everything except person". The wildcard is deliberately PRESERVED in the
+// clamped role (expanding it against the metamodel is the fail-open risk this
+// design avoids), so the denial must be enforced by the match-time predicates.
+// If both halves are not present the ceiling leaks.
+func TestClamp_WildcardMeetsDenial(t *testing.T) {
+	t.Parallel()
+	p := mustPolicy(t, `
+client_baselines:
+  apps:
+    applies_to: [app]
+    deny_read: [person]
+    deny_update: [person]
+`)
+	c := p.ceilingFor("app", nil)
+	got := c.clamp(RoleDef{Read: []string{"*"}, Update: []string{"*"}})
+
+	// Half one: the list keeps the wildcard (nothing else is expressible).
+	if !slices.Contains(got.Read, "*") {
+		t.Errorf("Read = %v, want the wildcard preserved", got.Read)
+	}
+	// Half two: the predicates carry the denial.
+	if c.permitsRead("person") {
+		t.Error("permitsRead(person) = true; the deny_read is not enforced at match time")
+	}
+	if !c.permitsRead("ticket") {
+		t.Error("permitsRead(ticket) = false; the denial over-reached")
+	}
+	if c.permitsVerb(OpUpdate, "person") {
+		t.Error("permitsVerb(update, person) = true; the deny_update is not enforced")
+	}
+	if !c.permitsVerb(OpUpdate, "ticket") {
+		t.Error("permitsVerb(update, ticket) = false; the denial over-reached")
+	}
+}
+
+// TestClamp_ExplicitTypesMeetDenial checks the non-wildcard denial path: named
+// types are filtered out of the list directly.
+func TestClamp_ExplicitTypesMeetDenial(t *testing.T) {
+	t.Parallel()
+	p := mustPolicy(t, `
+client_baselines:
+  apps:
+    applies_to: [app]
+    deny_read: [person]
+`)
+	c := p.ceilingFor("app", nil)
+	got := c.clamp(RoleDef{Read: []string{"ticket", "person", "feature"}})
+	if slices.Contains(got.Read, "person") {
+		t.Errorf("Read = %v, still contains the denied type", got.Read)
+	}
+	if !slices.Equal(got.Read, []string{"ticket", "feature"}) {
+		t.Errorf("Read = %v, want [ticket feature]", got.Read)
+	}
+}
+
+// TestCeiling_OmittedAxisInherits pins the "omitted = inherited" rule that
+// keeps a two-line baseline two lines long. A baseline that only hides a field
+// must not accidentally restrict reads or writes.
+func TestCeiling_OmittedAxisInherits(t *testing.T) {
+	t.Parallel()
+	p := mustPolicy(t, `
+client_baselines:
+  apps:
+    applies_to: [app]
+    redact:
+      person: [salary]
+`)
+	c := p.ceilingFor("app", nil)
+	if !c.active {
+		t.Fatal("baseline did not match")
+	}
+	role := RoleDef{
+		Read:        []string{"ticket", "person"},
+		Update:      []string{"ticket"},
+		Permissions: []string{"history:read"},
+	}
+	got := c.clamp(role)
+	if !slices.Equal(got.Read, role.Read) {
+		t.Errorf("Read = %v, want unchanged %v — an omitted axis must inherit", got.Read, role.Read)
+	}
+	if !slices.Equal(got.Update, role.Update) {
+		t.Errorf("Update = %v, want unchanged %v", got.Update, role.Update)
+	}
+	if !slices.Equal(got.Permissions, role.Permissions) {
+		t.Errorf("Permissions = %v, want unchanged %v", got.Permissions, role.Permissions)
+	}
+}
+
+// TestCeiling_ExplicitEmptyPermitsNothing is the counterpart: `read: []` is a
+// non-nil empty list and must mean "nothing", not "omitted". YAML distinguishes
+// these and so must the compiler, or an operator cannot express a hard lockout.
+func TestCeiling_ExplicitEmptyPermitsNothing(t *testing.T) {
+	t.Parallel()
+	p := mustPolicy(t, `
+client_baselines:
+  locked:
+    applies_to: [service]
+    read: []
+`)
+	c := p.ceilingFor("service", nil)
+	if !c.active {
+		t.Fatal("baseline did not match")
+	}
+	if c.permitsRead("ticket") {
+		t.Error("permitsRead(ticket) = true under `read: []`; want nothing permitted")
+	}
+	got := c.clamp(RoleDef{Read: []string{"ticket", "person"}})
+	if len(got.Read) != 0 {
+		t.Errorf("Read = %v, want empty", got.Read)
+	}
+}
+
+// TestScopes_ReopenUnderAllowlist: a scope adds to a closed allowlist.
+func TestScopes_ReopenUnderAllowlist(t *testing.T) {
+	t.Parallel()
+	p := mustPolicy(t, `
+client_baselines:
+  apps:
+    applies_to: [app]
+    read: [ticket]
+scope_grants:
+  rela.people.read:
+    read: [person]
+`)
+	base := p.ceilingFor("app", nil)
+	if base.permitsRead("person") {
+		t.Fatal("precondition: person readable without the scope")
+	}
+	withScope := p.ceilingFor("app", []string{"rela.people.read"})
+	if !withScope.permitsRead("person") {
+		t.Error("scope did not re-open person")
+	}
+	if !withScope.permitsRead("ticket") {
+		t.Error("scope removed the baseline's own grant")
+	}
+}
+
+// TestScopes_ReopenUnderDenial: a scope removes a type from a denial.
+func TestScopes_ReopenUnderDenial(t *testing.T) {
+	t.Parallel()
+	p := mustPolicy(t, `
+client_baselines:
+  apps:
+    applies_to: [app]
+    deny_read: [person, audit-record]
+scope_grants:
+  rela.people.read:
+    read: [person]
+`)
+	c := p.ceilingFor("app", []string{"rela.people.read"})
+	if !c.permitsRead("person") {
+		t.Error("scope did not lift the denial on person")
+	}
+	if c.permitsRead("audit-record") {
+		t.Error("scope lifted a denial it did not name")
+	}
+}
+
+// TestScopes_ReopenUnderWildcardDenial is the "read-only client, except
+// tickets" case — the shape most deployments will actually write, and one that
+// list-subtraction cannot express: removing "ticket" from a deny list of ["*"]
+// leaves ["*"], which still denies everything. Regression test for exactly that
+// bug, caught by TestScopes_MoreScopesNeverNarrows during development.
+func TestScopes_ReopenUnderWildcardDenial(t *testing.T) {
+	t.Parallel()
+	p := mustPolicy(t, `
+client_baselines:
+  apps:
+    applies_to: [app]
+    deny_write: ["*"]
+scope_grants:
+  rela.tickets.write:
+    update: [ticket]
+`)
+	base := p.ceilingFor("app", nil)
+	if base.permitsVerb(OpUpdate, "ticket") {
+		t.Fatal("precondition: deny_write did not deny")
+	}
+
+	c := p.ceilingFor("app", []string{"rela.tickets.write"})
+	if !c.permitsVerb(OpUpdate, "ticket") {
+		t.Error("scope did not carve ticket out of a wildcard denial")
+	}
+	// The carve-out is surgical: it must not lift the wildcard generally, and
+	// must not reach verbs the scope did not name.
+	if c.permitsVerb(OpUpdate, "person") {
+		t.Error("the exception widened beyond the type the scope named")
+	}
+	if c.permitsVerb(OpDelete, "ticket") {
+		t.Error("an update scope also re-opened delete")
+	}
+
+	// And it survives the clamp: a role that may update tickets keeps that.
+	got := c.clamp(RoleDef{Read: []string{"*"}, Update: []string{"ticket", "person"}})
+	if !slices.Contains(got.Update, "ticket") {
+		t.Errorf("Update = %v, want ticket preserved by the scope exception", got.Update)
+	}
+	if slices.Contains(got.Update, "person") {
+		t.Errorf("Update = %v, person should stay denied", got.Update)
+	}
+}
+
+// TestScopes_MoreScopesNeverNarrows is the monotonicity property that makes a
+// scoped token safe to reason about: adding a scope can only widen (within the
+// ceiling), never restrict. If this inverted, a client could be broken by
+// GAINING a permission, which is deeply unintuitive.
+func TestScopes_MoreScopesNeverNarrows(t *testing.T) {
+	t.Parallel()
+	p := mustPolicy(t, `
+client_baselines:
+  apps:
+    applies_to: [app]
+    read: [ticket]
+    deny_update: ["*"]
+scope_grants:
+  a:
+    read: [person]
+  b:
+    update: [ticket]
+`)
+	types := []string{"ticket", "person", "feature", "audit-record"}
+	none := p.ceilingFor("app", nil)
+	both := p.ceilingFor("app", []string{"a", "b"})
+
+	for _, ty := range types {
+		if none.permitsRead(ty) && !both.permitsRead(ty) {
+			t.Errorf("read %q: permitted with no scopes but denied with two", ty)
+		}
+		if none.permitsVerb(OpUpdate, ty) && !both.permitsVerb(OpUpdate, ty) {
+			t.Errorf("update %q: permitted with no scopes but denied with two", ty)
+		}
+	}
+	// And the widening actually happened.
+	if !both.permitsRead("person") || !both.permitsVerb(OpUpdate, "ticket") {
+		t.Error("scopes did not widen as expected")
+	}
+}
+
+// TestScopes_OrderIndependent: scopes union, so the order they arrive in (which
+// is whatever the IdP put in the claim string) must not change the outcome.
+func TestScopes_OrderIndependent(t *testing.T) {
+	t.Parallel()
+	p := mustPolicy(t, `
+client_baselines:
+  apps:
+    applies_to: [app]
+    read: [ticket]
+scope_grants:
+  a:
+    read: [person]
+  b:
+    read: [feature]
+`)
+	ab := p.ceilingFor("app", []string{"a", "b"})
+	ba := p.ceilingFor("app", []string{"b", "a"})
+	for _, ty := range []string{"ticket", "person", "feature", "other"} {
+		if ab.permitsRead(ty) != ba.permitsRead(ty) {
+			t.Errorf("read %q differs by scope order: ab=%v ba=%v",
+				ty, ab.permitsRead(ty), ba.permitsRead(ty))
+		}
+	}
+}
+
+// TestScopes_UnknownContributesNothing: an IdP must not be able to invent
+// capability by minting a scope name the operator never wrote.
+func TestScopes_UnknownContributesNothing(t *testing.T) {
+	t.Parallel()
+	p := mustPolicy(t, `
+client_baselines:
+  apps:
+    applies_to: [app]
+    read: [ticket]
+`)
+	c := p.ceilingFor("app", []string{"rela.admin", "*", "person"})
+	for _, ty := range []string{"person", "audit-record", "anything"} {
+		if c.permitsRead(ty) {
+			t.Errorf("unknown scope granted read on %q", ty)
+		}
+	}
+	if !c.permitsRead("ticket") {
+		t.Error("unknown scopes disturbed the baseline")
+	}
+}
+
+// TestScopes_DoNotMutatePolicy guards a sharing bug: reopen() edits slices that
+// originate in the Policy, so a missing clone would let ONE request's scope set
+// permanently widen the ceiling for every later request. That is a persistent
+// privilege escalation from a single token.
+func TestScopes_DoNotMutatePolicy(t *testing.T) {
+	t.Parallel()
+	p := mustPolicy(t, `
+client_baselines:
+  apps:
+    applies_to: [app]
+    read: [ticket]
+    deny_update: [person]
+scope_grants:
+  wide:
+    read: [person, feature, audit-record]
+    update: [person]
+`)
+	// A request carrying the widening scope.
+	if c := p.ceilingFor("app", []string{"wide"}); !c.permitsRead("person") {
+		t.Fatal("precondition: scope did not widen")
+	}
+	// A later request with NO scopes must see the original ceiling.
+	after := p.ceilingFor("app", nil)
+	if after.permitsRead("person") {
+		t.Error("a scoped request permanently widened the baseline's read allowlist")
+	}
+	if after.permitsVerb(OpUpdate, "person") {
+		t.Error("a scoped request permanently lifted the baseline's deny_update")
+	}
+	if got := p.ClientBaselines["apps"].Read; !slices.Equal(got, []string{"ticket"}) {
+		t.Errorf("policy read list mutated to %v", got)
+	}
+}
+
+// TestClamp_DoesNotAliasRoleBackingArray: clamp takes a RoleDef by value but
+// its slices are shared with the Policy. Writing through them would corrupt the
+// role for every other principal.
+func TestClamp_DoesNotAliasRoleBackingArray(t *testing.T) {
+	t.Parallel()
+	p := mustPolicy(t, `
+client_baselines:
+  apps:
+    applies_to: [app]
+    read: [ticket]
+`)
+	c := p.ceilingFor("app", nil)
+	original := []string{"*"}
+	got := c.clamp(RoleDef{Read: original})
+	if len(got.Read) > 0 {
+		got.Read[0] = "mutated"
+	}
+	if original[0] != "*" {
+		t.Errorf("clamp wrote through to the caller's slice: %v", original)
+	}
+	if base := p.ClientBaselines["apps"].Read; !slices.Equal(base, []string{"ticket"}) {
+		t.Errorf("clamp mutated the policy's own list: %v", base)
+	}
+}
+
+// TestPermissions_DenyWithholds pins AC8 at the compiler layer.
+func TestPermissions_DenyWithholds(t *testing.T) {
+	t.Parallel()
+	p := mustPolicy(t, `
+client_baselines:
+  apps:
+    applies_to: [app]
+    deny_permissions: [history:read]
+`)
+	c := p.ceilingFor("app", nil)
+	if c.permitsPermission("history:read") {
+		t.Error("deny_permissions did not withhold history:read")
+	}
+	if !c.permitsPermission("export:bulk") {
+		t.Error("deny_permissions withheld a permission it did not name")
+	}
+	got := c.clamp(RoleDef{Permissions: []string{"history:read", "export:bulk"}})
+	if slices.Contains(got.Permissions, "history:read") {
+		t.Errorf("Permissions = %v, still holds the withheld permission", got.Permissions)
+	}
+}
+
+// TestCeiling_DisjointnessMakesSelectionDeterministic: load-time validation
+// guarantees one baseline per principal_type, so selection cannot depend on map
+// iteration order. Exercised repeatedly because a map-order bug is flaky by
+// nature and would otherwise pass most runs.
+func TestCeiling_DisjointnessMakesSelectionDeterministic(t *testing.T) {
+	t.Parallel()
+	p := mustPolicy(t, `
+client_baselines:
+  alpha:
+    applies_to: [app]
+    read: [ticket]
+  beta:
+    applies_to: [pat]
+    read: [person]
+  gamma:
+    applies_to: [service]
+    read: [feature]
+`)
+	for range 50 {
+		if c := p.ceilingFor("app", nil); c.name != "alpha" {
+			t.Fatalf("principal_type app selected %q, want alpha", c.name)
+		}
+		if c := p.ceilingFor("pat", nil); c.name != "beta" {
+			t.Fatalf("principal_type pat selected %q, want beta", c.name)
+		}
+	}
+}

--- a/internal/acl/ceilingguard_test.go
+++ b/internal/acl/ceilingguard_test.go
@@ -1,0 +1,275 @@
+package acl
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/Sourcehaven-BV/rela/internal/principal"
+)
+
+// exemptFiles are the files in this package NOT scanned for direct role
+// lookups. Everything else is scanned.
+//
+// The list is an EXEMPTION list, not an inclusion list, so a newly added file
+// fails closed: it must either be clean or be explicitly exempted here with a
+// reason. An inclusion list would silently skip a new evaluation path — the
+// same forget-shaped hole `applies_to` disjointness exists to remove.
+var exemptFiles = map[string]string{
+	// The policy's own accessors and load-time compilation legitimately read
+	// role definitions: they answer "what does this policy declare?", which has
+	// no principal and therefore no ceiling.
+	"policy.go":         "policy structure, no principal in scope",
+	"ceiling.go":        "ceiling definition + load-time validation",
+	"ceilingcompile.go": "the clamp itself — reads roles to narrow them",
+	"declarative.go":    "constructor and policy accessors",
+	"request.go":        "defines roleFor, the clamp point",
+}
+
+// directRoleLookup matches `<something>.Roles[` — the pattern that reaches a
+// RoleDef without passing through the ceiling.
+var directRoleLookup = regexp.MustCompile(`policy\.Roles\[`)
+
+// declarationCheck matches the two shapes that only ask whether a role NAME is
+// declared, discarding the RoleDef. Those cannot leak capability: they gate
+// whether an attribution is added at all, and the resulting role is clamped
+// later when a predicate is asked of it.
+var declarationCheck = regexp.MustCompile(`_,\s*(ok|defined|hasEveryone)\s*:?=`)
+
+// policyWideReporters are functions with NO principal in scope, so there is no
+// ceiling to apply. They answer questions about the policy itself ("does the
+// everyone role grant read on ticket?", "which claims map to a granting
+// role?"), not about one principal's effective access — a ceiling would be
+// meaningless, since it is a property of a caller and these have none.
+//
+// Keep this list tiny. A function that HAS a principal and reports its access
+// belongs on Request and must clamp (grantingAttributions does).
+var policyWideReporters = map[string]bool{
+	"EveryoneGrants": true,
+	"AssertedGrants": true,
+}
+
+// enclosingFunc scans backwards for the nearest `func` declaration, so a
+// finding can be attributed to the function containing it.
+func enclosingFunc(lines []string, idx int) string {
+	re := regexp.MustCompile(`^func(?:\s+\([^)]*\))?\s+(\w+)`)
+	for i := idx; i >= 0; i-- {
+		if m := re.FindStringSubmatch(lines[i]); m != nil {
+			return m[1]
+		}
+	}
+	return ""
+}
+
+// TestNoDirectRoleLookupInEvaluationPaths is the structural guarantee behind
+// client attenuation.
+//
+// The ceiling is enforced by narrowing the RoleDef in [Request.roleFor], which
+// works precisely BECAUSE every evaluation path resolves role names through it.
+// A future path that reaches into policy.Roles directly would silently evaluate
+// against un-attenuated grants — a client restriction that reads correctly in
+// acl.yaml and does nothing at runtime.
+//
+// That failure is invisible: no error, no test breakage, just a restricted
+// client quietly holding its user's full authority. Prose in roleFor's doc
+// cannot catch it; this can.
+func TestNoDirectRoleLookupInEvaluationPaths(t *testing.T) {
+	t.Parallel()
+	all, err := filepath.Glob("*.go")
+	if err != nil {
+		t.Fatalf("glob: %v", err)
+	}
+	scanned := 0
+	for _, name := range all {
+		if strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		if _, exempt := exemptFiles[name]; exempt {
+			continue
+		}
+		scanned++
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			src, err := os.ReadFile(filepath.Clean(name))
+			if err != nil {
+				t.Fatalf("read %s: %v", name, err)
+			}
+			lines := strings.Split(string(src), "\n")
+			for i, line := range lines {
+				if !directRoleLookup.MatchString(line) {
+					continue
+				}
+				if declarationCheck.MatchString(line) {
+					continue // existence check, not a capability read
+				}
+				if fn := enclosingFunc(lines, i); policyWideReporters[fn] {
+					continue // no principal in scope; see policyWideReporters
+				}
+				t.Errorf("%s:%d: direct policy.Roles lookup bypasses the client "+
+					"ceiling — use Request.roleFor instead:\n\t%s",
+					name, i+1, strings.TrimSpace(line))
+			}
+		})
+	}
+
+	// A guard that scans nothing passes silently. Assert it found real work,
+	// so a broken glob or an over-broad exemption list surfaces as a failure
+	// rather than a green run.
+	if scanned < 5 {
+		t.Errorf("scanned only %d files; the guard is not covering the package", scanned)
+	}
+}
+
+// TestRoleFor_AppliesTheCeiling is the positive half: roleFor must actually
+// narrow, or the guard above protects nothing.
+func TestRoleFor_AppliesTheCeiling(t *testing.T) {
+	t.Parallel()
+	p := mustPolicy(t, `
+roles:
+  admin:
+    read: ["*"]
+    create: ["*"]
+    update: ["*"]
+    delete: ["*"]
+    permissions: [history:read]
+client_baselines:
+  apps:
+    applies_to: [app]
+    read: [ticket]
+    deny_write: ["*"]
+    deny_permissions: [history:read]
+`)
+	d, err := NewDeclarative(p, NullGraph{}, NullGraphQueryer{})
+	if err != nil {
+		t.Fatalf("NewDeclarative: %v", err)
+	}
+
+	t.Run("attenuated client", func(t *testing.T) {
+		t.Parallel()
+		req, err := d.ForPrincipal(verifiedClient("svc", "app"))
+		if err != nil {
+			t.Fatalf("ForPrincipal: %v", err)
+		}
+		role, ok := req.roleFor("admin")
+		if !ok {
+			t.Fatal("admin role not found")
+		}
+		if !equalStrings(role.Read, []string{"ticket"}) {
+			t.Errorf("Read = %v, want [ticket] — the wildcard must collapse to the ceiling", role.Read)
+		}
+		// deny_write: ["*"] is a PURE denial, so filterTypes preserves the
+		// role's wildcard (a plain list cannot spell "all except ...") and the
+		// denial is enforced at match time instead. Assert the predicate, which
+		// is what actually gates — not the list, which is expected to look
+		// permissive here.
+		for _, op := range []Op{OpCreate, OpUpdate, OpDelete} {
+			if req.ceiling.permitsVerb(op, "ticket") {
+				t.Errorf("deny_write did not deny %s", op)
+			}
+		}
+		if req.ceiling.permitsPermission("history:read") {
+			t.Error("deny_permissions did not withhold history:read")
+		}
+		if !equalStrings(role.Permissions, []string{}) && len(role.Permissions) > 0 {
+			t.Errorf("Permissions = %v, want the withheld permission filtered out", role.Permissions)
+		}
+	})
+
+	t.Run("interactive user is untouched", func(t *testing.T) {
+		t.Parallel()
+		req, err := d.ForPrincipal(verifiedClient("alice", "user"))
+		if err != nil {
+			t.Fatalf("ForPrincipal: %v", err)
+		}
+		role, ok := req.roleFor("admin")
+		if !ok {
+			t.Fatal("admin role not found")
+		}
+		for name, got := range map[string][]string{
+			"Read": role.Read, "Create": role.Create,
+			"Update": role.Update, "Delete": role.Delete,
+		} {
+			if !equalStrings(got, []string{"*"}) {
+				t.Errorf("%s = %v, want [*] — an interactive user must be unattenuated", name, got)
+			}
+		}
+		if !equalStrings(role.Permissions, []string{"history:read"}) {
+			t.Errorf("Permissions = %v, want [history:read]", role.Permissions)
+		}
+	})
+}
+
+// verifiedClient builds a principal as the JWT gate would: claims populated
+// through the Verified constructor, which is the only way they can be set.
+func verifiedClient(user, principalType string) principal.Principal {
+	return principal.VerifiedFrom(user, principal.ToolDataEntry, principal.Claims{
+		PrincipalType: principalType,
+	})
+}
+
+// TestCeiling_BothPermissionEntryPointsClamp pins that the ENTITY-SCOPED
+// permission check is attenuated too, not just the global one.
+//
+// HoldsPermissionForEntity is what the state-machine transition guard uses
+// (via affordances.requestGuard), so a gap here would let a restricted client
+// perform a guarded transition the ceiling withholds. Both entry points funnel
+// through grantsPermission today; this fails if a future refactor gives the
+// subject-aware path its own lookup.
+func TestCeiling_BothPermissionEntryPointsClamp(t *testing.T) {
+	t.Parallel()
+	p := mustPolicy(t, `
+roles:
+  approver:
+    read: ["*"]
+    permissions: [establish]
+assignments:
+  alice: approver
+client_baselines:
+  apps:
+    applies_to: [app]
+    deny_permissions: [establish]
+`)
+	d, err := NewDeclarative(p, NullGraph{}, NullGraphQueryer{})
+	if err != nil {
+		t.Fatalf("NewDeclarative: %v", err)
+	}
+	ctx := context.Background()
+
+	unrestricted, err := d.ForPrincipal(verifiedClient("alice", "user"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !unrestricted.HoldsPermission(ctx, "establish") {
+		t.Fatal("precondition: alice should hold establish")
+	}
+	if !unrestricted.HoldsPermissionForEntity(ctx, "TKT-1", "establish") {
+		t.Fatal("precondition: alice should hold establish for the entity")
+	}
+
+	client, err := d.ForPrincipal(verifiedClient("alice", "app"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if client.HoldsPermission(ctx, "establish") {
+		t.Error("global HoldsPermission ignored deny_permissions")
+	}
+	if client.HoldsPermissionForEntity(ctx, "TKT-1", "establish") {
+		t.Error("entity-scoped HoldsPermissionForEntity ignored deny_permissions — " +
+			"a restricted client could perform a guarded transition")
+	}
+}
+
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/acl/docs_example_test.go
+++ b/internal/acl/docs_example_test.go
@@ -9,6 +9,96 @@ import (
 	"github.com/Sourcehaven-BV/rela/internal/store/memstore"
 )
 
+// Doc-drift guard: the YAML below is copied verbatim from the "Restricting a
+// client below its user" section of docs/acl-overview.md, and the assertions
+// are the claims that section makes in prose.
+//
+// A documented ACL example that no longer matches behavior is worse than none:
+// a reader will copy it into a deployment and believe a client is restricted.
+func TestDocs_AclOverviewClientAttenuationExampleWorks(t *testing.T) {
+	t.Parallel()
+	p, err := acl.LoadPolicyBytes([]byte(`
+roles:
+  hr:
+    read: [person, ticket]
+    create: [ticket]
+    update: [person, ticket]
+    delete: [ticket]
+assignments:
+  alice: hr
+client_baselines:
+  apps:
+    applies_to: [app]
+    deny_write: ["*"]
+    redact:
+      person: [salary, bsn]
+scope_grants:
+  rela.tickets.write:
+    update: [ticket]
+`))
+	if err != nil {
+		t.Fatalf("the YAML in docs/acl-overview.md does not parse: %v", err)
+	}
+	st := memstore.New()
+	d, err := acl.NewDeclarative(p, acl.NewStoreGraph(st), st)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx := context.Background()
+
+	asClient := func(scopes []string) *acl.Request {
+		t.Helper()
+		req, rErr := d.ForPrincipal(principal.VerifiedFrom(
+			"alice", principal.ToolDataEntry,
+			principal.Claims{PrincipalType: "app", Scopes: scopes}))
+		if rErr != nil {
+			t.Fatal(rErr)
+		}
+		return req
+	}
+
+	// "deny_write: [\"*\"] is shorthand for denying create, update and delete."
+	noScope := asClient(nil)
+	for _, op := range []acl.Op{acl.OpCreate, acl.OpUpdate, acl.OpDelete} {
+		dec := noScope.AuthorizeWrite(ctx, acl.WriteRequest{
+			Op: op, Subject: acl.EntitySubject{Type: "ticket", ID: "TKT-1"},
+		})
+		if dec.Allow {
+			t.Errorf("%s allowed under deny_write: [\"*\"]", op)
+		}
+	}
+
+	// "A ceiling never grants" — reads the user holds are untouched.
+	if res := noScope.ReadQuery(ctx, "ticket"); !res.AllowAll {
+		t.Error("ticket read denied; the baseline only denies writes")
+	}
+
+	// "a scope ... hands one capability back", and only the one it names.
+	scoped := asClient([]string{"rela.tickets.write"})
+	if dec := scoped.AuthorizeWrite(ctx, acl.WriteRequest{
+		Op: acl.OpUpdate, Subject: acl.EntitySubject{Type: "ticket", ID: "TKT-1"},
+	}); !dec.Allow {
+		t.Errorf("rela.tickets.write did not re-open ticket update: %s", dec.Reason)
+	}
+	if dec := scoped.AuthorizeWrite(ctx, acl.WriteRequest{
+		Op: acl.OpUpdate, Subject: acl.EntitySubject{Type: "person", ID: "PERS-1"},
+	}); dec.Allow {
+		t.Error("the scope named only ticket, but person update was allowed")
+	}
+
+	// "A `principal_type` that matches no baseline is unrestricted."
+	unmatched, err := d.ForPrincipal(principal.VerifiedFrom(
+		"alice", principal.ToolDataEntry, principal.Claims{PrincipalType: "user"}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if dec := unmatched.AuthorizeWrite(ctx, acl.WriteRequest{
+		Op: acl.OpUpdate, Subject: acl.EntitySubject{Type: "person", ID: "PERS-1"},
+	}); !dec.Allow {
+		t.Errorf("an interactive user was attenuated: %s", dec.Reason)
+	}
+}
+
 // Doc-drift guard: the YAML below is copied verbatim from the
 // "Roles from a verified identity assertion" section of docs/acl-overview.md.
 // If the policy schema changes and the docs are not updated, this fails —

--- a/internal/acl/policy.go
+++ b/internal/acl/policy.go
@@ -113,6 +113,14 @@ type Policy struct {
 	RoleRelations       map[string]RoleRelationDef `yaml:"role_relations"`
 	InheritRolesThrough []string                   `yaml:"inherit_roles_through"`
 
+	// ClientBaselines and ScopeGrants implement client attenuation
+	// (TKT-IAC8TX): a ceiling that restricts a non-interactive client BELOW
+	// the user it acts as. Unlike every other field here, these can only
+	// REMOVE capability — see the package-level commentary in ceiling.go for
+	// the invariant and why it compiles at load time.
+	ClientBaselines map[string]ClientBaseline `yaml:"client_baselines"`
+	ScopeGrants     map[string]ScopeGrant     `yaml:"scope_grants"`
+
 	// UnmatchedPrincipal decides what happens when a verified principal's
 	// identifier resolves to no [Policy.UserEntityType] entity (the
 	// principal_property lookup found no match). It governs the data-entry
@@ -421,6 +429,8 @@ var knownPolicyKeys = map[string]bool{
 	"role_relations":            true,
 	"inherit_roles_through":     true,
 	"unmatched_principal":       true,
+	"client_baselines":          true,
+	"scope_grants":              true,
 }
 
 // LoadPolicy reads and parses `acl.yaml` at the given path.
@@ -629,8 +639,12 @@ func (p *Policy) validateUnmatchedPrincipal() error {
 
 func (p *Policy) Validate() error {
 	p.normalizeAssertedRoles()
+	p.normalizeClientAttenuation()
 
 	if err := p.validateUnmatchedPrincipal(); err != nil {
+		return err
+	}
+	if err := p.validateClientAttenuation(); err != nil {
 		return err
 	}
 

--- a/internal/acl/readquery.go
+++ b/internal/acl/readquery.go
@@ -25,9 +25,19 @@ type ReadQueryResult struct {
 // via the role-relations whose confers-role grants read on the type.
 // DenyAll when no role grants any kind of read.
 func (r *Request) readQuery(ctx context.Context, entityType string) ReadQueryResult {
+	// A client ceiling that denies reads of this type short-circuits every
+	// grant path below. Checked first because the ceiling can only ever remove:
+	// if it says no, no role — global, conferred or inherited — can say yes.
+	// This also closes the wildcard gap roleFor cannot express in a plain list
+	// (a role holding `read: ["*"]` under `deny_read: [person]` keeps its
+	// wildcard; see filterTypes).
+	if !r.ceiling.permitsRead(entityType) {
+		return ReadQueryResult{DenyAll: true}
+	}
+
 	globals := r.Globals(ctx)
 	for _, a := range globals.Attributions {
-		role, ok := r.d.policy.Roles[a.Role]
+		role, ok := r.roleFor(a.Role)
 		if !ok {
 			continue
 		}
@@ -38,7 +48,7 @@ func (r *Request) readQuery(ctx context.Context, entityType string) ReadQueryRes
 
 	var conferring []string
 	for relType, def := range r.d.policy.RoleRelations {
-		role, ok := r.d.policy.Roles[def.Confers]
+		role, ok := r.roleFor(def.Confers)
 		if !ok {
 			continue
 		}

--- a/internal/acl/request.go
+++ b/internal/acl/request.go
@@ -37,6 +37,14 @@ type Request struct {
 	principal     principal.Principal
 	globals       GlobalRoles
 	globalsLoaded bool
+
+	// ceiling is the client attenuation resolved from the principal's verified
+	// principal_type + scope claims (TKT-IAC8TX). Computed once at
+	// construction: it depends only on the bound principal and the immutable
+	// policy, so there is nothing to invalidate and no reason to recompute it
+	// per call. Inactive (and fully transparent) for an interactive user or any
+	// principal whose type no baseline covers.
+	ceiling compiledCeiling
 }
 
 // ForPrincipal opens a Request scope for `p`. Returns
@@ -48,7 +56,31 @@ func (d *Declarative) ForPrincipal(p principal.Principal) (*Request, error) {
 	if isUnstamped(p) {
 		return nil, fmt.Errorf("%w: User=%q Tool=%q", ErrUnstampedPrincipal, p.User, p.Tool)
 	}
-	return &Request{d: d, principal: p}, nil
+	return &Request{
+		d:         d,
+		principal: p,
+		ceiling:   d.policy.ceilingFor(p.PrincipalType(), p.Scopes()),
+	}, nil
+}
+
+// roleFor resolves a declared role name to its definition, NARROWED by the
+// request's client ceiling.
+//
+// This is THE clamp point for client attenuation. Every evaluation path in this
+// package resolves a role name and then asks a predicate of the result, so
+// narrowing here means read gating, write authorization and permission checks
+// all inherit the ceiling without any of them knowing it exists. Reaching into
+// `r.d.policy.Roles[...]` directly from an evaluation path BYPASSES the ceiling
+// — use this instead. Pinned by TestNoDirectRoleLookupInEvaluationPaths.
+//
+// The returned RoleDef holds plain allowlists; the runtime never learns the
+// word "deny". See ceiling.go for why that is load-bearing.
+func (r *Request) roleFor(name string) (RoleDef, bool) {
+	role, ok := r.d.policy.Roles[name]
+	if !ok {
+		return RoleDef{}, false
+	}
+	return r.ceiling.clamp(role), true
 }
 
 // Globals returns the principal's global role set, computing it on

--- a/internal/acl/resolver.go
+++ b/internal/acl/resolver.go
@@ -270,8 +270,14 @@ func (r *Request) holdsPermission(ctx context.Context, perm string) bool {
 
 // grantsPermission reports whether any role in attrs grants perm.
 func (r *Request) grantsPermission(attrs []RoleAttribution, perm string) bool {
+	// A client ceiling withholding this permission short-circuits every role,
+	// and closes the wildcard gap (a role holding `permissions: ["*"]` keeps
+	// its wildcard through roleFor under a pure denial).
+	if !r.ceiling.permitsPermission(perm) {
+		return false
+	}
 	for _, a := range attrs {
-		role, ok := r.d.policy.Roles[a.Role]
+		role, ok := r.roleFor(a.Role)
 		if !ok {
 			continue
 		}

--- a/internal/aclaudit/ceiling.go
+++ b/internal/aclaudit/ceiling.go
@@ -1,0 +1,327 @@
+package aclaudit
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/Sourcehaven-BV/rela/internal/acl"
+)
+
+// Client-attenuation audit rules (TKT-IAC8TX).
+//
+// These exist because of one specific failure mode: a ceiling that reads like
+// protection and enforces nothing. Unlike a wrong grant — which denies
+// something and gets noticed — a baseline that never matches, or a scope that
+// re-opens something no baseline closed, is completely silent. Nobody files a
+// bug about access they still have.
+//
+// The severities reflect that. An inert baseline is Medium, not Low: an
+// operator who wrote it believes a client is restricted when it is not.
+
+// checkCeilings runs the pure-policy ceiling checks (tier A).
+func checkCeilings(p *acl.Policy) []Finding {
+	f := make([]Finding, 0, 4)
+	f = append(f, checkInertBaseline(p)...)         // A11
+	f = append(f, checkUnreachableScopeGrant(p)...) // A12
+	f = append(f, checkEmptyAppliesTo(p)...)        // A13
+	return f
+}
+
+// A11 — a baseline that narrows nothing. The operator wrote a restriction block
+// and got no restriction; every client of that principal_type keeps its acting
+// user's full grants.
+func checkInertBaseline(p *acl.Policy) []Finding {
+	var f []Finding
+	for _, name := range sortedBaselineNames(p) {
+		b := p.ClientBaselines[name]
+		if b.Narrows() {
+			continue
+		}
+		f = append(f, Finding{
+			Rule: "A11-inert-client-baseline", Severity: Medium, Subject: name,
+			Detail: fmt.Sprintf("client baseline %q declares no restriction, so clients of "+
+				"principal type(s) %s keep their acting user's full access",
+				name, quoteJoin(b.AppliesTo)),
+			Fix: "add a restriction (deny_write, redact, visible, deny_read, deny_permissions), " +
+				"or remove the baseline if the client is meant to be unrestricted",
+		})
+	}
+	return f
+}
+
+// A13 — a baseline with no applies_to matches no principal_type at all. Same
+// class as A11 but a different mistake: the restriction is real, the selector
+// is missing.
+func checkEmptyAppliesTo(p *acl.Policy) []Finding {
+	var f []Finding
+	for _, name := range sortedBaselineNames(p) {
+		if len(p.ClientBaselines[name].AppliesTo) > 0 {
+			continue
+		}
+		f = append(f, Finding{
+			Rule: "A13-baseline-matches-nothing", Severity: Medium, Subject: name,
+			Detail: fmt.Sprintf("client baseline %q has an empty applies_to, so it matches no "+
+				"principal type and never applies", name),
+			Fix: "list the principal_type values this baseline covers " +
+				"(e.g. applies_to: [app, pat, service])",
+		})
+	}
+	return f
+}
+
+// A12 — a scope grant that re-opens something no baseline ever closes.
+//
+// This is the subtle one, and it is worth a finding precisely because the
+// symptom is invisible: the scope appears to work (the capability IS present),
+// so an operator concludes the mechanism is wired up correctly. Then they write
+// a second scope expecting the same and find it inert, because THAT one really
+// did depend on a baseline closing the capability first.
+//
+// Only reported when at least one baseline exists — a policy with scope_grants
+// and no baselines at all is a different (and more obvious) mistake, already
+// covered by the scope being wholly decorative.
+func checkUnreachableScopeGrant(p *acl.Policy) []Finding {
+	if len(p.ClientBaselines) == 0 || len(p.ScopeGrants) == 0 {
+		return nil
+	}
+	var f []Finding
+	for _, scope := range sortedScopeGrantNames(p) {
+		g := p.ScopeGrants[scope]
+		unreachable := unreachableTargets(p, g)
+		if len(unreachable) == 0 {
+			continue
+		}
+		f = append(f, Finding{
+			Rule: "A12-scope-reopens-nothing", Severity: Low, Subject: scope,
+			Detail: fmt.Sprintf("scope grant %q re-opens %s, which no client baseline closes; "+
+				"presenting this scope changes nothing",
+				scope, strings.Join(unreachable, ", ")),
+			Fix: "close the capability in a client_baselines block first, or drop the " +
+				"unreachable entries from the scope grant",
+		})
+	}
+	return f
+}
+
+// unreachableTargets lists the (axis, type) pairs a scope grant re-opens that
+// no baseline restricts. Returns human-readable labels, deduped and sorted.
+func unreachableTargets(p *acl.Policy, g acl.ScopeGrant) []string {
+	seen := map[string]bool{}
+	var out []string
+	note := func(axis, target string) {
+		label := axis + " " + target
+		if !seen[label] {
+			seen[label] = true
+			out = append(out, label)
+		}
+	}
+
+	for _, c := range []struct {
+		axis    string
+		targets []string
+		closed  func(acl.ClientBaseline, string) bool
+	}{
+		{"read", g.Read, func(b acl.ClientBaseline, t string) bool {
+			return restrictsVerb(b.Read, b.DenyRead, t)
+		}},
+		{"create", g.Create, func(b acl.ClientBaseline, t string) bool {
+			return restrictsVerb(b.Create, b.DenyCreate, t)
+		}},
+		{"update", g.Update, func(b acl.ClientBaseline, t string) bool {
+			return restrictsVerb(b.Update, b.DenyUpdate, t)
+		}},
+		{"delete", g.Delete, func(b acl.ClientBaseline, t string) bool {
+			return restrictsVerb(b.Delete, b.DenyDelete, t)
+		}},
+	} {
+		for _, target := range c.targets {
+			if !anyBaseline(p, func(b acl.ClientBaseline) bool { return c.closed(b, target) }) {
+				note(c.axis, target)
+			}
+		}
+	}
+
+	for _, perm := range g.Permissions {
+		closed := anyBaseline(p, func(b acl.ClientBaseline) bool {
+			return restrictsVerb(b.Permissions, b.DenyPermissions, perm)
+		})
+		if !closed {
+			note("permission", perm)
+		}
+	}
+
+	for entityType, fields := range g.Visible {
+		for _, field := range fields {
+			closed := anyBaseline(p, func(b acl.ClientBaseline) bool {
+				return restrictsField(b, entityType, field)
+			})
+			if !closed {
+				note("field", entityType+"."+field)
+			}
+		}
+	}
+
+	sort.Strings(out)
+	return out
+}
+
+// restrictsVerb reports whether an allow/deny pair constrains target — i.e.
+// whether re-opening target could make any difference.
+func restrictsVerb(allow, deny []string, target string) bool {
+	if allow != nil && !containsOrWildcard(allow, target) {
+		return true // closed allowlist that omits target
+	}
+	return containsOrWildcard(deny, target)
+}
+
+// restrictsField reports whether a baseline hides entityType.field.
+func restrictsField(b acl.ClientBaseline, entityType, field string) bool {
+	if v, declared := b.Visible[entityType]; declared {
+		// Closed world: a field the block omits is hidden.
+		return !containsOrWildcard(v, field)
+	}
+	return containsOrWildcard(b.Redact[entityType], field)
+}
+
+func containsOrWildcard(list []string, target string) bool {
+	for _, v := range list {
+		if v == "*" || v == target {
+			return true
+		}
+	}
+	return false
+}
+
+func anyBaseline(p *acl.Policy, pred func(acl.ClientBaseline) bool) bool {
+	for _, b := range p.ClientBaselines {
+		if pred(b) {
+			return true
+		}
+	}
+	return false
+}
+
+// B8 — a ceiling names an entity type or field the metamodel doesn't declare,
+// so it restricts nothing. The same drift class B1/B4 catch for roles: a typo'd
+// type in a DENY position is worse than in a grant, because it silently fails
+// to protect rather than silently failing to permit.
+func checkCeilingsAgainstMetamodel(p *acl.Policy, m MetamodelReader) []Finding {
+	f := make([]Finding, 0, 4)
+	for _, name := range sortedBaselineNames(p) {
+		b := p.ClientBaselines[name]
+		f = append(f, ceilingTypeFindings(
+			"client baseline", name, b.Restriction, m)...)
+	}
+	for _, scope := range sortedScopeGrantNames(p) {
+		g := p.ScopeGrants[scope]
+		f = append(f, ceilingTypeFindings(
+			"scope grant", scope, g.Restriction, m)...)
+	}
+	return f
+}
+
+// ceilingTypeFindings reports undeclared entity types and fields in one block.
+func ceilingTypeFindings(
+	kind, name string, r acl.Restriction, m MetamodelReader,
+) []Finding {
+	var f []Finding
+	seen := map[string]bool{}
+
+	for _, c := range []struct {
+		axis  string
+		types []string
+	}{
+		{"read", r.Read}, {"create", r.Create}, {"update", r.Update}, {"delete", r.Delete},
+		{"deny_read", r.DenyRead}, {"deny_create", r.DenyCreate},
+		{"deny_update", r.DenyUpdate}, {"deny_delete", r.DenyDelete},
+	} {
+		for _, t := range c.types {
+			if t == "*" || m.HasEntityType(t) || seen[t] {
+				continue
+			}
+			seen[t] = true
+			f = append(f, Finding{
+				Rule: "B8-ceiling-undeclared-type", Severity: High, Subject: name,
+				Detail: fmt.Sprintf("%s %q names entity type %q (under %s) which the metamodel "+
+					"does not declare; the restriction matches nothing",
+					kind, name, t, c.axis),
+				Fix: fmt.Sprintf("declare entity type %q, or fix the %s entry (check for a typo)",
+					t, c.axis),
+			})
+		}
+	}
+
+	for _, m2 := range []struct {
+		axis   string
+		fields map[string][]string
+	}{{"visible", r.Visible}, {"redact", r.Redact}} {
+		for _, entityType := range sortedFieldMapKeys(m2.fields) {
+			if !m.HasEntityType(entityType) {
+				if !seen[entityType] {
+					seen[entityType] = true
+					f = append(f, Finding{
+						Rule: "B8-ceiling-undeclared-type", Severity: High, Subject: name,
+						Detail: fmt.Sprintf("%s %q names entity type %q (under %s) which the "+
+							"metamodel does not declare; the restriction matches nothing",
+							kind, name, entityType, m2.axis),
+						Fix: fmt.Sprintf("declare entity type %q, or fix the %s key",
+							entityType, m2.axis),
+					})
+				}
+				continue
+			}
+			for _, field := range m2.fields[entityType] {
+				if field == "*" || m.HasField(entityType, field) {
+					continue
+				}
+				f = append(f, Finding{
+					Rule: "B9-ceiling-undeclared-field", Severity: Medium, Subject: name,
+					Detail: fmt.Sprintf("%s %q names field %q on %q (under %s) which the metamodel "+
+						"does not declare", kind, name, field, entityType, m2.axis),
+					Fix: fmt.Sprintf("declare property %q on %q, or fix the %s entry",
+						field, entityType, m2.axis),
+				})
+			}
+		}
+	}
+	return f
+}
+
+func sortedBaselineNames(p *acl.Policy) []string {
+	out := make([]string, 0, len(p.ClientBaselines))
+	for k := range p.ClientBaselines {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func sortedScopeGrantNames(p *acl.Policy) []string {
+	out := make([]string, 0, len(p.ScopeGrants))
+	for k := range p.ScopeGrants {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func sortedFieldMapKeys(m map[string][]string) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func quoteJoin(in []string) string {
+	if len(in) == 0 {
+		return "(none)"
+	}
+	out := make([]string, 0, len(in))
+	for _, v := range in {
+		out = append(out, fmt.Sprintf("%q", v))
+	}
+	return strings.Join(out, ", ")
+}

--- a/internal/aclaudit/ceiling_test.go
+++ b/internal/aclaudit/ceiling_test.go
@@ -1,0 +1,281 @@
+package aclaudit
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/Sourcehaven-BV/rela/internal/acl"
+)
+
+// Client-attenuation audit rules (TKT-IAC8TX).
+//
+// Every rule here targets a ceiling that is SILENTLY inert. That is the whole
+// justification for auditing them: a broken grant denies something and someone
+// complains, but a broken restriction just... doesn't restrict, and nobody
+// files a bug about access they still have.
+
+func mustLoad(t *testing.T, body string) *acl.Policy {
+	t.Helper()
+	p, err := acl.LoadPolicyBytes([]byte(body))
+	if err != nil {
+		t.Fatalf("LoadPolicyBytes: %v", err)
+	}
+	return p
+}
+
+// personMeta declares a person type so the tier-B ceiling checks have a schema
+// to cross-check against.
+var personMeta = fakeMetamodel{
+	types: map[string]bool{"person": true, "ticket": true},
+	fields: map[string]map[string][]string{
+		"person": {"name": nil, "email": nil, "salary": nil},
+		"ticket": {"title": nil, "status": nil},
+	},
+}
+
+// TestAudit_A11_InertBaseline: a baseline that narrows nothing. The operator
+// believes a client is restricted; it holds its user's full access.
+func TestAudit_A11_InertBaseline(t *testing.T) {
+	t.Parallel()
+	p := mustLoad(t, `
+client_baselines:
+  apps:
+    applies_to: [app]
+    description: "locked down"
+`)
+	f := Audit(p, personMeta)
+	if !hasRule(f, "A11-inert-client-baseline") {
+		t.Fatal("a baseline with no restriction produced no finding")
+	}
+	// Medium, not Low: this is a believed-but-absent control, not cosmetic drift.
+	if got := ruleSeverity(f, "A11-inert-client-baseline"); got != Medium {
+		t.Errorf("severity = %v, want Medium", got)
+	}
+}
+
+func TestAudit_A11_RestrictiveBaseline_NoFinding(t *testing.T) {
+	t.Parallel()
+	p := mustLoad(t, `
+client_baselines:
+  apps:
+    applies_to: [app]
+    redact:
+      person: [salary]
+`)
+	if f := Audit(p, personMeta); hasRule(f, "A11-inert-client-baseline") {
+		t.Error("a baseline with a redact block was reported inert")
+	}
+}
+
+// TestAudit_A13_EmptyAppliesTo: the restriction is real but selects nothing.
+func TestAudit_A13_EmptyAppliesTo(t *testing.T) {
+	t.Parallel()
+	p := mustLoad(t, `
+client_baselines:
+  apps:
+    applies_to: []
+    deny_write: ["*"]
+`)
+	f := Audit(p, personMeta)
+	if !hasRule(f, "A13-baseline-matches-nothing") {
+		t.Fatal("a baseline with empty applies_to produced no finding")
+	}
+}
+
+// TestAudit_A12_ScopeReopensNothing is the subtle one. The scope APPEARS to
+// work — the capability is present — so an operator concludes the mechanism is
+// wired correctly, then writes a second scope that really does depend on a
+// baseline closing something first and finds it inert.
+func TestAudit_A12_ScopeReopensNothing(t *testing.T) {
+	t.Parallel()
+	p := mustLoad(t, `
+client_baselines:
+  apps:
+    applies_to: [app]
+    redact:
+      person: [salary]
+scope_grants:
+  rela.tickets.write:
+    update: [ticket]
+`)
+	f := Audit(p, personMeta)
+	if !hasRule(f, "A12-scope-reopens-nothing") {
+		t.Fatal("a scope re-opening a capability no baseline closes produced no finding")
+	}
+	// The message must name what is unreachable, or the operator cannot act.
+	var detail string
+	for _, x := range f {
+		if x.Rule == "A12-scope-reopens-nothing" {
+			detail = x.Detail
+		}
+	}
+	if !strings.Contains(detail, "update ticket") {
+		t.Errorf("detail %q does not name the unreachable target", detail)
+	}
+}
+
+func TestAudit_A12_ScopeReopensSomething_NoFinding(t *testing.T) {
+	t.Parallel()
+	p := mustLoad(t, `
+client_baselines:
+  apps:
+    applies_to: [app]
+    deny_write: ["*"]
+scope_grants:
+  rela.tickets.write:
+    update: [ticket]
+`)
+	if f := Audit(p, personMeta); hasRule(f, "A12-scope-reopens-nothing") {
+		t.Error("a scope carving out of deny_write was reported unreachable")
+	}
+}
+
+// TestAudit_A12_FieldReopen covers the field axis of the same rule, including
+// the closed-world case: a `visible:` block that omits a field IS closing it,
+// so a scope re-opening that field is reachable.
+func TestAudit_A12_FieldReopen(t *testing.T) {
+	t.Parallel()
+	t.Run("redact closes it", func(t *testing.T) {
+		t.Parallel()
+		p := mustLoad(t, `
+client_baselines:
+  apps:
+    applies_to: [app]
+    redact:
+      person: [salary]
+scope_grants:
+  rela.payroll:
+    visible:
+      person: [salary]
+`)
+		if f := Audit(p, personMeta); hasRule(f, "A12-scope-reopens-nothing") {
+			t.Error("a scope re-opening a redacted field was reported unreachable")
+		}
+	})
+
+	t.Run("closed-world visible closes it", func(t *testing.T) {
+		t.Parallel()
+		p := mustLoad(t, `
+client_baselines:
+  apps:
+    applies_to: [app]
+    visible:
+      person: [name]
+scope_grants:
+  rela.payroll:
+    visible:
+      person: [salary]
+`)
+		if f := Audit(p, personMeta); hasRule(f, "A12-scope-reopens-nothing") {
+			t.Error("a `visible:` block omitting salary does close it; the scope is reachable")
+		}
+	})
+
+	t.Run("nothing closes it", func(t *testing.T) {
+		t.Parallel()
+		p := mustLoad(t, `
+client_baselines:
+  apps:
+    applies_to: [app]
+    deny_write: ["*"]
+scope_grants:
+  rela.payroll:
+    visible:
+      person: [salary]
+`)
+		if f := Audit(p, personMeta); !hasRule(f, "A12-scope-reopens-nothing") {
+			t.Error("no baseline constrains person fields; the scope re-opens nothing")
+		}
+	})
+}
+
+// TestAudit_B8_CeilingUndeclaredType: a typo'd type in a DENY position is worse
+// than in a grant — it silently fails to PROTECT rather than failing to permit.
+func TestAudit_B8_CeilingUndeclaredType(t *testing.T) {
+	t.Parallel()
+	p := mustLoad(t, `
+client_baselines:
+  apps:
+    applies_to: [app]
+    deny_read: [persno]
+`)
+	f := Audit(p, personMeta)
+	if !hasRule(f, "B8-ceiling-undeclared-type") {
+		t.Fatal("a deny_read on an undeclared type produced no finding")
+	}
+	if got := ruleSeverity(f, "B8-ceiling-undeclared-type"); got != High {
+		t.Errorf("severity = %v, want High — a typo'd denial protects nothing", got)
+	}
+}
+
+func TestAudit_B8_RedactKeyUndeclaredType(t *testing.T) {
+	t.Parallel()
+	p := mustLoad(t, `
+client_baselines:
+  apps:
+    applies_to: [app]
+    redact:
+      persno: [salary]
+`)
+	if f := Audit(p, personMeta); !hasRule(f, "B8-ceiling-undeclared-type") {
+		t.Error("a redact block keyed on an undeclared type produced no finding")
+	}
+}
+
+// TestAudit_B9_CeilingUndeclaredField: the field-level equivalent.
+func TestAudit_B9_CeilingUndeclaredField(t *testing.T) {
+	t.Parallel()
+	p := mustLoad(t, `
+client_baselines:
+  apps:
+    applies_to: [app]
+    redact:
+      person: [salaryy]
+`)
+	f := Audit(p, personMeta)
+	if !hasRule(f, "B9-ceiling-undeclared-field") {
+		t.Fatal("a redact naming an undeclared field produced no finding")
+	}
+}
+
+func TestAudit_B9_DeclaredFields_NoFinding(t *testing.T) {
+	t.Parallel()
+	p := mustLoad(t, `
+client_baselines:
+  apps:
+    applies_to: [app]
+    redact:
+      person: [salary]
+    visible:
+      ticket: [title]
+`)
+	f := Audit(p, personMeta)
+	if hasRule(f, "B9-ceiling-undeclared-field") || hasRule(f, "B8-ceiling-undeclared-type") {
+		t.Error("a correct ceiling produced a drift finding")
+	}
+}
+
+// TestAudit_NoCeilings_NoFindings confirms the new rules are silent on every
+// existing policy: this feature is opt-in, and an operator who has never heard
+// of it must not suddenly see findings.
+func TestAudit_NoCeilings_NoFindings(t *testing.T) {
+	t.Parallel()
+	p := mustLoad(t, `
+roles:
+  reader:
+    read: ["*"]
+assignments:
+  alice: reader
+`)
+	for _, rule := range []string{
+		"A11-inert-client-baseline",
+		"A12-scope-reopens-nothing",
+		"A13-baseline-matches-nothing",
+		"B8-ceiling-undeclared-type",
+		"B9-ceiling-undeclared-field",
+	} {
+		if hasRule(Audit(p, personMeta), rule) {
+			t.Errorf("policy with no attenuation config produced %s", rule)
+		}
+	}
+}

--- a/internal/aclaudit/tier_a.go
+++ b/internal/aclaudit/tier_a.go
@@ -21,6 +21,7 @@ func tierA(p *acl.Policy) []Finding {
 	f = append(f, checkDeadPermissions(p)...)       // A7
 	f = append(f, checkWildcardWriteSprawl(p)...)   // A9
 	f = append(f, checkNameWhitespace(p)...)        // A10
+	f = append(f, checkCeilings(p)...)              // A11 / A12 / A13
 	return f
 }
 

--- a/internal/aclaudit/tier_b.go
+++ b/internal/aclaudit/tier_b.go
@@ -13,12 +13,13 @@ import (
 // sentinel, which is not an entity type (RR-TZ2S3G).
 func tierB(p *acl.Policy, m MetamodelReader) []Finding {
 	f := make([]Finding, 0, 8)
-	f = append(f, checkUndeclaredEntityTypes(p, m)...)  // B1
-	f = append(f, checkUndeclaredRelations(p, m)...)    // B2
-	f = append(f, checkMembershipFromCompat(p, m)...)   // B3
-	f = append(f, checkUndeclaredFields(p, m)...)       // B4
-	f = append(f, checkUndeclaredOptions(p, m)...)      // B5
-	f = append(f, checkUserEntityTypeDeclared(p, m)...) // B7
+	f = append(f, checkUndeclaredEntityTypes(p, m)...)    // B1
+	f = append(f, checkUndeclaredRelations(p, m)...)      // B2
+	f = append(f, checkMembershipFromCompat(p, m)...)     // B3
+	f = append(f, checkUndeclaredFields(p, m)...)         // B4
+	f = append(f, checkUndeclaredOptions(p, m)...)        // B5
+	f = append(f, checkUserEntityTypeDeclared(p, m)...)   // B7
+	f = append(f, checkCeilingsAgainstMetamodel(p, m)...) // B8 / B9
 	return f
 }
 

--- a/internal/aclmap/mapprincipal.go
+++ b/internal/aclmap/mapprincipal.go
@@ -101,6 +101,29 @@ type MapPrincipalResult struct {
 	// built-in everyone role gives every principal — the "fully cut off"
 	// signal for offboarding (UC2).
 	EveryoneOnly bool `json:"everyone_only"`
+
+	// As and Scopes echo the client attenuation this map was computed under
+	// (TKT-IAC8TX), empty when none was requested. Echoed rather than left
+	// implicit because the same principal yields DIFFERENT maps through
+	// different clients — an artifact that did not say which client it
+	// described would be actively misleading.
+	As     string   `json:"as,omitempty"`
+	Scopes []string `json:"scopes,omitempty"`
+}
+
+// ClientView asks for a map computed as a client of the given principal_type,
+// carrying the given scopes — what `rela acl map --as app` reports.
+//
+// The zero value means "no attenuation": the map covers the principal's own
+// access, which is what every caller predating client attenuation gets.
+type ClientView struct {
+	PrincipalType string
+	Scopes        []string
+}
+
+// isZero reports whether no client view was requested.
+func (c ClientView) isZero() bool {
+	return c.PrincipalType == "" && len(c.Scopes) == 0
 }
 
 // MapPrincipal computes principal P's effective access across the given
@@ -124,6 +147,27 @@ type MapPrincipalResult struct {
 func (e *Engine) MapPrincipal(
 	ctx context.Context, rawPrincipal string, verbFilter acl.Verb, typeFilter string, entityTypes []string,
 ) (*MapPrincipalResult, error) {
+	return e.MapPrincipalAs(ctx, rawPrincipal, verbFilter, typeFilter, entityTypes, ClientView{})
+}
+
+// MapPrincipalAs is [Engine.MapPrincipal] computed as a CLIENT of the
+// principal — the answer to "what can this MCP do when Alice connects it?"
+// (TKT-IAC8TX).
+//
+// A zero view is exactly [Engine.MapPrincipal]. A non-zero one resolves the
+// principal's client ceiling, so the reported access is what the client
+// actually has: the principal's own grants intersected with the baseline its
+// principal_type selects, widened by the scopes it presents.
+//
+// This is why the attenuation claims are stamped through principal.Verified
+// here rather than assembled as a literal: they are unexported precisely so no
+// composite literal can populate them, and an attestation tool must go through
+// the same door the request path does or it reports a different policy than the
+// one that runs.
+func (e *Engine) MapPrincipalAs(
+	ctx context.Context, rawPrincipal string, verbFilter acl.Verb, typeFilter string,
+	entityTypes []string, view ClientView,
+) (*MapPrincipalResult, error) {
 	verbs, err := resolveVerbs(verbFilter)
 	if err != nil {
 		return nil, err
@@ -146,8 +190,18 @@ func (e *Engine) MapPrincipal(
 			EveryoneOnly:  true,
 		}, nil
 	}
-	req, err := e.resolver.ForPrincipal(
-		principal.Principal{User: user, Tool: principal.ToolCLI, RawUser: rawShown})
+	p := principal.Principal{User: user, Tool: principal.ToolCLI, RawUser: rawShown}
+	if !view.isZero() {
+		// Stamp the attenuation claims through the verified constructor — the
+		// only path that can populate them — so the ceiling this map reports is
+		// the one the request path would compute.
+		p = principal.VerifiedFrom(user, principal.ToolCLI, principal.Claims{
+			PrincipalType: view.PrincipalType,
+			Scopes:        view.Scopes,
+		})
+		p.RawUser = rawShown
+	}
+	req, err := e.resolver.ForPrincipal(p)
 	if err != nil {
 		return nil, fmt.Errorf("aclmap: open resolver for %q: %w", user, err)
 	}
@@ -158,6 +212,8 @@ func (e *Engine) MapPrincipal(
 		Raw:           rawShown,
 		Verbs:         verbStrings(verbs),
 		EveryoneOnly:  true, // cleared as soon as a non-everyone route is found
+		As:            view.PrincipalType,
+		Scopes:        view.Scopes,
 	}
 
 	for _, typ := range mapTypes(typeFilter, entityTypes) {

--- a/internal/aclmap/mapprincipal_as_test.go
+++ b/internal/aclmap/mapprincipal_as_test.go
@@ -1,0 +1,199 @@
+package aclmap_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Sourcehaven-BV/rela/internal/aclmap"
+)
+
+// `rela acl map --as` (TKT-IAC8TX).
+//
+// The reason this needs its own coverage rather than trusting the acl-layer
+// tests: aclmap builds its OWN principal, and before this feature it built a
+// plain composite literal — which cannot carry the attenuation claims at all
+// (they are unexported by design). So an attestation tool could silently report
+// un-attenuated access for a client that is in fact restricted. That is the
+// worst failure class for a tool whose entire job is answering "who can do
+// what".
+
+// attenuatedPolicy extends the grounding policy with a client baseline that
+// makes app-type clients read-only, and a scope that hands back ticket writes.
+const attenuatedPolicy = groundingPolicy + `
+client_baselines:
+  apps:
+    applies_to: [app]
+    deny_write: ["*"]
+    deny_read: [incident]
+scope_grants:
+  rela.tickets.write:
+    update: [ticket]
+`
+
+func attenuatedWorld(t *testing.T) *world {
+	t.Helper()
+	return buildWorld(t, attenuatedPolicy,
+		[]ent{
+			{"PERS-ALICE", "person"},
+			{"INC-042", "incident"}, {"TKT-1", "ticket"}, {"PROJ", "project"},
+		},
+		nil,
+	)
+}
+
+// mapAs maps PERS-ALICE under a client view. The principal is fixed because
+// these tests vary the CLIENT, not the user — that is the whole point: one
+// principal, different access depending on what it connects through.
+func mapAs(t *testing.T, w *world, view aclmap.ClientView) *aclmap.MapPrincipalResult {
+	t.Helper()
+	res, err := w.eng.MapPrincipalAs(
+		context.Background(), "PERS-ALICE", "", "", groundingTypes, view)
+	if err != nil {
+		t.Fatalf("MapPrincipalAs(PERS-ALICE, %+v): %v", view, err)
+	}
+	return res
+}
+
+// TestMapPrincipalAs_ReportsAttenuatedAccess is the headline: Alice is a global
+// editor with full ticket CRUD, but an app-type client acting as her is
+// read-only and cannot reach incidents at all.
+func TestMapPrincipalAs_ReportsAttenuatedAccess(t *testing.T) {
+	t.Parallel()
+	w := attenuatedWorld(t)
+
+	// Alice herself: full editor access, as the un-attenuated map reports.
+	direct := mapAs(t, w, aclmap.ClientView{})
+	tk := typeOf(direct, "ticket")
+	if tk == nil {
+		t.Fatal("precondition: Alice should have ticket access")
+	}
+	for _, verb := range []string{"read", "create", "update", "delete"} {
+		if len(tk.Baseline[verb]) == 0 {
+			t.Fatalf("precondition: Alice's ticket baseline is missing %s", verb)
+		}
+	}
+	if typeOf(direct, "incident") == nil {
+		t.Fatal("precondition: Alice should be able to read incidents")
+	}
+
+	// The same Alice, through an app client: reads survive, writes do not.
+	viaApp := mapAs(t, w, aclmap.ClientView{PrincipalType: "app"})
+	tkApp := typeOf(viaApp, "ticket")
+	if tkApp == nil {
+		t.Fatal("ticket access vanished entirely; deny_write should leave read intact")
+	}
+	if len(tkApp.Baseline["read"]) == 0 {
+		t.Error("ticket read lost; the baseline only denies writes")
+	}
+	for _, verb := range []string{"create", "update", "delete"} {
+		if len(tkApp.Baseline[verb]) > 0 {
+			t.Errorf("ticket %s still reported under deny_write: [\"*\"]", verb)
+		}
+	}
+	// deny_read on incident is row-level: the type drops out of the map.
+	if typeOf(viaApp, "incident") != nil {
+		t.Error("incident still reported despite deny_read")
+	}
+}
+
+// TestMapPrincipalAs_ScopeReopens: the map must reflect scopes too, or an
+// operator debugging "why can this token write?" gets a map that disagrees with
+// the runtime.
+func TestMapPrincipalAs_ScopeReopens(t *testing.T) {
+	t.Parallel()
+	w := attenuatedWorld(t)
+
+	withScope := mapAs(t, w, aclmap.ClientView{
+		PrincipalType: "app",
+		Scopes:        []string{"rela.tickets.write"},
+	})
+	tk := typeOf(withScope, "ticket")
+	if tk == nil {
+		t.Fatal("no ticket access reported")
+	}
+	if len(tk.Baseline["update"]) == 0 {
+		t.Error("ticket update missing; rela.tickets.write should re-open it")
+	}
+	// The scope named only update — create and delete stay denied.
+	for _, verb := range []string{"create", "delete"} {
+		if len(tk.Baseline[verb]) > 0 {
+			t.Errorf("ticket %s reported; the scope re-opened only update", verb)
+		}
+	}
+}
+
+// TestMapPrincipalAs_EchoesTheClient: an artifact that does not say which
+// client it describes is actively misleading, because the same principal
+// produces different maps through different clients.
+func TestMapPrincipalAs_EchoesTheClient(t *testing.T) {
+	t.Parallel()
+	w := attenuatedWorld(t)
+
+	res := mapAs(t, w, aclmap.ClientView{
+		PrincipalType: "app",
+		Scopes:        []string{"rela.tickets.write"},
+	})
+	if res.As != "app" {
+		t.Errorf("As = %q, want app", res.As)
+	}
+	if len(res.Scopes) != 1 || res.Scopes[0] != "rela.tickets.write" {
+		t.Errorf("Scopes = %v, want [rela.tickets.write]", res.Scopes)
+	}
+
+	// And an un-attenuated map must not claim a client it did not use.
+	plain := mapAs(t, w, aclmap.ClientView{})
+	if plain.As != "" || len(plain.Scopes) != 0 {
+		t.Errorf("un-attenuated map echoed As=%q Scopes=%v", plain.As, plain.Scopes)
+	}
+}
+
+// TestMapPrincipalAs_ZeroViewMatchesMapPrincipal pins that the new entry point
+// is a strict superset: existing callers must see byte-identical results.
+func TestMapPrincipalAs_ZeroViewMatchesMapPrincipal(t *testing.T) {
+	t.Parallel()
+	w := attenuatedWorld(t)
+	ctx := context.Background()
+
+	old, err := w.eng.MapPrincipal(ctx, "PERS-ALICE", "", "", groundingTypes)
+	if err != nil {
+		t.Fatalf("MapPrincipal: %v", err)
+	}
+	zero := mapAs(t, w, aclmap.ClientView{})
+
+	if len(old.Types) != len(zero.Types) {
+		t.Fatalf("type count differs: %d vs %d", len(old.Types), len(zero.Types))
+	}
+	for i := range old.Types {
+		if old.Types[i].Type != zero.Types[i].Type {
+			t.Errorf("type[%d] = %q vs %q", i, old.Types[i].Type, zero.Types[i].Type)
+		}
+		for verb, routes := range old.Types[i].Baseline {
+			if len(zero.Types[i].Baseline[verb]) != len(routes) {
+				t.Errorf("%s.%s route count differs", old.Types[i].Type, verb)
+			}
+		}
+	}
+	if old.EveryoneOnly != zero.EveryoneOnly {
+		t.Errorf("EveryoneOnly differs: %v vs %v", old.EveryoneOnly, zero.EveryoneOnly)
+	}
+}
+
+// TestMapPrincipalAs_UnmatchedTypeIsUnrestricted: a principal_type no baseline
+// covers must report the principal's own access unchanged (AC3), so an operator
+// checking a type they have not configured is not misled into thinking it is
+// restricted.
+func TestMapPrincipalAs_UnmatchedTypeIsUnrestricted(t *testing.T) {
+	t.Parallel()
+	w := attenuatedWorld(t)
+
+	plain := mapAs(t, w, aclmap.ClientView{})
+	other := mapAs(t, w, aclmap.ClientView{PrincipalType: "some-other-type"})
+
+	if len(other.Types) != len(plain.Types) {
+		t.Errorf("unmatched principal_type changed the map: %d types vs %d",
+			len(other.Types), len(plain.Types))
+	}
+	if typeOf(other, "incident") == nil {
+		t.Error("incident dropped for an unmatched principal_type; no baseline covers it")
+	}
+}

--- a/internal/affordances/ceiling_test.go
+++ b/internal/affordances/ceiling_test.go
@@ -1,0 +1,341 @@
+package affordances_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Sourcehaven-BV/rela/internal/acl"
+	"github.com/Sourcehaven-BV/rela/internal/affordances"
+	"github.com/Sourcehaven-BV/rela/internal/entity"
+	"github.com/Sourcehaven-BV/rela/internal/metamodel"
+	"github.com/Sourcehaven-BV/rela/internal/principal"
+	"github.com/Sourcehaven-BV/rela/internal/store/memstore"
+)
+
+// Client attenuation, field axis (TKT-IAC8TX).
+//
+// These tests pin the ORIGINATING use case: an MCP client connected by an HR
+// user must not see person.salary, even though that user can. The distinguishing
+// property — and the reason this is not just another `visible:` test — is that
+// the SAME acting user gets different results depending on the client they came
+// through.
+
+// ceilingWorld wires a person type with a sensitive salary column, an `hr` role
+// that can see everything, and whatever attenuation policy the test supplies.
+type ceilingWorld struct {
+	resolver *affordances.PolicyResolver
+	decl     *acl.Declarative
+	person   *entity.Entity
+}
+
+func newCeilingWorld(t *testing.T, policyYAML string) ceilingWorld {
+	t.Helper()
+	meta := &metamodel.Metamodel{
+		Entities: map[string]metamodel.EntityDef{
+			"person": {
+				Properties: map[string]metamodel.PropertyDef{
+					"name":   {Type: metamodel.PropertyTypeString},
+					"email":  {Type: metamodel.PropertyTypeString},
+					"salary": {Type: metamodel.PropertyTypeString},
+					"bsn":    {Type: metamodel.PropertyTypeString},
+				},
+			},
+		},
+	}
+	policy, err := acl.LoadPolicyBytes([]byte(policyYAML))
+	if err != nil {
+		t.Fatalf("LoadPolicyBytes: %v", err)
+	}
+
+	ms := memstore.New()
+	mustCreateEntity(t, ms, "alice", "person")
+	p := entity.New("PERS-1", "person")
+	p.SetString("name", "Bob")
+	p.SetString("email", "bob@example.com")
+	p.SetString("salary", "100000")
+	p.SetString("bsn", "123456789")
+	mustCreate(t, ms, p)
+
+	decl, err := acl.NewDeclarative(policy, acl.NewStoreGraph(ms), ms)
+	if err != nil {
+		t.Fatalf("NewDeclarative: %v", err)
+	}
+	resolver, err := affordances.New(meta, storeRelationLookup{ms}, decl)
+	if err != nil {
+		t.Fatalf("affordances.New: %v", err)
+	}
+	return ceilingWorld{resolver: resolver, decl: decl, person: p}
+}
+
+// ctxFor builds a request context the way the dataentry middleware does:
+// a principal carrying verified claims, PLUS the acl.Request attached to ctx.
+// The ceiling is read from that Request — a context with only a principal has
+// no ceiling, which is why the middleware ordering is load-bearing.
+func (w ceilingWorld) ctxFor(t *testing.T, principalType string, scopes []string) context.Context {
+	t.Helper()
+	// The acting user is always alice: the whole point of these tests is that
+	// the SAME user gets different results through different clients, so
+	// varying the user would obscure what is being measured.
+	p := principal.VerifiedFrom("alice", principal.ToolDataEntry, principal.Claims{
+		PrincipalType: principalType,
+		Scopes:        scopes,
+	})
+	ctx := principal.With(context.Background(), p)
+	req, err := w.decl.ForPrincipal(p)
+	if err != nil {
+		t.Fatalf("ForPrincipal: %v", err)
+	}
+	return acl.WithRequest(ctx, req)
+}
+
+func hidden(t *testing.T, v affordances.FieldVerdicts, field string) bool {
+	t.Helper()
+	val, present := v.Visible[field]
+	return present && !val
+}
+
+const hrCanSeeEverything = `
+roles:
+  hr:
+    read: [person]
+    update: [person]
+assignments:
+  alice: hr
+`
+
+// TestCeiling_RedactHidesFieldsTheUserCanSee is the headline case. Alice's role
+// declares no `visible:` block at all, so she sees every property. The MCP
+// acting AS Alice must not see salary or bsn.
+func TestCeiling_RedactHidesFieldsTheUserCanSee(t *testing.T) {
+	t.Parallel()
+	w := newCeilingWorld(t, hrCanSeeEverything+`
+client_baselines:
+  apps:
+    applies_to: [app]
+    redact:
+      person: [salary, bsn]
+`)
+
+	// Alice at the browser: nothing hidden.
+	direct := w.resolver.FieldVerdicts(w.ctxFor(t, "user", nil), w.person)
+	for _, f := range []string{"name", "email", "salary", "bsn"} {
+		if hidden(t, direct, f) {
+			t.Errorf("interactive user: %s hidden, want visible", f)
+		}
+	}
+
+	// The MCP acting as Alice: salary and bsn hidden, the rest untouched.
+	viaApp := w.resolver.FieldVerdicts(w.ctxFor(t, "app", nil), w.person)
+	for _, f := range []string{"salary", "bsn"} {
+		if !hidden(t, viaApp, f) {
+			t.Errorf("attenuated client: %s visible, want hidden", f)
+		}
+	}
+	for _, f := range []string{"name", "email"} {
+		if hidden(t, viaApp, f) {
+			t.Errorf("attenuated client: %s hidden, want visible — redact over-reached", f)
+		}
+	}
+}
+
+// TestCeiling_VisibleIsClosedWorld pins AC4's fail-closed half: a `visible:`
+// ceiling hides everything it does not name, INCLUDING a property added to the
+// metamodel later. That is the property that makes the allowlist spelling worth
+// having — nobody has to remember to redact a new sensitive column.
+func TestCeiling_VisibleIsClosedWorld(t *testing.T) {
+	t.Parallel()
+	w := newCeilingWorld(t, hrCanSeeEverything+`
+client_baselines:
+  apps:
+    applies_to: [app]
+    visible:
+      person: [name]
+`)
+	v := w.resolver.FieldVerdicts(w.ctxFor(t, "app", nil), w.person)
+
+	if hidden(t, v, "name") {
+		t.Error("name hidden, want visible — it is the one field the ceiling names")
+	}
+	// email is NOT named in the ceiling and NOT named in any redact list. Under
+	// an open-world denylist it would leak; under closed-world it must be hidden.
+	// This stands in for "a property added to the metamodel tomorrow".
+	for _, f := range []string{"email", "salary", "bsn"} {
+		if !hidden(t, v, f) {
+			t.Errorf("%s visible, want hidden — `visible:` must be closed-world", f)
+		}
+	}
+}
+
+// TestCeiling_RedactIsOpenWorld is the counterpart: the denylist spelling hides
+// ONLY what it names, so a new property stays visible. Cheaper to write, weaker
+// guarantee — an operator choosing between the two needs both behaviors pinned.
+func TestCeiling_RedactIsOpenWorld(t *testing.T) {
+	t.Parallel()
+	w := newCeilingWorld(t, hrCanSeeEverything+`
+client_baselines:
+  apps:
+    applies_to: [app]
+    redact:
+      person: [salary]
+`)
+	v := w.resolver.FieldVerdicts(w.ctxFor(t, "app", nil), w.person)
+	if !hidden(t, v, "salary") {
+		t.Error("salary visible, want hidden")
+	}
+	if hidden(t, v, "bsn") {
+		t.Error("bsn hidden — redact must hide only what it names")
+	}
+}
+
+// TestCeiling_NeverReGrantsWhatARoleHid is the safety property at the field
+// axis. A role that hides a field via its own `visible:` block must keep it
+// hidden even when a ceiling names it: a ceiling only ever REMOVES.
+//
+// This is the bug the dimension.restrictTo intersection exists to prevent —
+// implementing it as `allow()` in a loop would union, clearing the role's
+// denial and handing the client MORE than its user has.
+func TestCeiling_NeverReGrantsWhatARoleHid(t *testing.T) {
+	t.Parallel()
+	w := newCeilingWorld(t, `
+roles:
+  hr:
+    read: [person]
+    visible:
+      person:
+        - field: name
+assignments:
+  alice: hr
+client_baselines:
+  apps:
+    applies_to: [app]
+    visible:
+      person: [name, salary]
+`)
+	// Alice's role hides salary (closed-world: only name is visible).
+	direct := w.resolver.FieldVerdicts(w.ctxFor(t, "user", nil), w.person)
+	if !hidden(t, direct, "salary") {
+		t.Fatal("precondition: the hr role should already hide salary")
+	}
+
+	// The ceiling names salary — but it must not re-grant it.
+	viaApp := w.resolver.FieldVerdicts(w.ctxFor(t, "app", nil), w.person)
+	if !hidden(t, viaApp, "salary") {
+		t.Error("the ceiling RE-GRANTED a field the role hid — a ceiling may only remove")
+	}
+	if hidden(t, viaApp, "name") {
+		t.Error("name hidden; both the role and the ceiling permit it")
+	}
+}
+
+// TestCeiling_ScopeReopensFields: a scope widens the field ceiling, bounded by
+// what the role allows.
+func TestCeiling_ScopeReopensFields(t *testing.T) {
+	t.Parallel()
+	w := newCeilingWorld(t, hrCanSeeEverything+`
+client_baselines:
+  apps:
+    applies_to: [app]
+    redact:
+      person: [salary, bsn]
+scope_grants:
+  rela.payroll:
+    visible:
+      person: [salary]
+`)
+	v := w.resolver.FieldVerdicts(
+		w.ctxFor(t, "app", []string{"rela.payroll"}), w.person)
+
+	if hidden(t, v, "salary") {
+		t.Error("salary hidden; the rela.payroll scope should re-open it")
+	}
+	if !hidden(t, v, "bsn") {
+		t.Error("bsn visible; the scope named only salary")
+	}
+}
+
+// TestCeiling_UnmatchedPrincipalTypeIsUnrestricted pins AC3 at the field axis:
+// a principal type no baseline covers — including one from a different IdP —
+// keeps exactly its user's visibility.
+func TestCeiling_UnmatchedPrincipalTypeIsUnrestricted(t *testing.T) {
+	t.Parallel()
+	w := newCeilingWorld(t, hrCanSeeEverything+`
+client_baselines:
+  apps:
+    applies_to: [app]
+    redact:
+      person: [salary]
+`)
+	for _, pt := range []string{"", "user", "some-other-idp-type"} {
+		v := w.resolver.FieldVerdicts(w.ctxFor(t, pt, nil), w.person)
+		if hidden(t, v, "salary") {
+			t.Errorf("principal_type %q: salary hidden, want visible (no baseline covers it)", pt)
+		}
+	}
+}
+
+// TestCeiling_AppliesWithoutAnACLRequestOnContext is a regression test for a
+// fail-open found in review.
+//
+// applyClientCeiling originally returned early when ctx carried no acl.Request,
+// so a principal stamped WITHOUT one kept its user's full field visibility —
+// the ceiling silently did not apply. Role resolution had no such gap:
+// resolveViaDeclarative, twenty lines away in the same file, opens a fresh
+// Request when ctx has none. So within a single FieldVerdicts call, roles
+// resolved and the ceiling did not.
+//
+// That is the only direction that matters here. The verb axis was never
+// affected (every ForPrincipal computes the ceiling at construction), but the
+// FIELD axis is the one carrying this feature's originating use case — an MCP
+// acting as an HR user must not see person.salary — and it read the ceiling
+// back out of ctx.
+//
+// Production callers do bind (attachACLRequest, ScriptReader.bind), so this was
+// not a reachable leak; but visibility.PolicyRedactor.HiddenProperties forwards
+// whatever ctx it is handed and binds nothing itself, so the guarantee rested
+// on wiring rather than structure. Now it rests on structure.
+func TestCeiling_AppliesWithoutAnACLRequestOnContext(t *testing.T) {
+	t.Parallel()
+	w := newCeilingWorld(t, hrCanSeeEverything+`
+client_baselines:
+  apps:
+    applies_to: [app]
+    redact:
+      person: [salary]
+`)
+	// A principal, but deliberately NO acl.Request — the shape every test in
+	// this file avoided by going through ctxFor.
+	ctx := principal.With(context.Background(),
+		principal.VerifiedFrom("alice", principal.ToolDataEntry, principal.Claims{
+			PrincipalType: "app",
+		}))
+
+	v := w.resolver.FieldVerdicts(ctx, w.person)
+	if !hidden(t, v, "salary") {
+		t.Error("salary VISIBLE for an attenuated client because no acl.Request was " +
+			"on ctx — the ceiling must not depend on upstream wiring")
+	}
+	if hidden(t, v, "name") {
+		t.Error("name hidden; redact named only salary")
+	}
+}
+
+// TestCeiling_UnstampedPrincipalIsUnrestricted is the counterpart: recovering
+// the Request must NOT invent a ceiling for a principal that has no verified
+// principal_type. An unstamped caller has no claim to key a baseline on, and a
+// ceiling can only narrow — so there is nothing to narrow toward.
+func TestCeiling_UnstampedPrincipalIsUnrestricted(t *testing.T) {
+	t.Parallel()
+	w := newCeilingWorld(t, hrCanSeeEverything+`
+client_baselines:
+  apps:
+    applies_to: [app]
+    redact:
+      person: [salary]
+`)
+	// No principal at all: principal.From returns the unknown/unknown default,
+	// which ForPrincipal rejects as unstamped.
+	v := w.resolver.FieldVerdicts(context.Background(), w.person)
+	if hidden(t, v, "salary") {
+		t.Error("an unstamped principal was attenuated; no baseline covers it")
+	}
+}

--- a/internal/affordances/dimension.go
+++ b/internal/affordances/dimension.go
@@ -44,6 +44,13 @@ type dimension struct {
 	ruleKind string
 }
 
+// kindHidden is the visible dimension's rule kind, used in attribution strings
+// ("affordance:hidden"). Named because three callers now pass it — the
+// role-declared `visible:` block, the historical closed-world opt-in, and the
+// client-attenuation ceiling — and a typo in any one would silently produce a
+// differently-labeled attribution.
+const kindHidden = "hidden"
+
 func newDimension() *dimension {
 	return &dimension{
 		allowed:    map[string]bool{},
@@ -63,6 +70,93 @@ func (d *dimension) allow(field string) {
 	d.allowed[field] = true
 	d.candidates[field] = true
 	delete(d.denyRole, field)
+}
+
+// restrictTo intersects the dimension with a client-attenuation ceiling
+// (TKT-IAC8TX): after it runs, a field is visible only if BOTH the roles and
+// the ceiling permit it.
+//
+// universe is the type's declared fields — needed because the dimension is a
+// sparse deny-map layered over "visible by default". When no role declared a
+// `visible:` block, `allowed` is EMPTY and yet every field is visible; seeding
+// from the universe converts that implicit state into the explicit set this can
+// intersect against. Without it a ceiling applied to an un-gated type would
+// hide everything (allowed stays empty → deny() denies the whole universe).
+//
+// This is deliberately NOT `allow` in a loop. allow() UNIONS — it adds a field
+// and clears any prior denial — which is exactly wrong for a ceiling: a ceiling
+// may only remove, so a field some role already denied must STAY denied even if
+// the ceiling names it. Intersecting keeps both constraints.
+//
+// rule attributes the resulting denials to the baseline rather than a role, so
+// a hidden field is debuggable ("this client is attenuated" vs "no role grants
+// it").
+func (d *dimension) restrictTo(keep, universe []string, rule string) {
+	if !d.optedIn {
+		// Nothing has constrained this dimension yet, so every field is
+		// implicitly visible. Make that explicit before intersecting.
+		for _, f := range universe {
+			d.allowed[f] = true
+			d.candidates[f] = true
+		}
+		// ruleKind labels the DIMENSION ("hidden"), not the individual denial —
+		// per-field attribution comes from denyRole below.
+		d.optIn(kindHidden)
+	}
+
+	allowed := make(map[string]bool, len(keep))
+	for _, f := range keep {
+		allowed[f] = true
+	}
+	// Drop anything currently allowed that the ceiling does not name, recording
+	// the ceiling as the denying rule. Fields already denied stay denied: this
+	// only ever removes from `allowed`.
+	for f := range d.allowed {
+		if !allowed[f] {
+			delete(d.allowed, f)
+			if _, seen := d.denyRole[f]; !seen {
+				d.denyRole[f] = rule
+			}
+		}
+	}
+	// Mention the ceiling's own fields as candidates so a stale ceiling entry
+	// (naming a field the metamodel no longer declares) still reports
+	// consistently rather than vanishing.
+	for f := range allowed {
+		d.candidates[f] = true
+	}
+}
+
+// redact hides exactly the named fields, leaving every other field alone — the
+// open-world sibling of [dimension.restrictTo].
+//
+// Like restrictTo it must seed from the universe when nothing has opted in yet,
+// because deny() emits nothing at all unless the dimension is closed-world. The
+// difference is what survives: here everything EXCEPT the named fields.
+func (d *dimension) redact(fields, universe []string, rule string) {
+	if len(fields) == 0 {
+		return
+	}
+	drop := make(map[string]bool, len(fields))
+	for _, f := range fields {
+		drop[f] = true
+	}
+	if !d.optedIn {
+		for _, f := range universe {
+			if !drop[f] {
+				d.allowed[f] = true
+			}
+			d.candidates[f] = true
+		}
+		d.optIn(kindHidden)
+	}
+	for _, f := range fields {
+		d.candidates[f] = true
+		delete(d.allowed, f)
+		if _, seen := d.denyRole[f]; !seen {
+			d.denyRole[f] = rule
+		}
+	}
 }
 
 // observeDeny records that role denied field (predicate failed). Only

--- a/internal/affordances/resolver.go
+++ b/internal/affordances/resolver.go
@@ -413,6 +413,14 @@ func (r *PolicyResolver) FieldVerdicts(ctx context.Context, e *entity.Entity) Fi
 		}
 	}
 
+	// Client attenuation, field axis (TKT-IAC8TX). Applied AFTER every role
+	// grant because a ceiling only ever removes: whatever the roles allowed,
+	// this can subtract from, and nothing here can add. Applied BEFORE the
+	// universe is resolved so a `visible:` ceiling gets the same closed-world
+	// treatment a role-declared block does — which is what makes a property
+	// added to the metamodel later hidden from a restricted client by default.
+	r.applyClientCeiling(ctx, e.Type, visible)
+
 	fieldUniverse := r.declaredFields(e.Type)
 	out.Writable, out.Attribution = writable.deny(fieldUniverse, out.Attribution)
 	visMap, attr := visible.deny(fieldUniverse, out.Attribution)
@@ -655,6 +663,66 @@ func (r *PolicyResolver) bindingFor(ctx context.Context, e *entity.Entity) (bc *
 		resolver:    r,
 	}
 	return bc, roles
+}
+
+// applyClientCeiling subtracts the request's client-attenuation field ceiling
+// (TKT-IAC8TX) from the visible dimension.
+//
+// It runs after every role grant and can only REMOVE — a ceiling never grants,
+// so a field no role made visible cannot become visible here.
+//
+// The two spellings map onto the dimension's existing vocabulary rather than a
+// parallel mechanism:
+//
+//   - `visible:` opts the dimension into CLOSED WORLD and allows exactly the
+//     named fields, so everything else on the type — including a property added
+//     to the metamodel tomorrow — is hidden. Same machinery, same semantics as
+//     a role-declared `visible:` block.
+//   - `redact:` denies the named fields only, leaving the rest alone.
+//
+// A denial attributed to the ceiling names the baseline rather than a role, so
+// an operator debugging a hidden field can tell "no role grants this" apart
+// from "this client is attenuated".
+func (r *PolicyResolver) applyClientCeiling(ctx context.Context, entityType string, visible *dimension) {
+	// Reuse the per-request scope when one is attached, else open a fresh
+	// Request — mirroring resolveViaDeclarative below.
+	//
+	// The fallback is load-bearing, not defensive. Returning early here (the
+	// original shape) made the ceiling depend on upstream wiring: role
+	// resolution opened its own Request and the ceiling did not, so on a ctx
+	// carrying a principal but no Request the roles applied and the
+	// attenuation silently did NOT. That is the fail-open direction — a
+	// restricted client keeping its user's full field visibility — and it is
+	// invisible, because nothing errors and the roles still resolve.
+	// visibility.PolicyRedactor forwards whatever ctx it is handed and binds
+	// nothing itself, so the guarantee must live here.
+	req := acl.FromContext(ctx)
+	if req == nil {
+		var err error
+		req, err = r.declarative.ForPrincipal(principal.From(ctx))
+		if err != nil {
+			// Unstamped: no verified principal_type, so no baseline can match.
+			// A ceiling only ever narrows, so there is nothing to narrow toward
+			// and returning is correct — unlike the stamped-but-unbound case
+			// above, which this recovers.
+			return
+		}
+	}
+	fc := req.FieldCeilingFor(entityType)
+	if !fc.Constrains() {
+		return
+	}
+	rule := "client-ceiling:" + fc.Baseline
+	universe := r.declaredFields(entityType)
+
+	if fc.Visible != nil {
+		// Closed world. restrictTo INTERSECTS rather than unions — a field some
+		// role already denied stays denied even though the ceiling names it,
+		// because a ceiling may only remove.
+		visible.restrictTo(fc.Visible, universe, rule)
+		return
+	}
+	visible.redact(fc.Redact, universe, rule)
 }
 
 // resolveViaDeclarative resolves the effective role set for

--- a/internal/cli/acl_map.go
+++ b/internal/cli/acl_map.go
@@ -39,6 +39,47 @@ type ACLMapCmd struct {
 	Principal string `help:"Principal to map (a user entity ID, or the raw identifier — email/UPN — when principal_property is set). Omit to map EVERY principal (whole-graph inventory)." default:""`
 	Verb      string `help:"Restrict to one verb: read|create|update|delete. Omit for all four." enum:",read,create,update,delete" default:""`
 	Type      string `help:"Restrict to one entity type. Omit for all declared types." default:""`
+	As        string `help:"Map as a CLIENT of this principal_type (e.g. app, pat, service), applying the matching client_baselines ceiling. Requires --principal." default:""`
+	Scope     string `help:"Space- or comma-separated scopes the client presents, re-opening capability the baseline closed. Requires --as." default:""`
+}
+
+// clientView builds the attenuation view from --as/--scope. Returns an error
+// when the flags are combined in a way that would silently report the wrong
+// thing rather than what the operator asked for.
+func (c *ACLMapCmd) clientView() (aclmap.ClientView, error) {
+	as := strings.TrimSpace(c.As)
+	scopes := splitScopes(c.Scope)
+
+	// --as without --principal would be meaningless: the whole-graph inventory
+	// enumerates principals from the graph, and a client ceiling is a property
+	// of one caller's token. Silently ignoring it would print an unattenuated
+	// map under a flag that promised attenuation.
+	if strings.TrimSpace(c.Principal) == "" && (as != "" || len(scopes) > 0) {
+		return aclmap.ClientView{}, stderrors.New(
+			"--as/--scope describe one client's token, so they require --principal " +
+				"(the whole-graph map has no single caller to attenuate)")
+	}
+	// A scope re-opens what a baseline closed; with no baseline selected there
+	// is nothing to re-open, so this is almost certainly a mistake.
+	if as == "" && len(scopes) > 0 {
+		return aclmap.ClientView{}, stderrors.New(
+			"--scope requires --as: scopes re-open capability a client baseline closed, " +
+				"and without --as no baseline applies")
+	}
+	return aclmap.ClientView{PrincipalType: as, Scopes: scopes}, nil
+}
+
+// splitScopes accepts either the space-delimited form the `scope` claim uses
+// (RFC 6749 §3.3) or a comma-separated list, since a shell user typing a flag
+// will reach for either.
+func splitScopes(v string) []string {
+	fields := strings.FieldsFunc(v, func(r rune) bool {
+		return r == ' ' || r == ',' || r == '\t' || r == '\n'
+	})
+	if len(fields) == 0 {
+		return nil
+	}
+	return fields
 }
 
 // Run executes `rela acl map`. It dispatches to the per-principal view
@@ -53,12 +94,18 @@ func (c *ACLMapCmd) Run(ctx context.Context, svc *readServices) error {
 		return err
 	}
 
+	view, err := c.clientView()
+	if err != nil {
+		return err
+	}
+
 	entityTypes := svc.Meta.EntityTypes()
 	if strings.TrimSpace(c.Principal) == "" {
 		return c.runAll(ctx, engine, entityTypes)
 	}
 
-	result, err := engine.MapPrincipal(ctx, c.Principal, acl.Verb(c.Verb), c.Type, entityTypes)
+	result, err := engine.MapPrincipalAs(
+		ctx, c.Principal, acl.Verb(c.Verb), c.Type, entityTypes, view)
 	if err != nil {
 		return err
 	}
@@ -126,6 +173,18 @@ func writeMapText(r *aclmap.MapPrincipalResult) {
 		who = fmt.Sprintf("%s (%s)", r.Principal, r.Raw)
 	}
 	out.WriteMessage("Effective access for %s — verbs: %s", who, joinVerbs(r.Verbs))
+
+	// Name the client this map describes. Without it the artifact is
+	// ambiguous: the same principal produces different maps through different
+	// clients, and a reader who assumed "Alice's access" would draw the wrong
+	// conclusion from an attenuated one.
+	if r.As != "" {
+		line := `  as client type "` + r.As + `"`
+		if len(r.Scopes) > 0 {
+			line += " with scopes " + strings.Join(r.Scopes, " ")
+		}
+		out.WriteMessage("%s — the client_baselines ceiling is applied below.", line)
+	}
 
 	if r.EveryoneOnly {
 		out.WriteMessage("  Only the built-in everyone baseline — no assigned, group, or graph-conferred access.")

--- a/internal/cli/acl_map_as_test.go
+++ b/internal/cli/acl_map_as_test.go
@@ -1,0 +1,117 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestACLMapCmd_ClientViewValidation pins the flag combinations that must FAIL
+// rather than silently print the wrong thing.
+//
+// The failure being prevented is specific: a flag named --as that promises
+// attenuation but produces an un-attenuated map would tell an operator a
+// restricted client has access it does not, or vice versa. An attestation tool
+// that quietly ignores a flag is worse than one that refuses.
+func TestACLMapCmd_ClientViewValidation(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name      string
+		cmd       ACLMapCmd
+		wantErr   string
+		wantType  string
+		wantScope []string
+	}{
+		{
+			name: "no attenuation flags",
+			cmd:  ACLMapCmd{Principal: "alice"},
+		},
+		{
+			name:     "as with principal",
+			cmd:      ACLMapCmd{Principal: "alice", As: "app"},
+			wantType: "app",
+		},
+		{
+			name:      "space-delimited scopes, as the claim spells them",
+			cmd:       ACLMapCmd{Principal: "alice", As: "app", Scope: "rela.read rela.tickets.write"},
+			wantType:  "app",
+			wantScope: []string{"rela.read", "rela.tickets.write"},
+		},
+		{
+			name:      "comma-delimited scopes, as a shell user types them",
+			cmd:       ACLMapCmd{Principal: "alice", As: "app", Scope: "rela.read,rela.tickets.write"},
+			wantType:  "app",
+			wantScope: []string{"rela.read", "rela.tickets.write"},
+		},
+		{
+			name:    "as without principal is refused",
+			cmd:     ACLMapCmd{As: "app"},
+			wantErr: "--principal",
+		},
+		{
+			name:    "scope without as is refused",
+			cmd:     ACLMapCmd{Principal: "alice", Scope: "rela.read"},
+			wantErr: "--scope requires --as",
+		},
+		{
+			name:    "scope without principal is refused",
+			cmd:     ACLMapCmd{Scope: "rela.read"},
+			wantErr: "--principal",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			view, err := tc.cmd.clientView()
+			if tc.wantErr != "" {
+				if err == nil {
+					t.Fatalf("clientView() = %+v, want an error containing %q", view, tc.wantErr)
+				}
+				if !strings.Contains(err.Error(), tc.wantErr) {
+					t.Errorf("error %q does not contain %q", err, tc.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("clientView() error = %v", err)
+			}
+			if view.PrincipalType != tc.wantType {
+				t.Errorf("PrincipalType = %q, want %q", view.PrincipalType, tc.wantType)
+			}
+			if len(view.Scopes) != len(tc.wantScope) {
+				t.Fatalf("Scopes = %v, want %v", view.Scopes, tc.wantScope)
+			}
+			for i := range tc.wantScope {
+				if view.Scopes[i] != tc.wantScope[i] {
+					t.Errorf("Scopes[%d] = %q, want %q", i, view.Scopes[i], tc.wantScope[i])
+				}
+			}
+		})
+	}
+}
+
+// TestSplitScopes covers the whitespace shapes a claim or a shell can produce.
+func TestSplitScopes(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		in   string
+		want int
+	}{
+		{"", 0},
+		{"   ", 0},
+		{"a", 1},
+		{"a b", 2},
+		{"a  b", 2},  // repeated separators collapse
+		{" a b ", 2}, // leading/trailing ignored
+		{"a,b", 2},   // comma form
+		{"a, b", 2},  // mixed
+		{"a\tb\nc", 3},
+	}
+	for _, tc := range tests {
+		t.Run(tc.in, func(t *testing.T) {
+			t.Parallel()
+			if got := splitScopes(tc.in); len(got) != tc.want {
+				t.Errorf("splitScopes(%q) = %v (%d), want %d elements", tc.in, got, len(got), tc.want)
+			}
+		})
+	}
+}

--- a/internal/dataentry/ceiling_e2e_test.go
+++ b/internal/dataentry/ceiling_e2e_test.go
@@ -1,0 +1,160 @@
+package dataentry
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/Sourcehaven-BV/rela/internal/acl"
+	"github.com/Sourcehaven-BV/rela/internal/entity"
+)
+
+// End-to-end client attenuation over real HTTP (TKT-IAC8TX).
+//
+// The unit tests in internal/acl prove the ceiling computes correctly. These
+// prove it SURVIVES THE REQUEST PATH — a separate question, because the path
+// rebuilds the Principal twice (verifiedPrincipal, then
+// resolvePrincipalEntity) and either rebuild can silently drop a claim. A
+// dropped principal_type matches no baseline, so the client is UNRESTRICTED:
+// the failure is invisible and fails open.
+//
+// READS ONLY. The write gate lives in entitymanager, and `newTestAppV1` does
+// not wire its entitymanager with the same ACL as the router (the same
+// limitation noted in acl_write_test.go), so a write test here would exercise a
+// NopACL manager and pass no matter what the ceiling said — worse than no test.
+// Write-path attenuation is covered at the gate itself, in
+// internal/entitymanager/ceiling_test.go.
+
+// ceilingRequest issues an authenticated GET as the given client.
+func ceilingRequest(t *testing.T, app *App, path string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, path, http.NoBody)
+	req.Header.Set(assertionHeader, "good")
+	rec := httptest.NewRecorder()
+	app.NewRouter().ServeHTTP(rec, req)
+	return rec
+}
+
+// denyReadApp wires an App where app-type clients cannot read tickets at all,
+// while the acting user is a full editor.
+func denyReadApp(t *testing.T) *App {
+	t.Helper()
+	app := newTestAppV1(t)
+	seedEntity(app, &entity.Entity{
+		ID: "TKT-001", Type: "ticket", Properties: map[string]any{"title": "T1"},
+	})
+	policy, err := acl.LoadPolicyBytes([]byte(`
+roles:
+  editor:
+    read: [ticket]
+    update: [ticket]
+assignments:
+  usr_alice: editor
+client_baselines:
+  apps:
+    applies_to: [app]
+    deny_read: [ticket]
+`))
+	if err != nil {
+		t.Fatalf("LoadPolicyBytes: %v", err)
+	}
+	app.acl = mustNewACL(t, policy, app.store)
+	app.SetPrincipalResolver(ChainResolvers(JWTPrincipalResolver(stubVerifier{
+		validToken: "good", subject: "usr_alice", principalType: "app",
+	}, assertionHeader)))
+	return app
+}
+
+// TestCeilingE2E_DenyReadIsIndistinguishableFrom404 pins AC9, the one place
+// client attenuation touches a secrecy boundary.
+//
+// Row-level denial must make the entity NONEXISTENT, not forbidden: a 403 on a
+// denied read is an existence oracle, telling the caller the id is real. The
+// two responses must be byte-identical.
+func TestCeilingE2E_DenyReadIsIndistinguishableFrom404(t *testing.T) {
+	app := denyReadApp(t)
+
+	denied := ceilingRequest(t, app, "/api/v1/tickets/TKT-001")
+	absent := ceilingRequest(t, app, "/api/v1/tickets/TKT-NOPE")
+
+	if denied.Code != http.StatusNotFound {
+		t.Errorf("denied read = %d, want 404 (a 403 is an existence oracle)\n%s",
+			denied.Code, denied.Body)
+	}
+	if absent.Code != http.StatusNotFound {
+		t.Fatalf("missing entity = %d, want 404", absent.Code)
+	}
+	// Compare the bodies with the echoed request path normalized away: the
+	// `instance` field legitimately differs (it is the URL the caller just
+	// typed, so it reveals nothing they did not already know). Everything else
+	// — status, type, title — must be identical, since any difference there is
+	// the oracle.
+	normalize := func(rec *httptest.ResponseRecorder, id string) string {
+		return strings.ReplaceAll(rec.Body.String(), id, "<id>")
+	}
+	if got, want := normalize(denied, "TKT-001"), normalize(absent, "TKT-NOPE"); got != want {
+		t.Errorf("denied and missing responses differ beyond the echoed path — "+
+			"the difference IS the oracle:\n denied:  %s\n missing: %s", got, want)
+	}
+}
+
+// TestCeilingE2E_DenyReadPrunesTheList: the row must also vanish from list
+// responses, or the 404 above is undone by the collection endpoint.
+func TestCeilingE2E_DenyReadPrunesTheList(t *testing.T) {
+	app := denyReadApp(t)
+
+	rec := ceilingRequest(t, app, "/api/v1/tickets")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET list = %d, want 200\n%s", rec.Code, rec.Body)
+	}
+	var payload struct {
+		Entities []json.RawMessage `json:"entities"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("decode list: %v\n%s", err, rec.Body)
+	}
+	if len(payload.Entities) != 0 {
+		t.Errorf("list returned %d entities under deny_read; want none pruned in\n%s",
+			len(payload.Entities), rec.Body)
+	}
+	if strings.Contains(rec.Body.String(), "TKT-001") {
+		t.Errorf("denied id leaked into the list body:\n%s", rec.Body)
+	}
+}
+
+// TestCeilingE2E_RESTSurfacesInheritTheCeiling probes REST routes beyond the
+// two the AC tests cover, confirming the ceiling reaches them all rather than
+// just the entity GET and list.
+//
+// It is a survey rather than a per-route assertion on purpose: the ceiling
+// rides on the acl.Request that attachACLRequest attaches to every /api/ path
+// (isAPIPath), so coverage is structural. What this pins is that no probed
+// surface leaks a denied id into its body.
+func TestCeilingE2E_RESTSurfacesInheritTheCeiling(t *testing.T) {
+	app := denyReadApp(t)
+
+	// Collection-shaped surfaces only. A per-entity GET is excluded because its
+	// 404 body echoes the requested path — which contains the id the caller
+	// just typed, so it is not a leak. That case is covered precisely by
+	// TestCeilingE2E_DenyReadIsIndistinguishableFrom404, which normalizes the
+	// echoed path away and compares everything else.
+	for _, path := range []string{
+		"/api/v1/tickets",
+		"/api/v1/_search?q=T1",
+		"/api/v1/_analyze",
+		"/api/v1/_sidebar",
+		"/api/v1/_schema",
+	} {
+		t.Run(path, func(t *testing.T) {
+			rec := ceilingRequest(t, app, path)
+			if rec.Code >= 500 {
+				t.Fatalf("%s = %d (server error)\n%s", path, rec.Code, rec.Body)
+			}
+			if strings.Contains(rec.Body.String(), "TKT-001") {
+				t.Errorf("%s leaked the denied entity id:\n%s", path, rec.Body)
+			}
+		})
+	}
+}

--- a/internal/dataentry/jwt_principal_test.go
+++ b/internal/dataentry/jwt_principal_test.go
@@ -17,6 +17,9 @@ type stubVerifier struct {
 	orgID      string
 	orgSlug    string
 	roles      []string
+	// principalType and scopes drive client attenuation (TKT-IAC8TX).
+	principalType string
+	scopes        []string
 }
 
 func (s stubVerifier) VerifyAssertion(_ context.Context, raw string) (AssertedIdentity, error) {
@@ -24,10 +27,12 @@ func (s stubVerifier) VerifyAssertion(_ context.Context, raw string) (AssertedId
 		return AssertedIdentity{}, errors.New("invalid")
 	}
 	return AssertedIdentity{
-		Subject: s.subject,
-		OrgID:   s.orgID,
-		OrgSlug: s.orgSlug,
-		Roles:   s.roles,
+		Subject:       s.subject,
+		OrgID:         s.orgID,
+		OrgSlug:       s.orgSlug,
+		Roles:         s.roles,
+		PrincipalType: s.principalType,
+		Scopes:        s.scopes,
 	}, nil
 }
 

--- a/internal/dataentry/router.go
+++ b/internal/dataentry/router.go
@@ -377,10 +377,19 @@ func resolvePrincipalEntity(
 		}
 		return ctx
 	}
-	// Rebuild via Verified so the assertion claims survive the substitution.
-	// A plain composite literal here would silently drop org and roles — the
-	// resolved principal would keep its identity but lose every asserted grant.
-	out := principal.Verified(id, p.Tool, p.OrgID(), p.OrgSlug(), p.Roles())
+	// Rebuild via VerifiedFrom so the assertion claims survive the substitution.
+	// A plain composite literal here would silently drop org, roles and the
+	// attenuation claims — the resolved principal would keep its identity but
+	// lose every asserted grant AND its ceiling. Losing the ceiling is the
+	// dangerous direction: it would silently WIDEN a restricted client to its
+	// acting user's full grants. Pinned by TestResolvePrincipalEntity_*.
+	out := principal.VerifiedFrom(id, p.Tool, principal.Claims{
+		OrgID:         p.OrgID(),
+		OrgSlug:       p.OrgSlug(),
+		Roles:         p.Roles(),
+		PrincipalType: p.PrincipalType(),
+		Scopes:        p.Scopes(),
+	})
 	out.RawUser = p.User
 	return principal.With(ctx, out)
 }
@@ -473,6 +482,13 @@ type AssertedIdentity struct {
 	OrgID   string
 	OrgSlug string
 	Roles   []string
+
+	// PrincipalType and Scopes drive client attenuation (TKT-IAC8TX): the
+	// former selects a ceiling in acl.yaml, the latter re-opens pieces of it.
+	// Both are absent for a proxy that doesn't model them, which means "no
+	// ceiling applies" — the principal keeps its acting user's grants.
+	PrincipalType string
+	Scopes        []string
 }
 
 // assertionVerifier verifies a signed assertion and projects the org/role
@@ -567,15 +583,39 @@ func verifiedPrincipal(id AssertedIdentity) (principal.Principal, bool) {
 	// verifier that forgets to. A role that sanitizes away is dropped rather than
 	// kept as "" — an empty role name can never match a policy mapping, so
 	// keeping it would only pad the attribution set.
-	roles := make([]string, 0, len(id.Roles))
-	for _, role := range id.Roles {
-		if s := sanitizeUser(role); s != "" {
-			roles = append(roles, s)
+	roles := sanitizeClaimList(id.Roles)
+	// Scopes get the same treatment for the same reason. A scope that sanitizes
+	// away is dropped rather than kept as "": it could never match a policy
+	// mapping, so keeping it would only re-open nothing at a cost.
+	scopes := sanitizeClaimList(id.Scopes)
+	return principal.VerifiedFrom(user, principal.ToolDataEntry, principal.Claims{
+		OrgID:   sanitizeUser(id.OrgID),
+		OrgSlug: sanitizeUser(id.OrgSlug),
+		Roles:   roles,
+		// A principal_type that sanitizes to "" matches no baseline, which means
+		// unrestricted. That is the correct failure direction: the ceiling is a
+		// restriction on top of the user's own grants, so losing it can never
+		// grant more than the acting user already had.
+		PrincipalType: sanitizeUser(id.PrincipalType),
+		Scopes:        scopes,
+	}), true
+}
+
+// sanitizeClaimList applies sanitizeUser to every element, dropping any that
+// sanitizes to empty. Shared by the roles and scopes projections: both are
+// already bounded by the verifier, and both are policy-map keys where an empty
+// string can never match anything.
+func sanitizeClaimList(in []string) []string {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(in))
+	for _, v := range in {
+		if s := sanitizeUser(v); s != "" {
+			out = append(out, s)
 		}
 	}
-	return principal.Verified(
-		user, principal.ToolDataEntry,
-		sanitizeUser(id.OrgID), sanitizeUser(id.OrgSlug), roles), true
+	return out
 }
 
 // stripBearer trims the header value and removes an optional "Bearer" auth

--- a/internal/entitymanager/ceiling_test.go
+++ b/internal/entitymanager/ceiling_test.go
@@ -1,0 +1,172 @@
+package entitymanager_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/Sourcehaven-BV/rela/internal/acl"
+	"github.com/Sourcehaven-BV/rela/internal/audit"
+	"github.com/Sourcehaven-BV/rela/internal/entity"
+	"github.com/Sourcehaven-BV/rela/internal/entitymanager"
+	"github.com/Sourcehaven-BV/rela/internal/principal"
+	"github.com/Sourcehaven-BV/rela/internal/statemachine"
+	"github.com/Sourcehaven-BV/rela/internal/store/memstore"
+)
+
+// Client attenuation at the WRITE gate (TKT-IAC8TX).
+//
+// manager.go:334 is the single chokepoint every write passes through, so this
+// is where a ceiling either stops a write or does not. The dataentry-level
+// equivalent cannot be written today: newTestAppV1 does not wire its
+// entitymanager with the same ACL as the router (see the note in
+// internal/dataentry/acl_write_test.go), so a dataentry test would exercise a
+// NopACL manager and pass regardless.
+
+const ceilingPolicy = `
+roles:
+  editor:
+    read: [requirement]
+    create: [requirement]
+    update: [requirement]
+    delete: [requirement]
+assignments:
+  alice: editor
+client_baselines:
+  apps:
+    applies_to: [app]
+    deny_write: ["*"]
+scope_grants:
+  rela.req.write:
+    update: [requirement]
+`
+
+// ceilingManager builds a Manager gated by the attenuation policy above, plus a
+// seeded requirement to act on.
+func ceilingManager(t *testing.T) (mgr *entitymanager.Manager, seededID string) {
+	t.Helper()
+	policy, err := acl.LoadPolicyBytes([]byte(ceilingPolicy))
+	if err != nil {
+		t.Fatalf("LoadPolicyBytes: %v", err)
+	}
+	st := memstore.New()
+	decl, err := acl.NewDeclarative(policy, acl.NewStoreGraph(st), st)
+	if err != nil {
+		t.Fatalf("NewDeclarative: %v", err)
+	}
+
+	seeded := entity.New("REQ-001", "requirement")
+	seeded.SetString("title", "seeded")
+	if cErr := st.CreateEntity(context.Background(), seeded); cErr != nil {
+		t.Fatalf("seed: %v", cErr)
+	}
+
+	mgr, err = entitymanager.New(entitymanager.Deps{
+		Store:       st,
+		Meta:        parseMeta(t),
+		Templater:   nopTemplater{},
+		Audit:       audit.Nop{},
+		ACL:         decl,
+		Transitions: statemachine.EmptySet(),
+		FieldGate:   entitymanager.AllowAllFieldGate{},
+	})
+	if err != nil {
+		t.Fatalf("entitymanager.New: %v", err)
+	}
+	return mgr, "REQ-001"
+}
+
+// ctxAsClient stamps a principal the way the verified-JWT gate does.
+func ctxAsClient(principalType string, scopes []string) context.Context {
+	return principal.With(context.Background(), principal.VerifiedFrom(
+		"alice", principal.ToolDataEntry, principal.Claims{
+			PrincipalType: principalType,
+			Scopes:        scopes,
+		}))
+}
+
+func updateTitle(
+	ctx context.Context, t *testing.T, mgr *entitymanager.Manager, id, title string,
+) error {
+	t.Helper()
+	_, err := mgr.PatchEntity(ctx, id, entity.Patch{
+		Properties: map[string]any{"title": title},
+	})
+	return err
+}
+
+// TestCeiling_DenyWriteBlocksTheWrite: Alice is a full editor, but a client
+// under a deny_write baseline cannot write as her.
+func TestCeiling_DenyWriteBlocksTheWrite(t *testing.T) {
+	t.Parallel()
+	mgr, id := ceilingManager(t)
+
+	err := updateTitle(ctxAsClient("app", nil), t, mgr, id, "edited by the app")
+	if err == nil {
+		t.Fatal("update succeeded under deny_write: [\"*\"]")
+	}
+	if !errors.Is(err, acl.ErrForbidden) {
+		t.Fatalf("error = %v, want acl.ErrForbidden", err)
+	}
+
+	// The denial must name the CEILING, not a missing role. An operator told
+	// "no role grants update" would go add a grant that is already there and
+	// watch it keep failing.
+	var fe *acl.ForbiddenError
+	if !errors.As(err, &fe) {
+		t.Fatalf("error is not a *acl.ForbiddenError: %v", err)
+	}
+	if fe.Decision.RuleKind != "client-ceiling" {
+		t.Errorf("RuleKind = %q, want client-ceiling (got reason %q)", fe.Decision.RuleKind, fe.Decision.Reason)
+	}
+	if fe.Decision.RuleID != "apps" {
+		t.Errorf("RuleID = %q, want the baseline name apps", fe.Decision.RuleID)
+	}
+}
+
+// TestCeiling_InteractiveUserWritesFine is the control: the same user, the same
+// policy, arriving as an interactive principal type, is unaffected. A naive
+// "restrict everything" implementation breaks exactly here.
+func TestCeiling_InteractiveUserWritesFine(t *testing.T) {
+	t.Parallel()
+	mgr, id := ceilingManager(t)
+
+	if err := updateTitle(ctxAsClient("user", nil), t, mgr, id, "edited by alice"); err != nil {
+		t.Fatalf("interactive user was attenuated: %v", err)
+	}
+}
+
+// TestCeiling_ScopeReopensTheWrite: the scope restores exactly what it names.
+func TestCeiling_ScopeReopensTheWrite(t *testing.T) {
+	t.Parallel()
+	mgr, id := ceilingManager(t)
+
+	ctx := ctxAsClient("app", []string{"rela.req.write"})
+	if err := updateTitle(ctx, t, mgr, id, "edited via scope"); err != nil {
+		t.Fatalf("rela.req.write did not re-open update: %v", err)
+	}
+
+	// The scope named update only — delete stays denied.
+	if _, err := mgr.DeleteEntity(ctx, id, false); !errors.Is(err, acl.ErrForbidden) {
+		t.Errorf("delete error = %v, want ErrForbidden (the scope re-opened only update)", err)
+	}
+}
+
+// TestCeiling_NeverGrantsPastTheUser is the safety property that makes a scoped
+// token safe to hand out: the SAME token used by a user without the underlying
+// grant still cannot write. The ceiling is an upper bound, never a source.
+func TestCeiling_NeverGrantsPastTheUser(t *testing.T) {
+	t.Parallel()
+	mgr, id := ceilingManager(t)
+
+	// bob holds no assignment at all, but presents the write scope.
+	ctx := principal.With(context.Background(), principal.VerifiedFrom(
+		"bob", principal.ToolDataEntry, principal.Claims{
+			PrincipalType: "app",
+			Scopes:        []string{"rela.req.write"},
+		}))
+
+	if err := updateTitle(ctx, t, mgr, id, "edited by bob"); !errors.Is(err, acl.ErrForbidden) {
+		t.Errorf("error = %v, want ErrForbidden — a scope must not grant past the acting user", err)
+	}
+}

--- a/internal/jwtauth/verifier.go
+++ b/internal/jwtauth/verifier.go
@@ -160,6 +160,19 @@ type AssertionClaims struct {
 	OrgID   string   // the "org_id" claim — the tenant the session is scoped to
 	OrgSlug string   // the "org_slug" claim — human-readable tenant name
 	Roles   []string // the "roles" claim — bare role names, scoped to OrgID
+
+	// PrincipalType is the "principal_type" claim — what KIND of caller this
+	// is (Pratique mints "user"/"app"/"pat"/"service"). Unlike Roles, which
+	// ADD capability, this selects a client-attenuation baseline that only
+	// ever REMOVES it (TKT-IAC8TX). Empty for a proxy that doesn't model it,
+	// which means "no baseline matches" — i.e. unrestricted.
+	PrincipalType string
+
+	// Scopes is the "scope" claim, split on whitespace per RFC 6749 §3.3
+	// (the claim is a space-delimited string, NOT an array — that is why it
+	// does not go through stringSliceClaim). Each scope may re-open capability
+	// the baseline closed, always bounded by what the acting user holds.
+	Scopes []string
 }
 
 // Claim-projection bounds. A verified signature proves the IdP asserted these
@@ -171,6 +184,14 @@ type AssertionClaims struct {
 const (
 	maxRoles     = 32
 	maxRoleRunes = 256
+
+	// Scopes are bounded for the same reason roles are, and separately because
+	// a scope list is attacker-influenceable in a way a role list is not: a
+	// client asks for its own scopes at token-issue time. The ceiling only ever
+	// narrows, so an unbounded scope list cannot escalate — but it can still
+	// cost per-scope work on every request.
+	maxScopes     = 32
+	maxScopeRunes = 256
 )
 
 // VerifyAssertion verifies a request assertion and projects the identity claims
@@ -195,11 +216,13 @@ func (v *Verifier) VerifyAssertion(ctx context.Context, raw string) (AssertionCl
 		return AssertionClaims{}, ErrInvalid
 	}
 	return AssertionClaims{
-		Subject: sub,
-		Email:   stringClaim(claims, "email"),
-		OrgID:   stringClaim(claims, "org_id"),
-		OrgSlug: stringClaim(claims, "org_slug"),
-		Roles:   stringSliceClaim(claims, "roles"),
+		Subject:       sub,
+		Email:         stringClaim(claims, "email"),
+		OrgID:         stringClaim(claims, "org_id"),
+		OrgSlug:       stringClaim(claims, "org_slug"),
+		Roles:         stringSliceClaim(claims, "roles"),
+		PrincipalType: stringClaim(claims, "principal_type"),
+		Scopes:        scopeClaim(claims, "scope"),
 	}, nil
 }
 
@@ -332,6 +355,54 @@ func stringSliceClaim(claims jwt.MapClaims, key string) []string {
 	if truncated {
 		slog.Warn("jwtauth: claim truncated",
 			"claim", key, "limit", maxRoles, "received", len(raw))
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// scopeClaim reads an OAuth `scope` claim: a SPACE-DELIMITED STRING, per
+// RFC 6749 §3.3 — not a JSON array. That is the whole reason it cannot reuse
+// stringSliceClaim.
+//
+// Tolerant of the shapes real providers emit: any run of whitespace separates,
+// and leading/trailing whitespace is ignored, so "a  b " yields ["a","b"]. A
+// non-string claim is treated as absent, matching stringClaim's rationale.
+//
+// As a concession to providers that DO send an array despite the RFC, an array
+// value is accepted too — dropping a caller's scopes because their IdP picked
+// the other encoding would silently over-restrict, and a scope only ever
+// re-opens capability the acting user already holds.
+func scopeClaim(claims jwt.MapClaims, key string) []string {
+	var fields []string
+	switch v := claims[key].(type) {
+	case string:
+		fields = strings.Fields(v)
+	case []any:
+		for _, elem := range v {
+			s, ok := elem.(string)
+			if !ok {
+				continue
+			}
+			fields = append(fields, strings.Fields(s)...)
+		}
+	default:
+		return nil
+	}
+
+	out := make([]string, 0, min(len(fields), maxScopes))
+	truncated := false
+	for _, f := range fields {
+		if len(out) >= maxScopes {
+			truncated = true
+			break
+		}
+		out = append(out, truncateRunes(f, maxScopeRunes))
+	}
+	if truncated {
+		slog.Warn("jwtauth: claim truncated",
+			"claim", key, "limit", maxScopes, "received", len(fields))
 	}
 	if len(out) == 0 {
 		return nil

--- a/internal/principal/principal.go
+++ b/internal/principal/principal.go
@@ -30,6 +30,12 @@
 // the outer limit of what belongs here. Session lifecycle, provisioning, and
 // role *expansion* remain out — they are separate concerns with their own
 // packages.
+//
+// It opened a second time (TKT-IAC8TX) on the same terms: `principalType` and
+// `scopes` earned their place by having an evaluator — internal/acl compiles
+// them into a client-attenuation ceiling. `client_id` was considered and left
+// out precisely because nothing evaluates it; it would be attribution-only
+// clutter, and the ceiling can key on it later if that changes.
 package principal
 
 import (
@@ -55,43 +61,87 @@ import (
 //
 // # Verified assertion claims
 //
-// orgID, orgSlug, and roles carry claims from a CRYPTOGRAPHICALLY VERIFIED
-// identity assertion. They are unexported on purpose: [Verified] is the only
-// way to populate them, so no composite literal anywhere in the tree can forge
-// a role. That matters because internal/acl trusts a Principal absolutely — it
-// verifies nothing itself — so a role reaching it from an unverified source
-// (a spoofable header, say) would be a complete authorization bypass. The
-// compiler enforces the trust boundary here rather than leaving it to a code
-// reviewer's memory.
+// orgID, orgSlug, roles, principalType and scopes carry claims from a
+// CRYPTOGRAPHICALLY VERIFIED identity assertion. They are unexported on
+// purpose: [VerifiedFrom] (and its [Verified] wrapper) is the only way to
+// populate them, so no composite literal anywhere in the tree can forge a role.
+// That matters because internal/acl trusts a Principal absolutely — it verifies
+// nothing itself — so a role reaching it from an unverified source (a spoofable
+// header, say) would be a complete authorization bypass. The compiler enforces
+// the trust boundary here rather than leaving it to a code reviewer's memory.
 //
-// Read them via [Principal.OrgID], [Principal.OrgSlug], [Principal.Roles].
+// Read them via [Principal.OrgID], [Principal.OrgSlug], [Principal.Roles],
+// [Principal.PrincipalType], [Principal.Scopes].
+//
+// The two attenuation claims run the OPPOSITE direction from roles: principalType
+// selects a ceiling that removes capability, and scopes re-open pieces of it
+// bounded by the acting user. So a forged one could only ever narrow — but they
+// share the constructor discipline anyway, because "this claim is safe to forge"
+// is not a property worth asking a future reader to re-derive.
 type Principal struct {
 	User    string
 	Tool    string
 	RawUser string
 
-	orgID   string
-	orgSlug string
-	roles   []string
+	orgID         string
+	orgSlug       string
+	roles         []string
+	principalType string
+	scopes        []string
 }
 
-// Verified constructs a Principal carrying claims from a verified identity
+// Claims carries the verified-assertion fields [VerifiedFrom] stamps onto a
+// Principal. It exists so the claim set can grow without re-churning every
+// call site the way a widening positional signature would: [Verified] already
+// took five arguments, and client attenuation (TKT-IAC8TX) needed two more.
+//
+// A zero Claims is valid — it produces a Principal with no verified claims,
+// which is what every non-assertion entry point wants.
+type Claims struct {
+	OrgID   string
+	OrgSlug string
+	Roles   []string
+
+	// PrincipalType selects a client-attenuation baseline in acl.yaml. Note
+	// the asymmetry with Roles: a role ADDS capability, a principal type only
+	// ever REMOVES it. That is why an unrecognized value is safe to ignore
+	// (no baseline matches → unrestricted) while an unrecognized role is
+	// dropped — both fail toward the acting user's own grants.
+	PrincipalType string
+
+	// Scopes re-open capability a baseline closed, always bounded by what the
+	// acting user holds. A scope can therefore never escalate past the user.
+	Scopes []string
+}
+
+// VerifiedFrom constructs a Principal carrying claims from a verified identity
 // assertion. Callers MUST have validated the assertion's signature before
 // calling this — see the type doc for why that is load-bearing.
 //
-// roles is defensively copied so a later mutation of the caller's slice cannot
-// retroactively change an authorization decision.
-func Verified(user, tool, orgID, orgSlug string, roles []string) Principal {
+// Slice claims are defensively copied so a later mutation of the caller's slice
+// cannot retroactively change an authorization decision.
+func VerifiedFrom(user, tool string, c Claims) Principal {
 	p := Principal{
-		User:    user,
-		Tool:    tool,
-		orgID:   orgID,
-		orgSlug: orgSlug,
+		User:          user,
+		Tool:          tool,
+		orgID:         c.OrgID,
+		orgSlug:       c.OrgSlug,
+		principalType: c.PrincipalType,
 	}
-	if len(roles) > 0 {
-		p.roles = slices.Clone(roles)
+	if len(c.Roles) > 0 {
+		p.roles = slices.Clone(c.Roles)
+	}
+	if len(c.Scopes) > 0 {
+		p.scopes = slices.Clone(c.Scopes)
 	}
 	return p
+}
+
+// Verified is the original positional constructor, retained because it reads
+// well at the many call sites that only ever carry org + roles. It delegates to
+// [VerifiedFrom]; prefer that one when setting the attenuation claims.
+func Verified(user, tool, orgID, orgSlug string, roles []string) Principal {
+	return VerifiedFrom(user, tool, Claims{OrgID: orgID, OrgSlug: orgSlug, Roles: roles})
 }
 
 // OrgID returns the verified `org_id` claim, or "" when the principal did not
@@ -123,6 +173,32 @@ func (p Principal) Roles() []string {
 	return slices.Clone(p.roles)
 }
 
+// PrincipalType returns the verified `principal_type` claim — what KIND of
+// caller this is (e.g. "user", "app", "pat", "service"). Empty for every
+// non-assertion entry point, and for a proxy that does not model it.
+//
+// This selects a client-attenuation baseline in acl.yaml (TKT-IAC8TX). Unlike
+// [Principal.Roles] it can only ever REMOVE capability, never add it, so an
+// unrecognized value is not a security event: no baseline matches and the
+// principal keeps exactly its acting user's grants.
+func (p Principal) PrincipalType() string { return p.principalType }
+
+// Scopes returns the verified `scope` claim, split on whitespace. Empty for
+// every non-assertion entry point.
+//
+// A scope re-opens capability a client baseline closed, always intersected with
+// what the acting user holds — so a scope can never grant past the user. Like
+// [Principal.Roles], these are the IdP's names, mapped through an
+// operator-authored allowlist in acl.yaml; an unknown scope grants nothing.
+//
+// The returned slice is a copy; mutating it cannot affect authorization.
+func (p Principal) Scopes() []string {
+	if len(p.scopes) == 0 {
+		return nil
+	}
+	return slices.Clone(p.scopes)
+}
+
 // IsZero reports whether p carries no identity at all. Entry points use it to
 // reject an unconfigured Principal at construction time.
 //
@@ -147,6 +223,9 @@ func (p Principal) Clone() Principal {
 	if len(p.roles) > 0 {
 		p.roles = slices.Clone(p.roles)
 	}
+	if len(p.scopes) > 0 {
+		p.scopes = slices.Clone(p.scopes)
+	}
 	return p
 }
 
@@ -161,16 +240,23 @@ func (p Principal) Clone() Principal {
 // about what "clean" means.
 func (p Principal) Sanitized(clean func(string) string) Principal {
 	out := Principal{
-		User:    clean(p.User),
-		Tool:    clean(p.Tool),
-		RawUser: clean(p.RawUser),
-		orgID:   clean(p.orgID),
-		orgSlug: clean(p.orgSlug),
+		User:          clean(p.User),
+		Tool:          clean(p.Tool),
+		RawUser:       clean(p.RawUser),
+		orgID:         clean(p.orgID),
+		orgSlug:       clean(p.orgSlug),
+		principalType: clean(p.principalType),
 	}
 	if len(p.roles) > 0 {
 		out.roles = make([]string, 0, len(p.roles))
 		for _, r := range p.roles {
 			out.roles = append(out.roles, clean(r))
+		}
+	}
+	if len(p.scopes) > 0 {
+		out.scopes = make([]string, 0, len(p.scopes))
+		for _, s := range p.scopes {
+			out.scopes = append(out.scopes, clean(s))
 		}
 	}
 	return out
@@ -185,19 +271,23 @@ func (p Principal) Equal(q Principal) bool {
 		p.RawUser == q.RawUser &&
 		p.orgID == q.orgID &&
 		p.orgSlug == q.orgSlug &&
-		slices.Equal(p.roles, q.roles)
+		p.principalType == q.principalType &&
+		slices.Equal(p.roles, q.roles) &&
+		slices.Equal(p.scopes, q.scopes)
 }
 
 // principalJSON is the wire format. It is a separate type because the assertion
 // claims live in unexported fields (see the [Principal] doc), which
 // encoding/json cannot reach in either direction.
 type principalJSON struct {
-	User    string   `json:"user"`
-	Tool    string   `json:"tool"`
-	RawUser string   `json:"raw_user,omitempty"`
-	OrgID   string   `json:"org_id,omitempty"`
-	OrgSlug string   `json:"org_slug,omitempty"`
-	Roles   []string `json:"roles,omitempty"`
+	User          string   `json:"user"`
+	Tool          string   `json:"tool"`
+	RawUser       string   `json:"raw_user,omitempty"`
+	OrgID         string   `json:"org_id,omitempty"`
+	OrgSlug       string   `json:"org_slug,omitempty"`
+	Roles         []string `json:"roles,omitempty"`
+	PrincipalType string   `json:"principal_type,omitempty"`
+	Scopes        []string `json:"scopes,omitempty"`
 }
 
 // MarshalJSON emits the assertion claims alongside the exported fields. Every
@@ -205,12 +295,14 @@ type principalJSON struct {
 // byte-identical to what previous versions wrote.
 func (p Principal) MarshalJSON() ([]byte, error) {
 	return json.Marshal(principalJSON{
-		User:    p.User,
-		Tool:    p.Tool,
-		RawUser: p.RawUser,
-		OrgID:   p.orgID,
-		OrgSlug: p.orgSlug,
-		Roles:   p.roles,
+		User:          p.User,
+		Tool:          p.Tool,
+		RawUser:       p.RawUser,
+		OrgID:         p.orgID,
+		OrgSlug:       p.orgSlug,
+		Roles:         p.roles,
+		PrincipalType: p.principalType,
+		Scopes:        p.scopes,
 	})
 }
 
@@ -227,12 +319,14 @@ func (p *Principal) UnmarshalJSON(data []byte) error {
 		return err
 	}
 	*p = Principal{
-		User:    w.User,
-		Tool:    w.Tool,
-		RawUser: w.RawUser,
-		orgID:   w.OrgID,
-		orgSlug: w.OrgSlug,
-		roles:   w.Roles,
+		User:          w.User,
+		Tool:          w.Tool,
+		RawUser:       w.RawUser,
+		orgID:         w.OrgID,
+		orgSlug:       w.OrgSlug,
+		roles:         w.Roles,
+		principalType: w.PrincipalType,
+		scopes:        w.Scopes,
 	}
 	return nil
 }

--- a/tickets/entities/automated-measures/MEAS-PRINCIPAL-RESTAMP.md
+++ b/tickets/entities/automated-measures/MEAS-PRINCIPAL-RESTAMP.md
@@ -1,0 +1,39 @@
+---
+id: MEAS-PRINCIPAL-RESTAMP
+type: automated-measure
+title: Principal re-stamp sites preserve verified claims
+description: A test that every context re-stamp of a Principal (changing Tool while keeping identity) preserves orgID, orgSlug, roles and RawUser. Guards the class of bug where a plain composite literal silently zeroes the unexported verified-assertion fields.
+kind: test
+location: internal/dataentry/sync_handlers_test.go + internal/principal/
+status: proposed
+---
+
+## What it guards
+
+The trust-boundary design in `internal/principal` (unexported claim fields +
+`Verified()` as sole constructor) makes *forging* a claim impossible but makes
+*dropping* one easy and silent — a composite literal compiles fine and zeroes
+them.
+
+`resolvePrincipalEntity` (`internal/dataentry/router.go:380-382`) carries a
+prose comment warning about this. Prose does not fail CI; `syncContext`
+(`sync_handlers.go:20-23`) has the same shape and the bug (BUG-0Q8MCZ).
+
+## Shape
+
+A table-driven test over the re-stamp sites asserting that a Principal built by
+`principal.Verified(...)` with non-empty org/slug/roles/RawUser survives the
+re-stamp with only `Tool` changed.
+
+Stronger variant worth considering: if the fix introduces a single blessed
+helper (e.g. `principal.WithTool`), test the helper directly and add a lint or
+grep-based guard that no other site constructs a `principal.Principal{...}`
+literal from an existing principal. That converts a convention into a structural
+guarantee — the same move TKT-80EWGM made for `PatchEntity` when it removed the
+raw write-prep handle rather than documenting against it.
+
+## Why automated rather than review
+
+The failure is invisible at the call site: the code compiles, tests pass, and
+the only symptom is an authorization grant quietly not applying in a deployment
+that uses asserted roles. Reviewers have already missed it once.

--- a/tickets/entities/bugs/BUG-0Q8MCZ.md
+++ b/tickets/entities/bugs/BUG-0Q8MCZ.md
@@ -1,0 +1,69 @@
+---
+id: BUG-0Q8MCZ
+type: bug
+title: syncContext drops every verified assertion claim (org, roles) via a plain composite literal
+description: syncContext rebuilds the Principal with a plain composite literal, which cannot carry the unexported verified-assertion fields (orgID, orgSlug, roles) or RawUser. Under a verified-JWT deployment using asserted_role_assignments, every grant sourced from a signed identity assertion evaporates on the sync path. Same failure mode resolvePrincipalEntity explicitly guards against at router.go:380-382.
+priority: medium
+status: backlog
+---
+
+## Symptom
+
+`internal/dataentry/sync_handlers.go:20-23`:
+
+```go
+func syncContext(ctx context.Context) context.Context {
+	p := principal.From(ctx)
+	return principal.With(ctx, principal.Principal{User: p.User, Tool: principal.ToolSync})
+}
+```
+
+This rebuilds the Principal with a **plain composite literal**, which cannot
+carry the unexported verified-assertion fields. So a sync request silently loses
+`orgID`, `orgSlug`, `roles` — and `RawUser`.
+
+## Impact
+
+Under a verified-JWT deployment using `asserted_role_assignments`, every grant
+sourced from a signed identity assertion **evaporates on the sync path**.
+`internal/acl/resolver.go:57-65` is the only consumer of `Principal.Roles()`;
+with an empty role slice it contributes nothing, so a principal whose entire
+authority came from asserted roles is reduced to whatever `Assignments` /
+membership gives it — typically nothing.
+
+`RawUser` loss additionally degrades audit attribution for principals resolved
+via `principal_property`.
+
+## Root cause
+
+This is exactly the failure mode `resolvePrincipalEntity` documents and guards
+against at `internal/dataentry/router.go:380-382` — that call site uses
+`principal.Verified(...)` precisely because a composite literal would drop org
+and roles. `syncContext` is the same re-stamp pattern without the guard.
+
+The trust-boundary design (unexported fields + `Verified()` as sole constructor,
+`internal/principal/principal.go:58-95`) makes forging a claim impossible, but
+it also makes *dropping* one easy and silent: a composite literal compiles fine
+and zeroes them.
+
+## Fix sketch
+
+Re-stamp from the existing principal rather than rebuilding it — clone and
+override `Tool`, or add a `principal.WithTool(p, tool)` helper so the re-stamp
+idiom is available without reaching for a literal. A `Verified(...)` call
+mirroring `router.go:383` also works but restates every field.
+
+Worth considering whether the general shape (re-stamp Tool, keep everything
+else) deserves one blessed helper, since this is the second site to need it and
+the third would likely repeat the bug.
+
+## Notes
+
+Found while planning **TKT-IAC8TX** (client attenuation). That ticket adds
+`principal_type` / `scope` to Principal; both would be dropped here too, which
+would silently disable client attenuation on the sync path. Fixing this is not a
+prerequisite for that ticket, but leaving it unfixed adds a second silently-
+attenuated surface.
+
+No test currently pins claim preservation across `syncContext` — the fix should
+add one.

--- a/tickets/entities/docs-checklists/DOCS-O3LYQN.md
+++ b/tickets/entities/docs-checklists/DOCS-O3LYQN.md
@@ -1,0 +1,62 @@
+---
+id: DOCS-O3LYQN
+type: docs-checklist
+title: 'Documentation: Client attenuation (TKT-IAC8TX)'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Code Documentation
+
+- [x] New exported types and functions carry godoc
+- [x] Non-obvious decisions explain WHY, not just what
+
+The load-time-compilation decision and the matcher-not-expanded-set choice are
+documented at the top of `internal/acl/ceiling.go` and `ceilingcompile.go`
+respectively, because both are the kind of thing a future reader would
+"simplify" into a runtime denial or a metamodel expansion — which is exactly the
+fail-open direction.
+
+## Project Documentation
+
+- [x] `CLAUDE.md` — added a standing rule: "Restrictions compile at LOAD time;
+the evaluator has no denial primitive." Names the clamp point
+(`Request.roleFor`), the guard test, and why a runtime deny would force
+re-deriving `ReadQuery`'s SQL pushdown.
+- [x] `internal/acl/ceiling.go` — package-level commentary on the invariant,
+the disjointness rule, and why there is no combination semantics.
+- [x] `docs-project/entities/guides/GUIDE-acl-overview.md` — new "Restricting a
+client below its user" section: the invariant, baseline selection, the two
+spellings table, scopes, and what it does NOT do.
+- [x] `docs-project/entities/guides/GUIDE-acl-security.md` — new "Client
+attenuation" section: trust boundary, the inverted direction of harm (dropping a
+claim removes the ceiling), why this does not contradict the additive model, and
+the audit rules.
+- [x] `docs/` regenerated via `just docs`; `just docs-check` green.
+
+## Correction made
+
+The security guide previously said ACL evaluation is additive "and no rule can
+subtract". This feature made that partially untrue, so the claim was corrected
+rather than left to rot — it now explains why org enforcement still cannot work
+the same way (it needs a per-row predicate, which the read path deliberately
+lacks, whereas a ceiling compiles against a claim value set the operator
+enumerates).
+
+## External Documentation
+
+- [x] ~~API reference~~ (N/A: no new HTTP endpoint or wire field; the ceiling
+changes what existing endpoints return, not their shape)
+- [x] CLI: `rela acl map --as/--scope` flags carry help text; new audit rules
+(A11/A12/A13/B8/B9) emit their own `fix:` guidance.
+
+## Verification
+
+- [x] The documented `acl.yaml` example is pinned by a doc-drift test
+(`TestDocs_AclOverviewClientAttenuationExampleWorks`) that asserts the PROSE
+CLAIMS, not merely that the YAML parses — a wrong ACL example gets copied into a
+deployment where someone believes a client is restricted.
+- [x] The documented `rela acl map --as` console output is a verbatim copy of a
+real run against a throwaway project, not written from memory. (My first draft
+had the route format wrong; running it caught that.)

--- a/tickets/entities/implementation-checklists/IMPL-GX8C6A.md
+++ b/tickets/entities/implementation-checklists/IMPL-GX8C6A.md
@@ -1,0 +1,91 @@
+---
+id: IMPL-GX8C6A
+type: implementation-checklist
+title: 'Implementation: Client attenuation: principal_type baselines + scope re-openings as an ACL ceiling below the acting user'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Development
+
+- [x] Unit tests written for new code
+- [x] Integration tests written (full flow, not just units)
+- [x] Feature implemented
+- [x] All edge cases from planning handled
+
+**What was built** (8 commits on `tkt-iac8tx-client-attenuation`):
+
+1. Claims plumbing — `principal_type` + `scope` from `jwtauth.AssertionClaims`
+through `dataentry.AssertedIdentity` → `principal.VerifiedFrom`. Added a
+`principal.Claims` struct so the constructor stops growing positionally (it was
+already at 5 args); `Verified` kept as a wrapper so 27 existing call sites
+didn't churn.
+2. Policy types — `client_baselines` / `scope_grants`, shared `Restriction`
+body carrying both spellings per axis, disjointness + one-spelling validation.
+3. Load-time compilation (`ceilingcompile.go`) — a MATCHER, not an expanded
+type set.
+4. Enforcement — `Request.roleFor` as the single clamp point, plus match-time
+predicates for the wildcard case; field axis via `dimension.restrictTo` /
+`dimension.redact` in `internal/affordances`.
+5. `rela acl audit` rules A11/A12/A13/B8/B9 + `rela acl map --as`.
+6. Docs (both guides, regenerated) + a `CLAUDE.md` standing rule.
+
+**Edge cases from planning, all covered:** empty/whitespace scope; `applies_to:
+[]`; undeclared type in a ceiling; `"*"` in both spellings; `deny_read` on a
+type the user cannot read; a scope re-opening what the user lacks; bounded scope
+count; whitespace-padded keys (the RR-IK355A trap); historical subjects.
+
+## Bugs found by the tests during implementation
+
+All three would have failed **open** or silently — worth recording because each
+was found by a test written before the code was trusted, not by review:
+
+- `trimAll` collapsed an explicit `read: []` to nil, turning a hard lockout
+into no restriction at all.
+- Scopes re-opened denials by list subtraction, so `deny_write: ["*"]` plus a
+scope left the wildcard intact and re-opened nothing. Fixed with an explicit
+`except` carve-out checked ahead of the wildcard.
+- `deny_write` expanded before validation ran, so a colliding `deny_update` was
+silently discarded rather than rejected.
+
+## Manual verification
+
+- [x] Feature tested end-to-end manually
+- [x] Each acceptance criterion verified
+- [x] Verification evidence documented
+
+Built a throwaway project (`/tmp/aclx`) with a `person`/`ticket` metamodel and
+the worked-example policy, then ran the real CLI:
+
+- `rela acl map --principal alice --as app --scope rela.tickets.write` →
+reported read on person+ticket and update on ticket only; the same command
+without `--as` reported alice's full create/update/delete. The documented output
+in `GUIDE-acl-overview.md` is a verbatim copy of this run (I had written the
+route format from memory first and corrected it to match).
+- `rela acl audit` on the well-formed policy → no ceiling findings.
+- `rela acl audit` on an inert policy → `A11-inert-client-baseline` (medium)
+and `A12-scope-reopens-nothing` (low), both with actionable fixes.
+
+## Quality
+
+- [x] Code follows project patterns
+- [x] No silent failures (errors surfaced, not just logged)
+
+`just check` (lint, arch-lint, plimsoll, lint-md, test), `just coverage-check`
+(77.2%, both thresholds pass) and `just docs-check` all green.
+
+Silent-failure review: the security-critical invariants (`applies_to` overlap,
+both-spellings-per-axis, blank keys, deny spellings on a scope grant) are HARD
+load errors, not warnings — an operator must not get a policy that looks
+restrictive and is not. Drift-class findings (undeclared type/field) are audit
+findings rather than boot failures, matching the tolerant-by-design convention
+`acl.yaml` already follows.
+
+## Structural guarantees added
+
+- `TestNoDirectRoleLookupInEvaluationPaths` — scans every non-exempt file in
+`internal/acl` and fails if an evaluation path reaches `policy.Roles[...]`
+directly, bypassing the clamp. Verified it actually fires by injecting a bypass
+into `readquery.go` and confirming the failure, then reverting.
+- The exemption-list (not inclusion-list) shape means a NEW file fails closed.

--- a/tickets/entities/planning-checklists/PLAN-PXV4F9.md
+++ b/tickets/entities/planning-checklists/PLAN-PXV4F9.md
@@ -1,0 +1,305 @@
+---
+id: PLAN-PXV4F9
+type: planning-checklist
+title: 'Planning: Client attenuation: principal_type baselines + scope re-openings as an ACL ceiling below the acting user'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Understanding
+
+- [x] Problem/requirements clearly understood
+- [x] Scope defined (what's in/out documented below)
+- [x] Acceptance criteria documented with specific test scenarios
+
+**Scope:**
+
+IN: `principal_type`/`scope` claim extraction through to `principal.Principal`;
+`client_baselines` + `scope_grants` policy keys; load-time compilation to plain
+allowlists; the clamp after role resolution; enforcement on read gate,
+`visible:` redaction, write authorize and named permissions; a distinguishable
+`SourceKind`; `rela acl audit` rules; `rela acl map --as`; docs.
+
+OUT: MCP `list_tools` filtering and MCP read gating (both TKT-G3PPD — this
+ticket makes the *policy* expressible, it does not wire `internal/mcp` into
+`internal/visibility`); org enforcement (separate, named in TKT-RP3X3Q);
+`client_id` keying (mechanism supports adding it later at no semantic cost);
+unifying verbs and permissions (IDEA-HUWQ); `syncContext` claim-dropping
+(BUG-0Q8MCZ).
+
+**Acceptance Criteria:** 13 criteria on TKT-IAC8TX, each mapped to a test
+scenario under Test Plan below.
+
+## Research
+
+- [x] For larger features: run `/research` to create a structured research doc
+- [x] Searched for existing libraries that solve this problem
+- [x] Checked codebase for similar patterns or reusable code
+- [x] Looked for reference implementations in other projects
+- [x] Reviewed relevant rela concepts for prior art
+
+**Research Doc:** N/A — the design was settled through direct discussion with
+the user (see the "Why this shape" section on TKT-IAC8TX, which records the
+rejected alternatives and the reasoning). A `/research` survey of token
+attenuation prior art (OAuth downscoping, Macaroons/caveats, Biscuit, GCP
+credential attenuation) was offered and declined in favour of proceeding.
+
+**Existing Solutions:**
+
+Codebase prior art, all verified by direct read:
+
+- `asserted_role_assignments` (`internal/acl/policy.go:112`, resolver at
+`resolver.go:57-65`) — the precedent for claim → policy mapping. Establishes
+that a claim value is never a role name; it only selects an operator-authored
+entry, so an IdP cannot name a rela role the deployment did not choose. This
+ticket follows the identical discipline for `principal_type`/`scope`.
+- Closed-world `visible:` (`internal/affordances/resolver.go:370`,
+`compileFieldBlock` at `:256`) — a role declaring a `visible:` block for a type
+asserts a *complete* list; unnamed fields redact. This is the existing machinery
+the allowlist form reuses, and the source of the fail-closed property. Already
+conformance-tested by `internal/visibility/visibilitytest/suite.go`.
+- `EveryoneRole` (`internal/acl/policy.go:34`, `resolver.go:63`) — precedent for
+a role entering the effective set with no graph walk.
+- `store.Formatter` / `HistoryReader` / `VersionWriter` — the optional-capability
+type-assertion idiom, if the clamp needs to be optional per backend.
+- `PermitsRead`/`ReadQuery` compiling to `store.GraphQuery`
+(`internal/acl/readquery.go:16-27`) — the reason a *runtime* denial primitive
+was rejected: read gating pushes down into SQL, so a runtime deny would have to
+become a SQL predicate. Load-time compilation sidesteps this entirely.
+
+External: the shape is OAuth token downscoping / capability attenuation
+(Macaroon caveats, Biscuit, GCP credential attenuation). No library is
+applicable — the ceiling must compile against rela's own `RoleDef` vocabulary.
+
+## Approach
+
+- [x] Technical approach chosen and documented
+- [x] Approach builds on existing patterns (not reinventing)
+- [x] Alternatives considered (document why rejected)
+- [x] Dependencies identified (packages, APIs, types)
+
+**Technical Approach:**
+
+The key insight that makes this tractable: **compile the ceiling at load time,
+not at evaluation time.** A baseline/scope block is static config, so `redact:
+{person: [salary]}` is resolvable against the metamodel when the policy loads —
+enumerate `person`'s declared fields, subtract `salary`, store the result as an
+ordinary allowlist. The runtime evaluator never learns the word "deny";
+`decideFromAttrs`, `readQuery`, `grantsPermission` and `FieldVerdicts` keep
+seeing plain allowlists. DEC-RG878's additive union semantics are untouched.
+
+Five steps:
+
+1. **Claim extraction.** Add `PrincipalType`/`Scope` to
+`jwtauth.AssertionClaims` (`verifier.go:157-163`) and project them in
+`VerifyAssertion` (`:186-204`), bounded the way `roles` is (`maxRoles=32`,
+`maxRoleRunes=256`, `:171-174`). Thread through `dataentry.AssertedIdentity`
+(`router.go:471-476`) → `verifiedPrincipal` (`:554-579`) → `principal.Verified`
+(`principal.go:84`). Preserve the unexported-field +
+`Verified()`-only-constructor shape so the compiler keeps enforcing the trust
+boundary.
+
+2. **Policy types.** `Policy.ClientBaselines map[string]ClientBaseline` and
+`Policy.ScopeGrants map[string]ScopeGrant`, plus entries in `knownPolicyKeys`
+(`policy.go:413-424` — the reflection parity test `policy_parity_test.go:15-30`
+fails CI without them). A shared `restrictionBlock` type carries both spellings
+per axis (`Read`/`DenyRead`, `Update`/`DenyUpdate`, `Visible`/`Redact`, …).
+
+3. **Load-time compilation.** In `Validate` / `ValidateAgainstMetamodel`:
+reject overlapping `applies_to` sets; reject both spellings for one type in one
+block; expand `"*"`; expand `deny_write` to create+update+delete; resolve
+denylist forms to allowlists against the metamodel. Output is a compiled
+`ceiling` keyed by principal_type, with per-scope deltas.
+
+4. **The clamp.** After role resolution produces effective grants, intersect
+with `baseline ∪ matched scope_grants`. Applied at the point where
+`computeGlobals`/`ForEntity` results feed `decideFromAttrs`, `readQuery`,
+`grantsPermission` and `FieldVerdicts` — one place per axis, not per call site.
+A new `SourceKind` (`SourceCeiling`) so a clamped denial is attributable and
+distinguishable from a role-grant denial.
+
+5. **Tooling + docs.** `rela acl audit` rules; `rela acl map --as <profile>`;
+`docs/acl-security.md` trust-boundary section; `docs/acl-overview.md`.
+
+**Alternatives rejected** (full reasoning on TKT-IAC8TX): runtime deny rules
+(would force re-derivation of the whole evaluation core including SQL pushdown);
+intersecting denial sets across profiles (denials cancel — `{salary} ∩ {bsn} =
+{}` — forcing every profile to restate every denial); flat per-profile
+allowlists restating everything (effort O(schema size) per profile, drifts as
+the metamodel grows). `Tool` as a selector was dropped: it is self-asserted, and
+mixing a spoofable key with signed claims invites operators to lean on the weak
+one.
+
+**Files to modify:**
+
+- `internal/jwtauth/verifier.go` — `AssertionClaims`, `VerifyAssertion`
+- `internal/principal/principal.go` — new fields + the nine methods that touch
+them (`Verified`, `Sanitized`, `Equal`, `IsZero`, `Clone`, `principalJSON`,
+`MarshalJSON`, `UnmarshalJSON`)
+- `internal/dataentry/router.go` — `AssertedIdentity`, `verifiedPrincipal`,
+`resolvePrincipalEntity` (must forward new fields or they drop silently)
+- `cmd/rela-server/main.go` — the adapter
+- `internal/acl/policy.go` — `Policy` fields, `knownPolicyKeys`, `Validate`,
+`ValidateAgainstMetamodel`, the compilation
+- `internal/acl/resolver.go`, `request.go`, `readquery.go`, `authz_write.go` —
+the clamp
+- `internal/acl/source.go` — new `SourceKind` (note: adding one is
+compiler-silent; `sourceKindPriority`, both `String()` methods, `lessSource` and
+five tables in `source_test.go` need entries)
+- `internal/affordances/resolver.go` — field-verdict clamp
+- `internal/aclaudit/tier_a.go`, `tier_b.go` — new rules
+- `internal/aclmap/` — `--as` support
+- `docs/acl-security.md`, `docs/acl-overview.md`
+
+## Security Considerations
+
+- [x] Input sources identified (user input, config, external APIs)
+- [x] Input validation approach defined (allowlist preferred over blocklist)
+- [x] Security-sensitive operations identified (file access, auth, crypto)
+- [x] Error handling doesn't leak sensitive information
+
+**Input Sources & Validation:**
+
+| Source | Validation | On invalid |
+|---|---|---|
+| `principal_type` claim (JWT) | Only after ES256 signature verification. Used solely as a **lookup key** into operator-authored `client_baselines` — never interpreted as a capability name. Length/count bounded like `roles`. | No matching baseline → unrestricted (gated by the user's own roles). AC11 audit rule surfaces uncovered types. |
+| `scope` claim (JWT) | Same: verified-only, lookup key into `scope_grants`, bounded. | Unknown scope value → contributes nothing (silently dropped, mirroring the `Assignments` guard at `resolver.go:36-38`). |
+| `acl.yaml` blocks | Structural validation at load: disjoint `applies_to`; not-both-spellings-per-type; types/fields cross-checked against the metamodel. | Hard startup error for the security-critical invariants (overlap, double-spelling); `slog.Warn` for drift, matching the tolerant-by-design convention. |
+
+**Security-Sensitive Operations:**
+
+- **Trust boundary (the critical one).** `internal/acl` verifies nothing — a
+Principal is trusted absolutely. `principal_type`/`scope` MUST be populated only
+after signature verification. The existing unexported-field +
+`Verified()`-sole-constructor shape (`principal.go:58-95`) enforces this at
+compile time; the new fields must keep it. A spoofable-header path setting them
+would be a full authorization bypass.
+- **Direction of failure.** Because a ceiling only ever *narrows*, a bug in the
+clamp fails toward less access, not more. The one exception is the compilation
+step: a `"*"` expansion or denylist→allowlist resolution that produces too large
+a set would over-grant. That step needs direct tests, not just end-to-end ones.
+- **Row-level denial is a secrecy boundary.** `deny_read` must make entities
+*nonexistent* (404 indistinguishable from a real 404, pruned lists, no count
+leak) per the row-level rule in CLAUDE.md — not merely redacted.
+- **Config is not secret.** Per CLAUDE.md, baseline/scope names and the types
+they mention are operator-authored config; a 403 naming the ceiling is correct
+and useful. Do NOT contort to conceal profile names.
+- **No new external I/O, no crypto, no filesystem surface.** Compilation is
+pure; verification reuses the existing `jwtauth` path.
+
+## Test Plan
+
+- [x] Test scenarios documented for each acceptance criterion
+- [x] Edge cases identified and documented
+- [x] Negative test cases defined (invalid input, error conditions)
+- [x] Integration test approach defined (not just unit tests)
+
+**Test Scenarios (AC → test):**
+
+| AC | Scenario |
+|---|---|
+| 1 | `jwtauth` table test: assertion with/without `principal_type`+`scope` → Principal exposes both / empty, no error. Plus `--principal-header` and loopback unchanged. |
+| 2 | `Policy.Validate` rejects two baselines both listing `app`; error names both blocks. |
+| 3 | Explicit pinned test: `principal_type: user` (and an unknown string) → unrestricted. Must not drift. |
+| 4 | Two-part: `redact:` — hide named fields, then add a field to the type fixture and assert it still shows. `visible:` — inverse: added field is hidden. |
+| 5 | `Validate` rejects `visible:` + `redact:` for the same type in one block. |
+| 6 | `deny_write: ["*"]` → create, update and delete all denied. |
+| 7 | The ceiling-never-grants proof: same token + scope, two users (privileged / read-only) → strictly less for the lesser user. |
+| 8 | `deny_permissions` withholds `history:read` and a command `permission:` the user's role grants. |
+| 9 | `deny_read` → 404 identical to a real 404, entity absent from lists, count not incremented. |
+| 10 | `rela acl map --as <profile>` golden output. |
+| 11 | `aclaudit` table test: uncovered principal_type; no-op baseline; undeclared type/field. |
+| 12 | Deny reason names the ceiling, distinguishable from a role-grant denial. |
+| 13 | `NopACL`/`ReadOnlyACL` behaviour byte-identical. |
+
+**Integration approach:** the unit tests above sit in `internal/acl` (using the
+`World` fixture in `testutil_test.go`) and `internal/aclaudit`. End-to-end
+coverage goes in `internal/dataentry` alongside the ~20 existing `acl_*_test.go`
+files — a real HTTP request carrying a verified assertion, asserting the
+response body is redacted/404'd. `internal/visibility/visibilitytest/suite.go`
+must still pass unchanged (the ceiling must not break the Reader contract).
+
+**Edge Cases:**
+
+- Empty `scope` string; whitespace-only scope; scope naming no known grant.
+- `applies_to: []` (matches nothing — dead config, audit should flag).
+- A baseline naming a type absent from the metamodel.
+- `"*"` in both allowlist and denylist form.
+- `deny_read` on a type the user cannot read anyway (no-op, must not error).
+- A scope re-opening something the *user* lacks (bounded by intersection → still
+denied; this is AC7).
+- Very many scopes on one token (bound it like `maxRoles`).
+- Unicode / whitespace-padded profile keys — RR-IK355A on TKT-RP3X3Q records
+that a whitespace-padded `asserted_role_assignments` key loads clean but is
+permanently unmatchable. Same trap here; normalize and reject blank keys.
+- Historical/deleted entities: field redaction already fails closed
+(`PermHistoryReadRedacted`, TKT-73C6B2) — confirm the ceiling composes and does
+not accidentally *reveal*.
+
+**Negative Tests:**
+
+- Unsigned / wrong-issuer / expired assertion carrying `principal_type` → 401,
+claims never reach the Principal.
+- A composite-literal-constructed Principal cannot carry `principal_type`
+(compile-time; assert via the existing `Verified`-only discipline).
+- Overlapping `applies_to` → startup fails, server does not boot.
+- Both spellings for one type → load error, not a silent merge.
+
+## Risk Assessment
+
+- [x] Technical risks assessed with mitigations
+- [x] Security risks assessed (see Security Considerations)
+- [x] Effort estimated (xs/s/m/l/xl)
+
+**Effort: L.** Touches jwtauth, principal, dataentry, acl, affordances,
+aclaudit, aclmap and docs, but each change is shallow; the load-time-compilation
+choice is what keeps it from being XL.
+
+**Risks:**
+
+| Risk | Mitigation |
+|---|---|
+| Compilation over-grants (`"*"` expansion, denylist→allowlist) — the one direction that fails open | Direct unit tests on the compiler, not just end-to-end; golden-file the compiled output |
+| A ceiling that silently protects nothing (baseline for a principal_type the IdP never sends) | AC11 audit rule; `rela acl map --as` for manual verification |
+| Adding a `SourceKind` is compiler-silent (every switch has a default → renders "unknown", sorts at 999) | Five tables in `source_test.go`, `sourceKindPriority`, both `String()`s and `lessSource` need entries; TKT-RP3X3Q suggested a reflective guard — worth adding here |
+| `Principal` field addition touches nine methods + the audit wire format | Follow the TKT-RP3X3Q precedent exactly; `principalJSON` uses `omitempty` so old consumers ignore new keys |
+| `syncContext` already drops all claims (BUG-0Q8MCZ) — new fields drop too | Filed separately with a preventive measure (MEAS-PRINCIPAL-RESTAMP); not a blocker but adds a second silently-attenuated surface until fixed |
+| `rela acl map` cannot model asserted claims today (`mapall.go:71-74`) | AC10 requires extending it; scope it as part of this ticket |
+| 9-minute stale-claim window (assertion TTL hard-coded upstream, `signer.go:22`) | Document; do not attempt to fix |
+| Perf: the clamp runs per request | It is a set intersection over already-resolved grants, and `Request` already caches `GlobalRoles`; benchmark against `internal/affordances/bench_test.go` if the field path shows up |
+
+## Documentation Planning
+
+- [x] User-facing docs identified (skip if internal refactor)
+- [x] Docs-checklist will be created when entering implementation
+
+**Documentation Impact:**
+
+- [x] `docs/acl-security.md` — the trust-boundary section (why `principal_type`
+is only trustworthy post-verification, why `Tool` was rejected as a selector)
+and the row-level-denial semantics of `deny_read`
+- [x] `docs/acl-overview.md` — the resolver vocabulary gains baselines and
+scope grants; **pinned by `internal/acl/docfields_test.go` and
+`docs_example_test.go`**, so these are not optional
+- [x] `docs/cli-reference.md` — `rela acl map --as`, new `rela acl audit` rules
+- [x] `CLAUDE.md` — decided YES during implementation. Added a "Restrictions
+compile at LOAD time; the evaluator has no denial primitive" rule naming the
+clamp point and the guard test, because "don't add a runtime deny" is exactly
+what the next person would reintroduce.
+- [x] ~~`docs/metamodel.md`~~ (N/A: no metamodel changes)
+- [x] ~~`README.md`~~ (N/A: no project-level change)
+
+## Design Review
+
+- [x] ~~Run `/design-review` before starting implementation~~ (N/A: the design
+was settled interactively with the user across several rounds; the rejected
+alternatives and their reasoning are recorded in the "Why this shape" section of
+TKT-IAC8TX. A full code review ran instead, after implementation.)
+- [x] All critical/significant findings addressed — see the review responses
+linked from TKT-IAC8TX (RR-B6DRAG critical, RR-48B6MT significant, both
+addressed).
+
+**Design Review Findings:** RR-B6DRAG (critical, addressed), RR-48B6MT
+(significant, addressed), RR-UYB99D and RR-U41F3D (minor, addressed), RR-MUJUWS
+(minor, deferred), RR-9K9NSJ (nit, wont-fix).

--- a/tickets/entities/review-checklists/REV-HIH8K8.md
+++ b/tickets/entities/review-checklists/REV-HIH8K8.md
@@ -1,0 +1,86 @@
+---
+id: REV-HIH8K8
+type: review-checklist
+title: 'Review: Client attenuation: principal_type baselines + scope re-openings as an ACL ceiling below the acting user'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Automated Checks
+
+- [x] `just test` — all pass
+- [x] `just lint` — 0 issues
+- [x] `just coverage-check` — 77.2%, package and total thresholds pass
+- [x] `just arch-lint` — no warnings
+- [x] `just plimsoll` — no type over a load line
+- [x] `just lint-md` — 0 issues
+- [x] `just docs-check` — docs regenerated and committed
+
+## Code Review
+
+- [x] `cranky-code-reviewer` run over the full branch diff
+
+Six findings, all triaged and linked via `has-review-response`:
+
+| ID | Severity | Status |
+|---|---|---|
+| RR-B6DRAG | critical | addressed |
+| RR-48B6MT | significant | addressed |
+| RR-UYB99D | minor | addressed |
+| RR-U41F3D | minor | addressed |
+| RR-MUJUWS | minor | deferred |
+| RR-9K9NSJ | nit | wont-fix |
+
+**The critical finding was a genuine fail-open I missed.** `applyClientCeiling`
+returned early when ctx carried no `acl.Request`, so a stamped-but-unbound
+principal kept its user's full field visibility — while `resolveViaDeclarative`,
+twenty lines away in the same file, opened its own Request. Within one
+`FieldVerdicts` call, roles resolved and the ceiling did not. Every test in the
+suite bound via a helper, so the whole suite passed over the hole.
+
+I reproduced it with a failing test before fixing, then fixed it by mirroring
+the sibling's fallback. Not reachable in production (`attachACLRequest` and
+`ScriptReader.bind` both bind), but `visibility.PolicyRedactor` forwards
+whatever ctx it is handed and binds nothing, so the guarantee rested on wiring
+rather than structure.
+
+The reviewer also explicitly could NOT substantiate: policy mutation across
+requests, aliasing, an un-predicated consumer of the clamped wildcard lists, or
+gaps in relation writes / transitions / `HoldsPermissionForEntity`. I
+independently re-probed the mutation and aliasing claims and agree.
+
+## Acceptance Verification
+
+Each AC from TKT-IAC8TX, with the test that pins it:
+
+| AC | Verdict | Evidence |
+|---|---|---|
+| 1 — claims reach the Principal | PASS | `jwtauth` + `dataentry` round-trip tests; absent claims yield empty, no error |
+| 2 — overlapping `applies_to` is a startup error | PASS | `TestClientBaselines_DisjointAppliesTo`, plus a determinism test so the reported pair is stable |
+| 3 — unmatched principal_type is unrestricted | PASS | pinned at three layers: compiler, affordances, aclmap |
+| 4 — `redact` open-world / `visible` closed-world | PASS | `TestCeiling_RedactIsOpenWorld`, `TestCeiling_VisibleIsClosedWorld` |
+| 5 — both spellings for one type is a load error | PASS | `TestRestriction_OneSpellingPerAxis` (4 sub-cases) |
+| 6 — `deny_write: ["*"]` covers three verbs | PASS | `TestDenyWrite_ExpandsToThreeVerbs` + an ordering regression test |
+| 7 — a ceiling never grants past the user | PASS | `TestCeiling_NeverGrantsPastTheUser` (entitymanager), `TestClamp_NeverGrants` (acl) |
+| 8 — `deny_permissions` withholds | PASS | both entry points, incl. the entity-scoped one backing transition guards |
+| 9 — row denial is indistinguishable from 404 | PASS | `TestCeilingE2E_DenyReadIsIndistinguishableFrom404` + list-pruning test |
+| 10 — `acl map --as` renders the ceiling | PASS | 5 aclmap tests + verified against a real project |
+| 11 — audit flags inert/undeclared config | PASS | `internal/aclaudit/ceiling_test.go`; verified on a real project |
+| 12 — deny names the ceiling | PASS | `RuleKind="client-ceiling"`, `RuleID`=baseline name |
+| 13 — NopACL/ReadOnlyACL unchanged | PASS | existing suites green; ceiling is inert without policy config |
+
+## Scope honesty
+
+Two limitations are documented rather than silently left:
+
+- **Relation meta fields are not attenuated** — a separate grant vocabulary
+with no ceiling equivalent. Row-level `deny_read` still covers both endpoints.
+- **stdio MCP is not addressable** — no authentication, so no verified claim to
+key a baseline on. This ticket makes the policy expressible; wiring
+`internal/mcp` through the read gate is TKT-G3PPD, deferred at the user's
+explicit request ("i will fix mcp later; let's first make the code available").
+
+## PR
+
+Not yet raised — branch `tkt-iac8tx-client-attenuation`, 8 commits.

--- a/tickets/entities/review-responses/RR-48B6MT.md
+++ b/tickets/entities/review-responses/RR-48B6MT.md
@@ -1,0 +1,9 @@
+---
+id: RR-48B6MT
+type: review-response
+title: Grep guard used an inclusion list, silently skipping new evaluation files
+finding: 'TestNoDirectRoleLookupInEvaluationPaths iterated four hardcoded filenames. A NEW file added to internal/acl containing a direct policy.Roles[...] lookup would never be scanned — the guard would pass and the ceiling would be silently bypassed on that path. The guard''s own premise (request.go: ''Every evaluation path in this package resolves a role name'') was enforced for only four enumerated files. This is the same forget-shaped hole that applies_to disjointness exists to remove.'
+severity: significant
+resolution: 'Inverted to an EXEMPTION list: the test now globs *.go, skips _test.go, and skips five explicitly-reasoned exemptions (policy.go, ceiling.go, ceilingcompile.go, declarative.go, request.go — all policy-structure or the clamp itself). A new file fails closed: it must be clean or be added to the exemption list with a reason. Coverage went from 4 files to 13. Added a `scanned < 5` assertion so a broken glob or over-broad exemption list surfaces as a failure rather than a vacuously green run. Verified the guard still fires by injecting a bypass into readquery.go.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-9K9NSJ.md
+++ b/tickets/entities/review-responses/RR-9K9NSJ.md
@@ -1,0 +1,12 @@
+---
+id: RR-9K9NSJ
+type: review-response
+title: Suggested structural guard asserting every FieldVerdicts caller binds first
+finding: Proposed a guard test (in the style of the policy.Roles[ grep guard) asserting that every FieldVerdicts caller is preceded by a Bind/WithRequest, to close the CLASS of the critical fail-open rather than the single instance.
+severity: nit
+reason: |-
+    The critical fix removed the precondition this guard would police. applyClientCeiling now opens its own Request when ctx lacks one, so a caller that does not bind gets the ceiling anyway — there is no longer a 'must bind first' rule to enforce. A guard asserting it would encode a requirement that no longer exists.
+
+    It would also be brittle: the 6+ FieldVerdicts call sites in internal/dataentry are not co-located with their binding (binding happens in middleware, calls happen in handlers), so a lexical proximity check would produce false positives and get suppressed. Removing the dependency is strictly better than policing it — the same reasoning TKT-80EWGM applied when it deleted the raw write-prep handle instead of documenting against it.
+status: wont-fix
+---

--- a/tickets/entities/review-responses/RR-B6DRAG.md
+++ b/tickets/entities/review-responses/RR-B6DRAG.md
@@ -1,0 +1,9 @@
+---
+id: RR-B6DRAG
+type: review-response
+title: Field-axis ceiling failed open when ctx carried no acl.Request
+finding: 'applyClientCeiling (internal/affordances/resolver.go:686-690) returned early when acl.FromContext(ctx) was nil, so a principal stamped WITHOUT an acl.Request kept its acting user''s full field visibility — the ceiling silently did not apply. Twenty lines below in the same file, resolveViaDeclarative hits the identical condition and opens a fresh Request instead. So within a single FieldVerdicts call, on a ctx carrying a principal but no Request: role resolution worked, the client ceiling did not. Every test in internal/affordances/ceiling_test.go bound via the ctxFor helper, so the whole suite passed over the hole. Not reachable in production (attachACLRequest covers /api/, ScriptReader.bind covers Lua), but visibility.PolicyRedactor.HiddenProperties forwards whatever ctx it is handed and binds nothing itself, so the guarantee rested on wiring rather than structure. This is the fail-open direction, in the axis carrying the ticket''s originating use case (MCP-as-HR-user must not see person.salary).'
+severity: critical
+resolution: 'applyClientCeiling now opens its own Request when ctx has none, mirroring resolveViaDeclarative. An unstamped principal still returns early — it has no verified principal_type, so no baseline can match and a ceiling can only narrow. Pinned by TestCeiling_AppliesWithoutAnACLRequestOnContext (reproduced the fail-open before the fix) and TestCeiling_UnstampedPrincipalIsUnrestricted (the counterpart: recovery must not invent a ceiling).'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-MUJUWS.md
+++ b/tickets/entities/review-responses/RR-MUJUWS.md
@@ -1,0 +1,9 @@
+---
+id: RR-MUJUWS
+type: review-response
+title: Restriction axis lists are hand-enumerated across seven sites in two packages
+finding: Narrows, denySpellings, validateSpellings, validateNoBlanks, normalized, expanded (internal/acl/ceiling.go) and unreachableTargets (internal/aclaudit/ceiling.go) each re-enumerate the same 13 Restriction fields by hand. Adding a 14th axis means touching seven sites across two packages, and the failure mode of missing one is silently inert config — exactly what A11/A13 exist to catch at runtime because it cannot be caught at compile time. A []axis{name, get, set} descriptor table iterated by all seven would make the omission a compile error.
+severity: minor
+reason: 'Real and correctly diagnosed, but it is a refactor of code that is currently correct and fully tested, with no behaviour change. Doing it inside the review cycle of a security feature adds churn to the diff a reviewer has already read. Worth its own ticket, and the trigger is concrete: the next axis added.'
+status: deferred
+---

--- a/tickets/entities/review-responses/RR-U41F3D.md
+++ b/tickets/entities/review-responses/RR-U41F3D.md
@@ -1,0 +1,27 @@
+---
+id: RR-U41F3D
+type: review-response
+title: A baseline denial is carve-out-able by any scope, undocumented
+finding: verbCeiling.except is checked ahead of both allow and deny (ceilingcompile.go:71-76), so a scope grant naming a capability re-opens it even when a baseline explicitly denied it. There is no way to mark a baseline denial un-carve-out-able. The reviewer confirmed this cannot escalate past the acting user (the result still intersects user_grants at filterTypes/grantsVerb) and could not construct an escalation — so it is a documentation gap, not a hole. A12 only fires for the inverse case (a scope re-opening what NO baseline closes), so nothing surfaces this to an operator.
+severity: minor
+resolution: Documented rather than changed, because the behaviour is the intended OAuth semantic and an un-carve-out-able marker would introduce a precedence rule the design deliberately has none of. Added a 'A baseline denial is a default, not a floor' section to the ScopeGrant godoc (internal/acl/ceiling.go) and the same guidance in operator prose in GUIDE-acl-overview.md. The safety argument is unchanged and pinned by TestCeiling_NeverGrantsPastTheUser and TestScopes_MoreScopesNeverNarrows.
+status: addressed
+---
+
+## Resolution
+
+Documented in two places rather than changed, because the behaviour is the
+intended OAuth semantic ("scopes widen only WITHIN the ceiling") and adding an
+un-carve-out-able marker would introduce a precedence rule the design
+deliberately has none of.
+
+- `ScopeGrant` godoc (`internal/acl/ceiling.go`) gains a "A baseline denial is a
+default, not a floor" section: any scope naming a capability re-opens it; the
+floor is the acting user, not the baseline; if a capability must never reach a
+client class, do not write a scope grant naming it.
+- The same guidance in operator-facing prose in `GUIDE-acl-overview.md`, since
+this is a mental-model question an operator hits before a developer does.
+
+The safety argument is unchanged and already pinned by
+`TestCeiling_NeverGrantsPastTheUser` (entitymanager) and
+`TestScopes_MoreScopesNeverNarrows` (acl).

--- a/tickets/entities/review-responses/RR-UYB99D.md
+++ b/tickets/entities/review-responses/RR-UYB99D.md
@@ -1,0 +1,9 @@
+---
+id: RR-UYB99D
+type: review-response
+title: FieldCeilingFor re-derived the baseline the Request already resolved
+finding: FieldCeilingFor called policy.baselineFor(principal.PrincipalType()) on every invocation, even though compiledCeiling.name already held the baseline matched at Request construction. Two lookups keyed off the same source, derived at different times — they agree only because the principal is immutable after binding, which undercuts the stated reason for computing the ceiling once ('there is nothing to invalidate'). Also a map walk on every field verdict in a list response.
+severity: minor
+resolution: compiledCeiling now stores the matched ClientBaseline at construction; FieldCeilingFor reads it. One derivation, one source of truth, no per-call lookup.
+status: addressed
+---

--- a/tickets/entities/tickets/TKT-IAC8TX.md
+++ b/tickets/entities/tickets/TKT-IAC8TX.md
@@ -1,0 +1,302 @@
+---
+id: TKT-IAC8TX
+type: ticket
+title: 'Client attenuation: principal_type baselines + scope re-openings as an ACL ceiling below the acting user'
+kind: enhancement
+priority: medium
+effort: l
+status: done
+---
+
+Let a verified non-interactive client (MCP, app, PAT, service account) be
+restricted **below** the user it acts as. Named `client_baselines` are selected
+by a disjoint `principal_type` match; `scope_grants` re-open capability on top.
+
+```
+effective = user_grants ∩ (baseline ∪ scope_grants)
+```
+
+Compiled at load into plain allowlists, so the runtime evaluator is unchanged —
+no denial primitive, DEC-RG878 union semantics intact.
+
+## Problem
+
+An OIDC proxy (Pratique) mints principals carrying `principal_type`
+(`user`/`app`/`pat`/`service`), `scope` and `client_id`. rela reads **none** of
+them — `internal/jwtauth.VerifySubject` projects only `sub`, `email`, `org_id`,
+`org_slug`, `roles` (`verifier.go:157-163,186-204`), and `email` is dropped
+again at the `dataentry.AssertedIdentity` adapter (`router.go:471-476`).
+
+Consequence: a client acts with the **full authority of the user it acts as**.
+An MCP server connected by an HR user can read `person.salary` because that user
+can. There is no way to say "this client, acting as this user, sees less."
+
+TKT-RP3X3Q explicitly deferred this: *"`principal_type` — Pratique's own
+middleware does not surface it; if rela needs to distinguish a PAT from an
+interactive user that is its own ticket."* This is that ticket.
+
+Aggravating factor: **MCP reads are entirely ungated today.** `internal/mcp`
+imports neither `internal/acl` nor `internal/visibility`; handlers call the raw
+store (`tools_entity.go:35,86,124,201,246,297`). Writes are gated downstream by
+entitymanager, reads are not. Documented at
+`docs/server-security.md:340,389-396` and `docs/acl-security.md:743-746`,
+tracked as TKT-G3PPD.
+
+## Design
+
+### The invariant
+
+Two properties fall out of `user_grants ∩ (baseline ∪ scope_grants)`, and both
+are load-bearing:
+
+1. **A ceiling never grants.** Intersection with `user_grants` means a token
+cannot exceed the user it acts as, whatever it claims. A read-only user with a
+write-scoped token still cannot write.
+2. **Scopes widen only within the ceiling.** `baseline ∪ scope_grants` is a
+union, so more scopes = more capability — matching how OAuth scopes work
+everywhere else — but still clamped by (1).
+
+### Why this shape, and not the alternatives
+
+Considered and rejected in design discussion:
+
+- **Explicit deny rules subtracting from the union at runtime.** Would invert
+DEC-RG878's additive semantics and force re-derivation of `authorizeWrite`,
+`readQuery` (which compiles to `store.GraphQuery` and pushes into SQL),
+`PermitsReadMany`, `FieldVerdicts`, `TransitionVerdicts`, `AccessRoutes` and all
+of `internal/aclmap`. **Note the correction:** a deny rule applied at *load*
+time — subtracting from the role's allowlists to produce a derived narrowed
+allowlist — needs none of that. That realisation is what this design rests on.
+The runtime never learns the word "deny"; it still sees a plain allowlist.
+Wildcards expand against the metamodel at load (`ValidateAgainstMetamodel`
+already runs there).
+- **Intersecting denial sets across profiles.** `{salary} ∩ {bsn} = {}` — the
+denials cancel, and every profile must restate every denial or it evaporates.
+Rejected: the restatement cost is the thing we are trying to avoid.
+- **A flat per-profile allowlist that restates everything.** Clear as glass, but
+effort is O(schema size) per profile and drifts as the metamodel grows.
+
+The baseline+scopes shape puts the effort where it belongs: the baseline is
+written once per client class, and a scope's cost is proportional to what it
+re-opens.
+
+### Selection: exactly one baseline, no combination rule
+
+`client_baselines` are named blocks, each declaring `applies_to:
+[<principal_type>…]`. **The `applies_to` sets must be disjoint — overlap is a
+load error, not a precedence puzzle.** So exactly one baseline matches any
+token, and there is no baseline-vs-baseline combination semantics to specify or
+document.
+
+A `principal_type` matching no baseline is **unrestricted** (gated only by the
+user's own roles). This is what makes `principal_type: user` work with no
+special-casing. It also means an unknown type string from another provider
+escapes the ceiling — hence the audit rule below.
+
+`Tool` was considered as a selector and **dropped**: it is self-asserted by the
+entry-point binary, not cryptographically verified, and mixing a spoofable key
+with signed claims in one mechanism invites operators to lean on the weak one.
+stdio MCP (which has no authentication at all) is therefore not addressable by
+this feature; that is TKT-G3PPD's problem, not this one.
+
+### Allowlist or denylist, per type, per block
+
+Each block picks the posture that fits, per entity type:
+
+| Allowlist (fail-closed) | Denylist (low-effort) |
+|---|---|
+| `visible: {person: [name, email]}` | `redact: {person: [salary, bsn]}` |
+| `read: [ticket, person]` | `deny_read: [audit-record]` |
+| `update: [ticket]` | `deny_update: ["*"]` |
+
+Declaring both spellings for the same type in one block is a **load error**.
+
+`deny_write: ["*"]` is shorthand expanding at load to create+update+delete —
+"read-only client" should be one line, not three.
+
+**Omitted axis = inherited** (the block does not narrow it).
+
+The allowlist form inherits the existing **closed-world `visible:`** semantics
+(`affordances/resolver.go:370` — a role declaring a `visible:` block for a type
+asserts a complete list; unnamed fields redact). That is what gives the
+fail-closed property: a field added to `person` tomorrow is hidden from any
+client whose block names `person` under `visible:`, with no operator action.
+
+### Verbs vs permissions stay separate
+
+`RoleDef` has two distinct axes and this ticket mirrors both rather than
+unifying them:
+
+- **verb × entity type** — `Create`/`Update`/`Delete`/`Read []string`, evaluated
+by `grantsVerb(role, op, target)` (`policy.go:288`).
+- **named capabilities** — `Permissions []string`, evaluated by
+`grantsPermission` (`resolver.go:272`), flat string match, no type parameter.
+
+So `update: [ticket]` is not expressible as a permission (permissions have
+nowhere to put the type). `deny_permissions:` covers the second axis and reaches
+every `permission:` value in the system — command guards, document guards,
+navigation, `history:read`, `history:read-redacted`, delegate-X.
+
+**IDEA-HUWQ** proposes collapsing these two axes into one named-permission
+catalog, and its own sequencing note says to hold until TKT-VMD8 lands. Unifying
+here would mean redesigning the core grant model inside a client-restriction
+ticket. If IDEA-HUWQ later lands, this ceiling collapses with it for free — both
+spellings already compile to the same clamp at load.
+
+## Worked example
+
+Metamodel: `person` (name, email, phone, salary, bsn), `ticket` (title, status,
+body, assignee), `audit-record` (actor, action, timestamp).
+
+```yaml
+roles:
+  hr:
+    read:   [person, ticket, audit-record]
+    update: [person, ticket]
+    delete: [ticket]
+    permissions: [history:read]
+    # no visible: block -> Alice sees ALL fields
+
+client_baselines:
+  apps:
+    applies_to: [app]
+    deny_write: ["*"]
+    deny_permissions: [history:read]
+    redact:
+      person: [salary, bsn]
+    # read omitted -> inherits the user's rows
+
+  service-accounts:
+    applies_to: [service]
+    read: [ticket]
+    visible:
+      ticket: [title, status]
+
+scope_grants:
+  rela.people.read:
+    read: [person]
+    visible: {person: [name, email]}
+  rela.tickets.write:
+    update: [ticket]
+```
+
+Alice (role `hr`) connects an MCP client; token has `principal_type: app`,
+`scope: "rela.tickets.write"`.
+
+- **read** — baseline omits it, `rela.people.read` absent → inherits Alice's
+`{person, ticket, audit-record}`.
+- **person fields** — `redact:` removes salary and bsn. Alice still sees them in
+the SPA; the MCP does not. **This is the original ask.**
+- **update** — `deny_write: ["*"]` ∪ `rela.tickets.write` → `{ticket}`,
+intersected with Alice's `{person, ticket}` → `{ticket}`. If read-only Bob used
+the same token: `{} ∩ {ticket} = {}`. The ceiling never grants past the user.
+- **history:read** — withheld despite Alice's role granting it.
+
+A `service` token with no scope sees ticket rows only, title+status only —
+person rows 404 (row-level, not redaction: nonexistence is the secret, per the
+row-level rule in CLAUDE.md).
+
+## Scope
+
+**In scope**
+
+- `principal_type` + `scope` claim extraction: `jwtauth.AssertionClaims`
+(`verifier.go:157-163`) → `dataentry.AssertedIdentity` (`router.go:471-476`) →
+`principal.Verified` (`principal.go:84`). Bounded like `roles` is
+(`maxRoles=32`, `maxRoleRunes=256`, `verifier.go:171-174`).
+- New `Policy` fields + `knownPolicyKeys` (`policy.go:413-424`, guarded by the
+reflection parity test `policy_parity_test.go:15-30`).
+- Load-time compilation of baselines/scope_grants into plain allowlists,
+including `"*"` expansion against the metamodel.
+- The clamp, applied after role resolution: `computeGlobals`/`ForEntity` results
+narrowed before `decideFromAttrs`, `readQuery`, `grantsPermission`,
+`FieldVerdicts`.
+- Enforcement on every surface the ACL already reaches: read gate, `visible:`
+redaction, write authorize, named permissions.
+- A distinguishable `SourceKind` so attribution names the ceiling that clamped.
+- `rela acl audit` rules (below) + `rela acl map --as <profile>` to render a
+compiled ceiling.
+- Docs: `docs/acl-security.md` (trust-boundary section), `docs/acl-overview.md`
+(pinned by `docfields_test.go` / `docs_example_test.go`).
+
+**Out of scope**
+
+- **MCP `list_tools` filtering** → TKT-G3PPD. A client denied writes still sees
+write tools and gets a runtime rejection.
+- **MCP read gating generally** → TKT-G3PPD. `internal/mcp` bypasses the read
+path entirely; this ticket makes the *policy* expressible, it does not wire MCP
+into `internal/visibility`.
+- **Org enforcement** (`OrgID`/`OrgSlug` are attribution-only,
+`principal.go:100-104`) — separate ticket, named in TKT-RP3X3Q.
+- **`client_id` keying** — the mechanism supports adding a third table later at
+no semantic cost (still exactly-one-baseline); not built now.
+- **Unifying verbs and permissions** → IDEA-HUWQ.
+- **`syncContext` claim-dropping** (below) — pre-existing, its own ticket.
+
+## Acceptance criteria
+
+1. A verified assertion carrying `principal_type` and `scope` yields a
+Principal exposing both; absent claims yield empty values with no error
+(`--principal-header` and loopback paths unchanged).
+2. Two `client_baselines` whose `applies_to` sets overlap is a **startup error**
+naming both blocks.
+3. A token whose `principal_type` matches no baseline is unrestricted —
+pinned by an explicit test so it cannot drift.
+4. `redact:` hides exactly the named fields; a field added to the type later
+still shows. `visible:` hides everything unnamed, including fields added later.
+Both pinned.
+5. Declaring `visible:` and `redact:` for the same type in one block is a load
+error.
+6. `deny_write: ["*"]` denies create, update and delete.
+7. A scope re-opens capability the baseline closed, bounded by the user: the
+same token used by a lesser-privileged user grants strictly less.
+8. `deny_permissions:` withholds a named permission the user's role grants
+(verified against `history:read` and a command `permission:`).
+9. Row-denial is indistinguishable from nonexistence — 404, pruned lists, no
+count leak (per the row-level rule).
+10. `rela acl map --as <profile>` renders the compiled effective ceiling.
+11. `rela acl audit` flags: a `principal_type` value no baseline covers; a
+baseline that narrows nothing (dead config); a block naming an undeclared
+type/field.
+12. Attribution names the ceiling in the deny reason, distinguishably from a
+role-grant denial.
+13. `NopACL` / `ReadOnlyACL` unchanged.
+
+## Risks
+
+- **Trust boundary.** `internal/acl` verifies nothing; a Principal is trusted
+absolutely. `principal_type`/`scope` MUST be populated only after signature
+verification — the unexported-field + `Verified()` constructor shape
+(`principal.go:58-95`) already enforces this at compile time and must be
+preserved for the new fields. A spoofable-header path setting them would be a
+full bypass.
+- **A ceiling that silently grants nothing.** An operator writing a baseline for
+a `principal_type` the IdP never sends gets no error and no protection — AC11's
+audit rule is the mitigation.
+- **`syncContext` (`sync_handlers.go:20-23`) already drops all verified claims
+today** — a plain composite literal, exactly the failure
+`resolvePrincipalEntity` (`router.go:380-382`) warns about. New fields would be
+dropped too. Pre-existing bug; **file separately** rather than fixing inline.
+- **Eleven plain-composite-literal Principal construction sites** (CLI, MCP,
+scheduler, desktop, docs, webhook, aclmap ×2, docscapture, header/env resolvers)
+need a zero-value decision for the new fields.
+- **`rela acl map` cannot model asserted claims today** (`mapall.go:71-74`) —
+AC10 requires extending it.
+- **Adding a field to `Principal` touches nine methods** (`Verified`,
+`Sanitized`, `Equal`, `IsZero`, `Clone`, `principalJSON`, `MarshalJSON`,
+`UnmarshalJSON`) plus the audit wire format.
+- **9-minute stale-claim window** — assertion TTL is hard-coded upstream
+(`signer.go:22`); a scope change takes up to 9 minutes to take effect. Document,
+do not try to fix.
+
+## Prior art
+
+- Extends **FEAT-AESD4**, whose design already calls for exactly this:
+*"MCP transport intersects user capabilities with agent scope and defaults
+agents to read-only."* This is the policy half of that.
+- **DEC-RG878** — union semantics preserved (load-time compilation).
+- **TKT-RP3X3Q** — deferred `principal_type` here; established
+`asserted_role_assignments` as the precedent for claim→policy mapping and the
+`SourceAsserted` attribution kind.
+- **TKT-G3PPD** — MCP transport intersection, consumes this policy.
+- **IDEA-HUWQ** — would later collapse the verb/permission duality.

--- a/tickets/relations/BUG-0Q8MCZ--adds-measure--MEAS-PRINCIPAL-RESTAMP.md
+++ b/tickets/relations/BUG-0Q8MCZ--adds-measure--MEAS-PRINCIPAL-RESTAMP.md
@@ -1,0 +1,5 @@
+---
+from: BUG-0Q8MCZ
+relation: adds-measure
+to: MEAS-PRINCIPAL-RESTAMP
+---

--- a/tickets/relations/BUG-0Q8MCZ--affects--authorization.md
+++ b/tickets/relations/BUG-0Q8MCZ--affects--authorization.md
@@ -1,0 +1,5 @@
+---
+from: BUG-0Q8MCZ
+relation: affects
+to: authorization
+---

--- a/tickets/relations/BUG-0Q8MCZ--fixes--FEAT-AESD4.md
+++ b/tickets/relations/BUG-0Q8MCZ--fixes--FEAT-AESD4.md
@@ -1,0 +1,5 @@
+---
+from: BUG-0Q8MCZ
+relation: fixes
+to: FEAT-AESD4
+---

--- a/tickets/relations/MEAS-PRINCIPAL-RESTAMP--protects--authorization.md
+++ b/tickets/relations/MEAS-PRINCIPAL-RESTAMP--protects--authorization.md
@@ -1,0 +1,5 @@
+---
+from: MEAS-PRINCIPAL-RESTAMP
+relation: protects
+to: authorization
+---

--- a/tickets/relations/TKT-IAC8TX--affects--authorization.md
+++ b/tickets/relations/TKT-IAC8TX--affects--authorization.md
@@ -1,0 +1,5 @@
+---
+from: TKT-IAC8TX
+relation: affects
+to: authorization
+---

--- a/tickets/relations/TKT-IAC8TX--affects--data-entry-server.md
+++ b/tickets/relations/TKT-IAC8TX--affects--data-entry-server.md
@@ -1,0 +1,5 @@
+---
+from: TKT-IAC8TX
+relation: affects
+to: data-entry-server
+---

--- a/tickets/relations/TKT-IAC8TX--affects--mcp-api.md
+++ b/tickets/relations/TKT-IAC8TX--affects--mcp-api.md
@@ -1,0 +1,5 @@
+---
+from: TKT-IAC8TX
+relation: affects
+to: mcp-api
+---

--- a/tickets/relations/TKT-IAC8TX--has-docs--DOCS-O3LYQN.md
+++ b/tickets/relations/TKT-IAC8TX--has-docs--DOCS-O3LYQN.md
@@ -1,0 +1,5 @@
+---
+from: TKT-IAC8TX
+relation: has-docs
+to: DOCS-O3LYQN
+---

--- a/tickets/relations/TKT-IAC8TX--has-implementation--IMPL-GX8C6A.md
+++ b/tickets/relations/TKT-IAC8TX--has-implementation--IMPL-GX8C6A.md
@@ -1,0 +1,5 @@
+---
+from: TKT-IAC8TX
+relation: has-implementation
+to: IMPL-GX8C6A
+---

--- a/tickets/relations/TKT-IAC8TX--has-planning--PLAN-PXV4F9.md
+++ b/tickets/relations/TKT-IAC8TX--has-planning--PLAN-PXV4F9.md
@@ -1,0 +1,5 @@
+---
+from: TKT-IAC8TX
+relation: has-planning
+to: PLAN-PXV4F9
+---

--- a/tickets/relations/TKT-IAC8TX--has-review--REV-HIH8K8.md
+++ b/tickets/relations/TKT-IAC8TX--has-review--REV-HIH8K8.md
@@ -1,0 +1,5 @@
+---
+from: TKT-IAC8TX
+relation: has-review
+to: REV-HIH8K8
+---

--- a/tickets/relations/TKT-IAC8TX--has-review-response--RR-48B6MT.md
+++ b/tickets/relations/TKT-IAC8TX--has-review-response--RR-48B6MT.md
@@ -1,0 +1,5 @@
+---
+from: TKT-IAC8TX
+relation: has-review-response
+to: RR-48B6MT
+---

--- a/tickets/relations/TKT-IAC8TX--has-review-response--RR-9K9NSJ.md
+++ b/tickets/relations/TKT-IAC8TX--has-review-response--RR-9K9NSJ.md
@@ -1,0 +1,5 @@
+---
+from: TKT-IAC8TX
+relation: has-review-response
+to: RR-9K9NSJ
+---

--- a/tickets/relations/TKT-IAC8TX--has-review-response--RR-B6DRAG.md
+++ b/tickets/relations/TKT-IAC8TX--has-review-response--RR-B6DRAG.md
@@ -1,0 +1,5 @@
+---
+from: TKT-IAC8TX
+relation: has-review-response
+to: RR-B6DRAG
+---

--- a/tickets/relations/TKT-IAC8TX--has-review-response--RR-MUJUWS.md
+++ b/tickets/relations/TKT-IAC8TX--has-review-response--RR-MUJUWS.md
@@ -1,0 +1,5 @@
+---
+from: TKT-IAC8TX
+relation: has-review-response
+to: RR-MUJUWS
+---

--- a/tickets/relations/TKT-IAC8TX--has-review-response--RR-U41F3D.md
+++ b/tickets/relations/TKT-IAC8TX--has-review-response--RR-U41F3D.md
@@ -1,0 +1,5 @@
+---
+from: TKT-IAC8TX
+relation: has-review-response
+to: RR-U41F3D
+---

--- a/tickets/relations/TKT-IAC8TX--has-review-response--RR-UYB99D.md
+++ b/tickets/relations/TKT-IAC8TX--has-review-response--RR-UYB99D.md
@@ -1,0 +1,5 @@
+---
+from: TKT-IAC8TX
+relation: has-review-response
+to: RR-UYB99D
+---

--- a/tickets/relations/TKT-IAC8TX--implements--FEAT-AESD4.md
+++ b/tickets/relations/TKT-IAC8TX--implements--FEAT-AESD4.md
@@ -1,0 +1,5 @@
+---
+from: TKT-IAC8TX
+relation: implements
+to: FEAT-AESD4
+---


### PR DESCRIPTION
Restricts a non-interactive client **below the user it acts as**. An OIDC proxy mints principals carrying `principal_type` and `scope`; rela read neither, so an MCP server connected by an HR user could read `person.salary` because that user can.

```
effective = user_grants ∩ (baseline ∪ matched scope_grants)
```

```yaml
client_baselines:
  apps:
    applies_to: [app]        # verified principal_type; sets must be disjoint
    deny_write: ["*"]
    redact:
      person: [salary, bsn]  # hidden from the client, visible to the user
scope_grants:
  rela.tickets.write:
    update: [ticket]         # hands one capability back
```

Two properties are load-bearing: **a ceiling never grants** (intersection with the user's own grants means a token cannot exceed its user), and **scopes widen only within it** (so a client is never broken by *gaining* a scope).

## Where to look first

| File | Why |
|---|---|
| `internal/acl/ceiling.go` | Policy vocabulary + validation. The `deny_write`-expands-**after**-validation ordering is subtle — see the regression test. |
| `internal/acl/ceilingcompile.go` | The compiler. A **matcher**, not an expanded type set. |
| `internal/acl/request.go` | `roleFor` — the single clamp point everything else inherits. |
| `internal/affordances/dimension.go` | `restrictTo` **intersects**; using `allow()` would let a ceiling re-grant. |

## Why it compiles at load time

Restrictions resolve into plain allowlists when `acl.yaml` loads, so the runtime evaluator never gains a denial primitive and DEC-RG878's additive union semantics are untouched.

A runtime deny would have to be re-derived in *every* evaluation path **including `readQuery`**, which compiles to a `store.GraphQuery` pushed into SQL — so it would have to become a SQL predicate per backend.

The compiled ceiling is a **matcher, not an expanded set**: expanding wildcards against the metamodel is the one step that can fail *open* (stale schema, a type added later, a subtly wrong set difference). A matcher has no universe to get wrong.

`Request.roleFor` is the single clamp point — every evaluation path resolves role names through it, so read gating, write authz, permission checks and the affordance resolver all inherit the ceiling without knowing it exists. A guard test scans the package and fails if a path reaches `policy.Roles` directly; it uses an **exemption** list, so a new file fails closed. (I verified it fires by injecting a bypass, then reverting.)

## Bugs found while building this

Four, every one of which failed **open** or silently:

- `trimAll` collapsed an explicit `read: []` to nil — turning a hard lockout into no restriction at all.
- Scopes re-opened denials by list subtraction, so `deny_write: ["*"]` plus a scope left the wildcard intact and re-opened nothing. Now an explicit `except` carve-out, checked ahead of the wildcard.
- `deny_write` expanded **before** validation, silently discarding a colliding `deny_update` instead of rejecting it.
- *(code review)* `applyClientCeiling` returned early when ctx carried no `acl.Request`, so a stamped-but-unbound principal kept full field visibility — while `resolveViaDeclarative`, twenty lines away, opened its own Request. Within one `FieldVerdicts` call, roles resolved and the ceiling did not.

## Scope

Enforced everywhere the ACL already reaches: read gate, `visible:` redaction, write authorize, and named permissions (both global **and** entity-scoped, so state-machine transition guards clamp too).

**Not covered — documented rather than hidden:**

- **Relation *meta* fields** — a separate grant vocabulary with no ceiling equivalent. Row-level `deny_read` still gates both endpoints.
- **stdio MCP** — no authentication, so no verified claim to key a baseline on. This makes the *policy* expressible; wiring `internal/mcp` through the read gate is **TKT-G3PPD**.

Also adds `rela acl audit` rules for the failure mode that produces no symptom (a ceiling that reads like protection and enforces nothing), and `rela acl map --as <type>` to show what a client actually gets.

## Verification

- `just ci` green (check + coverage 77.2% + build + docs-check).
- 3 review passes: my own tests caught 3 fail-opens; `cranky-code-reviewer` caught the 4th; `crit` caught that the docs undersold the feature.
- 6 review responses linked to TKT-IAC8TX — 1 critical + 1 significant + 2 minor addressed, 1 deferred, 1 wont-fix.
- Manually verified against a throwaway project; the documented CLI output is a verbatim copy of a real run.

Implements FEAT-AESD4 · Ticket TKT-IAC8TX
