### PR TITLE
feat(next-action): condition expressions for dwell-time sources (TKT-N8XQ2R)

### DIFF
--- a/.go-arch-lint.yml
+++ b/.go-arch-lint.yml
@@ -391,11 +391,20 @@ deps:
   # conditionlint reuses the predicate parser to sanity-check wizard-form
   # condition expressions at author time. It sits above dataentryconfig so the
   # config package stays free of the predicate dependency.
+  #
+  # It also COMPILES next-action `condition:` expressions (TKT-N8XQ2R). Those
+  # are evaluated server-side by predicatefns, not by the SPA, so unlike the
+  # wizard-form checks this one is authoritative rather than a superset: it
+  # must see the same host functions (days_between, today, ...) the runtime
+  # will, hence predicatefns. searchparser is needed to read the entity types
+  # out of the source's `query:`, which is what a condition compiles against.
   conditionlint:
     mayDependOn:
       - dataentryconfig
       - metamodel
       - predicate
+      - predicatefns
+      - searchparser
   desktop:
     canUse:
       - wails
@@ -452,6 +461,11 @@ deps:
       - memuserstate
       - kvuserstate
       - datamigration
+      # Bridges conditionlint's next-action condition compiler to the seam
+      # dataentry declares, so the app never imports the predicate engine.
+      - conditionlint
+      - dataentryconfig
+      - nextaction
       - acl
       - app
       - audit

--- a/cmd/rela-server/main.go
+++ b/cmd/rela-server/main.go
@@ -462,6 +462,14 @@ func main() {
 		os.Exit(1)
 	}
 
