### PR TITLE
docs(tickets): mark FEAT-79DTF9 in-progress

### DIFF
--- a/tickets/entities/features/FEAT-79DTF9.md
+++ b/tickets/entities/features/FEAT-79DTF9.md
@@ -5,7 +5,7 @@ title: Declarative next-action layer
 summary: Operator-configured rules that derive one suggested follow-up from graph state and surface it as an advisory hint in the UI.
 description: Operator-configured sources derive a suggested follow-up from graph state and surface one at a time in the UI — advisory ("could do"), never a task queue. Sources yield entity-shaped candidates; operator-defined ordered bands rank them, with stable-random selection within a band. Snooze/mute/cooldown live in a per-user state service (mem/disk/postgres), never in the graph, and resolved suggestions are never cached because a cross-principal cache would defeat the ACL gate. Phase 0 ships without store changes; Phase 1 extends store.GraphQuery with property predicates.
 priority: medium
-status: proposed
+status: implemented
 ---
 
 ## What

--- a/tickets/entities/features/FEAT-79DTF9.md
+++ b/tickets/entities/features/FEAT-79DTF9.md
@@ -5,7 +5,7 @@ title: Declarative next-action layer
 summary: Operator-configured rules that derive one suggested follow-up from graph state and surface it as an advisory hint in the UI.
 description: Operator-configured sources derive a suggested follow-up from graph state and surface one at a time in the UI — advisory ("could do"), never a task queue. Sources yield entity-shaped candidates; operator-defined ordered bands rank them, with stable-random selection within a band. Snooze/mute/cooldown live in a per-user state service (mem/disk/postgres), never in the graph, and resolved suggestions are never cached because a cross-principal cache would defeat the ACL gate. Phase 0 ships without store changes; Phase 1 extends store.GraphQuery with property predicates.
 priority: medium
-status: implemented
+status: in-progress
 ---
 
 ## What


### PR DESCRIPTION
The declarative next-action layer shipped in #1365 (Phase 0 + the dataentry
pushdown) and #1312 (TKT-F4TIS6, GraphQuery property predicates), but the
feature entity still read `proposed`.

It is **not** fully shipped, so this marks it `in-progress` rather than
`implemented`.

## What works

Six of the eight grounding scenarios in RES-09YLLL:

- **S6** first run, **S8** quip (ambient/stable-random)
- **S2** `pick_one`, **S3** no-billing-contact, **S5** completed-without-invoice
  — property predicates and relation negation (`RelationPredicate.Negate`)

Plus the whole engine: bands, suggestion key, cooldown/snooze/mute over a
user-state service (mem / kv / postgres + conformance suite), the one-slot UX,
and the declarative `next_action_bands` / `next_actions` config.

## What does not

**S1** ("proposal out 11 days, no reply — chase it?") and **S4** ("SOW has been
in draft a while") need date arithmetic, which is deliberately absent:
`store.PropOp` is equality-only because ordered comparison needs the property's
declared type from the metamodel, and the store layer does not consult it.

Those are the dwell-time sources — the `stalled` and `blocking` bands exist and
are documented, but an operator cannot currently express *what makes something
stalled*. That is the gap between this and `implemented`.

**S7** (far-side recency) stays out of scope, as recorded in the research.

`rela validate --project tickets` is green (exit 0).