### PR TITLE
fix(ci): cover the two remaining postgres-tagged packages (BUG-8HT4XN)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -512,20 +512,37 @@ jobs:
       # still turns a MISSING DSN into a hard failure, which is the regression
       # that actually matters.
       #
-      # internal/cli is scoped to its wiring tests rather than run whole. The
-      # package also holds render tests that shell out through internal/cmdexec,
-      # which fails closed without a working sandbox — and bubblewrap cannot set
-      # up its loopback device on this job's runner ("RTM_NEWADDR: Operation not
+      # internal/cli and internal/dataentry are scoped with -run rather than run
+      # whole. Both hold tests that shell out through internal/cmdexec, which
+      # fails closed without a working sandbox — and bubblewrap cannot set up its
+      # loopback device on this job's runner ("RTM_NEWADDR: Operation not
       # permitted"), even with the package installed, unlike the `test` job.
       # Those tests are backend-independent and already covered there; running
       # them here would gate the postgres wiring on an unrelated sandbox
       # capability. The `test` job remains the owner of full-package coverage.
+      #
+      # THE LIST BELOW MUST COVER EVERY PACKAGE WITH A postgres-TAGGED FILE.
+      # That is the rule this step exists to enforce: the original defect
+      # (BUG-3KQW7P) was tag coverage scoped to the package that motivated the
+      # tag (the store) rather than to everything the tag changes, so tagged code
+      # elsewhere compiled on every PR and never ran. Find the current set with:
+      #
+      #   grep -rl '^//go:build postgres' --include='*.go' internal/ cmd/ \
+      #     | xargs -n1 dirname | sort -u
+      #
+      # internal/dataentry earns its place: store_bridge_postgres_test.go holds
+      # TestStoreEventBridgeCrossProcessSSE, the ONLY end-to-end proof that a
+      # write in one process reaches another's SSE feed over LISTEN/NOTIFY —
+      # TKT-WZYWM9's headline feature, and the path TKT-9TOEBH changed the wire
+      # format of. Verified non-vacuous: with remote emission disabled it fails.
       - name: Run composition-root wiring tests against PostgreSQL
         run: |
           set -euo pipefail
           go test -race -tags postgres ./internal/appbuild/...
           go test -race -tags postgres -run 'TestNewMCPServices|TestMCPServices|TestMCPWatcher' \
             ./internal/cli/
+          go test -race -tags postgres -run 'TestStoreEventBridge' ./internal/dataentry/
+          go test -race -tags postgres ./internal/docscli/
 
   # Cross-compile every (GOOS, build-tag) combination GoReleaser ships so a
   # platform-specific compile break (e.g. a unix-only syscall used without a

--- a/tickets/entities/automated-measures/AM-postgres-tag-coverage-complete.md
+++ b/tickets/entities/automated-measures/AM-postgres-tag-coverage-complete.md
@@ -1,0 +1,29 @@
+---
+id: AM-postgres-tag-coverage-complete
+type: automated-measure
+title: The Postgres CI step covers every postgres-tagged package
+kind: ci
+location: .github/workflows/ci.yml (Postgres Backend → "Run composition-root wiring tests against PostgreSQL")
+status: active
+description: 'Extends AM-postgres-tagged-wiring-tests from appbuild+cli to every package holding a postgres-tagged file — adding internal/dataentry and internal/docscli, which CI compiled on every PR and never ran. The load-bearing addition is internal/dataentry: TestStoreEventBridgeCrossProcessSSE is the only end-to-end proof that a write in one process reaches another process''s SSE feed over LISTEN/NOTIFY (TKT-WZYWM9), on the payload path TKT-9TOEBH rewrote. Verified non-vacuous by mutation: with l.store.emit(fe.ev) removed from the pgstore listener, the step fails in 5.2s; unmutated it passes under -race. The step carries the enumerating grep inline so a future tagged package is visibly in or out of the list rather than silently omitted.'
+---
+
+## What it catches
+
+A regression in cross-process change delivery — the LISTEN/NOTIFY path behind
+live-reload in a multi-process postgres deployment. Before this, that path had
+**no** CI coverage at any level: the only test exercising it is postgres-tagged,
+and no job ran tagged tests outside `pgstore` and (since BUG-3KQW7P)
+`appbuild`/`cli`.
+
+## Known limitation
+
+The completeness property — "the step's package list equals the set of
+postgres-tagged packages" — is enforced by a documented invariant and an inline
+grep recipe, **not** by an executing check. A new tagged package still relies on
+its author reading the comment.
+
+A guard test comparing the two sets would close that, but it needs a home
+outside any tagged package (it must run on the default build to be useful) and
+would have to parse the workflow YAML. Deliberately not built here; recorded on
+BUG-8HT4XN as the stronger follow-up rather than pretended.

