### PR TITLE
docs(tickets): dedupe the validate-fails-open bug (BUG-RMCK9U → BUG-NEQRY2)

### DIFF
--- a/tickets/entities/automated-measures/AM-validate-fails-on-unparseable-entity.md
+++ b/tickets/entities/automated-measures/AM-validate-fails-on-unparseable-entity.md
@@ -1,9 +1,21 @@
 ---
 id: AM-validate-fails-on-unparseable-entity
 type: automated-measure
-title: rela validate exits non-zero when an entity cannot be parsed
+title: 'SUPERSEDED by AM-validate-fails-closed-on-unparseable-entity'
 description: Guards the failure mode where a malformed entity is silently dropped from the result set and validate still exits 0. A fixture entity with unparseable frontmatter must make validate exit non-zero and name the offending path.
 kind: ci
 location: internal/cli/validate.go + tickets CI job in .github/workflows/ci.yml
-status: proposed
+status: deprecated
 ---
+
+> **Superseded.** Filed alongside BUG-RMCK9U, which is a duplicate of
+> BUG-NEQRY2; the surviving measure is
+> `AM-validate-fails-closed-on-unparseable-entity`. Kept as `deprecated` rather
+> than deleted so the `adds-measure` relation from BUG-RMCK9U stays intact and
+> the trail is readable.
+>
+> Note the two describe slightly different guards, and the survivor is the
+> better one: this measure named `ci.yml` as a location, which is what
+> #1363 actually shipped — a grep for a log line. The survivor targets
+> `internal/cli/`, i.e. the exit code itself, which is the guarantee that
+> should not live in a pipeline file.

--- a/tickets/entities/bugs/BUG-NEQRY2.md
+++ b/tickets/entities/bugs/BUG-NEQRY2.md
@@ -108,3 +108,34 @@ Re-verified on `develop` at 93240281 (after #1337 landed): restoring the
 unquoted frontmatter still yields `EXIT=0` and "All validations passed" while
 logging 2 `failed to parse frontmatter` errors. The individual files were
 repaired; the behaviour that hid them was not.
+
+## Mitigated in CI, not fixed in the tool (#1363)
+
+TKT-W76LRP added an **"Entities all parse"** step to `ci.yml` that runs the
+store scan and greps stderr for `failed to parse frontmatter`, failing the job
+when it matches. That closes the merge-gate hole this ticket was filed about,
+and it is why this is no longer urgent.
+
+It does not fix the bug. Re-verified on `develop` at 4259daca, after #1363 and
+#1360 landed: a project containing one unparseable entity still makes
+
+```console
+$ rela validate --check cardinality --check properties --check validations
+All validations passed.
+EXIT=0
+```
+
+`rela validate` continues to report success over a corpus it did not fully
+read. The CI job now catches it out-of-band by pattern-matching a log line —
+which works, but means the guarantee lives in a grep in a YAML file rather than
+in the command's exit code. Anyone running `rela validate` locally, or from a
+different pipeline, still gets a green result on a partial read.
+
+The remaining work is the one-line-ish version of the fix: propagate the
+iterator error to a non-zero exit and name the offending files. The CI step can
+then become redundant rather than load-bearing.
+
+## Duplicate
+
+Filed independently as **BUG-RMCK9U** (merged in #1330's stack) while this
+ticket was open. That one is closed `wont-fix` pointing here.

--- a/tickets/entities/bugs/BUG-RMCK9U.md
+++ b/tickets/entities/bugs/BUG-RMCK9U.md
@@ -1,12 +1,29 @@
 ---
 id: BUG-RMCK9U
 type: bug
-title: rela validate exits 0 when an entity's frontmatter cannot be parsed
+title: 'DUPLICATE of BUG-NEQRY2: rela validate exits 0 when frontmatter cannot be parsed'
 description: An entity whose YAML frontmatter fails to parse is skipped with a WARN by store.ListEntities, but rela validate still reports 'All validations passed' and exits 0. CI therefore cannot catch a malformed entity, and every automation run fails at 'collect existing IDs', silently skipping checklist creation repo-wide.
 priority: high
 effort: s
-status: backlog
+status: wont-fix
 ---
+
+
+> **Duplicate of BUG-NEQRY2 — closed in its favour.**
+>
+> The same defect was filed twice, three days apart, by two people who each
+> tripped over it while doing something else. That is itself evidence for the
+> bug: it is only ever found by accident.
+>
+> BUG-NEQRY2 is the surviving ticket. It has the fuller write-up — the causal
+> chain showing how the silent under-count hid a merged-`done` bug with no
+> review record, and the comparison against the earlier `AM-date-property-
+> write-roundtrip` occurrence that failed *loudly* and so was fixed at once.
+> That asymmetry is the argument for failing closed, and it is worth keeping.
+>
+> The reproduction below is still accurate and still reproduces; it is left in
+> place rather than deleted so anyone landing here from a search sees the
+> evidence rather than a redirect.
 
 ## Reproduction
 


### PR DESCRIPTION
`BUG-RMCK9U` and `BUG-NEQRY2` are the same defect, filed three days apart by two people who each tripped over it while doing something else. Both are now on `develop`, so this closes one.

## Resolution

**`BUG-NEQRY2` survives.** Its write-up is stronger: it carries the causal chain showing how the silent under-count hid a merged-`done` bug with no review record for days, and the comparison against the earlier `AM-date-property-write-roundtrip` occurrence that failed *loudly* and so was fixed immediately. That asymmetry is the actual argument for failing closed, and it's worth keeping.

**`BUG-RMCK9U` → `wont-fix`**, titled as a duplicate and pointing at the survivor. Its reproduction is left in place rather than deleted, so anyone landing there from a search sees the evidence instead of a redirect.

**`AM-validate-fails-on-unparseable-entity` → `deprecated`**, not deleted, so its `adds-measure` relation stays intact. The two measures differ in a way that favours the survivor: mine named `ci.yml` as the location — which is what #1363 actually shipped, a grep for a log line — while the survivor targets `internal/cli/`, i.e. the exit code itself.

That the same bug was found twice, both times by accident, is itself evidence for it.

## Also: what #1363 did and did not do

TKT-W76LRP added an **"Entities all parse"** CI step that runs the store scan and greps stderr for `failed to parse frontmatter`. That closes the merge-gate hole and is why this is no longer urgent.

**It does not fix the bug.** Re-verified on `develop` at `4259daca`, after both #1363 and #1360 landed:

```console
$ rela validate --check cardinality --check properties --check validations
All validations passed.
EXIT=0
```

…while the same run logged **2** `failed to parse frontmatter` errors. `rela validate` still reports success over a corpus it did not fully read. The guarantee currently lives in a grep in a YAML file rather than in the command's exit code, so anyone running it locally, or from a different pipeline, still gets green on a partial read.

I've written this into the surviving ticket so it isn't later closed on the false premise that #1363 fixed it. The remaining work is small: propagate the iterator error to a non-zero exit and name the offending files, after which the CI step becomes redundant rather than load-bearing.

## Testing

`rela validate` clean on the full tickets corpus. No code changes.

Tickets-PR: this PR