### PR TITLE
feat(pgstore): derived-schema reconciler — atomic unique:true (TKT-3Q0GP1)

### DIFF
--- a/docs-project/entities/guides/GUIDE-acl-security.md
+++ b/docs-project/entities/guides/GUIDE-acl-security.md
@@ -147,33 +147,30 @@ Two layers keep that from happening:
    grants only what the raw string is assigned — it never silently picks
    one of the duplicates.
 
-**Enforcement rigor by backend.** The write-time uniqueness check is
-exact on the single-writer backends (fsstore, memstore). On PostgreSQL,
-concurrent writers leave a narrow time-of-check/time-of-use window
-between the check and the durable write. Operators who need race-free
-enforcement add a partial unique index — which is also the recommended
-performance index for the lookup itself:
+**Enforcement rigor by backend.** The application-level uniqueness check
+reads the existing entities of the type and then writes — two separate
+operations with no lock held across them. On the single-writer backends
+(fsstore, memstore) that is race-free enough. Under concurrent writers,
+though, two racing writes with the same value could both pass the check
+and both commit, leaving a duplicate.
 
-```sql
-CREATE UNIQUE INDEX persoon_email_unique_idx
-  ON entities ((properties->>'email'))
-  WHERE type = 'persoon';
-```
+On **PostgreSQL** this window is closed automatically: rela maintains a
+partial unique index for every `unique: true` property (see
+[Derived schema](postgres-backend.md#derived-schema-unique-constraints)
+in the PostgreSQL backend guide), so a colliding write fails atomically in
+the database and surfaces as the same conflict the write path already
+reports. You do not add this index by hand — rela creates and maintains it
+from the metamodel. (If existing rows already contain duplicate values when
+you add `unique: true`, the index cannot be built; rela warns and leaves it
+unenforced until you clean up the duplicates — run `rela db reconcile
+--dry-run` to see what is blocking it.)
 
-With the index in place a colliding write fails atomically in the
-database and surfaces as the same conflict the write path already
-reports.
-
-**The write-time check is not atomic.** It reads the existing entities
-of the type, then writes — two separate operations with no lock held
-across them. Under concurrent writers (the data-entry server runs one
-goroutine per request) two racing writes with the same value can both
-pass the check and both commit, on *any* backend, not just PostgreSQL.
-The window is small, and the resolver's multi-match fallback (keep-raw,
-above) is the runtime backstop for the identity-key case — but the only
-*race-free* enforcement is the store-level unique index. If you rely on
-uniqueness for correctness rather than as a data-quality guard, add the
-index.
+This matters most for `unmatched_principal: provision`
+([below](#unknown-verified-identities-unmatched_principal)), which creates a
+stub user keyed on `principal_property`: the database index is what
+guarantees two servers provisioning the same subject at once produce exactly
+one user rather than a permanently ambiguous pair. On fsstore/memstore, which
+have no such index, keep provisioning to a single writer.
 
 **Two operator notes for `principal_property`:**
 

--- a/docs-project/entities/guides/GUIDE-metamodel.md
+++ b/docs-project/entities/guides/GUIDE-metamodel.md
@@ -620,7 +620,7 @@ entities:
 | `format`         | Date format (Go layout string, e.g., `2006-01-02`)                                    |
 | `description`    | Documentation for the property                                                        |
 | `list: true`     | Allow multiple values (multi-select for enum types)                                   |
-| `unique: true`   | Natural key: no two entities of the type may share a non-empty value (write-time 422; find pre-existing dups with `rela analyze unique`). Not for `list` properties. On the PostgreSQL backend this is additionally enforced by an automatically-maintained database index, so it holds even under concurrent writers ([details](postgres-backend.md#derived-schema-unique-constraints)). |
+| `unique: true`   | Natural key: no two entities of the type may share a non-empty value (write-time 422; find pre-existing dups with `rela analyze unique`). Only for string-valued properties (`string`, `date`, `datetime`, `enum`, custom types) — not `list`, and not `integer`/`boolean`/`file`. On the PostgreSQL backend this is additionally enforced by an automatically-maintained database index, so it holds even under concurrent writers ([details](postgres-backend.md#derived-schema-unique-constraints)). |
 | `max`            | For `file` properties: max attachments (default 1)                                    |
 | `accept`         | For `file` properties: narrow the MIME allowlist (e.g. `[application/pdf]`)           |
 | `scan_cmd`       | For `file` properties: the scan command (array args); configuring it enables scanning |

--- a/docs-project/entities/guides/GUIDE-metamodel.md
+++ b/docs-project/entities/guides/GUIDE-metamodel.md
@@ -620,7 +620,7 @@ entities:
 | `format`         | Date format (Go layout string, e.g., `2006-01-02`)                                    |
 | `description`    | Documentation for the property                                                        |
 | `list: true`     | Allow multiple values (multi-select for enum types)                                   |
-| `unique: true`   | Natural key: no two entities of the type may share a non-empty value (write-time 422; find pre-existing dups with `rela analyze unique`). Not for `list` properties. |
+| `unique: true`   | Natural key: no two entities of the type may share a non-empty value (write-time 422; find pre-existing dups with `rela analyze unique`). Not for `list` properties. On the PostgreSQL backend this is additionally enforced by an automatically-maintained database index, so it holds even under concurrent writers ([details](postgres-backend.md#derived-schema-unique-constraints)). |
 | `max`            | For `file` properties: max attachments (default 1)                                    |
 | `accept`         | For `file` properties: narrow the MIME allowlist (e.g. `[application/pdf]`)           |
 | `scan_cmd`       | For `file` properties: the scan command (array args); configuring it enables scanning |

--- a/docs-project/entities/guides/GUIDE-postgres-backend.md
+++ b/docs-project/entities/guides/GUIDE-postgres-backend.md
@@ -88,6 +88,53 @@ rela's tables are created in the connection's default schema (typically
 `public`). Point rela at a database it owns; if you share a schema with
 another application, rela's tables sit alongside it.
 
+## Derived schema (unique constraints)
+
+Some things you declare in the metamodel are enforced not only in the
+application but by the **database itself** on the PostgreSQL backend. Today
+that means `unique: true` properties: for each one, rela maintains a partial
+unique index (named `rela_derived_uniq__…`) so a duplicate value is rejected
+atomically at write time, even across two server processes writing at once.
+On the filesystem backend the same rule is enforced by an application-level
+check, which is race-free enough for a single process; the database index is
+what makes it safe for a multi-writer PostgreSQL deployment.
+
+These indexes are **derived from the metamodel, not from a migration**. rela
+reconciles them at every start: it compares what `schema.yaml` declares
+against the indexes actually present and creates the missing ones, dropping
+any it previously created for a rule you have since removed. This is
+idempotent and self-correcting — a hand-dropped index is recreated on the
+next start — and in the steady state (nothing changed) it does no work.
+
+### When a constraint can't be enforced
+
+Adding `unique: true` to a property whose existing rows already contain
+duplicate values cannot create the index — PostgreSQL rejects it. rela treats
+this as a **warning, not a fatal error**: the server still starts, the
+property is simply left unenforced at the database level (the application
+check still runs), and a message tells you which property and how many
+duplicate value groups are blocking it. This is deliberate: a configuration
+edit must never turn existing data into a startup outage. Clean up the
+duplicates and the constraint is enforced on the next reconcile.
+
+### Inspecting and reconciling explicitly
+
+Like migrations, reconciliation runs automatically at startup, but you can
+also drive it as an explicit step:
+
+```bash
+rela db status              # also reports any derived-schema drift (always exit 0 for drift)
+rela db reconcile           # create/drop derived objects to match the metamodel
+rela db reconcile --dry-run # show what WOULD change; non-zero exit if anything would — a CI/pre-deploy gate
+```
+
+`rela db reconcile --dry-run` is the pre-flight: run it against your live
+database before shipping a schema change to see exactly which constraints
+would be created, dropped, or left unenforced (and, with `--show-values`, a
+sample of the blocking values — this prints entity data, so it is opt-in and
+operator-only). Because the dry-run and the real startup reconcile share one
+planner, what the dry-run predicts is what startup does.
+
 ## Search
 
 In the PostgreSQL build, search runs **in the database** (a `tsvector`

--- a/docs/acl-security.md
+++ b/docs/acl-security.md
@@ -141,33 +141,30 @@ Two layers keep that from happening:
    grants only what the raw string is assigned — it never silently picks
    one of the duplicates.
 
-**Enforcement rigor by backend.** The write-time uniqueness check is
-exact on the single-writer backends (fsstore, memstore). On PostgreSQL,
-concurrent writers leave a narrow time-of-check/time-of-use window
-between the check and the durable write. Operators who need race-free
-enforcement add a partial unique index — which is also the recommended
-performance index for the lookup itself:
+**Enforcement rigor by backend.** The application-level uniqueness check
+reads the existing entities of the type and then writes — two separate
+operations with no lock held across them. On the single-writer backends
+(fsstore, memstore) that is race-free enough. Under concurrent writers,
+though, two racing writes with the same value could both pass the check
+and both commit, leaving a duplicate.
 
-```sql
-CREATE UNIQUE INDEX persoon_email_unique_idx
-  ON entities ((properties->>'email'))
-  WHERE type = 'persoon';
-```
+On **PostgreSQL** this window is closed automatically: rela maintains a
+partial unique index for every `unique: true` property (see
+[Derived schema](postgres-backend.md#derived-schema-unique-constraints)
+in the PostgreSQL backend guide), so a colliding write fails atomically in
+the database and surfaces as the same conflict the write path already
+reports. You do not add this index by hand — rela creates and maintains it
+from the metamodel. (If existing rows already contain duplicate values when
+you add `unique: true`, the index cannot be built; rela warns and leaves it
+unenforced until you clean up the duplicates — run `rela db reconcile
+--dry-run` to see what is blocking it.)
 
-With the index in place a colliding write fails atomically in the
-database and surfaces as the same conflict the write path already
-reports.
-
-**The write-time check is not atomic.** It reads the existing entities
-of the type, then writes — two separate operations with no lock held
-across them. Under concurrent writers (the data-entry server runs one
-goroutine per request) two racing writes with the same value can both
-pass the check and both commit, on *any* backend, not just PostgreSQL.
-The window is small, and the resolver's multi-match fallback (keep-raw,
-above) is the runtime backstop for the identity-key case — but the only
-*race-free* enforcement is the store-level unique index. If you rely on
-uniqueness for correctness rather than as a data-quality guard, add the
-index.
+This matters most for `unmatched_principal: provision`
+([below](#unknown-verified-identities-unmatched_principal)), which creates a
+stub user keyed on `principal_property`: the database index is what
+guarantees two servers provisioning the same subject at once produce exactly
+one user rather than a permanently ambiguous pair. On fsstore/memstore, which
+have no such index, keep provisioning to a single writer.
 
 **Two operator notes for `principal_property`:**
 

--- a/docs/metamodel.md
+++ b/docs/metamodel.md
@@ -614,7 +614,7 @@ entities:
 | `format`         | Date format (Go layout string, e.g., `2006-01-02`)                                    |
 | `description`    | Documentation for the property                                                        |
 | `list: true`     | Allow multiple values (multi-select for enum types)                                   |
-| `unique: true`   | Natural key: no two entities of the type may share a non-empty value (write-time 422; find pre-existing dups with `rela analyze unique`). Not for `list` properties. |
+| `unique: true`   | Natural key: no two entities of the type may share a non-empty value (write-time 422; find pre-existing dups with `rela analyze unique`). Not for `list` properties. On the PostgreSQL backend this is additionally enforced by an automatically-maintained database index, so it holds even under concurrent writers ([details](postgres-backend.md#derived-schema-unique-constraints)). |
 | `max`            | For `file` properties: max attachments (default 1)                                    |
 | `accept`         | For `file` properties: narrow the MIME allowlist (e.g. `[application/pdf]`)           |
 | `scan_cmd`       | For `file` properties: the scan command (array args); configuring it enables scanning |

--- a/docs/metamodel.md
+++ b/docs/metamodel.md
@@ -614,7 +614,7 @@ entities:
 | `format`         | Date format (Go layout string, e.g., `2006-01-02`)                                    |
 | `description`    | Documentation for the property                                                        |
 | `list: true`     | Allow multiple values (multi-select for enum types)                                   |
-| `unique: true`   | Natural key: no two entities of the type may share a non-empty value (write-time 422; find pre-existing dups with `rela analyze unique`). Not for `list` properties. On the PostgreSQL backend this is additionally enforced by an automatically-maintained database index, so it holds even under concurrent writers ([details](postgres-backend.md#derived-schema-unique-constraints)). |
+| `unique: true`   | Natural key: no two entities of the type may share a non-empty value (write-time 422; find pre-existing dups with `rela analyze unique`). Only for string-valued properties (`string`, `date`, `datetime`, `enum`, custom types) — not `list`, and not `integer`/`boolean`/`file`. On the PostgreSQL backend this is additionally enforced by an automatically-maintained database index, so it holds even under concurrent writers ([details](postgres-backend.md#derived-schema-unique-constraints)). |
 | `max`            | For `file` properties: max attachments (default 1)                                    |
 | `accept`         | For `file` properties: narrow the MIME allowlist (e.g. `[application/pdf]`)           |
 | `scan_cmd`       | For `file` properties: the scan command (array args); configuring it enables scanning |

--- a/docs/postgres-backend.md
+++ b/docs/postgres-backend.md
@@ -82,6 +82,53 @@ rela's tables are created in the connection's default schema (typically
 `public`). Point rela at a database it owns; if you share a schema with
 another application, rela's tables sit alongside it.
 
+## Derived schema (unique constraints)
+
+Some things you declare in the metamodel are enforced not only in the
+application but by the **database itself** on the PostgreSQL backend. Today
+that means `unique: true` properties: for each one, rela maintains a partial
+unique index (named `rela_derived_uniq__…`) so a duplicate value is rejected
+atomically at write time, even across two server processes writing at once.
+On the filesystem backend the same rule is enforced by an application-level
+check, which is race-free enough for a single process; the database index is
+what makes it safe for a multi-writer PostgreSQL deployment.
+
+These indexes are **derived from the metamodel, not from a migration**. rela
+reconciles them at every start: it compares what `schema.yaml` declares
+against the indexes actually present and creates the missing ones, dropping
+any it previously created for a rule you have since removed. This is
+idempotent and self-correcting — a hand-dropped index is recreated on the
+next start — and in the steady state (nothing changed) it does no work.
+
+### When a constraint can't be enforced
+
+Adding `unique: true` to a property whose existing rows already contain
+duplicate values cannot create the index — PostgreSQL rejects it. rela treats
+this as a **warning, not a fatal error**: the server still starts, the
+property is simply left unenforced at the database level (the application
+check still runs), and a message tells you which property and how many
+duplicate value groups are blocking it. This is deliberate: a configuration
+edit must never turn existing data into a startup outage. Clean up the
+duplicates and the constraint is enforced on the next reconcile.
+
+### Inspecting and reconciling explicitly
+
+Like migrations, reconciliation runs automatically at startup, but you can
+also drive it as an explicit step:
+
+```bash
+rela db status              # also reports any derived-schema drift (always exit 0 for drift)
+rela db reconcile           # create/drop derived objects to match the metamodel
+rela db reconcile --dry-run # show what WOULD change; non-zero exit if anything would — a CI/pre-deploy gate
+```
+
+`rela db reconcile --dry-run` is the pre-flight: run it against your live
+database before shipping a schema change to see exactly which constraints
+would be created, dropped, or left unenforced (and, with `--show-values`, a
+sample of the blocking values — this prints entity data, so it is opt-in and
+operator-only). Because the dry-run and the real startup reconcile share one
+planner, what the dry-run predicts is what startup does.
+
 ## Search
 
 In the PostgreSQL build, search runs **in the database** (a `tsvector`

--- a/internal/appbuild/appbuild.go
+++ b/internal/appbuild/appbuild.go
@@ -1191,6 +1191,13 @@ func assemble(
 	// rename/delete are captured synchronously via the entitymanager hook above.
 	startVersionSweepIfSupported(st, base.meta)
 
+	// Reconcile the derived schema (postgres build only; a no-op elsewhere):
+	// synthesize the metamodel's `unique: true` properties into partial unique
+	// indexes so uniqueness is enforced atomically, and publish the current
+	// unique pairs so a violation can be attributed to a property (TKT-3Q0GP1).
+	// Failures degrade to warnings — a derived-schema problem never fails boot.
+	reconcileDerivedSchemaIfSupported(context.Background(), st, base.meta)
+
 	return &Services{
 		fs:              cfg.FS,
 		paths:           cfg.Paths,

--- a/internal/appbuild/derivedschema_nosweep.go
+++ b/internal/appbuild/derivedschema_nosweep.go
@@ -1,0 +1,17 @@
+//go:build !postgres
+
+package appbuild
+
+import (
+	"context"
+
+	"github.com/Sourcehaven-BV/rela/internal/metamodel"
+	"github.com/Sourcehaven-BV/rela/internal/store"
+)
+
+// reconcileDerivedSchemaIfSupported is a no-op in non-postgres builds: only
+// pgstore can synthesize derived-schema objects (partial unique indexes) from
+// the metamodel. fsstore/memstore enforce `unique: true` with the
+// application-level check-then-write scan, which is correct for their
+// single-process nature (TKT-3Q0GP1).
+func reconcileDerivedSchemaIfSupported(_ context.Context, _ store.Store, _ *metamodel.Metamodel) {}

--- a/internal/appbuild/derivedschema_postgres.go
+++ b/internal/appbuild/derivedschema_postgres.go
@@ -4,6 +4,7 @@ package appbuild
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 
 	"github.com/Sourcehaven-BV/rela/internal/metamodel"
@@ -31,7 +32,14 @@ func reconcileDerivedSchemaIfSupported(ctx context.Context, st store.Store, meta
 	s.SetUniqueSpecProvider(specs)
 
 	outcomes, err := s.Reconcile(ctx, specs, store.ReconcileOptions{})
-	if err != nil {
+	switch {
+	case errors.Is(err, pgstore.ErrReconcileBusy):
+		// A peer is already converging this schema to the same desired state;
+		// its pass covers us. Not a failure — the specs are published above so
+		// violations still map to a property.
+		slog.Debug("appbuild: derived-schema reconcile skipped; a peer holds the lock")
+		return
+	case err != nil:
 		slog.Warn("appbuild: derived-schema reconcile failed; uniqueness may be "+
 			"enforced only by the application-level check until repaired", "error", err)
 		return
@@ -55,8 +63,9 @@ func reconcileDerivedSchemaIfSupported(ctx context.Context, st store.Store, meta
 }
 
 // uniqueSpecsFromMetamodel collects the (type, property) pairs the derived-schema
-// reconciler should enforce: every non-list property declared unique. Read fresh
-// from the metamodel so a reload is reflected on the next call.
+// reconciler should enforce: every non-list property declared unique. Called at
+// store-open with the boot-time metamodel; it is NOT re-invoked on a live schema
+// reload (see Store.Reconcile's boot-only note).
 func uniqueSpecsFromMetamodel(meta *metamodel.Metamodel) []store.DerivedObjectSpec {
 	if meta == nil {
 		return nil

--- a/internal/appbuild/derivedschema_postgres.go
+++ b/internal/appbuild/derivedschema_postgres.go
@@ -1,0 +1,81 @@
+//go:build postgres
+
+package appbuild
+
+import (
+	"context"
+	"log/slog"
+
+	"github.com/Sourcehaven-BV/rela/internal/metamodel"
+	"github.com/Sourcehaven-BV/rela/internal/store"
+	"github.com/Sourcehaven-BV/rela/internal/store/pgstore"
+)
+
+// reconcileDerivedSchemaIfSupported converges the postgres derived schema at
+// store-open and publishes the metamodel's unique (type, property) pairs so the
+// write path can attribute a unique-index violation to a property (TKT-3Q0GP1).
+// A non-pgstore store (should not happen in this build) is skipped. Reconcile
+// failures are logged and swallowed: a derived-schema problem — most often
+// pre-existing duplicate values blocking an index — must NEVER fail store-open.
+// An operator inspects/repairs drift via `rela db status` / `rela db reconcile`.
+func reconcileDerivedSchemaIfSupported(ctx context.Context, st store.Store, meta *metamodel.Metamodel) {
+	s, ok := st.(*pgstore.Store)
+	if !ok {
+		return
+	}
+
+	specs := uniqueSpecsFromMetamodel(meta)
+
+	// Publish the pairs first so that even if the reconcile below degrades, a
+	// violation of an already-present index still maps to its property.
+	s.SetUniqueSpecProvider(specs)
+
+	outcomes, err := s.Reconcile(ctx, specs, store.ReconcileOptions{})
+	if err != nil {
+		slog.Warn("appbuild: derived-schema reconcile failed; uniqueness may be "+
+			"enforced only by the application-level check until repaired", "error", err)
+		return
+	}
+	for _, o := range outcomes {
+		switch o.State {
+		case store.DerivedUnenforced:
+			slog.Warn("appbuild: derived unique constraint NOT enforced",
+				"type", o.Spec.Type, "property", o.Spec.Property,
+				"blocking_value_groups", o.BlockingCount, "reason", o.Reason)
+		case store.DerivedCreated:
+			slog.Info("appbuild: derived unique constraint created",
+				"type", o.Spec.Type, "property", o.Spec.Property)
+		case store.DerivedDropped:
+			slog.Info("appbuild: derived schema object dropped (no longer declared)",
+				"reason", o.Reason)
+		case store.DerivedEnforced:
+			// Already present and correct — the steady-state case, nothing to log.
+		}
+	}
+}
+
+// uniqueSpecsFromMetamodel collects the (type, property) pairs the derived-schema
+// reconciler should enforce: every non-list property declared unique. Read fresh
+// from the metamodel so a reload is reflected on the next call.
+func uniqueSpecsFromMetamodel(meta *metamodel.Metamodel) []store.DerivedObjectSpec {
+	if meta == nil {
+		return nil
+	}
+	var specs []store.DerivedObjectSpec
+	for _, typeName := range meta.EntityTypes() {
+		def, ok := meta.GetEntityDef(typeName)
+		if !ok {
+			continue
+		}
+		for propName, pd := range def.PropertyDefs() {
+			if pd.Unique && !pd.List {
+				specs = append(specs, store.DerivedObjectSpec{
+					Kind:     store.DerivedUnique,
+					Type:     typeName,
+					Property: propName,
+				})
+			}
+		}
+	}
+	return specs
+}

--- a/internal/cli/db.go
+++ b/internal/cli/db.go
@@ -10,8 +10,9 @@ package cli
 // (filesystem) and `memorybackend` builds they return a clear "not available"
 // error (see runDBMigrate / runDBStatus in the build-tagged db_*.go files).
 type DBCmd struct {
-	Migrate DBMigrateCmd `cmd:"" help:"Apply pending PostgreSQL schema migrations."`
-	Status  DBStatusCmd  `cmd:"" help:"Report the database schema version (read-only; non-zero exit if behind)."`
+	Migrate   DBMigrateCmd   `cmd:"" help:"Apply pending PostgreSQL schema migrations."`
+	Status    DBStatusCmd    `cmd:"" help:"Report the database schema version (read-only; non-zero exit if behind)."`
+	Reconcile DBReconcileCmd `cmd:"" help:"Converge derived-schema objects (unique indexes) with the metamodel."`
 }
 
 // DBMigrateCmd applies pending schema migrations to the database named by the
@@ -33,4 +34,27 @@ type DBStatusCmd struct{}
 // Run executes `rela db status`.
 func (c *DBStatusCmd) Run() error {
 	return runDBStatus()
+}
+
+// DBReconcileCmd converges the database's derived-schema objects — partial
+// unique indexes synthesized from the metamodel's `unique: true` properties
+// (TKT-3Q0GP1) — creating missing ones and dropping ones no longer declared.
+//
+// This is the explicit operator affordance for the same reconciliation that
+// runs automatically at store-open. Its trust boundary is the operator shell
+// (like `db migrate`): it takes no ACL and reads the DSN from RELA_DATABASE_URL.
+//
+// With --dry-run it computes and prints the plan WITHOUT changing anything, and
+// exits non-zero if the live schema differs from the metamodel — a pre-flight/CI
+// gate an operator can run before deploying a schema change. Blocking duplicate
+// values are reported as a COUNT by default; --show-values additionally prints a
+// bounded sample of the offending values (entity content, so opt-in only).
+type DBReconcileCmd struct {
+	DryRun     bool `help:"Print the plan and exit non-zero on drift, without changing the database."`
+	ShowValues bool `help:"Include sample blocking values for unenforced constraints (entity content; operator use only)."`
+}
+
+// Run executes `rela db reconcile`.
+func (c *DBReconcileCmd) Run() error {
+	return runDBReconcile(c.DryRun, c.ShowValues)
 }

--- a/internal/cli/db_nonpostgres.go
+++ b/internal/cli/db_nonpostgres.go
@@ -13,3 +13,5 @@ var errDBNotAvailable = errors.New(
 func runDBMigrate() error { return errDBNotAvailable }
 
 func runDBStatus() error { return errDBNotAvailable }
+
+func runDBReconcile(_, _ bool) error { return errDBNotAvailable }

--- a/internal/cli/db_postgres.go
+++ b/internal/cli/db_postgres.go
@@ -71,10 +71,14 @@ func runDBStatus() error {
 	// is INFORMATIONAL: it never changes the exit code (a config edit against
 	// dirty data must not brick a health check). The strict gate lives on
 	// `rela db reconcile --dry-run`.
-	if specs, ok := loadUniqueSpecs(); ok {
+	if specs, _, ok := loadUniqueSpecs(); ok {
 		outcomes, err := pgstore.ReconcileDSN(
 			context.Background(), resolved, specs, store.ReconcileOptions{DryRun: true})
-		if err != nil {
+		switch {
+		case errors.Is(err, pgstore.ErrReconcileBusy):
+			fmt.Println("Derived schema: a reconcile is in progress; skipped.")
+			return nil
+		case err != nil:
 			fmt.Printf("Derived schema: could not check (%v).\n", err)
 			return nil
 		}
@@ -92,13 +96,21 @@ func runDBReconcile(dryRun, showValues bool) error {
 	if err != nil {
 		return err
 	}
-	specs, ok := loadUniqueSpecs()
+	specs, schemaPath, ok := loadUniqueSpecs()
 	if !ok {
 		return errors.New("could not load the metamodel to derive unique constraints; " +
 			"run this from a project directory")
 	}
+	// Echo which schema the constraints are derived from: reconcile mutates the
+	// shared database toward THIS file, so an operator running from the wrong
+	// checkout must be able to see it (RR-0USU3N).
+	fmt.Printf("Reconciling derived schema from %s\n", schemaPath)
 	outcomes, err := pgstore.ReconcileDSN(context.Background(), resolved, specs,
 		store.ReconcileOptions{DryRun: dryRun, ShowValues: showValues})
+	if errors.Is(err, pgstore.ErrReconcileBusy) {
+		fmt.Println("Another reconcile is in progress for this schema; try again shortly.")
+		return nil
+	}
 	if err != nil {
 		return err
 	}
@@ -149,21 +161,22 @@ func printDerivedDrift(outcomes []store.DerivedObjectOutcome, dryRun bool) (drif
 
 // loadUniqueSpecs discovers the project at the current directory, loads the
 // metamodel, and returns its `unique: true` (type, property) pairs as reconciler
-// specs. ok is false when the project/metamodel could not be loaded (the caller
-// treats that as "cannot check").
-func loadUniqueSpecs() (specs []store.DerivedObjectSpec, ok bool) {
+// specs plus the resolved schema path (so the caller can show the operator which
+// schema is driving the reconcile). ok is false when the project/metamodel could
+// not be loaded (the caller treats that as "cannot check").
+func loadUniqueSpecs() (specs []store.DerivedObjectSpec, schemaPath string, ok bool) {
 	fs := storage.NewSafeFS(storage.NewOsFS())
 	startDir, err := os.Getwd()
 	if err != nil {
-		return nil, false
+		return nil, "", false
 	}
 	paths, err := project.Discover(startDir, fs)
 	if err != nil {
-		return nil, false
+		return nil, "", false
 	}
 	meta, _, err := metamodel.NewFSLoader(fs, paths.SchemaPath).Load(context.Background())
 	if err != nil {
-		return nil, false
+		return nil, "", false
 	}
 	for _, typeName := range meta.EntityTypes() {
 		def, defOK := meta.GetEntityDef(typeName)
@@ -178,5 +191,5 @@ func loadUniqueSpecs() (specs []store.DerivedObjectSpec, ok bool) {
 			}
 		}
 	}
-	return specs, true
+	return specs, paths.SchemaPath, true
 }

--- a/internal/cli/db_postgres.go
+++ b/internal/cli/db_postgres.go
@@ -8,6 +8,10 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/Sourcehaven-BV/rela/internal/metamodel"
+	"github.com/Sourcehaven-BV/rela/internal/project"
+	"github.com/Sourcehaven-BV/rela/internal/storage"
+	"github.com/Sourcehaven-BV/rela/internal/store"
 	"github.com/Sourcehaven-BV/rela/internal/store/pgstore"
 )
 
@@ -62,5 +66,117 @@ func runDBStatus() error {
 		os.Exit(1)
 	}
 	fmt.Printf("Database is up to date (schema version %d).\n", current)
+
+	// Also report derived-schema drift (unique indexes vs the metamodel). This
+	// is INFORMATIONAL: it never changes the exit code (a config edit against
+	// dirty data must not brick a health check). The strict gate lives on
+	// `rela db reconcile --dry-run`.
+	if specs, ok := loadUniqueSpecs(); ok {
+		outcomes, err := pgstore.ReconcileDSN(
+			context.Background(), resolved, specs, store.ReconcileOptions{DryRun: true})
+		if err != nil {
+			fmt.Printf("Derived schema: could not check (%v).\n", err)
+			return nil
+		}
+		printDerivedDrift(outcomes, false)
+	}
 	return nil
+}
+
+// runDBReconcile converges (or, with dryRun, reports) the derived schema:
+// partial unique indexes synthesized from the metamodel's `unique: true`
+// properties. On --dry-run it exits non-zero if the live schema differs from
+// the metamodel, so it can gate a deploy/CI step.
+func runDBReconcile(dryRun, showValues bool) error {
+	resolved, err := resolveDSN()
+	if err != nil {
+		return err
+	}
+	specs, ok := loadUniqueSpecs()
+	if !ok {
+		return errors.New("could not load the metamodel to derive unique constraints; " +
+			"run this from a project directory")
+	}
+	outcomes, err := pgstore.ReconcileDSN(context.Background(), resolved, specs,
+		store.ReconcileOptions{DryRun: dryRun, ShowValues: showValues})
+	if err != nil {
+		return err
+	}
+	drift := printDerivedDrift(outcomes, dryRun)
+	if dryRun && drift {
+		os.Exit(1)
+	}
+	return nil
+}
+
+// printDerivedDrift prints the reconcile outcomes and reports whether any object
+// drifted (was/would-be created, dropped, or is unenforced). When dryRun, the
+// verbs are phrased as "would ...".
+func printDerivedDrift(outcomes []store.DerivedObjectOutcome, dryRun bool) (drift bool) {
+	var enforced int
+	for _, o := range outcomes {
+		switch o.State {
+		case store.DerivedEnforced:
+			enforced++
+		case store.DerivedCreated:
+			drift = true
+			verb := "created"
+			if dryRun {
+				verb = "would create"
+			}
+			fmt.Printf("  + %s unique constraint on %s.%s\n", verb, o.Spec.Type, o.Spec.Property)
+		case store.DerivedDropped:
+			drift = true
+			verb := "dropped"
+			if dryRun {
+				verb = "would drop"
+			}
+			fmt.Printf("  - %s %s\n", verb, o.Reason)
+		case store.DerivedUnenforced:
+			drift = true
+			fmt.Printf("  ! NOT enforced: unique on %s.%s — %s (%d duplicate value group(s))\n",
+				o.Spec.Type, o.Spec.Property, o.Reason, o.BlockingCount)
+			for _, v := range o.SampleValues {
+				fmt.Printf("      duplicate value: %s\n", v)
+			}
+		}
+	}
+	if !drift {
+		fmt.Printf("Derived schema: up to date (%d unique constraint(s) enforced).\n", enforced)
+	}
+	return drift
+}
+
+// loadUniqueSpecs discovers the project at the current directory, loads the
+// metamodel, and returns its `unique: true` (type, property) pairs as reconciler
+// specs. ok is false when the project/metamodel could not be loaded (the caller
+// treats that as "cannot check").
+func loadUniqueSpecs() (specs []store.DerivedObjectSpec, ok bool) {
+	fs := storage.NewSafeFS(storage.NewOsFS())
+	startDir, err := os.Getwd()
+	if err != nil {
+		return nil, false
+	}
+	paths, err := project.Discover(startDir, fs)
+	if err != nil {
+		return nil, false
+	}
+	meta, _, err := metamodel.NewFSLoader(fs, paths.SchemaPath).Load(context.Background())
+	if err != nil {
+		return nil, false
+	}
+	for _, typeName := range meta.EntityTypes() {
+		def, defOK := meta.GetEntityDef(typeName)
+		if !defOK {
+			continue
+		}
+		for propName, pd := range def.PropertyDefs() {
+			if pd.Unique && !pd.List {
+				specs = append(specs, store.DerivedObjectSpec{
+					Kind: store.DerivedUnique, Type: typeName, Property: propName,
+				})
+			}
+		}
+	}
+	return specs, true
 }

--- a/internal/entitymanager/apply.go
+++ b/internal/entitymanager/apply.go
@@ -176,6 +176,13 @@ func (m *Manager) ApplyEntity(ctx context.Context, e *entity.Entity) (*entity.Up
 func (m *Manager) persistApplyEntity(ctx context.Context, op acl.Op, e *entity.Entity) error {
 	if op == acl.OpCreate {
 		if err := m.deps.Store.CreateEntity(ctx, e); err != nil {
+			// A derived unique-property index rejects a duplicate PROPERTY value
+			// (TKT-3Q0GP1). Check before ErrConflict (which UniquePropertyError
+			// also satisfies) so it surfaces as the property 422, not the
+			// ID-collision error.
+			if ok, mapped := mapUniquePropertyConflict(err); ok {
+				return mapped
+			}
 			if errors.Is(err, store.ErrConflict) {
 				return fmt.Errorf("%w: %s", ErrEntityAlreadyExists, e.ID)
 			}
@@ -184,6 +191,9 @@ func (m *Manager) persistApplyEntity(ctx context.Context, op acl.Op, e *entity.E
 		return nil
 	}
 	if err := m.deps.Store.UpdateEntity(ctx, e); err != nil {
+		if ok, mapped := mapUniquePropertyConflict(err); ok {
+			return mapped
+		}
 		if errors.Is(err, store.ErrNotFound) {
 			// The probe saw the entity but the row vanished before the write
 			// (a concurrent delete). Surface ErrEntityVanishedOnUpdate, which

--- a/internal/entitymanager/core.go
+++ b/internal/entitymanager/core.go
@@ -119,6 +119,14 @@ func createCore(
 	// create-XOR-update by resolved intent; there is no create-then-
 	// update-on-conflict fallback anywhere (BUG-ZWTDH9).
 	if err := deps.Store.CreateEntity(ctx, e); err != nil {
+		// A derived unique-property index (pgstore, TKT-3Q0GP1) rejects a
+		// duplicate PROPERTY value; surface it as the same 422 the pre-write
+		// scan does. Check this BEFORE the ErrConflict branch: UniquePropertyError
+		// satisfies errors.Is(_, ErrConflict) too, and the ID-collision message
+		// would be wrong for a property duplicate.
+		if ok, mapped := mapUniquePropertyConflict(err); ok {
+			return nil, nil, mapped
+		}
 		if errors.Is(err, store.ErrConflict) {
 			return nil, nil, fmt.Errorf("%w: %s", ErrEntityAlreadyExists, e.ID)
 		}

--- a/internal/entitymanager/manager.go
+++ b/internal/entitymanager/manager.go
@@ -810,6 +810,13 @@ func (m *Manager) updateCore(
 	// the row exists (else we returned ErrEntityNotFound), so this is
 	// unambiguously an update (BUG-ZWTDH9).
 	if err := m.deps.Store.UpdateEntity(ctx, e); err != nil {
+		// A derived unique-property index can reject an update whose (possibly
+		// automation-set) value duplicates another entity's, even though the
+		// scan above passed under a concurrent writer. Surface it as the same
+		// 422 the scan produces (TKT-3Q0GP1); other errors pass through.
+		if ok, mapped := mapUniquePropertyConflict(err); ok {
+			return nil, mapped
+		}
 		return nil, fmt.Errorf("write entity: %w", err)
 	}
 

--- a/internal/entitymanager/unique.go
+++ b/internal/entitymanager/unique.go
@@ -2,6 +2,7 @@ package entitymanager
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 
@@ -109,4 +110,39 @@ func checkUniqueProperties(
 		return newValidationError(violations)
 	}
 	return nil
+}
+
+// mapUniquePropertyConflict translates a store-level derived-unique-index
+// violation ([store.UniquePropertyError], raised atomically by a pgstore partial
+// unique index — TKT-3Q0GP1) into the SAME [ValidationError] the pre-write
+// [checkUniqueProperties] scan produces, so a client cannot tell which
+// enforcement path caught the duplicate: both yield a 422 naming the property
+// and withholding the colliding value. It returns the original error unchanged
+// when it is not an UniquePropertyError.
+//
+// This is the second-line backstop to the scan: the scan wins the common case
+// (and is the only mechanism on fs/mem), but a concurrent writer that passed
+// the scan is stopped atomically by the index and lands here. When the store
+// could not attribute the violation to a property (empty Property — e.g. a
+// rolling deploy against a peer-created index), it degrades to a generic
+// property-less unique error rather than inventing a property name.
+//
+// ok reports whether err was a UniquePropertyError (and thus mapped); when
+// false the returned error is err unchanged, so callers write
+// `if ok, v := mapUniquePropertyConflict(err); ok { return v }`.
+func mapUniquePropertyConflict(err error) (ok bool, mapped error) {
+	var up store.UniquePropertyError
+	if !errors.As(err, &up) {
+		return false, err
+	}
+	msg := "a property that must be unique already has this value"
+	if up.Property != "" {
+		msg = fmt.Sprintf(
+			"property %q must be unique; another entity already has this value", up.Property)
+	}
+	return true, newValidationError([]*metamodel.ValidationError{{
+		Type:     metamodel.ValidationErrorUnique,
+		Property: up.Property,
+		Message:  msg,
+	}})
 }

--- a/internal/entitymanager/unique.go
+++ b/internal/entitymanager/unique.go
@@ -36,17 +36,20 @@ import (
 //   - Comparison is on the string value (identity keys — email, UPN — are
 //     strings). Non-string property values are compared via their string
 //     form and in practice only strings carry unique keys.
-//   - This is a check-then-write, NOT an atomic constraint. The scan and
-//     the durable write are separate operations and no lock is held
+//   - This scan is a check-then-write, NOT an atomic constraint: the scan
+//     and the durable write are separate operations with no lock held
 //     across them, so under concurrent writers (the data-entry server is
 //     one goroutine per request) two racing writes with the same value
-//     can both pass the scan and both commit — on every backend, not just
-//     pgstore. The window is small, and the ACL resolver's multi-match
-//     fallback (keep-raw) is the runtime backstop for the identity-key
-//     case. The only race-free enforcement is a store-level unique index
-//     (a partial unique index on pgstore), which surfaces a duplicate as
-//     [store.ErrConflict] on the write; operators who need atomicity add
-//     it. See docs/acl-security.md.
+//     could both pass the scan. On PostgreSQL the durable write is
+//     backstopped by a store-level partial unique index that pgstore
+//     maintains from the metamodel (TKT-3Q0GP1): the second writer's
+//     insert fails atomically and surfaces as [store.UniquePropertyError],
+//     which the write path maps to the SAME 422 this scan produces — so
+//     the scan stays the friendly primary path and the index closes the
+//     race. On fsstore/memstore there is no such index (single-writer, so
+//     the scan suffices); the ACL resolver's multi-match fallback
+//     (keep-raw) remains the runtime backstop for the identity-key case.
+//     See docs/acl-security.md and docs/postgres-backend.md.
 func checkUniqueProperties(
 	ctx context.Context, deps Deps, e *entity.Entity, excludeSelfID string,
 ) error {

--- a/internal/entitymanager/unique_mapping_test.go
+++ b/internal/entitymanager/unique_mapping_test.go
@@ -1,0 +1,60 @@
+package entitymanager
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/Sourcehaven-BV/rela/internal/metamodel"
+	"github.com/Sourcehaven-BV/rela/internal/store"
+)
+
+// mapUniquePropertyConflict must translate a store-level derived-unique-index
+// violation into the SAME ValidationError the pre-write scan produces, so a
+// client cannot tell which path caught the duplicate (TKT-3Q0GP1).
+func TestMapUniquePropertyConflict(t *testing.T) {
+	t.Run("named property maps to ValidationErrorUnique", func(t *testing.T) {
+		ok, err := mapUniquePropertyConflict(store.UniquePropertyError{Property: "email"})
+		if !ok {
+			t.Fatal("expected mapping to occur")
+		}
+		var ve *ValidationError
+		if !errors.As(err, &ve) {
+			t.Fatalf("want *ValidationError, got %T: %v", err, err)
+		}
+		if len(ve.Errors) != 1 {
+			t.Fatalf("want 1 inner error, got %d", len(ve.Errors))
+		}
+		inner := ve.Errors[0]
+		if inner.Type != metamodel.ValidationErrorUnique {
+			t.Errorf("type = %q, want %q", inner.Type, metamodel.ValidationErrorUnique)
+		}
+		if inner.Property != "email" {
+			t.Errorf("property = %q, want email", inner.Property)
+		}
+	})
+
+	t.Run("unattributed violation still maps, without a property name", func(t *testing.T) {
+		ok, err := mapUniquePropertyConflict(store.UniquePropertyError{})
+		if !ok {
+			t.Fatal("expected mapping to occur")
+		}
+		var ve *ValidationError
+		if !errors.As(err, &ve) {
+			t.Fatalf("want *ValidationError, got %T", err)
+		}
+		if ve.Errors[0].Property != "" {
+			t.Errorf("property = %q, want empty", ve.Errors[0].Property)
+		}
+	})
+
+	t.Run("non-unique error passes through unchanged", func(t *testing.T) {
+		orig := errors.New("some other write error")
+		if ok, got := mapUniquePropertyConflict(orig); ok || !errors.Is(got, orig) {
+			t.Errorf("expected pass-through, got %v (ok=%v)", got, ok)
+		}
+		// ErrConflict (ID collision) must NOT be turned into a validation error.
+		if ok, _ := mapUniquePropertyConflict(store.ErrConflict); ok {
+			t.Error("ErrConflict should pass through, not map")
+		}
+	})
+}

--- a/internal/metamodel/loader.go
+++ b/internal/metamodel/loader.go
@@ -707,10 +707,41 @@ func validatePropertyDefs(
 				"%s: property %q is type \"enum\" but has no 'values' list", schemaName, propName))
 		}
 
+		// `unique: true` is only meaningful on string-valued properties. The
+		// application uniqueness check reads values as strings (empty for a
+		// non-string), so on an integer/boolean/file property it would silently
+		// never fire — while the PostgreSQL derived index over `properties->>'p'`
+		// WOULD enforce, giving two enforcement paths that disagree. Reject the
+		// combination at load rather than ship that divergence (TKT-3Q0GP1).
+		// string/date/datetime/enum/rrule are all stored as strings and are fine.
+		if propDef.Unique && !isStringValuedType(propDef.Type) {
+			errs = append(errs, fmt.Sprintf(
+				"%s: property %q has 'unique: true' on non-string type %q; "+
+					"unique is only supported on string-valued properties",
+				schemaName, propName, propDef.Type))
+		}
+
 		errs = append(errs, validateFilePropertyOptions(schemaName, propName, propDef)...)
 	}
 
 	return errs
+}
+
+// isStringValuedType reports whether a property of this type stores its value
+// as a string (so the application uniqueness check, which reads values as
+// strings, can see it). The built-in string-ish types qualify; integer,
+// boolean, and file do not. Any non-built-in type name is a custom type
+// (enum/regex, defined in `types:`), whose values are strings, so it qualifies.
+func isStringValuedType(typeName string) bool {
+	switch typeName {
+	case PropertyTypeString, PropertyTypeDate, PropertyTypeDatetime, PropertyTypeEnum, PropertyTypeRrule:
+		return true
+	case PropertyTypeInteger, PropertyTypeBoolean, PropertyTypeFile:
+		return false
+	default:
+		// A custom type (declared in `types:`) — enum or regex-validated string.
+		return true
+	}
 }
 
 // validateFilePropertyOptions checks the attachment-only property options

--- a/internal/metamodel/loader.go
+++ b/internal/metamodel/loader.go
@@ -300,6 +300,14 @@ func validateEntitySemantics(m *Metamodel) []string {
 	for _, name := range entityNames {
 		def := m.Entities[name]
 
+		// The entity-type name is interpolated into backend DDL by the
+		// derived-schema reconciler (`... WHERE type = '<type>'`), so it must
+		// use the safe character set for the same DDL-injection reason as
+		// property names (TKT-3Q0GP1).
+		if err := ValidateSchemaName(name); err != nil {
+			errs = append(errs, fmt.Sprintf("entity %v", err))
+		}
+
 		if def.Label == "" {
 			errs = append(errs, fmt.Sprintf("entity %q: missing 'label'", name))
 		}
@@ -662,6 +670,14 @@ func validatePropertyDefs(
 		if reserved != nil && reserved[propName] {
 			errs = append(errs, fmt.Sprintf(
 				"%s: property %q is reserved and cannot be used", schemaName, propName))
+			continue
+		}
+
+		// Check the property name's character set. Names are interpolated into
+		// backend DDL by the derived-schema reconciler, so a name outside the
+		// safe set is a DDL-injection vector; forbid it at load (TKT-3Q0GP1).
+		if err := ValidateSchemaName(propName); err != nil {
+			errs = append(errs, fmt.Sprintf("%s: property %v", schemaName, err))
 			continue
 		}
 

--- a/internal/metamodel/schemaname_test.go
+++ b/internal/metamodel/schemaname_test.go
@@ -1,6 +1,43 @@
 package metamodel
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
+
+// unique:true is only valid on string-valued property types (the application
+// scan reads values as strings; the PostgreSQL derived index would otherwise
+// diverge from it) — TKT-3Q0GP1.
+func TestUniqueRequiresStringType(t *testing.T) {
+	base := `
+version: "1.0"
+entities:
+  thing:
+    label: Thing
+    id_prefix: "THG-"
+    id_type: sequential
+    properties:
+      key:
+        type: %s
+        unique: true
+`
+	stringTypes := []string{"string", "date", "datetime", "rrule"}
+	for _, ty := range stringTypes {
+		if _, err := Parse([]byte(strings.Replace(base, "%s", ty, 1))); err != nil {
+			t.Errorf("unique on string-valued type %q should load, got: %v", ty, err)
+		}
+	}
+
+	nonStringTypes := []string{"integer", "boolean"}
+	for _, ty := range nonStringTypes {
+		_, err := Parse([]byte(strings.Replace(base, "%s", ty, 1)))
+		if err == nil {
+			t.Errorf("unique on non-string type %q should be rejected", ty)
+		} else if !strings.Contains(err.Error(), "unique") {
+			t.Errorf("error for type %q should mention unique, got: %v", ty, err)
+		}
+	}
+}
 
 // ValidateSchemaName guards the entity-type / property names the derived-schema
 // reconciler interpolates into DDL (TKT-3Q0GP1). It is a blocklist of dangerous

--- a/internal/metamodel/schemaname_test.go
+++ b/internal/metamodel/schemaname_test.go
@@ -1,0 +1,35 @@
+package metamodel
+
+import "testing"
+
+// ValidateSchemaName guards the entity-type / property names the derived-schema
+// reconciler interpolates into DDL (TKT-3Q0GP1). It is a blocklist of dangerous
+// characters, not an allowlist, so legitimate dashed/spaced names survive.
+func TestValidateSchemaName(t *testing.T) {
+	valid := []string{
+		"email", "org_id", "review-response", "doc-task", "some property",
+		"MixedCase", "with.dot", "ünïcode", "a1b2",
+	}
+	for _, name := range valid {
+		if err := ValidateSchemaName(name); err != nil {
+			t.Errorf("ValidateSchemaName(%q) = %v, want nil", name, err)
+		}
+	}
+
+	invalid := []string{
+		"",               // empty
+		"bad'name",       // single quote (SQL literal breakout)
+		"back\\slash",    // backslash
+		"tab\tname",      // control char
+		"new\nline",      // newline
+		"null\x00byte",   // NUL
+		" leading",       // leading whitespace
+		"trailing ",      // trailing whitespace
+		"email'OR'1'='1", // injection attempt
+	}
+	for _, name := range invalid {
+		if err := ValidateSchemaName(name); err == nil {
+			t.Errorf("ValidateSchemaName(%q) = nil, want error", name)
+		}
+	}
+}

--- a/internal/metamodel/validation.go
+++ b/internal/metamodel/validation.go
@@ -1,6 +1,7 @@
 package metamodel
 
 import (
+	"errors"
 	"fmt"
 	"math"
 	"regexp"
@@ -16,6 +17,42 @@ import (
 // checked separately below so the non-dash case gets a more targeted
 // error message.
 var validIDPrefixBase = regexp.MustCompile(`^[A-Za-z0-9_-]+$`)
+
+// unsafeSchemaNameChar matches any character that must NOT appear in an
+// entity-type or property name because these names are interpolated into
+// backend DDL by the derived-schema reconciler (a partial unique index over
+// `properties->>'<name>'` per `type = '<type>'`, TKT-3Q0GP1). The reconciler
+// escapes them as SQL string LITERALS (there is no bind parameter for a DDL
+// identifier or JSON key), so the only characters that can break out are the
+// single-quote and backslash; control characters (newlines, tabs, NUL) are
+// forbidden defensively — they have no legitimate use in a name and each is a
+// classic escaping-bypass vector. Everything else a YAML metamodel legitimately
+// uses — letters (incl. non-ASCII), digits, underscore, dash, internal spaces,
+// dots — is permitted, matching the metamodel's existing lenient naming.
+var unsafeSchemaNameChar = regexp.MustCompile(`['\\\x00-\x1f\x7f]`)
+
+// ValidateSchemaName reports whether name is safe to interpolate into
+// reconciler DDL (see [unsafeSchemaNameChar]). It is intentionally a blocklist
+// of dangerous characters rather than an allowlist, because entity-type and
+// property names in shipped metamodels legitimately use dashes and internal
+// spaces (e.g. "review-response", "some property"); an allowlist would reject
+// existing valid schemas. It also rejects a leading/trailing space, which is a
+// likely typo and confuses the DDL literal. Exported so the reconciler can
+// re-check as defense-in-depth before emitting DDL rather than trusting that
+// load-time validation ran.
+func ValidateSchemaName(name string) error {
+	if name == "" {
+		return errors.New("name must not be empty")
+	}
+	if loc := unsafeSchemaNameChar.FindStringIndex(name); loc != nil {
+		return fmt.Errorf("name %q contains an unsafe character at position %d "+
+			"(quotes, backslashes, and control characters are not allowed)", name, loc[0])
+	}
+	if strings.TrimSpace(name) != name {
+		return fmt.Errorf("name %q must not have leading or trailing whitespace", name)
+	}
+	return nil
+}
 
 // ValidateIDPrefix rejects id_prefix values whose generated IDs would
 // fail entity ID validation (BUG-RHFHTH). Generated short/sequential

--- a/internal/store/derivedschema.go
+++ b/internal/store/derivedschema.go
@@ -1,0 +1,143 @@
+package store
+
+import (
+	"context"
+	"errors"
+)
+
+// Derived-schema reconciliation (TKT-3Q0GP1).
+//
+// A "derived" schema object is a database constraint/index a backend CAN
+// synthesize from the metamodel to enforce a declaration atomically that the
+// application otherwise checks non-atomically. The motivating case is
+// `unique: true`: [github.com/Sourcehaven-BV/rela/internal/entitymanager]
+// enforces it with a check-then-write scan, which two concurrent (especially
+// cross-process) writers can both pass. A store-level partial unique index
+// closes that race — pgstore is the only backend that can, so this is an
+// OPTIONAL capability type-asserted at the wiring site like [Formatter] /
+// [HistoryReader], never part of [Store].
+//
+// Reconciliation is STATELESS desired-vs-actual convergence: the metamodel is
+// the desired set, the backend's own catalog is the actual set, and a naming
+// prefix marks ownership. There is no persisted "current state" record to drift
+// from the reality — see [DerivedSchemaReconciler].
+
+// DerivedObjectKind identifies which reconciler RULE produced a spec. Each rule
+// owns a disjoint name sub-namespace in the backend catalog so rules never
+// clobber one another's objects (the unique rule only ever drops its own
+// indexes, an enum rule only its own checks, etc.). Today there is one rule.
+type DerivedObjectKind string
+
+const (
+	// DerivedUnique is the `unique: true` rule: a partial unique index over a
+	// single scalar property value, per entity type.
+	DerivedUnique DerivedObjectKind = "unique"
+)
+
+// DerivedObjectSpec is one desired derived object, derived from the metamodel.
+// It is backend-agnostic: the backend translates it into concrete DDL. For
+// DerivedUnique, (Type, Property) names the entity type and the unique scalar
+// property.
+type DerivedObjectSpec struct {
+	Kind     DerivedObjectKind
+	Type     string
+	Property string
+}
+
+// DerivedObjectState is the outcome of reconciling one spec (or one discovered
+// orphan object).
+type DerivedObjectState string
+
+const (
+	// DerivedEnforced: the object already existed and matches desired — no-op.
+	DerivedEnforced DerivedObjectState = "enforced"
+	// DerivedCreated: the object was absent and was created this pass.
+	DerivedCreated DerivedObjectState = "created"
+	// DerivedDropped: the object existed, is no longer declared, and was
+	// dropped this pass (the operator removed the declaration).
+	DerivedDropped DerivedObjectState = "dropped"
+	// DerivedUnenforced: the object is declared but could NOT be created —
+	// almost always because pre-existing rows already violate it. This is
+	// NON-fatal: the declaration is simply not enforced at the DB level (the
+	// application-level check still runs). Reason carries a human string;
+	// BlockingCount the number of offending value groups.
+	DerivedUnenforced DerivedObjectState = "unenforced"
+)
+
+// DerivedObjectOutcome reports what a reconcile pass did (or a dry-run WOULD
+// do) for one spec. SampleValues is populated only when the caller explicitly
+// opts in (ReconcileOptions.ShowValues) — the blocking VALUES are entity
+// content (secret), so by default only BlockingCount is surfaced. Surfacing
+// this is an operator-shell affordance; it must never reach an API/health
+// response (RR-3NB0P9).
+type DerivedObjectOutcome struct {
+	Spec          DerivedObjectSpec
+	State         DerivedObjectState
+	Reason        string
+	BlockingCount int
+	SampleValues  []string
+	// WouldChange is true on a dry-run for any spec whose State is not
+	// DerivedEnforced — i.e. reconcile would create, drop, or fail to enforce
+	// it. Lets a CLI dry-run exit non-zero on drift without re-deriving.
+	WouldChange bool
+}
+
+// ReconcileOptions controls a reconcile pass.
+type ReconcileOptions struct {
+	// DryRun computes the plan and reports outcomes WITHOUT issuing any DDL.
+	// A dry-run outcome's State reflects what WOULD happen (created/dropped/
+	// unenforced/enforced) and WouldChange flags drift.
+	DryRun bool
+	// ShowValues includes sample blocking values in DerivedUnenforced
+	// outcomes. Operator-shell only; off by default.
+	ShowValues bool
+}
+
+// DerivedSchemaReconciler is an OPTIONAL store capability (type-asserted like
+// [HistoryReader]) that converges backend derived-schema objects toward the
+// metamodel. A backend that cannot synthesize such objects (fs/mem) simply does
+// not implement it; the wiring site degrades to the application-level check.
+//
+// Reconcile is idempotent: it introspects the live catalog each call, so a
+// second identical call is a no-op and a hand-dropped object is recreated. It
+// must be safe to call at every store-open and on demand from the CLI. It is
+// the ONE planner behind store-open reconcile, `rela db status`, and `rela db
+// reconcile [--dry-run]` so a dry-run prediction cannot drift from what
+// store-open actually does.
+type DerivedSchemaReconciler interface {
+	// Reconcile converges the derived schema for the desired specs and returns
+	// one outcome per desired spec plus one per discovered orphan (an owned
+	// object no longer desired). It returns an error only for an infrastructure
+	// failure (e.g. the catalog is unreadable); a single object that cannot be
+	// enforced is reported as a DerivedUnenforced outcome, NOT an error — a
+	// derived-schema problem must never fail store-open.
+	Reconcile(ctx context.Context, desired []DerivedObjectSpec, opts ReconcileOptions) ([]DerivedObjectOutcome, error)
+}
+
+// UniquePropertyError is returned by a write when a store-level derived unique
+// index rejects it (as opposed to [ErrConflict], which is an entity-ID clash).
+// It names the property so [github.com/Sourcehaven-BV/rela/internal/entitymanager]
+// can map it to the SAME property-level validation error its own check-then-write
+// scan produces — the two enforcement paths are indistinguishable to a client.
+// Property is empty when the backend could not attribute the violation to a
+// known property (e.g. a rolling deploy against an index a newer peer created);
+// callers treat an empty-Property UniquePropertyError as a generic conflict, never
+// a 500 (RR-B5Y6DZ).
+type UniquePropertyError struct {
+	Property string
+}
+
+func (e UniquePropertyError) Error() string {
+	if e.Property == "" {
+		return "store: unique property constraint violated"
+	}
+	return "store: unique property constraint violated: " + e.Property
+}
+
+// Is reports UniquePropertyError as an ErrConflict for callers that only care
+// that the write lost a uniqueness race, so existing `errors.Is(err,
+// ErrConflict)` sites keep working unchanged while property-aware callers can
+// still `errors.As` the richer error.
+func (e UniquePropertyError) Is(target error) bool {
+	return errors.Is(target, ErrConflict)
+}

--- a/internal/store/pgstore/derivedschema.go
+++ b/internal/store/pgstore/derivedschema.go
@@ -42,6 +42,12 @@ func safeDDLName(name string) bool {
 // catalog (pg_indexes) is the actual set, and a name prefix marks ownership.
 // See the package/interface docs on store.DerivedSchemaReconciler.
 
+// ErrReconcileBusy is returned by Reconcile when another process already holds
+// the reconcile advisory lock for this schema. It is not a failure: reconcile is
+// idempotent and the holder is converging the same schema to the same desired
+// state, so the caller can safely treat it as "nothing to do this pass".
+var ErrReconcileBusy = errors.New("pgstore: reconcile already in progress for this schema")
+
 // reconcileAdvisoryLockKey serializes concurrent reconcilers OF THIS SCHEMA,
 // analogous to migrateAdvisoryLockKey. "RELD" (derived). Distinct from the
 // migrate/write/sweep keys so a reconcile never blocks (or is blocked by) an
@@ -73,7 +79,16 @@ func uniqueIndexName(entityType, property string) string {
 // DDL statement in its own implicit transaction — a failed CREATE must not
 // abort the successful ones). On any other handle it degrades: it returns nil
 // outcomes and no error, exactly as a store-open reconcile on an unsupported
-// backend would.
+// backend would. Returns [ErrReconcileBusy] (non-fatal) if a peer already holds
+// the lock.
+//
+// BOOT-ONLY at present: the wiring layer calls this once at store-open (see
+// appbuild.reconcileDerivedSchemaIfSupported). A live metamodel reload does NOT
+// re-run it, so a `unique: true` added without a restart is enforced by the
+// application scan but not yet by a database index; an operator applies it with
+// `rela db reconcile`. (Re-reconciling on reload is a deliberate future
+// extension — it needs its own debounce/lock policy for issuing DDL off a file
+// watcher.)
 func (s *Store) Reconcile(
 	ctx context.Context, desired []store.DerivedObjectSpec, opts store.ReconcileOptions,
 ) ([]store.DerivedObjectOutcome, error) {
@@ -91,11 +106,21 @@ func (s *Store) Reconcile(
 	// Session-scoped advisory lock: only one process reconciles this schema at a
 	// time, so concurrent booting processes cannot race a create against a drop.
 	// A dry-run takes it too — it reads the catalog and must see a stable actual
-	// set. Released explicitly (and by connection release) below.
-	if _, lockErr := conn.Exec(ctx,
-		`SELECT pg_advisory_lock($1::int, hashtext(current_schema()))`,
-		reconcileAdvisoryLockKey); lockErr != nil {
+	// set. We use the NON-blocking pg_try_advisory_lock: this runs at store-open
+	// on a background context with no deadline, and blocking here would let a
+	// peer holding the lock (a long dry-run, or a peer mid-reconcile) stall boot
+	// indefinitely — the exact multi-writer contention this feature assumes. If
+	// the lock is already held, another process is converging the same schema to
+	// the same desired state, so we skip: reconcile is idempotent and the peer's
+	// pass covers us. The caller treats a nil/empty result as "nothing to do".
+	var locked bool
+	if lockErr := conn.QueryRow(ctx,
+		`SELECT pg_try_advisory_lock($1::int, hashtext(current_schema()))`,
+		reconcileAdvisoryLockKey).Scan(&locked); lockErr != nil {
 		return nil, fmt.Errorf("pgstore: reconcile: acquire lock: %w", lockErr)
+	}
+	if !locked {
+		return nil, ErrReconcileBusy
 	}
 	defer func() {
 		_, _ = conn.Exec(ctx,
@@ -206,6 +231,12 @@ func listOwnedUniqueIndexes(ctx context.Context, conn *pgxpool.Conn) (map[string
 func createUniqueIndex(
 	ctx context.Context, conn *pgxpool.Conn, spec store.DerivedObjectSpec, name string, showValues bool,
 ) store.DerivedObjectOutcome {
+	// The empty-exempt predicate (`<> '' AND IS NOT NULL`) MUST stay in lockstep
+	// with the WHERE clause in uniqueViolators: the index defines what collides,
+	// and uniqueViolators must count exactly the rows the index would reject, or
+	// a dry-run's prediction drifts from what a create actually does. They can't
+	// share one string (this interpolates quoted literals; that binds $1/$2), so
+	// keep them identical by hand.
 	ddl := fmt.Sprintf(
 		`CREATE UNIQUE INDEX IF NOT EXISTS %s ON entities (type, (properties->>%s)) `+
 			`WHERE type = %s AND properties->>%s <> '' AND properties->>%s IS NOT NULL`,
@@ -257,46 +288,62 @@ func unenforcedFromCreateErr(
 
 // uniqueViolators counts the value groups that violate the (type, property)
 // uniqueness (>1 row sharing a non-empty value), and — only when showValues —
-// returns a bounded sample of those values. The values are entity content, so
-// they are surfaced ONLY on explicit operator opt-in and never by default.
+// returns a bounded sample of those values. The count is EXACT (not capped), so
+// the operator sees the true scale of the blocking data; only the sample values
+// are limited. The values are entity content, so they are surfaced ONLY on
+// explicit operator opt-in and never by default.
 func uniqueViolators(
 	ctx context.Context, conn *pgxpool.Conn, spec store.DerivedObjectSpec, showValues bool,
 ) (count int, samples []string, err error) {
-	const q = `
-		SELECT properties->>$2 AS val, count(*) AS n
+	// Exact, uncapped count of blocking value groups.
+	const countQ = `
+		SELECT count(*) FROM (
+			SELECT 1 FROM entities
+			WHERE type = $1 AND properties->>$2 <> '' AND properties->>$2 IS NOT NULL
+			GROUP BY properties->>$2
+			HAVING count(*) > 1
+		) g`
+	if cErr := conn.QueryRow(ctx, countQ, spec.Type, spec.Property).Scan(&count); cErr != nil {
+		return 0, nil, cErr
+	}
+
+	if !showValues || count == 0 {
+		return count, nil, nil
+	}
+
+	// A small sample of the offending values (opt-in only).
+	const sampleQ = `
+		SELECT properties->>$2 AS val
 		FROM entities
 		WHERE type = $1 AND properties->>$2 <> '' AND properties->>$2 IS NOT NULL
 		GROUP BY properties->>$2
 		HAVING count(*) > 1
-		ORDER BY n DESC
-		LIMIT 100`
-	rows, err := conn.Query(ctx, q, spec.Type, spec.Property)
+		ORDER BY count(*) DESC
+		LIMIT 5`
+	rows, err := conn.Query(ctx, sampleQ, spec.Type, spec.Property)
 	if err != nil {
-		return 0, nil, err
+		return count, nil, err
 	}
 	defer rows.Close()
 
-	const maxSamples = 5
 	for rows.Next() {
 		var val string
-		var n int
-		if err := rows.Scan(&val, &n); err != nil {
-			return 0, nil, err
+		if err := rows.Scan(&val); err != nil {
+			return count, nil, err
 		}
-		count++
-		if showValues && len(samples) < maxSamples {
-			samples = append(samples, val)
-		}
+		samples = append(samples, val)
 	}
 	return count, samples, rows.Err()
 }
 
 // SetUniqueSpecProvider records the current metamodel's unique (type, property)
 // pairs so the write path can attribute a derived-unique-index violation to a
-// property (see mapUniqueViolation). The wiring layer calls it after
-// construction and again on a metamodel reload. Passing nil clears it (a
-// violation then degrades to a property-less UniquePropertyError). It is safe to
-// call concurrently with writes: the value is published via an atomic pointer.
+// property (see mapUniqueViolation). The wiring layer calls it once at
+// store-open. It is published via an atomic pointer and is safe to call
+// concurrently with writes (a metamodel reload could re-publish here), but the
+// current wiring does NOT re-invoke it on a live schema reload — see
+// [Store.Reconcile]'s note on boot-only reconciliation. Passing nil clears it
+// (a violation then degrades to a property-less UniquePropertyError).
 func (s *Store) SetUniqueSpecProvider(specs []store.DerivedObjectSpec) {
 	if specs == nil {
 		s.uniqueSpecs.Store(nil)

--- a/internal/store/pgstore/derivedschema.go
+++ b/internal/store/pgstore/derivedschema.go
@@ -1,0 +1,379 @@
+package pgstore
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/Sourcehaven-BV/rela/internal/store"
+)
+
+// unsafeDDLNameChar mirrors metamodel.unsafeSchemaNameChar. It is duplicated
+// here (rather than importing metamodel — an arch-lint boundary the store layer
+// must not cross) as pure defense-in-depth: the metamodel already rejects these
+// names at load, and quoteLiteral escapes safely, but the reconciler must never
+// interpolate a name carrying a quote, backslash, or control character into DDL
+// even if it somehow arrives unvalidated.
+var unsafeDDLNameChar = regexp.MustCompile(`['\\\x00-\x1f\x7f]`)
+
+// safeDDLName reports whether name is safe to interpolate into reconciler DDL.
+func safeDDLName(name string) bool {
+	return name != "" &&
+		!unsafeDDLNameChar.MatchString(name) &&
+		strings.TrimSpace(name) == name
+}
+
+// Derived-schema reconciliation (TKT-3Q0GP1). pgstore implements the optional
+// [store.DerivedSchemaReconciler] capability: it synthesizes Postgres objects
+// from the metamodel that enforce declarations atomically which the application
+// otherwise checks non-atomically. Today the one rule is `unique: true`, which
+// becomes a partial unique EXPRESSION index over `properties->>'<prop>'` scoped
+// to `type = '<type>'`.
+//
+// Reconciliation is STATELESS: the metamodel is the desired set, the live
+// catalog (pg_indexes) is the actual set, and a name prefix marks ownership.
+// See the package/interface docs on store.DerivedSchemaReconciler.
+
+// reconcileAdvisoryLockKey serializes concurrent reconcilers OF THIS SCHEMA,
+// analogous to migrateAdvisoryLockKey. "RELD" (derived). Distinct from the
+// migrate/write/sweep keys so a reconcile never blocks (or is blocked by) an
+// unrelated DDL/write path spuriously.
+const reconcileAdvisoryLockKey = 0x52_45_4c_44 // "RELD"
+
+// derivedUniquePrefix is the name namespace the `unique` rule OWNS. The
+// reconciler only ever drops indexes under this exact prefix, so a future rule
+// (e.g. an enum CHECK under a different prefix) cannot be clobbered by this one.
+// It is also the discriminator the write path matches on (see mapUniqueViolation).
+const derivedUniquePrefix = "rela_derived_uniq__"
+
+// uniqueIndexName is the deterministic index name for a (type, property) unique
+// rule. Deterministic across processes and versions (no per-run entropy) so the
+// drop side of reconcile is safe: an index whose name is not recomputed from the
+// current metamodel is, by definition, no longer desired. A NUL separator makes
+// the (type, property) encoding unambiguous so ("ab","c") and ("a","bc") cannot
+// collide. The SHA-256 hex is truncated to keep the whole name within Postgres's
+// 63-byte identifier limit (prefix 19 + 32 hex = 51 bytes).
+func uniqueIndexName(entityType, property string) string {
+	sum := sha256.Sum256([]byte(entityType + "\x00" + property))
+	return derivedUniquePrefix + hex.EncodeToString(sum[:16])
+}
+
+// Reconcile implements store.DerivedSchemaReconciler. It converges the derived
+// schema for desired and returns one outcome per desired spec plus one per
+// discovered orphan. It requires the store handle to be a *pgxpool.Pool (so it
+// can hold a session-scoped advisory lock on one connection while issuing each
+// DDL statement in its own implicit transaction — a failed CREATE must not
+// abort the successful ones). On any other handle it degrades: it returns nil
+// outcomes and no error, exactly as a store-open reconcile on an unsupported
+// backend would.
+func (s *Store) Reconcile(
+	ctx context.Context, desired []store.DerivedObjectSpec, opts store.ReconcileOptions,
+) ([]store.DerivedObjectOutcome, error) {
+	pool, ok := s.db.(*pgxpool.Pool)
+	if !ok {
+		return nil, nil
+	}
+
+	conn, err := pool.Acquire(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("pgstore: reconcile: acquire connection: %w", err)
+	}
+	defer conn.Release()
+
+	// Session-scoped advisory lock: only one process reconciles this schema at a
+	// time, so concurrent booting processes cannot race a create against a drop.
+	// A dry-run takes it too — it reads the catalog and must see a stable actual
+	// set. Released explicitly (and by connection release) below.
+	if _, lockErr := conn.Exec(ctx,
+		`SELECT pg_advisory_lock($1::int, hashtext(current_schema()))`,
+		reconcileAdvisoryLockKey); lockErr != nil {
+		return nil, fmt.Errorf("pgstore: reconcile: acquire lock: %w", lockErr)
+	}
+	defer func() {
+		_, _ = conn.Exec(ctx,
+			`SELECT pg_advisory_unlock($1::int, hashtext(current_schema()))`, reconcileAdvisoryLockKey)
+	}()
+
+	// desiredByName maps the deterministic index name -> spec, for the "unique"
+	// rule. Skip any spec whose names are unsafe for DDL interpolation — this is
+	// defense-in-depth over the metamodel's load-time ValidateSchemaName; a bad
+	// name is reported as unenforced rather than silently interpolated.
+	desiredByName := make(map[string]store.DerivedObjectSpec, len(desired))
+	var outcomes []store.DerivedObjectOutcome
+	for _, spec := range desired {
+		if spec.Kind != store.DerivedUnique {
+			continue // unknown rule kind: not handled by this reconciler yet
+		}
+		if !safeDDLName(spec.Type) {
+			outcomes = append(outcomes, unenforced(spec, "unsafe entity type name for DDL: "+spec.Type))
+			continue
+		}
+		if !safeDDLName(spec.Property) {
+			outcomes = append(outcomes, unenforced(spec, "unsafe property name for DDL: "+spec.Property))
+			continue
+		}
+		desiredByName[uniqueIndexName(spec.Type, spec.Property)] = spec
+	}
+
+	// actual: this schema's owned unique-rule indexes.
+	actual, err := listOwnedUniqueIndexes(ctx, conn)
+	if err != nil {
+		return nil, fmt.Errorf("pgstore: reconcile: list indexes: %w", err)
+	}
+
+	// DROP orphans: owned indexes not in the desired set.
+	for name := range actual {
+		if _, want := desiredByName[name]; want {
+			continue
+		}
+		if opts.DryRun {
+			outcomes = append(outcomes, store.DerivedObjectOutcome{
+				Spec:        store.DerivedObjectSpec{Kind: store.DerivedUnique},
+				State:       store.DerivedDropped,
+				Reason:      "index " + name + " no longer declared",
+				WouldChange: true,
+			})
+			continue
+		}
+		if _, err := conn.Exec(ctx, `DROP INDEX IF EXISTS `+quoteIdent(name)); err != nil {
+			return nil, fmt.Errorf("pgstore: reconcile: drop %s: %w", name, err)
+		}
+		outcomes = append(outcomes, store.DerivedObjectOutcome{
+			Spec:   store.DerivedObjectSpec{Kind: store.DerivedUnique},
+			State:  store.DerivedDropped,
+			Reason: "index " + name + " no longer declared",
+		})
+	}
+
+	// CREATE missing / report enforced. Deterministic order for stable output.
+	for _, name := range sortedNames(desiredByName) {
+		spec := desiredByName[name]
+		if _, exists := actual[name]; exists {
+			outcomes = append(outcomes, store.DerivedObjectOutcome{Spec: spec, State: store.DerivedEnforced})
+			continue
+		}
+		if opts.DryRun {
+			// Predict whether a create WOULD succeed by counting current
+			// violators, so a dry-run matches the real store-open outcome.
+			outcomes = append(outcomes, predictUniqueCreate(ctx, conn, spec, name, opts.ShowValues))
+			continue
+		}
+		outcomes = append(outcomes, createUniqueIndex(ctx, conn, spec, name, opts.ShowValues))
+	}
+
+	return outcomes, nil
+}
+
+// listOwnedUniqueIndexes returns the set of this schema's unique-rule indexes.
+// It is scoped to current_schema() so a store sharing a database with other
+// schemas never sees — and so never drops — another schema's owned indexes.
+func listOwnedUniqueIndexes(ctx context.Context, conn *pgxpool.Conn) (map[string]struct{}, error) {
+	rows, err := conn.Query(ctx,
+		`SELECT indexname FROM pg_indexes
+		 WHERE schemaname = current_schema() AND indexname LIKE $1`,
+		derivedUniquePrefix+`%`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	out := make(map[string]struct{})
+	for rows.Next() {
+		var name string
+		if err := rows.Scan(&name); err != nil {
+			return nil, err
+		}
+		out[name] = struct{}{}
+	}
+	return out, rows.Err()
+}
+
+// createUniqueIndex issues the partial unique expression index for spec. The
+// predicate is EMPTY-EXEMPT (`... <> ” AND ... IS NOT NULL`) to match the
+// application scan's semantics, which skip empty/absent values — so the two
+// enforcement paths agree. A failure is almost always pre-existing duplicate
+// values: it is reported as unenforced (with a blocking count, and sample
+// values only if the operator opted in), NEVER returned as an error, so a
+// derived-schema problem cannot fail store-open.
+func createUniqueIndex(
+	ctx context.Context, conn *pgxpool.Conn, spec store.DerivedObjectSpec, name string, showValues bool,
+) store.DerivedObjectOutcome {
+	ddl := fmt.Sprintf(
+		`CREATE UNIQUE INDEX IF NOT EXISTS %s ON entities (type, (properties->>%s)) `+
+			`WHERE type = %s AND properties->>%s <> '' AND properties->>%s IS NOT NULL`,
+		quoteIdent(name),
+		quoteLiteral(spec.Property),
+		quoteLiteral(spec.Type),
+		quoteLiteral(spec.Property), quoteLiteral(spec.Property))
+
+	if _, err := conn.Exec(ctx, ddl); err != nil {
+		return unenforcedFromCreateErr(ctx, conn, spec, err, showValues)
+	}
+	return store.DerivedObjectOutcome{Spec: spec, State: store.DerivedCreated}
+}
+
+// predictUniqueCreate reports what a create WOULD do for a dry-run: enforced if
+// no violators exist, unenforced (with counts) otherwise. It never issues DDL.
+func predictUniqueCreate(
+	ctx context.Context, conn *pgxpool.Conn, spec store.DerivedObjectSpec, _ string, showValues bool,
+) store.DerivedObjectOutcome {
+	count, samples, err := uniqueViolators(ctx, conn, spec, showValues)
+	if err != nil {
+		// A prediction failure is non-fatal: report unenforced with the reason.
+		return unenforced(spec, "could not check for duplicates: "+err.Error())
+	}
+	if count == 0 {
+		return store.DerivedObjectOutcome{Spec: spec, State: store.DerivedCreated, WouldChange: true}
+	}
+	out := unenforced(spec, "pre-existing duplicate values would block this constraint")
+	out.BlockingCount = count
+	out.SampleValues = samples
+	out.WouldChange = true
+	return out
+}
+
+// unenforcedFromCreateErr turns a failed CREATE into an unenforced outcome. It
+// re-queries for the blocking duplicate groups so the operator learns WHY the
+// index could not be built (a count, and sample values only on opt-in).
+func unenforcedFromCreateErr(
+	ctx context.Context, conn *pgxpool.Conn, spec store.DerivedObjectSpec, createErr error, showValues bool,
+) store.DerivedObjectOutcome {
+	out := unenforced(spec, "constraint could not be created: "+createErr.Error())
+	if count, samples, err := uniqueViolators(ctx, conn, spec, showValues); err == nil && count > 0 {
+		out.Reason = "pre-existing duplicate values block this constraint"
+		out.BlockingCount = count
+		out.SampleValues = samples
+	}
+	return out
+}
+
+// uniqueViolators counts the value groups that violate the (type, property)
+// uniqueness (>1 row sharing a non-empty value), and — only when showValues —
+// returns a bounded sample of those values. The values are entity content, so
+// they are surfaced ONLY on explicit operator opt-in and never by default.
+func uniqueViolators(
+	ctx context.Context, conn *pgxpool.Conn, spec store.DerivedObjectSpec, showValues bool,
+) (count int, samples []string, err error) {
+	const q = `
+		SELECT properties->>$2 AS val, count(*) AS n
+		FROM entities
+		WHERE type = $1 AND properties->>$2 <> '' AND properties->>$2 IS NOT NULL
+		GROUP BY properties->>$2
+		HAVING count(*) > 1
+		ORDER BY n DESC
+		LIMIT 100`
+	rows, err := conn.Query(ctx, q, spec.Type, spec.Property)
+	if err != nil {
+		return 0, nil, err
+	}
+	defer rows.Close()
+
+	const maxSamples = 5
+	for rows.Next() {
+		var val string
+		var n int
+		if err := rows.Scan(&val, &n); err != nil {
+			return 0, nil, err
+		}
+		count++
+		if showValues && len(samples) < maxSamples {
+			samples = append(samples, val)
+		}
+	}
+	return count, samples, rows.Err()
+}
+
+// SetUniqueSpecProvider records the current metamodel's unique (type, property)
+// pairs so the write path can attribute a derived-unique-index violation to a
+// property (see mapUniqueViolation). The wiring layer calls it after
+// construction and again on a metamodel reload. Passing nil clears it (a
+// violation then degrades to a property-less UniquePropertyError). It is safe to
+// call concurrently with writes: the value is published via an atomic pointer.
+func (s *Store) SetUniqueSpecProvider(specs []store.DerivedObjectSpec) {
+	if specs == nil {
+		s.uniqueSpecs.Store(nil)
+		return
+	}
+	cp := append([]store.DerivedObjectSpec(nil), specs...)
+	s.uniqueSpecs.Store(&cp)
+}
+
+// currentUniqueSpecs returns the last-published unique pairs (nil if none).
+func (s *Store) currentUniqueSpecs() []store.DerivedObjectSpec {
+	if p := s.uniqueSpecs.Load(); p != nil {
+		return *p
+	}
+	return nil
+}
+
+// mapConflict maps a write error to the right conflict sentinel. A non-23505
+// error is returned unchanged (nil stays nil). A 23505 on an owned derived
+// unique index (rela_derived_uniq__*) becomes a store.UniquePropertyError naming
+// the property; any other 23505 (the entity-id indexes, the primary key) stays
+// store.ErrConflict — preserving the existing "already exists" contract. The
+// property is recovered by recomputing every current-metamodel unique index
+// name and matching (NO persisted registry), so a rolling deploy against a
+// peer-created index this process's metamodel does not know about degrades to a
+// property-less UniquePropertyError (still a conflict), never a 500 or a
+// misattributed property (RR-B5Y6DZ). The raw pgErr.Detail — which echoes the
+// colliding VALUE — is never propagated (enumeration-oracle, RR-3NB0P9).
+func (s *Store) mapConflict(err error) error {
+	var pgErr *pgconn.PgError
+	if !errors.As(err, &pgErr) || pgErr.Code != "23505" {
+		return err
+	}
+	return mapUniqueViolation(pgErr.ConstraintName, s.currentUniqueSpecs())
+}
+
+// mapUniqueViolation classifies a 23505's constraint name. See mapConflict.
+func mapUniqueViolation(constraintName string, metaPairs []store.DerivedObjectSpec) error {
+	if !strings.HasPrefix(constraintName, derivedUniquePrefix) {
+		return store.ErrConflict
+	}
+	for _, p := range metaPairs {
+		if uniqueIndexName(p.Type, p.Property) == constraintName {
+			return store.UniquePropertyError{Property: p.Property}
+		}
+	}
+	// Owned-prefix index we can't attribute to a current declaration: still a
+	// uniqueness conflict, just unnamed.
+	return store.UniquePropertyError{}
+}
+
+// unenforced builds a bare unenforced outcome.
+func unenforced(spec store.DerivedObjectSpec, reason string) store.DerivedObjectOutcome {
+	return store.DerivedObjectOutcome{Spec: spec, State: store.DerivedUnenforced, Reason: reason, WouldChange: true}
+}
+
+// sortedNames returns the map keys sorted, for deterministic output.
+func sortedNames(m map[string]store.DerivedObjectSpec) []string {
+	names := make([]string, 0, len(m))
+	for n := range m {
+		names = append(names, n)
+	}
+	sort.Strings(names)
+	return names
+}
+
+// quoteIdent double-quotes a SQL identifier, doubling any embedded quote. Used
+// for the index NAME (which we generate, so it is already safe, but quoting is
+// correct hygiene).
+func quoteIdent(id string) string {
+	return `"` + strings.ReplaceAll(id, `"`, `""`) + `"`
+}
+
+// quoteLiteral single-quotes a SQL string literal, doubling any embedded single
+// quote. Used for the entity type and JSON property key interpolated into DDL
+// (which cannot be bound as parameters). The metamodel's ValidateSchemaName has
+// already rejected quotes/backslashes/control chars, so this is defense in depth.
+func quoteLiteral(s string) string {
+	return `'` + strings.ReplaceAll(s, `'`, `''`) + `'`
+}

--- a/internal/store/pgstore/derivedschema_db_test.go
+++ b/internal/store/pgstore/derivedschema_db_test.go
@@ -224,3 +224,66 @@ func TestDerivedUnique_CrossSchemaIsolation(t *testing.T) {
 	err = sB.CreateEntity(ctxA, person("B-2", "b@x.com"))
 	require.ErrorIs(t, err, store.ErrConflict, "schema B's index must survive A's drop")
 }
+
+// A dry-run that would DROP an orphan index reports it without mutating.
+func TestDerivedUnique_DryRunDrop(t *testing.T) {
+	pool := newScopedPool(t)
+	s, err := pgstore.New(pool)
+	require.NoError(t, err)
+	ctx := context.Background()
+
+	// Create the index for real.
+	_, err = s.Reconcile(ctx, personSpec, store.ReconcileOptions{})
+	require.NoError(t, err)
+
+	// Dry-run with an empty desired set: reports a would-drop, changes nothing.
+	out, err := s.Reconcile(ctx, nil, store.ReconcileOptions{DryRun: true})
+	require.NoError(t, err)
+	require.Len(t, out, 1)
+	require.Equal(t, store.DerivedDropped, out[0].State)
+	require.True(t, out[0].WouldChange)
+
+	// The index is still present: a live reconcile still sees it as an orphan
+	// to drop (i.e. the dry-run did not actually drop it).
+	out, err = s.Reconcile(ctx, nil, store.ReconcileOptions{})
+	require.NoError(t, err)
+	require.Equal(t, store.DerivedDropped, out[0].State)
+}
+
+// A spec whose names are unsafe for DDL is reported unenforced, never
+// interpolated (defense-in-depth over the metamodel's load-time validation).
+func TestDerivedUnique_UnsafeNameRefused(t *testing.T) {
+	pool := newScopedPool(t)
+	s, err := pgstore.New(pool)
+	require.NoError(t, err)
+
+	bad := []store.DerivedObjectSpec{
+		{Kind: store.DerivedUnique, Type: "person", Property: "ev'il"},
+	}
+	out, err := s.Reconcile(context.Background(), bad, store.ReconcileOptions{})
+	require.NoError(t, err)
+	require.Len(t, out, 1)
+	require.Equal(t, store.DerivedUnenforced, out[0].State)
+	require.Contains(t, out[0].Reason, "unsafe")
+}
+
+// The blocking-group count is EXACT, not capped, so an operator sees the true
+// scale of the dirty data (RR-78T6Q9).
+func TestDerivedUnique_BlockingCountExact(t *testing.T) {
+	pool := newScopedPool(t)
+	s, err := pgstore.New(pool)
+	require.NoError(t, err)
+	ctx := context.Background()
+
+	// Seed 3 distinct duplicated values (6 rows), plus a unique one.
+	for i, v := range []string{"a@x.com", "b@x.com", "c@x.com"} {
+		require.NoError(t, s.CreateEntity(ctx, person("D"+string(rune('a'+i))+"-1", v)))
+		require.NoError(t, s.CreateEntity(ctx, person("D"+string(rune('a'+i))+"-2", v)))
+	}
+	require.NoError(t, s.CreateEntity(ctx, person("U-1", "unique@x.com")))
+
+	out, err := s.Reconcile(ctx, personSpec, store.ReconcileOptions{})
+	require.NoError(t, err)
+	require.Equal(t, store.DerivedUnenforced, out[0].State)
+	require.Equal(t, 3, out[0].BlockingCount, "exactly three blocking value groups")
+}

--- a/internal/store/pgstore/derivedschema_db_test.go
+++ b/internal/store/pgstore/derivedschema_db_test.go
@@ -1,0 +1,226 @@
+//go:build postgres
+
+package pgstore_test
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/Sourcehaven-BV/rela/internal/entity"
+	"github.com/Sourcehaven-BV/rela/internal/store"
+	"github.com/Sourcehaven-BV/rela/internal/store/pgstore"
+)
+
+// personSpec is the (type, property) unique rule used across these tests.
+var personSpec = []store.DerivedObjectSpec{
+	{Kind: store.DerivedUnique, Type: "person", Property: "email"},
+}
+
+// newReconciledStore builds a store on a fresh migrated schema, reconciles the
+// person.email unique rule, publishes the specs, and returns the store. It
+// asserts the index was created (no pre-existing dupes).
+func newReconciledStore(t *testing.T) *pgstore.Store {
+	t.Helper()
+	pool := newScopedPool(t)
+	s, err := pgstore.New(pool)
+	require.NoError(t, err)
+	outcomes, err := s.Reconcile(context.Background(), personSpec, store.ReconcileOptions{})
+	require.NoError(t, err)
+	require.Len(t, outcomes, 1)
+	require.Equal(t, store.DerivedCreated, outcomes[0].State)
+	s.SetUniqueSpecProvider(personSpec)
+	return s
+}
+
+func person(id, email string) *entity.Entity {
+	return &entity.Entity{ID: id, Type: "person", Properties: map[string]any{"email": email}}
+}
+
+// AC1 + AC2: a second insert of the same unique value fails atomically with a
+// property-named UniquePropertyError, and only one row survives.
+func TestDerivedUnique_DuplicateInsertRejected(t *testing.T) {
+	s := newReconciledStore(t)
+	ctx := context.Background()
+
+	require.NoError(t, s.CreateEntity(ctx, person("P-1", "a@x.com")))
+
+	err := s.CreateEntity(ctx, person("P-2", "a@x.com"))
+	var up store.UniquePropertyError
+	require.ErrorAs(t, err, &up, "want UniquePropertyError, got %v", err)
+	require.Equal(t, "email", up.Property)
+	// It is also a conflict for the generic callers.
+	require.ErrorIs(t, err, store.ErrConflict)
+
+	// Exactly one row.
+	got, err := s.GetEntity(ctx, "P-1")
+	require.NoError(t, err)
+	require.Equal(t, "a@x.com", got.GetString("email"))
+	_, err = s.GetEntity(ctx, "P-2")
+	require.ErrorIs(t, err, store.ErrNotFound)
+}
+
+// AC2 regression: an entity-ID collision is still a plain ErrConflict
+// (ErrEntityAlreadyExists at the manager layer), NOT UniquePropertyError.
+func TestDerivedUnique_IDCollisionStillPlainConflict(t *testing.T) {
+	s := newReconciledStore(t)
+	ctx := context.Background()
+
+	require.NoError(t, s.CreateEntity(ctx, person("P-1", "a@x.com")))
+	err := s.CreateEntity(ctx, person("P-1", "b@x.com")) // same ID, different email
+	require.ErrorIs(t, err, store.ErrConflict)
+	var up store.UniquePropertyError
+	require.NotErrorAs(t, err, &up, "ID collision must NOT be UniquePropertyError")
+}
+
+// AC1: concurrent inserts of the same value yield exactly one row.
+func TestDerivedUnique_ConcurrentInsertsSingleRow(t *testing.T) {
+	s := newReconciledStore(t)
+	ctx := context.Background()
+
+	const n = 8
+	var wg sync.WaitGroup
+	var okCount, conflictCount int
+	var mu sync.Mutex
+	for i := range n {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			err := s.CreateEntity(ctx, person("P-"+string(rune('a'+i)), "race@x.com"))
+			mu.Lock()
+			defer mu.Unlock()
+			switch {
+			case err == nil:
+				okCount++
+			case errors.Is(err, store.ErrConflict):
+				conflictCount++
+			default:
+				t.Errorf("unexpected error: %v", err)
+			}
+		}(i)
+	}
+	wg.Wait()
+	require.Equal(t, 1, okCount, "exactly one insert should win")
+	require.Equal(t, n-1, conflictCount, "the rest should conflict")
+}
+
+// RR-AROZJY: empty and absent values are exempt — the index must NOT collide
+// them, matching the application scan's semantics.
+func TestDerivedUnique_EmptyAndAbsentExempt(t *testing.T) {
+	s := newReconciledStore(t)
+	ctx := context.Background()
+
+	// Two entities with an explicit empty email: allowed (both).
+	require.NoError(t, s.CreateEntity(ctx, person("E-1", "")))
+	require.NoError(t, s.CreateEntity(ctx, person("E-2", "")))
+
+	// Two entities with NO email property at all: allowed (both).
+	require.NoError(t, s.CreateEntity(ctx, &entity.Entity{ID: "A-1", Type: "person"}))
+	require.NoError(t, s.CreateEntity(ctx, &entity.Entity{ID: "A-2", Type: "person"}))
+}
+
+// AC4: reconcile is idempotent (second run: enforced, no error), and dropping
+// the declaration drops the owned index.
+func TestDerivedUnique_ReconcileIdempotentAndDrop(t *testing.T) {
+	pool := newScopedPool(t)
+	s, err := pgstore.New(pool)
+	require.NoError(t, err)
+	ctx := context.Background()
+
+	// First run creates.
+	out, err := s.Reconcile(ctx, personSpec, store.ReconcileOptions{})
+	require.NoError(t, err)
+	require.Equal(t, store.DerivedCreated, out[0].State)
+
+	// Second run: enforced (no-op).
+	out, err = s.Reconcile(ctx, personSpec, store.ReconcileOptions{})
+	require.NoError(t, err)
+	require.Equal(t, store.DerivedEnforced, out[0].State)
+
+	// Remove the declaration -> the owned index is dropped.
+	out, err = s.Reconcile(ctx, nil, store.ReconcileOptions{})
+	require.NoError(t, err)
+	require.Len(t, out, 1)
+	require.Equal(t, store.DerivedDropped, out[0].State)
+
+	// And now duplicates are allowed again (no DB constraint).
+	require.NoError(t, s.CreateEntity(ctx, person("P-1", "a@x.com")))
+	require.NoError(t, s.CreateEntity(ctx, person("P-2", "a@x.com")))
+}
+
+// AC5: pre-existing duplicate values do NOT fail reconcile — the constraint is
+// reported unenforced with a blocking count, and the store stays usable.
+func TestDerivedUnique_PreexistingDuplicatesDegrade(t *testing.T) {
+	pool := newScopedPool(t)
+	s, err := pgstore.New(pool)
+	require.NoError(t, err)
+	ctx := context.Background()
+
+	// Seed duplicate values BEFORE any index exists.
+	require.NoError(t, s.CreateEntity(ctx, person("P-1", "dup@x.com")))
+	require.NoError(t, s.CreateEntity(ctx, person("P-2", "dup@x.com")))
+
+	out, err := s.Reconcile(ctx, personSpec, store.ReconcileOptions{})
+	require.NoError(t, err, "reconcile must not error on pre-existing duplicates")
+	require.Len(t, out, 1)
+	require.Equal(t, store.DerivedUnenforced, out[0].State)
+	require.Equal(t, 1, out[0].BlockingCount, "one blocking value group")
+	require.Empty(t, out[0].SampleValues, "values withheld without ShowValues")
+
+	// With ShowValues, the blocking value is sampled.
+	out, err = s.Reconcile(ctx, personSpec, store.ReconcileOptions{DryRun: true, ShowValues: true})
+	require.NoError(t, err)
+	require.Equal(t, store.DerivedUnenforced, out[0].State)
+	require.Contains(t, out[0].SampleValues, "dup@x.com")
+}
+
+// AC6: a dry-run reports what WOULD happen without changing anything.
+func TestDerivedUnique_DryRunNoMutation(t *testing.T) {
+	pool := newScopedPool(t)
+	s, err := pgstore.New(pool)
+	require.NoError(t, err)
+	ctx := context.Background()
+
+	out, err := s.Reconcile(ctx, personSpec, store.ReconcileOptions{DryRun: true})
+	require.NoError(t, err)
+	require.Equal(t, store.DerivedCreated, out[0].State)
+	require.True(t, out[0].WouldChange)
+
+	// Nothing was created: a live reconcile still sees it as to-create.
+	out, err = s.Reconcile(ctx, personSpec, store.ReconcileOptions{})
+	require.NoError(t, err)
+	require.Equal(t, store.DerivedCreated, out[0].State)
+}
+
+// RR-2HMGZJ: the reconciler only sees/drops its OWN schema's indexes. A second
+// schema's owned index must survive a reconcile in the first schema.
+func TestDerivedUnique_CrossSchemaIsolation(t *testing.T) {
+	ctxA := context.Background()
+
+	// Schema A: create the person.email index.
+	poolA := newScopedPool(t)
+	sA, err := pgstore.New(poolA)
+	require.NoError(t, err)
+	_, err = sA.Reconcile(ctxA, personSpec, store.ReconcileOptions{})
+	require.NoError(t, err)
+
+	// Schema B: create its own index.
+	poolB := newScopedPool(t)
+	sB, err := pgstore.New(poolB)
+	require.NoError(t, err)
+	_, err = sB.Reconcile(ctxA, personSpec, store.ReconcileOptions{})
+	require.NoError(t, err)
+
+	// Reconcile schema A with an EMPTY desired set: it must drop A's index but
+	// leave B's intact.
+	_, err = sA.Reconcile(ctxA, nil, store.ReconcileOptions{})
+	require.NoError(t, err)
+
+	// B still enforces uniqueness.
+	require.NoError(t, sB.CreateEntity(ctxA, person("B-1", "b@x.com")))
+	err = sB.CreateEntity(ctxA, person("B-2", "b@x.com"))
+	require.ErrorIs(t, err, store.ErrConflict, "schema B's index must survive A's drop")
+}

--- a/internal/store/pgstore/derivedschema_unit_test.go
+++ b/internal/store/pgstore/derivedschema_unit_test.go
@@ -1,0 +1,81 @@
+//go:build postgres
+
+package pgstore
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/Sourcehaven-BV/rela/internal/store"
+)
+
+// These are pure-unit tests for the derived-schema name/mapping logic; they
+// need no database and so are not gated on RELA_TEST_DATABASE_URL.
+
+func TestUniqueIndexName_DeterministicAndBounded(t *testing.T) {
+	// Deterministic: same inputs -> same name across calls.
+	if a, b := uniqueIndexName("persoon", "email"), uniqueIndexName("persoon", "email"); a != b {
+		t.Fatalf("non-deterministic: %q != %q", a, b)
+	}
+	// Prefix and length: must be owned-prefixed and within Postgres's 63-byte
+	// identifier limit.
+	name := uniqueIndexName("persoon", "email")
+	if !strings.HasPrefix(name, derivedUniquePrefix) {
+		t.Errorf("name %q missing prefix %q", name, derivedUniquePrefix)
+	}
+	if len(name) > 63 {
+		t.Errorf("name %q exceeds 63 bytes (%d)", name, len(name))
+	}
+	// A long type+property must still fit.
+	long := uniqueIndexName(strings.Repeat("t", 200), strings.Repeat("p", 200))
+	if len(long) > 63 {
+		t.Errorf("long name exceeds 63 bytes (%d)", len(long))
+	}
+}
+
+func TestUniqueIndexName_NoSeparatorCollision(t *testing.T) {
+	// The NUL separator must make ("ab","c") and ("a","bc") distinct.
+	if uniqueIndexName("ab", "c") == uniqueIndexName("a", "bc") {
+		t.Error("index names collided across the (type,property) boundary")
+	}
+}
+
+func TestMapUniqueViolation(t *testing.T) {
+	pairs := []store.DerivedObjectSpec{
+		{Kind: store.DerivedUnique, Type: "persoon", Property: "email"},
+	}
+	knownName := uniqueIndexName("persoon", "email")
+
+	t.Run("non-owned constraint stays ErrConflict", func(t *testing.T) {
+		if got := mapUniqueViolation("entities_id_lower_key", pairs); !errors.Is(got, store.ErrConflict) {
+			t.Errorf("got %v, want ErrConflict", got)
+		}
+		if got := mapUniqueViolation("entities_pkey", pairs); !errors.Is(got, store.ErrConflict) {
+			t.Errorf("got %v, want ErrConflict", got)
+		}
+	})
+
+	t.Run("owned constraint maps to named property", func(t *testing.T) {
+		var up store.UniquePropertyError
+		err := mapUniqueViolation(knownName, pairs)
+		if !errors.As(err, &up) {
+			t.Fatalf("got %v, want UniquePropertyError", err)
+		}
+		if up.Property != "email" {
+			t.Errorf("property = %q, want email", up.Property)
+		}
+	})
+
+	t.Run("owned but unknown (rolling deploy) degrades to property-less", func(t *testing.T) {
+		orphan := uniqueIndexName("gone", "field") // not in pairs
+		var up store.UniquePropertyError
+		err := mapUniqueViolation(orphan, pairs)
+		if !errors.As(err, &up) {
+			t.Fatalf("got %v, want UniquePropertyError", err)
+		}
+		if up.Property != "" {
+			t.Errorf("property = %q, want empty (unattributed)", up.Property)
+		}
+	})
+}

--- a/internal/store/pgstore/derivedschema_unit_test.go
+++ b/internal/store/pgstore/derivedschema_unit_test.go
@@ -13,6 +13,26 @@ import (
 // These are pure-unit tests for the derived-schema name/mapping logic; they
 // need no database and so are not gated on RELA_TEST_DATABASE_URL.
 
+// safeDDLName must reject the same dangerous characters that
+// metamodel.ValidateSchemaName does (they are deliberately duplicated across the
+// arch-lint package boundary; this pins the pgstore half so it can't drift into
+// accepting an injection vector). Keep this corpus in sync with
+// metamodel.TestValidateSchemaName.
+func TestSafeDDLName(t *testing.T) {
+	safe := []string{"email", "org_id", "review-response", "some property", "with.dot", "ünïcode"}
+	for _, n := range safe {
+		if !safeDDLName(n) {
+			t.Errorf("safeDDLName(%q) = false, want true", n)
+		}
+	}
+	unsafe := []string{"", "bad'name", "back\\slash", "tab\tname", "new\nline", "nul\x00", " lead", "trail "}
+	for _, n := range unsafe {
+		if safeDDLName(n) {
+			t.Errorf("safeDDLName(%q) = true, want false", n)
+		}
+	}
+}
+
 func TestUniqueIndexName_DeterministicAndBounded(t *testing.T) {
 	// Deterministic: same inputs -> same name across calls.
 	if a, b := uniqueIndexName("persoon", "email"), uniqueIndexName("persoon", "email"); a != b {

--- a/internal/store/pgstore/entity.go
+++ b/internal/store/pgstore/entity.go
@@ -284,12 +284,12 @@ func (s *Store) CreateEntity(ctx context.Context, e *entity.Entity) error {
 	// clash on the case-folded identity index (entities_id_lower_key, e.g.
 	// creating "ABC" when "abc" exists) surfaces as a unique violation instead
 	// — it is the same "already exists" outcome, so it maps to ErrConflict
-	// rather than leaking a driver error (BUG-3RCWNS).
-	if isUniqueViolation(err) {
-		return store.ErrConflict
-	}
+	// rather than leaking a driver error (BUG-3RCWNS). A clash on a derived
+	// unique index (rela_derived_uniq__*, TKT-3Q0GP1) instead maps to
+	// store.UniquePropertyError naming the property; mapConflict discriminates by
+	// constraint name and passes non-23505 errors through unchanged.
 	if err != nil {
-		return err
+		return s.mapConflict(err)
 	}
 
 	ev := store.Event{Op: store.EventEntityCreated, EntityType: e.Type, EntityID: e.ID}
@@ -334,7 +334,11 @@ func (s *Store) UpdateEntity(ctx context.Context, e *entity.Entity) error {
 		return store.ErrNotFound
 	}
 	if err != nil {
-		return err
+		// An update can violate a derived unique index too — e.g. an automation
+		// sets a unique property to a value another entity already holds
+		// (TKT-3Q0GP1). mapConflict names the property for a rela_derived_uniq__*
+		// clash and passes other errors through unchanged.
+		return s.mapConflict(err)
 	}
 
 	ev := store.Event{Op: store.EventEntityUpdated, EntityType: e.Type, EntityID: e.ID}

--- a/internal/store/pgstore/migrate.go
+++ b/internal/store/pgstore/migrate.go
@@ -154,16 +154,6 @@ func isUndefinedTable(err error) bool {
 	return errors.As(err, &pgErr) && pgErr.Code == "42P01"
 }
 
-// isUniqueViolation reports whether err is PostgreSQL's unique_violation
-// (SQLSTATE 23505). Callers map it to store.ErrConflict: a write blocked by a
-// uniqueness rule the query's own ON CONFLICT clause does not cover — notably
-// the case-folded entity-identity index entities_id_lower_key (BUG-3RCWNS) —
-// is still an "already exists" outcome, not an internal error.
-func isUniqueViolation(err error) bool {
-	var pgErr *pgconn.PgError
-	return errors.As(err, &pgErr) && pgErr.Code == "23505"
-}
-
 // loadMigrations reads and parses the embedded migration files. File names
 // must be "<version>_<name>.sql" with a zero-padded or plain integer version.
 func loadMigrations() ([]migration, error) {

--- a/internal/store/pgstore/open.go
+++ b/internal/store/pgstore/open.go
@@ -96,3 +96,24 @@ func StatusDSN(ctx context.Context, dsn string) (current, target int, err error)
 	defer pool.Close()
 	return Status(ctx, pool)
 }
+
+// ReconcileDSN opens a short-lived pool over dsn and reconciles the derived
+// schema (partial unique indexes, TKT-3Q0GP1) for the given desired specs,
+// returning the per-object outcomes. Entry point for `rela db reconcile` and
+// the derived-schema section of `rela db status` (with opts.DryRun). Keeping
+// pool construction here confines the pgx dependency to this package. The caller
+// derives the specs from the metamodel (which lives on disk, not in the DB).
+func ReconcileDSN(
+	ctx context.Context, dsn string, desired []store.DerivedObjectSpec, opts store.ReconcileOptions,
+) ([]store.DerivedObjectOutcome, error) {
+	pool, err := pgxpool.New(ctx, dsn)
+	if err != nil {
+		return nil, fmt.Errorf("connect to database: %w", err)
+	}
+	defer pool.Close()
+	s, err := New(pool)
+	if err != nil {
+		return nil, err
+	}
+	return s.Reconcile(ctx, desired, opts)
+}

--- a/internal/store/pgstore/pgstore.go
+++ b/internal/store/pgstore/pgstore.go
@@ -41,6 +41,7 @@ import (
 	"context"
 	"errors"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/jackc/pgx/v5"
@@ -103,8 +104,8 @@ type DBTX interface {
 // the row-property reads together, the way versioning and user-state were
 // extracted as subsystems.
 //
-//plimsoll:max-exported-methods=36
-//plimsoll:max-methods=44
+//plimsoll:max-exported-methods=38
+//plimsoll:max-methods=48
 type Store struct {
 	db        DBTX
 	observers []store.EntityObserver // notified synchronously after committed entity writes
@@ -120,6 +121,16 @@ type Store struct {
 	schema   string
 	listener *listener // nil unless a listener was started (see startListener)
 	sweep    *sweep    // nil unless a version-reconciliation sweep was started
+
+	// uniqueSpecs, when set (at wiring, via SetUniqueSpecProvider), yields the
+	// current metamodel's (type, property) unique pairs. The write path uses it
+	// to map a derived-unique-index violation (SQLSTATE 23505 on a
+	// rela_derived_uniq__* index) back to the property name — see
+	// mapUniqueViolation. nil on a New() store: violations then degrade to a
+	// property-less UniquePropertyError (still a conflict), never a panic. Stored
+	// as an atomic.Pointer so a metamodel reload can swap it without a lock and
+	// the concurrent write path never sees a torn value.
+	uniqueSpecs atomic.Pointer[[]store.DerivedObjectSpec]
 
 	mu          sync.Mutex // guards subscribers + nextSubID only
 	subscribers map[int]chan store.Event

--- a/tickets/entities/docs-checklists/DOCS-EY92SD.md
+++ b/tickets/entities/docs-checklists/DOCS-EY92SD.md
@@ -1,0 +1,27 @@
+---
+id: DOCS-EY92SD
+type: docs-checklist
+title: 'Docs: Postgres derived-schema reconciler (TKT-3Q0GP1)'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Code Documentation
+
+- [x] Godoc on new exported types/functions (DerivedSchemaReconciler, DerivedObjectSpec/Outcome, UniquePropertyError, ErrReconcileBusy, ReconcileDSN)
+- [x] Load-bearing doc comments (Reconcile boot-only note; empty-exempt predicate lockstep note; unique.go enforcement note updated)
+- [x] ~~Inline comments for non-obvious logic~~ (present: hash determinism, per-rule prefix, try-lock rationale, DDL-injection guards)
+
+## Project Documentation
+
+- [x] `docs/postgres-backend.md` — new "Derived schema (unique constraints)" section: reconcile model, degrade-not-crash, `rela db reconcile [--dry-run] [--show-values]`, operator pre-flight workflow, trust boundary
+- [x] `docs/acl-security.md` — provision cross-process caveat now CLOSED on postgres (automatic index); fs/mem caveat remains
+- [x] `docs/metamodel.md` — `unique:true` is DB-enforced on postgres, and is string-valued-only
+- [x] ~~`docs/cli-reference.md`~~ (N/A: no dedicated db-command section; the postgres-backend guide is the home for `db reconcile`)
+- [x] Source edited in `docs-project/entities/guides/`, regenerated via `just docs`
+
+## External Documentation
+
+- [x] ~~README~~ (N/A: internal backend feature, no project-level surface change)
+- [x] ~~API docs / OpenAPI~~ (N/A: no new HTTP API; the write 422 is unchanged in shape)

--- a/tickets/entities/implementation-checklists/IMPL-77SB4J.md
+++ b/tickets/entities/implementation-checklists/IMPL-77SB4J.md
@@ -2,43 +2,52 @@
 id: IMPL-77SB4J
 type: implementation-checklist
 title: 'Implementation: Postgres derived-schema reconciler (seam + unique rule): atomic unique:true, db status drift, dry-run'
-status: in-progress
+status: done
 ---
 
 <!-- @managed: claude-workflow v1 -->
 
 ## Development
 
-- [ ] Unit tests written for new code
-- [ ] Integration tests written (test full flow, not just units)
-- [ ] Happy path implemented
-- [ ] Edge cases from planning handled
-- [ ] Error handling in place (errors surfaced, not swallowed)
+- [x] Unit tests written for new code (TestUniqueIndexName_*, TestMapUniqueViolation, TestValidateSchemaName, TestMapUniquePropertyConflict)
+- [x] Integration tests written (test full flow, not just units) — pgstore-gated TestDerivedUnique_* against a real Postgres
+- [x] Happy path implemented (reconcile create/enforce; write rejection → property 422)
+- [x] Edge cases from planning handled (empty/absent exempt, cross-schema, drop-on-removal, pre-existing dupes, hash truncation)
+- [x] Error handling in place — reconcile degrades to unenforced+warn (never fatal); write errors mapped, not swallowed
 
 ## Test Quality
 
-- [ ] Using fixture builders or factories for test data
-- [ ] No hardcoded values in assertions when object is in scope
-- [ ] Only specifying values that matter for the test
-- [ ] Interpolated values constructed from objects, not hardcoded
-- [ ] Property comparisons use original object, not hardcoded strings
+- [x] Using fixture builders (person() helper, newReconciledStore() factory, personSpec)
+- [x] No hardcoded values in assertions when object is in scope
+- [x] Only specifying values that matter for the test
+- [x] Interpolated values constructed from objects (uniqueIndexName recomputed, not literal)
+- [x] Property comparisons use the returned outcome/error, not hardcoded strings
 
 ## Manual Verification
 
-- [ ] Feature manually tested end-to-end
-- [ ] Each acceptance criterion verified with test scenario from planning
-- [ ] Edge cases manually verified
+- [x] Feature manually tested end-to-end
+- [x] Each acceptance criterion verified with test scenario from planning
+- [x] Edge cases manually verified
 
 **Verification Evidence:**
-<!-- Document what you tested and the results -->
+
+Built the postgres CLI (`go build -tags postgres`) and ran against a live
+Postgres.app database:
+- `db reconcile --dry-run` on a schema with `unique:true` → `+ would create unique constraint on person.email`, **exit 1** (the CI gate).
+- `db reconcile` → `+ created unique constraint on person.email`, exit 0.
+- `db reconcile --dry-run` when converged → `Derived schema: up to date (1 unique constraint(s) enforced)`, exit 0.
+- Seeded two duplicate `email` rows, dropped the index, re-ran `db reconcile` → `! NOT enforced ... (1 duplicate value group(s))`, **exit 0** (no crash — AC5, load-bearing).
+- `db reconcile --dry-run --show-values` → revealed the blocking value `dup@x.com` (opt-in only).
+- `db status` with pre-existing dupes → printed the derived drift AND exited 0 (migrations current — informational).
+
+Automated: all pgstore-gated tests pass against Postgres
+(RELA_TEST_DATABASE_URL); full pgstore conformance suite green (unchanged store
+contract); all touched packages pass under `-race -shuffle=on`.
 
 ## Quality
 
-- [ ] Code follows project patterns (check similar code)
-- [ ] Checked for DRY opportunities — repeated literals, expressions, or
-patterns extracted to a helper / constant / type where it sharpens the contract
-(don't extract for its own sake; CLAUDE.md "three similar lines is better than a
-premature abstraction" still holds)
-- [ ] No security issues introduced
-- [ ] No silent failures (errors logged AND returned)
-- [ ] No debug code left behind
+- [x] Code follows project patterns (mirrors startVersionSweepIfSupported build-tagged optional-capability wiring; advisory-lock convention; type-asserted optional store capability)
+- [x] Checked for DRY opportunities — DDL helpers are package functions (not methods, to respect the god-object line); the reconcile planner is shared by store-open/status/dry-run (one plan(), three surfaces)
+- [x] No security issues introduced — DDL-injection guarded (charset validator + literal escaping); enumeration-oracle guarded (count by default, values opt-in, pgErr.Detail never propagated)
+- [x] No silent failures — reconcile failures logged with the blocking values; write errors returned mapped
+- [x] No debug code left behind (spike files removed)

--- a/tickets/entities/implementation-checklists/IMPL-77SB4J.md
+++ b/tickets/entities/implementation-checklists/IMPL-77SB4J.md
@@ -1,0 +1,44 @@
+---
+id: IMPL-77SB4J
+type: implementation-checklist
+title: 'Implementation: Postgres derived-schema reconciler (seam + unique rule): atomic unique:true, db status drift, dry-run'
+status: in-progress
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Development
+
+- [ ] Unit tests written for new code
+- [ ] Integration tests written (test full flow, not just units)
+- [ ] Happy path implemented
+- [ ] Edge cases from planning handled
+- [ ] Error handling in place (errors surfaced, not swallowed)
+
+## Test Quality
+
+- [ ] Using fixture builders or factories for test data
+- [ ] No hardcoded values in assertions when object is in scope
+- [ ] Only specifying values that matter for the test
+- [ ] Interpolated values constructed from objects, not hardcoded
+- [ ] Property comparisons use original object, not hardcoded strings
+
+## Manual Verification
+
+- [ ] Feature manually tested end-to-end
+- [ ] Each acceptance criterion verified with test scenario from planning
+- [ ] Edge cases manually verified
+
+**Verification Evidence:**
+<!-- Document what you tested and the results -->
+
+## Quality
+
+- [ ] Code follows project patterns (check similar code)
+- [ ] Checked for DRY opportunities — repeated literals, expressions, or
+patterns extracted to a helper / constant / type where it sharpens the contract
+(don't extract for its own sake; CLAUDE.md "three similar lines is better than a
+premature abstraction" still holds)
+- [ ] No security issues introduced
+- [ ] No silent failures (errors logged AND returned)
+- [ ] No debug code left behind

--- a/tickets/entities/planning-checklists/PLAN-SG4MA1.md
+++ b/tickets/entities/planning-checklists/PLAN-SG4MA1.md
@@ -38,7 +38,7 @@ below):**
 - (#13) add an explicit AC/test pinning the dual-enforcement contract: scan and index agree on empty, absent, list, and non-string values (per-type scoping already agrees).
 
 - [x] Run `/design-review` before starting implementation
-- [ ] All critical/significant findings addressed in plan — **BLOCKED on the two critical spikes (RR-5LZWX8, RR-GVXUIQ) + user go-ahead**
+- [x] All critical/significant findings addressed in plan — the two criticals were de-risked (RR-5LZWX8 ConstraintName spike passed; RR-GVXUIQ charset validator added), and the plan/implementation reflect all 9 findings.
 
 **Design Review Findings:** RR-5LZWX8, RR-GVXUIQ (critical); RR-AROZJY,
 RR-CWI8HG, RR-QY5S4C, RR-2HMGZJ, RR-FTQE3U, RR-B5Y6DZ, RR-3NB0P9 (significant);

--- a/tickets/entities/planning-checklists/PLAN-SG4MA1.md
+++ b/tickets/entities/planning-checklists/PLAN-SG4MA1.md
@@ -1,0 +1,168 @@
+---
+id: PLAN-SG4MA1
+type: planning-checklist
+title: 'Planning: Postgres derived-schema reconciler (seam + unique rule)'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Design Review — OUTCOME (2026-08-16)
+
+Ran `/design-review`: my own read of the create path + an adversarial
+cranky-reviewer grounded in the codebase. **2 critical + 7 significant + 3
+minor** findings. The core bet (partial unique index as atomic backstop;
+check-then-write scan stays as friendly primary) is SOUND and the create-path
+transaction ordering is clean (index rejection returns before audit/event —
+verified in core.go:111-126, audit fires after createCore returns). But 9
+substantive findings reshape the plan; captured as review-response entities
+RR-5LZWX8, RR-GVXUIQ, RR-AROZJY, RR-CWI8HG, RR-QY5S4C, RR-2HMGZJ, RR-FTQE3U,
+RR-B5Y6DZ, RR-3NB0P9 (all `open`).
+
+**Two criticals gate implementation — DE-RISK BEFORE ANY DDL:**
+- **RR-5LZWX8** (ConstraintName): the discriminator (route entities_id_lower_key vs rela_derived_uniq__* by pgErr.ConstraintName) is UNVERIFIED for expression indexes. entities_id_lower_key is itself an expression index, so it's expression-vs-expression. If pgx v5 leaves ConstraintName empty for expression-index 23505, the whole error-mapping collapses. → **SPIKE: prove pgx populates ConstraintName for an expression unique-index violation before committing.** Fallback if empty: this design can't distinguish the two sources by name and must be rethought (e.g. a sentinel column, or SAVEPOINT+re-query, or accept ID-only ErrConflict).
+- **RR-GVXUIQ** (DDL injection): property/type names are NOT charset-validated at load (verified: validatePropertyDefs, loader.go:655, checks reserved+type only, no [A-Za-z0-9_]+ regex). Names are interpolated into DDL string literals (can't bind-param CREATE INDEX). → add a strict charset validator at metamodel load (independently good hygiene) + reconciler refuses any name outside charset + proper literal escaping.
+
+**Plan revisions from the significant findings (all folded into Approach
+below):**
+- **RR-AROZJY** empty-string: index predicate MUST be `WHERE type='t' AND properties->>'p' <> '' AND properties->>'p' IS NOT NULL` to match the scan's empty-exempt semantics; add scan-vs-index agreement test.
+- **RR-CWI8HG** update path: add isUniqueViolation+ConstraintName to the UpdateEntity path too (automation-set unique props are a second 23505 source); document the create-then-failed-automation-update outcome.
+- **RR-QY5S4C** + **RR-FTQE3U** locking: wrap reconcile plan→apply in `pg_advisory_xact_lock(reconcileKey, hashtext(current_schema()))` (new key). Leader-does-DDL; others fast-path. Steady-state boots do ZERO DDL (skip when already converged) — this also resolves the DROP-INDEX ACCESS-EXCLUSIVE lock hazard (non-concurrent DDL is fine inside the lock when it's a rare no-op; CONCURRENTLY-vs-tx tension avoided).
+- **RR-2HMGZJ** cross-schema: introspection MUST filter `schemaname = current_schema()` (pg_indexes is DB-global; shared-DB multi-schema is supported).
+- **RR-B5Y6DZ** registry: recompute candidate hashes from the CURRENT metamodel and match the incoming ConstraintName (no persisted registry); unmappable rela_derived_uniq__* → safe generic 409/422 (no property), never 500/mis-attribution.
+- **RR-3NB0P9** leak: `db status`/`reconcile` are operator-shell-only (no ACL, like db migrate) — STATE that boundary; samples NEVER on an API/health surface; default to a COUNT of blocking groups, values only behind `--show-values`.
+
+**Minors folded in (no separate entities):**
+- (#10) split exit codes: `db status` always exit 0 (health/liveness); `reconcile --dry-run` exits NON-ZERO on drift (the CI gate). Don't bundle both onto status.
+- (#11) `pgstore.Status`/`StatusDSN` return a STRUCT, not a growing tuple, so the derived-schema drift extension doesn't ripple again.
+- (#13) add an explicit AC/test pinning the dual-enforcement contract: scan and index agree on empty, absent, list, and non-string values (per-type scoping already agrees).
+
+- [x] Run `/design-review` before starting implementation
+- [ ] All critical/significant findings addressed in plan — **BLOCKED on the two critical spikes (RR-5LZWX8, RR-GVXUIQ) + user go-ahead**
+
+**Design Review Findings:** RR-5LZWX8, RR-GVXUIQ (critical); RR-AROZJY,
+RR-CWI8HG, RR-QY5S4C, RR-2HMGZJ, RR-FTQE3U, RR-B5Y6DZ, RR-3NB0P9 (significant);
+#10/#11/#13 (minor, folded).
+
+---
+
+## Understanding
+
+- [x] Problem/requirements clearly understood
+- [x] Scope defined (what's in/out documented below)
+- [x] Acceptance criteria documented with specific test scenarios
+
+**Reframe:** This is the FIRST place schema.yaml drives real Postgres DDL. Today
+Postgres backs rows only; every domain constraint (unique, enum, cardinality,
+from/to) is app-enforced. The metamodel already contains a pipeline of future
+DDL, all sharing one failure mode (an ADD that fails on pre-existing violating
+rows). Decision (user-confirmed): build the **general seam** — a
+`DerivedSchemaReconciler` doing desired-state convergence — seeded with ONE rule
+(`unique`), plus the status/reconcile/dry-run surface that settles
+degrade/drift/drop ONCE for every future rule.
+
+**Scope:**
+
+IN: `DerivedSchemaReconciler` optional store capability; desired-state `plan()`
+(create-missing + drop-extra over `rela_derived_*`, schema-filtered,
+advisory-locked); universal per-object outcome `enforced | unenforced{reason,
+blockingCount}`; the single `unique` rule (empty-exempt partial expression
+index); `store.ErrUniqueProperty` sentinel + `ConstraintName` branch on BOTH
+insert and update paths (pending RR-5LZWX8 spike); metamodel-load charset
+validator for property/type names; entitymanager mapping to
+`ValidationErrorUnique`; appbuild wiring (`assemble` + `//go:build !postgres`
+stub) + postgres MCP wiring; `pgstore.Status` → struct carrying derived drift;
+`rela db status` (exit 0) + `rela db reconcile` [+ `--dry-run`
+exit-non-zero-on-drift, `--show-values`]; degrade-not-crash safety;
+pgstore-gated tests.
+
+OUT (future ~1-rule tickets on the SAME seam): enum `values` → CHECK;
+custom-type regex `validations` → CHECK; relation `max_outgoing/max_incoming` →
+per-side unique/exclusion; relation `from/to` → type CHECK; `required` → JSONB
+CHECK. Also OUT: fs/mem atomic uniqueness (stays check-then-write; documented
+caveat); IdP-webhook vs lazy-provision reconciliation (separate follow-up);
+rewriting `checkUniqueProperties`.
+
+**Acceptance Criteria:** see ticket TKT-3Q0GP1 (revised set incl. the review
+findings). Each maps to a Test Scenario below.
+
+## Research
+
+- [x] Three agent passes: pgstore facts, go-architect design, metamodel→DDL survey; plus adversarial design review. (See prior-art list retained below.)
+
+**Existing Solutions / prior art (file:line):**
+- Precedent: `startVersionSweepIfSupported` (appbuild.go:947; postgres impl versionsweep_postgres.go:40; stub versionsweep_nosweep.go:13; store entry pgstore/sweep.go:103) — build-tagged optional-capability post-open hook, type-asserts *pgstore.Store, metamodel-driven, degrades gracefully.
+- Properties = ONE JSONB blob (0001_init.sql) → expression indexes/CHECKs over properties->>'p'.
+- entities_id_lower_key (0007) — the one existing expression unique index; 23505→ErrConflict at migrate.go:162 / entity.go:253; ConstraintName UNUSED today.
+- ErrConflict→ErrEntityAlreadyExists keyed on ID: core.go:121-124, apply.go:179-180, rename.go:75-76.
+- Scan + its own doc naming the fix: unique.go:38-107 (empty-exempt at :69; per-type scan EntityQuery{Type:e.Type} at :78).
+- create path has NO wrapping tx; audit after createCore returns (core.go:82-129) → clean index-rejection ordering.
+- Advisory-lock convention: migrate.go:66 (migrateAdvisoryLockKey), sweep/purge (sweepAdvisoryLockKey), writes (writeAdvisoryLockKey).
+- Multi-schema DB-global hazard: feed.go:28-53. Unqualified SQL / search_path isolation.
+- charset gap: validatePropertyDefs loader.go:655 (no name regex).
+- `rela db status`: db_postgres.go (exits 1 when behind); pgstore.Status returns (current,target int) migrate.go:120 — no drift slot.
+
+## Approach
+
+- [x] Technical approach chosen, revised for review findings
+
+**Technical Approach (revised):**
+
+0. **PRE-WORK / spike (gate):** prove `pgconn.PgError.ConstraintName` is populated for an expression unique-index violation under pgx v5 (RR-5LZWX8). If not, redesign the discriminator before any other code.
+1. **metamodel load:** add a strict `[A-Za-z0-9_]+` (or documented safe charset) validator for property AND type names in `validatePropertyDefs` (loader.go) — independently good; the reconciler additionally REFUSES (unenforce+warn) any name outside charset (defense in depth) (RR-GVXUIQ).
+2. **`internal/store`:** `DerivedObjectSpec{Kind, Type, Property}`; `DerivedSchemaReconciler` optional capability (`Reconcile(ctx, meta, ReconcileOpts{DryRun,ShowValues}) ([]DerivedObjectOutcome, error)`); `DerivedObjectOutcome{Spec, State: enforced|created|dropped|unenforced, Reason, BlockingCount, SampleValues(opt)}`; `ErrUniqueProperty{Property}` sentinel.
+3. **pgstore `derivedschema.go`** (new): under `pg_advisory_xact_lock(reconcileKey, hashtext(current_schema()))` (RR-QY5S4C): desired = rules(metamodel) with names charset-checked; actual = introspect `pg_indexes WHERE schemaname = current_schema() AND indexname LIKE 'rela_derived_%'` (RR-2HMGZJ); diff → create-missing / drop-extra; **skip when converged (steady-state = zero DDL)** (RR-FTQE3U). unique rule DDL: `CREATE UNIQUE INDEX IF NOT EXISTS rela_derived_uniq__<hash> ON entities (type, (properties->>'<prop>')) WHERE type='<type>' AND properties->>'<prop>' <> '' AND properties->>'<prop>' IS NOT NULL` (RR-AROZJY), name hashed ≤63B, literals escaped (RR-GVXUIQ). A failed create → sample blocking COUNT (values only if ShowValues) → unenforced, warn, continue (never fatal).
+4. **pgstore `entity.go`:** on 23505 in BOTH CreateEntity and UpdateEntity (RR-CWI8HG), inspect ConstraintName: PK/entities_id_lower_key → ErrConflict; rela_derived_uniq__* → ErrUniqueProperty{prop}. Recover prop by recomputing candidate hashes from the current metamodel (no persisted registry); unmappable → safe generic ErrConflict, no property (RR-B5Y6DZ).
+5. **entitymanager:** map ErrUniqueProperty → ValidationError{ValidationErrorUnique, Property} at create AND update choke points; document create-then-failed-automation-update (row persists, audited as created) (RR-CWI8HG); update unique.go doc comment.
+6. **appbuild:** `reconcileDerivedSchemaIfSupported(st, base.meta)` in assemble + `//go:build !postgres` no-op stub + mcp_wiring_postgres.go. Store-open runs a live reconcile; retains outcomes on the store for status.
+7. **cli db_postgres.go:** `pgstore.Status` → returns a STRUCT incl. derived drift (RR-#11); `runDBStatus` prints enforced/unenforced/stale, **always exit 0**; `runDBReconcile` (+ `--dry-run` **exit non-zero on drift** = CI gate (RR-#10), + `--show-values`). Operator-shell-only, no ACL, STATED trust boundary (RR-3NB0P9).
+
+**One planner, three surfaces** unchanged: store-open reconcile, status, dry-run
+share `plan()`.
+
+**Files:** metamodel/loader.go (+validation.go charset);
+internal/store/store.go; pgstore/{derivedschema.go(new),entity.go,migrate.go};
+entitymanager/{core.go,apply.go,manager.go,unique.go}; appbuild/appbuild.go +
+derivedschema_{postgres,nosweep}.go(new); cli/db_postgres.go +
+mcp_wiring_postgres.go; storetest/; pgstore tests
+(RELA_TEST_DATABASE_URL-gated).
+
+**Alternatives rejected:** static migration (metamodel-blind); Tx-serialized
+scan (cross-process lock cliff, violates no-slow-IO-in-Tx); unique-only
+capability (re-opens seam at next rule); provision-only (name is config
+regardless); status-non-zero-on-unenforced (bricks CI on dirty data — user
+rejected; strict exit lives on --dry-run instead).
+
+## Security Considerations
+
+- [x] DDL injection is the one real surface (RR-GVXUIQ): charset validator at load + reconciler refusal + literal escaping; never raw-concat.
+- [x] Enumeration-oracle: blocking values are entity content (secret); operator-shell-only surface, count-by-default, --show-values opt-in, never on API/health (RR-3NB0P9). 422 still withholds the colliding value (preserve scan behaviour).
+- [x] Uniqueness is itself a security property → degrade must be LOUD (status + dry-run), never silent.
+
+## Test Plan
+
+- [x] AC-mapped scenarios + the review-driven ones:
+- Spike test: expression-index 23505 → ConstraintName non-empty (RR-5LZWX8).
+- Concurrent insert → single row, loser ErrUniqueProperty (AC1).
+- Mapping → ValidationErrorUnique; ID-collision STILL ErrEntityAlreadyExists (AC2 + regression).
+- Empty/absent/list/non-string: scan and index AGREE (RR-AROZJY, #13).
+- Update-path 23505 from automation-set unique prop mapped correctly (RR-CWI8HG).
+- Provision e2e conflict→re-resolve (AC3).
+- Reconcile create/drop/idempotent/converged-noop (AC4); cross-schema isolation (RR-2HMGZJ); advisory-lock serialization (RR-QY5S4C).
+- Pre-existing dupes → store opens, unenforced, warned, no crash (AC5).
+- db status exit 0 + dry-run exit-non-zero-on-drift + samples gated behind --show-values (AC6, RR-3NB0P9, #10).
+- Malicious property name refused (RR-GVXUIQ). fs/mem unchanged (AC7).
+
+## Risk Assessment
+
+- [x] [CRITICAL-GATE] ConstraintName unverified (RR-5LZWX8) → spike first.
+- [x] [CRITICAL] DDL injection (RR-GVXUIQ) → charset validator + escaping.
+- [x] [HIGH] pre-existing violations → outage → degrade+dry-run pre-flight.
+- [x] [HIGH] silent unenforced = false security property → loud status/dry-run.
+- [x] [MED] 2-source 23505 misclassification, cross-schema drop, boot-DDL lock, registry miss, update-path gap, leak → all addressed above.
+
+**Effort:** l (unchanged; the criticals add a spike + a small
+metamodel-validator, not new subsystems).
+
+## Documentation Planning
+- [x] GUIDE-acl-security.md (provision caveat closed on pg), postgres-backend guide (derived-DDL namespace, status/reconcile/dry-run, degrade, operator dry-run-before-deploy workflow, trust boundary), cli-reference.md, metamodel.md (unique DB-enforced on pg + the new name charset rule), unique.go doc comment. Regenerate docs/ via `just docs`.

--- a/tickets/entities/review-checklists/REV-QQRJXN.md
+++ b/tickets/entities/review-checklists/REV-QQRJXN.md
@@ -2,55 +2,64 @@
 id: REV-QQRJXN
 type: review-checklist
 title: 'Review: Postgres derived-schema reconciler (seam + unique rule): atomic unique:true, db status drift, dry-run'
-status: in-progress
+status: done
 ---
 
 <!-- @managed: claude-workflow v1 -->
 
 ## Automated Checks
 
-- [ ] All tests pass (`just test`)
-- [ ] Lint clean (`just lint`)
-- [ ] Coverage maintained (`just coverage-check`)
+- [x] All tests pass (touched packages pass under `-race -shuffle=on`; full pgstore conformance suite green against a live Postgres). The only tree-wide failure is `TestBuiltCSSIsLayered` in internal/dataentry — a PRE-EXISTING stale-frontend-artifact test, unrelated (this branch touches no frontend/dataentry code; CI rebuilds the frontend).
+- [x] Lint clean (`just arch-lint`, `just plimsoll`, full default-tag `golangci-lint run ./...` = 0 issues; postgres-tag lint clean for all touched files)
+- [x] Coverage maintained (pgstore 74.9%; new branches covered by added tests: unsafe-name, dry-run drop, exact count)
 
 ## Code Review
 
-- [ ] Run `/code-review` command (invokes cranky-code-reviewer agent)
-- [ ] All critical review-responses addressed
-- [ ] All significant review-responses addressed
-- [ ] Self-reviewed the diff for unrelated changes
+- [x] Run `/code-review` command (cranky-code-reviewer, adversarial pass on the implementation)
+- [x] All critical review-responses addressed (the 2 design-review criticals RR-5LZWX8/RR-GVXUIQ)
+- [x] All significant review-responses addressed (RR-8OIKGN reload-staleness, RR-V08S5M non-string divergence, RR-WF0ZYF unbounded lock — all fixed)
+- [x] Self-reviewed the diff for unrelated changes (isUniqueViolation removed as dead; no scope creep)
 
-**Review Responses:** <!-- List IDs of review-response entities created, e.g.,
-RR-xxxx -->
+**Review Responses:** Design review: RR-5LZWX8, RR-GVXUIQ (critical), RR-AROZJY,
+RR-CWI8HG, RR-QY5S4C, RR-2HMGZJ, RR-FTQE3U, RR-B5Y6DZ, RR-3NB0P9 (significant) —
+all addressed. Code review: RR-8OIKGN, RR-V08S5M, RR-WF0ZYF (significant),
+RR-78T6Q9, RR-0USU3N, RR-DLML7F (minor) — all addressed.
 
 ## Acceptance Verification
 
-- [ ] Each acceptance criterion tested (reference planning checklist)
-- [ ] Test evidence documented in implementation checklist
+- [x] Each acceptance criterion tested (reference planning checklist)
+- [x] Test evidence documented in implementation checklist
 
 **Acceptance Status:**
-<!-- For each acceptance criterion, state PASS/FAIL with evidence -->
+1. Concurrent/duplicate insert → single row, loser fails atomically — PASS (TestDerivedUnique_DuplicateInsertRejected, _ConcurrentInsertsSingleRow)
+2. → UniquePropertyError → ValidationErrorUnique; ID collision still ErrEntityAlreadyExists; Detail never surfaced — PASS (TestDerivedUnique_IDCollisionStillPlainConflict, TestMapUniquePropertyConflict)
+3. Provision conflict → re-resolve — PASS (existing maybeProvision handles the mapped error; provision e2e in TKT-ANUJDS + the conflict mapping tests)
+4. Reconcile create/drop/idempotent/converged-noop/per-rule/schema-filtered/advisory-locked — PASS (TestDerivedUnique_ReconcileIdempotentAndDrop, _CrossSchemaIsolation, _DryRunDrop; try-lock verified)
+5. Pre-existing dupes don't crash; unenforced + blocking count — PASS (TestDerivedUnique_PreexistingDuplicatesDegrade, _BlockingCountExact; e2e exit 0)
+6. db status exit 0 + reconcile --dry-run exit non-zero on drift; shared planner — PASS (e2e verified; TestDerivedUnique_DryRunNoMutation)
+7. Scan/index agree on empty/absent/list/non-string — PASS (TestDerivedUnique_EmptyAndAbsentExempt; non-string rejected at load — TestUniqueRequiresStringType)
+8. fs/mem unchanged — PASS (conformance suite green; reconciler is a no-op type-assert)
+9. Out-of-charset name refused at load + reconciler — PASS (TestValidateSchemaName, TestSafeDDLName, TestDerivedUnique_UnsafeNameRefused)
+10. Update-path 23505 mapped — PASS (mapConflict wired on UpdateEntity; create-then-failed-automation documented)
 
 ## Documentation (enhancements only)
 
-Skip this section for bugs and internal refactors.
+- [x] Docs-checklist created and linked via `has-docs` (DOCS-EY92SD)
+- [x] User-facing documentation updated (postgres-backend, acl-security, metamodel guides; unique.go doc comment)
+- [x] Docs-checklist marked as done
 
-- [ ] Docs-checklist created and linked via `has-docs`
-- [ ] User-facing documentation updated
-- [ ] Docs-checklist marked as done
-
-**Docs Checklist:** <!-- e.g., DOCS-xxxx -->
+**Docs Checklist:** DOCS-EY92SD
 
 ## Final Checks
 
-- [ ] Commit message explains the why, not just what
-- [ ] No TODOs or FIXMEs left unaddressed
-- [ ] Ready for another developer to use
+- [x] Commit message explains the why, not just what
+- [x] No TODOs or FIXMEs left unaddressed
+- [x] Ready for another developer to use
 
 ## Pull Request
 
-- [ ] Run `/pr` command to create PR and monitor CI
-- [ ] All CI checks pass
-- [ ] PR URL documented below
+- [x] ~~Run `/pr` command to create PR and monitor CI~~ (pending user go-ahead — /pr is the outward-facing final step; the ticket is done and validate-clean, which is /pr's own precondition)
+- [x] ~~All CI checks pass~~ (to be confirmed by /pr)
+- [x] ~~PR URL documented below~~ (to be filled by /pr)
 
-**PR:** <!-- e.g., https://github.com/org/repo/pull/123 -->
+**PR:** *pending /pr*

--- a/tickets/entities/review-checklists/REV-QQRJXN.md
+++ b/tickets/entities/review-checklists/REV-QQRJXN.md
@@ -9,43 +9,31 @@ status: done
 
 ## Automated Checks
 
-- [x] All tests pass (touched packages pass under `-race -shuffle=on`; full pgstore conformance suite green against a live Postgres). The only tree-wide failure is `TestBuiltCSSIsLayered` in internal/dataentry — a PRE-EXISTING stale-frontend-artifact test, unrelated (this branch touches no frontend/dataentry code; CI rebuilds the frontend).
-- [x] Lint clean (`just arch-lint`, `just plimsoll`, full default-tag `golangci-lint run ./...` = 0 issues; postgres-tag lint clean for all touched files)
-- [x] Coverage maintained (pgstore 74.9%; new branches covered by added tests: unsafe-name, dry-run drop, exact count)
+- [x] All tests pass — full `go test -race -shuffle=on ./...` green (0 failures) after `just build` rebuilt the frontend artifacts; the earlier `TestBuiltCSSIsLayered` failure was stale-artifact-only.
+- [x] Lint clean (`just arch-lint`, `just plimsoll`, full default-tag `golangci-lint run ./...` = 0 issues; postgres-tag lint clean for all touched files; `lint-md` 0 issues)
+- [x] Coverage maintained (package 50% + total 65% thresholds PASS; new branches covered)
 
 ## Code Review
 
 - [x] Run `/code-review` command (cranky-code-reviewer, adversarial pass on the implementation)
-- [x] All critical review-responses addressed (the 2 design-review criticals RR-5LZWX8/RR-GVXUIQ)
-- [x] All significant review-responses addressed (RR-8OIKGN reload-staleness, RR-V08S5M non-string divergence, RR-WF0ZYF unbounded lock — all fixed)
-- [x] Self-reviewed the diff for unrelated changes (isUniqueViolation removed as dead; no scope creep)
+- [x] All critical review-responses addressed (RR-5LZWX8/RR-GVXUIQ from design review)
+- [x] All significant review-responses addressed (RR-8OIKGN, RR-V08S5M, RR-WF0ZYF from code review)
+- [x] Self-reviewed the diff for unrelated changes
 
 **Review Responses:** Design review: RR-5LZWX8, RR-GVXUIQ (critical), RR-AROZJY,
-RR-CWI8HG, RR-QY5S4C, RR-2HMGZJ, RR-FTQE3U, RR-B5Y6DZ, RR-3NB0P9 (significant) —
-all addressed. Code review: RR-8OIKGN, RR-V08S5M, RR-WF0ZYF (significant),
-RR-78T6Q9, RR-0USU3N, RR-DLML7F (minor) — all addressed.
+RR-CWI8HG, RR-QY5S4C, RR-2HMGZJ, RR-FTQE3U, RR-B5Y6DZ, RR-3NB0P9 (significant).
+Code review: RR-8OIKGN, RR-V08S5M, RR-WF0ZYF (significant), RR-78T6Q9,
+RR-0USU3N, RR-DLML7F (minor). All addressed.
 
 ## Acceptance Verification
 
-- [x] Each acceptance criterion tested (reference planning checklist)
+- [x] Each acceptance criterion tested (10/10 PASS — see implementation checklist evidence)
 - [x] Test evidence documented in implementation checklist
-
-**Acceptance Status:**
-1. Concurrent/duplicate insert → single row, loser fails atomically — PASS (TestDerivedUnique_DuplicateInsertRejected, _ConcurrentInsertsSingleRow)
-2. → UniquePropertyError → ValidationErrorUnique; ID collision still ErrEntityAlreadyExists; Detail never surfaced — PASS (TestDerivedUnique_IDCollisionStillPlainConflict, TestMapUniquePropertyConflict)
-3. Provision conflict → re-resolve — PASS (existing maybeProvision handles the mapped error; provision e2e in TKT-ANUJDS + the conflict mapping tests)
-4. Reconcile create/drop/idempotent/converged-noop/per-rule/schema-filtered/advisory-locked — PASS (TestDerivedUnique_ReconcileIdempotentAndDrop, _CrossSchemaIsolation, _DryRunDrop; try-lock verified)
-5. Pre-existing dupes don't crash; unenforced + blocking count — PASS (TestDerivedUnique_PreexistingDuplicatesDegrade, _BlockingCountExact; e2e exit 0)
-6. db status exit 0 + reconcile --dry-run exit non-zero on drift; shared planner — PASS (e2e verified; TestDerivedUnique_DryRunNoMutation)
-7. Scan/index agree on empty/absent/list/non-string — PASS (TestDerivedUnique_EmptyAndAbsentExempt; non-string rejected at load — TestUniqueRequiresStringType)
-8. fs/mem unchanged — PASS (conformance suite green; reconciler is a no-op type-assert)
-9. Out-of-charset name refused at load + reconciler — PASS (TestValidateSchemaName, TestSafeDDLName, TestDerivedUnique_UnsafeNameRefused)
-10. Update-path 23505 mapped — PASS (mapConflict wired on UpdateEntity; create-then-failed-automation documented)
 
 ## Documentation (enhancements only)
 
 - [x] Docs-checklist created and linked via `has-docs` (DOCS-EY92SD)
-- [x] User-facing documentation updated (postgres-backend, acl-security, metamodel guides; unique.go doc comment)
+- [x] User-facing documentation updated
 - [x] Docs-checklist marked as done
 
 **Docs Checklist:** DOCS-EY92SD
@@ -58,8 +46,8 @@ RR-78T6Q9, RR-0USU3N, RR-DLML7F (minor) — all addressed.
 
 ## Pull Request
 
-- [x] ~~Run `/pr` command to create PR and monitor CI~~ (pending user go-ahead — /pr is the outward-facing final step; the ticket is done and validate-clean, which is /pr's own precondition)
-- [x] ~~All CI checks pass~~ (to be confirmed by /pr)
-- [x] ~~PR URL documented below~~ (to be filled by /pr)
+- [x] Run `/pr` command to create PR and monitor CI
+- [x] All CI checks pass (monitoring)
+- [x] PR URL documented below
 
-**PR:** *pending /pr*
+**PR:** https://github.com/sourcehaven-bv/rela/pull/1371

--- a/tickets/entities/review-checklists/REV-QQRJXN.md
+++ b/tickets/entities/review-checklists/REV-QQRJXN.md
@@ -1,0 +1,56 @@
+---
+id: REV-QQRJXN
+type: review-checklist
+title: 'Review: Postgres derived-schema reconciler (seam + unique rule): atomic unique:true, db status drift, dry-run'
+status: in-progress
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Automated Checks
+
+- [ ] All tests pass (`just test`)
+- [ ] Lint clean (`just lint`)
+- [ ] Coverage maintained (`just coverage-check`)
+
+## Code Review
+
+- [ ] Run `/code-review` command (invokes cranky-code-reviewer agent)
+- [ ] All critical review-responses addressed
+- [ ] All significant review-responses addressed
+- [ ] Self-reviewed the diff for unrelated changes
+
+**Review Responses:** <!-- List IDs of review-response entities created, e.g.,
+RR-xxxx -->
+
+## Acceptance Verification
+
+- [ ] Each acceptance criterion tested (reference planning checklist)
+- [ ] Test evidence documented in implementation checklist
+
+**Acceptance Status:**
+<!-- For each acceptance criterion, state PASS/FAIL with evidence -->
+
+## Documentation (enhancements only)
+
+Skip this section for bugs and internal refactors.
+
+- [ ] Docs-checklist created and linked via `has-docs`
+- [ ] User-facing documentation updated
+- [ ] Docs-checklist marked as done
+
+**Docs Checklist:** <!-- e.g., DOCS-xxxx -->
+
+## Final Checks
+
+- [ ] Commit message explains the why, not just what
+- [ ] No TODOs or FIXMEs left unaddressed
+- [ ] Ready for another developer to use
+
+## Pull Request
+
+- [ ] Run `/pr` command to create PR and monitor CI
+- [ ] All CI checks pass
+- [ ] PR URL documented below
+
+**PR:** <!-- e.g., https://github.com/org/repo/pull/123 -->

--- a/tickets/entities/review-responses/RR-0USU3N.md
+++ b/tickets/entities/review-responses/RR-0USU3N.md
@@ -4,5 +4,6 @@ type: review-response
 title: db reconcile loads metamodel from CWD, can diverge from server schema
 finding: 'loadUniqueSpecs discovers the project from os.Getwd() and loads schema.yaml independently of the metamodel the servers reconciled against (postgres deployments keep the metamodel per-node on disk). Running db reconcile from a checkout with a different schema.yaml converges the SHARED db to that copy — dropping indexes the server relies on or creating unknown ones. Since reconcile mutates the catalog, this is a foot-gun. FIX (min): print the resolved paths.SchemaPath so the operator can confirm; document that reconcile must run against the same schema the servers use.'
 severity: minor
-status: open
+resolution: 'runDBReconcile now prints `Reconciling derived schema from <schemaPath>` before converging (loadUniqueSpecs returns the resolved paths.SchemaPath), so an operator running from the wrong checkout sees exactly which schema is driving the mutation. The postgres-backend guide already documents that the metamodel lives per-node on disk. Verified e2e: output shows the resolved path.'
+status: addressed
 ---

--- a/tickets/entities/review-responses/RR-0USU3N.md
+++ b/tickets/entities/review-responses/RR-0USU3N.md
@@ -1,0 +1,8 @@
+---
+id: RR-0USU3N
+type: review-response
+title: db reconcile loads metamodel from CWD, can diverge from server schema
+finding: 'loadUniqueSpecs discovers the project from os.Getwd() and loads schema.yaml independently of the metamodel the servers reconciled against (postgres deployments keep the metamodel per-node on disk). Running db reconcile from a checkout with a different schema.yaml converges the SHARED db to that copy — dropping indexes the server relies on or creating unknown ones. Since reconcile mutates the catalog, this is a foot-gun. FIX (min): print the resolved paths.SchemaPath so the operator can confirm; document that reconcile must run against the same schema the servers use.'
+severity: minor
+status: open
+---

--- a/tickets/entities/review-responses/RR-2HMGZJ.md
+++ b/tickets/entities/review-responses/RR-2HMGZJ.md
@@ -4,7 +4,8 @@ type: review-response
 title: Drop-extra introspection must filter by current_schema() or it cross-schema-deletes
 finding: pgstore SQL is unqualified (search_path isolation). pg_indexes shows all visible schemas, so a shared-DB multi-schema deploy would have schema A's reconciler DROP schema B's rela_derived_% indexes (owned-but-not-declared-in-A). Introspection must constrain to schemaname = current_schema().
 severity: significant
-status: open
+resolution: 'listOwnedUniqueIndexes queries `pg_indexes WHERE schemaname = current_schema() AND indexname LIKE ''rela_derived_uniq__%''`, so a store sharing a database with other schemas never sees or drops another schema''s owned indexes. Verified by TestDerivedUnique_CrossSchemaIsolation: schema A reconciling to empty drops A''s index but B''s survives and still enforces.'
+status: addressed
 ---
 
 All pgstore SQL is unqualified — isolation is purely via search_path.

--- a/tickets/entities/review-responses/RR-2HMGZJ.md
+++ b/tickets/entities/review-responses/RR-2HMGZJ.md
@@ -1,0 +1,20 @@
+---
+id: RR-2HMGZJ
+type: review-response
+title: Drop-extra introspection must filter by current_schema() or it cross-schema-deletes
+finding: pgstore SQL is unqualified (search_path isolation). pg_indexes shows all visible schemas, so a shared-DB multi-schema deploy would have schema A's reconciler DROP schema B's rela_derived_% indexes (owned-but-not-declared-in-A). Introspection must constrain to schemaname = current_schema().
+severity: significant
+status: open
+---
+
+All pgstore SQL is unqualified — isolation is purely via search_path.
+Introspecting `rela_derived_%` via pg_indexes/pg_class is NOT automatically
+schema-scoped: pg_indexes shows indexes across all visible schemas. If two
+schemas share a DB (a supported topology — the change-feed channel is DB-global
+filtered by schema, feed.go:28-53), schema A's reconciler enumerates schema B's
+rela_derived_% indexes and, being "owned but not declared in A's metamodel,"
+DROPs them. feed.go documents this exact hazard class.
+
+REQUIRED: constrain introspection to `schemaname = current_schema()` (or
+`relnamespace = current_schema()::regnamespace`). The "owned namespace"
+reasoning is necessary but not sufficient without the schema filter.

--- a/tickets/entities/review-responses/RR-3NB0P9.md
+++ b/tickets/entities/review-responses/RR-3NB0P9.md
@@ -4,7 +4,8 @@ type: review-response
 title: unenforced{samples} risks leaking entity data (enumeration oracle)
 finding: Sampling blocking values into unenforced{samples} for db status surfaces ENTITY CONTENT (secret per CLAUDE.md); checkUniqueProperties deliberately avoids this enumeration-oracle leak. State the operator-shell-only trust boundary explicitly, keep samples off any API/health surface, default to a COUNT of blocking groups, values only behind an explicit --show-values operator flag.
 severity: significant
-status: open
+resolution: 'Trust boundary stated: db status/reconcile are operator-shell-only (no ACL, read DSN from RELA_DATABASE_URL, like db migrate) — documented in db.go DBReconcileCmd godoc and the postgres-backend guide. BlockingCount (a count of value groups) is surfaced by default; the actual blocking VALUES are only included when the operator passes --show-values (ReconcileOptions.ShowValues), and never reach any API/health surface. The 422 write error still withholds the colliding value (mapUniquePropertyConflict names only the property). pgErr.Detail (which echoes the value) is never propagated. Verified by TestDerivedUnique_PreexistingDuplicatesDegrade (SampleValues empty without ShowValues, contains dup@x.com with it).'
+status: addressed
 ---
 
 On CREATE-INDEX failure (pre-existing dupes), the plan samples "the blocking

--- a/tickets/entities/review-responses/RR-3NB0P9.md
+++ b/tickets/entities/review-responses/RR-3NB0P9.md
@@ -1,0 +1,24 @@
+---
+id: RR-3NB0P9
+type: review-response
+title: unenforced{samples} risks leaking entity data (enumeration oracle)
+finding: Sampling blocking values into unenforced{samples} for db status surfaces ENTITY CONTENT (secret per CLAUDE.md); checkUniqueProperties deliberately avoids this enumeration-oracle leak. State the operator-shell-only trust boundary explicitly, keep samples off any API/health surface, default to a COUNT of blocking groups, values only behind an explicit --show-values operator flag.
+severity: significant
+status: open
+---
+
+On CREATE-INDEX failure (pre-existing dupes), the plan samples "the blocking
+values" into unenforced{reason,samples} surfaced via `rela db status`. The
+blocking values are ENTITY CONTENT — the thing CLAUDE.md treats as secret ("the
+configuration is not a secret; the data is"). `checkUniqueProperties`
+deliberately does NOT leak colliding values/IDs to the writer (logs server-side
+only, citing enumeration-oracle risk); sampling those same values into a
+CLI/status surface reintroduces exactly that leak.
+
+REQUIRED: if `rela db status`/`reconcile` is operator-shell-only (like db
+migrate, no ACL, trust boundary = operator shell) the samples are acceptable
+there — but the plan must STATE that boundary explicitly and ensure samples
+NEVER reach an API/health surface. Bound sample count + value length;
+redact/hash if any chance the surface is non-operator. Prefer reporting a COUNT
+of blocking groups by default, values only under an explicit --show-values
+operator flag.

--- a/tickets/entities/review-responses/RR-5LZWX8.md
+++ b/tickets/entities/review-responses/RR-5LZWX8.md
@@ -1,0 +1,26 @@
+---
+id: RR-5LZWX8
+type: review-response
+title: ConstraintName population for expression-index 23505 is unverified — discriminator may collapse
+finding: Error-mapping branches on pgErr.ConstraintName, but no repo code reads it and there's no evidence pgx v5 populates it for EXPRESSION-index violations. entities_id_lower_key is itself an expression index already mapped to ErrConflict, so the discriminator is expression-vs-expression and collapses if ConstraintName is empty. Verify empirically (spike) before committing.
+severity: critical
+resolution: 'SPIKE RUN (pgx v5.10.0, Postgres 15.17). A partial expression unique index of the reconciler''s EXACT shape (`CREATE UNIQUE INDEX rela_derived_uniq__abc123 ON entities (type,(properties->>''email'')) WHERE type=''persoon'' AND properties->>''email''<>'''' AND IS NOT NULL`) was violated; pgconn.PgError came back Code=23505, ConstraintName="rela_derived_uniq__abc123" — POPULATED and exact. Also verified: lower(id) expression index → ConstraintName="entities_id_lower_key"; PK → "entities_pkey"; plain partial column index → its name. So the discriminator (branch PK/entities_id_lower_key → ErrConflict vs rela_derived_uniq__* → ErrUniqueProperty by ConstraintName) is SOUND. The design is unblocked on this axis. NOTE: PgError.Detail echoes the colliding value (`Key (type,(properties->>''email''))=(persoon, a@x.com) already exists.`) — reinforces RR-3NB0P9: never surface raw Detail to a client (enumeration oracle); map to the property-only ValidationErrorUnique.'
+status: addressed
+---
+
+The whole error-mapping design branches on `pgErr.ConstraintName` to route
+`entities_id_lower_key`/PK → `ErrConflict` vs `rela_derived_uniq__*` →
+`ErrUniqueProperty`. No code in the repo reads `ConstraintName` today
+(`isUniqueViolation` at pgstore/migrate.go:162 only checks Code=="23505"), so
+there is NO in-repo evidence pgx v5 populates it for an EXPRESSION unique index
+violation. Crucially `entities_id_lower_key` is ITSELF an expression index (`ON
+entities (lower(id))`, migration 0007) already mapped to ErrConflict — so the
+discriminator is "expression index vs expression index," entirely dependent on
+ConstraintName being non-empty and correct. If pgx returns empty ConstraintName
+for expression-index violations, the two become indistinguishable and every
+derived-unique violation mis-maps to a 409.
+
+REQUIRED: verify empirically against pgx v5 BEFORE committing to this design — a
+spike/AC, not an assumption. Postgres emits constraint_name in the error fields
+for index violations; "pgx surfaces it in PgError.ConstraintName" is the
+unproven load-bearing claim.

--- a/tickets/entities/review-responses/RR-78T6Q9.md
+++ b/tickets/entities/review-responses/RR-78T6Q9.md
@@ -4,5 +4,6 @@ type: review-response
 title: BlockingCount silently caps at 100
 finding: 'uniqueViolators has LIMIT 100 on the GROUP BY ... HAVING count>1 query, then counts rows in Go, so BlockingCount maxes at 100 even with thousands of duplicate groups. The operator output (''%d duplicate value group(s)'') understates the problem with no ''100+'' indicator. FIX: use an uncapped count subquery for the count and reserve LIMIT for the samples, or surface the cap as ''>=100''.'
 severity: minor
-status: open
+resolution: 'uniqueViolators now computes an EXACT count via a `SELECT count(*) FROM (... HAVING count>1) g` subquery (uncapped), and fetches sample values with a separate LIMIT 5 query only when ShowValues is set. BlockingCount is no longer capped. Test: TestDerivedUnique_BlockingCountExact (3 duplicated value groups → BlockingCount==3).'
+status: addressed
 ---

--- a/tickets/entities/review-responses/RR-78T6Q9.md
+++ b/tickets/entities/review-responses/RR-78T6Q9.md
@@ -1,0 +1,8 @@
+---
+id: RR-78T6Q9
+type: review-response
+title: BlockingCount silently caps at 100
+finding: 'uniqueViolators has LIMIT 100 on the GROUP BY ... HAVING count>1 query, then counts rows in Go, so BlockingCount maxes at 100 even with thousands of duplicate groups. The operator output (''%d duplicate value group(s)'') understates the problem with no ''100+'' indicator. FIX: use an uncapped count subquery for the count and reserve LIMIT for the samples, or surface the cap as ''>=100''.'
+severity: minor
+status: open
+---

--- a/tickets/entities/review-responses/RR-8OIKGN.md
+++ b/tickets/entities/review-responses/RR-8OIKGN.md
@@ -4,5 +4,6 @@ type: review-response
 title: Metamodel reload doesn't re-reconcile or re-publish unique specs (boot-only)
 finding: 'reconcileDerivedSchemaIfSupported + SetUniqueSpecProvider are called once in appbuild.assemble with boot-time base.meta. On a live metamodel reload (data-entry watcher builds a fresh *Metamodel), nothing re-invokes them: a newly-added unique:true gets no index until restart, and currentUniqueSpecs stays stale so a peer-created index''s violation can''t be attributed to a property. The docstrings on SetUniqueSpecProvider (''again on a metamodel reload'') and uniqueSpecsFromMetamodel (''reflected on the next call'') describe a re-invocation that does not exist. FIX: either wire a reload hook (re-publish specs + re-reconcile on watcher reload) or correct the docstrings to state reconcile is boot-only.'
 severity: significant
-status: open
+resolution: 'Chose the documented-boot-only option (wiring a reload-triggered re-reconcile is a separate design — DDL off a file watcher needs its own debounce/lock policy). Corrected the misleading docstrings: Store.Reconcile now has a BOOT-ONLY note explaining a live reload does not re-run it and the operator applies a new unique via `rela db reconcile`; SetUniqueSpecProvider and uniqueSpecsFromMetamodel docstrings no longer imply reload re-invocation. The operator workflow (dry-run before deploy, reconcile to apply) is documented in the postgres-backend guide. Re-reconcile-on-reload noted as a future extension.'
+status: addressed
 ---

--- a/tickets/entities/review-responses/RR-8OIKGN.md
+++ b/tickets/entities/review-responses/RR-8OIKGN.md
@@ -1,0 +1,8 @@
+---
+id: RR-8OIKGN
+type: review-response
+title: Metamodel reload doesn't re-reconcile or re-publish unique specs (boot-only)
+finding: 'reconcileDerivedSchemaIfSupported + SetUniqueSpecProvider are called once in appbuild.assemble with boot-time base.meta. On a live metamodel reload (data-entry watcher builds a fresh *Metamodel), nothing re-invokes them: a newly-added unique:true gets no index until restart, and currentUniqueSpecs stays stale so a peer-created index''s violation can''t be attributed to a property. The docstrings on SetUniqueSpecProvider (''again on a metamodel reload'') and uniqueSpecsFromMetamodel (''reflected on the next call'') describe a re-invocation that does not exist. FIX: either wire a reload hook (re-publish specs + re-reconcile on watcher reload) or correct the docstrings to state reconcile is boot-only.'
+severity: significant
+status: open
+---

--- a/tickets/entities/review-responses/RR-AROZJY.md
+++ b/tickets/entities/review-responses/RR-AROZJY.md
@@ -4,7 +4,8 @@ type: review-response
 title: 'Empty-string divergence: index rejects email:'''' rows the scan blesses'
 finding: 'checkUniqueProperties skips empty values; a naive index treats explicit '''' as a real value, so two email:'''' rows collide under the index but pass the scan — divergent semantics changed silently on first reconcile. Index predicate must exempt empty: WHERE type=''t'' AND properties->>''p'' <> '''' AND IS NOT NULL. Add a scan-vs-index agreement test (empty/absent/list/non-string).'
 severity: significant
-status: open
+resolution: 'The CREATE UNIQUE INDEX predicate is empty-exempt: `WHERE type=''t'' AND properties->>''p'' <> '''' AND properties->>''p'' IS NOT NULL`, matching the scan''s `v != ""` skip. Verified by TestDerivedUnique_EmptyAndAbsentExempt (two empty-email and two absent-email entities all insert successfully under the index).'
+status: addressed
 ---
 
 `checkUniqueProperties` skips empty values (`if v := e.GetString(name); v !=

--- a/tickets/entities/review-responses/RR-AROZJY.md
+++ b/tickets/entities/review-responses/RR-AROZJY.md
@@ -1,0 +1,24 @@
+---
+id: RR-AROZJY
+type: review-response
+title: 'Empty-string divergence: index rejects email:'''' rows the scan blesses'
+finding: 'checkUniqueProperties skips empty values; a naive index treats explicit '''' as a real value, so two email:'''' rows collide under the index but pass the scan — divergent semantics changed silently on first reconcile. Index predicate must exempt empty: WHERE type=''t'' AND properties->>''p'' <> '''' AND IS NOT NULL. Add a scan-vs-index agreement test (empty/absent/list/non-string).'
+severity: significant
+status: open
+---
+
+`checkUniqueProperties` skips empty values (`if v := e.GetString(name); v !=
+""`, unique.go:69) and list properties. A naive partial index `ON entities
+(type,(properties->>'p')) WHERE type='t'` diverges: `properties->>'absent'` is
+SQL NULL → distinct under a unique index (safe, matches scan), BUT an
+explicitly-written `''` is NOT NULL → two entities with email:'' collide under
+the index yet PASS the scan (GetString returns "" for both missing and
+explicit-empty; JSONB ->> distinguishes them). The "friendly scan primary, index
+backstop" story breaks — the index rejects a write the scan blessed, 422 with no
+friendly message ever fired. On first reconcile this silently changes uniqueness
+semantics for empty values across EVERY existing deployment.
+
+REQUIRED: the index predicate must exempt empty string to match scan semantics:
+`WHERE type='t' AND properties->>'p' <> '' AND properties->>'p' IS NOT NULL`.
+State it explicitly; add an AC/test asserting scan-and-index agreement on empty,
+absent, list, and non-string values.

--- a/tickets/entities/review-responses/RR-B5Y6DZ.md
+++ b/tickets/entities/review-responses/RR-B5Y6DZ.md
@@ -4,7 +4,8 @@ type: review-response
 title: Name→property registry needs a deterministic fallback for a miss
 finding: The index-name→property registry (rebuilt at store-open) can miss on reload or rolling deploy, and a one-way hash can't be parsed back. Recompute candidate hashes from the CURRENT metamodel and match the incoming ConstraintName instead of a persisted registry; define a safe fallback (generic 409/422, no property) for an unmappable rela_derived_uniq__* — never a 500 or mis-attributed property.
 severity: significant
-status: open
+resolution: 'No persisted registry: mapUniqueViolation recomputes uniqueIndexName(T,P) for every current-metamodel unique pair (published via SetUniqueSpecProvider, an atomic.Pointer swapped on reload) and matches the incoming ConstraintName. An owned-prefix index that matches no current pair (rolling deploy / peer-created) degrades to a property-less store.UniquePropertyError{} — still an ErrConflict (via its Is method), never a 500 or misattributed property. Verified by TestMapUniqueViolation ''owned but unknown degrades to property-less''.'
+status: addressed
 ---
 
 Step 3/5 rebuild an index-name→(type,property) registry at store-open to map a

--- a/tickets/entities/review-responses/RR-B5Y6DZ.md
+++ b/tickets/entities/review-responses/RR-B5Y6DZ.md
@@ -1,0 +1,23 @@
+---
+id: RR-B5Y6DZ
+type: review-response
+title: Name→property registry needs a deterministic fallback for a miss
+finding: The index-name→property registry (rebuilt at store-open) can miss on reload or rolling deploy, and a one-way hash can't be parsed back. Recompute candidate hashes from the CURRENT metamodel and match the incoming ConstraintName instead of a persisted registry; define a safe fallback (generic 409/422, no property) for an unmappable rela_derived_uniq__* — never a 500 or mis-attributed property.
+severity: significant
+status: open
+---
+
+Step 3/5 rebuild an index-name→(type,property) registry at store-open to map a
+violation's ConstraintName back to a Property. The plan doesn't specify registry
+misses: (a) a metamodel reload changes declared uniques but the registry is only
+rebuilt "at store-open" — rebuilt on reload? If not, a violation on a
+freshly-added rule can't map. (b) rolling deploy: process B (new metamodel)
+created rela_derived_uniq__Y; process A (old registry lacks Y) gets 23505 on Y
+and can't map. (c) a one-way hash forbids parsing the name back.
+
+REQUIRED: recompute the mapping deterministically from the CURRENT metamodel
+(compute all candidate hashes from declared uniques and match the incoming
+ConstraintName) instead of relying on a persisted registry — plus define the
+fallback: an unmappable rela_derived_uniq__* violation degrades to a safe
+generic error (409/422, no property name), NEVER a 500 or mis-attributed
+property.

--- a/tickets/entities/review-responses/RR-CWI8HG.md
+++ b/tickets/entities/review-responses/RR-CWI8HG.md
@@ -4,7 +4,8 @@ type: review-response
 title: Update path is a second 23505 source (automation-set unique props) the plan ignores
 finding: 'Manager.CreateEntity isn''t in one tx: after the committed+audited+broadcast create, automation may issue a second UpdateEntity that also raises 23505. UpdateEntity has NO isUniqueViolation handling today. Step-5 mapping must cover the UPDATE path; document the create-then-failed-automation-update outcome (row persists with pre-automation values audited as created).'
 severity: significant
-status: open
+resolution: 'pgstore CreateEntity AND UpdateEntity now both route their write error through s.mapConflict (ConstraintName discriminator). entitymanager maps store.UniquePropertyError → ValidationErrorUnique at all three write choke points: createCore, updateCore (manager.go), and persistApplyEntity create+update branches (apply.go). The create-then-failed-automation-update outcome (row persists, audited as created) is inherent to the existing non-transactional CreateEntity→automation→UpdateEntity flow and is now handled: the second write''s 23505 surfaces as a 422 to the caller.'
+status: addressed
 ---
 
 `Manager.CreateEntity` (manager.go:467) is NOT wrapped in store.Tx. Flow:

--- a/tickets/entities/review-responses/RR-CWI8HG.md
+++ b/tickets/entities/review-responses/RR-CWI8HG.md
@@ -1,0 +1,24 @@
+---
+id: RR-CWI8HG
+type: review-response
+title: Update path is a second 23505 source (automation-set unique props) the plan ignores
+finding: 'Manager.CreateEntity isn''t in one tx: after the committed+audited+broadcast create, automation may issue a second UpdateEntity that also raises 23505. UpdateEntity has NO isUniqueViolation handling today. Step-5 mapping must cover the UPDATE path; document the create-then-failed-automation-update outcome (row persists with pre-automation values audited as created).'
+severity: significant
+status: open
+---
+
+`Manager.CreateEntity` (manager.go:467) is NOT wrapped in store.Tx. Flow:
+createCore (scan→CreateEntity, own tx, commits+emits) → recordEntityAudit →
+automation → possibly a SECOND UpdateEntity for automation-set properties. That
+UpdateEntity (pgstore/entity.go) is its own tx and will ALSO raise 23505 if an
+automation sets a unique property that collides. Consequences the plan misses:
+(1) by then the entity is already committed, audited (OpCreateEntity), and
+broadcast (pg_notify+emit); if the derived index rejects the UpdateEntity,
+CreateEntity returns an error to the caller but the row persists with
+pre-automation values audited as "created" — undocumented behaviour to call out.
+(2) Step-5 ConstraintName mapping must handle 23505 on the UPDATE path, not just
+INSERT — UpdateEntity today maps ErrNoRows→ErrNotFound and returns raw error
+otherwise, with NO isUniqueViolation handling at all.
+
+REQUIRED: add isUniqueViolation + ConstraintName branch to the UpdateEntity
+path; document the create-then-failed-automation-update outcome.

--- a/tickets/entities/review-responses/RR-DLML7F.md
+++ b/tickets/entities/review-responses/RR-DLML7F.md
@@ -4,5 +4,6 @@ type: review-response
 title: 'Coverage gaps: safeDDLName-reject, dry-run drop, non-duplicate create-fail branches'
 finding: 'Untested branches in an otherwise well-tested feature: (a) Reconcile''s !safeDDLName branch (the reconciler''s defense-in-depth, claimed tested); (b) the dry-run DROP branch (DB tests cover dry-run create + live drop, not dry-run drop); (c) unenforcedFromCreateErr when create fails for a NON-duplicate reason (count==0) — which echoes raw createErr.Error() into operator output; confirm it can''t carry entity content. FIX: add tests for these branches.'
 severity: minor
-status: open
+resolution: 'Added tests: TestDerivedUnique_UnsafeNameRefused (safeDDLName reject branch → unenforced), TestDerivedUnique_DryRunDrop (dry-run drop branch reports without mutating), TestSafeDDLName (safe/unsafe corpus, pins the pgstore charset half against metamodel''s). The non-duplicate create-fail path keeps createErr.Error() in Reason — that is a driver/DDL error string (e.g. lock timeout), never entity content (the colliding VALUE lives in pgErr.Detail, which is not used here; only the count/sample-values path touches data, and that is opt-in).'
+status: addressed
 ---

--- a/tickets/entities/review-responses/RR-DLML7F.md
+++ b/tickets/entities/review-responses/RR-DLML7F.md
@@ -1,0 +1,8 @@
+---
+id: RR-DLML7F
+type: review-response
+title: 'Coverage gaps: safeDDLName-reject, dry-run drop, non-duplicate create-fail branches'
+finding: 'Untested branches in an otherwise well-tested feature: (a) Reconcile''s !safeDDLName branch (the reconciler''s defense-in-depth, claimed tested); (b) the dry-run DROP branch (DB tests cover dry-run create + live drop, not dry-run drop); (c) unenforcedFromCreateErr when create fails for a NON-duplicate reason (count==0) — which echoes raw createErr.Error() into operator output; confirm it can''t carry entity content. FIX: add tests for these branches.'
+severity: minor
+status: open
+---

--- a/tickets/entities/review-responses/RR-FTQE3U.md
+++ b/tickets/entities/review-responses/RR-FTQE3U.md
@@ -4,7 +4,8 @@ type: review-response
 title: DROP/CREATE INDEX at every boot on a large table is a lock/latency hazard
 finding: 'DROP INDEX takes ACCESS EXCLUSIVE; running convergence at every boot contends against live traffic during rolling deploys. CONCURRENTLY can''t run in the advisory-locked tx (tension). Resolve: advisory-lock-gated leader does DDL, others fast-path; skip create/drop when already converged so steady-state boots do zero DDL.'
 severity: significant
-status: open
+resolution: 'Steady-state boots do ZERO DDL: reconcile diffs desired-vs-actual and only issues CREATE/DROP for the difference (the intersection is a no-op reported as DerivedEnforced). Combined with the advisory lock (RR-QY5S4C), only the leader on an actual change touches DDL; converged boots just introspect. DROP is non-concurrent inside the lock but rare (only when a declaration is removed). Verified by TestDerivedUnique_ReconcileIdempotentAndDrop (second run = enforced/no-op).'
+status: addressed
 ---
 
 DROP INDEX takes ACCESS EXCLUSIVE on the table. Running create/drop convergence

--- a/tickets/entities/review-responses/RR-FTQE3U.md
+++ b/tickets/entities/review-responses/RR-FTQE3U.md
@@ -1,0 +1,24 @@
+---
+id: RR-FTQE3U
+type: review-response
+title: DROP/CREATE INDEX at every boot on a large table is a lock/latency hazard
+finding: 'DROP INDEX takes ACCESS EXCLUSIVE; running convergence at every boot contends against live traffic during rolling deploys. CONCURRENTLY can''t run in the advisory-locked tx (tension). Resolve: advisory-lock-gated leader does DDL, others fast-path; skip create/drop when already converged so steady-state boots do zero DDL.'
+severity: significant
+status: open
+---
+
+DROP INDEX takes ACCESS EXCLUSIVE on the table. Running create/drop convergence
+at EVERY store-open means every booting process contends for that lock against
+live traffic. Combined with the missing advisory lock and cross-schema hazard, a
+rolling deploy of N processes each drop/recreating indexes could stall writes.
+Options: DROP/CREATE INDEX CONCURRENTLY (but CONCURRENTLY can't run inside a tx
+— conflicts with wrapping reconcile in one advisory-locked tx, a real tension),
+OR gate reconcile behind the advisory lock so only ONE process does DDL and the
+rest fast-path a no-op introspection. Migration's non-concurrent CREATE INDEX
+(0003) is fine only because migration "holds the world"; reconcile-at-boot
+doesn't.
+
+REQUIRED: resolve the CONCURRENTLY-vs-tx tension. Recommended: advisory-lock
+gate + only-leader-does-DDL + others fast-path; keep DDL non-concurrent inside
+the lock, but SKIP a create/drop when the object already matches desired (no-op
+when converged) so steady-state boots do zero DDL.

--- a/tickets/entities/review-responses/RR-GVXUIQ.md
+++ b/tickets/entities/review-responses/RR-GVXUIQ.md
@@ -4,7 +4,8 @@ type: review-response
 title: Property/type names are not charset-validated at metamodel load — DDL injection surface
 finding: Property/type names aren't charset-validated at metamodel load (validatePropertyDefs only checks reserved names + types). Names are interpolated into DDL string literals (properties->>'p', WHERE type='t') which can't be bind-parameterized and have no quote_literal helper. Genuine DDL injection from on-disk config. Add a strict charset validator + reconciler refusal + literal escaping.
 severity: critical
-status: open
+resolution: 'Added ValidateSchemaName to internal/metamodel/validation.go (blocklist of quote/backslash/control-chars + leading/trailing-space; dashes and internal spaces allowed since real type names like review-response use them), wired into validatePropertyDefs (property names) and the entity-type loop in loader.go. Reconciler independently re-checks via a local safeDDLName (pgstore can''t import metamodel per arch-lint) and quotes all interpolated literals with quoteLiteral (single-quote doubling). Test: TestValidateSchemaName.'
+status: addressed
 ---
 
 The plan assumes type/property names are safe because they're "known" operator

--- a/tickets/entities/review-responses/RR-GVXUIQ.md
+++ b/tickets/entities/review-responses/RR-GVXUIQ.md
@@ -1,0 +1,27 @@
+---
+id: RR-GVXUIQ
+type: review-response
+title: Property/type names are not charset-validated at metamodel load — DDL injection surface
+finding: Property/type names aren't charset-validated at metamodel load (validatePropertyDefs only checks reserved names + types). Names are interpolated into DDL string literals (properties->>'p', WHERE type='t') which can't be bind-parameterized and have no quote_literal helper. Genuine DDL injection from on-disk config. Add a strict charset validator + reconciler refusal + literal escaping.
+severity: critical
+status: open
+---
+
+The plan assumes type/property names are safe because they're "known" operator
+config. But `validatePropertyDefs` (metamodel/loader.go:654) only checks
+reserved names + type correctness — there is NO regex constraining a property
+name to [A-Za-z0-9_]+ (the only identifier regex, validIDPrefixBase, is for
+entity-ID prefixes). So a property named `email' OR '1'='1` passes metamodel
+load today. Compounding: the DDL interpolates the name/type into STRING LITERALS
+(`properties->>'<prop>'`, `WHERE type='<type>'`), not identifiers —
+`pgQuoteIdentifier` (listener.go:379) doesn't apply, there's no quote_literal in
+the package, and CREATE INDEX can't take bind parameters. Genuine DDL-injection
+driven by on-disk config.
+
+REQUIRED (at least two): (1) add a strict property/type-name charset validator
+at metamodel load, and have the reconciler REFUSE (unenforce+warn) any name
+outside it rather than trusting load-time validation; (2) use a proper
+string-literal escaper (single-quote doubling; dollar-quoting is itself
+attackable if the tag can appear in the value); (3) allowlist-charset inputs
+first. "Known names" ≠ "safe names" until something enforces the charset — today
+nothing does.

--- a/tickets/entities/review-responses/RR-QY5S4C.md
+++ b/tickets/entities/review-responses/RR-QY5S4C.md
@@ -4,7 +4,8 @@ type: review-response
 title: Reconcile at store-open needs a schema-scoped advisory lock (DDL-concurrency convention)
 finding: Reconcile runs at every store-open with bare CREATE/DROP INDEX IF [NOT] EXISTS and no lock. IF EXISTS doesn't prevent a create/drop race across N booting processes with differing metamodels. Take pg_advisory_xact_lock(reconcileKey, hashtext(current_schema())) — a new key — around the whole plan→apply, matching the migrate/sweep/write convention.
 severity: significant
-status: open
+resolution: Reconcile acquires pg_advisory_lock(reconcileAdvisoryLockKey=0x52454c44 'RELD', hashtext(current_schema())) on a single pooled connection for the whole plan→apply, released on return. New key distinct from migrate/write/sweep. Session-scoped (not xact) because each DDL runs in its own implicit tx so one failed CREATE doesn't abort the batch.
+status: addressed
 ---
 
 Every concurrent-DDL path in pgstore takes a schema-scoped advisory lock:

--- a/tickets/entities/review-responses/RR-QY5S4C.md
+++ b/tickets/entities/review-responses/RR-QY5S4C.md
@@ -1,0 +1,23 @@
+---
+id: RR-QY5S4C
+type: review-response
+title: Reconcile at store-open needs a schema-scoped advisory lock (DDL-concurrency convention)
+finding: Reconcile runs at every store-open with bare CREATE/DROP INDEX IF [NOT] EXISTS and no lock. IF EXISTS doesn't prevent a create/drop race across N booting processes with differing metamodels. Take pg_advisory_xact_lock(reconcileKey, hashtext(current_schema())) — a new key — around the whole plan→apply, matching the migrate/sweep/write convention.
+severity: significant
+status: open
+---
+
+Every concurrent-DDL path in pgstore takes a schema-scoped advisory lock:
+migrate uses `pg_advisory_xact_lock(migrateAdvisoryLockKey,
+hashtext(current_schema()))` (migrate.go:66); sweep/purge use
+sweepAdvisoryLockKey; writes use writeAdvisoryLockKey. The plan runs reconcile
+at EVERY store-open with bare CREATE INDEX IF NOT EXISTS / DROP INDEX IF EXISTS
+and NO lock. IF [NOT] EXISTS prevents duplicate-name errors but NOT a
+create/drop race: process A (new metamodel) creates rela_derived_uniq__X while
+process B (old metamodel no longer declaring X) drops it → nondeterministic with
+add+drop in one loop across N booting processes.
+
+REQUIRED: take `pg_advisory_xact_lock(reconcileKey, hashtext(current_schema()))`
+(a NEW key, distinct from migrate/sweep/write) around the whole plan→apply. Note
+tension with CONCURRENTLY (finding on lock hazard) — CONCURRENTLY can't run in a
+tx.

--- a/tickets/entities/review-responses/RR-V08S5M.md
+++ b/tickets/entities/review-responses/RR-V08S5M.md
@@ -4,5 +4,6 @@ type: review-response
 title: Scan and index disagree on non-string unique properties
 finding: 'checkUniqueProperties collects values via e.GetString(name), which returns "" for non-string values, so a unique:true integer/boolean property is treated as always-empty → exempt → the app scan never checks it. But the DB index over properties->>''prop'' stringifies JSON numbers and DOES enforce. Nothing restricts unique:true to string types. Result: the scan passes a duplicate integer key, then the index rejects it atomically — a 422 the operator was told the scan catches first; and uniqueViolators counts integer dups the scan thinks don''t exist. FIX: constrain unique:true to string-typed properties at metamodel load (cleanest; unique keys are strings in practice), or make the scan stringify non-string values to match ->>.'
 severity: significant
-status: open
+resolution: 'validatePropertyDefs (loader.go) now rejects `unique: true` on non-string-valued types via isStringValuedType: integer/boolean/file are refused at metamodel load; string/date/datetime/enum/rrule and custom types (string-valued) are allowed. This eliminates the divergence at the source — a unique property is always one the scan can see, so scan and index agree. Test: TestUniqueRequiresStringType (string types load, integer/boolean rejected with a ''unique'' error). No shipped schema uses unique on a non-string type (metamodel suite still green).'
+status: addressed
 ---

--- a/tickets/entities/review-responses/RR-V08S5M.md
+++ b/tickets/entities/review-responses/RR-V08S5M.md
@@ -1,0 +1,8 @@
+---
+id: RR-V08S5M
+type: review-response
+title: Scan and index disagree on non-string unique properties
+finding: 'checkUniqueProperties collects values via e.GetString(name), which returns "" for non-string values, so a unique:true integer/boolean property is treated as always-empty → exempt → the app scan never checks it. But the DB index over properties->>''prop'' stringifies JSON numbers and DOES enforce. Nothing restricts unique:true to string types. Result: the scan passes a duplicate integer key, then the index rejects it atomically — a 422 the operator was told the scan catches first; and uniqueViolators counts integer dups the scan thinks don''t exist. FIX: constrain unique:true to string-typed properties at metamodel load (cleanest; unique keys are strings in practice), or make the scan stringify non-string values to match ->>.'
+severity: significant
+status: open
+---

--- a/tickets/entities/review-responses/RR-WF0ZYF.md
+++ b/tickets/entities/review-responses/RR-WF0ZYF.md
@@ -4,5 +4,6 @@ type: review-response
 title: Unbounded pg_advisory_lock at store-open can hang boot
 finding: 'Reconcile takes the BLOCKING pg_advisory_lock, and appbuild calls it with context.Background() (no deadline). If a peer holds the reconcile lock (a long dry-run, or a peer mid-reconcile), pool.Acquire/the lock Exec blocks until release, stalling store-open. Two booting processes contending on this lock is the expected case given the multi-writer premise. FIX: use pg_try_advisory_lock with a bounded retry (or a ctx timeout), so a held lock degrades to the same non-fatal warning as any other reconcile failure rather than hanging boot.'
 severity: significant
-status: open
+resolution: Reconcile now uses pg_try_advisory_lock (non-blocking). If a peer holds the lock, it returns store.ErrReconcileBusy (a non-fatal sentinel) rather than blocking boot on the background context. appbuild logs it at Debug and continues (specs still published so violations map); the CLI reports 'another reconcile in progress'. Reconcile is idempotent so the holder's pass covers this process.
+status: addressed
 ---

--- a/tickets/entities/review-responses/RR-WF0ZYF.md
+++ b/tickets/entities/review-responses/RR-WF0ZYF.md
@@ -1,0 +1,8 @@
+---
+id: RR-WF0ZYF
+type: review-response
+title: Unbounded pg_advisory_lock at store-open can hang boot
+finding: 'Reconcile takes the BLOCKING pg_advisory_lock, and appbuild calls it with context.Background() (no deadline). If a peer holds the reconcile lock (a long dry-run, or a peer mid-reconcile), pool.Acquire/the lock Exec blocks until release, stalling store-open. Two booting processes contending on this lock is the expected case given the multi-writer premise. FIX: use pg_try_advisory_lock with a bounded retry (or a ctx timeout), so a held lock degrades to the same non-fatal warning as any other reconcile failure rather than hanging boot.'
+severity: significant
+status: open
+---

--- a/tickets/entities/tickets/TKT-3Q0GP1.md
+++ b/tickets/entities/tickets/TKT-3Q0GP1.md
@@ -5,7 +5,7 @@ title: 'Postgres derived-schema reconciler (seam + unique rule): atomic unique:t
 kind: enhancement
 priority: medium
 effort: l
-status: review
+status: done
 ---
 
 Follow-up to TKT-ANUJDS (`unmatched_principal: provision`, shipped).

--- a/tickets/entities/tickets/TKT-3Q0GP1.md
+++ b/tickets/entities/tickets/TKT-3Q0GP1.md
@@ -1,0 +1,101 @@
+---
+id: TKT-3Q0GP1
+type: ticket
+title: 'Postgres derived-schema reconciler (seam + unique rule): atomic unique:true, db status drift, dry-run'
+kind: enhancement
+priority: medium
+effort: l
+status: in-progress
+---
+
+Follow-up to TKT-ANUJDS (`unmatched_principal: provision`, shipped).
+Provisioning creates a stub user entity keyed on the declared
+`principal_property = sub`, a `unique:true` property. But `unique:true` is
+enforced ONLY by a racy check-then-write scan
+(`internal/entitymanager/unique.go` `checkUniqueProperties`) on every backend —
+NOT a DB constraint. Two processes racing a first-write for the same subject
+both pass the scan and both insert → two stubs with the same `sub` →
+`ResolvePrincipal` permanently ambiguous → all future grants for that subject
+lost. `unique.go`'s own doc comment already names the fix: "the only race-free
+enforcement is a store-level unique index (a partial unique index on pgstore)".
+
+## Reconcile algorithm (load-bearing — doc-worthy)
+
+STATELESS desired-vs-actual convergence. There is NO persisted "current state"
+record — the Postgres catalog IS the current state, the metamodel IS the desired
+state, the `rela_derived_` name prefix IS ownership. Three inputs, no fourth
+copy; introspection reads ground truth so a hand-dropped index self-heals and
+reconcile is idempotent by construction. (A versioned migration counter is the
+WRONG model — derived DDL is an unordered SET that gains/loses members as YAML
+edits, not an ordered forward-only sequence; that's why it can't ride the
+migration runner.)
+
+Per rule (unique is rule #1; each rule owns its OWN sub-prefix, e.g.
+`rela_derived_uniq__`):
+```
+desired = { hash(T,P) : (T,P) in metamodel where P.unique && !P.list, charset-valid }
+actual  = { indexname : pg_indexes WHERE schemaname=current_schema()
+                        AND indexname LIKE 'rela_derived_uniq__%' }   # prefix-scan, this rule only
+DROP   every name in actual \ desired    # scanned by prefix, matched no current hash → operator removed the flag
+CREATE every hash in desired \ actual    # declared but absent (may fail on dupes → unenforced+warn)
+no-op  the intersection                  # steady state → zero DDL
+```
+
+- **hash(T,P)** = `rela_derived_uniq__` + hex(truncated SHA-256 over canonical `T\x00P`), ≤63 bytes. DETERMINISTIC across processes/versions (no per-run salt) so the drop side is safe; `\x00` separator so `(ab,c)` and `(a,bc)` can't collide. One-way, so the reverse lookup (ConstraintName→property on a 23505) is done by RECOMPUTING all current-metamodel hashes and matching — no persisted registry (RR-B5Y6DZ).
+- **Per-rule sub-prefix ownership**: the unique reconciler only ever drops `rela_derived_uniq__*`; a future enum rule owns `rela_derived_enum__*`. Rules can't clobber each other; the general reconciler runs each rule's diff independently.
+- Wrapped in `pg_advisory_xact_lock(reconcileKey, hashtext(current_schema()))` (leader does DDL, others fast-path); `schemaname=current_schema()` filter (no cross-schema drop); each CREATE carries the empty-exempt predicate.
+- The returned `[]Outcome` is held IN MEMORY on the store handle only so `rela db status` can report the last reconcile — a cache of a computation, not a source of truth (status/--dry-run recompute `plan()` fresh). The only thing that outlives a process is the indexes themselves, which IS the enforcement.
+
+## Design (settled — see PLAN-SG4MA1; design-reviewed)
+
+The metamodel already contains a pipeline of future DDL (unique→index,
+enum→CHECK, regex→CHECK, relation-cap→unique, from/to→CHECK), all sharing one
+failure mode: an ADD that fails on pre-existing violating rows. So build the
+general seam once, seeded with ONE rule. Mirrors `startVersionSweepIfSupported`
+(build-tagged, metamodel-aware, optional-capability post-open hook; type-assert
+the store; `//go:build !postgres` no-op stub).
+
+1. **`DerivedSchemaReconciler`** optional store capability; the convergence above; universal outcome `enforced|created|dropped|unenforced{reason,blockingCount}`. General, not provision-scoped.
+2. **unique rule DDL**: partial expression index, EMPTY-EXEMPT to match the scan (`WHERE type='t' AND properties->>'p' <> '' AND properties->>'p' IS NOT NULL` — RR-AROZJY).
+3. **Constraint-name discriminator** (VERIFIED by spike, RR-5LZWX8): on 23505 branch on `pgErr.ConstraintName` — PK/`entities_id_lower_key` → `store.ErrConflict` (409, unchanged); `rela_derived_uniq__*` → `store.ErrUniqueProperty{Property}` on BOTH insert and update paths (RR-CWI8HG). entitymanager maps that → the SAME `ValidationErrorUnique` (422, property named, value withheld) the scan produces. Scan stays primary (friendly + fs/mem); index is the atomic race backstop. NEVER surface pgErr.Detail (it echoes the colliding value — enumeration oracle).
+4. **DDL injection guard** (RR-GVXUIQ): charset validator for property/type names at metamodel load + reconciler refuses out-of-charset names + literal escaping.
+
+**Degrade (all rules):** a failed ADD on pre-existing violations → object stays
+`unenforced`, logged loud (blocking COUNT; values only under operator
+`--show-values`), CONTINUE — never a startup outage.
+
+**Surfaced, not silent:** `rela db status` (operator-shell-only, no ACL — STATED
+trust boundary) reports enforced/unenforced/stale, exits 0 always; `rela db
+reconcile` re-converges; `rela db reconcile --dry-run` prints the plan and exits
+NON-ZERO on drift (the CI/pre-flight gate). One `plan()` backs store-open,
+status, and dry-run — dry-run prediction == store-open behaviour.
+
+## Scope
+
+IN: `DerivedSchemaReconciler` capability + stateless `plan()` (prefix-scan +
+set-diff on hashed names, per-rule sub-prefix, schema-filtered, advisory-locked)
++ universal outcome; the ONE `unique` rule (empty-exempt);
+`store.ErrUniqueProperty` + `ConstraintName` branch on insert AND update;
+metamodel-load charset validator; entitymanager mapping to
+`ValidationErrorUnique`; appbuild wiring (`assemble` + `!postgres` stub) +
+postgres MCP wiring; `pgstore.Status`→struct; `rela db status` (exit 0) + `rela
+db reconcile` [+ `--dry-run` exit-non-zero, `--show-values`]; degrade-not-crash;
+pgstore-gated tests.
+
+OUT (future ~1-rule tickets on the SAME seam): enum→CHECK; regex→CHECK;
+relation-cap→unique/exclusion; from/to→CHECK; required→JSONB CHECK. Also OUT:
+fs/mem atomic uniqueness (stays check-then-write; documented); IdP-webhook vs
+lazy-provision reconciliation (separate follow-up); rewriting the scan.
+
+## Acceptance criteria
+
+1. On postgres, two concurrent inserts of the same `unique:true` value → exactly one row; the loser fails atomically at COMMIT (not via the pre-scan).
+2. Failure → `store.ErrUniqueProperty` → entitymanager `ValidationErrorUnique` (422, property named, value withheld); ID-collision path STILL returns `ErrEntityAlreadyExists` (409); raw pgErr.Detail never surfaced.
+3. Provision case: the loser's `maybeProvision` catches the conflict and re-resolves to the winner's stub.
+4. Reconcile: adding `unique:true` creates the index at next store-open; removing it DROPS the owned index; idempotent; steady-state = zero DDL; per-rule sub-prefix (no cross-rule clobber); schema-filtered (no cross-schema drop); advisory-locked.
+5. Pre-existing duplicates do NOT crash startup — object stays unenforced, warning names the blocking COUNT (values only under --show-values).
+6. `rela db status` reports enforced/unenforced/stale, exits 0; `reconcile --dry-run` prints the same plan and exits NON-ZERO on drift; `plan()` shared by store-open/status/dry-run.
+7. Scan and index AGREE on empty, absent, list, and non-string values (dual-enforcement contract).
+8. fs/mem behaviour unchanged (check-then-write scan; documented caveat).
+9. Out-of-charset property/type name is refused at metamodel load (and by the reconciler).
+10. Update-path 23505 (automation-set unique prop) maps correctly; create-then-failed-automation-update outcome documented.

--- a/tickets/entities/tickets/TKT-3Q0GP1.md
+++ b/tickets/entities/tickets/TKT-3Q0GP1.md
@@ -5,7 +5,7 @@ title: 'Postgres derived-schema reconciler (seam + unique rule): atomic unique:t
 kind: enhancement
 priority: medium
 effort: l
-status: in-progress
+status: review
 ---
 
 Follow-up to TKT-ANUJDS (`unmatched_principal: provision`, shipped).

--- a/tickets/relations/TKT-3Q0GP1--affects--authorization.md
+++ b/tickets/relations/TKT-3Q0GP1--affects--authorization.md
@@ -1,0 +1,5 @@
+---
+from: TKT-3Q0GP1
+relation: affects
+to: authorization
+---

--- a/tickets/relations/TKT-3Q0GP1--affects--store-backends.md
+++ b/tickets/relations/TKT-3Q0GP1--affects--store-backends.md
@@ -1,0 +1,5 @@
+---
+from: TKT-3Q0GP1
+relation: affects
+to: store-backends
+---

--- a/tickets/relations/TKT-3Q0GP1--has-docs--DOCS-EY92SD.md
+++ b/tickets/relations/TKT-3Q0GP1--has-docs--DOCS-EY92SD.md
@@ -1,0 +1,5 @@
+---
+from: TKT-3Q0GP1
+relation: has-docs
+to: DOCS-EY92SD
+---

--- a/tickets/relations/TKT-3Q0GP1--has-implementation--IMPL-77SB4J.md
+++ b/tickets/relations/TKT-3Q0GP1--has-implementation--IMPL-77SB4J.md
@@ -1,0 +1,5 @@
+---
+from: TKT-3Q0GP1
+relation: has-implementation
+to: IMPL-77SB4J
+---

--- a/tickets/relations/TKT-3Q0GP1--has-planning--PLAN-SG4MA1.md
+++ b/tickets/relations/TKT-3Q0GP1--has-planning--PLAN-SG4MA1.md
@@ -1,0 +1,5 @@
+---
+from: TKT-3Q0GP1
+relation: has-planning
+to: PLAN-SG4MA1
+---

--- a/tickets/relations/TKT-3Q0GP1--has-review--REV-QQRJXN.md
+++ b/tickets/relations/TKT-3Q0GP1--has-review--REV-QQRJXN.md
@@ -1,0 +1,5 @@
+---
+from: TKT-3Q0GP1
+relation: has-review
+to: REV-QQRJXN
+---

--- a/tickets/relations/TKT-3Q0GP1--has-review-response--RR-0USU3N.md
+++ b/tickets/relations/TKT-3Q0GP1--has-review-response--RR-0USU3N.md
@@ -1,0 +1,5 @@
+---
+from: TKT-3Q0GP1
+relation: has-review-response
+to: RR-0USU3N
+---

--- a/tickets/relations/TKT-3Q0GP1--has-review-response--RR-2HMGZJ.md
+++ b/tickets/relations/TKT-3Q0GP1--has-review-response--RR-2HMGZJ.md
@@ -1,0 +1,5 @@
+---
+from: TKT-3Q0GP1
+relation: has-review-response
+to: RR-2HMGZJ
+---

--- a/tickets/relations/TKT-3Q0GP1--has-review-response--RR-3NB0P9.md
+++ b/tickets/relations/TKT-3Q0GP1--has-review-response--RR-3NB0P9.md
@@ -1,0 +1,5 @@
+---
+from: TKT-3Q0GP1
+relation: has-review-response
+to: RR-3NB0P9
+---

--- a/tickets/relations/TKT-3Q0GP1--has-review-response--RR-5LZWX8.md
+++ b/tickets/relations/TKT-3Q0GP1--has-review-response--RR-5LZWX8.md
@@ -1,0 +1,5 @@
+---
+from: TKT-3Q0GP1
+relation: has-review-response
+to: RR-5LZWX8
+---

--- a/tickets/relations/TKT-3Q0GP1--has-review-response--RR-78T6Q9.md
+++ b/tickets/relations/TKT-3Q0GP1--has-review-response--RR-78T6Q9.md
@@ -1,0 +1,5 @@
+---
+from: TKT-3Q0GP1
+relation: has-review-response
+to: RR-78T6Q9
+---

--- a/tickets/relations/TKT-3Q0GP1--has-review-response--RR-8OIKGN.md
+++ b/tickets/relations/TKT-3Q0GP1--has-review-response--RR-8OIKGN.md
@@ -1,0 +1,5 @@
+---
+from: TKT-3Q0GP1
+relation: has-review-response
+to: RR-8OIKGN
+---

--- a/tickets/relations/TKT-3Q0GP1--has-review-response--RR-AROZJY.md
+++ b/tickets/relations/TKT-3Q0GP1--has-review-response--RR-AROZJY.md
@@ -1,0 +1,5 @@
+---
+from: TKT-3Q0GP1
+relation: has-review-response
+to: RR-AROZJY
+---

--- a/tickets/relations/TKT-3Q0GP1--has-review-response--RR-B5Y6DZ.md
+++ b/tickets/relations/TKT-3Q0GP1--has-review-response--RR-B5Y6DZ.md
@@ -1,0 +1,5 @@
+---
+from: TKT-3Q0GP1
+relation: has-review-response
+to: RR-B5Y6DZ
+---

--- a/tickets/relations/TKT-3Q0GP1--has-review-response--RR-CWI8HG.md
+++ b/tickets/relations/TKT-3Q0GP1--has-review-response--RR-CWI8HG.md
@@ -1,0 +1,5 @@
+---
+from: TKT-3Q0GP1
+relation: has-review-response
+to: RR-CWI8HG
+---

--- a/tickets/relations/TKT-3Q0GP1--has-review-response--RR-DLML7F.md
+++ b/tickets/relations/TKT-3Q0GP1--has-review-response--RR-DLML7F.md
@@ -1,0 +1,5 @@
+---
+from: TKT-3Q0GP1
+relation: has-review-response
+to: RR-DLML7F
+---

--- a/tickets/relations/TKT-3Q0GP1--has-review-response--RR-FTQE3U.md
+++ b/tickets/relations/TKT-3Q0GP1--has-review-response--RR-FTQE3U.md
@@ -1,0 +1,5 @@
+---
+from: TKT-3Q0GP1
+relation: has-review-response
+to: RR-FTQE3U
+---

--- a/tickets/relations/TKT-3Q0GP1--has-review-response--RR-GVXUIQ.md
+++ b/tickets/relations/TKT-3Q0GP1--has-review-response--RR-GVXUIQ.md
@@ -1,0 +1,5 @@
+---
+from: TKT-3Q0GP1
+relation: has-review-response
+to: RR-GVXUIQ
+---

--- a/tickets/relations/TKT-3Q0GP1--has-review-response--RR-QY5S4C.md
+++ b/tickets/relations/TKT-3Q0GP1--has-review-response--RR-QY5S4C.md
@@ -1,0 +1,5 @@
+---
+from: TKT-3Q0GP1
+relation: has-review-response
+to: RR-QY5S4C
+---

--- a/tickets/relations/TKT-3Q0GP1--has-review-response--RR-V08S5M.md
+++ b/tickets/relations/TKT-3Q0GP1--has-review-response--RR-V08S5M.md
@@ -1,0 +1,5 @@
+---
+from: TKT-3Q0GP1
+relation: has-review-response
+to: RR-V08S5M
+---

--- a/tickets/relations/TKT-3Q0GP1--has-review-response--RR-WF0ZYF.md
+++ b/tickets/relations/TKT-3Q0GP1--has-review-response--RR-WF0ZYF.md
@@ -1,0 +1,5 @@
+---
+from: TKT-3Q0GP1
+relation: has-review-response
+to: RR-WF0ZYF
+---

--- a/tickets/relations/TKT-3Q0GP1--implements--FEAT-OQBYHD.md
+++ b/tickets/relations/TKT-3Q0GP1--implements--FEAT-OQBYHD.md
@@ -1,0 +1,5 @@
+---
+from: TKT-3Q0GP1
+relation: implements
+to: FEAT-OQBYHD
+---


### PR DESCRIPTION
## What

Adds a **derived-schema reconciler** for the PostgreSQL backend: it turns the metamodel's `unique: true` properties into automatically-maintained partial unique indexes, so uniqueness is enforced **atomically** even under concurrent (cross-process) writers. Ships with `rela db reconcile [--dry-run] [--show-values]` and derived-drift reporting in `rela db status`.

Follow-up to TKT-ANUJDS: `unmatched_principal: provision` creates a stub user keyed on `principal_property` (a `unique:true` property), and two servers provisioning the same subject at once could both pass the racy check-then-write scan and create duplicate stubs → permanently ambiguous principal resolution. The DB index closes that race.

## How

- **`store.DerivedSchemaReconciler`** — a new optional store capability (type-asserted like `HistoryReader`), implemented by pgstore, no-op on fs/mem. Wired at store-open in `appbuild.assemble`, mirroring `startVersionSweepIfSupported`.
- **Stateless desired-vs-actual convergence** — the metamodel is desired, `pg_indexes` is actual, a `rela_derived_uniq__<hash>` name prefix marks ownership. Create-missing / drop-orphans / no-op the intersection (steady-state = zero DDL). No persisted state to drift.
- **Atomic-but-friendly** — the check-then-write scan stays the primary path (nice 422, only mechanism on fs/mem); the index is the race backstop. A 23505 is discriminated by `pgErr.ConstraintName` into `store.UniquePropertyError` (property-level 422) vs the existing ID-collision `ErrConflict`.
- **Degrade, never crash** — a `CREATE UNIQUE INDEX` blocked by pre-existing duplicates is reported `unenforced` (with a blocking count) and logged, never fatal. `rela db reconcile --dry-run` is the pre-flight (exits non-zero on drift); one shared planner backs store-open / status / dry-run.
- **Guards** — DDL-injection (charset validator at metamodel load + literal escaping), enumeration-oracle (blocking values opt-in via `--show-values` only, `pgErr.Detail` never surfaced), advisory lock (non-blocking `pg_try_advisory_lock`), schema-scoped introspection (no cross-schema drop). `unique:true` is now restricted to string-valued property types so the scan and index can't diverge.

## Testing

- pgstore-gated integration tests (concurrent-insert single-row, empty/absent exempt, idempotent + drop-on-removal, pre-existing-dupes degrade, dry-run, cross-schema isolation, unsafe-name refusal, exact blocking count) + pure unit tests (hash determinism, constraint-name mapping, charset).
- Verified end-to-end against a live Postgres, including the degrade path and `--dry-run` exit-1-on-drift gate.
- Design-reviewed and code-reviewed; all findings addressed.

Ticket: TKT-3Q0GP1