### PR TITLE
feat(state): postgres-backed state.KV for cluster-shared cache and settings (TKT-VC27L3)

### DIFF
--- a/.go-arch-lint.yml
+++ b/.go-arch-lint.yml
@@ -9,6 +9,7 @@ exclude:
   - internal/store/storetest
   - internal/entitymanager/entitymanagertest
   - internal/visibility/visibilitytest
+  - internal/state/statetest
   - frontend
   - e2e
   - .claude

--- a/.testcoverage.yml
+++ b/.testcoverage.yml
@@ -74,6 +74,7 @@ exclude:
     - ^internal/testutil       # test helpers
     - ^internal/store/storetest # shared conformance test kit (exercised via backends)
     - ^internal/visibility/visibilitytest # shared conformance test kit (exercised via visibility + future wirings)
+    - ^internal/state/statetest # shared conformance test kit (exercised via FSKV + pgstore's StateKV)
     - ^internal/store/pgstore  # covered by the dedicated postgres CI job (needs a live DB; skipped without RELA_TEST_DATABASE_URL)
     - ^internal/entitymanager/entitymanagertest # shared test doubles (PanicOnUse etc.), exercised via consumers
     - ^internal/store/graphquerynaive # exercised through every backend's graphquery tests; cross-package coverage isn't attributed without -coverpkg, so its own number reads 0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -348,9 +348,23 @@ Rules when touching this:
   between recipes, it belongs in a shared helper. This is what keeps the three
   recipes from drifting (and where future per-backend audit/ACL variation goes).
 - **The metamodel is always read from disk**, even in the postgres build —
-  `schema.yaml`, `templates/`, `.rela/` stay on the filesystem; PostgreSQL
-  backs entities/relations/attachments/search only. A postgres deployment
-  still needs a `--project` dir.
+  `schema.yaml` and `templates/` stay on the filesystem, as does operator-authored
+  config generally; PostgreSQL backs entities/relations/attachments/search. A
+  postgres deployment still needs a `--project` dir.
+
+  The exception is **runtime-written state** (TKT-VC27L3): on the postgres build
+  `state.KV` is database-backed (`pgstore.StateKV`, wired via `stateKVFor`), so
+  the document render cache, user settings, the operator logo/theme and the
+  CalDAV alias table live in the `state_kv` table rather than under `.rela/`.
+  That is deliberate — `docs/postgres-backend.md` documents several rela-server
+  processes against one database, and node-local state means an uploaded logo is
+  served by exactly one of them. Rows sit in the store's schema, so
+  schema-per-tenant scopes this state for free. **Key validation is the `state`
+  package's job** (`state.ValidatedKV` wraps the backend at the wiring site):
+  pgstore must not import `internal/state` (arch-lint forbids a store depending
+  on an application package), so it stores whatever key it is handed and the
+  wrapper enforces the same rules `storage.RootedFS` gives FSKV. Any new backend
+  must pass `internal/state/statetest.RunAll`.
 - **Multi-writer change feed** (TKT-WZYWM9). The postgres watcher delivers
   cross-process writes via PostgreSQL `LISTEN/NOTIFY`: each committed write does
   `pg_notify(rela_changed, '<origin>:<schema>:<kind>:<op>:<id>')` inside its

