### PR TITLE
chore(ci): adopt commentlint — comment-discipline gate + advisory report (TKT-MTWQ4G)

### DIFF
--- a/.commentlint.yml
+++ b/.commentlint.yml
@@ -1,0 +1,43 @@
+# commentlint configuration — see https://github.com/sourcehaven-bv/commentlint
+#
+# CI runs two steps (the "Comment lint" job in ci.yml):
+#
+#   gate   — commented-code. Clean today, so a regression fails the build.
+#   report — every other enabled rule, advisory (continue-on-error).
+#
+# The advisory rules have a real backlog: nil-contract 100, duplication 119,
+# doclink 58, param-contract 5, restatement 19. They are being worked down; a gate that is
+# red on arrival just teaches people to ignore the job. Promote a rule to the
+# gate once its backlog reaches zero.
+#
+# Suppressing a false positive:
+#   - preferred: //commentlint:ignore <rule>  <reason> on the declaration line
+#   - here:      a path glob under `ignore:`, or a house idiom under
+#                `allow-phrases:` when the same prose recurs across many sites
+
+rules:
+  # Length is a poor proxy for "this comment explains the system": the mode on
+  # this corpus is one line over the threshold, and the highest-value comment
+  # in the tree (a verified sandbox limitation on a one-line function) has the
+  # worst doc:body ratio. Duplication is the signal we act on instead.
+  too-long: false
+  # Flags shared acronyms (ACL, DSN, JWT, SSE) as out-of-scope terms. Useful
+  # to rank a cleanup sweep by hand; far too noisy to run unattended.
+  scope-reach: false
+  # Not gated. golangci-lint enables revive's `exported` rule, so every
+  # exported symbol MUST carry a doc starting with its name; for a trivial
+  # accessor (`Title returns the entity's title`) the name really does say it
+  # all, and this rule's advice — "otherwise delete" — would break the build.
+  # The ~19 remaining findings are all that shape. It stays ON for the report
+  # job, where it is still worth reading for unexported helpers.
+  restatement: true
+
+exclude:
+  - "frontend/**"
+  - testdata
+
+allow-phrases:
+  # Drawing the nil-vs-empty-slice distinction describes how YAML decodes,
+  # not a contract about what a caller may pass. Load-bearing across the ACL
+  # ceiling code (`read: []` means "permit nothing", absent means "inherit").
+  - "non-nil empty slice"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -180,7 +180,7 @@ jobs:
 
       - name: Install commentlint
         # Keep in sync with commentlint_version in the justfile.
-        run: go install github.com/sourcehaven-bv/commentlint@v0.2.0
+        run: go install github.com/sourcehaven-bv/commentlint@v0.2.1
 
       # Gate: clean today, so a regression fails the build. Rules are promoted
       # here from the advisory step once their backlog reaches zero.
@@ -189,9 +189,19 @@ jobs:
 
       # Advisory: real findings with a backlog being worked down. Visible in
       # the log, never red — see .commentlint.yml for why each rule is here.
+      #
+      # One invocation PER RULE, deliberately: the cross-comment rules
+      # (duplication, nil-contract, doclink, param-contract) each have their
+      # own output shape and replace the per-comment output rather than adding
+      # to it, so a single run would silently report only one of them.
       - name: Comment report (advisory)
         continue-on-error: true
-        run: commentlint -rank -top 30 ./internal ./cmd
+        run: |
+          for rule in restatement param-contract doclink nil-contract duplication; do
+            echo "::group::commentlint $rule"
+            commentlint -rules "$rule" -rank -top 30 ./internal ./cmd || true
+            echo "::endgroup::"
+          done
 
   lint-markdown:
     name: Lint Markdown

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,6 +167,32 @@ jobs:
       - name: Check type load lines
         run: plimsoll ./...
 
+  comment-lint:
+    name: Comment lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Set up Go
+        uses: actions/setup-go@v7
+        with:
+          go-version: '1.26.6'
+
+      - name: Install commentlint
+        # Keep in sync with commentlint_version in the justfile.
+        run: go install github.com/sourcehaven-bv/commentlint@v0.2.0
+
+      # Gate: clean today, so a regression fails the build. Rules are promoted
+      # here from the advisory step once their backlog reaches zero.
+      - name: Check comments (gate)
+        run: commentlint -rules commented-code ./internal ./cmd
+
+      # Advisory: real findings with a backlog being worked down. Visible in
+      # the log, never red — see .commentlint.yml for why each rule is here.
+      - name: Comment report (advisory)
+        continue-on-error: true
+        run: commentlint -rank -top 30 ./internal ./cmd
+
   lint-markdown:
     name: Lint Markdown
     runs-on: ubuntu-latest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -546,6 +546,34 @@ is the mandated `store.Store` interface, so its directive is a documented
 "required interface" exception rather than a ratchet target. Prefer splitting the
 type over raising the number.
 
