### PR TITLE
perf(dashboard): derive card display data once per card (TKT-ERHWL0)

### DIFF
--- a/frontend/src/views/DashboardView.test.ts
+++ b/frontend/src/views/DashboardView.test.ts
@@ -156,4 +156,88 @@ describe('DashboardView', () => {
 
     expect(searchEntitiesMock).toHaveBeenCalledTimes(2)
   })
+
+  // TKT-ERHWL0. The template asks for a breakdown/table twice per card
+  // (`v-if="…length"` then `v-for`). Both derivations are O(N) or worse over
+  // the card's whole result set, so they must be memoized rather than
+  // recomputed per call site.
+  describe('derived card data is memoized', () => {
+    function entity(id: string, props: Record<string, unknown>): Entity {
+      return { id, type: 'ticket', properties: props } as unknown as Entity
+    }
+
+    it('derives a breakdown once even though the template reads it twice', async () => {
+      // A getter on `status` counts every read of the property. Two template
+      // call sites over 3 entities is 3 reads when memoized, 6 when not.
+      let reads = 0
+      const rows = ['todo', 'todo', 'done'].map((status, i) =>
+        entity(`TKT-${i}`, {
+          get status() {
+            reads++
+            return status
+          },
+        })
+      )
+      searchEntitiesMock.mockResolvedValue({
+        data: rows,
+        meta: { total: rows.length, page: 1, per_page: 50, has_more: false },
+      })
+      seedDashboard([card({ display: 'breakdown', group_by: 'status' })])
+
+      const wrapper = await mountView()
+
+      expect(wrapper.text()).toContain('todo')
+      expect(reads).toBe(rows.length)
+    })
+
+    it('sorts table rows once even though the template reads them twice', async () => {
+      const rows = ['c', 'a', 'b'].map((t, i) => entity(`TKT-${i}`, { title: t }))
+      searchEntitiesMock.mockResolvedValue({
+        data: rows,
+        meta: { total: rows.length, page: 1, per_page: 50, has_more: false },
+      })
+      seedDashboard([
+        card({
+          display: 'table',
+          columns: [{ property: 'title' }],
+          sort: [{ property: 'title', direction: 'asc' }],
+        }),
+      ])
+
+      const wrapper = await mountView()
+
+      const cells = wrapper.findAll('tbody td').map((td) => td.text())
+      expect(cells).toEqual(['a', 'b', 'c'])
+    })
+
+    // The memo must not outlive the data it was derived from. `cardData` is a
+    // ref holding a Map mutated with `.set()`, so the computed has to track
+    // the ref itself — the arriving search response must reach the template.
+    //
+    // Note this asserts the memo invalidates *as data lands*, not on a later
+    // reload: `loadData` runs only from `onMounted`, so a card list swapped
+    // after mount does not refetch (pre-existing, unrelated to TKT-ERHWL0).
+    it('renders data that arrives after the initial render', async () => {
+      let resolveSearch!: (r: ListResponse<Entity>) => void
+      searchEntitiesMock.mockReturnValue(
+        new Promise<ListResponse<Entity>>((res) => {
+          resolveSearch = res
+        })
+      )
+      seedDashboard([card({ display: 'breakdown', group_by: 'status' })])
+
+      // Mount without awaiting the search: the breakdown is empty, and the
+      // computed has already been evaluated once in that state.
+      const wrapper = mount(DashboardView)
+      expect(wrapper.text()).not.toContain('done')
+
+      resolveSearch({
+        data: [entity('TKT-2', { status: 'done' })],
+        meta: { total: 1, page: 1, per_page: 50, has_more: false },
+      })
+      await flushPromises()
+
+      expect(wrapper.text()).toContain('done')
+    })
+  })
 })

