### PR TITLE
perf(dataentry): serve custom/ assets via http.ServeContent

### DIFF
--- a/docs/customisation.md
+++ b/docs/customisation.md
@@ -240,8 +240,10 @@ suppressed.
 - `custom.css` and `custom.js` are optional and independent. Absent means no
   reference is injected, and the URL 404s.
 - Changes are picked up without a server restart. Reload the page.
-- Served with `Cache-Control: no-cache`, so an edit is visible on reload rather
-  than stranding you on a cached copy.
+- Served with `Cache-Control: no-cache` plus an `ETag`, so a browser
+  revalidates on every request but an unchanged asset comes back as a bodiless
+  `304` — your edits appear immediately, and a large font or image is not
+  re-downloaded on every page. `Range` requests are supported.
 - Every file in `custom/` is served, including nested paths. Files **outside**
   `custom/` are never reachable through `/_custom/`, and there is no directory
   listing and no `index.html` resolution — `/_custom/fonts/` is a 404, not a

--- a/e2e/pages/customisation.page.ts
+++ b/e2e/pages/customisation.page.ts
@@ -31,6 +31,19 @@ export class CustomisationPage extends BasePage {
     return { status: res.status(), contentType: res.headers()['content-type'] ?? '', body: await res.text() };
   }
 
+  /**
+   * Fetch a /_custom/ asset with optional request headers, exposing the status
+   * and response headers a caching assertion needs.
+   */
+  async fetchCustomAssetWithHeaders(
+    serverUrl: string,
+    relPath: string,
+    headers: Record<string, string> = {},
+  ) {
+    const res = await this.page.request.get(`${serverUrl}/_custom/${relPath}`, { headers });
+    return { status: res.status(), headers: res.headers(), body: await res.text() };
+  }
+
   /** Whether the SPA shell references the operator's module script. */
   async hasCustomScript(): Promise<boolean> {
     return (await this.page.locator('script[src="/_custom/custom.js"]').count()) > 0;

--- a/e2e/tests/customisation.spec.ts
+++ b/e2e/tests/customisation.spec.ts
@@ -161,4 +161,29 @@ test.describe('Operator customisation hooks', () => {
       );
     }
   });
+
+  test('an unchanged asset revalidates to a 304 instead of re-transferring', async ({
+    appPage,
+    testProject,
+    serverUrl,
+  }) => {
+    // The point of moving to http.ServeContent: a webfont or image is not
+    // re-downloaded on every navigation. Asserted over real HTTP because this
+    // is protocol behaviour a Go unit test can only approximate.
+    writeCustom(testProject, 'logo.svg', '<svg xmlns="http://www.w3.org/2000/svg"/>');
+
+    const custom = new CustomisationPage(appPage);
+
+    const first = await custom.fetchCustomAssetWithHeaders(serverUrl, 'logo.svg');
+    expect(first.status).toBe(200);
+    const etag = first.headers['etag'];
+    expect(etag, 'asset must carry a validator').toBeTruthy();
+    expect(first.headers['cache-control']).toContain('no-cache');
+
+    const second = await custom.fetchCustomAssetWithHeaders(serverUrl, 'logo.svg', {
+      'If-None-Match': etag,
+    });
+    expect(second.status, 'unchanged asset must revalidate to 304').toBe(304);
+    expect(second.body, '304 must carry no body').toBe('');
+  });
 });

--- a/internal/dataentry/CLAUDE.md
+++ b/internal/dataentry/CLAUDE.md
@@ -270,6 +270,23 @@ file (fonts, logos, images) is served as-is. Rules for new code:
   `.env`, `.git/config`, `.DS_Store`. It contributes ZERO traversal defence
   (`path.Clean` resolves `..` before it runs) and is a filename heuristic, not a
   secrets scanner — `notes.md` and `custom.css~` are served.
