### PR TITLE
fix(tickets): file BUG-ZE4354 — form Cancel walks out of the SPA

### DIFF
--- a/tickets/entities/automated-measures/AM-form-cancel-stays-in-spa.md
+++ b/tickets/entities/automated-measures/AM-form-cancel-stays-in-spa.md
@@ -1,0 +1,31 @@
+---
+id: AM-form-cancel-stays-in-spa
+type: automated-measure
+title: 'Test: form Cancel resolves a route target instead of walking out of the SPA'
+description: 'Pins BUG-ZE4354: Cancel must never leave the SPA. Unit arms cover return_to-first, the no-history fallback, and the unchanged back() path; the load-bearing E2E arm opens a create form directly in a fresh context (empty history) and asserts the app is still mounted on an in-app route — the existing suite only reaches forms via in-app links, which is why it never caught this.'
+kind: test
+location: frontend/src/components/forms/DynamicForm.*.test.ts + e2e/tests/forms.spec.ts
+status: proposed
+---
+
+Pins the fix for BUG-ZE4354: **Cancel must never leave the SPA.**
+
+The defect was that `handleCancel` called `router.back()` unconditionally — a
+browser-history operation with no route target. On a directly-opened form
+(pasted URL, bookmark, new tab) there is no prior in-app entry, so back walked
+out of the application.
+
+## What the test asserts
+
+1. **Unit** — with `return_to` set, Cancel pushes that route (it is already
+honoured by the submit path; the asymmetry with Cancel was the bug).
+2. **Unit** — with no history and no `return_to`, Cancel pushes a fallback
+route rather than calling `back()`.
+3. **Unit** — with in-app history, Cancel still calls `back()` (no regression
+for the common path).
+4. **E2E** — open a create form **directly** in a fresh context, click Cancel,
+and assert the app is still mounted on an in-app route.
+
+The E2E arm is the load-bearing one. A unit test with a mocked router can be
+made to pass while the real history stack still escapes the app, so the
+regression guard has to exercise a real browser with an empty history.

