### PR TITLE
fix(dataentry): keep form Cancel inside the SPA (BUG-ZE4354)

### DIFF
--- a/e2e/pages/form.page.ts
+++ b/e2e/pages/form.page.ts
@@ -17,6 +17,17 @@ export class FormPage extends BasePage {
     this.titleInput = page.locator("#field-title");
   }
 
+  /** The app shell chrome — present whenever the SPA is mounted. */
+  get appChrome(): Locator {
+    return this.page.locator(".sidebar, nav").first();
+  }
+
+  /** Navigate to a list view (used to seed in-app history before a form). */
+  async navigateToList(listId: string) {
+    await this.navigateTo(`/list/${listId}`);
+    await this.waitForSpinnerToDisappear();
+  }
+
   async navigateToCreateForm(formId: string) {
     await this.navigateTo(`/form/${formId}`);
     await this.waitForSpinnerToDisappear();

--- a/e2e/tests/forms.spec.ts
+++ b/e2e/tests/forms.spec.ts
@@ -185,6 +185,41 @@ test.describe('Edit Form - Default Relation Picker Save (BUG-UNEBR regression)',
   });
 });
 
+// Cancel/Back must land inside the app (BUG-ZE4354).
+//
+// `router.back()` is a browser-history operation with no route target, so on a
+// form opened COLD — the exact shape below, a direct navigation with no prior
+// in-app entry — it walked out of the SPA entirely. The existing specs never
+// caught it because they all reach forms via an in-app link, which leaves a
+// history entry to go back to.
+test.describe('Form cancel navigation', () => {
+  test('cancel on a directly-opened form stays in the app', async ({ appPage }) => {
+    const formPage = new FormPage(appPage);
+    await formPage.navigateToCreateForm('feature');
+
+    await formPage.cancel();
+
+    // The load-bearing assertions: we left the form, we are on a real in-app
+    // route, and the SPA is still mounted. Before the fix this landed on the
+    // browser's pre-app page (about:blank in a fresh context).
+    await expect(appPage).not.toHaveURL(/\/form\//);
+    await expect(appPage).toHaveURL(/\/(list\/[a-z_]+|$)/);
+    expect(appPage.url()).not.toContain('about:blank');
+    await expect(formPage.appChrome).toBeVisible();
+  });
+
+  test('cancel still goes back when there is in-app history', async ({ appPage }) => {
+    // No regression for the common path.
+    const formPage = new FormPage(appPage);
+    await formPage.navigateToList('features');
+    await formPage.navigateToCreateForm('feature');
+
+    await formPage.cancel();
+
+    await expect(appPage).toHaveURL(/\/list\/features/);
+  });
+});
+
 // Inline entity creation from a relation field (TKT-OMUD56).
 //
 // The affordance is derived, not configured: it appears for a target type when

--- a/frontend/src/components/forms/DynamicForm.cancel.test.ts
+++ b/frontend/src/components/forms/DynamicForm.cancel.test.ts
@@ -1,0 +1,148 @@
+// Cancel/Back navigation on a form (BUG-ZE4354).
+//
+// `router.back()` is a browser-history operation with no route target. On a
+// form opened cold — pasted URL, bookmark, new tab — there is no in-app entry
+// behind it, so back walked out of the SPA entirely. To the user that reads as
+// "the Cancel button does nothing".
+//
+// The signal that distinguishes the two cases is `history.state.back`, which
+// vue-router writes on a push and which a full page load leaves null no matter
+// how deep the browser's own history is. `window.history.length` cannot be
+// used: it counts pre-SPA entries and reads >= 2 even on a fresh open.
+
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { mount, flushPromises } from '@vue/test-utils'
+import { useSchemaStore, useEntitiesStore } from '@/stores'
+import DynamicForm from './DynamicForm.vue'
+
+const push = vi.fn()
+const back = vi.fn()
+
+// `historyState` stands in for `router.options.history.state`: null-ish `back`
+// means the app was loaded cold at this URL.
+let historyState: { back?: string | null } = {}
+let routeQuery: Record<string, string> = {}
+
+vi.mock('vue-router', () => ({
+  useRouter: () => ({
+    push,
+    back,
+    replace: vi.fn(),
+    options: { history: { get state() { return historyState } } },
+  }),
+  useRoute: () => ({ query: routeQuery, params: {}, path: '/form/ticket-form' }),
+  onBeforeRouteLeave: vi.fn(),
+}))
+
+vi.mock('@/api', async () => {
+  const actual = await vi.importActual<Record<string, unknown>>('@/api')
+  return {
+    ...actual,
+    getTemplates: vi.fn().mockResolvedValue([]),
+    dryRunCreateEntity: vi.fn().mockImplementation(async (_t: string, body: unknown) => ({
+      properties: (body as { properties?: Record<string, unknown> })?.properties ?? {},
+      _fields: {},
+      _relations: {},
+      warnings: [],
+    })),
+  }
+})
+
+const ENTITY_TYPE = {
+  name: 'ticket',
+  label: 'Ticket',
+  id_type: 'short',
+  properties: { title: { type: 'string' } },
+}
+
+const FORM = { id: 'ticket-form', entity: 'ticket', fields: [{ property: 'title' }] }
+
+async function mountForm(opts: { list?: boolean } = {}) {
+  const schema = useSchemaStore()
+  schema.forms.set(FORM.id, FORM as never)
+  schema.entityTypes.set('ticket', ENTITY_TYPE as never)
+  if (opts.list !== false) {
+    schema.lists.set('all_tickets', { entity: 'ticket', title: 'All' } as never)
+  }
+  schema.loaded = true
+  useEntitiesStore()
+
+  const wrapper = mount(DynamicForm, {
+    props: { formId: FORM.id },
+    global: {
+      stubs: {
+        RouterLink: true,
+        MarkdownEditor: true,
+        RelationPicker: true,
+        RelationCards: true,
+        AutoSaveIndicator: true,
+        HelpModal: true,
+      },
+    },
+  })
+  await flushPromises()
+  return wrapper
+}
+
+async function clickCancel(wrapper: Awaited<ReturnType<typeof mountForm>>) {
+  const btn = wrapper.findAll('button').find((b) => b.text().includes('Cancel'))
+  expect(btn, 'Cancel button should render').toBeTruthy()
+  await btn!.trigger('click')
+  await flushPromises()
+}
+
+describe('DynamicForm — Cancel navigation', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.clearAllMocks()
+    historyState = {}
+    routeQuery = {}
+  })
+
+  it('goes back when the SPA has an in-app entry behind it', async () => {
+    // The common path: reached the form from a list or detail page.
+    historyState = { back: '/list/all_tickets' }
+    await clickCancel(await mountForm())
+
+    expect(back).toHaveBeenCalledTimes(1)
+    expect(push).not.toHaveBeenCalled()
+  })
+
+  it('pushes the type list instead of leaving the SPA when opened cold', async () => {
+    // The bug: no in-app entry, so back() would walk out of the app.
+    await clickCancel(await mountForm())
+
+    expect(back).not.toHaveBeenCalled()
+    expect(push).toHaveBeenCalledWith('/list/all_tickets')
+  })
+
+  it('falls back to the dashboard when the type has no list', async () => {
+    await clickCancel(await mountForm({ list: false }))
+
+    expect(back).not.toHaveBeenCalled()
+    expect(push).toHaveBeenCalledWith('/')
+  })
+
+  it('prefers return_to over history', async () => {
+    // The submit path already honours return_to; Cancel not consulting it was
+    // the asymmetry at the heart of the bug. An explicit target beats history
+    // even when going back would have worked.
+    routeQuery = { return_to: '/list/open_tickets' }
+    historyState = { back: '/somewhere/else' }
+    await clickCancel(await mountForm())
+
+    expect(push).toHaveBeenCalledWith('/list/open_tickets')
+    expect(back).not.toHaveBeenCalled()
+  })
+
+  it('ignores an unsafe return_to and still stays in the app', async () => {
+    // readReturnTo rejects off-origin values; the fallback must then apply
+    // rather than the form navigating to an attacker-supplied URL.
+    routeQuery = { return_to: 'https://evil.example.com/phish' }
+    await clickCancel(await mountForm())
+
+    expect(push).toHaveBeenCalledWith('/list/all_tickets')
+    expect(push).not.toHaveBeenCalledWith('https://evil.example.com/phish')
+  })
+})

