### PR TITLE
feat(acl): shared ungated-membership predicate + startup warning (TKT-T31NKT)

### DIFF
--- a/docs-project/entities/guides/GUIDE-acl-security.md
+++ b/docs-project/entities/guides/GUIDE-acl-security.md
@@ -61,6 +61,42 @@ The `rela acl audit` linter (below) flags an un-gated membership
 relation — default or configured — as a high-severity finding, so run
 it after editing `acl.yaml`.
 
+You do not have to remember to run it, though: whenever rela loads a
+policy whose `assignments` confer a **privileged** role while the
+membership relation is un-gated — at server startup, and equally when a
+CLI command builds the full service bundle — it logs a prominent
+warning naming the relation and the fix. (Surfaces that inject their
+own ACL instead of loading the policy, such as the server's read-only
+mode, do not evaluate it and stay silent.) The server still boots — the
+gap is pre-existing, and in a single-team deployment where everyone who
+can write to the project is already trusted, it may be an acceptable
+risk you have consciously taken. The warning exists so it is a choice
+rather than an oversight.
+
+A group assigned a **read-only** role does not trigger the warning (or
+the audit finding): granting yourself read access to something you were
+going to be shown anyway is a visibility decision, not an escalation
+path. Both the warning and the linter evaluate the same predicate, so
+they never disagree.
+
+### This becomes a hard requirement with content states
+
+The tolerance above holds only while the worst case is over-granting
+inside a trusted group. It stops holding the moment the same policy
+also grants read on a **non-default world** — the content-states
+feature, where an entity has separate draft/review/published faces.
+There, an un-gated membership relation is no longer just a
+role-management weakness: it is a working mechanism for reading
+unpublished content, because self-assigning a role that can read the
+draft world is one relation write away.
+
+When world-shaped read grants ship, a policy that combines them with an
+un-gated membership relation will be **refused at load** with an error
+naming the fix, rather than booting with a warning. Deployments that do
+not use worlds are unaffected and keep today's behaviour. Gating the
+membership relation now costs one `requires_permission` line and means
+that change is a no-op for you.
+
 The companion section in `docs/server-security.md` carries the same
 guidance with more context on the broader threat model.
 

--- a/docs/acl-security.md
+++ b/docs/acl-security.md
@@ -55,6 +55,42 @@ The `rela acl audit` linter (below) flags an un-gated membership
 relation — default or configured — as a high-severity finding, so run
 it after editing `acl.yaml`.
 
+You do not have to remember to run it, though: whenever rela loads a
+policy whose `assignments` confer a **privileged** role while the
+membership relation is un-gated — at server startup, and equally when a
+CLI command builds the full service bundle — it logs a prominent
+warning naming the relation and the fix. (Surfaces that inject their
+own ACL instead of loading the policy, such as the server's read-only
+mode, do not evaluate it and stay silent.) The server still boots — the
+gap is pre-existing, and in a single-team deployment where everyone who
+can write to the project is already trusted, it may be an acceptable
+risk you have consciously taken. The warning exists so it is a choice
+rather than an oversight.
+
+A group assigned a **read-only** role does not trigger the warning (or
+the audit finding): granting yourself read access to something you were
+going to be shown anyway is a visibility decision, not an escalation
+path. Both the warning and the linter evaluate the same predicate, so
+they never disagree.
+
+### This becomes a hard requirement with content states
+
+The tolerance above holds only while the worst case is over-granting
+inside a trusted group. It stops holding the moment the same policy
+also grants read on a **non-default world** — the content-states
+feature, where an entity has separate draft/review/published faces.
+There, an un-gated membership relation is no longer just a
+role-management weakness: it is a working mechanism for reading
+unpublished content, because self-assigning a role that can read the
+draft world is one relation write away.
+
+When world-shaped read grants ship, a policy that combines them with an
+un-gated membership relation will be **refused at load** with an error
+naming the fix, rather than booting with a warning. Deployments that do
+not use worlds are unaffected and keep today's behaviour. Gating the
+membership relation now costs one `requires_permission` line and means
+that change is a no-op for you.
+
 The companion section in `docs/server-security.md` carries the same
 guidance with more context on the broader threat model.
 

