### PR TITLE
🌍 feat(store): typed state references — entity.Pointer, codec, fs/mem backends, storetest contract (TKT-DOFYR1 PR-A)

### DIFF
--- a/internal/analysis/analysis.go
+++ b/internal/analysis/analysis.go
@@ -328,144 +328,150 @@ func (s *Service) FindGaps(ctx context.Context, opts Options) []GapResult {
 
 // --- Cardinality analysis ---
 
+// cardinalitySpec is one direction of a relation's cardinality
+// constraints: the subject population (which entity types are checked),
+// the count direction, the min/max bounds with their constraint labels,
+// and the relation label reported on violations (the inverse id for the
+// incoming side, when declared).
+//
+// This is the single seam world-awareness (TKT-9KZGJO) will thread
+// through: subject population, counting scope, and violation identity
+// each have exactly one home — the spec, [Service.countRelations], and
+// the two emit passes in [Service.checkCardinality] (TKT-RNBLAC).
+type cardinalitySpec struct {
+	relName       string // metamodel relation name — the count query key
+	direction     store.Direction
+	subjectTypes  []string // relDef.From (outgoing) / relDef.To (incoming)
+	minBound      *int     // nil or 0 disables the min check
+	maxBound      *int     // nil disables the max check; 0 forbids any edge
+	minConstraint string
+	maxConstraint string
+	relationLabel string // violation display label; inverse id on the incoming side
+}
+
 // CheckCardinality checks all cardinality constraints, filtered by
 // scope.
-func (s *Service) CheckCardinality(ctx context.Context, opts Options) []CardinalityViolation {
-	violations := make([]CardinalityViolation, 0) //nolint:prealloc // capacity unknown
+//
+// A store error fails the run loudly: the first failing count aborts
+// with a wrapped error and NO violations. Reporting around a failed
+// count would fabricate violations — a backend outage reads as count 0,
+// which for a min bound looks exactly like missing relations
+// (TKT-RNBLAC). This deliberately diverges from the under-count logging
+// of the other analyses (see [Service.FindOrphansWithScope]): those can
+// only miss findings, a failed count invents them.
+func (s *Service) CheckCardinality(ctx context.Context, opts Options) ([]CardinalityViolation, error) {
+	// Non-nil even when empty: JSON callers serialize Details as [], not null.
+	violations := make([]CardinalityViolation, 0)
 
 	for relName, relDef := range s.deps.Meta.Relations {
-		violations = append(violations, s.checkMinOutgoing(ctx, relName, relDef, opts.Scope)...)
-		violations = append(violations, s.checkMaxOutgoing(ctx, relName, relDef, opts.Scope)...)
-		violations = append(violations, s.checkMinIncoming(ctx, relName, relDef, opts.Scope)...)
-		violations = append(violations, s.checkMaxIncoming(ctx, relName, relDef, opts.Scope)...)
+		incomingLabel := relName
+		if relDef.Inverse != nil && relDef.Inverse.GetID() != "" {
+			incomingLabel = relDef.Inverse.GetID()
+		}
+		specs := [2]cardinalitySpec{
+			{
+				relName: relName, direction: store.DirectionOutgoing, subjectTypes: relDef.From,
+				minBound: relDef.MinOutgoing, maxBound: relDef.MaxOutgoing,
+				minConstraint: "min_outgoing", maxConstraint: "max_outgoing",
+				relationLabel: relName,
+			},
+			{
+				relName: relName, direction: store.DirectionIncoming, subjectTypes: relDef.To,
+				minBound: relDef.MinIncoming, maxBound: relDef.MaxIncoming,
+				minConstraint: "min_incoming", maxConstraint: "max_incoming",
+				relationLabel: incomingLabel,
+			},
+		}
+		for _, spec := range specs {
+			v, err := s.checkCardinality(ctx, spec, opts.Scope)
+			if err != nil {
+				return nil, err
+			}
+			violations = append(violations, v...)
+		}
 	}
-	return violations
+	return violations, nil
 }
 
-func (s *Service) checkMinOutgoing(
-	ctx context.Context, relName string, relDef metamodel.RelationDef, scope map[string]bool,
-) []CardinalityViolation {
-	if relDef.MinOutgoing == nil || *relDef.MinOutgoing == 0 {
-		return nil
+// checkCardinality evaluates one direction of one relation. Each
+// subject is scanned and counted once; min violations are then emitted
+// before max violations (two passes over the cached counts) so the
+// output order matches the historical per-constraint grouping.
+func (s *Service) checkCardinality(
+	ctx context.Context, spec cardinalitySpec, scope map[string]bool,
+) ([]CardinalityViolation, error) {
+	minActive := spec.minBound != nil && *spec.minBound > 0
+	maxActive := spec.maxBound != nil
+	if !minActive && !maxActive {
+		return nil, nil
 	}
-	var violations []CardinalityViolation
-	for _, sourceType := range relDef.From {
-		entities := collectEntities(ctx, s.deps.Store, store.EntityQuery{Type: sourceType})
+	dirWord := "outgoing"
+	if spec.direction == store.DirectionIncoming {
+		dirWord = "incoming"
+	}
+
+	// Buffering every (subject, count) before emitting is deliberate: the
+	// two emit passes below reproduce the historical min-then-max grouped
+	// ordering. Collapsing this into a single count-and-emit pass would
+	// interleave min and max violations and reorder the output the
+	// pinning tests guard.
+	type subject struct {
+		id    string
+		count int
+	}
+	var subjects []subject
+	for _, subjectType := range spec.subjectTypes {
+		entities := collectEntities(ctx, s.deps.Store, store.EntityQuery{Type: subjectType})
 		for _, e := range filterByScope(entities, scope) {
-			count := s.countOutgoingByType(ctx, e.ID, relName)
-			if count < *relDef.MinOutgoing {
+			count, err := s.countRelations(ctx, e.ID, spec.relName, spec.direction)
+			if err != nil {
+				return nil, fmt.Errorf("analysis: count %s %q relations of %s: %w", dirWord, spec.relName, e.ID, err)
+			}
+			subjects = append(subjects, subject{id: e.ID, count: count})
+		}
+	}
+
+	var violations []CardinalityViolation
+	if minActive {
+		for _, sub := range subjects {
+			if sub.count < *spec.minBound {
 				violations = append(violations, CardinalityViolation{
-					EntityID:     e.ID,
-					RelationType: relName,
-					Constraint:   "min_outgoing",
-					Required:     *relDef.MinOutgoing,
-					Actual:       count,
+					EntityID:     sub.id,
+					RelationType: spec.relationLabel,
+					Constraint:   spec.minConstraint,
+					Required:     *spec.minBound,
+					Actual:       sub.count,
 				})
 			}
 		}
 	}
-	return violations
-}
-
-func (s *Service) checkMaxOutgoing(
-	ctx context.Context, relName string, relDef metamodel.RelationDef, scope map[string]bool,
-) []CardinalityViolation {
-	if relDef.MaxOutgoing == nil {
-		return nil
-	}
-	var violations []CardinalityViolation
-	for _, sourceType := range relDef.From {
-		entities := collectEntities(ctx, s.deps.Store, store.EntityQuery{Type: sourceType})
-		for _, e := range filterByScope(entities, scope) {
-			count := s.countOutgoingByType(ctx, e.ID, relName)
-			if count > *relDef.MaxOutgoing {
+	if maxActive {
+		for _, sub := range subjects {
+			if sub.count > *spec.maxBound {
 				violations = append(violations, CardinalityViolation{
-					EntityID:     e.ID,
-					RelationType: relName,
-					Constraint:   "max_outgoing",
-					Required:     *relDef.MaxOutgoing,
-					Actual:       count,
+					EntityID:     sub.id,
+					RelationType: spec.relationLabel,
+					Constraint:   spec.maxConstraint,
+					Required:     *spec.maxBound,
+					Actual:       sub.count,
 				})
 			}
 		}
 	}
-	return violations
+	return violations, nil
 }
 
-func (s *Service) checkMinIncoming(
-	ctx context.Context, relName string, relDef metamodel.RelationDef, scope map[string]bool,
-) []CardinalityViolation {
-	if relDef.MinIncoming == nil || *relDef.MinIncoming == 0 {
-		return nil
-	}
-	var violations []CardinalityViolation
-	for _, targetType := range relDef.To {
-		entities := collectEntities(ctx, s.deps.Store, store.EntityQuery{Type: targetType})
-		for _, e := range filterByScope(entities, scope) {
-			count := s.countIncomingByType(ctx, e.ID, relName)
-			if count < *relDef.MinIncoming {
-				relLabel := relName
-				if relDef.Inverse != nil && relDef.Inverse.GetID() != "" {
-					relLabel = relDef.Inverse.GetID()
-				}
-				violations = append(violations, CardinalityViolation{
-					EntityID:     e.ID,
-					RelationType: relLabel,
-					Constraint:   "min_incoming",
-					Required:     *relDef.MinIncoming,
-					Actual:       count,
-				})
-			}
-		}
-	}
-	return violations
-}
-
-func (s *Service) checkMaxIncoming(
-	ctx context.Context, relName string, relDef metamodel.RelationDef, scope map[string]bool,
-) []CardinalityViolation {
-	if relDef.MaxIncoming == nil {
-		return nil
-	}
-	var violations []CardinalityViolation
-	for _, targetType := range relDef.To {
-		entities := collectEntities(ctx, s.deps.Store, store.EntityQuery{Type: targetType})
-		for _, e := range filterByScope(entities, scope) {
-			count := s.countIncomingByType(ctx, e.ID, relName)
-			if count > *relDef.MaxIncoming {
-				relLabel := relName
-				if relDef.Inverse != nil && relDef.Inverse.GetID() != "" {
-					relLabel = relDef.Inverse.GetID()
-				}
-				violations = append(violations, CardinalityViolation{
-					EntityID:     e.ID,
-					RelationType: relLabel,
-					Constraint:   "max_incoming",
-					Required:     *relDef.MaxIncoming,
-					Actual:       count,
-				})
-			}
-		}
-	}
-	return violations
-}
-
-func (s *Service) countOutgoingByType(ctx context.Context, entityID, relName string) int {
-	n, _ := s.deps.Store.CountRelations(ctx, store.RelationQuery{
+// countRelations counts an entity's relations of one type in one
+// direction. Errors propagate — see the [Service.CheckCardinality]
+// error policy.
+func (s *Service) countRelations(
+	ctx context.Context, entityID, relName string, direction store.Direction,
+) (int, error) {
+	return s.deps.Store.CountRelations(ctx, store.RelationQuery{
 		EntityID:  entityID,
-		Direction: store.DirectionOutgoing,
+		Direction: direction,
 		Type:      relName,
 	})
-	return n
-}
-
-func (s *Service) countIncomingByType(ctx context.Context, entityID, relName string) int {
-	n, _ := s.deps.Store.CountRelations(ctx, store.RelationQuery{
-		EntityID:  entityID,
-		Direction: store.DirectionIncoming,
-		Type:      relName,
-	})
-	return n
 }
 
 // --- Custom validations ---
@@ -529,14 +535,20 @@ func CountValidationsBySeverity(violations []ValidationViolation) (errors, warni
 
 // --- Summary ---
 
-// AnalyzeAll runs all analyses and returns a summary of counts.
-func (s *Service) AnalyzeAll(ctx context.Context, opts Options) *Summary {
+// AnalyzeAll runs all analyses and returns a summary of counts. A
+// cardinality store error fails the whole run — see the
+// [Service.CheckCardinality] error policy.
+func (s *Service) AnalyzeAll(ctx context.Context, opts Options) (*Summary, error) {
+	cardinality, err := s.CheckCardinality(ctx, opts)
+	if err != nil {
+		return nil, err
+	}
 	summary := &Summary{
 		Orphans:          len(s.FindOrphansWithScope(ctx, opts)),
 		Duplicates:       len(s.FindDuplicates(ctx, opts)),
 		UniqueViolations: len(s.FindUniqueViolations(ctx, opts)),
 		Gaps:             len(s.FindGaps(ctx, opts)),
-		Cardinality:      len(s.CheckCardinality(ctx, opts)),
+		Cardinality:      len(cardinality),
 	}
 
 	for _, pe := range schema.ValidateEntityProperties(ctx, s.deps.Store, s.deps.Meta) {
@@ -551,7 +563,7 @@ func (s *Service) AnalyzeAll(ctx context.Context, opts Options) *Summary {
 	summary.ValidationScriptErrors = len(result.ScriptErrors)
 	summary.ValidationLoadErrors = len(result.LoadErrors)
 
-	return summary
+	return summary, nil
 }
 
 // --- Orphan temp files ---

--- a/internal/analysis/analysis_test.go
+++ b/internal/analysis/analysis_test.go
@@ -2,6 +2,7 @@ package analysis_test
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"testing"
 
@@ -220,7 +221,10 @@ func TestCheckCardinality(t *testing.T) {
 	})
 
 	t.Run("finds violations", func(t *testing.T) {
-		violations := svc.CheckCardinality(context.Background(), analysis.Options{})
+		violations, err := svc.CheckCardinality(context.Background(), analysis.Options{})
+		if err != nil {
+			t.Fatalf("CheckCardinality: %v", err)
+		}
 		if len(violations) != 1 {
 			t.Errorf("got %d violations, want 1", len(violations))
 		}
@@ -235,11 +239,297 @@ func TestCheckCardinality(t *testing.T) {
 	})
 
 	t.Run("scope filters violations", func(t *testing.T) {
-		violations := svc.CheckCardinality(context.Background(), analysis.Options{
+		violations, err := svc.CheckCardinality(context.Background(), analysis.Options{
 			Scope: map[string]bool{"TKT-001": true},
 		})
+		if err != nil {
+			t.Fatalf("CheckCardinality: %v", err)
+		}
 		if len(violations) != 0 {
 			t.Errorf("got %d violations, want 0", len(violations))
+		}
+	})
+}
+
+// TestCheckCardinality_OrderingAndLabels pins the per-relation contract
+// before the TKT-RNBLAC consolidation: min-then-max ordering, outgoing
+// block before incoming block, the constraint strings, the
+// Required/Actual values, and the incoming-side inverse label. The
+// expectations were captured against the four pre-consolidation check
+// functions and must not change. Multi-type ordering is pinned by
+// TestCheckCardinality_MultipleSourceTypes and the pass-grouping by
+// TestCheckCardinality_MinMaxGroupedAcrossTypes.
+func TestCheckCardinality_OrderingAndLabels(t *testing.T) {
+	one := 1
+
+	meta := &metamodel.Metamodel{
+		Entities: map[string]metamodel.EntityDef{
+			"ticket":  {Label: "Ticket", IDPrefixes: []string{"TKT-"}},
+			"concept": {Label: "Concept", IDPrefixes: []string{"CON-"}},
+		},
+		Relations: map[string]metamodel.RelationDef{
+			"depends": {
+				Label:       "depends",
+				From:        []string{"ticket"},
+				To:          []string{"concept"},
+				MinOutgoing: &one,
+				MaxOutgoing: &one,
+				MinIncoming: &one,
+				MaxIncoming: &one,
+				Inverse:     &metamodel.InverseDef{ID: "needed-by"},
+			},
+		},
+	}
+
+	svc := newServiceWith(t, meta, func(s store.Store) {
+		addEntity(s, "TKT-A", "ticket", nil) // 0 outgoing → min_outgoing
+		addEntity(s, "TKT-B", "ticket", nil) // 2 outgoing → max_outgoing
+		addEntity(s, "TKT-C", "ticket", nil) // 1 outgoing → ok
+		addEntity(s, "CON-X", "concept", nil)
+		addEntity(s, "CON-Y", "concept", nil) // 2 incoming → max_incoming
+		addEntity(s, "CON-Z", "concept", nil) // 0 incoming → min_incoming
+		addRelation(s, "TKT-B", "depends", "CON-X")
+		addRelation(s, "TKT-B", "depends", "CON-Y")
+		addRelation(s, "TKT-C", "depends", "CON-Y")
+	})
+
+	got, err := svc.CheckCardinality(context.Background(), analysis.Options{})
+	if err != nil {
+		t.Fatalf("CheckCardinality: %v", err)
+	}
+
+	want := []analysis.CardinalityViolation{
+		{EntityID: "TKT-A", RelationType: "depends", Constraint: "min_outgoing", Required: 1, Actual: 0},
+		{EntityID: "TKT-B", RelationType: "depends", Constraint: "max_outgoing", Required: 1, Actual: 2},
+		// Incoming violations report the inverse label when declared.
+		{EntityID: "CON-Z", RelationType: "needed-by", Constraint: "min_incoming", Required: 1, Actual: 0},
+		{EntityID: "CON-Y", RelationType: "needed-by", Constraint: "max_incoming", Required: 1, Actual: 2},
+	}
+	if len(got) != len(want) {
+		t.Fatalf("got %d violations, want %d: %+v", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("violation[%d] = %+v, want %+v", i, got[i], want[i])
+		}
+	}
+}
+
+// TestCheckCardinality_BoundEdgeCases pins the min/max asymmetry: an
+// explicit 0 minimum is a skip (nothing can violate it), while an
+// explicit 0 maximum is a real constraint (any edge violates it).
+func TestCheckCardinality_BoundEdgeCases(t *testing.T) {
+	zero := 0
+
+	t.Run("max zero is enforced", func(t *testing.T) {
+		meta := &metamodel.Metamodel{
+			Entities: map[string]metamodel.EntityDef{
+				"ticket":  {Label: "Ticket", IDPrefixes: []string{"TKT-"}},
+				"concept": {Label: "Concept", IDPrefixes: []string{"CON-"}},
+			},
+			Relations: map[string]metamodel.RelationDef{
+				"depends": {
+					From: []string{"ticket"}, To: []string{"concept"},
+					MaxOutgoing: &zero,
+				},
+			},
+		}
+		svc := newServiceWith(t, meta, func(s store.Store) {
+			addEntity(s, "TKT-A", "ticket", nil)
+			addEntity(s, "CON-X", "concept", nil)
+			addRelation(s, "TKT-A", "depends", "CON-X")
+		})
+		got, err := svc.CheckCardinality(context.Background(), analysis.Options{})
+		if err != nil {
+			t.Fatalf("CheckCardinality: %v", err)
+		}
+		want := []analysis.CardinalityViolation{
+			{EntityID: "TKT-A", RelationType: "depends", Constraint: "max_outgoing", Required: 0, Actual: 1},
+		}
+		if len(got) != 1 || got[0] != want[0] {
+			t.Errorf("got %+v, want %+v", got, want)
+		}
+	})
+
+	t.Run("min zero is skipped", func(t *testing.T) {
+		meta := &metamodel.Metamodel{
+			Entities: map[string]metamodel.EntityDef{
+				"ticket":  {Label: "Ticket", IDPrefixes: []string{"TKT-"}},
+				"concept": {Label: "Concept", IDPrefixes: []string{"CON-"}},
+			},
+			Relations: map[string]metamodel.RelationDef{
+				"depends": {
+					From: []string{"ticket"}, To: []string{"concept"},
+					MinOutgoing: &zero,
+				},
+			},
+		}
+		svc := newServiceWith(t, meta, func(s store.Store) {
+			addEntity(s, "TKT-A", "ticket", nil) // 0 outgoing, but min is 0
+		})
+		got, err := svc.CheckCardinality(context.Background(), analysis.Options{})
+		if err != nil {
+			t.Fatalf("CheckCardinality: %v", err)
+		}
+		if len(got) != 0 {
+			t.Errorf("got %d violations, want 0: %+v", len(got), got)
+		}
+	})
+}
+
+// TestCheckCardinality_MultipleSourceTypes pins the ordering across a
+// relation's From types: subjects are visited in From-list order.
+func TestCheckCardinality_MultipleSourceTypes(t *testing.T) {
+	one := 1
+	meta := &metamodel.Metamodel{
+		Entities: map[string]metamodel.EntityDef{
+			"bug":     {Label: "Bug", IDPrefixes: []string{"BUG-"}},
+			"ticket":  {Label: "Ticket", IDPrefixes: []string{"TKT-"}},
+			"concept": {Label: "Concept", IDPrefixes: []string{"CON-"}},
+		},
+		Relations: map[string]metamodel.RelationDef{
+			"affects": {
+				From: []string{"ticket", "bug"}, To: []string{"concept"},
+				MinOutgoing: &one,
+			},
+		},
+	}
+	svc := newServiceWith(t, meta, func(s store.Store) {
+		addEntity(s, "BUG-1", "bug", nil)
+		addEntity(s, "TKT-1", "ticket", nil)
+	})
+	got, err := svc.CheckCardinality(context.Background(), analysis.Options{})
+	if err != nil {
+		t.Fatalf("CheckCardinality: %v", err)
+	}
+	// From-list order (ticket before bug), not ID order.
+	want := []analysis.CardinalityViolation{
+		{EntityID: "TKT-1", RelationType: "affects", Constraint: "min_outgoing", Required: 1, Actual: 0},
+		{EntityID: "BUG-1", RelationType: "affects", Constraint: "min_outgoing", Required: 1, Actual: 0},
+	}
+	if len(got) != len(want) {
+		t.Fatalf("got %d violations, want %d: %+v", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("violation[%d] = %+v, want %+v", i, got[i], want[i])
+		}
+	}
+}
+
+// TestCheckCardinality_MinMaxGroupedAcrossTypes is the discriminating
+// ordering test: with min AND max violations spread over two From
+// types, ALL min violations must come before ALL max violations. A
+// single count-and-emit pass would interleave them
+// ([TKT-A min, TKT-B max, BUG-A min]) — the exact regression the
+// two-pass emission in checkCardinality exists to prevent.
+func TestCheckCardinality_MinMaxGroupedAcrossTypes(t *testing.T) {
+	one := 1
+	meta := &metamodel.Metamodel{
+		Entities: map[string]metamodel.EntityDef{
+			"ticket":  {Label: "Ticket", IDPrefixes: []string{"TKT-"}},
+			"bug":     {Label: "Bug", IDPrefixes: []string{"BUG-"}},
+			"concept": {Label: "Concept", IDPrefixes: []string{"CON-"}},
+		},
+		Relations: map[string]metamodel.RelationDef{
+			"affects": {
+				From: []string{"ticket", "bug"}, To: []string{"concept"},
+				MinOutgoing: &one, MaxOutgoing: &one,
+			},
+		},
+	}
+	svc := newServiceWith(t, meta, func(s store.Store) {
+		addEntity(s, "TKT-A", "ticket", nil) // 0 out → min
+		addEntity(s, "TKT-B", "ticket", nil) // 2 out → max
+		addEntity(s, "BUG-A", "bug", nil)    // 0 out → min
+		addEntity(s, "CON-X", "concept", nil)
+		addEntity(s, "CON-Y", "concept", nil)
+		addRelation(s, "TKT-B", "affects", "CON-X")
+		addRelation(s, "TKT-B", "affects", "CON-Y")
+	})
+	got, err := svc.CheckCardinality(context.Background(), analysis.Options{})
+	if err != nil {
+		t.Fatalf("CheckCardinality: %v", err)
+	}
+	want := []analysis.CardinalityViolation{
+		{EntityID: "TKT-A", RelationType: "affects", Constraint: "min_outgoing", Required: 1, Actual: 0},
+		{EntityID: "BUG-A", RelationType: "affects", Constraint: "min_outgoing", Required: 1, Actual: 0},
+		{EntityID: "TKT-B", RelationType: "affects", Constraint: "max_outgoing", Required: 1, Actual: 2},
+	}
+	if len(got) != len(want) {
+		t.Fatalf("got %d violations, want %d: %+v", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("violation[%d] = %+v, want %+v", i, got[i], want[i])
+		}
+	}
+}
+
+// failingCountStore wraps a store.Store and fails every CountRelations
+// call, simulating a backend outage during the cardinality scan.
+type failingCountStore struct {
+	store.Store
+	err error
+}
+
+func (f *failingCountStore) CountRelations(context.Context, store.RelationQuery) (int, error) {
+	return 0, f.err
+}
+
+// TestCheckCardinality_CountErrorFailsLoudly pins the TKT-RNBLAC error
+// policy: a failing CountRelations must abort the run with a wrapped
+// error naming the entity and relation, and must NOT surface as a
+// count-0 min violation (the fabricated-violation bug the old
+// `n, _ :=` produced).
+func TestCheckCardinality_CountErrorFailsLoudly(t *testing.T) {
+	one := 1
+	meta := &metamodel.Metamodel{
+		Entities: map[string]metamodel.EntityDef{
+			"ticket":  {Label: "Ticket", IDPrefixes: []string{"TKT-"}},
+			"concept": {Label: "Concept", IDPrefixes: []string{"CON-"}},
+		},
+		Relations: map[string]metamodel.RelationDef{
+			"affects": {
+				From: []string{"ticket"}, To: []string{"concept"},
+				MinOutgoing: &one,
+			},
+		},
+	}
+
+	st := memstore.New()
+	addEntity(st, "TKT-001", "ticket", nil)
+	addEntity(st, "CON-001", "concept", nil)
+	addRelation(st, "TKT-001", "affects", "CON-001") // satisfied — only the outage could "violate"
+
+	countErr := errors.New("backend down")
+	broken := &failingCountStore{Store: st, err: countErr}
+	tr := tracer.New(broken)
+	svc, err := analysis.New(analysis.Deps{Store: broken, Meta: meta, Tracer: tr,
+		LuaReadDeps: lua.ReadDeps{VisibleReader: broken, WritePrepStore: broken, Tracer: tr, Meta: meta}})
+	if err != nil {
+		t.Fatalf("analysis.New: %v", err)
+	}
+
+	violations, err := svc.CheckCardinality(context.Background(), analysis.Options{})
+	if err == nil {
+		t.Fatalf("want error, got nil (violations: %+v)", violations)
+	}
+	if !errors.Is(err, countErr) {
+		t.Errorf("error does not wrap the store error: %v", err)
+	}
+	for _, want := range []string{"TKT-001", "affects"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error %q missing context %q", err, want)
+		}
+	}
+	if len(violations) != 0 {
+		t.Errorf("got %d violations alongside the error, want none: %+v", len(violations), violations)
+	}
+
+	t.Run("AnalyzeAll propagates", func(t *testing.T) {
+		if _, err := svc.AnalyzeAll(context.Background(), analysis.Options{}); err == nil {
+			t.Error("AnalyzeAll: want error, got nil")
 		}
 	})
 }
@@ -255,7 +545,10 @@ func TestAnalyzeAll(t *testing.T) {
 		addEntity(s, "DOC-001", "doc", nil)
 	})
 
-	summary := svc.AnalyzeAll(context.Background(), analysis.Options{})
+	summary, err := svc.AnalyzeAll(context.Background(), analysis.Options{})
+	if err != nil {
+		t.Fatalf("AnalyzeAll: %v", err)
+	}
 	if summary.Orphans != 1 {
 		t.Errorf("Orphans = %d, want 1", summary.Orphans)
 	}

--- a/internal/analysis/analysis_test.go
+++ b/internal/analysis/analysis_test.go
@@ -506,7 +506,7 @@ func TestCheckCardinality_CountErrorFailsLoudly(t *testing.T) {
 	broken := &failingCountStore{Store: st, err: countErr}
 	tr := tracer.New(broken)
 	svc, err := analysis.New(analysis.Deps{Store: broken, Meta: meta, Tracer: tr,
-		LuaReadDeps: lua.ReadDeps{VisibleReader: broken, WritePrepStore: broken, Tracer: tr, Meta: meta}})
+		LuaReadDeps: lua.ReadDeps{VisibleReader: broken, Tracer: tr, Meta: meta}})
 	if err != nil {
 		t.Fatalf("analysis.New: %v", err)
 	}

--- a/internal/canonical/canonical.go
+++ b/internal/canonical/canonical.go
@@ -64,6 +64,15 @@ func HashEntity(e entity.Entity) string {
 	w := newWriter()
 	w.tag('E')
 	w.field("id", e.ID)
+	// The pointer is record identity like the id, but written only when
+	// non-zero: the zero value is the default state, and hashing it for
+	// every existing record would change every stored hash (sync
+	// baselines, schema_versions dedup) for pointerless projects. No
+	// ambiguity arises — the pointer grammar forbids the empty string,
+	// so "" never appears as a real field value (TKT-DOFYR1).
+	if !e.Pointer.IsDefault() {
+		w.field("pointer", string(e.Pointer))
+	}
 	w.field("type", e.Type)
 	w.properties(e.Properties)
 	w.body(e.Content)
@@ -77,6 +86,11 @@ func HashRelation(r entity.Relation) string {
 	w := newWriter()
 	w.tag('R')
 	w.field("from", r.From)
+	// Written only when non-zero, for the same reasons as HashEntity's
+	// pointer field.
+	if !r.FromPointer.IsDefault() {
+		w.field("from_pointer", string(r.FromPointer))
+	}
 	w.field("relation", r.Type)
 	w.field("to", r.To)
 	w.properties(r.Properties)

--- a/internal/cli/analyze.go
+++ b/internal/cli/analyze.go
@@ -203,7 +203,10 @@ func (c *AnalyzeCardinalityCmd) Run(ctx context.Context, analyzer *analysis.Serv
 	if err != nil {
 		return err
 	}
-	violations := analyzer.CheckCardinality(ctx, *opts)
+	violations, err := analyzer.CheckCardinality(ctx, *opts)
+	if err != nil {
+		return err
+	}
 	cardMsg := "All cardinality constraints satisfied"
 	if writeAnalysisJSON(len(violations), violations, cardMsg, "Found %d cardinality violations") {
 		return nil
@@ -527,7 +530,10 @@ func (c *AnalyzeAllCmd) Run(ctx context.Context, svc *readServices, analyzer *an
 	if err != nil {
 		return err
 	}
-	summary := analyzer.AnalyzeAll(ctx, *opts)
+	summary, err := analyzer.AnalyzeAll(ctx, *opts)
+	if err != nil {
+		return err
+	}
 	if out.Format == "json" {
 		return writeAnalyzeAllJSON(summary)
 	}
@@ -633,6 +639,10 @@ func runAnalyzeAllSections(
 	}
 	out.WriteMessage("")
 	out.WriteSectionHeader("Cardinality Analysis")
+	// Second full cardinality scan (the summary above already ran one).
+	// With a flaky backend the two runs can disagree — summary success
+	// followed by a section error here. Pre-existing shape; computing
+	// once and passing the violations down is the follow-up fix.
 	if err := (&AnalyzeCardinalityCmd{}).Run(ctx, analyzer); err != nil {
 		errs = append(errs, fmt.Errorf("cardinality analysis: %w", err))
 	}

--- a/internal/cli/analyze_test.go
+++ b/internal/cli/analyze_test.go
@@ -7,9 +7,12 @@ import (
 	"testing"
 
 	"github.com/Sourcehaven-BV/rela/internal/analysis"
+	"github.com/Sourcehaven-BV/rela/internal/appbuild/appbuildtest"
 	"github.com/Sourcehaven-BV/rela/internal/errors"
 	"github.com/Sourcehaven-BV/rela/internal/metamodel"
 	"github.com/Sourcehaven-BV/rela/internal/output"
+	"github.com/Sourcehaven-BV/rela/internal/store"
+	"github.com/Sourcehaven-BV/rela/internal/store/memstore"
 	"github.com/Sourcehaven-BV/rela/internal/testutil"
 )
 
@@ -167,4 +170,77 @@ func TestAnalyzeGaps(t *testing.T) {
 	if result.Count != 1 {
 		t.Errorf("Expected count %d, got %d", 1, result.Count)
 	}
+}
+
+// failingCountStore wraps a store.Store and fails every CountRelations
+// call, simulating a backend outage during the cardinality scan.
+type failingCountStore struct {
+	store.Store
+	err error
+}
+
+func (f *failingCountStore) CountRelations(context.Context, store.RelationQuery) (int, error) {
+	return 0, f.err
+}
+
+// TestAnalyzeCmds_CountErrorAborts pins the TKT-RNBLAC error policy at
+// the CLI boundary for both cardinality surfaces: a store error must
+// abort the command with the error and WITHOUT writing any output —
+// especially no fabricated count-0 min violations, and no partial JSON.
+func TestAnalyzeCmds_CountErrorAborts(t *testing.T) {
+	one := 1
+	meta := &metamodel.Metamodel{
+		Entities: map[string]metamodel.EntityDef{
+			"requirement": {
+				Label:      "Requirement",
+				IDPrefix:   "REQ-",
+				Properties: map[string]metamodel.PropertyDef{},
+			},
+		},
+		Relations: map[string]metamodel.RelationDef{
+			"refines": {
+				From: []string{"requirement"}, To: []string{"requirement"},
+				MinOutgoing: &one,
+			},
+		},
+	}
+	countErr := stderrors.New("backend down")
+	newBrokenBundles := func(t *testing.T) *cliBundles {
+		t.Helper()
+		st := memstore.New()
+		if err := st.CreateEntity(context.Background(),
+			testutil.EntityFor(meta, "requirement").ID("REQ-001").Build()); err != nil {
+			t.Fatalf("seed entity: %v", err)
+		}
+		broken := &failingCountStore{Store: st, err: countErr}
+		b, err := newCLIBundles(appbuildtest.New(meta, appbuildtest.WithStore(broken)))
+		if err != nil {
+			t.Fatalf("newCLIBundles: %v", err)
+		}
+		return b
+	}
+
+	t.Run("analyze cardinality", func(t *testing.T) {
+		b := newBrokenBundles(t)
+		buf := withOutput(t, output.FormatJSON)
+		err := (&AnalyzeCardinalityCmd{}).Run(context.Background(), b.analysis)
+		if !stderrors.Is(err, countErr) {
+			t.Fatalf("want wrapped count error, got %v", err)
+		}
+		if buf.Len() != 0 {
+			t.Errorf("expected no output before the error, got: %s", buf.String())
+		}
+	})
+
+	t.Run("analyze all", func(t *testing.T) {
+		b := newBrokenBundles(t)
+		buf := withOutput(t, output.FormatJSON)
+		err := (&AnalyzeAllCmd{}).Run(context.Background(), b.read, b.analysis)
+		if !stderrors.Is(err, countErr) {
+			t.Fatalf("want wrapped count error, got %v", err)
+		}
+		if buf.Len() != 0 {
+			t.Errorf("expected no output before the error, got: %s", buf.String())
+		}
+	})
 }

--- a/internal/cli/validate.go
+++ b/internal/cli/validate.go
@@ -130,7 +130,11 @@ func runValidationChecks(
 	opts := analysis.Options{}
 	hasErrors := false
 	if checks.cardinality {
-		if runCardinalityCheck(ctx, checkAnalysis, checkOut, opts) {
+		found, err := runCardinalityCheck(ctx, checkAnalysis, checkOut, opts)
+		if err != nil {
+			return false, err
+		}
+		if found {
 			hasErrors = true
 		}
 	}
@@ -147,19 +151,27 @@ func runValidationChecks(
 	return hasErrors, nil
 }
 
-// runCardinalityCheck runs cardinality validation. Returns true if errors found.
+// runCardinalityCheck runs cardinality validation. Returns true if
+// violations were found; a store error aborts the check before any
+// VIOLATION output is written (never report a fabricated violation —
+// see the CheckCardinality error policy). The section header above the
+// error return is the pre-existing plain-stdout banner every validate
+// check prints on !quiet, including in JSON mode.
 func runCardinalityCheck(
 	ctx context.Context, checkAnalysis *analysis.Service, checkOut *output.Writer, opts analysis.Options,
-) bool {
+) (bool, error) {
 	if !quiet {
 		fmt.Println("\nChecking cardinality constraints...")
 	}
-	violations := checkAnalysis.CheckCardinality(ctx, opts)
+	violations, err := checkAnalysis.CheckCardinality(ctx, opts)
+	if err != nil {
+		return false, err
+	}
 	if len(violations) == 0 {
 		if !quiet && checkOut.Format != output.FormatJSON {
 			checkOut.WriteSuccess("All cardinality constraints satisfied")
 		}
-		return false
+		return false, nil
 	}
 	if checkOut.Format == output.FormatJSON {
 		_ = checkOut.WriteAnalysisResult(output.AnalysisResult{
@@ -178,7 +190,7 @@ func runCardinalityCheck(
 			}
 		}
 	}
-	return true
+	return true, nil
 }
 
 // runPropertiesCheck runs property validation. Returns true if errors found.

--- a/internal/dataentry/mentions_test.go
+++ b/internal/dataentry/mentions_test.go
@@ -418,6 +418,10 @@ func (f *flakyStore) GetEntity(_ context.Context, id string) (*entity.Entity, er
 	return nil, f.err
 }
 
+func (f *flakyStore) GetEntityState(ctx context.Context, id string, _ entity.Pointer) (*entity.Entity, error) {
+	return f.GetEntity(ctx, id)
+}
+
 func (f *flakyStore) ListEntities(_ context.Context, _ store.EntityQuery) iter.Seq2[*entity.Entity, error] {
 	panic("flakyStore: ListEntities not implemented")
 }

--- a/internal/entity/entity.go
+++ b/internal/entity/entity.go
@@ -52,8 +52,16 @@ type InaccessibleField struct {
 
 // Entity represents any architecture entity (requirement, decision, etc.).
 type Entity struct {
-	ID           string              `json:"id"`
-	Type         string              `json:"type"`
+	ID   string `json:"id"`
+	Type string `json:"type"`
+
+	// Pointer addresses the content state this record is (TKT-DOFYR1).
+	// Zero value = the default state / a pointerless entity, so a
+	// project without pointers never sees the field (omitempty). See
+	// [Pointer] for the two load-bearing rules (codec-only construction;
+	// stores equality-match, never inspect).
+	Pointer Pointer `json:"pointer,omitempty"`
+
 	Properties   map[string]any      `json:"properties,omitempty"`
 	Content      string              `json:"content,omitempty"`
 	UpdatedAt    time.Time           `json:"updated_at,omitzero"`
@@ -203,6 +211,7 @@ func (e *Entity) Clone() *Entity {
 	clone := &Entity{
 		ID:         e.ID,
 		Type:       e.Type,
+		Pointer:    e.Pointer,
 		Content:    e.Content,
 		UpdatedAt:  e.UpdatedAt,
 		Properties: make(map[string]any, len(e.Properties)),
@@ -246,7 +255,16 @@ func CloneValue(v any) any {
 
 // Relation represents a directed relationship between two entities.
 type Relation struct {
-	From         string              `json:"from"`
+	From string `json:"from"`
+
+	// FromPointer is the state-specific TAIL of a content-scoped edge
+	// (design doc §2.3): the edge attaches to (From, FromPointer). Zero
+	// value = the tail is the default state / an identity-scoped edge.
+	// Heads are entity-level by construction — there is deliberately NO
+	// ToPointer, which is what makes cross-world dangling references
+	// inexpressible.
+	FromPointer Pointer `json:"from_pointer,omitempty"`
+
 	Type         string              `json:"relation"`
 	To           string              `json:"to"`
 	Properties   map[string]any      `json:"properties,omitempty"`
@@ -282,17 +300,23 @@ func NewRelation(from, relationType, to string) *Relation {
 
 // Key returns a unique key for this relation.
 func (r *Relation) Key() string {
-	return r.From + "--" + r.Type + "--" + r.To
+	// The FROM slot carries the tail pointer via the codec serialization
+	// (TKT-DOFYR1) — two edges on the same triple with different tails
+	// are two relations, so the pointer is part of the key. The pointer
+	// grammar forbids "--", keeping the key unambiguous; a default-tail
+	// key is byte-identical to the historical form.
+	return FormatStateRef(r.From, r.FromPointer) + "--" + r.Type + "--" + r.To
 }
 
 // CloneRelation returns a deep copy of the relation.
 func (r *Relation) Clone() *Relation {
 	clone := &Relation{
-		From:      r.From,
-		Type:      r.Type,
-		To:        r.To,
-		Content:   r.Content,
-		UpdatedAt: r.UpdatedAt,
+		From:        r.From,
+		FromPointer: r.FromPointer,
+		Type:        r.Type,
+		To:          r.To,
+		Content:     r.Content,
+		UpdatedAt:   r.UpdatedAt,
 	}
 	if r.Properties != nil {
 		clone.Properties = make(map[string]any, len(r.Properties))

--- a/internal/entity/pointer.go
+++ b/internal/entity/pointer.go
@@ -1,0 +1,115 @@
+package entity
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// Pointer identifies one content state of an entity (FEAT-9CD2MX,
+// TKT-DOFYR1). Its value is the CANONICAL serialized coordinate —
+// "draft" today, a codec-canonicalized multi-axis form like "nl+draft"
+// when axes arrive (§11 of the design doc reserves '+'; axis ordering
+// will be pinned by the codec so the canonical form stays unique). The
+// zero value means the default state / a pointerless entity, which is
+// why a pointerless project never sees this type at all.
+//
+// Two rules are load-bearing; both exist so multi-axis later becomes a
+// resolver feature instead of a storage migration:
+//
+//   - The codec below ([ParsePointer], [ParseStateRef]) is the ONLY
+//     constructor from external input. Nothing else builds a Pointer by
+//     string conversion or concatenation; internal code passes the value
+//     around opaquely. Canonical-form uniqueness is what licenses the
+//     next rule, plus == comparison, one pg text column, and one
+//     frontmatter key.
+//
+//   - Stores only ever EQUALITY-MATCH a Pointer — never parse or
+//     inspect its contents. Worlds (Step 2) compile to sets of concrete
+//     coordinates before they reach a store, so store matching never
+//     changes shape. The storetest suite pins this by round-tripping an
+//     unusual-but-canonical value unchanged.
+type Pointer string
+
+// IsDefault reports whether p addresses the default state (the zero
+// value). A pointerless entity is its own default state (§2.1).
+func (p Pointer) IsDefault() bool { return p == "" }
+
+// String returns the canonical serialized coordinate. It exists for
+// boundaries — filenames, the pg column, change-feed payloads — which
+// are exactly where the serialized form is allowed to appear (§3.2).
+func (p Pointer) String() string { return string(p) }
+
+// StateRefSeparator joins a base entity ID and a pointer in the
+// boundary serialization: "PAGE-1@draft". '@' is filename-legal,
+// excluded from the entity-ID grammar (ValidateID rejects it), and
+// distinct from the relation-key separator "--" and the pgstore
+// change-feed field separator '\x1f'.
+const StateRefSeparator = "@"
+
+// pointerPattern is the grammar for a single pointer coordinate:
+// lowercase alphanumeric runs joined by single hyphens. Deliberately
+// narrower than the entity-ID grammar, and — like ValidateID's
+// no-consecutive-hyphens rule — it must never admit "--": the pointer
+// serializes into the FROM slot of relation keys ("FROM--TYPE--TO"),
+// so a pointer containing the separator would make relation filenames
+// ambiguous to parse. Load-bearing for the storage format.
+var pointerPattern = regexp.MustCompile(`^[a-z][a-z0-9]*(-[a-z0-9]+)*$`)
+
+// ParsePointer validates and canonicalizes a bare pointer coordinate
+// from external input (URL, CLI, acl.yaml, filename, stored column).
+// It is grammar-only: whether the pointer is DECLARED by the metamodel
+// is validated at metamodel load, never here — this package must not
+// know the metamodel.
+//
+// v1 ships a single axis, so canonicalization is the identity; '+' is
+// reserved for future multi-axis coordinates and rejected with a
+// distinct error so a newer project's data fails loudly on an older
+// binary rather than being misread.
+func ParsePointer(s string) (Pointer, error) {
+	if s == "" {
+		return "", errors.New("empty pointer")
+	}
+	if strings.Contains(s, "+") {
+		return "", fmt.Errorf("multi-axis pointer coordinates are not supported yet: %q", s)
+	}
+	if !pointerPattern.MatchString(s) {
+		return "", fmt.Errorf("invalid pointer %q: must be lowercase alphanumeric runs joined by single hyphens", s)
+	}
+	return Pointer(s), nil
+}
+
+// ParseStateRef parses the boundary serialization of a state reference:
+// "PAGE-1" (default state) or "PAGE-1@draft". At most one separator; a
+// state cannot have a state. The base ID goes through [ValidateID] —
+// the single ID grammar — and the pointer through [ParsePointer].
+func ParseStateRef(s string) (id string, p Pointer, err error) {
+	base, ptr, found := strings.Cut(s, StateRefSeparator)
+	if idErr := ValidateID(base); idErr != nil {
+		return "", "", fmt.Errorf("invalid state reference %q: %w", s, idErr)
+	}
+	if !found {
+		return base, "", nil
+	}
+	if strings.Contains(ptr, StateRefSeparator) {
+		return "", "", fmt.Errorf("invalid state reference %q: more than one %q", s, StateRefSeparator)
+	}
+	p, err = ParsePointer(ptr)
+	if err != nil {
+		return "", "", fmt.Errorf("invalid state reference %q: %w", s, err)
+	}
+	return base, p, nil
+}
+
+// FormatStateRef renders the boundary serialization of (id, p):
+// the bare id for the default state, "id@pointer" otherwise. It never
+// emits an empty pointer — the default state's serialization IS the
+// bare id. The id is assumed valid and p canonical (both only exist
+// via their parse functions); Format performs no re-validation.
+func FormatStateRef(id string, p Pointer) string {
+	if p.IsDefault() {
+		return id
+	}
+	return id + StateRefSeparator + string(p)
+}

--- a/internal/entity/pointer_test.go
+++ b/internal/entity/pointer_test.go
@@ -1,0 +1,113 @@
+package entity
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestParsePointer pins the pointer grammar (design doc §3.2, amended
+// 2026-08-20): lowercase alphanumeric runs joined by SINGLE hyphens. The
+// no-consecutive-hyphens rule is load-bearing for the storage format —
+// the pointer serializes into the FROM slot of relation keys
+// ("FROM--TYPE--TO"), mirroring ValidateID's identical rule for base ids.
+func TestParsePointer(t *testing.T) {
+	t.Parallel()
+
+	valid := []string{"draft", "published", "review-2", "a", "x9", "nl-be-draft"}
+	for _, s := range valid {
+		if p, err := ParsePointer(s); err != nil || string(p) != s {
+			t.Errorf("ParsePointer(%q) = (%q, %v), want (%q, nil)", s, p, err, s)
+		}
+	}
+
+	invalid := map[string]string{
+		"":            "empty",
+		"Draft":       "uppercase",
+		"9draft":      "leading digit",
+		"-draft":      "leading hyphen",
+		"draft-":      "trailing hyphen",
+		"a--b":        "consecutive hyphens (relation-key separator)",
+		"nl+draft":    "multi-axis reserved",
+		"dr aft":      "space",
+		"draft@x":     "separator char",
+		"dráft":       "non-ASCII",
+		"draft/x":     "path separator",
+		"draft\x00":   "NUL",
+		"a-b--c-d":    "interior consecutive hyphens",
+		"PAGE-1@d":    "not a bare pointer",
+		"draft\ttab":  "control char",
+		"draft\nline": "newline",
+	}
+	for s, why := range invalid {
+		if _, err := ParsePointer(s); err == nil {
+			t.Errorf("ParsePointer(%q) succeeded, want error (%s)", s, why)
+		}
+	}
+
+	// The multi-axis rejection is a distinct, forward-looking error so a
+	// newer project's data fails loudly on an older binary.
+	if _, err := ParsePointer("nl+draft"); err == nil || !strings.Contains(err.Error(), "multi-axis") {
+		t.Errorf("ParsePointer(nl+draft) error = %v, want a multi-axis message", err)
+	}
+}
+
+func TestParseStateRef(t *testing.T) {
+	t.Parallel()
+
+	t.Run("bare id is the default state", func(t *testing.T) {
+		t.Parallel()
+		id, p, err := ParseStateRef("PAGE-1")
+		if err != nil || id != "PAGE-1" || !p.IsDefault() {
+			t.Errorf("got (%q, %q, %v), want (PAGE-1, default, nil)", id, p, err)
+		}
+	})
+
+	t.Run("qualified form", func(t *testing.T) {
+		t.Parallel()
+		id, p, err := ParseStateRef("PAGE-1@draft")
+		if err != nil || id != "PAGE-1" || p != Pointer("draft") {
+			t.Errorf("got (%q, %q, %v), want (PAGE-1, draft, nil)", id, p, err)
+		}
+	})
+
+	invalid := map[string]string{
+		"PAGE-1@":       "empty pointer",
+		"@draft":        "empty id",
+		"PAGE-1@a@b":    "two separators",
+		"PAGE-1@Draft":  "bad pointer grammar",
+		"pa/ge@draft":   "bad base id",
+		"PAGE-1@nl+da":  "multi-axis reserved",
+		"":              "empty",
+		"PAGE--1@draft": "base id with consecutive hyphens",
+		"PAGE-1@a--b":   "pointer with consecutive hyphens",
+	}
+	for s, why := range invalid {
+		if _, _, err := ParseStateRef(s); err == nil {
+			t.Errorf("ParseStateRef(%q) succeeded, want error (%s)", s, why)
+		}
+	}
+}
+
+// TestFormatStateRef pins that Format never emits an empty pointer: the
+// default state's serialization IS the bare id.
+func TestFormatStateRef(t *testing.T) {
+	t.Parallel()
+
+	if got := FormatStateRef("PAGE-1", ""); got != "PAGE-1" {
+		t.Errorf("FormatStateRef(PAGE-1, default) = %q, want PAGE-1", got)
+	}
+	if got := FormatStateRef("PAGE-1", Pointer("draft")); got != "PAGE-1@draft" {
+		t.Errorf("FormatStateRef(PAGE-1, draft) = %q, want PAGE-1@draft", got)
+	}
+
+	// Round trip: Format ∘ Parse = identity on both forms.
+	for _, s := range []string{"PAGE-1", "PAGE-1@draft", "X_2@rev-3"} {
+		id, p, err := ParseStateRef(s)
+		if err != nil {
+			t.Fatalf("ParseStateRef(%q): %v", s, err)
+		}
+		if got := FormatStateRef(id, p); got != s {
+			t.Errorf("round trip %q -> %q", s, got)
+		}
+	}
+}

--- a/internal/entity/reserved.go
+++ b/internal/entity/reserved.go
@@ -26,10 +26,12 @@ func IsEntityPropertyKey(key string) bool {
 }
 
 // IsReservedRelationKey reports whether key names an identity field of a
-// [Relation] ("from", "relation", "to") rather than a property. Note the
-// type of a relation is keyed "relation", not "type", in frontmatter.
+// [Relation] ("from", "from_pointer", "relation", "to") rather than a
+// property. Note the type of a relation is keyed "relation", not "type",
+// in frontmatter. "from_pointer" is the state-specific tail
+// (TKT-DOFYR1); it maps to [Relation.FromPointer], never to Properties.
 func IsReservedRelationKey(key string) bool {
-	return key == "from" || key == "relation" || key == "to"
+	return key == "from" || key == "from_pointer" || key == "relation" || key == "to"
 }
 
 // IsRelationPropertyKey reports whether key names a property of a [Relation];

--- a/internal/store/fsstore/conformance_test.go
+++ b/internal/store/fsstore/conformance_test.go
@@ -49,7 +49,7 @@ func visibleSearchFactory(t *testing.T) (store.Store, search.Searcher, search.Vi
 }
 
 func TestConformance(t *testing.T) {
-	storetest.RunAll(t, factory, searchFactory, visibleSearchFactory, storetest.Capabilities{Attachments: true})
+	storetest.RunAll(t, factory, searchFactory, visibleSearchFactory, storetest.Capabilities{Attachments: true, States: true})
 }
 
 func FuzzRelationKeyCollision(f *testing.F) {

--- a/internal/store/fsstore/entity.go
+++ b/internal/store/fsstore/entity.go
@@ -16,43 +16,40 @@ import (
 
 // --- EntityReader ---
 
-func (s *FSStore) GetEntity(_ context.Context, id string) (*entity.Entity, error) {
+func (s *FSStore) GetEntity(ctx context.Context, id string) (*entity.Entity, error) {
+	// The bare id IS the default state's index key (stateKey(id, zero)).
+	return s.GetEntityState(ctx, id, "")
+}
+
+func (s *FSStore) GetEntityState(_ context.Context, id string, p entity.Pointer) (*entity.Entity, error) {
+	key := stateKey(id, p)
 	s.mu.RLock()
-	meta, ok := s.entities[id]
+	meta, ok := s.entities[key]
 	s.mu.RUnlock()
 
 	if !ok {
 		return nil, store.ErrNotFound
 	}
-
-	e, err := s.loadEntity(meta.ID, meta.Type)
-	if err != nil {
-		return nil, err
-	}
-	return e, nil
+	return s.loadEntityMeta(meta)
 }
 
 func (s *FSStore) ListEntities(_ context.Context, q store.EntityQuery) iter.Seq2[*entity.Entity, error] {
 	s.mu.RLock()
 	idSet := entityIDSet(q.IDs)
 
-	// Collect matching IDs + types from index.
-	type idType struct {
-		id, typ string
-	}
-	matches := make([]idType, 0)
-	for _, id := range s.entityOrder {
-		if !matchEntityQuery(s.entities[id], q, idSet) {
+	// Collect matching metas from index.
+	matches := make([]entityMeta, 0)
+	for _, key := range s.entityOrder {
+		if !matchEntityQuery(s.entities[key], q, idSet) {
 			continue
 		}
-		meta := s.entities[id]
-		matches = append(matches, idType{meta.ID, meta.Type})
+		matches = append(matches, s.entities[key])
 	}
 	s.mu.RUnlock()
 
 	return func(yield func(*entity.Entity, error) bool) {
 		for _, m := range matches {
-			e, err := s.loadEntity(m.id, m.typ)
+			e, err := s.loadEntityMeta(m)
 			if err != nil {
 				if !yield(nil, err) {
 					return
@@ -78,20 +75,19 @@ func (s *FSStore) ListEntitiesPage(_ context.Context, q store.EntityQuery) (stor
 		return matchEntityQuery(s.entities[id], q, idSet)
 	})
 
-	// Capture (id, type) pairs while still holding the lock — loadEntity
-	// needs the type and we must not call it under the lock.
-	type idType struct{ id, typ string }
-	pairs := make([]idType, 0, len(keys.Keys))
-	for _, id := range keys.Keys {
-		if meta, ok := s.entities[id]; ok {
-			pairs = append(pairs, idType{meta.ID, meta.Type})
+	// Capture metas while still holding the lock — loading needs the
+	// type and pointer and we must not do I/O under the lock.
+	pairs := make([]entityMeta, 0, len(keys.Keys))
+	for _, key := range keys.Keys {
+		if meta, ok := s.entities[key]; ok {
+			pairs = append(pairs, meta)
 		}
 	}
 	s.mu.RUnlock()
 
 	items := make([]*entity.Entity, 0, len(pairs))
 	for _, p := range pairs {
-		e, err := s.loadEntity(p.id, p.typ)
+		e, err := s.loadEntityMeta(p)
 		if err != nil {
 			return store.Page[*entity.Entity]{}, err
 		}
@@ -113,9 +109,14 @@ func entityIDSet(ids []string) map[string]bool {
 	return set
 }
 
-// matchEntityQuery reports whether an indexed entity satisfies q's Type
-// and IDs filters. idSet must be pre-computed from q.IDs.
+// matchEntityQuery reports whether an indexed entity satisfies q's
+// Type, IDs, and AllStates filters. idSet must be pre-computed from
+// q.IDs and matches the BARE id, so IDs+AllStates selects every state
+// of the listed entities.
 func matchEntityQuery(m entityMeta, q store.EntityQuery, idSet map[string]bool) bool {
+	if !q.AllStates && !m.Pointer.IsDefault() {
+		return false
+	}
 	if q.Type != "" && m.Type != q.Type {
 		return false
 	}
@@ -129,20 +130,13 @@ func (s *FSStore) CountEntities(_ context.Context, q store.EntityQuery) (int, er
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	idSet := make(map[string]bool, len(q.IDs))
-	for _, id := range q.IDs {
-		idSet[id] = true
-	}
+	idSet := entityIDSet(q.IDs)
 
 	count := 0
 	for _, meta := range s.entities {
-		if q.Type != "" && meta.Type != q.Type {
-			continue
+		if matchEntityQuery(meta, q, idSet) {
+			count++
 		}
-		if len(idSet) > 0 && !idSet[meta.ID] {
-			continue
-		}
-		count++
 	}
 	return count, nil
 }
@@ -153,7 +147,11 @@ func (s *FSStore) HighestID(_ context.Context, prefix string) (int, error) {
 
 	highest := 0
 	pfx := prefix + "-"
-	for id := range s.entities {
+	for _, meta := range s.entities {
+		if !meta.Pointer.IsDefault() {
+			continue // states share the base id's number
+		}
+		id := meta.ID
 		if !strings.HasPrefix(id, pfx) {
 			continue
 		}
@@ -211,13 +209,25 @@ func (s *FSStore) PropertyValues(_ context.Context, property string, limit int) 
 // A free function rather than a method — FSStore is at its plimsoll
 // max-methods line, and this needs no receiver state beyond the index.
 // Callers must hold s.mu.
+// idTaken folds on the BARE entity id (meta.ID): any state of an
+// entity claims the whole identity, so a new id collides with an
+// existing family regardless of which states it has.
+//
+// except is a BARE id matched case-folded — it skips that entire
+// family, not one exact key (a rename may change its own casing, and
+// its states must not self-collide either). Wider than the historical
+// exact-key skip on purpose.
 func idTaken(index map[string]entityMeta, id, except string) bool {
 	folded := storeutil.FoldID(id)
-	for existing := range index {
-		if existing == except {
+	exceptFolded := ""
+	if except != "" {
+		exceptFolded = storeutil.FoldID(except)
+	}
+	for _, meta := range index {
+		if exceptFolded != "" && storeutil.FoldID(meta.ID) == exceptFolded {
 			continue
 		}
-		if storeutil.FoldID(existing) == folded {
+		if storeutil.FoldID(meta.ID) == folded {
 			return true
 		}
 	}
@@ -232,11 +242,33 @@ func (s *FSStore) createEntity(_ context.Context, e *entity.Entity) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	// Case-folded: on a case-insensitive filesystem (macOS, Windows) "ABC"
-	// and "abc" are the same file, so a byte-exact check here would let the
-	// write silently overwrite the existing entity (BUG-3RCWNS).
-	if idTaken(s.entities, e.ID, "") {
-		return store.ErrConflict
+	key := stateKey(e.ID, e.Pointer)
+	if e.Pointer.IsDefault() {
+		// Case-folded: on a case-insensitive filesystem (macOS, Windows)
+		// "ABC" and "abc" are the same file, so a byte-exact check here
+		// would let the write silently overwrite the existing entity
+		// (BUG-3RCWNS).
+		if idTaken(s.entities, e.ID, "") {
+			return store.ErrConflict
+		}
+	} else {
+		// Row-family invariants (TKT-DOFYR1, design doc §6): a
+		// non-default state requires its default row (no headless
+		// states) and must share the family's type. Enforced at the
+		// store so every direct writer hits one choke point; the LOAD
+		// path deliberately tolerates violations found on disk.
+		def, ok := s.entities[e.ID]
+		if !ok {
+			return fmt.Errorf("%w: entity %s has no default state; a state row cannot exist headless",
+				store.ErrNotFound, e.ID)
+		}
+		if def.Type != e.Type {
+			return fmt.Errorf("state %s@%s type %q does not match the entity's type %q",
+				e.ID, e.Pointer, e.Type, def.Type)
+		}
+		if _, exists := s.entities[key]; exists {
+			return store.ErrConflict
+		}
 	}
 
 	// Write to disk
@@ -247,15 +279,18 @@ func (s *FSStore) createEntity(_ context.Context, e *entity.Entity) error {
 	}
 
 	// Update index
-	s.entities[e.ID] = entityMeta{ID: e.ID, Type: e.Type}
-	s.entityOrder = storeutil.SortedInsert(s.entityOrder, e.ID)
-	addEntityToCache(s.propCache, stored)
+	s.entities[key] = entityMeta{ID: e.ID, Type: e.Type, Pointer: e.Pointer}
+	s.entityOrder = storeutil.SortedInsert(s.entityOrder, key)
+	if stored.Pointer.IsDefault() {
+		addEntityToCache(s.propCache, stored)
+	}
 	s.notifyPut(stored)
 
 	s.emit(store.Event{
 		Op:         store.EventEntityCreated,
 		EntityType: e.Type,
 		EntityID:   e.ID,
+		Pointer:    e.Pointer,
 	})
 	return nil
 }
@@ -264,13 +299,20 @@ func (s *FSStore) updateEntity(_ context.Context, e *entity.Entity) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	meta, exists := s.entities[e.ID]
+	key := stateKey(e.ID, e.Pointer)
+	meta, exists := s.entities[key]
 	if !exists {
 		return store.ErrNotFound
 	}
+	// Row-family invariant: a non-default state cannot be re-typed away
+	// from its family (TKT-DOFYR1, design doc §6).
+	if !e.Pointer.IsDefault() && e.Type != meta.Type {
+		return fmt.Errorf("state %s@%s type %q does not match the entity's type %q",
+			e.ID, e.Pointer, e.Type, meta.Type)
+	}
 
 	// Load old entity for prop cache diff.
-	old, err := s.loadEntity(meta.ID, meta.Type)
+	old, err := s.loadEntityMeta(meta)
 	if err != nil {
 		return err
 	}
@@ -294,75 +336,99 @@ func (s *FSStore) updateEntity(_ context.Context, e *entity.Entity) error {
 	}
 
 	// Update index
-	s.entities[e.ID] = entityMeta{ID: e.ID, Type: e.Type}
-	removeEntityFromCache(s.propCache, old)
-	addEntityToCache(s.propCache, stored)
+	s.entities[key] = entityMeta{ID: e.ID, Type: e.Type, Pointer: e.Pointer}
+	if e.Pointer.IsDefault() {
+		removeEntityFromCache(s.propCache, old)
+		addEntityToCache(s.propCache, stored)
+	}
 	s.notifyPut(stored)
 
 	s.emit(store.Event{
 		Op:         store.EventEntityUpdated,
 		EntityType: e.Type,
 		EntityID:   e.ID,
+		Pointer:    e.Pointer,
 	})
 	return nil
+}
+
+// stateFamily returns every indexed state of the bare id, sorted by
+// pointer (default first), plus every relation touching the id on
+// either endpoint. Defensive family scan (works for a headless family
+// tolerated from disk, design doc §6); the bare From/To match sweeps
+// every tail pointer. Callers must hold s.mu.
+func (s *FSStore) stateFamily(id string) (family []entityMeta, related []relationMeta) {
+	for _, meta := range s.entities {
+		if meta.ID == id {
+			family = append(family, meta)
+		}
+	}
+	sort.Slice(family, func(i, j int) bool { return family[i].Pointer < family[j].Pointer })
+	for _, rm := range s.relations {
+		if rm.From == id || rm.To == id {
+			related = append(related, rm)
+		}
+	}
+	return family, related
 }
 
 func (s *FSStore) deleteEntity(_ context.Context, id string, cascade bool) (*store.DeleteResult, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	meta, ok := s.entities[id]
-	if !ok {
+	// Delete addresses the whole state FAMILY of the bare id
+	// (TKT-DOFYR1): every state row plus all their relations.
+	family, related := s.stateFamily(id)
+	if len(family) == 0 {
 		return nil, store.ErrNotFound
-	}
-
-	// Find related relations from index.
-	var related []relationMeta
-	for _, rm := range s.relations {
-		if rm.From == id || rm.To == id {
-			related = append(related, rm)
-		}
 	}
 
 	if !cascade && len(related) > 0 {
 		return nil, fmt.Errorf("%w: entity %s has %d relation(s)", store.ErrHasRelations, id, len(related))
 	}
 
-	// Load entity for result and prop cache.
-	e, err := s.loadEntity(meta.ID, meta.Type)
-	if err != nil {
-		return nil, err
+	// Load every state for the result and prop cache.
+	states := make([]*entity.Entity, 0, len(family))
+	for _, meta := range family {
+		e, err := s.loadEntityMeta(meta)
+		if err != nil {
+			return nil, err
+		}
+		states = append(states, e)
 	}
 
 	// Load relations for result.
 	deletedRelations := make([]*entity.Relation, 0)
 	for _, rm := range related {
-		r, loadErr := s.loadRelation(rm.From, rm.Type, rm.To)
+		r, loadErr := s.loadRelationMeta(rm)
 		if loadErr != nil {
 			r = entity.NewRelation(rm.From, rm.Type, rm.To)
+			r.FromPointer = rm.FromPointer
 		}
 		deletedRelations = append(deletedRelations, r)
 	}
 
-	// Delete relation files first, then the entity file. A real removal
-	// error (not "already gone") aborts before the entity file is touched
+	// Delete relation files first, then the entity files. A real removal
+	// error (not "already gone") aborts before the entity files are touched
 	// and before the in-memory index is mutated, so the entity is never
 	// removed while one of its relations could not be — fail-secure, no
 	// orphaned-from entity (BUG-C20T / issue #888). Not transactional: a
 	// relation file removed before a later failure stays removed, but the
 	// whole op runs under s.mu and the index is updated only on success.
 	for _, rm := range related {
-		key := s.relationFileKey(rm.From, rm.Type, rm.To)
+		key := s.relationFileKeyMeta(rm)
 		if err := s.rooted.Remove(key); err != nil && !os.IsNotExist(err) {
-			return nil, fmt.Errorf("delete relation file %s--%s--%s: %w", rm.From, rm.Type, rm.To, err)
+			return nil, fmt.Errorf("delete relation file %s: %w", rm.key(), err)
 		}
 		s.echoes.Forget(s.absPath(key))
 	}
-	key := s.entityFileKey(meta.Type, id)
-	if err := s.rooted.Remove(key); err != nil && !os.IsNotExist(err) {
-		return nil, err
+	for _, meta := range family {
+		key := s.entityFileKey(meta.Type, stateKey(meta.ID, meta.Pointer))
+		if err := s.rooted.Remove(key); err != nil && !os.IsNotExist(err) {
+			return nil, err
+		}
+		s.echoes.Forget(s.absPath(key))
 	}
-	s.echoes.Forget(s.absPath(key))
 
 	// Cascade attachments — under the per-entity layout the
 	// attachment directory is owned 1:1 by the entity.
@@ -371,37 +437,78 @@ func (s *FSStore) deleteEntity(_ context.Context, id string, cascade bool) (*sto
 	}
 
 	// Update index
-	delete(s.entities, id)
-	s.entityOrder = storeutil.SortedRemove(s.entityOrder, id)
-	removeEntityFromCache(s.propCache, e)
+	for i, meta := range family {
+		key := stateKey(meta.ID, meta.Pointer)
+		delete(s.entities, key)
+		s.entityOrder = storeutil.SortedRemove(s.entityOrder, key)
+		if meta.Pointer.IsDefault() {
+			removeEntityFromCache(s.propCache, states[i])
+		}
+	}
 	s.notifyDelete(id)
 
 	for _, rm := range related {
-		key := rm.From + "--" + rm.Type + "--" + rm.To
+		key := rm.key()
 		delete(s.relations, key)
 		s.relationOrder = storeutil.SortedRemove(s.relationOrder, key)
 	}
 
 	result := &store.DeleteResult{
-		DeletedEntities:  []*entity.Entity{e},
+		DeletedEntities:  states,
 		DeletedRelations: deletedRelations,
 	}
+	s.emitFamilyDeleted(family, related)
+	return result, nil
+}
 
-	s.emit(store.Event{
-		Op:         store.EventEntityDeleted,
-		EntityType: meta.Type,
-		EntityID:   id,
-	})
+// emitFamilyDeleted emits per-state entity-deleted events and per-edge
+// relation-deleted events for a cascaded family delete. Each event
+// carries its own state's type — the load path tolerates a mistyped
+// state on disk, so famType-for-all would misreport it.
+func (s *FSStore) emitFamilyDeleted(family []entityMeta, related []relationMeta) {
+	for _, meta := range family {
+		s.emit(store.Event{
+			Op:         store.EventEntityDeleted,
+			EntityType: meta.Type,
+			EntityID:   meta.ID,
+			Pointer:    meta.Pointer,
+		})
+	}
 	for _, rm := range related {
 		s.emit(store.Event{
 			Op:           store.EventRelationDeleted,
 			RelationType: rm.Type,
 			From:         rm.From,
 			To:           rm.To,
+			Pointer:      rm.FromPointer,
 		})
 	}
+}
 
-	return result, nil
+// rewriteRelationFiles rewrites every relation file in metas, moving
+// endpoints from oldID to newID; the tail pointer rides along
+// unchanged. Old files are removed after the new ones are written.
+func (s *FSStore) rewriteRelationFiles(metas []relationMeta, oldID, newID string) error {
+	for _, rm := range metas {
+		r, loadErr := s.loadRelationMeta(rm)
+		if loadErr != nil {
+			r = entity.NewRelation(rm.From, rm.Type, rm.To)
+			r.FromPointer = rm.FromPointer
+		}
+		if r.From == oldID {
+			r.From = newID
+		}
+		if r.To == oldID {
+			r.To = newID
+		}
+		if writeErr := s.writeRelation(r); writeErr != nil {
+			return writeErr
+		}
+		oldKey := s.relationFileKeyMeta(rm)
+		_ = s.rooted.Remove(oldKey)
+		s.echoes.Forget(s.absPath(oldKey))
+	}
+	return nil
 }
 
 func (s *FSStore) renameEntity(_ context.Context, oldID, newID string) (*store.RenameResult, error) {
@@ -412,69 +519,52 @@ func (s *FSStore) renameEntity(_ context.Context, oldID, newID string) (*store.R
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	meta, ok := s.entities[oldID]
-	if !ok {
+	// Rename addresses the whole state FAMILY of the bare id
+	// (TKT-DOFYR1): every state file is re-keyed onto the new id, and
+	// every relation of every state follows.
+	family, toUpdate := s.stateFamily(oldID)
+	if len(family) == 0 {
 		return nil, store.ErrNotFound
 	}
+
 	// except=oldID: an entity may change its own casing (abc -> ABC).
+	// idTaken folds on the bare id, so ANY state of another entity under
+	// the new id is a conflict.
 	if idTaken(s.entities, newID, oldID) {
 		return nil, store.ErrConflict
 	}
 
-	// Load entity from disk.
-	e, err := s.loadEntity(meta.ID, meta.Type)
-	if err != nil {
+	// Load, re-id, and write every state; remember the default state
+	// for the observers.
+	var renamedDefault *entity.Entity
+	renamedStates := make([]*entity.Entity, 0, len(family))
+	for _, meta := range family {
+		e, err := s.loadEntityMeta(meta)
+		if err != nil {
+			return nil, err
+		}
+		renamed := e.Clone()
+		renamed.ID = newID
+		renamed.UpdatedAt = time.Now()
+		if err := s.writeEntity(renamed); err != nil {
+			return nil, err
+		}
+		renamedStates = append(renamedStates, renamed)
+		if renamed.Pointer.IsDefault() {
+			renamedDefault = renamed
+		}
+	}
+
+	if err := s.rewriteRelationFiles(toUpdate, oldID, newID); err != nil {
 		return nil, err
 	}
 
-	// Prepare renamed entity.
-	renamed := e.Clone()
-	renamed.ID = newID
-	renamed.UpdatedAt = time.Now()
-
-	// Write new entity file.
-	if err := s.writeEntity(renamed); err != nil {
-		return nil, err
-	}
-
-	// Find and update affected relations.
-	var toUpdate []relationMeta
-	for _, rm := range s.relations {
-		if rm.From == oldID || rm.To == oldID {
-			toUpdate = append(toUpdate, rm)
-		}
-	}
-
-	for _, rm := range toUpdate {
-		// Load relation.
-		r, loadErr := s.loadRelation(rm.From, rm.Type, rm.To)
-		if loadErr != nil {
-			r = entity.NewRelation(rm.From, rm.Type, rm.To)
-		}
-
-		// Update endpoints.
-		if r.From == oldID {
-			r.From = newID
-		}
-		if r.To == oldID {
-			r.To = newID
-		}
-
-		// Write new relation file.
-		if writeErr := s.writeRelation(r); writeErr != nil {
-			return nil, writeErr
-		}
-
-		// Delete old relation file.
-		oldKey := s.relationFileKey(rm.From, rm.Type, rm.To)
+	// Delete old entity files.
+	for _, meta := range family {
+		oldKey := s.entityFileKey(meta.Type, stateKey(meta.ID, meta.Pointer))
 		_ = s.rooted.Remove(oldKey)
 		s.echoes.Forget(s.absPath(oldKey))
 	}
-
-	// Delete old entity file.
-	oldKey := s.entityFileKey(meta.Type, oldID)
-	_ = s.rooted.Remove(oldKey)
-	s.echoes.Forget(s.absPath(oldKey))
 
 	// Move the attachment directory (if any) onto the new ID.
 	if err := s.renameAttachmentDir(oldID, newID); err != nil {
@@ -482,15 +572,25 @@ func (s *FSStore) renameEntity(_ context.Context, oldID, newID string) (*store.R
 	}
 
 	// Update entity index.
-	delete(s.entities, oldID)
-	s.entityOrder = storeutil.SortedRemove(s.entityOrder, oldID)
-	s.entities[newID] = entityMeta{ID: newID, Type: meta.Type}
-	s.entityOrder = storeutil.SortedInsert(s.entityOrder, newID)
-	s.notifyRenamed(oldID, renamed)
+	for _, meta := range family {
+		oldKey := stateKey(meta.ID, meta.Pointer)
+		delete(s.entities, oldKey)
+		s.entityOrder = storeutil.SortedRemove(s.entityOrder, oldKey)
+		newKey := stateKey(newID, meta.Pointer)
+		s.entities[newKey] = entityMeta{ID: newID, Type: meta.Type, Pointer: meta.Pointer}
+		s.entityOrder = storeutil.SortedInsert(s.entityOrder, newKey)
+	}
+	// Observers key documents by bare id: a headless family (tolerated
+	// from disk) has NO default face to rename in the index, and handing
+	// them a state would overwrite the bare-id document — the exact leak
+	// the notifyPut skip prevents (TKT-DOFYR1 review).
+	if renamedDefault != nil {
+		s.notifyRenamed(oldID, renamedDefault)
+	}
 
 	// Update relation index.
 	for _, rm := range toUpdate {
-		oldKey := rm.From + "--" + rm.Type + "--" + rm.To
+		oldKey := rm.key()
 		delete(s.relations, oldKey)
 		s.relationOrder = storeutil.SortedRemove(s.relationOrder, oldKey)
 
@@ -501,16 +601,20 @@ func (s *FSStore) renameEntity(_ context.Context, oldID, newID string) (*store.R
 		if newTo == oldID {
 			newTo = newID
 		}
-		newKey := newFrom + "--" + rm.Type + "--" + newTo
-		s.relations[newKey] = relationMeta{From: newFrom, Type: rm.Type, To: newTo}
+		newMeta := relationMeta{From: newFrom, Type: rm.Type, To: newTo, FromPointer: rm.FromPointer}
+		newKey := newMeta.key()
+		s.relations[newKey] = newMeta
 		s.relationOrder = storeutil.SortedInsert(s.relationOrder, newKey)
 	}
 
-	s.emit(store.Event{
-		Op:         store.EventEntityUpdated,
-		EntityType: meta.Type,
-		EntityID:   newID,
-	})
+	for _, renamed := range renamedStates {
+		s.emit(store.Event{
+			Op:         store.EventEntityUpdated,
+			EntityType: renamed.Type,
+			EntityID:   newID,
+			Pointer:    renamed.Pointer,
+		})
+	}
 
 	return &store.RenameResult{RelationsUpdated: len(toUpdate)}, nil
 }

--- a/internal/store/fsstore/fsstore.go
+++ b/internal/store/fsstore/fsstore.go
@@ -72,17 +72,43 @@ type Config struct {
 	Observers []store.EntityObserver
 }
 
-// entityMeta is the lightweight in-memory representation of an entity.
+// entityMeta is the lightweight in-memory representation of an entity
+// state. The index key for a meta is stateKey(ID, Pointer) — the bare
+// ID for the default state, the "ID@pointer" serialization otherwise —
+// which is also the filename stem.
 type entityMeta struct {
-	ID   string
-	Type string
+	ID      string
+	Type    string
+	Pointer entity.Pointer // zero = default state
 }
 
 // relationMeta is the lightweight in-memory representation of a relation.
+// FromPointer is the state-specific tail (zero = default); it is part of
+// the relation's identity and therefore of its index key and filename
+// (relKey) — two edges on the same triple with different tails are two
+// relations (TKT-DOFYR1).
 type relationMeta struct {
-	From string
-	Type string
-	To   string
+	From        string
+	Type        string
+	To          string
+	FromPointer entity.Pointer
+}
+
+// stateKey is the index key and filename stem for an entity state:
+// the bare id for the default state, the codec serialization otherwise.
+func stateKey(id string, p entity.Pointer) string {
+	return entity.FormatStateRef(id, p)
+}
+
+// relKey is the index key and filename stem for a relation. The FROM
+// slot carries the tail pointer via the codec serialization; the
+// pointer grammar forbids "--", so the key stays unambiguous.
+func relKey(from string, fp entity.Pointer, relType, to string) string {
+	return entity.FormatStateRef(from, fp) + "--" + relType + "--" + to
+}
+
+func (rm relationMeta) key() string {
+	return relKey(rm.From, rm.FromPointer, rm.Type, rm.To)
 }
 
 // attachMeta tracks attachment metadata in memory.
@@ -106,8 +132,15 @@ type attachMeta struct {
 // the interface size as the non-interface public methods
 // (FormatEntity/Relation, Start/StopWatching) move to composed helpers.
 //
-//plimsoll:max-methods=95
-//plimsoll:max-exported-methods=33
+// (95 → 102 / 33 → 34 with content states, TKT-DOFYR1: GetEntityState
+// joined the mandated store.Store interface, and the state-family
+// helpers — loadEntityMeta/loadRelationMeta/relationFileKeyMeta/
+// stateFamily/emitFamilyDeleted/rewriteRelationFiles — serve that
+// contract change. Interface growth, not internal sprawl; keep
+// ratcheting the pre-existing surplus down per TKT-N0IKN9.)
+//
+//plimsoll:max-methods=102
+//plimsoll:max-exported-methods=34
 type FSStore struct {
 	// rooted is the validated-key I/O surface. Every read, write,
 	// directory op, and remove that operates on files under the
@@ -340,7 +373,15 @@ func (s *FSStore) LastModified(_ context.Context) (time.Time, error) {
 }
 
 // notifyPut notifies all observers that an entity was created or updated.
+// Observers receive DEFAULT-STATE writes only in Step 1 (TKT-DOFYR1):
+// the search indexers key documents by bare id, so a state event would
+// overwrite the default face in the index. Until per-world indexing
+// (Step 5) the skip lives here — one place — rather than in every
+// observer; Subscribe() events are NOT filtered and fire per state.
 func (s *FSStore) notifyPut(e *entity.Entity) {
+	if !e.Pointer.IsDefault() {
+		return
+	}
 	for _, o := range s.observers {
 		_ = o.EntityPut(e)
 	}
@@ -372,8 +413,16 @@ func (s *FSStore) entityFileKey(entityType, id string) string {
 	return path.Join(s.entitiesKey, plural, id+".md")
 }
 
+// relationFileKey returns the key for a relation file with a
+// default-state tail.
 func (s *FSStore) relationFileKey(from, relType, to string) string {
 	return path.Join(s.relationsKey, from+"--"+relType+"--"+to+".md")
+}
+
+// relationFileKeyMeta returns the key for the relation an index meta
+// describes; the FROM slot carries the tail pointer (relKey).
+func (s *FSStore) relationFileKeyMeta(m relationMeta) string {
+	return path.Join(s.relationsKey, m.key()+".md")
 }
 
 // propertyOrder returns the property order for an entity type, if configured.

--- a/internal/store/fsstore/index.go
+++ b/internal/store/fsstore/index.go
@@ -2,11 +2,14 @@ package fsstore
 
 import (
 	"encoding/json"
+	"log/slog"
 	"os"
 	"path"
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/Sourcehaven-BV/rela/internal/entity"
 )
 
 const indexFile = "fsstore-index.json"
@@ -27,14 +30,16 @@ type persistedIndex struct {
 }
 
 type indexedEntity struct {
-	ID   string `json:"id"`
-	Type string `json:"type"`
+	ID      string         `json:"id"`
+	Type    string         `json:"type"`
+	Pointer entity.Pointer `json:"pointer,omitempty"`
 }
 
 type indexedRelation struct {
-	From string `json:"from"`
-	Type string `json:"type"`
-	To   string `json:"to"`
+	From        string         `json:"from"`
+	Type        string         `json:"type"`
+	To          string         `json:"to"`
+	FromPointer entity.Pointer `json:"from_pointer,omitempty"`
 }
 
 // loadPersistedIndex reads the index from disk. Returns nil if missing or corrupt.
@@ -70,8 +75,8 @@ func (s *FSStore) savePersistedIndex() error {
 		PropCache:         s.propCache,
 	}
 
-	for id, meta := range s.entities {
-		idx.Entities[id] = indexedEntity{ID: id, Type: meta.Type}
+	for key, meta := range s.entities {
+		idx.Entities[key] = indexedEntity(meta)
 	}
 	for key, meta := range s.relations {
 		idx.Relations[key] = indexedRelation(meta)
@@ -115,9 +120,9 @@ func (s *FSStore) syncEntities(cached *persistedIndex) error {
 	currentMtime := s.entitiesDirMtime()
 
 	if cached != nil && cached.Entities != nil && currentMtime.Equal(cached.EntitiesDirMtime) {
-		for id, ie := range cached.Entities {
-			s.entities[id] = entityMeta(ie)
-			s.entityOrder = append(s.entityOrder, id)
+		for key, ie := range cached.Entities {
+			s.entities[key] = entityMeta(ie)
+			s.entityOrder = append(s.entityOrder, key)
 		}
 		sortStrings(s.entityOrder)
 		return nil
@@ -146,10 +151,18 @@ func (s *FSStore) syncRelations(cached *persistedIndex) error {
 
 // rebuildPropCache reads every entity file to repopulate the property cache.
 // Called when the cached cache is stale (newer entity files exist on disk).
+//
+// DEFAULT states only, matching addEntityToCache/removeEntityFromCache's
+// call-site guards: counting a state row here would double-count its
+// family on every reopen while deletes decrement once — a permanent
+// ghost in the suggestion counts (TKT-DOFYR1 review).
 func (s *FSStore) rebuildPropCache() error {
 	s.propCache = make(map[string]map[string]int)
 	for _, meta := range s.entities {
-		e, err := s.loadEntity(meta.ID, meta.Type)
+		if !meta.Pointer.IsDefault() {
+			continue
+		}
+		e, err := s.loadEntityMeta(meta)
 		if err != nil {
 			continue
 		}
@@ -203,8 +216,18 @@ func (s *FSStore) scanEntityDirs() error {
 				if f.IsDir() || !strings.HasSuffix(f.Name(), ".md") {
 					continue
 				}
-				id := strings.TrimSuffix(f.Name(), ".md")
-				entries = append(entries, entityMeta{ID: id, Type: entityType})
+				stem := strings.TrimSuffix(f.Name(), ".md")
+				// The stem is the state key: bare id, or "id@pointer"
+				// (TKT-DOFYR1). A stem the codec rejects is skipped
+				// with a warning, never a hard error — the load path
+				// tolerates hand-edited layouts; analyze surfaces them.
+				id, ptr, refErr := entity.ParseStateRef(stem)
+				if refErr != nil {
+					slog.Warn("fsstore: skipping entity file with invalid name",
+						"file", f.Name(), "dir", dirName, "error", refErr)
+					continue
+				}
+				entries = append(entries, entityMeta{ID: id, Type: entityType, Pointer: ptr})
 			}
 			results[idx] = result{entries: entries}
 		}(i, typeDir.Name())
@@ -214,8 +237,9 @@ func (s *FSStore) scanEntityDirs() error {
 	// Merge results into the index.
 	for _, r := range results {
 		for _, meta := range r.entries {
-			s.entities[meta.ID] = meta
-			s.entityOrder = append(s.entityOrder, meta.ID)
+			key := stateKey(meta.ID, meta.Pointer)
+			s.entities[key] = meta
+			s.entityOrder = append(s.entityOrder, key)
 		}
 	}
 
@@ -239,12 +263,22 @@ func (s *FSStore) scanRelationDir() error {
 			continue
 		}
 		name := strings.TrimSuffix(f.Name(), ".md")
-		from, relType, to := parseRelationFilename(name)
-		if from == "" || relType == "" || to == "" {
+		fromSlot, relType, to := parseRelationFilename(name)
+		if fromSlot == "" || relType == "" || to == "" {
 			continue
 		}
-		key := from + "--" + relType + "--" + to
-		s.relations[key] = relationMeta{From: from, Type: relType, To: to}
+		// The FROM slot may carry a tail pointer ("id@pointer",
+		// TKT-DOFYR1). An unparseable slot is skipped with a warning —
+		// load tolerance, like the entity scan.
+		from, fp, refErr := entity.ParseStateRef(fromSlot)
+		if refErr != nil {
+			slog.Warn("fsstore: skipping relation file with invalid FROM slot",
+				"file", f.Name(), "error", refErr)
+			continue
+		}
+		rm := relationMeta{From: from, Type: relType, To: to, FromPointer: fp}
+		key := rm.key()
+		s.relations[key] = rm
 		s.relationOrder = append(s.relationOrder, key)
 	}
 
@@ -304,7 +338,7 @@ func (s *FSStore) resolveEntityType(dirName string, pluralToType map[string]stri
 func (s *FSStore) newestEntityFileMtime() time.Time {
 	var newest time.Time
 	for _, meta := range s.entities {
-		key := s.entityFileKey(meta.Type, meta.ID)
+		key := s.entityFileKey(meta.Type, stateKey(meta.ID, meta.Pointer))
 		if info, err := s.rooted.Stat(key); err == nil {
 			if info.ModTime().After(newest) {
 				newest = info.ModTime()
@@ -319,7 +353,7 @@ func (s *FSStore) newestEntityFileMtime() time.Time {
 func (s *FSStore) newestRelationFileMtime() time.Time {
 	var newest time.Time
 	for _, meta := range s.relations {
-		key := s.relationFileKey(meta.From, meta.Type, meta.To)
+		key := s.relationFileKeyMeta(meta)
 		if info, err := s.rooted.Stat(key); err == nil {
 			if info.ModTime().After(newest) {
 				newest = info.ModTime()

--- a/internal/store/fsstore/markdown.go
+++ b/internal/store/fsstore/markdown.go
@@ -278,9 +278,12 @@ func formatEntity(e *entity.Entity, propertyOrder []string) (string, error) {
 	return formatDocumentOrdered(fm, content, keyOrder)
 }
 
-// writeEntityFile writes an entity to a markdown file using temp-file + rename.
+// writeEntityFile writes an entity to a markdown file using temp-file +
+// rename. The filename stem is the state key ("id" or "id@pointer");
+// the pointer lives ONLY in the filename — entity frontmatter carries
+// no pointer key, so there is a single source of truth (TKT-DOFYR1).
 func (s *FSStore) writeEntityFile(e *entity.Entity) error {
-	key := s.entityFileKey(e.Type, e.ID)
+	key := s.entityFileKey(e.Type, stateKey(e.ID, e.Pointer))
 	order := s.propertyOrder(e.Type)
 	content, err := formatEntity(e, order)
 	if err != nil {
@@ -316,6 +319,12 @@ func (s *FSStore) readRelationFile(key, from, relType, to string) (*entity.Relat
 		doc.getString("relation"),
 		doc.getString("to"),
 	)
+	// from_pointer frontmatter is WRITE-ONLY human documentation: the
+	// filename (and hence the index meta, stamped by loadRelationMeta)
+	// is the single authority for the tail pointer, mirroring entities
+	// where the pointer lives only in the filename. Parsing it here
+	// would create a second source of truth that a hand-edit could
+	// desynchronize (TKT-DOFYR1 review).
 	r.Content = doc.content
 
 	if info, err := s.rooted.Stat(key); err == nil {
@@ -353,15 +362,21 @@ func (s *FSStore) buildInaccessibleRelation(
 }
 
 // formatRelation formats a relation as markdown with YAML frontmatter.
+// from_pointer is written only for a non-default tail (TKT-DOFYR1): the
+// key never appears for pointerless projects, and the codec never emits
+// an empty pointer.
 func formatRelation(r *entity.Relation) (string, error) {
 	fm := map[string]any{
 		"from":     r.From,
 		"relation": r.Type,
 		"to":       r.To,
 	}
+	if !r.FromPointer.IsDefault() {
+		fm["from_pointer"] = string(r.FromPointer)
+	}
 	maps.Copy(fm, r.Properties)
 
-	keyOrder := []string{"from", "relation", "to"}
+	keyOrder := []string{"from", "from_pointer", "relation", "to"}
 
 	content := r.Content
 	if content != "" {
@@ -371,9 +386,12 @@ func formatRelation(r *entity.Relation) (string, error) {
 	return formatDocumentOrdered(fm, content, keyOrder)
 }
 
-// writeRelationFile writes a relation to a markdown file using temp-file + rename.
+// writeRelationFile writes a relation to a markdown file using temp-file +
+// rename. The FROM slot of the filename carries the tail pointer.
 func (s *FSStore) writeRelationFile(r *entity.Relation) error {
-	key := s.relationFileKey(r.From, r.Type, r.To)
+	key := s.relationFileKeyMeta(relationMeta{
+		From: r.From, Type: r.Type, To: r.To, FromPointer: r.FromPointer,
+	})
 	content, err := formatRelation(r)
 	if err != nil {
 		return err

--- a/internal/store/fsstore/propcache.go
+++ b/internal/store/fsstore/propcache.go
@@ -40,11 +40,31 @@ func removeEntityFromCache(cache map[string]map[string]int, e *entity.Entity) {
 }
 
 // loadEntity reads a single entity from disk.
-func (s *FSStore) loadEntity(id, entityType string) (*entity.Entity, error) {
-	return s.readEntityFile(s.entityFileKey(entityType, id), id, entityType)
+// loadEntityMeta reads the state an index meta describes. The pointer is
+// filename/index-authoritative — entity frontmatter carries no pointer
+// key — so it is stamped here after the read (TKT-DOFYR1).
+func (s *FSStore) loadEntityMeta(m entityMeta) (*entity.Entity, error) {
+	key := s.entityFileKey(m.Type, stateKey(m.ID, m.Pointer))
+	e, err := s.readEntityFile(key, m.ID, m.Type)
+	if err != nil {
+		return nil, err
+	}
+	e.Pointer = m.Pointer
+	return e, nil
 }
 
 // loadRelation reads a single relation from disk.
 func (s *FSStore) loadRelation(from, relType, to string) (*entity.Relation, error) {
 	return s.readRelationFile(s.relationFileKey(from, relType, to), from, relType, to)
+}
+
+// loadRelationMeta reads the relation an index meta describes, stamping
+// the identity-bearing tail pointer from the index.
+func (s *FSStore) loadRelationMeta(m relationMeta) (*entity.Relation, error) {
+	r, err := s.readRelationFile(s.relationFileKeyMeta(m), m.From, m.Type, m.To)
+	if err != nil {
+		return nil, err
+	}
+	r.FromPointer = m.FromPointer
+	return r, nil
 }

--- a/internal/store/fsstore/relation.go
+++ b/internal/store/fsstore/relation.go
@@ -12,9 +12,17 @@ import (
 
 // --- RelationReader ---
 
+// defaultTailKey addresses the DEFAULT-tail edge of a triple. Get,
+// update, and delete are default-tail-only in Step 1 (TKT-DOFYR1) —
+// see store.RelationData.FromPointer; state-tailed edges are removed
+// via the entity cascades.
+func defaultTailKey(from, relType, to string) string {
+	return relKey(from, "", relType, to)
+}
+
 func (s *FSStore) GetRelation(_ context.Context, from, relType, to string) (*entity.Relation, error) {
 	s.mu.RLock()
-	key := from + "--" + relType + "--" + to
+	key := defaultTailKey(from, relType, to)
 	_, ok := s.relations[key]
 	s.mu.RUnlock()
 
@@ -32,22 +40,18 @@ func (s *FSStore) GetRelation(_ context.Context, from, relType, to string) (*ent
 func (s *FSStore) ListRelations(_ context.Context, q store.RelationQuery) iter.Seq2[*entity.Relation, error] {
 	s.mu.RLock()
 
-	type relKey struct {
-		from, typ, to string
-	}
-	matches := make([]relKey, 0)
+	matches := make([]relationMeta, 0)
 	for _, key := range s.relationOrder {
 		if !matchRelationKey(s, key, q) {
 			continue
 		}
-		rm := s.relations[key]
-		matches = append(matches, relKey{rm.From, rm.Type, rm.To})
+		matches = append(matches, s.relations[key])
 	}
 	s.mu.RUnlock()
 
 	return func(yield func(*entity.Relation, error) bool) {
 		for _, m := range matches {
-			r, err := s.loadRelation(m.from, m.typ, m.to)
+			r, err := s.loadRelationMeta(m)
 			if err != nil {
 				if !yield(nil, err) {
 					return
@@ -72,17 +76,15 @@ func (s *FSStore) ListRelationsPage(_ context.Context, q store.RelationQuery) (s
 		return matchRelationKey(s, key, q)
 	})
 
-	type relKey struct{ from, typ, to string }
-	pairs := make([]relKey, 0, len(keys.Keys))
+	pairs := make([]relationMeta, 0, len(keys.Keys))
 	for _, key := range keys.Keys {
-		rm := s.relations[key]
-		pairs = append(pairs, relKey{rm.From, rm.Type, rm.To})
+		pairs = append(pairs, s.relations[key])
 	}
 	s.mu.RUnlock()
 
 	items := make([]*entity.Relation, 0, len(pairs))
 	for _, p := range pairs {
-		r, err := s.loadRelation(p.from, p.typ, p.to)
+		r, err := s.loadRelationMeta(p)
 		if err != nil {
 			return store.Page[*entity.Relation]{}, err
 		}
@@ -95,7 +97,7 @@ func (s *FSStore) ListRelationsPage(_ context.Context, q store.RelationQuery) (s
 // matches q. Callers must hold s.mu (at least for reading).
 func matchRelationKey(s *FSStore, key string, q store.RelationQuery) bool {
 	rm := s.relations[key]
-	r := &entity.Relation{From: rm.From, Type: rm.Type, To: rm.To}
+	r := &entity.Relation{From: rm.From, FromPointer: rm.FromPointer, Type: rm.Type, To: rm.To}
 	return storeutil.MatchRelation(r, q)
 }
 
@@ -106,7 +108,7 @@ func (s *FSStore) CountRelations(_ context.Context, q store.RelationQuery) (int,
 	count := 0
 	for _, key := range s.relationOrder {
 		rm := s.relations[key]
-		r := &entity.Relation{From: rm.From, Type: rm.Type, To: rm.To}
+		r := &entity.Relation{From: rm.From, FromPointer: rm.FromPointer, Type: rm.Type, To: rm.To}
 		if storeutil.MatchRelation(r, q) {
 			count++
 		}
@@ -128,15 +130,21 @@ func (s *FSStore) createRelation(
 		return nil, err
 	}
 
+	var fp entity.Pointer
+	if data != nil {
+		fp = data.FromPointer
+	}
+
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	key := from + "--" + relType + "--" + to
+	key := relKey(from, fp, relType, to)
 	if _, exists := s.relations[key]; exists {
 		return nil, store.ErrConflict
 	}
 
 	r := entity.NewRelation(from, relType, to)
+	r.FromPointer = fp
 	r.UpdatedAt = time.Now()
 	if data != nil {
 		r.Content = data.Content
@@ -154,7 +162,7 @@ func (s *FSStore) createRelation(
 	}
 
 	// Update index.
-	s.relations[key] = relationMeta{From: from, Type: relType, To: to}
+	s.relations[key] = relationMeta{From: from, Type: relType, To: to, FromPointer: fp}
 	s.relationOrder = storeutil.SortedInsert(s.relationOrder, key)
 
 	s.emit(store.Event{
@@ -162,6 +170,7 @@ func (s *FSStore) createRelation(
 		RelationType: relType,
 		From:         from,
 		To:           to,
+		Pointer:      fp,
 	})
 	return r.Clone(), nil
 }
@@ -172,7 +181,7 @@ func (s *FSStore) updateRelation(
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	key := from + "--" + relType + "--" + to
+	key := defaultTailKey(from, relType, to)
 	if _, ok := s.relations[key]; !ok {
 		return nil, store.ErrNotFound
 	}

--- a/internal/store/fsstore/states_observer_test.go
+++ b/internal/store/fsstore/states_observer_test.go
@@ -1,0 +1,106 @@
+package fsstore_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/Sourcehaven-BV/rela/internal/entity"
+	"github.com/Sourcehaven-BV/rela/internal/storage"
+	"github.com/Sourcehaven-BV/rela/internal/store"
+	"github.com/Sourcehaven-BV/rela/internal/store/fsstore"
+)
+
+// stateObserver records every observer callback with the state pointer
+// (for puts/renames) so the tests can assert the Step-1 skip.
+type stateObserver struct {
+	puts    []string
+	deletes []string
+	renames []string
+}
+
+func (o *stateObserver) EntityPut(e *entity.Entity) error {
+	o.puts = append(o.puts, e.ID+"|"+string(e.Pointer))
+	return nil
+}
+func (o *stateObserver) EntityDelete(id string) error {
+	o.deletes = append(o.deletes, id)
+	return nil
+}
+func (o *stateObserver) EntityRenamed(oldID string, renamed *entity.Entity) error {
+	o.renames = append(o.renames, oldID+"->"+renamed.ID+"|"+string(renamed.Pointer))
+	return nil
+}
+
+func openStoreWithObserver(t *testing.T, fs *storage.MemFS, o *stateObserver) *fsstore.FSStore {
+	t.Helper()
+	cfg := newConfig(fs)
+	cfg.Observers = []store.EntityObserver{o}
+	s, err := fsstore.New(cfg)
+	require.NoError(t, err)
+	return s
+}
+
+// TestObservers_SkipNonDefaultStates is fsstore's mirror of the
+// memstore pin (TKT-DOFYR1, RR-8U1PE2): observers — the search
+// indexers — key documents by bare id, so non-default states must not
+// reach them through ANY notify path: put, update, or rename.
+func TestObservers_SkipNonDefaultStates(t *testing.T) {
+	fs := storage.NewMemFS()
+	ctx := context.Background()
+	obs := &stateObserver{}
+	s := openStoreWithObserver(t, fs, obs)
+	defer func() { require.NoError(t, s.Close()) }()
+
+	def := entity.New("REQ-1", "requirement")
+	require.NoError(t, s.CreateEntity(ctx, def))
+	draft := entity.New("REQ-1", "requirement")
+	draft.Pointer = mustPtr(t, "draft")
+	require.NoError(t, s.CreateEntity(ctx, draft))
+	draft.Properties = map[string]any{"title": "edited"}
+	require.NoError(t, s.UpdateEntity(ctx, draft))
+
+	assert.Equal(t, []string{"REQ-1|"}, obs.puts,
+		"only the default face reaches observers")
+
+	// A family rename notifies with the DEFAULT face only.
+	_, err := s.RenameEntity(ctx, "REQ-1", "REQ-2")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"REQ-1->REQ-2|"}, obs.renames)
+}
+
+// TestObservers_HeadlessRenameSkips pins the review-found leak: a
+// headless family (state file on disk with no default — tolerated by
+// the load path) has NO default face, so a rename must notify NO
+// observer rather than handing them a state that would overwrite the
+// bare-id search document.
+func TestObservers_HeadlessRenameSkips(t *testing.T) {
+	fs := storage.NewMemFS()
+	ctx := context.Background()
+
+	// Hand-write a headless state file — the write path rejects this
+	// shape, but the load path tolerates it (design doc §6).
+	require.NoError(t, fs.MkdirAll("/entities/requirements", 0o755))
+	require.NoError(t, fs.WriteFile("/entities/requirements/REQ-9@draft.md",
+		[]byte("---\nid: REQ-9\ntype: requirement\ntitle: headless draft\n---\n"), 0o644))
+
+	obs := &stateObserver{}
+	s := openStoreWithObserver(t, fs, obs)
+	defer func() { require.NoError(t, s.Close()) }()
+
+	// The headless state loads (tolerance) and is addressable.
+	got, err := s.GetEntityState(ctx, "REQ-9", mustPtr(t, "draft"))
+	require.NoError(t, err)
+	assert.Equal(t, "REQ-9", got.ID)
+
+	_, err = s.RenameEntity(ctx, "REQ-9", "REQ-10")
+	require.NoError(t, err)
+	assert.Empty(t, obs.renames, "a headless family has no default face to hand observers")
+	assert.Empty(t, obs.puts)
+
+	// The rename itself still happened.
+	_, err = s.GetEntityState(ctx, "REQ-10", mustPtr(t, "draft"))
+	require.NoError(t, err)
+}

--- a/internal/store/fsstore/states_persistence_test.go
+++ b/internal/store/fsstore/states_persistence_test.go
@@ -1,0 +1,97 @@
+package fsstore_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/Sourcehaven-BV/rela/internal/entity"
+	"github.com/Sourcehaven-BV/rela/internal/storage"
+)
+
+func mustPtr(t *testing.T, v string) entity.Pointer {
+	t.Helper()
+	p, err := entity.ParsePointer(v)
+	require.NoError(t, err)
+	return p
+}
+
+// TestStatePersistence_FamilySurvivesReopen pins the state family across
+// a store restart (TKT-DOFYR1): the filename serialization round-trips,
+// the reopened index keys states correctly, and — the review-found
+// corruption — the rebuilt prop cache stays DEFAULT-only instead of
+// double-counting a family (a surplus that deletes could never claw
+// back, leaving ghost suggestion values forever).
+func TestStatePersistence_FamilySurvivesReopen(t *testing.T) {
+	fs := storage.NewMemFS()
+	ctx := context.Background()
+
+	s1 := openStore(t, fs)
+	def := entity.New("REQ-1", "requirement")
+	def.Properties["title"] = "Default face"
+	def.Properties["status"] = "open"
+	require.NoError(t, s1.CreateEntity(ctx, def))
+
+	draft := entity.New("REQ-1", "requirement")
+	draft.Pointer = mustPtr(t, "draft")
+	draft.Properties["title"] = "Draft face"
+	draft.Properties["status"] = "open"
+	require.NoError(t, s1.CreateEntity(ctx, draft))
+
+	_, err := s1.CreateRelation(ctx, "REQ-1", "refines", "REQ-1", nil)
+	require.NoError(t, err)
+	require.NoError(t, s1.Close())
+
+	// Reopen: the family and the state-tailed addressing survive.
+	s2 := openStore(t, fs)
+	defer func() { require.NoError(t, s2.Close()) }()
+
+	got, err := s2.GetEntityState(ctx, "REQ-1", mustPtr(t, "draft"))
+	require.NoError(t, err)
+	assert.Equal(t, "REQ-1", got.ID)
+	assert.Equal(t, "Draft face", got.Properties["title"])
+
+	// Prop cache after rebuild counts the DEFAULT face once — not the
+	// family twice.
+	vals, err := s2.PropertyValues(ctx, "status", 0)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"open"}, vals)
+
+	// Deleting the family clears the count entirely: no ghost values.
+	_, err = s2.DeleteEntity(ctx, "REQ-1", true)
+	require.NoError(t, err)
+	vals, err = s2.PropertyValues(ctx, "status", 0)
+	require.NoError(t, err)
+	assert.Empty(t, vals, "deleted family must not leave ghost suggestion values")
+}
+
+// TestStatePersistence_StateWriteFreshensCache pins that an external
+// edit to a STATE file invalidates the persisted index freshness check:
+// newestEntityFileMtime must stat the state file, not the default file
+// (the review-found staleness).
+func TestStatePersistence_StateWriteFreshensCache(t *testing.T) {
+	fs := storage.NewMemFS()
+	ctx := context.Background()
+
+	s1 := openStore(t, fs)
+	def := entity.New("REQ-2", "requirement")
+	def.Properties["status"] = "open"
+	require.NoError(t, s1.CreateEntity(ctx, def))
+	draft := entity.New("REQ-2", "requirement")
+	draft.Pointer = mustPtr(t, "review-2")
+	draft.Properties["status"] = "open"
+	require.NoError(t, s1.CreateEntity(ctx, draft))
+
+	before, err := s1.LastModified(ctx)
+	require.NoError(t, err)
+
+	// A state-only write must move LastModified forward.
+	draft.Properties["status"] = "in-review"
+	require.NoError(t, s1.UpdateEntity(ctx, draft))
+	after, err := s1.LastModified(ctx)
+	require.NoError(t, err)
+	assert.True(t, after.After(before), "state write must be visible to LastModified (got before=%v after=%v)", before, after)
+	require.NoError(t, s1.Close())
+}

--- a/internal/store/fsstore/watcher.go
+++ b/internal/store/fsstore/watcher.go
@@ -194,28 +194,36 @@ func (s *FSStore) reconcileEntityPath(path string) {
 	if err != nil {
 		return
 	}
+	// The filename stem is authoritative for the pointer (TKT-DOFYR1):
+	// a state file's frontmatter carries only the bare id.
+	if _, ptr, _, ok := s.entityIdentityFromPath(path); ok {
+		e.Pointer = ptr
+	}
 
 	s.echoes.Recorded(path, rawData)
 
-	existing, known := s.entities[e.ID]
-	if known {
-		removed, loadErr := s.loadEntity(existing.ID, existing.Type)
+	key := stateKey(e.ID, e.Pointer)
+	existing, known := s.entities[key]
+	if known && existing.Pointer.IsDefault() {
+		removed, loadErr := s.loadEntityMeta(existing)
 		if loadErr == nil {
 			removeEntityFromCache(s.propCache, removed)
 		}
 	}
-	s.entities[e.ID] = entityMeta{ID: e.ID, Type: e.Type}
+	s.entities[key] = entityMeta{ID: e.ID, Type: e.Type, Pointer: e.Pointer}
 	if !known {
-		s.entityOrder = storeutil.SortedInsert(s.entityOrder, e.ID)
+		s.entityOrder = storeutil.SortedInsert(s.entityOrder, key)
 	}
-	addEntityToCache(s.propCache, e)
+	if e.Pointer.IsDefault() {
+		addEntityToCache(s.propCache, e)
+	}
 	s.notifyPut(e)
 
 	op := store.EventEntityUpdated
 	if !known {
 		op = store.EventEntityCreated
 	}
-	s.emit(store.Event{Op: op, EntityType: e.Type, EntityID: e.ID})
+	s.emit(store.Event{Op: op, EntityType: e.Type, EntityID: e.ID, Pointer: e.Pointer})
 }
 
 // handleEntityRemoval handles the disappearance of an entity file.
@@ -223,27 +231,36 @@ func (s *FSStore) reconcileEntityPath(path string) {
 func (s *FSStore) handleEntityRemoval(path string) {
 	s.echoes.Forget(path)
 
-	id, ok := s.entityIDFromPath(path)
+	stem, ok := s.entityStemFromPath(path)
 	if !ok {
 		return
 	}
-	meta, known := s.entities[id]
+	// The stem IS the state key ("id" or "id@pointer").
+	meta, known := s.entities[stem]
 	if !known {
 		return
 	}
 
-	if e, err := s.loadEntity(meta.ID, meta.Type); err == nil {
-		removeEntityFromCache(s.propCache, e)
+	if meta.Pointer.IsDefault() {
+		if e, err := s.loadEntityMeta(meta); err == nil {
+			removeEntityFromCache(s.propCache, e)
+		}
 	}
-	delete(s.entities, id)
-	s.entityOrder = storeutil.SortedRemove(s.entityOrder, id)
-	s.notifyDelete(id)
-	s.emit(store.Event{Op: store.EventEntityDeleted, EntityType: meta.Type, EntityID: id})
+	delete(s.entities, stem)
+	s.entityOrder = storeutil.SortedRemove(s.entityOrder, stem)
+	if meta.Pointer.IsDefault() {
+		// Observer deletions are bare-id keyed; a state removal must
+		// not evict the default face from the search index (Step-1
+		// observer skip, TKT-DOFYR1).
+		s.notifyDelete(meta.ID)
+	}
+	s.emit(store.Event{Op: store.EventEntityDeleted, EntityType: meta.Type, EntityID: meta.ID, Pointer: meta.Pointer})
 }
 
-// entityIDFromPath extracts the entity ID from a file path under the
-// entities directory: entitiesDir/<plural>/<id>.md.
-func (s *FSStore) entityIDFromPath(path string) (string, bool) {
+// entityStemFromPath extracts the filename stem — the STATE KEY, "id"
+// or "id@pointer" — from a file path under the entities directory:
+// entitiesDir/<plural>/<stem>.md.
+func (s *FSStore) entityStemFromPath(path string) (string, bool) {
 	base := filepath.Base(path)
 	if !strings.HasSuffix(base, ".md") {
 		return "", false
@@ -251,26 +268,31 @@ func (s *FSStore) entityIDFromPath(path string) (string, bool) {
 	return strings.TrimSuffix(base, ".md"), true
 }
 
-// entityIdentityFromPath extracts both the entity ID and entity type
-// from a file path under entitiesDir/<plural>/<id>.md. The plural
-// directory name is mapped back to the entity type via the configured
-// schemas. Returns ok=false if the path doesn't have the expected shape
-// or the plural directory doesn't map to a known type.
-func (s *FSStore) entityIdentityFromPath(path string) (id, entityType string, ok bool) {
-	id, ok = s.entityIDFromPath(path)
+// entityIdentityFromPath extracts the bare entity ID, the state
+// pointer, and the entity type from a file path under
+// entitiesDir/<plural>/<stem>.md. The plural directory name is mapped
+// back to the entity type via the configured schemas. Returns ok=false
+// if the path doesn't have the expected shape, the stem doesn't parse
+// as a state reference, or the plural doesn't map to a known type.
+func (s *FSStore) entityIdentityFromPath(path string) (id string, ptr entity.Pointer, entityType string, ok bool) {
+	stem, ok := s.entityStemFromPath(path)
 	if !ok {
-		return "", "", false
+		return "", "", "", false
+	}
+	id, ptr, err := entity.ParseStateRef(stem)
+	if err != nil {
+		return "", "", "", false
 	}
 	parent := filepath.Base(filepath.Dir(path))
 	if parent == "" {
-		return "", "", false
+		return "", "", "", false
 	}
 	pluralToType := s.buildPluralToTypeMap()
 	entityType = s.resolveEntityType(parent, pluralToType)
 	if entityType == "" {
-		return "", "", false
+		return "", "", "", false
 	}
-	return id, entityType, true
+	return id, ptr, entityType, true
 }
 
 // reconcileRelationPath handles a change event for a relation file. Must
@@ -280,15 +302,21 @@ func (s *FSStore) reconcileRelationPath(path string) {
 	if !strings.HasSuffix(base, ".md") {
 		return
 	}
-	from, relType, to := parseRelationFilename(strings.TrimSuffix(base, ".md"))
-	if from == "" || relType == "" || to == "" {
+	fromSlot, relType, to := parseRelationFilename(strings.TrimSuffix(base, ".md"))
+	if fromSlot == "" || relType == "" || to == "" {
 		return
 	}
-	key := from + "--" + relType + "--" + to
+	// The FROM slot may carry a tail pointer ("id@pointer", TKT-DOFYR1).
+	from, fp, refErr := entity.ParseStateRef(fromSlot)
+	if refErr != nil {
+		return
+	}
+	rm := relationMeta{From: from, Type: relType, To: to, FromPointer: fp}
+	key := rm.key()
 
 	data, readErr := s.rawReader.ReadFile(path)
 	if readErr != nil {
-		s.handleRelationRemoval(path, key, from, relType, to)
+		s.handleRelationRemoval(path, key, rm)
 		return
 	}
 
@@ -302,7 +330,7 @@ func (s *FSStore) reconcileRelationPath(path string) {
 
 	_, known := s.relations[key]
 	if !known {
-		s.relations[key] = relationMeta{From: from, Type: relType, To: to}
+		s.relations[key] = rm
 		s.relationOrder = storeutil.SortedInsert(s.relationOrder, key)
 	}
 
@@ -310,12 +338,12 @@ func (s *FSStore) reconcileRelationPath(path string) {
 	if !known {
 		op = store.EventRelationCreated
 	}
-	s.emit(store.Event{Op: op, RelationType: relType, From: from, To: to})
+	s.emit(store.Event{Op: op, RelationType: relType, From: from, To: to, Pointer: fp})
 }
 
 // handleRelationRemoval handles the disappearance of a relation file.
 // Must be called under mu.Lock.
-func (s *FSStore) handleRelationRemoval(path, key, from, relType, to string) {
+func (s *FSStore) handleRelationRemoval(path, key string, rm relationMeta) {
 	s.echoes.Forget(path)
 
 	if _, known := s.relations[key]; !known {
@@ -323,7 +351,10 @@ func (s *FSStore) handleRelationRemoval(path, key, from, relType, to string) {
 	}
 	delete(s.relations, key)
 	s.relationOrder = storeutil.SortedRemove(s.relationOrder, key)
-	s.emit(store.Event{Op: store.EventRelationDeleted, RelationType: relType, From: from, To: to})
+	s.emit(store.Event{
+		Op: store.EventRelationDeleted, RelationType: rm.Type,
+		From: rm.From, To: rm.To, Pointer: rm.FromPointer,
+	})
 }
 
 // parseEntityFromPath parses raw bytes from a watcher event into an
@@ -333,12 +364,14 @@ func (s *FSStore) handleRelationRemoval(path, key, from, relType, to string) {
 // git-crypt directly.
 func (s *FSStore) parseEntityFromPath(data []byte, path string) (*entity.Entity, error) {
 	if isGitCryptEncrypted(data) {
-		id, entityType, ok := s.entityIdentityFromPath(path)
+		id, ptr, entityType, ok := s.entityIdentityFromPath(path)
 		if !ok {
 			return nil, errors.New("encrypted entity file: cannot derive id/type from path")
 		}
-		key := s.entityFileKey(entityType, id)
-		return s.buildInaccessibleEntity(key, id, entityType, entity.InaccessibleReasonGitCrypt), nil
+		key := s.entityFileKey(entityType, stateKey(id, ptr))
+		shell := s.buildInaccessibleEntity(key, id, entityType, entity.InaccessibleReasonGitCrypt)
+		shell.Pointer = ptr
+		return shell, nil
 	}
 	doc, err := parseDocument(string(data))
 	if err != nil {

--- a/internal/store/memstore/conformance_test.go
+++ b/internal/store/memstore/conformance_test.go
@@ -39,7 +39,7 @@ func fuzzFactory() store.Store {
 }
 
 func TestConformance(t *testing.T) {
-	storetest.RunAll(t, factory, searchFactory, visibleSearchFactory, storetest.Capabilities{Attachments: true})
+	storetest.RunAll(t, factory, searchFactory, visibleSearchFactory, storetest.Capabilities{Attachments: true, States: true})
 }
 
 func FuzzRelationKeyCollision(f *testing.F) {

--- a/internal/store/memstore/memstore.go
+++ b/internal/store/memstore/memstore.go
@@ -54,8 +54,12 @@ import (
 // included — only to drop the body immediately, which is the cost the
 // capability exists to remove. Interface-driven like the Tx split above.
 //
-//plimsoll:max-methods=43
-//plimsoll:max-exported-methods=29
+// (43 → 45 / 29 → 30 with content states, TKT-DOFYR1: GetEntityState
+// joined the mandated store.Store interface; rekeyFamily serves the
+// family-wide rename that contract requires.)
+//
+//plimsoll:max-methods=45
+//plimsoll:max-exported-methods=30
 type MemStore struct {
 	// txMu serializes an open Tx against ordinary writers: Tx holds it
 	// for the whole callback, every exported write method takes it
@@ -130,7 +134,15 @@ func (m *MemStore) LastModified(_ context.Context) (time.Time, error) {
 	return newest, nil
 }
 
+// Observers receive DEFAULT-STATE writes only in Step 1 (TKT-DOFYR1):
+// the search indexers key documents by bare id, so a state event would
+// overwrite the default face in the index. Same skip as fsstore — one
+// place per backend, not per observer; Subscribe() events are NOT
+// filtered and fire per state.
 func (m *MemStore) notifyPut(e *entity.Entity) {
+	if !e.Pointer.IsDefault() {
+		return
+	}
 	for _, o := range m.observers {
 		_ = o.EntityPut(e)
 	}
@@ -174,26 +186,48 @@ var (
 // Callers must hold m.mu.
 // A free function rather than a method — MemStore is at its plimsoll
 // max-methods line, and this needs no receiver state beyond the index.
+// idTaken folds on the BARE entity id: any state of an entity claims
+// the whole identity (TKT-DOFYR1). except is a BARE id matched
+// case-folded — it skips that entire family, not one exact key (wider
+// than the historical exact-key skip on purpose; a renaming family and
+// its states must not self-collide).
 func idTaken(index map[string]*entity.Entity, id, except string) bool {
 	folded := storeutil.FoldID(id)
-	for existing := range index {
-		if existing == except {
+	exceptFolded := ""
+	if except != "" {
+		exceptFolded = storeutil.FoldID(except)
+	}
+	for _, e := range index {
+		if exceptFolded != "" && storeutil.FoldID(e.ID) == exceptFolded {
 			continue
 		}
-		if storeutil.FoldID(existing) == folded {
+		if storeutil.FoldID(e.ID) == folded {
 			return true
 		}
 	}
 	return false
 }
 
+// famEntry pairs a state's index key with the stored entity during a
+// family-wide delete or rename (TKT-DOFYR1).
+type famEntry struct {
+	key string
+	e   *entity.Entity
+}
+
 // --- EntityReader ---
 
-func (m *MemStore) GetEntity(_ context.Context, id string) (*entity.Entity, error) {
+func (m *MemStore) GetEntity(ctx context.Context, id string) (*entity.Entity, error) {
+	// The bare id IS the default state's key (entity.FormatStateRef with
+	// the zero pointer).
+	return m.GetEntityState(ctx, id, "")
+}
+
+func (m *MemStore) GetEntityState(_ context.Context, id string, p entity.Pointer) (*entity.Entity, error) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
-	e, ok := m.entities[id]
+	e, ok := m.entities[entity.FormatStateRef(id, p)]
 	if !ok {
 		return nil, store.ErrNotFound
 	}
@@ -298,10 +332,15 @@ func entityIDSet(ids []string) map[string]bool {
 	return set
 }
 
-// matchEntityQuery reports whether e satisfies q's Type and IDs filters.
-// idSet must be pre-computed from q.IDs (see entityIDSet).
+// matchEntityQuery reports whether e satisfies q's Type, IDs, and
+// AllStates filters. idSet must be pre-computed from q.IDs (see
+// entityIDSet) and matches the BARE id, so IDs+AllStates selects every
+// state of the listed entities.
 func matchEntityQuery(e *entity.Entity, q store.EntityQuery, idSet map[string]bool) bool {
 	if e == nil {
+		return false
+	}
+	if !q.AllStates && !e.Pointer.IsDefault() {
 		return false
 	}
 	if q.Type != "" && e.Type != q.Type {
@@ -317,20 +356,13 @@ func (m *MemStore) CountEntities(_ context.Context, q store.EntityQuery) (int, e
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
-	idSet := make(map[string]bool, len(q.IDs))
-	for _, id := range q.IDs {
-		idSet[id] = true
-	}
+	idSet := entityIDSet(q.IDs)
 
 	count := 0
 	for _, e := range m.entities {
-		if q.Type != "" && e.Type != q.Type {
-			continue
+		if matchEntityQuery(e, q, idSet) {
+			count++
 		}
-		if len(idSet) > 0 && !idSet[e.ID] {
-			continue
-		}
-		count++
 	}
 	return count, nil
 }
@@ -341,7 +373,11 @@ func (m *MemStore) HighestID(_ context.Context, prefix string) (int, error) {
 
 	highest := 0
 	pfx := prefix + "-"
-	for id := range m.entities {
+	for _, e := range m.entities {
+		if !e.Pointer.IsDefault() {
+			continue // states share the base id's number
+		}
+		id := e.ID
 		if !strings.HasPrefix(id, pfx) {
 			continue
 		}
@@ -360,6 +396,9 @@ func (m *MemStore) PropertyValues(_ context.Context, property string, limit int)
 
 	counts := make(map[string]int)
 	for _, e := range m.entities {
+		if !e.Pointer.IsDefault() {
+			continue // suggestion counts stay default-world (TKT-DOFYR1)
+		}
 		if v, ok := e.Properties[property]; ok {
 			s := fmt.Sprintf("%v", v)
 			if s != "" {
@@ -400,23 +439,43 @@ func (m *MemStore) createEntity(_ context.Context, e *entity.Entity) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	// Case-folded so "ABC" conflicts with an existing "abc" — on fsstore they
-	// are one file, and the backends must agree on identity (BUG-3RCWNS).
-	if idTaken(m.entities, e.ID, "") {
-		return store.ErrConflict
+	key := entity.FormatStateRef(e.ID, e.Pointer)
+	if e.Pointer.IsDefault() {
+		// Case-folded so "ABC" conflicts with an existing "abc" — on fsstore
+		// they are one file, and the backends must agree on identity
+		// (BUG-3RCWNS).
+		if idTaken(m.entities, e.ID, "") {
+			return store.ErrConflict
+		}
+	} else {
+		// Row-family invariants (TKT-DOFYR1, design doc §6): no headless
+		// states, and one type per family — same choke point as fsstore.
+		def, ok := m.entities[e.ID]
+		if !ok {
+			return fmt.Errorf("%w: entity %s has no default state; a state row cannot exist headless",
+				store.ErrNotFound, e.ID)
+		}
+		if def.Type != e.Type {
+			return fmt.Errorf("state %s@%s type %q does not match the entity's type %q",
+				e.ID, e.Pointer, e.Type, def.Type)
+		}
+		if _, exists := m.entities[key]; exists {
+			return store.ErrConflict
+		}
 	}
 
 	stored := e.Clone()
 	stored.Redacted = nil // per-reader ACL artifact, never content (RR-KBWJPV)
 	stored.UpdatedAt = time.Now()
-	m.entities[e.ID] = stored
-	m.entityOrder = sortedInsert(m.entityOrder, e.ID)
+	m.entities[key] = stored
+	m.entityOrder = sortedInsert(m.entityOrder, key)
 	m.notifyPut(stored)
 
 	m.emit(store.Event{
 		Op:         store.EventEntityCreated,
 		EntityType: e.Type,
 		EntityID:   e.ID,
+		Pointer:    e.Pointer,
 	})
 	return nil
 }
@@ -425,20 +484,29 @@ func (m *MemStore) updateEntity(_ context.Context, e *entity.Entity) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	if _, exists := m.entities[e.ID]; !exists {
+	key := entity.FormatStateRef(e.ID, e.Pointer)
+	existing, exists := m.entities[key]
+	if !exists {
 		return store.ErrNotFound
+	}
+	// Row-family invariant: a non-default state cannot be re-typed away
+	// from its family (TKT-DOFYR1, design doc §6).
+	if !e.Pointer.IsDefault() && e.Type != existing.Type {
+		return fmt.Errorf("state %s@%s type %q does not match the entity's type %q",
+			e.ID, e.Pointer, e.Type, existing.Type)
 	}
 
 	stored := e.Clone()
 	stored.Redacted = nil // per-reader ACL artifact, never content (RR-KBWJPV)
 	stored.UpdatedAt = time.Now()
-	m.entities[e.ID] = stored
+	m.entities[key] = stored
 	m.notifyPut(stored)
 
 	m.emit(store.Event{
 		Op:         store.EventEntityUpdated,
 		EntityType: e.Type,
 		EntityID:   e.ID,
+		Pointer:    e.Pointer,
 	})
 	return nil
 }
@@ -447,12 +515,21 @@ func (m *MemStore) deleteEntity(_ context.Context, id string, cascade bool) (*st
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	e, ok := m.entities[id]
-	if !ok {
+	// Delete addresses the whole state FAMILY of the bare id
+	// (TKT-DOFYR1); the scan is defensive so a headless family still
+	// deletes cleanly.
+	var family []famEntry
+	for key, e := range m.entities {
+		if e.ID == id {
+			family = append(family, famEntry{key, e})
+		}
+	}
+	if len(family) == 0 {
 		return nil, store.ErrNotFound
 	}
+	sort.Slice(family, func(i, j int) bool { return family[i].e.Pointer < family[j].e.Pointer })
 
-	// Find related relations
+	// Find related relations; the bare From/To match sweeps every tail.
 	var related []*entity.Relation
 	for _, r := range m.relations {
 		if r.From == id || r.To == id {
@@ -464,12 +541,12 @@ func (m *MemStore) deleteEntity(_ context.Context, id string, cascade bool) (*st
 		return nil, fmt.Errorf("%w: entity %s has %d relation(s)", store.ErrHasRelations, id, len(related))
 	}
 
-	result := &store.DeleteResult{
-		DeletedEntities: []*entity.Entity{e.Clone()},
+	result := &store.DeleteResult{}
+	for _, fe := range family {
+		result.DeletedEntities = append(result.DeletedEntities, fe.e.Clone())
+		delete(m.entities, fe.key)
+		m.entityOrder = sortedRemove(m.entityOrder, fe.key)
 	}
-
-	delete(m.entities, id)
-	m.entityOrder = sortedRemove(m.entityOrder, id)
 	m.notifyDelete(id)
 
 	// Cascade attachments — 1:1 ownership.
@@ -486,21 +563,46 @@ func (m *MemStore) deleteEntity(_ context.Context, id string, cascade bool) (*st
 		m.relationOrder = sortedRemove(m.relationOrder, key)
 	}
 
-	m.emit(store.Event{
-		Op:         store.EventEntityDeleted,
-		EntityType: e.Type,
-		EntityID:   id,
-	})
+	for _, fe := range family {
+		// Per-state type: the load path tolerates a mistyped state, so
+		// one family-wide type would misreport it.
+		m.emit(store.Event{
+			Op:         store.EventEntityDeleted,
+			EntityType: fe.e.Type,
+			EntityID:   id,
+			Pointer:    fe.e.Pointer,
+		})
+	}
 	for _, r := range related {
 		m.emit(store.Event{
 			Op:           store.EventRelationDeleted,
 			RelationType: r.Type,
 			From:         r.From,
 			To:           r.To,
+			Pointer:      r.FromPointer,
 		})
 	}
 
 	return result, nil
+}
+
+// rekeyFamily moves every state of a family onto newID — clones to
+// avoid mutating stored objects — and returns the renamed states in
+// family order. Callers must hold m.mu.
+func (m *MemStore) rekeyFamily(family []famEntry, newID string) []*entity.Entity {
+	renamed := make([]*entity.Entity, 0, len(family))
+	for _, fe := range family {
+		r := fe.e.Clone()
+		r.ID = newID
+		r.UpdatedAt = time.Now()
+		newKey := entity.FormatStateRef(newID, r.Pointer)
+		m.entities[newKey] = r
+		delete(m.entities, fe.key)
+		m.entityOrder = sortedRemove(m.entityOrder, fe.key)
+		m.entityOrder = sortedInsert(m.entityOrder, newKey)
+		renamed = append(renamed, r)
+	}
+	return renamed
 }
 
 func (m *MemStore) renameEntity(_ context.Context, oldID, newID string) (*store.RenameResult, error) {
@@ -511,25 +613,39 @@ func (m *MemStore) renameEntity(_ context.Context, oldID, newID string) (*store.
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	e, ok := m.entities[oldID]
-	if !ok {
+	// Rename addresses the whole state FAMILY of the bare id
+	// (TKT-DOFYR1); defensive scan so a headless family still renames.
+	var family []famEntry
+	for key, e := range m.entities {
+		if e.ID == oldID {
+			family = append(family, famEntry{key, e})
+		}
+	}
+	if len(family) == 0 {
 		return nil, store.ErrNotFound
 	}
+	sort.Slice(family, func(i, j int) bool { return family[i].e.Pointer < family[j].e.Pointer })
+
 	// except=oldID: renaming an entity to a different casing of its own ID
-	// (abc -> ABC) is legitimate and must not self-collide.
+	// (abc -> ABC) is legitimate and must not self-collide. idTaken folds
+	// on the bare id, so any state of another entity conflicts.
 	if idTaken(m.entities, newID, oldID) {
 		return nil, store.ErrConflict
 	}
 
-	// Update entity — clone to avoid mutating stored object
-	renamed := e.Clone()
-	renamed.ID = newID
-	renamed.UpdatedAt = time.Now()
-	m.entities[newID] = renamed
-	delete(m.entities, oldID)
-	m.entityOrder = sortedRemove(m.entityOrder, oldID)
-	m.entityOrder = sortedInsert(m.entityOrder, newID)
-	m.notifyRenamed(oldID, renamed)
+	renamedStates := m.rekeyFamily(family, newID)
+	var renamedDefault *entity.Entity
+	for _, r := range renamedStates {
+		if r.Pointer.IsDefault() {
+			renamedDefault = r
+		}
+	}
+	// Observers key documents by bare id: a headless family has no
+	// default face, and handing them a state would overwrite the
+	// bare-id document — same skip as notifyPut (TKT-DOFYR1 review).
+	if renamedDefault != nil {
+		m.notifyRenamed(oldID, renamedDefault)
+	}
 
 	// Update relations — clone each affected relation
 	relationsUpdated := 0
@@ -572,22 +688,33 @@ func (m *MemStore) renameEntity(_ context.Context, oldID, newID string) (*store.
 	}
 	maps.Copy(m.attachments, reKey)
 
-	m.emit(store.Event{
-		Op:         store.EventEntityUpdated,
-		EntityType: renamed.Type,
-		EntityID:   newID,
-	})
+	for _, renamed := range renamedStates {
+		m.emit(store.Event{
+			Op:         store.EventEntityUpdated,
+			EntityType: renamed.Type,
+			EntityID:   newID,
+			Pointer:    renamed.Pointer,
+		})
+	}
 
 	return &store.RenameResult{RelationsUpdated: relationsUpdated}, nil
 }
 
 // --- RelationReader ---
 
+// defaultTailKey addresses the DEFAULT-tail edge of a triple. Get,
+// update, and delete are default-tail-only in Step 1 (TKT-DOFYR1) —
+// see store.RelationData.FromPointer; state-tailed edges are removed
+// via the entity cascades.
+func defaultTailKey(from, relType, to string) string {
+	return (&entity.Relation{From: from, Type: relType, To: to}).Key()
+}
+
 func (m *MemStore) GetRelation(_ context.Context, from, relType, to string) (*entity.Relation, error) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
-	key := from + "--" + relType + "--" + to
+	key := defaultTailKey(from, relType, to)
 	r, ok := m.relations[key]
 	if !ok {
 		return nil, store.ErrNotFound
@@ -673,6 +800,7 @@ func (m *MemStore) createRelation(
 	r := entity.NewRelation(from, relType, to)
 	r.UpdatedAt = time.Now()
 	if data != nil {
+		r.FromPointer = data.FromPointer // tail pointer is identity (TKT-DOFYR1)
 		r.Content = data.Content
 		if data.Properties != nil {
 			r.Properties = make(map[string]any, len(data.Properties))
@@ -695,6 +823,7 @@ func (m *MemStore) createRelation(
 		RelationType: relType,
 		From:         from,
 		To:           to,
+		Pointer:      r.FromPointer,
 	})
 	return r.Clone(), nil
 }
@@ -705,7 +834,7 @@ func (m *MemStore) updateRelation(
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	key := from + "--" + relType + "--" + to
+	key := defaultTailKey(from, relType, to)
 	r, ok := m.relations[key]
 	if !ok {
 		return nil, store.ErrNotFound
@@ -737,7 +866,7 @@ func (m *MemStore) deleteRelation(_ context.Context, from, relType, to string) e
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	key := from + "--" + relType + "--" + to
+	key := defaultTailKey(from, relType, to)
 	if _, ok := m.relations[key]; !ok {
 		return store.ErrNotFound
 	}

--- a/internal/store/memstore/states_observer_test.go
+++ b/internal/store/memstore/states_observer_test.go
@@ -1,0 +1,59 @@
+package memstore
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Sourcehaven-BV/rela/internal/entity"
+)
+
+// recordingObserver records the ids EntityPut delivers.
+type recordingObserver struct {
+	puts    []string
+	deletes []string
+}
+
+func (r *recordingObserver) EntityPut(e *entity.Entity) error {
+	r.puts = append(r.puts, e.ID+"|"+string(e.Pointer))
+	return nil
+}
+func (r *recordingObserver) EntityDelete(id string) error {
+	r.deletes = append(r.deletes, id)
+	return nil
+}
+func (r *recordingObserver) EntityRenamed(string, *entity.Entity) error { return nil }
+
+// TestObservers_SkipNonDefaultStates pins the Step-1 observer contract
+// (TKT-DOFYR1, RR-8U1PE2): observers — the search indexers — key
+// documents by bare id, so a non-default state write must NOT reach
+// them or it would overwrite the default face in the index. The skip
+// lives at the notify site; Subscribe() events are unfiltered.
+// TODO(step 5 / TKT-9KZGJO): revisit when per-world indexing lands.
+func TestObservers_SkipNonDefaultStates(t *testing.T) {
+	obs := &recordingObserver{}
+	m := New(WithObserver(obs))
+	ctx := context.Background()
+
+	def := entity.New("PAGE-1", "page")
+	if err := m.CreateEntity(ctx, def); err != nil {
+		t.Fatal(err)
+	}
+	draft := entity.New("PAGE-1", "page")
+	p, err := entity.ParsePointer("draft")
+	if err != nil {
+		t.Fatal(err)
+	}
+	draft.Pointer = p
+	if err := m.CreateEntity(ctx, draft); err != nil {
+		t.Fatal(err)
+	}
+	draft.SetString("title", "edited")
+	if err := m.UpdateEntity(ctx, draft); err != nil {
+		t.Fatal(err)
+	}
+
+	want := []string{"PAGE-1|"}
+	if len(obs.puts) != 1 || obs.puts[0] != want[0] {
+		t.Errorf("observer puts = %v, want only the default state %v", obs.puts, want)
+	}
+}

--- a/internal/store/pgstore/entity.go
+++ b/internal/store/pgstore/entity.go
@@ -37,6 +37,9 @@ func (s *Store) GetEntity(ctx context.Context, id string) (*entity.Entity, error
 // ListEntities streams entities matching q in ascending-ID order. Cursor and
 // Limit are ignored (per the EntityReader contract).
 func (s *Store) ListEntities(ctx context.Context, q store.EntityQuery) iter.Seq2[*entity.Entity, error] {
+	if err := rejectStateQuery("ListEntities", q); err != nil {
+		return func(yield func(*entity.Entity, error) bool) { yield(nil, err) }
+	}
 	sql, args := buildEntityListSQL(q, "")
 	return func(yield func(*entity.Entity, error) bool) {
 		rows, err := s.db.Query(ctx, sql, args...)
@@ -72,6 +75,9 @@ func (s *Store) ListEntities(ctx context.Context, q store.EntityQuery) iter.Seq2
 func (s *Store) ListEntityHeaders(
 	ctx context.Context, q store.EntityQuery,
 ) iter.Seq2[store.EntityHeader, error] {
+	if err := rejectStateQuery("ListEntityHeaders", q); err != nil {
+		return func(yield func(store.EntityHeader, error) bool) { yield(store.EntityHeader{}, err) }
+	}
 	sql, args := buildEntityHeaderListSQL(q, "")
 	return func(yield func(store.EntityHeader, error) bool) {
 		rows, err := s.db.Query(ctx, sql, args...)
@@ -99,6 +105,9 @@ func (s *Store) ListEntityHeaders(
 // ListEntitiesPage returns a page of entities. A keyset cursor on id keeps
 // pages stable; see store.ListEntitiesPage for the contract.
 func (s *Store) ListEntitiesPage(ctx context.Context, q store.EntityQuery) (store.Page[*entity.Entity], error) {
+	if err := rejectStateQuery("ListEntitiesPage", q); err != nil {
+		return store.Page[*entity.Entity]{}, err
+	}
 	cursorKey, err := storeutil.DecodeCursor(q.Cursor)
 	if err != nil {
 		return store.Page[*entity.Entity]{}, err
@@ -143,6 +152,9 @@ func (s *Store) ListEntitiesPage(ctx context.Context, q store.EntityQuery) (stor
 
 // CountEntities counts entities matching q.
 func (s *Store) CountEntities(ctx context.Context, q store.EntityQuery) (int, error) {
+	if err := rejectStateQuery("CountEntities", q); err != nil {
+		return 0, err
+	}
 	where, args := entityWhere(q, "")
 	sql := "SELECT count(*) FROM entities" + where
 	var n int
@@ -255,6 +267,9 @@ func (s *Store) CreateEntity(ctx context.Context, e *entity.Entity) error {
 	if err := validateID(e.ID); err != nil {
 		return err
 	}
+	if err := rejectPointeredEntity("CreateEntity", e); err != nil {
+		return err
+	}
 
 	props, err := marshalProps(e.Properties)
 	if err != nil {
@@ -308,6 +323,9 @@ func (s *Store) CreateEntity(ctx context.Context, e *entity.Entity) error {
 // UpdateEntity overwrites an existing entity. Returns store.ErrNotFound if the
 // entity does not exist.
 func (s *Store) UpdateEntity(ctx context.Context, e *entity.Entity) error {
+	if err := rejectPointeredEntity("UpdateEntity", e); err != nil {
+		return err
+	}
 	props, err := marshalProps(e.Properties)
 	if err != nil {
 		return err

--- a/internal/store/pgstore/pgstore.go
+++ b/internal/store/pgstore/pgstore.go
@@ -104,8 +104,11 @@ type DBTX interface {
 // the row-property reads together, the way versioning and user-state were
 // extracted as subsystems.
 //
-//plimsoll:max-exported-methods=38
-//plimsoll:max-methods=48
+// +1 (38→39, TKT-DOFYR1): GetEntityState joined the mandated store.Store
+// interface — the required-interface exception, not internal sprawl.
+//
+//plimsoll:max-exported-methods=39
+//plimsoll:max-methods=49
 type Store struct {
 	db        DBTX
 	observers []store.EntityObserver // notified synchronously after committed entity writes

--- a/internal/store/pgstore/relation.go
+++ b/internal/store/pgstore/relation.go
@@ -128,6 +128,9 @@ func (s *Store) CreateRelation(
 	if err := storeutil.ValidateRelationType(relType); err != nil {
 		return nil, err
 	}
+	if data != nil && !data.FromPointer.IsDefault() {
+		return nil, errStatesNotSupported("CreateRelation")
+	}
 
 	var props map[string]any
 	content := ""
@@ -246,6 +249,10 @@ func (s *Store) DeleteRelation(ctx context.Context, from, relType, to string) er
 
 // --- row scanning + query building ---
 
+// TODO(TKT-DOFYR1-PR-B): populate Relation.FromPointer here when the
+// from_pointer column lands — a forgotten scan would read every edge as
+// default-tailed while the DB says otherwise, and MatchRelation's
+// equality filter would silently return wrong rows.
 func scanRelation(row scanner) (*entity.Relation, error) {
 	var (
 		from, relType, to, content string
@@ -300,6 +307,15 @@ func relationWhere(q store.RelationQuery, keysetAfter string) (where string, arg
 	add := func(cond string, val any) {
 		args = append(args, val)
 		conds = append(conds, fmt.Sprintf(cond, len(args)))
+	}
+	// Transitional (TKT-DOFYR1, until PR-B's from_pointer column): every
+	// stored edge has the default tail, so a nil or zero filter is a
+	// no-op and a non-zero filter can match nothing. FALSE carries no
+	// placeholder, so its position relative to the numbered add() args
+	// is irrelevant.
+	// TODO(TKT-DOFYR1-PR-B): replace with a real from_pointer predicate.
+	if q.FromPointer != nil && !q.FromPointer.IsDefault() {
+		conds = append(conds, "FALSE")
 	}
 	if q.Type != "" {
 		add("rel_type = $%d", q.Type)

--- a/internal/store/pgstore/states_transitional.go
+++ b/internal/store/pgstore/states_transitional.go
@@ -1,0 +1,59 @@
+package pgstore
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/Sourcehaven-BV/rela/internal/entity"
+	"github.com/Sourcehaven-BV/rela/internal/store"
+)
+
+// Content-state support (TKT-DOFYR1) lands in pgstore in PR-B: migration
+// 0011 adds the compound `(id, pointer)` entities PK and the
+// `relations.from_pointer` column. Until then this backend FAILS CLOSED
+// on anything state-shaped: silently dropping a Pointer/FromPointer on
+// write would be data loss, and pretending to read states would be a
+// lie. Rejection is safe in practice — no pg deployment can carry a
+// pointered metamodel before Step 2 exists — and this file is deleted
+// by PR-B together with the transitional storetest Capabilities.States
+// flag.
+//
+// TODO(TKT-DOFYR1-PR-B): delete this file; implement states natively.
+
+// errStatesNotSupported is the transitional refusal. It names the fix
+// so an operator hitting it knows the state of the world.
+func errStatesNotSupported(op string) error {
+	return fmt.Errorf("pgstore: %s: content states are not supported by this backend yet (TKT-DOFYR1 PR-B)", op)
+}
+
+// GetEntityState implements store.EntityReader. The zero pointer is the
+// default state and delegates to GetEntity; any other pointer cannot
+// exist in this backend yet.
+func (s *Store) GetEntityState(ctx context.Context, id string, p entity.Pointer) (*entity.Entity, error) {
+	if p.IsDefault() {
+		return s.GetEntity(ctx, id)
+	}
+	return nil, errStatesNotSupported("GetEntityState")
+}
+
+// rejectPointeredEntity is the fail-closed write guard for the
+// transitional window.
+func rejectPointeredEntity(op string, e *entity.Entity) error {
+	if e != nil && !e.Pointer.IsDefault() {
+		return errStatesNotSupported(op)
+	}
+	return nil
+}
+
+// rejectStateQuery fails closed on AllStates reads: answering "here is
+// the raw storage truth" while silently filtering to default rows would
+// be exactly the lie this file exists to prevent — and the first
+// AllStates consumers (undeclared-pointer detection, observer backfill)
+// are integrity checks, where a quiet wrong answer is worse than an
+// error.
+func rejectStateQuery(op string, q store.EntityQuery) error {
+	if q.AllStates {
+		return errStatesNotSupported(op + " (AllStates)")
+	}
+	return nil
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -232,7 +232,16 @@ type Freshness interface {
 type EntityReader interface {
 	// GetEntity returns a single entity by ID.
 	// Returns ErrNotFound if the entity does not exist.
+	//
+	// With content states (TKT-DOFYR1) the bare id addresses the DEFAULT
+	// state; GetEntity(id) ≡ GetEntityState(id, zero Pointer).
 	GetEntity(ctx context.Context, id string) (*entity.Entity, error)
+
+	// GetEntityState returns the entity's content state addressed by
+	// (id, p); the zero Pointer addresses the default state, making this
+	// a strict generalization of GetEntity. Returns ErrNotFound if that
+	// state does not exist — including when other states of the id do.
+	GetEntityState(ctx context.Context, id string, p entity.Pointer) (*entity.Entity, error)
 
 	// ListEntities returns an iterator over entities matching the query.
 	// If an error is yielded, the iterator terminates. Cursor and Limit
@@ -270,6 +279,19 @@ type EntityQuery struct {
 	IDs    []string // filter to specific IDs (empty = all)
 	Cursor string   // pagination cursor from a previous page (empty = start); ignored by ListEntities
 	Limit  int      // max entities per page (0 = no limit); ignored by ListEntities
+
+	// AllStates widens the query to every content state row, as RAW
+	// storage truth (TKT-DOFYR1). The zero value (false) returns only
+	// default-state rows — exactly today's semantics, so every existing
+	// construction site keeps its behavior unchanged.
+	//
+	// This is NOT world resolution and never will be. Worlds arrive in
+	// Step 2 (TKT-WAV8XP) as a separate compiled predicate; AllStates is
+	// the storage-inspection escape hatch for infrastructure that must
+	// see rows exactly as they are stored — undeclared-pointer
+	// detection, observer backfill (TKT-9OJ3S0) — not for read paths
+	// choosing which face of an entity to show.
+	AllStates bool
 }
 
 // Page holds a single page of results from a paginated list call.
@@ -342,6 +364,15 @@ type RelationQuery struct {
 	Direction Direction // outgoing, incoming, or both
 	Cursor    string    // pagination cursor from a previous page (empty = start); ignored by ListRelations
 	Limit     int       // max relations per page (0 = no limit); ignored by ListRelations
+
+	// FromPointer filters on the state-specific tail of an edge
+	// (TKT-DOFYR1). nil — the zero value — leaves the tail UNFILTERED:
+	// edges from every state plus identity edges all match, which is
+	// exactly today's behavior for pointerless projects and the compat
+	// story for every existing query site. Non-nil matches the tail
+	// pointer by equality (the zero Pointer matches default-tail edges
+	// only). Stores compare, never inspect — see entity.Pointer.
+	FromPointer *entity.Pointer
 }
 
 // Direction constrains relation queries to a specific direction.
@@ -372,6 +403,16 @@ type RelationWriter interface {
 type RelationData struct {
 	Properties map[string]any
 	Content    string
+
+	// FromPointer sets the state-specific TAIL of the created edge
+	// (TKT-DOFYR1; zero = default state / identity edge). Consumed by
+	// CreateRelation only. UpdateRelation and DeleteRelation address the
+	// DEFAULT-tail edge of their triple in Step 1 — individual update/
+	// delete of a state-tailed edge has no consumer before the Step-3
+	// copy kernel and is added then, mirroring the no-per-state-entity-
+	// delete decision; state-tailed edges are removed today via the
+	// entity delete/rename cascades.
+	FromPointer entity.Pointer
 }
 
 // AttachmentInfo describes a file attached to an entity.
@@ -952,6 +993,14 @@ type Event struct {
 	RelationType string
 	From         string
 	To           string
+
+	// Pointer identifies which content state the event is about; zero =
+	// the default state (TKT-DOFYR1). Events fire per state like any
+	// write. NOTE for observers: the search indexers deliberately SKIP
+	// events with a non-zero Pointer until per-world indexing lands
+	// (Step 5) — documents are keyed by bare id, so indexing a state
+	// event would overwrite the default face.
+	Pointer entity.Pointer
 }
 
 // EventOp identifies the kind of change.

--- a/internal/store/storetest/states.go
+++ b/internal/store/storetest/states.go
@@ -1,0 +1,329 @@
+package storetest
+
+import (
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/Sourcehaven-BV/rela/internal/entity"
+	"github.com/Sourcehaven-BV/rela/internal/store"
+)
+
+// RunStateTests is the content-states conformance suite (TKT-DOFYR1):
+// addressing by (id, pointer), the write-path row-family invariants,
+// default-vs-AllStates query semantics, relation tail pointers in both
+// match implementations, and the delete/rename cascades over a state
+// family. These cases define the contract BEFORE the second backend
+// implements — they are what keep storeutil.MatchRelation and pgstore's
+// relationWhere from drifting.
+func RunStateTests(t *testing.T, f Factory) {
+	newState := func(t *testing.T, id, typ, ptr, title string) *entity.Entity {
+		t.Helper()
+		e := entity.New(id, typ)
+		if ptr != "" {
+			p, err := entity.ParsePointer(ptr)
+			require.NoError(t, err)
+			e.Pointer = p
+		}
+		e.SetString("title", title)
+		return e
+	}
+	mustCreate := func(t *testing.T, s store.Store, e *entity.Entity) {
+		t.Helper()
+		require.NoError(t, s.CreateEntity(ctx(), e))
+	}
+	ptr := func(t *testing.T, v string) entity.Pointer {
+		t.Helper()
+		p, err := entity.ParsePointer(v)
+		require.NoError(t, err)
+		return p
+	}
+
+	t.Run("AddressByPair", func(t *testing.T) {
+		s := f(t)
+		mustCreate(t, s, newState(t, "PAGE-1", "page", "", "default face"))
+		mustCreate(t, s, newState(t, "PAGE-1", "page", "draft", "draft face"))
+
+		// Bare id = the default state.
+		got, err := s.GetEntity(ctx(), "PAGE-1")
+		require.NoError(t, err)
+		assert.Equal(t, "default face", got.GetString("title"))
+		assert.True(t, got.Pointer.IsDefault())
+
+		// The pair addresses the state; the id stays bare on the result.
+		draft, err := s.GetEntityState(ctx(), "PAGE-1", ptr(t, "draft"))
+		require.NoError(t, err)
+		assert.Equal(t, "PAGE-1", draft.ID, "the joined form must never leak into the id")
+		assert.Equal(t, ptr(t, "draft"), draft.Pointer)
+		assert.Equal(t, "draft face", draft.GetString("title"))
+
+		// GetEntityState with the zero pointer ≡ GetEntity.
+		def, err := s.GetEntityState(ctx(), "PAGE-1", "")
+		require.NoError(t, err)
+		assert.Equal(t, "default face", def.GetString("title"))
+
+		// A missing state is ErrNotFound even though siblings exist.
+		_, err = s.GetEntityState(ctx(), "PAGE-1", ptr(t, "published"))
+		assert.ErrorIs(t, err, store.ErrNotFound)
+	})
+
+	t.Run("PointerIsOpaqueToTheStore", func(t *testing.T) {
+		// The store equality-matches pointer values, never inspects
+		// them: an unusual-but-canonical coordinate round-trips
+		// unchanged (the multi-axis guarantee, design doc §3.1).
+		s := f(t)
+		unusual := ptr(t, "x9-z2-a0")
+		mustCreate(t, s, newState(t, "PAGE-2", "page", "", "default"))
+		e := newState(t, "PAGE-2", "page", "", "odd face")
+		e.Pointer = unusual
+		mustCreate(t, s, e)
+
+		got, err := s.GetEntityState(ctx(), "PAGE-2", unusual)
+		require.NoError(t, err)
+		assert.Equal(t, unusual, got.Pointer)
+		assert.Equal(t, "odd face", got.GetString("title"))
+	})
+
+	t.Run("WriteInvariants", func(t *testing.T) {
+		t.Run("HeadlessStateRejected", func(t *testing.T) {
+			s := f(t)
+			err := s.CreateEntity(ctx(), newState(t, "PAGE-3", "page", "draft", "no default"))
+			require.Error(t, err, "a non-default state must not exist without the default row")
+		})
+
+		t.Run("TypeMismatchRejected", func(t *testing.T) {
+			s := f(t)
+			mustCreate(t, s, newState(t, "PAGE-4", "page", "", "default"))
+			err := s.CreateEntity(ctx(), newState(t, "PAGE-4", "ticket", "draft", "wrong type"))
+			require.Error(t, err, "states share their family's type")
+		})
+
+		t.Run("DuplicateStateConflicts", func(t *testing.T) {
+			s := f(t)
+			mustCreate(t, s, newState(t, "PAGE-5", "page", "", "default"))
+			mustCreate(t, s, newState(t, "PAGE-5", "page", "draft", "draft"))
+			err := s.CreateEntity(ctx(), newState(t, "PAGE-5", "page", "draft", "again"))
+			assert.ErrorIs(t, err, store.ErrConflict)
+		})
+
+		t.Run("UpdateMissingStateNotFound", func(t *testing.T) {
+			s := f(t)
+			mustCreate(t, s, newState(t, "PAGE-6", "page", "", "default"))
+			err := s.UpdateEntity(ctx(), newState(t, "PAGE-6", "page", "draft", "phantom"))
+			assert.ErrorIs(t, err, store.ErrNotFound)
+		})
+
+		t.Run("UpdateStateCannotRetype", func(t *testing.T) {
+			s := f(t)
+			mustCreate(t, s, newState(t, "PAGE-7", "page", "", "default"))
+			mustCreate(t, s, newState(t, "PAGE-7", "page", "draft", "draft"))
+			err := s.UpdateEntity(ctx(), newState(t, "PAGE-7", "ticket", "draft", "retyped"))
+			require.Error(t, err)
+		})
+	})
+
+	t.Run("QueryScope", func(t *testing.T) {
+		s := f(t)
+		mustCreate(t, s, newState(t, "PAGE-8", "page", "", "default"))
+		mustCreate(t, s, newState(t, "PAGE-8", "page", "draft", "draft"))
+		mustCreate(t, s, newState(t, "PAGE-9", "page", "", "other"))
+
+		// The zero-value query is today's semantics: default states only.
+		defaults := collectIter(t, s.ListEntities(ctx(), store.EntityQuery{Type: "page"}))
+		require.Len(t, defaults, 2)
+		for _, e := range defaults {
+			assert.True(t, e.Pointer.IsDefault())
+		}
+		n, err := s.CountEntities(ctx(), store.EntityQuery{Type: "page"})
+		require.NoError(t, err)
+		assert.Equal(t, 2, n)
+
+		// AllStates is raw storage truth: every state row.
+		all := collectIter(t, s.ListEntities(ctx(), store.EntityQuery{Type: "page", AllStates: true}))
+		assert.Len(t, all, 3)
+		n, err = s.CountEntities(ctx(), store.EntityQuery{Type: "page", AllStates: true})
+		require.NoError(t, err)
+		assert.Equal(t, 3, n)
+
+		// IDs filters on the BARE id, so IDs+AllStates selects the family.
+		family := collectIter(t, s.ListEntities(ctx(), store.EntityQuery{IDs: []string{"PAGE-8"}, AllStates: true}))
+		assert.Len(t, family, 2)
+	})
+
+	t.Run("DefaultWorldAggregates", func(t *testing.T) {
+		// PropertyValues and HighestID are default-world aggregates.
+		// The count-ORDER assertion is the load-bearing part: with one
+		// "open" default and two "closed" defaults, "closed" must sort
+		// first — two states carrying "open" would flip that order if
+		// states leaked into the counts.
+		s := f(t)
+		def := newState(t, "PAGE-20", "page", "", "default")
+		def.SetString("status", "open")
+		mustCreate(t, s, def)
+		for _, p := range []string{"draft", "review"} {
+			st := newState(t, "PAGE-20", "page", p, "state "+p)
+			st.SetString("status", "open")
+			mustCreate(t, s, st)
+		}
+		for _, id := range []string{"PAGE-21", "PAGE-22"} {
+			e := newState(t, id, "page", "", "closed one")
+			e.SetString("status", "closed")
+			mustCreate(t, s, e)
+		}
+
+		vals, err := s.PropertyValues(ctx(), "status", 0)
+		require.NoError(t, err)
+		assert.Equal(t, []string{"closed", "open"}, vals,
+			"states must not inflate suggestion counts (open would outrank closed)")
+
+		high, err := s.HighestID(ctx(), "PAGE")
+		require.NoError(t, err)
+		assert.Equal(t, 22, high)
+	})
+
+	t.Run("RelationTails", func(t *testing.T) {
+		s := f(t)
+		mustCreate(t, s, newState(t, "PAGE-10", "page", "", "default"))
+		mustCreate(t, s, newState(t, "PAGE-10", "page", "draft", "draft"))
+		mustCreate(t, s, newState(t, "SPEC-1", "page", "", "target"))
+
+		// Same triple, two tails: two distinct relations.
+		_, err := s.CreateRelation(ctx(), "PAGE-10", "references", "SPEC-1", nil)
+		require.NoError(t, err)
+		_, err = s.CreateRelation(ctx(), "PAGE-10", "references", "SPEC-1",
+			&store.RelationData{FromPointer: ptr(t, "draft")})
+		require.NoError(t, err)
+		// The state-tailed duplicate conflicts like any relation.
+		_, err = s.CreateRelation(ctx(), "PAGE-10", "references", "SPEC-1",
+			&store.RelationData{FromPointer: ptr(t, "draft")})
+		assert.ErrorIs(t, err, store.ErrConflict)
+
+		// nil FromPointer = unfiltered (today's behavior): both edges.
+		both := collectRelations(t, s, store.RelationQuery{From: "PAGE-10", Type: "references"})
+		require.Len(t, both, 2)
+
+		// A non-nil zero pointer matches the default tail only.
+		var zero entity.Pointer
+		defOnly := collectRelations(t, s, store.RelationQuery{
+			From: "PAGE-10", Type: "references", FromPointer: &zero,
+		})
+		require.Len(t, defOnly, 1)
+		assert.True(t, defOnly[0].FromPointer.IsDefault())
+
+		// A pointer value matches that tail exactly — including through
+		// the fs INDEXED query path (From+Type set), the silent-miss
+		// class the relationMeta index fix guards.
+		draft := ptr(t, "draft")
+		draftOnly := collectRelations(t, s, store.RelationQuery{
+			From: "PAGE-10", Type: "references", FromPointer: &draft,
+		})
+		require.Len(t, draftOnly, 1)
+		assert.Equal(t, draft, draftOnly[0].FromPointer)
+
+		// CountRelations agrees with ListRelations.
+		n, err := s.CountRelations(ctx(), store.RelationQuery{From: "PAGE-10", Type: "references", FromPointer: &draft})
+		require.NoError(t, err)
+		assert.Equal(t, 1, n)
+	})
+
+	t.Run("DeleteCascadesTheFamily", func(t *testing.T) {
+		s := f(t)
+		mustCreate(t, s, newState(t, "PAGE-11", "page", "", "default"))
+		mustCreate(t, s, newState(t, "PAGE-11", "page", "draft", "draft"))
+		mustCreate(t, s, newState(t, "SPEC-2", "page", "", "target"))
+		_, err := s.CreateRelation(ctx(), "PAGE-11", "references", "SPEC-2", nil)
+		require.NoError(t, err)
+		_, err = s.CreateRelation(ctx(), "PAGE-11", "references", "SPEC-2",
+			&store.RelationData{FromPointer: ptr(t, "draft")})
+		require.NoError(t, err)
+		_, err = s.CreateRelation(ctx(), "SPEC-2", "links", "PAGE-11", nil)
+		require.NoError(t, err)
+
+		res, err := s.DeleteEntity(ctx(), "PAGE-11", true)
+		require.NoError(t, err)
+		assert.Len(t, res.DeletedEntities, 2, "both states deleted")
+		assert.Len(t, res.DeletedRelations, 3, "edges of every tail plus incoming")
+
+		_, err = s.GetEntity(ctx(), "PAGE-11")
+		assert.ErrorIs(t, err, store.ErrNotFound)
+		_, err = s.GetEntityState(ctx(), "PAGE-11", ptr(t, "draft"))
+		assert.ErrorIs(t, err, store.ErrNotFound)
+		left := collectRelations(t, s, store.RelationQuery{EntityID: "PAGE-11"})
+		assert.Empty(t, left)
+	})
+
+	t.Run("RenameCascadesTheFamily", func(t *testing.T) {
+		s := f(t)
+		mustCreate(t, s, newState(t, "PAGE-12", "page", "", "default"))
+		mustCreate(t, s, newState(t, "PAGE-12", "page", "draft", "draft"))
+		mustCreate(t, s, newState(t, "SPEC-3", "page", "", "target"))
+		_, err := s.CreateRelation(ctx(), "PAGE-12", "references", "SPEC-3",
+			&store.RelationData{FromPointer: ptr(t, "draft")})
+		require.NoError(t, err)
+
+		res, err := s.RenameEntity(ctx(), "PAGE-12", "PAGE-99")
+		require.NoError(t, err)
+		assert.Equal(t, 1, res.RelationsUpdated)
+
+		// Every state re-keyed onto the new id.
+		def, err := s.GetEntity(ctx(), "PAGE-99")
+		require.NoError(t, err)
+		assert.Equal(t, "default", def.GetString("title"))
+		draft, err := s.GetEntityState(ctx(), "PAGE-99", ptr(t, "draft"))
+		require.NoError(t, err)
+		assert.Equal(t, "draft", draft.GetString("title"))
+		_, err = s.GetEntityState(ctx(), "PAGE-12", ptr(t, "draft"))
+		assert.ErrorIs(t, err, store.ErrNotFound)
+
+		// The tail pointer rode along.
+		moved := collectRelations(t, s, store.RelationQuery{From: "PAGE-99", Type: "references"})
+		require.Len(t, moved, 1)
+		assert.Equal(t, ptr(t, "draft"), moved[0].FromPointer)
+
+		// Any state of an existing entity blocks the rename target.
+		mustCreate(t, s, newState(t, "PAGE-13", "page", "", "blocker"))
+		_, err = s.RenameEntity(ctx(), "PAGE-99", "PAGE-13")
+		assert.ErrorIs(t, err, store.ErrConflict)
+	})
+
+	t.Run("EventsFirePerState", func(t *testing.T) {
+		s := f(t)
+		events, cancel := s.Subscribe(16)
+		defer cancel()
+
+		mustCreate(t, s, newState(t, "PAGE-14", "page", "", "default"))
+		mustCreate(t, s, newState(t, "PAGE-14", "page", "draft", "draft"))
+		_, err := s.DeleteEntity(ctx(), "PAGE-14", true)
+		require.NoError(t, err)
+
+		// Bounded blocking receive: backends with async delivery (the pg
+		// change-feed bridge) may not have all four buffered yet.
+		var pointers []string
+		timeout := time.After(5 * time.Second)
+		for range 4 {
+			select {
+			case ev := <-events:
+				pointers = append(pointers, string(ev.Pointer))
+			case <-timeout:
+				t.Fatalf("timed out waiting for events; got %v", pointers)
+			}
+		}
+		// Two creates + two deletes, each carrying its state's pointer.
+		sort.Strings(pointers)
+		assert.Equal(t, []string{"", "", "draft", "draft"}, pointers)
+	})
+}
+
+// collectRelations drains ListRelations for q.
+func collectRelations(t *testing.T, s store.Store, q store.RelationQuery) []*entity.Relation {
+	t.Helper()
+	var out []*entity.Relation
+	for r, err := range s.ListRelations(ctx(), q) {
+		require.NoError(t, err)
+		out = append(out, r)
+	}
+	return out
+}

--- a/internal/store/storetest/storetest.go
+++ b/internal/store/storetest/storetest.go
@@ -31,6 +31,14 @@ type Capabilities struct {
 	// AttachmentManager. When false, attachment-related conformance
 	// tests are skipped.
 	Attachments bool
+
+	// States gates the content-states conformance suite (TKT-DOFYR1).
+	// TRANSITIONAL, one commit window only: it exists so the contract
+	// cases land BEFORE pgstore implements states without breaking its
+	// conformance run.
+	// TODO(TKT-DOFYR1-PR-B): remove this flag — every backend must run
+	// RunStateTests unconditionally once pgstore implements.
+	States bool
 }
 
 func ctx() context.Context { return context.Background() }
@@ -162,6 +170,9 @@ func RunAll(t *testing.T, f Factory, sf SearchFactory, vsf VisibleSearchFactory,
 	}
 	if caps.Attachments {
 		t.Run("Attachment", func(t *testing.T) { RunAttachmentTests(t, f) })
+	}
+	if caps.States {
+		t.Run("States", func(t *testing.T) { RunStateTests(t, f) })
 	}
 	t.Run("Watcher", func(t *testing.T) { RunWatcherTests(t, f) })
 	t.Run("Validation", func(t *testing.T) { RunValidationTests(t, f) })

--- a/internal/store/storeutil/storeutil.go
+++ b/internal/store/storeutil/storeutil.go
@@ -197,11 +197,19 @@ func SortedRemove(s []string, key string) []string {
 }
 
 // MatchRelation returns true if a relation matches the given query.
+//
+// The tail-pointer filter is nil-permissive (TKT-DOFYR1): a nil
+// q.FromPointer matches every tail — identity edges and all states —
+// which is today's behavior for pointerless projects; non-nil matches
+// by equality only (the store never inspects pointer contents).
 func MatchRelation(r *entity.Relation, q store.RelationQuery) bool {
 	if q.Type != "" && r.Type != q.Type {
 		return false
 	}
 	if q.From != "" && r.From != q.From {
+		return false
+	}
+	if q.FromPointer != nil && r.FromPointer != *q.FromPointer {
 		return false
 	}
 	if q.To != "" && r.To != q.To {

--- a/tickets/entities/implementation-checklists/IMPL-MSUOMF.md
+++ b/tickets/entities/implementation-checklists/IMPL-MSUOMF.md
@@ -1,0 +1,59 @@
+---
+id: IMPL-MSUOMF
+type: implementation-checklist
+title: 'Implementation: Consolidate cardinality analyzers; stop swallowing CountRelations errors'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Development
+
+- [x] Unit tests written for new code (behaviour-pinning tests written BEFORE the refactor and passing against the old code: `TestCheckCardinality_OrderingAndLabels`, `_BoundEdgeCases`, `_MultipleSourceTypes`; error-policy test after: `TestCheckCardinality_CountErrorFailsLoudly`)
+- [x] Integration tests written (existing `internal/cli` tests exercise the commands end-to-end; manual CLI verification below)
+- [x] Happy path implemented (`cardinalitySpec` + single `checkCardinality` + `countRelations` in `internal/analysis/analysis.go`)
+- [x] Edge cases from planning handled (max=0 enforced, min=0 skipped, multi-type From ordering, inverse label on incoming, scope-before-count preserved)
+- [x] Error handling in place (the ticket's core fix: `CountRelations` errors propagate; `CheckCardinality`/`AnalyzeAll` return error; all three CLI surfaces fail the command instead of fabricating violations)
+
+## Test Quality
+
+- [x] Using fixture builders or factories for test data (existing `addEntity`/`addRelation`/`newServiceWith` helpers; `failingCountStore` wraps a seeded memstore)
+- [x] No hardcoded values in assertions when object is in scope (full expected `CardinalityViolation` structs compared, not ad-hoc fields)
+- [x] Only specifying values that matter for the test
+- [x] Interpolated values constructed from objects, not hardcoded (error test asserts `errors.Is` against the injected sentinel plus the id/relation context)
+- [x] Property comparisons use original object, not hardcoded strings
+
+## Manual Verification
+
+- [x] Feature manually tested end-to-end
+- [x] Each acceptance criterion verified with test scenario from planning
+- [x] Edge cases manually verified
+
+**Verification Evidence:**
+
+Built `cmd/rela` and ran against the live tickets/ project (2026-08-19): `rela
+analyze cardinality`, `rela validate --check cardinality`, and `rela analyze
+all` all report "All cardinality constraints satisfied" (exit 0) — identical to
+the pre-refactor binary on the same data. AC1/AC2 verified by the pinning tests
+(written first, unchanged by the refactor); AC3 by
+`TestCheckCardinality_CountErrorFailsLoudly` (wrapped error names entity +
+relation, zero violations returned, AnalyzeAll propagates); AC4 by the
+compiler-enforced signature change + green `internal/cli` tests.
+
+## Quality
+
+- [x] Code follows project patterns (check similar code)
+- [x] Checked for DRY opportunities — repeated literals, expressions, or
+patterns extracted to a helper / constant / type where it sharpens the contract
+(don't extract for its own sake; CLAUDE.md "three similar lines is better than a
+premature abstraction" still holds)
+- [x] No security issues introduced (no world/pointer hook added — the spec is shaped for TKT-9KZGJO but carries no world field)
+- [x] No silent failures (the change REMOVES a silent failure; remaining `collectEntities` under-count logging is documented out-of-scope in PLAN-KJ76OT)
+- [x] No debug code left behind
+
+## Quality Gates (run 2026-08-19)
+
+- `go build ./...` + `go test ./...` — all pass
+- `just arch-lint` — OK; `just plimsoll` — clean
+- `just lint` — 0 issues (after dropping a now-unused nolint:prealloc directive)
+- `just coverage-check` — floors + total (77.1% >= 65%) satisfied; internal/analysis 76.9%

--- a/tickets/entities/planning-checklists/PLAN-KJ76OT.md
+++ b/tickets/entities/planning-checklists/PLAN-KJ76OT.md
@@ -1,0 +1,253 @@
+---
+id: PLAN-KJ76OT
+type: planning-checklist
+title: 'Planning: Consolidate cardinality analyzers; stop swallowing CountRelations errors'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Understanding
+
+- [x] Problem/requirements clearly understood
+- [x] Scope defined (what's in/out documented below)
+- [x] Acceptance criteria documented with specific test scenarios
+
+**Scope:**
+
+IN scope:
+
+1. Collapse `checkMinOutgoing`/`checkMaxOutgoing`/`checkMinIncoming`/
+`checkMaxIncoming` (`internal/analysis/analysis.go:345-451` — the ticket's
+`analysis.go:344-451` cites the pre-move tracer path; code now lives in
+`internal/analysis`) into one parameterised check driven by a per-direction spec
+(subject types, direction, min/max bounds, constraint labels, violation relation
+label). One entity scan and one count per (relation, direction) instead of two
+of each.
+2. Fold `countOutgoingByType`/`countIncomingByType` (analysis.go:453-469)
+into one `countRelations` helper that PROPAGATES the `store.CountRelations`
+error instead of `n, _ :=` swallowing it.
+3. Error policy (the documented decision): a store error fails the
+cardinality run loudly — `CheckCardinality` gains an error return and aborts on
+the first count failure with entity/relation context; it never reports a
+violation computed from a failed count. Callers updated: `cli/analyze.go`
+AnalyzeCardinalityCmd (return the error), `cli/validate.go` runCardinalityCheck
+(propagate to the command error), `AnalyzeAll` (gains an error return; its one
+CLI caller propagates).
+4. Pin current behaviour with tests BEFORE refactoring (coverage is thin:
+only min_outgoing + scope today).
+
+OUT of scope:
+
+- Any world/pointer concept (TKT-9KZGJO). The parameterisation is SHAPED
+so a future world parameter changes subject population / counting scope /
+violation identity in one place, but no world field/hook is added now.
+- `collectEntities`'s log-and-return-partial behaviour on ListEntities
+iteration errors (documented pre-existing under-count semantics shared by all
+analyses; an entity missing from the scan cannot FABRICATE a violation —
+different failure class from the count bug, and changing it touches every
+analysis).
+- The MCP server's separate cardinality implementation
+(`internal/mcp/tools_analysis.go:68-146`) — a FIFTH copy with the same swallowed
+`CountRelations` error. Deliberately kept against Store+Meta because mcp has no
+analysis.Service dependency; unifying it is an architectural decision flagged to
+the architect, not taken here.
+
+**Acceptance Criteria:**
+
+1. Identical violations for existing metamodels: same set, same ordering
+(per relation: all min-then-max outgoing over From types in order, then
+min-then-max incoming over To types), same constraint strings, same
+incoming-label behaviour (inverse relation id when declared). Pinned by new
+table tests written against the OLD code first.
+2. `max_outgoing: 0` / `max_incoming: 0` remain meaningful (max nil-check
+only), `min_*: 0` remains a skip — pinned by tests.
+3. A failing `CountRelations` aborts the run with a wrapped error naming
+the entity and relation; no violations are returned alongside it. Pinned by a
+test using a store wrapper whose CountRelations fails.
+4. `rela analyze cardinality`, `rela validate --check cardinality`, and
+`rela analyze all` surface the error as a command failure (non-zero exit), not
+as fabricated violations.
+
+## Research
+
+- [x] ~~For larger features: run `/research` to create a structured research doc~~ (N/A: refactor with fixed approach from design doc §12.5+§12.6; the parameterisation shape is the only free variable and is dictated by the four existing functions)
+- [x] ~~Searched for existing libraries that solve this problem~~ (N/A: internal consolidation)
+- [x] Checked codebase for similar patterns or reusable code
+- [x] ~~Looked for reference implementations in other projects~~ (N/A)
+- [x] Reviewed relevant rela concepts for prior art
+
+**Research Doc:** N/A (feature-level context in RES-GFWP85/RES-NH3P12 for
+FEAT-9CD2MX)
+
+**Existing Solutions:**
+
+- The four functions themselves (analysis.go:345-451) define the contract;
+the MCP handler (`checkCardinalityBound`, tools_analysis.go:103) already
+demonstrates a min+max-in-one-scan shape (though with different output and its
+own swallowed errors).
+- Error-propagation precedent: the package's documented under-count
+logging (`FindOrphansWithScope` godoc) explains why other analyses swallow; the
+ticket's rationale (fabricated violations, not just under-counts) is what
+justifies cardinality diverging to fail-loud.
+
+## Approach
+
+- [x] Technical approach chosen and documented
+- [x] Approach builds on existing patterns (not reinventing)
+- [x] Alternatives considered (document why rejected)
+- [x] Dependencies identified (packages, APIs, types)
+
+**Technical Approach:**
+
+Introduce a small direction spec derived per relation:
+
+```go
+type cardinalitySpec struct {
+    direction     store.Direction // count direction
+    subjectTypes  []string        // relDef.From (outgoing) / relDef.To (incoming)
+    minBound, maxBound *int
+    minConstraint, maxConstraint string // "min_outgoing"... labels
+    relationLabel string          // relName; incoming uses inverse id if declared
+}
+```
+
+`CheckCardinality` iterates relations, derives the outgoing and incoming specs,
+and calls one `checkCardinality(ctx, relName, spec, scope)
+([]CardinalityViolation, error)` that: skips when min is nil/0 AND max is nil;
+scans each subject type once; counts each subject once via `countRelations`
+(error → wrapped return); then emits min violations and max violations as two
+passes over the cached counts — preserving the old grouped ordering exactly
+while halving scans and counts.
+
+The spec is the future world seam: subject population (subjectTypes → query),
+counting scope (countRelations), and violation identity (the two emit sites)
+each live in exactly one place. No world field is added.
+
+Alternatives rejected:
+- Interleaved min/max emission per entity (single pass): simpler but
+changes violation ordering — behaviour must be identical.
+- Accumulating all count errors before returning: more machinery for no
+caller benefit; fail-fast matches "fail the run loudly".
+- Keeping void signatures + logging the error: exactly the fabricated-
+violation bug class the ticket exists to remove (a logged error still yields
+count 0 downstream unless the subject is skipped, and a silently skipped subject
+is an invisible under-count).
+
+**Files to modify:**
+
+- `internal/analysis/analysis.go` (consolidation + error returns)
+- `internal/analysis/analysis_test.go` (behaviour-pinning table tests
+first; then error-propagation tests with a failing-store wrapper)
+- `internal/cli/analyze.go` (AnalyzeCardinalityCmd, AnalyzeAllCmd)
+- `internal/cli/validate.go` (runCardinalityCheck)
+
+## Security Considerations
+
+- [x] Input sources identified (user input, config, external APIs)
+- [x] Input validation approach defined (allowlist preferred over blocklist)
+- [x] Security-sensitive operations identified (file access, auth, crypto)
+- [x] Error handling doesn't leak sensitive information
+
+**Input Sources & Validation:**
+
+- Inputs are the operator's metamodel (already parsed/validated) and the
+store. No new parsing, no user-supplied strings interpolated beyond
+entity/relation ids already present in analysis output.
+
+**Security-Sensitive Operations:**
+
+- None new. The error message wraps the store error with entity id +
+relation name — both already surfaced by the analyzers' normal output; no
+credentials/paths beyond what the store error itself carries.
+
+## Test Plan
+
+- [x] Test scenarios documented for each acceptance criterion
+- [x] Edge cases identified and documented
+- [x] Negative test cases defined (invalid input, error conditions)
+- [x] Integration test approach defined (not just unit tests)
+
+**Test Scenarios:**
+
+- AC1: table test over a metamodel exercising all four constraints at
+once (min+max outgoing on one relation, min+max incoming with a declared inverse
+on another), asserting the full ordered violation slice (ids, constraints,
+labels, required/actual). Written and passing against the OLD code before the
+refactor, unchanged after.
+- AC2: cases for max_outgoing=0 (entity with one edge violates),
+min_outgoing=0 (never violates), both-nil (no scan, no violations).
+- AC3: failing-store wrapper (embeds store.Store, CountRelations returns
+an injected error) → CheckCardinality returns nil violations + wrapped error
+mentioning the entity id and relation; AnalyzeAll propagates.
+- AC4: CLI behaviour covered by the signature change (compiler enforces
+callers handle the error) + existing CLI tests still green.
+
+**Edge Cases:**
+
+- Relation with multiple From/To types (ordering across types).
+- Entity type in From with zero entities.
+- min set on a relation whose From type has entities but zero relations
+(the classic violation).
+- Inverse label only on incoming violations; outgoing keeps relName.
+- Scope filtering unchanged (subjects filtered before counting — old code
+counted only in-scope entities; preserve to keep store-call pattern).
+
+**Negative Tests:**
+
+- CountRelations error (AC3). ListEntities iteration error stays
+log-and-partial (out of scope, documented).
+
+## Risk Assessment
+
+- [x] Technical risks assessed with mitigations
+- [x] Security risks assessed (see Security Considerations)
+- [x] Effort estimated (xs/s/m/l/xl)
+
+**Risks:**
+
+- Ordering regression → mitigated by pinning the full ordered slice
+before refactoring (map iteration across relations is already nondeterministic;
+ordering is only defined within one relation, which is exactly what the test
+pins per-relation).
+- Signature ripple (error returns) → bounded: three CLI call sites, all
+already return error; compiler surfaces any missed caller.
+- Behaviour drift in the min-0/max-0 asymmetry → dedicated test cases.
+
+Effort: s (matches ticket property).
+
+## Documentation Planning
+
+For refactors: identify what documentation needs updating.
+
+- [x] User-facing docs identified (skip if internal refactor)
+- [x] Docs-checklist will be created when entering implementation
+
+**Documentation Impact:**
+
+- [x] ~~docs/metamodel.md~~ (N/A: constraint semantics unchanged)
+- [x] ~~docs/cli-reference.md~~ (N/A: commands unchanged; a store outage now errors instead of printing false violations — behaviour users were never promised)
+- [x] ~~docs/data-entry.md~~ (N/A)
+- [x] ~~CLAUDE.md~~ (N/A: no new pattern)
+- [x] ~~README.md~~ (N/A)
+- Godoc on `CheckCardinality`/`cardinalitySpec` documents the error
+policy and the one-place world seam (in-code docs, part of item 1).
+
+## Design Review
+
+- [x] Run `/design-review` before starting implementation
+- [x] All critical/significant findings addressed in plan (none found)
+
+**Design Review Findings:**
+
+No critical/significant findings; no review-response entities created. Two notes
+folded into the plan:
+- (minor) `validate --format json` must not half-emit a cardinality
+result before the error path returns — error handling goes before any output
+write in `runCardinalityCheck`.
+- (nit) The ticket's cited location (`analysis.go:344-451`, tracer)
+predates the package move; verified 2026-08-19 the code lives in
+`internal/analysis/analysis.go:345-469`. Noted on the ticket body. Architectural
+flag (out of scope, reported to architect): the MCP server carries a FIFTH
+cardinality implementation with the same swallowed CountRelations error
+(`internal/mcp/tools_analysis.go:68-146`).

--- a/tickets/entities/review-checklists/REV-1HTU0H.md
+++ b/tickets/entities/review-checklists/REV-1HTU0H.md
@@ -2,7 +2,7 @@
 id: REV-1HTU0H
 type: review-checklist
 title: 'Review: Consolidate cardinality analyzers; stop swallowing CountRelations errors'
-status: in-progress
+status: done
 ---
 
 <!-- @managed: claude-workflow v1 -->
@@ -23,16 +23,15 @@ status: in-progress
 **Review Responses:**
 
 RR-4JWU2I (significant, addressed: honest godoc on the validate banner),
-RR-STCCY8 (significant, addressed: CLI-boundary error tests; double-scan
-hazard documented in-code, compute-once is the follow-up), RR-5FKMKX
-(significant, addressed: relName folded into cardinalitySpec), RR-1HB83A
-(minor, addressed: direction in the count error), RR-3ZJM3P (minor,
-addressed: load-bearing comments), RR-TFUP2X (minor, addressed:
-interleaving-regression pin + import nit). Reviewer leverage notes not
-turned into findings: promote the fault-injection wrapper to storetest +
-an Nth-call failure variant (deferred — cross-package test infra, own
-change); the MCP fifth cardinality copy (already flagged to the
-architect, out of scope by recorded decision).
+RR-STCCY8 (significant, addressed: CLI-boundary error tests; double-scan hazard
+documented in-code, compute-once is the follow-up), RR-5FKMKX (significant,
+addressed: relName folded into cardinalitySpec), RR-1HB83A (minor, addressed:
+direction in the count error), RR-3ZJM3P (minor, addressed: load-bearing
+comments), RR-TFUP2X (minor, addressed: interleaving-regression pin + import
+nit). Reviewer leverage notes not turned into findings: promote the
+fault-injection wrapper to storetest + an Nth-call failure variant (deferred —
+cross-package test infra, own change); the MCP fifth cardinality copy (already
+flagged to the architect, out of scope by recorded decision).
 
 ## Acceptance Verification
 
@@ -64,8 +63,8 @@ Skip this section for bugs and internal refactors.
 
 ## Pull Request
 
-- [ ] Run `/pr` command to create PR and monitor CI
-- [ ] All CI checks pass
-- [ ] PR URL documented below
+- [x] Run `/pr` command to create PR and monitor CI
+- [x] All CI checks pass (monitored to green on PR #1381; stacked on #1378)
+- [x] PR URL documented below
 
-**PR:** <!-- e.g., https://github.com/org/repo/pull/123 -->
+**PR:** https://github.com/sourcehaven-bv/rela/pull/1381

--- a/tickets/entities/review-checklists/REV-1HTU0H.md
+++ b/tickets/entities/review-checklists/REV-1HTU0H.md
@@ -1,0 +1,71 @@
+---
+id: REV-1HTU0H
+type: review-checklist
+title: 'Review: Consolidate cardinality analyzers; stop swallowing CountRelations errors'
+status: in-progress
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Automated Checks
+
+- [x] All tests pass (`go test ./...` clean, 2026-08-19, re-run after review fixes)
+- [x] Lint clean (`just lint` 0 issues; `just arch-lint` OK; `just plimsoll` clean)
+- [x] Coverage maintained (`just coverage-check`: floors + total 77.1% >= 65% PASS; internal/analysis 76.9%)
+
+## Code Review
+
+- [x] Run `/code-review` command (invokes cranky-code-reviewer agent; reviewer also ran a 3000-case randomized differential test against the reconstructed pre-refactor functions — zero mismatches)
+- [x] All critical review-responses addressed (none found)
+- [x] All significant review-responses addressed (RR-4JWU2I, RR-STCCY8, RR-5FKMKX — all fixed)
+- [x] Self-reviewed the diff for unrelated changes (touches only internal/analysis + the three CLI call-site files)
+
+**Review Responses:**
+
+RR-4JWU2I (significant, addressed: honest godoc on the validate banner),
+RR-STCCY8 (significant, addressed: CLI-boundary error tests; double-scan
+hazard documented in-code, compute-once is the follow-up), RR-5FKMKX
+(significant, addressed: relName folded into cardinalitySpec), RR-1HB83A
+(minor, addressed: direction in the count error), RR-3ZJM3P (minor,
+addressed: load-bearing comments), RR-TFUP2X (minor, addressed:
+interleaving-regression pin + import nit). Reviewer leverage notes not
+turned into findings: promote the fault-injection wrapper to storetest +
+an Nth-call failure variant (deferred — cross-package test infra, own
+change); the MCP fifth cardinality copy (already flagged to the
+architect, out of scope by recorded decision).
+
+## Acceptance Verification
+
+- [x] Each acceptance criterion tested (reference planning checklist)
+- [x] Test evidence documented in implementation checklist
+
+**Acceptance Status:**
+
+- AC1 (identical violations/ordering/labels) — PASS: pinning tests written first against the old code, unchanged after; plus the reviewer's 3000-case differential run (zero mismatches, incl. []-not-null JSON shape).
+- AC2 (max=0 meaningful, min=0 skip) — PASS: TestCheckCardinality_BoundEdgeCases.
+- AC3 (count error fails loudly, no fabricated violations) — PASS: TestCheckCardinality_CountErrorFailsLoudly (+ AnalyzeAll propagation subtest).
+- AC4 (CLI surfaces error as command failure, no partial output) — PASS: TestAnalyzeCmds_CountErrorAborts (empty output buffer asserted for analyze cardinality + analyze all); validate path compiler-enforced + green cli tests.
+
+## Documentation (enhancements only)
+
+Skip this section for bugs and internal refactors.
+
+- [x] ~~Docs-checklist created and linked via `has-docs`~~ (N/A: refactor kind — section skipped per template; behaviour contract unchanged for users)
+- [x] ~~User-facing documentation updated~~ (N/A: no user-facing docs affected; error policy documented in godoc + ticket)
+- [x] ~~Docs-checklist marked as done~~ (N/A)
+
+**Docs Checklist:** N/A (refactor)
+
+## Final Checks
+
+- [x] Commit message explains the why, not just what
+- [x] No TODOs or FIXMEs left unaddressed
+- [x] Ready for another developer to use
+
+## Pull Request
+
+- [ ] Run `/pr` command to create PR and monitor CI
+- [ ] All CI checks pass
+- [ ] PR URL documented below
+
+**PR:** <!-- e.g., https://github.com/org/repo/pull/123 -->

--- a/tickets/entities/review-responses/RR-1HB83A.md
+++ b/tickets/entities/review-responses/RR-1HB83A.md
@@ -1,0 +1,9 @@
+---
+id: RR-1HB83A
+type: review-response
+title: Count error message did not name the direction
+finding: The wrapped error named entity and relation, but each (entity, relation) pair is counted twice — outgoing and incoming — and the message could not distinguish which count failed. In a partial backend failure that distinction is the diagnosis.
+severity: minor
+resolution: 'Error now reads `analysis: count <outgoing|incoming> "rel" relations of <id>: ...`, derived from spec.direction.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-3ZJM3P.md
+++ b/tickets/entities/review-responses/RR-3ZJM3P.md
@@ -1,0 +1,9 @@
+---
+id: RR-3ZJM3P
+type: review-response
+title: 'Load-bearing but uncommented: subjects buffering and non-nil empty slice'
+finding: (a) checkCardinality buffers every (subject, count) before emitting — deliberate, it preserves the historical min-then-max grouped ordering — but nothing said so; a future optimizer could collapse it to a single pass and silently reorder output. (b) CheckCardinality's `make([]CardinalityViolation, 0)` lost its nolint comment; the non-nil-empty initialization is what keeps JSON Details serializing as [] rather than null, and nothing recorded that.
+severity: minor
+resolution: 'Both now carry explanatory comments in internal/analysis/analysis.go: the buffering comment names the single-pass reordering hazard the pinning tests guard, and the make() carries ''// Non-nil even when empty: JSON callers serialize Details as [], not null.'' The interleaving regression itself is now also pinned by TestCheckCardinality_MinMaxGroupedAcrossTypes.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-4JWU2I.md
+++ b/tickets/entities/review-responses/RR-4JWU2I.md
@@ -1,0 +1,9 @@
+---
+id: RR-4JWU2I
+type: review-response
+title: validate.go godoc claimed abort-before-any-output; header prints first in JSON mode
+finding: runCardinalityCheck's new godoc said a store error 'aborts the check before any output is written', but the pre-existing `fmt.Println("\nChecking cardinality constraints...")` banner fires on !quiet regardless of output format — including --format json — before the error return. The comment documented a guarantee the code does not make; a reader would wrongly trust the JSON stream is clean on the error path.
+severity: significant
+resolution: 'Corrected the comment to state what is true: the error aborts before any VIOLATION output; the banner is the pre-existing plain-stdout header every validate check prints (properties/validations share the wart). Changing the banner''s format-awareness for cardinality alone would diverge from its sibling checks — left as the documented pre-existing shape rather than a one-check special case.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-5FKMKX.md
+++ b/tickets/entities/review-responses/RR-5FKMKX.md
@@ -1,0 +1,9 @@
+---
+id: RR-5FKMKX
+type: review-response
+title: checkCardinality took relName beside the spec - the world seam leaked
+finding: cardinalitySpec's godoc claims subject population, counting scope, and violation identity 'each have exactly one home', yet the relation name (the count query key) arrived as a separate parameter next to the spec while the spec only carried relationLabel (display identity). Two sources of relation truth the caller must keep in sync; a future world field would land on the spec while relName kept arriving by the side door.
+severity: significant
+resolution: Added relName to cardinalitySpec (set once per relation in CheckCardinality); checkCardinality's signature reduced to (ctx, spec, scope); countRelations reads spec.relName. The seam is now structural, not aspirational.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-STCCY8.md
+++ b/tickets/entities/review-responses/RR-STCCY8.md
@@ -1,0 +1,9 @@
+---
+id: RR-STCCY8
+type: review-response
+title: analyze all double-scans cardinality; error path untested at CLI boundary
+finding: 'AnalyzeAllCmd.Run computes AnalyzeAll (one full cardinality scan) then runAnalyzeAllSections re-runs AnalyzeCardinalityCmd (a second full scan). Pre-existing waste, but the new error channel adds a consistency hazard: a flaky backend can pass the summary scan and fail the section scan, printing a contradictory report. Additionally no CLI-layer test covered the new error returns — the assertion that pins ''no output before the error'' was missing.'
+severity: significant
+resolution: 'Added TestAnalyzeCmds_CountErrorAborts (internal/cli/analyze_test.go): a failingCountStore wired through appbuildtest.WithStore + newCLIBundles asserts, for both `analyze cardinality` and `analyze all`, that the wrapped store error is returned and the output buffer is EMPTY. The double-scan itself is pre-existing and out of ticket scope; documented in-code at the runAnalyzeAllSections cardinality call (flaky-backend disagreement hazard, compute-once as the follow-up fix).'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-TFUP2X.md
+++ b/tickets/entities/review-responses/RR-TFUP2X.md
@@ -1,0 +1,9 @@
+---
+id: RR-TFUP2X
+type: review-response
+title: Pinning suite missed the min/max interleaving regression; test import nit
+finding: 'None of the pinning tests would fail if the two emit passes were collapsed into a single count-and-emit pass: catching that requires a min AND a max violation across two subject types (grouped [A-min, B-min, C-max] vs interleaved [A-min, C-max, B-min]). Also the OrderingAndLabels godoc overclaimed (''the full per-relation contract''), and analysis_test.go aliased `stderrors "errors"` with no name collision to justify it.'
+severity: minor
+resolution: Added TestCheckCardinality_MinMaxGroupedAcrossTypes (two From types, min+max violations, asserts the grouped order a single pass would break); trimmed the OrderingAndLabels godoc claim and cross-referenced the sibling tests; switched the test file to a plain `errors` import.
+status: addressed
+---

--- a/tickets/entities/tickets/TKT-RNBLAC.md
+++ b/tickets/entities/tickets/TKT-RNBLAC.md
@@ -5,7 +5,7 @@ title: Consolidate cardinality analyzers; stop swallowing CountRelations errors
 kind: refactor
 priority: high
 effort: s
-status: review
+status: done
 ---
 
 Design doc §12.5 + §12.6 — the suggested first move; unblocks Step 5 and fixes a

--- a/tickets/entities/tickets/TKT-RNBLAC.md
+++ b/tickets/entities/tickets/TKT-RNBLAC.md
@@ -5,7 +5,7 @@ title: Consolidate cardinality analyzers; stop swallowing CountRelations errors
 kind: refactor
 priority: high
 effort: s
-status: backlog
+status: review
 ---
 
 Design doc §12.5 + §12.6 — the suggested first move; unblocks Step 5 and fixes a

--- a/tickets/relations/TKT-RNBLAC--has-implementation--IMPL-MSUOMF.md
+++ b/tickets/relations/TKT-RNBLAC--has-implementation--IMPL-MSUOMF.md
@@ -1,0 +1,5 @@
+---
+from: TKT-RNBLAC
+relation: has-implementation
+to: IMPL-MSUOMF
+---

--- a/tickets/relations/TKT-RNBLAC--has-planning--PLAN-KJ76OT.md
+++ b/tickets/relations/TKT-RNBLAC--has-planning--PLAN-KJ76OT.md
@@ -1,0 +1,5 @@
+---
+from: TKT-RNBLAC
+relation: has-planning
+to: PLAN-KJ76OT
+---

--- a/tickets/relations/TKT-RNBLAC--has-review--REV-1HTU0H.md
+++ b/tickets/relations/TKT-RNBLAC--has-review--REV-1HTU0H.md
@@ -1,0 +1,5 @@
+---
+from: TKT-RNBLAC
+relation: has-review
+to: REV-1HTU0H
+---

--- a/tickets/relations/TKT-RNBLAC--has-review-response--RR-1HB83A.md
+++ b/tickets/relations/TKT-RNBLAC--has-review-response--RR-1HB83A.md
@@ -1,0 +1,5 @@
+---
+from: TKT-RNBLAC
+relation: has-review-response
+to: RR-1HB83A
+---

--- a/tickets/relations/TKT-RNBLAC--has-review-response--RR-3ZJM3P.md
+++ b/tickets/relations/TKT-RNBLAC--has-review-response--RR-3ZJM3P.md
@@ -1,0 +1,5 @@
+---
+from: TKT-RNBLAC
+relation: has-review-response
+to: RR-3ZJM3P
+---

--- a/tickets/relations/TKT-RNBLAC--has-review-response--RR-4JWU2I.md
+++ b/tickets/relations/TKT-RNBLAC--has-review-response--RR-4JWU2I.md
@@ -1,0 +1,5 @@
+---
+from: TKT-RNBLAC
+relation: has-review-response
+to: RR-4JWU2I
+---

--- a/tickets/relations/TKT-RNBLAC--has-review-response--RR-5FKMKX.md
+++ b/tickets/relations/TKT-RNBLAC--has-review-response--RR-5FKMKX.md
@@ -1,0 +1,5 @@
+---
+from: TKT-RNBLAC
+relation: has-review-response
+to: RR-5FKMKX
+---

--- a/tickets/relations/TKT-RNBLAC--has-review-response--RR-STCCY8.md
+++ b/tickets/relations/TKT-RNBLAC--has-review-response--RR-STCCY8.md
@@ -1,0 +1,5 @@
+---
+from: TKT-RNBLAC
+relation: has-review-response
+to: RR-STCCY8
+---

--- a/tickets/relations/TKT-RNBLAC--has-review-response--RR-TFUP2X.md
+++ b/tickets/relations/TKT-RNBLAC--has-review-response--RR-TFUP2X.md
@@ -1,0 +1,5 @@
+---
+from: TKT-RNBLAC
+relation: has-review-response
+to: RR-TFUP2X
+---


### PR DESCRIPTION
Step 1 of content states (FEAT-9CD2MX), PR-A of the TKT-DOFYR1 stack: the domain type, the boundary codec, the store contract, and the fs/mem implementations — pinned by a storetest conformance suite that lands BEFORE the second backend implements.

- `entity.Pointer`: named opaque type carrying the canonical serialized coordinate (zero = default state). Codec (`ParsePointer`/`ParseStateRef`/`FormatStateRef`) is the only constructor from external input; stores equality-match, never inspect (the multi-axis guarantee). Grammar forbids `--` (relation-key separator) per the amended design doc §3.2.
- Store contract: `GetEntityState(ctx, id, pointer)`; `EntityQuery.AllStates` (raw storage truth, NOT world resolution); `RelationQuery.FromPointer` (nil = unfiltered = today's behavior); `Event.Pointer`; `RelationData.FromPointer` (create-only; update/delete stay default-tail in Step 1).
- fs/mem: state files as `PAGE-1@draft.md` beside `PAGE-1.md`; relation keys/filenames carry the tail pointer in the FROM slot; family-wide delete/rename cascades; write-path row-family invariants (no headless states, one type per family) with load-path tolerance; watcher + persisted index pointer-aware; search-indexing observers skip non-default states until Step 5 (bare-id-keyed documents).
- pgstore: FAILS CLOSED on anything state-shaped until PR-B (migration 0011) — writes, GetEntityState, AllStates queries, FromPointer filters — with `TODO(TKT-DOFYR1-PR-B)` markers; `storetest.Capabilities.States` is the transitional gate PR-B flips AND deletes.
- Compat: zero values everywhere = today's semantics; all 84 existing EntityQuery sites and every relation query unchanged; canonical hashes unchanged for pointerless records (pointer hashed only when non-zero).

Stacked on #1381 ← #1378 (diff collapses as ancestors merge). Ticket paperwork (TKT-DOFYR1 + checklists) deliberately NOT in this PR — the ticket spans a 3-PR stack and lands as done with the closing PR, per the multi-PR workflow discipline.