### PR TITLE
fix(frontend): style CheckboxWidget from design tokens (TKT-CBSTYLE)

### DIFF
--- a/frontend/src/components/forms/RelationCards.test.ts
+++ b/frontend/src/components/forms/RelationCards.test.ts
@@ -13,6 +13,7 @@ import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { mount, flushPromises } from '@vue/test-utils'
 import { createPinia, setActivePinia } from 'pinia'
 import RelationCards from './RelationCards.vue'
+import CheckboxWidget from '@/widgets/CheckboxWidget.vue'
 import { useSchemaStore } from '@/stores/schema'
 import type { FormFieldOrRelation, RelationAffordance, Entity } from '@/types'
 
@@ -189,6 +190,86 @@ describe('RelationCards affordance plumbing', () => {
     expect(row.exists()).toBe(true)
     expect(row.text()).toBe('Pseudoniem API')
     expect(row.text()).not.toBe('FEAT-DO-1')
+    wrapper.unmount()
+  })
+})
+
+// TKT-CBSTYLE. Both boolean inputs in RelationCards render the shared
+// CheckboxWidget rather than a locally-styled `<input type="checkbox">`.
+//
+// This file used to hand-roll a duplicate of the widget's CSS
+// (`.inline-edit-checkbox`). The copies drifted — the tick was off-centre and
+// the focus ring was a hardcoded indigo — and fixing the widget silently left
+// this surface broken. These tests pin the consolidation so the duplicate
+// cannot come back unnoticed: they assert the WIDGET is mounted, not merely
+// that some checkbox exists, which a re-introduced raw input would satisfy.
+describe('RelationCards boolean meta fields use the shared CheckboxWidget', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.clearAllMocks()
+  })
+
+  async function mountWithBoolean(opts: {
+    verdict?: RelationAffordance
+    meta?: Record<string, unknown>
+  }) {
+    const schemaStore = useSchemaStore()
+    schemaStore.entityTypes.set('ticket', {
+      name: 'ticket', label: 'Ticket', properties: {},
+    } as never)
+    schemaStore.entityTypes.set('feature', {
+      name: 'feature', label: 'Feature', properties: {},
+    } as never)
+    schemaStore.relationTypes.set('implements', {
+      name: 'implements',
+      from: ['ticket'],
+      to: ['feature'],
+      properties: { blocking: { type: 'boolean' } },
+    } as never)
+    seedRelations(['FEAT-001'], { 'FEAT-001': opts.meta ?? {} })
+    const field: FormFieldOrRelation = {
+      relation: 'implements',
+      label: 'Implements',
+      widget: 'cards',
+      properties: [{ property: 'blocking', label: 'Blocking' }],
+    } as never
+    const wrapper = mount(RelationCards, {
+      props: {
+        field, entityType: 'ticket', entityId: 'TKT-001', verdict: opts.verdict,
+      },
+      attachTo: document.body,
+    })
+    await flushPromises()
+    return wrapper
+  }
+
+  it('renders CheckboxWidget for a boolean meta property', async () => {
+    const wrapper = await mountWithBoolean({})
+    expect(wrapper.findComponent(CheckboxWidget).exists()).toBe(true)
+    wrapper.unmount()
+  })
+
+  it('reflects the stored boolean value', async () => {
+    const wrapper = await mountWithBoolean({ meta: { blocking: true } })
+    const cb = wrapper.findComponent(CheckboxWidget)
+    expect((cb.find('input').element as HTMLInputElement).checked).toBe(true)
+    wrapper.unmount()
+  })
+
+  it('a writable=false verdict still disables the boolean field', async () => {
+    // The disabled path used to be a plain :disabled attribute on a raw input;
+    // it now travels through the widget's prop. Same ACL guarantee either way.
+    const wrapper = await mountWithBoolean({
+      verdict: { fields: { blocking: { writable: false } } } as never,
+    })
+    const input = wrapper.findComponent(CheckboxWidget).find('input')
+    expect(input.attributes('disabled')).toBeDefined()
+    wrapper.unmount()
+  })
+
+  it('no locally-styled checkbox class remains in the rendered output', async () => {
+    const wrapper = await mountWithBoolean({})
+    expect(wrapper.find('.inline-edit-checkbox').exists()).toBe(false)
     wrapper.unmount()
   })
 })

--- a/frontend/src/components/forms/RelationCards.vue
+++ b/frontend/src/components/forms/RelationCards.vue
@@ -7,6 +7,10 @@ import { useSchemaStore } from '@/stores'
 import { getEntityRelations, searchEntities, getEntity, getErrorMessage } from '@/api'
 import { entityDisplayTitle } from '@/utils/entityDisplay'
 import InlineCreateFormModal from './InlineCreateFormModal.vue'
+// The shared boolean widget, rather than a local `<input type="checkbox">`.
+// This file used to hand-roll the same custom-drawn checkbox (TKT-CBSTYLE), so
+// a fix to the glyph had to be made twice — and the second copy was missed.
+import CheckboxWidget from '@/widgets/CheckboxWidget.vue'
 import { useInlineCreate } from '@/composables/useInlineCreate'
 import type { FormFieldOrRelation, RelationProperty } from '@/types/config'
 import type { RelationEntry, Entity } from '@/types/entity'
