### PR TITLE
fix(ci): run composition-root wiring tests under -tags postgres

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -437,12 +437,6 @@ jobs:
         with:
           go-version: '1.26.6'
 
-      # internal/cli renders documents through internal/cmdexec, which FAILS
-      # CLOSED without a sandbox — so the wiring-test step below needs
-      # bubblewrap for the same reason the `test` and `e2e` jobs do.
-      - name: Install bubblewrap (command sandbox)
-        run: sudo apt-get update && sudo apt-get install -y bubblewrap
-
       # Trust auth: no password in the DSN. The DB is ephemeral and
       # runner-local, so there is no credential to keep out of the log.
       - name: Configure test database URL
@@ -512,8 +506,21 @@ jobs:
       # legitimately need no database. RELA_TEST_DATABASE_REQUIRED (job env)
       # still turns a MISSING DSN into a hard failure, which is the regression
       # that actually matters.
+      #
+      # internal/cli is scoped to its wiring tests rather than run whole. The
+      # package also holds render tests that shell out through internal/cmdexec,
+      # which fails closed without a working sandbox — and bubblewrap cannot set
+      # up its loopback device on this job's runner ("RTM_NEWADDR: Operation not
+      # permitted"), even with the package installed, unlike the `test` job.
+      # Those tests are backend-independent and already covered there; running
+      # them here would gate the postgres wiring on an unrelated sandbox
+      # capability. The `test` job remains the owner of full-package coverage.
       - name: Run composition-root wiring tests against PostgreSQL
-        run: go test -race -tags postgres ./internal/appbuild/... ./internal/cli/...
+        run: |
+          set -euo pipefail
+          go test -race -tags postgres ./internal/appbuild/...
+          go test -race -tags postgres -run 'TestNewMCPServices|TestMCPServices|TestMCPWatcher' \
+            ./internal/cli/
 
   # Cross-compile every (GOOS, build-tag) combination GoReleaser ships so a
   # platform-specific compile break (e.g. a unix-only syscall used without a

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -437,6 +437,12 @@ jobs:
         with:
           go-version: '1.26.6'
 
+      # internal/cli renders documents through internal/cmdexec, which FAILS
+      # CLOSED without a sandbox — so the wiring-test step below needs
+      # bubblewrap for the same reason the `test` and `e2e` jobs do.
+      - name: Install bubblewrap (command sandbox)
+        run: sudo apt-get update && sudo apt-get install -y bubblewrap
+
       # Trust auth: no password in the DSN. The DB is ephemeral and
       # runner-local, so there is no credential to keep out of the log.
       - name: Configure test database URL

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -489,6 +489,26 @@ jobs:
           fi
           echo "OK: pgstore suite ran against PostgreSQL with no skips."
 
+      # The step above covers the STORE under -tags postgres. Nothing covered
+      # the WIRING: `internal/appbuild` and `internal/cli` were compiled with
+      # the tag but never run with it, so every build-agnostic composition-root
+      # test in them (Services fully populated, Close idempotent, acl.yaml
+      # loaded, corrupt CalDAV cache non-fatal) silently regressed on the
+      # postgres build and stayed invisible until someone ran the tagged suite
+      # by hand.
+      #
+      # These are not backend tests — they assert wiring that must hold on
+      # every backend — so they run against the same database rather than
+      # being excluded. backendtest gives each one a private migrated schema.
+      #
+      # Skips are tolerated here, unlike the pgstore step: a few cases
+      # deliberately assert boot failures that occur before any store opens and
+      # legitimately need no database. RELA_TEST_DATABASE_REQUIRED (job env)
+      # still turns a MISSING DSN into a hard failure, which is the regression
+      # that actually matters.
+      - name: Run composition-root wiring tests against PostgreSQL
+        run: go test -race -tags postgres ./internal/appbuild/... ./internal/cli/...
+
   # Cross-compile every (GOOS, build-tag) combination GoReleaser ships so a
   # platform-specific compile break (e.g. a unix-only syscall used without a
   # build-tagged fallback) fails here at PR time instead of silently at

--- a/.go-arch-lint.yml
+++ b/.go-arch-lint.yml
@@ -47,6 +47,7 @@ components:
   app:              { in: internal/app }
   appbuild:         { in: internal/appbuild }
   appbuildtest:     { in: internal/appbuild/appbuildtest }
+  backendtest:      { in: internal/appbuild/backendtest }
 
   # Domain services
   analysis:         { in: internal/analysis }
@@ -466,6 +467,14 @@ deps:
       - tracer
       - validator
       - visibility
+  # backendtest supplies each build's test backend. The pgx dependency is
+  # confined to its postgres-tagged file, which the default build does not
+  # compile — the same arrangement pgstore uses.
+  backendtest:
+    mayDependOn:
+      - appbuild
+    canUse:
+      - pgx
   appbuildtest:
     mayDependOn:
       - acl

--- a/.testcoverage.yml
+++ b/.testcoverage.yml
@@ -76,6 +76,7 @@ exclude:
     - ^internal/visibility/visibilitytest # shared conformance test kit (exercised via visibility + future wirings)
     - ^internal/state/statetest # shared conformance test kit (exercised via FSKV + pgstore's StateKV)
     - ^internal/userstate/userstatetest # shared conformance test kit (exercised via mem/kv/pgstore backends)
+    - ^internal/appbuild/backendtest # build-tagged test backend supplier; the postgres half only compiles under -tags postgres
     - ^internal/store/pgstore  # covered by the dedicated postgres CI job (needs a live DB; skipped without RELA_TEST_DATABASE_URL)
     - ^internal/entitymanager/entitymanagertest # shared test doubles (PanicOnUse etc.), exercised via consumers
     - ^internal/store/graphquerynaive # exercised through every backend's graphquery tests; cross-package coverage isn't attributed without -coverpkg, so its own number reads 0

--- a/internal/appbuild/appbuild_acl_test.go
+++ b/internal/appbuild/appbuild_acl_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/Sourcehaven-BV/rela/internal/acl"
 	"github.com/Sourcehaven-BV/rela/internal/app"
 	"github.com/Sourcehaven-BV/rela/internal/appbuild"
+	"github.com/Sourcehaven-BV/rela/internal/appbuild/backendtest"
 	"github.com/Sourcehaven-BV/rela/internal/audit"
 	"github.com/Sourcehaven-BV/rela/internal/project"
 	"github.com/Sourcehaven-BV/rela/internal/script"