--- a/frontend/src/views/DashboardView.test.ts
+++ b/frontend/src/views/DashboardView.test.ts
@@ -191,7 +191,20 @@ describe('DashboardView', () => {
     })
 
     it('sorts table rows once even though the template reads them twice', async () => {
-      const rows = ['c', 'a', 'b'].map((t, i) => entity(`TKT-${i}`, { title: t }))
+      // Counting reads of `title`, not just asserting the order: the order was
+      // already correct before this change, so a bare `toEqual` pins sorting
+      // and says nothing about how often the rows were derived. Deriving twice
+      // costs a second sort pass, which this count catches.
+      let reads = 0
+      const values = ['c', 'a', 'b']
+      const rows = values.map((t, i) =>
+        entity(`TKT-${i}`, {
+          get title() {
+            reads++
+            return t
+          },
+        })
+      )
       searchEntitiesMock.mockResolvedValue({
         data: rows,
         meta: { total: rows.length, page: 1, per_page: 50, has_more: false },
@@ -208,6 +221,58 @@ describe('DashboardView', () => {
 
       const cells = wrapper.findAll('tbody td').map((td) => td.text())
       expect(cells).toEqual(['a', 'b', 'c'])
+
+      // Sorting reads each row's property, then rendering reads it once per
+      // cell. Deriving a second time re-runs the sort — measured at 15 reads
+      // against the pre-TKT-ERHWL0 code, versus 9 here.
+      const derivedTwice = 15
+      expect(reads).toBeLessThan(derivedTwice)
+    })
+
+    // The collision this keying must not have. `cardKey()` covers
+    // [title, query, display] — correct for `cardData`, where two cards with
+    // one query share a fetch, but NOT sufficient to key derived data:
+    // `group_by` changes the breakdown without changing the key. Keying the
+    // derivation by cardKey rendered the second card's breakdown on both tiles.
+    it('gives two cards differing only in group_by their own breakdown', async () => {
+      searchEntitiesMock.mockResolvedValue({
+        data: [entity('TKT-1', { status: 'todo', priority: 'high' })],
+        meta: { total: 1, page: 1, per_page: 50, has_more: false },
+      })
+      seedDashboard([
+        card({ title: 'T', query: 'type:ticket', display: 'breakdown', group_by: 'status' }),
+        card({ title: 'T', query: 'type:ticket', display: 'breakdown', group_by: 'priority' }),
+      ])
+
+      const tiles = (await mountView()).findAll('.dashboard-card')
+
+      expect(tiles).toHaveLength(2)
+      expect(tiles[0].text()).toContain('todo')
+      expect(tiles[1].text()).toContain('high')
+    })
+
+    // A count card renders one number, so it must not pay to copy and sort a
+    // result set nothing displays.
+    it('does not derive table rows for a count card', async () => {
+      let reads = 0
+      const rows = ['c', 'a', 'b'].map((t, i) =>
+        entity(`TKT-${i}`, {
+          get title() {
+            reads++
+            return t
+          },
+        })
+      )
+      searchEntitiesMock.mockResolvedValue({
+        data: rows,
+        meta: { total: rows.length, page: 1, per_page: 50, has_more: false },
+      })
+      seedDashboard([card({ display: 'count', sort: [{ property: 'title', direction: 'asc' }] })])
+
+      const wrapper = await mountView()
+
+      expect(wrapper.text()).toContain('3')
+      expect(reads).toBe(0)
     })
 
     // The memo must not outlive the data it was derived from. `cardData` is a

--- a/frontend/src/views/DashboardView.vue
+++ b/frontend/src/views/DashboardView.vue
@@ -62,104 +62,90 @@ async function loadData() {
   }
 }
 
-function getCardCount(card: DashboardCard): number {
-  return cardData.value.get(cardKey(card))?.count || 0
+type Breakdown = Array<{ value: string; count: number; percentage: number }>
+
+/** One rendered tile: the card plus everything the template needs derived. */
+interface CardView {
+  card: DashboardCard
+  key: string
+  count: number
+  breakdown: Breakdown
+  rows: Entity[]
+}
+
+function buildBreakdown(card: DashboardCard, entities: Entity[]): Breakdown {
+  if (!card.group_by) return []
+
+  const groupBy = card.group_by
+  const counts: Record<string, number> = {}
+  let total = 0
+
+  for (const entity of entities) {
+    const value = String(entity.properties[groupBy] || 'Unknown')
+    counts[value] = (counts[value] || 0) + 1
+    total++
+  }
+
+  return Object.entries(counts)
+    .map(([value, count]) => ({
+      value,
+      count,
+      percentage: total > 0 ? (count / total) * 100 : 0,
+    }))
+    .sort((a, b) => b.count - a.count)
+}
+
+function buildRows(card: DashboardCard, entities: Entity[]): Entity[] {
+  const sorted = [...entities]
+
+  if (card.sort?.length) {
+    const sort = card.sort[0]
+    sorted.sort((a, b) => {
+      const aVal = String(a.properties[sort.property] || '')
+      const bVal = String(b.properties[sort.property] || '')
+      const cmp = aVal.localeCompare(bVal)
+      return sort.direction === 'desc' ? -cmp : cmp
+    })
+  }
+
+  return card.limit ? sorted.slice(0, card.limit) : sorted
 }
 
 /**
- * Breakdown and table rows, derived once per card and cached until the card
- * list or the loaded data changes (TKT-ERHWL0).
+ * The rendered tiles, with each card's display data derived exactly once
+ * (TKT-ERHWL0).
  *
- * These are `computed` maps rather than plain functions because the template
- * asks for each twice — `v-if="…length"` and then `v-for` — and both are
- * O(N) or worse over the card's whole result set (a group-by, and a copy plus
- * a `localeCompare` sort). As plain functions that is two full passes per
- * card per render, over every matched entity, to show at most `card.limit`
- * rows.
+ * The template used to call `getBreakdown(card)` / `getTableRows(card)` twice
+ * per card — once for `v-if="…length"`, once for `v-for` — and both are O(N)
+ * or worse over the card's whole result set (a group-by; a copy plus a
+ * `localeCompare` sort). Deriving into the view model the template iterates
+ * means each derivation has exactly one call site, structurally, rather than
+ * being deduplicated by a cache.
  *
- * Keyed by `cardKey()` for the same reason `cardData` is: the card list is
- * per-principal, so an index would bind one card's rows to another's tile.
+ * One entry per card BY POSITION, deliberately not a Map keyed by `cardKey()`.
+ * `cardKey` covers `[title, query, display]`, which is right for `cardData` —
+ * two cards with the same query legitimately share one fetch — but wrong here,
+ * because `group_by` / `sort` / `limit` change the derivation without changing
+ * the key. Keying the derived data by `cardKey` let a "by status" card render a
+ * "by priority" card's breakdown: the exact one-card's-data-on-another's-tile
+ * bug `cardKey` was introduced (TKT-53KICM) to prevent.
+ *
+ * Deriving only for the display mode that renders it also keeps a count card
+ * from paying for a table copy of a result set nothing shows.
  */
-type Breakdown = Array<{ value: string; count: number; percentage: number }>
-
-const breakdowns = computed<Map<string, Breakdown>>(() => {
-  const out = new Map<string, Breakdown>()
-
-  for (const card of cards.value) {
+const cardViews = computed<CardView[]>(() =>
+  cards.value.map((card) => {
     const key = cardKey(card)
-    const data = cardData.value.get(key)
-    if (!data || !card.group_by) {
-      out.set(key, [])
-      continue
-    }
-
-    const groupBy = card.group_by
-    const counts: Record<string, number> = {}
-    let total = 0
-
-    for (const entity of data.entities) {
-      const value = String(entity.properties[groupBy] || 'Unknown')
-      counts[value] = (counts[value] || 0) + 1
-      total++
-    }
-
-    out.set(
+    const entities = cardData.value.get(key)?.entities ?? []
+    return {
+      card,
       key,
-      Object.entries(counts)
-        .map(([value, count]) => ({
-          value,
-          count,
-          percentage: total > 0 ? (count / total) * 100 : 0,
-        }))
-        .sort((a, b) => b.count - a.count)
-    )
-  }
-
-  return out
-})
-
-const tableRows = computed<Map<string, Entity[]>>(() => {
-  const out = new Map<string, Entity[]>()
-
-  for (const card of cards.value) {
-    const key = cardKey(card)
-    const data = cardData.value.get(key)
-    if (!data) {
-      out.set(key, [])
-      continue
+      count: cardData.value.get(key)?.count || 0,
+      breakdown: card.display === 'breakdown' ? buildBreakdown(card, entities) : [],
+      rows: card.display === 'table' ? buildRows(card, entities) : [],
     }
-
-    let entities = [...data.entities]
-
-    // Apply sort
-    if (card.sort?.length) {
-      const sort = card.sort[0]
-      entities.sort((a, b) => {
-        const aVal = String(a.properties[sort.property] || '')
-        const bVal = String(b.properties[sort.property] || '')
-        const cmp = aVal.localeCompare(bVal)
-        return sort.direction === 'desc' ? -cmp : cmp
-      })
-    }
-
-    // Apply limit
-    if (card.limit) {
-      entities = entities.slice(0, card.limit)
-    }
-
-    out.set(key, entities)
-  }
-
-  return out
-})
-
-function getBreakdown(card: DashboardCard): Breakdown {
-  return breakdowns.value.get(cardKey(card)) || []
-}
-
-function getTableRows(card: DashboardCard): Entity[] {
-  return tableRows.value.get(cardKey(card)) || []
-}
+  })
+)
 
 function getColumnLabel(col: { property?: string; label?: string }): string {
   return col.label || col.property || ''
@@ -217,14 +203,14 @@ onMounted(async () => {
 
       <div v-else class="dashboard-grid">
         <div
-          v-for="card in cards"
-          :key="cardKey(card)"
+          v-for="view in cardViews"
+          :key="view.key"
           class="dashboard-card"
         >
           <div class="card-header">
-            <h3>{{ card.title }}</h3>
+            <h3>{{ view.card.title }}</h3>
             <router-link
-              :to="`/search?q=${encodeURIComponent(card.query)}`"
+              :to="`/search?q=${encodeURIComponent(view.card.query)}`"
               class="card-link"
               title="View in search"
             >
@@ -233,14 +219,14 @@ onMounted(async () => {
           </div>
 
           <!-- Count display -->
-          <div v-if="card.display === 'count'" class="card-count">
-            <span class="count-number">{{ getCardCount(card) }}</span>
+          <div v-if="view.card.display === 'count'" class="card-count">
+            <span class="count-number">{{ view.count }}</span>
           </div>
 
           <!-- Breakdown display -->
-          <div v-else-if="card.display === 'breakdown'" class="card-breakdown">
+          <div v-else-if="view.card.display === 'breakdown'" class="card-breakdown">
             <div
-              v-for="item in getBreakdown(card)"
+              v-for="item in view.breakdown"
               :key="item.value"
               class="breakdown-row"
             >
@@ -253,24 +239,24 @@ onMounted(async () => {
               </div>
               <span class="breakdown-count">{{ item.count }}</span>
             </div>
-            <div v-if="getBreakdown(card).length === 0" class="no-data">
+            <div v-if="view.breakdown.length === 0" class="no-data">
               No data
             </div>
           </div>
 
           <!-- Table display -->
-          <div v-else-if="card.display === 'table'" class="card-table">
-            <table v-if="getTableRows(card).length > 0">
+          <div v-else-if="view.card.display === 'table'" class="card-table">
+            <table v-if="view.rows.length > 0">
               <thead>
                 <tr>
-                  <th v-for="col in card.columns" :key="col.property">
+                  <th v-for="col in view.card.columns" :key="col.property">
                     {{ getColumnLabel(col) }}
                   </th>
                 </tr>
               </thead>
               <tbody>
-                <tr v-for="entity in getTableRows(card)" :key="entity.id">
-                  <td v-for="col in card.columns" :key="col.property">
+                <tr v-for="entity in view.rows" :key="entity.id">
+                  <td v-for="col in view.card.columns" :key="col.property">
                     <router-link
                       v-if="getCellLink(entity, col)"
                       :to="getCellLink(entity, col)!"

--- a/frontend/src/views/DashboardView.vue
+++ b/frontend/src/views/DashboardView.vue
@@ -66,52 +66,99 @@ function getCardCount(card: DashboardCard): number {
   return cardData.value.get(cardKey(card))?.count || 0
 }
 
-function getBreakdown(card: DashboardCard): Array<{ value: string; count: number; percentage: number }> {
-  const data = cardData.value.get(cardKey(card))
-  if (!data || !card.group_by) return []
+/**
+ * Breakdown and table rows, derived once per card and cached until the card
+ * list or the loaded data changes (TKT-ERHWL0).
+ *
+ * These are `computed` maps rather than plain functions because the template
+ * asks for each twice — `v-if="…length"` and then `v-for` — and both are
+ * O(N) or worse over the card's whole result set (a group-by, and a copy plus
+ * a `localeCompare` sort). As plain functions that is two full passes per
+ * card per render, over every matched entity, to show at most `card.limit`
+ * rows.
+ *
+ * Keyed by `cardKey()` for the same reason `cardData` is: the card list is
+ * per-principal, so an index would bind one card's rows to another's tile.
+ */
+type Breakdown = Array<{ value: string; count: number; percentage: number }>
 
-  const groupBy = card.group_by
-  const counts: Record<string, number> = {}
-  let total = 0
+const breakdowns = computed<Map<string, Breakdown>>(() => {
+  const out = new Map<string, Breakdown>()
 
-  for (const entity of data.entities) {
-    const value = String(entity.properties[groupBy] || 'Unknown')
-    counts[value] = (counts[value] || 0) + 1
-    total++
+  for (const card of cards.value) {
+    const key = cardKey(card)
+    const data = cardData.value.get(key)
+    if (!data || !card.group_by) {
+      out.set(key, [])
+      continue
+    }
+
+    const groupBy = card.group_by
+    const counts: Record<string, number> = {}
+    let total = 0
+
+    for (const entity of data.entities) {
+      const value = String(entity.properties[groupBy] || 'Unknown')
+      counts[value] = (counts[value] || 0) + 1
+      total++
+    }
+
+    out.set(
+      key,
+      Object.entries(counts)
+        .map(([value, count]) => ({
+          value,
+          count,
+          percentage: total > 0 ? (count / total) * 100 : 0,
+        }))
+        .sort((a, b) => b.count - a.count)
+    )
   }
 
-  return Object.entries(counts)
-    .map(([value, count]) => ({
-      value,
-      count,
-      percentage: total > 0 ? (count / total) * 100 : 0,
-    }))
-    .sort((a, b) => b.count - a.count)
+  return out
+})
+
+const tableRows = computed<Map<string, Entity[]>>(() => {
+  const out = new Map<string, Entity[]>()
+
+  for (const card of cards.value) {
+    const key = cardKey(card)
+    const data = cardData.value.get(key)
+    if (!data) {
+      out.set(key, [])
+      continue
+    }
+
+    let entities = [...data.entities]
+
+    // Apply sort
+    if (card.sort?.length) {
+      const sort = card.sort[0]
+      entities.sort((a, b) => {
+        const aVal = String(a.properties[sort.property] || '')
+        const bVal = String(b.properties[sort.property] || '')
+        const cmp = aVal.localeCompare(bVal)
+        return sort.direction === 'desc' ? -cmp : cmp
+      })
+    }
+
+    // Apply limit
+    if (card.limit) {
+      entities = entities.slice(0, card.limit)
+    }
+
+    out.set(key, entities)
+  }
+
+  return out
+})
+
+function getBreakdown(card: DashboardCard): Breakdown {
+  return breakdowns.value.get(cardKey(card)) || []
 }
 
 function getTableRows(card: DashboardCard): Entity[] {
-  const data = cardData.value.get(cardKey(card))
-  if (!data) return []
-
-  let entities = [...data.entities]
-
-  // Apply sort
-  if (card.sort?.length) {
-    const sort = card.sort[0]
-    entities.sort((a, b) => {
-      const aVal = String(a.properties[sort.property] || '')
-      const bVal = String(b.properties[sort.property] || '')
-      const cmp = aVal.localeCompare(bVal)
-      return sort.direction === 'desc' ? -cmp : cmp
-    })
-  }
-
-  // Apply limit
-  if (card.limit) {
-    entities = entities.slice(0, card.limit)
-  }
-
-  return entities
+  return tableRows.value.get(cardKey(card)) || []
 }
 
 function getColumnLabel(col: { property?: string; label?: string }): string {

--- a/tickets/entities/features/FEAT-BSPT7O.md
+++ b/tickets/entities/features/FEAT-BSPT7O.md
@@ -1,0 +1,9 @@
+---
+id: FEAT-BSPT7O
+type: feature
+title: Dashboard scales with graph size
+summary: The dashboard's transferred payload and render work track what it displays, not the size of the graph behind it.
+description: 'Every dashboard card fetches full entity records regardless of what it displays. The dogfooded tickets/data-entry.yaml has 7 cards, all display: count or display: breakdown -- displays needing only an aggregate -- yet one dashboard load transfers 4.1MB of JSON at 8000 entities. Measured through handleV1Search: 500 entities -> 256KB, 1000 -> 513KB, 2000 -> 1.0MB, 4000 -> 2.1MB, 8000 -> 4.1MB (clean linear growth). A single count card rendering one integer ships 379KB at 4000 entities. Covers making both the wire payload and the client-side render work proportional to what is actually shown.'
+priority: medium
+status: proposed
+---

--- a/tickets/entities/implementation-checklists/IMPL-ERHWL0.md
+++ b/tickets/entities/implementation-checklists/IMPL-ERHWL0.md
@@ -1,0 +1,91 @@
+<!-- @managed: claude-workflow v1 -->
+---
+id: IMPL-ERHWL0
+type: implementation-checklist
+title: 'Implementation: Memoize dashboard breakdown and table-row derivation'
+status: done
+---
+
+## Development
+
+- [x] Unit tests written for new code
+- [x] ~~Integration tests written (test full flow, not just units)~~ (N/A: no
+      cross-component flow — one component's internal derivation, no API, store
+      or router involvement changed. The component-level tests mount the real
+      view and drive it through the real template, which is the full flow here.)
+- [x] Happy path implemented
+- [x] Edge cases from planning handled
+- [x] Error handling in place (errors surfaced, not swallowed)
+
+Two `computed` maps (`breakdowns`, `tableRows`) keyed by `cardKey(card)`;
+`getBreakdown` / `getTableRows` reduced to lookups with a `|| []` fallback for a
+card whose search has not yet resolved. All three planning edge cases covered:
+missing `group_by`, key absent from `cardData`, and data landing after first
+render.
+
+No error handling to add or remove — these derivations are pure reductions over
+already-fetched data. `loadData`'s existing try/catch is untouched.
+
+## Test Quality
+
+- [x] Using fixture builders or factories for test data
+- [x] No hardcoded values in assertions when object is in scope
+- [x] Only specifying values that matter for the test
+- [x] Interpolated values constructed from objects, not hardcoded
+- [x] Property comparisons use original object, not hardcoded strings
+
+Reused the file's existing `card()` / `seedDashboard()` factories from #1316
+rather than adding a parallel set. Added a local `entity()` helper for row
+fixtures. The read-count assertion is `expect(reads).toBe(rows.length)` — derived
+from the fixture, not the literal `3`, so it stays correct if the fixture grows.
+
+## Manual Verification
+
+- [x] Feature manually tested end-to-end
+- [x] Each acceptance criterion verified with test scenario from planning
+- [x] Edge cases manually verified
+
+**Verification Evidence:**
+
+AC1 — breakdown derived once. A getter on `status` counts property reads; 3
+entities through two template call sites yields **3 reads**. Mutation-tested:
+reverting `getBreakdown` to its non-memoized form fails with
+`AssertionError: expected 6 to be 3`, confirming the guard bites and that the
+doubling was real. Re-confirmed after the rebase onto develop.
+
+AC2 — table rows derived once. A card sorted `title asc` over input
+`['c','a','b']` renders `['a','b','c']`.
+
+AC3 — no output change. The 7 pre-existing #1316 cases pass unmodified.
+
+Edge case (data arriving post-render): mount without awaiting the search, assert
+the value is absent, resolve the promise, assert it appears. This is the memo
+invalidating against a `.set()`-mutated Map inside a `ref`.
+
+Full suite after rebase: **1665 tests / 105 files pass**. `vue-tsc --noEmit`
+clean. `npm run build` clean. `npm run lint` 0 errors, no warnings in the
+changed files.
+
+One test I wrote was wrong and was replaced: it asserted a refetch after
+swapping the card list, but `loadData` runs only from `onMounted`, so nothing
+refetches. That is pre-existing behaviour unrelated to this ticket (noted in the
+review checklist); the replacement exercises the real invalidation path.
+
+## Quality
+
+- [x] Code follows project patterns (check similar code)
+- [x] Checked for DRY opportunities — repeated literals, expressions, or
+      patterns extracted to a helper / constant / type where it
+      sharpens the contract
+- [x] No security issues introduced
+- [x] No silent failures (errors logged AND returned)
+- [x] No debug code left behind
+
+Follows the precomputed-rows pattern `frontend/CLAUDE.md` prescribes for dense
+surfaces (RR-UD2A). Extracted a `Breakdown` type alias, which was previously an
+inline structural type repeated in the signature — that one sharpens the
+contract and is used by both the computed and the getter. Did not extract the
+two map-building loops into a shared generic helper: they share shape but not
+logic (a group-by vs. a sort-and-slice), and merging them would obscure both.
+
+`cardKey` reused from #1316 rather than duplicated.

--- a/tickets/entities/planning-checklists/PLAN-ERHWL0.md
+++ b/tickets/entities/planning-checklists/PLAN-ERHWL0.md
@@ -1,0 +1,170 @@
+<!-- @managed: claude-workflow v1 -->
+---
+id: PLAN-ERHWL0
+type: planning-checklist
+title: 'Planning: Memoize dashboard breakdown and table-row derivation'
+status: done
+---
+
+## Understanding
+
+- [x] Problem/requirements clearly understood
+- [x] Scope defined (what's in/out documented below)
+- [x] Acceptance criteria documented with specific test scenarios
+
+**Scope:**
+
+IN: `getBreakdown` / `getTableRows` in `frontend/src/views/DashboardView.vue`
+become memoized derivations, evaluated once per card per render instead of once
+per template call site (each is referenced twice).
+
+OUT: everything that changes the wire format or the amount of data fetched.
+Server-side aggregation (TKT-AIEGHU), limit/sort pushdown (TKT-8AUD1U) and
+bounding the structured search path (TKT-T0DK37) are separate tickets under the
+same feature — deliberately so, because each collides with in-flight work
+elsewhere while this one does not.
+
+**Acceptance Criteria:**
+
+1. `getBreakdown` evaluates at most once per card per render.
+   Test: a `status` property getter that counts reads; 3 entities through two
+   template call sites must produce 3 reads, not 6.
+2. `getTableRows` evaluates at most once per card per render.
+   Test: a sorted table card renders rows in the configured order.
+3. No change to rendered output for count, breakdown or table cards.
+   Test: the 7 pre-existing `DashboardView.test.ts` cases (from #1316) stay green.
+
+## Research
+
+- [x] For larger features: run `/research` to create a structured research doc
+- [x] Searched for existing libraries that solve this problem
+- [x] Checked codebase for similar patterns or reusable code
+- [x] Looked for reference implementations in other projects
+- [x] Reviewed relevant rela concepts for prior art
+
+**Research Doc:** N/A — xs refactor, single file, no approach ambiguity.
+
+**Existing Solutions:**
+
+- No library needed: Vue's own `computed` is the memoization primitive.
+- Prior art in-tree: `frontend/CLAUDE.md` already documents this exact hazard for
+  dense surfaces — "Resolve per column/field, not per cell — `resolve()` walks a
+  Map and can `console.warn`, which at 200 rows is 200 warnings per render. See
+  `PropertyDisplay.vue`'s precomputed `rows` (RR-UD2A) for the pattern." This
+  ticket applies the same fix one surface over.
+- The card-identity problem was already solved upstream: PR #1316 (TKT-53KICM)
+  introduced `cardKey()` because the card list is per-principal and an
+  index-keyed map binds one card's data to another's tile. Reused as the memo
+  key rather than inventing a second keying scheme.
+
+## Approach
+
+- [x] Technical approach chosen and documented
+- [x] Approach builds on existing patterns (not reinventing)
+- [x] Alternatives considered (document why rejected)
+- [x] Dependencies identified (packages, APIs, types)
+
+**Technical Approach:**
+
+Two `computed` maps, `breakdowns` and `tableRows`, each keyed by `cardKey(card)`
+and built by iterating `cards.value`. The exported `getBreakdown` /
+`getTableRows` become thin lookups into those maps, so every template call site
+is unchanged and the diff stays confined to the `<script setup>` block.
+
+Alternatives rejected:
+
+- **Per-card child component.** Vue would memoize naturally, but it restructures
+  the template for a perf fix and conflicts far harder with #1316.
+- **Cache in a plain `Map` keyed by card, invalidated manually.** Reintroduces
+  the invalidation bug `computed` exists to prevent.
+- **Compute inside `loadData` and store the result.** Couples derivation to
+  fetching; a later config-only change (e.g. `group_by`) would not re-derive.
+
+**Files to modify:**
+
+- `frontend/src/views/DashboardView.vue`
+- `frontend/src/views/DashboardView.test.ts`
+
+## Security Considerations
+
+- [x] Input sources identified (user input, config, external APIs)
+- [x] Input validation approach defined (allowlist preferred over blocklist)
+- [x] Security-sensitive operations identified (file access, auth, crypto)
+- [x] Error handling doesn't leak sensitive information
+
+**Input Sources & Validation:**
+
+No new inputs. The derivations read the same two sources as before: card config
+from `/_config` and entity rows from `/_search`. Both already flow through the
+ACL-scoped read path server-side; this change alters only *when* the client
+reduces them, never *what* it receives.
+
+**Security-Sensitive Operations:**
+
+None. Specifically NOT a place to add filtering: #1316 pins that the view must
+render whatever the server returned and must not re-decide visibility
+client-side (`does not filter on card.permission client-side`). Memoization
+preserves that — it caches the reduction, it does not gate it.
+
+## Test Plan
+
+- [x] Test scenarios documented for each acceptance criterion
+- [x] Edge cases identified and documented
+- [x] Negative test cases defined (invalid input, error conditions)
+- [x] Integration test approach defined (not just unit tests)
+
+**Test Scenarios:**
+
+| Criterion | Test |
+|---|---|
+| AC1 breakdown derived once | counting getter on `status`; expect reads == entity count |
+| AC2 table rows derived once | sorted card renders `['a','b','c']` from input `['c','a','b']` |
+| AC3 no output change | the 7 existing #1316 cases stay green |
+
+**Edge Cases:**
+
+- Card with no `group_by` → empty breakdown, no crash.
+- Card key absent from `cardData` (search still in flight) → `|| []` fallback.
+- Data arriving *after* first render — the memo must invalidate. `cardData` is a
+  `ref` holding a `Map` mutated via `.set()`, so this is the real reactivity
+  risk; covered by resolving the search promise post-mount.
+
+**Negative Tests:**
+
+Mutation test: revert the getter to its non-memoized form and confirm the
+counting test fails (6 reads vs 3). A guard that does not fail against the old
+code pins nothing.
+
+## Risk Assessment
+
+- [x] Technical risks assessed with mitigations
+- [x] Security risks assessed (see Security Considerations)
+- [x] Effort estimated (xs/s/m/l/xl)
+
+**Risks:**
+
+- *Memo fails to invalidate when card data lands.* The plausible failure mode,
+  given `.set()` mutation on a Map inside a `ref`. Mitigated by an explicit test
+  that renders before the search resolves, then asserts the value appears.
+- *Conflict with #1316.* It rewrites the same getters. Mitigated by branching
+  from it rather than develop; since merged, rebased onto develop cleanly.
+
+## Documentation Planning
+
+- [x] User-facing docs identified (skip if internal refactor)
+- [x] Docs-checklist will be created when entering implementation
+
+**Documentation Impact:**
+
+N/A — internal refactor. No user-visible behaviour, config surface or API
+changes, so no docs-checklist (`kind: refactor`, so the
+`done-enhancement-needs-docs-done` gate does not apply).
+
+## Design Review
+
+- [x] Run `/design-review` before starting implementation
+- [x] All critical/significant findings addressed in plan
+
+**Design Review Findings:** None — xs single-file refactor with no interface or
+wire-format change. The one design decision (reuse `cardKey` rather than add a
+second keying scheme) was settled by reading #1316.

--- a/tickets/entities/review-checklists/REV-ERHWL0.md
+++ b/tickets/entities/review-checklists/REV-ERHWL0.md
@@ -1,0 +1,108 @@
+<!-- @managed: claude-workflow v1 -->
+---
+id: REV-ERHWL0
+type: review-checklist
+title: 'Review: Memoize dashboard breakdown and table-row derivation'
+status: pending
+---
+
+## Automated Checks
+
+- [x] All tests pass (`just test`)
+- [x] Lint clean (`just lint`)
+- [x] Coverage maintained (`just coverage-check`)
+
+Go: `just test` no failures; `just lint` 0 issues; `just coverage-check` package
+floor (50%) and total (65%) both PASS at 77.6%. The change is frontend-only, so
+Go coverage is unmoved — run to prove nothing regressed.
+
+Frontend: 1667 tests / 105 files pass, `vue-tsc --noEmit` clean, `npm run lint`
+0 errors with no warnings in the changed files, `npm run build` clean.
+
+## Code Review
+
+- [x] Run `/code-review` command (invokes cranky-code-reviewer agent)
+- [x] All critical review-responses addressed
+- [x] All significant review-responses addressed
+- [x] Self-reviewed the diff for unrelated changes
+
+**Review Responses:** RR-DBKEY1 (critical), RR-DBTEST2 (significant),
+RR-DBEAGER3 (significant) — all `addressed`.
+
+The critical finding was real and I reproduced it independently before acting on
+it: keying the derived data by `cardKey` rendered one card's breakdown on
+another card's tile. The fix restructures to a per-card view model rather than
+widening the key, which removes the collision class instead of avoiding one
+instance of it.
+
+Three reviewer suggestions were NOT taken, deliberately:
+
+- *Hoist a shared frozen empty array for the `|| []` fallbacks* (nit) — the
+  fallbacks no longer exist; the view model always supplies a real array.
+- *Build the map once in `loadData` after `Promise.all` settles* — that couples
+  derivation to fetching, so a config-only change (e.g. a different `group_by`)
+  would not re-derive. The reactive form is correct; the O(cards²) concern is
+  bounded by cards-per-dashboard, which is single digits.
+- *`type Breakdown` sits under the doc comment* (nit) — resolved incidentally:
+  the comment now sits on `cardViews`, and `Breakdown` is declared above it.
+
+Diff self-review: two files, both in scope. No unrelated changes. `getCardCount`
+was deleted because the view model supplies the count — verified it has no other
+caller.
+
+## Acceptance Verification
+
+- [x] Each acceptance criterion tested (reference planning checklist)
+- [x] Test evidence documented in implementation checklist
+
+**Acceptance Status:**
+
+- **AC1 — breakdown derived once per card per render: PASS.** Counting getter
+  yields 3 reads for 3 entities across two template call sites. Mutation-tested:
+  the pre-change form gives 9.
+- **AC2 — table rows derived once per card per render: PASS.** Sorted card
+  renders `['a','b','c']` and stays under the 15-read pre-change bound.
+  Mutation-tested: the pre-change form gives 21. (This criterion was initially
+  signed off on a test that could not fail — see RR-DBTEST2.)
+- **AC3 — no change to rendered output: PASS.** The 7 pre-existing #1316 cases
+  pass unmodified. Note AC3 as originally written was too weak: it would have
+  been satisfied by the RR-DBKEY1 collision, since no existing test covered two
+  cards sharing a key. The added regression test closes that gap.
+
+Every load-bearing guard was mutation-tested — each was broken individually and
+confirmed to fail: collision keying, display guards, and both double-derivation
+counters.
+
+## Documentation (enhancements only)
+
+Skip this section for bugs and internal refactors.
+
+- [x] ~~Docs-checklist created and linked via `has-docs`~~ (N/A: `kind: refactor`,
+      no user-facing surface changes — the `done-enhancement-needs-docs-done`
+      gate does not apply)
+- [x] ~~User-facing documentation updated~~ (N/A: internal refactor)
+- [x] ~~Docs-checklist marked as done~~ (N/A: internal refactor)
+
+**Docs Checklist:** N/A
+
+## Final Checks
+
+- [x] Commit message explains the why, not just what
+- [x] No TODOs or FIXMEs left unaddressed
+- [x] Ready for another developer to use
+
+The godoc on `cardViews` records why derived data must not be keyed by
+`cardKey`, so the collision is not reintroduced by someone consolidating the two
+keying schemes.
+
+## Pull Request
+
+- [ ] Run `/pr` command to create PR and monitor CI
+- [ ] All CI checks pass
+- [ ] PR URL documented below
+
+**PR:** Not yet opened. `rela validate` is blocked repo-wide by BUG-E9DYW5
+(`status: done`, no `has-review`), introduced by #1314 and unrelated to this
+ticket. Three open PRs fix it — #1328, #1330, #1335 — each also repairing the
+malformed `AM-feed-field-redaction.md` frontmatter that was masking the
+violation. This PR opens once any of them merges.

--- a/tickets/entities/review-checklists/REV-ERHWL0.md
+++ b/tickets/entities/review-checklists/REV-ERHWL0.md
@@ -3,7 +3,7 @@
 id: REV-ERHWL0
 type: review-checklist
 title: 'Review: Memoize dashboard breakdown and table-row derivation'
-status: pending
+status: done
 ---
 
 ## Automated Checks
@@ -13,11 +13,15 @@ status: pending
 - [x] Coverage maintained (`just coverage-check`)
 
 Go: `just test` no failures; `just lint` 0 issues; `just coverage-check` package
-floor (50%) and total (65%) both PASS at 77.6%. The change is frontend-only, so
-Go coverage is unmoved — run to prove nothing regressed.
+floor (50%) and total (65%) both PASS at 77.7%. The change is frontend-only, so
+Go coverage is unmoved — run to prove nothing regressed. `just arch-lint` and
+`just plimsoll` clean.
 
-Frontend: 1667 tests / 105 files pass, `vue-tsc --noEmit` clean, `npm run lint`
+Frontend: 1674 tests / 106 files pass, `vue-tsc --noEmit` clean, `npm run lint`
 0 errors with no warnings in the changed files, `npm run build` clean.
+
+Re-verified after rebasing onto develop across the Pinia 3→4 major bump,
+including re-running the mutation tests.
 
 ## Code Review
 
@@ -97,12 +101,23 @@ keying schemes.
 
 ## Pull Request
 
-- [ ] Run `/pr` command to create PR and monitor CI
-- [ ] All CI checks pass
-- [ ] PR URL documented below
+- [x] Run `/pr` command to create PR and monitor CI
+- [x] ~~All CI checks pass~~ (N/A: every job this branch can affect passes;
+      "Rela Tickets" is red on develop for unrelated tickets — see below)
+- [x] PR URL documented below
 
-**PR:** Not yet opened. `rela validate` is blocked repo-wide by BUG-E9DYW5
-(`status: done`, no `has-review`), introduced by #1314 and unrelated to this
-ticket. Three open PRs fix it — #1328, #1330, #1335 — each also repairing the
-malformed `AM-feed-field-redaction.md` frontmatter that was masking the
-violation. This PR opens once any of them merges.
+**PR:** https://github.com/sourcehaven-bv/rela/pull/1361
+
+All checks pass except **Rela Tickets**, which runs
+`rela validate --project tickets`. That job is red on `develop` itself: a clean
+`develop` worktree reports the same 10 errors, none from this branch —
+TKT-UIR41P missing `has-docs`/`has-review`, three open `RR-*` blocking merge,
+and three bugs missing `has-review` (one also missing a description).
+
+The 11th error was this ticket's own `has-review` gate, which fired because this
+checklist stayed `pending` until the PR existed — the PR boxes could not be
+honestly checked before then. Resolved by completing it now that #1361 is open.
+
+The earlier blocker (BUG-E9DYW5 + the malformed `AM-feed-field-redaction.md`
+frontmatter masking it) was fixed on develop by #1337, not by any of the three
+dedicated PRs — #1335 was closed, #1328 and #1330 are now redundant.

--- a/tickets/entities/review-responses/RR-DBEAGER3.md
+++ b/tickets/entities/review-responses/RR-DBEAGER3.md
@@ -1,0 +1,16 @@
+---
+id: RR-DBEAGER3
+type: review-response
+title: Eager derivation made count cards pay for table rows nothing renders
+finding: |-
+    The Map-based implementation built an entry for EVERY card on any invalidation, regardless of display mode. `breakdowns` bailed early for a card with no `group_by`, so a count card cost O(1) there — but `tableRows` guarded only on `if (!data)`.
+
+    So a `display: count` card over a 5000-row result set executed `[...data.entities]`, a full array copy, plus a `localeCompare` sort when the card carried a `sort:` — to produce a list nothing renders. Measured at ~28ms of mount-and-settle for 20 count cards over 5000 rows, essentially all of it copying arrays that are never read.
+
+    A regression on the exact axis the ticket exists to improve: it removed two wasted passes from breakdown/table cards and added one to every count card.
+severity: significant
+resolution: |-
+    `cardViews` derives per display mode — `card.display === 'breakdown' ? buildBreakdown(...) : []` and the same for `rows` — so a card only pays for the derivation it renders. This falls out of the restructure in RR-DBKEY1 rather than being a separate guard.
+
+    Pinned by 'does not derive table rows for a count card', which asserts zero property reads for a count card carrying a `sort:`. Mutation-verified: removing the display guards fails it.
+status: addressed

--- a/tickets/entities/review-responses/RR-DBKEY1.md
+++ b/tickets/entities/review-responses/RR-DBKEY1.md
@@ -1,0 +1,25 @@
+---
+id: RR-DBKEY1
+type: review-response
+title: Keying derived card data by cardKey renders one card's breakdown on another card's tile
+finding: |-
+    The first implementation memoized `getBreakdown` / `getTableRows` into `computed` Maps keyed by `cardKey(card)`. `cardKey` hashes `[title, query, display]` — it does NOT include `group_by`, `sort`, `columns` or `limit`.
+
+    That omission is benign for `cardData`, the fetch cache: two cards with the same query legitimately issue one request and share one `{entities, count}`. It is NOT benign for derived data, because the derivation reads exactly the fields the key omits. Two cards colliding on the key both write to `out.set(key, …)` — last writer wins — and both tiles then read that single entry.
+
+    Reproduced independently of the review, with two breakdown cards sharing title/query/display, one `group_by: status` and one `group_by: priority`, over one entity `{status: todo, priority: high}`:
+
+        OLD  tile0 => "T todo1"   tile1 => "T high1"   (correct)
+        NEW  tile0 => "T high1"   tile1 => "T high1"   (tile0 wrong)
+
+    Confirmed as a regression, not a pre-existing fault: reverting `getBreakdown` to its non-memoized form makes the same scenario pass.
+
+    This is the exact one-card's-data-on-another's-tile failure that TKT-53KICM introduced `cardKey` to prevent, reintroduced one layer up in the derivation. It is silent — the user sees a plausible chart of the wrong dimension — and "tickets by status" beside "tickets by priority" over one saved query is an ordinary dashboard config.
+severity: critical
+resolution: |-
+    Restructured rather than patched. Instead of Maps keyed by a string, a single `cardViews` computed maps `cards.value` to one `CardView` per card BY POSITION, and the template `v-for`s over that. No key is shared between cards, so the collision class cannot exist — rather than being avoided by widening the key, which would leave the next person free to narrow it again.
+
+    `cardKey` is still used for `cardData` (where sharing a fetch is correct and desirable) and as the `v-for` `:key`. The godoc on `cardViews` states why the two must not be merged.
+
+    Pinned by 'gives two cards differing only in group_by their own breakdown'. Mutation-verified: routing the breakdown back through a cardKey lookup fails it.
+status: addressed

--- a/tickets/entities/review-responses/RR-DBTEST2.md
+++ b/tickets/entities/review-responses/RR-DBTEST2.md
@@ -1,0 +1,16 @@
+---
+id: RR-DBTEST2
+type: review-response
+title: The table-rows test asserted sort order, so it pinned nothing this ticket changed
+finding: |-
+    'sorts table rows once even though the template reads them twice' asserted only `cells === ['a','b','c']`. The pre-TKT-ERHWL0 code sorted correctly too, so the assertion held equally against the implementation the ticket replaces.
+
+    Demonstrated: reverting to the non-memoized getters failed the breakdown test (6 reads vs 3) while this one PASSED. Its name promises 'once' and 'twice' and it verified neither — it pinned sorting, which was never at risk.
+severity: significant
+resolution: |-
+    Instrumented the same way as the breakdown test: a counting getter on `title`, so the assertion measures how many times the rows were derived rather than what order they came out in. The order assertion is kept — it is still worth pinning — but it is no longer the only one.
+
+    The bound is expressed as `expect(reads).toBeLessThan(15)` with `15` named as the measured pre-change count, rather than a bare magic number: sort comparisons plus one read per rendered cell is implementation detail that could shift, while 'fewer than deriving twice' is the property under test.
+
+    Mutation-verified: with the template calling the derivations twice again, it fails at 21 reads.
+status: addressed

--- a/tickets/entities/tickets/TKT-8AUD1U.md
+++ b/tickets/entities/tickets/TKT-8AUD1U.md
@@ -1,0 +1,50 @@
+---
+id: TKT-8AUD1U
+type: ticket
+title: 'Dashboard table cards: push limit and sort into the query'
+kind: enhancement
+priority: medium
+effort: m
+status: backlog
+---
+
+## What
+
+`DashboardCard.Limit` (`internal/dataentryconfig/config.go:726`) is applied
+**client-side only**, in `getTableRows` via `.slice(0, card.limit)` — after the
+full result set has been serialized and transferred. A `limit: 5` table card
+downloads all matching rows to display 5.
+
+`card.sort` has the same shape: sorting happens in the browser with
+`localeCompare`, so it cannot be pushed down as-authored.
+
+## Why it isn't just "add LIMIT"
+
+Sort must move server-side *with* the limit, or the wrong rows get truncated —
+limiting before an unsorted set returns an arbitrary 5, not the top 5. So this
+ticket is really "make `sort` a store-side ordering, then bound it", which is
+why it is `m` not `s`.
+
+The `localeCompare` semantics are also not free to reproduce: the store would
+need a compatible collation, or the config needs to declare that ordering is
+byte/natural rather than locale-aware. Decide this explicitly rather than
+silently changing which rows appear.
+
+## Sequencing — check before starting
+
+Overlaps `rela-query-paging` (branch `tkt-ju3s5n-graphquery-paging`,
+TKT-JU3S5N): keyset paging for `GraphQueryer` via a separate `GraphPageQuery`.
+That commit's rationale explicitly notes paging lives off `GraphQuery` because
+`GraphCount` / `MatchingIDs` must answer for the whole matched set. It also
+references a follow-up TKT-YWDGZD for pushing the ACL predicate down.
+
+Build on that rather than inventing a second bounding mechanism. Re-check
+whether it has merged before starting.
+
+## Acceptance
+
+- A `limit: N` table card transfers O(N) rows, not O(matching entities).
+- Rows displayed are the same ones as today for the configured sort, or the
+ordering change is documented and deliberate.
+- Cards with no `limit` keep working (bounded by whatever cap the paging work
+establishes).

--- a/tickets/entities/tickets/TKT-AIEGHU.md
+++ b/tickets/entities/tickets/TKT-AIEGHU.md
@@ -1,0 +1,69 @@
+---
+id: TKT-AIEGHU
+type: ticket
+title: Server-side aggregation for count and breakdown dashboard cards
+kind: enhancement
+priority: high
+effort: m
+status: backlog
+---
+
+## What
+
+A `display: count` card renders one integer. A `display: breakdown` card renders
+a group-by tally. Both currently download **every matching entity in full** and
+compute the aggregate in the browser.
+
+`handleV1Search` (`internal/dataentry/api_v1.go:1352`) serializes every match
+with full properties and body, then sets `Meta.Total = len(data)` — the count is
+derived *from* the full payload rather than instead of it. `DashboardView.vue`
+calls `searchEntities(card.query)` per card and reduces client-side in
+`getCardCount` / `getBreakdown`.
+
+## Measured
+
+Through `handleV1Search`, 7 cards (the dogfooded `tickets/data-entry.yaml` set,
+all count/breakdown):
+
+| entities | 7 cards, wall | JSON transferred |
+|---|---|---|
+| 500 | 3.5 ms | 256 KB |
+| 1 000 | 5.6 ms | 513 KB |
+| 2 000 | 11.1 ms | 1.0 MB |
+| 4 000 | 28.4 ms | 2.1 MB |
+| 8 000 | 53.8 ms | **4.1 MB** |
+
+Linear, but with a brutal constant: one count card ships 379 KB at 4000 entities
+to display a single number.
+
+## How
+
+Return an aggregate instead of rows when the card's display mode only needs one:
+`{total}` for `count`, `{value: count}` map for `breakdown`. The card config
+already carries `display` and `group_by`, so the server has everything it needs
+to decide.
+
+`store.GraphCount` already returns `(matched, total)` — prefer it over
+materializing and counting. Mind RR-SSPCCI ("GraphCount total is a count oracle
+over hidden rows"): the aggregate must be computed over the **ACL-scoped** set,
+same as the current search path, or it becomes a disclosure channel for rows the
+principal cannot read.
+
+## Sequencing — check before starting
+
+This reshapes the card payload, which is **also** what the in-flight
+optional-body work does (making entity content optional on fetch). Land after
+that, or coordinate — otherwise the two collide on the same wire shape.
+
+Also depends on PR #1316 (TKT-53KICM), which adds `GET /api/v1/_dashboard` and
+rewrites `DashboardView.vue`; that endpoint is the natural home for a card-aware
+aggregate response.
+
+Re-verify both before picking this up.
+
+## Acceptance
+
+- A `count` card transfers O(1) bytes regardless of graph size.
+- A `breakdown` card transfers O(distinct group values), not O(matching entities).
+- Aggregates respect ACL scoping — no count over rows the principal cannot read.
+- `table` cards are out of scope here (see the limit/sort pushdown ticket).

--- a/tickets/entities/tickets/TKT-ERHWL0.md
+++ b/tickets/entities/tickets/TKT-ERHWL0.md
@@ -5,7 +5,7 @@ title: Memoize dashboard breakdown and table-row derivation
 kind: refactor
 priority: medium
 effort: xs
-status: backlog
+status: done
 ---
 
 ## What

--- a/tickets/entities/tickets/TKT-ERHWL0.md
+++ b/tickets/entities/tickets/TKT-ERHWL0.md
@@ -1,0 +1,62 @@
+---
+id: TKT-ERHWL0
+type: ticket
+title: Memoize dashboard breakdown and table-row derivation
+kind: refactor
+priority: medium
+effort: xs
+status: backlog
+---
+
+## What
+
+`getBreakdown` and `getTableRows` in `frontend/src/views/DashboardView.vue` are
+plain functions, not `computed`. Each is called **twice** in the template, so
+every re-render redoes the work twice over the full result set:
+
+- `getBreakdown(card)` at `:196` (`v-for`) and `:209` (`v-if ... .length === 0`)
+- `getTableRows(card)` at `:216` (`v-if ... .length > 0`) and `:225` (`v-for`)
+
+`getBreakdown` is an O(N) group-by; `getTableRows` copies the array and runs an
+O(N log N) `localeCompare` sort. At 4000 entities a breakdown card does two full
+group-bys per render, and a table card two full sorts — to display at most
+`card.limit` rows.
+
+Note the config values directly above them (`title`, `description`, `cards`)
+*are* `computed`; only the per-row data functions were left as methods.
+
+## Why this one first
+
+This is the only finding in FEAT-BSPT7O that touches no wire format and
+duplicates no in-flight work:
+
+- Pushing property filters into the store is **already built** in the
+`rela-next-action` branch (`c5960f9c`, "perf(dataentry): push equality property
+filters into the store").
+- Bounding result sets overlaps `rela-query-paging` (TKT-JU3S5N, keyset paging
+for `GraphQueryer`).
+- Server-side aggregation reshapes the card payload, which is exactly what the
+in-flight optional-body work also does — so it should land after that settles.
+
+## How
+
+Replace the two functions with a single `computed` map keyed by `cardKey(card)`,
+returning the derived breakdown/rows per card. PR #1316 (TKT-53KICM) introduces
+`cardKey()` for exactly this identity problem — reuse it rather than adding a
+second keying scheme.
+
+The template call sites stay as they are; they just read a memoized value.
+
+## Sequencing
+
+**Branch from `feat/dashboard-card-permissions` (PR #1316), not `develop`.**
+#1316 rewrites `DashboardView.vue` (+58/−19), re-keying these getters from array
+index to `cardKey`. It leaves them as plain double-called functions, so this
+ticket survives that change intact — but rebasing onto develop would conflict in
+exactly these lines.
+
+## Acceptance
+
+- `getBreakdown` / `getTableRows` each evaluate at most once per card per render.
+- No change to rendered output for count, breakdown, or table cards.
+- Existing `DashboardView.test.ts` (added by #1316) stays green.

--- a/tickets/entities/tickets/TKT-ERHWL0.md
+++ b/tickets/entities/tickets/TKT-ERHWL0.md
@@ -40,12 +40,19 @@ in-flight optional-body work also does — so it should land after that settles.
 
 ## How
 
-Replace the two functions with a single `computed` map keyed by `cardKey(card)`,
-returning the derived breakdown/rows per card. PR #1316 (TKT-53KICM) introduces
-`cardKey()` for exactly this identity problem — reuse it rather than adding a
-second keying scheme.
+A single `cardViews` computed maps `cards.value` to one view model per card —
+`{card, key, count, breakdown, rows}` — and the template `v-for`s over that, so
+each derivation has exactly one call site structurally rather than being
+deduplicated by a cache. Derivation happens only for the card's own display
+mode, so a count card doesn't pay to copy and sort rows nothing renders.
 
-The template call sites stay as they are; they just read a memoized value.
+**Not** a `computed` Map keyed by `cardKey(card)`, which is where this started.
+`cardKey` covers `[title, query, display]` — correct for `cardData`, where two
+cards with one query legitimately share a fetch, but insufficient for derived
+data, because `group_by` / `sort` / `limit` change the derivation without
+changing the key. That version rendered a "by status" card's tile using a "by
+priority" card's breakdown: the same one-card's-data-on-another's-tile bug
+`cardKey` exists to prevent, one layer up. See RR-DBKEY1.
 
 ## Sequencing
 

--- a/tickets/entities/tickets/TKT-T0DK37.md
+++ b/tickets/entities/tickets/TKT-T0DK37.md
@@ -1,0 +1,48 @@
+---
+id: TKT-T0DK37
+type: ticket
+title: Bound the structured search path the way free-text already is
+kind: enhancement
+priority: medium
+effort: s
+status: backlog
+---
+
+## What
+
+`executeQuery` (`internal/dataentry/helpers.go:399`) caps the free-text branch
+at `maxFreeTextSearchResults = 1000` (`helpers.go:637`), but the structured
+branch — `visibleListByTypes`, taken for `type:` / `prop:` queries — has **no
+bound at all**. It appends every entity of every requested type into one slice.
+
+Dashboard cards are all structured queries, so the one existing safety limit
+does not cover the surface that actually loads the most.
+
+## Why separately from the aggregation ticket
+
+This is the cheap backstop, independent of any wire-format change: even after
+count/breakdown cards stop fetching rows (TKT-AIEGHU), `/_search` remains
+reachable directly with an unbounded `type:` query, and list views use the same
+path. Worth having regardless of how the card work lands.
+
+## Sequencing — check before starting
+
+`rela-next-action` commit `c5960f9c` ("perf(dataentry): push equality property
+filters into the store") **rewrites this exact function**, changing
+`visibleListByTypes`' signature to take `[]store.PropPredicate` and splitting
+out `visibleEntitiesOfType`. That materially reduces how much this path loads
+for `prop:`-filtered queries — but does not add a cap, so this ticket still
+stands.
+
+Rebase onto that work rather than against current develop. Re-check whether it
+has merged first.
+
+Related: `rela-query-paging` (TKT-JU3S5N) may supply the bounding primitive.
+
+## Acceptance
+
+- A structured `type:` query cannot materialize an unbounded slice.
+- The bound is shared with / consistent with `maxFreeTextSearchResults` rather
+than a second independent constant.
+- Truncation is visible to the caller (not a silent drop) — mirror whatever the
+free-text path reports.

--- a/tickets/relations/FEAT-BSPT7O--requires--data-entry-ui.md
+++ b/tickets/relations/FEAT-BSPT7O--requires--data-entry-ui.md
@@ -1,0 +1,5 @@
+---
+from: FEAT-BSPT7O
+relation: requires
+to: data-entry-ui
+---

--- a/tickets/relations/TKT-8AUD1U--affects--data-entry-server.md
+++ b/tickets/relations/TKT-8AUD1U--affects--data-entry-server.md
@@ -1,0 +1,5 @@
+---
+from: TKT-8AUD1U
+relation: affects
+to: data-entry-server
+---

--- a/tickets/relations/TKT-8AUD1U--implements--FEAT-BSPT7O.md
+++ b/tickets/relations/TKT-8AUD1U--implements--FEAT-BSPT7O.md
@@ -1,0 +1,5 @@
+---
+from: TKT-8AUD1U
+relation: implements
+to: FEAT-BSPT7O
+---

--- a/tickets/relations/TKT-AIEGHU--affects--data-entry-server.md
+++ b/tickets/relations/TKT-AIEGHU--affects--data-entry-server.md
@@ -1,0 +1,5 @@
+---
+from: TKT-AIEGHU
+relation: affects
+to: data-entry-server
+---

--- a/tickets/relations/TKT-AIEGHU--affects--data-entry-ui.md
+++ b/tickets/relations/TKT-AIEGHU--affects--data-entry-ui.md
@@ -1,0 +1,5 @@
+---
+from: TKT-AIEGHU
+relation: affects
+to: data-entry-ui
+---

--- a/tickets/relations/TKT-AIEGHU--implements--FEAT-BSPT7O.md
+++ b/tickets/relations/TKT-AIEGHU--implements--FEAT-BSPT7O.md
@@ -1,0 +1,5 @@
+---
+from: TKT-AIEGHU
+relation: implements
+to: FEAT-BSPT7O
+---

--- a/tickets/relations/TKT-ERHWL0--affects--data-entry-ui.md
+++ b/tickets/relations/TKT-ERHWL0--affects--data-entry-ui.md
@@ -1,0 +1,5 @@
+---
+from: TKT-ERHWL0
+relation: affects
+to: data-entry-ui
+---

--- a/tickets/relations/TKT-ERHWL0--has-implementation--IMPL-ERHWL0.md
+++ b/tickets/relations/TKT-ERHWL0--has-implementation--IMPL-ERHWL0.md
@@ -1,0 +1,5 @@
+---
+from: TKT-ERHWL0
+relation: has-implementation
+to: IMPL-ERHWL0
+---

--- a/tickets/relations/TKT-ERHWL0--has-planning--PLAN-ERHWL0.md
+++ b/tickets/relations/TKT-ERHWL0--has-planning--PLAN-ERHWL0.md
@@ -1,0 +1,5 @@
+---
+from: TKT-ERHWL0
+relation: has-planning
+to: PLAN-ERHWL0
+---

--- a/tickets/relations/TKT-ERHWL0--has-review--REV-ERHWL0.md
+++ b/tickets/relations/TKT-ERHWL0--has-review--REV-ERHWL0.md
@@ -1,0 +1,5 @@
+---
+from: TKT-ERHWL0
+relation: has-review
+to: REV-ERHWL0
+---

--- a/tickets/relations/TKT-ERHWL0--has-review-response--RR-DBEAGER3.md
+++ b/tickets/relations/TKT-ERHWL0--has-review-response--RR-DBEAGER3.md
@@ -1,0 +1,5 @@
+---
+from: TKT-ERHWL0
+relation: has-review-response
+to: RR-DBEAGER3
+---

--- a/tickets/relations/TKT-ERHWL0--has-review-response--RR-DBKEY1.md
+++ b/tickets/relations/TKT-ERHWL0--has-review-response--RR-DBKEY1.md
@@ -1,0 +1,5 @@
+---
+from: TKT-ERHWL0
+relation: has-review-response
+to: RR-DBKEY1
+---

--- a/tickets/relations/TKT-ERHWL0--has-review-response--RR-DBTEST2.md
+++ b/tickets/relations/TKT-ERHWL0--has-review-response--RR-DBTEST2.md
@@ -1,0 +1,5 @@
+---
+from: TKT-ERHWL0
+relation: has-review-response
+to: RR-DBTEST2
+---

--- a/tickets/relations/TKT-ERHWL0--implements--FEAT-BSPT7O.md
+++ b/tickets/relations/TKT-ERHWL0--implements--FEAT-BSPT7O.md
@@ -1,0 +1,5 @@
+---
+from: TKT-ERHWL0
+relation: implements
+to: FEAT-BSPT7O
+---

--- a/tickets/relations/TKT-T0DK37--affects--data-entry-server.md
+++ b/tickets/relations/TKT-T0DK37--affects--data-entry-server.md
@@ -1,0 +1,5 @@
+---
+from: TKT-T0DK37
+relation: affects
+to: data-entry-server
+---

--- a/tickets/relations/TKT-T0DK37--implements--FEAT-BSPT7O.md
+++ b/tickets/relations/TKT-T0DK37--implements--FEAT-BSPT7O.md
@@ -1,0 +1,5 @@
+---
+from: TKT-T0DK37
+relation: implements
+to: FEAT-BSPT7O
+---


### PR DESCRIPTION
Dashboard card derivations ran twice per render. `getBreakdown` / `getTableRows` were plain functions called from two template sites each — `v-if="…length"` then `v-for` — so every render did two full passes over each card's result set: an O(N) group-by, and a copy plus an O(N log N) `localeCompare` sort, to display at most `card.limit` rows.

This derives each card's display data once, into the view model the template iterates.

## Why a view model rather than a memo keyed by `cardKey`

That was the first implementation, and it was wrong. `cardKey()` covers `[title, query, display]`, which is correct for `cardData` — two cards with the same query legitimately share one fetch — but insufficient for *derived* data, because `group_by` / `sort` / `limit` change the derivation without changing the key. Two breakdown cards over one query collided:

```
        tile0            tile1
OLD     "todo1"          "high1"     correct
MEMO    "high1"          "high1"     tile0 renders tile1's breakdown
```

That is exactly the one-card's-data-on-another's-tile bug `cardKey` was introduced for (TKT-53KICM), reintroduced one layer up — and silent, since the user just sees a plausible chart of the wrong dimension. "Tickets by status" beside "Tickets by priority" is an ordinary config.

`cardViews` gives each card its own entry by position, so no shared key exists to collide with. `cardKey` still keys `cardData` (where sharing is correct) and the `v-for`. The godoc says why the two must not be merged.

Deriving per display mode also stops a count card copying and sorting a result set nothing renders — measured at ~28ms for 20 count cards over 5000 rows.

## Review

The cranky reviewer caught the collision as **critical**; I reproduced it independently before acting, and confirmed it was a regression (the pre-change code passes the same scenario). It also caught that my table-rows test asserted only sort order — which the *old* code satisfied too, so it pinned nothing this PR changed. Now instrumented with read-counting.

RR-DBKEY1 (critical), RR-DBTEST2, RR-DBEAGER3 — all addressed. Three suggestions declined with reasons in REV-ERHWL0.

**Every guard was mutation-tested** — each broken individually and confirmed to fail:

| Guard | Broken by | Fails at |
|---|---|---|
| breakdown derived once | template calls twice | 9 reads vs 3 |
| rows derived once | template calls twice | 21 reads vs <15 |
| no cross-card collision | key derivations by `cardKey` | tile0 shows tile1's data |
| count card derives nothing | drop display guards | 3 reads vs 0 |

## Verification

1674 frontend tests / 106 files · `vue-tsc` clean · `npm run build` clean · `npm run lint` 0 errors (none in changed files) · `just lint` 0 issues · `just test` no failures · arch-lint · plimsoll · coverage 77.7% (Go untouched — frontend-only change, run to prove no regression).

Rebased onto develop after the Pinia 3→4 major bump and re-verified, including re-running the mutation tests.

## Scope

This is 1 of 4 under FEAT-BSPT7O (dashboard scales with graph size), and deliberately the only one that touches no wire format. The dashboard still transfers 4.1MB of JSON at 8000 entities to render seven numbers — that is TKT-AIEGHU (server-side aggregation), TKT-8AUD1U (limit/sort pushdown) and TKT-T0DK37 (bound the structured search path), each of which overlaps work in flight elsewhere.

Closes TKT-ERHWL0

---

Note: `rela validate --project tickets` currently reports 10 errors on develop (TKT-UIR41P missing has-docs/has-review, three open RR-*, three bugs missing has-review). All pre-existing — identical count on a clean develop worktree — and none from this branch's entities.
