### PR TITLE
docs(tickets): rescope TKT-69TDK8 — short IDs are the primary path

### DIFF
--- a/tickets/entities/tickets/TKT-69TDK8.md
+++ b/tickets/entities/tickets/TKT-69TDK8.md
@@ -1,7 +1,7 @@
 ---
 id: TKT-69TDK8
 type: ticket
-title: 'collectAllIDs scans every entity with content on each create: O(n) latency and no fault isolation'
+title: 'collectAllIDs scans every entity with content on each auto-ID create: O(n) latency and no fault isolation'
 kind: refactor
 priority: high
 effort: m
@@ -10,15 +10,25 @@ status: backlog
 
 ## Problem
 
-Every `create_entity` for a sequential-ID type loads **every entity in the
-store, including full markdown content**, to compute the next ID number
+Every `create_entity` for an auto-ID type loads **every entity in the store,
+including full markdown content**, to compute the new ID
 (`internal/entitymanager/core.go:207`):
 
 ```go
 existingIDs, err := collectAllIDs(ctx, deps.Store)
-...
+if err != nil {
+    return "", fmt.Errorf("collect existing IDs: %w", err)
+}
+if entityDef.IsShortID() {
+    return entity.GenerateShortID(existingIDs, prefix, len(existingIDs), entityDef.GetIDCaps()), nil
+}
 return entity.GenerateNextID(existingIDs, prefix), nil
 ```
+
+The scan happens **before** the branch, so it costs the same whether the type
+uses short or sequential IDs. Since `GetIDType()` defaults to `short`, this is
+the common path for nearly every create in a typical project — see Fix
+direction, where this reverses the priorities this ticket was first written with.
 
 `collectAllIDs` iterates `ListEntities` and keeps only `e.ID`, but pgstore's
 `buildEntityListSQL` selects `id, type, properties, content, updated_at` with no
@@ -64,46 +74,174 @@ corrupt file should be that file, not all writes.
 
 ## Fix direction
 
-**Do not fetch content.** This is the natural first consumer of
-`store.EntityHeader` / `ListEntityHeaders` from the analyze-memory ticket —
-headers carry ID, type and properties, never the body. That alone removes the
-535 MB transfer.
+### Short IDs are the primary path, not an afterthought
 
-Better still, do not scan at all. Computing "max sequence number for prefix P"
-is a `SELECT max(...) WHERE id LIKE 'P-%'` — an indexed aggregate, O(log n), no
-rows to the client. That likely wants a store capability (`NextSequentialID` or
-similar), type-asserted like `HistoryReader`, with the existing scan as the
-generic fallback for backends that cannot express it.
+`GetIDType()` **defaults to `IDTypeShort`** when `id_type` is unset, so short is
+both the declared majority and the implicit default. In `tickets/schema.yaml`,
+17 of 24 types are `short` and 7 are `manual` (which skips generation entirely).
+Across the whole repo `id_type: sequential` appears **only in
+`prototypes/data-entry/project/schema.yaml`** — no shipped schema uses it.
 
-Note the correctness constraint documented on `collectAllIDs`: a *partial* scan
-must never feed ID generation, because a truncated list can hide a high-numbered
-existing ID and the generator would mint a duplicate. Any replacement must
-preserve fail-loudly-on-error semantics. `createCore` rejects a collision with
-`ErrEntityAlreadyExists`, so the failure mode is a spurious conflict rather than
-data loss — but the invariant should be kept, not weakened.
+So the sequential path this ticket was originally written around is the rare
+case, and `GenerateShortID` is what actually runs on nearly every create. Fix
+short IDs first; sequential is the secondary case.
 
