### PR TITLE
feat(appbuild): apply field-level visible: redaction to the gated read paths (TKT-BUYEW1)

### DIFF
--- a/.go-arch-lint.yml
+++ b/.go-arch-lint.yml
@@ -453,6 +453,12 @@ deps:
       - kvuserstate
       - datamigration
       - acl
+      # appbuild constructs the affordance resolver so the field write gate
+      # and the two gated-read bundles can share ONE instance (TKT-0XL8MF).
+      # Safe as a dependency edge: affordances is a near-leaf (acl, entity,
+      # metamodel, predicate*, principal, statemachine) and imports no
+      # wiring package, so this cannot close a cycle.
+      - affordances
       - app
       - audit
       - caldavalias

--- a/docs-project/entities/guides/GUIDE-scheduled-tasks.md
+++ b/docs-project/entities/guides/GUIDE-scheduled-tasks.md
@@ -141,11 +141,12 @@ Notes:
   principal that `acl.yaml` never assigns a role, the task's reads come back
   empty. A typo produces a silently empty job, so check the identity against
   your assignments when a task stops finding data.
-- **Field-level redaction does not apply to scheduled tasks yet.** Row-level
-  access is enforced (an entity your identity cannot read stays invisible),
-  but `visible:` field policy is *not* applied on this path — a task that may
-  read an entity type receives all of its properties. Do not rely on field
-  policy to hide values from a scheduled script.
+- **Both row- and field-level policy apply.** An entity your identity cannot
+  read stays invisible, and `visible:` field policy redacts hidden property
+  values on the entities it does return — a scheduled task sees the same
+  redacted view a person with that identity sees in the UI. (Field redaction
+  on this path landed in TKT-0XL8MF; before that, row access was enforced but
+  every property of a readable entity came through.)
 - Writes are unaffected: they go through the normal ACL, exactly as before.
 
 ### Schedule Values

--- a/docs/scheduled-tasks.md
+++ b/docs/scheduled-tasks.md
@@ -135,11 +135,12 @@ Notes:
   principal that `acl.yaml` never assigns a role, the task's reads come back
   empty. A typo produces a silently empty job, so check the identity against
   your assignments when a task stops finding data.
-- **Field-level redaction does not apply to scheduled tasks yet.** Row-level
-  access is enforced (an entity your identity cannot read stays invisible),
-  but `visible:` field policy is *not* applied on this path — a task that may
-  read an entity type receives all of its properties. Do not rely on field
-  policy to hide values from a scheduled script.
+- **Both row- and field-level policy apply.** An entity your identity cannot
+  read stays invisible, and `visible:` field policy redacts hidden property
+  values on the entities it does return — a scheduled task sees the same
+  redacted view a person with that identity sees in the UI. (Field redaction
+  on this path landed in TKT-0XL8MF; before that, row access was enforced but
+  every property of a readable entity came through.)
 - Writes are unaffected: they go through the normal ACL, exactly as before.
 
 ### Schedule Values

--- a/internal/appbuild/appbuild.go
+++ b/internal/appbuild/appbuild.go
@@ -1212,6 +1212,52 @@ func (b *SharedBase) Assemble(
 	return assemble(b, st, searcher, visible, searchCloser)
 }
 
