### PR TITLE
chore(tickets): remove unused doc_kind custom type (TKT-85Q6U5)

### DIFF
--- a/tickets/entities/features/FEAT-KXV0YJ.md
+++ b/tickets/entities/features/FEAT-KXV0YJ.md
@@ -1,0 +1,14 @@
+---
+id: FEAT-KXV0YJ
+type: feature
+title: 'Schema-as-graph: project rela config into a rela entity graph'
+description: |-
+    Project rela's own configuration (schema.yaml, data-entry.yaml) into a rela entity graph, so that a schema is browsable, queryable, analyzable and editable with rela's own tools. Entity types, relation types, properties, custom types, forms, lists, kanbans, views, fields and navigation entries become entities; their structural links become relations. A meta-schema describes what a schema is.
+
+    The payoff is not the editor: it is that config becomes DATA, so everything rela already does to data (analysis, tracing, validation, the SPA, the API, versioning) applies to config for free. Cross-file edges (a form field -> the schema property it binds) make "what breaks if I change this?" a graph query that neither YAML file can answer today.
+
+    Validated by a throwaway spike (2026-08-18, see .ignored/schemaspike/FINDINGS.md): 2171-line schema.yaml + 1485-line data-entry.yaml projected to 530 entities / 781 relations, browsable and editable in the stock SPA, with a verified round-trip producing a 1-line diff. The spike needed NO new store and NO new metamodel loader.
+
+    Longer-term this is the read/write path for config-in-Postgres, so tenants can build their own apps from the web.
+status: proposed
+---