--- a/tickets/entities/bugs/BUG-8HT4XN.md
+++ b/tickets/entities/bugs/BUG-8HT4XN.md
@@ -1,0 +1,67 @@
+---
+id: BUG-8HT4XN
+type: bug
+title: 'Postgres CI misses two tagged packages; the cross-process SSE test has never run'
+priority: medium
+description: 'BUG-3KQW7P added a Postgres-job step for internal/appbuild and internal/cli, but two packages with postgres-tagged files were left out: internal/dataentry and internal/docscli. The dataentry one matters — store_bridge_postgres_test.go holds TestStoreEventBridgeCrossProcessSSE, the only end-to-end proof that a write in one process reaches another process''s SSE feed over LISTEN/NOTIFY (TKT-WZYWM9''s headline feature, and the path TKT-9TOEBH changed the wire format of). CI compiled it on every PR and never ran it. Both packages pass today, so nothing is broken; the defect is the missing gate. Fixed by extending the existing step to cover every postgres-tagged package, with the enumerating grep recorded inline so the list cannot silently fall behind again.'
+status: done
+why1: 'internal/dataentry and internal/docscli contain postgres-tagged files that no CI job executes.'
+why2: 'The Postgres job runs pgstore plus the appbuild/cli step added by BUG-3KQW7P — a list that never included them.'
+why3: 'BUG-3KQW7P was scoped to the packages whose tests were observed failing, rather than to every package the build tag changes.'
+why4: 'The failing tests were the visible symptom; the two packages here compile and pass under the tag, so they produced no signal to scope toward.'
+why5: 'Both this and BUG-3KQW7P share one systemic cause: CI coverage for a build tag is maintained as a hand-written package list with nothing tying it to the actual set of tagged files, so the list drifts silently as tagged code spreads.'
+prevention: 'The step now documents the invariant (must cover every postgres-tagged package) and embeds the grep that enumerates the current set, so the next person extending the tag has the check in front of them. A test-level guard that fails when the two sets diverge is the stronger fix — deliberately not built here, since it needs a home outside any tagged package; recorded as the follow-up.'
+---
+
+## Description
+
+Follow-up to BUG-3KQW7P, found by asking the question that bug's root cause
+implies: *which packages actually have postgres-tagged files?*
+
+```
+$ grep -rl '^//go:build postgres' --include='*.go' internal/ cmd/ \
+    | xargs -n1 dirname | sort -u
+internal/appbuild
+internal/appbuild/backendtest
+internal/cli
+internal/dataentry      <-- not in CI
+internal/docscli        <-- not in CI
+internal/store/pgstore
+```
+
+Both pass locally, so **nothing is broken today**. The defect is the absent
+gate, which is what let BUG-3KQW7P's 13 failures accumulate unnoticed.
+
+## Why internal/dataentry is the one that matters
+
+`store_bridge_postgres_test.go` contains `TestStoreEventBridgeCrossProcessSSE`
+— the only end-to-end assertion that a write committed by one process reaches
+a *different* process's SSE feed via `LISTEN/NOTIFY`. That is the headline of
+TKT-WZYWM9, and TKT-9TOEBH later changed that payload's wire format.
+
+The test is sound; it simply never ran. Verified non-vacuous rather than
+assumed: with `l.store.emit(fe.ev)` removed from the listener, it fails in
+5.2s. (Two other mutations — swapping `kind`/`op` in the payload, dropping the
+self-echo filter — correctly pass: the field swap is symmetric across encoder
+and decoder, and self-echo is *local* double-emission, which a two-store test
+cannot observe by construction.)
+
+`internal/docscli`'s tagged file is a 19-line capturer; it is included for
+completeness, not because it carries comparable risk.
+
+## Fix
+
+Extend the existing wiring step rather than adding a parallel one, so the
+"cover every tagged package" rule lives in one place:
+
+```yaml
+go test -race -tags postgres -run 'TestStoreEventBridge' ./internal/dataentry/
+go test -race -tags postgres ./internal/docscli/
+```
+
+`internal/dataentry` is `-run`-scoped for the same reason `internal/cli`
+already is: the full package needs the command sandbox, and this job's runner
+cannot create bubblewrap's loopback device. Those tests are backend-independent
+and the `test` job owns them.
+
+Adds ~14s to the job.

--- a/tickets/entities/review-checklists/REV-8HT4XN.md
+++ b/tickets/entities/review-checklists/REV-8HT4XN.md
@@ -67,4 +67,4 @@ follow-up on BUG-8HT4XN instead of being half-built here.
 - [x] PR created and CI monitored
 - [x] PR URL documented below
 
