### PR TITLE
refactor(pgstore): one shared NOTIFY channel with schema in payload (TKT-9TOEBH)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -303,18 +303,24 @@ Rules when touching this:
   still needs a `--project` dir.
 - **Multi-writer change feed** (TKT-WZYWM9). The postgres watcher delivers
   cross-process writes via PostgreSQL `LISTEN/NOTIFY`: each committed write does
-  `pg_notify(<schema-scoped channel>, '<origin>:<kind>:<op>:<id>')` inside its
+  `pg_notify(rela_changed, '<origin>:<schema>:<kind>:<op>:<id>')` inside its
   transaction (so the 5 single-statement writes are wrapped in a tx); a listener
   goroutine (own connection, started in `Open`, stopped in `Close`) turns remote
-  notifications into `store.Event`s on the in-process `Subscribe()` fan-out. A
-  per-store random `originID` in the payload filters self-echoes (the listener
-  skips its own writes — local writes are already emitted in-process). NOTIFY is
-  best-effort, so a `seq > watermark` catch-up (overlap window + idempotent
-  re-snapshot; runs on connect/reconnect/safety-ticker, NOT per notification)
-  recovers anything missed. The channel is schema-scoped (`rela_changed_<schema>`)
-  because LISTEN is database-global — all processes of one deployment share a
-  schema/channel. If the listener can't connect, the store degrades with a
-  warning (local events still work). Exact ordering (xid8 + `pg_snapshot_xmin`)
+  notifications into `store.Event`s on the in-process `Subscribe()` fan-out. Two
+  payload fields do the routing, both filtered on receipt: a per-store random
+  `originID` drops self-echoes (local writes are already emitted in-process), and
+  the writing `schema` drops traffic from other schemas sharing the channel.
+  NOTIFY is best-effort, so a `seq > watermark` catch-up (overlap window +
+  idempotent re-snapshot; runs on connect/reconnect/safety-ticker, NOT per
+  notification) recovers anything missed. **The channel is ONE constant
+  (`rela_changed`), not one per schema** (TKT-9TOEBH): LISTEN is database-global
+  *and* needs a dedicated session, so a per-schema name would cost one
+  permanently-held connection per schema — the term that does not shrink under
+  pooling. Isolation lives in the payload instead. What is **not** shared is the
+  catch-up: `rela_seq` is per-schema and the catch-up query is unqualified SQL,
+  so priming/catch-up stay bound to each store's own pool — do not "simplify"
+  them onto a shared connection. If the listener can't connect, the store
+  degrades with a warning (local events still work). Exact ordering (xid8 + `pg_snapshot_xmin`)
   is the documented upgrade, not built. The data-entry SSE feed consumes this
   via `App.startStoreEventBridge` (entity events only). fsstore/memstore stay
   in-process single-writer by nature.

--- a/docs-project/entities/guides/GUIDE-postgres-backend.md
+++ b/docs-project/entities/guides/GUIDE-postgres-backend.md
@@ -110,6 +110,11 @@ What you need to know to run it:
 - Each process opens **one extra connection** to receive change notifications.
   If it can't, the process still works normally; only the live cross-server
   updates are unavailable (a warning is logged).
+- That is **one connection per process, not per schema**. All processes LISTEN
+  on a single shared channel (`rela_changed`) and the writing schema travels in
+  the notification payload, so a process serving several schemas on one database
+  still needs only the one connection. Notifications from a schema a store does
+  not read are discarded on arrival.
 - Live updates cover **entity** create/update/delete. Relation and attachment
   edits are reflected on the next page load rather than pushed live.
 

--- a/docs/postgres-backend.md
+++ b/docs/postgres-backend.md
@@ -104,6 +104,11 @@ What you need to know to run it:
 - Each process opens **one extra connection** to receive change notifications.
   If it can't, the process still works normally; only the live cross-server
   updates are unavailable (a warning is logged).
+- That is **one connection per process, not per schema**. All processes LISTEN
+  on a single shared channel (`rela_changed`) and the writing schema travels in
+  the notification payload, so a process serving several schemas on one database
+  still needs only the one connection. Notifications from a schema a store does
+  not read are discarded on arrival.
 - Live updates cover **entity** create/update/delete. Relation and attachment
   edits are reflected on the next page load rather than pushed live.
 

--- a/internal/store/pgstore/export_test.go
+++ b/internal/store/pgstore/export_test.go
@@ -33,22 +33,26 @@ func SetNotifyDisabledForTest(t *testing.T, disabled bool) {
 }
 
 // FeedPayloadForTest builds a NOTIFY payload for an entity event with the given
