### PR TITLE
🌍 feat(worldreader): world-resolved read surface, scope dispatch, ACL parity (TKT-WAV8XP PR-D)

### DIFF
--- a/.go-arch-lint.yml
+++ b/.go-arch-lint.yml
@@ -88,6 +88,7 @@ components:
   # values. The one place that knows both vocabularies, so that stores and
   # visibility (neither of which may import metamodel) can hold the result.
   worlds:           { in: internal/worlds }
+  worldreader:      { in: internal/worldreader }
   migration:        { in: internal/migration }
   markdown:         { in: internal/markdown }
   canonical:        { in: internal/canonical }
@@ -483,6 +484,11 @@ deps:
       # The composition root compiles the metamodel's `worlds:` at startup so
       # an invalid pointer name fails the boot (TKT-WAV8XP).
       - worlds
+      # ...and binds a compiled world to a read surface. The metamodel
+      # adapters (alias canonicalization, relation-scope classification)
+      # live HERE rather than in worldreader, which arch-lint pins to
+      # entity + store so guard rule 1 stays structural (TKT-WAV8XP PR-D).
+      - worldreader
   # backendtest supplies each build's test backend. The pgx dependency is
   # confined to its postgres-tagged file, which the default build does not
   # compile — the same arrangement pgstore uses.
@@ -757,6 +763,24 @@ deps:
     mayDependOn:
       - entity
       - metamodel
+      - store
+  # worldreader is the RUNTIME half of worlds: it holds a store and reads.
+  #
+  # It deliberately may NOT depend on acl, visibility, principal or
+  # affordances. That is GUARD RULE 1 (TKT-WAV8XP): world resolution is
+  # principal-independent, and it must complete BEFORE the ACL gate is
+  # consulted — if the gate ran first, a prime the principal may not read
+  # would fall through to the chain's next candidate, and the face a
+  # reader receives would reveal what the ACL denied them. Enforced here
+  # AND by a package-scan test (worldreader/guard_test.go), because
+  # arch-lint alone would not catch a principal read off ctx.
+  #
+  # It also may not depend on metamodel: the compiled WorldScope is
+  # metamodel-free by construction, and a TypeCanonicalizer interface is
+  # supplied at the wiring site.
+  worldreader:
+    mayDependOn:
+      - entity
       - store
   migration:
     mayDependOn:

--- a/docs-project/entities/guides/GUIDE-metamodel.md
+++ b/docs-project/entities/guides/GUIDE-metamodel.md
@@ -1020,6 +1020,28 @@ Lowercase alphanumeric runs joined by single hyphens: `draft`,
 no doubled hyphens, and `+` is reserved. Invalid names are reported at
 startup.
 
+### What worlds do NOT do yet
+
+Two limits are deliberate, and you will meet both if you try to use a
+world today.
+
+**There is no way to ask for a world per request.** No `?world=` query
+parameter, no `--world` flag. A surface is *built* over its world and
+cannot be asked to serve a different one. Request-level selection needs
+its own permission check — letting any caller name a world would make
+"which faces may I see?" a client decision — so it ships together with
+that check rather than before it.
+
+**A world-bound surface cannot have search.** Search results are not
+world-scoped yet: the index holds default-state documents, so a search
+box on a `published` surface would return drafts. Rather than serve
+wrong results quietly, constructing a world-bound surface *with* a
+searcher fails outright. Access control cannot paper over this — the
+permission gate is deliberately world-independent, so nothing downstream
+would catch a draft that leaked in through search.
+
+Both lift when per-world indexing and request-level selection land.
+
 ### Checking stored states
 
 `rela analyze states` reports state rows the schema does not account for —

--- a/docs/metamodel.md
+++ b/docs/metamodel.md
@@ -1014,6 +1014,28 @@ Lowercase alphanumeric runs joined by single hyphens: `draft`,
 no doubled hyphens, and `+` is reserved. Invalid names are reported at
 startup.
 
+### What worlds do NOT do yet
+
+Two limits are deliberate, and you will meet both if you try to use a
+world today.
+
+**There is no way to ask for a world per request.** No `?world=` query
+parameter, no `--world` flag. A surface is *built* over its world and
+cannot be asked to serve a different one. Request-level selection needs
+its own permission check — letting any caller name a world would make
+"which faces may I see?" a client decision — so it ships together with
+that check rather than before it.
+
+**A world-bound surface cannot have search.** Search results are not
+world-scoped yet: the index holds default-state documents, so a search
+box on a `published` surface would return drafts. Rather than serve
+wrong results quietly, constructing a world-bound surface *with* a
+searcher fails outright. Access control cannot paper over this — the
+permission gate is deliberately world-independent, so nothing downstream
+would catch a draft that leaked in through search.
+
+Both lift when per-world indexing and request-level selection land.
+
 ### Checking stored states
 
 `rela analyze states` reports state rows the schema does not account for —

--- a/internal/acl/readquery.go
+++ b/internal/acl/readquery.go
@@ -73,20 +73,23 @@ func (r *Request) readQuery(ctx context.Context, entityType string) ReadQueryRes
 		return ReadQueryResult{DenyAll: true}
 	}
 
-	// World is deliberately left ZERO here, which means the DEFAULT world
-	// (store.WorldScope's zero value). This is NOT an assertion that the
-	// ACL path is world-safe: a world-scoped read must have its scope
-	// INJECTED from above by the world-resolved reader (internal/worldreader,
-	// TKT-WAV8XP PR-D), which is the layer that owns a compiled WorldScope.
+	// World is deliberately left ZERO here, and that is CORRECT rather
+	// than a gap: the world is stamped onto this query by the caller,
+	// at internal/visibility's listPushdown seam, which copies it from
+	// the EntityQuery it was given (TKT-WAV8XP PR-D).
 	//
-	// internal/acl structurally cannot resolve one itself — arch-lint
+	// internal/acl structurally cannot resolve a world itself — arch-lint
 	// forbids it from importing internal/metamodel, and a WorldScope is
-	// compiled from the metamodel. So the seam belongs above this package,
-	// not in it. Until PR-D wires that injection, store.GraphQuery.World is
-	// honored by the backends (PR-B) but never set on this path.
+	// compiled from the metamodel. So the scope belongs to the layer
+	// above, which is why this composer emits a world-free query and the
+	// wiring seam stamps it.
 	//