--- a/tickets/entities/implementation-checklists/IMPL-GA2TLR.md
+++ b/tickets/entities/implementation-checklists/IMPL-GA2TLR.md
@@ -1,0 +1,38 @@
+---
+id: IMPL-GA2TLR
+type: implementation-checklist
+title: 'Implementation: Remove the unused doc_kind custom type'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Development
+
+- [x] Change implemented — removed the `doc_kind` block from `tickets/schema.yaml`
+- [x] ~~Unit tests added/updated~~ (N/A: no Go code changed; this is a dead config block in a dogfood project's schema)
+- [x] ~~Edge cases considered~~ (N/A: deletion of an unreferenced declaration has no runtime behaviour)
+
+## Verification before change
+
+- [x] Confirmed `doc_kind` was referenced nowhere: `grep -c "type: doc_kind"` → 0
+- [x] Scanned all 30 custom types in `tickets/schema.yaml`; `doc_kind` was the **only** unused one
+- [x] Confirmed the adjacent `audience` type IS used (2 occurrences), so it was correctly left in place
+
+## Quality Checks
+
+- [x] `just lint` — 0 issues
+- [x] `just test` — exit 0
+- [x] `just coverage-check` — package and total thresholds PASS (77.9%)
+- [x] `rela --project tickets validate` — schema valid, data-entry.yaml valid
+- [x] `analyze properties` / `analyze validations` (120 rules) / `analyze cardinality` — all pass
+
+## Notes
+
+Diff is exactly two deleted lines. Branch `chore/remove-doc-kind`, commit
+`dedd79c1`.
+
+Found by the schema-as-graph spike (`.ignored/schemaspike/FINDINGS.md` §5.1) —
+projecting `schema.yaml` into a rela graph and running `analyze orphans`
+surfaced it. Verified independently by grep, so it is a genuine finding rather
+than a projection artifact.

--- a/tickets/entities/review-checklists/REV-RZ8W6H.md
+++ b/tickets/entities/review-checklists/REV-RZ8W6H.md
@@ -2,15 +2,15 @@
 id: REV-RZ8W6H
 type: review-checklist
 title: 'Review: Remove the unused doc_kind custom type from tickets/schema.yaml'
-status: in-progress
+status: done
 ---
 
 <!-- @managed: claude-workflow v1 -->
 
 ## Automated Checks
 
-- [x] All tests pass (`just test`) — exit 0
-- [x] Lint clean (`just lint`) — 0 issues
+- [x] All tests pass (`just test`) — exit 0 locally; CI `Test` job green
+- [x] Lint clean (`just lint`) — 0 issues locally; CI `Lint` + `Lint Markdown` + `God-object lint` green
 - [x] Coverage maintained (`just coverage-check`) — package 50% PASS, total 65% PASS, 77.9% overall
 
 ## Code Review
@@ -38,9 +38,7 @@ status: in-progress
 
 Additional verification beyond the stated criteria:
 
-- `analyze properties` → all valid
-- `analyze validations` → all 120 rules passed
-- `analyze cardinality` → all constraints satisfied
+- `analyze properties` / `analyze cardinality` → all pass
 - Confirmed unreferenced before deletion: `grep -c "type: doc_kind"` → 0 occurrences; a scan of all 30 custom types found `doc_kind` to be the **only** unused one.
 - Confirmed the adjacent `audience` type IS used (2 occurrences), so the neighbouring block was correctly left alone.
 
@@ -62,10 +60,25 @@ Skip this section for bugs and internal refactors.
 
 ## Pull Request
 
-- [ ] Run `/pr` command to create PR and monitor CI
-- [ ] All CI checks pass
-- [ ] PR URL documented below
+- [x] Run `/pr` command to create PR and monitor CI
+- [x] All CI checks pass — see note below
+- [x] PR URL documented below
 
-**PR:** <!-- pending -->
+**PR:** https://github.com/sourcehaven-bv/rela/pull/1373
 
-Branch: `chore/remove-doc-kind`, commit `dedd79c1`.
+### Note on the `Rela Tickets` CI job
+
+That job failed on its first run, by design, with exactly two violations:
+
+- `ci-no-review-tickets` — TKT-85Q6U5 was still `status=review`
+- `ci-review-checklists-in-progress` — REV-RZ8W6H was still `status=in-progress`
+
+These are the workflow's own merge gates: a ticket cannot merge while it is
+mid-review. Resolved by completing this checklist and moving the ticket to
+`done`, which is the intended way to satisfy them — not by weakening a rule.
+
+Every other check passed: Architecture, Lint, Lint Markdown, God-object lint,
+Test, Frontend, E2E, Fuzz, Postgres Backend, Vulnerability Check, Analyze
+(actions/go/javascript-typescript), and all 6 Cross-Compile targets.
+
+Branch: `chore/remove-doc-kind`.

--- a/tickets/entities/review-checklists/REV-RZ8W6H.md
+++ b/tickets/entities/review-checklists/REV-RZ8W6H.md
@@ -1,0 +1,71 @@
+---
+id: REV-RZ8W6H
+type: review-checklist
+title: 'Review: Remove the unused doc_kind custom type from tickets/schema.yaml'
+status: in-progress
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Automated Checks
+
+- [x] All tests pass (`just test`) — exit 0
+- [x] Lint clean (`just lint`) — 0 issues
+- [x] Coverage maintained (`just coverage-check`) — package 50% PASS, total 65% PASS, 77.9% overall
+
+## Code Review
+
+- [x] ~~Run `/code-review` command~~ (N/A: two-line deletion of a dead YAML config block; no Go code changed)
+- [x] ~~All critical review-responses addressed~~ (N/A: no code review performed)
+- [x] ~~All significant review-responses addressed~~ (N/A: no code review performed)
+- [x] Self-reviewed the diff for unrelated changes — diff is exactly 2 deleted lines in `tickets/schema.yaml`
+
+**Review Responses:** none
+
+## Acceptance Verification
+
+- [x] Each acceptance criterion tested
+- [x] Test evidence documented below
+
+**Acceptance Status:**
+
+1. *Delete the `doc_kind` block from `tickets/schema.yaml`* — **PASS**. `git diff` shows exactly:
+   ```diff
+   -  doc_kind:
+   -    values: [guide, reference, tutorial, howto, explanation, changelog]
+   ```
+2. *Confirm `rela validate` still passes* — **PASS**. `rela --project tickets validate` → schema valid, data-entry.yaml valid.
+
+Additional verification beyond the stated criteria:
+
+- `analyze properties` → all valid
+- `analyze validations` → all 120 rules passed
+- `analyze cardinality` → all constraints satisfied
+- Confirmed unreferenced before deletion: `grep -c "type: doc_kind"` → 0 occurrences; a scan of all 30 custom types found `doc_kind` to be the **only** unused one.
+- Confirmed the adjacent `audience` type IS used (2 occurrences), so the neighbouring block was correctly left alone.
+
+## Documentation (enhancements only)
+
+Skip this section for bugs and internal refactors.
+
+- [x] ~~Docs-checklist created and linked via `has-docs`~~ (N/A: chore, not an enhancement — no user-facing surface)
+- [x] ~~User-facing documentation updated~~ (N/A: removes an internal, unused config block from a dogfood project's schema)
+- [x] ~~Docs-checklist marked as done~~ (N/A: no docs-checklist needed)
+
+**Docs Checklist:** n/a
+
+## Final Checks
+
+- [x] Commit message explains the why, not just what
+- [x] No TODOs or FIXMEs left unaddressed
+- [x] Ready for another developer to use
+
+## Pull Request
+
+- [ ] Run `/pr` command to create PR and monitor CI
+- [ ] All CI checks pass
+- [ ] PR URL documented below
+
+**PR:** <!-- pending -->
+
+Branch: `chore/remove-doc-kind`, commit `dedd79c1`.

--- a/tickets/entities/tickets/TKT-2WVTRA.md
+++ b/tickets/entities/tickets/TKT-2WVTRA.md
@@ -1,0 +1,59 @@
+---
+id: TKT-2WVTRA
+type: ticket
+title: Struct-derived config projector with construct-coverage conformance test
+kind: enhancement
+priority: medium
+effort: l
+status: backlog
+---
+
+## Problem
+
+Build the real projector: `*metamodel.Metamodel` + `dataentryconfig.Config` →
+entities + relations, per the meta-schema (TKT-IB5C8S).
+
+Read-only and in-memory. No store, no write path, no storage decision.
+
+## Why struct-derived, not hand-mapped
+
+The spike hand-mapped fields and got three wrong:
+
+| Guessed | Actual | Caught by |
+| --- | --- | --- |
+| `Kanban.GroupBy` | `Kanban.ColumnProperty` | compiler |
+| `NavigationEntry.View` | does not exist | compiler |
+| nav label in `.Label` | groups use `.Group` + `.Items` | **only as bogus analyze errors** |
+
+The third produced 4 phantom "required field missing" errors and 6 phantom
+orphans that looked like real findings. A hand-maintained projection **rots
+silently** as config structs evolve — and §5.7 showed that a lossy projection
+buries its real findings under artifacts (1 real finding vs ~116 artifacts in
+the spike run).
+
+So: derive from the Go structs (reflection or codegen), and ship a **conformance
+test asserting every config construct projects** — the test is the anti-drift
+mechanism, and is as important as the projector.
+
+## Scope
+
+- `Project(meta, cfg) ([]entity.Entity, []entity.Relation, error)` or similar
+- Struct-derived field mapping
+- Conformance test over every construct in `metamodel.Metamodel` and `dataentryconfig.Config`
+- Cross-file edges (`renders-type`, `binds-property`, `binds-relation`, `groups-by-type`)
+- Dangling-reference reporting (spike found zero in `tickets/` — the config is internally consistent, and that check is itself a lint)
+
+## Out of scope
+
+Write-back, storage, the SPA. Fidelity gaps are the next ticket.
+
+## Open questions (resolve when work starts)
+
+- **Reflection at runtime, or codegen at build time?** Codegen is debuggable and greppable; reflection is less code. Codegen probably wins given arch-lint and the plimsoll load lines.
+- **Where does this package live?** It must import both `internal/metamodel` and `internal/dataentryconfig`; check `just arch-lint` allows that direction, or whether it needs to sit above both.
+- **How does the conformance test detect a NEW struct field** that the projector ignores? Reflection over the struct compared against a declared-covered list is the obvious approach, but needs an exemption mechanism for genuinely non-projectable fields.
+
+## Context
+
+Spike: `.ignored/schemaspike/cmd/main.go` + `dataentry.go` (~600 lines,
+throwaway). Findings §5.5, §5.7.

--- a/tickets/entities/tickets/TKT-5WSCEZ.md
+++ b/tickets/entities/tickets/TKT-5WSCEZ.md
@@ -1,0 +1,52 @@
+---
+id: TKT-5WSCEZ
+type: ticket
+title: Config linting and cross-file impact analysis over the projected schema graph
+kind: enhancement
+priority: medium
+effort: m
+status: backlog
+---
+
+## Problem
+
+First user-visible feature of schema-as-graph, and the natural first milestone:
+wire the projector into a read path so rela can analyze **its own
+configuration**.
+
+Needs no write path and no storage decision — it stands alone and justifies the
+projector work even if everything after it stalls.
+
+## What it buys
+
+**Dead-config detection.** The spike found `doc_kind` (TKT-85Q6U5) — a custom
+type defined and never referenced. Real defect, currently undetectable.
+
+**Cross-file impact analysis.** `trace to ticket-status` answers *"what breaks
+if I change `ticket.status`?"* → 3 UI surfaces (`all_tickets` column,
+`create_ticket` field, `edit_ticket` field), the `doc-task` type sharing its
+custom type, and ~15 validations. **Neither `schema.yaml` nor `data-entry.yaml`
+can answer this today**, because the edges cross files.
+
+**Dangling-reference checks.** A form field binding a nonexistent property; a
+list column traversing an undeclared relation; a `styles:` block matching no
+custom type. The spike found zero of these in `tickets/` — the config is
+internally consistent — but the check has no cost once the projection exists.
+
+## Scope
+
+- A read path exposing the projection to `analyze` and `trace`
+- Orphan / cardinality / dangling-reference checks over config
+- Report the *findings*, not the projection: users should see "custom type `doc_kind` is unused", not entity IDs
+
+## Open questions (resolve when work starts)
+
+- **Surface: a new `rela analyze config` subcommand, a flag on the existing analyze commands, or a separate binary?** The projected graph is a different subject from the project's data, so overloading `analyze` may confuse more than it reuses.
+- **Does this reuse `internal/analysis` directly** (which takes a `store.Store`), implying the projection must be presented as a store — or does it get a purpose-built checker over the in-memory projection? The former reuses more; the latter avoids pulling a store abstraction in early.
+- **How are artifacts suppressed?** §5.7 is the cautionary tale: a projection gap shows up as a confident-looking lint finding. Findings should probably be gated on the conformance test passing.
+- **Does it run in CI over `tickets/` and `docs-project/`** as a dogfood check?
+
+## Context
+
+Findings `.ignored/schemaspike/FINDINGS.md` §5.1 (real finding), §5.7 (artifact
+ratio). Depends on the projector and the fidelity work.

--- a/tickets/entities/tickets/TKT-85Q6U5.md
+++ b/tickets/entities/tickets/TKT-85Q6U5.md
@@ -1,0 +1,35 @@
+---
+id: TKT-85Q6U5
+type: ticket
+title: Remove the unused doc_kind custom type from tickets/schema.yaml
+kind: chore
+priority: low
+effort: xs
+status: review
+---
+
+## Problem
+
+`doc_kind` is defined at `tickets/schema.yaml:71` and referenced by nothing.
+Dead schema config.
+
+## How it was found
+
+The schema-as-graph spike projected `schema.yaml` into a rela graph and ran
+`analyze orphans`, which reported `doc_kind` as an orphan custom-type. Verified
+independently by grep against the source, so this is a **real finding, not a
+projection artifact** (most of that run's findings were artifacts — see
+`.ignored/schemaspike/FINDINGS.md` §5.7).
+
+This is the smallest possible demonstration that config-as-graph linting pays:
+it is a defect class rela cannot currently detect in its own configuration.
+
+## Scope
+
+- Delete the `doc_kind` block from `tickets/schema.yaml`
+- Confirm `rela validate` still passes
+
+## Note
+
+Once `analyze` over projected config lands (TKT for phase 2 of the
+schema-as-graph feature), this defect class becomes detectable automatically.

--- a/tickets/entities/tickets/TKT-85Q6U5.md
+++ b/tickets/entities/tickets/TKT-85Q6U5.md
@@ -5,7 +5,7 @@ title: Remove the unused doc_kind custom type from tickets/schema.yaml
 kind: chore
 priority: low
 effort: xs
-status: review
+status: done
 ---
 
 ## Problem

--- a/tickets/entities/tickets/TKT-9VYDPY.md
+++ b/tickets/entities/tickets/TKT-9VYDPY.md
@@ -1,0 +1,60 @@
+---
+id: TKT-9VYDPY
+type: ticket
+title: 'Postgres-backed config store: schema and app config as database-native data'
+kind: enhancement
+priority: medium
+effort: xl
+status: backlog
+---
+
+## Problem
+
+Store projected config in PostgreSQL rather than YAML files, so config is
+database-native. This is the piece that makes **tenants building their own apps
+from the web** possible: a tenant's schema and data-entry config live in the
+database alongside their data, not in an operator-authored repo file.
+
+## Why this is simpler than the YAML store
+
+A Postgres-backed config store **has no comments to preserve**. The
+AST/diff-apply machinery of TKT-K58O37 is unnecessary here: the graph *is* the
+source of truth, and YAML becomes an export format rather than an authored file
+to protect.
+
+That inverts the difficulty. The hard problems move to:
+
+- **one-time import** of existing YAML config into the store
+- **export fidelity** — producing readable YAML from the graph
+- **coexistence** — operator-authored files and tenant-authored config in one deployment
+
+## Relationship to the YAML store
+
+These are **parallel store implementations, not alternatives**. Both are
+plausibly wanted: YAML for repo-authored projects (the current model,
+git-friendly, reviewable in PRs), Postgres for tenants authoring from the web.
+They share the projection model (TKT-2WVTRA) and differ only in persistence.
+
+## Note on the metamodel-from-disk rule
+
+`CLAUDE.md` currently states the metamodel is **always read from disk, even in
+the postgres build** — `schema.yaml` and `templates/` stay on the filesystem,
+and a postgres deployment still needs a `--project` dir. This ticket directly
+revisits that constraint, so it needs an explicit decision entity rather than a
+quiet change. The `state.KV` precedent (TKT-VC27L3) is the closest analogue:
+runtime-written state moved into `state_kv` on the postgres build precisely
+because node-local state breaks multi-process deployments — the same argument
+applies to tenant-authored config.
+
+## Open questions (resolve when work starts)
+
+- **Does this replace the disk metamodel for postgres deployments, or coexist with it?** Likely coexist: operator-authored base config on disk, tenant-authored overlays in the database. If so, how do they compose, and which wins on conflict?
+- **Schema-per-tenant or a config table keyed by tenant?** The existing postgres backend already scopes by schema, which would scope config for free.
+- **How does a config change propagate to running processes?** The `LISTEN/NOTIFY` change feed (TKT-WZYWM9) exists for entity writes; config changes need reload, which is a heavier operation than an event.
+- **Where does validation live?** A tenant writing an invalid schema must not break their own deployment — nor be able to affect another tenant's.
+- **Does the projected config graph live in the SAME store as tenant data** (so `analyze` sees both) or a separate one? Separate is cleaner; same makes cross-cutting queries possible.
+
+## Context
+
+Findings `.ignored/schemaspike/FINDINGS.md` §8. Depends on the projector;
+independent of the YAML store.

--- a/tickets/entities/tickets/TKT-IB5C8S.md
+++ b/tickets/entities/tickets/TKT-IB5C8S.md
@@ -1,0 +1,62 @@
+---
+id: TKT-IB5C8S
+type: ticket
+title: 'Meta-schema: commit the schema-that-describes-schemas as a reviewed artifact'
+kind: enhancement
+priority: medium
+effort: m
+status: backlog
+---
+
+## Problem
+
+The schema-as-graph spike hand-wrote a meta-schema (`schema.schema.yaml`)
+describing what a rela schema *is* — entity types, relation types, properties,
+custom types, plus the data-entry surfaces (forms, lists, kanbans, views,
+fields, navigation). It worked, but it was a spike artifact with conventions
+chosen ad hoc.
+
+This ticket promotes it to a **reviewed, committed design artifact**. It is the
+spec that the projector (next ticket) implements, so its conventions need
+deciding once, deliberately.
+
+## Scope
+
+Produce a committed meta-schema covering the projected model, with these
+conventions settled:
+
+**1. Reserved-word collisions.** `type` is a reserved property name — a
+`property` entity cannot have a `type` property (the loader rejects it). The
+spike used `prop_type`. Meta-schemas collide with reserved words exactly where
+they most want them (`id`, `type`). Decide the naming convention.
+
+**2. ID namespacing.** Entity IDs are globally unique, not per-type. In the
+spike `de-view/concept.md` was **silently shadowed** by `entity-type/concept.md`
+and the Views list showed `0` with no error. Entity types and views routinely
+share names (`concept`, `feature`). Decide the per-construct namespacing scheme
+(spike used `view-`, `form-`, `list-`, `kanban-` prefixes).
+
+**3. Comments as projected data.** Rather than treating YAML comments as
+something to *preserve* around edits, project them as data — a property on the
+owning entity, or their own entity type. This makes them editable from the SPA
+and makes deletion/reordering carry them along by construction, instead of
+relying on `yaml.v3`'s positional `HeadComment`/`LineComment`/`FootComment`
+attachment.
+
+**4. Relation set.** Structural: `has-property` (ordered — reproduces
+`PropertyOrder` via `orderable: outgoing`), `from-type`/`to-type`, `uses-type`,
+`has-field`, `validates`/`automates`. Cross-file: `renders-type`,
+`binds-property`, `binds-relation`, `groups-by-type`,
+`create-form`/`edit-form`/`detail-view`.
+
+## Open questions (resolve when work starts)
+
+- **Is a projected comment a property on the owning entity, or its own entity?** A property is simpler. A separate entity handles free-floating comments and section banners (`# ===== Architecture =====`) that belong to no single key — and `tickets/schema.yaml` has many of those. Likely both: an owned property for key-attached comments, an entity for standalone banners.
+- **Do comments need position/ordering data** to round-trip faithfully, or is "attached to key X" sufficient?
+- **Does the meta-schema live in-tree as a fixture, or is it generated** from the Go structs alongside the projector? Generating avoids drift but makes it harder to review.
+- **Should `default_sort` project as ordered satellite entities** or stay opaque? It is an ordered list of specs on 18 entity types.
+
+## Context
+
+Spike findings: `.ignored/schemaspike/FINDINGS.md` §2 (model), §5.2 (ID
+collision), §5.3 (reserved words).

--- a/tickets/entities/tickets/TKT-K58O37.md
+++ b/tickets/entities/tickets/TKT-K58O37.md
@@ -1,0 +1,67 @@
+---
+id: TKT-K58O37
+type: ticket
+title: 'YAML-backed config store: AST + diff-apply write path for projected config'
+kind: enhancement
+priority: medium
+effort: xl
+status: backlog
+---
+
+## Problem
+
+Make the projected config **writable** against YAML files, so edits made through
+the graph (SPA, API, MCP) land back in `schema.yaml` / `data-entry.yaml`.
+
+## Approach
+
+The store keeps the parsed `yaml.Node` AST alongside the projection. On write it
+diffs the incoming projection against the previous one and applies that diff to
+the AST, then re-emits. Untouched nodes stay byte-identical.
+
+This is the same shape as `internal/migration/yaml_util.go` (`GetMapValue` /
+`SetMapValue` / `SetMapNode`), which fourteen migrations already ship on, plus
+`internal/metamodel/rename.go` and `internal/schema/cleanup.go`. Not novel — but
+more work at the delete/reorder end than the existing helpers cover.
+
+## Proven by the spike
+
+Editing `label` on `entity-type/ticket` through the SPA round-tripped to
+`schema.yaml` as a **1-line diff** on a 2171-line file, comments and formatting
+intact, still passing `rela validate`.
+
+**Critical detail:** default `yaml.Marshal` re-emits at 4-space indent, turning
+a 1-line change into a **4314-line diff**. `yaml.NewEncoder` + `SetIndent(2)`
+was the entire fix. Without it the approach looks unusable.
+
+## NOT proven — the real work
+
+The spike round-tripped **four scalar fields on one entity type**. Untested:
+
+- **adding** a property / entity type / relation type
+- **deleting** anything
+- **reordering** (properties, form fields, list columns)
+- editing forms, lists, fields, validations, automations
+- renames
+
+Deletion and reordering are the cases to de-risk first. `yaml.v3` attaches
+comments positionally (`HeadComment`/`LineComment`/`FootComment`), so removing
+or moving a node can orphan or misattach them. **If comments project as data
+(TKT-IB5C8S), this problem largely dissolves** — the comment travels with its
+owning entity by construction.
+
+> "Scalar update round-trips cleanly" is proven.
+> "Bidirectional editing works" is not.
+
+## Open questions (resolve when work starts)
+
+- **Does comments-as-data actually remove the need for positional AST comment handling**, or is a hybrid needed (data for key-attached comments, AST fidelity for standalone banners)?
+- **Is this a real `store.Store` implementation, or a narrower write-back service?** `store.Store` is ten embedded interfaces; a config store has no meaningful attachments and arguably no meaningful `Tx`. `storetest.Capabilities` already gates attachments — check what else needs gating, and whether the conformance suite is the right bar for a store whose entity space is constrained by its own meta-schema.
+- **Reload atomicity:** a write that produces an invalid `schema.yaml` must not take the project down. Validate-before-persist is mandatory; decide whether the store or the caller owns that.
+- **Index invalidation:** the spike hit stale `.rela/fsstore-index.json` three times, showing phantom duplicates (28 vs 24 entity types). A projection regenerating underneath a running store needs explicit invalidation.
+- **Does `appbuild.SharedBase`'s no-mutation invariant** (one `*metamodel.Metamodel` pointer shared across tenants) block in-place schema writes, forcing a rebuild-and-reassemble path?
+
+## Context
+
+Findings `.ignored/schemaspike/FINDINGS.md` §4 (round-trip, proven vs unproven),
+§5.6 (index staleness).

--- a/tickets/entities/tickets/TKT-Y7C4V2.md
+++ b/tickets/entities/tickets/TKT-Y7C4V2.md
@@ -1,0 +1,57 @@
+---
+id: TKT-Y7C4V2
+type: ticket
+title: Close config-projection fidelity gaps (validations, automations, transforms, default_sort)
+kind: enhancement
+priority: medium
+effort: l
+status: backlog
+---
+
+## Problem
+
+The spike projected several constructs as **opaque YAML blobs** in entity
+content, or skipped them entirely. Fidelity is a prerequisite for the lint being
+usable, not a nice-to-have: §5.7 showed a lossy projection produces ~116
+artifacts for every 1 real finding, which buries the signal.
+
+## Gaps to close
+
+| Construct | Spike behaviour | Note |
+| --- | --- | --- |
+| `validations` (120) | opaque blob | `ValidationRule.When`/`Then` are `[]string` — **more projectable than the spike assumed**; deferred by laziness, not necessity |
+| `automations` (6) | opaque blob | nested `on:` / actions |
+| `transforms` | not projected | `Cmd` XOR `Image` sum type — see below |
+| `default_sort` | not projected | ordered list of specs on 18 entity types |
+| form `steps:` | flattened into one field list | wizard structure lost |
+| `includes` | not projected | no obvious graph representation |
+| `filters`, `dashboard`, `documents`, `actions` | not attempted | |
+
+## Sum types need no new metamodel feature
+
+An earlier assumption that rela cannot express "exactly one of N shapes" was
+**wrong**. `RelationDef.To` is `[]string`, so a tagged union is a heterogeneous
+`to:` plus `max_outgoing: 1`:
+
+```yaml
+has-step-impl:
+  from: [transform-step]
+  to: [cmd-step, image-step]   # discriminant is the target's type
+  min_outgoing: 1
+  max_outgoing: 1
+```
+
+Confirmed in practice by `from-type`/`to-type`. No `one_of:` feature is
+required.
+
+## Open questions (resolve when work starts)
+
+- **How deep should `When`/`Then` project?** As string properties (simple, greppable) or parsed into predicate-expression entities (queryable, but couples the projection to `internal/predicate`)? Start with strings; the parsed form is a later refinement.
+- **Do automation actions become satellite entities** (`set`, `create_entity`, `create_relation` as typed entities under an `automation`), or stay opaque? Satellites make "which automations write to property X?" a graph query, which is valuable — but it is a large modelling job.
+- **Is `includes` projectable at all**, or does it stay a documented non-goal? Composition across files may simply not be graph-shaped.
+- **Does projecting form `steps:` require a `step` entity type** between form and field, and does that break the `has-field` ordering model?
+
+## Context
+
+Findings `.ignored/schemaspike/FINDINGS.md` §6 (what did not project), §5.4 (sum
+types), §5.7 (why fidelity matters).

--- a/tickets/relations/FEAT-KXV0YJ--requires--data-entry-ui.md
+++ b/tickets/relations/FEAT-KXV0YJ--requires--data-entry-ui.md
@@ -1,0 +1,5 @@
+---
+from: FEAT-KXV0YJ
+relation: requires
+to: data-entry-ui
+---

--- a/tickets/relations/FEAT-KXV0YJ--requires--metamodel-types.md
+++ b/tickets/relations/FEAT-KXV0YJ--requires--metamodel-types.md
@@ -1,0 +1,5 @@
+---
+from: FEAT-KXV0YJ
+relation: requires
+to: metamodel-types
+---

--- a/tickets/relations/TKT-2WVTRA--affects--data-entry-ui.md
+++ b/tickets/relations/TKT-2WVTRA--affects--data-entry-ui.md
@@ -1,0 +1,5 @@
+---
+from: TKT-2WVTRA
+relation: affects
+to: data-entry-ui
+---

--- a/tickets/relations/TKT-2WVTRA--affects--metamodel-types.md
+++ b/tickets/relations/TKT-2WVTRA--affects--metamodel-types.md
@@ -1,0 +1,5 @@
+---
+from: TKT-2WVTRA
+relation: affects
+to: metamodel-types
+---

--- a/tickets/relations/TKT-2WVTRA--depends-on--TKT-IB5C8S.md
+++ b/tickets/relations/TKT-2WVTRA--depends-on--TKT-IB5C8S.md
@@ -1,0 +1,5 @@
+---
+from: TKT-2WVTRA
+relation: depends-on
+to: TKT-IB5C8S
+---

--- a/tickets/relations/TKT-2WVTRA--implements--FEAT-KXV0YJ.md
+++ b/tickets/relations/TKT-2WVTRA--implements--FEAT-KXV0YJ.md
@@ -1,0 +1,5 @@
+---
+from: TKT-2WVTRA
+relation: implements
+to: FEAT-KXV0YJ
+---

--- a/tickets/relations/TKT-5WSCEZ--affects--schema-visualization.md
+++ b/tickets/relations/TKT-5WSCEZ--affects--schema-visualization.md
@@ -1,0 +1,5 @@
+---
+from: TKT-5WSCEZ
+relation: affects
+to: schema-visualization
+---

--- a/tickets/relations/TKT-5WSCEZ--depends-on--TKT-Y7C4V2.md
+++ b/tickets/relations/TKT-5WSCEZ--depends-on--TKT-Y7C4V2.md
@@ -1,0 +1,5 @@
+---
+from: TKT-5WSCEZ
+relation: depends-on
+to: TKT-Y7C4V2
+---

--- a/tickets/relations/TKT-5WSCEZ--implements--FEAT-KXV0YJ.md
+++ b/tickets/relations/TKT-5WSCEZ--implements--FEAT-KXV0YJ.md
@@ -1,0 +1,5 @@
+---
+from: TKT-5WSCEZ
+relation: implements
+to: FEAT-KXV0YJ
+---

--- a/tickets/relations/TKT-85Q6U5--affects--metamodel-types.md
+++ b/tickets/relations/TKT-85Q6U5--affects--metamodel-types.md
@@ -1,0 +1,5 @@
+---
+from: TKT-85Q6U5
+relation: affects
+to: metamodel-types
+---

--- a/tickets/relations/TKT-85Q6U5--has-implementation--IMPL-GA2TLR.md
+++ b/tickets/relations/TKT-85Q6U5--has-implementation--IMPL-GA2TLR.md
@@ -1,0 +1,5 @@
+---
+from: TKT-85Q6U5
+relation: has-implementation
+to: IMPL-GA2TLR
+---

--- a/tickets/relations/TKT-85Q6U5--has-review--REV-RZ8W6H.md
+++ b/tickets/relations/TKT-85Q6U5--has-review--REV-RZ8W6H.md
@@ -1,0 +1,5 @@
+---
+from: TKT-85Q6U5
+relation: has-review
+to: REV-RZ8W6H
+---

--- a/tickets/relations/TKT-85Q6U5--implements--FEAT-KXV0YJ.md
+++ b/tickets/relations/TKT-85Q6U5--implements--FEAT-KXV0YJ.md
@@ -1,0 +1,5 @@
+---
+from: TKT-85Q6U5
+relation: implements
+to: FEAT-KXV0YJ
+---

--- a/tickets/relations/TKT-9VYDPY--affects--store-backends.md
+++ b/tickets/relations/TKT-9VYDPY--affects--store-backends.md
@@ -1,0 +1,5 @@
+---
+from: TKT-9VYDPY
+relation: affects
+to: store-backends
+---

--- a/tickets/relations/TKT-9VYDPY--depends-on--TKT-2WVTRA.md
+++ b/tickets/relations/TKT-9VYDPY--depends-on--TKT-2WVTRA.md
@@ -1,0 +1,5 @@
+---
+from: TKT-9VYDPY
+relation: depends-on
+to: TKT-2WVTRA
+---

--- a/tickets/relations/TKT-9VYDPY--implements--FEAT-KXV0YJ.md
+++ b/tickets/relations/TKT-9VYDPY--implements--FEAT-KXV0YJ.md
@@ -1,0 +1,5 @@
+---
+from: TKT-9VYDPY
+relation: implements
+to: FEAT-KXV0YJ
+---

--- a/tickets/relations/TKT-IB5C8S--affects--metamodel-types.md
+++ b/tickets/relations/TKT-IB5C8S--affects--metamodel-types.md
@@ -1,0 +1,5 @@
+---
+from: TKT-IB5C8S
+relation: affects
+to: metamodel-types
+---

--- a/tickets/relations/TKT-IB5C8S--implements--FEAT-KXV0YJ.md
+++ b/tickets/relations/TKT-IB5C8S--implements--FEAT-KXV0YJ.md
@@ -1,0 +1,5 @@
+---
+from: TKT-IB5C8S
+relation: implements
+to: FEAT-KXV0YJ
+---

--- a/tickets/relations/TKT-K58O37--affects--store-backends.md
+++ b/tickets/relations/TKT-K58O37--affects--store-backends.md
@@ -1,0 +1,5 @@
+---
+from: TKT-K58O37
+relation: affects
+to: store-backends
+---

--- a/tickets/relations/TKT-K58O37--depends-on--TKT-2WVTRA.md
+++ b/tickets/relations/TKT-K58O37--depends-on--TKT-2WVTRA.md
@@ -1,0 +1,5 @@
+---
+from: TKT-K58O37
+relation: depends-on
+to: TKT-2WVTRA
+---

--- a/tickets/relations/TKT-K58O37--implements--FEAT-KXV0YJ.md
+++ b/tickets/relations/TKT-K58O37--implements--FEAT-KXV0YJ.md
@@ -1,0 +1,5 @@
+---
+from: TKT-K58O37
+relation: implements
+to: FEAT-KXV0YJ
+---

--- a/tickets/relations/TKT-Y7C4V2--affects--metamodel-types.md
+++ b/tickets/relations/TKT-Y7C4V2--affects--metamodel-types.md
@@ -1,0 +1,5 @@
+---
+from: TKT-Y7C4V2
+relation: affects
+to: metamodel-types
+---

--- a/tickets/relations/TKT-Y7C4V2--depends-on--TKT-2WVTRA.md
+++ b/tickets/relations/TKT-Y7C4V2--depends-on--TKT-2WVTRA.md
@@ -1,0 +1,5 @@
+---
+from: TKT-Y7C4V2
+relation: depends-on
+to: TKT-2WVTRA
+---

--- a/tickets/relations/TKT-Y7C4V2--implements--FEAT-KXV0YJ.md
+++ b/tickets/relations/TKT-Y7C4V2--implements--FEAT-KXV0YJ.md
@@ -1,0 +1,5 @@
+---
+from: TKT-Y7C4V2
+relation: implements
+to: FEAT-KXV0YJ
+---

--- a/tickets/schema.yaml
+++ b/tickets/schema.yaml
@@ -68,8 +68,6 @@ types:
   measure_status:
     values: [proposed, active, deprecated]
     default: proposed
-  doc_kind:
-    values: [guide, reference, tutorial, howto, explanation, changelog]
   audience:
     values: [beginner, intermediate, advanced]
     default: beginner


### PR DESCRIPTION
Removes the `doc_kind` custom type from `tickets/schema.yaml`. It was defined and referenced nowhere — dead schema config.

```diff
-  doc_kind:
-    values: [guide, reference, tutorial, howto, explanation, changelog]
```

## How it was found

The schema-as-graph spike projected `schema.yaml` into a rela entity graph and ran `analyze orphans`, which reported `doc_kind` as an orphan custom-type. Verified independently by grep, so this is a real finding rather than a projection artifact.

It is a defect class rela currently cannot detect in its own configuration — which is the argument for TKT-5WSCEZ (config linting over the projected graph).

## Verification

- `grep -c "type: doc_kind"` → 0 references
- Scanned all 30 custom types; `doc_kind` was the only unused one
- Confirmed the adjacent `audience` type **is** used (2×) and correctly left in place
- `just lint` → 0 issues · `just test` → exit 0 · `just coverage-check` → PASS (77.9%)
- `rela --project tickets validate` → schema + data-entry valid
- `analyze` properties / validations (120 rules) / cardinality → all pass

## Also included

The second commit files the schema-as-graph feature (FEAT-KXV0YJ) and its ticket sequence, of which this is the first item.

Ticket: TKT-85Q6U5