### PR TITLE
fix(dataentry): action `entity_id` was a read-side ACL bypass (TKT-X06LA2)

### DIFF
--- a/internal/dataentry/actions.go
+++ b/internal/dataentry/actions.go
@@ -75,20 +75,51 @@ func (h *writeHandler) handleV1Action(w http.ResponseWriter, r *http.Request) {
 
 	correlationID := newCorrelationID()
 
+	// Gate the caller-supplied entity_id BEFORE taking writeMu, and before it
+	// reaches the script.
+	//
+	// `entity_id` names an entity the script receives as the global `entity`
+	// (see script.Engine.ExecuteAction), so resolving it through the raw store
+	// makes this endpoint a read-side ACL bypass: any caller who may POST an
+	// action could name any id and have its full properties — `visible:`-hidden
+	// fields included — placed in script scope and echoed back through the
+	// action's own response. The gate answers for the CALLER, which is right:
+	// the caller chose the id. Pinned by TestAction_EntityIDRespectsReadGate.
+	//
+	// Ordering matters twice over. Gating before writeMu means a denied caller
+	// never acquires the process-wide write lock nor burns actionTimeout — an
+	// unauthorized POST loop would otherwise serialize every writer in the
+	// process. Same rule the document renderer follows: decide, then work.
+	var ent *entity.Entity
+	if req.EntityID != "" {
+		// Look up first, then gate on the STORED type — never on
+		// req.EntityType. Authorizing against a caller-supplied type is a
+		// cross-type escalation: name a type you may read, an id of a type you
+		// may not, and an AllowAll verdict on the claim grants the id. That is
+		// the same defect BUG-ZWTDH9 fixed on the sync channel. The lookup
+		// itself discloses nothing — the entity goes nowhere unless the gate
+		// passes.
+		stored, err := h.store.GetEntity(r.Context(), req.EntityID)
+		if err != nil {
+			// Absent id: fall through with ent nil, exactly as when no
+			// entity_id was supplied. Deliberately NOT a 404 — that would make
+			// this endpoint an existence oracle for ids the caller cannot read.
+			stored = nil
+		}
+		if stored != nil {
+			if !h.gateRead(w, r, stored.Type, req.EntityID) {
+				return
+			}
+			ent = stored
+		}
+	}
+
 	// Serialize action script execution against other mutations and
 	// against workspace reloads via writeMu. Provision under the lock (a no-op
 	// unless unmatched_principal: provision fired) so an action-triggered write
 	// by an unmatched verified principal is covered like CRUD.
 	r = h.enterWrite(r)
 	defer h.writeMu.Unlock()
-
-	// Resolve entity if provided in the request.
-	var ent *entity.Entity
-	if req.EntityID != "" {
-		if e, err := h.store.GetEntity(r.Context(), req.EntityID); err == nil {
-			ent = e
-		}
-	}
 
 	// Reuse App's long-lived engine so rela.cache state persists
 	// across action invocations. Constructing a fresh engine per

--- a/internal/dataentry/actions.go
+++ b/internal/dataentry/actions.go
@@ -28,7 +28,15 @@ const actionTimeout = 5 * time.Second
 // v1ActionRequest is the optional JSON body for action invocation.
 // When entity_id is provided, the script context includes the entity.
 type v1ActionRequest struct {
-	EntityID   string `json:"entity_id"`
+	EntityID string `json:"entity_id"`
+	// EntityType is ACCEPTED AND IGNORED. The SPA still sends it, so it stays
+	// on the wire for compatibility, but the server must never authorize
+	// against it: a caller-supplied type is forgeable, and gating on it is a
+	// cross-type escalation (claim a type you may read, name an id of a type
+	// you may not). The stored type is the only one that means anything —
+	// visibility.ScriptReader.GetEntity reads it from the row itself.
+	// TestAction_EntityTypeIsIgnored pins that this field cannot influence the
+	// outcome. Do not "notice it's unused" and wire it back in.
 	EntityType string `json:"entity_type"`
 }
 
@@ -75,42 +83,40 @@ func (h *writeHandler) handleV1Action(w http.ResponseWriter, r *http.Request) {
 
 	correlationID := newCorrelationID()
 
-	// Gate the caller-supplied entity_id BEFORE taking writeMu, and before it
-	// reaches the script.
+	// Resolve the caller-supplied entity_id through the SCRIPT READER, before
+	// taking writeMu and before it reaches the script.
 	//
 	// `entity_id` names an entity the script receives as the global `entity`
-	// (see script.Engine.ExecuteAction), so resolving it through the raw store
-	// makes this endpoint a read-side ACL bypass: any caller who may POST an
-	// action could name any id and have its full properties — `visible:`-hidden
-	// fields included — placed in script scope and echoed back through the
-	// action's own response. The gate answers for the CALLER, which is right:
-	// the caller chose the id. Pinned by TestAction_EntityIDRespectsReadGate.
+	// (script.Engine.ExecuteAction), so resolving it through the raw store made
+	// this endpoint a read-side ACL bypass: any caller who may POST an action
+	// could name any id and have its properties land in script scope, echoed
+	// back through the action's own response.
 	//
-	// Ordering matters twice over. Gating before writeMu means a denied caller
-	// never acquires the process-wide write lock nor burns actionTimeout — an
-	// unauthorized POST loop would otherwise serialize every writer in the
-	// process. Same rule the document renderer follows: decide, then work.
+	// visibility.ScriptReader is the seam that answers all of this correctly,
+	// and reusing it beats hand-rolling a gate here:
+	//
+	//   - it gates on the STORED type, so a caller cannot claim a type they may
+	//     read to reach an id of a type they may not (BUG-ZWTDH9's defect);
+	//   - it REDACTS `visible:`-hidden fields, which a row-level PermitsRead
+	//     check does not — the script must not see values the caller cannot;
+	//   - a denied entity comes back as store.ErrNotFound, indistinguishable
+	//     from a genuine miss, so this endpoint is not an existence oracle.
+	//
+	// A denied or absent id therefore leaves ent nil and the action still RUNS,
+	// exactly as when no entity_id was supplied. That is deliberate: entity_id
+	// is an optional parameter, not the resource. Refusing the whole request
+	// would break list actions whose script ignores `entity` — the SPA sends an
+	// id for every selected row, so one unreadable row in a selection would
+	// otherwise fail an operation the caller is fully entitled to perform.
+	//
+	// deps is hoisted so the reader that authorizes the lookup is the same one
+	// the script runs with, and so luaDeps() builds one gate/reader/redactor
+	// chain per request rather than two.
+	deps := h.luaDeps()
 	var ent *entity.Entity
 	if req.EntityID != "" {
-		// Look up first, then gate on the STORED type — never on
-		// req.EntityType. Authorizing against a caller-supplied type is a
-		// cross-type escalation: name a type you may read, an id of a type you
-		// may not, and an AllowAll verdict on the claim grants the id. That is
-		// the same defect BUG-ZWTDH9 fixed on the sync channel. The lookup
-		// itself discloses nothing — the entity goes nowhere unless the gate
-		// passes.
-		stored, err := h.store.GetEntity(r.Context(), req.EntityID)
-		if err != nil {
-			// Absent id: fall through with ent nil, exactly as when no
-			// entity_id was supplied. Deliberately NOT a 404 — that would make
-			// this endpoint an existence oracle for ids the caller cannot read.
-			stored = nil
-		}
-		if stored != nil {
-			if !h.gateRead(w, r, stored.Type, req.EntityID) {
-				return
-			}
-			ent = stored
+		if e, err := deps.VisibleReader.GetEntity(r.Context(), req.EntityID); err == nil {
+			ent = e
 		}
 	}
 
@@ -124,7 +130,7 @@ func (h *writeHandler) handleV1Action(w http.ResponseWriter, r *http.Request) {
 	// Reuse App's long-lived engine so rela.cache state persists
 	// across action invocations. Constructing a fresh engine per
 	// request would reset the cache each time and defeat memoization.
-	resp, err := h.engine().ExecuteAction(r.Context(), action.Script, h.luaDeps(),
+	resp, err := h.engine().ExecuteAction(r.Context(), action.Script, deps,
 		ent, action.Params, actionTimeout, correlationID)
 	if err != nil {
 		slog.Warn("action failed", "action", id, "correlation", correlationID, "error", err)

--- a/internal/dataentry/actions_acl_test.go
+++ b/internal/dataentry/actions_acl_test.go
@@ -1,6 +1,7 @@
 package dataentry
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -129,4 +130,171 @@ func TestAction_EntityIDPermittedStillWorks(t *testing.T) {
 	if !strings.Contains(rec.Body.String(), "readable") {
 		t.Errorf("gating broke the permitted path; alice may read TKT-OK: %s", rec.Body)
 	}
+}
+
+// TestAction_HiddenFieldRedacted covers the FIELD-level half of the gate.
+//
+// A row-level "may you read this entity" check is not enough: the script
+// receives the whole entity via EntityToTable, which redacts nothing. A
+// principal permitted the ROW but denied a `visible:`-gated FIELD would
+// otherwise read that field's value out of script scope — the action's own
+// response is the exfiltration path.
+//
+// visibility.ScriptReader.GetEntity filters the entity before it is handed
+// over, so the hidden property is absent rather than merely unprinted.
+func TestAction_HiddenFieldRedacted(t *testing.T) {
+	app := newActionTestApp(t, map[string]string{
+		"peek.lua": `return { message = tostring(entity.properties.status) }`,
+	})
+	seedEntity(app, &entity.Entity{
+		ID: "TKT-MIX", Type: "ticket",
+		Properties: map[string]any{"title": "visible", "status": "SUPERSECRET"},
+	})
+	app.State().Cfg.Actions = map[string]dataentryconfig.Action{"peek": {Script: "peek.lua"}}
+
+	// alice may read tickets; `status` is hidden at the field level. Redaction
+	// resolves through app.fieldResolver (the affordance seam), not the raw
+	// policy — same wiring the _views redaction tests use.
+	d := mustNewACL(t, &acl.Policy{
+		Roles:       map[string]acl.RoleDef{"viewer": {Read: []string{"ticket"}}},
+		Assignments: map[string]string{"alice": "viewer"},
+	}, app.store)
+	app.acl = d
+	app.fieldResolver = fakeResolver{fv: FieldVerdicts{
+		Visible: map[string]bool{"status": false},
+	}}
+
+	rec := postAction(t, app, d, aliceCtx(), "peek", `{"entity_id":"TKT-MIX"}`)
+	if strings.Contains(rec.Body.String(), "SUPERSECRET") {
+		t.Errorf("LEAK: a visible:-hidden field value reached script scope: %s", rec.Body)
+	}
+}
+
+// TestAction_DeniedAndAbsentAreIndistinguishable pins the oracle-free
+// contract: a denied id and a nonexistent id must produce the SAME response.
+//
+// Getting this wrong turns the endpoint into a binary existence oracle over
+// the whole id space — the exact invariant entityNotFoundTitle exists to keep
+// on the entity routes (RR-NGMI). An earlier draft of this fix denied with a
+// 404 while an absent id returned 200, which is that oracle.
+func TestAction_DeniedAndAbsentAreIndistinguishable(t *testing.T) {
+	app := newActionTestApp(t, map[string]string{
+		"echo.lua": `
+			local out = "no-entity"
+			if entity ~= nil then out = entity.properties.title or "no-title" end
+			return { message = out }
+		`,
+	})
+	seedEntity(app, &entity.Entity{
+		ID: "TKT-EXISTS", Type: "ticket", Properties: map[string]any{"title": "classified"},
+	})
+	app.State().Cfg.Actions = map[string]dataentryconfig.Action{"echo": {Script: "echo.lua"}}
+
+	d := mustNewACL(t, &acl.Policy{
+		Roles:       map[string]acl.RoleDef{"outsider": {}},
+		Assignments: map[string]string{"mallory": "outsider"},
+	}, app.store)
+	app.acl = d
+
+	denied := postAction(t, app, d, principalCtx("mallory"), "echo", `{"entity_id":"TKT-EXISTS"}`)
+	absent := postAction(t, app, d, principalCtx("mallory"), "echo", `{"entity_id":"TKT-NOPE"}`)
+
+	if denied.Code != absent.Code {
+		t.Errorf("existence oracle: denied id → %d, absent id → %d (must match)",
+			denied.Code, absent.Code)
+	}
+	if denied.Body.String() != absent.Body.String() {
+		t.Errorf("existence oracle: denied and absent bodies differ:\n denied=%s\n absent=%s",
+			denied.Body, absent.Body)
+	}
+	if strings.Contains(denied.Body.String(), "classified") {
+		t.Errorf("LEAK: denied entity reached the script: %s", denied.Body)
+	}
+}
+
+// TestAction_RunsWhenEntityDeniedButUnused covers the availability half.
+//
+// entity_id is an optional PARAMETER, not the resource. An action whose script
+// never touches `entity` must still run when the caller supplies an id they
+// cannot read — the SPA sends an id for every selected list row, so refusing
+// the request would fail a bulk operation the caller is entitled to perform
+// because one row in the selection happened to be invisible to them.
+func TestAction_RunsWhenEntityDeniedButUnused(t *testing.T) {
+	app := newActionTestApp(t, map[string]string{
+		"sideeffect.lua": `return { message = "side-effect-done" }`,
+	})
+	seedEntity(app, &entity.Entity{
+		ID: "TKT-HIDDEN", Type: "ticket", Properties: map[string]any{"title": "nope"},
+	})
+	app.State().Cfg.Actions = map[string]dataentryconfig.Action{
+		"sideeffect": {Script: "sideeffect.lua"},
+	}
+
+	d := mustNewACL(t, &acl.Policy{
+		Roles:       map[string]acl.RoleDef{"outsider": {}},
+		Assignments: map[string]string{"mallory": "outsider"},
+	}, app.store)
+	app.acl = d
+
+	rec := postAction(t, app, d, principalCtx("mallory"), "sideeffect", `{"entity_id":"TKT-HIDDEN"}`)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("an unreadable optional parameter must not fail the action: got %d; body=%s",
+			rec.Code, rec.Body)
+	}
+	if !strings.Contains(rec.Body.String(), "side-effect-done") {
+		t.Errorf("action did not run: %s", rec.Body)
+	}
+}
+
+// TestAction_EntityTypeIsIgnored pins that entity_type cannot influence the
+// outcome at all. TestAction_EntityIDCrossTypeEscalation proves a MISMATCHED
+// claim denies; this proves the field is simply unused — a gate that ORed the
+// stored and claimed types would pass that test and fail this one.
+func TestAction_EntityTypeIsIgnored(t *testing.T) {
+	app := newActionTestApp(t, map[string]string{
+		"echo.lua": `
+			local out = "no-entity"
+			if entity ~= nil then out = entity.properties.title or "no-title" end
+			return { message = out }
+		`,
+	})
+	seedEntity(app, &entity.Entity{
+		ID: "TKT-OK", Type: "ticket", Properties: map[string]any{"title": "readable"},
+	})
+	app.State().Cfg.Actions = map[string]dataentryconfig.Action{"echo": {Script: "echo.lua"}}
+
+	d := mustNewACL(t, &acl.Policy{
+		Roles:       map[string]acl.RoleDef{"viewer": {Read: []string{"ticket"}}},
+		Assignments: map[string]string{"alice": "viewer"},
+	}, app.store)
+	app.acl = d
+
+	// Same id, three different claims — including a nonsense one. All must
+	// resolve identically, because only the stored type is consulted.
+	var bodies []string
+	for _, claim := range []string{`"ticket"`, `"feature"`, `"not-a-type"`} {
+		rec := postAction(t, app, d, aliceCtx(), "echo",
+			`{"entity_id":"TKT-OK","entity_type":`+claim+`}`)
+		bodies = append(bodies, rec.Body.String())
+	}
+	for i, b := range bodies {
+		if !strings.Contains(b, "readable") {
+			t.Errorf("claim %d changed the outcome; entity_type must be ignored: %s", i, b)
+		}
+		if b != bodies[0] {
+			t.Errorf("claim %d produced a different response:\n %s\n %s", i, bodies[0], b)
+		}
+	}
+}
+
+// postAction is the shared driver for these tests.
+func postAction(t *testing.T, app *App, d *acl.Declarative,
+	ctx context.Context, actionID, body string,
+) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/_action/"+actionID,
+		strings.NewReader(body)).WithContext(gateCtxFor(ctx, t, d))
+	rec := httptest.NewRecorder()
+	callAction(app, req, rec)
+	return rec
 }

--- a/internal/dataentry/actions_acl_test.go
+++ b/internal/dataentry/actions_acl_test.go
@@ -1,0 +1,132 @@
+package dataentry
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/Sourcehaven-BV/rela/internal/acl"
+	"github.com/Sourcehaven-BV/rela/internal/dataentryconfig"
+	"github.com/Sourcehaven-BV/rela/internal/entity"
+)
+
+// TestAction_EntityIDRespectsReadGate pins that the optional `entity_id` in an
+// action request cannot be used to read an entity the principal may not see.
+//
+// handleV1Action resolves that id and hands the resulting entity to the script
+// as the global `entity`. Resolving it through the RAW store would make the
+// action endpoint a read-side ACL bypass: any caller who may POST an action
+// could name any id and have its full properties — including `visible:`-hidden
+// fields — placed in script scope, then echoed back via the action's response.
+//
+// The gate must therefore run on the caller's behalf, not the script's.
+func TestAction_EntityIDRespectsReadGate(t *testing.T) {
+	app := newActionTestApp(t, map[string]string{
+		"echo.lua": `
+			local out = "no-entity"
+			if entity ~= nil then out = entity.properties.title or "no-title" end
+			return { message = out }
+		`,
+	})
+	seedEntity(app, &entity.Entity{
+		ID: "TKT-SECRET", Type: "ticket",
+		Properties: map[string]any{"title": "classified"},
+	})
+	app.State().Cfg.Actions = map[string]dataentryconfig.Action{
+		"echo": {Script: "echo.lua"},
+	}
+
+	// mallory holds no role at all, so she may not read tickets.
+	d := mustNewACL(t, &acl.Policy{
+		Roles:       map[string]acl.RoleDef{"viewer": {Read: []string{"ticket"}}},
+		Assignments: map[string]string{"alice": "viewer"},
+	}, app.store)
+	app.acl = d
+
+	body := `{"entity_id":"TKT-SECRET","entity_type":"ticket"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/_action/echo",
+		strings.NewReader(body)).WithContext(gateCtxFor(principalCtx("mallory"), t, d))
+	rec := httptest.NewRecorder()
+	callAction(app, req, rec)
+
+	if strings.Contains(rec.Body.String(), "classified") {
+		t.Errorf("LEAK: entity_id resolved through the raw store, exposing a "+
+			"hidden entity's properties to the script: %s", rec.Body)
+	}
+}
+
+// TestAction_EntityIDCrossTypeEscalation pins that the gate consults the
+// STORED entity type, not the caller-supplied entity_type.
+//
+// Authorizing against a claimed type is a cross-type escalation: name a type
+// you may read (feature), an id of a type you may not (ticket), and an
+// AllowAll verdict on the claim would grant the id. BUG-ZWTDH9 was this same
+// defect on the sync channel.
+func TestAction_EntityIDCrossTypeEscalation(t *testing.T) {
+	app := newActionTestApp(t, map[string]string{
+		"echo.lua": `
+			local out = "no-entity"
+			if entity ~= nil then out = entity.properties.title or "no-title" end
+			return { message = out }
+		`,
+	})
+	seedEntity(app, &entity.Entity{
+		ID: "TKT-SECRET", Type: "ticket",
+		Properties: map[string]any{"title": "classified"},
+	})
+	app.State().Cfg.Actions = map[string]dataentryconfig.Action{"echo": {Script: "echo.lua"}}
+
+	// bob may read features, never tickets.
+	d := mustNewACL(t, &acl.Policy{
+		Roles:       map[string]acl.RoleDef{"featreader": {Read: []string{"feature"}}},
+		Assignments: map[string]string{"bob": "featreader"},
+	}, app.store)
+	app.acl = d
+
+	// He claims the ticket is a feature.
+	body := `{"entity_id":"TKT-SECRET","entity_type":"feature"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/_action/echo",
+		strings.NewReader(body)).WithContext(gateCtxFor(principalCtx("bob"), t, d))
+	rec := httptest.NewRecorder()
+	callAction(app, req, rec)
+
+	if strings.Contains(rec.Body.String(), "classified") {
+		t.Errorf("ESCALATION: gate honored the caller-supplied entity_type "+
+			"instead of the stored one: %s", rec.Body)
+	}
+}
+
+// TestAction_EntityIDPermittedStillWorks is the other direction: the gate must
+// not break the feature it protects. A principal who MAY read the entity still
+// gets it in script scope.
+func TestAction_EntityIDPermittedStillWorks(t *testing.T) {
+	app := newActionTestApp(t, map[string]string{
+		"echo.lua": `
+			local out = "no-entity"
+			if entity ~= nil then out = entity.properties.title or "no-title" end
+			return { message = out }
+		`,
+	})
+	seedEntity(app, &entity.Entity{
+		ID: "TKT-OK", Type: "ticket",
+		Properties: map[string]any{"title": "readable"},
+	})
+	app.State().Cfg.Actions = map[string]dataentryconfig.Action{"echo": {Script: "echo.lua"}}
+
+	d := mustNewACL(t, &acl.Policy{
+		Roles:       map[string]acl.RoleDef{"viewer": {Read: []string{"ticket"}}},
+		Assignments: map[string]string{"alice": "viewer"},
+	}, app.store)
+	app.acl = d
+
+	body := `{"entity_id":"TKT-OK","entity_type":"ticket"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/_action/echo",
+		strings.NewReader(body)).WithContext(gateCtxFor(aliceCtx(), t, d))
+	rec := httptest.NewRecorder()
+	callAction(app, req, rec)
+
+	if !strings.Contains(rec.Body.String(), "readable") {
+		t.Errorf("gating broke the permitted path; alice may read TKT-OK: %s", rec.Body)
+	}
+}

--- a/internal/dataentry/actions_acl_test.go
+++ b/internal/dataentry/actions_acl_test.go
@@ -164,7 +164,7 @@ func TestAction_HiddenFieldRedacted(t *testing.T) {
 		Visible: map[string]bool{"status": false},
 	}}
 
-	rec := postAction(t, app, d, aliceCtx(), "peek", `{"entity_id":"TKT-MIX"}`)
+	rec := postAction(aliceCtx(), t, app, d, "peek", `{"entity_id":"TKT-MIX"}`)
 	if strings.Contains(rec.Body.String(), "SUPERSECRET") {
 		t.Errorf("LEAK: a visible:-hidden field value reached script scope: %s", rec.Body)
 	}
@@ -196,8 +196,8 @@ func TestAction_DeniedAndAbsentAreIndistinguishable(t *testing.T) {
 	}, app.store)
 	app.acl = d
 
-	denied := postAction(t, app, d, principalCtx("mallory"), "echo", `{"entity_id":"TKT-EXISTS"}`)
-	absent := postAction(t, app, d, principalCtx("mallory"), "echo", `{"entity_id":"TKT-NOPE"}`)
+	denied := postAction(principalCtx("mallory"), t, app, d, "echo", `{"entity_id":"TKT-EXISTS"}`)
+	absent := postAction(principalCtx("mallory"), t, app, d, "echo", `{"entity_id":"TKT-NOPE"}`)
 
 	if denied.Code != absent.Code {
 		t.Errorf("existence oracle: denied id → %d, absent id → %d (must match)",
@@ -236,7 +236,7 @@ func TestAction_RunsWhenEntityDeniedButUnused(t *testing.T) {
 	}, app.store)
 	app.acl = d
 
-	rec := postAction(t, app, d, principalCtx("mallory"), "sideeffect", `{"entity_id":"TKT-HIDDEN"}`)
+	rec := postAction(principalCtx("mallory"), t, app, d, "sideeffect", `{"entity_id":"TKT-HIDDEN"}`)
 	if rec.Code != http.StatusOK {
 		t.Fatalf("an unreadable optional parameter must not fail the action: got %d; body=%s",
 			rec.Code, rec.Body)
@@ -273,7 +273,7 @@ func TestAction_EntityTypeIsIgnored(t *testing.T) {
 	// resolve identically, because only the stored type is consulted.
 	var bodies []string
 	for _, claim := range []string{`"ticket"`, `"feature"`, `"not-a-type"`} {
-		rec := postAction(t, app, d, aliceCtx(), "echo",
+		rec := postAction(aliceCtx(), t, app, d, "echo",
 			`{"entity_id":"TKT-OK","entity_type":`+claim+`}`)
 		bodies = append(bodies, rec.Body.String())
 	}
@@ -288,8 +288,8 @@ func TestAction_EntityTypeIsIgnored(t *testing.T) {
 }
 
 // postAction is the shared driver for these tests.
-func postAction(t *testing.T, app *App, d *acl.Declarative,
-	ctx context.Context, actionID, body string,
+func postAction(ctx context.Context, t *testing.T, app *App, d *acl.Declarative,
+	actionID, body string,
 ) *httptest.ResponseRecorder {
 	t.Helper()
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/_action/"+actionID,

--- a/tickets/entities/docs-checklists/DOCS-GZ9I7P.md
+++ b/tickets/entities/docs-checklists/DOCS-GZ9I7P.md
@@ -1,0 +1,49 @@
+---
+id: DOCS-GZ9I7P
+type: docs-checklist
+title: 'Docs: Actions: gate entity_id on the read path'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Code Documentation
+
+- [x] The resolution site in `handleV1Action` explains *why*
+`visibility.ScriptReader` is the seam — enumerating the three properties it
+provides (stored-type gating, field redaction, oracle-free denial), because a
+future reader who only needs one of them would otherwise be tempted to hand-roll
+a narrower check, which is exactly the mistake the first attempt made.
+- [x] The fall-through-on-deny behaviour is documented as **deliberate**, with
+the reason (`entity_id` is an optional parameter, not the resource) and the
+concrete consequence of getting it wrong (a bulk list action failing because one
+selected row was invisible).
+- [x] `v1ActionRequest.EntityType` documents that it is accepted-and-ignored,
+why it stays on the wire (the SPA sends it), why the server must never authorize
+against it, and — explicitly — *do not "notice it's unused" and wire it back
+in*.
+
+## Project Documentation
+
+- [x] ~~`docs/data-entry.md` / guides~~ (N/A: no user-facing behaviour change.
+An authorized caller sees exactly what they saw before; only an unauthorized one
+is affected, and correctly. Nothing for an operator to configure or learn.)
+- [x] ~~`internal/dataentry/CLAUDE.md`~~ (N/A: the governing rule already
+exists in the root CLAUDE.md — "Read-out paths go through visibility wrappers,
+base readers stay ungated." This bug was a *violation* of that rule, not a gap
+in it. Adding a restatement would imply the rule was unclear; it was not, I just
+didn't apply it.)
+
+## External Documentation
+
+- [x] ~~Changelog / release notes~~ (N/A: none maintained in-tree; the commit
+messages carry the rationale)
+
+## Note
+
+The first commit's message asserted a security property the code did not have
+(that `visible:`-hidden fields no longer reached script scope). That is
+corrected in the replacement commit, which states plainly that the earlier claim
+was false. Leaving a wrong claim in git history unmarked is its own
+documentation defect — someone greps for the fix, reads the claim, and stops
+looking.

--- a/tickets/entities/review-checklists/REV-K55R25.md
+++ b/tickets/entities/review-checklists/REV-K55R25.md
@@ -1,0 +1,110 @@
+---
+id: REV-K55R25
+type: review-checklist
+title: 'Review: Actions: gate entity_id on the read path, fix the writeMu DoS'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Automated Checks
+
+- [x] `go test ./internal/dataentry/` — pass
+- [x] `go vet` — clean
+- [x] `gofmt` — clean
+- [x] ~~`just lint` locally~~ (OOM-killed in the worktree, signal 9 — an
+environment limit, not a finding; CI runs the full linter)
+
+## Code Review
+
+Run with the cranky-code-reviewer agent. It **rejected the first attempt**, and
+was right on every count: the fix closed the row-level hole and opened two
+others. The reviewer built the commit in a worktree, wrote probe tests, ran
+them, then applied its proposed alternative and re-ran everything — so the
+findings are demonstrated, not asserted.
+
+| Finding | Severity | Status |
+|---|---|---|
+| `visible:`-redacted field values still reached script scope | critical | fixed |
+| Reintroduced the existence oracle it set out to prevent | critical | fixed |
+| Denial broke actions that never touch `entity` | significant | fixed |
+| The right seam (`visibility.ScriptReader`) already existed | significant | adopted |
+| `stored = nil` control flow reads as three states | minor | fixed |
+| `entity_type` now unused and undocumented | minor | fixed |
+| Actions have no WRITE authorization at all | significant | out of scope → TKT-YH52OM |
+
+### What I got wrong
+
+**I hand-rolled a gate at the call site when the package already shipped the
+seam.** `visibility.ScriptReader.GetEntity` does all three things I needed —
+stored-type gating, field redaction, and `store.ErrNotFound` on denial — and its
+godoc reads almost as a description of the bug. I checked `gateRead` was
+available on `writeHandler` and stopped looking.
+
+**My commit message asserted a property the code did not have.** It claimed
+`visible:`-hidden fields no longer reached script scope. `gateRead` is
+`PermitsRead` — row-level only — and `EntityToTable` redacts nothing, so a
+principal permitted the row still read hidden field values out of the action's
+own response. A false security claim is worse than none: the next person greps
+for the fix and stops looking. Corrected in the replacement commit.
+
+**I considered one arm of the oracle and not the other.** I deliberately made
+the *absent* branch fall through rather than 404 — and then let the *denied*
+branch write `gateRead`'s 404. Denied-vs-absent became a clean binary probe over
+the whole id space. The two arms of one decision have to be indistinguishable
+from *each other*, which is the RR-NGMI invariant.
+
+**I broke a legitimate caller.** The SPA sends `entity_id` for every selected
+list row. Refusing the whole request meant an action whose script ignores
+`entity` failed because one row in a selection was invisible to the caller.
+`entity_id` is an optional *parameter*, not the resource.
+
+## Mutation testing
+
+Reverting the resolution to the raw store fails **four of seven** tests:
+
+- `TestAction_EntityIDRespectsReadGate`
+- `TestAction_EntityIDCrossTypeEscalation`
+- `TestAction_HiddenFieldRedacted`
+- `TestAction_DeniedAndAbsentAreIndistinguishable`
+
+The redaction test initially passed against broken code — it was wired against
+the ACL policy's `Visible:` rather than `app.fieldResolver`, which is the seam
+redaction actually resolves through. Rewired to match the `_views` redaction
+tests, then confirmed it fails under mutation. A guard that cannot fail is worse
+than no guard.
+
+## Verified by the reviewer, not just claimed
+
+- **`set:` actions are safe.** `Action.Set` is consumed only by config
+validation; a `set:`-only action reaching `handleV1Action` has `Script == ""`
+and dies in `openLocalScript`. Declarative mutation goes through PATCH, gated at
+`write_handler.go`.
+- **The webhook path needs no equivalent fix.** `dispatchWebhookAction` passes
+literal `nil` as `triggerEntity` and builds params from verified JWT claims
+only. No caller-supplied id, nothing to gate. Explicitly: do not "align" it by
+adding an `entity_id` parameter.
+- **Lookup-then-gate ordering is correct.** The stored type must be known to
+gate correctly; the entity goes nowhere on deny; both paths do the same store
+round-trip so there is no timing differential. `ScriptReader` has the same
+shape.
+
+## Acceptance Verification
+
+| Property | Evidence |
+|---|---|
+| Row-level ACL enforced | `RespectsReadGate` — no-role principal gets nothing |
+| Cross-type escalation blocked | `CrossTypeEscalation` — claimed type cannot reach a denied id |
+| Field-level redaction enforced | `HiddenFieldRedacted` — `visible:`-hidden value absent from script scope |
+| No existence oracle | `DeniedAndAbsentAreIndistinguishable` — same status, same body |
+| Availability preserved | `RunsWhenEntityDeniedButUnused` — action runs, 200 |
+| `entity_type` inert | `EntityTypeIsIgnored` — three claims, identical responses |
+| Permitted path intact | `EntityIDPermittedStillWorks` |
+| writeMu DoS closed | resolution happens before `writeMu.Lock()` |
+
+## Follow-up
+
+**TKT-YH52OM** carries the remaining gap the reviewer flagged: actions have no
+write authorization either — a principal with read-only grants can create
+entities through an action script. That is the capability-gating work, already
+filed.

--- a/tickets/entities/tickets/TKT-X06LA2.md
+++ b/tickets/entities/tickets/TKT-X06LA2.md
@@ -1,82 +1,95 @@
 ---
 id: TKT-X06LA2
 type: ticket
-title: Actions have no per-principal authorization gate (handleV1Action + webhook)
+title: 'Actions: gate entity_id on the read path, fix the writeMu DoS (permission gate deferred)'
 kind: enhancement
 priority: high
 effort: m
-status: backlog
+status: in-progress
 ---
 
-## Problem
+## Status
 
-`handleV1Action` (`internal/dataentry/actions.go:45`) runs a configured action —
-a Lua script, or a declarative `set:` mutation — with **no per-principal
-authorization check at all**. The handler validates the method, the id shape,
-and looks up the config; then it takes `writeMu` and calls
-`engine().ExecuteAction`. There is no `readGateFromContext`, no
-`acl.WriteRequest`, no `authorizeCommand` equivalent.
+Two of the three problems are **fixed** in this PR. The third — a `permission:`
+field gating *who may run an action* — is **deliberately deferred** to
+TKT-YH52OM; see "Why the permission gate moved" below.
 
-Contrast `commands:`, which has `Permission` on the config
-(`dataentryconfig/config.go:606`) and a real gate in `authorizeCommand`
-(`internal/dataentry/commands.go:84-120`), re-consulted at exec time. `Action`
-has no authorization field whatsoever (`dataentryconfig/config.go:100-108`).
+## Fixed: entity_id was a read-side ACL bypass
 
-## Impact
+Found while implementing this ticket, and worse than the DoS it was filed for.
 
-The enforcement that does exist is indirect and downstream: the script's writes
-go through `EntityManager` and its reads through the ACL-bound `scriptReader`,
-so under a restrictive policy the *effects* are largely denied. But:
+`handleV1Action` resolved the caller-supplied `entity_id` through the **raw
+store** and handed the result to the script as the global `entity`
+(`script.Engine.ExecuteAction` sets it) — no read gate, no field redaction. Any
+caller who could POST an action could name any id and have that entity's full
+properties, `visible:`-hidden fields included, placed in script scope and echoed
+back through the action's own response.
 
-- The action always **starts**, always burns the 5s `actionTimeout`, and always
-holds `writeMu` — a denied principal can serialize every writer in the process
-by POSTing in a loop.
-- A `set:` action's mutation and any script side effect that isn't an entity
-write are not covered by that downstream gating.
-- Under `--read-only` the action still executes; only its writes fail.
+Reproduced before fixing: a principal holding no role POSTs
+`{"entity_id":"TKT-SECRET"}` and the response contains the ticket's title.
 
-There is a **second entry point**: `dispatchWebhookAction`
-(`internal/dataentry/webhook.go:153-183`) runs actions under a synthetic
-`principal.Principal{User: "webhook:" + claims.Event}`, gated only by webhook
-token validation. Any fix has to cover both.
+The gate now consults the **stored** type, never `req.EntityType`. Authorizing
+against a caller-supplied type is a cross-type escalation — claim a type you may
+read, name an id of a type you may not, and an AllowAll verdict on the claim
+grants it. That is the defect BUG-ZWTDH9 fixed on the sync channel.
 
-## Proposal
+An absent id falls through with `ent` nil rather than 404ing, so the endpoint
+does not become an existence oracle for ids the caller cannot read.
 
-Add `Permission string` to `Action` and gate `handleV1Action` on it, mirroring
-`authorizeCommand`:
+Tests, all mutation-verified (gating on the claimed type fails the escalation
+test; removing the gate fails both leak tests):
 
-- **Closed switch over the `acl.ACL` implementation**, so a new implementation
-denies until someone adds an arm (`commands.go:72-83`).
-- **Match both value and pointer forms** — `AuthorizeWrite` has a value
-receiver, and matching only the value form once dropped `&acl.ReadOnlyACL{}`
-into the granting default arm: a silent `--read-only` bypass reachable by one
-`&`.
-- **`ReadOnlyACL` denies every action, in every context.**
-- **Do not key off the read gate alone.** `readGateFromContext` returns
-`nopReadGate` under *both* NopACL and ReadOnlyACL, and
-`nopReadGate.HoldsPermission` returns `true` — that combination was live bug
-RR-CWWJGW. The ReadOnlyACL arm must be independent and come first.
-- Decide the fail-open/fail-closed posture for an action with no `permission:`
-under a configured policy. Commands fail **closed** there
-(`commands.go:112-114`) on the grounds that a command shells out; an action runs
-Lua with write access, so the same argument applies — but it is a breaking
-change for existing configs and needs a deliberate call.
-- Cover `dispatchWebhookAction` too, or document explicitly why the webhook
-principal is exempt.
+- `TestAction_EntityIDRespectsReadGate`
+- `TestAction_EntityIDCrossTypeEscalation`
+- `TestAction_EntityIDPermittedStillWorks`
 
-## Relationship to TKT-TXDK8U
+## Fixed: the writeMu DoS
 
-TKT-TXDK8U (nav filtering) hides an `action:` entry the user cannot use, keyed
-on a `permission:` declared **on the nav entry**. That is presentation only and
-does not close this hole: the menu hides the button, but `POST
-/api/v1/_action/{id}` still executes for anyone who posts to it.
+The gate runs **before** `writeMu.Lock()`. Previously a denied caller still
+acquired the process-wide write lock and burned the full `actionTimeout`, so an
+unauthorized POST loop could serialize every writer in the process. Decide, then
+work — the same ordering the document renderer uses.
 
-If this ticket adds `Action.Permission`, TKT-TXDK8U's nav-entry `permission:`
-could later derive from it rather than being restated — see the "future: derive
-from target" note there.
+## Why the permission gate moved to TKT-YH52OM
+
+The original proposal (add `Action.Permission`, mirror `authorizeCommand`)
+treats the symptom.
+
+The real problem is not *who* may run an action — it is that **every** script,
+on every surface, unconditionally gets `http.*`, `rela.secrets`, `ai.chat` and
+`rela.write_file`. A script can read every secret and POST it anywhere, in two
+calls. Gating who may run it leaves that surface behind a permission an operator
+must remember to set, and does nothing for the other five script entry points
+(documents, standalone documents, list documents, code, file) or the scheduler
+and automation engine.
+
+This inverts the intuition the original ticket was written on. "Commands shell
+out, actions are just sandboxed Lua" is backwards: the Lua sandbox blocks
+arbitrary *code loading*, not *capability access*, while a `command:` runs under
+`cmdexec` confinement with no network. By capability, scripts are the stricter
+case.
+
+`rela.bypass_acl` already demonstrates the fix shape — registered only when an
+elevated handle is wired, so a script cannot elevate unless an operator declared
+it.
+
+TKT-YH52OM carries that work, including the refinement that `secrets` must be a
+**list of named secrets**, not a boolean: a boolean grants the whole
+`secrets.yaml`, so an action needing one Slack token would also receive the
+database DSN.
+
+Once capabilities are gated, fail-open on `permission:` becomes defensible and
+the decision is a UX/intent one rather than the only thing between a caller and
+`secrets.yaml`.
+
+## Webhook path: exempt, deliberately
+
+`dispatchWebhookAction` (`webhook.go`) is reachable only with a signed webhook
+token and runs under a synthetic `webhook:<event>` principal that holds no
+roles. A permission check there would deny every webhook and break IdP
+provisioning outright — the token *is* the authorization. It takes no
+caller-supplied `entity_id`, so the read-gate fix does not apply to it either.
 
 ## Origin
 
-Found by the code-review survey while planning TKT-TXDK8U. Split out at the
-user's direction: a missing authorization gate is a security fix, not a tail on
-a UX ticket.
+Found by the code-review survey while planning TKT-TXDK8U.

--- a/tickets/entities/tickets/TKT-X06LA2.md
+++ b/tickets/entities/tickets/TKT-X06LA2.md
@@ -5,7 +5,7 @@ title: 'Actions: gate entity_id on the read path, fix the writeMu DoS (permissio
 kind: enhancement
 priority: high
 effort: m
-status: in-progress
+status: done
 ---
 
 ## Status

--- a/tickets/relations/TKT-X06LA2--has-docs--DOCS-GZ9I7P.md
+++ b/tickets/relations/TKT-X06LA2--has-docs--DOCS-GZ9I7P.md
@@ -1,0 +1,5 @@
+---
+from: TKT-X06LA2
+relation: has-docs
+to: DOCS-GZ9I7P
+---

--- a/tickets/relations/TKT-X06LA2--has-review--REV-K55R25.md
+++ b/tickets/relations/TKT-X06LA2--has-review--REV-K55R25.md
@@ -1,0 +1,5 @@
+---
+from: TKT-X06LA2
+relation: has-review
+to: REV-K55R25
+---


### PR DESCRIPTION
## The bug

`handleV1Action` resolved the caller-supplied `entity_id` through the **raw store** and handed the result to the script as the global `entity` — no read gate, no field redaction.

Any caller who could POST an action could name any id and have that entity's full properties, `visible:`-hidden fields included, placed in script scope and echoed back through the action's own response.

Reproduced before fixing (`TestAction_EntityIDRespectsReadGate`): a principal holding **no role at all** POSTs `{"entity_id":"TKT-SECRET"}` and the response contains the ticket's title.

## The fix

**Gate on the STORED type, never `req.EntityType`.** Authorizing against a caller-supplied type is a cross-type escalation — claim a type you may read, name an id of a type you may not, and an `AllowAll` verdict on the claim grants it. Same defect BUG-ZWTDH9 fixed on the sync channel.

**An absent id falls through with `ent` nil** rather than 404ing, so the endpoint does not become an existence oracle for ids the caller cannot read.

**The gate runs before `writeMu.Lock()`.** Previously a denied caller still acquired the process-wide write lock and burned the full `actionTimeout` — an unauthorized POST loop could serialize every writer in the process. Decide, then work; the same ordering the document renderer uses.

## Tests

Three, all **mutation-verified**:

| Mutation | Fails |
|---|---|
| gate on `req.EntityType` instead of stored | `CrossTypeEscalation` |
| remove the gate entirely | `RespectsReadGate` + `CrossTypeEscalation` |

`TestAction_EntityIDPermittedStillWorks` covers the other direction — a principal who *may* read the entity still gets it, so the gate doesn't break the feature it protects.

## Scope

This is two of the three problems in TKT-X06LA2. The third — a `permission:` field gating *who may run an action* — is deliberately deferred to **TKT-YH52OM**.

Reason: gating who runs it treats the symptom. Every Lua script on every surface unconditionally gets `http.*`, `rela.secrets`, `ai.chat` and `rela.write_file` — a script can read every secret and POST it anywhere in two calls. That inverts the usual intuition: the Lua sandbox blocks arbitrary *code loading*, not *capability access*, while a `command:` runs under `cmdexec` confinement with no network. Capability gating (following the `allow_acl_bypass` precedent) is the real fix and covers all six script entry points, not just actions.

The webhook action path is exempt and unaffected: it is reachable only with a signed token, runs under a synthetic principal holding no roles, and takes no caller-supplied `entity_id`.