-	// Do NOT "fix" this by giving internal/acl a metamodel dependency: that
-	// breaks the boundary that keeps ACL evaluable without a schema.
+	// Do NOT "fix" this by giving internal/acl a metamodel dependency:
+	// that breaks the boundary keeping ACL evaluable without a schema.
+	// And do NOT drop the copy at listPushdown — pushdown reaches past
+	// every decorator to the raw store, so without it a world-scoped
+	// list silently degrades to the default world for exactly the
+	// ACL-gated principals (RR-GQWRLD).
 	q := &store.GraphQuery{
 		EntityType: entityType,
 		HasInbound: &store.RelationPredicate{

--- a/internal/appbuild/appbuild.go
+++ b/internal/appbuild/appbuild.go
@@ -90,6 +90,11 @@ type Services struct {
 	paths *project.Context
 	meta  *metamodel.Metamodel
 	store store.Store
+	// worlds is the compiled world set, carried so a caller can build a
+	// world-bound read surface (WorldSurface). Tenant-independent and
+	// metamodel-derived, like meta — it is copied from the SharedBase
+	// rather than recompiled per assembly.
+	worlds worlds.Compiled
 	// versions is the content-versioning service (history reads, version writes,
 	// purge), a separate concern injected by the backend recipe — nil on builds
 	// without versioning (fs/mem; fsstore uses git). Consumers bind the narrow
@@ -657,10 +662,19 @@ func NewFromCollaborators(c Collaborators) (*Services, error) {
 		}
 		visible = v
 	}
+	// Compile worlds from the supplied metamodel so this construction path
+	// offers the same world surface as the base-assembly path. A failure
+	// here is a metamodel error and must surface, not silently yield a
+	// Services whose WorldSurface always 404s.
+	compiledWorlds, err := worlds.Compile(c.Meta)
+	if err != nil {
+		return nil, fmt.Errorf("appbuild.NewFromCollaborators: compile worlds: %w", err)
+	}
 	return &Services{
 		fs:              c.FS,
 		paths:           c.Paths,
 		meta:            c.Meta,
+		worlds:          compiledWorlds,
 		store:           c.Store,
 		searcher:        c.Searcher,
 		visibleSearcher: visible,
@@ -1091,10 +1105,12 @@ type SharedBase struct {
 // Worlds returns the compiled world scopes this base was built from.
 //
 // Compiled once here because compilation is metamodel-derived and therefore
-// tenant-independent — the same reason `meta` lives on the base. Nothing
-// consumes it yet; the store contract lands in PR-B and the read decorator in
-// PR-D (TKT-WAV8XP). It is compiled from PR-A regardless so that an invalid
-// pointer name fails the boot instead of waiting for a consumer.
+// tenant-independent — the same reason `meta` lives on the base. It is
+// compiled at boot so an invalid pointer name fails startup rather than the
+// first request that needs a world.
+//
+// Consumed by [Services.WorldSurface], which resolves a world by name and
+// binds it to a read surface (TKT-WAV8XP PR-D).
 func (b *SharedBase) Worlds() worlds.Compiled { return b.worlds }
 
 // Meta returns the loaded metamodel this base was built from. Exposed so a host
@@ -1332,6 +1348,7 @@ func assemble(
 		fs:              cfg.FS,
 		paths:           cfg.Paths,
 		meta:            base.meta,
+		worlds:          base.worlds,
 		store:           st,
 		versions:        versions,
 		searcher:        searcher,

--- a/internal/appbuild/worldsurface.go
+++ b/internal/appbuild/worldsurface.go
@@ -1,0 +1,100 @@
+package appbuild
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/Sourcehaven-BV/rela/internal/metamodel"
+	"github.com/Sourcehaven-BV/rela/internal/store"
+	"github.com/Sourcehaven-BV/rela/internal/worldreader"
+)
+
+// metamodelCanon adapts the metamodel to worldreader.TypeCanonicalizer.
+//
+// It lives HERE rather than in worldreader because that package must not
+// import metamodel (arch-lint pins it to entity + store). A compiled
+// WorldScope is metamodel-free by construction, and the alias table is
+// the one metamodel fact the resolver needs — so it arrives as a narrow
+// interface satisfied at the wiring site.
+type metamodelCanon struct{ meta *metamodel.Metamodel }
+
+func (c metamodelCanon) CanonicalType(name string) (string, bool) {
+	if c.meta == nil {
+		return name, false
+	}
+	return c.meta.ResolveAlias(name), true
+}
+
+// metamodelScopes adapts the metamodel to worldreader.ScopeClassifier.
+//
+// Identity is the DEFAULT: a relation type that declares no scope, or one
+// the metamodel does not know, is identity-scoped. That is the direction
+// that keeps a pointerless project unchanged, and it is also the safe
+// direction here — an identity edge is visible from every face, so
+// misclassifying a content edge as identity shows an edge that a stricter
+// reading would hide, rather than hiding one a reader needs.
+type metamodelScopes struct{ meta *metamodel.Metamodel }
+
+func (c metamodelScopes) IsContentScoped(relType string) bool {
+	if c.meta == nil {
+		return false
+	}
+	def, ok := c.meta.GetRelationDef(relType)
+	if !ok {
+		return false
+	}
+	return def.Scope.IsContent()
+}
+
+// WorldSurface builds a read surface bound to the named world.
+//
+// A package-level FUNCTION rather than a method on [Services], deliberately.
+// Services sits at its god-object load line (25 exported methods, pinned by a
+// plimsoll directive), and the project rule is to split the type rather than
+// raise the number. Nothing here needs to be a method: it reads three fields
+// off svc and composes worldreader types, so a function keeps the composition
+// root's public surface flat while the wiring stays in one place.
+//
+// The world is resolved by NAME from the compiled set and then FIXED: the
+// returned surface has no world parameter and no setter (Q10). A caller
+// that wants a different world builds a different surface. Request-level
+// world selection is deliberately not available here — it needs its own
+// grant check, and shipping a plumbed-but-ungated world parameter is the
+// half-built thing this arc declined to build.
+//
+// Passing the empty name yields the DEFAULT world: every entity via its
+// default state, byte-identical to the pre-worlds system.
+//
+// searcher may be nil. When it is not, and the world is non-default, it
+// must be able to honor that world — NewSurface refuses otherwise
+// (RULING 3). No searcher can today, so a world-bound surface is
+// currently search-free by construction rather than by remembering.
+func WorldSurface(
+	svc *Services, name string, searcher worldreader.WorldAwareSearcher,
+) (*worldreader.Surface, error) {
+	if svc == nil {
+		return nil, errors.New("appbuild: WorldSurface: services must be non-nil")
+	}
+	scope := store.DefaultWorld()
+	if name != "" {
+		found, ok := svc.worlds.Lookup(name)
+		if !ok {
+			return nil, fmt.Errorf("appbuild: no such world %q", name)
+		}
+		scope = found
+	}
+
+	resolver, err := worldreader.NewResolver(svc.store, scope, metamodelCanon{meta: svc.meta})
+	if err != nil {
+		return nil, fmt.Errorf("appbuild: world surface: %w", err)
+	}
+	relations, err := worldreader.NewRelationReader(svc.store, metamodelScopes{meta: svc.meta})
+	if err != nil {
+		return nil, fmt.Errorf("appbuild: world surface: %w", err)
+	}
+	surface, err := worldreader.NewSurface(resolver, relations, searcher)
+	if err != nil {
+		return nil, fmt.Errorf("appbuild: world surface %q: %w", name, err)
+	}
+	return surface, nil
+}

--- a/internal/appbuild/worldsurface_test.go
+++ b/internal/appbuild/worldsurface_test.go
@@ -1,0 +1,203 @@
+package appbuild_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/Sourcehaven-BV/rela/internal/appbuild"
+	"github.com/Sourcehaven-BV/rela/internal/appbuild/appbuildtest"
+	"github.com/Sourcehaven-BV/rela/internal/entity"
+	"github.com/Sourcehaven-BV/rela/internal/metamodel"
+	"github.com/Sourcehaven-BV/rela/internal/worldreader"
+)
+
+// worldSchema declares one type with two content states and two worlds:
+// `editorial` prefers the review face and falls back to the default;
+// `public` serves only the published face and excludes everything else.
+const worldSchema = `
+entities:
+  page:
+    label: Page
+    plural: pages
+    id_prefix: "PAGE-"
+    id_type: sequential
+    properties:
+      title:
+        type: string
+        required: true
+    pointers:
+      review: {}
+      published: {}
+relations: {}
+worlds:
+  editorial:
+    select: [review]
+    otherwise: default
+  public:
+    select: [published]
+    otherwise: exclude
+`
+
+func newWorldServices(t *testing.T) *appbuild.Services {
+	t.Helper()
+	meta, err := metamodel.Parse([]byte(worldSchema))
+	require.NoError(t, err, "the world schema must parse — worlds are declared in the metamodel")
+	return appbuildtest.New(meta)
+}
+
+// TestWorldSurface_ResolvesThroughTheWiredStack is the end-to-end wiring
+// check: a world named in schema.yaml is compiled at boot, looked up by
+// name, and bound to a surface that resolves against the real store.
+//
+// It exercises the adapters that cannot live in worldreader itself —
+// alias canonicalization and relation-scope classification both need the
+// metamodel, which arch-lint forbids that package from importing.
+func TestWorldSurface_ResolvesThroughTheWiredStack(t *testing.T) {
+	svc := newWorldServices(t)
+	defer func() { _ = svc.Close() }()
+	ctx := context.Background()
+
+	// PAGE-1 holds all three faces; PAGE-2 only its default.
+	base := entity.New("PAGE-1", "page")
+	base.SetString("title", "draft face")
+	require.NoError(t, svc.Store().CreateEntity(ctx, base))
+
+	review := entity.New("PAGE-1", "page")
+	review.Pointer = entity.Pointer("review")
+	review.SetString("title", "review face")
+	require.NoError(t, svc.Store().CreateEntity(ctx, review))
+
+	published := entity.New("PAGE-1", "page")
+	published.Pointer = entity.Pointer("published")
+	published.SetString("title", "published face")
+	require.NoError(t, svc.Store().CreateEntity(ctx, published))
+
+	lonely := entity.New("PAGE-2", "page")
+	lonely.SetString("title", "only a draft")
+	require.NoError(t, svc.Store().CreateEntity(ctx, lonely))
+
+	for _, tc := range []struct {
+		name      string
+		world     string
+		id        string
+		wantTitle string
+		wantVia   worldreader.Rule
+		wantGone  bool
+	}{
+		{
+			name:      "editorial prefers the review face",
+			world:     "editorial",
+			id:        "PAGE-1",
+			wantTitle: "review face",
+			wantVia:   worldreader.RuleChain,
+		},
+		{
+			name:      "editorial falls back to the default face",
+			world:     "editorial",
+			id:        "PAGE-2",
+			wantTitle: "only a draft",
+			wantVia:   worldreader.RuleFallbackDefault,
+		},
+		{
+			name:      "public serves the published face",
+			world:     "public",
+			id:        "PAGE-1",
+			wantTitle: "published face",
+			wantVia:   worldreader.RuleChain,
+		},
+		{
+			name:     "public EXCLUDES an entity with no published face",
+			world:    "public",
+			id:       "PAGE-2",
+			wantGone: true,
+			wantVia:  worldreader.RuleExcluded,
+		},
+		{
+			name:      "the empty name is the default world",
+			world:     "",
+			id:        "PAGE-1",
+			wantTitle: "draft face",
+			wantVia:   worldreader.RuleUnscoped,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			surface, err := appbuild.WorldSurface(svc, tc.world, nil)
+			require.NoError(t, err)
+
+			got, err := surface.Resolver().Resolve(ctx, "page", tc.id)
+			require.NoError(t, err)
+
+			assert.Equal(t, tc.wantVia, got.Via, "provenance")
+			if tc.wantGone {
+				assert.False(t, got.Found, "the world must exclude this entity entirely")
+				return
+			}
+			require.True(t, got.Found)
+			assert.Equal(t, tc.wantTitle, got.Entity.GetString("title"))
+		})
+	}
+}
+
+// TestWorldSurface_UnknownWorldIsAnError: a surface must not silently
+// degrade to the default world when the name is wrong. That is the
+// fail-open direction — a typo in a deployment config would serve drafts
+// from a surface meant to be public.
+func TestWorldSurface_UnknownWorldIsAnError(t *testing.T) {
+	svc := newWorldServices(t)
+	defer func() { _ = svc.Close() }()
+
+	_, err := appbuild.WorldSurface(svc, "no-such-world", nil)
+	require.Error(t, err, "an unknown world must be refused, never defaulted")
+	assert.Contains(t, err.Error(), "no-such-world")
+}
+
+// TestWorldSurface_AliasResolvesToItsCanonicalType pins the adapter that
+// makes alias canonicalization work end to end. WorldScope is keyed on
+// CANONICAL names, so an alias reaching it unresolved is an unknown type
+// → rule 1 → the default face served in a world that meant to exclude
+// it. Fail-open, which is why the wiring supplies a real canonicalizer.
+func TestWorldSurface_AliasResolvesToItsCanonicalType(t *testing.T) {
+	meta, err := metamodel.Parse([]byte(`
+entities:
+  page:
+    label: Page
+    plural: pages
+    aliases: [pg]
+    id_prefix: "PAGE-"
+    id_type: sequential
+    properties:
+      title:
+        type: string
+        required: true
+    pointers:
+      published: {}
+relations: {}
+worlds:
+  public:
+    select: [published]
+    otherwise: exclude
+`))
+	require.NoError(t, err)
+	svc := appbuildtest.New(meta)
+	defer func() { _ = svc.Close() }()
+	ctx := context.Background()
+
+	only := entity.New("PAGE-1", "page")
+	only.SetString("title", "unpublished")
+	require.NoError(t, svc.Store().CreateEntity(ctx, only))
+
+	surface, err := appbuild.WorldSurface(svc, "public", nil)
+	require.NoError(t, err)
+
+	// Query by the ALIAS. The world excludes unpublished pages, so the
+	// answer must be "not found" — not the default face.
+	got, err := surface.Resolver().Resolve(ctx, "pg", "PAGE-1")
+	require.NoError(t, err)
+	assert.False(t, got.Found,
+		"an aliased type must canonicalize before the scope is consulted: "+
+			"otherwise it is an unknown type, which is rule 1, which serves "+
+			"the default face in a world that meant to exclude it")
+}

--- a/internal/visibility/pushdown.go
+++ b/internal/visibility/pushdown.go
@@ -92,7 +92,29 @@ func listPushdown(
 		// acl.PermitsReadMany, which errors here.
 		return nil, false
 	}
-	return redactingSeq(ctx, gq.GraphQuery(ctx, *rqr.Query), redact), true
+	// Carry the WORLD from the EntityQuery onto the composed GraphQuery
+	// (TKT-WAV8XP PR-D). This is the seam the whole two-mechanism design
+	// turns on: pushdown reaches PAST every decorator to the raw store,
+	// so a world that rides only on the decorator silently degrades to
+	// the default world exactly here — and exactly for ACL-gated
+	// principals, since AllowAll takes the EntityQuery branch above.
+	//
+	// That is not hypothetical: it is the fail-open PR-B's review found
+	// (RR-GQWRLD), where `otherwise: exclude` stopped excluding and a
+	// published world served drafts. `internal/acl` cannot set this
+	// itself — arch-lint forbids it importing metamodel, so it cannot
+	// compile a WorldScope — which is why the copy happens at this
+	// wiring seam instead. Pinned by the decorator/pushdown parity test.
+	// COPY the composed query before stamping the world. The ACL layer
+	// may cache or reuse the ReadQueryResult per principal, so mutating
+	// *rqr.Query in place would leak one request's world into the next
+	// caller's — a cross-request scope bleed. The copy is shallow, which
+	// is exactly right here: World is a value field, so assigning it
+	// touches only this copy, while the predicate pointers it shares
+	// (HasInbound/HasOutbound/Props) are read-only downstream.
+	worldQuery := *rqr.Query
+	worldQuery.World = q.World
+	return redactingSeq(ctx, gq.GraphQuery(ctx, worldQuery), redact), true
 }
 
 // redactingSeq applies the field redactor to every row of src.

--- a/internal/visibility/worldparity_test.go
+++ b/internal/visibility/worldparity_test.go
@@ -1,0 +1,219 @@
+package visibility
+
+import (
+	"context"
+	"iter"
+	"testing"
+
+	"github.com/Sourcehaven-BV/rela/internal/acl"
+	"github.com/Sourcehaven-BV/rela/internal/entity"
+	"github.com/Sourcehaven-BV/rela/internal/store"
+)
+
+// DECORATOR/PUSHDOWN PARITY for worlds (TKT-WAV8XP PR-D).
+//
+// A world reaches the store two ways, and both are required:
+//
+//   - as a DECORATOR, on the read paths that go through a reader; and
+//   - as a FIELD ON THE QUERY, because listPushdown composes a GraphQuery
+//     and hands it to the RAW store, reaching past every decorator.
+//
+// The two must agree. They did not in PR-B: `GraphQuery.World` existed and
+// was never populated on this path, so a world-scoped list silently
+// degraded to the default world — and did so for exactly the ACL-GATED
+// principals, because the AllowAll branch takes the EntityQuery path and
+// only a principal WITH a policy query reaches the GraphQuery branch
+// (RR-GQWRLD).
+//
+// That is why these tests exercise the COMPOSED-QUERY branch specifically.
+// A parity test covering only AllowAll would have passed throughout the
+// window the bug was live.
+
+// worldCapturingSpy records the queries it is handed so a test can assert
+// the world ARRIVED. Asserting on returned rows cannot do that: the spy
+// returns whatever rows it was seeded with regardless of scope, and in a
+// real store a wrongly-defaulted world still returns plausible rows —
+// which is precisely why the original bug was invisible.
+type worldCapturingSpy struct {
+	store.Store
+	graphQueries  []store.GraphQuery
+	entityQueries []store.EntityQuery
+	rows          []*entity.Entity
+}
+
+func (s *worldCapturingSpy) GraphQuery(
+	_ context.Context, q store.GraphQuery,
+) iter.Seq2[*entity.Entity, error] {
+	s.graphQueries = append(s.graphQueries, q)
+	return s.seq()
+}
+
+func (s *worldCapturingSpy) ListEntities(
+	_ context.Context, q store.EntityQuery,
+) iter.Seq2[*entity.Entity, error] {
+	s.entityQueries = append(s.entityQueries, q)
+	return s.seq()
+}
+
+func (s *worldCapturingSpy) GraphCount(
+	context.Context, store.GraphQuery,
+) (matched, total int, err error) {
+	return 0, 0, nil
+}
+
+func (s *worldCapturingSpy) MatchingIDs(
+	context.Context, store.GraphQuery, []string,
+) (map[string]bool, error) {
+	return map[string]bool{}, nil
+}
+
+func (s *worldCapturingSpy) seq() iter.Seq2[*entity.Entity, error] {
+	return func(yield func(*entity.Entity, error) bool) {
+		for _, e := range s.rows {
+			if !yield(e, nil) {
+				return
+			}
+		}
+	}
+}
+
+func testWorld() store.WorldScope {
+	return store.NewWorldScope(map[string]store.TypeResolution{
+		"ticket": {
+			Chain:    []entity.Pointer{"published"},
+			Fallback: store.FallbackExclude,
+		},
+	})
+}
+
+// TestWorldParity_ComposedQueryBranchCarriesTheWorld is the regression
+// test for RR-GQWRLD. A principal WITH a policy query takes the
+// GraphQuery branch, and the world must travel onto that query.
+func TestWorldParity_ComposedQueryBranchCarriesTheWorld(t *testing.T) {
+	t.Parallel()
+	spy := &worldCapturingSpy{}
+	red := &countingRedactor{}
+	// A composed ACL query: this is what an ACL-GATED principal produces,
+	// and the branch the bug lived on.
+	p := stubProvider{res: acl.ReadQueryResult{Query: &store.GraphQuery{EntityType: "ticket"}}}
+
+	world := testWorld()
+	_, ok := listPushdown(context.Background(), p, spy, red.redact,
+		store.EntityQuery{Type: "ticket", World: world})
+	if !ok {
+		t.Fatal("pushdown declined a composable query")
+	}
+	if len(spy.graphQueries) != 1 {
+		t.Fatalf("GraphQuery calls = %d, want 1", len(spy.graphQueries))
+	}
+
+	got := spy.graphQueries[0]
+	if got.World.IsDefaultWorld() {
+		t.Fatal("the composed GraphQuery reached the store with the DEFAULT world: " +
+			"a world-scoped list silently degraded to unscoped for an ACL-gated " +
+			"principal — drafts leak and `otherwise: exclude` stops excluding (RR-GQWRLD)")
+	}
+	res, scoped := got.World.For("ticket")
+	if !scoped {
+		t.Fatal("the world arrived but lost its ticket resolution")
+	}
+	if len(res.Chain) != 1 || res.Chain[0] != entity.Pointer("published") {
+		t.Errorf("chain = %v, want [published]", res.Chain)
+	}
+	if res.Fallback != store.FallbackExclude {
+		t.Errorf("fallback = %v, want exclude", res.Fallback)
+	}
+}
+
+// TestWorldParity_AllowAllBranchCarriesTheWorld covers the other branch.
+// AllowAll skips the GraphQuery entirely and lists directly, so it is a
+// SEPARATE mechanism that could regress independently — which is the
+// whole reason parity has to be asserted rather than assumed.
+func TestWorldParity_AllowAllBranchCarriesTheWorld(t *testing.T) {
+	t.Parallel()
+	spy := &worldCapturingSpy{}
+	red := &countingRedactor{}
+	p := stubProvider{res: acl.ReadQueryResult{AllowAll: true}}
+
+	world := testWorld()
+	_, ok := listPushdown(context.Background(), p, spy, red.redact,
+		store.EntityQuery{Type: "ticket", World: world})
+	if !ok {
+		t.Fatal("pushdown declined the AllowAll branch")
+	}
+	if len(spy.entityQueries) != 1 {
+		t.Fatalf("ListEntities calls = %d, want 1", len(spy.entityQueries))
+	}
+	if spy.entityQueries[0].World.IsDefaultWorld() {
+		t.Fatal("the AllowAll branch dropped the world")
+	}
+}
+
+// TestWorldParity_BothBranchesAgree is the parity assertion proper: for
+// the SAME requested world, the two branches must hand the store the same
+// scope. A divergence here is the shape of the original bug — one path
+// honoring the world while the other quietly serves the default.
+func TestWorldParity_BothBranchesAgree(t *testing.T) {
+	t.Parallel()
+	world := testWorld()
+
+	composedSpy := &worldCapturingSpy{}
+	red := &countingRedactor{}
+	composed := stubProvider{res: acl.ReadQueryResult{Query: &store.GraphQuery{EntityType: "ticket"}}}
+	if _, ok := listPushdown(context.Background(), composed, composedSpy, red.redact,
+		store.EntityQuery{Type: "ticket", World: world}); !ok {
+		t.Fatal("composed branch declined")
+	}
+
+	allowSpy := &worldCapturingSpy{}
+	allow := stubProvider{res: acl.ReadQueryResult{AllowAll: true}}
+	if _, ok := listPushdown(context.Background(), allow, allowSpy, red.redact,
+		store.EntityQuery{Type: "ticket", World: world}); !ok {
+		t.Fatal("AllowAll branch declined")
+	}
+
+	gotComposed := composedSpy.graphQueries[0].World
+	gotAllow := allowSpy.entityQueries[0].World
+
+	// Compare the OBSERVABLE scope rather than the struct: WorldScope
+	// holds an unexported map, and the contract is what For() answers.
+	for _, typ := range []string{"ticket", "unscoped-type"} {
+		cRes, cOK := gotComposed.For(typ)
+		aRes, aOK := gotAllow.For(typ)
+		if cOK != aOK {
+			t.Fatalf("type %q: composed scoped=%v, AllowAll scoped=%v — the two "+
+				"paths disagree about whether the world covers this type", typ, cOK, aOK)
+		}
+		if !cOK {
+			continue
+		}
+		if len(cRes.Chain) != len(aRes.Chain) || cRes.Fallback != aRes.Fallback {
+			t.Fatalf("type %q: composed=%v/%v, AllowAll=%v/%v — divergent resolution",
+				typ, cRes.Chain, cRes.Fallback, aRes.Chain, aRes.Fallback)
+		}
+		for i := range cRes.Chain {
+			if cRes.Chain[i] != aRes.Chain[i] {
+				t.Fatalf("type %q: chain diverges at %d: %q vs %q",
+					typ, i, cRes.Chain[i], aRes.Chain[i])
+			}
+		}
+	}
+}
+
+// TestWorldParity_DefaultWorldStaysDefault pins the zero-cost path: a
+// query carrying no world must not acquire one. The pointerless project
+// has to keep paying nothing.
+func TestWorldParity_DefaultWorldStaysDefault(t *testing.T) {
+	t.Parallel()
+	spy := &worldCapturingSpy{}
+	red := &countingRedactor{}
+	p := stubProvider{res: acl.ReadQueryResult{Query: &store.GraphQuery{EntityType: "ticket"}}}
+
+	if _, ok := listPushdown(context.Background(), p, spy, red.redact,
+		store.EntityQuery{Type: "ticket"}); !ok {
+		t.Fatal("pushdown declined")
+	}
+	if !spy.graphQueries[0].World.IsDefaultWorld() {
+		t.Error("a world-free query must reach the store world-free")
+	}
+}

--- a/internal/worldreader/guard_test.go
+++ b/internal/worldreader/guard_test.go
@@ -1,0 +1,157 @@
+package worldreader_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/Sourcehaven-BV/rela/internal/entity"
+	"github.com/Sourcehaven-BV/rela/internal/store"
+	"github.com/Sourcehaven-BV/rela/internal/worldreader"
+)
+
+// GUARD RULE 1 — resolution is PRINCIPAL-INDEPENDENT.
+//
+// A world resolves the same prime for every reader. This file pins that
+// twice, because the two failures look nothing alike:
+//
+//   - BEHAVIOURALLY: two principals resolve the same entity to the same
+//     face, and a denied principal gets NOTHING rather than a different
+//     face.
+//   - STRUCTURALLY: the package cannot even express a principal-dependent
+//     resolution, because it imports nothing that carries a principal.
+//
+// The behavioral test alone would not stop someone adding a gate and
+// keeping the test green for the fixtures it happens to use; the
+// structural test alone would not catch resolution reading a principal
+// off ctx. Both are needed.
+//
+// The stake: if the gate ran BEFORE resolution, a prime the principal may
+// not read would fall through to the chain's next candidate, and the face
+// a reader receives would reveal what the ACL denied them — an existence
+// oracle. Resolve-then-gate is the fixed order, and the only way to keep
+// it is that the resolver cannot consult a gate at all.
+
+// forbiddenImports are packages whose presence would mean resolution can
+// see a principal or an ACL decision.
+var forbiddenImports = map[string]string{
+	"internal/acl":         "an ACL type in the resolver means resolution could depend on a decision",
+	"internal/visibility":  "the gate must run AFTER resolution, never inside it",
+	"internal/principal":   "a principal in scope means resolution could vary by reader",
+	"internal/affordances": "affordance policy is principal-scoped",
+	"internal/aclmap":      "ACL mapping is principal-scoped",
+}
+
+// exemptFiles are files NOT scanned. An EXEMPTION list, not an inclusion
+// list, so a newly added file fails closed: it must be clean or be
+// exempted here with a reason.
+var exemptFiles = map[string]string{
+	// This guard names the forbidden packages in order to forbid them.
+	"guard_test.go": "the guard itself — names the packages it forbids",
+}
+
+// TestGuardRule1_PackageCannotSeeAPrincipal is the structural half: scan
+// every non-exempt file for an import that would let resolution vary by
+// reader.
+func TestGuardRule1_PackageCannotSeeAPrincipal(t *testing.T) {
+	entries, err := os.ReadDir(".")
+	require.NoError(t, err)
+
+	scanned := 0
+	for _, e := range entries {
+		name := e.Name()
+		if e.IsDir() || !strings.HasSuffix(name, ".go") {
+			continue
+		}
+		if reason, exempt := exemptFiles[name]; exempt {
+			t.Logf("skipping %s: %s", name, reason)
+			continue
+		}
+		src, readErr := os.ReadFile(filepath.Join(".", name))
+		require.NoError(t, readErr)
+		scanned++
+
+		for pkg, why := range forbiddenImports {
+			// Assert on a bool rather than via NotContains: the latter
+			// dumps the whole file into the failure message, which buries
+			// the one line that matters.
+			if strings.Contains(string(src), "rela/"+pkg+"\"") {
+				t.Errorf("%s imports %s — guard rule 1 forbids it: %s", name, pkg, why)
+			}
+		}
+	}
+	require.Positive(t, scanned, "the guard must actually scan files, or it proves nothing")
+}
+
+// TestGuardRule1_ConstructorTakesNoGate pins the constructor's shape by
+// its signature rather than its body: NewResolver's collaborators are a
+// state reader, a scope and a canonicalizer. Adding a gate parameter
+// would have to change this call, which is the point.
+func TestGuardRule1_ConstructorTakesNoGate(_ *testing.T) {
+	// Assigning the constructor to a variable of its expected signature
+	// makes a new parameter — a gate, a principal — a compile error.
+	var newResolver = worldreader.NewResolver
+	_ = newResolver
+}
+
+// principalKey mimics a caller stashing an identity on ctx. The resolver
+// must ignore it — it has no way to read it, which is the guarantee.
+type principalKey struct{}
+
+// TestGuardRule1_SamePrimeForEveryPrincipal is the behavioral half, in
+// the shape the plan specifies: an entity with default, review and
+// published states; a world selecting [review, published] with
+// `otherwise: default`. Both principals must get 'review'.
+func TestGuardRule1_SamePrimeForEveryPrincipal(t *testing.T) {
+	states := map[entity.Pointer]string{
+		"":          "the default face",
+		"review":    "the review face",
+		"published": "the published face",
+	}
+	reader := stateReaderFunc(func(_ context.Context, id string, p entity.Pointer) (*entity.Entity, error) {
+		title, ok := states[p]
+		if id != "PAGE-1" || !ok {
+			return nil, store.ErrNotFound
+		}
+		e := entity.New(id, "page")
+		e.Pointer = p
+		e.SetString("title", title)
+		return e, nil
+	})
+
+	scope := store.NewWorldScope(map[string]store.TypeResolution{
+		"page": {
+			Chain:    []entity.Pointer{"review", "published"},
+			Fallback: store.FallbackDefaultState,
+		},
+	})
+	r, err := worldreader.NewResolver(reader, scope, identityCanon{})
+	require.NoError(t, err)
+
+	// Two "principals", distinguishable only by what the caller put on
+	// ctx. The resolver has no way to read either.
+	principalA := context.WithValue(context.Background(), principalKey{}, "may-read-everything")
+	principalB := context.WithValue(context.Background(), principalKey{}, "denied-on-PAGE-1")
+
+	resA, err := r.Resolve(principalA, "page", "PAGE-1")
+	require.NoError(t, err)
+	resB, err := r.Resolve(principalB, "page", "PAGE-1")
+	require.NoError(t, err)
+
+	assert.Equal(t, entity.Pointer("review"), resA.Pointer,
+		"chain order is load-bearing: review precedes published")
+	assert.Equal(t, resA.Pointer, resB.Pointer,
+		"guard rule 1: the prime must not depend on the principal")
+	assert.Equal(t, "the review face", resB.Entity.GetString("title"))
+
+	// The gate's job is to withhold the resolved face ENTIRELY. It must
+	// never hand principal B a different face — that is the oracle. The
+	// resolver cannot express that, which is what this whole file pins:
+	// B either gets 'review' (as here, before gating) or nothing at all
+	// once the gate downstream denies it.
+}

