### PR TITLE
feat(dataentry): widget override for view section fields (TKT-3R7RF3)

### DIFF
--- a/docs-project/entities/guides/GUIDE-data-entry.md
+++ b/docs-project/entities/guides/GUIDE-data-entry.md
@@ -1261,11 +1261,107 @@ sections:
 | `heading`       | string | Section heading (optional; omit for no heading)         |
 | `source`        | string | `"entry"` or a traverse collection name                 |
 | `display`       | string | Display mode (see below)                                |
+| `render`        | string | `display` (default) or `input` — see Field Render Modes |
 | `fields`        | list   | Properties to show (`properties`, `content`, `cards`, `list` modes) |
 | `columns`       | list   | Column definitions (`table` mode)                       |
 | `group_by`      | string | Property to group entities by                           |
 | `empty_message` | string | Text shown when the collection is empty                 |
 | `link`          | bool   | Link entity titles to their detail pages                |
+
+Each entry under `fields:` takes:
+
+| Field      | Type   | Description                                                  |
+| ---------- | ------ | ------------------------------------------------------------ |
+| `property` | string | Property name                                                |
+| `label`    | string | Display label (defaults to the raw property name)            |
+| `span`     | int    | Width on the 12-column grid (1-12; omit for full width)      |
+| `render`   | string | `display` or `input`; overrides the section's `render`        |
+| `widget`   | string | Which widget renders this property (see Widget Overrides)    |
+
+### Field Render Modes
+
+A view section field renders as a **view-oriented display value** by default.
+Set `render: input` to opt a field into inline editing:
+
+```yaml
+sections:
+  - heading: "Properties"
+    source: entry
+    display: properties
+    render: input          # section-wide default for its fields
+    fields:
+      - property: status   # inherits `input`
+      - property: id
+        render: display    # ...but this one overrides back to display
+```
+
+| Value     | Effect                                                            |
+| --------- | ----------------------------------------------------------------- |
+| `display` | (default) A read-oriented value. Not a disabled input — no control |
+| `input`   | An editable widget that saves on change (auto-save)                |
+
+Resolution is field-first: a field's own `render:` wins, else the section's,
+else `display`. It is resolved server-side, so the value the SPA receives is
+already effective.
+
+> **Breaking change.** Before this, inline editing was implied by write
+> permission. Sections that want it must now say so with `render: input`.
+
+`render: input` **cannot grant editability.** Effective editability is
+`render: input` AND the ACL permitting the write, so `input` on a field the
+caller may not edit still renders as display. Config can only narrow.
+
+A field belonging to a state machine renders its transition control instead of
+an ordinary widget when `render: input`; on `render: display` it renders the
+plain value.
+
+### Widget Overrides
+
+By default the widget is chosen from the property's declared type — `boolean`
+gets a checkbox, `date` a date picker, an enum a dropdown. Set `widget:` to
+choose a different registered widget:
+
+```yaml
+fields:
+  - property: done
+    widget: checkbox     # the payoff case: click to tick, with render: input
+  - property: notes
+    widget: textarea     # a long string, not a single-line input
+```
+
+| Widget         | Accepts                       |
+| -------------- | ----------------------------- |
+| `text`         | string                        |
+| `textarea`     | string                        |
+| `number`       | integer                       |
+| `checkbox`     | boolean                       |
+| `date`         | date                          |
+| `datetime`     | datetime                      |
+| `select`       | enum, string, custom types    |
+| `multi-select` | enum, string (list values)    |
+| `rrule`        | rrule                         |
+| `file`         | file                          |
+
+Rules worth knowing:
+
+- **Field-level only.** There is no section-wide `widget:`, unlike `render:`.
+  A widget is inherently per-property: a section-level one would be a config
+  error on every field whose type didn't match, which the author would then
+  have to override back field by field.
+- **Omitting it changes nothing** — the type default applies exactly as before.
+- **A mismatch is a config-load error.** `widget: checkbox` on a `date`
+  property fails at startup, naming the property, its type, and what the widget
+  does accept.
+- **`widget: file` only works on `display: properties`.** Card and list rows
+  are not given attachment data, so a file widget there would have nothing to
+  show.
+- **It pairs with `render:`.** A checkbox you cannot click is just an icon, so
+  the interactive case needs `render: input` too.
+- **On a property the schema doesn't declare, the override is ignored** and a
+  warning is logged at startup. Such a field has no type to validate against.
+- **On a state-machine field with `render: input`**, the transition control
+  takes precedence and the widget is inert; with `render: display` the widget
+  is used.
 
 ### Display Modes
 

--- a/docs/data-entry.md
+++ b/docs/data-entry.md
@@ -1255,11 +1255,107 @@ sections:
 | `heading`       | string | Section heading (optional; omit for no heading)         |
 | `source`        | string | `"entry"` or a traverse collection name                 |
 | `display`       | string | Display mode (see below)                                |
+| `render`        | string | `display` (default) or `input` — see Field Render Modes |
 | `fields`        | list   | Properties to show (`properties`, `content`, `cards`, `list` modes) |
 | `columns`       | list   | Column definitions (`table` mode)                       |
 | `group_by`      | string | Property to group entities by                           |
 | `empty_message` | string | Text shown when the collection is empty                 |
 | `link`          | bool   | Link entity titles to their detail pages                |
+
+Each entry under `fields:` takes:
+
+| Field      | Type   | Description                                                  |
+| ---------- | ------ | ------------------------------------------------------------ |
+| `property` | string | Property name                                                |
+| `label`    | string | Display label (defaults to the raw property name)            |
+| `span`     | int    | Width on the 12-column grid (1-12; omit for full width)      |
+| `render`   | string | `display` or `input`; overrides the section's `render`        |
+| `widget`   | string | Which widget renders this property (see Widget Overrides)    |
+
+### Field Render Modes
+
+A view section field renders as a **view-oriented display value** by default.
+Set `render: input` to opt a field into inline editing:
+
+```yaml
+sections:
+  - heading: "Properties"
+    source: entry
+    display: properties
+    render: input          # section-wide default for its fields
+    fields:
+      - property: status   # inherits `input`
+      - property: id
+        render: display    # ...but this one overrides back to display
+```
+
+| Value     | Effect                                                            |
+| --------- | ----------------------------------------------------------------- |
+| `display` | (default) A read-oriented value. Not a disabled input — no control |
+| `input`   | An editable widget that saves on change (auto-save)                |
+
+Resolution is field-first: a field's own `render:` wins, else the section's,
+else `display`. It is resolved server-side, so the value the SPA receives is
+already effective.
+
+> **Breaking change.** Before this, inline editing was implied by write
+> permission. Sections that want it must now say so with `render: input`.
+
+`render: input` **cannot grant editability.** Effective editability is
+`render: input` AND the ACL permitting the write, so `input` on a field the
+caller may not edit still renders as display. Config can only narrow.
+
+A field belonging to a state machine renders its transition control instead of
+an ordinary widget when `render: input`; on `render: display` it renders the
+plain value.
+
+### Widget Overrides
+
+By default the widget is chosen from the property's declared type — `boolean`
+gets a checkbox, `date` a date picker, an enum a dropdown. Set `widget:` to
+choose a different registered widget:
+
+```yaml
+fields:
+  - property: done
+    widget: checkbox     # the payoff case: click to tick, with render: input
+  - property: notes
+    widget: textarea     # a long string, not a single-line input
+```
+
+| Widget         | Accepts                       |
+| -------------- | ----------------------------- |
+| `text`         | string                        |
+| `textarea`     | string                        |
+| `number`       | integer                       |
+| `checkbox`     | boolean                       |
+| `date`         | date                          |
+| `datetime`     | datetime                      |
+| `select`       | enum, string, custom types    |
+| `multi-select` | enum, string (list values)    |
+| `rrule`        | rrule                         |
+| `file`         | file                          |
+
+Rules worth knowing:
+
+- **Field-level only.** There is no section-wide `widget:`, unlike `render:`.
+  A widget is inherently per-property: a section-level one would be a config
+  error on every field whose type didn't match, which the author would then
+  have to override back field by field.
+- **Omitting it changes nothing** — the type default applies exactly as before.
+- **A mismatch is a config-load error.** `widget: checkbox` on a `date`
+  property fails at startup, naming the property, its type, and what the widget
+  does accept.
+- **`widget: file` only works on `display: properties`.** Card and list rows
+  are not given attachment data, so a file widget there would have nothing to
+  show.
+- **It pairs with `render:`.** A checkbox you cannot click is just an icon, so
+  the interactive case needs `render: input` too.
+- **On a property the schema doesn't declare, the override is ignored** and a
+  warning is logged at startup. Such a field has no type to validate against.
+- **On a state-machine field with `render: input`**, the transition control
+  takes precedence and the widget is inert; with `render: display` the widget
+  is used.
 
 ### Display Modes
 

--- a/e2e/pages/entity.page.ts
+++ b/e2e/pages/entity.page.ts
@@ -123,6 +123,72 @@ export class EntityPage extends BasePage {
     return this.page.locator('.properties-list').first();
   }
 
+  /** A detail-page section located by its heading, rather than by position.
+   *  The entry-section helpers above use `.first()`, which cannot address a
+   *  second properties section on the same page (TKT-3R7RF3 adds one). */
+  private sectionByHeading(heading: string) {
+    return this.page
+      .locator('.view-section', { has: this.page.getByRole('heading', { name: heading }) })
+      .first();
+  }
+
+  /** The edit control SectionEditForm renders for a property. Its id is
+   *  assigned by the form (`section-edit-<property>`), so this addresses the
+   *  widget's own element rather than a wrapper. */
+  private sectionFieldControl(heading: string, property: string) {
+    return this.sectionByHeading(heading).locator(`#section-edit-${property}`);
+  }
+
+  /** Assert a property renders as a TEXTAREA — the load-bearing widget-override
+   *  case (TKT-3R7RF3). A string property's type default is TextWidget's
+   *  `<input>`, so a textarea here can only come from `widget: textarea`. */
+  async expectSectionFieldIsTextarea(heading: string, property: string) {
+    const control = this.sectionFieldControl(heading, property);
+    await expect(control).toBeVisible();
+    await expect(control).toHaveJSProperty('tagName', 'TEXTAREA');
+  }
+
+  /** Assert a property renders as an ENABLED checkbox, i.e. the override
+   *  reached the EDIT arm rather than a display span or a disabled control. */
+  async expectSectionCheckboxEnabled(heading: string, property: string) {
+    const box = this.sectionFieldControl(heading, property);
+    await expect(box).toBeVisible();
+    await expect(box).toHaveAttribute('type', 'checkbox');
+    await expect(box).toBeEnabled();
+  }
+
+  /** Assert an overridden checkbox is checked (or not). Separate from the
+   *  enabled-assertion so a spec can prove a toggle SURVIVED a reload, which
+   *  is what distinguishes a real inline edit from a local DOM change. */
+  async expectSectionCheckboxChecked(heading: string, property: string, checked = true) {
+    const box = this.sectionFieldControl(heading, property);
+    if (checked) {
+      await expect(box).toBeChecked();
+    } else {
+      await expect(box).not.toBeChecked();
+    }
+  }
+
+  /** Click a checkbox rendered by a widget override and return its new state.
+   *
+   *  Waits for the autosave PATCH to land before returning. SectionEditForm
+   *  debounces saves by 800ms, so a caller that reloads immediately races the
+   *  timer and sees the pre-edit value — which looks exactly like a dropped
+   *  write rather than a test that asserted too early. */
+  async toggleSectionCheckbox(heading: string, property: string): Promise<boolean> {
+    const box = this.sectionFieldControl(heading, property);
+    const patched = this.page.waitForResponse(
+      (r) =>
+        r.url().includes('/api/v1/') &&
+        r.request().method() === 'PATCH' &&
+        r.status() < 400,
+      { timeout: 5000 },
+    );
+    await box.click();
+    await patched;
+    return box.isChecked();
+  }
+
   /** Assert the entry properties section renders as DISPLAY values: visible,
    *  but with no inline-edit form mounted (TKT-HOIX1 — the `render: display`
    *  default). */

--- a/e2e/pages/entity.page.ts
+++ b/e2e/pages/entity.page.ts
@@ -177,9 +177,15 @@ export class EntityPage extends BasePage {
    *  write rather than a test that asserted too early. */
   async toggleSectionCheckbox(heading: string, property: string): Promise<boolean> {
     const box = this.sectionFieldControl(heading, property);
+    // Match the PATCH for THIS entity, not any PATCH: on a page with more
+    // than one autosaving control a broad predicate resolves on the wrong
+    // request, and the caller's reload then races the real save — the exact
+    // flake this wait exists to remove.
+    const entityId = this.page.url().split('/').pop() ?? '';
     const patched = this.page.waitForResponse(
       (r) =>
         r.url().includes('/api/v1/') &&
+        r.url().includes(entityId) &&
         r.request().method() === 'PATCH' &&
         r.status() < 400,
       { timeout: 5000 },

--- a/e2e/tests/fixtures.ts
+++ b/e2e/tests/fixtures.ts
@@ -1227,6 +1227,22 @@ views:
         fields:
           - property: status
           - property: assignee
+      # TKT-3R7RF3: a section whose fields opt into inline edit AND override
+      # which widget renders them. The done property is a boolean, so its type
+      # default is already checkbox; title is the load-bearing case — a string
+      # would default to TextWidget, and only a widget override makes it a
+      # textarea. Keeps the override honest: if the plumbing silently dropped,
+      # the textarea assertion fails even though the checkbox one would pass.
+      # (No backticks in this comment: it lives inside a TS template literal.)
+      - heading: "Progress"
+        source: entry
+        display: properties
+        render: input
+        fields:
+          - property: done
+            widget: checkbox
+          - property: title
+            widget: textarea
       - heading: "Implements"
         source: implemented
         display: list
@@ -1498,6 +1514,7 @@ type: task
 title: Write unit tests
 status: draft
 assignee: Alice
+done: false
 ---
 
 Write unit tests for auth module.

--- a/e2e/tests/view-section-widget-override.spec.ts
+++ b/e2e/tests/view-section-widget-override.spec.ts
@@ -1,0 +1,62 @@
+import { test, expect } from './fixtures';
+import { EntityPage } from '../pages';
+import { SEED } from './fixtures';
+
+// TKT-3R7RF3: a view section field can override WHICH widget renders it,
+// independent of the type-derived default.
+//
+// The fixture's `task` view (DATA_ENTRY_YAML in fixtures.ts) carries a
+// "Progress" section with `render: input` and two overrides:
+//   done  (boolean) widget: checkbox   → also its type default
+//   title (string)  widget: textarea   → NOT its type default (that is text)
+//
+// `title` is the load-bearing case. A boolean already resolves to a checkbox
+// on its own, so a checkbox assertion alone would still pass if the override
+// were silently dropped. Only the textarea proves config reached the registry.
+test.describe('View section widget override (TKT-3R7RF3)', () => {
+  test('a string property renders as a textarea when overridden', async ({ appPage }) => {
+    const entity = new EntityPage(appPage);
+    await entity.navigateToEntity('task', SEED.tasks.writeUnitTests);
+
+    // Type default for `string` is TextWidget's <input>. A <textarea> here can
+    // only come from `widget: textarea`.
+    await entity.expectSectionFieldIsTextarea('Progress', 'title');
+  });
+
+  test('an overridden checkbox is interactive, not a display icon', async ({ appPage }) => {
+    const entity = new EntityPage(appPage);
+    await entity.navigateToEntity('task', SEED.tasks.writeUnitTests);
+
+    // Display-mode CheckboxWidget renders a DISABLED checkbox with no id, so
+    // matching an enabled `#section-edit-done` proves the edit arm was taken —
+    // the "a checkbox you cannot click is just an icon" case from the ticket.
+    await entity.expectSectionCheckboxEnabled('Progress', 'done');
+  });
+
+  test('clicking the overridden checkbox persists the change', async ({ appPage }) => {
+    const entity = new EntityPage(appPage);
+    await entity.navigateToEntity('task', SEED.tasks.writeUnitTests);
+
+    // Seeded false; toggling must flip it and survive a reload, which is what
+    // makes this a real inline edit rather than a local DOM change.
+    const after = await entity.toggleSectionCheckbox('Progress', 'done');
+    expect(after).toBe(true);
+
+    await appPage.reload();
+    await entity.expectSectionCheckboxEnabled('Progress', 'done');
+    await entity.expectSectionCheckboxChecked('Progress', 'done');
+  });
+
+  // The widget axis must not disturb the render axis TKT-HOIX1 established.
+  // The entry section above "Progress" omits `render:`, so it must still be
+  // display-rendered even though a sibling section opts into input.
+  test('the display-default section is unaffected by a sibling override', async ({
+    appPage,
+  }) => {
+    const entity = new EntityPage(appPage);
+    await entity.navigateToEntity('task', SEED.tasks.writeUnitTests);
+
+    await entity.expectEntrySectionRendersDisplay();
+    await entity.expectEntrySectionHasNoFormControls();
+  });
+});

--- a/frontend/src/api/views.ts
+++ b/frontend/src/api/views.ts
@@ -24,6 +24,16 @@ export interface ViewSectionField {
   // Opting in to 'input' does NOT grant editability: the ACL verdict in
   // `_fields` still decides, so 'input' on a read-only field renders display.
   render?: 'input' | 'display'
+  // Config's widget override (TKT-3R7RF3): the registered widget name to use
+  // instead of the type-derived default. Absent means "use the default",
+  // i.e. defaultWidgetFor's dispatch — the server does NOT resolve it.
+  //
+  // Honoured only when the property is in the schema (the 'schema' arm of
+  // SectionEditField). A field the metamodel doesn't declare routes through
+  // resolveFromHint, which takes no name, and the server could not have
+  // type-checked the override for it either (RR-2GBB0V) — config load emits a
+  // warning for that case rather than silently doing nothing.
+  widget?: string
 }
 
 // Entity data for view sections.

--- a/frontend/src/components/entity/sectionEditFields.test.ts
+++ b/frontend/src/components/entity/sectionEditFields.test.ts
@@ -433,3 +433,52 @@ describe('rowShouldRouteToInlineEdit (TKT-IHC7C cap behaviour)', () => {
     expect(rowShouldRouteToInlineEdit(row, 1, CAP, schemaResolver)).toBe(false)
   })
 })
+
+// TKT-3R7RF3: the `widget:` override is carried from the wire onto
+// SectionEditField, on BOTH union arms. Which arm honours it is
+// SectionEditForm's decision (widgetRows), not this builder's — carrying it
+// uniformly is what keeps that decision in one place.
+describe('widget override plumbing (TKT-3R7RF3)', () => {
+  it('carries widget onto a schema-arm field', () => {
+    const fields = buildSectionEditFields(
+      [{ property: 'status', label: 'Status', widget: 'textarea' }],
+      { type: 'ticket' },
+      () => ({ type: 'enum', values: ['a'] }) as PropertyDef,
+    )
+    expect(fields[0].kind).toBe('schema')
+    expect(fields[0].widget).toBe('textarea')
+  })
+
+  it('carries widget onto a hint-arm field too (dropped later, not here)', () => {
+    const fields = buildSectionEditFields(
+      [{ property: 'mystery', label: 'Mystery', widget: 'textarea' }],
+      { type: 'ticket' },
+      () => undefined,
+    )
+    expect(fields[0].kind).toBe('hint')
+    // Carried, so the drop stays a single decision in widgetRows rather than
+    // being spread across the builder as well (RR-2GBB0V).
+    expect(fields[0].widget).toBe('textarea')
+  })
+
+  it('leaves widget undefined when the config omits it', () => {
+    const fields = buildSectionEditFields(
+      [{ property: 'status', label: 'Status' }],
+      { type: 'ticket' },
+      () => ({ type: 'enum', values: ['a'] }) as PropertyDef,
+    )
+    expect(fields[0].widget).toBeUndefined()
+  })
+
+  // The widget axis must not disturb the render/ACL routing decision.
+  it('does not affect inline-edit routing', () => {
+    const withWidget = sectionShouldRouteToInlineEdit(
+      [{ property: 'status', label: 'Status', render: 'display', widget: 'textarea' }],
+      { type: 'ticket', _fields: { status: { writable: true } } },
+      () => ({ type: 'enum', values: ['a'] }) as PropertyDef,
+    )
+    // render: display still wins — a widget override is presentation, not
+    // permission, and cannot promote a display field into an edit host.
+    expect(withWidget).toBe(false)
+  })
+})

--- a/frontend/src/components/entity/sectionEditFields.ts
+++ b/frontend/src/components/entity/sectionEditFields.ts
@@ -56,6 +56,9 @@ export function buildSectionEditFields(
     // Server-resolved (section → field inheritance already applied); carried
     // through as its own property, never folded into `verdict` (RR-PGGRBD).
     const render = f.render
+    // Widget override (TKT-3R7RF3), carried verbatim. Honoured only on the
+    // schema arm below; SectionEditForm's widgetRows enforces that.
+    const widget = f.widget
     if (def) {
       out.push({
         property: f.property,
@@ -64,6 +67,7 @@ export function buildSectionEditFields(
         transitions,
         span: f.span,
         render,
+        widget,
         kind: 'schema',
         propertyDef: def,
       })
@@ -75,6 +79,7 @@ export function buildSectionEditFields(
         transitions,
         span: f.span,
         render,
+        widget,
         kind: 'hint',
         routingHint: viewFieldRoutingHint(f),
       })

--- a/frontend/src/components/forms/SectionEditForm.test.ts
+++ b/frontend/src/components/forms/SectionEditForm.test.ts
@@ -446,3 +446,155 @@ describe('SectionEditForm', () => {
     })
   })
 })
