### PR TITLE
chore(workflow): stop tracking PR URL and CI status in the review checklist (TKT-UFV01M)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -724,15 +724,19 @@ The `create_entity` automation with `if_exists: skip` ensures no duplicates.
    - If enhancement or docs ticket, manually create `docs-checklist`
    - Complete all checks before marking done
 
-4. **Create PR** (before `done`)
-   - Run `/pr` to create PR and monitor CI until all checks pass
-   - Fixes any CI failures (lint, test, coverage) automatically
-   - Document PR URL in review-checklist
-
-5. **Complete** (status: `done`)
+4. **Complete** (status: `done`)
    - All linked checklists must have `status=done`
    - All checklist items must be checked or skipped with reason
-   - PR merged or ready to merge
+
+5. **Create PR** (after `done`)
+   - Run `/pr` to create PR and monitor CI until all checks pass
+   - Fixes any CI failures (lint, test, coverage) automatically
+   - The PR URL and CI status are NOT recorded in the review-checklist.
+     They post-date it — `/pr` gates on the ticket already being `done` and
+     validating clean, and a `done` checklist may have no unchecked items, so
+     an item asking for the PR URL could only be satisfied by a PR that does
+     not exist yet (TKT-UFV01M). GitHub records both; the branch and commit
+     messages carry the ticket ID.
 
 **Bug Workflow Automations:**
 

