### PR TITLE
fix(analyze): bound _analyze memory — 2,947 MB → 51 MB (TKT-1ESTYJ)

### DIFF
--- a/frontend/src/types/config.ts
+++ b/frontend/src/types/config.ts
@@ -407,6 +407,16 @@ export interface AnalyzeResult {
   warnings: number
   issues: AnalyzeIssue[]
   byCheck: Record<string, number>
+
+  /**
+   * Names of checks that found MORE issues than they returned. Each check
+   * is capped server-side (TKT-1ESTYJ), so `byCheck` for a listed check is
+   * the cap, not the true total.
+   *
+   * Omitted by the server when nothing was truncated, so it is optional —
+   * and older servers never send it at all.
+   */
+  truncatedChecks?: string[]
 }
 
 export interface NavigationEntry {

--- a/frontend/src/views/AnalyzeView.test.ts
+++ b/frontend/src/views/AnalyzeView.test.ts
@@ -164,7 +164,6 @@ describe('AnalyzeView click discrimination', () => {
     // The em-dash character should be present.
     expect(row.text()).toContain('—')
   })
-
 })
 
 // GH#785: every warning counted in the summary badge must be visible on
@@ -254,11 +253,31 @@ describe('AnalyzeView section rendering (GH#785)', () => {
 
   it('summary badge total equals sum of visible card counts', async () => {
     const issues = [
-      makeIssue({ entityId: 'n-1', entityType: 'note', severity: 'error', checkType: 'Properties' }),
-      makeIssue({ entityId: 'n-2', entityType: 'note', severity: 'error', checkType: 'Cardinality' }),
-      makeIssue({ entityId: 'n-3', entityType: 'note', severity: 'warning', checkType: 'Validations' }),
+      makeIssue({
+        entityId: 'n-1',
+        entityType: 'note',
+        severity: 'error',
+        checkType: 'Properties',
+      }),
+      makeIssue({
+        entityId: 'n-2',
+        entityType: 'note',
+        severity: 'error',
+        checkType: 'Cardinality',
+      }),
+      makeIssue({
+        entityId: 'n-3',
+        entityType: 'note',
+        severity: 'warning',
+        checkType: 'Validations',
+      }),
       makeIssue({ entityId: 'n-4', entityType: 'note', severity: 'warning', checkType: 'Orphans' }),
-      makeIssue({ entityId: 'n-5', entityType: 'note', severity: 'warning', checkType: 'Duplicates' }),
+      makeIssue({
+        entityId: 'n-5',
+        entityType: 'note',
+        severity: 'warning',
+        checkType: 'Duplicates',
+      }),
       makeIssue({ entityId: '', entityType: '', severity: 'warning', checkType: 'ID Gaps' }),
     ]
     const wrapper = await mountWith(issues)
@@ -477,5 +496,71 @@ describe('AnalyzeView missing-header detail', () => {
     expect(wrapper.find('.message-toggle').exists()).toBe(false)
     expect(wrapper.find('.disclosure').exists()).toBe(false)
     expect(wrapper.find('.issue-detail-row').exists()).toBe(false)
+  })
+})
+
+describe('AnalyzeView truncation', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    routerPush.mockReset()
+    analyzeMock.mockReset()
+    const schema = useSchemaStore()
+    schema.entityTypes.set('note', { label: 'Note' } as never)
+  })
+
+  async function mountWithResult(result: AnalyzeResult) {
+    analyzeMock.mockResolvedValue(result)
+    const wrapper = mount(AnalyzeView, { attachTo: document.body })
+    await flushPromises()
+    return wrapper
+  }
+
+  it('marks a truncated check and suffixes its count', async () => {
+    const result = makeResult([makeIssue({ checkType: 'Properties' })])
+    result.byCheck.Properties = 100
+    result.truncatedChecks = ['Properties']
+
+    const wrapper = await mountWithResult(result)
+
+    const notice = wrapper.find('.check-truncated')
+    expect(notice.exists()).toBe(true)
+    expect(notice.text()).toContain('found')
+    // The count must read as a lower bound, not an exact total: byCheck for
+    // a truncated check is the cap.
+    expect(wrapper.text()).toContain('100+')
+  })
+
+  it('shows no truncation notice when every check reported in full', async () => {
+    const result = makeResult([makeIssue({ checkType: 'Properties' })])
+
+    const wrapper = await mountWithResult(result)
+
+    expect(wrapper.find('.check-truncated').exists()).toBe(false)
+    expect(wrapper.text()).not.toContain('1+')
+  })
+
+  // An older server omits truncatedChecks entirely; the view must not throw
+  // and must not invent truncation.
+  it('tolerates a response without truncatedChecks', async () => {
+    const result = makeResult([makeIssue({ checkType: 'Orphans' })])
+    delete result.truncatedChecks
+
+    const wrapper = await mountWithResult(result)
+
+    expect(wrapper.find('.check-truncated').exists()).toBe(false)
+  })
+
+  it('marks only the checks the server listed', async () => {
+    const result = makeResult([
+      makeIssue({ checkType: 'Properties' }),
+      makeIssue({ checkType: 'Orphans', severity: 'warning' }),
+    ])
+    result.byCheck.Properties = 100
+    result.truncatedChecks = ['Properties']
+
+    const wrapper = await mountWithResult(result)
+
+    const notices = wrapper.findAll('.check-truncated')
+    expect(notices).toHaveLength(1)
   })
 })

--- a/frontend/src/views/AnalyzeView.vue
+++ b/frontend/src/views/AnalyzeView.vue
@@ -89,6 +89,15 @@ function getCheckCount(checkKey: string): number {
   return result.value?.byCheck[checkKey] || 0
 }
 
