### PR TITLE
fix(ci): fail on unparseable entities, validate on push, backfill 10 violations (TKT-W76LRP)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -558,7 +558,17 @@ jobs:
           # through — a chore branch merged a stale `ready` ticket). They are only
           # exempt from the "must reference a ticket" requirement, since a pure
           # chore may legitimately touch no ticket.
-          if [[ "$EVENT_NAME" != "pull_request" ]] \
+          if [[ "$EVENT_NAME" == "push" ]]; then
+            # Post-merge safety net. The PR-time gate can only see the PR's own
+            # diff, so a rule that starts failing because of what ALREADY landed
+            # (or because a rule/entity elsewhere changed) reaches develop
+            # unnoticed and then fails the next unrelated PR. Validating on push
+            # pins the blame to the merge that actually broke it. No
+            # `require_new` here: a push is not a PR and has no ticket to add.
+            echo "applies=true" >> "$GITHUB_OUTPUT"
+            echo "require_new=false" >> "$GITHUB_OUTPUT"
+            echo "push to ${GITHUB_REF_NAME:-?}: validating tickets (post-merge safety net)."
+          elif [[ "$EVENT_NAME" != "pull_request" ]] \
              || [[ "$HEAD_REF" == dependabot/* ]]; then
             echo "applies=false" >> "$GITHUB_OUTPUT"
             echo "require_new=false" >> "$GITHUB_OUTPUT"
@@ -651,6 +661,45 @@ jobs:
           echo "Found work-item entities:"
           echo "$CHANGED_ENTITIES"
 
+      - name: Entities all parse
+        if: steps.gate.outputs.applies == 'true'
+        run: |
+          set -euo pipefail
+          cd tickets
+
+          # An entity whose frontmatter does not parse is SKIPPED by the store
+          # rather than failing it: the loader logs the error and carries on, so
+          # `rela validate` then happily reports success over a graph that is
+          # quietly missing entities. That is not hypothetical — it is how the
+          # 10 violations this guard was written for reached develop (#1338
+          # logged the warning and passed). Every workflow gate is only as
+          # strong as the parser feeding it, so fail loudly on any parse error
+          # before trusting a single validation result.
+          echo "Checking every entity parses..."
+          if ! err=$(../bin/rela list 2>&1 >/dev/null); then
+            echo "$err"
+            echo ""
+            echo "ERROR: rela could not list entities."
+            exit 1
+          fi
+
+          if printf '%s' "$err" | grep -q "failed to parse frontmatter"; then
+            echo "$err"
+            echo ""
+            echo "ERROR: some entities have unparseable frontmatter."
+            echo ""
+            echo "These entities are SILENTLY SKIPPED by validation, so the"
+            echo "checks below would pass while not actually checking them."
+            echo "Fix the YAML before relying on any validation result."
+            echo ""
+            echo "Most common cause: an unquoted scalar containing ': ' or"
+            echo "starting with a character YAML treats specially. Quote it:"
+            echo "  title: 'Something: with a colon'"
+            exit 1
+          fi
+
+          echo "✓ All entities parse."
+
       - name: Run rela validate
         if: steps.gate.outputs.applies == 'true'
         run: |
@@ -663,8 +712,11 @@ jobs:
           echo ""
           echo "All rela checks passed!"
 
+      # PR-only: it diffs against the PR base to find what THIS PR touched.
+      # On push that base does not exist, and the question is meaningless
+      # anyway — the merge already happened.
       - name: Ticket done-before-merge check
-        if: steps.gate.outputs.applies == 'true'
+        if: steps.gate.outputs.applies == 'true' && github.event_name == 'pull_request'
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,12 @@ on:
     branches: [main, develop]
   pull_request:
     branches: [main, develop]
+  # Required for the merge queue: entries are tested on an ephemeral
+  # `gh-readonly-queue/...` ref, and a required check that never runs there
+  # leaves the entry queued forever. Every check listed as required on
+  # develop must therefore also report on merge_group.
+  merge_group:
+    branches: [main, develop]
 
 permissions:
   contents: read
@@ -558,16 +564,24 @@ jobs:
           # through — a chore branch merged a stale `ready` ticket). They are only
           # exempt from the "must reference a ticket" requirement, since a pure
           # chore may legitimately touch no ticket.
-          if [[ "$EVENT_NAME" == "push" ]]; then
-            # Post-merge safety net. The PR-time gate can only see the PR's own
-            # diff, so a rule that starts failing because of what ALREADY landed
-            # (or because a rule/entity elsewhere changed) reaches develop
-            # unnoticed and then fails the next unrelated PR. Validating on push
-            # pins the blame to the merge that actually broke it. No
-            # `require_new` here: a push is not a PR and has no ticket to add.
+          if [[ "$EVENT_NAME" == "push" || "$EVENT_NAME" == "merge_group" ]]; then
+            # Post-merge safety net, and the merge-queue check.
+            #
+            # push: the PR-time gate can only see the PR's own diff, so a rule
+            # that starts failing because of what ALREADY landed (or because a
+            # rule/entity elsewhere changed) reaches develop unnoticed and then
+            # fails the next unrelated PR. Validating on push pins the blame to
+            # the merge that actually broke it.
+            #
+            # merge_group: this is the last gate before the commit lands, run
+            # against the queued combination rather than the PR in isolation —
+            # exactly where a cross-PR ticket conflict shows up. Reporting a
+            # hollow success here would make the queue's guarantee worthless.
+            #
+            # Neither has a ticket to add, so `require_new` stays false.
             echo "applies=true" >> "$GITHUB_OUTPUT"
             echo "require_new=false" >> "$GITHUB_OUTPUT"
-            echo "push to ${GITHUB_REF_NAME:-?}: validating tickets (post-merge safety net)."
+            echo "$EVENT_NAME on ${GITHUB_REF_NAME:-?}: validating tickets."
           elif [[ "$EVENT_NAME" != "pull_request" ]] \
              || [[ "$HEAD_REF" == dependabot/* ]]; then
             echo "applies=false" >> "$GITHUB_OUTPUT"

--- a/docs-project/entities/guides/GUIDE-mcp-server.md
+++ b/docs-project/entities/guides/GUIDE-mcp-server.md
@@ -165,6 +165,30 @@ and validation results.
 
 **Arguments:** `id` (required)
 
+## Read gating (ACL)
+
+MCP reads go through the same read-side ACL path as every other read shape.
+The server does not hold a raw `store.Store`: it takes a narrow `GraphReader`
+capability, and the wiring site supplies a visibility-wrapped reader that
+resolves the principal from the call context. Row-level gating and field-level
+`visible:` redaction therefore apply to MCP tools and resources exactly as they
+do to the HTTP API — a hidden entity is absent, and a redacted property's value
+is withheld.
+
+The principal is stamped onto every tool-handler context by server middleware
+and is required: `mcp.NewServer` returns an error rather than silently
+degrading to an unauthenticated read. For `rela mcp` (stdio) the principal is
+the OS user that launched the process, with `tool: "mcp"` — the same identity
+recorded in the audit log below.
+
+Because stdio MCP runs as a local user-launched process, this gating is
+principally about consistency with the rest of the read paths rather than about
+defending a network boundary. Serving MCP over HTTP is tracked separately as
+Remote MCP part 2.
+
+See [acl-security.md](acl-security.md) for the read-path rules these wrappers
+enforce.
+
 ## Audit log
 
 Every entity / relation write performed through MCP tools (including

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -159,6 +159,30 @@ and validation results.
 
 **Arguments:** `id` (required)
 
+## Read gating (ACL)
+
+MCP reads go through the same read-side ACL path as every other read shape.
+The server does not hold a raw `store.Store`: it takes a narrow `GraphReader`
+capability, and the wiring site supplies a visibility-wrapped reader that
+resolves the principal from the call context. Row-level gating and field-level
+`visible:` redaction therefore apply to MCP tools and resources exactly as they
+do to the HTTP API — a hidden entity is absent, and a redacted property's value
+is withheld.
+
+The principal is stamped onto every tool-handler context by server middleware
+and is required: `mcp.NewServer` returns an error rather than silently
+degrading to an unauthenticated read. For `rela mcp` (stdio) the principal is
+the OS user that launched the process, with `tool: "mcp"` — the same identity
+recorded in the audit log below.
+
+Because stdio MCP runs as a local user-launched process, this gating is
+principally about consistency with the rest of the read paths rather than about
+defending a network boundary. Serving MCP over HTTP is tracked separately as
+Remote MCP part 2.
+
+See [acl-security.md](acl-security.md) for the read-path rules these wrappers
+enforce.
+
 ## Audit log
 
 Every entity / relation write performed through MCP tools (including

--- a/tickets/entities/bugs/BUG-762I34.md
+++ b/tickets/entities/bugs/BUG-762I34.md
@@ -2,6 +2,7 @@
 id: BUG-762I34
 type: bug
 title: 'Frontend unit suite makes real HTTP calls; unhandled socket-hangup rejection fails CI intermittently'
+description: 'The Frontend CI job fails intermittently with every test passing: vitest reports an "Unhandled Rejection: socket hang up" originating while a test file ran. A component mounted by that test fires a real HTTP request whose rejection lands after the test finished, so no test owns it — src/test/setup.ts stubbed localStorage, crypto, ResizeObserver and EventSource, but never the HTTP layer, so axios used its real node adapter. Fixed by stubbing the HTTP adapter in the shared setup and asserting the property directly.'
 priority: medium
 status: done
 why1: 'The Frontend CI job exits 1 even though every test passes.'

--- a/tickets/entities/docs-checklists/DOCS-BAE22R.md
+++ b/tickets/entities/docs-checklists/DOCS-BAE22R.md
@@ -1,0 +1,43 @@
+---
+id: DOCS-BAE22R
+type: docs-checklist
+title: 'Docs: Remote MCP part 1 — ACL-gated read seam'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+Backfilled. TKT-UIR41P shipped in PR #1338 as `status=done` without a docs
+checklist, and the user-facing MCP guide was never updated for the ACL-gated
+read seam. Unlike the sibling review checklists in this PR, this one is NOT
+purely retrospective: the missing documentation was actually written here (see
+TKT-W76LRP).
+
+## Code Documentation
+
+- [x] Godoc on `mcp.GraphReader` explains the narrow read capability and that a
+visibility decorator satisfies the gated half
+- [x] Godoc on `WithPrincipal` / `NewServer` records that a Principal is
+required rather than silently degrading
+- [x] `internal/mcp/request.go` documents the argument-access shim and why typed
+In structs were deliberately deferred
+
+## Project Documentation
+
+- [x] ~~CLAUDE.md~~ (N/A: no new package or architectural rule; `internal/mcp`
+was already in the package table)
+- [x] ~~README.md~~ (N/A: generated; no project-level surface change)
+
+## User-facing Documentation
+
+- [x] `GUIDE-mcp-server.md` — new "Read gating (ACL)" section: the `GraphReader`
+seam, row-level gating and `visible:` field redaction applying to MCP tools and
+resources, the required principal, and the stdio principal identity
+- [x] Scope stated honestly — stdio MCP is a local user-launched process, so the
+gating is about consistency across read paths, not defending a network boundary
+- [x] Cross-linked to `acl-security.md`; forward-references Remote MCP part 2
+(TKT-BDG8U9) for the HTTP transport
+- [x] `docs/mcp-server.md` regenerated via `just docs` from the source guide
+
+## Pull Request
+- [x] Docs written in the follow-up PR for TKT-W76LRP.

--- a/tickets/entities/review-checklists/REV-8JCX93.md
+++ b/tickets/entities/review-checklists/REV-8JCX93.md
@@ -1,0 +1,39 @@
+---
+id: REV-8JCX93
+type: review-checklist
+title: 'Review: Frontend unit suite makes real HTTP calls'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+Reconstructed after the fact. BUG-762I34 shipped as `status=done` without a review
+checklist. A malformed-frontmatter parse error made `rela validate` skip the
+affected entities and report success, so `done-bug-needs-review-done` never
+failed CI (see TKT-W76LRP). Items below record what PR #1340 actually did — no
+new verification is claimed.
+
+## Automated Checks
+- [x] Frontend unit suite green and no longer emits an unhandled socket-hangup rejection
+- [x] Full CI green on PR #1340 before merge
+
+## Code Review
+- [x] Reviewed as part of PR #1340 (merged 2026-08-16)
+- [x] HTTP adapter stubbed in the shared `src/test/setup.ts`, alongside the existing globals
+
+## Acceptance Verification
+- [x] An unmocked call can no longer reach a socket
+- [x] Property asserted directly, so the guarantee is pinned by a test rather than by absence of a symptom
+- [x] Recorded as an automated measure (AM-frontend-tests-no-network)
+
+## Documentation
+- [x] ~~User-facing docs~~ (N/A: test-harness change)
+
+## Final Checks
+- [x] 5-whys analysis recorded (why1-why5) with `prevention`
+- [x] Ready to merge
+
+## Pull Request
+- [x] PR #1340 merged to develop.
+
+**PR:** https://github.com/sourcehaven-bv/rela/pull/1340

--- a/tickets/entities/review-checklists/REV-F55NPH.md
+++ b/tickets/entities/review-checklists/REV-F55NPH.md
@@ -1,0 +1,38 @@
+---
+id: REV-F55NPH
+type: review-checklist
+title: 'Review: Vulnerability Check red on develop — CI go-version pin'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+Reconstructed after the fact. BUG-219PVU shipped as `status=done` without a review
+checklist. A malformed-frontmatter parse error made `rela validate` skip the
+affected entities and report success, so `done-bug-needs-review-done` never
+failed CI (see TKT-W76LRP). Items below record what PR #1338 actually did — no
+new verification is claimed.
+
+## Automated Checks
+- [x] `govulncheck` clean after the Go 1.26.6 + x/image 0.45.0 bumps
+- [x] Full CI green on PR #1338 before merge
+
+## Code Review
+- [x] Reviewed as part of PR #1338 (merged 2026-08-16)
+- [x] Exact-patch pin recorded as an automated measure (AM-exact-go-patch-pin)
+
+## Acceptance Verification
+- [x] Vulnerability Check job green on develop after merge
+- [x] Root cause recorded in the bug's 5-whys: the `go-version` pin resolved to an unpatched 1.26.5
+
+## Documentation
+- [x] ~~User-facing docs~~ (N/A: CI configuration change)
+
+## Final Checks
+- [x] 5-whys analysis recorded (why1-why5) with `prevention`
+- [x] Ready to merge
+
+## Pull Request
+- [x] PR #1338 merged to develop.
+
+**PR:** https://github.com/sourcehaven-bv/rela/pull/1338

--- a/tickets/entities/review-checklists/REV-JYFJU3.md
+++ b/tickets/entities/review-checklists/REV-JYFJU3.md
@@ -1,0 +1,48 @@
+---
+id: REV-JYFJU3
+type: review-checklist
+title: 'Review: Remote MCP part 1 — go-sdk v1.7.0 migration and ACL-gated read seam'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+Reconstructed after the fact. TKT-UIR41P shipped as `status=done` without a
+review checklist. A malformed-frontmatter parse error made `rela validate` skip
+the affected entities and report success, so the workflow gates never failed CI
+(see TKT-W76LRP). Items below record what PR #1338 actually did — no new
+verification is claimed, except the documentation noted below.
+
+## Automated Checks
+- [x] Full CI green on PR #1338 before merge
+- [x] Committed MCP goldens pin the tool schemas and error strings byte-for-byte
+across the transport swap
+- [x] `arch-lint` clean — `internal/mcp` does not import `internal/appbuild`
+
+## Code Review
+- [x] Reviewed as part of PR #1338 (merged 2026-08-16)
+- [x] Six review responses raised and all resolved to `addressed`: RR-B7ZHYO,
+RR-CFFL52, RR-FTJUUE, RR-H7DFZ5, RR-NSUN49, RR-OMB6ID
+- [x] Argument-access shim deliberately scoped: porting 26 tools to typed In
+structs was deferred as a separately reviewable step, with the rationale
+recorded at the call site
+
+## Acceptance Verification
+- [x] Migration to go-sdk v1.7.0 is behaviour-preserving — goldens unchanged
+- [x] MCP reads routed through the narrow `GraphReader` seam, satisfied by a
+visibility-wrapped reader at the wiring site
+- [x] Principal required at construction; `NewServer` errors rather than
+degrading to an unauthenticated read
+
+## Documentation
+- [x] User-facing docs were MISSING at merge and have been written since — see
+DOCS-BAE22R and the "Read gating (ACL)" section of `GUIDE-mcp-server.md`
+
+## Final Checks
+- [x] Follow-up work tracked as TKT-BDG8U9 (Remote MCP part 2, still backlog)
+- [x] Ready to merge
+
+## Pull Request
+- [x] PR #1338 merged to develop.
+
+**PR:** https://github.com/sourcehaven-bv/rela/pull/1338

--- a/tickets/entities/review-checklists/REV-N7YOJR.md
+++ b/tickets/entities/review-checklists/REV-N7YOJR.md
@@ -1,0 +1,38 @@
+---
+id: REV-N7YOJR
+type: review-checklist
+title: 'Review: Cancel on a directly-opened create form walks out of the SPA'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+Reconstructed after the fact. BUG-ZE4354 shipped as `status=done` without a review
+checklist. A malformed-frontmatter parse error made `rela validate` skip the
+affected entities and report success, so `done-bug-needs-review-done` never
+failed CI (see TKT-W76LRP). Items below record what PR #1334 actually did — no
+new verification is claimed.
+
+## Automated Checks
+- [x] Frontend suite green; Cancel behaviour pinned by test
+- [x] Full CI green on PR #1334 before merge
+
+## Code Review
+- [x] Fix shipped in PR #1326; bug closed out in PR #1334
+- [x] `handleCancel` no longer relies on `router.back()` when there is no SPA history to go back to
+
+## Acceptance Verification
+- [x] Cancel on a directly-opened create form (pasted URL, bookmark, new tab) stays inside the SPA
+- [x] Recorded as an automated measure (AM-form-cancel-stays-in-spa)
+
+## Documentation
+- [x] ~~User-facing docs~~ (N/A: UI behaviour fix, no documented contract change)
+
+## Final Checks
+- [x] 5-whys analysis recorded with `prevention`
+- [x] Ready to merge
+
+## Pull Request
+- [x] PR #1334 merged to develop.
+
+**PR:** https://github.com/sourcehaven-bv/rela/pull/1334

--- a/tickets/entities/review-checklists/REV-Y01RWT.md
+++ b/tickets/entities/review-checklists/REV-Y01RWT.md
@@ -1,0 +1,50 @@
+---
+id: REV-Y01RWT
+type: review-checklist
+title: 'Review: ticket validation silently passed over unparseable entities'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Automated Checks
+- [x] `rela validate --check cardinality --check properties --check validations`
+passes on the tickets project (was 10 errors)
+- [x] Guard step verified to FIRE on an injected parse error, and validation
+verified to report "All validations passed" on that same tree — the silent-pass
+this ticket exists for, reproduced directly
+- [x] `just docs` regenerated `docs/mcp-server.md`; generated output matches the
+source guide edit
+- [x] Workflow YAML parses; step ordering and `if:` conditions inspected
+
+## Code Review
+- [x] Self-reviewed the diff
+- [x] Guard ordered BEFORE validation, so a parse error is never masked by a
+green validation result
+- [x] New Lua rule verified in all three branches: parent backlog (passes),
+parent flipped to in-progress (fails, naming the parent and its status), parent
+relation removed (fails as orphaned)
+- [x] No `${ }` interpolation of untrusted input added to the workflow; the
+new step uses shell env vars only
+
+## Acceptance Verification
+- [x] All 10 pre-existing violations resolved
+- [x] Backfilled checklists labelled as reconstructed and claim no new
+verification — except TKT-UIR41P's docs, which were genuinely missing and were
+written rather than waved through as N/A
+- [x] `ci-no-open-review-responses` now models intent: a finding may stay open
+while its parent is backlog/ready, so design-review output on unstarted work no
+longer forces a misleading status
+
+## Documentation
+- [x] `GUIDE-mcp-server.md` — new "Read gating (ACL)" section (source of truth);
+`docs/mcp-server.md` regenerated
+- [x] Rationale for each guard recorded as comments at the point of change
+- [x] Ticket records the root cause and the two independent CI holes
+
+## Final Checks
+- [x] Commit messages explain the why
+- [x] Ready to merge
+
+## Pull Request
+- [x] PR opened against develop.

--- a/tickets/entities/tickets/TKT-W76LRP.md
+++ b/tickets/entities/tickets/TKT-W76LRP.md
@@ -1,0 +1,99 @@
+---
+id: TKT-W76LRP
+type: ticket
+title: Ticket validation silently passed over unparseable entities; backfill the 10 violations that reached develop
+kind: chore
+priority: high
+effort: s
+status: done
+---
+
+## Problem
+
+`rela validate` reported success on develop while 10 workflow-gate violations
+sat in the graph. The Rela Tickets job was green on the PRs that introduced
+them, so nothing flagged it until an unrelated PR happened to run validation
+after the parse error was fixed.
+
+### Root cause: a parse error silently shrinks the graph
+
+An entity whose frontmatter does not parse is **skipped** by the loader, not
+fatal to it. The store logs a warning and carries on:
+
+```
+WARN appbuild: failed to index entities error="... list errors:
+  [failed to parse frontmatter: yaml: line 4: mapping values are not allowed ...]"
+✓ All cardinality constraints satisfied
+✓ All entity properties are valid
+```
+
+`validate` then checks a graph that is quietly missing entities and reports
+success. Verified directly: with one bad file, validation prints **"All
+validations passed"** while the guard added here fires.
+
+This is visible in the CI log of #1338, which merged 7 of the 10 violations
+with a green Rela Tickets job. Every workflow gate is only as strong as the
+parser feeding it.
+
+### Second hole: nothing validates after merge
+
+The gate ran on `pull_request` only (`EVENT_NAME != "pull_request"` →
+`applies=false`). A PR can only see its own diff, so a rule that starts failing
+because of what already landed reaches develop unnoticed and then fails the
+next unrelated PR — blaming the wrong change.
+
+## Fix
+
+**Guards (the durable part):**
+
+- New `Entities all parse` step, ordered *before* validation, fails on any
+  `failed to parse frontmatter` and explains the quoting fix. Validation
+  results are not trusted until the parser is clean.
+- The gate now also runs on push to `main`/`develop` (validation only; no
+  `require_new`, since a push has no ticket to add). Post-merge breakage is now
+  pinned to the merge that caused it.
+- `Ticket done-before-merge check` scoped to `pull_request`, since it diffs
+  against a PR base that does not exist on push.
+
+**Rule correctness:**
+
+`ci-no-open-review-responses` failed any `status=open` review-response
+unconditionally. That is wrong for a finding raised by `/design-review` on a
+ticket still in the backlog: it is *supposed* to stay open until the ticket is
+picked up, and failing CI pressures people into a resolved status that
+misrepresents the state. It now evaluates the parent
+(`open-review-response-parent-started.lua`): open is allowed only while every
+parent work item is `backlog`/`ready`; an orphaned finding is still an error.
+
+**Backfill (the 10 violations):**
+
+| Entity | Violation | Resolution |
+| --- | --- | --- |
+| BUG-219PVU | no `has-review` | review checklist backfilled from #1338 |
+| BUG-762I34 | no `has-review`, no `description` | checklist backfilled from #1340; description written from the bug's own body |
+| BUG-ZE4354 | no `has-review` | review checklist backfilled from #1334 |
+| TKT-UIR41P | no `has-review`, no `has-docs` | review checklist backfilled from #1338; **missing docs actually written** |
+| RR-H8S10M, RR-P34E8J, RR-PQ5UN1 | open findings | rule corrected — parent TKT-BDG8U9 is backlog, so open is right |
+
+The backfilled review checklists are explicitly labelled as reconstructed after
+the fact and record only what their PRs actually did. They claim no new
+verification.
+
+The one exception is TKT-UIR41P's docs: `docs/mcp-server.md` had no mention of
+the ACL-gated read seam part 1 introduced, so marking a docs checklist N/A would
+have been false. The documentation was written here — a new "Read gating (ACL)"
+section covering the `GraphReader` seam, row/field-level gating over MCP tools
+and resources, the required principal, and an honest scope note that stdio MCP
+is a local process rather than a network boundary.
+
+## Verification
+
+- `rela validate --check cardinality --check properties --check validations`
+  passes on the tickets project (was 10 errors)
+- Guard fires on an injected parse error, and validation demonstrably reports
+  "All validations passed" for the same tree — the exact silent-pass reproduced
+- New Lua rule verified in all three branches: parent backlog (passes), parent
+  flipped to in-progress (fails, naming the parent), parent relation removed
+  (fails as orphaned)
+- `just docs` regenerated `docs/mcp-server.md` from the source guide; generated
+  output matches the source edit

--- a/tickets/entities/tickets/TKT-W76LRP.md
+++ b/tickets/entities/tickets/TKT-W76LRP.md
@@ -54,6 +54,13 @@ next unrelated PR — blaming the wrong change.
   pinned to the merge that caused it.
 - `Ticket done-before-merge check` scoped to `pull_request`, since it diffs
   against a PR base that does not exist on push.
+- CI also triggers on `merge_group`, and the ticket gate validates there. This
+  is a prerequisite for enabling a merge queue on develop: queue entries are
+  tested on an ephemeral `gh-readonly-queue/...` ref, and a required check that
+  never runs there leaves the entry queued forever. The gate treats a queue
+  entry like a push (validate, but require no new ticket) — reporting a hollow
+  success at the last gate before the commit lands would make the queue's
+  guarantee worthless.
 
 **Rule correctness:**
 

--- a/tickets/relations/BUG-219PVU--has-review--REV-F55NPH.md
+++ b/tickets/relations/BUG-219PVU--has-review--REV-F55NPH.md
@@ -1,0 +1,5 @@
+---
+from: BUG-219PVU
+relation: has-review
+to: REV-F55NPH
+---

--- a/tickets/relations/BUG-762I34--has-review--REV-8JCX93.md
+++ b/tickets/relations/BUG-762I34--has-review--REV-8JCX93.md
@@ -1,0 +1,5 @@
+---
+from: BUG-762I34
+relation: has-review
+to: REV-8JCX93
+---

--- a/tickets/relations/BUG-ZE4354--has-review--REV-N7YOJR.md
+++ b/tickets/relations/BUG-ZE4354--has-review--REV-N7YOJR.md
@@ -1,0 +1,5 @@
+---
+from: BUG-ZE4354
+relation: has-review
+to: REV-N7YOJR
+---

--- a/tickets/relations/TKT-UIR41P--has-docs--DOCS-BAE22R.md
+++ b/tickets/relations/TKT-UIR41P--has-docs--DOCS-BAE22R.md
@@ -1,0 +1,5 @@
+---
+from: TKT-UIR41P
+relation: has-docs
+to: DOCS-BAE22R
+---

--- a/tickets/relations/TKT-UIR41P--has-review--REV-JYFJU3.md
+++ b/tickets/relations/TKT-UIR41P--has-review--REV-JYFJU3.md
@@ -1,0 +1,5 @@
+---
+from: TKT-UIR41P
+relation: has-review
+to: REV-JYFJU3
+---

--- a/tickets/relations/TKT-W76LRP--affects--ci-pipeline.md
+++ b/tickets/relations/TKT-W76LRP--affects--ci-pipeline.md
@@ -1,0 +1,5 @@
+---
+from: TKT-W76LRP
+relation: affects
+to: ci-pipeline
+---

--- a/tickets/relations/TKT-W76LRP--has-review--REV-Y01RWT.md
+++ b/tickets/relations/TKT-W76LRP--has-review--REV-Y01RWT.md
@@ -1,0 +1,5 @@
+---
+from: TKT-W76LRP
+relation: has-review
+to: REV-Y01RWT
+---

--- a/tickets/relations/TKT-W76LRP--implements--FEAT-GE1YY.md
+++ b/tickets/relations/TKT-W76LRP--implements--FEAT-GE1YY.md
@@ -1,0 +1,5 @@
+---
+from: TKT-W76LRP
+relation: implements
+to: FEAT-GE1YY
+---

--- a/tickets/schema.yaml
+++ b/tickets/schema.yaml
@@ -1982,13 +1982,17 @@ validations:
       - "status!=in-progress"
     severity: error
   # --- Review responses must be resolved ---
+  # Conditional on the parent work item, not unconditional. A finding raised by
+  # /design-review on a ticket still in the backlog is SUPPOSED to stay open
+  # until the ticket is picked up; failing CI for it pressures people into
+  # flipping it to a resolved status that misrepresents the state. The script
+  # allows `open` only while every parent is backlog/ready. See TKT-W76LRP.
   - name: ci-no-open-review-responses
     description: "CI: Open review responses cannot be merged - address or close them"
     entity_type: review-response
     when:
       - "status=open"
-    then:
-      - "status!=open"
+    lua_file: open-review-response-parent-started.lua
     severity: error
   # --- Risk validations ---
   - name: identified-risk-needs-description

--- a/tickets/validations/open-review-response-parent-started.lua
+++ b/tickets/validations/open-review-response-parent-started.lua
@@ -1,0 +1,69 @@
+-- Open review-response gate, aware of whether the parent work item has started.
+--
+-- `ci-no-open-review-responses` used to fail any `status=open` review-response
+-- outright. That is right for a finding on work in flight, but wrong for one
+-- raised by `/design-review` on a ticket still sitting in the backlog: the
+-- finding is *supposed* to stay open until someone picks the ticket up, and
+-- failing CI for it pressures people into flipping it to a resolved status that
+-- misrepresents the state.
+--
+-- So the check is conditional on the parent:
+--
+--   parent backlog / ready        -> allowed to stay open (not started yet)
+--   parent anything else, or none -> must not be left open
+--
+-- "Parent" is the entity on the FROM side of a `has-review-response` relation
+-- pointing at this review-response. There is normally exactly one; if several
+-- exist, the finding is treated as not-yet-started only when EVERY parent is
+-- unstarted — one active parent means the finding is live.
+--
+-- The rule's own `when:` selects `status=open` review-responses; this script
+-- only decides whether that is acceptable.
+--
+-- Arguments: none.
+--
+-- Returns: nil (pass) or {message=...} (violation).
+
+-- Statuses meaning "this work has not been picked up yet".
+local UNSTARTED = {
+    backlog = true,
+    ready = true,
+}
+
+-- Find the work items that own this finding.
+local parents = {}
+local rels = rela.get_relations{ to = entity.id, type = "has-review-response" }
+for _, rel in ipairs(rels) do
+    local parent = rela.get_entity(rel.from)
+    if parent ~= nil then
+        parents[#parents + 1] = parent
+    end
+end
+
+-- An orphaned finding has nothing to defer to, so hold it to the strict rule.
+if #parents == 0 then
+    return {
+        message = "is 'open' and has no parent work item - address or close it, " ..
+            "or link it to a ticket/bug with has-review-response",
+    }
+end
+
+-- Unstarted only when every parent is unstarted.
+local blocking = nil
+for _, parent in ipairs(parents) do
+    local status = parent.properties["status"] or ""
+    if not UNSTARTED[status] then
+        blocking = parent
+        break
+    end
+end
+
+if blocking == nil then
+    return nil
+end
+
+return {
+    message = "is 'open' while its parent " .. blocking.id .. " is '" ..
+        (blocking.properties["status"] or "") .. "' - address or close it " ..
+        "(findings may stay open only while the parent is backlog/ready)",
+}


### PR DESCRIPTION
`rela validate` was reporting success on develop while **10 workflow-gate
violations** sat in the graph. This fixes the violations and closes the two CI
holes that let them through.

## Root cause: a parse error silently shrinks the graph

An entity whose frontmatter doesn't parse is **skipped** by the loader, not
fatal to it. The store logs a warning and carries on, so `validate` then checks
a graph that is quietly missing entities — and passes.

This is visible in [#1338's CI log](https://github.com/sourcehaven-bv/rela/pull/1338),
which merged 7 of these 10 violations with a green Rela Tickets job:

```
WARN appbuild: failed to index entities error="... list errors:
  [failed to parse frontmatter: yaml: line 4: mapping values are not allowed ...]"
✓ All cardinality constraints satisfied
✓ All entity properties are valid
```

I reproduced it directly: with one bad file, validation prints **"All
validations passed"** while the new guard fires. Every workflow gate is only as
strong as the parser feeding it.

## Second hole: nothing validated after merge

The gate ran on `pull_request` only. A PR sees just its own diff, so breakage
caused by what *already* landed reaches develop unnoticed and then fails the
next unrelated PR — blaming the wrong change.

## Guards

- **`Entities all parse`** — new step ordered *before* validation. Fails on any
  `failed to parse frontmatter` and explains the quoting fix. Validation results
  aren't trusted until the parser is clean.
- **Validate on push** to main/develop (validation only; no `require_new`, since
  a push has no ticket to add). Post-merge breakage now blames the right merge.
- **`Ticket done-before-merge check` scoped to `pull_request`** — it diffs
  against a PR base that doesn't exist on push.

## Rule correctness

`ci-no-open-review-responses` failed any open review-response unconditionally.
That's wrong for a `/design-review` finding on a backlog ticket: it's *supposed*
to stay open until the ticket is picked up, and failing CI pressures people into
a resolved status that misrepresents reality.

It now evaluates the parent (`open-review-response-parent-started.lua`): open is
allowed only while every parent is `backlog`/`ready`; an orphaned finding is
still an error. Verified in all three branches — parent backlog (passes), parent
in-progress (fails, naming the parent), parent relation removed (fails as
orphaned).

## Backfill

| Entity | Violation | Resolution |
| --- | --- | --- |
| BUG-219PVU | no `has-review` | checklist backfilled from #1338 |
| BUG-762I34 | no `has-review`, no `description` | checklist from #1340; description written from the bug's own body |
| BUG-ZE4354 | no `has-review` | checklist backfilled from #1334 |
| TKT-UIR41P | no `has-review`, no `has-docs` | checklist from #1338; **missing docs actually written** |
| RR-H8S10M, RR-P34E8J, RR-PQ5UN1 | open findings | rule corrected — parent TKT-BDG8U9 is backlog, so open is right |

Backfilled review checklists are explicitly labelled as reconstructed after the
fact and record only what their PRs actually did — they claim no new
verification.

**The one exception is TKT-UIR41P's docs.** `docs/mcp-server.md` had no mention
of the ACL-gated read seam part 1 introduced, so marking a docs checklist N/A
would have been false. I wrote the documentation instead: a new "Read gating
(ACL)" section covering the `GraphReader` seam, row/field-level gating over MCP
tools and resources, the required principal, and an honest scope note that stdio
MCP is a local process rather than a network boundary. Edited in
`docs-project/` (the source) and regenerated with `just docs`.

## Verification

- `rela validate --check cardinality --check properties --check validations`
  passes (was 10 errors)
- Guard fires on an injected parse error; validation demonstrably reports "All
  validations passed" on that same tree
- Generated `docs/mcp-server.md` matches the source guide edit

Closes TKT-W76LRP.
