### PR TITLE
🌍 feat(store): world-scoped entity queries on fs/mem (TKT-WAV8XP PR-B)

### DIFF
--- a/internal/acl/readquery.go
+++ b/internal/acl/readquery.go
@@ -73,6 +73,20 @@ func (r *Request) readQuery(ctx context.Context, entityType string) ReadQueryRes
 		return ReadQueryResult{DenyAll: true}
 	}
 
+	// World is deliberately left ZERO here, which means the DEFAULT world
+	// (store.WorldScope's zero value). This is NOT an assertion that the
+	// ACL path is world-safe: a world-scoped read must have its scope
+	// INJECTED from above by the world-resolved reader (internal/worldreader,
+	// TKT-WAV8XP PR-D), which is the layer that owns a compiled WorldScope.
+	//
+	// internal/acl structurally cannot resolve one itself — arch-lint
+	// forbids it from importing internal/metamodel, and a WorldScope is
+	// compiled from the metamodel. So the seam belongs above this package,
+	// not in it. Until PR-D wires that injection, store.GraphQuery.World is
+	// honored by the backends (PR-B) but never set on this path.
+	//
+	// Do NOT "fix" this by giving internal/acl a metamodel dependency: that
+	// breaks the boundary that keeps ACL evaluable without a schema.
 	q := &store.GraphQuery{
 		EntityType: entityType,
 		HasInbound: &store.RelationPredicate{

--- a/internal/store/fsstore/conformance_test.go
+++ b/internal/store/fsstore/conformance_test.go
@@ -49,7 +49,7 @@ func visibleSearchFactory(t *testing.T) (store.Store, search.Searcher, search.Vi
 }
 
 func TestConformance(t *testing.T) {
-	storetest.RunAll(t, factory, searchFactory, visibleSearchFactory, storetest.Capabilities{Attachments: true})
+	storetest.RunAll(t, factory, searchFactory, visibleSearchFactory, storetest.Capabilities{Attachments: true, Worlds: true})
 }
 
 func FuzzRelationKeyCollision(f *testing.F) {

--- a/internal/store/fsstore/entity.go
+++ b/internal/store/fsstore/entity.go
@@ -34,6 +34,9 @@ func (s *FSStore) GetEntityState(_ context.Context, id string, p entity.Pointer)
 }
 
 func (s *FSStore) ListEntities(_ context.Context, q store.EntityQuery) iter.Seq2[*entity.Entity, error] {
+	if err := storeutil.ValidateEntityQuery(q); err != nil {
+		return func(yield func(*entity.Entity, error) bool) { yield(nil, err) }
+	}
 	s.mu.RLock()
 	idSet := entityIDSet(q.IDs)
 
@@ -46,6 +49,8 @@ func (s *FSStore) ListEntities(_ context.Context, q store.EntityQuery) iter.Seq2
 		matches = append(matches, s.entities[key])
 	}
 	s.mu.RUnlock()
+
+	matches = keepPrimes(q.World, matches)
 
 	return func(yield func(*entity.Entity, error) bool) {
 		for _, m := range matches {
@@ -64,6 +69,9 @@ func (s *FSStore) ListEntities(_ context.Context, q store.EntityQuery) iter.Seq2
 }
 
 func (s *FSStore) ListEntitiesPage(_ context.Context, q store.EntityQuery) (store.Page[*entity.Entity], error) {
+	if err := storeutil.ValidateEntityQuery(q); err != nil {
+		return store.Page[*entity.Entity]{}, err
+	}
 	cursorKey, err := storeutil.DecodeCursor(q.Cursor)
 	if err != nil {
 		return store.Page[*entity.Entity]{}, err
@@ -71,9 +79,25 @@ func (s *FSStore) ListEntitiesPage(_ context.Context, q store.EntityQuery) (stor
 
 	s.mu.RLock()
 	idSet := entityIDSet(q.IDs)
-	keys := storeutil.PaginateSortedKeys(s.entityOrder, cursorKey, q.Limit, func(id string) bool {
-		return matchEntityQuery(s.entities[id], q, idSet)
-	})
+	matches := func(id string) bool { return matchEntityQuery(s.entities[id], q, idSet) }
+
+	var keys storeutil.PageKeys
+	if q.World.IsDefaultWorld() {
+		keys = storeutil.PaginateSortedKeysFunc(
+			s.entityOrder, cursorKey, q.Limit, matches, storeutil.CompareStateKeys)
+	} else {
+		// The world path buffers ONE family at a time and counts PRIMES
+		// against the limit — see storeutil.PaginateWorldPrimes.
+		keys = storeutil.PaginateWorldPrimes(
+			s.entityOrder, cursorKey, q.Limit, q.World, matches,
+			func(key string) (storeutil.WorldCandidate, bool) {
+				m, ok := s.entities[key]
+				if !ok {
+					return storeutil.WorldCandidate{}, false
+				}
+				return storeutil.WorldCandidate{ID: m.ID, Type: m.Type, Pointer: m.Pointer}, true
+			})
+	}
 
 	// Capture metas while still holding the lock — loading needs the
 	// type and pointer and we must not do I/O under the lock.
@@ -109,36 +133,65 @@ func entityIDSet(ids []string) map[string]bool {
 	return set
 }
 
-// matchEntityQuery reports whether an indexed entity satisfies q's
-// Type, IDs, and AllStates filters. idSet must be pre-computed from
-// q.IDs and matches the BARE id, so IDs+AllStates selects every state
-// of the listed entities.
+// matchEntityQuery adapts this backend's index metadata to the shared
+// rule in storeutil. The rule itself must not live here: memstore
+// applies the identical filter, and the two byte-similar copies this
+// replaced are exactly the drift storetest exists to catch.
 func matchEntityQuery(m entityMeta, q store.EntityQuery, idSet map[string]bool) bool {
-	if !q.AllStates && !m.Pointer.IsDefault() {
-		return false
-	}
-	if q.Type != "" && m.Type != q.Type {
-		return false
-	}
-	if len(idSet) > 0 && !idSet[m.ID] {
-		return false
-	}
-	return true
+	return storeutil.MatchEntityQuery(m.Type, m.ID, m.Pointer, q, idSet)
 }
 
 func (s *FSStore) CountEntities(_ context.Context, q store.EntityQuery) (int, error) {
+	if err := storeutil.ValidateEntityQuery(q); err != nil {
+		return 0, err
+	}
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
 	idSet := entityIDSet(q.IDs)
 
-	count := 0
+	// The default world resolves every row to itself, so counting needs
+	// no buffer — and this is the common path for a project that never
+	// declares a pointer, which must stay allocation-free.
+	if q.World.IsDefaultWorld() {
+		n := 0
+		for _, meta := range s.entities {
+			if matchEntityQuery(meta, q, idSet) {
+				n++
+			}
+		}
+		return n, nil
+	}
+
+	matches := make([]entityMeta, 0)
 	for _, meta := range s.entities {
 		if matchEntityQuery(meta, q, idSet) {
-			count++
+			matches = append(matches, meta)
 		}
 	}
-	return count, nil
+	// Counts must be world-scoped, not raw: an unscoped tally tells a
+	// published-world surface how many unpublished drafts exist.
+	return len(keepPrimes(q.World, matches)), nil
+}
+
+// keepPrimes resolves a world over matched index metadata, returning
+// only each entity's prime. A no-op for the default world.
+func keepPrimes(w store.WorldScope, metas []entityMeta) []entityMeta {
+	if w.IsDefaultWorld() || len(metas) == 0 {
+		return metas
+	}
+	cands := make([]storeutil.WorldCandidate, len(metas))
+	for i, m := range metas {
+		cands[i] = storeutil.WorldCandidate{ID: m.ID, Type: m.Type, Pointer: m.Pointer}
+	}
+	primes := storeutil.WorldPrimes(w, cands)
+	kept := make([]entityMeta, 0, len(primes))
+	for _, m := range metas {
+		if p, ok := primes[m.ID]; ok && p == m.Pointer {
+			kept = append(kept, m)
+		}
+	}
+	return kept
 }
 
 func (s *FSStore) HighestID(_ context.Context, prefix string) (int, error) {
@@ -278,7 +331,7 @@ func (s *FSStore) createEntity(_ context.Context, e *entity.Entity) error {
 
 	// Update index
 	s.entities[key] = entityMeta{ID: e.ID, Type: e.Type, Pointer: e.Pointer}
-	s.entityOrder = storeutil.SortedInsert(s.entityOrder, key)
+	s.entityOrder = storeutil.SortedInsertFunc(s.entityOrder, key, storeutil.CompareStateKeys)
 	if stored.Pointer.IsDefault() {
 		addEntityToCache(s.propCache, stored)
 	}
@@ -437,7 +490,7 @@ func (s *FSStore) deleteEntity(_ context.Context, id string, cascade bool) (*sto
 	for i, meta := range family {
 		key := stateKey(meta.ID, meta.Pointer)
 		delete(s.entities, key)
-		s.entityOrder = storeutil.SortedRemove(s.entityOrder, key)
+		s.entityOrder = storeutil.SortedRemoveFunc(s.entityOrder, key, storeutil.CompareStateKeys)
 		if meta.Pointer.IsDefault() {
 			removeEntityFromCache(s.propCache, states[i])
 		}
@@ -572,10 +625,10 @@ func (s *FSStore) renameEntity(_ context.Context, oldID, newID string) (*store.R
 	for _, meta := range family {
 		oldKey := stateKey(meta.ID, meta.Pointer)
 		delete(s.entities, oldKey)
-		s.entityOrder = storeutil.SortedRemove(s.entityOrder, oldKey)
+		s.entityOrder = storeutil.SortedRemoveFunc(s.entityOrder, oldKey, storeutil.CompareStateKeys)
 		newKey := stateKey(newID, meta.Pointer)
 		s.entities[newKey] = entityMeta{ID: newID, Type: meta.Type, Pointer: meta.Pointer}
-		s.entityOrder = storeutil.SortedInsert(s.entityOrder, newKey)
+		s.entityOrder = storeutil.SortedInsertFunc(s.entityOrder, newKey, storeutil.CompareStateKeys)
 	}
 	// Observers key documents by bare id: a headless family (tolerated
 	// from disk) has NO default face to rename in the index, and handing

--- a/internal/store/fsstore/fsstore.go
+++ b/internal/store/fsstore/fsstore.go
@@ -23,6 +23,7 @@ import (
 	"log/slog"
 	"os"
 	"path"
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -30,6 +31,7 @@ import (
 	"github.com/Sourcehaven-BV/rela/internal/entity"
 	"github.com/Sourcehaven-BV/rela/internal/storage"
 	"github.com/Sourcehaven-BV/rela/internal/store"
+	"github.com/Sourcehaven-BV/rela/internal/store/storeutil"
 )
 
 // recentHashCapacity bounds how many recently-written file hashes are
@@ -459,6 +461,25 @@ func (s *FSStore) cleanupTempFiles() {
 			_ = s.rooted.Remove(p)
 		}
 	}
+}
+
+// sortStateKeys sorts entity state keys ("id" or "id@pointer") by the
+// (bare id, pointer) tuple, the ordering every entityOrder mutation
+// uses (storeutil.SortedInsertFunc / SortedRemoveFunc with
+// storeutil.CompareStateKeys).
+//
+// The index CONSTRUCTION paths must use the same comparator as the
+// mutation paths or the slice is sorted one way and binary-searched
+// another: SortedRemoveFunc then misses a key that is present and
+// panics, on the ordinary default-world delete path after any process
+// restart. Plain sortStrings is wrong here because '@' (0x40) sorts
+// after the digits (0x30-0x39), so PAGE-10's family lands inside
+// PAGE-1's. See storeutil.CompareStateKeys.
+//
+// relationOrder is NOT sorted with this — relations carry no pointer,
+// so plain string order is correct there.
+func sortStateKeys(keys []string) {
+	slices.SortFunc(keys, storeutil.CompareStateKeys)
 }
 
 // sortStrings sorts a string slice in place.

--- a/internal/store/fsstore/index.go
+++ b/internal/store/fsstore/index.go
@@ -124,7 +124,7 @@ func (s *FSStore) syncEntities(cached *persistedIndex) error {
 			s.entities[key] = entityMeta(ie)
 			s.entityOrder = append(s.entityOrder, key)
 		}
-		sortStrings(s.entityOrder)
+		sortStateKeys(s.entityOrder)
 		return nil
 	}
 
@@ -243,7 +243,7 @@ func (s *FSStore) scanEntityDirs() error {
 		}
 	}
 
-	sortStrings(s.entityOrder)
+	sortStateKeys(s.entityOrder)
 	return nil
 }
 

--- a/internal/store/fsstore/states_reopen_order_test.go
+++ b/internal/store/fsstore/states_reopen_order_test.go
@@ -1,0 +1,121 @@
+package fsstore_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/Sourcehaven-BV/rela/internal/entity"
+	"github.com/Sourcehaven-BV/rela/internal/storage"
+	"github.com/Sourcehaven-BV/rela/internal/store"
+)
+
+// TestReopenPreservesStateKeyOrdering pins the index CONSTRUCTION paths
+// to the same comparator the mutation paths use (TKT-WAV8XP PR-B).
+//
+// entityOrder is maintained by storeutil.SortedInsertFunc /
+// SortedRemoveFunc under storeutil.CompareStateKeys — the (bare id,
+// pointer) tuple. If a construction path sorts by plain string order
+// instead, the slice is sorted one way and binary-searched another. The
+// symptom is NOT subtle and NOT world-specific: SortedRemoveFunc misses
+// a key that is present and PANICS on the ordinary default-world delete
+// path, on every process restart.
+//
+// The ids are the Ruling-1 hazard set: '@' is 0x40 and the digits are
+// 0x30-0x39, so '@' sorts after any digit and PAGE-10's family lands
+// inside PAGE-1's under plain string order.
+//
+// The shared conformance suite cannot catch this — its factory only ever
+// builds a fresh store and never reopens one, so it never exercises
+// index reconstruction at all.
+func TestReopenPreservesStateKeyOrdering(t *testing.T) {
+	hazardIDs := []string{"PAGE-1", "PAGE-10", "PAGE-2"}
+
+	seed := func(t *testing.T, fs *storage.MemFS) {
+		t.Helper()
+		s := openStore(t, fs)
+		ctx := context.Background()
+		for _, id := range hazardIDs {
+			require.NoError(t, s.CreateEntity(ctx, &entity.Entity{
+				ID: id, Type: "thing", Properties: map[string]any{"title": id + " default"},
+			}))
+			require.NoError(t, s.CreateEntity(ctx, &entity.Entity{
+				ID: id, Type: "thing", Pointer: entity.Pointer("published"),
+				Properties: map[string]any{"title": id + " published"},
+			}))
+		}
+		require.NoError(t, s.Close())
+	}
+
+	// Both construction paths must be covered: syncEntities restores from
+	// the cached index when the entities-dir mtime is unchanged, and cold-
+	// scans the directory tree otherwise. They sort entityOrder separately.
+	for _, tc := range []struct {
+		name      string
+		dropCache bool
+	}{
+		{name: "CachedIndexRestore", dropCache: false},
+		{name: "ColdDirectoryScan", dropCache: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			fs := storage.NewMemFS()
+			seed(t, fs)
+			if tc.dropCache {
+				// Force the cold scan by removing the persisted index.
+				_ = fs.Remove("/.rela/fsstore-index.json")
+			}
+
+			s := openStore(t, fs)
+			defer func() { _ = s.Close() }()
+			ctx := context.Background()
+
+			// A world-scoped page must resolve each family to its
+			// published face, one prime per entity, across every page
+			// boundary. Under a mis-sorted index PAGE-1 yields twice.
+			world := store.NewWorldScope(map[string]store.TypeResolution{
+				"thing": {
+					Chain:    []entity.Pointer{entity.Pointer("published")},
+					Fallback: store.FallbackDefaultState,
+				},
+			})
+			want := map[string]string{
+				"PAGE-1":  "PAGE-1 published",
+				"PAGE-10": "PAGE-10 published",
+				"PAGE-2":  "PAGE-2 published",
+			}
+			for _, limit := range []int{1, 2, 3} {
+				got := map[string]string{}
+				cursor := ""
+				for range 10 { // bounded: 3 primes
+					page, err := s.ListEntitiesPage(ctx, store.EntityQuery{
+						Type: "thing", World: world, Limit: limit, Cursor: cursor,
+					})
+					require.NoError(t, err)
+					for _, e := range page.Items {
+						if prev, dup := got[e.ID]; dup {
+							t.Fatalf("limit %d: %s yielded twice (%q then %q)",
+								limit, e.ID, prev, e.GetString("title"))
+						}
+						got[e.ID] = e.GetString("title")
+					}
+					if page.NextCursor == "" {
+						break
+					}
+					cursor = page.NextCursor
+				}
+				assert.Equal(t, want, got, "paging with limit %d after reopen", limit)
+			}
+
+			// The default-world delete path must not panic. This is the
+			// symptom that has nothing to do with worlds.
+			_, err := s.DeleteEntity(ctx, "PAGE-1", false)
+			require.NoError(t, err, "delete after reopen")
+
+			n, err := s.CountEntities(ctx, store.EntityQuery{Type: "thing"})
+			require.NoError(t, err)
+			assert.Equal(t, 2, n, "default-state count after deleting one family")
+		})
+	}
+}

--- a/internal/store/fsstore/watcher.go
+++ b/internal/store/fsstore/watcher.go
@@ -212,7 +212,7 @@ func (s *FSStore) reconcileEntityPath(path string) {
 	}
 	s.entities[key] = entityMeta{ID: e.ID, Type: e.Type, Pointer: e.Pointer}
 	if !known {
-		s.entityOrder = storeutil.SortedInsert(s.entityOrder, key)
+		s.entityOrder = storeutil.SortedInsertFunc(s.entityOrder, key, storeutil.CompareStateKeys)
 	}
 	if e.Pointer.IsDefault() {
 		addEntityToCache(s.propCache, e)
@@ -247,7 +247,7 @@ func (s *FSStore) handleEntityRemoval(path string) {
 		}
 	}
 	delete(s.entities, stem)
-	s.entityOrder = storeutil.SortedRemove(s.entityOrder, stem)
+	s.entityOrder = storeutil.SortedRemoveFunc(s.entityOrder, stem, storeutil.CompareStateKeys)
 	if meta.Pointer.IsDefault() {
 		// Observer deletions are bare-id keyed; a state removal must
 		// not evict the default face from the search index (Step-1

--- a/internal/store/graphquery.go
+++ b/internal/store/graphquery.go
@@ -27,6 +27,24 @@ type GraphQuery struct {
 	Props       []PropPredicate    // entity's own properties match (AND)
 	HasInbound  *RelationPredicate // entity has matching relation FROM (expanded) endpoints
 	HasOutbound *RelationPredicate // entity has matching relation TO (expanded) endpoints
+
+	// World scopes the RESULT to each entity's prime under the compiled
+	// world, exactly as [EntityQuery.World] does. The zero value is the
+	// default world.
+	//
+	// It must live here as well as on EntityQuery, not only there: the
+	// ACL read path swaps an EntityQuery for a GraphQuery the moment a
+	// policy query exists (internal/visibility/pushdown.go), and the
+	// AllowAll principal takes the EntityQuery branch. A world carried
+	// on only one of the two would make the list path and the
+	// single-entity path disagree — and would do so precisely for the
+	// privileged principal.
+	//
+	// Scoping applies to the entities the query RETURNS. Relation
+	// predicates walk the graph's identity structure and are NOT
+	// world-resolved: who an entity is related to must not depend on the
+	// reader's world.
+	World WorldScope
 }
 
 // PropOp is the comparison a [PropPredicate] applies. Deliberately only

--- a/internal/store/graphquerynaive/naive.go
+++ b/internal/store/graphquerynaive/naive.go
@@ -48,7 +48,7 @@ const depthCap = DepthCap
 // the iterator.
 func Run(ctx context.Context, r Reader, q store.GraphQuery) iter.Seq2[*entity.Entity, error] {
 	return func(yield func(*entity.Entity, error) bool) {
-		candidates, err := collectByType(ctx, r, q.EntityType)
+		candidates, err := collectByType(ctx, r, q.EntityType, q.World)
 		if err != nil {
 			yield(nil, err)
 			return
@@ -72,7 +72,7 @@ func Run(ctx context.Context, r Reader, q store.GraphQuery) iter.Seq2[*entity.En
 
 // Count returns (matched, total) for q against r.
 func Count(ctx context.Context, r Reader, q store.GraphQuery) (matched, total int, err error) {
-	candidates, err := collectByType(ctx, r, q.EntityType)
+	candidates, err := collectByType(ctx, r, q.EntityType, q.World)
 	if err != nil {
 		return 0, 0, err
 	}
@@ -101,7 +101,7 @@ func MatchingIDs(ctx context.Context, r Reader, q store.GraphQuery, ids []string
 	if len(out) == 0 {
 		return out, nil
 	}
-	for e, err := range r.ListEntities(ctx, store.EntityQuery{Type: q.EntityType}) {
+	for e, err := range r.ListEntities(ctx, store.EntityQuery{Type: q.EntityType, World: q.World}) {
 		if err != nil {
 			return nil, err
 		}
@@ -117,9 +117,20 @@ func MatchingIDs(ctx context.Context, r Reader, q store.GraphQuery, ids []string
 	return out, nil
 }
 
-func collectByType(ctx context.Context, r Reader, typ string) ([]*entity.Entity, error) {
+// collectByType seeds the candidate set: the entities the query may
+// RETURN, so it carries the world (store.GraphQuery.World). The relation
+// walks in matches() deliberately do NOT — who an entity is related to
+// must not depend on the reader's world.
+//
+// Passing the world here is load-bearing rather than cosmetic. The ACL
+// read path swaps an EntityQuery for a GraphQuery as soon as a policy
+// query exists (internal/visibility/pushdown.go), so dropping it would
+// make a world-scoped list silently degrade to unscoped for exactly the
+// gated principals: under `otherwise: exclude` the entities the world
+// meant to hide become visible, and a published world serves drafts.
+func collectByType(ctx context.Context, r Reader, typ string, w store.WorldScope) ([]*entity.Entity, error) {
 	var out []*entity.Entity
-	for e, err := range r.ListEntities(ctx, store.EntityQuery{Type: typ}) {
+	for e, err := range r.ListEntities(ctx, store.EntityQuery{Type: typ, World: w}) {
 		if err != nil {
 			return nil, err
 		}

--- a/internal/store/memstore/conformance_test.go
+++ b/internal/store/memstore/conformance_test.go
@@ -39,7 +39,7 @@ func fuzzFactory() store.Store {
 }
 
 func TestConformance(t *testing.T) {
-	storetest.RunAll(t, factory, searchFactory, visibleSearchFactory, storetest.Capabilities{Attachments: true})
+	storetest.RunAll(t, factory, searchFactory, visibleSearchFactory, storetest.Capabilities{Attachments: true, Worlds: true})
 }
 
 func FuzzRelationKeyCollision(f *testing.F) {

--- a/internal/store/memstore/memstore.go
+++ b/internal/store/memstore/memstore.go
@@ -174,6 +174,39 @@ var (
 	sortedRemove     = storeutil.SortedRemove
 )
 
+// The ENTITY order is keyed by state key ("id" or "id@pointer") and must
+// sort as the tuple (bare id, pointer) so an entity's states stay
+// contiguous — see storeutil.CompareStateKeys for why plain string order
+// splits a family. Relations keep plain string order; their keys are not
+// state keys.
+func entityInsert(s []string, key string) []string {
+	return storeutil.SortedInsertFunc(s, key, storeutil.CompareStateKeys)
+}
+
+func entityRemove(s []string, key string) []string {
+	return storeutil.SortedRemoveFunc(s, key, storeutil.CompareStateKeys)
+}
+
+// worldKeep resolves a world over matched entities, returning only each
+// entity's prime. A no-op for the default world (TKT-WAV8XP).
+func worldKeep(w store.WorldScope, matched []*entity.Entity) []*entity.Entity {
+	if w.IsDefaultWorld() || len(matched) == 0 {
+		return matched
+	}
+	cands := make([]storeutil.WorldCandidate, len(matched))
+	for i, e := range matched {
+		cands[i] = storeutil.WorldCandidate{ID: e.ID, Type: e.Type, Pointer: e.Pointer}
+	}
+	primes := storeutil.WorldPrimes(w, cands)
+	kept := make([]*entity.Entity, 0, len(primes))
+	for _, e := range matched {
+		if p, ok := primes[e.ID]; ok && p == e.Pointer {
+			kept = append(kept, e)
+		}
+	}
+	return kept
+}
+
 // idTaken reports whether any key of index case-folds to the same identity as
 // id. except is skipped so a rename can ask "does any OTHER entity claim this
 // identity?" without self-colliding.
@@ -235,6 +268,9 @@ func (m *MemStore) GetEntityState(_ context.Context, id string, p entity.Pointer
 }
 
 func (m *MemStore) ListEntities(_ context.Context, q store.EntityQuery) iter.Seq2[*entity.Entity, error] {
+	if err := storeutil.ValidateEntityQuery(q); err != nil {
+		return func(yield func(*entity.Entity, error) bool) { yield(nil, err) }
+	}
 	m.mu.RLock()
 	idSet := entityIDSet(q.IDs)
 
@@ -247,6 +283,8 @@ func (m *MemStore) ListEntities(_ context.Context, q store.EntityQuery) iter.Seq
 		snapshot = append(snapshot, e.Clone())
 	}
 	m.mu.RUnlock()
+
+	snapshot = worldKeep(q.World, snapshot)
 
 	return func(yield func(*entity.Entity, error) bool) {
 		for _, e := range snapshot {
@@ -269,15 +307,26 @@ func (m *MemStore) ListEntities(_ context.Context, q store.EntityQuery) iter.Seq
 func (m *MemStore) ListEntityHeaders(
 	_ context.Context, q store.EntityQuery,
 ) iter.Seq2[store.EntityHeader, error] {
+	if err := storeutil.ValidateEntityQuery(q); err != nil {
+		return func(yield func(store.EntityHeader, error) bool) { yield(store.EntityHeader{}, err) }
+	}
 	m.mu.RLock()
 	idSet := entityIDSet(q.IDs)
 
-	snapshot := make([]store.EntityHeader, 0)
+	matched := make([]*entity.Entity, 0)
 	for _, id := range m.entityOrder {
 		e := m.entities[id]
 		if !matchEntityQuery(e, q, idSet) {
 			continue
 		}
+		matched = append(matched, e)
+	}
+	// Resolve BEFORE projecting: the world picks whole rows, and a
+	// header carries the pointer that identifies which face it is.
+	matched = worldKeep(q.World, matched)
+
+	snapshot := make([]store.EntityHeader, 0, len(matched))
+	for _, e := range matched {
 		snapshot = append(snapshot, store.EntityHeader{
 			ID:         e.ID,
 			Type:       e.Type,
@@ -298,6 +347,9 @@ func (m *MemStore) ListEntityHeaders(
 }
 
 func (m *MemStore) ListEntitiesPage(_ context.Context, q store.EntityQuery) (store.Page[*entity.Entity], error) {
+	if err := storeutil.ValidateEntityQuery(q); err != nil {
+		return store.Page[*entity.Entity]{}, err
+	}
 	cursorKey, err := storeutil.DecodeCursor(q.Cursor)
 	if err != nil {
 		return store.Page[*entity.Entity]{}, err
@@ -307,9 +359,25 @@ func (m *MemStore) ListEntitiesPage(_ context.Context, q store.EntityQuery) (sto
 	defer m.mu.RUnlock()
 
 	idSet := entityIDSet(q.IDs)
-	keys := storeutil.PaginateSortedKeys(m.entityOrder, cursorKey, q.Limit, func(id string) bool {
-		return matchEntityQuery(m.entities[id], q, idSet)
-	})
+	matches := func(id string) bool { return matchEntityQuery(m.entities[id], q, idSet) }
+
+	var keys storeutil.PageKeys
+	if q.World.IsDefaultWorld() {
+		keys = storeutil.PaginateSortedKeysFunc(
+			m.entityOrder, cursorKey, q.Limit, matches, storeutil.CompareStateKeys)
+	} else {
+		// The world path buffers ONE family at a time and counts PRIMES
+		// against the limit — see storeutil.PaginateWorldPrimes.
+		keys = storeutil.PaginateWorldPrimes(
+			m.entityOrder, cursorKey, q.Limit, q.World, matches,
+			func(key string) (storeutil.WorldCandidate, bool) {
+				e, ok := m.entities[key]
+				if !ok {
+					return storeutil.WorldCandidate{}, false
+				}
+				return storeutil.WorldCandidate{ID: e.ID, Type: e.Type, Pointer: e.Pointer}, true
+			})
+	}
 
 	items := make([]*entity.Entity, 0, len(keys.Keys))
 	for _, id := range keys.Keys {
@@ -333,39 +401,49 @@ func entityIDSet(ids []string) map[string]bool {
 	return set
 }
 
-// matchEntityQuery reports whether e satisfies q's Type, IDs, and
-// AllStates filters. idSet must be pre-computed from q.IDs (see
-// entityIDSet) and matches the BARE id, so IDs+AllStates selects every
-// state of the listed entities.
+// matchEntityQuery adapts a stored entity to the shared rule in
+// storeutil. The rule itself must not live here: fsstore applies the
+// identical filter, and the two byte-similar copies this replaced are
+// exactly the drift storetest exists to catch. The nil guard stays
+// local — it is this backend's map-miss, not part of the rule.
 func matchEntityQuery(e *entity.Entity, q store.EntityQuery, idSet map[string]bool) bool {
 	if e == nil {
 		return false
 	}
-	if !q.AllStates && !e.Pointer.IsDefault() {
-		return false
-	}
-	if q.Type != "" && e.Type != q.Type {
-		return false
-	}
-	if len(idSet) > 0 && !idSet[e.ID] {
-		return false
-	}
-	return true
+	return storeutil.MatchEntityQuery(e.Type, e.ID, e.Pointer, q, idSet)
 }
 
 func (m *MemStore) CountEntities(_ context.Context, q store.EntityQuery) (int, error) {
+	if err := storeutil.ValidateEntityQuery(q); err != nil {
+		return 0, err
+	}
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
 	idSet := entityIDSet(q.IDs)
 
-	count := 0
+	// The default world resolves every row to itself, so counting needs
+	// no buffer — and this is the common path for a project that never
+	// declares a pointer, which must stay allocation-free.
+	if q.World.IsDefaultWorld() {
+		n := 0
+		for _, e := range m.entities {
+			if matchEntityQuery(e, q, idSet) {
+				n++
+			}
+		}
+		return n, nil
+	}
+
+	matched := make([]*entity.Entity, 0)
 	for _, e := range m.entities {
 		if matchEntityQuery(e, q, idSet) {
-			count++
+			matched = append(matched, e)
 		}
 	}
-	return count, nil
+	// Counts must be world-scoped, not raw: an unscoped tally tells a
+	// published-world surface how many unpublished drafts exist.
+	return len(worldKeep(q.World, matched)), nil
 }
 
 func (m *MemStore) HighestID(_ context.Context, prefix string) (int, error) {
@@ -467,7 +545,7 @@ func (m *MemStore) createEntity(_ context.Context, e *entity.Entity) error {
 	stored.Redacted = nil // per-reader ACL artifact, never content (RR-KBWJPV)
 	stored.UpdatedAt = time.Now()
 	m.entities[key] = stored
-	m.entityOrder = sortedInsert(m.entityOrder, key)
+	m.entityOrder = entityInsert(m.entityOrder, key)
 	m.notifyPut(stored)
 
 	m.emit(store.Event{
@@ -543,7 +621,7 @@ func (m *MemStore) deleteEntity(_ context.Context, id string, cascade bool) (*st
 	for _, fe := range family {
 		result.DeletedEntities = append(result.DeletedEntities, fe.e.Clone())
 		delete(m.entities, fe.key)
-		m.entityOrder = sortedRemove(m.entityOrder, fe.key)
+		m.entityOrder = entityRemove(m.entityOrder, fe.key)
 	}
 	m.notifyDelete(id)
 
@@ -596,8 +674,8 @@ func (m *MemStore) rekeyFamily(family []famEntry, newID string) []*entity.Entity
 		newKey := entity.FormatStateRef(newID, r.Pointer)
 		m.entities[newKey] = r
 		delete(m.entities, fe.key)
-		m.entityOrder = sortedRemove(m.entityOrder, fe.key)
-		m.entityOrder = sortedInsert(m.entityOrder, newKey)
+		m.entityOrder = entityRemove(m.entityOrder, fe.key)
+		m.entityOrder = entityInsert(m.entityOrder, newKey)
 		renamed = append(renamed, r)
 	}
 	return renamed

--- a/internal/store/pgstore/entity.go
+++ b/internal/store/pgstore/entity.go
@@ -19,6 +19,33 @@ import (
 	"github.com/Sourcehaven-BV/rela/internal/store/storeutil"
 )
 
+// checkQueryScope rejects a query this backend cannot answer.
+//
+// It applies the shared AllStates+World contradiction rule, and then —
+// until PR-C lands the SQL pushdown — REFUSES a non-default World
+// outright (TKT-WAV8XP, decision Q8).
+//
+// The refusal is deliberate and must stay loud. The alternative, a
+// naive path that resolves primes by filtering rows in Go, would be an
+// unnoticed per-row scan in the one backend that has scale, and it
+// would silently pass the conformance suite while doing the thing the
+// design forbids. An error names the gap; a slow correct answer hides
+// it. Removed in PR-C, together with storetest.Capabilities.Worlds.
+func checkQueryScope(q store.EntityQuery) error {
+	if err := storeutil.ValidateEntityQuery(q); err != nil {
+		return err
+	}
+	if !q.World.IsDefaultWorld() {
+		// A plain error, not a new sentinel: this refusal is deleted in
+		// PR-C, and a sentinel would invite a caller to branch on a
+		// condition designed to stop existing.
+		return errors.New(
+			"pgstore: world-scoped queries are not implemented yet (TKT-WAV8XP PR-C); " +
+				"the SQL pushdown lands there and this refusal is removed with it")
+	}
+	return nil
+}
+
 // --- EntityReader ---
 
 // GetEntity returns a single entity by ID, or store.ErrNotFound. The
@@ -46,6 +73,9 @@ func (s *Store) GetEntityState(ctx context.Context, id string, p entity.Pointer)
 // ListEntities streams entities matching q in ascending-ID order. Cursor and
 // Limit are ignored (per the EntityReader contract).
 func (s *Store) ListEntities(ctx context.Context, q store.EntityQuery) iter.Seq2[*entity.Entity, error] {
+	if err := checkQueryScope(q); err != nil {
+		return func(yield func(*entity.Entity, error) bool) { yield(nil, err) }
+	}
 	sql, args := buildEntityListSQL(q, "")
 	return func(yield func(*entity.Entity, error) bool) {
 		rows, err := s.db.Query(ctx, sql, args...)
@@ -81,6 +111,9 @@ func (s *Store) ListEntities(ctx context.Context, q store.EntityQuery) iter.Seq2
 func (s *Store) ListEntityHeaders(
 	ctx context.Context, q store.EntityQuery,
 ) iter.Seq2[store.EntityHeader, error] {
+	if err := checkQueryScope(q); err != nil {
+		return func(yield func(store.EntityHeader, error) bool) { yield(store.EntityHeader{}, err) }
+	}
 	sql, args := buildEntityHeaderListSQL(q, "")
 	return func(yield func(store.EntityHeader, error) bool) {
 		rows, err := s.db.Query(ctx, sql, args...)
@@ -108,6 +141,9 @@ func (s *Store) ListEntityHeaders(
 // ListEntitiesPage returns a page of entities. A keyset cursor on id keeps
 // pages stable; see store.ListEntitiesPage for the contract.
 func (s *Store) ListEntitiesPage(ctx context.Context, q store.EntityQuery) (store.Page[*entity.Entity], error) {
+	if err := checkQueryScope(q); err != nil {
+		return store.Page[*entity.Entity]{}, err
+	}
 	cursorKey, err := storeutil.DecodeCursor(q.Cursor)
 	if err != nil {
 		return store.Page[*entity.Entity]{}, err
@@ -155,6 +191,9 @@ func (s *Store) ListEntitiesPage(ctx context.Context, q store.EntityQuery) (stor
 
 // CountEntities counts entities matching q.
 func (s *Store) CountEntities(ctx context.Context, q store.EntityQuery) (int, error) {
+	if err := checkQueryScope(q); err != nil {
+		return 0, err
+	}
 	where, args := entityWhere(q, "")
 	sql := "SELECT count(*) FROM entities" + where
 	var n int
@@ -743,6 +782,15 @@ func scanEntityHeader(row scanner) (store.EntityHeader, error) {
 // zero-value query that is exactly the contract's historical
 // ascending-id order (the pointer column is constant ”); under
 // AllStates the states of an id sort immediately after its default row.
+//
+// That contiguity is a SHARED contract, not a pgstore detail: fs/mem
+// match it via storeutil.CompareStateKeys, which orders their index by
+// the same (bare id, pointer) tuple. It is load-bearing for world
+// resolution, which buffers one family and decides at end-of-family
+// (TKT-WAV8XP). Note fs/mem need an explicit comparator to get here —
+// they key on the JOINED "id@pointer" string, and '@' (0x40) sorts after
+// the digits (0x30-0x39), so plain string order puts PAGE-10's family
+// inside PAGE-1's. Changing either side's ordering breaks the other.
 func buildEntityListSQL(q store.EntityQuery, keysetAfter string) (sql string, args []any) {
 	where, args := entityWhere(q, keysetAfter)
 	sql = `SELECT id, type, pointer, properties, content, updated_at FROM entities` +

--- a/internal/store/pgstore/graphquery.go
+++ b/internal/store/pgstore/graphquery.go
@@ -2,6 +2,7 @@ package pgstore
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"iter"
 	"strings"
@@ -19,7 +20,23 @@ import (
 // SELECT by type; when only one of HasInbound / HasOutbound is set,
 // only that EXISTS clause is emitted. Both nil → degenerate
 // "everything of this type" answer (covered by the conformance suite).
+// checkGraphQueryScope mirrors checkQueryScope for the graph shape: the
+// world must reach BOTH query types or the list path and the ACL
+// pushdown path diverge (TKT-WAV8XP F1/F5). Removed in PR-C with its
+// EntityQuery twin.
+func checkGraphQueryScope(q store.GraphQuery) error {
+	if !q.World.IsDefaultWorld() {
+		return errors.New(
+			"pgstore: world-scoped graph queries are not implemented yet (TKT-WAV8XP PR-C); " +
+				"the SQL pushdown lands there and this refusal is removed with it")
+	}
+	return nil
+}
+
 func (s *Store) GraphQuery(ctx context.Context, q store.GraphQuery) iter.Seq2[*entity.Entity, error] {
+	if err := checkGraphQueryScope(q); err != nil {
+		return func(yield func(*entity.Entity, error) bool) { yield(nil, err) }
+	}
 	sqlText, args := buildGraphQuerySQL(q, false)
 	return func(yield func(*entity.Entity, error) bool) {
 		rows, err := s.db.Query(ctx, sqlText, args...)
@@ -52,6 +69,9 @@ func (s *Store) GraphQuery(ctx context.Context, q store.GraphQuery) iter.Seq2[*e
 // recursive CTE shape — duplicating the WITH RECURSIVE inside a
 // single FILTER expression saves nothing.
 func (s *Store) GraphCount(ctx context.Context, q store.GraphQuery) (matched, total int, err error) {
+	if scopeErr := checkGraphQueryScope(q); scopeErr != nil {
+		return 0, 0, scopeErr
+	}
 	matchedSQL, matchedArgs := buildGraphQuerySQL(q, true)
 	if err = s.db.QueryRow(ctx, matchedSQL, matchedArgs...).Scan(&matched); err != nil {
 		return 0, 0, fmt.Errorf("pgstore: graph count (matched): %w", err)
@@ -68,6 +88,9 @@ func (s *Store) GraphCount(ctx context.Context, q store.GraphQuery) (matched, to
 // (true = matched, false = no-match). Push-down: a single SQL round
 // trip regardless of |ids|.
 func (s *Store) MatchingIDs(ctx context.Context, q store.GraphQuery, ids []string) (map[string]bool, error) {
+	if err := checkGraphQueryScope(q); err != nil {
+		return nil, err
+	}
 	out := make(map[string]bool, len(ids))
 	for _, id := range ids {
 		out[id] = false

--- a/internal/store/pgstore/world_refusal_test.go
+++ b/internal/store/pgstore/world_refusal_test.go
@@ -1,0 +1,99 @@
+//go:build postgres
+
+package pgstore
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/Sourcehaven-BV/rela/internal/entity"
+	"github.com/Sourcehaven-BV/rela/internal/store"
+)
+
+// These pin pgstore's transitional refusal of world-scoped queries
+// (TKT-WAV8XP, decision Q8). They are pure-unit — the refusal happens
+// before any SQL is built — so they are not gated on
+// RELA_TEST_DATABASE_URL.
+//
+// They live HERE and not in storetest deliberately (RR-MNOBJK). The
+// shared conformance suite states ONE contract for all backends; asking
+// it to accept correct rows from fs/mem and a refusal from pg would
+// defeat the point of having it. fs/mem opt into RunWorldTests via
+// Capabilities.Worlds in PR-B; PR-C implements the SQL pushdown, sets
+// pg's behavior to match, deletes that flag, and deletes this file.
+
+func worldScope(t *testing.T) store.WorldScope {
+	t.Helper()
+	p, err := entity.ParsePointer("published")
+	if err != nil {
+		t.Fatal(err)
+	}
+	return store.NewWorldScope(map[string]store.TypeResolution{
+		"page": {Chain: []entity.Pointer{p}, Fallback: store.FallbackExclude},
+	})
+}
+
+// TestCheckQueryScope_RefusesNonDefaultWorld pins that the refusal is
+// LOUD. The alternative considered and rejected was a naive path
+// resolving primes by filtering rows in Go: that would pass the
+// conformance suite while doing the per-row scan the design forbids, in
+// the one backend that has scale. An error names the gap; a slow correct
+// answer hides it.
+func TestCheckQueryScope_RefusesNonDefaultWorld(t *testing.T) {
+	err := checkQueryScope(store.EntityQuery{Type: "page", World: worldScope(t)})
+	if err == nil {
+		t.Fatal("pgstore must refuse a world-scoped query until PR-C")
+	}
+	// The message must name the ticket and the PR that removes it, or the
+	// next reader cannot tell a deliberate gap from a missing feature.
+	for _, want := range []string{"TKT-WAV8XP", "PR-C"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("refusal must name %q, got: %v", want, err)
+		}
+	}
+}
+
+// TestCheckQueryScope_DefaultWorldIsUnaffected is the load-bearing
+// negative: the zero WorldScope is the DEFAULT world, not "no world", so
+// a refusal keyed on the wrong condition would reject every existing
+// query in the codebase.
+func TestCheckQueryScope_DefaultWorldIsUnaffected(t *testing.T) {
+	for _, q := range []store.EntityQuery{
+		{},
+		{Type: "page"},
+		{Type: "page", AllStates: true},
+		{Type: "page", World: store.DefaultWorld()},
+	} {
+		if err := checkQueryScope(q); err != nil {
+			t.Errorf("checkQueryScope(%+v) = %v, want nil", q, err)
+		}
+	}
+}
+
+// TestCheckQueryScope_AllStatesAndWorldConflict pins that pgstore
+// inherits the shared contradiction rule (decision Q3) rather than
+// reimplementing it. AllStates is raw storage truth and a world resolves
+// each entity to one state; honoring both is impossible.
+func TestCheckQueryScope_AllStatesAndWorldConflict(t *testing.T) {
+	err := checkQueryScope(store.EntityQuery{
+		Type: "page", AllStates: true, World: worldScope(t),
+	})
+	if !errors.Is(err, store.ErrInvalidQuery) {
+		t.Fatalf("want ErrInvalidQuery, got %v", err)
+	}
+}
+
+// TestCheckGraphQueryScope_RefusesNonDefaultWorld covers the second
+// query type. The world must reach BOTH or the list path and the ACL
+// pushdown path diverge — and they diverge for the AllowAll principal
+// specifically, who takes the EntityQuery branch (F1/F5).
+func TestCheckGraphQueryScope_RefusesNonDefaultWorld(t *testing.T) {
+	if err := checkGraphQueryScope(store.GraphQuery{EntityType: "page"}); err != nil {
+		t.Errorf("the default world must be unaffected, got %v", err)
+	}
+	err := checkGraphQueryScope(store.GraphQuery{EntityType: "page", World: worldScope(t)})
+	if err == nil {
+		t.Fatal("pgstore must refuse a world-scoped graph query until PR-C")
+	}
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -292,6 +292,20 @@ type EntityQuery struct {
 	// detection, observer backfill (TKT-9OJ3S0) — not for read paths
 	// choosing which face of an entity to show.
 	AllStates bool
+
+	// World resolves each entity to at most one of its content states —
+	// the "prime" — per the compiled per-type ranked chain and fallback
+	// verdict (TKT-WAV8XP). The ZERO VALUE is the default world: every
+	// entity contributes its default state, byte-identical to the
+	// pre-worlds behavior, which is what keeps every existing
+	// construction site unchanged and costs a pointerless project
+	// nothing.
+	//
+	// World and AllStates are MUTUALLY EXCLUSIVE: AllStates is raw
+	// storage truth and world resolution is its opposite, so a query
+	// setting both is rejected with [ErrInvalidQuery] rather than
+	// silently resolved by a precedence rule nobody would remember.
+	World WorldScope
 }
 
 // Page holds a single page of results from a paginated list call.

--- a/internal/store/storetest/storetest.go
+++ b/internal/store/storetest/storetest.go
@@ -31,6 +31,21 @@ type Capabilities struct {
 	// AttachmentManager. When false, attachment-related conformance
 	// tests are skipped.
 	Attachments bool
+
+	// Worlds indicates whether the store resolves EntityQuery.World.
+	//
+	// TODO(TKT-WAV8XP-PR-C): remove this field and run RunWorldTests
+	// unconditionally. It exists for exactly one commit window: fs and
+	// mem implement world resolution in PR-B, pgstore's SQL pushdown
+	// lands in PR-C, and until then pgstore REFUSES a non-default World
+	// loudly (asserted by a pg-specific test, not here). Without the
+	// gate the one shared suite would have to accept two contradictory
+	// outcomes — correct rows for fs/mem, a refusal for pg — which is
+	// precisely what a conformance suite exists to prevent.
+	//
+	// A transitional flag that outlives its window becomes a permanent
+	// conformance opt-out, so PR-C deletes it rather than setting it.
+	Worlds bool
 }
 
 func ctx() context.Context { return context.Background() }
@@ -164,6 +179,9 @@ func RunAll(t *testing.T, f Factory, sf SearchFactory, vsf VisibleSearchFactory,
 		t.Run("Attachment", func(t *testing.T) { RunAttachmentTests(t, f) })
 	}
 	t.Run("States", func(t *testing.T) { RunStateTests(t, f) })
+	if caps.Worlds {
+		t.Run("Worlds", func(t *testing.T) { RunWorldTests(t, f) })
+	}
 	t.Run("Watcher", func(t *testing.T) { RunWatcherTests(t, f) })
 	t.Run("Validation", func(t *testing.T) { RunValidationTests(t, f) })
 	t.Run("Tx", func(t *testing.T) { RunTxTests(t, f) })

--- a/internal/store/storetest/worlds.go
+++ b/internal/store/storetest/worlds.go
@@ -1,0 +1,418 @@
+package storetest
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/Sourcehaven-BV/rela/internal/entity"
+	"github.com/Sourcehaven-BV/rela/internal/store"
+)
+
+// RunWorldTests is the world-resolution conformance suite (TKT-WAV8XP):
+// the three resolution rules, chain order, the at-most-one-prime
+// invariant, exclude-vs-default fallback, the zero-value default-world
+// fast path, and the AllStates+World refusal.
+//
+// These cases define the contract BEFORE the second backend implements
+// it. fs/mem resolve in shared Go (storeutil); pgstore resolves in SQL
+// in PR-C — this suite is what stops the two from drifting, exactly as
+// RunStateTests does for content states.
+//
+// Gated by Capabilities.Worlds for one commit window; see that field.
+func RunWorldTests(t *testing.T, f Factory) {
+	ptr := func(t *testing.T, v string) entity.Pointer {
+		t.Helper()
+		p, err := entity.ParsePointer(v)
+		require.NoError(t, err)
+		return p
+	}
+	newState := func(t *testing.T, id, typ, p, title string) *entity.Entity {
+		t.Helper()
+		e := entity.New(id, typ)
+		if p != "" {
+			e.Pointer = ptr(t, p)
+		}
+		e.SetString("title", title)
+		return e
+	}
+	mustCreate := func(t *testing.T, s store.Store, e *entity.Entity) {
+		t.Helper()
+		require.NoError(t, s.CreateEntity(ctx(), e))
+	}
+	// scope builds a one-type world so each case states its own rule.
+	scope := func(t *testing.T, typ string, fb store.Fallback, chain ...string) store.WorldScope {
+		t.Helper()
+		coords := make([]entity.Pointer, 0, len(chain))
+		for _, c := range chain {
+			coords = append(coords, ptr(t, c))
+		}
+		return store.NewWorldScope(map[string]store.TypeResolution{
+			typ: {Chain: coords, Fallback: fb},
+		})
+	}
+	// titles collects the resolved faces, keyed by bare id, and asserts
+	// the at-most-one-prime invariant on the way through.
+	titles := func(t *testing.T, s store.Store, q store.EntityQuery) map[string]string {
+		t.Helper()
+		out := map[string]string{}
+		for e, err := range s.ListEntities(ctx(), q) {
+			require.NoError(t, err)
+			if prev, dup := out[e.ID]; dup {
+				t.Fatalf("at-most-one-prime violated: %s resolved to both %q and %q",
+					e.ID, prev, e.GetString("title"))
+			}
+			out[e.ID] = e.GetString("title")
+		}
+		return out
+	}
+
+	// Rule 2: the first coordinate that EXISTS wins, and ordering is the
+	// whole semantic content of a chain — the same world must pick
+	// different states for different entities.
+	t.Run("Rule2_FirstExistingCoordinateWins", func(t *testing.T) {
+		s := f(t)
+		// PAGE-1 holds both; PAGE-2 holds only the later coordinate.
+		mustCreate(t, s, newState(t, "PAGE-1", "page", "", "1 default"))
+		mustCreate(t, s, newState(t, "PAGE-1", "page", "review", "1 review"))
+		mustCreate(t, s, newState(t, "PAGE-1", "page", "published", "1 published"))
+		mustCreate(t, s, newState(t, "PAGE-2", "page", "", "2 default"))
+		mustCreate(t, s, newState(t, "PAGE-2", "page", "published", "2 published"))
+
+		got := titles(t, s, store.EntityQuery{
+			Type:  "page",
+			World: scope(t, "page", store.FallbackExclude, "review", "published"),
+		})
+		assert.Equal(t, map[string]string{
+			"PAGE-1": "1 review",    // review outranks published
+			"PAGE-2": "2 published", // no review row, so published wins
+		}, got, "a chain is a ranked preference, not a set")
+	})
+
+	// The inverse chain over the same data must give the other answer,
+	// or the implementation is matching a SET and the order is decorative.
+	t.Run("Rule2_ChainOrderIsLoadBearing", func(t *testing.T) {
+		s := f(t)
+		mustCreate(t, s, newState(t, "PAGE-1", "page", "", "default"))
+		mustCreate(t, s, newState(t, "PAGE-1", "page", "review", "review face"))
+		mustCreate(t, s, newState(t, "PAGE-1", "page", "published", "published face"))
+
+		forward := titles(t, s, store.EntityQuery{
+			Type:  "page",
+			World: scope(t, "page", store.FallbackExclude, "review", "published"),
+		})
+		reverse := titles(t, s, store.EntityQuery{
+			Type:  "page",
+			World: scope(t, "page", store.FallbackExclude, "published", "review"),
+		})
+		assert.Equal(t, "review face", forward["PAGE-1"])
+		assert.Equal(t, "published face", reverse["PAGE-1"],
+			"reversing the chain must reverse the winner")
+	})
+
+	// Rule 3 under `otherwise: exclude` — absence IS the publication bit.
+	// An entity with no coordinate in the chain is not in the world at
+	// all; it must not fall back to its default face.
+	t.Run("Rule3_ExcludeOmitsTheEntity", func(t *testing.T) {
+		s := f(t)
+		mustCreate(t, s, newState(t, "PAGE-1", "page", "", "1 default"))
+		mustCreate(t, s, newState(t, "PAGE-1", "page", "published", "1 published"))
+		mustCreate(t, s, newState(t, "PAGE-2", "page", "", "2 default")) // no published row
+
+		got := titles(t, s, store.EntityQuery{
+			Type:  "page",
+			World: scope(t, "page", store.FallbackExclude, "published"),
+		})
+		assert.Equal(t, map[string]string{"PAGE-1": "1 published"}, got)
+		assert.NotContains(t, got, "PAGE-2",
+			"an unpublished entity must be ABSENT, not served as its draft")
+	})
+
+	// Rule 3 under `otherwise: default` — the same data, the opposite
+	// verdict. This pair is why the fallback is a verdict and not a
+	// chain suffix.
+	t.Run("Rule3_DefaultFallsBackToTheDefaultState", func(t *testing.T) {
+		s := f(t)
+		mustCreate(t, s, newState(t, "PAGE-1", "page", "", "1 default"))
+		mustCreate(t, s, newState(t, "PAGE-1", "page", "published", "1 published"))
+		mustCreate(t, s, newState(t, "PAGE-2", "page", "", "2 default"))
+
+		got := titles(t, s, store.EntityQuery{
+			Type:  "page",
+			World: scope(t, "page", store.FallbackDefaultState, "published"),
+		})
+		assert.Equal(t, map[string]string{
+			"PAGE-1": "1 published",
+			"PAGE-2": "2 default",
+		}, got)
+	})
+
+	// Rule 1: a type ABSENT from the scope contributes its default state
+	// in every world. Absence and the zero TypeResolution mean opposite
+	// things, and this is the case that tells them apart — a backend
+	// reading a map-miss as the zero value would drop `ticket` entirely.
+	t.Run("Rule1_UnscopedTypeContributesItsDefaultState", func(t *testing.T) {
+		s := f(t)
+		mustCreate(t, s, newState(t, "PAGE-1", "page", "", "page default"))
+		mustCreate(t, s, newState(t, "PAGE-1", "page", "published", "page published"))
+		mustCreate(t, s, newState(t, "TKT-1", "ticket", "", "ticket default"))
+
+		// A world naming only `page`; `ticket` is absent from the map.
+		got := titles(t, s, store.EntityQuery{
+			World: scope(t, "page", store.FallbackExclude, "published"),
+		})
+		assert.Equal(t, "page published", got["PAGE-1"])
+		assert.Equal(t, "ticket default", got["TKT-1"],
+			"a type the world does not name keeps its default state (rule 1)")
+	})
+
+	// The at-most-one-prime invariant, stated on its own. `pointer IN
+	// (...)` would return two rows for PAGE-1 and is the obvious wrong
+	// implementation.
+	t.Run("AtMostOnePrimePerEntity", func(t *testing.T) {
+		s := f(t)
+		mustCreate(t, s, newState(t, "PAGE-1", "page", "", "default"))
+		mustCreate(t, s, newState(t, "PAGE-1", "page", "review", "review"))
+		mustCreate(t, s, newState(t, "PAGE-1", "page", "published", "published"))
+
+		q := store.EntityQuery{
+			Type:  "page",
+			World: scope(t, "page", store.FallbackDefaultState, "review", "published"),
+		}
+		titles(t, s, q) // fatals on a duplicate id
+
+		n, err := s.CountEntities(ctx(), q)
+		require.NoError(t, err)
+		assert.Equal(t, 1, n, "an entity holding three faces contributes exactly one row")
+	})
+
+	// The zero WorldScope is the DEFAULT WORLD, and must be
+	// byte-identical to the pre-worlds query — this is what keeps every
+	// existing construction site and every pointerless project free.
+	t.Run("ZeroWorldIsTodaysBehavior", func(t *testing.T) {
+		s := f(t)
+		mustCreate(t, s, newState(t, "PAGE-1", "page", "", "default face"))
+		mustCreate(t, s, newState(t, "PAGE-1", "page", "published", "published face"))
+
+		bare := titles(t, s, store.EntityQuery{Type: "page"})
+		zero := titles(t, s, store.EntityQuery{Type: "page", World: store.DefaultWorld()})
+		assert.Equal(t, map[string]string{"PAGE-1": "default face"}, bare)
+		assert.Equal(t, bare, zero, "the zero WorldScope must not change any result")
+	})
+
+	// A project that never declares a pointer must be untouched by the
+	// feature existing.
+	t.Run("PointerlessProjectIsUnaffected", func(t *testing.T) {
+		s := f(t)
+		mustCreate(t, s, newState(t, "TKT-1", "ticket", "", "one"))
+		mustCreate(t, s, newState(t, "TKT-2", "ticket", "", "two"))
+
+		want := map[string]string{"TKT-1": "one", "TKT-2": "two"}
+		assert.Equal(t, want, titles(t, s, store.EntityQuery{Type: "ticket"}))
+		assert.Equal(t, want, titles(t, s, store.EntityQuery{
+			Type:  "ticket",
+			World: scope(t, "page", store.FallbackExclude, "published"),
+		}), "a world scoping another type must not touch this one")
+	})
+
+	// A non-default world must actually return a NON-DEFAULT row. The
+	// candidate filter is WIDENED under a world (every state of a family
+	// becomes a candidate, and resolution picks among them afterwards);
+	// if someone later "optimizes" that back to a default-only filter,
+	// every world silently resolves to default faces and this is the
+	// only case that says so. The failure mode is silence in the
+	// direction of serving the wrong face: a published world that quietly
+	// shows drafts reads exactly like a correctly-working one.
+	t.Run("NonDefaultWorldReturnsANonDefaultState", func(t *testing.T) {
+		s := f(t)
+		mustCreate(t, s, newState(t, "PAGE-1", "page", "", "the draft nobody should see"))
+		mustCreate(t, s, newState(t, "PAGE-1", "page", "published", "the published face"))
+
+		q := store.EntityQuery{
+			Type:  "page",
+			World: scope(t, "page", store.FallbackExclude, "published"),
+		}
+		var got []*entity.Entity
+		for e, err := range s.ListEntities(ctx(), q) {
+			require.NoError(t, err)
+			got = append(got, e)
+		}
+		require.Len(t, got, 1)
+		assert.Equal(t, "the published face", got[0].GetString("title"))
+		assert.False(t, got[0].Pointer.IsDefault(),
+			"the resolved row must be the STATE row, not the default face")
+		assert.Equal(t, ptr(t, "published"), got[0].Pointer)
+	})
+
+	// Families must stay CONTIGUOUS in the backend's ordering, or a page
+	// boundary can split one and the resolver decides a prime having seen
+	// only part of it. Because the fallback verdict is a decision about
+	// ABSENCE, a partial view yields a WRONG prime, not a slow one.
+	//
+	// The ids matter: '@' is 0x40 and digits are 0x30-0x39, so under
+	// plain string ordering of the joined "id@pointer" key, PAGE-10 sorts
+	// BETWEEN PAGE-1 and PAGE-1@draft and splits PAGE-1's family. This
+	// case is why fs/mem sort by the (bare id, pointer) tuple; a refactor
+	// back to concatenated keys dies here.
+	t.Run("FamiliesStayContiguousAcrossPageBoundaries", func(t *testing.T) {
+		s := f(t)
+		for _, id := range []string{"PAGE-1", "PAGE-10", "PAGE-2"} {
+			mustCreate(t, s, newState(t, id, "page", "", id+" default"))
+			mustCreate(t, s, newState(t, id, "page", "published", id+" published"))
+		}
+
+		// FallbackDefaultState is the discriminating verdict. Under plain
+		// string ordering PAGE-1's family splits into two NON-ADJACENT
+		// runs (`PAGE-1`, then `PAGE-10`'s whole family, then
+		// `PAGE-1@published`), so a family-buffering resolver decides
+		// PAGE-1 TWICE: the first run sees only the default row, fires
+		// the fallback, and emits the draft face; the second run sees
+		// only the published row and emits that. The entity appears
+		// twice, and one of the two rows is the face the world was
+		// supposed to replace. With `exclude` both runs happen to agree,
+		// which is why this case must use `default`.
+		world := scope(t, "page", store.FallbackDefaultState, "published")
+		want := map[string]string{
+			"PAGE-1":  "PAGE-1 published",
+			"PAGE-10": "PAGE-10 published",
+			"PAGE-2":  "PAGE-2 published",
+		}
+
+		// Unpaged is the oracle.
+		assert.Equal(t, want, titles(t, s, store.EntityQuery{Type: "page", World: world}))
+
+		// Paging one prime at a time must produce the same set: every
+		// page boundary falls between two families.
+		for _, limit := range []int{1, 2, 3} {
+			got := map[string]string{}
+			cursor := ""
+			for range 10 { // bounded: 3 primes, so this always terminates
+				page, err := s.ListEntitiesPage(ctx(), store.EntityQuery{
+					Type: "page", World: world, Limit: limit, Cursor: cursor,
+				})
+				require.NoError(t, err)
+				for _, e := range page.Items {
+					if prev, dup := got[e.ID]; dup {
+						t.Fatalf("limit %d: %s yielded twice (%q then %q)",
+							limit, e.ID, prev, e.GetString("title"))
+					}
+					got[e.ID] = e.GetString("title")
+				}
+				if page.NextCursor == "" {
+					break
+				}
+				cursor = page.NextCursor
+			}
+			assert.Equal(t, want, got, "paging with limit %d must not drop or split a family", limit)
+		}
+	})
+
+	// The header path must resolve the world too. ListEntityHeaders is an
+	// OPTIONAL capability (store.HeaderReader): memstore and pgstore
+	// implement it natively, fsstore does not and is served by the generic
+	// store.ListEntityHeaders fallback over ListEntities. Both arms are
+	// exercised here by going through the package-level helper, which is
+	// what every caller uses.
+	//
+	// Worth stating why this case exists: the header suite in header.go
+	// passes no World, and RunWorldTests otherwise covers the other six
+	// query entry points — so without this, a natively-implemented header
+	// path could serve the default world while the list beside it serves
+	// the requested one, and no conformance case would notice. That gap
+	// matters most for pgstore, whose PR-B refusal is what currently
+	// stands in for this coverage (TKT-WAV8XP PR-C deletes the refusal).
+	t.Run("HeaderPathHonorsTheWorld", func(t *testing.T) {
+		s := f(t)
+		mustCreate(t, s, newState(t, "HDR-1", "page", "", "HDR-1 draft"))
+		mustCreate(t, s, newState(t, "HDR-1", "page", "published", "HDR-1 published"))
+		// HDR-2 has no published state, so `exclude` must drop it.
+		mustCreate(t, s, newState(t, "HDR-2", "page", "", "HDR-2 draft only"))
+
+		q := store.EntityQuery{
+			Type:  "page",
+			World: scope(t, "page", store.FallbackExclude, "published"),
+		}
+		got := map[string]string{}
+		for h, err := range store.ListEntityHeaders(ctx(), s, q) {
+			require.NoError(t, err)
+			if prev, dup := got[h.ID]; dup {
+				t.Fatalf("at-most-one-prime violated: %s resolved to both %q and %q",
+					h.ID, prev, h.Properties["title"])
+			}
+			title, _ := h.Properties["title"].(string)
+			got[h.ID] = title
+		}
+		assert.Equal(t, map[string]string{"HDR-1": "HDR-1 published"}, got,
+			"headers must be world-scoped: the published face only, and no excluded entity")
+	})
+
+	// A world must reach the GRAPH-query path as well as the list path.
+	// The ACL read path swaps an EntityQuery for a GraphQuery the moment
+	// a policy query exists (internal/visibility/pushdown.go), so a world
+	// honored on only one of the two fails OPEN for exactly the gated
+	// principals: `otherwise: exclude` stops hiding, and a published
+	// world starts serving drafts. Pinned here rather than per-backend
+	// because all three delegate the seed to the same helper.
+	t.Run("GraphQueryHonorsTheWorld", func(t *testing.T) {
+		s := f(t)
+		mustCreate(t, s, newState(t, "GQ-1", "page", "", "GQ-1 default"))
+		mustCreate(t, s, newState(t, "GQ-1", "page", "published", "GQ-1 published"))
+		// GQ-2 holds no published state, so `exclude` must drop it.
+		mustCreate(t, s, newState(t, "GQ-2", "page", "", "GQ-2 default only"))
+
+		world := scope(t, "page", store.FallbackExclude, "published")
+		q := store.GraphQuery{EntityType: "page", World: world}
+
+		got := map[string]string{}
+		for e, err := range s.GraphQuery(ctx(), q) {
+			require.NoError(t, err)
+			if prev, dup := got[e.ID]; dup {
+				t.Fatalf("at-most-one-prime violated: %s resolved to both %q and %q",
+					e.ID, prev, e.GetString("title"))
+			}
+			got[e.ID] = e.GetString("title")
+		}
+		assert.Equal(t, map[string]string{"GQ-1": "GQ-1 published"}, got,
+			"GraphQuery must return primes, not default states")
+
+		// The same scope must reach the count and membership paths, or
+		// a gated list and its total disagree.
+		matched, total, err := s.GraphCount(ctx(), q)
+		require.NoError(t, err)
+		assert.Equal(t, 1, matched, "GraphCount matched")
+		assert.Equal(t, 1, total, "GraphCount total counts world-scoped candidates")
+
+		ids, err := s.MatchingIDs(ctx(), q, []string{"GQ-1", "GQ-2"})
+		require.NoError(t, err)
+		assert.Equal(t, map[string]bool{"GQ-1": true, "GQ-2": false}, ids,
+			"an entity the world excludes must not match")
+	})
+
+	// AllStates and World are mutually exclusive (decision Q3): raw
+	// storage truth versus resolution. The refusal is shared so every
+	// backend inherits it; silently honoring one would be a precedence
+	// rule nobody remembers.
+	t.Run("AllStatesWithWorldIsRejected", func(t *testing.T) {
+		s := f(t)
+		mustCreate(t, s, newState(t, "PAGE-1", "page", "", "default"))
+
+		q := store.EntityQuery{
+			Type:      "page",
+			AllStates: true,
+			World:     scope(t, "page", store.FallbackExclude, "published"),
+		}
+		var got error
+		for _, err := range s.ListEntities(ctx(), q) {
+			if err != nil {
+				got = err
+				break
+			}
+		}
+		assert.ErrorIs(t, got, store.ErrInvalidQuery,
+			"a contradictory query must be refused, not silently resolved")
+
+		_, err := s.CountEntities(ctx(), q)
+		assert.ErrorIs(t, err, store.ErrInvalidQuery)
+	})
+}

--- a/internal/store/storeutil/storeutil.go
+++ b/internal/store/storeutil/storeutil.go
@@ -114,6 +114,54 @@ func SortedInsert(s []string, key string) []string {
 	return slices.Insert(s, i, key)
 }
 
+// CompareStateKeys orders two entity state keys ("id" or "id@pointer")
+// as the TUPLE (bare id, pointer), which is what pgstore's
+// `ORDER BY id ASC, pointer ASC` does. One ordering contract across all
+// three backends (TKT-WAV8XP).
+//
+// Plain string comparison on the joined key is NOT equivalent, and the
+// difference is a correctness bug rather than a cosmetic one. The
+// separator '@' is 0x40 and the digits are 0x30-0x39, so '@' sorts AFTER
+// any digit and a numerically-prefixed sibling lands INSIDE the family:
+//
+//	string order: PAGE-1  PAGE-10  PAGE-10@draft  PAGE-1@draft  PAGE-2
+//	tuple order:  PAGE-1  PAGE-1@draft  PAGE-10  PAGE-10@draft  PAGE-2
+//
+// World resolution buffers one family and decides at end-of-family, and
+// the fallback verdict is a decision about ABSENCE — so a family split
+// across a page boundary yields a WRONG prime, not a slow one (an entity
+// dropped under `otherwise: exclude`, or its default face served when a
+// published row exists further down). With `id_type: sequential` that
+// starts at ten entities.
+//
+// A comparator rather than a lower-sorting separator on purpose: a
+// separator encodes the invariant into an ASCII accident that a future
+// id-grammar change would break silently.
+func CompareStateKeys(a, b string) int {
+	aID, aPtr, _ := strings.Cut(a, entity.StateRefSeparator)
+	bID, bPtr, _ := strings.Cut(b, entity.StateRefSeparator)
+	if c := strings.Compare(aID, bID); c != 0 {
+		return c
+	}
+	return strings.Compare(aPtr, bPtr)
+}
+
+// SortedInsertFunc adds key to a slice sorted by cmp.
+func SortedInsertFunc(s []string, key string, cmp func(a, b string) int) []string {
+	i, _ := slices.BinarySearchFunc(s, key, cmp)
+	return slices.Insert(s, i, key)
+}
+
+// SortedRemoveFunc removes key from a slice sorted by cmp. The key must
+// exist — callers should only call this after confirming presence.
+func SortedRemoveFunc(s []string, key string, cmp func(a, b string) int) []string {
+	i, found := slices.BinarySearchFunc(s, key, cmp)
+	if !found {
+		panic("storeutil: SortedRemoveFunc called with missing key: " + key)
+	}
+	return slices.Delete(s, i, i+1)
+}
+
 // EncodeCursor turns a sort key into an opaque pagination cursor.
 // Callers MUST NOT parse cursors — round-trip only via DecodeCursor.
 func EncodeCursor(key string) string {
@@ -186,6 +234,49 @@ func PaginateSortedKeys(
 	return page
 }
 
+// PaginateSortedKeysFunc is [PaginateSortedKeys] over a slice sorted by
+// cmp rather than by plain string order (TKT-WAV8XP; see
+// [CompareStateKeys]).
+//
+// A cursor issued before the ordering changed is a MISMATCHED cursor,
+// which [store.EntityReader.ListEntitiesPage] documents as
+// implementation-defined — cursors are opaque and valid only for the
+// same query on the same store. It restarts from the beginning rather
+// than resuming at a binary-search position derived under the old
+// ordering, because that position would silently SKIP rows, which a
+// paging caller cannot distinguish from end-of-results. Same reasoning
+// as the unparseable-cursor restart (TKT-DOFYR1 PR-B).
+func PaginateSortedKeysFunc(
+	sortedKeys []string,
+	cursorKey string,
+	limit int,
+	match func(key string) bool,
+	cmp func(a, b string) int,
+) PageKeys {
+	start := 0
+	if cursorKey != "" {
+		i, found := slices.BinarySearchFunc(sortedKeys, cursorKey, cmp)
+		start = i
+		if found {
+			start = i + 1
+		}
+	}
+
+	page := PageKeys{}
+	for i := start; i < len(sortedKeys); i++ {
+		key := sortedKeys[i]
+		if !match(key) {
+			continue
+		}
+		if limit > 0 && len(page.Keys) == limit {
+			page.NextCursor = EncodeCursor(page.Keys[len(page.Keys)-1])
+			return page
+		}
+		page.Keys = append(page.Keys, key)
+	}
+	return page
+}
+
 // SortedRemove removes key from a sorted slice.
 // The key must exist — callers should only call this after confirming presence.
 func SortedRemove(s []string, key string) []string {
@@ -246,6 +337,261 @@ func MatchRelation(r *entity.Relation, q store.RelationQuery) bool {
 		}
 	}
 	return true
+}
+
+// ValidateEntityQuery rejects a query whose fields contradict each
+// other. Today that is AllStates together with a non-default World
+// (TKT-WAV8XP): AllStates is raw storage truth and world resolution is
+// its opposite, so honoring both is impossible and honoring one
+// silently is a precedence rule nobody remembers.
+//
+// It lives here rather than in each backend so every implementation
+// inherits the same refusal — a backend that forgot the check would
+// answer a contradictory query with a plausible-looking result, which
+// is worse than an error. Pinned by the shared conformance suite.
+func ValidateEntityQuery(q store.EntityQuery) error {
+	if q.AllStates && !q.World.IsDefaultWorld() {
+		return fmt.Errorf(
+			"%w: AllStates and World are mutually exclusive — AllStates is raw storage "+
+				"truth, a World resolves each entity to one state", store.ErrInvalidQuery)
+	}
+	return nil
+}
+
+// MatchEntityQuery reports whether an entity with the given type,
+// bare id and pointer satisfies q's Type, IDs and AllStates filters.
+// idSet must be pre-computed from q.IDs (see the backends' entityIDSet)
+// and matches the BARE id, so IDs+AllStates selects every state of the
+// listed entities.
+//
+// It takes the three fields rather than an *entity.Entity because
+// fsstore matches against its in-memory index metadata, which
+// deliberately holds no loaded entity — the previous byte-similar
+// copies in fsstore and memstore had diverged in signature only.
+//
+// This is NOT world resolution and cannot be: a world picks at most one
+// state per entity, which is a per-FAMILY ranked choice, so no
+// per-row predicate can express it. World-scoped listing resolves
+// primes separately, after matching.
+//
+// Under a non-default World the pointer filter is WIDENED rather than
+// applied: every state of a family is a candidate, and resolution
+// chooses among them afterwards. Keeping the default-only filter here
+// would discard the very rows the chain selects, leaving a world able
+// to return only default states — the failure would look like "the
+// world does nothing" rather than an error.
+func MatchEntityQuery(entityType, id string, p entity.Pointer, q store.EntityQuery, idSet map[string]bool) bool {
+	if !q.AllStates && q.World.IsDefaultWorld() && !p.IsDefault() {
+		return false
+	}
+	if q.Type != "" && entityType != q.Type {
+		return false
+	}
+	if len(idSet) > 0 && !idSet[id] {
+		return false
+	}
+	return true
+}
+
+// WorldCandidate is one stored state row offered to [WorldPrimes]: the
+// bare id, its type, and its pointer. Backends pass their index metadata
+// rather than a loaded entity, so resolution costs no I/O.
+type WorldCandidate struct {
+	ID      string
+	Type    string
+	Pointer entity.Pointer
+}
+
+// WorldPrimes selects, per bare id, the single state row that world w
+// resolves to — the "prime" (TKT-WAV8XP, design doc §4.1). It returns
+// the winning pointer per id; an id absent from the result contributes
+// nothing to the world.
+//
+// Candidates must be the rows of WHOLE families: the fallback verdict is
+// a decision about ABSENCE, so an id whose candidates are only partly
+// present can resolve to the wrong prime rather than merely a stale one.
+// That is why the fs/mem index sorts by [CompareStateKeys] and callers
+// buffer a family before deciding.
+//
+// The three resolution rules:
+//
+//   - rule 1: the type has no resolution in w (absent from the scope) —
+//     the DEFAULT state, matching the pre-worlds behavior. Absence is NOT
+//     the zero TypeResolution, which excludes; see [store.WorldScope].
+//   - rule 2: the first coordinate in the chain that EXISTS for this id.
+//   - rule 3: no chain coordinate exists — the chain's Fallback decides,
+//     either the default state or nothing at all.
+//
+// Decisions are made AFTER the whole candidate set is seen, never
+// streaming per row: no backend documents an iteration order strong
+// enough to conclude "this coordinate is absent" mid-family, and the
+// same hazard already bit analysis.CheckStates.
+func WorldPrimes(w store.WorldScope, candidates []WorldCandidate) map[string]entity.Pointer {
+	if len(candidates) == 0 {
+		return nil
+	}
+
+	// Per id: the best rank seen so far (lower wins), whether a default
+	// row exists, and the id's type. Buffered, then decided below.
+	type family struct {
+		typ         string
+		bestRank    int
+		bestPtr     entity.Pointer
+		haveBest    bool
+		haveDefault bool
+	}
+	// The family's type comes from whichever row arrives first. Every
+	// backend rejects a state whose type differs from its family's on
+	// write (StateTypeMismatchError), so a family is single-typed and
+	// the choice is arbitrary-but-equal. It is recorded rather than
+	// re-derived because fsstore builds its index from directory
+	// structure alone, without reading files: a hand-edited tree could
+	// present a mixed-type family, and the answer should not then depend
+	// on map iteration order upstream.
+	fams := make(map[string]*family, len(candidates))
+	for _, c := range candidates {
+		f, ok := fams[c.ID]
+		if !ok {
+			f = &family{typ: c.Type}
+			fams[c.ID] = f
+		}
+		if c.Pointer.IsDefault() {
+			f.haveDefault = true
+			// The default row is the family's identity row everywhere
+			// else in the codebase; prefer its type so a (write-rejected,
+			// hand-edited-tree-only) mixed-type family still resolves the
+			// same way regardless of candidate order.
+			f.typ = c.Type
+		}
+		res, scoped := w.For(c.Type)
+		if !scoped {
+			continue // rule 1: decided below from haveDefault
+		}
+		for rank, coord := range res.Chain {
+			if coord != c.Pointer {
+				continue
+			}
+			if !f.haveBest || rank < f.bestRank {
+				f.bestRank, f.bestPtr, f.haveBest = rank, coord, true
+			}
+			break
+		}
+	}
+
+	out := make(map[string]entity.Pointer, len(fams))
+	for id, f := range fams {
+		res, scoped := w.For(f.typ)
+		switch {
+		case !scoped:
+			// Rule 1: the world says nothing about this type.
+			if f.haveDefault {
+				out[id] = entity.Pointer("")
+			}
+		case f.haveBest:
+			// Rule 2.
+			out[id] = f.bestPtr
+		case res.Fallback == store.FallbackDefaultState && f.haveDefault:
+			// Rule 3, `otherwise: default`.
+			out[id] = entity.Pointer("")
+		default:
+			// Rule 3, `otherwise: exclude` — absence IS the publication
+			// bit, so the id contributes nothing.
+		}
+	}
+	return out
+}
+
+// PaginateWorldPrimes walks a contiguously-ordered key slice and returns
+// up to limit PRIMES, plus the cursor to resume after the last family it
+// emitted (TKT-WAV8XP).
+//
+// The limit counts primes, not candidate rows: an entity holding three
+// faces consumes one slot of a page, not three. Memory is bounded by ONE
+// FAMILY, not by the result set — which is the whole reason the index
+// sorts by [CompareStateKeys]. Buffering everything and cutting
+// afterwards would be correct but O(all matching rows) per page, and a
+// page-at-a-time scan that decided mid-family would produce a WRONG
+// prime, since the fallback verdict is a decision about absence.
+//
+// load maps a key to its candidate; a key that is absent (concurrently
+// deleted) is skipped.
+//
+// match MUST be family-constant — it may only test properties shared by
+// every row of a family (type, bare id), never a per-row property. Rows
+// it rejects never reach [WorldPrimes], and resolution decides on
+// ABSENCE: filtering away the published row makes the chain look
+// unsatisfied, so the fallback fires and the default face is served in a
+// world that meant to replace or exclude it. [MatchEntityQuery] is
+// family-constant today (Type and IDs only). A per-row predicate pushed
+// in here — a property filter, an updated-at bound, a pointer fast path
+// — silently breaks world resolution in the serve-the-wrong-face
+// direction; resolve the family first and filter the primes afterwards.
+func PaginateWorldPrimes(
+	sortedKeys []string,
+	cursorKey string,
+	limit int,
+	w store.WorldScope,
+	match func(key string) bool,
+	load func(key string) (WorldCandidate, bool),
+) PageKeys {
+	start := 0
+	if cursorKey != "" {
+		i, found := slices.BinarySearchFunc(sortedKeys, cursorKey, CompareStateKeys)
+		start = i
+		if found {
+			start = i + 1
+		}
+	}
+
+	page := PageKeys{}
+	var famKeys []string
+	var famCands []WorldCandidate
+
+	// flush resolves one buffered family and appends its prime, if any.
+	// Returns false when the page is full and a further prime exists.
+	flush := func() bool {
+		if len(famCands) == 0 {
+			return true
+		}
+		primes := WorldPrimes(w, famCands)
+		defer func() { famKeys, famCands = famKeys[:0], famCands[:0] }()
+		for i, c := range famCands {
+			p, ok := primes[c.ID]
+			if !ok || p != c.Pointer {
+				continue
+			}
+			if limit > 0 && len(page.Keys) == limit {
+				page.NextCursor = EncodeCursor(page.Keys[len(page.Keys)-1])
+				return false
+			}
+			page.Keys = append(page.Keys, famKeys[i])
+		}
+		return true
+	}
+
+	curID := ""
+	for i := start; i < len(sortedKeys); i++ {
+		key := sortedKeys[i]
+		c, ok := load(key)
+		if !ok {
+			continue
+		}
+		// A family boundary: everything about the previous id has been
+		// seen, so it is safe to decide its prime.
+		if c.ID != curID {
+			if !flush() {
+				return page
+			}
+			curID = c.ID
+		}
+		if !match(key) {
+			continue
+		}
+		famKeys = append(famKeys, key)
+		famCands = append(famCands, c)
+	}
+	flush()
+	return page
 }
 
 // LimitAttachmentReader wraps r so reads fail with

--- a/internal/store/storeutil/worlds_test.go
+++ b/internal/store/storeutil/worlds_test.go
@@ -1,0 +1,324 @@
+package storeutil_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/Sourcehaven-BV/rela/internal/entity"
+	"github.com/Sourcehaven-BV/rela/internal/store"
+	"github.com/Sourcehaven-BV/rela/internal/store/storeutil"
+)
+
+func ptr(t *testing.T, v string) entity.Pointer {
+	t.Helper()
+	p, err := entity.ParsePointer(v)
+	require.NoError(t, err)
+	return p
+}
+
+// pageScope builds a one-type world over `page`.
+func pageScope(t *testing.T, fb store.Fallback, chain ...string) store.WorldScope {
+	t.Helper()
+	coords := make([]entity.Pointer, 0, len(chain))
+	for _, c := range chain {
+		coords = append(coords, ptr(t, c))
+	}
+	return store.NewWorldScope(map[string]store.TypeResolution{
+		"page": {Chain: coords, Fallback: fb},
+	})
+}
+
+func cand(id, typ string, p entity.Pointer) storeutil.WorldCandidate {
+	return storeutil.WorldCandidate{ID: id, Type: typ, Pointer: p}
+}
+
+// TestCompareStateKeys pins the ordering the whole world path depends on:
+// state keys sort as the TUPLE (bare id, pointer), not as the joined
+// string. '@' is 0x40 and the digits are 0x30-0x39, so under plain string
+// order a numerically-prefixed sibling lands inside the family.
+func TestCompareStateKeys(t *testing.T) {
+	t.Run("a family is contiguous", func(t *testing.T) {
+		keys := []string{"PAGE-2", "PAGE-1@published", "PAGE-10", "PAGE-1", "PAGE-10@draft", "PAGE-1@draft"}
+		var got []string
+		for _, k := range keys {
+			got = storeutil.SortedInsertFunc(got, k, storeutil.CompareStateKeys)
+		}
+		assert.Equal(t, []string{
+			"PAGE-1", "PAGE-1@draft", "PAGE-1@published", "PAGE-10", "PAGE-10@draft", "PAGE-2",
+		}, got, "PAGE-10 must not sort between PAGE-1 and its states")
+	})
+
+	t.Run("ordering is total and self-consistent", func(t *testing.T) {
+		cases := []struct {
+			a, b string
+			want int
+		}{
+			{"PAGE-1", "PAGE-1", 0},
+			{"PAGE-1", "PAGE-1@draft", -1},  // default state sorts first
+			{"PAGE-1@draft", "PAGE-1", 1},   // and the inverse
+			{"PAGE-1@draft", "PAGE-10", -1}, // the whole point
+			{"PAGE-1@draft", "PAGE-1@published", -1},
+			{"PAGE-2", "PAGE-10", 1}, // lexical on the id, as before
+		}
+		for _, tc := range cases {
+			assert.Equal(t, tc.want, storeutil.CompareStateKeys(tc.a, tc.b), "%s vs %s", tc.a, tc.b)
+		}
+	})
+}
+
+func TestSortedInsertRemoveFunc(t *testing.T) {
+	var keys []string
+	for _, k := range []string{"PAGE-10", "PAGE-1@draft", "PAGE-1"} {
+		keys = storeutil.SortedInsertFunc(keys, k, storeutil.CompareStateKeys)
+	}
+	assert.Equal(t, []string{"PAGE-1", "PAGE-1@draft", "PAGE-10"}, keys)
+
+	keys = storeutil.SortedRemoveFunc(keys, "PAGE-1@draft", storeutil.CompareStateKeys)
+	assert.Equal(t, []string{"PAGE-1", "PAGE-10"}, keys)
+
+	assert.Panics(t, func() {
+		storeutil.SortedRemoveFunc(keys, "PAGE-404", storeutil.CompareStateKeys)
+	}, "removing a missing key is a caller bug, not a silent no-op")
+}
+
+// TestWorldPrimes covers the three resolution rules directly, so a
+// regression is attributed here rather than only surfacing through a
+// backend's conformance run.
+func TestWorldPrimes(t *testing.T) {
+	def := entity.Pointer("")
+
+	t.Run("rule 2: first existing coordinate wins", func(t *testing.T) {
+		got := storeutil.WorldPrimes(
+			pageScope(t, store.FallbackExclude, "review", "published"),
+			[]storeutil.WorldCandidate{
+				cand("PAGE-1", "page", def),
+				cand("PAGE-1", "page", ptr(t, "review")),
+				cand("PAGE-1", "page", ptr(t, "published")),
+				cand("PAGE-2", "page", def),
+				cand("PAGE-2", "page", ptr(t, "published")),
+			})
+		assert.Equal(t, map[string]entity.Pointer{
+			"PAGE-1": ptr(t, "review"),
+			"PAGE-2": ptr(t, "published"),
+		}, got)
+	})
+
+	t.Run("rule 2 is order-sensitive, not set membership", func(t *testing.T) {
+		cands := []storeutil.WorldCandidate{
+			cand("PAGE-1", "page", ptr(t, "review")),
+			cand("PAGE-1", "page", ptr(t, "published")),
+		}
+		fwd := storeutil.WorldPrimes(pageScope(t, store.FallbackExclude, "review", "published"), cands)
+		rev := storeutil.WorldPrimes(pageScope(t, store.FallbackExclude, "published", "review"), cands)
+		assert.Equal(t, ptr(t, "review"), fwd["PAGE-1"])
+		assert.Equal(t, ptr(t, "published"), rev["PAGE-1"])
+	})
+
+	t.Run("candidate order must not change the answer", func(t *testing.T) {
+		// The chain decides, not the order rows happen to arrive in.
+		w := pageScope(t, store.FallbackExclude, "review", "published")
+		forward := storeutil.WorldPrimes(w, []storeutil.WorldCandidate{
+			cand("PAGE-1", "page", ptr(t, "review")),
+			cand("PAGE-1", "page", ptr(t, "published")),
+		})
+		backward := storeutil.WorldPrimes(w, []storeutil.WorldCandidate{
+			cand("PAGE-1", "page", ptr(t, "published")),
+			cand("PAGE-1", "page", ptr(t, "review")),
+		})
+		assert.Equal(t, forward, backward)
+		assert.Equal(t, ptr(t, "review"), forward["PAGE-1"])
+	})
+
+	t.Run("rule 3: exclude contributes nothing", func(t *testing.T) {
+		got := storeutil.WorldPrimes(
+			pageScope(t, store.FallbackExclude, "published"),
+			[]storeutil.WorldCandidate{cand("PAGE-2", "page", def)})
+		assert.NotContains(t, got, "PAGE-2",
+			"absence IS the publication bit — no fallback to the draft face")
+	})
+
+	t.Run("rule 3: default falls back to the default state", func(t *testing.T) {
+		got := storeutil.WorldPrimes(
+			pageScope(t, store.FallbackDefaultState, "published"),
+			[]storeutil.WorldCandidate{cand("PAGE-2", "page", def)})
+		assert.Equal(t, map[string]entity.Pointer{"PAGE-2": def}, got)
+	})
+
+	t.Run("rule 3 default cannot invent a missing default row", func(t *testing.T) {
+		// A headless family (no default row) has nothing to fall back to.
+		got := storeutil.WorldPrimes(
+			pageScope(t, store.FallbackDefaultState, "published"),
+			[]storeutil.WorldCandidate{cand("PAGE-3", "page", ptr(t, "archived"))})
+		assert.NotContains(t, got, "PAGE-3")
+	})
+
+	t.Run("rule 1: a type the world does not name keeps its default state", func(t *testing.T) {
+		got := storeutil.WorldPrimes(
+			pageScope(t, store.FallbackExclude, "published"),
+			[]storeutil.WorldCandidate{
+				cand("TKT-1", "ticket", def),
+				cand("PAGE-1", "page", def),
+				cand("PAGE-1", "page", ptr(t, "published")),
+			})
+		assert.Equal(t, def, got["TKT-1"],
+			"absence from the scope is rule 1, NOT the zero TypeResolution's exclude")
+		assert.Equal(t, ptr(t, "published"), got["PAGE-1"])
+	})
+
+	t.Run("no candidates", func(t *testing.T) {
+		assert.Nil(t, storeutil.WorldPrimes(pageScope(t, store.FallbackExclude, "published"), nil))
+	})
+}
+
+// TestPaginateWorldPrimes pins that the limit counts PRIMES rather than
+// candidate rows, and that paging never splits or duplicates a family.
+func TestPaginateWorldPrimes(t *testing.T) {
+	// Three entities, each with a default and a published face, in the
+	// tuple order the fs/mem index maintains.
+	keys := []string{
+		"PAGE-1", "PAGE-1@published",
+		"PAGE-10", "PAGE-10@published",
+		"PAGE-2", "PAGE-2@published",
+	}
+	load := func(key string) (storeutil.WorldCandidate, bool) {
+		id, p, err := entity.ParseStateRef(key)
+		if err != nil {
+			return storeutil.WorldCandidate{}, false
+		}
+		return storeutil.WorldCandidate{ID: id, Type: "page", Pointer: p}, true
+	}
+	always := func(string) bool { return true }
+	w := pageScope(t, store.FallbackDefaultState, "published")
+
+	t.Run("the limit counts primes, not rows", func(t *testing.T) {
+		// Six rows, three primes. A limit of 2 must yield 2 entities,
+		// not 2 rows of one entity's family.
+		page := storeutil.PaginateWorldPrimes(keys, "", 2, w, always, load)
+		assert.Equal(t, []string{"PAGE-1@published", "PAGE-10@published"}, page.Keys)
+		assert.NotEmpty(t, page.NextCursor, "a further prime exists")
+	})
+
+	t.Run("paging visits every prime exactly once", func(t *testing.T) {
+		for _, limit := range []int{1, 2, 3, 5} {
+			var got []string
+			cursor := ""
+			for range 10 {
+				page := storeutil.PaginateWorldPrimes(keys, cursor, limit, w, always, load)
+				got = append(got, page.Keys...)
+				if page.NextCursor == "" {
+					break
+				}
+				decoded, err := storeutil.DecodeCursor(page.NextCursor)
+				require.NoError(t, err)
+				cursor = decoded
+			}
+			assert.Equal(t, []string{
+				"PAGE-1@published", "PAGE-10@published", "PAGE-2@published",
+			}, got, "limit %d", limit)
+		}
+	})
+
+	t.Run("an unmatched family still closes cleanly", func(t *testing.T) {
+		// Filtering out PAGE-10 entirely must not merge its neighbors.
+		match := func(key string) bool {
+			id, _, _ := entity.ParseStateRef(key)
+			return id != "PAGE-10"
+		}
+		page := storeutil.PaginateWorldPrimes(keys, "", 0, w, match, load)
+		assert.Equal(t, []string{"PAGE-1@published", "PAGE-2@published"}, page.Keys)
+	})
+
+	t.Run("a row that vanished is skipped", func(t *testing.T) {
+		gone := func(key string) (storeutil.WorldCandidate, bool) {
+			if key == "PAGE-10@published" {
+				return storeutil.WorldCandidate{}, false
+			}
+			return load(key)
+		}
+		page := storeutil.PaginateWorldPrimes(keys, "", 0, w, always, gone)
+		// PAGE-10 keeps only its default row, so the fallback supplies it.
+		assert.Equal(t, []string{"PAGE-1@published", "PAGE-10", "PAGE-2@published"}, page.Keys)
+	})
+}
+
+// TestValidateEntityQuery pins decision Q3: AllStates is raw storage
+// truth and a world resolves each entity to one state, so a query
+// setting both is refused rather than silently resolved.
+func TestValidateEntityQuery(t *testing.T) {
+	world := pageScope(t, store.FallbackExclude, "published")
+
+	t.Run("the contradiction is rejected", func(t *testing.T) {
+		err := storeutil.ValidateEntityQuery(store.EntityQuery{AllStates: true, World: world})
+		assert.ErrorIs(t, err, store.ErrInvalidQuery)
+	})
+
+	t.Run("either alone is fine", func(t *testing.T) {
+		// The zero WorldScope is the DEFAULT world, not "no world" — a
+		// check keyed on the wrong condition would reject every existing
+		// query in the codebase.
+		for _, q := range []store.EntityQuery{
+			{},
+			{AllStates: true},
+			{World: world},
+			{World: store.DefaultWorld()},
+			{AllStates: true, World: store.DefaultWorld()},
+		} {
+			assert.NoError(t, storeutil.ValidateEntityQuery(q), "%+v", q)
+		}
+	})
+}
+
+// TestMatchEntityQuery pins the shared filter, including the widening
+// that world resolution depends on.
+func TestMatchEntityQuery(t *testing.T) {
+	draft := ptr(t, "draft")
+	def := entity.Pointer("")
+
+	t.Run("default-only unless AllStates or a world", func(t *testing.T) {
+		assert.True(t, storeutil.MatchEntityQuery("page", "PAGE-1", def, store.EntityQuery{}, nil))
+		assert.False(t, storeutil.MatchEntityQuery("page", "PAGE-1", draft, store.EntityQuery{}, nil),
+			"a state row is not in the default world")
+		assert.True(t, storeutil.MatchEntityQuery(
+			"page", "PAGE-1", draft, store.EntityQuery{AllStates: true}, nil))
+	})
+
+	t.Run("a non-default world WIDENS the pointer filter", func(t *testing.T) {
+		// Resolution picks the prime afterwards, so every state must
+		// reach it. Filtering to default rows first would leave a world
+		// able to return only default faces — and that reads as a
+		// correctly-empty published world rather than as an error.
+		q := store.EntityQuery{World: pageScope(t, store.FallbackExclude, "published")}
+		assert.True(t, storeutil.MatchEntityQuery("page", "PAGE-1", draft, q, nil))
+		assert.True(t, storeutil.MatchEntityQuery("page", "PAGE-1", def, q, nil))
+	})
+
+	t.Run("type and id filters still apply", func(t *testing.T) {
+		q := store.EntityQuery{Type: "page"}
+		assert.False(t, storeutil.MatchEntityQuery("ticket", "TKT-1", def, q, nil))
+
+		idSet := map[string]bool{"PAGE-1": true}
+		assert.True(t, storeutil.MatchEntityQuery("page", "PAGE-1", def, q, idSet))
+		assert.False(t, storeutil.MatchEntityQuery("page", "PAGE-9", def, q, idSet))
+	})
+}
+
+// A mixed-type family is unreachable through the write API (every
+// backend rejects a state whose type differs from its family's), but
+// fsstore builds its index from directory structure without reading
+// files, so a hand-edited tree can present one. The answer must not
+// depend on the order candidates happen to arrive in.
+func TestWorldPrimes_MixedTypeFamilyIsOrderIndependent(t *testing.T) {
+	w := store.NewWorldScope(map[string]store.TypeResolution{
+		"page": {Chain: []entity.Pointer{"published"}, Fallback: store.FallbackExclude},
+	})
+	def := storeutil.WorldCandidate{ID: "A", Type: "other", Pointer: ""}
+	pub := storeutil.WorldCandidate{ID: "A", Type: "page", Pointer: "published"}
+
+	forward := storeutil.WorldPrimes(w, []storeutil.WorldCandidate{def, pub})
+	reverse := storeutil.WorldPrimes(w, []storeutil.WorldCandidate{pub, def})
+
+	assert.Equal(t, forward, reverse,
+		"candidate order must not change the verdict for a mixed-type family")
+}


### PR DESCRIPTION
PR-B of the TKT-WAV8XP (worlds, Step 2) stack. **Code-only**; paperwork lives on the companion PR.

Tickets-PR: #1394

Stack: #1378 ← #1381 ← #1386 ← #1388 ← #1389 ← #1393 (PR-A) ← **this**. Retarget to `develop` as ancestors merge.

## What lands

- `EntityQuery.World` **and** `GraphQuery.World` (finding F1). Both are needed: `visibility/pushdown.go` swaps an `EntityQuery` for a `GraphQuery` the moment a policy query exists, so a world on only one makes the two paths disagree — specifically for ACL-gated principals.
- `storeutil.ValidateEntityQuery` — `AllStates` + `World` together is a hard `ErrInvalidQuery`. In shared code so no backend can forget it.
- `storeutil.MatchEntityQuery` — folds the duplicated `matchEntityQuery` in fsstore/memstore (finding F3). Takes `(entityType, id, pointer)` rather than an `*entity.Entity` because fsstore matches index metadata with no loaded entity; that signature difference is why the two copies existed.
- `storeutil.CompareStateKeys` + `sortStateKeys` — tuple ordering on `(bare id, pointer)` so an entity's states are contiguous, matching pgstore's `ORDER BY id ASC, pointer ASC`.
- `storeutil.WorldPrimes` / `PaginateWorldPrimes` — resolution buffering **one family**, flushing at id boundaries, counting **primes** against the limit.
- `Capabilities.Worlds` gating `RunWorldTests`, with a `TODO(TKT-WAV8XP-PR-C): remove` marker. PR-C flips pgstore and **deletes the flag** — a transitional flag that outlives its window becomes a permanent conformance opt-out.
- pgstore refuses a non-zero `World` loudly at all 7 entry points until PR-C implements pushdown.

## Why the ordering change

fs/mem sorted a single concatenated key (`PAGE-1@draft`). `@` is 0x40 and digits are 0x30–0x39, so `@` sorts *after* any digit and a numerically-prefixed sibling lands inside the family:

```
PAGE-1  PAGE-10  PAGE-10@draft  PAGE-1@draft  PAGE-1@published  PAGE-2
```

A family-buffering resolver then decides an entity **twice**, and since the fallback verdict is a decision about *absence*, a partial view yields a **wrong** prime rather than a slow one. With `id_type: sequential` this triggers at ten entities. Cursors are contractually opaque and mismatched-cursor behaviour is implementation-defined, so no migration is owed.

## Review findings fixed (2 critical)

Full write-ups on the companion PR #1394: RR-IDXSRT, RR-GQWRLD (critical);
RR-FAMTYP, RR-MATCHF, RR-HDRWLD (significant); RR-CNTALL (minor).

- **Index construction vs mutation ordering** — the two index *construction* sites still sorted the old way, so after any process restart the slice was sorted one way and binary-searched another: a panic on ordinary `DeleteEntity`, in the default world, with no world scope involved. Now pinned by `TestReopenPreservesStateKeyOrdering` covering both cached-restore and cold-scan.
- **`GraphQuery.World` was dropped by `graphquerynaive`** — plumbed into the struct, then discarded, so a world-scoped list silently degraded to unscoped exactly for ACL-gated principals (drafts leak; `otherwise: exclude` stops excluding). Pinned by `GraphQueryHonorsTheWorld` over GraphQuery + GraphCount + MatchingIDs.

Plus: family type now prefers the default row's (order-independence); the family-constant `match` invariant documented at the site; `CountEntities`' allocation-free fast path restored for the default world.

Both criticals share a moral worth stating: **"the field exists" and "the field is honored end-to-end" are different claims needing different tests.** The `GraphQuery.World` fail-open is the failure predicted at design review (RR-7FOWDB) arriving by a different mechanism than expected — not a zero `World` passed in, but a `World` that *was* passed being discarded downstream. Note also that pgstore was safe from it only via its temporary refusal, which **PR-C removes**.

Every fix above is pinned by a test **verified non-vacuous**: each was confirmed to fail when the fix is reverted (for the header case, by neutering *memstore's native* implementation, since fsstore's fallback cannot fail that way).

## Notes for the reviewer

- **Staged gap, not a bug:** `internal/acl/readquery.go` builds `GraphQuery` values with a zero `World`. `internal/acl` cannot import `metamodel` under arch-lint, so it structurally cannot resolve a world; injection is PR-D's job via `internal/worldreader`. **Do not "fix" this by widening acl's deps.** Commented at the site.
- **`ValidateEntityQuery` appears at 3 sites in fsstore vs 4 in memstore.** Not a missed call site: fsstore doesn't implement the optional `HeaderReader`, so `ListEntityHeaders` routes through the generic fallback over `ListEntities`, which is already guarded.
- **`HeaderPathHonorsTheWorld`** closes a gap found by enumerating the paths pgstore's refusal protects: `ListEntityHeaders` is native in memstore/pgstore but a fallback in fsstore, and the pre-existing header suite passes no `World` — so the fallback's correctness masked untested native paths. Verified by neutering memstore's native implementation.
- **`keepPrimes`/`worldKeep` nine-line duplication left deliberately** — a generic over two element types adds more indirection than it saves, and PR-C/PR-D may reshape the call sites.
- **`internal/dataentry` local flake:** the package sits near the 600s default under `-race -cover`, aggravated by parallel local runs across worktrees. Observed, not a confirmed single cause; it passes standalone (455s, zero named failures) with these changes present. CI is the arbiter.
