### PR TITLE
fix(tickets): repair frontmatter that silently disabled ticket validation

### DIFF
--- a/tickets/entities/automated-measures/AM-feed-field-redaction.md
+++ b/tickets/entities/automated-measures/AM-feed-field-redaction.md
@@ -1,8 +1,8 @@
 ---
 id: AM-feed-field-redaction
 type: automated-measure
-title: The ICS feed omits visible:-hidden properties, and redaction runs after the filter
-description: TestDeclarativeFeed_RedactsHiddenProperties asserts a hidden property never reaches a rendered event. TestDeclarativeFeed_RedactionDoesNotChangeMembership pins the ORDER by hiding the property the where: clause filters on and asserting the event still appears - moving redaction before the filter drops it, so feed membership would vary per principal. TestDeclarativeFeed_RedactionCopies asserts the shared store entity is not mutated. All three verified to fail against the fix being removed.
+title: 'The ICS feed omits visible:-hidden properties, and redaction runs after the filter'
+description: 'TestDeclarativeFeed_RedactsHiddenProperties asserts a hidden property never reaches a rendered event. TestDeclarativeFeed_RedactionDoesNotChangeMembership pins the ORDER by hiding the property the where: clause filters on and asserting the event still appears - moving redaction before the filter drops it, so feed membership would vary per principal. TestDeclarativeFeed_RedactionCopies asserts the shared store entity is not mutated. All three verified to fail against the fix being removed.'
 kind: test
 location: internal/dataentry/feed_provider_test.go
 status: active

--- a/tickets/entities/automated-measures/AM-validate-fails-closed-on-unparseable-entity.md
+++ b/tickets/entities/automated-measures/AM-validate-fails-closed-on-unparseable-entity.md
@@ -1,0 +1,9 @@
+---
+id: AM-validate-fails-closed-on-unparseable-entity
+type: automated-measure
+title: rela validate exits non-zero when an entity cannot be parsed
+description: Test that a project containing one entity file with unparseable YAML frontmatter makes rela validate exit non-zero and name the offending file, rather than reporting success over a partial corpus.
+kind: test
+location: internal/cli/ (test to be written with the fix)
+status: proposed
+---

--- a/tickets/entities/bugs/BUG-NEQRY2.md
+++ b/tickets/entities/bugs/BUG-NEQRY2.md
@@ -1,0 +1,88 @@
+---
+id: BUG-NEQRY2
+type: bug
+title: rela validate exits 0 when entity frontmatter fails to parse — validation silently skips those entities
+description: A single entity file with unparseable YAML frontmatter makes store.ListEntities return an iterator error. rela validate logs it as a WARN, skips the entity, and still prints 'All validations passed' with exit 0. CI is therefore green on a corpus it never fully read, and any rule violation on the skipped entity is invisible.
+priority: high
+effort: s
+status: backlog
+---
+
+## Symptom
+
+One entity file with unparseable YAML frontmatter is enough to make `rela
+validate` report success while **not having validated that entity**.
+
+Reproduced against this repo's own `tickets/` project by restoring the exact
+breakage that shipped in PR #1314:
+
+```console
+$ cd tickets && ../bin/rela validate \
+    --check cardinality --check properties --check validations
+...
+All validations passed.
+EXIT=0
+```
+
+— while the same run emitted **2** `failed to parse frontmatter` errors. The
+affected entity was skipped, not validated.
+
+## Why this matters
+
+It is not a cosmetic logging issue. The skipped entity's rule violations
+disappear with it, so a green CI run can hide real failures.
+
+That is exactly what happened:
+
+- `AM-feed-field-redaction.md` had unquoted `visible:` / `where:` inside plain
+scalars (`title:` / `description:`), so its frontmatter failed to parse.
+- The parse failure made `store.ListEntities` error and under-count.
+- `done-bug-needs-review-done` therefore never evaluated **BUG-E9DYW5**, which
+had been merged `done` with no review checklist at all.
+- CI on `develop` reported "All 120 validation rules passed" throughout.
+
+The violation only surfaced when the frontmatter was repaired — i.e. the
+corpus-level failure was *masking* an item-level failure, and the masking was
+silent in both directions.
+
+## Root cause (initial reading, to confirm)
+
+`store.ListEntities` surfaces the problem as an **iterator error** rather than a
+hard failure. Callers log it at WARN (`analysis: store.ListEntities iterator
+error; results may under-count`) and carry on with a partial result set. For an
+*analysis* command "best effort over what parsed" is arguable; for a
+**validation gate whose exit code gates merges**, a partial read is not a pass.
+
+## Proposed fix
+
+`rela validate` should fail closed: if any entity could not be read or parsed,
+exit non-zero and name the offending files, regardless of whether the entities
+that *did* parse are clean. A validation run that skipped input has not
+validated the project.
+
+Worth deciding separately whether other read paths should also harden or keep
+degrading gracefully — `validate` is the one with a merge gate behind it, so it
+is the one that must not lie.
+
+Consider also a cheap dedicated check (`rela validate --check frontmatter`, or
+folding it into the existing checks) so the failure names the file and the YAML
+error directly rather than surfacing as a downstream under-count.
+
+## Prior art in this repo
+
+This is the **second** occurrence of the same YAML class, both from an unquoted
+`key:` inside a plain scalar:
+
+- `AM-date-property-write-roundtrip.md` — `due: 2026-08-12` in `description:`.
+Blocked *all* entity creation (`collect existing IDs: failed to parse
+frontmatter`), so that one at least failed loudly.
+- `AM-feed-field-redaction.md` — `visible:` / `where:`. Did **not** fail
+loudly; it silently disabled validation for the affected entities.
+
+The first was noisy and got fixed immediately; the second was silent and
+persisted through CI. That asymmetry is the argument for failing closed.
+
+## Provenance
+
+Found while resolving merge conflicts for PR #1319 (scheduler failure backoff),
+after repairing the second broken file exposed the hidden BUG-E9DYW5 violation.