--- a/internal/worldreader/relations.go
+++ b/internal/worldreader/relations.go
@@ -1,0 +1,153 @@
+package worldreader
+
+import (
+	"context"
+	"errors"
+	"iter"
+
+	"github.com/Sourcehaven-BV/rela/internal/entity"
+	"github.com/Sourcehaven-BV/rela/internal/store"
+)
+
+// RelationLister is the narrow relation-read surface the dispatcher
+// needs. Declared at the call site.
+type RelationLister interface {
+	ListRelations(ctx context.Context, q store.RelationQuery) iter.Seq2[*entity.Relation, error]
+}
+
+// ScopeClassifier answers whether a relation type is CONTENT-scoped
+// (attached to one state) or IDENTITY-scoped (attached to the entity as
+// such). It is satisfied by the metamodel; declared here so this package
+// need not import it.
+//
+// Identity is the default: a type that declares nothing is identity-
+// scoped, which is what keeps a pointerless project unchanged.
+type ScopeClassifier interface {
+	IsContentScoped(relType string) bool
+}
+
+// RelationReader issues relation queries already scoped to a world.
+//
+// It exists so the scope dispatch is UNREPRESENTABLE to omit. A caller
+// handed this capability cannot issue a raw nil-tail query through it;
+// the only way to read relations on a world-resolved surface is to go
+// through Neighbors, which applies the dispatch. Handing out a
+// [store.RelationQuery] and trusting callers to set FromPointer
+// correctly would make the safe path the one you have to remember.
+type RelationReader struct {
+	lister  RelationLister
+	classes ScopeClassifier
+}
+
+// NewRelationReader builds the world-scoped relation capability.
+func NewRelationReader(lister RelationLister, classes ScopeClassifier) (*RelationReader, error) {
+	if lister == nil {
+		return nil, errors.New("worldreader: NewRelationReader: lister must be non-nil")
+	}
+	if classes == nil {
+		return nil, errors.New("worldreader: NewRelationReader: classes must be non-nil")
+	}
+	return &RelationReader{lister: lister, classes: classes}, nil
+}
+
+// Neighbors returns the edges of one resolved entity under its world.
+//
+// The dispatch is per relation TYPE, which is why it cannot be one query
+// (Q4). [store.RelationQuery] deliberately gained no world and no new
+// selector — DOFYR1's FromPointer contract stays frozen — so the two
+// classes are queried separately and merged:
+//
+//   - IDENTITY-scoped types query with a NIL tail. An identity edge
+//     belongs to the entity, not to a face of it, so it must be visible
+//     from every face; filtering by the prime's pointer would hide an
+//     entity's role and containment edges whenever its prime is not the
+//     default state.
+//   - CONTENT-scoped types query with the PRIME'S pointer, so a
+//     non-prime state's content edges stay invisible.
+//
+// # The fallback trap
+//
+// When the prime came from `otherwise: default` (or from rule 1), its
+// pointer IS the zero Pointer — and as a FromPointer VALUE the zero
+// pointer does not mean "unfiltered". It means DEFAULT-TAIL-ONLY, which
+// is a different filter from nil. That is correct for the content-scoped
+// query (the default face's own edges) and would be WRONG for the
+// identity-scoped one, which must stay nil. The two look identical in a
+// debugger — both are "the zero pointer" — which is why they are
+// separated structurally here and pinned by a named test.
+func (rr *RelationReader) Neighbors(
+	ctx context.Context, res Resolved, dir store.Direction,
+) ([]*entity.Relation, error) {
+	if !res.Found || res.Entity == nil {
+		// The world excludes this entity, so it has no edges IN THIS
+		// WORLD. Returning storage's edges here would leak the
+		// existence the exclusion is meant to withhold.
+		return nil, nil
+	}
+	id := res.Entity.ID
+
+	// Identity edges: NIL tail, deliberately. See the fallback trap above.
+	identityQ := store.RelationQuery{
+		Direction:   dir,
+		FromPointer: nil,
+	}
+	setEndpoint(&identityQ, id, dir)
+
+	// Content edges: the prime's pointer BY VALUE, including when that
+	// value is the zero pointer.
+	prime := res.Pointer
+	contentQ := store.RelationQuery{
+		Direction:   dir,
+		FromPointer: &prime,
+	}
+	setEndpoint(&contentQ, id, dir)
+
+	// Merge, keeping each edge under the query whose scope class matches
+	// its type. Both queries over-return: the nil-tail query also
+	// matches content edges, and the pointer query also matches identity
+	// edges stored with that tail. Classifying on the way out is what
+	// makes the merge exact rather than a union with duplicates.
+	var out []*entity.Relation
+	if err := collect(rr.lister.ListRelations(ctx, identityQ), func(rel *entity.Relation) {
+		if !rr.classes.IsContentScoped(rel.Type) {
+			out = append(out, rel)
+		}
+	}); err != nil {
+		return nil, err
+	}
+	if err := collect(rr.lister.ListRelations(ctx, contentQ), func(rel *entity.Relation) {
+		if rr.classes.IsContentScoped(rel.Type) {
+			out = append(out, rel)
+		}
+	}); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// collect drains a relation iterator, aborting on the first error.
+func collect(seq iter.Seq2[*entity.Relation, error], keep func(*entity.Relation)) error {
+	for rel, err := range seq {
+		if err != nil {
+			return err
+		}
+		keep(rel)
+	}
+	return nil
+}
+
+// setEndpoint points the query at id on the side the direction implies.
+//
+// DirectionBoth uses EntityID (match either endpoint), NOT From: setting
+// From alone would silently narrow "both" to outgoing-only, and
+// DirectionBoth is the ZERO value, so that mistake would be the default.
+func setEndpoint(q *store.RelationQuery, id string, dir store.Direction) {
+	switch dir {
+	case store.DirectionOutgoing:
+		q.From = id
+	case store.DirectionIncoming:
+		q.To = id
+	case store.DirectionBoth:
+		q.EntityID = id
+	}
+}

--- a/internal/worldreader/relations_test.go
+++ b/internal/worldreader/relations_test.go
@@ -1,0 +1,201 @@
+package worldreader_test
+
+import (
+	"context"
+	"iter"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/Sourcehaven-BV/rela/internal/entity"
+	"github.com/Sourcehaven-BV/rela/internal/store"
+	"github.com/Sourcehaven-BV/rela/internal/worldreader"
+)
+
+// recordingLister captures the queries issued so a test can assert on the
+// FromPointer the dispatch chose — the distinction under test is between
+// nil and a pointer-to-zero, which no assertion on the RESULTS could
+// detect when a fixture happens to have only default-tail edges.
+type recordingLister struct {
+	queries []store.RelationQuery
+	rels    []*entity.Relation
+}
+
+func (r *recordingLister) ListRelations(
+	_ context.Context, q store.RelationQuery,
+) iter.Seq2[*entity.Relation, error] {
+	r.queries = append(r.queries, q)
+	rels := r.rels
+	return func(yield func(*entity.Relation, error) bool) {
+		for _, rel := range rels {
+			if !yield(rel, nil) {
+				return
+			}
+		}
+	}
+}
+
+// contentTypes classifies the named types as content-scoped; everything
+// else is identity-scoped (the default, which keeps pointerless projects
+// unchanged).
+type contentTypes map[string]bool
+
+func (c contentTypes) IsContentScoped(relType string) bool { return c[relType] }
+
+// TestNeighbors_FallbackTrap_ZeroPointerIsNotNil is the Q4 fallback trap
+// (RR-CGRV0X follow-through 1), and it is the reason the dispatch issues
+// two queries instead of one.
+//
+// When a prime is reached by `otherwise: default` — or by rule 1 — its
+// pointer IS the zero Pointer. As a store.RelationQuery.FromPointer
+// VALUE the zero pointer does NOT mean "unfiltered": it means
+// default-tail-ONLY, a strictly different filter from nil. The two are
+// indistinguishable in a debugger (both print as the empty pointer),
+// so the invariant has to be pinned on the QUERY, not on the results.
+//
+// Getting this wrong in the identity direction hides an entity's role and
+// containment edges; getting it wrong in the content direction shows a
+// non-prime state's edges.
+func TestNeighbors_FallbackTrap_ZeroPointerIsNotNil(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		res  worldreader.Resolved
+	}{
+		{
+			name: "fallback to default state",
+			res: worldreader.Resolved{
+				Entity: entity.New("PAGE-1", "page"),
+				// Zero pointer, reached via the fallback.
+				Via:   worldreader.RuleFallbackDefault,
+				Found: true,
+			},
+		},
+		{
+			name: "unscoped type (rule 1)",
+			res: worldreader.Resolved{
+				Entity: entity.New("PAGE-1", "page"),
+				Via:    worldreader.RuleUnscoped,
+				Found:  true,
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			lister := &recordingLister{}
+			rr, err := worldreader.NewRelationReader(lister, contentTypes{})
+			require.NoError(t, err)
+
+			_, err = rr.Neighbors(context.Background(), tc.res, store.DirectionOutgoing)
+			require.NoError(t, err)
+			require.Len(t, lister.queries, 2, "one identity query + one content query")
+
+			identityQ, contentQ := lister.queries[0], lister.queries[1]
+
+			assert.Nil(t, identityQ.FromPointer,
+				"identity edges must query with a NIL tail: a pointer-to-zero would "+
+					"filter to default-tail edges only and hide identity edges")
+
+			require.NotNil(t, contentQ.FromPointer,
+				"content edges must query with the prime's pointer BY VALUE, not nil")
+			assert.Equal(t, entity.Pointer(""), *contentQ.FromPointer,
+				"the fallback prime's pointer is the zero pointer, and it must be "+
+					"passed as a value so the filter means default-tail-only")
+		})
+	}
+}
+
+// TestNeighbors_ContentQueryUsesThePrimesPointer pins the non-fallback
+// half: when the prime is a real chain coordinate, content edges are
+// scoped to THAT state while identity edges stay unfiltered.
+func TestNeighbors_ContentQueryUsesThePrimesPointer(t *testing.T) {
+	lister := &recordingLister{}
+	rr, err := worldreader.NewRelationReader(lister, contentTypes{})
+	require.NoError(t, err)
+
+	res := worldreader.Resolved{
+		Entity:  entity.New("PAGE-1", "page"),
+		Pointer: entity.Pointer("published"),
+		Via:     worldreader.RuleChain,
+		Found:   true,
+	}
+	_, err = rr.Neighbors(context.Background(), res, store.DirectionOutgoing)
+	require.NoError(t, err)
+	require.Len(t, lister.queries, 2)
+
+	assert.Nil(t, lister.queries[0].FromPointer, "identity tail stays nil for every prime")
+	require.NotNil(t, lister.queries[1].FromPointer)
+	assert.Equal(t, entity.Pointer("published"), *lister.queries[1].FromPointer)
+}
+
+// TestNeighbors_MergesByScopeClass pins that each edge is kept under the
+// query whose scope class matches its type. Both queries over-return —
+// the nil-tail query also matches content edges — so a naive union would
+// duplicate every identity edge and leak non-prime content edges.
+func TestNeighbors_MergesByScopeClass(t *testing.T) {
+	identityRel := &entity.Relation{From: "PAGE-1", Type: "owned-by", To: "USER-1"}
+	contentRel := &entity.Relation{From: "PAGE-1", Type: "mentions", To: "PAGE-2"}
+	lister := &recordingLister{rels: []*entity.Relation{identityRel, contentRel}}
+
+	rr, err := worldreader.NewRelationReader(lister, contentTypes{"mentions": true})
+	require.NoError(t, err)
+
+	res := worldreader.Resolved{
+		Entity:  entity.New("PAGE-1", "page"),
+		Pointer: entity.Pointer("published"),
+		Via:     worldreader.RuleChain,
+		Found:   true,
+	}
+	got, err := rr.Neighbors(context.Background(), res, store.DirectionOutgoing)
+	require.NoError(t, err)
+
+	// Each edge appears exactly once, under its own class.
+	require.Len(t, got, 2, "each edge kept once, no duplicates from the two queries")
+	assert.Equal(t, "owned-by", got[0].Type, "identity edge from the nil-tail query")
+	assert.Equal(t, "mentions", got[1].Type, "content edge from the pointer query")
+}
+
+// TestNeighbors_ExcludedEntityHasNoEdges: an entity the world excludes has
+// no edges IN THIS WORLD. Returning storage's edges would leak exactly
+// the existence the exclusion withholds.
+func TestNeighbors_ExcludedEntityHasNoEdges(t *testing.T) {
+	lister := &recordingLister{rels: []*entity.Relation{
+		{From: "PAGE-1", Type: "owned-by", To: "USER-1"},
+	}}
+	rr, err := worldreader.NewRelationReader(lister, contentTypes{})
+	require.NoError(t, err)
+
+	got, err := rr.Neighbors(context.Background(),
+		worldreader.Resolved{Via: worldreader.RuleExcluded}, store.DirectionOutgoing)
+	require.NoError(t, err)
+
+	assert.Empty(t, got, "an excluded entity contributes no edges")
+	assert.Empty(t, lister.queries, "and no query is issued at all")
+}
+
+// TestNeighbors_DirectionBothMatchesEitherEndpoint pins the endpoint
+// selection. DirectionBoth is the ZERO value of store.Direction, so
+// setting From alone would silently narrow every unspecified query to
+// outgoing-only — a wrong-by-default failure.
+func TestNeighbors_DirectionBothMatchesEitherEndpoint(t *testing.T) {
+	lister := &recordingLister{}
+	rr, err := worldreader.NewRelationReader(lister, contentTypes{})
+	require.NoError(t, err)
+
+	res := worldreader.Resolved{Entity: entity.New("PAGE-1", "page"), Found: true}
+	_, err = rr.Neighbors(context.Background(), res, store.DirectionBoth)
+	require.NoError(t, err)
+
+	for _, q := range lister.queries {
+		assert.Equal(t, "PAGE-1", q.EntityID, "DirectionBoth must filter on either endpoint")
+		assert.Empty(t, q.From, "From alone would narrow both to outgoing-only")
+		assert.Empty(t, q.To)
+	}
+}
+
+func TestNewRelationReader_RejectsNilCollaborators(t *testing.T) {
+	_, err := worldreader.NewRelationReader(nil, contentTypes{})
+	require.Error(t, err, "a nil lister must be rejected, not silently accepted")
+
+	_, err = worldreader.NewRelationReader(&recordingLister{}, nil)
+	require.Error(t, err, "a nil classifier would make every type identity-scoped")
+}