--- a/frontend/src/components/forms/DynamicForm.vue
+++ b/frontend/src/components/forms/DynamicForm.vue
@@ -1062,12 +1062,46 @@ async function handleSubmit() {
   }
 }
 
+/**
+ * Whether this SPA instance has somewhere in-app to go back to.
+ *
+ * `history.state.back` is written by vue-router on a push and is the only
+ * reliable signal here: a full page load (direct URL, bookmark, refresh)
+ * leaves it null no matter how deep the browser's history already is.
+ * `window.history.length` cannot be used for this — it counts entries from
+ * before the app was ever loaded, so it reads >= 2 even on a fresh open
+ * (BUG-ZE4354).
+ */
+function hasAppHistory(): boolean {
+  return (router.options.history.state as { back?: unknown } | null)?.back != null
+}
+
+/**
+ * Cancel/Back must land somewhere inside the app.
+ *
+ * `router.back()` alone is a browser-history operation with no route target,
+ * so on a directly-opened form there is no in-app entry behind it and back
+ * walks out of the SPA entirely — which reads to the user as "the button does
+ * nothing" (BUG-ZE4354). Resolution order mirrors `useBackTarget` and the
+ * submit path, which already honours `returnTo`.
+ */
 function handleCancel() {
   if (props.embedded) {
     emit('inline-cancelled')
     return
   }
-  router.back()
+  if (returnTo.value) {
+    router.push(returnTo.value)
+    return
+  }
+  if (hasAppHistory()) {
+    router.back()
+    return
+  }
+  // Opened cold: fall back to the entity type's list, or the dashboard when
+  // no list is configured for it.
+  const listId = formConfig.value ? schemaStore.findListIdForEntityType(formConfig.value.entity) : undefined
+  router.push(listId ? `/list/${listId}` : '/')
 }
 
 function updateField(property: string, value: unknown) {


### PR DESCRIPTION
Fixes **BUG-ZE4354**.

Tickets-PR: #1325

## The bug

Cancel called `router.back()` unconditionally — a *browser history* operation
with no route target. On a form opened cold (pasted URL, bookmark, new tab)
there is no in-app entry behind it, so back walked out of the application. To
the user that reads as "the button does nothing".

Measured before the fix:

| Case | Before | After Cancel |
| --- | --- | --- |
| Opened directly in a fresh tab | `/form/create_ticket` | `about:blank` |
| Arrived via an in-app link | `/form/create_ticket` | `/list/all_tickets` |

Pre-existing on `develop` — not a TKT-OMUD56 regression; that ticket only added
an `embedded` early-return above the `router.back()` call. Found while manually
testing its demo.

## The fix

Resolution order mirrors `useBackTarget` and the submit path:

1. an explicit validated `return_to`,
2. else `router.back()` **when there is in-app history**,
3. else push the entity type's list — or `/` when the type has no list.

The asymmetry was the heart of it: `returnTo` is already resolved in this
component and already honoured on submit; Cancel just never consulted it.

## The subtle part

`window.history.length` **cannot** answer "is there anywhere in-app to go back
to" — it counts entries from before the app was loaded and reads ≥ 2 even on a
fresh open. `history.state.back` is written by vue-router on a push and stays
null through any full page load, which is exactly the needed distinction.

I verified this in a real browser both ways before relying on it — and the
first probe was misleading (`page.goto` is a full load, not an SPA push), so
this is measured rather than assumed.

## Scope

Page mode only. The embedded inline-create modal still emits
`inline-cancelled` and never reaches this code.

`?from=` is deliberately **not** consulted: no caller threads it to a form
today, so that branch would be dead code. `useBackTarget` keeps it for the
surfaces that do.

## Tests

Five unit arms (back-with-history; cold-open list fallback; dashboard fallback;
`return_to` precedence; unsafe `return_to` rejected — the open-redirect guard)
plus two e2e arms.

The **e2e direct-open** case is load-bearing: the existing suite only ever
reached forms via in-app links, which is exactly why this shipped unnoticed.

All arms **mutation-checked** against the pre-fix code — 4/5 unit and the
direct-open e2e fail when the fix is reverted, while the no-regression arm
keeps passing.

Local: 1610 unit tests pass · 242 e2e pass · eslint 0 errors · e2e lint +
typecheck clean.