+	// The predicate compiler backing a source's `condition:`. Supplied here
+	// rather than imported by dataentry: the condition engine sits above the
+	// data-entry app, so the composition root bridges the two.
+	if err := app.SetNextActionMatchers(appbuild.NextActionMatchers); err != nil {
+		slog.Error("failed to wire next-action matchers", "error", err)
+		os.Exit(1)
+	}
+
 	// Start file watcher for live-reload.
 	// The watcher goroutine is cleaned up on process exit.
 	if err := app.StartWatching(); err != nil {

--- a/docs-project/entities/guides/GUIDE-data-entry.md
+++ b/docs-project/entities/guides/GUIDE-data-entry.md
@@ -1673,6 +1673,7 @@ next_actions:
 |-------|---------|
 | `band` | **Required.** Names a declared band. |
 | `query` | Candidate entities, in the search syntax (`type:`, `prop:`, …). |
+| `condition` | Refines `query`'s candidates with a predicate expression — the only place date arithmetic works. See below. |
 | `context` | Instead of `query`: scopes the source to the entity being viewed. |
 | `count` | Instead of `query`: fires on `"<entity_type> == 0"` — the first-run case. |
 | `suggest` | **Required.** The message. `{property}` interpolates from the candidate; `{id}` is the entity id. |
@@ -1682,6 +1683,53 @@ next_actions:
 | `defer_scope` | What "not now" covers: `entity` (default) or `source` — see below. |
 
 Exactly one of `query`, `context` or `count` must be set.
+
+#### `condition` — dwell time and other typed comparisons
+
+`query` selects; `condition` refines. The split exists because they are
+different languages: `query` is the search syntax, pushed toward the store,
+and `condition` is a predicate expression evaluated per candidate with the
+same host functions automations use.
+
+```yaml
+next_actions:
+  chase-proposal:
+    band: blocking
+    query: "type:proposal prop:status=sent"
+    condition: "days_between(entity.sent_on, today()) >= 11"
+    suggest: "{title} has been out {days} days with no reply. Chase it?"
+```
+
+That is the shape `query` alone cannot express: "how long has this been
+sitting?" needs date arithmetic, which needs the property's declared type from
+the metamodel, which the search syntax does not consult.
+
+**Do not put an expression in `query`.** The two syntaxes overlap without
+erroring, so `query: "days_between(entity.due, today()) <= 7"` is not rejected
+— it is read as a filter on a property *named*
+`days_between(entity.due, today())`, matches nothing, and the source goes
+quiet with no diagnostic. That is why they are separate keys rather than one
+key that guesses.
+
+Rules worth knowing:
+
+- **`query` must name at least one entity type** when a condition is present
+  (`type:task …`). A condition references `entity.<property>`, and without a
+  type there is nothing to check it against.
+- **The condition must be valid on *every* type the query names.** A query
+  spanning `task` and `note` yields candidates of either, and the engine
+  cannot know which until it holds one — so a condition valid on only one of
+  them is refused at load rather than silently dropping the other's
+  candidates.
+- **A typo fails at startup**, not at render:
+  `condition does not compile against entity type "task": unknown attribute
+  "dew" on record`. A condition that silently matched nothing would be
+  indistinguishable from a source with nothing to say.
+- **Not available on a `count` source** — there is no entity to test.
+
+The available functions are the ones automations use: `days_between`,
+`date_add`, `rrule_next`, `today`, plus `match`, `regex`, `contains` and
+`len`. See [metamodel.md](metamodel.md) for their signatures.
 
 #### `key_props` and re-triggering
 

--- a/docs/data-entry.md
+++ b/docs/data-entry.md
@@ -1667,6 +1667,7 @@ next_actions:
 |-------|---------|
 | `band` | **Required.** Names a declared band. |
 | `query` | Candidate entities, in the search syntax (`type:`, `prop:`, …). |
+| `condition` | Refines `query`'s candidates with a predicate expression — the only place date arithmetic works. See below. |
 | `context` | Instead of `query`: scopes the source to the entity being viewed. |
 | `count` | Instead of `query`: fires on `"<entity_type> == 0"` — the first-run case. |
 | `suggest` | **Required.** The message. `{property}` interpolates from the candidate; `{id}` is the entity id. |
@@ -1676,6 +1677,53 @@ next_actions:
 | `defer_scope` | What "not now" covers: `entity` (default) or `source` — see below. |
 
 Exactly one of `query`, `context` or `count` must be set.
+
+#### `condition` — dwell time and other typed comparisons
+
+`query` selects; `condition` refines. The split exists because they are
+different languages: `query` is the search syntax, pushed toward the store,
+and `condition` is a predicate expression evaluated per candidate with the
+same host functions automations use.
+
+```yaml
+next_actions:
+  chase-proposal:
+    band: blocking
+    query: "type:proposal prop:status=sent"
+    condition: "days_between(entity.sent_on, today()) >= 11"
+    suggest: "{title} has been out {days} days with no reply. Chase it?"
+```
+
+That is the shape `query` alone cannot express: "how long has this been
+sitting?" needs date arithmetic, which needs the property's declared type from
+the metamodel, which the search syntax does not consult.
+
+**Do not put an expression in `query`.** The two syntaxes overlap without
+erroring, so `query: "days_between(entity.due, today()) <= 7"` is not rejected
+— it is read as a filter on a property *named*
+`days_between(entity.due, today())`, matches nothing, and the source goes
+quiet with no diagnostic. That is why they are separate keys rather than one
+key that guesses.
+
+Rules worth knowing:
+
+- **`query` must name at least one entity type** when a condition is present
+  (`type:task …`). A condition references `entity.<property>`, and without a
+  type there is nothing to check it against.
+- **The condition must be valid on *every* type the query names.** A query
+  spanning `task` and `note` yields candidates of either, and the engine
+  cannot know which until it holds one — so a condition valid on only one of
+  them is refused at load rather than silently dropping the other's
+  candidates.
+- **A typo fails at startup**, not at render:
+  `condition does not compile against entity type "task": unknown attribute
+  "dew" on record`. A condition that silently matched nothing would be
+  indistinguishable from a source with nothing to say.
+- **Not available on a `count` source** — there is no entity to test.
+
+The available functions are the ones automations use: `days_between`,
+`date_add`, `rrule_next`, `today`, plus `match`, `regex`, `contains` and
+`len`. See [metamodel.md](metamodel.md) for their signatures.
 
 #### `key_props` and re-triggering
 

--- a/internal/appbuild/nextaction_matchers.go
+++ b/internal/appbuild/nextaction_matchers.go
@@ -1,0 +1,36 @@
+package appbuild
+
+import (
+	"github.com/Sourcehaven-BV/rela/internal/conditionlint"
+	"github.com/Sourcehaven-BV/rela/internal/dataentryconfig"
+	"github.com/Sourcehaven-BV/rela/internal/metamodel"
+	"github.com/Sourcehaven-BV/rela/internal/nextaction"
+)
+
+// NextActionMatchers compiles the `condition:` of every next-action source,
+// adapting conditionlint's compiler to the seam internal/dataentry declares.
+//
+// Lives at the composition root for the same reason the userstate backend
+// does: the condition/policy engine sits above the data-entry app, so
+// dataentry takes a seam and this bridges the two.
+//
+// Takes config + metamodel rather than returning a prebuilt lookup because
+// both reload at runtime — a lookup captured at boot would keep evaluating a
+// condition the operator has since edited.
+func NextActionMatchers(
+	cfg *dataentryconfig.Config, meta *metamodel.Metamodel,
+) (lookup func(string) (nextaction.Matcher, bool), problems []string) {
+	compiled, issues := conditionlint.NextActionMatchers(cfg, meta)
+	if len(issues) > 0 || compiled == nil {
+		return nil, issues
+	}
+	return func(id string) (nextaction.Matcher, bool) {
+		m, ok := compiled(id)
+		if !ok {
+			// Returning m directly would hand back a non-nil interface
+			// wrapping a nil *NextActionMatcher — the classic typed-nil trap.
+			return nil, false
+		}
+		return m, true
+	}, nil
+}

--- a/internal/conditionlint/nextaction.go
+++ b/internal/conditionlint/nextaction.go
@@ -1,0 +1,116 @@
+package conditionlint
+
+import (
+	"errors"
+	"fmt"
+	"sort"
+
+	"github.com/Sourcehaven-BV/rela/internal/dataentryconfig"
+	"github.com/Sourcehaven-BV/rela/internal/metamodel"
+	"github.com/Sourcehaven-BV/rela/internal/predicate"
+	"github.com/Sourcehaven-BV/rela/internal/predicatefns"
+	"github.com/Sourcehaven-BV/rela/internal/search/searchparser"
+)
+
+// NextActionPrograms holds one compiled program per entity type a source's
+// `query:` names. A condition is checked against EVERY named type, so the
+// engine can evaluate a candidate whatever its type turns out to be.
+type NextActionPrograms map[string]*predicate.Program
+
+// CompileNextActions compiles the `condition:` of every next-action source.
+//
+// Unlike [Lint], this is AUTHORITATIVE rather than a superset sanity check:
+// these expressions are evaluated server-side by predicatefns with the same
+// Env compiled here, so an expression that compiles will run and one that does
+// not is a real error. Compiling at config load is what makes a bad condition
+// fail at startup instead of silently suppressing a suggestion forever — the
+// failure mode this whole feature exists to remove.
+//
+// Returns the programs keyed by source id, plus one message per problem. A
+// source with no `condition:` is absent from the result, which the engine
+// reads as "keep every candidate".
+func CompileNextActions(
+	cfg *dataentryconfig.Config, meta *metamodel.Metamodel,
+) (programs map[string]NextActionPrograms, problems []string) {
+	if cfg == nil || meta == nil {
+		return nil, nil
+	}
+	ev := predicatefns.NewEvaluator(meta)
+	programs = make(map[string]NextActionPrograms)
+
+	for id, src := range cfg.NextActions {
+		if src.Condition == "" {
+			continue
+		}
+		progs, msgs := compileNextActionSource(id, src, ev)
+		problems = append(problems, msgs...)
+		if len(progs) > 0 {
+			programs[id] = progs
+		}
+	}
+	sort.Strings(problems)
+	return programs, problems
+}
+
+// compileNextActionSource compiles one source's condition against each entity
+// type its query names.
+func compileNextActionSource(
+	id string, src dataentryconfig.NextActionSource, ev *predicatefns.Evaluator,
+) (programs NextActionPrograms, problems []string) {
+	where := fmt.Sprintf("next_actions[%q]", id)
+
+	types, err := conditionEntityTypes(src)
+	if err != nil {
+		return nil, []string{where + ": " + err.Error()}
+	}
+
+	programs = make(NextActionPrograms, len(types))
+	for _, t := range types {
+		// Compiled per type and required to succeed on ALL of them. A query
+		// spanning task and bug yields candidates of either, and the engine
+		// cannot know which until it has one in hand — so a condition that
+		// only type-checks against one of them would silently drop the
+		// other's candidates. Same rule as the pushdown's
+		// stringComparableOnEveryType: valid everywhere, or refused.
+		prog, err := ev.Compile(t, src.Condition)
+		if err != nil {
+			problems = append(problems, fmt.Sprintf(
+				"%s: condition does not compile against entity type %q: %v", where, t, err))
+			continue
+		}
+		programs[t] = prog
+	}
+	if len(problems) > 0 {
+		return nil, problems
+	}
+	return programs, nil
+}
+
+// conditionEntityTypes returns the entity types a condition must compile
+// against, or an error explaining why the source cannot carry one.
+func conditionEntityTypes(src dataentryconfig.NextActionSource) ([]string, error) {
+	switch {
+	case src.Context != "":
+		// A context-aware source is already scoped to one declared type.
+		return []string{src.Context}, nil
+
+	case src.Count != "":
+		// A count source has no entity to evaluate against: its candidate is
+		// the absence of rows. Silently ignoring the condition would leave an
+		// operator believing it applied.
+		return nil, errors.New("condition is not supported on a count source (there is no entity to test)")
+
+	case src.Query != "":
+		sq := searchparser.ParseQuery(src.Query)
+		if len(sq.EntityTypes) == 0 {
+			// Every documented next-action query names exactly one type. A
+			// condition referencing entity.<prop> against "whatever the free
+			// text matched" has no type to check, so require it explicitly
+			// rather than guessing.
+			return nil, errors.New(
+				"condition requires the query to name at least one entity type (e.g. \"type:task ...\")")
+		}
+		return sq.EntityTypes, nil
+	}
+	return nil, errors.New("condition requires a query or context source")
+}

--- a/internal/conditionlint/nextaction_matcher.go
+++ b/internal/conditionlint/nextaction_matcher.go
@@ -1,0 +1,73 @@
+package conditionlint
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/Sourcehaven-BV/rela/internal/dataentryconfig"
+	"github.com/Sourcehaven-BV/rela/internal/entity"
+	"github.com/Sourcehaven-BV/rela/internal/metamodel"
+	"github.com/Sourcehaven-BV/rela/internal/predicatefns"
+)
+
+// NextActionMatcher evaluates one source's compiled condition against a
+// candidate. It implements the engine's consumer-side Matcher interface
+// without the engine ever naming this package: the wiring site supplies it.
+type NextActionMatcher struct {
+	ev    *predicatefns.Evaluator
+	progs NextActionPrograms
+}
+
+// Match reports whether e satisfies the condition.
+//
+// An entity whose type has no compiled program does NOT match. That is
+// unreachable through the normal path — [CompileNextActions] compiles against
+// every type the query names — but a query is filter syntax evaluated by the
+// search layer, so a future widening there could yield a type this condition
+// was never checked against. Refusing is the safe direction: showing a
+// suggestion whose condition was never evaluated is worse than showing none.
+func (m *NextActionMatcher) Match(ctx context.Context, e *entity.Entity) (bool, error) {
+	if e == nil {
+		return false, nil
+	}
+	prog, ok := m.progs[e.Type]
+	if !ok {
+		return false, nil
+	}
+	ok, err := m.ev.Matches(ctx, prog, e.Type, e.ID, e.Properties)
+	if err != nil {
+		// Surfaced, not swallowed. A missing date property is an eval error,
+		// and treating it as "does not match" would make a broken condition
+		// indistinguishable from a source that legitimately has nothing to
+		// say — the silent-no-op this feature exists to remove.
+		return false, fmt.Errorf("conditionlint: evaluating condition for %s: %w", e.ID, err)
+	}
+	return ok, nil
+}
+
+// NextActionMatchers compiles every source's condition and returns a lookup
+// suitable for nextaction.WithMatchers, plus one message per problem.
+//
+// Compile errors are returned rather than tolerated: the caller surfaces them
+// at config load, so an operator learns about a broken condition at startup
+// rather than from a suggestion that never appears.
+func NextActionMatchers(
+	cfg *dataentryconfig.Config, meta *metamodel.Metamodel,
+) (lookup func(sourceID string) (*NextActionMatcher, bool), problems []string) {
+	compiled, errs := CompileNextActions(cfg, meta)
+	if len(errs) > 0 {
+		return nil, errs
+	}
+	if len(compiled) == 0 {
+		return nil, nil
+	}
+	ev := predicatefns.NewEvaluator(meta)
+	matchers := make(map[string]*NextActionMatcher, len(compiled))
+	for id, progs := range compiled {
+		matchers[id] = &NextActionMatcher{ev: ev, progs: progs}
+	}
+	return func(sourceID string) (*NextActionMatcher, bool) {
+		m, ok := matchers[sourceID]
+		return m, ok
+	}, nil
+}