-Fault isolation is a separate decision that needs an explicit call: should a
-malformed entity file be skipped-with-warning during ID generation, or continue
-to fail closed? Failing closed is defensible (it is the current documented
-intent), but today it fails closed on *all writes* rather than on the affected
-entity, which is almost certainly not intended.
+### Short IDs need almost nothing from the store
+
+```go
+existingIDs, err := collectAllIDs(ctx, deps.Store)   // O(n), full content
+...
+return entity.GenerateShortID(existingIDs, prefix, len(existingIDs), caps), nil
+```
+
+`GenerateShortID` uses the full id set for exactly two things:
+
+1. `calculateIDLength(entityCount)` — birthday-paradox thresholds at
+   500 / 1500 / 10000 / 50000. This needs a **count**, and only its bucket. A
+   `COUNT(*)` is an indexed aggregate; even an approximate count would do, since
+   the thresholds are order-of-magnitude heuristics.
+2. A membership set for collision retry (100 attempts, lengthening periodically).
+
+Point 2 does not need a materialised set at all. `store.CreateEntity` already
+returns `ErrConflict` on a duplicate id, and `createCore` already maps that to
+`ErrEntityAlreadyExists` — so **retry-on-conflict at the write** is strictly more
+correct than pre-checking against a snapshot, which is racy by construction:
+between the scan and the insert another writer can take the id. The current
+membership check does not prevent collisions, it only makes them rarer.
+
+Target shape: generate a candidate from a cheap count, attempt the insert, and
+on `ErrConflict` regenerate (lengthening as now). This removes the scan from the
+common path entirely and closes the TOCTOU window at the same time.
+
+### Sequential IDs: an indexed aggregate, with two traps
+
+Secondary in priority, but the scan must go here too. Computing "highest
+sequence number for prefix P" is an indexed aggregate — O(log n), one row to the
+client — behind a store capability type-asserted like `HistoryReader`, with the
+existing scan as the generic fallback.
+
+**Trap 1 — `max(id)` is lexicographic and mints duplicates.**
+`ExtractHighestNumber` compares `id.Number` **numerically**; SQL `max(id)`
+compares **lexicographically**. Today's `%03d` padding makes the two agree below
+1000, but padding does not truncate: the 1000th entity is `TKT-1000`, and
+`'TKT-1000' < 'TKT-999'`. A `max(id)` implementation passes every small-fixture
+test and starts minting duplicates at exactly 1000 entities of one prefix. The
+aggregate must extract and cast the numeric part, e.g.
+
+```sql
+SELECT max((substring(id from '^TKT-(\d+)$'))::int) FROM entities
+```
+
+ignoring ids that do not match, mirroring `ParseEntityID`'s skip-on-error.
+
+**Trap 2 — scope by PREFIX, not by entity type.** Narrowing with
+`EntityQuery{Type: entityType}` looks free but is unsafe: `GetIDPrefixes`
+returns a *list*, `MatchesID` scans it, and nothing forbids two types sharing a
+prefix. `ExtractHighestNumber` deliberately filters by **prefix across all
+types**. Scoping to one type would mint duplicates wherever a prefix is shared.
+
+### `EntityHeader` is the fallback, not the fix
+
+`store.EntityHeader` / `ListEntityHeaders` removes the body bytes but keeps the
+O(n) row scan, and still fetches and unmarshals the `properties` JSONB per row
+for a function that reads only `e.ID`. It is the right generic fallback for
+backends that cannot express the aggregates, but it does not reach AC1 or AC3.
+
+### Fault isolation is resolved as a side effect
+
+`collectAllIDs`'s doc comment justifies failing loudly because *a partial scan
+can hide a high-numbered ID*. That is exactly right for a scan — and dissolves
+under an aggregate, which never returns a partial. An unparseable entity file
+cannot corrupt a `COUNT(*)` or a `max()` over the `id` column: the id is intact
+whether or not the frontmatter parses. So the aggregates remove the "one corrupt
+file makes the project read-only" defect without needing a fail-open/fail-closed
+policy call. The header path would *not* fix it — it still runs the file through
+the parser and still fails the whole iterator.
+
+The policy decision remains only for the fallback scan, which must keep
+fail-loudly semantics.
 
 ## Scope
 
 **In scope**
 
-- Remove content from the ID-generation read path.
-- Evaluate and, if viable, implement an indexed max-sequence store capability with a
-scan fallback.
-- Decide and document the fault-isolation behaviour for a malformed entity.
+- **Short-ID generation (primary)**: replace the full scan with a cheap count
+plus retry-on-`ErrConflict` at the write.
+- **Sequential-ID generation (secondary)**: prefix-scoped, numeric max-sequence
+store capability.
+- `EntityHeader` for the fallback read path, so no fallback fetches bodies.
+- Document fault-isolation behaviour for a malformed entity on the fallback path.
 - Benchmark create latency at 1k / 10k / 100k entities, before and after.
 
 **Out of scope**
 