-// origin and id, exactly as the producer would. Test-only.
-func FeedPayloadForTest(origin string, op store.EventOp, id string) string {
-	return notifyPayload(origin, store.Event{Op: op, EntityID: id})
+// origin, schema and id, exactly as the producer would. Test-only.
+func FeedPayloadForTest(origin, schema string, op store.EventOp, id string) string {
+	return notifyPayload(origin, schema, store.Event{Op: op, EntityID: id})
 }
 
 // NotificationEmitsForTest runs the listener's handleNotification with a
-// listener bound to selfOrigin and the given payload, and reports whether an
-// event was emitted to a subscriber. This isolates the origin-filter decision
-// from feed/DB timing. Test-only.
-func NotificationEmitsForTest(t *testing.T, selfOrigin, payload string) bool {
+// listener bound to (selfOrigin, selfSchema) and the given payload, and reports
+// whether an event was emitted to a subscriber. This isolates the filter
+// decisions from feed/DB timing. Test-only.
+//
+// selfSchema is an explicit parameter rather than defaulted: with a shared
+// channel, "" == "" would make a caller that forgot it pass vacuously, which is
+// the exact failure mode the schema filter exists to prevent.
+func NotificationEmitsForTest(t *testing.T, selfOrigin, selfSchema, payload string) bool {
 	t.Helper()
 	s := &Store{subscribers: make(map[int]chan store.Event)}
 	ch, cancel := s.Subscribe(1)
 	defer cancel()
 
-	l := &listener{store: s, originID: selfOrigin}
+	l := &listener{store: s, originID: selfOrigin, schema: selfSchema}
 	l.handleNotification(&pgconn.Notification{Payload: payload})
 
 	select {
@@ -62,6 +66,12 @@ func NotificationEmitsForTest(t *testing.T, selfOrigin, payload string) bool {
 // WriteAdvisoryLockKeyForTest exposes the Tx write-serialization advisory
 // key so the stress tests can assert it never leaks in pg_locks. Test-only.
 const WriteAdvisoryLockKeyForTest = writeAdvisoryLockKey
+
+// FeedChannelForTest exposes the shared NOTIFY channel so a test can emit a
+// raw notification onto the same channel the listener LISTENs on. Referencing
+// the constant (rather than rebuilding the name) means a rename cannot leave a
+// test quietly notifying a channel nobody hears. Test-only.
+const FeedChannelForTest = feedChannel
 
 // BuildGraphQuerySQLForTest exposes the internal SQL builder so
 // explain-plan tests can render the SQL without going through a pgx

--- a/internal/store/pgstore/feed.go
+++ b/internal/store/pgstore/feed.go
@@ -25,11 +25,23 @@ var notifyDisabled atomic.Bool
 //
 // # Channel scoping
 //
-// LISTEN/NOTIFY channels are DATABASE-global, not schema-scoped. Since the
-// conformance harness runs many isolated schemas on one database, the channel
-// name is schema-qualified (rela_changed_<schema>) so two schemas never
-// cross-talk. All processes of one deployment share a schema, so they share a
-// channel and see each other's writes.
+// LISTEN/NOTIFY channels are DATABASE-global, not schema-scoped, and many
+// schemas can share one database (the conformance harness, the postgres e2e,
+// and a multi-tenant deployment all do). Isolation is therefore enforced by
+// carrying the writing schema IN THE PAYLOAD and filtering on receipt, NOT by
+// giving each schema its own channel name.
+//
+// The channel is a single constant (rela_changed). That is deliberate: LISTEN
+// requires a dedicated session per connection, so a per-schema channel name
+// would cost one permanently-held connection PER SCHEMA before any pooling.
+// A constant channel lets one connection serve every schema a process touches.
+// The listener already filters (it drops its own echoes by originID), so schema
+// filtering is one more predicate rather than new machinery.
+//
+// What this does NOT share is the seq-watermark catch-up: `rela_seq` is
+// per-schema and the catch-up query is unqualified SQL resolved through the
+// connection's search_path, so priming and catching up stay bound to each
+// store's own pool. See listener.go.
 //
 // # Self-echo
 //
@@ -37,9 +49,10 @@ var notifyDisabled atomic.Bool
 // the writing store's random originID; the listener skips notifications whose
 // origin matches its own store (those writes were already emitted in-process).
 
-// feedChannelPrefix is the constant part of the NOTIFY channel; the active
-// schema is appended (see resolveChannel).
-const feedChannelPrefix = "rela_changed_"
+// feedChannel is the single NOTIFY channel every rela process LISTENs on,
+// regardless of schema. The writing schema travels in the payload instead of
+// the channel name — see the "Channel scoping" note above for why.
+const feedChannel = "rela_changed"
 
 // payloadSep separates payload fields. It is '\x1f' (ASCII Unit Separator),
 // which storeutil.ValidateID rejects in entity IDs and relation types (control
@@ -59,41 +72,60 @@ func newOriginID() string {
 	return hex.EncodeToString(b[:])
 }
 
-// resolveChannel returns the schema-scoped NOTIFY channel for this store's
-// connection. The schema is the first entry of the active search_path
-// (current_schema()), which is where the store's tables live.
-func resolveChannel(ctx context.Context, db DBTX) (string, error) {
+// resolveSchema returns the schema this store's tables live in — the first
+// entry of the active search_path (current_schema()). It is stamped into every
+// NOTIFY payload and matched on receipt, so it is what keeps two schemas
+// sharing one channel from cross-talking.
+//
+// A schema containing the payload separator would shift every field and break
+// the parse, so it is rejected here rather than trusted. PostgreSQL permits
+// almost anything inside a quoted identifier, and schema names are
+// operator- (or, under multi-tenancy, tenant-) derived, so this is a trust
+// boundary and not a formality. Failing loudly at Open beats emitting
+// unparseable notifications for the life of the process.
+func resolveSchema(ctx context.Context, db DBTX) (string, error) {
 	var schema string
 	if err := db.QueryRow(ctx, `SELECT current_schema()`).Scan(&schema); err != nil {
-		return "", fmt.Errorf("pgstore: resolve schema for change channel: %w", err)
+		return "", fmt.Errorf("pgstore: resolve schema for change feed: %w", err)
 	}
 	if schema == "" {
 		schema = "public"
 	}
-	return feedChannelPrefix + schema, nil
+	if strings.Contains(schema, payloadSep) {
+		return "", fmt.Errorf("pgstore: schema name %q contains the change-feed payload separator", schema)
+	}
+	return schema, nil
 }
 
-// feedEvent is the wire form of a change: the writing store's origin plus the
-// fields needed to reconstruct a store.Event. Encoded as 7 SEP-joined fields:
+// feedEvent is the wire form of a change: the writing store's origin and
+// schema, plus the fields needed to reconstruct a store.Event. Encoded as 8
+// SEP-joined fields:
 //
-//	origin SEP kind SEP op SEP entityType SEP a SEP b SEP c
+//	origin SEP schema SEP kind SEP op SEP entityType SEP a SEP b SEP c
 //
 // where (a,b,c) are (id,"","") for an entity or (from,relType,to) for a
 // relation, and entityType is the entity's type ("" for relations).
 //
+// origin and schema are the two routing fields — the listener drops a
+// notification whose origin is its own (already emitted in-process) or whose
+// schema is not the one its store reads. Everything after them is event data.
+//
 // The separator (\x1f, a control char) cannot appear in an id or relation type
-// because storeutil.ValidateID rejects control characters. entityType is NOT
-// validated for control chars on write; a type containing \x1f would inject an
-// extra field, fail the 7-field parse, and degrade that one notification to a
-// catch-up (handleNotification returns needCatchUp) — never a corruption.
+// because storeutil.ValidateID rejects control characters, and resolveSchema
+// rejects it in a schema name. entityType is NOT validated for control chars on
+// write; a type containing \x1f would inject an extra field, fail the 8-field
+// parse, and degrade that one notification to a catch-up (handleNotification
+// returns needCatchUp) — never a corruption.
 type feedEvent struct {
 	origin string
+	schema string
 	ev     store.Event
 }
 
-// notifyPayload encodes a store.Event (with this store's origin) for pg_notify.
-// Entities use the EntityType/EntityID fields; relations use RelationType/From/To.
-func notifyPayload(origin string, ev store.Event) string {
+// notifyPayload encodes a store.Event (with this store's origin and schema) for
+// pg_notify. Entities use the EntityType/EntityID fields; relations use
+// RelationType/From/To.
+func notifyPayload(origin, schema string, ev store.Event) string {
 	kind, op := feedKindOp(ev.Op)
 	var a, b, c string
 	switch ev.Op {
@@ -104,22 +136,23 @@ func notifyPayload(origin string, ev store.Event) string {
 	}
 	// EntityType is carried for entity events so the listener can rebuild a
 	// faithful event; relations don't carry a type beyond RelationType.
-	return strings.Join([]string{origin, kind, op, ev.EntityType, a, b, c}, payloadSep)
+	return strings.Join([]string{origin, schema, kind, op, ev.EntityType, a, b, c}, payloadSep)
 }
 
 // parseFeedPayload reverses notifyPayload. Returns ok=false for any malformed
 // payload (the listener then falls back to the catch-up query rather than
 // trusting a bad NOTIFY).
 // payloadFields is the number of SEP-joined fields in a notify payload:
-// origin, kind, op, entityType, a, b, c.
-const payloadFields = 7
+// origin, schema, kind, op, entityType, a, b, c.
+const payloadFields = 8
 
 func parseFeedPayload(payload string) (feedEvent, bool) {
 	parts := strings.Split(payload, payloadSep)
 	if len(parts) != payloadFields {
 		return feedEvent{}, false
 	}
-	origin, kind, op, entType, a, b, c := parts[0], parts[1], parts[2], parts[3], parts[4], parts[5], parts[6]
+	origin, schema, kind, op := parts[0], parts[1], parts[2], parts[3]
+	entType, a, b, c := parts[4], parts[5], parts[6], parts[7]
 	feOp, ok := feedOp(kind, op)
 	if !ok {
 		return feedEvent{}, false
@@ -131,7 +164,7 @@ func parseFeedPayload(payload string) (feedEvent, bool) {
 	case "r":
 		ev.From, ev.RelationType, ev.To = a, b, c
 	}
-	return feedEvent{origin: origin, ev: ev}, true
+	return feedEvent{origin: origin, schema: schema, ev: ev}, true
 }
 
 // feedKindOp maps a store.EventOp to the compact (kind, op) payload codes.
@@ -174,22 +207,23 @@ func feedOp(kind, op string) (store.EventOp, bool) {
 	}
 }
 
-// notify emits a NOTIFY for ev on this store's channel, carrying this store's
-// origin. q is the write's transaction (or the pool) — calling it inside the
-// write's transaction makes the notification atomic with the write: it fires
-// only on commit, never on rollback.
+// notify emits a NOTIFY for ev on the shared feed channel, carrying this
+// store's origin and schema so receivers can route it. q is the write's
+// transaction (or the pool) — calling it inside the write's transaction makes
+// the notification atomic with the write: it fires only on commit, never on
+// rollback.
 //
-// A store with no resolved channel (built via New without listener wiring, e.g.
+// A store with no resolved schema (built via New without listener wiring, e.g.
 // conformance tests) makes this a no-op. Errors are intentionally ignored: the
 // notification is a best-effort hint and the seq catch-up recovers anything
 // lost — a failed NOTIFY must never fail the write.
 func (s *Store) notify(ctx context.Context, q DBTX, ev store.Event) {
-	if s.channel == "" {
+	if s.schema == "" {
 		return
 	}
 	if notifyDisabled.Load() {
 		return // test hook: force the catch-up path to be the only delivery channel
 	}
 	// pg_notify takes (text, text), both bound parameters — no injection surface.
-	_, _ = q.Exec(ctx, `SELECT pg_notify($1, $2)`, s.channel, notifyPayload(s.originID, ev))
+	_, _ = q.Exec(ctx, `SELECT pg_notify($1, $2)`, feedChannel, notifyPayload(s.originID, s.schema, ev))
 }

--- a/internal/store/pgstore/listener.go
+++ b/internal/store/pgstore/listener.go
@@ -46,9 +46,15 @@ var catchUpInterval atomic.Int64
 func init() { catchUpInterval.Store(int64(defaultCatchUpInterval)) }
 
 // listener runs the cross-process change feed for one Store: it holds a
-// dedicated PostgreSQL connection, LISTENs on the store's schema-scoped channel,
-// turns notifications (and a seq-watermark catch-up) into store.Events, and
-// emits them to the store's in-process subscribers.
+// dedicated PostgreSQL connection, LISTENs on the shared feed channel, turns
+// notifications (and a seq-watermark catch-up) into store.Events, and emits
+// them to the store's in-process subscribers.
+//
+// Because the channel is shared by every schema on the database, the listener
+// filters on receipt: it drops a notification whose schema is not its own, and
+// one whose origin is its own store (already emitted in-process). The
+// seq-watermark catch-up is NOT shared — `rela_seq` is per-schema and the
+// catch-up query is unqualified SQL — so it runs against this store's pool.
 //
 // It owns its own connection (separate from the store's query pool) so a slow
 // LISTEN never starves query traffic. Lifecycle is owned by the Store:
@@ -56,7 +62,7 @@ func init() { catchUpInterval.Store(int64(defaultCatchUpInterval)) }
 type listener struct {
 	store    *Store
 	dsn      string
-	channel  string
+	schema   string
 	originID string
 
 	cancel context.CancelFunc
@@ -64,8 +70,8 @@ type listener struct {
 }
 
 // startListener builds and starts a listener for s against dsn. It resolves the
-// schema-scoped channel from a throwaway connection, then runs the loop in a
-// goroutine. A failure to establish the initial connection is returned so the
+// store's schema (stamped into payloads and matched on receipt), then runs the
+// loop in a goroutine. A failure to establish the initial connection is returned so the
 // caller can degrade with a warning (the store stays usable; cross-process
 // events are simply unavailable).
 func startListener(ctx context.Context, s *Store, dsn string) (*listener, error) {
@@ -73,20 +79,23 @@ func startListener(ctx context.Context, s *Store, dsn string) (*listener, error)
 	if err != nil {
 		return nil, err
 	}
-	channel, err := resolveChannel(ctx, conn)
+	// Resolve on the store's own pool, not this listener connection: the
+	// producer writes through the pool, so the schema stamped into payloads
+	// must be the pool's. They are the same DSN today, but tying it to the
+	// writer is what stays correct if a pool ever repoints its search_path.
+	schema, err := resolveSchema(ctx, s.db)
 	if err != nil {
 		_ = conn.Close(ctx)
 		return nil, err
 	}
-	// Keep the store's producer channel in sync with the listener's (both must
-	// match for self/remote notifications to land on the same channel).
-	s.channel = channel
+	// Enabling the producer (see Store.notify, which no-ops on an empty schema).
+	s.schema = schema
 
 	lctx, cancel := context.WithCancel(context.Background())
 	l := &listener{
 		store:    s,
 		dsn:      dsn,
-		channel:  channel,
+		schema:   schema,
 		originID: s.originID,
 		cancel:   cancel,
 		done:     make(chan struct{}),
@@ -179,23 +188,38 @@ func (l *listener) run(ctx context.Context, conn *pgx.Conn) {
 	}
 }
 
-// listen issues LISTEN on the channel. The channel is a server-generated,
-// identifier-shaped string (prefix + current_schema()), quoted to be safe.
+// listen issues LISTEN on the shared feed channel. The name is a compile-time
+// constant; it is quoted only because LISTEN does not accept bound parameters.
 func (l *listener) listen(ctx context.Context, conn *pgx.Conn) error {
-	_, err := conn.Exec(ctx, "LISTEN "+pgQuoteIdentifier(l.channel))
+	_, err := conn.Exec(ctx, "LISTEN "+pgQuoteIdentifier(feedChannel))
 	return err
 }
 
-// handleNotification turns one NOTIFY into a store.Event, skipping our own
-// writes (already emitted in-process). It returns true when the caller should
-// run an immediate catch-up: an unparseable payload (e.g. one truncated past
+// handleNotification turns one NOTIFY into a store.Event, skipping notifications
+// that are not ours to deliver. It returns true when the caller should run an
+// immediate catch-up: an unparseable payload (e.g. one truncated past
 // pg_notify's 8000-byte limit) is never trusted, so we reconcile from real rows
 // right away rather than waiting for the safety ticker.
+//
+// Two filters, in this order:
+//
+//   - **Schema.** Every schema on the database shares one channel, so a write
+//     to another schema arrives here too. It describes rows this store cannot
+//     see; emitting it would fabricate an event for an entity that does not
+//     exist in this store's schema. Checked BEFORE origin because a foreign
+//     schema's write is irrelevant regardless of who wrote it.
+//   - **Origin.** Our own write, already emitted in-process by the writer.
+//
+// Neither triggers a catch-up: both are expected, correctly-formed traffic, not
+// a signal that anything was missed.
 func (l *listener) handleNotification(n *pgconn.Notification) (needCatchUp bool) {
 	fe, ok := parseFeedPayload(n.Payload)
 	if !ok {
 		slog.Debug("pgstore listener: unparseable notification payload; catching up", "channel", n.Channel)
 		return true
+	}
+	if fe.schema != l.schema {
+		return false // another schema sharing this channel — not our rows
 	}
 	if fe.origin == l.originID {
 		return false // our own write — already emitted in-process
@@ -350,8 +374,8 @@ func (l *listener) reconnect(ctx context.Context) (*pgx.Conn, error) {
 
 // pgQuoteIdentifier quotes a PostgreSQL identifier (doubling embedded quotes)
 // for safe interpolation into LISTEN, which does not accept bound parameters.
-// The channel is server-derived (prefix + current_schema()), so this is
-// defense-in-depth rather than a live injection vector.
+// The channel is a compile-time constant, so this is defense-in-depth rather
+// than a live injection vector.
 func pgQuoteIdentifier(ident string) string {
 	out := make([]byte, 0, len(ident)+2)
 	out = append(out, '"')

--- a/internal/store/pgstore/listener_test.go
+++ b/internal/store/pgstore/listener_test.go
@@ -158,18 +158,40 @@ func TestCatchUpRecoversMissedEvents(t *testing.T) {
 // allowed to re-emit recent rows; that's why the guarantee is on the
 // notification path, not "exactly once ever".)
 func TestSelfNotificationFiltered(t *testing.T) {
-	selfPayload := pgstore.FeedPayloadForTest("origin-self", store.EventEntityCreated, "DEC-1")
-	require.False(t, pgstore.NotificationEmitsForTest(t, "origin-self", selfPayload),
+	const schema = "s1"
+	selfPayload := pgstore.FeedPayloadForTest("origin-self", schema, store.EventEntityCreated, "DEC-1")
+	require.False(t, pgstore.NotificationEmitsForTest(t, "origin-self", schema, selfPayload),
 		"self-origin notification must be filtered (already emitted in-process)")
 
-	remotePayload := pgstore.FeedPayloadForTest("origin-other", store.EventEntityCreated, "FEAT-2")
-	require.True(t, pgstore.NotificationEmitsForTest(t, "origin-self", remotePayload),
+	remotePayload := pgstore.FeedPayloadForTest("origin-other", schema, store.EventEntityCreated, "FEAT-2")
+	require.True(t, pgstore.NotificationEmitsForTest(t, "origin-self", schema, remotePayload),
 		"remote-origin notification must be emitted")
 }
 
+// TestForeignSchemaNotificationFiltered pins the schema filter directly, without
+// feed/DB timing. Every schema on a database shares one channel (feedChannel),
+// so a notification from another schema DOES arrive here and must be dropped:
+// it describes rows this store cannot see, and emitting it would fabricate an
+// event for an entity that does not exist in this schema.
+//
+// The remote-origin case is the load-bearing one — a same-origin foreign-schema
+// payload would be dropped by the origin filter anyway, so it cannot tell
+// whether the schema filter works.
+func TestForeignSchemaNotificationFiltered(t *testing.T) {
+	foreign := pgstore.FeedPayloadForTest("origin-other", "schema-b", store.EventEntityCreated, "FEAT-B")
+	require.False(t, pgstore.NotificationEmitsForTest(t, "origin-self", "schema-a", foreign),
+		"a notification from another schema must not be emitted")
+
+	own := pgstore.FeedPayloadForTest("origin-other", "schema-a", store.EventEntityCreated, "FEAT-A")
+	require.True(t, pgstore.NotificationEmitsForTest(t, "origin-self", "schema-a", own),
+		"a remote-origin notification for our own schema must be emitted")
+}
+
 // TestChannelIsolationAcrossSchemas (AC7): two writers on DIFFERENT schemas in
-// the same database do NOT see each other's notifications (schema-scoped
-// channel). This is what keeps parallel tests from cross-talking.
+// the same database do NOT see each other's notifications. Since TKT-9TOEBH
+// they share one channel, so the isolation now comes from the payload's schema
+// field being filtered on receipt rather than from distinct channel names —
+// this test pins the end-to-end guarantee either way.
 func TestChannelIsolationAcrossSchemas(t *testing.T) {
 	schemaX := freshFeedSchema(t)
 	schemaY := freshFeedSchema(t)
@@ -180,13 +202,14 @@ func TestChannelIsolationAcrossSchemas(t *testing.T) {
 	defer cancelX()
 
 	ctx := context.Background()
-	// Write on Y; X must NOT receive it (different schema => different channel).
+	// Write on Y; X must NOT receive it. The NOTIFY does reach X's listener (one
+	// shared channel), so this exercises the payload schema filter for real.
 	require.NoError(t, y.CreateEntity(ctx, entity.New("FEAT-Y", "feature")))
 
 	select {
 	case ev := <-chX:
 		if ev.EntityID == "FEAT-Y" {
-			t.Fatalf("schema X received schema Y's notification — channel not isolated: %+v", ev)
+			t.Fatalf("schema X received schema Y's notification — schema filter not applied: %+v", ev)
 		}
 	case <-time.After(1500 * time.Millisecond):
 		// good — isolated
@@ -284,7 +307,7 @@ func TestMalformedNotificationTriggersCatchUp(t *testing.T) {
 		"INSERT INTO "+pgQuoteIdent(schema)+".entities (id, type) VALUES ('GAR-1', 'ticket')")
 	require.NoError(t, err)
 	_, err = admin.Exec(ctx,
-		"SELECT pg_notify('rela_changed_'||$1, 'not-a-valid-payload')", schema)
+		"SELECT pg_notify($1, 'not-a-valid-payload')", pgstore.FeedChannelForTest)
 	require.NoError(t, err)
 
 	ev := waitForEntityEvent(t, ch, "GAR-1", 5*time.Second)

--- a/internal/store/pgstore/pgstore.go
+++ b/internal/store/pgstore/pgstore.go
@@ -17,7 +17,7 @@
 // In addition to the injected query pool, a store opened via [Open] owns a
 // change-feed listener (see feed.go / listener.go) holding its OWN dedicated
 // connection, started in Open and stopped in Close. Each committed write emits
-// a NOTIFY on a schema-scoped channel; the listener turns OTHER processes'
+// a NOTIFY on the shared feed channel; the listener turns OTHER processes'
 // notifications into store.Events on the same in-process Subscribe() fan-out as
 // local writes, so multiple processes against one database see each other's
 // changes. Store.Close stops the listener (closing its connection) before
@@ -84,12 +84,15 @@ type Store struct {
 	db        DBTX
 	observers []store.EntityObserver // notified synchronously after committed entity writes
 
-	// Cross-process change feed (see feed.go / listener.go). originID identifies
-	// this store's own NOTIFY echoes so the listener can skip them; channel is
-	// the schema-scoped NOTIFY channel (empty => the producer is a no-op, e.g.
-	// for a New() store with no listener wiring). Both are set at construction.
+	// Cross-process change feed (see feed.go / listener.go). Every process
+	// LISTENs on one constant channel (feedChannel); these two fields are what
+	// route a notification. originID identifies this store's own NOTIFY echoes
+	// so the listener can skip them. schema is the schema this store's tables
+	// live in, stamped into each payload so receivers on other schemas ignore
+	// it — and doubling as the "feed is wired" flag: empty => the producer
+	// no-ops, as for a New() store with no listener wiring.
 	originID string
-	channel  string
+	schema   string
 	listener *listener // nil unless a listener was started (see startListener)
 	sweep    *sweep    // nil unless a version-reconciliation sweep was started
 
@@ -145,11 +148,11 @@ func New(db DBTX, opts ...Option) (*Store, error) {
 		originID:    newOriginID(),
 		subscribers: make(map[int]chan store.Event),
 	}
-	// The producer NOTIFY channel is left empty here (producer no-ops) until a
-	// listener is started via Open, which resolves the schema-scoped channel and
-	// sets s.channel for both producer and listener. A store built with New and
-	// no listener (e.g. the conformance harness) simply emits no cross-process
-	// notifications — its in-process watcher is unaffected.
+	// The producer's schema is left empty here (producer no-ops) until a
+	// listener is started via Open, which resolves it via resolveSchema. A
+	// store built with New and no listener (e.g. the conformance harness)
+	// simply emits no cross-process notifications — its in-process watcher is
+	// unaffected.
 	for _, opt := range opts {
 		opt(s)
 	}

--- a/internal/store/pgstore/tx.go
+++ b/internal/store/pgstore/tx.go
@@ -78,7 +78,7 @@ func (s *Store) Tx(ctx context.Context, fn func(store.Store) error) error {
 	view := &Store{
 		db:          tx,
 		originID:    s.originID,
-		channel:     s.channel,
+		schema:      s.schema,
 		subscribers: make(map[int]chan store.Event),
 		txPending:   pending,
 	}

--- a/tickets/entities/tickets/TKT-9TOEBH.md
+++ b/tickets/entities/tickets/TKT-9TOEBH.md
@@ -1,0 +1,141 @@
+---
+id: TKT-9TOEBH
+type: ticket
+title: 'pgstore: one shared NOTIFY channel with schema in the payload, not one channel per schema'
+kind: refactor
+priority: medium
+effort: m
+status: backlog
+---
+
+## Description
+
+The cross-process change feed names its NOTIFY channel `rela_changed_<schema>`
+(`feed.go:42,65-74`). Because `LISTEN` requires a dedicated session per
+connection, a process serving N schemas needs **N long-lived connections just to
+hear about changes** — before any pooling for actual queries.
+
+Replace the per-schema channel with **one channel (`rela_changed`) carrying the
+schema as a payload field**, and have the listener filter. Live updates then
+cost **one connection per process** instead of one per schema.
+
+### Why (stands on its own)
+
+Today `pgstore.Open` opens a dedicated `pgx.Connect` purely to `LISTEN`
+(`listener.go:72`), outside the pool. That is one non-pooled connection per
+store, permanently held. Even in the current single-schema deployment this is a
+fixed cost per process; the multi-process deployment story in
+`docs/postgres-backend.md` already notes "each process opens one extra
+connection to receive change notifications".
+
+The per-schema name buys **nothing that the payload cannot**: the listener
+already parses a structured payload and already filters (it drops self-echoes by
+`originID`, `listener.go:200-202`). Adding a schema field and one more filter
+predicate is strictly less machinery than a dynamically-named channel that must
+be resolved at connect time and kept in sync with the producer (`listener.go:82`
+mutates `s.channel` as a side effect — a wart this removes).
+
+### Why it also matters later
+
+Multi-tenant SaaS (RES-D54281) is capped by exactly this. The connection budget
+is ~17/tenant today, and the analysis there identified the LISTEN session — not
+the pool — as the term that does **not** shrink under apartment-style pooling.
+This is the change that decouples "live updates" from "tenants per process".
+
+## The important subtlety: LISTEN is shareable, catch-up is not
+
+Do not conflate the two halves. Verified:
+
+- The **dedicated connection is used ONLY for `LISTEN`** (`listener.go:72-96`).
+- **`primeWatermark` (`listener.go:224`) and `catchUp` (`listener.go:254`) run on
+`l.store.db` — the store's pool**, not the dedicated connection.
+
+That matters because the catch-up query is **unqualified SQL** (`FROM entities`,
+`FROM relations`, `FROM deletions`) resolved through the connection's
+`search_path`, and the watermark is a `rela_seq` value that is **per-schema**. A
+single shared connection therefore *cannot* run catch-up for N schemas, and a
+shared watermark would be meaningless.
+
+So the split is:
+
+- **Shared**: the LISTEN session and the channel. One per process.
+- **Per-schema, unchanged**: the watermark, `primeWatermark`, `catchUp`, and the
+30s safety-net poll — each already bound to its own store's pool.
+
+Getting this wrong in the direction of "share everything" silently breaks
+recovery of missed notifications, which is precisely the failure mode the
+watermark exists to prevent — and it fails *quietly*, like the sweep-lock bug in
+RES-S8CH9C's R1.
+
+## Scope
+
+**In scope**
+
+- Change `feedChannelPrefix` usage to a single constant channel name; drop
+`resolveChannel`'s per-schema suffix (keep resolving `current_schema()` — it
+becomes a payload field instead of part of the name).
+- Add `schema` to the payload (`notifyPayload`/`parseFeedPayload`,
+`feed.go:95-130`); bump `payloadFields` 7 → 8.
+- Filter in `handleNotification`: ignore a notification whose schema is not this
+listener's, alongside the existing `originID` self-echo check.
+- Remove the `s.channel` side-effect assignment in `startListener`
+(`listener.go:82`) — with a constant channel, producer and consumer no longer
+need to be reconciled at runtime.
+
+**Out of scope**
+
+- Sharing ONE listener goroutine/connection across N stores. This ticket makes
+the channel shareable; actually multiplexing one connection to many stores is
+the follow-up, and depends on the `appbuild.Services` split (RES-D54281).
+**Landing this first means that follow-up is wiring, not protocol design.**
+- Redis or any external bus. That is the cross-cluster answer (RES-D54281), not
+this.
+- Anything touching the watermark, catch-up, or the sweep.
+
+## Compatibility: this is a wire-format break
+
+An 8-field payload fails the 7-field parse in an old listener, and vice versa.
+`parseFeedPayload` returns `ok=false` on a bad payload and the listener
+**degrades to catch-up** (`feed.go:110-113` documents exactly this) rather than
+corrupting — so a mixed-version fleet stays *correct*, but loses live push until
+every process is upgraded, self-healing within `catchUpInterval` (30s).
+
+That is an acceptable, bounded degradation, but it MUST be stated in the PR and
+release notes: **during a rolling upgrade, cross-process live updates lag by up
+to 30s.** Old and new processes also LISTEN on different channel names, so they
+simply do not see each other until both sides are new.
+
+## Acceptance criteria
+
+1. All processes LISTEN on one constant channel regardless of schema.
+2. A notification for schema A is ignored by a listener bound to schema B, pinned
+by a test using two schemas on one database (the harness already does this —
+`listener_test.go:53` returns the schema name for exactly this purpose).
+3. Self-echo filtering by `originID` still works, unchanged.
+4. Two stores on two schemas in one process both receive their own live events
+and neither receives the other's.
+5. A malformed/short payload still degrades to catch-up rather than erroring or
+emitting a wrong event.
+6. `primeWatermark`/`catchUp` behaviour is untouched — same tables, same overlap,
+same per-schema seq semantics.
+7. `s.channel` is no longer assigned from the listener.
+8. Fail-before check: each new test must be shown to fail against the pre-change
+code. A schema-filter test is exactly the shape that can pass vacuously (see
+RES-S8CH9C R1's note that the obvious lock-scoping test passed against a
+deliberately broken build).
+9. `just test-postgres` passes; `just ci` passes.
+
+## Notes
+
+- `notifyDisabled` (`feed.go:19`) and `catchUpInterval` (`listener.go:44`) are
+package-level test hooks. They stay process-global here; with N stores per
+process they would become a shared knob, which is fine for tests but worth a
+comment.
+- The payload separator is `\x1f`, rejected by `storeutil.ValidateID` in ids and
+relation types (`feed.go:44-47`). **Schema names must be validated the same
+way** before landing in the payload — an unvalidated schema containing `\x1f`
+would shift every field. Schema names are operator/tenant-derived, so this is a
+trust boundary, not a formality (RES-D54281 already requires
+`^[a-z][a-z0-9_]{0,30}$` for tenant schema names).
+- `docs/postgres-backend.md:103-110` documents the per-schema channel and the
+"one extra connection" cost; update both.

--- a/tickets/relations/RES-D54281--informs--TKT-9TOEBH.md
+++ b/tickets/relations/RES-D54281--informs--TKT-9TOEBH.md
@@ -1,0 +1,5 @@
+---
+from: RES-D54281
+relation: informs
+to: TKT-9TOEBH
+---

--- a/tickets/relations/TKT-9TOEBH--affects--store-backends.md
+++ b/tickets/relations/TKT-9TOEBH--affects--store-backends.md
@@ -1,0 +1,5 @@
+---
+from: TKT-9TOEBH
+relation: affects
+to: store-backends
+---

--- a/tickets/relations/TKT-9TOEBH--implements--FEAT-CO4YP.md
+++ b/tickets/relations/TKT-9TOEBH--implements--FEAT-CO4YP.md
@@ -1,0 +1,5 @@
+---
+from: TKT-9TOEBH
+relation: implements
+to: FEAT-CO4YP
+---


### PR DESCRIPTION
The cross-process change feed named its NOTIFY channel `rela_changed_<schema>`.
Because `LISTEN` needs a dedicated session, that cost **one permanently-held
connection per schema**. This moves the schema into the payload and LISTENs on a
single constant channel (`rela_changed`), so live updates cost **one connection
per process** regardless of how many schemas it touches.

Ticket: TKT-9TOEBH. Design: RES-D54281. Independent of #1318 — both branch from
`develop` and touch disjoint files.

## Why

The per-schema channel name bought nothing the payload cannot. The listener
already parses a structured payload and already filters (self-echoes by
`originID`), so schema filtering is one more predicate rather than new
machinery. It also removes a wart: `startListener` used to reach back and mutate
`s.channel` to keep producer and consumer in sync. With a constant channel there
is nothing to synchronise.

For multi-tenancy (RES-D54281) this is the term that does **not** shrink under
apartment-style pooling, so it caps tenants-per-process directly.

## The subtlety: LISTEN is shareable, catch-up is not

Verified before touching anything:

- the dedicated connection is used **only** for `LISTEN`
- `primeWatermark` and `catchUp` run on `l.store.db` — the store's **pool**

That matters because the catch-up query is unqualified SQL resolved through
`search_path`, and the watermark is a **per-schema** `rela_seq` value. So a
shared connection cannot run catch-up for N schemas, and a shared watermark
would be meaningless.

Shared: the LISTEN session and channel. Per-schema and untouched: the watermark,
priming, catch-up, the 30s safety poll. Getting this wrong toward
"share everything" would silently break recovery of missed notifications — the
exact failure the watermark exists to prevent. Both the package doc and
CLAUDE.md now say so explicitly.

## Filter order

Schema is checked **before** origin: a foreign schema's write is irrelevant
regardless of who wrote it, and emitting it would fabricate an event for an
entity that does not exist in this store's schema. Neither filter triggers a
catch-up — both are expected, well-formed traffic, not evidence of a miss.

## Testing: the trap this could have fallen into

A schema-filter test passes vacuously if both sides default to `""`. So
`NotificationEmitsForTest` takes `selfSchema` as an **explicit parameter**
rather than defaulting it, and every new assertion was checked to fail against
the pre-change code:

- remove the schema filter → `TestForeignSchemaNotificationFiltered` **and** the
  end-to-end `TestChannelIsolationAcrossSchemas` both fail
- remove the origin filter → `TestSelfNotificationFiltered` fails

The end-to-end failure is the meaningful one: it proves the shared channel
really does deliver cross-schema traffic that the filter must drop, rather than
the test passing because nothing arrived.

`TestMalformedNotificationTriggersCatchUp` previously emitted on
`'rela_changed_'||$1`; it now references the exported constant, so a future
rename cannot leave it quietly notifying a channel nobody hears.

## Wire-format break — rolling upgrade note

The payload goes 7 → 8 fields, and old/new processes LISTEN on different channel
names. A mixed-version fleet stays **correct** (an unparseable payload degrades
to catch-up by design, never to a wrong event) but loses live cross-process push
until every process is upgraded, self-healing within `catchUpInterval` (30s).

**Operators doing a rolling upgrade should expect cross-process live updates to
lag by up to 30s during the rollout.** Single-process deployments are unaffected.

## Also

`resolveSchema` rejects a schema name containing the payload separator (`\x1f`)
rather than trusting it — it would shift every field. PostgreSQL allows almost
anything in a quoted identifier and schema names are operator- (later tenant-)
derived, so this is a trust boundary. Failing at `Open` beats emitting
unparseable notifications for the life of the process.

Docs updated: `docs/postgres-backend.md`, the `docs-project` guide mirror, and
the CLAUDE.md change-feed rule (which stated the old per-schema naming as
architecture).

## Verification

- `go build ./...` and `go build -tags postgres ./...`
- full pgstore suite against a live PostgreSQL 15 (`-count=1`, includes
  conformance + fuzz)
- full default-build `go test ./...`
- `just arch-lint` clean; `golangci-lint` clean on every changed file

Note: `internal/appbuild` and `internal/cli` fail under `-tags postgres` on this
branch — they also fail identically on unmodified `develop` (tests that need an
FS project, run under the postgres tag). Pre-existing, unrelated, and not
covered by CI's postgres job.