--- a/cmd/rela-desktop/main.go
+++ b/cmd/rela-desktop/main.go
@@ -172,6 +172,7 @@ func (d *Desktop) LoadProject(dir string) string {
 		svc.EntityManager(), svc.Searcher(), svc.VisibleSearcher(), svc.ACL(),
 		fieldResolver,
 		svc.Audit(),
+		svc.State(),
 	)
 	if err != nil {
 		return d.failLoad(err)

--- a/cmd/rela-server/main.go
+++ b/cmd/rela-server/main.go
@@ -420,6 +420,7 @@ func main() {
 		svc.EntityManager(), svc.Searcher(), svc.VisibleSearcher(), svc.ACL(),
 		fieldResolver,
 		svc.Audit(),
+		svc.State(),
 	)
 	if err != nil {
 		var configErr *dataentry.ConfigValidationError

--- a/docs-project/entities/guides/GUIDE-postgres-backend.md
+++ b/docs-project/entities/guides/GUIDE-postgres-backend.md
@@ -117,6 +117,12 @@ What you need to know to run it:
   not read are discarded on arrival.
 - Live updates cover **entity** create/update/delete. Relation and attachment
   edits are reflected on the next page load rather than pushed live.
+- **Durable UI state is shared too.** The document render cache, user settings,
+  the operator logo/theme and the CalDAV alias table live in the database on
+  this build, not in each node's `.rela/` directory. Upload a logo on one node
+  and every node serves it; a document rendered on one node is not re-rendered
+  on the next. (On the filesystem build this state stays under `.rela/`, which
+  is correct for a single-process deployment.)
 
 ### Write transactions
 

--- a/docs/postgres-backend.md
+++ b/docs/postgres-backend.md
@@ -111,6 +111,12 @@ What you need to know to run it:
   not read are discarded on arrival.
 - Live updates cover **entity** create/update/delete. Relation and attachment
   edits are reflected on the next page load rather than pushed live.
+- **Durable UI state is shared too.** The document render cache, user settings,
+  the operator logo/theme and the CalDAV alias table live in the database on
+  this build, not in each node's `.rela/` directory. Upload a logo on one node
+  and every node serves it; a document rendered on one node is not re-rendered
+  on the next. (On the filesystem build this state stays under `.rela/`, which
+  is correct for a single-process deployment.)
 
 ### Write transactions
 

--- a/internal/appbuild/appbuild.go
+++ b/internal/appbuild/appbuild.go
@@ -913,7 +913,7 @@ func assemble(
 	// here and threaded into the recorders and the Services bundle.
 	versions := versionServiceFor(st)
 
-	stateKV, aliases, err := buildStateAndAliases(cfg.FS, cfg.Paths)
+	stateKV, aliases, err := buildStateAndAliases(cfg.FS, cfg.Paths, stateKVFor(st))
 	if err != nil {
 		return nil, err
 	}
@@ -1079,10 +1079,23 @@ func (s *Services) Close() error {
 // not a store capability. Both are built BEFORE the entitymanager because its
 // rename/delete hooks take the alias service: only the write choke-point knows
 // old->new, so an alias rewrite has to ride along with the write.
-func buildStateAndAliases(fs storage.FS, paths *project.Context) (state.KV, *caldavalias.Service, error) {
-	stateKV, err := buildStateKV(fs, paths)
-	if err != nil {
-		return nil, nil, err
+//
+// backendKV, when non-nil, is a store-backed state store (pgstore's — see
+// stateKVFor) and wins over the filesystem. That is what makes the render
+// cache, user settings, the operator logo and the CalDAV alias table shared by
+// every process serving a schema instead of node-local (TKT-VC27L3). It is nil
+// on the fs/memory builds, where a project IS one directory on one machine and
+// the filesystem is the right home.
+func buildStateAndAliases(
+	fs storage.FS, paths *project.Context, backendKV state.KV,
+) (state.KV, *caldavalias.Service, error) {
+	stateKV := backendKV
+	if stateKV == nil {
+		var err error
+		stateKV, err = buildStateKV(fs, paths)
+		if err != nil {
+			return nil, nil, err
+		}
 	}
 	aliases, err := caldavalias.New(context.Background(), stateKV)
 	if err != nil {
@@ -1100,9 +1113,16 @@ func buildStateAndAliases(fs storage.FS, paths *project.Context) (state.KV, *cal
 		// That check now lives at the serving boundary — registerCalDAVRoutes
 		// refuses to mount without a healthy table — so the failure lands on
 		// the path that can actually cause the damage.
+		// Name the right location: with a database-backed state store the
+		// aliases are a row, not a file, and pointing an operator at a path
+		// that does not exist would send them hunting for the wrong thing.
+		location := filepath.Join(paths.CacheDir, "caldav", "aliases.json")
+		if backendKV != nil {
+			location = "database state store, key caldav/aliases.json"
+		}
 		slog.Warn("caldav alias table unreadable; CalDAV will refuse to serve. "+
-			"Delete the file to start fresh (synced clients will re-create their entries).",
-			"path", filepath.Join(paths.CacheDir, "caldav", "aliases.json"),
+			"Clear it to start fresh (synced clients will re-create their entries).",
+			"location", location,
 			"error", err)
 		return stateKV, nil, nil
 	}

--- a/internal/appbuild/statekv_postgres_test.go
+++ b/internal/appbuild/statekv_postgres_test.go
@@ -1,0 +1,73 @@
+//go:build postgres
+
+package appbuild_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/Sourcehaven-BV/rela/internal/appbuild"
+	"github.com/Sourcehaven-BV/rela/internal/audit"
+	"github.com/Sourcehaven-BV/rela/internal/project"
+	"github.com/Sourcehaven-BV/rela/internal/script"
+	"github.com/Sourcehaven-BV/rela/internal/storage"
+)
+
+// TestPostgresBuild_StateIsDatabaseBacked is the wiring assertion for
+// TKT-VC27L3: on the postgres build, Services.State() must be the database
+// store, NOT an FSKV under the project's .rela/.
+//
+// Asserting on the concrete type would be brittle and would not prove the data
+// actually lands in the database. Instead this writes through the KV and then
+// checks the project directory stayed clean — the observable difference an
+// operator cares about, and the one that breaks when a future refactor
+// accidentally reinstates the filesystem KV.
+func TestPostgresBuild_StateIsDatabaseBacked(t *testing.T) {
+	dsn := os.Getenv("RELA_TEST_DATABASE_URL")
+	if dsn == "" {
+		t.Skip("RELA_TEST_DATABASE_URL not set")
+	}
+
+	root := writeMinimalProject(t)
+	fs := storage.NewSafeFS(storage.NewOsFS())
+	paths, err := project.Discover(root, fs)
+	if err != nil {
+		t.Fatalf("Discover: %v", err)
+	}
+
+	svc, err := appbuild.New(appbuild.Config{
+		FS:           fs,
+		Paths:        paths,
+		ScriptEngine: script.NewEngine(),
+		Audit:        audit.Nop{},
+		DatabaseURL:  dsn,
+	})
+	if err != nil {
+		t.Fatalf("appbuild.New: %v", err)
+	}
+	t.Cleanup(func() { _ = svc.Close() })
+
+	ctx := context.Background()
+	const key = "documents/DOC-1-abc.html"
+	if err = svc.State().Put(ctx, key, []byte("<html>rendered</html>")); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+
+	got, err := svc.State().Get(ctx, key)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if string(got) != "<html>rendered</html>" {
+		t.Fatalf("Get = %q", got)
+	}
+
+	// The write must not have landed on disk: an FSKV would have created
+	// .rela/documents/DOC-1-abc.html.
+	onDisk := filepath.Join(paths.CacheDir, "documents", "DOC-1-abc.html")
+	if _, statErr := os.Stat(onDisk); statErr == nil {
+		t.Fatalf("state was written to %s — the postgres build must keep state in "+
+			"the database, or it stays node-local across a load-balanced fleet", onDisk)
+	}
+}

--- a/internal/appbuild/versionsweep_nosweep.go
+++ b/internal/appbuild/versionsweep_nosweep.go
@@ -4,6 +4,7 @@ package appbuild
 
 import (
 	"github.com/Sourcehaven-BV/rela/internal/metamodel"
+	"github.com/Sourcehaven-BV/rela/internal/state"
 	"github.com/Sourcehaven-BV/rela/internal/store"
 )
 
@@ -17,3 +18,9 @@ func startVersionSweepIfSupported(_ store.Store, _ *metamodel.Metamodel) {}
 // (not a typed nil) is load-bearing: the entitymanager recorder factories and the
 // service bundles nil-check this, and a typed-nil would defeat that check.
 func versionServiceFor(_ store.Store) store.VersionService { return nil }
+
+// stateKVFor returns nil in non-postgres builds: fsstore and memstore have no
+// database to keep shared state in, so the caller falls back to the filesystem
+// KV rooted at the project's .rela/ — which is correct for a single-process
+// deployment. Genuinely nil (not a typed nil) so that nil-check works.
+func stateKVFor(_ store.Store) state.KV { return nil }

--- a/internal/appbuild/versionsweep_postgres.go
+++ b/internal/appbuild/versionsweep_postgres.go
@@ -98,16 +98,16 @@ func versionServiceFor(st store.Store) store.VersionService {
 // Returns a genuinely nil interface for a non-pgstore store so the caller's
 // nil-check falls back to the filesystem KV.
 func stateKVFor(st store.Store) state.KV {
-	s, ok := st.(*pgstore.Store)
-	if !ok {
+	raw := pgstore.StateStoreFor(st)
+	if raw == nil {
 		return nil
 	}
 	// pgstore stores whatever key it is handed; ValidatedKV applies the key
 	// rules FSKV gets from RootedFS, so both backends accept exactly the same
 	// keys. See state.ValidatedKV.
-	kv, err := state.NewValidatedKV(s.StateStore())
+	kv, err := state.NewValidatedKV(raw)
 	if err != nil {
-		// Unreachable: StateStore never returns nil. Fall back rather than fail
+		// Unreachable: raw is non-nil here. Fall back rather than fail
 		// startup over an impossible case.
 		slog.Warn("appbuild: could not wrap database state store; falling back "+
 			"to the filesystem (state will be node-local)", "error", err)

--- a/internal/appbuild/versionsweep_postgres.go
+++ b/internal/appbuild/versionsweep_postgres.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/Sourcehaven-BV/rela/internal/metamodel"
+	"github.com/Sourcehaven-BV/rela/internal/state"
 	"github.com/Sourcehaven-BV/rela/internal/store"
 	"github.com/Sourcehaven-BV/rela/internal/store/pgstore"
 )
@@ -81,4 +82,36 @@ func versionServiceFor(st store.Store) store.VersionService {
 		return s.VersionStore()
 	}
 	return nil
+}
+
+// stateKVFor returns a database-backed [state.KV] sharing the store's pool, so
+// the document render cache, user settings, the operator logo and scheduler
+// bookkeeping are shared by every process serving this schema instead of living
+// in each node's own .rela/ directory (TKT-VC27L3).
+//
+// That matters for the multi-process deployment docs/postgres-backend.md already
+// documents: with an FSKV, an operator's logo upload lands on whichever node
+// served the POST and every other node keeps serving the old one, with no error
+// anywhere. It also means a schema-per-tenant deployment gets per-tenant state
+// for free — the search_path that scopes entities scopes this table.
+//
+// Returns a genuinely nil interface for a non-pgstore store so the caller's
+// nil-check falls back to the filesystem KV.
+func stateKVFor(st store.Store) state.KV {
+	s, ok := st.(*pgstore.Store)
+	if !ok {
+		return nil
+	}
+	// pgstore stores whatever key it is handed; ValidatedKV applies the key
+	// rules FSKV gets from RootedFS, so both backends accept exactly the same
+	// keys. See state.ValidatedKV.
+	kv, err := state.NewValidatedKV(s.StateStore())
+	if err != nil {
+		// Unreachable: StateStore never returns nil. Fall back rather than fail
+		// startup over an impossible case.
+		slog.Warn("appbuild: could not wrap database state store; falling back "+
+			"to the filesystem (state will be node-local)", "error", err)
+		return nil
+	}
+	return kv
 }

--- a/internal/dataentry/app.go
+++ b/internal/dataentry/app.go
@@ -591,6 +591,7 @@ func NewApp(
 	aclImpl acl.ACL,
 	fieldResolver FieldVerdictResolver,
 	auditSink audit.Audit,
+	stateKV state.KV,
 ) (*App, error) {
 	// Reject nil required collaborators up front rather than letting a
 	// downstream handler panic on the first request that exercises them.
@@ -621,13 +622,18 @@ func NewApp(
 	if auditSink == nil {
 		return nil, errors.New("dataentry.NewApp: auditSink is required (pass audit.Nop{} to opt out)")
 	}
+	if stateKV == nil {
+		return nil, errors.New("dataentry.NewApp: stateKV is required (wire appbuild's Services.State())")
+	}
 	// Construct reconstructible services from the primitives.
 	cfgLoader := config.NewFSLoader(fs, paths.Root)
-	kvRoot, err := storage.NewRootedFS(fs, paths.CacheDir)
-	if err != nil {
-		return nil, fmt.Errorf("dataentry: rooted fs for state kv: %w", err)
-	}
-	kv := state.NewFSKV(kvRoot)
+	// The state store comes from the caller (appbuild's Services.State()) rather
+	// than being rebuilt here: on the postgres build it is database-backed, so
+	// the render cache, user settings and the operator logo are shared by every
+	// process serving the schema. Rebuilding an FSKV here would silently pin
+	// those back to this node's .rela/ — the bug where an uploaded logo is
+	// visible only on whichever node served the POST (TKT-VC27L3).
+	kv := stateKV
 	trc := tracer.New(st)
 	templater := templating.NewFSTemplater(fs, paths)
 	// The validator (val) is built AFTER app.affordances below — its reader is

--- a/internal/docscapture/server.go
+++ b/internal/docscapture/server.go
@@ -99,6 +99,7 @@ func standUp(ctx context.Context, projectDir string, seed []docs.SeedOp) (*proje
 		svc.EntityManager(), svc.Searcher(), svc.VisibleSearcher(), svc.ACL(),
 		dataentry.NopFieldVerdictResolver{},
 		svc.Audit(),
+		svc.State(),
 	)
 	if err != nil {
 		svc.Close()

--- a/internal/state/fskv_conformance_test.go
+++ b/internal/state/fskv_conformance_test.go
@@ -1,0 +1,24 @@
+package state_test
+
+import (
+	"testing"
+
+	"github.com/Sourcehaven-BV/rela/internal/state"
+	"github.com/Sourcehaven-BV/rela/internal/state/statetest"
+	"github.com/Sourcehaven-BV/rela/internal/storage"
+)
+
+func TestFSKV_Conformance(t *testing.T) {
+	statetest.RunAll(t, func(tb testing.TB) state.KV {
+		tb.Helper()
+		mem := storage.NewMemFS()
+		if err := mem.MkdirAll("/root", 0o755); err != nil {
+			tb.Fatalf("mkdir root: %v", err)
+		}
+		rfs, err := storage.NewRootedFS(mem, "/root")
+		if err != nil {
+			tb.Fatalf("NewRootedFS: %v", err)
+		}
+		return state.NewFSKV(rfs)
+	})
+}

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -9,8 +9,10 @@ package state
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io/fs"
 	"os"
+	"strings"
 
 	"github.com/Sourcehaven-BV/rela/internal/storage"
 )
@@ -31,6 +33,112 @@ type KV interface {
 	// error — callers using Delete to clear optional state shouldn't have
 	// to special-case "already gone."
 	Delete(ctx context.Context, key string) error
+}
+
+// ValidateKey reports whether key is acceptable to every [KV] backend.
+//
+// FSKV resolves keys to filesystem paths, so [storage.RootedFS] already rejects
+// traversal, absolute paths, backslashes, colons and Windows reserved names. A
+// database backend has no such constraint and would happily store `../../etc`
+// — which would mean a key that works on PostgreSQL fails after a migration to
+// the filesystem backend. Non-filesystem backends call this so the contract is
+// the same everywhere; FSKV keeps relying on RootedFS, which is the stricter
+// (and authoritative) barrier.
+//
+// The rules mirror RootedFS.resolve deliberately. If that ever gains a rule,
+// this must gain it too — the shared conformance suite in state/statetest
+// exercises both backends against one key table, so a divergence fails there.
+func ValidateKey(key string) error {
+	if key == "" {
+		return errors.New("state: key must not be empty")
+	}
+	for _, c := range key {
+		if c < 0x20 || c == 0x7f {
+			return errors.New("state: control character (including NUL) not allowed in key")
+		}
+	}
+	if strings.ContainsRune(key, '\\') {
+		return errors.New("state: backslash not allowed in key (use forward slash)")
+	}
+	if strings.ContainsRune(key, ':') {
+		return errors.New("state: colon not allowed in key")
+	}
+	if strings.HasPrefix(key, "/") {
+		return errors.New("state: key must be relative")
+	}
+	for seg := range strings.SplitSeq(key, "/") {
+		if seg == "" || seg == "." || seg == ".." {
+			return errors.New("state: traversal or empty segment not allowed in key")
+		}
+		stem := strings.ToLower(seg)
+		if i := strings.Index(stem, "."); i >= 0 {
+			stem = stem[:i]
+		}
+		if windowsReservedKeySegment[stem] {
+			return fmt.Errorf("state: Windows reserved name %q not allowed in key", seg)
+		}
+	}
+	return nil
+}
+
+// windowsReservedKeySegment mirrors storage's list so a key valid on a database
+// backend stays valid if the project is later served from the filesystem.
+var windowsReservedKeySegment = map[string]bool{
+	"con": true, "prn": true, "aux": true, "nul": true,
+	"com1": true, "com2": true, "com3": true, "com4": true,
+	"com5": true, "com6": true, "com7": true, "com8": true, "com9": true,
+	"lpt1": true, "lpt2": true, "lpt3": true, "lpt4": true,
+	"lpt5": true, "lpt6": true, "lpt7": true, "lpt8": true, "lpt9": true,
+}
+
+// ValidatedKV wraps a KV that does not validate keys itself, applying
+// [ValidateKey] before every operation.
+//
+// It exists so key policy has exactly one implementation. FSKV gets validation
+// for free from [storage.RootedFS], which must reject traversal and
+// Windows-hostile names because it resolves keys to real paths. A database
+// backend has no such constraint and would happily store `../../etc` — so
+// without this a key accepted on PostgreSQL would be refused after a migration
+// to the filesystem backend, and the two backends would not be interchangeable.
+//
+// Architecture note: the database backend lives in a store package, which may
+// not import this one (see .go-arch-lint.yml). Wrapping at the wiring site
+// keeps the rules here, next to the contract they belong to, instead of copied
+// into a backend where they could silently drift.
+type ValidatedKV struct {
+	inner KV
+}
+
+var _ KV = (*ValidatedKV)(nil)
+
+// NewValidatedKV wraps inner with key validation. Returns an error if inner is
+// nil — a KV that silently accepts nothing is worse than a boot failure.
+func NewValidatedKV(inner KV) (*ValidatedKV, error) {
+	if inner == nil {
+		return nil, errors.New("state: NewValidatedKV requires an inner KV")
+	}
+	return &ValidatedKV{inner: inner}, nil
+}
+
+func (v *ValidatedKV) Get(ctx context.Context, key string) ([]byte, error) {
+	if err := ValidateKey(key); err != nil {
+		return nil, err
+	}
+	return v.inner.Get(ctx, key)
+}
+
+func (v *ValidatedKV) Put(ctx context.Context, key string, data []byte) error {
+	if err := ValidateKey(key); err != nil {
+		return err
+	}
+	return v.inner.Put(ctx, key, data)
+}
+
+func (v *ValidatedKV) Delete(ctx context.Context, key string) error {
+	if err := ValidateKey(key); err != nil {
+		return err
+	}
+	return v.inner.Delete(ctx, key)
 }
 
 // FSKV stores state under a root directory on a filesystem. Key

--- a/internal/state/statetest/statetest.go
+++ b/internal/state/statetest/statetest.go
@@ -1,0 +1,282 @@
+// Package statetest is the conformance harness for [state.KV]
+// implementations. Any new backend must pass [RunAll].
+//
+// It exists because the KV contract is carried almost entirely in prose on the
+// interface, and two of its clauses are load-bearing in ways a backend author
+// would not guess:
+//
+//   - A missing key must fail with an error satisfying [os.IsNotExist].
+//     internal/dataentry's document cache distinguishes "no cached render" from
+//     "the cache is broken" by exactly this; a backend returning a bare
+//     "not found" error would turn every cache miss into a hard failure.
+//   - Deleting a missing key must SUCCEED. logoStore.Delete documents itself as
+//     idempotent and calls Delete unconditionally to clear optional state.
+//
+// The key-validation clause matters for a different reason: FSKV resolves keys
+// to filesystem paths, so it must reject traversal and Windows-hostile names. A
+// database backend has no such constraint and would happily store `../../etc`,
+// silently accepting keys the filesystem backend rejects. Divergence there means
+// a project that works on one backend breaks when migrated to the other, so the
+// suite holds both to the stricter contract.
+package statetest
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"os"
+	"testing"
+
+	"github.com/Sourcehaven-BV/rela/internal/state"
+)
+
+// Factory returns a fresh, empty KV for one subtest. Implementations that need
+// cleanup should register it on tb.
+type Factory func(tb testing.TB) state.KV
+
+// RunAll runs every conformance test against the KV produced by newKV.
+func RunAll(t *testing.T, newKV Factory) {
+	t.Helper()
+	for name, fn := range map[string]func(*testing.T, Factory){
+		"RoundTrip":               testRoundTrip,
+		"Overwrite":               testOverwrite,
+		"HierarchicalKeys":        testHierarchicalKeys,
+		"EmptyValue":              testEmptyValue,
+		"BinaryValue":             testBinaryValue,
+		"GetMissingIsNotExist":    testGetMissingIsNotExist,
+		"DeleteRemoves":           testDeleteRemoves,
+		"DeleteMissingIsNotError": testDeleteMissingIsNotError,
+		"DeleteIsIdempotent":      testDeleteIsIdempotent,
+		"RejectsInvalidKeys":      testRejectsInvalidKeys,
+		"KeysAreDistinct":         testKeysAreDistinct,
+		"ValueIsNotAliased":       testValueIsNotAliased,
+	} {
+		t.Run(name, func(t *testing.T) { fn(t, newKV) })
+	}
+}
+
+func testRoundTrip(t *testing.T, newKV Factory) {
+	t.Helper()
+	kv := newKV(t)
+	ctx := context.Background()
+	want := []byte(`{"a":1}`)
+	if err := kv.Put(ctx, "cache.json", want); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+	got, err := kv.Get(ctx, "cache.json")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if !bytes.Equal(got, want) {
+		t.Fatalf("Get = %q, want %q", got, want)
+	}
+}
+
+func testOverwrite(t *testing.T, newKV Factory) {
+	t.Helper()
+	kv := newKV(t)
+	ctx := context.Background()
+	if err := kv.Put(ctx, "k", []byte("first")); err != nil {
+		t.Fatalf("Put first: %v", err)
+	}
+	if err := kv.Put(ctx, "k", []byte("second")); err != nil {
+		t.Fatalf("Put second: %v", err)
+	}
+	got, err := kv.Get(ctx, "k")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if string(got) != "second" {
+		t.Fatalf("Get = %q, want %q — Put must replace, not append", got, "second")
+	}
+}
+
+// testHierarchicalKeys pins the documented key shape: callers group state under
+// a common prefix (the document cache uses "documents/<id>-<hash>.html"), so a
+// backend must accept a `/`-separated key and create whatever intermediate
+// structure it needs.
+func testHierarchicalKeys(t *testing.T, newKV Factory) {
+	t.Helper()
+	kv := newKV(t)
+	ctx := context.Background()
+	const key = "documents/DOC-1-deadbeef.html"
+	if err := kv.Put(ctx, key, []byte("<html>")); err != nil {
+		t.Fatalf("Put nested: %v", err)
+	}
+	got, err := kv.Get(ctx, key)
+	if err != nil {
+		t.Fatalf("Get nested: %v", err)
+	}
+	if string(got) != "<html>" {
+		t.Fatalf("Get = %q, want %q", got, "<html>")
+	}
+}
+
+// testEmptyValue guards a real ambiguity: a backend that treats a zero-length
+// value as absent would make a legitimately-empty cached render look like a
+// miss, re-rendering forever.
+func testEmptyValue(t *testing.T, newKV Factory) {
+	t.Helper()
+	kv := newKV(t)
+	ctx := context.Background()
+	if err := kv.Put(ctx, "empty", []byte{}); err != nil {
+		t.Fatalf("Put empty: %v", err)
+	}
+	got, err := kv.Get(ctx, "empty")
+	if err != nil {
+		t.Fatalf("Get empty: %v (an empty value must be present, not missing)", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("Get = %q, want empty", got)
+	}
+}
+
+// testBinaryValue matters because the logo store round-trips arbitrary uploaded
+// bytes; a backend that assumes UTF-8 text would corrupt them.
+func testBinaryValue(t *testing.T, newKV Factory) {
+	t.Helper()
+	kv := newKV(t)
+	ctx := context.Background()
+	want := []byte{0x00, 0xff, 0xfe, 0x01, 0x80, '\n', 0x7f}
+	if err := kv.Put(ctx, "logo.png", want); err != nil {
+		t.Fatalf("Put binary: %v", err)
+	}
+	got, err := kv.Get(ctx, "logo.png")
+	if err != nil {
+		t.Fatalf("Get binary: %v", err)
+	}
+	if !bytes.Equal(got, want) {
+		t.Fatalf("Get = %v, want %v", got, want)
+	}
+}
+
+func testGetMissingIsNotExist(t *testing.T, newKV Factory) {
+	t.Helper()
+	kv := newKV(t)
+	_, err := kv.Get(context.Background(), "never-written.json")
+	if err == nil {
+		t.Fatal("Get of a missing key must return an error")
+	}
+	if !errors.Is(err, os.ErrNotExist) && !os.IsNotExist(err) {
+		t.Fatalf("Get of a missing key = %v; must satisfy os.IsNotExist so callers "+
+			"can tell a cache miss from a broken backend", err)
+	}
+}
+
+func testDeleteRemoves(t *testing.T, newKV Factory) {
+	t.Helper()
+	kv := newKV(t)
+	ctx := context.Background()
+	if err := kv.Put(ctx, "k", []byte("v")); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+	if err := kv.Delete(ctx, "k"); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	if _, err := kv.Get(ctx, "k"); !errors.Is(err, os.ErrNotExist) && !os.IsNotExist(err) {
+		t.Fatalf("Get after Delete = %v, want a not-exist error", err)
+	}
+}
+
+func testDeleteMissingIsNotError(t *testing.T, newKV Factory) {
+	t.Helper()
+	kv := newKV(t)
+	if err := kv.Delete(context.Background(), "never-existed.json"); err != nil {
+		t.Fatalf("Delete of a missing key must succeed (callers clear optional "+
+			"state unconditionally), got %v", err)
+	}
+}
+
+func testDeleteIsIdempotent(t *testing.T, newKV Factory) {
+	t.Helper()
+	kv := newKV(t)
+	ctx := context.Background()
+	if err := kv.Put(ctx, "k", []byte("v")); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+	if err := kv.Delete(ctx, "k"); err != nil {
+		t.Fatalf("Delete #1: %v", err)
+	}
+	if err := kv.Delete(ctx, "k"); err != nil {
+		t.Fatalf("Delete #2 must be a no-op, got %v", err)
+	}
+}
+
+// testRejectsInvalidKeys holds every backend to FSKV's stricter key rules, so a
+// key that works on one backend cannot fail on another. See the package doc.
+func testRejectsInvalidKeys(t *testing.T, newKV Factory) {
+	t.Helper()
+	ctx := context.Background()
+	for _, key := range []string{
+		"",            // empty
+		"..",          // traversal
+		"sub/../esc",  // traversal mid-key
+		"/abs",        // absolute
+		"with\\bs",    // backslash
+		"with:colon",  // Windows drive letter / ADS
+		"a//b",        // empty segment
+		"./rel",       // dot segment
+		"nul\x00byte", // control character
+	} {
+		t.Run(key, func(t *testing.T) {
+			kv := newKV(t)
+			if err := kv.Put(ctx, key, []byte("x")); err == nil {
+				t.Errorf("Put(%q) must be rejected", key)
+			}
+			if _, err := kv.Get(ctx, key); err == nil {
+				t.Errorf("Get(%q) must be rejected", key)
+			}
+			if err := kv.Delete(ctx, key); err == nil {
+				t.Errorf("Delete(%q) must be rejected", key)
+			}
+		})
+	}
+}
+
+// testKeysAreDistinct catches a backend that normalizes or collapses keys —
+// e.g. treating "a/b" and "a-b" alike, or lowercasing.
+func testKeysAreDistinct(t *testing.T, newKV Factory) {
+	t.Helper()
+	kv := newKV(t)
+	ctx := context.Background()
+	keys := []string{"a/b", "a-b", "A/b", "a/b.json"}
+	for i, k := range keys {
+		if err := kv.Put(ctx, k, []byte{byte('0' + i)}); err != nil {
+			t.Fatalf("Put(%q): %v", k, err)
+		}
+	}
+	for i, k := range keys {
+		got, err := kv.Get(ctx, k)
+		if err != nil {
+			t.Fatalf("Get(%q): %v", k, err)
+		}
+		if len(got) != 1 || got[0] != byte('0'+i) {
+			t.Errorf("Get(%q) = %q, want %q — keys must not collide", k, got, []byte{byte('0' + i)})
+		}
+	}
+}
+
+// testValueIsNotAliased ensures a backend does not hand back a slice the caller
+// can mutate into the store (a live risk for an in-memory implementation).
+func testValueIsNotAliased(t *testing.T, newKV Factory) {
+	t.Helper()
+	kv := newKV(t)
+	ctx := context.Background()
+	if err := kv.Put(ctx, "k", []byte("original")); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+	got, err := kv.Get(ctx, "k")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	for i := range got {
+		got[i] = 'X'
+	}
+	again, err := kv.Get(ctx, "k")
+	if err != nil {
+		t.Fatalf("Get again: %v", err)
+	}
+	if string(again) != "original" {
+		t.Fatalf("mutating a returned value changed the store: %q", again)
+	}
+}

--- a/internal/state/validate_test.go
+++ b/internal/state/validate_test.go
@@ -1,0 +1,159 @@
+package state_test
+
+import (
+	"context"
+	"errors"
+	"os"
+	"testing"
+
+	"github.com/Sourcehaven-BV/rela/internal/state"
+	"github.com/Sourcehaven-BV/rela/internal/state/statetest"
+)
+
+// TestValidateKey pins the key rules directly. They mirror
+// storage.RootedFS.resolve deliberately: a key accepted by a database backend
+// must still be accepted after a migration to the filesystem backend, so the
+// two must agree. The conformance suite exercises the same rules through both
+// backends; this table documents them in one readable place.
+func TestValidateKey(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		key  string
+		ok   bool
+	}{
+		{"simple", "cache.json", true},
+		{"nested", "documents/DOC-1-abc.html", true},
+		{"deeply nested", "a/b/c/d.txt", true},
+		{"dots in filename", "aliases.v2.json", true},
+		{"leading dot file", ".hidden", true},
+
+		{"empty", "", false},
+		{"traversal", "..", false},
+		{"traversal mid-key", "sub/../esc", false},
+		{"leading traversal", "../etc/passwd", false},
+		{"absolute", "/abs", false},
+		{"backslash", "with\\bs", false},
+		{"colon", "c:drive", false},
+		{"empty segment", "a//b", false},
+		{"dot segment", "./rel", false},
+		{"trailing slash", "dir/", false},
+		{"NUL", "nul\x00byte", false},
+		{"control char", "bell\x07", false},
+		{"DEL", "del\x7f", false},
+		{"windows reserved", "con", false},
+		{"windows reserved with ext", "PRN.txt", false},
+		{"windows reserved in segment", "sub/aux/file", false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			err := state.ValidateKey(tc.key)
+			if tc.ok && err != nil {
+				t.Fatalf("ValidateKey(%q) = %v, want nil", tc.key, err)
+			}
+			if !tc.ok && err == nil {
+				t.Fatalf("ValidateKey(%q) = nil, want an error", tc.key)
+			}
+		})
+	}
+}
+
+// permissiveKV is a KV with no key policy at all — the shape of a database
+// backend, which stores whatever string it is handed.
+type permissiveKV struct {
+	data map[string][]byte
+}
+
+func newPermissiveKV() *permissiveKV { return &permissiveKV{data: map[string][]byte{}} }
+
+func (p *permissiveKV) Get(_ context.Context, key string) ([]byte, error) {
+	v, ok := p.data[key]
+	if !ok {
+		return nil, &os.PathError{Op: "get", Path: key, Err: os.ErrNotExist}
+	}
+	return append([]byte(nil), v...), nil
+}
+
+func (p *permissiveKV) Put(_ context.Context, key string, data []byte) error {
+	p.data[key] = append([]byte(nil), data...)
+	return nil
+}
+
+func (p *permissiveKV) Delete(_ context.Context, key string) error {
+	delete(p.data, key)
+	return nil
+}
+
+// TestValidatedKV_RejectsBeforeDelegating is the point of the wrapper: an
+// invalid key must never reach the inner store. Asserting the inner store stays
+// empty (rather than just that an error came back) is what proves rejection
+// happened first — a wrapper that delegated and then errored would leave the
+// row behind.
+func TestValidatedKV_RejectsBeforeDelegating(t *testing.T) {
+	inner := newPermissiveKV()
+	kv, err := state.NewValidatedKV(inner)
+	if err != nil {
+		t.Fatalf("NewValidatedKV: %v", err)
+	}
+	ctx := context.Background()
+
+	if err := kv.Put(ctx, "../escape", []byte("x")); err == nil {
+		t.Fatal("Put with a traversal key must be rejected")
+	}
+	if len(inner.data) != 0 {
+		t.Fatalf("invalid key reached the inner store: %v", inner.data)
+	}
+	if _, err := kv.Get(ctx, "../escape"); err == nil {
+		t.Fatal("Get with a traversal key must be rejected")
+	}
+	if err := kv.Delete(ctx, "../escape"); err == nil {
+		t.Fatal("Delete with a traversal key must be rejected")
+	}
+}
+
+// TestValidatedKV_PassesValidKeysThrough ensures the wrapper is transparent for
+// keys that are fine — it must not become a second, stricter policy.
+func TestValidatedKV_PassesValidKeysThrough(t *testing.T) {
+	inner := newPermissiveKV()
+	kv, err := state.NewValidatedKV(inner)
+	if err != nil {
+		t.Fatalf("NewValidatedKV: %v", err)
+	}
+	ctx := context.Background()
+	const key = "documents/DOC-1-abc.html"
+
+	if err = kv.Put(ctx, key, []byte("<html>")); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+	got, err := kv.Get(ctx, key)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if string(got) != "<html>" {
+		t.Fatalf("Get = %q", got)
+	}
+	if err = kv.Delete(ctx, key); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	if _, err = kv.Get(ctx, key); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("Get after Delete = %v, want not-exist", err)
+	}
+}
+
+func TestNewValidatedKV_RejectsNilInner(t *testing.T) {
+	if _, err := state.NewValidatedKV(nil); err == nil {
+		t.Fatal("a nil inner KV must fail at construction, not at first use")
+	}
+}
+
+// TestValidatedKV_Conformance runs the full shared contract through the wrapper
+// over a permissive backend — the same composition production uses over
+// pgstore, so the wrapper is proven not to break any clause of the contract.
+func TestValidatedKV_Conformance(t *testing.T) {
+	statetest.RunAll(t, func(tb testing.TB) state.KV {
+		tb.Helper()
+		kv, err := state.NewValidatedKV(newPermissiveKV())
+		if err != nil {
+			tb.Fatalf("NewValidatedKV: %v", err)
+		}
+		return kv
+	})
+}

--- a/internal/store/pgstore/export_test.go
+++ b/internal/store/pgstore/export_test.go
@@ -67,6 +67,10 @@ func NotificationEmitsForTest(t *testing.T, selfOrigin, selfSchema, payload stri
 // key so the stress tests can assert it never leaks in pg_locks. Test-only.
 const WriteAdvisoryLockKeyForTest = writeAdvisoryLockKey
 
+// MaxStateValueBytesForTest exposes the state-value ceiling so a test can build
+// an over-limit payload without restating the constant. Test-only.
+const MaxStateValueBytesForTest = maxStateValueBytes
+
 // FeedChannelForTest exposes the shared NOTIFY channel so a test can emit a
 // raw notification onto the same channel the listener LISTENs on. Referencing
 // the constant (rather than rebuilding the name) means a rename cannot leave a

--- a/internal/store/pgstore/migrations/0008_state_kv.sql
+++ b/internal/store/pgstore/migrations/0008_state_kv.sql
@@ -1,0 +1,31 @@
+-- Durable key/value state for the postgres build (TKT-VC27L3).
+--
+-- Backs internal/state.KV: the document render cache, user settings, the
+-- operator logo/theme, and scheduler bookkeeping. On the filesystem build this
+-- lives under the project's .rela/ directory, which is node-local — wrong for
+-- the load-balanced multi-process deployment documented in
+-- docs/postgres-backend.md, where an operator uploading a logo lands it on
+-- whichever node served the POST while every other node keeps serving the old
+-- one.
+--
+-- The key is the same `/`-separated hierarchical string the FS backend uses
+-- (e.g. "documents/DOC-1-<hash>.html"), stored verbatim: no normalization, so
+-- two keys differing only in case or separator stay distinct exactly as they do
+-- on disk. COLLATE "C" makes comparison byte-exact for the same reason
+-- entities.id uses it — a locale-sensitive collation could equate keys the
+-- filesystem treats as different.
+--
+-- Values are BYTEA and read/written whole, matching `attachments`: the logo is
+-- arbitrary uploaded bytes and a cached render is HTML, so neither is text and
+-- neither streams. `state.KV` has no streaming API on any backend.
+--
+-- Deliberately NOT given a `seq` column: rela_seq feeds the change-feed
+-- watermark (primeWatermark/catchUp scan entities/relations/deletions), and
+-- burning sequence values on cache writes would erode the overlap budget and
+-- drop real events. State is not part of the entity change feed.
+CREATE TABLE state_kv (
+    key        TEXT        COLLATE "C" PRIMARY KEY,
+    value      BYTEA       NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);

--- a/internal/store/pgstore/statekv.go
+++ b/internal/store/pgstore/statekv.go
@@ -1,0 +1,118 @@
+package pgstore
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/jackc/pgx/v5"
+)
+
+// maxStateValueBytes caps a single state value. The two large writers are the
+// operator logo (an uploaded image) and a cached document render (HTML), so the
+// ceiling is generous — but unbounded is wrong for a table every node reads:
+// one pathological render would be fetched whole by every process on every
+// cache hit. A value over the cap is refused at Put rather than truncated,
+// since a silently truncated cached render would be served as if valid.
+const maxStateValueBytes = 32 << 20 // 32 MiB
+
+// StateKV is the PostgreSQL-backed durable key/value store. It structurally
+// satisfies internal/state.KV; the interface is deliberately NOT named here,
+// because a store backend may not depend on an application-level package (see
+// .go-arch-lint.yml — pgstore's allowed deps are store-layer only). The wiring
+// site binds the two.
+//
+// It exists because the filesystem backend is node-local. docs/postgres-backend.md
+// documents running several rela-server processes against one database; under
+// that topology an FSKV render cache is per-node (N nodes, up to N renders of
+// the same document) and, worse, an operator's uploaded logo lands on whichever
+// node served the POST while the others keep serving the old one — a visible
+// bug with no error message. Putting this state in the database that is already
+// the source of truth for entities and attachments fixes both.
+//
+// Rows live in the store's schema, so a schema-per-tenant deployment gets
+// per-tenant state for free: the same search_path that scopes entities scopes
+// this table.
+//
+// # Key policy lives with the caller
+//
+// This type stores whatever key it is given. Key VALIDATION (rejecting
+// traversal, absolute paths, Windows-hostile names) is the state package's
+// contract, enforced by state.ValidatedKV wrapping this — one implementation of
+// those rules rather than a copy here that could drift from the filesystem
+// backend's.
+type StateKV struct {
+	db DBTX
+}
+
+// NewStateKV constructs a StateKV over the given handle. db is typically the
+// pool; state writes deliberately do NOT participate in a store.Tx (a document
+// render is slow, and CLAUDE.md forbids slow I/O inside a Tx callback).
+func NewStateKV(db DBTX) (*StateKV, error) {
+	if db == nil {
+		return nil, errors.New("pgstore: NewStateKV requires a database handle")
+	}
+	return &StateKV{db: db}, nil
+}
+
+// StateStore returns a state store sharing this store's pool, mirroring
+// [Store.VersionStore]: an optional service derived from the store rather than
+// part of the store.Store interface, so the pool stays unexported.
+func (s *Store) StateStore() *StateKV {
+	return &StateKV{db: s.db}
+}
+
+// Get returns the value at key, or an error satisfying os.IsNotExist when the
+// key is absent. That specific error shape is load-bearing: the document cache
+// tells "no cached render" from "the backend is broken" by testing it, so a
+// bare not-found error would turn every cache miss into a hard failure.
+func (s *StateKV) Get(ctx context.Context, key string) ([]byte, error) {
+	var value []byte
+	err := s.db.QueryRow(ctx, `SELECT value FROM state_kv WHERE key = $1`, key).Scan(&value)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, &os.PathError{Op: "get", Path: key, Err: os.ErrNotExist}
+	}
+	if err != nil {
+		return nil, fmt.Errorf("pgstore: read state %q: %w", key, err)
+	}
+	// A NULL-free BYTEA scan can still yield nil for a zero-length value; the
+	// contract distinguishes "empty" from "missing", so normalize to non-nil.
+	if value == nil {
+		value = []byte{}
+	}
+	return value, nil
+}
+
+// Put writes data at key, replacing any existing value.
+func (s *StateKV) Put(ctx context.Context, key string, data []byte) error {
+	if len(data) > maxStateValueBytes {
+		return fmt.Errorf("pgstore: state value for %q is %d bytes, over the %d-byte limit",
+			key, len(data), maxStateValueBytes)
+	}
+	// Copy defensively: pgx retains the slice for the duration of the call, and
+	// a caller reusing its buffer must not be able to change what was stored.
+	stored := bytes.Clone(data)
+	if stored == nil {
+		stored = []byte{}
+	}
+	_, err := s.db.Exec(ctx, `
+		INSERT INTO state_kv (key, value) VALUES ($1, $2)
+		ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value, updated_at = now()`,
+		key, stored)
+	if err != nil {
+		return fmt.Errorf("pgstore: write state %q: %w", key, err)
+	}
+	return nil
+}
+
+// Delete removes the value at key. Deleting a missing key is NOT an error —
+// callers (logoStore.Delete) clear optional state unconditionally and document
+// themselves as idempotent.
+func (s *StateKV) Delete(ctx context.Context, key string) error {
+	if _, err := s.db.Exec(ctx, `DELETE FROM state_kv WHERE key = $1`, key); err != nil {
+		return fmt.Errorf("pgstore: delete state %q: %w", key, err)
+	}
+	return nil
+}

--- a/internal/store/pgstore/statekv.go
+++ b/internal/store/pgstore/statekv.go
@@ -8,6 +8,8 @@ import (
 	"os"
 
 	"github.com/jackc/pgx/v5"
+
+	"github.com/Sourcehaven-BV/rela/internal/store"
 )
 
 // maxStateValueBytes caps a single state value. The two large writers are the
@@ -57,10 +59,21 @@ func NewStateKV(db DBTX) (*StateKV, error) {
 	return &StateKV{db: db}, nil
 }
 
-// StateStore returns a state store sharing this store's pool, mirroring
-// [Store.VersionStore]: an optional service derived from the store rather than
-// part of the store.Store interface, so the pool stays unexported.
-func (s *Store) StateStore() *StateKV {
+// StateStoreFor returns a state store sharing st's connection handle, or nil if
+// st is not a pgstore. The composition root calls this to obtain the service it
+// injects, so the state table is read through the same pool the store queries.
+//
+// A package-level function rather than a method on [Store] on purpose. Store
+// carries a pinned plimsoll load line and an explicit warning against adding
+// capability accessors back onto it — every one re-invites the
+// type-assert-a-capability-off-the-store pattern that the version refactor
+// removed. Taking store.Store here keeps the wiring identical for the caller
+// while leaving Store's method set untouched.
+func StateStoreFor(st store.Store) *StateKV {
+	s, ok := st.(*Store)
+	if !ok {
+		return nil
+	}
 	return &StateKV{db: s.db}
 }
 

--- a/internal/store/pgstore/statekv_test.go
+++ b/internal/store/pgstore/statekv_test.go
@@ -1,0 +1,105 @@
+package pgstore_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/Sourcehaven-BV/rela/internal/state"
+	"github.com/Sourcehaven-BV/rela/internal/state/statetest"
+	"github.com/Sourcehaven-BV/rela/internal/store/pgstore"
+)
+
+// TestStateKV_Conformance runs the shared state.KV contract against the
+// PostgreSQL backend. FSKV runs the identical suite in internal/state, which is
+// the point: the two backends are interchangeable only if one suite holds both.
+func TestStateKV_Conformance(t *testing.T) {
+	statetest.RunAll(t, func(tb testing.TB) state.KV {
+		tb.Helper()
+		pool := newScopedPool(tb)
+		raw, err := pgstore.NewStateKV(pool)
+		if err != nil {
+			tb.Fatalf("NewStateKV: %v", err)
+		}
+		// Wrapped exactly as the wiring site does: key validation is the state
+		// package's contract, not pgstore's, so the conformance suite must
+		// exercise the same composition production uses.
+		kv, err := state.NewValidatedKV(raw)
+		if err != nil {
+			tb.Fatalf("NewValidatedKV: %v", err)
+		}
+		return kv
+	})
+}
+
+func TestNewStateKV_RejectsNilHandle(t *testing.T) {
+	_, err := pgstore.NewStateKV(nil)
+	require.Error(t, err, "a nil handle must fail at construction, not at first use")
+}
+
+// TestStateKV_SharedAcrossConnections is the property the whole ticket exists
+// for: two independently-constructed KVs against the SAME schema observe each
+// other's writes. On FSKV in a multi-process deployment they would not — each
+// node has its own .rela/ — which is why an operator's logo upload is currently
+// invisible to every other node.
+//
+// Two separate pools, not two KVs over one pool: sharing a pool would pass even
+// if the implementation cached in memory, which is exactly the failure this
+// guards against.
+func TestStateKV_SharedAcrossConnections(t *testing.T) {
+	schema := freshFeedSchema(t)
+	ctx := context.Background()
+
+	writer, err := pgstore.NewStateKV(poolForSchema(t, schema))
+	require.NoError(t, err)
+	reader, err := pgstore.NewStateKV(poolForSchema(t, schema))
+	require.NoError(t, err)
+
+	require.NoError(t, writer.Put(ctx, "theme/logo", []byte("PNGDATA")))
+
+	got, err := reader.Get(ctx, "theme/logo")
+	require.NoError(t, err, "a second connection must see the first's write")
+	require.Equal(t, "PNGDATA", string(got))
+
+	// And a delete propagates the same way.
+	require.NoError(t, writer.Delete(ctx, "theme/logo"))
+	_, err = reader.Get(ctx, "theme/logo")
+	require.Error(t, err, "a second connection must see the first's delete")
+}
+
+// TestStateKV_IsolatedAcrossSchemas pins the multi-tenant property: state lives
+// in the store's schema, so the same key in two schemas is two values. This is
+// what makes schema-per-tenant give per-tenant state for free — without it the
+// document render cache would serve one tenant's HTML to another.
+func TestStateKV_IsolatedAcrossSchemas(t *testing.T) {
+	ctx := context.Background()
+	a, err := pgstore.NewStateKV(poolForSchema(t, freshFeedSchema(t)))
+	require.NoError(t, err)
+	b, err := pgstore.NewStateKV(poolForSchema(t, freshFeedSchema(t)))
+	require.NoError(t, err)
+
+	const key = "documents/DOC-1-samehash.html"
+	require.NoError(t, a.Put(ctx, key, []byte("tenant-a")))
+	require.NoError(t, b.Put(ctx, key, []byte("tenant-b")))
+
+	gotA, err := a.Get(ctx, key)
+	require.NoError(t, err)
+	gotB, err := b.Get(ctx, key)
+	require.NoError(t, err)
+
+	require.Equal(t, "tenant-a", string(gotA))
+	require.Equal(t, "tenant-b", string(gotB), "one schema's state must not overwrite another's")
+}
+
+// TestStateKV_RejectsOversizeValue pins the cap. A value over the limit is
+// refused rather than truncated: a silently truncated cached render would be
+// served as though it were a complete document.
+func TestStateKV_RejectsOversizeValue(t *testing.T) {
+	kv, err := pgstore.NewStateKV(newScopedPool(t))
+	require.NoError(t, err)
+	oversize := make([]byte, pgstore.MaxStateValueBytesForTest+1)
+	err = kv.Put(context.Background(), "big", oversize)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "over the")
+}

--- a/internal/store/pgstore/status_test.go
+++ b/internal/store/pgstore/status_test.go
@@ -33,8 +33,8 @@ func TestStatusFreshSchema(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 0, current, "un-migrated schema is version 0")
 	// target is the highest embedded migration version — bump this when a new
-	// migration is added (0007_entity_id_case_identity.sql took it from 6 to 7).
-	require.Equal(t, 7, target, "binary embeds migrations through 0007")
+	// migration is added (0008_state_kv.sql took it from 7 to 8).
+	require.Equal(t, 8, target, "binary embeds migrations through 0008")
 }
 
 // TestStatusAfterMigrate verifies Status reports current==target once Migrate


### PR DESCRIPTION
Tickets-PR: #1323

TKT-VC27L3 lives on #1323 (the ticket-only PR that scoped this work), so this
PR is code-only. The ticket reaches a terminal state when that PR merges.

Adds a PostgreSQL-backed `state.KV` alongside `FSKV`, selected on the postgres
build. Implements TKT-VC27L3 (#1323).

## Why

`docs/postgres-backend.md` documents running several `rela-server` processes
against one database. Until now everything on `state.KV` lived under each node's
own `.rela/`, so:

- **An operator uploads a logo and only one node serves it.** It lands on
  whichever node handled the POST; the others keep serving the old one, with no
  error anywhere. Same for user settings and the CalDAV alias table.
- **The render cache is per-node** — N nodes, up to N renders of the same
  document. A `command:` renderer shelling out to an external tool is exactly
  what you want cached once.

PostgreSQL is already the source of truth for entities, relations, attachments
and search in that deployment.

## Shape

`state.KV` was already the documented swap boundary, so this is an
implementation, not a refactor — no new abstraction, consumers unchanged.

- `pgstore.StateKV` + migration `0008_state_kv.sql`.
- `stateKVFor(st)` follows the existing `versionServiceFor` pattern: returns the
  DB-backed KV on postgres, nil elsewhere, and `assemble` falls back to `FSKV`.
- `dataentry.NewApp` now takes the KV instead of building its own `FSKV` — that
  second construction site would otherwise have left half the consumers
  (render cache, settings, logo) on disk regardless of the wiring.

Rows live in the store's schema, so schema-per-tenant scopes this state for
free — which is what RES-D54281 needs from it.

## Two design points worth review

**Key validation moved to a wrapper.** `pgstore` may not import
`internal/state` (arch-lint: a store backend must not depend on an
application-level package — I hit this and it was right). So `StateKV` stores
whatever key it is handed, and `state.ValidatedKV` wraps it at the wiring site,
applying the same rules `storage.RootedFS` gives `FSKV` for free. One
implementation of the rules rather than a copy in the backend that could drift.
Without it a key accepted on PostgreSQL would be rejected after migrating to the
filesystem backend.

**Conformance suite over prose.** The KV contract had two load-bearing clauses
carried only in interface comments: a missing key must fail with an
`os.IsNotExist`-satisfying error (the document cache distinguishes "no cached
render" from "backend broken" by exactly this), and deleting a missing key must
*succeed* (`logoStore.Delete` documents itself as idempotent). `statetest.RunAll`
now holds both backends to one contract; `FSKV` passed it unchanged, which is
the baseline that makes it trustworthy.

## Verification

Every new assertion was checked to fail against a deliberately broken
implementation:

- not-exist error shape → `GetMissingIsNotExist` + `DeleteRemoves` fail
- key validation dropped → `RejectsInvalidKeys` fails
- `Delete` of a missing key errors → `DeleteMissingIsNotError` +
  `DeleteIsIdempotent` fail
- state shared across schemas → `IsolatedAcrossSchemas` fails
- `stateKVFor` returns nil (silent fallback to disk) →
  `TestPostgresBuild_StateIsDatabaseBacked` fails, naming the consequence

That last one asserts the project directory stays clean after a write rather
than type-asserting, so it catches a future refactor reinstating the filesystem
KV.

Also: `go build` both tags, full default `go test ./...`, full pgstore suite
against live PostgreSQL 15, `just arch-lint` clean, `golangci-lint run ./...`
clean, coverage 77.6% (up from 77.1%, floors pass). `statetest` is excluded from
coverage like its `storetest`/`visibilitytest` siblings. `status_test.go`'s
migration-count assertion bumped 7 → 8 as its comment instructs.

Docs updated: `docs/postgres-backend.md`, the guide mirror, and the CLAUDE.md
rule that said `.rela/` always stays on the filesystem — now true only for
operator-authored config.

Pre-existing and unrelated (identical on `develop`, verified by worktree): four
postgres-tagged lint findings in `graphquery_explain_test.go` /
`sweepConfigFromEnv`, and 10 `internal/appbuild` test failures under
`-tags postgres` (FS-project tests run under the postgres tag; not covered by
CI's postgres job).
