### PR TITLE
fix(frontend): stop the unit suite reaching the network (BUG-762I34)

### DIFF
--- a/frontend/src/test/noNetwork.test.ts
+++ b/frontend/src/test/noNetwork.test.ts
@@ -1,0 +1,43 @@
+// Guard for BUG-762I34: the unit suite must never reach the network.
+//
+// Before the fix, src/test/setup.ts stubbed localStorage, crypto,
+// ResizeObserver and EventSource but not HTTP, so the shared axios instance
+// used its real node adapter and dialled localhost:3000. Any component with an
+// onMounted fetch (ExportMenu -> getTransforms, reached transitively by
+// DynamicForm and the entity/list views) therefore fired a real request. Local
+// runs got a fast ECONNREFUSED that the component's own catch swallowed; a
+// slower CI runner got `socket hang up` AFTER the triggering test had finished,
+// which vitest reports as an unhandled rejection and fails the run on — with
+// every test passing.
+//
+// These assert the property rather than the symptom, because the symptom is
+// timing-dependent and does not reproduce locally. If someone removes the
+// adapter stub, or adds an api module that builds its own axios instance, this
+// fails deterministically here instead of intermittently in someone else's PR.
+import { describe, it, expect } from 'vitest'
+import axios from 'axios'
+
+import { api } from '@/api/client'
+import { getTransforms } from '@/api/transforms'
+
+describe('unit suite never reaches the network', () => {
+  it('has a non-default axios adapter installed', () => {
+    // The real node adapter is a function named "httpAdapter"; the stub is our
+    // own arrow function. Asserting "not the built-in" rather than a specific
+    // identity keeps this from breaking if the stub is refactored.
+    expect(axios.defaults.adapter).toBeTypeOf('function')
+    expect((axios.defaults.adapter as { name?: string })?.name).not.toBe('httpAdapter')
+  })
+
+  it('resolves an unmocked GET instead of attempting a connection', async () => {
+    // Before the fix this rejected with AggregateError/ECONNREFUSED ::1:3000.
+    await expect(api.get('/_probe_no_such_endpoint')).resolves.toBeDefined()
+  })
+
+  it('resolves the real onMounted call that caused the flake', async () => {
+    // getTransforms() is what ExportMenu calls; it also memoises the promise at
+    // module scope, which is why a rejection could outlive the component that
+    // created it and end up unowned.
+    await expect(getTransforms()).resolves.toBeDefined()
+  })
+})

--- a/frontend/src/test/setup.ts
+++ b/frontend/src/test/setup.ts
@@ -1,3 +1,4 @@
+import axios from 'axios'
 import { vi } from 'vitest'
 import { config } from '@vue/test-utils'
 import { createPinia, setActivePinia } from 'pinia'
@@ -114,3 +115,32 @@ class MockEventSource {
 }
 
 vi.stubGlobal('EventSource', MockEventSource)
+
+// ---------------------------------------------------------------------------
+// Block real HTTP from the unit suite.
+//
+// Every component that mounts an ExportMenu (transitively: DynamicForm,
+// EntityDetail, list views) calls getTransforms() in onMounted. Nothing stubbed
+// the HTTP layer, so those calls left the process and tried to reach
+// localhost:3000. Locally that fails immediately with ECONNREFUSED and the
+// component's own catch swallows it; on a slower, more contended CI runner the
+// socket is torn down mid-request instead, and the rejection lands AFTER the
+// test that triggered it has finished — so no test owns it and vitest reports
+// "Unhandled Rejection: socket hang up" and exits 1 with every test passing.
+// That is the intermittent Frontend failure.
+//
+// Replacing the adapter fixes the class, not the instance: any axios call from
+// any test resolves in-process, deterministically, with no socket. A test that
+// wants a specific payload still mocks its own module (vi.mock) as before —
+// this only decides what an UNMOCKED call does, and "empty 200" keeps the
+// mount-and-assert tests that never cared about the response working unchanged.
+//
+// Deliberately NOT a rejection: several components log to console.error on a
+// failed load, which would spam every unrelated test's output.
+axios.defaults.adapter = async (config) => ({
+  data: [],
+  status: 200,
+  statusText: 'OK',
+  headers: {},
+  config,
+})

--- a/tickets/entities/automated-measures/AM-frontend-tests-no-network.md
+++ b/tickets/entities/automated-measures/AM-frontend-tests-no-network.md
@@ -1,0 +1,9 @@
+---
+id: AM-frontend-tests-no-network
+type: automated-measure
+title: The frontend unit suite cannot reach the network
+description: 'noNetwork.test.ts asserts three things - that a non-default axios adapter is installed, that an unmocked GET resolves instead of attempting a connection, and that getTransforms() (the real onMounted call behind the flake) resolves. It targets the ROOT CAUSE rather than the symptom, deliberately - the symptom (an unhandled socket-hangup rejection failing an otherwise-green run) is timing-dependent and does not reproduce locally, so a symptom-shaped test would pass against the broken code. All three verified to fail (3 failed / 3) with the adapter stub removed from src/test/setup.ts, and pass with it. Catches both regressions that would reintroduce BUG-762I34: removing the stub, and adding an api module that builds its own axios instance.'
+kind: test
+location: frontend/src/test/noNetwork.test.ts
+status: active
+---

