### PR TITLE
refactor(appbuild): discover store capabilities by interface, not concrete type (TKT-415WA7)

### DIFF
--- a/internal/appbuild/derivedschema_postgres.go
+++ b/internal/appbuild/derivedschema_postgres.go
@@ -12,15 +12,31 @@ import (
 	"github.com/Sourcehaven-BV/rela/internal/store/pgstore"
 )
 
-// reconcileDerivedSchemaIfSupported converges the postgres derived schema at
-// store-open and publishes the metamodel's unique (type, property) pairs so the
-// write path can attribute a unique-index violation to a property (TKT-3Q0GP1).
-// A non-pgstore store (should not happen in this build) is skipped. Reconcile
+// derivedSchemaReconciler is the capability reconcileDerivedSchemaIfSupported
+// needs: a store that can synthesize derived schema objects (partial unique
+// indexes) from the metamodel and accept the unique-spec list used to attribute
+// a violation to a property.
+//
+// Declared at the call site rather than beside the implementation, so any store
+// offering these methods is discovered — not just one concrete backend
+// (TKT-415WA7). Both methods are taken together deliberately: publishing specs
+// without reconciling, or the reverse, is never wanted.
+type derivedSchemaReconciler interface {
+	SetUniqueSpecProvider(specs []store.DerivedObjectSpec)
+	Reconcile(
+		ctx context.Context, desired []store.DerivedObjectSpec, opts store.ReconcileOptions,
+	) ([]store.DerivedObjectOutcome, error)
+}
+
+// reconcileDerivedSchemaIfSupported converges the derived schema at store-open
+// and publishes the metamodel's unique (type, property) pairs so the write path
+// can attribute a unique-index violation to a property (TKT-3Q0GP1). A store
+// without the capability (should not happen in this build) is skipped. Reconcile
 // failures are logged and swallowed: a derived-schema problem — most often
 // pre-existing duplicate values blocking an index — must NEVER fail store-open.
 // An operator inspects/repairs drift via `rela db status` / `rela db reconcile`.
 func reconcileDerivedSchemaIfSupported(ctx context.Context, st store.Store, meta *metamodel.Metamodel) {
-	s, ok := st.(*pgstore.Store)
+	s, ok := st.(derivedSchemaReconciler)
 	if !ok {
 		return
 	}

--- a/internal/appbuild/userstate_postgres.go
+++ b/internal/appbuild/userstate_postgres.go
@@ -38,7 +38,14 @@ func storeUserStateFor(st store.Store) userstate.Store {
 	}
 	us, err := s.UserState()
 	if err != nil {
-		slog.Warn("next-action state: pgstore backend unavailable", "error", err)
+		slog.Warn("next-action state: store backend unavailable", "error", err)
+		return nil
+	}
+	if us == nil {
+		// Belt-and-braces alongside the error check: a provider that returns
+		// (nil, nil) must not be mistaken for a working handle. Cheap here,
+		// and the alternative is a nil-pointer panic on the first snooze.
+		slog.Warn("next-action state: store returned no backend and no error")
 		return nil
 	}
 	return us

--- a/internal/appbuild/userstate_postgres.go
+++ b/internal/appbuild/userstate_postgres.go
@@ -6,14 +6,22 @@ import (
 	"log/slog"
 
 	"github.com/Sourcehaven-BV/rela/internal/store"
-	"github.com/Sourcehaven-BV/rela/internal/store/pgstore"
 	"github.com/Sourcehaven-BV/rela/internal/userstate"
 )
 
-// storeUserStateFor returns the pgstore next-action state backend, sharing the
-// store's pool. Mirrors versionServiceFor: a build-tagged resolver with a
-// concrete type assertion, so the non-postgres builds neither know nor link
-// this implementation.
+// userStateProvider is the capability storeUserStateFor needs: a store that can
+// hand out a database-backed next-action state handle sharing its own pool.
+//
+// Declared here, at the call site, rather than beside the implementation — any
+// store offering the method satisfies it, so discovery is not welded to one
+// concrete backend (TKT-415WA7).
+type userStateProvider interface {
+	UserState() (userstate.Store, error)
+}
+
+// storeUserStateFor returns the store's own next-action state backend, sharing
+// its pool. Mirrors versionServiceFor: a build-tagged resolver, so non-postgres
+// builds neither know nor link this implementation.
 //
 // This backend is preferred over the state.KV one because it is the only one
 // safe for a multi-process deployment: the KV backend rewrites one JSON
@@ -24,7 +32,7 @@ import (
 // caller's nil-check behaves, falling back to the KV backend rather than
 // handing out a broken handle.
 func storeUserStateFor(st store.Store) userstate.Store {
-	s, ok := st.(*pgstore.Store)
+	s, ok := st.(userStateProvider)
 	if !ok {
 		return nil
 	}

--- a/internal/appbuild/versionsweep_postgres.go
+++ b/internal/appbuild/versionsweep_postgres.go
@@ -33,13 +33,27 @@ func (p metaProjectionProvider) Projection() (hash string, projectionJSON []byte
 	return proj.Hash(), b
 }
 
-// startVersionSweepIfSupported starts the pgstore reconciliation sweep. In the
-// postgres build the store is a *pgstore.Store; a non-pgstore store (should not
-// happen in this build) is left unswept. The sweep cadence is taken from
-// sweepConfigFromEnv so a test/dev deployment can make create/update versions
-// appear quickly (production uses the zero-value defaults: 5m interval/idle).
+// versionSweeper is the capability startVersionSweepIfSupported needs: a store
+// that runs its own debounced reconciliation sweep to capture create/update
+// versions.
+//
+// NOTE: the signature still names pgstore types (ProjectionProvider,
+// SweepConfig), so in practice only pgstore can satisfy it — a second backend
+// would have to import pgstore, which is not real decoupling. Promoting those
+// two types into internal/store is the remaining half of this work and is
+// tracked separately. What is fixed here is that DISCOVERY no longer requires
+// being the one concrete type.
+type versionSweeper interface {
+	StartVersionSweep(provider pgstore.ProjectionProvider, cfg pgstore.SweepConfig)
+}
+
+// startVersionSweepIfSupported starts the store's reconciliation sweep. A store
+// without the capability (should not happen in this build) is left unswept. The
+// sweep cadence is taken from sweepConfigFromEnv so a test/dev deployment can
+// make create/update versions appear quickly (production uses the zero-value
+// defaults: 5m interval/idle).
 func startVersionSweepIfSupported(st store.Store, meta *metamodel.Metamodel) {
-	if s, ok := st.(*pgstore.Store); ok {
+	if s, ok := st.(versionSweeper); ok {
 		s.StartVersionSweep(metaProjectionProvider{meta: meta}, sweepConfigFromEnv())
 	}
 }
@@ -85,12 +99,22 @@ func sweepConfigFromEnv() pgstore.SweepConfig {
 	}
 }
 
-// versionServiceFor returns the pgstore versioning service (history reads, version
-// writes, purge) sharing the store's pool. Returns a genuinely nil interface for a
-// non-pgstore store (should not happen in this build), so nil-checks downstream
-// behave correctly.
+// versionServiceProvider is the capability versionServiceFor needs: a store that
+// can hand out a versioning service (history reads, version writes, purge)
+// sharing its own pool.
+//
+// NOTE: like versionSweeper, the return type is still pgstore-specific. See that
+// comment for why, and for what the remaining work is.
+type versionServiceProvider interface {
+	VersionStore() *pgstore.VersionStore
+}
+
+// versionServiceFor returns the store's versioning service (history reads,
+// version writes, purge) sharing its pool. Returns a genuinely nil interface for
+// a store without the capability (should not happen in this build), so
+// nil-checks downstream behave correctly.
 func versionServiceFor(st store.Store) store.VersionService {
-	if s, ok := st.(*pgstore.Store); ok {
+	if s, ok := st.(versionServiceProvider); ok {
 		return s.VersionStore()
 	}
 	return nil

--- a/internal/appbuild/versionsweep_postgres.go
+++ b/internal/appbuild/versionsweep_postgres.go
@@ -110,14 +110,28 @@ type versionServiceProvider interface {
 }
 
 // versionServiceFor returns the store's versioning service (history reads,
-// version writes, purge) sharing its pool. Returns a genuinely nil interface for
-// a store without the capability (should not happen in this build), so
-// nil-checks downstream behave correctly.
+// version writes, purge) sharing its pool. Returns a genuinely nil interface —
+// never a typed nil — both for a store without the capability and for one whose
+// handle came back nil, so nil-checks downstream behave correctly.
+//
+// The explicit nil-pointer guard is load-bearing, and it became necessary when
+// discovery widened from a concrete type to an interface. Asserting
+// st.(*pgstore.Store) bounded the reachable implementations to exactly one,
+// whose VersionStore() is unconditionally non-nil; an interface admits any
+// implementation, including one that returns a nil pointer on a partial-init
+// path. Boxing that into store.VersionService yields a NON-nil interface, so
+// versionRecorderFor (appbuild.go) and startDataMigration would both pass their
+// nil-checks and then panic on first use — at write time, in production.
 func versionServiceFor(st store.Store) store.VersionService {
-	if s, ok := st.(versionServiceProvider); ok {
-		return s.VersionStore()
+	s, ok := st.(versionServiceProvider)
+	if !ok {
+		return nil
 	}
-	return nil
+	vs := s.VersionStore()
+	if vs == nil {
+		return nil
+	}
+	return vs
 }
 
 // stateKVFor returns a database-backed [state.KV] sharing the store's pool, so
@@ -133,6 +147,14 @@ func versionServiceFor(st store.Store) store.VersionService {
 //
 // Returns a genuinely nil interface for a non-pgstore store so the caller's
 // nil-check falls back to the filesystem KV.
+//
+// NOT widened by TKT-415WA7, unlike the three resolvers above: discovery still
+// goes through pgstore.StateStoreFor, which type-asserts *pgstore.Store
+// internally. So a second backend gets version sweeps, user state and derived
+// schema by interface, then silently falls back to node-local FSKV for state.
+// That partial adoption is worse than none — it degrades quietly at runtime
+// rather than loudly at wiring — so it must be closed before a second backend
+// ships. Tracked in TKT-L3FNEN.
 func stateKVFor(st store.Store) state.KV {
 	raw := pgstore.StateStoreFor(st)
 	if raw == nil {

--- a/internal/appbuild/widen_assertions_postgres_test.go
+++ b/internal/appbuild/widen_assertions_postgres_test.go
@@ -1,0 +1,195 @@
+//go:build postgres
+
+package appbuild
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/Sourcehaven-BV/rela/internal/metamodel"
+	"github.com/Sourcehaven-BV/rela/internal/store"
+	"github.com/Sourcehaven-BV/rela/internal/store/memstore"
+	"github.com/Sourcehaven-BV/rela/internal/store/pgstore"
+	"github.com/Sourcehaven-BV/rela/internal/userstate"
+)
+
+// These tests pin TKT-415WA7: appbuild discovers optional store capabilities by
+// INTERFACE, not by asserting the concrete *pgstore.Store. Without them the
+// refactor is unverified — the resolvers would still compile if someone
+// reintroduced a concrete assertion, and the block would silently return.
+//
+// The fakes are deliberately NOT pgstore types. That is the whole point: if a
+// resolver only accepted *pgstore.Store, every "fake is wired" test below would
+// fail.
+
+// --- fakes ---------------------------------------------------------------
+
+// fakeStore embeds a real memstore so it satisfies store.Store without
+// hand-writing 26 methods; the capability methods are added by the wrappers
+// below. Embedding a genuine implementation also keeps the fakes honest — they
+// cannot accidentally diverge from the interface.
+type fakeStore struct{ store.Store }
+
+func newFakeStore(t *testing.T) fakeStore {
+	t.Helper()
+	return fakeStore{Store: memstore.New()}
+}
+
+type fakeUserStateStore struct {
+	fakeStore
+	called bool
+	err    error
+}
+
+func (f *fakeUserStateStore) UserState() (userstate.Store, error) {
+	f.called = true
+	if f.err != nil {
+		return nil, f.err
+	}
+	// A nil userstate.Store with a nil error is enough: the resolver's contract
+	// is about which handle it returns, not what the handle does.
+	return nil, nil //nolint:nilnil // exercising the resolver, not the backend
+}
+
+type fakeReconciler struct {
+	fakeStore
+	specsPublished []store.DerivedObjectSpec
+	reconcileCalls int
+	reconcileErr   error
+}
+
+func (f *fakeReconciler) SetUniqueSpecProvider(specs []store.DerivedObjectSpec) {
+	f.specsPublished = specs
+}
+
+func (f *fakeReconciler) Reconcile(
+	_ context.Context, desired []store.DerivedObjectSpec, _ store.ReconcileOptions,
+) ([]store.DerivedObjectOutcome, error) {
+	f.reconcileCalls++
+	if f.reconcileErr != nil {
+		return nil, f.reconcileErr
+	}
+	outcomes := make([]store.DerivedObjectOutcome, 0, len(desired))
+	for _, spec := range desired {
+		outcomes = append(outcomes, store.DerivedObjectOutcome{Spec: spec, State: store.DerivedCreated})
+	}
+	return outcomes, nil
+}
+
+type fakeSweeper struct {
+	fakeStore
+	started bool
+	gotCfg  pgstore.SweepConfig
+}
+
+func (f *fakeSweeper) StartVersionSweep(_ pgstore.ProjectionProvider, cfg pgstore.SweepConfig) {
+	f.started = true
+	f.gotCfg = cfg
+}
+
+// --- AC-3: a non-pgstore store satisfying the interfaces is wired identically
+
+func TestCapabilitiesDiscoveredByInterface_NotConcreteType(t *testing.T) {
+	// A nil metamodel is the simplest valid input here: uniqueSpecsFromMetamodel
+	// returns no specs for it, which exercises the discovery path (the thing
+	// under test) without dragging a schema fixture into a wiring test.
+	var meta *metamodel.Metamodel
+
+	t.Run("user state", func(t *testing.T) {
+		f := &fakeUserStateStore{fakeStore: newFakeStore(t)}
+		storeUserStateFor(f)
+		if !f.called {
+			t.Fatal("storeUserStateFor did not reach a non-pgstore store implementing UserState")
+		}
+	})
+
+	t.Run("derived schema reconciler", func(t *testing.T) {
+		f := &fakeReconciler{fakeStore: newFakeStore(t)}
+		reconcileDerivedSchemaIfSupported(t.Context(), f, meta)
+		if f.reconcileCalls != 1 {
+			t.Fatalf("Reconcile called %d times, want 1", f.reconcileCalls)
+		}
+	})
+
+	t.Run("version sweep", func(t *testing.T) {
+		f := &fakeSweeper{fakeStore: newFakeStore(t)}
+		startVersionSweepIfSupported(f, meta)
+		if !f.started {
+			t.Fatal("startVersionSweepIfSupported did not reach a non-pgstore store implementing StartVersionSweep")
+		}
+	})
+}
+
+// TestDerivedSchemaPublishesSpecsBeforeReconciling pins the ordering the
+// resolver's own comment calls out: specs are published FIRST so a violation of
+// an already-present index still maps to a property even when the reconcile
+// below degrades.
+func TestDerivedSchemaPublishesSpecsBeforeReconciling(t *testing.T) {
+	f := &fakeReconciler{
+		fakeStore:    newFakeStore(t),
+		reconcileErr: errors.New("reconcile unavailable"),
+	}
+	reconcileDerivedSchemaIfSupported(t.Context(), f, nil)
+
+	if f.reconcileCalls != 1 {
+		t.Errorf("Reconcile calls = %d, want 1", f.reconcileCalls)
+	}
+	// specsPublished is non-nil only if SetUniqueSpecProvider ran; a failing
+	// Reconcile must not prevent that, and must not panic.
+	if f.specsPublished == nil && len(f.specsPublished) != 0 {
+		t.Error("specs were not published before the failing reconcile")
+	}
+}
+
+// --- AC-4: the genuinely-nil contract -------------------------------------
+
+// TestResolversReturnUntypedNilWithoutCapability is the load-bearing negative
+// test. A TYPED nil (e.g. `var s *pgstore.Store; return s`) satisfies the
+// interface but compares != nil, which would silently defeat every downstream
+// fallback — the failure mode three separate doc comments in this package warn
+// about. Asserting on the interface value is the only way to catch it.
+func TestResolversReturnUntypedNilWithoutCapability(t *testing.T) {
+	plain := newFakeStore(t) // implements store.Store and nothing else
+
+	if got := storeUserStateFor(plain); got != nil {
+		t.Errorf("storeUserStateFor = %#v, want untyped nil so the KV fallback engages", got)
+	}
+	if got := versionServiceFor(plain); got != nil {
+		t.Errorf("versionServiceFor = %#v, want untyped nil so version recording is skipped", got)
+	}
+	if got := stateKVFor(plain); got != nil {
+		t.Errorf("stateKVFor = %#v, want untyped nil so the FSKV fallback engages", got)
+	}
+
+	// Must not panic, and must not start a sweep.
+	startVersionSweepIfSupported(plain, nil)
+	reconcileDerivedSchemaIfSupported(t.Context(), plain, nil)
+}
+
+// TestUserStateErrorYieldsUntypedNil covers the other typed-nil path: the
+// capability is present but fails. The resolver must still hand back an untyped
+// nil rather than an interface wrapping a broken handle.
+func TestUserStateErrorYieldsUntypedNil(t *testing.T) {
+	f := &fakeUserStateStore{fakeStore: newFakeStore(t), err: errors.New("pool exhausted")}
+	if got := storeUserStateFor(f); got != nil {
+		t.Errorf("storeUserStateFor = %#v on error, want untyped nil", got)
+	}
+}
+
+// --- AC-2: pgstore still satisfies every widened interface ----------------
+
+// TestPgstoreSatisfiesWidenedInterfaces is a compile-time assertion. If a future
+// change to pgstore's method set breaks one of these, the failure lands here
+// with a clear name rather than as a silently-skipped capability at runtime —
+// which is exactly how this class of bug hides.
+func TestPgstoreSatisfiesWidenedInterfaces(t *testing.T) {
+	var s *pgstore.Store
+	var (
+		_ userStateProvider       = s
+		_ derivedSchemaReconciler = s
+		_ versionSweeper          = s
+		_ versionServiceProvider  = s
+	)
+	t.Log("pgstore.Store satisfies all four widened capability interfaces")
+}

--- a/internal/appbuild/widen_assertions_postgres_test.go
+++ b/internal/appbuild/widen_assertions_postgres_test.go
@@ -5,6 +5,7 @@ package appbuild
 import (
 	"context"
 	"errors"
+	"slices"
 	"testing"
 
 	"github.com/Sourcehaven-BV/rela/internal/metamodel"
@@ -33,7 +34,9 @@ type fakeStore struct{ store.Store }
 
 func newFakeStore(t *testing.T) fakeStore {
 	t.Helper()
-	return fakeStore{Store: memstore.New()}
+	m := memstore.New()
+	t.Cleanup(func() { _ = m.Close() })
+	return fakeStore{Store: m}
 }
 
 type fakeUserStateStore struct {
@@ -57,16 +60,23 @@ type fakeReconciler struct {
 	specsPublished []store.DerivedObjectSpec
 	reconcileCalls int
 	reconcileErr   error
+
+	// calls records the method order. A bool pair cannot express "published
+	// BEFORE reconciling", and the published slice is legitimately empty for a
+	// metamodel with no unique properties — so its nilness proves nothing.
+	calls []string
 }
 
 func (f *fakeReconciler) SetUniqueSpecProvider(specs []store.DerivedObjectSpec) {
 	f.specsPublished = specs
+	f.calls = append(f.calls, "SetUniqueSpecProvider")
 }
 
 func (f *fakeReconciler) Reconcile(
 	_ context.Context, desired []store.DerivedObjectSpec, _ store.ReconcileOptions,
 ) ([]store.DerivedObjectOutcome, error) {
 	f.reconcileCalls++
+	f.calls = append(f.calls, "Reconcile")
 	if f.reconcileErr != nil {
 		return nil, f.reconcileErr
 	}
@@ -75,6 +85,20 @@ func (f *fakeReconciler) Reconcile(
 		outcomes = append(outcomes, store.DerivedObjectOutcome{Spec: spec, State: store.DerivedCreated})
 	}
 	return outcomes, nil
+}
+
+// fakeNilVersionStore has the capability but hands back a nil pointer — the
+// partial-init path a real backend could plausibly take. Boxing that into
+// store.VersionService is what produces a non-nil interface wrapping nil.
+type fakeNilVersionStore struct{ fakeStore }
+
+func (fakeNilVersionStore) VersionStore() *pgstore.VersionStore { return nil }
+
+// fakeNilUserState returns (nil, nil): no handle, no error.
+type fakeNilUserState struct{ fakeStore }
+
+func (fakeNilUserState) UserState() (userstate.Store, error) {
+	return nil, nil //nolint:nilnil // deliberately exercising the (nil, nil) contract hole
 }
 
 type fakeSweeper struct {
@@ -132,13 +156,15 @@ func TestDerivedSchemaPublishesSpecsBeforeReconciling(t *testing.T) {
 	}
 	reconcileDerivedSchemaIfSupported(t.Context(), f, nil)
 
-	if f.reconcileCalls != 1 {
-		t.Errorf("Reconcile calls = %d, want 1", f.reconcileCalls)
-	}
-	// specsPublished is non-nil only if SetUniqueSpecProvider ran; a failing
-	// Reconcile must not prevent that, and must not panic.
-	if f.specsPublished == nil && len(f.specsPublished) != 0 {
-		t.Error("specs were not published before the failing reconcile")
+	// Order is the assertion. An earlier draft tested
+	// `specsPublished == nil && len(specsPublished) != 0`, which is
+	// tautologically false for a slice (a nil slice has len 0) and so could
+	// never fail — a dead check masquerading as coverage.
+	want := []string{"SetUniqueSpecProvider", "Reconcile"}
+	if !slices.Equal(f.calls, want) {
+		t.Errorf("call order = %v, want %v (specs must be published before "+
+			"reconciling, so a violation of an existing index still maps to a "+
+			"property when reconcile degrades)", f.calls, want)
 	}
 }
 
@@ -158,6 +184,9 @@ func TestResolversReturnUntypedNilWithoutCapability(t *testing.T) {
 	if got := versionServiceFor(plain); got != nil {
 		t.Errorf("versionServiceFor = %#v, want untyped nil so version recording is skipped", got)
 	}
+	// stateKVFor is included for its nil contract only — NOT as evidence of
+	// interface parity. It still discovers via pgstore.StateStoreFor's internal
+	// concrete assertion (see its doc comment and TKT-L3FNEN).
 	if got := stateKVFor(plain); got != nil {
 		t.Errorf("stateKVFor = %#v, want untyped nil so the FSKV fallback engages", got)
 	}
@@ -165,6 +194,32 @@ func TestResolversReturnUntypedNilWithoutCapability(t *testing.T) {
 	// Must not panic, and must not start a sweep.
 	startVersionSweepIfSupported(plain, nil)
 	reconcileDerivedSchemaIfSupported(t.Context(), plain, nil)
+}
+
+// TestCapabilityPresentButHandleNilYieldsUntypedNil is the branch the
+// no-capability test CANNOT reach, and the one that actually regressed when
+// discovery widened from a concrete type to an interface.
+//
+// Asserting st.(*pgstore.Store) bounded the reachable implementations to one
+// whose VersionStore() is unconditionally non-nil. An interface admits any
+// implementation — so a nil pointer boxed into store.VersionService yields a
+// NON-nil interface, and every downstream nil-check silently passes before
+// panicking at write time.
+func TestCapabilityPresentButHandleNilYieldsUntypedNil(t *testing.T) {
+	t.Run("version service", func(t *testing.T) {
+		f := fakeNilVersionStore{fakeStore: newFakeStore(t)}
+		if got := versionServiceFor(f); got != nil {
+			t.Errorf("versionServiceFor = %#v, want untyped nil; a typed nil "+
+				"passes downstream nil-checks and panics on first use", got)
+		}
+	})
+
+	t.Run("user state", func(t *testing.T) {
+		f := fakeNilUserState{fakeStore: newFakeStore(t)}
+		if got := storeUserStateFor(f); got != nil {
+			t.Errorf("storeUserStateFor = %#v, want untyped nil", got)
+		}
+	})
 }
 
 // TestUserStateErrorYieldsUntypedNil covers the other typed-nil path: the
@@ -179,17 +234,14 @@ func TestUserStateErrorYieldsUntypedNil(t *testing.T) {
 
 // --- AC-2: pgstore still satisfies every widened interface ----------------
 
-// TestPgstoreSatisfiesWidenedInterfaces is a compile-time assertion. If a future
-// change to pgstore's method set breaks one of these, the failure lands here
-// with a clear name rather than as a silently-skipped capability at runtime —
+// Compile-time assertions, at file scope rather than wrapped in a func Test:
+// they cannot fail at runtime, so a test would only add a fake green line to
+// the report. If a change to pgstore's method set breaks one, the build fails
+// here — instead of the capability being silently skipped at wiring time,
 // which is exactly how this class of bug hides.
-func TestPgstoreSatisfiesWidenedInterfaces(t *testing.T) {
-	var s *pgstore.Store
-	var (
-		_ userStateProvider       = s
-		_ derivedSchemaReconciler = s
-		_ versionSweeper          = s
-		_ versionServiceProvider  = s
-	)
-	t.Log("pgstore.Store satisfies all four widened capability interfaces")
-}
+var (
+	_ userStateProvider       = (*pgstore.Store)(nil)
+	_ derivedSchemaReconciler = (*pgstore.Store)(nil)
+	_ versionSweeper          = (*pgstore.Store)(nil)
+	_ versionServiceProvider  = (*pgstore.Store)(nil)
+)

--- a/tickets/entities/decisions/DEC-LFSYNY.md
+++ b/tickets/entities/decisions/DEC-LFSYNY.md
@@ -1,0 +1,113 @@
+---
+id: DEC-LFSYNY
+type: decision
+title: Proceed with a SQLite store backend for single-process desktop, at pgstore's transaction tier
+context: 'rela had a large gap between fsstore (markdown files, full-graph residency, git for history) and pgstore (indexed, versioned, but needs a database server). A single-server or desktop deployment wants pgstore''s properties at fsstore''s operational cost. TKT-TWIO11 settled the driver (modernc.org/sqlite, pure Go, no CGO); RES-03TUXO recommended targeting single-process desktop; a throwaway spike then measured the Transactor semantics that could not be established from documentation, because the two relevant upstream issues (#192, #232) are open with no conclusive resolution.'
+consequences: 'GO. SQLite lands at pgstore''s transaction tier, not fsstore''s: real rollback and post-commit-only events, giving up only cross-process serialization. Accepted trade-offs: single-process only (enforced by an advisory lock, not documented and hoped for); no git-diffable markdown on this backend, with content versioning as the replacement per the precedent in docs/postgres-backend.md; synchronous=NORMAL means a crash can lose recently committed transactions; no custom FTS5 tokenizers ever; network/sync filesystems unsupported (unmeasured — no network storage available). Prerequisite: three *pgstore.Store concrete-type assertions in appbuild must be widened to interfaces before a third smart backend can opt into versioning, state or derived-schema.'
+date: "2026-08-23"
+status: accepted
+---
+
+## Decision
+
+Build a SQLite `store.Store` backend for **single-process desktop and
+single-server** deployments, using `modernc.org/sqlite`, at **pgstore's
+transaction tier**. Staged, with the concurrency gate now passed.
+
+## Evidence
+
+Measured on the throwaway spike (`spike/sqlite-tx-TKT-TWIO11`,
+`internal/store/sqlitespike/RESULTS.md`). Numbers, not adjectives.
+
+### The finding that mattered most
+
+**`busy_timeout` must be set via the DSN `_pragma=` parameter, not
+`db.Exec("PRAGMA ...")`.** A PRAGMA is per-connection: `db.Exec` configures
+whichever pooled connection serves that call and leaves every later connection
+at 0, while reading back correctly.
+
+| Configuration | Second writer (holder holds a 2s write tx) |
+|---|---|
+| `db.Exec("PRAGMA busy_timeout=5000")` | fails at **0.00s**, `SQLITE_BUSY` |
+| DSN `?_pragma=busy_timeout(5000)` | waits **2.05s**, succeeds |
+
+This reproduces upstream #192 exactly and plausibly explains #232 — mattn takes
+`_busy_timeout` in the DSN, so a straight port that moves it into `db.Exec`
+silently loses it. **Neither issue reproduced as a driver defect once the DSN
+form was used.** The risk that justified the whole spike turned out to be an
+application-side pooling mistake, which is a much better position than a driver
+we cannot fix.
+
+### Transactor semantics (AC-3)
+
+Arm A (4 connections, `BEGIN IMMEDIATE`), 30s soak: **31,106 counter commits,
+22,036 pair transactions**, clean sweep, no watchdog dump.
+
+The controls are what make this a measurement:
+
+- **Arm B (deferred) FAILS** — lock upgrade returns `SQLITE_BUSY` regardless
+of `busy_timeout`. `BEGIN IMMEDIATE` is load-bearing, not cargo-cult.
+- **Arm C (`MaxOpenConns(1)`) HANGS** — `database/sql` pool starvation, not a
+SQLite lock, reproduced in ~30 lines with no rela code. **Never serialize by
+shrinking the pool**; use a normal pool plus an in-process write mutex.
+- **Arm E: `RunTxRollbackTests` PASSES**, including `NoEventsOnRollback` and
+`EventsDeliveredAfterCommit` — the suite fsstore and memstore deliberately do
+not attempt.
+
+| | fsstore | **sqlite (measured)** | pgstore |
+|---|---|---|---|
+| Serialization | in-process mutex | **in-process mutex + SQLite write lock** | cross-process |
+| Rollback | none | **yes** | yes |
+| Events on rollback | n/a | **withheld** | withheld |
+
+### Performance (AC-5), 10k entities
+
+Cold open **2.23ms**; steady-state single write **127µs**; bulk load 223ms
+(44,749/sec). Cold open is the clearest win: fsstore parses and indexes all 10k
+markdown files at startup, which is the residency that motivated the
+investigation. The accepted ~1.5-1.9x modernc-vs-mattn write penalty is
+irrelevant at 22µs/entity — the driver choice does not gate this work.
+
+### Multi-process (AC-4)
+
+`unique:` is enforced by an **untransacted** `ListEntities` scan
+(`entitymanager/unique.go:82`; zero `.Tx(` sites in the package), so the race is
+not even multi-process-specific. A multi-process SQLite backend inheriting
+`reconcileDerivedSchemaIfSupported` as a no-op would have **no uniqueness
+backstop at all**. Separately, SQLite's own constraints ARE cross-connection: 8
+racers on one ID gave 1 winner, 7 `ErrConflict`, 0 other.
+
+This is why single-process is **enforced by an advisory lock**, not merely
+documented.
+
+## What we are accepting
+
+1. **Single-process only**, enforced at open. A second process must fail
+loudly rather than corrupt quietly.
+2. **No git-diffable markdown** on this backend. Content versioning is the
+replacement, exactly as `docs/postgres-backend.md:194` already frames it for
+pgstore. This is why versioning is *not optional* here.
+3. **`synchronous=NORMAL`** — a crash can lose recently committed
+transactions. A deliberate durability trade for a backend replacing git as the
+history story, revisit if it proves wrong.
+4. **No custom FTS5 tokenizers**, ever (modernc exposes no registration API).
+5. **Network/sync filesystems unsupported** — and this one is **assumed, not
+measured**: no network storage was available. Mitigation: `Open` already reads
+back the real `journal_mode`, so refuse to start (or warn loudly) when it is not
+`wal`. That converts a silent corruption risk into a clear error for the desktop
+user who puts a project in iCloud.
+
+## Prerequisite before any backend work
+
+`appbuild` discovers pgstore capabilities by **concrete-type assertion**
+(`derivedschema_postgres.go:23`, `userstate_postgres.go:27`,
+`versionsweep_postgres.go:42,93`), and `StateKV` is not a store interface at
+all. **These must be widened to interfaces first** — a third smart backend
+cannot otherwise opt into versioning, state or derived-schema. Independently
+valuable; easy to miss in an estimate.
+
+## Not licensed by this decision
+
+Multi-process SQLite, replacing pgstore for shared servers, FTS5 search
+integration, SQL pushdown, or `ManifestSince`. Each is a separate decision.
+Stage 2's effort is **unestimated until scoped**.

--- a/tickets/entities/docs-checklists/DOCS-4NYE03.md
+++ b/tickets/entities/docs-checklists/DOCS-4NYE03.md
@@ -1,0 +1,57 @@
+---
+id: DOCS-4NYE03
+type: docs-checklist
+title: 'Docs: Investigate SQLite as a third store backend (TKT-TWIO11)'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+**Investigation ticket — no user-facing change shipped.** The deliverable is
+DEC-LFSYNY plus the measurements in `internal/store/sqlitespike/RESULTS.md`.
+Items are marked N/A with a reason rather than silently ticked.
+
+## Code Documentation
+
+- [x] Package doc written — `internal/store/sqlitespike` opens by stating it is
+a THROWAWAY that answers one question, is not a backend, and lives on a branch
+that is never merged. That framing is the most important thing a reader needs.
+- [x] Non-obvious decisions explained at the point of use — the DSN-vs-`db.Exec`
+PRAGMA finding is documented in `Open` where the mistake would be made again,
+not in a separate note; `verifyBusyTimeout` explains why it pins two
+connections; the nested-`Tx` comment cites `pgstore/tx.go:61-63` and names the
+self-deadlock it prevents.
+- [x] Unimplemented methods say why — `errUnsupported` exists precisely so a
+spike cannot emit confident wrong evidence from a silent stub.
+- [x] Reproduction instructions — `RESULTS.md` ends with runnable commands,
+including the warning that arm C hangs by design and must be run under
+`timeout`.
+
+## Project Documentation
+
+- [x] ~~`docs/` guide~~ (N/A: nothing ships. A `docs/sqlite-backend.md`
+paralleling `postgres-backend.md` is scoped into TKT-G91TBK, including the
+single-writer constraint and the git-versus-version-history trade-off.)
+- [x] ~~`CLAUDE.md` backend table row + build-tag rules~~ (N/A: no backend
+exists yet. Scoped into TKT-G91TBK, together with the CI backend-isolation
+assertions.)
+- [x] ~~`README.md` backend selection guidance~~ (N/A: same reason.)
+- [x] Decision recorded where the project looks for decisions — DEC-LFSYNY,
+with measurements rather than adjectives, and an explicit "not licensed by this
+decision" section so it cannot be read as approving multi-process SQLite or a
+desktop-default switch.
+
+## Knowledge Capture
+
+- [x] Findings that would otherwise be rediscovered are written into the
+follow-up ticket, not left in a branch. TKT-G91TBK carries a "do not rediscover"
+list: DSN PRAGMAs, `BEGIN IMMEDIATE`, never shrink the pool to serialize,
+nested-`Tx` shape, and `storeutil` as the validity oracle.
+- [x] The unmeasured gap is documented as unmeasured — arm F (WAL on network
+filesystems) is recorded in RESULTS.md, the review checklist and the ticket body
+as **assumed, not verified**, with the ready-made probe command and a concrete
+startup-guard mitigation in TKT-G91TBK.
+- [x] Design-review value captured — PLAN-ZLVJC3 records that C1 (module layout
+could not compile) and C3 (primary arm made the risk unobservable) were caught
+before implementation, and that C3 was then confirmed in execution when arm C
+hung.

--- a/tickets/entities/implementation-checklists/IMPL-BB3OA5.md
+++ b/tickets/entities/implementation-checklists/IMPL-BB3OA5.md
@@ -1,0 +1,88 @@
+---
+id: IMPL-BB3OA5
+type: implementation-checklist
+title: 'Implementation: appbuild: widen the three *pgstore.Store concrete-type assertions to interfaces'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+Branch: `refactor/appbuild-widen-assertions-TKT-415WA7` · commit `caa2923b`.
+
+## Development
+
+- [x] Unit tests written for new code — `widen_assertions_postgres_test.go`
+- [x] Integration tests written — the existing appbuild wiring suite and the
+pgstore conformance suite both run against a **live database** here
+(`RELA_TEST_DATABASE_URL` pointed at a local `rela_test_twio`), so AC-2 is
+verified rather than skipped.
+- [x] Happy path implemented — all four assertion sites converted
+- [x] Edge cases from planning handled — untyped-nil contract, partial
+implementation, `UserState()` error path, `ErrReconcileBusy` still Debug-level
+- [x] Error handling in place — resolver bodies below the assertion are
+unchanged, so log levels and error paths are untouched
+
+## Test Quality
+
+- [x] Using fixture builders or factories for test data — fakes embed a real
+`memstore` so they satisfy `store.Store` without hand-writing 26 methods, and
+cannot silently diverge from the interface
+- [x] No hardcoded values in assertions when object is in scope
+- [x] Only specifying values that matter — each fake implements exactly one
+capability, which is what proves the interfaces are independent
+- [x] Interpolated values constructed from objects, not hardcoded
+- [x] Property comparisons use original object, not hardcoded strings
+
+## Manual Verification
+
+- [x] Feature manually tested end-to-end
+- [x] Each acceptance criterion verified with test scenario from planning
+- [x] Edge cases manually verified
+
+**Verification Evidence:**
+
+| AC | Verdict | Evidence |
+|----|---------|----------|
+| 1 — no `st.(*pgstore.Store)` in appbuild | **PASS** | `grep` returns nothing across all four sites |
+| 2 — pgstore behaviour unchanged | **PASS** | Against a live DB: `internal/appbuild` 3.2s, `appbuildtest` 0.7s, `backendtest` 1.0s, `pgstore` 28.6s — all ok |
+| 3 — non-pgstore store wired identically | **PASS** | `TestCapabilitiesDiscoveredByInterface_NotConcreteType` — three fakes, none a pgstore type, all reached |
+| 4 — untyped-nil contract holds | **PASS** | `TestResolversReturnUntypedNilWithoutCapability` + `TestUserStateErrorYieldsUntypedNil` |
+| 5 — arch-lint + all build tags | **PASS** | arch-lint "OK - No warnings found"; default / `memorybackend` / `postgres` all build; `golangci-lint` 0 issues, including `--build-tags postgres` |
+
+**The AC-3 test is not vacuous — verified by deliberate regression.** I restored
+the old `st.(*pgstore.Store)` assertion in `storeUserStateFor` and re-ran:
+
+```
+--- FAIL: TestCapabilitiesDiscoveredByInterface_NotConcreteType/user_state
+    storeUserStateFor did not reach a non-pgstore store implementing UserState
+```
+
+Then reverted. Without that check the test would pass whether or not the
+refactor worked, which is the usual way a refactor test provides false comfort.
+
+**A useful signal fell out of the change:** `userstate_postgres.go` no longer
+imports pgstore at all. That file is now genuinely backend-neutral.
+`derivedschema_postgres.go` retains the import only for the `errors.Is(err,
+pgstore.ErrReconcileBusy)` sentinel — far weaker coupling than a type assertion.
+
+**Partial by design, and filed as TKT-L3FNEN.** `versionSweeper` and
+`versionServiceProvider` still name pgstore types (`ProjectionProvider`,
+`SweepConfig`, `*VersionStore`), so only pgstore can satisfy them in practice.
+Discovery is unblocked; the signatures are not yet neutral. This is stated in
+the code comments, the commit message and the follow-up ticket so "no concrete
+assertions remain" cannot be misread as "backend-neutral".
+
+## Quality
+
+- [x] Code follows project patterns — consumer-side interfaces at the call
+site, per CLAUDE.md and the existing `HistoryReader` / `Formatter` /
+`TypeWatermark` precedent
+- [x] Checked for DRY opportunities — four separate interfaces rather than one
+umbrella, deliberately: a store implementing `UserState()` but not `Reconcile`
+must get one and skip the other, which an umbrella would prevent
+- [x] No security issues introduced — compile-time discovery change only; no
+new input, no new parsing; `state.NewValidatedKV` still wraps the raw KV
+- [x] No silent failures — the untyped-nil contract is now pinned by tests
+rather than only by doc comments
+- [x] No debug code left behind — `go.mod` re-tidied to drop the
+`modernc.org/sqlite` dependency carried over from the spike branch

--- a/tickets/entities/implementation-checklists/IMPL-IXY9N5.md
+++ b/tickets/entities/implementation-checklists/IMPL-IXY9N5.md
@@ -1,0 +1,135 @@
+---
+id: IMPL-IXY9N5
+type: implementation-checklist
+title: 'Implementation: Investigate SQLite as a third store backend for single-server and desktop deployments'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+**This ticket is investigation-only.** The "implementation" is a throwaway spike
+whose only product is evidence (see PLAN-ZLVJC3). Items about shipping code are
+marked N/A with a reason rather than silently ticked.
+
+Branch: `spike/sqlite-tx-TKT-TWIO11` — **never merge**. Raw numbers:
+`internal/store/sqlitespike/RESULTS.md`.
+
+## Development
+
+- [x] Unit tests written for new code
+- [x] Integration tests written (test full flow, not just units) — the spike
+runs the SHARED conformance harness (`storetest.RunTxStressTest`,
+`RunTxRollbackTests`, 4 fuzz targets) rather than bespoke tests, which is the
+point: it measures against the real contract.
+- [x] Happy path implemented — the `store.Store` subset the Tx tests exercise
+- [x] Edge cases from planning handled — nested Tx joins without a pool
+acquire (`pgstore/tx.go:61-63` shape); `journal_mode` return value checked, not
+assumed; fuzz temp-dir lifecycle; ctx-cancellation rollback via
+`context.WithoutCancel`
+- [x] Error handling in place — every unimplemented method returns
+`errUnsupported` loudly. A silent stub in a spike produces confident, wrong
+evidence, so none were used.
+
+## Test Quality
+
+- [x] Using fixture builders or factories for test data — `storetest.Factory` /
+`FuzzFactory`, plus a table-driven `arms()` matrix
+- [x] No hardcoded values in assertions when object is in scope
+- [x] Only specifying values that matter for the test — each arm varies ONLY
+pool size, Tx mode and event mode; everything else is held constant, which is
+what makes B a valid control for A
+- [x] Interpolated values constructed from objects, not hardcoded
+- [x] Property comparisons use original object, not hardcoded strings
+
+## Manual Verification
+
+- [x] Feature manually tested end-to-end
+- [x] Each acceptance criterion verified with test scenario from planning
+- [x] Edge cases manually verified
+
+**Verification Evidence:**
+
+**Headline finding — `busy_timeout` must come from the DSN, not `db.Exec`.** A
+PRAGMA is per-connection, so `db.Exec` configures one pooled connection and
+leaves the rest at 0 — while reading back correctly. Measured with a holder
+keeping a write tx open 2s:
+
+| Configuration | Second writer |
+|---|---|
+| `db.Exec("PRAGMA busy_timeout=5000")` | fails at **0.00s**, SQLITE_BUSY |
+| DSN `?_pragma=busy_timeout(5000)` | waits **2.05s**, succeeds |
+
+Reproduces upstream #192, and plausibly explains #232 (mattn takes
+`_busy_timeout` in the DSN, so a straight port loses it). **Neither reproduced
+as a driver bug once the DSN form was used.** Guarded by `verifyBusyTimeout`,
+which pins two connections open at once and asserts both agree.
+
+**AC-3 — PASSES.** Arm A (4 conns, `BEGIN IMMEDIATE`) at 30s: **31,106 counter
+commits, 22,036 pair txs**, final sweep clean, no watchdog dump. Controls make
+it a measurement rather than an assumption:
+
+| Arm | Result |
+|---|---|
+| A — 4 conns, IMMEDIATE | PASS (30s soak) |
+| B — 4 conns, deferred | **FAIL**: `counter tx: update STRS-CTR: database is locked (5)` → `BEGIN IMMEDIATE` is load-bearing |
+| C — `MaxOpenConns(1)` | **HANGS** — `database/sql` pool starvation, NOT a SQLite lock; reproduced in ~30 lines with no rela code |
+| D — ship shape, inline events | PASS — 3,451 commits |
+| E — `RunTxRollbackTests` | **PASS**, incl. `NoEventsOnRollback` + `EventsDeliveredAfterCommit` |
+
+Arm C retroactively vindicates design-review finding C3: had it stayed primary
+as first planned, the spike would have hung and been misread as "modernc's
+locking is broken" — the opposite of the evidence.
+
+**Arm E is the material surprise.** SQLite gives the STRONG Tx contract free.
+Under DEC-8UIL0 a SQLite backend sits at **pgstore's tier, not fsstore's**,
+giving up only cross-process serialization.
+
+**AC-4 — answered.** (a) `unique:` is an untransacted `ListEntities` scan
+(`entitymanager/unique.go:82`, zero `.Tx(` sites in the package), so the race is
+not even multi-process-specific; a multi-process SQLite backend inheriting the
+`!postgres` no-op would have NO uniqueness backstop. (b) 8 racers on one ID →
+**1 winner, 7 `ErrConflict`, 0 other**: SQLite's own constraints ARE
+cross-connection; the application scan is not.
+
+**AC-5 — passes with large margin** (10k entities, local APFS):
+
+| | Measured | Gate |
+|---|---|---|
+| Cold open | **2.23ms** | <1s (~450x) |
+| Steady-state write | **127µs** | <50ms (~390x) |
+| Bulk load | 223ms (44,749/s) | not gated |
+
+Cold open is the clearest win over fsstore, which parses and indexes all 10k
+markdown files at startup — the residency that motivated the investigation.
+
+**Fuzz — 4/4 pass, 68k execs, and one found a REAL gap.**
+`FuzzRelationKeyCollision` seed #4 failed initially: `CreateRelation` accepted
+an empty relation type because the spike skipped
+`storeutil.ValidateRelationType`. Fixed. Evidence that the conformance harness
+earns its keep — a hand-written store WILL miss validation the oracle enforces.
+
+**AC-6 — `synchronous=NORMAL`** is recorded as a durability decision, not a
+knob: in WAL it means a crash can lose recently committed transactions, which
+matters for a backend whose purpose is replacing git as the history story.
+
+**Arm F — NOT RUN.** No network storage available (operator decision,
+2026-08-23). Carried forward as an **accepted, unmeasured limitation**, not a
+result. `TestJournalMode` honours `RELA_SPIKE_DB_DIR` and is ready to run if a
+mount appears.
+
+## Quality
+
+- [x] Code follows project patterns — Tx shape from `pgstore/tx.go`, graph
+query delegated to `graphquerynaive` exactly as fsstore does, `storeutil`
+validators used as the oracle
+- [x] Checked for DRY opportunities — one `querier` seam serves both pooled and
+tx-bound execution so method bodies are not duplicated; `buildRelationQuery` is
+shared by list and count so filter semantics cannot drift
+- [x] No security issues introduced — spike takes no untrusted input;
+parameterized SQL throughout; no credential handling (SQLite has no DSN secret)
+- [x] No silent failures — unimplemented methods return `errUnsupported`;
+`verifyBusyTimeout` converts a silent misconfiguration into a startup error
+- [x] No debug code left behind
+- [x] ~~Shipping code reviewed for production readiness~~ (N/A: throwaway
+spike, build-tag gated, never merged; default build verified unaffected via `go
+build ./...`)

--- a/tickets/entities/planning-checklists/PLAN-V0003S.md
+++ b/tickets/entities/planning-checklists/PLAN-V0003S.md
@@ -1,0 +1,266 @@
+---
+id: PLAN-V0003S
+type: planning-checklist
+title: 'Planning: appbuild: widen the three *pgstore.Store concrete-type assertions to interfaces'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Understanding
+
+- [x] Problem/requirements clearly understood
+- [x] Scope defined (what's in/out documented below)
+- [x] Acceptance criteria documented with specific test scenarios
+
+**Scope:**
+
+Four `st.(*pgstore.Store)` concrete-type assertions in `internal/appbuild` make
+pgstore capabilities undiscoverable by any other backend. Replace them with
+consumer-side interfaces, per the pattern the codebase already uses everywhere
+else (`HistoryReader`, `Formatter`, `TypeWatermark` are all interface-asserted
+at the wiring site).
+
+IN scope — the four sites:
+
+| Site | Capability |
+|---|---|
+| `derivedschema_postgres.go:23` | `SetUniqueSpecProvider` + `Reconcile` |
+| `userstate_postgres.go:27` | `UserState()` |
+| `versionsweep_postgres.go:42` | `StartVersionSweep` |
+| `versionsweep_postgres.go:93` | `VersionStore()` |
+
+Plus `pgstore.StateStoreFor` (`statekv.go:72`), which performs the same concrete
+assertion internally on behalf of `stateKVFor`.
+
+NOT in scope:
+
+- Implementing any capability for a new backend. This removes the structural
+block only.
+- Changing behaviour. The postgres build must be behaviourally identical.
+- Adding accessor methods to `pgstore.Store` — see the risk table; its plimsoll
+load line explicitly warns against exactly that.
+
+**Acceptance Criteria:**
+
+1. **No `st.(*pgstore.Store)` remains in `internal/appbuild`.** Test: `grep`
+returns nothing; verified in CI-visible form by the assertion being gone from
+all four sites.
+2. **pgstore behaviour unchanged.** Test: the postgres conformance suite and
+the appbuild wiring tests pass against a real database (`RELA_TEST_DATABASE_URL`
+is available in this environment — verified, the suite runs rather than skips).
+3. **A non-pgstore store satisfying the interfaces is wired identically.**
+Test: a fake implementing the new interfaces, asserted through the same
+resolvers, receives the same calls. This is the criterion that actually proves
+the block is gone; without it the refactor is unverified.
+4. **The nil-fallback contract still holds.** Test: a store implementing none
+of the interfaces yields a genuinely nil interface (not a typed nil), so callers
+fall back to FSKV / in-memory user state. A typed nil would silently defeat
+every `!= nil` check downstream.
+5. `just arch-lint` clean; `go build` for default, `memorybackend` and
+`postgres` tags.
+
+## Research
+
+- [x] For larger features: run `/research` — N/A, RES-03TUXO already covers it
+- [x] Searched for existing libraries that solve this problem
+- [x] Checked codebase for similar patterns or reusable code
+- [x] Looked for reference implementations in other projects
+- [x] Reviewed relevant rela concepts for prior art
+
+**Research Doc:** RES-03TUXO — identified these assertions as the structural
+prerequisite for a third smart backend.
+
+**Existing Solutions:**
+
+The pattern to copy is already in-tree, which is what makes this low-risk:
+
+- **`store.VersionService`** (`store.go:909-916`) — an umbrella interface used
+purely as a wiring vehicle, returning nil on non-pg builds. `versionServiceFor`
+already RETURNS an interface; only its discovery is concrete.
+- **Optional capabilities asserted as interfaces**: `HeaderReader`
+(`store.go:474`), `Formatter` (`cli/fmt.go:20`), `TypeWatermark`
+(`dataentry/caldav_backend.go:660`).
+- **Consumer-side interface declaration** is the documented house rule
+(CLAUDE.md; `dataentry/sync.go:17` `manifestProvider` is the model).
+- **The genuinely-nil contract** is spelled out in `userstate_nostore.go:16`
+and `versionsweep_nosweep.go:20,26` — preserve it verbatim.
+
+## Approach
+
+- [x] Technical approach chosen and documented
+- [x] Approach builds on existing patterns (not reinventing)
+- [x] Alternatives considered (document why rejected)
+- [x] Dependencies identified (packages, APIs, types)
+
+**Technical Approach:**
+
+Declare consumer-side interfaces in `internal/appbuild` (the consumer), assert
+against those, and let pgstore satisfy them structurally with **no change to
+pgstore at all**. That last point is the crux: `pgstore.Store` carries
+`//plimsoll:max-exported-methods=38` plus an explicit warning that a third
+capability accessor "should not raise these numbers again", so this refactor
+must not add methods there.
+
+Four interfaces, each named for what the consumer needs:
+
+```go
+// derivedSchemaReconciler — derivedschema_postgres.go
+type derivedSchemaReconciler interface {
+    SetUniqueSpecProvider(specs []store.DerivedObjectSpec)
+    Reconcile(ctx context.Context, desired []store.DerivedObjectSpec,
+        opts store.ReconcileOptions) ([]store.DerivedObjectOutcome, error)
+}
+
+// userStateProvider — userstate_postgres.go
+type userStateProvider interface {
+    UserState() (userstate.Store, error)
+}
+
+// versionServiceProvider — versionsweep_postgres.go
+type versionServiceProvider interface {
+    VersionStore() *pgstore.VersionStore   // see note below
+}
+
+// versionSweeper — versionsweep_postgres.go
+type versionSweeper interface {
+    StartVersionSweep(provider pgstore.ProjectionProvider, cfg pgstore.SweepConfig)
+}
+```
+
+**Two of these still name pgstore types, and that is a deliberate limit of this
+ticket.** `StartVersionSweep` takes `pgstore.ProjectionProvider` and
+`pgstore.SweepConfig`; `VersionStore()` returns `*pgstore.VersionStore`. A
+second backend could satisfy them only by importing pgstore, which is not
+genuine decoupling. Fully generalising means promoting those types into
+`internal/store` — a larger, separate change touching pgstore's public API.
+
+What this ticket delivers is nonetheless the load-bearing half: **discovery is
+no longer welded to one concrete type**, the files stay build-tagged so nothing
+non-postgres links pgstore, and the remaining coupling is now visible in an
+interface signature instead of hidden in a type assertion. The residual is
+recorded as a follow-up rather than pretended away.
+
+`stateKVFor` keeps calling `pgstore.StateStoreFor`, whose internal assertion is
+pgstore's own business (it is documented there as a deliberate alternative to a
+`Store` method, for the same plimsoll reason). Widening it is the same
+promote-the-types problem; noted in the follow-up.
+
+**Files to modify:**
+
+- `internal/appbuild/derivedschema_postgres.go` — interface + assertion
+- `internal/appbuild/userstate_postgres.go` — interface + assertion
+- `internal/appbuild/versionsweep_postgres.go` — two interfaces + assertions
+- `internal/appbuild/widen_assertions_postgres_test.go` — NEW: fake-backed test
+proving a non-pgstore type is wired identically (AC-3) and that a store
+implementing nothing yields untyped nil (AC-4)
+
+## Security Considerations
+
+- [x] Input sources identified (user input, config, external APIs)
+- [x] Input validation approach defined (allowlist preferred over blocklist)
+- [x] Security-sensitive operations identified (file access, auth, crypto)
+- [x] Error handling doesn't leak sensitive information
+
+**Input Sources & Validation:** None. This is a compile-time discovery change;
+no new input reaches the process, no wire format changes, no new parsing.
+
+**Security-Sensitive Operations:**
+
+- **`state.NewValidatedKV` must keep wrapping the raw KV.** It applies the key
+rules FSKV gets from RootedFS; dropping it would let a caller write arbitrary
+keys. Untouched here, and the test asserts the wrapper is still applied.
+- **No ACL surface.** Read gating lives in `internal/visibility` decorators at
+the wiring site, never in the store (DEC-ZBI39P).
+- **Widening does not widen privilege.** An interface assertion admits a type
+that implements the methods; it does not grant a capability the store did not
+already have. The capabilities remain per-build via the existing tags.
+
+## Test Plan
+
+- [x] Test scenarios documented for each acceptance criterion
+- [x] Edge cases identified and documented
+- [x] Negative test cases defined (invalid input, error conditions)
+- [x] Integration test approach defined (not just unit tests)
+
+**Test Scenarios:**
+
+| AC | Scenario | Pass condition |
+|----|----------|----------------|
+| 1 | `grep -rn 'st\.(\*pgstore\.Store)' internal/appbuild` | no matches |
+| 2 | `go test -tags postgres ./internal/store/pgstore/ ./internal/appbuild/...` against a live DB | all pass, unchanged |
+| 3 | Fake implementing `derivedSchemaReconciler` / `userStateProvider` / `versionServiceProvider` / `versionSweeper`, passed to each resolver | each resolver calls through to the fake |
+| 4 | A bare `store.Store` (memstore) passed to each resolver | returns are `== nil` as an INTERFACE, not a typed nil |
+| 5 | `just arch-lint`; build all three tags | clean |
+
+**Edge Cases:**
+
+- **Typed-nil trap.** `var s *pgstore.Store; return s` satisfies the interface
+but is `!= nil`. The tests assert `got == nil` on the interface value
+specifically — this is the failure mode the existing doc comments warn about
+three separate times, so it deserves a test rather than a comment.
+- **Partial implementation.** A store implementing `UserState()` but not
+`Reconcile` must get user-state wiring and skip derived-schema. Separate
+interfaces (not one umbrella) is what makes this work.
+- **`UserState()` returning an error** must still yield untyped nil so the
+caller falls back, rather than a non-nil interface wrapping a broken handle.
+- **`Reconcile` returning `ErrReconcileBusy`** must remain a Debug-level
+non-failure, not a warning.
+- **memstore/fsstore under the postgres tag** — the "should not happen" path;
+must skip silently, not panic.
+
+**Negative Tests:**
+
+- Store implementing none of the interfaces → every resolver returns nil and
+the FSKV / in-memory fallbacks engage.
+- Sweep never started for a store lacking `StartVersionSweep`.
+
+## Risk Assessment
+
+- [x] Technical risks assessed with mitigations
+- [x] Security risks assessed (see Security Considerations)
+- [x] Effort estimated (xs/s/m/l/xl)
+
+**Risks:**
+
+| Risk | Likelihood | Mitigation |
+|------|-----------|------------|
+| Typed nil silently defeats every downstream nil-check | Medium | Explicit tests on the interface value; the existing doc comments already flag it, now pinned by assertions |
+| Temptation to add accessor methods to `pgstore.Store` | Medium | Forbidden: its plimsoll line says a third capability accessor "should not raise these numbers again". Interfaces are declared consumer-side; **pgstore is not modified at all** |
+| Refactor looks complete but coupling remains via pgstore types in signatures | **High** | Stated plainly in the Approach and filed as a follow-up. Do NOT let this ticket claim full decoupling |
+| Postgres tests skipped, so AC-2 unverified | Low | A local postgres is running and `rela_test_twio` is created; the suite was confirmed to RUN (13.2s) rather than skip before starting |
+| Behaviour drift in log levels / error paths | Low | Resolver bodies are unchanged below the assertion; only the discovery line changes |
+
+**Effort:** m — four small mechanical changes plus a genuinely new test file.
+The care is in the nil semantics and in not overstating the outcome.
+
+## Documentation Planning
+
+- [x] User-facing docs identified (skip if internal refactor)
+- [x] Docs-checklist will be created when entering implementation
+
+**Documentation Impact:**
+
+- [x] N/A — internal refactor, no user-facing behaviour change. The doc
+comments at each site are updated in place to say "a store that implements X"
+instead of "a *pgstore.Store", since those comments currently assert the
+concrete type as a fact.
+
+## Design Review
+
+- [x] Run `/design-review` before starting implementation
+- [x] All critical/significant findings addressed in plan
+
+**Design Review Findings:**
+
+Self-reviewed against the codebase before implementation; the prior ticket's
+external review surfaced the two traps already folded in above:
+
+1. **Do not add methods to `pgstore.Store`** — its plimsoll directive and the
+`StateStoreFor` doc comment both warn that capability accessors re-invite the
+pattern being removed. Resolved: interfaces declared consumer-side, pgstore
+untouched.
+2. **Do not overclaim.** Two interfaces still name pgstore types, so a second
+backend cannot satisfy them without importing pgstore. Resolved by stating the
+residual explicitly in the Approach and filing it as a follow-up rather than
+letting "no concrete assertions remain" imply full decoupling.

--- a/tickets/entities/planning-checklists/PLAN-ZLVJC3.md
+++ b/tickets/entities/planning-checklists/PLAN-ZLVJC3.md
@@ -1,0 +1,468 @@
+---
+id: PLAN-ZLVJC3
+type: planning-checklist
+title: 'Planning: Investigate SQLite as a third store backend for single-server and desktop deployments'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Understanding
+
+- [x] Problem/requirements clearly understood
+- [x] Scope defined (what's in/out documented below)
+- [x] Acceptance criteria documented with specific test scenarios
+
+**Scope:**
+
+This ticket remains **investigation-only**. Its two unanswered acceptance
+criteria (3: precise `Transactor` semantics; 4: the change-feed decision) cannot
+be answered honestly from documentation alone — the research named modernc's
+locking behaviour as the highest-risk unknown, backed by two open upstream
+issues. So the remaining work is a **throwaway spike** whose sole output is
+evidence, plus the decision entity that closes the ticket.
+
+IN scope:
+
+- A throwaway SQLite store at `internal/store/sqlitespike/` behind a
+`//go:build sqlitespike` tag, on a branch that is **never merged**, implementing
+the subset of `store.Store` the Tx contract tests exercise.
+- Running `storetest.RunTxStressTest` across six configuration arms, the six
+fuzz targets, and `RunTxRollbackTests`.
+- A ~60-line sidecar-file advisory lock (the only surviving path to a positive
+AC-4 — see the Approach section).
+- Three separate performance measurements: cold open, steady-state single
+write, bulk load.
+- A `decision` entity recording the outcome, linked via `informs`.
+- An implementation ticket (or a no-go note) with a grounded estimate.
+
+NOT in scope:
+
+- **Merging anything to `develop`.** This is the isolation invariant — not
+"nothing under `internal/`", which was the earlier phrasing and which forced a
+module layout that does not compile.
+- The stage-2 interface-widening refactor of the three `*pgstore.Store`
+assertions. That is real production work and belongs to the implementation
+ticket.
+- FTS5 search integration, SQL pushdown, versioning implementation.
+- `PRAGMA optimize` / query-planner tuning — explicitly not measured here.
+- Migration tooling between backends.
+
+**Acceptance Criteria:**
+
+Restating the ticket's open criteria with concrete test scenarios. Criteria 1,
+2, 5 and 6 are already satisfied by RES-03TUXO; criterion 2 (driver) was met on
+2026-08-22.
+
+1. **(AC-3) `Transactor` semantics stated precisely, alongside fs and pg.**
+Test: arm A (multi-connection, `BEGIN IMMEDIATE`) passes
+`storetest.RunTxStressTest` at `RELA_STRESS_SECONDS=30` with zero watchdog
+deadlock dumps, zero lost updates, and pair-atomicity holding. Output is a
+three-row table (fs / sqlite / pg) covering serialization scope, rollback and
+event timing — **footnoted with what the stress test does not cover**
+(attachments, `RenameEntity`, `Close` under an open Tx, ctx cancellation), so
+the decision entity cannot overclaim.
+
+2. **(AC-4) Change-feed decision explicit.** The earlier formulation — "show
+a second process violating the `unique:` invariant" — was **unrunnable**, and
+verifying that is itself the finding. `unique:` is enforced in
+`entitymanager/unique.go:82` by a full `ListEntities` scan, and there are **zero
+`.Tx(` call sites in `internal/entitymanager`** (verified), so the scan and the
+subsequent write are not transactional. A bare `store.Store` spike has no
+`unique:` logic to violate. Replaced by two constructible pieces:
+
+   - **(a) A code-level argument, already complete and stronger than a demo.**
+Because scan-then-write is untransacted, the race is not SQLite-specific and not
+even multi-process-specific — two goroutines in one process can already
+interleave. What multi-process removes is the in-process `txMu` that currently
+keeps the window narrow. Therefore a multi-process SQLite backend inheriting
+`reconcileDerivedSchemaIfSupported` as a no-op would have `unique:` enforcement
+**with no backstop whatsoever**. Recorded in the decision entity with citations;
+needs no experiment.
+   - **(b) A runnable store-layer experiment:** two processes both
+`CreateEntity` with the same ID; assert `store.ErrConflict` is returned exactly
+once. This tests SQLite's own `PRIMARY KEY` constraint across processes, which
+should pass — an honest and useful finding, since it shows SQLite's
+*constraints* are cross-process while the *application scan* is not.
+
+3. **(AC-5) Performance — three measurements, not one.** The earlier single
+comparison (10k bulk insert vs. fsstore's index build) compared two different
+operations and gated on the wrong axis.
+   - **Cold open**: SQLite open vs. fsstore's startup index build. SQLite
+should win decisively — avoiding full-graph residency is the stated motivation.
+   - **Steady-state single write**: one `BEGIN IMMEDIATE`/insert/commit. This
+is the interactive path and the number that actually matters.
+   - **Bulk load**: 10k entities in one transaction vs. fsstore writing 10k
+markdown files (the comparable operation).
+
+No pass/fail gate on bulk load — TKT-TWIO11 §3 already accepted modernc is
+~1.5-1.9x slower than mattn there. The gate is on cold open and steady-state
+write.
+
+4. **(AC-6) The `synchronous=NORMAL` durability trade recorded as a decision**,
+not left as a tuning knob: in WAL mode it means a crash can lose recently
+committed transactions, which matters for a backend whose purpose is replacing
+git as the durability and history story.
+
+5. **Go/no-go recorded as a decision entity** with the measured numbers, not
+adjectives.
+
+## Research
+
+- [x] For larger features: run `/research` to create a structured research doc
+- [x] Searched for existing libraries that solve this problem
+- [x] Checked codebase for similar patterns or reusable code
+- [x] Looked for reference implementations in other projects
+- [x] Reviewed relevant rela concepts for prior art
+
+**Research Doc:** RES-03TUXO (done) — recommends Option C staged, with this
+spike as stage 1 and an explicit go/no-go gate.
+
+**Existing Solutions:**
+
+- **Driver**: `modernc.org/sqlite` v1.57.0 chosen over `mattn/go-sqlite3`;
+settled in TKT-TWIO11 §3 with empirical verification. Pure Go, FTS5/JSON1/
+R-tree compiled in unconditionally, all six release targets cross-compile at
+`CGO_ENABLED=0`.
+- **Conformance harness**: `internal/store/storetest` — `RunAll` +
+`RunTxStressTest` + six fuzz targets. `Capabilities` has exactly one field
+(`Attachments`), so almost nothing is opt-out.
+- **Template to copy**: `internal/store/memstore/conformance_test.go` (~70
+lines) is the minimal wiring template.
+- **Weak-Tx reference impl**: `internal/store/fsstore/tx.go:31-42` — `txMu`
+mutex, `lockTx()` helper, every exported write a `defer s.lockTx()()` one-liner.
+The spike's Tx should start from this shape and add `BEGIN IMMEDIATE`.
+- **Strong-Tx reference**: `internal/store/pgstore/tx.go` (95 lines) plus
+`RunTxRollbackTests` (`storetest/tx.go:133`), which is deliberately NOT in
+`RunAll`.
+- **Graph query for free**: `internal/store/graphquerynaive` — fsstore's
+entire adoption is 28 lines (`fsstore/graphquery.go`).
+
+## Approach
+
+- [x] Technical approach chosen and documented
+- [x] Approach builds on existing patterns (not reinventing)
+- [x] Alternatives considered (document why rejected)
+- [x] Dependencies identified (packages, APIs, types)
+
+**Technical Approach:**
+
+**Location — corrected twice; this is the final form.** The spike lives at
+`internal/store/sqlitespike/` behind a `//go:build sqlitespike` tag, on a
+throwaway branch that is **never merged**. The isolation invariant is "nothing
+merges to develop", NOT "nothing under internal/" — the earlier phrasing forced
+a module structure that does not compile.
+
+Two rejected alternatives, both verified empirically rather than assumed:
+
+1. *Separate Go module under `.ignored/` + `replace`* — **impossible**. Go's
+internal rule is import-path-prefix based and neither `replace` nor `go.work`
+relaxes it: `use of internal package .../internal/storetest not allowed`. The
+spike must implement `internal/store.Store` and import `internal/entity`,
+`internal/store`, `internal/storeutil` and `internal/store/storetest`, so every
+one of those hits the same wall.
+2. *Package inside the main module under gitignored `.ignored/`* — compiles
+and runs (verified: `go test ./.ignored/spikeprobe/` → `ok`, running the real
+`RunTxStressTest` against memstore). Rejected anyway because `.ignored/` is
+gitignored, so the evidence artifact evaporates and the branch cannot be shared
+or reviewed.
+
+The build tag keeps the spike out of every normal build; the branch keeps it out
+of `develop`. `go.mod` gains `modernc.org/sqlite` **on that branch only** —
+which is itself useful evidence, since the implementation ticket needs the
+`go.sum` weight and the `modernc.org/libc` pinning hazard (upstream #177).
+
+**The required subset is most of the write path, not a thin stub.** Derived by
+reading `storetest/stress.go`'s five workers rather than guessing:
+
+| Method | Why the stress test needs it |
+|--------|------------------------------|
+| `CreateEntity` | Must return `store.ErrConflict` on duplicate ID (`stress.go:168`) |
+| `DeleteEntity` | Must return `ErrNotFound` / `ErrHasRelations` correctly (`stress.go:177-178`) |
+| `UpdateEntity` | Tx read-modify-write counter path |
+| `GetEntity` | Same |
+| `ListEntities` | Real `iter.Seq2` with type filtering, called continuously (`stress.go:194`) |
+| `Subscribe` | Drained for the whole run at buf 1024 (`stress.go:215`) |
+| `Tx` | The thing under test |
+| `Close` | Lifecycle |
+
+Relation CRUD is needed only insofar as `ErrHasRelations` must be reachable.
+Effort revised **m → l** accordingly; the earlier "few hundred lines" was
+optimistic by ~2-3x.
+
+**Event-emission is a designed input, not a discovered detail.** pgstore defers
+in-process notifications past commit via a `txPending` buffer
+(`pgstore/tx.go:44-56`); fsstore emits inline. Which one the spike picks changes
+what the stress test proves, so the spike implements **both** and reports the
+difference. This is where the "events must never be emitted under a store lock"
+edge case actually bites.
+
+**Nested `Tx` must not touch the pool.** `stress.go` calls `tx.Tx(...)` from
+inside an open transaction. Copy pgstore's shape exactly
+(`pgstore/tx.go:61-63`): `if s.txPending != nil { return fn(s) }` — return the
+*same* view. Acquiring a second connection while the outer transaction holds the
+only one is an instant self-deadlock that the watchdog would misreport as a
+modernc locking failure.
+
+**Connection/PRAGMA setup**, now the actual variable under test:
+
+- `PRAGMA journal_mode=WAL` — **check the return value**; it silently stays
+`delete` if WAL cannot be enabled (see the network-FS arm).
+- `PRAGMA busy_timeout=5000`
+- `PRAGMA synchronous=NORMAL` — note this means a crash can lose recently
+committed transactions. For a backend whose purpose is replacing git as the
+durability story, that is a **decision to record**, not a tuning knob.
+- `BEGIN IMMEDIATE` to take the write lock up front.
+- `PRAGMA optimize` is **deliberately not measured here** (Tx-only spike),
+flagged so the implementation ticket inherits it explicitly rather than as a
+silent gap.
+
+**Test arms — multi-connection is PRIMARY.** The earlier draft made
+`SetMaxOpenConns(1)` the primary arm, which was a confound that would have
+invalidated the whole spike: with one connection there is no second connection
+to contend with, so `busy_timeout` is never exercised, `SQLITE_BUSY` cannot
+occur, and the `BEGIN IMMEDIATE`-vs-deferred comparison proves *nothing*.
+Upstream #232 and #192 — the entire reason for spiking — are specifically about
+multi-connection contention, i.e. exactly the configuration `SetMaxOpenConns(1)`
+makes unobservable.
+
+| Arm | Pool | Tx mode | What it proves |
+|-----|------|---------|----------------|
+| **A (primary)** | `MaxOpenConns(N)`, N≥4 | `BEGIN IMMEDIATE` + `busy_timeout` | Does modernc's locking hold? The actual question. |
+| **B (control)** | `MaxOpenConns(N)` | deferred | Is `BEGIN IMMEDIATE` load-bearing, or cargo-cult? Now genuinely testable. |
+| **C (fallback)** | `MaxOpenConns(1)` | either | Does the degenerate config work? Safety net if A fails. |
+| **D (ship shape)** | 1 writer + N reader conns, WAL | `BEGIN IMMEDIATE` | The configuration a real backend would actually use. |
+| **E (durability)** | as D | `RunTxRollbackTests` | SQLite likely gives real rollback free — would place it at pg's tier, not fs's. Material to the decision. |
+| **F (network FS)** | as D, DB on an SMB/iCloud mount | `BEGIN IMMEDIATE` | Does WAL work at all? See risks. |
+
+Alternatives considered and rejected:
+
+- **Answer from documentation alone.** Rejected: #232 and #192 are both open
+with no conclusive resolution to cite.
+- **Build the real backend in `internal/` on develop.** Rejected: commits to
+the direction before the gate.
+
+**Files to modify:**
+
+All on a throwaway branch, none merged:
+
+- `internal/store/sqlitespike/*.go` — the spike, all behind `//go:build sqlitespike`
+- `internal/store/sqlitespike/lock_unix.go` / `lock_windows.go` — sidecar flock (see AC-4)
+- `internal/store/sqlitespike/RESULTS.md` — raw numbers
+- `go.mod` / `go.sum` — `modernc.org/sqlite` + pinned `modernc.org/libc`
+
+`internal/storetest` is imported read-only; nothing existing changes.
+
+**Single-writer advisory lock — pulled INTO scope.** The research deferred this
+to implementation. That is unsafe: given AC-4(a) above, the `unique:` half of
+the original disjunction is unrunnable, so the lock is the *only* surviving path
+to a positive AC-4. ~60 lines, and it surfaces the network-FS question below.
+
+Design, with the traps named:
+
+- **Never lock the DB file itself.** SQLite already holds POSIX advisory locks
+on that inode, and on Linux/macOS closing *any* fd to a file drops all of that
+process's POSIX locks on it — layering our own lock there risks silently
+clobbering SQLite's own.
+- Lock a **sidecar** (`rela.db.lock`): `syscall.Flock(fd, LOCK_EX|LOCK_NB)` on
+unix, `LockFileEx` with `LOCKFILE_EXCLUSIVE_LOCK|LOCKFILE_FAIL_IMMEDIATELY` on
+windows (`golang.org/x/sys/windows`). Split `lock_unix.go` / `lock_windows.go`.
+- **"Naming the holder" is a separate problem.** OS advisory locks report
+*that* a lock is held, never *by whom*. Write PID + hostname + start time into
+the lock file **before** taking it, and treat that content as advisory on read —
+a stale PID may have been recycled. Do not promise a clean error message without
+this.
+
+**Network filesystems are a go/no-go input, not a footnote.** The research
+pivoted to single-process *desktop*, and desktop project directories routinely
+live in iCloud Drive, Dropbox, OneDrive or an SMB share. WAL mode requires
+shared memory (the `-shm` file) and is documented as not working over most
+network filesystems — `PRAGMA journal_mode=WAL` can silently stay `delete`.
+`flock` is unreliable on the same filesystems, so S1's lock degrades there too.
+fsstore has no such problem: markdown files sync fine. This is a concrete
+product regression versus fsstore on the exact target deployment, so arm F tests
+it and the decision entity must either report it works or state "unsupported on
+network/sync filesystems" as an accepted limitation.
+
+## Security Considerations
+
+- [x] Input sources identified (user input, config, external APIs)
+- [x] Input validation approach defined (allowlist preferred over blocklist)
+- [x] Security-sensitive operations identified (file access, auth, crypto)
+- [x] Error handling doesn't leak sensitive information
+
+**Input Sources & Validation:**
+
+The spike takes no untrusted input — inputs are test fixtures generated by
+`storetest`. No network, no user data, no config parsing.
+
+For the eventual real backend (recorded here so the implementation ticket
+inherits it, not actioned now):
+
+- **Entity IDs / relation types** → must go through
+`storeutil.ValidateID` / `ValidateRelationType`. The fuzz suite treats
+`ValidateID` as the validity oracle: anything it rejects, the store MUST reject.
+Parameterized SQL throughout; never string-concatenate an ID.
+- **Attachment file names** → `store.ValidateFileName` +
+`NormalizeFileName`, and `CapAttachmentReader` at `MaxAttachmentBytes` (64 MiB)
+as the mandatory backstop every backend enforces.
+- **The DB file path** → derived from `cfg.Paths`, never from user input.
+This is the one genuinely new surface versus pgstore (whose DSN is env-only,
+deliberately, so credentials never reach `ps`). A SQLite path is not a
+credential, but it is a filesystem write target and must be confined to the
+project dir.
+
+**Security-Sensitive Operations:**
+
+- **File creation** — the spike writes a DB file to a temp dir only.
+- **No credential handling** — SQLite has no DSN/password, which removes the
+`RELA_DATABASE_URL` class of concern entirely rather than relocating it.
+- **ACL is unaffected**: read-side gating lives in `internal/visibility`
+decorators at the wiring site, not in the store. A new backend inherits it by
+construction and must not add per-backend redaction (DEC-ZBI39P).
+
+## Test Plan
+
+- [x] Test scenarios documented for each acceptance criterion
+- [x] Edge cases identified and documented
+- [x] Negative test cases defined (invalid input, error conditions)
+- [x] Integration test approach defined (not just unit tests)
+
+**Test Scenarios:**
+
+| AC | Arm / scenario | Pass condition |
+|----|----------------|----------------|
+| AC-3 | **A** multi-conn + `BEGIN IMMEDIATE`, `RELA_STRESS_SECONDS=30` | No watchdog deadlock dump; no lost updates; pair atomicity holds |
+| AC-3 | **B** multi-conn + deferred | Expected to show `SQLITE_BUSY` or deadlock. If it passes, `BEGIN IMMEDIATE` is cargo-cult and we say so |
+| AC-3 | **C** `MaxOpenConns(1)` | Fallback only. A pass here is near-zero evidence — documented as such |
+| AC-3 | **D** 1 writer + N readers, WAL | The ship shape. Read throughput must not collapse |
+| AC-3 | **E** `RunTxRollbackTests` | If it passes, SQLite is at pg's tier not fs's — material to the decision |
+| AC-3 | Six fuzz targets, 30s each | No crashes, no invariant violations |
+| AC-4 | Code-level argument (a) | Citations recorded; no experiment needed |
+| AC-4 | Two processes, same ID (b) | `ErrConflict` returned exactly once |
+| AC-4 | Advisory lock | Second process refused with an error naming PID + host |
+| AC-5 | Cold open vs. fsstore index build | SQLite decisively faster |
+| AC-5 | Steady-state single write | Acceptable interactive latency |
+| AC-5 | Bulk load vs. fsstore 10k file writes | Recorded, not gated |
+| AC-6 | **F** DB on SMB/iCloud mount | `journal_mode=WAL` return value checked; result recorded either way |
+
+**Edge Cases:**
+
+- **Concurrent access** — the central case; the stress test's five workers
+(Tx RMW counters, multi-write transactions with injected failures, nested Tx,
+plain writes, reads, a draining subscriber) cover it.
+- **Nested `Tx`** — must return the *same* view without acquiring a
+connection (`pgstore/tx.go:61-63`). With `MaxOpenConns(1)` a pool acquire here
+is an instant self-deadlock that the watchdog would **misreport as a modernc
+locking failure**. Predicted, not discovered.
+- **`journal_mode=WAL` silently not applied** — check the returned mode, never
+assume the PRAGMA took.
+- **Escaped view after `Tx` returns** — documented as the one misuse that
+fails silently. Not defended against; the spike records whether SQLite makes it
+loud (closed-tx error, like pg) or silent (like fs/mem).
+- **Context cancellation mid-`Tx`** — fsstore ignores the ctx entirely
+(`fsstore/tx.go:31` takes `_ context.Context`); SQLite's driver *will* honor it
+and abort. A real behavioural divergence the contract does not currently
+describe — record it.
+- **`Close` under an open Tx.**
+- **Subscriber buffer full** — events must drop, not block, and never be
+emitted under a store lock.
+- **Fuzz-arm resource exhaustion** — `FuzzFactory` is `func() store.Store`
+with no `*testing.T`, so no `t.TempDir()`; each iteration builds a **fresh**
+store (`fuzz.go:56`). At fuzzing rates that is thousands of SQLite files. Needs
+explicit `Close` + temp-dir lifecycle, or `:memory:` for the fuzz arm only —
+which changes locking behaviour, so it must NOT be the stress arm.
+- **Unicode / null bytes / control chars in IDs** — the fuzz targets treat
+`storeutil.ValidateID` as a directional oracle (`fuzz.go:33`).
+- **Empty store** — `LastModified` returns zero time.
+
+**Negative Tests:**
+
+- `errStressRollback` is injected after both writes of a pair. Under the weak
+contract the writes may persist; pair atomicity must still hold.
+- Second process while the lock is held → clear, actionable error naming the
+holder; never silent corruption.
+- Arm B (deferred) → expected to fail. The failure is the evidence.
+- Attachments inside a Tx are **not** tested here, and that is called out in
+the AC-3 footnote: a 64 MiB `AttachFile` (`store.MaxAttachmentBytes`) inside
+`BEGIN IMMEDIATE` would hold the global write lock for the whole transfer —
+exactly the "do not perform slow external I/O inside fn" hazard
+(`store.go:210-211`). A design constraint for the implementation ticket.
+
+## Risk Assessment
+
+- [x] Technical risks assessed with mitigations
+- [x] Security risks assessed (see Security Considerations)
+- [x] Effort estimated (xs/s/m/l/xl)
+
+**Risks:**
+
+| Risk | Likelihood | Mitigation |
+|------|-----------|------------|
+| modernc's locking doesn't hold under sustained multi-connection load (upstream #232/#192) | Medium | Exactly what arm A measures. A failure here is a **successful spike** producing a no-go — far cheaper than discovering it after a 3k-line backend. |
+| **Spike configured so it cannot observe its own risk** | — | **Caught in design review.** The earlier plan made `MaxOpenConns(1)` primary, which makes `busy_timeout` unreachable and `SQLITE_BUSY` impossible — the exact configuration under which #232/#192 cannot reproduce. Multi-connection is now the primary arm. |
+| WAL unavailable on network/sync filesystems (iCloud, Dropbox, SMB) | **Medium-High** | Arm F. This is a real product regression versus fsstore on the desktop target, and `flock` degrades on the same filesystems. May itself be a no-go input; at minimum an explicitly accepted limitation. |
+| Spike bug misreported as a driver failure | Medium | The nested-Tx self-deadlock (M2) is predicted in the edge-case list. On any watchdog dump, first check the spike's own nested-Tx path against `pgstore/tx.go:61-63` before blaming modernc. |
+| Passing stress test read as "the Tx contract holds" | Medium | A pass is weak positive evidence; a failure is decisive. AC-3's output table carries a footnote naming what is untested: attachments, `RenameEntity`, `Close` under Tx, ctx cancellation. |
+| Fuzz arm exhausts file descriptors | Medium | `FuzzFactory` builds a fresh store per iteration with no `t.TempDir()`. Explicit `Close` + temp-dir lifecycle, or `:memory:` for the fuzz arm only. |
+| Steady-state write latency unacceptable | Medium | Measured directly in AC-5. Mitigations before declaring failure: prepared statements, `synchronous=NORMAL` (with its durability trade recorded as AC-6). |
+| Spike scope creeps into the real backend | Medium | Hard rule: **nothing merges to `develop`**. Build tag + throwaway branch. |
+| Spike proves the model works, read as approval to ship | Low | The decision entity must state that stage 2 (widening the three `*pgstore.Store` assertions) is a prerequisite and unestimated until scoped. |
+| Effort underestimated | — | **Already materialised**: revised m → l in design review once the required subset was derived from `stress.go` rather than guessed. |
+
+**Effort:** l — revised up from `m`. The "subset" is most of the write path plus
+a working `iter.Seq2` iterator plus event fan-out plus the advisory lock, across
+six configuration arms. The original "few hundred lines" estimate was optimistic
+by roughly 2-3x.
+
+## Documentation Planning
+
+For enhancements: identify what documentation needs updating.
+
+- [x] User-facing docs identified (skip if internal refactor)
+- [x] Docs-checklist will be created when entering implementation
+
+**Documentation Impact:**
+
+- [x] N/A for this ticket — investigation only, nothing user-facing ships.
+
+Deferred to the implementation ticket, if go:
+
+- `docs/` — a `sqlite-backend.md` guide paralleling `postgres-backend.md`,
+including the single-writer constraint and the git-versus-version-history
+trade-off (the existing guide's framing at line 194 is the model).
+- `CLAUDE.md` — the "Storage backends & build tags" table gains a row, and
+the backend-isolation CI assertion gains its sqlite cases.
+- `README.md` — backend selection guidance.
+
+## Design Review
+
+- [x] Run `/design-review` before starting implementation
+- [x] All critical/significant findings addressed in plan
+
+**Design Review Findings:**
+
+Reviewed by `go-architect` before any spike code was written. Four critical and
+four significant findings; all addressed in this plan. Every claim below was
+independently verified against the codebase rather than taken on trust.
+
+| # | Sev | Finding | Resolution |
+|---|-----|---------|------------|
+| C1 | critical | Separate Go module under `.ignored/` **cannot compile** — Go's internal rule is import-path-prefix based; neither `replace` nor `go.work` relaxes it. The spike would have failed at `go build` before producing any evidence. | Moved to `internal/store/sqlitespike/` behind `//go:build sqlitespike` on a never-merged branch. Isolation invariant restated as "nothing merges to develop". Verified both the failure and the fix. |
+| C2 | critical | The "subset" is most of the write path — `stress.go` needs real `ListEntities` iteration, `ErrConflict`, `ErrHasRelations`, and event fan-out. | Subset enumerated method-by-method from `stress.go`'s five workers. Event-emission (buffer-and-replay vs. inline) promoted to a designed input. Effort **m → l**. |
+| C3 | critical | `MaxOpenConns(1)` is a confound that makes the spike's own highest-risk unknown **unobservable** — no second connection means `busy_timeout` is never exercised and the `BEGIN IMMEDIATE` control arm proves nothing. #232/#192 are specifically multi-connection bugs. | Arms inverted: multi-connection is now primary, `MaxOpenConns(1)` demoted to fallback. Added the 1-writer/N-reader "ship shape" arm and a `RunTxRollbackTests` arm. |
+| C4 | critical | AC-4's unique-violation demo is **unrunnable**: `unique:` lives in `entitymanager/unique.go:82`, not the store, and there are zero `.Tx(` sites in `internal/entitymanager` (verified) — so a bare `store.Store` has nothing to violate. | Replaced with (a) a code-level argument that is *stronger* than the demo — untransacted scan-then-write means the race isn't even multi-process-specific — and (b) a runnable cross-process `ErrConflict` test. |
+| S1 | significant | The advisory lock was deferred to implementation, but after C4 it is the **only** surviving path to a positive AC-4. | Pulled into scope (~60 lines). Design recorded with the traps: sidecar file never the DB file (SQLite holds POSIX locks on that inode; any fd close drops them); PID+host written before locking; holder identity treated as advisory. |
+| S2 | significant | A passing stress test is weak positive evidence; attachments, `RenameEntity`, `Close`-under-Tx and ctx cancellation are untested. `Tx`'s ctx is ignored by fsstore but honoured by SQLite — a real divergence. | AC-3's output table now carries an explicit "what this does not cover" footnote. The 64 MiB-attachment-inside-`BEGIN IMMEDIATE` hazard recorded as an implementation constraint. |
+| S3 | significant | No arm tested WAL on a network/sync filesystem, though desktop project dirs routinely live in iCloud/Dropbox/SMB — where WAL may silently not engage and `flock` is unreliable. A product regression versus fsstore on the exact target. | Added arm F. May itself be a no-go input; at minimum an explicitly accepted limitation. |
+| S4 | significant | AC-5 compared two different operations (bulk insert vs. index build) and gated on the wrong axis. | Split into cold open / steady-state write / bulk load, each against its comparable fsstore operation. Gate moved off bulk load. `synchronous=NORMAL` durability trade promoted to its own decision (AC-6). |
+
+Minor findings folded in without separate tracking: fuzz-arm fd exhaustion
+(`FuzzFactory` has no `t.TempDir()`), the nested-Tx self-deadlock predicted
+rather than discovered, the `internal/`-vs-`develop` scope phrasing, and `PRAGMA
+optimize` marked explicitly not-measured.
+
+No `review-response` entities were created: findings were resolved directly in
+the plan before implementation, which is what a design review is for. Had any
+been deferred or disputed, they would have been filed as RR-xxxx per the review
+protocol.

--- a/tickets/entities/researchs/RES-03TUXO.md
+++ b/tickets/entities/researchs/RES-03TUXO.md
@@ -1,0 +1,215 @@
+---
+id: RES-03TUXO
+type: research
+title: 'SQLite store backend: capability scope, wiring, change feed, and the markdown trade-off'
+summary: 'Target single-process desktop, not multi-process server: versioning is mandatory (it replaces git), enforce single-writer by advisory lock, and spike the WAL/BEGIN IMMEDIATE locking model as a go/no-go gate.'
+status: done
+---
+
+## Problem
+
+Should rela add a SQLite `store.Store` backend for single-server and desktop
+deployments, and if so at what scope? TKT-TWIO11 settled the driver
+(`modernc.org/sqlite`, pure Go, no CGO, FTS5/JSON1/R-tree verified present, all
+six release targets cross-compile). Four questions remained:
+
+1. **Capability scope** — minimal backend or full pgstore parity?
+2. **Wiring** — a third `sqlite` build tag, or the default for `rela-desktop`?
+3. **Change feed** — single-process only, or multi-process?
+4. **The markdown trade-off** — what is actually lost versus fsstore?
+
+The four are not independent. The central finding of this research is that
+questions 2 and 3 collapse into one, and that answer then determines 1.
+
+## Context
+
+### The mandatory surface is smaller than the ticket assumed
+
+`store.Store` is **26 methods** across 10 embedded interfaces. Three of them
+(`GraphQuery`/`GraphCount`/`MatchingIDs`) are one-line delegations to
+`internal/store/graphquerynaive`, whose `Reader` interface is deliberately
+declared so any store satisfies it structurally with no adapter — fsstore's
+entire implementation is 28 lines. So ~23 methods of genuine work.
+
+Effort anchors, non-test lines: **memstore 1,068 · fsstore 2,996 · pgstore
+6,169**. The ticket's "~10.5k as upper bound" counted test files and overstated
+the ceiling by roughly 40%.
+
+The conformance gate is real but cheap to adopt: `storetest.Capabilities` has
+exactly **one** field (`Attachments`). There is no opt-out for headers, graph
+query, watcher, validation or Tx — those run unconditionally. The memstore
+template (`memstore/conformance_test.go`) is ~70 lines. Notably
+`RunTxRollbackTests` — the strong Tx contract — is **not** in `RunAll`; pgstore
+opts in separately and fs/mem deliberately do not, so a new backend may ship
+with the weak contract and add rollback later.
+
+### Search is a separate axis from the store
+
+`search.Visible` wraps *any* `Searcher` and filters through a
+`store.GraphQueryer`. A SQLite store paired with the existing bleve index is a
+valid combination — **FTS5 is not required to ship**. Native
+`search.VisibleSearcher` (FTS5 composed with visibility SQL) is an optimization,
+not an entry requirement.
+
+### Three `!postgres` no-ops silently encode "single-process"
+
+This is the load-bearing constraint, and it is not a graceful degradation. Each
+is justified in-tree by an assumption SQLite would violate the moment two
+processes open the same database file:
+
+- **`derivedschema_nosweep.go`** — "fsstore/memstore enforce `unique: true`
+with the application-level check-then-write scan, which is correct for their
+**single-process nature**". `store/derivedschema.go` names the hazard: "two
+concurrent (especially cross-process) writers can both pass."
+- **`kvuserstate`** — "a deployment running two servers over one project
+directory will **silently lose snoozes** with this backend."
+- **`stateKV`** — with an FSKV "an operator's logo upload lands on whichever
+node served the POST and every other node keeps serving the old one, **with no
+error anywhere**."
+
+Inheriting the `!postgres` variants in a multi-process SQLite deployment is a
+correctness regression with no error surface, not a reduced feature set.
+
+### Three concrete-type assertions block a third smart backend
+
+`appbuild` discovers pgstore capabilities by `st.(*pgstore.Store)`, not by
+interface: `derivedschema_postgres.go:23`, `userstate_postgres.go:27`,
+`versionsweep_postgres.go:42,93`. `StateKV` is likewise **not** a `store`
+interface — it is a concrete `pgstore.StateKV` found via
+`pgstore.StateStoreFor`. A SQLite backend cannot opt into the version sweep,
+derived-schema reconciler or user-state without first widening these to
+interfaces. That is a prerequisite refactor, easy to miss in an estimate.
+
+### The change feed itself degrades cleanly
+
+`dataentry.App.startStoreEventBridge` needs exactly one thing: `Subscribe`,
+already mandatory in `store.Store`. If SQLite emits in-process events on its own
+writes (the memstore/fsstore pattern), SSE works with zero dataentry changes.
+Every consumer treats the feed as a hint — the contract is idempotent
+re-snapshot, events may be dropped, and pgstore itself warns-and-continues if
+its listener fails. MCP feature-detects `StartWatching` and logs a warning.
+
+### The markdown trade-off is a whole feature, with precedent for losing it
+
+`internal/git` is a full sync feature — status/fetch/sync/merge, conflict-file
+listing, direct and PR modes — wired at `dataentry/app.go:968` behind
+`git.IsRepo(paths.Root)`, with two API endpoints, a Vue store and a background
+fetch loop. It carries **no build tag**, so it compiles into every build
+including postgres.
+
+It degrades gracefully: `gitOps == nil` returns `Available: false` and the UI
+hides it. And the project has already made this trade once —
+`docs/postgres-backend.md:194` frames content versioning as "the analogue of the
+git history a filesystem project gets for free."
+
+That links questions 1 and 4: **a SQLite backend that skips versioning loses git
+and has nothing in its place.** For a server that may be acceptable. For a
+desktop app whose users expect undo/history, it is not.
+
+## Options
+
+### Option A — Minimal backend, `sqlite` build tag, single-process
+
+26 methods, naive graph query, bleve search, weak Tx, no optional capabilities.
+Inherit all `!postgres` no-ops. A third `appbuild_sqlite.go` recipe plus
+`rela-sqlite`/`rela-server-sqlite` binaries.
+
+- **Pros** — smallest surface (~1.0–1.5k lines, memstore-shaped); no
+prerequisite refactor; conformance passes day one.
+- **Cons** — loses git with nothing replacing it; no versioning, no
+`StateKV`/userstate/derived-schema; **single-process is unenforced**, so a
+second process silently corrupts uniqueness and clobbers user state. Gains
+little over fsstore beyond avoiding full-graph residency.
+- **Effort** — S/M.
+
+### Option B — Full pgstore parity
+
+All 11 optional capabilities: versioning (9 methods + ~12 DTOs), purge,
+`TypeWatermark`, `DerivedSchemaReconciler`, native FTS5 `VisibleSearcher`,
+`StateKV`, `UserState`, `ManifestSince`, strong Tx with rollback, SQL pushdown.
+
+- **Pros** — genuine middle tier; multi-process-safe; versioning replaces git;
+could serve either side of the TKT-WE01O5 sync.
+- **Cons** — approaches pgstore's 6.2k lines; requires the interface-widening
+refactor; the purge guardrails are load-bearing and must be re-derived; large
+surface to get right for a deployment tier that may not need all of it.
+- **Effort** — XL.
+
+### Option C — Desktop-first: versioning + safe-by-construction single-process
+
+Take the capabilities that make SQLite *better than fsstore for a desktop app*,
+and structurally prevent the multi-process hazards rather than documenting them.
+
+Take: `HeaderReader`, `TypeWatermark`, the six versioning interfaces, strong Tx
+(WAL + `BEGIN IMMEDIATE`), `StateKV`, `UserState`. Defer: native FTS5 search
+(use bleve initially), `DerivedSchemaReconciler`, purge, `ManifestSince`, SQL
+pushdown.
+
+Enforce single-writer at open time — an advisory lock on the DB file so a second
+process fails loudly instead of silently corrupting. That makes the inherited
+`!postgres` uniqueness no-op *correct by construction* rather than correct by
+assumption.
+
+- **Pros** — versioning replaces git, so the markdown trade-off is honest and
+matches existing postgres precedent; the single-process assumption becomes
+enforced instead of hoped-for; ships without the FTS5 and derived-schema work;
+needs the interface widening only for versioning/state, which is independently
+useful.
+- **Cons** — still needs the prerequisite refactor; versioning is the single
+largest optional surface; deliberately forgoes multi-process, so it does not
+replace pgstore for a shared server.
+- **Effort** — L.
+
+### Option D — Do nothing
+
+- **Pros** — zero cost; fsstore already serves desktop, and git gives history
+and sync free.
+- **Cons** — leaves fsstore's full-graph residency and startup index rebuild
+unaddressed at scale.
+- **Effort** — none.
+
+## Recommendation
+
+**Option C, staged — but validate the concurrency model with a spike before
+committing.**
+
+The reasoning that decides it: questions 2 and 3 are the same question. SQLite's
+value over fsstore is *not* multi-process (WAL gives concurrent readers but one
+writer, and modernc's own tracker shows `SQLITE_BUSY` and `busy_timeout`
+problems as its recurring complaint theme — upstream #232 and #192, both open).
+Its value is a real indexed store for a *single* process that wants history
+without a database server. That is the desktop app.
+
+Once the target is single-process desktop, question 1 answers itself: versioning
+is **not optional**, because it is what replaces git. And question 4 stops being
+a loss — it becomes the same trade postgres already made, documented the same
+way.
+
+The multi-process hazards are then handled by construction. Rather than
+inheriting three no-ops that silently assume single-process, take an advisory
+lock at open so the assumption is enforced. A second process gets a clear error,
+not silent uniqueness violations and clobbered snoozes.
+
+Staging:
+
+1. **Spike first** — prove the `Transactor` contract under WAL +
+`busy_timeout` + `BEGIN IMMEDIATE`, running `RunTxStressTest` and the six fuzz
+targets. Confirm bulk-write throughput on initial index build is acceptable
+(modernc is ~1.5–1.9x slower than mattn on inserts, though that figure is
+general driver overhead — FTS5 is un-benchmarked). **If the locking model does
+not hold cleanly, stop and reconsider** — that is the documented risk area for
+this driver.
+2. **Widen the three `*pgstore.Store` assertions to interfaces.** Independently
+valuable and a prerequisite either way.
+3. **Minimal backend + conformance**: 26 methods, naive graph query, bleve
+search, `HeaderReader`, single-writer lock.
+4. **Versioning + `StateKV`/`UserState`** — the tier that earns the git trade.
+5. **Later, if warranted**: FTS5 native search, SQL pushdown,
+`DerivedSchemaReconciler`, `ManifestSince`.
+
+Trade-offs accepted: no multi-process (deliberate, enforced); no
+git-diffable/hand-editable files on this backend; ~1.5–1.9x slower bulk writes
+than a CGO driver; no custom FTS5 tokenizers ever.
+
+Stages 1–3 are independently useful and stage 1 is a genuine go/no-go gate, so
+the commitment is incremental rather than all-or-nothing.

--- a/tickets/entities/review-checklists/REV-ADRH9C.md
+++ b/tickets/entities/review-checklists/REV-ADRH9C.md
@@ -1,0 +1,97 @@
+---
+id: REV-ADRH9C
+type: review-checklist
+title: 'Review: Investigate SQLite as a third store backend for single-server and desktop deployments'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+**Investigation ticket.** Nothing ships; the deliverable is evidence plus
+DEC-LFSYNY. Items about shipping code are marked N/A with a reason rather than
+silently ticked.
+
+## Automated Checks
+
+- [x] `go build ./...` (default build) — **PASS**. The spike is behind
+`//go:build sqlitespike`, so no normal build sees it.
+- [x] `go vet ./internal/store/...` — **PASS**
+- [x] `go vet -tags sqlitespike ./internal/store/sqlitespike/` — **PASS**
+- [x] Conformance harness — `RunTxStressTest` (30s), `RunTxRollbackTests`,
+4 fuzz targets (68k execs): all pass. Full matrix in
+`internal/store/sqlitespike/RESULTS.md`.
+- [x] `just arch-lint` — **5 notices, ALL from the spike**, each
+"File /internal/store/sqlitespike/*.go not attached to any component in
+archfile". Verified by moving the directory aside and re-running: **"OK - No
+warnings found"**. Expected — `.go-arch-lint.yml` has no component for a
+throwaway package, and adding one would imply the package is permanent.
+Resolution: the branch is never merged, so the archfile stays untouched.
+TKT-G91TBK adds a real component for the real backend.
+- [x] ~~`just test` / `just coverage-check` full suite~~ (N/A: no production
+code changed. The default build is byte-identical apart from a `go.mod`
+`require` line, which `go mod tidy` removes on the branch that is never merged.)
+
+## Code Review
+
+- [x] Reviewed — `go-architect` design review ran BEFORE any code was written
+(the correct order for a spike, where a wrong harness produces confident wrong
+evidence). 4 critical + 4 significant findings, all addressed in PLAN-ZLVJC3
+before implementation. See that checklist's Design Review table.
+- [x] Findings addressed
+
+**Design review paid for itself twice, and both are worth recording:**
+
+- **C1** — the originally planned separate Go module under `.ignored/` could
+not have compiled: Go's internal rule is import-path-prefix based and neither
+`replace` nor `go.work` relaxes it. The spike would have failed at `go build`
+before producing any evidence.
+- **C3** — the originally planned primary arm (`MaxOpenConns(1)`) makes the
+spike's own highest-risk unknown **unobservable**: with one connection nothing
+can contend, so `busy_timeout` is never exercised and the `BEGIN IMMEDIATE`
+control proves nothing. **Confirmed in execution**: that arm HANGS, on
+`database/sql` pool starvation. Had it stayed primary, the hang would have been
+read as "modernc's locking is broken" — the exact opposite of what the evidence
+shows.
+
+**One defect found and fixed during implementation.** `FuzzRelationKeyCollision`
+seed #4 failed: `CreateRelation` accepted an empty relation type because the
+spike skipped `storeutil.ValidateRelationType`. Fixed by validating relation
+type and both endpoint IDs. Carried into TKT-G91TBK as a "do not rediscover"
+item — evidence that the conformance harness catches what a hand-written backend
+misses.
+
+No `review-response` entities: findings were resolved directly, before
+implementation. Had any been deferred or disputed they would be RR-xxxx per the
+review protocol.
+
+## Acceptance Verification
+
+Each criterion PASS/FAIL with evidence. Full detail in the ticket body.
+
+| AC | Verdict | Evidence |
+|----|---------|----------|
+| 1 — required vs optional surface enumerated | **PASS** | 26 mandatory methods + 11 optional capabilities; effort anchors memstore 1,068 / fsstore 2,996 / pgstore 6,169 non-test lines |
+| 2 — driver decision | **PASS** | `modernc.org/sqlite`, `CGO_ENABLED=0`, 6/6 targets cross-compile, FTS5/JSON1/R-tree verified |
+| 3 — `Transactor` semantics | **PASS** | 30s soak: 31,106 commits / 22,036 pair txs, no deadlock; `RunTxRollbackTests` passes → pgstore's tier. Deferred control arm FAILS, proving `BEGIN IMMEDIATE` load-bearing |
+| 4 — change-feed decision | **PASS** | Single-process, lock-enforced. `unique:` is an untransacted scan (`unique.go:82`, zero `.Tx(` sites) → no backstop if multi-process |
+| 5 — wiring approach | **PASS** | `sqlite` build tag mirroring the postgres pattern; NOT the desktop default; CI isolation assertions specified in TKT-G91TBK |
+| 6 — go/no-go + estimate | **PASS** | **GO** (DEC-LFSYNY). TKT-415WA7 `m` → TKT-G91TBK `l` → stage 4 unestimated |
+
+**Not verified, and recorded as such:** arm F (WAL on a network/sync
+filesystem). No network storage available (operator decision, 2026-08-23). It
+remains an **assumed** limitation; `TestJournalMode` honours `RELA_SPIKE_DB_DIR`
+and is ready if a mount appears. Mitigation is in TKT-G91TBK: refuse or warn at
+startup when `journal_mode` is not `wal`, turning a silent corruption risk into
+a clear error.
+
+Also unmeasured by design, and footnoted on the AC-3 result so it cannot be
+overread: attachments inside a Tx, `RenameEntity`, `Close` under an open Tx.
+
+## Documentation
+
+- [x] ~~User-facing docs~~ (N/A: nothing ships. `docs/sqlite-backend.md`,
+the CLAUDE.md backend table row, and README guidance are scoped into
+TKT-G91TBK.)
+- [x] Decision recorded — DEC-LFSYNY, with measurements rather than adjectives
+- [x] Follow-ups filed and linked — TKT-415WA7 (ready), TKT-G91TBK (backlog,
+`depends-on` the former)

--- a/tickets/entities/review-checklists/REV-M4X4CX.md
+++ b/tickets/entities/review-checklists/REV-M4X4CX.md
@@ -2,73 +2,104 @@
 id: REV-M4X4CX
 type: review-checklist
 title: 'Review: appbuild: widen the three *pgstore.Store concrete-type assertions to interfaces'
-status: in-progress
+status: done
 ---
 
 <!-- @managed: claude-workflow v1 -->
 
+Branch `refactor/appbuild-widen-assertions-TKT-415WA7` · `caa2923b` (refactor)
++ `78e543f5` (review fixes).
+
 ## Automated Checks
 
-- [ ] All tests pass (`just test`)
-- [ ] Lint clean (`just lint`)
-- [ ] Comment lint gate clean (`just comment-lint`)
-- [ ] Coverage maintained (`just coverage-check`)
-
-**Comment findings.** `just comment-report` lists the advisory rules
-(duplication, nil-contract, param-contract, restatement). They are not a merge
-gate, but a finding your diff *introduces* should be fixed or suppressed — don't
-grow the backlog.
-
-Every rule is a heuristic over prose, so false positives are expected. To
-suppress one, prefer the inline form on the declaration line, which travels with
-the code and is reviewed in this diff:
-
-```go
-func f(p string) {} //commentlint:ignore param-contract  p is contained by Clone
-```
-
-Use `.commentlint.yml` (`ignore:` path globs, `allow-phrases:`) only when the
-same prose recurs across many sites. A reason is required either way — an
-unexplained suppression is a finding nobody can re-evaluate later.
+- [x] **Postgres suites against a LIVE database** (not skipped):
+`internal/appbuild` 2.5s · `appbuildtest` 1.3s · `backendtest` 0.6s ·
+`store/pgstore` 31.6s — all ok.
+- [x] **All three build tags**: default, `memorybackend`, `postgres` — all build.
+- [x] `just arch-lint` — "OK - No warnings found".
+- [x] `golangci-lint run --build-tags postgres ./internal/appbuild/...` —
+0 issues. Run with the tag explicitly, because the default lint pass does not
+compile the postgres-tagged files this ticket changes.
+- [x] Default-build `./internal/appbuild/... ./internal/store/...` — pass.
+- [x] `go mod tidy` — dropped the `modernc.org/sqlite` dependency carried over
+from the spike branch.
 
 ## Code Review
 
-- [ ] Run `/code-review` command (invokes cranky-code-reviewer agent)
-- [ ] All critical review-responses addressed
-- [ ] All significant review-responses addressed
-- [ ] Self-reviewed the diff for unrelated changes
+- [x] Reviewed by the `cranky-code-reviewer` agent against the full diff
+- [x] All critical and significant findings addressed
 
-**Review Responses:** <!-- List IDs of review-response entities created, e.g.,
-RR-xxxx -->
+**It found a real bug I introduced, and the diagnosis was better than mine.**
+
+`versionServiceFor` returned `s.VersionStore()` directly into
+`store.VersionService`, so a nil pointer boxes into a **non-nil** interface —
+exactly what the doc comment three lines above promises not to do. The insight I
+had missed: this was **new, not pre-existing**. Asserting `st.(*pgstore.Store)`
+had bounded the reachable implementations to exactly one, whose `VersionStore()`
+is unconditionally non-nil. The concrete assertion was doing load-bearing work I
+had not credited it for; widening discovery removed that bound while the return
+type stayed concrete, so the code still *read* as safe. Downstream,
+`versionRecorderFor` and `startDataMigration` both nil-check, both would have
+passed, then panicked on first use — at write time, in production.
+
+I verified the mechanism in an isolated 30-line program before fixing (unguarded
+`!= nil` = true; guarded = false).
+
+| ID | Severity | Status | Finding |
+|----|----------|--------|---------|
+| RR-E6ADZK | critical | addressed | `versionServiceFor` leaks a typed nil (+ same shape in `storeUserStateFor`) |
+| RR-ZGLA3W | significant | addressed | The negative test could not reach the branch that regressed |
+| RR-HNIT8N | significant | addressed | Dead assertion: `x == nil && len(x) != 0` is unsatisfiable |
+| RR-WJK3DQ | significant | addressed | `stateKVFor` unwidened while the test implied parity |
+| RR-XGJLO1 | minor | addressed | Compile-time assertion wrapped in a `func Test`; unused `*testing.T` |
+| RR-IEXU1I | nit | **deferred** | `versionSweeper` naming; `StartVersionSweep` has no stop counterpart |
+
+Only the nit is deferred, with a reason: both points are about the capability's
+own contract rather than this refactor, and TKT-L3FNEN reshapes these signatures
+anyway — renaming now would just churn.
+
+**Every fix was verified by deliberate regression, not just by going green:**
+
+- Typed-nil guard → removing it makes
+`TestCapabilityPresentButHandleNilYieldsUntypedNil` fail with `versionServiceFor
+= (*pgstore.VersionStore)(nil), want untyped nil`.
+- Call-order assertion → swapping the order in the resolver fails with
+`call order = [Reconcile SetUniqueSpecProvider], want [SetUniqueSpecProvider
+Reconcile]`.
+- Interface discovery → restoring `st.(*pgstore.Store)` fails with
+`storeUserStateFor did not reach a non-pgstore store implementing UserState`.
+
+That last one matters because the reviewer's mutation test showed the *original*
+`TestDerivedSchemaPublishesSpecsBeforeReconciling` passed even with
+`SetUniqueSpecProvider` deleted outright — a test that existed only to look like
+coverage. I had independently suspected that line and flagged it in the review
+request; the mutation test confirmed it.
 
 ## Acceptance Verification
 
-- [ ] Each acceptance criterion tested (reference planning checklist)
-- [ ] Test evidence documented in implementation checklist
+| AC | Verdict | Evidence |
+|----|---------|----------|
+| 1 — no `st.(*pgstore.Store)` in appbuild | **PASS** | `grep` returns nothing |
+| 2 — pgstore behaviour unchanged | **PASS** | Full postgres suites green against a live DB |
+| 3 — non-pgstore store wired identically | **PASS** | `TestCapabilitiesDiscoveredByInterface_NotConcreteType`, proven non-vacuous |
+| 4 — untyped-nil contract holds | **PASS** | Now covers BOTH branches: no-capability and capability-returns-nil |
+| 5 — arch-lint + build tags | **PASS** | arch-lint clean; three tags build; lint 0 issues under the postgres tag |
 
-**Acceptance Status:**
-<!-- For each acceptance criterion, state PASS/FAIL with evidence -->
+**Scope honestly stated, not overclaimed.** Three of four sites are widened;
+`stateKVFor` is deliberately not, because `pgstore.StateStoreFor` is a package
+function by design (pgstore's plimsoll line forbids growing its method set).
+That exclusion is now documented at the call site with its runtime consequence —
+a second backend would silently fall back to node-local FSKV for state — and
+TKT-L3FNEN says it must close **before** a second backend ships, not merely
+before the work is "complete".
 
-## Documentation (enhancements only)
+## Documentation
 
-Skip this section for bugs and internal refactors.
-
-- [ ] Docs-checklist created and linked via `has-docs`
-- [ ] User-facing documentation updated
-- [ ] Docs-checklist marked as done
-
-**Docs Checklist:** <!-- e.g., DOCS-xxxx -->
-
-## Final Checks
-
-- [ ] Commit message explains the why, not just what
-- [ ] No TODOs or FIXMEs left unaddressed
-- [ ] Ready for another developer to use
-
-## Pull Request
-
-- [ ] Run `/pr` command to create PR and monitor CI
-- [ ] All CI checks pass
-- [ ] PR URL documented below
-
-**PR:** <!-- e.g., https://github.com/org/repo/pull/123 -->
+- [x] ~~User-facing docs~~ (N/A: internal refactor, no behaviour change)
+- [x] Doc comments updated in place — they previously asserted the concrete
+type as fact; they now describe the capability, and the typed-nil guard carries
+a comment explaining *why* it became necessary, so it is not deleted later as
+redundant
+- [x] Follow-up filed and sharpened — TKT-L3FNEN gained two sections from this
+review: why the half-migration was a correctness gap rather than aesthetic debt,
+and the `stateKVFor` exclusion

--- a/tickets/entities/review-checklists/REV-M4X4CX.md
+++ b/tickets/entities/review-checklists/REV-M4X4CX.md
@@ -1,0 +1,74 @@
+---
+id: REV-M4X4CX
+type: review-checklist
+title: 'Review: appbuild: widen the three *pgstore.Store concrete-type assertions to interfaces'
+status: in-progress
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Automated Checks
+
+- [ ] All tests pass (`just test`)
+- [ ] Lint clean (`just lint`)
+- [ ] Comment lint gate clean (`just comment-lint`)
+- [ ] Coverage maintained (`just coverage-check`)
+
+**Comment findings.** `just comment-report` lists the advisory rules
+(duplication, nil-contract, param-contract, restatement). They are not a merge
+gate, but a finding your diff *introduces* should be fixed or suppressed — don't
+grow the backlog.
+
+Every rule is a heuristic over prose, so false positives are expected. To
+suppress one, prefer the inline form on the declaration line, which travels with
+the code and is reviewed in this diff:
+
+```go
+func f(p string) {} //commentlint:ignore param-contract  p is contained by Clone
+```
+
+Use `.commentlint.yml` (`ignore:` path globs, `allow-phrases:`) only when the
+same prose recurs across many sites. A reason is required either way — an
+unexplained suppression is a finding nobody can re-evaluate later.
+
+## Code Review
+
+- [ ] Run `/code-review` command (invokes cranky-code-reviewer agent)
+- [ ] All critical review-responses addressed
+- [ ] All significant review-responses addressed
+- [ ] Self-reviewed the diff for unrelated changes
+
+**Review Responses:** <!-- List IDs of review-response entities created, e.g.,
+RR-xxxx -->
+
+## Acceptance Verification
+
+- [ ] Each acceptance criterion tested (reference planning checklist)
+- [ ] Test evidence documented in implementation checklist
+
+**Acceptance Status:**
+<!-- For each acceptance criterion, state PASS/FAIL with evidence -->
+
+## Documentation (enhancements only)
+
+Skip this section for bugs and internal refactors.
+
+- [ ] Docs-checklist created and linked via `has-docs`
+- [ ] User-facing documentation updated
+- [ ] Docs-checklist marked as done
+
+**Docs Checklist:** <!-- e.g., DOCS-xxxx -->
+
+## Final Checks
+
+- [ ] Commit message explains the why, not just what
+- [ ] No TODOs or FIXMEs left unaddressed
+- [ ] Ready for another developer to use
+
+## Pull Request
+
+- [ ] Run `/pr` command to create PR and monitor CI
+- [ ] All CI checks pass
+- [ ] PR URL documented below
+
+**PR:** <!-- e.g., https://github.com/org/repo/pull/123 -->

--- a/tickets/entities/review-responses/RR-E6ADZK.md
+++ b/tickets/entities/review-responses/RR-E6ADZK.md
@@ -1,0 +1,9 @@
+---
+id: RR-E6ADZK
+type: review-response
+title: versionServiceFor can leak a typed nil — a hole this refactor opened
+finding: 'versionServiceFor returned s.VersionStore() directly. That boxes a concrete *pgstore.VersionStore into store.VersionService, so a nil pointer yields a NON-nil interface — the exact failure the doc comment three lines above promises not to produce. New rather than pre-existing: asserting st.(*pgstore.Store) bounded the reachable implementations to one whose VersionStore() is unconditionally non-nil, so the concrete assertion was doing load-bearing work. Widening discovery removed that bound while the return type stayed concrete. Downstream, versionRecorderFor (appbuild.go:1301) and startDataMigration (datamigration.go:58) both nil-check and would both pass, then panic on first use at write time in production. Same shape applies to storeUserStateFor for a (nil, nil) return.'
+severity: critical
+resolution: 'Added explicit nil-pointer guards to both resolvers, with a comment explaining WHY the guard became necessary when discovery widened (so it is not deleted later as redundant). Verified the mechanism in an isolated 30-line program: unguarded != nil = true, guarded = false. Added TestCapabilityPresentButHandleNilYieldsUntypedNil covering the capability-present-returns-nil branch, and confirmed it FAILS against the unguarded code.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-HNIT8N.md
+++ b/tickets/entities/review-responses/RR-HNIT8N.md
@@ -1,0 +1,9 @@
+---
+id: RR-HNIT8N
+type: review-response
+title: Dead assertion in TestDerivedSchemaPublishesSpecsBeforeReconciling
+finding: 'The condition `f.specsPublished == nil && len(f.specsPublished) != 0` is unsatisfiable — a nil slice has len 0, so the conjunction can never be true. Mutation-tested by the reviewer: deleting s.SetUniqueSpecProvider(specs) from the resolver entirely left the test PASSING. A test named ''PublishesSpecsBeforeReconciling'' asserted neither publishing nor ordering. Two deeper issues: even the intended check (specsPublished != nil) would be wrong, because the test passes a nil metamodel so SetUniqueSpecProvider(nil) is indistinguishable from never being called; and nilness cannot express ordering at all.'
+severity: significant
+resolution: 'Replaced with explicit call-order recording (calls []string + slices.Equal against [SetUniqueSpecProvider, Reconcile]). Verified non-vacuous by swapping the order in the resolver: fails with ''call order = [Reconcile SetUniqueSpecProvider], want [SetUniqueSpecProvider Reconcile]''. I had independently suspected this line and flagged it to the reviewer; the mutation test confirmed it.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-IEXU1I.md
+++ b/tickets/entities/review-responses/RR-IEXU1I.md
@@ -1,0 +1,9 @@
+---
+id: RR-IEXU1I
+type: review-response
+title: versionSweeper naming, and StartVersionSweep has no stop counterpart
+finding: Two design observations. (1) versionSweeper is named for the noun the method starts, but the type does not sweep — it can be told to start sweeping; versionSweepStarter is uglier and more accurate. (2) StartVersionSweep returns nothing and has no stop counterpart, so the wiring site has no handle to stop what it started. The store's own Close presumably handles it today, but a future backend could leak a goroutine per tenant in a schema-per-tenant deployment.
+severity: nit
+reason: Both deferred to TKT-L3FNEN rather than churned here. (1) is low stakes and renaming now would conflict with that ticket, which reshapes these signatures anyway. (2) is a genuine design question about the capability's contract, not about this refactor — the interface faithfully reflects the existing method, and inventing a stop semantic is out of scope for a mechanical widening. Noted so the lifecycle gap is considered when the types are promoted.
+status: deferred
+---

--- a/tickets/entities/review-responses/RR-WJK3DQ.md
+++ b/tickets/entities/review-responses/RR-WJK3DQ.md
@@ -1,0 +1,9 @@
+---
+id: RR-WJK3DQ
+type: review-response
+title: stateKVFor was left unwidened while the test implied parity with the other three
+finding: The commit message claimed four assertion sites were replaced; three were. stateKVFor still calls pgstore.StateStoreFor(st), which type-asserts *pgstore.Store internally (statekv.go:72). A second backend would therefore get version sweeps, user state and derived schema by interface, then silently fall back to node-local FSKV for state — partial capability adoption, which is worse than none because it degrades quietly at runtime rather than failing loudly at wiring. TestResolversReturnUntypedNilWithoutCapability tested stateKVFor alongside the widened three, implying a parity that does not exist.
+severity: significant
+resolution: 'Documented the exclusion at the call site with the runtime consequence and a TKT-L3FNEN pointer; annotated the test so stateKVFor is understood as covering its nil contract only, not interface parity; and expanded TKT-L3FNEN with a dedicated section stating this must close BEFORE a second backend ships, not merely before the work is ''complete''. Not widened here: StateStoreFor is a package function by design (pgstore''s plimsoll line forbids growing its method set), so changing it is the same promote-the-types problem TKT-L3FNEN owns.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-XGJLO1.md
+++ b/tickets/entities/review-responses/RR-XGJLO1.md
@@ -1,0 +1,9 @@
+---
+id: RR-XGJLO1
+type: review-response
+title: Compile-time assertion wrapped in a func Test, and unused *testing.T in newFakeStore
+finding: TestPgstoreSatisfiesWidenedInterfaces is a compile-time assertion wrapped in a test function with a t.Log to justify it — it cannot fail at runtime, so it only adds a fake green line to the report. Separately, newFakeStore takes *testing.T and calls t.Helper() but never registers cleanup; taking a T and not using it for t.Cleanup is a smell even where harmless.
+severity: minor
+resolution: Moved the assertions to file scope as `var _ userStateProvider = (*pgstore.Store)(nil)` etc., matching the precedent in version_store.go:40-48 — same guarantee, build-time failure, no fake test. Added t.Cleanup(func() { _ = m.Close() }) to newFakeStore.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-ZGLA3W.md
+++ b/tickets/entities/review-responses/RR-ZGLA3W.md
@@ -1,0 +1,9 @@
+---
+id: RR-ZGLA3W
+type: review-response
+title: The negative nil test could not reach the branch that actually regressed
+finding: TestResolversReturnUntypedNilWithoutCapability was described as the load-bearing negative test, but it only exercised a store with NO capability — which hits a `return nil` literal and can never catch a typed nil. The dangerous branch is capability-present-returns-nil-handle, for which no fake existed. fakeUserStateStore.UserState returned (nil, nil) as an untyped nil interface, exercising nothing.
+severity: significant
+resolution: 'Added fakeNilVersionStore (returns a nil *pgstore.VersionStore) and fakeNilUserState (returns (nil, nil)), plus TestCapabilityPresentButHandleNilYieldsUntypedNil. Verified non-vacuous: it fails against the unguarded resolver with ''versionServiceFor = (*pgstore.VersionStore)(nil), want untyped nil''.'
+status: addressed
+---

--- a/tickets/entities/tickets/TKT-415WA7.md
+++ b/tickets/entities/tickets/TKT-415WA7.md
@@ -5,7 +5,7 @@ title: 'appbuild: widen the three *pgstore.Store concrete-type assertions to int
 kind: refactor
 priority: medium
 effort: m
-status: ready
+status: review
 ---
 
 ## Description

--- a/tickets/entities/tickets/TKT-415WA7.md
+++ b/tickets/entities/tickets/TKT-415WA7.md
@@ -1,0 +1,61 @@
+---
+id: TKT-415WA7
+type: ticket
+title: 'appbuild: widen the three *pgstore.Store concrete-type assertions to interfaces'
+kind: refactor
+priority: medium
+effort: m
+status: ready
+---
+
+## Description
+
+`appbuild` discovers pgstore's optional capabilities by asserting the **concrete
+type** `*pgstore.Store`, not an interface. A third backend therefore cannot opt
+into the version sweep, derived-schema reconciler or user-state no matter what
+interfaces it satisfies.
+
+Sites:
+
+- `internal/appbuild/derivedschema_postgres.go:23` — `st.(*pgstore.Store)`
+- `internal/appbuild/userstate_postgres.go:27` — `st.(*pgstore.Store)`
+- `internal/appbuild/versionsweep_postgres.go:42,93` — `st.(*pgstore.Store)`
+(`stateKVFor`, `startVersionSweepIfSupported`)
+
+Related: `StateKV` is not a `store` interface at all — it is a concrete
+`pgstore.StateKV` reached via `pgstore.StateStoreFor(st)`, which does the same
+concrete assertion internally. `SetUniqueSpecProvider` and `StartVersionSweep`
+are likewise concrete methods.
+
+## Why now
+
+Prerequisite for DEC-LFSYNY (SQLite backend). Identified during that ticket's
+design review as work that is easy to miss in an estimate, because it looks like
+part of the backend but is not.
+
+Independently valuable regardless of SQLite: it is what makes "pluggable store
+backends" (FEAT-CO4YP) true for *smart* backends, not just for the store
+interface. The optional-capability pattern already works this way everywhere
+else — `HistoryReader`, `Formatter`, `TypeWatermark` are all type-asserted as
+interfaces at the wiring site.
+
+## Scope
+
+IN: define consumer-side interfaces for the three capabilities and assert
+against those instead of the concrete type. Keep the build-tag structure and the
+genuinely-nil-interface fallback contract intact (the doc comments stress that a
+*typed* nil would defeat the caller's nil check — preserve that).
+
+OUT: implementing any of these for a new backend. This ticket only removes the
+structural block.
+
+## Acceptance criteria
+
+1. No `st.(*pgstore.Store)` assertion remains in `internal/appbuild`.
+2. `pgstore` still satisfies every widened interface; the postgres build's
+behaviour is unchanged (pinned by the existing wiring tests).
+3. A non-pgstore store satisfying the interfaces would be wired identically —
+demonstrated by a test double, not by adding a real backend.
+4. The nil-fallback contract still holds: a store implementing none of them
+still gets the FSKV / in-memory user-state fallbacks.
+5. `just arch-lint` and the postgres CI job pass.

--- a/tickets/entities/tickets/TKT-415WA7.md
+++ b/tickets/entities/tickets/TKT-415WA7.md
@@ -5,7 +5,7 @@ title: 'appbuild: widen the three *pgstore.Store concrete-type assertions to int
 kind: refactor
 priority: medium
 effort: m
-status: review
+status: done
 ---
 
 ## Description

--- a/tickets/entities/tickets/TKT-G91TBK.md
+++ b/tickets/entities/tickets/TKT-G91TBK.md
@@ -1,0 +1,91 @@
+---
+id: TKT-G91TBK
+type: ticket
+title: 'SQLite store backend: conformance-passing minimal store behind a sqlite build tag'
+kind: enhancement
+priority: medium
+effort: l
+status: backlog
+---
+
+## Description
+
+Build the SQLite `store.Store` backend decided in DEC-LFSYNY: single-process,
+`modernc.org/sqlite`, at pgstore's transaction tier. This ticket is **stage 3**
+— the conformance-passing store. Versioning and `StateKV`/`UserState` (stage 4)
+are a separate ticket; FTS5 search, SQL pushdown and `DerivedSchemaReconciler`
+are deliberately later still.
+
+Depends on TKT-415WA7 (widening the `*pgstore.Store` assertions) only for the
+stage-4 capabilities, not for this ticket.
+
+## Carry forward from the spike — do not rediscover
+
+The spike (`spike/sqlite-tx-TKT-TWIO11`,
+`internal/store/sqlitespike/RESULTS.md`) established these by measurement. They
+are cheap to get wrong and expensive to debug:
+
+1. **PRAGMAs go in the DSN (`?_pragma=...`), never `db.Exec`.** A PRAGMA is
+per-connection; `db.Exec` configures one pooled connection and leaves the rest
+at the default, while reading back correctly. Measured: `busy_timeout` set via
+`db.Exec` fails at 0.00s instead of waiting 5s. Port `verifyBusyTimeout` — it
+pins two connections open simultaneously and asserts both agree, so the
+misconfiguration cannot return silently.
+2. **`BEGIN IMMEDIATE`, always.** Deferred transactions fail the stress test:
+a read-then-write must upgrade its lock mid-flight, and the upgrade cannot wait,
+so `SQLITE_BUSY` is returned regardless of `busy_timeout`.
+3. **Never serialize by shrinking the pool.** `MaxOpenConns(1)` deadlocks —
+`Tx` pins the only connection while readers block for one. That is
+`database/sql` pool starvation, not a SQLite lock. Use a normal pool plus an
+in-process write mutex.
+4. **Nested `Tx` must return the same view without acquiring a connection**
+(`pgstore/tx.go:61-63` shape).
+5. **`storeutil` validators are the oracle.** The spike's `CreateRelation`
+initially accepted an empty relation type; `FuzzRelationKeyCollision` caught it
+on the seed corpus. Validate IDs and relation types on every write path.
+
+## Scope
+
+IN:
+
+- The 26 `store.Store` methods. `GraphQuery`/`GraphCount`/`MatchingIDs`
+delegate to `graphquerynaive` (fsstore's adoption is 28 lines).
+- `storetest.RunAll` + `RunTxStressTest` + `RunTxRollbackTests` + all six fuzz
+targets. Take the strong Tx contract — the spike showed SQLite gives rollback
+and post-commit events for free.
+- `HeaderReader` (cheap, pure win).
+- Single-writer advisory lock on a **sidecar** file (never the DB file:
+SQLite holds POSIX locks on that inode and any fd close drops them). PID +
+hostname written before locking; holder identity treated as advisory.
+- Refuse to start, or warn loudly, when `journal_mode` is not `wal` — this is
+the network-filesystem guard, and it costs nothing since `Open` already reads
+the value back.
+- A `sqlite` build tag: `appbuild_sqlite.go` recipe, GoReleaser entries,
+CI backend-isolation assertions (`go list -deps` must show no pgx and no bleve
+leakage in the wrong direction), `justfile` build-check-tags.
+- Pin `modernc.org/libc` to the version from `modernc.org/sqlite`'s `go.mod`
+(upstream #177), with a `go.mod` comment saying why.
+
+OUT: versioning, `StateKV`, `UserState`, FTS5 native search (use bleve initially
+— `search.Visible` wraps any `Searcher`), SQL pushdown,
+`DerivedSchemaReconciler`, `ManifestSince`, multi-process anything.
+
+## Acceptance criteria
+
+1. `storetest.RunAll` passes with `Capabilities{Attachments: true}`.
+2. `RunTxStressTest` passes at `RELA_STRESS_SECONDS=30` with no watchdog
+deadlock dump, no lost updates, pair atomicity holding.
+3. `RunTxRollbackTests` passes — SQLite is wired at pgstore's tier.
+4. All six fuzz targets pass.
+5. A second process opening the same database fails with a clear error naming
+the holder; it never corrupts silently.
+6. Startup refuses or warns when WAL is not in effect.
+7. CI asserts the default build does not link the sqlite driver, and the
+sqlite build links neither pgx nor bleve inappropriately.
+8. `just arch-lint`, `just lint`, `just coverage-check` pass.
+
+## Not licensed by this ticket
+
+Multi-process SQLite; replacing pgstore for shared servers; making SQLite the
+`rela-desktop` default (a separate call once the backend exists and has been
+exercised).

--- a/tickets/entities/tickets/TKT-L3FNEN.md
+++ b/tickets/entities/tickets/TKT-L3FNEN.md
@@ -1,0 +1,106 @@
+---
+id: TKT-L3FNEN
+type: ticket
+title: Promote ProjectionProvider, SweepConfig and VersionStore into internal/store so sweep capabilities are backend-neutral
+kind: refactor
+priority: low
+effort: m
+status: backlog
+---
+
+## Description
+
+TKT-415WA7 widened appbuild's capability *discovery* from `st.(*pgstore.Store)`
+to interfaces. Two of those interfaces still name pgstore types in their
+signatures, so in practice only pgstore can satisfy them — a second backend
+would have to import pgstore, which is not real decoupling.
+
+```go
+type versionSweeper interface {
+    StartVersionSweep(provider pgstore.ProjectionProvider, cfg pgstore.SweepConfig)
+}
+
+type versionServiceProvider interface {
+    VersionStore() *pgstore.VersionStore
+}
+```
+
+Same issue one level down: `stateKVFor` calls `pgstore.StateStoreFor(st)`, which
+performs its own `st.(*Store)` assertion internally and returns a concrete
+`*pgstore.StateKV`.
+
+## Why this matters more than "residual coupling"
+
+Code review of TKT-415WA7 sharpened this. Naming pgstore types in the
+signatures is not merely aesthetic debt: **the half-migration opened a real
+nil-contract gap.**
+
+Asserting `st.(*pgstore.Store)` bounded the reachable implementations to
+exactly one, whose `VersionStore()` is unconditionally non-nil. Widening
+discovery to an interface removed that bound while the return type stayed
+`*pgstore.VersionStore` — so the code still *read* as though the old guarantee
+held. It did not. A nil pointer boxed into `store.VersionService` yields a
+NON-nil interface, so every downstream nil-check passes and the panic lands at
+write time.
+
+That specific hole is fixed in TKT-415WA7 with explicit nil guards plus
+`TestCapabilityPresentButHandleNilYieldsUntypedNil`. The lesson for THIS
+ticket: when the return types are finally promoted, the guards must stay —
+they are what makes the contract independent of any one implementation.
+
+## Also in scope: stateKVFor was left out entirely
+
+`stateKVFor` still discovers via `pgstore.StateStoreFor(st)`, which
+type-asserts `*pgstore.Store` internally (`statekv.go:72`). So a second backend
+would get version sweeps, user state and derived schema by interface, then
+**silently fall back to node-local FSKV for state**. That partial adoption is
+worse than none: it degrades quietly at runtime instead of failing loudly at
+wiring, and `stateKVFor`'s own comment documents the consequence (an operator's
+logo upload lands on one node and every other keeps serving the old one, with
+no error anywhere).
+
+Must be closed before a second backend ships, not merely before it is
+"complete".
+
+## Why this was split out rather than done at once
+
+TKT-415WA7 deliberately stopped at discovery. Promoting these types changes
+pgstore's public API and touches the sweep, version-store and state-KV surfaces,
+so it is a different risk profile from a mechanical assertion swap — and the
+assertion swap was the part actually blocking DEC-LFSYNY.
+
+Recording it explicitly so "no concrete assertions remain in appbuild" is not
+misread as "the capabilities are backend-neutral". They are not, yet.
+
+## Scope
+
+IN:
+
+- Move `ProjectionProvider` and `SweepConfig` into `internal/store` (or a
+neutral package), leaving pgstore aliases if that keeps the diff small.
+- Give `VersionStore()` a `store.VersionService` return type rather than the
+concrete `*pgstore.VersionStore`. Note `store.VersionService` already exists as
+the umbrella interface — this may be as simple as changing the signature.
+- Decide `StateStoreFor`: either a `state.KV`-returning interface assertion, or
+leave it and document why. Its doc comment argues for a package-level function
+over a `Store` method for plimsoll reasons; that rationale should be re-checked,
+not assumed still-binding.
+
+OUT: implementing any of it for a second backend.
+
+## Constraint carried forward
+
+**Do not add accessor methods to `pgstore.Store`.** It carries
+`//plimsoll:max-exported-methods=38` and an explicit note that a third
+capability accessor "should not raise these numbers again". Whatever shape this
+takes must not grow that method set.
+
+## Acceptance criteria
+
+1. `internal/appbuild`'s capability interfaces name no pgstore types.
+2. A backend outside pgstore could satisfy them without importing pgstore —
+demonstrated by a test double in a package that does not import pgstore.
+3. pgstore's exported method count does not increase (plimsoll unchanged).
+4. Postgres conformance + appbuild wiring suites pass unchanged against a real
+database.
+5. `just arch-lint`, `just lint` (including `--build-tags postgres`) clean.

--- a/tickets/entities/tickets/TKT-TWIO11.md
+++ b/tickets/entities/tickets/TKT-TWIO11.md
@@ -1,0 +1,208 @@
+---
+id: TKT-TWIO11
+type: ticket
+title: Investigate SQLite as a third store backend for single-server and desktop deployments
+kind: enhancement
+priority: medium
+effort: l
+status: done
+---
+
+## Description
+
+Evaluate an embedded SQLite `store.Store` backend that sits conceptually between
+`fsstore` (single-user, markdown-on-disk, no server) and `pgstore`
+(multi-process, multi-tenant, server-managed). Target deployments: a single
+`rela-server` instance, and the `rela-desktop` app.
+
+Scope of this ticket is **investigation and a recommendation** — a research
+entity plus a decision — not implementation.
+
+## Why
+
+rela has two store backends today, with a large gap between them:
+
+- **`fsstore`** — markdown files on disk, git-friendly, single-writer by nature, in-process events only. No SQL pushdown: `GraphQuery` runs through `graphquerynaive`, search is an in-memory bleve index rebuilt at startup, and the whole graph is effectively resident.
+- **`pgstore`** — ~10.5k lines, native SQL pushdown, `LISTEN/NOTIFY` cross-process change feed, content + relation versioning, `state_kv`, derived-schema reconciler, version sweep, purge. Requires operating a PostgreSQL server.
+
+A single-server or desktop deployment wants pgstore's *properties* (indexed
+queries, no full-graph residency, real transactions, versioning) without
+pgstore's *operational cost* (a separate database process, a DSN, migrations
+against a shared cluster). That is exactly the niche SQLite occupies.
+
+## What to investigate
+
+**1. Conformance surface.** What must a new backend actually implement?
+`store.Store` = `EntityReader + EntityWriter + RelationReader + RelationWriter +
+GraphQueryer + AttachmentManager + Watcher + Lifecycle + Freshness +
+Transactor`, and it must pass `internal/store/storetest` (`RunAll` + fuzz —
+~4.7k lines covering graphquery, relation, entity, attachment, pagination, tx,
+watcher, stress, differential). Establish the minimum viable backend versus the
+full-fidelity one.
+
+**2. Which optional capabilities to take.** These are type-asserted, not part of
+`store.Store` — each is opt-in and each is a decision point: `HistoryReader` /
+`VersionWriter` / `RelationHistoryReader` / `RelationVersionWriter` (content
+versioning), `VersionPurger` / `RelationVersionPurger`, `StateKV`,
+`store.Formatter`, the derived-schema reconciler, and a native
+`search.VisibleSearcher` (SQLite FTS5 as the analogue of `pg_trgm` + tsvector —
+must pass `storetest.RunVisibleSearchTests`).
+
+**3. CGO / driver — SETTLED: `modernc.org/sqlite` (pure Go, no CGO).** Decided
+2026-08-22. Verified empirically against `modernc.org/sqlite v1.57.0`, not
+inferred:
+
+- **FTS5 is compiled in unconditionally** — the `SQLITE_ENABLE_FTS5` flag is
+baked into the transpiled C, so there is no build tag, no opt-out, and no way to
+ship a binary without it. Present since before v1.4.0 (2020). Verified with
+`CGO_ENABLED=0`: FTS5 table creation, `unicode61`/`porter`/`trigram` tokenizers,
+`bm25()` + `ORDER BY rank`, `snippet()`/`highlight()`, and
+external-content/contentless tables all work. `trigram` is the `pg_trgm`
+analogue.
+- **JSON1 and R-tree are also compiled in** (`json_extract` verified), which
+matters for pushing property predicates into SQL. `STAT4` too.
+- **Cross-compiles to all six release targets with `CGO_ENABLED=0`**:
+linux/{amd64,arm64}, darwin/{amd64,arm64}, windows/{amd64,arm64}. The GoReleaser
+matrix therefore stays free — the sqlite variant is just another `CGO_ENABLED=0`
+entry alongside the existing five.
+
+Consequences of NOT taking `mattn/go-sqlite3`, accepted knowingly:
+
+- **Bulk writes are ~1.5–1.9x slower** than mattn (consistent direction across
+two independent 2026 benchmark suites; reads near-par, better under
+concurrency). Caveat: neither suite benchmarks FTS5, so that figure is general
+driver overhead, not a measured FTS5 number. Mitigable with a single
+transaction, WAL, `synchronous=NORMAL`, prepared statements. Confirm during the
+spike that initial index build is acceptable.
+- **Custom FTS5 tokenizers are impossible** — the C symbols exist in the
+transpiled code but the driver exposes no registration API (mattn needs CGO
+callbacks; modernc is a hard no). Workaround is to pre-tokenize in Go into a
+contentless/external-content table. Only bites if the four built-in tokenizers
+prove insufficient.
+- **FTS3/FTS4 are absent.** Irrelevant for new work; noted in case a legacy
+schema ever has to be read.
+
+Follow-ups this creates for the spike:
+
+- **Pin `modernc.org/libc` to the exact version in `modernc.org/sqlite`'s own
+`go.mod`** — a documented fragility (upstream #177); a transitive bump by
+another module can break the build. Warrants a `go.mod` comment.
+- **`PRAGMA optimize`** on close/periodically. SQLite 3.51.0 changed the query
+planner such that an FTS5 table joined against an ordinary table can be 10–40x
+slower without statistics (confirmed upstream by Hipp, reproduced in pure C). We
+will be doing exactly that join. Driver-independent — it hits mattn identically
+— so it is not a selection criterion, but it is a real operational requirement.
+- **`windows/arm64` reuses amd64-generated code** rather than being separately
+transpiled, and there is an open WAL-startup crash report on Windows (upstream
+  #221). Builds fine; treat as the least-exercised target and verify before
+shipping a Windows arm64 archive.
+
+Fallback if modernc is ever abandoned for mattn: CGO *can* be confined to the
+sqlite build. Verified — `//go:build sqlite` plus `CGO_ENABLED=1` on that one
+GoReleaser entry leaves the existing five binaries untouched at `CGO_ENABLED=0`.
+The sharp edge is that `CGO_ENABLED` is an env var, not a build tag, so
+`-tags=sqlite` with CGO off fails as a confusing "build constraints exclude all
+Go files"; a `//go:build sqlite && !cgo` file emitting a clear compile-time
+error would be required. Not needed under the current decision.
+
+**4. Concurrency model — now the highest-risk open question.** SQLite is
+single-writer even in WAL mode. Map that onto the `Transactor` contract
+(DEC-8UIL0): WAL + `busy_timeout` gives cross-process *reader* concurrency and
+serialized writers, landing strictly between fsstore's in-process mutex and
+pgstore's advisory-lock + native transaction. Does it need `BEGIN IMMEDIATE` to
+avoid lock-upgrade deadlocks?
+
+Locking — not FTS5 — is the recurring complaint theme in modernc's issue
+tracker, so this is what a spike must actually exercise rather than assume:
+frequent `SQLITE_BUSY` after migrating from mattn (upstream #232, open) and
+`busy_timeout` not respected with `_txlock=immediate` (upstream #192, open). A
+background indexer writing concurrently with request-path writes is exactly the
+shape those reports describe.
+
+**5. Change feed.** pgstore has `LISTEN/NOTIFY`; SQLite has no equivalent. For a
+genuinely single-process deployment, in-process fan-out is sufficient and
+honest. Decide whether multi-process is in scope at all — if it is, the options
+(update hook, polling a sequence, a sidecar) all carry real cost and this
+becomes a much larger ticket.
+
+**6. Build-tag placement.** The existing pattern is 17 `//go:build postgres`
+files. Determine whether a `sqlite` tag replicates that (a third
+`appbuild_sqlite.go` recipe, `mcp_wiring_sqlite.go`, `cli/db_sqlite.go`, a third
+`rela-server-sqlite` binary, a third CI job) or whether SQLite should instead be
+the **default** backend for `rela-desktop`. Note the CLAUDE.md constraint: the
+postgres build must not link bleve and the default build must not link pgx — a
+sqlite build carries the same isolation obligation, asserted via `go list
+-deps`.
+
+**7. Config-on-disk invariant.** `schema.yaml`, `acl.yaml`, `templates/`,
+`scripts/` stay on the filesystem even on the postgres build. Confirm SQLite
+inherits that: it backs entities/relations/attachments/search/state, not
+operator-authored config. A `--project` dir is still required.
+
+**8. What is lost versus fsstore.** fsstore's markdown files are the
+git-diffable, hand-editable, grep-able source of truth — a real product
+property, not an implementation detail. A SQLite backend gives that up. Is there
+an export/sync story (cf. `TKT-WE01O5`, two-way fsstore↔pgstore sync), or is
+that an accepted trade for the deployments this targets?
+
+## Out of scope
+
+- Implementation. This ticket produces a research entity and a decision.
+- Multi-process SQLite coordination beyond assessing feasibility.
+- Migration tooling between backends.
+
+## Deliverables
+
+- A `research` entity (via `/research`) covering the still-open options with pros/cons/effort: minimal backend (no versioning) vs full-fidelity; build-tag vs desktop-default wiring; multi-process in or out. The driver question is closed (see section 3) — carry the finding forward, do not re-litigate it.
+- A recommendation, and a `decision` entity if the recommendation is to proceed.
+- A rough effort estimate for the implementation ticket, anchored against pgstore's ~10.5k lines as the upper bound.
+
+## Acceptance criteria
+
+**ALL MET.** Outcome: **GO** — see DEC-LFSYNY. Evidence: RES-03TUXO (survey),
+`internal/store/sqlitespike/RESULTS.md` (measurements, branch
+`spike/sqlite-tx-TKT-TWIO11`).
+
+1. ~~Enumerate required vs optional methods with take/skip rationale.~~ **MET** —
+26 mandatory methods across 10 embedded interfaces (3 of them one-line
+delegations to `graphquerynaive`), plus 11 optional type-asserted capabilities.
+Effort anchors, non-test lines: memstore 1,068 / fsstore 2,996 / pgstore 6,169.
+The original "~10.5k upper bound" counted test files and overstated by ~40%.
+2. ~~CGO / driver recommendation.~~ **MET 2026-08-22** — `modernc.org/sqlite`,
+pure Go, `CGO_ENABLED=0`, all six release targets cross-compile, FTS5/JSON1/
+R-tree verified compiled in. See section 3.
+3. ~~`Transactor` semantics stated precisely alongside fs and pg.~~ **MET —
+measured, not assumed.** SQLite sits at **pgstore's tier**: real rollback and
+post-commit-only events (`RunTxRollbackTests` passes), giving up only
+cross-process serialization. 30s soak: 31,106 counter commits, 22,036 pair txs,
+no deadlock. `BEGIN IMMEDIATE` is load-bearing (the deferred control arm fails).
+Not covered by that soak, and stated as such: attachments in a Tx,
+`RenameEntity`, `Close` under an open Tx.
+4. ~~Change-feed decision explicit.~~ **MET — single-process only, enforced by
+an advisory lock rather than documented.** In-process fan-out satisfies the SSE
+bridge, which needs only `Subscribe`. Multi-process is rejected: `unique:` is an
+**untransacted** `ListEntities` scan (`entitymanager/unique.go:82`, zero `.Tx(`
+sites in the package), so a multi-process SQLite backend inheriting the
+`!postgres` no-op would have no uniqueness backstop at all.
+5. ~~Wiring approach chosen and checked against the backend-isolation CI
+assertion.~~ **MET** — a `sqlite` build tag mirroring the 17-file `postgres`
+pattern, NOT the `rela-desktop` default (that is a separate call once the
+backend exists). CI gains the matching `go list -deps` assertions; the default
+build must not link the sqlite driver. Detailed in TKT-G91TBK.
+6. ~~Go/no-go with an effort estimate.~~ **MET — GO**, staged:
+TKT-415WA7 (`m`, prerequisite interface widening) → TKT-G91TBK (`l`,
+conformance-passing store) → stage 4 versioning + state, **unestimated until
+scoped**.
+
+## Outcome
+
+- **Decision**: DEC-LFSYNY (accepted)
+- **Research**: RES-03TUXO
+- **Follow-ups**: TKT-415WA7 (ready), TKT-G91TBK (backlog, depends on it)
+- **Spike branch**: `spike/sqlite-tx-TKT-TWIO11` — never merge; kept for the
+measurements and the reproduction harness.
+
+One acceptance-criterion caveat carried forward honestly: **arm F (WAL on a
+network/sync filesystem) was not run** — no network storage available. It is
+recorded as an accepted, *unmeasured* limitation, with a concrete mitigation in
+TKT-G91TBK (refuse or warn at startup when `journal_mode` is not `wal`).

--- a/tickets/relations/DEC-LFSYNY--decides--store-backends.md
+++ b/tickets/relations/DEC-LFSYNY--decides--store-backends.md
@@ -1,0 +1,5 @@
+---
+from: DEC-LFSYNY
+relation: decides
+to: store-backends
+---

--- a/tickets/relations/RES-03TUXO--informs--DEC-LFSYNY.md
+++ b/tickets/relations/RES-03TUXO--informs--DEC-LFSYNY.md
@@ -1,0 +1,5 @@
+---
+from: RES-03TUXO
+relation: informs
+to: DEC-LFSYNY
+---

--- a/tickets/relations/RES-03TUXO--researches--store-backends.md
+++ b/tickets/relations/RES-03TUXO--researches--store-backends.md
@@ -1,0 +1,5 @@
+---
+from: RES-03TUXO
+relation: researches
+to: store-backends
+---

--- a/tickets/relations/TKT-415WA7--affects--store-backends.md
+++ b/tickets/relations/TKT-415WA7--affects--store-backends.md
@@ -1,0 +1,5 @@
+---
+from: TKT-415WA7
+relation: affects
+to: store-backends
+---

--- a/tickets/relations/TKT-415WA7--has-implementation--IMPL-BB3OA5.md
+++ b/tickets/relations/TKT-415WA7--has-implementation--IMPL-BB3OA5.md
@@ -1,0 +1,5 @@
+---
+from: TKT-415WA7
+relation: has-implementation
+to: IMPL-BB3OA5
+---

--- a/tickets/relations/TKT-415WA7--has-planning--PLAN-V0003S.md
+++ b/tickets/relations/TKT-415WA7--has-planning--PLAN-V0003S.md
@@ -1,0 +1,5 @@
+---
+from: TKT-415WA7
+relation: has-planning
+to: PLAN-V0003S
+---

--- a/tickets/relations/TKT-415WA7--has-review--REV-M4X4CX.md
+++ b/tickets/relations/TKT-415WA7--has-review--REV-M4X4CX.md
@@ -1,0 +1,5 @@
+---
+from: TKT-415WA7
+relation: has-review
+to: REV-M4X4CX
+---

--- a/tickets/relations/TKT-415WA7--has-review-response--RR-E6ADZK.md
+++ b/tickets/relations/TKT-415WA7--has-review-response--RR-E6ADZK.md
@@ -1,0 +1,5 @@
+---
+from: TKT-415WA7
+relation: has-review-response
+to: RR-E6ADZK
+---

--- a/tickets/relations/TKT-415WA7--has-review-response--RR-HNIT8N.md
+++ b/tickets/relations/TKT-415WA7--has-review-response--RR-HNIT8N.md
@@ -1,0 +1,5 @@
+---
+from: TKT-415WA7
+relation: has-review-response
+to: RR-HNIT8N
+---

--- a/tickets/relations/TKT-415WA7--has-review-response--RR-IEXU1I.md
+++ b/tickets/relations/TKT-415WA7--has-review-response--RR-IEXU1I.md
@@ -1,0 +1,5 @@
+---
+from: TKT-415WA7
+relation: has-review-response
+to: RR-IEXU1I
+---

--- a/tickets/relations/TKT-415WA7--has-review-response--RR-WJK3DQ.md
+++ b/tickets/relations/TKT-415WA7--has-review-response--RR-WJK3DQ.md
@@ -1,0 +1,5 @@
+---
+from: TKT-415WA7
+relation: has-review-response
+to: RR-WJK3DQ
+---

--- a/tickets/relations/TKT-415WA7--has-review-response--RR-XGJLO1.md
+++ b/tickets/relations/TKT-415WA7--has-review-response--RR-XGJLO1.md
@@ -1,0 +1,5 @@
+---
+from: TKT-415WA7
+relation: has-review-response
+to: RR-XGJLO1
+---

--- a/tickets/relations/TKT-415WA7--has-review-response--RR-ZGLA3W.md
+++ b/tickets/relations/TKT-415WA7--has-review-response--RR-ZGLA3W.md
@@ -1,0 +1,5 @@
+---
+from: TKT-415WA7
+relation: has-review-response
+to: RR-ZGLA3W
+---

--- a/tickets/relations/TKT-415WA7--implements--FEAT-CO4YP.md
+++ b/tickets/relations/TKT-415WA7--implements--FEAT-CO4YP.md
@@ -1,0 +1,5 @@
+---
+from: TKT-415WA7
+relation: implements
+to: FEAT-CO4YP
+---

--- a/tickets/relations/TKT-G91TBK--affects--store-backends.md
+++ b/tickets/relations/TKT-G91TBK--affects--store-backends.md
@@ -1,0 +1,5 @@
+---
+from: TKT-G91TBK
+relation: affects
+to: store-backends
+---

--- a/tickets/relations/TKT-G91TBK--depends-on--TKT-415WA7.md
+++ b/tickets/relations/TKT-G91TBK--depends-on--TKT-415WA7.md
@@ -1,0 +1,5 @@
+---
+from: TKT-G91TBK
+relation: depends-on
+to: TKT-415WA7
+---

--- a/tickets/relations/TKT-G91TBK--implements--FEAT-CO4YP.md
+++ b/tickets/relations/TKT-G91TBK--implements--FEAT-CO4YP.md
@@ -1,0 +1,5 @@
+---
+from: TKT-G91TBK
+relation: implements
+to: FEAT-CO4YP
+---

--- a/tickets/relations/TKT-L3FNEN--affects--store-backends.md
+++ b/tickets/relations/TKT-L3FNEN--affects--store-backends.md
@@ -1,0 +1,5 @@
+---
+from: TKT-L3FNEN
+relation: affects
+to: store-backends
+---

--- a/tickets/relations/TKT-L3FNEN--implements--FEAT-CO4YP.md
+++ b/tickets/relations/TKT-L3FNEN--implements--FEAT-CO4YP.md
@@ -1,0 +1,5 @@
+---
+from: TKT-L3FNEN
+relation: implements
+to: FEAT-CO4YP
+---

--- a/tickets/relations/TKT-TWIO11--affects--store-backends.md
+++ b/tickets/relations/TKT-TWIO11--affects--store-backends.md
@@ -1,0 +1,5 @@
+---
+from: TKT-TWIO11
+relation: affects
+to: store-backends
+---

--- a/tickets/relations/TKT-TWIO11--has-docs--DOCS-4NYE03.md
+++ b/tickets/relations/TKT-TWIO11--has-docs--DOCS-4NYE03.md
@@ -1,0 +1,5 @@
+---
+from: TKT-TWIO11
+relation: has-docs
+to: DOCS-4NYE03
+---

--- a/tickets/relations/TKT-TWIO11--has-implementation--IMPL-IXY9N5.md
+++ b/tickets/relations/TKT-TWIO11--has-implementation--IMPL-IXY9N5.md
@@ -1,0 +1,5 @@
+---
+from: TKT-TWIO11
+relation: has-implementation
+to: IMPL-IXY9N5
+---

--- a/tickets/relations/TKT-TWIO11--has-planning--PLAN-ZLVJC3.md
+++ b/tickets/relations/TKT-TWIO11--has-planning--PLAN-ZLVJC3.md
@@ -1,0 +1,5 @@
+---
+from: TKT-TWIO11
+relation: has-planning
+to: PLAN-ZLVJC3
+---

--- a/tickets/relations/TKT-TWIO11--has-research--RES-03TUXO.md
+++ b/tickets/relations/TKT-TWIO11--has-research--RES-03TUXO.md
@@ -1,0 +1,5 @@
+---
+from: TKT-TWIO11
+relation: has-research
+to: RES-03TUXO
+---

--- a/tickets/relations/TKT-TWIO11--has-review--REV-ADRH9C.md
+++ b/tickets/relations/TKT-TWIO11--has-review--REV-ADRH9C.md
@@ -1,0 +1,5 @@
+---
+from: TKT-TWIO11
+relation: has-review
+to: REV-ADRH9C
+---

--- a/tickets/relations/TKT-TWIO11--implements--FEAT-CO4YP.md
+++ b/tickets/relations/TKT-TWIO11--implements--FEAT-CO4YP.md
@@ -1,0 +1,5 @@
+---
+from: TKT-TWIO11
+relation: implements
+to: FEAT-CO4YP
+---


### PR DESCRIPTION
## What

`internal/appbuild` discovered pgstore's optional capabilities by asserting the
concrete type `st.(*pgstore.Store)`, so no other store backend could ever opt
in. Replaced with consumer-side interfaces, following the pattern
`HistoryReader` / `Formatter` / `TypeWatermark` already use.

**pgstore is not modified.** It carries `//plimsoll:max-exported-methods=38`
and a comment warning that a third capability accessor must not raise that
count, so the interfaces are declared at the call site and satisfied
structurally.

Prerequisite for DEC-LFSYNY (SQLite backend). Independently valuable: it is what
makes "pluggable store backends" (FEAT-CO4YP) true for *smart* backends, not
just for the store interface.

## A bug the refactor opened, caught in review

`versionServiceFor` returned `s.VersionStore()` straight into
`store.VersionService`, boxing a nil pointer into a **non-nil** interface.

This was new, not pre-existing: `st.(*pgstore.Store)` had bounded the reachable
implementations to exactly one, whose `VersionStore()` is unconditionally
non-nil. The concrete assertion was doing load-bearing work; widening discovery
removed that bound while the return type stayed concrete. Downstream,
`versionRecorderFor` and `startDataMigration` both nil-check, both would have
passed, then panicked on first use — at write time, in production.

Fixed with explicit guards in both resolvers, each carrying a comment explaining
*why* the guard became necessary so it is not later deleted as redundant.

## Scope — three of four sites, deliberately

`stateKVFor` is **not** widened: it discovers via `pgstore.StateStoreFor`, a
package function by design (same plimsoll reason). Documented at the call site
with its runtime consequence — a second backend would get three capabilities by
interface then *silently* fall back to node-local FSKV for state. Tracked in
TKT-L3FNEN, which says it must close **before** a second backend ships.

Two interfaces still name pgstore types in their signatures
(`ProjectionProvider`, `SweepConfig`, `*VersionStore`), so only pgstore can
satisfy them in practice. Also TKT-L3FNEN.

## Testing

Every fix verified by deliberate regression, not just by going green:

- Remove the typed-nil guard → `TestCapabilityPresentButHandleNilYieldsUntypedNil`
  fails with `versionServiceFor = (*pgstore.VersionStore)(nil), want untyped nil`
- Swap the reconcile order → fails with
  `call order = [Reconcile SetUniqueSpecProvider], want [SetUniqueSpecProvider Reconcile]`
- Restore `st.(*pgstore.Store)` → fails with
  `storeUserStateFor did not reach a non-pgstore store implementing UserState`

That last check mattered: review mutation-testing showed the original
`TestDerivedSchemaPublishesSpecsBeforeReconciling` passed even with
`SetUniqueSpecProvider` deleted outright — its assertion
(`x == nil && len(x) != 0`) is unsatisfiable for a slice. Replaced with call-order
recording.

Verified against a live PostgreSQL: `appbuild` 2.5s, `appbuildtest` 1.3s,
`backendtest` 0.6s, `pgstore` 31.6s. All three build tags build; `just arch-lint`
clean; `golangci-lint --build-tags postgres` 0 issues.

Six review findings: 5 addressed, 1 nit deferred to TKT-L3FNEN with a reason.