+- **Assets are delivered by `http.ServeContent`, not `w.Write`.** That is what
+  gives conditional requests, `Range` and correct `HEAD` in one call; before it,
+  a static webfont re-transferred on every navigation and a `HEAD` returned a
+  body. Two things must survive any change here: the explicit `Content-Type`
+  (ServeContent sniffs when it cannot infer one — the exact behaviour `nosniff`
+  exists to prevent) and the pre-read size gate, since ServeContent would
+  otherwise happily stream a file of any size.
+- **The ETag is modtime+size, deliberately not a content hash.** Hashing would
+  read the whole file per request — a read amplifier on an unauthenticated
+  route, and the cost ServeContent was adopted to avoid. `http.FileServer` makes
+  the same trade. The blind spot (an edit preserving both modtime and size) is
+  bounded by `Cache-Control: no-cache`, which forces revalidation anyway.
+- **`openCustomEntryFile` duplicates the containment chain** because it must
+  return a live handle, so it cannot delegate to `openCustomEntry`. A duplicated
+  security check drifts: `TestOpenCustomEntryFile_MatchesOpenCustomEntry` pins
+  that the two agree, and `TestOpenCustomEntryFile_NeverEscapes` attacks the new
+  path independently.
 - **`/_custom/` is PUBLIC and UNAUTHENTICATED** — not an `isAPIPath`, so outside
   both the JWT gate and ACL, deliberately, so the shell loads before login. This
   is a wider exposure than `apps/`, which this code otherwise copies. Every

--- a/internal/dataentry/custom.go
+++ b/internal/dataentry/custom.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path"
 	"strings"
+	"time"
 
 	"github.com/Sourcehaven-BV/rela/internal/project"
 )
@@ -172,6 +173,84 @@ func openCustomEntry(projectRoot, entry string) ([]byte, error) {
 		return nil, errCustomAssetNotFound
 	}
 	return b, nil
+}
+
+// customEntryFile is an open custom/ entry plus the metadata http.ServeContent
+// needs. Close releases the file AND the two os.Root handles that scoped it —
+// all three must outlive the response body, which is why they travel together
+// rather than being closed inside the opener.
+type customEntryFile struct {
+	File    *os.File
+	ModTime time.Time
+	Size    int64
+
+	roots []io.Closer
+}
+
+// Close releases the file and its scoping roots, innermost first.
+func (c *customEntryFile) Close() {
+	_ = c.File.Close()
+	for i := len(c.roots) - 1; i >= 0; i-- {
+		_ = c.roots[i].Close()
+	}
+}
+
+// openCustomEntryFile resolves an entry exactly as openCustomEntry does, but
+// hands back the OPEN file so http.ServeContent can stream it and honor Range
+// and conditional requests. The caller MUST Close the result.
+//
+// Same containment chain, same uniform error. Kept as a sibling of
+// openCustomEntry rather than replacing it because the shell-injection path
+// genuinely wants the bytes, and a Close-me handle is the wrong shape there.
+func openCustomEntryFile(projectRoot, entry string) (*customEntryFile, error) {
+	rel, ok := validCustomEntry(entry)
+	if !ok {
+		return nil, errCustomAssetNotFound
+	}
+
+	root, err := os.OpenRoot(projectRoot)
+	if err != nil {
+		return nil, errCustomAssetNotFound
+	}
+	customRoot, err := root.OpenRoot(project.CustomDir)
+	if err != nil {
+		_ = root.Close()
+		return nil, errCustomAssetNotFound
+	}
+	closeRoots := func() {
+		_ = customRoot.Close()
+		_ = root.Close()
+	}
+
+	f, err := customRoot.Open(rel)
+	if err != nil {
+		closeRoots()
+		return nil, errCustomAssetNotFound
+	}
+
+	info, err := f.Stat()
+	if err != nil || info.IsDir() {
+		_ = f.Close()
+		closeRoots()
+		return nil, errCustomAssetNotFound
+	}
+	// Same pre-read size gate as openCustomEntry: reject from the Stat so an
+	// oversize file cannot be used as a read amplifier on this unauthenticated
+	// route. ServeContent would otherwise happily stream 4 GiB.
+	if info.Size() > maxCustomFileBytes {
+		slog.Warn("custom asset exceeds size cap, not served",
+			"entry", rel, "max_bytes", maxCustomFileBytes)
+		_ = f.Close()
+		closeRoots()
+		return nil, errCustomAssetNotFound
+	}
+
+	return &customEntryFile{
+		File:    f,
+		ModTime: info.ModTime(),
+		Size:    info.Size(),
+		roots:   []io.Closer{root, customRoot},
+	}, nil
 }
 
 // customAssetExists reports whether an entry is present under custom/. Runs on