--- a/tickets/entities/bugs/BUG-762I34.md
+++ b/tickets/entities/bugs/BUG-762I34.md
@@ -1,0 +1,108 @@
+---
+id: BUG-762I34
+type: bug
+title: 'Frontend unit suite makes real HTTP calls; unhandled socket-hangup rejection fails CI intermittently'
+priority: medium
+status: done
+why1: 'The Frontend CI job exits 1 even though every test passes.'
+why2: 'vitest reports an "Unhandled Rejection: socket hang up" that originated while a test file was running, and fails the run on it.'
+why3: 'A component mounted by that test fires a real HTTP request whose rejection lands after the test has finished, so no test owns it.'
+why4: 'The request leaves the process at all — `src/test/setup.ts` stubs localStorage, crypto, ResizeObserver and EventSource, but never the HTTP layer, so axios uses its real node adapter and dials localhost:3000.'
+why5: 'Test-double coverage was added reactively, one global at a time, as each broke a test. Network was never the thing that broke a test locally (ECONNREFUSED returns fast and components catch it), so nothing forced the gap into view until CI timing turned the same call into a late rejection.'
+prevention: 'Stub the HTTP adapter in the shared setup so an unmocked call can never reach a socket, and assert the property directly (a test that fails if the api layer reaches the network) rather than trusting that no future component adds an onMounted fetch.'
+---
+
+## Description
+
+The `Frontend` CI job fails intermittently with **every test passing**:
+
+```
+Test Files  105 passed (105)
+⎯⎯ Unhandled Errors ⎯⎯
+Vitest caught 1 unhandled error during the test run.
+⎯⎯ Unhandled Rejection ⎯⎯
+This error originated in "src/components/forms/DynamicForm.test.ts"
+Error: socket hang up
+##[error]Process completed with exit code 1.
+```
+
+Observed on PR #1327, a **Go-only change** that touched no frontend file — which
+is what makes it clearly environmental rather than caused by the PR. It passed
+on rerun.
+
+## Root cause
+
+`src/test/setup.ts` mocks `localStorage`, `crypto`, `ResizeObserver` and
+`EventSource` — but **nothing stubs HTTP**. The api client
+(`src/api/client.ts`) is a real axios instance, so in the unit suite it uses
+axios's node adapter and dials `localhost:3000`.
+
+Confirmed by probe: calling `getTransforms()` inside a test rejects with
+
+```
+AggregateError: connect ECONNREFUSED ::1:3000 / 127.0.0.1:3000
+```
+
+`ExportMenu.vue` calls `getTransforms()` in `onMounted`, so every component that
+mounts one transitively (DynamicForm, entity detail, list views) fires that
+request.
+
+**Why it is intermittent.** Locally the connection is refused immediately, the
+rejection settles inside the test, and `ExportMenu`'s own `catch` swallows it —
+invisible. On a slower, more contended CI runner the socket is instead
+established-then-torn-down (`socket hang up`), and the rejection settles *after*
+the triggering test has completed. No test owns it, so vitest reports it as an
+unhandled rejection and exits non-zero.
+
+Note the component is **not** at fault: `ExportMenu` aborts on unmount via
+`AbortController` and catches its own errors. The abort cannot help once the
+promise has already been handed to a caller that has gone away, and the shared
+`transformsCache` module-level promise in `api/transforms.ts` means the
+rejection can outlive the component that created it.
+
+## Impact
+
+Wasted CI reruns and, worse, **eroded signal**: a red Frontend job that is
+usually noise trains reviewers to rerun rather than read. It also fails PRs that
+cannot possibly have caused it (a Go-only change), which is actively
+misleading.
+
+No production impact — this is test-harness-only.
+
+## Fix
+
+Stub the axios adapter in `src/test/setup.ts` so an unmocked call resolves
+in-process (empty `200`) instead of reaching a socket. Fixes the class rather
+than the instance: any axios call from any test is now deterministic.
+
+Deliberately resolves rather than rejects — several components `console.error`
+on a failed load, and rejecting would spam every unrelated test's output.
+Tests that need a specific payload keep mocking their own module with
+`vi.mock`; this only decides what an *unmocked* call does.
+
+## Verification
+
+- Probe before: `ECONNREFUSED ::1:3000`. Probe after: resolves, no socket.
+- Full suite: 105 files / 1662 tests pass.
+- `typecheck`, `lint` (0 errors, 92 warnings — **identical to `develop`**),
+  `build`, and the work-tree-clean-after-build check all pass.
+
+The flake itself does not reproduce locally (5 consecutive clean runs) because
+it needs CI's timing; the fix is verified against the *root cause* — that the
+suite reaches the network at all — rather than against the symptom.
+
+## Preventive measure
+
+`frontend/src/test/noNetwork.test.ts` (AM-frontend-tests-no-network) asserts the
+property directly: a non-default adapter is installed, an unmocked GET resolves
+rather than connecting, and `getTransforms()` — the real `onMounted` call behind
+the flake — resolves.
+
+It targets the **root cause, not the symptom**, deliberately. A symptom-shaped
+test (assert no unhandled rejection) would pass against the broken code, because
+the rejection only appears under CI timing. Verified: 3 failed / 3 with the
+adapter stub removed, 3 passed with it.
+
+That also covers the second way this could regress — someone adding an api
+module that constructs its own axios instance instead of using the shared
+client.