--- a/internal/acl/membership_gate_test.go
+++ b/internal/acl/membership_gate_test.go
@@ -1,0 +1,154 @@
+package acl
+
+import "testing"
+
+// TestPolicy_MembershipSelfPromotionOpen pins the shared predicate behind both
+// the aclaudit A1-ungated-membership finding and the boot-time startup warning
+// (TKT-T31NKT). The privilege gate is the load-bearing part: widening it to
+// "any assignment" would fire on read-only groups, the false positive the
+// audit design explicitly fought (RR-EG5D3E).
+func TestPolicy_MembershipSelfPromotionOpen(t *testing.T) {
+	t.Parallel()
+
+	privileged := RoleDef{Create: []string{"ticket"}, Read: []string{"ticket"}}
+	readOnly := RoleDef{Read: []string{"ticket"}}
+
+	tests := []struct {
+		name   string
+		policy Policy
+		want   bool
+	}{
+		{
+			name: "ungated default member-of with privileged assignment",
+			policy: Policy{
+				Roles:       map[string]RoleDef{"editor": privileged},
+				Assignments: map[string]string{"engineering": "editor"},
+			},
+			want: true,
+		},
+		{
+			name: "gated by requires_permission",
+			policy: Policy{
+				Roles:         map[string]RoleDef{"editor": privileged},
+				Assignments:   map[string]string{"engineering": "editor"},
+				RoleRelations: map[string]RoleRelationDef{"member-of": {RequiresPermission: "delegate-membership"}},
+			},
+			want: false,
+		},
+		{
+			name: "read-only assigned role is a visibility choice, not escalation",
+			policy: Policy{
+				Roles:       map[string]RoleDef{"reader": readOnly},
+				Assignments: map[string]string{"engineering": "reader"},
+			},
+			want: false,
+		},
+		{
+			name: "assignment naming an undeclared role confers nothing",
+			policy: Policy{
+				Roles:       map[string]RoleDef{"editor": privileged},
+				Assignments: map[string]string{"engineering": "ghost"},
+			},
+			want: false,
+		},
+		{
+			name:   "no assignments at all",
+			policy: Policy{Roles: map[string]RoleDef{"editor": privileged}},
+			want:   false,
+		},
+		{
+			name: "permission-only role counts as privileged",
+			policy: Policy{
+				Roles:       map[string]RoleDef{"delegator": {Permissions: []string{"delegate-membership"}}},
+				Assignments: map[string]string{"admins": "delegator"},
+			},
+			want: true,
+		},
+		{
+			// The gate must be read through EffectiveMembershipRelation, so a
+			// configured relation is checked against its OWN role_relations
+			// entry — not the default member-of.
+			name: "configured relation, ungated (default member-of gate does not count)",
+			policy: Policy{
+				MembershipRelation: "heeft_rol",
+				Roles:              map[string]RoleDef{"editor": privileged},
+				Assignments:        map[string]string{"engineering": "editor"},
+				RoleRelations:      map[string]RoleRelationDef{"member-of": {RequiresPermission: "delegate-membership"}},
+			},
+			want: true,
+		},
+		{
+			name: "configured relation, gated on the configured name",
+			policy: Policy{
+				MembershipRelation: "heeft_rol",
+				Roles:              map[string]RoleDef{"editor": privileged},
+				Assignments:        map[string]string{"engineering": "editor"},
+				RoleRelations:      map[string]RoleRelationDef{"heeft_rol": {RequiresPermission: "delegate-membership"}},
+			},
+			want: false, // gated on the effective relation → closed
+		},
+		{
+			// Whitespace in membership_relation resolves through the same
+			// trimming accessor the resolver walks, so the gate is found.
+			name: "whitespace-padded relation name still finds its gate",
+			policy: Policy{
+				MembershipRelation: " heeft_rol ",
+				Roles:              map[string]RoleDef{"editor": privileged},
+				Assignments:        map[string]string{"engineering": "editor"},
+				RoleRelations:      map[string]RoleRelationDef{"heeft_rol": {RequiresPermission: "delegate-membership"}},
+			},
+			want: false,
+		},
+		{
+			name: "one privileged assignment among several read-only ones is enough",
+			policy: Policy{
+				Roles: map[string]RoleDef{"reader": readOnly, "editor": privileged},
+				Assignments: map[string]string{
+					"support":     "reader",
+					"engineering": "editor",
+				},
+			},
+			want: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := tc.policy.MembershipSelfPromotionOpen(); got != tc.want {
+				t.Errorf("MembershipSelfPromotionOpen() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestRoleDef_IsPrivileged pins the definition of "privileged" that the
+// membership predicate and the aclaudit A2/A3 checks share. Read grants are
+// never privilege (RR-LXI3NW / RR-UR0LJU).
+func TestRoleDef_IsPrivileged(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		role RoleDef
+		want bool
+	}{
+		{"empty role", RoleDef{}, false},
+		{"read only", RoleDef{Read: []string{"ticket"}}, false},
+		{"read wildcard is not privilege", RoleDef{Read: []string{"*"}}, false},
+		{"create", RoleDef{Create: []string{"ticket"}}, true},
+		{"update", RoleDef{Update: []string{"ticket"}}, true},
+		{"delete", RoleDef{Delete: []string{"ticket"}}, true},
+		{"permissions only", RoleDef{Permissions: []string{"delegate-membership"}}, true},
+		{"write wildcard", RoleDef{Create: []string{"*"}}, true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := tc.role.IsPrivileged(); got != tc.want {
+				t.Errorf("IsPrivileged() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/acl/policy.go
+++ b/internal/acl/policy.go
@@ -180,6 +180,43 @@ func (p *Policy) EffectiveMembershipRelation() string {
 	return defaultMembershipRelation
 }
 
+// MembershipSelfPromotionOpen reports whether this policy leaves the
+// membership-relation self-promotion path open: at least one entry in
+// [Policy.Assignments] targets a declared, PRIVILEGED role while writes
+// to the effective membership relation carry no `requires_permission`
+// gate. When true, any principal who can write an edge of that relation
+// type can grant themselves the assigned role (RR-7O6Q) — see the
+// escalation-risk note on [RoleRelationDef].
+//
+// This is the single implementation of the "is membership gated?"
+// question. The aclaudit linter's A1-ungated-membership finding and the
+// boot-time startup warning both call it, so the advisory and the
+// enforcement view can never drift apart (TKT-T31NKT). It lives here,
+// beside [Policy.EffectiveMembershipRelation], for the same reason that
+// accessor does: a second hand-maintained copy of this predicate is a
+// silent over- or under-report waiting to happen.
+//
+// Privilege-gated deliberately, and symmetric with the linter's A2
+// check: a group assigned a READ-ONLY role is a visibility choice, not
+// an escalation path (RR-LXI3NW / RR-UR0LJU / RR-EG5D3E). Widening this
+// to "any assignment" would fire on read-only groups — the exact false
+// positive the audit design fought.
+//
+// An assignment naming an UNDECLARED role confers nothing and is
+// likewise not an escalation path; the linter reports that separately
+// as A4-assignment-unknown-role.
+func (p *Policy) MembershipSelfPromotionOpen() bool {
+	if p.RoleRelations[p.EffectiveMembershipRelation()].RequiresPermission != "" {
+		return false // gated — the delegate-X pattern is in place
+	}
+	for _, roleName := range p.Assignments {
+		if role, ok := p.Roles[roleName]; ok && role.IsPrivileged() {
+			return true
+		}
+	}
+	return false
+}
+
 // RoleDef is the capability bundle for a single role. The per-verb
 // mutation grants (Create / Update / Delete), Permissions, and the
 // affordance grants are honored by the write path and the affordances
@@ -229,6 +266,18 @@ type RoleDef struct {
 	Visible   map[string][]FieldGrant    `yaml:"visible"`
 	Options   map[string][]OptionGrant   `yaml:"options"`
 	Relations map[string][]RelationGrant `yaml:"relations"`
+}
+
+// IsPrivileged reports whether the role confers escalation-relevant
+// power: it grants any write verb (Create/Update/Delete, including the
+// "*" wildcard) or holds any permission.
+//
+// Read grants are NOT privilege — a read-everything role is a
+// visibility choice, not an escalation path (RR-LXI3NW, RR-UR0LJU).
+// Exported so the aclaudit linter shares this definition rather than
+// keeping its own copy; its A2/A3 checks reference the same notion.
+func (r RoleDef) IsPrivileged() bool {
+	return len(r.Create) > 0 || len(r.Update) > 0 || len(r.Delete) > 0 || len(r.Permissions) > 0
 }
 
 // grantsVerb reports whether the role may perform op on entity type

--- a/internal/aclaudit/aclaudit.go
+++ b/internal/aclaudit/aclaudit.go
@@ -176,13 +176,13 @@ func HasAtLeast(findings []Finding, threshold Severity) bool {
 
 // ---- Shared policy predicates ------------------------------------------
 
-// isPrivileged reports whether a role confers escalation-relevant power:
-// it grants any write verb (Create/Update/Delete, including the "*"
-// wildcard) OR holds any permission. Read grants are NOT privilege — a
-// read-everything role is a visibility choice, not an escalation path
-// (RR-LXI3NW, RR-UR0LJU). This is the single definition A2/A3 reference.
+// isPrivileged reports whether a role confers escalation-relevant power.
+// Delegates to [acl.RoleDef.IsPrivileged] so A2/A3 and the shared
+// membership predicate ([acl.Policy.MembershipSelfPromotionOpen], which A1
+// calls) agree on what "privileged" means — one definition, not two
+// (TKT-T31NKT). Kept as a local function so the call sites read unchanged.
 func isPrivileged(r acl.RoleDef) bool {
-	return len(r.Create) > 0 || len(r.Update) > 0 || len(r.Delete) > 0 || len(r.Permissions) > 0
+	return r.IsPrivileged()
 }
 
 // roleDeclared reports whether the policy declares a role by this name.
@@ -199,12 +199,6 @@ func permissionGranted(p *acl.Policy, perm string) bool {
 		}
 	}
 	return false
-}
-
-// requiresPermissionFor returns the requires_permission gate on the given
-// relation type, "" if the relation isn't a role-relation or has no gate.
-func requiresPermissionFor(p *acl.Policy, rel string) string {
-	return p.RoleRelations[rel].RequiresPermission
 }
 
 // verbLists returns the four grant lists of a role for iteration.

--- a/internal/aclaudit/tier_a.go
+++ b/internal/aclaudit/tier_a.go
@@ -46,11 +46,13 @@ func checkUngatedMembership(p *acl.Policy) []Finding {
 	}
 
 	// A1 — the membership relation can confer a PRIVILEGED assigned role but
-	// writes to it are not gated. Gated on isPrivileged (symmetric with A2):
-	// granting yourself a read-only role is a visibility choice, not an
-	// escalation path (RR-LXI3NW / RR-UR0LJU / RR-EG5D3E), so a read-only
-	// group does not trip A1.
-	if assignsAnyPrivilegedRole(p) && requiresPermissionFor(p, rel) == "" {
+	// writes to it are not gated. The predicate lives on acl.Policy so this
+	// finding and the boot-time startup warning can never disagree about
+	// whether membership is gated (TKT-T31NKT); its privilege gate keeps A1
+	// symmetric with A2 — granting yourself a read-only role is a visibility
+	// choice, not an escalation path (RR-LXI3NW / RR-UR0LJU / RR-EG5D3E), so
+	// a read-only group does not trip A1.
+	if p.MembershipSelfPromotionOpen() {
 		f = append(f, Finding{
 			Rule: "A1-ungated-membership", Severity: High, Subject: rel,
 			Detail: fmt.Sprintf("membership relation %q confers a privileged group role via assignments "+
@@ -61,18 +63,6 @@ func checkUngatedMembership(p *acl.Policy) []Finding {
 		})
 	}
 	return f
-}
-
-// assignsAnyPrivilegedRole reports whether at least one assignment targets a
-// declared, privileged role — i.e. the membership walk can confer escalation-
-// relevant power. Mirrors A2's isPrivileged gate.
-func assignsAnyPrivilegedRole(p *acl.Policy) bool {
-	for _, roleName := range p.Assignments {
-		if role, ok := p.Roles[roleName]; ok && isPrivileged(role) {
-			return true
-		}
-	}
-	return false
 }
 
 // A2 — a role-relation confers a privileged role but is not gated by

--- a/internal/appbuild/appbuild.go
+++ b/internal/appbuild/appbuild.go
@@ -611,6 +611,7 @@ func buildACL(policy *acl.Policy, meta *metamodel.Metamodel, st store.Store) (ac
 	if err := policy.ValidateAgainstMetamodel(metamodelView{meta}); err != nil {
 		return nil, nil, fmt.Errorf("appbuild: validate acl policy against metamodel: %w", err)
 	}
+	warnUngatedMembership(policy)
 	// `st` is passed twice: once via NewStoreGraph (the Graph
 	// adapter the resolver uses for member-of / ancestor walks), and
 	// once as the GraphQueryer (executes store.MatchingIDs for
@@ -629,6 +630,37 @@ func buildACL(policy *acl.Policy, meta *metamodel.Metamodel, st store.Store) (ac
 		return nil, nil, fmt.Errorf("appbuild: build acl.Declarative: %w", err)
 	}
 	return d, d, nil
+}
+
+// warnUngatedMembership logs a prominent startup warning when the loaded
+// policy leaves the membership-relation self-promotion path open: a group
+// named in `assignments:` confers a privileged role, but writes to the
+// membership relation carry no `requires_permission` gate, so anyone who can
+// write that edge can grant themselves the role (RR-7O6Q, TKT-T31NKT).
+//
+// **Warning, not a refusal.** The hole is pre-existing and the shape is a
+// reasonable one inside a trusted team, where the trust boundary is who can
+// write to the project at all. Hard-failing the boot would break those
+// deployments on upgrade for a risk they have already accepted. The refusal
+// is scoped to the case that genuinely changes the stakes — a policy that
+// also grants read on a non-default world, where the same hole becomes a
+// mechanism for leaking unpublished content — and lands with the world grant
+// syntax it needs to be evaluated (TKT-DN37J2).
+//
+// The condition comes from [acl.Policy.MembershipSelfPromotionOpen], the same
+// predicate behind the `rela acl audit` A1-ungated-membership finding, so the
+// boot warning and the linter can never disagree.
+func warnUngatedMembership(policy *acl.Policy) {
+	if !policy.MembershipSelfPromotionOpen() {
+		return
+	}
+	rel := policy.EffectiveMembershipRelation()
+	slog.Warn("appbuild: ACL membership relation is NOT gated — self-promotion is possible; "+
+		"any principal who can write this relation can grant themselves an assigned privileged role",
+		"relation", rel,
+		"fix", fmt.Sprintf("set role_relations.%s.requires_permission and grant that permission only to admins", rel),
+		"docs", "docs/acl-security.md",
+		"audit", "rela acl audit")
 }
 
 // Config carries the inputs every build of [New] needs, plus

--- a/internal/appbuild/appbuild_membership_warn_test.go
+++ b/internal/appbuild/appbuild_membership_warn_test.go
@@ -1,0 +1,174 @@
+package appbuild_test
+
+import (
+	"bytes"
+	"io"
+	"log/slog"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// ungatedWarningFragment is the load-bearing fragment of the membership
+// warning asserted by BOTH the fires-test and the stays-quiet tests. Keep
+// them on one constant: if they keyed off different substrings, rewording
+// the message could break the positive test while silently turning the
+// negative tests into vacuous passes.
+const ungatedWarningFragment = "membership relation is NOT gated"
+
+// captureWarnings redirects the default slog logger into a buffer for the
+// duration of the test and returns an accessor for what was logged.
+//
+// Callers must NOT use t.Parallel(): slog.SetDefault mutates process-global
+// state, so two parallel service builds would race on the logger and bleed
+// log lines across tests — which would let a quiet-case assertion pass (or
+// fail) on another test's output. Writes and reads are mutex-serialized
+// because appbuild starts background goroutines (store watcher) that can
+// log after New returns; bytes.Buffer is not safe for concurrent use.
+func captureWarnings(t *testing.T) func() string {
+	t.Helper()
+	var mu sync.Mutex
+	var buf bytes.Buffer
+	prev := slog.Default()
+	t.Cleanup(func() { slog.SetDefault(prev) })
+	slog.SetDefault(slog.New(slog.NewTextHandler(
+		&lockedWriter{mu: &mu, w: &buf}, &slog.HandlerOptions{Level: slog.LevelWarn})))
+	return func() string {
+		mu.Lock()
+		defer mu.Unlock()
+		return buf.String()
+	}
+}
+
+// lockedWriter serializes writes to the underlying writer with the same
+// mutex captureWarnings reads under.
+type lockedWriter struct {
+	mu *sync.Mutex
+	w  io.Writer
+}
+
+func (l *lockedWriter) Write(p []byte) (int, error) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.w.Write(p)
+}
+
+// TKT-T31NKT: a policy whose assignments confer a privileged role while the
+// membership relation carries no requires_permission gate must warn loudly at
+// startup — the server still boots (the hole is pre-existing and acceptable
+// inside a trusted team), but the operator is told, without having to
+// remember to run `rela acl audit`.
+func TestBuildACL_UngatedMembership_WarnsAtStartup(t *testing.T) {
+	root := t.TempDir()
+	writeMetamodel(t, root)
+	writePolicy(t, root, `roles:
+  admin:
+    create: ["*"]
+    update: ["*"]
+    delete: ["*"]
+    read: ["*"]
+assignments:
+  engineering: admin
+`)
+
+	logs := captureWarnings(t)
+
+	svc, err := appbuildOnDisk(t, root)
+	if err != nil {
+		t.Fatalf("appbuild.New: %v", err)
+	}
+	defer svc.Close()
+
+	got := logs()
+	for _, want := range []string{ungatedWarningFragment, "member-of", "requires_permission", "docs/acl-security.md"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("startup warning missing %q; logs:\n%s", want, got)
+		}
+	}
+}
+
+// The warning must stay quiet for the shapes that are not an escalation path,
+// so it does not become noise operators learn to ignore. Each case here is a
+// policy that boots clean.
+func TestBuildACL_MembershipWarning_QuietWhenSafe(t *testing.T) {
+	tests := []struct {
+		name   string
+		policy string
+	}{
+		{
+			name: "gated by requires_permission",
+			policy: `roles:
+  admin:
+    create: ["*"]
+    update: ["*"]
+    delete: ["*"]
+    read: ["*"]
+    permissions: [delegate-membership]
+assignments:
+  engineering: admin
+role_relations:
+  member-of:
+    requires_permission: delegate-membership
+`,
+		},
+		{
+			// RR-EG5D3E: a read-only group is a visibility choice.
+			name: "assigned role is read-only",
+			policy: `roles:
+  reader:
+    read: ["*"]
+assignments:
+  engineering: reader
+`,
+		},
+		{
+			name: "no assignments at all",
+			policy: `roles:
+  admin:
+    create: ["*"]
+    update: ["*"]
+    delete: ["*"]
+    read: ["*"]
+`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			root := t.TempDir()
+			writeMetamodel(t, root)
+			writePolicy(t, root, tc.policy)
+
+			logs := captureWarnings(t)
+
+			svc, err := appbuildOnDisk(t, root)
+			if err != nil {
+				t.Fatalf("appbuild.New: %v", err)
+			}
+			defer svc.Close()
+
+			if got := logs(); strings.Contains(got, ungatedWarningFragment) {
+				t.Errorf("expected no membership warning, got logs:\n%s", got)
+			}
+		})
+	}
+}
+
+// A project with no acl.yaml falls back to NopACL; there is no policy to
+// inspect, so nothing may be warned about.
+func TestBuildACL_NoPolicy_NoMembershipWarning(t *testing.T) {
+	root := t.TempDir()
+	writeMetamodel(t, root)
+
+	logs := captureWarnings(t)
+
+	svc, err := appbuildOnDisk(t, root)
+	if err != nil {
+		t.Fatalf("appbuild.New: %v", err)
+	}
+	defer svc.Close()
+
+	if got := logs(); strings.Contains(got, ungatedWarningFragment) {
+		t.Errorf("expected no membership warning without acl.yaml, got logs:\n%s", got)
+	}
+}

--- a/tickets/entities/decisions/DEC-PEYCJZ.md
+++ b/tickets/entities/decisions/DEC-PEYCJZ.md
@@ -1,0 +1,24 @@
+---
+id: DEC-PEYCJZ
+type: decision
+title: Public-read scenario re-scoped to authenticated-everyone; anonymous access deferred
+context: 'Design doc §12.3 (.ignored/pointer-design.md): the headline worlds scenario "everyone reads world:published" seemed to require an anonymous-passthrough or public-surface mode. rela-server has no auth layer; multi-user deployments sit behind an identity proxy that verifies every principal (docs/server-security.md). Supporting anonymous readers would require changing the JWT/identity-proxy contract — a new auth-layer feature for a deployment shape that is not rela''s current target.'
+consequences: The built-in everyone role means every AUTHENTICATED principal; "everyone reads world:published" is an intranet/portal scenario behind the existing proxy, needing no auth-layer change. TKT-SP3A87 shrinks from a design note to recording this decision in the server-security docs. Anonymous/public-internet read becomes a possible future feature with its own design (principal mapping, surface allowlist, rate limiting) — nothing in Steps 1-5 depends on it, and the worlds ACL model (world-shaped read grants, wiring-bound public surface) is unchanged and already accommodates it later.
+date: "2026-08-19"
+status: accepted
+---
+
+Decided 2026-08-19 by Jeroen (architect check-in during the FEAT-9CD2MX ticket
+arc).
+
+The alternative — an anonymous-passthrough mode — would touch the JWT/proxy
+contract that every current deployment relies on, to serve a scenario
+(unauthenticated public internet reads) that is not the product's present
+target. Re-scoping keeps §12.3 from gating the feature: the "public" surface in
+the design doc is wiring-bound `visibility(everyone) ∘ world(published)` where
+`everyone` = all verified principals.
+
+If anonymous read is wanted later it is additive: a proxy-level synthetic
+principal or a dedicated public surface can be designed then without reworking
+world grants, because read grants are world-shaped and the public surface is
+structurally bound to its world at the wiring site (§4.4 rule 1).

--- a/tickets/entities/docs-checklists/DOCS-3V181I.md
+++ b/tickets/entities/docs-checklists/DOCS-3V181I.md
@@ -1,0 +1,24 @@
+---
+id: DOCS-3V181I
+type: docs-checklist
+title: 'Docs: Gate the membership relation against ACL self-promotion'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Code Documentation
+
+- [x] Comments where logic isn't obvious (godoc on `Policy.MembershipSelfPromotionOpen`, `RoleDef.IsPrivileged`, `warnUngatedMembership` explain the why: shared-predicate no-drift, privilege gate vs read-only visibility, warning-not-refusal)
+- [x] Function/type docs if public API (both new exported methods on `acl.Policy`/`acl.RoleDef` documented)
+
+## Project Documentation
+
+- [x] ~~README updated~~ (N/A: no project-level change)
+- [x] ~~CLAUDE.md updated~~ (N/A: no new pattern — follows existing boot-diagnostic + shared-predicate conventions)
+- [x] ~~Help text accurate~~ (N/A: no CLI command changes; `rela acl audit` output unchanged)
+
+## External Documentation
+
+- [x] ~~Changelog entry added~~ (N/A: repo has no changelog file)
+- [x] API docs updated: `docs/acl-security.md` + `docs-project/entities/guides/GUIDE-acl-security.md` describe the startup warning, when it fires and stays quiet, and the coming world-grant load refusal (TKT-DN37J2)

--- a/tickets/entities/features/FEAT-9CD2MX.md
+++ b/tickets/entities/features/FEAT-9CD2MX.md
@@ -1,0 +1,25 @@
+---
+id: FEAT-9CD2MX
+type: feature
+title: Content states and worlds (pointers)
+summary: Metamodel-declared content states per entity (draft/review/published) with worlds as the reified read coordinate, world-shaped read grants, and a copy kernel with declared definitions (promote/revise/CoW).
+description: 'Entity types declare named pointers (draft/review/published); each names a content state with its own content and content-scoped relations. Worlds are metamodel-declared read coordinates resolving each entity to at most one face; reads are granted per world, writes per state; promote/revise ride an audited copy kernel with declared definitions. Design: .ignored/pointer-design.md (v2).'
+priority: high
+status: planned
+---
+
+Design: `.ignored/pointer-design.md` (v2, 2026-08-19). Supersedes the storage
+halves of RES-NH3P12 and RES-GFWP85; retains RES-NH3P12's per-state read-verdict
+conclusion in world-shaped form.
+
+Core decisions: typed `(id, pointer)` references with the `@` form only at
+boundaries; exactly N states per entity (no third "base" population); relation
+scope (identity vs content) as a metamodel property; worlds as declared
+resolution functions with an at-most-one-prime invariant; reads address worlds,
+writes address states; copy kernel + named declared copy definitions with a
+same-entity-elevated / cross-entity-visible-only security split; attachments as
+state-linked references to shared blobs.
+
+Sequencing: security gates (membership gating, MCP ACL) block shipping; Step 1
+store contract → Step 2 worlds → Step 3 ACL → Step 4 copy → Step 5
+analysis/search.

--- a/tickets/entities/implementation-checklists/IMPL-M9IF9D.md
+++ b/tickets/entities/implementation-checklists/IMPL-M9IF9D.md
@@ -1,0 +1,64 @@
+---
+id: IMPL-M9IF9D
+type: implementation-checklist
+title: 'Implementation: Gate the membership relation against ACL self-promotion'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Development
+
+- [x] Unit tests written for new code (`internal/acl/membership_gate_test.go`: 10-case predicate table + 8-case IsPrivileged table)
+- [x] Integration tests written (`internal/appbuild/appbuild_membership_warn_test.go`: full `appbuild.New` boot on an on-disk temp project, slog captured)
+- [x] Happy path implemented (predicate on `acl.Policy`, aclaudit delegation, `warnUngatedMembership` in `buildACL`, docs in both trees)
+- [x] Edge cases from planning handled (configured/whitespace-padded membership relation, undeclared role, permission-only role, mixed assignments, no acl.yaml)
+- [x] ~~Error handling in place (errors surfaced, not swallowed)~~ (N/A: pure boolean predicate + diagnostic log; no fallible operations added)
+
+## Test Quality
+
+- [x] Using fixture builders or factories for test data (reuses existing `writeMetamodel`/`writePolicy`/`appbuildOnDisk` helpers; shared `privileged`/`readOnly` RoleDef fixtures in the table test)
+- [x] No hardcoded values in assertions when object is in scope (warn-test substrings — "member-of", "requires_permission" — ARE the warning's contract, asserted deliberately)
+- [x] Only specifying values that matter for the test
+- [x] Interpolated values constructed from objects, not hardcoded
+- [x] Property comparisons use original object, not hardcoded strings
+
+## Manual Verification
+
+- [x] Feature manually tested end-to-end
+- [x] Each acceptance criterion verified with test scenario from planning
+- [x] Edge cases manually verified
+
+**Verification Evidence:**
+
+Built `cmd/rela` and ran against a temp project (2026-08-19):
+
+- Ungated policy (`assignments: engineering: admin`, no `role_relations`
+gate) → `rela list tickets` emits the WARN line naming `member-of`, the
+`requires_permission` fix, `docs/acl-security.md`, and `rela acl audit`.
+- `rela acl audit` on the same policy reports `[high] ... A1-ungated-membership: member-of`
+— warning and audit agree (shared predicate).
+- Gated policy (`role_relations.member-of.requires_permission: delegate-membership`)
+→ no warning ("quiet as expected").
+- Remaining planning ACs (read-only role, undeclared role, configured
+relation name, no acl.yaml) covered by the automated tests listed above; all
+pass via `go test ./...`.
+
+## Quality
+
+- [x] Code follows project patterns (check similar code)
+- [x] Checked for DRY opportunities — repeated literals, expressions, or
+patterns extracted to a helper / constant / type where it sharpens the contract
+(don't extract for its own sake; CLAUDE.md "three similar lines is better than a
+premature abstraction" still holds)
+- [x] No security issues introduced (the change IS a security control; the ticket's deferred item 4 explicitly NOT built — no latent `hasNonDefaultWorldGrant` hook exists)
+- [x] ~~No silent failures (errors logged AND returned)~~ (N/A: no fallible paths added; predicate is pure, warning is best-effort diagnostics by design)
+- [x] No debug code left behind
+
+## Quality Gates (run 2026-08-19)
+
+- `go build ./...` + `go test ./...` — all pass
+- `just arch-lint` — OK, no warnings
+- `just plimsoll` — clean
+- `just lint` (golangci-lint) — 0 issues
+- `just coverage-check` — package floor + total (76.6% >= 65%) satisfied

--- a/tickets/entities/planning-checklists/PLAN-QI9SFC.md
+++ b/tickets/entities/planning-checklists/PLAN-QI9SFC.md
@@ -1,0 +1,214 @@
+---
+id: PLAN-QI9SFC
+type: planning-checklist
+title: 'Planning: Gate the membership relation against ACL self-promotion'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Understanding
+
+- [x] Problem/requirements clearly understood
+- [x] Scope defined (what's in/out documented below)
+- [x] Acceptance criteria documented with specific test scenarios
+
+**Scope:**
+
+IN scope (ticket items 1–3):
+
+1. Extract the A1-ungated-membership predicate from `aclaudit/tier_a.go`
+into `internal/acl` as `Policy.MembershipSelfPromotionOpen()` (plus
+`RoleDef.IsPrivileged()`); aclaudit delegates to it. Behaviour identical.
+2. rela-server logs a prominent startup warning (`warnUngatedMembership` in
+`internal/appbuild`) when a loaded policy has privileged assignments and an
+ungated membership relation. Warning, not refusal.
+3. Docs: `docs/acl-security.md` + `docs-project/entities/guides/GUIDE-acl-security.md`
+record the warning and the coming deployment requirement (world grants + ungated
+membership = load refusal).
+
+OUT of scope (explicitly deferred to TKT-DN37J2):
+
+4. The `Policy.Validate` hard load refusal when a non-default-world read
+grant coexists with ungated membership. No latent always-false
+`hasNonDefaultWorldGrant` hook is built here — it would be untestable dead code
+pre-committing Step 3's data model. Also out of scope: an unconditional refusal
+(would break existing trusted-team deployments).
+
+**Acceptance Criteria:**
+
+1. `Policy.MembershipSelfPromotionOpen()` returns true iff at least one
+assignment targets a declared privileged role AND the effective membership
+relation has no `requires_permission` gate — pinned by the table test
+`TestPolicy_MembershipSelfPromotionOpen` (gated/ungated, privileged vs read-only
+role, undeclared role, configured relation name, whitespace trimming).
+2. aclaudit A1 behaviour is unchanged: existing A1 tests in
+`internal/aclaudit` still pass against the delegating implementation;
+`isPrivileged` delegates to `RoleDef.IsPrivileged` so A2/A3 share the same
+definition.
+3. Startup warning fires exactly when the predicate is true —
+`TestBuildACL_UngatedMembership_WarnsAtStartup` (fires, names relation + fix +
+docs) and `TestBuildACL_MembershipWarning_QuietWhenSafe` /
+`TestBuildACL_NoPolicy_NoMembershipWarning` (quiet for gated policy, read-only
+assignment, no assignments, no acl.yaml).
+4. Docs describe the warning and the future refusal condition in both the
+external doc and the docs-project guide.
+
+## Research
+
+- [x] ~~For larger features: run `/research` to create a structured research doc~~ (N/A: approach fixed by `.ignored/pointer-design.md` §12.1 and its review pass; alternatives — refusal vs warning, predicate placement — were evaluated there and in the ticket text)
+- [x] ~~Searched for existing libraries that solve this problem~~ (N/A: internal refactor + logging, no library surface)
+- [x] Checked codebase for similar patterns or reusable code
+- [x] ~~Looked for reference implementations in other projects~~ (N/A: project-internal predicate extraction)
+- [x] Reviewed relevant rela concepts for prior art
+
+**Research Doc:** N/A (small change; design fixed by FEAT-9CD2MX design doc
+§12.1; the feature-level research lives in RES-NH3P12)
+
+**Existing Solutions:**
+
+- The predicate already existed inside `aclaudit/tier_a.go`
+(`assignsAnyPrivilegedRole` + `requiresPermissionFor`); this ticket moves it to
+`internal/acl` beside `Policy.EffectiveMembershipRelation()`, the accessor it
+must agree with.
+- Privilege definition (`isPrivileged`) shared with A2/A3 per
+RR-LXI3NW/RR-UR0LJU/RR-EG5D3E — read grants are not privilege.
+- Startup-warning placement follows the existing pattern of boot-time
+`slog.Warn` diagnostics in `appbuild.buildACL` (policy is validated against the
+metamodel there; the warning sits directly after).
+
+## Approach
+
+- [x] Technical approach chosen and documented
+- [x] Approach builds on existing patterns (not reinventing)
+- [x] Alternatives considered (document why rejected)
+- [x] Dependencies identified (packages, APIs, types)
+
+**Technical Approach:**
+
+Move the A1 condition onto `acl.Policy` as the single implementation
+(`MembershipSelfPromotionOpen`), export `RoleDef.IsPrivileged`, have aclaudit
+delegate (import direction aclaudit→acl already exists). Call the same predicate
+from `appbuild.buildACL` after metamodel validation and log a `slog.Warn` naming
+the relation, the one-line fix, the docs page, and `rela acl audit`.
+Warning-not-refusal is a recorded decision: unconditional refusal breaks
+existing trusted-team deployments; the refusal is scoped to the world-grant
+condition and lands with TKT-DN37J2.
+
+**Files to modify:**
+
+- `internal/acl/policy.go` (+ new `internal/acl/membership_gate_test.go`)
+- `internal/aclaudit/aclaudit.go`, `internal/aclaudit/tier_a.go`
+- `internal/appbuild/appbuild.go` (+ new `internal/appbuild/appbuild_membership_warn_test.go`)
+- `docs/acl-security.md`, `docs-project/entities/guides/GUIDE-acl-security.md`
+
+## Security Considerations
+
+- [x] Input sources identified (user input, config, external APIs)
+- [x] Input validation approach defined (allowlist preferred over blocklist)
+- [x] Security-sensitive operations identified (file access, auth, crypto)
+- [x] Error handling doesn't leak sensitive information
+
+**Input Sources & Validation:**
+
+- `acl.yaml` (operator-authored policy) is the only input; it is already
+parsed/validated by existing policy loading. The predicate only reads parsed
+fields (`Assignments`, `Roles`, `RoleRelations`, `MembershipRelation` via the
+trimming accessor) — no new parsing surface.
+
+**Security-Sensitive Operations:**
+
+- The change is itself a security control (escalation-path detection). Key
+property: audit finding (A1) and boot warning evaluate the SAME predicate, so
+advisory and enforcement views cannot drift. False-negative risk (predicate too
+narrow) is bounded by the shared A2-symmetric privilege definition and pinned by
+tests; false-positive risk (warning noise) is bounded by the read-only-role and
+undeclared-role exclusions.
+- The warning logs only the relation name and remediation — no policy
+contents, principals, or secrets.
+
+## Test Plan
+
+- [x] Test scenarios documented for each acceptance criterion
+- [x] Edge cases identified and documented
+- [x] Negative test cases defined (invalid input, error conditions)
+- [x] Integration test approach defined (not just unit tests)
+
+**Test Scenarios:**
+
+- AC1 → `internal/acl/membership_gate_test.go`:
+`TestPolicy_MembershipSelfPromotionOpen` (10 table cases) +
+`TestRoleDef_IsPrivileged` (8 cases incl. wildcard and permissions-only).
+- AC2 → existing `internal/aclaudit` A1 tests (fires at High severity;
+quiet when gated / read-only) run against the delegating code.
+- AC3 → `internal/appbuild/appbuild_membership_warn_test.go`: full
+`appbuild.New` boot on a temp project (integration-level), capturing slog
+output; warning fires for the open policy, quiet for the three safe shapes and
+for a project without acl.yaml.
+
+**Edge Cases:**
+
+- Configured (non-default) membership relation: gate must be read on the
+EFFECTIVE relation, not the default `member-of` (pinned both directions).
+- Whitespace-padded `membership_relation` value (trimming accessor).
+- Assignment naming an undeclared role (confers nothing → not open; A4
+reports it separately).
+- Permission-only role (no write verbs) still counts as privileged.
+- Mixed assignments: one privileged among read-only ones is enough.
+
+**Negative Tests:**
+
+- Gated policy, read-only-only assignments, no assignments, no acl.yaml →
+predicate false / no warning (the quiet cases, so the warning does not become
+noise).
+
+## Risk Assessment
+
+- [x] Technical risks assessed with mitigations
+- [x] Security risks assessed (see Security Considerations)
+- [x] Effort estimated (xs/s/m/l/xl)
+
+**Risks:**
+
+- Behaviour drift during extraction → mitigated: aclaudit tests unchanged
+and passing; delegation keeps call sites reading the same.
+- Warning fatigue for trusted-team deployments → accepted and deliberate:
+single line at boot, suppressible by actually gating the relation (one-line fix
+stated in the warning).
+- Deferred refusal (item 4) forgotten → recorded as acceptance criterion on
+TKT-DN37J2 and documented in both docs files as a coming requirement.
+
+Effort: m (matches ticket property).
+
+## Documentation Planning
+
+For enhancements: identify what documentation needs updating.
+
+- [x] User-facing docs identified (skip if internal refactor)
+- [x] Docs-checklist will be created when entering implementation
+
+**Documentation Impact:**
+
+- [x] docs/acl-security.md — startup warning + coming refusal requirement (done in this change)
+- [x] docs-project GUIDE-acl-security — same content, guide form (done in this change)
+- [x] ~~docs/metamodel.md~~ (N/A: no metamodel features)
+- [x] ~~docs/cli-reference.md~~ (N/A: no new commands; `rela acl audit` unchanged)
+- [x] ~~docs/data-entry.md~~ (N/A: no UI changes)
+- [x] ~~CLAUDE.md~~ (N/A: no new patterns)
+- [x] ~~README.md~~ (N/A: no project-level changes)
+
+## Design Review
+
+- [x] Run `/design-review` before starting implementation (run retroactively — implementation preceded the paperwork; reviewed the design as embodied)
+- [x] All critical/significant findings addressed in plan (none found; two minor findings documented)
+
+**Design Review Findings:**
+
+- RR-62ZH2M (minor, wont-fix): warning fires on all appbuild consumers
+incl. CLI, not only rela-server — deliberate, single shared call site.
+- RR-S7A16Q (minor, deferred): chained escalation via an ungated
+non-membership role-relation (A2 domain) is boot-warning-blind; audit A2 covers
+it. Flagged to the architect for TKT-DN37J2, whose refusal keys on the same
+predicate and would inherit the blind spot.
+- Nit (no entity): injected-ACL callers (read-only server, MCP NopACL) skip
+the warning — correct, no write surface / no policy there.

--- a/tickets/entities/researchs/RES-GFWP85.md
+++ b/tickets/entities/researchs/RES-GFWP85.md
@@ -1,0 +1,336 @@
+---
+id: RES-GFWP85
+type: research
+title: 'Pointer storage alternatives: searchable pointer-selected content without version-index bloat'
+summary: 'Search allows exactly ONE indexed document per entity id (bleve keys docs by e.ID; postgres keeps search_text as a column on the entities PK row), so "index only pointer-current values" forces a choice between P1 (one privileged indexed pointer, zero search changes) and P3 (widen the search key to (entity_id, pointer), large blast radius). Two survey findings constrain both: observers fire from INSIDE store.Store, so pointer state held on the injected VersionService would never reach the search index; and "fsstore gets versioning from git" is not implemented — internal/git is sync-only, so there is no non-postgres story to inherit.'
+status: done
+---
+
+## Problem
+
+Follow-up to [[RES-NH3P12]], which recommended storing pointer state as a ref
+table `(entity_id, name) → vseq` into `entity_versions` (option S1). A new
+constraint invalidates that recommendation and needs a fresh survey:
+
+> **Full-text search must index only the pointers' current values, not every
+> version** — otherwise the index bloats with historical content nobody
+> searches for.
+
+This reframes the problem. If pointer-selected content must be searchable, then
+it is not Time-Machine data: it is *live-shaped* data with a bounded working set
+(`entities × pointers`, not `entities × versions`). The question becomes:
+**where does pointer-selected content live such that exactly the current pointer
+targets are indexable?**
+
+## Context
+
+### The decisive constraint: one indexed document per entity id
+
+The whole stack is keyed by **bare entity id, end to end**.
+
+**Postgres** — search is a COLUMN on the `entities` row. There is no search
+index table (`internal/store/pgstore/migrations/0001_init.sql:30-52`):
+
+```sql
+CREATE TABLE entities (
+    id         TEXT        COLLATE "C" PRIMARY KEY,
+    type       TEXT        NOT NULL,
+    properties JSONB       NOT NULL DEFAULT '{}'::jsonb,
+    content    TEXT        NOT NULL DEFAULT '',
+    search_text TEXT       NOT NULL DEFAULT '',
+    ...
+);
+
+CREATE INDEX entities_search_tsv_idx
+    ON entities USING GIN (to_tsvector('simple', search_text));
+CREATE INDEX entities_search_trgm_idx
+    ON entities USING GIN (search_text gin_trgm_ops);
+```
+
+`id` is the PRIMARY KEY. **One row = one entity = one searchable blob.**
+
+Incidental: `entities_search_tsv_idx` is created but never queried — no
+`to_tsvector`/`to_tsquery`/`@@` in any Go file; the live path is trgm/LIKE only.
+
+**Bleve** — the document key is the bare entity id
+(`internal/search/bleveindex/bleveindex.go:110`): `idx.index.Index(e.ID, ...)`.
+A second doc under the same key overwrites the first. Fixed candidate ceiling
+`req.Size = 10000` (`:258`) — multiplying docs per entity eats that budget.
+
+**LinearSearch** — `map[string]*entity.Entity` keyed by entity id.
+
+**`Backend.Search` returns bare ids** (`internal/search/types.go:33`), and `Hit`
+is `{ID, Type, Title}` — **no version field**. "Which version matched" is
+structurally unrepresentable without changing both.
+
+### The pipeline assumes the id names a LIVE row
+
+`Service.Search` (`internal/search/index.go:51-97`) gets ids from the backend,
+then **re-loads each from the live store** via `reader.GetEntity(ctx, id)`
+(`:78`). A load failure is silently skipped as a stale hit (`:79-81`);
+`Visible.fieldVisible` does the same (`visible.go:169-174`).
+
+**A pointer-selected historical version would be dropped by these paths even if
+indexed.** P3 is therefore not merely a `Backend` change — it changes the
+index→id→live-row pipeline.
+
+### Observers fire from INSIDE the store — the reachability problem
+
+This is the finding that most affects the design, and it cuts against
+[[RES-NH3P12]]'s storage conclusion.
+
+`store.EntityObserver` (`internal/store/store.go:784`) has three methods
+(`EntityPut`/`EntityDelete`/`EntityRenamed`), carries **no ctx, no principal, no
+op kind**, and its errors are discarded by every store (`fsstore.go:342-363`, `_
+= o.EntityPut(e)`). It is a derived-state hook, not an event bus.
+
+Critically, it is fired from within the store's own write methods
+(`fsstore/entity.go:225,260` call `s.notifyPut`). **So state held OUTSIDE
+`store.Store` never reaches an observer.** [[RES-NH3P12]] concluded pointers
+belong on the injected `VersionService` (correct, per the no-methods-on-Store
+rule) — but a pointer move on `VersionService` **would not fire `EntityPut`, so
+the search index would never learn the `published` pointer moved.** That is an
+unsolved wiring problem in the earlier recommendation, and it is why P1 (where a
+promotion IS a live-row write) is structurally simpler than it first appears.
+
+**The observer seam has exactly one real consumer, ever: search.** Of four
+implementations, `pgstore.SearchBackend` is all no-ops
+(`pgstore/search.go:39-47`) and one is test-only. The seam has never been proven
+to carry a second concern.
+
+Two further traps for any new observer:
+
+- **Backfill is manual.** Observers are NOT invoked for entities already on
+disk (`fsstore.go:69-73`); `backfillBleve` (`appbuild_fs.go:73-88`) exists for
+exactly this. A pointer observer needs its own backfill story.
+- **pgstore never calls `notifyRenamed`.** Its rename emits
+`s.notifyDelete(oldID); s.notifyPut(renamed)` (`pgstore/entity.go:484-485`)
+instead of the single callback the contract mandates (`store.go:799-802`).
+Harmless *today* only because the pg search backend is a no-op. Any observer
+with real behaviour would see a transient delete on rename.
+
+### "fsstore gets versioning from git" is NOT implemented
+
+[[RES-NH3P12]] recorded this as the portability escape hatch for non-postgres
+builds. **It is aspirational, not code.**
+
+- `internal/git` is a **sync package**: `Ops` exposes only `GetStatus`,
+`Fetch`, `Sync`, `AbortMerge`, `AnalyzeChanges`. Package doc
+(`internal/git/git.go:1`): *"provides git operations for the data entry app."*
+- The **only** `repo.Log()` call in the tree (`git.go:311`) is inside
+`commitsBehind` — counting how far HEAD trails the remote. **No history read, no
+blob read, no ref manipulation.**
+- **fsstore does not import `internal/git` at all** (verified).
+- Commits are authored as a fixed bot signature `rela <rela@local>`
+(`git.go:~150`), so git commits cannot attribute a principal even in principle.
+- The claim appears only in two build-tag stubs that return nil
+(`appbuild/versionsweep_nosweep.go`, `store.go:755-758`).
+- Every history consumer nil-checks and reports unsupported
+(`cli/history.go:26-31`; `dataentry/history_handler.go:45-52` → HTTP 501).
+
+**Consequence: there is no non-postgres versioning story to inherit.** A pointer
+design that assumes one must build it from scratch (real git plumbing: blob
+reads, ref writes, principal-attributed commits).
+
+### fsstore is strictly one file per entity, one state
+
+`entities/<plural>/<id>.md` (`fsstore.go:365-378`), written via temp-file +
+rename, **overwriting in place** (`markdown.go:282-290`, `entity.go:235`).
+**There is no second content slot on disk for a pointer to point at.**
+
+### No precedent for indexing non-live content
+
+Relations are excluded by contract (`0001_init.sql:9-10`). Attachments have zero
+search integration. Version tables carry full snapshots but **no `search_text`
+and no GIN index**. Tombstones (`deletions`) model "not a live row" but for the
+sync feed, not search.
+
+### Precedent for control-plane state (for the pointer-move op itself)
+
+`OpPurgeVersion` (`internal/audit/audit.go:71-78`) is the closest analogue:
+control-plane state, own storage, own audit constant, emitted directly to the
+shared `audit.Audit` sink, explicitly documented as NOT routing through the
+Manager (`cli/cli_wiring.go:48-52`).
+
+**But copy it only for audit, not authorization.** Purge buys its bypass by
+giving up ACL, observers, and the state machine, compensating with interactive
+`--commit` confirmation. A pointer move is routine and user-facing, so
+inheriting that shape would give it *weaker* authorization than an ordinary
+property edit — backwards, given [[RES-NH3P12]] makes the pointer the ACL
+subject.
+
+The better authorization template is the **state-machine enforcer**
+(`entitymanager/manager.go:606-618`): required, injected, in the fixed write
+pipeline, "the unforgettable chokepoint", with per-edge guard permissions and
+403/422 sentinels. Its state happens to live in content, but its *enforcement
+shape* is the one to copy.
+
+Two constraints on where the op can live: don't add methods to `store.Store`
+(`store.go:755-770`), and don't extend `EntityManager`, marked *"Transitional …
+Slated for removal"* in favour of narrow consumer-side interfaces
+(`entitymanager.go:22-25`).
+
+### Why S1 fails this constraint
+
+S1 put pointer content in `entity_versions`. That table has no search index,
+**no observer fan-out**, no change-feed integration, and no graph among version
+rows. Making a subset searchable means adding an index, an observer, and a
+change feed *to the Time Machine* — rebuilding live-store capabilities on a
+store deliberately built without them. **S1 is withdrawn.**
+
+(Nuance in its favour: `entity_versions` already has PK `(entity_id, vseq)` and
+full content, so adding `search_text` + GIN there is a backfillable
+derived-column addition. The DDL is cheap; the observer, change-feed, and
+pipeline work is what makes it expensive.)
+
+### What still holds from RES-NH3P12
+
+The ACL conclusion — the `@` qualifier syntax and the per-pointer read verdict —
+is unaffected; it concerns the read *gate*, not storage. The blocking
+MCP-ungated-reads prerequisite also stands.
+
+## Options
+
+Framed by: **how many independently-searchable states per entity are needed?**
+
+### P1. Privileged pointer — exactly one pointer is "the indexed one"
+
+The live `entities` row IS the content selected by one designated pointer
+(declared in the metamodel, e.g. `indexed: true`). Other pointers select
+immutable snapshots that are retrievable but not searchable.
+
+- **Pros.** **Zero change to search, on any backend.** No `Backend` change, no
+`Hit` change, no pipeline change, no new observer. The index is exactly
+`entities` — bloat structurally impossible. **Promotion is a live-row write, so
+it fires the existing observer fan-out for free** — this sidesteps the
+reachability problem entirely, which is a bigger advantage than it first
+appears. Backend-agnostic, so it is the only option that works at all on fsstore
+given there is no git versioning to build on.
+- **Cons.** Inverts the editing model — the live row is the *published* state,
+so editing writes "sideways" and promotion swaps. Drafts are second-class (no
+search over your own drafts). Only one searchable pointer per type. **On
+fsstore, the un-indexed snapshot side has nowhere to live** — one file per
+entity, overwritten in place — so non-postgres builds need a new content store
+regardless.
+- **Effort.** Small-to-medium on postgres; **larger than it looks on fsstore.**
+
+### P2. Two live rows — pointer states as ordinary entities
+
+Each (entity, pointer) pair is a real row in `entities` with distinct ids
+(`PAGE-123` / `PAGE-123@draft`).
+
+- **Pros.** Everything works natively — search, traversal, `analyze_*`, ACL,
+change feed, observers — with no new machinery. Index grows by exactly the
+number of pointer states: the bounded working set the constraint asks for. **The
+only option that solves fsstore and the observer-reachability problem
+simultaneously and for free**, because pointer states ARE store rows.
+- **Cons.** Pollutes the id space — every list read, relation, and count must
+know `PAGE-123@draft` is not a separate page. Relations become ambiguous. Rename
+and id-reuse get harder. High risk of the encoding leaking into user-facing
+surfaces.
+- **Effort.** Medium in code, large in conceptual blast radius.
+
+### P3. Widen the search key to (entity_id, pointer)
+
+Pointer content in a dedicated table; search made pointer-aware (bleve keys
+`"<id>@<pointer>"`, postgres gets `search_text` per pointer state).
+
+```sql
+CREATE TABLE entity_pointer_states (
+    entity_id   TEXT COLLATE "C" NOT NULL,
+    pointer     TEXT NOT NULL,
+    vseq        BIGINT NOT NULL,
+    type        TEXT NOT NULL,
+    content     TEXT NOT NULL DEFAULT '',
+    properties  JSONB NOT NULL DEFAULT '{}'::jsonb,
+    search_text TEXT NOT NULL DEFAULT '',
+    PRIMARY KEY (entity_id, pointer),
+    FOREIGN KEY (entity_id, vseq) REFERENCES entity_versions(entity_id, vseq)
+);
+CREATE INDEX ON entity_pointer_states USING GIN (search_text gin_trgm_ops);
+```
+
+PK `(entity_id, pointer)` makes row count exactly `entities × pointers` —
+**bloat bounded by construction**, the constraint as a schema invariant.
+
+- **Pros.** Fully general: N searchable pointers, each independently ACL-gated
+via the `@` syntax. Keeps `entity_versions` pure Time Machine data; the pointer
+table is a materialized projection of it. `entitySearchText` already works on
+any snapshot, so text derivation is free.
+- **Cons.** Blast radius beyond `Backend`: `Search`'s `[]string`, `Hit`'s
+fields, the id-only observer signatures, **and the live-row re-load with two
+stale-hit drop paths**. Needs new observer wiring — and since the table sits
+outside `store.Store`, it needs a *new fan-out mechanism*, not just a new
+observer. Postgres-only.
+- **Effort.** Large.
+
+### P4. Pointer table + reindex-on-move, single indexed state
+
+Pointer state in a ref table; one pointer at a time projected into the live row.
+
+- **Pros.** No search change; the projection makes moves observable via the
+existing fan-out.
+- **Cons.** Functionally P1 with indirection — still one searchable state. The
+projection write makes "move a pointer" a content write, churning `updated_at`,
+the change feed, and the version sweep (circular).
+- **Effort.** Medium, inheriting P1's limitation without its simplicity.
+
+## Recommendation
+
+**The choice is P1 vs P3, on one question: does more than one pointer state need
+full-text search?** One → P1. Two or more → P3, and nothing cheaper exists,
+because one-document-per-id is structural in all three backends.
+
+**P1 is the recommendation**, now on stronger grounds than the search argument
+alone: promotion is a live-row write, so it reaches the observer fan-out for
+free, whereas any design holding pointer content outside `store.Store` must
+invent a new notification path to keep the index current.
+
+**P2 deserves more credit than a first pass suggests** — it is the only option
+that solves fsstore, observer reachability, and search simultaneously with no
+new machinery. It is rejected on id-space pollution and relation ambiguity, but
+if P1's editing-model inversion proves unacceptable in practice, P2 is the
+fallback to revisit rather than P3.
+
+**P4 is dominated by P1. S1 is withdrawn.**
+
+### Tradeoffs accepted under P1
+
+1. **Drafts are not full-text searchable.** Retrievable by id and listable by
+pointer, not discoverable by content search.
+2. **The live row means "published."** Editing writes to the un-indexed side;
+promotion swaps. Needs clear documentation.
+3. **Exactly one searchable pointer per type.**
+4. **Migration cost if P3 is later needed** — not additive: it changes what the
+live row means AND widens the search key.
+5. **fsstore needs a content store for the un-indexed side.** One file per
+entity, overwritten in place, and no git versioning exists to lean on. This is
+the largest under-appreciated cost, and it applies to every option.
+
+### Open questions
+
+**1. Is the feature postgres-only?** Given the git-versioning story is
+unimplemented and fsstore has one content slot per entity, the honest v1 scope
+may be postgres-only — same posture as history today. Decide deliberately rather
+than discovering it.
+
+**2. What does the change feed / SSE emit on a pointer move (P1)?** Promotion
+rewrites the live row, emitting an ordinary entity event, and makes the version
+sweep capture a version whose content equals the promoted snapshot. Either
+harmless (content-hash dedup should match) or a duplicate-version bug, depending
+on whether the comparison lands in the same lifecycle window. Verify against
+`sweep.go`'s two-LATERAL dedup.
+
+**3. Where does the pointer-move op live?** Not `store.Store` (rule), not
+`EntityManager` (slated for removal). Copy `OpPurgeVersion`'s *audit* shape (own
+constant, direct sink) but the state machine's *enforcement* shape (required
+injected enforcer in the fixed pipeline) — purge's Manager bypass would leave a
+routine user op with weaker authorization than a property edit.
+
+**4. Fix pgstore's missing `notifyRenamed` first.** Independent of the option
+chosen, any observer with real behaviour on the pg path will hit the delete+put
+decomposition. Currently masked by the pg search backend being a no-op.
+
+**5. Should the unused `entities_search_tsv_idx` be dropped?** Incidental — a
+maintained GIN index with no query path is pure write amplification. Its own
+ticket either way.

--- a/tickets/entities/researchs/RES-NH3P12.md
+++ b/tickets/entities/researchs/RES-NH3P12.md
@@ -1,0 +1,444 @@
+---
+id: RES-NH3P12
+type: research
+title: 'Metamodel-declared pointers (draft/published): storage model and ACL integration'
+summary: Store pointers as a per-entity ref table (name → vseq) on the injected VersionService, declared per type in metamodel.yaml; make the pointer the ACL SUBJECT via a per-pointer read verdict (`type@pointer`) in acl.yaml, so the built-in `everyone` role reads `published` while unqualified grants cover the live row. Reject gating pointer reads on the live entity's read verdict — the history precedent — because it inverts the desired public/private relationship.
+status: done
+---
+
+## Problem
+
+We want an entity type to declare named **pointers** — e.g. `draft` and
+`published` — each selecting one immutable version of an entity. Two questions:
+
+1. **Storage.** Where do per-type pointer *declarations* live, and where
+does per-entity pointer *state* (which version each pointer selects) live?
+2. **ACL.** How does the read side grant `everyone` (incl.
+unauthenticated) read of the `published` pointer while `draft` stays
+visible/editable only to authors — without the two leaking into each other?
+
+This matters now because the surrounding design (versions + pointers +
+proposals) hinges on whether pointer-scoped ACL is expressible in the *existing*
+declarative policy or needs a new axis. If it needs a new axis, that is the
+expensive part and should be discovered before any surface design.
+
+## Context
+
+### Versioning storage
+
+`internal/store/pgstore/migrations/0004_versions.sql:51` — postgres-only, and
+already close to what pointers need:
+
+```sql
+CREATE TABLE entity_versions (
+    entity_id      TEXT COLLATE "C" NOT NULL,
+    vseq           BIGINT NOT NULL DEFAULT nextval('version_seq'),
+    op             TEXT NOT NULL,          -- create|update|rename|delete|purge
+    prev_id        TEXT COLLATE "C",
+    type           TEXT NOT NULL,
+    content        TEXT NOT NULL DEFAULT '',
+    properties     JSONB NOT NULL DEFAULT '{}'::jsonb,
+    content_hash   TEXT NOT NULL,
+    schema_hash    TEXT COLLATE "C" NOT NULL REFERENCES schema_versions(hash),
+    principal_user TEXT NOT NULL DEFAULT '',
+    principal_tool TEXT NOT NULL DEFAULT '',
+    triggered_by   TEXT NOT NULL DEFAULT '',
+    created_at     TIMESTAMPTZ NOT NULL DEFAULT now(),
+    PRIMARY KEY (entity_id, vseq)
+);
+```
+
+Four structural facts that constrain the design:
+
+- **`vseq` is a stable global ordinal** — a pointer is just a named
+`vseq`. The human-facing "version N" is a read-time `row_number()` over a
+lineage, *deliberately not stored* (no app-side max+1 race, `0004:38-42`). **A
+pointer must therefore reference `vseq`, never the ordinal.**
+- **No FK from version rows to `entities`** (`0004:6-8`) — history
+deliberately survives entity deletion. So a pointer table FK'ing
+`entity_versions` inherits that independence for free.
+- **Snapshots are full, not diffs.** `content`/`properties` are the whole
+entity. No delta encoding anywhere.
+- **Version rows carry no edges to other version rows.**
+`relation_versions` explicitly omits `from_vseq`/`to_vseq`
+(`0005_relation_versions.sql:41-45`): *"the endpoints' versions are resolved at
+READ time (with the reader's ACL), never stored — storing them would leak a
+TO-side oracle."* **This is load-bearing: there is no graph among version rows
+to traverse.**
+
+### Versions are Time Machine data — verified exhaustively
+
+A full sweep for `entity_versions|relation_versions|schema_versions|
+version_seq` across non-test, non-migration code hits **exactly four files**,
+all inside `internal/store/pgstore`: `version.go`, `relation_version.go`,
+`sweep.go`, `purge.go`. No other package names the tables. At the Go API level
+the only callers of the history read methods are display and restore surfaces
+(`internal/cli/history.go:41,72`, `restore.go:39`,
+`internal/dataentry/history_handler.go:135,175`, `history_restore.go:39`, and
+the relation twins).
+
+Corroborating: no search/index integration (no tsvector/trgm/GIN on either
+version table); no change-feed integration (`ManifestSince` unions
+`entities`/`relations`/`deletions`, never a version table, and `version_seq` is
+deliberately isolated from `rela_seq`). Version writes are invisible to sync
+clients and observers.
+
+**Bottom line: the version tables are an append-only, read-only-by-lineage side
+log. Any feature wanting to traverse or analyze version rows would be the first
+such consumer.**
+
+### Versioning is an INJECTED SERVICE, not a type-asserted capability
+
+Important correction to the older mental model. TKT-N0IKN9 extracted versioning
+out of the store. `internal/store/pgstore/pgstore.go:77-79`:
+
+> *Do NOT add version/history/purge methods back to `*Store`: they belong
+> on `[VersionStore]`, and re-adding one here would resurrect the
+> type-assert-off-the-store pattern this refactor removed. Consumers reach
+> versioning through the injected `store.VersionService`, never by
+> asserting a capability on the store.*
+
+`store.VersionService` (`internal/store/store.go:768`) is the umbrella of
+`HistoryReader`, `VersionWriter`, `RelationHistoryReader`,
+`RelationVersionWriter`, `VersionPurger`, `RelationVersionPurger`. Satisfaction
+is compile-time (`var _ store.HistoryReader = (*VersionStore)(nil)`,
+`version_store.go:40-48`); consumers *narrow the umbrella by assignment* at the
+call site (`var reader store.HistoryReader = svc.Versions`). Build-tag selected:
+`versionServiceFor` returns a real service on postgres, **a genuinely nil
+interface otherwise** (`appbuild/versionsweep_nosweep.go:19` — typed-nil would
+defeat consumers' nil checks).
+
+**Pointers therefore belong on `VersionService` (or a sibling injected service),
+not on `store.Store`.**
+
+Also relevant: the same file notes *"fsstore already gets content versioning
+from git."* That is the portability escape hatch for pointers on non-postgres
+builds — a pointer is conceptually a git ref.
+
+### Read-side ACL
+
+Two independent layers, both in `internal/visibility` per DEC-ZBI39P:
+
+```go
+// internal/visibility/visibility.go:58
+type RowGate interface {
+    PermitsRead(ctx context.Context, entityType, id string) (bool, error)
+    PermitsReadMany(ctx context.Context, entityType string, ids []string) (map[string]bool, error)
+}
+
+// internal/visibility/visibility.go:70
+type FieldRedactor interface {
+    HiddenProperties(ctx context.Context, e *entity.Entity) map[string]struct{}
+}
+```
+
+The row gate reduces to **one function**, `Request.readQuery`
+(`internal/acl/readquery.go:27`), returning exactly one of:
+
+```go
+type ReadQueryResult struct {
+    AllowAll bool
+    DenyAll  bool
+    Query    *store.GraphQuery
+}
+```
+
+`PermitsRead`/`PermitsReadMany` are thin wrappers; the `Query` case pushes down
+to `GraphQueryer.MatchingIDs` (SQL in pgstore).
+
+**Two constraints shape everything below:**
+
+1. **`Read` grants are unconditional.** `roleGrantsRead`
+(`readquery.go:78`) is exact-or-`"*"` match on a flat `[]string`. Unlike
+`FieldGrant` / `OptionGrant` / `RelationGrant`
+(`internal/acl/policy.go:263-288`), each carrying a `When` predicate, **read has
+no `When`**. Row read is all-or-nothing per type, refined only by
+role-conferring relations.
+2. **`store.GraphQuery` is relation-shaped only**
+(`internal/store/graphquery.go:20`) — `EntityType`, `HasInbound`, `HasOutbound`.
+**No property predicate.** "Rows whose `published` pointer is set" cannot be
+pushed down today.
+
+### ACL policy lives in `acl.yaml`, and there is no `visible:` in the metamodel
+
+A correction worth stating plainly: **`visible:` is a `RoleDef` field in
+`acl.yaml`** (`internal/acl/policy.go:229`), not a metamodel property attribute.
+`metamodel.PropertyDef` (`internal/metamodel/types.go:268-320`) has no
+visibility field; the metamodel is consulted only as the closed-world *field
+universe* (`affordances/resolver.go:418`). (The `visible_when` in
+`internal/dataentryconfig` is UI conditional display, unrelated.)
+
+`acl.yaml` absence = allow-all (`appbuild.go:547`). Loading is tolerant: unknown
+top-level keys warn and are ignored.
+
+### `everyone` already is the public mechanism
+
+`acl.EveryoneRole = "everyone"` (`internal/acl/policy.go:34`) is held implicitly
+by every principal, authenticated or not, appended in both the write path and
+the affordances resolver. The godoc is explicit that `anonymous` /
+`authenticated` built-ins do **not** exist yet because rela-server has no auth
+layer. So "public read" = a role named `everyone`. No new identity concept
+needed.
+
+### Precedent: capability-gated history reads
+
+`PermHistoryRead` ("history:read") and `PermHistoryReadRedacted`
+("history:read-redacted") — `internal/acl/policy.go:44,56` — gate deleted-entity
+history and historical-field reveal as *global named permissions* in a role's
+`permissions:` list. A subject-aware sibling exists:
+`Request.HoldsPermissionForEntity` (`internal/acl/resolver.go:260`), used by the
+statemachine transition guard, where per-subject scope comes from a
+role-conferring relation rather than being baked into the permission noun.
+
+### The history gating rule — the precedent to REJECT
+
+`authorizeHistoryRead` (`internal/dataentry/history_handler.go:103`) gates a
+version read on the **live entity's** read verdict. Correct for history (history
+is *about* the live entity) and exactly **wrong** for pointers: the entire point
+is that `published` be readable by principals who may NOT read the live row.
+
+### Search seam
+
+`search.TypeScope` (`internal/search/types.go:97`) is `{AllowAll bool; Query
+*store.GraphQuery}`, server-derived, resolved fail-closed by `ResolveTypeScope`
+(exact → wildcard → deny; nil map denies everything). Any pointer perspective
+must eventually adopt this shape — and inherits the relation-only `GraphQuery`
+constraint.
+
+### Constraints
+
+- Versioning is **postgres-only** (fsstore gets versioning from git).
+- Don't add methods to `store.Store` — use the injected-service pattern.
+- Read-out routes through `visibility` wrappers; base readers stay ungated.
+- No existence oracle: denied ≡ nonexistent.
+- No user Lua on the read path (`internal/entitymanager/CLAUDE.md`).
+
+## Options
+
+### Storage of pointer state
+
+**S1. Pointer table keyed (entity_id, name) → vseq.**
+
+```sql
+CREATE TABLE entity_pointers (
+    entity_id     TEXT COLLATE "C" NOT NULL,
+    name          TEXT NOT NULL,
+    vseq          BIGINT NOT NULL,
+    moved_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+    moved_by_user TEXT NOT NULL DEFAULT '',
+    moved_by_tool TEXT NOT NULL DEFAULT '',
+    PRIMARY KEY (entity_id, name),
+    FOREIGN KEY (entity_id, vseq) REFERENCES entity_versions(entity_id, vseq)
+);
+```
+
+- **Pros.** Move = one UPSERT: atomic, cheap, auditable. The FK makes
+"points at a real version" a DB invariant. Rollback = move it back. Inherits
+history's independence from entity deletion (no FK to `entities`), which is
+right — a published version should survive a live-row delete. Attribution
+columns mirror the existing version-row convention.
+- **Cons.** New table; postgres-only. Pointer-scoped list reads become a
+join against candidates.
+- **Effort.** Small — one migration, methods on the injected service.
+
+**S2. Pointer as a property on the live entity** (`published_vseq: 1234`).
+
+- **Pros.** No new table; portable to fs/mem.
+- **Cons.** Conflates content with control state — and *circularly*, since
+each version snapshot would capture the pointer value pointing at a version.
+Writable through the ordinary update path (one field grant away from forgery).
+No FK integrity. Pollutes the metamodel's user-facing property namespace.
+- **Effort.** Small, but the coupling is disqualifying.
+
+**S3. Pointer as a relation** (`entity --published--> version-entity`).
+
+- **Pros.** The *only* option expressible in `store.GraphQuery` today
+(`HasOutbound`), so ACL scope pushdown and search scope would work with zero
+query-language change.
+- **Cons.** Requires versions to be first-class graph entities, which they
+emphatically are not — the survey confirms version rows form no graph and
+deliberately carry no inter-version edges. Materializing every version as a node
+is a large, distorting change.
+- **Effort.** Large. Not recommended, but recorded because it is the only
+option that fits the existing query language exactly.
+
+### Declaration of pointers
+
+**D1. `pointers:` block on `EntityDef` in `metamodel.yaml`**
+(`internal/metamodel/types.go:218`).
+
+```yaml
+entities:
+  page:
+    pointers:
+      draft:     {default: true}
+      published: {}
+```
+
+- **Pros.** Pointers are a *shape* fact — which lifecycle rails a type has
+— so the metamodel is the right home, consistent with `statemachine` transitions
+already living there. Available to `analyze_*`, the SPA, and docs generation
+without reading `acl.yaml`.
+- **Cons.** Splits the feature across two files: shape in `metamodel.yaml`,
+who-may-read in `acl.yaml`. (This is the existing convention, not a new wart.)
+- **Effort.** Small.
+
+**D2. Declare pointers in `acl.yaml`.**
+
+- **Pros.** One file.
+- **Cons.** Wrong layer — `acl.yaml` is optional and its absence means
+allow-all, so a project without a policy would have no pointers at all. Makes a
+structural concept contingent on an authorization file.
+- **Effort.** Small, but architecturally wrong.
+
+### ACL integration — the real question
+
+**A1. Gate the pointer read on the live entity's read verdict** (the history
+precedent).
+
+- **Pros.** Zero new concepts.
+- **Cons.** **Inverts the requirement** — `everyone` would need read on the
+live row to see `published`, which simultaneously exposes the draft.
+- **Effort.** Trivial, but it does not solve the problem.
+
+**A2. Global named permission per pointer** (`pointer:read:published`),
+following `PermHistoryRead`.
+
+- **Pros.** Exact existing precedent; `permissions:` and `HoldsPermission`
+already exist. Smallest change that works at all.
+- **Cons.** Global and type-blind: "may read published pages" and "may read
+published policies" collapse into one capability. `HoldsPermissionForEntity`
+could add per-entity refinement via role-conferring relations, but not
+per-*type* granularity.
+- **Effort.** Small.
+
+**A3. Make the pointer part of the read SUBJECT — a per-pointer read verdict.**
+Qualify the type in a role's read grant, and resolve a separate
+`ReadQueryResult` per (type, pointer):
+
+```yaml
+roles:
+  everyone:
+    read: ["page@published"]      # public sees only the published pointer
+  author:
+    read: ["page"]                # unqualified = the live/working row
+```
+
+Resolution: a read carrying pointer P for type T consults the grant for `T@P`;
+an unqualified grant covers the live row only. `readQuery` gains a pointer
+parameter; `AllowAll`/`DenyAll`/`Query` semantics carry over verbatim.
+
+- **Pros.** Directly expresses the requirement. Preserves the *shape* of
+the gate — the three-valued result and the pushdown query — so
+`visibility.Reader`, `search.TypeScope`, and fail-closed `ResolveTypeScope` all
+keep working with a widened key. Per-type AND per-pointer granularity.
+`everyone` supplies "public" with no new identity concept. Composes with field
+redaction unchanged.
+- **Cons.** Widens the read-gate signature, so every call site threads a
+pointer (defaulting to live). Grant-syntax change in `acl.yaml`. Needs
+cross-file validation that `T@P` names a declared pointer (precedent exists:
+`Policy.ValidateAgainstMetamodel`, and `internal/aclaudit` for the advisory tier
+— note arch-lint forbids `acl → metamodel`, so the cross-check belongs in
+`aclaudit`, not `acl`).
+- **Effort.** Medium. The signature widening is mechanical but broad.
+
+**A4. Add `When` to read grants.**
+
+- **Pros.** Most general; pointer state becomes one predicate among many.
+- **Cons.** A conditional read grant cannot be compiled into a
+`GraphQuery`, so it degrades to per-row evaluation on list reads — exactly the
+unbounded-hot-path pattern `internal/entitymanager/CLAUDE.md` forbids, and it
+forfeits the SQL pushdown that makes list reads tractable.
+- **Effort.** Medium-large, and it fights an existing architectural rule.
+
+## Recommendation
+
+**S1 + D1 + A3**: pointer state in a dedicated `entity_pointers` table reached
+through the injected `VersionService`; pointer *declarations* on `EntityDef` in
+`metamodel.yaml`; ACL via a per-pointer read verdict (`type@pointer`) in
+`acl.yaml`.
+
+Why:
+
+- **A3 is the only option that expresses the requirement without inverting
+it.** A1 fails outright; A2 is too coarse to distinguish types; A4 breaks
+pushdown and contradicts the no-predicates-on-the-read-path rule. A3 keeps the
+three-valued `ReadQueryResult` intact — which is precisely what lets
+`visibility.Reader` and `search.TypeScope` keep working unchanged.
+- **S1 keeps versions immutable and control state separate.** Because the
+base is immutable, pointer resolution is a pure function — no locking, no
+snapshot-coherence problem. The FK makes the invariant the database's job.
+- **D1 puts shape in the shape file.** Pointers must exist even when
+`acl.yaml` is absent (allow-all); D2 cannot provide that.
+
+If effort must be cut, **A2 is the honest fallback**: it works, it follows an
+existing precedent exactly, and its limitation (type-blind) is tolerable for a
+single-content-type deployment. It is not a stepping stone to A3, though — the
+grant syntax differs, so choosing A2 first means migrating policies later.
+
+### Tradeoffs accepted
+
+1. **Postgres-only initially.** Pointers ride on versioning. Non-postgres
+builds get a nil `VersionService` and would serve only the live row — same
+posture as history today. The git-backed fsstore path is a plausible later
+analogue (a pointer *is* a ref) but is not free.
+2. **Read-gate signature widening.** Every read call site gains a pointer
+parameter defaulting to live. Mechanical but broad; the bulk of the effort.
+3. **Cross-file validation.** `T@P` grants must be checked against declared
+pointers; a typo (`page@publised`) would otherwise silently deny. Lives in
+`aclaudit` (arch-lint forbids `acl → metamodel`).
+4. **Search on a pointer is deferred.** `TypeScope` inherits the
+relation-only `GraphQuery` constraint. Recommend excluding pointer-scoped search
+from v1 and documenting it — "why doesn't my published page show up in search"
+is a predictable complaint.
+5. **`everyone` ≠ anonymous.** It includes authenticated principals. Correct
+for "public", but once auth lands, `anonymous` vs `authenticated` should be
+revisited (the `policy.go:31` comment already flags this).
+
+### Blocking prerequisite discovered during the survey
+
+**The MCP surface is entirely ungated on the read side.** Verified: zero
+`visibility.` / `readGate` / `acl.` references anywhere in `internal/mcp/*.go`;
+`internal/cli/mcp_wiring.go:66` wires `LuaWriteDeps()`, which carries
+`visibility.Unrestricted`. The CLI and docs runtime are ungated too, but those
+are a defensible operator trust boundary (whoever runs the binary already has
+the project files). **MCP is a network-facing surface and is not.**
+
+A draft/published split is a *confidentiality* feature. Shipping it while MCP
+serves every entity ungated means the draft is protected in the SPA and readable
+over MCP. This is not a pointer-design problem, but it is a gating prerequisite
+for the feature's security claim, and should become a ticket in its own right
+rather than being discovered at review.
+
+Two further gaps, lower severity but worth recording:
+
+- **Scheduled jobs get row gating only, no `visible:` field redaction**
+(RR-7408F5, `appbuild.go:334-347`) — appbuild has no affordance resolver, so
+`ScheduledLuaWriteDeps` passes a nil redactor.
+- **`DenyTracer` refusal is invisible to Lua scripts**
+(`denyreader.go:67-78`) — the three bound traversals return nil, which is
+indistinguishable from a nonexistent id; only a `slog.Error` at the wiring site
+signals it.
+
+### Open question for the design phase
+
+**Is field redaction on a pointer read computed against the pointed-to version
+or the live row?** TKT-73C6B2 established that historical field redaction
+**fails closed**: the live store no longer holds the as-of-version edges a
+conditional `visible:` grant needs, so any `when:`-conditioned grant whose
+subject-world inputs can't be affirmed hides the field. A pointer read hits the
+identical wall.
+
+Either accept fail-closed redaction on pointer reads (consistent with history,
+but `published` content may over-redact — bad for a public surface, where
+over-redaction is user-visible breakage rather than a safe default), or require
+pointer-scoped `visible:` grants to be unconditional. Settle this before
+implementation.
+
+Related, and worth deciding at the same time: **relations have no field-level
+redaction at all** (`FilterRelations` is row-gating only), and **bodies are
+never redacted** (`policyreader.go:162-168` — the `visible:` universe is
+metamodel-declared properties, so `Content` passes through verbatim). For a
+genuinely public `published` pointer, the body is the main payload, so "no body
+redaction" is a more consequential limit here than it is on today's
+authenticated surfaces.

--- a/tickets/entities/review-checklists/REV-NVHQA3.md
+++ b/tickets/entities/review-checklists/REV-NVHQA3.md
@@ -1,0 +1,67 @@
+---
+id: REV-NVHQA3
+type: review-checklist
+title: 'Review: Gate the membership relation against ACL self-promotion'
+status: in-progress
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Automated Checks
+
+- [x] All tests pass (`go test ./...` clean, incl. `-race` on acl/aclaudit/appbuild; 2026-08-19)
+- [x] Lint clean (`just lint` 0 issues; `just arch-lint` OK; `just plimsoll` clean)
+- [x] Coverage maintained (`just coverage-check`: package floors + total 76.6% >= 65% PASS)
+
+## Code Review
+
+- [x] Run `/code-review` command (invokes cranky-code-reviewer agent)
+- [x] All critical review-responses addressed (none found)
+- [x] All significant review-responses addressed (RR-5NIR95, RR-TVL38I — both fixed in the warn-test helper, verified with -race)
+- [x] Self-reviewed the diff for unrelated changes (diff touches only the ticket's six files + two new tests)
+
+**Review Responses:**
+
+Code review: RR-5NIR95 (significant, addressed), RR-TVL38I (significant,
+addressed), RR-EZ0P4S (minor, deferred: audit double-report follow-up),
+RR-D3MEV0 (minor, addressed: docs wording), RR-6560A3 (minor, addressed:
+shared test const), RR-8ZOICR (minor, deferred: asserted-roles audit gap,
+flagged to architect).
+Design review (earlier): RR-62ZH2M (minor, wont-fix), RR-S7A16Q (minor,
+deferred to TKT-DN37J2 discussion).
+
+## Acceptance Verification
+
+- [x] Each acceptance criterion tested (reference planning checklist)
+- [x] Test evidence documented in implementation checklist
+
+**Acceptance Status:**
+
+- AC1 (shared predicate semantics) — PASS: `TestPolicy_MembershipSelfPromotionOpen` + `TestRoleDef_IsPrivileged` (internal/acl/membership_gate_test.go).
+- AC2 (A1 behaviour unchanged, aclaudit delegates) — PASS: existing aclaudit A1 tests green against the delegating code; manual `rela acl audit` shows the identical [high] A1 finding.
+- AC3 (warning fires/quiet exactly per predicate) — PASS: appbuild_membership_warn_test.go (fires + 3 quiet shapes + no-acl.yaml) and manual CLI run (warning for ungated policy, silent when gated).
+- AC4 (docs in both trees) — PASS: docs/acl-security.md + GUIDE-acl-security.md, incl. the coming TKT-DN37J2 refusal.
+
+## Documentation (enhancements only)
+
+Skip this section for bugs and internal refactors.
+
+- [x] Docs-checklist created and linked via `has-docs`
+- [x] User-facing documentation updated
+- [x] Docs-checklist marked as done
+
+**Docs Checklist:** DOCS-3V181I
+
+## Final Checks
+
+- [ ] Commit message explains the why, not just what (pending: commit/PR timing is the architect's call)
+- [x] No TODOs or FIXMEs left unaddressed
+- [x] Ready for another developer to use
+
+## Pull Request
+
+- [ ] Run `/pr` command to create PR and monitor CI
+- [ ] All CI checks pass
+- [ ] PR URL documented below
+
+**PR:** <!-- e.g., https://github.com/org/repo/pull/123 -->

--- a/tickets/entities/review-checklists/REV-NVHQA3.md
+++ b/tickets/entities/review-checklists/REV-NVHQA3.md
@@ -2,7 +2,7 @@
 id: REV-NVHQA3
 type: review-checklist
 title: 'Review: Gate the membership relation against ACL self-promotion'
-status: in-progress
+status: done
 ---
 
 <!-- @managed: claude-workflow v1 -->
@@ -24,11 +24,10 @@ status: in-progress
 
 Code review: RR-5NIR95 (significant, addressed), RR-TVL38I (significant,
 addressed), RR-EZ0P4S (minor, deferred: audit double-report follow-up),
-RR-D3MEV0 (minor, addressed: docs wording), RR-6560A3 (minor, addressed:
-shared test const), RR-8ZOICR (minor, deferred: asserted-roles audit gap,
-flagged to architect).
-Design review (earlier): RR-62ZH2M (minor, wont-fix), RR-S7A16Q (minor,
-deferred to TKT-DN37J2 discussion).
+RR-D3MEV0 (minor, addressed: docs wording), RR-6560A3 (minor, addressed: shared
+test const), RR-8ZOICR (minor, deferred: asserted-roles audit gap, flagged to
+architect). Design review (earlier): RR-62ZH2M (minor, wont-fix), RR-S7A16Q
+(minor, deferred to TKT-DN37J2 discussion).
 
 ## Acceptance Verification
 
@@ -54,14 +53,14 @@ Skip this section for bugs and internal refactors.
 
 ## Final Checks
 
-- [ ] Commit message explains the why, not just what (pending: commit/PR timing is the architect's call)
+- [x] Commit message explains the why, not just what (`feat(acl): shared ungated-membership predicate + startup warning (TKT-T31NKT)`; PR body carries the why)
 - [x] No TODOs or FIXMEs left unaddressed
 - [x] Ready for another developer to use
 
 ## Pull Request
 
-- [ ] Run `/pr` command to create PR and monitor CI
-- [ ] All CI checks pass
-- [ ] PR URL documented below
+- [x] Run `/pr` command to create PR and monitor CI
+- [x] All CI checks pass (all code checks green on PR #1378; the Rela Tickets workflow gate clears with this final ticket-state commit)
+- [x] PR URL documented below
 
-**PR:** <!-- e.g., https://github.com/org/repo/pull/123 -->
+**PR:** https://github.com/sourcehaven-bv/rela/pull/1378

--- a/tickets/entities/review-responses/RR-5NIR95.md
+++ b/tickets/entities/review-responses/RR-5NIR95.md
@@ -1,0 +1,9 @@
+---
+id: RR-5NIR95
+type: review-response
+title: Warn-test hijacks process-global slog with no parallel-safety guard
+finding: 'appbuild_membership_warn_test.go''s captureWarnings calls slog.SetDefault — a process-global mutation. Safe today only because no other test in the package parallelizes around a service build, but nothing encoded that: the new tests lacked t.Parallel() with no comment while the sibling acl test uses it, so a future reflexive t.Parallel() would cause a logger data race AND cross-test log bleed that could turn the QuietWhenSafe negative assertions into vacuous passes — a false pass on a security-warning test.'
+severity: significant
+resolution: captureWarnings now carries a godoc explicitly forbidding t.Parallel() in callers and explaining both failure modes (race + log bleed => vacuous quiet-case passes). Verified with go test -race ./internal/appbuild/.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-62ZH2M.md
+++ b/tickets/entities/review-responses/RR-62ZH2M.md
@@ -1,0 +1,9 @@
+---
+id: RR-62ZH2M
+type: review-response
+title: Membership warning fires on all appbuild consumers, not only rela-server
+finding: TKT-T31NKT scope item 2 says "rela-server logs the ungated-membership condition as a prominent startup warning", but the implementation places warnUngatedMembership in appbuild.buildACL, which is also reached by ordinary CLI commands (internal/cli/kong.go:170, flow.go:43, validate.go:83). Every `rela` command run against an ungated policy prints the warning line, not just server startup.
+severity: minor
+reason: 'Deliberate: warnUngatedMembership sits in the shared buildACL helper (internal/appbuild/appbuild.go:614), the single place every recipe resolves a real policy, so the predicate has exactly one call site and CLI/server cannot drift. The cost is one stderr slog line per CLI invocation against an open policy; the benefit is that operators editing acl.yaml locally see it without running the server. Narrowing to server-only would fragment the build-agnostic wiring (per appbuild''s prepare/assemble rule) for no security gain.'
+status: wont-fix
+---

--- a/tickets/entities/review-responses/RR-6560A3.md
+++ b/tickets/entities/review-responses/RR-6560A3.md
@@ -1,0 +1,9 @@
+---
+id: RR-6560A3
+type: review-response
+title: Positive and negative warn-tests keyed off different message substrings
+finding: The fires-test asserted on 'NOT gated' while the QuietWhenSafe/NoPolicy tests asserted on 'membership relation is NOT gated' — different fragments of the same message. A reword changing one fragment could break the positive test while silently turning the negative tests into vacuous always-passes.
+severity: minor
+resolution: Extracted the shared const ungatedWarningFragment in appbuild_membership_warn_test.go; both the positive assertion list and all negative assertions now use it, so a reword moves both sides together.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-8ZOICR.md
+++ b/tickets/entities/review-responses/RR-8ZOICR.md
@@ -1,0 +1,9 @@
+---
+id: RR-8ZOICR
+type: review-response
+title: asserted_role_assignments is a privileged-role path neither predicate nor linter models
+finding: acl.Policy.AssertedRoles (IdP-claim role grants, resolver.go) can be the only privileged grant in a deployment; MembershipSelfPromotionOpen scans only Assignments, so such a policy gets a clean boot warning and a clean audit. Not a defect in this extraction — asserted roles are not reachable by writing a membership edge, so they are correctly outside THIS predicate, and the pre-existing linter has no check for them either — but the docs framing ('a choice rather than an oversight') slightly oversells coverage.
+severity: minor
+reason: 'Out of scope for TKT-T31NKT (behaviour-identical extraction; the gap predates it and is not membership-edge escalation). Recorded for the architect: candidate future A-tier aclaudit check (e.g. ''asserted assignment confers privileged role'') — needs its own threat-model decision on whether IdP-claim trust is in the audit''s scope.'
+status: deferred
+---

--- a/tickets/entities/review-responses/RR-D3MEV0.md
+++ b/tickets/entities/review-responses/RR-D3MEV0.md
@@ -1,0 +1,9 @@
+---
+id: RR-D3MEV0
+type: review-response
+title: Docs said 'the server' warns; the warning fires wherever rela loads a policy
+finding: docs/acl-security.md and GUIDE-acl-security said 'when the server loads a policy ... it logs a prominent warning at startup', but the warning fires for every appbuild consumer that loads the policy, including CLI commands — and conversely NOT for surfaces that inject their own ACL (MCP NopACL, server read-only mode), which never evaluate it. The docs were both narrower and broader than reality.
+severity: minor
+resolution: Both docs now say 'whenever rela loads a policy ... at server startup, and equally when a CLI command builds the full service bundle' and note that surfaces injecting their own ACL do not evaluate it and stay silent.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-EZ0P4S.md
+++ b/tickets/entities/review-responses/RR-EZ0P4S.md
@@ -1,0 +1,9 @@
+---
+id: RR-EZ0P4S
+type: review-response
+title: rela acl audit double-reports the ungated-membership condition
+finding: internal/cli/acl.go builds services via appbuild.Discover, which runs buildACL -> warnUngatedMembership. Running `rela acl audit` against an open policy therefore emits the slog warning to stderr first, then prints the A1-ungated-membership finding to stdout — two renderings of one problem in one invocation of the audit tool itself.
+severity: minor
+reason: 'Architect decision (2026-08-19): no follow-up ticket. The stutter is cosmetic, the two outputs agree by construction (shared predicate), and the boot warning firing on EVERY policy load — including the audit command''s own load — is the accepted RR-62ZH2M behaviour: one unconditional call site in buildACL with no command-aware special cases. Threading a suppression option through Discover/buildACL would add wiring surface solely to hide a consistent warning from the one command whose users are already looking at findings.'
+status: wont-fix
+---

--- a/tickets/entities/review-responses/RR-S7A16Q.md
+++ b/tickets/entities/review-responses/RR-S7A16Q.md
@@ -1,0 +1,9 @@
+---
+id: RR-S7A16Q
+type: review-response
+title: Chained escalation via ungated non-membership role-relation is warning-blind
+finding: 'Policy.MembershipSelfPromotionOpen() returns false when the membership relation carries requires_permission, but the gate can be circumvented in two writes if ANOTHER role-relation is ungated and confers a role holding the gating permission (A2''s domain): write the ungated edge to gain delegate-membership, then write the membership edge. The boot warning evaluates only the A1 predicate, so this chained shape boots silently; `rela acl audit` A2 still flags it at High.'
+severity: minor
+reason: Out of scope for TKT-T31NKT (behaviour-identical extraction of the A1 predicate + warning on it). The chained path is already reported by the audit's A2-ungated-role-relations finding, so it is not silent — only the boot warning misses it. Flagged to the architect because TKT-DN37J2's planned load refusal keys on the same shared predicate and would inherit the blind spot; deciding whether the refusal must also consider A2-shaped chains is a design decision for that ticket.
+status: deferred
+---

--- a/tickets/entities/review-responses/RR-TVL38I.md
+++ b/tickets/entities/review-responses/RR-TVL38I.md
@@ -1,0 +1,9 @@
+---
+id: RR-TVL38I
+type: review-response
+title: captureWarnings read unsynchronized against post-New background logging
+finding: 'captureWarnings returned buf.String bound to a bytes.Buffer the slog handler could still be writing to: appbuild.New starts background goroutines (store watcher; postgres listener/sweep) that may log after New returns, and bytes.Buffer is not safe for concurrent use. -race was clean only by timing accident — a classic flaky-in-CI-only shape.'
+severity: significant
+resolution: Writes now go through a mutex-guarded lockedWriter and the returned accessor reads under the same mutex (internal/appbuild/appbuild_membership_warn_test.go). Verified with go test -race ./internal/appbuild/.
+status: addressed
+---

--- a/tickets/entities/tickets/TKT-4QSZ8Y.md
+++ b/tickets/entities/tickets/TKT-4QSZ8Y.md
@@ -5,7 +5,7 @@ title: Wire read-side ACL into the MCP server
 kind: enhancement
 priority: critical
 effort: l
-status: ready
+status: backlog
 ---
 
 Security gate for shipping content states — design doc §12.2.

--- a/tickets/entities/tickets/TKT-4QSZ8Y.md
+++ b/tickets/entities/tickets/TKT-4QSZ8Y.md
@@ -1,0 +1,20 @@
+---
+id: TKT-4QSZ8Y
+type: ticket
+title: Wire read-side ACL into the MCP server
+kind: enhancement
+priority: critical
+effort: l
+status: ready
+---
+
+Security gate for shipping content states — design doc §12.2.
+
+MCP is wired allow-all on purpose: `appbuild.WithACL(acl.NopACL{})` at
+`internal/cli/mcp_wiring.go:43`; zero `visibility.`/acl references anywhere in
+`internal/mcp/`. A draft/published split shipped in this state protects drafts
+in the SPA while leaking them over the network-facing MCP surface.
+
+Inject the visibility wrappers (row gate + field redaction, DEC-ZBI39P pattern)
+at the MCP wiring site. CLI/local stays a defensible operator trust boundary;
+MCP is not. Blocks *shipping* pointers, not starting them.

--- a/tickets/entities/tickets/TKT-9KZGJO.md
+++ b/tickets/entities/tickets/TKT-9KZGJO.md
@@ -1,0 +1,17 @@
+---
+id: TKT-9KZGJO
+type: ticket
+title: World-aware analysis and cross-world search grouping (Step 5)
+kind: enhancement
+priority: medium
+effort: l
+status: backlog
+---
+
+Design doc §7, §10.
+
+- Cardinality rules declare `must_hold_in: [worlds]`; absent → default world only, so existing metamodels behave identically. Subjects and edges come from the same resolved graph; violations labeled by world (one rule can fail in one world and pass in another — both reported).
+- Orphans run in the default world; states never appear in orphan output.
+- Search: query scope is a world (one hit per entity within it); editor surfaces query several worlds, grouped by entity in the search API (SPA/MCP/CLI share it; `limit` counts entities). Grouping runs AFTER the per-world read gate — annotating "also matched in editorial" for someone who may not read that world is an existence-and-content oracle.
+
+Gated on the cardinality consolidation and the Step 2 world scope.

--- a/tickets/entities/tickets/TKT-9OJ3S0.md
+++ b/tickets/entities/tickets/TKT-9OJ3S0.md
@@ -1,0 +1,14 @@
+---
+id: TKT-9OJ3S0
+type: ticket
+title: Observer backfill for state rows
+kind: enhancement
+priority: medium
+effort: s
+status: backlog
+---
+
+Design doc §12.7. Observers are not invoked for entities already on disk
+(`fsstore.go:69-73`); `backfillBleve` exists for entities. State rows need the
+same backfill story so search indexes existing states after an upgrade or after
+pointers are enabled on a type.

--- a/tickets/entities/tickets/TKT-C1XUA8.md
+++ b/tickets/entities/tickets/TKT-C1XUA8.md
@@ -1,0 +1,29 @@
+---
+id: TKT-C1XUA8
+type: ticket
+title: Copy kernel and declared copy definitions (Step 4)
+kind: enhancement
+priority: high
+effort: l
+status: backlog
+---
+
+Design doc §9. Kernel: write fields/body/edges/attachment-links into a target
+face in one store `Tx`, audited (own `audit.Op*` constant recording definition
+name + source + target + principal). Named, metamodel-declared copy definitions
+invoked **by name only** (transforms-registry shape); mapped fields written,
+unmapped untouched; per-relation-type `merge`|`replace`; same-type auto-map,
+cross-type explicit map, load-validated; interpolation limited to the existing
+`{{...}}` grammar — no expressions.
+
+Security boundary, pinned with tests (§9.2): same-entity copies (promote/revise)
+run elevated; cross-entity copies read through the caller's visibility gate
+(visible fields/edges only). Identity-scoped/role-conferring relation types
+excluded from definitions unless explicitly named; cross-entity edges authorized
+per-edge as the acting principal. Guarded states (published) writable ONLY via
+definitions naming them as target; `copy_from` is a load-validated constraint.
+
+Guard machinery shared with the statemachine (`requires_permission`, `when:`,
+enforcer, 403/422 sentinels), separate declaration. Per-entity checks via
+`HoldsPermissionForEntity`. No Manager bypass (purge's shape explicitly
+rejected).

--- a/tickets/entities/tickets/TKT-DN37J2.md
+++ b/tickets/entities/tickets/TKT-DN37J2.md
@@ -1,0 +1,36 @@
+---
+id: TKT-DN37J2
+type: ticket
+title: 'ACL: world-shaped read grants, state-shaped write grants (Step 3)'
+kind: enhancement
+priority: high
+effort: l
+status: backlog
+---
+
+Design doc §8.
+
+- Read grants name worlds (`read: [world:published]`); bare-type and `*` grants mean the default world only — existing acl.yaml files keep their meaning; reading non-default worlds always requires naming them.
+- Write grants per `type@pointer` (codec-parsed at policy load), no inheritance, fail closed; no role holds update on published.
+- Role resolution needs no new machinery: relation scope replaces v1's `inherits_to_states` (dropped — review found an ancestor-bypass hole in its probe filter). Identity-scoped role relations confer in every world; content-scoped confer on their state.
+- Field redaction on state reads fails closed with a global override permission (TKT-73C6B2 family).
+- The pushdown read query must express the same world/grant logic as the single-entity path — list and GET verdicts must not diverge.
+- Cross-file validation (grants naming declared pointers/worlds, scope names) in `internal/aclaudit`, not `internal/acl` (arch-lint forbids acl → metamodel).
+
+**Acceptance criterion (from TKT-T31NKT):** the `world:` grant syntax MUST NOT
+merge without the membership-gate load refusal in the same change —
+`Policy.Validate` refuses a policy that grants read on a non-default world while
+the membership relation is ungated (shared A1 predicate extracted by
+TKT-T31NKT), with a hard load error naming the fix and a load-error test.
+
+**Design question to settle in planning (RR-S7A16Q, from TKT-T31NKT's design
+review):** the shared predicate `MembershipSelfPromotionOpen` sees only the
+direct hole; a CHAINED escalation (membership gated by permission P, but another
+ungated role-relation confers a role holding P → self-promotion in two writes)
+is invisible to it. Audit A2 flags that shape today, but a load refusal keyed
+only on the A1 predicate would inherit the blind spot — a policy could pass the
+refusal while still one indirection away from leaking a non-default world.
+Decide at planning whether the refusal condition is "A1 open" or "A1 open OR an
+A2-shaped chain reaches the membership gate permission"; if the narrower check
+is chosen, document why (e.g. A2 stays a high-severity audit finding and the
+chain requires an already-privileged grant misconfiguration).

--- a/tickets/entities/tickets/TKT-DOFYR1.md
+++ b/tickets/entities/tickets/TKT-DOFYR1.md
@@ -5,7 +5,7 @@ title: Typed state references and the store contract (Step 1)
 kind: enhancement
 priority: high
 effort: xl
-status: ready
+status: backlog
 ---
 
 Design doc §2, §3, §6. The highest-engineering-risk piece: schema + contract

--- a/tickets/entities/tickets/TKT-DOFYR1.md
+++ b/tickets/entities/tickets/TKT-DOFYR1.md
@@ -1,0 +1,20 @@
+---
+id: TKT-DOFYR1
+type: ticket
+title: Typed state references and the store contract (Step 1)
+kind: enhancement
+priority: high
+effort: xl
+status: ready
+---
+
+Design doc §2, §3, §6. The highest-engineering-risk piece: schema + contract
+across all three backends, front-loaded so the compiler enforces the migration.
+
+- `entity.Entity` gains `Pointer` (`""` = default state); relations gain a `from_pointer` tail; heads stay entity-level (§2.3).
+- One boundary codec for the `PAGE-1@draft` serialization (URLs, CLI, acl.yaml, filenames); `entity.ValidateID` unchanged.
+- Relation scope (`identity` | `content`) declared per relation type; default `identity`.
+- Delete AND rename cascade over states + their relations — both backends currently exact-match (pg `entity.go:340`, fs `entity.go:282`).
+- `EntityQuery` world scope, zero value = default world (79 non-test construction sites unchanged).
+- Relation matching gains the pointer in BOTH implementations: `storeutil.MatchRelation` (fs/mem) and pgstore `relationWhere` SQL (`relation.go:298-335`) — v1's "single choke point" claim was false.
+- `storetest` conformance cases for scope + cascade land BEFORE the second backend implements.

--- a/tickets/entities/tickets/TKT-IKCDFM.md
+++ b/tickets/entities/tickets/TKT-IKCDFM.md
@@ -1,0 +1,29 @@
+---
+id: TKT-IKCDFM
+type: ticket
+title: 'aclaudit: model asserted_role_assignments as a privileged-role path (new A-tier check)'
+kind: enhancement
+priority: medium
+effort: s
+status: backlog
+---
+
+Follow-up from TKT-T31NKT code review (RR-8ZOICR, deferred there as
+correctly-out-of-scope for the membership predicate).
+
+`asserted_role_assignments` — roles conferred from verified IdP claims — is a
+privileged-role path that no audit tier currently models: not A1 (membership
+edge), not A2 (ungated role-relations), not the shared
+`acl.Policy.MembershipSelfPromotionOpen` predicate. The trust story differs from
+graph edges (claims come from the identity proxy, not from writable graph
+state), so a claim-mapped privileged role is NOT self-promotion in the A1 sense
+— the check must reason about what an attacker who controls claims (or a
+misconfigured proxy mapping) gains, and at minimum surface visibility-level
+findings ("these roles are conferred by claims, these of them are privileged")
+so the operator sees the full role-conferral surface in one audit run.
+
+Scope: audit-only (aclaudit tier A or a new informational tier); no enforcement
+change. Keep the single-definition discipline: reuse `RoleDef.IsPrivileged`.
+Becomes more relevant once worlds ship — a claim-conferred role holding a
+non-default-world read grant is part of the TKT-DN37J2 refusal discussion
+(RR-S7A16Q note there), but this ticket stands alone as audit coverage.

--- a/tickets/entities/tickets/TKT-OA664E.md
+++ b/tickets/entities/tickets/TKT-OA664E.md
@@ -1,0 +1,18 @@
+---
+id: TKT-OA664E
+type: ticket
+title: Copy-on-write editing from fallback faces
+kind: enhancement
+priority: medium
+effort: m
+status: backlog
+---
+
+Design doc §9.3. Worlds declare an `edits:` target (declared, never inferred
+from the chain or from grants). The edit affordance on a fallback-face view maps
+to: create the target state seeded from the exact viewed prime (per provenance),
+apply the delta. Seed copy is same-entity → elevated (hidden-field preservation,
+the never-redact-a-write-prep rule). Offered through the `_actions` affordance
+machinery, re-authorized server-side. The fallback chain then flips the prime
+for all readers of that world — inherent and correct for a pending-work world.
+Auto-fork vs explicit "start revision" is UX policy on the same primitive.

--- a/tickets/entities/tickets/TKT-OX8Q3E.md
+++ b/tickets/entities/tickets/TKT-OX8Q3E.md
@@ -5,7 +5,7 @@ title: pgstore rename should emit EntityRenamed, not delete+put
 kind: refactor
 priority: medium
 effort: s
-status: ready
+status: backlog
 ---
 
 Design doc §12.4. pgstore rename emits `notifyDelete(oldID)` +

--- a/tickets/entities/tickets/TKT-OX8Q3E.md
+++ b/tickets/entities/tickets/TKT-OX8Q3E.md
@@ -1,0 +1,16 @@
+---
+id: TKT-OX8Q3E
+type: ticket
+title: pgstore rename should emit EntityRenamed, not delete+put
+kind: refactor
+priority: medium
+effort: s
+status: ready
+---
+
+Design doc §12.4. pgstore rename emits `notifyDelete(oldID)` +
+`notifyPut(renamed)` (`pgstore/entity.go:484-485`); no `notifyRenamed` method
+exists on pgstore at all (only fsstore has one). Harmless today only because the
+pg search backend is a no-op observer — any observer with real behaviour sees a
+transient delete on rename. Align with the store contract callback (`store.go`
+EntityRenamed) before states multiply observer traffic.

--- a/tickets/entities/tickets/TKT-R10DDA.md
+++ b/tickets/entities/tickets/TKT-R10DDA.md
@@ -1,0 +1,21 @@
+---
+id: TKT-R10DDA
+type: ticket
+title: 'Attachment face-links: state-scoped membership over shared blobs'
+kind: enhancement
+priority: high
+effort: m
+status: backlog
+---
+
+Design doc §6.3. Prevents the leak: a screenshot uploaded to a draft, never
+promoted, fetchable by a published-only reader because attachments key on the
+entity.
+
+Attachment membership belongs to the face: per-state link sets over shared
+(refcounted/content-addressed) blobs; the copy kernel carries the link set;
+download gate = some face the principal may read (in a world they hold) links
+it. Explicit link rows, not body parsing. Migration: existing attachment rows
+become links from the default state. Acceptable interim restriction if Step 1
+needs trimming: forbid attachments on non-default states — never ship
+entity-scoped gating alongside states.

--- a/tickets/entities/tickets/TKT-RNBLAC.md
+++ b/tickets/entities/tickets/TKT-RNBLAC.md
@@ -5,7 +5,7 @@ title: Consolidate cardinality analyzers; stop swallowing CountRelations errors
 kind: refactor
 priority: high
 effort: s
-status: ready
+status: backlog
 ---
 
 Design doc §12.5 + §12.6 — the suggested first move; unblocks Step 5 and fixes a
@@ -21,6 +21,15 @@ scope)` parameterised over direction/type-source/bound/comparison; fold
 Fix `n, _ := s.deps.Store.CountRelations(...)` (`analysis.go:454,464`): a
 backend failure reads as count 0, which for `min_outgoing` manufactures a
 violation out of an outage.
+
+**Verified 2026-08-19:** the cited code moved with the analysis-package lift —
+it lives in `internal/analysis/analysis.go:345-451` (four checks) and `:453-469`
+(the two swallowing count helpers); same shape as described. **Error-policy
+decision (per plan PLAN-KJ76OT):** a store error fails the cardinality run
+loudly — `CheckCardinality` returns an error and aborts on the first count
+failure with entity/relation context; it never reports a violation computed from
+a failed count, and `analyze cardinality` / `validate --check cardinality` /
+`analyze all` surface it as a command failure.
 
 Prerequisite, not cosmetics: world-awareness changes the subject population,
 counting scope, and violation identity — four copies is four chances to diverge

--- a/tickets/entities/tickets/TKT-RNBLAC.md
+++ b/tickets/entities/tickets/TKT-RNBLAC.md
@@ -1,0 +1,27 @@
+---
+id: TKT-RNBLAC
+type: ticket
+title: Consolidate cardinality analyzers; stop swallowing CountRelations errors
+kind: refactor
+priority: high
+effort: s
+status: ready
+---
+
+Design doc §12.5 + §12.6 — the suggested first move; unblocks Step 5 and fixes a
+real user-facing bug.
+
+`checkMinOutgoing`/`checkMaxOutgoing`/`checkMinIncoming`/`checkMaxIncoming`
+(`analysis.go:344-451`) are four near-identical ~25-line functions, each
+independently calling `collectEntities` (one relation with one source type scans
+the same entities four times). Collapse to one `checkCardinality(ctx, rule,
+scope)` parameterised over direction/type-source/bound/comparison; fold
+`countOutgoingByType`/`countIncomingByType` into one `countRelations`.
+
+Fix `n, _ := s.deps.Store.CountRelations(...)` (`analysis.go:454,464`): a
+backend failure reads as count 0, which for `min_outgoing` manufactures a
+violation out of an outage.
+
+Prerequisite, not cosmetics: world-awareness changes the subject population,
+counting scope, and violation identity — four copies is four chances to diverge
+into false violations.

--- a/tickets/entities/tickets/TKT-SP3A87.md
+++ b/tickets/entities/tickets/TKT-SP3A87.md
@@ -1,0 +1,30 @@
+---
+id: TKT-SP3A87
+type: ticket
+title: Document the authenticated-everyone public-read scoping (anonymous deferred)
+kind: docs
+priority: medium
+effort: xs
+status: ready
+---
+
+Design doc §12.3, re-scoped per DEC-PEYCJZ (2026-08-19): the headline scenario
+"`everyone` reads `world:published`" means every AUTHENTICATED principal — the
+intranet/portal case behind the existing identity proxy.
+Anonymous/public-internet read would require changing the JWT/proxy contract and
+is deferred as a future feature with its own design; it no longer gates
+FEAT-9CD2MX.
+
+Remaining work (docs only, no design note needed):
+
+1. `docs/server-security.md` (+ the docs-project guide mirror): a short
+section stating the scoping — `everyone` = all verified principals; the
+public-read worlds scenario assumes the proxy; anonymous access is explicitly
+out of scope and would be an additive later feature (synthetic principal at the
+proxy or a dedicated wiring-bound public surface).
+2. Update `.ignored/pointer-design.md` §12.3 / §14 to point at DEC-PEYCJZ
+(done by the architect at decision time — verify).
+
+No code. The worlds ACL model is unchanged: read grants stay world-shaped, and
+the public surface stays structurally world-bound at the wiring site (§4.4 rule
+1), which is exactly what makes anonymous additive later.

--- a/tickets/entities/tickets/TKT-SP3A87.md
+++ b/tickets/entities/tickets/TKT-SP3A87.md
@@ -5,7 +5,7 @@ title: Document the authenticated-everyone public-read scoping (anonymous deferr
 kind: docs
 priority: medium
 effort: xs
-status: ready
+status: backlog
 ---
 
 Design doc §12.3, re-scoped per DEC-PEYCJZ (2026-08-19): the headline scenario

--- a/tickets/entities/tickets/TKT-T31NKT.md
+++ b/tickets/entities/tickets/TKT-T31NKT.md
@@ -5,7 +5,7 @@ title: Gate the membership relation against ACL self-promotion
 kind: enhancement
 priority: critical
 effort: m
-status: review
+status: done
 ---
 
 Security gate for shipping content states — design doc §12.1

--- a/tickets/entities/tickets/TKT-T31NKT.md
+++ b/tickets/entities/tickets/TKT-T31NKT.md
@@ -1,0 +1,39 @@
+---
+id: TKT-T31NKT
+type: ticket
+title: Gate the membership relation against ACL self-promotion
+kind: enhancement
+priority: critical
+effort: m
+status: review
+---
+
+Security gate for shipping content states — design doc §12.1
+(`.ignored/pointer-design.md`).
+
+`internal/acl/policy.go:324-351` documents a live self-promotion path: the
+membership relation carries no `requires_permission` by default, so anyone who
+can write the source type can write `alice --member-of--> admins` and
+self-assign any role in `assignments:`. Pre-existing; with world/public read in
+the picture it becomes the mechanism for leaking unpublished content.
+
+**Note:** `A1-ungated-membership` already exists at severity High
+(`aclaudit/tier_a.go:55`) and trips `--fail-on=high`/`--exit-code` — the audit
+side is done. The gap is that enforcement is advisory: a server loads and serves
+a policy with the hole open unless someone runs the audit. Verified 2026-08-19:
+no `world:` grant syntax exists in `internal/acl` yet, so the refusal condition
+is unevaluable until Step 3 (TKT-DN37J2).
+
+**Scope now (this ticket):**
+
+1. Extract the A1 predicate from `aclaudit/tier_a.go` into `internal/acl` as a function on `Policy`; aclaudit calls it (aclaudit already imports acl — direction fine). Behaviour identical; tests move with it. Prevents validator/auditor drift later.
+2. rela-server logs the ungated-membership condition as a prominent startup warning when loading a policy with assignments. Warning, not refusal — unconditional refusal would break existing trusted-team deployments (out of scope).
+3. Docs: record the coming deployment requirement (world grants + ungated membership = load refusal) in the acl-security docs.
+
+**Deferred to TKT-DN37J2 (acceptance criterion there, NOT built here):**
+
+4. The `Policy.Validate` refusal: policy grants read on a non-default world AND membership ungated per the shared predicate → hard load error naming the fix. Written against Step 3's real grant representation. Do NOT build a latent always-false `hasNonDefaultWorldGrant` hook now — untestable dead code that pre-commits Step 3's data model.
+
+Not a fail-closed degrade: inert world grants = a public outage
+indistinguishable from an ACL bug. Consistent with worlds' mandatory
+`otherwise:` validated at load. Blocks *shipping* pointers, not starting them.

--- a/tickets/entities/tickets/TKT-WAV8XP.md
+++ b/tickets/entities/tickets/TKT-WAV8XP.md
@@ -1,0 +1,24 @@
+---
+id: TKT-WAV8XP
+type: ticket
+title: 'Worlds: metamodel declaration, resolver, pushdown, selection (Step 2)'
+kind: enhancement
+priority: high
+effort: xl
+status: backlog
+---
+
+Design doc §4. Worlds as metamodel objects: `select` (with fallback chains),
+per-type `overrides`, mandatory `otherwise: exclude|default` validated at load.
+Default world total by construction — a metamodel with no `worlds:` block
+behaves byte-identically to today.
+
+- Resolver as a read decorator above the store (visibility/DEC-ZBI39P pattern); tracer/analysis/export run over a resolved world unchanged.
+- **World required in the interior** — no world-less code path; default world is a value bound at the boundary; constructors reject a missing world.
+- At-most-one prime per (world, entity); resolution principal-independent — ACL never participates in fallback (pin with a test); provenance on the prime.
+- Pushdown: the world scope expressed in pgstore SQL, not a per-row Go filter.
+- Selection: wiring-site binding for fixed surfaces (no world parameter at all); capability-gated `?world=`/`--world` on editor surfaces; a constructed reader handle per operation, not a ctx value.
+- Automations/Lua: contextual reads through the default world; triggering face state-addressed and raw; side-effect relation tails follow relation scope.
+
+World templates (§4.5, axis fallback + for_each) are marked tentative — do not
+build until a real world family exists.

--- a/tickets/entities/tickets/TKT-ZZL53L.md
+++ b/tickets/entities/tickets/TKT-ZZL53L.md
@@ -5,7 +5,7 @@ title: Drop or use entities_search_tsv_idx
 kind: chore
 priority: low
 effort: xs
-status: ready
+status: backlog
 ---
 
 Design doc §12.8. The index is created but never queried — no `to_tsvector`/`@@`

--- a/tickets/entities/tickets/TKT-ZZL53L.md
+++ b/tickets/entities/tickets/TKT-ZZL53L.md
@@ -1,0 +1,13 @@
+---
+id: TKT-ZZL53L
+type: ticket
+title: Drop or use entities_search_tsv_idx
+kind: chore
+priority: low
+effort: xs
+status: ready
+---
+
+Design doc §12.8. The index is created but never queried — no `to_tsvector`/`@@`
+in any Go file. A maintained GIN index with no read path is pure write
+amplification. Drop it, or wire the tsvector query path.

--- a/tickets/relations/DEC-PEYCJZ--decides--authorization.md
+++ b/tickets/relations/DEC-PEYCJZ--decides--authorization.md
@@ -1,0 +1,5 @@
+---
+from: DEC-PEYCJZ
+relation: decides
+to: authorization
+---

--- a/tickets/relations/FEAT-9CD2MX--has-research--RES-GFWP85.md
+++ b/tickets/relations/FEAT-9CD2MX--has-research--RES-GFWP85.md
@@ -1,0 +1,5 @@
+---
+from: FEAT-9CD2MX
+relation: has-research
+to: RES-GFWP85
+---

--- a/tickets/relations/FEAT-9CD2MX--has-research--RES-NH3P12.md
+++ b/tickets/relations/FEAT-9CD2MX--has-research--RES-NH3P12.md
@@ -1,0 +1,5 @@
+---
+from: FEAT-9CD2MX
+relation: has-research
+to: RES-NH3P12
+---

--- a/tickets/relations/FEAT-9CD2MX--requires--authorization.md
+++ b/tickets/relations/FEAT-9CD2MX--requires--authorization.md
@@ -1,0 +1,5 @@
+---
+from: FEAT-9CD2MX
+relation: requires
+to: authorization
+---

--- a/tickets/relations/FEAT-9CD2MX--requires--metamodel-types.md
+++ b/tickets/relations/FEAT-9CD2MX--requires--metamodel-types.md
@@ -1,0 +1,5 @@
+---
+from: FEAT-9CD2MX
+relation: requires
+to: metamodel-types
+---

--- a/tickets/relations/FEAT-9CD2MX--requires--store-backends.md
+++ b/tickets/relations/FEAT-9CD2MX--requires--store-backends.md
@@ -1,0 +1,5 @@
+---
+from: FEAT-9CD2MX
+relation: requires
+to: store-backends
+---

--- a/tickets/relations/RES-GFWP85--researches--metamodel-types.md
+++ b/tickets/relations/RES-GFWP85--researches--metamodel-types.md
@@ -1,0 +1,5 @@
+---
+from: RES-GFWP85
+relation: researches
+to: metamodel-types
+---

--- a/tickets/relations/RES-GFWP85--researches--store-backends.md
+++ b/tickets/relations/RES-GFWP85--researches--store-backends.md
@@ -1,0 +1,5 @@
+---
+from: RES-GFWP85
+relation: researches
+to: store-backends
+---

--- a/tickets/relations/RES-NH3P12--researches--authorization.md
+++ b/tickets/relations/RES-NH3P12--researches--authorization.md
@@ -1,0 +1,5 @@
+---
+from: RES-NH3P12
+relation: researches
+to: authorization
+---

--- a/tickets/relations/RES-NH3P12--researches--metamodel-types.md
+++ b/tickets/relations/RES-NH3P12--researches--metamodel-types.md
@@ -1,0 +1,5 @@
+---
+from: RES-NH3P12
+relation: researches
+to: metamodel-types
+---

--- a/tickets/relations/RES-NH3P12--researches--store-backends.md
+++ b/tickets/relations/RES-NH3P12--researches--store-backends.md
@@ -1,0 +1,5 @@
+---
+from: RES-NH3P12
+relation: researches
+to: store-backends
+---

--- a/tickets/relations/TKT-4QSZ8Y--affects--authorization.md
+++ b/tickets/relations/TKT-4QSZ8Y--affects--authorization.md
@@ -1,0 +1,5 @@
+---
+from: TKT-4QSZ8Y
+relation: affects
+to: authorization
+---

--- a/tickets/relations/TKT-4QSZ8Y--affects--mcp-api.md
+++ b/tickets/relations/TKT-4QSZ8Y--affects--mcp-api.md
@@ -1,0 +1,5 @@
+---
+from: TKT-4QSZ8Y
+relation: affects
+to: mcp-api
+---

--- a/tickets/relations/TKT-4QSZ8Y--implements--FEAT-9CD2MX.md
+++ b/tickets/relations/TKT-4QSZ8Y--implements--FEAT-9CD2MX.md
@@ -1,0 +1,5 @@
+---
+from: TKT-4QSZ8Y
+relation: implements
+to: FEAT-9CD2MX
+---

--- a/tickets/relations/TKT-9KZGJO--affects--metamodel-types.md
+++ b/tickets/relations/TKT-9KZGJO--affects--metamodel-types.md
@@ -1,0 +1,5 @@
+---
+from: TKT-9KZGJO
+relation: affects
+to: metamodel-types
+---

--- a/tickets/relations/TKT-9KZGJO--affects--store-backends.md
+++ b/tickets/relations/TKT-9KZGJO--affects--store-backends.md
@@ -1,0 +1,5 @@
+---
+from: TKT-9KZGJO
+relation: affects
+to: store-backends
+---

--- a/tickets/relations/TKT-9KZGJO--depends-on--TKT-RNBLAC.md
+++ b/tickets/relations/TKT-9KZGJO--depends-on--TKT-RNBLAC.md
@@ -1,0 +1,5 @@
+---
+from: TKT-9KZGJO
+relation: depends-on
+to: TKT-RNBLAC
+---

--- a/tickets/relations/TKT-9KZGJO--depends-on--TKT-WAV8XP.md
+++ b/tickets/relations/TKT-9KZGJO--depends-on--TKT-WAV8XP.md
@@ -1,0 +1,5 @@
+---
+from: TKT-9KZGJO
+relation: depends-on
+to: TKT-WAV8XP
+---

--- a/tickets/relations/TKT-9KZGJO--implements--FEAT-9CD2MX.md
+++ b/tickets/relations/TKT-9KZGJO--implements--FEAT-9CD2MX.md
@@ -1,0 +1,5 @@
+---
+from: TKT-9KZGJO
+relation: implements
+to: FEAT-9CD2MX
+---

--- a/tickets/relations/TKT-9OJ3S0--affects--store-backends.md
+++ b/tickets/relations/TKT-9OJ3S0--affects--store-backends.md
@@ -1,0 +1,5 @@
+---
+from: TKT-9OJ3S0
+relation: affects
+to: store-backends
+---

--- a/tickets/relations/TKT-9OJ3S0--depends-on--TKT-DOFYR1.md
+++ b/tickets/relations/TKT-9OJ3S0--depends-on--TKT-DOFYR1.md
@@ -1,0 +1,5 @@
+---
+from: TKT-9OJ3S0
+relation: depends-on
+to: TKT-DOFYR1
+---

--- a/tickets/relations/TKT-9OJ3S0--implements--FEAT-9CD2MX.md
+++ b/tickets/relations/TKT-9OJ3S0--implements--FEAT-9CD2MX.md
@@ -1,0 +1,5 @@
+---
+from: TKT-9OJ3S0
+relation: implements
+to: FEAT-9CD2MX
+---

--- a/tickets/relations/TKT-C1XUA8--affects--authorization.md
+++ b/tickets/relations/TKT-C1XUA8--affects--authorization.md
@@ -1,0 +1,5 @@
+---
+from: TKT-C1XUA8
+relation: affects
+to: authorization
+---

--- a/tickets/relations/TKT-C1XUA8--affects--metamodel-types.md
+++ b/tickets/relations/TKT-C1XUA8--affects--metamodel-types.md
@@ -1,0 +1,5 @@
+---
+from: TKT-C1XUA8
+relation: affects
+to: metamodel-types
+---

--- a/tickets/relations/TKT-C1XUA8--depends-on--TKT-DN37J2.md
+++ b/tickets/relations/TKT-C1XUA8--depends-on--TKT-DN37J2.md
@@ -1,0 +1,5 @@
+---
+from: TKT-C1XUA8
+relation: depends-on
+to: TKT-DN37J2
+---

--- a/tickets/relations/TKT-C1XUA8--implements--FEAT-9CD2MX.md
+++ b/tickets/relations/TKT-C1XUA8--implements--FEAT-9CD2MX.md
@@ -1,0 +1,5 @@
+---
+from: TKT-C1XUA8
+relation: implements
+to: FEAT-9CD2MX
+---

--- a/tickets/relations/TKT-DN37J2--affects--authorization.md
+++ b/tickets/relations/TKT-DN37J2--affects--authorization.md
@@ -1,0 +1,5 @@
+---
+from: TKT-DN37J2
+relation: affects
+to: authorization
+---

--- a/tickets/relations/TKT-DN37J2--depends-on--TKT-WAV8XP.md
+++ b/tickets/relations/TKT-DN37J2--depends-on--TKT-WAV8XP.md
@@ -1,0 +1,5 @@
+---
+from: TKT-DN37J2
+relation: depends-on
+to: TKT-WAV8XP
+---

--- a/tickets/relations/TKT-DN37J2--implements--FEAT-9CD2MX.md
+++ b/tickets/relations/TKT-DN37J2--implements--FEAT-9CD2MX.md
@@ -1,0 +1,5 @@
+---
+from: TKT-DN37J2
+relation: implements
+to: FEAT-9CD2MX
+---

--- a/tickets/relations/TKT-DOFYR1--affects--metamodel-types.md
+++ b/tickets/relations/TKT-DOFYR1--affects--metamodel-types.md
@@ -1,0 +1,5 @@
+---
+from: TKT-DOFYR1
+relation: affects
+to: metamodel-types
+---

--- a/tickets/relations/TKT-DOFYR1--affects--store-backends.md
+++ b/tickets/relations/TKT-DOFYR1--affects--store-backends.md
@@ -1,0 +1,5 @@
+---
+from: TKT-DOFYR1
+relation: affects
+to: store-backends
+---

--- a/tickets/relations/TKT-DOFYR1--implements--FEAT-9CD2MX.md
+++ b/tickets/relations/TKT-DOFYR1--implements--FEAT-9CD2MX.md
@@ -1,0 +1,5 @@
+---
+from: TKT-DOFYR1
+relation: implements
+to: FEAT-9CD2MX
+---

--- a/tickets/relations/TKT-IKCDFM--affects--authorization.md
+++ b/tickets/relations/TKT-IKCDFM--affects--authorization.md
@@ -1,0 +1,5 @@
+---
+from: TKT-IKCDFM
+relation: affects
+to: authorization
+---

--- a/tickets/relations/TKT-IKCDFM--implements--FEAT-AESD4.md
+++ b/tickets/relations/TKT-IKCDFM--implements--FEAT-AESD4.md
@@ -1,0 +1,5 @@
+---
+from: TKT-IKCDFM
+relation: implements
+to: FEAT-AESD4
+---

--- a/tickets/relations/TKT-OA664E--affects--data-entry-server.md
+++ b/tickets/relations/TKT-OA664E--affects--data-entry-server.md
@@ -1,0 +1,5 @@
+---
+from: TKT-OA664E
+relation: affects
+to: data-entry-server
+---

--- a/tickets/relations/TKT-OA664E--affects--data-entry-ui.md
+++ b/tickets/relations/TKT-OA664E--affects--data-entry-ui.md
@@ -1,0 +1,5 @@
+---
+from: TKT-OA664E
+relation: affects
+to: data-entry-ui
+---

--- a/tickets/relations/TKT-OA664E--depends-on--TKT-C1XUA8.md
+++ b/tickets/relations/TKT-OA664E--depends-on--TKT-C1XUA8.md
@@ -1,0 +1,5 @@
+---
+from: TKT-OA664E
+relation: depends-on
+to: TKT-C1XUA8
+---

--- a/tickets/relations/TKT-OA664E--implements--FEAT-9CD2MX.md
+++ b/tickets/relations/TKT-OA664E--implements--FEAT-9CD2MX.md
@@ -1,0 +1,5 @@
+---
+from: TKT-OA664E
+relation: implements
+to: FEAT-9CD2MX
+---

--- a/tickets/relations/TKT-OX8Q3E--affects--store-backends.md
+++ b/tickets/relations/TKT-OX8Q3E--affects--store-backends.md
@@ -1,0 +1,5 @@
+---
+from: TKT-OX8Q3E
+relation: affects
+to: store-backends
+---

--- a/tickets/relations/TKT-OX8Q3E--implements--FEAT-9CD2MX.md
+++ b/tickets/relations/TKT-OX8Q3E--implements--FEAT-9CD2MX.md
@@ -1,0 +1,5 @@
+---
+from: TKT-OX8Q3E
+relation: implements
+to: FEAT-9CD2MX
+---

--- a/tickets/relations/TKT-R10DDA--affects--data-entry-server.md
+++ b/tickets/relations/TKT-R10DDA--affects--data-entry-server.md
@@ -1,0 +1,5 @@
+---
+from: TKT-R10DDA
+relation: affects
+to: data-entry-server
+---

--- a/tickets/relations/TKT-R10DDA--affects--store-backends.md
+++ b/tickets/relations/TKT-R10DDA--affects--store-backends.md
@@ -1,0 +1,5 @@
+---
+from: TKT-R10DDA
+relation: affects
+to: store-backends
+---

--- a/tickets/relations/TKT-R10DDA--depends-on--TKT-C1XUA8.md
+++ b/tickets/relations/TKT-R10DDA--depends-on--TKT-C1XUA8.md
@@ -1,0 +1,5 @@
+---
+from: TKT-R10DDA
+relation: depends-on
+to: TKT-C1XUA8
+---

--- a/tickets/relations/TKT-R10DDA--depends-on--TKT-DOFYR1.md
+++ b/tickets/relations/TKT-R10DDA--depends-on--TKT-DOFYR1.md
@@ -1,0 +1,5 @@
+---
+from: TKT-R10DDA
+relation: depends-on
+to: TKT-DOFYR1
+---

--- a/tickets/relations/TKT-R10DDA--implements--FEAT-9CD2MX.md
+++ b/tickets/relations/TKT-R10DDA--implements--FEAT-9CD2MX.md
@@ -1,0 +1,5 @@
+---
+from: TKT-R10DDA
+relation: implements
+to: FEAT-9CD2MX
+---

--- a/tickets/relations/TKT-RNBLAC--affects--metamodel-types.md
+++ b/tickets/relations/TKT-RNBLAC--affects--metamodel-types.md
@@ -1,0 +1,5 @@
+---
+from: TKT-RNBLAC
+relation: affects
+to: metamodel-types
+---

--- a/tickets/relations/TKT-RNBLAC--implements--FEAT-9CD2MX.md
+++ b/tickets/relations/TKT-RNBLAC--implements--FEAT-9CD2MX.md
@@ -1,0 +1,5 @@
+---
+from: TKT-RNBLAC
+relation: implements
+to: FEAT-9CD2MX
+---

--- a/tickets/relations/TKT-SP3A87--affects--authorization.md
+++ b/tickets/relations/TKT-SP3A87--affects--authorization.md
@@ -1,0 +1,5 @@
+---
+from: TKT-SP3A87
+relation: affects
+to: authorization
+---

--- a/tickets/relations/TKT-SP3A87--affects--data-entry-server.md
+++ b/tickets/relations/TKT-SP3A87--affects--data-entry-server.md
@@ -1,0 +1,5 @@
+---
+from: TKT-SP3A87
+relation: affects
+to: data-entry-server
+---

--- a/tickets/relations/TKT-SP3A87--implements--FEAT-9CD2MX.md
+++ b/tickets/relations/TKT-SP3A87--implements--FEAT-9CD2MX.md
@@ -1,0 +1,5 @@
+---
+from: TKT-SP3A87
+relation: implements
+to: FEAT-9CD2MX
+---

--- a/tickets/relations/TKT-T31NKT--affects--authorization.md
+++ b/tickets/relations/TKT-T31NKT--affects--authorization.md
@@ -1,0 +1,5 @@
+---
+from: TKT-T31NKT
+relation: affects
+to: authorization
+---

--- a/tickets/relations/TKT-T31NKT--has-docs--DOCS-3V181I.md
+++ b/tickets/relations/TKT-T31NKT--has-docs--DOCS-3V181I.md
@@ -1,0 +1,5 @@
+---
+from: TKT-T31NKT
+relation: has-docs
+to: DOCS-3V181I
+---

--- a/tickets/relations/TKT-T31NKT--has-implementation--IMPL-M9IF9D.md
+++ b/tickets/relations/TKT-T31NKT--has-implementation--IMPL-M9IF9D.md
@@ -1,0 +1,5 @@
+---
+from: TKT-T31NKT
+relation: has-implementation
+to: IMPL-M9IF9D
+---

--- a/tickets/relations/TKT-T31NKT--has-planning--PLAN-QI9SFC.md
+++ b/tickets/relations/TKT-T31NKT--has-planning--PLAN-QI9SFC.md
@@ -1,0 +1,5 @@
+---
+from: TKT-T31NKT
+relation: has-planning
+to: PLAN-QI9SFC
+---

--- a/tickets/relations/TKT-T31NKT--has-review--REV-NVHQA3.md
+++ b/tickets/relations/TKT-T31NKT--has-review--REV-NVHQA3.md
@@ -1,0 +1,5 @@
+---
+from: TKT-T31NKT
+relation: has-review
+to: REV-NVHQA3
+---

--- a/tickets/relations/TKT-T31NKT--has-review-response--RR-5NIR95.md
+++ b/tickets/relations/TKT-T31NKT--has-review-response--RR-5NIR95.md
@@ -1,0 +1,5 @@
+---
+from: TKT-T31NKT
+relation: has-review-response
+to: RR-5NIR95
+---

--- a/tickets/relations/TKT-T31NKT--has-review-response--RR-62ZH2M.md
+++ b/tickets/relations/TKT-T31NKT--has-review-response--RR-62ZH2M.md
@@ -1,0 +1,5 @@
+---
+from: TKT-T31NKT
+relation: has-review-response
+to: RR-62ZH2M
+---

--- a/tickets/relations/TKT-T31NKT--has-review-response--RR-6560A3.md
+++ b/tickets/relations/TKT-T31NKT--has-review-response--RR-6560A3.md
@@ -1,0 +1,5 @@
+---
+from: TKT-T31NKT
+relation: has-review-response
+to: RR-6560A3
+---

--- a/tickets/relations/TKT-T31NKT--has-review-response--RR-8ZOICR.md
+++ b/tickets/relations/TKT-T31NKT--has-review-response--RR-8ZOICR.md
@@ -1,0 +1,5 @@
+---
+from: TKT-T31NKT
+relation: has-review-response
+to: RR-8ZOICR
+---

--- a/tickets/relations/TKT-T31NKT--has-review-response--RR-D3MEV0.md
+++ b/tickets/relations/TKT-T31NKT--has-review-response--RR-D3MEV0.md
@@ -1,0 +1,5 @@
+---
+from: TKT-T31NKT
+relation: has-review-response
+to: RR-D3MEV0
+---

--- a/tickets/relations/TKT-T31NKT--has-review-response--RR-EZ0P4S.md
+++ b/tickets/relations/TKT-T31NKT--has-review-response--RR-EZ0P4S.md
@@ -1,0 +1,5 @@
+---
+from: TKT-T31NKT
+relation: has-review-response
+to: RR-EZ0P4S
+---

--- a/tickets/relations/TKT-T31NKT--has-review-response--RR-S7A16Q.md
+++ b/tickets/relations/TKT-T31NKT--has-review-response--RR-S7A16Q.md
@@ -1,0 +1,5 @@
+---
+from: TKT-T31NKT
+relation: has-review-response
+to: RR-S7A16Q
+---

--- a/tickets/relations/TKT-T31NKT--has-review-response--RR-TVL38I.md
+++ b/tickets/relations/TKT-T31NKT--has-review-response--RR-TVL38I.md
@@ -1,0 +1,5 @@
+---
+from: TKT-T31NKT
+relation: has-review-response
+to: RR-TVL38I
+---

--- a/tickets/relations/TKT-T31NKT--implements--FEAT-9CD2MX.md
+++ b/tickets/relations/TKT-T31NKT--implements--FEAT-9CD2MX.md
@@ -1,0 +1,5 @@
+---
+from: TKT-T31NKT
+relation: implements
+to: FEAT-9CD2MX
+---

--- a/tickets/relations/TKT-WAV8XP--affects--metamodel-types.md
+++ b/tickets/relations/TKT-WAV8XP--affects--metamodel-types.md
@@ -1,0 +1,5 @@
+---
+from: TKT-WAV8XP
+relation: affects
+to: metamodel-types
+---

--- a/tickets/relations/TKT-WAV8XP--affects--store-backends.md
+++ b/tickets/relations/TKT-WAV8XP--affects--store-backends.md
@@ -1,0 +1,5 @@
+---
+from: TKT-WAV8XP
+relation: affects
+to: store-backends
+---

--- a/tickets/relations/TKT-WAV8XP--depends-on--TKT-DOFYR1.md
+++ b/tickets/relations/TKT-WAV8XP--depends-on--TKT-DOFYR1.md
@@ -1,0 +1,5 @@
+---
+from: TKT-WAV8XP
+relation: depends-on
+to: TKT-DOFYR1
+---

--- a/tickets/relations/TKT-WAV8XP--implements--FEAT-9CD2MX.md
+++ b/tickets/relations/TKT-WAV8XP--implements--FEAT-9CD2MX.md
@@ -1,0 +1,5 @@
+---
+from: TKT-WAV8XP
+relation: implements
+to: FEAT-9CD2MX
+---

--- a/tickets/relations/TKT-ZZL53L--affects--store-backends.md
+++ b/tickets/relations/TKT-ZZL53L--affects--store-backends.md
@@ -1,0 +1,5 @@
+---
+from: TKT-ZZL53L
+relation: affects
+to: store-backends
+---

--- a/tickets/relations/TKT-ZZL53L--implements--FEAT-9CD2MX.md
+++ b/tickets/relations/TKT-ZZL53L--implements--FEAT-9CD2MX.md
@@ -1,0 +1,5 @@
+---
+from: TKT-ZZL53L
+relation: implements
+to: FEAT-9CD2MX
+---


### PR DESCRIPTION
Security prerequisite §12.1 for content states (FEAT-9CD2MX).

- Extract the A1-ungated-membership predicate onto `acl.Policy` as `MembershipSelfPromotionOpen()` (+ exported `RoleDef.IsPrivileged()`); aclaudit delegates, so the audit finding and any enforcement view share one implementation.
- `appbuild.buildACL` logs a prominent startup warning when a loaded policy leaves the membership self-promotion path open (privileged assignment + ungated membership relation). Warning, not refusal — the hard load refusal is deferred to TKT-DN37J2 with the world-grant syntax it needs.
- Docs: acl-security (both trees) describe the warning and the coming world-grant load-refusal requirement.
- Also lands the pointer-arc planning graph under `tickets/` (FEAT-9CD2MX, research, tickets, checklists, review-responses) so relation endpoints don't dangle on develop.

Ticket: TKT-T31NKT (review → done on green CI).