--- a/internal/dataentry/custom_handler.go
+++ b/internal/dataentry/custom_handler.go
@@ -1,7 +1,10 @@
 package dataentry
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"net/http"
+	"strconv"
 	"strings"
 )
 
@@ -23,33 +26,41 @@ import (
 // There is deliberately NO index resolution: /_custom/fonts/ must 404, not
 // serve fonts/index.html. "Serve arbitrary files from a directory" is the exact
 // phrasing that invites someone to add it later.
+//
+// Delivery goes through http.ServeContent (TKT-IWMETE follow-up), which gives
+// conditional requests, Range and correct HEAD semantics in one call. Before
+// this, a 200KB webfont re-transferred in full on every navigation and a
+// non-GET method still received a body.
 func (c *customAssets) serveAsset(w http.ResponseWriter, r *http.Request) {
 	entry := strings.TrimPrefix(r.URL.Path, customURLPrefix)
 
-	body, err := openCustomEntry(c.projectRoot, entry)
+	f, err := openCustomEntryFile(c.projectRoot, entry)
 	if err != nil {
 		http.NotFound(w, r)
 		return
 	}
+	defer f.Close()
 
 	h := w.Header()
 	// Extension-based, from the same fixed map apps/ uses: deterministic across
 	// deploy boxes (unlike mime.TypeByExtension), unknown → octet-stream, which
 	// a browser will neither execute nor render.
+	//
+	// Set explicitly because ServeContent would otherwise sniff the first 512
+	// bytes when it cannot infer a type from the name — the exact behavior
+	// nosniff exists to prevent.
 	h.Set("Content-Type", appEntryContentType(entry))
 	// The bytes are operator-authored and may be executable; never let a
 	// browser sniff a different type out of them.
 	h.Set("X-Content-Type-Options", "nosniff")
 	// These URLs are NOT content-hashed — /_custom/logo.svg is stable forever —
 	// so heuristic caching would serve a stale asset after an operator edits it
-	// with no way to bust it. no-cache means "revalidate", not "don't store".
-	//
-	// Known gap (RR-DR-ETAG): there is no ETag/Last-Modified, so a static
-	// webfont re-transfers in full on every navigation. RR-CR-ETAG deferred
-	// this when the only outputs were a 3.4KB shell and two text files; that
-	// rationale does not carry to a 200KB font, and the fix (http.ServeContent)
-	// would bring conditional requests and Range in one call.
+	// with no way to bust it. no-cache means "revalidate, then reuse if
+	// unchanged", which is exactly right now that there is an ETag to
+	// revalidate against: the browser still asks every time, but an unmodified
+	// asset comes back as a bodiless 304.
 	h.Set("Cache-Control", "no-cache")
+	h.Set("ETag", customEntryETag(f.ModTime.UnixNano(), f.Size))
 
 	// #nosec G705 -- not an HTML sink in the XSS sense. The bytes are
 	// operator-authored by design: this is the documented "custom.js is fully
@@ -59,9 +70,26 @@ func (c *customAssets) serveAsset(w http.ResponseWriter, r *http.Request) {
 	// endpoint with the caller's session. Escaping operator CSS or JS would
 	// break the feature rather than protect anything.
 	//
-	// NOTE: the pre-TKT-IWMETE version of this comment claimed the boundary was
-	// "the two-name allowlist, which decides WHICH file may be read". That
-	// allowlist is gone. The boundary is now validCustomEntry + the nested
-	// os.OpenRoot containment in openCustomEntry.
-	_, _ = w.Write(body)
+	// The containment boundary is validCustomEntry + the nested os.OpenRoot in
+	// openCustomEntryFile — NOT a filename allowlist, which TKT-IWMETE removed.
+	http.ServeContent(w, r, entry, f.ModTime, f.File)
+}
+
+// customEntryETag derives a strong ETag from an entry's modtime and size.
+//
+// Deliberately NOT a content hash: hashing would mean reading the whole file on
+// every request, which is what ServeContent was adopted to avoid, and on an
+// unauthenticated route that is a read amplifier. modtime+size is what
+// http.FileServer uses for the same reason. The failure mode — an edit that
+// preserves both — is not reachable by an operator editing a file, and
+// Cache-Control: no-cache means a stale entity is at worst one revalidation old
+// rather than cached indefinitely.
+//
+// Hashed rather than formatted so the value leaks no filesystem metadata.
+func customEntryETag(modUnixNano, size int64) string {
+	// Formatted rather than converted to uint64: the values are non-negative
+	// here, but a signed->unsigned cast is a gosec G115 finding and suppressing
+	// it would be noise for no benefit. Hashing the text is equivalent.
+	sum := sha256.Sum256([]byte(strconv.FormatInt(modUnixNano, 10) + ":" + strconv.FormatInt(size, 10)))
+	return `"` + hex.EncodeToString(sum[:16]) + `"`
 }

--- a/internal/dataentry/custom_test.go
+++ b/internal/dataentry/custom_test.go
@@ -925,3 +925,29 @@ func TestOpenCustomEntryFile_NeverEscapes(t *testing.T) {
 		})
 	}
 }