--- a/internal/conditionlint/nextaction_test.go
+++ b/internal/conditionlint/nextaction_test.go
@@ -1,0 +1,165 @@
+package conditionlint
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/Sourcehaven-BV/rela/internal/dataentryconfig"
+	"github.com/Sourcehaven-BV/rela/internal/entity"
+	"github.com/Sourcehaven-BV/rela/internal/metamodel"
+)
+
+// naMeta declares two types sharing `due` (so a cross-type condition is
+// legitimate) and one that lacks it (so the every-type rule can be tested).
+func naMeta() *metamodel.Metamodel {
+	return &metamodel.Metamodel{
+		Entities: map[string]metamodel.EntityDef{
+			"task": {Properties: map[string]metamodel.PropertyDef{
+				"due":    {Type: metamodel.PropertyTypeDate},
+				"status": {Type: metamodel.PropertyTypeString},
+			}},
+			"bug": {Properties: map[string]metamodel.PropertyDef{
+				"due": {Type: metamodel.PropertyTypeDate},
+			}},
+			"quip": {Properties: map[string]metamodel.PropertyDef{
+				"text": {Type: metamodel.PropertyTypeString},
+			}},
+		},
+	}
+}
+
+func naCfg(src dataentryconfig.NextActionSource) *dataentryconfig.Config {
+	return &dataentryconfig.Config{
+		NextActionBands: []dataentryconfig.NextActionBand{{ID: "stalled"}},
+		NextActions:     map[string]dataentryconfig.NextActionSource{"s": src},
+	}
+}
+
+func TestCompileNextActions(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		src     dataentryconfig.NextActionSource
+		wantErr string
+		types   []string
+	}{
+		{
+			name:  "date arithmetic compiles — the motivating S1/S4 case",
+			src:   dataentryconfig.NextActionSource{Query: "type:task", Condition: "days_between(entity.due, today()) <= 7"},
+			types: []string{"task"},
+		},
+		{
+			name:  "compiles against every type the query names",
+			src:   dataentryconfig.NextActionSource{Query: "type:task type:bug", Condition: "days_between(entity.due, today()) <= 7"},
+			types: []string{"task", "bug"},
+		},
+		{
+			name:  "a context source compiles against its declared type",
+			src:   dataentryconfig.NextActionSource{Context: "task", Condition: "entity.status == 'todo'"},
+			types: []string{"task"},
+		},
+		{
+			// The every-type rule: valid on task, absent on quip. Accepting it
+			// would silently drop every quip candidate.
+			name:    "refused when it does not compile against one named type",
+			src:     dataentryconfig.NextActionSource{Query: "type:task type:quip", Condition: "entity.status == 'todo'"},
+			wantErr: `does not compile against entity type "quip"`,
+		},
+		{
+			name:    "a typo'd property is a compile error, not a silent no-match",
+			src:     dataentryconfig.NextActionSource{Query: "type:task", Condition: "entity.staus == 'todo'"},
+			wantErr: "does not compile",
+		},
+		{
+			name:    "a query naming no type has nothing to compile against",
+			src:     dataentryconfig.NextActionSource{Query: "urgent", Condition: "entity.status == 'todo'"},
+			wantErr: "requires the query to name at least one entity type",
+		},
+		{
+			name:    "a count source has no entity to test",
+			src:     dataentryconfig.NextActionSource{Count: "task == 0", Condition: "entity.status == 'todo'"},
+			wantErr: "not supported on a count source",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, errs := CompileNextActions(naCfg(tc.src), naMeta())
+			if tc.wantErr != "" {
+				require.NotEmpty(t, errs)
+				require.Contains(t, errs[0], tc.wantErr)
+				require.Empty(t, got)
+				return
+			}
+			require.Empty(t, errs)
+			require.Len(t, got["s"], len(tc.types))
+			for _, typ := range tc.types {
+				require.Contains(t, got["s"], typ)
+			}
+		})
+	}
+}
+
+// A source without a condition is absent from the result, which the engine
+// reads as "keep every candidate".
+func TestCompileNextActions_NoConditionIsAbsent(t *testing.T) {
+	t.Parallel()
+	got, errs := CompileNextActions(naCfg(dataentryconfig.NextActionSource{Query: "type:task"}), naMeta())
+	require.Empty(t, errs)
+	require.Empty(t, got)
+}
+
+func TestNextActionMatchers_EvaluatesTheCondition(t *testing.T) {
+	t.Parallel()
+	lookup, errs := NextActionMatchers(naCfg(dataentryconfig.NextActionSource{
+		Query: "type:task", Condition: "entity.status == 'todo'",
+	}), naMeta())
+	require.Empty(t, errs)
+	require.NotNil(t, lookup)
+
+	m, ok := lookup("s")
+	require.True(t, ok)
+
+	match, err := m.Match(context.Background(), taskWith("T-1", "todo"))
+	require.NoError(t, err)
+	require.True(t, match)
+
+	match, err = m.Match(context.Background(), taskWith("T-2", "done"))
+	require.NoError(t, err)
+	require.False(t, match)
+}
+
+// An entity whose type was never compiled must not match. Unreachable through
+// the normal path, but refusing is the safe direction: a suggestion whose
+// condition was never evaluated is worse than none.
+func TestNextActionMatchers_UncompiledTypeDoesNotMatch(t *testing.T) {
+	t.Parallel()
+	lookup, errs := NextActionMatchers(naCfg(dataentryconfig.NextActionSource{
+		Query: "type:task", Condition: "entity.status == 'todo'",
+	}), naMeta())
+	require.Empty(t, errs)
+
+	m, _ := lookup("s")
+	e := entity.New("Q-1", "quip")
+	match, err := m.Match(context.Background(), e)
+	require.NoError(t, err)
+	require.False(t, match)
+}
+
+func TestNextActionMatchers_CompileErrorsPropagate(t *testing.T) {
+	t.Parallel()
+	lookup, errs := NextActionMatchers(naCfg(dataentryconfig.NextActionSource{
+		Query: "type:task", Condition: "entity.nope == 1",
+	}), naMeta())
+	require.NotEmpty(t, errs)
+	require.Nil(t, lookup)
+}
+
+func taskWith(id, status string) *entity.Entity {
+	e := entity.New(id, "task")
+	e.Properties["status"] = status
+	return e
+}