--- a/internal/worldreader/resolver_test.go
+++ b/internal/worldreader/resolver_test.go
@@ -1,0 +1,232 @@
+package worldreader_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/Sourcehaven-BV/rela/internal/entity"
+	"github.com/Sourcehaven-BV/rela/internal/store"
+	"github.com/Sourcehaven-BV/rela/internal/worldreader"
+)
+
+// stateReaderFunc adapts a function to worldreader.StateReader.
+type stateReaderFunc func(context.Context, string, entity.Pointer) (*entity.Entity, error)
+
+func (f stateReaderFunc) GetEntityState(
+	ctx context.Context, id string, p entity.Pointer,
+) (*entity.Entity, error) {
+	return f(ctx, id, p)
+}
+
+// identityCanon is a canonicalizer with no aliases: every name is already
+// canonical.
+type identityCanon struct{}
+
+func (identityCanon) CanonicalType(name string) (string, bool) { return name, true }
+
+// aliasCanon maps one alias to its canonical type.
+type aliasCanon map[string]string
+
+func (a aliasCanon) CanonicalType(name string) (string, bool) {
+	if canonical, ok := a[name]; ok {
+		return canonical, true
+	}
+	return name, true
+}
+
+// statesFixture builds a reader over a fixed set of stored states. The
+// entity type is fixed: these tests vary the WORLD and the stored
+// pointers, and a second type would only exercise the scope map, which
+// TestResolve_Rules already covers via its unscoped-type case.
+func statesFixture(t *testing.T, id string, pointers ...entity.Pointer) worldreader.StateReader {
+	t.Helper()
+	const typ = "page"
+	have := map[entity.Pointer]bool{}
+	for _, p := range pointers {
+		have[p] = true
+	}
+	return stateReaderFunc(func(_ context.Context, gotID string, p entity.Pointer) (*entity.Entity, error) {
+		if gotID != id || !have[p] {
+			return nil, store.ErrNotFound
+		}
+		e := entity.New(id, typ)
+		e.Pointer = p
+		e.SetString("title", id+"@"+string(p))
+		return e, nil
+	})
+}
+
+func pageScope(fb store.Fallback, chain ...entity.Pointer) store.WorldScope {
+	return store.NewWorldScope(map[string]store.TypeResolution{
+		"page": {Chain: chain, Fallback: fb},
+	})
+}
+
+// TestResolve_Rules walks the three resolution rules. They must agree
+// with storeutil.WorldPrimes and the SQL pushdown — the whole point of
+// having one contract is that the decorator cannot drift from them.
+func TestResolve_Rules(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		stored   []entity.Pointer
+		scope    store.WorldScope
+		wantPtr  entity.Pointer
+		wantVia  worldreader.Rule
+		wantMiss bool
+	}{
+		{
+			name:    "rule 2: first existing coordinate wins",
+			stored:  []entity.Pointer{"", "review", "published"},
+			scope:   pageScope(store.FallbackDefaultState, "review", "published"),
+			wantPtr: "review",
+			wantVia: worldreader.RuleChain,
+		},
+		{
+			name:    "rule 2: chain order is the whole semantic content",
+			stored:  []entity.Pointer{"", "review", "published"},
+			scope:   pageScope(store.FallbackDefaultState, "published", "review"),
+			wantPtr: "published",
+			wantVia: worldreader.RuleChain,
+		},
+		{
+			name:    "rule 2: skips a coordinate that does not exist",
+			stored:  []entity.Pointer{"", "published"},
+			scope:   pageScope(store.FallbackExclude, "review", "published"),
+			wantPtr: "published",
+			wantVia: worldreader.RuleChain,
+		},
+		{
+			name:    "rule 3: otherwise-default serves the default face",
+			stored:  []entity.Pointer{""},
+			scope:   pageScope(store.FallbackDefaultState, "published"),
+			wantPtr: "",
+			wantVia: worldreader.RuleFallbackDefault,
+		},
+		{
+			name:     "rule 3: otherwise-exclude yields nothing",
+			stored:   []entity.Pointer{""},
+			scope:    pageScope(store.FallbackExclude, "published"),
+			wantMiss: true,
+			wantVia:  worldreader.RuleExcluded,
+		},
+		{
+			name:    "rule 1: unscoped type keeps its default state",
+			stored:  []entity.Pointer{"", "published"},
+			scope:   store.NewWorldScope(map[string]store.TypeResolution{"note": {}}),
+			wantPtr: "",
+			wantVia: worldreader.RuleUnscoped,
+		},
+		{
+			name:     "otherwise-default still yields nothing when no state exists at all",
+			stored:   nil,
+			scope:    pageScope(store.FallbackDefaultState, "published"),
+			wantMiss: true,
+			wantVia:  worldreader.RuleExcluded,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			r, err := worldreader.NewResolver(
+				statesFixture(t, "PAGE-1", tc.stored...), tc.scope, identityCanon{})
+			require.NoError(t, err)
+
+			got, err := r.Resolve(context.Background(), "page", "PAGE-1")
+			require.NoError(t, err)
+
+			assert.Equal(t, tc.wantVia, got.Via, "provenance")
+			if tc.wantMiss {
+				assert.False(t, got.Found, "the world must exclude this entity")
+				assert.Nil(t, got.Entity)
+				return
+			}
+			require.True(t, got.Found)
+			require.NotNil(t, got.Entity)
+			assert.Equal(t, tc.wantPtr, got.Pointer)
+			assert.Equal(t, "PAGE-1@"+string(tc.wantPtr), got.Entity.GetString("title"))
+		})
+	}
+}
+
+// TestResolve_AliasCanonicalizesAtTheBoundary is the alias trap, named
+// for its failure.
+//
+// store.WorldScope is keyed on CANONICAL type names — a store holds no
+// metamodel and cannot resolve an alias. So an alias reaching
+// WorldScope.For arrives as an unknown type, which is ok=false, which is
+// rule 1: the DEFAULT STATE SERVED IN A WORLD THAT MEANT TO EXCLUDE IT.
+//
+// That is fail-OPEN, which is why canonicalization happens at this
+// boundary rather than being left to callers to remember.
+func TestResolve_AliasCanonicalizesAtTheBoundary(t *testing.T) {
+	// Only the default state exists, and the world excludes anything
+	// without a published state. Correct answer: NOT FOUND.
+	reader := statesFixture(t, "PAGE-1", "")
+	scope := pageScope(store.FallbackExclude, "published")
+
+	canon := aliasCanon{"pages": "page"} // "pages" is an alias for "page"
+	r, err := worldreader.NewResolver(reader, scope, canon)
+	require.NoError(t, err)
+
+	got, err := r.Resolve(context.Background(), "pages", "PAGE-1")
+	require.NoError(t, err)
+
+	assert.False(t, got.Found,
+		"an ALIASED type must resolve through its canonical name: treating "+
+			"the alias as an unknown type is rule 1, which serves the default "+
+			"state in a world that meant to exclude it — fail-open")
+	assert.Equal(t, worldreader.RuleExcluded, got.Via)
+}
+
+// TestResolve_StoreFaultIsNotAMiss: only the visibility Reader may
+// collapse a fault into a clean miss (its oracle-free contract requires
+// it). Doing that here would make a backend outage look like an
+// exclusion at the wrong layer, and the operator would debug the world
+// instead of the database.
+func TestResolve_StoreFaultIsNotAMiss(t *testing.T) {
+	boom := errors.New("connection refused")
+	reader := stateReaderFunc(func(context.Context, string, entity.Pointer) (*entity.Entity, error) {
+		return nil, boom
+	})
+	r, err := worldreader.NewResolver(reader, pageScope(store.FallbackExclude, "published"), identityCanon{})
+	require.NoError(t, err)
+
+	_, err = r.Resolve(context.Background(), "page", "PAGE-1")
+	assert.ErrorIs(t, err, boom, "a store fault must surface, not read as an exclusion")
+}
+
+// TestResolve_ChainShortCircuits pins that the walk stops at the first
+// hit. Chains are 1-3 in practice and the common case is a single point
+// read; walking the whole chain regardless would multiply every Get.
+func TestResolve_ChainShortCircuits(t *testing.T) {
+	var asked []entity.Pointer
+	reader := stateReaderFunc(func(_ context.Context, id string, p entity.Pointer) (*entity.Entity, error) {
+		asked = append(asked, p)
+		if p != "review" {
+			return nil, store.ErrNotFound
+		}
+		e := entity.New(id, "page")
+		e.Pointer = p
+		return e, nil
+	})
+	r, err := worldreader.NewResolver(reader,
+		pageScope(store.FallbackDefaultState, "review", "published"), identityCanon{})
+	require.NoError(t, err)
+
+	_, err = r.Resolve(context.Background(), "page", "PAGE-1")
+	require.NoError(t, err)
+
+	assert.Equal(t, []entity.Pointer{"review"}, asked,
+		"the first hit wins; later coordinates and the fallback are never fetched")
+}
+
+func TestNewResolver_RejectsNilCollaborators(t *testing.T) {
+	_, err := worldreader.NewResolver(nil, store.DefaultWorld(), identityCanon{})
+	require.Error(t, err, "a nil reader must be rejected")
+
+	_, err = worldreader.NewResolver(statesFixture(t, "X"), store.DefaultWorld(), nil)
+	require.Error(t, err,
+		"a nil canonicalizer would make every aliased type rule 1 — the fail-open direction")
+}