+**Comment discipline** (`just comment-lint`, CI job "Comment lint").
+[commentlint](https://github.com/sourcehaven-bv/commentlint) checks comments
+against the scope they are attached to. Only `commented-code` is a gate; the
+rest are advisory (`just comment-report`) with a backlog being worked down:
+
+- **`duplication`** — the same fact explained in two or more comments. The
+  signal we act on: a fact stored three times gets corrected in one place and
+  goes stale in two. Remedy is to hoist it to the type or package they cite.
+- **`nil-contract`** — nil behaviour as ad-hoc prose. Go cannot express this
+  in a type, so the convention is `Nil: rejected|accepted|never returned —
+  <why>`. Fixing one removes it permanently (the rule skips tagged comments).
+- **`doclink`** — a `[Bracketed.Reference]` that resolves to nothing. Go
+  degrades these silently (pkg.go.dev renders the literal brackets) and no
+  other linter catches them — `go vet`, `staticcheck` and `godoclint` all
+  report zero on a broken link. Most are a bare `[Method]` where Go needs
+  `[Recv.Method]`; the finding names the qualified form.
+- **`param-contract`** — a precondition asserted about a bare `string`/`int`
+  parameter ("MUST already have passed containedPath"). Usually a missing
+  type; this repo already does it where it matters most, e.g.
+  `principal.Principal` keeps `roles` unexported so they can only enter
+  through a verifying constructor.
+- `too-long` and `scope-reach` are **off** — see `.commentlint.yml` for why.
+
+False positives are expected (every rule is a heuristic over prose). Suppress
+with `//commentlint:ignore <rule>  <reason>` on the declaration line, or via
+`.commentlint.yml` when the same prose recurs across many sites. A reason is
+required either way.
+
 ## Security
 
 `govulncheck` runs on every PR touching `go.mod` / `go.sum` (the `vulncheck`

--- a/internal/affordances/resolver.go
+++ b/internal/affordances/resolver.go
@@ -272,7 +272,6 @@ func (r *PolicyResolver) compileFieldBlock(
 	return errs
 }
 
-// compileOptionBlock validates + compiles an options block.
 func (r *PolicyResolver) compileOptionBlock(
 	roleName, entityType string, grants []acl.OptionGrant, out *[]compiledOptionGrant,
 ) []error {

--- a/internal/dataentry/caldav_ctag.go
+++ b/internal/dataentry/caldav_ctag.go
@@ -162,7 +162,6 @@ func retagPropstatStatus(resp, marker string) string {
 	return resp[:at] + seg + resp[end:]
 }
 
-// firstElementText returns the text of the first <name>...</name> element.
 func firstElementText(s, name string) (string, bool) {
 	open := "<" + name + ">"
 	i := strings.Index(s, open)

--- a/internal/dataentryconfig/validate.go
+++ b/internal/dataentryconfig/validate.go
@@ -71,7 +71,6 @@ var validFilterOperators = map[string]bool{
 	"in": true, // comma-separated list, matches any
 }
 
-// Valid sort directions
 var validSortDirections = map[string]bool{
 	"":     true, // default (asc)
 	"asc":  true,
@@ -140,7 +139,6 @@ var validDashboardDisplayModes = map[string]bool{
 	"breakdown": true,
 }
 
-// Valid command contexts
 var validCommandContexts = map[string]bool{
 	"entity": true,
 	"list":   true,
@@ -148,14 +146,12 @@ var validCommandContexts = map[string]bool{
 	"global": true,
 }
 
-// Valid relation directions
 var validRelationDirections = map[Direction]bool{
 	"":                true, // default (outgoing)
 	DirectionOutgoing: true,
 	DirectionIncoming: true,
 }
 
-// Valid relation widgets
 var validRelationWidgets = map[string]bool{
 	"":                true, // default (auto-detect from cardinality)
 	WidgetSelect:      true,

--- a/internal/git/clone.go
+++ b/internal/git/clone.go
@@ -135,7 +135,9 @@ func containedPath(base, path string) (string, error) {
 	return abs, nil
 }
 
-// credentialFileMode is the file permissions for credential files.
+// credentialFileMode is owner-only: the credentials file holds the access token
+// in cleartext (git's store helper has no other format), so any group/other read
+// bit would hand the token to every local user.
 const credentialFileMode = 0o600
 
 // storeCredentials stores credentials for future git operations.

--- a/internal/imgproc/orientation.go
+++ b/internal/imgproc/orientation.go
@@ -45,7 +45,7 @@ const (
 	tiffMagic        = 0x002A
 	tiffHeaderLen    = 8 // "II"/"MM" + magic(2) + IFD0 offset(4)
 
-	exifHeaderLen = 6 // "Exif\0\0"
+	exifHeaderLen = 6 //commentlint:ignore restatement  the literal IS the why: those 6 bytes
 )
 
 // applyOrientation returns img transformed per the EXIF orientation tag found

--- a/internal/importer/importer.go
+++ b/internal/importer/importer.go
@@ -602,7 +602,6 @@ func parseCSV(r io.Reader) (*ImportData, error) {
 	return &ImportData{Entities: entities}, nil
 }
 
-// parseRelationsCSV parses a relations CSV file
 func (imp *Importer) parseRelationsCSV(path string) ([]RelationData, error) {
 	file, err := imp.source.Open(path)
 	if err != nil {

--- a/internal/lua/markdown.go
+++ b/internal/lua/markdown.go
@@ -1168,7 +1168,6 @@ func (r *Runtime) extractCodeBlockContent(fcb *ast.FencedCodeBlock, source []byt
 	return strings.TrimSuffix(sb.String(), "\n")
 }
 
-// extractLinesContent extracts content from a node with Lines().
 func (r *Runtime) extractLinesContent(n ast.Node, source []byte) string {
 	var sb strings.Builder
 	if ln, ok := n.(interface{ Lines() *text.Segments }); ok {
@@ -1447,7 +1446,6 @@ func (r *Runtime) deepCopyTable(tbl *lua.LTable) *lua.LTable {
 	return newTbl
 }
 
-// renderNodes renders AST nodes to markdown.
 func renderNodes(sb *strings.Builder, nodes *lua.LTable) {
 	// Use sequential access to preserve document order
 	for i := 1; i <= nodes.Len(); i++ {
@@ -1463,7 +1461,6 @@ func renderNodes(sb *strings.Builder, nodes *lua.LTable) {
 	}
 }
 
-// renderNode renders a single AST node to markdown.
 func renderNode(sb *strings.Builder, node *lua.LTable) {
 	switch blockKindOf(node) {
 	case nodeTypeHeading:
@@ -1508,13 +1505,11 @@ func renderHeading(sb *strings.Builder, node *lua.LTable) {
 	sb.WriteByte('\n')
 }
 
-// renderParagraph renders a paragraph node.
 func renderParagraph(sb *strings.Builder, node *lua.LTable) {
 	writeInlinesOrFallback(sb, node, renderInlines)
 	sb.WriteByte('\n')
 }
 
-// renderCodeBlock renders a code block node.
 func renderCodeBlock(sb *strings.Builder, node *lua.LTable) {
 	language := ""
 	if l, ok := node.RawGetString("language").(lua.LString); ok {
@@ -1683,7 +1678,6 @@ func prefixLines(sb *strings.Builder, prefix, s string) {
 	}
 }
 
-// renderRaw renders a raw node.
 func renderRaw(sb *strings.Builder, node *lua.LTable) {
 	content := ""
 	if c, ok := node.RawGetString("content").(lua.LString); ok {

--- a/internal/lua/runtime.go
+++ b/internal/lua/runtime.go
@@ -2468,7 +2468,9 @@ func luaValueToSortable(v lua.LValue) (str string, num float64, isNum bool) {
 	}
 }
 
-// hoursPerDay is the number of hours in a day.
+// hoursPerDay converts the elapsed-hours difference luaDaysSince measures into
+// whole days. This is absolute elapsed time, not calendar days, so a DST
+// transition shifts the boundary by an hour — acceptable for a day counter.
 const hoursPerDay = 24
 
 // luaDaysSince implements rela.days_since(date_string) -> number

--- a/internal/schema/analyze.go
+++ b/internal/schema/analyze.go
@@ -132,7 +132,6 @@ func (a *Analysis) HasIssues() bool {
 	return a.TotalUnused() > 0 || a.TotalLowUsage() > 0
 }
 
-// findEntityTypeReferences finds all references to an entity type.
 func findEntityTypeReferences(
 	entityType string,
 	meta *metamodel.Metamodel,
@@ -239,7 +238,6 @@ func findEntityTypeInDataEntry(entityType string, cfg *dataentryconfig.Config) [
 	return refs
 }
 
-// findRelationTypeReferences finds all references to a relation type.
 func findRelationTypeReferences(
 	relationType string,
 	meta *metamodel.Metamodel,

--- a/internal/store/fsstore/fsstore.go
+++ b/internal/store/fsstore/fsstore.go
@@ -372,7 +372,6 @@ func (s *FSStore) entityFileKey(entityType, id string) string {
 	return path.Join(s.entitiesKey, plural, id+".md")
 }
 
-// relationFileKey returns the key for a relation file.
 func (s *FSStore) relationFileKey(from, relType, to string) string {
 	return path.Join(s.relationsKey, from+"--"+relType+"--"+to+".md")
 }

--- a/justfile
+++ b/justfile
@@ -251,15 +251,29 @@ vet:
 # Comment discipline. The gate (commented-code) is clean and enforced in CI;
 # the report surfaces the advisory rules whose backlog is still being worked
 # down. Keep commentlint_version in sync with .github/workflows/ci.yml.
-commentlint_version := "v0.2.0"
+commentlint_version := "v0.2.1"
 comment-lint:
     @echo "==> commentlint (gate)"
     go run github.com/sourcehaven-bv/commentlint@{{commentlint_version}} -rules commented-code ./internal ./cmd
 
+# One invocation per rule, because the cross-comment rules replace the
+# per-comment output rather than adding to it — a single run would silently
+# report only one of them.
+#
 # Advisory comment findings, worst-first. Never fails; this is a worklist.
 comment-report rule="":
-    @go run github.com/sourcehaven-bv/commentlint@{{commentlint_version}} -rank -top 40 \
-        {{ if rule != "" { "-rules " + rule } else { "" } }} ./internal ./cmd
+    #!/usr/bin/env bash
+    set -uo pipefail
+    if [ -n "{{rule}}" ]; then
+        go run github.com/sourcehaven-bv/commentlint@{{commentlint_version}} \
+            -rules "{{rule}}" -rank -top 40 ./internal ./cmd
+        exit 0
+    fi
+    for rule in restatement param-contract doclink nil-contract duplication; do
+        echo "==> commentlint $rule"
+        go run github.com/sourcehaven-bv/commentlint@{{commentlint_version}} \
+            -rules "$rule" -rank -top 40 ./internal ./cmd || true
+    done
 
 # Run all checks (lint + arch-lint + lint-md + test)
 check: lint arch-lint plimsoll comment-lint lint-md test

--- a/justfile
+++ b/justfile
@@ -248,8 +248,21 @@ vet:
 
 # ── CI & Checks ──
 
+# Comment discipline. The gate (commented-code) is clean and enforced in CI;
+# the report surfaces the advisory rules whose backlog is still being worked
+# down. Keep commentlint_version in sync with .github/workflows/ci.yml.
+commentlint_version := "v0.2.0"
+comment-lint:
+    @echo "==> commentlint (gate)"
+    go run github.com/sourcehaven-bv/commentlint@{{commentlint_version}} -rules commented-code ./internal ./cmd
+
+# Advisory comment findings, worst-first. Never fails; this is a worklist.
+comment-report rule="":
+    @go run github.com/sourcehaven-bv/commentlint@{{commentlint_version}} -rank -top 40 \
+        {{ if rule != "" { "-rules " + rule } else { "" } }} ./internal ./cmd
+
 # Run all checks (lint + arch-lint + lint-md + test)
-check: lint arch-lint plimsoll lint-md test
+check: lint arch-lint plimsoll comment-lint lint-md test
 
 # Generate docs from rela entities via mdcomp
 docs: build-cli

--- a/tickets/entities/docs-checklists/DOCS-OPDZK2.md
+++ b/tickets/entities/docs-checklists/DOCS-OPDZK2.md
@@ -1,0 +1,50 @@
+---
+id: DOCS-OPDZK2
+type: docs-checklist
+title: 'Docs: Adopt commentlint in CI: comment-discipline gate + advisory report'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Code Documentation
+
+- [x] Exported symbols documented — N/A in this repo (no Go code added); the
+upstream tool's new code carries package-level docs explaining why each rule
+exists and what it deliberately does not do
+- [x] Non-obvious decisions carry a WHY — `.commentlint.yml` documents the
+reason each disabled rule is disabled, with the evidence, rather than just
+listing `false`
+- [x] `CLAUDE.md` updated — commentlint documented alongside plimsoll and
+arch-lint, covering the three high-signal rules and the suppression mechanisms
+
+## Project Documentation
+
+- [x] `CLAUDE.md` — new "Comment discipline" section under Lint
+- [x] `.commentlint.yml` — inline rationale for every rule decision
+- [x] `tickets/templates/entities/review-checklist.md` — gate checkbox plus
+suppression guidance for future PRs
+- [x] ~~`docs/` guides~~ (N/A: contributor tooling, not a user-facing feature.
+No CLI command, no API surface, no UI. `docs/` is generated from the
+docs-project rela graph and describes rela to its *users*; a CI linter for
+rela's own source has no place there — the same reason plimsoll and arch-lint
+are documented in `CLAUDE.md` only.)
+- [x] ~~`README.md`~~ (N/A: same reasoning; README is user-facing)
+
+## External Documentation
+
+- [x] Tool README documents the new rules — the upstream repo covers
+`doclink`, `param-contract`, `nil-contract` and `duplication`, each with its
+rationale, its known false-positive classes, and a "Why not length" section
+recording why the original `too-long` rule was abandoned
+- [x] Suppression documented — README "Suppressing false positives" covers
+both the inline directive and `.commentlint.yml`, and states that a reason is
+required either way
+- [x] ~~Migration notes~~ (N/A: additive change, nothing to migrate)
+
+## Verification
+
+- [x] Every documented command was run and produces the documented output
+- [x] Counts quoted in docs match reality — re-verified after the v0.2.1 fix:
+restatement 19, param-contract 5, doclink 58, nil-contract 100, duplication 119
+(301 total)

--- a/tickets/entities/implementation-checklists/IMPL-TZWUHA.md
+++ b/tickets/entities/implementation-checklists/IMPL-TZWUHA.md
@@ -2,43 +2,107 @@
 id: IMPL-TZWUHA
 type: implementation-checklist
 title: 'Implementation: Adopt commentlint in CI: comment-discipline gate + advisory report'
-status: in-progress
+status: done
 ---
 
 <!-- @managed: claude-workflow v1 -->
 
 ## Development
 
-- [ ] Unit tests written for new code
-- [ ] Integration tests written (test full flow, not just units)
-- [ ] Happy path implemented
-- [ ] Edge cases from planning handled
-- [ ] Error handling in place (errors surfaced, not swallowed)
+- [x] ~~Unit tests written for new code~~ (N/A: no Go code is added to this
+repo. The linter's rules are unit-tested upstream — 20 tests in
+sourcehaven-bv/commentlint covering config parsing, glob matching, inline
+directives, and each rule's behaviour including its known false-positive
+classes. What this ticket adds here is CI wiring and config, verified by running
+it.)
+- [x] ~~Integration tests written~~ (N/A: the integration IS the CI job;
+verified by executing every recipe and parsing the workflow — see Manual
+Verification.)
+- [x] Happy path implemented — gate + advisory report both run
+- [x] Edge cases from planning handled — UTF-8 truncation fixed upstream
+before adoption; absent-config and narrow-suppression cases covered by upstream
+tests
+- [x] Error handling in place — a malformed `.commentlint.yml` fails with a
+line number rather than being silently ignored
 
 ## Test Quality
 
-- [ ] Using fixture builders or factories for test data
-- [ ] No hardcoded values in assertions when object is in scope
-- [ ] Only specifying values that matter for the test
-- [ ] Interpolated values constructed from objects, not hardcoded
-- [ ] Property comparisons use original object, not hardcoded strings
+- [x] ~~Using fixture builders or factories for test data~~ (N/A: no tests
+added in this repo)
+- [x] ~~No hardcoded values in assertions when object is in scope~~ (N/A)
+- [x] ~~Only specifying values that matter for the test~~ (N/A)
+- [x] ~~Interpolated values constructed from objects, not hardcoded~~ (N/A)
+- [x] ~~Property comparisons use original object, not hardcoded strings~~ (N/A)
 
 ## Manual Verification
 
-- [ ] Feature manually tested end-to-end
-- [ ] Each acceptance criterion verified with test scenario from planning
-- [ ] Edge cases manually verified
+- [x] Feature manually tested end-to-end
+- [x] Each acceptance criterion verified with test scenario from planning
+- [x] Edge cases manually verified
 
 **Verification Evidence:**
-<!-- Document what you tested and the results -->
+
+Every gate run with its exit code captured:
+
+```
+lint         EXIT=0
+arch-lint    EXIT=0
+plimsoll     EXIT=0
+comment-lint EXIT=0   ("no findings across 9876 comments")
+lint-md      EXIT=0
+```
+
+`just ci` was also run to completion twice on this branch: `0 issues` from
+golangci-lint, all package tests `ok`, `Summary: 0 issues in 0 files` from
+markdownlint, and `✓ Docs are up to date.` Zero `FAIL` lines across the run.
+
+Per acceptance criterion:
+
+1. **Gate exits 0 on this branch** — `just comment-lint` → EXIT=0, "no findings
+across 9876 comments".
+2. **Gate catches a regression** — `commented-code` is 0 today; the rule is
+unit-tested upstream. Not re-verified by planting commented-out code here, since
+that would mean committing a deliberate defect.
+3. **Advisory report runs and never fails** — `just comment-report
+param-contract` lists 5 findings and exits 0.
+4. **CI job registers** — `ci.yml` parsed with a YAML loader; `comment-lint`
+present with 5 steps, alongside the 15 existing jobs.
+5. **Suppression works both ways** — the inline directive is used in anger at
+`internal/imgproc/orientation.go:48` (the `exifHeaderLen` false positive, where
+the literal `"Exif\0\0"` IS the reason for the value), and `allow-phrases`
+carries the ACL nil-vs-empty-slice idiom. Both verified end-to-end upstream
+before release.
 
 ## Quality
 
-- [ ] Code follows project patterns (check similar code)
-- [ ] Checked for DRY opportunities — repeated literals, expressions, or
-patterns extracted to a helper / constant / type where it sharpens the contract
-(don't extract for its own sake; CLAUDE.md "three similar lines is better than a
-premature abstraction" still holds)
-- [ ] No security issues introduced
-- [ ] No silent failures (errors logged AND returned)
-- [ ] No debug code left behind
+- [x] Code follows project patterns — deliberately mirrors the plimsoll job
+(`ci.yml:153`) and its justfile recipe, including the pinned version and the
+"keep in sync" comment on both sides
+- [x] Checked for DRY opportunities — the version string is duplicated between
+`justfile` and `ci.yml`. Left duplicated on purpose: that is the existing
+convention for `plimsoll_version`, and a shared source would need a new
+mechanism for one string. Both sites carry a sync comment.
+- [x] No security issues introduced — CI installs one more pinned third-party
+binary from an org-owned repo through the module proxy, the same exposure
+plimsoll already carries. One security *improvement*: `credentialFileMode` now
+documents why `0600` matters (the file holds an access token in cleartext)
+instead of restating the constant.
+- [x] No silent failures — the gate fails the build; the advisory step is
+explicitly `continue-on-error` and says so in a comment
+- [x] No debug code left behind
+
+**Comment fixes included (found by the tool, verified by hand):**
+
+| File | Change |
+|---|---|
+| `dataentryconfig/validate.go` | 4 pure restatements deleted (siblings already had none) |
+| `lua/markdown.go`, `schema/analyze.go`, `fsstore.go`, `importer.go`, `affordances/resolver.go`, `dataentry/caldav_ctag.go` | restatements on unexported helpers deleted |
+| `git/clone.go` | `credentialFileMode` — documents why `0600` (cleartext token) |
+| `lua/runtime.go` | `hoursPerDay` — elapsed-time vs calendar-day, DST caveat |
+| `imgproc/orientation.go` | inline suppression of a false positive, with reason |
+
+Exported-decl restatements were deliberately NOT "fixed": golangci-lint enables
+revive's `exported` rule, so every exported symbol must carry a doc starting
+with its name. For a trivial accessor the name genuinely says it all, and the
+rule's advice ("otherwise delete") would break the build. Those 19 stay advisory
+— a limitation of the rule on exported Go API, not a backlog.

--- a/tickets/entities/implementation-checklists/IMPL-TZWUHA.md
+++ b/tickets/entities/implementation-checklists/IMPL-TZWUHA.md
@@ -1,0 +1,44 @@
+---
+id: IMPL-TZWUHA
+type: implementation-checklist
+title: 'Implementation: Adopt commentlint in CI: comment-discipline gate + advisory report'
+status: in-progress
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Development
+
+- [ ] Unit tests written for new code
+- [ ] Integration tests written (test full flow, not just units)
+- [ ] Happy path implemented
+- [ ] Edge cases from planning handled
+- [ ] Error handling in place (errors surfaced, not swallowed)
+
+## Test Quality
+
+- [ ] Using fixture builders or factories for test data
+- [ ] No hardcoded values in assertions when object is in scope
+- [ ] Only specifying values that matter for the test
+- [ ] Interpolated values constructed from objects, not hardcoded
+- [ ] Property comparisons use original object, not hardcoded strings
+
+## Manual Verification
+
+- [ ] Feature manually tested end-to-end
+- [ ] Each acceptance criterion verified with test scenario from planning
+- [ ] Edge cases manually verified
+
+**Verification Evidence:**
+<!-- Document what you tested and the results -->
+
+## Quality
+
+- [ ] Code follows project patterns (check similar code)
+- [ ] Checked for DRY opportunities — repeated literals, expressions, or
+patterns extracted to a helper / constant / type where it sharpens the contract
+(don't extract for its own sake; CLAUDE.md "three similar lines is better than a
+premature abstraction" still holds)
+- [ ] No security issues introduced
+- [ ] No silent failures (errors logged AND returned)
+- [ ] No debug code left behind

--- a/tickets/entities/planning-checklists/PLAN-SKXUEV.md
+++ b/tickets/entities/planning-checklists/PLAN-SKXUEV.md
@@ -1,0 +1,204 @@
+---
+id: PLAN-SKXUEV
+type: planning-checklist
+title: 'Planning: Adopt commentlint in CI: comment-discipline gate + advisory report'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+> **Note on sequencing.** This ticket was written *after* the work, which was
+> done exploratorily (evaluate the linter → find its rules wanting → improve
+> the tool → adopt it). The checklist below records what was actually decided
+> and verified, not a plan written in advance. Flagged rather than backdated.
+
+## Understanding
+
+- [x] Problem/requirements clearly understood
+- [x] Scope defined (what's in/out documented below)
+- [x] Acceptance criteria documented with specific test scenarios
+
+**Scope:**
+
+IN: commentlint as a CI job (gate + advisory report), `.commentlint.yml` with
+rule rationale, justfile recipes, `CLAUDE.md` docs, review-checklist guidance on
+suppression, and the handful of genuine comment fixes found while wiring it.
+
+OUT: working down the advisory backlog (duplication 119, nil-contract 100,
+doclink 58, param-contract 5, restatement 19). Each is its own follow-up. Also
+out: the upstream tool itself, which lives in its own repo and is already
+released at v0.2.0.
+
+**Acceptance Criteria:**
+
+1. `just comment-lint` exits 0 on develop — verified, "no findings across 9876
+comments".
+2. The gate fails on a regression — verified by construction: `commented-code`
+is 0 today, and the rule has a unit test upstream.
+3. `just comment-report [rule]` lists advisory findings and never fails —
+verified for `param-contract`.
+4. CI job is valid YAML and appears in the job list — verified by parsing
+`ci.yml` (`comment-lint`, 5 steps).
+5. A false positive can be suppressed two ways — verified end-to-end upstream
+(inline directive and `allow-phrases`), and used in anger here for
+`exifHeaderLen`.
+
+## Research
+
+- [x] ~~For larger features: run `/research`~~ (N/A: `s` effort, single CI job
+following an established in-repo pattern)
+- [x] Searched for existing libraries that solve this problem
+- [x] Checked codebase for similar patterns or reusable code
+- [x] Looked for reference implementations in other projects
+- [x] Reviewed relevant rela concepts for prior art
+
+**Research Doc:** N/A — small change, prior art already in-repo.
+
+**Existing Solutions:**
+
+Existing tooling was tested directly against a deliberately broken doc link
+(`[Set.Enforce]` where the method is `EnforceUpdate`):
+
+- `go vet` — exit 0
+- `staticcheck` — 0 issues
+- golangci-lint **`godoclint`** — 0 issues (enabled specifically to test this)
+- `go doc` — renders the link as plain text, no diagnostic
+
+Go's `go/doc/comment` degrades an unresolvable link silently by design: a
+`DocLink` is only produced when the caller supplies a `LookupSym` resolver.
+Nothing in the standard pipeline reports the failure, which is why the `doclink`
+rule is worth having at all.
+
+Codebase prior art: `arch-lint` (`justfile:210`) and `plimsoll` (`justfile:218`,
+CI job "God-object lint", `ci.yml:153`) are the same shape — a pinned
+third-party linter, version in the justfile, mirrored in `ci.yml`. This ticket
+copies that shape deliberately rather than inventing a new one.
+
+## Approach
+
+- [x] Technical approach chosen and documented
+- [x] Approach builds on existing patterns (not reinventing)
+- [x] Alternatives considered (document why rejected)
+- [x] Dependencies identified (packages, APIs, types)
+
+**Technical Approach:**
+
+Mirror the plimsoll job exactly: `go install …/commentlint@v0.2.0`, pinned
+version duplicated in the justfile with a "keep in sync" comment (the existing
+convention). Two CI steps rather than one:
+
+- gate: `commentlint -rules commented-code ./internal ./cmd`
+- report: `commentlint -rank -top 30 ./internal ./cmd`, `continue-on-error`
+
+**Alternatives rejected:**
+
+1. *Gate everything.* Would be red on arrival with 301 findings. A gate that
+fails on day one trains people to ignore the job, so the split exists.
+2. *Report only, no gate.* Nothing would catch a regression;
+`commented-code` is clean and cheap to keep clean.
+3. *Vendor the linter into the repo.* Rejected — it is generic, useful
+outside rela, and the repo already consumes plimsoll this way.
+4. *Enable `too-long` / `scope-reach`.* Rejected on evidence; see the ticket
+body and `.commentlint.yml`.
+
+**Files to modify:** `.commentlint.yml` (new), `.github/workflows/ci.yml`,
+`justfile`, `CLAUDE.md`, `tickets/templates/entities/review-checklist.md`, plus
+5 comment-only source edits.
+
+## Security Considerations
+
+- [x] Input sources identified (user input, config, external APIs)
+- [x] Input validation approach defined (allowlist preferred over blocklist)
+- [x] Security-sensitive operations identified (file access, auth, crypto)
+- [x] Error handling doesn't leak sensitive information
+
+**Input Sources & Validation:**
+
+The linter reads Go source and `.commentlint.yml`, both operator-authored and
+already in the repo. No runtime input, no network, no untrusted data. It runs in
+CI only and produces no artifact.
+
+The one real consideration is **supply chain**: CI installs a third-party
+binary. Mitigated the same way plimsoll is — pinned to an immutable version tag
+(`@v0.2.0`), from an org-owned public repo, resolved through the Go module proxy
+with checksum verification. Not a new class of exposure.
+
+**Security-Sensitive Operations:**
+
+None introduced. One *improvement*: the `credentialFileMode` fix documents why
+the git credentials file (which holds an access token in cleartext) must stay
+`0600` — the previous comment restated the constant and hid the reason.
+
+## Test Plan
+
+- [x] Test scenarios documented for each acceptance criterion
+- [x] Edge cases identified and documented
+- [x] Negative test cases defined (invalid input, error conditions)
+- [x] Integration test approach defined (not just unit tests)
+
+**Test Scenarios:**
+
+Rule behaviour is tested upstream (20 unit tests in the commentlint repo,
+covering config parsing, glob matching, inline directives, and each rule). In
+*this* repo the integration surface is what gets verified: `just comment-lint`
+exits 0, `just comment-report` runs and never fails, `ci.yml` parses and
+registers the job, `golangci-lint` and the full test suite stay green over the
+comment edits.
+
+**Edge Cases:**
+
+- UTF-8: excerpt truncation must not split a multi-byte rune. This corpus is
+full of em dashes and arrows; byte-slicing produced invalid UTF-8 and broke a
+consumer. Fixed upstream (rune-aware truncation) before adoption.
+- Empty/absent config: the tool must work with no `.commentlint.yml`.
+- A comment already carrying a `Nil:` tag must not re-fire (convergence).
+- Suppression must be narrow: naming one rule must not silence others.
+
+**Negative Tests:**
+
+Malformed `.commentlint.yml` (bad bool, non-numeric setting, orphan list item)
+must fail loudly with a line number, not silently ignore the file. Covered
+upstream by `TestParseFileConfigErrors`.
+
+## Risk Assessment
+
+- [x] Technical risks assessed with mitigations
+- [x] Security risks assessed (see Security Considerations)
+- [x] Effort estimated (xs/s/m/l/xl) — `s`
+
+**Risks:**
+
+1. *False positives erode trust.* Highest risk, since every rule is a
+heuristic over prose. Mitigated three ways: only a clean rule gates; two
+suppression mechanisms with a required reason; and the rules were tuned against
+this corpus before adoption (e.g. `nil-contract` dropped from 196 to 100 by
+excluding descriptive `non-nil` and error-only returns).
+2. *Backlog never worked down.* Advisory findings can be ignored forever.
+Mitigated by recording the count per rule in `.commentlint.yml` and the ticket,
+so drift is visible, and by the review-checklist rule that a finding your own
+diff introduces should be fixed or suppressed.
+3. *Version drift between justfile and ci.yml.* Same risk plimsoll already
+carries; mitigated the same way, with a "keep in sync" comment on both.
+
+## Documentation Planning
+
+- [x] User-facing docs identified (skip if internal refactor)
+- [x] Docs-checklist will be created when entering implementation
+
+**Documentation Impact:**
+
+- [x] `CLAUDE.md` — new tooling, documented next to plimsoll/arch-lint
+- [x] `tickets/templates/entities/review-checklist.md` — PR-checklist guidance
+- [x] `.commentlint.yml` — inline rationale for every disabled rule
+- [x] N/A for `docs/` — this is contributor tooling, not a user-facing feature;
+no CLI command, no API, no UI surface
+
+## Design Review
+
+- [x] ~~Run `/design-review` before starting implementation~~ (N/A: the design
+question — which rules gate vs. report, and on what evidence — was settled
+empirically against the corpus during the work, and is recorded in the ticket
+body and `.commentlint.yml`. See the sequencing note above.)
+- [x] All critical/significant findings addressed in plan
+
+**Design Review Findings:** N/A

--- a/tickets/entities/review-checklists/REV-7ILS94.md
+++ b/tickets/entities/review-checklists/REV-7ILS94.md
@@ -1,0 +1,74 @@
+---
+id: REV-7ILS94
+type: review-checklist
+title: 'Review: Adopt commentlint in CI: comment-discipline gate + advisory report'
+status: in-progress
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Automated Checks
+
+- [ ] All tests pass (`just test`)
+- [ ] Lint clean (`just lint`)
+- [ ] Comment lint gate clean (`just comment-lint`)
+- [ ] Coverage maintained (`just coverage-check`)
+
+**Comment findings.** `just comment-report` lists the advisory rules
+(duplication, nil-contract, param-contract, restatement). They are not a merge
+gate, but a finding your diff *introduces* should be fixed or suppressed — don't
+grow the backlog.
+
+Every rule is a heuristic over prose, so false positives are expected. To
+suppress one, prefer the inline form on the declaration line, which travels with
+the code and is reviewed in this diff:
+
+```go
+func f(p string) {} //commentlint:ignore param-contract  p is contained by Clone
+```
+
+Use `.commentlint.yml` (`ignore:` path globs, `allow-phrases:`) only when the
+same prose recurs across many sites. A reason is required either way — an
+unexplained suppression is a finding nobody can re-evaluate later.
+
+## Code Review
+
+- [ ] Run `/code-review` command (invokes cranky-code-reviewer agent)
+- [ ] All critical review-responses addressed
+- [ ] All significant review-responses addressed
+- [ ] Self-reviewed the diff for unrelated changes
+
+**Review Responses:** <!-- List IDs of review-response entities created, e.g.,
+RR-xxxx -->
+
+## Acceptance Verification
+
+- [ ] Each acceptance criterion tested (reference planning checklist)
+- [ ] Test evidence documented in implementation checklist
+
+**Acceptance Status:**
+<!-- For each acceptance criterion, state PASS/FAIL with evidence -->
+
+## Documentation (enhancements only)
+
+Skip this section for bugs and internal refactors.
+
+- [ ] Docs-checklist created and linked via `has-docs`
+- [ ] User-facing documentation updated
+- [ ] Docs-checklist marked as done
+
+**Docs Checklist:** <!-- e.g., DOCS-xxxx -->
+
+## Final Checks
+
+- [ ] Commit message explains the why, not just what
+- [ ] No TODOs or FIXMEs left unaddressed
+- [ ] Ready for another developer to use
+
+## Pull Request
+
+- [ ] Run `/pr` command to create PR and monitor CI
+- [ ] All CI checks pass
+- [ ] PR URL documented below
+
+**PR:** <!-- e.g., https://github.com/org/repo/pull/123 -->

--- a/tickets/entities/review-checklists/REV-7ILS94.md
+++ b/tickets/entities/review-checklists/REV-7ILS94.md
@@ -2,73 +2,83 @@
 id: REV-7ILS94
 type: review-checklist
 title: 'Review: Adopt commentlint in CI: comment-discipline gate + advisory report'
-status: in-progress
+status: done
 ---
 
 <!-- @managed: claude-workflow v1 -->
 
 ## Automated Checks
 
-- [ ] All tests pass (`just test`)
-- [ ] Lint clean (`just lint`)
-- [ ] Comment lint gate clean (`just comment-lint`)
-- [ ] Coverage maintained (`just coverage-check`)
+- [x] All tests pass (`just test`) — full `just ci` run twice on this branch;
+every package `ok`, zero `FAIL` lines
+- [x] Lint clean (`just lint`) — EXIT=0, "0 issues"
+- [x] Comment lint gate clean (`just comment-lint`) — EXIT=0, "no findings
+across 9876 comments"
+- [x] Coverage maintained (`just coverage-check`) — runs inside `just ci`;
+no floor breached (this change adds no Go code to the repo)
 
-**Comment findings.** `just comment-report` lists the advisory rules
-(duplication, nil-contract, param-contract, restatement). They are not a merge
-gate, but a finding your diff *introduces* should be fixed or suppressed — don't
-grow the backlog.
-
-Every rule is a heuristic over prose, so false positives are expected. To
-suppress one, prefer the inline form on the declaration line, which travels with
-the code and is reviewed in this diff:
-
-```go
-func f(p string) {} //commentlint:ignore param-contract  p is contained by Clone
-```
-
-Use `.commentlint.yml` (`ignore:` path globs, `allow-phrases:`) only when the
-same prose recurs across many sites. A reason is required either way — an
-unexplained suppression is a finding nobody can re-evaluate later.
+Also verified independently: `arch-lint` EXIT=0, `plimsoll` EXIT=0, `lint-md`
+EXIT=0, and `ci.yml` parses with the `comment-lint` job registered (5 steps).
 
 ## Code Review
 
-- [ ] Run `/code-review` command (invokes cranky-code-reviewer agent)
-- [ ] All critical review-responses addressed
-- [ ] All significant review-responses addressed
-- [ ] Self-reviewed the diff for unrelated changes
+- [x] Run `/code-review` — performed on the diff (`git diff develop...HEAD`)
+- [x] All critical review-responses addressed — none raised
+- [x] All significant review-responses addressed — RR-TK4N2J
+- [x] Self-reviewed the diff for unrelated changes
 
-**Review Responses:** <!-- List IDs of review-response entities created, e.g.,
-RR-xxxx -->
+**Review Responses:** RR-TK4N2J (significant, addressed), RR-DK21QY (minor,
+addressed)
+
+Both were real defects in the work under review, not nits:
+
+- **RR-TK4N2J** — the advisory step reported only `restatement` (19), because
+the four rules carrying the backlog are opt-in and were never enabled. The
+entire gate/report split is justified by making that backlog visible, so the
+step was not doing the one job it existed for. Fixed by looping per rule; all
+five now report, totalling 301.
+- **RR-DK21QY** — `-rank -top N` counted only displayed findings, so the
+report claimed 40 duplication findings where there were 119. Fixed **upstream**
+(v0.2.1) rather than worked around, since a misleading count is a tool bug;
+regression tests added there.
 
 ## Acceptance Verification
 
-- [ ] Each acceptance criterion tested (reference planning checklist)
-- [ ] Test evidence documented in implementation checklist
+- [x] Each acceptance criterion tested (reference planning checklist)
+- [x] Test evidence documented in implementation checklist
 
 **Acceptance Status:**
-<!-- For each acceptance criterion, state PASS/FAIL with evidence -->
+
+1. Gate exits 0 on this branch — **PASS** (EXIT=0, 9876 comments)
+2. Gate catches a regression — **PASS by construction** (rule is 0 today and
+unit-tested upstream; not re-verified by committing deliberate dead code)
+3. Advisory report runs and never fails — **PASS** (all five rules, 301
+findings, `continue-on-error` plus `|| true`)
+4. CI job registers — **PASS** (YAML parsed, `comment-lint` with 5 steps)
+5. Suppression works both ways — **PASS** (inline directive used at
+`imgproc/orientation.go:48`; `allow-phrases` carries the ACL idiom)
 
 ## Documentation (enhancements only)
 
-Skip this section for bugs and internal refactors.
+- [x] Docs-checklist created and linked via `has-docs`
+- [x] User-facing documentation updated — N/A for `docs/`, justified in the
+docs-checklist (contributor tooling, same treatment as plimsoll)
+- [x] Docs-checklist marked as done
 
-- [ ] Docs-checklist created and linked via `has-docs`
-- [ ] User-facing documentation updated
-- [ ] Docs-checklist marked as done
-
-**Docs Checklist:** <!-- e.g., DOCS-xxxx -->
+**Docs Checklist:** DOCS-OPDZK2
 
 ## Final Checks
 
-- [ ] Commit message explains the why, not just what
-- [ ] No TODOs or FIXMEs left unaddressed
-- [ ] Ready for another developer to use
+- [x] Commit message explains the why, not just what — both commits lead with
+the reasoning (why the split exists; why the loop is needed)
+- [x] No TODOs or FIXMEs left unaddressed
+- [x] Ready for another developer to use — `just comment-lint` and
+`just comment-report [rule]` both documented in `CLAUDE.md`
 
 ## Pull Request
 
-- [ ] Run `/pr` command to create PR and monitor CI
-- [ ] All CI checks pass
-- [ ] PR URL documented below
+- [x] Run `/pr` command to create PR and monitor CI
+- [x] All CI checks pass
+- [x] PR URL documented below
 
-**PR:** <!-- e.g., https://github.com/org/repo/pull/123 -->
+**PR:** https://github.com/sourcehaven-bv/rela/pull/1390

--- a/tickets/entities/review-responses/RR-DK21QY.md
+++ b/tickets/entities/review-responses/RR-DK21QY.md
@@ -1,0 +1,42 @@
+---
+id: RR-DK21QY
+type: review-response
+title: -rank -top N truncates the summary count, so the advisory report understates the backlog
+finding: With -rank -top N, commentlint's trailing summary line counts only the DISPLAYED findings, not the total. `-rules duplication -rank -top 40` prints "40 duplicated facts across 95 comment sites" where the true totals are 119 and 255. The advisory report exists to make the backlog visible, so a silently truncated count defeats its purpose — a reader tracking drift over time would see 40 and conclude the backlog is a third its real size.
+severity: minor
+resolution: 'Fixed upstream rather than worked around, since a misleading count is a tool bug not a wiring choice. commentlint v0.2.1 counts the full result set and appends "— showing N" only when -top actually truncated. Verified: `-rules duplication -rank -top 40` now prints "119 duplicated facts across 255 comment sites — showing 40"; restatement (19, under the cap) prints no annotation. Regression tests added upstream (TestShowingOf, TestShownCount). rela pinned to v0.2.1 in justfile and ci.yml.'
+status: addressed
+---
+
+## Finding
+
+`-rank -top N` caps the displayed findings, which is intended — but the summary
+line is computed from the truncated slice, not the full result set:
+
+```
+$ commentlint -rules duplication ./internal ./cmd
+119 duplicated facts across 255 comment sites (corpus: 9876 comments)
+
+$ commentlint -rules duplication -rank -top 40 ./internal ./cmd
+40 duplicated facts across 95 comment sites (corpus: 9876 comments)
+```
+
+The advisory report is the only mechanism making the backlog visible, and the
+ticket's own justification depends on those counts being trustworthy. A reader
+watching for drift would read 40 and conclude the backlog is a third of its real
+size. The tool's own README warns against exactly this under "No silent caps" —
+a bounded report should say what it dropped.
+
+## Severity
+
+Minor rather than significant: the findings themselves are correct and the
+per-rule totals are recoverable by dropping `-top`. It misleads about volume,
+not about content.
+
+## Resolution options
+
+1. Report both: "showing 40 of 119". Correct fix, needs an upstream change.
+2. Drop `-rank -top` from the CI advisory step so counts are honest, accepting
+longer log output (the `::group::` folds already keep it readable).
+
+Option 2 unblocks this ticket; option 1 is the upstream follow-up.

--- a/tickets/entities/review-responses/RR-TK4N2J.md
+++ b/tickets/entities/review-responses/RR-TK4N2J.md
@@ -1,0 +1,62 @@
+---
+id: RR-TK4N2J
+type: review-response
+title: Advisory CI step reports only restatement — the four rules with the real backlog never run
+finding: 'The advisory CI step runs `commentlint -rank -top 30` with no -rules flag, which reports only restatement (19 findings). The four opt-in cross-comment rules that carry the actual backlog — duplication 119, nil-contract 100, doclink 58, param-contract 5 — never run, so the backlog the gate/report split exists to surface is invisible in CI. Enabling them in .commentlint.yml does not fix it: each cross-comment rule returns early and replaces the per-comment output, so only one runs per invocation.'
+severity: significant
+resolution: 'The CI advisory step and the `comment-report` recipe now invoke commentlint once per rule (restatement, param-contract, doclink, nil-contract, duplication), each wrapped in a ::group:: fold in CI. Verified: all five now report, totalling 301 findings and matching the ticket''s table. A comment at both sites records WHY the loop exists — the cross-comment rules replace rather than augment the per-comment output, so a single invocation would silently report only one.'
+status: addressed
+---
+
+## Finding
+
+The "Comment report (advisory)" step runs:
+
+```
+commentlint -rank -top 30 ./internal ./cmd
+```
+
+That reports **19 findings** (restatement only), not the 301 the ticket claims
+it surfaces. `duplication`, `nil-contract`, `doclink` and `param-contract` are
+opt-in (`false` in `DefaultConfig`) and are not enabled in `.commentlint.yml`,
+so the step silently omits every rule the ticket was written to surface.
+
+Worse, the advisory step is the ONLY visibility mechanism for the backlog. The
+whole gate/report split is justified by "the advisory rules have a real
+backlog... they are being worked down" — but nothing in CI ever prints them, so
+the backlog is invisible and the justification is hollow.
+
+## Evidence
+
+```
+$ commentlint -rank -top 30 ./internal ./cmd
+19 findings across 9876 comments (0.2%)
+```
+
+Expected per the ticket: duplication 119, nil-contract 100, doclink 58,
+param-contract 5, restatement 19.
+
+## Compounding: the rules cannot be combined in one invocation
+
+Enabling them in `.commentlint.yml` does not fix it. Each cross-comment rule
+returns early in `main.go` (they have their own output shape), so exactly one
+runs per invocation and it REPLACES the per-comment output rather than adding to
+it:
+
+```
+$ commentlint -config /tmp/test-cl.yml -rank -top 3 ./internal
+3 duplicated facts across 8 comment sites   # restatement output is gone
+```
+
+So the fix is not a one-line config change — the CI step has to invoke the tool
+once per rule.
+
+## Resolution options
+
+1. Run the advisory step once per rule (`for r in duplication nil-contract
+doclink param-contract restatement; do commentlint -rules $r ...; done`). Fixes
+it here, no upstream change.
+2. Fix upstream so cross-comment rules compose in one run, then simplify the
+step. Better long-term, but blocks this ticket on a tool release.
+
+Option 1 now; option 2 as a follow-up.

--- a/tickets/entities/tickets/TKT-MTWQ4G.md
+++ b/tickets/entities/tickets/TKT-MTWQ4G.md
@@ -5,7 +5,7 @@ title: 'Adopt commentlint in CI: comment-discipline gate + advisory report'
 kind: enhancement
 priority: medium
 effort: s
-status: review
+status: done
 ---
 
 ## Problem

--- a/tickets/entities/tickets/TKT-MTWQ4G.md
+++ b/tickets/entities/tickets/TKT-MTWQ4G.md
@@ -5,7 +5,7 @@ title: 'Adopt commentlint in CI: comment-discipline gate + advisory report'
 kind: enhancement
 priority: medium
 effort: s
-status: in-progress
+status: review
 ---
 
 ## Problem

--- a/tickets/entities/tickets/TKT-MTWQ4G.md
+++ b/tickets/entities/tickets/TKT-MTWQ4G.md
@@ -1,0 +1,75 @@
+---
+id: TKT-MTWQ4G
+type: ticket
+title: 'Adopt commentlint in CI: comment-discipline gate + advisory report'
+kind: enhancement
+priority: medium
+effort: s
+status: in-progress
+---
+
+## Problem
+
+Comment quality has no automated signal. `/code-review` catches stale and
+misleading comments case by case — the tickets tree holds a long tail of
+review-responses about exactly that ("Stale doc comment on X", "Comment falsely
+claims Y") — but nothing runs over the corpus and nothing catches a regression
+before review.
+
+## Approach
+
+Adopt [commentlint](https://github.com/sourcehaven-bv/commentlint) (MIT,
+`sourcehaven-bv`) as a CI job, in the same shape as `arch-lint` and `plimsoll`:
+pinned version in the justfile, mirrored in `ci.yml`.
+
+Two steps, deliberately split:
+
+- **gate** — `commented-code`. Clean today (0 findings), so a regression fails
+the build.
+- **report** — advisory (`continue-on-error`), surfacing the rules that have a
+real backlog.
+
+A gate that is red on arrival trains people to ignore the job, so a rule is
+promoted to the gate only once its backlog reaches zero.
+
+## Rules and their backlog at adoption
+
+| Rule | Findings | Status |
+|---|---|---|
+| `commented-code` | 0 | gate |
+| `param-contract` | 5 | advisory |
+| `restatement` | 19 | advisory |
+| `doclink` | 58 | advisory |
+| `nil-contract` | 100 | advisory |
+| `duplication` | 119 | advisory |
+
+`too-long` and `scope-reach` are disabled outright — see `.commentlint.yml` for
+the evidence. Length is a poor proxy for "this comment explains the system": the
+mode on this corpus is one line over the threshold, and the highest-value
+comment in the tree (a verified sandbox-escape limitation on a one-line
+function) has the worst doc:body ratio in the repo. `scope-reach` flags shared
+acronyms (ACL, DSN, JWT, SSE) as out-of-scope terms.
+
+## Notable
+
+`doclink` catches dead godoc links, which **no other tool reports**. Go degrades
+an unresolvable `[Symbol]` silently — pkg.go.dev renders the literal brackets —
+and `go vet`, `staticcheck` and golangci-lint's `godoclint` all return zero on a
+deliberately broken link. Most findings are a bare `[Method]` where Go requires
+`[Recv.Method]`.
+
+## Scope
+
+- `.commentlint.yml` — rule config, disabled-rule rationale, allow-phrases
+- `.github/workflows/ci.yml` — "Comment lint" job (gate + advisory report)
+- `justfile` — `comment-lint` (added to `just check`), `comment-report [rule]`
+- `CLAUDE.md` — rule documentation next to plimsoll/arch-lint
+- `tickets/templates/entities/review-checklist.md` — gate checkbox plus
+suppression guidance (inline `//commentlint:ignore <rule>  <reason>` preferred;
+`.commentlint.yml` for recurring prose; reason required either way)
+- Four genuine restatement fixes found while wiring it up, plus one inline
+suppression of a false positive
+
+## Out of scope
+
+Working down the advisory backlog. Each rule's backlog is its own follow-up.

--- a/tickets/relations/TKT-MTWQ4G--affects--ci-pipeline.md
+++ b/tickets/relations/TKT-MTWQ4G--affects--ci-pipeline.md
@@ -1,0 +1,5 @@
+---
+from: TKT-MTWQ4G
+relation: affects
+to: ci-pipeline
+---

--- a/tickets/relations/TKT-MTWQ4G--has-docs--DOCS-OPDZK2.md
+++ b/tickets/relations/TKT-MTWQ4G--has-docs--DOCS-OPDZK2.md
@@ -1,0 +1,5 @@
+---
+from: TKT-MTWQ4G
+relation: has-docs
+to: DOCS-OPDZK2
+---

--- a/tickets/relations/TKT-MTWQ4G--has-implementation--IMPL-TZWUHA.md
+++ b/tickets/relations/TKT-MTWQ4G--has-implementation--IMPL-TZWUHA.md
@@ -1,0 +1,5 @@
+---
+from: TKT-MTWQ4G
+relation: has-implementation
+to: IMPL-TZWUHA
+---

--- a/tickets/relations/TKT-MTWQ4G--has-planning--PLAN-SKXUEV.md
+++ b/tickets/relations/TKT-MTWQ4G--has-planning--PLAN-SKXUEV.md
@@ -1,0 +1,5 @@
+---
+from: TKT-MTWQ4G
+relation: has-planning
+to: PLAN-SKXUEV
+---

--- a/tickets/relations/TKT-MTWQ4G--has-review--REV-7ILS94.md
+++ b/tickets/relations/TKT-MTWQ4G--has-review--REV-7ILS94.md
@@ -1,0 +1,5 @@
+---
+from: TKT-MTWQ4G
+relation: has-review
+to: REV-7ILS94
+---

--- a/tickets/relations/TKT-MTWQ4G--has-review-response--RR-DK21QY.md
+++ b/tickets/relations/TKT-MTWQ4G--has-review-response--RR-DK21QY.md
@@ -1,0 +1,5 @@
+---
+from: TKT-MTWQ4G
+relation: has-review-response
+to: RR-DK21QY
+---

--- a/tickets/relations/TKT-MTWQ4G--has-review-response--RR-TK4N2J.md
+++ b/tickets/relations/TKT-MTWQ4G--has-review-response--RR-TK4N2J.md
@@ -1,0 +1,5 @@
+---
+from: TKT-MTWQ4G
+relation: has-review-response
+to: RR-TK4N2J
+---

--- a/tickets/relations/TKT-MTWQ4G--implements--FEAT-GE1YY.md
+++ b/tickets/relations/TKT-MTWQ4G--implements--FEAT-GE1YY.md
@@ -1,0 +1,5 @@
+---
+from: TKT-MTWQ4G
+relation: implements
+to: FEAT-GE1YY
+---

--- a/tickets/templates/entities/review-checklist.md
+++ b/tickets/templates/entities/review-checklist.md
@@ -8,7 +8,25 @@ status: pending
 
 - [ ] All tests pass (`just test`)
 - [ ] Lint clean (`just lint`)
+- [ ] Comment lint gate clean (`just comment-lint`)
 - [ ] Coverage maintained (`just coverage-check`)
+
+**Comment findings.** `just comment-report` lists the advisory rules
+(duplication, nil-contract, param-contract, restatement). They are not a
+merge gate, but a finding your diff *introduces* should be fixed or
+suppressed — don't grow the backlog.
+
+Every rule is a heuristic over prose, so false positives are expected. To
+suppress one, prefer the inline form on the declaration line, which travels
+with the code and is reviewed in this diff:
+
+```go
+func f(p string) {} //commentlint:ignore param-contract  p is contained by Clone
+```
+
+Use `.commentlint.yml` (`ignore:` path globs, `allow-phrases:`) only when the
+same prose recurs across many sites. A reason is required either way — an
+unexplained suppression is a finding nobody can re-evaluate later.
 
 ## Code Review
 


### PR DESCRIPTION
Adopts [commentlint](https://github.com/sourcehaven-bv/commentlint) as a CI job,
in the same shape as `arch-lint` and `plimsoll`: pinned version in the justfile,
mirrored in `ci.yml`.

## Gate vs. report

Two steps, deliberately split:

- **gate** — `commented-code`. Clean today (0 findings), so a regression fails
  the build.
- **report** — advisory (`continue-on-error`), one invocation per rule.

A gate that is red on arrival trains people to ignore the job, so a rule moves
to the gate only once its backlog reaches zero.

| Rule | Findings | Status |
|---|---|---|
| `commented-code` | 0 | **gate** |
| `param-contract` | 5 | advisory |
| `restatement` | 19 | advisory |
| `doclink` | 58 | advisory |
| `nil-contract` | 100 | advisory |
| `duplication` | 119 | advisory |

`too-long` and `scope-reach` are disabled outright, with the evidence recorded
in `.commentlint.yml`. Length turned out to be a poor proxy for "this comment
explains the system": the mode on this corpus is one line over the threshold,
and the highest-value comment in the tree — a *verified* sandbox-escape
limitation on a one-line function — has the worst doc:body ratio in the repo.

## Notable: `doclink`

Catches dead godoc links, which **no other tool reports**. Go degrades an
unresolvable `[Symbol]` silently (pkg.go.dev renders the literal brackets), and
`go vet`, `staticcheck` and golangci-lint's `godoclint` all return zero on a
deliberately broken link — verified on a minimal repro. Most findings here are a
bare `[Method]` where Go requires `[Recv.Method]`; `[Set.Enforce]` in
`statemachine` is a genuine rename casualty.

## Suppressing false positives

Every rule is a heuristic over prose, so false positives are expected:

- **inline** (preferred) — `//commentlint:ignore <rule>  <reason>` on the
  declaration line; travels with the code, reviewed in the diff that adds it
- **`.commentlint.yml`** — path globs and `allow-phrases`, for prose that
  recurs across many sites

A reason is required either way. Documented in `CLAUDE.md` and added to the
review-checklist template.

## Comment fixes included

Genuine findings surfaced while wiring it up: four pure restatements deleted,
`credentialFileMode` documented with why `0600` matters (the file holds an
access token in cleartext), `hoursPerDay` documented as elapsed-time rather than
calendar-day conversion, and one inline suppression of a false positive.

Exported-decl restatements were deliberately **not** "fixed" — revive's
`exported` rule requires those doc comments, so the tool's advice ("otherwise
delete") would break the build.

## Review findings addressed

- **RR-TK4N2J** (significant) — the advisory step reported only `restatement`;
  the four rules with the real backlog are opt-in and never ran. Fixed by
  looping per rule; all five now report, totalling 301.
- **RR-DK21QY** (minor) — `-rank -top N` counted only displayed findings
  (claimed 40 duplication findings where there were 119). Fixed **upstream** in
  commentlint v0.2.1 with regression tests, rather than worked around.

## Verification

`lint`, `arch-lint`, `plimsoll`, `comment-lint`, `lint-md` all EXIT=0.
`just ci` run to completion: 0 lint issues, all packages `ok`, docs up to date.

Ticket: TKT-MTWQ4G · Planning PLAN-SKXUEV · Impl IMPL-TZWUHA · Review REV-7ILS94 · Docs DOCS-OPDZK2