+
+// TestServeAsset_OversizeNotStreamed pins the pre-read size gate against the
+// ServeContent path specifically.
+//
+// The gate exists because /_custom/ is unauthenticated: without it, one
+// oversize file in custom/ is a read amplifier. Moving delivery to
+// ServeContent made this easy to lose — ServeContent takes a ReadSeeker and
+// will happily stream a file of any size, so the cap MUST be enforced from the
+// Stat in openCustomEntryFile, before a handle is ever returned.
+func TestServeAsset_OversizeNotStreamed(t *testing.T) {
+	root := t.TempDir()
+	writeCustom(t, root, "huge.png", strings.Repeat("x", maxCustomFileBytes+1))
+	custom := newCustomAssets(root, []byte(testShell), func() bool { return true })
+
+	rec := httptest.NewRecorder()
+	custom.serveAsset(rec, httptest.NewRequest(http.MethodGet, customURLPrefix+"huge.png", http.NoBody))
+
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want 404", rec.Code)
+	}
+	// A 404 body is a few dozen bytes; anything near the cap means the file was
+	// streamed before the gate ran.
+	if rec.Body.Len() > 1024 {
+		t.Errorf("response carried %d bytes — the oversize file was streamed", rec.Body.Len())
+	}
+}

--- a/internal/dataentry/custom_test.go
+++ b/internal/dataentry/custom_test.go
@@ -2,6 +2,7 @@ package dataentry
 
 import (
 	"bytes"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -9,6 +10,7 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/Sourcehaven-BV/rela/internal/project"
 )