--- a/internal/worldreader/surface.go
+++ b/internal/worldreader/surface.go
@@ -1,0 +1,111 @@
+package worldreader
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/Sourcehaven-BV/rela/internal/store"
+)
+
+// WorldAwareSearcher is the capability a searcher must advertise before
+// it may back a world-bound surface: it declares which worlds it can
+// actually serve.
+//
+// No searcher implements this today, and that is the point — see
+// [NewSurface].
+type WorldAwareSearcher interface {
+	// ServesWorld reports whether this searcher's results are scoped to
+	// the given world.
+	ServesWorld(w store.WorldScope) bool
+}
+
+// Surface is a world-bound read surface: a resolver, its relation
+// capability, and (optionally) a searcher, all fixed to ONE world at
+// construction.
+//
+// There is no world parameter on any method, and no setter. A surface IS
+// its world (Q10). Request-level world selection is deliberately not
+// shipped here: it needs its own grant check, and a plumbed-but-ungated
+// world parameter would be exactly the half-built thing this arc declined
+// to ship.
+type Surface struct {
+	resolver  *Resolver
+	relations *RelationReader
+	searcher  WorldAwareSearcher
+}
+
+// ErrSearcherCannotServeWorld is returned when a world-bound surface is
+// constructed over a searcher that cannot honor its world.
+var ErrSearcherCannotServeWorld = errors.New(
+	"worldreader: searcher cannot serve this surface's world")
+
+// NewSurface binds a resolver, its relation reader, and a searcher into
+// one world-scoped surface.
+//
+// # The searcher-constructibility criterion (RULING 3)
+//
+// A world-bound surface must not be CONSTRUCTIBLE with a searcher that
+// cannot honor its world. This is the DEC-ZBI39P stance — structurally
+// incapable rather than "defaults to safe" — and it is enforced here, at
+// construction, rather than by a runtime check on the search path.
+//
+// The reason it cannot be a runtime check: `internal/search` is
+// world-agnostic BY CONSTRUCTION. Its Query type carries no world and its
+// Searcher interface has no world parameter, so there is nothing on the
+// search path to test. A refusal there would be a concept introduced
+// solely to reject itself. See that package's doc.
+//
+// So the check lives where the world actually exists — here — and it is
+// deliberately strict:
+//
+//   - DEFAULT world: any searcher is fine. Every searcher serves the
+//     default world today, so a pointerless project is unaffected.
+//   - NON-DEFAULT world with NO searcher: allowed. A surface without
+//     search cannot return wrongly-scoped hits.
+//   - NON-DEFAULT world WITH a searcher: the searcher must implement
+//     [WorldAwareSearcher] and affirm it serves this world. Nothing does
+//     today, so this REFUSES — which is the intended outcome. Per-world
+//     indexing is Step 5 (TKT-9KZGJO); until it lands, a world-bound
+//     surface with a working-but-wrong search box must be impossible to
+//     build rather than merely discouraged.
+//
+// The failure mode this closes: the ACL row gate CANNOT catch a
+// wrongly-scoped search hit, because guard rule 1 makes the row gate
+// world-independent. A draft surfacing through search would reach the
+// user with nothing downstream to stop it.
+func NewSurface(
+	resolver *Resolver, relations *RelationReader, searcher WorldAwareSearcher,
+) (*Surface, error) {
+	if resolver == nil {
+		return nil, errors.New("worldreader: NewSurface: resolver must be non-nil")
+	}
+	if relations == nil {
+		return nil, errors.New("worldreader: NewSurface: relations must be non-nil")
+	}
+
+	if !resolver.Scope().IsDefaultWorld() && searcher != nil {
+		if !searcher.ServesWorld(resolver.Scope()) {
+			return nil, fmt.Errorf(
+				"%w: build the surface without a searcher, or wait for per-world "+
+					"indexing (TKT-9KZGJO) — a world-bound surface must not serve "+
+					"default-world hits, and the ACL row gate cannot catch them "+
+					"because it is world-independent by design (guard rule 1)",
+				ErrSearcherCannotServeWorld)
+		}
+	}
+
+	return &Surface{resolver: resolver, relations: relations, searcher: searcher}, nil
+}
+
+// Resolver returns the surface's resolver. The world is already bound.
+func (s *Surface) Resolver() *Resolver { return s.resolver }
+
+// Relations returns the world-scoped relation capability. Callers get
+// this rather than a [store.RelationQuery], so the scope dispatch cannot
+// be omitted.
+func (s *Surface) Relations() *RelationReader { return s.relations }
+
+// Searcher returns the surface's searcher, which may be nil. It is
+// guaranteed to serve this surface's world — NewSurface refuses any
+// other combination.
+func (s *Surface) Searcher() WorldAwareSearcher { return s.searcher }

