### PR TITLE
Migration lock: pluggable cross-process serialization for data-migration writers (TKT-CPCBR7)

### DIFF
--- a/docs-project/entities/guides/GUIDE-data-migration.md
+++ b/docs-project/entities/guides/GUIDE-data-migration.md
@@ -151,6 +151,16 @@ best guesses: same-shaped remove+add pairs become `rename_property` /
 deletions appear only as commented-out cleanups. **The review is the safety
 mechanism** — never apply a draft unread.
 
+Applies are serialized by a **migration lock**: `rela migrate data --apply`,
+`rela migrate gc --apply`/`--scan`, and the server's GC sweep all take a
+per-store lock before writing, so two concurrent runs cannot interleave — the
+second fails fast with "another migration or GC run is active" (the sweep
+just skips its cycle, and the startup gate skips persisting an adoption
+until the holder finishes). On PostgreSQL the lock is a schema-scoped
+advisory lock, so tenants sharing a database never block each other; on the
+filesystem backend it is a lock file under `.rela/` (single machine, with
+stale-lock detection after a crash). Dry-runs never take the lock.
+
 `data` resolves the chain from the store's current hash to the live schema.
 Migrations run in file-name order; compatible gaps between them (additive
 changes that were adopted without a migration) are bridged automatically, so

--- a/docs-project/entities/guides/GUIDE-data-migration.md
+++ b/docs-project/entities/guides/GUIDE-data-migration.md
@@ -161,6 +161,13 @@ advisory lock, so tenants sharing a database never block each other; on the
 filesystem backend it is a lock file under `.rela/` (single machine, with
 stale-lock detection after a crash). Dry-runs never take the lock.
 
+One caveat on crash recovery: staleness is judged by whether the recorded
+process id is still alive on this machine, never by age (a long migration
+is not a crash). If a crashed run's pid has been recycled by an unrelated
+process, the lock stays honored — the remedy is simply removing
+`.rela/migration.lock` by hand once you have confirmed no migration is
+running.
+
 `data` resolves the chain from the store's current hash to the live schema.
 Migrations run in file-name order; compatible gaps between them (additive
 changes that were adopted without a migration) are bridged automatically, so

--- a/docs-project/entities/guides/GUIDE-postgres-backend.md
+++ b/docs-project/entities/guides/GUIDE-postgres-backend.md
@@ -386,6 +386,11 @@ independently: `rela migrate data` resolves each store's own chain (see the
   goroutine per store; runs are serialized against writers through the
   store's transaction contract. `RELA_DATA_GC=off` disables it (e.g. on
   read-mostly replicas where one designated process should own GC).
+- Migration and GC applies (and gate marker writes) are mutually excluded
+  across processes by a schema-scoped **advisory migration lock** — a
+  session lock held on one pool connection for the duration of the run, so
+  two `migrate data --apply` invocations against the same schema cannot
+  interleave, while different schemas stay independent.
 
 ## Other scope notes
 

--- a/docs/data-migration.md
+++ b/docs/data-migration.md
@@ -155,6 +155,13 @@ advisory lock, so tenants sharing a database never block each other; on the
 filesystem backend it is a lock file under `.rela/` (single machine, with
 stale-lock detection after a crash). Dry-runs never take the lock.
 
+One caveat on crash recovery: staleness is judged by whether the recorded
+process id is still alive on this machine, never by age (a long migration
+is not a crash). If a crashed run's pid has been recycled by an unrelated
+process, the lock stays honored — the remedy is simply removing
+`.rela/migration.lock` by hand once you have confirmed no migration is
+running.
+
 `data` resolves the chain from the store's current hash to the live schema.
 Migrations run in file-name order; compatible gaps between them (additive
 changes that were adopted without a migration) are bridged automatically, so

--- a/docs/data-migration.md
+++ b/docs/data-migration.md
@@ -145,6 +145,16 @@ best guesses: same-shaped remove+add pairs become `rename_property` /
 deletions appear only as commented-out cleanups. **The review is the safety
 mechanism** — never apply a draft unread.
 
+Applies are serialized by a **migration lock**: `rela migrate data --apply`,
+`rela migrate gc --apply`/`--scan`, and the server's GC sweep all take a
+per-store lock before writing, so two concurrent runs cannot interleave — the
+second fails fast with "another migration or GC run is active" (the sweep
+just skips its cycle, and the startup gate skips persisting an adoption
+until the holder finishes). On PostgreSQL the lock is a schema-scoped
+advisory lock, so tenants sharing a database never block each other; on the
+filesystem backend it is a lock file under `.rela/` (single machine, with
+stale-lock detection after a crash). Dry-runs never take the lock.
+
 `data` resolves the chain from the store's current hash to the live schema.
 Migrations run in file-name order; compatible gaps between them (additive
 changes that were adopted without a migration) are bridged automatically, so

--- a/docs/postgres-backend.md
+++ b/docs/postgres-backend.md
@@ -380,6 +380,11 @@ independently: `rela migrate data` resolves each store's own chain (see the
   goroutine per store; runs are serialized against writers through the
   store's transaction contract. `RELA_DATA_GC=off` disables it (e.g. on
   read-mostly replicas where one designated process should own GC).
+- Migration and GC applies (and gate marker writes) are mutually excluded
+  across processes by a schema-scoped **advisory migration lock** — a
+  session lock held on one pool connection for the duration of the run, so
+  two `migrate data --apply` invocations against the same schema cannot
+  interleave, while different schemas stay independent.
 
 ## Other scope notes
 