@@ -710,6 +712,215 @@ func TestOpenCustomEntry_NeverEscapes(t *testing.T) {
 			b, err := openCustomEntry(root, v)
 			if err == nil && strings.Contains(string(b), "LEAKED") {
 				t.Errorf("LEAK: %q served %q from outside custom/", v, b)
+			}
+		})
+	}
+}
+
+// TestServeAsset_ConditionalRequests pins the payoff of moving to
+// http.ServeContent: an unchanged asset revalidates to a bodiless 304 instead
+// of re-transferring. Before this, a 200KB webfont was sent in full on every
+// navigation (RR-CR2-SERVECONTENT).
+func TestServeAsset_ConditionalRequests(t *testing.T) {
+	root := t.TempDir()
+	writeCustom(t, root, "logo.svg", "<svg/>")
+	custom := newCustomAssets(root, []byte(testShell), func() bool { return true })
+
+	// First request: full body plus a validator.
+	rec := httptest.NewRecorder()
+	custom.serveAsset(rec, httptest.NewRequest(http.MethodGet, customURLPrefix+"logo.svg", http.NoBody))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	etag := rec.Header().Get("ETag")
+	if etag == "" {
+		t.Fatal("no ETag — conditional requests cannot work without a validator")
+	}
+	if rec.Body.String() != "<svg/>" {
+		t.Fatalf("body = %q, want the asset", rec.Body.String())
+	}
+
+	// Second request with the validator: 304, no body.
+	req := httptest.NewRequest(http.MethodGet, customURLPrefix+"logo.svg", http.NoBody)
+	req.Header.Set("If-None-Match", etag)
+	rec2 := httptest.NewRecorder()
+	custom.serveAsset(rec2, req)
+
+	if rec2.Code != http.StatusNotModified {
+		t.Errorf("status = %d, want 304 for an unchanged asset", rec2.Code)
+	}
+	if rec2.Body.Len() != 0 {
+		t.Errorf("304 carried a %d-byte body; it must be empty", rec2.Body.Len())
+	}
+}
+
+// TestServeAsset_ETagChangesOnEdit is the other half: a 304 is only correct if
+// editing the file invalidates the validator. A constant ETag would serve stale
+// content forever.
+func TestServeAsset_ETagChangesOnEdit(t *testing.T) {
+	root := t.TempDir()
+	writeCustom(t, root, "custom.css", ".a{color:red}")
+	custom := newCustomAssets(root, []byte(testShell), func() bool { return true })
+
+	get := func() (string, string) {
+		rec := httptest.NewRecorder()
+		custom.serveAsset(rec, httptest.NewRequest(http.MethodGet, customURLPrefix+"custom.css", http.NoBody))
+		return rec.Header().Get("ETag"), rec.Body.String()
+	}
+
+	etag1, body1 := get()
+
+	// Rewrite with different content AND a distinct modtime — the ETag derives
+	// from modtime+size, so a same-size edit within one filesystem timestamp
+	// tick is the known blind spot (documented on customEntryETag).
+	writeCustom(t, root, "custom.css", ".a{color:blue}!!")
+	future := time.Now().Add(2 * time.Second)
+	if err := os.Chtimes(filepath.Join(root, project.CustomDir, "custom.css"), future, future); err != nil {
+		t.Fatal(err)
+	}
+
+	etag2, body2 := get()
+	if body1 == body2 {
+		t.Fatal("fixture did not change the content")
+	}
+	if etag1 == etag2 {
+		t.Error("ETag unchanged after an edit — clients would serve stale content indefinitely")
+	}
+}
+
+// TestServeAsset_RangeAndHEAD pins the other two things ServeContent brings.
+// Previously every method received a full body, including HEAD, and Range was
+// ignored.
+func TestServeAsset_RangeAndHEAD(t *testing.T) {
+	root := t.TempDir()
+	writeCustom(t, root, "fonts/brand.woff2", "0123456789")
+	custom := newCustomAssets(root, []byte(testShell), func() bool { return true })
+	const path = customURLPrefix + "fonts/brand.woff2"
+
+	t.Run("range yields 206 and the requested bytes", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, path, http.NoBody)
+		req.Header.Set("Range", "bytes=2-4")
+		rec := httptest.NewRecorder()
+		custom.serveAsset(rec, req)
+
+		if rec.Code != http.StatusPartialContent {
+			t.Errorf("status = %d, want 206", rec.Code)
+		}
+		if got := rec.Body.String(); got != "234" {
+			t.Errorf("body = %q, want %q", got, "234")
+		}
+	})
+
+	t.Run("HEAD carries headers but no body", func(t *testing.T) {
+		rec := httptest.NewRecorder()
+		custom.serveAsset(rec, httptest.NewRequest(http.MethodHead, path, http.NoBody))
+
+		if rec.Code != http.StatusOK {
+			t.Errorf("status = %d, want 200", rec.Code)
+		}
+		if rec.Body.Len() != 0 {
+			t.Errorf("HEAD returned a %d-byte body", rec.Body.Len())
+		}
+		if ct := rec.Header().Get("Content-Type"); ct != "font/woff2" {
+			t.Errorf("Content-Type = %q, want font/woff2", ct)
+		}
+	})
+}
+
+// TestServeAsset_HeadersSurviveServeContent guards the headers this route sets
+// deliberately. ServeContent writes its own Content-Type when it can infer one,
+// so nosniff and the explicit type must still be what leaves the handler —
+// otherwise an unknown extension could be sniffed into something executable.
+func TestServeAsset_HeadersSurviveServeContent(t *testing.T) {
+	root := t.TempDir()
+	// .avif is NOT in appContentTypes, so it must come back as octet-stream
+	// rather than whatever content sniffing would guess.
+	writeCustom(t, root, "data.avif", "<html>not really avif</html>")
+	custom := newCustomAssets(root, []byte(testShell), func() bool { return true })
+
+	rec := httptest.NewRecorder()
+	custom.serveAsset(rec, httptest.NewRequest(http.MethodGet, customURLPrefix+"data.avif", http.NoBody))
+
+	if got := rec.Header().Get("Content-Type"); got != "application/octet-stream" {
+		t.Errorf("Content-Type = %q, want application/octet-stream (content must not be sniffed)", got)
+	}
+	if got := rec.Header().Get("X-Content-Type-Options"); got != "nosniff" {
+		t.Errorf("X-Content-Type-Options = %q, want nosniff", got)
+	}
+	if got := rec.Header().Get("Cache-Control"); got != "no-cache" {
+		t.Errorf("Cache-Control = %q, want no-cache", got)
+	}
+}
+
+// TestOpenCustomEntryFile_MatchesOpenCustomEntry pins that the two openers
+// agree. They share a containment chain by construction, but a divergence would
+// mean the shell references an asset the handler refuses (or vice versa).
+func TestOpenCustomEntryFile_MatchesOpenCustomEntry(t *testing.T) {
+	root := t.TempDir()
+	writeCustom(t, root, "custom.css", ".a{}")
+	writeCustom(t, root, "fonts/b.woff2", "F")
+	writeCustom(t, root, ".env", "SECRET=1")
+	writeCustom(t, root, "big.png", strings.Repeat("x", maxCustomFileBytes+1))
+	writeProjectRoot(t, root, "outside.txt", "LEAKED")
+
+	entries := []string{
+		"custom.css", "fonts/b.woff2", ".env", "big.png",
+		"../outside.txt", "..%2Foutside.txt", "", ".", "..",
+		"fonts", "nope.css", "sub/.git/config",
+	}
+	for _, e := range entries {
+		t.Run(strconv.Quote(e), func(t *testing.T) {
+			_, byteErr := openCustomEntry(root, e)
+			fh, fileErr := openCustomEntryFile(root, e)
+			if fileErr == nil {
+				fh.Close()
+			}
+			if (byteErr == nil) != (fileErr == nil) {
+				t.Errorf("openCustomEntry err=%v but openCustomEntryFile err=%v — the two openers must agree",
+					byteErr, fileErr)
+			}
+		})
+	}
+}
+
+// TestOpenCustomEntryFile_NeverEscapes attacks the ServeContent read path
+// directly. openCustomEntryFile duplicates the containment chain (it must hand
+// back a live handle, so it cannot simply call openCustomEntry), and a
+// duplicated security check is exactly the kind that drifts. Asserts the
+// property, not the error: sensitive files outside custom/ with no decoy
+// inside, and the content must never appear.
+func TestOpenCustomEntryFile_NeverEscapes(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, project.CustomDir), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeProjectRoot(t, root, "outside.txt", "LEAKED-OUTSIDE")
+	writeProjectRoot(t, root, "schema.yaml", "LEAKED-SCHEMA")
+
+	// A symlink INSIDE custom/ pointing at an in-project file outside it: the
+	// case a single os.OpenRoot would follow, since the target never leaves the
+	// project root.
+	link := filepath.Join(root, project.CustomDir, "link.yaml")
+	if err := os.Symlink(filepath.Join(root, "schema.yaml"), link); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+
+	vectors := []string{
+		"../outside.txt", "../../outside.txt", "../schema.yaml", "link.yaml",
+		"sub/../../outside.txt", "/outside.txt", "....//outside.txt",
+		"a/b/../../../outside.txt", "..%2Foutside.txt",
+		"../../../../../../etc/passwd",
+	}
+	for _, v := range vectors {
+		t.Run(strconv.Quote(v), func(t *testing.T) {
+			fh, err := openCustomEntryFile(root, v)
+			if err != nil {
+				return // refused outright
+			}
+			defer fh.Close()
+			b, _ := io.ReadAll(fh.File)
+			if strings.Contains(string(b), "LEAKED") {
+				t.Errorf("LEAK: %q streamed %q from outside custom/", v, b)
 			}
 		})
 	}