@@ -110,7 +111,7 @@ func TestDiscover_MalformedACL_FailsBoot(t *testing.T) {
 	writeMetamodel(t, root)
 	writePolicy(t, root, "roles:\n  admin:\n    create: [not-closed\n")
 
-	svc, err := appbuildOnDisk(t, root)
+	svc, err := appbuildOnDiskNoBackend(t, root)
 	if err == nil {
 		svc.Close()
 		t.Fatalf("appbuild.New: expected error on malformed acl.yaml, got nil")
@@ -161,7 +162,7 @@ func TestDiscover_PrincipalPropertyUnknown_FailsBoot(t *testing.T) {
 	writeMetamodelBody(t, root, principalPropertyMetamodel)
 	writePolicy(t, root, "user_entity_type: persoon\nprincipal_property: ghost\n")
 
-	svc, err := appbuildOnDisk(t, root)
+	svc, err := appbuildOnDiskNoBackend(t, root)
 	if err == nil {
 		svc.Close()
 		t.Fatalf("expected boot to fail on unknown principal_property, got nil")
@@ -218,12 +219,44 @@ func writePolicy(t *testing.T, root, body string) {
 // appbuildOnDisk builds a Services bundle from a real on-disk project
 // rooted at root. Uses appbuild.New directly so we can supply our own
 // audit sink without disturbing the test filesystem.
+//
+// The backend comes from backendtest, so on the postgres build this needs — and
+// waits for — a database. Use [appbuildOnDiskNoBackend] for a case that asserts
+// boot FAILS before any store is opened; it must not be gated on a database it
+// never reaches.
 func appbuildOnDisk(t *testing.T, root string) (*appbuild.Services, error) {
 	t.Helper()
 	return appbuildOnDiskWithOpts(t, root)
 }
 
 func appbuildOnDiskWithOpts(t *testing.T, root string, opts ...appbuild.Option) (*appbuild.Services, error) {
+	t.Helper()
+	// backendtest.DSN supplies whatever the current build needs to reach a store
+	// — "" on fs/memory, a private migrated schema on postgres. These are
+	// ACL-wiring assertions, not backend assertions, so they must not hard-code
+	// one.
+	//
+	// DSN rather than Options because this path calls appbuild.New, which reads
+	// Config.DatabaseURL and ignores WithDatabaseURL by design.
+	return newOnDisk(t, backendtest.DSN(t), root, opts...)
+}
+
+// appbuildOnDiskNoBackend builds without asking backendtest for a backend.
+//
+// The config-validation gates (malformed acl.yaml, an unknown
+// principal_property) reject the project BEFORE the recipe opens a store, so
+// they assert the same thing on every build with no database present. Routing
+// them through appbuildOnDisk would turn genuine coverage into a skip whenever
+// the postgres build runs without a server — the tests would still be green,
+// but they would no longer be checking anything.
+func appbuildOnDiskNoBackend(t *testing.T, root string) (*appbuild.Services, error) {
+	t.Helper()
+	return newOnDisk(t, "", root)
+}
+
+// newOnDisk builds a Services over the project at root. dsn is empty on the
+// fs/memory builds, where the recipe ignores Config.DatabaseURL entirely.
+func newOnDisk(t *testing.T, dsn, root string, opts ...appbuild.Option) (*appbuild.Services, error) {
 	t.Helper()
 	fs := storage.NewSafeFS(storage.NewOsFS())
 	paths, err := project.Discover(root, fs)
@@ -238,5 +271,6 @@ func appbuildOnDiskWithOpts(t *testing.T, root string, opts ...appbuild.Option) 
 		Paths:        paths,
 		ScriptEngine: script.NewEngine(),
 		Audit:        audit.Nop{},
+		DatabaseURL:  dsn,
 	}, opts...)
 }

--- a/internal/appbuild/appbuild_test.go
+++ b/internal/appbuild/appbuild_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/Sourcehaven-BV/rela/internal/appbuild"
+	"github.com/Sourcehaven-BV/rela/internal/appbuild/backendtest"
 	"github.com/Sourcehaven-BV/rela/internal/audit"
 	"github.com/Sourcehaven-BV/rela/internal/script"
 )
@@ -51,11 +52,35 @@ func writeMinimalProject(t *testing.T) string {
 	return root
 }
 
+// discover is appbuild.Discover with whatever the current build needs to reach
+// a store. The tests below assert build-agnostic composition-root behavior, so
+// they must not hard-code a backend; on the postgres build backendtest supplies
+// a private migrated schema (and skips when no database is configured).
+func discover(t *testing.T, root string) (*appbuild.Services, error) {
+	t.Helper()
+	return appbuild.Discover(root, script.NewEngine(), backendtest.Options(t)...)
+}
+
+// discoverer returns a discover func pinned to ONE backend, for a test that
+// builds twice over the same project and needs the second build to observe what
+// the first wrote.
+//
+// Calling discover twice would not do that on postgres: backendtest hands out a
+// fresh schema per call, so the second build would come up empty and the test
+// would assert against state it never planted.
+func discoverer(t *testing.T) func(string) (*appbuild.Services, error) {
+	t.Helper()
+	backend := backendtest.Options(t)
+	return func(root string) (*appbuild.Services, error) {
+		return appbuild.Discover(root, script.NewEngine(), backend...)
+	}
+}
+
 // TestDiscover_BuildsAllServices verifies that appbuild.Discover
 // returns a Services with every field populated.
 func TestDiscover_BuildsAllServices(t *testing.T) {
 	root := writeMinimalProject(t)
-	svc, err := appbuild.Discover(root, script.NewEngine())
+	svc, err := discover(t, root)
 	if err != nil {
 		t.Fatalf("Discover: %v", err)
 	}
@@ -100,7 +125,7 @@ func TestDiscover_BuildsAllServices(t *testing.T) {
 // produce non-empty bundles from the focused services.
 func TestDiscover_LuaDepsDerivable(t *testing.T) {
 	root := writeMinimalProject(t)
-	svc, err := appbuild.Discover(root, script.NewEngine())
+	svc, err := discover(t, root)
 	if err != nil {
 		t.Fatalf("Discover: %v", err)
 	}
@@ -142,7 +167,7 @@ func TestDiscover_MissingProject(t *testing.T) {
 // invocations are no-ops.
 func TestClose_Idempotent(t *testing.T) {
 	root := writeMinimalProject(t)
-	svc, err := appbuild.Discover(root, script.NewEngine())
+	svc, err := discover(t, root)
 	if err != nil {
 		t.Fatalf("Discover: %v", err)
 	}
@@ -161,7 +186,7 @@ func TestClose_Idempotent(t *testing.T) {
 // TestNew_RejectsNilDeps pins the constructor's nil-rejection.
 func TestNew_RejectsNilDeps(t *testing.T) {
 	root := writeMinimalProject(t)
-	svc, err := appbuild.Discover(root, script.NewEngine())
+	svc, err := discover(t, root)
 	if err != nil {
 		t.Fatalf("seed: %v", err)
 	}
@@ -219,21 +244,36 @@ func TestNew_RejectsNilDeps(t *testing.T) {
 // to mount without a healthy table, so a synced client cannot re-create its
 // entries as new entities. The failure just lands on the path that can actually
 // cause that damage.
+// The table is corrupted through the state.KV rather than by writing the file
+// directly. Where it LIVES is backend-specific — a file under .rela/caldav/ on
+// the fs build, a state_kv row on postgres (TKT-VC27L3) — but the key is the
+// same on both, so going through the KV asserts the degrade-don't-die behavior
+// on whichever backend is compiled in. Writing the file instead made this a
+// filesystem test wearing a wiring test's name: under -tags postgres it
+// corrupted a file nothing reads, the alias table loaded clean, and the
+// assertion failed.
 func TestCorruptAliasTableDoesNotBrickTheBinary(t *testing.T) {
 	root := writeMinimalProject(t)
+	build := discoverer(t) // both builds must share one backend
 
-	cacheDir := filepath.Join(root, ".rela", "caldav")
-	if err := os.MkdirAll(cacheDir, 0o750); err != nil {
-		t.Fatalf("mkdir: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(cacheDir, "aliases.json"),
-		[]byte("this is not json"), 0o600); err != nil {
-		t.Fatalf("write corrupt table: %v", err)
-	}
-
-	svc, err := appbuild.Discover(root, script.NewEngine())
+	// First build: obtain the state store this project resolves to, and plant
+	// the corrupt table in it.
+	seed, err := build(root)
 	if err != nil {
-		t.Fatalf("a corrupt CalDAV cache file must not fail project build: %v", err)
+		t.Fatalf("seed build: %v", err)
+	}
+	const aliasKey = "caldav/aliases.json" // caldavalias.stateKey
+	if err = seed.State().Put(t.Context(), aliasKey, []byte("this is not json")); err != nil {
+		t.Fatalf("plant corrupt table: %v", err)
+	}
+	if err = seed.Close(); err != nil {
+		t.Fatalf("close seed: %v", err)
+	}
+
+	// Second build over the same project now reads the corrupt table.
+	svc, err := build(root)
+	if err != nil {
+		t.Fatalf("a corrupt CalDAV alias table must not fail project build: %v", err)
 	}
 	t.Cleanup(func() { _ = svc.Close() })
 

--- a/internal/appbuild/backendtest/backendtest.go
+++ b/internal/appbuild/backendtest/backendtest.go
@@ -1,0 +1,90 @@
+// Package backendtest supplies the backend a build-agnostic wiring test needs.
+//
+// Tests in `internal/appbuild` and `internal/cli` assert properties of the
+// composition root that hold for EVERY backend: that Services comes back with
+// every field populated, that Close is idempotent, that acl.yaml loads into a
+// Declarative, that a corrupt CalDAV cache does not brick boot. None of them
+// care which store is underneath — they call New/Discover because that is the
+// wiring entry point, not because they are testing a store.
+//
+// On the default and memorybackend builds that is free: the recipe opens an
+// fsstore or memstore from the project directory the test just wrote. The
+// postgres recipe cannot — it requires a DSN and a reachable server, so every
+// one of those tests failed under `-tags postgres` with "postgres build
+// requires a database URL". The assertions were fine; they simply had no
+// backend to make.
+//
+// This package is the seam. [Options] returns whatever the current build needs
+// to reach a usable store: nothing at all for fs/memory, and for postgres a
+// DSN pointing at a freshly-created, migrated, per-test schema. A test calls it
+// and stays backend-agnostic.
+//
+// # Skip policy
+//
+// When the postgres build has no database the tests SKIP rather than fail. That
+// is a deliberate trade with a known cost: a developer running
+// `go test -tags postgres ./...` without a server gets a clean run, but a skip
+// and a pass are indistinguishable in exit codes and CI summaries
+// (RR-0EWZQW — the pgstore suite has the same shape and the same hazard).
+//
+// The mitigation is identical to pgstore's, and reuses its variable rather than
+// inventing a second one: when RELA_TEST_DATABASE_REQUIRED is set, a missing
+// DSN is a hard failure instead of a skip. CI's Postgres Backend job sets it,
+// so the gate cannot silently disarm there — which is the environment whose job
+// is to prove the postgres backend works.
+package backendtest
+
+import (
+	"os"
+	"strings"
+)
+
+// testDBEnv names the DSN the postgres build's wiring tests connect with. It is
+// deliberately the SAME variable the pgstore suite uses: one database, one
+// setup step, one thing to configure.
+const testDBEnv = "RELA_TEST_DATABASE_URL"
+
+// requireDBEnv turns the skip below into a failure. See the package doc; the
+// semantics mirror internal/store/pgstore's requireDBEnv exactly, because an
+// environment that promises a database should get the same strictness from
+// every suite that needs one.
+const requireDBEnv = "RELA_TEST_DATABASE_REQUIRED"
+
+// TB is the subset of *testing.T the helpers use. Taking an interface rather
+// than *testing.T keeps this package free of a testing import in its signature
+// and lets a caller pass a *testing.B or a wrapper.
+type TB interface {
+	Helper()
+	Skipf(format string, args ...any)
+	Fatalf(format string, args ...any)
+	Cleanup(func())
+}
+
+// dsnRequired reports whether an absent DSN must fail rather than skip.
+// A variable set to "" / "0" / "false" does not opt in, so a shell that exports
+// it empty behaves like an unset one instead of hard-failing every suite.
+func dsnRequired(getenv func(string) string) bool {
+	v := getenv(requireDBEnv)
+	return v != "" && v != "0" && !strings.EqualFold(v, "false")
+}
+
+// missingDSN raises the right signal for an absent DSN: a hard failure when the
+// environment promised a database, a skip otherwise.
+func missingDSN(tb TB, getenv func(string) string) {
+	tb.Helper()
+	if dsnRequired(getenv) {
+		tb.Fatalf(
+			"%s is set, so the %s wiring tests must run, but %s is empty.\n"+
+				"These tests assert composition-root behavior on the postgres build; "+
+				"skipping them silently would let a postgres-only wiring regression merge.\n"+
+				"Set %s to a reachable PostgreSQL DSN, or unset %s to allow skipping.",
+			requireDBEnv, buildName, testDBEnv, testDBEnv, requireDBEnv)
+		return
+	}
+	tb.Skipf("%s not set; skipping %s wiring tests", testDBEnv, buildName)
+}
+
+// Getenv is the environment accessor the helpers read through. It exists so the
+// resolution rules above are testable without mutating process state — the same
+// discipline appbuild.resolveDatabaseURL uses.
+var Getenv = os.Getenv

--- a/internal/appbuild/backendtest/backendtest_internal_test.go
+++ b/internal/appbuild/backendtest/backendtest_internal_test.go
@@ -1,0 +1,98 @@
+package backendtest
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// The skip-vs-fail decision is the whole safety property of this package: get it
+// wrong in the permissive direction and CI's Postgres job silently stops testing
+// anything (RR-0EWZQW). It is asserted directly, with getenv injected, because
+// an end-to-end assertion cannot distinguish "gate worked" from "no database
+// configured" — the two look identical from outside.
+func TestDSNRequired(t *testing.T) {
+	env := func(v string) func(string) string {
+		return func(key string) string {
+			if key != requireDBEnv {
+				return ""
+			}
+			return v
+		}
+	}
+
+	for _, tc := range []struct {
+		name string
+		val  string
+		want bool
+	}{
+		{"unset does not require", "", false},
+		// A shell that exports the variable empty or explicitly off must behave
+		// like an unset one, or every developer inheriting it hard-fails.
+		{"zero does not require", "0", false},
+		{"false does not require", "false", false},
+		{"FALSE does not require", "FALSE", false},
+		{"one requires", "1", true},
+		{"true requires", "true", true},
+		// Anything else is opt-in: the variable exists to be strict, so an
+		// unrecognized value must not silently fall back to permissive.
+		{"arbitrary value requires", "yes", true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := dsnRequired(env(tc.val)); got != tc.want {
+				t.Errorf("dsnRequired(%q) = %v, want %v", tc.val, got, tc.want)
+			}
+		})
+	}
+}
+
+// recorder captures which of Skipf/Fatalf missingDSN chose, so the branch is
+// observable without actually skipping or failing the running test.
+type recorder struct {
+	skipped bool
+	failed  bool
+	msg     string
+}
+
+func (r *recorder) Helper()        {}
+func (r *recorder) Cleanup(func()) {}
+func (r *recorder) Skipf(f string, a ...any) {
+	r.skipped = true
+	r.msg = fmt.Sprintf(f, a...)
+}
+func (r *recorder) Fatalf(f string, a ...any) {
+	r.failed = true
+	r.msg = fmt.Sprintf(f, a...)
+}
+
+func TestMissingDSN_SkipsOrFails(t *testing.T) {
+	t.Run("skips when not required", func(t *testing.T) {
+		r := &recorder{}
+		missingDSN(r, func(string) string { return "" })
+		if !r.skipped || r.failed {
+			t.Errorf("want skip, got skipped=%v failed=%v", r.skipped, r.failed)
+		}
+		if !strings.Contains(r.msg, testDBEnv) {
+			t.Errorf("skip message must name %s so the reason is actionable; got %q", testDBEnv, r.msg)
+		}
+	})
+
+	t.Run("fails when required", func(t *testing.T) {
+		r := &recorder{}
+		missingDSN(r, func(key string) string {
+			if key == requireDBEnv {
+				return "1"
+			}
+			return ""
+		})
+		if !r.failed || r.skipped {
+			t.Errorf("want fail, got skipped=%v failed=%v", r.skipped, r.failed)
+		}
+		// The operator has to know which variable to set and which to unset.
+		for _, want := range []string{testDBEnv, requireDBEnv} {
+			if !strings.Contains(r.msg, want) {
+				t.Errorf("failure message must name %s; got %q", want, r.msg)
+			}
+		}
+	})
+}

--- a/internal/appbuild/backendtest/backendtest_local.go
+++ b/internal/appbuild/backendtest/backendtest_local.go
@@ -1,0 +1,20 @@
+//go:build !postgres
+
+package backendtest
+
+import "github.com/Sourcehaven-BV/rela/internal/appbuild"
+
+// buildName labels this build in skip and failure messages.
+const buildName = "filesystem/memory"
+
+// Options returns no options: the fs and memory recipes open a store from the
+// project directory the test already wrote, so there is nothing to supply and
+// nothing that can be unavailable. These builds never skip.
+func Options(_ TB) []appbuild.Option { return nil }
+
+// Env returns no environment overrides, for the same reason.
+func Env(_ TB) map[string]string { return nil }
+
+// DSN returns "": these builds have no database, and Config.DatabaseURL is
+// ignored by their recipes.
+func DSN(_ TB) string { return "" }

--- a/internal/appbuild/backendtest/backendtest_postgres.go
+++ b/internal/appbuild/backendtest/backendtest_postgres.go
@@ -1,0 +1,161 @@
+//go:build postgres
+
+package backendtest
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"sync"
+	"sync/atomic"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/Sourcehaven-BV/rela/internal/appbuild"
+)
+
+// buildName labels this build in skip and failure messages.
+const buildName = "postgres"
+
+var (
+	adminPoolOnce sync.Once
+	adminPool     *pgxpool.Pool
+	errAdminPool  error
+	schemaCounter atomic.Int64
+)
+
+// Options returns a DSN option pointing at a private, migrated schema created
+// for this test and dropped when it finishes. Skips (or fails — see the package
+// doc) when no database is configured.
+//
+// Isolation is per-schema, matching the pgstore suite: the store opens its own
+// transactions and emits watcher events after commit, so a wrapping rollback
+// would break both. A fresh schema also keeps rela_seq per-test and lets
+// subtests run in parallel.
+//
+// Migrations are NOT run here. appbuild's postgres recipe opens the store via
+// pgstore.Open, which migrates on first open — so letting it do that is both
+// less duplication and a slightly wider test: it exercises the auto-migrate
+// path the real binary takes on a fresh database.
+func Options(tb TB) []appbuild.Option {
+	tb.Helper()
+	dsn := scopedDSN(tb)
+	if dsn == "" {
+		return nil // unreachable: scopedDSN skips or fails first.
+	}
+	return []appbuild.Option{appbuild.WithDatabaseURL(dsn)}
+}
+
+// Env returns the environment a test must set for a code path that reads the
+// DSN from the process environment rather than accepting an option —
+// appbuild.Discover, and therefore cli.newMCPServices. The caller applies it
+// with t.Setenv so it is undone automatically.
+func Env(tb TB) map[string]string {
+	tb.Helper()
+	dsn := scopedDSN(tb)
+	if dsn == "" {
+		return nil // unreachable: scopedDSN skips or fails first.
+	}
+	return map[string]string{"RELA_DATABASE_URL": dsn}
+}
+
+// DSN returns a connection string for a private, migrated schema, for a test
+// that builds an appbuild.Config by hand.
+//
+// appbuild.New deliberately reads the DSN from Config.DatabaseURL and ignores
+// WithDatabaseURL — a caller assembling a Config has already decided where the
+// data lives — so [Options] is inert on that path and the field must be set
+// directly. Returns "" on the fs/memory builds, where Config.DatabaseURL is
+// unused.
+func DSN(tb TB) string {
+	tb.Helper()
+	return scopedDSN(tb)
+}
+
+// scopedDSN creates the per-test schema and returns a DSN pinned to it.
+func scopedDSN(tb TB) string {
+	tb.Helper()
+	base := Getenv(testDBEnv)
+	if base == "" {
+		missingDSN(tb, Getenv)
+		return ""
+	}
+
+	admin := adminConn(tb, base)
+	if admin == nil {
+		return ""
+	}
+
+	ctx := context.Background()
+	schema := fmt.Sprintf("relawiring_%d_%d", os.Getpid(), schemaCounter.Add(1))
+	if _, err := admin.Exec(ctx, "CREATE SCHEMA "+quoteIdent(schema)); err != nil {
+		tb.Fatalf("create schema %s: %v", schema, err)
+		return ""
+	}
+	tb.Cleanup(func() {
+		_, _ = admin.Exec(context.Background(), "DROP SCHEMA "+quoteIdent(schema)+" CASCADE")
+	})
+
+	dsn, err := dsnWithSearchPath(base, schema)
+	if err != nil {
+		tb.Fatalf("build scoped DSN: %v", err)
+		return ""
+	}
+	return dsn
+}
+
+// adminConn returns a process-wide pool on the default search_path, used only
+// to CREATE and DROP the per-test schemas.
+func adminConn(tb TB, dsn string) *pgxpool.Pool {
+	tb.Helper()
+	adminPoolOnce.Do(func() {
+		adminPool, errAdminPool = pgxpool.New(context.Background(), dsn)
+	})
+	if errAdminPool != nil {
+		tb.Fatalf("connect to %s: %v", testDBEnv, errAdminPool)
+		return nil
+	}
+	return adminPool
+}
+
+// dsnWithSearchPath pins search_path to the private schema, keeping public on
+// the path for pg_trgm (the search backend's operators live there).
+//
+// The setting is threaded through the DSN rather than a pgxpool.Config because
+// appbuild's recipe takes a DSN string and builds its own pool — the seam that
+// exists so appbuild owns the pool's lifecycle.
+//
+// Built by re-serializing the parsed config rather than appending "?search_path="
+// to the caller's string: pgx accepts both URL and key/value ("host=x dbname=y")
+// DSNs, and query-string surgery silently produces garbage for the latter.
+func dsnWithSearchPath(base, schema string) (string, error) {
+	cfg, err := pgx.ParseConfig(base)
+	if err != nil {
+		return "", fmt.Errorf("parse %s: %w", testDBEnv, err)
+	}
+	kv := []string{
+		"host=" + cfg.Host,
+		fmt.Sprintf("port=%d", cfg.Port),
+		"user=" + cfg.User,
+		"dbname=" + cfg.Database,
+		"search_path=" + schema + ",public",
+	}
+	if cfg.Password != "" {
+		kv = append(kv, "password="+cfg.Password)
+	}
+	// TLSConfig is nil exactly when the DSN disabled it; preserve that, since
+	// the CI container speaks plaintext and would reject a negotiated upgrade.
+	if cfg.TLSConfig == nil {
+		kv = append(kv, "sslmode=disable")
+	}
+	return strings.Join(kv, " "), nil
+}
+
+// quoteIdent renders a generated schema name as a quoted identifier. The names
+// are built from a PID and a counter so they cannot contain a quote; the
+// doubling is belt-and-braces against a future caller-supplied name.
+func quoteIdent(name string) string {
+	return `"` + strings.ReplaceAll(name, `"`, `""`) + `"`
+}

--- a/internal/appbuild/versionsweep_postgres.go
+++ b/internal/appbuild/versionsweep_postgres.go
@@ -61,7 +61,19 @@ func sweepConfigFromEnv() pgstore.SweepConfig {
 		}
 		d, err := time.ParseDuration(v)
 		if err != nil {
-			slog.Warn("appbuild: ignoring invalid sweep duration", "env", env, "value", v, "error", err)
+			// G706 flags v as tainted because its analysis stops at the slog
+			// call and cannot see the handler that encodes the record. The
+			// message is a constant and v travels as a structured ATTRIBUTE,
+			// which slog's handlers quote and escape — so an injected newline
+			// cannot forge a second record. That is the same invariant
+			// internal/dataentry pins in TestSlogTextHandlerEscapesNewlines.
+			//
+			// The value is worth echoing: this is an operator debugging their
+			// own typo'd RELA_VERSION_SWEEP_* setting, and a warning that
+			// withholds the rejected value is much harder to act on.
+			//nolint:gosec // G706: constant message, user data as an escaped attribute
+			slog.Warn("appbuild: ignoring invalid sweep duration",
+				"env", env, "value", v, "error", err)
 			return 0
 		}
 		return d

--- a/internal/cli/mcp_wiring_test.go
+++ b/internal/cli/mcp_wiring_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/Sourcehaven-BV/rela/internal/appbuild/backendtest"
 	"github.com/Sourcehaven-BV/rela/internal/entity"
 	relaerrors "github.com/Sourcehaven-BV/rela/internal/errors"
 	"github.com/Sourcehaven-BV/rela/internal/search"
@@ -40,6 +41,25 @@ relations: {}
 	return root
 }
 
+// mcpServicesForTest is newMCPServices with a backend the current build can
+// actually open.
+//
+// newMCPServices calls appbuild.Discover, which resolves its DSN from the
+// process environment, so unlike the appbuild tests this cannot pass an option
+// — backendtest.Env supplies the variables instead and t.Setenv unwinds them.
+// On fs/memory the map is empty and this is exactly newMCPServices.
+//
+// The tests below assert MCP wiring (deps populated, writes reach the search
+// index, Close is idempotent), none of which is backend-specific; they simply
+// need a store to exist.
+func mcpServicesForTest(t *testing.T, root string) (*mcpServices, error) {
+	t.Helper()
+	for k, v := range backendtest.Env(t) {
+		t.Setenv(k, v)
+	}
+	return newMCPServices(root)
+}
+
 func TestNewMCPServices_NoProject(t *testing.T) {
 	dir := t.TempDir() // empty — no metamodel.yaml
 
@@ -67,7 +87,7 @@ func TestNewMCPServices_BadMetamodel(t *testing.T) {
 func TestNewMCPServices_Succeeds(t *testing.T) {
 	root := seedProject(t)
 
-	svc, err := newMCPServices(root)
+	svc, err := mcpServicesForTest(t, root)
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = svc.Close() })
 
@@ -87,7 +107,7 @@ func TestNewMCPServices_Succeeds(t *testing.T) {
 func TestNewMCPServices_WritesReachSearchIndex(t *testing.T) {
 	root := seedProject(t)
 
-	svc, err := newMCPServices(root)
+	svc, err := mcpServicesForTest(t, root)
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = svc.Close() })
 
@@ -110,7 +130,7 @@ func TestNewMCPServices_WritesReachSearchIndex(t *testing.T) {
 func TestMCPServices_CloseIdempotent(t *testing.T) {
 	root := seedProject(t)
 
-	svc, err := newMCPServices(root)
+	svc, err := mcpServicesForTest(t, root)
 	require.NoError(t, err)
 
 	// First close releases the backend + store.

--- a/internal/dataentry/store_bridge_test.go
+++ b/internal/dataentry/store_bridge_test.go
@@ -18,10 +18,16 @@ const sseWaitTimeout = 5 * time.Second
 
 // waitForEntityChange reads from the broker channel until it finds an
 // entity-change event for the given type, or fails after sseWaitTimeout.
-// entityType varies across callers (incl. the postgres-tagged bridge
-// test, invisible to the default-build linter).
 //
-//nolint:unparam // entityType varies in the postgres-tagged caller
+// entityType looks constant to the default-build linter — every caller in this
+// file passes "ticket" — but the postgres-tagged bridge test passes "feature".
+// Neither `unparam` nor `nolintlint` can see both builds at once: suppressing
+// unparam leaves an "unused directive" under -tags postgres, and dropping the
+// directive fails unparam on the default build. The parameter is genuinely
+// varying, so it is left in place and the suppression is applied to both
+// linters, whichever one the current build actually raises.
+//
+//nolint:unparam,nolintlint // entityType varies in the postgres-tagged caller; see above
 func waitForEntityChange(t *testing.T, ch <-chan sseEvent, entityType string) sseEvent {
 	t.Helper()
 	deadline := time.After(sseWaitTimeout)

--- a/internal/store/pgstore/graphquery_explain_test.go
+++ b/internal/store/pgstore/graphquery_explain_test.go
@@ -26,7 +26,7 @@ import (
 // The assertion is index-positive (the index name appears in the
 // plan) rather than seq-scan-negative — the planner is allowed to
 // pick seq scans for the outer SELECT at small scale when its
-// selectivity estimates favour them. Only the per-iteration CTE
+// selectivity estimates favor them. Only the per-iteration CTE
 // recursion needs to be index-backed; that's where blast radius is
 // non-linear in graph size.
 //
@@ -51,7 +51,7 @@ func TestGraphQueryExplainUsesIndex(t *testing.T) {
 		id := fmt.Sprintf("TKT-%06d", i)
 		require.NoError(t, s.CreateEntity(ctx, entity.New(id, "ticket")))
 		if i%10 == 0 {
-			_, err := s.CreateRelation(ctx, "engineering", "owns", id, nil)
+			_, err = s.CreateRelation(ctx, "engineering", "owns", id, nil)
 			require.NoError(t, err)
 		}
 	}
@@ -76,9 +76,12 @@ func TestGraphQueryExplainUsesIndex(t *testing.T) {
 
 	// The recursive CTE must use the composite index for the
 	// per-iteration rel_type lookup.
-	if !strings.Contains(plan, "Index Scan using relations_type_from_idx") &&
-		!strings.Contains(plan, "Bitmap Index Scan on relations_type_from_idx") {
-		t.Errorf("composite index relations_type_from_idx is not used in the plan; the CTE will degrade per-iteration:\n%s", plan)
+	// Either access method is fine; both are index-backed.
+	indexed := strings.Contains(plan, "Index Scan using relations_type_from_idx") ||
+		strings.Contains(plan, "Bitmap Index Scan on relations_type_from_idx")
+	if !indexed {
+		t.Errorf("composite index relations_type_from_idx is not used in the plan; "+
+			"the CTE will degrade per-iteration:\n%s", plan)
 	}
 }
 

--- a/tickets/entities/automated-measures/AM-postgres-tagged-wiring-tests.md
+++ b/tickets/entities/automated-measures/AM-postgres-tagged-wiring-tests.md
@@ -1,0 +1,32 @@
+---
+id: AM-postgres-tagged-wiring-tests
+type: automated-measure
+title: The Postgres CI job runs the composition-root wiring tests, not just the store
+description: 'The Postgres Backend job gained a step running `go test -race -tags postgres ./internal/appbuild/... ./internal/cli/...` against its live database. Before this, the job compiled every build-tag combination but scoped its test step to ./internal/store/pgstore/..., so postgres-tagged code in the composition root was compiled on every PR and never executed — which is how 13 failing tests sat on develop unnoticed. Verified to catch a real regression, not just the original symptom: with the state KV dropped from the postgres wiring path (a mutation that compiles and passes untagged), the step fails with "State is nil". Paired with backendtest''s RELA_TEST_DATABASE_REQUIRED gate, which hard-fails rather than skipping when the job''s DSN goes missing — so the measure cannot silently disarm the way an unguarded skip would.'
+kind: ci
+location: .github/workflows/ci.yml (Postgres Backend → "Run composition-root wiring tests against PostgreSQL")
+status: active
+---
+
+## What it catches
+
+Two distinct regressions:
+
+1. **A postgres-only wiring break.** Any change to `appbuild`'s postgres recipe
+   or the shared `prepare`/`assemble` path that works on fs/memory but not
+   postgres. Verified by mutation: nulling the state KV on the postgres path
+   compiles and passes the default suite, and this step fails it.
+
+2. **The gate disarming itself.** `RELA_TEST_DATABASE_REQUIRED` (already set as
+   job env for the pgstore suite) makes `backendtest` hard-fail on a missing
+   DSN instead of skipping — so a dropped env var or renamed service container
+   goes red rather than turning the step into a silent no-op.
+
+## Why skips are tolerated here
+
+Unlike the pgstore step, this one does **not** grep for `--- SKIP`. A few cases
+in these packages assert boot failures that occur before any store is opened
+(`TestDiscover_MissingProject`, `TestNewMCPServices_BadMetamodel`,
+`TestDiscover_MalformedACL_FailsBoot`) and legitimately need no database; they
+run ungated on every build. The failure mode worth guarding is a *missing DSN*,
+which the env var already covers.

--- a/tickets/entities/bugs/BUG-3KQW7P.md
+++ b/tickets/entities/bugs/BUG-3KQW7P.md
@@ -1,0 +1,88 @@
+---
+id: BUG-3KQW7P
+type: bug
+title: 'Composition-root tests fail under -tags postgres; CI compiles the tag but never runs or lints it'
+priority: medium
+description: '13 composition-root tests in internal/appbuild and internal/cli fail under -tags postgres because they inherit the postgres recipe''s DSN requirement while asserting build-agnostic wiring. CI never caught it: the Postgres job compiles every build-tag combination but scopes its test step to internal/store/pgstore, and golangci-lint runs untagged, so 13 lint findings were invisible too. Fixed with internal/appbuild/backendtest (supplies each build a backend; hard-fails rather than skips when the CI DSN is missing) plus a Postgres-job step running the wiring packages against the live database.'
+status: done
+why1: '13 tests in internal/appbuild and internal/cli fail under `-tags postgres`, and 13 lint findings appear only with the tag.'
+why2: 'The failing tests call appbuild.New/Discover, and the postgres recipe refuses to open a store without a DSN — so each fails with "postgres build requires a database URL".'
+why3: 'They are build-agnostic composition-root assertions (Services populated, Close idempotent, acl.yaml loaded) that need SOME store, not a postgres one — but no seam existed to hand a tagged build a usable backend, so they inherited the recipe''s DSN requirement.'
+why4: 'Nothing ran them: the Postgres Backend job compiles every build-tag combination but scopes its test step to ./internal/store/pgstore/..., and golangci-lint runs untagged — so tagged code outside pgstore was compiled, never executed, never linted.'
+why5: 'CI coverage for a build tag was scoped to the package that motivated the tag (the store) rather than to everything the tag changes. The store was treated as the backend-specific surface, but the composition root is build-tagged too — so its postgres half had no gate at all and silently rotted.'
+prevention: 'Added internal/appbuild/backendtest so a tagged build can supply its own backend, and extended the Postgres job to run the wiring packages against the live database. When adding a build tag, gate every package the tag changes, not just the one it was introduced for.'
+---
+
+## Description
+
+Found while running the postgres-tagged suite by hand during the multi-tenancy
+work — not reported by CI, because CI never runs it.
+
+**13 test failures** under `-tags postgres`, all identical in shape:
+
+```
+--- FAIL: TestDiscover_BuildsAllServices
+    appbuild: postgres build requires a database URL (set RELA_DATABASE_URL)
+```
+
+**13 lint findings** that appear only with the tag: gosec G706, an `err`
+shadow, four misspellings, an unused `nolint` directive, a whitespace nit.
+
+## Why CI missed it
+
+| Job | Covers |
+|---|---|
+| Postgres Backend | compiles all tag combinations; **runs tests only for `./internal/store/pgstore/...`** |
+| Lint | **untagged only** |
+| Cross-Compile | compiles `linux/darwin/windows × postgres` |
+
+So postgres-tagged code outside `pgstore` was compiled on every PR but never
+executed and never linted.
+
+## Root cause
+
+The failing tests assert **build-agnostic** composition-root behaviour: that
+`Services` comes back fully populated, that `Close` is idempotent, that
+`acl.yaml` loads into a `Declarative`, that a corrupt CalDAV cache doesn't brick
+boot. They call `New`/`Discover` because that is the wiring entry point — not
+because they test a store. The postgres recipe requires a DSN, so all of them
+failed for a reason unrelated to what they assert.
+
+Two things confirm this reading. `appbuildtest` **passed** throughout, because it
+assembles over a memstore instead of going through the recipe. And within the
+same files, tests asserting failures that occur *before* the backend opens
+(`TestDiscover_MissingProject`, `TestNewMCPServices_BadMetamodel`) also passed.
+That boundary is the seam the fix builds on.
+
+## A latent test bug this surfaced
+
+`TestCorruptAliasTableDoesNotBrickTheBinary` wrote a corrupt
+`.rela/caldav/aliases.json`. Since TKT-VC27L3 the alias table is a `state_kv`
+row on the postgres build — so there it corrupted a file nothing reads, the
+table loaded clean, and the assertion failed **against correct production
+code**. It was a filesystem test wearing a wiring test's name.
+
+## Fix
+
+`internal/appbuild/backendtest` supplies whatever the current build needs to
+reach a store: nothing on fs/memory, a private migrated schema on postgres.
+
+Skip policy follows `pgstore`'s precedent (RR-0EWZQW): without a database the
+tests skip so a developer's `go test -tags postgres ./...` stays clean, but
+`RELA_TEST_DATABASE_REQUIRED` — the same variable, not a second one — turns a
+missing DSN into a hard failure. Tests that assert boot failures before any
+store opens stay **ungated**, so they don't degrade into skips.
+
+The corrupt-alias test now writes through `state.KV`, where the table lives on
+either backend. Verified non-vacuous by mutation.
+
+The Postgres job gained a step running the wiring packages against the same
+database (and bubblewrap, which `internal/cli`'s render tests need).
+
+## Verification
+
+Against PostgreSQL 15: the 13 previously-failing tests pass, including under
+`-race`; both builds lint clean; the full default suite is green; the strictness
+gate hard-fails when the DSN is missing. A simulated postgres-only wiring
+regression (dropping the state KV) is caught by the new step — it would have
+merged silently before.

--- a/tickets/entities/review-checklists/REV-3KQW7P.md
+++ b/tickets/entities/review-checklists/REV-3KQW7P.md
@@ -1,0 +1,84 @@
+---
+id: REV-3KQW7P
+type: review-checklist
+title: 'Review: Composition-root tests fail under -tags postgres; CI compiles the tag but never runs or lints it'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Automated Checks
+
+- [x] All tests pass — full default suite green (83 packages); postgres-tagged `internal/appbuild/...` + `internal/cli/...` green against PostgreSQL 15, including `-race` (the exact new CI step); memorybackend build + tests green
+- [x] Lint clean — `golangci-lint run ./...` **and** `--build-tags postgres ./...` both 0 issues (the tagged run was the point: it was never run before); `just arch-lint` OK; God-object lint OK
+- [x] Coverage maintained — `just coverage-check` exit 0, package + total floors satisfied (77.7%)
+
+## Code Review
+
+- [x] Self-reviewed the diff for unrelated changes — the only non-test source edit is a lint comment in `versionsweep_postgres.go`; no production behaviour changes
+- [x] ~~All critical review-responses addressed~~ (none raised)
+- [x] ~~All significant review-responses addressed~~ (none raised)
+
+**Two judgement calls worth recording:**
+
+1. **G706 on `sweepConfigFromEnv`.** First fix added a `sanitizeForLog` helper.
+   Removed it: `internal/dataentry` already establishes — pinned by
+   `TestSlogTextHandlerEscapesNewlines` — that a constant message plus user data
+   as a structured *attribute* is safe, because slog's handler quotes and
+   escapes it. The sanitizer implied a protection that already existed, so a
+   `nolint` citing that invariant is the honest fix.
+
+2. **Skip-vs-fail.** Skipping without a database risks turning 13 real tests
+   into 13 silent no-ops (RR-0EWZQW). Mitigated by reusing pgstore's
+   `RELA_TEST_DATABASE_REQUIRED` rather than inventing a second variable, and by
+   keeping the three tests that assert pre-store boot failures **ungated** so
+   they still genuinely run with no database present.
+
+## Acceptance Verification
+
+- [x] Each acceptance criterion tested
+- [x] Test evidence documented
+
+**Verified, with fail-before checks rather than assumed:**
+
+| Claim | Evidence |
+|---|---|
+| 13 previously-failing tests now pass | reproduced red on `develop` first, then green with a live DB |
+| Corrupt-alias test is non-vacuous | mutated `buildStateAndAliases` to serve an empty table → test fails as intended |
+| New CI step catches a real regression | nulled the state KV on the postgres wiring path (compiles, passes untagged) → step fails "State is nil" |
+| Strictness gate fires | `RELA_TEST_DATABASE_REQUIRED=1` with no DSN → hard failure, not skip |
+| Skip path is clean | no DSN → 3 tests still run, backend-reaching ones skip |
+| No schema leakage | 0 `relawiring_%` schemas left after ~40 runs |
+| Dependency isolation intact | `go list -deps`: pgx absent from default build, bleve absent from postgres build |
+
+## Documentation (enhancements only)
+
+- [x] ~~User-facing documentation updated~~ (N/A: CI/test-infrastructure fix, no user-visible surface)
+- [x] ~~Docs-checklist created~~ (N/A: not an enhancement or docs ticket)
+
+## Final Checks
+
+- [x] Commit message explains the why (root cause: tag coverage scoped to the package that motivated the tag, not everything the tag changes)
+- [x] No TODOs or FIXMEs left unaddressed
+- [x] Ready for another developer to use — `backendtest` is documented at package level, including why the skip policy is what it is
+
+## Pull Request
+
+- [x] PR created and CI monitored
+- [x] PR URL documented below
+
+**PR:** https://github.com/sourcehaven-bv/rela/pull/1362
+
+**One scoping decision made during CI iteration.** The first version of the new
+step ran `./internal/cli/...` whole and failed on
+`TestRenderCmd_WritesRenderedFile`: that test shells out through
+`internal/cmdexec`, which fails closed without a sandbox, and this job's runner
+cannot create bubblewrap's loopback device (`RTM_NEWADDR: Operation not
+permitted`) even after installing the package — unlike the `test` job.
+
+The step now names the MCP wiring tests explicitly. The render test is
+backend-independent and already covered by the `test` job, so gating the
+postgres wiring on an unrelated sandbox capability bought nothing. Deliberately
+NOT fixed by relaxing the sandbox or adding a skip inside the test — both would
+weaken a real confinement guarantee to satisfy a job that does not need it.
+Verified the narrowed filter still runs all three originally-failing CLI tests.

--- a/tickets/relations/BUG-3KQW7P--adds-measure--AM-postgres-tagged-wiring-tests.md
+++ b/tickets/relations/BUG-3KQW7P--adds-measure--AM-postgres-tagged-wiring-tests.md
@@ -1,0 +1,5 @@
+---
+from: BUG-3KQW7P
+relation: adds-measure
+to: AM-postgres-tagged-wiring-tests
+---

--- a/tickets/relations/BUG-3KQW7P--affects--ci-pipeline.md
+++ b/tickets/relations/BUG-3KQW7P--affects--ci-pipeline.md
@@ -1,0 +1,5 @@
+---
+from: BUG-3KQW7P
+relation: affects
+to: ci-pipeline
+---

--- a/tickets/relations/BUG-3KQW7P--affects--store-backends.md
+++ b/tickets/relations/BUG-3KQW7P--affects--store-backends.md
@@ -1,0 +1,5 @@
+---
+from: BUG-3KQW7P
+relation: affects
+to: store-backends
+---

--- a/tickets/relations/BUG-3KQW7P--affects--test-fixtures.md
+++ b/tickets/relations/BUG-3KQW7P--affects--test-fixtures.md
@@ -1,0 +1,5 @@
+---
+from: BUG-3KQW7P
+relation: affects
+to: test-fixtures
+---

--- a/tickets/relations/BUG-3KQW7P--fixes--FEAT-GE1YY.md
+++ b/tickets/relations/BUG-3KQW7P--fixes--FEAT-GE1YY.md
@@ -1,0 +1,5 @@
+---
+from: BUG-3KQW7P
+relation: fixes
+to: FEAT-GE1YY
+---

--- a/tickets/relations/BUG-3KQW7P--has-review--REV-3KQW7P.md
+++ b/tickets/relations/BUG-3KQW7P--has-review--REV-3KQW7P.md
@@ -1,0 +1,5 @@
+---
+from: BUG-3KQW7P
+relation: has-review
+to: REV-3KQW7P
+---


### PR DESCRIPTION
Two pre-existing issues found while running the postgres-tagged suite locally during the multi-tenancy work. Both were invisible to CI.

## What was broken

**13 tests failed** under `-tags postgres` in `internal/appbuild` and `internal/cli`:

```
--- FAIL: TestDiscover_BuildsAllServices
    appbuild: postgres build requires a database URL (set RELA_DATABASE_URL)
```

**13 lint findings** appeared only with the tag (gosec, shadow, misspell, unparam, whitespace, nolintlint).

## Why CI never caught it

The Postgres Backend job compiles every build-tag combination, but runs tests only for `./internal/store/pgstore/...`. `golangci-lint` runs untagged. So tagged code in every other package was compiled but never executed or linted.

## Root cause of the failures

All 13 share one cause. They assert **build-agnostic composition-root behavior** — `Services` fully populated, `Close` idempotent, `acl.yaml` loaded into a `Declarative`, a corrupt CalDAV cache non-fatal. They call `New`/`Discover` because that's the wiring entry point, not because they test a store. The postgres recipe requires a DSN, so each failed identically.

Notably `appbuildtest` **passed** all along — it assembles over a memstore instead of going through the recipe. And within the same files, tests asserting failures that happen *before* the backend opens (`TestDiscover_MissingProject`, `TestNewMCPServices_BadMetamodel`) also passed. That's the seam this PR builds on.

## The fix

New `internal/appbuild/backendtest` supplies whatever the current build needs: nothing on fs/memory, a **private migrated schema** on postgres (per-schema isolation, matching the pgstore suite).

**Skip policy** follows the precedent in `pgstore/testdb_test.go`. Without a database the tests skip, so `go test -tags postgres ./...` stays clean locally — but `RELA_TEST_DATABASE_REQUIRED` turns a missing DSN into a hard failure, reusing pgstore's variable rather than inventing a second one. That's RR-0EWZQW's lesson: a skip and a pass are indistinguishable in CI summaries.

Tests that assert boot failures before any store opens keep running **ungated**, so they don't silently become skips.

## A real test bug this surfaced

`TestCorruptAliasTableDoesNotBrickTheBinary` wrote a corrupt `.rela/caldav/aliases.json`. Since TKT-VC27L3 the alias table is a `state_kv` row on postgres — so on that build it corrupted a file nothing reads, the table loaded clean, and the assertion failed **against correct production code**. It was a filesystem test wearing a wiring test's name.

It now corrupts the table through `state.KV`, which is where it lives on either backend. Verified non-vacuous: mutated `buildStateAndAliases` to discard the corrupt table and serve an empty one, and the test fails as intended.

## Preventing recurrence

Added a step to the Postgres job running the wiring packages against the same database. Skips are tolerated there (a few cases legitimately need no database), while `RELA_TEST_DATABASE_REQUIRED` still catches a missing DSN.

## Lint notes

Two worth flagging:

- **G706** on `sweepConfigFromEnv` — I first added a sanitizer, then removed it. `internal/dataentry` already establishes (pinned by `TestSlogTextHandlerEscapesNewlines`) that a constant message plus user data as an *attribute* is safe, because slog's handler escapes it. A `nolint` matching that precedent is honest; a sanitizer implied a protection that was already there.
- **`waitForEntityChange`** — genuine build-tag paradox: the `unparam` directive is required on the default build and unused under postgres, where a second caller varies the argument. Now suppresses `nolintlint` too.

## Verification

Against PostgreSQL 15 (local):

| Check | Result |
|---|---|
| 13 previously-failing tests, with DB | pass |
| Same, `-race` (the new CI step) | pass |
| Postgres build, no DB | clean skips |
| `RELA_TEST_DATABASE_REQUIRED=1`, no DSN | hard-fails as designed |
| `golangci-lint`, default + postgres | 0 issues each |
| Full default suite | 83 packages, green |
| memorybackend build + tests | pass |
| `just arch-lint`, `just coverage-check` | pass |
| Dependency isolation (`go list -deps`) | pgx out of default, bleve out of postgres |

No production behavior changes: the only non-test source edit is a lint comment.