--- a/tickets/entities/bugs/BUG-ZE4354.md
+++ b/tickets/entities/bugs/BUG-ZE4354.md
@@ -1,0 +1,93 @@
+---
+id: BUG-ZE4354
+type: bug
+title: Cancel on a directly-opened create form walks out of the SPA (router.back with no history)
+description: 'On a create form opened directly (pasted URL, bookmark, new tab), Cancel appears to do nothing. handleCancel calls router.back(), a browser-history operation with no route target; with no prior SPA entry it walks out of the app entirely (measured: lands on about:blank). Works when the form is reached via an in-app link. Pre-existing on develop, not a TKT-OMUD56 regression. Fix: prefer the already-resolved returnTo (which the submit path honours but Cancel ignores), fall back to history only when an in-app entry exists, else push the type''s list view.'
+priority: medium
+status: backlog
+---
+
+## Symptom
+
+On a create form opened **directly** (pasted URL, bookmark, new tab), the
+**Cancel** button appears to do nothing.
+
+## What actually happens
+
+It is not a no-op. `handleCancel` calls `router.back()`
+(`frontend/src/components/forms/DynamicForm.vue:1019`), which is a *browser
+history* operation, not a route target. With no prior SPA entry in the tab's
+history, back walks **out of the app** — to whatever preceded it. In a normal
+tab that is the new-tab page, which reads to the user as "nothing happened".
+
+Measured with Playwright against the running app:
+
+| Case | Before | After Cancel |
+| --- | --- | --- |
+| Opened directly in a fresh tab | `/form/create_ticket` | `about:blank` |
+| Arrived via an in-app link | `/form/create_ticket` | `/list/all_tickets` |
+
+So the button works whenever the form is reached the normal way (sidebar, a
+list's "+ New", a detail page) and only misbehaves on direct entry.
+
+## Reproduction
+
+1. Open a new browser tab.
+2. Paste `http://<host>/form/create_ticket` and load it.
+3. Click **Cancel**.
+
+Expected: return somewhere sensible in the app. Actual: leaves the SPA.
+
+## Scope
+
+Pre-existing, not a regression: `handleCancel` was `router.back()` on `develop`
+before TKT-OMUD56, which only added an `embedded` early-return above it (the
+nested-modal path emits `inline-cancelled` and never reaches `router.back()`).
+Found while manually testing that ticket's demo.
+
+Applies to the edit form too — where the button is labelled **Back** — since
+both go through the same `handleCancel`.
+
+## Suggested fix
+
+Prefer an explicit target, fall back to history, then to a sensible default. The
+pieces already exist:
+
+- `returnTo` is already resolved in this component from a validated
+`?return_to=` (`applyReturnToFromQuery`, using `readReturnTo`'s open-redirect
+guard) and is already honoured by the **submit** path — Cancel simply does not
+consult it. That asymmetry is the core of the bug.
+- `useBackTarget` (`frontend/src/composables/useBackTarget.ts:44`) already
+encodes the resolution order `return_to` → `?from=` → null, and is the
+established precedent for "where does back go" in this SPA.
+- `findListIdForEntityType` (`stores/schema.ts`) resolves a type's list view
+for a last-resort default.
+
+Sketch:
+
+```ts
+function handleCancel() {
+  if (props.embedded) { emit('inline-cancelled'); return }
+  if (returnTo.value) { router.push(returnTo.value); return }
+  // Only go back when there is an in-app entry to go back to.
+  if (hasAppHistory()) { router.back(); return }
+  const listId = schemaStore.findListIdForEntityType(formConfig.value.entity)
+  router.push(listId ? `/list/${listId}` : '/')
+}
+```
+
+The history check is the load-bearing part — `window.history.length` is
+unreliable (it counts pre-SPA entries), so prefer tracking whether this SPA
+instance has navigated at all (e.g. a router `afterEach` counter, or
+`router.options.history.state.back != null`).
+
+Reusing `useBackTarget` rather than re-deriving the order would keep the two
+surfaces consistent.
+
+## Test plan
+
+- Unit: Cancel with `returnTo` set pushes it; without history pushes the list
+fallback; with history calls `back()`.
+- E2E: open a create form directly, click Cancel, assert the app is still
+mounted and on a sensible route (currently would land off-app).
+- Regression: arriving via a list "+ New" still returns to that list.

--- a/tickets/relations/BUG-ZE4354--adds-measure--AM-form-cancel-stays-in-spa.md
+++ b/tickets/relations/BUG-ZE4354--adds-measure--AM-form-cancel-stays-in-spa.md
@@ -1,0 +1,5 @@
+---
+from: BUG-ZE4354
+relation: adds-measure
+to: AM-form-cancel-stays-in-spa
+---

--- a/tickets/relations/BUG-ZE4354--affects--data-entry-ui.md
+++ b/tickets/relations/BUG-ZE4354--affects--data-entry-ui.md
@@ -1,0 +1,5 @@
+---
+from: BUG-ZE4354
+relation: affects
+to: data-entry-ui
+---

--- a/tickets/relations/BUG-ZE4354--fixes--FEAT-Q767.md
+++ b/tickets/relations/BUG-ZE4354--fixes--FEAT-Q767.md
@@ -1,0 +1,5 @@
+---
+from: BUG-ZE4354
+relation: fixes
+to: FEAT-Q767
+---


### PR DESCRIPTION
Files **BUG-ZE4354**. Ticket only — no code change yet.

## The bug

On a create form opened **directly** (pasted URL, bookmark, new tab), the
**Cancel** button appears to do nothing.

It is not a no-op. `handleCancel` calls `router.back()` — a *browser history*
operation with no route target — so with no prior in-app entry it walks out of
the application entirely.

Measured with Playwright against a running instance:

| Case | Before | After Cancel |
| --- | --- | --- |
| Opened directly in a fresh tab | `/form/create_ticket` | `about:blank` |
| Arrived via an in-app link | `/form/create_ticket` | `/list/all_tickets` |

So it works whenever the form is reached the normal way and only misbehaves on
direct entry. Applies to the edit form too (button labelled **Back**), since
both go through the same handler.

## Not a regression

`handleCancel` was already `router.back()` on `develop` before TKT-OMUD56;
that ticket only added an `embedded` early-return above it. Found while
manually testing its demo.

## Suggested fix

Recorded on the ticket. The pieces already exist: `returnTo` is resolved in
this component from a validated `?return_to=` and is **already honoured by the
submit path** — Cancel simply does not consult it, and that asymmetry is the
core of the defect. `useBackTarget` already encodes the `return_to` → `?from=`
resolution order, and `findListIdForEntityType` gives a last-resort default.

The load-bearing detail: `window.history.length` is unreliable for the
"is there anywhere to go back to" check, since it counts pre-SPA entries.

## Status

Filed in **backlog**, not `ready` — it is not scheduled, and the CI ticket gate
correctly rejects a `ready` item whose code has not shipped.

Linked to its concept, the feature it fixes, and a regression measure
(`AM-form-cancel-stays-in-spa`) whose load-bearing arm is an E2E test that
opens a form in a fresh context with empty history — the existing suite only
ever reaches forms via in-app links, which is exactly why this was never caught.