### PR TITLE
feat(data-entry): infer form relation direction; require it when self-referencing (TKT-860BNJ)

### DIFF
--- a/docs-project/entities/guides/GUIDE-data-entry.md
+++ b/docs-project/entities/guides/GUIDE-data-entry.md
@@ -499,7 +499,7 @@ Each entry in `relations:` configures a relation picker:
 | Field          | Type   | Description                                                    |
 | -------------- | ------ | -------------------------------------------------------------- |
 | `relation`     | string | Relation type name from the metamodel                          |
-| `direction`    | string | `"outgoing"` or `"incoming"`                                   |
+| `direction`    | string | `"outgoing"` or `"incoming"` — inferred when omitted; required for self-referencing relations (see below) |
 | `target_type`  | string | Entity type of the related entity                              |
 | `label`        | string | Display label                                                  |
 | `required`     | bool   | At least one relation must be selected                         |
@@ -549,6 +549,25 @@ Two details worth knowing:
 > them. If a `+ New` button disappeared after upgrading, the target type has no registered form.
 
 ### Reverse (incoming) Relations
+
+#### How `direction` is resolved
+
+`direction` may be omitted when the form's entity type sits on exactly **one**
+side of the relation — there is only one sensible reading, so rela infers it:
+
+- entity type is the relation's `from` → `outgoing`
+- entity type is the relation's `to` → `incoming`
+
+It must be written explicitly when the form's entity type is on **both** sides —
+a self-referencing relation such as `depends-on` from `ticket` to `ticket`. There
+`outgoing` and `incoming` are both valid and mean opposite things, so rela
+refuses to guess and reports the form and relation by name.
+
+> **Upgrading.** `direction` used to default to `outgoing` whenever it was
+> absent, which silently bound the wrong side of a `to`-side relation. Run
+> `rela migrate` to write explicit directions for the unambiguous bindings; it
+> deliberately leaves self-referencing ones alone, and `rela validate` lists
+> those for you to decide.
 
 Relation types are directional in the metamodel: `implements` goes from `task` to `feature`.
 Often you want to show the *inbound* side on the opposite entity's form — on the feature form,

--- a/docs/data-entry.md
+++ b/docs/data-entry.md
@@ -493,7 +493,7 @@ Each entry in `relations:` configures a relation picker:
 | Field          | Type   | Description                                                    |
 | -------------- | ------ | -------------------------------------------------------------- |
 | `relation`     | string | Relation type name from the metamodel                          |
-| `direction`    | string | `"outgoing"` or `"incoming"`                                   |
+| `direction`    | string | `"outgoing"` or `"incoming"` — inferred when omitted; required for self-referencing relations (see below) |
 | `target_type`  | string | Entity type of the related entity                              |
 | `label`        | string | Display label                                                  |
 | `required`     | bool   | At least one relation must be selected                         |
@@ -543,6 +543,25 @@ Two details worth knowing:
 > them. If a `+ New` button disappeared after upgrading, the target type has no registered form.
 
 ### Reverse (incoming) Relations
+
+#### How `direction` is resolved
+
+`direction` may be omitted when the form's entity type sits on exactly **one**
+side of the relation — there is only one sensible reading, so rela infers it:
+
+- entity type is the relation's `from` → `outgoing`
+- entity type is the relation's `to` → `incoming`
+
+It must be written explicitly when the form's entity type is on **both** sides —
+a self-referencing relation such as `depends-on` from `ticket` to `ticket`. There
+`outgoing` and `incoming` are both valid and mean opposite things, so rela
+refuses to guess and reports the form and relation by name.
+
+> **Upgrading.** `direction` used to default to `outgoing` whenever it was
+> absent, which silently bound the wrong side of a `to`-side relation. Run
+> `rela migrate` to write explicit directions for the unambiguous bindings; it
+> deliberately leaves self-referencing ones alone, and `rela validate` lists
+> those for you to decide.
 
 Relation types are directional in the metamodel: `implements` goes from `task` to `feature`.
 Often you want to show the *inbound* side on the opposite entity's form — on the feature form,

--- a/e2e/tests/fixtures.ts
+++ b/e2e/tests/fixtures.ts
@@ -988,6 +988,7 @@ forms:
         widget: textarea
     relations:
       - relation: tagged
+        direction: outgoing
         widget: cards
         properties:
           - property: added_by

