### PR TITLE
ci: ignore typescript major bumps until TS 7.1 (TKT-WVCE1A)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -59,6 +59,13 @@ updates:
     ignore:
       - dependency-name: "vue-router"
         update-types: ["version-update:semver-major"]
+      # TypeScript 7.0 ships no JS compiler API, so typescript-eslint caps
+      # its peer range at <6.1.0 and hard-errors at runtime on TS 7 ("does
+      # not support TS 7.0"). No typescript-eslint 8.x release can lift this;
+      # Microsoft expects the new API in TS 7.1. Revisit then — dropping this
+      # ignore is the whole change. See typescript-eslint#10940.
+      - dependency-name: "typescript"
+        update-types: ["version-update:semver-major"]
     # Groups bundle minor+patch only. Majors fall out as individual PRs
     # so a single breaking upgrade can't block the safe ones in its group.
     # Auto-merge is unconditional on green CI, so each PR (group or
@@ -118,6 +125,12 @@ updates:
     cooldown:
       default-days: 7
       semver-major-days: 14
+    # Same TS 7 block as /frontend above: typescript-eslint refuses to load
+    # against TS 7.0, and e2e's lint config depends on it for the Page Object
+    # Pattern rules. Revisit when TS 7.1 ships the new compiler API.
+    ignore:
+      - dependency-name: "typescript"
+        update-types: ["version-update:semver-major"]
     groups:
       playwright:
         patterns:

--- a/tickets/entities/review-checklists/REV-DB4IPJ.md
+++ b/tickets/entities/review-checklists/REV-DB4IPJ.md
@@ -1,0 +1,36 @@
+---
+id: REV-DB4IPJ
+type: review-checklist
+title: 'Review: Ignore TypeScript major bumps until TS 7.1 lands a compiler API'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Automated Checks
+- [x] `dependabot.yml` parses as valid YAML; both `ignore` blocks land in the intended `/frontend` and `/e2e` entries
+- [x] Full CI green on PR #1331 apart from this ticket gate (lint, Test, Frontend, Postgres, cross-compile, CodeQL)
+- [x] ~~Go tests~~ (N/A: config-only change, no Go code touched)
+
+## Code Review
+- [x] ~~cranky-code-reviewer~~ (N/A: no code change — a Dependabot config rule; nothing to review beyond the YAML diff)
+- [x] Self-reviewed the diff: only `.github/dependabot.yml`, two additive `ignore` entries
+
+## Acceptance Verification
+- [x] Blocker re-verified upstream: `typescript-eslint` 8.67.0 still caps `peerDependencies.typescript` at `>=4.8.4 <6.1.0`
+- [x] `ERESOLVE` reproduced locally against the latest release; `--legacy-peer-deps` also fails on a hard runtime guard ("does not support TS 7.0")
+- [x] Scope confirmed majors-only — TS 6.x patch/minor updates still flow; `build-tooling` group is already minor/patch-only so no group PR can reintroduce the major
+
+## Documentation
+- [x] Rationale recorded inline as YAML comments next to each rule, with the upstream issue link (typescript-eslint#10940)
+- [x] Revisit condition documented: delete both entries when TS 7.1 ships the new compiler API
+
+## Final Checks
+- [x] Commit message explains the why (upstream peer cap, no API in TS 7.0)
+- [x] Follow-ups noted on the PR: close #1220 and #1227 once merged; `e2e/tsconfig.json` needs `moduleResolution: node16` before any future TS 7 bump
+- [x] Ready to merge
+
+## Pull Request
+- [x] PR #1331 opened against develop.
+
+**PR:** https://github.com/sourcehaven-bv/rela/pull/1331

--- a/tickets/entities/tickets/TKT-WVCE1A.md
+++ b/tickets/entities/tickets/TKT-WVCE1A.md
@@ -5,7 +5,7 @@ title: Ignore TypeScript major bumps until TS 7.1 lands a compiler API
 kind: chore
 priority: medium
 effort: xs
-status: review
+status: done
 ---
 
 ## Problem

--- a/tickets/entities/tickets/TKT-WVCE1A.md
+++ b/tickets/entities/tickets/TKT-WVCE1A.md
@@ -1,0 +1,52 @@
+---
+id: TKT-WVCE1A
+type: ticket
+title: Ignore TypeScript major bumps until TS 7.1 lands a compiler API
+kind: chore
+priority: medium
+effort: xs
+status: review
+---
+
+## Problem
+
+Dependabot keeps reopening TypeScript 7.0 major bumps that cannot pass CI:
+[#1220](https://github.com/sourcehaven-bv/rela/pull/1220) (`/e2e`) and
+[#1227](https://github.com/sourcehaven-bv/rela/pull/1227) (`/frontend`). Both
+fail `npm ci` with `ERESOLVE`.
+
+The cause is upstream and not a version-range oversight: **TypeScript 7.0 ships
+no JS compiler API at all.** `typescript-eslint` therefore caps
+`peerDependencies.typescript` at `>=4.8.4 <6.1.0` — still true in 8.67.0 and in
+the canary line. Forcing the install past it does not help; `typescript-eslint`
+has a hard runtime guard that refuses to load:
+
+```
+Error: typescript-eslint does not support TS 7.0.
+```
+
+Upstream ([typescript-eslint#10940](https://github.com/typescript-eslint/typescript-eslint/issues/10940))
+is explicit that nothing can be done until TypeScript ships the new API, which
+Microsoft expects in **TS 7.1**. The thread is locked.
+
+Both `/frontend` and `/e2e` depend on `typescript-eslint`; in `/e2e` it also
+enforces the Page Object Pattern lint rules.
+
+Note `/frontend` already pins `typescript: ~6.0.3` (patch-only) and Dependabot
+proposed the major anyway — a package.json range does not constrain it, so an
+`ignore` rule is what actually stops the churn.
+
+## Fix
+
+Add a `version-update:semver-major` ignore for `typescript` to both npm blocks
+in `.github/dependabot.yml`. Scoped to majors only, so TS 6.x patch/minor
+updates keep flowing. The `build-tooling` group is already `minor`/`patch`-only,
+so no group PR can smuggle the major back in.
+
+## Revisit
+
+When TS 7.1 ships the new compiler API, delete the two `ignore` entries — that
+is the whole change. The e2e sources were verified to typecheck clean under TS
+7.0 (`tsc --noEmit`, 0 errors across 52 files), so the eventual bump should be
+mechanical, modulo switching `e2e/tsconfig.json` off `moduleResolution: node`
+(removed in TS 7, `error TS5108`) to `node16`.

--- a/tickets/relations/TKT-WVCE1A--affects--ci-pipeline.md
+++ b/tickets/relations/TKT-WVCE1A--affects--ci-pipeline.md
@@ -1,0 +1,5 @@
+---
+from: TKT-WVCE1A
+relation: affects
+to: ci-pipeline
+---

--- a/tickets/relations/TKT-WVCE1A--has-review--REV-DB4IPJ.md
+++ b/tickets/relations/TKT-WVCE1A--has-review--REV-DB4IPJ.md
@@ -1,0 +1,5 @@
+---
+from: TKT-WVCE1A
+relation: has-review
+to: REV-DB4IPJ
+---

--- a/tickets/relations/TKT-WVCE1A--implements--FEAT-GE1YY.md
+++ b/tickets/relations/TKT-WVCE1A--implements--FEAT-GE1YY.md
@@ -1,0 +1,5 @@
+---
+from: TKT-WVCE1A
+relation: implements
+to: FEAT-GE1YY
+---


### PR DESCRIPTION
Stops Dependabot reopening TypeScript 7.0 majors that cannot pass CI:
#1220 (`/e2e`) and #1227 (`/frontend`). Both fail `npm ci` with `ERESOLVE`.

## Why it can't be fixed by upgrading

**TypeScript 7.0 ships no JS compiler API at all**, so `typescript-eslint` caps
`peerDependencies.typescript` at `>=4.8.4 <6.1.0` — still true in the latest
release (8.67.0) and in the canary line. This is not a version-range oversight
that a `typescript-eslint` bump will lift.

`--legacy-peer-deps` does not rescue it either. `typescript-eslint` has a hard
runtime guard and refuses to load:

```
Error: typescript-eslint does not support TS 7.0.
```

Upstream ([typescript-eslint#10940](https://github.com/typescript-eslint/typescript-eslint/issues/10940))
states nothing can be done until TypeScript ships the new API, expected in
**TS 7.1**; the thread is locked.

Both directories depend on `typescript-eslint` — in `/e2e` it also enforces the
Page Object Pattern lint rules.

## Note on pinning

`/frontend` already pins `typescript: ~6.0.3` (patch-only) and Dependabot
proposed the major anyway. A package.json range doesn't constrain Dependabot, so
an `ignore` rule is what actually stops the churn.

## Scope

Majors only (`version-update:semver-major`), so TS 6.x patch/minor updates keep
flowing. The `build-tooling` group is already `minor`/`patch`-only, so no group
PR can smuggle the major back in.

## Revisit

When TS 7.1 lands, delete the two `ignore` entries — that's the whole change.
The e2e sources already typecheck clean under TS 7.0 (`tsc --noEmit`, 0 errors
across 52 files), so the bump should be mechanical, modulo switching
`e2e/tsconfig.json` off `moduleResolution: node` (removed in TS 7, `error
TS5108`) to `node16`.

Closes TKT-WVCE1A. Suggest closing #1220 and #1227 once this merges.