-- Short-ID generation strategy (`entityDef.IsShortID()` takes a different path through
-`GenerateShortID` and needs the count, not the max — assess separately).
-- The `_analyze` retention fix (separate ticket; this one consumes its `EntityHeader`
-type if that lands first).
+- The `_analyze` retention fix (landed in TKT-1ESTYJ; this consumes its
+`EntityHeader` type for the fallback path).
+- Changing the birthday-paradox thresholds or the short-ID alphabet.
+
+## Acceptance criteria
+
+1. Create latency is flat in entity count for **short-ID** types (the default):
+   creating entity #100,000 costs approximately what #100 costs.
+2. The same holds for sequential-ID types.
+3. No entity body is transferred from the store during ID generation, verified by
+query inspection or a store-level assertion.
+4. Uncontended create at 262k entities drops from 0.74 s to well under 50 ms.
+5. 80-way concurrent creates no longer produce multi-second latencies.
+6. **Short-ID collisions are resolved at the write, not by pre-check**: a
+concurrent create that loses the race retries and succeeds rather than
+surfacing `ErrEntityAlreadyExists` to the caller.
+7. **Numeric, not lexicographic** (sequential): crossing 999 → 1000 mints
+`TKT-1000` then `TKT-1001`, never a duplicate.
+8. **Prefix-scoped, not type-scoped** (sequential): two entity types sharing an
+`id_prefix` never receive the same generated id.
+9. A malformed entity file no longer fails creates of *other* entities when the
+aggregate path is available; documented, tested behaviour on the fallback path.
+
+## Test plan
+
+- **Latency benchmark** at 1k / 10k / 100k entities asserting sub-linear scaling,
+run for a **short-ID type** (the default path) — this is the test that would
+have surfaced the defect.
+- **Short-ID concurrency test** — the pin for AC6. N concurrent creates of one
+short-ID type; assert N distinct ids and zero surfaced conflicts. Should fail
+against the current pre-check, which is racy between scan and insert.
+- **Short-ID length test**: the id length still follows the count thresholds
+(500 / 1500 / 10000 / 50000) once the count comes from an aggregate.
+- **999 → 1000 boundary test** — the pin for AC7. Seed a prefix to `TKT-0999`,
+create, assert `TKT-1000`, then `TKT-1001`. Fails against `max(id)`.
+- **Shared-prefix test** — the pin for AC8. Two types declaring the same
+`id_prefix`; interleaved creates produce strictly increasing distinct ids.
+- Error-propagation test: an injected store error during ID generation fails the
+create; no ID is minted.
+- Malformed-entity test: with the aggregates available, a corrupt file does not
+block creates of other entities; on the fallback path, pin the chosen behaviour.
+- `storetest` conformance for the new capabilities, plus explicit fallback
+coverage (fsstore/memstore exercise the fallback, pgstore the native path).
+
+**In scope**
+
+- Implement an indexed max-sequence store capability, scoped by prefix, with a
+scan fallback for backends that cannot express it.
+- Remove content from the ID-generation fallback read path (via `EntityHeader`).
+- Short-ID generation (see below) — either solved here or split into its own
+ticket before this one is called done, but not left unstated.
+- Document the fault-isolation behaviour for a malformed entity on the fallback path.
+- Benchmark create latency at 1k / 10k / 100k entities, before and after.
+
+**Short IDs need a different capability.** `entityDef.IsShortID()` takes the
+`GenerateShortID` path, which needs *both* a count (for `calculateIDLength`'s
+birthday-paradox thresholds) *and* the full existing-ID set as a membership
+check for collision retry. A max-aggregate does nothing for either. It wants
+`COUNT(*)` plus a per-candidate existence probe. Note `store.CreateEntity`
+already returns `ErrConflict`, so retry-on-conflict against the store is a
+plausible and much cheaper design than materialising the id set. Left
+unaddressed, a short-ID type keeps the full scan and this ticket only half-lands.
+
+**Out of scope**
+
+- The `_analyze` retention fix (landed in TKT-1ESTYJ; this consumes its
+`EntityHeader` type for the fallback path).
 
 ## Acceptance criteria
 