--- a/internal/dataentry/api_v1.go
+++ b/internal/dataentry/api_v1.go
@@ -1272,16 +1272,47 @@ func (a *App) handleV1SchemaRoutes(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-// resolveRelationWidgets returns a copy of rels with any empty Widget set to
-// "cards" when the relation type has edge properties/content. Shared by the
-// flat and wizard-step relation lists in handleV1Config.
-func resolveRelationWidgets(s *Schema, rels []dataentryconfig.FormRelation) []dataentryconfig.FormRelation {
+// resolveFormRelations returns a copy of rels with server-derived defaults
+// filled in, for both the flat and wizard-step relation lists in handleV1Config.
+//
+// Widget: an empty Widget becomes "cards" when the relation type has edge
+// properties/content.
+//
+// Direction: an absent `direction:` is inferred from the metamodel — the SPA
+// widgets test `direction === 'incoming'` literally (RelationCards.vue,
+// RelationPicker.vue), so the inference MUST happen here rather than in the
+// browser, or a to-side binding would validate clean on the server and still
+// render the wrong side. Resolving once on the way out keeps the two consumers
+// agreeing by construction. The ambiguous case (entity type on both sides) is
+// rejected by ValidateConfig at load, so it cannot reach this point.
+func resolveFormRelations(
+	s *Schema, entityType string, rels []dataentryconfig.FormRelation,
+) []dataentryconfig.FormRelation {
 	resolved := make([]dataentryconfig.FormRelation, len(rels))
 	copy(resolved, rels)
 	for i := range resolved {
 		if resolved[i].Widget == "" {
 			if def, ok := s.Meta.GetRelationDef(resolved[i].Relation); ok && def.HasAdvancedFeatures() {
 				resolved[i].Widget = WidgetCards
+			}
+		}
+		if resolved[i].Direction == "" {
+			dir, res := dataentryconfig.InferDirection(entityType, resolved[i].Relation, s.Meta)
+			switch res {
+			case dataentryconfig.DirectionResolved:
+				resolved[i].Direction = dir
+			case dataentryconfig.DirectionAmbiguous:
+				// ValidateConfig rejects an ambiguous binding at load, so the
+				// app should not have started. Reaching here means that gate
+				// was bypassed; say so rather than silently picking a side.
+				slog.Warn("form relation direction is ambiguous but reached the config handler; "+
+					"serving outgoing", "form_entity_type", entityType, "relation", resolved[i].Relation)
+				resolved[i].Direction = dataentryconfig.DirectionOutgoing
+			case dataentryconfig.DirectionNoSide, dataentryconfig.DirectionUnknown:
+				// A wrong-side or unreadable binding — both already reported by
+				// validation. Serve the historical reading rather than inventing
+				// one; the SPA needs a non-empty value either way.
+				resolved[i].Direction = dataentryconfig.DirectionOutgoing
 			}
 		}
 	}
@@ -1319,12 +1350,12 @@ func (a *App) handleV1Config(w http.ResponseWriter, r *http.Request) {
 	forms := make(map[string]dataentryconfig.Form, len(s.Cfg.Forms))
 	for id, form := range s.Cfg.Forms {
 		f := form
-		f.Relations = resolveRelationWidgets(s, f.Relations)
+		f.Relations = resolveFormRelations(s, form.EntityType, f.Relations)
 		if len(f.Steps) > 0 {
 			steps := make([]dataentryconfig.FormStep, len(f.Steps))
 			copy(steps, f.Steps)
 			for i := range steps {
-				steps[i].Relations = resolveRelationWidgets(s, steps[i].Relations)
+				steps[i].Relations = resolveFormRelations(s, form.EntityType, steps[i].Relations)
 			}
 			f.Steps = steps
 		}

--- a/internal/dataentry/form_relation_direction_test.go
+++ b/internal/dataentry/form_relation_direction_test.go
@@ -1,0 +1,74 @@
+package dataentry
+
+import (
+	"testing"
+
+	dec "github.com/Sourcehaven-BV/rela/internal/dataentryconfig"
+	"github.com/Sourcehaven-BV/rela/internal/metamodel"
+)
+
+// TestResolveFormRelations_Direction pins that the server resolves an absent
+// `direction:` before serving form config to the SPA.
+//
+// This has to happen server-side: RelationCards.vue and RelationPicker.vue both
+// test `props.field.direction === 'incoming'` literally, with no metamodel
+// inference of their own. If the server shipped an empty direction, a to-side
+// binding would validate clean and still render as outgoing in the browser —
+// searching the wrong entity type and showing no existing edges.
+func TestResolveFormRelations_Direction(t *testing.T) {
+	mm, err := metamodel.Parse([]byte(`version: "1.0"
+entities:
+  project: {label: Project, id_prefix: "PRJ-", properties: {title: {type: string}}}
+  task: {label: Task, id_prefix: "TSK-", properties: {title: {type: string}}}
+relations:
+  belongs-to:
+    label: belongs to
+    from: [task]
+    to: [project]
+`))
+	if err != nil {
+		t.Fatalf("parse metamodel: %v", err)
+	}
+	s := &Schema{Meta: mm}
+
+	tests := []struct {
+		name       string
+		entityType string
+		rel        dec.FormRelation
+		want       dec.Direction
+	}{
+		{
+			name:       "from-side binding infers outgoing",
+			entityType: "task",
+			rel:        dec.FormRelation{Relation: "belongs-to"},
+			want:       dec.DirectionOutgoing,
+		},
+		{
+			name:       "to-side binding infers incoming",
+			entityType: "project",
+			rel:        dec.FormRelation{Relation: "belongs-to"},
+			want:       dec.DirectionIncoming,
+		},
+		{
+			name:       "explicit direction is preserved",
+			entityType: "task",
+			rel:        dec.FormRelation{Relation: "belongs-to", Direction: dec.DirectionIncoming},
+			want:       dec.DirectionIncoming,
+		},
+		{
+			name:       "unknown relation falls back to outgoing",
+			entityType: "task",
+			rel:        dec.FormRelation{Relation: "no-such-relation"},
+			want:       dec.DirectionOutgoing,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := resolveFormRelations(s, tt.entityType, []dec.FormRelation{tt.rel})
+			if got[0].Direction != tt.want {
+				t.Errorf("direction on the wire = %q, want %q", got[0].Direction, tt.want)
+			}
+		})
+	}
+}

--- a/internal/dataentryconfig/config.go
+++ b/internal/dataentryconfig/config.go
@@ -48,7 +48,15 @@ func (d *Direction) UnmarshalYAML(value *yaml.Node) error {
 		return err
 	}
 	switch s {
-	case "", "outgoing":
+	case "":
+		// A written-but-empty `direction: ""` (or a bare `direction:`) is NOT
+		// the same as an absent key. Absent means "infer from the metamodel";
+		// collapsing an empty value to outgoing here would let a config walk
+		// straight past the ambiguity check that makes a self-referencing
+		// relation an error. Leave it empty so the single inference rule in
+		// InferDirection owns the decision.
+		*d = ""
+	case "outgoing":
 		*d = DirectionOutgoing
 	case "incoming":
 		*d = DirectionIncoming

--- a/internal/dataentryconfig/config_test.go
+++ b/internal/dataentryconfig/config_test.go
@@ -230,9 +230,18 @@ func TestDirection_UnmarshalYAML(t *testing.T) {
 		wantErr string
 	}{
 		{
-			name: "empty defaults to outgoing",
+			// A written-but-empty value must stay empty, NOT collapse to
+			// outgoing: empty means "infer from the metamodel", and collapsing
+			// it here would let `direction: ""` bypass the ambiguity check on
+			// a self-referencing relation.
+			name: "empty stays empty so inference owns the decision",
 			yaml: `direction: ""`,
-			want: DirectionOutgoing,
+			want: "",
+		},
+		{
+			name: "bare key stays empty",
+			yaml: `direction:`,
+			want: "",
 		},
 		{
 			name: "outgoing",

--- a/internal/dataentryconfig/direction.go
+++ b/internal/dataentryconfig/direction.go
@@ -1,0 +1,75 @@
+package dataentryconfig
+
+import (
+	"slices"
+
+	"github.com/Sourcehaven-BV/rela/internal/metamodel"
+)
+
+// DirectionResolution reports the outcome of inferring a relation binding's
+// direction from the metamodel.
+type DirectionResolution int
+
+const (
+	// DirectionResolved means the form's entity type sits on exactly one side
+	// of the relation, so the direction has a single correct answer.
+	DirectionResolved DirectionResolution = iota
+	// DirectionAmbiguous means the entity type sits on BOTH sides (a
+	// self-referencing relation such as `depends-on` from ticket to ticket).
+	// Outgoing and incoming are both meaningful and mean opposite things, so
+	// the author must say which one they meant.
+	DirectionAmbiguous
+	// DirectionNoSide means the entity type is on neither side. The binding is
+	// wrong regardless of direction; validateFormRelationSide reports it with
+	// the valid types.
+	DirectionNoSide
+	// DirectionUnknown means inference could not run at all: no metamodel, no
+	// entity type, or a relation name absent from the metamodel. This is
+	// deliberately distinct from DirectionNoSide — that one is a statement
+	// ABOUT the relation, this one means we never got to look. A caller that
+	// treats them alike will silently ship a default for a config it simply
+	// failed to read.
+	DirectionUnknown
+)
+
+// InferDirection resolves the direction of a relation binding authored without
+// an explicit `direction:` key.
+//
+// Direction used to default to outgoing when absent, which is wrong in two
+// different ways. On a `to`-side binding it silently bound the wrong side, and
+// on a self-referencing relation it silently picked one of two equally valid
+// readings. Inference removes the first case (there is only one right answer,
+// so making the author write it adds nothing) and DirectionAmbiguous surfaces
+// the second as an error rather than a guess.
+//
+// entityType is the form's entity type. A caller that does not know it (a
+// metamodel-less migration pass) cannot infer and should not try.
+//
+// NOTE: internal/migration mirrors this truth table in
+// FormRelationDirectionMigration.inferDirection. It cannot call this function —
+// it walks yaml.Node against the narrower MetamodelProvider rather than a
+// *metamodel.Metamodel — so the two must be changed in lockstep. If you add a
+// resolution case here, add it there.
+func InferDirection(
+	entityType, relation string, meta *metamodel.Metamodel,
+) (Direction, DirectionResolution) {
+	if meta == nil || entityType == "" || relation == "" {
+		return DirectionOutgoing, DirectionUnknown
+	}
+	def, ok := meta.GetRelationDef(relation)
+	if !ok {
+		return DirectionOutgoing, DirectionUnknown
+	}
+	inFrom := slices.Contains(def.From, entityType)
+	inTo := slices.Contains(def.To, entityType)
+	switch {
+	case inFrom && inTo:
+		return DirectionOutgoing, DirectionAmbiguous
+	case inFrom:
+		return DirectionOutgoing, DirectionResolved
+	case inTo:
+		return DirectionIncoming, DirectionResolved
+	default:
+		return DirectionOutgoing, DirectionNoSide
+	}
+}

--- a/internal/dataentryconfig/validate.go
+++ b/internal/dataentryconfig/validate.go
@@ -460,11 +460,29 @@ func validateFormRelation(
 	relDef, ok := meta.GetRelationDef(r.Relation)
 	switch {
 	case ok:
+		// An absent `direction:` is inferred from the metamodel when the form's
+		// entity type sits on exactly one side. When it sits on BOTH (a
+		// self-referencing relation like `depends-on`), outgoing and incoming
+		// are both meaningful and mean opposite things, so the author must say
+		// which — there is no safe default to fall back on.
+		_, res := InferDirection(entityType, r.Relation, meta)
+		ambiguous := r.Direction == "" && res == DirectionAmbiguous
+		if ambiguous {
+			errs = append(errs, fmt.Sprintf(
+				"form %q: %srelation[%d] needs an explicit `direction:` — entity type %q is both a from "+
+					"and a to of relation %q, so outgoing and incoming are both valid and mean "+
+					"opposite things (set `direction: outgoing` or `direction: incoming`)",
+				formID, ctx, i, entityType, r.Relation))
+		}
 		// Canonical name resolved — check that the form's entity type is on
 		// the correct side of the edge for the chosen direction. Wrong-side
 		// configs are silently broken otherwise: the widget searches the wrong
-		// target type and never shows existing edges.
-		errs = append(errs, validateFormRelationSide(formID, i, entityType, r, relDef)...)
+		// target type and never shows existing edges. Skipped when ambiguous:
+		// without a direction there is no side to check against, and the error
+		// above is the actionable one.
+		if !ambiguous {
+			errs = append(errs, validateFormRelationSide(formID, i, entityType, r, relDef, meta)...)
+		}
 	default:
 		if canonical, isInverse := meta.InverseOwner(r.Relation); isInverse {
 			errs = append(errs, fmt.Sprintf(
@@ -495,20 +513,33 @@ func validateFormRelation(
 // validateFormRelationSide checks that the form's entity type sits on
 // the side of the relation that matches the chosen direction. An
 // outgoing relation must be authored from a `From:` type; an incoming
-// one must be authored from a `To:` type. Mismatch returns an error;
-// when the entity is on the opposite side the message hints at
-// flipping the direction.
+// one must be authored from a `To:` type.
+//
+// The direction it checks against comes from InferDirection — the single
+// shared rule — so an absent key resolves the same way here as it does in the
+// server's config handler and the migration. Do not re-derive the side test
+// locally: a second copy that drifts silently binds the wrong side, which is
+// the exact bug class this file exists to prevent.
+//
+// When the author wrote an explicit direction and picked the wrong one, the
+// message hints at flipping it. (For an ABSENT direction no hint is possible:
+// inference already resolved it to whichever side the entity type is on, so a
+// wrong-side error there means the type is on neither side and flipping would
+// not help.)
 func validateFormRelationSide(
-	formID string, i int, entityType string, r FormRelation, relDef *metamodel.RelationDef,
+	formID string, i int, entityType string, r FormRelation, relDef *metamodel.RelationDef, meta *metamodel.Metamodel,
 ) []string {
 	if entityType == "" {
 		return nil
 	}
-	incoming := r.Direction.IsIncoming()
+	dir := r.Direction
+	if dir == "" {
+		dir, _ = InferDirection(entityType, r.Relation, meta)
+	}
 	expected, opposite := relDef.From, relDef.To
 	expectedSide, oppositeSide := "from", "to"
 	flipDir := DirectionIncoming
-	if incoming {
+	if dir.IsIncoming() {
 		expected, opposite = relDef.To, relDef.From
 		expectedSide, oppositeSide = "to", "from"
 		flipDir = DirectionOutgoing
@@ -517,7 +548,7 @@ func validateFormRelationSide(
 		return nil
 	}
 	hint := ""
-	if r.Direction == "" && slices.Contains(opposite, entityType) {
+	if r.Direction != "" && slices.Contains(opposite, entityType) {
 		hint = fmt.Sprintf(" (set `direction: %s` to bind the %s side of %q)", flipDir, oppositeSide, r.Relation)
 	}
 	return []string{fmt.Sprintf(

--- a/internal/dataentryconfig/validate_test.go
+++ b/internal/dataentryconfig/validate_test.go
@@ -467,6 +467,10 @@ relations:
     label: multi source
     from: [from_entity, other_entity]
     to: [to_entity]
+  depends_on:
+    label: depends on
+    from: [from_entity]
+    to: [from_entity]
 `
 	m, err := metamodel.Parse([]byte(yaml))
 	if err != nil {
@@ -504,10 +508,11 @@ func TestValidateConfig_FormRelationInverseName(t *testing.T) {
 	}
 }
 
-func TestValidateConfig_FormRelationWrongSide_HintsIncoming(t *testing.T) {
+func TestValidateConfig_FormRelationToSide_InfersIncoming(t *testing.T) {
 	meta := inverseTestMetamodel(t)
-	// to_entity is on the TO side of connects_to; the default outgoing
-	// direction makes this form silently broken.
+	// to_entity is ONLY on the TO side of connects_to, so an absent direction
+	// has exactly one correct answer and is inferred as incoming rather than
+	// defaulting to outgoing and being reported as wrong-side.
 	cfg := &Config{
 		Forms: map[string]Form{
 			"edit_to": {
@@ -517,27 +522,17 @@ func TestValidateConfig_FormRelationWrongSide_HintsIncoming(t *testing.T) {
 		},
 	}
 
-	err := ValidateConfig([]byte(`version: "1.0"`), cfg, meta)
-	if err == nil {
-		t.Fatal("expected error for form entity not on the source side of an outgoing relation")
-	}
-	msg := err.Error()
-	if !strings.Contains(msg, `"to_entity"`) {
-		t.Errorf("expected error to mention form entity type, got: %v", err)
-	}
-	if !strings.Contains(msg, `"connects_to"`) {
-		t.Errorf("expected error to mention the relation, got: %v", err)
-	}
-	if !strings.Contains(msg, "direction: incoming") {
-		t.Errorf("expected hint to set direction: incoming, got: %v", err)
+	if err := ValidateConfig([]byte(`version: "1.0"`), cfg, meta); err != nil {
+		t.Fatalf("expected an unambiguous to-side binding to infer incoming, got: %v", err)
 	}
 }
 
-func TestValidateConfig_FormRelationWrongSide_NoHintWhenDirectionExplicit(t *testing.T) {
+func TestValidateConfig_FormRelationWrongSide_HintsWhenDirectionExplicit(t *testing.T) {
 	meta := inverseTestMetamodel(t)
-	// Explicit outgoing with form entity on the wrong side — flipping the
-	// direction would help, but the user has explicitly chosen outgoing,
-	// so we error without a "did you mean" hint.
+	// Explicit outgoing with the form entity on the TO side. The author wrote a
+	// direction and picked the wrong one, so flipping it is the actionable fix
+	// and the message says so. (An ABSENT direction cannot reach here for this
+	// shape — inference would have resolved it to incoming.)
 	cfg := &Config{
 		Forms: map[string]Form{
 			"edit_to": {
@@ -551,8 +546,12 @@ func TestValidateConfig_FormRelationWrongSide_NoHintWhenDirectionExplicit(t *tes
 	if err == nil {
 		t.Fatal("expected error for form entity not on the source side")
 	}
-	if !strings.Contains(err.Error(), `"to_entity"`) {
+	msg := err.Error()
+	if !strings.Contains(msg, `"to_entity"`) {
 		t.Errorf("expected error to mention form entity type, got: %v", err)
+	}
+	if !strings.Contains(msg, "direction: incoming") {
+		t.Errorf("expected hint to suggest flipping to incoming, got: %v", err)
 	}
 }
 
@@ -2680,4 +2679,90 @@ func TestValidateDocuments_LegacyIDPlaceholderRejected(t *testing.T) {
 			t.Errorf("arg %q: error should name {in} as the replacement, got: %s", arg, err.Error())
 		}
 	}
+}
+
+// TestValidateConfig_FormRelationSelfReferencing_RequiresDirection pins the one
+// case inference cannot resolve: when the form's entity type is BOTH the from
+// and the to of the relation, outgoing and incoming are equally valid and mean
+// opposite things. Guessing would silently pick one reading, so the author must
+// say which.
+func TestValidateConfig_FormRelationSelfReferencing_RequiresDirection(t *testing.T) {
+	meta := inverseTestMetamodel(t)
+	cfg := &Config{
+		Forms: map[string]Form{
+			"edit_from": {
+				EntityType: "from_entity",
+				Relations:  []FormRelation{{Relation: "depends_on"}},
+			},
+		},
+	}
+
+	err := ValidateConfig([]byte(`version: "1.0"`), cfg, meta)
+	if err == nil {
+		t.Fatal("expected an error for a self-referencing relation with no explicit direction")
+	}
+	msg := err.Error()
+	for _, want := range []string{"depends_on", "from_entity", "direction"} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("expected error to mention %q, got: %v", want, err)
+		}
+	}
+}
+
+// An explicit direction resolves the ambiguity either way.
+func TestValidateConfig_FormRelationSelfReferencing_ExplicitDirectionOK(t *testing.T) {
+	meta := inverseTestMetamodel(t)
+	for _, dir := range []Direction{DirectionOutgoing, DirectionIncoming} {
+		t.Run(string(dir), func(t *testing.T) {
+			cfg := &Config{
+				Forms: map[string]Form{
+					"edit_from": {
+						EntityType: "from_entity",
+						Relations:  []FormRelation{{Relation: "depends_on", Direction: dir}},
+					},
+				},
+			}
+			if err := ValidateConfig([]byte(`version: "1.0"`), cfg, meta); err != nil {
+				t.Errorf("explicit direction %q should validate, got: %v", dir, err)
+			}
+		})
+	}
+}
+
+// TestValidateConfig_EmptyDirectionStringIsNotOutgoing pins the fix for a hole
+// in the ambiguity check: `direction: ""` (written but empty, as a templating
+// system or config generator emits) used to unmarshal to "outgoing" and so
+// walked straight past the self-referencing check that is the whole point of
+// requiring an explicit direction. An empty value must be treated the same as
+// an absent key — inferred, and rejected when ambiguous.
+func TestValidateConfig_EmptyDirectionStringIsNotOutgoing(t *testing.T) {
+	meta := inverseTestMetamodel(t)
+
+	t.Run("ambiguous relation still errors", func(t *testing.T) {
+		cfg := &Config{
+			Forms: map[string]Form{
+				"edit_from": {
+					EntityType: "from_entity",
+					Relations:  []FormRelation{{Relation: "depends_on", Direction: ""}},
+				},
+			},
+		}
+		if err := ValidateConfig([]byte(`version: "1.0"`), cfg, meta); err == nil {
+			t.Fatal("empty direction must not bypass the self-referencing check")
+		}
+	})
+
+	t.Run("to-side binding still infers incoming", func(t *testing.T) {
+		cfg := &Config{
+			Forms: map[string]Form{
+				"edit_to": {
+					EntityType: "to_entity",
+					Relations:  []FormRelation{{Relation: "connects_to", Direction: ""}},
+				},
+			},
+		}
+		if err := ValidateConfig([]byte(`version: "1.0"`), cfg, meta); err != nil {
+			t.Fatalf("empty direction should infer incoming on a to-side binding, got: %v", err)
+		}
+	})
 }

--- a/internal/migration/dataentry_cleanup.go
+++ b/internal/migration/dataentry_cleanup.go
@@ -16,7 +16,6 @@ func init() {
 //   - widget matching the type→widget mapping
 //   - required matching metamodel property
 //   - default matching metamodel/type default
-//   - direction when unambiguous from metamodel
 //   - target_type when single target in metamodel
 //   - relation label matching the metamodel relation label
 //
@@ -28,6 +27,15 @@ func init() {
 // convention-grounded removal depending on a client re-implementing an English
 // title-casing transform, which silently downgraded labels to raw identifiers.
 // See DEC-6C1NAA: a label is authored, never derived.
+//
+// It likewise does NOT remove `direction`, even when the form's entity type sits
+// on only one side of the relation. That removal looked metamodel-grounded but
+// failed the re-derivation test: nothing infers direction back. An absent
+// `direction` is parsed as `outgoing` (Direction.UnmarshalYAML maps "" and
+// "outgoing" to the same value) and the SPA widgets test `direction === 'incoming'`
+// literally. So stripping `direction: incoming` from a to-side binding both flips
+// the widget to the wrong side and makes ValidateConfig reject the file the
+// migration just wrote — leaving a project that no longer starts.
 type DataEntryCleanupMigration struct {
 	meta MetamodelProvider
 }
@@ -128,7 +136,6 @@ func (m *DataEntryCleanupMigration) isRedundantField(node *yaml.Node, entityType
 func (m *DataEntryCleanupMigration) isRedundantRelation(node *yaml.Node, entityType string) bool {
 	return m.isRedundantRelationWidget(node) ||
 		m.isRedundantRelationLabel(node) ||
-		m.isRedundantDirection(node, entityType) ||
 		m.isRedundantTargetType(node, entityType)
 }
 
@@ -225,38 +232,6 @@ func (m *DataEntryCleanupMigration) isRedundantRelationLabel(node *yaml.Node) bo
 
 	relLabel := m.meta.GetRelationLabel(rel)
 	return relLabel != "" && label == relLabel
-}
-
-// isRedundantDirection checks if direction can be inferred from metamodel.
-func (m *DataEntryCleanupMigration) isRedundantDirection(node *yaml.Node, entityType string) bool {
-	if m.meta == nil || entityType == "" {
-		return false
-	}
-
-	rel := getScalarValue(node, "relation")
-	direction := getScalarValue(node, "direction")
-	if rel == "" || direction == "" {
-		return false
-	}
-
-	fromTypes := m.meta.GetRelationFrom(rel)
-	toTypes := m.meta.GetRelationTo(rel)
-	if len(fromTypes) == 0 && len(toTypes) == 0 {
-		return false
-	}
-
-	inFrom := containsStr(fromTypes, entityType)
-	inTo := containsStr(toTypes, entityType)
-
-	// Direction is redundant if it can be unambiguously inferred
-	if inFrom && !inTo && direction == "outgoing" {
-		return true
-	}
-	if inTo && !inFrom && direction == "incoming" {
-		return true
-	}
-
-	return false
 }
 
 // isRedundantTargetType checks if target_type can be inferred from metamodel.
@@ -364,9 +339,6 @@ func (m *DataEntryCleanupMigration) cleanupFormRelations(formDef *yaml.Node, ent
 		}
 		if m.isRedundantRelationLabel(rel) {
 			DeleteMapKey(rel, "label")
-		}
-		if m.isRedundantDirection(rel, entityType) {
-			DeleteMapKey(rel, "direction")
 		}
 		if m.isRedundantTargetType(rel, entityType) {
 			DeleteMapKey(rel, "target_type")

--- a/internal/migration/dataentry_cleanup_test.go
+++ b/internal/migration/dataentry_cleanup_test.go
@@ -334,7 +334,9 @@ forms:
 			expect: true,
 		},
 		{
-			name: "detects redundant direction when unambiguous",
+			// direction is never stripped now (it is not re-derivable —
+			// see the migration doc comment), so it alone is not a trigger.
+			name: "does not detect direction alone",
 			yaml: `
 forms:
   create_ticket:
@@ -343,7 +345,7 @@ forms:
       - relation: belongs-to
         direction: outgoing
 `,
-			expect: true,
+			expect: false,
 		},
 		{
 			name: "detects redundant target_type when single target",
@@ -605,7 +607,7 @@ forms:
 			wantKeep:   []string{"property: priority"},
 		},
 		{
-			name: "removes redundant direction and target_type",
+			name: "removes redundant target_type but keeps direction",
 			input: `
 forms:
   create_ticket:
@@ -616,8 +618,8 @@ forms:
         target_type: category
         required: true
 `,
-			wantAbsent: []string{"direction: outgoing", "target_type: category"},
-			wantKeep:   []string{"relation: belongs-to", "required: true"},
+			wantAbsent: []string{"target_type: category"},
+			wantKeep:   []string{"relation: belongs-to", "required: true", "direction: outgoing"},
 		},
 		{
 			name: "removes redundant relation label",
@@ -856,5 +858,60 @@ func TestResolveWidgetFromType(t *testing.T) {
 				t.Errorf("ResolveWidgetFromType(%q) = %q, want %q", tt.propType, got, tt.want)
 			}
 		})
+	}
+}
+
+// TestDataEntryCleanupMigration_PreservesIncomingDirection pins the fix for the
+// migrate/validate contradiction: the cleanup migration used to strip
+// `direction: incoming` from a form whose entity type sits only on the relation's
+// `to` side, reasoning that it was inferable. Nothing infers it back — an absent
+// direction parses as `outgoing` — so the migration rewrote a valid config into
+// one that ValidateConfig rejects, and re-running migrate reported "No migrations
+// needed" rather than repairing it.
+func TestDataEntryCleanupMigration_PreservesIncomingDirection(t *testing.T) {
+	meta := &mockMetamodel{
+		entities: map[string]mockEntityDef{
+			"category": {properties: map[string]mockPropertyDef{
+				"title": {propType: "string"},
+			}},
+		},
+		relations: map[string]mockRelationDef{
+			// A category is only ever the TO side of belongs-to.
+			"belongs-to": {label: "belongs to", from: []string{"ticket"}, to: []string{"category"}},
+		},
+	}
+
+	input := `
+forms:
+  edit_category:
+    entity_type: category
+    relations:
+      - relation: belongs-to
+        direction: incoming
+        widget: cards
+`
+
+	m := &DataEntryCleanupMigration{}
+	m.SetMetamodel(meta)
+
+	var doc yaml.Node
+	if err := yaml.Unmarshal([]byte(input), &doc); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	if m.Detect(&doc) {
+		t.Error("Detect() = true, want false: direction: incoming is not redundant")
+	}
+
+	if err := m.Apply(&doc); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	out, err := yaml.Marshal(&doc)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if !strings.Contains(string(out), "direction: incoming") {
+		t.Errorf("migration stripped direction: incoming; the form would bind the wrong side "+
+			"and the config would no longer validate.\ngot:\n%s", out)
 	}
 }

--- a/internal/migration/form_relation_direction.go
+++ b/internal/migration/form_relation_direction.go
@@ -1,0 +1,161 @@
+package migration
+
+import (
+	"slices"
+
+	"gopkg.in/yaml.v3"
+)
+
+func init() {
+	Register(&FormRelationDirectionMigration{})
+}
+
+// FormRelationDirectionMigration writes an explicit `direction:` onto form
+// relation bindings that omit one, so the key stops being implicit.
+//
+// `direction` used to default to outgoing when absent. That default was wrong
+// in two different ways. On a `to`-side binding it silently bound the wrong
+// side of the edge (the widget searched the wrong entity type and never showed
+// existing edges). On a self-referencing relation — the form's entity type is
+// BOTH the from and the to, e.g. `depends-on` from ticket to ticket — it
+// silently picked one of two equally valid, opposite readings.
+//
+// This migration fills in only the unambiguous half: bindings whose entity type
+// sits on exactly ONE side, where there is a single correct answer. The
+// self-referencing case is deliberately LEFT ALONE — the migration cannot know
+// which reading the author meant, and writing a guess would cement it invisibly.
+// Those are reported by ValidateConfig instead, which names each offending form
+// and relation so a human can decide. That is why `rela migrate` is not always
+// sufficient to make a project load: it is the easy-mode upgrade for the cases
+// that have one right answer, not a rubber stamp over the ones that do not.
+type FormRelationDirectionMigration struct {
+	meta MetamodelProvider
+}
+
+// SetMetamodel implements MetamodelAware.
+func (m *FormRelationDirectionMigration) SetMetamodel(meta MetamodelProvider) {
+	m.meta = meta
+}
+
+func (m *FormRelationDirectionMigration) Name() string {
+	return "form-relation-direction"
+}
+
+func (m *FormRelationDirectionMigration) Description() string {
+	return "Write explicit direction: on form relations that omit it"
+}
+
+func (m *FormRelationDirectionMigration) FileTypes() []FileType {
+	return []FileType{FileTypeDataEntry}
+}
+
+func (m *FormRelationDirectionMigration) Detect(doc *yaml.Node) bool {
+	return m.walk(doc, false)
+}
+
+func (m *FormRelationDirectionMigration) Apply(doc *yaml.Node) error {
+	m.walk(doc, true)
+	return nil
+}
+
+// walk visits every form relation binding. With apply=false it reports whether
+// any binding would change; with apply=true it writes the inferred directions.
+func (m *FormRelationDirectionMigration) walk(doc *yaml.Node, apply bool) bool {
+	if m.meta == nil {
+		return false // without a metamodel nothing can be inferred
+	}
+	root := GetDocumentRoot(doc)
+	if root == nil {
+		return false
+	}
+	forms := GetMapValue(root, "forms")
+	if forms == nil || forms.Kind != yaml.MappingNode {
+		return false
+	}
+
+	changed := false
+	for i := 1; i < len(forms.Content); i += 2 {
+		formDef := forms.Content[i]
+		if formDef.Kind != yaml.MappingNode {
+			continue
+		}
+		entityType := getScalarValue(formDef, "entity_type")
+		if entityType == "" {
+			continue
+		}
+		// Flat relation list, plus each wizard step's own list.
+		if m.walkRelations(GetMapValue(formDef, "relations"), entityType, apply) {
+			changed = true
+			if !apply {
+				return true
+			}
+		}
+		steps := GetMapValue(formDef, "steps")
+		if steps == nil || steps.Kind != yaml.SequenceNode {
+			continue
+		}
+		for _, step := range steps.Content {
+			if step.Kind != yaml.MappingNode {
+				continue
+			}
+			if m.walkRelations(GetMapValue(step, "relations"), entityType, apply) {
+				changed = true
+				if !apply {
+					return true
+				}
+			}
+		}
+	}
+	return changed
+}
+
+func (m *FormRelationDirectionMigration) walkRelations(relations *yaml.Node, entityType string, apply bool) bool {
+	if relations == nil || relations.Kind != yaml.SequenceNode {
+		return false
+	}
+	changed := false
+	for _, rel := range relations.Content {
+		if rel.Kind != yaml.MappingNode {
+			continue
+		}
+		dir, ok := m.inferDirection(rel, entityType)
+		if !ok {
+			continue
+		}
+		changed = true
+		if !apply {
+			return true
+		}
+		SetMapValue(rel, "direction", dir)
+	}
+	return changed
+}
+
+// inferDirection returns the direction to write for a binding, and whether it
+// should be written at all.
+//
+// This mirrors dataentryconfig.InferDirection and must stay in lockstep with
+// it. It cannot call that function directly: migrations walk yaml.Node against
+// the narrow MetamodelProvider interface, not a *metamodel.Metamodel. It reports false when the binding already has a
+// direction, names an unknown relation, or is ambiguous (entity type on both
+// sides) — the last of which is left for the author to resolve.
+func (m *FormRelationDirectionMigration) inferDirection(rel *yaml.Node, entityType string) (string, bool) {
+	relation := getScalarValue(rel, "relation")
+	if relation == "" || getScalarValue(rel, "direction") != "" {
+		return "", false
+	}
+	fromTypes := m.meta.GetRelationFrom(relation)
+	toTypes := m.meta.GetRelationTo(relation)
+	inFrom := slices.Contains(fromTypes, entityType)
+	inTo := slices.Contains(toTypes, entityType)
+	switch {
+	case inFrom && inTo:
+		return "", false // ambiguous: only the author knows which was meant
+	case inFrom:
+		return "outgoing", true
+	case inTo:
+		return "incoming", true
+	default:
+		return "", false // on neither side; a wrong-side error, not a default
+	}
+}

--- a/internal/migration/form_relation_direction_test.go
+++ b/internal/migration/form_relation_direction_test.go
@@ -1,0 +1,175 @@
+package migration
+
+import (
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func directionTestMetamodel() *mockMetamodel {
+	return &mockMetamodel{
+		relations: map[string]mockRelationDef{
+			// task is only ever the FROM; project only ever the TO.
+			"belongs-to": {label: "belongs to", from: []string{"task"}, to: []string{"project"}},
+			// self-referencing: task is on BOTH sides.
+			"depends-on": {label: "depends on", from: []string{"task"}, to: []string{"task"}},
+		},
+	}
+}
+
+func applyDirectionMigration(t *testing.T, input string) (string, bool) {
+	t.Helper()
+	m := &FormRelationDirectionMigration{}
+	m.SetMetamodel(directionTestMetamodel())
+
+	var doc yaml.Node
+	if err := yaml.Unmarshal([]byte(input), &doc); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	detected := m.Detect(&doc)
+	if err := m.Apply(&doc); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	out, err := yaml.Marshal(&doc)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	return string(out), detected
+}
+
+func TestFormRelationDirectionMigration(t *testing.T) {
+	tests := []struct {
+		name         string
+		input        string
+		wantDetect   bool
+		wantContains []string
+		wantAbsent   []string
+	}{
+		{
+			name: "from-side binding gains outgoing",
+			input: `
+forms:
+  edit_task:
+    entity_type: task
+    relations:
+      - relation: belongs-to
+`,
+			wantDetect:   true,
+			wantContains: []string{"direction: outgoing"},
+		},
+		{
+			name: "to-side binding gains incoming",
+			input: `
+forms:
+  edit_project:
+    entity_type: project
+    relations:
+      - relation: belongs-to
+`,
+			wantDetect:   true,
+			wantContains: []string{"direction: incoming"},
+		},
+		{
+			name: "self-referencing binding is left for the author",
+			input: `
+forms:
+  edit_task:
+    entity_type: task
+    relations:
+      - relation: depends-on
+`,
+			wantDetect: false,
+			wantAbsent: []string{"direction:"},
+		},
+		{
+			name: "explicit direction is preserved",
+			input: `
+forms:
+  edit_task:
+    entity_type: task
+    relations:
+      - relation: belongs-to
+        direction: incoming
+`,
+			wantDetect:   false,
+			wantContains: []string{"direction: incoming"},
+			wantAbsent:   []string{"direction: outgoing"},
+		},
+		{
+			name: "wizard step relations are migrated too",
+			input: `
+forms:
+  wizard_task:
+    entity_type: task
+    steps:
+      - title: Step one
+        relations:
+          - relation: belongs-to
+`,
+			wantDetect:   true,
+			wantContains: []string{"direction: outgoing"},
+		},
+		{
+			name: "unknown relation is left alone",
+			input: `
+forms:
+  edit_task:
+    entity_type: task
+    relations:
+      - relation: no-such-relation
+`,
+			wantDetect: false,
+			wantAbsent: []string{"direction:"},
+		},
+		{
+			name: "form without entity_type is left alone",
+			input: `
+forms:
+  edit_task:
+    relations:
+      - relation: belongs-to
+`,
+			wantDetect: false,
+			wantAbsent: []string{"direction:"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			out, detected := applyDirectionMigration(t, tt.input)
+			if detected != tt.wantDetect {
+				t.Errorf("Detect() = %v, want %v", detected, tt.wantDetect)
+			}
+			for _, want := range tt.wantContains {
+				if !strings.Contains(out, want) {
+					t.Errorf("output should contain %q:\n%s", want, out)
+				}
+			}
+			for _, absent := range tt.wantAbsent {
+				if strings.Contains(out, absent) {
+					t.Errorf("output should not contain %q:\n%s", absent, out)
+				}
+			}
+		})
+	}
+}
+
+// Without a metamodel nothing is inferable, so the migration must be inert
+// rather than guessing.
+func TestFormRelationDirectionMigration_NoMetamodel(t *testing.T) {
+	m := &FormRelationDirectionMigration{}
+	var doc yaml.Node
+	if err := yaml.Unmarshal([]byte(`
+forms:
+  edit_task:
+    entity_type: task
+    relations:
+      - relation: belongs-to
+`), &doc); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if m.Detect(&doc) {
+		t.Error("Detect() = true without a metamodel, want false")
+	}
+}

--- a/internal/projectsetup/migrate_validate_roundtrip_test.go
+++ b/internal/projectsetup/migrate_validate_roundtrip_test.go
@@ -1,0 +1,119 @@
+package projectsetup_test
+
+import (
+	"bytes"
+	"path/filepath"
+	"testing"
+
+	"github.com/Sourcehaven-BV/rela/internal/projectsetup"
+	"github.com/Sourcehaven-BV/rela/internal/storage"
+)
+
+// TestMigrateThenValidate_RoundTrip asserts the general contract that `rela
+// migrate` must never rewrite a valid project into an invalid one.
+//
+// This is a guard for every migration, not just the one that motivated it: a
+// migration edits config, and `rela validate` (plus rela-server startup, which
+// runs the same dataentryconfig.ValidateConfig) decides whether that config is
+// loadable. Nothing structurally couples the two, so a migration can strip a key
+// the validator requires. That is exactly what the dataentry-cleanup migration
+// did to `direction: incoming` — and because migrate is idempotent, re-running
+// it reported "No migrations needed" instead of repairing the damage, leaving a
+// project that could not start.
+func TestMigrateThenValidate_RoundTrip(t *testing.T) {
+	// A to-side form binding: `category` is only ever the TO of belongs-to, so
+	// the binding needs an explicit `direction: incoming` to be valid.
+	const schema = `version: "1.0"
+namespace: "https://example.com/test#"
+entities:
+  ticket:
+    label: Ticket
+    id_prefix: TKT
+    id_type: manual
+    properties:
+      title:
+        type: string
+  category:
+    label: Category
+    id_prefix: CAT
+    id_type: manual
+    properties:
+      title:
+        type: string
+relations:
+  belongs-to:
+    label: belongs to
+    from: [ticket]
+    to: [category]
+`
+
+	const dataEntry = `forms:
+  edit_category:
+    entity_type: category
+    title: Edit category
+    fields:
+      - property: title
+    relations:
+      - relation: belongs-to
+        direction: incoming
+        widget: cards
+`
+
+	fs := storage.NewMemFS()
+	root := "/proj"
+	if _, err := projectsetup.InitializeWithFS(root, fs); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	if err := fs.WriteFile(filepath.Join(root, "schema.yaml"), []byte(schema), 0o644); err != nil {
+		t.Fatalf("write schema: %v", err)
+	}
+	if err := fs.WriteFile(filepath.Join(root, "data-entry.yaml"), []byte(dataEntry), 0o644); err != nil {
+		t.Fatalf("write data-entry: %v", err)
+	}
+
+	// Precondition: the project is valid before migrating. If this fails the
+	// test fixture is wrong, not the migration.
+	before, err := projectsetup.ValidateWithFS(root, fs)
+	if err != nil {
+		t.Fatalf("validate before: %v", err)
+	}
+	if before.HasErrors() {
+		t.Fatalf("fixture is not valid before migrate: metamodel=%v data-entry=%v",
+			before.MetamodelError, before.DataEntryError)
+	}
+
+	if _, migrateErr := projectsetup.MigrateWithFS(root, fs); migrateErr != nil {
+		t.Fatalf("migrate: %v", migrateErr)
+	}
+
+	after, err := projectsetup.ValidateWithFS(root, fs)
+	if err != nil {
+		t.Fatalf("validate after: %v", err)
+	}
+	if after.HasErrors() {
+		migrated, _ := fs.ReadFile(filepath.Join(root, "data-entry.yaml"))
+		t.Errorf("migrate turned a valid project into an invalid one.\n"+
+			"metamodel error: %v\ndata-entry error: %v\nmigrated data-entry.yaml:\n%s",
+			after.MetamodelError, after.DataEntryError, migrated)
+	}
+
+	// Idempotence. The original bug's worst property was not the corruption
+	// itself but that re-running the tool reported "No migrations needed" while
+	// leaving the damage — so a second pass must be a fixed point, for every
+	// registered migration, not just the one this fixture exercises.
+	firstPass, err := fs.ReadFile(filepath.Join(root, "data-entry.yaml"))
+	if err != nil {
+		t.Fatalf("read after first migrate: %v", err)
+	}
+	if _, secondErr := projectsetup.MigrateWithFS(root, fs); secondErr != nil {
+		t.Fatalf("second migrate: %v", secondErr)
+	}
+	secondPass, err := fs.ReadFile(filepath.Join(root, "data-entry.yaml"))
+	if err != nil {
+		t.Fatalf("read after second migrate: %v", err)
+	}
+	if !bytes.Equal(firstPass, secondPass) {
+		t.Errorf("migrate is not idempotent — a second pass changed the file.\nfirst:\n%s\nsecond:\n%s",
+			firstPass, secondPass)
+	}
+}

--- a/prototypes/data-entry/catalog/data-entry.yaml
+++ b/prototypes/data-entry/catalog/data-entry.yaml
@@ -39,9 +39,11 @@ forms:
       - property: featured
     relations:
       - relation: made-by
+        direction: outgoing
         label: "Brand"
         required: true
       - relation: tagged
+        direction: outgoing
         label: "Tags"
         widget: multi-select
   edit_product:
@@ -65,9 +67,11 @@ forms:
       - property: featured
     relations:
       - relation: made-by
+        direction: outgoing
         label: "Brand"
         required: true
       - relation: tagged
+        direction: outgoing
         label: "Tags"
         widget: multi-select
       - relation: accessory-for

--- a/prototypes/data-entry/project/data-entry.yaml
+++ b/prototypes/data-entry/project/data-entry.yaml
@@ -84,8 +84,10 @@ forms:
         hidden: true
     relations:
       - relation: belongs-to
+        direction: outgoing
         required: true
       - relation: tagged
+        direction: outgoing
         widget: multi-select
   edit_ticket:
     entity_type: ticket
@@ -125,8 +127,10 @@ forms:
       - property: is_blocked
     relations:
       - relation: belongs-to
+        direction: outgoing
         required: true
       - relation: tagged
+        direction: outgoing
         widget: cards
         properties:
           - property: added_by

--- a/tickets/data-entry.yaml
+++ b/tickets/data-entry.yaml
@@ -141,12 +141,15 @@ forms:
           rejected: [captured]
     relations:
       - relation: related-idea
+        direction: outgoing
         widget: multi-select
         label: "Related Ideas"
       - relation: inspires
+        direction: outgoing
         widget: multi-select
       - relation: promotes-to
         label: "Promoted To"
+        direction: outgoing
     side_panel:
       traverse:
         - from: entry
@@ -206,6 +209,7 @@ forms:
         label: "Elaborates Ideas"
         widget: multi-select
         required: true
+        direction: outgoing
   edit_future_concept:
     entity_type: future-concept
     title: "Edit Future Concept"
@@ -238,16 +242,21 @@ forms:
       - relation: elaborates
         label: "Elaborates Ideas"
         widget: multi-select
+        direction: outgoing
       - relation: extends-concept
         label: "Extends Concepts"
         widget: multi-select
+        direction: outgoing
       - relation: enables
         label: "Would Enable Features"
         widget: multi-select
+        direction: outgoing
       - relation: replaces
         label: "Would Replace"
         widget: multi-select
+        direction: outgoing
       - relation: blocked-by-concept
+        direction: outgoing
         label: "Blocked By"
         widget: multi-select
     side_panel:
@@ -309,6 +318,7 @@ forms:
       - relation: requires
         label: "Requires Concepts"
         widget: multi-select
+        direction: outgoing
   edit_feature:
     entity_type: feature
     title: "Edit Feature"
@@ -333,7 +343,9 @@ forms:
       - relation: requires
         label: "Requires Concepts"
         widget: multi-select
+        direction: outgoing
       - relation: refines
+        direction: outgoing
     side_panel:
       traverse:
         - from: entry
@@ -395,10 +407,12 @@ forms:
       - relation: implements
         label: "Implements Feature"
         required: true
+        direction: outgoing
       - relation: affects
         label: "Affects Concepts"
         widget: multi-select
         required: true
+        direction: outgoing
   edit_ticket:
     entity_type: ticket
     title: "Edit Ticket"
@@ -423,23 +437,30 @@ forms:
     relations:
       - relation: implements
         label: "Implements Feature"
+        direction: outgoing
       - relation: affects
         label: "Affects Concepts"
         widget: multi-select
+        direction: outgoing
       - relation: depends-on
+        direction: outgoing
         widget: multi-select
       - relation: has-planning
         label: "Planning Checklist"
         inline_create: create_planning_checklist
+        direction: outgoing
       - relation: has-implementation
         label: "Implementation Checklist"
         inline_create: create_implementation_checklist
+        direction: outgoing
       - relation: has-review
         label: "Review Checklist"
         inline_create: create_review_checklist
+        direction: outgoing
       - relation: has-docs
         label: "Docs Checklist"
         inline_create: create_docs_checklist
+        direction: outgoing
   # ─────────────────────────────────────────────────
   # Bugs
   # ─────────────────────────────────────────────────
@@ -460,9 +481,11 @@ forms:
       - relation: fixes
         label: "Fixes Feature"
         required: true
+        direction: outgoing
       - relation: affects
         label: "Affects Concepts"
         widget: multi-select
+        direction: outgoing
   edit_bug:
     entity_type: bug
     title: "Edit Bug"
@@ -510,22 +533,29 @@ forms:
     relations:
       - relation: fixes
         label: "Fixes Feature"
+        direction: outgoing
       - relation: affects
         label: "Affects Concepts"
         widget: multi-select
+        direction: outgoing
       - relation: caused-by
+        direction: outgoing
         widget: multi-select
       - relation: adds-measure
         widget: multi-select
+        direction: outgoing
       - relation: has-bug-analysis
         label: "Analysis Checklist"
         inline_create: create_bug_analysis_checklist
+        direction: outgoing
       - relation: has-implementation
         label: "Implementation Checklist"
         inline_create: create_implementation_checklist
+        direction: outgoing
       - relation: has-review
         label: "Review Checklist"
         inline_create: create_review_checklist
+        direction: outgoing
   # ─────────────────────────────────────────────────
   # Concepts
   # ─────────────────────────────────────────────────
@@ -566,6 +596,7 @@ forms:
           deprecated: [stable]
     relations:
       - relation: concept-depends-on
+        direction: outgoing
         label: "Depends On"
         widget: multi-select
   # ─────────────────────────────────────────────────
@@ -589,6 +620,7 @@ forms:
         label: "Decides Concepts"
         widget: multi-select
         required: true
+        direction: outgoing
   edit_decision:
     entity_type: decision
     title: "Edit Decision"
@@ -612,7 +644,9 @@ forms:
       - relation: decides
         label: "Decides Concepts"
         widget: multi-select
+        direction: outgoing
       - relation: supersedes
+        direction: outgoing
   # ─────────────────────────────────────────────────
   # Workflow Checklists
   # ─────────────────────────────────────────────────

--- a/tickets/entities/docs-checklists/DOCS-B5KK6J.md
+++ b/tickets/entities/docs-checklists/DOCS-B5KK6J.md
@@ -1,0 +1,44 @@
+---
+id: DOCS-B5KK6J
+type: docs-checklist
+title: 'Docs: Form relation direction inference + required direction for self-referencing relations'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Code Documentation
+
+- [x] Godoc on new exported symbols — `InferDirection` and `DirectionResolution`
+(`internal/dataentryconfig/direction.go`) document the rule and why the old
+default was unsafe
+- [x] Package/type docs updated — `FormRelationDirectionMigration` explains why
+it deliberately skips self-referencing bindings; `DataEntryCleanupMigration`
+records why `direction` is NOT re-derivable (unlike widget/target_type/label)
+- [x] `resolveFormRelations` documents why direction MUST be resolved
+server-side (the SPA tests `direction === 'incoming'` literally)
+
+## Project Documentation
+
+- [x] `docs/data-entry.md` — new "How `direction` is resolved" section under
+"Reverse (incoming) Relations", with the from/to/both table and an upgrade note
+pointing at `rela migrate`
+- [x] `direction` row in the form-relations field table updated to state that it
+is inferred when omitted and required for self-referencing relations
+- [x] ~~Architecture docs~~ (N/A: no package boundary or wiring change; the new
+`direction.go` sits inside the existing `dataentryconfig` package)
+
+## External Documentation
+
+- [x] ~~README~~ (N/A: no top-level feature or command added)
+- [x] ~~CHANGELOG~~ (N/A: project does not maintain one; the breaking change is
+documented in the docs upgrade note and the ticket)
+- [x] Migration path documented — `rela migrate` handles unambiguous bindings;
+`rela validate` lists the self-referencing ones the author must decide
+
+## Verification
+
+- [x] Docs examples match actual behavior (the from/to/both table mirrors
+`InferDirection`'s switch exactly)
+- [x] Upgrade note is accurate — verified end-to-end on `tickets/data-entry.yaml`
+(26 auto-filled, 8 listed for the author)

--- a/tickets/entities/implementation-checklists/IMPL-LU7OOK.md
+++ b/tickets/entities/implementation-checklists/IMPL-LU7OOK.md
@@ -1,0 +1,95 @@
+---
+id: IMPL-LU7OOK
+type: implementation-checklist
+title: 'Implementation: Form relation direction: infer from schema, require it when self-referencing (drop the implicit outgoing default)'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Development
+
+- [x] Unit tests written for new code
+- [x] Integration tests written (test full flow, not just units)
+- [x] Happy path implemented
+- [x] Edge cases from planning handled
+- [x] Error handling in place (errors surfaced, not swallowed)
+
+Files changed:
+
+| File | Change |
+| --- | --- |
+| `internal/dataentryconfig/direction.go` | NEW — `InferDirection`, the single shared rule (`Resolved`/`Ambiguous`/`NoSide`) |
+| `internal/dataentryconfig/validate.go` | Ambiguous bindings error; `validateFormRelationSide` uses the inferred direction |
+| `internal/dataentry/api_v1.go` | `resolveRelationWidgets` → `resolveFormRelations`, now also fills direction before serving |
+| `internal/migration/form_relation_direction.go` | NEW — writes explicit direction for unambiguous bindings (flat + wizard steps) |
+| `internal/migration/dataentry_cleanup.go` | Removed `isRedundantDirection` (the strip that started this) |
+| `internal/projectsetup/migrate_validate_roundtrip_test.go` | NEW — general migrate→validate guard |
+| `docs/data-entry.md` | "How `direction` is resolved" + upgrade note |
+| `tickets/`, `prototypes/*` data-entry.yaml | Migrated (26 auto + 8 hand-resolved in tickets/, 8 in prototypes) |
+
+## Test Quality
+
+- [x] Using fixture builders or factories for test data
+- [x] No hardcoded values in assertions when object is in scope
+- [x] Only specifying values that matter for the test
+- [x] Interpolated values constructed from objects, not hardcoded
+- [x] Property comparisons use original object, not hardcoded strings
+
+Table-driven subtests throughout, shared metamodel fixtures
+(`directionTestMetamodel`, `inverseTestMetamodel`).
+
+## Manual Verification
+
+- [x] Feature manually tested end-to-end
+- [x] Each acceptance criterion verified with test scenario from planning
+- [x] Edge cases manually verified
+
+**Verification Evidence:**
+
+Both new regression tests were confirmed to FAIL against the pre-fix code (via
+`git stash`) and pass after — they are real regression tests, not tautologies.
+
+End-to-end on a scratch project (task/project/self-referencing `depends-on`):
+
+```
+$ rela migrate
+  ✓ form-relation-direction: Write explicit direction: on form relations that omit it
+# from-side binding gained `direction: outgoing`
+# to-side binding gained `direction: incoming`
+# self-referencing `depends-on` left untouched
+
+$ rela validate
+  ✗ form "edit_task": relation[1] needs an explicit `direction:` — entity type
+    "task" is both a from and a to of relation "depends-on", so outgoing and
+    incoming are both valid and mean opposite things
+```
+
+On the real `tickets/data-entry.yaml`: 26 of 34 bindings auto-filled, 8
+self-referencing listed by form + relation. After hand-resolving those 8 to
+`outgoing` (preserving today's runtime behavior), the project validates clean
+and a second `rela migrate` reports "No migrations needed" (idempotent).
+
+AC verification:
+
+| AC | Result | Evidence |
+| --- | --- | --- |
+| 1. from-side infers outgoing | PASS | `TestResolveFormRelations_Direction/from-side...` |
+| 2. to-side infers incoming | PASS | `TestValidateConfig_FormRelationToSide_InfersIncoming`, `TestResolveFormRelations_Direction/to-side...` |
+| 3. self-referencing errors | PASS | `TestValidateConfig_FormRelationSelfReferencing_RequiresDirection` |
+| 4. explicit preserved | PASS | `..._ExplicitDirectionOK`, `TestFormRelationDirectionMigration/explicit_direction_is_preserved` |
+| 5. migrate fills unambiguous, skips ambiguous | PASS | `TestFormRelationDirectionMigration` (7 subtests incl. wizard steps) |
+| 6. migrate never invalidates | PASS | `TestMigrateThenValidate_RoundTrip` |
+| 7. cleanup no longer strips direction | PASS | `TestDataEntryCleanupMigration_PreservesIncomingDirection` |
+
+Pre-existing unrelated failure: `prototypes/data-entry/catalog` has an invalid
+widget `"search"`; confirmed present before this change via `git stash`.
+
+## Quality
+
+- [x] Code follows project patterns (check similar code)
+- [x] Checked for DRY opportunities — one `InferDirection` shared by validation,
+the server and the migration rather than three copies of the side-check
+- [x] No security issues introduced
+- [x] No silent failures (errors logged AND returned)
+- [x] No debug code left behind

--- a/tickets/entities/review-checklists/REV-AJYIJN.md
+++ b/tickets/entities/review-checklists/REV-AJYIJN.md
@@ -1,0 +1,100 @@
+---
+id: REV-AJYIJN
+type: review-checklist
+title: 'Review: Form relation direction: infer from schema, require it when self-referencing (drop the implicit outgoing default)'
+status: in-progress
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Automated Checks
+
+- [x] All tests pass (`go test ./internal/...` — full suite green)
+- [x] Lint clean (`golangci-lint run ./...` — 0 issues; `just arch-lint` — OK)
+- [x] Coverage maintained (`just coverage-check` — package floor 50% PASS,
+total floor 65% PASS, total 78.0%)
+
+Frontend unit tests were NOT run — `vitest` is not installed in this checkout.
+Mitigating: no frontend file was changed (`git status -- frontend/` is empty).
+The SPA's `direction === 'incoming'` check is unchanged by design; the server
+now guarantees a non-empty direction reaches it.
+
+## Code Review
+
+- [x] Run `/code-review` command (invokes cranky-code-reviewer agent)
+- [x] All critical review-responses addressed
+- [x] All significant review-responses addressed
+- [x] Self-reviewed the diff for unrelated changes
+
+**Review Responses:** RR-BL8OW8 (critical, addressed), RR-GJLLB6 (critical,
+addressed), RR-8KKIC8 (significant, addressed), RR-O22R9L (significant,
+addressed), RR-5NENZ3 (significant, addressed), RR-NRYAFC (significant, deferred
+→ TKT-E4I6NX).
+
+The review found a genuine hole in the headline feature: `direction: ""`
+unmarshalled to `"outgoing"` and walked straight past the ambiguity check. I
+reproduced it independently before accepting the finding. Fixed at the parser so
+an empty value stays empty and the single inference rule owns the decision.
+
+One finding was deferred with justification: the mutable-singleton migration
+registry (RR-NRYAFC) is a pre-existing pattern affecting every `MetamodelAware`
+migration, so it is filed as TKT-E4I6NX rather than widened into this ticket.
+
+Reviewer leverage suggestions taken: migrate idempotence assertion added to the
+round-trip test (the original bug's worst property was that re-running reported
+success while leaving damage). Not taken: fuzzing the round-trip invariant —
+worthwhile, but a separate piece of work.
+
+## Acceptance Verification
+
+- [x] Each acceptance criterion tested (reference planning checklist)
+- [x] Test evidence documented in implementation checklist
+
+**Acceptance Status:**
+
+| AC | Result | Evidence |
+| --- | --- | --- |
+| 1. from-side infers outgoing | PASS | `TestResolveFormRelations_Direction/from-side...` |
+| 2. to-side infers incoming | PASS | `TestValidateConfig_FormRelationToSide_InfersIncoming` + wire-level `TestResolveFormRelations_Direction/to-side...` |
+| 3. self-referencing errors | PASS | `TestValidateConfig_FormRelationSelfReferencing_RequiresDirection`; also holds for `direction: ""` (`..._EmptyDirectionStringIsNotOutgoing`) |
+| 4. explicit preserved | PASS | `..._ExplicitDirectionOK`, `TestFormRelationDirectionMigration/explicit_direction_is_preserved` |
+| 5. migrate fills unambiguous, skips ambiguous | PASS | `TestFormRelationDirectionMigration` (7 subtests incl. wizard steps) |
+| 6. migrate never invalidates | PASS | `TestMigrateThenValidate_RoundTrip` (+ idempotence) |
+| 7. cleanup no longer strips direction | PASS | `TestDataEntryCleanupMigration_PreservesIncomingDirection` |
+
+Real-config verification: `tickets/` and `prototypes/data-entry/project`
+validate clean. `prototypes/data-entry/catalog` fails on an invalid widget
+`"search"` — confirmed pre-existing via `git stash`, unrelated to this change.
+
+E2E fixture caught during review: `e2e/tests/fixtures.ts` had an ambiguous
+`tagged` (feature→feature) form binding that would have failed server startup
+and broken the whole e2e suite. Fixed to `direction: outgoing`, matching the
+seeded FEAT-001→FEAT-002 edge; the extracted fixture now validates clean.
+
+## Documentation (enhancements only)
+
+- [x] Docs-checklist created and linked via `has-docs`
+- [x] User-facing documentation updated
+- [x] Docs-checklist marked as done
+
+**Docs Checklist:** DOCS-B5KK6J
+
+## Final Checks
+
+- [x] Commit message explains the why, not just what
+- [x] No TODOs or FIXMEs left unaddressed
+- [x] Ready for another developer to use
+
+## Pull Request
+
+- [x] ~~Run `/pr` command to create PR and monitor CI~~ (N/A yet: nothing has
+been committed — the working tree holds the change and the user has not asked
+for a commit or PR)
+- [x] ~~All CI checks pass~~ (N/A yet: no PR; local equivalents all pass — see
+Automated Checks above)
+- [x] ~~PR URL documented below~~ (N/A yet: no PR)
+
+**PR:** not created. This checklist stays `in-progress` and the ticket stays in
+`review` until the change is committed and a PR is opened — the workflow's
+"cannot be merged" gate is doing its job here, since there is genuinely nothing
+merged yet.

--- a/tickets/entities/review-checklists/REV-AJYIJN.md
+++ b/tickets/entities/review-checklists/REV-AJYIJN.md
@@ -2,7 +2,7 @@
 id: REV-AJYIJN
 type: review-checklist
 title: 'Review: Form relation direction: infer from schema, require it when self-referencing (drop the implicit outgoing default)'
-status: in-progress
+status: done
 ---
 
 <!-- @managed: claude-workflow v1 -->
@@ -87,14 +87,12 @@ seeded FEAT-001→FEAT-002 edge; the extracted fixture now validates clean.
 
 ## Pull Request
 
-- [x] ~~Run `/pr` command to create PR and monitor CI~~ (N/A yet: nothing has
-been committed — the working tree holds the change and the user has not asked
-for a commit or PR)
-- [x] ~~All CI checks pass~~ (N/A yet: no PR; local equivalents all pass — see
-Automated Checks above)
-- [x] ~~PR URL documented below~~ (N/A yet: no PR)
+- [x] Run `/pr` command to create PR and monitor CI
+- [x] All CI checks pass
+- [x] PR URL documented below
 
-**PR:** not created. This checklist stays `in-progress` and the ticket stays in
-`review` until the change is committed and a PR is opened — the workflow's
-"cannot be merged" gate is doing its job here, since there is genuinely nothing
-merged yet.
+**PR:** https://github.com/sourcehaven-bv/rela/pull/1376
+
+CI on the PR covered the two gaps that could not be closed locally: **Frontend**
+passed (vitest is not installed in this checkout) and **E2E** exercised the
+`e2e/tests/fixtures.ts` `tagged` binding fix against a real server boot.

--- a/tickets/entities/review-responses/RR-5NENZ3.md
+++ b/tickets/entities/review-responses/RR-5NENZ3.md
@@ -1,0 +1,9 @@
+---
+id: RR-5NENZ3
+type: review-response
+title: Ambiguity error used break inside a switch to skip the side check
+finding: The ambiguous path appended its error then used `break` inside a switch inside an if, skipping validateFormRelationSide. Skipping is correct (without a direction there is no side to check), but `break` in that nesting is the construct that gets misread on the next edit — someone adds a statement after the if block expecting it to run.
+severity: significant
+resolution: 'Restructured to an explicit `ambiguous` boolean: the error is appended when ambiguous, and the side check is guarded on !ambiguous with a comment stating why it is skipped. No control-flow trickery, and the span/widget checks below still run in both cases.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-8KKIC8.md
+++ b/tickets/entities/review-responses/RR-8KKIC8.md
@@ -1,0 +1,9 @@
+---
+id: RR-8KKIC8
+type: review-response
+title: Wrong-side hint became unreachable dead code
+finding: 'The `(set direction: X to bind the Y side)` hint was gated on r.Direction == "" plus entityType in the opposite set — but once inference resolves an absent direction, that combination returns nil earlier, so the hint could never fire. The reviewer brute-forced every from/to/entityType combination to confirm unreachability. The test that used to cover it had been rewritten and no longer asserted the hint, so user-facing error text was unexecuted and untested.'
+severity: significant
+resolution: 'Inverted the gate to r.Direction != "": the hint now fires where it is genuinely actionable — the author wrote an explicit direction and picked the wrong one. For an absent direction no hint is possible (inference already resolved it, so a wrong-side error means the type is on neither side and flipping would not help); the godoc says so. TestValidateConfig_FormRelationWrongSide_HintsWhenDirectionExplicit now asserts the hint text.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-BL8OW8.md
+++ b/tickets/entities/review-responses/RR-BL8OW8.md
@@ -1,0 +1,9 @@
+---
+id: RR-BL8OW8
+type: review-response
+title: 'direction: "" bypasses the ambiguity check entirely'
+finding: 'Direction.UnmarshalYAML mapped the empty string to DirectionOutgoing (`case "", "outgoing"`). The whole change assumes "absent means empty in Go", which holds only for a MISSING key. A written-but-empty `direction: ""` unmarshalled to "outgoing" and so walked straight past the self-referencing ambiguity check — the entire point of the ticket. Confirmed against the real ValidateConfig: an ambiguous binding with direction: "" validated clean. Also, on a to-side binding, direction: "" produced a confusing wrong-side error instead of inferring incoming. This is not hypothetical: `direction: {{ .dir }}` with an unset variable, or any config generator, emits exactly this.'
+severity: critical
+resolution: 'Fixed in internal/dataentryconfig/config.go: UnmarshalYAML no longer collapses "" to outgoing — an empty value now stays empty so the single InferDirection rule owns the decision. Updated TestDirection_UnmarshalYAML (the case that pinned the old collapse) and added a bare-key case. New regression test TestValidateConfig_EmptyDirectionStringIsNotOutgoing covers both arms: ambiguous still errors, to-side still infers incoming.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-GJLLB6.md
+++ b/tickets/entities/review-responses/RR-GJLLB6.md
@@ -1,0 +1,9 @@
+---
+id: RR-GJLLB6
+type: review-response
+title: validateFormRelationSide re-implemented InferDirection inline
+finding: 'InferDirection was written and documented as "the single shared rule", but validateFormRelationSide kept a second copy of the same truth table inline (against relDef rather than meta). The two agreed today but would not stay agreeing: the next person adding a case changes one and misses the other, and the failure mode is silently binding the wrong side — exactly the bug class this ticket exists to prevent. You cannot claim a single shared rule and keep a second copy forty lines away.'
+severity: critical
+resolution: 'Fixed: validateFormRelationSide now takes *metamodel.Metamodel and calls InferDirection for an absent direction, so there is exactly one side-resolution rule in the package. Its godoc states the rule explicitly and warns against re-deriving it locally.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-NRYAFC.md
+++ b/tickets/entities/review-responses/RR-NRYAFC.md
@@ -1,0 +1,9 @@
+---
+id: RR-NRYAFC
+type: review-response
+title: Migration singletons carry mutable metamodel state in a global registry
+finding: Register(&FormRelationDirectionMigration{}) puts a single mutable instance in a package-level registry, and DetectFromNodeWithMetamodel mutates it via SetMetamodel on every call. Two projects migrated concurrently (or parallel tests) could infer against the wrong schema — and for this migration specifically, a stale m.meta writes WRONG DIRECTIONS into a user's config file. The race detector is on in CI, so it would surface eventually.
+severity: significant
+reason: 'Pre-existing pattern, not introduced here: DataEntryCleanupMigration and every other MetamodelAware migration share it, and fixing it means reworking the registry contract for all of them. Out of scope for this ticket, which is already a breaking change. Filed as follow-up TKT-E4I6NX so the specific new risk (a stale metamodel writing wrong directions into operator config, rather than merely a wrong detect) is recorded rather than lost.'
+status: deferred
+---

--- a/tickets/entities/review-responses/RR-O22R9L.md
+++ b/tickets/entities/review-responses/RR-O22R9L.md
@@ -1,0 +1,9 @@
+---
+id: RR-O22R9L
+type: review-response
+title: DirectionNoSide conflated bad inputs with a genuine wrong-side; api_v1 fallback laundered them all to outgoing
+finding: 'InferDirection returned DirectionNoSide for five distinct situations (nil metamodel, empty entityType, empty relation, unknown relation, genuine wrong-side) — three of which are not about sides at all. resolveFormRelations then funnelled every non-Resolved outcome into DirectionOutgoing via a bare else, with a comment asserting "both already reported by validation". That assertion is load-bearing and unenforced: s.Meta == nil would silently ship outgoing for every binding in the app, reintroducing the exact default the ticket removed, in the place furthest from the author''s eyes.'
+severity: significant
+resolution: 'Added DirectionUnknown as a distinct outcome (inference could not run: no metamodel/entity type/unknown relation) versus DirectionNoSide (a statement about the relation). resolveFormRelations now switches on the outcome explicitly, and logs a warning for DirectionAmbiguous — which should be unreachable because ValidateConfig rejects it at load, so reaching it means the gate was bypassed and that must be visible rather than silently resolved.'
+status: addressed
+---

--- a/tickets/entities/tickets/TKT-860BNJ.md
+++ b/tickets/entities/tickets/TKT-860BNJ.md
@@ -1,0 +1,93 @@
+---
+id: TKT-860BNJ
+type: ticket
+title: 'Form relation direction: infer from schema, require it when self-referencing (drop the implicit outgoing default)'
+kind: enhancement
+priority: high
+effort: m
+status: review
+---
+
+## Description
+
+An absent `direction:` on a form relation binding used to mean outgoing. That
+default was wrong in two ways: on a to-side binding it silently bound the wrong
+side of the edge, and on a self-referencing relation it silently picked one of
+two opposite readings. Replace it with metamodel inference (on exactly one side
+=> that direction) plus a hard error when the form's entity type is on BOTH
+sides. `rela migrate` writes the explicit direction for every unambiguous
+binding; the self-referencing ones are deliberately left for the author and
+listed by `rela validate`.
+
+## Background
+
+Found while investigating a bug report claiming `rela validate` passed on a
+config `rela-server` refused to start on. That claim did not reproduce — both
+paths call the same `dataentryconfig.ValidateConfig` — but the investigation
+surfaced two real defects.
+
+### Defect 1: migrate stripped `direction: incoming`
+
+`DataEntryCleanupMigration.isRedundantDirection` removed `direction` when the
+form's entity type sat on exactly one side, reasoning it was inferable. Nothing
+inferred it back: absent parsed as outgoing, and the SPA widgets test `direction
+=== 'incoming'` literally. So migrate rewrote a valid config into one
+`ValidateConfig` rejects, and re-running migrate reported "No migrations needed"
+rather than repairing it — leaving a project permanently unable to start.
+
+### Defect 2: the implicit outgoing default itself
+
+The deeper problem is that absent-means-outgoing is magical for relations. It is
+silently wrong on a to-side binding, and on a self-referencing relation
+(`depends-on` from ticket to ticket) outgoing and incoming are both valid and
+mean opposite things — so the default was guessing. On
+`tickets/data-entry.yaml`, 8 of 34 bindings hit that ambiguous case.
+
+## Approach
+
+Direction is resolved by which side the form's entity type sits on:
+
+| Entity type is | Result |
+| --- | --- |
+| the relation's `from` only | inferred `outgoing` |
+| the relation's `to` only | inferred `incoming` |
+| both (self-referencing) | error — author must choose |
+| neither | wrong-side error (unchanged) |
+
+`InferDirection` in `internal/dataentryconfig/direction.go` is the single shared
+rule, used by validation, the server's config handler, and the migration.
+
+Server-side resolution is load-bearing. `RelationCards.vue` and
+`RelationPicker.vue` both test `direction === 'incoming'` literally with no
+inference of their own, so `resolveFormRelations` (formerly
+`resolveRelationWidgets`) fills the direction in before serving config. Without
+it an inferred-incoming binding would validate clean and still render the wrong
+side in the browser.
+
+## Scope
+
+IN: form relations (`FormRelation`) — where a wrong side binds the wrong entity
+type on write.
+
+OUT: `ListColumn`, `FilterControl`, `KanbanCardField`, `CalDAVCollection` still
+default to outgoing. A wrong-side column renders an empty cell; a wrong-side
+form corrupts a write. Removing the default there is a possible follow-up.
+
+## Acceptance criteria
+
+1. A from-side binding with no `direction:` validates and serves `outgoing`.
+2. A to-side binding with no `direction:` validates and serves `incoming` (previously
+a wrong-side error).
+3. A self-referencing binding with no `direction:` is a validation error naming the
+form, entity type and relation.
+4. An explicit `direction:` is always preserved verbatim.
+5. `rela migrate` writes explicit directions for unambiguous bindings (flat and wizard
+steps) and leaves self-referencing ones untouched.
+6. `rela migrate` never rewrites a valid project into an invalid one.
+7. The cleanup migration no longer strips `direction`.
+
+## Breaking change
+
+Upgrading without running `rela migrate` fails startup for any config with a
+self-referencing form binding. The error names the form and relation; migrate
+handles everything else. Chosen deliberately over a staged rollout.

--- a/tickets/entities/tickets/TKT-860BNJ.md
+++ b/tickets/entities/tickets/TKT-860BNJ.md
@@ -5,7 +5,7 @@ title: 'Form relation direction: infer from schema, require it when self-referen
 kind: enhancement
 priority: high
 effort: m
-status: review
+status: done
 ---
 
 ## Description

--- a/tickets/entities/tickets/TKT-E4I6NX.md
+++ b/tickets/entities/tickets/TKT-E4I6NX.md
@@ -1,0 +1,48 @@
+---
+id: TKT-E4I6NX
+type: ticket
+title: Migration registry holds mutable singletons; SetMetamodel races across concurrent migrate runs
+kind: refactor
+priority: medium
+effort: s
+status: backlog
+---
+
+## Description
+
+`migration.Register` stores a **single mutable instance** of each migration in a
+package-level `registry` slice (`internal/migration/migration.go`). For
+`MetamodelAware` migrations the runner then mutates that shared instance via
+`SetMetamodel(meta)` on every call (`DetectFromNodeWithMetamodel`).
+
+Two projects migrated concurrently — or parallel tests — can therefore have one
+run's metamodel observed by another run's Detect/Apply.
+
+## Why it matters more now
+
+Until recently a stale `m.meta` meant a wrong *detect* (a key stripped or not).
+`FormRelationDirectionMigration` (TKT-860BNJ) raises the stakes: it **writes
+inferred directions into the user's data-entry.yaml**. Inferring against the
+wrong schema writes a wrong `direction:` into operator config — silently binding
+the wrong side of a relation, which is the exact failure class TKT-860BNJ exists
+to eliminate.
+
+The race detector is on in CI, so this surfaces eventually — but only if a test
+happens to migrate two projects concurrently, which none do today.
+
+## Approach sketch
+
+Registry should hold **constructors** (or the runner should clone before use) so
+each migrate run gets its own instance and metamodel. Alternatively pass the
+metamodel as a parameter to `Detect`/`Apply` rather than stashing it on the
+receiver — that removes the mutable state entirely and makes the interface
+honest about its inputs.
+
+The second is cleaner but touches every migration's signature; the first is
+mechanical. Worth deciding before the next metamodel-aware migration lands.
+
+## Source
+
+Raised as RR-NRYAFC during the TKT-860BNJ code review; deferred there as a
+pre-existing pattern affecting all `MetamodelAware` migrations, not a defect
+introduced by that ticket.

--- a/tickets/relations/TKT-860BNJ--affects--data-entry-ui.md
+++ b/tickets/relations/TKT-860BNJ--affects--data-entry-ui.md
@@ -1,0 +1,5 @@
+---
+from: TKT-860BNJ
+relation: affects
+to: data-entry-ui
+---

--- a/tickets/relations/TKT-860BNJ--has-docs--DOCS-B5KK6J.md
+++ b/tickets/relations/TKT-860BNJ--has-docs--DOCS-B5KK6J.md
@@ -1,0 +1,5 @@
+---
+from: TKT-860BNJ
+relation: has-docs
+to: DOCS-B5KK6J
+---

--- a/tickets/relations/TKT-860BNJ--has-implementation--IMPL-LU7OOK.md
+++ b/tickets/relations/TKT-860BNJ--has-implementation--IMPL-LU7OOK.md
@@ -1,0 +1,5 @@
+---
+from: TKT-860BNJ
+relation: has-implementation
+to: IMPL-LU7OOK
+---

--- a/tickets/relations/TKT-860BNJ--has-review--REV-AJYIJN.md
+++ b/tickets/relations/TKT-860BNJ--has-review--REV-AJYIJN.md
@@ -1,0 +1,5 @@
+---
+from: TKT-860BNJ
+relation: has-review
+to: REV-AJYIJN
+---

--- a/tickets/relations/TKT-860BNJ--has-review-response--RR-5NENZ3.md
+++ b/tickets/relations/TKT-860BNJ--has-review-response--RR-5NENZ3.md
@@ -1,0 +1,5 @@
+---
+from: TKT-860BNJ
+relation: has-review-response
+to: RR-5NENZ3
+---

--- a/tickets/relations/TKT-860BNJ--has-review-response--RR-8KKIC8.md
+++ b/tickets/relations/TKT-860BNJ--has-review-response--RR-8KKIC8.md
@@ -1,0 +1,5 @@
+---
+from: TKT-860BNJ
+relation: has-review-response
+to: RR-8KKIC8
+---

--- a/tickets/relations/TKT-860BNJ--has-review-response--RR-BL8OW8.md
+++ b/tickets/relations/TKT-860BNJ--has-review-response--RR-BL8OW8.md
@@ -1,0 +1,5 @@
+---
+from: TKT-860BNJ
+relation: has-review-response
+to: RR-BL8OW8
+---

--- a/tickets/relations/TKT-860BNJ--has-review-response--RR-GJLLB6.md
+++ b/tickets/relations/TKT-860BNJ--has-review-response--RR-GJLLB6.md
@@ -1,0 +1,5 @@
+---
+from: TKT-860BNJ
+relation: has-review-response
+to: RR-GJLLB6
+---

--- a/tickets/relations/TKT-860BNJ--has-review-response--RR-NRYAFC.md
+++ b/tickets/relations/TKT-860BNJ--has-review-response--RR-NRYAFC.md
@@ -1,0 +1,5 @@
+---
+from: TKT-860BNJ
+relation: has-review-response
+to: RR-NRYAFC
+---

--- a/tickets/relations/TKT-860BNJ--has-review-response--RR-O22R9L.md
+++ b/tickets/relations/TKT-860BNJ--has-review-response--RR-O22R9L.md
@@ -1,0 +1,5 @@
+---
+from: TKT-860BNJ
+relation: has-review-response
+to: RR-O22R9L
+---

--- a/tickets/relations/TKT-860BNJ--implements--FEAT-R7SOT.md
+++ b/tickets/relations/TKT-860BNJ--implements--FEAT-R7SOT.md
@@ -1,0 +1,5 @@
+---
+from: TKT-860BNJ
+relation: implements
+to: FEAT-R7SOT
+---

--- a/tickets/relations/TKT-E4I6NX--affects--data-entry-ui.md
+++ b/tickets/relations/TKT-E4I6NX--affects--data-entry-ui.md
@@ -1,0 +1,5 @@
+---
+from: TKT-E4I6NX
+relation: affects
+to: data-entry-ui
+---

--- a/tickets/relations/TKT-E4I6NX--implements--FEAT-R7SOT.md
+++ b/tickets/relations/TKT-E4I6NX--implements--FEAT-R7SOT.md
@@ -1,0 +1,5 @@
+---
+from: TKT-E4I6NX
+relation: implements
+to: FEAT-R7SOT
+---


### PR DESCRIPTION
## What

An absent `direction:` on a form relation binding used to mean outgoing. That default was silently wrong in two different ways:

- On a **to-side** binding it bound the wrong side of the edge — the widget searched the wrong entity type and never showed existing edges.
- On a **self-referencing** relation (`depends-on` from ticket to ticket) it picked one of two equally valid, opposite readings.

Direction is now resolved by which side the form's entity type sits on:

| Entity type is… | Result |
|---|---|
| the relation's `from` only | inferred `outgoing` |
| the relation's `to` only | inferred `incoming` |
| **both** (self-referencing) | **error** — author must choose |
| neither | wrong-side error (unchanged) |

`InferDirection` (`internal/dataentryconfig/direction.go`) is the single shared rule, used by validation, the server's config handler, and the migration.

**Server-side resolution is load-bearing.** `RelationCards.vue` and `RelationPicker.vue` both test `direction === 'incoming'` literally with no inference of their own, so `resolveFormRelations` fills the direction in before serving config. Without it an inferred-incoming binding would validate clean and still render the wrong side in the browser. The SPA is unchanged.

## Why it started

Investigating a bug report that `rela validate` passed on a config `rela-server` refused to start on. That claim did not reproduce — both paths call the same `ValidateConfig` — but it surfaced a real defect: `DataEntryCleanupMigration` was **stripping** `direction: incoming` from to-side bindings, rewriting valid configs into ones validation rejects. Re-running migrate then reported "No migrations needed" rather than repairing it, leaving a project permanently unable to start. That strip is removed here.

## Migration

`rela migrate` writes explicit directions for every unambiguous binding (flat and wizard-step). It deliberately **leaves self-referencing ones alone** — it cannot know which reading the author meant, and a guess would cement it invisibly. `rela validate` lists those by form and relation.

On `tickets/data-entry.yaml`: 26 of 34 auto-filled, 8 hand-resolved.

## Breaking change

Upgrading without running `rela migrate` fails startup for any config with a self-referencing form binding. The error names the form and relation; migrate handles everything else.

## Scope

**In:** form relations (`FormRelation`) — where a wrong side binds the wrong entity type on write.

**Out:** `ListColumn`, `FilterControl`, `KanbanCardField`, `CalDAVCollection` still default to outgoing. A wrong-side column renders an empty cell; a wrong-side form corrupts a write. Possible follow-up.

## Review

Reviewed by cranky-code-reviewer; 6 findings, 5 addressed, 1 deferred to TKT-E4I6NX (mutable migration singletons — a pre-existing pattern across all `MetamodelAware` migrations).

Two criticals worth calling out, both real:

1. **`direction: ""` bypassed the ambiguity check entirely.** `UnmarshalYAML` mapped the empty string to `"outgoing"`, so a written-but-empty value (what a config generator or an unset template variable emits) walked straight past the new check. Fixed at the parser — an empty value now stays empty so the single inference rule owns the decision.
2. **`validateFormRelationSide` re-implemented the inference inline**, despite `InferDirection` being documented as the one shared rule. Collapsed onto the shared function.

Also caught during review: `e2e/tests/fixtures.ts` had an ambiguous `tagged` (feature→feature) binding that would have failed startup and broken the whole e2e suite.

## Verification

- `go test ./internal/...` green · `golangci-lint run ./...` 0 issues · `just arch-lint` OK · coverage 78.0% (both floors pass)
- Both new regression tests confirmed to **fail against the pre-fix code** and pass after
- `TestMigrateThenValidate_RoundTrip` pins the general invariant (migrate never turns a valid project invalid) plus idempotence

Not run: frontend unit tests (`vitest` not installed locally) — no frontend file changed. Pre-existing unrelated failure: `prototypes/data-entry/catalog` has an invalid widget `"search"`, confirmed present before this change.