### PR TITLE
docs(tickets): file BUG-SDMD6O — list endpoint retains a whole type to render one page

### DIFF
--- a/tickets/entities/automated-measures/AM-list-endpoint-bounded-retention.md
+++ b/tickets/entities/automated-measures/AM-list-endpoint-bounded-retention.md
@@ -1,0 +1,48 @@
+---
+id: AM-list-endpoint-bounded-retention
+type: automated-measure
+title: "One list request's heap is bounded by page size, not by the type's entity count"
+kind: test
+location: internal/dataentry/ + internal/store/pgstore/ (test to be written with the fix)
+status: proposed
+description: "A list request over a type with N large-bodied entities must not retain N bodies to render one page. Pins BUG-SDMD6O. Must run against a REAL backend — memstore shares body strings and reports the same heap either way, which is why this defect shipped."
+---
+
+Pins BUG-SDMD6O.
+
+`GET /api/v1/<type>` over a type holding N entities with large bodies must
+retain heap proportional to **page size**, not to N.
+
+Measured baseline on current `develop` (pgstore, 5,000 x 20KB bodies, one
+request): **+101 MB** retained to render 50 rows. Header-only retention over the
+same data is **+1 MB**.
+
+## The load-bearing part: it must not run on memstore
+
+memstore hands out entities that **share** the body string rather than
+materialising a copy, so the identical probe reports **~1 MB whether or not the
+defect is present**. A memstore assertion here is not a weak test, it is a test
+that cannot fail.
+
+That is precisely why this shipped: the fast unit path is structurally blind to
+body-retention cost. The assertion belongs in the DB-gated pgstore suite
+(`RELA_TEST_DATABASE_URL`, skipped when unset), alongside the store conformance
+tests.
+
+## Assertions
+
+1. Heap growth for one list request over 5,000 x 20KB entities stays well below
+   the dataset's body size — single-digit MB, not ~100 MB.
+2. Byte-identical results before and after: same ids, same order, same `total`,
+   across AllowAll / scope-restricted / DenyAll verdicts.
+3. ACL row-gating and field redaction unchanged, asserted as **equivalence
+   against the existing `ListEntities` path** rather than hand-written
+   expectations — the pattern TKT-1ESTYJ used, and mutation-verified by removing
+   the gate and confirming failure.
+4. Callers that genuinely need bodies (export) still receive them.
+
+## Note
+
+The sibling risk is concurrency: N simultaneous list requests hold N copies. A
+concurrency variant of assertion 1 is worth adding if it can be kept cheap —
+TKT-1ESTYJ's 3-concurrent case is the precedent (6,264 MB → 55 MB).