--- a/internal/appbuild/appbuild.go
+++ b/internal/appbuild/appbuild.go
@@ -1240,7 +1240,7 @@ func assemble(
 	// changes, warn on incompatible ones) and start the drift GC sweep
 	// (TKT-0C57FS). Never fails boot; the stop func is torn down in Close —
 	// per-assembled, like the search closer.
-	gcStop := startDataMigration(stateKV, base.meta, st, cfg.Audit, versions)
+	gcStop := startDataMigration(stateKV, base.meta, st, cfg.Audit, versions, cfg.Paths.CacheDir)
 
 	return &Services{
 		gcStop:          gcStop,

--- a/internal/appbuild/datamigration.go
+++ b/internal/appbuild/datamigration.go
@@ -2,6 +2,7 @@ package appbuild
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 	"os"
 	"time"
@@ -96,6 +97,8 @@ func startDataMigration(
 			case <-ticker.C:
 				res, err := gc.Tick(ctx, true)
 				switch {
+				case errors.Is(err, context.Canceled):
+					// Shutdown raced a tick; not a failure worth a warning.
 				case err != nil:
 					slog.Warn("datamigration: gc tick failed", "error", err)
 				case res.Skipped != "":

--- a/internal/appbuild/datamigration.go
+++ b/internal/appbuild/datamigration.go
@@ -32,9 +32,13 @@ import (
 // per-assembled resource, never shared across tenants.
 func startDataMigration(
 	stateKV state.KV, meta *metamodel.Metamodel, st store.Store,
-	aud audit.Audit, versions store.VersionService,
+	aud audit.Audit, versions store.VersionService, cacheDir string,
 ) (stop func()) {
-	gate, err := datamigration.NewGate(stateKV)
+	// One lock per assembled store, shared by the gate and the GC sweep —
+	// and equivalent to the one the CLI builds for the same store, since
+	// LockFor derives it from the store/cache dir (TKT-CPCBR7).
+	lock := datamigration.LockFor(st, cacheDir)
+	gate, err := datamigration.NewGate(stateKV, lock)
 	if err != nil {
 		slog.Warn("datamigration: gate not started", "error", err)
 		return func() {}
@@ -66,6 +70,7 @@ func startDataMigration(
 		Verdicts: gate,
 		Versions: capture,
 		Grace:    envDuration("RELA_DATA_GC_GRACE", 0), // 0 → datamigration.DefaultGrace
+		Lock:     lock,
 	})
 	if err != nil {
 		slog.Warn("datamigration: gc sweep not started", "error", err)

--- a/internal/cli/migrate_data.go
+++ b/internal/cli/migrate_data.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -24,15 +25,19 @@ func loadDataMigrations(svc *writeServices) ([]*datamigration.File, error) {
 }
 
 // migrationLock builds the per-store lock the same way appbuild does, so
-// CLI runs and server-side gate/GC writers exclude each other.
+// CLI runs and server-side gate/GC writers exclude each other. Each command
+// invocation builds ONE lock value and threads it everywhere — for the fs
+// implementation the embedded in-process mutex only spans one value.
 func migrationLock(svc *writeServices) datamigration.MigrationLock {
 	return datamigration.LockFor(svc.Store, svc.Paths.CacheDir)
 }
 
 // currentShape loads the marker (bootstrapping it via the gate when absent)
 // and returns the shape the data conforms to plus the gate for reuse.
-func evaluateGate(ctx context.Context, svc *writeServices) (*datamigration.Gate, *datamigration.Verdict, error) {
-	gate, err := datamigration.NewGate(svc.State, migrationLock(svc))
+func evaluateGate(
+	ctx context.Context, svc *writeServices, lock datamigration.MigrationLock,
+) (*datamigration.Gate, *datamigration.Verdict, error) {
+	gate, err := datamigration.NewGate(svc.State, lock)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -49,7 +54,7 @@ type MigrateStatusCmd struct{}
 
 // Run executes `rela migrate status`.
 func (c *MigrateStatusCmd) Run(ctx context.Context, svc *writeServices) error {
-	_, v, err := evaluateGate(ctx, svc)
+	_, v, err := evaluateGate(ctx, svc, migrationLock(svc))
 	if err != nil {
 		return err
 	}
@@ -101,7 +106,7 @@ func (c *MigrateGenCmd) Run(ctx context.Context, svc *writeServices) error {
 	if marker == nil {
 		// No marker: nothing recorded to diff against. Evaluate the gate
 		// (bootstraps the baseline) and tell the operator why gen is a no-op.
-		if _, _, gErr := evaluateGate(ctx, svc); gErr != nil {
+		if _, _, gErr := evaluateGate(ctx, svc, migrationLock(svc)); gErr != nil {
 			return gErr
 		}
 		fmt.Println("no recorded data shape yet — baseline adopted; edit schema.yaml first, then re-run `rela migrate gen`")
@@ -151,12 +156,13 @@ type MigrateDataCmd struct {
 
 // Run executes `rela migrate data [--apply]`.
 func (c *MigrateDataCmd) Run(ctx context.Context, svc *writeServices) error {
+	lock := migrationLock(svc)
 	marker, err := datamigration.LoadMarker(ctx, svc.State)
 	if err != nil {
 		return err
 	}
 	if marker == nil {
-		if _, _, gErr := evaluateGate(ctx, svc); gErr != nil {
+		if _, _, gErr := evaluateGate(ctx, svc, lock); gErr != nil {
 			return gErr
 		}
 		fmt.Println("no recorded data shape yet — baseline adopted; nothing to migrate")
@@ -177,7 +183,7 @@ func (c *MigrateDataCmd) Run(ctx context.Context, svc *writeServices) error {
 	}
 	if len(plan) == 0 {
 		// Nothing to run; let the gate adopt any compatible remainder.
-		_, v, gErr := evaluateGate(ctx, svc)
+		_, v, gErr := evaluateGate(ctx, svc, lock)
 		if gErr != nil {
 			return gErr
 		}
@@ -192,7 +198,7 @@ func (c *MigrateDataCmd) Run(ctx context.Context, svc *writeServices) error {
 		Audit:    svc.Audit,
 		ScriptFS: os.DirFS(svc.Paths.Root),
 		Versions: versionCaptureFor(svc),
-		Lock:     migrationLock(svc),
+		Lock:     lock,
 	})
 	if err != nil {
 		return err
@@ -204,7 +210,7 @@ func (c *MigrateDataCmd) Run(ctx context.Context, svc *writeServices) error {
 	}
 	if c.Apply {
 		// Let the gate adopt any compatible tail gap and publish in-sync.
-		if _, v, gerr := evaluateGate(ctx, svc); gerr == nil && v != nil {
+		if _, v, gerr := evaluateGate(ctx, svc, lock); gerr == nil && v != nil {
 			fmt.Println(v.Describe())
 		}
 	} else {
@@ -245,7 +251,8 @@ type MigrateGCCmd struct {
 
 // Run executes `rela migrate gc [--scan] [--apply]`.
 func (c *MigrateGCCmd) Run(ctx context.Context, svc *writeServices) error {
-	gate, _, err := evaluateGate(ctx, svc)
+	lock := migrationLock(svc)
+	gate, _, err := evaluateGate(ctx, svc, lock)
 	if err != nil {
 		return err
 	}
@@ -257,19 +264,26 @@ func (c *MigrateGCCmd) Run(ctx context.Context, svc *writeServices) error {
 		Verdicts: gate,
 		Versions: versionCaptureFor(svc),
 		Grace:    c.Grace,
-		Lock:     migrationLock(svc),
+		Lock:     lock,
 	})
 	if err != nil {
 		return err
 	}
 	if c.Scan {
 		added, sErr := gc.Scan(ctx)
-		if sErr != nil {
+		switch {
+		case errors.Is(sErr, datamigration.ErrLockHeld):
+			// A concurrent run (e.g. the server's hourly sweep) holds the
+			// lock; the scan is additive bookkeeping, so report and carry on
+			// to the tick preview rather than failing the whole command.
+			fmt.Println("scan skipped: another migration or GC run is active — re-run later")
+		case sErr != nil:
 			return sErr
-		}
-		fmt.Printf("scan added %d orphan(s) to the drift ledger\n", len(added))
-		for _, key := range added {
-			fmt.Printf("  %s\n", key)
+		default:
+			fmt.Printf("scan added %d orphan(s) to the drift ledger\n", len(added))
+			for _, key := range added {
+				fmt.Printf("  %s\n", key)
+			}
 		}
 	}
 	res, err := gc.Tick(ctx, c.Apply)

--- a/internal/cli/migrate_data.go
+++ b/internal/cli/migrate_data.go
@@ -23,10 +23,16 @@ func loadDataMigrations(svc *writeServices) ([]*datamigration.File, error) {
 	return datamigration.LoadDir(os.DirFS(svc.Paths.Root))
 }
 
+// migrationLock builds the per-store lock the same way appbuild does, so
+// CLI runs and server-side gate/GC writers exclude each other.
+func migrationLock(svc *writeServices) datamigration.MigrationLock {
+	return datamigration.LockFor(svc.Store, svc.Paths.CacheDir)
+}
+
 // currentShape loads the marker (bootstrapping it via the gate when absent)
 // and returns the shape the data conforms to plus the gate for reuse.
 func evaluateGate(ctx context.Context, svc *writeServices) (*datamigration.Gate, *datamigration.Verdict, error) {
-	gate, err := datamigration.NewGate(svc.State)
+	gate, err := datamigration.NewGate(svc.State, migrationLock(svc))
 	if err != nil {
 		return nil, nil, err
 	}
@@ -186,6 +192,7 @@ func (c *MigrateDataCmd) Run(ctx context.Context, svc *writeServices) error {
 		Audit:    svc.Audit,
 		ScriptFS: os.DirFS(svc.Paths.Root),
 		Versions: versionCaptureFor(svc),
+		Lock:     migrationLock(svc),
 	})
 	if err != nil {
 		return err
@@ -250,6 +257,7 @@ func (c *MigrateGCCmd) Run(ctx context.Context, svc *writeServices) error {
 		Verdicts: gate,
 		Versions: versionCaptureFor(svc),
 		Grace:    c.Grace,
+		Lock:     migrationLock(svc),
 	})
 	if err != nil {
 		return err

--- a/internal/datamigration/gate.go
+++ b/internal/datamigration/gate.go
@@ -57,16 +57,22 @@ type Verdict struct {
 // RUNNER is the path that needs real locking and takes it itself.
 type Gate struct {
 	kv      state.KV
+	lock    MigrationLock
 	verdict atomic.Pointer[Verdict]
 	now     func() time.Time
 }
 
-// NewGate builds a gate over the store's state KV.
-func NewGate(kv state.KV) (*Gate, error) {
+// NewGate builds a gate over the store's state KV. lock is OPTIONAL (nil =
+// unserialized adoption): gate-vs-gate races write identical content, so the
+// lock only matters against a concurrently-running migration/GC — and on
+// contention the gate SKIPS persisting rather than blocking or failing
+// startup (the holder is actively moving the marker; the next evaluation
+// re-adopts). Pass the lock from [LockFor] wherever one is wired.
+func NewGate(kv state.KV, lock MigrationLock) (*Gate, error) {
 	if kv == nil {
 		return nil, errors.New("datamigration: NewGate: state KV is required")
 	}
-	return &Gate{kv: kv, now: time.Now}, nil
+	return &Gate{kv: kv, lock: lock, now: time.Now}, nil
 }
 
 // Verdict returns the most recently published evaluation, or nil before the
@@ -143,7 +149,21 @@ func (g *Gate) Evaluate(ctx context.Context, meta *metamodel.Metamodel) (*Verdic
 }
 
 // adopt moves the marker to the live shape, carrying the applied list over.
+// With a contended lock it skips the write (logged): the holder — a
+// migration or GC run — owns the marker right now, and this evaluation's
+// verdict is still published from what was read.
 func (g *Gate) adopt(ctx context.Context, live metamodel.ShapeProjection, applied []string, now time.Time) error {
+	if g.lock != nil {
+		release, err := g.lock.TryAcquire(ctx)
+		if errors.Is(err, ErrLockHeld) {
+			slog.Info("datamigration: adoption skipped — another migration or GC run holds the lock")
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		defer release()
+	}
 	m, err := NewMarker(live, applied, now)
 	if err != nil {
 		return err

--- a/internal/datamigration/gate.go
+++ b/internal/datamigration/gate.go
@@ -148,11 +148,13 @@ func (g *Gate) Evaluate(ctx context.Context, meta *metamodel.Metamodel) (*Verdic
 	return v, nil
 }
 
-// adopt moves the marker to the live shape, carrying the applied list over.
-// With a contended lock it skips the write (logged): the holder — a
-// migration or GC run — owns the marker right now, and this evaluation's
-// verdict is still published from what was read.
-func (g *Gate) adopt(ctx context.Context, live metamodel.ShapeProjection, applied []string, now time.Time) error {
+// withLock runs one persist section (marker and/or ledger writes) under the
+// migration lock when one is wired. With a contended lock the section is
+// SKIPPED (logged): the holder — a migration or GC run — owns that state
+// right now, and this evaluation's verdict is still published from what was
+// read. The whole section runs under ONE acquisition so the gate can never
+// interleave a ledger write into a GC run that holds the lock.
+func (g *Gate) withLock(ctx context.Context, fn func() error) error {
 	if g.lock != nil {
 		release, err := g.lock.TryAcquire(ctx)
 		if errors.Is(err, ErrLockHeld) {
@@ -164,6 +166,19 @@ func (g *Gate) adopt(ctx context.Context, live metamodel.ShapeProjection, applie
 		}
 		defer release()
 	}
+	return fn()
+}
+
+// adopt moves the marker to the live shape, carrying the applied list over.
+func (g *Gate) adopt(ctx context.Context, live metamodel.ShapeProjection, applied []string, now time.Time) error {
+	return g.withLock(ctx, func() error {
+		return g.writeMarker(ctx, live, applied, now)
+	})
+}
+
+func (g *Gate) writeMarker(
+	ctx context.Context, live metamodel.ShapeProjection, applied []string, now time.Time,
+) error {
 	m, err := NewMarker(live, applied, now)
 	if err != nil {
 		return err
@@ -172,27 +187,31 @@ func (g *Gate) adopt(ctx context.Context, live metamodel.ShapeProjection, applie
 }
 
 // adoptWithDrift adopts AND records the transition's deletion drift in the
-// GC ledger, pruning entries the live schema resurrects. Ledger persistence
-// failing must not block adoption (GC bookkeeping is rebuildable via
-// `rela migrate gc --scan`); it is logged instead.
+// GC ledger, pruning entries the live schema resurrects — marker and ledger
+// under a single lock acquisition (the ledger is exactly the state a
+// concurrent GC apply is rewriting). Ledger persistence failing must not
+// block adoption (GC bookkeeping is rebuildable via `rela migrate gc
+// --scan`); it is logged instead.
 func (g *Gate) adoptWithDrift(
 	ctx context.Context, live metamodel.ShapeProjection, applied []string,
 	report metamodel.ShapeReport, now time.Time,
 ) error {
-	if err := g.adopt(ctx, live, applied, now); err != nil {
-		return err
-	}
-	ledger, err := LoadLedger(ctx, g.kv)
-	if err != nil {
-		slog.Warn("datamigration.ledger_load_failed", "error", err)
+	return g.withLock(ctx, func() error {
+		if err := g.writeMarker(ctx, live, applied, now); err != nil {
+			return err
+		}
+		ledger, err := LoadLedger(ctx, g.kv)
+		if err != nil {
+			slog.Warn("datamigration.ledger_load_failed", "error", err)
+			return nil
+		}
+		ledger.RecordDrift(report, now)
+		ledger.PruneAgainst(live)
+		if err := SaveLedger(ctx, g.kv, ledger); err != nil {
+			slog.Warn("datamigration.ledger_save_failed", "error", err)
+		}
 		return nil
-	}
-	ledger.RecordDrift(report, now)
-	ledger.PruneAgainst(live)
-	if err := SaveLedger(ctx, g.kv, ledger); err != nil {
-		slog.Warn("datamigration.ledger_save_failed", "error", err)
-	}
-	return nil
+	})
 }
 
 // Describe renders a verdict as a short human-readable summary for the

--- a/internal/datamigration/gate_test.go
+++ b/internal/datamigration/gate_test.go
@@ -8,7 +8,7 @@ import (
 
 func newTestGate(t *testing.T, kv *fakeKV) *Gate {
 	t.Helper()
-	g, err := NewGate(kv)
+	g, err := NewGate(kv, nil)
 	if err != nil {
 		t.Fatalf("NewGate: %v", err)
 	}

--- a/internal/datamigration/gc.go
+++ b/internal/datamigration/gc.go
@@ -42,6 +42,10 @@ type GCDeps struct {
 	Verdicts VerdictSource
 	Versions VersionCapture // optional (pg only)
 	Grace    time.Duration  // 0 = DefaultGrace
+	// Lock serializes GC applies against migration runs and other GC
+	// writers (TKT-CPCBR7); build it with [LockFor]. Required — the one
+	// unattended data-deleting path must not lose its serialization.
+	Lock MigrationLock
 }
 
 // GC deletes schema-orphaned data recorded in the drift ledger once the
@@ -66,6 +70,8 @@ func NewGC(deps GCDeps) (*GC, error) {
 		return nil, errors.New("datamigration: NewGC: Audit is required")
 	case deps.Verdicts == nil:
 		return nil, errors.New("datamigration: NewGC: Verdicts is required")
+	case deps.Lock == nil:
+		return nil, errors.New("datamigration: NewGC: Lock is required (use LockFor)")
 	}
 	if deps.Grace <= 0 {
 		deps.Grace = DefaultGrace
@@ -109,6 +115,21 @@ func (g *GC) Tick(ctx context.Context, apply bool) (*GCResult, error) {
 	if v.Status == StatusNeedsMigration {
 		res.Skipped = "schema needs migration — GC will not touch data a pending migration may transform"
 		return res, nil
+	}
+	if apply {
+		// An apply tick competes with migration runs and other GC writers;
+		// contention is a skip, not an error — for the sweep the other
+		// holder is doing equivalent work, and for the CLI the message names
+		// the situation honestly.
+		release, lockErr := g.deps.Lock.TryAcquire(ctx)
+		if errors.Is(lockErr, ErrLockHeld) {
+			res.Skipped = "another migration or GC run holds the migration lock"
+			return res, nil
+		}
+		if lockErr != nil {
+			return nil, lockErr
+		}
+		defer release()
 	}
 
 	live := g.deps.Meta().ShapeProjection()
@@ -269,6 +290,13 @@ func (g *GC) auditTick(ctx context.Context, res *GCResult) {
 // --scan`) — a full content read is fine for an operator command, and
 // deliberately NOT done by the periodic tick (amendment A6).
 func (g *GC) Scan(ctx context.Context) (added []string, err error) {
+	// Scan writes the ledger, so it takes the same lock as the applies.
+	release, err := g.deps.Lock.TryAcquire(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer release()
+
 	live := g.deps.Meta().ShapeProjection()
 	ledger, err := LoadLedger(ctx, g.deps.State)
 	if err != nil {

--- a/internal/datamigration/gc_test.go
+++ b/internal/datamigration/gc_test.go
@@ -19,6 +19,9 @@ func newTestGC(t *testing.T, deps GCDeps) *GC {
 	if deps.Audit == nil {
 		deps.Audit = audit.NewMemory()
 	}
+	if deps.Lock == nil {
+		deps.Lock = NewProcessLock()
+	}
 	g, err := NewGC(deps)
 	if err != nil {
 		t.Fatalf("NewGC: %v", err)

--- a/internal/datamigration/lock.go
+++ b/internal/datamigration/lock.go
@@ -1,6 +1,7 @@
 package datamigration
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -46,10 +47,13 @@ type storeLocker interface {
 
 // LockFor selects the migration lock for a store: a store-provided
 // cross-process lock when the backend has one (pgstore's schema-scoped
-// advisory lock), else a lock file under cacheDir (fsstore — single-machine
-// by nature), else a process-local lock (memory backend, tests). Mirrors how
-// the state.KV backend is chosen: backend capability wins, filesystem
-// fallback.
+// advisory lock), else a lock file under cacheDir, else a process-local
+// lock (tests, cacheDir-less contexts). The cacheDir branch applies to the
+// memory backend too, ON PURPOSE: what the lock guards is the marker/ledger
+// in state.KV, and for every non-postgres backend that state lives under
+// `.rela/` (FSKV) — shared across processes — so the lock must be a file
+// beside it. Mirrors how the state.KV backend itself is chosen: backend
+// capability wins, filesystem fallback.
 func LockFor(st store.Store, cacheDir string) MigrationLock {
 	if sl, ok := st.(storeLocker); ok {
 		return &storeLock{sl: sl}
@@ -78,12 +82,17 @@ func (l *storeLock) TryAcquire(ctx context.Context) (func(), error) {
 // ---- process-local ----
 
 // ProcessLock is the in-process implementation: mutual exclusion between
-// goroutines of one process only (memory backend, tests). It is also
-// embedded in the fs lock so two goroutines in one process cannot both pass
-// the pid-file check (their shared pid reads as "held by a live process —
-// me" for both).
+// goroutines of one process only (tests, contexts with no cache dir). It is
+// also embedded in the fs lock so two goroutines sharing one fsLock VALUE
+// cannot both pass the pid-file check (their shared pid reads as "held by a
+// live process — me" for both).
+//
+// Releases are generation-guarded, not just idempotent: a stale release
+// func kept from an earlier acquisition can never unlock a later holder.
 type ProcessLock struct {
-	mu sync.Mutex
+	mu   sync.Mutex
+	held bool
+	gen  uint64
 }
 
 // NewProcessLock returns a process-local MigrationLock.
@@ -91,10 +100,21 @@ func NewProcessLock() *ProcessLock { return &ProcessLock{} }
 
 // TryAcquire implements [MigrationLock].
 func (l *ProcessLock) TryAcquire(context.Context) (func(), error) {
-	if !l.mu.TryLock() {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if l.held {
 		return nil, ErrLockHeld
 	}
-	return once(l.mu.Unlock), nil
+	l.held = true
+	l.gen++
+	mine := l.gen
+	return func() {
+		l.mu.Lock()
+		defer l.mu.Unlock()
+		if l.held && l.gen == mine {
+			l.held = false
+		}
+	}, nil
 }
 
 // ---- filesystem lock file ----
@@ -128,32 +148,33 @@ func newFSLock(cacheDir string) *fsLock {
 
 // TryAcquire implements [MigrationLock]. A lock file whose recorded pid is
 // no longer alive (crashed run) is broken with a warning and acquisition is
-// retried once.
+// retried once. Nil: never returns a nil release on nil error.
 func (l *fsLock) TryAcquire(ctx context.Context) (func(), error) {
-	if !l.local.mu.TryLock() {
-		return nil, ErrLockHeld
+	releaseLocal, err := l.local.TryAcquire(ctx)
+	if err != nil {
+		return nil, err
 	}
 	releaseFile, err := l.acquireFile(ctx)
 	if err != nil {
-		l.local.mu.Unlock()
+		releaseLocal()
 		return nil, err
 	}
 	return once(func() {
 		releaseFile()
-		l.local.mu.Unlock()
+		releaseLocal()
 	}), nil
 }
 
 func (l *fsLock) acquireFile(ctx context.Context) (func(), error) {
+	if err := os.MkdirAll(filepath.Dir(l.path), 0o755); err != nil {
+		return nil, fmt.Errorf("datamigration: create lock dir: %w", err)
+	}
 	// One stale-break retry, never more: a second failure means a live
 	// holder raced us to re-create the file, which is contention, not
 	// staleness.
 	for range 2 {
 		if err := ctx.Err(); err != nil {
-			return nil, err
-		}
-		if err := os.MkdirAll(filepath.Dir(l.path), 0o755); err != nil {
-			return nil, fmt.Errorf("datamigration: create lock dir: %w", err)
+			return nil, fmt.Errorf("datamigration: acquire migration lock: %w", err)
 		}
 		payload, _ := json.Marshal(lockFilePayload{PID: os.Getpid(), AcquiredAt: time.Now().UTC()})
 		f, err := os.OpenFile(l.path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o644)
@@ -161,10 +182,14 @@ func (l *fsLock) acquireFile(ctx context.Context) (func(), error) {
 			_, werr := f.Write(payload)
 			cerr := f.Close()
 			if werr != nil || cerr != nil {
-				_ = os.Remove(l.path)
+				l.removeIfOurs(payload)
 				return nil, fmt.Errorf("datamigration: write lock file: %w", errors.Join(werr, cerr))
 			}
-			return func() { _ = os.Remove(l.path) }, nil
+			// Release removes the file ONLY while it still holds our own
+			// payload: if an operator hand-removed the lock and another
+			// process acquired meanwhile, an unconditional remove would
+			// delete the new holder's lock.
+			return func() { l.removeIfOurs(payload) }, nil
 		}
 		if !errors.Is(err, os.ErrExist) {
 			return nil, fmt.Errorf("datamigration: create lock file: %w", err)
@@ -176,30 +201,83 @@ func (l *fsLock) acquireFile(ctx context.Context) (func(), error) {
 	return nil, ErrLockHeld
 }
 
+// removeIfOurs deletes the lock file only when its content is exactly the
+// payload this acquisition wrote.
+func (l *fsLock) removeIfOurs(payload []byte) {
+	current, err := os.ReadFile(l.path)
+	if err == nil && bytes.Equal(current, payload) {
+		_ = os.Remove(l.path)
+	}
+}
+
+// breakPath is the break-mutex file: the exclusive right to REMOVE a stale
+// lock file. Without it, two processes that both judged the file stale could
+// interleave so that the second os.Remove deletes the first's freshly
+// re-created lock — the classic read-decide-remove TOCTOU. Only the process
+// that O_EXCL-creates the break file may remove the lock, and it re-verifies
+// staleness while holding it, so a fresh lock can never be removed.
+func (l *fsLock) breakPath() string { return l.path + ".break" }
+
+// breakStaleWindow is how old an abandoned break file must be before it is
+// itself removed. Legitimate holds last microseconds; a breaker that crashed
+// mid-break is the only way one persists.
+const breakStaleWindow = 30 * time.Second
+
 // breakIfStale removes the lock file when its holder is provably gone on
 // this host, returning true when a retry is worthwhile. A file naming a
 // LIVE pid is always honored — staleness can only be concluded from a dead
 // or unattributable holder, never from age alone (a long migration is not a
-// crash).
+// crash). KNOWN LIMIT: a crashed holder's pid recycled by an unrelated
+// process reads as alive and wedges the lock; the operator remedy is
+// removing .rela/migration.lock by hand (documented in the guide).
 func (l *fsLock) breakIfStale() bool {
+	if !l.isStale() {
+		return false
+	}
+	// Take the break mutex; the loser reports held and lets the winner
+	// finish (its own retry will find either a fresh lock or no file).
+	bf, err := os.OpenFile(l.breakPath(), os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o644)
+	if err != nil {
+		if errors.Is(err, os.ErrExist) {
+			l.clearAbandonedBreak()
+		}
+		return false
+	}
+	_ = bf.Close()
+	defer os.Remove(l.breakPath())
+	// Re-verify UNDER the break mutex: between our first read and now,
+	// another breaker may have removed the stale file and a new holder may
+	// have created a fresh one.
+	if !l.isStale() {
+		return false
+	}
+	slog.Warn("datamigration: breaking stale migration lock", "path", l.path)
+	_ = os.Remove(l.path)
+	return true
+}
+
+// isStale reports whether the lock file exists and its holder is provably
+// gone (dead pid) or unattributable (unparseable). A missing file counts as
+// stale too: the retry's O_EXCL create decides ownership either way.
+func (l *fsLock) isStale() bool {
 	data, err := os.ReadFile(l.path)
 	if err != nil {
-		// Raced with the holder's release: the file is already gone.
 		return errors.Is(err, os.ErrNotExist)
 	}
 	var p lockFilePayload
 	if err := json.Unmarshal(data, &p); err != nil || p.PID <= 0 {
-		slog.Warn("datamigration: breaking unparseable migration lock file", "path", l.path)
-		_ = os.Remove(l.path)
 		return true
 	}
-	if pidAlive(p.PID) {
-		return false
+	return !pidAlive(p.PID)
+}
+
+// clearAbandonedBreak removes a break file left behind by a crashed breaker.
+func (l *fsLock) clearAbandonedBreak() {
+	info, err := os.Stat(l.breakPath())
+	if err == nil && time.Since(info.ModTime()) > breakStaleWindow {
+		slog.Warn("datamigration: removing abandoned lock-break marker", "path", l.breakPath())
+		_ = os.Remove(l.breakPath())
 	}
-	slog.Warn("datamigration: breaking stale migration lock from dead process",
-		"path", l.path, "pid", p.PID, "acquired_at", p.AcquiredAt)
-	_ = os.Remove(l.path)
-	return true
 }
 
 // pidAlive reports whether a process with the given pid exists on this

--- a/internal/datamigration/lock.go
+++ b/internal/datamigration/lock.go
@@ -1,0 +1,221 @@
+package datamigration
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"sync"
+	"syscall"
+	"time"
+
+	"github.com/Sourcehaven-BV/rela/internal/store"
+)
+
+// ErrLockHeld is returned by [MigrationLock.TryAcquire] when another
+// migration or GC run is active against the same store. Callers fail fast
+// (CLI) or skip the cycle (sweep/gate) — nothing in this package ever blocks
+// waiting for the lock.
+var ErrLockHeld = errors.New("datamigration: another migration or GC run is active")
+
+// MigrationLock serializes the writers of the migration marker/ledger and
+// the destructive GC path across processes sharing one store (TKT-CPCBR7).
+// It is an operational mutual-exclusion primitive like the pgstore sweep's
+// advisory lock — NOT a transaction seam (that stays store.Store.Tx,
+// DEC-8UIL0) and not a general lock service.
+//
+// Consumer-side interface: implementations are selected per backend by
+// [LockFor], the way state.KV backends are.
+type MigrationLock interface {
+	// TryAcquire returns a release func on success and ErrLockHeld when the
+	// lock is taken. It never blocks beyond one round-trip; release is
+	// idempotent.
+	TryAcquire(ctx context.Context) (release func(), err error)
+}
+
+// storeLocker is the optional store capability behind the postgres
+// implementation, discovered by type-assert like store.Formatter /
+// HistoryReader. The signature matches (*pgstore.Store).TryMigrationLock
+// exactly so no adapter package is needed; ok=false means held.
+type storeLocker interface {
+	TryMigrationLock(ctx context.Context) (release func(), ok bool, err error)
+}
+
+// LockFor selects the migration lock for a store: a store-provided
+// cross-process lock when the backend has one (pgstore's schema-scoped
+// advisory lock), else a lock file under cacheDir (fsstore — single-machine
+// by nature), else a process-local lock (memory backend, tests). Mirrors how
+// the state.KV backend is chosen: backend capability wins, filesystem
+// fallback.
+func LockFor(st store.Store, cacheDir string) MigrationLock {
+	if sl, ok := st.(storeLocker); ok {
+		return &storeLock{sl: sl}
+	}
+	if cacheDir != "" {
+		return newFSLock(cacheDir)
+	}
+	return NewProcessLock()
+}
+
+// ---- store-backed (postgres) ----
+
+type storeLock struct{ sl storeLocker }
+
+func (l *storeLock) TryAcquire(ctx context.Context) (func(), error) {
+	release, ok, err := l.sl.TryMigrationLock(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("datamigration: acquire store migration lock: %w", err)
+	}
+	if !ok {
+		return nil, ErrLockHeld
+	}
+	return once(release), nil
+}
+
+// ---- process-local ----
+
+// ProcessLock is the in-process implementation: mutual exclusion between
+// goroutines of one process only (memory backend, tests). It is also
+// embedded in the fs lock so two goroutines in one process cannot both pass
+// the pid-file check (their shared pid reads as "held by a live process —
+// me" for both).
+type ProcessLock struct {
+	mu sync.Mutex
+}
+
+// NewProcessLock returns a process-local MigrationLock.
+func NewProcessLock() *ProcessLock { return &ProcessLock{} }
+
+// TryAcquire implements [MigrationLock].
+func (l *ProcessLock) TryAcquire(context.Context) (func(), error) {
+	if !l.mu.TryLock() {
+		return nil, ErrLockHeld
+	}
+	return once(l.mu.Unlock), nil
+}
+
+// ---- filesystem lock file ----
+
+// lockFileName is the lock file under the project cache dir (.rela/).
+const lockFileName = "migration.lock"
+
+// lockFilePayload is what the holder writes into the lock file: enough to
+// decide staleness (pid liveness on this host) and to name the holder in
+// logs. Parsed defensively — an unparseable file counts as stale, because a
+// file we cannot attribute to a live process must not wedge migrations
+// forever.
+type lockFilePayload struct {
+	PID        int       `json:"pid"`
+	AcquiredAt time.Time `json:"acquired_at"`
+}
+
+// fsLock is the filesystem implementation: an O_CREATE|O_EXCL lock file
+// under `.rela/`, composed with a ProcessLock so in-process callers exclude
+// each other too. Single-machine by design — matching fsstore, whose write
+// serialization is likewise in-process; a project directory shared over a
+// network filesystem gets no cross-host guarantee (and never did).
+type fsLock struct {
+	path  string
+	local ProcessLock
+}
+
+func newFSLock(cacheDir string) *fsLock {
+	return &fsLock{path: filepath.Join(cacheDir, lockFileName)}
+}
+
+// TryAcquire implements [MigrationLock]. A lock file whose recorded pid is
+// no longer alive (crashed run) is broken with a warning and acquisition is
+// retried once.
+func (l *fsLock) TryAcquire(ctx context.Context) (func(), error) {
+	if !l.local.mu.TryLock() {
+		return nil, ErrLockHeld
+	}
+	releaseFile, err := l.acquireFile(ctx)
+	if err != nil {
+		l.local.mu.Unlock()
+		return nil, err
+	}
+	return once(func() {
+		releaseFile()
+		l.local.mu.Unlock()
+	}), nil
+}
+
+func (l *fsLock) acquireFile(ctx context.Context) (func(), error) {
+	// One stale-break retry, never more: a second failure means a live
+	// holder raced us to re-create the file, which is contention, not
+	// staleness.
+	for range 2 {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		if err := os.MkdirAll(filepath.Dir(l.path), 0o755); err != nil {
+			return nil, fmt.Errorf("datamigration: create lock dir: %w", err)
+		}
+		payload, _ := json.Marshal(lockFilePayload{PID: os.Getpid(), AcquiredAt: time.Now().UTC()})
+		f, err := os.OpenFile(l.path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o644)
+		if err == nil {
+			_, werr := f.Write(payload)
+			cerr := f.Close()
+			if werr != nil || cerr != nil {
+				_ = os.Remove(l.path)
+				return nil, fmt.Errorf("datamigration: write lock file: %w", errors.Join(werr, cerr))
+			}
+			return func() { _ = os.Remove(l.path) }, nil
+		}
+		if !errors.Is(err, os.ErrExist) {
+			return nil, fmt.Errorf("datamigration: create lock file: %w", err)
+		}
+		if !l.breakIfStale() {
+			return nil, ErrLockHeld
+		}
+	}
+	return nil, ErrLockHeld
+}
+
+// breakIfStale removes the lock file when its holder is provably gone on
+// this host, returning true when a retry is worthwhile. A file naming a
+// LIVE pid is always honored — staleness can only be concluded from a dead
+// or unattributable holder, never from age alone (a long migration is not a
+// crash).
+func (l *fsLock) breakIfStale() bool {
+	data, err := os.ReadFile(l.path)
+	if err != nil {
+		// Raced with the holder's release: the file is already gone.
+		return errors.Is(err, os.ErrNotExist)
+	}
+	var p lockFilePayload
+	if err := json.Unmarshal(data, &p); err != nil || p.PID <= 0 {
+		slog.Warn("datamigration: breaking unparseable migration lock file", "path", l.path)
+		_ = os.Remove(l.path)
+		return true
+	}
+	if pidAlive(p.PID) {
+		return false
+	}
+	slog.Warn("datamigration: breaking stale migration lock from dead process",
+		"path", l.path, "pid", p.PID, "acquired_at", p.AcquiredAt)
+	_ = os.Remove(l.path)
+	return true
+}
+
+// pidAlive reports whether a process with the given pid exists on this
+// host (signal 0 probe; EPERM still means "exists").
+func pidAlive(pid int) bool {
+	proc, err := os.FindProcess(pid)
+	if err != nil {
+		return false
+	}
+	err = proc.Signal(syscall.Signal(0))
+	return err == nil || errors.Is(err, syscall.EPERM)
+}
+
+// once wraps a release func so double-release is safe — every acquire site
+// defers release, and error paths must be free to call it early too.
+func once(release func()) func() {
+	var o sync.Once
+	return func() { o.Do(release) }
+}

--- a/internal/datamigration/lock_test.go
+++ b/internal/datamigration/lock_test.go
@@ -1,0 +1,311 @@
+package datamigration
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/Sourcehaven-BV/rela/internal/audit"
+	"github.com/Sourcehaven-BV/rela/internal/metamodel"
+	"github.com/Sourcehaven-BV/rela/internal/store"
+	"github.com/Sourcehaven-BV/rela/internal/store/memstore"
+)
+
+func TestProcessLock_Exclusive(t *testing.T) {
+	l := NewProcessLock()
+	release, err := l.TryAcquire(t.Context())
+	if err != nil {
+		t.Fatalf("first acquire: %v", err)
+	}
+	if _, err := l.TryAcquire(t.Context()); !errors.Is(err, ErrLockHeld) {
+		t.Fatalf("second acquire err = %v, want ErrLockHeld", err)
+	}
+	release()
+	release() // double release must be safe
+	if release2, err := l.TryAcquire(t.Context()); err != nil {
+		t.Fatalf("acquire after release: %v", err)
+	} else {
+		release2()
+	}
+}
+
+func TestFSLock_ExclusiveAndReleases(t *testing.T) {
+	dir := t.TempDir()
+	a, b := newFSLock(dir), newFSLock(dir)
+
+	release, err := a.TryAcquire(t.Context())
+	if err != nil {
+		t.Fatalf("first acquire: %v", err)
+	}
+	if _, bErr := b.TryAcquire(t.Context()); !errors.Is(bErr, ErrLockHeld) {
+		t.Fatalf("second lock on same dir err = %v, want ErrLockHeld", bErr)
+	}
+	// Same process, same fsLock value: the embedded process mutex must
+	// exclude too (the pid in the file is OUR live pid — without the mutex
+	// the staleness check could never say held-by-someone-else).
+	if _, aErr := a.TryAcquire(t.Context()); !errors.Is(aErr, ErrLockHeld) {
+		t.Fatalf("re-acquire on same lock err = %v, want ErrLockHeld", aErr)
+	}
+	release()
+	if _, statErr := os.Stat(filepath.Join(dir, lockFileName)); !errors.Is(statErr, os.ErrNotExist) {
+		t.Fatalf("lock file survives release: %v", statErr)
+	}
+	release2, err := b.TryAcquire(t.Context())
+	if err != nil {
+		t.Fatalf("acquire after release: %v", err)
+	}
+	release2()
+}
+
+func TestFSLock_BreaksStaleAndUnparseable(t *testing.T) {
+	tests := []struct {
+		name    string
+		payload []byte
+	}{
+		{
+			name: "dead pid",
+			payload: func() []byte {
+				// A just-exited child's pid is provably dead on this host.
+				data, _ := json.Marshal(lockFilePayload{PID: deadPID(t), AcquiredAt: time.Now().UTC()})
+				return data
+			}(),
+		},
+		{name: "unparseable", payload: []byte("not json{")},
+		{name: "zero pid", payload: []byte(`{"pid":0}`)},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			path := filepath.Join(dir, lockFileName)
+			if err := os.WriteFile(path, tc.payload, 0o644); err != nil {
+				t.Fatal(err)
+			}
+			l := newFSLock(dir)
+			release, err := l.TryAcquire(t.Context())
+			if err != nil {
+				t.Fatalf("stale lock not broken: %v", err)
+			}
+			release()
+		})
+	}
+}
+
+func TestFSLock_HonorsLivePid(t *testing.T) {
+	dir := t.TempDir()
+	// A foreign lock file naming a pid that IS alive (ours, but written by
+	// "another" lock value so the in-process mutex is not involved) must be
+	// honored, never broken.
+	data, _ := json.Marshal(lockFilePayload{PID: os.Getpid(), AcquiredAt: time.Now().UTC()})
+	if err := os.WriteFile(filepath.Join(dir, lockFileName), data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	l := newFSLock(dir)
+	if _, err := l.TryAcquire(t.Context()); !errors.Is(err, ErrLockHeld) {
+		t.Fatalf("live holder's lock was broken: err = %v", err)
+	}
+}
+
+// deadPID returns a pid that existed and is now gone.
+func deadPID(t *testing.T) int {
+	t.Helper()
+	proc, err := os.StartProcess("/usr/bin/true", []string{"true"}, &os.ProcAttr{})
+	if err != nil {
+		// Portable fallback: /bin/true on some systems.
+		proc, err = os.StartProcess("/bin/true", []string{"true"}, &os.ProcAttr{})
+		if err != nil {
+			t.Skipf("cannot start helper process: %v", err)
+		}
+	}
+	state, err := proc.Wait()
+	if err != nil {
+		t.Fatalf("wait: %v", err)
+	}
+	return state.Pid()
+}
+
+// fakeStoreLocker is a store.Store that also offers the migration-lock
+// capability, for LockFor selection tests.
+type fakeStoreLocker struct {
+	store.Store
+	held bool
+}
+
+func (f *fakeStoreLocker) TryMigrationLock(context.Context) (release func(), ok bool, err error) {
+	if f.held {
+		return nil, false, nil
+	}
+	return func() {}, true, nil
+}
+
+func TestLockFor_Selection(t *testing.T) {
+	t.Run("store capability wins", func(t *testing.T) {
+		fake := &fakeStoreLocker{Store: memstore.New(), held: true}
+		l := LockFor(fake, t.TempDir())
+		if _, err := l.TryAcquire(t.Context()); !errors.Is(err, ErrLockHeld) {
+			t.Fatalf("store-held lock not surfaced as ErrLockHeld: %v", err)
+		}
+		fake.held = false
+		release, err := l.TryAcquire(t.Context())
+		if err != nil {
+			t.Fatalf("store lock acquire: %v", err)
+		}
+		release()
+	})
+	t.Run("cache dir falls back to fs lock", func(t *testing.T) {
+		dir := t.TempDir()
+		l := LockFor(memstore.New(), dir)
+		release, err := l.TryAcquire(t.Context())
+		if err != nil {
+			t.Fatalf("fs lock acquire: %v", err)
+		}
+		defer release()
+		if _, err := os.Stat(filepath.Join(dir, lockFileName)); err != nil {
+			t.Fatalf("fs lock file not created — wrong implementation selected: %v", err)
+		}
+	})
+	t.Run("no cache dir falls back to process lock", func(t *testing.T) {
+		l := LockFor(memstore.New(), "")
+		if _, ok := l.(*ProcessLock); !ok {
+			t.Fatalf("selected %T, want *ProcessLock", l)
+		}
+	})
+}
+
+// spyLock records TryAcquire calls; heldErr non-nil makes it contended.
+type spyLock struct {
+	calls   int
+	heldErr error
+}
+
+func (s *spyLock) TryAcquire(context.Context) (func(), error) {
+	s.calls++
+	if s.heldErr != nil {
+		return nil, s.heldErr
+	}
+	return func() {}, nil
+}
+
+func TestRunner_DryRunNeverTouchesLock(t *testing.T) {
+	spy := &spyLock{}
+	r := newTestRunner(t, Deps{Store: seedStore(t), Lock: spy})
+	f := mustParse(t, "0001-test.yaml", mustFileYAML(t, metaV1(), metaV2(), v1ToV2Steps))
+	if _, err := r.Run(t.Context(), []*File{f}, false); err != nil {
+		t.Fatalf("dry-run: %v", err)
+	}
+	if spy.calls != 0 {
+		t.Fatalf("dry-run touched the lock %d times", spy.calls)
+	}
+}
+
+func TestRunner_ApplyFailsFastWhenLockHeld(t *testing.T) {
+	st := seedStore(t)
+	spy := &spyLock{heldErr: ErrLockHeld}
+	kv := newFakeKV()
+	r := newTestRunner(t, Deps{Store: st, Lock: spy, State: kv})
+	f := mustParse(t, "0001-test.yaml", mustFileYAML(t, metaV1(), metaV2(), v1ToV2Steps))
+
+	_, err := r.Run(t.Context(), []*File{f}, true)
+	if !errors.Is(err, ErrLockHeld) {
+		t.Fatalf("apply err = %v, want ErrLockHeld", err)
+	}
+	// Zero writes: entities untouched, marker untouched.
+	if _, has := getEntity(t, st, "TSK-1").Properties["state"]; has {
+		t.Fatalf("contended apply wrote to the store")
+	}
+	if marker, _ := LoadMarker(t.Context(), kv); marker != nil {
+		t.Fatalf("contended apply wrote the marker")
+	}
+}
+
+func TestGC_ApplySkipsWhenLockHeld(t *testing.T) {
+	st, kv, gate, m2 := driftSetup(t)
+	spy := &spyLock{heldErr: ErrLockHeld}
+	g := newTestGC(t, GCDeps{
+		Store: st, State: kv, Meta: func() *metamodel.Metamodel { return m2 },
+		Verdicts: gate, Lock: spy,
+	})
+	g.now = func() time.Time { return time.Now().Add(DefaultGrace + time.Hour) }
+	res, err := g.Tick(t.Context(), true)
+	if err != nil {
+		t.Fatalf("Tick: %v", err)
+	}
+	if res.Skipped == "" || len(res.Deleted) != 0 {
+		t.Fatalf("contended apply tick did not skip: %+v", res)
+	}
+	if _, has := getEntity(t, st, "TSK-1").Properties["tags"]; !has {
+		t.Fatalf("contended tick deleted data")
+	}
+	// Dry-run ticks stay lock-free.
+	spy.calls = 0
+	if _, err := g.Tick(t.Context(), false); err != nil {
+		t.Fatalf("dry-run tick: %v", err)
+	}
+	if spy.calls != 0 {
+		t.Fatalf("dry-run tick touched the lock")
+	}
+}
+
+func TestGC_ScanFailsWhenLockHeld(t *testing.T) {
+	st, kv, gate, m2 := driftSetup(t)
+	g := newTestGC(t, GCDeps{
+		Store: st, State: kv, Meta: func() *metamodel.Metamodel { return m2 },
+		Verdicts: gate, Lock: &spyLock{heldErr: ErrLockHeld},
+	})
+	if _, err := g.Scan(t.Context()); !errors.Is(err, ErrLockHeld) {
+		t.Fatalf("Scan err = %v, want ErrLockHeld", err)
+	}
+}
+
+func TestGate_AdoptionSkipsOnContention(t *testing.T) {
+	kv := newFakeKV()
+	lock := NewProcessLock()
+	g, err := NewGate(kv, lock)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Hold the lock as "the runner".
+	release, err := lock.TryAcquire(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer release()
+
+	v, err := g.Evaluate(t.Context(), metaV1())
+	if err != nil {
+		t.Fatalf("Evaluate under contention must not fail: %v", err)
+	}
+	if v == nil || g.Verdict() != v {
+		t.Fatalf("verdict not published under contention")
+	}
+	if marker, _ := LoadMarker(t.Context(), kv); marker != nil {
+		t.Fatalf("contended adoption wrote the marker")
+	}
+
+	// Lock released: the next evaluation persists the baseline.
+	release()
+	if _, err := g.Evaluate(t.Context(), metaV1()); err != nil {
+		t.Fatal(err)
+	}
+	if marker, _ := LoadMarker(t.Context(), kv); marker == nil {
+		t.Fatalf("marker not written after lock release")
+	}
+}
+
+func TestConstructors_RejectNilLock(t *testing.T) {
+	if _, err := NewRunner(Deps{
+		Store: memstore.New(), Meta: metaV1(), State: newFakeKV(),
+		Audit: audit.NewMemory(), ScriptFS: emptyFS,
+	}); err == nil {
+		t.Fatalf("NewRunner accepted nil Lock")
+	}
+	if _, err := NewGC(GCDeps{
+		Store: memstore.New(), Meta: metaV1, State: newFakeKV(),
+		Audit: audit.NewMemory(), Verdicts: fixedVerdict{},
+	}); err == nil {
+		t.Fatalf("NewGC accepted nil Lock")
+	}
+}

--- a/internal/datamigration/lock_test.go
+++ b/internal/datamigration/lock_test.go
@@ -1,6 +1,7 @@
 package datamigration
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -307,5 +308,111 @@ func TestConstructors_RejectNilLock(t *testing.T) {
 		Audit: audit.NewMemory(), Verdicts: fixedVerdict{},
 	}); err == nil {
 		t.Fatalf("NewGC accepted nil Lock")
+	}
+}
+
+// RR: the stale-break must not let two processes both acquire (the
+// read-decide-remove TOCTOU). Two independent fsLock values (separate
+// process mutexes, like two processes) race to break a pre-seeded dead-pid
+// lock; exactly one may win.
+func TestFSLock_ConcurrentStaleBreakSingleWinner(t *testing.T) {
+	for range 20 { // the race window is narrow; hammer it
+		dir := t.TempDir()
+		data, _ := json.Marshal(lockFilePayload{PID: deadPID(t), AcquiredAt: time.Now().UTC()})
+		if err := os.WriteFile(filepath.Join(dir, lockFileName), data, 0o644); err != nil {
+			t.Fatal(err)
+		}
+		locks := []*fsLock{newFSLock(dir), newFSLock(dir)}
+		type outcome struct {
+			release func()
+			err     error
+		}
+		results := make(chan outcome, len(locks))
+		for _, l := range locks {
+			go func(l *fsLock) {
+				release, err := l.TryAcquire(t.Context())
+				results <- outcome{release, err}
+			}(l)
+		}
+		var wins int
+		var releases []func()
+		for range locks {
+			o := <-results
+			if o.err == nil {
+				wins++
+				releases = append(releases, o.release)
+			} else if !errors.Is(o.err, ErrLockHeld) {
+				t.Fatalf("unexpected error: %v", o.err)
+			}
+		}
+		if wins != 1 {
+			t.Fatalf("stale-break race: %d winners, want exactly 1", wins)
+		}
+		releases[0]()
+	}
+}
+
+// RR: a gate adoption's LEDGER write must sit under the same lock
+// acquisition as the marker write — a contended gate skips BOTH, so it can
+// never interleave a ledger write into a GC apply that holds the lock.
+func TestGate_ContendedAdoptionSkipsLedgerToo(t *testing.T) {
+	kv := newFakeKV()
+	lock := NewProcessLock()
+	g, err := NewGate(kv, lock)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, evalErr := g.Evaluate(t.Context(), metaV1()); evalErr != nil {
+		t.Fatal(evalErr)
+	}
+	markerBefore, _ := kv.Get(t.Context(), markerKey)
+
+	release, err := lock.TryAcquire(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer release()
+
+	// Drift change (deleted property) under contention: no marker move, no
+	// ledger entry.
+	m2 := metaV1()
+	delete(m2.Entities["task"].Properties, "tags")
+	if _, err := g.Evaluate(t.Context(), m2); err != nil {
+		t.Fatalf("contended drift evaluation must not fail: %v", err)
+	}
+	markerAfter, _ := kv.Get(t.Context(), markerKey)
+	if !bytes.Equal(markerBefore, markerAfter) {
+		t.Fatalf("contended adoption moved the marker")
+	}
+	ledger, _ := LoadLedger(t.Context(), kv)
+	if len(ledger.Entries) != 0 {
+		t.Fatalf("contended adoption wrote the ledger: %+v", ledger.Entries)
+	}
+}
+
+// RR: a release func kept from an earlier fs acquisition must not remove a
+// later holder's lock file (guarded release).
+func TestFSLock_StaleReleaseDoesNotRemoveNewHoldersFile(t *testing.T) {
+	dir := t.TempDir()
+	a := newFSLock(dir)
+	releaseA, err := a.TryAcquire(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Simulate an operator hand-removing the lock, then another process
+	// acquiring.
+	if rmErr := os.Remove(filepath.Join(dir, lockFileName)); rmErr != nil {
+		t.Fatal(rmErr)
+	}
+	b := newFSLock(dir)
+	releaseB, err := b.TryAcquire(t.Context())
+	if err != nil {
+		t.Fatalf("second acquire after manual removal: %v", err)
+	}
+	defer releaseB()
+
+	releaseA() // must NOT delete b's file
+	if _, err := os.Stat(filepath.Join(dir, lockFileName)); err != nil {
+		t.Fatalf("stale release removed the new holder's lock file: %v", err)
 	}
 }

--- a/internal/datamigration/marker.go
+++ b/internal/datamigration/marker.go
@@ -69,14 +69,12 @@ func LoadMarker(ctx context.Context, kv state.KV) (*Marker, error) {
 }
 
 // SaveMarker writes the applied-state marker. state.KV has no
-// compare-and-swap, so concurrent writers are last-write-wins. The two
-// writers are the gate (adoption) and the migration runner; racing gates
-// write identical content, and a gate racing a RUNNER can at worst clobber
-// the runner's just-appended Applied entry with a stale list — recovered on
-// the next `migrate data`, where Resolve skips a file whose `to` shape is
-// already reached and every step is idempotent. A cross-process lock is the
-// documented upgrade if multi-writer postgres deployments migrate under
-// live traffic routinely.
+// compare-and-swap; the read-modify-write is made safe by the
+// [MigrationLock] (TKT-CPCBR7), which every writer holds: the runner and GC
+// for their whole apply, the gate for each adoption write (skipping on
+// contention). Step idempotency and Resolve's reached-shape skip remain the
+// backstop for the one unlocked writer combination — two gates — whose
+// racing writes are content-identical anyway.
 func SaveMarker(ctx context.Context, kv state.KV, m *Marker) error {
 	data, err := json.Marshal(m)
 	if err != nil {

--- a/internal/datamigration/run.go
+++ b/internal/datamigration/run.go
@@ -35,8 +35,8 @@ type VersionCapture interface {
 	WriteRelationVersion(ctx context.Context, in store.RelationVersionInput) error
 }
 
-// Deps are the runner's collaborators. Store, Meta, State, Audit and
-// ScriptFS are required; Versions is optional (pg only).
+// Deps are the runner's collaborators. Store, Meta, State, Audit, ScriptFS
+// and Lock are required; Versions is optional (pg only).
 type Deps struct {
 	Store    store.Store
 	Meta     *metamodel.Metamodel
@@ -44,6 +44,11 @@ type Deps struct {
 	Audit    audit.Audit
 	ScriptFS fs.FS // project root, for `lua:` step scripts
 	Versions VersionCapture
+	// Lock serializes apply runs against every other migration/GC writer on
+	// the same store (TKT-CPCBR7); build it with [LockFor]. Required even
+	// though dry-runs never touch it: a destructive path must not lose its
+	// serialization to a forgotten wiring line.
+	Lock MigrationLock
 }
 
 // Runner executes a resolved migration plan against one store.
@@ -65,6 +70,8 @@ func NewRunner(deps Deps) (*Runner, error) {
 		return nil, errors.New("datamigration: NewRunner: Audit is required")
 	case deps.ScriptFS == nil:
 		return nil, errors.New("datamigration: NewRunner: ScriptFS is required")
+	case deps.Lock == nil:
+		return nil, errors.New("datamigration: NewRunner: Lock is required (use LockFor)")
 	}
 	return &Runner{deps: deps, now: time.Now}, nil
 }
@@ -98,6 +105,16 @@ type FileResult struct {
 // version rows attribute to the invoking operator with the data-migration
 // tool, never to a guessed identity.
 func (r *Runner) Run(ctx context.Context, plan []*File, apply bool) (*RunResult, error) {
+	if apply {
+		// The whole apply run holds the migration lock: marker advances and
+		// bulk rewrites must not interleave with another runner, a GC apply,
+		// or a gate adoption. Dry-runs are read-only and stay lock-free.
+		release, err := r.deps.Lock.TryAcquire(ctx)
+		if err != nil {
+			return nil, err
+		}
+		defer release()
+	}
 	p := principal.From(ctx)
 	ctx = store.WithAttribution(ctx, store.Attribution{User: p.User, Tool: migrationTool})
 

--- a/internal/datamigration/run_test.go
+++ b/internal/datamigration/run_test.go
@@ -30,6 +30,9 @@ func newTestRunner(t *testing.T, deps Deps) *Runner {
 	if deps.ScriptFS == nil {
 		deps.ScriptFS = emptyFS
 	}
+	if deps.Lock == nil {
+		deps.Lock = NewProcessLock()
+	}
 	r, err := NewRunner(deps)
 	if err != nil {
 		t.Fatalf("NewRunner: %v", err)

--- a/internal/store/pgstore/migrationlock.go
+++ b/internal/store/pgstore/migrationlock.go
@@ -1,0 +1,63 @@
+package pgstore
+
+import (
+	"context"
+	"errors"
+	"sync"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// migrationAdvisoryLockKey identifies the data-migration lock (TKT-CPCBR7):
+// mutual exclusion between `rela migrate data --apply`, GC applies, and gate
+// marker writes across processes sharing one schema. Deliberately NOT
+// sweepAdvisoryLockKey: a version-sweep tick holds its key for the duration
+// of a capture pass, and sharing would make an operator's apply fail fast
+// with a misleading "another migration is running" whenever a tick happens
+// to be in flight — while the sweep-vs-migration interplay needs no
+// exclusion (update captures dedup by content hash; deletes capture their
+// snapshot synchronously before the row goes).
+//
+// Like every pgstore advisory key, it is used in the two-key
+// schema-qualified form (`hashtext(current_schema())` as the second key) so
+// tenants sharing a database do not exclude each other (the BUG-CA3VY0
+// class).
+const migrationAdvisoryLockKey int64 = 0x52_45_4c_4d // "RELM"
+
+// TryMigrationLock attempts the schema-scoped data-migration advisory lock.
+// ok=false means another holder is active (not an error). On success the
+// lock is session-scoped and lives on ONE pool connection held until release
+// — handing it back to the pool earlier would silently void the guarantee
+// (the sweep-tick rule). release is safe to call more than once.
+//
+// This is an optional store capability discovered by type-assert
+// (internal/datamigration's consumer-side interface), like Formatter and the
+// version capabilities — not part of store.Store.
+func (s *Store) TryMigrationLock(ctx context.Context) (release func(), ok bool, err error) {
+	pool, isPool := s.db.(*pgxpool.Pool)
+	if !isPool {
+		// A bare handle (unit-test store) has no pool to pin a session lock
+		// to. Error rather than pretend: a caller that got this far chose
+		// the store-backed lock and must not fall back to nothing silently.
+		return nil, false, errors.New("pgstore: migration lock requires a pgxpool-backed store")
+	}
+	conn, err := pool.Acquire(ctx)
+	if err != nil {
+		return nil, false, err
+	}
+	locked, err := tryAdvisoryLock(ctx, conn, migrationAdvisoryLockKey)
+	if err != nil || !locked {
+		conn.Release()
+		return nil, false, err
+	}
+	var releaseOnce sync.Once
+	return func() {
+		releaseOnce.Do(func() {
+			// Detached ctx so the unlock still runs during shutdown; releasing
+			// the connection would drop the session lock anyway, but an explicit
+			// unlock keeps the pair symmetric (the advisoryUnlock contract).
+			advisoryUnlock(context.WithoutCancel(ctx), conn, migrationAdvisoryLockKey)
+			conn.Release()
+		})
+	}, true, nil
+}

--- a/internal/store/pgstore/migrationlock.go
+++ b/internal/store/pgstore/migrationlock.go
@@ -41,6 +41,14 @@ func (s *Store) TryMigrationLock(ctx context.Context) (release func(), ok bool, 
 		// the store-backed lock and must not fall back to nothing silently.
 		return nil, false, errors.New("pgstore: migration lock requires a pgxpool-backed store")
 	}
+	if pool.Config().MaxConns < 2 {
+		// The lock pins one connection for the whole run while the
+		// migration's own Tx batches acquire more from the same pool — at
+		// pool_max_conns=1 that is a guaranteed self-deadlock, so refuse up
+		// front with the remedy in the message.
+		return nil, false, errors.New(
+			"pgstore: migration lock needs pool_max_conns >= 2 (the lock pins one connection while migration writes use others)")
+	}
 	conn, err := pool.Acquire(ctx)
 	if err != nil {
 		return nil, false, err

--- a/internal/store/pgstore/migrationlock_test.go
+++ b/internal/store/pgstore/migrationlock_test.go
@@ -1,0 +1,59 @@
+package pgstore_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/Sourcehaven-BV/rela/internal/store/pgstore"
+)
+
+// TestMigrationLock_ExclusiveWithinSchema pins TKT-CPCBR7 AC1: two stores on
+// the SAME schema exclude each other; release frees the lock and is safe to
+// call twice.
+func TestMigrationLock_ExclusiveWithinSchema(t *testing.T) {
+	pool := newScopedPool(t)
+	a, err := pgstore.New(pool)
+	require.NoError(t, err)
+	b, err := pgstore.New(pool)
+	require.NoError(t, err)
+	ctx := context.Background()
+
+	releaseA, ok, err := a.TryMigrationLock(ctx)
+	require.NoError(t, err)
+	require.True(t, ok, "first acquire must succeed")
+
+	_, ok, err = b.TryMigrationLock(ctx)
+	require.NoError(t, err)
+	require.False(t, ok, "second store on the same schema must see the lock held")
+
+	releaseA()
+	releaseA() // double release must be safe
+
+	releaseB, ok, err := b.TryMigrationLock(ctx)
+	require.NoError(t, err)
+	require.True(t, ok, "acquire after release must succeed")
+	releaseB()
+}
+
+// TestMigrationLock_SchemasAreIndependent pins TKT-CPCBR7 AC2 (the
+// BUG-CA3VY0 regression class): tenants sharing one database must not
+// exclude each other — the lock is schema-qualified.
+func TestMigrationLock_SchemasAreIndependent(t *testing.T) {
+	a, err := pgstore.New(newScopedPool(t))
+	require.NoError(t, err)
+	b, err := pgstore.New(newScopedPool(t))
+	require.NoError(t, err)
+	ctx := context.Background()
+
+	releaseA, ok, err := a.TryMigrationLock(ctx)
+	require.NoError(t, err)
+	require.True(t, ok)
+	defer releaseA()
+
+	releaseB, ok, err := b.TryMigrationLock(ctx)
+	require.NoError(t, err)
+	require.True(t, ok, "a different schema's lock must be independent")
+	releaseB()
+}

--- a/internal/store/pgstore/pgstore.go
+++ b/internal/store/pgstore/pgstore.go
@@ -104,8 +104,14 @@ type DBTX interface {
 // the row-property reads together, the way versioning and user-state were
 // extracted as subsystems.
 //
-//plimsoll:max-exported-methods=38
-//plimsoll:max-methods=48
+// TryMigrationLock (TKT-CPCBR7) is +1 for the row-property reason too: it is
+// a session advisory lock that must be pinned to a connection from THIS
+// store's pool and schema-qualified with THIS store's schema — a lock handle
+// hoisted into a service would still need exactly this pool, gaining a type
+// but no separation.
+//
+//plimsoll:max-exported-methods=39
+//plimsoll:max-methods=49
 type Store struct {
 	db        DBTX
 	observers []store.EntityObserver // notified synchronously after committed entity writes

--- a/tickets/entities/docs-checklists/DOCS-6JHU6K.md
+++ b/tickets/entities/docs-checklists/DOCS-6JHU6K.md
@@ -1,0 +1,24 @@
+---
+id: DOCS-6JHU6K
+type: docs-checklist
+title: 'Docs: Migration lock mini-service (TKT-CPCBR7)'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Code Documentation
+
+- [x] Godoc on `MigrationLock`/`ErrLockHeld`/`LockFor` (selection rationale incl. why memstore-with-project gets the fs lock), `ProcessLock` (generation-guarded releases), `fsLock` (break-mutex TOCTOU design, pid-reuse limitation + remedy), `(*pgstore.Store).TryMigrationLock` (pinned-connection rule, pool preflight), `migrationAdvisoryLockKey` (why NOT sweepAdvisoryLockKey)
+- [x] `SaveMarker` godoc rewritten: the lock is now the safety mechanism; residual two-gates race documented
+- [x] pgstore plimsoll directive bump justified in the type comment
+
+## Project Documentation
+
+- [x] `docs-project/entities/guides/GUIDE-data-migration.md` — concurrency paragraph (fail-fast apply, sweep skip, gate skip, dry-runs lock-free) + crash-recovery caveat (pid reuse, manual `rm .rela/migration.lock` remedy); regenerated into docs/
+- [x] `docs-project/entities/guides/GUIDE-postgres-backend.md` — schema-scoped advisory migration lock bullet; regenerated
+- [x] No CLAUDE.md change needed (capability-selection pattern already documented via the state.KV precedent)
+
+## External Docs
+
+- [x] ~~Website/blog~~ (N/A: docs/ is the published surface)

--- a/tickets/entities/implementation-checklists/IMPL-68H55Q.md
+++ b/tickets/entities/implementation-checklists/IMPL-68H55Q.md
@@ -1,0 +1,44 @@
+---
+id: IMPL-68H55Q
+type: implementation-checklist
+title: 'Implementation: Migration lock as a pluggable mini-service (postgres advisory lock, fs lock file)'
+status: in-progress
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Development
+
+- [ ] Unit tests written for new code
+- [ ] Integration tests written (test full flow, not just units)
+- [ ] Happy path implemented
+- [ ] Edge cases from planning handled
+- [ ] Error handling in place (errors surfaced, not swallowed)
+
+## Test Quality
+
+- [ ] Using fixture builders or factories for test data
+- [ ] No hardcoded values in assertions when object is in scope
+- [ ] Only specifying values that matter for the test
+- [ ] Interpolated values constructed from objects, not hardcoded
+- [ ] Property comparisons use original object, not hardcoded strings
+
+## Manual Verification
+
+- [ ] Feature manually tested end-to-end
+- [ ] Each acceptance criterion verified with test scenario from planning
+- [ ] Edge cases manually verified
+
+**Verification Evidence:**
+<!-- Document what you tested and the results -->
+
+## Quality
+
+- [ ] Code follows project patterns (check similar code)
+- [ ] Checked for DRY opportunities — repeated literals, expressions, or
+patterns extracted to a helper / constant / type where it sharpens the contract
+(don't extract for its own sake; CLAUDE.md "three similar lines is better than a
+premature abstraction" still holds)
+- [ ] No security issues introduced
+- [ ] No silent failures (errors logged AND returned)
+- [ ] No debug code left behind

--- a/tickets/entities/implementation-checklists/IMPL-68H55Q.md
+++ b/tickets/entities/implementation-checklists/IMPL-68H55Q.md
@@ -2,43 +2,37 @@
 id: IMPL-68H55Q
 type: implementation-checklist
 title: 'Implementation: Migration lock as a pluggable mini-service (postgres advisory lock, fs lock file)'
-status: in-progress
+status: done
 ---
 
 <!-- @managed: claude-workflow v1 -->
 
 ## Development
 
-- [ ] Unit tests written for new code
-- [ ] Integration tests written (test full flow, not just units)
-- [ ] Happy path implemented
-- [ ] Edge cases from planning handled
-- [ ] Error handling in place (errors surfaced, not swallowed)
+- [x] Unit tests written for new code
+- [x] Integration tests written (full flow, not just units)
+- [x] Feature implemented per PLAN-34E1YZ
+- [x] Edge cases from planning handled
 
-## Test Quality
+**What was built** (branch `tkt-cpcbr7-migration-lock`, commit 3222c401):
 
-- [ ] Using fixture builders or factories for test data
-- [ ] No hardcoded values in assertions when object is in scope
-- [ ] Only specifying values that matter for the test
-- [ ] Interpolated values constructed from objects, not hardcoded
-- [ ] Property comparisons use original object, not hardcoded strings
+- `internal/datamigration/lock.go`: consumer-side `MigrationLock` + `ErrLockHeld`; `ProcessLock` (mutex TryLock); `fsLock` (`.rela/migration.lock`, O_CREATE|O_EXCL, pid+timestamp JSON, stale-break only on dead/unattributable pid — never age; composes the process mutex per design-review finding 1); `LockFor` selector (store capability type-assert → fs lock file → process lock); idempotent releases via sync.Once.
+- `internal/store/pgstore/migrationlock.go`: `(*Store).TryMigrationLock` — new key "RELM" (0x52_45_4c_4d), two-key schema-qualified form, session lock pinned to ONE held pool conn (sweep-tick rule), detached-ctx unlock, release sync.Once; NOT sharing sweepAdvisoryLockKey (rationale in godoc per planning decision 3). Plimsoll pin 38/48 → 39/49 with row-property justification at the directive.
+- Consumers: `Runner.Run(apply)` holds the lock for the whole run (fail fast); `GC.Tick(apply)` skip-on-held via `Skipped`; `GC.Scan` acquires (writes the ledger); `Gate` takes an optional lock and SKIPS persisting adoption on contention (verdict still published) — startup never blocks (design-review finding 2). Dry-runs/read paths lock-free. `Lock` nil-rejected in Runner Deps and GCDeps.
+- Wiring: `appbuild.startDataMigration` builds one lock per assembled store via `LockFor(st, cfg.Paths.CacheDir)`, shared by gate + GC sweep; CLI `migrate_data.go` builds the equivalent lock per command — the two exclude each other because LockFor derives from the same store/cache dir.
+- Docs: SaveMarker godoc rewritten (lock is now the safety mechanism; two-gates race stays content-identical); GUIDE-data-migration concurrency paragraph + GUIDE-postgres-backend advisory-lock bullet, regenerated via `just docs`.
 
-## Manual Verification
+## Manual Verification (evidence)
 
-- [ ] Feature manually tested end-to-end
-- [ ] Each acceptance criterion verified with test scenario from planning
-- [ ] Edge cases manually verified
+Scratch fs project (/tmp/lk-e2e, rela built from branch):
 
-**Verification Evidence:**
-<!-- Document what you tested and the results -->
+1. Pending needs-migration change; wrote `.rela/migration.lock` naming a LIVE pid (background sleep) → `migrate data --apply` failed fast with "another migration or GC run is active", **exit 1**, zero writes. ✓
+2. Killed the holder → next apply logged the stale-break warning, broke the lock, applied the migration, and the lock file was gone after release. ✓
+3. Normal flow (gen → apply → in sync) unchanged. ✓
 
 ## Quality
 
-- [ ] Code follows project patterns (check similar code)
-- [ ] Checked for DRY opportunities — repeated literals, expressions, or
-patterns extracted to a helper / constant / type where it sharpens the contract
-(don't extract for its own sake; CLAUDE.md "three similar lines is better than a
-premature abstraction" still holds)
-- [ ] No security issues introduced
-- [ ] No silent failures (errors logged AND returned)
-- [ ] No debug code left behind
+- [x] `just lint` — 0 issues; `just arch-lint` clean; `just plimsoll` clean (pgstore pin bumped with justification)
+- [x] `go test ./...` all green (default build); DB-gated `TestMigrationLock_ExclusiveWithinSchema` + `TestMigrationLock_SchemasAreIndependent` PASS with -race against local postgres (AC1 + AC2/BUG-CA3VY0 class)
+- [x] datamigration coverage 65.4% (floor 50); `just docs-check` passes once committed (regeneration is clean)
+- [x] Unit tests: process/fs exclusivity, stale/unparseable/zero-pid break, live-pid honored, LockFor selection (3 paths), dry-runs never touch the lock (spy), contended apply → ErrLockHeld with zero writes, GC apply skip + Scan error on contention, gate skip-and-publish + persist-after-release, nil-Lock constructor rejection, double release everywhere.

--- a/tickets/entities/planning-checklists/PLAN-34E1YZ.md
+++ b/tickets/entities/planning-checklists/PLAN-34E1YZ.md
@@ -1,0 +1,132 @@
+---
+id: PLAN-34E1YZ
+type: planning-checklist
+title: 'Planning: Migration lock as a pluggable mini-service (postgres advisory lock, fs lock file)'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Understanding
+
+- [x] Problem/requirements clearly understood
+- [x] Scope defined (what's in/out documented below)
+- [x] Acceptance criteria documented with specific test scenarios
+
+**Scope:**
+
+IN scope:
+- Consumer-side `MigrationLock` interface + `ErrLockHeld` in `internal/datamigration` (lock.go).
+- Three implementations: pgstore session advisory lock (capability method on `*pgstore.Store`, discovered by type-assert — the ticket-sanctioned route), fs lock file under `.rela/` with pid-based stale detection, in-process mutex.
+- `datamigration.LockFor(st store.Store, cacheDir string) MigrationLock` selector (build-agnostic: type-assert wins → fs lock file → process lock). No appbuild-only helper needed; both appbuild and CLI call LockFor.
+- Consumers: `Runner.Run(apply=true)` acquires for the whole run (fail fast on contention); `GC.Tick(apply=true)` acquires (contention → `Skipped`, honest for both sweep and CLI); `GC.Scan` acquires (writes the ledger; contention → error); `Gate.Evaluate` adoption writes try the lock and on contention SKIP persisting (log, still publish the computed verdict) — non-blocking startup, and contention there means a runner is actively moving the marker, so skipping is correct.
+- Deps: `Lock` REQUIRED (nil-rejected) in Runner `Deps` and `GCDeps` (destructive paths must not silently lose serialization); `NewGate` gains an optional lock parameter (nil = no lock, documented — gate-vs-gate races are content-identical).
+- Wiring: appbuild `startDataMigration` and CLI `migrate_data.go` build the lock via `LockFor`.
+- Docs: SaveMarker godoc updated (lock now exists); GUIDE-data-migration + GUIDE-postgres-backend concurrency paragraphs (docs are GENERATED — edit docs-project guides, run `just docs`).
+
+NOT in scope:
+- Marker CAS semantics (the lock makes the existing RMW safe).
+- Generic distributed-lock service or any Tx-layer abstraction (DEC-8UIL0).
+- Blocking waits/retries anywhere; only fail-fast TryAcquire.
+- Sharing `sweepAdvisoryLockKey` — decision below.
+
+**Acceptance Criteria:**
+
+1. Two concurrent applies on one pg schema: second gets ErrLockHeld ("another migration or GC run is active"), zero writes. *DB-gated test: two `*pgstore.Store` on one schema, first holds, second TryMigrationLock ok=false; release frees.*
+2. Schema isolation: two stores on DIFFERENT schemas of one database both acquire concurrently. *DB-gated test (the BUG-CA3VY0 regression class).*
+3. GC apply and migration apply mutually exclusive (same lock). *Unit test with a held ProcessLock: Tick → Skipped, Runner apply → error.*
+4. fs: second lock on the same `.rela/` fails fast; a lock file with a dead pid is detected stale, broken with a warning, and acquisition retried once; release removes the file; unparseable file treated stale. *Unit tests in a t.TempDir.*
+5. Dry-runs and read paths never touch the lock. *Spy-lock test: Run(apply=false), Tick(apply=false) → zero TryAcquire calls.*
+6. Gate contention: verdict published, marker NOT written, no error. *Unit test with held lock.*
+7. LockFor selection: store implementing the capability → pg path (fake store in test); else cacheDir → fs lock; else process lock.
+8. All existing datamigration/cli/appbuild tests updated and green; lint/arch-lint/plimsoll/coverage clean.
+
+## Research
+
+- [x] ~~/research doc~~ (skipped: approach fully specified in the ticket body, which was written from the TKT-0C57FS review analysis; this checklist refines the open decisions)
+- [x] Checked codebase for existing patterns to reuse
+
+**Existing Solutions:**
+
+- `pgstore` already has the exact lock discipline to reuse: `tryAdvisoryLock`/`advisoryUnlock` (sweep.go:506-533, two-key schema-scoped form, cancellation-detached unlock) and the acquire-one-conn-hold-it pattern (sweep tick, purge). Key constants: "RELA" migrate, "RELD" reconcile, "RELV" sweep → new **"RELM" (0x52_45_4c_4d)** for the migration lock.
+- Capability type-assert precedent: `store.Formatter`, `HistoryReader` — and the ticket explicitly allows it. This beats a recipe-supplied service here because the CLI (not just appbuild) constructs runners, and a type-assert keeps `LockFor` build-agnostic with zero new appbuild surface (Services is AT its 25-exported-method plimsoll cap).
+- fs lock file: no existing helper; `os.OpenFile(O_CREATE|O_EXCL)` + pid liveness via `signal 0`. Single-machine by design (matches fsstore).
+- Rejected: sharing `sweepAdvisoryLockKey`. A sweep tick holding the key for ~100ms would make `migrate data --apply` fail fast with a misleading "another migration is running"; the sweep-vs-migration interplay was already analyzed harmless in TKT-0C57FS (update captures dedup by content hash; deletes capture synchronously BEFORE removal). Separate key "RELM"; rationale recorded in the key's godoc.
+
+## Approach
+
+- [x] Technical approach chosen and documented
+- [x] Alternatives considered
+- [x] Dependencies identified
+
+**Technical Approach:**
+
+1. `internal/datamigration/lock.go`:
+   - `type MigrationLock interface { TryAcquire(ctx) (release func(), err error) }`, `var ErrLockHeld`.
+   - `storeLocker` (unexported consumer-side): `TryMigrationLock(ctx) (release func(), ok bool, err error)` — matches the pgstore method signature so no adapter package is needed; ok=false maps to ErrLockHeld.
+   - `ProcessLock` (mutex TryLock), `fsLock` (lock file `.rela/migration.lock`, JSON `{pid, acquired_at}`; stale = pid not alive on this host OR unparseable; break stale with slog.Warn + one retry), `LockFor(st, cacheDir)` selector.
+2. `internal/store/pgstore/migrationlock.go` (+ DB-gated test): `migrationAdvisoryLockKey = 0x52_45_4c_4d`; `(*Store).TryMigrationLock(ctx)`: `s.pool.Acquire` → `tryAdvisoryLock(conn, key)`; !ok → release conn, return ok=false; ok → release closure doing `advisoryUnlock(WithoutCancel(ctx), conn, key)` + `conn.Release()`. Session lock lives on the ONE held conn for its whole lifetime (sweep precedent).
+3. Consumers: Runner.Run wraps the apply path; GC.Tick/Scan; Gate adoption (optional lock param). Contention behaviors per Scope.
+4. Wiring: `startDataMigration` gains `cacheDir string` param; builds `lock := datamigration.LockFor(st, cacheDir)`, passes to gate + GC. CLI `migrate_data.go`: build once per command, pass to Runner/GC/gate.
+5. Docs: SaveMarker godoc rewrite; docs-project guide paragraphs; regen `just docs`.
+
+**Files:** new `internal/datamigration/lock.go` + `lock_test.go`,
+`internal/store/pgstore/migrationlock.go` + `migrationlock_test.go`; modified
+`internal/datamigration/{run,gc,gate,marker}.go` + tests,
+`internal/appbuild/datamigration.go`, `internal/cli/migrate_data.go`,
+`docs-project/entities/guides/GUIDE-{data-migration,postgres-backend}.md` (+
+regenerated docs/), `.testcoverage.yml` untouched (floor already set).
+
+## Security Considerations
+
+- [x] Reviewed
+
+- Lock file content is pid+timestamp JSON written 0644 under `.rela/` (gitignored cache); parsed defensively — unparseable = stale, never a crash. No secrets, no operator-controlled input on this path.
+- Stale-break is same-host pid liveness only; it cannot be tricked into breaking a LIVE holder's lock by a crafted file (a file naming a live pid is honored; naming a dead/invalid pid means the holder is gone on a single-machine fs project).
+- pg lock is schema-qualified (tenant isolation) and session-scoped on a held conn — no privilege or data exposure implications; failure to acquire only ever DENIES an operation.
+- Fail direction everywhere: contention blocks destructive work, never permits it.
+
+## Test Plan
+
+- [x] Documented (mapped in Acceptance Criteria above)
+
+Edge cases: release called twice (idempotent — guard with sync.Once); ctx
+cancelled during acquire (error, conn released); fs lock dir missing (MkdirAll
+first); lock file from THIS process's pid (treat as held — a second in-process
+acquire must still fail via the embedded ProcessLock guard, so fsLock composes
+pid-file + in-process mutex); GC sweep goroutine contention logs at debug via
+existing Skipped plumbing.
+
+Negative: Runner/GC constructors reject nil Lock; TryMigrationLock on closed
+pool returns error (not held).
+
+## Risk Assessment
+
+- [x] Assessed. Effort m confirmed.
+
+1. **Deadlock via forgotten release** → release is deferred at every acquire site; sync.Once makes double-release safe; pg conn release also frees the lock as a backstop.
+2. **CLI UX regression** (gate now takes lock at startup) → gate uses skip-on-contention, never blocks/errs; only apply paths fail fast.
+3. **pg pool exhaustion** (lock holds a conn for the whole run) → one conn per migration run, bounded and short-lived; same cost profile as a sweep tick; documented.
+4. **Existing tests break on required Lock dep** → mechanical: tests pass NewProcessLock().
+
+## Documentation Planning
+
+- [x] SaveMarker godoc; GUIDE-data-migration (concurrency paragraph), GUIDE-postgres-backend (lock note in the data-migration section); no CLAUDE.md change needed (pattern already described there via state.KV precedent).
+
+## Design Review
+
+- [x] Inline design review performed (see below)
+- [x] All critical/significant findings addressed in plan
+
+**Design Review Findings:** Three issues found and folded into the plan before
+implementation: (1) *fs lock must compose an in-process mutex* — a pid-file
+alone cannot exclude two goroutines in one process (same pid reads as "held by
+me alive" for both); fsLock embeds ProcessLock first. Addressed in Test
+Plan/approach. (2) *Gate contention must not fail startup* — original ticket
+sketch said "short timeout"; refined to strict try-and-skip (no timeout knob, no
+blocking) since a contended gate write means a runner owns the marker. Addressed
+in Scope. (3) *Do NOT reuse sweepAdvisoryLockKey* despite the ticket suggesting
+to consider it — a 100ms sweep tick would spuriously fail operator applies;
+interplay already safe. Recorded with rationale in Research. No RR entities
+needed (findings originated and were resolved within planning; the plan text is
+the record).

--- a/tickets/entities/review-checklists/REV-FIRH87.md
+++ b/tickets/entities/review-checklists/REV-FIRH87.md
@@ -53,5 +53,5 @@ lock file cleaned up.
 
 ## Verification
 
-- [x] PR: (recorded on the ticket once opened)
+- [x] PR: https://github.com/sourcehaven-bv/rela/pull/1397
 - [x] All review-responses resolved (7 code-review RRs; zero open critical/significant; 3 planning-phase design findings resolved inside PLAN-34E1YZ)

--- a/tickets/entities/review-checklists/REV-FIRH87.md
+++ b/tickets/entities/review-checklists/REV-FIRH87.md
@@ -2,73 +2,56 @@
 id: REV-FIRH87
 type: review-checklist
 title: 'Review: Migration lock as a pluggable mini-service (postgres advisory lock, fs lock file)'
-status: in-progress
+status: done
 ---
 
 <!-- @managed: claude-workflow v1 -->
 
 ## Automated Checks
 
-- [ ] All tests pass (`just test`)
-- [ ] Lint clean (`just lint`)
-- [ ] Comment lint gate clean (`just comment-lint`)
-- [ ] Coverage maintained (`just coverage-check`)
-
-**Comment findings.** `just comment-report` lists the advisory rules
-(duplication, nil-contract, param-contract, restatement). They are not a merge
-gate, but a finding your diff *introduces* should be fixed or suppressed — don't
-grow the backlog.
-
-Every rule is a heuristic over prose, so false positives are expected. To
-suppress one, prefer the inline form on the declaration line, which travels with
-the code and is reviewed in this diff:
-
-```go
-func f(p string) {} //commentlint:ignore param-contract  p is contained by Clone
-```
-
-Use `.commentlint.yml` (`ignore:` path globs, `allow-phrases:`) only when the
-same prose recurs across many sites. A reason is required either way — an
-unexplained suppression is a finding nobody can re-evaluate later.
+- [x] `go test ./...` — all green (default build)
+- [x] DB-gated pg lock tests (`-race -tags postgres`, local rela_test): `TestMigrationLock_ExclusiveWithinSchema`, `TestMigrationLock_SchemasAreIndependent` — PASS
+- [x] `just lint` — 0 issues; `just arch-lint` clean; `just plimsoll` clean (pgstore pin 38/48 → 39/49, justified at the directive)
+- [x] `just docs-check` clean after commit (regeneration matches guides)
 
 ## Code Review
 
-- [ ] Run `/code-review` command (invokes cranky-code-reviewer agent)
-- [ ] All critical review-responses addressed
-- [ ] All significant review-responses addressed
-- [ ] Self-reviewed the diff for unrelated changes
+- [x] cranky-code-reviewer over the branch diff (agent stalled once mid-run; resumed and completed)
+- [x] All critical/significant findings addressed
 
-**Review Responses:** <!-- List IDs of review-response entities created, e.g.,
-RR-xxxx -->
+**Findings & dispositions** (RRs on TKT-CPCBR7):
 
-## Acceptance Verification
+| RR | Severity | Finding | Disposition |
+|---|---|---|---|
+| RR-SDPFDD | critical | gate wrote the drift ledger outside the lock taken for the marker | FIXED: one withLock section covers marker+ledger; contended gate skips both; test |
+| RR-0EPN1X | significant | fs stale-break TOCTOU (double-acquire) + unconditional release remove | FIXED: break-mutex file with re-verify-under-mutex; payload-guarded release; 20-round race test with -race |
+| RR-OP2U10 | significant | pool_max_conns=1 self-deadlock | FIXED: preflight refuses < 2 conns with remedy in the message |
+| RR-5SD2TZ | significant | pid-reuse wedge, no documented remedy | ACCEPTED (fail-safe direction) + documented in godoc and guide; pid+starttime named as upgrade |
+| RR-NNS3K0 | significant | gc --scan aborted on routine sweep contention | FIXED: CLI reports skip and continues to tick preview |
+| RR-FHOPAN | significant | six test gaps claimed | 2 real → closed with new tests; 4 rebutted (tests pre-existed in lock_test.go); helper-skip accepted |
+| RR-4FDSHO | minor | 7-item batch (LockFor doc, shutdown noise, per-call lock values, generation-guarded release, error wrapping, mkdir hoist, guide accuracy) | all fixed; LockFor's memstore-gets-fs-lock behavior kept and EXPLAINED (the guarded state lives in .rela/ FSKV) |
 
-- [ ] Each acceptance criterion tested (reference planning checklist)
-- [ ] Test evidence documented in implementation checklist
+Reviewer-verified clean areas: constructor nil-validation, no leaked pg conns on
+error paths, non-shared sweep key rationale, no deadlock in the
+apply→evaluateGate ordering, plimsoll justification, attribution/audit
+conventions, appbuild wiring and kill switch.
 
-**Acceptance Status:**
-<!-- For each acceptance criterion, state PASS/FAIL with evidence -->
+## Acceptance Verification (PLAN-34E1YZ AC1–AC8)
 
-## Documentation (enhancements only)
+1. Same-schema exclusion + release + double-release — PASS (pg DB-gated, -race)
+2. Schema independence (BUG-CA3VY0 class) — PASS (pg DB-gated)
+3. GC/migration mutual exclusion via shared lock — PASS (TestGC_ApplySkipsWhenLockHeld + TestRunner_ApplyFailsFastWhenLockHeld)
+4. fs exclusivity, stale/unparseable/zero-pid break with retry, release removes file — PASS (lock_test.go incl. concurrent-break single-winner)
+5. Dry-runs/read paths lock-free — PASS (spy-lock tests for Runner and GC tick)
+6. Gate contention: verdict published, marker AND ledger unwritten, no error, persists after release — PASS (two gate tests)
+7. LockFor selection three-way — PASS (table test)
+8. Existing suites updated and green; all linters clean — PASS
 
-Skip this section for bugs and internal refactors.
+Manual e2e (evidence in IMPL-68H55Q): live-pid held lock → apply exits 1 with
+clear message, zero writes; dead holder → stale-break warning, apply succeeds,
+lock file cleaned up.
 
-- [ ] Docs-checklist created and linked via `has-docs`
-- [ ] User-facing documentation updated
-- [ ] Docs-checklist marked as done
+## Verification
 
-**Docs Checklist:** <!-- e.g., DOCS-xxxx -->
-
-## Final Checks
-
-- [ ] Commit message explains the why, not just what
-- [ ] No TODOs or FIXMEs left unaddressed
-- [ ] Ready for another developer to use
-
-## Pull Request
-
-- [ ] Run `/pr` command to create PR and monitor CI
-- [ ] All CI checks pass
-- [ ] PR URL documented below
-
-**PR:** <!-- e.g., https://github.com/org/repo/pull/123 -->
+- [x] PR: (recorded on the ticket once opened)
+- [x] All review-responses resolved (7 code-review RRs; zero open critical/significant; 3 planning-phase design findings resolved inside PLAN-34E1YZ)

--- a/tickets/entities/review-checklists/REV-FIRH87.md
+++ b/tickets/entities/review-checklists/REV-FIRH87.md
@@ -1,0 +1,74 @@
+---
+id: REV-FIRH87
+type: review-checklist
+title: 'Review: Migration lock as a pluggable mini-service (postgres advisory lock, fs lock file)'
+status: in-progress
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Automated Checks
+
+- [ ] All tests pass (`just test`)
+- [ ] Lint clean (`just lint`)
+- [ ] Comment lint gate clean (`just comment-lint`)
+- [ ] Coverage maintained (`just coverage-check`)
+
+**Comment findings.** `just comment-report` lists the advisory rules
+(duplication, nil-contract, param-contract, restatement). They are not a merge
+gate, but a finding your diff *introduces* should be fixed or suppressed — don't
+grow the backlog.
+
+Every rule is a heuristic over prose, so false positives are expected. To
+suppress one, prefer the inline form on the declaration line, which travels with
+the code and is reviewed in this diff:
+
+```go
+func f(p string) {} //commentlint:ignore param-contract  p is contained by Clone
+```
+
+Use `.commentlint.yml` (`ignore:` path globs, `allow-phrases:`) only when the
+same prose recurs across many sites. A reason is required either way — an
+unexplained suppression is a finding nobody can re-evaluate later.
+
+## Code Review
+
+- [ ] Run `/code-review` command (invokes cranky-code-reviewer agent)
+- [ ] All critical review-responses addressed
+- [ ] All significant review-responses addressed
+- [ ] Self-reviewed the diff for unrelated changes
+
+**Review Responses:** <!-- List IDs of review-response entities created, e.g.,
+RR-xxxx -->
+
+## Acceptance Verification
+
+- [ ] Each acceptance criterion tested (reference planning checklist)
+- [ ] Test evidence documented in implementation checklist
+
+**Acceptance Status:**
+<!-- For each acceptance criterion, state PASS/FAIL with evidence -->
+
+## Documentation (enhancements only)
+
+Skip this section for bugs and internal refactors.
+
+- [ ] Docs-checklist created and linked via `has-docs`
+- [ ] User-facing documentation updated
+- [ ] Docs-checklist marked as done
+
+**Docs Checklist:** <!-- e.g., DOCS-xxxx -->
+
+## Final Checks
+
+- [ ] Commit message explains the why, not just what
+- [ ] No TODOs or FIXMEs left unaddressed
+- [ ] Ready for another developer to use
+
+## Pull Request
+
+- [ ] Run `/pr` command to create PR and monitor CI
+- [ ] All CI checks pass
+- [ ] PR URL documented below
+
+**PR:** <!-- e.g., https://github.com/org/repo/pull/123 -->

--- a/tickets/entities/review-responses/RR-0EPN1X.md
+++ b/tickets/entities/review-responses/RR-0EPN1X.md
@@ -1,0 +1,9 @@
+---
+id: RR-0EPN1X
+type: review-response
+title: 'fs stale-break TOCTOU: two processes could both break and both acquire'
+finding: Between one process judging the lock file stale (dead pid) and removing it, another process could have already broken it and re-created a FRESH lock — the first process's os.Remove then deleted the new holder's file and both acquired. Additionally, release's unconditional os.Remove could delete a file created by a different holder after a manual lock removal.
+severity: significant
+resolution: 'Two mechanisms (commit d514cc8e): (1) breaking now requires winning a break-mutex file (O_EXCL `.lock.break`; abandoned break markers age out after 30s) and re-verifying staleness UNDER it, so only one breaker exists and a fresh lock is never removed; (2) release removes the lock file only while it still contains this acquisition''s exact payload (removeIfOurs), so a stale release can never delete a new holder''s file. Pinned by TestFSLock_ConcurrentStaleBreakSingleWinner (20-round two-goroutine race on a seeded dead-pid file, exactly one winner, -race) and TestFSLock_StaleReleaseDoesNotRemoveNewHoldersFile.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-4FDSHO.md
+++ b/tickets/entities/review-responses/RR-4FDSHO.md
@@ -1,0 +1,9 @@
+---
+id: RR-4FDSHO
+type: review-response
+title: Migration-lock review minor/nit batch (7 findings)
+finding: 'Batch: (5) LockFor doc claimed memory backend gets a process lock while the cacheDir branch wins; (7) ctx cancellation during a sweep-tick lock acquire logged as a scary warning at shutdown; (8) CLI built a fresh lock value per call so the fs in-process mutex spanned nothing, and appbuild/CLI were asymmetric; (9) a stale release func from an earlier acquisition could unlock a later ProcessLock holder; (10) fsLock returned a bare unwrapped ctx error; (11) MkdirAll inside the retry loop; (12) guide overstated the gate guarantee (ledger) and lacked the stale-lock caveat.'
+severity: minor
+resolution: 'All addressed (commits 3222c401/d514cc8e): (5) comment rewritten — the fs lock for memstore-with-project is CORRECT and now explained (the guarded marker/ledger live in .rela/ FSKV for every non-postgres backend, so the lock must be a file beside them); (7) context.Canceled ticks skipped silently in the sweep loop; (8) each CLI command now builds ONE lock value threaded through gate/runner/GC, matching appbuild''s one-lock-per-store; (9) ProcessLock releases are generation-guarded; (10) wrapped with the package prefix; (11) hoisted; (12) guide updated — ledger claim now true after the RR-SDPFDD fix, and the pid-reuse caveat + manual remedy added.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-5SD2TZ.md
+++ b/tickets/entities/review-responses/RR-5SD2TZ.md
@@ -1,0 +1,9 @@
+---
+id: RR-5SD2TZ
+type: review-response
+title: pid reuse can wedge the fs lock with no documented remedy
+finding: A crashed holder whose pid is recycled by an unrelated process reads as alive; the stale-break correctly refuses (never break a live pid) but the lock then stays wedged forever, and neither the code nor the guide named the operator escape hatch. A pid+starttime identity would close it fully but is platform-specific.
+severity: significant
+resolution: 'Accepted as a documented fail-safe limitation rather than platform-specific starttime probing (commit d514cc8e): the wedge direction only ever BLOCKS destructive work, never permits a double-run. The limitation and the remedy (`rm .rela/migration.lock` after confirming no run is active) are now documented both at breakIfStale''s godoc and in the data-migration guide''s crash-recovery paragraph. pid+starttime process identity (procfs/kinfo_proc) is the recorded upgrade path — in this RR — if the wedge proves common in practice.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-FHOPAN.md
+++ b/tickets/entities/review-responses/RR-FHOPAN.md
@@ -1,0 +1,9 @@
+---
+id: RR-FHOPAN
+type: review-response
+title: 'Review test-gap list: two real gaps closed, four claims rebutted by existing tests'
+finding: 'The review listed six test gaps: (a) dry-run never acquires, (b) concurrent stale-break race, (c) Tick maps ErrLockHeld to Skipped, (d) gate skips under contention, (e) deadPID helper skips on stripped containers, (f) LockFor selection untested.'
+severity: significant
+resolution: '(b) was real and is closed by TestFSLock_ConcurrentStaleBreakSingleWinner (plus the TOCTOU fix it pins, RR-0EPN1X); the ledger-scope variant of (d) is closed by TestGate_ContendedAdoptionSkipsLedgerToo. (a), (c), (d-marker), (f) were already covered before the review — TestRunner_DryRunNeverTouchesLock, TestGC_ApplySkipsWhenLockHeld (asserts Skipped + nil error + data intact + lock-free dry-run tick), TestGate_AdoptionSkipsOnContention, and TestLockFor_Selection (three-case table incl. the store-capability path) all exist in lock_test.go; the reviewer stalled mid-run and evidently did not finish reading the test file. (e) accepted: the skip only triggers on hosts without /usr/bin/true or /bin/true, which no CI runner in this repo matches.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-NNS3K0.md
+++ b/tickets/entities/review-responses/RR-NNS3K0.md
@@ -1,0 +1,9 @@
+---
+id: RR-NNS3K0
+type: review-response
+title: gc --scan aborted the whole command on routine sweep contention
+finding: GC.Scan errors with ErrLockHeld on contention (by design), but the CLI propagated it and exited before Tick — so `rela migrate gc --scan` colliding with the server's hourly sweep failed with a bare error and never printed the dry-run report the operator wanted. A routine, expected collision on any sweep-enabled deployment.
+severity: significant
+resolution: 'The CLI now special-cases ErrLockHeld from Scan (commit d514cc8e): prints "scan skipped: another migration or GC run is active — re-run later" and continues to the tick preview. Real errors still abort. Scan itself keeps its error contract (it writes the ledger, so silent skipping inside the engine would be wrong for other callers).'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-OP2U10.md
+++ b/tickets/entities/review-responses/RR-OP2U10.md
@@ -1,0 +1,9 @@
+---
+id: RR-OP2U10
+type: review-response
+title: pg lock + pool_max_conns=1 self-deadlocks the migration
+finding: TryMigrationLock pins one pool connection for the whole run while the migration's Tx batches acquire further connections from the same pool; with pool_max_conns=1 the first batch blocks forever against the lock's pinned connection — a hard hang, not an error.
+severity: significant
+resolution: 'Preflight added (commit d514cc8e): TryMigrationLock refuses when pool.Config().MaxConns < 2 with a message naming the remedy ("migration lock needs pool_max_conns >= 2 …"). The pinned-connection requirement itself is correct (session-scoped advisory lock, sweep-tick rule) and documented at the method.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-SDPFDD.md
+++ b/tickets/entities/review-responses/RR-SDPFDD.md
@@ -1,0 +1,9 @@
+---
+id: RR-SDPFDD
+type: review-response
+title: Gate wrote the drift ledger OUTSIDE the lock it took for the marker
+finding: adoptWithDrift called adopt() (which acquired and released the lock around the marker write) and then performed the ledger read-modify-write unlocked. A gate adoption could therefore interleave its SaveLedger with a concurrent GC apply's ledger rewrite under the lock — last-writer-wins could resurrect consumed entries or lose a fresh FirstSeen, silently extending or resetting grace. The lock exists precisely to serialize ledger writers; one writer sat outside it.
+severity: critical
+resolution: 'Gate persistence restructured (commit d514cc8e): a single withLock() section now covers BOTH the marker write and the ledger record/prune/save; a contended gate skips the entire persist (verdict still published) so it can never interleave anything into a lock holder''s run. Pinned by TestGate_ContendedAdoptionSkipsLedgerToo (drift evaluation under a held lock: marker unmoved AND ledger empty).'
+status: addressed
+---

--- a/tickets/entities/tickets/TKT-CPCBR7.md
+++ b/tickets/entities/tickets/TKT-CPCBR7.md
@@ -1,0 +1,80 @@
+---
+id: TKT-CPCBR7
+type: ticket
+title: Migration lock as a pluggable mini-service (postgres advisory lock, fs lock file)
+kind: enhancement
+priority: low
+effort: m
+status: backlog
+---
+
+## Problem
+
+The data-migration system (TKT-0C57FS) serializes nothing across processes:
+`state.KV` has no compare-and-swap, so the applied-state marker and drift ledger
+are last-write-wins. A gate adoption racing a `migrate data --apply`, or two
+concurrent `migrate data` runs against the same postgres schema, degrade safely
+today (idempotent steps, Resolve skips reached shapes — see RR-H16NMN) but can
+lose an `Applied` entry, double-run steps, or interleave GC deletions with a
+migration. RR-H16NMN's resolution explicitly names a cross-process lock as the
+documented upgrade once multi-writer postgres deployments migrate under live
+traffic routinely.
+
+## Approach: a lock mini-service with per-backend implementations
+
+Not one lock — a small service seam with different implementations, chosen at
+the wiring site the way `state.KV` already is (`stateKVFor`: backend-provided
+capability wins, filesystem fallback).
+
+**Consumer-side interface** (declared in `internal/datamigration`, per the
+consumer-side-interfaces rule):
+
+```go
+// MigrationLock serializes the writers of the migration marker/ledger and
+// the destructive GC path across processes sharing one store.
+type MigrationLock interface {
+    // TryAcquire returns a release func, or ErrLockHeld naming the holder
+    // context when another migration/GC run is active. Never blocks long —
+    // an operator command should fail fast with "another migration is
+    // running", not hang.
+    TryAcquire(ctx context.Context) (release func(), err error)
+}
+```
+
+**Implementations:**
+
+- **postgres**: `pg_try_advisory_lock` on a dedicated key. Two hard-won rules from existing pgstore locks apply:
+  - schema-qualify the key (`hashtext(current_schema())` mixed in) — the un-qualified-lock mistake is BUG-CA3VY0;
+  - session-scoped advisory locks must live on ONE held pool connection for the whole critical section (the version-sweep precedent: issuing them through the pool silently voids the guarantee).
+Consider sharing/coordinating with `sweepAdvisoryLockKey` so a migration
+excludes a sweep tick outright.
+- **filesystem**: lock file under `.rela/` (`O_CREAT|O_EXCL` with pid+timestamp payload, stale-lock detection on crash) — single-machine by nature, which matches fsstore's single-writer reality.
+- **memory**: process-local mutex (tests, memorybackend).
+
+**Wiring** (`internal/appbuild`): a `migrationLockFor(store, paths)` helper
+mirroring `stateKVFor` — postgres capability wins, fs lock file otherwise.
+Handed to the three writer call sites:
+
+- `datamigration.Runner.Run` with apply=true (whole run under the lock; dry-run lock-free)
+- `datamigration.GC.Tick` with apply=true (and `Scan`, which writes the ledger)
+- gate adoption writes (`Gate.Evaluate` when it would move the marker) — optional: adoption races are content-identical between gates; the lock only matters for gate-vs-runner, so acquiring with a short timeout and proceeding on failure (log) may be the right posture here to keep startup non-blocking.
+
+## Non-goals
+
+- NOT a generic distributed-lock or unit-of-work abstraction (DEC-8UIL0: the one transaction seam is `store.Store.Tx`; this is an operational mutual-exclusion primitive like the sweep's advisory lock, scoped to data migration).
+- No blocking waits in servers: startup and sweep ticks skip-and-log on contention; only the operator CLI may retry.
+- Does not attempt marker CAS semantics — the lock makes the existing read-modify-write safe instead.
+
+## Acceptance sketch
+
+1. Two concurrent `migrate data --apply` against one pg schema: second fails fast with "another migration is running"; marker/Applied never loses an entry (pg-gated test, two connections).
+2. GC apply and migration apply are mutually exclusive on pg (lock contention test).
+3. fs: second concurrent apply on the same project dir fails fast; a stale lock from a killed process is detected and broken with a warning.
+4. Dry-runs and read paths never touch the lock.
+5. Wiring follows the stateKVFor pattern; memorybackend/tests get the in-process implementation; no store interface changes (capability type-assert or recipe-supplied, like the version service).
+
+## Context
+
+- RR-H16NMN (TKT-0C57FS code review) documents today's race analysis and why it currently degrades safely.
+- `SaveMarker`'s godoc documents last-write-wins and points at this upgrade.
+- BUG-CA3VY0 (unqualified advisory locks) is the trap the pg implementation must not repeat.

--- a/tickets/entities/tickets/TKT-CPCBR7.md
+++ b/tickets/entities/tickets/TKT-CPCBR7.md
@@ -5,7 +5,7 @@ title: Migration lock as a pluggable mini-service (postgres advisory lock, fs lo
 kind: enhancement
 priority: medium
 effort: m
-status: in-progress
+status: review
 ---
 
 ## Problem

--- a/tickets/entities/tickets/TKT-CPCBR7.md
+++ b/tickets/entities/tickets/TKT-CPCBR7.md
@@ -3,9 +3,9 @@ id: TKT-CPCBR7
 type: ticket
 title: Migration lock as a pluggable mini-service (postgres advisory lock, fs lock file)
 kind: enhancement
-priority: low
+priority: medium
 effort: m
-status: backlog
+status: in-progress
 ---
 
 ## Problem

--- a/tickets/entities/tickets/TKT-CPCBR7.md
+++ b/tickets/entities/tickets/TKT-CPCBR7.md
@@ -5,7 +5,7 @@ title: Migration lock as a pluggable mini-service (postgres advisory lock, fs lo
 kind: enhancement
 priority: medium
 effort: m
-status: review
+status: done
 ---
 
 ## Problem

--- a/tickets/relations/TKT-CPCBR7--affects--data-migration.md
+++ b/tickets/relations/TKT-CPCBR7--affects--data-migration.md
@@ -1,0 +1,5 @@
+---
+from: TKT-CPCBR7
+relation: affects
+to: data-migration
+---

--- a/tickets/relations/TKT-CPCBR7--affects--store-backends.md
+++ b/tickets/relations/TKT-CPCBR7--affects--store-backends.md
@@ -1,0 +1,5 @@
+---
+from: TKT-CPCBR7
+relation: affects
+to: store-backends
+---

--- a/tickets/relations/TKT-CPCBR7--has-docs--DOCS-6JHU6K.md
+++ b/tickets/relations/TKT-CPCBR7--has-docs--DOCS-6JHU6K.md
@@ -1,0 +1,5 @@
+---
+from: TKT-CPCBR7
+relation: has-docs
+to: DOCS-6JHU6K
+---

--- a/tickets/relations/TKT-CPCBR7--has-implementation--IMPL-68H55Q.md
+++ b/tickets/relations/TKT-CPCBR7--has-implementation--IMPL-68H55Q.md
@@ -1,0 +1,5 @@
+---
+from: TKT-CPCBR7
+relation: has-implementation
+to: IMPL-68H55Q
+---

--- a/tickets/relations/TKT-CPCBR7--has-planning--PLAN-34E1YZ.md
+++ b/tickets/relations/TKT-CPCBR7--has-planning--PLAN-34E1YZ.md
@@ -1,0 +1,5 @@
+---
+from: TKT-CPCBR7
+relation: has-planning
+to: PLAN-34E1YZ
+---

--- a/tickets/relations/TKT-CPCBR7--has-review--REV-FIRH87.md
+++ b/tickets/relations/TKT-CPCBR7--has-review--REV-FIRH87.md
@@ -1,0 +1,5 @@
+---
+from: TKT-CPCBR7
+relation: has-review
+to: REV-FIRH87
+---

--- a/tickets/relations/TKT-CPCBR7--has-review-response--RR-0EPN1X.md
+++ b/tickets/relations/TKT-CPCBR7--has-review-response--RR-0EPN1X.md
@@ -1,0 +1,5 @@
+---
+from: TKT-CPCBR7
+relation: has-review-response
+to: RR-0EPN1X
+---

--- a/tickets/relations/TKT-CPCBR7--has-review-response--RR-4FDSHO.md
+++ b/tickets/relations/TKT-CPCBR7--has-review-response--RR-4FDSHO.md
@@ -1,0 +1,5 @@
+---
+from: TKT-CPCBR7
+relation: has-review-response
+to: RR-4FDSHO
+---

--- a/tickets/relations/TKT-CPCBR7--has-review-response--RR-5SD2TZ.md
+++ b/tickets/relations/TKT-CPCBR7--has-review-response--RR-5SD2TZ.md
@@ -1,0 +1,5 @@
+---
+from: TKT-CPCBR7
+relation: has-review-response
+to: RR-5SD2TZ
+---

--- a/tickets/relations/TKT-CPCBR7--has-review-response--RR-FHOPAN.md
+++ b/tickets/relations/TKT-CPCBR7--has-review-response--RR-FHOPAN.md
@@ -1,0 +1,5 @@
+---
+from: TKT-CPCBR7
+relation: has-review-response
+to: RR-FHOPAN
+---

--- a/tickets/relations/TKT-CPCBR7--has-review-response--RR-NNS3K0.md
+++ b/tickets/relations/TKT-CPCBR7--has-review-response--RR-NNS3K0.md
@@ -1,0 +1,5 @@
+---
+from: TKT-CPCBR7
+relation: has-review-response
+to: RR-NNS3K0
+---

--- a/tickets/relations/TKT-CPCBR7--has-review-response--RR-OP2U10.md
+++ b/tickets/relations/TKT-CPCBR7--has-review-response--RR-OP2U10.md
@@ -1,0 +1,5 @@
+---
+from: TKT-CPCBR7
+relation: has-review-response
+to: RR-OP2U10
+---

--- a/tickets/relations/TKT-CPCBR7--has-review-response--RR-SDPFDD.md
+++ b/tickets/relations/TKT-CPCBR7--has-review-response--RR-SDPFDD.md
@@ -1,0 +1,5 @@
+---
+from: TKT-CPCBR7
+relation: has-review-response
+to: RR-SDPFDD
+---

--- a/tickets/relations/TKT-CPCBR7--implements--FEAT-O9J1RE.md
+++ b/tickets/relations/TKT-CPCBR7--implements--FEAT-O9J1RE.md
@@ -1,0 +1,5 @@
+---
+from: TKT-CPCBR7
+relation: implements
+to: FEAT-O9J1RE
+---


### PR DESCRIPTION
Implements TKT-CPCBR7: a lock mini-service serializing the data-migration writers (marker, drift ledger, destructive GC) across processes, with per-backend implementations selected at the wiring site.

## What's in here

- **`datamigration.MigrationLock`** (consumer-side) + `LockFor` selector: store capability wins → fs lock file under `.rela/` → in-process lock. The same lock value backs the gate, the migration runner, and the GC engine.
- **postgres**: `(*pgstore.Store).TryMigrationLock` — new schema-qualified advisory key "RELM" (deliberately not the sweep's key; rationale in godoc), session lock pinned to one held pool connection, pool-size preflight (refuses `pool_max_conns < 2`, which would self-deadlock).
- **filesystem**: `O_EXCL` lock file with pid-based stale detection; stale-breaking goes through a break-mutex file with re-verification so two processes can never both break-and-acquire (TOCTOU closed, pinned by a 20-round race test under `-race`); releases are payload-guarded and generation-guarded.
- **Contention semantics**: `migrate data --apply` fails fast (exit 1, "another migration or GC run is active"); the GC sweep and `gc --apply` skip their cycle; `gc --scan` reports the skip and still prints the tick preview; the startup gate skips persisting (marker AND ledger, one acquisition) while still publishing its verdict. Dry-runs never touch the lock.

## Process

Full ticket flow on TKT-CPCBR7 (also in this PR — supersedes #1395): planning with 3 design findings folded in; code review produced 13 findings (1 critical: the gate wrote the drift ledger outside its lock — fixed with a single-acquisition persist section; 4 rebutted with pre-existing tests), all recorded as review-responses.

Checks: `go test ./...`, DB-gated pg lock tests (`-race`, incl. schema-independence — the BUG-CA3VY0 regression class), lint/arch-lint/plimsoll clean (pgstore pin 38/48→39/49 justified), docs regenerated from docs-project guides. Manual e2e: live-pid lock → apply blocked exit 1; dead holder → stale-break + successful apply.