+
+// TKT-3R7RF3: the `widget:` override selects which registered widget renders a
+// field, instead of the type-derived default.
+describe('widget override (TKT-3R7RF3)', () => {
+  it('renders the overridden widget instead of the type default', () => {
+    const { wrapper } = mountForm({
+      fields: [
+        {
+          property: 'title',
+          label: 'Title',
+          kind: 'schema',
+          propertyDef: TEXT_DEF,
+          render: 'input',
+          widget: 'textarea',
+        },
+      ],
+    })
+    // string would ordinarily resolve to TextWidget.
+    expect(wrapper.findComponent({ name: 'TextareaWidget' }).exists()).toBe(true)
+    expect(wrapper.findComponent({ name: 'TextWidget' }).exists()).toBe(false)
+  })
+
+  it('omitting the override keeps the type default', () => {
+    const { wrapper } = mountForm({
+      fields: [
+        { property: 'title', label: 'Title', kind: 'schema', propertyDef: TEXT_DEF, render: 'input' },
+      ],
+    })
+    expect(wrapper.findComponent({ name: 'TextWidget' }).exists()).toBe(true)
+    expect(wrapper.findComponent({ name: 'TextareaWidget' }).exists()).toBe(false)
+  })
+
+  it('applies on the display arm too, not just edit', () => {
+    const { wrapper } = mountForm({
+      fields: [
+        {
+          property: 'title',
+          label: 'Title',
+          kind: 'schema',
+          propertyDef: TEXT_DEF,
+          render: 'display',
+          widget: 'textarea',
+        },
+      ],
+    })
+    const w = wrapper.findComponent({ name: 'TextareaWidget' })
+    expect(w.exists()).toBe(true)
+    expect(w.props('mode')).toBe('display')
+  })
+
+  // RR-2GBB0V: the hint arm has no PropertyDef, so the server could not have
+  // type-checked the override — it must be provably DROPPED, not silently
+  // honoured. Guards against a refactor that plumbs `widget` into
+  // resolveFromHint or reads it before the kind check.
+  it('is DROPPED on the hint arm', () => {
+    const { wrapper } = mountForm({
+      fields: [
+        {
+          property: 'mystery',
+          label: 'Mystery',
+          kind: 'hint',
+          routingHint: { kind: 'text', propertyName: 'mystery' },
+          render: 'input',
+          widget: 'textarea',
+        },
+      ],
+      initialValues: { mystery: 'x' },
+    })
+    // The hint's own kind wins: 'text' -> TextWidget, override ignored.
+    expect(wrapper.findComponent({ name: 'TextWidget' }).exists()).toBe(true)
+    expect(wrapper.findComponent({ name: 'TextareaWidget' }).exists()).toBe(false)
+  })
+
+  // RR-66MT0D: the StatusControl interaction is TWO-AXIS, not simply inert.
+  it('is inert on a machine field with render: input (StatusControl owns it)', () => {
+    const { wrapper } = mountForm({
+      fields: [
+        {
+          property: 'status',
+          label: 'Status',
+          kind: 'schema',
+          propertyDef: ENUM_DEF,
+          render: 'input',
+          transitions: [],
+          widget: 'textarea',
+        },
+      ],
+    })
+    expect(wrapper.findComponent({ name: 'StatusControl' }).exists()).toBe(true)
+    expect(wrapper.findComponent({ name: 'TextareaWidget' }).exists()).toBe(false)
+  })
+
+  it('IS honoured on a machine field with render: display', () => {
+    const { wrapper } = mountForm({
+      fields: [
+        {
+          property: 'status',
+          label: 'Status',
+          kind: 'schema',
+          propertyDef: ENUM_DEF,
+          render: 'display',
+          transitions: [],
+          widget: 'textarea',
+        },
+      ],
+    })
+    // render: display deliberately falls through to the display arm rather
+    // than rendering a disabled StatusControl (TKT-HOIX1), so the widget wins.
+    expect(wrapper.findComponent({ name: 'StatusControl' }).exists()).toBe(false)
+    expect(wrapper.findComponent({ name: 'TextareaWidget' }).props('mode')).toBe('display')
+  })
+
+  // The ACL conjunction is untouched by widget selection: config can only
+  // DOWNGRADE editability. A widget override must not create a path around it.
+  it('does not make a read-only field editable', () => {
+    const { wrapper } = mountForm({
+      fields: [
+        {
+          property: 'title',
+          label: 'Title',
+          kind: 'schema',
+          propertyDef: TEXT_DEF,
+          render: 'input',
+          verdict: { writable: false },
+          widget: 'textarea',
+        },
+      ],
+    })
+    expect(wrapper.findComponent({ name: 'TextareaWidget' }).props('mode')).toBe('display')
+  })
+
+  // An unknown name must not throw or blank the field — resolve() falls back
+  // to the type default and warns. Defensive: the server rejects these at
+  // config load, so this only fires on shape drift.
+  it('falls back to the type default on an unknown widget name', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const { wrapper } = mountForm({
+      fields: [
+        {
+          property: 'title',
+          label: 'Title',
+          kind: 'schema',
+          propertyDef: TEXT_DEF,
+          render: 'input',
+          widget: 'no-such-widget',
+        },
+      ],
+    })
+    expect(wrapper.findComponent({ name: 'TextWidget' }).exists()).toBe(true)
+    warn.mockRestore()
+  })
+})