-**PR:** (filled in on creation)
+**PR:** https://github.com/sourcehaven-bv/rela/pull/1383

--- a/tickets/entities/review-checklists/REV-8HT4XN.md
+++ b/tickets/entities/review-checklists/REV-8HT4XN.md
@@ -1,0 +1,70 @@
+---
+id: REV-8HT4XN
+type: review-checklist
+title: 'Review: Postgres CI misses two tagged packages; the cross-process SSE test has never run'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Automated Checks
+
+- [x] All tests pass — all four commands in the extended step green under `-race` against PostgreSQL 15; full default suite green
+- [x] Lint clean — `golangci-lint run ./...` and `--build-tags postgres ./...` both 0 issues; `just arch-lint` OK
+- [x] Coverage maintained — `just coverage-check` exit 0 (no Go source changed; workflow + tickets only)
+
+## Code Review
+
+- [x] Self-reviewed the diff — one workflow step extended by two lines plus explanatory comment; no Go source changes
+- [x] ~~All critical review-responses addressed~~ (none raised)
+- [x] ~~All significant review-responses addressed~~ (none raised)
+
+**Checked for duplicate work before opening:** all 9 open PRs listed (none touch
+CI or the postgres tag), the Postgres job on current `origin/develop` inspected
+directly, and the ticket corpus grepped for the affected packages. `RR-9ZB7ZO`
+matched on "postgres-tagged" but concerns benchmark comments — unrelated.
+
+## Acceptance Verification
+
+- [x] Each acceptance criterion tested
+- [x] Test evidence documented
+
+| Claim | Evidence |
+|---|---|
+| Two tagged packages were uncovered | `grep -rl '^//go:build postgres'` yields 6 packages; the job ran 4 |
+| List is now complete | re-ran the grep against the patched step: every tagged package covered (`appbuild/...` subsumes `backendtest`; `pgstore` has its own step) |
+| New coverage catches a real regression | removed `l.store.emit(fe.ev)` → `TestStoreEventBridgeCrossProcessSSE` FAILS in 5.2s |
+| Nothing was actually broken | all four commands pass unmutated under `-race` |
+| Cost is acceptable | ~14s added to the job |
+
+**A correction worth recording.** My first mutation runs appeared to pass and I
+initially read the test as vacuous. That was Go serving cached results: re-run
+with `-count=1`, the emit-disabled mutation fails as it should. Two further
+mutations (swapping `kind`/`op`; dropping the self-echo filter) genuinely do
+pass, and correctly so — the field swap is symmetric across encoder and decoder,
+and self-echo is *local* double-emission, which a two-store test cannot observe.
+The test is sound; only its absence from CI was the defect.
+
+## Documentation (enhancements only)
+
+- [x] ~~User-facing documentation updated~~ (N/A: CI-only change, no user-visible surface)
+- [x] ~~Docs-checklist created~~ (N/A: not an enhancement or docs ticket)
+
+## Final Checks
+
+- [x] Commit message explains the why (same systemic cause as BUG-3KQW7P: a hand-maintained package list with nothing tying it to the tagged-file set)
+- [x] No TODOs or FIXMEs left unaddressed
+- [x] Ready for another developer to use — the enumerating grep is in the workflow comment
+
+**Known limitation, stated rather than papered over:** completeness is enforced
+by a documented invariant and an inline grep, not an executing check. A guard
+test comparing the two sets is the stronger fix; it needs a home outside any
+tagged package and must parse the workflow YAML, so it is recorded as a
+follow-up on BUG-8HT4XN instead of being half-built here.
+
+## Pull Request
+
+- [x] PR created and CI monitored
+- [x] PR URL documented below
+
+**PR:** (filled in on creation)

--- a/tickets/relations/BUG-8HT4XN--adds-measure--AM-postgres-tag-coverage-complete.md
+++ b/tickets/relations/BUG-8HT4XN--adds-measure--AM-postgres-tag-coverage-complete.md
@@ -1,0 +1,5 @@
+---
+from: BUG-8HT4XN
+relation: adds-measure
+to: AM-postgres-tag-coverage-complete
+---

--- a/tickets/relations/BUG-8HT4XN--affects--ci-pipeline.md
+++ b/tickets/relations/BUG-8HT4XN--affects--ci-pipeline.md
@@ -1,0 +1,5 @@
+---
+from: BUG-8HT4XN
+relation: affects
+to: ci-pipeline
+---

--- a/tickets/relations/BUG-8HT4XN--affects--store-backends.md
+++ b/tickets/relations/BUG-8HT4XN--affects--store-backends.md
@@ -1,0 +1,5 @@
+---
+from: BUG-8HT4XN
+relation: affects
+to: store-backends
+---