@@ -114,19 +252,32 @@ query inspection or a store-level assertion.
 3. Uncontended create at 262k entities drops from 0.74 s to well under 50 ms.
 4. 80-way concurrent creates no longer produce multi-second latencies.
 5. Generated IDs remain collision-free — the existing "partial scan must not feed the
-generator" invariant holds, with a test that a store error during ID generation
-fails the create rather than minting a possibly-duplicate ID.
-6. Documented, tested behaviour for a malformed entity file during ID generation.
+generator" invariant holds on the fallback path, with a test that a store error
+during ID generation fails the create rather than minting a possibly-duplicate ID.
+6. **Numeric, not lexicographic**: crossing the 999 → 1000 boundary for a prefix
+mints `TKT-1000` then `TKT-1001`, never a duplicate of an existing id.
+7. **Prefix-scoped, not type-scoped**: two entity types sharing an `id_prefix`
+never receive the same generated id.
+8. A malformed entity file no longer fails creates of *other* entities when the
+aggregate path is available; documented, tested behaviour on the fallback path.
 
 ## Test plan
 
 - **Latency benchmark** at 1k / 10k / 100k entities asserting sub-linear scaling
 (this is the test that would have surfaced the defect).
+- **999 → 1000 boundary test** — the pin for AC6. Seed a prefix up to `TKT-0999`,
+create, assert `TKT-1000`; create again, assert `TKT-1001`. This test fails
+against a `max(id)` implementation and is the reason it exists.
+- **Shared-prefix test** — the pin for AC7. Two entity types declaring the same
+`id_prefix`; interleaved creates must produce strictly increasing distinct ids.
 - Collision test: concurrent creates of the same type must not produce duplicate IDs.
 - Error-propagation test: an injected store error during ID generation fails the
 create; no ID is minted.
-- Malformed-entity test pinning whichever fault-isolation behaviour is chosen.
-- `storetest` conformance for any new capability, plus explicit fallback coverage.
+- Malformed-entity test: with the aggregate available, a corrupt file does not
+block creates of other entities; on the fallback path, pin whichever behaviour
+is chosen.
+- `storetest` conformance for the new capability, plus explicit fallback coverage
+(fsstore/memstore exercise the fallback, pgstore the native path).
 
 ## Related
 

--- a/tickets/entities/tickets/TKT-69TDK8.md
+++ b/tickets/entities/tickets/TKT-69TDK8.md
@@ -98,8 +98,8 @@ return entity.GenerateShortID(existingIDs, prefix, len(existingIDs), caps), nil
 
 1. `calculateIDLength(entityCount)` — birthday-paradox thresholds at
    500 / 1500 / 10000 / 50000. This needs a **count**, and only its bucket. A
-   `COUNT(*)` is an indexed aggregate; even an approximate count would do, since
-   the thresholds are order-of-magnitude heuristics.
+   `COUNT(*)` is an indexed aggregate; an approximate or slightly stale count is
+   safe (see "The precision was never required" below).
 2. A membership set for collision retry (100 attempts, lengthening periodically).
 
 Point 2 does not need a materialised set at all. `store.CreateEntity` already
@@ -112,6 +112,60 @@ membership check does not prevent collisions, it only makes them rarer.
 Target shape: generate a candidate from a cheap count, attempt the insert, and
 on `ErrConflict` regenerate (lengthening as now). This removes the scan from the
 common path entirely and closes the TOCTOU window at the same time.