--- a/tickets/entities/bugs/BUG-SDMD6O.md
+++ b/tickets/entities/bugs/BUG-SDMD6O.md
@@ -1,0 +1,127 @@
+---
+id: BUG-SDMD6O
+type: bug
+description: "scopedSortedEntities accumulates every entity of a type (bodies included) before handleV1ListEntities slices it to perPage. Measured 101 MB vs 1 MB on pgstore for 5000x20KB entities to render 50 rows. Invisible on memstore, which shares body strings."
+why1: One list request holds ~100 MB of entity bodies to render a 50-row page.
+why2: scopedSortedEntities returns []*entity.Entity for the whole type; pagination slices only after the pipeline returns.
+why3: Sort, filter and free-text intersection genuinely need the full SET, so the full LOAD was assumed necessary along with it — but a list row renders properties, never the body.
+why4: When EntityHeader landed (TKT-1ESTYJ) it was applied to the analyze path that motivated it; the list path has the same shape and was not revisited.
+why5: "The default test backend (memstore) shares body strings rather than materialising them, so body-retention costs ~1 MB there and ~101 MB on a real backend. The regression is structurally invisible to the fast test path, so no unit test could have caught it."
+title: GET /api/v1/<type> retains every entity of the type (bodies included) to render one page
+priority: high
+effort: m
+status: backlog
+---
+
+## Symptom
+
+`GET /api/v1/<type>` loads **every entity of that type, bodies included**, into
+one slice, then slices it to `perPage` afterwards. Rendering 50 rows of a 5,000
+-row type transfers and retains all 5,000 bodies.
+
+This is the shape that made `_analyze` an OOM (TKT-1ESTYJ), on a more frequently
+hit endpoint: the analyze fix removed whole-store retention, but the per-type
+list path still retains a whole type.
+
+## Measured
+
+Real pgstore, 5,000 entities x 20KB bodies (~97 MB), one request:
+
+| Retention | Heap |
+|---|---|
+| Whole entities (current) | **+101 MB** |
+| Headers only | **+1 MB** |
+
+A **100x** difference to render 50 rows. Cost scales with the largest single
+type and with concurrency: N simultaneous list requests hold N copies.
+
+Note memstore shows only +1 MB for the same probe — it shares body strings
+rather than materialising them, so this defect is **invisible on the default
+in-memory test path** and only appears against a real backend. That is why unit
+tests did not catch it, and it is the same blind spot that hid the analyze bug.
+
+## Root cause
+
+`internal/dataentry/api_v1.go`, `scopedSortedEntities` (~:287). Both verdict
+branches accumulate `*entity.Entity`:
+
+```go
+case rqr.AllowAll:
+    for e, err := range a.Services().Store.ListEntities(ctx, store.EntityQuery{Type: typeName}) {
+        entities = append(entities, e)      // whole entity, body included
+    }
+default:
+    for e, err := range a.Services().Store.GraphQuery(ctx, *rqr.Query) {
+        entities = append(entities, e)      // same
+    }
+```
+
+`handleV1ListEntities` (~:592) paginates only after the pipeline returns:
+
+```go
+entities, err := a.scopedSortedEntities(r.Context(), typeName, query)
+total := len(entities)
+entities = entities[start:end]              // 50 of 5000, after loading all
+```
+
+The full set is genuinely needed *as a set* — sort, filter, and free-text
+intersection all run across it, and `total` feeds the pagination envelope. What
+is NOT needed is each entity's **body**: a list row renders properties, and the
+row's body is never read.
+
+## Why this is not the analyze bug again
+
+Analyze retained the whole store; this retains one type. It is bounded by the
+largest type rather than the whole dataset, so it is less severe. But that bound
+is exactly what the scheduler leak (BUG-ZKK2UL) destroyed in production — it
+inflated one type to 11k rows. The two defects compound the same way analyze and
+the scheduler did.
+
+## Fix direction
+
+Sort/filter/count on **headers**, then load bodies only for the page.
+
+`store.EntityHeader` / `ListEntityHeaders` already exists (TKT-1ESTYJ) and
+carries id, type, properties and updated_at — everything the sort and property
+filters read. The shape becomes:
+
+1. `ListEntityHeaders` / a header-yielding `GraphQuery` for the ACL branch
+2. filter + sort + free-text intersect over headers (`total` from the count)
+3. `GetEntity`/`EntityQuery{IDs: pageIDs}` for the ~50 rows actually rendered
+
+Blockers to resolve:
+
+- **`GraphQueryer` has no header variant.** The ACL branch yields
+`*entity.Entity`. Either add a header-returning graph query or accept bodies on
+the gated path only.
+- **`visibility` header gating already exists** (`FilterHeaders`,
+`ScriptReader.ListEntityHeaders`) from TKT-1ESTYJ, so the ACL equivalence work
+is largely done and asserted against `ListEntities`.
+- **Does anything downstream read `.Content` from a list row?** Export
+(`export.go`) shares `scopedSortedEntities`; a markdown export may legitimately
+need bodies. That caller likely wants the whole-entity path retained, so the
+header path must be opt-in per caller rather than a blanket swap.
+
+## Acceptance criteria
+
+1. Heap for one list request is flat in the type's entity count, not linear:
+5,000 x 20KB renders within a few MB, not ~100 MB.
+2. `total`, sort order, filtering, and free-text results are byte-identical to
+today for every existing test.
+3. ACL row-gating and field redaction are unchanged — asserted as equivalence
+against the current path, not hand-written expectations (the TKT-1ESTYJ
+pattern).
+4. Export and any caller that genuinely needs bodies keeps them.
+5. N concurrent list requests scale in page size, not in type size.
+
+## Test plan
+
+- **Retention test against a real backend** (pgstore, DB-gated like the existing
+suite): assert heap growth for one list request is bounded well below the
+dataset's body size. Must fail on current develop.
+- **Explicitly not memstore** for that assertion — it shares body strings and
+reports ~1 MB either way, which is what let this ship.
+- Equivalence tests: same ids, same order, same `total` before/after, across
+AllowAll / scoped / DenyAll verdicts.
+- ACL equivalence asserted against `ListEntities` output, mutation-verified by
+removing the gate and confirming failure.