--- a/tickets/relations/BUG-8HT4XN--affects--test-fixtures.md
+++ b/tickets/relations/BUG-8HT4XN--affects--test-fixtures.md
@@ -1,0 +1,5 @@
+---
+from: BUG-8HT4XN
+relation: affects
+to: test-fixtures
+---

--- a/tickets/relations/BUG-8HT4XN--fixes--FEAT-GE1YY.md
+++ b/tickets/relations/BUG-8HT4XN--fixes--FEAT-GE1YY.md
@@ -1,0 +1,5 @@
+---
+from: BUG-8HT4XN
+relation: fixes
+to: FEAT-GE1YY
+---

--- a/tickets/relations/BUG-8HT4XN--has-review--REV-8HT4XN.md
+++ b/tickets/relations/BUG-8HT4XN--has-review--REV-8HT4XN.md
@@ -1,0 +1,5 @@
+---
+from: BUG-8HT4XN
+relation: has-review
+to: REV-8HT4XN
+---


### PR DESCRIPTION
Follow-up to #1362 (BUG-3KQW7P), found by asking the question that bug's root cause implies: *which packages actually have postgres-tagged files?*

```
$ grep -rl '^//go:build postgres' --include='*.go' internal/ cmd/ | xargs -n1 dirname | sort -u
internal/appbuild
internal/appbuild/backendtest
internal/cli
internal/dataentry      <-- compiled every PR, never run
internal/docscli        <-- compiled every PR, never run
internal/store/pgstore
```

#1362 covered `appbuild` and `cli` — the packages whose tests were observed failing. These two compile and pass under the tag, so they produced no symptom to scope toward, and were missed.

**Both pass today, so nothing is broken.** The defect is the absent gate — the same one that let #1362's 13 failures accumulate unnoticed.

## Why `internal/dataentry` matters

`store_bridge_postgres_test.go` holds `TestStoreEventBridgeCrossProcessSSE` — the **only** end-to-end assertion that a write committed by one process reaches a *different* process's SSE feed over `LISTEN/NOTIFY`.

That is TKT-WZYWM9's headline feature, and **TKT-9TOEBH (#1322) changed that payload's wire format**. The one test covering that path end-to-end has never executed in CI.

`internal/docscli`'s tagged file is a 19-line capturer — included for completeness, not comparable risk.

## Verified non-vacuous

I checked the test actually proves something rather than assuming it:

| Mutation | Result | Why |
|---|---|---|
| Remove `l.store.emit(fe.ev)` | **FAILS (5.2s)** | genuinely proves cross-process delivery |
| Swap `kind`/`op` in payload | passes | symmetric — encoder and decoder share field order |
| Drop self-echo filter | passes | self-echo is *local* double-emission; a two-store test can't observe it |

The latter two are correct passes, not weaknesses. The test is sound; only its absence from CI was the defect.

*One correction on my own process:* my first mutation runs appeared to pass and I initially read the test as vacuous. That was Go serving cached results — `-count=1` gives the real answer, recorded above.

## The change

Extends the existing step rather than adding a parallel one, so the "cover every tagged package" rule lives in one place:

```yaml
go test -race -tags postgres -run 'TestStoreEventBridge' ./internal/dataentry/
go test -race -tags postgres ./internal/docscli/
```

`dataentry` is `-run`-scoped for the same reason `cli` already is: the full package needs the command sandbox, and this job's runner cannot create bubblewrap's loopback device. Those tests are backend-independent; the `test` job owns them.

The enumerating grep is recorded in the step's comment so the list is visibly in or out of date rather than silently stale.

**Cost:** ~14s.

## Known limitation, stated rather than papered over

Completeness is enforced by a documented invariant and an inline grep, **not** an executing check. A new tagged package still relies on its author reading the comment.

A guard test comparing the two sets would close that, but it needs a home outside any tagged package (it must run on the default build) and would have to parse the workflow YAML. Deliberately not built here — recorded on BUG-8HT4XN as the stronger follow-up. Happy to do it if you'd rather have it now.

## Verification

| Check | Result |
|---|---|
| All four step commands, `-race`, live PostgreSQL 15 | pass |
| New line vs. broken cross-process delivery | fails as intended |
| Full default suite | green |
| Lint, default + `-tags postgres` | 0 issues each |
| `arch-lint`, `coverage-check` | pass |
| `rela validate` (cardinality/properties/validations) | all pass |

No Go source changed — workflow and ticket entities only.

**Checked for duplicate work first:** all 9 open PRs (none touch CI or the postgres tag), the job on current `origin/develop`, and the ticket corpus.