+
+#### The precision was never required — say so in the signature
+
+`calculateIDLength` only picks a **starting** length; the retry loop lengthens
+on collision regardless. So the count was never load-bearing for correctness,
+only for how often the loop retries. Today's `len(existingIDs)` is exact by
+accident of implementation, not by requirement — the current signature
+over-promises a precision the algorithm does not need.
+
+That means the contract can be loosened without accommodating anything: it is
+documenting what was already true, and stands on its own even if the aggregate
+work is deferred.
+
+Loosen it on the **parameter**, not the function name:
+
+```go
+// calculateIDLength determines the ID length from an entity count, using
+// birthday-paradox thresholds to keep collision probability low.
+//
+// The count need only be accurate to its bucket (500/1500/10000/50000):
+// it selects a STARTING length and GenerateShortID lengthens on collision,
+// so an approximate or stale count is safe. Being one bucket low costs one
+// base36 character, recovered by the retry loop. Never use this count for
+// anything requiring an exact population.
+func calculateIDLength(approxEntityCount int) int
+```
+
+Renaming the *function* (e.g. `getApproxIDLength`) would put the hedge on the
+wrong side: the return value stays exact and deterministic, and no caller may
+treat it as a hint. It is the **input** whose precision is optional, so the
+parameter is where the looseness belongs — and it shows up at every call site,
+which is exactly where someone would otherwise reach for an exact count.
+
+Do this in the same commit as the signature change: once membership moves to
+retry-on-`ErrConflict`, `existingIDs` disappears and `GenerateShortID` becomes
+`GenerateShortID(prefix string, approxEntityCount int, caps string)` — the two
+callers currently pass `len(existingIDs)` as the count, so the redundant pair
+collapses.
+
+Two constraints on the loosening:
+
+- **Do not redefine `store.CountEntities`.** It already exists
+  (`store.go:255`) and is exact; `cli/rename.go` and `cli/schema.go` display its
+  result to users, where an estimate would be a regression. Either keep calling
+  the exact method (the rename alone still documents the contract) or add a
+  separate approximate capability — do not weaken the existing one in place.
+- **A wrong bucket must be safe, not merely unlikely.** Under-estimating yields
+  shorter starting ids and more collisions, which is exactly why AC7
+  (resolve collisions at the write) is a prerequisite: with retry-on-conflict a
+  bad estimate costs an extra round-trip instead of a duplicate id. Landing the
+  approximate count *before* the retry change would trade correctness for speed.
+
+The payoff is that this licenses `reltuples`-style planner estimates on pgstore,
+which are O(1) and touch no rows at all.
 
 ### Sequential IDs: an indexed aggregate, with two traps
 
@@ -145,7 +199,7 @@ types**. Scoping to one type would mint duplicates wherever a prefix is shared.
 `store.EntityHeader` / `ListEntityHeaders` removes the body bytes but keeps the
 O(n) row scan, and still fetches and unmarshals the `properties` JSONB per row
 for a function that reads only `e.ID`. It is the right generic fallback for
-backends that cannot express the aggregates, but it does not reach AC1 or AC3.
+backends that cannot express the aggregates, but it does not reach AC1 or AC5.
 
 ### Fault isolation is resolved as a side effect
 
@@ -167,6 +221,8 @@ fail-loudly semantics.
 
 - **Short-ID generation (primary)**: replace the full scan with a cheap count
 plus retry-on-`ErrConflict` at the write.
+- Loosen the count contract in the signature (`approxEntityCount`) and document
+that only the bucket matters — the precision was never required.
 - **Sequential-ID generation (secondary)**: prefix-scoped, numeric max-sequence
 store capability.
 - `EntityHeader` for the fallback read path, so no fallback fetches bodies.
@@ -182,20 +238,23 @@ store capability.
 ## Acceptance criteria
 
 1. Create latency is flat in entity count for **short-ID** types (the default):
-   creating entity #100,000 costs approximately what #100 costs.
+creating entity #100,000 costs approximately what #100 costs.
 2. The same holds for sequential-ID types.
-3. No entity body is transferred from the store during ID generation, verified by
+3. The count feeding `calculateIDLength` is named and documented as approximate
+(`approxEntityCount` or similar), and `store.CountEntities` keeps its exact
+contract for its existing display callers.
+4. No entity body is transferred from the store during ID generation, verified by
 query inspection or a store-level assertion.