--- a/tickets/entities/review-responses/RR-CR2-SERVECONTENT.md
+++ b/tickets/entities/review-responses/RR-CR2-SERVECONTENT.md
@@ -8,18 +8,35 @@ finding: serveAsset uses w.Write, so POST/PUT/DELETE/OPTIONS all return 200 with
   the deferral be re-opened or re-justified rather than inherited. Shipping with an acknowledging comment
   is not a re-justification.
 severity: minor
-status: deferred
-resolution: DEFERRED to a follow-up ticket, explicitly rather than by inheritance. http.ServeContent would
-  give conditional requests, Range and correct HEAD in one call and would let the manual ReadAll go -
-  the reviewer's highest-leverage suggestion. Not taken here because it changes the read path this ticket
-  just hardened (nested OpenRoot + size check) and would want its own traversal re-verification; folding
-  it into a security-sensitive breaking change is how the careful part gets rushed. Recorded so the next
-  person re-opens it deliberately.
-reason: 'Deferred, not dropped. The fix (http.ServeContent) replaces the exact read path this ticket just
-  hardened with a nested os.OpenRoot and a pre-read size check, so it needs its own traversal and containment
-  re-verification. Bundling that into a breaking layout change is how the careful part gets rushed. The
-  current behaviour is a performance and HTTP-correctness gap, not a security one: assets still serve
-  correctly, just without conditional requests or Range. Follow-up ticket to be opened against FEAT-MD4N6Z.'
+status: addressed
+resolution: 'RESOLVED. serveAsset now delivers via http.ServeContent, which brings conditional requests,
+  Range and correct HEAD semantics in one call. A new openCustomEntryFile returns a live *os.File plus
+  modtime/size instead of bytes; the byte-returning openCustomEntry stays for the shell-injection path,
+  which genuinely wants bytes and would be the wrong shape with a Close-me handle.
+
+
+  ETag is modtime+size, deliberately not a content hash: hashing would read the whole file on every request,
+  which is the exact cost ServeContent was adopted to avoid and a read amplifier on this unauthenticated
+  route. http.FileServer makes the same trade. Cache-Control stays no-cache, so an operator edit is still
+  visible on reload - it now costs a bodiless 304 rather than a full re-transfer.
+
+
+  Two properties had to survive the rewrite and are pinned by tests: the explicit Content-Type (ServeContent
+  sniffs when it cannot infer one - the exact behavior nosniff exists to prevent) and the pre-read size
+  gate (ServeContent would otherwise stream a file of any size).
+
+
+  The deferral concern - that this replaces the read path TKT-IWMETE had just hardened and needs its own
+  containment re-verification - was addressed rather than assumed away. openCustomEntryFile duplicates
+  the containment chain because it cannot delegate to openCustomEntry, and a duplicated security check
+  drifts, so: TestOpenCustomEntryFile_MatchesOpenCustomEntry asserts the two openers agree across 12 vectors,
+  and TestOpenCustomEntryFile_NeverEscapes attacks the new path independently with 10 traversal/symlink
+  vectors asserting content absence. Verified before the change that os.Root files are seekable (ServeContent
+  requires io.ReadSeeker) and that Range yields a real 206.
+
+
+  Also added an e2e test asserting a real 304 over HTTP, since the previous ticket showed Go tests alone
+  can miss protocol behavior.'
 ---
 
 Raised by `/code-review` of the TKT-IWMETE implementation.