--- a/tickets/relations/BUG-762I34--adds-measure--AM-frontend-tests-no-network.md
+++ b/tickets/relations/BUG-762I34--adds-measure--AM-frontend-tests-no-network.md
@@ -1,0 +1,5 @@
+---
+from: BUG-762I34
+relation: adds-measure
+to: AM-frontend-tests-no-network
+---

--- a/tickets/relations/BUG-762I34--affects--ci-pipeline.md
+++ b/tickets/relations/BUG-762I34--affects--ci-pipeline.md
@@ -1,0 +1,5 @@
+---
+from: BUG-762I34
+relation: affects
+to: ci-pipeline
+---

--- a/tickets/relations/BUG-762I34--affects--test-isolation.md
+++ b/tickets/relations/BUG-762I34--affects--test-isolation.md
@@ -1,0 +1,5 @@
+---
+from: BUG-762I34
+relation: affects
+to: test-isolation
+---

--- a/tickets/relations/BUG-762I34--fixes--FEAT-015.md
+++ b/tickets/relations/BUG-762I34--fixes--FEAT-015.md
@@ -1,0 +1,5 @@
+---
+from: BUG-762I34
+relation: fixes
+to: FEAT-015
+---


### PR DESCRIPTION
Fixes the intermittent `Frontend` CI failure where **every test passes** but the
job still exits 1:

```
Test Files  105 passed (105)
⎯⎯ Unhandled Rejection ⎯⎯
This error originated in "src/components/forms/DynamicForm.test.ts"
Error: socket hang up
##[error]Process completed with exit code 1.
```

Seen on #1327 — a Go-only PR that touched no frontend file, which is what makes
it clearly environmental.

## Root cause

`src/test/setup.ts` stubs `localStorage`, `crypto`, `ResizeObserver` and
`EventSource` — but **nothing stubs HTTP**. The api client is a real axios
instance, so in the unit suite it used axios's node adapter and dialled
`localhost:3000`.

Confirmed by probe: `getTransforms()` inside a test rejected with
`AggregateError: connect ECONNREFUSED ::1:3000 / 127.0.0.1:3000`.

`ExportMenu.vue` calls `getTransforms()` in `onMounted`, so every component that
mounts one transitively (DynamicForm, entity detail, list views) fired that
request.

**Why intermittent:** locally the connection is refused immediately, the
rejection settles inside the test, and `ExportMenu`'s own `catch` swallows it.
On a slower CI runner the socket is instead established-then-torn-down (`socket
hang up`) and the rejection settles *after* the triggering test finished — so no
test owns it, and vitest fails the run.

Worth noting the component is **not** at fault: it aborts on unmount via
`AbortController` and catches its own errors. But `api/transforms.ts` memoises
the promise at module scope, so a rejection can outlive the component that
created it.

## Fix

One change to the shared setup: install an axios adapter that resolves
in-process (empty `200`) instead of reaching a socket. Fixes the class, not the
instance — any axios call from any test is now deterministic.

It resolves rather than rejects on purpose: several components `console.error`
on a failed load, and rejecting would spam every unrelated test's output. Tests
needing a specific payload keep using `vi.mock`; this only decides what an
*unmocked* call does.

## Preventive measure

`frontend/src/test/noNetwork.test.ts` (AM-frontend-tests-no-network) asserts the
**root cause, not the symptom** — deliberately. A symptom-shaped test ("no
unhandled rejection") would pass against the broken code, since the rejection
only appears under CI timing.

Verified both ways: **3 failed / 3** with the adapter stub removed, 3 passed
with it. It also covers the other regression path — someone adding an api module
that builds its own axios instance rather than using the shared client.

## Verification

- Probe before: `ECONNREFUSED ::1:3000`. After: resolves, no socket.
- Full suite: **106 files / 1665 tests pass**.
- `typecheck` clean; `lint` **0 errors, 92 warnings — identical count to
  `develop`** (verified by stash); `build` succeeds; work tree clean after build.
- The flake itself does not reproduce locally (5 consecutive clean runs), which
  is exactly why the fix is verified against the root cause instead.

BUG-762I34 carries the full 5-whys. The systemic answer (why5): test doubles
were added reactively, one global at a time, as each broke a test — and network
never broke a test locally, so the gap stayed invisible until CI timing exposed
it.