--- a/internal/worldreader/surface_test.go
+++ b/internal/worldreader/surface_test.go
@@ -1,0 +1,113 @@
+package worldreader_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/Sourcehaven-BV/rela/internal/entity"
+	"github.com/Sourcehaven-BV/rela/internal/store"
+	"github.com/Sourcehaven-BV/rela/internal/worldreader"
+)
+
+// fixedSearcher answers ServesWorld with a canned verdict.
+type fixedSearcher struct{ serves bool }
+
+func (f fixedSearcher) ServesWorld(store.WorldScope) bool { return f.serves }
+
+func newParts(t *testing.T, scope store.WorldScope) (*worldreader.Resolver, *worldreader.RelationReader) {
+	t.Helper()
+	r, err := worldreader.NewResolver(statesFixture(t, "PAGE-1", ""), scope, identityCanon{})
+	require.NoError(t, err)
+	rr, err := worldreader.NewRelationReader(&recordingLister{}, contentTypes{})
+	require.NoError(t, err)
+	return r, rr
+}
+
+// TestNewSurface_SearcherConstructibility is RULING 3's criterion: a
+// world-bound surface must not be CONSTRUCTIBLE over a searcher that
+// cannot honor its world.
+//
+// It is enforced at construction rather than on the search path because
+// internal/search is world-agnostic by construction — its Query carries
+// no world, so there is nothing there to check. And the ACL row gate
+// cannot compensate: guard rule 1 makes it world-independent, so a
+// wrongly-scoped hit would reach the user unopposed.
+func TestNewSurface_SearcherConstructibility(t *testing.T) {
+	worldScope := store.NewWorldScope(map[string]store.TypeResolution{
+		"page": {Chain: []entity.Pointer{"published"}, Fallback: store.FallbackExclude},
+	})
+
+	for _, tc := range []struct {
+		name     string
+		scope    store.WorldScope
+		searcher worldreader.WorldAwareSearcher
+		wantErr  bool
+	}{
+		{
+			name:     "default world accepts any searcher",
+			scope:    store.DefaultWorld(),
+			searcher: fixedSearcher{serves: false},
+		},
+		{
+			name:  "non-default world with NO searcher is fine",
+			scope: worldScope,
+		},
+		{
+			name:     "non-default world REFUSES a searcher that cannot serve it",
+			scope:    worldScope,
+			searcher: fixedSearcher{serves: false},
+			wantErr:  true,
+		},
+		{
+			name:     "non-default world accepts a searcher that affirms it",
+			scope:    worldScope,
+			searcher: fixedSearcher{serves: true},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			r, rr := newParts(t, tc.scope)
+			got, err := worldreader.NewSurface(r, rr, tc.searcher)
+			if tc.wantErr {
+				require.Error(t, err, "a world-bound surface must not be constructible here")
+				require.ErrorIs(t, err, worldreader.ErrSearcherCannotServeWorld)
+				assert.Nil(t, got)
+				return
+			}
+			require.NoError(t, err)
+			require.NotNil(t, got)
+		})
+	}
+}
+
+// TestNewSurface_TodaysSearchersCannotBackAWorldBoundSurface pins the
+// intended outcome rather than only the mechanism: NOTHING implements
+// WorldAwareSearcher today, so the nil-searcher case is the only way to
+// build a world-bound surface until per-world indexing lands (Step 5,
+// TKT-9KZGJO). If a future searcher starts affirming ServesWorld without
+// actually scoping its index, this test is where that claim should be
+// re-examined.
+func TestNewSurface_TodaysSearchersCannotBackAWorldBoundSurface(t *testing.T) {
+	worldScope := store.NewWorldScope(map[string]store.TypeResolution{
+		"page": {Chain: []entity.Pointer{"published"}, Fallback: store.FallbackExclude},
+	})
+	r, rr := newParts(t, worldScope)
+
+	// A stand-in for any of today's searchers: it does not implement
+	// WorldAwareSearcher at all, so it cannot be passed here — the
+	// compiler enforces that. Passing one that says "no" is the closest
+	// representable equivalent.
+	_, err := worldreader.NewSurface(r, rr, fixedSearcher{serves: false})
+	require.ErrorIs(t, err, worldreader.ErrSearcherCannotServeWorld)
+}
+
+func TestNewSurface_RejectsNilCollaborators(t *testing.T) {
+	r, rr := newParts(t, store.DefaultWorld())
+
+	_, err := worldreader.NewSurface(nil, rr, nil)
+	require.Error(t, err)
+
+	_, err = worldreader.NewSurface(r, nil, nil)
+	require.Error(t, err, "without the relation capability the scope dispatch could be bypassed")
+}

