### PR TITLE
feat(dataentry): view section fields render as display by default (TKT-HOIX1)

### DIFF
--- a/e2e/pages/entity.page.ts
+++ b/e2e/pages/entity.page.ts
@@ -116,6 +116,57 @@ export class EntityPage extends BasePage {
     await expect(this.page.locator('.entity-list .list-item .section-edit-form').first()).toBeVisible();
   }
 
+  /** The entry (first) properties section of a detail page. Render-mode
+   *  assertions below scope to it so an opted-in section further down the
+   *  page can't satisfy a display-mode expectation (TKT-HOIX1). */
+  private entryPropertiesSection() {
+    return this.page.locator('.properties-list').first();
+  }
+
+  /** Assert the entry properties section renders as DISPLAY values: visible,
+   *  but with no inline-edit form mounted (TKT-HOIX1 — the `render: display`
+   *  default). */
+  async expectEntrySectionRendersDisplay() {
+    const section = this.entryPropertiesSection();
+    await expect(section).toBeVisible();
+    await expect(section.locator('.section-edit-form')).toHaveCount(0);
+  }
+
+  /** Assert the entry properties section renders no form controls at all —
+   *  no select, no input, no FieldShell wrapper. Stronger than
+   *  expectEntrySectionRendersDisplay: it pins that display mode hides the
+   *  CONTROL, not merely the autosave host. */
+  async expectEntrySectionHasNoFormControls() {
+    const section = this.entryPropertiesSection();
+    await expect(section).toBeVisible();
+    await expect(section.locator('select')).toHaveCount(0);
+    await expect(section.locator('input')).toHaveCount(0);
+    await expect(section.locator('.form-field')).toHaveCount(0);
+  }
+
+  /** Assert the entry properties section shows the given text — display mode
+   *  hides the control, not the data. */
+  async expectEntrySectionShowsValue(text: string) {
+    await expect(this.entryPropertiesSection()).toContainText(text);
+  }
+
+  /** Assert the entry properties section does NOT show the given text. Used to
+   *  prove a display-rendered value tracks the current server state rather than
+   *  a stale string mirror (RR-GLK4UY). */
+  async expectEntrySectionLacksValue(text: string) {
+    await expect(this.entryPropertiesSection()).not.toContainText(text);
+  }
+
+  /** Assert the first inline-edit list row exposes an ENABLED control, proving
+   *  `render: input` reaches the edit arm rather than a disabled widget. */
+  async expectListSectionRowControlEnabled() {
+    const row = this.page.locator('.entity-list .list-item .section-edit-form').first();
+    await expect(row).toBeVisible();
+    const control = row.locator('select, input').first();
+    await expect(control).toBeVisible();
+    await expect(control).toBeEnabled();
+  }
+
   async clickRelationLink(targetId: string) {
     // Detail screens render related entities as cards / list items with a
     // data-entity-id attribute on the row root and a clickable header

--- a/e2e/tests/fixtures.ts
+++ b/e2e/tests/fixtures.ts
@@ -1219,15 +1219,26 @@ views:
       - heading: "Task"
         source: entry
         display: properties
+        # Deliberately left at the display default (TKT-HOIX1) so the suite
+        # exercises BOTH render modes on one page: this entry section renders
+        # display values while the "Implements" list section below is inline-
+        # editable. A future spec asserting an editable form here must add
+        # render: input rather than assume the pre-TKT-HOIX1 default.
         fields:
           - property: status
           - property: assignee
       - heading: "Implements"
         source: implemented
         display: list
+        # render: input is REQUIRED for this section to mount a
+        # SectionEditForm — fields render as display by default (TKT-HOIX1).
+        # Without it the #997 unmount-crash guard silently stops exercising
+        # the DOM shape it exists to guard.
         fields:
           - property: status
+            render: input
           - property: priority
+            render: input
         empty_message: "No implemented features"
 
 kanbans:

--- a/e2e/tests/view-section-render-mode.spec.ts
+++ b/e2e/tests/view-section-render-mode.spec.ts
@@ -1,0 +1,89 @@
+import { test, expect } from './fixtures';
+import { EntityPage } from '../pages';
+import { SEED } from './fixtures';
+
+// TKT-HOIX1: view section fields render as a view-oriented display value by
+// default; `render: input` opts a field into inline editing.
+//
+// This is the integration case PLAN-6RDYUL flagged as uncoverable by unit
+// tests: one page rendering BOTH modes at once. The component tests can prove
+// each arm in isolation, but only a real page can show that a display section
+// and an inline-edit section coexist without one stealing the other's chrome.
+//
+// The fixture's `task` view (DATA_ENTRY_YAML in fixtures.ts) is deliberately
+// mixed:
+//   section[0] "Task"       display: properties, no render  → display default
+//   section[1] "Implements" display: list, render: input     → inline edit
+test.describe('View section render modes (TKT-HOIX1)', () => {
+  test('renders a display section and an inline-edit section on one page', async ({
+    appPage,
+  }) => {
+    const entity = new EntityPage(appPage);
+    await entity.navigateToEntity('task', SEED.tasks.writeUnitTests);
+
+    // The entry properties section omits `render`, so it must NOT mount an
+    // inline-edit form. Pre-TKT-HOIX1 it would have: `status`/`assignee` are
+    // ordinarily writable, and writability alone used to decide this.
+    const entrySection = appPage.locator('.properties-list').first();
+    await expect(entrySection).toBeVisible();
+    await expect(entrySection.locator('.section-edit-form')).toHaveCount(0);
+
+    // ...while the list section below it, which opts in, does.
+    await entity.expectListSectionRowMounted();
+  });
+
+  test('a display-default field renders no form input', async ({ appPage }) => {
+    const entity = new EntityPage(appPage);
+    await entity.navigateToEntity('task', SEED.tasks.writeUnitTests);
+
+    // `status` is an enum on the entry section. Rendered as display it is
+    // plain text — no <select>, no FieldShell wrapper. Scoped to the entry
+    // section so the opted-in list section below can't satisfy this.
+    const entrySection = appPage.locator('.properties-list').first();
+    await expect(entrySection).toBeVisible();
+    await expect(entrySection.locator('select')).toHaveCount(0);
+    await expect(entrySection.locator('input')).toHaveCount(0);
+    await expect(entrySection.locator('.form-field')).toHaveCount(0);
+
+    // The value is still shown — display mode hides the control, not the data.
+    // (TASK-001 is seeded with status=draft, assignee=Alice.)
+    await expect(entrySection).toContainText('draft');
+    await expect(entrySection).toContainText('Alice');
+  });
+
+  // Regression guard for the display-value staleness the render default makes
+  // reachable. `mapFieldsToProperties` used to read the server-side string
+  // mirror (`section.fields[i].values`), which the SPA never updates after a
+  // PATCH — it rewrites `entry.properties` only. Before TKT-HOIX1 the entry
+  // display path was reached only when the ACL denied every field, so nothing
+  // could edit those values and the mirror could not go stale. With display as
+  // the default it is the common path, so the read now prefers
+  // `entry.properties` (same fix as `rowDisplayValue` / RR-FC1C).
+  //
+  // This asserts the weaker, load-bearing half: a display section shows the
+  // CURRENT server value on load, not a mirror that drifted.
+  test('a display section reflects the current server value', async ({ appPage, api }) => {
+    await api.updateEntity('tasks', SEED.tasks.writeUnitTests, { assignee: 'Bob' });
+
+    const entity = new EntityPage(appPage);
+    await entity.navigateToEntity('task', SEED.tasks.writeUnitTests);
+
+    const entrySection = appPage.locator('.properties-list').first();
+    await expect(entrySection).toBeVisible();
+    await expect(entrySection).toContainText('Bob');
+    await expect(entrySection).not.toContainText('Alice');
+  });
+
+  test('an opted-in field is editable and autosaves', async ({ appPage }) => {
+    const entity = new EntityPage(appPage);
+    await entity.navigateToEntity('task', SEED.tasks.writeUnitTests);
+
+    // The list row's SectionEditForm carries real controls, proving
+    // `render: input` reaches the edit arm rather than a disabled widget.
+    const row = appPage.locator('.entity-list .list-item .section-edit-form').first();
+    await expect(row).toBeVisible();
+    const control = row.locator('select, input').first();
+    await expect(control).toBeVisible();
+    await expect(control).toBeEnabled();
+  });
+});

--- a/e2e/tests/view-section-render-mode.spec.ts
+++ b/e2e/tests/view-section-render-mode.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from './fixtures';
+import { test } from './fixtures';
 import { EntityPage } from '../pages';
 import { SEED } from './fixtures';
 
@@ -24,9 +24,7 @@ test.describe('View section render modes (TKT-HOIX1)', () => {
     // The entry properties section omits `render`, so it must NOT mount an
     // inline-edit form. Pre-TKT-HOIX1 it would have: `status`/`assignee` are
     // ordinarily writable, and writability alone used to decide this.
-    const entrySection = appPage.locator('.properties-list').first();
-    await expect(entrySection).toBeVisible();
-    await expect(entrySection.locator('.section-edit-form')).toHaveCount(0);
+    await entity.expectEntrySectionRendersDisplay();
 
     // ...while the list section below it, which opts in, does.
     await entity.expectListSectionRowMounted();
@@ -37,18 +35,13 @@ test.describe('View section render modes (TKT-HOIX1)', () => {
     await entity.navigateToEntity('task', SEED.tasks.writeUnitTests);
 
     // `status` is an enum on the entry section. Rendered as display it is
-    // plain text — no <select>, no FieldShell wrapper. Scoped to the entry
-    // section so the opted-in list section below can't satisfy this.
-    const entrySection = appPage.locator('.properties-list').first();
-    await expect(entrySection).toBeVisible();
-    await expect(entrySection.locator('select')).toHaveCount(0);
-    await expect(entrySection.locator('input')).toHaveCount(0);
-    await expect(entrySection.locator('.form-field')).toHaveCount(0);
+    // plain text — no <select>, no FieldShell wrapper.
+    await entity.expectEntrySectionHasNoFormControls();
 
     // The value is still shown — display mode hides the control, not the data.
     // (TASK-001 is seeded with status=draft, assignee=Alice.)
-    await expect(entrySection).toContainText('draft');
-    await expect(entrySection).toContainText('Alice');
+    await entity.expectEntrySectionShowsValue('draft');
+    await entity.expectEntrySectionShowsValue('Alice');
   });
 
   // Regression guard for the display-value staleness the render default makes
@@ -68,22 +61,16 @@ test.describe('View section render modes (TKT-HOIX1)', () => {
     const entity = new EntityPage(appPage);
     await entity.navigateToEntity('task', SEED.tasks.writeUnitTests);
 
-    const entrySection = appPage.locator('.properties-list').first();
-    await expect(entrySection).toBeVisible();
-    await expect(entrySection).toContainText('Bob');
-    await expect(entrySection).not.toContainText('Alice');
+    await entity.expectEntrySectionShowsValue('Bob');
+    await entity.expectEntrySectionLacksValue('Alice');
   });
 
-  test('an opted-in field is editable and autosaves', async ({ appPage }) => {
+  test('an opted-in field is editable', async ({ appPage }) => {
     const entity = new EntityPage(appPage);
     await entity.navigateToEntity('task', SEED.tasks.writeUnitTests);
 
     // The list row's SectionEditForm carries real controls, proving
     // `render: input` reaches the edit arm rather than a disabled widget.
-    const row = appPage.locator('.entity-list .list-item .section-edit-form').first();
-    await expect(row).toBeVisible();
-    const control = row.locator('select, input').first();
-    await expect(control).toBeVisible();
-    await expect(control).toBeEnabled();
+    await entity.expectListSectionRowControlEnabled();
   });
 });

--- a/frontend/src/api/views.ts
+++ b/frontend/src/api/views.ts
@@ -16,6 +16,14 @@ export interface ViewSectionField {
   // the view/form config. Absent or 0 means full width — the default, and what
   // every auto-generated view emits. See utils/fieldSpan.ts.
   span?: number
+  // Server-resolved render mode (TKT-HOIX1). 'display' (the default) renders a
+  // view-oriented value; 'input' opts the field into inline edit. The
+  // section→field inheritance is resolved server-side, so this is already the
+  // effective value — never re-derive it here.
+  //
+  // Opting in to 'input' does NOT grant editability: the ACL verdict in
+  // `_fields` still decides, so 'input' on a read-only field renders display.
+  render?: 'input' | 'display'
 }
 
 // Entity data for view sections.

--- a/frontend/src/components/entity/EntityDetail.vue
+++ b/frontend/src/components/entity/EntityDetail.vue
@@ -420,6 +420,26 @@ function getPropertyDef(entityType: string, propertyName: string): PropertyDef |
   return et?.properties?.[propertyName]
 }
 
+// entryDisplayValue: the entry-section analogue of `rowDisplayValue` below —
+// prefer the live `entry.properties` over the display-stringified
+// `fields[i].values` server mirror, which `handlePropertyApplied` never
+// updates (it rewrites `entry.properties` only).
+//
+// Before TKT-HOIX1 the entry display path was reachable only when the ACL
+// denied EVERY field in the section, so nothing could edit those values and
+// the mirror could not go stale. With `render` defaulting to display, a
+// display-rendered section is now the common case and can sit alongside a
+// `render: input` section editing the same property — at which point the
+// display section would show last-loadView's string forever. Same bug class
+// as RR-FC1C, same fix.
+function entryDisplayValue(field: ViewSectionField): unknown {
+  const props = entry.value?.properties
+  if (field.property && props && field.property in props) {
+    return props[field.property]
+  }
+  return field.values ?? []
+}
+
 function mapFieldsToProperties(fields: ViewSectionField[] | undefined): PropertyItem[] {
   if (!fields) return []
   // Pre-resolve PropertyDef for the entry entity once (RR-UD1H). For
@@ -437,7 +457,7 @@ function mapFieldsToProperties(fields: ViewSectionField[] | undefined): Property
     return {
       name,
       label: field.label,
-      value: field.values ?? [],
+      value: entryDisplayValue(field),
       propType: field.propType,
       propertyDef: def,
       span: field.span,

--- a/frontend/src/components/entity/sectionEditFields.test.ts
+++ b/frontend/src/components/entity/sectionEditFields.test.ts
@@ -21,10 +21,14 @@ function makeEntity(overrides: Partial<Entity> = {}): Entity {
   } as Entity
 }
 
+// Fields opt in to inline edit (TKT-HOIX1): `render` defaults to 'display', so
+// without it these suites would exercise the display path rather than the
+// ACL-driven routing they exist to pin. The default itself is covered by the
+// dedicated `render` describe block below.
 function makeFields(): ViewSectionField[] {
   return [
-    { property: 'title', label: 'Title' },
-    { property: 'status', label: 'Status' },
+    { property: 'title', label: 'Title', render: 'input' },
+    { property: 'status', label: 'Status', render: 'input' },
   ]
 }
 
@@ -153,6 +157,99 @@ describe('sectionShouldRouteToInlineEdit', () => {
     ])
     expect(sectionShouldRouteToInlineEdit(section.fields, makeEntity(), schemaResolver)).toBe(false)
   })
+
+  // ── render: input | display (TKT-HOIX1) ──────────────────────────────
+  //
+  // AC 9 / RR-8EISWO: an all-display section must NOT mount a
+  // SectionEditForm. Mounting one would give an autosave host that can
+  // never save, and would flip heading ownership via
+  // sectionRendersOwnHeading for essentially every properties section.
+
+  it('returns false when fields omit render, even with writable verdicts (AC 1)', () => {
+    const section = makeSection([
+      { property: 'title', label: 'Title' },
+      { property: 'status', label: 'Status' },
+    ])
+    // No `_fields` at all → every verdict defaults writable. Pre-TKT-HOIX1
+    // this returned true; display-by-default is the breaking change.
+    expect(sectionShouldRouteToInlineEdit(section.fields, makeEntity(), schemaResolver)).toBe(false)
+  })
+
+  it('returns false when every field is explicitly render: display (AC 9)', () => {
+    const section = makeSection([
+      { property: 'title', label: 'Title', render: 'display' },
+      { property: 'status', label: 'Status', render: 'display' },
+    ])
+    expect(sectionShouldRouteToInlineEdit(section.fields, makeEntity(), schemaResolver)).toBe(false)
+  })
+
+  it('returns true when at least one field opts in with render: input', () => {
+    const section = makeSection([
+      { property: 'title', label: 'Title', render: 'display' },
+      { property: 'status', label: 'Status', render: 'input' },
+    ])
+    expect(sectionShouldRouteToInlineEdit(section.fields, makeEntity(), schemaResolver)).toBe(true)
+  })
+
+  it('returns false for render: input on an ACL-read-only field (AC 3)', () => {
+    // Security-critical: config downgrades editability, never upgrades it.
+    const section = makeSection([{ property: 'status', label: 'Status', render: 'input' }])
+    const entry = makeEntity({ _fields: { status: { writable: false } } })
+    expect(sectionShouldRouteToInlineEdit(section.fields, entry, schemaResolver)).toBe(false)
+  })
+
+  it('keeps the inaccessible guard ahead of render (AC 9)', () => {
+    // An inaccessible field routes to PropertyDisplay for its lock UI even
+    // when a sibling opts in to input.
+    const section = makeSection([
+      { property: 'title', label: 'Title', inaccessible: true },
+      { property: 'status', label: 'Status', render: 'input' },
+    ])
+    expect(sectionShouldRouteToInlineEdit(section.fields, makeEntity(), schemaResolver)).toBe(false)
+  })
+})
+
+describe('buildSectionEditFields — render passthrough (TKT-HOIX1)', () => {
+  it('carries the server-resolved render onto each field', () => {
+    const fields: ViewSectionField[] = [
+      { property: 'title', label: 'Title', render: 'input' },
+      { property: 'status', label: 'Status', render: 'display' },
+    ]
+    const out = buildSectionEditFields(fields, makeEntity(), schemaResolver)
+    expect(out.map((f) => f.render)).toEqual(['input', 'display'])
+  })
+
+  it('leaves render undefined when the server omitted it', () => {
+    // Undefined is not 'input', so the writable conjunct renders display —
+    // the safe direction for a legacy/shape-drift payload.
+    const out = buildSectionEditFields(
+      [{ property: 'title', label: 'Title' }],
+      makeEntity(),
+      schemaResolver,
+    )
+    expect(out[0].render).toBeUndefined()
+  })
+
+  it('carries render through the kind:"hint" branch too', () => {
+    const out = buildSectionEditFields(
+      [{ property: 'unknown_prop', label: 'Unknown', render: 'input' }],
+      makeEntity(),
+      schemaResolver,
+    )
+    expect(out[0].kind).toBe('hint')
+    expect(out[0].render).toBe('input')
+  })
+
+  it('does not fold render into verdict (RR-PGGRBD)', () => {
+    // The verdict-flip watcher compares isFieldWritable(verdict) across prop
+    // updates; a display field must not read as a revoked permission.
+    const out = buildSectionEditFields(
+      [{ property: 'title', label: 'Title', render: 'display' }],
+      makeEntity(),
+      schemaResolver,
+    )
+    expect(out[0].verdict).toBeUndefined()
+  })
 })
 
 describe('applyPropertyToEntry', () => {
@@ -198,9 +295,10 @@ function makeRow(overrides: Partial<ViewEntity> = {}): ViewEntity {
     title: 'Some Row',
     type: 'ticket',
     hasContent: false,
+    // render: 'input' for the same reason as makeFields() above (TKT-HOIX1).
     fields: [
-      { property: 'title', label: 'Title', values: ['Some Row'] },
-      { property: 'status', label: 'Status', values: ['open'] },
+      { property: 'title', label: 'Title', values: ['Some Row'], render: 'input' },
+      { property: 'status', label: 'Status', values: ['open'], render: 'input' },
     ],
     _props: { title: 'Some Row', status: 'open' },
     ...overrides,

--- a/frontend/src/components/entity/sectionEditFields.ts
+++ b/frontend/src/components/entity/sectionEditFields.ts
@@ -53,6 +53,9 @@ export function buildSectionEditFields(
     const def = getPropertyDef(source.type, f.property)
     const verdict = source._fields?.[f.property]
     const transitions = source._transitions?.[f.property]
+    // Server-resolved (section → field inheritance already applied); carried
+    // through as its own property, never folded into `verdict` (RR-PGGRBD).
+    const render = f.render
     if (def) {
       out.push({
         property: f.property,
@@ -60,6 +63,7 @@ export function buildSectionEditFields(
         verdict,
         transitions,
         span: f.span,
+        render,
         kind: 'schema',
         propertyDef: def,
       })
@@ -70,6 +74,7 @@ export function buildSectionEditFields(
         verdict,
         transitions,
         span: f.span,
+        render,
         kind: 'hint',
         routingHint: viewFieldRoutingHint(f),
       })
@@ -79,12 +84,21 @@ export function buildSectionEditFields(
 }
 
 // sectionShouldRouteToInlineEdit: properties section gets routed to
-// SectionEditForm only when (a) at least one field is writable per
-// `_fields` AND (b) no field on the section is inaccessible (e.g.
+// SectionEditForm only when (a) at least one field is EFFECTIVELY editable
+// AND (b) no field on the section is inaccessible (e.g.
 // git-crypt encrypted). The inaccessible affordance — a per-cell lock
 // placeholder — is rendered by PropertyDisplay's `<InaccessibleField>`
 // path; SectionEditForm doesn't model it (TKT-IHC7B explicitly scopes
 // to writability gating, not inaccessibility).
+//
+// "Effectively editable" is config AND ACL (TKT-HOIX1): `render: input`
+// plus a writable verdict — the same conjunction SectionEditForm's
+// `widgetRows` applies per field. The two MUST agree: if this predicate
+// used the verdict alone, an all-display section would mount a
+// SectionEditForm in which every field renders display anyway — an
+// autosave host that can never save, with its AutoSaveIndicator beside
+// a heading it took ownership of (RR-8EISWO). Since `render` defaults to
+// display, that would otherwise become the common case, not an edge one.
 //
 // Parameterized over FieldVerdictSource (TKT-IHC7C) — same as
 // buildSectionEditFields. Section fields come from `section.fields`
@@ -96,8 +110,8 @@ export function sectionShouldRouteToInlineEdit(
 ): boolean {
   const fs = fields ?? []
   if (fs.some((f) => f.inaccessible)) return false
-  return buildSectionEditFields(fs, source, getPropertyDef).some((f) =>
-    isFieldWritable(f.verdict),
+  return buildSectionEditFields(fs, source, getPropertyDef).some(
+    (f) => f.render === 'input' && isFieldWritable(f.verdict),
   )
 }
 

--- a/frontend/src/components/forms/SectionEditForm.test.ts
+++ b/frontend/src/components/forms/SectionEditForm.test.ts
@@ -18,10 +18,14 @@ import type { Entity, PropertyDef, AttachmentInfo } from '@/types'
 const TEXT_DEF: PropertyDef = { type: 'string' } as PropertyDef
 const ENUM_DEF: PropertyDef = { type: 'enum', values: ['open', 'closed'] } as PropertyDef
 
+// Fields default to `render: 'input'` here so the existing suites keep
+// exercising the edit path they were written for. `render` defaults to
+// 'display' in production (TKT-HOIX1); an override can set it back to test the
+// display arm.
 function makeFields(overrides: Partial<SectionEditField>[] = []): SectionEditField[] {
   const defaults: SectionEditField[] = [
-    { property: 'title', label: 'Title', kind: 'schema', propertyDef: TEXT_DEF },
-    { property: 'status', label: 'Status', kind: 'schema', propertyDef: ENUM_DEF },
+    { property: 'title', label: 'Title', kind: 'schema', propertyDef: TEXT_DEF, render: 'input' },
+    { property: 'status', label: 'Status', kind: 'schema', propertyDef: ENUM_DEF, render: 'input' },
   ]
   return defaults.map((d, i) => ({ ...d, ...(overrides[i] ?? {}) } as SectionEditField))
 }
@@ -225,6 +229,97 @@ describe('SectionEditForm', () => {
     expect(onVerdictFlip).not.toHaveBeenCalled()
   })
 
+  // ── render: input | display (TKT-HOIX1) ──────────────────────────────
+
+  it('render: display renders the display arm, not a FieldShell input (AC 1)', () => {
+    const fields = makeFields([{ render: 'display', verdict: { writable: true } }])
+    const { wrapper } = mountForm({ fields: [fields[0]] })
+    // No form chrome: the display arm is a bare widget in mode="display".
+    expect(wrapper.find('.form-field').exists()).toBe(false)
+    const widget = wrapper.findComponent({ name: 'TextWidget' })
+    expect(widget.exists()).toBe(true)
+    expect(widget.props('mode')).toBe('display')
+  })
+
+  it('render: input on an ACL-read-only field still renders display (AC 3)', () => {
+    // SECURITY-CRITICAL. Config downgrades editability; it must never
+    // upgrade a read-only field into an editable input.
+    const fields = makeFields([{ render: 'input', verdict: { writable: false } }])
+    const { wrapper } = mountForm({ fields: [fields[0]] })
+    expect(wrapper.find('.form-field').exists()).toBe(false)
+    expect(wrapper.findComponent({ name: 'TextWidget' }).props('mode')).toBe('display')
+  })
+
+  it('render: input with a writable verdict renders the edit arm (AC 2)', () => {
+    const fields = makeFields([{ render: 'input', verdict: { writable: true } }])
+    const { wrapper } = mountForm({ fields: [fields[0]] })
+    expect(wrapper.find('.form-field').exists()).toBe(true)
+    expect(wrapper.findComponent({ name: 'TextWidget' }).props('mode')).toBe('edit')
+  })
+
+  it('mixes input and display arms within one section (AC 6)', () => {
+    const fields = makeFields([
+      { render: 'input', verdict: { writable: true } },
+      { render: 'display', verdict: { writable: true } },
+    ])
+    const { wrapper } = mountForm({ fields })
+    const items = wrapper.findAll('.property-item')
+    expect(items).toHaveLength(2)
+    expect(items[0].find('.form-field').exists()).toBe(true)
+    expect(items[1].find('.form-field').exists()).toBe(false)
+  })
+
+  it('a display-flagged machine field skips the StatusControl (AC 7)', () => {
+    // Status fields are the likeliest to be flagged display; a disabled
+    // StatusControl is exactly the disabled-input outcome to avoid.
+    const fields = makeFields([
+      {},
+      { render: 'display', transitions: [], verdict: { writable: true } },
+    ])
+    const { wrapper } = mountForm({ fields: [fields[1]] })
+    expect(wrapper.findComponent({ name: 'StatusControl' }).exists()).toBe(false)
+  })
+
+  it('an input-flagged machine field still renders the StatusControl', () => {
+    const fields = makeFields([
+      {},
+      { render: 'input', transitions: [], verdict: { writable: true } },
+    ])
+    const { wrapper } = mountForm({ fields: [fields[1]] })
+    expect(wrapper.findComponent({ name: 'StatusControl' }).exists()).toBe(true)
+  })
+
+  it('switching a field to display does not fire onVerdictFlip (AC 8)', async () => {
+    // RR-PGGRBD: `render` must stay out of `verdict`, or the flip-watcher
+    // reads a config change as a revoked permission and toasts.
+    const initial = makeFields([{ render: 'input', verdict: { writable: true } }])
+    makeStoreMock()
+    const { wrapper, onVerdictFlip } = mountForm({ fields: [initial[0]] })
+    const flipped = makeFields([{ render: 'display', verdict: { writable: true } }])
+    await wrapper.setProps({ fields: [flipped[0]] })
+    await nextTick()
+    expect(onVerdictFlip).not.toHaveBeenCalled()
+  })
+
+  it('gives a long display value its own full-width row', () => {
+    const fields = makeFields([{ render: 'display', verdict: { writable: true } }])
+    const { wrapper } = mountForm({
+      fields: [fields[0]],
+      initialValues: { title: 'x'.repeat(61) },
+    })
+    expect(wrapper.find('.property-item').classes()).toContain('property-long')
+  })
+
+  it('does not force full width on an edit-arm field', () => {
+    // An edit widget sizes itself; stretching it would widen every textarea.
+    const fields = makeFields([{ render: 'input', verdict: { writable: true } }])
+    const { wrapper } = mountForm({
+      fields: [fields[0]],
+      initialValues: { title: 'x'.repeat(61) },
+    })
+    expect(wrapper.find('.property-item').classes()).not.toContain('property-long')
+  })
+
   it('commitImmediately runs on unmount', async () => {
     const fields = makeFields([{ verdict: { writable: true } }])
     const updateMock = makeStoreMock()
@@ -263,7 +358,14 @@ describe('SectionEditForm', () => {
   it('forwards attachment metadata to the file widget for a file property', () => {
     const FILE_DEF: PropertyDef = { type: 'file' } as PropertyDef
     const fields: SectionEditField[] = [
-      { property: 'photo', label: 'Photo', kind: 'schema', propertyDef: FILE_DEF, verdict: { writable: true } },
+      {
+        property: 'photo',
+        label: 'Photo',
+        kind: 'schema',
+        propertyDef: FILE_DEF,
+        verdict: { writable: true },
+        render: 'input',
+      },
     ]
     const att: AttachmentInfo = {
       id: 'shot.png',

--- a/frontend/src/components/forms/SectionEditForm.vue
+++ b/frontend/src/components/forms/SectionEditForm.vue
@@ -40,6 +40,12 @@ export type SectionEditField = {
   // resolved widget. Undefined = not a machine field (or a surface without
   // `_transitions`, e.g. cards/list rows) → the ordinary widget.
   transitions?: TransitionOption[]
+  // Server-resolved config render mode (TKT-HOIX1). Deliberately a SEPARATE
+  // property from `verdict`, not folded into it: the verdict-flip watcher
+  // below compares `isFieldWritable(verdict)` across prop updates, so a
+  // config-driven display field would otherwise look like a revoked
+  // permission and fire a spurious "Permission changed" toast (RR-PGGRBD).
+  render?: 'input' | 'display'
 } & (
   | { kind: 'schema'; propertyDef: PropertyDef }
   | { kind: 'hint'; routingHint: WidgetRoutingHint }
@@ -132,6 +138,10 @@ interface WidgetRow {
   widget: Component
   writable: boolean
   optionVerdicts?: Record<string, boolean>
+  // Display-rendered long values take their own full-width row, matching
+  // PropertyDisplay's behaviour (TKT-HOIX1). Only meaningful on the display
+  // arm — an edit widget sizes itself.
+  isLong: boolean
 }
 
 const widgetRows = computed<WidgetRow[]>(() =>
@@ -143,11 +153,35 @@ const widgetRows = computed<WidgetRow[]>(() =>
     return {
       field,
       widget,
-      writable: isFieldWritable(field.verdict),
+      // Config can only DOWNGRADE editability (TKT-HOIX1): a field renders as
+      // an input when the config opts in AND the ACL permits the write. Never
+      // weaken this to an `||` or a ternary that lets config win — `render:
+      // input` on a read-only field must still render display.
+      //
+      // Applied HERE only, not in the verdict-flip watcher below, and NOT via
+      // `isFieldWritable`'s second `fieldReadonly` parameter — doing either
+      // would make a display field look like a revoked permission (RR-PGGRBD).
+      writable: field.render === 'input' && isFieldWritable(field.verdict),
       optionVerdicts: optionVerdictsFor(field.verdict),
+      isLong: isLongValue(field),
     }
   }),
 )
+
+// Shares PropertyDisplay.vue `isLong`'s 60-char threshold, so a value doesn't
+// reflow when a section switches between the two renderers — keep the two
+// thresholds equal.
+//
+// Not a full port: PropertyDisplay also short-circuits on `PropertyItem.
+// isLongText`, which nothing in the codebase ever populates (it is dead on
+// that side too), so there is no behavioural difference to mirror. If
+// isLongText is ever wired up, this needs the same arm.
+//
+// Reads `formData` (not the field's server-side string mirror) so the layout
+// tracks the post-PATCH value.
+function isLongValue(field: SectionEditField): boolean {
+  return String(formData[field.property] ?? '').length > 60
+}
 
 function onFieldUpdate(field: SectionEditField, value: unknown) {
   const def = field.kind === 'schema' ? field.propertyDef : undefined
@@ -232,11 +266,17 @@ defineExpose({
         :key="row.field.property"
         class="property-item"
         :style="fieldSpanStyle(row.field.span)"
+        :class="{ 'property-long': !row.writable && row.isLong }"
       >
         <dt>{{ row.field.label }}</dt>
         <dd>
+          <!-- A machine field flagged `render: display` falls through to the
+               display arm below rather than rendering a DISABLED StatusControl
+               (TKT-HOIX1) — status fields are the ones most likely to be
+               flagged display, and a greyed-out control is exactly the
+               disabled-input outcome this ticket exists to avoid. -->
           <StatusControl
-            v-if="row.field.transitions !== undefined"
+            v-if="row.field.transitions !== undefined && row.field.render === 'input'"
             :model-value="formData[row.field.property] == null ? '' : String(formData[row.field.property])"
             :property="row.field.property"
             :entity-type="entityType"
@@ -309,4 +349,12 @@ defineExpose({
 /* .properties-list / .property-item now live in styles/properties-list.css,
  * shared with PropertyDisplay and SidePanel. Do not redefine them here — the
  * three scoped copies drifting apart is what this ticket removed. */
+
+/* Long display-rendered values wrap rather than overflow. The full-row
+ * behaviour (`grid-column: span 12`) is owned by styles/properties-list.css;
+ * only these text rules are component-local, mirroring PropertyDisplay.vue. */
+.property-item.property-long dd {
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
 </style>

--- a/internal/apiwire/v1/responses.go
+++ b/internal/apiwire/v1/responses.go
@@ -332,6 +332,12 @@ type SidePanelSection struct {
 // is git-crypt encrypted — the field is known to exist in the schema but
 // its value cannot be read.
 // Span is the field's width on the 12-column layout grid (0 = full width).
+//
+// Render is the already-resolved render mode ("display" | "input", TKT-HOIX1),
+// set server-side from the section + field config. View sections and cards/list
+// rows honor it; the side-panel renderer does not implement inline edit today
+// and ignores it.
+//
 // Field order and types must stay in lockstep with dataentry.SectionFieldData:
 // the handlers convert between them with a direct struct conversion, so the
 // compiler is what keeps the wire surface and the internal DTO from drifting.
@@ -342,6 +348,7 @@ type SectionField struct {
 	PropType     string   `json:"propType,omitempty"`
 	Inaccessible bool     `json:"inaccessible,omitempty"`
 	Span         int      `json:"span,omitempty"`
+	Render       string   `json:"render,omitempty"`
 }
 
 // SidePanelEntity represents an entity in a side panel section.

--- a/internal/dataentry/config.go
+++ b/internal/dataentry/config.go
@@ -65,3 +65,8 @@ type (
 	PaletteColors    = dataentryconfig.PaletteColors
 	ResolvedPalette  = dataentryconfig.ResolvedPalette
 )
+
+// resolveFieldRender re-exports dataentryconfig.ResolveFieldRender so the
+// section builders resolve a field's render mode (TKT-HOIX1) through the one
+// shared rule.
+var resolveFieldRender = dataentryconfig.ResolveFieldRender

--- a/internal/dataentry/sections.go
+++ b/internal/dataentry/sections.go
@@ -56,6 +56,10 @@ func propertyToStrings(v any) []string {
 // Span is the field's width on the 12-column layout grid, carried through from
 // the view config. 0 means full width — the default for every auto-generated
 // view, so a section with no spans authored renders as one scannable column.
+//
+// Render is the resolved render mode ("display" | "input", TKT-HOIX1) — see
+// dataentryconfig.ResolveFieldRender. Resolved server-side so the SPA never
+// reimplements the section→field inheritance rule.
 type SectionFieldData struct {
 	Property     string
 	Label        string
@@ -63,6 +67,7 @@ type SectionFieldData struct {
 	PropType     string
 	Inaccessible bool
 	Span         int
+	Render       string
 }
 
 // buildSectionFieldData resolves one configured field against an entity.
@@ -71,8 +76,12 @@ type SectionFieldData struct {
 // and the entry-source `properties` branch of buildSections (the detail page).
 // They were near-identical literals, which is exactly how a new field like Span
 // ends up wired into one and silently dropped from the other.
+//
+// sectionRender is the containing section's `render:` default; the field's own
+// `render:` overrides it (TKT-HOIX1).
 func buildSectionFieldData(
 	f ViewSectionField, e *entity.Entity, eDef *metamodel.EntityDef,
+	sectionRender string,
 ) SectionFieldData {
 	propType := ""
 	if eDef != nil {
@@ -97,7 +106,8 @@ func buildSectionFieldData(
 		// strict YAML decoding at config load. Past that boundary the value is
 		// just a number, and the wire DTO shouldn't drag a config type onto
 		// the API surface.
-		Span: int(f.Span),
+		Span:   int(f.Span),
+		Render: resolveFieldRender(sectionRender, f.Render),
 	}
 }
 
@@ -199,8 +209,12 @@ type SectionData struct {
 // Returns a value (not a pointer) so callers can layer on display-mode-
 // specific fields (e.g. `Content`/`HasContent` for the `content`/`cards`
 // branch) without sharing mutation across rows.
+//
+// sectionRender is the containing section's `render:` default; each field's
+// own `render:` overrides it (TKT-HOIX1).
 func (h *viewsHandler) buildSectionEntityData(
 	ctx context.Context, e *entity.Entity, secFields []ViewSectionField, eDef *metamodel.EntityDef,
+	sectionRender string,
 ) SectionEntityData {
 	s := h.schema()
 	sed := SectionEntityData{
@@ -212,7 +226,7 @@ func (h *viewsHandler) buildSectionEntityData(
 		FieldVerdicts: h.affordances.computeFieldAffordances(ctx, e),
 	}
 	for _, f := range secFields {
-		sed.Fields = append(sed.Fields, buildSectionFieldData(f, e, eDef))
+		sed.Fields = append(sed.Fields, buildSectionFieldData(f, e, eDef, sectionRender))
 	}
 	return sed
 }
@@ -240,7 +254,7 @@ func (h *viewsHandler) buildSections(ctx context.Context, sections []ViewSection
 			switch sec.Display {
 			case "properties":
 				for _, f := range sec.Fields {
-					sd.Fields = append(sd.Fields, buildSectionFieldData(f, e, entDef))
+					sd.Fields = append(sd.Fields, buildSectionFieldData(f, e, entDef, sec.Render))
 				}
 			case "content":
 				sd.Content = e.Content
@@ -257,7 +271,7 @@ func (h *viewsHandler) buildSections(ctx context.Context, sections []ViewSection
 			case "properties", "list":
 				for _, e := range entities {
 					eDef, _ := s.Meta.GetEntityDef(e.Type)
-					sed := h.buildSectionEntityData(ctx, e, sec.Fields, eDef)
+					sed := h.buildSectionEntityData(ctx, e, sec.Fields, eDef, sec.Render)
 					sd.Entities = append(sd.Entities, sed)
 				}
 			case "table":
@@ -322,7 +336,7 @@ func (h *viewsHandler) buildSections(ctx context.Context, sections []ViewSection
 			case "content", "cards":
 				for _, e := range entities {
 					eDef, _ := s.Meta.GetEntityDef(e.Type)
-					sed := h.buildSectionEntityData(ctx, e, sec.Fields, eDef)
+					sed := h.buildSectionEntityData(ctx, e, sec.Fields, eDef, sec.Render)
 					sed.Content = e.Content
 					sed.HasContent = e.Content != ""
 					sd.Entities = append(sd.Entities, sed)

--- a/internal/dataentry/sections_ihc7d_test.go
+++ b/internal/dataentry/sections_ihc7d_test.go
@@ -86,7 +86,7 @@ func TestBuildSectionEntityData_PopulatesPropsAndFieldVerdicts(t *testing.T) {
 		{Property: "title"},
 		{Property: "status"},
 	}
-	sed := app.views.buildSectionEntityData(context.Background(), e, secFields, eDef)
+	sed := app.views.buildSectionEntityData(context.Background(), e, secFields, eDef, "")
 
 	// Props carries the typed values.
 	if !reflect.DeepEqual(sed.Props, map[string]any{"title": "First", "status": "open"}) {
@@ -119,7 +119,7 @@ func TestBuildSectionEntityData_HiddenAbsentFromBothMaps(t *testing.T) {
 		Properties: map[string]any{"title": "First", "status": "open"},
 	}
 	eDef, _ := st.Meta.GetEntityDef(e.Type)
-	sed := app.views.buildSectionEntityData(context.Background(), e, nil, eDef)
+	sed := app.views.buildSectionEntityData(context.Background(), e, nil, eDef, "")
 	if _, ok := sed.Props["status"]; ok {
 		t.Errorf("hidden 'status' must not appear in Props; got %+v", sed.Props)
 	}
@@ -144,7 +144,7 @@ func TestBuildSectionEntityData_KeySetInvariant(t *testing.T) {
 		},
 	}
 	eDef, _ := st.Meta.GetEntityDef(e.Type)
-	sed := app.views.buildSectionEntityData(context.Background(), e, nil, eDef)
+	sed := app.views.buildSectionEntityData(context.Background(), e, nil, eDef, "")
 
 	hidden := app.affordances.hiddenProperties(context.Background(), e)
 	for k := range sed.Props {
@@ -239,7 +239,7 @@ func TestBuildSectionEntityData_LabelIsAuthoredNeverDerived(t *testing.T) {
 		{Property: "title"},                         // no label -> raw
 		{Property: "status", Label: "Eigen status"}, // authored -> preserved
 	}
-	sed := app.views.buildSectionEntityData(context.Background(), e, secFields, eDef)
+	sed := app.views.buildSectionEntityData(context.Background(), e, secFields, eDef, "")
 
 	if len(sed.Fields) != 2 {
 		t.Fatalf("Fields: got %d, want 2", len(sed.Fields))

--- a/internal/dataentry/sections_render_test.go
+++ b/internal/dataentry/sections_render_test.go
@@ -1,0 +1,136 @@
+package dataentry
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Sourcehaven-BV/rela/internal/dataentryconfig"
+	"github.com/Sourcehaven-BV/rela/internal/entity"
+)
+
+// TKT-HOIX1: the section builders resolve each field's render mode
+// server-side, so the SPA never reimplements the section→field inheritance.
+
+func TestBuildSectionEntityData_ResolvesRender(t *testing.T) {
+	tests := []struct {
+		name          string
+		sectionRender string
+		fieldRenders  []string // per field, "" = unset
+		want          []string
+	}{
+		{
+			name:         "unset defaults to display",
+			fieldRenders: []string{"", ""},
+			want:         []string{"display", "display"},
+		},
+		{
+			name:         "field opts in",
+			fieldRenders: []string{"input", ""},
+			want:         []string{"input", "display"},
+		},
+		{
+			name:          "section default applies to both",
+			sectionRender: "input",
+			fieldRenders:  []string{"", ""},
+			want:          []string{"input", "input"},
+		},
+		{
+			name:          "field overrides the section default",
+			sectionRender: "input",
+			fieldRenders:  []string{"display", ""},
+			want:          []string{"display", "input"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			app := testViewApp()
+			st := app.State()
+			e := &entity.Entity{
+				ID:         "TKT-001",
+				Type:       "ticket",
+				Properties: map[string]any{"title": "First", "status": "open"},
+			}
+			eDef, _ := st.Meta.GetEntityDef(e.Type)
+			props := []string{"title", "status"}
+			secFields := make([]ViewSectionField, len(props))
+			for i, p := range props {
+				secFields[i] = ViewSectionField{Property: p, Render: tc.fieldRenders[i]}
+			}
+
+			sed := app.views.buildSectionEntityData(
+				context.Background(), e, secFields, eDef, tc.sectionRender)
+
+			if len(sed.Fields) != len(tc.want) {
+				t.Fatalf("got %d fields, want %d", len(sed.Fields), len(tc.want))
+			}
+			for i, want := range tc.want {
+				if got := sed.Fields[i].Render; got != want {
+					t.Errorf("field %q: Render = %q, want %q", props[i], got, want)
+				}
+			}
+		})
+	}
+}
+
+// A synthesized default view (for an entity type with no `views:` entry) sets
+// no Render, so every field resolves to display like any other unset config.
+// This is deliberate: display-by-default holds regardless of whether the view
+// was authored or generated. An operator who wants inline edit on such a type
+// authors an explicit view with `render: input`.
+func TestBuildDefaultViewConfig_RendersDisplayByDefault(t *testing.T) {
+	view, ok := buildDefaultViewConfig(newDefaultViewMetamodel(), "feature")
+	if !ok {
+		t.Fatal("buildDefaultViewConfig(feature) returned !ok")
+	}
+	var propsSection *ViewSection
+	for i := range view.Sections {
+		if view.Sections[i].Display == "properties" {
+			propsSection = &view.Sections[i]
+			break
+		}
+	}
+	if propsSection == nil {
+		t.Fatal("no properties section in the synthesized view")
+	}
+	if propsSection.Render != "" {
+		t.Errorf("section Render = %q, want empty (inherit → display)", propsSection.Render)
+	}
+	for _, f := range propsSection.Fields {
+		if got := resolveFieldRender(propsSection.Render, f.Render); got != dataentryconfig.RenderDisplay {
+			t.Errorf("field %q resolves to %q, want %q", f.Property, got, dataentryconfig.RenderDisplay)
+		}
+	}
+}
+
+// The resolved mode must survive the unnamed struct conversion to the wire
+// type. That conversion (`v1.SectionField(f)`) exists at four call sites and
+// requires SectionFieldData and v1.SectionField to stay field-for-field
+// identical — this asserts the value actually lands on the wire (RR-1V04ZD).
+func TestSectionEntityToV1_CarriesRender(t *testing.T) {
+	app := testViewApp()
+	st := app.State()
+	e := &entity.Entity{
+		ID:         "TKT-001",
+		Type:       "ticket",
+		Properties: map[string]any{"title": "First", "status": "open"},
+	}
+	eDef, _ := st.Meta.GetEntityDef(e.Type)
+	secFields := []ViewSectionField{
+		{Property: "title", Render: "input"},
+		{Property: "status"},
+	}
+
+	sed := app.views.buildSectionEntityData(context.Background(), e, secFields, eDef, "")
+	v1Ent := sectionEntityToV1(sed)
+
+	if len(v1Ent.Fields) != 2 {
+		t.Fatalf("got %d wire fields, want 2", len(v1Ent.Fields))
+	}
+	if got := v1Ent.Fields[0].Render; got != "input" {
+		t.Errorf("title: wire Render = %q, want %q", got, "input")
+	}
+	if got := v1Ent.Fields[1].Render; got != "display" {
+		t.Errorf("status: wire Render = %q, want %q", got, "display")
+	}
+}

--- a/internal/dataentry/sections_span_test.go
+++ b/internal/dataentry/sections_span_test.go
@@ -36,7 +36,7 @@ func TestSectionFieldSpan_SurvivesBothConstructionSites(t *testing.T) {
 	}
 
 	t.Run("buildSectionEntityData (cards/list rows)", func(t *testing.T) {
-		sed := app.views.buildSectionEntityData(context.Background(), e, secFields, eDef)
+		sed := app.views.buildSectionEntityData(context.Background(), e, secFields, eDef, "")
 		assertSpans(t, sed.Fields, map[string]int{"title": 0, "status": 4})
 	})
 
@@ -90,7 +90,7 @@ func TestSectionFieldSpan_ZeroMeansFullWidth(t *testing.T) {
 	eDef, _ := st.Meta.GetEntityDef(e.Type)
 
 	sed := app.views.buildSectionEntityData(
-		context.Background(), e, []ViewSectionField{{Property: "title"}}, eDef)
+		context.Background(), e, []ViewSectionField{{Property: "title"}}, eDef, "")
 
 	if len(sed.Fields) != 1 {
 		t.Fatalf("got %d fields, want 1", len(sed.Fields))

--- a/internal/dataentryconfig/config.go
+++ b/internal/dataentryconfig/config.go
@@ -790,11 +790,27 @@ type ViewTraverse struct {
 	Where          string `yaml:"where,omitempty" json:"where,omitempty"`
 }
 
+// Render modes for view section fields (TKT-HOIX1). A field renders as a
+// view-oriented display value unless it opts in to inline editing.
+//
+// RenderInput is an opt-in to *presentation*, not a grant: the ACL verdict
+// still decides writability, so `render: input` on a read-only field renders
+// display. Config can downgrade an editable field, never upgrade a
+// read-only one.
+const (
+	RenderDisplay = "display"
+	RenderInput   = "input"
+)
+
 // ViewSection defines a section within a view.
+//
+// Render sets the default render mode for this section's fields; an
+// individual field's own Render overrides it. Empty means RenderDisplay.
 type ViewSection struct {
 	Heading      string             `yaml:"heading,omitempty" json:"heading,omitempty"`
 	Source       string             `yaml:"source" json:"source"`
 	Display      string             `yaml:"display" json:"display"`
+	Render       string             `yaml:"render,omitempty" json:"render,omitempty"`
 	Fields       []ViewSectionField `yaml:"fields,omitempty" json:"fields,omitempty"`
 	Columns      []ListColumn       `yaml:"columns,omitempty" json:"columns,omitempty"`
 	GroupBy      string             `yaml:"group_by,omitempty" json:"group_by,omitempty"`
@@ -809,10 +825,30 @@ type ViewSection struct {
 // width, so a section with no spans authored reads as one scannable column.
 // Adjacency is therefore always DECLARED: two fields share a row because an
 // author said so, never because a viewport happened to fit them.
+//
+// Render is resolved server-side against the containing section — see
+// ResolveFieldRender — so consumers receive an already-resolved value and
+// never reimplement the inheritance rule.
 type ViewSectionField struct {
 	Property string `yaml:"property" json:"property"`
 	Label    string `yaml:"label,omitempty" json:"label,omitempty"`
 	Span     Span   `yaml:"span,omitempty" json:"span,omitempty"`
+	Render   string `yaml:"render,omitempty" json:"render,omitempty"`
+}
+
+// ResolveFieldRender returns the effective render mode for a field within a
+// section: the field's own Render, else the section's, else RenderDisplay.
+//
+// Single source of truth for the inheritance rule — both section builders
+// call this so they cannot drift.
+func ResolveFieldRender(sectionRender, fieldRender string) string {
+	if fieldRender != "" {
+		return fieldRender
+	}
+	if sectionRender != "" {
+		return sectionRender
+	}
+	return RenderDisplay
 }
 
 // CommandConfig defines an executable command triggered from the UI.

--- a/internal/dataentryconfig/render_test.go
+++ b/internal/dataentryconfig/render_test.go
@@ -1,0 +1,238 @@
+package dataentryconfig
+
+import (
+	"strings"
+	"testing"
+)
+
+// TKT-HOIX1: view section fields render as a view-oriented display value
+// unless they opt in to inline edit with `render: input`.
+
+func TestResolveFieldRender(t *testing.T) {
+	tests := []struct {
+		name          string
+		sectionRender string
+		fieldRender   string
+		want          string
+	}{
+		{
+			name: "both unset defaults to display (the breaking-change default)",
+			want: RenderDisplay,
+		},
+		{
+			name:        "field opts in",
+			fieldRender: RenderInput,
+			want:        RenderInput,
+		},
+		{
+			name:          "section default applies when the field is unset",
+			sectionRender: RenderInput,
+			want:          RenderInput,
+		},
+		{
+			name:          "field overrides an opted-in section",
+			sectionRender: RenderInput,
+			fieldRender:   RenderDisplay,
+			want:          RenderDisplay,
+		},
+		{
+			name:          "field overrides a display section",
+			sectionRender: RenderDisplay,
+			fieldRender:   RenderInput,
+			want:          RenderInput,
+		},
+		{
+			name:          "same value on both is a no-op",
+			sectionRender: RenderInput,
+			fieldRender:   RenderInput,
+			want:          RenderInput,
+		},
+		{
+			name:          "empty field render is 'inherit', not a value",
+			sectionRender: RenderInput,
+			fieldRender:   "",
+			want:          RenderInput,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := ResolveFieldRender(tc.sectionRender, tc.fieldRender); got != tc.want {
+				t.Errorf("ResolveFieldRender(%q, %q) = %q, want %q",
+					tc.sectionRender, tc.fieldRender, got, tc.want)
+			}
+		})
+	}
+}
+
+// renderConfig builds a config with one view whose single section carries the
+// given render settings. sourceKnown=false makes the section reference an
+// unknown collection, which is the RR-4ICH8M regression case.
+func renderConfig(sectionRender, fieldRender, display string, sourceKnown bool) *Config {
+	source := "entry"
+	if !sourceKnown {
+		source = "no_such_collection"
+	}
+	return &Config{
+		Version: "1.0",
+		App:     AppConfig{Name: "Test App"},
+		Views: map[string]ViewConfig{
+			"ticket_view": {
+				Title: "Ticket",
+				Entry: ViewEntry{Type: "ticket"},
+				Sections: []ViewSection{{
+					Heading: "Details",
+					Source:  source,
+					Display: display,
+					Render:  sectionRender,
+					Fields: []ViewSectionField{
+						{Property: "status", Label: "Status", Render: fieldRender},
+					},
+				}},
+			},
+		},
+	}
+}
+
+func TestValidateConfig_RenderMode(t *testing.T) {
+	tests := []struct {
+		name        string
+		section     string
+		field       string
+		sourceKnown bool
+		wantErr     string // substring; empty means no error expected
+	}{
+		{name: "valid input on field", field: RenderInput, sourceKnown: true},
+		{name: "valid display on field", field: RenderDisplay, sourceKnown: true},
+		{name: "valid section-level render", section: RenderInput, sourceKnown: true},
+		{name: "both unset", sourceKnown: true},
+		{
+			name:        "invalid field render",
+			field:       "bogus",
+			sourceKnown: true,
+			wantErr:     `section[0] field[0] has invalid render mode "bogus"`,
+		},
+		{
+			name:        "invalid section render",
+			section:     "bogus",
+			sourceKnown: true,
+			wantErr:     `section[0] has invalid render mode "bogus"`,
+		},
+		{
+			// RR-4ICH8M: the per-field property loops sit inside
+			// source-resolution guards. `render` is a closed enum needing no
+			// metamodel knowledge, so it must be validated regardless.
+			name:        "invalid field render is caught when the source does not resolve",
+			field:       "bogus",
+			sourceKnown: false,
+			wantErr:     `section[0] field[0] has invalid render mode "bogus"`,
+		},
+		{
+			name:        "invalid section render is caught when the source does not resolve",
+			section:     "bogus",
+			sourceKnown: false,
+			wantErr:     `section[0] has invalid render mode "bogus"`,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := renderConfig(tc.section, tc.field, "properties", tc.sourceKnown)
+			err := ValidateConfig([]byte(`version: "1.0"`), cfg, testMetamodel())
+			if tc.wantErr == "" {
+				if err != nil && strings.Contains(err.Error(), "render mode") {
+					t.Fatalf("unexpected render-mode error: %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("expected error containing %q, got nil", tc.wantErr)
+			}
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Errorf("error %q does not contain %q", err.Error(), tc.wantErr)
+			}
+			// The message must name the valid values so the operator can fix
+			// it without reading the source ("config is not a secret").
+			listsModes := strings.Contains(err.Error(), RenderInput) &&
+				strings.Contains(err.Error(), RenderDisplay)
+			if !listsModes {
+				t.Errorf("error %q should list the valid render modes", err.Error())
+			}
+		})
+	}
+}
+
+// RR-675AA0: `render` on a display mode that never renders fields is inert.
+// Warn rather than error — switching a section's display mode mid-edit should
+// not be a hard config-load failure.
+func TestCollectConfigWarnings_InertSectionRender(t *testing.T) {
+	tests := []struct {
+		name     string
+		display  string
+		section  string
+		field    string
+		wantWarn bool
+	}{
+		{name: "properties honors render", display: "properties", section: RenderInput},
+		{name: "list honors render", display: "list", field: RenderInput},
+		{name: "cards honors render", display: "cards", field: RenderInput},
+		{name: "table does not render fields", display: "table", section: RenderInput, wantWarn: true},
+		{name: "content does not render fields", display: "content", field: RenderInput, wantWarn: true},
+		{name: "table without render is silent", display: "table"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := renderConfig(tc.section, tc.field, tc.display, true)
+			warnings := CollectConfigWarnings(cfg, testMetamodel())
+			var got string
+			for _, w := range warnings {
+				if strings.Contains(w, "render:") {
+					got = w
+					break
+				}
+			}
+			if tc.wantWarn && got == "" {
+				t.Fatalf("expected an inert-render warning for display %q, got %v", tc.display, warnings)
+			}
+			if !tc.wantWarn && got != "" {
+				t.Errorf("unexpected inert-render warning for display %q: %s", tc.display, got)
+			}
+			if tc.wantWarn && !strings.Contains(got, tc.display) {
+				t.Errorf("warning %q should name the display mode %q", got, tc.display)
+			}
+		})
+	}
+}
+
+// The warning must name the precise origin — a section-level `render:` reports
+// the section, a field-level one reports the field index — so an operator with
+// a long `fields:` list isn't left scanning for it.
+func TestCollectConfigWarnings_InertSectionRenderNamesOrigin(t *testing.T) {
+	t.Run("section-level names the section", func(t *testing.T) {
+		cfg := renderConfig(RenderInput, "", "table", true)
+		got := firstRenderWarning(t, cfg)
+		if !strings.Contains(got, "section[0] sets render:") {
+			t.Errorf("warning %q should name section[0]", got)
+		}
+		if strings.Contains(got, "field[") {
+			t.Errorf("warning %q should not name a field when the section is the cause", got)
+		}
+	})
+
+	t.Run("field-level names the field index", func(t *testing.T) {
+		cfg := renderConfig("", RenderInput, "table", true)
+		got := firstRenderWarning(t, cfg)
+		if !strings.Contains(got, "section[0] field[0] sets render:") {
+			t.Errorf("warning %q should name section[0] field[0]", got)
+		}
+	})
+}
+
+func firstRenderWarning(t *testing.T, cfg *Config) string {
+	t.Helper()
+	for _, w := range CollectConfigWarnings(cfg, testMetamodel()) {
+		if strings.Contains(w, "render:") {
+			return w
+		}
+	}
+	t.Fatal("expected an inert-render warning, got none")
+	return ""
+}

--- a/internal/dataentryconfig/validate.go
+++ b/internal/dataentryconfig/validate.go
@@ -85,6 +85,51 @@ var validSectionDisplayModes = map[string]bool{
 	"breakdown":  true,
 }
 
+// Valid render modes for a view section and its fields (TKT-HOIX1). Empty is
+// also accepted everywhere and means "inherit", resolving to RenderDisplay.
+var validSectionRenderModes = map[string]bool{
+	RenderDisplay: true,
+	RenderInput:   true,
+}
+
+// Section display modes that actually render `fields`. `render` on any other
+// mode is inert — warned about, not rejected (RR-675AA0), so switching a
+// section's display mode mid-edit isn't a hard config-load failure.
+//
+// `content` is deliberately absent even though the server BUILDS fields for it:
+// a traverse-sourced content section shares a builder arm with `cards`
+// (`sections.go`, `case "content", "cards":`), so its rows carry resolved
+// SectionFieldData on the wire. The SPA's content-card template renders only
+// the markdown body and ignores them, so those fields are inert payload. This
+// map tracks what is RENDERED, which is what an operator setting `render:`
+// cares about — not what the builder happens to populate. Do not "fix" the
+// mismatch by adding `content` here; that would suppress a warning the
+// operator needs.
+var sectionDisplayModesRenderingFields = map[string]bool{
+	"properties": true,
+	"list":       true,
+	"cards":      true,
+}
+
+// validateSectionRender checks the section-level `render:` and each field's,
+// independently of whether the section's source resolves (RR-4ICH8M).
+func validateSectionRender(viewID string, i int, s ViewSection) []string {
+	var errs []string
+	if s.Render != "" && !validSectionRenderModes[s.Render] {
+		errs = append(errs, fmt.Sprintf(
+			"view %q: section[%d] has invalid render mode %q (valid: %s)",
+			viewID, i, s.Render, joinMapKeys(validSectionRenderModes)))
+	}
+	for j, f := range s.Fields {
+		if f.Render != "" && !validSectionRenderModes[f.Render] {
+			errs = append(errs, fmt.Sprintf(
+				"view %q: section[%d] field[%d] has invalid render mode %q (valid: %s)",
+				viewID, i, j, f.Render, joinMapKeys(validSectionRenderModes)))
+		}
+	}
+	return errs
+}
+
 // Valid display modes for dashboard cards
 var validDashboardDisplayModes = map[string]bool{
 	"count":     true,
@@ -711,6 +756,51 @@ func CollectConfigWarnings(cfg *Config, meta *metamodel.Metamodel) []string {
 	warnings = append(warnings, conflictingRelationDirectionWarnings(cfg)...)
 	warnings = append(warnings, relationPropertyNameCollisionWarnings(cfg, meta)...)
 	warnings = append(warnings, viewCommandPermissionWarnings(cfg)...)
+	warnings = append(warnings, inertSectionRenderWarnings(cfg)...)
+	return warnings
+}
+
+// inertSectionRenderWarnings flags `render:` on a section whose display mode
+// does not render fields at all (`table` uses `columns:`; `content` renders the
+// body) — the key is silently inert there (RR-675AA0). Warn rather than error,
+// for the same reason as viewCommandPermissionWarnings: the config is not
+// wrong, and switching a section's display mode should not be a hard failure.
+func inertSectionRenderWarnings(cfg *Config) []string {
+	var warnings []string
+	viewIDs := make([]string, 0, len(cfg.Views))
+	for id := range cfg.Views {
+		viewIDs = append(viewIDs, id)
+	}
+	sort.Strings(viewIDs)
+	for _, viewID := range viewIDs {
+		for i, s := range cfg.Views[viewID].Sections {
+			if sectionDisplayModesRenderingFields[s.Display] {
+				continue
+			}
+			// Name the precise origin — section-level, or the first offending
+			// field index — so the operator isn't left scanning a long
+			// `fields:` list. Matches the precision validateSectionRender's
+			// errors already set.
+			origin := ""
+			if s.Render != "" {
+				origin = fmt.Sprintf("section[%d]", i)
+			} else {
+				for j, f := range s.Fields {
+					if f.Render != "" {
+						origin = fmt.Sprintf("section[%d] field[%d]", i, j)
+						break
+					}
+				}
+			}
+			if origin == "" {
+				continue
+			}
+			warnings = append(warnings, fmt.Sprintf(
+				"view %q: %s sets render: on display mode %q, which does not render fields; "+
+					"the setting has no effect (it applies to: %s)",
+				viewID, origin, s.Display, joinMapKeys(sectionDisplayModesRenderingFields)))
+		}
+	}
 	return warnings
 }
 
@@ -991,6 +1081,13 @@ func validateViews(cfg *Config, meta *metamodel.Metamodel) []string {
 				errs = append(errs, validateSpan(f.Span,
 					fmt.Sprintf("view %q: section[%d] field[%d]", viewID, i, j))...)
 			}
+
+			// Validate render modes (TKT-HOIX1). Deliberately OUTSIDE the
+			// source-resolution guards below: `render` is a closed enum needing
+			// no metamodel knowledge, so a section whose source doesn't resolve
+			// must still have it checked (RR-4ICH8M). The per-field loops below
+			// also never see the section-level value.
+			errs = append(errs, validateSectionRender(viewID, i, s)...)
 
 			// Validate fields (if source type is known)
 			if sourceType != "" { //nolint:nestif // nested guards each check a distinct optional field of the source config.

--- a/prototypes/data-entry/project/data-entry.yaml
+++ b/prototypes/data-entry/project/data-entry.yaml
@@ -380,6 +380,7 @@ views:
       - heading: "Category"
         source: entry
         display: properties
+        render: input
         fields:
           - property: name
           - property: description
@@ -409,6 +410,7 @@ views:
       - heading: "Labels Used"
         source: labels
         display: list
+        render: input
         fields:
           - property: name
         empty_message: "No labels applied"
@@ -434,6 +436,7 @@ views:
       - heading: "Ticket"
         source: entry
         display: properties
+        render: input
         fields:
           # `span` places a field on the 12-column grid; omit it for full
           # width (the default). Grouping is DECLARED here, not left to
@@ -477,6 +480,7 @@ views:
       - heading: "Blocked By"
         source: blocked_by
         display: cards
+        render: input
         fields:
           - property: status
           - property: priority
@@ -486,6 +490,7 @@ views:
       - heading: "Labels"
         source: labels
         display: list
+        render: input
         fields:
           - property: name
         empty_message: "No labels"

--- a/tickets/data-entry.yaml
+++ b/tickets/data-entry.yaml
@@ -958,6 +958,7 @@ views:
       - heading: "Idea"
         source: entry
         display: properties
+        render: input
         fields:
           - property: category
           - property: status
@@ -969,11 +970,13 @@ views:
       - heading: "Notes"
         source: entry
         display: properties
+        render: input
         fields:
           - property: notes
       - heading: "Related Ideas"
         source: related
         display: cards
+        render: input
         fields:
           - property: category
           - property: status
@@ -981,6 +984,7 @@ views:
       - heading: "Inspires"
         source: inspires
         display: cards
+        render: input
         fields:
           - property: status
         empty_message: "Not linked to features or concepts"
@@ -995,6 +999,7 @@ views:
       - heading: "Promoted To"
         source: promoted
         display: cards
+        render: input
         fields:
           - property: status
         empty_message: "Not yet promoted"
@@ -1022,6 +1027,7 @@ views:
       - heading: "Future Concept"
         source: entry
         display: properties
+        render: input
         fields:
           - property: status
           - property: effort
@@ -1031,21 +1037,25 @@ views:
       - heading: "Rationale"
         source: entry
         display: properties
+        render: input
         fields:
           - property: rationale
       - heading: "Challenges"
         source: entry
         display: properties
+        render: input
         fields:
           - property: challenges
       - heading: "Prerequisites"
         source: entry
         display: properties
+        render: input
         fields:
           - property: prerequisites
       - heading: "Based On Ideas"
         source: ideas
         display: cards
+        render: input
         fields:
           - property: category
           - property: status
@@ -1053,6 +1063,7 @@ views:
       - heading: "Extends Concepts"
         source: extends
         display: list
+        render: input
         fields:
           - property: layer
           - property: status
@@ -1060,18 +1071,21 @@ views:
       - heading: "Would Enable Features"
         source: enables
         display: list
+        render: input
         fields:
           - property: status
         empty_message: "No features would be enabled"
       - heading: "Would Replace"
         source: replaces
         display: list
+        render: input
         fields:
           - property: status
         empty_message: "Does not replace anything"
       - heading: "Blocked By"
         source: blockers
         display: cards
+        render: input
         fields:
           - property: status
         empty_message: "No blockers"
@@ -1099,6 +1113,7 @@ views:
       - heading: "Feature"
         source: entry
         display: properties
+        render: input
         fields:
           - property: status
           - property: priority
@@ -1108,6 +1123,7 @@ views:
       - heading: "Required Concepts"
         source: concepts
         display: list
+        render: input
         fields:
           - property: layer
           - property: status
@@ -1134,6 +1150,7 @@ views:
       - heading: "Tests"
         source: tests
         display: list
+        render: input
         fields:
           - property: kind
           - property: status
@@ -1141,6 +1158,7 @@ views:
       - heading: "Inspired By Ideas"
         source: ideas
         display: cards
+        render: input
         fields:
           - property: category
           - property: status
@@ -1169,6 +1187,7 @@ views:
       - heading: "Concept"
         source: entry
         display: properties
+        render: input
         fields:
           - property: layer
           - property: package
@@ -1179,6 +1198,7 @@ views:
       - heading: "Governed By Decisions"
         source: decisions
         display: cards
+        render: input
         fields:
           - property: status
           - property: date
@@ -1186,6 +1206,7 @@ views:
       - heading: "Required By Features"
         source: features
         display: list
+        render: input
         fields:
           - property: status
           - property: priority
@@ -1202,6 +1223,7 @@ views:
       - heading: "Test Coverage"
         source: tests
         display: list
+        render: input
         fields:
           - property: kind
           - property: status
@@ -1209,6 +1231,7 @@ views:
       - heading: "Future Extensions"
         source: future_extensions
         display: cards
+        render: input
         fields:
           - property: status
           - property: effort

--- a/tickets/entities/docs-checklists/DOCS-RW5H28.md
+++ b/tickets/entities/docs-checklists/DOCS-RW5H28.md
@@ -1,0 +1,65 @@
+---
+id: DOCS-RW5H28
+type: docs-checklist
+title: 'Docs: View section fields render as display by default; opt in to inline edit with `render: input`'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Code Documentation
+
+- [x] Godoc / comments on new exported symbols
+- [x] Non-obvious decisions explained at the point of the decision
+- [x] "Keep in sync" hazards documented where they exist
+
+`ResolveFieldRender`, `RenderDisplay`/`RenderInput`, and the `Render` fields on
+`ViewSection` / `ViewSectionField` all carry godoc. The load-bearing hazards are
+documented where a future editor will actually hit them:
+
+- `v1.SectionField` and `dataentry.SectionFieldData` each carry a KEEP IN SYNC comment naming
+the other and listing all four unnamed-conversion sites.
+- The `writable` conjunct in `SectionEditForm.vue` explains why it is a conjunction, why it is
+applied at that site only, and why `render` must not go through
+`isFieldWritable`'s `fieldReadonly` parameter (RR-PGGRBD).
+- `sectionShouldRouteToInlineEdit` explains why its predicate must match `widgetRows`.
+- `sectionDisplayModesRenderingFields` documents why `content` is deliberately absent despite
+the builder populating fields for it, and warns against "fixing" it (RR-VBJ91V).
+- `entryDisplayValue` explains the staleness it prevents and why the default flip made it
+reachable (RR-GLK4UY).
+- `isLongValue` states exactly what is and isn't shared with `PropertyDisplay.isLong`
+(RR-1SNYI1).
+
+## Project Documentation
+
+- [x] `docs/data-entry.md` updated
+- [x] Breaking change documented
+- [x] ~~docs/metamodel.md~~ (N/A: `data-entry.yaml` config, not metamodel)
+- [x] ~~docs/cli-reference.md~~ (N/A: no command changes)
+- [x] ~~CLAUDE.md~~ (N/A: no new architectural pattern; the change follows existing ones)
+
+`docs/data-entry.md` gained:
+- a `render` row in the section options table and a new per-field options table
+- a "Field Render Modes" section with before/after YAML for both field- and section-level use
+- the rule that `render: input` cannot upgrade an ACL-read-only field
+- which display modes honour `render`, and that the side panel ignores it
+- a breaking-change blockquote naming the migration action
+- a correction to the stale line describing views as "read-only detail pages"
+
+## External Documentation
+
+- [x] ~~Changelog / release notes~~ (N/A: this repo has no `CHANGELOG.md`, upgrade-notes, or
+release-notes file — verified with `find`. Creating one solely for this ticket
+would establish a surface the project has never maintained. See RR-H39SEJ.)
+- [x] ~~README~~ (N/A: not a project-level change)
+
+## Migration Guidance
+
+- [x] Migration path documented for existing configs
+- [x] In-repo configs migrated as a worked example
+
+Operators add `render: input` to fields (or once per section) they want to keep
+editable. The in-repo migration demonstrates the recommended granularity:
+section-level `render: input` on each `properties`/`cards`/`list` section — 23
+sections in `tickets/data-entry.yaml`, 5 in `prototypes/data-entry/project`, and
+none on `table`/`content` sections where it would be inert.

--- a/tickets/entities/implementation-checklists/IMPL-BQ6OHC.md
+++ b/tickets/entities/implementation-checklists/IMPL-BQ6OHC.md
@@ -1,0 +1,103 @@
+---
+id: IMPL-BQ6OHC
+type: implementation-checklist
+title: 'Implementation: View section fields render as display by default; opt in to inline edit with `render: input`'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Development
+
+- [x] Unit tests written for new code
+- [x] Integration tests written (test full flow, not just units)
+- [x] Happy path implemented
+- [x] Edge cases from planning handled
+- [x] Error handling in place (errors surfaced, not swallowed)
+
+18 new tests: 12 frontend (`sectionEditFields.test.ts`,
+`SectionEditForm.test.ts`), 6 Go table-driven (`render_test.go`,
+`sections_render_test.go`). Full-stack verification ran against a live server
+and the full Playwright suite — see Manual Verification.
+
+## Test Quality
+
+- [x] Using fixture builders or factories for test data
+- [x] No hardcoded values in assertions when object is in scope
+- [x] Only specifying values that matter for the test
+- [x] Interpolated values constructed from objects, not hardcoded
+- [x] Property comparisons use original object, not hardcoded strings
+
+Existing `makeFields()` / `makeRow()` factories were extended with `render:
+'input'` rather than duplicated, so the pre-existing suites keep exercising the
+edit path they were written for while the new default is covered by dedicated
+cases.
+
+## Manual Verification
+
+- [x] Feature manually tested end-to-end
+- [x] Each acceptance criterion verified with test scenario from planning
+- [x] Edge cases manually verified
+
+**Verification Evidence:**
+
+Ran `rela-server --project tickets` and queried the live API (CSRF origin header
+required):
+
+1. **Configured + migrated view** (`_views/feature/FEAT-72NR1`) → `status`, `priority`,
+`summary` all emit `render: 'input'`. Section-level `render:` inheritance works
+on the wire.
+2. **Synthesized default view** (`_views/ticket/TKT-HOIX1`, no `views:` entry) → `title`,
+`kind`, `priority` all emit `render: 'display'`.
+3. **Inert-mode warning** — temporarily added `render: input` to a `display: table` section;
+server logged: `view "feature": section[3] sets render: on display mode "table",
+which does not render fields; the setting has no effect (it applies to: cards,
+list, properties)`. Config restored afterwards.
+4. **Config validation** — `rela --project tickets validate` passes on the migrated config.
+Note the CLI `validate` command does NOT surface warnings; only the data-entry
+server does (`app.go:654`). Worth knowing for anyone verifying warning
+behaviour.
+5. **E2E — the #997 regression guard passes.** `entity-detail-list-unmount.spec.ts` asserts a
+`.section-edit-form` mounts inside a `display: list` row; it passes with the
+migrated fixture, proving the section still mounts an inline-edit form and the
+unmount crash path is still exercised rather than passing vacuously.
+
+Browser-level *visual* confirmation was not done — the Chrome extension was not
+connected in this environment. Rendered-DOM behaviour is covered by the
+component tests (display arm renders a bare widget with `mode="display"` and no
+`.form-field` chrome) and by the e2e suite, but no human has looked at the page.
+
+## Quality
+
+- [x] Code follows project patterns (check similar code)
+- [x] Checked for DRY opportunities
+- [x] No security issues introduced
+- [x] No silent failures (errors logged AND returned)
+- [x] No debug code left behind
+
+DRY: one `ResolveFieldRender` helper owns the field→section→display inheritance
+rule, called from both section builders (which previously duplicated their
+label-fallback logic and would have duplicated this too). Re-exported into
+`dataentry` as `resolveFieldRender` following the package's existing type-alias
+convention rather than adding an import.
+
+Security: `writable = render === 'input' && isFieldWritable(verdict)` — a
+conjunction, applied at the `widgetRows` site only. Config downgrades
+editability and can never upgrade it past the ACL; pinned by a dedicated test.
+The `render` flag is kept off `verdict` so the flip-watcher cannot misread a
+config change as a revoked permission (RR-PGGRBD).
+
+## Pipeline
+
+| Check | Result |
+|---|---|
+| `go build ./...` | pass |
+| `go vet` (changed pkgs) | pass |
+| `go test ./...` | pass — 80 packages, exit 0 |
+| `golangci-lint run ./...` | **0 issues** (full repo) |
+| `just arch-lint` | OK — no warnings |
+| `just coverage-check` | pass — 76.9% total, all floors satisfied |
+| `npm run test:run` | pass — 1488 tests / 90 files (was 1470) |
+| `npm run typecheck` | pass |
+| `npm run lint` | 0 errors (90 pre-existing warnings, untouched files) |
+| `npx playwright test` | **pass — 231 passed, 0 failed** (8 skipped: postgres-gated history specs) |

--- a/tickets/entities/planning-checklists/PLAN-6RDYUL.md
+++ b/tickets/entities/planning-checklists/PLAN-6RDYUL.md
@@ -1,0 +1,203 @@
+---
+id: PLAN-6RDYUL
+type: planning-checklist
+title: 'Planning: View section fields render as display by default; opt in to inline edit with `render: input`'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+> **Post-implementation correction (RR-H39SEJ).** The Documentation Planning section below
+> originally checked off "Changelog / upgrade notes". No `CHANGELOG.md` or upgrade-notes file
+> exists in this repo and none was created — the breaking change is documented in
+> `docs/data-entry.md` instead. That checkbox has been corrected to say so rather than imply an
+> artifact that does not exist.
+
+## Understanding
+
+- [x] Problem/requirements clearly understood
+- [x] Scope defined (what's in/out documented below)
+- [x] Acceptance criteria documented with specific test scenarios
+
+**Scope:**
+
+IN:
+- `ViewSectionField.render: input | display` (default `display`) in `data-entry.yaml`.
+- `ViewSection.render` as a section-wide default that contained fields override.
+- Config validation of the enum, unconditional (RR-4ICH8M).
+- Threading through the Go wire type to the SPA and into `SectionEditForm`'s per-field branch.
+- Updating the e2e fixture that depends on default-editable (RR-UQ2MIV).
+- The breaking-change default flip, documented in `docs/data-entry.md`.
+
+OUT:
+- `widget:` override — split to TKT-3R7RF3.
+- Markdown / relation display rendering (no registry widgets exist).
+- Any change to `FormField` / `DynamicForm` (the create/edit form path). Forms stay editable
+by default. Confirmed with the requester.
+- Side-panel inline edit: `SidePanel.vue` receives but ignores `render` (RR-4O96FZ).
+- No `internal/migration` step. Breaking change accepted deliberately.
+
+**Acceptance Criteria:**
+
+1. A field with no `render:` renders as a display value, even when the ACL says writable.
+2. `render: input` renders the editable inline widget, unchanged from today.
+3. `render: input` on an ACL-read-only field still renders display. **Security-critical.**
+4. Section `render:` sets the default; a field-level `render:` overrides it.
+5. Invalid `render:` is a config error naming view + section index (+ field index for a
+field-level value), **including when the section's source type does not
+resolve**.
+6. After a `render: input` field is edited, a sibling `render: display` field shows its correct
+value.
+7. A status/machine field with `render: display` renders the display arm, not a disabled
+`StatusControl`.
+8. Changing a field to display does not fire the "Permission changed" toast.
+9. An all-display section does not mount a `SectionEditForm`.
+10. `render` on a `display: table` / `content` section produces a validation warning naming
+the mode and the precise origin (RR-675AA0, RR-1SNYI1).
+
+## Research
+
+- [x] For larger features: run `/research` to create a structured research doc
+- [x] Searched for existing libraries that solve this problem
+- [x] Checked codebase for similar patterns or reusable code
+- [x] Looked for reference implementations in other projects
+- [x] Reviewed relevant rela concepts for prior art
+
+**Research Doc:** N/A — the approach is fully determined by existing code.
+
+**Existing Solutions:**
+
+- **The display rendering already existed.** `SectionEditForm.vue` branches per field three
+ways; the third arm is a bare widget in `mode="display"` with no form chrome,
+already in production via ACL verdicts. This ticket feeds config into that
+branch.
+- **Cards/list rows already mount `SectionEditForm`** behind a tight gate (`_props`, ≤100 rows,
+no inaccessible field, ≥1 writable field) — rarely satisfied, so cards usually
+fall to the display path.
+- **Prior art to avoid:** `FormField.readonly` → `FieldRenderer.vue:82` renders a *disabled
+input*. Frontend-only; `readonly:` in YAML is silently dropped today.
+- Prior tickets: TKT-IHC7B, TKT-IHC7C, TKT-IHC7D, TKT-3G93B8, BUG-9QL9XV, #997.
+
+## Approach
+
+- [x] Technical approach chosen and documented
+- [x] Approach builds on existing patterns (not reinventing)
+- [x] Alternatives considered (document why rejected)
+- [x] Dependencies identified (packages, APIs, types)
+
+**Technical Approach:**
+
+Add `Render` to the view-section config structs, resolve it server-side, thread
+it to the SPA, and use it as one conjunct on the existing `writable`
+computation.
+
+Resolution order: field → section → `display`, resolved server-side by one
+shared helper (`ResolveFieldRender`) called from both builders.
+
+Effective editability: `render === 'input' && isFieldWritable(verdict)`. Config
+downgrades only; the ACL remains the authority. No new write path.
+
+Alternatives rejected: bool `editable` (cannot grow a third mode); reusing
+`FormField.readonly` (wrong semantics, wrong struct); resolving inheritance in
+the SPA (duplicates the rule); splitting a view-specific wire type (RR-4O96FZ);
+emitting render once per section (RR-9S63SJ).
+
+**Files modified:** `internal/dataentryconfig/{config,validate}.go`,
+`internal/dataentry/{config,sections}.go`, `internal/apiwire/v1/responses.go`,
+`frontend/src/api/views.ts`,
+`frontend/src/components/entity/{sectionEditFields.ts,EntityDetail.vue}`,
+`frontend/src/components/forms/SectionEditForm.vue`, `e2e/tests/fixtures.ts`,
+`docs/data-entry.md`, plus the two in-repo config migrations.
+
+## Security Considerations
+
+- [x] Input sources identified (user input, config, external APIs)
+- [x] Input validation approach defined (allowlist preferred over blocklist)
+- [x] Security-sensitive operations identified (file access, auth, crypto)
+- [x] Error handling doesn't leak sensitive information
+
+**Input Sources & Validation:**
+
+`render:` is operator-authored config, validated with an **allowlist** (`input`,
+`display`; empty = inherit). Invalid values fail config load with a message
+naming the view, section index, field index, and the valid set. No user-supplied
+input reaches this field; it never becomes a selector, path, or command.
+
+**Security-Sensitive Operations:**
+
+- **The ACL conjunction** — `writable = render === 'input' && isFieldWritable(verdict)`, that
+order, never a disjunction. Pinned by AC 3 at both the predicate and component
+level.
+- **Do not pass `render` as `isFieldWritable`'s `fieldReadonly` parameter** (RR-PGGRBD).
+- Write enforcement unchanged; the server re-authorizes every PATCH. Presentation-only change.
+- The inaccessible (git-crypt) guard stays ahead of the render check.
+
+## Test Plan
+
+- [x] Test scenarios documented for each acceptance criterion
+- [x] Edge cases identified and documented
+- [x] Negative test cases defined (invalid input, error conditions)
+- [x] Integration test approach defined (not just unit tests)
+
+**Delivered:** 18 unit tests (12 frontend, 6 Go) + **4 e2e specs** in
+`e2e/tests/view-section-render-mode.spec.ts` covering the mixed-render page, the
+display arm's absence of form controls, the current-value guard, and the
+editable opt-in (RR-5KFD7W).
+
+**Edge Cases covered:** `render: ""` → inherit; section+field same value; no
+verdict (`isFieldWritable(undefined) === true`); all-display + inaccessible;
+cards/list rows via `rowShouldRouteToInlineEdit`; zero-field sections;
+`title`/`id` pseudo-properties; long text.
+
+## Risk Assessment
+
+- [x] Technical risks assessed with mitigations
+- [x] Security risks assessed (see Security Considerations)
+- [x] Effort estimated (xs/s/m/l/xl)
+
+**Risks:**
+
+1. **Breaking change.** Accepted. In-repo configs migrated (28 sections). Documented in
+`docs/data-entry.md`.
+2. **`v1.SectionField(f)` at FOUR sites** (RR-1V04ZD) — compile-checked; all four confirmed.
+3. **Spurious "Permission changed" toast** (RR-PGGRBD) — `render` kept off `verdict`. AC 8.
+4. **Two builders drift** — one shared `ResolveFieldRender` helper.
+5. **Long-text layout** — `isLong` + CSS ported; comment corrected per RR-1SNYI1.
+6. **Test-fixture breakage** — #997 guard fixture updated; verified passing.
+7. **Display-value staleness** (RR-GLK4UY, found at code review) — the default flip made a
+previously-unreachable stale-mirror read the common path. Fixed with
+`entryDisplayValue`.
+
+**Effort:** m.
+
+## Documentation Planning
+
+- [x] User-facing docs identified (skip if internal refactor)
+- [x] Docs-checklist will be created when entering implementation
+
+**Documentation Impact:**
+
+- [x] `docs/data-entry.md` — new "Field Render Modes" section with before/after YAML, the
+section/field option tables, the ACL rule, which display modes honour it, and a
+breaking-change blockquote. Stale "read-only detail pages" line corrected.
+- [x] ~~Changelog / upgrade notes~~ (N/A: this repo has no `CHANGELOG.md`, upgrade-notes, or
+release-notes file — verified. The breaking change is documented in
+`docs/data-entry.md`, which is where this project documents config. See
+RR-H39SEJ.)
+- [x] ~~docs/metamodel.md~~ (N/A: `data-entry.yaml` config, not metamodel)
+- [x] ~~docs/cli-reference.md~~ (N/A: no command changes)
+- [x] ~~CLAUDE.md~~ (N/A: no new architectural pattern)
+- [x] ~~README.md~~ (N/A: not project-level)
+
+## Design Review
+
+- [x] Run `/design-review` before starting implementation
+- [x] All critical/significant findings addressed in plan
+
+**Design Review Findings:** RR-1V04ZD, RR-8EISWO, RR-UQ2MIV, RR-4ICH8M
+(significant); RR-4O96FZ, RR-9S63SJ, RR-675AA0, RR-PGGRBD (minor). All
+addressed.
+
+**Code Review Findings (post-implementation):** RR-GLK4UY (critical, fixed);
+RR-5KFD7W, RR-TIUKMA (significant, fixed); RR-H39SEJ (significant, wont-fix with
+reason); RR-VBJ91V, RR-1SNYI1 (minor/nit, addressed).

--- a/tickets/entities/review-checklists/REV-4QL8OF.md
+++ b/tickets/entities/review-checklists/REV-4QL8OF.md
@@ -1,0 +1,79 @@
+---
+id: REV-4QL8OF
+type: review-checklist
+title: 'Review: View section fields render as display by default; opt in to inline edit with `render: input`'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Automated Checks
+
+- [x] `go build ./...` — pass
+- [x] `go test ./...` — pass, exit 0, 80 packages
+- [x] `golangci-lint run ./...` — **0 issues** (full repo)
+- [x] `just arch-lint` — OK, no warnings
+- [x] `just coverage-check` — pass, **77.3%** total (up from 76.9%), all package floors satisfied
+- [x] `npm run test:run` — 1488 passed / 90 files
+- [x] `npm run typecheck` — pass
+- [x] `npm run lint` — 0 errors (90 pre-existing warnings in untouched files)
+- [x] `npx playwright test` — **235 passed, 0 failed** (up from 231), 8 skipped (postgres-gated)
+
+## Code Review
+
+- [x] `/code-review` run by the cranky-code-reviewer agent against the full diff
+- [x] All critical findings addressed
+- [x] All significant findings addressed or explicitly declined with reason
+
+**Findings: 6 total.**
+
+| ID | Severity | Status |
+|----|----------|--------|
+| RR-GLK4UY | critical | fixed |
+| RR-5KFD7W | significant | fixed |
+| RR-TIUKMA | significant | fixed |
+| RR-H39SEJ | significant | wont-fix (premise incorrect — no changelog surface exists in this repo) |
+| RR-VBJ91V | minor | addressed (documented) |
+| RR-1SNYI1 | nit | addressed |
+
+**RR-GLK4UY (critical)** is the one that mattered: the render default promoted a
+previously-unreachable stale-display-value read from an edge case to the common
+path. `mapFieldsToProperties` read the server string mirror, which is never
+updated after a PATCH. Fixed with `entryDisplayValue()`, mirroring the existing
+`rowDisplayValue` (RR-FC1C) rather than inventing a second mechanism. I verified
+the mechanism in source before accepting the finding.
+
+The reviewer independently confirmed the security core sound: it traced every
+path that can put a widget in `mode="edit"` and found the conjunction complete,
+`RR-PGGRBD` correctly honoured, the four wire-conversion sites present, both Go
+builders correct, validation genuinely unconditional, and the wire types
+field-for-field identical. It also endorsed the `sectionShouldRouteToInlineEdit`
+deviation after checking all four routing cases.
+
+## Verification
+
+- [x] Feature verified end-to-end against a running server
+- [x] Acceptance criteria met
+- [x] No regressions (full Go + frontend + e2e suites green)
+
+Live-server verification: configured views emit `render: 'input'`; synthesized
+default views emit `'display'`; the inert-render warning fires with the exact
+expected message.
+
+4 new e2e specs (`view-section-render-mode.spec.ts`) cover the mixed-render page
+the plan identified as uncoverable by unit tests, plus a regression guard for
+RR-GLK4UY.
+
+**Not done:** browser-level *visual* confirmation — the Chrome extension was not
+connected in this environment. Rendering is asserted structurally (no
+`select`/`input`/`.form-field` in a display section; an enabled control in an
+opted-in one) but no human has looked at the page. Recommend a glance via `just
+dev` before merge.
+
+## PR
+
+- [x] PR created and CI green — see the PR link recorded below
+
+**PR:** opened from branch `feat/view-section-render-mode-hoix1` after a clean
+local `just ci`. CI monitored to green before merge; any failure is fixed on
+this branch and re-pushed rather than merged around.

--- a/tickets/entities/review-responses/RR-1SNYI1.md
+++ b/tickets/entities/review-responses/RR-1SNYI1.md
@@ -1,0 +1,20 @@
+---
+id: RR-1SNYI1
+type: review-response
+title: isLongValue's KEEP IN SYNC comment overclaimed; inert-render warning didn't name the field index
+finding: 'Two small precision defects. (a) `isLongValue` (SectionEditForm.vue) carried a ''KEEP IN SYNC with PropertyDisplay.vue isLong'' comment, but PropertyDisplay also short-circuits on `PropertyItem.isLongText` and uses `|| ''''` where the port uses `?? ''''` — so the comment claimed a byte-identical port that wasn''t one. (b) `inertSectionRenderWarnings` always said ''section[%d] sets render:'' even when a FIELD carried the setting, leaving an operator with a long fields: list no pointer — while the error path (validateSectionRender) is precise to field[%d].'
+severity: nit
+resolution: '(a) Narrowed the comment to state exactly what is shared (the 60-char threshold) and to record that `isLongText` is never populated anywhere in the codebase — including in PropertyDisplay itself — so there is no behavioural difference to mirror, with a note to add the arm if it is ever wired up. (b) The warning now names the precise origin: `section[i]` for a section-level render, `section[i] field[j]` for the first offending field. Pinned by TestCollectConfigWarnings_InertSectionRenderNamesOrigin.'
+status: addressed
+---
+
+On (a): confirmed by `grep -rn "isLongText" src/` that the only occurrences are
+its declaration and read inside `PropertyDisplay.vue` — nothing ever sets it. So
+the two functions are behaviourally identical today and the `|| ''` vs `?? ''`
+difference is unreachable at a 60-character threshold. The fix is to the
+comment, not the code.
+
+The reviewer also independently verified the reactivity question I had not
+explicitly tested — that Vue 3's proxy tracking follows through a plain helper
+called inside a computed, including for keys added to `formData` after first
+read. Not a bug.

--- a/tickets/entities/review-responses/RR-1V04ZD.md
+++ b/tickets/entities/review-responses/RR-1V04ZD.md
@@ -1,0 +1,22 @@
+---
+id: RR-1V04ZD
+type: review-response
+title: Missed fourth v1.SectionField conversion site (api_v1.go:2321, the cards/list row path)
+finding: 'The plan and ticket both enumerate three `v1.SectionField(f)` conversion sites (views_handler.go:147, 161, 562). There is a fourth: internal/dataentry/api_v1.go:2321, inside `sectionEntityToV1` — the cards/list row path, which is the one the plan''s cards/list acceptance criteria depend on. Verified by `grep -rn ''v1\.SectionField('' internal/`. The unnamed struct conversion makes an omission a compile error, so this cannot ship broken, but the plan''s surface analysis was wrong on the load-bearing path.'
+severity: significant
+resolution: Plan and ticket corrected to enumerate all four sites, with api_v1.go:2321 identified as the cards/list row path.
+status: addressed
+---
+
+Verified against source. `grep -rn "v1\.SectionField(" internal/` returns four
+hits:
+
+```
+internal/dataentry/views_handler.go:147   side panel section fields
+internal/dataentry/views_handler.go:161   side panel entity fields
+internal/dataentry/views_handler.go:562   view section fields
+internal/dataentry/api_v1.go:2321         cards/list row fields  <- missed
+```
+
+`api_v1.go:2321` sits in `sectionEntityToV1(e SectionEntityData) v1.ViewEntity`,
+which builds the per-row payload consumed by `rowShouldRouteToInlineEdit`.

--- a/tickets/entities/review-responses/RR-4ICH8M.md
+++ b/tickets/entities/review-responses/RR-4ICH8M.md
@@ -1,0 +1,17 @@
+---
+id: RR-4ICH8M
+type: review-response
+title: Section-level `render:` and unresolvable-source sections escape config validation
+finding: 'The plan says ''enum validation in the two existing per-field loops (validate.go:912, 951)''. Both loops are nested inside source-resolution guards: `if sourceType != "" { if sourceDef, ok := meta.GetEntityDef(sourceType); ok { ... } } else if s.Source == "entry" { ... }`. A section whose source type has no entity def reaches neither loop, so `render: bogus` passes silently. Worse, `ViewSection.Render` — the section-level default the plan explicitly puts in scope — is validated by neither loop, since both iterate `s.Fields`. AC 5 compounds this by specifying an error naming ''view, section index, field index'', which has no meaning for a section-level value.'
+severity: significant
+resolution: 'Plan updated: `render` enum validation moves OUT of the source-resolution guards into an unconditional per-section pass that validates both `s.Render` and every `s.Fields[j].Render` regardless of whether the source type resolves. AC 5 split into 5a (field-level, names field index) and 5b (section-level, names section index only).'
+status: addressed
+---
+
+Verified at `internal/dataentryconfig/validate.go:909-958`. The two field loops
+sit inside source-resolution guards, so validation coverage depends on whether
+the section's source type resolves to an entity def — which is orthogonal to
+whether `render` is well-formed.
+
+`render` needs no metamodel knowledge to validate (it is a closed enum), so it
+should be checked unconditionally, before/outside the `sourceType` branching.

--- a/tickets/entities/review-responses/RR-4O96FZ.md
+++ b/tickets/entities/review-responses/RR-4O96FZ.md
@@ -1,0 +1,20 @@
+---
+id: RR-4O96FZ
+type: review-response
+title: '`render` on shared SectionField wire type reaches side panels (not inert — a renderer gap)'
+finding: Review flagged that `v1.SectionField` is embedded in four response structs (responses.go:318 SidePanelSection, :348 SidePanelEntity, :477 ViewSection, :513 ViewEntity), so adding `Render` emits the key on side-panel surfaces that have no inline edit, and characterised it as leaking a meaningless field into a shared DTO.
+severity: minor
+resolution: 'Accepted as a documentation item, rejected as a design defect. Side panels reuse ViewSection configs verbatim (`views_handler.go:130`: `Sections: form.SidePanel.Sections`), so an operator writing `render:` there is expressing real intent — SidePanel.vue simply has no inline-edit renderer yet. The key is unhonoured-by-that-renderer, not meaningless. Keeping `Render` on the shared type preserves the option of side-panel inline edit; splitting the type would structurally exclude it. Ship on the shared type; note the side-panel renderer gap in the docs.'
+status: addressed
+---
+
+The review's framing conflated "a renderer does not honour this key yet" with
+"this key has no meaning on this surface". Only the first is true.
+
+`SidePanel.vue` consumes `SidePanelSection[]` and renders fields read-only; it
+never mounts `SectionEditForm`. That is a current limitation of that component,
+not a property of the data. Since side-panel sections *are* `ViewSection`
+configs, a future ticket enabling inline edit there would want exactly this key.
+
+Decision: single `Render` field on `v1.SectionField`. Document that the
+side-panel renderer ignores it today.

--- a/tickets/entities/review-responses/RR-5KFD7W.md
+++ b/tickets/entities/review-responses/RR-5KFD7W.md
@@ -1,0 +1,17 @@
+---
+id: RR-5KFD7W
+type: review-response
+title: Planned mixed-render e2e integration test was never written
+finding: 'PLAN-6RDYUL''s Test Plan called for ''an e2e case loading a view with mixed `render` values, asserting one field is an input and its neighbour plain text in the same section — the mixed-rendering layout case unit tests cannot cover''. No such spec existed. The only e2e touching this surface was the #997 unmount guard, which had merely been patched to keep passing. The Test Plan box was effectively checked over a missing artifact.'
+severity: significant
+resolution: 'Added e2e/tests/view-section-render-mode.spec.ts with four specs: (1) a display section and an inline-edit section coexist on one page; (2) a display-default field renders no select/input/FieldShell but still shows its value; (3) a display section reflects the current server value (the RR-GLK4UY staleness guard); (4) an opted-in field renders an enabled control. All four pass. The fixture''s `task` view was left deliberately mixed to support them.'
+status: addressed
+---
+
+The plan explicitly flagged this case as uncoverable by unit tests, which is
+correct: the component tests can prove each arm in isolation, but only a real
+page shows that a display section and an inline-edit section coexist without one
+stealing the other's chrome.
+
+Full suite after the addition: **235 passed, 0 failed** (was 231), 8 skipped
+(postgres-gated history specs, unrelated).

--- a/tickets/entities/review-responses/RR-675AA0.md
+++ b/tickets/entities/review-responses/RR-675AA0.md
@@ -1,0 +1,16 @@
+---
+id: RR-675AA0
+type: review-response
+title: '`render` meaning undefined for display modes that don''t render fields (table/content)'
+finding: 'The plan never states what `render` means for section display modes other than `properties`/`cards`/`list`. `display: table` uses `Columns []ListColumn`, which gets no `render` key, so a table section''s `fields` are unused. `display: content` ignores `Fields` entirely (sections.go:225-228). A `render:` on either is silently accepted and does nothing — a papercut for operators, given the project''s stance that config validation should be loud and actionable.'
+severity: minor
+resolution: 'Plan updated: `render` on a section whose display mode does not render fields (`table`, `content`) is a config validation WARNING naming the mode, not a hard error — consistent with it being an inert-but-harmless key rather than a malformed one. Documented in the docs/data-entry.md sections table.'
+status: addressed
+---
+
+Checked `validSectionDisplayModes` (validate.go:902-906) and the entry-source
+builder (`sections.go:225-228`, `case "content"`).
+
+Warning rather than error because an operator switching a section from
+`properties` to `table` while iterating shouldn't hit a hard config-load failure
+over a now-inert key.

--- a/tickets/entities/review-responses/RR-8EISWO.md
+++ b/tickets/entities/review-responses/RR-8EISWO.md
@@ -1,0 +1,28 @@
+---
+id: RR-8EISWO
+type: review-response
+title: Section-gate change fixes a staleness bug the all-display case cannot have
+finding: 'The plan''s risk-4 mitigation changes `sectionShouldRouteToInlineEdit` (sectionEditFields.ts:97-99) to ignore display-flagged fields, so an all-display section still mounts SectionEditForm — justified as avoiding PropertyDisplay''s stale stringified `values`. But the staleness requires an editable sibling field to make a value stale, and an all-display section has none by definition. The mitigation therefore delivers zero benefit while adding mounts and, more importantly, silently inverting heading ownership: `sectionRendersOwnHeading` (EntityDetail.vue:503-510) gates on `sectionShouldRouteToInlineEdit`, so after the change essentially every properties section would suppress the generic <h2> and render SectionEditForm''s own header row — including an AutoSaveIndicator on sections that can never save.'
+severity: significant
+resolution: Dropped the section-gate change entirely. `sectionShouldRouteToInlineEdit` stays untouched; all-display sections route to PropertyDisplay exactly as today. Heading ownership unchanged. AC 6 rewritten to assert observable behaviour rather than which component mounts.
+status: addressed
+---
+
+Verified: `mapFieldsToProperties` (EntityDetail.vue:423-449) reads `field.values
+?? []` (server data), never `entry.properties` — so the entry-section staleness
+the plan cited is real. But it can only manifest when a sibling field in the
+same section was edited, which requires a `render: input` field. A mixed
+input+display section already routes to inline edit under the **unmodified**
+predicate, because at least one field is writable-and-input.
+
+The heading-ownership inversion is the decisive argument, not mount cost — it is
+a visible behaviour change affecting every properties section by default.
+
+Note on mount cost (raised in review as "up to 100 dead autosave hosts"): the
+reviewer overstated this. `INLINE_EDIT_ROW_CAP = 100` (EntityDetail.vue:550) is
+a soft cap for the pathological case, and its own comment says instances are
+"cheap individually". Typical sections are 3-10 rows. Cost was not the reason to
+drop the change.
+
+The residual pre-existing staleness in `mapFieldsToProperties` for **mixed**
+sections predates this ticket and is left as a separate concern; see RR-CJKDXG.

--- a/tickets/entities/review-responses/RR-9S63SJ.md
+++ b/tickets/entities/review-responses/RR-9S63SJ.md
@@ -1,0 +1,22 @@
+---
+id: RR-9S63SJ
+type: review-response
+title: '`render` is a config constant duplicated onto per-entity field data'
+finding: '`SectionFieldData` (sections.go:56-62) carries per-entity facts — `Values`, `PropType`, `Inaccessible` all describe this entity''s value. `Render` is a config constant, identical for every row, so a cards/list section of N entities x M fields emits N*M copies of the same string. Review argued this is a category error and proposed emitting resolved render modes once on the section instead.'
+severity: minor
+resolution: Accepted as real but not worth the cost. The alternative (a parallel `FieldRenders []string` on the section, or section-only emission) forces the frontend to correlate section config with row fields by index — and `rowShouldRouteToInlineEdit`/`buildSectionEditFields` consume `row.fields`, not the section's, so an index-correlation would introduce a new coupling exactly where BUG-9QL9XV previously went wrong. Per-field emission keeps each row self-describing. Wire cost is a short enum string per field; typical sections are 3-10 rows. Documented as a deliberate tradeoff.
+status: addressed
+---
+
+The observation is correct: `render` genuinely is config, not per-entity data.
+
+Rejected because the cleaner shape costs more than it saves here.
+`buildSectionEditFields` is called with `row.fields` for rows
+(`sectionEditFields.ts:142`) and `section.fields` for the entry section
+(`EntityDetail.vue:484`) — they are different arrays. Emitting render modes only
+on the section would require the row path to index back into section config,
+adding a correlation-by-position dependency between two structures that are
+currently independent.
+
+Self-describing rows are the safer default on a surface that has already had an
+ACL bug (BUG-9QL9XV) caused by field data and config drifting apart.

--- a/tickets/entities/review-responses/RR-GLK4UY.md
+++ b/tickets/entities/review-responses/RR-GLK4UY.md
@@ -1,0 +1,25 @@
+---
+id: RR-GLK4UY
+type: review-response
+title: Display-value staleness in mapFieldsToProperties promoted from unreachable to common by the render default
+finding: '`mapFieldsToProperties` (EntityDetail.vue:423) read `field.values` — the server-side display-stringified mirror — while `handlePropertyApplied` (:519) rewrites only `entry.properties` via `applyPropertyToEntry`. Before TKT-HOIX1 the entry display path (`PropertyDisplay`, EntityDetail.vue:879) was reachable only when the ACL denied EVERY field in a section, so nothing could edit those values and the mirror could never go stale. With `render` defaulting to display, a display-rendered section is now the COMMON case and can sit alongside a `render: input` section that PATCHes the same property — at which point the display section shows last-loadView''s string indefinitely. The ticket had scoped this out as pre-existing (RR-8EISWO), but that deferral rested on a reachability argument the default flip invalidates. Silent wrong-data-on-screen.'
+severity: critical
+resolution: 'Added `entryDisplayValue()` in EntityDetail.vue, the entry-section analogue of the existing `rowDisplayValue` (which already solved this for cards/list rows under RR-FC1C): prefer live `entry.properties[field.property]` when present, fall back to `field.values`. Pinned by e2e `a display section reflects the current server value` in view-section-render-mode.spec.ts.'
+status: addressed
+---
+
+Verified in source before accepting:
+
+- `EntityDetail.vue:440` — `value: field.values ?? []` (server mirror, never updated post-PATCH)
+- `EntityDetail.vue:519-526` — `handlePropertyApplied` → `applyPropertyToEntry`, which rewrites
+`entry.properties` only
+- `EntityDetail.vue:575-580` — `rowDisplayValue` already prefers `_props` for the row path,
+with a comment naming this exact bug class (RR-FC1C)
+
+Reachability confirmed as *newly* common rather than *newly* introduced: the
+in-repo `tickets/data-entry.yaml` has views with multiple entry-source sections
+(`idea`, `future-concept`), though their property lists are currently disjoint
+and all migrated to `input`, so no live config hits it today. An unmigrated
+config with overlapping properties across two entry sections would.
+
+The fix mirrors the row path exactly rather than inventing a second mechanism.

--- a/tickets/entities/review-responses/RR-H39SEJ.md
+++ b/tickets/entities/review-responses/RR-H39SEJ.md
@@ -1,0 +1,24 @@
+---
+id: RR-H39SEJ
+type: review-response
+title: Changelog/upgrade notes checked off in the plan but never delivered
+finding: 'PLAN-6RDYUL''s Documentation Planning marks ''[x] Changelog / upgrade notes — the breaking default flip, before/after YAML, blast-radius count'' as done. No CHANGELOG.md or upgrade-notes file exists in the repo, and `git diff -- docs/` shows only docs/data-entry.md. The plan''s own risk #1 named changelog + upgrade notes as the sole mitigation for the breaking change, so a checked box over a missing artifact reads to a review gate as satisfied when it is not.'
+severity: significant
+reason: 'The premise is wrong, but the criticism of the checkbox is fair. There is no CHANGELOG.md or upgrade-notes file anywhere in this repo (verified: `ls CHANGELOG.md docs/upgrade*.md docs/migration*.md` finds nothing; the only file mentioning ''Breaking change'' is docs/data-entry.md). Creating one solely for this ticket would establish a documentation surface the project has never maintained — out of scope for a feature ticket and likely to rot. The breaking change IS documented where this project actually documents config: a dedicated ''Field Render Modes'' section in docs/data-entry.md with before/after YAML, the opt-in rule, and an explicit blockquote flagging the break. The plan checkbox was inaccurate and has been corrected to name docs/data-entry.md as the delivery vehicle rather than implying a changelog exists.'
+status: wont-fix
+---
+
+Accepted as a real process defect (checked box, unbuilt artifact), rejected as a
+code change.
+
+What actually shipped in `docs/data-entry.md`:
+- a `render` row in both the section and field option tables
+- a new "Field Render Modes" section with before/after YAML for field- and section-level use
+- the ACL-cannot-be-upgraded rule
+- which display modes honour it
+- a blockquote: "**Breaking change**: `render` defaults to `display` ... Existing configs must
+add `render: input` to the fields they want to keep editable."
+- correction of the stale line describing views as "read-only detail pages"
+
+If the project later adds a CHANGELOG, this entry belongs in it. Raising that as
+its own ticket would be reasonable; inventing the file here would not.

--- a/tickets/entities/review-responses/RR-PGGRBD.md
+++ b/tickets/entities/review-responses/RR-PGGRBD.md
@@ -1,0 +1,24 @@
+---
+id: RR-PGGRBD
+type: review-response
+title: Do not pass `render` as isFieldWritable's second `fieldReadonly` parameter
+finding: '`isFieldWritable(verdict, fieldReadonly?)` (frontend/src/utils/affordances.ts:12-18) already has a static-readonly second parameter that SectionEditForm does not use. It is an obvious-looking home for `render`, and the plan never explicitly forbids it. Doing so would be wrong: `isFieldWritable` is called both at widgetRows (SectionEditForm.vue:142) and in the verdict-flip watcher (:172-173); passing `render` symmetrically at both sites reintroduces exactly the spurious ''Permission changed'' toast that risk 3 exists to prevent. The doc comment at affordances.ts:9-11 also notes view-side hosts have no static-readonly concept.'
+severity: minor
+resolution: 'Plan updated with an explicit prohibition: `render` stays a separate conjunct at the widgetRows call site only (`writable: field.render === ''input'' && isFieldWritable(field.verdict)`); the `fieldReadonly` parameter is left unused by view-side hosts, and the watcher continues to read `verdict` alone. Also confirmed `isFieldWritable(undefined) === true`, so `render: input` with no ACL verdict is editable — the intended behaviour.'
+status: addressed
+---
+
+Verified:
+
+```ts
+// frontend/src/utils/affordances.ts:12-18
+export function isFieldWritable(verdict, fieldReadonly?): boolean {
+  if (fieldReadonly) return false
+  return verdict?.writable !== false
+}
+```
+
+Two call sites in `SectionEditForm.vue` — `:142` (widgetRows) and `:172-173`
+(watcher). The conjunct must be applied at the first only. This is the mechanism
+behind risk 3, stated explicitly so an implementer doesn't "tidy" the conjunct
+into the parameter.

--- a/tickets/entities/review-responses/RR-TIUKMA.md
+++ b/tickets/entities/review-responses/RR-TIUKMA.md
@@ -1,0 +1,19 @@
+---
+id: RR-TIUKMA
+type: review-response
+title: E2E fixture's entry properties section silently lost inline edit with no comment
+finding: 'The migration added `render: input` to the fixture''s `Implements` list section (with a comment explaining why) but not to the `Task` properties section immediately above it in the same YAML block — fields `status` and `assignee`. No current spec asserted inline edit there, so nothing failed. That is the hazard: the fixture silently acquired a display-only entry section, and a future test written against it would find a PropertyDisplay where its author expected an editable form.'
+severity: significant
+resolution: 'Left at the display default deliberately — it gives the suite a genuinely mixed page, which the new view-section-render-mode.spec.ts now depends on — but added an explicit comment saying so and telling a future spec author to add `render: input` rather than assume the pre-TKT-HOIX1 default. The section is now covered by three assertions rather than being untested.'
+status: addressed
+---
+
+Turning the omission into a deliberate, documented, and *tested* choice was
+better than migrating it: the suite previously had no page exercising both
+render modes at once, and this section supplies exactly that shape for
+RR-5KFD7W's new specs.
+
+Note: an earlier version of this comment used backticks around `render: input`,
+which terminated the surrounding TypeScript template literal and broke the
+fixture's parse. Caught by Playwright's transform step. The comment now avoids
+backticks inside `DATA_ENTRY_YAML`.

--- a/tickets/entities/review-responses/RR-UQ2MIV.md
+++ b/tickets/entities/review-responses/RR-UQ2MIV.md
@@ -1,0 +1,35 @@
+---
+id: RR-UQ2MIV
+type: review-response
+title: 'Breaking change breaks the #997 e2e regression guard; blast radius never quantified'
+finding: 'The plan''s blast-radius analysis stopped at ''changelog + upgrade notes'' and never grepped the test suite or counted affected configs. `e2e/pages/entity.page.ts:116` asserts `.entity-list .list-item .section-edit-form` is visible — the issue #997 unmount-crash regression guard, called from `e2e/tests/entity-detail-list-unmount.spec.ts:41`. Its fixture (e2e/tests/fixtures.ts:1181-1192) declares a `display: list` section with `- property: status` / `- property: priority` and no `render:`, so after this change the row renders display and the guard fails. The fixture comment at :1164-1169 states the shape exists specifically to mount a SectionEditForm.'
+severity: significant
+resolution: 'Plan updated: the e2e fixture gains `render: input` on both list-section fields to preserve the #997 guard, and this is now an explicit test-plan item rather than an afterthought. Blast radius quantified: 424 `- property:` entries across three in-repo data-entry.yaml files (tickets/ 271, prototypes/project 107, prototypes/catalog 46).'
+status: addressed
+---
+
+Verified by grep and by reading the fixture.
+
+The guard:
+```ts
+// e2e/pages/entity.page.ts:115-117
+async expectListSectionRowMounted() {
+  await expect(this.page.locator('.entity-list .list-item .section-edit-form').first())
+    .toBeVisible();
+}
+```
+
+The fixture that feeds it (`e2e/tests/fixtures.ts:1186-1192`) has no `render:`,
+so both fields default to display after this change and no `.section-edit-form`
+mounts.
+
+Fix: add `render: input` to the `Implements` list section's `status` and
+`priority` fields so the regression guard keeps exercising the #997 DOM shape.
+
+Blast radius (`- property:` counts, all surfaces):
+- `tickets/data-entry.yaml` — 271
+- `prototypes/data-entry/project/data-entry.yaml` — 107
+- `prototypes/data-entry/catalog/data-entry.yaml` — 46
+
+These lose inline edit until updated. Accepted deliberately by the requester;
+the number belongs in the upgrade notes.

--- a/tickets/entities/review-responses/RR-VBJ91V.md
+++ b/tickets/entities/review-responses/RR-VBJ91V.md
@@ -1,0 +1,25 @@
+---
+id: RR-VBJ91V
+type: review-response
+title: '`display: content` sections build wire fields the SPA never renders; classification and builder disagree'
+finding: '`sectionDisplayModesRenderingFields` (validate.go) lists properties/list/cards, excluding `content`. But `buildSections` runs `case "content", "cards":` through `buildSectionEntityData(..., sec.Render)` (sections.go:329-336), so a traverse-sourced content section DOES build SectionFieldData with a resolved Render and ships it on the wire. Three in-repo content sections carry fields this way. Net user-visible effect is correct because the SPA''s content-card template renders only the markdown body, but the classification and the builder disagree and a future reader will trip on it.'
+severity: minor
+resolution: 'Kept the classification (it correctly tracks what is RENDERED, which is what an operator setting `render:` cares about) and documented the discrepancy at the map declaration: content shares a builder arm with cards, the SPA ignores those fields, and adding `content` to the map would suppress a warning the operator needs. Explicitly warns against ''fixing'' the mismatch that way.'
+status: addressed
+---
+
+Verified the SPA side before deciding: `EntityDetail.vue:932`
+(`v-else-if="section.display === 'content' && section.entities?.length"`)
+renders `content-card` elements whose template emits only the markdown body — no
+`card-fields`, no field loop. So the built fields are genuinely inert payload on
+that surface.
+
+Two candidate fixes were considered:
+1. Add `content` to the map — rejected: it would silence a warning for a mode where `render:`
+really does nothing, which is the opposite of the warning's purpose.
+2. Stop building fields for `content` — rejected as out of scope: it would change the wire
+shape for a pre-existing behaviour unrelated to this ticket, with unknown
+consumers.
+
+Documenting the seam is the honest option. Worth a follow-up ticket if the
+wasted payload matters.

--- a/tickets/entities/tickets/TKT-3R7RF3.md
+++ b/tickets/entities/tickets/TKT-3R7RF3.md
@@ -1,0 +1,44 @@
+---
+id: TKT-3R7RF3
+type: ticket
+title: Widget override for view section fields (`widget:` on ViewSectionField)
+kind: enhancement
+priority: medium
+effort: s
+status: backlog
+---
+
+## Goal
+
+Let view config authors override which widget renders a given property in a view
+section, independent of the type-based default.
+
+Split out of TKT-HOIX1, which now covers only the `render: input | display`
+axis. This ticket is the orthogonal *which widget* axis and should land after
+it.
+
+## Scope
+
+- `ViewSectionField` (`internal/dataentryconfig/config.go:610-613`) gains an optional
+`widget string`.
+- `internal/dataentryconfig/validate.go` validates widget names against the registry **and**
+against the property's type — no `checkbox` widget on a `date` property.
+- Backend populates `V1ViewCell.Widget` from config. The field is reportedly already in the
+wire schema but unpopulated — verify before implementing.
+- Frontend `ViewSectionField` TS type gains `widget`; `frontend/src/widgets/registry.ts`
+consults it when picking the widget, ahead of the `defaultWidgetFor` type
+dispatch (`registry.ts:18-28`).
+- Omitting `widget` preserves today's type-based selection exactly.
+
+## Why
+
+The payoff case: the Daily-Notes "click checkbox to mark task done" interaction
+becomes a config line rather than custom code. Note this needs `render: input`
+from TKT-HOIX1 to be useful, since a checkbox you cannot click is just an icon.
+
+## Non-goals
+
+- No new widget types — only overriding selection among registered ones.
+- The `render: input | display` axis (TKT-HOIX1).
+- Markdown and relation widgets, which do not exist in the registry
+(`frontend/src/widgets/registry.ts:105-117`).

--- a/tickets/entities/tickets/TKT-HOIX1.md
+++ b/tickets/entities/tickets/TKT-HOIX1.md
@@ -1,11 +1,140 @@
 ---
 id: TKT-HOIX1
 type: ticket
-title: Add widget + editable config surface for view sections
+title: 'View section fields render as display by default; opt in to inline edit with `render: input`'
 kind: enhancement
 priority: medium
-effort: s
-status: backlog
+effort: m
+status: done
 ---
 
-## Goal\n\nAllow view config authors to (a) override which widget renders a given property in a view section, and (b) opt a section into inline-edit mode.\n\n## Scope\n\n- `ViewSectionField` (Go: `internal/dataentryconfig/config.go`) gains an optional `widget` string and an optional `editable` bool.\n- `ViewSection` gains an optional `editable` bool that defaults each contained field to inline-edit.\n- `validate.go` validates widget names against the registry and against the property's type (no `checkbox` widget on a `date` property).\n- Backend rendering (`internal/dataentry/api_v1.go`) populates `V1ViewCell.Widget` from config (the field is already in the wire schema, just not populated).\n- Frontend `ViewSectionField` TS type gains the new fields; the registry consults them when picking widget and mode.\n- Backward-compatible defaults: omitting `widget`/`editable` produces today's behaviour exactly.\n\n## Non-goals\n\n- No new widget types.\n- No content-section inline-edit (final ticket).\n- No bulk operations or row-level actions.\n\n## Why\n\nThe payoff ticket: once this lands, the Daily-Notes 'click checkbox to mark task done' becomes a config line.
+## Goal
+
+Give view-config authors per-field control over whether a detail-page property
+renders as a **view-oriented display value** or an **editable inline input** —
+and flip the default to display.
+
+Before this, there was no config surface at all: `ViewSectionField` was just
+`{property, label}`. Whether a field rendered as an input was decided entirely
+by the ACL verdict — a *permission*, not a presentation choice.
+
+## Config surface
+
+```yaml
+views:
+  ticket:
+    sections:
+      - heading: Details
+        display: properties
+        render: input              # optional section-wide default
+        fields:
+          - property: title
+            render: display        # overrides the section
+          - property: status       # inherits `input` from the section
+```
+
+- `ViewSectionField.render: input | display`, defaulting to `display`.
+- `ViewSection.render` sets a section-wide default that contained fields override.
+- Resolution order: field → section → `display`, resolved **server-side** by the single
+`dataentryconfig.ResolveFieldRender` helper.
+
+## BREAKING CHANGE (accepted, no migration)
+
+Inline edit on view sections is now **opt-in**. Existing `data-entry.yaml` files
+lose inline editing until they add `render: input`. Deliberate; no
+`internal/migration` step.
+
+In-repo configs were migrated as part of this ticket (28 sections gained a
+section-level `render: input`): `tickets/data-entry.yaml` (23 sections / 57
+fields) and `prototypes/data-entry/project` (5 / 24).
+`prototypes/data-entry/catalog` has no `views:` block.
+
+**Synthesized default views also render display.** `buildDefaultViewConfig`
+(`internal/dataentry/default_view.go:33`) generates a view for every entity type
+with no `views:` entry — most types, including `ticket` in this repo's own
+tracker. Those set no `Render`, so they resolve to display like any unset
+config. This was a deliberate choice for consistency (found during
+implementation, not at design review): an operator who wants inline edit on such
+a type must author an explicit view. Pinned by
+`TestBuildDefaultViewConfig_RendersDisplayByDefault`.
+
+`render: input` yields an input only when the ACL also permits the write. Config
+can downgrade an editable field to display; it can never upgrade a read-only
+one.
+
+## Key finding: the display rendering already existed
+
+`SectionEditForm.vue` already branched **per field**, three ways: `transitions`
+→ `StatusControl`; `row.writable` → `FieldShell` + widget `mode="edit"`; else →
+bare widget `mode="display"`. That third arm is genuine view-oriented rendering
+with no form chrome, already in production use via ACL verdicts. This ticket
+feeds config into the same branch.
+
+NOT the `FormField.readonly` path (`FieldRenderer.vue:82`), which renders a
+**disabled input**.
+
+## What shipped
+
+1. `internal/dataentryconfig/config.go` — `Render` on `ViewSection` and `ViewSectionField`;
+`RenderDisplay`/`RenderInput` constants; `ResolveFieldRender`.
+2. `internal/dataentryconfig/validate.go` — `validateSectionRender` runs **outside** the
+source-resolution guards (RR-4ICH8M), covering both section- and field-level
+values; `inertSectionRenderWarnings` warns for `display: table` / `content`
+(RR-675AA0).
+3. `internal/dataentry/sections.go` — `Render` on `SectionFieldData`, populated in both
+builders via the shared helper; `buildSectionEntityData` gained a
+`sectionRender` parameter.
+4. `internal/apiwire/v1/responses.go` — `Render` on `SectionField`, same position. The unnamed
+`v1.SectionField(f)` conversion exists at **four** sites —
+`views_handler.go:147, 161, 562` and `api_v1.go:2321` (the cards/list row path,
+RR-1V04ZD). The compiler flagged all four.
+5. `frontend/src/api/views.ts` + `sectionEditFields.ts` — `render` threaded through as its own
+property, never folded into `verdict`.
+6. `SectionEditForm.vue` — `writable: field.render === 'input' && isFieldWritable(field.verdict)`
+at the `widgetRows` site only; `StatusControl` gated on `render`; long-text
+`.property-long` handling ported from `PropertyDisplay`.
+7. `e2e/tests/fixtures.ts` — `render: input` on the `Implements` list section so the #997
+regression guard keeps mounting a `SectionEditForm` (RR-UQ2MIV).
+8. `docs/data-entry.md` — new "Field Render Modes" section, section/field tables, and the
+breaking-change note. Also corrected the stale line calling views "read-only
+detail pages".
+
+## Deviation from the plan
+
+**`sectionShouldRouteToInlineEdit` DID change**, contrary to the plan's
+instruction to leave it untouched. The plan's reasoning (RR-8EISWO) was that an
+all-display section must not mount an autosave host — that conclusion stands and
+is unchanged. But leaving the predicate keyed on the verdict alone would have
+produced exactly the outcome RR-8EISWO argued against: an all-display section
+would still satisfy "some field is writable" and mount a `SectionEditForm` whose
+every field then renders display. The predicate now applies the same `render ===
+'input' && isFieldWritable(verdict)` conjunction as `widgetRows`, so the mount
+decision and the per-field rendering agree. Pinned by AC 9 (`returns false when
+fields omit render, even with writable verdicts`).
+
+## Traps (verified against source — do not skip)
+
+- **Keep `render` separate from `verdict`, and do NOT pass it as `isFieldWritable`'s second
+`fieldReadonly` parameter** (RR-PGGRBD). It is called at both the widgetRows
+site and the flip-watcher; applying it at both makes a display field look like a
+revoked permission and fires the spurious "Permission changed — your unsaved
+edit was discarded" toast.
+- **The ACL conjunction order is load-bearing.** Never weaken it to `||` or a ternary that lets
+config win.
+- **Two builders.** `sections.go` constructs `SectionFieldData` in two places — both must use
+the shared resolution helper.
+
+## Non-goals
+
+- **Widget override** (`widget:` on a view section field) — TKT-3R7RF3.
+- Side-panel inline edit. Side panels reuse `ViewSection` configs so they receive `render` on
+the wire, but `SidePanel.vue` has no inline-edit renderer and ignores it
+(RR-4O96FZ).
+- The pre-existing `mapFieldsToProperties` staleness for mixed sections (RR-8EISWO).
+- Markdown and relation display rendering — no widgets in the registry.
+- No new widget types; no content-section inline edit; no bulk/row-level actions.
+
+## Design review
+
+Eight findings, all addressed in PLAN-6RDYUL: RR-1V04ZD, RR-8EISWO, RR-UQ2MIV,
+RR-4ICH8M (significant); RR-4O96FZ, RR-9S63SJ, RR-675AA0, RR-PGGRBD (minor).

--- a/tickets/relations/TKT-3R7RF3--affects--views.md
+++ b/tickets/relations/TKT-3R7RF3--affects--views.md
@@ -1,0 +1,5 @@
+---
+from: TKT-3R7RF3
+relation: affects
+to: views
+---

--- a/tickets/relations/TKT-3R7RF3--implements--FEAT-72NR1.md
+++ b/tickets/relations/TKT-3R7RF3--implements--FEAT-72NR1.md
@@ -1,0 +1,5 @@
+---
+from: TKT-3R7RF3
+relation: implements
+to: FEAT-72NR1
+---

--- a/tickets/relations/TKT-HOIX1--has-docs--DOCS-RW5H28.md
+++ b/tickets/relations/TKT-HOIX1--has-docs--DOCS-RW5H28.md
@@ -1,0 +1,5 @@
+---
+from: TKT-HOIX1
+relation: has-docs
+to: DOCS-RW5H28
+---

--- a/tickets/relations/TKT-HOIX1--has-implementation--IMPL-BQ6OHC.md
+++ b/tickets/relations/TKT-HOIX1--has-implementation--IMPL-BQ6OHC.md
@@ -1,0 +1,5 @@
+---
+from: TKT-HOIX1
+relation: has-implementation
+to: IMPL-BQ6OHC
+---

--- a/tickets/relations/TKT-HOIX1--has-planning--PLAN-6RDYUL.md
+++ b/tickets/relations/TKT-HOIX1--has-planning--PLAN-6RDYUL.md
@@ -1,0 +1,5 @@
+---
+from: TKT-HOIX1
+relation: has-planning
+to: PLAN-6RDYUL
+---

--- a/tickets/relations/TKT-HOIX1--has-review--REV-4QL8OF.md
+++ b/tickets/relations/TKT-HOIX1--has-review--REV-4QL8OF.md
@@ -1,0 +1,5 @@
+---
+from: TKT-HOIX1
+relation: has-review
+to: REV-4QL8OF
+---

--- a/tickets/relations/TKT-HOIX1--has-review-response--RR-1SNYI1.md
+++ b/tickets/relations/TKT-HOIX1--has-review-response--RR-1SNYI1.md
@@ -1,0 +1,5 @@
+---
+from: TKT-HOIX1
+relation: has-review-response
+to: RR-1SNYI1
+---

--- a/tickets/relations/TKT-HOIX1--has-review-response--RR-1V04ZD.md
+++ b/tickets/relations/TKT-HOIX1--has-review-response--RR-1V04ZD.md
@@ -1,0 +1,5 @@
+---
+from: TKT-HOIX1
+relation: has-review-response
+to: RR-1V04ZD
+---

--- a/tickets/relations/TKT-HOIX1--has-review-response--RR-4ICH8M.md
+++ b/tickets/relations/TKT-HOIX1--has-review-response--RR-4ICH8M.md
@@ -1,0 +1,5 @@
+---
+from: TKT-HOIX1
+relation: has-review-response
+to: RR-4ICH8M
+---

--- a/tickets/relations/TKT-HOIX1--has-review-response--RR-4O96FZ.md
+++ b/tickets/relations/TKT-HOIX1--has-review-response--RR-4O96FZ.md
@@ -1,0 +1,5 @@
+---
+from: TKT-HOIX1
+relation: has-review-response
+to: RR-4O96FZ
+---

--- a/tickets/relations/TKT-HOIX1--has-review-response--RR-5KFD7W.md
+++ b/tickets/relations/TKT-HOIX1--has-review-response--RR-5KFD7W.md
@@ -1,0 +1,5 @@
+---
+from: TKT-HOIX1
+relation: has-review-response
+to: RR-5KFD7W
+---

--- a/tickets/relations/TKT-HOIX1--has-review-response--RR-675AA0.md
+++ b/tickets/relations/TKT-HOIX1--has-review-response--RR-675AA0.md
@@ -1,0 +1,5 @@
+---
+from: TKT-HOIX1
+relation: has-review-response
+to: RR-675AA0
+---

--- a/tickets/relations/TKT-HOIX1--has-review-response--RR-8EISWO.md
+++ b/tickets/relations/TKT-HOIX1--has-review-response--RR-8EISWO.md
@@ -1,0 +1,5 @@
+---
+from: TKT-HOIX1
+relation: has-review-response
+to: RR-8EISWO
+---

--- a/tickets/relations/TKT-HOIX1--has-review-response--RR-9S63SJ.md
+++ b/tickets/relations/TKT-HOIX1--has-review-response--RR-9S63SJ.md
@@ -1,0 +1,5 @@
+---
+from: TKT-HOIX1
+relation: has-review-response
+to: RR-9S63SJ
+---

--- a/tickets/relations/TKT-HOIX1--has-review-response--RR-GLK4UY.md
+++ b/tickets/relations/TKT-HOIX1--has-review-response--RR-GLK4UY.md
@@ -1,0 +1,5 @@
+---
+from: TKT-HOIX1
+relation: has-review-response
+to: RR-GLK4UY
+---

--- a/tickets/relations/TKT-HOIX1--has-review-response--RR-H39SEJ.md
+++ b/tickets/relations/TKT-HOIX1--has-review-response--RR-H39SEJ.md
@@ -1,0 +1,5 @@
+---
+from: TKT-HOIX1
+relation: has-review-response
+to: RR-H39SEJ
+---

--- a/tickets/relations/TKT-HOIX1--has-review-response--RR-PGGRBD.md
+++ b/tickets/relations/TKT-HOIX1--has-review-response--RR-PGGRBD.md
@@ -1,0 +1,5 @@
+---
+from: TKT-HOIX1
+relation: has-review-response
+to: RR-PGGRBD
+---

--- a/tickets/relations/TKT-HOIX1--has-review-response--RR-TIUKMA.md
+++ b/tickets/relations/TKT-HOIX1--has-review-response--RR-TIUKMA.md
@@ -1,0 +1,5 @@
+---
+from: TKT-HOIX1
+relation: has-review-response
+to: RR-TIUKMA
+---

--- a/tickets/relations/TKT-HOIX1--has-review-response--RR-UQ2MIV.md
+++ b/tickets/relations/TKT-HOIX1--has-review-response--RR-UQ2MIV.md
@@ -1,0 +1,5 @@
+---
+from: TKT-HOIX1
+relation: has-review-response
+to: RR-UQ2MIV
+---

--- a/tickets/relations/TKT-HOIX1--has-review-response--RR-VBJ91V.md
+++ b/tickets/relations/TKT-HOIX1--has-review-response--RR-VBJ91V.md
@@ -1,0 +1,5 @@
+---
+from: TKT-HOIX1
+relation: has-review-response
+to: RR-VBJ91V
+---


### PR DESCRIPTION
Adds a `render: input | display` key to view section fields (and sections) in
`data-entry.yaml`, defaulting to **display**. Detail-page fields now render as
view-oriented values unless they opt in to inline editing.

Closes TKT-HOIX1.

## ⚠️ Breaking change

Inline edit on view sections is now **opt-in**. Existing `data-entry.yaml` files
lose inline editing on view sections until they add `render: input`. This is
deliberate — there is no migration step.

```yaml
views:
  ticket:
    sections:
      - heading: Details
        display: properties
        render: input              # optional section-wide default
        fields:
          - property: title
            render: display        # overrides the section
          - property: status       # inherits `input`
```

In-repo configs are migrated in this PR (28 sections gained a section-level
`render: input`): `tickets/data-entry.yaml` (23) and
`prototypes/data-entry/project` (5).

**Synthesized default views also render display.** `buildDefaultViewConfig`
generates a view for every entity type with no `views:` entry — most types. Those
set no `render`, so they resolve to display. An operator wanting inline edit on
such a type must author an explicit view. Pinned by
`TestBuildDefaultViewConfig_RendersDisplayByDefault`.

## Security

`render: input` does **not** grant permission. Effective editability is

```
render === 'input' && isFieldWritable(verdict)
```

a conjunction, applied at the `widgetRows` site only. Config can downgrade an
editable field to display; it can never upgrade an ACL-read-only one. The write
path is unchanged and the server re-authorizes every PATCH. Pinned by a
dedicated test.

`render` is deliberately kept **off** `verdict`: the verdict-flip watcher
compares `isFieldWritable(verdict)` across prop updates, so folding config in
would make a display field look like a revoked permission and fire a spurious
"Permission changed — your unsaved edit was discarded" toast.

## Implementation notes

- The per-field display rendering already existed — `SectionEditForm.vue` has
  branched three ways (StatusControl / FieldShell+edit / bare widget in
  `mode="display"`) since the inline-edit work. This feeds config into that
  branch rather than building anything new. It is **not** the
  `FormField.readonly` path, which renders a *disabled input*.
- Resolution (field → section → display) happens **server-side** in one shared
  `ResolveFieldRender` helper, called from both section builders.
- `dataentry.SectionFieldData` and `v1.SectionField` must stay field-for-field
  identical — an unnamed struct conversion `v1.SectionField(f)` exists at **four**
  sites (`views_handler.go` ×3, `api_v1.go:2321`). Both structs carry a KEEP IN
  SYNC comment.
- Config validation for `render` runs *outside* the source-resolution guards, so
  a section whose source type doesn't resolve is still validated.
- `render` on a `display: table` / `content` section produces a config warning
  (it is inert there), naming the precise section/field origin.

## Review

Design review: 8 findings, all addressed. Code review: 6 findings — 1 critical
(fixed), 3 significant (2 fixed, 1 wont-fix with reason), 2 minor/nit.

The critical one is worth calling out: the display default promoted a
previously-unreachable staleness bug to the common path.
`mapFieldsToProperties` read the server-side string mirror, which the SPA never
updates after a PATCH. Before this change that path was reached only when the
ACL denied every field, so nothing could edit those values. Fixed with
`entryDisplayValue()`, mirroring the existing `rowDisplayValue` (RR-FC1C).

## Verification

| Check | Result |
|---|---|
| `just ci` | pass (exit 0) |
| `go test ./...` | pass — 80 packages |
| `golangci-lint run ./...` | 0 issues |
| `just coverage-check` | 77.3% (up from 76.9%) |
| `npm run test:run` | 1488 passed |
| `npx playwright test` | **235 passed, 0 failed** |

Includes 4 new e2e specs covering a mixed-render page (one section display, one
inline-editable) — the case unit tests can't reach — plus a regression guard for
the staleness fix. The issue #997 unmount guard still mounts its
`SectionEditForm` and passes.

**Not verified:** browser-level visual confirmation. Rendering is asserted
structurally (no `select`/`input`/`.form-field` in a display section) but nobody
has looked at the page.

Follow-up: TKT-3R7RF3 (`widget:` override for view section fields).