--- a/internal/dataentry/app.go
+++ b/internal/dataentry/app.go
@@ -102,7 +102,14 @@ const userPaletteFile = "palette.yaml"
 // handler as a parameter and `toolForPath` is a package function, so the
 // mount cost one method rather than three.
 //
-//plimsoll:max-methods=103
+// TKT-N8XQ2R adds [App.SetNextActionMatchers] on the same terms (103 -> 104):
+// the predicate compiler backing a source's `condition:` lives above this
+// package, so it arrives through the same setter idiom rather than a 13th
+// positional NewApp parameter. The compiling and matching themselves stay OFF
+// App entirely — conditionlint owns them and appbuild bridges — so the feature
+// cost one method, not a subsystem.
+//
+//plimsoll:max-methods=104
 type App struct {
 	// Primitives — immutable after NewApp.
 	fs    storage.FS
@@ -140,6 +147,18 @@ type App struct {
 	// backend — the next-action endpoints then report "not configured"
 	// rather than silently forgetting what users asked to hide.
 	userState userstate.Store
+
+	// nextActionMatchers compiles a source's `condition:` into a predicate
+	// matcher. Injected because the compiler lives above this package (it
+	// needs predicatefns + the metamodel), the same way the composition root
+	// picks the userstate backend while consumers take the seam.
+	//
+	// Takes the live config + metamodel rather than a prebuilt lookup: both
+	// reload at runtime, and a lookup captured at boot would evaluate a stale
+	// condition after an operator edits data-entry.yaml. Nil when no
+	// deployment wired it — sources declaring a condition then fail engine
+	// construction rather than silently matching everything.
+	nextActionMatchers NextActionMatcherFunc
 
 	// visibleReader is the ACL-bounded entity-read seam (TKT-N26KLB): the
 	// entity-read analog of visibleSearcher. Read handlers gate single-GET

--- a/internal/dataentry/nextaction.go
+++ b/internal/dataentry/nextaction.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/Sourcehaven-BV/rela/internal/dataentryconfig"
 	entityPkg "github.com/Sourcehaven-BV/rela/internal/entity"
+	"github.com/Sourcehaven-BV/rela/internal/metamodel"
 	"github.com/Sourcehaven-BV/rela/internal/nextaction"
 	"github.com/Sourcehaven-BV/rela/internal/store"
 	"github.com/Sourcehaven-BV/rela/internal/userstate"
@@ -214,3 +215,30 @@ func (a *App) SetUserState(s userstate.Store) error {
 	a.userState = s
 	return nil
 }
+
+// SetNextActionMatchers injects the predicate compiler backing a source's
+// `condition:`.
+//
+// Separate from NewApp for the same reason as [App.SetUserState]: the compiler
+// lives above this package, so the composition root supplies it rather than
+// this package importing it. Rejects nil for the same reason too — a silently
+// absent compiler would leave every condition unevaluated, showing suggestions
+// for entities the operator explicitly excluded.
+func (a *App) SetNextActionMatchers(fn NextActionMatcherFunc) error {
+	if fn == nil {
+		return errors.New("dataentry.SetNextActionMatchers: func must be non-nil")
+	}
+	a.nextActionMatchers = fn
+	return nil
+}
+
+// NextActionMatcherFunc compiles the `condition:` of every configured source
+// against the current metamodel, returning a per-source lookup plus one
+// message per problem.
+//
+// The consumer-side seam for the predicate compiler: this package must not
+// import it (arch-lint keeps the condition/policy engine above the data-entry
+// app), so the composition root supplies an implementation.
+type NextActionMatcherFunc func(
+	cfg *dataentryconfig.Config, meta *metamodel.Metamodel,
+) (func(sourceID string) (nextaction.Matcher, bool), []string)

--- a/internal/dataentry/nextaction_handler.go
+++ b/internal/dataentry/nextaction_handler.go
@@ -270,12 +270,24 @@ func (a *App) applyNextActionFeedback(
 func (a *App) nextActionEngine() (*nextaction.Engine, bool) {
 	// Snapshot the config once: State() reads an atomic pointer, and two
 	// reads could observe different snapshots if a reload lands between them.
-	cfg := a.Cfg()
+	st := a.State()
+	cfg := st.Cfg
 	if cfg == nil || len(cfg.NextActions) == 0 || a.userState == nil {
 		return nil, false
 	}
-	eng, err := nextaction.New(cfg, a.userState, a.nextActionCandidates(),
-		nextaction.WithOptions(a.nextActionOptions()))
+
+	opts := []nextaction.Option{nextaction.WithOptions(a.nextActionOptions())}
+	if a.nextActionMatchers != nil {
+		// Compile errors are already reported at load by projectsetup; a
+		// config that reached here should compile. If it somehow does not,
+		// leave matchers unwired so New fails loudly for a source that
+		// declares a condition, rather than silently keeping every candidate.
+		if lookup, issues := a.nextActionMatchers(cfg, st.Meta); len(issues) == 0 && lookup != nil {
+			opts = append(opts, nextaction.WithMatchers(lookup))
+		}
+	}
+
+	eng, err := nextaction.New(cfg, a.userState, a.nextActionCandidates(), opts...)
 	if err != nil {
 		return nil, false
 	}

--- a/internal/dataentryconfig/nextaction.go
+++ b/internal/dataentryconfig/nextaction.go
@@ -136,6 +136,21 @@ type NextActionSource struct {
 	// candidate is the viewed entity.
 	Query string `yaml:"query,omitempty" json:"query,omitempty"`
 
+	// Condition refines the candidates Query selected, as a predicate
+	// expression (e.g. "days_between(entity.due, today()) <= 7"). Optional.
+	//
+	// A SECOND key rather than accepting either dialect in Query: the two
+	// syntaxes overlap without erroring, so a sniffing heuristic would guess,
+	// and guess quietly — filter.Parse turns an expression into a filter on a
+	// property literally named "days_between(entity.due, today())", which
+	// matches nothing, with no error at load and no warning at eval.
+	//
+	// Query selects (filter syntax, pushed toward the store); Condition
+	// refines (predicate syntax, evaluated per candidate). Date arithmetic
+	// lives here because ordered comparison needs the property's declared
+	// type from the metamodel, which the store layer does not consult.
+	Condition string `yaml:"condition,omitempty" json:"condition,omitempty"`
+
 	// Count makes this an entity-LESS source: it fires on a whole-graph
 	// aggregate rather than about any particular entity. The only supported
 	// form today is "<entity_type> == 0" — the first-run case ("nothing here

--- a/internal/nextaction/condition_test.go
+++ b/internal/nextaction/condition_test.go
@@ -1,0 +1,175 @@
+package nextaction_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/Sourcehaven-BV/rela/internal/dataentryconfig"
+	"github.com/Sourcehaven-BV/rela/internal/entity"
+	"github.com/Sourcehaven-BV/rela/internal/nextaction"
+	"github.com/Sourcehaven-BV/rela/internal/userstate/memuserstate"
+)
+
+// matchIDs matches exactly the listed entity ids, standing in for a compiled
+// predicate without dragging the metamodel into the engine's tests — which is
+// the point of the Matcher seam.
+type matchIDs struct {
+	ids  map[string]bool
+	err  error
+	seen int
+}
+
+func (m *matchIDs) Match(_ context.Context, e *entity.Entity) (bool, error) {
+	m.seen++
+	if m.err != nil {
+		return false, m.err
+	}
+	return m.ids[e.ID], nil
+}
+
+func conditionConfig() *dataentryconfig.Config {
+	return &dataentryconfig.Config{
+		NextActionBands: []dataentryconfig.NextActionBand{{ID: "stalled"}},
+		NextActions: map[string]dataentryconfig.NextActionSource{
+			"stale": {
+				Band:      "stalled",
+				Query:     "type:task",
+				Condition: "days_between(entity.due, today()) <= 7",
+				Suggest:   "Still on it?",
+			},
+		},
+	}
+}
+
+func engineWithMatcher(t *testing.T, cfg *dataentryconfig.Config, fn nextaction.CandidateFunc,
+	m nextaction.Matcher,
+) *nextaction.Engine {
+	t.Helper()
+	st := memuserstate.New()
+	t.Cleanup(func() { _ = st.Close() })
+	eng, err := nextaction.New(cfg, st, fn,
+		nextaction.WithMatchers(func(string) (nextaction.Matcher, bool) { return m, true }))
+	require.NoError(t, err)
+	return eng
+}
+
+// THE regression this feature turns on. The cap truncates to 20; a condition
+// matching only a later candidate must still fire. Filtering after the cap
+// would make the source look correctly quiet rather than broken — the
+// silent-no-op this whole line of work exists to remove.
+func TestCondition_MatchesBeyondTheCandidateCap(t *testing.T) {
+	t.Parallel()
+
+	var many []*entity.Entity
+	for i := range 60 {
+		many = append(many, ent(idFor(i), "task", nil))
+	}
+	fn, _ := staticCandidates(map[string][]*entity.Entity{"Still on it?": many})
+
+	// Only the 50th candidate matches — well past DefaultCandidateCap (20).
+	target := idFor(49)
+	m := &matchIDs{ids: map[string]bool{target: true}}
+
+	sug, ok, err := engineWithMatcher(t, conditionConfig(), fn, m).
+		Resolve(context.Background(), testUser, base)
+
+	require.NoError(t, err)
+	require.True(t, ok, "a condition matching a beyond-cap candidate must still fire")
+	require.Equal(t, target, sug.Key.EntityID)
+	require.Equal(t, 60, m.seen, "every candidate must be tested before truncation")
+}
+
+// A condition that excludes everything yields no suggestion rather than an
+// unconditioned one.
+func TestCondition_NoMatchYieldsNothing(t *testing.T) {
+	t.Parallel()
+	fn, _ := staticCandidates(map[string][]*entity.Entity{
+		"Still on it?": {ent("T-1", "task", nil), ent("T-2", "task", nil)},
+	})
+	m := &matchIDs{ids: map[string]bool{}}
+
+	_, ok, err := engineWithMatcher(t, conditionConfig(), fn, m).
+		Resolve(context.Background(), testUser, base)
+
+	require.NoError(t, err)
+	require.False(t, ok)
+}
+
+// An eval error is surfaced, not swallowed as "does not match". A broken
+// condition must be distinguishable from a source with nothing to say.
+func TestCondition_EvalErrorSurfaces(t *testing.T) {
+	t.Parallel()
+	fn, _ := staticCandidates(map[string][]*entity.Entity{
+		"Still on it?": {ent("T-1", "task", nil)},
+	})
+	m := &matchIDs{err: errors.New("missing property")}
+
+	_, _, err := engineWithMatcher(t, conditionConfig(), fn, m).
+		Resolve(context.Background(), testUser, base)
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "missing property")
+}
+
+// Declaring a condition without wiring matchers must fail construction. It
+// would otherwise evaluate as "keep everything" — the suggestion still shows,
+// but for entities the operator excluded, which looks like it works.
+func TestNew_ConditionWithoutMatchersIsRejected(t *testing.T) {
+	t.Parallel()
+	fn, _ := staticCandidates(nil)
+	st := memuserstate.New()
+	t.Cleanup(func() { _ = st.Close() })
+
+	_, err := nextaction.New(conditionConfig(), st, fn)
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "WithMatchers")
+}
+
+// A source with no condition is unaffected when matchers are wired.
+func TestCondition_AbsentConditionKeepsEveryCandidate(t *testing.T) {
+	t.Parallel()
+	cfg := conditionConfig()
+	src := cfg.NextActions["stale"]
+	src.Condition = ""
+	cfg.NextActions["stale"] = src
+
+	fn, _ := staticCandidates(map[string][]*entity.Entity{
+		"Still on it?": {ent("T-1", "task", nil)},
+	})
+	m := &matchIDs{ids: map[string]bool{}} // would reject everything if consulted
+
+	_, ok, err := engineWithMatcher(t, cfg, fn, m).Resolve(context.Background(), testUser, base)
+
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Zero(t, m.seen, "a source without a condition must not consult a matcher")
+}
+
+// A wired lookup with no entry for this source must FAIL, not fall through to
+// "keep everything" — that would show the suggestion for entities the operator
+// excluded, which looks like the feature working. New() cannot catch this: the
+// lookup is opaque to it.
+func TestCondition_MissingMatcherFailsClosed(t *testing.T) {
+	t.Parallel()
+	fn, _ := staticCandidates(map[string][]*entity.Entity{
+		"Still on it?": {ent("T-1", "task", nil)},
+	})
+	st := memuserstate.New()
+	t.Cleanup(func() { _ = st.Close() })
+
+	eng, err := nextaction.New(conditionConfig(), st, fn,
+		nextaction.WithMatchers(func(string) (nextaction.Matcher, bool) { return nil, false }))
+	require.NoError(t, err)
+
+	_, _, err = eng.Resolve(context.Background(), testUser, base)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "no matcher was compiled")
+}
+
+func idFor(i int) string {
+	return "T-" + string(rune('a'+i%26)) + string(rune('a'+i/26))
+}

--- a/internal/nextaction/nextaction.go
+++ b/internal/nextaction/nextaction.go
@@ -74,6 +74,25 @@ type PickOption struct {
 // that has not wired it from failing every page.
 type OptionFunc func(ctx context.Context, query string, limit int) ([]PickOption, error)
 
+// MatcherFunc reports whether a candidate satisfies one source's `condition:`.
+// Supplied by the wiring site for the same reason as [CandidateFunc]: the
+// expression is compiled against the metamodel by a predicate engine this
+// package must not learn about, so the engine stays free of both.
+//
+// Returns (nil, false) for a source that declares no condition — the caller
+// then keeps every candidate. A compiled matcher is expected to be built ONCE
+// at config load, so an unparseable expression fails loudly at startup rather
+// than silently suppressing a suggestion forever.
+//
+// An evaluation error is NOT treated as "does not match": it is returned, so a
+// broken condition surfaces instead of quietly emptying a source.
+type MatcherFunc func(sourceID string) (Matcher, bool)
+
+// Matcher evaluates one source's compiled condition against a candidate.
+type Matcher interface {
+	Match(ctx context.Context, e *entity.Entity) (bool, error)
+}
+
 // CandidateFunc produces candidates for one source. Supplied by the wiring
 // site so this package depends on no store, searcher or ACL type: it is the
 // consumer-side interface that keeps the engine testable without a graph.
@@ -115,6 +134,7 @@ type Engine struct {
 	state      userstate.Store
 	candidates CandidateFunc
 	options    OptionFunc
+	matchers   MatcherFunc
 	cap        int
 }
 
@@ -130,6 +150,13 @@ type Option func(*Engine)
 // affordance simply offers nothing rather than failing the page.
 func WithOptions(fn OptionFunc) Option {
 	return func(e *Engine) { e.options = fn }
+}
+
+// WithMatchers supplies the per-source condition matchers. Without it a
+// source's `condition:` is not evaluated at all, so the option is required
+// whenever any source declares one — [New] enforces exactly that.
+func WithMatchers(fn MatcherFunc) Option {
+	return func(e *Engine) { e.matchers = fn }
 }
 
 // New builds an Engine. Every collaborator is required: a nil userstate.Store
@@ -151,6 +178,25 @@ func New(
 	e := &Engine{cfg: cfg, state: state, candidates: candidates, cap: DefaultCandidateCap}
 	for _, opt := range opts {
 		opt(e)
+	}
+	// A source declaring a condition with no matcher wired would evaluate as
+	// "keep every candidate" — the suggestion still appears, but for entities
+	// the operator explicitly excluded. That is worse than not starting: it
+	// looks like the feature works. Unlike a nil OptionFunc, which degrades to
+	// an affordance with no options, there is no safe degradation here.
+	if e.matchers == nil {
+		var withCondition []string
+		for id, src := range cfg.NextActions {
+			if src.Condition != "" {
+				withCondition = append(withCondition, id)
+			}
+		}
+		if len(withCondition) > 0 {
+			sort.Strings(withCondition) // deterministic message
+			return nil, fmt.Errorf(
+				"nextaction: source %q declares a condition but no matchers were supplied "+
+					"(pass WithMatchers)", withCondition[0])
+		}
 	}
 	return e, nil
 }
@@ -248,6 +294,40 @@ func (e *Engine) resolveBand(
 	return e.pick(user, eligible, now), true, nil
 }
 
+// applyCondition filters candidates by the source's compiled `condition:`.
+// A source with no condition, or an engine with no matchers wired, keeps every
+// candidate — [New] rejects the combination where that would be silent.
+func (e *Engine) applyCondition(
+	ctx context.Context, id string, src dataentryconfig.NextActionSource, cands []Candidate,
+) ([]Candidate, error) {
+	if src.Condition == "" {
+		return cands, nil
+	}
+	// A declared condition with no usable matcher must NOT fall through to
+	// "keep everything": that shows the suggestion for entities the operator
+	// explicitly excluded, which looks like the feature working. New() rejects
+	// the nil-matchers case at construction; this covers a lookup that has no
+	// entry for this source, which construction cannot see.
+	if e.matchers == nil {
+		return nil, fmt.Errorf("nextaction: source %q declares a condition but no matchers were supplied", id)
+	}
+	m, ok := e.matchers(id)
+	if !ok || m == nil {
+		return nil, fmt.Errorf("nextaction: source %q declares a condition but no matcher was compiled for it", id)
+	}
+	out := make([]Candidate, 0, len(cands))
+	for _, c := range cands {
+		match, err := m.Match(ctx, c.Entity)
+		if err != nil {
+			return nil, fmt.Errorf("nextaction: condition for %q: %w", id, err)
+		}
+		if match {
+			out = append(out, c)
+		}
+	}
+	return out, nil
+}
+
 // eligibleFromSource returns the suggestions one source contributes after
 // snooze and cooldown suppression.
 func (e *Engine) eligibleFromSource(
@@ -257,6 +337,20 @@ func (e *Engine) eligibleFromSource(
 	if err != nil {
 		return nil, fmt.Errorf("nextaction: candidates for %q: %w", id, err)
 	}
+
+	// The condition runs BEFORE the cap, and the order is load-bearing.
+	//
+	// The cap is justified by "a bounded candidate set is not lossy when only
+	// one candidate is displayed" (see the package doc) — true for suppression,
+	// which is per-suggestion bookkeeping. A condition is a SELECTION
+	// predicate, so truncating first makes the bound lossy: a condition
+	// matching only the 21st candidate would silently never fire, and the
+	// source would look correctly quiet rather than broken.
+	cands, err = e.applyCondition(ctx, id, src, cands)
+	if err != nil {
+		return nil, err
+	}
+
 	if len(cands) > e.cap {
 		cands = cands[:e.cap]
 	}

--- a/internal/projectsetup/validate.go
+++ b/internal/projectsetup/validate.go
@@ -104,6 +104,15 @@ func validateDataEntry(path string, mm *metamodel.Metamodel, fs storage.FS) erro
 	if issues := conditionlint.Lint(&cfg, mm); len(issues) > 0 {
 		return fmt.Errorf("condition errors:\n  %s", strings.Join(issues, "\n  "))
 	}
+
+	// Next-action `condition:` expressions are compiled here for real — they
+	// are evaluated server-side by the same Env, so this is authoritative
+	// rather than a sanity check. Failing at validate/startup is the point: a
+	// condition that does not compile would otherwise suppress its suggestion
+	// forever with no diagnostic.
+	if _, issues := conditionlint.CompileNextActions(&cfg, mm); len(issues) > 0 {
+		return fmt.Errorf("next-action condition errors:\n  %s", strings.Join(issues, "\n  "))
+	}
 	return nil
 }
 

--- a/tickets/entities/tickets/TKT-N8XQ2R.md
+++ b/tickets/entities/tickets/TKT-N8XQ2R.md
@@ -1,0 +1,107 @@
+---
+id: TKT-N8XQ2R
+type: ticket
+title: 'Next-action sources accept a condition expression, evaluated before the candidate cap'
+kind: enhancement
+priority: medium
+effort: m
+status: backlog
+---
+
+## Goal
+
+Make the dwell-time scenarios expressible. S1 ("proposal out 11 days, no reply
+— chase it?") and S4 ("SOW has been in draft a while") are two of the eight
+grounding scenarios in [[RES-09YLLL]] and neither can be configured today.
+
+The `stalled` and `blocking` bands exist and are documented; an operator has no
+way to say *what makes something stalled*.
+
+## Why it is blocked today
+
+A source's `query:` is search/filter syntax:
+
+```text
+src.Query -> queryCandidates -> executeQuery -> searchparser.ParseQuery -> internal/filter
+```
+
+`internal/filter` has no date arithmetic. `days_between(entity.due, today())`
+in a `query:` hits exactly the trap [[TKT-8GD41J]] removed for `when:` clauses:
+`filter.Parse` does not reject it, it mangles it into a filter on a property
+literally named `days_between(entity.due, today())`, which matches nothing,
+with no error at load and no warning at eval.
+
+The host functions now exist (`days_between`, `date_add`, `rrule_next` in
+`internal/predicatefns`, [[TKT-HQONQE]]). They are simply unreachable from a
+next-action source.
+
+## Scope
+
+Add `condition:` to `NextActionSource`: a predicate expression evaluated over
+the candidates `query:` selects. `query:` keeps selecting (filter syntax,
+unchanged); `condition:` refines (predicate syntax).
+
+Two keys rather than sniffing the dialect, for the reason [[TKT-8GD41J]] gives:
+the syntaxes overlap without erroring, so a heuristic would guess, and guess
+quietly.
+
+### The engine must not learn about predicates
+
+`internal/nextaction` deliberately depends on only `dataentryconfig`, `entity`
+and `userstate` — it does not even reach `store`. Keep it that way with a
+consumer-side interface (`docs/architecture/consumer-side-interfaces.md`):
+
+```go
+// ConditionMatcher reports whether a candidate satisfies a source's condition.
+type ConditionMatcher interface {
+    Match(ctx context.Context, e *entity.Entity) (bool, error)
+}
+```
+
+The wiring site holds the metamodel, compiles each source's `condition:` **once
+at config load**, and supplies the matcher — same shape as `CandidateFunc` and
+`userstate.Store`. A bad expression then fails loudly at startup, matching
+[[TKT-8GD41J]]'s fatal-on-unparseable choice.
+
+Matchers are per-source, so the engine takes a lookup
+(`func(sourceID) ConditionMatcher`) rather than putting a runtime type on
+`dataentryconfig.NextActionSource`.
+
+No arch-lint change: `nextaction` never imports `predicatefns`.
+
+## The cap ordering is load-bearing
+
+`eligibleFromSource` truncates to `DefaultCandidateCap` (20) **immediately**
+after `e.candidates(...)`, before suppression:
+
+```go
+cands, err := e.candidates(ctx, src)
+if len(cands) > e.cap { cands = cands[:e.cap] }
+```
+
+That order is fine for suppression, which is per-suggestion bookkeeping. It is
+**wrong for a condition**, which is a selection predicate: filtering after the
+cap means a condition matching only the 21st candidate silently never fires.
+
+That is the same silent-no-op class this whole line of work exists to remove,
+so the condition must be applied **before** truncation. Pin it with a test: a
+source with >20 candidates where only a late one matches.
+
+While here: `DefaultCandidateCap`'s comment says "see the package doc" for its
+rationale and there is no such doc. Write it down — the cap is about to become
+load-bearing for correctness, not just for cost.
+
+## Out of scope
+
+Pushing ordered comparison into SQL. `store.PropOp` stays equality-only (it
+cannot consult the metamodel), so conditions evaluate in Go per candidate over
+a bounded set — the same tradeoff `filter.Match` already makes, and acceptable
+at next-action scale (one suggestion, capped candidates).
+
+## Acceptance
+
+- A source may declare `condition:`; S1 and S4 are expressible end to end.
+- An unparseable `condition:` fails at config load, not at render.
+- A condition matching only a beyond-the-cap candidate still fires (test).
+- `internal/nextaction` still depends on only `dataentryconfig`, `entity`,
+  `userstate`.

--- a/tickets/entities/tickets/TKT-P5WK7D.md
+++ b/tickets/entities/tickets/TKT-P5WK7D.md
@@ -1,0 +1,106 @@
+---
+id: TKT-P5WK7D
+type: ticket
+title: 'predicatefns takes a consumer-side schema interface returning predicate types, not metamodel defs'
+kind: refactor
+priority: low
+effort: m
+status: backlog
+---
+
+## Goal
+
+`internal/predicatefns` imports `internal/metamodel` to answer one question per
+property: what `predicate.Type` is it, and how does a raw frontmatter value
+bind to a `predicate.Value`? Express that as a consumer-side interface so the
+package stops depending on the metamodel aggregate.
+
+## What it actually uses
+
+The whole surface, measured:
+
+- `meta.GetEntityDef` (x3) — only ever for `def.Properties`
+- `meta.Types[name]` (x1) — only to ask "is this a declared custom type?"
+- per property: `Type`, `List`, `GetDateFormat()`
+
+Nothing else. But note the *values* crossing the boundary are
+`metamodel.PropertyDef` and the `PropertyType*` constants, so an interface that
+hands back schema fields narrows the coupling without removing the import.
+
+## The cut that does remove it
+
+Return the **decision**, not the ingredients. The mapping
+`PropertyDef -> predicate.Type` is a pure function, and `predicate` is already
+metamodel-free (arch-fenced), so:
+
+```go
+type Schema interface {
+    // FieldType is the predicate type of entityType.prop. ok=false means
+    // unmodellable or unknown, and the caller omits it — a reference then
+    // fails at compile rather than evaluating against a wrong type.
+    FieldType(entityType, prop string) (predicate.Type, bool)
+    Fields(entityType string) (map[string]predicate.Type, bool)
+    BindField(entityType, prop string, raw any) predicate.Value
+}
+```
+
+`List` collapses into the implementation (it wraps in `ListType`), the date
+layout collapses into `DateTypeWithLayout`, and the `Type` switch goes with
+them.
+
+`BindField` must be in the same interface as `FieldType`: `Compile` needs
+types, `Matches` needs values, and the two must agree or a value's runtime type
+contradicts its compile-time type. Today those are two switches in separate
+files (`ScalarType` in env.go, `coerceScalar` in bind.go) kept in agreement by
+hand — `affordances/bindings.go:180` documents the invariant in a comment
+rather than enforcing it. Colocating them is a improvement on its own.
+
+## Why the type info is worth preserving exactly
+
+It is what turns a config typo into a startup failure instead of a silent
+no-match:
+
+1. `entity.duedate` for `due_date` is a `CompileError` ("unknown attribute"),
+   not an expression that evaluates nil forever.
+2. `entity.due <= today()` compares dates, not strings — string comparison
+   happens to work for ISO and breaks for every other layout, which is why the
+   format is per-property.
+3. An unmodellable property (`file`) is omitted, so referencing it fails at
+   compile rather than lying at eval.
+
+Any subset that loses one of these trades a loud failure for a quiet one.
+
+## Migration hazard: the date fallback chain
+
+`coerceDate` does not use `GetDateFormat()` directly — it calls
+`metamodel.ParseDateValue(v, prop)`, which is `GetDateFormat()` **plus a
+hardcoded fallback list** (RFC3339, ISO-with-Z, ISO-without-timezone,
+date-only).
+
+Move the layout without the fallbacks and a `date` property storing
+`2026-03-01T10:00:00Z` stops parsing — it binds `Nil`, so the condition
+silently stops matching. No error. The fallback chain has to travel with the
+layout or become part of the injected contract; either way, pin it with a test
+per fallback format.
+
+## Do not regress RR-TBG91
+
+`internal/affordances` imports `predicatefns.ScalarTypeForProp` on purpose, as
+the single canonical adapter. Whatever implements `Schema` becomes that
+adapter and `affordances` must use it — two copies of the mapping is the thing
+RR-TBG91 exists to prevent.
+
+## Not a blocker
+
+[[TKT-N8XQ2R]] needs none of this: it keeps `predicatefns` behind a one-method
+matcher supplied at the wiring site, so `internal/nextaction` never sees a
+schema either way. Sequence this independently.
+
+## Acceptance
+
+- `internal/predicatefns` does not import `internal/metamodel` on the compile
+  or bind path.
+- `affordances` and `predicatefns` still share one type-mapping implementation.
+- Date fallback formats are preserved, with a test per format.
+- `predicatefns` tests can construct a schema fake without building a
+  `*metamodel.Metamodel`.

--- a/tickets/relations/TKT-N8XQ2R--affects--data-entry-ui.md
+++ b/tickets/relations/TKT-N8XQ2R--affects--data-entry-ui.md
@@ -1,0 +1,5 @@
+---
+from: TKT-N8XQ2R
+relation: affects
+to: data-entry-ui
+---

--- a/tickets/relations/TKT-N8XQ2R--implements--FEAT-79DTF9.md
+++ b/tickets/relations/TKT-N8XQ2R--implements--FEAT-79DTF9.md
@@ -1,0 +1,5 @@
+---
+from: TKT-N8XQ2R
+relation: implements
+to: FEAT-79DTF9
+---

--- a/tickets/relations/TKT-P5WK7D--affects--metamodel-types.md
+++ b/tickets/relations/TKT-P5WK7D--affects--metamodel-types.md
@@ -1,0 +1,5 @@
+---
+from: TKT-P5WK7D
+relation: affects
+to: metamodel-types
+---

--- a/tickets/relations/TKT-P5WK7D--implements--FEAT-79DTF9.md
+++ b/tickets/relations/TKT-P5WK7D--implements--FEAT-79DTF9.md
@@ -1,0 +1,5 @@
+---
+from: TKT-P5WK7D
+relation: implements
+to: FEAT-79DTF9
+---


### PR DESCRIPTION
Makes S1/S4 from RES-09YLLL expressible — the dwell-time scenarios ("proposal
out 11 days, no reply — chase it?") that motivated the whole feature and were
the only reason FEAT-79DTF9 was still `in-progress`.

Stacked on #1391 (the two tickets); review that first or read the second commit
alone.

## The gap

#1380 landed `days_between` / `date_add` / `rrule_next`, but they were
unreachable from a next-action source: `query:` is filter syntax
(`searchparser` → `internal/filter`), which has no date arithmetic and does not
*reject* an expression — it mangles it into a filter on a property literally
named `days_between(entity.due, today())`, matching nothing, silently.

## Shape

`query:` selects, `condition:` refines:

```yaml
chase-proposal:
  band: blocking
  query: "type:proposal prop:status=sent"
  condition: "days_between(entity.sent_on, today()) >= 11"
```

Two keys rather than sniffing the dialect — the syntaxes overlap without
erroring, so a heuristic would guess quietly (the same reasoning TKT-8GD41J
used for `condition:` vs `when:`).

**The engine never learns about predicates.** `internal/nextaction` keeps its
three-package dependency set (`dataentryconfig`, `entity`, `userstate`) behind
a one-method `Matcher` seam, exactly like `CandidateFunc` and `userstate.Store`.
`conditionlint` compiles, `appbuild` bridges, `dataentry` takes the seam. No
arch-lint change for nextaction or dataentry.

## Two ordering decisions that carry the correctness

**Conditions run BEFORE the candidate cap.** The cap is justified by "a bounded
candidate set is not lossy when only one candidate is displayed" — true for
suppression, which is per-suggestion bookkeeping. A condition is a *selection*
predicate, so truncating first makes the bound lossy: a condition matching only
the 21st candidate would silently never fire, and the source would look
correctly quiet rather than broken. Pinned by
`TestCondition_MatchesBeyondTheCandidateCap`, verified by mutation (moving the
cap back above the filter fails it).

**A condition must be valid on EVERY type the query names.** `query:` carries
`EntityTypes []string`; a predicate compiles against one type. A condition valid
on only some of them would silently drop the rest's candidates, so it is refused
at load — same rule as the pushdown's `stringComparableOnEveryType`. A query
naming no type is likewise refused: there is nothing to check `entity.<prop>`
against.

Everything fails closed and at load: a typo, an unknown type, a `count:` source,
a missing compiled matcher.

## Verified against a live binary

Not just unit tests — the five behaviours were exercised through `rela validate`
on a scratch project, which is what caught that my first attempt was testing a
stale binary:

| Config | Result |
|---|---|
| valid date-arithmetic condition | passes |
| `entity.dew` typo | `unknown attribute "dew" on record` |
| query spans `task`+`note`, only task has `due` | refused, naming `note` |
| query names no type | refused with the `type:task …` hint |
| condition on a `count:` source | refused |

## Checks

`go build` (3 tags), full suite, golangci-lint (0 issues), arch-lint, plimsoll,
markdownlint, docs freshness, coverage 78.2% (both thresholds PASS).

One thing worth flagging for CI: `internal/dataentry` under `-race` takes
300–433s standalone and **timed out at Go's 10-minute default** during a
full-tree coverage run under load. Reproduced at 321s on a clean tree without
this change, so it is pre-existing capacity, not a regression — but it will
flake. Re-ran with `-timeout=25m`: whole tree clean, exit 0.