--- a/internal/worldreader/worldreader.go
+++ b/internal/worldreader/worldreader.go
@@ -1,0 +1,247 @@
+// Package worldreader is the RUNTIME half of content-state worlds
+// (TKT-WAV8XP Step 2): it resolves an entity to the single state a world
+// selects — its "prime" — and hands out capabilities that carry that
+// resolution so callers cannot accidentally read around it.
+//
+// It is deliberately separate from [internal/worlds], which is the pure
+// COMPILER (metamodel → [store.WorldScope]) and holds no store. This
+// package holds a store and does the reading.
+//
+// # Guard rule 1: resolution is PRINCIPAL-INDEPENDENT
+//
+// A world resolves the same prime for every reader. Nothing in this
+// package takes a principal, an ACL gate, or an [internal/acl] type, and
+// that is a structural guarantee rather than a convention — see
+// `guard_test.go`, which scans the package and fails on such a
+// dependency.
+//
+// The reason is an existence oracle. Resolution must complete BEFORE the
+// ACL gate is consulted: if the gate ran first, a prime the principal
+// may not read would fall through to the chain's next candidate, and the
+// face a reader receives would then reveal what the ACL denied them. So
+// the order is fixed — resolve, then gate — and the only way to keep it
+// is that the resolver cannot consult a gate at all.
+//
+// Consequently a denied entity yields NOTHING, never a different face.
+//
+// # Two mechanisms, one contract
+//
+// Resolution reaches the store two ways, and both are required:
+//
+//   - as a DECORATOR, for the read paths that go through a reader; and
+//   - as a FIELD ON THE QUERY ([store.EntityQuery.World] /
+//     [store.GraphQuery.World]), because `internal/visibility`'s pushdown
+//     composes a GraphQuery and hands it straight to the raw store,
+//     reaching past every decorator.
+//
+// A decorator-only design would silently degrade to the default world on
+// the pushdown path — which is precisely the ACL-path fail-open found in
+// PR-B review (RR-GQWRLD). `parity_test.go` pins that the two paths agree,
+// including for a principal carrying a policy query.
+package worldreader
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/Sourcehaven-BV/rela/internal/entity"
+	"github.com/Sourcehaven-BV/rela/internal/store"
+)
+
+// StateReader is the narrow read surface the resolver needs: addressing
+// one stored state directly. Declared here, at the call site, rather than
+// taken from the store package wholesale.
+type StateReader interface {
+	GetEntityState(ctx context.Context, id string, p entity.Pointer) (*entity.Entity, error)
+}
+
+// Resolved is a prime plus the PROVENANCE of how it was chosen.
+//
+// The provenance is not decoration: "the published face" and "the default
+// face, because no published state exists" are different facts about the
+// same bytes, and a caller that renders a publication badge, logs an
+// audit line, or decides whether to offer an edit affordance needs to
+// tell them apart. Returning only the entity would force every such
+// caller to re-derive the verdict, and re-deriving it requires the chain
+// — which is exactly what this package exists to own.
+type Resolved struct {
+	// Entity is the resolved state. Never nil when Found is true.
+	Entity *entity.Entity
+
+	// Pointer is the coordinate Entity was stored at. The zero pointer
+	// means the default state, whether it was reached by rule 1, by an
+	// explicit chain coordinate, or by the fallback — Via distinguishes
+	// those.
+	Pointer entity.Pointer
+
+	// Via records WHICH resolution rule produced this prime.
+	Via Rule
+
+	// Found is false when the world excludes this entity. The entity may
+	// exist in storage; in this world it does not.
+	Found bool
+}
+
+// Rule names the resolution rule that selected a prime, matching the
+// three rules in the design doc and [storeutil.WorldPrimes].
+type Rule int
+
+const (
+	// RuleUnscoped is rule 1: the world declares no resolution for this
+	// entity's type, so it contributes its default state. This is the
+	// common case in a mixed graph and costs no chain walk.
+	RuleUnscoped Rule = iota
+	// RuleChain is rule 2: the first chain coordinate that EXISTS.
+	RuleChain
+	// RuleFallbackDefault is rule 3 under `otherwise: default`: no chain
+	// coordinate exists, so the default state stands in.
+	RuleFallbackDefault
+	// RuleExcluded is rule 3 under `otherwise: exclude`: no chain
+	// coordinate exists and the entity is absent from this world.
+	RuleExcluded
+)
+
+// String names the rule for logs and test failures.
+func (r Rule) String() string {
+	switch r {
+	case RuleUnscoped:
+		return "unscoped"
+	case RuleChain:
+		return "chain"
+	case RuleFallbackDefault:
+		return "fallback-default"
+	case RuleExcluded:
+		return "excluded"
+	default:
+		return fmt.Sprintf("Rule(%d)", int(r))
+	}
+}
+
+// TypeCanonicalizer maps a possibly-aliased entity type name to its
+// canonical name. [store.WorldScope] is keyed on CANONICAL names only —
+// a store holds no metamodel and cannot resolve an alias — so a caller
+// that took a type name from user input or from a stored row must
+// canonicalize before the scope is consulted.
+//
+// Skipping this is FAIL-OPEN, not fail-closed: an alias reaches
+// [store.WorldScope.For] as an unknown type, which is ok=false, which is
+// rule 1 — the default state served in a world that meant to exclude it.
+// That is why canonicalization happens at this boundary rather than being
+// left to callers.
+type TypeCanonicalizer interface {
+	CanonicalType(name string) (string, bool)
+}
+
+// Resolver resolves entities to their prime under one fixed world.
+//
+// The world is bound at CONSTRUCTION and there is no per-call world
+// parameter (Q10). A surface is built over its world; it cannot be asked
+// to serve a different one. That is the DEC-ZBI39P stance — structurally
+// incapable rather than defaulting to safe — and it is why request-level
+// world selection is a separate ticket with its own grant check rather
+// than a parameter plumbed through now.
+type Resolver struct {
+	reader StateReader
+	scope  store.WorldScope
+	canon  TypeCanonicalizer
+}
+
+// NewResolver builds a Resolver over a fixed world.
+//
+// Required collaborators are rejected when nil rather than silently
+// substituted, per the project constructor rule: a no-op canonicalizer
+// would turn every aliased type into rule 1, which is the fail-open
+// direction described on [TypeCanonicalizer].
+func NewResolver(reader StateReader, scope store.WorldScope, canon TypeCanonicalizer) (*Resolver, error) {
+	if reader == nil {
+		return nil, errors.New("worldreader: NewResolver: reader must be non-nil")
+	}
+	if canon == nil {
+		return nil, errors.New("worldreader: NewResolver: canon must be non-nil")
+	}
+	return &Resolver{reader: reader, scope: scope, canon: canon}, nil
+}
+
+// Scope returns the world this resolver is bound to, for the wiring site
+// to copy onto a query ([store.EntityQuery.World]) on the pushdown path.
+func (r *Resolver) Scope() store.WorldScope { return r.scope }
+
+// Resolve walks the chain for one entity and returns its prime.
+//
+// entityType may be an alias; it is canonicalized here (see
+// [TypeCanonicalizer]).
+//
+// The walk is at most len(chain)+1 point reads, and chains are 1-3 in
+// practice — the common case is a single call. It reads one coordinate at
+// a time rather than listing the family because a point read is what
+// every backend is fastest at, and because the chain short-circuits: the
+// first hit wins and the rest are never fetched.
+//
+// A missing state is not an error. Only a real store fault is, and it is
+// returned rather than swallowed — the caller (the visibility Reader)
+// owns the decision to collapse faults into a clean miss, and duplicating
+// that policy here would make a backend outage indistinguishable from an
+// exclusion at the wrong layer.
+func (r *Resolver) Resolve(ctx context.Context, entityType, id string) (Resolved, error) {
+	typ := entityType
+	if canonical, ok := r.canon.CanonicalType(entityType); ok {
+		typ = canonical
+	}
+
+	res, scoped := r.scope.For(typ)
+	if !scoped {
+		// Rule 1: unscoped type contributes its default state.
+		e, found, err := r.getState(ctx, id, "")
+		if err != nil {
+			return Resolved{}, err
+		}
+		if !found {
+			return Resolved{Via: RuleUnscoped}, nil
+		}
+		return Resolved{Entity: e, Via: RuleUnscoped, Found: true}, nil
+	}
+
+	// Rule 2: the first coordinate that EXISTS wins. Chain order is the
+	// entire semantic content of a world.
+	for _, coord := range res.Chain {
+		e, found, err := r.getState(ctx, id, coord)
+		if err != nil {
+			return Resolved{}, err
+		}
+		if found {
+			return Resolved{Entity: e, Pointer: coord, Via: RuleChain, Found: true}, nil
+		}
+	}
+
+	// Rule 3: no coordinate exists; the fallback decides.
+	if res.Fallback != store.FallbackDefaultState {
+		// `otherwise: exclude` — absence IS the publication bit.
+		return Resolved{Via: RuleExcluded}, nil
+	}
+	e, found, err := r.getState(ctx, id, "")
+	if err != nil {
+		return Resolved{}, err
+	}
+	if !found {
+		return Resolved{Via: RuleExcluded}, nil
+	}
+	return Resolved{Entity: e, Via: RuleFallbackDefault, Found: true}, nil
+}
+
+// getState reads one coordinate. The bool distinguishes ABSENCE (a
+// coordinate the chain may skip) from a FAULT (which must surface) —
+// returning a nil entity with a nil error would conflate them at the
+// call site, which is the one distinction this walk turns on.
+func (r *Resolver) getState(
+	ctx context.Context, id string, p entity.Pointer,
+) (e *entity.Entity, found bool, err error) {
+	e, err = r.reader.GetEntityState(ctx, id, p)
+	if err != nil {
+		if errors.Is(err, store.ErrNotFound) {
+			return nil, false, nil
+		}
+		return nil, false, err
+	}
+	return e, true, nil
+}