-4. Uncontended create at 262k entities drops from 0.74 s to well under 50 ms.
-5. 80-way concurrent creates no longer produce multi-second latencies.
-6. **Short-ID collisions are resolved at the write, not by pre-check**: a
+5. Uncontended create at 262k entities drops from 0.74 s to well under 50 ms.
+6. 80-way concurrent creates no longer produce multi-second latencies.
+7. **Short-ID collisions are resolved at the write, not by pre-check**: a
 concurrent create that loses the race retries and succeeds rather than
 surfacing `ErrEntityAlreadyExists` to the caller.
-7. **Numeric, not lexicographic** (sequential): crossing 999 → 1000 mints
+8. **Numeric, not lexicographic** (sequential): crossing 999 → 1000 mints
 `TKT-1000` then `TKT-1001`, never a duplicate.
-8. **Prefix-scoped, not type-scoped** (sequential): two entity types sharing an
+9. **Prefix-scoped, not type-scoped** (sequential): two entity types sharing an
 `id_prefix` never receive the same generated id.
-9. A malformed entity file no longer fails creates of *other* entities when the
+10. A malformed entity file no longer fails creates of *other* entities when the
 aggregate path is available; documented, tested behaviour on the fallback path.
 
 ## Test plan
@@ -203,14 +262,17 @@ aggregate path is available; documented, tested behaviour on the fallback path.
 - **Latency benchmark** at 1k / 10k / 100k entities asserting sub-linear scaling,
 run for a **short-ID type** (the default path) — this is the test that would
 have surfaced the defect.
-- **Short-ID concurrency test** — the pin for AC6. N concurrent creates of one
+- **Short-ID concurrency test** — the pin for AC7. N concurrent creates of one
 short-ID type; assert N distinct ids and zero surfaced conflicts. Should fail
 against the current pre-check, which is racy between scan and insert.
 - **Short-ID length test**: the id length still follows the count thresholds
 (500 / 1500 / 10000 / 50000) once the count comes from an aggregate.
-- **999 → 1000 boundary test** — the pin for AC7. Seed a prefix to `TKT-0999`,
+- **Approximate-count tolerance test**: feed a deliberately off-by-N count near
+each threshold and assert creates still produce unique, valid ids — pinning that
+the estimate is allowed to be wrong without correctness loss.
+- **999 → 1000 boundary test** — the pin for AC8. Seed a prefix to `TKT-0999`,
 create, assert `TKT-1000`, then `TKT-1001`. Fails against `max(id)`.
-- **Shared-prefix test** — the pin for AC8. Two types declaring the same
+- **Shared-prefix test** — the pin for AC9. Two types declaring the same
 `id_prefix`; interleaved creates produce strictly increasing distinct ids.
 - Error-propagation test: an injected store error during ID generation fails the
 create; no ID is minted.
@@ -243,41 +305,6 @@ unaddressed, a short-ID type keeps the full scan and this ticket only half-lands
 - The `_analyze` retention fix (landed in TKT-1ESTYJ; this consumes its
 `EntityHeader` type for the fallback path).
 
-## Acceptance criteria
-
-1. Create latency is flat in entity count for sequential-ID types: creating entity
-   #100,000 costs approximately what #100 costs.
-2. No entity body is transferred from the store during ID generation, verified by
-query inspection or a store-level assertion.
-3. Uncontended create at 262k entities drops from 0.74 s to well under 50 ms.
-4. 80-way concurrent creates no longer produce multi-second latencies.
-5. Generated IDs remain collision-free — the existing "partial scan must not feed the
-generator" invariant holds on the fallback path, with a test that a store error
-during ID generation fails the create rather than minting a possibly-duplicate ID.
-6. **Numeric, not lexicographic**: crossing the 999 → 1000 boundary for a prefix
-mints `TKT-1000` then `TKT-1001`, never a duplicate of an existing id.
-7. **Prefix-scoped, not type-scoped**: two entity types sharing an `id_prefix`
-never receive the same generated id.
-8. A malformed entity file no longer fails creates of *other* entities when the
-aggregate path is available; documented, tested behaviour on the fallback path.
-
-## Test plan
-
-- **Latency benchmark** at 1k / 10k / 100k entities asserting sub-linear scaling
-(this is the test that would have surfaced the defect).
-- **999 → 1000 boundary test** — the pin for AC6. Seed a prefix up to `TKT-0999`,
-create, assert `TKT-1000`; create again, assert `TKT-1001`. This test fails
-against a `max(id)` implementation and is the reason it exists.
-- **Shared-prefix test** — the pin for AC7. Two entity types declaring the same
-`id_prefix`; interleaved creates must produce strictly increasing distinct ids.
-- Collision test: concurrent creates of the same type must not produce duplicate IDs.
-- Error-propagation test: an injected store error during ID generation fails the
-create; no ID is minted.
-- Malformed-entity test: with the aggregate available, a corrupt file does not
-block creates of other entities; on the fallback path, pin whichever behaviour
-is chosen.
-- `storetest` conformance for the new capability, plus explicit fallback coverage
-(fsstore/memstore exercise the fallback, pgstore the native path).
 
 ## Related
 