--- a/frontend/src/components/forms/SectionEditForm.vue
+++ b/frontend/src/components/forms/SectionEditForm.vue
@@ -46,6 +46,11 @@ export type SectionEditField = {
   // config-driven display field would otherwise look like a revoked
   // permission and fire a spurious "Permission changed" toast (RR-PGGRBD).
   render?: 'input' | 'display'
+  // Config's widget override (TKT-3R7RF3). Applied on the 'schema' arm only —
+  // see widgetRows. Carried on the shared half of the union rather than inside
+  // the 'schema' variant so buildSectionEditFields can assign it uniformly;
+  // the ARM decides whether it is honoured, not the presence of the field.
+  widget?: string
 } & (
   | { kind: 'schema'; propertyDef: PropertyDef }
   | { kind: 'hint'; routingHint: WidgetRoutingHint }
@@ -146,9 +151,16 @@ interface WidgetRow {
 
 const widgetRows = computed<WidgetRow[]>(() =>
   props.fields.map((field) => {
+    // The config override applies ONLY on the schema arm. The hint arm fires
+    // for a property the metamodel does not declare, so there is no
+    // PropertyDef the server could have type-checked the widget against
+    // (RR-2GBB0V) — honouring it here would push an unvalidated widget into a
+    // live edit control, since an unschema'd field is editable (a missing
+    // verdict reads as writable), not read-only. Config load warns instead.
+    // resolve() already falls back to the type default on an unknown name.
     const widget =
       field.kind === 'schema'
-        ? defaultRegistry.resolve(undefined, field.propertyDef)
+        ? defaultRegistry.resolve(field.widget, field.propertyDef)
         : defaultRegistry.resolveFromHint(field.routingHint)
     return {
       field,

--- a/frontend/src/widgets/__tests__/registry.widgetTable.test.ts
+++ b/frontend/src/widgets/__tests__/registry.widgetTable.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { defineWidgetRegistry, defaultWidgetFor } from '../registry'
+import TextWidget from '../TextWidget.vue'
+import TextareaWidget from '../TextareaWidget.vue'
+import NumberWidget from '../NumberWidget.vue'
+import CheckboxWidget from '../CheckboxWidget.vue'
+import DateWidget from '../DateWidget.vue'
+import DatetimeWidget from '../DatetimeWidget.vue'
+import SelectWidget from '../SelectWidget.vue'
+import MultiSelectWidget from '../MultiSelectWidget.vue'
+import RruleWidget from '../RruleWidget.vue'
+import FileWidget from '../FileWidget.vue'
+import type { PropertyDef } from '@/types'
+import type { WidgetEntry } from '../types'
+
+type SupportedTypes = NonNullable<WidgetEntry['supportedPropertyTypes']>
+
+// TKT-3R7RF3 / RR-Z0GGTO: the other half of the cross-language drift guard.
+// Go's sectionFieldWidgetTypes (internal/dataentryconfig/validate.go) validates
+// a `widget:` override at config load; this registry decides what actually
+// renders. Both assert against the SAME fixture, so neither can move alone.
+//
+// If this fails, the SPA registry and the server validator disagree: either a
+// widget accepts a property type the server would reject (author writes valid
+// config, gets an error) or the reverse (server accepts config that renders a
+// widget which can't represent the value).
+const FIXTURE = resolve(
+  __dirname,
+  '../../../../internal/dataentryconfig/testdata/widget_property_types.json',
+)
+
+// The registry's own supportedPropertyTypes, read from a freshly built
+// registry rather than hardcoded — that is the point, it must reflect the
+// real registration calls in buildDefaultRegistry.
+function registeredSupportedTypes(): Record<string, string[]> {
+  const r = defineWidgetRegistry()
+  const entries: Record<string, string[]> = {}
+  const register = (name: string, component: unknown, supported: SupportedTypes) => {
+    r.register(name, {
+      component: component as never,
+      supportedPropertyTypes: supported,
+    })
+    entries[name] = [...supported].sort()
+  }
+  // Mirrors buildDefaultRegistry exactly. Kept as its own list so a widget
+  // added there without a fixture entry fails the count assertion below.
+  register('text', TextWidget, ['string'])
+  register('textarea', TextareaWidget, ['string'])
+  register('number', NumberWidget, ['integer'])
+  register('checkbox', CheckboxWidget, ['boolean'])
+  register('date', DateWidget, ['date'])
+  register('datetime', DatetimeWidget, ['datetime'])
+  register('select', SelectWidget, ['enum', 'string'])
+  register('multi-select', MultiSelectWidget, ['enum', 'string'])
+  register('rrule', RruleWidget, ['rrule'])
+  register('file', FileWidget, ['file'])
+  return entries
+}
+
+describe('widget/property-type table agrees with the Go validator', () => {
+  it('matches the shared fixture exactly', () => {
+    const fixture = JSON.parse(readFileSync(FIXTURE, 'utf-8')) as Record<string, string[]>
+    const sortedFixture = Object.fromEntries(
+      Object.entries(fixture).map(([k, v]) => [k, [...v].sort()]),
+    )
+    expect(registeredSupportedTypes()).toEqual(sortedFixture)
+  })
+
+  it('every fixture widget is resolvable by name', () => {
+    const fixture = JSON.parse(readFileSync(FIXTURE, 'utf-8')) as Record<string, string[]>
+    const r = defineWidgetRegistry()
+    r.register('text', { component: TextWidget, supportedPropertyTypes: ['string'] })
+    // A name the server accepts but the registry cannot resolve would fall
+    // back to the type default at runtime — config that validates and then
+    // silently does something else. Assert the names line up.
+    for (const name of Object.keys(fixture)) {
+      expect(typeof name).toBe('string')
+      expect(name.trim()).toBe(name)
+      expect(name).toBe(name.toLowerCase())
+    }
+  })
+})
+
+// AC2 (RR-693NL9): omitting `widget:` must reproduce today's selection
+// byte-for-byte. This lives in the FRONTEND because the section path's
+// type→widget dispatch is defaultWidgetFor — the Go resolveWidget /
+// ResolveWidgetFromType path serves table cells, a different surface. A Go
+// test here would pin a mapping this code never consults.
+describe('omitting widget: preserves the type-derived default', () => {
+  const cases: Array<{ name: string; def: PropertyDef | undefined; want: string }> = [
+    { name: 'undefined propertyDef', def: undefined, want: 'text' },
+    { name: 'string', def: { type: 'string' } as PropertyDef, want: 'text' },
+    { name: 'integer', def: { type: 'integer' } as PropertyDef, want: 'number' },
+    { name: 'boolean', def: { type: 'boolean' } as PropertyDef, want: 'checkbox' },
+    { name: 'date', def: { type: 'date' } as PropertyDef, want: 'date' },
+    { name: 'datetime', def: { type: 'datetime' } as PropertyDef, want: 'datetime' },
+    { name: 'rrule', def: { type: 'rrule' } as PropertyDef, want: 'rrule' },
+    { name: 'file', def: { type: 'file' } as PropertyDef, want: 'file' },
+    {
+      name: 'enum values win over scalar type',
+      def: { type: 'string', values: ['a', 'b'] } as PropertyDef,
+      want: 'select',
+    },
+    {
+      name: 'list wins over values (RR-0Z1P6 order)',
+      def: { type: 'string', list: true, values: ['a'] } as PropertyDef,
+      want: 'multi-select',
+    },
+  ]
+
+  for (const tc of cases) {
+    it(tc.name, () => {
+      expect(defaultWidgetFor(tc.def)).toBe(tc.want)
+    })
+  }
+})

--- a/frontend/src/widgets/__tests__/registry.widgetTable.test.ts
+++ b/frontend/src/widgets/__tests__/registry.widgetTable.test.ts
@@ -1,84 +1,52 @@
 import { describe, it, expect } from 'vitest'
 import { readFileSync } from 'node:fs'
 import { resolve } from 'node:path'
-import { defineWidgetRegistry, defaultWidgetFor } from '../registry'
-import TextWidget from '../TextWidget.vue'
-import TextareaWidget from '../TextareaWidget.vue'
-import NumberWidget from '../NumberWidget.vue'
-import CheckboxWidget from '../CheckboxWidget.vue'
-import DateWidget from '../DateWidget.vue'
-import DatetimeWidget from '../DatetimeWidget.vue'
-import SelectWidget from '../SelectWidget.vue'
-import MultiSelectWidget from '../MultiSelectWidget.vue'
-import RruleWidget from '../RruleWidget.vue'
-import FileWidget from '../FileWidget.vue'
+import { defaultWidgetFor, defaultRegistry, WIDGET_REGISTRATIONS } from '../registry'
 import type { PropertyDef } from '@/types'
-import type { WidgetEntry } from '../types'
-
-type SupportedTypes = NonNullable<WidgetEntry['supportedPropertyTypes']>
 
 // TKT-3R7RF3 / RR-Z0GGTO: the other half of the cross-language drift guard.
 // Go's sectionFieldWidgetTypes (internal/dataentryconfig/validate.go) validates
 // a `widget:` override at config load; this registry decides what actually
 // renders. Both assert against the SAME fixture, so neither can move alone.
 //
-// If this fails, the SPA registry and the server validator disagree: either a
-// widget accepts a property type the server would reject (author writes valid
-// config, gets an error) or the reverse (server accepts config that renders a
-// widget which can't represent the value).
+// This asserts WIDGET_REGISTRATIONS — the array buildDefaultRegistry actually
+// consumes. An earlier version re-declared the registrations inside the test
+// and so asserted its own copy: mutating registry.ts left all 12 tests green,
+// which is worse than no guard because the comment claimed otherwise. If you
+// change this test, verify it still FAILS when you mutate a
+// supportedPropertyTypes entry in registry.ts.
 const FIXTURE = resolve(
   __dirname,
   '../../../../internal/dataentryconfig/testdata/widget_property_types.json',
 )
 
-// The registry's own supportedPropertyTypes, read from a freshly built
-// registry rather than hardcoded — that is the point, it must reflect the
-// real registration calls in buildDefaultRegistry.
-function registeredSupportedTypes(): Record<string, string[]> {
-  const r = defineWidgetRegistry()
-  const entries: Record<string, string[]> = {}
-  const register = (name: string, component: unknown, supported: SupportedTypes) => {
-    r.register(name, {
-      component: component as never,
-      supportedPropertyTypes: supported,
-    })
-    entries[name] = [...supported].sort()
-  }
-  // Mirrors buildDefaultRegistry exactly. Kept as its own list so a widget
-  // added there without a fixture entry fails the count assertion below.
-  register('text', TextWidget, ['string'])
-  register('textarea', TextareaWidget, ['string'])
-  register('number', NumberWidget, ['integer'])
-  register('checkbox', CheckboxWidget, ['boolean'])
-  register('date', DateWidget, ['date'])
-  register('datetime', DatetimeWidget, ['datetime'])
-  register('select', SelectWidget, ['enum', 'string'])
-  register('multi-select', MultiSelectWidget, ['enum', 'string'])
-  register('rrule', RruleWidget, ['rrule'])
-  register('file', FileWidget, ['file'])
-  return entries
+function loadFixture(): Record<string, string[]> {
+  const raw = JSON.parse(readFileSync(FIXTURE, 'utf-8')) as Record<string, string[]>
+  return Object.fromEntries(Object.entries(raw).map(([k, v]) => [k, [...v].sort()]))
 }
 
 describe('widget/property-type table agrees with the Go validator', () => {
-  it('matches the shared fixture exactly', () => {
-    const fixture = JSON.parse(readFileSync(FIXTURE, 'utf-8')) as Record<string, string[]>
-    const sortedFixture = Object.fromEntries(
-      Object.entries(fixture).map(([k, v]) => [k, [...v].sort()]),
+  it('the REAL registrations match the shared fixture exactly', () => {
+    const actual = Object.fromEntries(
+      WIDGET_REGISTRATIONS.map((e) => [e.name, [...e.supportedPropertyTypes].sort()]),
     )
-    expect(registeredSupportedTypes()).toEqual(sortedFixture)
+    expect(actual).toEqual(loadFixture())
   })
 
-  it('every fixture widget is resolvable by name', () => {
-    const fixture = JSON.parse(readFileSync(FIXTURE, 'utf-8')) as Record<string, string[]>
-    const r = defineWidgetRegistry()
-    r.register('text', { component: TextWidget, supportedPropertyTypes: ['string'] })
-    // A name the server accepts but the registry cannot resolve would fall
-    // back to the type default at runtime — config that validates and then
-    // silently does something else. Assert the names line up.
-    for (const name of Object.keys(fixture)) {
-      expect(typeof name).toBe('string')
-      expect(name.trim()).toBe(name)
-      expect(name).toBe(name.toLowerCase())
+  it('every fixture widget resolves to a real component in the default registry', () => {
+    // The names are the contract between server and client: a name the server
+    // accepts but the registry cannot resolve would silently fall back to the
+    // type default. resolve() returns the fallback rather than throwing, so
+    // compare against a KNOWN-unregistered name to prove these are distinct.
+    const fallback = defaultRegistry.resolve('definitely-not-a-widget', {
+      type: 'string',
+    } as PropertyDef)
+    for (const name of Object.keys(loadFixture())) {
+      const component = defaultRegistry.resolve(name, undefined)
+      expect(component, `widget "${name}" did not resolve`).toBeTruthy()
+      if (name !== 'text') {
+        expect(component, `widget "${name}" resolved to the fallback`).not.toBe(fallback)
+      }
     }
   })
 })

--- a/frontend/src/widgets/registry.ts
+++ b/frontend/src/widgets/registry.ts
@@ -1,3 +1,4 @@
+import type { Component } from 'vue'
 import type { PropertyDef } from '@/types'
 import type { WidgetEntry, WidgetRegistry, WidgetRoutingHint, WidgetHintKind } from './types'
 import TextWidget from './TextWidget.vue'
@@ -100,21 +101,40 @@ export function defineWidgetRegistry(): WidgetRegistry {
   }
 }
 
-function buildDefaultRegistry(): WidgetRegistry {
-  const r = defineWidgetRegistry()
-  r.register('text', { component: TextWidget, supportedPropertyTypes: ['string'] })
-  r.register('textarea', { component: TextareaWidget, supportedPropertyTypes: ['string'] })
-  r.register('number', { component: NumberWidget, supportedPropertyTypes: ['integer'] })
-  r.register('checkbox', { component: CheckboxWidget, supportedPropertyTypes: ['boolean'] })
-  r.register('date', { component: DateWidget, supportedPropertyTypes: ['date'] })
-  r.register('datetime', { component: DatetimeWidget, supportedPropertyTypes: ['datetime'] })
-  r.register('select', { component: SelectWidget, supportedPropertyTypes: ['enum', 'string'] })
-  r.register('multi-select', {
+// WIDGET_REGISTRATIONS is the single list buildDefaultRegistry consumes, and
+// the one the cross-language drift guard asserts against (TKT-3R7RF3).
+//
+// It is exported DATA rather than a sequence of register() calls inside the
+// builder because a test cannot observe those calls: the registry exposes no
+// enumeration, so the guard had to re-declare them — which meant it asserted
+// its own copy and stayed green while the real registrations drifted. Keeping
+// the list addressable makes the guard structurally unable to miss a change.
+export const WIDGET_REGISTRATIONS: ReadonlyArray<{
+  name: string
+  component: Component
+  supportedPropertyTypes: NonNullable<WidgetEntry['supportedPropertyTypes']>
+}> = [
+  { name: 'text', component: TextWidget, supportedPropertyTypes: ['string'] },
+  { name: 'textarea', component: TextareaWidget, supportedPropertyTypes: ['string'] },
+  { name: 'number', component: NumberWidget, supportedPropertyTypes: ['integer'] },
+  { name: 'checkbox', component: CheckboxWidget, supportedPropertyTypes: ['boolean'] },
+  { name: 'date', component: DateWidget, supportedPropertyTypes: ['date'] },
+  { name: 'datetime', component: DatetimeWidget, supportedPropertyTypes: ['datetime'] },
+  { name: 'select', component: SelectWidget, supportedPropertyTypes: ['enum', 'string'] },
+  {
+    name: 'multi-select',
     component: MultiSelectWidget,
     supportedPropertyTypes: ['enum', 'string'],
-  })
-  r.register('rrule', { component: RruleWidget, supportedPropertyTypes: ['rrule'] })
-  r.register('file', { component: FileWidget, supportedPropertyTypes: ['file'] })
+  },
+  { name: 'rrule', component: RruleWidget, supportedPropertyTypes: ['rrule'] },
+  { name: 'file', component: FileWidget, supportedPropertyTypes: ['file'] },
+]
+
+function buildDefaultRegistry(): WidgetRegistry {
+  const r = defineWidgetRegistry()
+  for (const { name, component, supportedPropertyTypes } of WIDGET_REGISTRATIONS) {
+    r.register(name, { component, supportedPropertyTypes })
+  }
   return r
 }
 

--- a/internal/apiwire/v1/responses.go
+++ b/internal/apiwire/v1/responses.go
@@ -360,6 +360,7 @@ type SectionField struct {
 	Inaccessible bool     `json:"inaccessible,omitempty"`
 	Span         int      `json:"span,omitempty"`
 	Render       string   `json:"render,omitempty"`
+	Widget       string   `json:"widget,omitempty"`
 }
 
 // SidePanelEntity represents an entity in a side panel section.

--- a/internal/dataentry/sections.go
+++ b/internal/dataentry/sections.go
@@ -68,6 +68,11 @@ type SectionFieldData struct {
 	Inaccessible bool
 	Span         int
 	Render       string
+	// Widget is the config's widget override for this field, empty when the
+	// author did not set one. Passed through verbatim: resolving it is the
+	// SPA's job (its registry owns the type→widget default), and the server
+	// has already rejected a name/type mismatch at config load (TKT-3R7RF3).
+	Widget string
 }
 
 // buildSectionFieldData resolves one configured field against an entity.
@@ -108,6 +113,10 @@ func buildSectionFieldData(
 		// the API surface.
 		Span:   int(f.Span),
 		Render: resolveFieldRender(sectionRender, f.Render),
+		// No section-level inheritance for Widget, unlike Render — a widget is
+		// per-property, and a section-wide one would be a config error on every
+		// field of a non-matching type. See ViewSectionField's godoc.
+		Widget: f.Widget,
 	}
 }
 

--- a/internal/dataentry/sections_widget_test.go
+++ b/internal/dataentry/sections_widget_test.go
@@ -1,0 +1,88 @@
+package dataentry
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Sourcehaven-BV/rela/internal/entity"
+)
+
+// TKT-3R7RF3: the section builders carry the config's `widget:` override
+// through to the wire verbatim. Resolving it is the SPA's job — the server
+// only validates it at config load and passes it along.
+
+func TestBuildSectionEntityData_CarriesWidget(t *testing.T) {
+	tests := []struct {
+		name    string
+		widgets []string // per field, "" = unset
+		want    []string
+	}{
+		{
+			name:    "unset stays empty (SPA applies its type default)",
+			widgets: []string{"", ""},
+			want:    []string{"", ""},
+		},
+		{
+			name:    "override is carried verbatim",
+			widgets: []string{"textarea", ""},
+			want:    []string{"textarea", ""},
+		},
+		{
+			name:    "per-field, not per-section",
+			widgets: []string{"textarea", "select"},
+			want:    []string{"textarea", "select"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			app := testViewApp()
+			st := app.State()
+			e := &entity.Entity{
+				ID:         "TKT-001",
+				Type:       "ticket",
+				Properties: map[string]any{"title": "First", "status": "open"},
+			}
+			eDef, _ := st.Meta.GetEntityDef(e.Type)
+			props := []string{"title", "status"}
+			secFields := make([]ViewSectionField, len(props))
+			for i, p := range props {
+				secFields[i] = ViewSectionField{Property: p, Widget: tc.widgets[i]}
+			}
+
+			sed := app.views.buildSectionEntityData(
+				context.Background(), e, secFields, eDef, "input")
+
+			if len(sed.Fields) != len(tc.want) {
+				t.Fatalf("got %d fields, want %d", len(sed.Fields), len(tc.want))
+			}
+			for i, want := range tc.want {
+				if got := sed.Fields[i].Widget; got != want {
+					t.Errorf("field %q: Widget = %q, want %q", props[i], got, want)
+				}
+			}
+		})
+	}
+}
+
+// The entry-source `properties` branch is a SECOND construction site. Both go
+// through buildSectionFieldData, which is exactly why a new field like this
+// one cannot be wired into one and silently dropped from the other — the
+// failure mode that helper's godoc exists to prevent.
+func TestBuildSectionFieldData_CarriesWidget(t *testing.T) {
+	e := &entity.Entity{
+		ID:         "TKT-001",
+		Type:       "ticket",
+		Properties: map[string]any{"title": "First"},
+	}
+	got := buildSectionFieldData(
+		ViewSectionField{Property: "title", Label: "Title", Widget: "textarea"},
+		e, nil, "input")
+	if got.Widget != "textarea" {
+		t.Errorf("Widget = %q, want %q", got.Widget, "textarea")
+	}
+	// The two axes are independent: a widget override must not disturb render.
+	if got.Render != "input" {
+		t.Errorf("Render = %q, want %q (widget must not affect it)", got.Render, "input")
+	}
+}

--- a/internal/dataentryconfig/config.go
+++ b/internal/dataentryconfig/config.go
@@ -29,7 +29,13 @@ const (
 	WidgetDate        = "date"
 	WidgetDatetime    = "datetime"
 	WidgetRrule       = "rrule"
-	WidgetCards       = "cards" // card-based UI for relations with properties
+	// WidgetFile is registered by the SPA (frontend/src/widgets/registry.ts)
+	// but had no Go constant until TKT-3R7RF3 needed to name it in the section
+	// field widget table. Note Metamodel.ResolveWidgetFromType has no `file`
+	// case and resolves a file property to "text" — a real divergence from the
+	// SPA's defaultWidgetFor, documented at sectionFieldWidgetTypes.
+	WidgetFile  = "file"
+	WidgetCards = "cards" // card-based UI for relations with properties
 )
 
 // Direction represents the edge direction for relation columns and form relations.
@@ -844,11 +850,24 @@ type ViewSection struct {
 // Render is resolved server-side against the containing section — see
 // ResolveFieldRender — so consumers receive an already-resolved value and
 // never reimplement the inheritance rule.
+//
+// Widget overrides which registered widget renders this property, instead of
+// the type-derived default (TKT-3R7RF3). Empty means "use the default", which
+// is the SPA's defaultWidgetFor dispatch — NOT a value this package resolves.
+//
+// Deliberately field-level only, with no section-level counterpart, which is
+// the one structural difference from Render. Render can inherit because BOTH
+// of its values are valid for every field; a section-level widget would be a
+// config-load error on every field whose type does not match it, turning one
+// authored line into N errors the operator must override back field by field.
+// Validating one would also need each field's property type — exactly the
+// metamodel-dependent context RR-4ICH8M moved the field-level check out of.
 type ViewSectionField struct {
 	Property string `yaml:"property" json:"property"`
 	Label    string `yaml:"label,omitempty" json:"label,omitempty"`
 	Span     Span   `yaml:"span,omitempty" json:"span,omitempty"`
 	Render   string `yaml:"render,omitempty" json:"render,omitempty"`
+	Widget   string `yaml:"widget,omitempty" json:"widget,omitempty"`
 }
 
 // ResolveFieldRender returns the effective render mode for a field within a

--- a/internal/dataentryconfig/testdata/widget_property_types.json
+++ b/internal/dataentryconfig/testdata/widget_property_types.json
@@ -1,0 +1,12 @@
+{
+  "text": ["string"],
+  "textarea": ["string"],
+  "number": ["integer"],
+  "checkbox": ["boolean"],
+  "date": ["date"],
+  "datetime": ["datetime"],
+  "select": ["enum", "string"],
+  "multi-select": ["enum", "string"],
+  "rrule": ["rrule"],
+  "file": ["file"]
+}

--- a/internal/dataentryconfig/validate.go
+++ b/internal/dataentryconfig/validate.go
@@ -114,6 +114,124 @@ var sectionDisplayModesRenderingFields = map[string]bool{
 	"cards":      true,
 }
 
+// sectionFieldWidgetTypes is the widget → accepted-property-types table for a
+// view section field's `widget:` override (TKT-3R7RF3).
+//
+// This is an INDEPENDENT literal, deliberately not derived from
+// Metamodel.ResolveWidgetFromType (RR-Z0GGTO). That function is the table-cell
+// resolver and has no `file` case — deriving from it would reject
+// `widget: file` on a `file` property, which is legal here. It also predates
+// the list/values precedence the SPA applies. Its godoc calls itself the single
+// source of truth for type→widget; on the section path that is not accurate,
+// and the two have already drifted.
+//
+// The authority this DOES mirror is the SPA registry's supportedPropertyTypes
+// (frontend/src/widgets/registry.ts). The two are kept honest by a paired
+// fixture asserted from both languages — see widgetTableFixture in
+// widget_table_test.go and the matching Vitest test. Change one, change the
+// fixture, and both sides fail until they agree.
+//
+// An empty type (a property the metamodel does not define) is handled by the
+// caller, not here: there is nothing to check it against.
+var sectionFieldWidgetTypes = map[string][]string{
+	WidgetText:        {metamodel.PropertyTypeString},
+	WidgetTextarea:    {metamodel.PropertyTypeString},
+	WidgetNumber:      {metamodel.PropertyTypeInteger},
+	WidgetCheckbox:    {metamodel.PropertyTypeBoolean},
+	WidgetDate:        {metamodel.PropertyTypeDate},
+	WidgetDatetime:    {metamodel.PropertyTypeDatetime},
+	WidgetSelect:      {metamodel.PropertyTypeEnum, metamodel.PropertyTypeString},
+	WidgetMultiSelect: {metamodel.PropertyTypeEnum, metamodel.PropertyTypeString},
+	WidgetRrule:       {metamodel.PropertyTypeRrule},
+	WidgetFile:        {metamodel.PropertyTypeFile},
+}
+
+// validateSectionFieldWidget checks each field's `widget:` override: the name
+// must be registered, and it must accept the property's declared type.
+//
+// Called OUTSIDE the source-resolution guards for the name check, which needs
+// no metamodel knowledge (the RR-4ICH8M lesson). The type-compatibility half
+// necessarily needs the property's definition, so it is skipped — not failed —
+// when the property is unknown; inertWidgetWarnings reports that case instead.
+//
+// `widget: file` is additionally rejected outside a `properties` section
+// (RR-NGY84F): only the entry mount site passes `:attachments` to
+// SectionEditForm, so a FileWidget forced into a cards/list row would render
+// with no attachments at all. Failing at config load beats rendering a widget
+// that cannot work.
+func validateSectionFieldWidget(
+	viewID string, i int, s ViewSection, eDef *metamodel.EntityDef,
+) []string {
+	var errs []string
+	for j, f := range s.Fields {
+		if f.Widget == "" {
+			continue
+		}
+		accepted, known := sectionFieldWidgetTypes[f.Widget]
+		if !known {
+			errs = append(errs, fmt.Sprintf(
+				"view %q: section[%d] field[%d] has invalid widget %q (valid: %s)",
+				viewID, i, j, f.Widget, joinWidgetTableKeys(sectionFieldWidgetTypes)))
+			continue
+		}
+		if f.Widget == WidgetFile && s.Display != "properties" {
+			errs = append(errs, fmt.Sprintf(
+				"view %q: section[%d] field[%d] sets widget: file on display mode %q; "+
+					"the file widget is only supported on display: properties",
+				viewID, i, j, s.Display))
+			continue
+		}
+		if eDef == nil {
+			continue
+		}
+		pd, ok := eDef.Properties[f.Property]
+		if !ok {
+			continue // unknown property — inertWidgetWarnings reports it
+		}
+		if !widgetAcceptsType(accepted, pd.Type) {
+			errs = append(errs, fmt.Sprintf(
+				"view %q: section[%d] field[%d] sets widget %q on property %q of type %q "+
+					"(widget %q accepts: %s)",
+				viewID, i, j, f.Widget, f.Property, pd.Type, f.Widget,
+				strings.Join(accepted, ", ")))
+		}
+	}
+	return errs
+}
+
+// widgetAcceptsType reports whether a widget's accepted-type list covers the
+// property type. A custom enum type (one declared under `types:`) is accepted
+// wherever `enum` is, matching how the SPA treats it as a select-like value.
+func widgetAcceptsType(accepted []string, propType string) bool {
+	for _, t := range accepted {
+		if t == propType {
+			return true
+		}
+		// A custom type resolves to enum semantics; the metamodel's own
+		// resolveWidget makes the same equivalence.
+		isCustomEnumLike := t == metamodel.PropertyTypeEnum && propType != "" &&
+			propType != metamodel.PropertyTypeString &&
+			!isBuiltinPropertyType(propType)
+		if isCustomEnumLike {
+			return true
+		}
+	}
+	return false
+}
+
+// isBuiltinPropertyType reports whether the type is one of the metamodel's
+// built-ins, as opposed to an operator-declared custom (enum-like) type.
+func isBuiltinPropertyType(t string) bool {
+	switch t {
+	case metamodel.PropertyTypeString, metamodel.PropertyTypeDate,
+		metamodel.PropertyTypeDatetime, metamodel.PropertyTypeInteger,
+		metamodel.PropertyTypeBoolean, metamodel.PropertyTypeEnum,
+		metamodel.PropertyTypeFile, metamodel.PropertyTypeRrule:
+		return true
+	}
+	return false
+}
+
 // validateSectionRender checks the section-level `render:` and each field's,
 // independently of whether the section's source resolves (RR-4ICH8M).
 func validateSectionRender(viewID string, i int, s ViewSection) []string {
@@ -761,6 +879,7 @@ func CollectConfigWarnings(cfg *Config, meta *metamodel.Metamodel) []string {
 	warnings = append(warnings, relationPropertyNameCollisionWarnings(cfg, meta)...)
 	warnings = append(warnings, viewCommandPermissionWarnings(cfg)...)
 	warnings = append(warnings, inertSectionRenderWarnings(cfg)...)
+	warnings = append(warnings, inertWidgetWarnings(cfg, meta)...)
 	return warnings
 }
 
@@ -806,6 +925,118 @@ func inertSectionRenderWarnings(cfg *Config) []string {
 		}
 	}
 	return warnings
+}
+
+// inertWidgetWarnings flags a `widget:` override that cannot take effect
+// (TKT-3R7RF3). Two inert cases, both warned rather than errored for the same
+// reason as inertSectionRenderWarnings — the config is not wrong, just
+// ineffective, and a display-mode switch should not be a hard load failure:
+//
+//   - a display mode that renders no fields at all (`table`, `content`), the
+//     exact case sectionDisplayModesRenderingFields already describes;
+//   - a property the metamodel does not declare. Such a field renders through
+//     the SPA's routing-hint path, which resolves a widget from the value's
+//     shape and takes no override name (RR-2GBB0V). Note this is NOT because
+//     the field is read-only — an unschema'd field IS editable, since a
+//     missing ACL verdict reads as writable. It is because there is no
+//     PropertyDef to type-check the override against, so honoring it would
+//     push an unvalidated widget into a live edit control.
+//
+// A third inert case is deliberately NOT warned: a state-machine field on
+// `render: input`, where the SPA's StatusControl owns the field and ignores
+// the widget. Machine-ness is a runtime, per-entity, per-principal fact
+// (computeTransitions, gated on a TransitionResolver the config layer cannot
+// see), so the warning is unbuildable here rather than merely unwritten
+// (RR-66MT0D). It is documented in docs/data-entry.md instead. That same field
+// on `render: display` DOES honor the widget, so the interaction is two-axis.
+func inertWidgetWarnings(cfg *Config, meta *metamodel.Metamodel) []string {
+	var warnings []string
+	viewIDs := make([]string, 0, len(cfg.Views))
+	for id := range cfg.Views {
+		viewIDs = append(viewIDs, id)
+	}
+	sort.Strings(viewIDs)
+	for _, viewID := range viewIDs {
+		view := cfg.Views[viewID]
+		collections := viewCollectionTypes(view, meta)
+		for i, s := range view.Sections {
+			renders := sectionDisplayModesRenderingFields[s.Display]
+			eDef, sourceType := widgetSectionDef(s, collections, meta)
+			for j, f := range s.Fields {
+				if f.Widget == "" {
+					continue
+				}
+				if !renders {
+					warnings = append(warnings, fmt.Sprintf(
+						"view %q: section[%d] field[%d] sets widget: on display mode %q, "+
+							"which does not render fields; the setting has no effect "+
+							"(it applies to: %s)",
+						viewID, i, j, s.Display,
+						joinMapKeys(sectionDisplayModesRenderingFields)))
+					continue
+				}
+				if eDef == nil {
+					continue
+				}
+				if _, ok := eDef.Properties[f.Property]; !ok {
+					warnings = append(warnings, fmt.Sprintf(
+						"view %q: section[%d] field[%d] sets widget %q on property %q, "+
+							"which type %q does not declare; the override is ignored "+
+							"(a widget can only be applied to a declared property)",
+						viewID, i, j, f.Widget, f.Property, sourceType))
+				}
+			}
+		}
+	}
+	return warnings
+}
+
+// widgetSectionDef resolves the entity def whose properties a section's fields
+// name, or nil when the source does not resolve (ValidateConfig already errors
+// on that separately, so the warning pass stays silent rather than guessing).
+func widgetSectionDef(
+	s ViewSection, collections map[string]string, meta *metamodel.Metamodel,
+) (def *metamodel.EntityDef, entityType string) {
+	if meta == nil || s.Source == "" {
+		return nil, ""
+	}
+	sourceType, ok := collections[s.Source]
+	if !ok || sourceType == "" {
+		return nil, ""
+	}
+	d, ok := meta.GetEntityDef(sourceType)
+	if !ok {
+		return nil, ""
+	}
+	return d, sourceType
+}
+
+// viewCollectionTypes rebuilds the collection-name → entity-type map a view's
+// `traverse:` block defines, the same way ValidateConfig does. Needed because
+// a section's `source:` names a collection, not a type.
+//
+// A traversal whose relation type is unknown yields an empty target type,
+// which callers treat as unresolvable — the warning pass stays silent rather
+// than guessing, since ValidateConfig already errors on that separately.
+func viewCollectionTypes(view ViewConfig, meta *metamodel.Metamodel) map[string]string {
+	out := make(map[string]string, len(view.Traverse)+1)
+	// "entry" is a collection name too — it refers to the view's entry entity
+	// type. ValidateConfig seeds it the same way; omitting it here silently
+	// skipped every `source: entry` section, which is the common case.
+	if view.Entry.Type != "" {
+		out["entry"] = view.Entry.Type
+	}
+	for _, t := range view.Traverse {
+		if t.CollectAs == "" {
+			continue
+		}
+		relName := t.Follow
+		if relName == "" {
+			relName = t.FollowIncoming
+		}
+		out[t.CollectAs] = determineTargetType(t, relName, meta)
+	}
+	return out
 }
 
 // viewCommandPermissionWarnings flags `permission:` on a `context: view`
@@ -1092,6 +1323,18 @@ func validateViews(cfg *Config, meta *metamodel.Metamodel) []string {
 			// must still have it checked (RR-4ICH8M). The per-field loops below
 			// also never see the section-level value.
 			errs = append(errs, validateSectionRender(viewID, i, s)...)
+
+			// Validate widget overrides (TKT-3R7RF3), outside the guard for the
+			// same reason: an unregistered widget name is checkable without the
+			// metamodel. The type-compatibility half needs the entity def, so
+			// it is passed when resolvable and skipped (never failed) when not.
+			var widgetDef *metamodel.EntityDef
+			if sourceType != "" {
+				if d, ok := meta.GetEntityDef(sourceType); ok {
+					widgetDef = d
+				}
+			}
+			errs = append(errs, validateSectionFieldWidget(viewID, i, s, widgetDef)...)
 
 			// Validate fields (if source type is known)
 			if sourceType != "" { //nolint:nestif // nested guards each check a distinct optional field of the source config.
@@ -1805,6 +2048,18 @@ func sortedMapKeys[V any](m map[string]V) []string {
 	}
 	natsort.Strings(keys)
 	return keys
+}
+
+// joinWidgetTableKeys is joinMapKeys for the widget→types table, whose value
+// type differs. Same output contract: sorted, comma-separated, for an error
+// message that tells the operator the valid set (the config is not a secret).
+func joinWidgetTableKeys(m map[string][]string) string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	natsort.Strings(keys)
+	return strings.Join(keys, ", ")
 }
 
 func joinMapKeys(m map[string]bool) string {

--- a/internal/dataentryconfig/validate.go
+++ b/internal/dataentryconfig/validate.go
@@ -128,11 +128,14 @@ var sectionDisplayModesRenderingFields = map[string]bool{
 // The authority this DOES mirror is the SPA registry's supportedPropertyTypes
 // (frontend/src/widgets/registry.ts). The two are kept honest by a paired
 // fixture asserted from both languages — see widgetTableFixture in
-// widget_table_test.go and the matching Vitest test. Change one, change the
-// fixture, and both sides fail until they agree.
+// widget_table_test.go and the matching Vitest test.
 //
-// An empty type (a property the metamodel does not define) is handled by the
-// caller, not here: there is nothing to check it against.
+// This map is only the TYPE half of the rule. It is NOT sufficient on its own:
+// the SPA's defaultWidgetFor dispatches on (list, values, type) IN THAT ORDER
+// (registry.ts:19-28, an order its own comment marks load-bearing per
+// RR-0Z1P6), so a table keyed on type alone is narrower than the dispatch it
+// claims to mirror. widgetAcceptsProperty applies the higher-precedence rules
+// first; see its godoc.
 var sectionFieldWidgetTypes = map[string][]string{
 	WidgetText:        {metamodel.PropertyTypeString},
 	WidgetTextarea:    {metamodel.PropertyTypeString},
@@ -144,6 +147,69 @@ var sectionFieldWidgetTypes = map[string][]string{
 	WidgetMultiSelect: {metamodel.PropertyTypeEnum, metamodel.PropertyTypeString},
 	WidgetRrule:       {metamodel.PropertyTypeRrule},
 	WidgetFile:        {metamodel.PropertyTypeFile},
+}
+
+// widgetAcceptsProperty reports whether a widget can render a property, and if
+// not, why — the reason becomes the operator's error message.
+//
+// The order of the checks mirrors the SPA's defaultWidgetFor dispatch
+// (registry.ts:19-28), because a validator that models a narrower key than the
+// renderer will accept config the renderer then handles differently:
+//
+//  1. `list: true` → only multi-select. This is the highest-precedence rule in
+//     the SPA and the one with teeth: a list property rendered through, say,
+//     TextareaWidget goes through useStringValue, so the array is flattened to
+//     a string and the auto-save PATCHes a SCALAR over a list. That is silent
+//     data corruption authorized by a config line the server called valid.
+//  2. a value set (`values:`, or a custom type with values) → only the
+//     select-family. A free-text widget over a constrained set lets an operator
+//     type anything; the write validator would reject it later, but the config
+//     should not have promised the control in the first place.
+//  3. otherwise the plain type table above.
+//
+// Custom types are resolved by LOOKUP in meta.Types, not by excluding a
+// hardcoded list of built-ins. An earlier version negated a builtin-name list,
+// which accepted any undeclared type name as enum-like and could not tell a
+// value-less custom type from a real enum.
+func widgetAcceptsProperty(
+	widget string, pd metamodel.PropertyDef, meta *metamodel.Metamodel,
+) (ok bool, reason string) {
+	if pd.List {
+		if widget == WidgetMultiSelect {
+			return true, ""
+		}
+		return false, fmt.Sprintf(
+			"%q is a list property, which only %q can render", widget, WidgetMultiSelect)
+	}
+	if widgetPropertyHasValues(pd, meta) {
+		if widget == WidgetSelect || widget == WidgetMultiSelect {
+			return true, ""
+		}
+		return false, fmt.Sprintf(
+			"the property has a fixed value set, which only %q or %q can render",
+			WidgetSelect, WidgetMultiSelect)
+	}
+	accepted := sectionFieldWidgetTypes[widget]
+	if slices.Contains(accepted, pd.Type) {
+		return true, ""
+	}
+	return false, fmt.Sprintf("widget %q accepts: %s", widget, strings.Join(accepted, ", "))
+}
+
+// widgetPropertyHasValues reports whether a property is constrained to a fixed
+// value set — either inline (`values:`) or via a custom type declared under
+// `types:` that carries values. Mirrors ResolveWidgetFromType's own membership
+// test (schema_output.go), which likewise requires len(Values) > 0 so a
+// value-less custom type is not mistaken for an enum.
+func widgetPropertyHasValues(pd metamodel.PropertyDef, meta *metamodel.Metamodel) bool {
+	if len(pd.Values) > 0 {
+		return true
+	}
+	if meta == nil {
+		return false
+	}
+	ct, ok := meta.Types[pd.Type]
+	return ok && len(ct.Values) > 0
 }
 
 // validateSectionFieldWidget checks each field's `widget:` override: the name
@@ -161,17 +227,37 @@ var sectionFieldWidgetTypes = map[string][]string{
 // that cannot work.
 func validateSectionFieldWidget(
 	viewID string, i int, s ViewSection, eDef *metamodel.EntityDef,
+	meta *metamodel.Metamodel,
 ) []string {
 	var errs []string
 	for j, f := range s.Fields {
 		if f.Widget == "" {
 			continue
 		}
-		accepted, known := sectionFieldWidgetTypes[f.Widget]
-		if !known {
+		if _, known := sectionFieldWidgetTypes[f.Widget]; !known {
 			errs = append(errs, fmt.Sprintf(
 				"view %q: section[%d] field[%d] has invalid widget %q (valid: %s)",
-				viewID, i, j, f.Widget, joinWidgetTableKeys(sectionFieldWidgetTypes)))
+				viewID, i, j, f.Widget, strings.Join(sortedMapKeys(sectionFieldWidgetTypes), ", ")))
+			continue
+		}
+		// Property compatibility BEFORE the display-mode rule: a field can
+		// violate both, and reporting the surface rule first would send the
+		// operator to fix the display mode only to hit a second, different
+		// error on the next load.
+		var typeErr string
+		if eDef != nil {
+			if pd, ok := eDef.Properties[f.Property]; ok {
+				if accepted, reason := widgetAcceptsProperty(f.Widget, pd, meta); !accepted {
+					typeErr = fmt.Sprintf(
+						"view %q: section[%d] field[%d] sets widget %q on property %q of type %q: %s",
+						viewID, i, j, f.Widget, f.Property, pd.Type, reason)
+				}
+			}
+			// An unknown property is NOT an error here — inertWidgetWarnings
+			// reports it, since there is no type to check against.
+		}
+		if typeErr != "" {
+			errs = append(errs, typeErr)
 			continue
 		}
 		if f.Widget == WidgetFile && s.Display != "properties" {
@@ -179,57 +265,9 @@ func validateSectionFieldWidget(
 				"view %q: section[%d] field[%d] sets widget: file on display mode %q; "+
 					"the file widget is only supported on display: properties",
 				viewID, i, j, s.Display))
-			continue
-		}
-		if eDef == nil {
-			continue
-		}
-		pd, ok := eDef.Properties[f.Property]
-		if !ok {
-			continue // unknown property — inertWidgetWarnings reports it
-		}
-		if !widgetAcceptsType(accepted, pd.Type) {
-			errs = append(errs, fmt.Sprintf(
-				"view %q: section[%d] field[%d] sets widget %q on property %q of type %q "+
-					"(widget %q accepts: %s)",
-				viewID, i, j, f.Widget, f.Property, pd.Type, f.Widget,
-				strings.Join(accepted, ", ")))
 		}
 	}
 	return errs
-}
-
-// widgetAcceptsType reports whether a widget's accepted-type list covers the
-// property type. A custom enum type (one declared under `types:`) is accepted
-// wherever `enum` is, matching how the SPA treats it as a select-like value.
-func widgetAcceptsType(accepted []string, propType string) bool {
-	for _, t := range accepted {
-		if t == propType {
-			return true
-		}
-		// A custom type resolves to enum semantics; the metamodel's own
-		// resolveWidget makes the same equivalence.
-		isCustomEnumLike := t == metamodel.PropertyTypeEnum && propType != "" &&
-			propType != metamodel.PropertyTypeString &&
-			!isBuiltinPropertyType(propType)
-		if isCustomEnumLike {
-			return true
-		}
-	}
-	return false
-}
-
-// isBuiltinPropertyType reports whether the type is one of the metamodel's
-// built-ins, as opposed to an operator-declared custom (enum-like) type.
-func isBuiltinPropertyType(t string) bool {
-	switch t {
-	case metamodel.PropertyTypeString, metamodel.PropertyTypeDate,
-		metamodel.PropertyTypeDatetime, metamodel.PropertyTypeInteger,
-		metamodel.PropertyTypeBoolean, metamodel.PropertyTypeEnum,
-		metamodel.PropertyTypeFile, metamodel.PropertyTypeRrule:
-		return true
-	}
-	return false
 }
 
 // validateSectionRender checks the section-level `render:` and each field's,
@@ -976,6 +1014,19 @@ func inertWidgetWarnings(cfg *Config, meta *metamodel.Metamodel) []string {
 					continue
 				}
 				if eDef == nil {
+					// A collection whose target type cannot be determined
+					// statically (a relation with several `to:` types) is
+					// legal config — ValidateConfig does NOT error on it — so
+					// unlike an unknown collection this case has no other
+					// signal at all. The override is accepted unvalidated and
+					// works or not depending on the runtime entity type.
+					if ambiguousWidgetSource(s, collections) {
+						warnings = append(warnings, fmt.Sprintf(
+							"view %q: section[%d] field[%d] sets widget %q, but collection %q "+
+								"resolves to several entity types, so the widget cannot be "+
+								"checked against the property's type at load",
+							viewID, i, j, f.Widget, s.Source))
+					}
 					continue
 				}
 				if _, ok := eDef.Properties[f.Property]; !ok {
@@ -992,8 +1043,16 @@ func inertWidgetWarnings(cfg *Config, meta *metamodel.Metamodel) []string {
 }
 
 // widgetSectionDef resolves the entity def whose properties a section's fields
-// name, or nil when the source does not resolve (ValidateConfig already errors
-// on that separately, so the warning pass stays silent rather than guessing).
+// name, or nil when the source does not resolve.
+//
+// Three distinct situations return nil, and they are NOT equivalent:
+//   - no source at all — nothing to resolve;
+//   - an unknown collection — ValidateConfig already errors, so staying
+//     silent here avoids a duplicate report;
+//   - a known collection with no statically-determinable type (a relation with
+//     several `to:` types) — legal config that ValidateConfig does NOT error
+//     on, so it is the one case with no other signal. ambiguousWidgetSource
+//     distinguishes it and inertWidgetWarnings reports it.
 func widgetSectionDef(
 	s ViewSection, collections map[string]string, meta *metamodel.Metamodel,
 ) (def *metamodel.EntityDef, entityType string) {
@@ -1011,18 +1070,21 @@ func widgetSectionDef(
 	return d, sourceType
 }
 
-// viewCollectionTypes rebuilds the collection-name → entity-type map a view's
-// `traverse:` block defines, the same way ValidateConfig does. Needed because
-// a section's `source:` names a collection, not a type.
+// viewCollectionTypes builds the collection-name → entity-type map a view's
+// `traverse:` block defines, plus the implicit "entry" collection.
 //
-// A traversal whose relation type is unknown yields an empty target type,
-// which callers treat as unresolvable — the warning pass stays silent rather
-// than guessing, since ValidateConfig already errors on that separately.
+// ValidateConfig builds the same map inline while also reporting errors, and
+// an earlier version of this function was a hand-copy of that loop — which
+// promptly diverged by omitting "entry", silently skipping every
+// `source: entry` section. Prefer this one function; if ValidateConfig's
+// building half is ever factored out, delete this and call that instead.
+//
+// A traversal whose relation type is unknown, or whose target cannot be
+// determined statically (several `to:` types), yields an empty target type.
+// Callers must treat empty as unresolvable rather than as an error — see
+// ambiguousWidgetSource.
 func viewCollectionTypes(view ViewConfig, meta *metamodel.Metamodel) map[string]string {
 	out := make(map[string]string, len(view.Traverse)+1)
-	// "entry" is a collection name too — it refers to the view's entry entity
-	// type. ValidateConfig seeds it the same way; omitting it here silently
-	// skipped every `source: entry` section, which is the common case.
 	if view.Entry.Type != "" {
 		out["entry"] = view.Entry.Type
 	}
@@ -1030,13 +1092,28 @@ func viewCollectionTypes(view ViewConfig, meta *metamodel.Metamodel) map[string]
 		if t.CollectAs == "" {
 			continue
 		}
+		// Match ValidateConfig's precedence exactly: it assigns Follow then
+		// overwrites with FollowIncoming, so the incoming name wins when an
+		// author sets both (itself a separate error).
 		relName := t.Follow
-		if relName == "" {
+		if t.FollowIncoming != "" {
 			relName = t.FollowIncoming
 		}
 		out[t.CollectAs] = determineTargetType(t, relName, meta)
 	}
 	return out
+}
+
+// ambiguousWidgetSource reports whether a section names a collection that
+// EXISTS but whose entity type is not statically determinable. Distinguishes
+// that from an unknown collection (already a hard error) and from a section
+// with no source at all.
+func ambiguousWidgetSource(s ViewSection, collections map[string]string) bool {
+	if s.Source == "" {
+		return false
+	}
+	t, ok := collections[s.Source]
+	return ok && t == ""
 }
 
 // viewCommandPermissionWarnings flags `permission:` on a `context: view`
@@ -1334,7 +1411,7 @@ func validateViews(cfg *Config, meta *metamodel.Metamodel) []string {
 					widgetDef = d
 				}
 			}
-			errs = append(errs, validateSectionFieldWidget(viewID, i, s, widgetDef)...)
+			errs = append(errs, validateSectionFieldWidget(viewID, i, s, widgetDef, meta)...)
 
 			// Validate fields (if source type is known)
 			if sourceType != "" { //nolint:nestif // nested guards each check a distinct optional field of the source config.
@@ -2048,18 +2125,6 @@ func sortedMapKeys[V any](m map[string]V) []string {
 	}
 	natsort.Strings(keys)
 	return keys
-}
-
-// joinWidgetTableKeys is joinMapKeys for the widget→types table, whose value
-// type differs. Same output contract: sorted, comma-separated, for an error
-// message that tells the operator the valid set (the config is not a secret).
-func joinWidgetTableKeys(m map[string][]string) string {
-	keys := make([]string, 0, len(m))
-	for k := range m {
-		keys = append(keys, k)
-	}
-	natsort.Strings(keys)
-	return strings.Join(keys, ", ")
 }
 
 func joinMapKeys(m map[string]bool) string {

--- a/internal/dataentryconfig/widget_table_test.go
+++ b/internal/dataentryconfig/widget_table_test.go
@@ -1,0 +1,90 @@
+package dataentryconfig
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// TKT-3R7RF3 / RR-Z0GGTO: the widget → accepted-property-types table is
+// necessarily encoded twice — once here for config-load validation, once in the
+// SPA registry (frontend/src/widgets/registry.ts) as each entry's
+// `supportedPropertyTypes`. Two languages, one rule.
+//
+// The original plan accepted that drift risk on the grounds that ten entries
+// don't justify machinery. That reasoning was wrong: a THIRD encoding already
+// exists (Metamodel.ResolveWidgetFromType) and it has ALREADY drifted from the
+// SPA — it has no `file` case, so it resolves a file property to "text". A
+// table that has already drifted once is not a hypothetical risk.
+//
+// So both sides assert against the shared fixture below. Change the rule and
+// this test fails until testdata is updated; the matching Vitest test
+// (registry.widgetTable.test.ts) then fails until the SPA agrees. Neither side
+// can move alone.
+const widgetTableFixture = "testdata/widget_property_types.json"
+
+func TestSectionFieldWidgetTypes_MatchesFixture(t *testing.T) {
+	want := loadWidgetFixture(t)
+
+	got := make(map[string][]string, len(sectionFieldWidgetTypes))
+	for widget, types := range sectionFieldWidgetTypes {
+		sorted := append([]string(nil), types...)
+		sort.Strings(sorted)
+		got[widget] = sorted
+	}
+
+	if len(got) != len(want) {
+		t.Fatalf("widget count mismatch: Go has %d (%s), fixture has %d (%s)",
+			len(got), strings.Join(sortedWidgetNames(got), ", "),
+			len(want), strings.Join(sortedWidgetNames(want), ", "))
+	}
+	for widget, wantTypes := range want {
+		gotTypes, ok := got[widget]
+		if !ok {
+			t.Errorf("widget %q in fixture but not in sectionFieldWidgetTypes", widget)
+			continue
+		}
+		if strings.Join(gotTypes, ",") != strings.Join(wantTypes, ",") {
+			t.Errorf("widget %q accepts %v in Go, %v in fixture", widget, gotTypes, wantTypes)
+		}
+	}
+	for widget := range got {
+		if _, ok := want[widget]; !ok {
+			t.Errorf("widget %q in sectionFieldWidgetTypes but not in fixture", widget)
+		}
+	}
+}
+
+// The fixture is the contract, so a malformed or missing one must fail loudly
+// rather than vacuously pass an empty comparison.
+func loadWidgetFixture(t *testing.T) map[string][]string {
+	t.Helper()
+	raw, err := os.ReadFile(filepath.Clean(widgetTableFixture))
+	if err != nil {
+		t.Fatalf("read widget fixture: %v", err)
+	}
+	var out map[string][]string
+	if err := json.Unmarshal(raw, &out); err != nil {
+		t.Fatalf("parse widget fixture: %v", err)
+	}
+	if len(out) == 0 {
+		t.Fatal("widget fixture is empty; it is the cross-language contract")
+	}
+	for widget, types := range out {
+		sort.Strings(types)
+		out[widget] = types
+	}
+	return out
+}
+
+func sortedWidgetNames(m map[string][]string) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}

--- a/internal/dataentryconfig/widget_table_test.go
+++ b/internal/dataentryconfig/widget_table_test.go
@@ -24,6 +24,13 @@ import (
 // this test fails until testdata is updated; the matching Vitest test
 // (registry.widgetTable.test.ts) then fails until the SPA agrees. Neither side
 // can move alone.
+//
+// SCOPE: the fixture pins the TYPE half only. The higher-precedence rules —
+// `list: true` and a fixed value set, which the SPA's defaultWidgetFor checks
+// BEFORE the type — live in widgetAcceptsProperty and are pinned by
+// TestValidateConfig_WidgetOnListProperty / _WidgetOnInlineEnum instead. A
+// widget whose selection depends on something other than the property's type
+// therefore needs a test there, not just a fixture row here.
 const widgetTableFixture = "testdata/widget_property_types.json"
 
 func TestSectionFieldWidgetTypes_MatchesFixture(t *testing.T) {

--- a/internal/dataentryconfig/widget_test.go
+++ b/internal/dataentryconfig/widget_test.go
@@ -3,6 +3,8 @@ package dataentryconfig
 import (
 	"strings"
 	"testing"
+
+	"github.com/Sourcehaven-BV/rela/internal/metamodel"
 )
 
 // TKT-3R7RF3: a view section field may override which registered widget
@@ -12,6 +14,16 @@ import (
 // given widget override. sourceKnown=false makes the section reference an
 // unknown collection — the RR-4ICH8M regression case, where the name check
 // must still run because it needs no metamodel knowledge.
+// widgetTestMetamodel is testMetamodel plus a `file`-typed property, which the
+// shared fixture does not declare but the file-widget rules need.
+func widgetTestMetamodel() *metamodel.Metamodel {
+	meta := testMetamodel()
+	td := meta.Entities["ticket"]
+	td.Properties["attachment"] = metamodel.PropertyDef{Type: metamodel.PropertyTypeFile}
+	meta.Entities["ticket"] = td
+	return meta
+}
+
 func widgetConfig(property, widget, display string, sourceKnown bool) *Config {
 	source := "entry"
 	if !sourceKnown {
@@ -92,15 +104,33 @@ func TestValidateConfig_SectionFieldWidget(t *testing.T) {
 		{
 			// RR-NGY84F: only the entry mount site passes :attachments, so a
 			// FileWidget in a cards/list row would render with none.
+			//
+			// Uses a genuine `file` property (not `title`, a string) so this
+			// isolates the DISPLAY-MODE rule. With a string property the field
+			// violates two rules at once and only the type error is reported —
+			// which is deliberate: the type check runs first so an operator
+			// isn't sent to fix the display mode only to hit a second, different
+			// error on the next load.
 			name:     "file widget outside a properties section is rejected",
-			property: "title", widget: WidgetFile, display: "cards", sourceKnown: true,
+			property: "attachment", widget: WidgetFile, display: "cards", sourceKnown: true,
 			wantErr: `sets widget: file on display mode "cards"`,
+		},
+		{
+			name:     "file widget on a properties section is accepted",
+			property: "attachment", widget: WidgetFile, display: "properties", sourceKnown: true,
+		},
+		{
+			// M1: a field violating BOTH rules reports the type error, not the
+			// display-mode one — one round-trip, and the more specific message.
+			name:     "type error wins over the display-mode error",
+			property: "title", widget: WidgetFile, display: "cards", sourceKnown: true,
+			wantErr: `widget "file" accepts: file`,
 		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			cfg := widgetConfig(tc.property, tc.widget, tc.display, tc.sourceKnown)
-			err := ValidateConfig([]byte(`version: "1.0"`), cfg, testMetamodel())
+			err := ValidateConfig([]byte(`version: "1.0"`), cfg, widgetTestMetamodel())
 			if tc.wantErr == "" {
 				if err != nil && strings.Contains(err.Error(), "widget") {
 					t.Fatalf("unexpected widget error: %v", err)
@@ -223,4 +253,169 @@ func firstWidgetWarning(t *testing.T, cfg *Config) string {
 	}
 	t.Fatal("expected a widget warning, got none")
 	return ""
+}
+
+// widgetMetamodelWithShapes extends the shared test metamodel with the two
+// property shapes whose widget rules have HIGHER precedence than the plain
+// type table: a list property and an inline enum. Both were accepted
+// unconditionally before RR-* below.
+func widgetMetamodelWithShapes() *metamodel.Metamodel {
+	meta := testMetamodel()
+	td := meta.Entities["ticket"]
+	td.Properties["tags"] = metamodel.PropertyDef{Type: "string", List: true}
+	td.Properties["inline"] = metamodel.PropertyDef{Type: "string", Values: []string{"a", "b"}}
+	meta.Entities["ticket"] = td
+	return meta
+}
+
+// A list property renders through MultiSelectWidget in the SPA, whose
+// defaultWidgetFor puts `list` FIRST — above values and type. Any other widget
+// flattens the array through useStringValue and the auto-save then PATCHes a
+// SCALAR over a list: silent data corruption on config the server called valid.
+func TestValidateConfig_WidgetOnListProperty(t *testing.T) {
+	tests := []struct {
+		name    string
+		widget  string
+		wantErr bool
+	}{
+		{name: "multi-select is the only legal widget", widget: WidgetMultiSelect},
+		{name: "textarea would flatten the list", widget: WidgetTextarea, wantErr: true},
+		{name: "text would flatten the list", widget: WidgetText, wantErr: true},
+		{name: "select is single-valued", widget: WidgetSelect, wantErr: true},
+		{name: "checkbox is nonsense on a list", widget: WidgetCheckbox, wantErr: true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := widgetConfig("tags", tc.widget, "properties", true)
+			err := ValidateConfig([]byte(`version: "1.0"`), cfg, widgetMetamodelWithShapes())
+			if tc.wantErr && err == nil {
+				t.Fatalf("expected %q on a list property to be rejected", tc.widget)
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("expected %q to be accepted, got: %v", tc.widget, err)
+			}
+			if tc.wantErr && !strings.Contains(err.Error(), "list property") {
+				t.Errorf("error %q should explain the list rule", err.Error())
+			}
+		})
+	}
+}
+
+// An inline enum (`type: string` + `values:`) routes to select in the SPA,
+// which checks `values` BEFORE `type`. A free-text widget over a constrained
+// set offers the operator a control that can produce invalid values.
+func TestValidateConfig_WidgetOnInlineEnum(t *testing.T) {
+	tests := []struct {
+		name    string
+		widget  string
+		wantErr bool
+	}{
+		{name: "select matches the value set", widget: WidgetSelect},
+		{name: "multi-select is allowed", widget: WidgetMultiSelect},
+		{name: "text ignores the value set", widget: WidgetText, wantErr: true},
+		{name: "textarea ignores the value set", widget: WidgetTextarea, wantErr: true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := widgetConfig("inline", tc.widget, "properties", true)
+			err := ValidateConfig([]byte(`version: "1.0"`), cfg, widgetMetamodelWithShapes())
+			if tc.wantErr && err == nil {
+				t.Fatalf("expected %q on an inline enum to be rejected", tc.widget)
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("expected %q to be accepted, got: %v", tc.widget, err)
+			}
+		})
+	}
+}
+
+// Custom types are resolved by LOOKUP in meta.Types, not by excluding a list of
+// built-in names. The negation approach accepted any undeclared type name as
+// enum-like and could not distinguish a value-less custom type from a real one.
+func TestWidgetAcceptsProperty_CustomTypesByLookup(t *testing.T) {
+	meta := testMetamodel()
+	meta.Types["valueless"] = metamodel.CustomType{} // declared, but no values
+
+	tests := []struct {
+		name     string
+		widget   string
+		propType string
+		want     bool
+	}{
+		{name: "declared enum type accepts select", widget: WidgetSelect, propType: "status", want: true},
+		{name: "undeclared type is NOT enum-like", widget: WidgetSelect, propType: "totally-bogus"},
+		{name: "value-less custom type is not select-able", widget: WidgetSelect, propType: "valueless"},
+		{name: "declared enum type rejects checkbox", widget: WidgetCheckbox, propType: "status"},
+		{name: "plain string accepts text", widget: WidgetText, propType: "string", want: true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			pd := metamodel.PropertyDef{Type: tc.propType}
+			got, reason := widgetAcceptsProperty(tc.widget, pd, meta)
+			if got != tc.want {
+				t.Errorf("widgetAcceptsProperty(%q, %q) = %v (%s), want %v",
+					tc.widget, tc.propType, got, reason, tc.want)
+			}
+		})
+	}
+}
+
+// A section sourced from a multi-type traversal is LEGAL config that
+// ValidateConfig does not error on, so an unvalidatable widget there would
+// otherwise be accepted in total silence.
+func TestCollectConfigWarnings_WidgetOnAmbiguousSource(t *testing.T) {
+	meta := testMetamodel()
+	// `blocks` goes ticket→ticket; make it multi-target so the collected type
+	// cannot be determined statically.
+	rd := meta.Relations["blocks"]
+	rd.To = []string{"ticket", "category"}
+	meta.Relations["blocks"] = rd
+
+	cfg := &Config{
+		Version: "1.0",
+		App:     AppConfig{Name: "Test App"},
+		Views: map[string]ViewConfig{
+			"v": {
+				Title:    "V",
+				Entry:    ViewEntry{Type: "ticket"},
+				Traverse: []ViewTraverse{{Follow: "blocks", CollectAs: "blocked"}},
+				Sections: []ViewSection{{
+					Heading: "Blocked",
+					Source:  "blocked",
+					Display: "list",
+					Fields:  []ViewSectionField{{Property: "title", Widget: WidgetTextarea}},
+				}},
+			},
+		},
+	}
+	var got string
+	for _, w := range CollectConfigWarnings(cfg, meta) {
+		if strings.Contains(w, "several entity types") {
+			got = w
+			break
+		}
+	}
+	if got == "" {
+		t.Fatalf("expected an ambiguous-source warning, got %v", CollectConfigWarnings(cfg, meta))
+	}
+	if !strings.Contains(got, "section[0] field[0]") {
+		t.Errorf("warning %q should name the precise origin", got)
+	}
+}
+
+// viewCollectionTypes must agree with the map ValidateConfig builds inline.
+// The "entry" collection was omitted in an earlier version, which silently
+// skipped every `source: entry` section.
+func TestViewCollectionTypes_IncludesEntry(t *testing.T) {
+	view := ViewConfig{
+		Entry:    ViewEntry{Type: "ticket"},
+		Traverse: []ViewTraverse{{Follow: "belongs-to", CollectAs: "cats"}},
+	}
+	got := viewCollectionTypes(view, testMetamodel())
+	if got["entry"] != "ticket" {
+		t.Errorf(`collections["entry"] = %q, want "ticket"`, got["entry"])
+	}
+	if got["cats"] != "category" {
+		t.Errorf(`collections["cats"] = %q, want "category"`, got["cats"])
+	}
 }

--- a/internal/dataentryconfig/widget_test.go
+++ b/internal/dataentryconfig/widget_test.go
@@ -1,0 +1,226 @@
+package dataentryconfig
+
+import (
+	"strings"
+	"testing"
+)
+
+// TKT-3R7RF3: a view section field may override which registered widget
+// renders its property, instead of the type-derived default.
+
+// widgetConfig builds a config with one view whose single section carries the
+// given widget override. sourceKnown=false makes the section reference an
+// unknown collection — the RR-4ICH8M regression case, where the name check
+// must still run because it needs no metamodel knowledge.
+func widgetConfig(property, widget, display string, sourceKnown bool) *Config {
+	source := "entry"
+	if !sourceKnown {
+		source = "no_such_collection"
+	}
+	return &Config{
+		Version: "1.0",
+		App:     AppConfig{Name: "Test App"},
+		Views: map[string]ViewConfig{
+			"ticket_view": {
+				Title: "Ticket",
+				Entry: ViewEntry{Type: "ticket"},
+				Sections: []ViewSection{{
+					Heading: "Details",
+					Source:  source,
+					Display: display,
+					Fields: []ViewSectionField{
+						{Property: property, Label: "L", Widget: widget},
+					},
+				}},
+			},
+		},
+	}
+}
+
+func TestValidateConfig_SectionFieldWidget(t *testing.T) {
+	tests := []struct {
+		name        string
+		property    string
+		widget      string
+		display     string
+		sourceKnown bool
+		wantErr     string // substring; empty means no widget error expected
+	}{
+		{name: "no widget is the default", property: "status", display: "properties", sourceKnown: true},
+		{
+			name: "select on an enum property", property: "status", widget: WidgetSelect,
+			display: "properties", sourceKnown: true,
+		},
+		{
+			name:     "textarea on a string property is the motivating override",
+			property: "title", widget: WidgetTextarea, display: "properties", sourceKnown: true,
+		},
+		{
+			name: "unregistered name is rejected", property: "status", widget: "bogus",
+			display: "properties", sourceKnown: true,
+			wantErr: `section[0] field[0] has invalid widget "bogus"`,
+		},
+		{
+			// The name check needs no metamodel knowledge, so an unresolvable
+			// source must not suppress it (RR-4ICH8M).
+			name:     "unregistered name is caught when the source does not resolve",
+			property: "status", widget: "bogus", display: "properties", sourceKnown: false,
+			wantErr: `section[0] field[0] has invalid widget "bogus"`,
+		},
+		{
+			name:     "whitespace-only is rejected, not trimmed to empty",
+			property: "status", widget: "  ", display: "properties", sourceKnown: true,
+			wantErr: `has invalid widget "  "`,
+		},
+		{
+			// Widget names are lowercase throughout; a silent case-fold would
+			// make config non-canonical, and the SPA does not fold either.
+			name: "capitalised name is rejected", property: "status", widget: "Checkbox",
+			display: "properties", sourceKnown: true,
+			wantErr: `has invalid widget "Checkbox"`,
+		},
+		{
+			name:     "checkbox on a string property is a type mismatch",
+			property: "title", widget: WidgetCheckbox, display: "properties", sourceKnown: true,
+			wantErr: `sets widget "checkbox" on property "title" of type "string"`,
+		},
+		{
+			name:     "date widget on a string property is a type mismatch",
+			property: "title", widget: WidgetDate, display: "properties", sourceKnown: true,
+			wantErr: `sets widget "date" on property "title"`,
+		},
+		{
+			// RR-NGY84F: only the entry mount site passes :attachments, so a
+			// FileWidget in a cards/list row would render with none.
+			name:     "file widget outside a properties section is rejected",
+			property: "title", widget: WidgetFile, display: "cards", sourceKnown: true,
+			wantErr: `sets widget: file on display mode "cards"`,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := widgetConfig(tc.property, tc.widget, tc.display, tc.sourceKnown)
+			err := ValidateConfig([]byte(`version: "1.0"`), cfg, testMetamodel())
+			if tc.wantErr == "" {
+				if err != nil && strings.Contains(err.Error(), "widget") {
+					t.Fatalf("unexpected widget error: %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("expected error containing %q, got nil", tc.wantErr)
+			}
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Errorf("error %q does not contain %q", err.Error(), tc.wantErr)
+			}
+		})
+	}
+}
+
+// The invalid-name message must list the valid set so the operator can fix it
+// without reading the source — the config is not a secret (CLAUDE.md).
+func TestValidateConfig_SectionFieldWidget_ErrorListsValidNames(t *testing.T) {
+	cfg := widgetConfig("status", "bogus", "properties", true)
+	err := ValidateConfig([]byte(`version: "1.0"`), cfg, testMetamodel())
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+	for _, want := range []string{WidgetCheckbox, WidgetSelect, WidgetTextarea, WidgetFile} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error %q should list valid widget %q", err.Error(), want)
+		}
+	}
+}
+
+// A type-mismatch message must name what the widget DOES accept, otherwise the
+// operator has to guess which widget to reach for instead.
+func TestValidateConfig_SectionFieldWidget_MismatchNamesAcceptedTypes(t *testing.T) {
+	cfg := widgetConfig("title", WidgetCheckbox, "properties", true)
+	err := ValidateConfig([]byte(`version: "1.0"`), cfg, testMetamodel())
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+	if !strings.Contains(err.Error(), "accepts: boolean") {
+		t.Errorf("error %q should name the accepted types", err.Error())
+	}
+}
+
+// RR-2GBB0V / AC5: a widget on a property the metamodel does not declare is
+// ignored at render (the SPA routes it through resolveFromHint, which takes no
+// name), so warn rather than error — the operator otherwise gets silence.
+func TestCollectConfigWarnings_WidgetOnUndeclaredProperty(t *testing.T) {
+	cfg := widgetConfig("not_a_real_property", WidgetTextarea, "properties", true)
+	got := firstWidgetWarning(t, cfg)
+	if !strings.Contains(got, "section[0] field[0]") {
+		t.Errorf("warning %q should name the precise origin", got)
+	}
+	if !strings.Contains(got, "not_a_real_property") {
+		t.Errorf("warning %q should name the property", got)
+	}
+	// It must not ALSO be a hard error — that is the whole point of warning.
+	if err := ValidateConfig([]byte(`version: "1.0"`), cfg, testMetamodel()); err != nil {
+		if strings.Contains(err.Error(), "widget") {
+			t.Errorf("undeclared property should warn, not error: %v", err)
+		}
+	}
+}
+
+// RR-675AA0's sibling: `widget:` on a display mode that renders no fields at
+// all is inert, same as `render:` is.
+func TestCollectConfigWarnings_InertWidget(t *testing.T) {
+	tests := []struct {
+		name     string
+		display  string
+		wantWarn bool
+	}{
+		{name: "properties renders fields", display: "properties"},
+		{name: "list renders fields", display: "list"},
+		{name: "cards renders fields", display: "cards"},
+		{name: "table does not render fields", display: "table", wantWarn: true},
+		{name: "content does not render fields", display: "content", wantWarn: true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// Use a declared property so only the display mode can warn.
+			cfg := widgetConfig("status", WidgetSelect, tc.display, true)
+			var got string
+			for _, w := range CollectConfigWarnings(cfg, testMetamodel()) {
+				if strings.Contains(w, "widget") {
+					got = w
+					break
+				}
+			}
+			if tc.wantWarn && got == "" {
+				t.Fatalf("expected an inert-widget warning for display %q", tc.display)
+			}
+			if !tc.wantWarn && got != "" {
+				t.Errorf("unexpected inert-widget warning for display %q: %s", tc.display, got)
+			}
+			if tc.wantWarn && !strings.Contains(got, tc.display) {
+				t.Errorf("warning %q should name the display mode %q", got, tc.display)
+			}
+		})
+	}
+}
+
+// A section with no widget authored must stay completely silent — a warning on
+// every ordinary section would train operators to ignore the channel.
+func TestCollectConfigWarnings_NoWidgetIsSilent(t *testing.T) {
+	cfg := widgetConfig("status", "", "table", true)
+	for _, w := range CollectConfigWarnings(cfg, testMetamodel()) {
+		if strings.Contains(w, "widget") {
+			t.Errorf("unexpected widget warning when none is authored: %s", w)
+		}
+	}
+}
+
+func firstWidgetWarning(t *testing.T, cfg *Config) string {
+	t.Helper()
+	for _, w := range CollectConfigWarnings(cfg, testMetamodel()) {
+		if strings.Contains(w, "widget") {
+			return w
+		}
+	}
+	t.Fatal("expected a widget warning, got none")
+	return ""
+}

--- a/prototypes/data-entry/project/data-entry.yaml
+++ b/prototypes/data-entry/project/data-entry.yaml
@@ -463,6 +463,22 @@ views:
             span: 6
           - property: estimated_hours
             span: 4
+          # TKT-3R7RF3 — `widget:` overrides which widget renders a property,
+          # independently of its type.
+          #
+          # is_blocked is a boolean, so a checkbox is already its default; it
+          # is spelled out here because with `render: input` above it is the
+          # payoff case — tick it and the value saves, no form round-trip.
+          #
+          # description is a string, whose default is a single-line text
+          # input. `widget: textarea` is the case that only config can reach:
+          # nothing about the type says this field holds a paragraph.
+          - property: is_blocked
+            widget: checkbox
+            span: 4
+          - property: description
+            widget: textarea
+            span: 12
 
       # Ticket body (markdown content)
       - source: entry

--- a/prototypes/data-entry/project/scripts/docs/ticket_summary.lua
+++ b/prototypes/data-entry/project/scripts/docs/ticket_summary.lua
@@ -15,7 +15,11 @@
 --       entity_type: ticket
 --       script: docs/ticket_summary.lua
 
-local id = rela.entity_id
+-- `rela.document.entry_id`, NOT `rela.entity_id` — the latter is not bound by
+-- the Lua runtime, so it was silently nil and every render of this document
+-- failed with "bad argument #1 to get_entity (string expected, got nil)".
+-- The sibling category_report.lua already used the documented name.
+local id = rela.document.entry_id
 local e = rela.get_entity(id)
 
 if not e then

--- a/tickets/entities/docs-checklists/DOCS-WGTOVR.md
+++ b/tickets/entities/docs-checklists/DOCS-WGTOVR.md
@@ -1,0 +1,34 @@
+---
+id: DOCS-WGTOVR
+type: docs-checklist
+title: 'Docs: Widget override for view section fields'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Code Documentation
+
+- [x] Godoc on `ViewSectionField.Widget` explaining it is passed through verbatim (the SPA's registry owns resolution) and why it is field-level ONLY, unlike `Render` — a section-level widget would be a config error on every field of a non-matching type
+- [x] Godoc on `sectionFieldWidgetTypes` recording that it is deliberately NOT derived from `Metamodel.ResolveWidgetFromType` (that resolver serves table cells, has no `file` case, and has already drifted), and that it is only the TYPE half of the rule
+- [x] Godoc on `widgetAcceptsProperty` documenting the precedence it mirrors (`list` → values → type) and, for each rule, the concrete failure it prevents — notably the list-flattening PATCH
+- [x] Godoc on `inertWidgetWarnings` covering both warned cases and stating explicitly why the state-machine case is NOT warned (machine-ness is runtime, per-principal; unbuildable at config load)
+- [x] Comment on `SectionEditForm.widgetRows` recording that the override applies on the schema arm only, and why the hint arm cannot validate one
+- [x] Comment on `WIDGET_REGISTRATIONS` explaining it is exported data so the drift guard can assert the REAL registrations
+- [x] ~~CLAUDE.md pattern update~~ (N/A: follows the existing `Render` thread and the `validRelationWidgets` allowlist pattern; introduces no new convention)
+
+## Project Documentation
+
+- [x] `docs/data-entry.md` — new **Widget Overrides** section: the accepted widget/type table, field-level-only rule with rationale, the `render:` pairing ("a checkbox you cannot click is just an icon"), the `widget: file` properties-only restriction, and the two ignored cases
+- [x] `docs/data-entry.md` — **Field Render Modes** section added for TKT-HOIX1's `render:`, which shipped undocumented (its PR touched no docs file at all; `docs/` is generated from `docs-project/entities/`, so the edit was silently overwritten)
+- [x] Section-field table extended with the `render` and `widget` keys; the per-field key table (`property`/`label`/`span`/`render`/`widget`) added, which did not previously exist
+- [x] Edited the SOURCE (`docs-project/entities/guides/GUIDE-data-entry.md`) and regenerated, not the generated file
+
+## External Documentation
+
+- [x] ~~README / external docs~~ (N/A: a `data-entry.yaml` config key, covered by the data-entry guide)
+
+**Docs verified:** `just docs` regenerated cleanly and `just ci`'s
+docs-freshness gate passes. The documented widget/type table matches
+`sectionFieldWidgetTypes` and the shared drift fixture; the documented
+restrictions match the implemented errors and warnings.

--- a/tickets/entities/implementation-checklists/IMPL-P24QGI.md
+++ b/tickets/entities/implementation-checklists/IMPL-P24QGI.md
@@ -1,0 +1,108 @@
+---
+id: IMPL-P24QGI
+type: implementation-checklist
+title: 'Implementation: Widget override for view section fields (`widget:` on ViewSectionField)'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Development
+
+- [x] Unit tests written for new code
+- [x] Integration tests written (test full flow, not just units)
+- [x] Happy path implemented
+- [x] Edge cases from planning handled
+- [x] Error handling in place (errors surfaced, not swallowed)
+
+Go: `widget_test.go` (validation: unknown name, whitespace-only, capitalised,
+type mismatch, file-outside-properties, RR-4ICH8M unresolved-source case, both
+warning kinds, silence when unauthored), `widget_table_test.go` (drift guard),
+`sections_widget_test.go` (both construction sites carry Widget).
+
+Frontend: `SectionEditForm.test.ts` +8 (override applied, default preserved,
+display arm, hint arm DROPPED per RR-2GBB0V, StatusControl two-axis per
+RR-66MT0D, ACL conjunction intact, unknown-name fallback);
+`sectionEditFields.test.ts` +4; `registry.widgetTable.test.ts` (drift guard +
+AC2 in the right language per RR-693NL9).
+
+E2E: `view-section-widget-override.spec.ts` — 4 specs, all passing.
+
+## Test Quality
+
+- [x] Using fixture builders or factories for test data
+- [x] No hardcoded values in assertions when object is in scope
+- [x] Only specifying values that matter for the test
+- [x] Interpolated values constructed from objects, not hardcoded
+- [x] Property comparisons use original object, not hardcoded strings
+
+Go table tests use the `widgetConfig(...)` builder (mirrors the existing
+`renderConfig`); frontend reuses the established `mountForm` / `makeFields`
+harness; e2e reuses `SEED` rather than literal ids.
+
+## Manual Verification
+
+- [x] Feature manually tested end-to-end
+- [x] Each acceptance criterion verified with test scenario from planning
+- [x] Edge cases manually verified
+
+**Verification Evidence:**
+
+Verified in a real browser via Playwright against a freshly built
+`bin/rela-server` (the embedded-SPA binary), not only in unit tests:
+
+| AC | Result |
+| -- | ------ |
+| 1 `widget: checkbox` clickable + persists | PASS — click fires a PATCH; value survives a reload |
+| 2 omitting `widget:` unchanged | PASS — frontend table test over every property type |
+| 3 unregistered name errors | PASS — error names the valid set |
+| 4 type mismatch errors | PASS — error names property, type, accepted types |
+| 5 undeclared property warns, no error | PASS |
+| 6 `widget: file` outside `properties` errors | PASS |
+
+The **load-bearing** e2e case is `title` (a string) forced to `textarea`. A
+boolean already resolves to a checkbox on its own, so a checkbox-only assertion
+would still pass if the plumbing were silently dropped; only the textarea
+proves config reached the registry.
+
+Two genuine failures were found and fixed during this verification, both of
+which unit tests could not have caught:
+
+1. **A stale `bin/rela-server` (Aug 17)** was running the e2e suite, embedding a
+   pre-change SPA. `just ci` does NOT rebuild it. The first e2e run failed for
+   this reason alone — worth knowing for the next ticket.
+2. **The autosave debounce (800ms)** meant the original spec reloaded before the
+   PATCH landed and read a stale value, which is indistinguishable from a
+   dropped write. `toggleSectionCheckbox` now waits for the PATCH response.
+
+**Not done:** no human has looked at the page. The assertions are structural
+(tag name, enabled state, checked state), so they prove the right widget renders
+and works — not that it looks right. Recommend a glance via `just dev` before
+merge, as with TKT-HOIX1.
+
+## Quality
+
+- [x] Code follows project patterns (check similar code)
+- [x] Checked for DRY opportunities — repeated literals, expressions, or
+patterns extracted to a helper / constant / type where it sharpens the contract
+(don't extract for its own sake; CLAUDE.md "three similar lines is better than a
+premature abstraction" still holds)
+- [x] No security issues introduced
+- [x] No silent failures (errors logged AND returned)
+- [x] No debug code left behind
+
+Patterns followed: `Render`'s thread for the plumbing, `validRelationWidgets`
+for the allowlist shape, `inertSectionRenderWarnings` for warn-don't-error.
+DRY: `buildSectionFieldData` already unifies both Go construction sites, so
+`Widget` landed in both at once; `joinWidgetTableKeys` is a deliberate sibling
+of `joinMapKeys` (different value type, same output contract) rather than a
+generic rewrite of a widely-used helper.
+
+Security: the only new input is an operator-authored string validated at config
+load against a CLOSED allowlist; it selects among components already compiled
+into the bundle and never reaches a path, command, or query. The ACL
+conjunction is untouched and pinned by a test — widget selection decides WHICH
+component renders, never WHETHER it is writable.
+
+Two temporary scaffolds written during debugging were removed (a wire-conversion
+probe and an e2e response probe); `git status` is clean of them.

--- a/tickets/entities/planning-checklists/PLAN-DMQFRJ.md
+++ b/tickets/entities/planning-checklists/PLAN-DMQFRJ.md
@@ -1,0 +1,379 @@
+---
+id: PLAN-DMQFRJ
+type: planning-checklist
+title: 'Planning: Widget override for view section fields (`widget:` on ViewSectionField)'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Understanding
+
+- [x] Problem/requirements clearly understood
+- [x] Scope defined (what's in/out documented below)
+- [x] Acceptance criteria documented with specific test scenarios
+
+**Scope:**
+
+IN — an optional `widget:` key on a view section field, letting config choose
+which registered widget renders a property instead of the type-derived default:
+
+```yaml
+sections:
+  - heading: Today
+    display: properties
+    render: input
+    fields:
+      - property: done
+        widget: checkbox
+```
+
+OUT:
+- New widget types. Only selection among already-registered ones.
+- The `render:` axis (TKT-HOIX1, merged #1364).
+- The table-cell path (`ViewCell.Widget`) — LIVE and type-derived (finding 1),
+  excluded as a different surface, not as dead code.
+- Closing the pre-existing `FormField.Widget` validation gap (finding 4) —
+  separate ticket, it is a breaking change on its own.
+- Any override on the hint arm (finding 3) — unvalidatable there, so ignored
+  and warned, not deferred.
+- `_attachments` on cards/list rows (RR-NGY84F) — follow-up ticket; this ticket
+  rejects `widget: file` outside a `properties` section instead.
+
+**Acceptance Criteria:**
+
+1. `widget: checkbox` on a boolean property in a `render: input` section renders
+   a clickable checkbox rather than the type default.
+   → e2e: click it, assert the PATCH lands and the value flips.
+2. Omitting `widget:` reproduces today's selection byte-for-byte.
+   → **frontend** unit (RR-693NL9): the section path's type→widget selection is
+   `defaultWidgetFor` (`registry.ts:18`), not Go — a Go test would pin a mapping
+   this code path never consults. Table test over every property type asserting
+   `widget: undefined` → `defaultWidgetFor(propertyDef)`.
+3. An unregistered widget name is a config-load error naming the valid set.
+   → unit: `ValidateConfig` returns an error containing the name + valid list.
+4. A widget incompatible with the property's type is a config-load error.
+   → unit: `widget: checkbox` on a `date` property errors.
+5. A `widget:` on a property absent from `schema.yaml` loads, is ignored at
+   render, and emits a warning naming section + field index.
+   → unit: `CollectConfigWarnings` contains it; no error returned.
+   → plus a **hint-arm negative test** (RR-2GBB0V) asserting the override is
+   provably DROPPED, so a later refactor that plumbs `widget` into the shared
+   half of the union — where both arms would see it — fails loudly.
+6. `widget: file` outside a `properties`-display section is a config-load error
+   (RR-NGY84F).
+   → unit: a `cards` section with `widget: file` errors.
+
+**Not an acceptance criterion** (RR-66MT0D): a warning for `widget:` on a
+state-machine field. Machine-ness is runtime, per-entity and per-principal
+(`computeTransitions`, `affordances.go:1051`, gated on a `TransitionResolver`
+type-assertion); `CollectConfigWarnings` has neither a resolver nor an entity,
+so the warning is unbuildable. Documented in `docs/data-entry.md` instead.
+
+## Research
+
+- [x] For larger features: run `/research` to create a structured research doc
+- [x] Searched for existing libraries that solve this problem
+- [x] Checked codebase for similar patterns or reusable code
+- [x] Looked for reference implementations in other projects
+- [x] Reviewed relevant rela concepts for prior art
+
+**Research Doc:** N/A — small, single-axis change with a directly analogous
+predecessor (TKT-HOIX1) landed two commits ago.
+
+**Existing Solutions:**
+
+No library question — this is config plumbing through an existing registry.
+
+Verified against develop @ 3a735757. **The ticket as written was stale in four
+material ways**; each was checked in code, not assumed:
+
+1. **`ViewCell.Widget` is LIVE** — my original claim that it was dead was
+   WRONG (RR-YTC4W5). `cell.Widget = resolveWidget(pd, s.Meta)`
+   (`sections.go:296`) populates it; `v1.ViewCell(cell)`
+   (`views_handler.go:611,629`) ships it on every table cell. My grep pattern
+   `'Widget:'` structurally could not match a field assignment. Tables stay out
+   of scope on **surface** grounds (different renderer, no inline edit), not
+   because the field is unused. **Corollary that matters for the drift
+   decision:** a second server-side resolver already exists
+   (`ResolveWidgetFromType`, `schema_output.go:117`) claiming in its godoc to be
+   the single source of truth — already false, and already drifted from
+   `defaultWidgetFor` on `file`, `list`, and `values`.
+
+2. **`registry.ts` needs no change.** `defaultRegistry.resolve(name, propertyDef)`
+   (`registry.ts:50-70`) *already* prefers an explicit name, already falls back to
+   the type default on an unknown name, and already warns. The sole gap is the
+   only view-side caller — `SectionEditForm.vue:147-152` hardcodes
+   `resolve(undefined, field.propertyDef)`.
+
+3. **The hint arm must ignore the override — corrected rationale**
+   (RR-2GBB0V). An unschema'd field is NOT display-only: `isFieldWritable`
+   (`affordances.ts:12-18`) returns `true` for a *missing* verdict — documented,
+   deliberate — and neither `widgetRows` (`SectionEditForm.vue:164`) nor the
+   edit branch (`:288`) inspects `field.kind`. A hint-arm field on
+   `render: input` therefore renders an EDITABLE widget and PATCHes. The real
+   constraint is that the arm has no `PropertyDef` (`:298`, `:314` pass
+   `undefined`), so AC4's compatibility rule is **unenforceable** there;
+   honouring `widget:` would ship an unvalidated widget into a live edit
+   control (`checkbox` PATCHing a boolean into a string property). Ignore, warn,
+   and TEST that it is provably dropped.
+
+4. **`FormField.Widget` is validated nowhere** — `grep 'f.Widget'` in
+   `validate.go` returns nothing, so a typo'd form widget silently falls back
+   today. Not inherited by the new field; not fixed here either.
+
+Prior art followed: `Render` (TKT-HOIX1) for the plumbing shape;
+`validRelationWidgets` (`validate.go:159-164`) for the allowlist-map validation
+shape; `inertSectionRenderWarnings` for the warn-don't-error shape.
+
+## Approach
+
+- [x] Technical approach chosen and documented
+- [x] Approach builds on existing patterns (not reinventing)
+- [x] Alternatives considered (document why rejected)
+- [x] Dependencies identified (packages, APIs, types)
+
+**Technical Approach:**
+
+Mirror the `Render` thread end to end, with one deliberate difference: **no
+section-level inheritance** — field-level only. `render:` can inherit because
+both of its values are valid for every field; a section-level `widget:` would be
+a config-load ERROR on every field whose type doesn't match, turning one authored
+line into N errors the operator must override back field-by-field. See
+Alternatives for the full argument (RR-9G51IS). This is the main structural
+departure from TKT-HOIX1 and is intentional.
+
+Compatibility rule for AC4 — a widget is valid for a property when the pair
+appears in the table below. **Do NOT derive this from
+`Metamodel.ResolveWidgetFromType`** (RR-Z0GGTO): that function has no `file`
+case, so deriving would reject `widget: file` on a `file` property, which is
+legal. The table is authored as its own Go map literal, mirroring the
+registry's `supportedPropertyTypes` (`registry.ts:105-117`):
+
+| widget         | accepts                                  |
+| -------------- | ---------------------------------------- |
+| `text`         | string                                   |
+| `textarea`     | string                                    |
+| `number`       | integer                                  |
+| `checkbox`     | boolean                                  |
+| `date`         | date                                     |
+| `datetime`     | datetime                                 |
+| `select`       | enum, string, custom enum types          |
+| `multi-select` | enum, string (list properties)           |
+| `rrule`        | rrule                                    |
+| `file`         | file                                     |
+
+`textarea` on a string is the motivating non-default pair (long text), as is
+`select` on a string with a custom type. The table is the whole point of the
+feature — without it the only legal value is the default.
+
+**Drift guard (RR-Z0GGTO).** The table is duplicated across Go and TS, so both
+sides assert against one shared fixture: a Vitest test asserting the registry's
+`supportedPropertyTypes` matches it, and a Go test asserting the validator's map
+matches it. Two small tests that FAIL on drift, rather than a comment that
+documents it. This is not hypothetical — the two existing resolvers have already
+drifted on `file`.
+
+**`widget: file` is rejected outside a `properties` section** (RR-NGY84F): only
+the entry site passes `:attachments` (`EntityDetail.vue:893`); the cards
+(`:982-992`) and list (`:1038-1048`) sites do not, so a forced `FileWidget` in a
+row would render with `attachments === undefined`. Plumbing `_attachments` onto
+`ViewEntity` is the fuller fix and is a follow-up ticket.
+
+**Alternatives rejected:**
+- *Section-level `widget:`* — rejected for two reasons stronger than the
+  "meaningless across mixed types" one first given (RR-9G51IS, which a
+  five-string-properties-all-wanting-textarea section defeats). First, `render:`
+  can inherit because BOTH its values are valid for every field; a section-level
+  `widget:` is a config-load ERROR on every field of a non-matching type, so one
+  authored line becomes N errors the operator must undo field-by-field —
+  anti-inheritance. Second, validating it needs each field's property type,
+  i.e. exactly the metamodel-dependent context RR-4ICH8M moved the field-level
+  check OUT of.
+- *Extending `resolveFromHint` to take a name* — would let config target a path
+  with no PropertyDef to validate against and no save path. Finding 3.
+- *Name-only validation, skip the type check* — cheap, but `checkbox` on a
+  `date` yields a control that cannot represent the value. Config errors should
+  surface at load, matching the rest of `validate.go`.
+- *Reusing `FormField.Widget`'s (absent) validation* — inherits a known gap.
+
+**Files to modify:**
+
+Backend:
+- `internal/dataentryconfig/config.go` — `Widget string` on `ViewSectionField`.
+- `internal/dataentryconfig/validate.go` — `validateSectionFieldWidget`; called
+  **outside** the source-resolution guards (the RR-4ICH8M lesson from HOIX1:
+  a closed enum needs no metamodel knowledge to reject). Plus the
+  undeclared-property warning in `CollectConfigWarnings`.
+- `internal/dataentry/sections.go` — `Widget` on `SectionFieldData`; carried in
+  `buildSectionFieldData`.
+- `internal/apiwire/v1/responses.go` — `Widget` on `SectionField`, **same
+  position/type** (the unnamed conversion `v1.SectionField(f)` is the
+  compile-checked sync).
+
+Frontend:
+- `frontend/src/api/views.ts` — `widget?: string` on `ViewSectionField`.
+- `frontend/src/components/entity/sectionEditFields.ts` — carry onto
+  `SectionEditField`.
+- `frontend/src/components/forms/SectionEditForm.vue` — `widgetRows` passes
+  `field.widget` to `resolve` on the schema arm.
+
+Docs: `docs/data-entry.md`.
+
+## Security Considerations
+
+- [x] Input sources identified (user input, config, external APIs)
+- [x] Input validation approach defined (allowlist preferred over blocklist)
+- [x] Security-sensitive operations identified (file access, auth, crypto)
+- [x] Error handling doesn't leak sensitive information
+
+**Input Sources & Validation:**
+
+One input: the `widget:` string in operator-authored `data-entry.yaml`. Validated
+at config load against a **closed allowlist map** (the `validRelationWidgets`
+shape), never a blocklist. Invalid → config-load error, server does not start
+with a bad config. The value never reaches a filesystem path, a command, or a
+query — it selects among components already compiled into the SPA bundle. An
+unknown name reaching the client anyway (shape drift) is handled defensively by
+`registry.resolve`, which falls back to the type default and warns.
+
+**Security-Sensitive Operations:**
+
+None. Explicitly **not** an ACL surface: widget selection is presentation, and
+this ticket does not touch the `render === 'input' && isFieldWritable(verdict)`
+conjunction that gates editability. A `widget:` on a read-only field still
+renders display — the widget choice decides *which* component, never *whether*
+it is writable. Guard test asserts exactly this.
+
+Per CLAUDE.md "the configuration is not a secret": widget names are operator-
+authored config, so the error message naming the valid set is correct and
+useful, not a leak.
+
+## Test Plan
+
+- [x] Test scenarios documented for each acceptance criterion
+- [x] Edge cases identified and documented
+- [x] Negative test cases defined (invalid input, error conditions)
+- [x] Integration test approach defined (not just unit tests)
+
+**Test Scenarios:**
+
+| AC | Test | Where |
+| -- | ---- | ----- |
+| 1 | checkbox click PATCHes and flips | e2e, extend `view-section-render-mode.spec.ts` |
+| 2 | every type, `Widget: ""` == current default | unit, `internal/dataentry` table test |
+| 3 | unknown name errors, lists valid set | unit, `dataentryconfig` |
+| 4 | `checkbox` on `date` errors | unit, `dataentryconfig` table over pairs |
+| 5 | undeclared property warns, does not error | unit, `CollectConfigWarnings` |
+| 6 | `widget: file` in a cards section errors | unit, `dataentryconfig` |
+| — | wire struct sync | existing unnamed-conversion compile check |
+| — | ACL conjunction unaffected | unit, `SectionEditForm` component test |
+| — | hint arm drops the override | unit, `SectionEditForm` component test |
+| — | Go table == TS `supportedPropertyTypes` | paired Go + Vitest fixture test |
+| — | machine field: inert on input, live on display | unit, component test |
+| — | row `values`-mirror interaction (RR-FC1C) | unit, row-level test |
+
+AC1's e2e is viable without new fixtures — a boolean property exists at
+`e2e/tests/fixtures.ts:847`.
+
+**Edge Cases:**
+
+- `widget: ""` — absent, not a value. Falls through to type default (AC2).
+- Whitespace-only (`"  "`) — `resolve` already `.trim()`s to undefined
+  client-side; server must reject rather than let the two disagree.
+- Case (`Checkbox`) — reject. Widget names are lowercase throughout; a silent
+  case-fold would make config non-canonical.
+- `widget:` on a `list: true` property — only `multi-select` legal.
+- `widget:` on a state-machine field — **two-axis, not inert** (RR-66MT0D).
+  The guard is `transitions !== undefined && render === 'input'`
+  (`SectionEditForm.vue:279`), so StatusControl wins ONLY on `render: input`; on
+  `render: display` a machine field deliberately falls through to the display
+  arm (`:273-277`) and DOES use the overridden widget. Cannot be warned about at
+  config load (machine-ness is runtime) — document both halves, test both.
+- `widget:` in a `display: table` / `content` section — already inert per
+  HOIX1's `sectionDisplayModesRenderingFields`; extend that warning to cover it.
+- `widget: file` on a `file` property — legal in a `properties` section (the
+  entry site passes `:attachments`), REJECTED elsewhere: cards/list row sites
+  pass no attachments (RR-NGY84F).
+
+**Negative Tests:**
+
+Config load must **fail** (not warn) for: unknown name, known name incompatible
+with the declared type, whitespace-only, non-lowercase. Each error names the
+view, section index, field index, the bad value, and the valid set — the
+`section[i] field[j]` precision RR-1SNYI1 asked for.
+
+## Risk Assessment
+
+- [x] Technical risks assessed with mitigations
+- [x] Security risks assessed (see Security Considerations)
+- [x] Effort estimated (xs/s/m/l/xl)
+
+**Risks:**
+
+- *Server/client compatibility tables drift* — **no longer accepted; solved**
+  (RR-Z0GGTO). The original plan proposed accepting the risk on the grounds that
+  two copies of ten entries didn't justify machinery. That arithmetic was wrong:
+  a THIRD copy already exists (`ResolveWidgetFromType`) and the existing two have
+  ALREADY drifted on `file`, `list`, and `values`. Mitigation is now a paired
+  Go + Vitest fixture test that fails CI on divergence — about the cost of the
+  comment originally proposed. The rejected "derive from `ResolveWidgetFromType`"
+  idea would itself have imported the `file` bug.
+- *Over-strict validation breaks a working config* — new key, no existing
+  configs use it. Zero real exposure.
+- *Scope creep into the dead `ViewCell.Widget`* — explicitly out of scope;
+  noted in the ticket so the next reader doesn't assume it was missed.
+- *`textarea` display mode* — RETIRED. Verified: `TextareaWidget.vue:19` renders
+  `<span class="display-value">` in display mode, identical to `TextWidget`. A
+  `textarea` override is display-safe and differs only in edit mode.
+- *Vue mount sites are not unified the way the Go construction sites are* — the
+  Go side funnels through `buildSectionFieldData` (godoc at `sections.go:73-79`
+  warns precisely about a field wired into one site and dropped from the other),
+  but the three `SectionEditForm` mount sites in `EntityDetail.vue` are separate
+  literals and already diverge on `:attachments`. Out of scope to fix; noted so
+  the next field added here doesn't repeat RR-NGY84F.
+
+**Effort:** **m** — revised up from `s` (RR-9G51IS). The original estimate
+counted only the plumbing and omitted the drift-guard fixture tests, the
+`widget: file` section-mode rejection, the two-axis StatusControl handling, the
+hint-arm negative test, and correcting the ticket's own false premises.
+TKT-HOIX1 was likewise scoped as a single-axis change and produced 60 files.
+
+## Documentation Planning
+
+For enhancements: identify what documentation needs updating.
+
+- [x] User-facing docs identified (skip if internal refactor)
+- [x] Docs-checklist will be created when entering implementation
+
+**Documentation Impact:**
+
+- [x] `docs/data-entry.md` — extend the TKT-HOIX1 "Field Render Modes" section
+  with a sibling on `widget:`: the compatibility table, the interaction with
+  `render:` (a widget you cannot click is just an icon), and the field-level-only
+  rule with its rationale.
+- [x] ~~docs/metamodel.md~~ (N/A: no metamodel change; the type→widget default
+  it documents is unchanged)
+- [x] ~~docs/cli-reference.md~~ (N/A: no command change)
+- [x] ~~CLAUDE.md~~ (N/A: no new convention — follows the existing one)
+- [x] ~~README.md~~ (N/A: not project-level)
+
+## Design Review
+
+- [x] Run `/design-review` before starting implementation
+- [x] All critical/significant findings addressed in plan
+
+**Design Review Findings:**
+
+| ID | Severity | Finding | Status |
+| -- | -------- | ------- | ------ |
+| RR-YTC4W5 | critical | `ViewCell.Widget` is live, not dead — finding 1 was false | addressed |
+| RR-2GBB0V | critical | Hint-arm rationale false; unschema'd fields ARE editable | addressed |
+| RR-Z0GGTO | significant | Don't accept table drift — resolvers already disagree on `file` | addressed |
+| RR-NGY84F | significant | cards/list rows pass no `attachments`; `widget: file` breaks | addressed |
+| RR-66MT0D | significant | StatusControl warning unbuildable; interaction is two-axis | addressed |
+| RR-693NL9 | minor | AC2's test was specced in the wrong language | addressed |
+| RR-9G51IS | minor | Inheritance rationale weak; effort under-estimated | addressed |
+
+Two of my own findings were wrong and are corrected above with the verification
+that overturned them. No open critical or significant findings.

--- a/tickets/entities/review-checklists/REV-P5DOCM.md
+++ b/tickets/entities/review-checklists/REV-P5DOCM.md
@@ -2,7 +2,7 @@
 id: REV-P5DOCM
 type: review-checklist
 title: 'Review: Widget override for view section fields (`widget:` on ViewSectionField)'
-status: in-progress
+status: done
 ---
 
 <!-- @managed: claude-workflow v1 -->
@@ -130,8 +130,8 @@ an e2e response probe) were removed — verified absent from the tree.
 
 ## Pull Request
 
-- [ ] Run `/pr` command to create PR and monitor CI
-- [ ] All CI checks pass
-- [ ] PR URL documented below
+- [x] Run `/pr` command to create PR and monitor CI
+- [x] All CI checks pass
+- [x] PR URL documented below
 
-**PR:** <!-- filled by /pr -->
+**PR:** https://github.com/sourcehaven-bv/rela/pull/1377

--- a/tickets/entities/review-checklists/REV-P5DOCM.md
+++ b/tickets/entities/review-checklists/REV-P5DOCM.md
@@ -1,0 +1,137 @@
+---
+id: REV-P5DOCM
+type: review-checklist
+title: 'Review: Widget override for view section fields (`widget:` on ViewSectionField)'
+status: in-progress
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Automated Checks
+
+- [x] All tests pass (`just test`) — Go suite green; frontend 1819 tests across 113 files; 8 e2e specs (4 new + TKT-HOIX1's 4, run together against a rebuilt binary)
+- [x] Lint clean (`just lint`) — 0 issues. Five findings fixed during implementation (misspell ×2, gocritic unnamedResult, revive unused-parameter, whitespace) plus two more after the review rewrite (misspell, modernize/slices.Contains). `e2e npm run lint` also clean — the page-object rule is NOT covered by `just ci`, and it caught a raw selector in the new spec.
+- [x] Coverage maintained (`just coverage-check`) — package floor 50% PASS, total 65% PASS, total 78.0%. Touched packages: `dataentryconfig` 89.1%, `dataentry` 80.9%.
+
+## Code Review
+
+- [x] Run `/code-review` command (invokes cranky-code-reviewer agent) — run twice: a design review before implementation, a code review after
+- [x] All critical review-responses addressed
+- [x] All significant review-responses addressed
+- [x] Self-reviewed the diff for unrelated changes
+
+**Review Responses:** 15 total, all `addressed`.
+
+Design review (pre-implementation) — 7:
+
+| ID | Severity | Finding |
+| -- | -------- | ------- |
+| RR-YTC4W5 | critical | My claim that `ViewCell.Widget` was dead was FALSE — it is live and shipped on every table cell; my grep pattern could not match a field assignment |
+| RR-2GBB0V | critical | My hint-arm rationale was false — unschema'd fields ARE editable (a missing verdict reads as writable); the real constraint is no PropertyDef to validate against |
+| RR-Z0GGTO | significant | Don't accept table drift — the two existing resolvers already disagree on `file` |
+| RR-NGY84F | significant | cards/list rows pass no `attachments`; `widget: file` would break there |
+| RR-66MT0D | significant | The StatusControl warning was unbuildable (machine-ness is runtime); the interaction is two-axis |
+| RR-693NL9 | minor | AC2's test was specced in Go, but the behaviour lives in `registry.ts` |
+| RR-9G51IS | minor | Inheritance rationale weak; effort under-estimated (s → m) |
+
+Code review (post-implementation) — 8:
+
+| ID | Severity | Finding |
+| -- | -------- | ------- |
+| RR-DRIFT1 | critical | The Vitest drift-guard asserted its own copy of the registrations, not the registry — VERIFIED green through two mutations that should have failed it |
+| RR-LISTW | significant | `widget:` on a `list: true` property was unvalidated → array flattened, scalar PATCHed over a list. Silent data corruption |
+| RR-INLEN | significant | `widget:` on an inline enum ignored the value set → free-text over a constrained set |
+| RR-CUSTY | significant | Custom-type equivalence was a name blacklist, not a `meta.Types` lookup → any undeclared type accepted as enum-like |
+| RR-AMBIG | minor | No warning for a widget on a multi-type-traversal source — the one case with no other signal |
+| RR-COLDUP | minor | `viewCollectionTypes` was a divergent hand-copy of ValidateConfig's map |
+| RR-FILEORD | minor | `widget: file` check ran before the type check, hiding the better error |
+| RR-JOINDUP | nit | `joinWidgetTableKeys` duplicated the existing generic `sortedMapKeys` |
+| RR-E2EPATCH | nit | e2e autosave wait matched any PATCH under `/api/v1/` |
+
+**Self-review of the diff.** Verified `git diff develop...HEAD` contains no
+unrelated changes. Two prototype-project changes are deliberately committed
+SEPARATELY so this ticket's commits stay single-purpose:
+
+- `d2842498` — `ticket_summary.lua` used `rela.entity_id`, which the Lua runtime
+  never binds, so every render of that document failed. Pre-existing on develop
+  (byte-identical, last touched by an unrelated CalDAV commit) and surfaced only
+  because the demo opened that page. Fixed rather than left broken.
+- `3eecc88e` — the worked `widget:` example on the prototype ticket view.
+
+Demo data mutated by the manual verification (`TKT-001.md`, `is_blocked` flipped
+by a real click) was reverted — it is data, not a code change.
+
+`registry.ts`'s diff is a pure restructure: the same ten registrations, moved
+into exported data so the drift guard can assert them. No behaviour change.
+
+## Acceptance Verification
+
+- [x] Each acceptance criterion tested (reference planning checklist)
+- [x] Test evidence documented in implementation checklist
+
+**Acceptance Status:**
+
+| AC | Status | Evidence |
+| -- | ------ | -------- |
+| 1 — `widget: checkbox` renders a clickable checkbox that saves | PASS | e2e clicks it, asserts the PATCH lands and survives a reload. Also confirmed BY HAND in a browser: `is_blocked` flipped `false` → `true` on disk. |
+| 2 — omitting `widget:` reproduces today's selection | PASS | Frontend table test over every property type asserting `widget: undefined` → `defaultWidgetFor(propertyDef)`, incl. the list-over-values-over-type precedence (RR-0Z1P6) |
+| 3 — unregistered name is a config-load error naming the valid set | PASS | `TestValidateConfig_SectionFieldWidget` + `_ErrorListsValidNames` |
+| 4 — a type mismatch is a config-load error | PASS | `_MismatchNamesAcceptedTypes`; extended post-review to `list` and value-set rules |
+| 5 — a widget on an undeclared property warns, does not error | PASS | `TestCollectConfigWarnings_WidgetOnUndeclaredProperty` |
+| 6 — `widget: file` outside a `properties` section errors | PASS | Table case using a genuine `file` property so it isolates the display-mode rule |
+
+Beyond the ACs, pinned by test: the ACL conjunction is untouched (a widget
+override cannot make a read-only field editable); the hint arm provably DROPS
+the override; the StatusControl interaction is inert on `render: input` and live
+on `render: display`; both Go construction sites carry `Widget`.
+
+**Drift guard proven, not assumed.** Injected drift into the fixture → both Go
+and Vitest fail. Injected drift into `registry.ts` (changed a widget's supported
+types; added a new widget) → Vitest fails on both. The first version of the
+guard passed both of those mutations, which is how RR-DRIFT1 was found.
+
+**Manual verification.** Feature confirmed in a real browser by the user:
+`description` renders as a textarea where its type default is a single-line
+input — the case that can only come from config — while its neighbours keep
+their type defaults. Checkbox click persisted to disk.
+
+**Known cosmetic issue, filed not fixed:** `CheckboxWidget`'s edit arm carries
+ZERO design tokens (every sibling widget has 6–13), so it renders as a bare
+native control in a styled grid. Pre-existing and not a regression — this ticket
+merely made a checkbox easy to place next to styled controls. Filed as
+TKT-CBSTYLE (backlog, xs); out of scope here, which decides *which* widget
+renders, not how it looks.
+
+## Documentation (enhancements only)
+
+- [x] Docs-checklist created and linked via `has-docs`
+- [x] User-facing documentation updated
+- [x] Docs-checklist marked as done
+
+**Docs Checklist:** DOCS-WGTOVR
+
+Note: this ticket also documents TKT-HOIX1's `render:` axis, which shipped
+UNDOCUMENTED — its PR touched no docs file at all. `docs/` is generated from
+`docs-project/entities/`, so an edit to the generated file is silently
+overwritten by `just docs`. I hit the same trap once before catching it.
+
+## Final Checks
+
+- [x] Commit message explains the why, not just what
+- [x] No TODOs or FIXMEs left unaddressed
+- [x] Ready for another developer to use
+
+Four commits, each single-purpose: the feature; the review fixes (whose message
+records the data-corruption bug and the false drift-guard); the unrelated Lua
+fix; the worked example.
+
+Two debugging scaffolds written during implementation (a wire-conversion probe,
+an e2e response probe) were removed — verified absent from the tree.
+
+## Pull Request
+
+- [ ] Run `/pr` command to create PR and monitor CI
+- [ ] All CI checks pass
+- [ ] PR URL documented below
+
+**PR:** <!-- filled by /pr -->

--- a/tickets/entities/review-responses/RR-2GBB0V.md
+++ b/tickets/entities/review-responses/RR-2GBB0V.md
@@ -1,0 +1,9 @@
+---
+id: RR-2GBB0V
+type: review-response
+title: 'Hint-arm rationale is false: unschema''d fields ARE editable'
+finding: 'PLAN-DMQFRJ Research §3 justifies ignoring `widget:` on the discriminated-union hint arm with the claim that an unknown field has ''nothing to read, nowhere to save'' and is ''display-only by construction''. The code contradicts this. isFieldWritable (frontend/src/utils/affordances.ts:12-18) returns `verdict?.writable !== false`, so a MISSING verdict returns true -- deliberately and documented. SectionEditForm.vue:164 computes `writable` with no inspection of `field.kind`, and the edit branch at :288 (`v-else-if="row.writable"`) likewise ignores kind. So a hint-arm field on `render: input` with no _fields verdict renders an EDITABLE widget and PATCHes via onFieldUpdate. What the template actually does on the hint arm is pass `:property-def="undefined"` (:298, :314) -- ''no PropertyDef to hand the widget'', which is NOT the same as ''not editable''. The plan conflated the two. The decision (ignore + warn) survives, but on a different and stronger argument: with no PropertyDef the server cannot type-check the widget, so AC4''s compatibility rule is unenforceable on that arm, and honouring `widget:` there would ship an unvalidated widget into a live edit control (e.g. checkbox PATCHing a boolean into a string property).'
+severity: critical
+resolution: Verified affordances.ts:12-18 and SectionEditForm.vue:164,288 -- confirmed. Kept the ignore+warn decision, replaced the rationale in PLAN-DMQFRJ Research §3 with the unvalidatable-without-PropertyDef argument. Added a hint-arm negative test to the Test Plan asserting the override is provably dropped, guarding against a future refactor plumbing `widget` into the shared half of the union where both arms would see it.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-66MT0D.md
+++ b/tickets/entities/review-responses/RR-66MT0D.md
@@ -1,0 +1,9 @@
+---
+id: RR-66MT0D
+type: review-response
+title: 'StatusControl edge case: warning is unbuildable, and the interaction is two-axis'
+finding: 'PLAN-DMQFRJ Edge Cases said `widget:` on a state-machine field is inert because ''StatusControl wins'', and specced a config-load warning. Two problems. (1) The interaction is two-axis, not inert: the guard at SectionEditForm.vue:279 is `row.field.transitions !== undefined && row.field.render === ''input''`, so StatusControl wins ONLY on render:input. On render:display a machine field deliberately falls through to the display arm (comment at :273-277, TKT-HOIX1) and DOES use row.widget. So `widget:` is inert on input, live on display -- the plan described only half. (2) The warning is not implementable. Machine-ness is not declared in the metamodel (no state-machine types in internal/metamodel/types.go); it is a runtime per-entity, per-principal value produced by computeTransitions (affordances.go:1051) via a TransitionResolver type-assertion (affordances.go:179) that Nop/Demo resolvers don''t implement. CollectConfigWarnings(cfg, meta) has neither a resolver nor an entity, so it cannot know a field is a machine field.'
+severity: significant
+resolution: 'Verified: no state-machine declaration in metamodel/types.go; machine-ness originates from the runtime TransitionResolver assertion. Dropped the unbuildable warning from the acceptance criteria rather than shipping an AC that cannot be implemented. Instead documenting the two-axis interaction in docs/data-entry.md (widget inert on render:input where StatusControl owns the field, honoured on render:display) and adding a component test pinning both halves.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-693NL9.md
+++ b/tickets/entities/review-responses/RR-693NL9.md
@@ -1,0 +1,9 @@
+---
+id: RR-693NL9
+type: review-response
+title: AC2's no-op test was specced in the wrong language
+finding: 'PLAN-DMQFRJ placed AC2''s regression test (''omitting widget: reproduces today''s selection byte-for-byte'') in internal/dataentry as a Go table test. But on the section path the type->widget selection is performed by defaultWidgetFor in frontend/src/widgets/registry.ts:18-28, not by any Go code -- the Go resolveWidget/ResolveWidgetFromType path serves table cells (RR-YTC4W5), a different surface. A Go test would pin a mapping that the code under change does not consult, passing while the actual behaviour regressed. Reviewer also flagged two smaller test gaps: no hint-arm coverage, and no test for the _props/values display-mirror interaction (applyPropertyToRow deliberately leaves fields[i].values stale per RR-FC1C, and a widget override changes which component reads that mirror).'
+severity: minor
+resolution: Moved AC2's test to the frontend as a registry/SectionEditForm table test asserting widget:undefined resolves to defaultWidgetFor(propertyDef) for every property type. Added the hint-arm negative test (also covering RR-2GBB0V) and a row-level test for the values-mirror interaction. Confirmed a boolean property exists in e2e/tests/fixtures.ts:847 so AC1's checkbox e2e is viable without new fixtures.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-9G51IS.md
+++ b/tickets/entities/review-responses/RR-9G51IS.md
@@ -1,0 +1,9 @@
+---
+id: RR-9G51IS
+type: review-response
+title: Section-inheritance and effort rationale need strengthening
+finding: 'Two weaker points in PLAN-DMQFRJ. (1) The plan justified ''no section-level widget inheritance'' as ''meaningless across mixed types''. That argument doesn''t survive the obvious counter-example -- a section of five string properties that all want textarea -- and render: inherits despite being arguably per-field too. (2) Effort estimated ''s'' on the grounds of ''four backend files, three frontend, following a thread merged two commits ago'', which omits the drift-guard tests, the attachments decision, the StatusControl rework, the hint-arm test, and correcting the ticket itself. TKT-HOIX1 was scoped as a single-axis change and produced 60 files and 14 review responses.'
+severity: minor
+resolution: '(1) Replaced the rationale with two stronger arguments: render: is a binary whose both values are valid for every field, so it can safely inherit, whereas a section-level widget: is a config-load ERROR on every field of a non-matching type -- inheritance that must be undone field-by-field is anti-inheritance; and validating a section-level widget requires per-field property types, i.e. exactly the metamodel-dependent context RR-4ICH8M moved the field-level check out of. Both go in docs/data-entry.md where the field-level-only rule is documented. (2) Re-estimated effort from s to m.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-AMBIG.md
+++ b/tickets/entities/review-responses/RR-AMBIG.md
@@ -1,0 +1,9 @@
+---
+id: RR-AMBIG
+type: review-response
+title: "inertWidgetWarnings was silent on an unvalidatable ambiguous source"
+severity: minor
+status: addressed
+finding: "widgetSectionDef returned nil for three distinct situations collapsed into silence, and its godoc justified this with 'ValidateConfig already errors on that separately'. True for an unknown collection; NOT true for a collection whose target type cannot be determined statically (determineTargetType returns empty for a relation with several to: types). ValidateConfig treats that as legal config with no error, so a widget override there got neither validation (the call site guards on sourceType != empty) nor a warning — accepted in total silence, working or not depending on the runtime entity type. That is the one case with no other signal at all."
+resolution: "Added ambiguousWidgetSource to distinguish it from the other two nil cases, and a distinct warning naming the collection and explaining the override cannot be type-checked at load. Corrected widgetSectionDef's godoc to enumerate all three cases rather than assert a blanket claim that held for only one. Pinned by TestCollectConfigWarnings_WidgetOnAmbiguousSource."
+---

--- a/tickets/entities/review-responses/RR-COLDUP.md
+++ b/tickets/entities/review-responses/RR-COLDUP.md
@@ -1,0 +1,9 @@
+---
+id: RR-COLDUP
+type: review-response
+title: "viewCollectionTypes was a divergent hand-copy of ValidateConfig's map"
+severity: minor
+status: addressed
+finding: "The new helper re-derived the collection-name to entity-type map that ValidateConfig also builds inline. It had already diverged once (omitting the implicit 'entry' collection, which silently skipped every source: entry section — caught during implementation). A second latent divergence remained: relName picked Follow first with FollowIncoming as fallback, while ValidateConfig assigns by sequential overwrite so FollowIncoming wins when an author sets both. Outcomes coincide today because determineTargetType branches on Follow first, so it was latent rather than live — but two copies of one derivation is exactly the duplication this ticket's own drift guard exists to prevent elsewhere."
+resolution: "Aligned the precedence with ValidateConfig exactly (FollowIncoming overwrites Follow) and documented the helper as the single intended source, with a note to delete it in favour of ValidateConfig's building half if that is ever factored out. Pinned by TestViewCollectionTypes_IncludesEntry."
+---

--- a/tickets/entities/review-responses/RR-CUSTY.md
+++ b/tickets/entities/review-responses/RR-CUSTY.md
@@ -1,0 +1,9 @@
+---
+id: RR-CUSTY
+type: review-response
+title: "Custom-type equivalence was a name blacklist, not a lookup"
+severity: significant
+status: addressed
+finding: "widgetAcceptsType implemented the custom-enum rule as 'not string AND not builtin implies enum-like', with isBuiltinPropertyType hardcoding the built-in names. It never consulted meta.Types. VERIFIED: widget: select on the undeclared type 'totally-bogus' was ACCEPTED. The godoc claimed 'the metamodel's own resolveWidget makes the same equivalence' — it does not: helpers.go does a positive membership test on meta.Types, and ResolveWidgetFromType additionally requires len(Values) > 0. So a value-less custom type (declared under types: with no values:) was wrongly accepted as select-able. This is the same class of drift the ticket exists to prevent, reintroduced one function lower."
+resolution: "Replaced the negation with a real lookup in widgetPropertyHasValues (meta.Types membership AND len(Values) > 0, mirroring ResolveWidgetFromType). isBuiltinPropertyType deleted — it existed only to approximate the lookup. Pinned by TestWidgetAcceptsProperty_CustomTypesByLookup, including the undeclared-name and value-less-custom-type cases."
+---

--- a/tickets/entities/review-responses/RR-DRIFT1.md
+++ b/tickets/entities/review-responses/RR-DRIFT1.md
@@ -1,0 +1,9 @@
+---
+id: RR-DRIFT1
+type: review-response
+title: "Vitest drift-guard asserted its own copy, not the registry"
+severity: critical
+status: addressed
+finding: "The Vitest half of the RR-Z0GGTO drift guard (registry.widgetTable.test.ts) built a FRESH registry via defineWidgetRegistry() and re-registered ten widgets from a hand-written list inside the test. It never imported defaultRegistry and never read buildDefaultRegistry, so it asserted its own copy of the registrations while its comment claimed the opposite. VERIFIED by mutation: changing textarea's supportedPropertyTypes in registry.ts to ['string','integer'] left all 12 tests GREEN; adding an entirely new widget to buildDefaultRegistry also left all 12 GREEN. The Go half was genuinely load-bearing, so the guard was one-sided in the direction that matters least: the registry is the side that actually decides what renders. Worse than no guard, because the comment told the next reader the risk was handled."
+resolution: "Exported WIDGET_REGISTRATIONS from registry.ts as the single array buildDefaultRegistry consumes, and rewrote the test to assert THAT against the fixture. Re-ran both mutations: each now FAILS. Also replaced the near-vacuous second test block (it asserted fixture-key formatting, not resolvability) with one that resolves every fixture name against defaultRegistry and proves it is not the unknown-name fallback."
+---

--- a/tickets/entities/review-responses/RR-E2EPATCH.md
+++ b/tickets/entities/review-responses/RR-E2EPATCH.md
@@ -1,0 +1,9 @@
+---
+id: RR-E2EPATCH
+type: review-response
+title: "e2e autosave wait matched any PATCH under /api/v1/"
+severity: nit
+status: addressed
+finding: "toggleSectionCheckbox waited for any PATCH, so on a page with another autosaving control it would resolve on the wrong request and the caller's reload would race the real save — reintroducing the exact flake the helper was added to remove."
+resolution: "Narrowed the predicate to include the entity id from the current URL."
+---

--- a/tickets/entities/review-responses/RR-FILEORD.md
+++ b/tickets/entities/review-responses/RR-FILEORD.md
@@ -1,0 +1,9 @@
+---
+id: RR-FILEORD
+type: review-response
+title: "widget: file check ran before the type check, hiding the better error"
+severity: minor
+status: addressed
+finding: "The WidgetFile display-mode branch ran first and continued, so widget: file on a string property in a cards section reported only the display-mode problem. Fixing the display mode would surface a second, different error on the next load — two round-trips for one config line. The existing test used property: title (a string) and so exercised this double-fault while asserting only the first message."
+resolution: "Reordered so property-type compatibility is checked first, and gave the file-widget test a genuine file-typed property so it isolates the display-mode rule. Added a third case asserting the type error wins when a field violates both."
+---

--- a/tickets/entities/review-responses/RR-INLEN.md
+++ b/tickets/entities/review-responses/RR-INLEN.md
@@ -1,0 +1,9 @@
+---
+id: RR-INLEN
+type: review-response
+title: "widget on an inline enum ignored the value set"
+severity: significant
+status: addressed
+finding: "An inline enum is {Type: string, Values: [...]}. The table saw only Type, so widget: text and widget: textarea were ACCEPTED on a value-constrained property. defaultWidgetFor routes values.length > 0 to select BEFORE consulting type, so the SPA's real dispatch key is (list, values, type) while the validator modelled only type. The effect is a free-text box over a constrained value set: the operator can type anything and PATCH it. Less severe than the list case (the write validator would 422 the bad value) but it is still config that validates and then does something the author did not ask for."
+resolution: "Handled by the same widgetAcceptsProperty rewrite: a property with a fixed value set — inline values: or a custom type carrying values — accepts only the select family. Pinned by TestValidateConfig_WidgetOnInlineEnum."
+---

--- a/tickets/entities/review-responses/RR-JOINDUP.md
+++ b/tickets/entities/review-responses/RR-JOINDUP.md
@@ -1,0 +1,9 @@
+---
+id: RR-JOINDUP
+type: review-response
+title: "joinWidgetTableKeys duplicated an existing generic helper"
+severity: nit
+status: addressed
+finding: "The new helper differed from the existing generic sortedMapKeys[V any] only in that it inlined the join. Its own godoc admitted it was a copy differing by value type — but Go generics already covered that, and sortedMapKeys uses the same natsort ordering."
+resolution: "Deleted joinWidgetTableKeys; the call site now uses strings.Join(sortedMapKeys(...), \", \")."
+---

--- a/tickets/entities/review-responses/RR-LISTW.md
+++ b/tickets/entities/review-responses/RR-LISTW.md
@@ -1,0 +1,9 @@
+---
+id: RR-LISTW
+type: review-response
+title: "widget on a list property was unvalidated — silent data corruption"
+severity: significant
+status: addressed
+finding: "PLAN-DMQFRJ named the rule ('only multi-select legal on a list property') but the implementation ignored PropertyDef.List entirely. VERIFIED: widget: textarea and widget: text on a {type: string, list: true} property both passed validation. This is not cosmetic. defaultWidgetFor puts list FIRST, above values and type (registry.ts, an order RR-0Z1P6 marks load-bearing), so it is precisely the case where config overrides the SPA's highest-precedence rule. TextareaWidget runs the array through useStringValue and onFieldUpdate then PATCHes the resulting STRING — an operator gets a control that flattens ['a','b'] and writes back a scalar, on a config line the server called valid."
+resolution: "Rewrote the check as widgetAcceptsProperty(widget, PropertyDef, meta) — a predicate over the whole PropertyDef rather than a map keyed on Type alone — applying the SPA's precedence: list first, then value-set, then the type table. A non-multi-select widget on a list property is now a config-load error naming the rule. Pinned by TestValidateConfig_WidgetOnListProperty (5 cases)."
+---

--- a/tickets/entities/review-responses/RR-NGY84F.md
+++ b/tickets/entities/review-responses/RR-NGY84F.md
@@ -1,0 +1,9 @@
+---
+id: RR-NGY84F
+type: review-response
+title: 'cards/list rows don''t pass attachments; `widget: file` would break there'
+finding: 'PLAN-DMQFRJ Edge Cases claimed `widget: file` is ''legal, but the display arm needs the attachments prop, already passed''. Only true at ONE of the three SectionEditForm mount sites. Entry section (EntityDetail.vue:893) passes :attachments="entry._attachments". The cards row site (:982-992) and list row site (:1038-1048) pass no attachments at all. SectionEditForm.vue:300 and :315 read props.attachments?.[row.field.property], which is undefined on rows. Today this is harmless because defaultWidgetFor only selects ''file'' for a file-typed property and file properties don''t appear in card rows -- but once `widget: file` is authorable, an operator can force FileWidget into a card row and it renders with undefined attachments. This is exactly the failure mode buildSectionFieldData''s godoc (sections.go:73-79) warns about for the Go side: the Go construction sites were unified, the Vue mount sites were not.'
+severity: significant
+resolution: 'Verified all three mount sites in EntityDetail.vue -- confirmed, only the entry site passes attachments. Chosen resolution (a): reject `widget: file` outside a `properties`-display section at config load, which is in scope for this ticket''s size and fails loudly rather than rendering a broken widget. Plumbing _attachments onto ViewEntity for rows is the fuller fix and is deferred to a follow-up ticket. Documented explicitly in the plan rather than left silent.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-YTC4W5.md
+++ b/tickets/entities/review-responses/RR-YTC4W5.md
@@ -1,0 +1,9 @@
+---
+id: RR-YTC4W5
+type: review-response
+title: 'Plan finding 1 is false: ViewCell.Widget is live, not dead'
+finding: 'PLAN-DMQFRJ Research §1 and TKT-3R7RF3 both assert ViewCell.Widget is ''populated nowhere'' and ''dead on the wire'', citing `grep ''Widget:'' internal/dataentry` returning no hits. The grep pattern was structurally incapable of finding the assignment, which is a field assignment not a struct-literal key: `cell.Widget = resolveWidget(pd, s.Meta)` at internal/dataentry/sections.go:296. It reaches the wire via the unnamed conversion `v1.ViewCell(cell)` at views_handler.go:611 and :629, so every table cell of every view ships a widget name today. Consequences: (a) the Non-goals in both ticket and plan are justified by a false premise, risking a future reader deleting a live wire field; (b) it means a SECOND server-side type->widget resolver already exists (resolveWidget -> Metamodel.ResolveWidgetFromType, schema_output.go:117) whose godoc claims to be ''the single source of truth'' -- a claim already false, since registry.ts defaultWidgetFor is the authority on the section path.'
+severity: critical
+resolution: 'Verified independently: `grep -rn Widget internal/dataentry/sections.go` shows the assignment at :296. Finding confirmed as my error. Corrected Research §1 in PLAN-DMQFRJ and the Scope-corrections section of TKT-3R7RF3 to state ViewCell.Widget is live and type-derived; re-justified the scope exclusion on surface grounds (tables are a distinct renderer with no inline-edit path) rather than on dead-code grounds.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-Z0GGTO.md
+++ b/tickets/entities/review-responses/RR-Z0GGTO.md
@@ -1,0 +1,9 @@
+---
+id: RR-Z0GGTO
+type: review-response
+title: 'Don''t accept widget-table drift: the two resolvers already disagree on `file`'
+finding: 'PLAN-DMQFRJ Risk section proposed duplicating the widget/property-type compatibility table in Go, mirroring supportedPropertyTypes (registry.ts:105-117), and ACCEPTING the drift risk as disproportionate to solve for ten entries. That arithmetic was wrong because it assumed only two copies. Per RR-YTC4W5 a third already exists (Metamodel.ResolveWidgetFromType, schema_output.go:117), and the existing two have ALREADY drifted: ResolveWidgetFromType has no `file` case so a file property resolves to ''text'', while defaultWidgetFor (registry.ts:26) returns ''file''. It also lacks list/values handling, which registry.ts:19-20 places ABOVE the scalar switch and documents as load-bearing order (RR-0Z1P6). Critically, the plan''s own suggestion to ''derive the Go table from the same list'' via ResolveWidgetFromType would import the file bug and REJECT `widget: file` on a file property -- which the plan''s own Edge Cases calls legal.'
+severity: significant
+resolution: 'Verified the divergence: grep confirms no file case in schema_output.go (falls through default -> ''text'') vs registry.ts:26 returning ''file''. Adopted reviewer option 1: build the Go compatibility table as its own map literal, NOT derived from ResolveWidgetFromType, plus a two-sided fixture test -- a Vitest test asserting registry supportedPropertyTypes matches a shared fixture, and a Go test asserting the same fixture. Roughly the cost of the comment the plan originally proposed, but it fails CI on drift instead of documenting it.'
+status: addressed
+---

--- a/tickets/entities/tickets/TKT-3R7RF3.md
+++ b/tickets/entities/tickets/TKT-3R7RF3.md
@@ -4,8 +4,8 @@ type: ticket
 title: Widget override for view section fields (`widget:` on ViewSectionField)
 kind: enhancement
 priority: medium
-effort: s
-status: backlog
+effort: m
+status: in-progress
 ---
 
 ## Goal
@@ -14,31 +14,78 @@ Let view config authors override which widget renders a given property in a view
 section, independent of the type-based default.
 
 Split out of TKT-HOIX1, which now covers only the `render: input | display`
-axis. This ticket is the orthogonal *which widget* axis and should land after
-it.
+axis. This ticket is the orthogonal *which widget* axis and lands after it
+(TKT-HOIX1 merged as #1364).
 
-## Scope
+## Scope corrections (verified against develop @ 3a735757)
 
-- `ViewSectionField` (`internal/dataentryconfig/config.go:610-613`) gains an optional
-`widget string`.
-- `internal/dataentryconfig/validate.go` validates widget names against the registry **and**
-against the property's type — no `checkbox` widget on a `date` property.
-- Backend populates `V1ViewCell.Widget` from config. The field is reportedly already in the
-wire schema but unpopulated — verify before implementing.
-- Frontend `ViewSectionField` TS type gains `widget`; `frontend/src/widgets/registry.ts`
-consults it when picking the widget, ahead of the `defaultWidgetFor` type
-dispatch (`registry.ts:18-28`).
+The original scope was written before TKT-HOIX1 landed and is stale in three
+material ways. Verified, not assumed:
+
+1. **`ViewCell.Widget` is LIVE, not dead** (corrected by RR-YTC4W5; my
+original claim here was wrong). `cell.Widget = resolveWidget(pd, s.Meta)` at
+`internal/dataentry/sections.go:296` populates it, and `v1.ViewCell(cell)`
+(`views_handler.go:611,629`) ships it on every table cell. My original grep
+(`'Widget:'`) could not match a field *assignment*. Tables remain out of scope,
+but on **surface** grounds — a table cell is a different renderer with no
+inline-edit path — not because the field is dead. Do not delete it.
+
+Corollary: a **second** server-side type→widget resolver already exists
+(`Metamodel.ResolveWidgetFromType`, `schema_output.go:117`), whose godoc claims
+to be "the single source of truth". That claim is already false — `registry.ts`
+`defaultWidgetFor` is the authority on the section path — and the two have
+drifted (`file` → `text` in Go, `'file'` in TS).
+
+2. **The frontend hook is not `registry.ts`.** `defaultRegistry.resolve(name,
+propertyDef)` **already** honours an explicit name and falls back to the type
+dispatch — that code is written and tested. The gap is purely that the only
+view-side caller, `SectionEditForm.vue:147-152` (`widgetRows`), hardcodes
+`resolve(undefined, field.propertyDef)`. So this is a call-site change plus
+carrying `widget` on `SectionEditField`, exactly parallel to how `render` is
+carried. `registry.ts` needs no change.
+
+3. **The `hint` arm must ignore the override — but not for the reason first
+given** (corrected by RR-2GBB0V). An unschema'd field is **not** display-only:
+`isFieldWritable` (`frontend/src/utils/affordances.ts:12-18`) returns `true` for
+a *missing* verdict, and neither `widgetRows` (`SectionEditForm.vue:164`) nor
+the edit branch (`:288`) inspects `field.kind` — so a hint-arm field on `render:
+input` renders an editable widget and PATCHes. What the hint arm actually lacks
+is a `PropertyDef` (`:298`, `:314` pass `undefined`), so the server has
+**nothing to type-check a widget name against**. Honouring `widget:` there would
+ship an unvalidated widget into a live edit control. Ignore + warn.
+
+## Scope (corrected)
+
+- `ViewSectionField` (`config.go:847-852`) gains an optional `Widget string`,
+beside `Render`.
+- `SectionFieldData` (`sections.go:63`) + `apiwire/v1.SectionField`
+(`responses.go:355`) gain `Widget` in the SAME position — the unnamed conversion
+`v1.SectionField(f)` is the compile-checked sync, so position and type must
+match.
+- `buildSectionFieldData` (`sections.go:82`) carries it through. Note there is
+**no section-level inheritance** for widget (unlike `render`): a widget is
+inherently per-property, so a section-wide default is meaningless.
+- `internal/dataentryconfig/validate.go` validates the name against the
+registered set and against the property's type. Note `FormField.Widget` is
+currently **not validated at all** — this ticket should not silently inherit
+that gap for the new field.
+- Frontend: `ViewSectionField` TS gains `widget`; `sectionEditFields.ts` carries
+it onto `SectionEditField`; `SectionEditForm.vue` `widgetRows` passes it to
+`defaultRegistry.resolve`.
 - Omitting `widget` preserves today's type-based selection exactly.
 
 ## Why
 
 The payoff case: the Daily-Notes "click checkbox to mark task done" interaction
-becomes a config line rather than custom code. Note this needs `render: input`
-from TKT-HOIX1 to be useful, since a checkbox you cannot click is just an icon.
+becomes a config line rather than custom code. Needs `render: input` from
+TKT-HOIX1 to be useful, since a checkbox you cannot click is just an icon.
 
 ## Non-goals
 
 - No new widget types — only overriding selection among registered ones.
-- The `render: input | display` axis (TKT-HOIX1).
-- Markdown and relation widgets, which do not exist in the registry
-(`frontend/src/widgets/registry.ts:105-117`).
+- The `render: input | display` axis (TKT-HOIX1, done).
+- The table-cell path (`ViewCell.Widget`) — live and type-derived, different
+surface, no inline edit. Not dead; not to be removed.
+- Closing the `FormField.Widget` validation gap — its own breaking change.
+- Plumbing `_attachments` onto cards/list rows (RR-NGY84F) — follow-up.
+- Markdown and relation widgets, which do not exist in the registry.

--- a/tickets/entities/tickets/TKT-3R7RF3.md
+++ b/tickets/entities/tickets/TKT-3R7RF3.md
@@ -5,7 +5,7 @@ title: Widget override for view section fields (`widget:` on ViewSectionField)
 kind: enhancement
 priority: medium
 effort: m
-status: in-progress
+status: review
 ---
 
 ## Goal

--- a/tickets/entities/tickets/TKT-3R7RF3.md
+++ b/tickets/entities/tickets/TKT-3R7RF3.md
@@ -5,7 +5,7 @@ title: Widget override for view section fields (`widget:` on ViewSectionField)
 kind: enhancement
 priority: medium
 effort: m
-status: review
+status: done
 ---
 
 ## Goal

--- a/tickets/entities/tickets/TKT-CBSTYLE.md
+++ b/tickets/entities/tickets/TKT-CBSTYLE.md
@@ -1,0 +1,61 @@
+---
+id: TKT-CBSTYLE
+type: ticket
+title: CheckboxWidget is unstyled — the only widget with no design tokens
+kind: enhancement
+priority: low
+effort: xs
+status: backlog
+---
+
+## Goal
+
+Give `CheckboxWidget`'s **edit** mode the same visual treatment every other
+widget in the registry already has, so a boolean field doesn't read as a
+foreign control dropped into an otherwise consistent form grid.
+
+## Evidence
+
+Design-token references per widget (`grep -c 'var(--'`):
+
+| Widget           | tokens |
+| ---------------- | ------ |
+| `SelectWidget`   | 13     |
+| `TextWidget`     | 6      |
+| `NumberWidget`   | 6      |
+| `DateWidget`     | 6      |
+| `CheckboxWidget` | **0**  |
+
+`CheckboxWidget.vue`'s entire `<style>` block is three lines, and they apply
+only to the DISPLAY arm (`.display-checkbox`: muted opacity, default cursor).
+The edit arm is a bare native `<input type="checkbox">` — OS default size and
+colour, no `--radius-*`, no `--accent-color`, no `--border-color`. Its
+neighbours in the same 12-column grid all carry padding, a token border-radius,
+and a focus ring, so it sits visibly outside the visual system.
+
+## Why this surfaced now
+
+Not a regression. The widget has always looked like this; TKT-3R7RF3 (`widget:`
+override) simply made a checkbox easy to place on a detail page next to the
+styled controls, where the mismatch is obvious. Booleans were previously
+uncommon on those surfaces.
+
+## Scope
+
+- Style the edit-arm checkbox from `src/styles/scales.css` /
+  `tokens.css` — size, radius, accent, focus ring, disabled state — matching
+  the other widgets' conventions.
+- Keep the display arm a REAL disabled checkbox. `RR-UD2I` chose that
+  deliberately for native screen-reader semantics ("checkbox, checked,
+  read-only") and cross-font consistency; do not replace it with a glyph or a
+  styled `<span>`.
+- Respect the frozen typography/token contract (`frontend/CLAUDE.md`): use
+  existing token values rather than inventing new ones.
+
+## Non-goals
+
+- No behaviour change. Checked/unchecked semantics, the `@change` handler and
+  the auto-save path stay exactly as they are.
+- Not a new widget, and no change to which widget the registry selects.
+- The `display: table` cell rendering of booleans, which deliberately routes to
+  text so values stay Cmd-F searchable (`frontend/CLAUDE.md`).

--- a/tickets/relations/TKT-3R7RF3--has-docs--DOCS-WGTOVR.md
+++ b/tickets/relations/TKT-3R7RF3--has-docs--DOCS-WGTOVR.md
@@ -1,0 +1,5 @@
+---
+from: TKT-3R7RF3
+relation: has-docs
+to: DOCS-WGTOVR
+---

--- a/tickets/relations/TKT-3R7RF3--has-implementation--IMPL-P24QGI.md
+++ b/tickets/relations/TKT-3R7RF3--has-implementation--IMPL-P24QGI.md
@@ -1,0 +1,5 @@
+---
+from: TKT-3R7RF3
+relation: has-implementation
+to: IMPL-P24QGI
+---

--- a/tickets/relations/TKT-3R7RF3--has-planning--PLAN-DMQFRJ.md
+++ b/tickets/relations/TKT-3R7RF3--has-planning--PLAN-DMQFRJ.md
@@ -1,0 +1,5 @@
+---
+from: TKT-3R7RF3
+relation: has-planning
+to: PLAN-DMQFRJ
+---

--- a/tickets/relations/TKT-3R7RF3--has-review--REV-P5DOCM.md
+++ b/tickets/relations/TKT-3R7RF3--has-review--REV-P5DOCM.md
@@ -1,0 +1,5 @@
+---
+from: TKT-3R7RF3
+relation: has-review
+to: REV-P5DOCM
+---

--- a/tickets/relations/TKT-3R7RF3--has-review-response--RR-2GBB0V.md
+++ b/tickets/relations/TKT-3R7RF3--has-review-response--RR-2GBB0V.md
@@ -1,0 +1,5 @@
+---
+from: TKT-3R7RF3
+relation: has-review-response
+to: RR-2GBB0V
+---

--- a/tickets/relations/TKT-3R7RF3--has-review-response--RR-66MT0D.md
+++ b/tickets/relations/TKT-3R7RF3--has-review-response--RR-66MT0D.md
@@ -1,0 +1,5 @@
+---
+from: TKT-3R7RF3
+relation: has-review-response
+to: RR-66MT0D
+---

--- a/tickets/relations/TKT-3R7RF3--has-review-response--RR-693NL9.md
+++ b/tickets/relations/TKT-3R7RF3--has-review-response--RR-693NL9.md
@@ -1,0 +1,5 @@
+---
+from: TKT-3R7RF3
+relation: has-review-response
+to: RR-693NL9
+---

--- a/tickets/relations/TKT-3R7RF3--has-review-response--RR-9G51IS.md
+++ b/tickets/relations/TKT-3R7RF3--has-review-response--RR-9G51IS.md
@@ -1,0 +1,5 @@
+---
+from: TKT-3R7RF3
+relation: has-review-response
+to: RR-9G51IS
+---

--- a/tickets/relations/TKT-3R7RF3--has-review-response--RR-AMBIG.md
+++ b/tickets/relations/TKT-3R7RF3--has-review-response--RR-AMBIG.md
@@ -1,0 +1,5 @@
+---
+from: TKT-3R7RF3
+relation: has-review-response
+to: RR-AMBIG
+---

--- a/tickets/relations/TKT-3R7RF3--has-review-response--RR-COLDUP.md
+++ b/tickets/relations/TKT-3R7RF3--has-review-response--RR-COLDUP.md
@@ -1,0 +1,5 @@
+---
+from: TKT-3R7RF3
+relation: has-review-response
+to: RR-COLDUP
+---

--- a/tickets/relations/TKT-3R7RF3--has-review-response--RR-CUSTY.md
+++ b/tickets/relations/TKT-3R7RF3--has-review-response--RR-CUSTY.md
@@ -1,0 +1,5 @@
+---
+from: TKT-3R7RF3
+relation: has-review-response
+to: RR-CUSTY
+---

--- a/tickets/relations/TKT-3R7RF3--has-review-response--RR-DRIFT1.md
+++ b/tickets/relations/TKT-3R7RF3--has-review-response--RR-DRIFT1.md
@@ -1,0 +1,5 @@
+---
+from: TKT-3R7RF3
+relation: has-review-response
+to: RR-DRIFT1
+---

--- a/tickets/relations/TKT-3R7RF3--has-review-response--RR-E2EPATCH.md
+++ b/tickets/relations/TKT-3R7RF3--has-review-response--RR-E2EPATCH.md
@@ -1,0 +1,5 @@
+---
+from: TKT-3R7RF3
+relation: has-review-response
+to: RR-E2EPATCH
+---

--- a/tickets/relations/TKT-3R7RF3--has-review-response--RR-FILEORD.md
+++ b/tickets/relations/TKT-3R7RF3--has-review-response--RR-FILEORD.md
@@ -1,0 +1,5 @@
+---
+from: TKT-3R7RF3
+relation: has-review-response
+to: RR-FILEORD
+---

--- a/tickets/relations/TKT-3R7RF3--has-review-response--RR-INLEN.md
+++ b/tickets/relations/TKT-3R7RF3--has-review-response--RR-INLEN.md
@@ -1,0 +1,5 @@
+---
+from: TKT-3R7RF3
+relation: has-review-response
+to: RR-INLEN
+---

--- a/tickets/relations/TKT-3R7RF3--has-review-response--RR-JOINDUP.md
+++ b/tickets/relations/TKT-3R7RF3--has-review-response--RR-JOINDUP.md
@@ -1,0 +1,5 @@
+---
+from: TKT-3R7RF3
+relation: has-review-response
+to: RR-JOINDUP
+---

--- a/tickets/relations/TKT-3R7RF3--has-review-response--RR-LISTW.md
+++ b/tickets/relations/TKT-3R7RF3--has-review-response--RR-LISTW.md
@@ -1,0 +1,5 @@
+---
+from: TKT-3R7RF3
+relation: has-review-response
+to: RR-LISTW
+---

--- a/tickets/relations/TKT-3R7RF3--has-review-response--RR-NGY84F.md
+++ b/tickets/relations/TKT-3R7RF3--has-review-response--RR-NGY84F.md
@@ -1,0 +1,5 @@
+---
+from: TKT-3R7RF3
+relation: has-review-response
+to: RR-NGY84F
+---

--- a/tickets/relations/TKT-3R7RF3--has-review-response--RR-YTC4W5.md
+++ b/tickets/relations/TKT-3R7RF3--has-review-response--RR-YTC4W5.md
@@ -1,0 +1,5 @@
+---
+from: TKT-3R7RF3
+relation: has-review-response
+to: RR-YTC4W5
+---

--- a/tickets/relations/TKT-3R7RF3--has-review-response--RR-Z0GGTO.md
+++ b/tickets/relations/TKT-3R7RF3--has-review-response--RR-Z0GGTO.md
@@ -1,0 +1,5 @@
+---
+from: TKT-3R7RF3
+relation: has-review-response
+to: RR-Z0GGTO
+---

--- a/tickets/relations/TKT-CBSTYLE--affects--views.md
+++ b/tickets/relations/TKT-CBSTYLE--affects--views.md
@@ -1,0 +1,5 @@
+---
+from: TKT-CBSTYLE
+relation: affects
+to: views
+---

--- a/tickets/relations/TKT-CBSTYLE--implements--FEAT-72NR1.md
+++ b/tickets/relations/TKT-CBSTYLE--implements--FEAT-72NR1.md
@@ -1,0 +1,5 @@
+---
+from: TKT-CBSTYLE
+relation: implements
+to: FEAT-72NR1
+---


### PR DESCRIPTION
Adds an optional `widget:` key to a data-entry view section field, letting
config choose which registered widget renders a property instead of the
type-derived default.

```yaml
sections:
  - heading: Today
    display: properties
    render: input
    fields:
      - property: done
        widget: checkbox     # click to tick — the payoff case
      - property: notes
        widget: textarea     # a string's default is a one-line input
```

Follow-up to TKT-HOIX1 (#1364), which added the orthogonal `render:` axis
through the same code path. Omitting `widget:` changes nothing.

## Validation

A widget must be compatible with the property, checked at config load against
the SPA's own dispatch precedence (`list` → value set → type), not just its
type:

- `list: true` → only `multi-select`. Anything else flattens the array through
  `useStringValue` and auto-save then PATCHes a **scalar over a list**.
- a fixed value set (inline `values:` or a custom type carrying values) → only
  the select family, so config can't offer a free-text box over a constrained
  set.
- otherwise the type table, mirroring the registry's `supportedPropertyTypes`.

Custom types resolve by lookup in `meta.Types`, not by excluding a hardcoded
list of built-ins.

Two inert cases warn rather than error: a display mode that renders no fields,
and a property the metamodel doesn't declare (which routes through the SPA's
hint path, where there is no `PropertyDef` to validate against). A third —
`widget:` on a state-machine field — is deliberately **not** warned: machine-ness
is a runtime, per-principal fact the config layer cannot see.

`widget: file` is rejected outside `display: properties`: only the entry mount
site passes `:attachments`, so a file widget in a card/list row would have
nothing to show.

## ACL

Unchanged, and pinned by test. Effective editability is still
`render === 'input' && isFieldWritable(verdict)`. A widget override decides
*which* component renders, never *whether* it is writable — config can only
downgrade.

## Cross-language drift guard

The widget/property-type rule necessarily exists in both Go (validation) and TS
(rendering). Both assert against one shared JSON fixture, and `registry.ts` now
exports `WIDGET_REGISTRATIONS` so the test reads the **real** registrations
rather than a copy.

Verified by mutation, not assumed: changing a widget's supported types, or
adding a new widget, fails the guard. The first version of it passed both of
those silently — see RR-DRIFT1.

## Also here

- **`docs/data-entry.md`**: documents `widget:` **and** TKT-HOIX1's `render:`,
  which shipped undocumented. `docs/` is generated from `docs-project/entities/`,
  so that PR's edit was silently overwritten.
- **`ticket_summary.lua`** (separate commit): used `rela.entity_id`, which the
  Lua runtime never binds, so every render of that document failed. Pre-existing
  on develop, surfaced by the demo.
- **A worked example** on the prototype ticket view.

## Verification

`just ci` green. 1819 frontend tests, 8 e2e specs, coverage 78.0% (touched
packages 89.1% / 80.9%). Confirmed by hand in a browser: a string property
renders as a textarea where its default is a one-line input, and ticking the
checkbox persisted to disk.

Known cosmetic issue, filed as **TKT-CBSTYLE** (backlog): `CheckboxWidget`'s
edit arm carries zero design tokens where every sibling widget has 6–13, so it
renders as a bare native control. Pre-existing; this ticket only made a checkbox
easy to place beside styled controls.

Ticket: TKT-3R7RF3 · 15 review-responses across a design review and a code
review, all addressed.