@@ -599,15 +603,13 @@ function onDragEnd() {
             />
 
             <!-- Boolean checkbox -->
-            <input
+            <CheckboxWidget
               v-else-if="isBoolean(prop.property)"
-              :checked="!!entry.meta?.[prop.property]"
-              type="checkbox"
-              class="inline-edit-checkbox"
+              :model-value="!!entry.meta?.[prop.property]"
+              mode="edit"
+              :property-name="prop.property"
               :disabled="isMetaFieldDisabled(prop.property)"
-              @change="
-                updateProperty(entry.id, prop.property, ($event.target as HTMLInputElement).checked)
-              "
+              @update:model-value="updateProperty(entry.id, prop.property, $event)"
             />
 
             <!-- Date / text / number input -->
@@ -708,10 +710,14 @@ function onDragEnd() {
               "
             />
 
-            <input
+            <!-- newMeta seeds every property to '' (see resetNewMeta), which the
+                 widget reads as unchecked and replaces with a real boolean on
+                 first toggle — same as the native v-model this replaced. -->
+            <CheckboxWidget
               v-else-if="isBoolean(prop.property)"
               v-model="newMeta[prop.property]"
-              type="checkbox"
+              mode="edit"
+              :property-name="prop.property"
             />
 
             <input
@@ -958,45 +964,11 @@ function onDragEnd() {
   box-shadow: 0 0 0 2px rgba(99, 102, 241, 0.1);
 }
 
-.inline-edit-checkbox {
-  appearance: none;
-  -webkit-appearance: none;
-  width: 18px;
-  height: 18px;
-  border: 2px solid var(--border-color, #4a4a5a);
-  border-radius: 4px;
-  background: var(--input-bg, #1e1e28);
-  cursor: pointer;
-  position: relative;
-  transition: all 0.15s;
-  flex-shrink: 0;
-}
-
-.inline-edit-checkbox:checked {
-  background: var(--accent-color, #6366f1);
-  border-color: var(--accent-color, #6366f1);
-}
-
-.inline-edit-checkbox:checked::after {
-  content: '';
-  position: absolute;
-  left: 5px;
-  top: 1px;
-  width: 5px;
-  height: 10px;
-  border: solid white;
-  border-width: 0 2px 2px 0;
-  transform: rotate(45deg);
-}
-
-.inline-edit-checkbox:hover {
-  border-color: var(--accent-color, #6366f1);
-}
-
-.inline-edit-checkbox:focus-visible {
-  outline: none;
-  box-shadow: 0 0 0 2px rgba(99, 102, 241, 0.3);
-}
+/* The `.inline-edit-checkbox` rules that used to live here are gone: both
+   boolean inputs in this file now render through CheckboxWidget, which owns
+   the styling. They were a hand-rolled duplicate of the widget's own CSS and
+   had already drifted from it (off-centre tick, hardcoded focus-ring colour).
+   Add nothing back here — style the widget instead. */
 
 .empty-state {
   padding: 16px;

--- a/frontend/src/widgets/CheckboxWidget.vue
+++ b/frontend/src/widgets/CheckboxWidget.vue
@@ -77,13 +77,32 @@ input[type='checkbox']:checked {
   border-color: var(--accent-color, #6366f1);
 }
 
-/* The checkmark: two borders of a rotated box. Geometry is copied from
-   RelationCards so the glyph is identical at the same 18px size. */
+/* The checkmark: the right and bottom borders of a box, rotated 45°, so the
+   two painted edges read as the short and long arms of a tick.
+
+   The ARM GEOMETRY (5×10, 2px stroke) is RelationCards', unchanged — it
+   matches the native glyph's proportions well. The POSITION is not:
+   RelationCards' `left: 5px; top: 1px` leaves the tick low and right, with
+   dead space along the top and the vertex nearly touching the bottom edge.
+
+   `top` is NEGATIVE and that is correct, not a typo. Rotating about the box
+   centre turns the 5×10 rect into a 10.61×8.49 ink bounding box, so the
+   painted glyph sits well inside — and below — the element's own edges.
+   `left`/`top` position the UNROTATED rect, so they are NOT the visible
+   margins and cannot be reasoned about as if they were.
+
+   These are tuned by eye at 13×, and deliberately NOT the arithmetic centre.
+   Centring the ink bounding box gives 4.5px/0.94px (1.7px clearance on all
+   four sides) — that was tried, and it reads as sitting low, because a tick's
+   mass is in its long upper-right arm while the eye tracks the lower-left
+   vertex. Optical centring wins over the bounding box here. If the 18px box or
+   2px stroke changes, re-tune the same way; do not scale these arithmetically
+   and do not "fix" them back to the computed centre. */
 input[type='checkbox']:checked::after {
   content: '';
   position: absolute;
-  left: 5px;
-  top: 1px;
+  left: 4px;
+  top: -1px;
   width: 5px;
   height: 10px;
   border: solid #fff;

--- a/frontend/src/widgets/CheckboxWidget.vue
+++ b/frontend/src/widgets/CheckboxWidget.vue
@@ -38,11 +38,113 @@ function onChange(event: Event) {
 </template>
 
 <style scoped>
-/* Visually distinct from an editable checkbox: muted opacity + no
-   pointer cursor make read-only state legible without losing the
-   native checkbox affordance. */
-.display-checkbox {
-  opacity: 0.85;
+/* TKT-CBSTYLE. The edit arm was a bare native checkbox — OS default size and
+   colour — sitting in the same 12-column grid as widgets that all carry
+   padding, a token radius and a focus ring, so it read as a foreign control.
+   This is the custom-drawn checkbox RelationCards.vue already uses for its
+   inline boolean edit (`.inline-edit-checkbox`), expressed in the scales.css
+   tokens: same 18px box, same accent fill, same CSS checkmark, so the two
+   boolean edit surfaces agree.
+
+   `appearance: none` is what makes the box drawable, and it also removes the
+   greyed rendering the browser gave the disabled DISPLAY arm for free. That
+   affordance was load-bearing (RR-UD2H reads the display arm as visibly
+   read-only), so the muted state below is now drawn explicitly rather than
+   inherited. */
+input[type='checkbox'] {
+  /* Unprefixed only: -webkit-appearance is unnecessary from Safari 15.4, and
+     nothing in this build regenerates prefixes (no autoprefixer, no
+     browserslist). RelationCards still carries the prefix; it predates that. */
+  appearance: none;
+  width: 18px;
+  height: 18px;
+  border: 2px solid var(--border-color);
+  border-radius: var(--radius-sm);
+  background: var(--input-bg);
+  position: relative;
+  cursor: pointer;
+
+  /* Named, not `all`: `all` would also animate the focus ring, so the
+     indicator would fade in rather than appear on tab. */
+  transition:
+    background-color 0.15s,
+    border-color 0.15s;
+  flex-shrink: 0;
+}
+
+input[type='checkbox']:checked {
+  background: var(--accent-color, #6366f1);
+  border-color: var(--accent-color, #6366f1);
+}
+
+/* The checkmark: two borders of a rotated box. Geometry is copied from
+   RelationCards so the glyph is identical at the same 18px size. */
+input[type='checkbox']:checked::after {
+  content: '';
+  position: absolute;
+  left: 5px;
+  top: 1px;
+  width: 5px;
+  height: 10px;
+  border: solid #fff;
+  border-width: 0 2px 2px 0;
+  transform: rotate(45deg);
+}
+
+input[type='checkbox']:hover:not(:disabled) {
+  border-color: var(--accent-color, #6366f1);
+}
+
+/* Derived from the accent rather than a hardcoded indigo. The sibling widgets
+   write `rgba(99, 102, 241, 0.1)` here, but that literal is NOT the app's
+   accent (#4772fb light / #6f93ff dark) — it renders as an off-hue ring that
+   ignores the theme, and an operator's `custom.css` accent would not reach it.
+   Copying that would propagate the one part of the prior art that is a bug. */
+input[type='checkbox']:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--accent-color) 30%, transparent);
+}
+
+/* `:not(.display-checkbox)` is load-bearing, not defensive.
+   `input[type='checkbox']:disabled` is (0,3,1) and `.display-checkbox:disabled`
+   is (0,3,0) — Vue's scoped `[data-v-x]` lifts both equally — so the element
+   rule WINS and a plain override below it never applies. The display arm was
+   silently getting `not-allowed`, inverting the intent stated here. Excluding
+   the arm rather than out-specifying it also can't be re-lost by a later edit. */
+input[type='checkbox']:disabled:not(.display-checkbox) {
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+
+/* Display mode is never interactive, so it takes the default cursor rather
+   than not-allowed — it is a rendered value, not a control you were denied.
+   Muted, not hidden: a checked read-only box must still read as checked.
+
+   0.6, not the 0.85 this file used before. That value was a nudge ON TOP OF
+   the browser's native disabled greying; with `appearance: none` it became the
+   ENTIRE read-only signal, and a 15% reduction on an accent-filled box is
+   near-imperceptible. The sibling widgets' disabled treatment
+   (`background: var(--hover-bg)`) can't be borrowed here: on a checkbox the
+   background IS the checked signal, so overwriting it would erase state to
+   convey read-only. Dimming preserves both. */
+.display-checkbox:disabled {
   cursor: default;
+  opacity: 0.6;
+}
+
+/* In forced-colors (Windows High Contrast) the OS replaces our background and
+   border, `box-shadow` is dropped entirely, and a `::after` checkmark is not
+   guaranteed — so a custom-painted checkbox can lose BOTH its focus ring and
+   its checked/unchecked distinction. Hand the control back to the OS, which
+   draws it correctly for free, and restore a ring that survives. */
+@media (forced-colors: active) {
+  input[type='checkbox'] {
+    appearance: auto;
+  }
+
+  input[type='checkbox']:focus-visible {
+    outline: 2px solid Highlight;
+    outline-offset: 2px;
+  }
 }
 </style>

--- a/frontend/src/widgets/CheckboxWidget.vue
+++ b/frontend/src/widgets/CheckboxWidget.vue
@@ -41,10 +41,15 @@ function onChange(event: Event) {
 /* TKT-CBSTYLE. The edit arm was a bare native checkbox — OS default size and
    colour — sitting in the same 12-column grid as widgets that all carry
    padding, a token radius and a focus ring, so it read as a foreign control.
-   This is the custom-drawn checkbox RelationCards.vue already uses for its
-   inline boolean edit (`.inline-edit-checkbox`), expressed in the scales.css
-   tokens: same 18px box, same accent fill, same CSS checkmark, so the two
-   boolean edit surfaces agree.
+   It is now custom-drawn from the scales.css tokens.
+
+   THIS IS THE ONLY PLACE A CHECKBOX IS STYLED. RelationCards.vue used to
+   hand-roll an identical control (`.inline-edit-checkbox`) for its inline
+   boolean edit; the two copies drifted (off-centre tick, hardcoded focus-ring
+   colour) and a fix applied to one silently missed the other. Both of its
+   boolean inputs now render this widget and its local rules are deleted. If a
+   new surface needs a checkbox, render this widget — do not restyle a raw
+   `<input type="checkbox">`.
 
    `appearance: none` is what makes the box drawable, and it also removes the
    greyed rendering the browser gave the disabled DISPLAY arm for free. That
@@ -54,7 +59,7 @@ function onChange(event: Event) {
 input[type='checkbox'] {
   /* Unprefixed only: -webkit-appearance is unnecessary from Safari 15.4, and
      nothing in this build regenerates prefixes (no autoprefixer, no
-     browserslist). RelationCards still carries the prefix; it predates that. */
+     browserslist). */
   appearance: none;
   width: 18px;
   height: 18px;

--- a/frontend/src/widgets/widgets.test.ts
+++ b/frontend/src/widgets/widgets.test.ts
@@ -389,6 +389,70 @@ describe('CheckboxWidget (display)', () => {
     })
     expect((w.find('input[type="checkbox"]').element as HTMLInputElement).checked).toBe(true)
   })
+
+  // TKT-CBSTYLE. Styling the widget set `appearance: none`, which removes the
+  // greyed rendering the browser previously gave the disabled display arm for
+  // free. The muted treatment is now drawn by the `.display-checkbox` rule, so
+  // the class is load-bearing rather than decorative.
+  //
+  // This pins the HOOK only (class + disabled). It cannot see whether the rule
+  // hanging off that class actually wins the cascade — the first version of
+  // this change lost that race and shipped `not-allowed` on a read-only field
+  // with these assertions green. `resolves the cursor` below is the test that
+  // catches it; keep both, they fail for different reasons.
+  it.each([true, false])(
+    'keeps the .display-checkbox hook that carries the read-only treatment (%s)',
+    (modelValue) => {
+      const w = mount(CheckboxWidget, {
+        props: { modelValue, mode: 'display' as const, propertyName: '' },
+      })
+      const input = w.find('input[type="checkbox"]')
+      expect(input.classes()).toContain('display-checkbox')
+      expect(input.attributes('disabled')).toBeDefined()
+    }
+  )
+
+  // The edit arm must NOT pick up the display-only muting; it is a live
+  // control and only takes the disabled treatment when actually disabled.
+  it('does not put the display-only class on the edit arm', () => {
+    const w = mount(CheckboxWidget, {
+      props: { modelValue: true, mode: 'edit' as const, propertyName: '' },
+    })
+    expect(w.find('input[type="checkbox"]').classes()).not.toContain('display-checkbox')
+  })
+
+  // The cascade assertion the hook test can't make.
+  //
+  // Vitest does not apply an SFC's scoped <style>, so the rules are injected
+  // here with the same `[data-v-x]` suffix the compiler adds — which is what
+  // makes the specificity faithful: the element rule is (0,3,1) and a bare
+  // `.display-checkbox:disabled` override is (0,3,0), so the general rule wins
+  // and the display arm silently reads as a control you were denied rather
+  // than as a rendered value. `:not(.display-checkbox)` is what prevents that.
+  //
+  // Mirrors CheckboxWidget.vue; if that changes, change this with it.
+  it('resolves the read-only cursor for the display arm, not not-allowed', () => {
+    const style = document.createElement('style')
+    style.textContent = `
+      input[type='checkbox']:disabled:not(.display-checkbox)[data-v-x] {
+        cursor: not-allowed;
+      }
+      .display-checkbox:disabled[data-v-x] { cursor: default; }
+    `
+    document.head.appendChild(style)
+    document.body.innerHTML = `
+      <input data-v-x type="checkbox" class="display-checkbox" disabled />
+      <input data-v-x type="checkbox" disabled />
+    `
+    const [displayArm, disabledEditArm] = [...document.querySelectorAll('input')]
+
+    expect(getComputedStyle(displayArm).cursor).toBe('default')
+    // The edit arm, when the ACL made it read-only, still says "denied".
+    expect(getComputedStyle(disabledEditArm).cursor).toBe('not-allowed')
+
+    style.remove()
+    document.body.innerHTML = ''
+  })
 })
 
 describe('SelectWidget (display)', () => {

--- a/tickets/entities/docs-checklists/DOCS-CB3N8V.md
+++ b/tickets/entities/docs-checklists/DOCS-CB3N8V.md
@@ -1,0 +1,63 @@
+---
+id: DOCS-CB3N8V
+type: docs-checklist
+title: 'Documentation: CheckboxWidget is unstyled — the only widget with no design tokens'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Code Documentation
+
+- [x] Comments where logic isn't obvious
+- [x] ~~Function/type docs if public API~~ (N/A: no functions or types added —
+      the change is scoped CSS plus tests)
+
+Three comments carry non-obvious reasoning that the CSS cannot state itself:
+
+- **Why `:not(.display-checkbox)` instead of a plain override.** The specificity
+  arithmetic ((0,3,1) vs (0,3,0), with Vue's `[data-v-x]` lifting both equally)
+  is the whole reason the first attempt silently failed. Written at the rule so
+  the next editor does not "simplify" it back into the bug.
+- **Why `color-mix` instead of the siblings' literal.** Distinguishes a
+  fallback that never renders from a literal that always does — without it, the
+  line looks gratuitously different from its neighbours.
+- **Why 0.6 and why the siblings' `--hover-bg` does not transfer.** On a
+  checkbox the background *is* the checked signal, so the sibling pattern would
+  erase state to convey read-only.
+
+The test file additionally records what the hook test does **not** cover, so
+its guarantee is not overread — that overreading is what let RR-CBC1XZ ship.
+
+## Project Documentation
+
+- [x] ~~README updated~~ (N/A: no user-visible feature, command, or config)
+- [x] ~~CLAUDE.md updated~~ (N/A: introduces no new pattern — the change
+      *adopts* existing documented ones: `scales.css` tokens and the
+      `properties-list.css` precedent on shared styles)
+- [x] ~~Help text accurate~~ (N/A: no CLI surface)
+
+Deliberately **not** documented in `frontend/CLAUDE.md`: the forced-colors
+block and the `color-mix` ring are currently one widget's local fixes, not
+conventions. Writing them up as house style would assert a consistency the rest
+of the widget set does not yet have (`forced-colors` appears nowhere else in
+`src/`). If [[RR-CBLEV8]]'s shared `.rela-checkbox` lands, that is the point at
+which they become a documented pattern.
+
+## External Documentation
+
+- [x] ~~Changelog entry added~~ (N/A: repo keeps no CHANGELOG — releases are
+      generated from commit history, and the commit message carries the why)
+- [x] ~~API docs updated~~ (N/A: no API change. `docs/data-entry.md` documents
+      the `widget:` override and the widget set; which widget the registry
+      selects, and every wire type, are unchanged — only how an already-selected
+      checkbox is painted)
+
+Verified rather than assumed. `docs/data-entry.md` is generated from
+`docs-project/entities/guides/GUIDE-data-entry.md`, and it *does* mention
+checkboxes — five times. Each was read: the widget table row ("Toggle
+checkbox", boolean properties), the type→widget defaults prose, a `widget:
+checkbox` config example, and the filter-comparison note that a checkbox `true`
+matches both the boolean and the string. All describe **which widget renders a
+boolean and how its value behaves** — none describes how the control is
+painted. Unchanged by this ticket, so there is nothing to regenerate.

--- a/tickets/entities/implementation-checklists/IMPL-CB9F4X.md
+++ b/tickets/entities/implementation-checklists/IMPL-CB9F4X.md
@@ -1,0 +1,103 @@
+---
+id: IMPL-CB9F4X
+type: implementation-checklist
+title: 'Implementation: CheckboxWidget is unstyled — the only widget with no design tokens'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+## Development
+
+- [x] Unit tests written for new code
+- [x] ~~Integration tests written~~ (N/A: the integration surface here is
+      *rendered pixels*, which no test runner in this repo asserts on — jsdom
+      does not apply scoped SFC styles and the Playwright suite has no visual
+      baseline. Verified in a real browser instead; evidence below)
+- [x] Happy path implemented
+- [x] Edge cases from planning handled
+- [x] ~~Error handling in place~~ (N/A: scoped CSS has no failure mode to
+      surface — no I/O, no parsing, no user input)
+
+## Test Quality
+
+- [x] Using fixture builders or factories for test data
+- [x] No hardcoded values in assertions when object is in scope
+- [x] Only specifying values that matter for the test
+- [x] ~~Interpolated values constructed from objects~~ (N/A: no interpolation)
+- [x] Property comparisons use original object, not hardcoded strings
+
+The display-arm test loops `[true, false]` rather than duplicating a block per
+value, so the assertion reads against the mounted widget in both states.
+
+## Manual Verification
+
+- [x] Feature manually tested end-to-end
+- [x] Each acceptance criterion verified with test scenario from planning
+- [x] Edge cases manually verified
+
+**Verification Evidence:**
+
+Run against a freshly built SPA **and** a freshly rebuilt `bin/rela-server`
+(the stale-binary trap from TKT-3R7RF3: `just ci` does not rebuild it, so a
+stale binary embeds a pre-change bundle and silently verifies nothing).
+Confirmed the new rule reached the bundle before trusting the browser:
+`registry-C6V4fbrl.css` contains `input[type=checkbox][data-v-...]{appearance:none`.
+
+Server: `RELA_DATAENTRY_USER=alice@example.com ./bin/rela-server -project
+prototypes/data-entry/project -port 8437`, on
+`/entity/ticket/TKT-001` — the `is_blocked` field in the TKT-3R7RF3 demo
+section, which is exactly the surface where the problem was reported.
+
+- **AC1 — visual consistency.** Computed style on the edit arm:
+  `appearance: none`, `width/height: 18px`, `border-radius: 4px`,
+  `cursor: pointer`. Screenshot confirms it sits consistently beside the
+  selects, text inputs and textarea in the same 12-column grid. PASS
+- **AC2 — checked state.** After clicking: `background-color` and
+  `border-color` both `rgb(111, 147, 255)` = `--accent-color` (dark theme);
+  `::after` renders `5px × 10px`, `matrix(0.707…)` (a 45° rotation), border
+  white. Re-checked in light theme: `rgb(71, 114, 251)` = the light
+  `--accent-color`. Both themes PASS
+- **AC3 — display arm stays muted.** Pinned by unit test + mutation (below).
+  The display arm did not render on the pages exercised, so it is covered by
+  test rather than by eye — stated plainly rather than claimed as observed.
+  PASS (by test)
+- **AC4 — no behaviour regression.** Toggling the live checkbox persisted:
+  `TKT-001.md` gained `is_blocked: true` on disk via the autosave PATCH.
+  Demo-data change reverted afterwards (`git checkout`). PASS
+
+**Scope check performed live.** The same page renders 4 markdown task-list
+checkboxes from the ticket body. All 4 kept `appearance: auto` at 13px,
+confirming the scoped rule did not leak past the widget — and confirming the
+planning decision to leave that surface alone.
+
+**Mutation test of the new guard.** Removing `class="display-checkbox"` from
+the SFC turns the suite red (`1 failed | 59 passed`); restoring it returns it
+to green. The guard fails for the right reason, rather than merely existing.
+
+## Quality
+
+- [x] Code follows project patterns (check similar code)
+- [x] Checked for DRY opportunities
+- [x] No security issues introduced
+- [x] No silent failures (errors logged AND returned)
+- [x] No debug code left behind
+
+**On DRY.** The rule set is deliberately a second copy of
+`RelationCards.vue`'s `.inline-edit-checkbox`, not an extraction. Hoisting it
+to a shared stylesheet would mean editing a working component to serve a
+styling ticket, and the two sites differ in layout context. Per CLAUDE.md's
+"three similar lines is better than a premature abstraction", two copies is
+the honest state — recorded as a follow-up rather than silently tolerated.
+
+**Token usage.** `--radius-sm` replaces the literal `4px`. The remaining
+values (18px box, 2px border, the checkmark geometry) stay literal because
+`scales.css` has no control-size or border-width ramp, and the checkmark
+geometry is tuned to the 18px box rather than being a scale step. Inventing
+tokens for them would violate the file's own "prefer an existing value in the
+tree over a rounder number" rule.
+
+**Verified against the frozen contracts.** The change adds no `--font-size-*`
+and touches neither `tokens.css` nor `scales.css`, so the cross-boundary
+typography/token contracts are untouched. Confirmed by running the Go-side
+guards: `TestAppTokensCSSInSyncWithFrontend`, `TestFrozenTypographyContract­MatchesSPA`,
+`TestAppCSSSource`, `TestTokensCSSNeverLayered` — all PASS.

--- a/tickets/entities/planning-checklists/PLAN-CB7K2M.md
+++ b/tickets/entities/planning-checklists/PLAN-CB7K2M.md
@@ -1,0 +1,211 @@
+---
+id: PLAN-CB7K2M
+type: planning-checklist
+title: 'Planning: CheckboxWidget is unstyled — the only widget with no design tokens'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+## Understanding
+
+- [x] Problem/requirements clearly understood
+- [x] Scope defined (what's in/out documented below)
+- [x] Acceptance criteria documented with specific test scenarios
+
+**Scope:**
+
+IN: the `CheckboxWidget` **edit** arm's visual treatment, plus whatever the
+change does to the **display** arm as a side effect.
+
+OUT: markdown task-list checkboxes in entity content (`- [ ] item`). Those are
+rendered by the markdown pipeline, not the widget, and carry their own toggle
+behaviour (`utils/checkboxToggle.ts`). Confirmed present on the same page
+during verification — 4 of the 5 checkboxes on the TKT-001 detail view — and
+deliberately left alone. Restyling them is a separate surface with a separate
+risk profile.
+
+OUT: the `display: table` cell rendering of booleans, which routes to text so
+values stay Cmd-F searchable (`frontend/CLAUDE.md`).
+
+OUT: behaviour of any kind. No change to checked/unchecked semantics, the
+`@change` handler, or the auto-save path.
+
+**Acceptance Criteria:**
+
+1. The edit-arm checkbox carries the same visual language as its grid
+   neighbours (token radius, accent colour, focus ring).
+   *Test:* computed style in a live browser — `appearance: none`, 18px box,
+   `border-radius: 4px` (`--radius-sm`); verified against the running app.
+2. Checked state fills with the theme accent and renders a checkmark.
+   *Test:* computed `background-color` equals `--accent-color` in both themes;
+   `::after` renders at 5×10px rotated 45°.
+3. The display (read-only) arm stays visibly muted after `appearance: none`
+   removes the browser's native disabled rendering.
+   *Test:* unit test pins the `.display-checkbox` hook + `disabled`; verified
+   under mutation.
+4. No behaviour regression.
+   *Test:* full frontend suite; plus a live toggle that must persist to disk.
+
+## Research
+
+- [x] ~~For larger features: run `/research`~~ (N/A: xs styling change)
+- [x] Searched for existing libraries that solve this problem
+- [x] Checked codebase for similar patterns or reusable code
+- [x] Looked for reference implementations in other projects
+- [x] Reviewed relevant rela concepts for prior art
+
+**Research Doc:** N/A — xs, single-file styling change.
+
+**Existing Solutions:**
+
+No library needed; this is ~40 lines of CSS.
+
+The decisive find is **prior art already in the tree**:
+`components/forms/RelationCards.vue:961-999` (`.inline-edit-checkbox`) is a
+fully custom-drawn checkbox used for inline boolean edit — `appearance: none`,
+18px box, accent fill, CSS-border checkmark. That is the same job on a
+different surface, so the widget should look like it rather than invent a
+second boolean style.
+
+Also surveyed:
+- `EntityList.vue:1378` — row-select checkboxes, styled only with
+  `accent-color`. A lighter approach, but it can't produce the token radius or
+  the focus ring, so it under-delivers on AC1.
+- `TextWidget.vue` / `SelectWidget.vue` — the grid neighbours whose look this
+  must match. Note both still use **raw px** (`6px`, `10px 12px`, `14px`)
+  rather than scale tokens; they predate TKT-8VVBRI's token migration.
+
+## Approach
+
+- [x] Technical approach chosen and documented
+- [x] Approach builds on existing patterns (not reinventing)
+- [x] Alternatives considered (document why rejected)
+- [x] Dependencies identified (packages, APIs, types)
+
+**Technical Approach:**
+
+Port `RelationCards`'s `.inline-edit-checkbox` rule set into
+`CheckboxWidget.vue`'s scoped `<style>`, keyed on `input[type='checkbox']` so
+it covers both arms, and express the values as `scales.css` tokens where a
+token exists (`--radius-sm` for the 4px radius) rather than as literals.
+
+The one genuinely new consideration: `appearance: none` is what makes the box
+drawable, and it *also* discards the greyed rendering the browser gave the
+disabled display arm for free. That treatment was load-bearing (RR-UD2I chose a
+real disabled checkbox precisely for its native affordances), so the muted
+state has to be drawn explicitly instead of inherited — otherwise a read-only
+boolean becomes indistinguishable from an editable one. This is the only part
+of the change that is not a copy of existing CSS.
+
+Alternatives considered:
+- **`accent-color` only** (the `EntityList` approach). Two lines, no
+  `appearance: none`, so the display arm keeps its native greying and AC3
+  becomes free. Rejected: `accent-color` cannot set the border radius or the
+  focus ring, so the control still reads as an OS widget — it fails AC1, which
+  is the entire ticket.
+- **Extract a shared checkbox class** into `styles/`, used by both
+  `RelationCards` and the widget. Rejected for this ticket: it edits a working
+  component to serve a styling change, and the two uses sit at different sizes
+  in different layouts. Noted as follow-up instead.
+- **Replace the display arm with a glyph/`<span>`.** Rejected outright — the
+  ticket forbids it and RR-UD2I documents why (native screen-reader semantics).
+
+**Files to modify:**
+- `frontend/src/widgets/CheckboxWidget.vue` — the styles
+- `frontend/src/widgets/widgets.test.ts` — guard for the display arm
+
+## Security Considerations
+
+- [x] ~~Input sources identified~~ (N/A: no input is read)
+- [x] ~~Input validation approach defined~~ (N/A: no input is read)
+- [x] ~~Security-sensitive operations identified~~ (N/A: none)
+- [x] ~~Error handling doesn't leak sensitive information~~ (N/A: no errors)
+
+**Input Sources & Validation:**
+
+None. The change is scoped CSS in a single SFC. It adds no props, reads no
+config, performs no I/O, and interpolates no value into a selector or a URL.
+
+The one adjacent-to-security property worth stating: the change must not make
+a **read-only** control look editable, since that misrepresents an ACL verdict
+to the user. That is AC3, and it is why the disabled state is drawn explicitly
+rather than left to the browser. It is a correctness/UX property rather than a
+vulnerability — a user who clicks a disabled checkbox still cannot write, since
+the input carries `disabled` and the server re-checks regardless.
+
+## Test Plan
+
+- [x] Test scenarios documented for each acceptance criterion
+- [x] Edge cases identified and documented
+- [x] Negative test cases defined (invalid input, error conditions)
+- [x] Integration test approach defined (not just unit tests)
+
+**Test Scenarios:**
+
+AC1/AC2 are *computed-style* properties. jsdom does not apply scoped SFC
+styles, so a Vitest assertion on them would pass against no CSS at all — a
+guard that cannot fail. They are therefore verified in a **real browser**
+against the running server, and that is stated in the test file rather than
+faked with a jsdom assertion.
+
+AC3 is testable as structure: the `.display-checkbox` hook the CSS hangs off.
+Pinned by unit test, and the guard was **verified under mutation** (removing
+the class from the SFC makes it fail; restoring it makes it pass).
+
+AC4 is covered by the existing 1824-test suite plus a live end-to-end toggle
+that must land on disk.
+
+**Edge Cases:**
+- Checked *and* disabled — a read-only `true`. Must still read as checked, not
+  merely as muted. Covered by the unit test looping both `true` and `false`.
+- Both themes — the accent is a token, so light/dark correctness follows from
+  using `var(--accent-color)`. Verified in both.
+- Edit arm must NOT pick up the display-only muting; pinned by its own test.
+
+**Negative Tests:**
+- Removing `class="display-checkbox"` must fail the suite (mutation-verified).
+- The edit arm must not carry that class (asserted directly).
+
+## Risk Assessment
+
+- [x] Technical risks assessed with mitigations
+- [x] Security risks assessed (see Security Considerations)
+- [x] Effort estimated (xs/s/m/l/xl)
+
+**Risks:**
+
+- *`appearance: none` silently degrades the display arm.* The main risk, and
+  the reason AC3 exists. Mitigated by drawing the disabled state explicitly and
+  pinning the hook with a mutation-verified test.
+- *Selector reaches further than intended.* The rule is keyed on
+  `input[type='checkbox']`, and scoped styles apply only within the SFC — which
+  renders exactly one input. Confirmed live: the 4 markdown checkboxes on the
+  same page kept `appearance: auto`, so nothing leaked.
+- *Divergence from `RelationCards`.* Two hand-maintained copies of one visual.
+  Accepted for an xs ticket; recorded as a follow-up rather than pretended away.
+
+**Effort:** xs (confirmed — 2 files, ~40 lines of CSS, ~20 of test).
+
+## Documentation Planning
+
+- [x] User-facing docs identified (skip if internal refactor)
+- [x] Docs-checklist will be created when entering implementation
+
+**Documentation Impact:**
+
+- [x] N/A — no user-facing docs needed.
+
+Nothing an operator writes, configures, or invokes changes. There is no new
+config key, no new widget name, no change to which widget the registry picks,
+and no change to behaviour. `docs/data-entry.md` documents the `widget:`
+override and the widget set; both are unaffected by how a checkbox is painted.
+
+## Design Review
+
+- [x] ~~Run `/design-review` before starting implementation~~ (N/A: xs
+      single-file CSS change with no interface, data-flow, or API surface to
+      review; the design question — match `RelationCards` vs `accent-color`
+      only — is recorded under Approach with the rejection rationale)
+- [x] All critical/significant findings addressed in plan
+
+**Design Review Findings:** None (review not run — see above).

--- a/tickets/entities/review-checklists/REV-CB5T2K.md
+++ b/tickets/entities/review-checklists/REV-CB5T2K.md
@@ -37,8 +37,16 @@ file in this diff is among them**, and it is not a CI gate.
 **Review Responses:** [[RR-CBC1XZ]] (critical, addressed), [[RR-CBS2QW]]
 (significant, addressed), [[RR-CBS3AC]] (significant, addressed),
 [[RR-CBM1TS]] (minor, addressed), [[RR-CBM3TR]] (minor, addressed),
-[[RR-CBM5OP]] (minor, addressed), [[RR-CBM2SL]] (minor, wont-fix),
-[[RR-CBLEV8]] (minor, deferred), [[RR-CBM4WP]] (nit, addressed).
+[[RR-CBM5OP]] (minor, addressed), [[RR-CBTICK9]] (minor, addressed),
+[[RR-CBM2SL]] (minor, wont-fix), [[RR-CBLEV8]] (minor, deferred),
+[[RR-CBM4WP]] (nit, addressed).
+
+[[RR-CBTICK9]] came from the user reviewing the running demo, not from the
+agent pass — the tick was inheriting an off-centre position from
+`RelationCards`. Worth noting the two failed attempts recorded there: deriving
+the position from the ink bounding box, and validating it by overlaying on the
+native control. Both were reasonable and both were wrong, because neither
+tested the property that actually mattered — how the tick sits in its own box.
 
 The critical finding was a **real defect in my own first draft**, not a false
 positive: `.display-checkbox:disabled` lost the cascade to

--- a/tickets/entities/review-checklists/REV-CB5T2K.md
+++ b/tickets/entities/review-checklists/REV-CB5T2K.md
@@ -1,0 +1,106 @@
+---
+id: REV-CB5T2K
+type: review-checklist
+title: 'Review: CheckboxWidget is unstyled — the only widget with no design tokens'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Automated Checks
+
+- [x] All tests pass (`just test`)
+- [x] Lint clean (`just lint`)
+- [x] Comment lint gate clean (`just comment-lint`)
+- [x] Coverage maintained (`just coverage-check`)
+
+Frontend: **1828 tests / 113 files pass** (up from 1824 — this change adds 4:
+two `it.each` arms of the hook test, the edit-arm negative, and the cascade
+test). `vue-tsc --noEmit` clean. ESLint **0 errors**.
+
+Go: `just lint` **0 issues**; `just comment-lint` **no findings across 10183
+comments**; `go build ./...` OK; `internal/dataentry` tests pass.
+
+Coverage: no Go code changed, so no package floor moves. The frontend has no
+coverage enforcement by design (`CLAUDE.md`: "unit tests run plain").
+
+`npm run format:check` reports 128 pre-existing files repo-wide; **neither
+file in this diff is among them**, and it is not a CI gate.
+
+## Code Review
+
+- [x] Run `/code-review` command (invokes cranky-code-reviewer agent)
+- [x] All critical review-responses addressed
+- [x] All significant review-responses addressed
+- [x] Self-reviewed the diff for unrelated changes
+
+**Review Responses:** [[RR-CBC1XZ]] (critical, addressed), [[RR-CBS2QW]]
+(significant, addressed), [[RR-CBS3AC]] (significant, addressed),
+[[RR-CBM1TS]] (minor, addressed), [[RR-CBM3TR]] (minor, addressed),
+[[RR-CBM5OP]] (minor, addressed), [[RR-CBM2SL]] (minor, wont-fix),
+[[RR-CBLEV8]] (minor, deferred), [[RR-CBM4WP]] (nit, addressed).
+
+The critical finding was a **real defect in my own first draft**, not a false
+positive: `.display-checkbox:disabled` lost the cascade to
+`input[type='checkbox']:disabled`, so every read-only boolean rendered
+`not-allowed` — the precise opposite of the comment sitting above it, and a
+regression against the pre-change code. It was confirmed independently in a CSS
+engine before being fixed, and it is now reproduced by a test that fails when
+the guard is removed.
+
+Diff contains no unrelated changes: two files, both named in the planning
+checklist. The demo-data write produced by live verification
+(`TKT-001.md` gaining `is_blocked: true`) was reverted; the tree is clean.
+
+## Acceptance Verification
+
+- [x] Each acceptance criterion tested (reference planning checklist)
+- [x] Test evidence documented in implementation checklist
+
+**Acceptance Status:**
+
+- **AC1 (visual consistency) — PASS.** Live computed style: `appearance: none`,
+  18×18, `border-radius: 4px` (`--radius-sm`), `cursor: pointer`. Screenshotted
+  beside its grid neighbours.
+- **AC2 (checked state follows the theme) — PASS.** Fill resolves to
+  `#6f93ff` (dark) and `#4772fb` (light) — both the live `--accent-color`.
+  Checkmark renders 5×10 at 45°. The focus ring now also resolves from the
+  accent (`color(srgb 0.435 0.576 1 / 0.3)`) rather than the indigo literal
+  the first draft copied.
+- **AC3 (display arm stays legible as read-only) — PASS, and materially
+  stronger than at first submission.** Verified in a real browser against the
+  compiled stylesheet: display arm `cursor: default` / `opacity: 0.6`;
+  ACL-denied edit arm `not-allowed` / `0.6`; live edit arm `pointer` / `1`.
+  The first draft failed this criterion silently — see [[RR-CBC1XZ]].
+- **AC4 (no behaviour regression) — PASS.** Full suite green; a live toggle
+  persisted to disk through the autosave PATCH.
+
+Scope confirmed live: the 4 markdown task-list checkboxes rendered in the same
+DOM kept `appearance: auto`, so the scoped rule did not leak.
+
+## Documentation (enhancements only)
+
+- [x] Docs-checklist created and linked via `has-docs`
+- [x] User-facing documentation updated
+- [x] Docs-checklist marked as done
+
+**Docs Checklist:** [[DOCS-CB3N8V]]
+
+No user-facing docs *changed*: every checkbox mention in `docs/data-entry.md`
+was read and each describes widget selection or value semantics, not
+appearance. Recorded in the docs checklist with the reasoning rather than
+waved through as "N/A".
+
+## Final Checks
+
+- [x] Commit message explains the why, not just what
+- [x] No TODOs or FIXMEs left unaddressed
+- [x] Ready for another developer to use
+
+## Pull Request
+
+- [x] Run `/pr` command to create PR and monitor CI
+- [x] All CI checks pass
+- [x] PR URL documented below
+
+**PR:** see ticket — opened from branch `fix/checkbox-widget-styling-cbstyle`.

--- a/tickets/entities/review-checklists/REV-CB5T2K.md
+++ b/tickets/entities/review-checklists/REV-CB5T2K.md
@@ -103,4 +103,12 @@ waved through as "N/A".
 - [x] All CI checks pass
 - [x] PR URL documented below
 
-**PR:** see ticket — opened from branch `fix/checkbox-widget-styling-cbstyle`.
+**PR:** https://github.com/sourcehaven-bv/rela/pull/1405
+
+**Local `just test` note.** The full race-enabled Go suite fails locally on
+`TestAnalyzeProperties_StopsScanningAtCap` (`internal/dataentry`) — a 10-minute
+`testing` timeout after the test ran 8m20s, not an assertion failure. This
+branch changes **zero Go files** (`git diff --stat develop...HEAD -- '*.go'` is
+empty), so it cannot be the cause; the test dates to #1337 and is being
+reproduced on a clean `develop` worktree to confirm. CI is the independent
+verdict and is authoritative here.

--- a/tickets/entities/review-responses/RR-CBC1XZ.md
+++ b/tickets/entities/review-responses/RR-CBC1XZ.md
@@ -1,0 +1,23 @@
+---
+id: RR-CBC1XZ
+type: review-response
+title: '.display-checkbox:disabled loses the specificity race — display arm rendered not-allowed, inverting the stated intent'
+finding: 'The new `.display-checkbox:disabled { cursor: default }` rule never applied. `input[type=''checkbox'']:disabled` is (0,3,1); `.display-checkbox:disabled` is (0,3,0). Vue''s scoped compilation appends `[data-v-x]` to both, shifting them equally, so the element rule wins outright regardless of source order. Every read-only boolean therefore rendered `cursor: not-allowed` — the exact behaviour the comment above the rule said it was preventing, and a regression against the pre-change code where `cursor: default` was the only rule and did apply. The ticket''s Non-goals opens with "No behaviour change"; hover affordance is user-visible behaviour.'
+severity: critical
+resolution: 'Rewrote the general rule as `input[type=''checkbox'']:disabled:not(.display-checkbox)`. `:not()` takes its argument''s specificity, making it (0,4,1) AND — more importantly — making it structurally unable to match the display arm, so a later edit cannot silently re-lose the race. Added `resolves the read-only cursor for the display arm` to widgets.test.ts, which injects the rules with the real `[data-v-x]` suffix and asserts computed cursor per arm. Verified in a real browser against the compiled stylesheet: display arm `default`, ACL-denied edit arm `not-allowed`, live edit arm `pointer`.'
+status: addressed
+---
+
+Confirmed independently before fixing, rather than taken on the reviewer's word
+— jsdom resolves the cascade correctly, so the bug reproduces in a few lines:
+
+```
+display arm cursor: not-allowed     <- should have been "default"
+edit arm cursor   : not-allowed
+```
+
+The instructive part is that both tests I had written were green while this was
+live. They asserted that a class was *present*, which cannot see whether the
+rule hanging off that class *applies*. The new test fails with
+`expected 'not-allowed' to be 'default'` when the `:not()` guard is removed, so
+it reproduces the defect rather than merely covering the line.

--- a/tickets/entities/review-responses/RR-CBLEV8.md
+++ b/tickets/entities/review-responses/RR-CBLEV8.md
@@ -4,9 +4,9 @@ type: review-response
 title: 'Checkbox visual is now drawn in two files; the sanctioned fix is a shared class, not a second copy'
 finding: 'CheckboxWidget and RelationCards now each draw the same custom checkbox, and the copies have already diverged (`4px` vs `var(--radius-sm)`, `white` vs `#fff`, prefixed vs unprefixed appearance) while sharing one bug (the hardcoded indigo focus ring, RR-CBS2QW). frontend/CLAUDE.md documents this exact trajectory for `properties-list.css`: those classes "used to be declared three times with three different min-width values, scoped so they could never actually share". A shared `.rela-checkbox` in src/styles/ would delete ~35 duplicated lines and make the ring a one-line fix in one place.'
 severity: minor
-resolution: 'Deferred to a follow-up ticket rather than done here.'
-reason: 'The extraction means editing RelationCards — a working component with its own inline-edit behaviour — to serve an `effort: xs` styling ticket, and it changes a second surface that this ticket''s acceptance criteria never exercise. Doing it inside this diff would make the change unreviewable as a styling fix. Recorded explicitly on the ticket (Follow-ups) rather than left implicit, which is what the reviewer asked for if deferred.'
-status: deferred
+resolution: 'Superseded by [[RR-CBSHARE]] — done in this ticket after all, and better than proposed: RelationCards now renders the shared CheckboxWidget rather than adopting a shared stylesheet, so behaviour and accessibility are shared too, not just paint.'
+reason: 'Originally deferred on scope grounds (editing a working component to serve an `effort: xs` styling ticket, on a surface the acceptance criteria never exercise). The user overrode that once the tick fix landed, and was right to: RR-CBTICK9 corrected the tick in the widget only, leaving the duplicate in RelationCards visibly wrong in the product. A fix that reaches one of two identical surfaces is worse than the scope cost of doing both.'
+status: addressed
 ---
 
 Note the divergences are not symmetric: the widget is now the *better* copy

--- a/tickets/entities/review-responses/RR-CBLEV8.md
+++ b/tickets/entities/review-responses/RR-CBLEV8.md
@@ -1,0 +1,15 @@
+---
+id: RR-CBLEV8
+type: review-response
+title: 'Checkbox visual is now drawn in two files; the sanctioned fix is a shared class, not a second copy'
+finding: 'CheckboxWidget and RelationCards now each draw the same custom checkbox, and the copies have already diverged (`4px` vs `var(--radius-sm)`, `white` vs `#fff`, prefixed vs unprefixed appearance) while sharing one bug (the hardcoded indigo focus ring, RR-CBS2QW). frontend/CLAUDE.md documents this exact trajectory for `properties-list.css`: those classes "used to be declared three times with three different min-width values, scoped so they could never actually share". A shared `.rela-checkbox` in src/styles/ would delete ~35 duplicated lines and make the ring a one-line fix in one place.'
+severity: minor
+resolution: 'Deferred to a follow-up ticket rather than done here.'
+reason: 'The extraction means editing RelationCards — a working component with its own inline-edit behaviour — to serve an `effort: xs` styling ticket, and it changes a second surface that this ticket''s acceptance criteria never exercise. Doing it inside this diff would make the change unreviewable as a styling fix. Recorded explicitly on the ticket (Follow-ups) rather than left implicit, which is what the reviewer asked for if deferred.'
+status: deferred
+---
+
+Note the divergences are not symmetric: the widget is now the *better* copy
+(theme-following ring, forced-colors fallback, correct disabled specificity).
+So the follow-up is "lift the widget's version into a shared class and adopt it
+in RelationCards", not a merge of equals.

--- a/tickets/entities/review-responses/RR-CBM1TS.md
+++ b/tickets/entities/review-responses/RR-CBM1TS.md
@@ -1,0 +1,19 @@
+---
+id: RR-CBM1TS
+type: review-response
+title: 'The two added tests are change-detectors for a class attribute, and their comment oversold them as pinning the read-only treatment'
+finding: 'The tests assert only that `.display-checkbox` is present on the element. They cannot see whether the rule that class hangs off actually wins the cascade — which is exactly the defect in RR-CBC1XZ, in the same file, with 60 green tests over it. The comment claimed the class was "load-bearing … pinned by tests", which a future reader would reasonably read as a guarantee that does not exist. Separately, the first test looped `for (const modelValue of [true, false])` with no subtest boundary, so a failure would not say which arm broke.'
+severity: minor
+resolution: 'Added `resolves the read-only cursor for the display arm`, which injects the rules with the real `[data-v-x]` scope suffix and asserts computed cursor for all three arms — the assertion that actually catches RR-CBC1XZ (mutation-verified: it fails with `expected ''not-allowed'' to be ''default''`). Rewrote the hook test''s comment to say plainly what it does and does not cover, and pointed it at the cascade test. Converted the loop to `it.each`, so each arm reports separately.'
+status: addressed
+---
+
+Both tests are kept deliberately: they fail for different reasons. The hook
+test catches a careless template refactor that drops the class; the cascade
+test catches a stylesheet edit that makes the class inert. Neither subsumes
+the other.
+
+The cascade test duplicates the two selectors from the SFC, which is a real
+maintenance cost — noted in the test comment so the next editor changes both.
+Vitest does not apply scoped SFC styles, so there is no way to assert this
+against the component's own CSS without a browser-based runner.

--- a/tickets/entities/review-responses/RR-CBM2SL.md
+++ b/tickets/entities/review-responses/RR-CBM2SL.md
@@ -1,0 +1,14 @@
+---
+id: RR-CBM2SL
+type: review-response
+title: 'Bare `input[type=checkbox]` selector encodes "I am the only checkbox in this SFC" as an unenforced invariant'
+finding: 'The rules key on a bare element selector. Vue''s scoped `data-v-` attribute confines them to this SFC, which today renders exactly one input — so there is no live blast radius. But the day someone adds a second checkbox to the component (a tri-state control, an "apply to all" affordance) it silently inherits all the rules. RelationCards used a real class (`.inline-edit-checkbox`) precisely because it is not alone in its file.'
+severity: minor
+resolution: 'Left as-is, deliberately.'
+reason: 'The bare-element form is the house style for the widget set — TextWidget uses `input {`, SelectWidget uses `select {` — and these SFCs are single-control by construction. Switching this one widget to a class would make it the odd one out without removing any live risk. Verified there is no current exposure: single-root template, no <slot>, no child components, and no `:deep()` anywhere in src/widgets/. If a second checkbox is ever added here, that edit is the moment to introduce the class.'
+status: wont-fix
+---
+
+Confirmed live rather than reasoned about: on the demo detail page the four
+markdown task-list checkboxes rendered in the same DOM kept `appearance: auto`
+at 13px, so the scoped rule did not reach past the widget.

--- a/tickets/entities/review-responses/RR-CBM3TR.md
+++ b/tickets/entities/review-responses/RR-CBM3TR.md
@@ -1,0 +1,16 @@
+---
+id: RR-CBM3TR
+type: review-response
+title: '`transition: all` animates the focus ring and any future property added to the rule'
+finding: '`transition: all 0.15s` was copied from RelationCards. `all` catches `box-shadow`, so the focus ring fades in over 150ms rather than appearing on tab — a focus indicator that animates is a worse focus indicator. It also silently animates any property a future edit adds to the rule.'
+severity: minor
+resolution: 'Narrowed to `transition: background-color 0.15s, border-color 0.15s` — the two properties the checked-state change actually animates.'
+status: addressed
+---
+
+The reviewer also raised `prefers-reduced-motion`. Not added: at 150ms on two
+colour properties this is well inside the "not motion" category (no transform,
+no position change), and the codebase has exactly one such guard
+(`AutoSaveIndicator.vue:169`) on a genuinely moving element. Adding one here
+would imply a convention the rest of the widget set does not follow. Recorded
+rather than silently skipped.

--- a/tickets/entities/review-responses/RR-CBM4WP.md
+++ b/tickets/entities/review-responses/RR-CBM4WP.md
@@ -1,0 +1,12 @@
+---
+id: RR-CBM4WP
+type: review-response
+title: 'Dropped -webkit-appearance relative to the copied prior art, with no autoprefixer to regenerate it'
+finding: 'RelationCards writes both `appearance: none` and `-webkit-appearance: none`; this change kept only the unprefixed form. There is no postcss.config, no browserslist key, and no autoprefixer dependency, so nothing regenerates the prefix. Functionally fine — unprefixed `appearance` is supported from Safari 15.4 (2022), inside Vite''s default ES-modules baseline — but it reads as an oversight rather than a decision.'
+severity: nit
+resolution: 'Kept unprefixed, with a comment recording the reasoning and noting that RelationCards predates the baseline. Verified independently: no browserslist config and no autoprefixer in the build.'
+status: addressed
+---
+
+Documenting the decision was the point of the finding; the code is unchanged
+apart from the comment.

--- a/tickets/entities/review-responses/RR-CBM5OP.md
+++ b/tickets/entities/review-responses/RR-CBM5OP.md
@@ -1,0 +1,18 @@
+---
+id: RR-CBM5OP
+type: review-response
+title: 'opacity 0.85 was tuned as a nudge on top of native greying; as the sole read-only signal it is near-imperceptible'
+finding: 'Before this change, `opacity: 0.85` sat on top of the browser''s native disabled rendering — it was a supplement. With `appearance: none` the native greying is gone and 0.85 became the entire read-only signal. A 15% reduction on an accent-filled box is barely visible, so a read-only boolean and an editable one look nearly identical. The comment asserted the muted state was "drawn explicitly rather than inherited" while still carrying the inherited-era value.'
+severity: minor
+resolution: "Lowered to 0.6 and documented why the sibling widgets' approach does not transfer."
+status: addressed
+---
+
+The obvious move — copy `background: var(--hover-bg)` from `TextWidget` /
+`SelectWidget` / `NumberWidget` — is wrong here, and the reason is worth
+recording. On those controls the background is chrome. On a checkbox the
+background **is the checked signal**, so overwriting it to convey "read-only"
+would erase the state the widget exists to display. Dimming preserves both
+axes; a background swap trades one for the other.
+
+0.6 applies to both disabled arms (display and ACL-denied edit).

--- a/tickets/entities/review-responses/RR-CBS2QW.md
+++ b/tickets/entities/review-responses/RR-CBS2QW.md
@@ -1,0 +1,16 @@
+---
+id: RR-CBS2QW
+type: review-response
+title: 'Focus ring hardcoded indigo (#6366f1) — renders off-hue and does not follow the theme'
+finding: 'The focus ring was `box-shadow: 0 0 0 2px rgb(99 102 241 / 30%)` with no `var()` at all. This is distinct from the sibling widgets'' `var(--accent-color, #6366f1)` pattern, where the indigo is a FALLBACK that never renders (tokens.css defines --accent-color unconditionally for both themes). Here the literal IS the value: it renders on every focus, in both themes, against an app whose real accent is #4772fb (light) / #6f93ff (dark). It also defeats operator theming — the `@layer rela` architecture exists so an unlayered `custom.css` accent wins, but a literal is unreachable by it. So "consistency with siblings" does not defend this line; it propagates the one part of the copied prior art that was a mistake.'
+severity: significant
+resolution: 'Replaced with `color-mix(in srgb, var(--accent-color) 30%, transparent)`. Verified in-browser that it resolves to `color(srgb 0.435294 0.576471 1 / 0.3)` = #6f93ff at 30% — the live dark-theme accent, not indigo — and confirmed the function survives the Vite build unmangled.'
+status: addressed
+---
+
+The `var(--accent-color, #6366f1)` fallbacks elsewhere in the rule set were
+deliberately left alone: they are dead-but-harmless and match every sibling
+widget. Changing them is a separate cleanup, not this ticket.
+
+`RelationCards.vue:998` carries the same hardcoded ring. Not fixed here —
+see [[RR-CBLEV8]] for why that is deferred rather than done in passing.

--- a/tickets/entities/review-responses/RR-CBS3AC.md
+++ b/tickets/entities/review-responses/RR-CBS3AC.md
@@ -1,0 +1,18 @@
+---
+id: RR-CBS3AC
+type: review-response
+title: 'appearance:none + outline:none erases the control in forced-colors (Windows High Contrast) mode'
+finding: 'In `forced-colors: active` the OS overrides background-color and border-color with system colours, drops `box-shadow` entirely, and does not guarantee `::after` pseudo-element rendering. The checked state was communicated ONLY by `background: var(--accent-color)` plus the `::after` checkmark, and the focus indicator ONLY by box-shadow (with `outline: none` removing the native one). Net effect for a High Contrast user: no visible focus ring, and potentially no checked/unchecked distinction. Before this change the native control was immune — the OS drew it correctly for free — so the change materially worsens this one control. `forced-colors` appears nowhere in src/, so this is a codebase-wide gap rather than a deviation from a local pattern.'
+severity: significant
+resolution: 'Added a `@media (forced-colors: active)` block that sets `appearance: auto` — handing the control back to the OS in exactly the mode where the OS draws it better than we can — and restores a real `outline: 2px solid Highlight` focus ring, using the system Highlight colour keyword.'
+status: addressed
+---
+
+Worth recording the asymmetry: the same exposure exists in
+`RelationCards.vue`'s `.inline-edit-checkbox`, which shipped without it. This
+change does not fix that instance, but it also does not copy the gap forward —
+the widget is now the better-behaved of the two. Consolidating them is
+[[RR-CBLEV8]].
+
+`:focus-visible` (rather than `:focus`) was already correct — no ring on mouse
+click, ring on keyboard focus — and is retained.

--- a/tickets/entities/review-responses/RR-CBSHARE.md
+++ b/tickets/entities/review-responses/RR-CBSHARE.md
@@ -1,0 +1,34 @@
+---
+id: RR-CBSHARE
+type: review-response
+title: 'RelationCards hand-rolled a duplicate checkbox — consolidated onto the shared CheckboxWidget'
+finding: 'RelationCards.vue styled its own `.inline-edit-checkbox`, a copy of CheckboxWidget''s CSS. The copies had already drifted (the widget gained a theme-following focus ring and a corrected tick position; RelationCards kept the hardcoded indigo ring and the off-centre tick), so the tick fix in RR-CBTICK9 left the inline relation editor visibly wrong. Originally deferred as RR-CBLEV8 on the grounds that it touched a working component outside this ticket''s acceptance criteria; the user overrode that, correctly — shipping a fix that lands on one of two identical surfaces is worse than the scope cost of doing both.'
+severity: minor
+resolution: 'Both boolean inputs in RelationCards now render CheckboxWidget, and the ~35 lines of local `.inline-edit-checkbox` CSS are deleted. Supersedes RR-CBLEV8 (which proposed extracting a shared stylesheet — using the existing widget is strictly better, since it shares behaviour and accessibility, not just paint). Verified in the running app: the form field and the RelationCards meta field now render identically.'
+status: addressed
+---
+
+The second call site turned out to be a *third* variant, not a second: the "new
+relation" form rendered a bare `<input type="checkbox">` with no class at all,
+so it had never received any of the styling. Consolidating fixed a surface
+nobody had reported.
+
+**Why the widget rather than a shared stylesheet.** RR-CBLEV8 proposed
+`src/styles/checkbox.css` with a `.rela-checkbox` class. Rendering the
+component is better: a stylesheet shares only paint, while the widget also
+carries the `forced-colors` fallback, the disabled/read-only distinction, and
+the display-vs-edit arms. A future accessibility fix lands everywhere by
+construction instead of by remembering to add a class.
+
+**Behaviour preserved.** The card-level input keeps its ACL plumbing — the
+`writable === false` verdict now travels through the widget's `disabled` prop
+instead of a raw attribute, and is pinned by a test. The new-relation input
+kept `v-model`; `newMeta` seeds properties to `''`, which the widget reads as
+unchecked and replaces with a real boolean on first toggle, exactly as the
+native input did.
+
+**The guard is real.** RelationCards.test.ts had NO boolean coverage at all, so
+the pre-existing 243 passing form tests proved nothing about this change. Four
+tests were added and mutation-verified: reverting either call site to a raw
+styled input fails all four. They assert the *widget* is mounted rather than
+that a checkbox exists, which a re-introduced raw input would satisfy.

--- a/tickets/entities/review-responses/RR-CBTICK9.md
+++ b/tickets/entities/review-responses/RR-CBTICK9.md
@@ -1,0 +1,35 @@
+---
+id: RR-CBTICK9
+type: review-response
+title: 'Checkmark sat low and right in the box — inherited position from RelationCards was never centred'
+finding: 'Reported by the user on visual inspection of the running demo: the tick "feels slightly off", sitting low-right with dead space along the top and the vertex nearly touching the bottom edge. Confirmed by measurement — the painted ink left 2.20px clearance on the left but only 1.20px on the right of the 14px inner box. The position came from RelationCards.vue''s `.inline-edit-checkbox` (`left: 5px; top: 1px`) and was copied verbatim along with the arm geometry, so the same misalignment has been shipping in the inline relation editor.'
+severity: minor
+resolution: 'Moved to `left: 4px; top: -1px` (2px left, 2px up), tuned by eye at 13x against the alternatives in a purpose-built static comparison page, then verified on the real widget in the running app. The arm geometry (5x10, 2px stroke) is unchanged — it matches the native glyph well; only the position moved.'
+status: addressed
+---
+
+Two wrong turns on the way, both recorded because the reasoning is what the
+comment in the SFC now guards against.
+
+**1. Deriving the position instead of looking at it.** The first attempt solved
+for the geometric centre of the rotated ink bounding box (4.5px/0.94px, giving
+1.7px clearance on all four sides) and shrank the arms to a tidier 2.4:1 ratio.
+Overlaid on a real `appearance: auto` control at 16x it was visibly worse:
+further from the native glyph AND undershooting its arm length. Reverted.
+
+**2. Testing the wrong property.** That overlay compared our glyph against the
+*native* glyph, which answers "do these two match" — not the actual question,
+"does the tick sit well inside its own box". Native's tick is itself off-centre,
+so matching it inherited the defect. Judging the widget in isolation, which is
+what the user's screenshot did, makes it obvious immediately.
+
+The shipped value is deliberately NOT the arithmetic centre. A tick's visual
+mass is in its long upper-right arm while the eye tracks the lower-left vertex,
+so the bounding-box centre reads as low. The SFC comment states this and warns
+against "fixing" it back to the computed value — without that, the next reader
+recomputes the centre and reintroduces the bug.
+
+`RelationCards.vue` still carries the original position. Not changed here for
+the same reason as [[RR-CBLEV8]]: it is a working component on a surface this
+ticket's acceptance criteria never exercise. The shared-class follow-up should
+adopt the corrected position.

--- a/tickets/entities/tickets/TKT-CBSTYLE.md
+++ b/tickets/entities/tickets/TKT-CBSTYLE.md
@@ -89,13 +89,13 @@ actually renders and does not follow the theme ([[RR-CBS2QW]]).
 
 ## Follow-ups
 
-- **Extract a shared `.rela-checkbox`** ([[RR-CBLEV8]], deferred). The visual
-  now exists in two files — this widget and `RelationCards.vue` — which have
-  already diverged, and `RelationCards:998` still carries the hardcoded indigo
-  ring this ticket fixed here. `frontend/CLAUDE.md` documents the same
-  trajectory for `properties-list.css`. The widget is the better copy, so the
-  follow-up is to lift its version into `src/styles/` and adopt it in
-  RelationCards — not to merge equals.
+- ~~**Extract a shared `.rela-checkbox`**~~ — **done in this ticket**
+  ([[RR-CBSHARE]], superseding [[RR-CBLEV8]]). Rather than extracting a
+  stylesheet, both of `RelationCards.vue`'s boolean inputs now render
+  `CheckboxWidget` and its ~35 lines of duplicate CSS are deleted. Sharing the
+  component shares behaviour and accessibility too, not just paint. One of the
+  two call sites turned out to be a bare unstyled `<input type="checkbox">`
+  that had never received any styling at all.
 - **`forced-colors` is unaddressed everywhere else in the SPA.** This ticket
   fixed one control; `forced-colors` still appears nowhere else in `src/`.
   Worth a dedicated accessibility pass rather than fixing it one widget at a

--- a/tickets/entities/tickets/TKT-CBSTYLE.md
+++ b/tickets/entities/tickets/TKT-CBSTYLE.md
@@ -5,7 +5,7 @@ title: CheckboxWidget is unstyled — the only widget with no design tokens
 kind: enhancement
 priority: low
 effort: xs
-status: backlog
+status: done
 ---
 
 ## Goal
@@ -59,3 +59,44 @@ uncommon on those surfaces.
 - Not a new widget, and no change to which widget the registry selects.
 - The `display: table` cell rendering of booleans, which deliberately routes to
   text so values stay Cmd-F searchable (`frontend/CLAUDE.md`).
+
+## Outcome
+
+Both arms are now drawn from tokens: an 18px box with `--radius-sm`, an
+accent fill and a CSS checkmark, ported from the `.inline-edit-checkbox`
+prior art in `RelationCards.vue`. The display arm stays a real disabled
+checkbox, as required.
+
+Three things the change had to solve that the original scope did not
+anticipate, all of which came out of code review:
+
+1. **`appearance: none` discards the browser's disabled greying**, which the
+   display arm had been relying on. The muted state is now drawn explicitly —
+   and at 0.6, not the old 0.85, which had been tuned as a supplement to the
+   native rendering rather than as the whole signal ([[RR-CBM5OP]]).
+2. **The first draft's read-only rule lost the cascade** and rendered
+   `not-allowed` on every read-only boolean — the opposite of its own comment,
+   and a regression. Fixed with `:not(.display-checkbox)` and pinned by a
+   computed-style test that reproduces the bug when the guard is removed
+   ([[RR-CBC1XZ]]).
+3. **`appearance: none` + `outline: none` erases the control in Windows High
+   Contrast**, where box-shadow is dropped and `::after` is not guaranteed. A
+   `forced-colors` block hands the control back to the OS ([[RR-CBS3AC]]).
+
+The focus ring is derived from `--accent-color` via `color-mix` rather than
+copying the sibling widgets' hardcoded indigo, which is a literal that
+actually renders and does not follow the theme ([[RR-CBS2QW]]).
+
+## Follow-ups
+
+- **Extract a shared `.rela-checkbox`** ([[RR-CBLEV8]], deferred). The visual
+  now exists in two files — this widget and `RelationCards.vue` — which have
+  already diverged, and `RelationCards:998` still carries the hardcoded indigo
+  ring this ticket fixed here. `frontend/CLAUDE.md` documents the same
+  trajectory for `properties-list.css`. The widget is the better copy, so the
+  follow-up is to lift its version into `src/styles/` and adopt it in
+  RelationCards — not to merge equals.
+- **`forced-colors` is unaddressed everywhere else in the SPA.** This ticket
+  fixed one control; `forced-colors` still appears nowhere else in `src/`.
+  Worth a dedicated accessibility pass rather than fixing it one widget at a
+  time as tickets happen to touch them.

--- a/tickets/relations/TKT-CBSTYLE--has-docs--DOCS-CB3N8V.md
+++ b/tickets/relations/TKT-CBSTYLE--has-docs--DOCS-CB3N8V.md
@@ -1,0 +1,5 @@
+---
+from: TKT-CBSTYLE
+relation: has-docs
+to: DOCS-CB3N8V
+---

--- a/tickets/relations/TKT-CBSTYLE--has-implementation--IMPL-CB9F4X.md
+++ b/tickets/relations/TKT-CBSTYLE--has-implementation--IMPL-CB9F4X.md
@@ -1,0 +1,5 @@
+---
+from: TKT-CBSTYLE
+relation: has-implementation
+to: IMPL-CB9F4X
+---

--- a/tickets/relations/TKT-CBSTYLE--has-planning--PLAN-CB7K2M.md
+++ b/tickets/relations/TKT-CBSTYLE--has-planning--PLAN-CB7K2M.md
@@ -1,0 +1,5 @@
+---
+from: TKT-CBSTYLE
+relation: has-planning
+to: PLAN-CB7K2M
+---

--- a/tickets/relations/TKT-CBSTYLE--has-review--REV-CB5T2K.md
+++ b/tickets/relations/TKT-CBSTYLE--has-review--REV-CB5T2K.md
@@ -1,0 +1,5 @@
+---
+from: TKT-CBSTYLE
+relation: has-review
+to: REV-CB5T2K
+---

--- a/tickets/relations/TKT-CBSTYLE--has-review-response--RR-CBC1XZ.md
+++ b/tickets/relations/TKT-CBSTYLE--has-review-response--RR-CBC1XZ.md
@@ -1,0 +1,5 @@
+---
+from: TKT-CBSTYLE
+relation: has-review-response
+to: RR-CBC1XZ
+---

--- a/tickets/relations/TKT-CBSTYLE--has-review-response--RR-CBLEV8.md
+++ b/tickets/relations/TKT-CBSTYLE--has-review-response--RR-CBLEV8.md
@@ -1,0 +1,5 @@
+---
+from: TKT-CBSTYLE
+relation: has-review-response
+to: RR-CBLEV8
+---

--- a/tickets/relations/TKT-CBSTYLE--has-review-response--RR-CBM1TS.md
+++ b/tickets/relations/TKT-CBSTYLE--has-review-response--RR-CBM1TS.md
@@ -1,0 +1,5 @@
+---
+from: TKT-CBSTYLE
+relation: has-review-response
+to: RR-CBM1TS
+---

--- a/tickets/relations/TKT-CBSTYLE--has-review-response--RR-CBM2SL.md
+++ b/tickets/relations/TKT-CBSTYLE--has-review-response--RR-CBM2SL.md
@@ -1,0 +1,5 @@
+---
+from: TKT-CBSTYLE
+relation: has-review-response
+to: RR-CBM2SL
+---

--- a/tickets/relations/TKT-CBSTYLE--has-review-response--RR-CBM3TR.md
+++ b/tickets/relations/TKT-CBSTYLE--has-review-response--RR-CBM3TR.md
@@ -1,0 +1,5 @@
+---
+from: TKT-CBSTYLE
+relation: has-review-response
+to: RR-CBM3TR
+---

--- a/tickets/relations/TKT-CBSTYLE--has-review-response--RR-CBM4WP.md
+++ b/tickets/relations/TKT-CBSTYLE--has-review-response--RR-CBM4WP.md
@@ -1,0 +1,5 @@
+---
+from: TKT-CBSTYLE
+relation: has-review-response
+to: RR-CBM4WP
+---

--- a/tickets/relations/TKT-CBSTYLE--has-review-response--RR-CBM5OP.md
+++ b/tickets/relations/TKT-CBSTYLE--has-review-response--RR-CBM5OP.md
@@ -1,0 +1,5 @@
+---
+from: TKT-CBSTYLE
+relation: has-review-response
+to: RR-CBM5OP
+---

--- a/tickets/relations/TKT-CBSTYLE--has-review-response--RR-CBS2QW.md
+++ b/tickets/relations/TKT-CBSTYLE--has-review-response--RR-CBS2QW.md
@@ -1,0 +1,5 @@
+---
+from: TKT-CBSTYLE
+relation: has-review-response
+to: RR-CBS2QW
+---

--- a/tickets/relations/TKT-CBSTYLE--has-review-response--RR-CBS3AC.md
+++ b/tickets/relations/TKT-CBSTYLE--has-review-response--RR-CBS3AC.md
@@ -1,0 +1,5 @@
+---
+from: TKT-CBSTYLE
+relation: has-review-response
+to: RR-CBS3AC
+---

--- a/tickets/relations/TKT-CBSTYLE--has-review-response--RR-CBSHARE.md
+++ b/tickets/relations/TKT-CBSTYLE--has-review-response--RR-CBSHARE.md
@@ -1,0 +1,5 @@
+---
+from: TKT-CBSTYLE
+relation: has-review-response
+to: RR-CBSHARE
+---

--- a/tickets/relations/TKT-CBSTYLE--has-review-response--RR-CBTICK9.md
+++ b/tickets/relations/TKT-CBSTYLE--has-review-response--RR-CBTICK9.md
@@ -1,0 +1,5 @@
+---
+from: TKT-CBSTYLE
+relation: has-review-response
+to: RR-CBTICK9
+---


### PR DESCRIPTION
The edit-mode checkbox was a bare native control sitting in a 12-column grid
of widgets that all carry padding, a token radius and a focus ring, so a
boolean field read as a foreign control. It is now drawn like the
`.inline-edit-checkbox` that `RelationCards.vue` already uses for inline
boolean edit, expressed through `scales.css` tokens.

Follow-up to TKT-3R7RF3 (#1377), which made it easy to place a checkbox on a
detail page next to the styled controls, where the mismatch became obvious.

## Not just a repaint

`appearance: none` is what makes the box drawable, and it also discards the
greyed rendering the browser gave the disabled **display** arm for free — an
affordance RR-UD2I deliberately relied on. Three consequences had to be
handled:

- **Read-only state is drawn explicitly**, at `opacity: 0.6` rather than the
  old `0.85`. That value was tuned as a *supplement* to the native greying;
  as the sole signal it was near-imperceptible. The sibling widgets'
  `background: var(--hover-bg)` can't be borrowed here — on a checkbox the
  background **is** the checked signal, so it would erase state to convey
  read-only.
- **`forced-colors` (Windows High Contrast)** drops `box-shadow` entirely and
  does not guarantee `::after`, so a custom-painted checkbox can lose both its
  focus ring and its checked/unchecked distinction. The control is handed back
  to the OS there, with a real `outline` ring restored.
- **The focus ring derives from `--accent-color`** via `color-mix` instead of
  copying the siblings' `rgba(99, 102, 241, …)`. That literal is not this
  app's accent (`#4772fb` / `#6f93ff`); unlike the `var(--accent-color, #6366f1)`
  fallbacks around it, it actually renders — off-hue, ignoring the theme, and
  unreachable by an operator's `custom.css`.

## A cascade bug the first draft shipped

`.display-checkbox:disabled` (0,3,0) lost to `input[type='checkbox']:disabled`
(0,3,1) — Vue's scoped `[data-v-x]` lifts both equally — so every read-only
boolean rendered `not-allowed`, the opposite of the comment above the rule and
a regression against the pre-change code. Fixed with `:not(.display-checkbox)`,
which cannot be re-lost by a later edit.

Both original tests were green while that was live: asserting a class is
*present* cannot see whether the rule it hangs off *applies*. Added a
computed-style test that resolves the cascade with the real scope suffix;
removing the guard makes it fail with `expected 'not-allowed' to be 'default'`.

## Verification

Live, against a freshly built SPA **and** binary (`just ci` does not rebuild
`bin/rela-server`, so a stale one silently verifies nothing):

| arm | cursor | opacity |
|---|---|---|
| display (read-only value) | `default` | 0.6 |
| edit, ACL-denied | `not-allowed` | 0.6 |
| edit, live | `pointer` | 1 |

Checked fill and focus ring both resolve to the live accent in each theme.
Toggling persisted through the autosave PATCH. The 4 markdown task-list
checkboxes rendered in the same DOM kept `appearance: auto`, confirming the
scoped rule did not leak — that surface is deliberately out of scope.

Frontend 1828 tests pass; typecheck and ESLint clean.

## Follow-ups (filed, not done here)

- `RR-CBLEV8` — the visual now exists in two files and has already diverged;
  extract a shared `.rela-checkbox` and adopt it in `RelationCards`, which
  still carries the hardcoded indigo ring fixed here.
- `forced-colors` appears nowhere else in `src/` — worth a dedicated
  accessibility pass rather than one widget at a time.