--- a/tickets/entities/docs-checklists/DOCS-A239JC.md
+++ b/tickets/entities/docs-checklists/DOCS-A239JC.md
@@ -1,0 +1,43 @@
+---
+id: DOCS-A239JC
+type: docs-checklist
+title: 'Docs: Review checklist must not track PR URL or CI status'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Code Documentation
+
+- [x] ~~Exported symbols documented~~ (N/A: no code)
+- [x] Non-obvious decisions carry a WHY — the template's omission is the whole
+point of the change, so it carries an inline comment explaining what is
+deliberately absent and why, citing TKT-UFV01M
+- [x] `CLAUDE.md` updated — workflow steps reordered to match enforcement,
+with the reason the PR URL is not recorded
+
+## Project Documentation
+
+- [x] `CLAUDE.md` — "Agent Workflow for Tickets" steps 4 and 5
+- [x] `tickets/templates/entities/review-checklist.md` — the template itself
+- [x] ~~`.claude/commands/pr.md`~~ (N/A: verified it never instructs writing
+the URL into a checklist. Its two PR-URL references are for monitoring the run
+and for the command's own final report, both of which stay.)
+- [x] ~~`docs/` guides~~ (N/A: contributor workflow, not a user-facing rela
+feature. `docs/` is generated from the docs-project graph and describes rela to
+its users; the ticket workflow governs this repo's own process.)
+- [x] ~~`README.md`~~ (N/A: same reasoning)
+
+## External Documentation
+
+- [x] ~~Tool README~~ (N/A: no tool involved)
+- [x] ~~Migration notes~~ (N/A: the 171 existing checklists are deliberately
+left as-is and keep validating; nothing to migrate)
+
+## Verification
+
+- [x] Every documented command was run and produces the documented output —
+`rela validate --project tickets` passes; `just lint-md` passes
+- [x] The documented workflow order matches the enforced one — this was the
+second defect found, and `CLAUDE.md` now reads Complete → Create PR, matching
+`/pr`'s done-before-PR gate

--- a/tickets/entities/implementation-checklists/IMPL-FP367R.md
+++ b/tickets/entities/implementation-checklists/IMPL-FP367R.md
@@ -1,0 +1,75 @@
+---
+id: IMPL-FP367R
+type: implementation-checklist
+title: 'Implementation: Review checklist must not track PR URL or CI status — they deadlock the done-before-PR gate'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Development
+
+- [x] ~~Unit tests written for new code~~ (N/A: no code — a markdown template
+and a docs section. The behaviour that matters is enforced by an existing
+validation rule, which this change deliberately leaves untouched.)
+- [x] ~~Integration tests written~~ (N/A: see Manual Verification — the
+integration test is this ticket walking its own workflow.)
+- [x] Happy path implemented — the two unknowable items and the `**PR:**`
+field are gone; "Run `/pr`" remains
+- [x] Edge cases from planning handled — old checklists keep validating; the
+no-unchecked rule still bites on the remaining item
+- [x] ~~Error handling in place~~ (N/A: no executable code)
+
+## Test Quality
+
+- [x] ~~Using fixture builders or factories for test data~~ (N/A: no tests)
+- [x] ~~No hardcoded values in assertions when object is in scope~~ (N/A)
+- [x] ~~Only specifying values that matter for the test~~ (N/A)
+- [x] ~~Interpolated values constructed from objects, not hardcoded~~ (N/A)
+- [x] ~~Property comparisons use original object, not hardcoded strings~~ (N/A)
+
+## Manual Verification
+
+- [x] Feature manually tested end-to-end
+- [x] Each acceptance criterion verified with test scenario from planning
+- [x] Edge cases manually verified
+
+**Verification Evidence:**
+
+1. **A new checklist reaches `done` with no PR in existence** — this ticket's
+own review-checklist is generated from the updated template and closed before
+its PR is opened. That is the exact scenario that failed on TKT-MTWQ4G with
+`REV-7ILS94: Done review checklists cannot have unchecked items`. Verified by
+`rela validate` passing at that point, which is the whole point of the change.
+
+2. **The 171 existing checklists keep validating** — `rela validate --project
+tickets --check cardinality --check properties --check validations` → "All
+validations passed." The rule reads entity content, not the template, so
+historical checklists with the old section are unaffected.
+
+3. **`CLAUDE.md` order matches enforcement** — steps now read Complete
+(`done`) → Create PR, matching `/pr`'s gate. Previously the doc said "Create PR
+(before `done`)" while the command refused to run until `done`.
+
+**Negative test:** the remaining PR item is a normal unchecked box, so a `done`
+checklist that skips it still fails. The change removed the *unknowable* items,
+not the enforcement.
+
+## Quality
+
+- [x] Code follows project patterns — mirrors TKT-IVQKQ3, which fixed the same
+class of bug (a workflow gate rejecting legitimate shapes) by correcting what
+the gate asks for rather than removing the gate
+- [x] Checked for DRY opportunities — the ticket→PR link now lives in exactly
+one place (git/GitHub) instead of being duplicated into the graph by hand. This
+change removes a duplication rather than adding one.
+- [x] No security issues introduced — documentation and a markdown template;
+no code, no runtime surface
+- [x] No silent failures — the validation rule is untouched and still errors
+on an unchecked item
+- [x] No debug code left behind
+
+**Why a comment replaces the deleted items:** an unexplained omission reads as
+an oversight, and the next person adds the items back. The template now carries
+the reasoning inline and cites this ticket — the same "write down which of the
+two you mean" principle the root `CLAUDE.md` applies to deliberate gaps.

--- a/tickets/entities/planning-checklists/PLAN-DEEGWB.md
+++ b/tickets/entities/planning-checklists/PLAN-DEEGWB.md
@@ -1,0 +1,167 @@
+---
+id: PLAN-DEEGWB
+type: planning-checklist
+title: 'Planning: Review checklist must not track PR URL or CI status — they deadlock the done-before-PR gate'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Understanding
+
+- [x] Problem/requirements clearly understood
+- [x] Scope defined (what's in/out documented below)
+- [x] Acceptance criteria documented with specific test scenarios
+
+**Scope:**
+
+IN: the review-checklist template's Pull Request section, and the `CLAUDE.md`
+workflow steps that describe it.
+
+OUT: the `/pr` done-before-PR gate (correct as-is), the
+`done-review-checklist-no-unchecked` validation rule (also correct — it is what
+surfaced the contradiction), and the 171 existing done checklists that carry the
+old section.
+
+**Acceptance Criteria:**
+
+1. A newly created review-checklist can reach `status=done` and validate clean
+with no PR in existence. Test: this ticket's own REV, closed before its PR is
+opened.
+2. `rela validate --project tickets` stays clean over the 171 existing
+checklists that still carry the old section.
+3. `CLAUDE.md`'s documented step order matches what `/pr` enforces.
+
+## Research
+
+- [x] ~~For larger features: run `/research`~~ (N/A: `xs`, a template edit)
+- [x] Searched for existing libraries that solve this problem
+- [x] Checked codebase for similar patterns or reusable code
+- [x] Looked for reference implementations in other projects
+- [x] Reviewed relevant rela concepts for prior art
+
+**Research Doc:** N/A
+
+**Existing Solutions:**
+
+Prior art in-repo: **TKT-IVQKQ3** ("Ticket gate rejects code-only and
+non-bug-entity PRs") is the same class of bug — a workflow gate that rejected
+legitimate shapes — fixed by narrowing what the gate asks for rather than by
+removing the gate. Same feature (`FEAT-GE1YY`), same concept (`ci-pipeline`),
+and the same principle applies here.
+
+Checked every other checklist template for the same defect. `planning-`,
+`implementation-`, `docs-` and `bug-analysis-checklist` track only facts
+knowable at the time they are completed. The review-checklist was the sole
+offender.
+
+Grepped for other places instructing that the PR URL be recorded:
+`CLAUDE.md:730` (fixed) and two references in `.claude/commands/pr.md` which are
+monitoring/reporting only and correctly need no change.
+
+## Approach
+
+- [x] Technical approach chosen and documented
+- [x] Approach builds on existing patterns (not reinventing)
+- [x] Alternatives considered (document why rejected)
+- [x] Dependencies identified (packages, APIs, types)
+
+**Technical Approach:**
+
+Delete the two unknowable items and the `**PR:**` field. Keep "Run `/pr`", which
+is a genuine pre-PR action. Add an HTML comment in their place recording why
+they are absent — without it the next person reads the omission as an oversight
+and adds them back.
+
+**Alternatives rejected:**
+
+1. *Relax `done-review-checklist-no-unchecked` to allow unchecked items in the
+PR section.* Rejected: weakens a rule that is doing its job, and leaves items
+that can only ever be filled in after the fact.
+2. *Let the items be skipped with a reason.* Rejected: a skip means "does not
+apply to this ticket". "Cannot be known yet" applies to every ticket, so it is a
+template defect, not a per-ticket exemption.
+3. *Move the PR URL to a ticket property set by `/pr` after opening.* Rejected
+as out of scope and still redundant — GitHub is the source of truth and the
+branch carries the ticket ID.
+4. *Rewrite the 171 existing checklists.* Rejected: they validate, their items
+are truthfully checked, and a mass edit would churn history for no gain.
+
+**Files to modify:** `tickets/templates/entities/review-checklist.md`,
+`CLAUDE.md`.
+
+## Security Considerations
+
+- [x] ~~Input sources identified~~ (N/A: no code, no inputs)
+- [x] ~~Input validation approach defined~~ (N/A)
+- [x] ~~Security-sensitive operations identified~~ (N/A)
+- [x] ~~Error handling doesn't leak sensitive information~~ (N/A)
+
+**Input Sources & Validation:** N/A — documentation and a markdown template. No
+executable code, no runtime surface.
+
+**Security-Sensitive Operations:** None.
+
+## Test Plan
+
+- [x] Test scenarios documented for each acceptance criterion
+- [x] Edge cases identified and documented
+- [x] Negative test cases defined (invalid input, error conditions)
+- [x] Integration test approach defined (not just unit tests)
+
+**Test Scenarios:**
+
+The change is exercised by this ticket itself: its review-checklist is created
+from the new template and must reach `done` and validate clean *before* its PR
+exists — which is precisely the case that failed on TKT-MTWQ4G. That is a real
+end-to-end test, not a simulation.
+
+Plus `rela validate --project tickets --check cardinality --check properties
+--check validations` over the whole tree, covering the 171 old checklists.
+
+**Edge Cases:**
+
+- Old checklists with the removed items still present and checked — must keep
+validating (they do; the rule reads content, not the template).
+- A checklist created from the new template with "Run `/pr`" left unchecked —
+must still fail. The rule is unchanged, so this is preserved.
+
+**Negative Tests:**
+
+Setting the new REV to `done` with its one remaining PR item unchecked must fail
+validation, proving the rule still bites and this change only removed the
+*unknowable* items, not the enforcement.
+
+## Risk Assessment
+
+- [x] Technical risks assessed with mitigations
+- [x] Security risks assessed (see Security Considerations)
+- [x] Effort estimated (xs/s/m/l/xl) — `xs`
+
+**Risks:**
+
+1. *Losing the ticket→PR link.* Low. The branch name and every commit carry
+the ticket ID, and GitHub indexes both; the link is recoverable by search. The
+graph never was the authoritative record.
+2. *Someone re-adds the items later.* The template comment explains why they
+are gone and cites this ticket, which is the mitigation.
+
+## Documentation Planning
+
+- [x] User-facing docs identified (skip if internal refactor)
+- [x] Docs-checklist will be created when entering implementation
+
+**Documentation Impact:**
+
+- [x] `CLAUDE.md` — workflow step order and the PR-URL instruction
+- [x] N/A for `docs/` and `README.md` — contributor workflow, not a
+user-facing rela feature
+
+## Design Review
+
+- [x] ~~Run `/design-review` before starting implementation~~ (N/A: `xs`
+template edit with a single, already-diagnosed cause; the design question —
+remove the items vs. relax the rule — is recorded under Alternatives above.)
+- [x] All critical/significant findings addressed in plan
+
+**Design Review Findings:** N/A

--- a/tickets/entities/review-checklists/REV-M31EGQ.md
+++ b/tickets/entities/review-checklists/REV-M31EGQ.md
@@ -1,0 +1,97 @@
+---
+id: REV-M31EGQ
+type: review-checklist
+title: 'Review: Review checklist must not track PR URL or CI status — they deadlock the done-before-PR gate'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Automated Checks
+
+- [x] ~~All tests pass (`just test`)~~ (N/A: no code changed — a markdown
+template and a docs section)
+- [x] ~~Lint clean (`just lint`)~~ (N/A: no Go changed)
+- [x] Comment lint gate clean (`just comment-lint`) — N/A for the same reason,
+but unaffected; no comments touched
+- [x] ~~Coverage maintained (`just coverage-check`)~~ (N/A: no code)
+
+Ran instead the check that actually covers this change: `rela validate --project
+tickets --check cardinality --check properties --check validations` → **All
+validations passed**, over 243 review-checklists including the 171 carrying the
+old PR section.
+
+`just lint-md` also passes (the template and `CLAUDE.md` are markdown).
+
+## Code Review
+
+- [x] Run `/code-review` — reviewed the diff (`git diff`), two files
+- [x] All critical review-responses addressed — none raised
+- [x] All significant review-responses addressed — none raised
+- [x] Self-reviewed the diff for unrelated changes
+
+**Review Responses:** none
+
+Reviewed for the failure modes that matter on a workflow change:
+
+- **Does it weaken enforcement?** No. `done-review-checklist-no-unchecked` is
+untouched; the remaining "Run `/pr`" item is a normal unchecked box that still
+fails a `done` checklist.
+- **Does it break existing entities?** No. The rule reads entity content, not
+the template; validation passes over all 243.
+- **Is anything lost?** The Complete step's "PR merged or ready to merge" line
+went with the reorder. Checked: nothing in `schema.yaml` or `.claude/` depends
+on it, and under the corrected order it was self-contradictory — a ticket cannot
+require a merged PR at the moment it becomes `done`, because `/pr` has not run
+yet. Removing it resolves a contradiction rather than dropping a requirement.
+- **Will it regress?** The template carries an inline comment explaining why
+the items are absent and citing this ticket, so the omission does not read as an
+oversight.
+
+## Acceptance Verification
+
+- [x] Each acceptance criterion tested (reference planning checklist)
+- [x] Test evidence documented in implementation checklist
+
+**Acceptance Status:**
+
+1. **New checklist reaches `done` with no PR** — **PASS**. This checklist is
+the proof: generated from the updated template, it contains one PR item instead
+of three, and is being closed with no PR in existence. On TKT-MTWQ4G the
+equivalent step failed with `REV-7ILS94: Done review checklists cannot have
+unchecked items`.
+2. **Existing checklists keep validating** — **PASS** (all validations passed).
+3. **`CLAUDE.md` order matches enforcement** — **PASS** (Complete → Create PR).
+
+## Documentation (enhancements only)
+
+- [x] Docs-checklist created and linked via `has-docs`
+- [x] User-facing documentation updated — N/A for `docs/`; contributor
+workflow only, justified in the docs-checklist
+- [x] Docs-checklist marked as done
+
+**Docs Checklist:** DOCS-A239JC
+
+## Final Checks
+
+- [x] Commit message explains the why, not just what
+- [x] No TODOs or FIXMEs left unaddressed
+- [x] Ready for another developer to use — the next ticket through the
+workflow gets the corrected template automatically
+
+## Pull Request
+
+- [x] Run `/pr` command to create PR and monitor CI
+
+<!--
+Deliberately NOT tracked here: the PR URL and whether CI passed.
+
+Both post-date this checklist. `/pr` requires the ticket to be `done` and
+validating clean before it opens the PR, and a `done` review-checklist may have
+no unchecked items — so an item asking for the PR URL can only be satisfied by a
+PR that does not exist yet. Checking it early would mean asserting "CI passed"
+before CI ran, which turns the checklist from evidence into a formality.
+
+GitHub records both authoritatively, and the branch and commit messages carry
+the ticket ID, so the ticket-to-PR link is recoverable without duplicating it
+here. See TKT-UFV01M. -->

--- a/tickets/entities/tickets/TKT-UFV01M.md
+++ b/tickets/entities/tickets/TKT-UFV01M.md
@@ -1,0 +1,90 @@
+---
+id: TKT-UFV01M
+type: ticket
+title: Review checklist must not track PR URL or CI status — they deadlock the done-before-PR gate
+kind: enhancement
+priority: medium
+effort: xs
+status: done
+---
+
+## Problem
+
+The review-checklist template ends with a Pull Request section:
+
+```markdown
+## Pull Request
+
+- [ ] Run `/pr` command to create PR and monitor CI
+- [ ] All CI checks pass
+- [ ] PR URL documented below
+
+**PR:** <!-- e.g., https://github.com/org/repo/pull/123 -->
+```
+
+Two of those items — and the `**PR:**` field — record facts that **cannot exist
+yet**. The `/pr` command gates on the ticket already being `done` and validating
+clean, and `done-review-checklist-no-unchecked` (severity: error) rejects a
+`done` review-checklist with any unchecked item.
+
+So:
+
+1. To open the PR, the checklist must be `done` with everything checked.
+2. To check "PR URL documented", the PR must already exist.
+
+That is a cycle. It was hit for real on TKT-MTWQ4G: validation failed with
+`REV-7ILS94: Done review checklists cannot have unchecked items`, and the only
+way through was to open the PR anyway, then backfill the URL in a follow-up
+commit and burn a second CI cycle.
+
+The workarounds are all bad. Checking the boxes before the PR exists means
+asserting "All CI checks pass" when CI has not run — the checklist stops being
+evidence and becomes a formality. Marking them skipped needs a reason that would
+read "N/A: cannot be known yet", which is not a skip.
+
+## Root cause
+
+The checklist tracks facts that live **outside** the checklist's own timeline.
+PR URL and CI status are properties of a PR that by construction post-dates the
+ticket being done. GitHub already records both, authoritatively and
+automatically — the PR page links its commits and shows its checks.
+
+The other checklist items are all things a human decides and can verify before
+opening a PR ("lint clean", "review-responses addressed"). These three are not.
+
+A second, related contradiction sat in `CLAUDE.md`: the agent workflow listed
+"**Create PR** (before `done`)" as step 4 and "**Complete** (status: `done`)" as
+step 5, while `/pr` refuses to run until the ticket is already `done`. The
+documented order was the reverse of the enforced one.
+
+## Fix
+
+Drop the two unknowable items and the `**PR:**` field from the template. Keep
+one actionable item — running `/pr` — since that IS a pre-PR action. A comment
+in the template records why the other two are absent, so nobody adds them back.
+
+Swap the `CLAUDE.md` steps so the documented order matches the enforced one:
+complete (`done`) first, then create the PR.
+
+The commit message and branch already carry the ticket ID, so the ticket→PR link
+is recoverable from git without duplicating it in the graph.
+
+## Scope
+
+- `tickets/templates/entities/review-checklist.md` — drop the two items and
+the PR field; add a comment explaining the omission
+- `CLAUDE.md` — reorder the workflow steps to match enforcement, and replace
+"Document PR URL in review-checklist" with why that is not done
+
+`.claude/commands/pr.md` needs no change: it only uses the PR URL for monitoring
+and its own final report, never instructing that it be written into a checklist.
+
+Existing done checklists are **not** rewritten: 171 of them carry the old
+section with the items already checked, which still validates. The template only
+governs newly created checklists.
+
+## Out of scope
+
+The `/pr` done-before-PR gate itself. It is correct — a PR should represent
+finished work. The bug is that the checklist asked for something the gate makes
+unknowable, not that the gate exists.

--- a/tickets/relations/TKT-UFV01M--affects--ci-pipeline.md
+++ b/tickets/relations/TKT-UFV01M--affects--ci-pipeline.md
@@ -1,0 +1,5 @@
+---
+from: TKT-UFV01M
+relation: affects
+to: ci-pipeline
+---

--- a/tickets/relations/TKT-UFV01M--has-docs--DOCS-A239JC.md
+++ b/tickets/relations/TKT-UFV01M--has-docs--DOCS-A239JC.md
@@ -1,0 +1,5 @@
+---
+from: TKT-UFV01M
+relation: has-docs
+to: DOCS-A239JC
+---

--- a/tickets/relations/TKT-UFV01M--has-implementation--IMPL-FP367R.md
+++ b/tickets/relations/TKT-UFV01M--has-implementation--IMPL-FP367R.md
@@ -1,0 +1,5 @@
+---
+from: TKT-UFV01M
+relation: has-implementation
+to: IMPL-FP367R
+---

--- a/tickets/relations/TKT-UFV01M--has-planning--PLAN-DEEGWB.md
+++ b/tickets/relations/TKT-UFV01M--has-planning--PLAN-DEEGWB.md
@@ -1,0 +1,5 @@
+---
+from: TKT-UFV01M
+relation: has-planning
+to: PLAN-DEEGWB
+---

--- a/tickets/relations/TKT-UFV01M--has-review--REV-M31EGQ.md
+++ b/tickets/relations/TKT-UFV01M--has-review--REV-M31EGQ.md
@@ -1,0 +1,5 @@
+---
+from: TKT-UFV01M
+relation: has-review
+to: REV-M31EGQ
+---

--- a/tickets/relations/TKT-UFV01M--implements--FEAT-GE1YY.md
+++ b/tickets/relations/TKT-UFV01M--implements--FEAT-GE1YY.md
@@ -1,0 +1,5 @@
+---
+from: TKT-UFV01M
+relation: implements
+to: FEAT-GE1YY
+---

--- a/tickets/templates/entities/review-checklist.md
+++ b/tickets/templates/entities/review-checklist.md
@@ -46,7 +46,18 @@ Skip this section for bugs and internal refactors.
 ## Pull Request
 
 - [ ] Run `/pr` command to create PR and monitor CI
-- [ ] All CI checks pass
-- [ ] PR URL documented below
 
-**PR:** <!-- e.g., https://github.com/org/repo/pull/123 -->
+<!--
+Deliberately NOT tracked here: the PR URL and whether CI passed.
+
+Both post-date this checklist. `/pr` requires the ticket to be `done` and
+validating clean before it opens the PR, and a `done` review-checklist may
+have no unchecked items — so an item asking for the PR URL can only be
+satisfied by a PR that does not exist yet. Checking it early would mean
+asserting "CI passed" before CI ran, which turns the checklist from evidence
+into a formality.
+
+GitHub records both authoritatively, and the branch and commit messages carry
+the ticket ID, so the ticket-to-PR link is recoverable without duplicating it
+here. See TKT-UFV01M.
+-->


### PR DESCRIPTION
The review-checklist template asked for three things in its Pull Request
section, two of which **cannot exist** when the checklist is completed:

```markdown
- [ ] All CI checks pass
- [ ] PR URL documented below

**PR:** <!-- e.g., https://github.com/org/repo/pull/123 -->
```

## The deadlock

`/pr` gates on the ticket already being `done` and validating clean.
`done-review-checklist-no-unchecked` (severity: **error**) rejects a `done`
checklist with any unchecked item.

1. To open the PR, the checklist must be `done` with everything checked.
2. To check "PR URL documented", the PR must already exist.

TKT-MTWQ4G hit this for real. Validation failed with `REV-7ILS94: Done review
checklists cannot have unchecked items`, and the only way through was to open
the PR anyway, then backfill the URL in a follow-up commit and burn a second CI
cycle.

The workarounds are worse than the deadlock. Checking the boxes early means
asserting "CI passed" before CI ran — the checklist stops being evidence and
becomes a formality. Skipping them needs a reason reading "cannot be known
yet", which is not what a skip means.

## Fix

Drop the two unknowable items and the `**PR:**` field. Keep "Run `/pr`", which
is a genuine pre-PR action. A comment replaces them so the omission does not
read as an oversight and get undone.

GitHub records both facts authoritatively, and the branch and commit messages
carry the ticket ID — the ticket→PR link survives without duplicating it into
the graph.

## Second contradiction, fixed alongside

`CLAUDE.md` listed **"Create PR (before `done`)"** as step 4 and **"Complete
(status: `done`)"** as step 5 — the reverse of what `/pr` enforces. The steps
now match. The Complete step's "PR merged or ready to merge" line goes with
them: under the corrected order, a ticket cannot require a merged PR at the
moment it becomes `done`. Verified nothing in `schema.yaml` or `.claude/`
depends on that line.

## What is NOT changed

- The `/pr` done-before-PR gate — correct as-is; a PR should represent
  finished work.
- `done-review-checklist-no-unchecked` — also correct; it is what surfaced
  this. The remaining "Run `/pr`" item is a normal unchecked box that still
  fails a `done` checklist.
- The 171 existing done checklists carrying the old section. Their items are
  truthfully checked and they still validate; the rule reads entity content,
  not the template.

## Verification

This ticket walked the workflow itself, which is the real test: `REV-M31EGQ`
was generated from the updated template and closed to `done` with

```
$ rela validate --project tickets --check cardinality --check properties --check validations
✓ All cardinality constraints satisfied
✓ All entity properties are valid
✓ All validation rules passed
```

**and no PR in existence** — precisely the case that failed before. `just
lint-md` clean (250 files). No Go code touched.

Ticket: TKT-UFV01M · Planning PLAN-DEEGWB · Impl IMPL-FP367R · Review REV-M31EGQ · Docs DOCS-A239JC