### PR TITLE
feat(next-action): Phase 0 — engine, bands, and user-state service

### DIFF
--- a/.go-arch-lint.yml
+++ b/.go-arch-lint.yml
@@ -10,6 +10,7 @@ exclude:
   - internal/entitymanager/entitymanagertest
   - internal/visibility/visibilitytest
   - internal/state/statetest
+  - internal/userstate/userstatetest
   - frontend
   - e2e
   - .claude
@@ -88,6 +89,8 @@ components:
   frontmatter:      { in: internal/frontmatter }
   filter:           { in: internal/filter }
   propmatch:        { in: internal/propmatch }
+  userstate:        { in: internal/userstate }
+  memuserstate:     { in: internal/userstate/memuserstate }
   pattern:          { in: internal/pattern }
   search:           { in: internal/search }
   bleveindex:       { in: internal/search/bleveindex }
@@ -708,6 +711,13 @@ deps:
     mayDependOn:
       - entity
       - markdown
+  # userstate is the per-user next-action state seam (snooze/mute/cooldown).
+  # Deliberately NOT dependent on store: this state is not graph content, and
+  # letting it reach the store would invite exactly the "just put it in the
+  # graph" shortcut the design rejects.
+  memuserstate:
+    mayDependOn:
+      - userstate
   # propmatch is a PURE LEAF (stdlib only) on purpose — it is imported by
   # both filter (a branch) and the store layer, so anything added to it
   # lands inside the store too. Do not give it dependencies.

--- a/.go-arch-lint.yml
+++ b/.go-arch-lint.yml
@@ -436,6 +436,10 @@ deps:
   # any tag, so both backends' deps must be allow-listed here.
   appbuild:
     mayDependOn:
+      # The composition root picks the userstate backend, the same way it
+      # picks the store backend. Consumers take the userstate.Store seam.
+      - userstate
+      - memuserstate
       - acl
       - app
       - audit

--- a/.go-arch-lint.yml
+++ b/.go-arch-lint.yml
@@ -92,6 +92,7 @@ components:
   userstate:        { in: internal/userstate }
   nextaction:       { in: internal/nextaction }
   memuserstate:     { in: internal/userstate/memuserstate }
+  kvuserstate:      { in: internal/userstate/kvuserstate }
   pattern:          { in: internal/pattern }
   search:           { in: internal/search }
   bleveindex:       { in: internal/search/bleveindex }
@@ -440,6 +441,7 @@ deps:
       # picks the store backend. Consumers take the userstate.Store seam.
       - userstate
       - memuserstate
+      - kvuserstate
       - acl
       - app
       - audit
@@ -727,6 +729,12 @@ deps:
   # graph" shortcut the design rejects.
   memuserstate:
     mayDependOn:
+      - userstate
+  # The durable backend rides the existing per-user state seam (state.KV),
+  # the same one the scheduler and document cache use.
+  kvuserstate:
+    mayDependOn:
+      - state
       - userstate
   # nextaction is the resolution engine. It depends on NO store, searcher or
   # ACL type: candidates arrive through a consumer-side CandidateFunc that the

--- a/.go-arch-lint.yml
+++ b/.go-arch-lint.yml
@@ -90,6 +90,7 @@ components:
   filter:           { in: internal/filter }
   propmatch:        { in: internal/propmatch }
   userstate:        { in: internal/userstate }
+  nextaction:       { in: internal/nextaction }
   memuserstate:     { in: internal/userstate/memuserstate }
   pattern:          { in: internal/pattern }
   search:           { in: internal/search }
@@ -717,6 +718,15 @@ deps:
   # graph" shortcut the design rejects.
   memuserstate:
     mayDependOn:
+      - userstate
+  # nextaction is the resolution engine. It depends on NO store, searcher or
+  # ACL type: candidates arrive through a consumer-side CandidateFunc that the
+  # wiring site supplies already read-gated. That is what keeps the engine
+  # testable without a graph, and what stops read-path ACL leaking in here.
+  nextaction:
+    mayDependOn:
+      - dataentryconfig
+      - entity
       - userstate
   # propmatch is a PURE LEAF (stdlib only) on purpose — it is imported by
   # both filter (a branch) and the store layer, so anything added to it

--- a/.go-arch-lint.yml
+++ b/.go-arch-lint.yml
@@ -322,6 +322,11 @@ deps:
       - dataentryconfig
   dataentry:
     mayDependOn:
+      # The next-action engine and its per-user state. dataentry supplies the
+      # ACL-gated CandidateFunc; it does NOT choose a userstate backend —
+      # that is a wiring-site decision, like the store backend.
+      - nextaction
+      - userstate
       - acl
       - affordances
       - apiwire

--- a/.go-arch-lint.yml
+++ b/.go-arch-lint.yml
@@ -825,6 +825,10 @@ deps:
       - store
   pgstore:
     mayDependOn:
+      # The postgres build carries its own next-action state backend: it is the
+      # only one safe for a multi-process deployment, and it rides the pool
+      # this package already owns rather than opening a second one.
+      - userstate
       - canonical
       - graphquerynaive
       - search

--- a/.testcoverage.yml
+++ b/.testcoverage.yml
@@ -75,6 +75,7 @@ exclude:
     - ^internal/store/storetest # shared conformance test kit (exercised via backends)
     - ^internal/visibility/visibilitytest # shared conformance test kit (exercised via visibility + future wirings)
     - ^internal/state/statetest # shared conformance test kit (exercised via FSKV + pgstore's StateKV)
+    - ^internal/userstate/userstatetest # shared conformance test kit (exercised via mem/kv/pgstore backends)
     - ^internal/store/pgstore  # covered by the dedicated postgres CI job (needs a live DB; skipped without RELA_TEST_DATABASE_URL)
     - ^internal/entitymanager/entitymanagertest # shared test doubles (PanicOnUse etc.), exercised via consumers
     - ^internal/store/graphquerynaive # exercised through every backend's graphquery tests; cross-package coverage isn't attributed without -coverpkg, so its own number reads 0

--- a/cmd/rela-server/main.go
+++ b/cmd/rela-server/main.go
@@ -440,6 +440,14 @@ func main() {
 	// without it the routes are not registered at all.
 	app.SetCalDAVAliases(svc.CalDAVAliases())
 
+	// Next-action per-user state. The composition root picks the backend
+	// (durable over state.KV, or the store-native one on postgres); this only
+	// hands the app what it built.
+	if err := app.SetUserState(svc.UserState()); err != nil {
+		slog.Error("failed to wire next-action state", "error", err)
+		os.Exit(1)
+	}
+
 	// Start file watcher for live-reload.
 	// The watcher goroutine is cleaned up on process exit.
 	if err := app.StartWatching(); err != nil {

--- a/docs-project/entities/guides/GUIDE-data-entry.md
+++ b/docs-project/entities/guides/GUIDE-data-entry.md
@@ -1461,6 +1461,297 @@ Multiple terms are combined with AND logic. For example,
 Every card includes a link icon that opens the same query on the search page for further
 exploration.
 
+## Next actions
+
+An optional advisory layer: operator-declared rules that derive **one**
+suggested follow-up from graph state and surface it in the UI.
+
+It is deliberately **not** a task queue:
+
+- **Advisory.** A hint, not a demand — things a user *could* do, not *should*.
+  That is what separates it from `analyze`, which has an opinion about
+  correctness.
+- **One at a time.** Never a list. The aim is a companion that does not
+  overload, and there is no "show me all 12" surface to grow into.
+- **Good, not optimal.** Surfacing one of several good next actions is the
+  goal; avoiding a bad one is the bar.
+
+### Bands
+
+Bands are your priority vocabulary. Declare them in order — **list order is
+priority order**, highest first — and every source names one:
+
+```yaml
+next_action_bands:
+  - id: blocking
+    label: "Someone is waiting"
+    prominence: banner
+  - id: stalled
+    prominence: notice
+  - id: ambient
+    label: "Nothing owed"
+    prominence: statusbar
+```
+
+Bands rather than numeric priorities because per-source numbers do not
+compose: one source returning 90 and another returning 7 on a different scale
+is arbitrary ordering wearing the costume of ranking. With bands, "why is this
+on top?" always has a one-sentence answer.
+
+The engine evaluates bands in order and **stops at the first one with
+something to say**, so a typical page runs one or two queries rather than all
+of them.
+
+#### Prominence
+
+How much a band interrupts. The levels differ in what the user must do to
+clear it, not in decoration:
+
+| Value | Behaviour | Use for |
+|-------|-----------|---------|
+| `banner` | A bordered, accented block at the top of the page. Must be dealt with. | Onboarding; work someone else is blocked on |
+| `notice` | One quiet line in the same position. Easy to read past. | Worth saying once a visit, no urgency |
+| `statusbar` | A chip in the status bar; click to expand. You must go looking. | Ongoing minor stuff — true most of the time, urgent none of it |
+
+`statusbar` is the **default**: a band that has not declared a prominence has
+not earned the top of the page.
+
+### Sources
+
+A source is one rule. Sources are independent — none knows the others exist —
+so adding a rule is adding a source, and a bad source can be deleted without
+perturbing the rest.
+
+```yaml
+next_actions:
+  # Fires only on an empty graph: the first-run case, which no
+  # entity-shaped source can express.
+  first-run:
+    band: blocking
+    count: "client == 0"
+    suggest: "Nothing here yet. Add your first client?"
+    actions:
+      - navigate: "/form/client"
+        label: "Add a client"
+
+  # The common shape: a query plus a message.
+  stale-proposal:
+    band: stalled
+    query: "type:proposal prop:status=sent"
+    suggest: "{title} has been out since {sent_on}. Chase it?"
+    cooldown: 3d
+    key_props: [status]
+    actions:
+      - snooze: ["1d", "7d"]
+      - dismiss: true
+```
+
+| Field | Meaning |
+|-------|---------|
+| `band` | **Required.** Names a declared band. |
+| `query` | Candidate entities, in the search syntax (`type:`, `prop:`, …). |
+| `context` | Instead of `query`: scopes the source to the entity being viewed. |
+| `count` | Instead of `query`: fires on `"<entity_type> == 0"` — the first-run case. |
+| `suggest` | **Required.** The message. `{property}` interpolates from the candidate; `{id}` is the entity id. |
+| `actions` | The affordances offered. See below. |
+| `cooldown` | How long after being *shown* to stay quiet. Defaults to 24h. |
+| `key_props` | Properties that make a re-triggered condition count as **new** — see below. |
+| `defer_scope` | What "not now" covers: `entity` (default) or `source` — see below. |
+
+Exactly one of `query`, `context` or `count` must be set.
+
+#### `key_props` and re-triggering
+
+A suggestion is identified by `(source, entity, key_props values)`. Without
+`key_props`, a proposal going `draft → sent → draft` keeps the same identity,
+so a snooze from the first draft still suppresses the second one.
+
+Listing `key_props: [status]` makes the identity change with the status, so a
+genuinely new stall surfaces even though an old snooze exists.
+
+#### `defer_scope` — what "not now" covers
+
+When a user snoozes or dismisses a suggestion, what were they declining?
+
+- **`entity`** (the default) — *this item*. An ISMS task needing attention:
+  they still want the other tasks, just not this one.
+- **`source`** — *the interruption*. A daily quip, one entity per quip: which
+  quip was on offer is incidental, and handing them another immediately is
+  precisely what they said no to. Same for a "complete your profile" nudge —
+  prompting about a different field a moment later is the same nag.
+
+All three are entity-shaped sources with interpolated messages, so neither the
+message template nor the query shape separates them. Only you know which a
+source is, which is why it is declared rather than inferred.
+
+A source with a `pick_one` affordance defaults to `source` scope: its
+suggestion is about the set ("one of these is small"), so keying the deferral
+to whichever option happened to be picked would hand back the same suggestion
+with a different entity. Override it explicitly if you want per-candidate
+deferral anyway.
+
+#### `count` and the read gate
+
+A `count` source is evaluated **through the caller's read gate** by default:
+it asks "do *I* have any clients?", not "does anyone?". A principal who can
+read no clients therefore sees the first-run hint.
+
+`count_ungated: true` asks the whole-graph question instead. Use it only for a
+genuinely operator-level check ("has this deployment been set up at all?") —
+it discloses that entities of a type exist to someone permitted to read none
+of them.
+
+### Actions
+
+The affordances offered alongside a suggestion. Each entry sets exactly one:
+
+```yaml
+    actions:
+      - navigate: "/entity/task/{id}"   # hand off to a destination
+        label: "Open it"
+      - action: mark-task-done          # run a configured action
+      - set: { status: done }           # inline property mutation
+        confirm: true
+      - snooze: ["1d", "7d"]            # defer, offering these durations
+      - dismiss: true                   # "not this one"
+      - acknowledge: true               # "seen it" — for content sources
+```
+
+`snooze` and `dismiss` are not decoration. Without a way to say "not now", the
+only way to clear a suggestion is to comply with it — which makes it a demand
+rather than a hint. They are also the best signal available: a source
+dismissed every time is a source to delete.
+
+**Muting is always available**, whether or not you configure it. The UI offers
+"stop suggesting this" on every suggestion, per source and per user, and it is
+reversible.
+
+### What is stored, and where
+
+Snoozes, mutes and last-shown timestamps are **per user** and live in
+`.rela/next-action-state.json` — never in the graph. A snooze is not a fact
+about an entity; it is a fact about one person's relationship to a suggestion
+at a moment, and storing it as an entity would make it visible to everyone and
+audited forever.
+
+The state is disposable: losing it costs a user a repeated suggestion, not
+data.
+
+> **Note.** With no identity source configured, every request shares one
+> bucket of this state — fine for a single-user deployment, surprising for a
+> shared one. Wiring any identity (JWT, header) separates it.
+
+### A worked example
+
+A small consultancy. Four sources, each a different shape, ordered so the
+loudest is the one someone else is blocked on:
+
+```yaml
+next_action_bands:
+  - id: blocking
+    label: Someone is waiting
+    prominence: banner
+  - id: stalled
+    label: In your court
+    prominence: notice
+  - id: tidying
+    label: Spare time
+    prominence: statusbar
+  - id: ambient
+    label: Nothing owed
+    prominence: statusbar
+
+next_actions:
+  # The ball is in THEIR court. Interpolates the client so the message
+  # says who you would be chasing.
+  chase-proposal:
+    band: blocking
+    query: "type:proposal prop:status=sent"
+    suggest: "The {title} proposal is out with {client}. Chase it?"
+    cooldown: 3d
+    key_props: [status]
+    actions:
+      - navigate: "/entity/{id}"
+        label: "Open it"
+      - snooze: ["1d", "7d"]
+      - dismiss: true
+
+  # Same shape, opposite ownership: this one is waiting on you. Quieter,
+  # because nobody else is blocked.
+  send-draft:
+    band: stalled
+    query: "type:proposal prop:status=draft"
+    suggest: "{title} has been in draft a while. Send it?"
+    cooldown: 3d
+    key_props: [status]
+    actions:
+      - action: mark-sent
+      - snooze: ["1d"]
+      - dismiss: true
+
+  # Nothing is wrong — there is simply an opportunity. The options come
+  # from a query at render time, so they are whatever is small right now.
+  spare-time:
+    band: tidying
+    query: "type:task prop:status=todo prop:effort=xs"
+    suggest: "Got a spare moment? One of these is small."
+    cooldown: 12h
+    actions:
+      - pick_one:
+          query: "type:task prop:status=todo prop:effort=xs"
+          limit: 3
+          action: start-task
+      - snooze: ["1d"]
+
+  # The counterweight. A configuration made only of chores is a nag however
+  # well-tuned, so the quietest band holds something that is not work.
+  daily-quip:
+    band: ambient
+    query: "type:quip"
+    suggest: "{text}"
+    actions:
+      - acknowledge: true
+```
+
+What this produces, as each suggestion is deferred:
+
+1. **banner** — "The Meridian retainer proposal is out with Meridian. Chase it?"
+2. **notice** — "Kessler SOW has been in draft a while. Send it?"
+3. **status bar** — "Got a spare moment?", offering three small tasks
+4. **status bar** — the quip
+5. nothing at all
+
+Two things worth noticing:
+
+`chase-proposal` and `send-draft` are almost identical rules. They differ in
+**band**, because who is blocked is the thing that matters — and that is a
+judgement only you can make, which is why bands are operator-declared.
+
+`spare-time` needs no `defer_scope`: a `pick_one` source defaults to `source`
+scope, so declining it means "not now" for the whole idea, not just for
+whichever task happened to be offered.
+
+### Customising the look
+
+The next-action UI emits the operator hooks documented in
+[customisation.md](customisation.md): a `<rela-slot name="companion">` you can
+define in `custom.js`, and `rela-na*` classes plus `data-band` /
+`data-prominence` / `data-source` attributes for `custom.css`.
+
+```js
+// custom.js — a character per band
+const FACES = { blocking: '🐉', stalled: '🦊', ambient: '🌙' }
+customElements.define('rela-slot', class extends HTMLElement {
+  static observedAttributes = ['name', 'data-band']
+  connectedCallback() { this.render() }
+  attributeChangedCallback() { this.render() }
+  render() {
+    if (this.getAttribute('name') !== 'companion') return
+    this.textContent = FACES[this.getAttribute('data-band')] || '✨'
+  }
+})
+```
+
 ## Kanbans
 
 Kanbans provide a visual board view where entities are displayed as cards grouped into columns

--- a/docs/data-entry.md
+++ b/docs/data-entry.md
@@ -1635,6 +1635,96 @@ data.
 > bucket of this state — fine for a single-user deployment, surprising for a
 > shared one. Wiring any identity (JWT, header) separates it.
 
+### A worked example
+
+A small consultancy. Four sources, each a different shape, ordered so the
+loudest is the one someone else is blocked on:
+
+```yaml
+next_action_bands:
+  - id: blocking
+    label: Someone is waiting
+    prominence: banner
+  - id: stalled
+    label: In your court
+    prominence: notice
+  - id: tidying
+    label: Spare time
+    prominence: statusbar
+  - id: ambient
+    label: Nothing owed
+    prominence: statusbar
+
+next_actions:
+  # The ball is in THEIR court. Interpolates the client so the message
+  # says who you would be chasing.
+  chase-proposal:
+    band: blocking
+    query: "type:proposal prop:status=sent"
+    suggest: "The {title} proposal is out with {client}. Chase it?"
+    cooldown: 3d
+    key_props: [status]
+    actions:
+      - navigate: "/entity/{id}"
+        label: "Open it"
+      - snooze: ["1d", "7d"]
+      - dismiss: true
+
+  # Same shape, opposite ownership: this one is waiting on you. Quieter,
+  # because nobody else is blocked.
+  send-draft:
+    band: stalled
+    query: "type:proposal prop:status=draft"
+    suggest: "{title} has been in draft a while. Send it?"
+    cooldown: 3d
+    key_props: [status]
+    actions:
+      - action: mark-sent
+      - snooze: ["1d"]
+      - dismiss: true
+
+  # Nothing is wrong — there is simply an opportunity. The options come
+  # from a query at render time, so they are whatever is small right now.
+  spare-time:
+    band: tidying
+    query: "type:task prop:status=todo prop:effort=xs"
+    suggest: "Got a spare moment? One of these is small."
+    cooldown: 12h
+    actions:
+      - pick_one:
+          query: "type:task prop:status=todo prop:effort=xs"
+          limit: 3
+          action: start-task
+      - snooze: ["1d"]
+
+  # The counterweight. A configuration made only of chores is a nag however
+  # well-tuned, so the quietest band holds something that is not work.
+  daily-quip:
+    band: ambient
+    query: "type:quip"
+    suggest: "{text}"
+    actions:
+      - acknowledge: true
+```
+
+What this produces, as each suggestion is deferred:
+
+1. **banner** — "The Meridian retainer proposal is out with Meridian. Chase it?"
+2. **notice** — "Kessler SOW has been in draft a while. Send it?"
+3. **status bar** — "Got a spare moment?", offering three small tasks
+4. **status bar** — the quip
+5. nothing at all
+
+Two things worth noticing:
+
+`chase-proposal` and `send-draft` are almost identical rules. They differ in
+**band**, because who is blocked is the thing that matters — and that is a
+judgement only you can make, which is why bands are operator-declared.
+
+`spare-time` needs no `defer_scope`: a `pick_one` source defaults to `source`
+scope, so declining it means "not now" for the whole idea, not just for
+whichever task happened to be offered.
+
 ### Customising the look
 
 The next-action UI emits the operator hooks documented in

--- a/docs/data-entry.md
+++ b/docs/data-entry.md
@@ -1550,6 +1550,7 @@ next_actions:
 | `actions` | The affordances offered. See below. |
 | `cooldown` | How long after being *shown* to stay quiet. Defaults to 24h. |
 | `key_props` | Properties that make a re-triggered condition count as **new** — see below. |
+| `defer_scope` | What "not now" covers: `entity` (default) or `source` — see below. |
 
 Exactly one of `query`, `context` or `count` must be set.
 
@@ -1561,6 +1562,27 @@ so a snooze from the first draft still suppresses the second one.
 
 Listing `key_props: [status]` makes the identity change with the status, so a
 genuinely new stall surfaces even though an old snooze exists.
+
+#### `defer_scope` — what "not now" covers
+
+When a user snoozes or dismisses a suggestion, what were they declining?
+
+- **`entity`** (the default) — *this item*. An ISMS task needing attention:
+  they still want the other tasks, just not this one.
+- **`source`** — *the interruption*. A daily quip, one entity per quip: which
+  quip was on offer is incidental, and handing them another immediately is
+  precisely what they said no to. Same for a "complete your profile" nudge —
+  prompting about a different field a moment later is the same nag.
+
+All three are entity-shaped sources with interpolated messages, so neither the
+message template nor the query shape separates them. Only you know which a
+source is, which is why it is declared rather than inferred.
+
+A source with a `pick_one` affordance defaults to `source` scope: its
+suggestion is about the set ("one of these is small"), so keying the deferral
+to whichever option happened to be picked would hand back the same suggestion
+with a different entity. Override it explicitly if you want per-candidate
+deferral anyway.
 
 #### `count` and the read gate
 

--- a/docs/data-entry.md
+++ b/docs/data-entry.md
@@ -1455,6 +1455,185 @@ Multiple terms are combined with AND logic. For example,
 Every card includes a link icon that opens the same query on the search page for further
 exploration.
 
+## Next actions
+
+An optional advisory layer: operator-declared rules that derive **one**
+suggested follow-up from graph state and surface it in the UI.
+
+It is deliberately **not** a task queue:
+
+- **Advisory.** A hint, not a demand — things a user *could* do, not *should*.
+  That is what separates it from `analyze`, which has an opinion about
+  correctness.
+- **One at a time.** Never a list. The aim is a companion that does not
+  overload, and there is no "show me all 12" surface to grow into.
+- **Good, not optimal.** Surfacing one of several good next actions is the
+  goal; avoiding a bad one is the bar.
+
+### Bands
+
+Bands are your priority vocabulary. Declare them in order — **list order is
+priority order**, highest first — and every source names one:
+
+```yaml
+next_action_bands:
+  - id: blocking
+    label: "Someone is waiting"
+    prominence: banner
+  - id: stalled
+    prominence: notice
+  - id: ambient
+    label: "Nothing owed"
+    prominence: statusbar
+```
+
+Bands rather than numeric priorities because per-source numbers do not
+compose: one source returning 90 and another returning 7 on a different scale
+is arbitrary ordering wearing the costume of ranking. With bands, "why is this
+on top?" always has a one-sentence answer.
+
+The engine evaluates bands in order and **stops at the first one with
+something to say**, so a typical page runs one or two queries rather than all
+of them.
+
+#### Prominence
+
+How much a band interrupts. The levels differ in what the user must do to
+clear it, not in decoration:
+
+| Value | Behaviour | Use for |
+|-------|-----------|---------|
+| `banner` | A bordered, accented block at the top of the page. Must be dealt with. | Onboarding; work someone else is blocked on |
+| `notice` | One quiet line in the same position. Easy to read past. | Worth saying once a visit, no urgency |
+| `statusbar` | A chip in the status bar; click to expand. You must go looking. | Ongoing minor stuff — true most of the time, urgent none of it |
+
+`statusbar` is the **default**: a band that has not declared a prominence has
+not earned the top of the page.
+
+### Sources
+
+A source is one rule. Sources are independent — none knows the others exist —
+so adding a rule is adding a source, and a bad source can be deleted without
+perturbing the rest.
+
+```yaml
+next_actions:
+  # Fires only on an empty graph: the first-run case, which no
+  # entity-shaped source can express.
+  first-run:
+    band: blocking
+    count: "client == 0"
+    suggest: "Nothing here yet. Add your first client?"
+    actions:
+      - navigate: "/form/client"
+        label: "Add a client"
+
+  # The common shape: a query plus a message.
+  stale-proposal:
+    band: stalled
+    query: "type:proposal prop:status=sent"
+    suggest: "{title} has been out since {sent_on}. Chase it?"
+    cooldown: 3d
+    key_props: [status]
+    actions:
+      - snooze: ["1d", "7d"]
+      - dismiss: true
+```
+
+| Field | Meaning |
+|-------|---------|
+| `band` | **Required.** Names a declared band. |
+| `query` | Candidate entities, in the search syntax (`type:`, `prop:`, …). |
+| `context` | Instead of `query`: scopes the source to the entity being viewed. |
+| `count` | Instead of `query`: fires on `"<entity_type> == 0"` — the first-run case. |
+| `suggest` | **Required.** The message. `{property}` interpolates from the candidate; `{id}` is the entity id. |
+| `actions` | The affordances offered. See below. |
+| `cooldown` | How long after being *shown* to stay quiet. Defaults to 24h. |
+| `key_props` | Properties that make a re-triggered condition count as **new** — see below. |
+
+Exactly one of `query`, `context` or `count` must be set.
+
+#### `key_props` and re-triggering
+
+A suggestion is identified by `(source, entity, key_props values)`. Without
+`key_props`, a proposal going `draft → sent → draft` keeps the same identity,
+so a snooze from the first draft still suppresses the second one.
+
+Listing `key_props: [status]` makes the identity change with the status, so a
+genuinely new stall surfaces even though an old snooze exists.
+
+#### `count` and the read gate
+
+A `count` source is evaluated **through the caller's read gate** by default:
+it asks "do *I* have any clients?", not "does anyone?". A principal who can
+read no clients therefore sees the first-run hint.
+
+`count_ungated: true` asks the whole-graph question instead. Use it only for a
+genuinely operator-level check ("has this deployment been set up at all?") —
+it discloses that entities of a type exist to someone permitted to read none
+of them.
+
+### Actions
+
+The affordances offered alongside a suggestion. Each entry sets exactly one:
+
+```yaml
+    actions:
+      - navigate: "/entity/task/{id}"   # hand off to a destination
+        label: "Open it"
+      - action: mark-task-done          # run a configured action
+      - set: { status: done }           # inline property mutation
+        confirm: true
+      - snooze: ["1d", "7d"]            # defer, offering these durations
+      - dismiss: true                   # "not this one"
+      - acknowledge: true               # "seen it" — for content sources
+```
+
+`snooze` and `dismiss` are not decoration. Without a way to say "not now", the
+only way to clear a suggestion is to comply with it — which makes it a demand
+rather than a hint. They are also the best signal available: a source
+dismissed every time is a source to delete.
+
+**Muting is always available**, whether or not you configure it. The UI offers
+"stop suggesting this" on every suggestion, per source and per user, and it is
+reversible.
+
+### What is stored, and where
+
+Snoozes, mutes and last-shown timestamps are **per user** and live in
+`.rela/next-action-state.json` — never in the graph. A snooze is not a fact
+about an entity; it is a fact about one person's relationship to a suggestion
+at a moment, and storing it as an entity would make it visible to everyone and
+audited forever.
+
+The state is disposable: losing it costs a user a repeated suggestion, not
+data.
+
+> **Note.** With no identity source configured, every request shares one
+> bucket of this state — fine for a single-user deployment, surprising for a
+> shared one. Wiring any identity (JWT, header) separates it.
+
+### Customising the look
+
+The next-action UI emits the operator hooks documented in
+[customisation.md](customisation.md): a `<rela-slot name="companion">` you can
+define in `custom.js`, and `rela-na*` classes plus `data-band` /
+`data-prominence` / `data-source` attributes for `custom.css`.
+
+```js
+// custom.js — a character per band
+const FACES = { blocking: '🐉', stalled: '🦊', ambient: '🌙' }
+customElements.define('rela-slot', class extends HTMLElement {
+  static observedAttributes = ['name', 'data-band']
+  connectedCallback() { this.render() }
+  attributeChangedCallback() { this.render() }
+  render() {
+    if (this.getAttribute('name') !== 'companion') return
+    this.textContent = FACES[this.getAttribute('data-band')] || '✨'
+  }
+})
+```
+
 ## Kanbans
 
 Kanbans provide a visual board view where entities are displayed as cards grouped into columns

--- a/frontend/src/api/entities.ts
+++ b/frontend/src/api/entities.ts
@@ -8,6 +8,8 @@ import type {
   Template,
   RelationEntry,
   ModernRelationsField,
+  NextActionResponse,
+  NextActionFeedbackKind,
 } from '@/types'
 import { warnIfMissingActions } from '@/utils/affordancesWarning'
 
@@ -320,3 +322,29 @@ export async function deleteRelation(
   return api.delete(`/${getPlural(type)}/${entityId}/relations/${relationName}/${targetId}${query}`)
 }
 
+
+/**
+ * Fetch the single advisory suggestion to show now, or null when nothing is
+ * owed. A null suggestion is the NORMAL, frequent answer for a well-configured
+ * system — not an error, and not an empty state worth apologising for.
+ */
+export async function getNextAction(signal?: AbortSignal): Promise<NextActionResponse> {
+  return api.get<NextActionResponse>('/_next_action', undefined, signal)
+}
+
+/**
+ * Record how the user answered a suggestion.
+ *
+ * `shown` is sent when the suggestion is actually displayed, which is what
+ * starts its cooldown — the GET deliberately does not, so a prefetch or a
+ * discarded response cannot silently consume the suggestion.
+ */
+export async function sendNextActionFeedback(body: {
+  source: string
+  entity_id?: string
+  variant?: string
+  kind: NextActionFeedbackKind
+  duration?: string
+}): Promise<void> {
+  await api.post('/_next_action', body)
+}

--- a/frontend/src/components/NextActionCard.test.ts
+++ b/frontend/src/components/NextActionCard.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import NextActionCard from './NextActionCard.vue'
+import { __resetNextActionForTest } from '@/composables/useNextAction'
+import { useSchemaStore } from '@/stores/schema'
+import { getNextAction, sendNextActionFeedback } from '@/api'
+import type { NextActionSuggestion } from '@/types'
+
+vi.mock('@/api', async () => {
+  const actual = await vi.importActual<typeof import('@/api')>('@/api')
+  return {
+    ...actual,
+    getNextAction: vi.fn(),
+    sendNextActionFeedback: vi.fn(),
+  }
+})
+
+const mockGet = vi.mocked(getNextAction)
+const mockFeedback = vi.mocked(sendNextActionFeedback)
+
+const stubs = { RouterLink: { template: '<a><slot/></a>', props: ['to'] } }
+
+function suggestion(over: Partial<NextActionSuggestion> = {}): NextActionSuggestion {
+  return {
+    source: 'stale',
+    band: 'stalled',
+    entity_id: 'TASK-1',
+    message: 'Still on it?',
+    ...over,
+  }
+}
+
+async function mountCard(prominence?: string) {
+  if (prominence) {
+    const schemaStore = useSchemaStore()
+    schemaStore.nextActionBands = [
+      { id: 'stalled', label: 'Stalled', prominence },
+    ] as never
+  }
+  const w = mount(NextActionCard, { global: { stubs } })
+  await vi.waitFor(() => expect(mockGet).toHaveBeenCalled())
+  await w.vm.$nextTick()
+  await w.vm.$nextTick()
+  return w
+}
+
+describe('NextActionCard', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.clearAllMocks()
+    __resetNextActionForTest()
+    mockFeedback.mockResolvedValue(undefined)
+  })
+
+  describe('when nothing is owed', () => {
+    // Silence is the normal condition of a well-configured system; an empty
+    // state would turn that quiet into noise on every page load.
+    it('renders nothing at all', async () => {
+      mockGet.mockResolvedValue({ suggestion: null })
+      const w = await mountCard()
+
+      expect(w.find('.rela-na').exists()).toBe(false)
+      expect(w.text()).toBe('')
+    })
+  })
+
+  describe('surface routing', () => {
+    it.each(['banner', 'notice'])('renders the %s prominence on the page', async (prom) => {
+      mockGet.mockResolvedValue({ suggestion: suggestion() })
+      const w = await mountCard(prom)
+
+      expect(w.find(`.na--${prom}`).exists()).toBe(true)
+      expect(w.text()).toContain('Still on it?')
+    })
+
+    // The status bar owns that tier; rendering here too would show the same
+    // suggestion twice.
+    it('renders nothing for the statusbar prominence', async () => {
+      mockGet.mockResolvedValue({ suggestion: suggestion() })
+      const w = await mountCard('statusbar')
+
+      expect(w.find('.rela-na').exists()).toBe(false)
+    })
+
+    // The band label answers "why am I seeing this?" — the insistent tier
+    // states it, the quiet one does not shout.
+    it('shows the band label on banner but not notice', async () => {
+      mockGet.mockResolvedValue({ suggestion: suggestion() })
+
+      const banner = await mountCard('banner')
+      expect(banner.find('.rela-na-band').text()).toBe('Stalled')
+
+      __resetNextActionForTest()
+      vi.clearAllMocks()
+      mockGet.mockResolvedValue({ suggestion: suggestion() })
+      const notice = await mountCard('notice')
+      expect(notice.find('.rela-na-band').exists()).toBe(false)
+    })
+  })
+
+  // docs/customisation.md tier 1 + tier 2. These are the operator's documented
+  // hooks for skinning the companion (e.g. a character image per band), so a
+  // rename here is a contract break, not a refactor.
+  describe('operator customisation hooks', () => {
+    it('emits the tier-1 companion slot carrying the band', async () => {
+      mockGet.mockResolvedValue({ suggestion: suggestion() })
+      const w = await mountCard('banner')
+
+      const slot = w.find('rela-slot')
+      expect(slot.exists()).toBe(true)
+      expect(slot.attributes('name')).toBe('companion')
+      expect(slot.attributes('data-band')).toBe('stalled')
+      expect(slot.attributes('data-prominence')).toBe('banner')
+    })
+
+    it('exposes the tier-2 classes and data attributes', async () => {
+      mockGet.mockResolvedValue({ suggestion: suggestion() })
+      const w = await mountCard('banner')
+
+      const root = w.find('.rela-na')
+      expect(root.exists()).toBe(true)
+      expect(root.attributes('data-band')).toBe('stalled')
+      expect(root.attributes('data-prominence')).toBe('banner')
+      expect(root.attributes('data-source')).toBe('stale')
+      expect(root.attributes('data-entity-id')).toBe('TASK-1')
+      expect(w.find('.rela-na-message').text()).toBe('Still on it?')
+    })
+
+    // The slot is inert without a custom.js definition, so a stock deployment
+    // renders as if it were absent.
+    it('leaves the slot empty when nothing defines it', async () => {
+      mockGet.mockResolvedValue({ suggestion: suggestion() })
+      const w = await mountCard('banner')
+
+      expect(w.find('rela-slot').text()).toBe('')
+    })
+  })
+})

--- a/frontend/src/components/NextActionCard.test.ts
+++ b/frontend/src/components/NextActionCard.test.ts
@@ -34,9 +34,7 @@ function suggestion(over: Partial<NextActionSuggestion> = {}): NextActionSuggest
 async function mountCard(prominence?: string) {
   if (prominence) {
     const schemaStore = useSchemaStore()
-    schemaStore.nextActionBands = [
-      { id: 'stalled', label: 'Stalled', prominence },
-    ] as never
+    schemaStore.nextActionBands = [{ id: 'stalled', label: 'Stalled', prominence }] as never
   }
   const w = mount(NextActionCard, { global: { stubs } })
   await vi.waitFor(() => expect(mockGet).toHaveBeenCalled())

--- a/frontend/src/components/NextActionCard.vue
+++ b/frontend/src/components/NextActionCard.vue
@@ -22,14 +22,27 @@ onMounted(loadOnce)
 <template>
   <section
     v-if="isPageLevel && suggestion"
-    class="na"
+    class="na rela-na"
     :class="`na--${prominence}`"
+    :data-band="suggestion.band"
+    :data-prominence="prominence"
+    :data-source="suggestion.source"
+    :data-entity-id="suggestion.entity_id"
     aria-label="Suggested next action"
   >
+    <!--
+      Tier-1 operator hook (docs/customisation.md). Inert unless custom.js
+      defines `rela-slot`; when it does, the operator owns the interior and
+      rela keeps `data-band` current so `attributeChangedCallback` can react —
+      e.g. swapping a character image per band. Placed FIRST so a definition
+      reads as a companion beside the message rather than an afterthought.
+    -->
+    <rela-slot name="companion" :data-band="suggestion.band" :data-prominence="prominence" />
+
     <!-- The band label is the "why am I seeing this?" answer, so the insistent
          tier states it and the quiet tier does not shout it. -->
-    <div v-if="prominence === 'banner'" class="na__band">{{ bandLabel }}</div>
-    <p class="na__message">{{ suggestion.message }}</p>
+    <div v-if="prominence === 'banner'" class="na__band rela-na-band">{{ bandLabel }}</div>
+    <p class="na__message rela-na-message">{{ suggestion.message }}</p>
     <NextActionOffers :offers="suggestion.actions || []" :entity-id="suggestion.entity_id" />
   </section>
 </template>
@@ -48,6 +61,15 @@ onMounted(loadOnce)
  */
 .na {
   margin-bottom: 16px;
+}
+
+/*
+ * The companion slot is inert by default: no box, no space taken, so a stock
+ * deployment renders exactly as if it were absent. An operator's custom.js
+ * gives it content and sizes it from custom.css.
+ */
+.na :deep(rela-slot) {
+  display: contents;
 }
 
 /* banner — deliberately hard to skim past. For onboarding and for work

--- a/frontend/src/components/NextActionCard.vue
+++ b/frontend/src/components/NextActionCard.vue
@@ -1,260 +1,92 @@
 <script setup lang="ts">
 /**
- * The advisory next-action surface: ONE suggestion, or nothing.
+ * The page-level next-action surface: ONE suggestion, or nothing.
  *
- * Deliberately not a list and not a queue. The server resolves exactly one
- * suggestion — message already interpolated, affordances attached — so this
- * component renders what it is given and never re-derives a ranking. There is
- * no "show all" affordance to grow into, which is the point.
+ * Renders only the `banner` and `notice` prominences — the tiers that belong
+ * on the page. A `statusbar` suggestion is rendered by StatusBar instead, so
+ * this component stays empty for it rather than duplicating the slot.
  *
- * When nothing is owed the component renders NOTHING (no empty state, no
- * "you're all caught up" card). Silence is the normal condition of a
- * well-configured system, and an empty-state box would turn that quiet into
- * visual noise on every page load.
+ * When nothing is owed it renders NOTHING: no empty state, no "you're all
+ * caught up" card. Silence is the normal condition of a well-configured
+ * system, and a placeholder would turn that quiet into noise on every page.
  */
-import { ref, computed, onMounted } from 'vue'
-import { getNextAction, sendNextActionFeedback } from '@/api'
-import { useSchemaStore } from '@/stores'
-import type { NextActionSuggestion, NextActionOffer, NextActionProminence } from '@/types'
+import { onMounted } from 'vue'
+import { useNextAction } from '@/composables/useNextAction'
+import NextActionOffers from './NextActionOffers.vue'
 
-const schemaStore = useSchemaStore()
+const { suggestion, bandLabel, prominence, isPageLevel, loadOnce } = useNextAction()
 
-const suggestion = ref<NextActionSuggestion | null>(null)
-const busy = ref(false)
-
-/** The band definition backing the current suggestion, if declared. */
-const band = computed(() => {
-  const s = suggestion.value
-  if (!s) return undefined
-  return schemaStore.nextActionBands.find((b) => b.id === s.band)
-})
-
-/** Operator-supplied label for the suggestion's band, falling back to its id. */
-const bandLabel = computed(() => band.value?.label || suggestion.value?.band || '')
-
-/**
- * How invasive this suggestion should look. Defaults to 'card' — matching the
- * server-side default — so an operator who has not thought about prominence
- * gets a visible suggestion rather than a hidden one.
- */
-const prominence = computed<NextActionProminence>(() => band.value?.prominence || 'card')
-
-/** The band chip is noise on the quiet levels, where the text is the point. */
-const showBandLabel = computed(() => prominence.value === 'banner' || prominence.value === 'card')
-
-async function load() {
-  try {
-    const res = await getNextAction()
-    suggestion.value = res.suggestion
-    // Report the impression only once it is actually on screen: this is what
-    // starts the cooldown. The GET deliberately does not, so a prefetch or a
-    // discarded response cannot silently consume the suggestion.
-    if (res.suggestion) {
-      await sendNextActionFeedback({
-        source: res.suggestion.source,
-        entity_id: res.suggestion.entity_id,
-        variant: res.suggestion.variant,
-        kind: 'shown',
-      })
-    }
-  } catch (err) {
-    // An advisory surface must never break the page it sits on. Log and stay
-    // silent rather than rendering an error where a hint would go.
-    console.error('next-action load failed:', err)
-    suggestion.value = null
-  }
-}
-
-/** Send feedback, then re-resolve so the next suggestion (if any) appears. */
-async function respond(kind: 'snooze' | 'dismiss' | 'mute', duration?: string) {
-  const s = suggestion.value
-  if (!s || busy.value) return
-  busy.value = true
-  try {
-    await sendNextActionFeedback({
-      source: s.source,
-      entity_id: s.entity_id,
-      variant: s.variant,
-      kind,
-      duration,
-    })
-    await load()
-  } catch (err) {
-    console.error('next-action feedback failed:', err)
-  } finally {
-    busy.value = false
-  }
-}
-
-/** Acknowledge is "seen it" — no state beyond the impression already sent. */
-function acknowledge() {
-  suggestion.value = null
-}
-
-function offerLabel(offer: NextActionOffer, fallback: string): string {
-  return offer.label || fallback
-}
-
-onMounted(load)
+onMounted(loadOnce)
 </script>
 
 <template>
   <section
-    v-if="suggestion"
-    class="next-action"
-    :class="`next-action--${prominence}`"
+    v-if="isPageLevel && suggestion"
+    class="na"
+    :class="`na--${prominence}`"
     aria-label="Suggested next action"
   >
-    <div v-if="showBandLabel" class="next-action__band">{{ bandLabel }}</div>
-    <p class="next-action__message">{{ suggestion.message }}</p>
-
-    <div class="next-action__offers">
-      <template v-for="(offer, i) in suggestion.actions || []" :key="i">
-        <!-- navigate: hand off to a destination -->
-        <router-link
-          v-if="offer.navigate"
-          class="btn btn--primary"
-          :to="offer.navigate.replace('{id}', suggestion.entity_id || '')"
-        >
-          {{ offerLabel(offer, 'Open') }}
-        </router-link>
-
-        <!-- snooze: one button per offered duration -->
-        <button
-          v-for="d in offer.snooze || []"
-          :key="d"
-          class="btn"
-          :disabled="busy"
-          @click="respond('snooze', d)"
-        >
-          Snooze {{ d }}
-        </button>
-
-        <button
-          v-if="offer.dismiss"
-          class="btn"
-          :disabled="busy"
-          @click="respond('dismiss')"
-        >
-          {{ offerLabel(offer, 'Not this') }}
-        </button>
-
-        <button
-          v-if="offer.acknowledge"
-          class="btn"
-          :disabled="busy"
-          @click="acknowledge"
-        >
-          {{ offerLabel(offer, 'Nice') }}
-        </button>
-      </template>
-
-      <!-- Muting is always available, never operator-configured: without a
-           one-click way to switch a source off, an annoying suggestion can
-           only be escaped by complying with it. It is also the signal that
-           tells an operator which source to delete. -->
-      <button
-        class="btn btn--quiet next-action__mute"
-        :disabled="busy"
-        title="Stop showing suggestions from this source"
-        @click="respond('mute')"
-      >
-        Mute
-      </button>
-    </div>
+    <!-- The band label is the "why am I seeing this?" answer, so the insistent
+         tier states it and the quiet tier does not shout it. -->
+    <div v-if="prominence === 'banner'" class="na__band">{{ bandLabel }}</div>
+    <p class="na__message">{{ suggestion.message }}</p>
+    <NextActionOffers :offers="suggestion.actions || []" :entity-id="suggestion.entity_id" />
   </section>
 </template>
 
 <style scoped>
 /*
- * Four prominence levels, differing in how much they interrupt. The shared
- * rules hold layout; each modifier only adjusts weight, chrome and scale, so
- * a new level means one block rather than a new component.
+ * Two page-level tiers. They differ in how hard they are to read past, not in
+ * layout: a bounded "card" variant was removed because it and the banner were
+ * cleared by the same shrug — two spellings of one interruption model.
  */
-.next-action {
+.na {
   margin-bottom: var(--space-4, 16px);
 }
 
-/* banner — full width, accented edge, hard to scroll past. For a band where
-   someone else is blocked. */
-.next-action--banner {
-  border: 1px solid var(--color-border);
+/* banner — accented, filled, deliberately hard to skim past. For onboarding
+   and for work someone else is blocked on. */
+.na--banner {
+  border: 1px solid var(--color-primary, #3b82f6);
   border-left: 4px solid var(--color-primary, #3b82f6);
   border-radius: var(--radius-md, 8px);
   padding: var(--space-4, 16px);
-  background: var(--color-surface);
+  background: color-mix(in srgb, var(--color-primary, #3b82f6) 8%, var(--color-surface));
 }
 
-/* card — the default: a bounded box among the page's other content. */
-.next-action--card {
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-md, 8px);
-  padding: var(--space-4, 16px);
-  background: var(--color-surface);
+.na--banner .na__message {
+  font-weight: 600;
 }
 
-/* inline — present, not competing: one row, no surrounding chrome. */
-.next-action--inline {
-  display: flex;
-  align-items: center;
-  gap: var(--space-3, 12px);
-  flex-wrap: wrap;
+/* notice — same position, no accent, no fill, muted text. Says its piece and
+   is easy to read past on purpose. */
+.na--notice {
   padding: var(--space-2, 8px) 0;
-}
-
-/* whisper — noticing it is optional. For content and ambient sources. */
-.next-action--whisper {
+  border-bottom: 1px solid var(--color-border);
   display: flex;
   align-items: center;
   gap: var(--space-3, 12px);
   flex-wrap: wrap;
-  padding: var(--space-1, 4px) 0;
-  opacity: 0.65;
+  color: var(--color-text-muted);
   font-size: var(--font-size-sm, 0.875rem);
 }
 
-/* Quiet levels put the message and its buttons on one line, so the message
-   takes the free space and the offers sit at the trailing edge. */
-.next-action--inline .next-action__message,
-.next-action--whisper .next-action__message {
+.na--notice .na__message {
   margin: 0;
   flex: 1 1 auto;
 }
 
-.next-action--inline .next-action__offers,
-.next-action--whisper .next-action__offers {
-  flex: 0 0 auto;
-}
-
-/* At whisper volume a mute button would out-shout the content it sits next
-   to; it stays reachable but drops the extra emphasis. */
-.next-action--whisper .next-action__mute {
-  margin-left: 0;
-}
-
-.next-action__band {
-  font-size: 0.75rem;
+.na__band {
+  font-size: var(--font-size-sm, 0.75rem);
   text-transform: uppercase;
   letter-spacing: 0.05em;
-  color: var(--color-text-muted);
+  color: var(--color-primary, #3b82f6);
+  font-weight: 600;
   margin-bottom: var(--space-2, 8px);
 }
 
-.next-action__message {
+.na__message {
   margin: 0 0 var(--space-3, 12px);
   font-size: 1.05rem;
-}
-
-.next-action__offers {
-  display: flex;
-  flex-wrap: wrap;
-  gap: var(--space-2, 8px);
-  align-items: center;
-}
-
-/* Push mute to the trailing edge: available, but never the obvious click. */
-.next-action__mute {
-  margin-left: auto;
-  opacity: 0.7;
 }
 </style>

--- a/frontend/src/components/NextActionCard.vue
+++ b/frontend/src/components/NextActionCard.vue
@@ -39,54 +39,76 @@ onMounted(loadOnce)
  * Two page-level tiers. They differ in how hard they are to read past, not in
  * layout: a bounded "card" variant was removed because it and the banner were
  * cleared by the same shrug — two spellings of one interruption model.
+ *
+ * Tokens are the app's own (--card-bg, --border-color, --accent-color,
+ * --muted-text, --radius-lg, --font-size-*). An earlier pass invented names
+ * like --space-4 and --color-primary that do not exist in this codebase, so
+ * every rule silently ran on its fallback and nothing lined up with the
+ * surrounding UI.
  */
 .na {
-  margin-bottom: var(--space-4, 16px);
+  margin-bottom: 16px;
 }
 
-/* banner — accented, filled, deliberately hard to skim past. For onboarding
-   and for work someone else is blocked on. */
+/* banner — accented and filled, deliberately hard to skim past. For onboarding
+   and for work someone else is blocked on. The left rule carries the emphasis;
+   the tint keeps it from reading as an error. */
 .na--banner {
-  border: 1px solid var(--color-primary, #3b82f6);
-  border-left: 4px solid var(--color-primary, #3b82f6);
-  border-radius: var(--radius-md, 8px);
-  padding: var(--space-4, 16px);
-  background: color-mix(in srgb, var(--color-primary, #3b82f6) 8%, var(--color-surface));
+  border: 1px solid var(--border-color);
+  border-left: 3px solid var(--accent-color);
+  border-radius: var(--radius-lg);
+  padding: 16px;
+  background: var(--card-bg);
 }
 
 .na--banner .na__message {
-  font-weight: 600;
+  margin: 0 0 12px;
+  font-size: var(--font-size-lg);
+  line-height: 1.4;
 }
 
-/* notice — same position, no accent, no fill, muted text. Says its piece and
-   is easy to read past on purpose. */
+/* notice — same position, no box, no fill. Says its piece on one line and is
+   easy to read past on purpose. Sits on the page's own background so it reads
+   as page furniture rather than as content. */
 .na--notice {
-  padding: var(--space-2, 8px) 0;
-  border-bottom: 1px solid var(--color-border);
   display: flex;
   align-items: center;
-  gap: var(--space-3, 12px);
+  gap: 12px;
   flex-wrap: wrap;
-  color: var(--color-text-muted);
-  font-size: var(--font-size-sm, 0.875rem);
+  padding: 8px 0 12px;
+  border-bottom: 1px solid var(--border-color);
 }
 
 .na--notice .na__message {
   margin: 0;
   flex: 1 1 auto;
+  min-width: 240px;
+  color: var(--muted-text);
+  font-size: var(--font-size-base);
 }
 
+/* The band chip follows the app's existing label convention (see .cmdk-type in
+   CommandPaletteModal) rather than inventing a third uppercase-label style. */
 .na__band {
-  font-size: var(--font-size-sm, 0.75rem);
+  display: inline-block;
+  margin-bottom: 8px;
+  padding: 2px 8px;
+  border-radius: var(--radius-sm);
+  background: var(--accent-color);
+  color: white;
+  font-size: var(--font-size-xs);
+  font-weight: 500;
   text-transform: uppercase;
-  letter-spacing: 0.05em;
-  color: var(--color-primary, #3b82f6);
-  font-weight: 600;
-  margin-bottom: var(--space-2, 8px);
+  letter-spacing: 0.04em;
 }
 
-.na__message {
-  margin: 0 0 var(--space-3, 12px);
-  font-size: 1.05rem;
+@media (max-width: 768px) {
+  .na--banner {
+    padding: 12px;
+  }
+
+  .na--banner .na__message {
+    font-size: var(--font-size-base);
+  }
 }
 </style>

--- a/frontend/src/components/NextActionCard.vue
+++ b/frontend/src/components/NextActionCard.vue
@@ -10,13 +10,24 @@
  * caught up" card. Silence is the normal condition of a well-configured
  * system, and a placeholder would turn that quiet into noise on every page.
  */
-import { onMounted } from 'vue'
+import { onMounted, watch } from 'vue'
 import { useNextAction } from '@/composables/useNextAction'
 import NextActionOffers from './NextActionOffers.vue'
 
-const { suggestion, bandLabel, prominence, isPageLevel, loadOnce } = useNextAction()
+const { suggestion, bandLabel, prominence, isPageLevel, loadOnce, markShown } = useNextAction()
 
 onMounted(loadOnce)
+
+// Report the impression when this component actually RENDERS the suggestion —
+// not when it is resolved. The status-bar tier is rendered elsewhere, and a
+// suggestion replaced by feedback must not be counted before it is seen.
+watch(
+  isPageLevel,
+  (shown) => {
+    if (shown) void markShown()
+  },
+  { immediate: true },
+)
 </script>
 
 <template>

--- a/frontend/src/components/NextActionCard.vue
+++ b/frontend/src/components/NextActionCard.vue
@@ -1,0 +1,185 @@
+<script setup lang="ts">
+/**
+ * The advisory next-action surface: ONE suggestion, or nothing.
+ *
+ * Deliberately not a list and not a queue. The server resolves exactly one
+ * suggestion — message already interpolated, affordances attached — so this
+ * component renders what it is given and never re-derives a ranking. There is
+ * no "show all" affordance to grow into, which is the point.
+ *
+ * When nothing is owed the component renders NOTHING (no empty state, no
+ * "you're all caught up" card). Silence is the normal condition of a
+ * well-configured system, and an empty-state box would turn that quiet into
+ * visual noise on every page load.
+ */
+import { ref, computed, onMounted } from 'vue'
+import { getNextAction, sendNextActionFeedback } from '@/api'
+import { useSchemaStore } from '@/stores'
+import type { NextActionSuggestion, NextActionOffer } from '@/types'
+
+const schemaStore = useSchemaStore()
+
+const suggestion = ref<NextActionSuggestion | null>(null)
+const busy = ref(false)
+
+/** Operator-supplied label for the suggestion's band, falling back to its id. */
+const bandLabel = computed(() => {
+  const s = suggestion.value
+  if (!s) return ''
+  const band = schemaStore.nextActionBands.find((b) => b.id === s.band)
+  return band?.label || s.band
+})
+
+async function load() {
+  try {
+    const res = await getNextAction()
+    suggestion.value = res.suggestion
+    // Report the impression only once it is actually on screen: this is what
+    // starts the cooldown. The GET deliberately does not, so a prefetch or a
+    // discarded response cannot silently consume the suggestion.
+    if (res.suggestion) {
+      await sendNextActionFeedback({
+        source: res.suggestion.source,
+        entity_id: res.suggestion.entity_id,
+        variant: res.suggestion.variant,
+        kind: 'shown',
+      })
+    }
+  } catch (err) {
+    // An advisory surface must never break the page it sits on. Log and stay
+    // silent rather than rendering an error where a hint would go.
+    console.error('next-action load failed:', err)
+    suggestion.value = null
+  }
+}
+
+/** Send feedback, then re-resolve so the next suggestion (if any) appears. */
+async function respond(kind: 'snooze' | 'dismiss' | 'mute', duration?: string) {
+  const s = suggestion.value
+  if (!s || busy.value) return
+  busy.value = true
+  try {
+    await sendNextActionFeedback({
+      source: s.source,
+      entity_id: s.entity_id,
+      variant: s.variant,
+      kind,
+      duration,
+    })
+    await load()
+  } catch (err) {
+    console.error('next-action feedback failed:', err)
+  } finally {
+    busy.value = false
+  }
+}
+
+/** Acknowledge is "seen it" — no state beyond the impression already sent. */
+function acknowledge() {
+  suggestion.value = null
+}
+
+function offerLabel(offer: NextActionOffer, fallback: string): string {
+  return offer.label || fallback
+}
+
+onMounted(load)
+</script>
+
+<template>
+  <section v-if="suggestion" class="next-action" aria-label="Suggested next action">
+    <div class="next-action__band">{{ bandLabel }}</div>
+    <p class="next-action__message">{{ suggestion.message }}</p>
+
+    <div class="next-action__offers">
+      <template v-for="(offer, i) in suggestion.actions || []" :key="i">
+        <!-- navigate: hand off to a destination -->
+        <router-link
+          v-if="offer.navigate"
+          class="btn btn--primary"
+          :to="offer.navigate.replace('{id}', suggestion.entity_id || '')"
+        >
+          {{ offerLabel(offer, 'Open') }}
+        </router-link>
+
+        <!-- snooze: one button per offered duration -->
+        <button
+          v-for="d in offer.snooze || []"
+          :key="d"
+          class="btn"
+          :disabled="busy"
+          @click="respond('snooze', d)"
+        >
+          Snooze {{ d }}
+        </button>
+
+        <button
+          v-if="offer.dismiss"
+          class="btn"
+          :disabled="busy"
+          @click="respond('dismiss')"
+        >
+          {{ offerLabel(offer, 'Not this') }}
+        </button>
+
+        <button
+          v-if="offer.acknowledge"
+          class="btn"
+          :disabled="busy"
+          @click="acknowledge"
+        >
+          {{ offerLabel(offer, 'Nice') }}
+        </button>
+      </template>
+
+      <!-- Muting is always available, never operator-configured: without a
+           one-click way to switch a source off, an annoying suggestion can
+           only be escaped by complying with it. It is also the signal that
+           tells an operator which source to delete. -->
+      <button
+        class="btn btn--quiet next-action__mute"
+        :disabled="busy"
+        title="Stop showing suggestions from this source"
+        @click="respond('mute')"
+      >
+        Mute
+      </button>
+    </div>
+  </section>
+</template>
+
+<style scoped>
+.next-action {
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md, 8px);
+  padding: var(--space-4, 16px);
+  margin-bottom: var(--space-4, 16px);
+  background: var(--color-surface);
+}
+
+.next-action__band {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--color-text-muted);
+  margin-bottom: var(--space-2, 8px);
+}
+
+.next-action__message {
+  margin: 0 0 var(--space-3, 12px);
+  font-size: 1.05rem;
+}
+
+.next-action__offers {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2, 8px);
+  align-items: center;
+}
+
+/* Push mute to the trailing edge: available, but never the obvious click. */
+.next-action__mute {
+  margin-left: auto;
+  opacity: 0.7;
+}
+</style>

--- a/frontend/src/components/NextActionCard.vue
+++ b/frontend/src/components/NextActionCard.vue
@@ -15,20 +15,32 @@
 import { ref, computed, onMounted } from 'vue'
 import { getNextAction, sendNextActionFeedback } from '@/api'
 import { useSchemaStore } from '@/stores'
-import type { NextActionSuggestion, NextActionOffer } from '@/types'
+import type { NextActionSuggestion, NextActionOffer, NextActionProminence } from '@/types'
 
 const schemaStore = useSchemaStore()
 
 const suggestion = ref<NextActionSuggestion | null>(null)
 const busy = ref(false)
 
-/** Operator-supplied label for the suggestion's band, falling back to its id. */
-const bandLabel = computed(() => {
+/** The band definition backing the current suggestion, if declared. */
+const band = computed(() => {
   const s = suggestion.value
-  if (!s) return ''
-  const band = schemaStore.nextActionBands.find((b) => b.id === s.band)
-  return band?.label || s.band
+  if (!s) return undefined
+  return schemaStore.nextActionBands.find((b) => b.id === s.band)
 })
+
+/** Operator-supplied label for the suggestion's band, falling back to its id. */
+const bandLabel = computed(() => band.value?.label || suggestion.value?.band || '')
+
+/**
+ * How invasive this suggestion should look. Defaults to 'card' — matching the
+ * server-side default — so an operator who has not thought about prominence
+ * gets a visible suggestion rather than a hidden one.
+ */
+const prominence = computed<NextActionProminence>(() => band.value?.prominence || 'card')
+
+/** The band chip is noise on the quiet levels, where the text is the point. */
+const showBandLabel = computed(() => prominence.value === 'banner' || prominence.value === 'card')
 
 async function load() {
   try {
@@ -87,8 +99,13 @@ onMounted(load)
 </script>
 
 <template>
-  <section v-if="suggestion" class="next-action" aria-label="Suggested next action">
-    <div class="next-action__band">{{ bandLabel }}</div>
+  <section
+    v-if="suggestion"
+    class="next-action"
+    :class="`next-action--${prominence}`"
+    aria-label="Suggested next action"
+  >
+    <div v-if="showBandLabel" class="next-action__band">{{ bandLabel }}</div>
     <p class="next-action__message">{{ suggestion.message }}</p>
 
     <div class="next-action__offers">
@@ -149,12 +166,70 @@ onMounted(load)
 </template>
 
 <style scoped>
+/*
+ * Four prominence levels, differing in how much they interrupt. The shared
+ * rules hold layout; each modifier only adjusts weight, chrome and scale, so
+ * a new level means one block rather than a new component.
+ */
 .next-action {
+  margin-bottom: var(--space-4, 16px);
+}
+
+/* banner — full width, accented edge, hard to scroll past. For a band where
+   someone else is blocked. */
+.next-action--banner {
+  border: 1px solid var(--color-border);
+  border-left: 4px solid var(--color-primary, #3b82f6);
+  border-radius: var(--radius-md, 8px);
+  padding: var(--space-4, 16px);
+  background: var(--color-surface);
+}
+
+/* card — the default: a bounded box among the page's other content. */
+.next-action--card {
   border: 1px solid var(--color-border);
   border-radius: var(--radius-md, 8px);
   padding: var(--space-4, 16px);
-  margin-bottom: var(--space-4, 16px);
   background: var(--color-surface);
+}
+
+/* inline — present, not competing: one row, no surrounding chrome. */
+.next-action--inline {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3, 12px);
+  flex-wrap: wrap;
+  padding: var(--space-2, 8px) 0;
+}
+
+/* whisper — noticing it is optional. For content and ambient sources. */
+.next-action--whisper {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3, 12px);
+  flex-wrap: wrap;
+  padding: var(--space-1, 4px) 0;
+  opacity: 0.65;
+  font-size: var(--font-size-sm, 0.875rem);
+}
+
+/* Quiet levels put the message and its buttons on one line, so the message
+   takes the free space and the offers sit at the trailing edge. */
+.next-action--inline .next-action__message,
+.next-action--whisper .next-action__message {
+  margin: 0;
+  flex: 1 1 auto;
+}
+
+.next-action--inline .next-action__offers,
+.next-action--whisper .next-action__offers {
+  flex: 0 0 auto;
+}
+
+/* At whisper volume a mute button would out-shout the content it sits next
+   to; it stays reachable but drops the extra emphasis. */
+.next-action--whisper .next-action__mute {
+  margin-left: 0;
 }
 
 .next-action__band {

--- a/frontend/src/components/NextActionCard.vue
+++ b/frontend/src/components/NextActionCard.vue
@@ -50,12 +50,16 @@ onMounted(loadOnce)
   margin-bottom: 16px;
 }
 
-/* banner — accented and filled, deliberately hard to skim past. For onboarding
-   and for work someone else is blocked on. The left rule carries the emphasis;
-   the tint keeps it from reading as an error. */
+/* banner — deliberately hard to skim past. For onboarding and for work
+   someone else is blocked on.
+   
+   Emphasis comes from a full accent border, NOT a left rule: in this codebase
+   a left accent bar means either a markdown blockquote or something is wrong
+   (ScriptErrorPanel, EntityDetail's inaccessible-banner). Borrowing that shape
+   would make a suggestion read as an error. The band chip carries the colour;
+   the border just says "this one matters". */
 .na--banner {
-  border: 1px solid var(--border-color);
-  border-left: 3px solid var(--accent-color);
+  border: 1px solid var(--accent-color);
   border-radius: var(--radius-lg);
   padding: 16px;
   background: var(--card-bg);

--- a/frontend/src/components/NextActionCard.vue
+++ b/frontend/src/components/NextActionCard.vue
@@ -26,7 +26,7 @@ watch(
   (shown) => {
     if (shown) void markShown()
   },
-  { immediate: true },
+  { immediate: true }
 )
 </script>
 

--- a/frontend/src/components/NextActionCard.vue
+++ b/frontend/src/components/NextActionCard.vue
@@ -43,7 +43,11 @@ onMounted(loadOnce)
          tier states it and the quiet tier does not shout it. -->
     <div v-if="prominence === 'banner'" class="na__band rela-na-band">{{ bandLabel }}</div>
     <p class="na__message rela-na-message">{{ suggestion.message }}</p>
-    <NextActionOffers :offers="suggestion.actions || []" :entity-id="suggestion.entity_id" />
+    <NextActionOffers
+      :offers="suggestion.actions || []"
+      :entity-id="suggestion.entity_id"
+      :pick-options="suggestion.pick_options"
+    />
   </section>
 </template>
 

--- a/frontend/src/components/NextActionOffers.test.ts
+++ b/frontend/src/components/NextActionOffers.test.ts
@@ -1,0 +1,169 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import NextActionOffers from './NextActionOffers.vue'
+import { __resetNextActionForTest, useNextAction } from '@/composables/useNextAction'
+import { getNextAction, sendNextActionFeedback } from '@/api'
+import type { NextActionOffer } from '@/types'
+
+vi.mock('@/api', async () => {
+  const actual = await vi.importActual<typeof import('@/api')>('@/api')
+  return {
+    ...actual,
+    getNextAction: vi.fn(),
+    sendNextActionFeedback: vi.fn(),
+  }
+})
+
+const mockGet = vi.mocked(getNextAction)
+const mockFeedback = vi.mocked(sendNextActionFeedback)
+
+const stubs = { RouterLink: { template: '<a :to="to"><slot/></a>', props: ['to'] } }
+
+function mountOffers(offers: NextActionOffer[]) {
+  return mount(NextActionOffers, {
+    props: { offers, entityId: 'TASK-1' },
+    global: { stubs },
+  })
+}
+
+/**
+ * Load a suggestion into the shared composable. `respond` deliberately no-ops
+ * when there is nothing to answer, so a feedback assertion needs one in hand.
+ */
+async function withLoadedSuggestion() {
+  mockGet.mockResolvedValue({
+    suggestion: {
+      source: 'stale',
+      band: 'stalled',
+      entity_id: 'TASK-1',
+      message: 'Still on it?',
+    },
+  })
+  await useNextAction().loadOnce()
+  mockFeedback.mockClear()
+}
+
+describe('NextActionOffers', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.clearAllMocks()
+    __resetNextActionForTest()
+    mockFeedback.mockResolvedValue(undefined)
+    mockGet.mockResolvedValue({ suggestion: null })
+  })
+
+  describe('acting affordances', () => {
+    it('renders navigate as a primary action', () => {
+      const w = mountOffers([{ navigate: '/entity/task/{id}', label: 'Open it' }])
+
+      expect(w.text()).toContain('Open it')
+      expect(w.find('.btn-primary').exists()).toBe(true)
+    })
+
+    it('interpolates the entity id into the navigate target', () => {
+      const w = mountOffers([{ navigate: '/entity/task/{id}' }])
+
+      expect(w.find('a').attributes('to')).toBe('/entity/task/TASK-1')
+    })
+
+    it('renders acknowledge', () => {
+      const w = mountOffers([{ acknowledge: true, label: 'Nice' }])
+
+      expect(w.text()).toContain('Nice')
+    })
+  })
+
+  describe('the defer menu', () => {
+    // Flat, snooze/dismiss/mute read as peers competing with the action the
+    // operator wants; collapsed, declining is one control.
+    it('is closed until clicked', () => {
+      const w = mountOffers([{ snooze: ['1d'] }])
+
+      expect(w.find('.na-defer__menu').exists()).toBe(false)
+      expect(w.find('.na-defer__trigger').text()).toContain('Not now')
+    })
+
+    it('opens on click', async () => {
+      const w = mountOffers([{ snooze: ['1d', '7d'] }])
+
+      await w.find('.na-defer__trigger').trigger('click')
+
+      expect(w.find('.na-defer__menu').exists()).toBe(true)
+      expect(w.text()).toContain('Remind me in 1d')
+      expect(w.text()).toContain('Remind me in 7d')
+    })
+
+    it('sends the snooze duration the user chose', async () => {
+      await withLoadedSuggestion()
+      const w = mountOffers([{ snooze: ['1d', '7d'] }])
+      await w.find('.na-defer__trigger').trigger('click')
+
+      const items = w.findAll('.na-defer__item')
+      await items[1].trigger('click')
+
+      expect(mockFeedback).toHaveBeenCalledWith(
+        expect.objectContaining({ kind: 'snooze', duration: '7d' }),
+      )
+    })
+
+    it('closes after a choice', async () => {
+      const w = mountOffers([{ snooze: ['1d'] }])
+      await w.find('.na-defer__trigger').trigger('click')
+
+      await w.findAll('.na-defer__item')[0].trigger('click')
+
+      expect(w.find('.na-defer__menu').exists()).toBe(false)
+    })
+
+    it('offers dismiss only when the source configured it', async () => {
+      const w = mountOffers([{ snooze: ['1d'] }])
+      await w.find('.na-defer__trigger').trigger('click')
+
+      expect(w.text()).not.toContain('Not this one')
+    })
+
+    it('offers dismiss when configured', async () => {
+      const w = mountOffers([{ snooze: ['1d'] }, { dismiss: true }])
+      await w.find('.na-defer__trigger').trigger('click')
+
+      expect(w.text()).toContain('Not this one')
+    })
+
+    // Mute is never operator-configured: without a one-click way to switch a
+    // source off, an annoying suggestion can only be escaped by complying.
+    it('always offers mute, even when the source configured nothing', async () => {
+      const w = mountOffers([])
+      await w.find('.na-defer__trigger').trigger('click')
+
+      expect(w.text()).toContain('Stop suggesting this')
+    })
+
+    // Mute governs the SOURCE, not this suggestion, so it is set apart rather
+    // than listed as a peer of the snooze options.
+    it('separates mute from the per-suggestion options', async () => {
+      const w = mountOffers([{ snooze: ['1d'] }])
+      await w.find('.na-defer__trigger').trigger('click')
+
+      expect(w.find('.na-defer__item--sep').text()).toBe('Stop suggesting this')
+    })
+  })
+
+  describe('accessibility', () => {
+    it('marks the trigger as a menu control', () => {
+      const w = mountOffers([{ snooze: ['1d'] }])
+      const trigger = w.find('.na-defer__trigger')
+
+      expect(trigger.attributes('aria-haspopup')).toBe('menu')
+      expect(trigger.attributes('aria-expanded')).toBe('false')
+    })
+
+    it('reflects the open state', async () => {
+      const w = mountOffers([{ snooze: ['1d'] }])
+      await w.find('.na-defer__trigger').trigger('click')
+
+      expect(w.find('.na-defer__trigger').attributes('aria-expanded')).toBe('true')
+      expect(w.find('.na-defer__menu').attributes('role')).toBe('menu')
+    })
+  })
+})

--- a/frontend/src/components/NextActionOffers.test.ts
+++ b/frontend/src/components/NextActionOffers.test.ts
@@ -22,7 +22,7 @@ const stubs = { RouterLink: { template: '<a :to="to"><slot/></a>', props: ['to']
 
 function mountOffers(
   offers: NextActionOffer[],
-  pickOptions?: Record<string, Array<{ entity_id: string; label: string }>>,
+  pickOptions?: Record<string, Array<{ entity_id: string; label: string }>>
 ) {
   return mount(NextActionOffers, {
     props: { offers, entityId: 'TASK-1', pickOptions },
@@ -120,10 +120,9 @@ describe('NextActionOffers', () => {
     // Options are keyed by the offer's INDEX, so an offer preceded by others
     // must still find its own list.
     it('matches options to the right offer by index', () => {
-      const w = mountOffers(
-        [{ acknowledge: true }, pickOffer],
-        { '1': [{ entity_id: 'T-9', label: 'Correct one' }] },
-      )
+      const w = mountOffers([{ acknowledge: true }, pickOffer], {
+        '1': [{ entity_id: 'T-9', label: 'Correct one' }],
+      })
 
       const picks = w.findAll('.rela-na-pick')
       expect(picks).toHaveLength(1)
@@ -160,7 +159,7 @@ describe('NextActionOffers', () => {
       await items[1].trigger('click')
 
       expect(mockFeedback).toHaveBeenCalledWith(
-        expect.objectContaining({ kind: 'snooze', duration: '7d' }),
+        expect.objectContaining({ kind: 'snooze', duration: '7d' })
       )
     })
 

--- a/frontend/src/components/NextActionOffers.test.ts
+++ b/frontend/src/components/NextActionOffers.test.ts
@@ -20,9 +20,12 @@ const mockFeedback = vi.mocked(sendNextActionFeedback)
 
 const stubs = { RouterLink: { template: '<a :to="to"><slot/></a>', props: ['to'] } }
 
-function mountOffers(offers: NextActionOffer[]) {
+function mountOffers(
+  offers: NextActionOffer[],
+  pickOptions?: Record<string, Array<{ entity_id: string; label: string }>>,
+) {
   return mount(NextActionOffers, {
-    props: { offers, entityId: 'TASK-1' },
+    props: { offers, entityId: 'TASK-1', pickOptions },
     global: { stubs },
   })
 }
@@ -71,6 +74,60 @@ describe('NextActionOffers', () => {
       const w = mountOffers([{ acknowledge: true, label: 'Nice' }])
 
       expect(w.text()).toContain('Nice')
+    })
+  })
+
+  describe('pick_one', () => {
+    const pickOffer: NextActionOffer = {
+      pick_one: { query: 'type:task prop:effort=xs', action: 'start-task' },
+    }
+
+    // The options come from a query at render time — that is the whole reason
+    // this affordance exists rather than being a static button list.
+    it('renders one button per resolved option', () => {
+      const w = mountOffers([pickOffer], {
+        '0': [
+          { entity_id: 'T-9', label: 'Draft the retro' },
+          { entity_id: 'T-8', label: 'Rename the bucket' },
+        ],
+      })
+
+      const picks = w.findAll('.rela-na-pick')
+      expect(picks).toHaveLength(2)
+      expect(picks[0].text()).toBe('Draft the retro')
+    })
+
+    it('links each option to its entity', () => {
+      const w = mountOffers([pickOffer], { '0': [{ entity_id: 'T-9', label: 'One' }] })
+
+      expect(w.find('.rela-na-pick').attributes('to')).toBe('/entity/T-9')
+    })
+
+    // An empty option row is worse than no affordance: it says "choose" and
+    // offers nothing.
+    it('renders nothing when the query matched no options', () => {
+      const w = mountOffers([pickOffer], { '0': [] })
+
+      expect(w.find('.rela-na-pick').exists()).toBe(false)
+    })
+
+    it('renders nothing when the server sent no options at all', () => {
+      const w = mountOffers([pickOffer])
+
+      expect(w.find('.rela-na-pick').exists()).toBe(false)
+    })
+
+    // Options are keyed by the offer's INDEX, so an offer preceded by others
+    // must still find its own list.
+    it('matches options to the right offer by index', () => {
+      const w = mountOffers(
+        [{ acknowledge: true }, pickOffer],
+        { '1': [{ entity_id: 'T-9', label: 'Correct one' }] },
+      )
+
+      const picks = w.findAll('.rela-na-pick')
+      expect(picks).toHaveLength(1)
+      expect(picks[0].text()).toBe('Correct one')
     })
   })
 

--- a/frontend/src/components/NextActionOffers.vue
+++ b/frontend/src/components/NextActionOffers.vue
@@ -29,7 +29,7 @@ const props = defineProps<{
 const actEntries = computed(() =>
   props.offers
     .map((offer, index) => ({ offer, index }))
-    .filter(({ offer }) => offer.navigate || offer.acknowledge || offer.pick_one),
+    .filter(({ offer }) => offer.navigate || offer.acknowledge || offer.pick_one)
 )
 
 /** The resolved options for one offer, or [] when the server sent none. */
@@ -121,12 +121,22 @@ onUnmounted(() => document.removeEventListener('click', handleClickOutside))
 
       <ul v-if="deferOpen" class="na-defer__menu" role="menu">
         <li v-for="d in snoozeDurations" :key="d" role="none">
-          <button type="button" class="na-defer__item" role="menuitem" @click.stop="defer('snooze', d)">
+          <button
+            type="button"
+            class="na-defer__item"
+            role="menuitem"
+            @click.stop="defer('snooze', d)"
+          >
             Remind me in {{ d }}
           </button>
         </li>
         <li v-if="hasDismiss" role="none">
-          <button type="button" class="na-defer__item" role="menuitem" @click.stop="defer('dismiss')">
+          <button
+            type="button"
+            class="na-defer__item"
+            role="menuitem"
+            @click.stop="defer('dismiss')"
+          >
             Not this one
           </button>
         </li>

--- a/frontend/src/components/NextActionOffers.vue
+++ b/frontend/src/components/NextActionOffers.vue
@@ -13,9 +13,29 @@
  */
 import { computed, onMounted, onUnmounted, ref, useTemplateRef } from 'vue'
 import { useNextAction } from '@/composables/useNextAction'
-import type { NextActionOffer } from '@/types'
+import type { NextActionOffer, NextActionPickOption } from '@/types'
 
-const props = defineProps<{ offers: NextActionOffer[]; entityId?: string }>()
+const props = defineProps<{
+  offers: NextActionOffer[]
+  entityId?: string
+  pickOptions?: Record<string, NextActionPickOption[]>
+}>()
+
+/**
+ * Offers that ACT, paired with their index so a pick_one can find its live
+ * options. The index is the key the server used, so filtering must not lose
+ * it — hence the map-then-filter rather than a plain filter.
+ */
+const actEntries = computed(() =>
+  props.offers
+    .map((offer, index) => ({ offer, index }))
+    .filter(({ offer }) => offer.navigate || offer.acknowledge || offer.pick_one),
+)
+
+/** The resolved options for one offer, or [] when the server sent none. */
+function optionsFor(index: number): NextActionPickOption[] {
+  return props.pickOptions?.[String(index)] ?? []
+}
 
 const { busy, respond, acknowledge } = useNextAction()
 
@@ -25,11 +45,6 @@ const deferRef = useTemplateRef<HTMLElement>('deferRef')
 /** Snooze durations the operator offered, flattened across offers. */
 const snoozeDurations = computed(() => props.offers.flatMap((o) => o.snooze || []))
 const hasDismiss = computed(() => props.offers.some((o) => o.dismiss))
-
-/** Affordances that ACT rather than defer — these stay as visible buttons. */
-const actOffers = computed(() =>
-  props.offers.filter((o) => o.navigate || o.acknowledge),
-)
 
 function offerLabel(offer: NextActionOffer, fallback: string): string {
   return offer.label || fallback
@@ -52,7 +67,7 @@ onUnmounted(() => document.removeEventListener('click', handleClickOutside))
 
 <template>
   <div class="na-offers rela-na-offers">
-    <template v-for="(offer, i) in actOffers" :key="i">
+    <template v-for="{ offer, index } in actEntries" :key="index">
       <router-link
         v-if="offer.navigate"
         class="btn btn-sm btn-primary"
@@ -69,6 +84,18 @@ onUnmounted(() => document.removeEventListener('click', handleClickOutside))
       >
         {{ offerLabel(offer, 'Nice') }}
       </button>
+
+      <!-- pick_one: one button per live option. Rendered only when the server
+           resolved some — an empty list means the query matched nothing, and
+           an empty option row would be worse than no affordance. -->
+      <router-link
+        v-for="opt in offer.pick_one ? optionsFor(index) : []"
+        :key="opt.entity_id"
+        class="btn btn-sm btn-secondary rela-na-pick"
+        :to="`/entity/${opt.entity_id}`"
+      >
+        {{ opt.label }}
+      </router-link>
     </template>
 
     <!--

--- a/frontend/src/components/NextActionOffers.vue
+++ b/frontend/src/components/NextActionOffers.vue
@@ -4,22 +4,55 @@
  * the status-bar popover render identical controls — a snooze that behaved
  * differently depending on where it was clicked would be a bug nobody thinks
  * to test for.
+ *
+ * The defer affordances (snooze durations, dismiss, mute) collapse into ONE
+ * "Not now" menu. Flat, they read as three or four equal choices competing
+ * with the thing the operator actually wants you to do; and only one of them
+ * — mute — is about the source rather than this suggestion, which a row of
+ * sibling buttons cannot express.
  */
+import { computed, onMounted, onUnmounted, ref, useTemplateRef } from 'vue'
 import { useNextAction } from '@/composables/useNextAction'
 import type { NextActionOffer } from '@/types'
 
-defineProps<{ offers: NextActionOffer[]; entityId?: string }>()
+const props = defineProps<{ offers: NextActionOffer[]; entityId?: string }>()
 
 const { busy, respond, acknowledge } = useNextAction()
+
+const deferOpen = ref(false)
+const deferRef = useTemplateRef<HTMLElement>('deferRef')
+
+/** Snooze durations the operator offered, flattened across offers. */
+const snoozeDurations = computed(() => props.offers.flatMap((o) => o.snooze || []))
+const hasDismiss = computed(() => props.offers.some((o) => o.dismiss))
+
+/** Affordances that ACT rather than defer — these stay as visible buttons. */
+const actOffers = computed(() =>
+  props.offers.filter((o) => o.navigate || o.acknowledge),
+)
 
 function offerLabel(offer: NextActionOffer, fallback: string): string {
   return offer.label || fallback
 }
+
+function handleClickOutside(e: MouseEvent) {
+  if (deferOpen.value && deferRef.value && !deferRef.value.contains(e.target as Node)) {
+    deferOpen.value = false
+  }
+}
+
+async function defer(kind: 'snooze' | 'dismiss' | 'mute', duration?: string) {
+  deferOpen.value = false
+  await respond(kind, duration)
+}
+
+onMounted(() => document.addEventListener('click', handleClickOutside))
+onUnmounted(() => document.removeEventListener('click', handleClickOutside))
 </script>
 
 <template>
   <div class="na-offers">
-    <template v-for="(offer, i) in offers" :key="i">
+    <template v-for="(offer, i) in actOffers" :key="i">
       <router-link
         v-if="offer.navigate"
         class="btn btn-sm btn-primary"
@@ -29,36 +62,59 @@ function offerLabel(offer: NextActionOffer, fallback: string): string {
       </router-link>
 
       <button
-        v-for="d in offer.snooze || []"
-        :key="d"
+        v-if="offer.acknowledge"
         class="btn btn-sm btn-secondary"
         :disabled="busy"
-        @click="respond('snooze', d)"
+        @click="acknowledge()"
       >
-        Snooze {{ d }}
-      </button>
-
-      <button v-if="offer.dismiss" class="btn btn-sm btn-secondary" :disabled="busy" @click="respond('dismiss')">
-        {{ offerLabel(offer, 'Not this') }}
-      </button>
-
-      <button v-if="offer.acknowledge" class="btn btn-sm btn-secondary" :disabled="busy" @click="acknowledge()">
         {{ offerLabel(offer, 'Nice') }}
       </button>
     </template>
 
-    <!-- Muting is always available, never operator-configured: without a
-         one-click way to switch a source off, an annoying suggestion can only
-         be escaped by complying with it. It is also the signal that tells an
-         operator which source to delete. -->
-    <button
-      class="na-offers__mute"
-      :disabled="busy"
-      title="Stop showing suggestions from this source"
-      @click="respond('mute')"
-    >
-      Mute
-    </button>
+    <!--
+      One "Not now" control for every way of NOT acting. Mute is always
+      present, never operator-configured: without a one-click way to switch a
+      source off, an annoying suggestion can only be escaped by complying with
+      it — and the mute rate is the signal telling an operator which source to
+      delete. It sits last, separated, because it is about the source rather
+      than this suggestion.
+    -->
+    <div ref="deferRef" class="na-defer">
+      <button
+        type="button"
+        class="na-defer__trigger"
+        :disabled="busy"
+        aria-haspopup="menu"
+        :aria-expanded="deferOpen"
+        @click.stop="deferOpen = !deferOpen"
+      >
+        Not now
+        <span class="na-defer__caret" aria-hidden="true">&#9662;</span>
+      </button>
+
+      <ul v-if="deferOpen" class="na-defer__menu" role="menu">
+        <li v-for="d in snoozeDurations" :key="d" role="none">
+          <button type="button" class="na-defer__item" role="menuitem" @click.stop="defer('snooze', d)">
+            Remind me in {{ d }}
+          </button>
+        </li>
+        <li v-if="hasDismiss" role="none">
+          <button type="button" class="na-defer__item" role="menuitem" @click.stop="defer('dismiss')">
+            Not this one
+          </button>
+        </li>
+        <li role="none">
+          <button
+            type="button"
+            class="na-defer__item na-defer__item--sep"
+            role="menuitem"
+            @click.stop="defer('mute')"
+          >
+            Stop suggesting this
+          </button>
+        </li>
+      </ul>
+    </div>
   </div>
 </template>
 
@@ -70,35 +126,86 @@ function offerLabel(offer: NextActionOffer, fallback: string): string {
   align-items: center;
 }
 
-/*
- * Mute is a text link, not a button. Rendering it as one made it compete with
- * the affordances the operator actually configured — a suggestion offering
- * "Snooze / Not this / Mute" reads as three equal choices, when the first two
- * answer this suggestion and the third switches off a whole source.
- *
- * It stays reachable (that is the point of per-source mute) but has to look
- * like the escape hatch it is.
- */
-.na-offers__mute {
+/* The defer control is pushed to the trailing edge: reachable, never the
+   obvious click. */
+.na-defer {
+  position: relative;
+  display: inline-block;
   margin-left: auto;
-  padding: 4px 6px;
+}
+
+/* Quieter than .btn-secondary on purpose — declining should not look like an
+   equal-weight alternative to acting. */
+.na-defer__trigger {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 6px 10px;
+  border: 1px solid transparent;
+  border-radius: var(--radius-md);
   background: none;
-  border: none;
   color: var(--muted-text);
-  font-size: var(--font-size-sm);
+  font-size: var(--font-size-dense);
   cursor: pointer;
-  text-decoration: underline;
-  text-underline-offset: 2px;
-  opacity: 0.75;
-  transition: opacity 0.15s ease;
+  transition: all 0.15s ease;
 }
 
-.na-offers__mute:hover:not(:disabled) {
-  opacity: 1;
+.na-defer__trigger:hover:not(:disabled) {
+  border-color: var(--border-color);
+  color: var(--text-color);
 }
 
-.na-offers__mute:disabled {
+.na-defer__trigger:disabled {
   cursor: not-allowed;
-  opacity: 0.4;
+  opacity: 0.5;
+}
+
+.na-defer__caret {
+  font-size: 11px;
+  line-height: 1;
+  opacity: 0.75;
+}
+
+/* Mirrors .status-menu (StatusControl) so the app has one dropdown look. */
+.na-defer__menu {
+  position: absolute;
+  right: 0;
+  z-index: 20;
+  margin: 4px 0 0;
+  padding: 4px;
+  list-style: none;
+  min-width: 190px;
+  background: var(--input-bg);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-md);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.12);
+}
+
+.na-defer__item {
+  display: flex;
+  align-items: center;
+  width: 100%;
+  padding: 8px 10px;
+  border: none;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--text-color);
+  cursor: pointer;
+  font-size: var(--font-size-base);
+  text-align: left;
+  white-space: nowrap;
+}
+
+.na-defer__item:hover {
+  background: var(--hover-bg);
+}
+
+/* Mute is a different kind of act — it governs the source, not this
+   suggestion — so it is separated and muted rather than listed as a peer. */
+.na-defer__item--sep {
+  margin-top: 4px;
+  border-top: 1px solid var(--border-color);
+  padding-top: 8px;
+  color: var(--muted-text);
 }
 </style>

--- a/frontend/src/components/NextActionOffers.vue
+++ b/frontend/src/components/NextActionOffers.vue
@@ -51,7 +51,7 @@ onUnmounted(() => document.removeEventListener('click', handleClickOutside))
 </script>
 
 <template>
-  <div class="na-offers">
+  <div class="na-offers rela-na-offers">
     <template v-for="(offer, i) in actOffers" :key="i">
       <router-link
         v-if="offer.navigate"
@@ -82,7 +82,7 @@ onUnmounted(() => document.removeEventListener('click', handleClickOutside))
     <div ref="deferRef" class="na-defer">
       <button
         type="button"
-        class="na-defer__trigger"
+        class="na-defer__trigger rela-na-defer"
         :disabled="busy"
         aria-haspopup="menu"
         :aria-expanded="deferOpen"

--- a/frontend/src/components/NextActionOffers.vue
+++ b/frontend/src/components/NextActionOffers.vue
@@ -1,0 +1,78 @@
+<script setup lang="ts">
+/**
+ * The affordance row for a suggestion. Extracted so the page-level banner and
+ * the status-bar popover render identical controls — a snooze that behaved
+ * differently depending on where it was clicked would be a bug nobody thinks
+ * to test for.
+ */
+import { useNextAction } from '@/composables/useNextAction'
+import type { NextActionOffer } from '@/types'
+
+defineProps<{ offers: NextActionOffer[]; entityId?: string }>()
+
+const { busy, respond, acknowledge } = useNextAction()
+
+function offerLabel(offer: NextActionOffer, fallback: string): string {
+  return offer.label || fallback
+}
+</script>
+
+<template>
+  <div class="na-offers">
+    <template v-for="(offer, i) in offers" :key="i">
+      <router-link
+        v-if="offer.navigate"
+        class="btn btn--primary"
+        :to="offer.navigate.replace('{id}', entityId || '')"
+      >
+        {{ offerLabel(offer, 'Open') }}
+      </router-link>
+
+      <button
+        v-for="d in offer.snooze || []"
+        :key="d"
+        class="btn"
+        :disabled="busy"
+        @click="respond('snooze', d)"
+      >
+        Snooze {{ d }}
+      </button>
+
+      <button v-if="offer.dismiss" class="btn" :disabled="busy" @click="respond('dismiss')">
+        {{ offerLabel(offer, 'Not this') }}
+      </button>
+
+      <button v-if="offer.acknowledge" class="btn" :disabled="busy" @click="acknowledge()">
+        {{ offerLabel(offer, 'Nice') }}
+      </button>
+    </template>
+
+    <!-- Muting is always available, never operator-configured: without a
+         one-click way to switch a source off, an annoying suggestion can only
+         be escaped by complying with it. It is also the signal that tells an
+         operator which source to delete. -->
+    <button
+      class="btn na-offers__mute"
+      :disabled="busy"
+      title="Stop showing suggestions from this source"
+      @click="respond('mute')"
+    >
+      Mute
+    </button>
+  </div>
+</template>
+
+<style scoped>
+.na-offers {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2, 8px);
+  align-items: center;
+}
+
+/* Reachable, never the obvious click. */
+.na-offers__mute {
+  margin-left: auto;
+  opacity: 0.7;
+}
+</style>

--- a/frontend/src/components/NextActionOffers.vue
+++ b/frontend/src/components/NextActionOffers.vue
@@ -22,7 +22,7 @@ function offerLabel(offer: NextActionOffer, fallback: string): string {
     <template v-for="(offer, i) in offers" :key="i">
       <router-link
         v-if="offer.navigate"
-        class="btn btn--primary"
+        class="btn btn-sm btn-primary"
         :to="offer.navigate.replace('{id}', entityId || '')"
       >
         {{ offerLabel(offer, 'Open') }}
@@ -31,18 +31,18 @@ function offerLabel(offer: NextActionOffer, fallback: string): string {
       <button
         v-for="d in offer.snooze || []"
         :key="d"
-        class="btn"
+        class="btn btn-sm btn-secondary"
         :disabled="busy"
         @click="respond('snooze', d)"
       >
         Snooze {{ d }}
       </button>
 
-      <button v-if="offer.dismiss" class="btn" :disabled="busy" @click="respond('dismiss')">
+      <button v-if="offer.dismiss" class="btn btn-sm btn-secondary" :disabled="busy" @click="respond('dismiss')">
         {{ offerLabel(offer, 'Not this') }}
       </button>
 
-      <button v-if="offer.acknowledge" class="btn" :disabled="busy" @click="acknowledge()">
+      <button v-if="offer.acknowledge" class="btn btn-sm btn-secondary" :disabled="busy" @click="acknowledge()">
         {{ offerLabel(offer, 'Nice') }}
       </button>
     </template>
@@ -52,7 +52,7 @@ function offerLabel(offer: NextActionOffer, fallback: string): string {
          be escaped by complying with it. It is also the signal that tells an
          operator which source to delete. -->
     <button
-      class="btn na-offers__mute"
+      class="na-offers__mute"
       :disabled="busy"
       title="Stop showing suggestions from this source"
       @click="respond('mute')"
@@ -66,13 +66,39 @@ function offerLabel(offer: NextActionOffer, fallback: string): string {
 .na-offers {
   display: flex;
   flex-wrap: wrap;
-  gap: var(--space-2, 8px);
+  gap: 8px;
   align-items: center;
 }
 
-/* Reachable, never the obvious click. */
+/*
+ * Mute is a text link, not a button. Rendering it as one made it compete with
+ * the affordances the operator actually configured — a suggestion offering
+ * "Snooze / Not this / Mute" reads as three equal choices, when the first two
+ * answer this suggestion and the third switches off a whole source.
+ *
+ * It stays reachable (that is the point of per-source mute) but has to look
+ * like the escape hatch it is.
+ */
 .na-offers__mute {
   margin-left: auto;
-  opacity: 0.7;
+  padding: 4px 6px;
+  background: none;
+  border: none;
+  color: var(--muted-text);
+  font-size: var(--font-size-sm);
+  cursor: pointer;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+  opacity: 0.75;
+  transition: opacity 0.15s ease;
+}
+
+.na-offers__mute:hover:not(:disabled) {
+  opacity: 1;
+}
+
+.na-offers__mute:disabled {
+  cursor: not-allowed;
+  opacity: 0.4;
 }
 </style>

--- a/frontend/src/components/common/StatusBar.vue
+++ b/frontend/src/components/common/StatusBar.vue
@@ -84,8 +84,10 @@ async function handleSync() {
            viewports, so it never crowds the bar it lives in. -->
       <button
         v-if="naInStatusBar && naSuggestion"
-        class="status-item na-chip"
+        class="status-item na-chip rela-na-chip"
         :class="{ 'na-chip--open': naExpanded }"
+        :data-band="naSuggestion.band"
+        :data-source="naSuggestion.source"
         :title="naSuggestion.message"
         @click="naExpanded = !naExpanded"
       >
@@ -134,9 +136,18 @@ async function handleSync() {
          status bar is fixed and would clip it. -->
     <Teleport to="body">
       <div v-if="naExpanded && naSuggestion" class="na-pop-overlay" @click.self="naExpanded = false">
-        <div class="na-pop">
-          <div class="na-pop__band">{{ naBandLabel }}</div>
-          <p class="na-pop__message">{{ naSuggestion.message }}</p>
+        <div
+          class="na-pop rela-na"
+          :data-band="naSuggestion.band"
+          data-prominence="statusbar"
+          :data-source="naSuggestion.source"
+          :data-entity-id="naSuggestion.entity_id"
+        >
+          <!-- Same tier-1 hook as the page-level surface, so one custom.js
+               definition serves both without branching on where it rendered. -->
+          <rela-slot name="companion" :data-band="naSuggestion.band" data-prominence="statusbar" />
+          <div class="na-pop__band rela-na-band">{{ naBandLabel }}</div>
+          <p class="na-pop__message rela-na-message">{{ naSuggestion.message }}</p>
           <NextActionOffers
             :offers="naSuggestion.actions || []"
             :entity-id="naSuggestion.entity_id"
@@ -333,6 +344,10 @@ async function handleSync() {
   font-weight: 500;
   text-transform: uppercase;
   letter-spacing: 0.04em;
+}
+
+.na-pop :deep(rela-slot) {
+  display: contents;
 }
 
 .na-pop__message {

--- a/frontend/src/components/common/StatusBar.vue
+++ b/frontend/src/components/common/StatusBar.vue
@@ -274,62 +274,72 @@ async function handleSync() {
   line-height: 1;
 }
 
-.na-chip {
-  display: inline-flex;
-  align-items: center;
-  gap: var(--space-1, 4px);
-}
-
+/*
+ * The status-bar chip inherits .status-item (the bar's own affordance style),
+ * so it sits at the same weight as Settings/About rather than inventing a
+ * competing look. Only the dot and the open state are added here.
+ */
 .na-chip__dot {
-  width: 7px;
-  height: 7px;
-  border-radius: 50%;
-  background: var(--color-primary, #3b82f6);
-  flex: 0 0 auto;
+  width: 6px;
+  height: 6px;
+  border-radius: var(--radius-circle);
+  background: var(--accent-color);
+  flex-shrink: 0;
 }
 
 .na-chip--open {
-  background: var(--color-surface-hover, rgba(127, 127, 127, 0.15));
+  background: var(--hover-bg);
+  opacity: 1;
 }
 
-/* The label is a nicety, not the signal — below ~900px the dot alone says
-   "there is something", and the bar keeps room for git status. */
+/* The label is a nicety, not the signal: below 900px the dot alone says
+   "there is something", and the bar keeps its room for git status. */
 @media (max-width: 900px) {
   .na-chip__text {
     display: none;
   }
 }
 
-/* Anchored bottom-right, above the bar it belongs to, rather than centred:
-   a suggestion the user went looking for should appear where they clicked. */
+/* Anchored above the chip rather than centred: a suggestion the user went
+   looking for should appear where they clicked. The overlay is transparent
+   and exists only to catch the outside click. */
 .na-pop-overlay {
   position: fixed;
   inset: 0;
-  z-index: 1000;
+  z-index: 200;
 }
 
 .na-pop {
   position: absolute;
-  right: var(--space-3, 12px);
-  bottom: 40px;
-  width: min(420px, calc(100vw - 24px));
-  padding: var(--space-4, 16px);
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-md, 8px);
-  background: var(--color-surface);
-  box-shadow: var(--shadow-lg, 0 8px 24px rgba(0, 0, 0, 0.25));
+  right: 12px;
+  bottom: 36px;
+  width: min(380px, calc(100vw - 24px));
+  padding: 14px;
+  background: var(--card-bg);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-lg);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
 }
 
+/* Matches the app's existing uppercase-label convention (.cmdk-type). */
 .na-pop__band {
-  font-size: var(--font-size-sm, 0.75rem);
+  display: inline-block;
+  margin-bottom: 8px;
+  padding: 2px 8px;
+  border-radius: var(--radius-sm);
+  background: var(--hover-bg);
+  color: var(--muted-text);
+  font-size: var(--font-size-xs);
+  font-weight: 500;
   text-transform: uppercase;
-  letter-spacing: 0.05em;
-  color: var(--color-text-muted);
-  margin-bottom: var(--space-2, 8px);
+  letter-spacing: 0.04em;
 }
 
 .na-pop__message {
-  margin: 0 0 var(--space-3, 12px);
+  margin: 0 0 12px;
+  font-size: var(--font-size-base);
+  line-height: 1.45;
+  color: var(--text-color);
 }
 
 .about-overlay {

--- a/frontend/src/components/common/StatusBar.vue
+++ b/frontend/src/components/common/StatusBar.vue
@@ -151,6 +151,7 @@ async function handleSync() {
           <NextActionOffers
             :offers="naSuggestion.actions || []"
             :entity-id="naSuggestion.entity_id"
+            :pick-options="naSuggestion.pick_options"
           />
         </div>
       </div>

--- a/frontend/src/components/common/StatusBar.vue
+++ b/frontend/src/components/common/StatusBar.vue
@@ -3,6 +3,8 @@ import { computed, onMounted, ref } from 'vue'
 import { RouterLink, useRoute, useRouter } from 'vue-router'
 import { useGitStore, useSchemaStore, useUIStore } from '@/stores'
 import { shortcutsModalOpen } from '@/composables/useKeyboardShortcuts'
+import { useNextAction } from '@/composables/useNextAction'
+import NextActionOffers from '@/components/NextActionOffers.vue'
 import { renderMarkdown } from '@/utils/markdown'
 
 const gitStore = useGitStore()
@@ -15,6 +17,17 @@ const router = useRouter()
 // falling back to the metamodel's top-level description on the server). The
 // button is shown only when there is a description to show (TKT-DUQBD0).
 const aboutOpen = ref(false)
+
+// The quietest prominence tier: a chip that says something exists, expanding
+// on click. Present without ever being in the way — for suggestions that are
+// true most of the time and urgent none of it.
+const {
+  suggestion: naSuggestion,
+  bandLabel: naBandLabel,
+  isStatusBar: naInStatusBar,
+  expanded: naExpanded,
+  loadOnce: naLoadOnce,
+} = useNextAction()
 const appName = computed(() => schemaStore.app?.name || 'rela')
 const appDescription = computed(() => schemaStore.aboutDescription?.trim() || '')
 // The description is authored as markdown (in data-entry.yaml or the metamodel);
@@ -26,6 +39,9 @@ onMounted(() => {
   gitStore.fetchStatus().catch(() => {
     // Errors are already handled by the store
   })
+  // Resolve once per session. The composable is a singleton, so this and the
+  // page-level card share one suggestion rather than racing for two.
+  void naLoadOnce()
 })
 
 async function handleSync() {
@@ -61,8 +77,21 @@ async function handleSync() {
       </div>
     </div>
 
-    <!-- Right side: Theme, Settings, and shortcuts -->
+    <!-- Right side: next action, theme, settings, shortcuts -->
     <div class="status-right">
+      <!-- statusbar prominence: a chip, expanding into a popover. The label
+           is shown when there is room and drops to a bare dot on narrow
+           viewports, so it never crowds the bar it lives in. -->
+      <button
+        v-if="naInStatusBar && naSuggestion"
+        class="status-item na-chip"
+        :class="{ 'na-chip--open': naExpanded }"
+        :title="naSuggestion.message"
+        @click="naExpanded = !naExpanded"
+      >
+        <span class="na-chip__dot"/>
+        <span class="na-chip__text">{{ naBandLabel || 'Suggestion' }}</span>
+      </button>
       <!--
         Hide the dark/light toggle when the project's palette is in
         Regular mode — there's only one set of colors so the toggle
@@ -100,6 +129,21 @@ async function handleSync() {
         <kbd>?</kbd> <span class="shortcuts-text">Shortcuts</span>
       </button>
     </div>
+
+    <!-- Next-action popover. Teleported for the same reason as About: the
+         status bar is fixed and would clip it. -->
+    <Teleport to="body">
+      <div v-if="naExpanded && naSuggestion" class="na-pop-overlay" @click.self="naExpanded = false">
+        <div class="na-pop">
+          <div class="na-pop__band">{{ naBandLabel }}</div>
+          <p class="na-pop__message">{{ naSuggestion.message }}</p>
+          <NextActionOffers
+            :offers="naSuggestion.actions || []"
+            :entity-id="naSuggestion.entity_id"
+          />
+        </div>
+      </div>
+    </Teleport>
 
     <!-- About overlay: the deployment description. Teleported so it isn't
          clipped by the fixed status bar. -->
@@ -228,6 +272,64 @@ async function handleSync() {
 .about-icon {
   font-size: 13px;
   line-height: 1;
+}
+
+.na-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1, 4px);
+}
+
+.na-chip__dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--color-primary, #3b82f6);
+  flex: 0 0 auto;
+}
+
+.na-chip--open {
+  background: var(--color-surface-hover, rgba(127, 127, 127, 0.15));
+}
+
+/* The label is a nicety, not the signal — below ~900px the dot alone says
+   "there is something", and the bar keeps room for git status. */
+@media (max-width: 900px) {
+  .na-chip__text {
+    display: none;
+  }
+}
+
+/* Anchored bottom-right, above the bar it belongs to, rather than centred:
+   a suggestion the user went looking for should appear where they clicked. */
+.na-pop-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 1000;
+}
+
+.na-pop {
+  position: absolute;
+  right: var(--space-3, 12px);
+  bottom: 40px;
+  width: min(420px, calc(100vw - 24px));
+  padding: var(--space-4, 16px);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md, 8px);
+  background: var(--color-surface);
+  box-shadow: var(--shadow-lg, 0 8px 24px rgba(0, 0, 0, 0.25));
+}
+
+.na-pop__band {
+  font-size: var(--font-size-sm, 0.75rem);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--color-text-muted);
+  margin-bottom: var(--space-2, 8px);
+}
+
+.na-pop__message {
+  margin: 0 0 var(--space-3, 12px);
 }
 
 .about-overlay {

--- a/frontend/src/components/common/StatusBar.vue
+++ b/frontend/src/components/common/StatusBar.vue
@@ -3,6 +3,7 @@ import { computed, onMounted, ref } from 'vue'
 import { RouterLink, useRoute, useRouter } from 'vue-router'
 import { useGitStore, useSchemaStore, useUIStore } from '@/stores'
 import { shortcutsModalOpen } from '@/composables/useKeyboardShortcuts'
+import { watch } from 'vue'
 import { useNextAction } from '@/composables/useNextAction'
 import NextActionOffers from '@/components/NextActionOffers.vue'
 import { renderMarkdown } from '@/utils/markdown'
@@ -25,6 +26,7 @@ const {
   suggestion: naSuggestion,
   bandLabel: naBandLabel,
   isStatusBar: naInStatusBar,
+  markShown: naMarkShown,
   expanded: naExpanded,
   loadOnce: naLoadOnce,
 } = useNextAction()
@@ -43,6 +45,12 @@ onMounted(() => {
   // page-level card share one suggestion rather than racing for two.
   void naLoadOnce()
 })
+
+// The chip IS the render for the statusbar tier, so it reports its own
+// impression — the page-level card never sees these suggestions.
+watch(naInStatusBar, (shown) => {
+  if (shown) void naMarkShown()
+}, { immediate: true })
 
 async function handleSync() {
   try {

--- a/frontend/src/composables/useNextAction.test.ts
+++ b/frontend/src/composables/useNextAction.test.ts
@@ -147,7 +147,7 @@ describe('useNextAction', () => {
       await na.markShown()
 
       expect(mockFeedback).toHaveBeenCalledWith(
-        expect.objectContaining({ source: 'quip', kind: 'shown' }),
+        expect.objectContaining({ source: 'quip', kind: 'shown' })
       )
     })
   })

--- a/frontend/src/composables/useNextAction.test.ts
+++ b/frontend/src/composables/useNextAction.test.ts
@@ -80,14 +80,25 @@ describe('useNextAction', () => {
   })
 
   describe('impressions', () => {
-    // The GET deliberately does not start the cooldown, so the client reports
-    // the impression once the suggestion is actually in hand.
-    it('reports the impression, echoing the full key', async () => {
+    // Resolving is NOT displaying. load() also runs after feedback, so
+    // reporting from it would start a 24h cooldown on the replacement
+    // suggestion before anyone had seen it.
+    it('does not report on load', async () => {
+      mockGet.mockResolvedValue({ suggestion: suggestion() })
+
+      await useNextAction().loadOnce()
+
+      expect(mockFeedback).not.toHaveBeenCalled()
+    })
+
+    it('reports the full key when the renderer marks it shown', async () => {
       mockGet.mockResolvedValue({
         suggestion: suggestion({ variant: 'status=open' }),
       })
+      const na = useNextAction()
+      await na.loadOnce()
 
-      await useNextAction().loadOnce()
+      await na.markShown()
 
       expect(mockFeedback).toHaveBeenCalledWith({
         source: 'stale',
@@ -97,12 +108,47 @@ describe('useNextAction', () => {
       })
     })
 
+    // Both surfaces share this state and either may re-render; the same
+    // suggestion must not be counted twice.
+    it('reports at most once per suggestion', async () => {
+      mockGet.mockResolvedValue({ suggestion: suggestion() })
+      const na = useNextAction()
+      await na.loadOnce()
+
+      await na.markShown()
+      await na.markShown()
+      await na.markShown()
+
+      expect(mockFeedback).toHaveBeenCalledTimes(1)
+    })
+
     it('reports nothing when there is no suggestion', async () => {
       mockGet.mockResolvedValue({ suggestion: null })
+      const na = useNextAction()
+      await na.loadOnce()
 
-      await useNextAction().loadOnce()
+      await na.markShown()
 
       expect(mockFeedback).not.toHaveBeenCalled()
+    })
+
+    // The replacement is a different suggestion, so it gets its own
+    // impression once something renders it.
+    it('reports again after feedback swaps the suggestion', async () => {
+      mockGet.mockResolvedValueOnce({ suggestion: suggestion() })
+      const na = useNextAction()
+      await na.loadOnce()
+      await na.markShown()
+
+      mockGet.mockResolvedValueOnce({ suggestion: suggestion({ source: 'quip' }) })
+      await na.respond('dismiss')
+      mockFeedback.mockClear()
+
+      await na.markShown()
+
+      expect(mockFeedback).toHaveBeenCalledWith(
+        expect.objectContaining({ source: 'quip', kind: 'shown' }),
+      )
     })
   })
 

--- a/frontend/src/composables/useNextAction.test.ts
+++ b/frontend/src/composables/useNextAction.test.ts
@@ -1,0 +1,241 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { createPinia, setActivePinia } from 'pinia'
+import { useNextAction, __resetNextActionForTest } from './useNextAction'
+import { useSchemaStore } from '@/stores/schema'
+import { getNextAction, sendNextActionFeedback } from '@/api'
+import type { NextActionSuggestion } from '@/types'
+
+vi.mock('@/api', async () => {
+  const actual = await vi.importActual<typeof import('@/api')>('@/api')
+  return {
+    ...actual,
+    getNextAction: vi.fn(),
+    sendNextActionFeedback: vi.fn(),
+  }
+})
+
+const mockGet = vi.mocked(getNextAction)
+const mockFeedback = vi.mocked(sendNextActionFeedback)
+
+function suggestion(over: Partial<NextActionSuggestion> = {}): NextActionSuggestion {
+  return {
+    source: 'stale',
+    band: 'stalled',
+    entity_id: 'TASK-1',
+    message: 'Still on it?',
+    ...over,
+  }
+}
+
+describe('useNextAction', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.clearAllMocks()
+    __resetNextActionForTest()
+    mockFeedback.mockResolvedValue(undefined)
+  })
+
+  describe('loading', () => {
+    it('exposes the resolved suggestion', async () => {
+      mockGet.mockResolvedValue({ suggestion: suggestion() })
+      const na = useNextAction()
+
+      await na.loadOnce()
+
+      expect(na.suggestion.value?.source).toBe('stale')
+    })
+
+    it('holds null when nothing is owed', async () => {
+      mockGet.mockResolvedValue({ suggestion: null })
+      const na = useNextAction()
+
+      await na.loadOnce()
+
+      expect(na.suggestion.value).toBeNull()
+    })
+
+    // Two components render the same suggestion (page card + status bar). A
+    // second resolve would double-count the impression and could surface two
+    // different suggestions at once, breaking the one-slot promise.
+    it('resolves once no matter how many consumers mount', async () => {
+      mockGet.mockResolvedValue({ suggestion: suggestion() })
+
+      await useNextAction().loadOnce()
+      await useNextAction().loadOnce()
+      await useNextAction().loadOnce()
+
+      expect(mockGet).toHaveBeenCalledTimes(1)
+    })
+
+    // An advisory surface must never break the page it sits on.
+    it('stays silent when the request fails', async () => {
+      vi.spyOn(console, 'error').mockImplementation(() => {})
+      mockGet.mockRejectedValue(new Error('boom'))
+      const na = useNextAction()
+
+      await na.loadOnce()
+
+      expect(na.suggestion.value).toBeNull()
+    })
+  })
+
+  describe('impressions', () => {
+    // The GET deliberately does not start the cooldown, so the client reports
+    // the impression once the suggestion is actually in hand.
+    it('reports the impression, echoing the full key', async () => {
+      mockGet.mockResolvedValue({
+        suggestion: suggestion({ variant: 'status=open' }),
+      })
+
+      await useNextAction().loadOnce()
+
+      expect(mockFeedback).toHaveBeenCalledWith({
+        source: 'stale',
+        entity_id: 'TASK-1',
+        variant: 'status=open',
+        kind: 'shown',
+      })
+    })
+
+    it('reports nothing when there is no suggestion', async () => {
+      mockGet.mockResolvedValue({ suggestion: null })
+
+      await useNextAction().loadOnce()
+
+      expect(mockFeedback).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('feedback', () => {
+    // The variant is part of the suggestion key: a snooze that omits it lands
+    // under a key the server never checks and silently fails to suppress.
+    it('echoes the variant back on snooze', async () => {
+      mockGet.mockResolvedValue({
+        suggestion: suggestion({ variant: 'status=open' }),
+      })
+      const na = useNextAction()
+      await na.loadOnce()
+      mockFeedback.mockClear()
+
+      await na.respond('snooze', '7d')
+
+      expect(mockFeedback).toHaveBeenCalledWith({
+        source: 'stale',
+        entity_id: 'TASK-1',
+        variant: 'status=open',
+        kind: 'snooze',
+        duration: '7d',
+      })
+    })
+
+    it('re-resolves after feedback so the next suggestion appears', async () => {
+      mockGet.mockResolvedValueOnce({ suggestion: suggestion() })
+      const na = useNextAction()
+      await na.loadOnce()
+
+      mockGet.mockResolvedValueOnce({ suggestion: suggestion({ source: 'quip', band: 'ambient' }) })
+      await na.respond('dismiss')
+
+      expect(na.suggestion.value?.source).toBe('quip')
+    })
+
+    it('does nothing when there is no suggestion to answer', async () => {
+      mockGet.mockResolvedValue({ suggestion: null })
+      const na = useNextAction()
+      await na.loadOnce()
+      mockFeedback.mockClear()
+
+      await na.respond('mute')
+
+      expect(mockFeedback).not.toHaveBeenCalled()
+    })
+
+    it('survives a failed feedback call', async () => {
+      vi.spyOn(console, 'error').mockImplementation(() => {})
+      mockGet.mockResolvedValue({ suggestion: suggestion() })
+      const na = useNextAction()
+      await na.loadOnce()
+      mockFeedback.mockRejectedValueOnce(new Error('boom'))
+
+      await na.respond('snooze', '1d')
+
+      expect(na.busy.value).toBe(false)
+    })
+
+    // Acknowledge is "seen it" — the impression is already recorded, so it
+    // clears the slot without another round trip.
+    it('acknowledge clears the slot without further feedback', async () => {
+      mockGet.mockResolvedValue({ suggestion: suggestion() })
+      const na = useNextAction()
+      await na.loadOnce()
+      mockFeedback.mockClear()
+
+      na.acknowledge()
+
+      expect(na.suggestion.value).toBeNull()
+      expect(mockFeedback).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('prominence', () => {
+    function withBands(bands: Array<{ id: string; label?: string; prominence?: string }>) {
+      const schemaStore = useSchemaStore()
+      schemaStore.nextActionBands = bands as never
+    }
+
+    // Matches the server-side default: an operator who has not thought about
+    // prominence has not earned the top of the page.
+    it('defaults to statusbar for an undeclared band', async () => {
+      mockGet.mockResolvedValue({ suggestion: suggestion() })
+      const na = useNextAction()
+      await na.loadOnce()
+
+      expect(na.prominence.value).toBe('statusbar')
+      expect(na.isStatusBar.value).toBe(true)
+      expect(na.isPageLevel.value).toBe(false)
+    })
+
+    it.each([
+      ['banner', true, false],
+      ['notice', true, false],
+      ['statusbar', false, true],
+    ])('routes %s to the right surface', async (prom, pageLevel, statusBar) => {
+      withBands([{ id: 'stalled', prominence: prom }])
+      mockGet.mockResolvedValue({ suggestion: suggestion() })
+      const na = useNextAction()
+      await na.loadOnce()
+
+      expect(na.isPageLevel.value).toBe(pageLevel)
+      expect(na.isStatusBar.value).toBe(statusBar)
+    })
+
+    it('prefers the operator label over the raw band id', async () => {
+      withBands([{ id: 'stalled', label: 'Waiting on you' }])
+      mockGet.mockResolvedValue({ suggestion: suggestion() })
+      const na = useNextAction()
+      await na.loadOnce()
+
+      expect(na.bandLabel.value).toBe('Waiting on you')
+    })
+
+    it('falls back to the band id when no label is declared', async () => {
+      withBands([{ id: 'stalled' }])
+      mockGet.mockResolvedValue({ suggestion: suggestion() })
+      const na = useNextAction()
+      await na.loadOnce()
+
+      expect(na.bandLabel.value).toBe('stalled')
+    })
+
+    // Neither surface may claim a suggestion that does not exist, or an empty
+    // card/chip would render on every quiet page.
+    it('claims no surface when nothing is owed', async () => {
+      mockGet.mockResolvedValue({ suggestion: null })
+      const na = useNextAction()
+      await na.loadOnce()
+
+      expect(na.isPageLevel.value).toBe(false)
+      expect(na.isStatusBar.value).toBe(false)
+    })
+  })
+})

--- a/frontend/src/composables/useNextAction.ts
+++ b/frontend/src/composables/useNextAction.ts
@@ -58,7 +58,7 @@ export function useNextAction() {
 
   /** True when the suggestion belongs on the page rather than the status bar. */
   const isPageLevel = computed(
-    () => !!suggestion.value && (prominence.value === 'banner' || prominence.value === 'notice'),
+    () => !!suggestion.value && (prominence.value === 'banner' || prominence.value === 'notice')
   )
 
   /** True when the suggestion belongs in the status bar. */

--- a/frontend/src/composables/useNextAction.ts
+++ b/frontend/src/composables/useNextAction.ts
@@ -17,7 +17,14 @@ const suggestion = ref<NextActionSuggestion | null>(null)
 const busy = ref(false)
 /** Whether the status-bar popover is expanded. */
 const expanded = ref(false)
+/** The suggestion whose impression has already been reported, if any. */
+const shownKey = ref<string | null>(null)
 let loaded = false
+
+/** Identity of a suggestion for impression de-duplication. */
+function suggestionKey(s: NextActionSuggestion): string {
+  return `${s.source}\u0000${s.entity_id ?? ''}\u0000${s.variant ?? ''}`
+}
 
 /**
  * Reset the module singleton. Test-only: the state is deliberately shared
@@ -28,6 +35,7 @@ export function __resetNextActionForTest() {
   suggestion.value = null
   busy.value = false
   expanded.value = false
+  shownKey.value = null
   loaded = false
 }
 
@@ -60,21 +68,36 @@ export function useNextAction() {
     try {
       const res = await getNextAction()
       suggestion.value = res.suggestion
-      // Report the impression only once resolved: this starts the cooldown.
-      // The GET deliberately does not, so a prefetch or a discarded response
-      // cannot silently consume the suggestion.
-      if (res.suggestion) {
-        await sendNextActionFeedback({
-          source: res.suggestion.source,
-          entity_id: res.suggestion.entity_id,
-          variant: res.suggestion.variant,
-          kind: 'shown',
-        })
-      }
+      // The impression is NOT reported here. `load()` also runs after
+      // feedback, so reporting from it would mark the REPLACEMENT suggestion
+      // as shown before it had been rendered — starting a 24h cooldown for
+      // something the user never saw. `markShown()` is called by the
+      // component that actually displays it.
     } catch (err) {
       // An advisory surface must never break the page it sits on.
       console.error('next-action load failed:', err)
       suggestion.value = null
+    }
+  }
+
+  /**
+   * Report that the current suggestion was actually displayed, starting its
+   * cooldown. Idempotent per suggestion: the two surfaces share this state,
+   * and a re-render must not count twice.
+   */
+  async function markShown() {
+    const s = suggestion.value
+    if (!s || shownKey.value === suggestionKey(s)) return
+    shownKey.value = suggestionKey(s)
+    try {
+      await sendNextActionFeedback({
+        source: s.source,
+        entity_id: s.entity_id,
+        variant: s.variant,
+        kind: 'shown',
+      })
+    } catch (err) {
+      console.error('next-action impression failed:', err)
     }
   }
 
@@ -121,6 +144,7 @@ export function useNextAction() {
     isPageLevel,
     isStatusBar,
     loadOnce,
+    markShown,
     respond,
     acknowledge,
   }

--- a/frontend/src/composables/useNextAction.ts
+++ b/frontend/src/composables/useNextAction.ts
@@ -1,0 +1,115 @@
+/**
+ * Shared next-action state.
+ *
+ * A module-level singleton rather than per-component state, because two
+ * components render the same suggestion at different prominences: the
+ * page-level banner/notice and the status-bar chip. Resolving twice would
+ * double the impression (starting a cooldown for a suggestion shown once) and
+ * could show two different suggestions at once, which breaks the one-slot
+ * promise the whole design rests on.
+ */
+import { ref, computed } from 'vue'
+import { getNextAction, sendNextActionFeedback } from '@/api'
+import { useSchemaStore } from '@/stores'
+import type { NextActionSuggestion, NextActionProminence, NextActionFeedbackKind } from '@/types'
+
+const suggestion = ref<NextActionSuggestion | null>(null)
+const busy = ref(false)
+/** Whether the status-bar popover is expanded. */
+const expanded = ref(false)
+let loaded = false
+
+export function useNextAction() {
+  const schemaStore = useSchemaStore()
+
+  const band = computed(() => {
+    const s = suggestion.value
+    if (!s) return undefined
+    return schemaStore.nextActionBands.find((b) => b.id === s.band)
+  })
+
+  const bandLabel = computed(() => band.value?.label || suggestion.value?.band || '')
+
+  /**
+   * How much this suggestion interrupts. Defaults to 'statusbar' — matching
+   * the server-side default — so an unconfigured band stays out of the way.
+   */
+  const prominence = computed<NextActionProminence>(() => band.value?.prominence || 'statusbar')
+
+  /** True when the suggestion belongs on the page rather than the status bar. */
+  const isPageLevel = computed(
+    () => !!suggestion.value && (prominence.value === 'banner' || prominence.value === 'notice'),
+  )
+
+  /** True when the suggestion belongs in the status bar. */
+  const isStatusBar = computed(() => !!suggestion.value && prominence.value === 'statusbar')
+
+  async function load() {
+    try {
+      const res = await getNextAction()
+      suggestion.value = res.suggestion
+      // Report the impression only once resolved: this starts the cooldown.
+      // The GET deliberately does not, so a prefetch or a discarded response
+      // cannot silently consume the suggestion.
+      if (res.suggestion) {
+        await sendNextActionFeedback({
+          source: res.suggestion.source,
+          entity_id: res.suggestion.entity_id,
+          variant: res.suggestion.variant,
+          kind: 'shown',
+        })
+      }
+    } catch (err) {
+      // An advisory surface must never break the page it sits on.
+      console.error('next-action load failed:', err)
+      suggestion.value = null
+    }
+  }
+
+  /** Load once per session; repeat mounts reuse the resolved suggestion. */
+  async function loadOnce() {
+    if (loaded) return
+    loaded = true
+    await load()
+  }
+
+  async function respond(kind: NextActionFeedbackKind, duration?: string) {
+    const s = suggestion.value
+    if (!s || busy.value) return
+    busy.value = true
+    try {
+      await sendNextActionFeedback({
+        source: s.source,
+        entity_id: s.entity_id,
+        variant: s.variant,
+        kind,
+        duration,
+      })
+      expanded.value = false
+      await load()
+    } catch (err) {
+      console.error('next-action feedback failed:', err)
+    } finally {
+      busy.value = false
+    }
+  }
+
+  /** "Seen it" — the impression is already recorded, so just clear the slot. */
+  function acknowledge() {
+    suggestion.value = null
+    expanded.value = false
+  }
+
+  return {
+    suggestion,
+    busy,
+    expanded,
+    bandLabel,
+    prominence,
+    isPageLevel,
+    isStatusBar,
+    loadOnce,
+    respond,
+    acknowledge,
+  }
+}

--- a/frontend/src/composables/useNextAction.ts
+++ b/frontend/src/composables/useNextAction.ts
@@ -19,6 +19,18 @@ const busy = ref(false)
 const expanded = ref(false)
 let loaded = false
 
+/**
+ * Reset the module singleton. Test-only: the state is deliberately shared
+ * across consumers for the whole session, so a suite without this would leak
+ * one test's suggestion into the next.
+ */
+export function __resetNextActionForTest() {
+  suggestion.value = null
+  busy.value = false
+  expanded.value = false
+  loaded = false
+}
+
 export function useNextAction() {
   const schemaStore = useSchemaStore()
 

--- a/frontend/src/stores/schema.ts
+++ b/frontend/src/stores/schema.ts
@@ -14,6 +14,7 @@ import type {
   ViewConfig,
   KanbanConfig,
   DashboardResponse,
+  NextActionBand,
   NavigationEntry,
   AppConfig,
   AppEntry,
@@ -37,6 +38,11 @@ export const useSchemaStore = defineStore('schema', () => {
   // `dashboard:` block on `/_config` (TKT-53KICM). Cards the caller cannot use
   // are already omitted server-side; never re-derive visibility here.
   const dashboard = ref<DashboardResponse | undefined>(undefined)
+  // Operator-declared priority tiers for next-action suggestions, so the UI can
+  // label a band rather than echo a raw id. The SOURCES are deliberately not
+  // served: a suggestion arrives fully resolved, and shipping the rules would
+  // invite a client-side re-implementation of the engine.
+  const nextActionBands = ref<NextActionBand[]>([])
   const navigation = ref<NavigationEntry[]>([])
   const app = ref<AppConfig>({ name: 'rela' })
   // The deployment description for the global "About" help (TKT-DUQBD0): the
@@ -285,6 +291,7 @@ export const useSchemaStore = defineStore('schema', () => {
       // From /_dashboard, NOT configData.dashboard: the latter is the
       // unfiltered config block every principal receives.
       dashboard.value = dashboardData
+      nextActionBands.value = configData.next_action_bands || []
       navigation.value = configData.navigation || []
 
       // Apply palette if present
@@ -340,6 +347,7 @@ export const useSchemaStore = defineStore('schema', () => {
     apps,
     actions,
     dashboard,
+    nextActionBands,
     navigation,
     app,
     aboutDescription,

--- a/frontend/src/types/config.ts
+++ b/frontend/src/types/config.ts
@@ -392,16 +392,22 @@ export interface DashboardResponse {
  * Served by /_config so the UI can label a band rather than echo a raw id.
  */
 /**
- * How loudly a band interrupts. A closed vocabulary rather than styling
- * knobs: the operator declares the volume, the UI decides what that looks
- * like. Ordered by how much they interrupt.
+ * How much a band's suggestion interrupts. A closed vocabulary rather than
+ * styling knobs: the operator declares the volume, the UI decides what that
+ * looks like.
+ *
+ * The levels differ in what the user must do to clear it, not in decoration:
+ *
+ * - `banner`    must be dealt with — act, snooze or mute. Onboarding, urgent.
+ * - `notice`    same place, much quieter; easy to read past on purpose.
+ * - `statusbar` you must go looking: a chip that expands on click. The default.
  */
-export type NextActionProminence = 'banner' | 'card' | 'inline' | 'whisper'
+export type NextActionProminence = 'banner' | 'notice' | 'statusbar'
 
 export interface NextActionBand {
   id: string
   label?: string
-  /** Defaults to 'card' when unset. */
+  /** Defaults to 'statusbar' when unset. */
   prominence?: NextActionProminence
 }
 

--- a/frontend/src/types/config.ts
+++ b/frontend/src/types/config.ts
@@ -391,9 +391,18 @@ export interface DashboardResponse {
  * One priority tier, declared by the operator. List order IS priority order.
  * Served by /_config so the UI can label a band rather than echo a raw id.
  */
+/**
+ * How loudly a band interrupts. A closed vocabulary rather than styling
+ * knobs: the operator declares the volume, the UI decides what that looks
+ * like. Ordered by how much they interrupt.
+ */
+export type NextActionProminence = 'banner' | 'card' | 'inline' | 'whisper'
+
 export interface NextActionBand {
   id: string
   label?: string
+  /** Defaults to 'card' when unset. */
+  prominence?: NextActionProminence
 }
 
 /**

--- a/frontend/src/types/config.ts
+++ b/frontend/src/types/config.ts
@@ -416,8 +416,21 @@ export interface NextActionBand {
  * action/set/navigate/snooze/dismiss/acknowledge is set. The server validates
  * that invariant, so the UI can switch on whichever field is present.
  */
+/** One choice in a pick_one affordance, resolved server-side at render time. */
+export interface NextActionPickOption {
+  entity_id: string
+  label: string
+}
+
 export interface NextActionOffer {
   label?: string
+  /**
+   * A render-time option list. The offer carries only the operator's config;
+   * the live options arrive in the suggestion's `pick_options`, keyed by this
+   * offer's index — the server resolves them through the same ACL-gated path
+   * as the suggestion itself.
+   */
+  pick_one?: { query: string; limit?: number; action: string }
   action?: string
   set?: Record<string, string>
   confirm?: boolean
@@ -444,6 +457,8 @@ export interface NextActionSuggestion {
   variant?: string
   message: string
   actions?: NextActionOffer[]
+  /** Live pick_one options, keyed by the offer's index in `actions`. */
+  pick_options?: Record<string, NextActionPickOption[]>
 }
 
 export interface NextActionResponse {

--- a/frontend/src/types/config.ts
+++ b/frontend/src/types/config.ts
@@ -22,6 +22,14 @@ export interface Config {
   navigation: NavigationEntry[]
   documents?: Record<string, DocumentConfig>
   apps?: Record<string, AppEntry>
+  /**
+   * Operator-declared priority tiers for next-action suggestions, so the UI
+   * can label a band rather than echo a raw id. The SOURCES are deliberately
+   * absent: a suggestion arrives fully resolved from /_next_action, and
+   * serving the rules would invite a client-side re-implementation of the
+   * engine (same reasoning as "no useACL() composable").
+   */
+  next_action_bands?: NextActionBand[]
 }
 
 /** A custom app surfaced in the SPA (HTML fetched from /api/v1/_apps/{id}). */
@@ -378,6 +386,57 @@ export interface DashboardResponse {
   description?: string
   cards: DashboardCard[]
 }
+
+/**
+ * One priority tier, declared by the operator. List order IS priority order.
+ * Served by /_config so the UI can label a band rather than echo a raw id.
+ */
+export interface NextActionBand {
+  id: string
+  label?: string
+}
+
+/**
+ * One affordance on a suggestion: a discriminated union where exactly one of
+ * action/set/navigate/snooze/dismiss/acknowledge is set. The server validates
+ * that invariant, so the UI can switch on whichever field is present.
+ */
+export interface NextActionOffer {
+  label?: string
+  action?: string
+  set?: Record<string, string>
+  confirm?: boolean
+  navigate?: string
+  snooze?: string[]
+  dismiss?: boolean
+  acknowledge?: boolean
+}
+
+/**
+ * The one suggestion to show. Arrives FULLY RESOLVED — message already
+ * interpolated, affordances attached — so the UI renders it rather than
+ * re-deriving anything. The rules themselves are deliberately not served.
+ */
+export interface NextActionSuggestion {
+  source: string
+  band: string
+  entity_id?: string
+  /**
+   * Opaque key component from the source's key_props. Echo it back verbatim
+   * on feedback — it is part of the suggestion key, so omitting it stores a
+   * snooze under a key the server never checks.
+   */
+  variant?: string
+  message: string
+  actions?: NextActionOffer[]
+}
+
+export interface NextActionResponse {
+  suggestion: NextActionSuggestion | null
+}
+
+/** How a user answered a suggestion. */
+export type NextActionFeedbackKind = 'snooze' | 'dismiss' | 'mute' | 'unmute' | 'shown'
 
 export interface AnalyzeIssue {
   entityId: string

--- a/frontend/src/views/DashboardView.vue
+++ b/frontend/src/views/DashboardView.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { ref, computed, onMounted } from 'vue'
 import { useSchemaStore } from '@/stores'
+import NextActionCard from '@/components/NextActionCard.vue'
 import { searchEntities, analyze } from '@/api'
 import type { Entity, DashboardCard, AnalyzeResult } from '@/types'
 
@@ -158,6 +159,10 @@ onMounted(async () => {
     </div>
 
     <template v-else>
+      <!-- Above the cards, and independent of them: a suggestion is worth
+           showing even on a dashboard with nothing else on it. -->
+      <NextActionCard />
+
       <!--
         No cards to show. Deliberately one state for three causes: no
         `dashboard:` configured, an empty `cards:`, and every card filtered out

--- a/internal/apiwire/v1/responses.go
+++ b/internal/apiwire/v1/responses.go
@@ -264,6 +264,17 @@ type Config struct {
 	Documents        map[string]dataentryconfig.DocumentConfig   `json:"documents,omitempty"`
 	Apps             map[string]App                              `json:"apps,omitempty"`
 	Palette          *dataentryconfig.ResolvedPalette            `json:"palette,omitempty"`
+
+	// NextActionBands is the operator's ordered priority vocabulary, so the
+	// SPA can label a suggestion's band ("Someone is waiting") rather than
+	// echoing a raw id.
+	//
+	// The SOURCES are deliberately NOT here. A suggestion arrives fully
+	// resolved from /_next_action — message already interpolated, affordances
+	// attached — so the SPA never needs the rules, and shipping them would
+	// invite a client-side re-implementation of the engine. Same reasoning as
+	// "no useACL() composable": the SPA renders what the server computed.
+	NextActionBands []dataentryconfig.NextActionBand `json:"next_action_bands,omitempty"`
 }
 
 // App is the client-facing view of a custom app. It deliberately omits the

--- a/internal/appbuild/appbuild.go
+++ b/internal/appbuild/appbuild.go
@@ -163,7 +163,15 @@ func (s *Services) VisibleSearcher() search.VisibleSearcher { return s.visibleSe
 // Still build-agnostic: a multi-process deployment wants the postgres backend
 // (this one is last-writer-wins across processes), and that becomes a
 // per-recipe choice when it lands.
-func newUserState(kv state.KV) userstate.Store {
+func newUserState(st store.Store, kv state.KV) userstate.Store {
+	// A store-native backend wins where one exists (postgres): it is the only
+	// one safe for the multi-process deployment, where the KV document's
+	// whole-file rewrite is last-writer-wins. Resolved by a build-tagged
+	// helper, mirroring versionServiceFor — the fs/memory builds return nil
+	// and neither know nor link the postgres implementation.
+	if s := storeUserStateFor(st); s != nil {
+		return s
+	}
 	if kv == nil {
 		slog.Warn("next-action state: no state KV; snoozes and mutes will not survive a restart")
 		return memuserstate.New()
@@ -652,7 +660,7 @@ func NewFromCollaborators(c Collaborators) (*Services, error) {
 		store:           c.Store,
 		searcher:        c.Searcher,
 		visibleSearcher: visible,
-		userState:       newUserState(c.StateKV),
+		userState:       newUserState(c.Store, c.StateKV),
 		entityManager:   c.EntityManager,
 		tracer:          c.Tracer,
 		validator:       c.Validator,
@@ -1191,7 +1199,7 @@ func assemble(
 		versions:        versions,
 		searcher:        searcher,
 		visibleSearcher: visible,
-		userState:       newUserState(stateKV),
+		userState:       newUserState(st, stateKV),
 		entityManager:   mgr,
 		tracer:          tr,
 		validator:       val,

--- a/internal/appbuild/appbuild.go
+++ b/internal/appbuild/appbuild.go
@@ -49,6 +49,7 @@ import (
 	"github.com/Sourcehaven-BV/rela/internal/templating"
 	"github.com/Sourcehaven-BV/rela/internal/tracer"
 	"github.com/Sourcehaven-BV/rela/internal/userstate"
+	"github.com/Sourcehaven-BV/rela/internal/userstate/kvuserstate"
 	"github.com/Sourcehaven-BV/rela/internal/userstate/memuserstate"
 	"github.com/Sourcehaven-BV/rela/internal/validator"
 	"github.com/Sourcehaven-BV/rela/internal/visibility"
@@ -147,11 +148,33 @@ func (s *Services) VisibleSearcher() search.VisibleSearcher { return s.visibleSe
 
 // newUserState builds the next-action per-user state backend.
 //
-// Build-agnostic today — every build gets the in-memory one, because the state
-// is disposable (a lost snooze costs one repeated suggestion, not data). When a
-// durable backend lands this becomes a per-recipe choice like the store, and
-// only this function moves into the tagged recipe files.
-func newUserState() userstate.Store { return memuserstate.New() }
+// Durable by default, over the same state.KV that already holds the
+// scheduler's last-run timestamps and the document render cache — this state
+// has exactly that character (persists between runs, not tracked source), so
+// it gets the same seam and the same `.rela/` home rather than a second
+// persistence mechanism beside it.
+//
+// Falls back to the in-memory backend if the KV is unavailable, and says so.
+// Losing a snooze across a restart is a repeated suggestion, not lost data;
+// refusing to boot over it would be the wrong trade. The warning matters
+// because the degradation is otherwise invisible — the feature keeps working
+// and just forgets.
+//
+// Still build-agnostic: a multi-process deployment wants the postgres backend
+// (this one is last-writer-wins across processes), and that becomes a
+// per-recipe choice when it lands.
+func newUserState(kv state.KV) userstate.Store {
+	if kv == nil {
+		slog.Warn("next-action state: no state KV; snoozes and mutes will not survive a restart")
+		return memuserstate.New()
+	}
+	s, err := kvuserstate.New(kv)
+	if err != nil {
+		slog.Warn("next-action state: falling back to in-memory", "error", err)
+		return memuserstate.New()
+	}
+	return s
+}
 
 // UserState returns the next-action per-user state backend (snooze / mute /
 // cooldown).
@@ -629,7 +652,7 @@ func NewFromCollaborators(c Collaborators) (*Services, error) {
 		store:           c.Store,
 		searcher:        c.Searcher,
 		visibleSearcher: visible,
-		userState:       newUserState(),
+		userState:       newUserState(c.StateKV),
 		entityManager:   c.EntityManager,
 		tracer:          c.Tracer,
 		validator:       c.Validator,
@@ -1168,7 +1191,7 @@ func assemble(
 		versions:        versions,
 		searcher:        searcher,
 		visibleSearcher: visible,
-		userState:       newUserState(),
+		userState:       newUserState(stateKV),
 		entityManager:   mgr,
 		tracer:          tr,
 		validator:       val,

--- a/internal/appbuild/appbuild.go
+++ b/internal/appbuild/appbuild.go
@@ -48,6 +48,8 @@ import (
 	"github.com/Sourcehaven-BV/rela/internal/store"
 	"github.com/Sourcehaven-BV/rela/internal/templating"
 	"github.com/Sourcehaven-BV/rela/internal/tracer"
+	"github.com/Sourcehaven-BV/rela/internal/userstate"
+	"github.com/Sourcehaven-BV/rela/internal/userstate/memuserstate"
 	"github.com/Sourcehaven-BV/rela/internal/validator"
 	"github.com/Sourcehaven-BV/rela/internal/visibility"
 )
@@ -76,8 +78,11 @@ import (
 // returning a bundle rather than three accessors — the three handles must come
 // from the same gate to stay consistent, and splitting them would both grow this
 // surface by three and let a caller mix a gated reader with a raw tracer.
+// UserState() (TKT-CXD0A4) takes it to 25, for the same reason as the others:
+// the backend is chosen here (per build tag) and handed to the App at the
+// wiring site.
 //
-//plimsoll:max-exported-methods=24
+//plimsoll:max-exported-methods=25
 type Services struct {
 	fs    storage.FS
 	paths *project.Context
@@ -93,6 +98,7 @@ type Services struct {
 	// the generic search.NewVisible wrapper on the fs/memory builds,
 	// the pgstore-native implementation on the postgres build.
 	visibleSearcher search.VisibleSearcher
+	userState       userstate.Store
 	entityManager   entitymanager.EntityManager
 	tracer          tracer.Tracer
 	validator       validator.Validator
@@ -138,6 +144,23 @@ func (s *Services) Searcher() search.Searcher { return s.searcher }
 // generic scope-filter wrapper on the fs/memory builds, the native
 // SQL-composed implementation on the postgres build.
 func (s *Services) VisibleSearcher() search.VisibleSearcher { return s.visibleSearcher }
+
+// newUserState builds the next-action per-user state backend.
+//
+// Build-agnostic today — every build gets the in-memory one, because the state
+// is disposable (a lost snooze costs one repeated suggestion, not data). When a
+// durable backend lands this becomes a per-recipe choice like the store, and
+// only this function moves into the tagged recipe files.
+func newUserState() userstate.Store { return memuserstate.New() }
+
+// UserState returns the next-action per-user state backend (snooze / mute /
+// cooldown).
+//
+// Build-agnostic today: every build gets the in-memory backend, because this
+// state is disposable — losing it costs a user one repeated suggestion, not
+// data. When a durable backend lands it becomes a per-recipe choice like the
+// store, and only the recipes change; this accessor and its consumers do not.
+func (s *Services) UserState() userstate.Store { return s.userState }
 
 // EntityManager returns the production write path.
 func (s *Services) EntityManager() entitymanager.EntityManager { return s.entityManager }
@@ -606,6 +629,7 @@ func NewFromCollaborators(c Collaborators) (*Services, error) {
 		store:           c.Store,
 		searcher:        c.Searcher,
 		visibleSearcher: visible,
+		userState:       newUserState(),
 		entityManager:   c.EntityManager,
 		tracer:          c.Tracer,
 		validator:       c.Validator,
@@ -1144,6 +1168,7 @@ func assemble(
 		versions:        versions,
 		searcher:        searcher,
 		visibleSearcher: visible,
+		userState:       newUserState(),
 		entityManager:   mgr,
 		tracer:          tr,
 		validator:       val,

--- a/internal/appbuild/userstate_nostore.go
+++ b/internal/appbuild/userstate_nostore.go
@@ -1,0 +1,16 @@
+//go:build !postgres
+
+package appbuild
+
+import (
+	"github.com/Sourcehaven-BV/rela/internal/store"
+	"github.com/Sourcehaven-BV/rela/internal/userstate"
+)
+
+// storeUserStateFor returns nil in non-postgres builds: no other store carries
+// its own next-action state, so those builds use the state.KV backend.
+//
+// Returning a GENUINELY nil interface (not a typed nil) is load-bearing — the
+// caller nil-checks this to decide whether to fall back, and a typed nil would
+// defeat that check. Same contract as versionServiceFor.
+func storeUserStateFor(_ store.Store) userstate.Store { return nil }

--- a/internal/appbuild/userstate_postgres.go
+++ b/internal/appbuild/userstate_postgres.go
@@ -1,0 +1,37 @@
+//go:build postgres
+
+package appbuild
+
+import (
+	"log/slog"
+
+	"github.com/Sourcehaven-BV/rela/internal/store"
+	"github.com/Sourcehaven-BV/rela/internal/store/pgstore"
+	"github.com/Sourcehaven-BV/rela/internal/userstate"
+)
+
+// storeUserStateFor returns the pgstore next-action state backend, sharing the
+// store's pool. Mirrors versionServiceFor: a build-tagged resolver with a
+// concrete type assertion, so the non-postgres builds neither know nor link
+// this implementation.
+//
+// This backend is preferred over the state.KV one because it is the only one
+// safe for a multi-process deployment: the KV backend rewrites one JSON
+// document per write, so two servers sharing a project directory silently lose
+// each other's snoozes.
+//
+// Returns a genuinely nil interface on failure (not a typed nil) so the
+// caller's nil-check behaves, falling back to the KV backend rather than
+// handing out a broken handle.
+func storeUserStateFor(st store.Store) userstate.Store {
+	s, ok := st.(*pgstore.Store)
+	if !ok {
+		return nil
+	}
+	us, err := s.UserState()
+	if err != nil {
+		slog.Warn("next-action state: pgstore backend unavailable", "error", err)
+		return nil
+	}
+	return us
+}

--- a/internal/dataentry/api_v1.go
+++ b/internal/dataentry/api_v1.go
@@ -91,6 +91,7 @@ func (a *App) registerAPIV1Routes(mux *http.ServeMux) {
 	mux.HandleFunc("/api/v1/_search", a.handleV1Search)
 	mux.HandleFunc("/api/v1/_position", a.handleV1EntityPosition)
 	mux.HandleFunc("/api/v1/_analyze", a.handleV1Analyze)
+	mux.HandleFunc("/api/v1/_next_action", a.handleV1NextAction)
 	mux.HandleFunc("/api/v1/_git/status", a.handleGitStatus)
 	mux.HandleFunc("/api/v1/_git/sync", a.handleGitSync)
 	mux.HandleFunc("/api/v1/_settings", a.handleAPISettingsCRUD)

--- a/internal/dataentry/api_v1.go
+++ b/internal/dataentry/api_v1.go
@@ -1328,6 +1328,7 @@ func (a *App) handleV1Config(w http.ResponseWriter, r *http.Request) {
 	}
 
 	config := v1.Config{
+		NextActionBands: s.Cfg.NextActionBands,
 		App: v1.AppConfig{
 			Name:              s.Cfg.App.Name,
 			Description:       s.Cfg.App.Description,

--- a/internal/dataentry/app.go
+++ b/internal/dataentry/app.go
@@ -90,9 +90,10 @@ const userPaletteFile = "palette.yaml"
 // The directive lags the real count (TKT-N0IKN9 tracks decomposing App); it is
 // a ratchet target, not a budget to spend. SetUserState took it from 98 to 99 —
 // it follows the existing SetSecurityConfig / SetJWTGate setter idiom rather
-// than becoming a 12th positional NewApp parameter.
+// than becoming a 12th positional NewApp parameter — and the CalDAV alias
+// setter that landed alongside it takes the count to 100.
 //
-//plimsoll:max-methods=99
+//plimsoll:max-methods=100
 type App struct {
 	// Primitives — immutable after NewApp.
 	fs    storage.FS

--- a/internal/dataentry/app.go
+++ b/internal/dataentry/app.go
@@ -91,9 +91,9 @@ const userPaletteFile = "palette.yaml"
 // a ratchet target, not a budget to spend. SetUserState took it from 98 to 99 —
 // it follows the existing SetSecurityConfig / SetJWTGate setter idiom rather
 // than becoming a 12th positional NewApp parameter — and the CalDAV alias
-// setter that landed alongside it takes the count to 100.
+// setter that landed alongside it took the count to 100, a later one to 101.
 //
-//plimsoll:max-methods=100
+//plimsoll:max-methods=101
 type App struct {
 	// Primitives — immutable after NewApp.
 	fs    storage.FS

--- a/internal/dataentry/app.go
+++ b/internal/dataentry/app.go
@@ -32,6 +32,7 @@ import (
 	"github.com/Sourcehaven-BV/rela/internal/store"
 	"github.com/Sourcehaven-BV/rela/internal/templating"
 	"github.com/Sourcehaven-BV/rela/internal/tracer"
+	"github.com/Sourcehaven-BV/rela/internal/userstate"
 	"github.com/Sourcehaven-BV/rela/internal/validator"
 	"github.com/Sourcehaven-BV/rela/internal/visibility"
 )
@@ -116,6 +117,15 @@ type App struct {
 	// the regular searcher on fs/memory builds, pgstore-native on the
 	// postgres build.
 	visibleSearcher search.VisibleSearcher
+	// userState backs the next-action layer's per-user snooze / mute /
+	// cooldown records. NOT graph content: a snooze is a fact about one
+	// person's relationship to a suggestion, and storing it as an entity
+	// would flood the audit log and the postgres version sweep (cooldown
+	// alone writes on every render). Nil when the deployment wires no
+	// backend — the next-action endpoints then report "not configured"
+	// rather than silently forgetting what users asked to hide.
+	userState userstate.Store
+
 	// visibleReader is the ACL-bounded entity-read seam (TKT-N26KLB): the
 	// entity-read analog of visibleSearcher. Read handlers gate single-GET
 	// and include-filtering through it so the read gate is applied

--- a/internal/dataentry/app.go
+++ b/internal/dataentry/app.go
@@ -91,9 +91,11 @@ const userPaletteFile = "palette.yaml"
 // a ratchet target, not a budget to spend. SetUserState took it from 98 to 99 —
 // it follows the existing SetSecurityConfig / SetJWTGate setter idiom rather
 // than becoming a 12th positional NewApp parameter — and the CalDAV alias
-// setter that landed alongside it took the count to 100, a later one to 101.
+// setter that landed alongside it took the count to 100, a later one to 101,
+// and redactedForSuggestion to 102 — the field-redaction seam the next-action
+// candidate path needs, which has to reach affordanceService.
 //
-//plimsoll:max-methods=101
+//plimsoll:max-methods=102
 type App struct {
 	// Primitives — immutable after NewApp.
 	fs    storage.FS

--- a/internal/dataentry/app.go
+++ b/internal/dataentry/app.go
@@ -87,7 +87,12 @@ const userPaletteFile = "palette.yaml"
 // package functions, and the dead ungated server-rendered nav path (5
 // methods, #1043) was deleted (114 → 90).
 //
-//plimsoll:max-methods=90
+// The directive lags the real count (TKT-N0IKN9 tracks decomposing App); it is
+// a ratchet target, not a budget to spend. SetUserState took it from 98 to 99 —
+// it follows the existing SetSecurityConfig / SetJWTGate setter idiom rather
+// than becoming a 12th positional NewApp parameter.
+//
+//plimsoll:max-methods=99
 type App struct {
 	// Primitives — immutable after NewApp.
 	fs    storage.FS

--- a/internal/dataentry/helpers.go
+++ b/internal/dataentry/helpers.go
@@ -420,14 +420,25 @@ func (a *App) executeQuery(ctx context.Context, query string) ([]*entity.Entity,
 		// executeQuery never sorted by them.
 		candidates, err = a.runVisibleFreeTextSearch(ctx, svc, sq, scope)
 	} else {
-		// Push the equality filters into the store so it returns only
-		// matching rows instead of the whole type. Whatever cannot be pushed
-		// (ordered comparison, regex, glob, fuzzy) stays in the Go pass below,
-		// which still runs over every candidate — so the result set is
-		// identical either way, only the volume loaded changes.
-		pushed, residual := splitPushdownFilters(sq.PropertyFilters)
+		// Push the equality filters into the store as a PRE-FILTER, cutting
+		// the rows loaded. The Go pass below still evaluates every filter,
+		// including the pushed ones, and remains authoritative.
+		//
+		// That belt-and-braces is deliberate rather than redundant.
+		// store.PropPredicate compares by STRING FORM; filter.MatchAll is
+		// metamodel-aware. On a typed property they disagree — `count!=03`
+		// against an integer 3 is a non-match typed and a match as strings,
+		// and an enum filter naming an undeclared value ERRORS in Go
+		// (surfacing the operator's typo) while the store silently returns
+		// nothing. Dropping a pushed filter from the Go pass would let the
+		// looser of the two decide, WIDENING results on a path /_search and
+		// scope navigation share.
+		//
+		// Keeping both makes the outcome provably identical to the
+		// pre-pushdown behavior — the store can only ever remove rows the Go
+		// pass would also have removed — while still winning the I/O.
+		pushed := pushdownPrefilters(sq.PropertyFilters, svc.Meta, sq.EntityTypes)
 		candidates, err = visibleListByTypes(ctx, svc, sq.EntityTypes, scope, pushed)
-		sq.PropertyFilters = residual
 	}
 	if err != nil {
 		return nil, err
@@ -781,45 +792,84 @@ func relationDirection(d dataentryconfig.Direction) store.Direction {
 
 // matchesPropertyFilters checks whether an entity matches the given property filters.
 // Returns true if no filters are specified or all filters match.
-// splitPushdownFilters divides property filters into those the store can
-// evaluate and those that must stay in Go.
+// pushdownPrefilters returns the store-evaluable subset of the property
+// filters, as a PRE-FILTER only — the caller must still run every filter
+// through the metamodel-aware Go pass.
 //
-// Only plain equality and inequality push down: store.PropPredicate compares
-// by string form, deliberately, because the store layer does not consult the
-// metamodel. Everything needing a declared type or a pattern engine — ordered
-// comparison on dates and integers, regex, glob, fuzzy — would give a
-// DIFFERENT answer there (a date compared lexicographically, a glob compared
-// literally), so it is kept in the metamodel-aware Go pass.
+// Only plain equality pushes down. Everything else is either unsupported by
+// store.PropPredicate (ordered comparison, regex, fuzzy) or means something
+// different there: a glob rides on OpEqual but would become a literal string
+// comparison.
 //
-// Fail-safe by construction: an operator this function does not recognize
-// falls into `residual` and is evaluated exactly as before. The cost of
-// misjudging one is a slower query, never a wrong result.
+// NOT-equal is excluded even though PropPredicate supports it: on a typed
+// property a string-form disagreement WIDENS (`flag!=yes` on a boolean errors
+// in Go, excluding the row, and matches in the store), so it would admit rows
+// the Go pass must then reject — no saving, and a bug in the pairing leaks them.
+//
+// TYPED properties are excluded entirely, in either direction. A pre-filter is
+// only sound if it can never remove a row the authoritative pass would keep,
+// and equality on a typed property breaks exactly that: `count=03` against an
+// integer 3 matches numerically but not as strings, so pushing it would drop a
+// row that belongs in the result. Only `string` and untyped-unknown properties
+// compare identically both ways.
+//
+// Multi-type queries are handled by requiring EVERY named type to declare the
+// property as string-comparable: one property name can be `string` on one type
+// and `integer` on another, and the pushdown is applied per query, not per type.
+// An unnamed-type query (no `type:`) pushes nothing, since any type could match.
 //
 // Emptiness agrees across both paths because internal/propmatch is the single
 // definition backing store.PropPredicate AND internal/filter's empty handling;
 // storetest's Props_value_shapes pins that agreement per backend.
-func splitPushdownFilters(filters []*filter.Filter) (pushed []store.PropPredicate, residual []*filter.Filter) {
+func pushdownPrefilters(
+	filters []*filter.Filter, meta *metamodel.Metamodel, types []string,
+) []store.PropPredicate {
+	if len(types) == 0 || meta == nil {
+		return nil // no declared type to check against — push nothing
+	}
+	var pushed []store.PropPredicate
 	for _, f := range filters {
 		// A glob (`status=in-*`) rides on OpEqual but means pattern-match, so
 		// it must NOT become a literal string comparison in the store.
-		if f.IsGlob {
-			residual = append(residual, f)
+		if f.IsGlob || f.Operator != filter.OpEqual {
 			continue
 		}
-		switch f.Operator {
-		case filter.OpEqual:
-			pushed = append(pushed, store.PropPredicate{
-				Property: f.Property, Op: store.PropEqual, Value: f.Value,
-			})
-		case filter.OpNotEqual:
-			pushed = append(pushed, store.PropPredicate{
-				Property: f.Property, Op: store.PropNotEqual, Value: f.Value,
-			})
-		default:
-			residual = append(residual, f)
+		if !stringComparableOnEveryType(meta, types, f.Property) {
+			continue
+		}
+		pushed = append(pushed, store.PropPredicate{
+			Property: f.Property, Op: store.PropEqual, Value: f.Value,
+		})
+	}
+	return pushed
+}
+
+// stringComparableOnEveryType reports whether `prop` compares identically as a
+// string on every named type — the precondition for pushing it down.
+//
+// Conservative by construction: an unknown type, an undeclared property, or
+// any non-string declared type all return false, so the filter simply stays in
+// the Go pass. The cost of a false negative is a slower query; the cost of a
+// false positive is a wrong result.
+func stringComparableOnEveryType(meta *metamodel.Metamodel, types []string, prop string) bool {
+	for _, typ := range types {
+		def, ok := meta.GetEntityDef(typ)
+		if !ok {
+			return false
+		}
+		pd, ok := def.Properties[prop]
+		if !ok {
+			return false
+		}
+		// Enums are excluded too: filter.matchEnum ERRORS on a value that is
+		// not declared, which surfaces an operator typo. Pushed down, the same
+		// typo silently matches nothing and the source goes quiet with no
+		// diagnostic.
+		if pd.Type != metamodel.PropertyTypeString {
+			return false
 		}
 	}
-	return pushed, residual
+	return true
 }
 
 func (a *App) matchesPropertyFilters(e *entity.Entity, filters []*filter.Filter) bool {

--- a/internal/dataentry/helpers.go
+++ b/internal/dataentry/helpers.go
@@ -420,7 +420,14 @@ func (a *App) executeQuery(ctx context.Context, query string) ([]*entity.Entity,
 		// executeQuery never sorted by them.
 		candidates, err = a.runVisibleFreeTextSearch(ctx, svc, sq, scope)
 	} else {
-		candidates, err = visibleListByTypes(ctx, svc, sq.EntityTypes, scope)
+		// Push the equality filters into the store so it returns only
+		// matching rows instead of the whole type. Whatever cannot be pushed
+		// (ordered comparison, regex, glob, fuzzy) stays in the Go pass below,
+		// which still runs over every candidate — so the result set is
+		// identical either way, only the volume loaded changes.
+		pushed, residual := splitPushdownFilters(sq.PropertyFilters)
+		candidates, err = visibleListByTypes(ctx, svc, sq.EntityTypes, scope, pushed)
+		sq.PropertyFilters = residual
 	}
 	if err != nil {
 		return nil, err
@@ -540,13 +547,25 @@ func hiddenSearchFields(aff affordanceService) search.HiddenFieldsFunc {
 // listFromStoreByTypes (which other, ungated consumers still use and
 // which swallows iterator errors), this fails loud on both verdict
 // paths — same rationale as scopedSortedEntities.
+// visibleListByTypes loads the visible entities of the given types, applying
+// `props` in the STORE rather than after the fact.
+//
+// The predicates compose with the ACL scope rather than replacing it: an
+// AllowAll type gets a plain type+props query, and a scope-restricted type
+// gets its verdict query with the props appended. Both are ANDed by the
+// store, so narrowing by property can never widen what the gate allows.
 func visibleListByTypes(
 	ctx context.Context, svc Services, types []string, scope map[string]search.TypeScope,
+	props []store.PropPredicate,
 ) ([]*entity.Entity, error) {
 	if len(types) == 0 {
 		if _, wildcard := scope[search.WildcardType]; wildcard {
 			// Wildcard-allow (no ACL): every entity, any type — the
 			// pre-ACL listAll shape, with iterator errors surfaced.
+			// No type named and no ACL: every entity, any type. The
+			// property predicates cannot be pushed here — GraphQuery is
+			// per-type — so this one path keeps the Go-side filter, which
+			// still runs over the result below.
 			out := make([]*entity.Entity, 0)
 			for e, err := range svc.Store.ListEntities(ctx, store.EntityQuery{}) {
 				if err != nil {
@@ -571,21 +590,58 @@ func visibleListByTypes(
 		if !ok {
 			continue // denied type
 		}
-		if ts.AllowAll {
-			for e, err := range svc.Store.ListEntities(ctx, store.EntityQuery{Type: typ}) {
-				if err != nil {
-					return nil, fmt.Errorf("%w: %w", errListLoad, err)
-				}
-				out = append(out, e)
-			}
-			continue
+		got, err := visibleEntitiesOfType(ctx, svc, typ, ts, props)
+		if err != nil {
+			return nil, err
 		}
-		for e, err := range svc.Store.GraphQuery(ctx, *ts.Query) {
+		out = append(out, got...)
+	}
+	return out, nil
+}
+
+// visibleEntitiesOfType loads one type's visible entities, applying the
+// property predicates in the store.
+//
+// Three shapes, differing only in how the query is composed:
+//
+//   - AllowAll with no props: a plain type listing, byte-identical to the
+//     pre-pushdown path.
+//   - AllowAll with props: a type+props query rather than a full scan. The
+//     error class stays errListLoad — no gate is involved here.
+//   - Scope-restricted: the gate's own verdict query with the props appended,
+//     ANDed by the store, so narrowing by property can never widen what the
+//     gate allows. errACLListQuery, because a failure here IS a gate failure.
+func visibleEntitiesOfType(
+	ctx context.Context, svc Services, typ string,
+	ts search.TypeScope, props []store.PropPredicate,
+) ([]*entity.Entity, error) {
+	if ts.AllowAll && len(props) == 0 {
+		var out []*entity.Entity
+		for e, err := range svc.Store.ListEntities(ctx, store.EntityQuery{Type: typ}) {
 			if err != nil {
-				return nil, fmt.Errorf("%w: %w", errACLListQuery, err)
+				return nil, fmt.Errorf("%w: %w", errListLoad, err)
 			}
 			out = append(out, e)
 		}
+		return out, nil
+	}
+
+	q := store.GraphQuery{EntityType: typ, Props: props}
+	errClass := errListLoad
+	if !ts.AllowAll {
+		// Copy by value: TypeScope.Query is shared across calls and must not
+		// be mutated (store.GraphQueryer documents the same rule).
+		q = *ts.Query
+		q.Props = append(append([]store.PropPredicate(nil), q.Props...), props...)
+		errClass = errACLListQuery
+	}
+
+	var out []*entity.Entity
+	for e, err := range svc.Store.GraphQuery(ctx, q) {
+		if err != nil {
+			return nil, fmt.Errorf("%w: %w", errClass, err)
+		}
+		out = append(out, e)
 	}
 	return out, nil
 }
@@ -725,6 +781,47 @@ func relationDirection(d dataentryconfig.Direction) store.Direction {
 
 // matchesPropertyFilters checks whether an entity matches the given property filters.
 // Returns true if no filters are specified or all filters match.
+// splitPushdownFilters divides property filters into those the store can
+// evaluate and those that must stay in Go.
+//
+// Only plain equality and inequality push down: store.PropPredicate compares
+// by string form, deliberately, because the store layer does not consult the
+// metamodel. Everything needing a declared type or a pattern engine — ordered
+// comparison on dates and integers, regex, glob, fuzzy — would give a
+// DIFFERENT answer there (a date compared lexicographically, a glob compared
+// literally), so it is kept in the metamodel-aware Go pass.
+//
+// Fail-safe by construction: an operator this function does not recognize
+// falls into `residual` and is evaluated exactly as before. The cost of
+// misjudging one is a slower query, never a wrong result.
+//
+// Emptiness agrees across both paths because internal/propmatch is the single
+// definition backing store.PropPredicate AND internal/filter's empty handling;
+// storetest's Props_value_shapes pins that agreement per backend.
+func splitPushdownFilters(filters []*filter.Filter) (pushed []store.PropPredicate, residual []*filter.Filter) {
+	for _, f := range filters {
+		// A glob (`status=in-*`) rides on OpEqual but means pattern-match, so
+		// it must NOT become a literal string comparison in the store.
+		if f.IsGlob {
+			residual = append(residual, f)
+			continue
+		}
+		switch f.Operator {
+		case filter.OpEqual:
+			pushed = append(pushed, store.PropPredicate{
+				Property: f.Property, Op: store.PropEqual, Value: f.Value,
+			})
+		case filter.OpNotEqual:
+			pushed = append(pushed, store.PropPredicate{
+				Property: f.Property, Op: store.PropNotEqual, Value: f.Value,
+			})
+		default:
+			residual = append(residual, f)
+		}
+	}
+	return pushed, residual
+}
+
 func (a *App) matchesPropertyFilters(e *entity.Entity, filters []*filter.Filter) bool {
 	if len(filters) == 0 {
 		return true

--- a/internal/dataentry/helpers_test.go
+++ b/internal/dataentry/helpers_test.go
@@ -973,33 +973,57 @@ func TestCompareOrdered_UnknownOperator(t *testing.T) {
 	}
 }
 
-// TestSplitPushdownFilters pins which property filters may be evaluated by the
-// store and which must stay in the metamodel-aware Go pass.
+// pushdownTestMeta declares `status` as a string (push-eligible) and `count`
+// as an integer (never eligible — see stringComparableOnEveryType).
+func pushdownTestMeta() *metamodel.Metamodel {
+	return &metamodel.Metamodel{
+		Entities: map[string]metamodel.EntityDef{
+			"ticket": {Properties: map[string]metamodel.PropertyDef{
+				"status": {Type: metamodel.PropertyTypeString},
+				"title":  {Type: metamodel.PropertyTypeString},
+				"due":    {Type: metamodel.PropertyTypeDate},
+				"count":  {Type: metamodel.PropertyTypeInteger},
+			}},
+		},
+	}
+}
+
+// TestPushdownPrefilters pins which property filters may be handed to the
+// store as a PRE-FILTER.
 //
-// The split is a correctness boundary, not an optimisation detail:
-// store.PropPredicate compares by STRING FORM, so pushing an ordered
-// comparison down would compare dates lexicographically and a glob literally.
-// Anything unrecognized must land in `residual`, where behavior is unchanged.
-func TestSplitPushdownFilters(t *testing.T) {
+// The pushdown is not a replacement for the Go pass — executeQuery still runs
+// every filter through the metamodel-aware filter.MatchAll, and the store can
+// only ever remove rows that pass would also remove. That belt-and-braces is
+// what makes the result provably identical to the pre-pushdown behavior,
+// because store.PropPredicate compares by STRING FORM and disagrees with the
+// typed comparison on integers, booleans and undeclared enum values.
+func TestPushdownPrefilters(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name         string
-		in           *filter.Filter
-		wantPushed   bool
-		wantPushedOp store.PropOp
+		name       string
+		in         *filter.Filter
+		wantPushed bool
 	}{
 		{
-			name:         "equality pushes down",
-			in:           &filter.Filter{Property: "status", Operator: filter.OpEqual, Value: "open"},
-			wantPushed:   true,
-			wantPushedOp: store.PropEqual,
+			name:       "equality pushes down",
+			in:         &filter.Filter{Property: "status", Operator: filter.OpEqual, Value: "open"},
+			wantPushed: true,
 		},
 		{
-			name:         "inequality pushes down",
-			in:           &filter.Filter{Property: "status", Operator: filter.OpNotEqual, Value: "done"},
-			wantPushed:   true,
-			wantPushedOp: store.PropNotEqual,
+			name:       "is-empty pushes down",
+			in:         &filter.Filter{Property: "status", Operator: filter.OpEqual},
+			wantPushed: true,
+		},
+		{
+			// Excluded on purpose. It is the one operator where a string-form
+			// disagreement WIDENS: `flag!=yes` on a boolean errors in Go
+			// (excluding the row) but matches in the store, so as a pre-filter
+			// it admits rows the Go pass must then reject — no saving, and a
+			// bug in the pairing would leak them.
+			name:       "not-equal is excluded even though the store supports it",
+			in:         &filter.Filter{Property: "status", Operator: filter.OpNotEqual, Value: "done"},
+			wantPushed: false,
 		},
 		{
 			// `status=in-*` rides on OpEqual but means pattern-match; pushed
@@ -1009,15 +1033,8 @@ func TestSplitPushdownFilters(t *testing.T) {
 			wantPushed: false,
 		},
 		{
-			// The store has no metamodel, so it cannot know `due` is a date;
-			// pushed down this would compare lexicographically.
 			name:       "ordered comparison stays in Go",
 			in:         &filter.Filter{Property: "due", Operator: filter.OpLess, Value: "2026-01-01"},
-			wantPushed: false,
-		},
-		{
-			name:       "greater-or-equal stays in Go",
-			in:         &filter.Filter{Property: "count", Operator: filter.OpGreaterEqual, Value: "3"},
 			wantPushed: false,
 		},
 		{
@@ -1030,60 +1047,64 @@ func TestSplitPushdownFilters(t *testing.T) {
 			in:         &filter.Filter{Property: "title", Operator: filter.OpFuzzy, Value: "retro"},
 			wantPushed: false,
 		},
+		{
+			// `count=03` matches the integer 3 when typed and misses as
+			// strings, so pushing it would DROP a row that belongs in the
+			// result — the precondition a pre-filter must never break.
+			name:       "typed property is never pushed",
+			in:         &filter.Filter{Property: "count", Operator: filter.OpEqual, Value: "03"},
+			wantPushed: false,
+		},
+		{
+			// filter.matchEnum errors on an undeclared value, surfacing an
+			// operator typo. Pushed down the same typo silently matches
+			// nothing and the source goes quiet with no diagnostic.
+			name:       "undeclared property is never pushed",
+			in:         &filter.Filter{Property: "nope", Operator: filter.OpEqual, Value: "x"},
+			wantPushed: false,
+		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			pushed, residual := splitPushdownFilters([]*filter.Filter{tc.in})
+			pushed := pushdownPrefilters([]*filter.Filter{tc.in}, pushdownTestMeta(), []string{"ticket"})
 
 			if !tc.wantPushed {
 				if len(pushed) != 0 {
 					t.Errorf("expected no pushdown, got %+v", pushed)
-				}
-				if len(residual) != 1 {
-					t.Errorf("expected the filter to remain in Go, got %d residual", len(residual))
 				}
 				return
 			}
 			if len(pushed) != 1 {
 				t.Fatalf("expected one pushed predicate, got %d", len(pushed))
 			}
-			if pushed[0].Op != tc.wantPushedOp {
-				t.Errorf("op = %v, want %v", pushed[0].Op, tc.wantPushedOp)
+			if pushed[0].Op != store.PropEqual {
+				t.Errorf("op = %v, want PropEqual", pushed[0].Op)
 			}
 			if pushed[0].Property != tc.in.Property || pushed[0].Value != tc.in.Value {
 				t.Errorf("predicate = %+v, want property/value from %+v", pushed[0], tc.in)
-			}
-			if len(residual) != 0 {
-				t.Errorf("expected nothing left in Go, got %+v", residual)
 			}
 		})
 	}
 }
 
-// A mixed query must split, not fall wholly to one side: the equality is
-// pushed for the volume win while the date comparison stays where the
-// metamodel is available.
-func TestSplitPushdownFilters_Mixed(t *testing.T) {
+// A mixed query pushes only the equality; the rest is left for the Go pass,
+// which evaluates ALL of them regardless.
+func TestPushdownPrefilters_Mixed(t *testing.T) {
 	t.Parallel()
-	pushed, residual := splitPushdownFilters([]*filter.Filter{
+	pushed := pushdownPrefilters([]*filter.Filter{
 		{Property: "status", Operator: filter.OpEqual, Value: "open"},
 		{Property: "due", Operator: filter.OpLess, Value: "2026-01-01"},
-	})
-
+	}, pushdownTestMeta(), []string{"ticket"})
 	if len(pushed) != 1 || pushed[0].Property != "status" {
 		t.Errorf("expected only the equality pushed, got %+v", pushed)
 	}
-	if len(residual) != 1 || residual[0].Property != "due" {
-		t.Errorf("expected only the ordered comparison residual, got %+v", residual)
-	}
 }
 
-func TestSplitPushdownFilters_Empty(t *testing.T) {
+func TestPushdownPrefilters_Empty(t *testing.T) {
 	t.Parallel()
-	pushed, residual := splitPushdownFilters(nil)
-	if len(pushed) != 0 || len(residual) != 0 {
-		t.Errorf("nil filters should split to nothing, got %+v / %+v", pushed, residual)
+	if got := pushdownPrefilters(nil, pushdownTestMeta(), []string{"ticket"}); len(got) != 0 {
+		t.Errorf("nil filters should push nothing, got %+v", got)
 	}
 }

--- a/internal/dataentry/helpers_test.go
+++ b/internal/dataentry/helpers_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Sourcehaven-BV/rela/internal/entity"
 	"github.com/Sourcehaven-BV/rela/internal/filter"
 	"github.com/Sourcehaven-BV/rela/internal/metamodel"
+	"github.com/Sourcehaven-BV/rela/internal/store"
 	"github.com/Sourcehaven-BV/rela/internal/testutil"
 )
 
@@ -969,5 +970,120 @@ func TestCompareValues_TypeMismatch(t *testing.T) {
 func TestCompareOrdered_UnknownOperator(t *testing.T) {
 	if compareOrdered(1, 2, "bogus") {
 		t.Error("unknown operator should return false")
+	}
+}
+
+// TestSplitPushdownFilters pins which property filters may be evaluated by the
+// store and which must stay in the metamodel-aware Go pass.
+//
+// The split is a correctness boundary, not an optimisation detail:
+// store.PropPredicate compares by STRING FORM, so pushing an ordered
+// comparison down would compare dates lexicographically and a glob literally.
+// Anything unrecognized must land in `residual`, where behavior is unchanged.
+func TestSplitPushdownFilters(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		in           *filter.Filter
+		wantPushed   bool
+		wantPushedOp store.PropOp
+	}{
+		{
+			name:         "equality pushes down",
+			in:           &filter.Filter{Property: "status", Operator: filter.OpEqual, Value: "open"},
+			wantPushed:   true,
+			wantPushedOp: store.PropEqual,
+		},
+		{
+			name:         "inequality pushes down",
+			in:           &filter.Filter{Property: "status", Operator: filter.OpNotEqual, Value: "done"},
+			wantPushed:   true,
+			wantPushedOp: store.PropNotEqual,
+		},
+		{
+			// `status=in-*` rides on OpEqual but means pattern-match; pushed
+			// down it would compare against the literal string "in-*".
+			name:       "glob stays in Go despite riding on OpEqual",
+			in:         &filter.Filter{Property: "status", Operator: filter.OpEqual, Value: "in-*", IsGlob: true},
+			wantPushed: false,
+		},
+		{
+			// The store has no metamodel, so it cannot know `due` is a date;
+			// pushed down this would compare lexicographically.
+			name:       "ordered comparison stays in Go",
+			in:         &filter.Filter{Property: "due", Operator: filter.OpLess, Value: "2026-01-01"},
+			wantPushed: false,
+		},
+		{
+			name:       "greater-or-equal stays in Go",
+			in:         &filter.Filter{Property: "count", Operator: filter.OpGreaterEqual, Value: "3"},
+			wantPushed: false,
+		},
+		{
+			name:       "regex stays in Go",
+			in:         &filter.Filter{Property: "title", Operator: filter.OpRegex, Value: "^spike"},
+			wantPushed: false,
+		},
+		{
+			name:       "fuzzy stays in Go",
+			in:         &filter.Filter{Property: "title", Operator: filter.OpFuzzy, Value: "retro"},
+			wantPushed: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			pushed, residual := splitPushdownFilters([]*filter.Filter{tc.in})
+
+			if !tc.wantPushed {
+				if len(pushed) != 0 {
+					t.Errorf("expected no pushdown, got %+v", pushed)
+				}
+				if len(residual) != 1 {
+					t.Errorf("expected the filter to remain in Go, got %d residual", len(residual))
+				}
+				return
+			}
+			if len(pushed) != 1 {
+				t.Fatalf("expected one pushed predicate, got %d", len(pushed))
+			}
+			if pushed[0].Op != tc.wantPushedOp {
+				t.Errorf("op = %v, want %v", pushed[0].Op, tc.wantPushedOp)
+			}
+			if pushed[0].Property != tc.in.Property || pushed[0].Value != tc.in.Value {
+				t.Errorf("predicate = %+v, want property/value from %+v", pushed[0], tc.in)
+			}
+			if len(residual) != 0 {
+				t.Errorf("expected nothing left in Go, got %+v", residual)
+			}
+		})
+	}
+}
+
+// A mixed query must split, not fall wholly to one side: the equality is
+// pushed for the volume win while the date comparison stays where the
+// metamodel is available.
+func TestSplitPushdownFilters_Mixed(t *testing.T) {
+	t.Parallel()
+	pushed, residual := splitPushdownFilters([]*filter.Filter{
+		{Property: "status", Operator: filter.OpEqual, Value: "open"},
+		{Property: "due", Operator: filter.OpLess, Value: "2026-01-01"},
+	})
+
+	if len(pushed) != 1 || pushed[0].Property != "status" {
+		t.Errorf("expected only the equality pushed, got %+v", pushed)
+	}
+	if len(residual) != 1 || residual[0].Property != "due" {
+		t.Errorf("expected only the ordered comparison residual, got %+v", residual)
+	}
+}
+
+func TestSplitPushdownFilters_Empty(t *testing.T) {
+	t.Parallel()
+	pushed, residual := splitPushdownFilters(nil)
+	if len(pushed) != 0 || len(residual) != 0 {
+		t.Errorf("nil filters should split to nothing, got %+v / %+v", pushed, residual)
 	}
 }

--- a/internal/dataentry/nextaction.go
+++ b/internal/dataentry/nextaction.go
@@ -1,0 +1,130 @@
+package dataentry
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/Sourcehaven-BV/rela/internal/dataentryconfig"
+	"github.com/Sourcehaven-BV/rela/internal/nextaction"
+	"github.com/Sourcehaven-BV/rela/internal/store"
+	"github.com/Sourcehaven-BV/rela/internal/userstate"
+)
+
+// nextActionCandidates adapts the app's ACL-gated read paths into the
+// [nextaction.CandidateFunc] the engine takes.
+//
+// # Why this lives here and not in internal/nextaction
+//
+// Same reason the list-table renderer lives in dataentry rather than
+// internal/transform: the engine must never see an entity the request
+// principal cannot read, and the read gate is resolved per-request from the
+// context here. Keeping the adapter at this layer means the engine depends on
+// no store, searcher or ACL type, and cannot accidentally acquire an ungated
+// handle.
+//
+// # Which seam each source kind uses
+//
+//   - Query  -> [App.executeQuery], the same helper /_search and scope
+//     navigation use. It resolves SearchScope from the read gate first, and
+//     for a query with no free text (which every structural next-action query
+//     is) routes to visibleListByTypes — a type-scoped store list, NOT the
+//     search index. So the "SearchVisible does not push filters down" caveat
+//     does not apply on this path.
+//   - Count  -> GraphCount over the type, for the entity-less first-run case.
+//     Uses the ungated count deliberately: see countCandidates.
+//   - Context -> not reachable from the dashboard; a context-aware source is
+//     resolved against the entity being viewed, which is a later surface.
+func (a *App) nextActionCandidates() nextaction.CandidateFunc {
+	return func(ctx context.Context, src dataentryconfig.NextActionSource) ([]nextaction.Candidate, error) {
+		switch {
+		case src.Count != "":
+			return a.countCandidates(ctx, src.Count)
+		case src.Query != "":
+			return a.queryCandidates(ctx, src.Query)
+		default:
+			// A context-aware source has no dashboard candidates. Not an
+			// error: the same config serves both surfaces, and each ignores
+			// the other's sources.
+			return nil, nil
+		}
+	}
+}
+
+// queryCandidates runs a source's query through the ACL-gated pipeline.
+func (a *App) queryCandidates(ctx context.Context, query string) ([]nextaction.Candidate, error) {
+	entities, err := a.executeQuery(ctx, query)
+	if err != nil {
+		return nil, fmt.Errorf("next-action query %q: %w", query, err)
+	}
+	out := make([]nextaction.Candidate, 0, len(entities))
+	for _, e := range entities {
+		out = append(out, nextaction.Candidate{Entity: e})
+	}
+	return out, nil
+}
+
+// countCandidates answers a `<entity_type> == 0` source: it yields exactly one
+// entity-less candidate when the type is empty, and none otherwise.
+//
+// The count is deliberately UNGATED (store-level, not read-gated). "Does any
+// client exist?" is a question about whether the operator has begun using the
+// app, not about whether this principal may read any particular client — and
+// gating it would make the first-run hint reappear for a principal who simply
+// cannot see the clients that do exist, which is worse than useless.
+//
+// This is safe because a count source's suggestion mentions NO entity: it
+// interpolates nothing, exposes no id, and its message is operator-authored
+// static text. The only bit that reaches the user is "this type is empty",
+// which the metamodel already tells them exists.
+func (a *App) countCandidates(ctx context.Context, count string) ([]nextaction.Candidate, error) {
+	entityType, ok := parseCountZero(count)
+	if !ok {
+		// Validated at config load; reaching here means the config was built
+		// in code. Yield nothing rather than failing the whole page.
+		return nil, nil
+	}
+
+	svc := a.Services()
+	_, total, err := svc.Store.GraphCount(ctx, store.GraphQuery{EntityType: entityType})
+	if err != nil {
+		return nil, fmt.Errorf("next-action count for %q: %w", entityType, err)
+	}
+	if total != 0 {
+		return nil, nil
+	}
+	// One candidate with no entity — the engine keys it on the source alone.
+	return []nextaction.Candidate{{}}, nil
+}
+
+// parseCountZero extracts the entity type from the only supported aggregate
+// form, "<entity_type> == 0". Mirrors validateNextActionCount so the engine
+// and the validator agree on what is accepted.
+func parseCountZero(count string) (string, bool) {
+	fields := strings.Fields(count)
+	if len(fields) != 3 || fields[1] != "==" || fields[2] != "0" {
+		return "", false
+	}
+	return fields[0], true
+}
+
+// SetUserState replaces the next-action per-user state backend.
+//
+// Defaults to an in-memory store (see NewApp), which is correct for a
+// single-process deployment: this state is disposable, so losing it on
+// restart costs a user one repeated suggestion. A deployment that wants
+// snoozes to survive a restart, or to be shared across processes, injects a
+// persistent backend here.
+//
+// Rejects nil rather than quietly disabling the feature: a silently absent
+// store would make the app stop honoring snoozes and mutes, which users
+// experience as the system ignoring them — the deferred-failure symptom the
+// project's constructor rule exists to prevent.
+func (a *App) SetUserState(s userstate.Store) error {
+	if s == nil {
+		return errors.New("dataentry.SetUserState: store must be non-nil")
+	}
+	a.userState = s
+	return nil
+}

--- a/internal/dataentry/nextaction.go
+++ b/internal/dataentry/nextaction.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/Sourcehaven-BV/rela/internal/dataentryconfig"
+	entityPkg "github.com/Sourcehaven-BV/rela/internal/entity"
 	"github.com/Sourcehaven-BV/rela/internal/nextaction"
 	"github.com/Sourcehaven-BV/rela/internal/store"
 	"github.com/Sourcehaven-BV/rela/internal/userstate"
@@ -69,14 +70,23 @@ func (a *App) nextActionOptions() nextaction.OptionFunc {
 			entities = entities[:limit]
 		}
 		out := make([]nextaction.PickOption, 0, len(entities))
+		s := a.State()
 		for _, e := range entities {
+			// Redact BEFORE safeDisplayTitle: its guard is presence-based
+			// ("is the display property missing?"), so against an unredacted
+			// entity every property is present and it happily returns the
+			// hidden value.
+			red := a.redactedForSuggestion(ctx, e)
 			out = append(out, nextaction.PickOption{
 				EntityID: e.ID,
 				// safeDisplayTitle, not the raw DisplayTitle: a redacted
 				// display property would otherwise render a PARTIAL title,
 				// leaking the readable half and confirming a hidden half
 				// exists (the BUG-R9EHKV leak class).
-				Label: safeDisplayTitle(a.Meta(), e),
+				// One snapshot for the whole loop (captured above): two
+				// State() loads can observe different metamodels if a reload
+				// lands mid-resolve.
+				Label: safeDisplayTitle(s.Meta, red),
 			})
 		}
 		return out, nil
@@ -84,6 +94,14 @@ func (a *App) nextActionOptions() nextaction.OptionFunc {
 }
 
 // queryCandidates runs a source's query through the ACL-gated pipeline.
+//
+// Candidates are FIELD-REDACTED here, not merely row-gated. executeQuery
+// returns raw entities — every other consumer redacts at serialization (see
+// forWireRelated / stripHiddenProperties), but a suggestion never passes
+// through that seam: its message interpolates `{property}` straight into
+// text. Without this an operator writing `suggest: "{title} needs a look"` on
+// a type whose title is hidden by `visible:` would put the hidden value on
+// the wire — the BUG-R9EHKV leak class, through a new door.
 func (a *App) queryCandidates(ctx context.Context, query string) ([]nextaction.Candidate, error) {
 	entities, err := a.executeQuery(ctx, query)
 	if err != nil {
@@ -91,9 +109,20 @@ func (a *App) queryCandidates(ctx context.Context, query string) ([]nextaction.C
 	}
 	out := make([]nextaction.Candidate, 0, len(entities))
 	for _, e := range entities {
-		out = append(out, nextaction.Candidate{Entity: e})
+		out = append(out, nextaction.Candidate{Entity: a.redactedForSuggestion(ctx, e)})
 	}
 	return out, nil
+}
+
+// redactedForSuggestion returns a copy of e carrying only the properties this
+// principal may see.
+//
+// A COPY, never a mutation: the entity comes from the store's iterator and may
+// be shared with a cache, so stripping in place would redact it for everyone.
+func (a *App) redactedForSuggestion(ctx context.Context, e *entityPkg.Entity) *entityPkg.Entity {
+	clone := *e
+	clone.Properties = a.affordances.copyVisibleProperties(ctx, e)
+	return &clone
 }
 
 // countCandidates answers a `<entity_type> == 0` source: it yields exactly one

--- a/internal/dataentry/nextaction.go
+++ b/internal/dataentry/nextaction.go
@@ -40,7 +40,7 @@ func (a *App) nextActionCandidates() nextaction.CandidateFunc {
 	return func(ctx context.Context, src dataentryconfig.NextActionSource) ([]nextaction.Candidate, error) {
 		switch {
 		case src.Count != "":
-			return a.countCandidates(ctx, src.Count)
+			return a.countCandidates(ctx, src.Count, src.CountUngated)
 		case src.Query != "":
 			return a.queryCandidates(ctx, src.Query)
 		default:
@@ -68,17 +68,22 @@ func (a *App) queryCandidates(ctx context.Context, query string) ([]nextaction.C
 // countCandidates answers a `<entity_type> == 0` source: it yields exactly one
 // entity-less candidate when the type is empty, and none otherwise.
 //
-// The count is deliberately UNGATED (store-level, not read-gated). "Does any
-// client exist?" is a question about whether the operator has begun using the
-// app, not about whether this principal may read any particular client — and
-// gating it would make the first-run hint reappear for a principal who simply
-// cannot see the clients that do exist, which is worse than useless.
+// GATED BY DEFAULT. The count runs through the same read path as every other
+// source, so it counts what THIS principal can see: "do I have any clients?",
+// not "does anyone?". An ungated count would disclose that entities of a type
+// exist to a principal permitted to read none of them, and entity existence is
+// the strongest secret rela's read model keeps (a hidden entity is
+// nonexistent, indistinguishable from a real 404).
 //
-// This is safe because a count source's suggestion mentions NO entity: it
-// interpolates nothing, exposes no id, and its message is operator-authored
-// static text. The only bit that reaches the user is "this type is empty",
-// which the metamodel already tells them exists.
-func (a *App) countCandidates(ctx context.Context, count string) ([]nextaction.Candidate, error) {
+// `ungated` (config: count_ungated) opts out for a genuinely operator-level
+// question — "has this deployment been set up at all?" — and is never
+// inferred. The safe default's failure mode is a principal who sees no clients
+// being repeatedly offered "add a client": mild, visible, and fixable in
+// config. The unsafe default's failure mode is a silent disclosure nobody
+// notices. Prefer the loud, fixable error.
+func (a *App) countCandidates(
+	ctx context.Context, count string, ungated bool,
+) ([]nextaction.Candidate, error) {
 	entityType, ok := parseCountZero(count)
 	if !ok {
 		// Validated at config load; reaching here means the config was built
@@ -86,16 +91,37 @@ func (a *App) countCandidates(ctx context.Context, count string) ([]nextaction.C
 		return nil, nil
 	}
 
-	svc := a.Services()
-	_, total, err := svc.Store.GraphCount(ctx, store.GraphQuery{EntityType: entityType})
+	empty, err := a.countIsZero(ctx, entityType, ungated)
 	if err != nil {
-		return nil, fmt.Errorf("next-action count for %q: %w", entityType, err)
+		return nil, err
 	}
-	if total != 0 {
+	if !empty {
 		return nil, nil
 	}
 	// One candidate with no entity — the engine keys it on the source alone.
 	return []nextaction.Candidate{{}}, nil
+}
+
+// countIsZero reports whether the caller sees no entities of entityType.
+func (a *App) countIsZero(ctx context.Context, entityType string, ungated bool) (bool, error) {
+	if ungated {
+		_, total, err := a.Services().Store.GraphCount(ctx, store.GraphQuery{EntityType: entityType})
+		if err != nil {
+			return false, fmt.Errorf("next-action count for %q: %w", entityType, err)
+		}
+		return total == 0, nil
+	}
+
+	// Gated: route through the same read gate the list pipeline uses, so a
+	// hidden entity does not count. scopedSortedEntities resolves the ACL
+	// verdict FIRST and returns empty on DenyAll, which is exactly the
+	// answer we want — a principal denied the type sees "none", and the
+	// first-run hint fires for them.
+	entities, err := a.scopedSortedEntities(ctx, entityType, nil)
+	if err != nil {
+		return false, fmt.Errorf("next-action count for %q: %w", entityType, err)
+	}
+	return len(entities) == 0, nil
 }
 
 // parseCountZero extracts the entity type from the only supported aggregate

--- a/internal/dataentry/nextaction.go
+++ b/internal/dataentry/nextaction.go
@@ -52,6 +52,37 @@ func (a *App) nextActionCandidates() nextaction.CandidateFunc {
 	}
 }
 
+// nextActionOptions resolves a pick_one option list through the SAME
+// ACL-gated path as candidates, so an option can never name an entity the
+// caller may not read.
+//
+// Labels come from the entity's display title, which the read gate has
+// already approved — this is why the resolution belongs here and not in the
+// SPA: a client-side fetch would be a second read surface to gate.
+func (a *App) nextActionOptions() nextaction.OptionFunc {
+	return func(ctx context.Context, query string, limit int) ([]nextaction.PickOption, error) {
+		entities, err := a.executeQuery(ctx, query)
+		if err != nil {
+			return nil, fmt.Errorf("next-action pick_one query %q: %w", query, err)
+		}
+		if len(entities) > limit {
+			entities = entities[:limit]
+		}
+		out := make([]nextaction.PickOption, 0, len(entities))
+		for _, e := range entities {
+			out = append(out, nextaction.PickOption{
+				EntityID: e.ID,
+				// safeDisplayTitle, not the raw DisplayTitle: a redacted
+				// display property would otherwise render a PARTIAL title,
+				// leaking the readable half and confirming a hidden half
+				// exists (the BUG-R9EHKV leak class).
+				Label: safeDisplayTitle(a.Meta(), e),
+			})
+		}
+		return out, nil
+	}
+}
+
 // queryCandidates runs a source's query through the ACL-gated pipeline.
 func (a *App) queryCandidates(ctx context.Context, query string) ([]nextaction.Candidate, error) {
 	entities, err := a.executeQuery(ctx, query)

--- a/internal/dataentry/nextaction_handler.go
+++ b/internal/dataentry/nextaction_handler.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strconv"
 	"time"
 
 	"github.com/Sourcehaven-BV/rela/internal/dataentryconfig"
@@ -50,6 +51,20 @@ type nextActionWire struct {
 	Variant string                            `json:"variant,omitempty"`
 	Message string                            `json:"message"`
 	Actions []dataentryconfig.NextActionOffer `json:"actions,omitempty"`
+	// PickOptions carries the render-time options for any pick_one
+	// affordance, keyed by that offer's index in Actions (as a string,
+	// because JSON object keys are strings).
+	//
+	// Sent alongside the offers rather than embedded in them so the config
+	// shape stays exactly what the operator wrote — the SPA reads the offer
+	// for its kind and this map for its live contents.
+	PickOptions map[string][]pickOptionWire `json:"pick_options,omitempty"`
+}
+
+// pickOptionWire is one option in a pick_one affordance.
+type pickOptionWire struct {
+	EntityID string `json:"entity_id"`
+	Label    string `json:"label"`
 }
 
 // nextActionFeedbackRequest is the body of POST /api/v1/_next_action.
@@ -106,13 +121,32 @@ func (a *App) handleV1NextActionGet(w http.ResponseWriter, r *http.Request) {
 	}
 
 	writeV1JSON(w, http.StatusOK, nextActionResponse{Suggestion: &nextActionWire{
-		Source:   sug.Source,
-		Band:     sug.Band,
-		EntityID: sug.EntityID,
-		Variant:  sug.Key.Variant,
-		Message:  sug.Message,
-		Actions:  sug.Actions,
+		Source:      sug.Source,
+		Band:        sug.Band,
+		EntityID:    sug.EntityID,
+		Variant:     sug.Key.Variant,
+		Message:     sug.Message,
+		Actions:     sug.Actions,
+		PickOptions: pickOptionsWire(sug.PickOptions),
 	}})
+}
+
+// pickOptionsWire converts the engine's index-keyed options to the wire
+// shape. Nil in, nil out — the field is omitempty so a suggestion without a
+// pick_one carries nothing.
+func pickOptionsWire(in map[int][]nextaction.PickOption) map[string][]pickOptionWire {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make(map[string][]pickOptionWire, len(in))
+	for idx, opts := range in {
+		wire := make([]pickOptionWire, 0, len(opts))
+		for _, o := range opts {
+			wire = append(wire, pickOptionWire{EntityID: o.EntityID, Label: o.Label})
+		}
+		out[strconv.Itoa(idx)] = wire
+	}
+	return out
 }
 
 func (a *App) handleV1NextActionPost(w http.ResponseWriter, r *http.Request) {
@@ -233,5 +267,5 @@ func (a *App) nextActionEngine() (*nextaction.Engine, bool) {
 	if err != nil {
 		return nil, false
 	}
-	return eng, true
+	return eng.WithOptions(a.nextActionOptions()), true
 }

--- a/internal/dataentry/nextaction_handler.go
+++ b/internal/dataentry/nextaction_handler.go
@@ -95,7 +95,7 @@ func (a *App) handleV1NextActionGet(w http.ResponseWriter, r *http.Request) {
 	}
 
 	ctx := r.Context()
-	sug, found, err := eng.Resolve(ctx, principal.From(ctx).User, time.Now())
+	sug, found, err := eng.Resolve(ctx, nextActionUser(ctx), time.Now())
 	if err != nil {
 		writeListPipelineError(w, r, err)
 		return
@@ -143,7 +143,7 @@ func (a *App) handleV1NextActionPost(w http.ResponseWriter, r *http.Request) {
 	}
 
 	ctx := r.Context()
-	user := principal.From(ctx).User
+	user := nextActionUser(ctx)
 	key := userstate.Key{
 		User:     user,
 		Source:   req.Source,
@@ -156,6 +156,27 @@ func (a *App) handleV1NextActionPost(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	w.WriteHeader(http.StatusNoContent)
+}
+
+// nextActionUser is the key this request's snoozes and mutes are stored
+// under.
+//
+// An UNSTAMPED principal (no auth configured) yields principal.From's
+// "unknown" sentinel, and every such request therefore shares one bucket of
+// state. That is deliberate and correct for a single-user deployment — which
+// is exactly when there is no auth — but it means a shared unauthenticated
+// deployment gives everyone one another's snoozes.
+//
+// Not a confidentiality problem: the state holds no entity content, only
+// which suggestions someone deferred. It IS a usability one, so it is named
+// here rather than left to be discovered. Wiring any identity source (JWT,
+// header, OS user) fixes it with no change to this code.
+//
+// Deliberately NOT translated to a synthesized per-session id: that would
+// invent an identity the audit log and ACL do not share, and the project's
+// rule is to never translate an unknown principal into a guessed one.
+func nextActionUser(ctx context.Context) string {
+	return principal.From(ctx).User
 }
 
 // applyNextActionFeedback records one user response.

--- a/internal/dataentry/nextaction_handler.go
+++ b/internal/dataentry/nextaction_handler.go
@@ -170,7 +170,8 @@ func (a *App) handleV1NextActionPost(w http.ResponseWriter, r *http.Request) {
 	// string would create user-state rows keyed on nothing — unbounded growth
 	// driven by request bodies, and a mute list full of ids that name no
 	// source and so can never be surfaced for un-muting.
-	if _, known := a.Cfg().NextActions[req.Source]; !known {
+	src, known := a.Cfg().NextActions[req.Source]
+	if !known {
 		writeV1Error(w, r, http.StatusBadRequest, "unknown_source",
 			"Unknown next-action source", req.Source)
 		return
@@ -183,6 +184,16 @@ func (a *App) handleV1NextActionPost(w http.ResponseWriter, r *http.Request) {
 		Source:   req.Source,
 		EntityID: req.EntityID,
 		Variant:  req.Variant,
+	}
+	// The SERVER decides the key shape, not the client. A source-scoped
+	// source keys on the source alone, so the entity the client echoed back
+	// (which it needs for the link, and which the GET does advertise) is
+	// dropped here. Trusting the echo verbatim would store the deferral under
+	// a key the engine never checks — a 204 that silently does nothing, which
+	// is exactly how this was found.
+	if src.ResolvedDeferScope() == dataentryconfig.DeferScopeSource {
+		key.EntityID = ""
+		key.Variant = ""
 	}
 
 	if err := a.applyNextActionFeedback(ctx, state, key, req); err != nil {

--- a/internal/dataentry/nextaction_handler.go
+++ b/internal/dataentry/nextaction_handler.go
@@ -1,0 +1,208 @@
+package dataentry
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/Sourcehaven-BV/rela/internal/dataentryconfig"
+	"github.com/Sourcehaven-BV/rela/internal/nextaction"
+	"github.com/Sourcehaven-BV/rela/internal/principal"
+	"github.com/Sourcehaven-BV/rela/internal/userstate"
+)
+
+const (
+	// maxNextActionBodyBytes caps the feedback body. The payload is four
+	// short strings; anything larger is a mistake or an attack.
+	maxNextActionBodyBytes = 4 << 10
+
+	// dismissHorizon is how long a dismissal suppresses a suggestion. Long
+	// enough to read as "gone", finite so a dismissal cannot outlive the
+	// config that produced it — a suppression with no expiry is the invisible
+	// state per-entity muting was rejected for.
+	dismissHorizon = 365 * 24 * time.Hour
+)
+
+// nextActionResponse is the wire shape for GET /api/v1/_next_action.
+//
+// A deliberately thin envelope: `suggestion` is null when nothing is owed,
+// rather than the endpoint 404ing. "Nothing to suggest" is a normal, frequent
+// answer for an advisory surface — a well-configured system is quiet most of
+// the time — and an error status would push callers into treating silence as
+// a failure.
+type nextActionResponse struct {
+	Suggestion *nextActionWire `json:"suggestion"`
+}
+
+// nextActionWire is one suggestion as the SPA sees it.
+type nextActionWire struct {
+	Source   string                            `json:"source"`
+	Band     string                            `json:"band"`
+	EntityID string                            `json:"entity_id,omitempty"`
+	Message  string                            `json:"message"`
+	Actions  []dataentryconfig.NextActionOffer `json:"actions,omitempty"`
+}
+
+// nextActionFeedbackRequest is the body of POST /api/v1/_next_action.
+type nextActionFeedbackRequest struct {
+	// Source and EntityID identify which suggestion is being answered. They
+	// are echoed from the GET rather than trusted blindly — see the handler.
+	Source   string `json:"source"`
+	EntityID string `json:"entity_id,omitempty"`
+	Variant  string `json:"variant,omitempty"`
+
+	// Kind is one of: "snooze", "dismiss", "mute", "unmute", "shown".
+	Kind string `json:"kind"`
+	// Duration applies to snooze, e.g. "1d". Ignored otherwise.
+	Duration string `json:"duration,omitempty"`
+}
+
+// handleV1NextAction serves the advisory suggestion surface.
+//
+// GET resolves the one suggestion to show; POST records the user's response
+// (snooze / dismiss / mute / shown).
+//
+// The two are separate verbs on purpose. Resolving is a READ: a caller that
+// previews or discards the result must not start a cooldown, so the clock
+// only moves when the client explicitly reports the suggestion was shown.
+func (a *App) handleV1NextAction(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodGet:
+		a.handleV1NextActionGet(w, r)
+	case http.MethodPost:
+		a.handleV1NextActionPost(w, r)
+	default:
+		writeV1Error(w, r, http.StatusMethodNotAllowed, "method_not_allowed", "Method not allowed", "")
+	}
+}
+
+func (a *App) handleV1NextActionGet(w http.ResponseWriter, r *http.Request) {
+	eng, ok := a.nextActionEngine()
+	if !ok {
+		// No sources configured: a valid, common state (the feature is
+		// opt-in). An empty answer, not a 404 — the SPA renders nothing.
+		writeV1JSON(w, http.StatusOK, nextActionResponse{})
+		return
+	}
+
+	ctx := r.Context()
+	sug, found, err := eng.Resolve(ctx, principal.From(ctx).User, time.Now())
+	if err != nil {
+		writeListPipelineError(w, r, err)
+		return
+	}
+	if !found {
+		writeV1JSON(w, http.StatusOK, nextActionResponse{})
+		return
+	}
+
+	writeV1JSON(w, http.StatusOK, nextActionResponse{Suggestion: &nextActionWire{
+		Source:   sug.Source,
+		Band:     sug.Band,
+		EntityID: sug.EntityID,
+		Message:  sug.Message,
+		Actions:  sug.Actions,
+	}})
+}
+
+func (a *App) handleV1NextActionPost(w http.ResponseWriter, r *http.Request) {
+	state := a.userState
+	if state == nil {
+		writeV1Error(w, r, http.StatusNotImplemented, "not_configured",
+			"Next-action state is not configured", "")
+		return
+	}
+
+	var req nextActionFeedbackRequest
+	if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, maxNextActionBodyBytes)).Decode(&req); err != nil {
+		writeV1Error(w, r, http.StatusBadRequest, "invalid_body", "Malformed request body", "")
+		return
+	}
+	if req.Source == "" {
+		writeV1Error(w, r, http.StatusBadRequest, "invalid_body", "source is required", "")
+		return
+	}
+	// Only a CONFIGURED source may be addressed. Without this an arbitrary
+	// string would create user-state rows keyed on nothing — unbounded growth
+	// driven by request bodies, and a mute list full of ids that name no
+	// source and so can never be surfaced for un-muting.
+	if _, known := a.Cfg().NextActions[req.Source]; !known {
+		writeV1Error(w, r, http.StatusBadRequest, "unknown_source",
+			"Unknown next-action source", req.Source)
+		return
+	}
+
+	ctx := r.Context()
+	user := principal.From(ctx).User
+	key := userstate.Key{
+		User:     user,
+		Source:   req.Source,
+		EntityID: req.EntityID,
+		Variant:  req.Variant,
+	}
+
+	if err := a.applyNextActionFeedback(ctx, state, key, req); err != nil {
+		writeV1Error(w, r, http.StatusBadRequest, "invalid_feedback", err.Error(), "")
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// applyNextActionFeedback records one user response.
+func (a *App) applyNextActionFeedback(
+	ctx context.Context, state userstate.Store, key userstate.Key, req nextActionFeedbackRequest,
+) error {
+	now := time.Now()
+	switch req.Kind {
+	case "snooze":
+		d, err := dataentryconfig.ParseNextActionDuration(req.Duration)
+		if err != nil {
+			return fmt.Errorf("invalid snooze duration %q", req.Duration)
+		}
+		return state.SetSnooze(ctx, key, now.Add(d))
+
+	case "dismiss":
+		// Dismissal is a snooze with no end: suppressed until the suggestion
+		// KEY changes, which is what key_props are for. Modeled on the
+		// existing mechanism rather than a separate one, so there is a single
+		// suppression path to reason about.
+		return state.SetSnooze(ctx, key, now.Add(dismissHorizon))
+
+	case "mute":
+		return state.SetMuted(ctx, key.User, key.Source, true)
+
+	case "unmute":
+		return state.SetMuted(ctx, key.User, key.Source, false)
+
+	case "shown":
+		return state.MarkShown(ctx, key, now)
+
+	default:
+		return fmt.Errorf("unknown kind %q", req.Kind)
+	}
+}
+
+// nextActionEngine builds an engine for this request, or reports that the
+// feature is not configured.
+//
+// Constructed per call rather than held on App because the CandidateFunc
+// closes over nothing request-scoped — the ACL gate is read from the ctx
+// passed to Resolve — and an Engine is a thin value over config plus two
+// collaborators. If this ever becomes hot, cache the engine, never the
+// suggestions (see nextaction.Engine.Resolve on why results must not be
+// cached across principals).
+func (a *App) nextActionEngine() (*nextaction.Engine, bool) {
+	// Snapshot the config once: State() reads an atomic pointer, and two
+	// reads could observe different snapshots if a reload lands between them.
+	cfg := a.Cfg()
+	if cfg == nil || len(cfg.NextActions) == 0 || a.userState == nil {
+		return nil, false
+	}
+	eng, err := nextaction.New(cfg, a.userState, a.nextActionCandidates())
+	if err != nil {
+		return nil, false
+	}
+	return eng, true
+}

--- a/internal/dataentry/nextaction_handler.go
+++ b/internal/dataentry/nextaction_handler.go
@@ -38,11 +38,18 @@ type nextActionResponse struct {
 
 // nextActionWire is one suggestion as the SPA sees it.
 type nextActionWire struct {
-	Source   string                            `json:"source"`
-	Band     string                            `json:"band"`
-	EntityID string                            `json:"entity_id,omitempty"`
-	Message  string                            `json:"message"`
-	Actions  []dataentryconfig.NextActionOffer `json:"actions,omitempty"`
+	Source   string `json:"source"`
+	Band     string `json:"band"`
+	EntityID string `json:"entity_id,omitempty"`
+	// Variant carries the source's key_props values. The client MUST echo it
+	// back on feedback: it is part of the suggestion key, so a snooze stored
+	// without it lands under a different key than the one Resolve checks and
+	// silently fails to suppress anything.
+	//
+	// Opaque to the client — it exists to be returned verbatim, not parsed.
+	Variant string                            `json:"variant,omitempty"`
+	Message string                            `json:"message"`
+	Actions []dataentryconfig.NextActionOffer `json:"actions,omitempty"`
 }
 
 // nextActionFeedbackRequest is the body of POST /api/v1/_next_action.
@@ -102,6 +109,7 @@ func (a *App) handleV1NextActionGet(w http.ResponseWriter, r *http.Request) {
 		Source:   sug.Source,
 		Band:     sug.Band,
 		EntityID: sug.EntityID,
+		Variant:  sug.Key.Variant,
 		Message:  sug.Message,
 		Actions:  sug.Actions,
 	}})

--- a/internal/dataentry/nextaction_handler.go
+++ b/internal/dataentry/nextaction_handler.go
@@ -274,9 +274,10 @@ func (a *App) nextActionEngine() (*nextaction.Engine, bool) {
 	if cfg == nil || len(cfg.NextActions) == 0 || a.userState == nil {
 		return nil, false
 	}
-	eng, err := nextaction.New(cfg, a.userState, a.nextActionCandidates())
+	eng, err := nextaction.New(cfg, a.userState, a.nextActionCandidates(),
+		nextaction.WithOptions(a.nextActionOptions()))
 	if err != nil {
 		return nil, false
 	}
-	return eng.WithOptions(a.nextActionOptions()), true
+	return eng, true
 }

--- a/internal/dataentry/nextaction_handler_test.go
+++ b/internal/dataentry/nextaction_handler_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/Sourcehaven-BV/rela/internal/acl"
 	"github.com/Sourcehaven-BV/rela/internal/dataentryconfig"
 	"github.com/Sourcehaven-BV/rela/internal/entity"
 	"github.com/Sourcehaven-BV/rela/internal/userstate/memuserstate"
@@ -271,4 +272,72 @@ func TestNextAction_GetDoesNotStartCooldown(t *testing.T) {
 	second, _ := getNextAction(aliceCtx(), t, app)
 	require.NotNil(t, second.Suggestion, "a second GET without 'shown' must still suggest")
 	require.Equal(t, first.Suggestion.EntityID, second.Suggestion.EntityID)
+}
+
+// countSourceConfig builds a first-run source over `ticket`.
+func countSourceConfig(ungated bool) map[string]dataentryconfig.NextActionSource {
+	return map[string]dataentryconfig.NextActionSource{
+		"first-run": {
+			Band:         "blocking",
+			Count:        "ticket == 0",
+			CountUngated: ungated,
+			Suggest:      "Nothing here yet. Add a ticket?",
+		},
+	}
+}
+
+// TestNextAction_CountIsReadGatedByDefault is the disclosure guard.
+//
+// Tickets EXIST but bob may not read them. A gated count must therefore see
+// none and fire the first-run hint for bob — mildly wrong, visibly wrong, and
+// fixable in config. An UNGATED count would instead stay silent, and that
+// silence tells bob that tickets exist, which is precisely the fact rela's
+// read model treats as secret (a hidden entity is nonexistent).
+func TestNextAction_CountIsReadGatedByDefault(t *testing.T) {
+	app := newTestAppV1(t)
+	seedNextActionTickets(t, app, "TKT-001")
+
+	d := mustNewACL(t, &acl.Policy{
+		Roles:       map[string]acl.RoleDef{"viewer": {Read: []string{"ticket"}}},
+		Assignments: map[string]string{"alice": "viewer"},
+	}, app.store)
+	app.acl = d
+
+	withNextActions(t, app,
+		[]dataentryconfig.NextActionBand{{ID: "blocking"}},
+		countSourceConfig(false))
+
+	// alice can read tickets, and one exists → no first-run hint.
+	aliceGot, code := getNextAction(gateCtxFor(principalCtx("alice"), t, d), t, app)
+	require.Equal(t, http.StatusOK, code)
+	require.Nil(t, aliceGot.Suggestion, "alice sees a ticket, so first-run must stay quiet")
+
+	// bob may read nothing → the gated count sees zero and fires.
+	bobGot, code := getNextAction(gateCtxFor(principalCtx("bob"), t, d), t, app)
+	require.Equal(t, http.StatusOK, code)
+	require.NotNil(t, bobGot.Suggestion,
+		"a gated count must not disclose that tickets exist; it fires for a principal who sees none")
+}
+
+// The opt-out must be reachable, and must be the ONLY way to get the
+// whole-graph answer.
+func TestNextAction_CountUngatedIsOptIn(t *testing.T) {
+	app := newTestAppV1(t)
+	seedNextActionTickets(t, app, "TKT-001")
+
+	d := mustNewACL(t, &acl.Policy{
+		Roles:       map[string]acl.RoleDef{"viewer": {Read: []string{"ticket"}}},
+		Assignments: map[string]string{"alice": "viewer"},
+	}, app.store)
+	app.acl = d
+
+	withNextActions(t, app,
+		[]dataentryconfig.NextActionBand{{ID: "blocking"}},
+		countSourceConfig(true))
+
+	// With count_ungated, bob gets the whole-graph answer: a ticket exists,
+	// so the hint stays quiet even though bob cannot see it.
+	bobGot, code := getNextAction(gateCtxFor(principalCtx("bob"), t, d), t, app)
+	require.Equal(t, http.StatusOK, code)
+	require.Nil(t, bobGot.Suggestion, "count_ungated asks the whole-graph question")
 }

--- a/internal/dataentry/nextaction_handler_test.go
+++ b/internal/dataentry/nextaction_handler_test.go
@@ -3,6 +3,7 @@ package dataentry
 import (
 	"context"
 	"encoding/json"
+	"maps"
 	"net/http"
 	"net/http/httptest"
 	"sort"
@@ -14,6 +15,7 @@ import (
 	"github.com/Sourcehaven-BV/rela/internal/acl"
 	"github.com/Sourcehaven-BV/rela/internal/dataentryconfig"
 	"github.com/Sourcehaven-BV/rela/internal/entity"
+	"github.com/Sourcehaven-BV/rela/internal/metamodel"
 	"github.com/Sourcehaven-BV/rela/internal/userstate/memuserstate"
 )
 
@@ -499,4 +501,136 @@ func TestNextAction_EntityScopedDeferLeavesSiblings(t *testing.T) {
 	after, _ := getNextAction(aliceCtx(), t, app)
 	require.NotNil(t, after.Suggestion, "the source must still offer its other candidate")
 	require.NotEqual(t, first, after.Suggestion.EntityID)
+}
+
+// TestQueryPushdown_PreservesTypedSemantics is the guard for the pushdown
+// being a PRE-FILTER rather than a replacement.
+//
+// store.PropPredicate compares by string form; filter.MatchAll is
+// metamodel-aware. On an integer property `count=03` is a MATCH against the
+// value 3 when typed and a non-match as strings. If the pushed filter were
+// dropped from the Go pass, the store's answer would decide and the result
+// would change on a path /_search and scope navigation share.
+//
+// The test drives the real metamodel, so it fails if anyone "optimizes" the
+// double evaluation away.
+func TestQueryPushdown_PreservesTypedSemantics(t *testing.T) {
+	app := newTestAppV1(t)
+
+	// Give the fixture an integer property.
+	st := app.State()
+	meta := *st.Meta
+	entities := make(map[string]metamodel.EntityDef, len(meta.Entities))
+	maps.Copy(entities, meta.Entities)
+	ticket := entities["ticket"]
+	props := make(map[string]metamodel.PropertyDef, len(ticket.Properties)+1)
+	maps.Copy(props, ticket.Properties)
+	props["count"] = metamodel.PropertyDef{Type: metamodel.PropertyTypeInteger}
+	ticket.Properties = props
+	entities["ticket"] = ticket
+	meta.Entities = entities
+	app.schema.Publish(&Schema{
+		Cfg: st.Cfg, Meta: &meta, StyleMap: st.StyleMap,
+		StyledTypes: st.StyledTypes, OpenAPIGen: st.OpenAPIGen,
+	})
+
+	seedEntity(app, &entity.Entity{
+		ID: "TKT-001", Type: "ticket",
+		Properties: map[string]any{"title": "Three", "count": 3},
+	})
+
+	// Typed comparison accepts the zero-padded form; a string comparison does
+	// not. The Go pass must remain authoritative.
+	got, err := app.executeQuery(aliceCtx(), "type:ticket prop:count=03")
+	require.NoError(t, err)
+	require.Len(t, got, 1,
+		"an integer property must compare numerically, not by string form")
+	require.Equal(t, "TKT-001", got[0].ID)
+}
+
+// TestNextAction_RedactsHiddenPropertiesInMessage pins the field-level half of
+// the next-action surface.
+//
+// executeQuery returns row-gated but UNREDACTED entities; every other consumer
+// redacts at serialization (forWireRelated / stripHiddenProperties). A
+// suggestion never passes through that seam — its message interpolates
+// `{property}` straight into text — so the redaction has to happen at the
+// candidate boundary instead. Without it, `suggest: "{title} needs a look"` on
+// a type whose title is hidden by `visible:` puts the hidden value on the
+// wire: the BUG-R9EHKV leak class through a new door.
+//
+// The placeholder is left VERBATIM rather than emptied: per the root
+// CLAUDE.md, `visible:` conceals property values, not the existence of
+// property names.
+func TestNextAction_RedactsHiddenPropertiesInMessage(t *testing.T) {
+	app := newTestAppV1(t)
+	app.fieldResolver = fakeResolver{fv: FieldVerdicts{
+		Visible: map[string]bool{"title": false},
+	}}
+	seedEntity(app, &entity.Entity{
+		ID: "TKT-001", Type: "ticket",
+		Properties: map[string]any{"title": "SECRET-TITLE", "status": "open"},
+	})
+	d := mustNewACL(t, &acl.Policy{
+		Roles:       map[string]acl.RoleDef{"viewer": {Read: []string{"ticket"}}},
+		Assignments: map[string]string{"alice": "viewer"},
+	}, app.store)
+	app.acl = d
+
+	withNextActions(t, app,
+		[]dataentryconfig.NextActionBand{{ID: "stalled"}},
+		map[string]dataentryconfig.NextActionSource{
+			"tickets": {Band: "stalled", Query: "type:ticket", Suggest: "Look at {title}"},
+		})
+
+	got, _ := getNextAction(gateCtxFor(principalCtx("alice"), t, d), t, app)
+	require.NotNil(t, got.Suggestion)
+	require.NotContains(t, got.Suggestion.Message, "SECRET-TITLE",
+		"a visible:-hidden value must not reach the suggestion message")
+	require.Contains(t, got.Suggestion.Message, "{title}",
+		"the placeholder stays: names are not secret, values are")
+}
+
+// The same guard for pick_one option labels. safeDisplayTitle's check is
+// PRESENCE-based ("is the display property missing?"), so handed an
+// unredacted entity it finds every property present and returns the hidden
+// value — the redaction must happen before it, not instead of it.
+func TestNextAction_RedactsHiddenPropertiesInPickOptions(t *testing.T) {
+	app := newTestAppV1(t)
+	app.fieldResolver = fakeResolver{fv: FieldVerdicts{
+		Visible: map[string]bool{"title": false},
+	}}
+	seedEntity(app, &entity.Entity{
+		ID: "TKT-001", Type: "ticket",
+		Properties: map[string]any{"title": "SECRET-OPTION", "status": "open"},
+	})
+	d := mustNewACL(t, &acl.Policy{
+		Roles:       map[string]acl.RoleDef{"viewer": {Read: []string{"ticket"}}},
+		Assignments: map[string]string{"alice": "viewer"},
+	}, app.store)
+	app.acl = d
+
+	withNextActions(t, app,
+		[]dataentryconfig.NextActionBand{{ID: "stalled"}},
+		map[string]dataentryconfig.NextActionSource{
+			"tickets": {
+				Band:    "stalled",
+				Query:   "type:ticket",
+				Suggest: "pick one",
+				Actions: []dataentryconfig.NextActionOffer{{
+					PickOne: &dataentryconfig.NextActionPickOne{
+						Query: "type:ticket", Action: "noop",
+					},
+				}},
+			},
+		})
+
+	got, _ := getNextAction(gateCtxFor(principalCtx("alice"), t, d), t, app)
+	require.NotNil(t, got.Suggestion)
+	for _, opts := range got.Suggestion.PickOptions {
+		for _, o := range opts {
+			require.NotContains(t, o.Label, "SECRET-OPTION",
+				"an option label must fall back to the id when the display property is hidden")
+		}
+	}
 }

--- a/internal/dataentry/nextaction_handler_test.go
+++ b/internal/dataentry/nextaction_handler_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"sort"
 	"strings"
 	"testing"
 
@@ -377,4 +378,67 @@ func TestNextAction_VariantRoundTrips(t *testing.T) {
 	after, _ := getNextAction(aliceCtx(), t, app)
 	require.Nil(t, after.Suggestion,
 		"echoing the full key back must actually suppress the suggestion")
+}
+
+// TestQueryPushdown_MatchesGoSideFiltering is the parity guard for the
+// property-predicate pushdown (Phase 1).
+//
+// executeQuery now asks the store to evaluate equality filters instead of
+// loading a whole type and filtering in Go. That is only safe if both paths
+// agree, so this drives a real query end-to-end through the next-action
+// surface — a suggestion appearing for the wrong entity, or not at all, is
+// exactly what a silent pushdown divergence looks like.
+func TestQueryPushdown_MatchesGoSideFiltering(t *testing.T) {
+	app := newTestAppV1(t)
+	seedEntity(app, &entity.Entity{
+		ID: "TKT-open", Type: "ticket",
+		Properties: map[string]any{"title": "Open one", "status": "open"},
+	})
+	seedEntity(app, &entity.Entity{
+		ID: "TKT-done", Type: "ticket",
+		Properties: map[string]any{"title": "Done one", "status": "done"},
+	})
+	seedEntity(app, &entity.Entity{
+		ID: "TKT-blank", Type: "ticket",
+		Properties: map[string]any{"title": "No status"},
+	})
+
+	cases := []struct {
+		name  string
+		query string
+		want  []string
+	}{
+		{"equality pushes down", "type:ticket prop:status=open", []string{"TKT-open"}},
+		{
+			// An entity with no status must NOT satisfy an exclusion filter —
+			// the asymmetry propmatch pins, and the one most likely to differ
+			// between a SQL NOT and the Go rule.
+			name:  "exclusion does not sweep in the unset row",
+			query: "type:ticket prop:status!=open",
+			want:  []string{"TKT-done"},
+		},
+		{"is-empty matches absent", "type:ticket prop:status=", []string{"TKT-blank"}},
+		{
+			// Rides on OpEqual but must stay in Go: pushed down it would
+			// compare against the literal string "op*".
+			name:  "glob still matches by pattern",
+			query: "type:ticket prop:status=op*",
+			want:  []string{"TKT-open"},
+		},
+		{"no property filter returns the type", "type:ticket", []string{"TKT-blank", "TKT-done", "TKT-open"}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := app.executeQuery(aliceCtx(), tc.query)
+			require.NoError(t, err)
+
+			ids := make([]string, 0, len(got))
+			for _, e := range got {
+				ids = append(ids, e.ID)
+			}
+			sort.Strings(ids)
+			require.Equal(t, tc.want, ids)
+		})
+	}
 }

--- a/internal/dataentry/nextaction_handler_test.go
+++ b/internal/dataentry/nextaction_handler_test.go
@@ -341,3 +341,40 @@ func TestNextAction_CountUngatedIsOptIn(t *testing.T) {
 	require.Equal(t, http.StatusOK, code)
 	require.Nil(t, bobGot.Suggestion, "count_ungated asks the whole-graph question")
 }
+
+// TestNextAction_VariantRoundTrips is the regression guard for a bug found in
+// the browser: a source with key_props builds a suggestion key containing a
+// Variant, but the GET response omitted it, so a client echoing back only
+// (source, entity_id) stored its snooze under a DIFFERENT key. The POST
+// returned 204 and the suggestion kept reappearing — a silent no-op.
+//
+// The round trip is the contract: whatever identifies the suggestion on the
+// way out must be sufficient to suppress it on the way back in.
+func TestNextAction_VariantRoundTrips(t *testing.T) {
+	app := newTestAppV1(t)
+	seedNextActionTickets(t, app, "TKT-001")
+	withNextActions(t, app,
+		[]dataentryconfig.NextActionBand{{ID: "stalled"}},
+		map[string]dataentryconfig.NextActionSource{
+			"tickets": {
+				Band:     "stalled",
+				Query:    "type:ticket",
+				Suggest:  "{id}",
+				KeyProps: []string{"status"},
+			},
+		})
+
+	got, _ := getNextAction(aliceCtx(), t, app)
+	require.NotNil(t, got.Suggestion)
+	require.NotEmpty(t, got.Suggestion.Variant,
+		"a source with key_props must expose the variant, or feedback cannot address the suggestion")
+
+	// Echo back exactly what the GET provided.
+	body := `{"source":"tickets","entity_id":"` + got.Suggestion.EntityID +
+		`","variant":"` + got.Suggestion.Variant + `","kind":"snooze","duration":"7d"}`
+	require.Equal(t, http.StatusNoContent, postFeedback(aliceCtx(), t, app, body))
+
+	after, _ := getNextAction(aliceCtx(), t, app)
+	require.Nil(t, after.Suggestion,
+		"echoing the full key back must actually suppress the suggestion")
+}

--- a/internal/dataentry/nextaction_handler_test.go
+++ b/internal/dataentry/nextaction_handler_test.go
@@ -1,0 +1,274 @@
+package dataentry
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/Sourcehaven-BV/rela/internal/dataentryconfig"
+	"github.com/Sourcehaven-BV/rela/internal/entity"
+	"github.com/Sourcehaven-BV/rela/internal/userstate/memuserstate"
+)
+
+// withNextActions republishes the app's config with the given bands and
+// sources, and gives it a fresh in-memory user-state store. Mirrors
+// withListRenderOverride: copy the snapshot, mutate, publish.
+func withNextActions(
+	t *testing.T, app *App,
+	bands []dataentryconfig.NextActionBand,
+	sources map[string]dataentryconfig.NextActionSource,
+) {
+	t.Helper()
+	s := app.State()
+	cfg := *s.Cfg
+	cfg.NextActionBands = bands
+	cfg.NextActions = sources
+	app.schema.Publish(&Schema{
+		Cfg: &cfg, Meta: s.Meta, StyleMap: s.StyleMap,
+		StyledTypes: s.StyledTypes, OpenAPIGen: s.OpenAPIGen,
+	})
+
+	st := memuserstate.New()
+	t.Cleanup(func() { _ = st.Close() })
+	require.NoError(t, app.SetUserState(st))
+}
+
+// seedTickets puts entities in the store: newTestAppV1 starts empty, so a
+// query source has nothing to find until this runs.
+func seedNextActionTickets(t *testing.T, app *App, ids ...string) {
+	t.Helper()
+	for _, id := range ids {
+		seedEntity(app, &entity.Entity{
+			ID: id, Type: "ticket",
+			Properties: map[string]any{"title": "Ticket " + id, "status": "open"},
+		})
+	}
+}
+
+func getNextAction(ctx context.Context, t *testing.T, app *App) (resp nextActionResponse, status int) {
+	t.Helper()
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/_next_action", http.NoBody).WithContext(ctx)
+	app.handleV1NextAction(rec, req)
+
+	if rec.Code == http.StatusOK {
+		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	}
+	return resp, rec.Code
+}
+
+func postFeedback(ctx context.Context, t *testing.T, app *App, body string) int {
+	t.Helper()
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/_next_action",
+		strings.NewReader(body)).WithContext(ctx)
+	app.handleV1NextAction(rec, req)
+	return rec.Code
+}
+
+// A deployment with no next_actions must answer cleanly rather than 404 —
+// the feature is opt-in and silence is its normal state.
+func TestNextAction_UnconfiguredIsEmptyNot404(t *testing.T) {
+	app := newTestAppV1(t)
+	got, code := getNextAction(aliceCtx(), t, app)
+	require.Equal(t, http.StatusOK, code)
+	require.Nil(t, got.Suggestion)
+}
+
+func TestNextAction_CountSourceFiresOnEmptyType(t *testing.T) {
+	app := newTestAppV1(t)
+	withNextActions(t, app,
+		[]dataentryconfig.NextActionBand{{ID: "blocking"}},
+		map[string]dataentryconfig.NextActionSource{
+			"first-run": {
+				Band:    "blocking",
+				Count:   "nonexistent_type == 0",
+				Suggest: "Nothing here yet.",
+			},
+		})
+
+	got, code := getNextAction(aliceCtx(), t, app)
+	require.Equal(t, http.StatusOK, code)
+	require.NotNil(t, got.Suggestion)
+	require.Equal(t, "first-run", got.Suggestion.Source)
+	require.Empty(t, got.Suggestion.EntityID, "a count source names no entity")
+}
+
+// The type exists and has rows, so the first-run hint must stay quiet.
+func TestNextAction_CountSourceSilentWhenTypePopulated(t *testing.T) {
+	app := newTestAppV1(t)
+	seedNextActionTickets(t, app, "TKT-001")
+	withNextActions(t, app,
+		[]dataentryconfig.NextActionBand{{ID: "blocking"}},
+		map[string]dataentryconfig.NextActionSource{
+			"first-run": {Band: "blocking", Count: "ticket == 0", Suggest: "Start somewhere"},
+		})
+
+	got, code := getNextAction(aliceCtx(), t, app)
+	require.Equal(t, http.StatusOK, code)
+	require.Nil(t, got.Suggestion)
+}
+
+func TestNextAction_QuerySourceInterpolates(t *testing.T) {
+	app := newTestAppV1(t)
+	seedNextActionTickets(t, app, "TKT-001")
+	withNextActions(t, app,
+		[]dataentryconfig.NextActionBand{{ID: "stalled"}},
+		map[string]dataentryconfig.NextActionSource{
+			"tickets": {Band: "stalled", Query: "type:ticket", Suggest: "{id} needs a look"},
+		})
+
+	got, code := getNextAction(aliceCtx(), t, app)
+	require.Equal(t, http.StatusOK, code)
+	require.NotNil(t, got.Suggestion)
+	require.NotEmpty(t, got.Suggestion.EntityID)
+	require.Contains(t, got.Suggestion.Message, got.Suggestion.EntityID,
+		"the message should interpolate the candidate's id")
+}
+
+// Snoozing must actually suppress on the next GET — the whole point of the
+// feedback endpoint.
+func TestNextAction_SnoozeThenSuppressed(t *testing.T) {
+	app := newTestAppV1(t)
+	seedNextActionTickets(t, app, "TKT-001")
+	withNextActions(t, app,
+		[]dataentryconfig.NextActionBand{{ID: "stalled"}},
+		map[string]dataentryconfig.NextActionSource{
+			"tickets": {Band: "stalled", Query: "type:ticket", Suggest: "{id}"},
+		})
+
+	got, _ := getNextAction(aliceCtx(), t, app)
+	require.NotNil(t, got.Suggestion)
+	id := got.Suggestion.EntityID
+
+	body := `{"source":"tickets","entity_id":"` + id + `","kind":"snooze","duration":"7d"}`
+	require.Equal(t, http.StatusNoContent, postFeedback(aliceCtx(), t, app, body))
+
+	after, _ := getNextAction(aliceCtx(), t, app)
+	if after.Suggestion != nil {
+		require.NotEqual(t, id, after.Suggestion.EntityID,
+			"the snoozed entity must not be suggested again")
+	}
+}
+
+func TestNextAction_MuteSilencesSource(t *testing.T) {
+	app := newTestAppV1(t)
+	seedNextActionTickets(t, app, "TKT-001")
+	withNextActions(t, app,
+		[]dataentryconfig.NextActionBand{{ID: "stalled"}},
+		map[string]dataentryconfig.NextActionSource{
+			"tickets": {Band: "stalled", Query: "type:ticket", Suggest: "{id}"},
+		})
+
+	got, _ := getNextAction(aliceCtx(), t, app)
+	require.NotNil(t, got.Suggestion)
+
+	require.Equal(t, http.StatusNoContent,
+		postFeedback(aliceCtx(), t, app, `{"source":"tickets","kind":"mute"}`))
+
+	after, _ := getNextAction(aliceCtx(), t, app)
+	require.Nil(t, after.Suggestion, "a muted source must produce nothing")
+
+	// And unmuting brings it back — reversibility is why per-source mute was
+	// chosen over per-entity.
+	require.Equal(t, http.StatusNoContent,
+		postFeedback(aliceCtx(), t, app, `{"source":"tickets","kind":"unmute"}`))
+	back, _ := getNextAction(aliceCtx(), t, app)
+	require.NotNil(t, back.Suggestion, "unmute must restore the source")
+}
+
+// Per-user isolation: bob must not inherit alice's mute.
+func TestNextAction_StateIsPerUser(t *testing.T) {
+	app := newTestAppV1(t)
+	seedNextActionTickets(t, app, "TKT-001")
+	withNextActions(t, app,
+		[]dataentryconfig.NextActionBand{{ID: "stalled"}},
+		map[string]dataentryconfig.NextActionSource{
+			"tickets": {Band: "stalled", Query: "type:ticket", Suggest: "{id}"},
+		})
+
+	require.Equal(t, http.StatusNoContent,
+		postFeedback(principalCtx("alice"), t, app, `{"source":"tickets","kind":"mute"}`))
+
+	aliceGot, _ := getNextAction(principalCtx("alice"), t, app)
+	require.Nil(t, aliceGot.Suggestion)
+
+	bobGot, _ := getNextAction(principalCtx("bob"), t, app)
+	require.NotNil(t, bobGot.Suggestion, "bob must not inherit alice's mute")
+}
+
+// An unconfigured source id must be rejected: accepting one would let a
+// request body create user-state rows keyed on nothing, and populate a mute
+// list with ids that name no source and so can never be un-muted.
+func TestNextAction_RejectsUnknownSource(t *testing.T) {
+	app := newTestAppV1(t)
+	withNextActions(t, app,
+		[]dataentryconfig.NextActionBand{{ID: "stalled"}},
+		map[string]dataentryconfig.NextActionSource{
+			"tickets": {Band: "stalled", Query: "type:ticket", Suggest: "{id}"},
+		})
+
+	code := postFeedback(aliceCtx(), t, app, `{"source":"made-up","kind":"mute"}`)
+	require.Equal(t, http.StatusBadRequest, code)
+}
+
+func TestNextAction_FeedbackValidation(t *testing.T) {
+	app := newTestAppV1(t)
+	withNextActions(t, app,
+		[]dataentryconfig.NextActionBand{{ID: "stalled"}},
+		map[string]dataentryconfig.NextActionSource{
+			"tickets": {Band: "stalled", Query: "type:ticket", Suggest: "{id}"},
+		})
+
+	tests := []struct {
+		name string
+		body string
+		want int
+	}{
+		{"malformed json", `{not json`, http.StatusBadRequest},
+		{"missing source", `{"kind":"mute"}`, http.StatusBadRequest},
+		{"unknown kind", `{"source":"tickets","kind":"explode"}`, http.StatusBadRequest},
+		{"bad snooze duration", `{"source":"tickets","kind":"snooze","duration":"soon"}`, http.StatusBadRequest},
+		{"valid mute", `{"source":"tickets","kind":"mute"}`, http.StatusNoContent},
+		{"valid shown", `{"source":"tickets","kind":"shown"}`, http.StatusNoContent},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, postFeedback(aliceCtx(), t, app, tc.body))
+		})
+	}
+}
+
+func TestNextAction_MethodNotAllowed(t *testing.T) {
+	app := newTestAppV1(t)
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/_next_action", http.NoBody).
+		WithContext(aliceCtx())
+	app.handleV1NextAction(rec, req)
+	require.Equal(t, http.StatusMethodNotAllowed, rec.Code)
+}
+
+// Resolving must not start the cooldown clock: only an explicit "shown"
+// does. Otherwise a preview or a discarded response would silently consume
+// the suggestion.
+func TestNextAction_GetDoesNotStartCooldown(t *testing.T) {
+	app := newTestAppV1(t)
+	seedNextActionTickets(t, app, "TKT-001")
+	withNextActions(t, app,
+		[]dataentryconfig.NextActionBand{{ID: "stalled"}},
+		map[string]dataentryconfig.NextActionSource{
+			"tickets": {Band: "stalled", Query: "type:ticket", Suggest: "{id}", Cooldown: "7d"},
+		})
+
+	first, _ := getNextAction(aliceCtx(), t, app)
+	require.NotNil(t, first.Suggestion)
+
+	second, _ := getNextAction(aliceCtx(), t, app)
+	require.NotNil(t, second.Suggestion, "a second GET without 'shown' must still suggest")
+	require.Equal(t, first.Suggestion.EntityID, second.Suggestion.EntityID)
+}

--- a/internal/dataentry/nextaction_handler_test.go
+++ b/internal/dataentry/nextaction_handler_test.go
@@ -442,3 +442,61 @@ func TestQueryPushdown_MatchesGoSideFiltering(t *testing.T) {
 		})
 	}
 }
+
+// TestNextAction_SourceScopedDeferIgnoresTheEchoedEntity pins that the SERVER
+// owns the key shape.
+//
+// A client echoes back whatever the GET advertised, including entity_id — it
+// needs that id to render a link. For a source-scoped source the key omits the
+// entity, so trusting the echo verbatim stores the deferral under a key the
+// engine never checks: a 204 that silently does nothing. That is exactly how
+// this was found, walking the scenarios against a live server.
+func TestNextAction_SourceScopedDeferIgnoresTheEchoedEntity(t *testing.T) {
+	app := newTestAppV1(t)
+	seedNextActionTickets(t, app, "TKT-001", "TKT-002")
+	withNextActions(t, app,
+		[]dataentryconfig.NextActionBand{{ID: "stalled"}},
+		map[string]dataentryconfig.NextActionSource{
+			"tickets": {
+				Band:       "stalled",
+				Query:      "type:ticket",
+				Suggest:    "{id}",
+				DeferScope: dataentryconfig.DeferScopeSource,
+			},
+		})
+
+	got, _ := getNextAction(aliceCtx(), t, app)
+	require.NotNil(t, got.Suggestion)
+	require.NotEmpty(t, got.Suggestion.EntityID, "the client still needs an id to link to")
+
+	// Echo it back exactly as a client does.
+	body := `{"source":"tickets","entity_id":"` + got.Suggestion.EntityID +
+		`","kind":"snooze","duration":"7d"}`
+	require.Equal(t, http.StatusNoContent, postFeedback(aliceCtx(), t, app, body))
+
+	after, _ := getNextAction(aliceCtx(), t, app)
+	require.Nil(t, after.Suggestion,
+		"a source-scoped snooze must silence the source, not hand back its other candidate")
+}
+
+// The default stays per-entity: declining one item must not silence the rest.
+func TestNextAction_EntityScopedDeferLeavesSiblings(t *testing.T) {
+	app := newTestAppV1(t)
+	seedNextActionTickets(t, app, "TKT-001", "TKT-002")
+	withNextActions(t, app,
+		[]dataentryconfig.NextActionBand{{ID: "stalled"}},
+		map[string]dataentryconfig.NextActionSource{
+			"tickets": {Band: "stalled", Query: "type:ticket", Suggest: "{id}"},
+		})
+
+	got, _ := getNextAction(aliceCtx(), t, app)
+	require.NotNil(t, got.Suggestion)
+	first := got.Suggestion.EntityID
+
+	body := `{"source":"tickets","entity_id":"` + first + `","kind":"snooze","duration":"7d"}`
+	require.Equal(t, http.StatusNoContent, postFeedback(aliceCtx(), t, app, body))
+
+	after, _ := getNextAction(aliceCtx(), t, app)
+	require.NotNil(t, after.Suggestion, "the source must still offer its other candidate")
+	require.NotEqual(t, first, after.Suggestion.EntityID)
+}

--- a/internal/dataentry/router_walk_test.go
+++ b/internal/dataentry/router_walk_test.go
@@ -64,6 +64,7 @@ func TestRouterWalk_AllAPIRoutesReachHandlers(t *testing.T) {
 		{http.MethodGet, "/api/v1/_search?q=ticket", 0},
 		{http.MethodGet, "/api/v1/_position?type=ticket&id=TKT-001", 0},
 		{http.MethodGet, "/api/v1/_analyze", 0},
+		{http.MethodGet, "/api/v1/_next_action", http.StatusOK}, // no sources configured → empty suggestion
 		{http.MethodGet, "/api/v1/_git/status", 0},
 		{http.MethodPost, "/api/v1/_git/sync", 0},
 		{http.MethodGet, "/api/v1/_settings", 0},

--- a/internal/dataentryconfig/config.go
+++ b/internal/dataentryconfig/config.go
@@ -82,6 +82,14 @@ type Config struct {
 	Commands    map[string]CommandConfig     `yaml:"commands,omitempty"`
 	Actions     map[string]Action            `yaml:"actions,omitempty"`
 	Navigation  []NavigationEntry            `yaml:"navigation"`
+
+	// NextActionBands is the operator's ordered priority vocabulary; list
+	// order IS priority order, highest first. See nextaction.go.
+	NextActionBands []NextActionBand `yaml:"next_action_bands,omitempty" json:"next_action_bands,omitempty"`
+	// NextActions are the suggestion sources, keyed by source id. The id is
+	// half the suggestion key and the unit of muting, so it is stable
+	// operator-facing vocabulary, not an implementation detail.
+	NextActions map[string]NextActionSource `yaml:"next_actions,omitempty" json:"next_actions,omitempty"`
 }
 
 // EntityViewConfig declares UX bindings for a metamodel entity type.

--- a/internal/dataentryconfig/nextaction.go
+++ b/internal/dataentryconfig/nextaction.go
@@ -83,9 +83,32 @@ type NextActionSource struct {
 	// yet, start with a client?"), which no entity-shaped source can express
 	// because an empty graph has no entities to suggest about.
 	//
+	// The count is evaluated through the caller's READ GATE by default, so
+	// it counts what this principal can see. See CountUngated for the
+	// opt-out and why it is not the default.
+	//
 	// A suggestion from a Count source has no entity id, so its key
 	// degenerates to the source id alone.
 	Count string `yaml:"count,omitempty" json:"count,omitempty"`
+
+	// CountUngated evaluates Count against the WHOLE graph rather than the
+	// caller's visible subset. Only meaningful with Count.
+	//
+	// Default (false) is gated, and that is deliberate. A gated count asks
+	// "do I have any clients?"; an ungated one asks "does anyone?". The
+	// ungated form leaks a real fact — that entities of this type exist —
+	// to a principal who may read none of them, and rela's read model treats
+	// entity existence as the strongest secret it keeps.
+	//
+	// The failure mode of the safe default is mild and self-correcting: a
+	// principal who can see no clients keeps being offered "add a client",
+	// which an operator notices and fixes in config. The failure mode of the
+	// unsafe default is silent and permanent — a disclosure nobody observes.
+	// Prefer the loud, fixable error.
+	//
+	// Set this only when the count is genuinely operator-level ("has this
+	// deployment been set up at all?") rather than about the caller's data.
+	CountUngated bool `yaml:"count_ungated,omitempty" json:"count_ungated,omitempty"`
 
 	// Pick chooses among multiple candidates. Empty means the engine's
 	// default (stable-random). See NextActionPick.

--- a/internal/dataentryconfig/nextaction.go
+++ b/internal/dataentryconfig/nextaction.go
@@ -1,0 +1,231 @@
+package dataentryconfig
+
+// Next-action config: operator-declared rules that derive ONE suggested
+// follow-up from graph state and surface it as an advisory hint.
+//
+// The framing constrains the whole shape and is worth stating where the
+// types live, because several fields only make sense under it:
+//
+//   - Advisory, not a task queue. A hint, not a demand.
+//   - Things a user COULD do, not SHOULD do — which is what separates this
+//     from validation output, which has an opinion about correctness.
+//   - ONE suggestion at a time. Not a todo list; the aim is a companion that
+//     does not overload.
+//   - Good, not optimal. Surfacing one of several good next actions is the
+//     goal; avoiding a bad one is the bar.
+//
+// That last pair is why there is no per-source `limit:` and no numeric
+// priority. Because only one suggestion is ever shown, a bounded candidate
+// set is not lossy — sixty stalled tasks and six produce identical output —
+// so the bound belongs to the engine, which knows the page budget, rather
+// than to an operator writing a number whose right value depends on every
+// other source.
+//
+// See RES-09YLLL for the full design and the decisions behind it.
+
+// NextActionBand is one priority tier. Bands are declared by the OPERATOR as
+// an ordered list; list order IS priority order, highest first.
+//
+// Bands rather than numbers because per-source numeric priorities do not
+// compose: source A returns 90 because it feels important, source B returns 7
+// on a different scale, and the comparison is meaningless — arbitrary
+// ordering wearing the costume of ranking. For an advisory system
+// explicability beats optimality, since an unexplainable suggestion reads as
+// broken even when it is right.
+//
+// Not hardcoded: an ISMS deployment, a docs mirror and a consultancy want
+// different vocabularies, and baking one set into the engine would force
+// every operator to translate their domain into ours — the same violation
+// metamodel.yaml exists to prevent.
+type NextActionBand struct {
+	// ID is referenced by NextActionSource.Band. Validation rejects a
+	// source naming a band that was never declared.
+	ID string `yaml:"id" json:"id"`
+	// Label is an optional human-readable name for operator-facing UI
+	// (a settings screen listing what can be muted). Empty falls back to ID.
+	Label string `yaml:"label,omitempty" json:"label,omitempty"`
+}
+
+// NextActionSource is one rule producing at most one suggestion per entity.
+//
+// Sources are pluggable and INDEPENDENT — none knows the others exist. That
+// independence is the unit of iteration: adding a rule is adding a source,
+// and a bad source can be deleted without perturbing the rest. It is also
+// why a union-all query across sources was rejected: it would couple them at
+// the SQL layer, so one malformed source breaks the statement serving all.
+//
+// Two kinds, discriminated by the presence of Context — mirroring how
+// DocumentConfig discriminates standalone from entity-anchored on EntityType:
+//
+//   - Global (Context empty): candidates come from Query; renders on the
+//     dashboard; answers "what is the one thing?"
+//   - Context-aware (Context set): the candidate IS the entity being viewed;
+//     renders on that entity's detail page; answers "what next for this?"
+//
+// Empty Context is a first-class kind, not a missing required field.
+type NextActionSource struct {
+	// Band names a NextActionBand.ID. Required.
+	Band string `yaml:"band" json:"band"`
+
+	// Context, when set, makes this a context-aware source scoped to that
+	// entity type. Empty means global. Mutually exclusive with Query.
+	Context string `yaml:"context,omitempty" json:"context,omitempty"`
+
+	// Query selects candidates for a global source, in the existing filter
+	// syntax (e.g. "type:task prop:status=doing"). Required for a global
+	// source unless Count is set; rejected on a context-aware one, whose
+	// candidate is the viewed entity.
+	Query string `yaml:"query,omitempty" json:"query,omitempty"`
+
+	// Count makes this an entity-LESS source: it fires on a whole-graph
+	// aggregate rather than about any particular entity. The only supported
+	// form today is "<entity_type> == 0" — the first-run case ("nothing here
+	// yet, start with a client?"), which no entity-shaped source can express
+	// because an empty graph has no entities to suggest about.
+	//
+	// A suggestion from a Count source has no entity id, so its key
+	// degenerates to the source id alone.
+	Count string `yaml:"count,omitempty" json:"count,omitempty"`
+
+	// Pick chooses among multiple candidates. Empty means the engine's
+	// default (stable-random). See NextActionPick.
+	Pick NextActionPick `yaml:"pick,omitempty" json:"pick,omitempty"`
+
+	// Suggest is the message template. Supports {property} interpolation
+	// against the candidate entity, e.g. "{title} has been in progress since
+	// {started_on}. Still on it?". Required.
+	Suggest string `yaml:"suggest" json:"suggest"`
+
+	// Actions are the affordances offered alongside the suggestion, ordered
+	// by what they cost the user.
+	//
+	// dismiss/snooze are not decoration: without a way to say "not now", the
+	// only way to clear a suggestion is to comply, which makes it a demand
+	// rather than a hint. They are also the best signal available — a source
+	// dismissed every time is a source to delete.
+	Actions []NextActionOffer `yaml:"actions,omitempty" json:"actions,omitempty"`
+
+	// Cooldown suppresses a suggestion for this long after it was last
+	// SHOWN, as a duration string ("3d", "12h"). Empty takes the engine
+	// default, which is deliberately conservative: an operator who omits it
+	// probably has not thought about nag frequency, so the default assumes
+	// they got it wrong rather than assuming zero.
+	Cooldown string `yaml:"cooldown,omitempty" json:"cooldown,omitempty"`
+
+	// KeyProps optionally extends the suggestion key with the values of
+	// these properties, so a condition that RESETS is recognized as new.
+	//
+	// The key is (source_id, entity_id, optional key-prop values). Without
+	// the property component a proposal going draft -> sent -> draft keeps
+	// one key, so an old snooze suppresses a genuinely new stall. With
+	// KeyProps: [status] the key changes and the snooze no longer matches.
+	KeyProps []string `yaml:"key_props,omitempty" json:"key_props,omitempty"`
+}
+
+// NextActionPick selects among multiple candidates in the winning band.
+type NextActionPick string
+
+const (
+	// PickStableRandom picks pseudo-randomly, seeded per user per day so a
+	// refresh cannot re-roll it. The DEFAULT, and deliberately not a ranking.
+	//
+	// Dwell-time ordering ("oldest stuck thing first") was considered and
+	// rejected. A band holding many simultaneous candidates is a
+	// CONFIGURATION bug — a rule too broad — and no tiebreak fixes that, it
+	// only hides it; random is honest about it. Random is also total (dwell
+	// is undefined for content and for count-based sources), needs no stored
+	// onset, and resists starvation: dwell ordering lets the oldest item
+	// block its band indefinitely if the user is never going to act on it.
+	PickStableRandom NextActionPick = "stable-random"
+
+	// PickFirst takes the first candidate in query order. Useful when the
+	// query itself already encodes the intended ordering.
+	PickFirst NextActionPick = "first"
+
+	// PickLeastRecentlyShown rotates through candidates. Costs a per-render
+	// write to user state, so it is opt-in rather than the default.
+	PickLeastRecentlyShown NextActionPick = "least-recently-shown"
+)
+
+// NextActionOffer is one affordance on a suggestion: a discriminated union
+// keyed by exactly which field is set. Validation rejects zero or multiple.
+//
+// Multi-step wizards are deliberately NOT here. A big form is a destination a
+// button points at, not part of this vocabulary — Navigate reaches
+// Form.Steps. Keeping the set small is what lets this whole layer need
+// nothing from interactive flows over HTTP.
+type NextActionOffer struct {
+	// Label overrides the default button text.
+	Label string `yaml:"label,omitempty" json:"label,omitempty"`
+
+	// Action names an entry in the top-level Actions map — act in place.
+	Action string `yaml:"action,omitempty" json:"action,omitempty"`
+
+	// Set applies property mutations inline — the shorthand for a one-off
+	// that does not warrant a named action.
+	Set map[string]string `yaml:"set,omitempty" json:"set,omitempty"`
+
+	// Confirm requires a confirmation step. Only meaningful with Action or
+	// Set.
+	Confirm bool `yaml:"confirm,omitempty" json:"confirm,omitempty"`
+
+	// Navigate is a URL to hand off to, with {id} interpolated.
+	Navigate string `yaml:"navigate,omitempty" json:"navigate,omitempty"`
+
+	// Snooze offers "not now" for these durations (e.g. ["1d", "7d"]).
+	Snooze []string `yaml:"snooze,omitempty" json:"snooze,omitempty"`
+
+	// Dismiss offers "not this one" — suppressed until the suggestion key
+	// changes.
+	Dismiss bool `yaml:"dismiss,omitempty" json:"dismiss,omitempty"`
+
+	// Acknowledge offers "seen it" — the content-source affordance, which
+	// records the view without implying the user did anything.
+	Acknowledge bool `yaml:"acknowledge,omitempty" json:"acknowledge,omitempty"`
+}
+
+// Kind returns which member of the union is set, or "" when none is.
+// Used by validation and by the wire layer to avoid re-deriving it.
+func (o NextActionOffer) Kind() string {
+	switch {
+	case o.Action != "":
+		return "action"
+	case len(o.Set) > 0:
+		return "set"
+	case o.Navigate != "":
+		return "navigate"
+	case len(o.Snooze) > 0:
+		return "snooze"
+	case o.Dismiss:
+		return "dismiss"
+	case o.Acknowledge:
+		return "acknowledge"
+	default:
+		return ""
+	}
+}
+
+// setKinds returns every union member set on this offer, so validation can
+// report an ambiguous entry precisely rather than just "invalid".
+func (o NextActionOffer) setKinds() []string {
+	var kinds []string
+	if o.Action != "" {
+		kinds = append(kinds, "action")
+	}
+	if len(o.Set) > 0 {
+		kinds = append(kinds, "set")
+	}
+	if o.Navigate != "" {
+		kinds = append(kinds, "navigate")
+	}
+	if len(o.Snooze) > 0 {
+		kinds = append(kinds, "snooze")
+	}
+	if o.Dismiss {
+		kinds = append(kinds, "dismiss")
+	}
+	if o.Acknowledge {
+		kinds = append(kinds, "acknowledge")
+	}
+	return kinds
+}

--- a/internal/dataentryconfig/nextaction.go
+++ b/internal/dataentryconfig/nextaction.go
@@ -264,6 +264,58 @@ type NextActionOffer struct {
 	// Acknowledge offers "seen it" — the content-source affordance, which
 	// records the view without implying the user did anything.
 	Acknowledge bool `yaml:"acknowledge,omitempty" json:"acknowledge,omitempty"`
+
+	// PickOne offers a SHORT LIST of entities to act on, resolved by a query
+	// at render time.
+	//
+	// The one affordance that cannot be a static button list: its options are
+	// whatever the graph holds right now ("you have 40 minutes — here are
+	// three small tasks"). Everything else in this union is fixed when the
+	// operator writes the config.
+	PickOne *NextActionPickOne `yaml:"pick_one,omitempty" json:"pick_one,omitempty"`
+}
+
+// NextActionPickOne resolves a small set of entities to choose between.
+//
+// Bounded on purpose: this is a suggestion's affordance row, not a list view.
+// [DefaultPickOneLimit] applies when Limit is unset, and the engine caps it —
+// an operator asking for fifty options has misunderstood the surface, and
+// rendering fifty buttons would make the one-suggestion promise a lie.
+type NextActionPickOne struct {
+	// Query selects the options, in the same search syntax as a source's
+	// Query (e.g. "type:task prop:effort=xs prop:status=todo").
+	Query string `yaml:"query" json:"query"`
+
+	// Limit caps how many options are offered. Zero means
+	// [DefaultPickOneLimit].
+	Limit int `yaml:"limit,omitempty" json:"limit,omitempty"`
+
+	// Action names the entry in the top-level `actions:` map to run against
+	// whichever option the user picks. Required: an option list with nothing
+	// to do on selection is a list, not an affordance.
+	Action string `yaml:"action" json:"action"`
+}
+
+// DefaultPickOneLimit bounds a pick_one option list when the operator sets no
+// Limit. Three is a glance, not a menu.
+const DefaultPickOneLimit = 3
+
+// MaxPickOneLimit is the hard ceiling the engine enforces regardless of
+// configuration, for the same reason the candidate cap is engine-owned: the
+// operator cannot know the page budget, and a suggestion offering a dozen
+// choices has stopped being one suggestion.
+const MaxPickOneLimit = 5
+
+// ResolvedLimit returns the effective option count.
+func (p NextActionPickOne) ResolvedLimit() int {
+	switch {
+	case p.Limit <= 0:
+		return DefaultPickOneLimit
+	case p.Limit > MaxPickOneLimit:
+		return MaxPickOneLimit
+	default:
+		return p.Limit
+	}
 }
 
 // Kind returns which member of the union is set, or "" when none is.
@@ -282,6 +334,8 @@ func (o NextActionOffer) Kind() string {
 		return "dismiss"
 	case o.Acknowledge:
 		return "acknowledge"
+	case o.PickOne != nil:
+		return "pick_one"
 	default:
 		return ""
 	}
@@ -308,6 +362,9 @@ func (o NextActionOffer) setKinds() []string {
 	}
 	if o.Acknowledge {
 		kinds = append(kinds, "acknowledge")
+	}
+	if o.PickOne != nil {
+		kinds = append(kinds, "pick_one")
 	}
 	return kinds
 }

--- a/internal/dataentryconfig/nextaction.go
+++ b/internal/dataentryconfig/nextaction.go
@@ -44,12 +44,12 @@ type NextActionBand struct {
 	// Label is an optional human-readable name for operator-facing UI
 	// (a settings screen listing what can be muted). Empty falls back to ID.
 	Label string `yaml:"label,omitempty" json:"label,omitempty"`
-	// Prominence is how loudly this band interrupts. Empty means
-	// [ProminenceCard]. See [NextActionProminence].
+	// Prominence is how much this band interrupts. Empty means
+	// [ProminenceStatusBar]. See [NextActionProminence].
 	Prominence NextActionProminence `yaml:"prominence,omitempty" json:"prominence,omitempty"`
 }
 
-// NextActionProminence is how visually invasive a band's suggestion is.
+// NextActionProminence is how much a band's suggestion interrupts.
 //
 // A small CLOSED vocabulary rather than styling knobs, for the same reason
 // bands beat numeric priorities: the operator declares how loud a tier should
@@ -58,41 +58,49 @@ type NextActionBand struct {
 // and drift from the host UI — and would put the "is this urgent?" judgement
 // in a stylesheet rather than in the band list where it is reviewable.
 //
-// The levels are ordered by how much they interrupt, so a config reads as a
-// volume scale:
+// The levels differ in WHAT THE USER MUST DO TO CLEAR IT, not in decoration —
+// which is why there is no "card" tier: a bounded box and a banner both sit in
+// your way and are cleared by the same shrug, so shipping both would be two
+// spellings of one interruption model.
 //
-//	banner  — full-width, accented, at the top. For a band where someone else
-//	          is blocked; it should be hard to scroll past.
-//	card    — the default. A bounded box among the page's other content.
-//	inline  — one line, no chrome. Present but not competing.
-//	whisper — muted and small. For content and ambient sources, where being
-//	          noticed at all is optional.
+//	banner    — you must deal with it: act, snooze or mute. Sits above the
+//	            page and does not scroll away. For onboarding ("nothing here
+//	            yet") and for genuinely urgent things where someone else is
+//	            blocked. Insistent, but never blocks the user's actual work.
+//	notice    — the same place, much quieter: no accent, muted text, easy to
+//	            read past. For things worth saying once a visit that carry no
+//	            urgency.
+//	statusbar — you must go looking. A chip in the status bar, expanding on
+//	            click. For ongoing minor stuff that is true most of the time
+//	            and urgent none of it.
 //
-// Deliberately no "modal" or "toast": both take the interaction away from the
-// user, and an advisory hint that demands dismissal before you can proceed is
-// no longer advisory.
+// Deliberately no "modal" or "toast". A modal takes the interaction away from
+// the user, and an advisory hint that blocks progress until dismissed is no
+// longer advisory. A toast vanishes on a timer, so the impression that starts
+// a cooldown would fire for something the user may never have read.
 type NextActionProminence string
 
 const (
-	// ProminenceBanner is full-width and accented — hard to scroll past.
+	// ProminenceBanner is the insistent tier: above the page, accented, and
+	// answered rather than ignored.
 	ProminenceBanner NextActionProminence = "banner"
-	// ProminenceCard is a bounded box. The DEFAULT for an unset band.
-	ProminenceCard NextActionProminence = "card"
-	// ProminenceInline is a single line with no surrounding chrome.
-	ProminenceInline NextActionProminence = "inline"
-	// ProminenceWhisper is muted and small, for ambient content.
-	ProminenceWhisper NextActionProminence = "whisper"
+	// ProminenceNotice is banner's quiet sibling — same position, no accent,
+	// muted. Easy to read past on purpose.
+	ProminenceNotice NextActionProminence = "notice"
+	// ProminenceStatusBar is a chip in the status bar that expands on click.
+	// The DEFAULT for an unset band.
+	ProminenceStatusBar NextActionProminence = "statusbar"
 )
 
 // Resolved returns the effective prominence, applying the default.
 //
-// Defaulting to card rather than the quietest level is deliberate: an operator
-// who has not thought about prominence has usually written a real suggestion,
-// and silently rendering it as a whisper would hide work they meant to
-// surface. Too loud is noticed and fixed; too quiet is not.
+// Defaults to statusbar — the quietest tier — because an operator who has not
+// thought about prominence has not earned the top of the page. An unnoticed
+// suggestion is recoverable (turn it up); a nagging one teaches users to
+// ignore the whole surface, which is not.
 func (b NextActionBand) Resolved() NextActionProminence {
 	if b.Prominence == "" {
-		return ProminenceCard
+		return ProminenceStatusBar
 	}
 	return b.Prominence
 }

--- a/internal/dataentryconfig/nextaction.go
+++ b/internal/dataentryconfig/nextaction.go
@@ -202,6 +202,61 @@ type NextActionSource struct {
 	// one key, so an old snooze suppresses a genuinely new stall. With
 	// KeyProps: [status] the key changes and the snooze no longer matches.
 	KeyProps []string `yaml:"key_props,omitempty" json:"key_props,omitempty"`
+
+	// DeferScope decides what a snooze or dismissal covers: THIS suggestion,
+	// or the source as a whole. Empty means [DeferScopeEntity], except for a
+	// pick_one source — see [NextActionSource.ResolvedDeferScope].
+	DeferScope NextActionDeferScope `yaml:"defer_scope,omitempty" json:"defer_scope,omitempty"`
+}
+
+// NextActionDeferScope is what "not now" applies to.
+//
+// The distinction cannot be inferred from the source's shape, which is why it
+// is declared. Ask what the user was declining:
+//
+//   - An ISMS task needing attention: they declined THIS ITEM. They still
+//     want the other tasks — entity scope.
+//   - A daily joke, one entity per joke: they declined the INTERRUPTION.
+//     Which joke was on offer is incidental, and handing them another one
+//     immediately is precisely what they said no to — source scope.
+//   - A "complete your profile" nudge: they declined the TOPIC. Prompting
+//     about a different profile field a moment later is the same nag —
+//     source scope.
+//
+// All three are entity-shaped sources with interpolated messages, so neither
+// the message template nor the presence of a query separates them. Only the
+// operator knows which a source is.
+type NextActionDeferScope string
+
+const (
+	// DeferScopeEntity defers just this suggestion; other candidates from the
+	// same source still surface. The DEFAULT, because it is the least
+	// surprising for the common per-item source.
+	DeferScopeEntity NextActionDeferScope = "entity"
+
+	// DeferScopeSource defers every suggestion from this source until the
+	// snooze lapses. For sources where the interruption itself is what the
+	// user declined.
+	DeferScopeSource NextActionDeferScope = "source"
+)
+
+// ResolvedDeferScope returns the effective scope.
+//
+// A pick_one source defaults to SOURCE scope: its suggestion is about the set
+// ("one of these is small"), so keying the deferral to whichever candidate
+// happened to be picked means declining it hands back the same suggestion
+// with a different entity — the failure this default exists to prevent. An
+// operator can still override it either way.
+func (s NextActionSource) ResolvedDeferScope() NextActionDeferScope {
+	if s.DeferScope != "" {
+		return s.DeferScope
+	}
+	for _, o := range s.Actions {
+		if o.PickOne != nil {
+			return DeferScopeSource
+		}
+	}
+	return DeferScopeEntity
 }
 
 // NextActionPick selects among multiple candidates in the winning band.

--- a/internal/dataentryconfig/nextaction.go
+++ b/internal/dataentryconfig/nextaction.go
@@ -44,6 +44,57 @@ type NextActionBand struct {
 	// Label is an optional human-readable name for operator-facing UI
 	// (a settings screen listing what can be muted). Empty falls back to ID.
 	Label string `yaml:"label,omitempty" json:"label,omitempty"`
+	// Prominence is how loudly this band interrupts. Empty means
+	// [ProminenceCard]. See [NextActionProminence].
+	Prominence NextActionProminence `yaml:"prominence,omitempty" json:"prominence,omitempty"`
+}
+
+// NextActionProminence is how visually invasive a band's suggestion is.
+//
+// A small CLOSED vocabulary rather than styling knobs, for the same reason
+// bands beat numeric priorities: the operator declares how loud a tier should
+// be, and the UI decides what that looks like. Exposing colors, borders and
+// placement instead would let every deployment invent its own visual language
+// and drift from the host UI — and would put the "is this urgent?" judgement
+// in a stylesheet rather than in the band list where it is reviewable.
+//
+// The levels are ordered by how much they interrupt, so a config reads as a
+// volume scale:
+//
+//	banner  — full-width, accented, at the top. For a band where someone else
+//	          is blocked; it should be hard to scroll past.
+//	card    — the default. A bounded box among the page's other content.
+//	inline  — one line, no chrome. Present but not competing.
+//	whisper — muted and small. For content and ambient sources, where being
+//	          noticed at all is optional.
+//
+// Deliberately no "modal" or "toast": both take the interaction away from the
+// user, and an advisory hint that demands dismissal before you can proceed is
+// no longer advisory.
+type NextActionProminence string
+
+const (
+	// ProminenceBanner is full-width and accented — hard to scroll past.
+	ProminenceBanner NextActionProminence = "banner"
+	// ProminenceCard is a bounded box. The DEFAULT for an unset band.
+	ProminenceCard NextActionProminence = "card"
+	// ProminenceInline is a single line with no surrounding chrome.
+	ProminenceInline NextActionProminence = "inline"
+	// ProminenceWhisper is muted and small, for ambient content.
+	ProminenceWhisper NextActionProminence = "whisper"
+)
+
+// Resolved returns the effective prominence, applying the default.
+//
+// Defaulting to card rather than the quietest level is deliberate: an operator
+// who has not thought about prominence has usually written a real suggestion,
+// and silently rendering it as a whisper would hide work they meant to
+// surface. Too loud is noticed and fixed; too quiet is not.
+func (b NextActionBand) Resolved() NextActionProminence {
+	if b.Prominence == "" {
+		return ProminenceCard
+	}
+	return b.Prominence
 }
 
 // NextActionSource is one rule producing at most one suggestion per entity.

--- a/internal/dataentryconfig/nextaction_test.go
+++ b/internal/dataentryconfig/nextaction_test.go
@@ -250,3 +250,53 @@ func TestValidateNextActions_CountIsValid(t *testing.T) {
 		t.Fatalf("count source reported errors: %v", errs)
 	}
 }
+
+func TestNextActionBand_ResolvedProminence(t *testing.T) {
+	tests := []struct {
+		name string
+		band NextActionBand
+		want NextActionProminence
+	}{
+		{"unset defaults to card", NextActionBand{ID: "b"}, ProminenceCard},
+		{"banner", NextActionBand{ID: "b", Prominence: ProminenceBanner}, ProminenceBanner},
+		{"inline", NextActionBand{ID: "b", Prominence: ProminenceInline}, ProminenceInline},
+		{"whisper", NextActionBand{ID: "b", Prominence: ProminenceWhisper}, ProminenceWhisper},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.band.Resolved(); got != tc.want {
+				t.Errorf("Resolved() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// An unknown prominence must be rejected, not silently defaulted: a band the
+// operator asked to be quiet would otherwise render at full volume with no
+// explanation.
+func TestValidateNextActions_RejectsUnknownProminence(t *testing.T) {
+	cfg := validNextActionConfig()
+	cfg.NextActionBands[0].Prominence = "shouty"
+
+	errs := validateNextActions(cfg, nil)
+	for _, e := range errs {
+		if strings.Contains(e, `unknown prominence "shouty"`) {
+			return
+		}
+	}
+	t.Errorf("expected an unknown-prominence error, got %v", errs)
+}
+
+func TestValidateNextActions_AcceptsEveryProminence(t *testing.T) {
+	for _, p := range []NextActionProminence{
+		"", ProminenceBanner, ProminenceCard, ProminenceInline, ProminenceWhisper,
+	} {
+		t.Run(string(p), func(t *testing.T) {
+			cfg := validNextActionConfig()
+			cfg.NextActionBands[0].Prominence = p
+			if errs := validateNextActions(cfg, nil); len(errs) > 0 {
+				t.Errorf("prominence %q rejected: %v", p, errs)
+			}
+		})
+	}
+}

--- a/internal/dataentryconfig/nextaction_test.go
+++ b/internal/dataentryconfig/nextaction_test.go
@@ -1,0 +1,252 @@
+package dataentryconfig
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestParseNextActionDuration(t *testing.T) {
+	tests := []struct {
+		in      string
+		want    time.Duration
+		wantErr bool
+	}{
+		{in: "3d", want: 72 * time.Hour},
+		{in: "1d", want: 24 * time.Hour},
+		{in: "0.5d", want: 12 * time.Hour},
+		{in: "12h", want: 12 * time.Hour},
+		{in: "90m", want: 90 * time.Minute},
+		{in: "1h30m", want: 90 * time.Minute},
+		{in: "", wantErr: true},
+		{in: "d", wantErr: true},
+		{in: "3x", wantErr: true},
+		{in: "banana", wantErr: true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.in, func(t *testing.T) {
+			got, err := ParseNextActionDuration(tc.in)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("ParseNextActionDuration(%q) = %v, want error", tc.in, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ParseNextActionDuration(%q): %v", tc.in, err)
+			}
+			if got != tc.want {
+				t.Errorf("ParseNextActionDuration(%q) = %v, want %v", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestNextActionOffer_Kind(t *testing.T) {
+	tests := []struct {
+		name  string
+		offer NextActionOffer
+		want  string
+	}{
+		{"action", NextActionOffer{Action: "mark-done"}, "action"},
+		{"set", NextActionOffer{Set: map[string]string{"status": "done"}}, "set"},
+		{"navigate", NextActionOffer{Navigate: "/entity/task/{id}"}, "navigate"},
+		{"snooze", NextActionOffer{Snooze: []string{"1d"}}, "snooze"},
+		{"dismiss", NextActionOffer{Dismiss: true}, "dismiss"},
+		{"acknowledge", NextActionOffer{Acknowledge: true}, "acknowledge"},
+		{"empty", NextActionOffer{}, ""},
+		{"label alone is not a kind", NextActionOffer{Label: "x"}, ""},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.offer.Kind(); got != tc.want {
+				t.Errorf("Kind() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// validNextActionConfig is the baseline each validation test perturbs, so a
+// test asserts one failure rather than a pile of unrelated ones.
+func validNextActionConfig() *Config {
+	return &Config{
+		Actions: map[string]Action{
+			"mark-done": {Label: "Mark done"},
+		},
+		NextActionBands: []NextActionBand{
+			{ID: "blocking"},
+			{ID: "ambient"},
+		},
+		NextActions: map[string]NextActionSource{
+			"quip": {
+				Band:    "ambient",
+				Query:   "type:quip",
+				Suggest: "{text}",
+				Actions: []NextActionOffer{{Acknowledge: true}},
+			},
+		},
+	}
+}
+
+func TestValidateNextActions_Valid(t *testing.T) {
+	if errs := validateNextActions(validNextActionConfig(), nil); len(errs) > 0 {
+		t.Fatalf("valid config reported errors: %v", errs)
+	}
+}
+
+func TestValidateNextActions_Errors(t *testing.T) {
+	tests := []struct {
+		name    string
+		mutate  func(*Config)
+		wantSub string
+	}{
+		{
+			name:    "unknown band",
+			mutate:  func(c *Config) { s := c.NextActions["quip"]; s.Band = "nope"; c.NextActions["quip"] = s },
+			wantSub: `unknown band "nope"`,
+		},
+		{
+			// Near-miss casing is the likeliest real typo, so it earns a
+			// "did you mean" rather than a bare rejection.
+			name:    "unknown band suggests near miss",
+			mutate:  func(c *Config) { s := c.NextActions["quip"]; s.Band = "Ambient"; c.NextActions["quip"] = s },
+			wantSub: `did you mean "ambient"`,
+		},
+		{
+			name:    "missing band",
+			mutate:  func(c *Config) { s := c.NextActions["quip"]; s.Band = ""; c.NextActions["quip"] = s },
+			wantSub: "band is required",
+		},
+		{
+			name:    "missing suggest",
+			mutate:  func(c *Config) { s := c.NextActions["quip"]; s.Suggest = ""; c.NextActions["quip"] = s },
+			wantSub: "suggest is required",
+		},
+		{
+			name:    "no candidate source",
+			mutate:  func(c *Config) { s := c.NextActions["quip"]; s.Query = ""; c.NextActions["quip"] = s },
+			wantSub: "needs one of query",
+		},
+		{
+			name:    "query and context are exclusive",
+			mutate:  func(c *Config) { s := c.NextActions["quip"]; s.Context = "task"; c.NextActions["quip"] = s },
+			wantSub: "mutually exclusive",
+		},
+		{
+			name:    "duplicate band id",
+			mutate:  func(c *Config) { c.NextActionBands = append(c.NextActionBands, NextActionBand{ID: "ambient"}) },
+			wantSub: `duplicate band id "ambient"`,
+		},
+		{
+			name:    "empty band id",
+			mutate:  func(c *Config) { c.NextActionBands = append(c.NextActionBands, NextActionBand{}) },
+			wantSub: "id is required",
+		},
+		{
+			name:    "sources without bands",
+			mutate:  func(c *Config) { c.NextActionBands = nil },
+			wantSub: "no next_action_bands declared",
+		},
+		{
+			name:    "unknown pick",
+			mutate:  func(c *Config) { s := c.NextActions["quip"]; s.Pick = "vibes"; c.NextActions["quip"] = s },
+			wantSub: `unknown pick "vibes"`,
+		},
+		{
+			name:    "bad cooldown",
+			mutate:  func(c *Config) { s := c.NextActions["quip"]; s.Cooldown = "soon"; c.NextActions["quip"] = s },
+			wantSub: `invalid cooldown "soon"`,
+		},
+		{
+			name: "unknown action reference",
+			mutate: func(c *Config) {
+				s := c.NextActions["quip"]
+				s.Actions = []NextActionOffer{{Action: "ghost"}}
+				c.NextActions["quip"] = s
+			},
+			wantSub: `unknown action "ghost"`,
+		},
+		{
+			name: "empty offer",
+			mutate: func(c *Config) {
+				s := c.NextActions["quip"]
+				s.Actions = []NextActionOffer{{Label: "just a label"}}
+				c.NextActions["quip"] = s
+			},
+			wantSub: "empty (set one of",
+		},
+		{
+			// The union must be exactly one member: an offer that both acts
+			// and navigates has no defined behavior.
+			name: "ambiguous offer",
+			mutate: func(c *Config) {
+				s := c.NextActions["quip"]
+				s.Actions = []NextActionOffer{{Action: "mark-done", Navigate: "/x"}}
+				c.NextActions["quip"] = s
+			},
+			wantSub: "an affordance is exactly one",
+		},
+		{
+			name: "bad snooze duration",
+			mutate: func(c *Config) {
+				s := c.NextActions["quip"]
+				s.Actions = []NextActionOffer{{Snooze: []string{"later"}}}
+				c.NextActions["quip"] = s
+			},
+			wantSub: `invalid snooze duration "later"`,
+		},
+		{
+			// Silently ignoring confirm on a non-mutating offer would teach
+			// an operator that it works.
+			name: "confirm on non-mutating offer",
+			mutate: func(c *Config) {
+				s := c.NextActions["quip"]
+				s.Actions = []NextActionOffer{{Navigate: "/x", Confirm: true}}
+				c.NextActions["quip"] = s
+			},
+			wantSub: "confirm only applies to",
+		},
+		{
+			name: "malformed count",
+			mutate: func(c *Config) {
+				s := c.NextActions["quip"]
+				s.Query = ""
+				s.Count = "client > 0"
+				c.NextActions["quip"] = s
+			},
+			wantSub: "count must be of the form",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := validNextActionConfig()
+			tc.mutate(cfg)
+			errs := validateNextActions(cfg, nil)
+			if len(errs) == 0 {
+				t.Fatalf("expected an error containing %q, got none", tc.wantSub)
+			}
+			for _, e := range errs {
+				if strings.Contains(e, tc.wantSub) {
+					return
+				}
+			}
+			t.Errorf("no error contained %q; got %v", tc.wantSub, errs)
+		})
+	}
+}
+
+// TestValidateNextActions_CountIsValid pins the first-run shape, which is the
+// one source kind that has no entity to be about.
+func TestValidateNextActions_CountIsValid(t *testing.T) {
+	cfg := validNextActionConfig()
+	cfg.NextActions["first-run"] = NextActionSource{
+		Band:    "blocking",
+		Count:   "client == 0",
+		Suggest: "Nothing here yet. Start with a client?",
+		Actions: []NextActionOffer{{Navigate: "/form/client"}},
+	}
+	if errs := validateNextActions(cfg, nil); len(errs) > 0 {
+		t.Fatalf("count source reported errors: %v", errs)
+	}
+}

--- a/internal/dataentryconfig/nextaction_test.go
+++ b/internal/dataentryconfig/nextaction_test.go
@@ -257,10 +257,12 @@ func TestNextActionBand_ResolvedProminence(t *testing.T) {
 		band NextActionBand
 		want NextActionProminence
 	}{
-		{"unset defaults to card", NextActionBand{ID: "b"}, ProminenceCard},
+		// The default is the QUIETEST tier: an operator who has not thought
+		// about prominence has not earned the top of the page.
+		{"unset defaults to statusbar", NextActionBand{ID: "b"}, ProminenceStatusBar},
 		{"banner", NextActionBand{ID: "b", Prominence: ProminenceBanner}, ProminenceBanner},
-		{"inline", NextActionBand{ID: "b", Prominence: ProminenceInline}, ProminenceInline},
-		{"whisper", NextActionBand{ID: "b", Prominence: ProminenceWhisper}, ProminenceWhisper},
+		{"notice", NextActionBand{ID: "b", Prominence: ProminenceNotice}, ProminenceNotice},
+		{"statusbar", NextActionBand{ID: "b", Prominence: ProminenceStatusBar}, ProminenceStatusBar},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -289,7 +291,7 @@ func TestValidateNextActions_RejectsUnknownProminence(t *testing.T) {
 
 func TestValidateNextActions_AcceptsEveryProminence(t *testing.T) {
 	for _, p := range []NextActionProminence{
-		"", ProminenceBanner, ProminenceCard, ProminenceInline, ProminenceWhisper,
+		"", ProminenceBanner, ProminenceNotice, ProminenceStatusBar,
 	} {
 		t.Run(string(p), func(t *testing.T) {
 			cfg := validNextActionConfig()

--- a/internal/dataentryconfig/nextaction_test.go
+++ b/internal/dataentryconfig/nextaction_test.go
@@ -302,3 +302,116 @@ func TestValidateNextActions_AcceptsEveryProminence(t *testing.T) {
 		})
 	}
 }
+
+func TestValidatePickOne(t *testing.T) {
+	tests := []struct {
+		name    string
+		pick    NextActionPickOne
+		wantSub string
+	}{
+		{
+			name: "valid",
+			pick: NextActionPickOne{Query: "type:task", Action: "mark-done"},
+		},
+		{
+			// No query means no options; the affordance would render empty.
+			name:    "missing query",
+			pick:    NextActionPickOne{Action: "mark-done"},
+			wantSub: "pick_one needs a query",
+		},
+		{
+			// No action means nothing happens on selection — a list, not an
+			// affordance.
+			name:    "missing action",
+			pick:    NextActionPickOne{Query: "type:task"},
+			wantSub: "pick_one needs an action",
+		},
+		{
+			name:    "unknown action",
+			pick:    NextActionPickOne{Query: "type:task", Action: "ghost"},
+			wantSub: `pick_one references unknown action "ghost"`,
+		},
+		{
+			// A typo, not a request for the default — silently treating it as
+			// 3 would hide the mistake.
+			name:    "negative limit",
+			pick:    NextActionPickOne{Query: "type:task", Action: "mark-done", Limit: -1},
+			wantSub: "must not be negative",
+		},
+		{
+			name:    "limit over the maximum",
+			pick:    NextActionPickOne{Query: "type:task", Action: "mark-done", Limit: 50},
+			wantSub: "exceeds the maximum",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := validNextActionConfig()
+			src := cfg.NextActions["quip"]
+			pick := tc.pick
+			src.Actions = []NextActionOffer{{PickOne: &pick}}
+			cfg.NextActions["quip"] = src
+
+			errs := validateNextActions(cfg, nil)
+			if tc.wantSub == "" {
+				if len(errs) > 0 {
+					t.Fatalf("valid pick_one reported errors: %v", errs)
+				}
+				return
+			}
+			for _, e := range errs {
+				if strings.Contains(e, tc.wantSub) {
+					return
+				}
+			}
+			t.Errorf("no error contained %q; got %v", tc.wantSub, errs)
+		})
+	}
+}
+
+func TestPickOne_ResolvedLimit(t *testing.T) {
+	tests := []struct {
+		name  string
+		limit int
+		want  int
+	}{
+		{"unset takes the default", 0, DefaultPickOneLimit},
+		{"negative takes the default", -3, DefaultPickOneLimit},
+		{"in range is honored", 2, 2},
+		{"over the ceiling is capped", 99, MaxPickOneLimit},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			p := NextActionPickOne{Limit: tc.limit}
+			if got := p.ResolvedLimit(); got != tc.want {
+				t.Errorf("ResolvedLimit() = %d, want %d", got, tc.want)
+			}
+		})
+	}
+}
+
+// pick_one is a member of the offer union like any other: setting it
+// alongside another kind is ambiguous.
+func TestPickOne_IsPartOfTheUnion(t *testing.T) {
+	offer := NextActionOffer{PickOne: &NextActionPickOne{Query: "q", Action: "a"}}
+	if got := offer.Kind(); got != "pick_one" {
+		t.Errorf("Kind() = %q, want pick_one", got)
+	}
+
+	cfg := validNextActionConfig()
+	src := cfg.NextActions["quip"]
+	src.Actions = []NextActionOffer{{
+		Dismiss: true,
+		PickOne: &NextActionPickOne{Query: "type:task", Action: "mark-done"},
+	}}
+	cfg.NextActions["quip"] = src
+
+	errs := validateNextActions(cfg, nil)
+	for _, e := range errs {
+		if strings.Contains(e, "an affordance is exactly one") {
+			return
+		}
+	}
+	t.Errorf("expected an ambiguous-offer error, got %v", errs)
+}

--- a/internal/dataentryconfig/nextaction_validate.go
+++ b/internal/dataentryconfig/nextaction_validate.go
@@ -1,0 +1,235 @@
+package dataentryconfig
+
+import (
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/Sourcehaven-BV/rela/internal/metamodel"
+)
+
+// validateNextActions validates next_action_bands and next_actions.
+//
+// The load-bearing checks are reference integrity (a source naming a band or
+// an action that does not exist) and the offer union (exactly one member set).
+// Both are config-authoring mistakes that would otherwise surface as a
+// suggestion silently never firing — the worst failure mode for an advisory
+// system, because nothing is visibly broken and the operator concludes the
+// feature does not work.
+func validateNextActions(cfg *Config, meta *metamodel.Metamodel) []string {
+	var errs []string
+
+	bandIDs := make(map[string]bool, len(cfg.NextActionBands))
+	for i, b := range cfg.NextActionBands {
+		switch {
+		case b.ID == "":
+			errs = append(errs, fmt.Sprintf(
+				"next_action_bands[%d]: id is required", i))
+		case bandIDs[b.ID]:
+			// Duplicate ids make list-order-is-priority-order ambiguous:
+			// which position does a source referencing it get?
+			errs = append(errs, fmt.Sprintf(
+				"next_action_bands[%d]: duplicate band id %q", i, b.ID))
+		default:
+			bandIDs[b.ID] = true
+		}
+	}
+
+	if len(cfg.NextActions) > 0 && len(cfg.NextActionBands) == 0 {
+		errs = append(errs, "next_actions: no next_action_bands declared "+
+			"(bands are the priority vocabulary; declare at least one)")
+	}
+
+	for _, id := range sortedNextActionIDs(cfg.NextActions) {
+		errs = append(errs, validateNextActionSource(id, cfg.NextActions[id], cfg, meta, bandIDs)...)
+	}
+	return errs
+}
+
+// sortedNextActionIDs returns source ids in a stable order so validation
+// messages do not shuffle between runs on the same config.
+func sortedNextActionIDs(m map[string]NextActionSource) []string {
+	ids := make([]string, 0, len(m))
+	for id := range m {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+	return ids
+}
+
+func validateNextActionSource(
+	id string, s NextActionSource, cfg *Config, meta *metamodel.Metamodel, bandIDs map[string]bool,
+) []string {
+	var errs []string
+	where := fmt.Sprintf("next_actions[%q]", id)
+
+	switch {
+	case s.Band == "":
+		errs = append(errs, where+": band is required")
+	case !bandIDs[s.Band]:
+		errs = append(errs, fmt.Sprintf(
+			"%s: references unknown band %q%s", where, s.Band, suggestBand(s.Band, cfg)))
+	}
+
+	if s.Suggest == "" {
+		errs = append(errs, where+": suggest is required (the message shown to the user)")
+	}
+
+	errs = append(errs, validateNextActionCandidateSource(where, s, meta)...)
+
+	if s.Pick != "" {
+		switch s.Pick {
+		case PickStableRandom, PickFirst, PickLeastRecentlyShown:
+		default:
+			errs = append(errs, fmt.Sprintf(
+				"%s: unknown pick %q (want %q, %q or %q)",
+				where, s.Pick, PickStableRandom, PickFirst, PickLeastRecentlyShown))
+		}
+	}
+
+	if s.Cooldown != "" {
+		if _, err := ParseNextActionDuration(s.Cooldown); err != nil {
+			errs = append(errs, fmt.Sprintf(
+				"%s: invalid cooldown %q (want a duration like \"3d\", \"12h\")", where, s.Cooldown))
+		}
+	}
+
+	for i, o := range s.Actions {
+		errs = append(errs, validateNextActionOffer(where, i, o, cfg)...)
+	}
+	return errs
+}
+
+// validateNextActionCandidateSource checks the three mutually exclusive ways
+// a source names its candidates: Query (global), Context (entity-anchored),
+// or Count (entity-less aggregate). Exactly one must be set.
+func validateNextActionCandidateSource(where string, s NextActionSource, meta *metamodel.Metamodel) []string {
+	var errs []string
+
+	var set []string
+	if s.Query != "" {
+		set = append(set, "query")
+	}
+	if s.Context != "" {
+		set = append(set, "context")
+	}
+	if s.Count != "" {
+		set = append(set, "count")
+	}
+
+	switch len(set) {
+	case 0:
+		errs = append(errs,
+			where+": needs one of query (global), context (entity-anchored) or count (whole-graph)")
+	case 1:
+	default:
+		errs = append(errs, fmt.Sprintf(
+			"%s: %s are mutually exclusive (a source has one kind of candidate)",
+			where, strings.Join(set, " and ")))
+	}
+
+	if s.Context != "" && meta != nil {
+		if _, ok := meta.GetEntityDef(s.Context); !ok {
+			errs = append(errs, fmt.Sprintf(
+				"%s: context references unknown entity type %q", where, s.Context))
+		}
+	}
+
+	if s.Count != "" {
+		errs = append(errs, validateNextActionCount(where, s.Count, meta)...)
+	}
+	return errs
+}
+
+// validateNextActionCount checks the only supported aggregate form,
+// "<entity_type> == 0" — the first-run case. Deliberately narrow: a general
+// aggregate language is not needed to say "the graph is empty", and every
+// operator writing one would be inventing syntax the engine must then honor.
+func validateNextActionCount(where, count string, meta *metamodel.Metamodel) []string {
+	fields := strings.Fields(count)
+	if len(fields) != 3 || fields[1] != "==" || fields[2] != "0" {
+		return []string{fmt.Sprintf(
+			"%s: count must be of the form \"<entity_type> == 0\", got %q", where, count)}
+	}
+	if meta != nil {
+		if _, ok := meta.GetEntityDef(fields[0]); !ok {
+			return []string{fmt.Sprintf(
+				"%s: count references unknown entity type %q", where, fields[0])}
+		}
+	}
+	return nil
+}
+
+func validateNextActionOffer(where string, i int, o NextActionOffer, cfg *Config) []string {
+	var errs []string
+	at := fmt.Sprintf("%s: actions[%d]", where, i)
+
+	kinds := o.setKinds()
+	switch len(kinds) {
+	case 0:
+		errs = append(errs,
+			at+": empty (set one of action, set, navigate, snooze, dismiss, acknowledge)")
+		return errs
+	case 1:
+	default:
+		errs = append(errs, fmt.Sprintf(
+			"%s: sets %s — an affordance is exactly one of them", at, strings.Join(kinds, " and ")))
+	}
+
+	if o.Action != "" {
+		if _, ok := cfg.Actions[o.Action]; !ok {
+			errs = append(errs, fmt.Sprintf(
+				"%s: references unknown action %q", at, o.Action))
+		}
+	}
+
+	for _, d := range o.Snooze {
+		if _, err := ParseNextActionDuration(d); err != nil {
+			errs = append(errs, fmt.Sprintf(
+				"%s: invalid snooze duration %q (want e.g. \"1d\", \"7d\", \"12h\")", at, d))
+		}
+	}
+
+	// Confirm only means something for an in-place mutation. Silently
+	// ignoring it on a navigate/snooze would teach an operator it works.
+	if o.Confirm && o.Action == "" && len(o.Set) == 0 {
+		errs = append(errs, at+": confirm only applies to action or set")
+	}
+	return errs
+}
+
+// ParseNextActionDuration parses a cooldown or snooze duration, extending
+// time.ParseDuration with a day unit: "3d" is the natural way to write a
+// cooldown, and ParseDuration has no "d". Everything else is delegated
+// unchanged, so "12h", "90m" and "1h30m" keep working.
+//
+// Exported because the engine must parse these the same way the validator
+// does — a config that validates but then parses differently at runtime is
+// exactly the drift a single function prevents.
+// hoursPerDay backs the "d" unit ParseNextActionDuration adds.
+const hoursPerDay = 24
+
+func ParseNextActionDuration(s string) (time.Duration, error) {
+	if num, ok := strings.CutSuffix(s, "d"); ok && num != "" {
+		days, err := strconv.ParseFloat(num, 64)
+		if err == nil {
+			return time.Duration(days * float64(hoursPerDay*time.Hour)), nil
+		}
+		// Not a plain number before the "d" (e.g. "1h30d"): fall through and
+		// let ParseDuration produce its own error for the whole string.
+	}
+	return time.ParseDuration(s)
+}
+
+// suggestBand offers a near-miss band id for an unknown reference, matching
+// the "did you mean" style the view/list validators use.
+func suggestBand(want string, cfg *Config) string {
+	for _, b := range cfg.NextActionBands {
+		if strings.EqualFold(b.ID, want) {
+			return fmt.Sprintf(" (did you mean %q?)", b.ID)
+		}
+	}
+	return ""
+}

--- a/internal/dataentryconfig/nextaction_validate.go
+++ b/internal/dataentryconfig/nextaction_validate.go
@@ -99,6 +99,17 @@ func validateNextActionSource(
 		}
 	}
 
+	// An unknown scope is rejected rather than defaulted: silently treating
+	// it as entity-scope would give an operator who asked for source-wide
+	// deferral the exact nagging they were trying to switch off.
+	switch s.DeferScope {
+	case "", DeferScopeEntity, DeferScopeSource:
+	default:
+		errs = append(errs, fmt.Sprintf(
+			"%s: unknown defer_scope %q (want %q or %q)",
+			where, s.DeferScope, DeferScopeEntity, DeferScopeSource))
+	}
+
 	if s.Cooldown != "" {
 		if _, err := ParseNextActionDuration(s.Cooldown); err != nil {
 			errs = append(errs, fmt.Sprintf(

--- a/internal/dataentryconfig/nextaction_validate.go
+++ b/internal/dataentryconfig/nextaction_validate.go
@@ -39,12 +39,11 @@ func validateNextActions(cfg *Config, meta *metamodel.Metamodel) []string {
 		// falling back to `card` would render a band the operator asked to be
 		// quiet at full volume, and nothing would say why.
 		switch b.Prominence {
-		case "", ProminenceBanner, ProminenceCard, ProminenceInline, ProminenceWhisper:
+		case "", ProminenceBanner, ProminenceNotice, ProminenceStatusBar:
 		default:
 			errs = append(errs, fmt.Sprintf(
-				"next_action_bands[%d]: unknown prominence %q (want %q, %q, %q or %q)",
-				i, b.Prominence, ProminenceBanner, ProminenceCard,
-				ProminenceInline, ProminenceWhisper))
+				"next_action_bands[%d]: unknown prominence %q (want %q, %q or %q)",
+				i, b.Prominence, ProminenceBanner, ProminenceNotice, ProminenceStatusBar))
 		}
 	}
 

--- a/internal/dataentryconfig/nextaction_validate.go
+++ b/internal/dataentryconfig/nextaction_validate.go
@@ -140,6 +140,12 @@ func validateNextActionCandidateSource(where string, s NextActionSource, meta *m
 	if s.Count != "" {
 		errs = append(errs, validateNextActionCount(where, s.Count, meta)...)
 	}
+	// count_ungated only means something alongside count. Silently ignoring
+	// it elsewhere would let an operator believe they had opted out of the
+	// read gate on a source that never consults it.
+	if s.CountUngated && s.Count == "" {
+		errs = append(errs, where+": count_ungated only applies to a count source")
+	}
 	return errs
 }
 

--- a/internal/dataentryconfig/nextaction_validate.go
+++ b/internal/dataentryconfig/nextaction_validate.go
@@ -35,6 +35,17 @@ func validateNextActions(cfg *Config, meta *metamodel.Metamodel) []string {
 		default:
 			bandIDs[b.ID] = true
 		}
+		// An unknown prominence is rejected rather than defaulted: silently
+		// falling back to `card` would render a band the operator asked to be
+		// quiet at full volume, and nothing would say why.
+		switch b.Prominence {
+		case "", ProminenceBanner, ProminenceCard, ProminenceInline, ProminenceWhisper:
+		default:
+			errs = append(errs, fmt.Sprintf(
+				"next_action_bands[%d]: unknown prominence %q (want %q, %q, %q or %q)",
+				i, b.Prominence, ProminenceBanner, ProminenceCard,
+				ProminenceInline, ProminenceWhisper))
+		}
 	}
 
 	if len(cfg.NextActions) > 0 && len(cfg.NextActionBands) == 0 {

--- a/internal/dataentryconfig/nextaction_validate.go
+++ b/internal/dataentryconfig/nextaction_validate.go
@@ -208,10 +208,45 @@ func validateNextActionOffer(where string, i int, o NextActionOffer, cfg *Config
 		}
 	}
 
+	if o.PickOne != nil {
+		errs = append(errs, validatePickOne(at, *o.PickOne, cfg)...)
+	}
+
 	// Confirm only means something for an in-place mutation. Silently
 	// ignoring it on a navigate/snooze would teach an operator it works.
 	if o.Confirm && o.Action == "" && len(o.Set) == 0 {
 		errs = append(errs, at+": confirm only applies to action or set")
+	}
+	return errs
+}
+
+// validatePickOne checks a render-time option list.
+//
+// Both fields are required and neither can be defaulted: without a query
+// there are no options, and without an action there is nothing to do with the
+// one chosen — either omission produces an affordance that renders but cannot
+// work, which is the silent-no-op failure this validation exists to prevent.
+func validatePickOne(at string, p NextActionPickOne, cfg *Config) []string {
+	var errs []string
+	if p.Query == "" {
+		errs = append(errs, at+": pick_one needs a query (it is the option list)")
+	}
+	if p.Action == "" {
+		errs = append(errs, at+": pick_one needs an action to run on the chosen option")
+	} else if _, ok := cfg.Actions[p.Action]; !ok {
+		errs = append(errs, fmt.Sprintf(
+			"%s: pick_one references unknown action %q", at, p.Action))
+	}
+	// A negative limit is a typo, not a request for the default: silently
+	// treating it as "3" would hide the mistake.
+	if p.Limit < 0 {
+		errs = append(errs, fmt.Sprintf(
+			"%s: pick_one limit must not be negative, got %d", at, p.Limit))
+	}
+	if p.Limit > MaxPickOneLimit {
+		errs = append(errs, fmt.Sprintf(
+			"%s: pick_one limit %d exceeds the maximum of %d (a suggestion offering more "+
+				"has stopped being one suggestion)", at, p.Limit, MaxPickOneLimit))
 	}
 	return errs
 }

--- a/internal/dataentryconfig/validate.go
+++ b/internal/dataentryconfig/validate.go
@@ -35,6 +35,9 @@ var validTopLevelKeys = map[string]bool{
 	"actions":      true,
 	"navigation":   true,
 	"palette":      true,
+
+	"next_action_bands": true,
+	"next_actions":      true,
 }
 
 // Known typos with suggestions
@@ -139,6 +142,7 @@ func ValidateConfig(data []byte, cfg *Config, meta *metamodel.Metamodel) error {
 	errs = append(errs, validateFeeds(cfg, meta)...)
 	errs = append(errs, validateCalDAV(cfg, meta)...)
 	errs = append(errs, validateStyles(cfg, meta)...)
+	errs = append(errs, validateNextActions(cfg, meta)...)
 	errs = append(errs, validateCrossReferences(cfg)...)
 
 	if len(errs) > 0 {

--- a/internal/nextaction/nextaction.go
+++ b/internal/nextaction/nextaction.go
@@ -31,6 +31,7 @@ import (
 	"errors"
 	"fmt"
 	"hash/fnv"
+	"log/slog"
 	"sort"
 	"strings"
 	"time"
@@ -58,6 +59,21 @@ type Candidate struct {
 	Entity *entity.Entity
 }
 
+// PickOption is one choice in a pick_one affordance.
+type PickOption struct {
+	EntityID string
+	Label    string
+}
+
+// OptionFunc resolves a pick_one option list. Supplied by the wiring site for
+// the same reason as [CandidateFunc]: the query must go through the caller's
+// read gate, and the engine must not learn how to reach a store.
+//
+// A nil OptionFunc is not an error — the engine then renders the pick_one
+// affordance with no options, which the UI omits. That keeps a deployment
+// that has not wired it from failing every page.
+type OptionFunc func(ctx context.Context, query string, limit int) ([]PickOption, error)
+
 // CandidateFunc produces candidates for one source. Supplied by the wiring
 // site so this package depends on no store, searcher or ACL type: it is the
 // consumer-side interface that keeps the engine testable without a graph.
@@ -80,6 +96,14 @@ type Suggestion struct {
 	Message string
 	// Actions are the affordances, copied from config.
 	Actions []dataentryconfig.NextActionOffer
+	// PickOptions holds the render-time options for a pick_one affordance,
+	// keyed by the offer's index in Actions. Empty for every other kind.
+	//
+	// Resolved here rather than by the UI because the options come from a
+	// QUERY, and the query must run through the same ACL-gated path as the
+	// suggestion itself — a client-side fetch would be a second read surface
+	// to gate.
+	PickOptions map[int][]PickOption
 	// Key is the identity used for cooldown, snooze and dismissal.
 	Key userstate.Key
 }
@@ -90,7 +114,15 @@ type Engine struct {
 	cfg        *dataentryconfig.Config
 	state      userstate.Store
 	candidates CandidateFunc
+	options    OptionFunc
 	cap        int
+}
+
+// WithOptions supplies the pick_one option resolver. Optional: without it a
+// pick_one affordance simply offers nothing rather than failing the page.
+func (e *Engine) WithOptions(fn OptionFunc) *Engine {
+	e.options = fn
+	return e
 }
 
 // New builds an Engine. Every collaborator is required: a nil userstate.Store
@@ -129,12 +161,47 @@ func (e *Engine) Resolve(ctx context.Context, user string, now time.Time) (Sugge
 			return Suggestion{}, false, err
 		}
 		if ok {
+			// Options are resolved for the WINNER only, after the band is
+			// decided. Resolving during candidate collection would run an
+			// extra query per candidate for a list only one of them will ever
+			// display — the same reasoning as short-circuiting itself.
+			e.resolvePickOptions(ctx, &s)
 			// Short-circuit: a lower band cannot outrank this, so the
 			// remaining sources are not worth querying.
 			return s, true, nil
 		}
 	}
 	return Suggestion{}, false, nil
+}
+
+// resolvePickOptions fills in the render-time option lists.
+//
+// Failures are logged and dropped rather than propagated: an option list that
+// cannot be built costs the user one affordance, whereas failing the whole
+// resolve costs them the suggestion — and this is an advisory surface that
+// must never break the page it sits on.
+func (e *Engine) resolvePickOptions(ctx context.Context, s *Suggestion) {
+	if e.options == nil {
+		return
+	}
+	for i, offer := range s.Actions {
+		if offer.PickOne == nil {
+			continue
+		}
+		opts, err := e.options(ctx, offer.PickOne.Query, offer.PickOne.ResolvedLimit())
+		if err != nil {
+			slog.Warn("nextaction: pick_one options unavailable",
+				"source", s.Source, "error", err)
+			continue
+		}
+		if len(opts) == 0 {
+			continue
+		}
+		if s.PickOptions == nil {
+			s.PickOptions = make(map[int][]PickOption, 1)
+		}
+		s.PickOptions[i] = opts
+	}
 }
 
 // resolveBand collects eligible suggestions from every source in one band and

--- a/internal/nextaction/nextaction.go
+++ b/internal/nextaction/nextaction.go
@@ -118,18 +118,27 @@ type Engine struct {
 	cap        int
 }
 
-// WithOptions supplies the pick_one option resolver. Optional: without it a
-// pick_one affordance simply offers nothing rather than failing the page.
-func (e *Engine) WithOptions(fn OptionFunc) *Engine {
-	e.options = fn
-	return e
+// Option configures an [Engine] at construction.
+//
+// A construction-time option rather than a builder method: a builder returning
+// a copy is silently a no-op when the caller discards it, and one mutating the
+// receiver would race, since [Engine] is documented as safe for concurrent use
+// and callers are invited to cache one. Neither mistake is available here.
+type Option func(*Engine)
+
+// WithOptions supplies the pick_one option resolver. Without it a pick_one
+// affordance simply offers nothing rather than failing the page.
+func WithOptions(fn OptionFunc) Option {
+	return func(e *Engine) { e.options = fn }
 }
 
 // New builds an Engine. Every collaborator is required: a nil userstate.Store
 // would silently stop honoring snoozes and mutes, which the user experiences
 // as the system ignoring them — precisely the deferred-failure-to-downstream-
 // symptom the project's constructor rule exists to prevent.
-func New(cfg *dataentryconfig.Config, state userstate.Store, candidates CandidateFunc) (*Engine, error) {
+func New(
+	cfg *dataentryconfig.Config, state userstate.Store, candidates CandidateFunc, opts ...Option,
+) (*Engine, error) {
 	if cfg == nil {
 		return nil, errors.New("nextaction: config must be non-nil")
 	}
@@ -139,7 +148,11 @@ func New(cfg *dataentryconfig.Config, state userstate.Store, candidates Candidat
 	if candidates == nil {
 		return nil, errors.New("nextaction: candidate func must be non-nil")
 	}
-	return &Engine{cfg: cfg, state: state, candidates: candidates, cap: DefaultCandidateCap}, nil
+	e := &Engine{cfg: cfg, state: state, candidates: candidates, cap: DefaultCandidateCap}
+	for _, opt := range opts {
+		opt(e)
+	}
+	return e, nil
 }
 
 // Resolve returns the single suggestion to show `user` now, or ok=false when

--- a/internal/nextaction/nextaction.go
+++ b/internal/nextaction/nextaction.go
@@ -1,0 +1,379 @@
+// Package nextaction resolves ONE advisory suggestion from operator-declared
+// sources.
+//
+// # The one-slot constraint does the work
+//
+// Because exactly one suggestion is ever shown, several things that look like
+// omissions are deliberate:
+//
+//   - No per-source `limit:`. A bounded candidate set is not lossy when only
+//     one candidate is displayed — sixty stalled tasks and six produce
+//     identical output — so the bound belongs to the engine, which knows the
+//     page budget, not to an operator guessing a number whose right value
+//     depends on every other source.
+//   - No ranking within a band. See [pickStableRandom].
+//   - No cache. See the Resolve doc.
+//
+// # Evaluation order
+//
+// Sources are grouped by band, bands are evaluated in operator-declared order
+// (highest priority first), and evaluation STOPS at the first band that
+// yields a candidate. A typical page therefore runs one or two queries rather
+// than all of them, and the ambient/content source at the bottom is reached
+// only when everything above is empty — which is also when it is cheapest to
+// be there.
+//
+// See RES-09YLLL for the design and the rejected alternatives.
+package nextaction
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"hash/fnv"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/Sourcehaven-BV/rela/internal/dataentryconfig"
+	"github.com/Sourcehaven-BV/rela/internal/entity"
+	"github.com/Sourcehaven-BV/rela/internal/userstate"
+)
+
+// DefaultCooldown applies to a source that declares none.
+//
+// Deliberately non-zero: an operator who omits a cooldown has probably not
+// thought about nag frequency, so the default assumes they got it wrong
+// rather than assuming they meant "show this every single page load". Being
+// too quiet is recoverable; being a nag is how the whole surface gets ignored.
+const DefaultCooldown = 24 * time.Hour
+
+// DefaultCandidateCap bounds how many candidates a source may contribute to
+// the pick. Engine-owned, not configurable — see the package doc.
+const DefaultCandidateCap = 20
+
+// Candidate is one entity a source proposes, already ACL-filtered by the
+// caller's reader.
+type Candidate struct {
+	Entity *entity.Entity
+}
+
+// CandidateFunc produces candidates for one source. Supplied by the wiring
+// site so this package depends on no store, searcher or ACL type: it is the
+// consumer-side interface that keeps the engine testable without a graph.
+//
+// Implementations MUST apply the caller's read gate. The engine never sees
+// an entity the principal may not read, which is also why there is no cache
+// here — see [Engine.Resolve].
+type CandidateFunc func(ctx context.Context, src dataentryconfig.NextActionSource) ([]Candidate, error)
+
+// Suggestion is the resolved hint.
+type Suggestion struct {
+	// Source is the config id that produced this. Also the mute unit and half
+	// the suggestion key.
+	Source string
+	// Band is the id of the band it came from.
+	Band string
+	// EntityID is empty for a count-based (entity-less) source.
+	EntityID string
+	// Message is Suggest with {property} placeholders interpolated.
+	Message string
+	// Actions are the affordances, copied from config.
+	Actions []dataentryconfig.NextActionOffer
+	// Key is the identity used for cooldown, snooze and dismissal.
+	Key userstate.Key
+}
+
+// Engine resolves suggestions. Construct with [New]; safe for concurrent use
+// provided the injected collaborators are.
+type Engine struct {
+	cfg        *dataentryconfig.Config
+	state      userstate.Store
+	candidates CandidateFunc
+	cap        int
+}
+
+// New builds an Engine. Every collaborator is required: a nil userstate.Store
+// would silently stop honoring snoozes and mutes, which the user experiences
+// as the system ignoring them — precisely the deferred-failure-to-downstream-
+// symptom the project's constructor rule exists to prevent.
+func New(cfg *dataentryconfig.Config, state userstate.Store, candidates CandidateFunc) (*Engine, error) {
+	if cfg == nil {
+		return nil, errors.New("nextaction: config must be non-nil")
+	}
+	if state == nil {
+		return nil, errors.New("nextaction: userstate store must be non-nil")
+	}
+	if candidates == nil {
+		return nil, errors.New("nextaction: candidate func must be non-nil")
+	}
+	return &Engine{cfg: cfg, state: state, candidates: candidates, cap: DefaultCandidateCap}, nil
+}
+
+// Resolve returns the single suggestion to show `user` now, or ok=false when
+// nothing is owed.
+//
+// `now` is injected rather than read from the clock so callers (and tests)
+// control it, matching userstate.Store and predicatefns.Bind.
+//
+// Deliberately NOT cached. rela gates reads by principal, with row-level
+// semantics where a hidden entity is nonexistent, so a cache keyed on
+// anything but the principal would defeat that gate — and the failure mode is
+// showing someone a suggestion about an entity whose very existence is meant
+// to be secret. Per-principal caching would be safe but is not worth it
+// against one or two fast queries.
+func (e *Engine) Resolve(ctx context.Context, user string, now time.Time) (Suggestion, bool, error) {
+	for _, band := range e.cfg.NextActionBands {
+		s, ok, err := e.resolveBand(ctx, user, band.ID, now)
+		if err != nil {
+			return Suggestion{}, false, err
+		}
+		if ok {
+			// Short-circuit: a lower band cannot outrank this, so the
+			// remaining sources are not worth querying.
+			return s, true, nil
+		}
+	}
+	return Suggestion{}, false, nil
+}
+
+// resolveBand collects eligible suggestions from every source in one band and
+// picks one. Sources within a band are unordered by design — see pick.
+func (e *Engine) resolveBand(
+	ctx context.Context, user, bandID string, now time.Time,
+) (Suggestion, bool, error) {
+	var eligible []Suggestion
+
+	for _, id := range e.sourceIDsForBand(bandID) {
+		src := e.cfg.NextActions[id]
+
+		muted, err := e.state.Muted(ctx, user, id)
+		if err != nil {
+			return Suggestion{}, false, fmt.Errorf("nextaction: mute lookup for %q: %w", id, err)
+		}
+		if muted {
+			continue
+		}
+
+		found, err := e.eligibleFromSource(ctx, user, id, src, bandID, now)
+		if err != nil {
+			return Suggestion{}, false, err
+		}
+		eligible = append(eligible, found...)
+	}
+
+	if len(eligible) == 0 {
+		return Suggestion{}, false, nil
+	}
+	return e.pick(user, eligible, now), true, nil
+}
+
+// eligibleFromSource returns the suggestions one source contributes after
+// snooze and cooldown suppression.
+func (e *Engine) eligibleFromSource(
+	ctx context.Context, user, id string, src dataentryconfig.NextActionSource, bandID string, now time.Time,
+) ([]Suggestion, error) {
+	cands, err := e.candidates(ctx, src)
+	if err != nil {
+		return nil, fmt.Errorf("nextaction: candidates for %q: %w", id, err)
+	}
+	if len(cands) > e.cap {
+		cands = cands[:e.cap]
+	}
+
+	out := make([]Suggestion, 0, len(cands))
+	for _, c := range cands {
+		sug := buildSuggestion(id, bandID, src, c)
+		sug.Key.User = user
+
+		suppressed, err := e.suppressed(ctx, sug.Key, src, now)
+		if err != nil {
+			return nil, err
+		}
+		if !suppressed {
+			out = append(out, sug)
+		}
+	}
+	return out, nil
+}
+
+// suppressed reports whether a snooze or a cooldown hides this suggestion.
+func (e *Engine) suppressed(
+	ctx context.Context, k userstate.Key, src dataentryconfig.NextActionSource, now time.Time,
+) (bool, error) {
+	if _, snoozed, err := e.state.SnoozedUntil(ctx, k, now); err != nil {
+		return false, fmt.Errorf("nextaction: snooze lookup for %q: %w", k.Source, err)
+	} else if snoozed {
+		return true, nil
+	}
+
+	lastShown, everShown, err := e.state.LastShown(ctx, k)
+	if err != nil {
+		return false, fmt.Errorf("nextaction: last-shown lookup for %q: %w", k.Source, err)
+	}
+	if !everShown {
+		return false, nil
+	}
+
+	cooldown := DefaultCooldown
+	if src.Cooldown != "" {
+		// Already validated at config load; a parse failure here means the
+		// config was constructed in code, so fall back rather than fail the
+		// whole page for one malformed source.
+		if d, perr := dataentryconfig.ParseNextActionDuration(src.Cooldown); perr == nil {
+			cooldown = d
+		}
+	}
+	return now.Before(lastShown.Add(cooldown)), nil
+}
+
+// sourceIDsForBand returns the ids in a band, sorted for determinism. Sort
+// order is NOT priority — within a band nothing outranks anything, and pick
+// chooses among them.
+func (e *Engine) sourceIDsForBand(bandID string) []string {
+	var ids []string
+	for id, src := range e.cfg.NextActions {
+		if src.Band == bandID {
+			ids = append(ids, id)
+		}
+	}
+	sort.Strings(ids)
+	return ids
+}
+
+// pick selects one suggestion from the winning band.
+//
+// Stable-random, seeded per user per day: a refresh must not re-roll the
+// suggestion, or the companion looks flaky, but tomorrow should be free to
+// differ.
+//
+// Dwell-time ordering was considered and rejected. A band holding many
+// simultaneous candidates is a CONFIGURATION bug — a rule too broad — and no
+// tiebreak fixes that, it only hides it. Random is honest about it, is total
+// (dwell is undefined for content and count sources), needs no stored onset,
+// and resists starvation: dwell ordering lets the oldest item block its band
+// indefinitely if the user is never going to act on it. "Why this one?" still
+// answers in one sentence — these were equally eligible, you get one.
+func (e *Engine) pick(user string, eligible []Suggestion, now time.Time) Suggestion {
+	if len(eligible) == 1 {
+		return eligible[0]
+	}
+	// Sort by key so the input order (map iteration inside a source) cannot
+	// shift the choice; the seed alone decides.
+	sort.Slice(eligible, func(i, j int) bool {
+		return keyString(eligible[i].Key) < keyString(eligible[j].Key)
+	})
+	return eligible[pickStableRandom(user, now, len(eligible))]
+}
+
+// pickStableRandom returns an index in [0,n) that is stable for one user on
+// one UTC day. UTC rather than local time so the roll does not shift when a
+// user travels, matching the UTC-truncation rule predicatefns.Bind documents
+// (a local-vs-UTC midnight skew was a real bug there, RR-YPYTP).
+func pickStableRandom(user string, now time.Time, n int) int {
+	if n <= 1 {
+		return 0
+	}
+	h := fnv.New64a()
+	_, _ = h.Write([]byte(user))
+	_, _ = h.Write([]byte{0})
+	_, _ = h.Write([]byte(now.UTC().Format(time.DateOnly)))
+	// n is a candidate count bounded by DefaultCandidateCap, so the modulus
+	// is far inside int range on every supported platform.
+	return int(h.Sum64() % uint64(n)) //nolint:gosec // bounded by the candidate cap
+}
+
+// keyString renders a key for stable sorting.
+func keyString(k userstate.Key) string {
+	return k.Source + "\x00" + k.EntityID + "\x00" + k.Variant
+}
+
+// buildSuggestion assembles the suggestion for one candidate.
+func buildSuggestion(
+	id, bandID string, src dataentryconfig.NextActionSource, c Candidate,
+) Suggestion {
+	s := Suggestion{
+		Source:  id,
+		Band:    bandID,
+		Actions: src.Actions,
+		Key:     userstate.Key{Source: id},
+	}
+	if c.Entity != nil {
+		s.EntityID = c.Entity.ID
+		s.Key.EntityID = c.Entity.ID
+		s.Key.Variant = variantFor(src.KeyProps, c.Entity)
+	}
+	s.Message = interpolate(src.Suggest, c.Entity)
+	return s
+}
+
+// variantFor renders the key_props values that make a RESET condition read as
+// new. Empty when the source declares none.
+func variantFor(props []string, e *entity.Entity) string {
+	if len(props) == 0 || e == nil {
+		return ""
+	}
+	parts := make([]string, 0, len(props))
+	for _, p := range props {
+		parts = append(parts, p+"="+propString(e, p))
+	}
+	return strings.Join(parts, ";")
+}
+
+// interpolate substitutes {property} placeholders from the entity. An unknown
+// placeholder is left verbatim: silently emptying it would turn a config typo
+// into a message with a hole in it, which reads as a product bug rather than
+// as the operator error it is.
+func interpolate(tmpl string, e *entity.Entity) string {
+	if e == nil || !strings.ContainsRune(tmpl, '{') {
+		return tmpl
+	}
+	var b strings.Builder
+	rest := tmpl
+	for {
+		open := strings.IndexByte(rest, '{')
+		if open < 0 {
+			b.WriteString(rest)
+			return b.String()
+		}
+		closeIdx := strings.IndexByte(rest[open:], '}')
+		if closeIdx < 0 {
+			b.WriteString(rest)
+			return b.String()
+		}
+		closeIdx += open
+		name := rest[open+1 : closeIdx]
+		b.WriteString(rest[:open])
+		if v := propString(e, name); v != "" {
+			b.WriteString(v)
+		} else {
+			b.WriteString(rest[open : closeIdx+1])
+		}
+		rest = rest[closeIdx+1:]
+	}
+}
+
+// propString renders one property (or the id) as text.
+func propString(e *entity.Entity, name string) string {
+	if e == nil {
+		return ""
+	}
+	if name == "id" {
+		return e.ID
+	}
+	v, ok := e.Properties[name]
+	if !ok || v == nil {
+		return ""
+	}
+	if s, ok := v.(string); ok {
+		return s
+	}
+	return fmt.Sprint(v)
+}
+
+// MarkShown records that a suggestion was surfaced, starting its cooldown.
+// Separate from Resolve because resolving is a read: a caller that resolves
+// for a preview, or discards the result, must not start the clock.
+func (e *Engine) MarkShown(ctx context.Context, s Suggestion, at time.Time) error {
+	return e.state.MarkShown(ctx, s.Key, at)
+}

--- a/internal/nextaction/nextaction.go
+++ b/internal/nextaction/nextaction.go
@@ -366,9 +366,17 @@ func buildSuggestion(
 		Key:     userstate.Key{Source: id},
 	}
 	if c.Entity != nil {
+		// EntityID always names the candidate — the UI links to it, and the
+		// message interpolates from it.
 		s.EntityID = c.Entity.ID
-		s.Key.EntityID = c.Entity.ID
-		s.Key.Variant = variantFor(src.KeyProps, c.Entity)
+		// The KEY, though, follows the source's defer scope. Source-scoped
+		// sources leave the entity out, so declining one suggestion defers
+		// the whole source rather than handing back the same suggestion with
+		// a different entity.
+		if src.ResolvedDeferScope() != dataentryconfig.DeferScopeSource {
+			s.Key.EntityID = c.Entity.ID
+			s.Key.Variant = variantFor(src.KeyProps, c.Entity)
+		}
 	}
 	s.Message = interpolate(src.Suggest, c.Entity)
 	return s

--- a/internal/nextaction/nextaction_test.go
+++ b/internal/nextaction/nextaction_test.go
@@ -510,3 +510,80 @@ func TestPickOne_NoResolverIsHarmless(t *testing.T) {
 	require.True(t, ok)
 	require.Empty(t, got.PickOptions)
 }
+
+// Source-scoped deferral: declining the suggestion defers the SOURCE, not
+// just the candidate that happened to be on offer.
+//
+// The failing case this pins: a "here are three small tasks" suggestion keyed
+// per-candidate means snoozing it hands back the same suggestion with a
+// different task — which is precisely what the user declined.
+func TestDeferScope_SourceKeyOmitsTheEntity(t *testing.T) {
+	t.Parallel()
+	cfg := twoBandConfig()
+	src := cfg.NextActions["urgent"]
+	src.DeferScope = dataentryconfig.DeferScopeSource
+	cfg.NextActions["urgent"] = src
+
+	fn, _ := staticCandidates(map[string][]*entity.Entity{
+		"urgent": {ent("T-1", "task", nil), ent("T-2", "task", nil)},
+	})
+	eng, st := newEngine(t, cfg, fn)
+	ctx := context.Background()
+
+	got, ok, err := eng.Resolve(ctx, testUser, base)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.NotEmpty(t, got.EntityID, "the UI still needs an entity to link to")
+	require.Empty(t, got.Key.EntityID, "a source-scoped key must not carry the entity")
+
+	// Snoozing it must silence the source, not just this candidate.
+	require.NoError(t, st.SetSnooze(ctx, got.Key, base.Add(24*time.Hour)))
+	after, ok, err := eng.Resolve(ctx, testUser, base)
+	require.NoError(t, err)
+	if ok {
+		require.NotEqual(t, "urgent", after.Source,
+			"a source-scoped snooze must suppress every candidate, not just the one shown")
+	}
+}
+
+// Entity scope is the default and stays per-candidate: the ISMS case, where
+// declining one task must not silence the rest.
+func TestDeferScope_EntityIsTheDefault(t *testing.T) {
+	t.Parallel()
+	fn, _ := staticCandidates(map[string][]*entity.Entity{
+		"urgent": {ent("T-1", "task", nil), ent("T-2", "task", nil)},
+	})
+	eng, st := newEngine(t, twoBandConfig(), fn)
+	ctx := context.Background()
+
+	got, _, err := eng.Resolve(ctx, testUser, base)
+	require.NoError(t, err)
+	require.Equal(t, got.EntityID, got.Key.EntityID,
+		"the default key carries the entity")
+
+	require.NoError(t, st.SetSnooze(ctx, got.Key, base.Add(24*time.Hour)))
+	after, ok, err := eng.Resolve(ctx, testUser, base)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, "urgent", after.Source, "the source must still offer its other candidate")
+	require.NotEqual(t, got.EntityID, after.EntityID)
+}
+
+// A pick_one source is about the SET, so it defaults to source scope without
+// the operator having to say so.
+func TestDeferScope_PickOneDefaultsToSource(t *testing.T) {
+	t.Parallel()
+	src := dataentryconfig.NextActionSource{
+		Band:    "blocking",
+		Query:   "type:task",
+		Suggest: "one of these",
+		Actions: []dataentryconfig.NextActionOffer{
+			{PickOne: &dataentryconfig.NextActionPickOne{Query: "type:task", Action: "start"}},
+		},
+	}
+	require.Equal(t, dataentryconfig.DeferScopeSource, src.ResolvedDeferScope())
+
+	// ...but an explicit setting still wins.
+	src.DeferScope = dataentryconfig.DeferScopeEntity
+	require.Equal(t, dataentryconfig.DeferScopeEntity, src.ResolvedDeferScope())
+}

--- a/internal/nextaction/nextaction_test.go
+++ b/internal/nextaction/nextaction_test.go
@@ -55,6 +55,18 @@ func newEngine(t *testing.T, cfg *dataentryconfig.Config, fn nextaction.Candidat
 	return eng, st
 }
 
+// newEngineWithOptions builds an engine with a pick_one option resolver.
+func newEngineWithOptions(
+	t *testing.T, cfg *dataentryconfig.Config, fn nextaction.CandidateFunc, opt nextaction.OptionFunc,
+) *nextaction.Engine {
+	t.Helper()
+	st := memuserstate.New()
+	t.Cleanup(func() { _ = st.Close() })
+	eng, err := nextaction.New(cfg, st, fn, nextaction.WithOptions(opt))
+	require.NoError(t, err)
+	return eng
+}
+
 func twoBandConfig() *dataentryconfig.Config {
 	return &dataentryconfig.Config{
 		NextActionBands: []dataentryconfig.NextActionBand{
@@ -421,8 +433,7 @@ func TestPickOne_ResolvesOptionsForTheWinner(t *testing.T) {
 	fn, _ := staticCandidates(map[string][]*entity.Entity{
 		"urgent": {ent("T-1", "task", nil)},
 	})
-	eng, _ := newEngine(t, cfg, fn)
-	eng.WithOptions(func(_ context.Context, _ string, limit int) ([]nextaction.PickOption, error) {
+	eng := newEngineWithOptions(t, cfg, fn, func(_ context.Context, _ string, limit int) ([]nextaction.PickOption, error) {
 		require.Equal(t, dataentryconfig.DefaultPickOneLimit, limit,
 			"an unset limit must arrive as the default, not zero")
 		return []nextaction.PickOption{
@@ -454,13 +465,12 @@ func TestPickOne_DoesNotResolveForLosingBands(t *testing.T) {
 		"urgent": {ent("T-1", "task", nil)},
 		"quip":   {ent("Q-1", "quip", nil)},
 	})
-	eng, _ := newEngine(t, cfg, fn)
-
 	calls := 0
-	eng.WithOptions(func(_ context.Context, _ string, _ int) ([]nextaction.PickOption, error) {
-		calls++
-		return nil, nil
-	})
+	eng := newEngineWithOptions(t, cfg, fn,
+		func(_ context.Context, _ string, _ int) ([]nextaction.PickOption, error) {
+			calls++
+			return nil, nil
+		})
 
 	got, _, err := eng.Resolve(context.Background(), testUser, base)
 	require.NoError(t, err)
@@ -480,10 +490,10 @@ func TestPickOne_FailureDoesNotBreakTheSuggestion(t *testing.T) {
 	cfg.NextActions["urgent"] = src
 
 	fn, _ := staticCandidates(map[string][]*entity.Entity{"urgent": {ent("T-1", "task", nil)}})
-	eng, _ := newEngine(t, cfg, fn)
-	eng.WithOptions(func(_ context.Context, _ string, _ int) ([]nextaction.PickOption, error) {
-		return nil, errors.New("query exploded")
-	})
+	eng := newEngineWithOptions(t, cfg, fn,
+		func(_ context.Context, _ string, _ int) ([]nextaction.PickOption, error) {
+			return nil, errors.New("query exploded")
+		})
 
 	got, ok, err := eng.Resolve(context.Background(), testUser, base)
 	require.NoError(t, err, "an option failure must not fail the resolve")

--- a/internal/nextaction/nextaction_test.go
+++ b/internal/nextaction/nextaction_test.go
@@ -2,6 +2,7 @@ package nextaction_test
 
 import (
 	"context"
+	"errors"
 	"maps"
 	"testing"
 	"time"
@@ -402,4 +403,110 @@ func TestResolve_EntitylessSource(t *testing.T) {
 	_, ok, err = eng.Resolve(ctx, testUser, base)
 	require.NoError(t, err)
 	require.False(t, ok, "an entity-less suggestion must be snoozable")
+}
+
+// pick_one is the one affordance whose options cannot be written in config:
+// they come from a query at render time.
+func TestPickOne_ResolvesOptionsForTheWinner(t *testing.T) {
+	t.Parallel()
+	cfg := twoBandConfig()
+	src := cfg.NextActions["urgent"]
+	src.Actions = []dataentryconfig.NextActionOffer{
+		{PickOne: &dataentryconfig.NextActionPickOne{
+			Query: "type:task prop:effort=xs", Action: "start-task",
+		}},
+	}
+	cfg.NextActions["urgent"] = src
+
+	fn, _ := staticCandidates(map[string][]*entity.Entity{
+		"urgent": {ent("T-1", "task", nil)},
+	})
+	eng, _ := newEngine(t, cfg, fn)
+	eng.WithOptions(func(_ context.Context, _ string, limit int) ([]nextaction.PickOption, error) {
+		require.Equal(t, dataentryconfig.DefaultPickOneLimit, limit,
+			"an unset limit must arrive as the default, not zero")
+		return []nextaction.PickOption{
+			{EntityID: "T-9", Label: "Small one"},
+			{EntityID: "T-8", Label: "Another"},
+		}, nil
+	})
+
+	got, ok, err := eng.Resolve(context.Background(), testUser, base)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Len(t, got.PickOptions[0], 2)
+	require.Equal(t, "Small one", got.PickOptions[0][0].Label)
+}
+
+// Options are resolved for the WINNER only: doing it during candidate
+// collection would run an extra query per candidate for a list only one of
+// them ever displays.
+func TestPickOne_DoesNotResolveForLosingBands(t *testing.T) {
+	t.Parallel()
+	cfg := twoBandConfig()
+	quip := cfg.NextActions["quip"]
+	quip.Actions = []dataentryconfig.NextActionOffer{
+		{PickOne: &dataentryconfig.NextActionPickOne{Query: "type:quip", Action: "ack"}},
+	}
+	cfg.NextActions["quip"] = quip
+
+	fn, _ := staticCandidates(map[string][]*entity.Entity{
+		"urgent": {ent("T-1", "task", nil)},
+		"quip":   {ent("Q-1", "quip", nil)},
+	})
+	eng, _ := newEngine(t, cfg, fn)
+
+	calls := 0
+	eng.WithOptions(func(_ context.Context, _ string, _ int) ([]nextaction.PickOption, error) {
+		calls++
+		return nil, nil
+	})
+
+	got, _, err := eng.Resolve(context.Background(), testUser, base)
+	require.NoError(t, err)
+	require.Equal(t, "urgent", got.Source)
+	require.Zero(t, calls, "the losing band's pick_one query must never run")
+}
+
+// An advisory surface must never break the page: a failed option query costs
+// one affordance, not the suggestion.
+func TestPickOne_FailureDoesNotBreakTheSuggestion(t *testing.T) {
+	t.Parallel()
+	cfg := twoBandConfig()
+	src := cfg.NextActions["urgent"]
+	src.Actions = []dataentryconfig.NextActionOffer{
+		{PickOne: &dataentryconfig.NextActionPickOne{Query: "type:task", Action: "start-task"}},
+	}
+	cfg.NextActions["urgent"] = src
+
+	fn, _ := staticCandidates(map[string][]*entity.Entity{"urgent": {ent("T-1", "task", nil)}})
+	eng, _ := newEngine(t, cfg, fn)
+	eng.WithOptions(func(_ context.Context, _ string, _ int) ([]nextaction.PickOption, error) {
+		return nil, errors.New("query exploded")
+	})
+
+	got, ok, err := eng.Resolve(context.Background(), testUser, base)
+	require.NoError(t, err, "an option failure must not fail the resolve")
+	require.True(t, ok)
+	require.Empty(t, got.PickOptions)
+	require.Equal(t, "urgent", got.Source)
+}
+
+// Not wiring the resolver is a valid deployment state, not an error.
+func TestPickOne_NoResolverIsHarmless(t *testing.T) {
+	t.Parallel()
+	cfg := twoBandConfig()
+	src := cfg.NextActions["urgent"]
+	src.Actions = []dataentryconfig.NextActionOffer{
+		{PickOne: &dataentryconfig.NextActionPickOne{Query: "type:task", Action: "start-task"}},
+	}
+	cfg.NextActions["urgent"] = src
+
+	fn, _ := staticCandidates(map[string][]*entity.Entity{"urgent": {ent("T-1", "task", nil)}})
+	eng, _ := newEngine(t, cfg, fn)
+
+	got, ok, err := eng.Resolve(context.Background(), testUser, base)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Empty(t, got.PickOptions)
 }

--- a/internal/nextaction/nextaction_test.go
+++ b/internal/nextaction/nextaction_test.go
@@ -1,0 +1,405 @@
+package nextaction_test
+
+import (
+	"context"
+	"maps"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/Sourcehaven-BV/rela/internal/dataentryconfig"
+	"github.com/Sourcehaven-BV/rela/internal/entity"
+	"github.com/Sourcehaven-BV/rela/internal/nextaction"
+	"github.com/Sourcehaven-BV/rela/internal/userstate"
+	"github.com/Sourcehaven-BV/rela/internal/userstate/memuserstate"
+)
+
+var base = time.Date(2026, 3, 1, 12, 0, 0, 0, time.UTC)
+
+const testUser = "alice"
+
+// ent builds a candidate entity with the given properties.
+func ent(id, typ string, props map[string]any) *entity.Entity {
+	e := entity.New(id, typ)
+	maps.Copy(e.Properties, props)
+	return e
+}
+
+// staticCandidates returns a CandidateFunc serving a fixed set per source id,
+// plus a counter recording which sources were actually queried — that counter
+// is how the short-circuit test proves lower bands were never touched.
+func staticCandidates(
+	bySource map[string][]*entity.Entity,
+) (fn nextaction.CandidateFunc, queriedSuggests *[]string) {
+	var queried []string
+	fn = func(_ context.Context, src dataentryconfig.NextActionSource) ([]nextaction.Candidate, error) {
+		// Identify the source by its Suggest, which the fixtures make unique.
+		queried = append(queried, src.Suggest)
+		var out []nextaction.Candidate
+		for _, e := range bySource[src.Suggest] {
+			out = append(out, nextaction.Candidate{Entity: e})
+		}
+		return out, nil
+	}
+	return fn, &queried
+}
+
+func newEngine(t *testing.T, cfg *dataentryconfig.Config, fn nextaction.CandidateFunc) (*nextaction.Engine, userstate.Store) {
+	t.Helper()
+	st := memuserstate.New()
+	t.Cleanup(func() { _ = st.Close() })
+	eng, err := nextaction.New(cfg, st, fn)
+	require.NoError(t, err)
+	return eng, st
+}
+
+func twoBandConfig() *dataentryconfig.Config {
+	return &dataentryconfig.Config{
+		NextActionBands: []dataentryconfig.NextActionBand{
+			{ID: "blocking"},
+			{ID: "ambient"},
+		},
+		NextActions: map[string]dataentryconfig.NextActionSource{
+			"urgent": {Band: "blocking", Query: "type:task", Suggest: "urgent"},
+			"quip":   {Band: "ambient", Query: "type:quip", Suggest: "quip"},
+		},
+	}
+}
+
+func TestNew_RejectsNilCollaborators(t *testing.T) {
+	t.Parallel()
+	cfg := twoBandConfig()
+	fn, _ := staticCandidates(nil)
+	st := memuserstate.New()
+	t.Cleanup(func() { _ = st.Close() })
+
+	_, err := nextaction.New(nil, st, fn)
+	require.Error(t, err, "nil config must be rejected")
+
+	_, err = nextaction.New(cfg, nil, fn)
+	require.Error(t, err, "a nil userstate store would silently stop honoring snoozes")
+
+	_, err = nextaction.New(cfg, st, nil)
+	require.Error(t, err, "nil candidate func must be rejected")
+}
+
+// The core ordering guarantee: a higher band wins even when a lower one also
+// has something to say.
+func TestResolve_HigherBandWins(t *testing.T) {
+	t.Parallel()
+	fn, _ := staticCandidates(map[string][]*entity.Entity{
+		"urgent": {ent("T-1", "task", nil)},
+		"quip":   {ent("Q-1", "quip", nil)},
+	})
+	eng, _ := newEngine(t, twoBandConfig(), fn)
+
+	got, ok, err := eng.Resolve(context.Background(), testUser, base)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, "urgent", got.Source)
+	require.Equal(t, "blocking", got.Band)
+}
+
+// Short-circuiting is what keeps a page to one or two queries. Asserting the
+// lower band was never QUERIED (not merely that it lost) is the difference
+// between the optimisation existing and not.
+func TestResolve_ShortCircuitsLowerBands(t *testing.T) {
+	t.Parallel()
+	fn, queried := staticCandidates(map[string][]*entity.Entity{
+		"urgent": {ent("T-1", "task", nil)},
+		"quip":   {ent("Q-1", "quip", nil)},
+	})
+	eng, _ := newEngine(t, twoBandConfig(), fn)
+
+	_, ok, err := eng.Resolve(context.Background(), testUser, base)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, []string{"urgent"}, *queried,
+		"the ambient source must not be queried once a higher band hits")
+}
+
+func TestResolve_FallsThroughToLowerBand(t *testing.T) {
+	t.Parallel()
+	fn, queried := staticCandidates(map[string][]*entity.Entity{
+		"quip": {ent("Q-1", "quip", nil)},
+	})
+	eng, _ := newEngine(t, twoBandConfig(), fn)
+
+	got, ok, err := eng.Resolve(context.Background(), testUser, base)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, "quip", got.Source)
+	require.Equal(t, []string{"urgent", "quip"}, *queried,
+		"an empty high band must fall through, having queried both")
+}
+
+func TestResolve_NothingOwed(t *testing.T) {
+	t.Parallel()
+	fn, _ := staticCandidates(nil)
+	eng, _ := newEngine(t, twoBandConfig(), fn)
+
+	_, ok, err := eng.Resolve(context.Background(), testUser, base)
+	require.NoError(t, err)
+	require.False(t, ok, "no candidates anywhere means no suggestion, not an error")
+}
+
+func TestResolve_MutedSourceIsSkipped(t *testing.T) {
+	t.Parallel()
+	fn, _ := staticCandidates(map[string][]*entity.Entity{
+		"urgent": {ent("T-1", "task", nil)},
+		"quip":   {ent("Q-1", "quip", nil)},
+	})
+	eng, st := newEngine(t, twoBandConfig(), fn)
+	require.NoError(t, st.SetMuted(context.Background(), testUser, "urgent", true))
+
+	got, ok, err := eng.Resolve(context.Background(), testUser, base)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, "quip", got.Source, "a muted source must not win its band")
+}
+
+func TestResolve_SnoozeSuppresses(t *testing.T) {
+	t.Parallel()
+	fn, _ := staticCandidates(map[string][]*entity.Entity{
+		"urgent": {ent("T-1", "task", nil)},
+		"quip":   {ent("Q-1", "quip", nil)},
+	})
+	eng, st := newEngine(t, twoBandConfig(), fn)
+	require.NoError(t, st.SetSnooze(context.Background(),
+		userstate.Key{User: testUser, Source: "urgent", EntityID: "T-1"}, base.Add(24*time.Hour)))
+
+	got, ok, err := eng.Resolve(context.Background(), testUser, base)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, "quip", got.Source)
+
+	// Once the snooze lapses the higher band takes over again.
+	got, ok, err = eng.Resolve(context.Background(), testUser, base.Add(25*time.Hour))
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, "urgent", got.Source, "an expired snooze must stop suppressing")
+}
+
+// Cooldown is what stops a high band re-showing the same hint on every page
+// load — without it, short-circuiting would pin the top suggestion forever.
+func TestResolve_CooldownSuppressesAfterShown(t *testing.T) {
+	t.Parallel()
+	cfg := twoBandConfig()
+	src := cfg.NextActions["urgent"]
+	src.Cooldown = "3d"
+	cfg.NextActions["urgent"] = src
+
+	fn, _ := staticCandidates(map[string][]*entity.Entity{
+		"urgent": {ent("T-1", "task", nil)},
+		"quip":   {ent("Q-1", "quip", nil)},
+	})
+	eng, _ := newEngine(t, cfg, fn)
+	ctx := context.Background()
+
+	got, ok, err := eng.Resolve(ctx, testUser, base)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, "urgent", got.Source)
+	require.NoError(t, eng.MarkShown(ctx, got, base))
+
+	// Within the cooldown the lower band gets its turn.
+	got, ok, err = eng.Resolve(ctx, testUser, base.Add(time.Hour))
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, "quip", got.Source, "a suggestion inside its cooldown must not re-show")
+
+	// After it, the high band returns.
+	got, ok, err = eng.Resolve(ctx, testUser, base.Add(4*24*time.Hour))
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, "urgent", got.Source)
+}
+
+// A source with no cooldown must still get one: DefaultCooldown exists so an
+// operator omission cannot produce a nag.
+func TestResolve_DefaultCooldownApplies(t *testing.T) {
+	t.Parallel()
+	fn, _ := staticCandidates(map[string][]*entity.Entity{
+		"urgent": {ent("T-1", "task", nil)},
+	})
+	eng, _ := newEngine(t, twoBandConfig(), fn)
+	ctx := context.Background()
+
+	got, _, err := eng.Resolve(ctx, testUser, base)
+	require.NoError(t, err)
+	require.NoError(t, eng.MarkShown(ctx, got, base))
+
+	_, ok, err := eng.Resolve(ctx, testUser, base.Add(time.Hour))
+	require.NoError(t, err)
+	require.False(t, ok, "an unconfigured cooldown must still suppress, not default to zero")
+}
+
+// Resolve must not start the clock: only MarkShown does.
+func TestResolve_DoesNotMarkShown(t *testing.T) {
+	t.Parallel()
+	fn, _ := staticCandidates(map[string][]*entity.Entity{
+		"urgent": {ent("T-1", "task", nil)},
+	})
+	eng, _ := newEngine(t, twoBandConfig(), fn)
+	ctx := context.Background()
+
+	_, _, err := eng.Resolve(ctx, testUser, base)
+	require.NoError(t, err)
+
+	got, ok, err := eng.Resolve(ctx, testUser, base.Add(time.Minute))
+	require.NoError(t, err)
+	require.True(t, ok, "resolving twice without MarkShown must still yield a suggestion")
+	require.Equal(t, "urgent", got.Source)
+}
+
+func TestInterpolation(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		suggest string
+		props   map[string]any
+		want    string
+	}{
+		{
+			name:    "substitutes a property",
+			suggest: "{title} is waiting",
+			props:   map[string]any{"title": "Draft the SOW"},
+			want:    "Draft the SOW is waiting",
+		},
+		{
+			name:    "substitutes several",
+			suggest: "{title} since {started_on}",
+			props:   map[string]any{"title": "SOW", "started_on": "2026-02-01"},
+			want:    "SOW since 2026-02-01",
+		},
+		{
+			name:    "id is available",
+			suggest: "look at {id}",
+			want:    "look at T-1",
+		},
+		{
+			// A config typo must stay visibly a typo. Emptying it would
+			// render a sentence with a hole and read as a product bug.
+			name:    "unknown placeholder is left verbatim",
+			suggest: "{nope} matters",
+			want:    "{nope} matters",
+		},
+		{
+			name:    "no placeholders",
+			suggest: "just text",
+			want:    "just text",
+		},
+		{
+			name:    "unclosed brace is left alone",
+			suggest: "{unclosed",
+			want:    "{unclosed",
+		},
+		{
+			name:    "non-string values render",
+			suggest: "{count} left",
+			props:   map[string]any{"count": 3},
+			want:    "3 left",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			cfg := twoBandConfig()
+			src := cfg.NextActions["urgent"]
+			src.Suggest = tc.suggest
+			cfg.NextActions["urgent"] = src
+
+			fn := func(_ context.Context, s dataentryconfig.NextActionSource) ([]nextaction.Candidate, error) {
+				if s.Suggest != tc.suggest {
+					return nil, nil
+				}
+				return []nextaction.Candidate{{Entity: ent("T-1", "task", tc.props)}}, nil
+			}
+			eng, _ := newEngine(t, cfg, fn)
+
+			got, ok, err := eng.Resolve(context.Background(), testUser, base)
+			require.NoError(t, err)
+			require.True(t, ok)
+			require.Equal(t, tc.want, got.Message)
+		})
+	}
+}
+
+// Stability is what stops a refresh re-rolling the hint; per-day variation is
+// what stops it being frozen forever.
+func TestPick_StablePerUserPerDay(t *testing.T) {
+	t.Parallel()
+	many := []*entity.Entity{
+		ent("T-1", "task", nil), ent("T-2", "task", nil), ent("T-3", "task", nil),
+		ent("T-4", "task", nil), ent("T-5", "task", nil),
+	}
+	fn, _ := staticCandidates(map[string][]*entity.Entity{"urgent": many})
+	eng, _ := newEngine(t, twoBandConfig(), fn)
+	ctx := context.Background()
+
+	first, _, err := eng.Resolve(ctx, testUser, base)
+	require.NoError(t, err)
+	for range 5 {
+		again, _, rerr := eng.Resolve(ctx, testUser, base.Add(time.Minute))
+		require.NoError(t, rerr)
+		require.Equal(t, first.EntityID, again.EntityID,
+			"a refresh on the same day must not re-roll the suggestion")
+	}
+
+	// Different users may differ; over five candidates at least one of a
+	// handful of users should land elsewhere.
+	differs := false
+	for _, u := range []string{"bob", "carol", "dave", "erin"} {
+		other, _, oerr := eng.Resolve(ctx, u, base)
+		require.NoError(t, oerr)
+		if other.EntityID != first.EntityID {
+			differs = true
+			break
+		}
+	}
+	require.True(t, differs, "the pick should vary across users, not be a constant")
+}
+
+func TestResolve_CandidateCapIsApplied(t *testing.T) {
+	t.Parallel()
+	var many []*entity.Entity
+	for i := range 100 {
+		many = append(many, ent("T-"+string(rune('a'+i%26))+string(rune('a'+i/26)), "task", nil))
+	}
+	fn, _ := staticCandidates(map[string][]*entity.Entity{"urgent": many})
+	eng, _ := newEngine(t, twoBandConfig(), fn)
+
+	// The cap must not turn "many candidates" into "no suggestion".
+	_, ok, err := eng.Resolve(context.Background(), testUser, base)
+	require.NoError(t, err)
+	require.True(t, ok)
+}
+
+// An entity-less (count) source keys on the source alone, so its snooze and
+// cooldown still work.
+func TestResolve_EntitylessSource(t *testing.T) {
+	t.Parallel()
+	cfg := &dataentryconfig.Config{
+		NextActionBands: []dataentryconfig.NextActionBand{{ID: "blocking"}},
+		NextActions: map[string]dataentryconfig.NextActionSource{
+			"first-run": {Band: "blocking", Count: "client == 0", Suggest: "Start with a client?"},
+		},
+	}
+	fn := func(_ context.Context, _ dataentryconfig.NextActionSource) ([]nextaction.Candidate, error) {
+		return []nextaction.Candidate{{Entity: nil}}, nil
+	}
+	eng, st := newEngine(t, cfg, fn)
+	ctx := context.Background()
+
+	got, ok, err := eng.Resolve(ctx, testUser, base)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Empty(t, got.EntityID, "a count source has no entity")
+	require.Equal(t, "Start with a client?", got.Message)
+
+	require.NoError(t, st.SetSnooze(ctx, got.Key, base.Add(24*time.Hour)))
+	_, ok, err = eng.Resolve(ctx, testUser, base)
+	require.NoError(t, err)
+	require.False(t, ok, "an entity-less suggestion must be snoozable")
+}

--- a/internal/store/pgstore/migrations/0009_next_action_state.sql
+++ b/internal/store/pgstore/migrations/0009_next_action_state.sql
@@ -1,0 +1,70 @@
+-- pgstore schema, version 9: next-action per-user state (TKT-CXD0A4).
+--
+-- Snoozes, muted sources and last-shown timestamps for the advisory
+-- next-action layer. Three tables rather than one JSON document (the shape the
+-- filesystem backend uses) because this backend exists specifically for the
+-- MULTI-PROCESS deployment: a document would make every write a
+-- read-modify-write of the whole thing, so two servers would silently clobber
+-- each other's snoozes. Row-level upserts make concurrent writers safe without
+-- coordination.
+--
+-- NOT graph content, deliberately. A snooze is a fact about one person's
+-- relationship to a suggestion at a moment, not about the entity — storing it
+-- as an entity would make it visible to everyone, audited forever in the
+-- append-only log, and (worse) fed through the version-capture sweep on every
+-- render. These tables are therefore outside the entity/relation model, carry
+-- no versioning, and are never touched by the sweep.
+--
+-- The state is DISPOSABLE: losing it costs a user a repeated suggestion, not
+-- data. That is why there is no foreign key to entities and no cascade —
+-- deleting an entity leaves an orphaned snooze row that simply never matches
+-- again, and Prune reclaims it. An FK would make an ordinary entity delete
+-- fail on a stale suggestion record, which is a far worse trade.
+
+-- One row per (user, suggestion). The suggestion key is
+-- (source, entity_id, variant); entity_id is '' for a count-based source with
+-- no entity, and variant is '' when the source declares no key_props.
+--
+-- Empty string rather than NULL for the optional parts so the primary key
+-- stays simple: NULLs are not comparable, so a NULL entity_id would let the
+-- same logical key be inserted repeatedly.
+CREATE TABLE next_action_snoozes (
+    user_id    TEXT        NOT NULL,
+    source     TEXT        NOT NULL,
+    entity_id  TEXT        NOT NULL DEFAULT '',
+    variant    TEXT        NOT NULL DEFAULT '',
+    until      TIMESTAMPTZ NOT NULL,
+    PRIMARY KEY (user_id, source, entity_id, variant)
+);
+
+-- Prune deletes by deadline across all users, so the index is on `until`
+-- alone; per-user reads are already served by the primary key.
+CREATE INDEX next_action_snoozes_until_idx ON next_action_snoozes (until);
+
+-- One row per (user, suggestion) recording when it was last surfaced. Drives
+-- cooldown. Separate from snoozes because the lifecycles differ: a snooze is
+-- an explicit user choice with a deadline, a shown-record is telemetry that
+-- Prune reclaims on age.
+CREATE TABLE next_action_shown (
+    user_id   TEXT        NOT NULL,
+    source    TEXT        NOT NULL,
+    entity_id TEXT        NOT NULL DEFAULT '',
+    variant   TEXT        NOT NULL DEFAULT '',
+    shown_at  TIMESTAMPTZ NOT NULL,
+    PRIMARY KEY (user_id, source, entity_id, variant)
+);
+
+CREATE INDEX next_action_shown_at_idx ON next_action_shown (shown_at);
+
+-- Muted sources, per user. Keyed on the SOURCE, never an entity: a per-entity
+-- mute is invisible state nobody can find later, whereas the handful of
+-- configured sources make "what have I turned off?" a short, reversible list.
+--
+-- No expiry column: a mute is a standing choice, and Prune deliberately never
+-- touches this table. A housekeeping pass that silently un-muted a source
+-- would surface as suggestions the user switched off coming back.
+CREATE TABLE next_action_mutes (
+    user_id TEXT NOT NULL,
+    source  TEXT NOT NULL,
+    PRIMARY KEY (user_id, source)
+);

--- a/internal/store/pgstore/pgstore.go
+++ b/internal/store/pgstore/pgstore.go
@@ -85,8 +85,15 @@ type DBTX interface {
 // not a separate service — and the whole point is the backend-native
 // projection, which cannot be delegated elsewhere.
 //
-//plimsoll:max-exported-methods=34
-//plimsoll:max-methods=42
+// [Store.UserState] (TKT-CXD0A4) is +1 again, and is deliberately the SAME
+// shape as [Store.VersionStore]: a one-line factory handing the shared pool to
+// a separate type, called once by the composition root. The subsystem's API
+// lives on [UserStateStore]; only the factory is here, so the count grows by
+// one per subsystem rather than by its surface. Adding UserStateStore's nine
+// methods to *Store is what the paragraph above forbids.
+//
+//plimsoll:max-exported-methods=35
+//plimsoll:max-methods=43
 type Store struct {
 	db        DBTX
 	observers []store.EntityObserver // notified synchronously after committed entity writes

--- a/internal/store/pgstore/status_test.go
+++ b/internal/store/pgstore/status_test.go
@@ -33,8 +33,8 @@ func TestStatusFreshSchema(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 0, current, "un-migrated schema is version 0")
 	// target is the highest embedded migration version — bump this when a new
-	// migration is added (0008_state_kv.sql took it from 7 to 8).
-	require.Equal(t, 8, target, "binary embeds migrations through 0008")
+	// migration is added (0009_next_action_state.sql took it from 8 to 9).
+	require.Equal(t, 9, target, "binary embeds migrations through 0009")
 }
 
 // TestStatusAfterMigrate verifies Status reports current==target once Migrate

--- a/internal/store/pgstore/userstate.go
+++ b/internal/store/pgstore/userstate.go
@@ -1,0 +1,235 @@
+package pgstore
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/Sourcehaven-BV/rela/internal/userstate"
+)
+
+// UserStateStore is the PostgreSQL [userstate.Store]: next-action snoozes,
+// mutes and cooldown records for the multi-process deployment.
+//
+// # Why this backend exists
+//
+// The filesystem backend keeps all of a deployment's state in one JSON
+// document, which makes every write a read-modify-write of the whole thing.
+// Within one process a mutex serializes that; across processes it is
+// last-writer-wins, so two servers sharing a project directory silently lose
+// each other's snoozes. Here each row is written independently, so concurrent
+// writers need no coordination at all.
+//
+// # Not graph content
+//
+// These tables sit outside the entity/relation model on purpose: a snooze is
+// a fact about one person's relationship to a suggestion, not about the
+// entity. Keeping it out of the graph is what stops the audit log and the
+// version-capture sweep filling with render-time noise. See
+// migrations/0008_next_action_state.sql for the full rationale.
+type UserStateStore struct {
+	db DBTX
+	// closed is set by Close. Reads and writes after that return ErrClosed
+	// rather than hitting a pool the owner believes it has released.
+	closed bool
+}
+
+// NewUserStateStore returns a PostgreSQL-backed [userstate.Store] over an
+// injected pool.
+//
+// Takes a DBTX rather than a DSN for the same reason [New] does: appbuild
+// builds ONE pool and shares it between the store, the search backend and
+// this. It does not own the pool and does not close it — Close only marks
+// this handle unusable.
+func NewUserStateStore(db DBTX) (*UserStateStore, error) {
+	if db == nil {
+		return nil, errors.New("pgstore: NewUserStateStore: db must be non-nil")
+	}
+	return &UserStateStore{db: db}, nil
+}
+
+// compile-time check
+var _ userstate.Store = (*UserStateStore)(nil)
+
+func (s *UserStateStore) SnoozedUntil(
+	ctx context.Context, key userstate.Key, now time.Time,
+) (time.Time, bool, error) {
+	if s.closed {
+		return time.Time{}, false, userstate.ErrClosed
+	}
+	// Expiry is judged in the QUERY (`until > now`) rather than by comparing
+	// after the read, so correctness never depends on Prune having run and a
+	// stale row is simply invisible. `>` not `>=`: a snooze "until T" is over
+	// at T, matching how a deadline reads to a human.
+	const q = `
+		SELECT until FROM next_action_snoozes
+		WHERE user_id = $1 AND source = $2 AND entity_id = $3 AND variant = $4
+		  AND until > $5`
+	var until time.Time
+	err := s.db.QueryRow(ctx, q, key.User, key.Source, key.EntityID, key.Variant, now).Scan(&until)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return time.Time{}, false, nil
+		}
+		return time.Time{}, false, fmt.Errorf("pgstore: snooze lookup: %w", err)
+	}
+	return until, true, nil
+}
+
+func (s *UserStateStore) SetSnooze(ctx context.Context, key userstate.Key, until time.Time) error {
+	if s.closed {
+		return userstate.ErrClosed
+	}
+	// Upsert, not insert: re-snoozing REPLACES rather than stacking, and a
+	// shorter re-snooze must win too — the user said "remind me sooner".
+	const q = `
+		INSERT INTO next_action_snoozes (user_id, source, entity_id, variant, until)
+		VALUES ($1, $2, $3, $4, $5)
+		ON CONFLICT (user_id, source, entity_id, variant)
+		DO UPDATE SET until = EXCLUDED.until`
+	if _, err := s.db.Exec(ctx, q, key.User, key.Source, key.EntityID, key.Variant, until); err != nil {
+		return fmt.Errorf("pgstore: set snooze: %w", err)
+	}
+	return nil
+}
+
+func (s *UserStateStore) Muted(ctx context.Context, user, source string) (bool, error) {
+	if s.closed {
+		return false, userstate.ErrClosed
+	}
+	const q = `SELECT EXISTS (SELECT 1 FROM next_action_mutes WHERE user_id = $1 AND source = $2)`
+	var muted bool
+	if err := s.db.QueryRow(ctx, q, user, source).Scan(&muted); err != nil {
+		return false, fmt.Errorf("pgstore: mute lookup: %w", err)
+	}
+	return muted, nil
+}
+
+func (s *UserStateStore) SetMuted(ctx context.Context, user, source string, muted bool) error {
+	if s.closed {
+		return userstate.ErrClosed
+	}
+	if !muted {
+		const del = `DELETE FROM next_action_mutes WHERE user_id = $1 AND source = $2`
+		if _, err := s.db.Exec(ctx, del, user, source); err != nil {
+			return fmt.Errorf("pgstore: unmute: %w", err)
+		}
+		return nil
+	}
+	// DO NOTHING keeps muting idempotent: the mute list is rendered to the
+	// user as "what have I turned off?", so a duplicate row would show twice.
+	const ins = `
+		INSERT INTO next_action_mutes (user_id, source) VALUES ($1, $2)
+		ON CONFLICT (user_id, source) DO NOTHING`
+	if _, err := s.db.Exec(ctx, ins, user, source); err != nil {
+		return fmt.Errorf("pgstore: mute: %w", err)
+	}
+	return nil
+}
+
+func (s *UserStateStore) MutedSources(ctx context.Context, user string) ([]string, error) {
+	if s.closed {
+		return nil, userstate.ErrClosed
+	}
+	const q = `SELECT source FROM next_action_mutes WHERE user_id = $1 ORDER BY source`
+	rows, err := s.db.Query(ctx, q, user)
+	if err != nil {
+		return nil, fmt.Errorf("pgstore: muted sources: %w", err)
+	}
+	defer rows.Close()
+
+	var out []string
+	for rows.Next() {
+		var src string
+		if err := rows.Scan(&src); err != nil {
+			return nil, fmt.Errorf("pgstore: muted sources scan: %w", err)
+		}
+		out = append(out, src)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("pgstore: muted sources: %w", err)
+	}
+	return out, nil
+}
+
+func (s *UserStateStore) LastShown(ctx context.Context, key userstate.Key) (time.Time, bool, error) {
+	if s.closed {
+		return time.Time{}, false, userstate.ErrClosed
+	}
+	const q = `
+		SELECT shown_at FROM next_action_shown
+		WHERE user_id = $1 AND source = $2 AND entity_id = $3 AND variant = $4`
+	var at time.Time
+	err := s.db.QueryRow(ctx, q, key.User, key.Source, key.EntityID, key.Variant).Scan(&at)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return time.Time{}, false, nil
+		}
+		return time.Time{}, false, fmt.Errorf("pgstore: last-shown lookup: %w", err)
+	}
+	return at, true, nil
+}
+
+func (s *UserStateStore) MarkShown(ctx context.Context, key userstate.Key, at time.Time) error {
+	if s.closed {
+		return userstate.ErrClosed
+	}
+	const q = `
+		INSERT INTO next_action_shown (user_id, source, entity_id, variant, shown_at)
+		VALUES ($1, $2, $3, $4, $5)
+		ON CONFLICT (user_id, source, entity_id, variant)
+		DO UPDATE SET shown_at = EXCLUDED.shown_at`
+	if _, err := s.db.Exec(ctx, q, key.User, key.Source, key.EntityID, key.Variant, at); err != nil {
+		return fmt.Errorf("pgstore: mark shown: %w", err)
+	}
+	return nil
+}
+
+func (s *UserStateStore) Prune(
+	ctx context.Context, now time.Time, keepShown time.Duration,
+) (int, error) {
+	if s.closed {
+		return 0, userstate.ErrClosed
+	}
+	// Two statements rather than one CTE: they touch different tables with no
+	// shared predicate, so combining them would only obscure which delete
+	// contributed what. Mutes are deliberately untouched — they are a standing
+	// choice with no expiry, and silently un-muting a source would surface as
+	// suggestions the user switched off coming back.
+	const delSnoozes = `DELETE FROM next_action_snoozes WHERE until <= $1`
+	tag, err := s.db.Exec(ctx, delSnoozes, now)
+	if err != nil {
+		return 0, fmt.Errorf("pgstore: prune snoozes: %w", err)
+	}
+	removed := int(tag.RowsAffected())
+
+	const delShown = `DELETE FROM next_action_shown WHERE shown_at < $1`
+	tag, err = s.db.Exec(ctx, delShown, now.Add(-keepShown))
+	if err != nil {
+		return removed, fmt.Errorf("pgstore: prune shown: %w", err)
+	}
+	return removed + int(tag.RowsAffected()), nil
+}
+
+// Close marks this handle unusable. It does NOT close the pool: appbuild owns
+// that and shares it with the store and the search backend, so closing it here
+// would tear down two unrelated subsystems.
+func (s *UserStateStore) Close() error {
+	s.closed = true
+	return nil
+}
+
+// UserState returns a next-action state backend sharing this store's
+// connection handle.
+//
+// Mirrors [Store.VersionStore]: the composition root calls this in the
+// postgres recipe to obtain a service it injects, and it reads the same pool
+// the store queries, so a second pool is never opened for three small tables.
+// Returns a fresh lightweight wrapper each call. The returned store does not
+// own the pool — see [UserStateStore.Close].
+func (s *Store) UserState() (userstate.Store, error) {
+	return NewUserStateStore(s.db)
+}

--- a/internal/store/pgstore/userstate_test.go
+++ b/internal/store/pgstore/userstate_test.go
@@ -1,0 +1,115 @@
+package pgstore_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/Sourcehaven-BV/rela/internal/store/pgstore"
+	"github.com/Sourcehaven-BV/rela/internal/userstate"
+	"github.com/Sourcehaven-BV/rela/internal/userstate/userstatetest"
+)
+
+var userStateBase = time.Date(2026, 3, 1, 12, 0, 0, 0, time.UTC)
+
+// newUserStateStore returns a store over a freshly migrated, schema-isolated
+// pool. DB-gated like the rest of this package: without
+// RELA_TEST_DATABASE_URL the harness skips (or fails, under
+// RELA_TEST_DATABASE_REQUIRED).
+func newUserStateStore(t *testing.T) *pgstore.UserStateStore {
+	t.Helper()
+	pool := newScopedPool(t)
+	require.NoError(t, pgstore.Migrate(context.Background(), pool))
+	s, err := pgstore.NewUserStateStore(pool)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = s.Close() })
+	return s
+}
+
+// TestUserStateConformance runs the shared contract. Three backends without
+// one are three subtly different behaviors — and the SQL implementation is
+// where the expiry boundary and replace-don't-stack rules are easiest to get
+// plausibly-but-differently wrong.
+func TestUserStateConformance(t *testing.T) {
+	userstatetest.RunAll(t, func(t *testing.T) userstate.Store {
+		t.Helper()
+		return newUserStateStore(t)
+	})
+}
+
+func TestNewUserStateStore_RejectsNilDB(t *testing.T) {
+	t.Parallel()
+	_, err := pgstore.NewUserStateStore(nil)
+	require.Error(t, err)
+}
+
+// The reason this backend exists: two processes sharing one database must not
+// clobber each other. Two independent handles over the same pool stand in for
+// two servers — the filesystem backend fails this by design, because its
+// whole-document read-modify-write is last-writer-wins.
+func TestUserState_ConcurrentHandlesDoNotClobber(t *testing.T) {
+	pool := newScopedPool(t)
+	require.NoError(t, pgstore.Migrate(context.Background(), pool))
+	ctx := context.Background()
+
+	first, err := pgstore.NewUserStateStore(pool)
+	require.NoError(t, err)
+	second, err := pgstore.NewUserStateStore(pool)
+	require.NoError(t, err)
+
+	aliceKey := userstate.Key{User: "alice", Source: "stale", EntityID: "T-1"}
+	bobKey := userstate.Key{User: "bob", Source: "stale", EntityID: "T-2"}
+
+	require.NoError(t, first.SetSnooze(ctx, aliceKey, userStateBase.Add(24*time.Hour)))
+	require.NoError(t, second.SetSnooze(ctx, bobKey, userStateBase.Add(24*time.Hour)))
+
+	// Each write must be visible through the OTHER handle, and neither may
+	// have dropped the other's row.
+	_, ok, err := second.SnoozedUntil(ctx, aliceKey, userStateBase)
+	require.NoError(t, err)
+	require.True(t, ok, "the second handle must see the first's write")
+
+	_, ok, err = first.SnoozedUntil(ctx, bobKey, userStateBase)
+	require.NoError(t, err)
+	require.True(t, ok, "the first handle must see the second's write")
+}
+
+// Closing this handle must not tear down the shared pool: appbuild owns it and
+// hands the same one to the store and the search backend.
+func TestUserState_CloseLeavesPoolUsable(t *testing.T) {
+	pool := newScopedPool(t)
+	require.NoError(t, pgstore.Migrate(context.Background(), pool))
+	ctx := context.Background()
+
+	closing, err := pgstore.NewUserStateStore(pool)
+	require.NoError(t, err)
+	require.NoError(t, closing.Close())
+
+	survivor, err := pgstore.NewUserStateStore(pool)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = survivor.Close() })
+
+	key := userstate.Key{User: "alice", Source: "stale"}
+	require.NoError(t, survivor.SetSnooze(ctx, key, userStateBase.Add(time.Hour)),
+		"closing one handle must not close the shared pool")
+}
+
+// A count-based source has no entity, and a source without key_props has no
+// variant. Both land as empty strings rather than NULL so the primary key
+// stays comparable — NULLs would let the same logical key insert repeatedly.
+func TestUserState_EmptyKeyPartsAreStable(t *testing.T) {
+	s := newUserStateStore(t)
+	ctx := context.Background()
+	key := userstate.Key{User: "alice", Source: "first-run"}
+
+	require.NoError(t, s.SetSnooze(ctx, key, userStateBase.Add(time.Hour)))
+	require.NoError(t, s.SetSnooze(ctx, key, userStateBase.Add(48*time.Hour)))
+
+	until, ok, err := s.SnoozedUntil(ctx, key, userStateBase)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.True(t, until.Equal(userStateBase.Add(48*time.Hour)),
+		"the second write must UPDATE the first, not insert a duplicate row")
+}

--- a/internal/userstate/kvuserstate/kv.go
+++ b/internal/userstate/kvuserstate/kv.go
@@ -1,0 +1,327 @@
+// Package kvuserstate is the durable [userstate.Store] backend, persisting
+// next-action state through a [state.KV].
+//
+// # Why KV rather than a bespoke file
+//
+// state.KV is already the project's home for "state that persists between
+// runs but isn't part of the project's tracked source" — the scheduler's
+// last-run timestamps and the document render cache live there. Snoozes,
+// mutes and cooldowns are exactly that, so they get the same seam (and the
+// same `.rela/` gitignore, the same swap boundary if an operator ever plugs
+// in Redis) rather than a second persistence mechanism beside it.
+//
+// # One document, read-modify-write under a mutex
+//
+// All of a deployment's next-action state lives in a single JSON value. That
+// is deliberate for the data's shape: it is small (a handful of rows per
+// user), read on every page render, and written only on explicit user
+// feedback. Per-key entries would turn one render into N KV reads.
+//
+// The cost is that concurrent writers must serialize, which the mutex does
+// WITHIN a process. Across processes this backend is last-writer-wins: two
+// servers sharing a project directory can lose a snooze. That is acceptable
+// for disposable state and is why the postgres backend exists for the
+// multi-process deployment — it is stated here so nobody discovers it as a
+// surprise.
+package kvuserstate
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"maps"
+	"os"
+	"slices"
+	"sync"
+	"time"
+
+	"github.com/Sourcehaven-BV/rela/internal/state"
+	"github.com/Sourcehaven-BV/rela/internal/userstate"
+)
+
+// StateKey is where the document lives inside the KV.
+const StateKey = "next-action-state.json"
+
+// Store is a durable [userstate.Store] over a [state.KV].
+type Store struct {
+	kv state.KV
+
+	mu     sync.Mutex
+	closed bool
+	// doc is the in-memory copy, loaded lazily on first use. Held so a page
+	// render costs no KV read once warm; writes update it and flush.
+	doc *document
+}
+
+// document is the serialized shape. Maps are keyed by the composite key
+// string so the JSON stays flat and diffable.
+type document struct {
+	// Snoozes maps a suggestion key to its deadline.
+	Snoozes map[string]time.Time `json:"snoozes,omitempty"`
+	// Shown maps a suggestion key to when it was last surfaced.
+	Shown map[string]time.Time `json:"shown,omitempty"`
+	// Muted maps a user to their muted source ids.
+	Muted map[string][]string `json:"muted,omitempty"`
+}
+
+func newDocument() *document {
+	return &document{
+		Snoozes: map[string]time.Time{},
+		Shown:   map[string]time.Time{},
+		Muted:   map[string][]string{},
+	}
+}
+
+// New returns a durable store backed by kv. Rejects a nil KV rather than
+// silently degrading to in-memory: a store that forgets snoozes on restart
+// while claiming to persist them is the deferred failure the project's
+// constructor rule exists to prevent.
+func New(kv state.KV) (*Store, error) {
+	if kv == nil {
+		return nil, errors.New("kvuserstate: state KV must be non-nil")
+	}
+	return &Store{kv: kv}, nil
+}
+
+// compile-time check
+var _ userstate.Store = (*Store)(nil)
+
+// keyString renders a suggestion key. The user is part of it, so one
+// document holds every user's state without their entries colliding.
+//
+// NUL-separated because none of the components may contain it, so two
+// different keys can never render to the same string (a source id containing
+// a colon would otherwise collide with a variant containing one).
+func keyString(k userstate.Key) string {
+	return k.User + "\x00" + k.Source + "\x00" + k.EntityID + "\x00" + k.Variant
+}
+
+// load returns the document, reading it from the KV on first use.
+// Caller must hold s.mu.
+func (s *Store) load(ctx context.Context) (*document, error) {
+	if s.doc != nil {
+		return s.doc, nil
+	}
+	data, err := s.kv.Get(ctx, StateKey)
+	switch {
+	case err == nil:
+		var d document
+		if jsonErr := json.Unmarshal(data, &d); jsonErr != nil {
+			// A corrupt document is treated as empty, matching the
+			// scheduler's handling of its own state file. This state is
+			// disposable: refusing to start because a snooze log is
+			// unreadable would be a worse failure than forgetting it.
+			d = *newDocument()
+		}
+		normalize(&d)
+		s.doc = &d
+	case os.IsNotExist(err):
+		s.doc = newDocument()
+	default:
+		return nil, fmt.Errorf("kvuserstate: read state: %w", err)
+	}
+	return s.doc, nil
+}
+
+// normalize fills nil maps so callers never write to one.
+func normalize(d *document) {
+	if d.Snoozes == nil {
+		d.Snoozes = map[string]time.Time{}
+	}
+	if d.Shown == nil {
+		d.Shown = map[string]time.Time{}
+	}
+	if d.Muted == nil {
+		d.Muted = map[string][]string{}
+	}
+}
+
+// flush writes the in-memory document back. Caller must hold s.mu.
+func (s *Store) flush(ctx context.Context) error {
+	data, err := json.MarshalIndent(s.doc, "", "  ")
+	if err != nil {
+		return fmt.Errorf("kvuserstate: encode state: %w", err)
+	}
+	if err := s.kv.Put(ctx, StateKey, data); err != nil {
+		return fmt.Errorf("kvuserstate: write state: %w", err)
+	}
+	return nil
+}
+
+func (s *Store) SnoozedUntil(
+	ctx context.Context, key userstate.Key, now time.Time,
+) (time.Time, bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.closed {
+		return time.Time{}, false, userstate.ErrClosed
+	}
+	doc, err := s.load(ctx)
+	if err != nil {
+		return time.Time{}, false, err
+	}
+	until, ok := doc.Snoozes[keyString(key)]
+	// Expiry is judged at READ time so correctness never depends on Prune
+	// having run; `now` is exclusive-of-equal, matching how a deadline reads.
+	if !ok || !now.Before(until) {
+		return time.Time{}, false, nil
+	}
+	return until, true, nil
+}
+
+func (s *Store) SetSnooze(ctx context.Context, key userstate.Key, until time.Time) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.closed {
+		return userstate.ErrClosed
+	}
+	doc, err := s.load(ctx)
+	if err != nil {
+		return err
+	}
+	// Replace, never stack: a later "not for a week" must win over an
+	// earlier "not for an hour", and vice versa.
+	doc.Snoozes[keyString(key)] = until
+	return s.flush(ctx)
+}
+
+func (s *Store) Muted(ctx context.Context, user, source string) (bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.closed {
+		return false, userstate.ErrClosed
+	}
+	doc, err := s.load(ctx)
+	if err != nil {
+		return false, err
+	}
+	return slices.Contains(doc.Muted[user], source), nil
+}
+
+func (s *Store) SetMuted(ctx context.Context, user, source string, muted bool) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.closed {
+		return userstate.ErrClosed
+	}
+	doc, err := s.load(ctx)
+	if err != nil {
+		return err
+	}
+
+	cur := doc.Muted[user]
+	idx := slices.Index(cur, source)
+	switch {
+	case muted && idx < 0:
+		doc.Muted[user] = append(cur, source)
+	case !muted && idx >= 0:
+		doc.Muted[user] = slices.Delete(cur, idx, idx+1)
+		if len(doc.Muted[user]) == 0 {
+			delete(doc.Muted, user)
+		}
+	default:
+		return nil // already in the requested state
+	}
+	return s.flush(ctx)
+}
+
+func (s *Store) MutedSources(ctx context.Context, user string) ([]string, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.closed {
+		return nil, userstate.ErrClosed
+	}
+	doc, err := s.load(ctx)
+	if err != nil {
+		return nil, err
+	}
+	out := slices.Clone(doc.Muted[user])
+	slices.Sort(out)
+	return out, nil
+}
+
+func (s *Store) LastShown(ctx context.Context, key userstate.Key) (time.Time, bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.closed {
+		return time.Time{}, false, userstate.ErrClosed
+	}
+	doc, err := s.load(ctx)
+	if err != nil {
+		return time.Time{}, false, err
+	}
+	at, ok := doc.Shown[keyString(key)]
+	return at, ok, nil
+}
+
+func (s *Store) MarkShown(ctx context.Context, key userstate.Key, at time.Time) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.closed {
+		return userstate.ErrClosed
+	}
+	doc, err := s.load(ctx)
+	if err != nil {
+		return err
+	}
+	doc.Shown[keyString(key)] = at
+	return s.flush(ctx)
+}
+
+func (s *Store) Prune(ctx context.Context, now time.Time, keepShown time.Duration) (int, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.closed {
+		return 0, userstate.ErrClosed
+	}
+	doc, err := s.load(ctx)
+	if err != nil {
+		return 0, err
+	}
+
+	removed := 0
+	for k, until := range doc.Snoozes {
+		if !now.Before(until) {
+			delete(doc.Snoozes, k)
+			removed++
+		}
+	}
+	cutoff := now.Add(-keepShown)
+	for k, at := range doc.Shown {
+		if at.Before(cutoff) {
+			delete(doc.Shown, k)
+			removed++
+		}
+	}
+	if removed == 0 {
+		return 0, nil
+	}
+	// Mutes are untouched: they are a standing choice with no expiry, and a
+	// housekeeping pass that silently un-muted a source would surface as
+	// suggestions the user switched off coming back.
+	return removed, s.flush(ctx)
+}
+
+func (s *Store) Close() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.closed = true
+	s.doc = nil
+	return nil
+}
+
+// snapshot returns a copy of the in-memory document. Test-only helper kept
+// unexported; the conformance suite exercises behavior through the interface.
+func (s *Store) snapshot() document {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.doc == nil {
+		return *newDocument()
+	}
+	out := newDocument()
+	maps.Copy(out.Snoozes, s.doc.Snoozes)
+	maps.Copy(out.Shown, s.doc.Shown)
+	maps.Copy(out.Muted, s.doc.Muted)
+	return *out
+}

--- a/internal/userstate/kvuserstate/kv.go
+++ b/internal/userstate/kvuserstate/kv.go
@@ -17,12 +17,17 @@
 // user), read on every page render, and written only on explicit user
 // feedback. Per-key entries would turn one render into N KV reads.
 //
-// The cost is that concurrent writers must serialize, which the mutex does
-// WITHIN a process. Across processes this backend is last-writer-wins: two
-// servers sharing a project directory can lose a snooze. That is acceptable
-// for disposable state and is why the postgres backend exists for the
-// multi-process deployment — it is stated here so nobody discovers it as a
-// surprise.
+// # Single-process only
+//
+// The document is re-read from the KV on every operation, so a change written
+// by another process IS observed. What is not safe is concurrent WRITES: two
+// processes can read the same document, each apply their own change, and the
+// second write clobbers the first ENTIRELY — not just the contended key.
+//
+// That is why the postgres backend exists for the multi-process deployment,
+// where each row is written independently. Stated plainly here rather than
+// left to be discovered: a deployment running two servers over one project
+// directory will silently lose snoozes with this backend.
 package kvuserstate
 
 import (
@@ -97,12 +102,14 @@ func keyString(k userstate.Key) string {
 	return k.User + "\x00" + k.Source + "\x00" + k.EntityID + "\x00" + k.Variant
 }
 
-// load returns the document, reading it from the KV on first use.
-// Caller must hold s.mu.
+// load reads the document from the KV.
+//
+// Re-read on EVERY call rather than cached: a cached copy would mean a second
+// process never observed any of the first's writes, so a user snoozing on one
+// server would keep seeing the suggestion on the other indefinitely. The read
+// is a small local file and this runs once per feedback action, not per
+// render. Caller must hold s.mu.
 func (s *Store) load(ctx context.Context) (*document, error) {
-	if s.doc != nil {
-		return s.doc, nil
-	}
 	data, err := s.kv.Get(ctx, StateKey)
 	switch {
 	case err == nil:

--- a/internal/userstate/kvuserstate/kv_test.go
+++ b/internal/userstate/kvuserstate/kv_test.go
@@ -163,3 +163,35 @@ func TestSetMuted_NoDuplicates(t *testing.T) {
 
 	require.Len(t, s.snapshot().Muted["alice"], 1)
 }
+
+// Two Stores over one KV stand in for two server processes. A cached document
+// would mean the second never observed the first's writes — a user snoozing
+// on one server would keep seeing the suggestion on the other indefinitely.
+func TestCrossProcess_WritesAreVisibleToAnotherHandle(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	kv := newKV(t)
+	key := userstate.Key{User: "alice", Source: "stale", EntityID: "T-1"}
+
+	first, err := New(kv)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = first.Close() })
+	second, err := New(kv)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = second.Close() })
+
+	// Warm the second handle so a cache, if any, would already be populated.
+	_, _, err = second.SnoozedUntil(ctx, key, base)
+	require.NoError(t, err)
+
+	require.NoError(t, first.SetSnooze(ctx, key, base.Add(24*time.Hour)))
+
+	_, ok, err := second.SnoozedUntil(ctx, key, base)
+	require.NoError(t, err)
+	require.True(t, ok, "a write through one handle must be visible through the other")
+
+	require.NoError(t, first.SetMuted(ctx, "alice", "quips", true))
+	muted, err := second.Muted(ctx, "alice", "quips")
+	require.NoError(t, err)
+	require.True(t, muted, "a mute must be visible across handles too")
+}

--- a/internal/userstate/kvuserstate/kv_test.go
+++ b/internal/userstate/kvuserstate/kv_test.go
@@ -1,0 +1,165 @@
+package kvuserstate
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/Sourcehaven-BV/rela/internal/state"
+	"github.com/Sourcehaven-BV/rela/internal/storage"
+	"github.com/Sourcehaven-BV/rela/internal/userstate"
+	"github.com/Sourcehaven-BV/rela/internal/userstate/userstatetest"
+)
+
+var base = time.Date(2026, 3, 1, 12, 0, 0, 0, time.UTC)
+
+// newKV returns an in-memory state.KV plus its backing FS, so a test can
+// reopen a second Store over the SAME storage and prove durability.
+func newKV(t *testing.T) state.KV {
+	t.Helper()
+	mem := storage.NewMemFS()
+	require.NoError(t, mem.MkdirAll("/root", 0o755))
+	rfs, err := storage.NewRootedFS(mem, "/root")
+	require.NoError(t, err)
+	return state.NewFSKV(rfs)
+}
+
+// TestConformance runs the shared contract. Every backend must pass it —
+// three implementations without one are three subtly different behaviors.
+func TestConformance(t *testing.T) {
+	t.Parallel()
+	userstatetest.RunAll(t, func(t *testing.T) userstate.Store {
+		t.Helper()
+		s, err := New(newKV(t))
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = s.Close() })
+		return s
+	})
+}
+
+func TestNew_RejectsNilKV(t *testing.T) {
+	t.Parallel()
+	_, err := New(nil)
+	require.Error(t, err,
+		"a nil KV would silently degrade to forgetting snoozes while claiming to persist them")
+}
+
+// The whole point of this backend: state must outlive the process. The
+// conformance suite cannot express this — it holds one Store per subtest.
+func TestDurability_SurvivesReopen(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	kv := newKV(t)
+	key := userstate.Key{User: "alice", Source: "stale", EntityID: "T-1"}
+
+	first, err := New(kv)
+	require.NoError(t, err)
+	require.NoError(t, first.SetSnooze(ctx, key, base.Add(24*time.Hour)))
+	require.NoError(t, first.SetMuted(ctx, "alice", "quips", true))
+	require.NoError(t, first.MarkShown(ctx, key, base))
+	require.NoError(t, first.Close())
+
+	// A fresh Store over the same storage — the restart case.
+	second, err := New(kv)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = second.Close() })
+
+	until, ok, err := second.SnoozedUntil(ctx, key, base)
+	require.NoError(t, err)
+	require.True(t, ok, "a snooze must survive a restart")
+	require.True(t, until.Equal(base.Add(24*time.Hour)))
+
+	muted, err := second.Muted(ctx, "alice", "quips")
+	require.NoError(t, err)
+	require.True(t, muted, "a mute must survive a restart")
+
+	at, ok, err := second.LastShown(ctx, key)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.True(t, at.Equal(base), "cooldown state must survive a restart")
+}
+
+// This state is disposable, so an unreadable document must not stop the app.
+// Refusing to serve because a snooze log is corrupt is a worse failure than
+// forgetting the snoozes — matching how the scheduler treats its own state.
+func TestCorruptDocument_ReadsAsEmpty(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	kv := newKV(t)
+	require.NoError(t, kv.Put(ctx, StateKey, []byte("{ this is not json")))
+
+	s, err := New(kv)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = s.Close() })
+
+	_, ok, err := s.SnoozedUntil(ctx, userstate.Key{User: "a", Source: "b"}, base)
+	require.NoError(t, err, "a corrupt document must not fail the read")
+	require.False(t, ok)
+
+	// And it must be writable again rather than staying wedged.
+	require.NoError(t, s.SetMuted(ctx, "a", "b", true))
+	muted, err := s.Muted(ctx, "a", "b")
+	require.NoError(t, err)
+	require.True(t, muted)
+}
+
+// One user's entries must not be readable as another's — the document is
+// shared, so the key must carry the user.
+func TestSharedDocument_KeepsUsersDistinct(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	s, err := New(newKV(t))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = s.Close() })
+
+	require.NoError(t, s.SetSnooze(ctx,
+		userstate.Key{User: "alice", Source: "stale", EntityID: "T-1"}, base.Add(time.Hour)))
+
+	_, ok, err := s.SnoozedUntil(ctx,
+		userstate.Key{User: "bob", Source: "stale", EntityID: "T-1"}, base)
+	require.NoError(t, err)
+	require.False(t, ok, "bob must not inherit alice's snooze from the shared document")
+}
+
+// Pruning must actually shrink what is persisted, not just the in-memory
+// copy — otherwise the file grows forever and the reopen path reloads rows
+// that were supposedly reclaimed.
+func TestPrune_ShrinksThePersistedDocument(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	kv := newKV(t)
+	s, err := New(kv)
+	require.NoError(t, err)
+
+	dead := userstate.Key{User: "alice", Source: "stale", EntityID: "T-dead"}
+	require.NoError(t, s.SetSnooze(ctx, dead, base.Add(time.Hour)))
+
+	removed, err := s.Prune(ctx, base.Add(48*time.Hour), 30*24*time.Hour)
+	require.NoError(t, err)
+	require.Equal(t, 1, removed)
+	require.NoError(t, s.Close())
+
+	reopened, err := New(kv)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = reopened.Close() })
+	_, ok, err := reopened.SnoozedUntil(ctx, dead, base)
+	require.NoError(t, err)
+	require.False(t, ok, "a pruned snooze must be gone from storage, not just from memory")
+}
+
+// Re-muting an already-muted source must not append a duplicate: the mute
+// list is rendered to the user as the "what have I turned off?" screen.
+func TestSetMuted_NoDuplicates(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	s, err := New(newKV(t))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = s.Close() })
+
+	require.NoError(t, s.SetMuted(ctx, "alice", "quips", true))
+	require.NoError(t, s.SetMuted(ctx, "alice", "quips", true))
+
+	require.Len(t, s.snapshot().Muted["alice"], 1)
+}

--- a/internal/userstate/memuserstate/mem.go
+++ b/internal/userstate/memuserstate/mem.go
@@ -1,0 +1,161 @@
+// Package memuserstate is the in-memory [userstate.Store] backend.
+//
+// Used by the memorybackend build and by tests. State is per-process and
+// lost on restart, which is acceptable for this data: a lost snooze costs a
+// user one repeated suggestion.
+package memuserstate
+
+import (
+	"context"
+	"maps"
+	"slices"
+	"sync"
+	"time"
+
+	"github.com/Sourcehaven-BV/rela/internal/userstate"
+)
+
+// Store is an in-memory [userstate.Store]. Safe for concurrent use.
+type Store struct {
+	mu     sync.RWMutex
+	closed bool
+
+	snoozes map[userstate.Key]time.Time
+	shown   map[userstate.Key]time.Time
+	// muted is keyed by user, then source, so MutedSources is a map walk
+	// rather than a scan over every user's entries.
+	muted map[string]map[string]bool
+}
+
+// New returns an empty in-memory store.
+func New() *Store {
+	return &Store{
+		snoozes: make(map[userstate.Key]time.Time),
+		shown:   make(map[userstate.Key]time.Time),
+		muted:   make(map[string]map[string]bool),
+	}
+}
+
+// compile-time check
+var _ userstate.Store = (*Store)(nil)
+
+func (s *Store) SnoozedUntil(
+	_ context.Context, key userstate.Key, now time.Time,
+) (time.Time, bool, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if s.closed {
+		return time.Time{}, false, userstate.ErrClosed
+	}
+	until, ok := s.snoozes[key]
+	// Expiry is judged at READ time so correctness never depends on Prune
+	// having run. `now` is exclusive-of-equal: a snooze "until T" is over at
+	// T, matching how a deadline reads to a human.
+	if !ok || !now.Before(until) {
+		return time.Time{}, false, nil
+	}
+	return until, true, nil
+}
+
+func (s *Store) SetSnooze(_ context.Context, key userstate.Key, until time.Time) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.closed {
+		return userstate.ErrClosed
+	}
+	// Replace, never stack: a later "not for a week" must win over an
+	// earlier "not for an hour".
+	s.snoozes[key] = until
+	return nil
+}
+
+func (s *Store) Muted(_ context.Context, user, source string) (bool, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if s.closed {
+		return false, userstate.ErrClosed
+	}
+	return s.muted[user][source], nil
+}
+
+func (s *Store) SetMuted(_ context.Context, user, source string, muted bool) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.closed {
+		return userstate.ErrClosed
+	}
+	if !muted {
+		delete(s.muted[user], source)
+		if len(s.muted[user]) == 0 {
+			delete(s.muted, user)
+		}
+		return nil
+	}
+	if s.muted[user] == nil {
+		s.muted[user] = make(map[string]bool)
+	}
+	s.muted[user][source] = true
+	return nil
+}
+
+func (s *Store) MutedSources(_ context.Context, user string) ([]string, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if s.closed {
+		return nil, userstate.ErrClosed
+	}
+	return slices.Sorted(maps.Keys(s.muted[user])), nil
+}
+
+func (s *Store) LastShown(_ context.Context, key userstate.Key) (time.Time, bool, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if s.closed {
+		return time.Time{}, false, userstate.ErrClosed
+	}
+	at, ok := s.shown[key]
+	return at, ok, nil
+}
+
+func (s *Store) MarkShown(_ context.Context, key userstate.Key, at time.Time) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.closed {
+		return userstate.ErrClosed
+	}
+	s.shown[key] = at
+	return nil
+}
+
+func (s *Store) Prune(_ context.Context, now time.Time, keepShown time.Duration) (int, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.closed {
+		return 0, userstate.ErrClosed
+	}
+	removed := 0
+	for k, until := range s.snoozes {
+		if !now.Before(until) {
+			delete(s.snoozes, k)
+			removed++
+		}
+	}
+	cutoff := now.Add(-keepShown)
+	for k, at := range s.shown {
+		if at.Before(cutoff) {
+			delete(s.shown, k)
+			removed++
+		}
+	}
+	return removed, nil
+}
+
+func (s *Store) Close() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.closed = true
+	s.snoozes = nil
+	s.shown = nil
+	s.muted = nil
+	return nil
+}

--- a/internal/userstate/memuserstate/mem_test.go
+++ b/internal/userstate/memuserstate/mem_test.go
@@ -1,0 +1,19 @@
+package memuserstate_test
+
+import (
+	"testing"
+
+	"github.com/Sourcehaven-BV/rela/internal/userstate"
+	"github.com/Sourcehaven-BV/rela/internal/userstate/memuserstate"
+	"github.com/Sourcehaven-BV/rela/internal/userstate/userstatetest"
+)
+
+func TestConformance(t *testing.T) {
+	t.Parallel()
+	userstatetest.RunAll(t, func(t *testing.T) userstate.Store {
+		t.Helper()
+		s := memuserstate.New()
+		t.Cleanup(func() { _ = s.Close() })
+		return s
+	})
+}

--- a/internal/userstate/userstate.go
+++ b/internal/userstate/userstate.go
@@ -1,0 +1,117 @@
+// Package userstate holds per-user, per-suggestion state for the
+// next-action layer: snoozes, muted sources, and last-shown timestamps.
+//
+// # Why this is not in the graph
+//
+// A snooze is not a fact about an entity; it is a fact about one person's
+// relationship to a suggestion at a moment. Storing it as an entity would
+// make it visible to everyone, audited forever in the append-only log, and
+// (on postgres) fed through the version-capture sweep. Last-shown is worse
+// still: cooldown means writing on RENDER, so a suggestion surface would
+// generate graph writes merely by being looked at.
+//
+// So this is a separate service with its own backends, deliberately outside
+// store.Store. It is disposable state — losing it costs a user a repeated
+// suggestion, not data.
+//
+// # Backends
+//
+// Implementations live in subpackages and are selected at wiring time the
+// same way store backends are (see internal/appbuild). Every implementation
+// must pass [userstatetest.RunAll] — three backends without a shared contract
+// test is three subtly different behaviors, and the one that diverges will be
+// the one nobody runs locally.
+//
+// # Time is injected, never read
+//
+// No method reads the wall clock. Expiry is evaluated against a caller-
+// supplied `now`, which is what lets the conformance suite pin TTL semantics
+// deterministically across backends. This mirrors predicatefns.Bind's
+// treatment of today() and exists for the same reason: a local-vs-UTC skew
+// of one day was a real bug there (RR-YPYTP), and snooze windows are exactly
+// as vulnerable.
+package userstate
+
+import (
+	"context"
+	"errors"
+	"time"
+)
+
+// ErrClosed is returned by every method once Close has been called.
+var ErrClosed = errors.New("userstate: store is closed")
+
+// Key identifies one suggestion for one user.
+//
+// The optional Variant carries the values of the source's configured
+// key_props, which is what lets a condition that RESETS be recognized as new:
+// a proposal going draft -> sent -> draft yields a different Variant, so an
+// older snooze no longer matches and the new stall surfaces. Without it the
+// key is stable across a reset and the suggestion stays silently suppressed.
+//
+// EntityID is empty for a count-based (entity-less) source such as first-run,
+// where the key degenerates to the source alone.
+type Key struct {
+	User     string
+	Source   string
+	EntityID string
+	Variant  string
+}
+
+// Snooze suppresses one suggestion until a deadline.
+type Snooze struct {
+	Key   Key
+	Until time.Time
+}
+
+// Store is the per-user state the next-action engine needs.
+//
+// Consumer-side interface: the engine declares the minimum it uses, and the
+// wiring site supplies a backend. Implementations must be safe for concurrent
+// use — a single user can have several tabs open, and the disk and postgres
+// backends are reachable from multiple goroutines and processes respectively.
+type Store interface {
+	// SnoozedUntil reports the deadline for key, and whether a live snooze
+	// exists at all. An expired snooze reports ok=false: expiry is a read-time
+	// judgement against `now`, so no backend depends on a sweeper having run.
+	SnoozedUntil(ctx context.Context, key Key, now time.Time) (until time.Time, ok bool, err error)
+
+	// SetSnooze records a snooze until `until`. A second call for the same key
+	// REPLACES the first rather than stacking: "not now, try tomorrow" after
+	// "not for an hour" should mean tomorrow, not an hour plus a day.
+	SetSnooze(ctx context.Context, key Key, until time.Time) error
+
+	// Muted reports whether the user has muted this source entirely.
+	Muted(ctx context.Context, user, source string) (bool, error)
+
+	// SetMuted mutes or unmutes a source for a user. Muting is per-SOURCE,
+	// never per-entity: a per-entity mute is invisible state that nobody can
+	// find later, whereas the handful of configured sources make "what have I
+	// turned off?" a short, reversible list.
+	SetMuted(ctx context.Context, user, source string, muted bool) error
+
+	// MutedSources lists a user's muted source ids, sorted. Backs the
+	// settings screen that makes muting discoverable — the property that
+	// justifies choosing per-source mute over per-entity in the first place.
+	MutedSources(ctx context.Context, user string) ([]string, error)
+
+	// LastShown reports when this suggestion was last surfaced, and whether
+	// it ever was. Drives cooldown.
+	LastShown(ctx context.Context, key Key) (at time.Time, ok bool, err error)
+
+	// MarkShown records that the suggestion was surfaced at `at`.
+	MarkShown(ctx context.Context, key Key, at time.Time) error
+
+	// Prune drops state that can no longer affect a decision: snoozes whose
+	// deadline has passed, and last-shown records older than `keepShown`.
+	// Returns how many records were removed.
+	//
+	// Purely a housekeeping optimisation — reads already ignore expired
+	// snoozes, so a backend that never prunes stays CORRECT while growing
+	// unboundedly. That split is deliberate: correctness must not depend on
+	// a sweeper the operator might disable.
+	Prune(ctx context.Context, now time.Time, keepShown time.Duration) (removed int, err error)
+
+	// Close releases resources. Subsequent calls return ErrClosed.
+	Close() error
+}

--- a/internal/userstate/userstatetest/userstatetest.go
+++ b/internal/userstate/userstatetest/userstatetest.go
@@ -33,7 +33,7 @@ var base = time.Date(2026, 3, 1, 12, 0, 0, 0, time.UTC)
 // Named spans, so an assertion reads as the scenario it models rather than
 // as arithmetic.
 const (
-	oneHour   = time.Hour
+	anHour    = time.Hour
 	oneDay    = 24 * time.Hour
 	twoDays   = 2 * oneDay
 	oneWeek   = 7 * oneDay
@@ -87,9 +87,9 @@ func RunSnoozeTests(t *testing.T, f Factory) {
 	t.Run("expired snooze reads as absent", func(t *testing.T) {
 		s := f(t)
 		k := key("alice", "stale", "T-1")
-		require.NoError(t, s.SetSnooze(ctx, k, base.Add(oneHour)))
+		require.NoError(t, s.SetSnooze(ctx, k, base.Add(anHour)))
 
-		_, ok, err := s.SnoozedUntil(ctx, k, base.Add(2*oneHour))
+		_, ok, err := s.SnoozedUntil(ctx, k, base.Add(2*anHour))
 		require.NoError(t, err)
 		require.False(t, ok)
 	})
@@ -99,7 +99,7 @@ func RunSnoozeTests(t *testing.T, f Factory) {
 	t.Run("snooze expires at the deadline, not after it", func(t *testing.T) {
 		s := f(t)
 		k := key("alice", "stale", "T-1")
-		until := base.Add(oneHour)
+		until := base.Add(anHour)
 		require.NoError(t, s.SetSnooze(ctx, k, until))
 
 		_, ok, err := s.SnoozedUntil(ctx, k, until)
@@ -114,7 +114,7 @@ func RunSnoozeTests(t *testing.T, f Factory) {
 	t.Run("re-snoozing replaces rather than stacks", func(t *testing.T) {
 		s := f(t)
 		k := key("alice", "stale", "T-1")
-		require.NoError(t, s.SetSnooze(ctx, k, base.Add(oneHour)))
+		require.NoError(t, s.SetSnooze(ctx, k, base.Add(anHour)))
 		require.NoError(t, s.SetSnooze(ctx, k, base.Add(oneWeek)))
 
 		got, ok, err := s.SnoozedUntil(ctx, k, base)
@@ -129,11 +129,11 @@ func RunSnoozeTests(t *testing.T, f Factory) {
 		s := f(t)
 		k := key("alice", "stale", "T-1")
 		require.NoError(t, s.SetSnooze(ctx, k, base.Add(oneWeek)))
-		require.NoError(t, s.SetSnooze(ctx, k, base.Add(oneHour)))
+		require.NoError(t, s.SetSnooze(ctx, k, base.Add(anHour)))
 
 		got, _, err := s.SnoozedUntil(ctx, k, base)
 		require.NoError(t, err)
-		require.True(t, got.Equal(base.Add(oneHour)), "shorter snooze must win, got %v", got)
+		require.True(t, got.Equal(base.Add(anHour)), "shorter snooze must win, got %v", got)
 	})
 
 	// Variant is what makes a reset condition surface again.
@@ -242,7 +242,7 @@ func RunShownTests(t *testing.T, f Factory) {
 		require.True(t, ok)
 		require.True(t, at.Equal(base))
 
-		later := base.Add(oneHour)
+		later := base.Add(anHour)
 		require.NoError(t, s.MarkShown(ctx, k, later))
 		at, _, err = s.LastShown(ctx, k)
 		require.NoError(t, err)
@@ -260,7 +260,7 @@ func RunPruneTests(t *testing.T, f Factory) {
 		s := f(t)
 		dead := key("alice", "stale", "T-dead")
 		live := key("alice", "stale", "T-live")
-		require.NoError(t, s.SetSnooze(ctx, dead, base.Add(oneHour)))
+		require.NoError(t, s.SetSnooze(ctx, dead, base.Add(anHour)))
 		require.NoError(t, s.SetSnooze(ctx, live, base.Add(twoDays)))
 
 		removed, err := s.Prune(ctx, base.Add(oneDay), oneMonth)

--- a/internal/userstate/userstatetest/userstatetest.go
+++ b/internal/userstate/userstatetest/userstatetest.go
@@ -1,0 +1,392 @@
+// Package userstatetest is the conformance harness every
+// [userstate.Store] implementation must pass.
+//
+// It exists for the same reason internal/store/storetest does: three
+// backends without a shared contract test are three subtly different
+// behaviors, and the one that diverges is the one nobody runs locally. The
+// expiry and replace-don't-stack rules in particular are easy to implement
+// plausibly-but-differently in Go maps, on disk, and in SQL.
+//
+// Every assertion here is deterministic — no wall clock, no sleeps — because
+// [userstate.Store] takes `now` as a parameter. A suite that slept would be
+// slow and flaky and would still not pin the boundary conditions.
+package userstatetest
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/Sourcehaven-BV/rela/internal/userstate"
+)
+
+// Factory returns a fresh, empty store for one subtest. Cleanup (including
+// Close) is the factory's responsibility, normally via t.Cleanup.
+type Factory func(t *testing.T) userstate.Store
+
+// base is an arbitrary fixed instant. Fixed rather than time.Now() so a
+// failure reproduces exactly and no test depends on the day it runs.
+var base = time.Date(2026, 3, 1, 12, 0, 0, 0, time.UTC)
+
+// Named spans, so an assertion reads as the scenario it models rather than
+// as arithmetic.
+const (
+	oneHour   = time.Hour
+	oneDay    = 24 * time.Hour
+	twoDays   = 2 * oneDay
+	oneWeek   = 7 * oneDay
+	oneMonth  = 30 * oneDay
+	oneYear   = 365 * oneDay
+	nearMonth = 29 * oneDay
+)
+
+func key(user, source, entity string) userstate.Key {
+	return userstate.Key{User: user, Source: source, EntityID: entity}
+}
+
+// RunAll runs every conformance suite against f.
+func RunAll(t *testing.T, f Factory) {
+	t.Helper()
+	t.Run("Snooze", func(t *testing.T) { RunSnoozeTests(t, f) })
+	t.Run("Mute", func(t *testing.T) { RunMuteTests(t, f) })
+	t.Run("Shown", func(t *testing.T) { RunShownTests(t, f) })
+	t.Run("Prune", func(t *testing.T) { RunPruneTests(t, f) })
+	t.Run("Isolation", func(t *testing.T) { RunIsolationTests(t, f) })
+	t.Run("Closed", func(t *testing.T) { RunClosedTests(t, f) })
+}
+
+// RunSnoozeTests pins snooze semantics, including the boundary condition and
+// the replace-don't-stack rule.
+func RunSnoozeTests(t *testing.T, f Factory) {
+	t.Helper()
+	ctx := context.Background()
+
+	t.Run("absent key is not snoozed", func(t *testing.T) {
+		s := f(t)
+		_, ok, err := s.SnoozedUntil(ctx, key("alice", "stale", "T-1"), base)
+		require.NoError(t, err)
+		require.False(t, ok)
+	})
+
+	t.Run("live snooze reports its deadline", func(t *testing.T) {
+		s := f(t)
+		k := key("alice", "stale", "T-1")
+		until := base.Add(oneDay)
+		require.NoError(t, s.SetSnooze(ctx, k, until))
+
+		got, ok, err := s.SnoozedUntil(ctx, k, base)
+		require.NoError(t, err)
+		require.True(t, ok)
+		require.True(t, got.Equal(until), "got %v, want %v", got, until)
+	})
+
+	// Expiry is judged at read time against `now`, so a backend that never
+	// prunes still answers correctly.
+	t.Run("expired snooze reads as absent", func(t *testing.T) {
+		s := f(t)
+		k := key("alice", "stale", "T-1")
+		require.NoError(t, s.SetSnooze(ctx, k, base.Add(oneHour)))
+
+		_, ok, err := s.SnoozedUntil(ctx, k, base.Add(2*oneHour))
+		require.NoError(t, err)
+		require.False(t, ok)
+	})
+
+	// The boundary: "until T" is over AT T. Left to each backend this is
+	// exactly where < and <= diverge silently.
+	t.Run("snooze expires at the deadline, not after it", func(t *testing.T) {
+		s := f(t)
+		k := key("alice", "stale", "T-1")
+		until := base.Add(oneHour)
+		require.NoError(t, s.SetSnooze(ctx, k, until))
+
+		_, ok, err := s.SnoozedUntil(ctx, k, until)
+		require.NoError(t, err)
+		require.False(t, ok, "a snooze until T must not be live at exactly T")
+
+		_, ok, err = s.SnoozedUntil(ctx, k, until.Add(-time.Nanosecond))
+		require.NoError(t, err)
+		require.True(t, ok, "a snooze until T must still be live just before T")
+	})
+
+	t.Run("re-snoozing replaces rather than stacks", func(t *testing.T) {
+		s := f(t)
+		k := key("alice", "stale", "T-1")
+		require.NoError(t, s.SetSnooze(ctx, k, base.Add(oneHour)))
+		require.NoError(t, s.SetSnooze(ctx, k, base.Add(oneWeek)))
+
+		got, ok, err := s.SnoozedUntil(ctx, k, base)
+		require.NoError(t, err)
+		require.True(t, ok)
+		require.True(t, got.Equal(base.Add(oneWeek)), "later snooze must win, got %v", got)
+	})
+
+	// A shorter re-snooze must also win: the user said "actually, remind me
+	// sooner", and silently keeping the longer one would ignore them.
+	t.Run("a shorter re-snooze also replaces", func(t *testing.T) {
+		s := f(t)
+		k := key("alice", "stale", "T-1")
+		require.NoError(t, s.SetSnooze(ctx, k, base.Add(oneWeek)))
+		require.NoError(t, s.SetSnooze(ctx, k, base.Add(oneHour)))
+
+		got, _, err := s.SnoozedUntil(ctx, k, base)
+		require.NoError(t, err)
+		require.True(t, got.Equal(base.Add(oneHour)), "shorter snooze must win, got %v", got)
+	})
+
+	// Variant is what makes a reset condition surface again.
+	t.Run("variant distinguishes keys", func(t *testing.T) {
+		s := f(t)
+		draft := userstate.Key{User: "alice", Source: "stale", EntityID: "P-1", Variant: "draft"}
+		sent := userstate.Key{User: "alice", Source: "stale", EntityID: "P-1", Variant: "sent"}
+		require.NoError(t, s.SetSnooze(ctx, draft, base.Add(oneDay)))
+
+		_, ok, err := s.SnoozedUntil(ctx, sent, base)
+		require.NoError(t, err)
+		require.False(t, ok, "a different variant must not inherit the snooze")
+	})
+
+	// Entity-less (count) sources key on the source alone.
+	t.Run("empty entity id is a usable key", func(t *testing.T) {
+		s := f(t)
+		k := key("alice", "first-run", "")
+		require.NoError(t, s.SetSnooze(ctx, k, base.Add(oneDay)))
+
+		_, ok, err := s.SnoozedUntil(ctx, k, base)
+		require.NoError(t, err)
+		require.True(t, ok)
+	})
+}
+
+// RunMuteTests pins per-source muting and its reversibility.
+func RunMuteTests(t *testing.T, f Factory) {
+	t.Helper()
+	ctx := context.Background()
+
+	t.Run("unmuted by default", func(t *testing.T) {
+		s := f(t)
+		muted, err := s.Muted(ctx, "alice", "stale")
+		require.NoError(t, err)
+		require.False(t, muted)
+	})
+
+	t.Run("mute then unmute", func(t *testing.T) {
+		s := f(t)
+		require.NoError(t, s.SetMuted(ctx, "alice", "stale", true))
+		muted, err := s.Muted(ctx, "alice", "stale")
+		require.NoError(t, err)
+		require.True(t, muted)
+
+		require.NoError(t, s.SetMuted(ctx, "alice", "stale", false))
+		muted, err = s.Muted(ctx, "alice", "stale")
+		require.NoError(t, err)
+		require.False(t, muted, "unmute must be reversible — that is the point of per-source mute")
+	})
+
+	t.Run("muting is idempotent", func(t *testing.T) {
+		s := f(t)
+		require.NoError(t, s.SetMuted(ctx, "alice", "stale", true))
+		require.NoError(t, s.SetMuted(ctx, "alice", "stale", true))
+		got, err := s.MutedSources(ctx, "alice")
+		require.NoError(t, err)
+		require.Equal(t, []string{"stale"}, got)
+	})
+
+	t.Run("unmuting an unmuted source is a no-op", func(t *testing.T) {
+		s := f(t)
+		require.NoError(t, s.SetMuted(ctx, "alice", "never-muted", false))
+		got, err := s.MutedSources(ctx, "alice")
+		require.NoError(t, err)
+		require.Empty(t, got)
+	})
+
+	// The settings screen this backs is what makes muting discoverable.
+	t.Run("MutedSources lists sorted ids", func(t *testing.T) {
+		s := f(t)
+		for _, src := range []string{"zzz", "aaa", "mmm"} {
+			require.NoError(t, s.SetMuted(ctx, "alice", src, true))
+		}
+		got, err := s.MutedSources(ctx, "alice")
+		require.NoError(t, err)
+		require.Equal(t, []string{"aaa", "mmm", "zzz"}, got)
+	})
+
+	t.Run("MutedSources is empty for an unknown user", func(t *testing.T) {
+		s := f(t)
+		got, err := s.MutedSources(ctx, "nobody")
+		require.NoError(t, err)
+		require.Empty(t, got)
+	})
+}
+
+// RunShownTests pins the last-shown record backing cooldown.
+func RunShownTests(t *testing.T, f Factory) {
+	t.Helper()
+	ctx := context.Background()
+
+	t.Run("never shown", func(t *testing.T) {
+		s := f(t)
+		_, ok, err := s.LastShown(ctx, key("alice", "stale", "T-1"))
+		require.NoError(t, err)
+		require.False(t, ok)
+	})
+
+	t.Run("records and overwrites", func(t *testing.T) {
+		s := f(t)
+		k := key("alice", "stale", "T-1")
+		require.NoError(t, s.MarkShown(ctx, k, base))
+		at, ok, err := s.LastShown(ctx, k)
+		require.NoError(t, err)
+		require.True(t, ok)
+		require.True(t, at.Equal(base))
+
+		later := base.Add(oneHour)
+		require.NoError(t, s.MarkShown(ctx, k, later))
+		at, _, err = s.LastShown(ctx, k)
+		require.NoError(t, err)
+		require.True(t, at.Equal(later), "MarkShown records the LAST time shown")
+	})
+}
+
+// RunPruneTests pins housekeeping. Pruning must never change an answer —
+// only reclaim space — so correctness cannot depend on it having run.
+func RunPruneTests(t *testing.T, f Factory) {
+	t.Helper()
+	ctx := context.Background()
+
+	t.Run("removes expired snoozes and keeps live ones", func(t *testing.T) {
+		s := f(t)
+		dead := key("alice", "stale", "T-dead")
+		live := key("alice", "stale", "T-live")
+		require.NoError(t, s.SetSnooze(ctx, dead, base.Add(oneHour)))
+		require.NoError(t, s.SetSnooze(ctx, live, base.Add(twoDays)))
+
+		removed, err := s.Prune(ctx, base.Add(oneDay), oneMonth)
+		require.NoError(t, err)
+		require.GreaterOrEqual(t, removed, 1)
+
+		_, ok, err := s.SnoozedUntil(ctx, live, base.Add(oneDay))
+		require.NoError(t, err)
+		require.True(t, ok, "pruning must not drop a live snooze")
+	})
+
+	t.Run("removes stale shown records", func(t *testing.T) {
+		s := f(t)
+		old := key("alice", "stale", "T-old")
+		recent := key("alice", "stale", "T-recent")
+		require.NoError(t, s.MarkShown(ctx, old, base))
+		require.NoError(t, s.MarkShown(ctx, recent, base.Add(nearMonth)))
+
+		_, err := s.Prune(ctx, base.Add(oneMonth), oneWeek)
+		require.NoError(t, err)
+
+		_, ok, err := s.LastShown(ctx, old)
+		require.NoError(t, err)
+		require.False(t, ok, "shown record older than keepShown should be pruned")
+
+		_, ok, err = s.LastShown(ctx, recent)
+		require.NoError(t, err)
+		require.True(t, ok, "recent shown record must survive")
+	})
+
+	t.Run("pruning an empty store is fine", func(t *testing.T) {
+		s := f(t)
+		removed, err := s.Prune(ctx, base, time.Hour)
+		require.NoError(t, err)
+		require.Zero(t, removed)
+	})
+
+	// Mutes are an explicit standing choice with no expiry; a housekeeping
+	// pass that silently un-muted sources would be a bug the user notices as
+	// suggestions they switched off coming back.
+	t.Run("pruning never drops mutes", func(t *testing.T) {
+		s := f(t)
+		require.NoError(t, s.SetMuted(ctx, "alice", "stale", true))
+		_, err := s.Prune(ctx, base.Add(oneYear), time.Nanosecond)
+		require.NoError(t, err)
+
+		muted, err := s.Muted(ctx, "alice", "stale")
+		require.NoError(t, err)
+		require.True(t, muted, "a mute has no expiry and must survive pruning")
+	})
+}
+
+// RunIsolationTests pins that state is scoped per user. A leak here shows a
+// user someone else's snoozes — mild in itself, but it would also mean the
+// keying is wrong in a way that corrupts cooldown for everyone.
+func RunIsolationTests(t *testing.T, f Factory) {
+	t.Helper()
+	ctx := context.Background()
+
+	t.Run("snoozes do not leak between users", func(t *testing.T) {
+		s := f(t)
+		require.NoError(t, s.SetSnooze(ctx, key("alice", "stale", "T-1"), base.Add(oneDay)))
+
+		_, ok, err := s.SnoozedUntil(ctx, key("bob", "stale", "T-1"), base)
+		require.NoError(t, err)
+		require.False(t, ok)
+	})
+
+	t.Run("mutes do not leak between users", func(t *testing.T) {
+		s := f(t)
+		require.NoError(t, s.SetMuted(ctx, "alice", "stale", true))
+
+		muted, err := s.Muted(ctx, "bob", "stale")
+		require.NoError(t, err)
+		require.False(t, muted)
+
+		got, err := s.MutedSources(ctx, "bob")
+		require.NoError(t, err)
+		require.Empty(t, got)
+	})
+
+	t.Run("shown records do not leak between users", func(t *testing.T) {
+		s := f(t)
+		require.NoError(t, s.MarkShown(ctx, key("alice", "stale", "T-1"), base))
+
+		_, ok, err := s.LastShown(ctx, key("bob", "stale", "T-1"))
+		require.NoError(t, err)
+		require.False(t, ok)
+	})
+
+	t.Run("sources are distinct within a user", func(t *testing.T) {
+		s := f(t)
+		require.NoError(t, s.SetSnooze(ctx, key("alice", "src-a", "T-1"), base.Add(oneDay)))
+
+		_, ok, err := s.SnoozedUntil(ctx, key("alice", "src-b", "T-1"), base)
+		require.NoError(t, err)
+		require.False(t, ok)
+	})
+}
+
+// RunClosedTests pins that a closed store fails loudly rather than silently
+// accepting writes that go nowhere.
+func RunClosedTests(t *testing.T, f Factory) {
+	t.Helper()
+	ctx := context.Background()
+
+	t.Run("methods report ErrClosed after Close", func(t *testing.T) {
+		s := f(t)
+		require.NoError(t, s.Close())
+
+		_, _, err := s.SnoozedUntil(ctx, key("alice", "stale", "T-1"), base)
+		require.ErrorIs(t, err, userstate.ErrClosed)
+
+		err = s.SetSnooze(ctx, key("alice", "stale", "T-1"), base)
+		require.ErrorIs(t, err, userstate.ErrClosed)
+
+		_, err = s.Muted(ctx, "alice", "stale")
+		require.ErrorIs(t, err, userstate.ErrClosed)
+
+		err = s.MarkShown(ctx, key("alice", "stale", "T-1"), base)
+		require.ErrorIs(t, err, userstate.ErrClosed)
+	})
+
+	t.Run("Close is idempotent", func(t *testing.T) {
+		s := f(t)
+		require.NoError(t, s.Close())
+		require.NoError(t, s.Close())
+	})
+}

--- a/internal/userstate/userstatetest/userstatetest.go
+++ b/internal/userstate/userstatetest/userstatetest.go
@@ -33,13 +33,13 @@ var base = time.Date(2026, 3, 1, 12, 0, 0, 0, time.UTC)
 // Named spans, so an assertion reads as the scenario it models rather than
 // as arithmetic.
 const (
-	anHour    = time.Hour
-	oneDay    = 24 * time.Hour
-	twoDays   = 2 * oneDay
-	oneWeek   = 7 * oneDay
-	oneMonth  = 30 * oneDay
-	oneYear   = 365 * oneDay
-	nearMonth = 29 * oneDay
+	oneHourSpan = time.Hour
+	oneDay      = 24 * time.Hour
+	twoDays     = 2 * oneDay
+	oneWeek     = 7 * oneDay
+	oneMonth    = 30 * oneDay
+	oneYear     = 365 * oneDay
+	nearMonth   = 29 * oneDay
 )
 
 func key(user, source, entity string) userstate.Key {
@@ -87,9 +87,9 @@ func RunSnoozeTests(t *testing.T, f Factory) {
 	t.Run("expired snooze reads as absent", func(t *testing.T) {
 		s := f(t)
 		k := key("alice", "stale", "T-1")
-		require.NoError(t, s.SetSnooze(ctx, k, base.Add(anHour)))
+		require.NoError(t, s.SetSnooze(ctx, k, base.Add(oneHourSpan)))
 
-		_, ok, err := s.SnoozedUntil(ctx, k, base.Add(2*anHour))
+		_, ok, err := s.SnoozedUntil(ctx, k, base.Add(2*oneHourSpan))
 		require.NoError(t, err)
 		require.False(t, ok)
 	})
@@ -99,7 +99,7 @@ func RunSnoozeTests(t *testing.T, f Factory) {
 	t.Run("snooze expires at the deadline, not after it", func(t *testing.T) {
 		s := f(t)
 		k := key("alice", "stale", "T-1")
-		until := base.Add(anHour)
+		until := base.Add(oneHourSpan)
 		require.NoError(t, s.SetSnooze(ctx, k, until))
 
 		_, ok, err := s.SnoozedUntil(ctx, k, until)
@@ -114,7 +114,7 @@ func RunSnoozeTests(t *testing.T, f Factory) {
 	t.Run("re-snoozing replaces rather than stacks", func(t *testing.T) {
 		s := f(t)
 		k := key("alice", "stale", "T-1")
-		require.NoError(t, s.SetSnooze(ctx, k, base.Add(anHour)))
+		require.NoError(t, s.SetSnooze(ctx, k, base.Add(oneHourSpan)))
 		require.NoError(t, s.SetSnooze(ctx, k, base.Add(oneWeek)))
 
 		got, ok, err := s.SnoozedUntil(ctx, k, base)
@@ -129,11 +129,11 @@ func RunSnoozeTests(t *testing.T, f Factory) {
 		s := f(t)
 		k := key("alice", "stale", "T-1")
 		require.NoError(t, s.SetSnooze(ctx, k, base.Add(oneWeek)))
-		require.NoError(t, s.SetSnooze(ctx, k, base.Add(anHour)))
+		require.NoError(t, s.SetSnooze(ctx, k, base.Add(oneHourSpan)))
 
 		got, _, err := s.SnoozedUntil(ctx, k, base)
 		require.NoError(t, err)
-		require.True(t, got.Equal(base.Add(anHour)), "shorter snooze must win, got %v", got)
+		require.True(t, got.Equal(base.Add(oneHourSpan)), "shorter snooze must win, got %v", got)
 	})
 
 	// Variant is what makes a reset condition surface again.
@@ -242,7 +242,7 @@ func RunShownTests(t *testing.T, f Factory) {
 		require.True(t, ok)
 		require.True(t, at.Equal(base))
 
-		later := base.Add(anHour)
+		later := base.Add(oneHourSpan)
 		require.NoError(t, s.MarkShown(ctx, k, later))
 		at, _, err = s.LastShown(ctx, k)
 		require.NoError(t, err)
@@ -260,7 +260,7 @@ func RunPruneTests(t *testing.T, f Factory) {
 		s := f(t)
 		dead := key("alice", "stale", "T-dead")
 		live := key("alice", "stale", "T-live")
-		require.NoError(t, s.SetSnooze(ctx, dead, base.Add(anHour)))
+		require.NoError(t, s.SetSnooze(ctx, dead, base.Add(oneHourSpan)))
 		require.NoError(t, s.SetSnooze(ctx, live, base.Add(twoDays)))
 
 		removed, err := s.Prune(ctx, base.Add(oneDay), oneMonth)

--- a/tickets/entities/docs-checklists/DOCS-BHFCLM.md
+++ b/tickets/entities/docs-checklists/DOCS-BHFCLM.md
@@ -1,0 +1,52 @@
+---
+id: DOCS-BHFCLM
+type: docs-checklist
+title: 'Docs: Next-action layer'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Code Documentation
+
+- [x] Godoc on the config types (`NextActionBand`, `NextActionSource`,
+      `NextActionOffer`, `NextActionPickOne`, the prominence and defer-scope
+      enums), each carrying the *reason* for its shape rather than restating
+      the field — why bands beat numeric priorities, why prominence is a closed
+      vocabulary, why `defer_scope` cannot be inferred.
+- [x] Package doc on `internal/nextaction` explaining what the one-slot
+      constraint buys: no per-source `limit:`, no ranking within a band, no
+      cache.
+- [x] Package doc on `internal/userstate` stating why this state is not graph
+      content, and on each backend stating its concurrency limits —
+      `kvuserstate` names its whole-document clobber explicitly rather than
+      understating it.
+- [x] The two ACL-sensitive seams carry their reasoning at the call site:
+      `queryCandidates` (field redaction, and why serialization-time redaction
+      does not reach a suggestion) and `countCandidates` (gated by default,
+      `count_ungated` never inferred).
+- [x] ~~CLAUDE.md pattern update~~ (N/A: no new architectural pattern — the
+      layer uses the existing consumer-side-interface, build-tagged-backend and
+      conformance-suite patterns rather than introducing one.)
+
+## Project Documentation
+
+- [x] `docs/data-entry.md` — a `## Next actions` section covering the framing
+      (advisory, one at a time, could-not-should), bands and prominence,
+      sources and their fields, `key_props`, `defer_scope`, the read-gated
+      `count`, the affordance vocabulary, and where per-user state lives.
+- [x] A worked example: the four-source consultancy configuration from
+      RES-09YLLL, with the suggestion sequence it produces and a note on why
+      two near-identical rules sit in different bands.
+- [x] Customisation documented against `docs/customisation.md`'s tiers — the
+      `<rela-slot name="companion">` hook and the `rela-na*` classes, with a
+      worked `custom.js` example.
+
+## External Documentation
+
+- [x] ~~README / external docs~~ (N/A: the feature is configured in
+      `data-entry.yaml`, so `docs/data-entry.md` is its home.)
+
+**Docs verified:** the worked example was run against a live server — every
+suggestion in the documented sequence appears in the order shown, and the
+`pick_one` limit behaves as described.

--- a/tickets/entities/implementation-checklists/IMPL-6JD2HW.md
+++ b/tickets/entities/implementation-checklists/IMPL-6JD2HW.md
@@ -1,0 +1,107 @@
+---
+id: IMPL-6JD2HW
+type: implementation-checklist
+title: 'Implementation: Next-action layer Phase 0'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Development
+
+- [x] Unit tests written for new code
+- [x] Integration tests written (test full flow, not just units)
+- [x] Happy path implemented
+- [x] Edge cases from planning handled
+- [x] Error handling in place (errors surfaced, not swallowed)
+
+Delivered:
+
+- `internal/dataentryconfig/nextaction*.go` — `next_action_bands:` (ordered,
+  operator-declared) and `next_actions:` sources, with validation that rejects
+  unknown band references, ambiguous affordance unions, and unknown prominence
+  or defer-scope values rather than defaulting them.
+- `internal/nextaction/` — the engine: band-order evaluation with
+  short-circuit, engine-owned candidate bound, stable-random pick within a
+  band, snooze/mute/cooldown suppression.
+- `internal/userstate/` — the per-user state seam plus a conformance suite,
+  and THREE backends: `memuserstate`, `kvuserstate` (durable, over the
+  existing `state.KV`), and `pgstore.UserStateStore` (row-level, for
+  multi-process deployments).
+- `internal/dataentry/` — the ACL-gated candidate adapter, the
+  `/api/v1/_next_action` GET/POST surface, and the option resolver for
+  `pick_one`.
+- `frontend/` — `NextActionCard`, `NextActionOffers`, the status-bar chip and
+  popover, and the shared `useNextAction` composable.
+
+Edge cases that needed deciding rather than coding:
+
+- **Count sources are read-gated by default** (`count_ungated:` opts out). An
+  ungated count discloses that entities of a type exist to a principal
+  permitted to read none of them.
+- **`defer_scope`** — what a snooze covers. Found by walking the research's
+  scenarios against a live server: a `pick_one` suggestion keyed per-candidate
+  hands back the same suggestion with a different entity.
+- **The server owns the key shape.** The handler drops the client's echoed
+  `entity_id` for a source-scoped source; trusting it stored the deferral under
+  a key the engine never checks — a 204 that silently did nothing.
+
+## Test Quality
+
+- [x] Using fixture builders or factories for test data
+- [x] No hardcoded values in assertions when object is in scope
+- [x] Only specifying values that matter for the test
+- [x] Interpolated values constructed from objects, not hardcoded
+- [x] Property comparisons use original object, not hardcoded strings
+
+The user-state contract lives in `userstatetest` and every backend runs it, so
+three implementations are held to one behaviour rather than each asserting its
+own. Time is injected throughout (`now` is a parameter, never read from the
+clock), which is what lets the suite pin TTL boundaries deterministically —
+including that a snooze "until T" is over AT T, exactly where `<` and `<=`
+diverge silently between a Go map, a JSON file and SQL.
+
+## Manual Verification
+
+- [x] Feature manually tested end-to-end
+- [x] Each acceptance criterion verified with test scenario from planning
+- [x] Edge cases manually verified
+
+**Verification Evidence:**
+
+Drove a real `rela-server` against a demo project in the browser for every
+prominence tier, and over HTTP for the full scenario set (RES-09YLLL S1/S2/S4/S8):
+banner → notice → status-bar `pick_one` (three options from a live query) →
+quip → nothing owed.
+
+Three defects were found this way and would not have surfaced from unit tests:
+
+1. **The variant did not round-trip.** A source with `key_props` built a key
+   containing a variant the GET never sent, so the client's snooze landed under
+   a different key. POST returned 204; the suggestion kept reappearing.
+2. **`pick_one` deferral was per-candidate** — see `defer_scope` above.
+3. **The handler trusted the client's echoed entity id**, so a source-scoped
+   snooze silently did nothing.
+
+Durability was verified by restarting the server: snoozed a suggestion, killed
+the process, restarted, and the suppression held. The postgres backend ran its
+conformance suite against live PostgreSQL under `-race`, 32 subtests, zero skips.
+
+## Quality
+
+- [x] Code follows project patterns (check similar code)
+- [x] Checked for DRY opportunities — the affordance row is one component
+      shared by the page surface and the status-bar popover, because a snooze
+      that behaved differently depending on where it was clicked is a bug
+      nobody thinks to test for. State is a module singleton for the same
+      reason: two components resolving independently would double-count the
+      impression and could show two suggestions at once.
+- [x] No security issues introduced — candidates and `pick_one` options both
+      route through the ACL-gated read path; option labels use
+      `safeDisplayTitle`, so a redacted display property cannot render a
+      partial title (the BUG-R9EHKV leak class).
+- [x] No silent failures (errors logged AND returned)
+- [x] No debug code left behind
+
+`just arch-lint`, `just plimsoll`, `golangci-lint run ./...` clean; frontend
+typecheck clean with 1706 tests and 0 lint errors.

--- a/tickets/entities/review-checklists/REV-3H4Q3L.md
+++ b/tickets/entities/review-checklists/REV-3H4Q3L.md
@@ -1,0 +1,56 @@
+---
+id: REV-3H4Q3L
+type: review-checklist
+title: 'Review: Next-action layer Phase 0: engine, bands, user-state service (no store changes)'
+status: in-progress
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Automated Checks
+
+- [ ] All tests pass (`just test`)
+- [ ] Lint clean (`just lint`)
+- [ ] Coverage maintained (`just coverage-check`)
+
+## Code Review
+
+- [ ] Run `/code-review` command (invokes cranky-code-reviewer agent)
+- [ ] All critical review-responses addressed
+- [ ] All significant review-responses addressed
+- [ ] Self-reviewed the diff for unrelated changes
+
+**Review Responses:** <!-- List IDs of review-response entities created, e.g.,
+RR-xxxx -->
+
+## Acceptance Verification
+
+- [ ] Each acceptance criterion tested (reference planning checklist)
+- [ ] Test evidence documented in implementation checklist
+
+**Acceptance Status:**
+<!-- For each acceptance criterion, state PASS/FAIL with evidence -->
+
+## Documentation (enhancements only)
+
+Skip this section for bugs and internal refactors.
+
+- [ ] Docs-checklist created and linked via `has-docs`
+- [ ] User-facing documentation updated
+- [ ] Docs-checklist marked as done
+
+**Docs Checklist:** <!-- e.g., DOCS-xxxx -->
+
+## Final Checks
+
+- [ ] Commit message explains the why, not just what
+- [ ] No TODOs or FIXMEs left unaddressed
+- [ ] Ready for another developer to use
+
+## Pull Request
+
+- [ ] Run `/pr` command to create PR and monitor CI
+- [ ] All CI checks pass
+- [ ] PR URL documented below
+
+**PR:** <!-- e.g., https://github.com/org/repo/pull/123 -->

--- a/tickets/entities/review-checklists/REV-3H4Q3L.md
+++ b/tickets/entities/review-checklists/REV-3H4Q3L.md
@@ -1,56 +1,87 @@
 ---
 id: REV-3H4Q3L
 type: review-checklist
-title: 'Review: Next-action layer Phase 0: engine, bands, user-state service (no store changes)'
-status: in-progress
+title: 'Review: Next-action layer Phase 0'
+status: done
 ---
 
 <!-- @managed: claude-workflow v1 -->
 
 ## Automated Checks
 
-- [ ] All tests pass (`just test`)
-- [ ] Lint clean (`just lint`)
-- [ ] Coverage maintained (`just coverage-check`)
+- [x] All tests pass (`just test`) — full `./internal/...` green; pgstore
+      additionally run against live PostgreSQL under `-race`
+- [x] Lint clean (`just lint`) — 0 issues; `just arch-lint` and
+      `just plimsoll` clean
+- [x] Coverage maintained (`just coverage-check`) — package floors satisfied
+
+Frontend: typecheck clean, 1709 tests, 0 lint errors.
 
 ## Code Review
 
-- [ ] Run `/code-review` command (invokes cranky-code-reviewer agent)
-- [ ] All critical review-responses addressed
-- [ ] All significant review-responses addressed
-- [ ] Self-reviewed the diff for unrelated changes
+- [x] Run `/code-review` command (invokes cranky-code-reviewer agent)
+- [x] All critical review-responses addressed — RR-9Z9V07, RR-HO25O0
+- [x] All significant review-responses addressed — RR-RV39AZ, RR-KK413X,
+      RR-3UZR29
+- [x] Self-reviewed the diff for unrelated changes
 
-**Review Responses:** <!-- List IDs of review-response entities created, e.g.,
-RR-xxxx -->
+**Review Responses:** RR-9Z9V07 (critical), RR-HO25O0 (critical), RR-RV39AZ
+(significant), RR-KK413X (significant), RR-3UZR29 (significant), RR-7BI6XC
+(minor), RR-R2CNC7 (minor) — all addressed.
+
+The two criticals were genuine and neither was visible from the feature's own
+tests:
+
+- **RR-9Z9V07** — suggestion messages leaked `visible:`-hidden property
+  values. Reproduced with a failing test before fixing. The root cause is the
+  one the root CLAUDE.md warns about: `executeQuery` returns raw entities and
+  every consumer is individually responsible for redacting on the way out.
+  `/_search` remembers; this layer forgot.
+- **RR-HO25O0** — the property pushdown changed results on a path `/_search`
+  and scope navigation share. My first fix was still wrong (it narrowed away a
+  typed match), which the tests caught.
 
 ## Acceptance Verification
 
-- [ ] Each acceptance criterion tested (reference planning checklist)
-- [ ] Test evidence documented in implementation checklist
+- [x] Each acceptance criterion tested
+- [x] Test evidence documented in implementation checklist
 
 **Acceptance Status:**
-<!-- For each acceptance criterion, state PASS/FAIL with evidence -->
+
+1. **Source resolution engine** — PASS. Band-order evaluation with
+   short-circuit (pinned by a test asserting a lower band is never *queried*),
+   engine-owned candidate bound, stable-random pick.
+2. **Operator-defined bands** — PASS. Ordered list, referenced by id,
+   validation rejects unknown references and unknown prominence values.
+3. **User-state service** — PASS. Three backends (mem, KV, postgres), all
+   passing one conformance suite.
+4. **Conformance suite** — PASS. 32 subtests per backend; the postgres run is
+   DB-gated and verified against live PostgreSQL with zero skips.
+5. **Render surface** — PASS. Three prominence tiers verified in a browser.
+6. **Affordances** — PASS, and extended: `pick_one` (Phase 1) resolves options
+   from a query at render time.
 
 ## Documentation (enhancements only)
 
-Skip this section for bugs and internal refactors.
+- [x] Docs-checklist created and linked via `has-docs`
+- [x] User-facing documentation updated
+- [x] Docs-checklist marked as done
 
-- [ ] Docs-checklist created and linked via `has-docs`
-- [ ] User-facing documentation updated
-- [ ] Docs-checklist marked as done
-
-**Docs Checklist:** <!-- e.g., DOCS-xxxx -->
+**Docs Checklist:** DOCS-BHFCLM
 
 ## Final Checks
 
-- [ ] Commit message explains the why, not just what
-- [ ] No TODOs or FIXMEs left unaddressed
-- [ ] Ready for another developer to use
+- [x] Commit message explains the why, not just what
+- [x] No TODOs or FIXMEs left unaddressed
+- [x] Ready for another developer to use
 
 ## Pull Request
 
-- [ ] Run `/pr` command to create PR and monitor CI
-- [ ] All CI checks pass
-- [ ] PR URL documented below
+- [x] ~~Run `/pr` command to create PR and monitor CI~~ (N/A: pushing and
+      opening a PR is the maintainer's call — not taken autonomously.)
+- [x] ~~All CI checks pass~~ (N/A: no PR yet. CI's constituent targets were run
+      locally — lint, arch-lint, plimsoll, full Go suite, the postgres suite
+      with `-race`, frontend typecheck/tests/lint — all green.)
+- [x] ~~PR URL documented below~~ (N/A: no PR yet)
 
-**PR:** <!-- e.g., https://github.com/org/repo/pull/123 -->
+**PR:** not created. The work sits on `feat/next-action-phase0`.

--- a/tickets/entities/review-responses/RR-3UZR29.md
+++ b/tickets/entities/review-responses/RR-3UZR29.md
@@ -1,0 +1,9 @@
+---
+id: RR-3UZR29
+type: review-response
+title: Impression reported on load rather than on render
+severity: significant
+status: addressed
+finding: 'The impression that starts a cooldown was reported from load(). Since load() also runs after feedback, snoozing suggestion A immediately marked its replacement B as shown -- starting B s 24h cooldown for an impression that never happened, so B was suppressed having never appeared. Directly contradicted the stated invariant that a discarded response cannot silently consume a suggestion.'
+resolution: 'load() no longer reports. A markShown() function is called by the component that actually renders the suggestion -- the page card for banner/notice, the status-bar chip for its own tier -- and is idempotent per suggestion key so the two shared surfaces cannot double-count. Four tests cover it, including that a replacement gets its own impression once rendered.'
+---

--- a/tickets/entities/review-responses/RR-7BI6XC.md
+++ b/tickets/entities/review-responses/RR-7BI6XC.md
@@ -1,0 +1,9 @@
+---
+id: RR-7BI6XC
+type: review-response
+title: Enum-value validation lost on pushdown
+severity: minor
+status: addressed
+finding: 'filter.matchEnum errors when a filter value is not a declared enum value, which surfaces an operator typo. Pushed down, prop:status=snet silently matched nothing and the source went permanently quiet with no diagnostic -- and the documented example in docs/data-entry.md is exactly this shape.'
+resolution: 'Subsumed by the pre-filter fix (RR-HO25O0): enums are excluded from pushdown eligibility, so matchEnum still runs and still errors on an undeclared value.'
+---

--- a/tickets/entities/review-responses/RR-9Z9V07.md
+++ b/tickets/entities/review-responses/RR-9Z9V07.md
@@ -1,0 +1,9 @@
+---
+id: RR-9Z9V07
+type: review-response
+title: Suggestion messages leaked visible:-hidden property values
+severity: critical
+status: addressed
+finding: 'executeQuery returns row-gated but UNREDACTED entities. Every other consumer redacts at serialization (forWireRelated -> stripHiddenProperties); the next-action path never serializes through that seam, because a suggestion interpolates {property} straight into text. An operator writing suggest: "{title} needs a look" on a type whose title is hidden by visible: put the hidden value on the wire. Reproduced with a failing test: message came back as "Look at SECRET-TITLE" while GET /api/v1/tickets/<id> correctly omitted it. This also defeated safeDisplayTitle in the pick_one option labels, whose guard is presence-based and therefore a no-op against an unredacted entity. The BUG-R9EHKV leak class through a new door.'
+resolution: 'Candidates and pick_one options are now field-redacted at the adapter boundary via affordanceService.copyVisibleProperties, on a COPY (the entity comes from the store iterator and may be shared). Options are redacted BEFORE safeDisplayTitle so its presence check works. An unresolvable placeholder is left verbatim ({title}) rather than emptied: per the root CLAUDE.md, visible: conceals values, not the existence of property names. Two tests pin it, one for the message and one for option labels.'
+---

--- a/tickets/entities/review-responses/RR-HO25O0.md
+++ b/tickets/entities/review-responses/RR-HO25O0.md
@@ -1,0 +1,9 @@
+---
+id: RR-HO25O0
+type: review-response
+title: Property pushdown changed results on the shared executeQuery path
+severity: critical
+status: addressed
+finding: 'The pushdown removed pushed filters from the Go pass, so store.PropPredicate (string-form comparison) became authoritative for them instead of the metamodel-aware filter.MatchAll. They disagree on typed properties: count!=03 against an integer 3 is a non-match typed and a match as strings; flag!=yes on a boolean errors in Go (excluding the row) and matches in the store. Two of the divergences were WIDENINGS, on a path /_search and scope navigation share.'
+resolution: 'The pushdown is now a pure PRE-FILTER: the Go pass still evaluates every filter and stays authoritative, so the store can only remove rows that pass would also remove. A first attempt at this was still wrong -- pushing count=03 NARROWED away a row the typed comparison matches -- so eligibility is now checked against the metamodel: only properties declared string on EVERY named type in the query are pushed, and an unnamed-type query pushes nothing. Not-equal is excluded entirely, since it is the operator where a disagreement widens. Tests cover the typed-property case end to end through the real metamodel.'
+---

--- a/tickets/entities/review-responses/RR-KK413X.md
+++ b/tickets/entities/review-responses/RR-KK413X.md
@@ -1,0 +1,9 @@
+---
+id: RR-KK413X
+type: review-response
+title: Engine.WithOptions mutated a shared receiver
+severity: significant
+status: addressed
+finding: 'kvuserstate.load() cached the document after first use and never re-read it, so a second process observed NONE of the first process s writes -- not merely conflicting ones. A user snoozing on server A kept seeing the suggestion on server B indefinitely, and B s next write clobbered A s whole document. The package doc understated this as last-writer-wins.'
+resolution: 'load() re-reads on every operation, so a cross-process write is observed. The remaining limitation (concurrent WRITES still clobber the whole document) is now stated plainly in the package doc rather than understated, with the postgres backend named as the multi-process answer. A test with two Stores over one KV pins visibility, and was mutation-tested: restoring the cache makes it fail.'
+---

--- a/tickets/entities/review-responses/RR-R2CNC7.md
+++ b/tickets/entities/review-responses/RR-R2CNC7.md
@@ -1,0 +1,9 @@
+---
+id: RR-R2CNC7
+type: review-response
+title: Engine.WithOptions mutated a shared receiver
+severity: minor
+status: addressed
+finding: 'Engine.WithOptions mutated its receiver and returned it, a builder on a value documented as safe for concurrent use -- and the handler doc invites caching an engine, which would have made it a live data race.'
+resolution: 'Replaced with a construction-time functional option, nextaction.WithOptions(fn) passed to New. Chosen over returning a copy because the tests revealed the builder shape is a footgun either way: a copy-returning builder is silently a no-op when the caller discards the result, which three tests did. Neither mistake is available now.'
+---

--- a/tickets/entities/review-responses/RR-RV39AZ.md
+++ b/tickets/entities/review-responses/RR-RV39AZ.md
@@ -1,0 +1,9 @@
+---
+id: RR-RV39AZ
+type: review-response
+title: pick_one options read a second metamodel snapshot
+severity: significant
+status: addressed
+finding: 'nextActionOptions called a.Meta() inside a loop -- a fresh atomic.Pointer load per call, and a different snapshot from the one executeQuery used to resolve the ACL scope. A config reload landing mid-resolve would label options against a metamodel that did not match the one that gated them. Violates the capture-state-once rule in the root CLAUDE.md.'
+resolution: 'One a.State() snapshot is taken above the loop and s.Meta used throughout.'
+---

--- a/tickets/entities/tickets/TKT-CXD0A4.md
+++ b/tickets/entities/tickets/TKT-CXD0A4.md
@@ -5,7 +5,7 @@ title: 'Next-action layer Phase 0: engine, bands, user-state service (no store c
 kind: enhancement
 priority: medium
 effort: l
-status: review
+status: done
 ---
 
 ## Goal

--- a/tickets/entities/tickets/TKT-CXD0A4.md
+++ b/tickets/entities/tickets/TKT-CXD0A4.md
@@ -5,7 +5,7 @@ title: 'Next-action layer Phase 0: engine, bands, user-state service (no store c
 kind: enhancement
 priority: medium
 effort: l
-status: backlog
+status: review
 ---
 
 ## Goal

--- a/tickets/relations/TKT-CXD0A4--has-docs--DOCS-BHFCLM.md
+++ b/tickets/relations/TKT-CXD0A4--has-docs--DOCS-BHFCLM.md
@@ -1,0 +1,5 @@
+---
+from: TKT-CXD0A4
+relation: has-docs
+to: DOCS-BHFCLM
+---

--- a/tickets/relations/TKT-CXD0A4--has-implementation--IMPL-6JD2HW.md
+++ b/tickets/relations/TKT-CXD0A4--has-implementation--IMPL-6JD2HW.md
@@ -1,0 +1,5 @@
+---
+from: TKT-CXD0A4
+relation: has-implementation
+to: IMPL-6JD2HW
+---

--- a/tickets/relations/TKT-CXD0A4--has-review--REV-3H4Q3L.md
+++ b/tickets/relations/TKT-CXD0A4--has-review--REV-3H4Q3L.md
@@ -1,0 +1,5 @@
+---
+from: TKT-CXD0A4
+relation: has-review
+to: REV-3H4Q3L
+---

--- a/tickets/relations/TKT-CXD0A4--has-review-response--RR-3UZR29.md
+++ b/tickets/relations/TKT-CXD0A4--has-review-response--RR-3UZR29.md
@@ -1,0 +1,5 @@
+---
+from: TKT-CXD0A4
+relation: has-review-response
+to: RR-3UZR29
+---

--- a/tickets/relations/TKT-CXD0A4--has-review-response--RR-7BI6XC.md
+++ b/tickets/relations/TKT-CXD0A4--has-review-response--RR-7BI6XC.md
@@ -1,0 +1,5 @@
+---
+from: TKT-CXD0A4
+relation: has-review-response
+to: RR-7BI6XC
+---

--- a/tickets/relations/TKT-CXD0A4--has-review-response--RR-9Z9V07.md
+++ b/tickets/relations/TKT-CXD0A4--has-review-response--RR-9Z9V07.md
@@ -1,0 +1,5 @@
+---
+from: TKT-CXD0A4
+relation: has-review-response
+to: RR-9Z9V07
+---

--- a/tickets/relations/TKT-CXD0A4--has-review-response--RR-HO25O0.md
+++ b/tickets/relations/TKT-CXD0A4--has-review-response--RR-HO25O0.md
@@ -1,0 +1,5 @@
+---
+from: TKT-CXD0A4
+relation: has-review-response
+to: RR-HO25O0
+---

--- a/tickets/relations/TKT-CXD0A4--has-review-response--RR-KK413X.md
+++ b/tickets/relations/TKT-CXD0A4--has-review-response--RR-KK413X.md
@@ -1,0 +1,5 @@
+---
+from: TKT-CXD0A4
+relation: has-review-response
+to: RR-KK413X
+---

--- a/tickets/relations/TKT-CXD0A4--has-review-response--RR-R2CNC7.md
+++ b/tickets/relations/TKT-CXD0A4--has-review-response--RR-R2CNC7.md
@@ -1,0 +1,5 @@
+---
+from: TKT-CXD0A4
+relation: has-review-response
+to: RR-R2CNC7
+---

--- a/tickets/relations/TKT-CXD0A4--has-review-response--RR-RV39AZ.md
+++ b/tickets/relations/TKT-CXD0A4--has-review-response--RR-RV39AZ.md
@@ -1,0 +1,5 @@
+---
+from: TKT-CXD0A4
+relation: has-review-response
+to: RR-RV39AZ
+---


### PR DESCRIPTION
Phase 0 of the next-action layer (TKT-CXD0A4, part of FEAT-79DTF9; design in RES-09YLLL).

An optional advisory layer: operator-declared rules that derive **one** suggested
follow-up from graph state and surface it as a hint in the data-entry UI.

Deliberately not a task queue — advisory, one at a time, good rather than optimal.
Silence is the normal state of a well-configured system.

## What's here

- **`internal/dataentryconfig`** — `next_action_bands` + `next_action_sources`
  config, validated at load.
- **`internal/nextaction`** — the engine. Bands are the priority vocabulary
  (list order is priority order); evaluation short-circuits at the first band
  with something to say, so a typical page runs one or two queries, not all of
  them. Ties broken by a stable-random pick seeded per user per day.
- **`internal/userstate`** — snooze / mute / cooldown state, with a conformance
  suite and three backends: `memuserstate`, `kvuserstate` (over `state.KV`), and
  `pgstore.UserStateStore` for multi-process deployments.
- **`internal/dataentry`** — the ACL-gated adapter and `_next_action` endpoint.
- **SPA** — card, offers row, status-bar surface, with `rela-` classes and a
  `<rela-slot name="companion">` so operators can skin it per `docs/customisation.md`.

Bands rather than numeric priorities because per-source numbers don't compose:
one source returning 90 and another returning 7 on a different scale is arbitrary
ordering wearing the costume of ranking. With bands, "why is this on top?" always
has a one-sentence answer.

## Security posture

No ungated reads. Suggestions are built from entities the principal can already
see, and count-based sources are gated unless the operator explicitly opts out
with `count_ungated`. A misconfigured source shows *first-run* to everyone rather
than leaking existence.

Two ACL defects were found and fixed during review, both with failing tests first:

- **Field redaction** — `executeQuery` returns unredacted entities, and a
  suggestion interpolates property values straight into user-visible text.
  `/_search` redacts at serialization, so that path was safe and this one wasn't.
  Fixed at the candidate boundary. Property *names* are left verbatim: the
  metamodel is served over the API, so they aren't secret.
- **Filter pushdown** — pushing predicates into the store changed results.
  Dropping pushed filters from the Go pass let string-form comparison decide
  (`count!=03` widened). Now metamodel-checked, string-only, equality-only, and
  strictly a pre-filter: the Go pass still evaluates every filter and stays
  authoritative.

## Verification

`just ci` green: lint, arch-lint, plimsoll, lint-md, tests, coverage (78.0%),
build, docs-check. Postgres suite passes uncached under `-race` with
`RELA_TEST_DATABASE_REQUIRED=1`. Frontend: 1716 tests, typecheck clean.

Live-verified in the browser — jsonb list handling, a 42P18 parameter bug, the
`variant` round-trip and `defer_scope` were all found that way, not by unit tests.

## Notes for the reviewer

- `rela validate --project tickets` currently reports 10 errors. **All are
  pre-existing on `develop`** (verified by swapping `tickets/` and re-running:
  same 10) and name other tickets — `BUG-762I34`, `BUG-219PVU`, `BUG-ZE4354`,
  `TKT-UIR41P` and three open review-responses. TKT-CXD0A4's own gates are green:
  `done`, all three checklists `done`, all seven review-responses `addressed`
  including both criticals.
- `internal/userstate/userstatetest` is excluded from coverage, beside the four
  sibling conformance harnesses already listed — its statements only execute
  when a backend calls `RunAll`.
- Migration renumbered `0008` → `0009` during rebase: `#1327` took `0008` for
  `state_kv`.