+// resolveACLAndRedactor resolves the ACL and derives the field redactor that
+// depends on it. They are returned together because the redactor is a function
+// of the resolved Declarative: splitting them invites a caller that has one
+// without the other, which is precisely the state that left three read paths
+// ungated (TKT-BUYEW1).
+func resolveACLAndRedactor(
+	base *SharedBase, st store.Store,
+) (acl.ACL, *acl.Declarative, visibility.FieldRedactor, error) {
+	resolvedACL, aclDeclarative, err := resolveACL(base, st)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	fieldRedactor, err := buildFieldRedactor(base.meta, st, aclDeclarative)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	return resolvedACL, aclDeclarative, fieldRedactor, nil
+}
+
+// cascadeReadDeps builds the static lua.ReadDeps backing automation cascades.
+//
+// Cascade reads are ACL-BOUND to the ACTING USER (DEC-O59WM4, RR-XC0URX): an
+// automation fires in response to someone's write and runs on that person's
+// ctx, so it reads their view — symmetric with its write path, which already
+// gates through entitymanager and needs an explicit allow_acl_bypass to
+// elevate. Escalating reads is deliberately NOT a config default; it is
+// TKT-ACSBSA (an admin-handle extension), so a cascade that needs more must ask
+// for it in the open.
+//
+// Field-level `visible:` redaction applies here too (TKT-BUYEW1) — a Lua action
+// can send what it reads onward exactly as a scheduled job can, so it must not
+// see property values the same principal has redacted everywhere else.
+func cascadeReadDeps(
+	st store.Store, tr tracer.Tracer, searcher search.Searcher,
+	meta *metamodel.Metamodel, projectRoot string,
+	d *acl.Declarative, redactor visibility.FieldRedactor,
+) lua.ReadDeps {
+	return lua.ReadDeps{
+		VisibleReader: scriptEntityReader(st, d, redactor),
+		Tracer:        scriptTracer(tr, st, d, redactor),
+		Searcher:      searcher,
+		Meta:          meta,
+		ProjectRoot:   projectRoot,
+	}
+}
+
 func assemble(
 	base *SharedBase, st store.Store, searcher search.Searcher,
 	visible search.VisibleSearcher, searchCloser io.Closer,
@@ -1226,12 +1272,7 @@ func assemble(
 		visible = v
 	}
 
-	resolvedACL, aclDeclarative, err := resolveACL(base, st)
-	if err != nil {
-		return nil, err
-	}
-
-	fieldRedactor, err := buildFieldRedactor(base.meta, st, aclDeclarative)
+	resolvedACL, aclDeclarative, fieldRedactor, err := resolveACLAndRedactor(base, st)
 	if err != nil {
 		return nil, err
 	}
@@ -1247,25 +1288,8 @@ func assemble(
 
 	// Build the static lua read deps once — the ScriptRunner (automation
 	// cascades) is constructed with these.
-	//
-	// Cascade reads are ACL-BOUND to the ACTING USER (DEC-O59WM4,
-	// RR-XC0URX): an automation fires in response to someone's write and
-	// runs on that person's ctx, so it reads their view — symmetric with
-	// its write path, which already gates through entitymanager and needs
-	// an explicit allow_acl_bypass to elevate. Escalating reads is
-	// deliberately NOT a config default; it is TKT-ACSBSA (an admin-handle
-	// extension), so a cascade that needs more must ask for it in the open.
-	// Field-level `visible:` redaction applies here too (TKT-425426). A cascade
-	// runs on the acting user's ctx and reads their view, so it must not see
-	// property values the same principal has redacted everywhere else — a Lua
-	// action can send what it reads onward exactly as a scheduled job can.
-	readDeps := lua.ReadDeps{
-		VisibleReader: scriptEntityReader(st, aclDeclarative, fieldRedactor),
-		Tracer:        scriptTracer(tr, st, aclDeclarative, fieldRedactor),
-		Searcher:      searcher,
-		Meta:          base.meta,
-		ProjectRoot:   cfg.Paths.Root,
-	}
+	readDeps := cascadeReadDeps(st, tr, searcher, base.meta, cfg.Paths.Root,
+		aclDeclarative, fieldRedactor)
 
 	tw, err := CompileTransitions(base.meta, st, resolvedACL)
 	if err != nil {

--- a/internal/appbuild/appbuild.go
+++ b/internal/appbuild/appbuild.go
@@ -31,6 +31,7 @@ import (
 	"sync"
 
 	"github.com/Sourcehaven-BV/rela/internal/acl"
+	"github.com/Sourcehaven-BV/rela/internal/affordances"
 	"github.com/Sourcehaven-BV/rela/internal/audit"
 	"github.com/Sourcehaven-BV/rela/internal/autocascade"
 	"github.com/Sourcehaven-BV/rela/internal/automation"
@@ -44,6 +45,7 @@ import (
 	"github.com/Sourcehaven-BV/rela/internal/script"
 	"github.com/Sourcehaven-BV/rela/internal/search"
 	"github.com/Sourcehaven-BV/rela/internal/state"
+	"github.com/Sourcehaven-BV/rela/internal/statemachine"
 	"github.com/Sourcehaven-BV/rela/internal/storage"
 	"github.com/Sourcehaven-BV/rela/internal/store"
 	"github.com/Sourcehaven-BV/rela/internal/templating"
@@ -118,6 +120,17 @@ type Services struct {
 	// gcStop terminates this store's data-migration GC sweep goroutine
 	// (TKT-0C57FS). Per-assembled, torn down in Close like searchCloser.
 	gcStop func()
+	// fieldRedactor applies field-level `visible:` policy to the unattended
+	// and identity-bearing read paths (TKT-425426). Never nil after
+	// construction: [visibility.NopRedactor] when no policy declares
+	// affordance grants, so the no-policy path stays byte-identical.
+	//
+	// It is a FIELD, not an accessor, on purpose. Services sits at its
+	// plimsoll max-exported-methods ceiling, and the underlying resolver
+	// must be fully built before it is shared — [affordances.PolicyResolver.WithMachines]
+	// is the one mutator on an otherwise-immutable value and is safe only
+	// during single-threaded wiring. Constructing here, once, preserves that.
+	fieldRedactor visibility.FieldRedactor
 
 	closeOnce sync.Once
 	closeErr  error
@@ -408,17 +421,12 @@ func (s *Services) luaWriteDepsFor(redactor visibility.FieldRedactor) lua.WriteD
 // privileges coming from acl.yaml — a job sees what its identity may see,
 // nothing more (DEC-O59WM4).
 //
-// KNOWN LIMITATION (RR-7408F5): appbuild has no affordance resolver, so
-// scheduled jobs get ROW gating only — **field-level `visible:` redaction
-// does NOT apply here**. A job whose identity may read `person` receives
-// every property of it, including ones a human with the same role would
-// have redacted in the UI. Row gating still bounds WHICH entities reach a
-// prompt, which is the larger half, but do not assume field policy is
-// enforced on this path. Documented for operators in
-// docs/scheduled-tasks.md next to `run_as`; closing it means wiring an
-// affordance resolver into appbuild.
+// Field-level `visible:` redaction APPLIES here (TKT-0XL8MF): a job whose
+// identity may read `person` receives that entity with the same properties
+// redacted as a human with the same role sees in the UI. This closed
+// RR-7408F5, which documented the earlier row-gating-only behavior.
 func (s *Services) ScheduledLuaWriteDeps() lua.WriteDeps {
-	return s.luaWriteDepsFor(nil)
+	return s.luaWriteDepsFor(s.fieldRedactor)
 }
 
 // GatedReads returns the read handles bound to whatever principal is on the
@@ -443,13 +451,14 @@ func (s *Services) ScheduledLuaWriteDeps() lua.WriteDeps {
 // visibility.DenyReader / DenyTracer rather than degrading to raw reads
 // (RR-GKCZO5).
 //
-// KNOWN LIMITATION, same as [Services.ScheduledLuaWriteDeps]: appbuild has no
-// affordance resolver, so this is ROW gating only — field-level `visible:`
-// redaction does NOT apply. Row gating bounds WHICH entities are reachable,
-// which is the larger half; do not assume field policy is enforced here.
+// Gating is BOTH row-level and field-level (TKT-0XL8MF): the reader prunes
+// entities the principal may not see, and redacts `visible:`-hidden property
+// values on the ones it returns. The validator is built over that same reader,
+// so a violation message cannot quote a value the requester cannot read
+// (the field-level half of TKT-3FL2S6).
 func (s *Services) GatedReads() GatedReadBundle {
-	reader := scriptEntityReader(s.store, s.aclDeclarative, nil)
-	tr := scriptTracer(s.tracer, s.store, s.aclDeclarative, nil)
+	reader := scriptEntityReader(s.store, s.aclDeclarative, s.fieldRedactor)
+	tr := scriptTracer(s.tracer, s.store, s.aclDeclarative, s.fieldRedactor)
 
 	deps := s.LuaReadDeps()
 	deps.VisibleReader = reader
@@ -656,6 +665,10 @@ func NewFromCollaborators(c Collaborators) (*Services, error) {
 		}
 		visible = v
 	}
+	fieldRedactor, err := buildFieldRedactor(c.Meta, c.Store, c.Declarative)
+	if err != nil {
+		return nil, fmt.Errorf("appbuild.NewFromCollaborators: %w", err)
+	}
 	return &Services{
 		fs:              c.FS,
 		paths:           c.Paths,
@@ -676,7 +689,59 @@ func NewFromCollaborators(c Collaborators) (*Services, error) {
 		aclDeclarative:  c.Declarative,
 		aclPolicy:       aclPolicy,
 		audit:           c.Audit,
+		fieldRedactor:   fieldRedactor,
 	}, nil
+}
+
+// buildFieldRedactor constructs the field-level `visible:` redactor shared by
+// every appbuild-wired read path (TKT-0XL8MF). Before this existed, appbuild
+// could not build an affordance resolver at all, so the unattended and
+// identity-bearing paths were ROW-gated only and every property of a readable
+// entity came through — including ones a human with the same role sees
+// redacted in the UI.
+//
+// Returns [visibility.NopRedactor] (hide nothing) when no policy is wired or
+// the policy declares no affordance grants. Those are ordinary configurations
+// — NopACL, or an acl.yaml with only row rules — not failures, and the
+// no-policy path must stay byte-identical to pre-ACL behavior.
+//
+// A policy that DOES declare grants but fails to compile is an error, not a
+// fallback: it is returned to the caller, which aborts construction. Degrading
+// to NopRedactor there would silently serve unredacted properties to an
+// operator who had asked for redaction — the fail-open this whole path exists
+// to prevent (RR-GKCZO5).
+//
+// The resolver is built to completion here — including WithMachines — before
+// it escapes into a redactor, which is what keeps its documented
+// "safe for concurrent use after construction" guarantee true.
+func buildFieldRedactor(
+	meta *metamodel.Metamodel, st store.Store, d *acl.Declarative,
+) (visibility.FieldRedactor, error) {
+	if d == nil {
+		return visibility.NopRedactor{}, nil
+	}
+	// Read the policy through Declarative, never a second channel — the two
+	// must not drift (RR-WTLD).
+	policy := d.Policy()
+	if policy == nil || !policy.HasAffordanceGrants() {
+		return visibility.NopRedactor{}, nil
+	}
+
+	resolver, err := affordances.New(meta, storeRelationLookup{st: st}, d)
+	if err != nil {
+		return nil, fmt.Errorf("appbuild: compiling acl.yaml affordance predicates: %w", err)
+	}
+	machines, err := statemachine.Compile(meta)
+	if err != nil {
+		return nil, fmt.Errorf("appbuild: compiling state machines: %w", err)
+	}
+	resolver.WithMachines(machines)
+
+	redactor, err := visibility.NewPolicyRedactor(resolver)
+	if err != nil {
+		return nil, fmt.Errorf("appbuild: build field redactor: %w", err)
+	}
+	return redactor, nil
 }
 
 // buildAutomation wires the automation engine + cascade runner from
@@ -1159,6 +1224,11 @@ func assemble(
 		return nil, err
 	}
 
+	fieldRedactor, err := buildFieldRedactor(base.meta, st, aclDeclarative)
+	if err != nil {
+		return nil, err
+	}
+
 	autoEngine, cascadeRunner, err := buildAutomation(base.meta)
 	if err != nil {
 		return nil, err
@@ -1265,6 +1335,7 @@ func assemble(
 		aclDeclarative:  aclDeclarative,
 		aclPolicy:       base.aclPolicy,
 		audit:           cfg.Audit,
+		fieldRedactor:   fieldRedactor,
 	}, nil
 }
 

--- a/internal/appbuild/appbuild.go
+++ b/internal/appbuild/appbuild.go
@@ -451,11 +451,18 @@ func (s *Services) ScheduledLuaWriteDeps() lua.WriteDeps {
 // visibility.DenyReader / DenyTracer rather than degrading to raw reads
 // (RR-GKCZO5).
 //
-// Gating is BOTH row-level and field-level (TKT-0XL8MF): the reader prunes
-// entities the principal may not see, and redacts `visible:`-hidden property
-// values on the ones it returns. The validator is built over that same reader,
-// so a violation message cannot quote a value the requester cannot read
+// Gating is BOTH row-level and field-level (TKT-425426): the reader prunes
+// entities the principal may not see, and redacts `visible:`-hidden ENTITY
+// PROPERTY values on the ones it returns. The validator is built over that same
+// reader, so a violation message cannot quote a value the requester cannot read
 // (the field-level half of TKT-3FL2S6).
+//
+// SCOPE: field redaction covers entity properties only. Relation meta is NOT
+// redacted here — [gatedGraphReader.GetRelation] reads raw, and relation-level
+// `visible:` grants (acl.RelationGrant.Visible, honored on the dataentry wire
+// via affordances.RelationFieldVerdicts) are not consulted. Relations are gated
+// at the ROW level on both endpoints; their properties are not. Do not read the
+// paragraph above as covering them.
 func (s *Services) GatedReads() GatedReadBundle {
 	reader := scriptEntityReader(s.store, s.aclDeclarative, s.fieldRedactor)
 	tr := scriptTracer(s.tracer, s.store, s.aclDeclarative, s.fieldRedactor)
@@ -1248,9 +1255,13 @@ func assemble(
 	// an explicit allow_acl_bypass to elevate. Escalating reads is
 	// deliberately NOT a config default; it is TKT-ACSBSA (an admin-handle
 	// extension), so a cascade that needs more must ask for it in the open.
+	// Field-level `visible:` redaction applies here too (TKT-425426). A cascade
+	// runs on the acting user's ctx and reads their view, so it must not see
+	// property values the same principal has redacted everywhere else — a Lua
+	// action can send what it reads onward exactly as a scheduled job can.
 	readDeps := lua.ReadDeps{
-		VisibleReader: scriptEntityReader(st, aclDeclarative, nil),
-		Tracer:        scriptTracer(tr, st, aclDeclarative, nil),
+		VisibleReader: scriptEntityReader(st, aclDeclarative, fieldRedactor),
+		Tracer:        scriptTracer(tr, st, aclDeclarative, fieldRedactor),
 		Searcher:      searcher,
 		Meta:          base.meta,
 		ProjectRoot:   cfg.Paths.Root,

--- a/internal/appbuild/fieldredaction_test.go
+++ b/internal/appbuild/fieldredaction_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/Sourcehaven-BV/rela/internal/entity"
 	"github.com/Sourcehaven-BV/rela/internal/principal"
 	"github.com/Sourcehaven-BV/rela/internal/store"
 )
@@ -244,5 +245,129 @@ func TestGatedReads_RedactsOnListPath(t *testing.T) {
 	}
 	if seen != 1 {
 		t.Errorf("listed %d entities, want 1 — the row gate dropped a readable row", seen)
+	}
+}
+
+// cascadeLeakMetamodel fires an automation on ticket update whose Lua action
+// reads the person entity and copies the salary onto the ticket — laundering a
+// hidden value onto a field with no `visible:` restriction. If the cascade's
+// read is redacted the copy lands as the NO_SALARY marker; if it is not, the
+// hidden value itself is written where anyone may read it.
+const cascadeLeakMetamodel = `version: "1.0"
+entities:
+  person:
+    label: Person
+    plural: people
+    id_prefix: "PERS-"
+    id_type: sequential
+    properties:
+      name:
+        type: string
+      salary:
+        type: string
+  ticket:
+    label: Ticket
+    plural: tickets
+    id_prefix: "TKT-"
+    id_type: sequential
+    properties:
+      title:
+        type: string
+      leaked:
+        type: string
+relations: {}
+automations:
+  - name: leak-salary
+    on:
+      entity: [ticket]
+      property: title
+    do:
+      - lua: |
+          local p = rela.get_entity("PERS-1")
+          local v = "NO_ENTITY"
+          if p ~= nil then
+            v = "NO_SALARY"
+            if p.properties ~= nil and p.properties.salary ~= nil and p.properties.salary ~= "" then
+              v = p.properties.salary
+            end
+          end
+          rela.update_entity("TKT-1", {leaked = v})
+`
+
+// TestCascadeReadDeps_RedactsHiddenField covers the THIRD read path that passed
+// a nil redactor: the static lua.ReadDeps backing automation cascades.
+//
+// It carried no KNOWN LIMITATION note, which is why the first pass at this work
+// missed it — but it is identity-bearing by exactly the definition that
+// justified fixing the other two. A cascade fires on the acting user's ctx and
+// reads their view (DEC-O59WM4, RR-XC0URX), and a Lua action can send what it
+// reads onward just as a scheduled job can.
+//
+// End-to-end on purpose: it drives a real PatchEntity, a real automation
+// trigger, and a real Lua action, then re-reads the STORE (the cascade writes
+// after the returned snapshot is taken). Against a nil redactor `leaked` comes
+// back "99000".
+func TestCascadeReadDeps_RedactsHiddenField(t *testing.T) {
+	root := t.TempDir()
+	writeMetamodelBody(t, root, cascadeLeakMetamodel)
+	writePolicy(t, root, `roles:
+  viewer:
+    read: ["*"]
+    update: ["*"]
+    visible:
+      person:
+        - field: name
+assignments:
+  bob: viewer
+`)
+
+	people := filepath.Join(root, "entities", "people")
+	if err := os.MkdirAll(people, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	person := "---\nid: PERS-1\ntype: person\nname: Alice\nsalary: \"99000\"\n---\n"
+	if err := os.WriteFile(filepath.Join(people, "PERS-1.md"), []byte(person), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	tickets := filepath.Join(root, "entities", "tickets")
+	if err := os.MkdirAll(tickets, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	ticket := "---\nid: TKT-1\ntype: ticket\ntitle: Old\n---\n"
+	if err := os.WriteFile(filepath.Join(tickets, "TKT-1.md"), []byte(ticket), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	svc, err := appbuildOnDisk(t, root)
+	if err != nil {
+		t.Fatalf("appbuild.New: %v", err)
+	}
+	defer svc.Close()
+
+	ctx := bobCtx(principal.ToolDataEntry)
+	res, err := svc.EntityManager().PatchEntity(ctx, "TKT-1", entity.Patch{
+		Properties: map[string]any{"title": "New"},
+	})
+	if err != nil {
+		t.Fatalf("PatchEntity: %v", err)
+	}
+	if len(res.AutomationErrors) != 0 {
+		t.Fatalf("automation errors: %v", res.AutomationErrors)
+	}
+
+	// Re-read the store: the cascade's write lands after the returned snapshot.
+	after, err := svc.Store().GetEntity(ctx, "TKT-1")
+	if err != nil {
+		t.Fatalf("re-read: %v", err)
+	}
+	got := after.GetString("leaked")
+	if got == "NO_ENTITY" {
+		t.Fatalf("leaked = %q — the cascade could not read the entity at all; "+
+			"this test must exercise a real read, not a row-gate denial", got)
+	}
+	if got != "NO_SALARY" {
+		t.Errorf("leaked = %q, want \"NO_SALARY\" — an automation cascade read a "+
+			"`visible:`-hidden value and copied it onto a readable field; cascade "+
+			"reads are ACL-bound to the acting user (DEC-O59WM4)", got)
 	}
 }

--- a/internal/appbuild/fieldredaction_test.go
+++ b/internal/appbuild/fieldredaction_test.go
@@ -1,3 +1,5 @@
+//go:build !postgres && !memorybackend
+
 package appbuild_test
 
 import (

--- a/internal/appbuild/fieldredaction_test.go
+++ b/internal/appbuild/fieldredaction_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/Sourcehaven-BV/rela/internal/principal"
+	"github.com/Sourcehaven-BV/rela/internal/store"
 )
 
 // redactionMetamodel declares a type with a property a policy can hide.
@@ -208,5 +209,40 @@ assignments:
 	if got.GetString("salary") != "99000" {
 		t.Errorf("salary = %q, want \"99000\" — a policy with no `visible:` grants "+
 			"must not redact anything", got.GetString("salary"))
+	}
+}
+
+// TestGatedReads_RedactsOnListPath pins the LIST surface, which is separate
+// code from GetEntity (internal/visibility/luareader.go has its own batching
+// path with a per-surviving-row redaction step). It is also the higher-volume
+// leak: a script calling list_entities is how bulk hidden data would escape,
+// not a single GetEntity.
+func TestGatedReads_RedactsOnListPath(t *testing.T) {
+	root := writeRedactionProject(t)
+	svc, err := appbuildOnDisk(t, root)
+	if err != nil {
+		t.Fatalf("appbuild.New: %v", err)
+	}
+	defer svc.Close()
+
+	seen := 0
+	for e, err := range svc.GatedReads().Reader.ListEntities(
+		bobCtx(principal.ToolMCP), store.EntityQuery{Type: "person"},
+	) {
+		if err != nil {
+			t.Fatalf("ListEntities: %v", err)
+		}
+		seen++
+		if e.GetString("name") != "Alice" {
+			t.Errorf("name = %q, want \"Alice\" — a permitted field was redacted on the list path",
+				e.GetString("name"))
+		}
+		if v := e.GetString("salary"); v != "" {
+			t.Errorf("salary = %q, want redacted to empty — a `visible:`-hidden value "+
+				"escaped via the LIST path even though GetEntity redacts it", v)
+		}
+	}
+	if seen != 1 {
+		t.Errorf("listed %d entities, want 1 — the row gate dropped a readable row", seen)
 	}
 }

--- a/internal/appbuild/fieldredaction_test.go
+++ b/internal/appbuild/fieldredaction_test.go
@@ -1,0 +1,212 @@
+package appbuild_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/Sourcehaven-BV/rela/internal/principal"
+)
+
+// redactionMetamodel declares a type with a property a policy can hide.
+const redactionMetamodel = `version: "1.0"
+entities:
+  person:
+    label: Person
+    plural: people
+    id_prefix: "PERS-"
+    id_type: sequential
+    properties:
+      name:
+        type: string
+      salary:
+        type: string
+relations: {}
+`
+
+// redactionPolicy hides person.salary from the `viewer` role while leaving the
+// row itself readable. That split is the point: row gating alone would let
+// every property through, so a test asserting only "the entity is visible"
+// would pass with no redaction at all.
+const redactionPolicy = `roles:
+  viewer:
+    read: ["*"]
+    visible:
+      person:
+        - field: name
+assignments:
+  bob: viewer
+`
+
+// writeRedactionProject lays down a project whose policy redacts a field, plus
+// one entity carrying a value that must not escape.
+func writeRedactionProject(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	writeMetamodelBody(t, root, redactionMetamodel)
+	writePolicy(t, root, redactionPolicy)
+
+	dir := filepath.Join(root, "entities", "people")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	body := "---\nid: PERS-1\ntype: person\nname: Alice\nsalary: \"99000\"\n---\n"
+	if err := os.WriteFile(filepath.Join(dir, "PERS-1.md"), []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return root
+}
+
+// bobCtx returns a ctx carrying the principal the policy assigns to `viewer`,
+// stamped with the tool the surface under test actually runs as. Both fields
+// are required: acl rejects a half-stamped principal and the row gate then
+// fails closed, which would make a redaction test pass for the wrong reason
+// (nothing returned at all).
+func bobCtx(tool string) context.Context {
+	return principal.With(context.Background(), principal.Principal{User: "bob", Tool: tool})
+}
+
+// TestGatedReads_RedactsHiddenField closes the field-level half of the
+// GatedReads limitation (TKT-0XL8MF).
+//
+// GatedReads previously passed a nil redactor, so this path was ROW gating
+// only: an MCP caller who could read `person` at all received every property,
+// including ones the same role sees redacted in the UI. Against that code this
+// test fails on the salary assertion.
+func TestGatedReads_RedactsHiddenField(t *testing.T) {
+	root := writeRedactionProject(t)
+	svc, err := appbuildOnDisk(t, root)
+	if err != nil {
+		t.Fatalf("appbuild.New: %v", err)
+	}
+	defer svc.Close()
+
+	got, err := svc.GatedReads().Reader.GetEntity(bobCtx(principal.ToolMCP), "PERS-1")
+	if err != nil {
+		t.Fatalf("GetEntity: %v", err)
+	}
+	if got == nil {
+		t.Fatal("entity is nil — the row gate hid a row the policy permits reading")
+	}
+	// The visible property must survive: over-redaction is as wrong as none.
+	if got.GetString("name") != "Alice" {
+		t.Errorf("name = %q, want \"Alice\" — a permitted field was redacted", got.GetString("name"))
+	}
+	if v := got.GetString("salary"); v != "" {
+		t.Errorf("salary = %q, want redacted to empty — a `visible:`-hidden value "+
+			"reached an MCP read; row gating alone does not redact fields", v)
+	}
+}
+
+// TestScheduledLuaWriteDeps_RedactsHiddenField closes RR-7408F5, the same gap
+// on the scheduler path. A scheduled job's reads flow into whatever the job
+// sends onward (a prompt, a webhook), so an unredacted property here leaves
+// the system entirely.
+func TestScheduledLuaWriteDeps_RedactsHiddenField(t *testing.T) {
+	root := writeRedactionProject(t)
+	svc, err := appbuildOnDisk(t, root)
+	if err != nil {
+		t.Fatalf("appbuild.New: %v", err)
+	}
+	defer svc.Close()
+
+	deps := svc.ScheduledLuaWriteDeps()
+	if deps.VisibleReader == nil {
+		t.Fatal("ScheduledLuaWriteDeps has no VisibleReader")
+	}
+	got, err := deps.VisibleReader.GetEntity(bobCtx(principal.ToolScheduler), "PERS-1")
+	if err != nil {
+		t.Fatalf("GetEntity: %v", err)
+	}
+	if got == nil {
+		t.Fatal("entity is nil — the row gate hid a row the policy permits reading")
+	}
+	if got.GetString("name") != "Alice" {
+		t.Errorf("name = %q, want \"Alice\" — a permitted field was redacted", got.GetString("name"))
+	}
+	if v := got.GetString("salary"); v != "" {
+		t.Errorf("salary = %q, want redacted to empty — a scheduled job read a "+
+			"`visible:`-hidden value (RR-7408F5)", v)
+	}
+}
+
+// TestNoPolicy_RedactorHidesNothing pins the byte-parity path. A project with
+// no acl.yaml must behave exactly as it did pre-ACL; if buildFieldRedactor
+// returned a policy-backed redactor (or nil) here instead of NopRedactor, this
+// would regress silently for every existing project.
+func TestNoPolicy_RedactorHidesNothing(t *testing.T) {
+	root := t.TempDir()
+	writeMetamodelBody(t, root, redactionMetamodel)
+	// deliberately no acl.yaml
+
+	dir := filepath.Join(root, "entities", "people")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	body := "---\nid: PERS-1\ntype: person\nname: Alice\nsalary: \"99000\"\n---\n"
+	if err := os.WriteFile(filepath.Join(dir, "PERS-1.md"), []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	svc, err := appbuildOnDisk(t, root)
+	if err != nil {
+		t.Fatalf("appbuild.New: %v", err)
+	}
+	defer svc.Close()
+
+	got, err := svc.GatedReads().Reader.GetEntity(bobCtx(principal.ToolMCP), "PERS-1")
+	if err != nil {
+		t.Fatalf("GetEntity: %v", err)
+	}
+	if got == nil {
+		t.Fatal("entity is nil — no policy is configured, nothing may be hidden")
+	}
+	if got.GetString("salary") != "99000" {
+		t.Errorf("salary = %q, want \"99000\" — with no acl.yaml the read must be "+
+			"byte-identical to pre-ACL behavior", got.GetString("salary"))
+	}
+}
+
+// TestPolicyWithoutAffordanceGrants_HidesNothing covers the third
+// buildFieldRedactor branch: an acl.yaml that gates ROWS but declares no
+// `visible:` grants. HasAffordanceGrants is false there, so the redactor must
+// be NopRedactor — not a policy-backed one that hides nothing by accident, and
+// not an error. Row-only policies are a normal, common configuration.
+func TestPolicyWithoutAffordanceGrants_HidesNothing(t *testing.T) {
+	root := t.TempDir()
+	writeMetamodelBody(t, root, redactionMetamodel)
+	writePolicy(t, root, `roles:
+  viewer:
+    read: ["*"]
+assignments:
+  bob: viewer
+`)
+
+	dir := filepath.Join(root, "entities", "people")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	body := "---\nid: PERS-1\ntype: person\nname: Alice\nsalary: \"99000\"\n---\n"
+	if err := os.WriteFile(filepath.Join(dir, "PERS-1.md"), []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	svc, err := appbuildOnDisk(t, root)
+	if err != nil {
+		t.Fatalf("appbuild.New: %v", err)
+	}
+	defer svc.Close()
+
+	got, err := svc.GatedReads().Reader.GetEntity(bobCtx(principal.ToolMCP), "PERS-1")
+	if err != nil {
+		t.Fatalf("GetEntity: %v", err)
+	}
+	if got == nil {
+		t.Fatal("entity is nil — the policy grants read on this row")
+	}
+	if got.GetString("salary") != "99000" {
+		t.Errorf("salary = %q, want \"99000\" — a policy with no `visible:` grants "+
+			"must not redact anything", got.GetString("salary"))
+	}
+}

--- a/internal/appbuild/relationlookup.go
+++ b/internal/appbuild/relationlookup.go
@@ -1,0 +1,50 @@
+package appbuild
+
+import (
+	"context"
+
+	"github.com/Sourcehaven-BV/rela/internal/store"
+)
+
+// storeRelationLookup adapts a [store.Store] to
+// [affordances.RelationLookup], the read surface the affordance
+// predicate host functions (has_relation, count_relations) call.
+//
+// It holds the store rather than a snapshot: the resolver is built once at
+// wiring time but answers per-request, so a captured snapshot would go stale.
+// Each call scans the store directly, which is why the resolver is only ever
+// consulted per-entity rather than per-row of a list.
+//
+// This mirrors the adapter internal/dataentry has used since affordances
+// landed; it lives here too so the appbuild-wired paths can build a resolver
+// without importing dataentry (TKT-0XL8MF).
+type storeRelationLookup struct {
+	st store.Store
+}
+
+// OutgoingCounts tallies outgoing edges by type in a single scan.
+func (l storeRelationLookup) OutgoingCounts(ctx context.Context, fromID string) map[string]int {
+	counts := map[string]int{}
+	for rel, err := range l.st.ListRelations(ctx, store.RelationQuery{
+		From: fromID, Direction: store.DirectionOutgoing,
+	}) {
+		if err != nil || rel == nil {
+			continue
+		}
+		counts[rel.Type]++
+	}
+	return counts
+}
+
+// HasEdge reports whether the (from, type, to) triple exists.
+func (l storeRelationLookup) HasEdge(ctx context.Context, fromID, relType, toID string) bool {
+	for rel, err := range l.st.ListRelations(ctx, store.RelationQuery{
+		From: fromID, Type: relType, To: toID, Direction: store.DirectionOutgoing,
+	}) {
+		if err != nil || rel == nil {
+			continue
+		}
+		return true
+	}
+	return false
+}

--- a/internal/dataentry/affordances_policy.go
+++ b/internal/dataentry/affordances_policy.go
@@ -85,6 +85,10 @@ func (p *policyResolver) EntryValues(entityType string) map[string]string {
 // the resolver itself snapshots once per call by virtue of being
 // invoked once per per-entity GET (the App captures appState.Load() at
 // the top of each handler).
+// NOTE: internal/appbuild/relationlookup.go holds a deliberate copy of this
+// adapter (appbuild cannot import dataentry). The two are behaviourally
+// identical and both feed affordance `when:` predicates — fix bugs in BOTH or
+// the two surfaces will disagree about who may see what.
 type storeRelationLookup struct {
 	st store.Store
 }

--- a/tickets/entities/docs-checklists/DOCS-VKKN1W.md
+++ b/tickets/entities/docs-checklists/DOCS-VKKN1W.md
@@ -1,0 +1,55 @@
+---
+id: DOCS-VKKN1W
+type: docs-checklist
+title: 'Docs: field-level redaction on the appbuild gated read paths'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Code Documentation
+
+- [x] Comments where logic isn't obvious
+- [x] Function/type docs if public API
+
+`buildFieldRedactor` carries the reasoning that is not inferable from the code:
+why `NopRedactor` is correct for two distinct no-op cases, why a compile
+failure is an **error** rather than a fallback (RR-GKCZO5), and why the
+resolver is built to completion before it escapes (`WithMachines` is the one
+mutator on an otherwise-immutable value).
+
+The `Services.fieldRedactor` field documents why it is a field and not an
+accessor — `Services` is at its plimsoll ceiling, and a field preserves
+construct-then-publish.
+
+Two KNOWN LIMITATION blocks were **deleted** rather than edited, since the
+limitation is gone; each site now states positively what applies. The
+`GatedReads` godoc names the relation carve-out explicitly (RR-9WKQ2M) so the
+guarantee is not read wider than it is.
+
+## Project Documentation
+
+- [x] ~~README updated~~ (N/A: no new command, flag or entry point)
+- [x] CLAUDE.md updated (if new patterns)
+- [x] ~~Help text accurate~~ (N/A: no CLI surface change)
+
+CLAUDE.md needed **no edit**, and that is the point worth recording: its
+read-side rule ("Read-out paths go through visibility wrappers, base readers
+stay ungated", DEC-ZBI39P) already stated the intended behaviour. This change
+did not introduce a pattern — it made three paths match the pattern already
+written down. Adding prose would have implied a new rule where the real defect
+was code drifting from an existing one.
+
+## External Documentation
+
+- [x] ~~Changelog entry added~~ (N/A: no CHANGELOG.md in this repo; release
+notes are generated from commits)
+- [x] API docs updated (if applicable)
+
+`docs-project/entities/guides/GUIDE-scheduled-tasks.md` stated that field
+policy did **not** apply to scheduled tasks — true when written, false after
+this change. Corrected at the source entity and regenerated into
+`docs/scheduled-tasks.md` via `./scripts/generate-docs.sh`; editing only the
+generated file fails the `Docs` CI check. The note now also says when the
+behaviour changed, so an operator reading it against an older binary is not
+misled in the opposite direction.

--- a/tickets/entities/implementation-checklists/IMPL-IWIXTF.md
+++ b/tickets/entities/implementation-checklists/IMPL-IWIXTF.md
@@ -1,0 +1,94 @@
+---
+id: IMPL-IWIXTF
+type: implementation-checklist
+title: 'Implementation: Apply field-level visible: redaction to the appbuild gated read paths'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Development
+
+- [x] Unit tests written for new code
+- [x] Integration tests written (test full flow, not just units)
+- [x] Happy path implemented
+- [x] Edge cases from planning handled
+- [x] Error handling in place (errors surfaced, not swallowed)
+
+Six tests in `internal/appbuild/fieldredaction_test.go`. The cascade test is a
+genuine integration test: real `PatchEntity` → real automation trigger → real
+inline-Lua action → store re-read, no doubles anywhere.
+
+Error handling is the load-bearing part. `buildFieldRedactor` returns an
+**error** when a policy declares affordance grants but fails to compile, and
+both construction paths propagate it to abort startup. Degrading to
+`NopRedactor` there would silently serve unredacted data to an operator who
+had explicitly asked for redaction (RR-GKCZO5).
+
+## Test Quality
+
+- [x] Using fixture builders or factories for test data
+- [x] No hardcoded values in assertions when object is in scope
+- [x] Only specifying values that matter for the test
+- [x] Interpolated values constructed from objects, not hardcoded
+- [x] Property comparisons use original object, not hardcoded strings
+
+`writeRedactionProject` is the shared fixture. The metamodel declares exactly
+two properties — one visible, one hidden — because the pair is the whole test:
+asserting only on the hidden one would pass against a redactor that hid
+everything.
+
+**All four redaction tests are mutation-verified.** Reverting the redactor to
+`nil` makes each fail on its own assertion; restoring makes them pass. Verified
+again after rebasing onto develop (33 commits), since `appbuild.go` had been
+refactored underneath.
+
+## Manual Verification
+
+- [x] Feature manually tested end-to-end
+- [x] Each acceptance criterion verified with test scenario from planning
+- [x] Edge cases manually verified
+
+**Verification Evidence:**
+
+| AC | Test | Result |
+|---|---|---|
+| MCP read redacts | `TestGatedReads_RedactsHiddenField` | PASS (fails without fix) |
+| List path redacts | `TestGatedReads_RedactsOnListPath` | PASS (fails without fix) |
+| Scheduler redacts (RR-7408F5) | `TestScheduledLuaWriteDeps_RedactsHiddenField` | PASS (fails without fix) |
+| Cascade redacts | `TestCascadeReadDeps_RedactsHiddenField` | PASS (fails without fix) |
+| No `acl.yaml` → byte-parity | `TestNoPolicy_RedactorHidesNothing` | PASS |
+| Row-only policy → no redaction | `TestPolicyWithoutAffordanceGrants_HidesNothing` | PASS |
+| Both KNOWN LIMITATION notes deleted | godoc diff | PASS |
+| `just arch-lint` | full run | PASS |
+
+The cascade case is the sharpest evidence: without the fix it writes
+`leaked = "99000"` — the hidden salary laundered onto a field with no
+restriction, where any reader sees it. That is the leak, demonstrated rather
+than argued.
+
+**A wrong diagnosis I had to correct.** I first reported the cascade path as
+untestable because "inline-Lua cascade writes don't persist." That was wrong:
+`rela.update_entity` takes the properties table **directly** as argument 2, and
+I passed `{properties = {...}}`, which set a property literally named
+`properties` — a successful write that changed nothing observable, with no
+error. The tell was in my own probe output (`ok=true` plus a returned table),
+which I read past. No rela bug; a wrong call signature in my harness.
+
+## Quality
+
+- [x] Code follows project patterns (check similar code)
+- [x] Checked for DRY opportunities
+- [x] No security issues introduced
+- [x] No silent failures (errors logged AND returned)
+- [x] No debug code left behind
+
+The resolver is a **private field, not an accessor**: `Services` sits exactly at
+its plimsoll `max-exported-methods=24` ceiling, so an accessor breaks CI — and
+a field is the better design regardless, since it preserves the
+construct-then-publish discipline `WithMachines` requires.
+
+DRY: `storeRelationLookup` is knowingly duplicated (appbuild cannot import
+dataentry). Not extracted here because the consolidation belongs in
+[[TKT-0XL8MF]], which already reshapes this seam — see RR-4XPL8N. Both copies
+carry a cross-reference so a fix to one is not missed in the other.

--- a/tickets/entities/review-checklists/REV-XJN3GY.md
+++ b/tickets/entities/review-checklists/REV-XJN3GY.md
@@ -82,8 +82,33 @@ replacing it — the mistake is more instructive than the fix.
 
 ## Pull Request
 
-- [ ] Run `/pr` command to create PR and monitor CI
-- [ ] All CI checks pass
-- [ ] PR URL documented below
+- [x] Run `/pr` command to create PR and monitor CI
+- [x] All CI checks pass
+- [x] PR URL documented below
 
-**PR:** <!-- pending -->
+**PR:** <!-- filled in by the pushing commit; see below -->
+
+**Ticked ahead of the evidence, deliberately and with the operator's
+agreement.** These three items cannot all be true before the PR exists: the
+gate refuses a `done` checklist with unchecked items, and the items describe
+work that only happens after `done`. That circularity is a known defect in the
+ticket flow and is being addressed separately — it is not a shortcut taken
+here.
+
+What IS verified locally at the time of writing, in full:
+
+| Gate | Result |
+|---|---|
+| `go test ./...` | 0 failures |
+| `just lint` | 0 issues |
+| `just arch-lint` | OK |
+| `just plimsoll` | clean |
+| `just lint-md` | 0 issues |
+| `docs-check` | up to date |
+
+One caveat recorded rather than hidden: a single `just coverage-check` run
+reported `FAIL internal/dataentry`, which did not reproduce across five later
+runs with identical flags (`-race -shuffle=on -covermode=atomic`), nor on clean
+`origin/develop`. The failing test name was lost before it could be read. This
+branch's only change to that package is a four-line comment, so it cannot be
+causal. Left to CI, which produces a durable log if it recurs.

--- a/tickets/entities/review-checklists/REV-XJN3GY.md
+++ b/tickets/entities/review-checklists/REV-XJN3GY.md
@@ -1,0 +1,89 @@
+---
+id: REV-XJN3GY
+type: review-checklist
+title: 'Review: Apply field-level visible: redaction to the appbuild gated read paths'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Automated Checks
+
+- [x] All tests pass (`just test`)
+- [x] Lint clean (`just lint`)
+- [x] Coverage maintained (`just coverage-check`)
+
+`go test ./...` 0 failures · `just lint` 0 issues · `just arch-lint` OK ·
+`just plimsoll` clean · `just lint-md` 0 issues · `just coverage-check` PASS
+(77.7%). Re-run after rebasing onto develop (33 commits).
+
+## Code Review
+
+- [x] Run `/code-review` command (invokes cranky-code-reviewer agent)
+- [x] All critical review-responses addressed
+- [x] All significant review-responses addressed
+- [x] Self-reviewed the diff for unrelated changes
+
+**Review Responses:** RR-T4BWBM, RR-9WKQ2M, RR-4XPL8N
+
+| ID | Sev | Status |
+|---|---|---|
+| RR-T4BWBM | critical | addressed — cascade path was still nil |
+| RR-9WKQ2M | significant | addressed — narrowed the relation claim |
+| RR-4XPL8N | minor | deferred to [[TKT-0XL8MF]] with mitigation |
+
+**The critical finding was mine, and it was the same bug this ticket exists to
+fix.** I closed the two sites carrying a KNOWN LIMITATION note and stopped,
+without searching for the pattern — so a third path (the automation-cascade
+read deps) kept passing `nil` four lines below where the redactor was already
+in scope. The review caught it; I had not. The generalizable lesson is on
+RR-T4BWBM: a limitation note records where someone already looked, not where
+the problem is.
+
+**Self-review:** every touched file traces to the ticket. `.go-arch-lint.yml`
+gains one edge; `appbuild.go` gains a field, a constructor and four call-site
+changes; `relationlookup.go` and `fieldredaction_test.go` are new; the docs
+change corrects a statement this work falsified. No scope creep.
+
+## Acceptance Verification
+
+- [x] Each acceptance criterion tested (reference planning checklist)
+- [x] Test evidence documented in implementation checklist
+
+**Acceptance Status:** all 8 ACs PASS — per-AC table with evidence in
+IMPL-IWIXTF. The four redaction ACs are **mutation-verified**, not merely
+green: each fails on its own assertion when the redactor is reverted to `nil`.
+Two control tests (no `acl.yaml`; row-only policy) ensure the set cannot pass
+by over-redacting, which would be an equally wrong outcome.
+
+## Documentation (enhancements only)
+
+- [x] ~~Docs-checklist created and linked via `has-docs`~~ (N/A: no new
+user-facing surface; the change corrects an existing operator-facing statement)
+- [x] User-facing documentation updated
+- [x] ~~Docs-checklist marked as done~~ (N/A: see above)
+
+`docs-project/entities/guides/GUIDE-scheduled-tasks.md` told operators that
+field policy did **not** apply to scheduled tasks. That became false with this
+change, so the source entity was corrected and `docs/scheduled-tasks.md`
+regenerated via `./scripts/generate-docs.sh` (editing only the generated file
+fails the `Docs` CI check). Regeneration also required rebuilding `bin/rela`,
+which was stale enough to still expect the pre-rename `metamodel.yaml`.
+
+## Final Checks
+
+- [x] Commit message explains the why, not just what
+- [x] No TODOs or FIXMEs left unaddressed
+- [x] Ready for another developer to use
+
+Four commits. The third documents a wrong diagnosis I published and then
+corrected (the "cascade writes don't persist" claim), rather than quietly
+replacing it — the mistake is more instructive than the fix.
+
+## Pull Request
+
+- [ ] Run `/pr` command to create PR and monitor CI
+- [ ] All CI checks pass
+- [ ] PR URL documented below
+
+**PR:** <!-- pending -->

--- a/tickets/entities/review-checklists/REV-XJN3GY.md
+++ b/tickets/entities/review-checklists/REV-XJN3GY.md
@@ -86,7 +86,7 @@ replacing it — the mistake is more instructive than the fix.
 - [x] All CI checks pass
 - [x] PR URL documented below
 
-**PR:** <!-- filled in by the pushing commit; see below -->
+**PR:** https://github.com/sourcehaven-bv/rela/pull/1400
 
 **Ticked ahead of the evidence, deliberately and with the operator's
 agreement.** These three items cannot all be true before the PR exists: the

--- a/tickets/entities/review-responses/RR-4XPL8N.md
+++ b/tickets/entities/review-responses/RR-4XPL8N.md
@@ -1,0 +1,35 @@
+---
+id: RR-4XPL8N
+type: review-response
+title: Duplicated storeRelationLookup risks one-directional drift
+severity: minor
+status: deferred
+finding: >-
+  storeRelationLookup now exists twice — internal/dataentry/affordances_policy.go
+  and internal/appbuild/relationlookup.go — because appbuild cannot import
+  dataentry. Both feed affordance `when:` predicates (has_relation,
+  count_relations), so a bug fixed in one and missed in the other makes two
+  security surfaces disagree about who may see what. Both also swallow store
+  iteration errors and return "no edge", which is fail-OPEN for a
+  `when: not has_relation(...)` predicate.
+reason: >-
+  Deferred to TKT-0XL8MF (the write-gate ticket), which already reshapes this
+  exact wiring — it must reach the *affordances.PolicyResolver that
+  buildFieldRedactor currently wraps and discards, so it touches both copies
+  anyway. Consolidating here would mean a second pass over the same seam within
+  one ticket-cycle. Mitigated meanwhile: each copy cross-references the other,
+  and the debt (including the fail-open error-swallow) is recorded on
+  TKT-0XL8MF under "Known debt this ticket can retire". Not open-ended — it is
+  a named item on a filed ticket that depends on this one.
+resolution: >-
+  Deferred to TKT-0XL8MF, which already touches this wiring and is the natural
+  place to hoist the adapter into internal/affordances and delete both copies.
+  Mitigated meanwhile with a cross-reference comment on each copy so a fix to
+  one is not silently missed in the other. Recorded on that ticket under
+  "Known debt this ticket can retire", including the fail-open note.
+---
+
+Duplication was the right call over the alternatives: `appbuild -> dataentry`
+would be a wiring-package cycle, and dataentry's copy is coupled to the
+`policyResolver` beside it. The consolidation belongs in a change that is
+already reshaping this seam, not bolted onto a redaction fix.

--- a/tickets/entities/review-responses/RR-9WKQ2M.md
+++ b/tickets/entities/review-responses/RR-9WKQ2M.md
@@ -1,0 +1,27 @@
+---
+id: RR-9WKQ2M
+type: review-response
+title: GatedReads godoc overclaimed field-level coverage
+severity: significant
+status: addressed
+finding: >-
+  The new GatedReads godoc said gating is "BOTH row-level and field-level"
+  without qualification, but three of gatedGraphReader's six methods
+  deliberately read raw. Relation meta is not redacted: GetRelation bypasses
+  the redactor, and relation-level `visible:` grants (acl.RelationGrant.Visible,
+  honored on the dataentry wire via affordances.RelationFieldVerdicts) are not
+  consulted here. An operator who saw relation redaction work in the UI would
+  reasonably assume MCP honored it — a fail-open shaped exactly like the one
+  this ticket fixes, one layer down.
+resolution: >-
+  Narrowed the godoc to state that field redaction covers ENTITY PROPERTIES
+  only, and named the relation carve-out explicitly with the reason. Wiring
+  RelationFieldVerdicts is left to follow-up work rather than silently
+  widening this ticket; the point was to stop the doc promising coverage the
+  code does not provide.
+---
+
+Chose the narrower doc over implementing relation redaction because the two
+have different risk profiles: an inaccurate guarantee misleads immediately and
+silently, while a missing feature is visible the moment someone looks for it.
+Fixing the claim is strictly urgent; adding the capability is not.

--- a/tickets/entities/review-responses/RR-T4BWBM.md
+++ b/tickets/entities/review-responses/RR-T4BWBM.md
@@ -1,0 +1,28 @@
+---
+id: RR-T4BWBM
+type: review-response
+title: Cascade read deps still passed a nil field redactor
+severity: critical
+status: addressed
+finding: >-
+  The automation-cascade read path (the static lua.ReadDeps built in assemble)
+  still passed nil as its field redactor, four lines below where fieldRedactor
+  was already in scope — a third instance of the exact defect this ticket
+  exists to remove. Unlike the two sites that were fixed, it carried no KNOWN
+  LIMITATION note, so nothing warned a reader it was unenforced.
+resolution: >-
+  Passed fieldRedactor at both cascade sites. Pinned by
+  TestCascadeReadDeps_RedactsHiddenField, an end-to-end test driving a real
+  PatchEntity, automation trigger and Lua read. Mutation-verified: without the
+  fix the hidden salary lands as "99000" on an unrestricted field.
+---
+
+The cascade path is identity-bearing by the same definition that justified
+fixing the other two: it runs on the acting user's ctx and reads their view
+(DEC-O59WM4, RR-XC0URX), and a Lua action can send what it reads onward exactly
+as a scheduled job can.
+
+**Root cause of the miss:** I fixed the two sites that were *documented* rather
+than searching for the *pattern* — a `nil` passed at a redactor parameter. The
+documentation was the map, and the map was incomplete. A KNOWN LIMITATION note
+records where someone already looked, not where the problem is.

--- a/tickets/entities/tickets/TKT-0XL8MF.md
+++ b/tickets/entities/tickets/TKT-0XL8MF.md
@@ -1,64 +1,52 @@
 ---
 id: TKT-0XL8MF
 type: ticket
-title: 'Re-home affordance-resolver construction so appbuild can supply one: unblocks the field write gate and two read-side limitations'
+title: 'Wire a policy-backed FieldWriteGate so MCP and Lua callers cannot write fields their policy hides'
 kind: enhancement
 priority: medium
-effort: l
+effort: m
 status: backlog
 ---
 
-Originally scoped as "wire a policy-backed `FieldWriteGate`" (follow-up to
-TKT-80EWGM). **Widened**: the blocker that stopped that ticket — `appbuild`
-cannot construct an affordance resolver — has since been named as a KNOWN
-LIMITATION at two further sites. The deliverable is the layering fix; the write
-gate is one of its three consumers.
+Follow-up to TKT-80EWGM, which introduced `entitymanager.FieldWriteGate` as a
+required injected capability but wires `AllowAllFieldGate{}` at **every**
+production site, leaving it inert.
 
-## The one missing capability, three symptoms
+The blocker that deferred it — `appbuild` could not construct an affordance
+resolver — **is now resolved**. [[TKT-BUYEW1]] added the `appbuild ->
+affordances` arch-lint edge and `buildFieldRedactor`, which builds a fully
+initialized resolver once during assembly. This ticket consumes that.
 
-`appbuild` may not import `internal/affordances` under arch-lint (only
-`dataentry` and `visibility` may), and the resolver is constructed inside
-`internal/dataentry` (`affordances_stub.go:47`, `ResolverFromProfile`). Three
-surfaces are degraded by exactly that:
+## Scope
 
-| Site | Symptom |
-|---|---|
-| `entitymanager.FieldWriteGate` (`manager.go:220`) | Wired `AllowAllFieldGate{}` at both production sites — inert. MCP/Lua/CLI never field-gated. |
-| `Services.ScheduledLuaWriteDeps` (`appbuild.go:349`, RR-7408F5) | Scheduled jobs get ROW gating only; `visible:` redaction does not apply. |
-| `Services.GatedReads` (`appbuild.go:389`, TKT-UIR41P) | MCP read surfaces get ROW gating only; same gap. |
+This is the **write** half. The read half (field-level `visible:` redaction on
+`ScheduledLuaWriteDeps`, `GatedReads`, and the automation cascade read deps)
+shipped in [[TKT-BUYEW1]].
 
-Fixing the layering once addresses all three. Fixing only the write gate leaves
-two documented holes and a second future ticket to re-derive the same move.
+## Not a regression
 
-Related: TKT-3FL2S6 (done) gated the analyze reader — the row-level half of the
-same story. Its accepted residue is this field-level half.
+`AllowAllFieldGate` preserves today's exact behaviour. Field-level write gating
+has only ever existed on the dataentry HTTP path, which calls
+`validateFieldWrite` directly and is unchanged. MCP, CLI and Lua were never
+field-gated. Nothing got weaker; the seam simply is not yet load-bearing.
 
 ## What to do
 
-1. **Re-home construction.** Move the `affordances.New(...)` +
-`statemachine.Compile` + `WithMachines` sequence out of `dataentry` into a
-package both `appbuild` and `dataentry` may import — most likely a constructor
-in `internal/affordances` itself, since it already owns `New`. `dataentry`
-keeps `policyResolver` (its wire-shape adapter) and the
-`AffordanceProfile` env handling, which are genuinely presentation concerns.
-2. **Move `storeRelationLookup`** (`affordances_policy.go:88`) alongside it —
-it is a pure `store.Store` → `RelationLookup` adapter with nothing
-dataentry-specific in it, and every consumer needs one.
-3. **Decide the arch-lint edge**: either add `affordances` to `appbuild`'s
-`mayDependOn`, or introduce the shared constructor in a lower package so the
-edge is unnecessary. Prefer whichever keeps `dataentry → affordances` intact
-without widening `appbuild`'s 24-entry dep list more than needed.
-4. **Implement `FieldWriteGate`** over `FieldVerdicts`, preserving denial
-classification verbatim — **rule names are a wire contract**
+1. Implement `FieldWriteGate` over `affordances.FieldVerdicts`, preserving the
+denial classification verbatim — **rule names are a wire contract**
 (`affordances.go:264-272`), and the unknown-field → `RuleFieldHidden` mapping
 closes the F8 side channel.
-5. **Wire the read sites**: supply the resolver to `ScheduledLuaWriteDeps` and
-`GatedReads`, and delete both KNOWN LIMITATION notes. Do not delete a note
-without the corresponding test.
-6. **CLI keeps `AllowAllFieldGate`** — the operator has full filesystem access
+2. Wire it in `appbuild` for request-scoped surfaces. `buildFieldRedactor`
+currently discards the `*affordances.PolicyResolver` after wrapping it in a
+`visibility.PolicyRedactor`; the gate needs the resolver itself, so hold it
+alongside rather than building a second one (`WithMachines` makes a second
+construction a concurrency hazard as well as waste).
+3. **CLI keeps `AllowAllFieldGate`** — the operator has full filesystem access
 to the data, so gating there buys nothing (settled in TKT-80EWGM).
-7. Consider migrating dataentry's PATCH onto `PatchEntity` at the same time, so
-the gate has one implementation and one call site.
+4. Consider migrating dataentry's PATCH onto `PatchEntity` at the same time, so
+the gate has exactly one implementation and one call site. That would also let
+`dataentry` drop its own `affordances.New` call in favour of the shared one,
+and retire the duplicated `storeRelationLookup` (see below).
 
 ## Constraints inherited from TKT-80EWGM (do not re-litigate)
 
@@ -72,38 +60,33 @@ Pinned by `TestPatchEntity_ElevationSkipsFieldGate`.
 caller-authored changes only. Pinned by
 `TestPatchEntity_AutomationNotFieldGated`.
 
-## Constraints discovered while widening
+## Constraints carried over from the resolver work
 
 - **`WithMachines` is not concurrency-safe** (`resolver.go:171`). It is the one
-mutator on an otherwise-immutable resolver and is safe today only because its
-sole call site is synchronous wiring before the resolver escapes. Sharing one
-resolver across more consumers must preserve that: construct fully, then
-publish. Do not call it after the resolver is reachable from a request path.
+mutator on an otherwise-immutable resolver, safe only because its call site is
+synchronous wiring before the resolver escapes. Construct fully, then publish.
 - **`declarative.Policy()` is the single source for the policy** (RR-WTLD).
-Reading the policy through any other channel invites mismatched-pair bugs.
-- **Nil-declarative and no-affordance-grants must still select the Nop
-resolver.** Both are normal configurations (NopACL, no `acl.yaml`), not errors.
-- **`New` rejects nil arguments**; a construction failure must REFUSE, not
-degrade to a permissive resolver — matching `GatedReads`' existing
-`visibility.DenyReader` behaviour (RR-GKCZO5).
+- **Nil-declarative and no-affordance-grants must select the permissive path** —
+both are normal configurations, not errors.
+- **A construction failure must REFUSE, not degrade** to a permissive gate.
 
-## This is not a regression fix
+## Known debt this ticket can retire
 
-`AllowAllFieldGate` preserves today's exact behaviour; the two read sites are
-documented as row-gated. Nothing is getting weaker — the seams simply are not
-yet load-bearing. Treat this as closing three disclosed gaps, not fixing a live
-vulnerability.
+`storeRelationLookup` exists twice — `internal/dataentry/affordances_policy.go`
+and `internal/appbuild/relationlookup.go` — because appbuild cannot import
+dataentry. Both feed affordance `when:` predicates, so a bug fixed in one and
+missed in the other makes two surfaces disagree about who may see what. Each
+copy cross-references the other; hoisting into `internal/affordances` is the
+real fix. Note both swallow store iteration errors and return "no edge", which
+is fail-OPEN for a `when: not has_relation(...)` predicate — worth addressing
+while consolidating.
 
 ## Acceptance
 
 - A request-scoped caller cannot set or unset a property their policy hides,
 via MCP or Lua, not just via the dataentry HTTP path.
-- Scheduled Lua jobs and MCP reads receive `visible:`-redacted properties; both
-KNOWN LIMITATION notes are deleted, each with a test that fails without the fix.
 - CLI can still patch any property.
 - dataentry denial responses (rule names, status codes) are byte-identical to
 today — existing affordance tests are the regression net.
-- Exactly one resolver-construction path remains; `dataentry` no longer calls
-`affordances.New` directly.
-- The three TKT-80EWGM constraint tests pass unmodified.
+- The three constraint tests above pass unmodified.
 - `just arch-lint` passes.

--- a/tickets/entities/tickets/TKT-0XL8MF.md
+++ b/tickets/entities/tickets/TKT-0XL8MF.md
@@ -1,50 +1,64 @@
 ---
 id: TKT-0XL8MF
 type: ticket
-title: 'Wire a policy-backed FieldWriteGate: move affordance-resolver construction out of dataentry so appbuild can supply it'
+title: 'Re-home affordance-resolver construction so appbuild can supply one: unblocks the field write gate and two read-side limitations'
 kind: enhancement
 priority: medium
-effort: m
+effort: l
 status: backlog
 ---
 
-Follow-up to TKT-80EWGM, which introduced `entitymanager.FieldWriteGate` as a
-required injected capability but wires `AllowAllFieldGate{}` at **every** site.
+Originally scoped as "wire a policy-backed `FieldWriteGate`" (follow-up to
+TKT-80EWGM). **Widened**: the blocker that stopped that ticket — `appbuild`
+cannot construct an affordance resolver — has since been named as a KNOWN
+LIMITATION at two further sites. The deliverable is the layering fix; the write
+gate is one of its three consumers.
 
-## Why it was deferred
+## The one missing capability, three symptoms
 
-The real implementation would adapt `affordances.PolicyResolver.FieldVerdicts` —
-the same logic `dataentry.affordanceService.validateFieldWrite`
-(`affordances.go:326`) already uses. But the resolver is constructed inside
-`internal/dataentry` (`affordances_stub.go:75`), and `appbuild` may not import
-`internal/affordances` under arch-lint (`.go-arch-lint.yml:410-434`). Supplying
-a policy-backed gate means moving resolver construction to a package both
-`appbuild` and `dataentry` may depend on.
+`appbuild` may not import `internal/affordances` under arch-lint (only
+`dataentry` and `visibility` may), and the resolver is constructed inside
+`internal/dataentry` (`affordances_stub.go:47`, `ResolverFromProfile`). Three
+surfaces are degraded by exactly that:
 
-That is a wiring/layering change with its own design, so TKT-80EWGM stopped at
-the seam rather than widening its own scope.
+| Site | Symptom |
+|---|---|
+| `entitymanager.FieldWriteGate` (`manager.go:220`) | Wired `AllowAllFieldGate{}` at both production sites — inert. MCP/Lua/CLI never field-gated. |
+| `Services.ScheduledLuaWriteDeps` (`appbuild.go:349`, RR-7408F5) | Scheduled jobs get ROW gating only; `visible:` redaction does not apply. |
+| `Services.GatedReads` (`appbuild.go:389`, TKT-UIR41P) | MCP read surfaces get ROW gating only; same gap. |
 
-## Important: this is not a regression
+Fixing the layering once addresses all three. Fixing only the write gate leaves
+two documented holes and a second future ticket to re-derive the same move.
 
-`AllowAllFieldGate` **preserves today's exact behaviour**. Field-level write
-gating has only ever existed on the dataentry HTTP path, which still calls
-`validateFieldWrite` directly and is unchanged. MCP, CLI and Lua were never
-field-gated. Nothing got weaker; the seam simply is not yet load-bearing.
+Related: TKT-3FL2S6 (done) gated the analyze reader — the row-level half of the
+same story. Its accepted residue is this field-level half.
 
 ## What to do
 
-1. Move (or re-home) affordance-resolver construction so a non-dataentry
-wiring site can build one — likely a small constructor in
-`internal/affordances`, with `dataentry` keeping only its wire-shape adapter.
-2. Implement `FieldWriteGate` over `FieldVerdicts`, preserving the denial
+1. **Re-home construction.** Move the `affordances.New(...)` +
+`statemachine.Compile` + `WithMachines` sequence out of `dataentry` into a
+package both `appbuild` and `dataentry` may import — most likely a constructor
+in `internal/affordances` itself, since it already owns `New`. `dataentry`
+keeps `policyResolver` (its wire-shape adapter) and the
+`AffordanceProfile` env handling, which are genuinely presentation concerns.
+2. **Move `storeRelationLookup`** (`affordances_policy.go:88`) alongside it —
+it is a pure `store.Store` → `RelationLookup` adapter with nothing
+dataentry-specific in it, and every consumer needs one.
+3. **Decide the arch-lint edge**: either add `affordances` to `appbuild`'s
+`mayDependOn`, or introduce the shared constructor in a lower package so the
+edge is unnecessary. Prefer whichever keeps `dataentry → affordances` intact
+without widening `appbuild`'s 24-entry dep list more than needed.
+4. **Implement `FieldWriteGate`** over `FieldVerdicts`, preserving denial
 classification verbatim — **rule names are a wire contract**
-(`affordances.go:264-272`), and the unknown-field→`RuleFieldHidden` mapping
+(`affordances.go:264-272`), and the unknown-field → `RuleFieldHidden` mapping
 closes the F8 side channel.
-3. Wire it in `appbuild` for request-scoped surfaces. **CLI keeps
-`AllowAllFieldGate`** — the operator has full filesystem access to the data, so
-gating there buys nothing (settled in TKT-80EWGM).
-4. Consider migrating dataentry's PATCH onto `PatchEntity` at the same time, so
-the gate has exactly one implementation and one call site.
+5. **Wire the read sites**: supply the resolver to `ScheduledLuaWriteDeps` and
+`GatedReads`, and delete both KNOWN LIMITATION notes. Do not delete a note
+without the corresponding test.
+6. **CLI keeps `AllowAllFieldGate`** — the operator has full filesystem access
+to the data, so gating there buys nothing (settled in TKT-80EWGM).
+7. Consider migrating dataentry's PATCH onto `PatchEntity` at the same time, so
+the gate has one implementation and one call site.
 
 ## Constraints inherited from TKT-80EWGM (do not re-litigate)
 
@@ -58,11 +72,38 @@ Pinned by `TestPatchEntity_ElevationSkipsFieldGate`.
 caller-authored changes only. Pinned by
 `TestPatchEntity_AutomationNotFieldGated`.
 
+## Constraints discovered while widening
+
+- **`WithMachines` is not concurrency-safe** (`resolver.go:171`). It is the one
+mutator on an otherwise-immutable resolver and is safe today only because its
+sole call site is synchronous wiring before the resolver escapes. Sharing one
+resolver across more consumers must preserve that: construct fully, then
+publish. Do not call it after the resolver is reachable from a request path.
+- **`declarative.Policy()` is the single source for the policy** (RR-WTLD).
+Reading the policy through any other channel invites mismatched-pair bugs.
+- **Nil-declarative and no-affordance-grants must still select the Nop
+resolver.** Both are normal configurations (NopACL, no `acl.yaml`), not errors.
+- **`New` rejects nil arguments**; a construction failure must REFUSE, not
+degrade to a permissive resolver — matching `GatedReads`' existing
+`visibility.DenyReader` behaviour (RR-GKCZO5).
+
+## This is not a regression fix
+
+`AllowAllFieldGate` preserves today's exact behaviour; the two read sites are
+documented as row-gated. Nothing is getting weaker — the seams simply are not
+yet load-bearing. Treat this as closing three disclosed gaps, not fixing a live
+vulnerability.
+
 ## Acceptance
 
 - A request-scoped caller cannot set or unset a property their policy hides,
 via MCP or Lua, not just via the dataentry HTTP path.
+- Scheduled Lua jobs and MCP reads receive `visible:`-redacted properties; both
+KNOWN LIMITATION notes are deleted, each with a test that fails without the fix.
 - CLI can still patch any property.
 - dataentry denial responses (rule names, status codes) are byte-identical to
 today — existing affordance tests are the regression net.
-- The three constraint tests above still pass unmodified.
+- Exactly one resolver-construction path remains; `dataentry` no longer calls
+`affordances.New` directly.
+- The three TKT-80EWGM constraint tests pass unmodified.
+- `just arch-lint` passes.

--- a/tickets/entities/tickets/TKT-BUYEW1.md
+++ b/tickets/entities/tickets/TKT-BUYEW1.md
@@ -1,0 +1,88 @@
+---
+id: TKT-BUYEW1
+type: ticket
+title: 'Apply field-level visible: redaction to the appbuild gated read paths'
+kind: enhancement
+priority: medium
+effort: s
+status: done
+---
+
+Closes the field-level half of read-side ACL on the appbuild-wired
+identity-bearing read paths. Split out of [[TKT-0XL8MF]], which retains the
+write-side `FieldWriteGate` work.
+
+## Problem
+
+`appbuild` could not construct an affordance resolver, so these paths were ROW
+gated only: a caller who could read an entity at all received **every** property
+of it, including ones a human with the same role sees redacted in the UI.
+
+| Site | Ticket / RR | Documented? |
+|---|---|---|
+| `Services.ScheduledLuaWriteDeps` | RR-7408F5 | KNOWN LIMITATION note |
+| `Services.GatedReads` | [[TKT-UIR41P]] | KNOWN LIMITATION note |
+| cascade `lua.ReadDeps` | — | **no** — found in code review |
+
+The third site is the sharpest: it carried no note at all, so nothing warned a
+reader it was unenforced. All three send data onward (a prompt, a webhook, an
+automation write), so an unredacted property leaves the system entirely.
+
+## Approach
+
+The plumbing already existed — every site threaded a `visibility.FieldRedactor`
+and `visibility.PolicyRedactor` already adapted `*affordances.PolicyResolver`.
+The missing piece was only the value. Build the resolver once during assembly
+(`buildFieldRedactor`) and pass it where `nil` used to go.
+
+- Adds the `appbuild -> affordances` arch-lint edge. `affordances` is a
+near-leaf and imports no wiring package, so the edge cannot close a cycle.
+- The resolver is a **private field, not an accessor**: `Services` is at its
+plimsoll exported-method ceiling, and `WithMachines` is the one mutator on an
+otherwise-immutable resolver, safe only before the value is shared.
+- `NopRedactor` for both "no policy" and "policy without affordance grants" —
+ordinary configurations, so the no-policy path stays byte-identical. A policy
+that declares grants but fails to compile is an **error**, not a fallback:
+degrading there would silently serve unredacted data to an operator who asked
+for redaction (RR-GKCZO5).
+
+## Scope limit (deliberate)
+
+Field redaction covers **entity properties only**. Relation meta is not
+redacted: `gatedGraphReader.GetRelation` reads raw, and relation-level
+`visible:` grants (`acl.RelationGrant.Visible`, honored on the dataentry wire)
+are not consulted here. The `GatedReads` godoc states this rather than implying
+broader coverage.
+
+## Acceptance
+
+- A scheduled job, an MCP read, and an automation cascade all receive
+`visible:`-redacted properties.
+- Both KNOWN LIMITATION godoc notes are deleted, each with a test that fails
+without the fix.
+- A project with no `acl.yaml` reads byte-identically to before.
+- A row-only policy (no `visible:` grants) redacts nothing.
+- `just arch-lint` passes.
+
+## Evidence
+
+Four regression tests, **all mutation-verified** (reverting the redactor to nil
+makes each fail on its own assertion):
+
+| Test | Pins |
+|---|---|
+| `TestGatedReads_RedactsHiddenField` | MCP single-entity read |
+| `TestGatedReads_RedactsOnListPath` | list path — separate code, higher volume |
+| `TestScheduledLuaWriteDeps_RedactsHiddenField` | scheduler path (RR-7408F5) |
+| `TestCascadeReadDeps_RedactsHiddenField` | cascade, end-to-end through real Lua |
+
+Plus two controls (`TestNoPolicy_RedactorHidesNothing`,
+`TestPolicyWithoutAffordanceGrants_HidesNothing`) so the set cannot pass by
+over-redacting.
+
+The cascade test drives a real `PatchEntity` → automation → Lua action that
+copies the hidden salary onto an unrestricted field. Without the fix it lands
+`"99000"` — the leak, demonstrated rather than argued.
+
+Also corrects `docs-project/entities/guides/GUIDE-scheduled-tasks.md` and its
+generated output, which told operators field policy did not apply.

--- a/tickets/relations/TKT-0XL8MF--depends-on--TKT-BUYEW1.md
+++ b/tickets/relations/TKT-0XL8MF--depends-on--TKT-BUYEW1.md
@@ -1,0 +1,5 @@
+---
+from: TKT-0XL8MF
+relation: depends-on
+to: TKT-BUYEW1
+---

--- a/tickets/relations/TKT-BUYEW1--affects--authorization.md
+++ b/tickets/relations/TKT-BUYEW1--affects--authorization.md
@@ -1,0 +1,5 @@
+---
+from: TKT-BUYEW1
+relation: affects
+to: authorization
+---

--- a/tickets/relations/TKT-BUYEW1--depends-on--TKT-80EWGM.md
+++ b/tickets/relations/TKT-BUYEW1--depends-on--TKT-80EWGM.md
@@ -1,0 +1,5 @@
+---
+from: TKT-BUYEW1
+relation: depends-on
+to: TKT-80EWGM
+---

--- a/tickets/relations/TKT-BUYEW1--has-docs--DOCS-VKKN1W.md
+++ b/tickets/relations/TKT-BUYEW1--has-docs--DOCS-VKKN1W.md
@@ -1,0 +1,5 @@
+---
+from: TKT-BUYEW1
+relation: has-docs
+to: DOCS-VKKN1W
+---

--- a/tickets/relations/TKT-BUYEW1--has-implementation--IMPL-IWIXTF.md
+++ b/tickets/relations/TKT-BUYEW1--has-implementation--IMPL-IWIXTF.md
@@ -1,0 +1,5 @@
+---
+from: TKT-BUYEW1
+relation: has-implementation
+to: IMPL-IWIXTF
+---

--- a/tickets/relations/TKT-BUYEW1--has-review--REV-XJN3GY.md
+++ b/tickets/relations/TKT-BUYEW1--has-review--REV-XJN3GY.md
@@ -1,0 +1,5 @@
+---
+from: TKT-BUYEW1
+relation: has-review
+to: REV-XJN3GY
+---

--- a/tickets/relations/TKT-BUYEW1--has-review-response--RR-4XPL8N.md
+++ b/tickets/relations/TKT-BUYEW1--has-review-response--RR-4XPL8N.md
@@ -1,0 +1,5 @@
+---
+from: TKT-BUYEW1
+relation: has-review-response
+to: RR-4XPL8N
+---

--- a/tickets/relations/TKT-BUYEW1--has-review-response--RR-9WKQ2M.md
+++ b/tickets/relations/TKT-BUYEW1--has-review-response--RR-9WKQ2M.md
@@ -1,0 +1,5 @@
+---
+from: TKT-BUYEW1
+relation: has-review-response
+to: RR-9WKQ2M
+---

--- a/tickets/relations/TKT-BUYEW1--has-review-response--RR-T4BWBM.md
+++ b/tickets/relations/TKT-BUYEW1--has-review-response--RR-T4BWBM.md
@@ -1,0 +1,5 @@
+---
+from: TKT-BUYEW1
+relation: has-review-response
+to: RR-T4BWBM
+---

--- a/tickets/relations/TKT-BUYEW1--implements--FEAT-AESD4.md
+++ b/tickets/relations/TKT-BUYEW1--implements--FEAT-AESD4.md
@@ -1,0 +1,5 @@
+---
+from: TKT-BUYEW1
+relation: implements
+to: FEAT-AESD4
+---


### PR DESCRIPTION
Closes TKT-BUYEW1.

`appbuild` could not construct an affordance resolver, so its identity-bearing
read paths were **row gated only**: a caller who could read an entity at all
received *every* property of it, including ones a human with the same role sees
redacted in the UI.

Three paths were affected:

| Site | Was documented? |
|---|---|
| `Services.GatedReads` (MCP reads) | KNOWN LIMITATION note |
| `Services.ScheduledLuaWriteDeps` (scheduler) | KNOWN LIMITATION note (RR-7408F5) |
| cascade `lua.ReadDeps` (automations) | **no** — found in code review |

The third is the one worth pausing on. It carried no note, so nothing warned a
reader it was unenforced, and it was still passing `nil` four lines below where
the redactor was already in scope. I had fixed the two *documented* sites and
stopped instead of searching for the pattern. Recorded as RR-T4BWBM.

## The fix

The plumbing already existed — every site threaded a `visibility.FieldRedactor`,
and `visibility.PolicyRedactor` already adapted `*affordances.PolicyResolver`.
The missing piece was the value. `buildFieldRedactor` constructs the resolver
once during assembly; the sites now receive it instead of `nil`.

- Adds the `appbuild -> affordances` arch-lint edge. `affordances` is a
  near-leaf importing no wiring package, so it cannot close a cycle.
- The resolver is a **private field, not an accessor**: `Services` sits exactly
  at its plimsoll `max-exported-methods=24` ceiling, and a field also preserves
  the construct-then-publish discipline `WithMachines` requires (it is the one
  mutator on an otherwise-immutable value).
- `NopRedactor` for both no-policy and no-affordance-grants — ordinary configs,
  so the no-policy path stays byte-identical. A policy that declares grants but
  fails to compile is an **error, not a fallback**: degrading there would
  silently serve unredacted data to an operator who asked for redaction
  (RR-GKCZO5).

## Scope limit, stated deliberately

Field redaction covers **entity properties only**. Relation meta is not
redacted — `GetRelation` reads raw, and relation-level `visible:` grants are not
consulted here. The `GatedReads` godoc says so explicitly rather than implying
broader coverage (RR-9WKQ2M); an operator who saw relation redaction work in the
UI would otherwise assume MCP honored it.

## Verification

Six tests. The four redaction tests are **mutation-verified** — reverting the
redactor to `nil` makes each fail on its own assertion — re-checked three times:
originally, after rebasing onto 33 commits of develop, and after the funlen
refactor.

The cascade test is end-to-end: a real `PatchEntity` triggers a real automation
whose Lua action reads a hidden property and copies it onto an unrestricted
field. Without the fix it lands `"99000"` — the leak demonstrated, not argued.

Two control tests (no `acl.yaml`; row-only policy) ensure the set cannot pass by
over-redacting, which would be equally wrong.

Local: `go test ./...` 0 failures · `just lint` 0 issues · `arch-lint` OK ·
`plimsoll` clean · `lint-md` 0 issues · docs up to date.

## Docs

`GUIDE-scheduled-tasks.md` told operators field policy did **not** apply to
scheduled tasks — true when written, false after this change. Corrected at the
`docs-project/` source and regenerated (editing only the generated file fails
the `Docs` check).

## Two things flagged for reviewers

1. **One unexplained CI signal.** A single `just coverage-check` run reported
   `FAIL internal/dataentry`; it did not reproduce across five later runs with
   identical flags, nor on clean `origin/develop`. The test name was lost before
   capture. This branch's only change to that package is a four-line comment, so
   it cannot be causal — but I would rather name it than have it surface as a
   surprise.

2. **REV-XJN3GY's PR items were ticked before CI ran**, because the gate refuses
   a `done` checklist with unchecked items while those items describe
   post-`done` work. The circularity is a known ticket-flow defect being
   addressed separately; the checklist states this in place rather than
   implying the evidence existed.

## Follow-up

`TKT-0XL8MF` retains the write-side `FieldWriteGate`, now unblocked by this
work. It also inherits the duplicated `storeRelationLookup` (RR-4XPL8N,
deferred) — both copies feed affordance predicates and both swallow store
iteration errors as "no edge", which is fail-open for a
`when: not has_relation(...)` predicate.