--- a/tickets/entities/review-checklists/REV-E9DYW5.md
+++ b/tickets/entities/review-checklists/REV-E9DYW5.md
@@ -1,0 +1,62 @@
+---
+id: REV-E9DYW5
+type: review-checklist
+title: 'Review: ICS feed serves `visible:`-redacted properties verbatim'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Provenance of this record
+
+**Backfilled.** BUG-E9DYW5 was completed and merged via
+[PR #1314](https://github.com/sourcehaven-bv/rela/pull/1314) without a
+`review-checklist` entity, so `done-bug-needs-review-done` was violated. The
+violation went undetected because `AM-feed-field-redaction.md` had unparseable
+YAML frontmatter (unquoted `visible:` / `where:` in plain scalars), which made
+`store.ListEntities` error and silently under-count — `analyze validations`
+reported "all 120 rules passed" while skipping the affected entities.
+
+This checklist records **what verifiably happened on that PR**, from the PR's
+own review history and merge state. It is not a re-review of the code, and it
+does not assert that anyone other than the named reviewer examined it.
+
+## Code Review
+
+- [x] Reviewed and approved before merge
+
+PR #1314 carries 4 review events from **tschmits**, concluding in `APPROVED`,
+and was merged 2026-08-14T10:47Z. That approval is the review of record for
+this bug.
+
+## Automated Checks
+
+- [x] CI green on the merge commit
+
+The PR merged into `develop`, which requires the full CI suite to pass. No
+per-job results are transcribed here — asserting specific local command output
+that nobody ran would be fabrication. The authoritative record is the PR's own
+check history.
+
+## Acceptance Verification
+
+- [x] Fix pinned by tests that fail without it
+
+Per `AM-feed-field-redaction`, three tests back the fix, all verified to fail
+against its removal:
+
+- `TestDeclarativeFeed_RedactsHiddenProperties` — a hidden property never
+  reaches a rendered event.
+- `TestDeclarativeFeed_RedactionDoesNotChangeMembership` — pins the **order**
+  (filter before redact) by hiding the property the `where:` clause filters on;
+  redacting first would drop the event and make feed membership vary per
+  principal.
+- `TestDeclarativeFeed_RedactionCopies` — the shared store entity is not
+  mutated.
+
+## Follow-up
+
+The bug's own `prevention` field records the durable fix as **not** done here:
+a distinct type for "redacted, safe to render" so a raw `*entity.Entity` cannot
+reach a serializer by accident. Redaction is currently enforced per-read-shape,
+so each new read path must remember it. That remains tracked separately.

--- a/tickets/relations/BUG-E9DYW5--has-review--REV-E9DYW5.md
+++ b/tickets/relations/BUG-E9DYW5--has-review--REV-E9DYW5.md
@@ -1,0 +1,5 @@
+---
+from: BUG-E9DYW5
+relation: has-review
+to: REV-E9DYW5
+---

--- a/tickets/relations/BUG-NEQRY2--adds-measure--AM-validate-fails-closed-on-unparseable-entity.md
+++ b/tickets/relations/BUG-NEQRY2--adds-measure--AM-validate-fails-closed-on-unparseable-entity.md
@@ -1,0 +1,5 @@
+---
+from: BUG-NEQRY2
+relation: adds-measure
+to: AM-validate-fails-closed-on-unparseable-entity
+---

--- a/tickets/relations/BUG-NEQRY2--affects--metamodel-types.md
+++ b/tickets/relations/BUG-NEQRY2--affects--metamodel-types.md
@@ -1,0 +1,5 @@
+---
+from: BUG-NEQRY2
+relation: affects
+to: metamodel-types
+---

--- a/tickets/relations/BUG-NEQRY2--fixes--FEAT-13863O.md
+++ b/tickets/relations/BUG-NEQRY2--fixes--FEAT-13863O.md
@@ -1,0 +1,5 @@
+---
+from: BUG-NEQRY2
+relation: fixes
+to: FEAT-13863O
+---


### PR DESCRIPTION
Split out of #1319 (scheduler failure backoff) so that PR stays scheduler-only.

## The problem

`tickets/entities/automated-measures/AM-feed-field-redaction.md` (from #1314)
has unquoted `visible:` and `where:` inside plain YAML scalars:

```yaml
title: The ICS feed omits visible:-hidden properties, and redaction runs after the filter
description: ... pins the ORDER by hiding the property the where: clause filters on ...
```

A colon-space inside a plain scalar is invalid YAML, so the frontmatter fails to
parse. That makes `store.ListEntities` return an iterator error, and the entity
is **skipped** — while `rela validate` still reports success.

## Why it matters

The skipped entity's rule violations vanish with it. Repairing the frontmatter
immediately surfaced a real, pre-existing failure:

```
✗ Done bugs must have completed review checklist (1):
  BUG-E9DYW5: ICS feed serves `visible:`-redacted properties verbatim
```

**BUG-E9DYW5 was merged `done` with no review checklist at all**, and
`done-bug-needs-review-done` never fired because the parse error hid it. CI on
`develop` reported "All 120 validation rules passed" throughout.

## Changes

1. **Quote the two scalars** in `AM-feed-field-redaction.md`. Content unchanged.

2. **Backfill `REV-E9DYW5`** and link it via `has-review`. This records what
   *verifiably happened* on #1314 — 4 review events from **tschmits** ending in
   `APPROVED`, merged 2026-08-14T10:47Z — and says so explicitly. It is **not** a
   re-review, and it does not transcribe per-job CI results nobody ran. A
   checklist asserting a review I did not perform would be a fabricated audit
   record; the PR's own history is the authoritative source.

3. **File `BUG-NEQRY2`** (backlog, high) for the tooling gap that allowed this.

## The tooling gap

`rela validate` fails **open**. Reproduced by restoring the exact breakage and
running the CI command verbatim:

```console
$ cd tickets && ../bin/rela validate \
    --check cardinality --check properties --check validations
...
All validations passed.
EXIT=0
```

— while the same run emitted 2 `failed to parse frontmatter` errors. A
validation run that skipped input has not validated the project, and its exit
code gates merges.

This is the **second** occurrence of this YAML class. The first
(`AM-date-property-write-roundtrip.md`, `due: 2026-08-12` in a description)
blocked *all* entity creation, so it failed loudly and got fixed immediately.
This one failed silently and persisted through CI. That asymmetry is the
argument for failing closed, which is what BUG-NEQRY2 proposes, pinned by
`AM-validate-fails-closed-on-unparseable-entity`.

## Verification

- `rela validate --check cardinality --check properties --check validations` → passes
- `analyze validations` → all 120 rules pass, **0 parse errors** (previously 2 with a false pass)
- `analyze cardinality` → all constraints satisfied
- Ticket done-before-merge gate replayed locally: `BUG-NEQRY2 = backlog` OK

No Go code changes.