--- a/tickets/entities/review-responses/RR-DR-ETAG.md
+++ b/tickets/entities/review-responses/RR-DR-ETAG.md
@@ -11,10 +11,13 @@ finding: 'RR-CR-ETAG was deferred on the explicit grounds that ''the shell is ~3
   is unaffected; that is wrong.'
 severity: minor
 status: addressed
-resolution: Folded into TKT-IWMETE and PLAN-6VVJJZ before implementation. Either re-open RR-CR-ETAG for
-  the asset path specifically (http.ServeContent gives ETag, conditional requests and Range in one call),
-  or explicitly re-justify the deferral against the new asset class rather than inheriting a rationale
-  that was written about a 3.4KB shell. Correct the ticket's Related section either way.
+resolution: "Folded into TKT-IWMETE and PLAN-6VVJJZ before implementation. Either re-open RR-CR-ETAG for\
+  \ the asset path specifically (http.ServeContent gives ETag, conditional requests and Range in one call),\
+  \ or explicitly re-justify the deferral against the new asset class rather than inheriting a rationale\
+  \ that was written about a 3.4KB shell. Correct the ticket's Related section either way. \n\nFOLLOW-UP\
+  \ COMPLETE: the deferral was re-opened rather than inherited again - see RR-CR2-SERVECONTENT. /_custom/\
+  \ now serves via http.ServeContent with an ETag, so a static webfont revalidates to a 304 instead of\
+  \ re-transferring on every navigation."
 ---
 
 Raised by `/design-review` of TKT-IWMETE before implementation.