### PR DESCRIPTION
PR-D — the closing PR of the TKT-WAV8XP (worlds, Step 2) stack. **Code-only**; paperwork on the companion PR.

Tickets-PR: #1394

Stack: #1393 (A) ← #1399 (B) ← #1402 (C) ← **this**. Retarget to `develop` as ancestors merge.

## The two things a reviewer most needs to know

**1. The staged gap from PR-B is closed — and `internal/acl` was not touched.**

Since PR-B, `GraphQuery.World` has been *honored but never set* on the ACL read path: the store respected the field, but the composed query arrived with a zero world. The fix turned out not to need injection into `acl` at all. `listPushdown` already holds **both halves** — the `EntityQuery` carrying the world, and the composed `GraphQuery` it hands to the raw store — so the world is stamped as it crosses that seam:

```go
worldQuery := *rqr.Query   // copy is LOAD-BEARING: ReadQueryResult may be cached
worldQuery.World = q.World // per principal; mutating in place bleeds one
                           // request's world into the next caller's
```

`internal/acl`'s diff is **comment-only** — it keeps emitting a world-free query, which is now correct rather than a gap, with the comment updated from "staged gap, PR-D will inject" to "the wiring seam stamps it". No new dependency, no new parameter on `ReadQueryFor`.

**2. The parity test proves why it had to cover the ACL-composed path.**

Reverting the two-line fix fails `TestWorldParity_ComposedQueryBranchCarriesTheWorld` and `TestWorldParity_BothBranchesAgree` — while **the AllowAll test stays green**. That is the empirical demonstration that a parity test exercising only the unrestricted principal would have passed through the entire window RR-GQWRLD's fail-open was live. The spy captures the constructed QUERY rather than asserting on rows, because a wrongly-defaulted world still returns plausible rows — which is exactly why the original bug was invisible.

## `internal/worldreader`

New package, arch-lint-pinned to `entity + store` — that pin is what keeps guard rule 1 (principal-independent resolution) **structural** rather than conventional. The metamodel adapters it needs (alias canonicalization, relation-scope classification) arrive as narrow interfaces satisfied at the wiring site in `appbuild`.

- **`Resolver`** — world bound at CONSTRUCTION, no per-call world parameter (Q10). The Get chain walk (RR-CUUZ9Z) walks the chain via `GetEntityState` per coordinate, short-circuits on the first hit, applies the fallback verdict, and returns not-found under `FallbackExclude`. A store fault **surfaces** rather than collapsing into a clean miss — presenting a backend outage as an exclusion would be the wrong answer at the wrong layer.
- **`Resolved{Entity, Pointer, Via, Found}`** — `Via` distinguishes unscoped / chain / fallback-default / excluded. "The published face" and "the default face because nothing is published" are different facts about the same bytes.
- **`RelationReader.Neighbors`** — the Q4 per-relation-type scope dispatch: identity-scoped types query with an unfiltered tail, content-scoped types with the prime's pointer, merged. **The omission is unrepresentable**: callers receive the capability, not a `RelationQuery`, so no raw nil-tail query can be issued through it.

### The Q4 fallback trap

When `otherwise: default` fires, the prime's pointer **is** the zero pointer — which as a `FromPointer` value means *default-tail-only*, a different filter from nil. `TestNeighbors_FallbackTrap_ZeroPointerIsNotNil` asserts on the constructed QUERY, deliberately: no assertion on results can distinguish nil from pointer-to-zero when a fixture happens to hold only default-tail edges. Both zero-pointer paths are covered (`otherwise: default` and rule 1).

## Guard rule 1, pinned three independent ways

Resolution must never depend on the principal — otherwise being served a fallback face tells you a hidden state exists above it.

1. **arch-lint** — `worldreader.mayDependOn` is exactly `entity + store`.
2. **Package scan** (`guard_test.go`, following `acl/ceilingguard_test.go`) with a fail-closed exemption list.
3. **Behavioural** — two principals resolve the same entity to the same face.

Each covers the others' blind spot: 1 and 2 miss a principal read off ctx; 3 alone stays green for its fixtures if someone adds a gate. All three verified non-vacuous by deliberate breakage.

## Also in this PR

- **Alias canonicalization at the resolver boundary.** An alias reaching `WorldScope.For` is an unknown type → rule 1 → **the default state served in a world that meant to exclude it**. Fail-open, which is why it is at the boundary rather than left to callers. Test named for the failure.
- **Searcher-constructibility** (Ruling 3): `NewSurface` refuses to build a world-bound surface over a searcher that cannot honor its world. Nothing implements `WorldAwareSearcher` today, so a non-default world + a searcher **refuses** — the intended outcome until per-world indexing (Step 5). Pinned with WHY the ACL row gate cannot cover for it: guard rule 1 makes it world-independent, so a draft surfacing through search reaches the user unopposed.
- **Unknown world names are an error, never a default** — a typo in a deployment config must not silently serve drafts from a surface meant to be public.
- **Docs** (`docs-project/` → regenerated): a "What worlds do NOT do yet" section covering the two user-visible limits — no per-request world selection (framed via *why*: it needs its own permission check, or "which faces may I see?" becomes a client decision), and no search on a world-bound surface.
- `appbuild.WorldSurface` is a **package-level function, not a `Services` method** — it reads three fields and composes worldreader types, so an accessor would have been accretion on the composition root's public API, which is what the god-object load line exists to catch.

## Verification

`golangci-lint` 0 issues, arch-lint OK, plimsoll clean, gofmt clean, both build tags, full suite green including pgstore against a real database.

`TestWorldSurface_ResolvesThroughTheWiredStack` drives the real path — worlds declared in `schema.yaml`, compiled at boot, looked up by name, bound to a surface, resolved against a real store: chain hit, fallback, exclusion, rule 1, and alias resolution.