### PR TITLE
🌍 refactor(analysis): consolidate cardinality checks; propagate CountRelations errors (TKT-RNBLAC)

### DIFF
--- a/internal/analysis/analysis.go
+++ b/internal/analysis/analysis.go
@@ -328,144 +328,150 @@ func (s *Service) FindGaps(ctx context.Context, opts Options) []GapResult {
 
 // --- Cardinality analysis ---
 
+// cardinalitySpec is one direction of a relation's cardinality
+// constraints: the subject population (which entity types are checked),
+// the count direction, the min/max bounds with their constraint labels,
+// and the relation label reported on violations (the inverse id for the
+// incoming side, when declared).
+//
+// This is the single seam world-awareness (TKT-9KZGJO) will thread
+// through: subject population, counting scope, and violation identity
+// each have exactly one home — the spec, [Service.countRelations], and
+// the two emit passes in [Service.checkCardinality] (TKT-RNBLAC).
+type cardinalitySpec struct {
+	relName       string // metamodel relation name — the count query key
+	direction     store.Direction
+	subjectTypes  []string // relDef.From (outgoing) / relDef.To (incoming)
+	minBound      *int     // nil or 0 disables the min check
+	maxBound      *int     // nil disables the max check; 0 forbids any edge
+	minConstraint string
+	maxConstraint string
+	relationLabel string // violation display label; inverse id on the incoming side
+}
+
 // CheckCardinality checks all cardinality constraints, filtered by
 // scope.
-func (s *Service) CheckCardinality(ctx context.Context, opts Options) []CardinalityViolation {
-	violations := make([]CardinalityViolation, 0) //nolint:prealloc // capacity unknown
+//
+// A store error fails the run loudly: the first failing count aborts
+// with a wrapped error and NO violations. Reporting around a failed
+// count would fabricate violations — a backend outage reads as count 0,
+// which for a min bound looks exactly like missing relations
+// (TKT-RNBLAC). This deliberately diverges from the under-count logging
+// of the other analyses (see [Service.FindOrphansWithScope]): those can
+// only miss findings, a failed count invents them.
+func (s *Service) CheckCardinality(ctx context.Context, opts Options) ([]CardinalityViolation, error) {
+	// Non-nil even when empty: JSON callers serialize Details as [], not null.
+	violations := make([]CardinalityViolation, 0)
 
 	for relName, relDef := range s.deps.Meta.Relations {
-		violations = append(violations, s.checkMinOutgoing(ctx, relName, relDef, opts.Scope)...)
-		violations = append(violations, s.checkMaxOutgoing(ctx, relName, relDef, opts.Scope)...)
-		violations = append(violations, s.checkMinIncoming(ctx, relName, relDef, opts.Scope)...)
-		violations = append(violations, s.checkMaxIncoming(ctx, relName, relDef, opts.Scope)...)
+		incomingLabel := relName
+		if relDef.Inverse != nil && relDef.Inverse.GetID() != "" {
+			incomingLabel = relDef.Inverse.GetID()
+		}
+		specs := [2]cardinalitySpec{
+			{
+				relName: relName, direction: store.DirectionOutgoing, subjectTypes: relDef.From,
+				minBound: relDef.MinOutgoing, maxBound: relDef.MaxOutgoing,
+				minConstraint: "min_outgoing", maxConstraint: "max_outgoing",
+				relationLabel: relName,
+			},
+			{
+				relName: relName, direction: store.DirectionIncoming, subjectTypes: relDef.To,
+				minBound: relDef.MinIncoming, maxBound: relDef.MaxIncoming,
+				minConstraint: "min_incoming", maxConstraint: "max_incoming",
+				relationLabel: incomingLabel,
+			},
+		}
+		for _, spec := range specs {
+			v, err := s.checkCardinality(ctx, spec, opts.Scope)
+			if err != nil {
+				return nil, err
+			}
+			violations = append(violations, v...)
+		}
 	}
-	return violations
+	return violations, nil
 }
 
-func (s *Service) checkMinOutgoing(
-	ctx context.Context, relName string, relDef metamodel.RelationDef, scope map[string]bool,
-) []CardinalityViolation {
-	if relDef.MinOutgoing == nil || *relDef.MinOutgoing == 0 {
-		return nil
+// checkCardinality evaluates one direction of one relation. Each
+// subject is scanned and counted once; min violations are then emitted
+// before max violations (two passes over the cached counts) so the
+// output order matches the historical per-constraint grouping.
+func (s *Service) checkCardinality(
+	ctx context.Context, spec cardinalitySpec, scope map[string]bool,
+) ([]CardinalityViolation, error) {
+	minActive := spec.minBound != nil && *spec.minBound > 0
+	maxActive := spec.maxBound != nil
+	if !minActive && !maxActive {
+		return nil, nil
 	}
-	var violations []CardinalityViolation
-	for _, sourceType := range relDef.From {
-		entities := collectEntities(ctx, s.deps.Store, store.EntityQuery{Type: sourceType})
+	dirWord := "outgoing"
+	if spec.direction == store.DirectionIncoming {
+		dirWord = "incoming"
+	}
+
+	// Buffering every (subject, count) before emitting is deliberate: the
+	// two emit passes below reproduce the historical min-then-max grouped
+	// ordering. Collapsing this into a single count-and-emit pass would
+	// interleave min and max violations and reorder the output the
+	// pinning tests guard.
+	type subject struct {
+		id    string
+		count int
+	}
+	var subjects []subject
+	for _, subjectType := range spec.subjectTypes {
+		entities := collectEntities(ctx, s.deps.Store, store.EntityQuery{Type: subjectType})
 		for _, e := range filterByScope(entities, scope) {
-			count := s.countOutgoingByType(ctx, e.ID, relName)
-			if count < *relDef.MinOutgoing {
+			count, err := s.countRelations(ctx, e.ID, spec.relName, spec.direction)
+			if err != nil {
+				return nil, fmt.Errorf("analysis: count %s %q relations of %s: %w", dirWord, spec.relName, e.ID, err)
+			}
+			subjects = append(subjects, subject{id: e.ID, count: count})
+		}
+	}
+
+	var violations []CardinalityViolation
+	if minActive {
+		for _, sub := range subjects {
+			if sub.count < *spec.minBound {
 				violations = append(violations, CardinalityViolation{
-					EntityID:     e.ID,
-					RelationType: relName,
-					Constraint:   "min_outgoing",
-					Required:     *relDef.MinOutgoing,
-					Actual:       count,
+					EntityID:     sub.id,
+					RelationType: spec.relationLabel,
+					Constraint:   spec.minConstraint,
+					Required:     *spec.minBound,
+					Actual:       sub.count,
 				})
 			}
 		}
 	}
-	return violations
-}
-
-func (s *Service) checkMaxOutgoing(
-	ctx context.Context, relName string, relDef metamodel.RelationDef, scope map[string]bool,
-) []CardinalityViolation {
-	if relDef.MaxOutgoing == nil {
-		return nil
-	}
-	var violations []CardinalityViolation
-	for _, sourceType := range relDef.From {
-		entities := collectEntities(ctx, s.deps.Store, store.EntityQuery{Type: sourceType})
-		for _, e := range filterByScope(entities, scope) {
-			count := s.countOutgoingByType(ctx, e.ID, relName)
-			if count > *relDef.MaxOutgoing {
+	if maxActive {
+		for _, sub := range subjects {
+			if sub.count > *spec.maxBound {
 				violations = append(violations, CardinalityViolation{
-					EntityID:     e.ID,
-					RelationType: relName,
-					Constraint:   "max_outgoing",
-					Required:     *relDef.MaxOutgoing,
-					Actual:       count,
+					EntityID:     sub.id,
+					RelationType: spec.relationLabel,
+					Constraint:   spec.maxConstraint,
+					Required:     *spec.maxBound,
+					Actual:       sub.count,
 				})
 			}
 		}
 	}
-	return violations
+	return violations, nil
 }
 
-func (s *Service) checkMinIncoming(
-	ctx context.Context, relName string, relDef metamodel.RelationDef, scope map[string]bool,
-) []CardinalityViolation {
-	if relDef.MinIncoming == nil || *relDef.MinIncoming == 0 {
-		return nil
-	}
-	var violations []CardinalityViolation
-	for _, targetType := range relDef.To {
-		entities := collectEntities(ctx, s.deps.Store, store.EntityQuery{Type: targetType})
-		for _, e := range filterByScope(entities, scope) {
-			count := s.countIncomingByType(ctx, e.ID, relName)
-			if count < *relDef.MinIncoming {
-				relLabel := relName
-				if relDef.Inverse != nil && relDef.Inverse.GetID() != "" {
-					relLabel = relDef.Inverse.GetID()
-				}
-				violations = append(violations, CardinalityViolation{
-					EntityID:     e.ID,
-					RelationType: relLabel,
-					Constraint:   "min_incoming",
-					Required:     *relDef.MinIncoming,
-					Actual:       count,
-				})
-			}
-		}
-	}
-	return violations
-}
-
-func (s *Service) checkMaxIncoming(
-	ctx context.Context, relName string, relDef metamodel.RelationDef, scope map[string]bool,
-) []CardinalityViolation {
-	if relDef.MaxIncoming == nil {
-		return nil
-	}
-	var violations []CardinalityViolation
-	for _, targetType := range relDef.To {
-		entities := collectEntities(ctx, s.deps.Store, store.EntityQuery{Type: targetType})
-		for _, e := range filterByScope(entities, scope) {
-			count := s.countIncomingByType(ctx, e.ID, relName)
-			if count > *relDef.MaxIncoming {
-				relLabel := relName
-				if relDef.Inverse != nil && relDef.Inverse.GetID() != "" {
-					relLabel = relDef.Inverse.GetID()
-				}
-				violations = append(violations, CardinalityViolation{
-					EntityID:     e.ID,
-					RelationType: relLabel,
-					Constraint:   "max_incoming",
-					Required:     *relDef.MaxIncoming,
-					Actual:       count,
-				})
-			}
-		}
-	}
-	return violations
-}
-
-func (s *Service) countOutgoingByType(ctx context.Context, entityID, relName string) int {
-	n, _ := s.deps.Store.CountRelations(ctx, store.RelationQuery{
+// countRelations counts an entity's relations of one type in one
+// direction. Errors propagate — see the [Service.CheckCardinality]
+// error policy.
+func (s *Service) countRelations(
+	ctx context.Context, entityID, relName string, direction store.Direction,
+) (int, error) {
+	return s.deps.Store.CountRelations(ctx, store.RelationQuery{
 		EntityID:  entityID,
-		Direction: store.DirectionOutgoing,
+		Direction: direction,
 		Type:      relName,
 	})
-	return n
-}
-
-func (s *Service) countIncomingByType(ctx context.Context, entityID, relName string) int {
-	n, _ := s.deps.Store.CountRelations(ctx, store.RelationQuery{
-		EntityID:  entityID,
-		Direction: store.DirectionIncoming,
-		Type:      relName,
-	})
-	return n
 }
 
 // --- Custom validations ---
@@ -529,14 +535,20 @@ func CountValidationsBySeverity(violations []ValidationViolation) (errors, warni
 
 // --- Summary ---
 
-// AnalyzeAll runs all analyses and returns a summary of counts.
-func (s *Service) AnalyzeAll(ctx context.Context, opts Options) *Summary {
+// AnalyzeAll runs all analyses and returns a summary of counts. A
+// cardinality store error fails the whole run — see the
+// [Service.CheckCardinality] error policy.
+func (s *Service) AnalyzeAll(ctx context.Context, opts Options) (*Summary, error) {
+	cardinality, err := s.CheckCardinality(ctx, opts)
+	if err != nil {
+		return nil, err
+	}
 	summary := &Summary{
 		Orphans:          len(s.FindOrphansWithScope(ctx, opts)),
 		Duplicates:       len(s.FindDuplicates(ctx, opts)),
 		UniqueViolations: len(s.FindUniqueViolations(ctx, opts)),
 		Gaps:             len(s.FindGaps(ctx, opts)),
-		Cardinality:      len(s.CheckCardinality(ctx, opts)),
+		Cardinality:      len(cardinality),
 	}
 
 	for _, pe := range schema.ValidateEntityProperties(ctx, s.deps.Store, s.deps.Meta) {
@@ -551,7 +563,7 @@ func (s *Service) AnalyzeAll(ctx context.Context, opts Options) *Summary {
 	summary.ValidationScriptErrors = len(result.ScriptErrors)
 	summary.ValidationLoadErrors = len(result.LoadErrors)
 
-	return summary
+	return summary, nil
 }
 
 // --- Orphan temp files ---

--- a/internal/analysis/analysis_test.go
+++ b/internal/analysis/analysis_test.go
@@ -2,6 +2,7 @@ package analysis_test
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"testing"
 
@@ -220,7 +221,10 @@ func TestCheckCardinality(t *testing.T) {
 	})
 
 	t.Run("finds violations", func(t *testing.T) {
-		violations := svc.CheckCardinality(context.Background(), analysis.Options{})
+		violations, err := svc.CheckCardinality(context.Background(), analysis.Options{})
+		if err != nil {
+			t.Fatalf("CheckCardinality: %v", err)
+		}
 		if len(violations) != 1 {
 			t.Errorf("got %d violations, want 1", len(violations))
 		}
@@ -235,11 +239,297 @@ func TestCheckCardinality(t *testing.T) {
 	})
 
 	t.Run("scope filters violations", func(t *testing.T) {
-		violations := svc.CheckCardinality(context.Background(), analysis.Options{
+		violations, err := svc.CheckCardinality(context.Background(), analysis.Options{
 			Scope: map[string]bool{"TKT-001": true},
 		})
+		if err != nil {
+			t.Fatalf("CheckCardinality: %v", err)
+		}
 		if len(violations) != 0 {
 			t.Errorf("got %d violations, want 0", len(violations))
+		}
+	})
+}
+
+// TestCheckCardinality_OrderingAndLabels pins the per-relation contract
+// before the TKT-RNBLAC consolidation: min-then-max ordering, outgoing
+// block before incoming block, the constraint strings, the
+// Required/Actual values, and the incoming-side inverse label. The
+// expectations were captured against the four pre-consolidation check
+// functions and must not change. Multi-type ordering is pinned by
+// TestCheckCardinality_MultipleSourceTypes and the pass-grouping by
+// TestCheckCardinality_MinMaxGroupedAcrossTypes.
+func TestCheckCardinality_OrderingAndLabels(t *testing.T) {
+	one := 1
+
+	meta := &metamodel.Metamodel{
+		Entities: map[string]metamodel.EntityDef{
+			"ticket":  {Label: "Ticket", IDPrefixes: []string{"TKT-"}},
+			"concept": {Label: "Concept", IDPrefixes: []string{"CON-"}},
+		},
+		Relations: map[string]metamodel.RelationDef{
+			"depends": {
+				Label:       "depends",
+				From:        []string{"ticket"},
+				To:          []string{"concept"},
+				MinOutgoing: &one,
+				MaxOutgoing: &one,
+				MinIncoming: &one,
+				MaxIncoming: &one,
+				Inverse:     &metamodel.InverseDef{ID: "needed-by"},
+			},
+		},
+	}
+
+	svc := newServiceWith(t, meta, func(s store.Store) {
+		addEntity(s, "TKT-A", "ticket", nil) // 0 outgoing → min_outgoing
+		addEntity(s, "TKT-B", "ticket", nil) // 2 outgoing → max_outgoing
+		addEntity(s, "TKT-C", "ticket", nil) // 1 outgoing → ok
+		addEntity(s, "CON-X", "concept", nil)
+		addEntity(s, "CON-Y", "concept", nil) // 2 incoming → max_incoming
+		addEntity(s, "CON-Z", "concept", nil) // 0 incoming → min_incoming
+		addRelation(s, "TKT-B", "depends", "CON-X")
+		addRelation(s, "TKT-B", "depends", "CON-Y")
+		addRelation(s, "TKT-C", "depends", "CON-Y")
+	})
+
+	got, err := svc.CheckCardinality(context.Background(), analysis.Options{})
+	if err != nil {
+		t.Fatalf("CheckCardinality: %v", err)
+	}
+
+	want := []analysis.CardinalityViolation{
+		{EntityID: "TKT-A", RelationType: "depends", Constraint: "min_outgoing", Required: 1, Actual: 0},
+		{EntityID: "TKT-B", RelationType: "depends", Constraint: "max_outgoing", Required: 1, Actual: 2},
+		// Incoming violations report the inverse label when declared.
+		{EntityID: "CON-Z", RelationType: "needed-by", Constraint: "min_incoming", Required: 1, Actual: 0},
+		{EntityID: "CON-Y", RelationType: "needed-by", Constraint: "max_incoming", Required: 1, Actual: 2},
+	}
+	if len(got) != len(want) {
+		t.Fatalf("got %d violations, want %d: %+v", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("violation[%d] = %+v, want %+v", i, got[i], want[i])
+		}
+	}
+}
+
+// TestCheckCardinality_BoundEdgeCases pins the min/max asymmetry: an
+// explicit 0 minimum is a skip (nothing can violate it), while an
+// explicit 0 maximum is a real constraint (any edge violates it).
+func TestCheckCardinality_BoundEdgeCases(t *testing.T) {
+	zero := 0
+
+	t.Run("max zero is enforced", func(t *testing.T) {
+		meta := &metamodel.Metamodel{
+			Entities: map[string]metamodel.EntityDef{
+				"ticket":  {Label: "Ticket", IDPrefixes: []string{"TKT-"}},
+				"concept": {Label: "Concept", IDPrefixes: []string{"CON-"}},
+			},
+			Relations: map[string]metamodel.RelationDef{
+				"depends": {
+					From: []string{"ticket"}, To: []string{"concept"},
+					MaxOutgoing: &zero,
+				},
+			},
+		}
+		svc := newServiceWith(t, meta, func(s store.Store) {
+			addEntity(s, "TKT-A", "ticket", nil)
+			addEntity(s, "CON-X", "concept", nil)
+			addRelation(s, "TKT-A", "depends", "CON-X")
+		})
+		got, err := svc.CheckCardinality(context.Background(), analysis.Options{})
+		if err != nil {
+			t.Fatalf("CheckCardinality: %v", err)
+		}
+		want := []analysis.CardinalityViolation{
+			{EntityID: "TKT-A", RelationType: "depends", Constraint: "max_outgoing", Required: 0, Actual: 1},
+		}
+		if len(got) != 1 || got[0] != want[0] {
+			t.Errorf("got %+v, want %+v", got, want)
+		}
+	})
+
+	t.Run("min zero is skipped", func(t *testing.T) {
+		meta := &metamodel.Metamodel{
+			Entities: map[string]metamodel.EntityDef{
+				"ticket":  {Label: "Ticket", IDPrefixes: []string{"TKT-"}},
+				"concept": {Label: "Concept", IDPrefixes: []string{"CON-"}},
+			},
+			Relations: map[string]metamodel.RelationDef{
+				"depends": {
+					From: []string{"ticket"}, To: []string{"concept"},
+					MinOutgoing: &zero,
+				},
+			},
+		}
+		svc := newServiceWith(t, meta, func(s store.Store) {
+			addEntity(s, "TKT-A", "ticket", nil) // 0 outgoing, but min is 0
+		})
+		got, err := svc.CheckCardinality(context.Background(), analysis.Options{})
+		if err != nil {
+			t.Fatalf("CheckCardinality: %v", err)
+		}
+		if len(got) != 0 {
+			t.Errorf("got %d violations, want 0: %+v", len(got), got)
+		}
+	})
+}
+
+// TestCheckCardinality_MultipleSourceTypes pins the ordering across a
+// relation's From types: subjects are visited in From-list order.
+func TestCheckCardinality_MultipleSourceTypes(t *testing.T) {
+	one := 1
+	meta := &metamodel.Metamodel{
+		Entities: map[string]metamodel.EntityDef{
+			"bug":     {Label: "Bug", IDPrefixes: []string{"BUG-"}},
+			"ticket":  {Label: "Ticket", IDPrefixes: []string{"TKT-"}},
+			"concept": {Label: "Concept", IDPrefixes: []string{"CON-"}},
+		},
+		Relations: map[string]metamodel.RelationDef{
+			"affects": {
+				From: []string{"ticket", "bug"}, To: []string{"concept"},
+				MinOutgoing: &one,
+			},
+		},
+	}
+	svc := newServiceWith(t, meta, func(s store.Store) {
+		addEntity(s, "BUG-1", "bug", nil)
+		addEntity(s, "TKT-1", "ticket", nil)
+	})
+	got, err := svc.CheckCardinality(context.Background(), analysis.Options{})
+	if err != nil {
+		t.Fatalf("CheckCardinality: %v", err)
+	}
+	// From-list order (ticket before bug), not ID order.
+	want := []analysis.CardinalityViolation{
+		{EntityID: "TKT-1", RelationType: "affects", Constraint: "min_outgoing", Required: 1, Actual: 0},
+		{EntityID: "BUG-1", RelationType: "affects", Constraint: "min_outgoing", Required: 1, Actual: 0},
+	}
+	if len(got) != len(want) {
+		t.Fatalf("got %d violations, want %d: %+v", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("violation[%d] = %+v, want %+v", i, got[i], want[i])
+		}
+	}
+}
+
+// TestCheckCardinality_MinMaxGroupedAcrossTypes is the discriminating
+// ordering test: with min AND max violations spread over two From
+// types, ALL min violations must come before ALL max violations. A
+// single count-and-emit pass would interleave them
+// ([TKT-A min, TKT-B max, BUG-A min]) — the exact regression the
+// two-pass emission in checkCardinality exists to prevent.
+func TestCheckCardinality_MinMaxGroupedAcrossTypes(t *testing.T) {
+	one := 1
+	meta := &metamodel.Metamodel{
+		Entities: map[string]metamodel.EntityDef{
+			"ticket":  {Label: "Ticket", IDPrefixes: []string{"TKT-"}},
+			"bug":     {Label: "Bug", IDPrefixes: []string{"BUG-"}},
+			"concept": {Label: "Concept", IDPrefixes: []string{"CON-"}},
+		},
+		Relations: map[string]metamodel.RelationDef{
+			"affects": {
+				From: []string{"ticket", "bug"}, To: []string{"concept"},
+				MinOutgoing: &one, MaxOutgoing: &one,
+			},
+		},
+	}
+	svc := newServiceWith(t, meta, func(s store.Store) {
+		addEntity(s, "TKT-A", "ticket", nil) // 0 out → min
+		addEntity(s, "TKT-B", "ticket", nil) // 2 out → max
+		addEntity(s, "BUG-A", "bug", nil)    // 0 out → min
+		addEntity(s, "CON-X", "concept", nil)
+		addEntity(s, "CON-Y", "concept", nil)
+		addRelation(s, "TKT-B", "affects", "CON-X")
+		addRelation(s, "TKT-B", "affects", "CON-Y")
+	})
+	got, err := svc.CheckCardinality(context.Background(), analysis.Options{})
+	if err != nil {
+		t.Fatalf("CheckCardinality: %v", err)
+	}
+	want := []analysis.CardinalityViolation{
+		{EntityID: "TKT-A", RelationType: "affects", Constraint: "min_outgoing", Required: 1, Actual: 0},
+		{EntityID: "BUG-A", RelationType: "affects", Constraint: "min_outgoing", Required: 1, Actual: 0},
+		{EntityID: "TKT-B", RelationType: "affects", Constraint: "max_outgoing", Required: 1, Actual: 2},
+	}
+	if len(got) != len(want) {
+		t.Fatalf("got %d violations, want %d: %+v", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("violation[%d] = %+v, want %+v", i, got[i], want[i])
+		}
+	}
+}
+
+// failingCountStore wraps a store.Store and fails every CountRelations
+// call, simulating a backend outage during the cardinality scan.
+type failingCountStore struct {
+	store.Store
+	err error
+}
+
+func (f *failingCountStore) CountRelations(context.Context, store.RelationQuery) (int, error) {
+	return 0, f.err
+}
+
+// TestCheckCardinality_CountErrorFailsLoudly pins the TKT-RNBLAC error
+// policy: a failing CountRelations must abort the run with a wrapped
+// error naming the entity and relation, and must NOT surface as a
+// count-0 min violation (the fabricated-violation bug the old
+// `n, _ :=` produced).
+func TestCheckCardinality_CountErrorFailsLoudly(t *testing.T) {
+	one := 1
+	meta := &metamodel.Metamodel{
+		Entities: map[string]metamodel.EntityDef{
+			"ticket":  {Label: "Ticket", IDPrefixes: []string{"TKT-"}},
+			"concept": {Label: "Concept", IDPrefixes: []string{"CON-"}},
+		},
+		Relations: map[string]metamodel.RelationDef{
+			"affects": {
+				From: []string{"ticket"}, To: []string{"concept"},
+				MinOutgoing: &one,
+			},
+		},
+	}
+
+	st := memstore.New()
+	addEntity(st, "TKT-001", "ticket", nil)
+	addEntity(st, "CON-001", "concept", nil)
+	addRelation(st, "TKT-001", "affects", "CON-001") // satisfied — only the outage could "violate"
+
+	countErr := errors.New("backend down")
+	broken := &failingCountStore{Store: st, err: countErr}
+	tr := tracer.New(broken)
+	svc, err := analysis.New(analysis.Deps{Store: broken, Meta: meta, Tracer: tr,
+		LuaReadDeps: lua.ReadDeps{VisibleReader: broken, WritePrepStore: broken, Tracer: tr, Meta: meta}})
+	if err != nil {
+		t.Fatalf("analysis.New: %v", err)
+	}
+
+	violations, err := svc.CheckCardinality(context.Background(), analysis.Options{})
+	if err == nil {
+		t.Fatalf("want error, got nil (violations: %+v)", violations)
+	}
+	if !errors.Is(err, countErr) {
+		t.Errorf("error does not wrap the store error: %v", err)
+	}
+	for _, want := range []string{"TKT-001", "affects"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error %q missing context %q", err, want)
+		}
+	}
+	if len(violations) != 0 {
+		t.Errorf("got %d violations alongside the error, want none: %+v", len(violations), violations)
+	}
+
+	t.Run("AnalyzeAll propagates", func(t *testing.T) {
+		if _, err := svc.AnalyzeAll(context.Background(), analysis.Options{}); err == nil {
+			t.Error("AnalyzeAll: want error, got nil")
 		}
 	})
 }
@@ -255,7 +545,10 @@ func TestAnalyzeAll(t *testing.T) {
 		addEntity(s, "DOC-001", "doc", nil)
 	})
 
-	summary := svc.AnalyzeAll(context.Background(), analysis.Options{})
+	summary, err := svc.AnalyzeAll(context.Background(), analysis.Options{})
+	if err != nil {
+		t.Fatalf("AnalyzeAll: %v", err)
+	}
 	if summary.Orphans != 1 {
 		t.Errorf("Orphans = %d, want 1", summary.Orphans)
 	}

--- a/internal/analysis/analysis_test.go
+++ b/internal/analysis/analysis_test.go
@@ -506,7 +506,7 @@ func TestCheckCardinality_CountErrorFailsLoudly(t *testing.T) {
 	broken := &failingCountStore{Store: st, err: countErr}
 	tr := tracer.New(broken)
 	svc, err := analysis.New(analysis.Deps{Store: broken, Meta: meta, Tracer: tr,
-		LuaReadDeps: lua.ReadDeps{VisibleReader: broken, WritePrepStore: broken, Tracer: tr, Meta: meta}})
+		LuaReadDeps: lua.ReadDeps{VisibleReader: broken, Tracer: tr, Meta: meta}})
 	if err != nil {
 		t.Fatalf("analysis.New: %v", err)
 	}

--- a/internal/cli/analyze.go
+++ b/internal/cli/analyze.go
@@ -203,7 +203,10 @@ func (c *AnalyzeCardinalityCmd) Run(ctx context.Context, analyzer *analysis.Serv
 	if err != nil {
 		return err
 	}
-	violations := analyzer.CheckCardinality(ctx, *opts)
+	violations, err := analyzer.CheckCardinality(ctx, *opts)
+	if err != nil {
+		return err
+	}
 	cardMsg := "All cardinality constraints satisfied"
 	if writeAnalysisJSON(len(violations), violations, cardMsg, "Found %d cardinality violations") {
 		return nil
@@ -527,7 +530,10 @@ func (c *AnalyzeAllCmd) Run(ctx context.Context, svc *readServices, analyzer *an
 	if err != nil {
 		return err
 	}
-	summary := analyzer.AnalyzeAll(ctx, *opts)
+	summary, err := analyzer.AnalyzeAll(ctx, *opts)
+	if err != nil {
+		return err
+	}
 	if out.Format == "json" {
 		return writeAnalyzeAllJSON(summary)
 	}
@@ -633,6 +639,10 @@ func runAnalyzeAllSections(
 	}
 	out.WriteMessage("")
 	out.WriteSectionHeader("Cardinality Analysis")
+	// Second full cardinality scan (the summary above already ran one).
+	// With a flaky backend the two runs can disagree — summary success
+	// followed by a section error here. Pre-existing shape; computing
+	// once and passing the violations down is the follow-up fix.
 	if err := (&AnalyzeCardinalityCmd{}).Run(ctx, analyzer); err != nil {
 		errs = append(errs, fmt.Errorf("cardinality analysis: %w", err))
 	}

--- a/internal/cli/analyze_test.go
+++ b/internal/cli/analyze_test.go
@@ -7,9 +7,12 @@ import (
 	"testing"
 
 	"github.com/Sourcehaven-BV/rela/internal/analysis"
+	"github.com/Sourcehaven-BV/rela/internal/appbuild/appbuildtest"
 	"github.com/Sourcehaven-BV/rela/internal/errors"
 	"github.com/Sourcehaven-BV/rela/internal/metamodel"
 	"github.com/Sourcehaven-BV/rela/internal/output"
+	"github.com/Sourcehaven-BV/rela/internal/store"
+	"github.com/Sourcehaven-BV/rela/internal/store/memstore"
 	"github.com/Sourcehaven-BV/rela/internal/testutil"
 )
 
@@ -167,4 +170,77 @@ func TestAnalyzeGaps(t *testing.T) {
 	if result.Count != 1 {
 		t.Errorf("Expected count %d, got %d", 1, result.Count)
 	}
+}
+
+// failingCountStore wraps a store.Store and fails every CountRelations
+// call, simulating a backend outage during the cardinality scan.
+type failingCountStore struct {
+	store.Store
+	err error
+}
+
+func (f *failingCountStore) CountRelations(context.Context, store.RelationQuery) (int, error) {
+	return 0, f.err
+}
+
+// TestAnalyzeCmds_CountErrorAborts pins the TKT-RNBLAC error policy at
+// the CLI boundary for both cardinality surfaces: a store error must
+// abort the command with the error and WITHOUT writing any output —
+// especially no fabricated count-0 min violations, and no partial JSON.
+func TestAnalyzeCmds_CountErrorAborts(t *testing.T) {
+	one := 1
+	meta := &metamodel.Metamodel{
+		Entities: map[string]metamodel.EntityDef{
+			"requirement": {
+				Label:      "Requirement",
+				IDPrefix:   "REQ-",
+				Properties: map[string]metamodel.PropertyDef{},
+			},
+		},
+		Relations: map[string]metamodel.RelationDef{
+			"refines": {
+				From: []string{"requirement"}, To: []string{"requirement"},
+				MinOutgoing: &one,
+			},
+		},
+	}
+	countErr := stderrors.New("backend down")
+	newBrokenBundles := func(t *testing.T) *cliBundles {
+		t.Helper()
+		st := memstore.New()
+		if err := st.CreateEntity(context.Background(),
+			testutil.EntityFor(meta, "requirement").ID("REQ-001").Build()); err != nil {
+			t.Fatalf("seed entity: %v", err)
+		}
+		broken := &failingCountStore{Store: st, err: countErr}
+		b, err := newCLIBundles(appbuildtest.New(meta, appbuildtest.WithStore(broken)))
+		if err != nil {
+			t.Fatalf("newCLIBundles: %v", err)
+		}
+		return b
+	}
+
+	t.Run("analyze cardinality", func(t *testing.T) {
+		b := newBrokenBundles(t)
+		buf := withOutput(t, output.FormatJSON)
+		err := (&AnalyzeCardinalityCmd{}).Run(context.Background(), b.analysis)
+		if !stderrors.Is(err, countErr) {
+			t.Fatalf("want wrapped count error, got %v", err)
+		}
+		if buf.Len() != 0 {
+			t.Errorf("expected no output before the error, got: %s", buf.String())
+		}
+	})
+
+	t.Run("analyze all", func(t *testing.T) {
+		b := newBrokenBundles(t)
+		buf := withOutput(t, output.FormatJSON)
+		err := (&AnalyzeAllCmd{}).Run(context.Background(), b.read, b.analysis)
+		if !stderrors.Is(err, countErr) {
+			t.Fatalf("want wrapped count error, got %v", err)
+		}
+		if buf.Len() != 0 {
+			t.Errorf("expected no output before the error, got: %s", buf.String())
+		}
+	})
 }

--- a/internal/cli/validate.go
+++ b/internal/cli/validate.go
@@ -130,7 +130,11 @@ func runValidationChecks(
 	opts := analysis.Options{}
 	hasErrors := false
 	if checks.cardinality {
-		if runCardinalityCheck(ctx, checkAnalysis, checkOut, opts) {
+		found, err := runCardinalityCheck(ctx, checkAnalysis, checkOut, opts)
+		if err != nil {
+			return false, err
+		}
+		if found {
 			hasErrors = true
 		}
 	}
@@ -147,19 +151,27 @@ func runValidationChecks(
 	return hasErrors, nil
 }
 
-// runCardinalityCheck runs cardinality validation. Returns true if errors found.
+// runCardinalityCheck runs cardinality validation. Returns true if
+// violations were found; a store error aborts the check before any
+// VIOLATION output is written (never report a fabricated violation —
+// see the CheckCardinality error policy). The section header above the
+// error return is the pre-existing plain-stdout banner every validate
+// check prints on !quiet, including in JSON mode.
 func runCardinalityCheck(
 	ctx context.Context, checkAnalysis *analysis.Service, checkOut *output.Writer, opts analysis.Options,
-) bool {
+) (bool, error) {
 	if !quiet {
 		fmt.Println("\nChecking cardinality constraints...")
 	}
-	violations := checkAnalysis.CheckCardinality(ctx, opts)
+	violations, err := checkAnalysis.CheckCardinality(ctx, opts)
+	if err != nil {
+		return false, err
+	}
 	if len(violations) == 0 {
 		if !quiet && checkOut.Format != output.FormatJSON {
 			checkOut.WriteSuccess("All cardinality constraints satisfied")
 		}
-		return false
+		return false, nil
 	}
 	if checkOut.Format == output.FormatJSON {
 		_ = checkOut.WriteAnalysisResult(output.AnalysisResult{
@@ -178,7 +190,7 @@ func runCardinalityCheck(
 			}
 		}
 	}
-	return true
+	return true, nil
 }
 
 // runPropertiesCheck runs property validation. Returns true if errors found.

--- a/tickets/entities/implementation-checklists/IMPL-MSUOMF.md
+++ b/tickets/entities/implementation-checklists/IMPL-MSUOMF.md
@@ -1,0 +1,59 @@
+---
+id: IMPL-MSUOMF
+type: implementation-checklist
+title: 'Implementation: Consolidate cardinality analyzers; stop swallowing CountRelations errors'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Development
+
+- [x] Unit tests written for new code (behaviour-pinning tests written BEFORE the refactor and passing against the old code: `TestCheckCardinality_OrderingAndLabels`, `_BoundEdgeCases`, `_MultipleSourceTypes`; error-policy test after: `TestCheckCardinality_CountErrorFailsLoudly`)
+- [x] Integration tests written (existing `internal/cli` tests exercise the commands end-to-end; manual CLI verification below)
+- [x] Happy path implemented (`cardinalitySpec` + single `checkCardinality` + `countRelations` in `internal/analysis/analysis.go`)
+- [x] Edge cases from planning handled (max=0 enforced, min=0 skipped, multi-type From ordering, inverse label on incoming, scope-before-count preserved)
+- [x] Error handling in place (the ticket's core fix: `CountRelations` errors propagate; `CheckCardinality`/`AnalyzeAll` return error; all three CLI surfaces fail the command instead of fabricating violations)
+
+## Test Quality
+
+- [x] Using fixture builders or factories for test data (existing `addEntity`/`addRelation`/`newServiceWith` helpers; `failingCountStore` wraps a seeded memstore)
+- [x] No hardcoded values in assertions when object is in scope (full expected `CardinalityViolation` structs compared, not ad-hoc fields)
+- [x] Only specifying values that matter for the test
+- [x] Interpolated values constructed from objects, not hardcoded (error test asserts `errors.Is` against the injected sentinel plus the id/relation context)
+- [x] Property comparisons use original object, not hardcoded strings
+
+## Manual Verification
+
+- [x] Feature manually tested end-to-end
+- [x] Each acceptance criterion verified with test scenario from planning
+- [x] Edge cases manually verified
+
+**Verification Evidence:**
+
+Built `cmd/rela` and ran against the live tickets/ project (2026-08-19): `rela
+analyze cardinality`, `rela validate --check cardinality`, and `rela analyze
+all` all report "All cardinality constraints satisfied" (exit 0) — identical to
+the pre-refactor binary on the same data. AC1/AC2 verified by the pinning tests
+(written first, unchanged by the refactor); AC3 by
+`TestCheckCardinality_CountErrorFailsLoudly` (wrapped error names entity +
+relation, zero violations returned, AnalyzeAll propagates); AC4 by the
+compiler-enforced signature change + green `internal/cli` tests.
+
+## Quality
+
+- [x] Code follows project patterns (check similar code)
+- [x] Checked for DRY opportunities — repeated literals, expressions, or
+patterns extracted to a helper / constant / type where it sharpens the contract
+(don't extract for its own sake; CLAUDE.md "three similar lines is better than a
+premature abstraction" still holds)
+- [x] No security issues introduced (no world/pointer hook added — the spec is shaped for TKT-9KZGJO but carries no world field)
+- [x] No silent failures (the change REMOVES a silent failure; remaining `collectEntities` under-count logging is documented out-of-scope in PLAN-KJ76OT)
+- [x] No debug code left behind
+
+## Quality Gates (run 2026-08-19)
+
+- `go build ./...` + `go test ./...` — all pass
+- `just arch-lint` — OK; `just plimsoll` — clean
+- `just lint` — 0 issues (after dropping a now-unused nolint:prealloc directive)
+- `just coverage-check` — floors + total (77.1% >= 65%) satisfied; internal/analysis 76.9%

--- a/tickets/entities/planning-checklists/PLAN-KJ76OT.md
+++ b/tickets/entities/planning-checklists/PLAN-KJ76OT.md
@@ -1,0 +1,253 @@
+---
+id: PLAN-KJ76OT
+type: planning-checklist
+title: 'Planning: Consolidate cardinality analyzers; stop swallowing CountRelations errors'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Understanding
+
+- [x] Problem/requirements clearly understood
+- [x] Scope defined (what's in/out documented below)
+- [x] Acceptance criteria documented with specific test scenarios
+
+**Scope:**
+
+IN scope:
+
+1. Collapse `checkMinOutgoing`/`checkMaxOutgoing`/`checkMinIncoming`/
+`checkMaxIncoming` (`internal/analysis/analysis.go:345-451` — the ticket's
+`analysis.go:344-451` cites the pre-move tracer path; code now lives in
+`internal/analysis`) into one parameterised check driven by a per-direction spec
+(subject types, direction, min/max bounds, constraint labels, violation relation
+label). One entity scan and one count per (relation, direction) instead of two
+of each.
+2. Fold `countOutgoingByType`/`countIncomingByType` (analysis.go:453-469)
+into one `countRelations` helper that PROPAGATES the `store.CountRelations`
+error instead of `n, _ :=` swallowing it.
+3. Error policy (the documented decision): a store error fails the
+cardinality run loudly — `CheckCardinality` gains an error return and aborts on
+the first count failure with entity/relation context; it never reports a
+violation computed from a failed count. Callers updated: `cli/analyze.go`
+AnalyzeCardinalityCmd (return the error), `cli/validate.go` runCardinalityCheck
+(propagate to the command error), `AnalyzeAll` (gains an error return; its one
+CLI caller propagates).
+4. Pin current behaviour with tests BEFORE refactoring (coverage is thin:
+only min_outgoing + scope today).
+
+OUT of scope:
+
+- Any world/pointer concept (TKT-9KZGJO). The parameterisation is SHAPED
+so a future world parameter changes subject population / counting scope /
+violation identity in one place, but no world field/hook is added now.
+- `collectEntities`'s log-and-return-partial behaviour on ListEntities
+iteration errors (documented pre-existing under-count semantics shared by all
+analyses; an entity missing from the scan cannot FABRICATE a violation —
+different failure class from the count bug, and changing it touches every
+analysis).
+- The MCP server's separate cardinality implementation
+(`internal/mcp/tools_analysis.go:68-146`) — a FIFTH copy with the same swallowed
+`CountRelations` error. Deliberately kept against Store+Meta because mcp has no
+analysis.Service dependency; unifying it is an architectural decision flagged to
+the architect, not taken here.
+
+**Acceptance Criteria:**
+
+1. Identical violations for existing metamodels: same set, same ordering
+(per relation: all min-then-max outgoing over From types in order, then
+min-then-max incoming over To types), same constraint strings, same
+incoming-label behaviour (inverse relation id when declared). Pinned by new
+table tests written against the OLD code first.
+2. `max_outgoing: 0` / `max_incoming: 0` remain meaningful (max nil-check
+only), `min_*: 0` remains a skip — pinned by tests.
+3. A failing `CountRelations` aborts the run with a wrapped error naming
+the entity and relation; no violations are returned alongside it. Pinned by a
+test using a store wrapper whose CountRelations fails.
+4. `rela analyze cardinality`, `rela validate --check cardinality`, and
+`rela analyze all` surface the error as a command failure (non-zero exit), not
+as fabricated violations.
+
+## Research
+
+- [x] ~~For larger features: run `/research` to create a structured research doc~~ (N/A: refactor with fixed approach from design doc §12.5+§12.6; the parameterisation shape is the only free variable and is dictated by the four existing functions)
+- [x] ~~Searched for existing libraries that solve this problem~~ (N/A: internal consolidation)
+- [x] Checked codebase for similar patterns or reusable code
+- [x] ~~Looked for reference implementations in other projects~~ (N/A)
+- [x] Reviewed relevant rela concepts for prior art
+
+**Research Doc:** N/A (feature-level context in RES-GFWP85/RES-NH3P12 for
+FEAT-9CD2MX)
+
+**Existing Solutions:**
+
+- The four functions themselves (analysis.go:345-451) define the contract;
+the MCP handler (`checkCardinalityBound`, tools_analysis.go:103) already
+demonstrates a min+max-in-one-scan shape (though with different output and its
+own swallowed errors).
+- Error-propagation precedent: the package's documented under-count
+logging (`FindOrphansWithScope` godoc) explains why other analyses swallow; the
+ticket's rationale (fabricated violations, not just under-counts) is what
+justifies cardinality diverging to fail-loud.
+
+## Approach
+
+- [x] Technical approach chosen and documented
+- [x] Approach builds on existing patterns (not reinventing)
+- [x] Alternatives considered (document why rejected)
+- [x] Dependencies identified (packages, APIs, types)
+
+**Technical Approach:**
+
+Introduce a small direction spec derived per relation:
+
+```go
+type cardinalitySpec struct {
+    direction     store.Direction // count direction
+    subjectTypes  []string        // relDef.From (outgoing) / relDef.To (incoming)
+    minBound, maxBound *int
+    minConstraint, maxConstraint string // "min_outgoing"... labels
+    relationLabel string          // relName; incoming uses inverse id if declared
+}
+```
+
+`CheckCardinality` iterates relations, derives the outgoing and incoming specs,
+and calls one `checkCardinality(ctx, relName, spec, scope)
+([]CardinalityViolation, error)` that: skips when min is nil/0 AND max is nil;
+scans each subject type once; counts each subject once via `countRelations`
+(error → wrapped return); then emits min violations and max violations as two
+passes over the cached counts — preserving the old grouped ordering exactly
+while halving scans and counts.
+
+The spec is the future world seam: subject population (subjectTypes → query),
+counting scope (countRelations), and violation identity (the two emit sites)
+each live in exactly one place. No world field is added.
+
+Alternatives rejected:
+- Interleaved min/max emission per entity (single pass): simpler but
+changes violation ordering — behaviour must be identical.
+- Accumulating all count errors before returning: more machinery for no
+caller benefit; fail-fast matches "fail the run loudly".
+- Keeping void signatures + logging the error: exactly the fabricated-
+violation bug class the ticket exists to remove (a logged error still yields
+count 0 downstream unless the subject is skipped, and a silently skipped subject
+is an invisible under-count).
+
+**Files to modify:**
+
+- `internal/analysis/analysis.go` (consolidation + error returns)
+- `internal/analysis/analysis_test.go` (behaviour-pinning table tests
+first; then error-propagation tests with a failing-store wrapper)
+- `internal/cli/analyze.go` (AnalyzeCardinalityCmd, AnalyzeAllCmd)
+- `internal/cli/validate.go` (runCardinalityCheck)
+
+## Security Considerations
+
+- [x] Input sources identified (user input, config, external APIs)
+- [x] Input validation approach defined (allowlist preferred over blocklist)
+- [x] Security-sensitive operations identified (file access, auth, crypto)
+- [x] Error handling doesn't leak sensitive information
+
+**Input Sources & Validation:**
+
+- Inputs are the operator's metamodel (already parsed/validated) and the
+store. No new parsing, no user-supplied strings interpolated beyond
+entity/relation ids already present in analysis output.
+
+**Security-Sensitive Operations:**
+
+- None new. The error message wraps the store error with entity id +
+relation name — both already surfaced by the analyzers' normal output; no
+credentials/paths beyond what the store error itself carries.
+
+## Test Plan
+
+- [x] Test scenarios documented for each acceptance criterion
+- [x] Edge cases identified and documented
+- [x] Negative test cases defined (invalid input, error conditions)
+- [x] Integration test approach defined (not just unit tests)
+
+**Test Scenarios:**
+
+- AC1: table test over a metamodel exercising all four constraints at
+once (min+max outgoing on one relation, min+max incoming with a declared inverse
+on another), asserting the full ordered violation slice (ids, constraints,
+labels, required/actual). Written and passing against the OLD code before the
+refactor, unchanged after.
+- AC2: cases for max_outgoing=0 (entity with one edge violates),
+min_outgoing=0 (never violates), both-nil (no scan, no violations).
+- AC3: failing-store wrapper (embeds store.Store, CountRelations returns
+an injected error) → CheckCardinality returns nil violations + wrapped error
+mentioning the entity id and relation; AnalyzeAll propagates.
+- AC4: CLI behaviour covered by the signature change (compiler enforces
+callers handle the error) + existing CLI tests still green.
+
+**Edge Cases:**
+
+- Relation with multiple From/To types (ordering across types).
+- Entity type in From with zero entities.
+- min set on a relation whose From type has entities but zero relations
+(the classic violation).
+- Inverse label only on incoming violations; outgoing keeps relName.
+- Scope filtering unchanged (subjects filtered before counting — old code
+counted only in-scope entities; preserve to keep store-call pattern).
+
+**Negative Tests:**
+
+- CountRelations error (AC3). ListEntities iteration error stays
+log-and-partial (out of scope, documented).
+
+## Risk Assessment
+
+- [x] Technical risks assessed with mitigations
+- [x] Security risks assessed (see Security Considerations)
+- [x] Effort estimated (xs/s/m/l/xl)
+
+**Risks:**
+
+- Ordering regression → mitigated by pinning the full ordered slice
+before refactoring (map iteration across relations is already nondeterministic;
+ordering is only defined within one relation, which is exactly what the test
+pins per-relation).
+- Signature ripple (error returns) → bounded: three CLI call sites, all
+already return error; compiler surfaces any missed caller.
+- Behaviour drift in the min-0/max-0 asymmetry → dedicated test cases.
+
+Effort: s (matches ticket property).
+
+## Documentation Planning
+
+For refactors: identify what documentation needs updating.
+
+- [x] User-facing docs identified (skip if internal refactor)
+- [x] Docs-checklist will be created when entering implementation
+
+**Documentation Impact:**
+
+- [x] ~~docs/metamodel.md~~ (N/A: constraint semantics unchanged)
+- [x] ~~docs/cli-reference.md~~ (N/A: commands unchanged; a store outage now errors instead of printing false violations — behaviour users were never promised)
+- [x] ~~docs/data-entry.md~~ (N/A)
+- [x] ~~CLAUDE.md~~ (N/A: no new pattern)
+- [x] ~~README.md~~ (N/A)
+- Godoc on `CheckCardinality`/`cardinalitySpec` documents the error
+policy and the one-place world seam (in-code docs, part of item 1).
+
+## Design Review
+
+- [x] Run `/design-review` before starting implementation
+- [x] All critical/significant findings addressed in plan (none found)
+
+**Design Review Findings:**
+
+No critical/significant findings; no review-response entities created. Two notes
+folded into the plan:
+- (minor) `validate --format json` must not half-emit a cardinality
+result before the error path returns — error handling goes before any output
+write in `runCardinalityCheck`.
+- (nit) The ticket's cited location (`analysis.go:344-451`, tracer)
+predates the package move; verified 2026-08-19 the code lives in
+`internal/analysis/analysis.go:345-469`. Noted on the ticket body. Architectural
+flag (out of scope, reported to architect): the MCP server carries a FIFTH
+cardinality implementation with the same swallowed CountRelations error
+(`internal/mcp/tools_analysis.go:68-146`).

--- a/tickets/entities/review-checklists/REV-1HTU0H.md
+++ b/tickets/entities/review-checklists/REV-1HTU0H.md
@@ -2,7 +2,7 @@
 id: REV-1HTU0H
 type: review-checklist
 title: 'Review: Consolidate cardinality analyzers; stop swallowing CountRelations errors'
-status: in-progress
+status: done
 ---
 
 <!-- @managed: claude-workflow v1 -->
@@ -23,16 +23,15 @@ status: in-progress
 **Review Responses:**
 
 RR-4JWU2I (significant, addressed: honest godoc on the validate banner),
-RR-STCCY8 (significant, addressed: CLI-boundary error tests; double-scan
-hazard documented in-code, compute-once is the follow-up), RR-5FKMKX
-(significant, addressed: relName folded into cardinalitySpec), RR-1HB83A
-(minor, addressed: direction in the count error), RR-3ZJM3P (minor,
-addressed: load-bearing comments), RR-TFUP2X (minor, addressed:
-interleaving-regression pin + import nit). Reviewer leverage notes not
-turned into findings: promote the fault-injection wrapper to storetest +
-an Nth-call failure variant (deferred — cross-package test infra, own
-change); the MCP fifth cardinality copy (already flagged to the
-architect, out of scope by recorded decision).
+RR-STCCY8 (significant, addressed: CLI-boundary error tests; double-scan hazard
+documented in-code, compute-once is the follow-up), RR-5FKMKX (significant,
+addressed: relName folded into cardinalitySpec), RR-1HB83A (minor, addressed:
+direction in the count error), RR-3ZJM3P (minor, addressed: load-bearing
+comments), RR-TFUP2X (minor, addressed: interleaving-regression pin + import
+nit). Reviewer leverage notes not turned into findings: promote the
+fault-injection wrapper to storetest + an Nth-call failure variant (deferred —
+cross-package test infra, own change); the MCP fifth cardinality copy (already
+flagged to the architect, out of scope by recorded decision).
 
 ## Acceptance Verification
 
@@ -64,8 +63,8 @@ Skip this section for bugs and internal refactors.
 
 ## Pull Request
 
-- [ ] Run `/pr` command to create PR and monitor CI
-- [ ] All CI checks pass
-- [ ] PR URL documented below
+- [x] Run `/pr` command to create PR and monitor CI
+- [x] All CI checks pass (monitored to green on PR #1381; stacked on #1378)
+- [x] PR URL documented below
 
-**PR:** <!-- e.g., https://github.com/org/repo/pull/123 -->
+**PR:** https://github.com/sourcehaven-bv/rela/pull/1381

--- a/tickets/entities/review-checklists/REV-1HTU0H.md
+++ b/tickets/entities/review-checklists/REV-1HTU0H.md
@@ -1,0 +1,71 @@
+---
+id: REV-1HTU0H
+type: review-checklist
+title: 'Review: Consolidate cardinality analyzers; stop swallowing CountRelations errors'
+status: in-progress
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Automated Checks
+
+- [x] All tests pass (`go test ./...` clean, 2026-08-19, re-run after review fixes)
+- [x] Lint clean (`just lint` 0 issues; `just arch-lint` OK; `just plimsoll` clean)
+- [x] Coverage maintained (`just coverage-check`: floors + total 77.1% >= 65% PASS; internal/analysis 76.9%)
+
+## Code Review
+
+- [x] Run `/code-review` command (invokes cranky-code-reviewer agent; reviewer also ran a 3000-case randomized differential test against the reconstructed pre-refactor functions — zero mismatches)
+- [x] All critical review-responses addressed (none found)
+- [x] All significant review-responses addressed (RR-4JWU2I, RR-STCCY8, RR-5FKMKX — all fixed)
+- [x] Self-reviewed the diff for unrelated changes (touches only internal/analysis + the three CLI call-site files)
+
+**Review Responses:**
+
+RR-4JWU2I (significant, addressed: honest godoc on the validate banner),
+RR-STCCY8 (significant, addressed: CLI-boundary error tests; double-scan
+hazard documented in-code, compute-once is the follow-up), RR-5FKMKX
+(significant, addressed: relName folded into cardinalitySpec), RR-1HB83A
+(minor, addressed: direction in the count error), RR-3ZJM3P (minor,
+addressed: load-bearing comments), RR-TFUP2X (minor, addressed:
+interleaving-regression pin + import nit). Reviewer leverage notes not
+turned into findings: promote the fault-injection wrapper to storetest +
+an Nth-call failure variant (deferred — cross-package test infra, own
+change); the MCP fifth cardinality copy (already flagged to the
+architect, out of scope by recorded decision).
+
+## Acceptance Verification
+
+- [x] Each acceptance criterion tested (reference planning checklist)
+- [x] Test evidence documented in implementation checklist
+
+**Acceptance Status:**
+
+- AC1 (identical violations/ordering/labels) — PASS: pinning tests written first against the old code, unchanged after; plus the reviewer's 3000-case differential run (zero mismatches, incl. []-not-null JSON shape).
+- AC2 (max=0 meaningful, min=0 skip) — PASS: TestCheckCardinality_BoundEdgeCases.
+- AC3 (count error fails loudly, no fabricated violations) — PASS: TestCheckCardinality_CountErrorFailsLoudly (+ AnalyzeAll propagation subtest).
+- AC4 (CLI surfaces error as command failure, no partial output) — PASS: TestAnalyzeCmds_CountErrorAborts (empty output buffer asserted for analyze cardinality + analyze all); validate path compiler-enforced + green cli tests.
+
+## Documentation (enhancements only)
+
+Skip this section for bugs and internal refactors.
+
+- [x] ~~Docs-checklist created and linked via `has-docs`~~ (N/A: refactor kind — section skipped per template; behaviour contract unchanged for users)
+- [x] ~~User-facing documentation updated~~ (N/A: no user-facing docs affected; error policy documented in godoc + ticket)
+- [x] ~~Docs-checklist marked as done~~ (N/A)
+
+**Docs Checklist:** N/A (refactor)
+
+## Final Checks
+
+- [x] Commit message explains the why, not just what
+- [x] No TODOs or FIXMEs left unaddressed
+- [x] Ready for another developer to use
+
+## Pull Request
+
+- [ ] Run `/pr` command to create PR and monitor CI
+- [ ] All CI checks pass
+- [ ] PR URL documented below
+
+**PR:** <!-- e.g., https://github.com/org/repo/pull/123 -->

--- a/tickets/entities/review-responses/RR-1HB83A.md
+++ b/tickets/entities/review-responses/RR-1HB83A.md
@@ -1,0 +1,9 @@
+---
+id: RR-1HB83A
+type: review-response
+title: Count error message did not name the direction
+finding: The wrapped error named entity and relation, but each (entity, relation) pair is counted twice — outgoing and incoming — and the message could not distinguish which count failed. In a partial backend failure that distinction is the diagnosis.
+severity: minor
+resolution: 'Error now reads `analysis: count <outgoing|incoming> "rel" relations of <id>: ...`, derived from spec.direction.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-3ZJM3P.md
+++ b/tickets/entities/review-responses/RR-3ZJM3P.md
@@ -1,0 +1,9 @@
+---
+id: RR-3ZJM3P
+type: review-response
+title: 'Load-bearing but uncommented: subjects buffering and non-nil empty slice'
+finding: (a) checkCardinality buffers every (subject, count) before emitting — deliberate, it preserves the historical min-then-max grouped ordering — but nothing said so; a future optimizer could collapse it to a single pass and silently reorder output. (b) CheckCardinality's `make([]CardinalityViolation, 0)` lost its nolint comment; the non-nil-empty initialization is what keeps JSON Details serializing as [] rather than null, and nothing recorded that.
+severity: minor
+resolution: 'Both now carry explanatory comments in internal/analysis/analysis.go: the buffering comment names the single-pass reordering hazard the pinning tests guard, and the make() carries ''// Non-nil even when empty: JSON callers serialize Details as [], not null.'' The interleaving regression itself is now also pinned by TestCheckCardinality_MinMaxGroupedAcrossTypes.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-4JWU2I.md
+++ b/tickets/entities/review-responses/RR-4JWU2I.md
@@ -1,0 +1,9 @@
+---
+id: RR-4JWU2I
+type: review-response
+title: validate.go godoc claimed abort-before-any-output; header prints first in JSON mode
+finding: runCardinalityCheck's new godoc said a store error 'aborts the check before any output is written', but the pre-existing `fmt.Println("\nChecking cardinality constraints...")` banner fires on !quiet regardless of output format — including --format json — before the error return. The comment documented a guarantee the code does not make; a reader would wrongly trust the JSON stream is clean on the error path.
+severity: significant
+resolution: 'Corrected the comment to state what is true: the error aborts before any VIOLATION output; the banner is the pre-existing plain-stdout header every validate check prints (properties/validations share the wart). Changing the banner''s format-awareness for cardinality alone would diverge from its sibling checks — left as the documented pre-existing shape rather than a one-check special case.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-5FKMKX.md
+++ b/tickets/entities/review-responses/RR-5FKMKX.md
@@ -1,0 +1,9 @@
+---
+id: RR-5FKMKX
+type: review-response
+title: checkCardinality took relName beside the spec - the world seam leaked
+finding: cardinalitySpec's godoc claims subject population, counting scope, and violation identity 'each have exactly one home', yet the relation name (the count query key) arrived as a separate parameter next to the spec while the spec only carried relationLabel (display identity). Two sources of relation truth the caller must keep in sync; a future world field would land on the spec while relName kept arriving by the side door.
+severity: significant
+resolution: Added relName to cardinalitySpec (set once per relation in CheckCardinality); checkCardinality's signature reduced to (ctx, spec, scope); countRelations reads spec.relName. The seam is now structural, not aspirational.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-STCCY8.md
+++ b/tickets/entities/review-responses/RR-STCCY8.md
@@ -1,0 +1,9 @@
+---
+id: RR-STCCY8
+type: review-response
+title: analyze all double-scans cardinality; error path untested at CLI boundary
+finding: 'AnalyzeAllCmd.Run computes AnalyzeAll (one full cardinality scan) then runAnalyzeAllSections re-runs AnalyzeCardinalityCmd (a second full scan). Pre-existing waste, but the new error channel adds a consistency hazard: a flaky backend can pass the summary scan and fail the section scan, printing a contradictory report. Additionally no CLI-layer test covered the new error returns — the assertion that pins ''no output before the error'' was missing.'
+severity: significant
+resolution: 'Added TestAnalyzeCmds_CountErrorAborts (internal/cli/analyze_test.go): a failingCountStore wired through appbuildtest.WithStore + newCLIBundles asserts, for both `analyze cardinality` and `analyze all`, that the wrapped store error is returned and the output buffer is EMPTY. The double-scan itself is pre-existing and out of ticket scope; documented in-code at the runAnalyzeAllSections cardinality call (flaky-backend disagreement hazard, compute-once as the follow-up fix).'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-TFUP2X.md
+++ b/tickets/entities/review-responses/RR-TFUP2X.md
@@ -1,0 +1,9 @@
+---
+id: RR-TFUP2X
+type: review-response
+title: Pinning suite missed the min/max interleaving regression; test import nit
+finding: 'None of the pinning tests would fail if the two emit passes were collapsed into a single count-and-emit pass: catching that requires a min AND a max violation across two subject types (grouped [A-min, B-min, C-max] vs interleaved [A-min, C-max, B-min]). Also the OrderingAndLabels godoc overclaimed (''the full per-relation contract''), and analysis_test.go aliased `stderrors "errors"` with no name collision to justify it.'
+severity: minor
+resolution: Added TestCheckCardinality_MinMaxGroupedAcrossTypes (two From types, min+max violations, asserts the grouped order a single pass would break); trimmed the OrderingAndLabels godoc claim and cross-referenced the sibling tests; switched the test file to a plain `errors` import.
+status: addressed
+---

--- a/tickets/entities/tickets/TKT-RNBLAC.md
+++ b/tickets/entities/tickets/TKT-RNBLAC.md
@@ -5,7 +5,7 @@ title: Consolidate cardinality analyzers; stop swallowing CountRelations errors
 kind: refactor
 priority: high
 effort: s
-status: review
+status: done
 ---
 
 Design doc §12.5 + §12.6 — the suggested first move; unblocks Step 5 and fixes a

--- a/tickets/entities/tickets/TKT-RNBLAC.md
+++ b/tickets/entities/tickets/TKT-RNBLAC.md
@@ -5,7 +5,7 @@ title: Consolidate cardinality analyzers; stop swallowing CountRelations errors
 kind: refactor
 priority: high
 effort: s
-status: backlog
+status: review
 ---
 
 Design doc §12.5 + §12.6 — the suggested first move; unblocks Step 5 and fixes a

--- a/tickets/relations/TKT-RNBLAC--has-implementation--IMPL-MSUOMF.md
+++ b/tickets/relations/TKT-RNBLAC--has-implementation--IMPL-MSUOMF.md
@@ -1,0 +1,5 @@
+---
+from: TKT-RNBLAC
+relation: has-implementation
+to: IMPL-MSUOMF
+---

--- a/tickets/relations/TKT-RNBLAC--has-planning--PLAN-KJ76OT.md
+++ b/tickets/relations/TKT-RNBLAC--has-planning--PLAN-KJ76OT.md
@@ -1,0 +1,5 @@
+---
+from: TKT-RNBLAC
+relation: has-planning
+to: PLAN-KJ76OT
+---

--- a/tickets/relations/TKT-RNBLAC--has-review--REV-1HTU0H.md
+++ b/tickets/relations/TKT-RNBLAC--has-review--REV-1HTU0H.md
@@ -1,0 +1,5 @@
+---
+from: TKT-RNBLAC
+relation: has-review
+to: REV-1HTU0H
+---

--- a/tickets/relations/TKT-RNBLAC--has-review-response--RR-1HB83A.md
+++ b/tickets/relations/TKT-RNBLAC--has-review-response--RR-1HB83A.md
@@ -1,0 +1,5 @@
+---
+from: TKT-RNBLAC
+relation: has-review-response
+to: RR-1HB83A
+---

--- a/tickets/relations/TKT-RNBLAC--has-review-response--RR-3ZJM3P.md
+++ b/tickets/relations/TKT-RNBLAC--has-review-response--RR-3ZJM3P.md
@@ -1,0 +1,5 @@
+---
+from: TKT-RNBLAC
+relation: has-review-response
+to: RR-3ZJM3P
+---

--- a/tickets/relations/TKT-RNBLAC--has-review-response--RR-4JWU2I.md
+++ b/tickets/relations/TKT-RNBLAC--has-review-response--RR-4JWU2I.md
@@ -1,0 +1,5 @@
+---
+from: TKT-RNBLAC
+relation: has-review-response
+to: RR-4JWU2I
+---

--- a/tickets/relations/TKT-RNBLAC--has-review-response--RR-5FKMKX.md
+++ b/tickets/relations/TKT-RNBLAC--has-review-response--RR-5FKMKX.md
@@ -1,0 +1,5 @@
+---
+from: TKT-RNBLAC
+relation: has-review-response
+to: RR-5FKMKX
+---

--- a/tickets/relations/TKT-RNBLAC--has-review-response--RR-STCCY8.md
+++ b/tickets/relations/TKT-RNBLAC--has-review-response--RR-STCCY8.md
@@ -1,0 +1,5 @@
+---
+from: TKT-RNBLAC
+relation: has-review-response
+to: RR-STCCY8
+---

--- a/tickets/relations/TKT-RNBLAC--has-review-response--RR-TFUP2X.md
+++ b/tickets/relations/TKT-RNBLAC--has-review-response--RR-TFUP2X.md
@@ -1,0 +1,5 @@
+---
+from: TKT-RNBLAC
+relation: has-review-response
+to: RR-TFUP2X
+---


### PR DESCRIPTION
Design doc §12.5+§12.6 — prerequisite for world-aware analysis (Step 5, TKT-9KZGJO).

- Collapse the four near-identical cardinality checks into one `checkCardinality` driven by a per-direction `cardinalitySpec` (subject population, count direction, bounds, labels — the single seam a future world parameter threads through). One entity scan + one count per (relation, direction) instead of two of each; min/max emitted as two passes over cached counts so output ordering is byte-identical to the old grouped order.
- Fix the swallowed `CountRelations` error (`n, _ :=`): a backend failure read as count 0, manufacturing `min_outgoing` violations out of an outage. `CheckCardinality`/`AnalyzeAll` now return an error; `analyze cardinality`, `validate --check cardinality`, and `analyze all` fail the command instead of reporting fabricated violations.
- Behaviour pinned before refactoring (ordering/labels/bound edge cases); reviewer additionally verified with a 3000-case randomized differential test against the old implementation — zero mismatches.

Stacked on #1378 (tkt-t31nkt-membership-gate) — retargets to develop when that merges.

Ticket: TKT-RNBLAC.