### PR DESCRIPTION
A 200KB webfont in `custom/` re-transferred in full on **every navigation**. The handler wrote the whole body with no validator, so a browser had nothing to revalidate against; `Range` was ignored and a `HEAD` still received a body.

Resolves `RR-CR2-SERVECONTENT`, deferred from #1321.

## The change

`serveAsset` now delivers through `http.ServeContent`, which brings conditional requests, `Range` and correct `HEAD` semantics in one call. A new `openCustomEntryFile` returns a live `*os.File` plus modtime/size instead of bytes; the byte-returning `openCustomEntry` stays for the shell-injection path, which genuinely wants bytes and would be the wrong shape with a Close-me handle.

**The ETag is modtime+size, not a content hash.** Hashing would read the whole file on every request — the exact cost `ServeContent` was adopted to avoid, and a read amplifier on this unauthenticated route. `http.FileServer` makes the same trade. `Cache-Control` stays `no-cache`, so an operator edit is still visible on reload; it now costs a bodiless `304` rather than a full re-transfer.

## Why this was deferred twice, and why it isn't now

`RR-CR-ETAG` deferred it on the grounds that "the shell is 3.4KB and uncacheable by design". That stopped being true the moment `custom/` started serving fonts — `RR-DR-ETAG` caught the stale rationale being inherited rather than re-justified. This closes it properly.

## The deferral's actual concern, addressed rather than assumed away

The stated reason for not doing this inside #1321 was that it replaces the read path that ticket had just hardened, and so needs its own containment re-verification. It got one:

- **`openCustomEntryFile` duplicates the containment chain** — it must return a live handle, so it cannot delegate to `openCustomEntry`. A duplicated security check drifts.
- `TestOpenCustomEntryFile_MatchesOpenCustomEntry` asserts the two openers agree across **12 vectors** (valid, dotfile, oversize, traversal, directory, missing).
- `TestOpenCustomEntryFile_NeverEscapes` attacks the new path independently with **10 traversal/symlink vectors**, asserting content absence rather than "the request errored" — including a symlink inside `custom/` pointing at an in-project file outside it, the case a single `os.OpenRoot` would follow.

Verified up front that `os.Root` files are seekable (`ServeContent` needs `io.ReadSeeker`) and that `Range` yields a real `206` — before writing the handler, since the whole approach depended on it.

## Two properties that had to survive the rewrite

Both are pinned by tests, because `ServeContent` would otherwise undo them:

- **Explicit `Content-Type`** — `ServeContent` sniffs the first 512 bytes when it cannot infer a type from the name, which is the exact behavior `nosniff` exists to prevent. `TestServeAsset_HeadersSurviveServeContent` feeds HTML bytes to a `.avif` and asserts `application/octet-stream`.
- **The pre-read size gate** — `ServeContent` would happily stream a file of any size, so the cap is enforced from the `Stat` before any handle is returned.

## Verification

New: 5 Go tests (304 round-trip, ETag changes on edit, Range `206`, `HEAD` bodiless, header survival) plus the two containment tests, and an e2e asserting a real `304` over HTTP — the previous ticket showed Go tests alone can miss protocol behavior.

`just ci` green end-to-end: Go suite, lint 0 issues, arch-lint, plimsoll, markdown, docs-check, coverage 77.4%. E2E suite passes.

## Unrelated pre-existing issue spotted

`tickets/entities/automated-measures/AM-feed-field-redaction.md` (from #1314, untouched here) has unquoted `title:` containing a colon, so its frontmatter fails to parse and `rela validate` warns that analysis "may under-count". Not fixed in this PR to keep it scoped — flagging it because it silently degrades ticket analysis.