### PR DESCRIPTION
Ticket-only. No code changes.

## Why

TKT-69TDK8 was written around `GenerateNextID` (sequential IDs) and had
`GenerateShortID` in **Out of scope**. That inverts reality:

- `GetIDType()` defaults to `IDTypeShort` when `id_type` is unset.
- `tickets/schema.yaml` is 17 `short` / 7 `manual`.
- `id_type: sequential` appears **once** in the whole repo, in
  `prototypes/data-entry/project/schema.yaml`. No shipped schema uses it.

So the ticket was scoped around the path essentially nothing runs, and left
the common path unaddressed.

The Problem section was also wrong about blast radius: `collectAllIDs` runs
*before* the `IsShortID()` branch, so the full scan costs the same either way.
It is every auto-ID create, not just sequential ones. Title updated to match.

## What changed

**Short IDs are now primary.** `GenerateShortID` uses the id set for two things:
a count for `calculateIDLength`, and a membership set for collision retry.

The membership set does not need to exist. `store.CreateEntity` already returns
`ErrConflict` and `createCore:122` already maps it to `ErrEntityAlreadyExists`,
so retry-on-conflict at the write is **strictly more correct** than the current
pre-check, which is racy by construction — between the scan and the insert
another writer can take the id. The existing check does not prevent collisions,
it only makes them rarer. Removing the scan closes a TOCTOU window rather than
trading correctness for speed.

**The count contract is loosened to approximate.** `entityCount` flows into
exactly one place, which buckets it into a *starting* length that the retry loop
lengthens on collision anyway. Precision was never load-bearing; `len(existingIDs)`
is exact by accident of implementation. Renaming the parameter to
`approxEntityCount` documents what was already true, and licenses `reltuples`-style
O(1) planner estimates on pgstore.

The hedge goes on the **parameter**, not the function name — the return value
stays exact and no caller may treat it as a hint.

Two constraints recorded: do not weaken `store.CountEntities` (exact, and
`cli/rename.go` + `cli/schema.go` show it to users), and land retry-on-conflict
*before* the approximate count, or a bad estimate becomes a duplicate id instead
of a round-trip.

**Sequential IDs kept as secondary, with two traps documented:**

1. `max(id)` is lexicographic. `%03d` padding does not truncate, so the 1000th
   entity is `TKT-1000` and `'TKT-1000' < 'TKT-999'`. Such an implementation
   passes every small-fixture test and mints duplicates at exactly 1000 entities
   of one prefix. The aggregate must cast the numeric part.
2. Scope by **prefix**, not entity type. `GetIDPrefixes` returns a list and
   nothing forbids two types sharing a prefix; `ExtractHighestNumber` filters by
   prefix across all types. Type-scoping would mint duplicates.

**Fault isolation resolves as a side effect.** A `COUNT(*)`/`max()` over the `id`
column cannot be corrupted by unparseable frontmatter — the id is intact whether
or not the YAML parses. The `EntityHeader` path would *not* fix this: it still
runs the file through the parser and still fails the whole iterator.

## Verification

- `rela show TKT-69TDK8` parses, relations intact (`affects`, `implements`).
- `rela validate --check cardinality --check properties --check validations`
  passes clean on this branch.

Ticket stays `backlog`, effort `m`.