### PR TITLE
docs(tickets): file BUG-NEQRY2 — rela validate passes on a partial corpus

### DIFF
--- a/tickets/entities/automated-measures/AM-validate-fails-closed-on-unparseable-entity.md
+++ b/tickets/entities/automated-measures/AM-validate-fails-closed-on-unparseable-entity.md
@@ -1,0 +1,9 @@
+---
+id: AM-validate-fails-closed-on-unparseable-entity
+type: automated-measure
+title: rela validate exits non-zero when an entity cannot be parsed
+description: Test that a project containing one entity file with unparseable YAML frontmatter makes rela validate exit non-zero and name the offending file, rather than reporting success over a partial corpus.
+kind: test
+location: internal/cli/ (test to be written with the fix)
+status: proposed
+---

--- a/tickets/entities/bugs/BUG-NEQRY2.md
+++ b/tickets/entities/bugs/BUG-NEQRY2.md
@@ -1,0 +1,110 @@
+---
+id: BUG-NEQRY2
+type: bug
+title: rela validate exits 0 when entity frontmatter fails to parse — validation silently skips those entities
+description: A single entity file with unparseable YAML frontmatter makes store.ListEntities return an iterator error. rela validate logs it as a WARN, skips the entity, and still prints 'All validations passed' with exit 0. CI is therefore green on a corpus it never fully read, and any rule violation on the skipped entity is invisible.
+priority: high
+effort: s
+status: backlog
+---
+
+## Symptom
+
+One entity file with unparseable YAML frontmatter is enough to make `rela
+validate` report success while **not having validated that entity**.
+
+Reproduced against this repo's own `tickets/` project by restoring the exact
+breakage that shipped in PR #1314:
+
+```console
+$ cd tickets && ../bin/rela validate \
+    --check cardinality --check properties --check validations
+...
+All validations passed.
+EXIT=0
+```
+
+— while the same run emitted **2** `failed to parse frontmatter` errors. The
+affected entity was skipped, not validated.
+
+## Why this matters
+
+It is not a cosmetic logging issue. The skipped entity's rule violations
+disappear with it, so a green CI run can hide real failures.
+
+That is exactly what happened:
+
+- `AM-feed-field-redaction.md` had unquoted `visible:` / `where:` inside plain
+scalars (`title:` / `description:`), so its frontmatter failed to parse.
+- The parse failure made `store.ListEntities` error and under-count.
+- `done-bug-needs-review-done` therefore never evaluated **BUG-E9DYW5**, which
+had been merged `done` with no review checklist at all.
+- CI on `develop` reported "All 120 validation rules passed" throughout.
+
+The violation only surfaced when the frontmatter was repaired — i.e. the
+corpus-level failure was *masking* an item-level failure, and the masking was
+silent in both directions.
+
+## Root cause (initial reading, to confirm)
+
+`store.ListEntities` surfaces the problem as an **iterator error** rather than a
+hard failure. Callers log it at WARN (`analysis: store.ListEntities iterator
+error; results may under-count`) and carry on with a partial result set. For an
+*analysis* command "best effort over what parsed" is arguable; for a
+**validation gate whose exit code gates merges**, a partial read is not a pass.
+
+## Proposed fix
+
+`rela validate` should fail closed: if any entity could not be read or parsed,
+exit non-zero and name the offending files, regardless of whether the entities
+that *did* parse are clean. A validation run that skipped input has not
+validated the project.
+
+Worth deciding separately whether other read paths should also harden or keep
+degrading gracefully — `validate` is the one with a merge gate behind it, so it
+is the one that must not lie.
+
+Consider also a cheap dedicated check (`rela validate --check frontmatter`, or
+folding it into the existing checks) so the failure names the file and the YAML
+error directly rather than surfacing as a downstream under-count.
+
+## Prior art in this repo
+
+This is the **second** occurrence of the same YAML class, both from an unquoted
+`key:` inside a plain scalar:
+
+- `AM-date-property-write-roundtrip.md` — `due: 2026-08-12` in `description:`.
+Blocked *all* entity creation (`collect existing IDs: failed to parse
+frontmatter`), so that one at least failed loudly.
+- `AM-feed-field-redaction.md` — `visible:` / `where:`. Did **not** fail
+loudly; it silently disabled validation for the affected entities.
+
+The first was noisy and got fixed immediately; the second was silent and
+persisted through CI until someone tripped over it by accident. That asymmetry
+is the argument for failing closed: the loud one needed no ticket, the quiet one
+hid a merged-`done` bug with no review record for days.
+
+## Independently found twice
+
+Two people hit this within days of each other, from different directions, and
+both stopped at the symptom rather than the tooling:
+
+- **TKT-1ESTYJ / #1337** quoted the frontmatter as a drive-by fix while working
+  on analyze memory, which re-exposed the hidden BUG-E9DYW5 violation. Its
+  backfilled `REV-E9DYW5` closes with exactly this diagnosis: *"A parse failure
+  during an analyze scan should be an error, not a warning that degrades into an
+  under-count — otherwise 'all rules passed' can mean 'the rule never saw the
+  file'. Worth its own ticket."* That ticket is this one.
+- Separately, while resolving merge conflicts for **#1319** (scheduler failure
+  backoff), repairing the same file surfaced the same violation.
+
+Neither encounter was looking for a validation bug; both tripped over it. That
+is the argument for fixing the tool rather than the files — the next occurrence
+will also be found by accident, if at all.
+
+## Still reproduces
+
+Re-verified on `develop` at 93240281 (after #1337 landed): restoring the
+unquoted frontmatter still yields `EXIT=0` and "All validations passed" while
+logging 2 `failed to parse frontmatter` errors. The individual files were
+repaired; the behaviour that hid them was not.

--- a/tickets/relations/BUG-NEQRY2--adds-measure--AM-validate-fails-closed-on-unparseable-entity.md
+++ b/tickets/relations/BUG-NEQRY2--adds-measure--AM-validate-fails-closed-on-unparseable-entity.md
@@ -1,0 +1,5 @@
+---
+from: BUG-NEQRY2
+relation: adds-measure
+to: AM-validate-fails-closed-on-unparseable-entity
+---

--- a/tickets/relations/BUG-NEQRY2--affects--metamodel-types.md
+++ b/tickets/relations/BUG-NEQRY2--affects--metamodel-types.md
@@ -1,0 +1,5 @@
+---
+from: BUG-NEQRY2
+relation: affects
+to: metamodel-types
+---

--- a/tickets/relations/BUG-NEQRY2--fixes--FEAT-13863O.md
+++ b/tickets/relations/BUG-NEQRY2--fixes--FEAT-13863O.md
@@ -1,0 +1,5 @@
+---
+from: BUG-NEQRY2
+relation: fixes
+to: FEAT-13863O
+---


### PR DESCRIPTION
Replaces #1328, which is now mostly redundant: **TKT-1ESTYJ (#1337) independently
fixed the same broken frontmatter and backfilled the same `REV-E9DYW5`** while I
had #1328 open awaiting review. Two of its three changes are already on
`develop`, so this PR carries only the part that is still missing.

Ticket entities only. No Go changes.

## The gap

An entity whose YAML frontmatter fails to parse is **skipped**, but `rela
validate` still exits 0:

```console
$ cd tickets && ../bin/rela validate \
    --check cardinality --check properties --check validations
...
All validations passed.
EXIT=0
```

— while the same run logs 2 `failed to parse frontmatter` errors. A validation
run that skipped input has not validated the project, and its exit code gates
merges.

**Re-verified on `develop` at 93240281, after #1337 landed.** The individual
files were repaired; the behaviour that hid them was not.

## Why it matters

This is how **BUG-E9DYW5** merged `done` with no review checklist. The
`done-bug-needs-review-done` rule never evaluated it, because the bug's own
measure entity was unparseable and therefore invisible. CI reported "All 120
validation rules passed" throughout.

## Independently found twice

Two people hit this within days, from different directions, and both stopped at
the symptom:

- **#1337 (TKT-1ESTYJ)** quoted the frontmatter as a drive-by while working on
  analyze memory. Its backfilled `REV-E9DYW5` closes with exactly this
  diagnosis: *"A parse failure during an analyze scan should be an error, not a
  warning that degrades into an under-count — otherwise 'all rules passed' can
  mean 'the rule never saw the file'. Worth its own ticket."* **This is that
  ticket.**
- **#1319** (scheduler backoff) surfaced the same violation while resolving
  merge conflicts.

Neither encounter was looking for a validation bug. That is the argument for
fixing the tool rather than the files — the next occurrence will also be found
by accident, if at all.

## Contents

- `BUG-NEQRY2` (backlog, high, effort=s) — the gap, with reproduction, an
  initial root-cause reading (`store.ListEntities` surfaces this as an iterator
  error that callers log at WARN and continue past), and a proposed fail-closed
  fix.
- `AM-validate-fails-closed-on-unparseable-entity` — the measure that would pin
  it: a project with one unparseable entity must make `validate` exit non-zero
  and name the file.
- Three relations (`affects`, `fixes`, `adds-measure`).

## Verification

- `analyze cardinality` → all constraints satisfied
- `analyze validations` → **10 errors, identical to clean `develop`**; these
  files add none. (`develop` is currently red from unrelated in-flight work:
  BUG-762I34, TKT-UIR41P, BUG-219PVU, BUG-ZE4354, and 3 open review responses.)
- Ticket done-before-merge gate replayed locally → `BUG-NEQRY2 = backlog` OK