--- a/tickets/relations/BUG-SDMD6O--adds-measure--AM-list-endpoint-bounded-retention.md
+++ b/tickets/relations/BUG-SDMD6O--adds-measure--AM-list-endpoint-bounded-retention.md
@@ -1,0 +1,5 @@
+---
+from: BUG-SDMD6O
+relation: adds-measure
+to: AM-list-endpoint-bounded-retention
+---

--- a/tickets/relations/BUG-SDMD6O--affects--data-entry-server.md
+++ b/tickets/relations/BUG-SDMD6O--affects--data-entry-server.md
@@ -1,0 +1,5 @@
+---
+from: BUG-SDMD6O
+relation: affects
+to: data-entry-server
+---

--- a/tickets/relations/BUG-SDMD6O--affects--rest-api.md
+++ b/tickets/relations/BUG-SDMD6O--affects--rest-api.md
@@ -1,0 +1,5 @@
+---
+from: BUG-SDMD6O
+relation: affects
+to: rest-api
+---

--- a/tickets/relations/BUG-SDMD6O--fixes--FEAT-CO4YP.md
+++ b/tickets/relations/BUG-SDMD6O--fixes--FEAT-CO4YP.md
@@ -1,0 +1,5 @@
+---
+from: BUG-SDMD6O
+relation: fixes
+to: FEAT-CO4YP
+---


### PR DESCRIPTION
Ticket-only. No code changes.

Re-swept the codebase for memory hotspots after the analyze fix (#1337) and 31
subsequent commits on develop. One real finding.

## BUG-SDMD6O

`GET /api/v1/<type>` loads **every entity of that type, bodies included**, into
one slice, then slices to `perPage` afterwards.

`internal/dataentry/api_v1.go:287` (`scopedSortedEntities`) accumulates
`*entity.Entity` on both verdict branches; `handleV1ListEntities:592` paginates
only after the pipeline returns.

### Measured, not asserted

Real pgstore, 5,000 entities x 20KB bodies (~97 MB), one request:

| Retention | Heap |
|---|---|
| Whole entities (current) | **+101 MB** |
| Headers only | **+1 MB** |

100x, to render 50 rows.

### Why it shipped

**memstore shares body strings rather than materialising them**, so the same
probe reports ~1 MB whether or not the defect is present. The regression is
structurally invisible to the default unit-test path — no memstore test could
have caught it, and a memstore assertion added now would not be a weak test but
one that *cannot fail*.

My first probe made exactly this mistake and reported +1 MB. Re-running against
pgstore gave +101 MB. The measure entity records this so whoever implements the
fix doesn't repeat it.

### Relationship to the analyze bug

Same shape as TKT-1ESTYJ, one scope down: analyze retained the whole store, this
retains one type. Bounded by the largest type — but that bound is exactly what
the scheduler leak (BUG-ZKK2UL) destroyed in production by inflating one type to
11k rows. The two compound the same way analyze and the scheduler did.

### Fix direction

Sort/filter/count on headers, load bodies only for the page. `store.EntityHeader`
already carries everything the sort and property filters read. Blockers noted in
the ticket: `GraphQueryer` has no header variant, and export shares
`scopedSortedEntities` and may legitimately need bodies — so the header path
should be opt-in per caller, not a blanket swap.

Filed `backlog`, priority high, effort m, with `AM-list-endpoint-bounded-retention`
as the regression measure.

## Also checked, deliberately not filed

- `entitymanager.collectAllIDs` — already TKT-69TDK8.
- `dataentry/helpers.go` `listAllFromStore` — unbounded, but already carries a
  comment explaining it is unreachable (both callers pass exactly one type) and
  why it was left as-is. Correct call; no new ticket.
- CLI full-store scans (`export`, `graph`, `sync/diff`, `schema/validate`) —
  bounded by operator invocation, not request-driven.
- `search/index.go`, `importer` — startup/batch paths, one-shot.

## Verification

`rela validate --check cardinality --check properties --check validations` — clean.