### PR TITLE
docs(tickets): next-action condition + predicatefns schema seam

### DIFF
--- a/tickets/entities/tickets/TKT-N8XQ2R.md
+++ b/tickets/entities/tickets/TKT-N8XQ2R.md
@@ -1,0 +1,107 @@
+---
+id: TKT-N8XQ2R
+type: ticket
+title: 'Next-action sources accept a condition expression, evaluated before the candidate cap'
+kind: enhancement
+priority: medium
+effort: m
+status: backlog
+---
+
+## Goal
+
+Make the dwell-time scenarios expressible. S1 ("proposal out 11 days, no reply
+— chase it?") and S4 ("SOW has been in draft a while") are two of the eight
+grounding scenarios in [[RES-09YLLL]] and neither can be configured today.
+
+The `stalled` and `blocking` bands exist and are documented; an operator has no
+way to say *what makes something stalled*.
+
+## Why it is blocked today
+
+A source's `query:` is search/filter syntax:
+
+```text
+src.Query -> queryCandidates -> executeQuery -> searchparser.ParseQuery -> internal/filter
+```
+
+`internal/filter` has no date arithmetic. `days_between(entity.due, today())`
+in a `query:` hits exactly the trap [[TKT-8GD41J]] removed for `when:` clauses:
+`filter.Parse` does not reject it, it mangles it into a filter on a property
+literally named `days_between(entity.due, today())`, which matches nothing,
+with no error at load and no warning at eval.
+
+The host functions now exist (`days_between`, `date_add`, `rrule_next` in
+`internal/predicatefns`, [[TKT-HQONQE]]). They are simply unreachable from a
+next-action source.
+
+## Scope
+
+Add `condition:` to `NextActionSource`: a predicate expression evaluated over
+the candidates `query:` selects. `query:` keeps selecting (filter syntax,
+unchanged); `condition:` refines (predicate syntax).
+
+Two keys rather than sniffing the dialect, for the reason [[TKT-8GD41J]] gives:
+the syntaxes overlap without erroring, so a heuristic would guess, and guess
+quietly.
+
+### The engine must not learn about predicates
+
+`internal/nextaction` deliberately depends on only `dataentryconfig`, `entity`
+and `userstate` — it does not even reach `store`. Keep it that way with a
+consumer-side interface (`docs/architecture/consumer-side-interfaces.md`):
+
+```go
+// ConditionMatcher reports whether a candidate satisfies a source's condition.
+type ConditionMatcher interface {
+    Match(ctx context.Context, e *entity.Entity) (bool, error)
+}
+```
+
+The wiring site holds the metamodel, compiles each source's `condition:` **once
+at config load**, and supplies the matcher — same shape as `CandidateFunc` and
+`userstate.Store`. A bad expression then fails loudly at startup, matching
+[[TKT-8GD41J]]'s fatal-on-unparseable choice.
+
+Matchers are per-source, so the engine takes a lookup
+(`func(sourceID) ConditionMatcher`) rather than putting a runtime type on
+`dataentryconfig.NextActionSource`.
+
+No arch-lint change: `nextaction` never imports `predicatefns`.
+
+## The cap ordering is load-bearing
+
+`eligibleFromSource` truncates to `DefaultCandidateCap` (20) **immediately**
+after `e.candidates(...)`, before suppression:
+
+```go
+cands, err := e.candidates(ctx, src)
+if len(cands) > e.cap { cands = cands[:e.cap] }
+```
+
+That order is fine for suppression, which is per-suggestion bookkeeping. It is
+**wrong for a condition**, which is a selection predicate: filtering after the
+cap means a condition matching only the 21st candidate silently never fires.
+
+That is the same silent-no-op class this whole line of work exists to remove,
+so the condition must be applied **before** truncation. Pin it with a test: a
+source with >20 candidates where only a late one matches.
+
+While here: `DefaultCandidateCap`'s comment says "see the package doc" for its
+rationale and there is no such doc. Write it down — the cap is about to become
+load-bearing for correctness, not just for cost.
+
+## Out of scope
+
+Pushing ordered comparison into SQL. `store.PropOp` stays equality-only (it
+cannot consult the metamodel), so conditions evaluate in Go per candidate over
+a bounded set — the same tradeoff `filter.Match` already makes, and acceptable
+at next-action scale (one suggestion, capped candidates).
+
+## Acceptance
+
+- A source may declare `condition:`; S1 and S4 are expressible end to end.
+- An unparseable `condition:` fails at config load, not at render.
+- A condition matching only a beyond-the-cap candidate still fires (test).
+- `internal/nextaction` still depends on only `dataentryconfig`, `entity`,
+  `userstate`.

--- a/tickets/entities/tickets/TKT-P5WK7D.md
+++ b/tickets/entities/tickets/TKT-P5WK7D.md
@@ -1,0 +1,106 @@
+---
+id: TKT-P5WK7D
+type: ticket
+title: 'predicatefns takes a consumer-side schema interface returning predicate types, not metamodel defs'
+kind: refactor
+priority: low
+effort: m
+status: backlog
+---
+
+## Goal
+
+`internal/predicatefns` imports `internal/metamodel` to answer one question per
+property: what `predicate.Type` is it, and how does a raw frontmatter value
+bind to a `predicate.Value`? Express that as a consumer-side interface so the
+package stops depending on the metamodel aggregate.
+
+## What it actually uses
+
+The whole surface, measured:
+
+- `meta.GetEntityDef` (x3) — only ever for `def.Properties`
+- `meta.Types[name]` (x1) — only to ask "is this a declared custom type?"
+- per property: `Type`, `List`, `GetDateFormat()`
+
+Nothing else. But note the *values* crossing the boundary are
+`metamodel.PropertyDef` and the `PropertyType*` constants, so an interface that
+hands back schema fields narrows the coupling without removing the import.
+
+## The cut that does remove it
+
+Return the **decision**, not the ingredients. The mapping
+`PropertyDef -> predicate.Type` is a pure function, and `predicate` is already
+metamodel-free (arch-fenced), so:
+
+```go
+type Schema interface {
+    // FieldType is the predicate type of entityType.prop. ok=false means
+    // unmodellable or unknown, and the caller omits it — a reference then
+    // fails at compile rather than evaluating against a wrong type.
+    FieldType(entityType, prop string) (predicate.Type, bool)
+    Fields(entityType string) (map[string]predicate.Type, bool)
+    BindField(entityType, prop string, raw any) predicate.Value
+}
+```
+
+`List` collapses into the implementation (it wraps in `ListType`), the date
+layout collapses into `DateTypeWithLayout`, and the `Type` switch goes with
+them.
+
+`BindField` must be in the same interface as `FieldType`: `Compile` needs
+types, `Matches` needs values, and the two must agree or a value's runtime type
+contradicts its compile-time type. Today those are two switches in separate
+files (`ScalarType` in env.go, `coerceScalar` in bind.go) kept in agreement by
+hand — `affordances/bindings.go:180` documents the invariant in a comment
+rather than enforcing it. Colocating them is a improvement on its own.
+
+## Why the type info is worth preserving exactly
+
+It is what turns a config typo into a startup failure instead of a silent
+no-match:
+
+1. `entity.duedate` for `due_date` is a `CompileError` ("unknown attribute"),
+   not an expression that evaluates nil forever.
+2. `entity.due <= today()` compares dates, not strings — string comparison
+   happens to work for ISO and breaks for every other layout, which is why the
+   format is per-property.
+3. An unmodellable property (`file`) is omitted, so referencing it fails at
+   compile rather than lying at eval.
+
+Any subset that loses one of these trades a loud failure for a quiet one.
+
+## Migration hazard: the date fallback chain
+
+`coerceDate` does not use `GetDateFormat()` directly — it calls
+`metamodel.ParseDateValue(v, prop)`, which is `GetDateFormat()` **plus a
+hardcoded fallback list** (RFC3339, ISO-with-Z, ISO-without-timezone,
+date-only).
+
+Move the layout without the fallbacks and a `date` property storing
+`2026-03-01T10:00:00Z` stops parsing — it binds `Nil`, so the condition
+silently stops matching. No error. The fallback chain has to travel with the
+layout or become part of the injected contract; either way, pin it with a test
+per fallback format.
+
+## Do not regress RR-TBG91
+
+`internal/affordances` imports `predicatefns.ScalarTypeForProp` on purpose, as
+the single canonical adapter. Whatever implements `Schema` becomes that
+adapter and `affordances` must use it — two copies of the mapping is the thing
+RR-TBG91 exists to prevent.
+
+## Not a blocker
+
+[[TKT-N8XQ2R]] needs none of this: it keeps `predicatefns` behind a one-method
+matcher supplied at the wiring site, so `internal/nextaction` never sees a
+schema either way. Sequence this independently.
+
+## Acceptance
+
+- `internal/predicatefns` does not import `internal/metamodel` on the compile
+  or bind path.
+- `affordances` and `predicatefns` still share one type-mapping implementation.
+- Date fallback formats are preserved, with a test per format.
+- `predicatefns` tests can construct a schema fake without building a
+  `*metamodel.Metamodel`.

--- a/tickets/relations/TKT-N8XQ2R--affects--data-entry-ui.md
+++ b/tickets/relations/TKT-N8XQ2R--affects--data-entry-ui.md
@@ -1,0 +1,5 @@
+---
+from: TKT-N8XQ2R
+relation: affects
+to: data-entry-ui
+---

--- a/tickets/relations/TKT-N8XQ2R--implements--FEAT-79DTF9.md
+++ b/tickets/relations/TKT-N8XQ2R--implements--FEAT-79DTF9.md
@@ -1,0 +1,5 @@
+---
+from: TKT-N8XQ2R
+relation: implements
+to: FEAT-79DTF9
+---

--- a/tickets/relations/TKT-P5WK7D--affects--metamodel-types.md
+++ b/tickets/relations/TKT-P5WK7D--affects--metamodel-types.md
@@ -1,0 +1,5 @@
+---
+from: TKT-P5WK7D
+relation: affects
+to: metamodel-types
+---

--- a/tickets/relations/TKT-P5WK7D--implements--FEAT-79DTF9.md
+++ b/tickets/relations/TKT-P5WK7D--implements--FEAT-79DTF9.md
@@ -1,0 +1,5 @@
+---
+from: TKT-P5WK7D
+relation: implements
+to: FEAT-79DTF9
+---


### PR DESCRIPTION
Two tickets from working out why S1/S4 in [[RES-09YLLL]] are still not
expressible after #1380 landed the date-arithmetic host functions.

## TKT-N8XQ2R — next-action sources accept a `condition:`

`days_between(...)` exists now but is unreachable from a next-action source:
`query:` is filter syntax (`searchparser` -> `internal/filter`), which has no
date arithmetic and, worse, does not *reject* an expression — it mangles it
into a filter on a property literally named `days_between(entity.due, today())`
that matches nothing, silently. Exactly the trap TKT-8GD41J removed for
`when:`.

Adds `condition:` alongside `query:` (two keys, not dialect-sniffing — the
syntaxes overlap without erroring). The engine stays ignorant of predicates via
a one-method `ConditionMatcher` supplied at the wiring site, so
`internal/nextaction` keeps its three-package dependency set and needs no
arch-lint change.

**The cap ordering is the load-bearing detail.** `eligibleFromSource`
truncates to `DefaultCandidateCap` immediately after fetching candidates.
That is fine for suppression (per-suggestion bookkeeping) and wrong for a
condition (a selection predicate): filter after the cap and a condition
matching only the 21st candidate silently never fires. Must be applied
pre-truncation, pinned by a test.

## TKT-P5WK7D — `predicatefns` schema seam

`predicatefns` uses exactly `GetEntityDef` (for `def.Properties`),
`Types[name]`, and per-property `Type` / `List` / `GetDateFormat()`. Returning
the *decision* (`predicate.Type`, `predicate.Value`) instead of the ingredients
drops the `metamodel` import entirely, since `predicate` is already
metamodel-free.

Two things recorded so they are not rediscovered the hard way:

- **`coerceDate` calls `metamodel.ParseDateValue`, not `GetDateFormat`** — that
  is the layout *plus* a hardcoded fallback chain (RFC3339, ISO-with-Z, etc.).
  Move the layout without the fallbacks and a `date` property holding
  `2026-03-01T10:00:00Z` binds `Nil` and the condition silently stops matching.
- **RR-TBG91** made `ScalarTypeForProp` the single canonical adapter shared with
  `affordances`; whatever implements the seam has to stay that.

Filed as `backlog`, independent of each other — N8XQ2R does not need P5WK7D.

`rela validate --project tickets` green; neither ticket is orphaned.