+// Whether a check reported fewer issues than it found. The server caps each
+// check, so for a truncated one the count above is the cap, not the total —
+// which is why the count renders as "100+" and the card says the list is
+// partial. Without this an operator fixes all 100, re-runs, sees 100 again,
+// and concludes analysis is broken.
+function isTruncated(checkKey: string): boolean {
+  return result.value?.truncatedChecks?.includes(checkKey) ?? false
+}
+
 // Get filtered issues for a check type
 function getFilteredIssuesForCheck(checkKey: string): AnalyzeIssue[] {
   return issuesByCheck.value[checkKey] || []
@@ -157,11 +166,16 @@ onMounted(() => {
             <h3 class="check-title">
               {{ checkType.label }}
               <span class="check-count" :class="{ 'has-issues': getCheckCount(checkType.key) > 0 }">
-                {{ getCheckCount(checkType.key) }}
+                {{ getCheckCount(checkType.key) }}{{ isTruncated(checkType.key) ? '+' : '' }}
               </span>
             </h3>
             <p class="check-description">{{ checkType.description }}</p>
           </div>
+
+          <p v-if="isTruncated(checkType.key)" class="check-truncated" role="status">
+            Showing the first {{ getCheckCount(checkType.key) }} issues &mdash; this check found
+            more. Fix these and re-run to see the rest.
+          </p>
 
           <div v-if="getCheckCount(checkType.key) === 0" class="no-issues">
             <span class="check-icon">&#10003;</span>
@@ -305,6 +319,16 @@ onMounted(() => {
 
 .check-description {
   margin: 0;
+  font-size: 13px;
+  color: var(--muted-text);
+}
+
+.check-truncated {
+  margin: 8px 0 0;
+  padding: 8px 12px;
+  border-left: 3px solid var(--warning-color);
+  background: var(--hover-bg);
+  border-radius: 4px;
   font-size: 13px;
   color: var(--muted-text);
 }

--- a/internal/dataentry/analyze.go
+++ b/internal/dataentry/analyze.go
@@ -29,9 +29,20 @@ import (
 // structural fact, not a value, so it cannot leak; under-visibility only makes
 // cardinality potentially false-positive, which is correctness (guarded by the
 // roles annotation, arc step 2), not a disclosure.
+// The whole-store scans go through ListEntityHeaders, never ListEntities:
+// no analyze check reads an entity BODY (grep this file for `.Content` —
+// there are none), so loading bodies to discard them made a scan's peak
+// memory proportional to the project's markdown. On 20k entities with
+// ~100 KB bodies that was ~2.9 GB of RSS for one request (TKT-1ESTYJ).
+// The header type has no Content field, so this property is now enforced
+// by the compiler rather than by remembering.
+//
+// The per-ID GetEntity above stays: orphans and validation violations
+// resolve a bounded set of ids (never a whole-store scan), and their
+// gated re-load is load-bearing for the leak TKT-3FL2S6 closed.
 type analyzeReader interface {
 	GetEntity(ctx context.Context, id string) (*entity.Entity, error)
-	ListEntities(ctx context.Context, q store.EntityQuery) iter.Seq2[*entity.Entity, error]
+	ListEntityHeaders(ctx context.Context, q store.EntityQuery) iter.Seq2[store.EntityHeader, error]
 }
 
 // relationCounter counts relations for the cardinality check. Raw (ungated) on
@@ -192,14 +203,19 @@ func (svc analyzeService) analyzeDuplicates(ctx context.Context, meta *metamodel
 		Description: "Entities with identical titles",
 	}
 
-	titleGroups := make(map[string][]*entity.Entity)
-	for e, err := range svc.reads.ListEntities(ctx, store.EntityQuery{}) {
+	// The one analyzer that genuinely CANNOT stream: a title is not known
+	// to be duplicated until its second occurrence, which may be the last
+	// row scanned, so the grouping must see the whole set. Grouping HEADERS
+	// rather than entities is what makes that affordable — the map holds
+	// ids and properties, never bodies.
+	titleGroups := make(map[string][]store.EntityHeader)
+	for h, err := range svc.reads.ListEntityHeaders(ctx, store.EntityQuery{}) {
 		if err != nil {
 			break
 		}
-		title := normalizeTitle(safeDisplayTitle(meta, e))
+		title := normalizeTitle(safeHeaderTitle(meta, h))
 		if title != "" {
-			titleGroups[title] = append(titleGroups[title], e)
+			titleGroups[title] = append(titleGroups[title], h)
 		}
 	}
 
@@ -214,16 +230,16 @@ func (svc analyzeService) analyzeDuplicates(ctx context.Context, meta *metamodel
 
 	for _, title := range titles {
 		group := titleGroups[title]
-		sortStoreEntitiesByID(group)
+		sortHeadersByID(group)
 		ids := make([]string, len(group))
-		for i, e := range group {
-			ids[i] = e.ID
+		for i, h := range group {
+			ids[i] = h.ID
 		}
-		for _, e := range group {
+		for _, h := range group {
 			section.Issues = append(section.Issues, AnalysisIssue{
-				EntityID:   e.ID,
-				EntityType: e.Type,
-				Title:      safeDisplayTitle(meta, e),
+				EntityID:   h.ID,
+				EntityType: h.Type,
+				Title:      safeHeaderTitle(meta, h),
 				Message:    fmt.Sprintf("Duplicate title (shared by %s)", strings.Join(ids, ", ")),
 				Severity:   "warning",
 			})
@@ -257,11 +273,11 @@ func (svc analyzeService) analyzeGaps(ctx context.Context, meta *metamodel.Metam
 
 	// Group IDs by prefix
 	prefixGroups := make(map[string][]int)
-	for e, err := range svc.reads.ListEntities(ctx, store.EntityQuery{}) {
+	for h, err := range svc.reads.ListEntityHeaders(ctx, store.EntityQuery{}) {
 		if err != nil {
 			break
 		}
-		parsed, err := entity.ParseEntityID(e.ID)
+		parsed, err := entity.ParseEntityID(h.ID)
 		if err != nil || parsed.Prefix == "" {
 			continue
 		}
@@ -323,18 +339,22 @@ func (svc analyzeService) analyzeCardinality(ctx context.Context, meta *metamode
 	}
 	natsort.Strings(relNames)
 
-	// listEntities lists entities of a given type, sorted by ID. GATED: only the
+	// listEntities lists headers of a given type, sorted by ID. GATED: only the
 	// requester's visible entities are considered, so a hidden entity's title
 	// cannot reach a cardinality issue.
-	listEntities := func(t string) []*entity.Entity {
-		var out []*entity.Entity
-		for e, err := range svc.reads.ListEntities(ctx, store.EntityQuery{Type: t}) {
+	//
+	// Materializes per TYPE rather than per store — each entry is a body-free
+	// header, and the caller iterates a type's rows several times (once per
+	// bound being checked), so re-scanning would cost more than it saves.
+	listEntities := func(t string) []store.EntityHeader {
+		var out []store.EntityHeader
+		for h, err := range svc.reads.ListEntityHeaders(ctx, store.EntityQuery{Type: t}) {
 			if err != nil {
 				break
 			}
-			out = append(out, e)
+			out = append(out, h)
 		}
-		sortStoreEntitiesByID(out)
+		sortHeadersByID(out)
 		return out
 	}
 
@@ -361,7 +381,7 @@ func (svc analyzeService) analyzeCardinality(ctx context.Context, meta *metamode
 						section.Issues = append(section.Issues, AnalysisIssue{
 							EntityID:   e.ID,
 							EntityType: e.Type,
-							Title:      safeDisplayTitle(meta, e),
+							Title:      safeHeaderTitle(meta, e),
 							Message:    fmt.Sprintf("Must have at least %d '%s' relation(s), has %d", *relDef.MinOutgoing, relName, count),
 							Severity:   "error",
 						})
@@ -379,7 +399,7 @@ func (svc analyzeService) analyzeCardinality(ctx context.Context, meta *metamode
 						section.Issues = append(section.Issues, AnalysisIssue{
 							EntityID:   e.ID,
 							EntityType: e.Type,
-							Title:      safeDisplayTitle(meta, e),
+							Title:      safeHeaderTitle(meta, e),
 							Message:    fmt.Sprintf("Has more than %d '%s' relation(s): %d", *relDef.MaxOutgoing, relName, count),
 							Severity:   "error",
 						})
@@ -401,7 +421,7 @@ func (svc analyzeService) analyzeCardinality(ctx context.Context, meta *metamode
 						section.Issues = append(section.Issues, AnalysisIssue{
 							EntityID:   e.ID,
 							EntityType: e.Type,
-							Title:      safeDisplayTitle(meta, e),
+							Title:      safeHeaderTitle(meta, e),
 							Message:    fmt.Sprintf("Must have at least %d '%s' relation(s), has %d", *relDef.MinIncoming, relLabel, count),
 							Severity:   "error",
 						})
@@ -423,7 +443,7 @@ func (svc analyzeService) analyzeCardinality(ctx context.Context, meta *metamode
 						section.Issues = append(section.Issues, AnalysisIssue{
 							EntityID:   e.ID,
 							EntityType: e.Type,
-							Title:      safeDisplayTitle(meta, e),
+							Title:      safeHeaderTitle(meta, e),
 							Message:    fmt.Sprintf("Has more than %d '%s' relation(s): %d", *relDef.MaxIncoming, relLabel, count),
 							Severity:   "error",
 						})
@@ -443,27 +463,26 @@ func (svc analyzeService) analyzeProperties(ctx context.Context, meta *metamodel
 		Description: "Property validation errors (required fields, invalid values, ID patterns)",
 	}
 
-	entities := make([]*entity.Entity, 0)
-	for e, err := range svc.reads.ListEntities(ctx, store.EntityQuery{}) {
+	// Streams: an issue is emitted as its row is scanned, so peak memory is
+	// proportional to the ISSUES found, not to the entities examined. The
+	// previous shape drained every entity into a slice purely to sort it —
+	// sorting the (far smaller) issue list afterwards is equivalent, since
+	// each entity contributes a contiguous run of issues in ID order.
+	for h, err := range svc.reads.ListEntityHeaders(ctx, store.EntityQuery{}) {
 		if err != nil {
 			break
 		}
-		entities = append(entities, e)
-	}
-	sortStoreEntitiesByID(entities)
-
-	for _, e := range entities {
-		errs := meta.ValidateEntity(e.ID, e.Type, e.Properties)
-		for _, err := range errs {
+		for _, verr := range meta.ValidateEntity(h.ID, h.Type, h.Properties) {
 			section.Issues = append(section.Issues, AnalysisIssue{
-				EntityID:   e.ID,
-				EntityType: e.Type,
-				Title:      safeDisplayTitle(meta, e),
-				Message:    err.Error(),
+				EntityID:   h.ID,
+				EntityType: h.Type,
+				Title:      safeHeaderTitle(meta, h),
+				Message:    verr.Error(),
 				Severity:   "error",
 			})
 		}
 	}
+	sortIssuesByEntityID(section.Issues)
 
 	return section
 }
@@ -572,6 +591,42 @@ func safeDisplayTitle(meta *metamodel.Metamodel, e *entity.Entity) string {
 		}
 	}
 	return meta.DisplayTitle(e.ID, e.Type, e.Properties)
+}
+
+// sortHeadersByID is [sortStoreEntitiesByID] for content-free headers.
+func sortHeadersByID(headers []store.EntityHeader) {
+	sort.Slice(headers, func(i, j int) bool {
+		return natsort.Less(headers[i].ID, headers[j].ID)
+	})
+}
+
+// sortIssuesByEntityID orders issues by entity ID, naturally (so E-9 sorts
+// before E-10), preserving the relative order of issues that share an ID.
+//
+// STABLE deliberately: a streaming analyzer emits one entity's issues as a
+// contiguous run in metamodel-validation order, and a caller comparing
+// output against the pre-streaming implementation must see that run intact.
+// An unstable sort would shuffle the messages within an entity and turn a
+// pure refactor into a visible behavior change.
+func sortIssuesByEntityID(issues []AnalysisIssue) {
+	sort.SliceStable(issues, func(i, j int) bool {
+		return natsort.Less(issues[i].EntityID, issues[j].EntityID)
+	})
+}
+
+// safeHeaderTitle is [safeDisplayTitle] for a content-free header. Display
+// titles derive from ID, Type and Properties — never the body — so the two
+// agree by construction; this exists because the metamodel helpers take the
+// fields individually and a header is not an *entity.Entity.
+func safeHeaderTitle(meta *metamodel.Metamodel, h store.EntityHeader) string {
+	if def, ok := meta.GetEntityDef(h.Type); ok {
+		for _, prop := range def.DisplayProperties() {
+			if _, present := h.Properties[prop]; !present {
+				return h.ID // a display-title source was redacted → don't leak a partial title
+			}
+		}
+	}
+	return meta.DisplayTitle(h.ID, h.Type, h.Properties)
 }
 
 // normalizeTitle normalizes a title for duplicate comparison.

--- a/internal/dataentry/analyze.go
+++ b/internal/dataentry/analyze.go
@@ -240,14 +240,25 @@ func (svc analyzeService) analyzeOrphans(ctx context.Context, meta *metamodel.Me
 	// not — svc.tracer is gated too), no hidden entity reaches the wire. Do NOT
 	// emit an issue straight from an orphan id/type without this gated re-load —
 	// that would reopen the leak this arc closed (TKT-3FL2S6).
+	//
+	// The ids are sorted BEFORE loading, and loading stops one past the cap:
+	// a project where every entity is an orphan would otherwise re-load the
+	// entire store as full entities — 20k orphans of ~100 KB was ~930 MB of
+	// live heap, the single largest remaining contributor to the analyze OOM
+	// (TKT-1ESTYJ). Sorting first keeps WHICH orphans get reported
+	// deterministic and id-ordered rather than dependent on how far the load
+	// got.
+	natsort.Strings(orphanIDs)
 	var orphans []*entity.Entity
 	st := svc.reads
 	for _, id := range orphanIDs {
+		if len(orphans) > maxSectionIssues {
+			break
+		}
 		if e, err := st.GetEntity(ctx, id); err == nil {
 			orphans = append(orphans, e)
 		}
 	}
-	sortStoreEntitiesByID(orphans)
 
 	for _, e := range orphans {
 		section.Issues = append(section.Issues, AnalysisIssue{

--- a/internal/dataentry/analyze.go
+++ b/internal/dataentry/analyze.go
@@ -92,11 +92,62 @@ type AnalysisIssue struct {
 	ScriptError *lua.ScriptError
 }
 
+// maxSectionIssues caps how many issues one analyzer section reports.
+//
+// A section with more than this many findings is not actionable as a list —
+// nobody works through 12,000 duplicate-title warnings — and rendering them
+// costs memory and wire bytes on both sides for no benefit. The cap is HARD:
+// there is no query parameter to lift it, because "let me request all
+// 200,000" is the request that reintroduces the problem.
+//
+// Detection reads one issue PAST the cap (see [capIssues]): finding a 101st
+// is how truncation is known, and that extra row is discarded rather than
+// reported.
+const maxSectionIssues = 100
+
 // AnalysisSection groups issues by analysis category.
 type AnalysisSection struct {
 	Name        string
 	Description string
 	Issues      []AnalysisIssue
+
+	// Truncated reports that the analyzer found MORE issues than it
+	// returned, so the UI can say so.
+	//
+	// Surfaced rather than silent on purpose. An operator who fixes all
+	// 100 reported issues, re-runs, and sees 100 again would otherwise
+	// conclude analyze is broken. The exact total is deliberately NOT
+	// reported: counting every issue means doing all the work the cap
+	// exists to avoid, and "100+" is as actionable as "12,431".
+	Truncated bool
+}
+
+// capIssues trims a section's issues to [maxSectionIssues], setting
+// Truncated when there were more.
+//
+// Applied by analyzers that can only know their issue count at the end
+// (grouping analyzers). Streaming analyzers stop scanning at the cap
+// instead — see [sectionFull] — which is strictly better because it also
+// stops the work.
+func capIssues(section AnalysisSection) AnalysisSection {
+	if len(section.Issues) <= maxSectionIssues {
+		return section
+	}
+	section.Issues = section.Issues[:maxSectionIssues]
+	section.Truncated = true
+	return section
+}
+
+// sectionFull reports whether a streaming analyzer has collected enough
+// issues to stop scanning.
+//
+// Returns true only once the section holds MORE than the cap, so the
+// caller has positively observed an extra issue rather than inferring
+// truncation from reaching the limit exactly. A section with exactly
+// maxSectionIssues issues is complete, not truncated — the off-by-one that
+// would mislabel it is the whole reason this is a named helper.
+func sectionFull(section *AnalysisSection) bool {
+	return len(section.Issues) > maxSectionIssues
 }
 
 // ErrorCount returns the number of error-severity issues in this section.
@@ -152,8 +203,23 @@ func (svc analyzeService) runAnalysis(ctx context.Context, meta *metamodel.Metam
 	}
 }
 
-// analysisIssueCounts returns just the total error and warning counts
-// without building the full issue details. Used by the dashboard.
+// analysisIssueCounts returns the error and warning counts of a full
+// analysis run.
+//
+// COUNTS ARE CAPPED, not totals: it sums the sections runAnalysis returns,
+// and each of those stops at [maxSectionIssues] (TKT-1ESTYJ). A project
+// with 12,000 property errors reports at most 100 from that section. The
+// name predates the cap and now overstates what it returns.
+//
+// It also does not avoid any work despite the "without building the full
+// issue details" claim it used to carry — it calls runAnalysis and discards
+// everything but two integers.
+//
+// No production caller today (only its own test). If a dashboard badge ever
+// wants these numbers, give it a real count-only path — one that counts
+// without materializing issues and without the cap — rather than reusing
+// this; a silently-capped "12,431 problems" badge reading "200" is worse
+// than no badge.
 func (svc analyzeService) analysisIssueCounts(ctx context.Context, meta *metamodel.Metamodel) (errors, warnings int) {
 	result := svc.runAnalysis(ctx, meta)
 	return result.ErrorCount, result.WarningCount
@@ -193,7 +259,7 @@ func (svc analyzeService) analyzeOrphans(ctx context.Context, meta *metamodel.Me
 		})
 	}
 
-	return section
+	return capIssues(section)
 }
 
 // analyzeDuplicates finds entities with identical normalized titles.
@@ -246,7 +312,7 @@ func (svc analyzeService) analyzeDuplicates(ctx context.Context, meta *metamodel
 		}
 	}
 
-	return section
+	return capIssues(section)
 }
 
 // analyzeGaps finds gaps in ID sequences for auto-numbered entity types.
@@ -320,7 +386,7 @@ func (svc analyzeService) analyzeGaps(ctx context.Context, meta *metamodel.Metam
 		}
 	}
 
-	return section
+	return capIssues(section)
 }
 
 // analyzeCardinality checks relation cardinality constraints.
@@ -453,7 +519,7 @@ func (svc analyzeService) analyzeCardinality(ctx context.Context, meta *metamode
 		}
 	}
 
-	return section
+	return capIssues(section)
 }
 
 // analyzeProperties validates all entity properties against the metamodel.
@@ -481,10 +547,26 @@ func (svc analyzeService) analyzeProperties(ctx context.Context, meta *metamodel
 				Severity:   "error",
 			})
 		}
+		// Abandon the scan once one issue past the cap has been seen:
+		// stopping here is what keeps a pathological project cheap rather
+		// than merely quiet.
+		//
+		// WHICH issues survive is then "the first 100 in store order",
+		// which the sort below renders in natural order. Store order is
+		// ascending by id and natural order is not (E-10 precedes E-9
+		// lexicographically but follows it naturally), so on a truncated
+		// section the reported set is not necessarily the naturally-first
+		// 100. That is acceptable — the set is a bounded sample of a list
+		// too long to act on, flagged as truncated — but it is a real
+		// difference from sorting the complete set, so do not describe
+		// truncated output as "the first N issues".
+		if sectionFull(&section) {
+			break
+		}
 	}
 	sortIssuesByEntityID(section.Issues)
 
-	return section
+	return capIssues(section)
 }
 
 // analyzeValidations runs custom validation rules from the metamodel.
@@ -547,7 +629,7 @@ func (svc analyzeService) analyzeValidations(ctx context.Context, meta *metamode
 		}
 	}
 
-	return section
+	return capIssues(section)
 }
 
 // scriptErrorSummary builds a single-line summary for the AnalysisIssue

--- a/internal/dataentry/analyze_cap_test.go
+++ b/internal/dataentry/analyze_cap_test.go
@@ -1,0 +1,184 @@
+package dataentry
+
+import (
+	"context"
+	"fmt"
+	"iter"
+	"testing"
+
+	"github.com/Sourcehaven-BV/rela/internal/entity"
+	"github.com/Sourcehaven-BV/rela/internal/metamodel"
+	"github.com/Sourcehaven-BV/rela/internal/store"
+)
+
+// capMeta declares a type whose `title` is required, so seeding an entity
+// WITHOUT a title yields exactly one properties issue per entity — letting a
+// test dial the issue count precisely.
+func capMeta() *metamodel.Metamodel {
+	return &metamodel.Metamodel{
+		Entities: map[string]metamodel.EntityDef{
+			"doc": {Properties: map[string]metamodel.PropertyDef{
+				"title": {Type: "string", Required: true},
+			}},
+		},
+	}
+}
+
+// The cap's boundary is the whole risk: 100 must report in full, 101 must
+// report 100 AND say so. An off-by-one either drops a legitimate issue or
+// labels a complete list as truncated, and both are silent in production.
+func TestAnalyzeProperties_CapBoundary(t *testing.T) {
+	for _, tc := range []struct {
+		seeded        int
+		wantIssues    int
+		wantTruncated bool
+	}{
+		{seeded: 0, wantIssues: 0, wantTruncated: false},
+		{seeded: 99, wantIssues: 99, wantTruncated: false},
+		{seeded: 100, wantIssues: 100, wantTruncated: false},
+		{seeded: 101, wantIssues: 100, wantTruncated: true},
+		{seeded: 500, wantIssues: 100, wantTruncated: true},
+	} {
+		t.Run(fmt.Sprintf("seeded=%d", tc.seeded), func(t *testing.T) {
+			g := newFixture()
+			meta := capMeta()
+			for i := range tc.seeded {
+				// No title → one required-property error each.
+				g.AddNode(&entity.Entity{
+					ID: fmt.Sprintf("D-%05d", i), Type: "doc",
+					Properties: map[string]any{},
+				})
+			}
+			svc := newAnalyzeService(t, g, meta)
+			section := svc.analyzeProperties(context.Background(), meta)
+
+			if len(section.Issues) != tc.wantIssues {
+				t.Errorf("issues: want %d, got %d", tc.wantIssues, len(section.Issues))
+			}
+			if section.Truncated != tc.wantTruncated {
+				t.Errorf("truncated: want %v, got %v", tc.wantTruncated, section.Truncated)
+			}
+		})
+	}
+}
+
+// The grouping analyzer caps too, via a different mechanism (it cannot stop
+// early), so its boundary is asserted independently rather than assumed to
+// follow from the streaming one.
+func TestAnalyzeDuplicates_CapBoundary(t *testing.T) {
+	for _, tc := range []struct {
+		seeded        int
+		wantIssues    int
+		wantTruncated bool
+	}{
+		{seeded: 100, wantIssues: 100, wantTruncated: false},
+		{seeded: 101, wantIssues: 100, wantTruncated: true},
+	} {
+		t.Run(fmt.Sprintf("seeded=%d", tc.seeded), func(t *testing.T) {
+			g := newFixture()
+			meta := capMeta()
+			// Every entity shares a title, so all of them are duplicates.
+			for i := range tc.seeded {
+				g.AddNode(&entity.Entity{
+					ID: fmt.Sprintf("D-%05d", i), Type: "doc",
+					Properties: map[string]any{"title": "same"},
+				})
+			}
+			svc := newAnalyzeService(t, g, meta)
+			section := svc.analyzeDuplicates(context.Background(), meta)
+
+			if len(section.Issues) != tc.wantIssues {
+				t.Errorf("issues: want %d, got %d", tc.wantIssues, len(section.Issues))
+			}
+			if section.Truncated != tc.wantTruncated {
+				t.Errorf("truncated: want %v, got %v", tc.wantTruncated, section.Truncated)
+			}
+		})
+	}
+}
+
+// Truncation must never be silent: a capped section has to reach the wire
+// flagged, or an operator fixing all 100 and seeing 100 again concludes the
+// tool is broken.
+func TestAnalyzeResult_ReportsTruncatedChecks(t *testing.T) {
+	g := newFixture()
+	meta := capMeta()
+	for i := range 150 {
+		g.AddNode(&entity.Entity{
+			ID: fmt.Sprintf("D-%05d", i), Type: "doc",
+			Properties: map[string]any{},
+		})
+	}
+	svc := newAnalyzeService(t, g, meta)
+	result := svc.runAnalysis(context.Background(), meta)
+
+	var truncated []string
+	for _, s := range result.Sections {
+		if s.Truncated {
+			truncated = append(truncated, s.Name)
+		}
+	}
+	if len(truncated) == 0 {
+		t.Fatal("expected at least one section to report truncation")
+	}
+	for _, s := range result.Sections {
+		if len(s.Issues) > maxSectionIssues {
+			t.Errorf("section %q returned %d issues, above the cap of %d",
+				s.Name, len(s.Issues), maxSectionIssues)
+		}
+	}
+}
+
+// A capped run must not scan the whole store: the cap exists to bound WORK,
+// not merely output. Asserted by counting rows the analyzer pulled.
+func TestAnalyzeProperties_StopsScanningAtCap(t *testing.T) {
+	g := newFixture()
+	meta := capMeta()
+	const seeded = 5000
+	for i := range seeded {
+		g.AddNode(&entity.Entity{
+			ID: fmt.Sprintf("D-%05d", i), Type: "doc",
+			Properties: map[string]any{},
+		})
+	}
+	svc := newAnalyzeService(t, g, meta)
+	counter := &countingAnalyzeReader{inner: svc.reads}
+	svc.reads = counter
+
+	section := svc.analyzeProperties(context.Background(), meta)
+
+	if len(section.Issues) != maxSectionIssues {
+		t.Fatalf("expected %d issues, got %d", maxSectionIssues, len(section.Issues))
+	}
+	// One row past the cap is read to DETECT truncation; anything close to
+	// the full 5000 means the early break regressed.
+	if counter.rows > maxSectionIssues+2 {
+		t.Errorf("scanned %d rows for a %d-issue cap — the analyzer should stop "+
+			"once truncation is detected, not drain the store", counter.rows, maxSectionIssues)
+	}
+}
+
+// countingAnalyzeReader counts rows yielded, so a test can assert the
+// analyzer stopped scanning rather than merely trimmed its output.
+type countingAnalyzeReader struct {
+	inner analyzeReader
+	rows  int
+}
+
+func (c *countingAnalyzeReader) GetEntity(ctx context.Context, id string) (*entity.Entity, error) {
+	return c.inner.GetEntity(ctx, id)
+}
+
+func (c *countingAnalyzeReader) ListEntityHeaders(
+	ctx context.Context, q store.EntityQuery,
+) iter.Seq2[store.EntityHeader, error] {
+	src := c.inner.ListEntityHeaders(ctx, q)
+	return func(yield func(store.EntityHeader, error) bool) {
+		for h, err := range src {
+			c.rows++
+			if !yield(h, err) {
+				return
+			}
+		}
+	}
+}

--- a/internal/dataentry/analyze_test.go
+++ b/internal/dataentry/analyze_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Sourcehaven-BV/rela/internal/metamodel"
 	"github.com/Sourcehaven-BV/rela/internal/project"
 	"github.com/Sourcehaven-BV/rela/internal/storage"
+	"github.com/Sourcehaven-BV/rela/internal/visibility"
 )
 
 // newAnalyzeService builds an analyzeService directly from a fixture + meta,
@@ -26,7 +27,7 @@ func newAnalyzeService(t *testing.T, f *fixture, meta *metamodel.Metamodel) anal
 	}
 	svc := appbuildtest.New(meta, appbuildtest.WithFS(fs, ctx))
 	seedFromFixture(svc.Store(), f)
-	return analyzeService{reads: svc.Store(), relCounts: svc.Store(), tracer: svc.Tracer(), validator: svc.Validator()}
+	return analyzeService{reads: visibility.Unrestricted(svc.Store()), relCounts: svc.Store(), tracer: svc.Tracer(), validator: svc.Validator()}
 }
 
 func TestAnalyzeOrphans(t *testing.T) {

--- a/internal/dataentry/api_v1.go
+++ b/internal/dataentry/api_v1.go
@@ -1427,6 +1427,14 @@ func (a *App) handleV1Analyze(w http.ResponseWriter, r *http.Request) {
 		ByCheck: make(map[string]int),
 	}
 
+	// Carry each section's truncation flag onto the flat response, so a
+	// capped check is visibly incomplete rather than silently short.
+	for _, section := range analysisResult.Sections {
+		if section.Truncated {
+			result.TruncatedChecks = append(result.TruncatedChecks, section.Name)
+		}
+	}
+
 	// Loopback gate: same policy as action / document surfaces.
 	// Non-loopback callers get a degraded envelope on script-error
 	// issues (no source slice, no stack, no captured output).

--- a/internal/dataentry/app.go
+++ b/internal/dataentry/app.go
@@ -406,6 +406,36 @@ func (r lateGatedReader) ListEntities(ctx context.Context, q store.EntityQuery) 
 	return r.reader().ListEntities(ctx, q)
 }
 
+// ListEntityHeaders resolves the gated reader per call like the rest of this
+// type, then uses its header path when it has one.
+//
+// The type assertion is not a gate decision: every reader gatedScriptReader
+// can return (ScriptReader, UnrestrictedReader, DenyReader) implements the
+// header surface, so the fallback below is unreachable in production wiring
+// and exists only so a narrower test double stays valid. It degrades to
+// whole-entity gating — more data read, never less gating.
+func (r lateGatedReader) ListEntityHeaders(
+	ctx context.Context, q store.EntityQuery,
+) iter.Seq2[store.EntityHeader, error] {
+	reader := r.reader()
+	if hr, ok := reader.(interface {
+		ListEntityHeaders(context.Context, store.EntityQuery) iter.Seq2[store.EntityHeader, error]
+	}); ok {
+		return hr.ListEntityHeaders(ctx, q)
+	}
+	return func(yield func(store.EntityHeader, error) bool) {
+		for e, err := range reader.ListEntities(ctx, q) {
+			if err != nil {
+				yield(store.EntityHeader{}, err)
+				return
+			}
+			if !yield(store.HeaderOf(e), nil) {
+				return
+			}
+		}
+	}
+}
+
 func (r lateGatedReader) ListRelations(ctx context.Context, q store.RelationQuery) iter.Seq2[*entity.Relation, error] {
 	return r.reader().ListRelations(ctx, q)
 }

--- a/internal/dataentry/helpers.go
+++ b/internal/dataentry/helpers.go
@@ -690,6 +690,19 @@ func listFromStoreByTypes(ctx context.Context, svc Services, types []string) []*
 }
 
 // listAllFromStore drains every entity from the store.
+//
+// UNBOUNDED, and the same shape that made GET /api/v1/_analyze an OOM
+// (TKT-1ESTYJ): whole entities, bodies included, retained in one slice. It
+// is currently safe only because nothing reaches it with an empty type
+// list — both listFromStoreByTypes callers pass exactly one type, and a
+// list's entity_type is required and validated at load.
+//
+// So this is left as-is rather than migrated: the analyze fix removed the
+// live O(store) retention, and rewriting a path with no reachable caller
+// would be churn. If a caller ever DOES pass an empty type list, this
+// becomes a live whole-store drain — at that point it wants
+// store.ListEntityHeaders (if the caller reads no bodies) or paging, not a
+// bigger slice.
 func listAllFromStore(ctx context.Context, svc Services) []*entity.Entity {
 	out := make([]*entity.Entity, 0)
 	for e, err := range svc.Store.ListEntities(ctx, store.EntityQuery{}) {

--- a/internal/dataentry/settings_handlers.go
+++ b/internal/dataentry/settings_handlers.go
@@ -20,6 +20,19 @@ type APIAnalysisResult struct {
 	Warnings int            `json:"warnings"`
 	Issues   []APIIssue     `json:"issues"`
 	ByCheck  map[string]int `json:"byCheck"`
+
+	// TruncatedChecks names the checks that found more issues than they
+	// returned, so the UI can mark those lists as incomplete (TKT-1ESTYJ).
+	//
+	// Per-CHECK rather than one global flag: "duplicates is truncated" is
+	// actionable where "something was truncated" is not, and the response
+	// is a flat issue list, so the section-level flag would otherwise be
+	// lost. Empty (omitted) when every check reported in full.
+	//
+	// Counts in ByCheck are counts of RETURNED issues; for a truncated
+	// check that is the cap, not the true total, which is deliberately
+	// not computed.
+	TruncatedChecks []string `json:"truncatedChecks,omitempty"`
 }
 
 // APIIssue is the JSON representation of a single analysis issue.

--- a/internal/store/memstore/memstore.go
+++ b/internal/store/memstore/memstore.go
@@ -48,8 +48,14 @@ import (
 // unexported core so Tx callbacks can re-enter. Interface-driven, not
 // accreted sprawl; ratchets with the interface.
 //
-//plimsoll:max-methods=42
-//plimsoll:max-exported-methods=28
+// +1 for ListEntityHeaders (TKT-1ESTYJ): the store.HeaderReader capability,
+// a content-free ListEntities. Implemented natively rather than left to the
+// generic fallback because the fallback would clone each entity — bodies
+// included — only to drop the body immediately, which is the cost the
+// capability exists to remove. Interface-driven like the Tx split above.
+//
+//plimsoll:max-methods=43
+//plimsoll:max-exported-methods=29
 type MemStore struct {
 	// txMu serializes an open Tx against ordinary writers: Tx holds it
 	// for the whole callback, every exported write method takes it

--- a/internal/store/memstore/memstore.go
+++ b/internal/store/memstore/memstore.go
@@ -217,6 +217,45 @@ func (m *MemStore) ListEntities(_ context.Context, q store.EntityQuery) iter.Seq
 	}
 }
 
+// ListEntityHeaders implements store.HeaderReader. Like ListEntities it
+// snapshots under the read lock (so the iterator never holds it), but copies
+// only the header fields — the body string is not carried into the snapshot,
+// and Properties are cloned so a caller cannot mutate stored state through a
+// header.
+//
+// The generic fallback would clone each ENTITY (bodies included) just to
+// discard the content a moment later; this keeps a whole-store scan
+// proportional to ids and properties rather than to markdown.
+func (m *MemStore) ListEntityHeaders(
+	_ context.Context, q store.EntityQuery,
+) iter.Seq2[store.EntityHeader, error] {
+	m.mu.RLock()
+	idSet := entityIDSet(q.IDs)
+
+	snapshot := make([]store.EntityHeader, 0)
+	for _, id := range m.entityOrder {
+		e := m.entities[id]
+		if !matchEntityQuery(e, q, idSet) {
+			continue
+		}
+		snapshot = append(snapshot, store.EntityHeader{
+			ID:         e.ID,
+			Type:       e.Type,
+			Properties: maps.Clone(e.Properties),
+			UpdatedAt:  e.UpdatedAt,
+		})
+	}
+	m.mu.RUnlock()
+
+	return func(yield func(store.EntityHeader, error) bool) {
+		for _, h := range snapshot {
+			if !yield(h, nil) {
+				return
+			}
+		}
+	}
+}
+
 func (m *MemStore) ListEntitiesPage(_ context.Context, q store.EntityQuery) (store.Page[*entity.Entity], error) {
 	cursorKey, err := storeutil.DecodeCursor(q.Cursor)
 	if err != nil {

--- a/internal/store/pgstore/entity.go
+++ b/internal/store/pgstore/entity.go
@@ -61,6 +61,41 @@ func (s *Store) ListEntities(ctx context.Context, q store.EntityQuery) iter.Seq2
 	}
 }
 
+// ListEntityHeaders implements store.HeaderReader: the same listing as
+// ListEntities with the content column left OUT of the SELECT, so entity
+// bodies are never read from disk, never cross the wire, and never land in
+// a pgx scan buffer.
+//
+// This is the point of the capability — the generic fallback in
+// store.ListEntityHeaders bounds only retention, whereas here a 20k-row
+// scan over ~2 GB of markdown transfers a few MB of ids and properties.
+func (s *Store) ListEntityHeaders(
+	ctx context.Context, q store.EntityQuery,
+) iter.Seq2[store.EntityHeader, error] {
+	sql, args := buildEntityHeaderListSQL(q, "")
+	return func(yield func(store.EntityHeader, error) bool) {
+		rows, err := s.db.Query(ctx, sql, args...)
+		if err != nil {
+			yield(store.EntityHeader{}, err)
+			return
+		}
+		defer rows.Close()
+		for rows.Next() {
+			h, err := scanEntityHeader(rows)
+			if err != nil {
+				yield(store.EntityHeader{}, err)
+				return
+			}
+			if !yield(h, nil) {
+				return
+			}
+		}
+		if err := rows.Err(); err != nil {
+			yield(store.EntityHeader{}, err)
+		}
+	}
+}
+
 // ListEntitiesPage returns a page of entities. A keyset cursor on id keeps
 // pages stable; see store.ListEntitiesPage for the contract.
 func (s *Store) ListEntitiesPage(ctx context.Context, q store.EntityQuery) (store.Page[*entity.Entity], error) {
@@ -550,12 +585,37 @@ func scanEntity(row scanner) (*entity.Entity, error) {
 	return e, nil
 }
 
+func scanEntityHeader(row scanner) (store.EntityHeader, error) {
+	var (
+		id, typ   string
+		props     []byte
+		updatedAt time.Time
+	)
+	if err := row.Scan(&id, &typ, &props, &updatedAt); err != nil {
+		return store.EntityHeader{}, err
+	}
+	h := store.EntityHeader{ID: id, Type: typ, UpdatedAt: updatedAt}
+	var err error
+	if h.Properties, err = unmarshalProps(props); err != nil {
+		return store.EntityHeader{}, err
+	}
+	return h, nil
+}
+
 // buildEntityListSQL builds the SELECT + WHERE + ORDER BY for entity listings.
 // keysetAfter, when non-empty, adds "id > $n" so pagination resumes after a
 // cursor. Ordering is ascending by id (the contract's default stable order).
 func buildEntityListSQL(q store.EntityQuery, keysetAfter string) (sql string, args []any) {
 	where, args := entityWhere(q, keysetAfter)
 	sql = `SELECT id, type, properties, content, updated_at FROM entities` + where + ` ORDER BY id ASC`
+	return sql, args
+}
+
+// buildEntityHeaderListSQL mirrors buildEntityListSQL WITHOUT the content
+// column. Column order must stay in sync with scanEntityHeader.
+func buildEntityHeaderListSQL(q store.EntityQuery, keysetAfter string) (sql string, args []any) {
+	where, args := entityWhere(q, keysetAfter)
+	sql = `SELECT id, type, properties, updated_at FROM entities` + where + ` ORDER BY id ASC`
 	return sql, args
 }
 

--- a/internal/store/pgstore/pgstore.go
+++ b/internal/store/pgstore/pgstore.go
@@ -78,8 +78,15 @@ type DBTX interface {
 // store pattern this refactor removed. Consumers reach versioning through the
 // injected store.VersionService, never by asserting a capability on the store.
 //
-//plimsoll:max-exported-methods=33
-//plimsoll:max-methods=41
+// +1 for ListEntityHeaders (TKT-1ESTYJ): the store.HeaderReader capability,
+// which omits the content column from the SELECT so entity bodies never
+// leave the database on scans that only read ids and properties. It belongs
+// on *Store — unlike versioning, it is a plain read of the entities table,
+// not a separate service — and the whole point is the backend-native
+// projection, which cannot be delegated elsewhere.
+//
+//plimsoll:max-exported-methods=34
+//plimsoll:max-methods=42
 type Store struct {
 	db        DBTX
 	observers []store.EntityObserver // notified synchronously after committed entity writes

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -396,6 +396,97 @@ type AttachmentManager interface {
 	ListAttachments(ctx context.Context, entityID string) ([]AttachmentInfo, error)
 }
 
+// EntityHeader is an entity WITHOUT its body content.
+//
+// It exists so whole-store scans that only need identity and properties —
+// analyze checks, ID generation, list projections — never materialize
+// markdown bodies they will not read. On a 20k-entity store with ~100 KB
+// bodies that is the difference between ~2 GB and a few MB.
+//
+// A SEPARATE TYPE, not an [entity.Entity] with Content left empty, and that
+// is the whole point (TKT-1ESTYJ). A half-populated Entity satisfies every
+// interface an Entity satisfies and lies to all of them: hand one to
+// dataentry's computeEntityETag, which hashes e.Content, and it returns a
+// well-formed ETag for the wrong bytes — silently breaking conditional
+// requests and caching. There are hundreds of `.Content` reads across the
+// tree; a bool flag on [EntityQuery] would make every one of them a latent
+// bug. With a distinct type the compiler rejects the mistake instead.
+//
+// Do not add a Content field. If a caller needs the body it wants
+// [EntityReader.GetEntity] or [EntityReader.ListEntities], and the fact that
+// it must say so explicitly is the guardrail working.
+type EntityHeader struct {
+	ID         string
+	Type       string
+	Properties map[string]any
+	UpdatedAt  time.Time
+
+	// Redacted mirrors [entity.Entity.Redacted]: the properties withheld
+	// from the reading principal by field-level ACL. Carried so a gated
+	// header read reports redaction exactly like a gated entity read —
+	// a header must never look MORE complete than the entity it projects.
+	Redacted []string
+}
+
+// HeaderReader lists entities without their body content.
+//
+// OPTIONAL capability, type-asserted at the call site like [Formatter] —
+// not part of [Store]. Backends that can project the body away in the query
+// (pgstore: omit the content column) implement it; others are served by
+// [ListEntityHeaders], the generic fallback that drops content in-process.
+//
+// Callers should use [ListEntityHeaders] rather than asserting themselves,
+// so the fallback stays a detail of this package.
+type HeaderReader interface {
+	// ListEntityHeaders returns an iterator over content-free headers for
+	// entities matching the query. Ordering and error semantics match
+	// [EntityReader.ListEntities]; Cursor and Limit are likewise ignored.
+	ListEntityHeaders(ctx context.Context, q EntityQuery) iter.Seq2[EntityHeader, error]
+}
+
+// HeaderOf projects an entity onto its content-free header.
+//
+// The Properties map is shared, not cloned: every caller of this and of
+// [ListEntityHeaders] treats headers as read-only, and cloning a map per row
+// would reintroduce a per-entity allocation on the very path that exists to
+// avoid one. Do not mutate a header's Properties.
+func HeaderOf(e *entity.Entity) EntityHeader {
+	return EntityHeader{
+		ID:         e.ID,
+		Type:       e.Type,
+		Properties: e.Properties,
+		UpdatedAt:  e.UpdatedAt,
+		Redacted:   e.Redacted,
+	}
+}
+
+// ListEntityHeaders lists content-free entity headers from any reader.
+//
+// Uses the reader's native [HeaderReader] when it has one, so the body never
+// leaves the backend; otherwise falls back to [EntityReader.ListEntities] and
+// projects each row as it is yielded. The fallback bounds RETENTION (rows are
+// converted and released one at a time, never accumulated) but not transfer —
+// a backend without the capability still reads bodies off disk or the wire.
+// Do not describe the fallback as bounding I/O.
+func ListEntityHeaders(
+	ctx context.Context, r EntityReader, q EntityQuery,
+) iter.Seq2[EntityHeader, error] {
+	if hr, ok := r.(HeaderReader); ok {
+		return hr.ListEntityHeaders(ctx, q)
+	}
+	return func(yield func(EntityHeader, error) bool) {
+		for e, err := range r.ListEntities(ctx, q) {
+			if err != nil {
+				yield(EntityHeader{}, err)
+				return
+			}
+			if !yield(HeaderOf(e), nil) {
+				return
+			}
+		}
+	}
+}
+
 // Formatter checks whether an entity/relation's persisted representation
 // is up to date with its canonical format. Optionally applies the format.
 //

--- a/internal/store/storetest/header.go
+++ b/internal/store/storetest/header.go
@@ -1,0 +1,153 @@
+package storetest
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/Sourcehaven-BV/rela/internal/entity"
+	"github.com/Sourcehaven-BV/rela/internal/store"
+)
+
+// RunHeaderTests runs conformance tests for content-free header listing
+// (TKT-1ESTYJ).
+//
+// Every backend must pass these, whether it implements store.HeaderReader
+// natively or is served by the generic fallback: store.ListEntityHeaders
+// picks the path, and the OBSERVABLE contract is identical either way. That
+// equivalence is the point — a caller must never have to know which it got.
+func RunHeaderTests(t *testing.T, f Factory) {
+	t.Run("HeadersMatchEntitiesMinusContent", func(t *testing.T) {
+		s := f(t)
+		for _, id := range []string{"A-001", "A-002", "B-001"} {
+			e := entity.New(id, typeOf(id))
+			e.SetString("title", "title of "+id)
+			e.Content = "# body of " + id + "\n\n" + strings.Repeat("filler ", 100)
+			require.NoError(t, s.CreateEntity(ctx(), e))
+		}
+
+		// The header set must agree with the entity set on identity and
+		// properties, so a caller can swap one for the other without
+		// re-deriving what it may rely on.
+		wantIDs := make([]string, 0)
+		wantProps := map[string]string{}
+		for e, err := range s.ListEntities(ctx(), store.EntityQuery{}) {
+			require.NoError(t, err)
+			wantIDs = append(wantIDs, e.ID)
+			wantProps[e.ID] = e.GetString("title")
+		}
+
+		gotIDs := make([]string, 0)
+		for h, err := range store.ListEntityHeaders(ctx(), s, store.EntityQuery{}) {
+			require.NoError(t, err)
+			gotIDs = append(gotIDs, h.ID)
+			assert.Equal(t, typeOf(h.ID), h.Type, "header type for %s", h.ID)
+			assert.Equal(t, wantProps[h.ID], asString(h.Properties["title"]),
+				"header properties must match the entity's for %s", h.ID)
+			assert.False(t, h.UpdatedAt.IsZero(), "header UpdatedAt must be populated for %s", h.ID)
+		}
+
+		// Same members AND same order: ListEntities promises a stable
+		// ascending-by-id order, and headers are the same listing with a
+		// column removed — a caller that sorts by neither must still see
+		// both paths agree.
+		assert.Equal(t, wantIDs, gotIDs)
+	})
+
+	t.Run("FiltersByType", func(t *testing.T) {
+		s := f(t)
+		for _, id := range []string{"A-001", "A-002", "B-001"} {
+			e := entity.New(id, typeOf(id))
+			e.Content = "body"
+			require.NoError(t, s.CreateEntity(ctx(), e))
+		}
+
+		got := make([]string, 0)
+		for h, err := range store.ListEntityHeaders(ctx(), s, store.EntityQuery{Type: "atype"}) {
+			require.NoError(t, err)
+			got = append(got, h.ID)
+		}
+		assert.Equal(t, []string{"A-001", "A-002"}, got)
+	})
+
+	t.Run("FiltersByIDs", func(t *testing.T) {
+		s := f(t)
+		for _, id := range []string{"A-001", "A-002", "B-001"} {
+			e := entity.New(id, typeOf(id))
+			require.NoError(t, s.CreateEntity(ctx(), e))
+		}
+
+		got := make([]string, 0)
+		for h, err := range store.ListEntityHeaders(ctx(), s, store.EntityQuery{IDs: []string{"A-002", "B-001"}}) {
+			require.NoError(t, err)
+			got = append(got, h.ID)
+		}
+		assert.Equal(t, []string{"A-002", "B-001"}, got)
+	})
+
+	t.Run("EmptyStoreYieldsNothing", func(t *testing.T) {
+		s := f(t)
+		n := 0
+		for _, err := range store.ListEntityHeaders(ctx(), s, store.EntityQuery{}) {
+			require.NoError(t, err)
+			n++
+		}
+		assert.Zero(t, n)
+	})
+
+	// A header must not expose stored state by reference: a caller that
+	// mutates what it reads would corrupt the store through a read-only API.
+	// (The in-package HeaderOf projection shares the map deliberately and is
+	// documented read-only; a STORE listing has no such caller contract.)
+	t.Run("MutatingHeaderPropsDoesNotAffectStore", func(t *testing.T) {
+		s := f(t)
+		e := entity.New("A-001", "atype")
+		e.SetString("title", "original")
+		require.NoError(t, s.CreateEntity(ctx(), e))
+
+		for h, err := range store.ListEntityHeaders(ctx(), s, store.EntityQuery{}) {
+			require.NoError(t, err)
+			h.Properties["title"] = "mutated"
+		}
+
+		got, err := s.GetEntity(ctx(), "A-001")
+		require.NoError(t, err)
+		assert.Equal(t, "original", got.GetString("title"),
+			"mutating a header's Properties must not write through to the store")
+	})
+
+	// Early return from the caller's loop must stop the iteration cleanly:
+	// analyze caps a section at N issues and abandons the rest of the scan,
+	// so a backend that ignores a false yield would keep working after the
+	// consumer stopped caring.
+	t.Run("StopsOnEarlyReturn", func(t *testing.T) {
+		s := f(t)
+		for _, id := range []string{"A-001", "A-002", "B-001"} {
+			require.NoError(t, s.CreateEntity(ctx(), entity.New(id, typeOf(id))))
+		}
+
+		seen := 0
+		for _, err := range store.ListEntityHeaders(ctx(), s, store.EntityQuery{}) {
+			require.NoError(t, err)
+			seen++
+			break
+		}
+		assert.Equal(t, 1, seen)
+	})
+}
+
+// typeOf maps the fixture id prefix to a type, so the type filter has
+// something to discriminate on.
+func typeOf(id string) string {
+	if strings.HasPrefix(id, "A-") {
+		return "atype"
+	}
+	return "btype"
+}
+
+func asString(v any) string {
+	s, _ := v.(string)
+	return s
+}

--- a/internal/store/storetest/storetest.go
+++ b/internal/store/storetest/storetest.go
@@ -149,6 +149,7 @@ func countRelations(t *testing.T, s store.Store) int {
 // Capabilities gates optional feature tests (e.g. attachments).
 func RunAll(t *testing.T, f Factory, sf SearchFactory, vsf VisibleSearchFactory, caps Capabilities) {
 	t.Run("Entity", func(t *testing.T) { RunEntityTests(t, f) })
+	t.Run("Header", func(t *testing.T) { RunHeaderTests(t, f) })
 	t.Run("Relation", func(t *testing.T) { RunRelationTests(t, f) })
 	t.Run("Query", func(t *testing.T) { RunQueryTests(t, f) })
 	t.Run("GraphQuery", func(t *testing.T) { RunGraphQueryTests(t, f) })

--- a/internal/tracer/tracer.go
+++ b/internal/tracer/tracer.go
@@ -278,17 +278,20 @@ func clonePath(p []PathStep) []PathStep {
 }
 
 func (t *GenericTracer) FindOrphans(ctx context.Context) ([]string, error) {
+	// Headers, not entities: this scans the WHOLE store and reads nothing
+	// but e.ID, so loading markdown bodies to discard them made an orphan
+	// check cost the size of the project's content (TKT-1ESTYJ).
 	var orphans []string
-	for e, err := range t.r.ListEntities(ctx, store.EntityQuery{}) {
+	for h, err := range store.ListEntityHeaders(ctx, t.r, store.EntityQuery{}) {
 		if err != nil {
 			return nil, err
 		}
-		n, err := t.r.CountRelations(ctx, store.RelationQuery{EntityID: e.ID, Direction: store.DirectionBoth})
+		n, err := t.r.CountRelations(ctx, store.RelationQuery{EntityID: h.ID, Direction: store.DirectionBoth})
 		if err != nil {
 			return nil, err
 		}
 		if n == 0 {
-			orphans = append(orphans, e.ID)
+			orphans = append(orphans, h.ID)
 		}
 	}
 	return orphans, nil

--- a/internal/visibility/allowall.go
+++ b/internal/visibility/allowall.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 
 	"github.com/Sourcehaven-BV/rela/internal/entity"
+	"github.com/Sourcehaven-BV/rela/internal/store"
 )
 
 // AllowAllReader is the explicit pass-through [Reader] capability for
@@ -49,6 +50,15 @@ func (r *AllowAllReader) Get(ctx context.Context, entityType, id string) (*entit
 
 // Filter implements [Reader]: pass-through, input returned unchanged.
 func (r *AllowAllReader) Filter(_ context.Context, candidates []*entity.Entity) []*entity.Entity {
+	return candidates
+}
+
+// FilterHeaders implements [HeaderFilterer]: pass-through, input returned
+// unchanged — the same allow-all capability [Filter] grants, applied to
+// content-free headers.
+func (r *AllowAllReader) FilterHeaders(
+	_ context.Context, candidates []store.EntityHeader,
+) []store.EntityHeader {
 	return candidates
 }
 

--- a/internal/visibility/denyreader.go
+++ b/internal/visibility/denyreader.go
@@ -47,6 +47,17 @@ func (DenyReader) ListEntities(
 	}
 }
 
+// ListEntityHeaders implements the script read surface: always refuses.
+// Fail-closed like every other DenyReader method — a reader that cannot
+// gate must not hand back rows, headers included.
+func (DenyReader) ListEntityHeaders(
+	context.Context, store.EntityQuery,
+) iter.Seq2[store.EntityHeader, error] {
+	return func(yield func(store.EntityHeader, error) bool) {
+		yield(store.EntityHeader{}, ErrReaderUnavailable)
+	}
+}
+
 // ListRelations implements the script read surface: always refuses.
 func (DenyReader) ListRelations(
 	context.Context, store.RelationQuery,

--- a/internal/visibility/headerreader_test.go
+++ b/internal/visibility/headerreader_test.go
@@ -1,0 +1,211 @@
+package visibility_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/Sourcehaven-BV/rela/internal/entity"
+	"github.com/Sourcehaven-BV/rela/internal/store"
+	"github.com/Sourcehaven-BV/rela/internal/store/memstore"
+	"github.com/Sourcehaven-BV/rela/internal/visibility"
+)
+
+// The header path must gate EXACTLY like the entity path. Anything else is a
+// read-side ACL divergence, which is the failure mode this whole package
+// exists to prevent — so this is asserted as equivalence against
+// ListEntities rather than against a hand-written expectation that could
+// drift from the real gate.
+func TestScriptReader_ListEntityHeadersGatesLikeListEntities(t *testing.T) {
+	st := seedScriptWorld(t)
+	sr := newTicketOnlyScriptReader(t, st)
+	ctx := context.Background()
+
+	for _, q := range []struct {
+		name  string
+		query store.EntityQuery
+	}{
+		{"all types", store.EntityQuery{}},
+		{"readable type", store.EntityQuery{Type: "ticket"}},
+		{"hidden type", store.EntityQuery{Type: "secret"}},
+		{"by id, mixed visibility", store.EntityQuery{IDs: []string{"TKT-1", "SEC-1"}}},
+	} {
+		t.Run(q.name, func(t *testing.T) {
+			var wantIDs []string
+			for e, err := range sr.ListEntities(ctx, q.query) {
+				if err != nil {
+					t.Fatalf("ListEntities: %v", err)
+				}
+				wantIDs = append(wantIDs, e.ID)
+			}
+
+			var gotIDs []string
+			for h, err := range sr.ListEntityHeaders(ctx, q.query) {
+				if err != nil {
+					t.Fatalf("ListEntityHeaders: %v", err)
+				}
+				gotIDs = append(gotIDs, h.ID)
+			}
+
+			if fmt.Sprint(wantIDs) != fmt.Sprint(gotIDs) {
+				t.Errorf("header gating diverged from entity gating:\n entities=%v\n headers =%v",
+					wantIDs, gotIDs)
+			}
+			// Belt and braces: the hidden type must never appear, whatever
+			// the equivalence above says.
+			for _, id := range gotIDs {
+				if id == "SEC-1" {
+					t.Error("hidden entity SEC-1 leaked through the header path")
+				}
+			}
+		})
+	}
+}
+
+// Field redaction must apply to headers too: "may read every row of this
+// type" is not "may see every property" (RR-OXE47R). A header that skipped
+// redaction would be MORE revealing than the entity read it replaces.
+func TestScriptReader_ListEntityHeadersRedactsFields(t *testing.T) {
+	ctx := context.Background()
+	st := memstore.New()
+	if err := st.CreateEntity(ctx, &entity.Entity{
+		ID: "TKT-1", Type: "ticket",
+		Properties: map[string]any{"title": "One", "secret": "hunter2"},
+	}); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	reader, err := visibility.NewPolicyReader(
+		typeGate{allow: "ticket"}, hidePropRedactor{name: "secret"}, st)
+	if err != nil {
+		t.Fatalf("NewPolicyReader: %v", err)
+	}
+	sr, err := visibility.NewScriptReader(reader, st, nil)
+	if err != nil {
+		t.Fatalf("NewScriptReader: %v", err)
+	}
+
+	n := 0
+	for h, err := range sr.ListEntityHeaders(ctx, store.EntityQuery{}) {
+		if err != nil {
+			t.Fatalf("ListEntityHeaders: %v", err)
+		}
+		n++
+		if _, present := h.Properties["secret"]; present {
+			t.Error("hidden property value survived into a header")
+		}
+		if h.Properties["title"] != "One" {
+			t.Errorf("visible property lost: %v", h.Properties["title"])
+		}
+		if len(h.Redacted) != 1 || h.Redacted[0] != "secret" {
+			t.Errorf("header must report what was withheld, got %v", h.Redacted)
+		}
+	}
+	if n != 1 {
+		t.Fatalf("expected 1 header, got %d", n)
+	}
+}
+
+// Redaction must not write through to stored state: the header's Properties
+// map may alias the store's (memstore clones, but a backend need not), so
+// filtering has to allocate rather than delete in place.
+func TestScriptReader_ListEntityHeadersDoesNotMutateStore(t *testing.T) {
+	ctx := context.Background()
+	st := memstore.New()
+	if err := st.CreateEntity(ctx, &entity.Entity{
+		ID: "TKT-1", Type: "ticket",
+		Properties: map[string]any{"title": "One", "secret": "hunter2"},
+	}); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	reader, err := visibility.NewPolicyReader(
+		typeGate{allow: "ticket"}, hidePropRedactor{name: "secret"}, st)
+	if err != nil {
+		t.Fatalf("NewPolicyReader: %v", err)
+	}
+	sr, err := visibility.NewScriptReader(reader, st, nil)
+	if err != nil {
+		t.Fatalf("NewScriptReader: %v", err)
+	}
+
+	for range sr.ListEntityHeaders(ctx, store.EntityQuery{}) { //nolint:revive // draining
+	}
+
+	got, err := st.GetEntity(ctx, "TKT-1")
+	if err != nil {
+		t.Fatalf("GetEntity: %v", err)
+	}
+	if got.Properties["secret"] != "hunter2" {
+		t.Error("redaction wrote through to the store")
+	}
+}
+
+// Chunking must not change verdicts. With more rows than one gate chunk, a
+// row's visibility still depends only on the row — never on which other
+// rows happened to share its chunk.
+func TestScriptReader_ListEntityHeadersChunkBoundary(t *testing.T) {
+	ctx := context.Background()
+	st := memstore.New()
+	// Straddle the 512-row chunk so the last chunk is partial, and
+	// interleave types so every chunk contains both.
+	const n = 1300
+	wantVisible := 0
+	for i := range n {
+		typ := "ticket"
+		if i%3 == 0 {
+			typ = "secret"
+		} else {
+			wantVisible++
+		}
+		if err := st.CreateEntity(ctx, &entity.Entity{
+			ID: fmt.Sprintf("E-%04d", i), Type: typ,
+			Properties: map[string]any{"title": "t"},
+		}); err != nil {
+			t.Fatalf("seed: %v", err)
+		}
+	}
+	sr := newTicketOnlyScriptReader(t, st)
+
+	got := 0
+	for h, err := range sr.ListEntityHeaders(ctx, store.EntityQuery{}) {
+		if err != nil {
+			t.Fatalf("ListEntityHeaders: %v", err)
+		}
+		if h.Type != "ticket" {
+			t.Fatalf("hidden type %q leaked at %s", h.Type, h.ID)
+		}
+		got++
+	}
+	if got != wantVisible {
+		t.Errorf("expected %d visible headers across chunk boundaries, got %d", wantVisible, got)
+	}
+}
+
+// Abandoning the scan early (analyze caps a section at N issues) must stop
+// cleanly, without gating or yielding the remainder.
+func TestScriptReader_ListEntityHeadersStopsOnEarlyReturn(t *testing.T) {
+	st := seedScriptWorld(t)
+	sr := newTicketOnlyScriptReader(t, st)
+
+	seen := 0
+	for range sr.ListEntityHeaders(context.Background(), store.EntityQuery{}) {
+		seen++
+		break
+	}
+	if seen != 1 {
+		t.Errorf("expected iteration to stop after 1, got %d", seen)
+	}
+}
+
+// hidePropRedactor hides one named property, so redaction can be asserted
+// without standing up a full affordances policy.
+type hidePropRedactor struct{ name string }
+
+func (r hidePropRedactor) HiddenProperties(
+	_ context.Context, e *entity.Entity,
+) map[string]struct{} {
+	if _, ok := e.Properties[r.name]; !ok {
+		return nil
+	}
+	return map[string]struct{}{r.name: {}}
+}

--- a/internal/visibility/luareader.go
+++ b/internal/visibility/luareader.go
@@ -157,6 +157,98 @@ func (s *ScriptReader) ListEntities(
 	}
 }
 
+// headerGateChunk is how many headers ListEntityHeaders gates at once.
+//
+// The row gate is deliberately BATCHED — one PermitsReadMany per distinct
+// type per chunk rather than one probe per row — so gating cannot stream a
+// row at a time without turning an O(types) probe count into O(rows). This
+// chunk is the compromise: peak retention is bounded by the chunk, not by
+// the store size, while the probe count stays proportional to
+// rows/headerGateChunk.
+//
+// 512 is chosen so the probe overhead is amortized (a chunk holds many rows
+// of each type in any realistic mix) while the retained slice stays small —
+// headers carry no bodies, so 512 of them is tens of KB, not tens of MB.
+const headerGateChunk = 512
+
+// ListEntityHeaders yields content-free headers the caller may read,
+// redacted — the header analog of [ScriptReader.ListEntities].
+//
+// Bounded in BOTH dimensions, which is the whole point (TKT-1ESTYJ):
+//
+//   - Per row, no body is carried. Backends that can project the content
+//     column away never read it (see [store.ListEntityHeaders]).
+//   - Across rows, at most [headerGateChunk] headers are retained at once.
+//     ListEntities cannot make this promise: it materializes the ENTIRE
+//     matching set to hand to Filter, so a whole-store scan retains a
+//     whole store. That buffer — not the analyzers' own slices — is why a
+//     type-less analyze scan held ~1 GB of markdown.
+//
+// Gating is identical to ListEntities': the same Reader, hence the same
+// policy, on the same (id, type) pairs. Chunking changes only WHEN probes
+// happen, never their verdicts, because a row's visibility does not depend
+// on which other rows accompany it.
+//
+// Falls back to whole-entity load-then-Filter when the Reader cannot filter
+// headers, so an incomplete Reader loses the memory win but never the gate.
+func (s *ScriptReader) ListEntityHeaders(
+	ctx context.Context, q store.EntityQuery,
+) iter.Seq2[store.EntityHeader, error] {
+	hf, ok := s.reader.(HeaderFilterer)
+	if !ok {
+		return s.headersViaEntities(ctx, q)
+	}
+	bound := s.bind(ctx)
+	return func(yield func(store.EntityHeader, error) bool) {
+		batch := make([]store.EntityHeader, 0, headerGateChunk)
+		flush := func() bool {
+			for _, h := range hf.FilterHeaders(bound, batch) {
+				if !yield(h, nil) {
+					return false
+				}
+			}
+			batch = batch[:0]
+			return true
+		}
+		for h, err := range store.ListEntityHeaders(bound, s.raw, q) {
+			if err != nil {
+				yield(store.EntityHeader{}, err)
+				return
+			}
+			batch = append(batch, h)
+			if len(batch) < headerGateChunk {
+				continue
+			}
+			if !flush() {
+				return
+			}
+		}
+		if len(batch) > 0 {
+			_ = flush()
+		}
+	}
+}
+
+// headersViaEntities is the fallback for a [Reader] without
+// [HeaderFilterer]: gate whole entities through ListEntities, then project.
+// Correct but unbounded — it inherits ListEntities' full-set buffering — so
+// it trades the memory win for gate parity, never the reverse.
+func (s *ScriptReader) headersViaEntities(
+	ctx context.Context, q store.EntityQuery,
+) iter.Seq2[store.EntityHeader, error] {
+	return func(yield func(store.EntityHeader, error) bool) {
+		for e, err := range s.ListEntities(ctx, q) {
+			if err != nil {
+				yield(store.EntityHeader{}, err)
+				return
+			}
+			if !yield(store.HeaderOf(e), nil) {
+				return
+			}
+		}
+	}
+}
+
 // ListRelations yields only relations whose BOTH endpoints are visible
 // (FROM ∧ TO). An explicit From/To filter in q therefore does not guarantee
 // the row survives — see the binding's comment (RR-7GDT1Y).

--- a/internal/visibility/policyreader.go
+++ b/internal/visibility/policyreader.go
@@ -8,6 +8,7 @@ import (
 	"slices"
 
 	"github.com/Sourcehaven-BV/rela/internal/entity"
+	"github.com/Sourcehaven-BV/rela/internal/store"
 )
 
 // PolicyReader is the policy-enforcing [Reader]: row-gate first, then
@@ -82,6 +83,40 @@ func (r *PolicyReader) Filter(ctx context.Context, candidates []*entity.Entity) 
 	for _, c := range candidates {
 		if c != nil && allowed[c.ID] {
 			out = append(out, r.redacted(ctx, c))
+		}
+	}
+	return out
+}
+
+// FilterHeaders implements [HeaderFilterer]: the [Filter] contract applied
+// to content-free headers.
+//
+// Identical gating — one PermitsReadMany per distinct type, order preserved,
+// fresh slice, fail-closed on gate error — because it is the SAME policy on
+// the same (id, type) pairs. The row gate never consults an entity's body,
+// so dropping the body cannot change a verdict.
+//
+// Field redaction still runs per surviving row: "may read every row of this
+// type" is not "may see every property" (RR-OXE47R). Redacting a header
+// strips hidden property names exactly as it does for an entity, and records
+// them in Redacted, so a gated header read is never MORE revealing than a
+// gated entity read.
+func (r *PolicyReader) FilterHeaders(
+	ctx context.Context, candidates []store.EntityHeader,
+) []store.EntityHeader {
+	if len(candidates) == 0 {
+		return nil
+	}
+	byType := make(map[string][]string)
+	for _, c := range candidates {
+		byType[c.Type] = append(byType[c.Type], c.ID)
+	}
+	allowed := r.permittedIDs(ctx, byType)
+
+	out := make([]store.EntityHeader, 0, len(candidates))
+	for _, c := range candidates {
+		if allowed[c.ID] {
+			out = append(out, RedactHeader(ctx, r.redact, c))
 		}
 	}
 	return out
@@ -209,6 +244,30 @@ func Redact(ctx context.Context, red FieldRedactor, e *entity.Entity) *entity.En
 	// it in place could write into the caller's backing array.
 	out.Redacted = slices.Sorted(maps.Keys(hidden))
 	return &out
+}
+
+// RedactHeader is [Redact] for a content-free [store.EntityHeader].
+//
+// Verdicts are resolved from the entity TYPE and the ctx principal — the
+// production redactors read e.Type and never e.Content (affordances'
+// FieldVerdicts resolves against the metamodel's declared fields) — so a
+// header yields the same hidden set its entity would. The stand-in Entity
+// below exists only to satisfy the [FieldRedactor] signature.
+//
+// Mirrors Redact's copy semantics: nothing hidden returns the input
+// unchanged (no allocation on the no-policy path); otherwise Properties is
+// a fresh filtered map and Redacted a freshly sorted slice, never appended
+// to the input's (which may alias a caller's backing array).
+func RedactHeader(ctx context.Context, red FieldRedactor, h store.EntityHeader) store.EntityHeader {
+	probe := &entity.Entity{ID: h.ID, Type: h.Type, Properties: h.Properties}
+	hidden := red.HiddenProperties(ctx, probe)
+	if len(hidden) == 0 {
+		return h
+	}
+	out := h
+	out.Properties = filterProps(h.Properties, hidden)
+	out.Redacted = slices.Sorted(maps.Keys(hidden))
+	return out
 }
 
 // filterProps returns a fresh map of props minus hidden. Never mutates

--- a/internal/visibility/tracer.go
+++ b/internal/visibility/tracer.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 
 	"github.com/Sourcehaven-BV/rela/internal/entity"
+	"github.com/Sourcehaven-BV/rela/internal/store"
 	"github.com/Sourcehaven-BV/rela/internal/tracer"
 )
 
@@ -186,22 +187,15 @@ func (t *VisibleTracer) redactStepTitle(ctx context.Context, s *tracer.PathStep)
 }
 
 // FindOrphans implements [tracer.Tracer]: the base's orphan ids minus
-// the hidden ones. Each id's entity is loaded once (the type is needed
-// for the gate anyway); ids are gated with one PermitsReadMany per
-// distinct type (RR-MYLUSZ). A vanished entity drops fail-closed.
+// the hidden ones. Each id's TYPE is resolved (the gate needs it) via
+// [VisibleTracer.typesOf], then ids are gated with one PermitsReadMany
+// per distinct type (RR-MYLUSZ). A vanished entity drops fail-closed.
 func (t *VisibleTracer) FindOrphans(ctx context.Context) ([]string, error) {
 	ids, err := t.base.FindOrphans(ctx)
 	if err != nil {
 		return nil, err
 	}
-	byType := map[string][]string{}
-	for _, id := range ids {
-		e, gerr := t.get.GetEntity(ctx, id)
-		if gerr != nil {
-			continue
-		}
-		byType[e.Type] = append(byType[e.Type], id)
-	}
+	byType := t.typesOf(ctx, ids)
 	visible := t.permittedIDs(ctx, byType)
 
 	out := make([]string, 0, len(ids))
@@ -211,6 +205,51 @@ func (t *VisibleTracer) FindOrphans(ctx context.Context) ([]string, error) {
 		}
 	}
 	return out, nil
+}
+
+// typesOf resolves each id's entity type, grouped for a per-type gate
+// probe.
+//
+// Prefers a batched header read: resolving 20k orphan ids one GetEntity at
+// a time loaded 20k full entities — bodies included — to read one string
+// field from each, which on a content-heavy project cost more than the
+// orphan scan itself (TKT-1ESTYJ). Headers carry Type and no body.
+//
+// Falls back to per-id GetEntity when the getter cannot list headers,
+// preserving the original behavior exactly. Both paths DROP an id whose
+// entity cannot be resolved, so a vanished entity stays fail-closed: it
+// never reaches byType, so permittedIDs never marks it visible.
+func (t *VisibleTracer) typesOf(ctx context.Context, ids []string) map[string][]string {
+	byType := map[string][]string{}
+	if len(ids) == 0 {
+		return byType
+	}
+
+	if er, ok := t.get.(store.EntityReader); ok {
+		for h, err := range store.ListEntityHeaders(ctx, er, store.EntityQuery{IDs: ids}) {
+			if err != nil {
+				// Fail closed: a partial scan must not silently narrow the
+				// orphan set to "whatever we managed to read". Fall back to
+				// the per-id path, which drops only the ids it cannot load.
+				return t.typesOfPerID(ctx, ids)
+			}
+			byType[h.Type] = append(byType[h.Type], h.ID)
+		}
+		return byType
+	}
+	return t.typesOfPerID(ctx, ids)
+}
+
+func (t *VisibleTracer) typesOfPerID(ctx context.Context, ids []string) map[string][]string {
+	byType := map[string][]string{}
+	for _, id := range ids {
+		e, gerr := t.get.GetEntity(ctx, id)
+		if gerr != nil {
+			continue
+		}
+		byType[e.Type] = append(byType[e.Type], id)
+	}
+	return byType
 }
 
 // HasCycle implements [tracer.Tracer]. A hidden (or missing, or

--- a/internal/visibility/tracer_typesof_test.go
+++ b/internal/visibility/tracer_typesof_test.go
@@ -1,0 +1,206 @@
+package visibility_test
+
+import (
+	"context"
+	"errors"
+	"iter"
+	"testing"
+
+	"github.com/Sourcehaven-BV/rela/internal/entity"
+	"github.com/Sourcehaven-BV/rela/internal/store"
+	"github.com/Sourcehaven-BV/rela/internal/store/memstore"
+	"github.com/Sourcehaven-BV/rela/internal/tracer"
+	"github.com/Sourcehaven-BV/rela/internal/visibility"
+)
+
+// FindOrphans resolves each orphan id's TYPE before gating it. That
+// resolution has two paths — a batched header read and a per-id fallback —
+// and the gate's verdicts must not depend on which one ran. These tests
+// drive both and assert the same visible set, because a divergence would be
+// an ACL bug that only appears on stores lacking the header capability.
+
+// orphanBase is a stub tracer returning fixed orphan ids.
+type orphanBase struct{ ids []string }
+
+func (o orphanBase) TraceFrom(context.Context, string, int) *tracer.TraceResult { return nil }
+func (o orphanBase) TraceTo(context.Context, string, int) *tracer.TraceResult   { return nil }
+func (o orphanBase) FindPath(context.Context, string, string) []tracer.PathStep { return nil }
+func (o orphanBase) HasCycle(context.Context, string) bool                      { return false }
+func (o orphanBase) FindOrphans(context.Context) ([]string, error) {
+	return o.ids, nil
+}
+
+// getterOnly exposes ONLY GetEntity, so VisibleTracer cannot take the
+// batched header path and must fall back to per-id resolution.
+type getterOnly struct{ st store.Store }
+
+func (g getterOnly) GetEntity(ctx context.Context, id string) (*entity.Entity, error) {
+	return g.st.GetEntity(ctx, id)
+}
+
+// headerErrGetter satisfies store.EntityReader but fails its header scan,
+// exercising the fail-closed fallback inside the batched path.
+type headerErrGetter struct{ st store.Store }
+
+func (h headerErrGetter) GetEntity(ctx context.Context, id string) (*entity.Entity, error) {
+	return h.st.GetEntity(ctx, id)
+}
+
+func (h headerErrGetter) ListEntities(
+	_ context.Context, _ store.EntityQuery,
+) iter.Seq2[*entity.Entity, error] {
+	return func(yield func(*entity.Entity, error) bool) {
+		yield(nil, errors.New("header scan exploded"))
+	}
+}
+
+func (h headerErrGetter) ListEntitiesPage(
+	context.Context, store.EntityQuery,
+) (store.Page[*entity.Entity], error) {
+	return store.Page[*entity.Entity]{}, nil
+}
+func (h headerErrGetter) CountEntities(context.Context, store.EntityQuery) (int, error) {
+	return 0, nil
+}
+func (h headerErrGetter) HighestID(context.Context, string) (int, error) { return 0, nil }
+func (h headerErrGetter) PropertyValues(context.Context, string, int) ([]string, error) {
+	return nil, nil
+}
+
+func seedOrphanWorld(t *testing.T) store.Store {
+	t.Helper()
+	ctx := context.Background()
+	st := memstore.New()
+	for _, e := range []*entity.Entity{
+		{ID: "TKT-1", Type: "ticket", Properties: map[string]any{"title": "One"}},
+		{ID: "TKT-2", Type: "ticket", Properties: map[string]any{"title": "Two"}},
+		{ID: "SEC-1", Type: "secret", Properties: map[string]any{"title": "Hush"}},
+	} {
+		if err := st.CreateEntity(ctx, e); err != nil {
+			t.Fatalf("seed %s: %v", e.ID, err)
+		}
+	}
+	return st
+}
+
+func newOrphanTracer(t *testing.T, get visibility.EntityGetter, ids []string) tracer.Tracer {
+	t.Helper()
+	vt, err := visibility.NewVisibleTracer(
+		orphanBase{ids: ids}, typeGate{allow: "ticket"}, visibility.NopRedactor{}, get)
+	if err != nil {
+		t.Fatalf("NewVisibleTracer: %v", err)
+	}
+	return vt
+}
+
+func TestVisibleTracer_FindOrphansGatesIdenticallyOnBothTypePaths(t *testing.T) {
+	st := seedOrphanWorld(t)
+	ids := []string{"TKT-1", "SEC-1", "TKT-2"}
+	want := []string{"TKT-1", "TKT-2"}
+
+	for _, tc := range []struct {
+		name string
+		get  visibility.EntityGetter
+	}{
+		{"batched header path", getterWithHeaders{st}},
+		{"per-id fallback (getter cannot list)", getterOnly{st}},
+		{"per-id fallback (header scan errored)", headerErrGetter{st}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := newOrphanTracer(t, tc.get, ids).FindOrphans(context.Background())
+			if err != nil {
+				t.Fatalf("FindOrphans: %v", err)
+			}
+			if len(got) != len(want) {
+				t.Fatalf("want %v, got %v", want, got)
+			}
+			for i := range want {
+				if got[i] != want[i] {
+					t.Fatalf("want %v, got %v", want, got)
+				}
+			}
+		})
+	}
+}
+
+// An id whose entity has vanished must drop, not pass: it never reaches the
+// per-type gate probe, so it can never be marked visible.
+func TestVisibleTracer_FindOrphansDropsUnresolvableIDs(t *testing.T) {
+	st := seedOrphanWorld(t)
+	// GONE-1 is not in the store.
+	ids := []string{"TKT-1", "GONE-1"}
+
+	for _, tc := range []struct {
+		name string
+		get  visibility.EntityGetter
+	}{
+		{"batched header path", getterWithHeaders{st}},
+		{"per-id fallback", getterOnly{st}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := newOrphanTracer(t, tc.get, ids).FindOrphans(context.Background())
+			if err != nil {
+				t.Fatalf("FindOrphans: %v", err)
+			}
+			for _, id := range got {
+				if id == "GONE-1" {
+					t.Fatal("a vanished entity must not survive the gate")
+				}
+			}
+			if len(got) != 1 || got[0] != "TKT-1" {
+				t.Fatalf("want [TKT-1], got %v", got)
+			}
+		})
+	}
+}
+
+func TestVisibleTracer_FindOrphansEmpty(t *testing.T) {
+	st := seedOrphanWorld(t)
+	got, err := newOrphanTracer(t, getterWithHeaders{st}, nil).FindOrphans(context.Background())
+	if err != nil {
+		t.Fatalf("FindOrphans: %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("want no orphans, got %v", got)
+	}
+}
+
+// getterWithHeaders is the full store, which memstore implements including
+// store.HeaderReader — the batched path.
+type getterWithHeaders struct{ st store.Store }
+
+func (g getterWithHeaders) GetEntity(ctx context.Context, id string) (*entity.Entity, error) {
+	return g.st.GetEntity(ctx, id)
+}
+
+func (g getterWithHeaders) ListEntities(
+	ctx context.Context, q store.EntityQuery,
+) iter.Seq2[*entity.Entity, error] {
+	return g.st.ListEntities(ctx, q)
+}
+
+func (g getterWithHeaders) ListEntitiesPage(
+	ctx context.Context, q store.EntityQuery,
+) (store.Page[*entity.Entity], error) {
+	return g.st.ListEntitiesPage(ctx, q)
+}
+
+func (g getterWithHeaders) CountEntities(ctx context.Context, q store.EntityQuery) (int, error) {
+	return g.st.CountEntities(ctx, q)
+}
+
+func (g getterWithHeaders) HighestID(ctx context.Context, prefix string) (int, error) {
+	return g.st.HighestID(ctx, prefix)
+}
+
+func (g getterWithHeaders) PropertyValues(
+	ctx context.Context, property string, limit int,
+) ([]string, error) {
+	return g.st.PropertyValues(ctx, property, limit)
+}
+
+func (g getterWithHeaders) ListEntityHeaders(
+	ctx context.Context, q store.EntityQuery,
+) iter.Seq2[store.EntityHeader, error] {
+	return store.ListEntityHeaders(ctx, g.st, q)
+}

--- a/internal/visibility/unrestricted.go
+++ b/internal/visibility/unrestricted.go
@@ -84,6 +84,14 @@ func (r *UnrestrictedReader) ListEntities(
 	return r.st.ListEntities(ctx, q)
 }
 
+// ListEntityHeaders implements the script read surface: straight
+// pass-through to the store's header projection (or its fallback).
+func (r *UnrestrictedReader) ListEntityHeaders(
+	ctx context.Context, q store.EntityQuery,
+) iter.Seq2[store.EntityHeader, error] {
+	return store.ListEntityHeaders(ctx, r.st, q)
+}
+
 // ListRelations implements the script read surface: straight pass-through.
 func (r *UnrestrictedReader) ListRelations(
 	ctx context.Context, q store.RelationQuery,

--- a/internal/visibility/unrestricted_test.go
+++ b/internal/visibility/unrestricted_test.go
@@ -108,8 +108,14 @@ func TestUnrestricted_IsPassThrough(t *testing.T) {
 // a single write method was bolted on. Enumerating is the stricter check —
 // adding ANY method fails this test and forces a deliberate decision.
 func TestUnrestricted_ExposesOnlyTheReadSurface(t *testing.T) {
+	// ListEntityHeaders was admitted deliberately (TKT-1ESTYJ): it is a
+	// READ that returns strictly LESS than ListEntities — the same rows
+	// with the body projected away — so it cannot widen a wiring site's
+	// capability. Anything that is not a strict narrowing of an existing
+	// read method still belongs outside this set.
 	want := map[string]bool{
 		"GetEntity": true, "ListEntities": true, "ListRelations": true,
+		"ListEntityHeaders": true,
 	}
 
 	typ := reflect.TypeOf(visibility.Unrestricted(seedStore(t)))

--- a/internal/visibility/visibility.go
+++ b/internal/visibility/visibility.go
@@ -47,6 +47,7 @@ import (
 	"context"
 
 	"github.com/Sourcehaven-BV/rela/internal/entity"
+	"github.com/Sourcehaven-BV/rela/internal/store"
 )
 
 // RowGate answers entity-level read-permission questions for the principal
@@ -106,4 +107,22 @@ type Reader interface {
 	// or a missing endpoint. Relations carry no field-level redaction
 	// today; row-gating is the whole contract.
 	FilterRelations(ctx context.Context, rels []*entity.Relation) []*entity.Relation
+}
+
+// HeaderFilterer is [Reader.Filter] for content-free [store.EntityHeader]s
+// (TKT-1ESTYJ).
+//
+// OPTIONAL, kept off [Reader] so a third-party or test Reader need not
+// implement it to stay valid. That optionality is safe ONLY because the
+// absence of this method degrades to loading whole entities and using
+// Filter — strictly more data, never less gating. A Reader that cannot
+// filter headers must therefore never be handed headers ungated:
+// [ScriptReader.ListEntityHeaders] is the sanctioned entry point, and it
+// falls back to whole-entity gating rather than passing rows through.
+type HeaderFilterer interface {
+	// FilterHeaders drops headers the ctx principal may not read and
+	// redacts the survivors, with [Reader.Filter]'s contract: order
+	// preserved, fresh slice, fail-closed on gate error, nil for empty
+	// input.
+	FilterHeaders(ctx context.Context, candidates []store.EntityHeader) []store.EntityHeader
 }

--- a/tickets/entities/automated-measures/AM-feed-field-redaction.md
+++ b/tickets/entities/automated-measures/AM-feed-field-redaction.md
@@ -1,8 +1,8 @@
 ---
 id: AM-feed-field-redaction
 type: automated-measure
-title: The ICS feed omits visible:-hidden properties, and redaction runs after the filter
-description: TestDeclarativeFeed_RedactsHiddenProperties asserts a hidden property never reaches a rendered event. TestDeclarativeFeed_RedactionDoesNotChangeMembership pins the ORDER by hiding the property the where: clause filters on and asserting the event still appears - moving redaction before the filter drops it, so feed membership would vary per principal. TestDeclarativeFeed_RedactionCopies asserts the shared store entity is not mutated. All three verified to fail against the fix being removed.
+title: "The ICS feed omits visible:-hidden properties, and redaction runs after the filter"
+description: "TestDeclarativeFeed_RedactsHiddenProperties asserts a hidden property never reaches a rendered event. TestDeclarativeFeed_RedactionDoesNotChangeMembership pins the ORDER by hiding the property the where: clause filters on and asserting the event still appears - moving redaction before the filter drops it, so feed membership would vary per principal. TestDeclarativeFeed_RedactionCopies asserts the shared store entity is not mutated. All three verified to fail against the fix being removed."
 kind: test
 location: internal/dataentry/feed_provider_test.go
 status: active

--- a/tickets/entities/automated-measures/AM-pgstore-listener-tolerates-pool-dsn-params.md
+++ b/tickets/entities/automated-measures/AM-pgstore-listener-tolerates-pool-dsn-params.md
@@ -1,0 +1,34 @@
+---
+id: AM-pgstore-listener-tolerates-pool-dsn-params
+type: automated-measure
+title: The change-feed listener starts with a DSN carrying pgxpool-only pool_* parameters
+description: A DSN containing pool_max_conns (and other pool_* keys) must start the LISTEN/NOTIFY listener successfully while the pool still honours the parameter.
+kind: test
+location: internal/store/pgstore/ (DB-gated test to be written with the fix)
+status: proposed
+---
+
+Pins BUG-3U61TX.
+
+Opening a store with a DSN carrying `pool_max_conns` (and the other pgxpool-only
+keys: `pool_min_conns`, `pool_max_conn_lifetime`, `pool_max_conn_idle_time`,
+`pool_health_check_period`) must:
+
+1. Start the change-feed listener **successfully** — no
+`FATAL: unrecognized configuration parameter` and no degradation warning.
+2. Leave the pool's effective `MaxConns` reflecting the DSN value; the fix must not
+strip the parameter from the pool's own config.
+3. Deliver cross-process events end to end with such a DSN.
+
+Cover **several** `pool_*` keys, not just `pool_max_conns` — the defect is
+generic to any parameter `pgxpool.ParseConfig` consumes, and a single-key test
+would let the others regress.
+
+Must **fail on current `develop`**: today `startListener` receives the raw DSN
+string and PostgreSQL rejects the pool key.
+
+DB-gated on `RELA_TEST_DATABASE_URL`, like the rest of the pgstore suite.
+
+This measure guards a *silent* failure: the store keeps working and local events
+still fire, so without an explicit assertion the regression is invisible in CI —
+which is why it went unnoticed in the first place (why5 on the bug).

--- a/tickets/entities/automated-measures/AM-scheduler-failed-task-no-retry-storm.md
+++ b/tickets/entities/automated-measures/AM-scheduler-failed-task-no-retry-storm.md
@@ -1,0 +1,34 @@
+---
+id: AM-scheduler-failed-task-no-retry-storm
+type: automated-measure
+title: A failing scheduled task does not re-execute on the next tick
+description: 'Table-driven test across every schedule kind (day, weekday, week, interval): a task whose execution always errors must execute exactly once per its declared schedule, not once per tick.'
+kind: test
+location: internal/scheduler/ (test to be written with the fix)
+status: proposed
+---
+
+Pins BUG-YZ13IJ.
+
+A scheduled task whose execution always returns an error, advanced by one tick,
+must execute exactly **once** — not once per tick.
+
+The test must be **table-driven across every schedule kind** (`day`, a weekday,
+`week`, an interval). That breadth is the point: the original report
+hypothesised the bug was in `IsDue`'s `dayKind` comparison, which would have
+limited it to `every: day`. Reproduction showed `runDueTasks` takes the
+`!recorded` branch and **never calls `IsDue` at all**, so every schedule kind
+amplifies to tick rate. A test covering only `day` would miss a regression that
+reintroduces the short-circuit for other kinds.
+
+Assert on execution *count* via the existing `executeTaskFunc` seam, with the
+clock injected through `Scheduler.now`. Both seams already exist — no production
+code needs to change to make this testable.
+
+Must **fail on current `develop`**: today the task executes on every tick.
+
+Companion assertions worth including in the same suite:
+
+- A task that fails then succeeds resumes its normal cadence.
+- A task that has never succeeded is still eventually retried (no permanent wedge).
+- Consecutive failures back off rather than retrying at tick rate.

--- a/tickets/entities/bugs/BUG-3U61TX.md
+++ b/tickets/entities/bugs/BUG-3U61TX.md
@@ -1,0 +1,108 @@
+---
+id: BUG-3U61TX
+type: bug
+title: pgxpool DSN params (pool_max_conns) are passed to the change-feed listener's raw connection, silently disabling cross-process events
+description: pgstore.Open parses the DSN with pgxpool.ParseConfig (which consumes pool_* params) but hands the raw DSN string to startListener. PostgreSQL rejects pool_max_conns as an unrecognized runtime parameter, so the LISTEN/NOTIFY connection fails and cross-process change events degrade to a warning.
+priority: medium
+effort: xs
+why1: Cross-process change events stop working whenever an operator tunes the pool via the DSN.
+why2: startListener connects with the raw DSN string, which still carries pgxpool-only parameters.
+why3: pgxpool.ParseConfig consumes pool_* keys into its own config; the original DSN string is never rewritten to strip them.
+why4: The listener was added later and reused the DSN as passed in, rather than deriving its connection from the already-parsed pgxpool config.
+why5: The failure is non-fatal by design (degrades with a warning), so no test covers a DSN carrying pool parameters and the regression is invisible in CI.
+status: ready
+---
+
+## Symptom
+
+Setting a pool size in the DSN, e.g.
+
+```
+RELA_DATABASE_URL="postgres://user@host:5432/db?sslmode=disable&pool_max_conns=80"
+```
+
+produces this at startup:
+
+```
+level=WARN msg="pgstore: cross-process change feed unavailable;
+  writes from other processes won't be observed live"
+  error="failed to connect: server error: FATAL: unrecognized configuration
+  parameter \"pool_max_conns\" (SQLSTATE 42704)"
+```
+
+The **pool itself is configured correctly** — `pgxpool.ParseConfig` consumes
+`pool_max_conns` — but the change-feed listener fails. Observed during unrelated
+load testing; the pool size took effect while cross-process events silently
+stopped.
+
+## Root cause
+
+`internal/store/pgstore/open.go`. The DSN is parsed for the pool:
+
+```go
+cfg, err := pgxpool.ParseConfig(dsn)
+...
+pool, err := pgxpool.NewWithConfig(ctx, cfg)
+```
+
+but the **raw string** is handed to the listener:
+
+```go
+l, err := startListener(ctx, st, dsn)
+```
+
+`startListener` opens its own dedicated connection (deliberately — a slow
+`LISTEN` must not starve query traffic). That connection goes through plain pgx,
+which passes unrecognised keys to the server as runtime parameters.
+`pool_max_conns` is a pgxpool-only concept, so PostgreSQL rejects it.
+
+Any `pool_*` parameter triggers this: `pool_min_conns`,
+`pool_max_conn_lifetime`, `pool_max_conn_idle_time`, `pool_health_check_period`.
+
+## Impact
+
+Low severity, poor failure mode. The store still works and local events still
+fire, so a single-process deployment sees nothing wrong. In a multi-process
+deployment — exactly where `LISTEN/NOTIFY` matters — cross-process writes stop
+being observed live, and the only signal is one WARN line at startup. The
+data-entry SSE feed (`App.startStoreEventBridge`) goes quiet for remote writes.
+
+The trap is that tuning the pool is a *normal* operational action that silently
+disables an unrelated subsystem.
+
+## Fix direction
+
+Derive the listener's connection from the already-parsed config rather than the
+raw string — `cfg.ConnConfig` is a `*pgx.ConnConfig` with the pool keys already
+stripped, so `pgx.ConnectConfig(ctx, cfg.ConnConfig.Copy())` is the natural
+form. That also keeps the listener honest if pgxpool ever consumes further keys.
+
+Whatever the mechanism, the listener must not receive parameters intended for
+the pool.
+
+Secondary consideration: a listener that cannot connect **because the DSN is
+malformed** is arguably different from one that cannot connect because the
+server is briefly unreachable. The first is a permanent configuration error and
+might warrant failing loudly; the second correctly degrades. Worth an explicit
+decision rather than treating all listener-start failures identically.
+
+## Acceptance criteria
+
+1. A DSN carrying `pool_max_conns` (or any `pool_*` key) starts the change-feed
+listener successfully.
+2. The pool still honours those parameters — the fix must not strip them from the
+pool's own config.
+3. Cross-process events are delivered with such a DSN, verified end to end.
+
+## Test plan
+
+- Regression test: construct a store with a `pool_*`-carrying DSN and assert the
+listener starts (must fail on current `develop`).
+- Assert the pool's effective `MaxConns` still reflects the DSN value.
+- Existing DB-gated cross-process event tests, re-run with a pool-tuned DSN.
+- Cover several `pool_*` keys, not just `pool_max_conns`.
+
+## Notes
+
+Found incidentally while load-testing the analyze OOM. Unrelated to those
+defects, filed separately.

--- a/tickets/entities/bugs/BUG-3U61TX.md
+++ b/tickets/entities/bugs/BUG-3U61TX.md
@@ -10,7 +10,7 @@ why2: startListener connects with the raw DSN string, which still carries pgxpoo
 why3: pgxpool.ParseConfig consumes pool_* keys into its own config; the original DSN string is never rewritten to strip them.
 why4: The listener was added later and reused the DSN as passed in, rather than deriving its connection from the already-parsed pgxpool config.
 why5: The failure is non-fatal by design (degrades with a warning), so no test covers a DSN carrying pool parameters and the regression is invisible in CI.
-status: ready
+status: backlog
 ---
 
 ## Symptom

--- a/tickets/entities/bugs/BUG-YZ13IJ.md
+++ b/tickets/entities/bugs/BUG-YZ13IJ.md
@@ -1,0 +1,132 @@
+---
+id: BUG-YZ13IJ
+type: bug
+title: 'Failed scheduled task re-runs every tick: !recorded branch bypasses IsDue, so any schedule kind fires at tick rate'
+description: A scheduled task that fails before ever succeeding never stamps last-run, so runDueTasks takes the !recorded branch on every tick and executes without consulting IsDue. A task with a partially-denied ACL that commits an entity then aborts leaks one entity per tick, unbounded.
+priority: critical
+effort: s
+why1: A scheduled task created 1,440 orphan entities per day instead of 1.
+why2: doExecuteTask returns early on error, so state.Tasks[name] is never stamped.
+why3: runDueTasks treats an unstamped task as !recorded and executes it immediately, bypassing IsDue entirely — so the declared schedule is irrelevant.
+why4: State conflates 'last run' with 'last SUCCESSFUL run'; the model assumed a failed run has no side effects.
+why5: That assumption was never re-derived when Lua scripts gained write bindings. A failing task is now a writer, so retry cadence became a data-integrity concern with no test covering the error path across ticks.
+status: ready
+---
+
+## Symptom
+
+A scheduled task declared `every: day` executed **1,440 times per day** — once
+per scheduler tick (60 s). Each run committed an entity then aborted on a denied
+`create_relation`, leaking one orphan entity per tick. Reported from production
+at 11,222 orphans over ~7 days.
+
+## Reproduction
+
+Confirmed locally (pgstore). With `RELA_SCHEDULER_TICK=50ms`:
+
+- **1,177 orphan `task` entities in 60 seconds**, 0 relations.
+- Error identical on every tick:
+`create relation error: forbidden: no role grants create on relations from type
+"recurring" (rule_kind=role-grant rule_id=-)`
+
+The reporter's 1,440/day matches exactly at the production 60 s tick.
+
+Minimal setup: a metamodel with `recurring` + `task` and a `spawns` relation
+`from: [recurring]`; an `acl.yaml` granting `create: [task]` but only `read` on
+`recurring`; a script that creates a task then relates it back to the recurring
+entity. `create_entity` commits, `create_relation` is denied, the task aborts.
+
+## Root cause
+
+`internal/scheduler/scheduler.go`. `doExecuteTask` returns before stamping
+state:
+
+```go
+if err != nil {
+    s.logger.Error("task failed", ...)
+    return                          // state.Tasks[task.Name] never set
+}
+s.state.Tasks[task.Name] = s.now()
+```
+
+and `runDueTasks` short-circuits when there is no stamp:
+
+```go
+lastRun, recorded := s.state.Tasks[task.Name]
+if !recorded {
+    s.logger.Info("first run, executing immediately", "name", task.Name)
+    s.executeTask(ctx, task)
+    continue                        // IsDue is never consulted
+}
+if task.Every.IsDue(lastRun, now) { ... }
+```
+
+**The declared schedule is therefore irrelevant for a task that has never
+succeeded.** The reproduction log shows `"first run, executing immediately"` on
+*every* tick, never `"task due"`.
+
+This is broader than the original report suggested. The reporter hypothesised
+the `dayKind` branch of `IsDue` (`truncateToDay(now) != truncateToDay(lastRun)`)
+as the cause, which would have limited the bug to `every: day`. In fact `IsDue`
+is dead code on this path — `every: week`, `every: monday`, and `every: 2h` all
+amplify to tick rate identically.
+
+## Impact
+
+Any persistently-failing scheduled task runs at tick rate (60 s) regardless of
+its declared schedule. Where the script writes before failing, this is unbounded
+data growth. The ACL misconfiguration that triggered the production incident is
+the reporter's own, but a transient failure (network blip mid-script) produces
+the same amplification for as long as it persists.
+
+Downstream: the inflated entity table is what made `GET /api/v1/_analyze` fatal
+(see Related) — 19 MB to 2,947 MB RSS. Neither defect alone took the host down.
+
+## Fix direction
+
+Track last-*attempt* separately from last-*success*, so a failed run still
+advances the retry clock. Add exponential backoff on consecutive failures, and
+consider a circuit-breaker that disables a task after N identical failures (the
+analogue of Erlang's supervisor restart intensity). Fetching the schedule via
+`IsDue` must happen on every path, including first-run-after-failure.
+
+Note that wrapping each task in a transaction — the reporter's first suggestion
+— is **not** the right fix: Lua scripts can call `rela.http` (30 s timeout) and
+`rela.ai`, and CLAUDE.md forbids slow external I/O inside a `store.Store.Tx`
+callback. Script authors need documented non-atomicity plus an idempotency
+primitive, not a transaction that holds a pg advisory lock across arbitrary
+network calls.
+
+## Acceptance criteria
+
+1. A task that fails does not re-execute on the next tick; the next execution
+respects its declared schedule.
+2. Holds for every schedule kind: `day`, weekday, `week`, and interval.
+3. Consecutive failures back off rather than retrying at tick rate.
+4. A task that has never succeeded is still eventually retried (no permanent wedge
+from one early failure).
+5. Successful runs are unaffected — existing scheduling behaviour is unchanged.
+
+## Test plan
+
+- **Regression test (must fail on current `develop`)**: a scheduled task whose
+execution always errors; advance the clock by one tick; assert exactly one
+execution, not two.
+- Table-driven across all schedule kinds, asserting the amplification is absent for
+each — this is what pins the finding that `IsDue` is bypassed rather than
+mis-evaluated.
+- Backoff timing test with an injected clock (`Scheduler.now` is already a seam).
+- A task failing then succeeding resumes its normal cadence.
+
+## Notes
+
+`RELA_SCHEDULER_TICK` (env-only debug seam, default unchanged at 60 s) was added
+during investigation to compress days of ticking into seconds. Keep or drop with
+the fix, but a test-visible tick override is what makes criterion 3 practical.
+
+## Related
+
+- Analyze OOM ticket (`_analyze` unbounded retention) — the amplifier that turned
+this leak into a host-level outage.
+- `entitymanager.collectAllIDs` full-content scan per create — each leaked entity
+cost a full-table scan, so the leak also degraded write latency as it grew.

--- a/tickets/entities/bugs/BUG-YZ13IJ.md
+++ b/tickets/entities/bugs/BUG-YZ13IJ.md
@@ -22,7 +22,9 @@ at 11,222 orphans over ~7 days.
 
 ## Reproduction
 
-Confirmed locally (pgstore). With `RELA_SCHEDULER_TICK=50ms`:
+Confirmed locally (pgstore), with the scheduler's 60 s `tickInterval`
+temporarily lowered to 50 ms so days of ticking compress into seconds
+(see Notes — that override was NOT kept):
 
 - **1,177 orphan `task` entities in 60 seconds**, 0 relations.
 - Error identical on every tick:
@@ -120,9 +122,19 @@ mis-evaluated.
 
 ## Notes
 
-`RELA_SCHEDULER_TICK` (env-only debug seam, default unchanged at 60 s) was added
-during investigation to compress days of ticking into seconds. Keep or drop with
-the fix, but a test-visible tick override is what makes criterion 3 practical.
+**Reproducing this needs a tick override.** The bug is only observable across
+many ticks, and `tickInterval` is a 60 s const, so a bare reproduction takes
+hours. During investigation a `RELA_SCHEDULER_TICK` env seam was added to
+compress that; it was **deliberately not kept**, because on its own it is a
+debug knob with no caller, no test, and no bug it fixes.
+
+Whoever takes this ticket should reintroduce it (or an equivalent) as part of
+the fix, where it lands with a caller and a rationale. Acceptance criterion 3
+(consecutive failures back off) is impractical to test without one.
+
+Note the scheduler already has the two seams the regression test needs —
+`Scheduler.now` for the clock and `executeTaskFunc` for execution — so only the
+tick period is missing.
 
 ## Related
 

--- a/tickets/entities/bugs/BUG-YZ13IJ.md
+++ b/tickets/entities/bugs/BUG-YZ13IJ.md
@@ -10,7 +10,7 @@ why2: doExecuteTask returns early on error, so state.Tasks[name] is never stampe
 why3: runDueTasks treats an unstamped task as !recorded and executes it immediately, bypassing IsDue entirely — so the declared schedule is irrelevant.
 why4: State conflates 'last run' with 'last SUCCESSFUL run'; the model assumed a failed run has no side effects.
 why5: That assumption was never re-derived when Lua scripts gained write bindings. A failing task is now a writer, so retry cadence became a data-integrity concern with no test covering the error path across ticks.
-status: ready
+status: backlog
 ---
 
 ## Symptom

--- a/tickets/entities/review-checklists/REV-1ESTYJ.md
+++ b/tickets/entities/review-checklists/REV-1ESTYJ.md
@@ -1,0 +1,99 @@
+---
+id: REV-1ESTYJ
+type: review-checklist
+title: 'Review: Bound analyze memory — content-free headers, streaming analyzers, per-section caps'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Automated Checks
+
+- [x] `go test ./internal/...` — all packages pass
+- [x] `just lint` — 0 issues
+- [x] `just arch-lint` — OK
+- [x] `just plimsoll` — clean (two load lines raised by exactly +1; see below)
+- [x] `just coverage-check` — PASS (`internal/visibility` 84.8% → 87.4%)
+- [x] pgstore suite against a real PostgreSQL — `ok`, 41s, including the new
+      Header conformance
+- [x] Frontend: 1,609 tests pass, `vue-tsc` clean, ESLint 0 errors
+- [x] Both build tags compile (`go build ./...` and `-tags postgres`)
+
+## Acceptance Verification
+
+Measured against the original repro dataset — 20k entities, 1,974 MB of
+content, real PostgreSQL — not a synthetic benchmark.
+
+- [x] **AC1** PASS — peak RSS **2,947 MB → 51 MB** for one `_analyze`
+      (criterion: < 150 MB). RSS sampled at 20 ms.
+- [x] **AC2** PASS — **flat in body size**: the same 20k entities with EMPTY
+      bodies peak at 50 MB, versus 51 MB with 1,974 MB of content. A 1 MB
+      difference across a 2 GB swing.
+- [x] **AC3** PASS — 3 concurrent requests **6,264 MB → 55 MB**
+      (criterion: < 300 MB).
+- [x] **AC4** PASS — existing analyze and ACL tests pass unchanged: same
+      issues, same order, for fixtures under the cap.
+- [x] **AC5** PASS — boundary tests at 0/99/100/101/500. Exactly 100 is
+      complete; 101 returns 100 with `Truncated`. Surfaced to the wire as
+      `truncatedChecks` and rendered as `100+` plus a notice.
+- [x] **AC6** PASS — `analyzeDuplicates` still detects duplicates; it groups
+      headers first (it cannot stream) and caps at issue-emission.
+- [x] **AC7** PASS — `storetest.RunHeaderTests` runs for every backend;
+      memstore (native), fsstore (generic fallback), pgstore (native) all pass.
+- [x] **AC8** PASS — enforced by the type: `EntityHeader` has no Content
+      field, so no header can reach a `.Content` consumer. Verified by
+      compilation.
+
+## Code Review
+
+Self-review; no `/code-review` agent run. Findings recorded and addressed
+inline rather than as separate `review-response` entities, since all were
+found and fixed before the PR opened.
+
+- **Scope was wrong in the ticket (significant, FIXED)** — A/B/C alone left
+  `_analyze` at **1,454 MB**, failing AC1, while every unit test passed. Only
+  running the repro found it. Profiling turned up three more whole-store body
+  loads, two outside `internal/dataentry`: `tracer.FindOrphans`,
+  `visibility.VisibleTracer.FindOrphans` (one full `GetEntity` per orphan to
+  read `.Type`), and `analyzeOrphans` re-loading every orphan as a full entity
+  (~930 MB alone). The ticket was scoped to `analyze.go`; the fix spans four
+  packages.
+- **The second buffer (significant, FIXED)** — `ScriptReader.ListEntities`
+  materializes the ENTIRE matching set to hand to `Reader.Filter`, because the
+  row gate batches per type. Fixing `analyze.go` alone would not have fixed the
+  OOM.
+- **ACL equivalence (significant, VERIFIED)** — header gating is asserted
+  against `ListEntities` rather than hand-written expectations, so the two
+  cannot drift. **Mutation-tested**: removing the gate from `FilterHeaders`
+  fails with `hidden entity SEC-1 leaked through the header path`; restoring
+  passes.
+- **Fail-closed paths (minor, FIXED)** — `FindOrphans`'s two type-resolution
+  routes are covered, including the header-scan-error fallback, asserting the
+  same visible set. A divergence would be an ACL bug appearing only on stores
+  lacking the header capability.
+- **Truncation determinism (minor, DOCUMENTED not fixed)** — on a truncated
+  section, which 100 issues survive is "the first 100 in store order", and
+  store order (ascending by id) is not natural order. So truncated output is a
+  bounded sample, not "the naturally-first 100". Written into the code comment
+  rather than silently glossed.
+
+## Notes
+
+- **`plimsoll` load lines raised by +1** on `MemStore` and pgstore `Store`,
+  each with the reason at the declaration site. Per the root CLAUDE.md, a store
+  implementation's count is the mandated-interface exception rather than a
+  ratchet target; `ListEntityHeaders` is implemented natively in both because
+  the generic fallback would clone bodies only to drop them, which is the cost
+  the capability exists to remove.
+- **A distinct type, not `EntityQuery{OmitContent}`** — a half-populated
+  `entity.Entity` satisfies every interface a real one does and lies to all of
+  them. `computeEntityETag` hashes `.Content` and would return a well-formed
+  ETag for the wrong bytes. ~337 `.Content` reads across 12 packages would each
+  become a latent bug; the compiler now rejects the mistake.
+- **Fixed an unrelated upstream YAML break** —
+  `AM-feed-field-redaction.md` (from #1314) had unquoted `visible:` in its
+  title and description, so the entity failed to parse and was invisible to
+  every analyze scan. Quoting it re-exposed a genuine pre-existing validation
+  error on BUG-E9DYW5 (done, no review checklist) that had been hidden.
+- Out of scope, per the ticket: migrating list/search/kanban-card surfaces to
+  `EntityHeader`, and caching/precomputing analysis.

--- a/tickets/entities/review-checklists/REV-E9DYW5.md
+++ b/tickets/entities/review-checklists/REV-E9DYW5.md
@@ -1,0 +1,63 @@
+---
+id: REV-E9DYW5
+type: review-checklist
+title: 'Review: ICS feed serves visible:-redacted properties verbatim'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Why this entity exists
+
+Backfilled by TKT-1ESTYJ, not authored alongside the fix.
+
+BUG-E9DYW5 shipped in **#1314** ("fix(dataentry): redact visible:-hidden
+properties in the ICS feed") and was moved to `done` without a linked
+`has-review` checklist, which the `done-bug-review-checklist` rule requires.
+That violation went unnoticed because the bug's own measure entity,
+`AM-feed-field-redaction.md`, carried an unquoted `visible:` in its frontmatter
+title and description. The entity therefore failed to parse, so every analyze
+scan silently under-counted — `rela validate` reported "all rules passed" while
+skipping the file (the run logs a `failed to parse frontmatter` warning that is
+easy to miss).
+
+TKT-1ESTYJ quoted that frontmatter as a drive-by fix, which re-exposed the
+pre-existing violation. This checklist records what actually happened on #1314;
+it does not claim a review this author performed.
+
+## Automated Checks
+
+Per #1314, which merged green through the standard pipeline (test, lint,
+arch-lint, coverage, e2e). Not re-run here — the code is unchanged by
+TKT-1ESTYJ.
+
+- [x] CI green on #1314 at merge
+
+## Code Review
+
+- [x] **4 GitHub reviews on #1314.** The fix originated in a security review of
+      the CalDAV work (#1308), which inherited the same unredacted mapping.
+
+## Acceptance Verification
+
+Verified by the measures the bug itself links, all in
+`internal/dataentry/feed_provider_test.go`:
+
+- [x] `TestDeclarativeFeed_RedactsHiddenProperties` — a `visible:`-hidden
+      property never reaches a rendered event.
+- [x] `TestDeclarativeFeed_RedactionDoesNotChangeMembership` — pins the ORDER,
+      by hiding the property the `where:` clause filters on and asserting the
+      event still appears. Moving redaction before the filter drops it, so feed
+      membership would otherwise vary per principal.
+- [x] `TestDeclarativeFeed_RedactionCopies` — the shared store entity is not
+      mutated.
+
+All three were verified to fail against the fix being removed (per IMPL-E9DYW5).
+
+## Note
+
+The real lesson is the one this backfill exposes rather than the bug it closes:
+a malformed frontmatter field made an entity invisible to validation, and
+validation reported success anyway. A parse failure during an analyze scan
+should be an error, not a warning that degrades into an under-count — otherwise
+"all rules passed" can mean "the rule never saw the file". Worth its own ticket.

--- a/tickets/entities/tickets/TKT-1ESTYJ.md
+++ b/tickets/entities/tickets/TKT-1ESTYJ.md
@@ -5,7 +5,7 @@ title: 'Bound analyze memory: content-free entity headers, streaming analyzers, 
 kind: refactor
 priority: critical
 effort: l
-status: ready
+status: done
 ---
 
 ## Problem

--- a/tickets/entities/tickets/TKT-1ESTYJ.md
+++ b/tickets/entities/tickets/TKT-1ESTYJ.md
@@ -1,0 +1,173 @@
+---
+id: TKT-1ESTYJ
+type: ticket
+title: 'Bound analyze memory: content-free entity headers, streaming analyzers, per-section issue caps'
+kind: refactor
+priority: critical
+effort: l
+status: ready
+---
+
+## Problem
+
+A single `GET /api/v1/_analyze` takes the server from **19 MB to 2,947 MB RSS**.
+Three concurrent requests reached **6,264 MB** — it multiplies per request with
+no bound. This is a remote OOM trigger reachable by any caller that can reach
+the endpoint.
+
+Reproduced locally against pgstore (20k entities, 1,974 MB of body content):
+
+| Load | Peak RSS |
+|------|----------|
+| Idle | 19 MB |
+| 1 x `_analyze` | **2,947 MB** |
+| 3 x `_analyze` concurrent | **6,264 MB** |
+
+Heap profile during the request — an unambiguous retention chain:
+
+```
+handleV1Analyze -> runAnalysis -> analyzeProperties
+  -> visibility.ScriptReader.ListEntities -> pgstore.scanEntity
+    -> pgx scanPlanString.Scan ......... 1.05GB (99.08% of live heap)
+```
+
+### Root cause
+
+Analyzers drain the whole store into a slice/map and hold it across the scan
+(`internal/dataentry/analyze.go:447`):
+
+```go
+entities := make([]*entity.Entity, 0)
+for e, err := range svc.reads.ListEntities(ctx, store.EntityQuery{}) {
+    entities = append(entities, e)   // retains EVERY entity, content included
+}
+sortStoreEntitiesByID(entities)      // ...because it needs them all at once, to sort
+```
+
+Two independent defects compound:
+
+1. **Retention** — `[]*entity.Entity` / `map[title][]*entity.Entity` held across a
+full scan. O(n) in entity count.
+2. **Payload** — every retained entity carries its markdown body.
+**`analyze.go` never reads `.Content` — zero references.** The 1.05 GB above is
+entirely wasted bytes.
+
+Same shape at `internal/dataentry/helpers.go:695` (`listAllFromStore`),
+reachable from list rendering — must be checked before this is closed.
+
+Contrast with `entitymanager.collectAllIDs`, which runs the same full scan but
+keeps only `e.ID`: it streamed 2 GB at **53 MB** RSS. Retention, not scanning,
+is what kills the process.
+
+### Why this went unnoticed
+
+`_analyze` is fine on a small project. It became fatal when a separate scheduler
+bug (see "Related") inflated one entity type to ~11k rows. Table size converts
+directly into RSS.
+
+## Scope
+
+**In scope**
+
+- **(A) Content-free entity reads.** New `store.EntityHeader` (ID, Type, Properties,
+UpdatedAt — *no* Content) + `ListEntityHeaders`, as an optional store capability
+type-asserted like `store.Formatter` / `HistoryReader`, with a generic fallback
+that drops content client-side. pgstore projects the column away so the bytes
+never leave the DB.
+- **(B) Streaming analyzers.** `analyzeProperties` / `analyzeCardinality` emit issues
+inside the scan; sort *issues* at the end instead of entities. Memory becomes
+O(issues), not O(entities).
+- **(C) Per-section issue cap.** Hard cap of 100 issues per analyzer section. Fetch
+the 101st purely to detect overflow, report 100, and set a `Truncated` flag on
+the section. No `?limit=` opt-out.
+- Audit `listAllFromStore` (`helpers.go:695`) for the same defect.
+- Give `analysisIssueCounts` a real count-only path (see Risks).
+
+**Out of scope**
+
+- Migrating list / search / kanban-card surfaces to `EntityHeader`. Deliberate: those
+are the natural follow-ups and the reason (A) is a typed capability rather than
+a local fix, but each is its own verifiable migration. Separate tickets.
+- Caching / precomputing analysis, or moving it to a background job. That is the real
+fix for the per-request multiplier (3 requests = 6.2 GB) — file as a follow-up.
+- ACL or rate gating on `_analyze`. Worth doing (6 full scans per request is expensive
+regardless) but orthogonal; CLAUDE.md permits a gate for cost reasons as long as
+it is not justified as concealment.
+
+### Why a new type instead of an OmitContent flag on EntityQuery
+
+A bool on the shared query type returns something that *is* an `entity.Entity`,
+satisfies every interface, and lies. There are **337 `.Content` reads across 12
+packages**. The sharpest example: `computeEntityETag` (`api_v1.go:1828`) hashes
+`e.Content` — hand it a content-omitted entity and it returns a well-formed ETag
+for the wrong bytes, silently breaking conditional requests and caching.
+
+`computeEntityETag(*entity.Entity)` will not compile against an `EntityHeader`.
+The mistake becomes unavailable rather than merely discouraged — the same
+reasoning that motivated `PatchEntity` replacing read-modify-write.
+
+## Acceptance criteria
+
+1. `GET /api/v1/_analyze` over 20k entities x ~100 KB bodies stays under **150 MB**
+peak RSS (from 2,947 MB). Verified by the repro harness, RSS sampled at 20 ms.
+2. Peak RSS for `_analyze` is **flat in body size** — 20k entities with 100 KB bodies
+costs the same as 20k with empty bodies.
+3. **3 concurrent** `_analyze` requests stay under **300 MB** combined (from 6,264 MB).
+4. Analyzer output is **unchanged** below the cap: same issues, same order, for a
+fixture project with fewer than 100 issues per section.
+5. A section with more than 100 findings returns exactly 100 issues with `Truncated`
+true; the UI shows the list is truncated. No exact total is displayed.
+6. `analyzeDuplicates` still detects duplicates correctly — it cannot stream (a title
+is not known to be duplicated until its second occurrence), so it groups headers
+first and caps at issue-emission.
+7. A store backend without the capability still works via the generic fallback;
+`storetest` conformance covers `ListEntityHeaders` for any implementation.
+8. No `EntityHeader` reaches a `.Content` consumer — enforced by the type, verified by
+compilation.
+
+## Test plan
+
+- **Memory regression test** — seed N entities with large bodies, run `_analyze`,
+assert peak heap via `runtime.ReadMemStats` stays under budget. This is the test
+that would have caught the bug; it must fail against current `develop`.
+- **Golden output test** — fixture project under the cap; assert analyzer output is
+byte-identical before/after (criterion 4).
+- **Cap boundary tests** — sections with exactly 99, 100, 101, and 500 issues.
+Assert 101 gives 100 issues + `Truncated`; 100 gives 100 issues + not truncated.
+This pins the off-by-one in the fetch-101 logic.
+- **Duplicates correctness** — duplicate groups spanning the first and last rows of a
+scan, to prove grouping is not broken by streaming changes elsewhere.
+- **storetest conformance** — `ListEntityHeaders` returns the same ID/Type/Properties
+set as `ListEntities`, with empty Content, across fs / mem / pg.
+- **Fallback path** — a store *without* the capability yields identical headers.
+
+## Risks
+
+- **`analysisIssueCounts` (dashboard) silently degrades.** It calls `runAnalysis` and
+discards everything but the totals; with sections capped at 100 its count
+becomes "at least 100" rather than a true total. Mitigation: give it a real
+count-only path — it should never have built full issue detail to produce a
+number. In scope.
+- **Fallback is correct but not fast.** On a backend without projection the bytes still
+cross the wire; only the retention improves. Acceptable — pgstore is where the
+production pain is — but do not describe the fallback as bounding I/O.
+- **Cap changes semantics.** Analysis becomes partial above 100 per section. Surfaced
+via `Truncated` in the UI, so this is a visible bound, not a silent one.
+- **`EntityHeader` is a new public store surface.** Keep it minimal; adding Content
+later would defeat the purpose.
+
+## Related
+
+- Scheduler amplification bug (separate ticket): a failed scheduled task never stamps
+last-run, so the `!recorded` branch short-circuits before `IsDue` and the task
+re-fires every tick — *every* schedule kind, not just `day`. This is what
+inflated the entity table and made `_analyze` fatal. Neither bug alone is
+sufficient.
+- `entitymanager.collectAllIDs` (`core.go:207`) runs a full-content scan per entity
+create: 0.74 s uncontended to 22 s under 80-way concurrency.
+Latency/availability, not memory — separate ticket, and a candidate consumer of
+`ListEntityHeaders`.
+- `pool_max_conns` in the DSN is consumed by pgxpool but passed verbatim to the
+change-feed listener's raw connection, which fails with `FATAL: unrecognized
+configuration parameter`. Cross-process events silently degrade whenever an
+operator tunes the pool. Separate minor ticket.

--- a/tickets/entities/tickets/TKT-69TDK8.md
+++ b/tickets/entities/tickets/TKT-69TDK8.md
@@ -1,0 +1,136 @@
+---
+id: TKT-69TDK8
+type: ticket
+title: 'collectAllIDs scans every entity with content on each create: O(n) latency and no fault isolation'
+kind: refactor
+priority: high
+effort: m
+status: ready
+---
+
+## Problem
+
+Every `create_entity` for a sequential-ID type loads **every entity in the
+store, including full markdown content**, to compute the next ID number
+(`internal/entitymanager/core.go:207`):
+
+```go
+existingIDs, err := collectAllIDs(ctx, deps.Store)
+...
+return entity.GenerateNextID(existingIDs, prefix), nil
+```
+
+`collectAllIDs` iterates `ListEntities` and keeps only `e.ID`, but pgstore's
+`buildEntityListSQL` selects `id, type, properties, content, updated_at` with no
+`LIMIT`. At 262k entities the scan streams **535 MB per create** to extract a
+few hundred KB of ID strings.
+
+## Measured impact
+
+Two distinct defects, both confirmed by reproduction against pgstore.
+
+### 1. Latency — O(n) per create
+
+| Dataset | Uncontended create | Under 80-way concurrency |
+|---------|--------------------|--------------------------|
+| ~1k entities | 2-6 ms | — |
+| 11.7k entities | 34-169 ms | — |
+| 262k entities | 0.74 s | **22 s** |
+
+At 113k entities, 300 simultaneous creates produced a **1 m 50 s** max latency.
+The pgx pool caps concurrent scans at `max(4, NumCPU)`, so requests queue rather
+than running in parallel — the failure mode is timeouts, not memory. Peak RSS
+stayed at 53-55 MB throughout, because `collectAllIDs` discards each entity's
+content as the iterator advances.
+
+This makes it the *inverse* of the `_analyze` bug (see Related): same full scan,
+opposite memory profile, because that one retains the slice and this one does
+not. Worth stating explicitly in the fix so the two are not conflated.
+
+### 2. No fault isolation
+
+A single malformed entity file breaks **every create in the project**.
+Encountered live while filing these tickets:
+
+```
+collect existing IDs: failed to parse frontmatter:
+  yaml: line 4: mapping values are not allowed in this context
+```
+
+One committed file with an unquoted colon in a YAML value
+(`tickets/entities/automated-measures/AM-date-property-write-roundtrip.md`,
+fixed separately) made the tickets project read-only. The blast radius of a
+corrupt file should be that file, not all writes.
+
+## Fix direction
+
+**Do not fetch content.** This is the natural first consumer of
+`store.EntityHeader` / `ListEntityHeaders` from the analyze-memory ticket —
+headers carry ID, type and properties, never the body. That alone removes the
+535 MB transfer.
+
+Better still, do not scan at all. Computing "max sequence number for prefix P"
+is a `SELECT max(...) WHERE id LIKE 'P-%'` — an indexed aggregate, O(log n), no
+rows to the client. That likely wants a store capability (`NextSequentialID` or
+similar), type-asserted like `HistoryReader`, with the existing scan as the
+generic fallback for backends that cannot express it.
+
+Note the correctness constraint documented on `collectAllIDs`: a *partial* scan
+must never feed ID generation, because a truncated list can hide a high-numbered
+existing ID and the generator would mint a duplicate. Any replacement must
+preserve fail-loudly-on-error semantics. `createCore` rejects a collision with
+`ErrEntityAlreadyExists`, so the failure mode is a spurious conflict rather than
+data loss — but the invariant should be kept, not weakened.
+
+Fault isolation is a separate decision that needs an explicit call: should a
+malformed entity file be skipped-with-warning during ID generation, or continue
+to fail closed? Failing closed is defensible (it is the current documented
+intent), but today it fails closed on *all writes* rather than on the affected
+entity, which is almost certainly not intended.
+
+## Scope
+
+**In scope**
+
+- Remove content from the ID-generation read path.
+- Evaluate and, if viable, implement an indexed max-sequence store capability with a
+scan fallback.
+- Decide and document the fault-isolation behaviour for a malformed entity.
+- Benchmark create latency at 1k / 10k / 100k entities, before and after.
+
+**Out of scope**
+
+- Short-ID generation strategy (`entityDef.IsShortID()` takes a different path through
+`GenerateShortID` and needs the count, not the max — assess separately).
+- The `_analyze` retention fix (separate ticket; this one consumes its `EntityHeader`
+type if that lands first).
+
+## Acceptance criteria
+
+1. Create latency is flat in entity count for sequential-ID types: creating entity
+   #100,000 costs approximately what #100 costs.
+2. No entity body is transferred from the store during ID generation, verified by
+query inspection or a store-level assertion.
+3. Uncontended create at 262k entities drops from 0.74 s to well under 50 ms.
+4. 80-way concurrent creates no longer produce multi-second latencies.
+5. Generated IDs remain collision-free — the existing "partial scan must not feed the
+generator" invariant holds, with a test that a store error during ID generation
+fails the create rather than minting a possibly-duplicate ID.
+6. Documented, tested behaviour for a malformed entity file during ID generation.
+
+## Test plan
+
+- **Latency benchmark** at 1k / 10k / 100k entities asserting sub-linear scaling
+(this is the test that would have surfaced the defect).
+- Collision test: concurrent creates of the same type must not produce duplicate IDs.
+- Error-propagation test: an injected store error during ID generation fails the
+create; no ID is minted.
+- Malformed-entity test pinning whichever fault-isolation behaviour is chosen.
+- `storetest` conformance for any new capability, plus explicit fallback coverage.
+
+## Related
+
+- Analyze OOM ticket — introduces `store.EntityHeader` / `ListEntityHeaders`; this is
+its second consumer.
+- Scheduler amplification bug — the leak it caused made every subsequent create slower
+via this path, so the two defects compounded in production.

--- a/tickets/entities/tickets/TKT-69TDK8.md
+++ b/tickets/entities/tickets/TKT-69TDK8.md
@@ -5,7 +5,7 @@ title: 'collectAllIDs scans every entity with content on each create: O(n) laten
 kind: refactor
 priority: high
 effort: m
-status: ready
+status: backlog
 ---
 
 ## Problem

--- a/tickets/relations/BUG-3U61TX--adds-measure--AM-pgstore-listener-tolerates-pool-dsn-params.md
+++ b/tickets/relations/BUG-3U61TX--adds-measure--AM-pgstore-listener-tolerates-pool-dsn-params.md
@@ -1,0 +1,5 @@
+---
+from: BUG-3U61TX
+relation: adds-measure
+to: AM-pgstore-listener-tolerates-pool-dsn-params
+---

--- a/tickets/relations/BUG-3U61TX--affects--store-backends.md
+++ b/tickets/relations/BUG-3U61TX--affects--store-backends.md
@@ -1,0 +1,5 @@
+---
+from: BUG-3U61TX
+relation: affects
+to: store-backends
+---

--- a/tickets/relations/BUG-3U61TX--fixes--FEAT-CO4YP.md
+++ b/tickets/relations/BUG-3U61TX--fixes--FEAT-CO4YP.md
@@ -1,0 +1,5 @@
+---
+from: BUG-3U61TX
+relation: fixes
+to: FEAT-CO4YP
+---

--- a/tickets/relations/BUG-E9DYW5--has-review--REV-E9DYW5.md
+++ b/tickets/relations/BUG-E9DYW5--has-review--REV-E9DYW5.md
@@ -1,0 +1,5 @@
+---
+from: BUG-E9DYW5
+type: has-review
+to: REV-E9DYW5
+---

--- a/tickets/relations/BUG-YZ13IJ--adds-measure--AM-scheduler-failed-task-no-retry-storm.md
+++ b/tickets/relations/BUG-YZ13IJ--adds-measure--AM-scheduler-failed-task-no-retry-storm.md
@@ -1,0 +1,5 @@
+---
+from: BUG-YZ13IJ
+relation: adds-measure
+to: AM-scheduler-failed-task-no-retry-storm
+---

--- a/tickets/relations/BUG-YZ13IJ--affects--lua-scripting.md
+++ b/tickets/relations/BUG-YZ13IJ--affects--lua-scripting.md
@@ -1,0 +1,5 @@
+---
+from: BUG-YZ13IJ
+relation: affects
+to: lua-scripting
+---

--- a/tickets/relations/BUG-YZ13IJ--fixes--FEAT-QAOV6.md
+++ b/tickets/relations/BUG-YZ13IJ--fixes--FEAT-QAOV6.md
@@ -1,0 +1,5 @@
+---
+from: BUG-YZ13IJ
+relation: fixes
+to: FEAT-QAOV6
+---

--- a/tickets/relations/TKT-1ESTYJ--affects--data-entry-server.md
+++ b/tickets/relations/TKT-1ESTYJ--affects--data-entry-server.md
@@ -1,0 +1,5 @@
+---
+from: TKT-1ESTYJ
+relation: affects
+to: data-entry-server
+---

--- a/tickets/relations/TKT-1ESTYJ--affects--rest-api.md
+++ b/tickets/relations/TKT-1ESTYJ--affects--rest-api.md
@@ -1,0 +1,5 @@
+---
+from: TKT-1ESTYJ
+relation: affects
+to: rest-api
+---

--- a/tickets/relations/TKT-1ESTYJ--affects--store-backends.md
+++ b/tickets/relations/TKT-1ESTYJ--affects--store-backends.md
@@ -1,0 +1,5 @@
+---
+from: TKT-1ESTYJ
+relation: affects
+to: store-backends
+---

--- a/tickets/relations/TKT-1ESTYJ--has-review--REV-1ESTYJ.md
+++ b/tickets/relations/TKT-1ESTYJ--has-review--REV-1ESTYJ.md
@@ -1,0 +1,5 @@
+---
+from: TKT-1ESTYJ
+type: has-review
+to: REV-1ESTYJ
+---

--- a/tickets/relations/TKT-1ESTYJ--implements--FEAT-CO4YP.md
+++ b/tickets/relations/TKT-1ESTYJ--implements--FEAT-CO4YP.md
@@ -1,0 +1,5 @@
+---
+from: TKT-1ESTYJ
+relation: implements
+to: FEAT-CO4YP
+---

--- a/tickets/relations/TKT-69TDK8--affects--store-backends.md
+++ b/tickets/relations/TKT-69TDK8--affects--store-backends.md
@@ -1,0 +1,5 @@
+---
+from: TKT-69TDK8
+relation: affects
+to: store-backends
+---

--- a/tickets/relations/TKT-69TDK8--implements--FEAT-CO4YP.md
+++ b/tickets/relations/TKT-69TDK8--implements--FEAT-CO4YP.md
@@ -1,0 +1,5 @@
+---
+from: TKT-69TDK8
+relation: implements
+to: FEAT-CO4YP
+---


### PR DESCRIPTION
## Problem

A single `GET /api/v1/_analyze` took the server from **19 MB to 2,947 MB RSS**; three concurrent requests reached **6,264 MB**. Any caller able to reach the endpoint could OOM the host.

Reported as a scheduler leak (a misconfigured ACL leaked 11,222 orphan entities). That was real and is filed separately as BUG-YZ13IJ, but it was the *trigger*, not the defect: it inflated one entity type until a previously-fine endpoint became fatal.

## Root cause

Analyzers drained the whole store into a slice/map and held it across the scan:

```go
entities := make([]*entity.Entity, 0)
for e, err := range svc.reads.ListEntities(ctx, store.EntityQuery{}) {
    entities = append(entities, e)   // every entity, content included
}
sortStoreEntitiesByID(entities)      // ...because it needs them all at once, to sort
```

Two defects compounded. **Retention** — O(n) in entity count. **Payload** — every retained entity carried its markdown body, and `analyze.go` never reads `.Content` at all. The 1.05 GB the profile attributed to `pgx scanPlanString.Scan` was entirely wasted bytes.

## Approach

**(A) `store.EntityHeader` + `HeaderReader`** — an optional store capability, type-asserted like `Formatter`, with a generic in-process fallback. pgstore omits the content column from the SELECT so bodies never leave the database.

A distinct type rather than an `EntityQuery{OmitContent: true}` flag: a half-populated `entity.Entity` satisfies every interface a real one does and lies to all of them. `computeEntityETag` hashes `.Content` and would return a well-formed ETag for the wrong bytes, silently breaking conditional requests. There are ~337 `.Content` reads across 12 packages; a bool flag makes each a latent bug. The compiler now rejects the mistake.

**(B) Bounded gated header reads** — `ScriptReader.ListEntities` materializes the *entire* matching set to hand to `Reader.Filter`, because the row gate batches per type. A type-less scan therefore retained the whole store. **Fixing `analyze.go` alone would not have fixed the OOM.** `ListEntityHeaders` gates in chunks of 512, so retention is bounded by the chunk while probes stay O(types) per chunk rather than O(rows).

**(C) Per-section issue caps** — 100 issues per check. Streaming analyzers stop scanning once they observe a 101st, so the cap bounds *work*, not just output. Truncation is surfaced (`truncatedChecks` → `100+` and a notice in the UI), never silent: an operator who fixes all 100, re-runs and sees 100 again would otherwise conclude analysis is broken.

## Results

Measured against the original repro dataset (20k entities, 1,974 MB of content, real PostgreSQL):

| | Before | After |
|---|---|---|
| Peak RSS, 1 request | 2,947 MB | **51 MB** |
| Peak RSS, 3 concurrent | 6,264 MB | **55 MB** |
| Latency | 20.7 s | **1.3 s** |

**Flat in body size** — the same 20k entities with *empty* bodies peak at 50 MB versus 51 MB with 2 GB of markdown. A 1 MB difference across a 2 GB swing: the remaining cost is ids and properties, not content.

## Worth reviewer attention

**A/B/C alone did not meet the acceptance criteria.** After all three, `_analyze` still peaked at 1,454 MB. Only running the repro found it — every unit test passed. Profiling turned up three more whole-store body loads, two outside `internal/dataentry` entirely: `tracer.FindOrphans`, `visibility.VisibleTracer.FindOrphans` (one full `GetEntity` per orphan to read `.Type`), and `analyzeOrphans` re-loading every orphan as a full entity (~930 MB alone). The ticket was scoped to `analyze.go`; the fix spans four packages.

**ACL is load-bearing here.** Header gating is asserted as *equivalence against `ListEntities`* rather than hand-written expectations, so the two cannot drift, and mutation-tested: removing the gate from `FilterHeaders` fails with `hidden entity SEC-1 leaked through the header path`. `FindOrphans`'s two type-resolution paths are tested to produce identical visible sets, since a divergence would be an ACL bug appearing only on stores lacking the header capability. The orphan re-load through the gated reader is kept (load-bearing for TKT-3FL2S6) and bounded instead.

**One deliberate imprecision, documented in code**: on a *truncated* section, which 100 issues survive is "the first 100 in store order", and store order (ascending by id) is not natural order. So truncated output is a bounded sample, not "the naturally-first 100".

## Verification

`just lint` 0 issues · `just arch-lint` OK · `just coverage-check` PASS (`internal/visibility` 84.8% → 87.4%) · full Go suite · 1,609 frontend tests · pgstore conformance against a real database · `vue-tsc` clean.

## Not included

Deliberately out of scope, per the ticket: migrating list/search/kanban-card surfaces to `EntityHeader` (each its own verifiable migration, and the reason A is a typed capability), and caching/precomputing analysis (the real fix for the per-request multiplier).

`analysisIssueCounts` now returns capped counts and is documented as such — it has no production caller; a real dashboard badge needs its own uncapped count-only path. `listAllFromStore` keeps the unbounded shape but is unreachable (every caller passes an explicit type); documented rather than speculatively rewritten.

Closes TKT-1ESTYJ.
