### PR TITLE
🌍 tickets: TKT-DN37J2 paperwork (companion to the PR-A..C stack)

### DIFF
--- a/tickets/entities/automated-measures/AM-delete-versions-every-face.md
+++ b/tickets/entities/automated-measures/AM-delete-versions-every-face.md
@@ -1,0 +1,27 @@
+---
+id: AM-delete-versions-every-face
+type: automated-measure
+title: Deleting an entity records a delete version for every face
+description: A test that Manager.DeleteEntity and RenameEntity capture one version per state row, not one for the default face. Guards the class of bug where a bare-id read feeds a capture while the store sweeps the whole state family.
+kind: test
+location: internal/entitymanager/manager_test.go
+status: proposed
+---
+
+## What it guards
+
+The write choke-point reads the entity with `GetEntity(id)` — the DEFAULT face
+— and captures one version from it, while `store.DeleteEntity` hard-deletes the
+whole family. The asymmetry is invisible at the call site because both take a
+bare id; nothing in the signature says one is per-face and the other per-family.
+
+`RR-181AFY` closed exactly this for cascade-deleted **relations**, and the loop
+it added sits directly below the entity capture that still has the bug. A test
+asserting "N faces in, N delete versions out" makes the two paths fail together
+rather than one silently lagging the other.
+
+## Shape
+
+Seed an entity with three faces, delete it, assert three `VersionOpDelete`
+captures with distinct pointers. Same for rename. A backend-independent test
+against a recording `VersionRecorder`, so it runs on every build tag.

--- a/tickets/entities/automated-measures/AM-relation-delete-addresses-the-tail.md
+++ b/tickets/entities/automated-measures/AM-relation-delete-addresses-the-tail.md
@@ -1,0 +1,31 @@
+---
+id: AM-relation-delete-addresses-the-tail
+type: automated-measure
+title: Relation delete addresses the tail, never a different face's edge
+description: Store conformance case asserting DeleteRelationState removes the edge with exactly the given tail and leaves same-triple siblings on other tails standing. Guards the class where dropping a tail silently re-addresses a different relation instead of failing.
+kind: test
+location: internal/store/storetest/states.go
+status: active
+---
+
+## What it guards
+
+A relation's tail is part of its IDENTITY — two edges on one triple with
+different tails are two relations. But `DeleteRelation`'s signature cannot
+express a tail, so a caller holding a state-tailed edge that drops it does not
+delete "approximately the right edge": it deletes the DEFAULT face's edge and
+reports success.
+
+That is not a hypothetical — it shipped in the copy kernel (BUG-CPYTAIL) and
+was silent in all three backends.
+
+## Shape
+
+`DeleteRelationStateAddressesTheTailNotTheTriple` seeds one edge per tail on the
+same triple, deletes the non-default one, and asserts the default-tail sibling
+SURVIVES — the survivor assertion is what makes it capable of failing.
+`DeleteRelationStateNotFound` asserts a missing tail is absent rather than
+"close enough", and that the miss did not delete the default edge.
+
+Implemented in TKT-C1XUA8 PR-D; runs against fsstore, memstore and pgstore via
+`storetest.RunAll`.

--- a/tickets/entities/automated-measures/AM-unmarshalyaml-alias-field-parity.md
+++ b/tickets/entities/automated-measures/AM-unmarshalyaml-alias-field-parity.md
@@ -1,0 +1,28 @@
+---
+id: AM-unmarshalyaml-alias-field-parity
+type: automated-measure
+title: Custom UnmarshalYAML alias structs stay in sync with their outer type
+description: A reflection test asserting each type with a custom UnmarshalYAML has an inner alias covering every field of the outer struct. Guards the class where adding a field parses clean and arrives as the zero value, so a declared setting silently becomes its default.
+kind: test
+location: internal/metamodel/
+status: proposed
+---
+
+## What it guards
+
+The alias-struct pattern (needed to avoid recursing into `UnmarshalYAML`)
+duplicates the field list, and YAML ignores unknown keys — so a field added to
+the outer type but not the alias is dropped **silently**. The schema loads, the
+value reads as unset, and the feature behaves as if the operator never wrote
+the line.
+
+Hit for real by `after:` on `CopyDef` (BUG-YAMLDROP): `after: discard` parsed
+clean as `keep`, which would have turned a consuming promote into a
+non-consuming one with no error anywhere.
+
+## Shape
+
+Table-driven over the affected types, comparing `reflect.NumField()` of the
+outer type against its alias, failing with a message naming the fix. Follows
+`internal/acl/ceilingguard_test.go`, which converts the same kind of
+convention-only invariant into a failing test with an exemption list.

--- a/tickets/entities/bugs/BUG-CPYTAIL.md
+++ b/tickets/entities/bugs/BUG-CPYTAIL.md
@@ -1,0 +1,63 @@
+---
+id: BUG-CPYTAIL
+type: bug
+title: "copy `relations: replace` deletes the DEFAULT face's edge and leaves the target's intact"
+description: applyCopyEdges listed the target face's edges by tail then called DeleteRelation with the tail dropped. Every backend's DeleteRelation is default-tail-only, so the delete silently removed the DEFAULT face's edge on the same triple — a face the copy has no business touching — and reported success, while the edge being replaced survived. Fixed in TKT-C1XUA8 PR-D by adding DeleteRelationState; filed for traceability.
+priority: high
+status: backlog
+why1: applyCopyEdges called DeleteRelation(rel.From, rel.Type, rel.To), dropping rel.FromPointer.
+why2: The tail is part of a relation's identity, but DeleteRelation's signature cannot express one, so dropping it silently re-addresses a different edge rather than failing.
+why3: No per-tail delete primitive existed — store.RelationData.FromPointer's godoc deferred it, saying individual delete of a state-tailed edge "has no consumer before the Step-3 copy kernel and is added then". The copy kernel landed without it.
+why4: The ErrNotFound branch at copy_apply.go:64 was written expecting a miss, which made the wrong-edge deletion look like a handled case rather than an unhandled one.
+why5: A deferred primitive was tracked only in a godoc comment on an unrelated struct field, so the consumer that was supposed to add it had no gate forcing the question at merge time.
+prevention: The conformance suite now carries DeleteRelationStateAddressesTheTailNotTheTriple, named for the hazard, so any backend regressing to default-tail addressing fails. More generally — when a godoc defers work to a named future consumer, that consumer needs a ticket, not a comment.
+---
+
+## Symptom
+
+`internal/entitymanager/copy_apply.go` (as shipped in TKT-C1XUA8 PR-C) listed
+the target face's edges filtered by tail:
+
+```go
+for rel, err := range view.ListRelations(ctx, store.RelationQuery{
+    From: plan.targetID, Type: e.relType, FromPointer: &tail,   // tail-scoped
+}) {
+    derr := view.DeleteRelation(ctx, rel.From, rel.Type, rel.To)  // tail DROPPED
+```
+
+All three backends address the default tail only:
+
+- pgstore `relation.go`: `... AND from_pointer = ''`
+- memstore `memstore.go`: `defaultTailKey(from, relType, to)`
+- fsstore `relation.go`: bare `from + "--" + relType + "--" + to`, identical to
+  `relKey(from, "", ...)`
+
+## Impact
+
+Reproduced against memstore before fixing. Given `PAGE-1` (default) and
+`PAGE-1@published` both holding `references -> SPEC-1`, deleting the
+published-tail edge the way the copy did:
+
+```
+delete returned: nil
+edges surviving: [PAGE-1@published--references--SPEC-1]
+```
+
+The delete **succeeded**, destroyed the **default** face's edge — which the
+copy never intended to touch — and left the published-tail edge it meant to
+replace alive. Silent, in all three backends, with no error path reached: the
+`ErrNotFound` branch was never taken, so the swallow at `copy_apply.go:64`
+was not even the mechanism.
+
+`promote-page` with `relations: replace` is the headline use case in design
+doc §9.1, and it was actively destructive.
+
+## Fix
+
+TKT-C1XUA8 PR-D adds `store.DeleteRelationState(ctx, from, pointer, relType, to)`
+across all three backends, reimplements `DeleteRelation` as
+`DeleteRelationState(…, "", …)` so the two cannot drift, and addresses the
+delete by `rel.FromPointer`. Pinned by
+`storetest/states.go` `DeleteRelationStateAddressesTheTailNotTheTriple` and by
+`TestCopy_ReplaceAddressesTheTargetTail`, both mutation-verified to fail
+against the old code.

--- a/tickets/entities/bugs/BUG-CPYTAIL.md
+++ b/tickets/entities/bugs/BUG-CPYTAIL.md
@@ -32,16 +32,43 @@ All three backends address the default tail only:
 - fsstore `relation.go`: bare `from + "--" + relType + "--" + to`, identical to
   `relKey(from, "", ...)`
 
-## Impact
+## Impact — reproduction transcript
 
-Reproduced against memstore before fixing. Given `PAGE-1` (default) and
-`PAGE-1@published` both holding `references -> SPEC-1`, deleting the
-published-tail edge the way the copy did:
+Reproduced against memstore before fixing, using a throwaway test that made
+exactly the call `applyCopyEdges` made. Setup: `PAGE-1` (default face) and
+`PAGE-1@published`, each holding its own `references -> SPEC-1` edge — two
+distinct relations differing only by tail.
+
+```go
+// This is exactly what applyCopyEdges does for `relations: replace` into
+// PAGE-1@published: it listed the published-tail edge, then called
+// DeleteRelation dropping the tail.
+if err := s.DeleteRelation(ctx, "PAGE-1", "references", "SPEC-1"); err != nil {
+    t.Fatalf("delete: %v", err)
+}
+```
+
+Output:
 
 ```
-delete returned: nil
-edges surviving: [PAGE-1@published--references--SPEC-1]
+=== RUN   TestTailBugDemo
+    edges surviving the intended delete of the PUBLISHED-tail edge:
+      [PAGE-1@published--references--SPEC-1]
+--- PASS: TestTailBugDemo (0.00s)
 ```
+
+Read that carefully — it is the worst of the three possible outcomes:
+
+1. The delete returned **nil**. Not `ErrNotFound`, so the `!errors.Is(derr,
+   store.ErrNotFound)` guard at the call site was never even reached.
+2. It deleted the **default face's** edge — a face the copy never addressed
+   and had no business modifying.
+3. The **published-tail edge it was trying to replace survived**.
+
+An earlier code-reading pass had predicted `ErrNotFound` as the likely
+(benign) branch. It was wrong, and only running it showed that. Had the
+reading stood, the PR description would have carried the benign version and a
+reviewer would reasonably have believed it.
 
 The delete **succeeded**, destroyed the **default** face's edge — which the
 copy never intended to touch — and left the published-tail edge it meant to

--- a/tickets/entities/bugs/BUG-DFLTCHAIN.md
+++ b/tickets/entities/bugs/BUG-DFLTCHAIN.md
@@ -63,11 +63,12 @@ that can never match.
 is still in open PRs. This defect was introduced by **PR #1393**
 (`TKT-WAV8XP PR-A`, commit d5ef3c66) and has never run for a user.
 
-That makes it cheaper to fix than a released bug, and it argues for fixing it
-**in #1393 itself** rather than as a follow-up on top — the epic is an
-18-PR stack, and a fix landing above the PR that introduced the bug means
-every intermediate PR carries the broken compiler. Decide before #1393
-merges; after that, a follow-up is the only option.
+**DECIDED (Jeroen, 2026-08-24): fix it as a follow-up PR at the TOP of the
+stack, not by amending #1393.** Rebasing eighteen branches to fix a defect
+no user can reach is not worth the churn, and the whole stack is being
+reviewed as one unit at the end anyway. The intermediate PRs carrying the
+broken compiler is acceptable precisely because none of them ship
+independently.
 
 Found during TKT-WRLDAPI PR-A review; confirmed empirically against the real
 compiler. Out of THAT PR's scope either way — it is a defect in

--- a/tickets/entities/bugs/BUG-DFLTCHAIN.md
+++ b/tickets/entities/bugs/BUG-DFLTCHAIN.md
@@ -1,0 +1,62 @@
+---
+id: BUG-DFLTCHAIN
+type: bug
+title: A world selecting a default-marked pointer by name compiles to an unmatchable chain
+severity: high
+status: backlog
+---
+
+**Two functions map a declared pointer name to a stored coordinate, and only
+one of them knows about `default: true`.**
+
+- `internal/worlds.declaredPointers` (`worlds.go:179-188`) maps declared names
+  through `entity.ParsePointer` and **never consults `PointerDef.Default`** —
+  so `draft` compiles to the coordinate `"draft"`.
+- `metamodel.StoredPointer` (`copies.go:282`) maps a default-marked name to
+  `""`, and its own godoc says getting this wrong "is not a cosmetic bug".
+
+So the store writes the default face at the zero coordinate while the world
+compiler looks for it under its declared name.
+
+## Reproduction
+
+```yaml
+page:
+  pointers:
+    draft:     { default: true }
+    published: {}
+worlds:
+  editorial:
+    select: [published, draft]
+```
+
+```
+compiled chain                        = ["published", "draft"]
+metamodel.StoredPointer(page, draft)  = ""
+```
+
+No row is ever keyed `"draft"`, so the second chain entry can never match. An
+entity holding ONLY its default face is **excluded from a world that
+explicitly asked for it by name**.
+
+## Why it matters
+
+- It presents to an operator as **"my editorial world is empty and I don't
+  know why"** — with no error, no warning, and a config that reads correctly.
+- **Nothing rejects it at load time.** The world compiles cleanly.
+- `TestCompile_ChainDedup` currently **pins the wrong behaviour as intended**,
+  so the bug has a test defending it.
+
+## Fix direction (not prescriptive)
+
+Route `declaredPointers` through the same default-aware mapping
+`StoredPointer` uses, so there is ONE definition of "declared name → stored
+coordinate" rather than two that disagree — the same shared-predicate
+discipline applied to A1/A2 in TKT-T31NKT and to `DeleteRelation`/
+`DeleteRelationState` in TKT-C1XUA8 PR-D. Fix the test that pins the current
+behaviour, and consider whether a load-time check should reject a chain entry
+that can never match.
+
+Found during TKT-WRLDAPI PR-A review; confirmed empirically against the real
+compiler. Out of that PR's scope — it is a pre-existing defect in
+`internal/worlds`, not in the API surface being added.

--- a/tickets/entities/bugs/BUG-DFLTCHAIN.md
+++ b/tickets/entities/bugs/BUG-DFLTCHAIN.md
@@ -57,6 +57,18 @@ discipline applied to A1/A2 in TKT-T31NKT and to `DeleteRelation`/
 behaviour, and consider whether a load-time check should reject a chain entry
 that can never match.
 
+## Where this lives — NOT shipped
+
+`internal/worlds` does not exist on `develop`; the whole content-states epic
+is still in open PRs. This defect was introduced by **PR #1393**
+(`TKT-WAV8XP PR-A`, commit d5ef3c66) and has never run for a user.
+
+That makes it cheaper to fix than a released bug, and it argues for fixing it
+**in #1393 itself** rather than as a follow-up on top — the epic is an
+18-PR stack, and a fix landing above the PR that introduced the bug means
+every intermediate PR carries the broken compiler. Decide before #1393
+merges; after that, a follow-up is the only option.
+
 Found during TKT-WRLDAPI PR-A review; confirmed empirically against the real
-compiler. Out of that PR's scope — it is a pre-existing defect in
-`internal/worlds`, not in the API surface being added.
+compiler. Out of THAT PR's scope either way — it is a defect in
+`internal/worlds`, not in the API surface being added there.

--- a/tickets/entities/bugs/BUG-FACEVER.md
+++ b/tickets/entities/bugs/BUG-FACEVER.md
@@ -1,0 +1,65 @@
+---
+id: BUG-FACEVER
+type: bug
+title: Entity delete versions only the default face; the other N-1 faces lose their delete marker
+description: Manager.DeleteEntity reads GetEntity(id) — the default face — and records one VersionOpDelete, while the store hard-deletes the whole state family. Every non-default face's history therefore ends with no delete marker and no restore path. This is the entity half of the bug RR-181AFY fixed for cascade-deleted relations. cascadeHost.DeleteEntity captures no version at all.
+priority: medium
+status: backlog
+---
+
+## Symptom
+
+`internal/entitymanager/manager.go:909-943`:
+
+```go
+current, err := m.deps.Store.GetEntity(ctx, id)   // :910 — DEFAULT FACE ONLY
+...
+m.recordEntityVersion(ctx, store.VersionOpDelete, current, "")  // :943
+```
+
+`GetEntity(id)` addresses the bare id, which is the default state. The store's
+`DeleteEntity` then sweeps the **whole state family** — pgstore
+`entity.go:467-469` says so explicitly ("the `WHERE id = $1` statements below
+sweep every state row"), and `storetest/states.go` pins it as
+`DeleteCascadesTheFamily`.
+
+So deleting an N-face entity hard-deletes N rows and records **one** delete
+version.
+
+## Impact
+
+The version schema is fully `(entity_id, pointer)`-keyed — `insertVersion`
+writes the pointer as column 2 and folds it into the content hash
+(`pgstore/version.go:44-88`), and lineage reads filter
+`AND pointer = CAST($2 AS text)`. Per-state versioning landed in TKT-C1XUA8
+PR-B. But nothing on the delete path enumerates the family to feed it:
+`AllStates` appears **nowhere** in `internal/entitymanager`.
+
+Each non-default face's `entity_versions` lineage therefore ends on whatever
+`create`/`update` the sweep last captured, with no `delete` row. There is no
+restore path and no record that the face ever went away.
+
+This is precisely the failure `RR-181AFY` fixed for cascade-deleted
+**relations** — see the comment at `manager.go:952-955`: *"This is the ONLY
+place cascade-deleted relations get versioned: the store's DeleteEntity
+bulk-deletes them below the write choke-point, so without this their history
+would silently end with no delete marker and no restore path."* The entity
+half of the same defect was never closed.
+
+`Manager.RenameEntity` has the same shape at `manager.go:1068`: one rename row
+for the default face while the store re-keys every face
+(`storetest/states.go` `RenameCascadesTheFamily`).
+
+`cascadeHost.DeleteEntity` (`internal/entitymanager/cascadehost.go:172-208`)
+is worse — it calls the store delete at :195 with **no version capture at
+all**, only a `recordCascade` audit at :207.
+
+## Fix sketch
+
+Enumerate the family with `store.EntityQuery{IDs: []string{id}, AllStates: true}`
+before the delete and capture one `VersionOpDelete` per face, the way the
+relation loop directly below already does per relation. Same for rename.
+
+Discovered while implementing TKT-C1XUA8 PR-D (`after: discard`); deliberately
+left out of that PR because it touches the ordinary delete path, which has
+nothing to do with copies.

--- a/tickets/entities/bugs/BUG-FACEVER.md
+++ b/tickets/entities/bugs/BUG-FACEVER.md
@@ -1,8 +1,8 @@
 ---
 id: BUG-FACEVER
 type: bug
-title: Entity delete versions only the default face; the other N-1 faces lose their delete marker
-description: Manager.DeleteEntity reads GetEntity(id) — the default face — and records one VersionOpDelete, while the store hard-deletes the whole state family. Every non-default face's history therefore ends with no delete marker and no restore path. This is the entity half of the bug RR-181AFY fixed for cascade-deleted relations. cascadeHost.DeleteEntity captures no version at all.
+title: "Versioning is not face-aware end to end: delete captures the default face only, the sync relation path cannot address a tail, and capture is not transactional"
+description: "Three facets of one defect — content versioning is per-(id,pointer) in the schema but the write choke-point still addresses faces by bare id. (1) Manager.DeleteEntity records one VersionOpDelete from GetEntity(id) while the store sweeps the whole family. (2) recordRelationVersion must skip state-tailed edges because recordIDForKey has no tail predicate, so a discarded face's edges lose their delete marker. (3) Capture is best-effort outside the store.Tx, so a rollback can leave a delete version for a live row. Fixing them separately would mean touching the same seam three times."
 priority: medium
 status: backlog
 ---
@@ -54,12 +54,64 @@ for the default face while the store re-keys every face
 is worse — it calls the store delete at :195 with **no version capture at
 all**, only a `recordCascade` audit at :207.
 
-## Fix sketch
+## Facet 2 — the sync relation path cannot address a tail
 
-Enumerate the family with `store.EntityQuery{IDs: []string{id}, AllStates: true}`
-before the delete and capture one `VersionOpDelete` per face, the way the
-relation loop directly below already does per relation. Same for rename.
+`recordRelationVersion` (`internal/entitymanager/version_hook.go`) deliberately
+**returns early for any edge whose `FromPointer` is non-default**, and the
+reason is sound: the synchronous record carries only the `(from, type, to)`
+triple, and pgstore resolves that to a lineage via `recordIDForKey`
+(`internal/store/pgstore/relation_version.go`), whose live lookup is
 
-Discovered while implementing TKT-C1XUA8 PR-D (`after: discard`); deliberately
-left out of that PR because it touches the ordinary delete path, which has
-nothing to do with copies.
+```sql
+SELECT rel_record_id FROM relations
+WHERE from_id = $1 AND rel_type = $2 AND to_id = $3 AND from_pointer = ''
+```
+
+— **no tail predicate on the caller's side**. Pushing a state-tailed edge
+through it would file that edge's delete under a **sibling face's** lineage.
+
+That is worse than the gap it would close: a missing delete marker is
+recoverable, a delete marker on the wrong face's history is corruption of a
+face nothing touched, and it would be silent.
+
+Consequence today: when `after: discard` (TKT-C1XUA8 PR-E) consumes a face,
+that face's outgoing edges are hard-deleted with **no delete version**. They
+ARE audited (`OpDeleteRelation`, `triggered_by: copy:<name>`), so the loss is
+visible and attributable — but the history ends without a marker.
+
+**Do not "fix" this by removing the skip.** The skip is load-bearing; the
+actual fix is facet 4 below.
+
+## Facet 3 — capture is not transactional with the write
+
+`VersionRecorder` is a Manager-level dependency writing on its own connection,
+and capture is best-effort by contract (errors logged, never propagated). So:
+
+- capture succeeds, transaction rolls back → a delete version for a live row
+  (recoverable noise);
+- capture fails, transaction commits → the row is gone with no marker.
+
+`Manager.DeleteEntity` already admits this in a comment: *"the store delete is
+still not transactional with this capture; strict atomicity is a future
+hardening."* Same window, now on a second path.
+
+## Fix sketch (one seam, not three)
+
+1. Enumerate the family with `store.EntityQuery{IDs: []string{id}, AllStates: true}`
+   before delete/rename and capture one version per face — the way the relation
+   loop directly below already does per relation.
+2. Give the synchronous relation record a **tail** (or a `rel_record_id`) so
+   `recordIDForKey` can address the right lineage, then drop the non-default
+   skip. This is what unblocks facet 2.
+3. Capture inside the `store.Tx` — needs a view-scoped recorder. **Care
+   required**: the pgstore sweep holds `pg_try_advisory_lock` per tick and
+   issues its inserts on the held connection; a second writer inside a copy's
+   transaction interacts with that guarantee, so this is not a rider on a
+   feature PR.
+
+All three touch the same boundary between the write choke-point and the
+version store, which is why they are one ticket.
+
+Discovered while implementing TKT-C1XUA8 PR-D/PR-E; deliberately left out of
+both because they touch the ordinary delete path and the versioning seam,
+neither of which is what those PRs are about.

--- a/tickets/entities/bugs/BUG-YAMLDROP.md
+++ b/tickets/entities/bugs/BUG-YAMLDROP.md
@@ -1,0 +1,69 @@
+---
+id: BUG-YAMLDROP
+type: bug
+title: Custom UnmarshalYAML alias structs silently drop any field added to the outer type
+description: Types with a custom UnmarshalYAML (CopyDef, WorldDef, ACLBypass, ScanPolicy) decode through an inner alias struct with an explicit field list. Adding a field to the outer struct is not enough — if it is missing from the alias it parses clean and arrives as the zero value, so a declared setting silently becomes its default with no error anywhere. Hit for real by `after:` on CopyDef.
+priority: medium
+status: backlog
+why1: CopyDef.UnmarshalYAML decodes into a local `raw` struct that lists fields explicitly, and `After` was added to CopyDef but not to `raw`.
+why2: The alias-struct pattern exists to avoid infinite recursion into UnmarshalYAML, and duplicating the field list is the standard way to do that — so the duplication is deliberate and looks correct.
+why3: YAML decoding ignores unknown keys by default, so a key present in the document with no matching alias field is not an error; it is silently dropped.
+why4: The failure is invisible at every stage — the schema loads clean, validation sees the zero value as "not set", and the feature simply behaves as though the operator never wrote the line.
+why5: A structural invariant (two field lists must stay in sync) was maintained by convention, with nothing mechanical asserting it — the same class the codebase converts to guard tests elsewhere.
+prevention: A reflection guard test comparing the outer type's field count against its alias, failing with "add the new field to raw in UnmarshalYAML". This is the ceilingguard_test.go pattern — the codebase already converts prose invariants into guard tests when the failure mode is silent.
+---
+
+## Symptom
+
+`internal/metamodel/types.go`, `CopyDef.UnmarshalYAML`:
+
+```go
+type raw struct {
+    From      string            `yaml:"from"`
+    To        string            `yaml:"to"`
+    Fields    any               `yaml:"fields,omitempty"`
+    Relations map[string]string `yaml:"relations,omitempty"`
+    Guard     CopyGuard         `yaml:"guard,omitempty"`
+}
+```
+
+Adding `After` to `CopyDef` was not enough. Until it was also added to `raw`,
+`after: discard` parsed **clean** and arrived as `""`.
+
+## Impact
+
+`""` is `keep`. So an operator writing
+
+```yaml
+copies:
+  promote-policy:
+    from: policy@draft
+    to:   policy@published
+    after: discard
+```
+
+would get a promote that silently **stops consuming the draft** — no error, no
+warning, the schema loads, and the only symptom is drafts accumulating that
+should have been consumed. Caught during TKT-C1XUA8 PR-E only because the
+load-refusal tests failed; without them it would have shipped.
+
+## Scope
+
+Every type in `internal/metamodel` with a custom `UnmarshalYAML` and an inner
+alias has the same hazard. Known: `CopyDef`, `WorldDef`, `ACLBypass`,
+`ScanPolicy`. A comment now warns at `CopyDef`'s alias, which stops the
+immediate repeat but not the class.
+
+## Fix
+
+A guard test per type (or one table-driven test over them):
+
+```go
+require.Equal(t, reflect.TypeOf(CopyDef{}).NumField(), aliasFieldCount,
+    "a field was added to CopyDef but not to raw in UnmarshalYAML — it will "+
+    "parse clean and arrive as the zero value")
+```
+
+Precedent: `internal/acl/ceilingguard_test.go` does exactly this for the
+role-resolution ceiling — scans the package, fails on a new unclean file, uses
+an exemption list. Same move, different invariant.

--- a/tickets/entities/planning-checklists/PLAN-BW4X7W.md
+++ b/tickets/entities/planning-checklists/PLAN-BW4X7W.md
@@ -1,0 +1,359 @@
+---
+id: PLAN-BW4X7W
+type: planning-checklist
+title: 'Planning: ACL: world-shaped read grants, state-shaped write grants (Step 3)'
+status: in-progress
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+Full planning survey: `.ignored/dn37j2-plan.md` (survey, decisions, PR
+decomposition). Architect decisions recorded there in §8 — binding.
+
+## Understanding
+
+- [x] Problem/requirements clearly understood
+- [x] Scope defined (what's in/out documented below)
+- [x] Acceptance criteria documented with specific test scenarios
+
+**Scope:**
+
+IN — three PRs:
+
+1. **PR-A** grant syntax + all load validation + the membership refusal +
+   world-name charset + client-ceiling worlds axis + the field-redaction
+   permission constant. No new capability; parsing, validation, refusal only.
+2. **PR-B** `aclaudit` cross-file (policy × metamodel) checks. Advisory only.
+3. **PR-C** request-level world selection (`?world=`, `--world`) and the
+   read-path grant check.
+
+OUT, deliberately:
+
+- **Closing RR-FOD7IB's sync-path redaction gap** (Q7 option (c)). §8.4 of
+  the design doc is "flagged, not solved"; Step 3 must not silently become
+  the ticket that solves it. Inherited gap gets a comment + follow-up ticket.
+- **Per-tool MCP `world` parameter** (Q3). MCP read gating is itself still
+  open (TKT-4QSZ8Y, a shipping gate); a world param on an ungated surface is
+  the partial-feature shape Q10 rejected. MCP stays wiring-bound.
+- **Per-world search indexing** — Step 5 (TKT-9KZGJO). Under a non-default
+  world search REFUSES rather than degrading.
+- **Copy kernel / promote** — Step 4 (TKT-C1XUA8).
+- **UI/UX for world selection** — Ruling 7: discussed with Jeroen directly,
+  never decided by agents.
+
+**Acceptance Criteria:**
+
+1. **The membership-gate load refusal ships with the syntax** (hard AC from
+   TKT-T31NKT). `Policy.Validate` refuses a policy granting read on a
+   non-default world while EITHER `MembershipSelfPromotionOpen()` OR the new
+   `UngatedPrivilegedRoleRelationOpen()` is true. Test: both arms produce a
+   load error naming the fix; a worldless policy with an open membership
+   relation still boots warn-only (backward compat).
+2. **Existing `acl.yaml` files keep their exact meaning.** Test: a policy
+   with no `world:` token compiles to zero world grants and produces
+   byte-identical read/write verdicts.
+3. **A `world:` token never reaches the type-matching machinery.** Test:
+   `roleGrantsRead`, `grantForRole`, `filterTypes` and `aclaudit`'s
+   `verbLists` never observe a `world:`-prefixed string.
+4. **State-shaped write grants load.** Test: `update: ["policy@draft"]` with
+   `read: ["policy"]` loads clean (the F2 fix); `update: ["page@draft"]` does
+   NOT grant `page@published` or the default state (no inheritance, fail
+   closed).
+5. **The grant check precedes resolver construction.** Test: a principal
+   without the world grant gets an EMPTY result, not a 403, and the resolver
+   is never constructed. Structural guard preferred over behavioural alone.
+6. **List and GET do not diverge under a world** (design §8.1). Test: an
+   ACL-gated principal (GraphQuery pushdown branch, not AllowAll) gets the
+   same world-scoped answer from `ListEntities` and from a single-entity GET.
+7. **Search refuses under a non-default world** rather than serving
+   default-world hits.
+
+## Research
+
+- [x] ~~For larger features: run `/research`~~ (N/A: design of record already
+      exists — `.ignored/pointer-design.md` §8, plus five prior review passes.
+      A research doc would restate it.)
+- [x] Searched for existing libraries that solve this problem
+- [x] Checked codebase for similar patterns or reusable code
+- [x] Looked for reference implementations in other projects
+- [x] Reviewed relevant rela concepts for prior art
+
+**Research Doc:** N/A — `.ignored/pointer-design.md` §8 is the design of
+record; `.ignored/dn37j2-plan.md` is the implementation survey against the
+current tree.
+
+**Existing Solutions:**
+
+Libraries: none applicable — this is policy semantics over an in-tree ACL.
+
+Patterns reused (all verified against the tree):
+
+- **Fail-closed + global override permission**: TKT-73C6B2's four-part shape
+  — constant in `internal/acl` (`policy.go:58`), registered in
+  `BuiltinPermissions()` (`policy.go:71-73`), fail-closed enforced
+  structurally in `affordances` via a ctx marker + forced `optIn`
+  (`resolver.go:392-394`), override consumed at the *handler* boundary
+  selecting a wholly-bypassing path (`history_handler.go:196-227`). Note the
+  comment there: merely unsetting the marker is NOT enough.
+- **Shared predicate between linter and boot check**: TKT-T31NKT's
+  `MembershipSelfPromotionOpen` (`policy.go:290-300`) called by both
+  `aclaudit` A1 (`tier_a.go:56`) and the startup warning
+  (`appbuild.go:966`), so the two can never disagree. Extended here with
+  `UngatedPrivilegedRoleRelationOpen`.
+- **Consumer-side narrow view across an arch-lint boundary**:
+  `aclaudit.MetamodelReader` (`aclaudit.go:112-136`) with the concrete
+  adapter in `internal/cli/acl.go:144`. Gains `HasWorld`/`HasPointer`.
+- **Package-scan structural guard**: `acl/ceilingguard_test.go`,
+  `worldreader/guard_test.go`, `acl/permguard_test.go` — all fail-closed
+  exemption lists.
+- **Compile-at-load-into-allowlists**: the client ceiling
+  (`ceilingcompile.go`), whose discipline the new worlds axis must follow.
+
+## Approach
+
+- [x] Technical approach chosen and documented
+- [x] Approach builds on existing patterns (not reinventing)
+- [x] Alternatives considered (document why rejected)
+- [x] Dependencies identified (packages, APIs, types)
+
+**Technical Approach:**
+
+*Read grants* — YAML spelling stays `read: [world:published]`, but a
+`world:`-prefixed entry is **split out of `RoleDef.Read` into a new
+`RoleDef.Worlds` at policy load** (`normalizeWorldGrants`, run at the top of
+`Policy.Validate` so it cannot be bypassed — the argument `Validate` already
+makes for `normalizeAssertedRoles`). This is forced, not cosmetic: left
+inline, a world token is intersected with a client ceiling's TYPE allow/deny
+by `filterTypes` (`ceilingcompile.go:277-300`), silently dropped under an
+allowlist ceiling and silently kept under a deny ceiling. Splitting also
+keeps `roleGrantsRead`, `grantForRole`, `verbLists` and B1 seeing a pure
+type list. No `world:*` wildcard (design §4.5's auto-widening argument).
+
+*Write grants* — `type@pointer` stays JOINED in `Create`/`Update`/`Delete`,
+because `RoleDef.IsPrivileged` counts `len(r.Update) > 0`; splitting would
+make a role holding only `update: ["page@draft"]` register as
+non-privileged, **silently disabling A1/A2 and the membership warning for
+exactly the policies this feature introduces**. Parsed by a local
+`parseStateGrant` reusing `entity.ParsePointer` — NOT `entity.ParseStateRef`,
+which validates its left side with `entity.ValidateID` (rejects internal
+spaces that `metamodel.ValidateSchemaName` permits in type names; verified
+by execution).
+
+*Client ceiling* — `Restriction` gains `worlds:`/`deny_worlds:`, clamped in
+`compiledCeiling.clamp`. (Q1 as overruled: the cheap "restricted clients read
+the default world only" is fail-closed in form but fail-OPEN in outcome,
+because the default world IS the draft face under the doc's own layout.)
+
+*Selection* — grant check BEFORE resolver construction, in a new
+`appbuild.WorldSurfaceFor` taking a consumer-side `WorldGate`. It cannot live
+in `worldreader`, which is arch-lint- and package-scan-pinned to
+`{entity, store}` (guard rule 1). `internal/acl` gains
+`Request.PermitsWorld`, resolving roles through `roleFor` (THE clamp point).
+A world-bound reader handle is constructed once per request in middleware and
+carried in ctx under a typed unexported key — a constructed handle, not a
+world value, so §4.4's "no ambient world" holds.
+
+Alternatives rejected: A2-chain reachability search in `Policy.Validate`
+(§4.2 — a graph walk with cycles in the most security-sensitive load path,
+to close a hole whose necessary condition a ten-line predicate already
+catches); explicit world threading through ~39 call sites (§3.2); world as a
+plain ctx value (re-resolvable per call, the incoherence §4.4 names).
+
+**Files to modify:**
+
+PR-A: `internal/acl/policy.go` (RoleDef.Worlds, normalizeWorldGrants,
+parseStateGrant, grantsVerbOnState, Validate + the F2 write⊆read fix, the
+refusal, UngatedPrivilegedRoleRelationOpen, the new Perm constant +
+BuiltinPermissions), `internal/acl/readquery.go` (roleGrantsWorldRead),
+`internal/acl/request.go` (PermitsWorld), `internal/acl/ceiling.go` +
+`ceilingcompile.go` (worlds axis), `internal/aclaudit/tier_a.go` (A2 rewired),
+`internal/aclaudit/ceiling.go` (worlds row), `internal/metamodel/loader.go`
+(world-name charset), `internal/affordances/resolver.go` (+ the state
+fail-closed opt-in), `docs/acl-security.md`.
+
+PR-B: `internal/aclaudit/{aclaudit,tier_b}.go`, `internal/cli/acl.go`
+(adapter), `internal/metamodel` (exported pointer/world lookups — none exist
+today; `anyTypeDeclaresPointer` is unexported and is "any type").
+
+PR-C: `internal/appbuild/worldsurface.go`, `internal/dataentry/{router,
+visiblereader,api_v1,entityreader}.go`, `internal/cli/kong.go` +
+`cli_wiring.go`.
+
+## Security Considerations
+
+- [x] Input sources identified (user input, config, external APIs)
+- [x] Input validation approach defined (allowlist preferred over blocklist)
+- [x] Security-sensitive operations identified (file access, auth, crypto)
+- [x] Error handling doesn't leak sensitive information
+
+**Input Sources & Validation:**
+
+| Input | Source | Validation | On invalid |
+| --- | --- | --- | --- |
+| `read: [world:X]` | operator, `acl.yaml` | prefix split; non-empty; no `*` | hard load error |
+| `update: ["T@p"]` | operator, `acl.yaml` | `entity.ParsePointer` on the pointer half | hard load error |
+| world name | operator, `schema.yaml` | **ALLOWLIST** `[a-z][a-z0-9]*(-[a-z0-9]+)*`, matching the pointer grammar | load refusal |
+| `?world=` | **untrusted, per request** | must match a declared world via `Compiled.Lookup` (already fail-closed) | named 400/404 |
+| `--world` | operator shell | same lookup | error |
+
+The world-name charset is the one place an allowlist replaces an existing
+blocklist. `metamodel.ValidateSchemaName` is deliberately lenient (permits
+internal spaces, `/`, `?`, `&`, `%`, `#`) because entity-type names need it;
+worlds do not, and worlds now reach URLs, CLI flags, and `acl.yaml` grant
+tokens. Zero deployed instances (worlds landed in PR-A of Step 2, fixtures
+only), so tightening now costs nothing and later is breaking forever.
+
+**Security-Sensitive Operations:**
+
+- **The load refusal is the ticket's hard AC.** Fails closed; over-refuses
+  only into policies already carrying a High audit finding.
+- **Grant check strictly precedes resolver construction.** Enforced
+  structurally: `worldreader` may not import `acl`/`principal`/`visibility`
+  (arch-lint `:781` + `guard_test.go`), so the check cannot drift into it.
+  That is guard rule 1 — world resolution is principal-independent, and if
+  the gate ran first a denied prime would fall through to the next chain
+  candidate, revealing what the ACL denied.
+- **`roleFor` is THE clamp point.** `PermitsWorld` must resolve through it,
+  never `policy.Roles[...]`; `ceilingguard_test.go` fails otherwise.
+- **Error text asymmetry (Q4), deliberate and commented at both sites:**
+  unknown world → named 400/404 (a config name is not a secret; CLAUDE.md is
+  explicit that a 403 naming a config-declared capability is *more* useful);
+  known world without grant → empty 200 (contents and existence are the
+  secret; a 403 there is an existence oracle).
+- **`internal/dataentry/entityreader.go:18` is deliberately UNGATED** and
+  backs relations/serialization. Most likely Step-3 leak site: it must become
+  world-bound or be explicitly documented default-world-only.
+- **New permission constant MUST be registered** in
+  `acl.BuiltinPermissions()` — two guards fire otherwise
+  (`permguard_test.go` and `acl audit` A7 telling operators to delete a
+  working grant, BUG-NRCJ9E).
+
+## Test Plan
+
+- [x] Test scenarios documented for each acceptance criterion
+- [x] Edge cases identified and documented
+- [x] Negative test cases defined (invalid input, error conditions)
+- [x] Integration test approach defined (not just unit tests)
+
+**Test Scenarios:** AC1 → load-error tests on both refusal arms + the
+warn-only backward-compat case, named so the over-refusal reads as
+deliberate. AC2 → a golden no-`world:` policy asserting identical verdicts.
+AC3 → a scan/unit test that the split leaves `Read` world-free. AC4 → table
+test over `grantsVerbOnState` covering the three-way meaning (bare grants the
+default state only; `T@p` grants only `p`; `*` grants every type's default
+state). AC5 → denial-is-empty behavioural test + a structural guard.
+AC6 → the RR-GQWRLD shape: an ACL-gated principal (policy query present, so
+the GraphQuery pushdown branch runs) compared against the GET path under the
+same world. AC7 → `NewSurface` refusal already exists; add the handler-level
+422.
+
+Integration: dataentry handler tests through the real middleware chain, since
+the grant check lives in middleware and unit tests of the seams would miss
+ordering.
+
+**Edge Cases:**
+
+- `read: ["world:"]`, `["world:*"]`, `["world:default"]` (legal, = default
+  world), a type literally named `default` (stays a type — no ambiguity).
+- `update: ["page@"]`, `["page@Draft"]` (uppercase), `["page@a--b"]`.
+- A type whose name contains a space (`"some property"`) — the
+  `ParseStateRef` trap; must parse via `parseStateGrant`.
+- `?world=` absent/empty → default world bound explicitly at the boundary
+  (§4.4: the interior never sees "unspecified").
+- `?world=` naming a declared world the principal cannot read → empty, and
+  indistinguishable from a genuinely empty world.
+- Ceiling with `worlds:` naming a world no role grants (inert — audit).
+- Unicode/percent-encoded `?world=` values after the charset tightening.
+
+**Negative Tests:** every "hard load error" row of the validation table
+above; the pushdown/GET divergence case; a searcher present under a
+non-default world (must refuse, `ErrSearcherCannotServeWorld`).
+
+## Risk Assessment
+
+- [x] Technical risks assessed with mitigations
+- [x] Security risks assessed (see Security Considerations)
+- [x] Effort estimated (xs/s/m/l/xl)
+
+**Risks:**
+
+1. **The ceiling worlds axis is new security-relevant compilation code.**
+   Mitigation: direct unit tests on the compilation step (CLAUDE.md's
+   standing rule — compilation is the one part that can fail toward more
+   access), plus the existing `ceilingguard_test.go`.
+2. **`Validate`'s stated contract changes.** Its godoc says it is a pure
+   structural gate that does NOT flag escalation foot-guns (TKT-Z8A62F moved
+   those to `aclaudit`). The refusal is a deliberate narrow exception and the
+   godoc must say why, or the file contradicts itself.
+3. **`rela acl audit` now refuses to load a policy the server rejects**
+   (Q6, accepted). Mitigation: the load error carries the full A1 fix text
+   and names `rela acl audit`.
+4. **`entityReader` ungated path** — risk 1 for an actual leak; explicit AC.
+5. **Survey method blind spot** (Ruling 5): this plan is grep-plus-read, not
+   AST-parsed. `aclmap` returned zero grant-list hits — the right outcome,
+   but evidence by absence. Flagged for `/design-review` and `/code-review`.
+
+**Effort:** l (unchanged) — three PRs, one of which is validation-only.
+
+## Documentation Planning
+
+- [x] User-facing docs identified
+- [x] Docs-checklist will be created when entering implementation
+
+**Documentation Impact:**
+
+- [x] `docs/acl-security.md` — flip the "This becomes a hard requirement with
+      content states" section (`:77-93`) from future to present tense. It
+      already promises this refusal to operators **in writing**, so shipping
+      without updating it leaves the docs lying in the other direction.
+      Also: the new grant syntax, the override permission, the ceiling axis.
+- [x] `docs/metamodel.md` — world-name charset.
+- [x] `docs/cli-reference.md` — `--world`.
+- [ ] `docs/data-entry.md` — deferred: any UI surfacing is Ruling 7 (Jeroen).
+- [x] CLAUDE.md — the "bare grants mean the default world / no inheritance
+      between states" rule is exactly the kind of invariant that gets
+      re-litigated; it belongs there.
+
+**Migration note owed:** an operator who adds `pointers:` to an existing type
+finds their existing `update: ["page"]` now covers only the default face.
+That is the correct fail-closed reading and it must be documented, not
+discovered.
+
+## Design Review
+
+- [x] Run `/design-review` before starting implementation
+- [ ] All critical/significant findings addressed in plan
+
+**Design Review Findings:** 10 findings, all VERIFIED against the tree before
+filing (the reviewer was right on every one I checked; three landed exactly in
+the blind spot §9 of the plan predicted).
+
+CRITICAL — RR-WEKTVV, RR-Q1LI2Y, RR-H98VX0, RR-LWE222, RR-SU4T68
+SIGNIFICANT — RR-YALMJ1, RR-TFATPO, RR-NFDPOA, RR-4TFZNL, RR-AC7GAH
+
+**BLOCKED on the architect — two findings undercut binding §8 rulings:**
+
+- **RR-WEKTVV vs Q5.** The approved refusal rests on "an ungated privileged
+  role-relation is a NECESSARY condition of every chain". It is not, because
+  `IsPrivileged` (policy.go:361-363) excludes `Read` by design (RR-LXI3NW).
+  This ticket makes a read grant escalation-relevant for the first time, so
+  `role_relations: {owns: {confers: viewer}}` ungated + `viewer: {read:
+  [world:published]}` is a DIRECT one-write self-promotion into a world grant
+  that BOTH proposed arms miss. Needs a third arm (a world-holding role counts
+  as privileged for the refusal) — probably a separate `IsWorldPrivileged()`
+  rather than widening `IsPrivileged`, which would shift A1/A2/A3 severity
+  semantics tree-wide.
+- **RR-SU4T68 vs Q2.** The "~3 seams, ~0 handlers" figure Q2 was approved on
+  is wrong: `store.GetEntity` takes no query struct so it CANNOT carry a
+  world (a `store.Store` interface question with storetest implications), and
+  50+ raw read paths plus whole subsystems (views, document render + its
+  world-blind cache key, commands, sidebar counts, search, tracer, caldav,
+  sync, MCP, Lua) bypass any handle. PR-C's scope needs re-deriving.
+
+Not blocked, foldable into PR-A once the above are settled: RR-Q1LI2Y
+(export the canonical predicates, delete the `internal/docs` copy),
+RR-H98VX0 (migration destroys grants), RR-LWE222 (normalize at
+`NewDeclarative` too), RR-YALMJ1 (B1/B8 in PR-A, not PR-B; fix the §2.3
+citation), RR-TFATPO (`deny_worlds` vs the implicit default world),
+RR-NFDPOA (spell the guard signature), RR-4TFZNL (`(bool, error)`),
+RR-AC7GAH (charset is a control; watch the metamodel→entity arch-lint edge).

--- a/tickets/entities/review-checklists/REV-7SY12K.md
+++ b/tickets/entities/review-checklists/REV-7SY12K.md
@@ -1,0 +1,74 @@
+---
+id: REV-7SY12K
+type: review-checklist
+title: 'Review: ACL: world-shaped read grants, state-shaped write grants (Step 3)'
+status: in-progress
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Automated Checks
+
+- [ ] All tests pass (`just test`)
+- [ ] Lint clean (`just lint`)
+- [ ] Comment lint gate clean (`just comment-lint`)
+- [ ] Coverage maintained (`just coverage-check`)
+
+**Comment findings.** `just comment-report` lists the advisory rules
+(duplication, nil-contract, param-contract, restatement). They are not a merge
+gate, but a finding your diff *introduces* should be fixed or suppressed — don't
+grow the backlog.
+
+Every rule is a heuristic over prose, so false positives are expected. To
+suppress one, prefer the inline form on the declaration line, which travels with
+the code and is reviewed in this diff:
+
+```go
+func f(p string) {} //commentlint:ignore param-contract  p is contained by Clone
+```
+
+Use `.commentlint.yml` (`ignore:` path globs, `allow-phrases:`) only when the
+same prose recurs across many sites. A reason is required either way — an
+unexplained suppression is a finding nobody can re-evaluate later.
+
+## Code Review
+
+- [ ] Run `/code-review` command (invokes cranky-code-reviewer agent)
+- [ ] All critical review-responses addressed
+- [ ] All significant review-responses addressed
+- [ ] Self-reviewed the diff for unrelated changes
+
+**Review Responses:** <!-- List IDs of review-response entities created, e.g.,
+RR-xxxx -->
+
+## Acceptance Verification
+
+- [ ] Each acceptance criterion tested (reference planning checklist)
+- [ ] Test evidence documented in implementation checklist
+
+**Acceptance Status:**
+<!-- For each acceptance criterion, state PASS/FAIL with evidence -->
+
+## Documentation (enhancements only)
+
+Skip this section for bugs and internal refactors.
+
+- [ ] Docs-checklist created and linked via `has-docs`
+- [ ] User-facing documentation updated
+- [ ] Docs-checklist marked as done
+
+**Docs Checklist:** <!-- e.g., DOCS-xxxx -->
+
+## Final Checks
+
+- [ ] Commit message explains the why, not just what
+- [ ] No TODOs or FIXMEs left unaddressed
+- [ ] Ready for another developer to use
+
+## Pull Request
+
+- [ ] Run `/pr` command to create PR and monitor CI
+- [ ] All CI checks pass
+- [ ] PR URL documented below
+
+**PR:** <!-- e.g., https://github.com/org/repo/pull/123 -->

--- a/tickets/entities/review-checklists/REV-T3OXWC.md
+++ b/tickets/entities/review-checklists/REV-T3OXWC.md
@@ -1,0 +1,74 @@
+---
+id: REV-T3OXWC
+type: review-checklist
+title: 'Review: Copy kernel and declared copy definitions (Step 4)'
+status: in-progress
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Automated Checks
+
+- [ ] All tests pass (`just test`)
+- [ ] Lint clean (`just lint`)
+- [ ] Comment lint gate clean (`just comment-lint`)
+- [ ] Coverage maintained (`just coverage-check`)
+
+**Comment findings.** `just comment-report` lists the advisory rules
+(duplication, nil-contract, param-contract, restatement). They are not a merge
+gate, but a finding your diff *introduces* should be fixed or suppressed — don't
+grow the backlog.
+
+Every rule is a heuristic over prose, so false positives are expected. To
+suppress one, prefer the inline form on the declaration line, which travels with
+the code and is reviewed in this diff:
+
+```go
+func f(p string) {} //commentlint:ignore param-contract  p is contained by Clone
+```
+
+Use `.commentlint.yml` (`ignore:` path globs, `allow-phrases:`) only when the
+same prose recurs across many sites. A reason is required either way — an
+unexplained suppression is a finding nobody can re-evaluate later.
+
+## Code Review
+
+- [ ] Run `/code-review` command (invokes cranky-code-reviewer agent)
+- [ ] All critical review-responses addressed
+- [ ] All significant review-responses addressed
+- [ ] Self-reviewed the diff for unrelated changes
+
+**Review Responses:** <!-- List IDs of review-response entities created, e.g.,
+RR-xxxx -->
+
+## Acceptance Verification
+
+- [ ] Each acceptance criterion tested (reference planning checklist)
+- [ ] Test evidence documented in implementation checklist
+
+**Acceptance Status:**
+<!-- For each acceptance criterion, state PASS/FAIL with evidence -->
+
+## Documentation (enhancements only)
+
+Skip this section for bugs and internal refactors.
+
+- [ ] Docs-checklist created and linked via `has-docs`
+- [ ] User-facing documentation updated
+- [ ] Docs-checklist marked as done
+
+**Docs Checklist:** <!-- e.g., DOCS-xxxx -->
+
+## Final Checks
+
+- [ ] Commit message explains the why, not just what
+- [ ] No TODOs or FIXMEs left unaddressed
+- [ ] Ready for another developer to use
+
+## Pull Request
+
+- [ ] Run `/pr` command to create PR and monitor CI
+- [ ] All CI checks pass
+- [ ] PR URL documented below
+
+**PR:** <!-- e.g., https://github.com/org/repo/pull/123 -->

--- a/tickets/entities/review-responses/RR-3TV7F4.md
+++ b/tickets/entities/review-responses/RR-3TV7F4.md
@@ -1,0 +1,17 @@
+---
+id: RR-3TV7F4
+type: review-response
+title: 'An allowlist worlds: ceiling silently revoked the default world'
+finding: |-
+    VERIFIED. With baseline `worlds: [published]`, permitsWorld("default") and permitsWorld("") both returned FALSE. So an operator scoping a client to the published world silently took away its ability to read the default world.
+
+    That is the same misreading the Q1 overrule spent a paragraph on, pointed the other way: the default world IS the draft face under the design doc's layout, so a client scoped to `published` would find its ordinary reads vanishing for a reason nothing in its config states. `worlds: [published]` reads as 'this client may ALSO reach published', not 'published and nothing else, including what it could already read'.
+
+    It was fail-closed, so not a leak — but it was undocumented, untested, and a trap.
+severity: significant
+resolution: |-
+    permitsWorld now admits the DEFAULT world unless it is EXPLICITLY denied (`deny_worlds: [default]`). A ceiling narrows what it NAMES, and the default world is the one world a grant never names — it is the absence of an entry.
+
+    The explicit-denial path still delegates to worlds.permits, so a scope grant can re-open a denied default world via the existing `except` semantics. Two tests pin both halves: TestCeilingWorlds_AllowlistDoesNotRevokeDefaultWorld and TestCeilingWorlds_ScopeReopensDeniedDefaultWorld.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-4GHZ60.md
+++ b/tickets/entities/review-responses/RR-4GHZ60.md
@@ -1,0 +1,27 @@
+---
+id: RR-4GHZ60
+type: review-response
+title: 'PR-B: three grants the linter failed to explain, and an untested alias claim'
+finding: |-
+    Four findings from the PR-B code review, all verified by execution before fixing. None is a security hole — every gap fails closed — but three are the linter failing at the one job it has: explaining a silent denial to an operator who cannot see why their grant does nothing. A linter that misdiagnoses is worse than no linter, because now someone trusts it.
+
+    1. `*@draft` produced ZERO findings while granting nothing. Verified: acl.GrantsVerbOnState honors `*` only for the default state, so `*@draft` matches an entity whose type is literally named `*`. B1 skipped it as a wildcard; B11 skipped it as an undeclared type. An operator writing it reasonably believes they granted draft-write across every type.
+
+    2. `world:Default` (any case variant) was flagged with a fix the loader REFUSES. Verified the emitted text: 'declare world "Default" under `worlds:`' — but validateWorlds rejects any name case-folding to "default" as reserved. The operator follows the advice, gets a schema load failure, and now has two problems. The grant IS dead (roleGrantsWorldRead compares case-sensitively), so flagging it was right; only the remedy was wrong.
+
+    3. On a policy that skipped Validate, RoleDef.Worlds is unpopulated, so B10 examined nothing and B1 instead reported the world token as an undeclared ENTITY TYPE — misleading advice at High severity, which gates CI.
+
+    4. metamodel.HasWorld/HasPointer had NO direct tests. Every assertion ran against fakeMetamodel, whose HasPointer is a different implementation with no alias handling at all — so HasPointer's doc claim 'resolves aliases through GetEntityDef' was asserted by a comment and verified by nothing.
+severity: significant
+resolution: |-
+    1. B11 special-cases the type wildcard before the HasEntityType gate, with a fix naming both real options (name each type, or drop the `@state`). Pinned by TestB11_TypeWildcardWithState, which also asserts a bare `*` is NOT flagged.
+
+    2. New `defaultWorldCaseVariant` helper, shared by the role-grant and ceiling paths, emitting a message that points at the lowercase spelling instead. TestB10_DefaultWorldCaseVariant asserts the fix does NOT say 'declare world "Default"'.
+
+    3. B10 now also scans Read for residual `world:` tokens and B1 skips them, so the diagnosis is right either way and there is exactly one finding. Audit's godoc states the precondition regardless. Pinned by TestB10_DiagnosesUnvalidatedPolicy.
+
+    4. Added internal/metamodel/worldpointer_test.go. Writing it caught that the alias claim needs InitAliases() — a hand-built Metamodel literal has no aliasMap, so ResolveAlias is a no-op and the case would have passed vacuously. Now genuinely verified.
+
+    Also: collapsed grantEntityType onto splitStateGrant (one splitter), fixed a comment naming a function that never existed, and reworded B11's fix to note that adding a `pointers:` block to satisfy an ACL typo is a schema change with real semantic consequences.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-4TFZNL.md
+++ b/tickets/entities/review-responses/RR-4TFZNL.md
@@ -1,0 +1,17 @@
+---
+id: RR-4TFZNL
+type: review-response
+title: PermitsWorld returning a bare bool collapses store outage into silent empty-200
+finding: |-
+    VERIFIED. dn37j2-plan.md §3.1 proposes `func (r *Request) PermitsWorld(ctx, world string) bool`, modelled on holdsPermission (resolver.go:265-267).
+
+    Wrong model. The world grant is a READ capability, and this package's read paths are error-carrying deliberately: PermitsRead returns (bool, error) (request.go:145), PermitsReadMany returns (map, error) (request.go:163), and listPushdown fails closed AND propagates (visibility/pushdown.go:74-79).
+
+    PermitsWorld as specified calls r.Globals(ctx) -> walkMembers (resolver.go:79-104), which on a graph error returns a PARTIAL result rather than erroring. So under a store outage PermitsWorld returns false for a principal who genuinely holds the grant. Fail-closed — fine so far. But per binding Q4 the caller must render false as EMPTY 200, indistinguishable from 'no grant'.
+
+    Net effect: a store outage becomes a silently empty page with NO operator signal and NO 500. That is the wrong failure mode for infrastructure failure, and it is the same class of error Q4 already resolved for the unknown-vs-denied distinction — two failure modes deserve two answers.
+
+    FIX: `PermitsWorld(ctx, world string) (bool, error)`. WorldSurfaceFor distinguishes DENIAL (empty 200, per Q4) from INFRASTRUCTURE ERROR (500). Same discipline Q4 applied.
+severity: significant
+status: open
+---

--- a/tickets/entities/review-responses/RR-4TP758.md
+++ b/tickets/entities/review-responses/RR-4TP758.md
@@ -1,0 +1,24 @@
+---
+id: RR-4TP758
+type: review-response
+title: 'PR-C shipped mixed-face responses: world-resolved entity, draft relations and neighbors'
+finding: |-
+    VERIFIED. The two world-capable handlers resolved the ENTITY through the world but read its relations and neighbors through the ungated, default-world entityReader:
+
+    - handleV1ListEntities -> a.reader.outgoing/incomingRelations (api_v1.go:632-633)
+    - handleV1GetEntity -> a.reader.outgoingRelations (api_v1.go:778)
+    - resolveV1Includes -> outgoingRelations + getEntity (api_v1.go:1565-1587)
+    - computeEntityETag -> outgoingRelations (api_v1.go:1904)
+
+    So `GET /api/v1/tickets/TKT-100?world=published&include=*` returned the published body wrapped in draft edges and draft included neighbors. This is exactly the mixed-face bug entityreader.go's own comment describes as 'hardest to see, because the entity would look right and its neighbors would not' — live in the two routes the PR allowlisted.
+
+    MY GUARD MISSED IT, and that is the more important defect: TestWorldCapableRoutesDoNotUseUngatedReader scanned scopedSortedEntities and getWorldEntity — the two store HELPERS — while the leak was in the HANDLERS that wrap them. It checked a proxy for the design instead of the design, and passed against broken code.
+
+    The ETag case is a distinct bug: folding default-world edges into the validator means a published-world GET could answer 304 against a draft-derived ETag — cross-world cache poisoning.
+severity: critical
+resolution: |-
+    A world-bound response now carries NO relations: both handlers read edges only when worldScopeFrom(ctx).IsDefaultWorld(). `?include=` is refused with 422 under a non-default world, and resolveV1Includes ALSO returns nil there — a defense living only in middleware is one route registration away from being bypassed. computeEntityETag folds the world NAME into the hash and skips the edge read when world-bound.
+
+    The guard was rewritten to scan the handlers transitively (handleV1ListEntities, handleV1GetEntity, resolveV1Includes, computeEntityETag) and to require that any function touching a.reader also consults the world. Rewriting it immediately surfaced two further leaks I had not fixed (resolveV1Includes, computeEntityETag) — which is the evidence it now checks the property rather than a proxy for it.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-6D7P4A.md
+++ b/tickets/entities/review-responses/RR-6D7P4A.md
@@ -1,0 +1,23 @@
+---
+id: RR-6D7P4A
+type: review-response
+title: 'Copy kernel authorized nothing for same-entity: a stranger could promote a draft they cannot read'
+finding: |-
+    VERIFIED by execution. My authorizeCopy returned nil for a same-entity copy whose definition had no `guard:`. The source read is elevated/raw, the target write was deliberately exempt from the ordinary write grant, so NO check of any kind ran:
+
+      HOLE: stranger mallory promoted PAGE-1. created=true props=map[secret:classified title:Draft]
+
+    Mallory held no role, could not read PAGE-1, could not write it — and published its draft including the field she may not see.
+
+    The reasoning that produced this is worth recording because it was persuasive and wrong. §9.2 says a guarded state is writable only by copy definitions naming it as target, 'each carrying its own guard'. I read that as making the definition the authority and dropped the checks. But 'each carrying its own guard' is a CONDITION, and I had made the guard optional — so the sentence's premise was unmet and the conclusion did not hold. The reviewer's phrasing is exact: I deleted a check and the godoc rationalized it. The godoc was self-refuting too, citing 'the ordinary read path' as authorization when for same-entity that path is explicitly elevated and gates nothing.
+severity: critical
+resolution: |-
+    Three checks, none redundant:
+
+    1. READ on the source, ALWAYS (new Deps.CopyReadGate). Elevation decides which FIELDS travel, not whether the principal may touch the entity — without this, elevation becomes a way to read what you cannot read.
+    2. The definition's guard, now MANDATORY AT LOAD for any definition targeting a non-default face (validateCopy), so §9.2's sentence always applies rather than being conditioned on operator diligence.
+    3. WRITE on the target for CROSS-ENTITY only — new identity, new audience, so it is an ordinary create.
+
+    The same-entity target stays exempt from (3) because nobody holds update on published by design; (1) and (2) stand in its place. Pinned by TestCopy_StrangerCannotPromote, verified to bite: removing the source read check reproduces the hole verbatim.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-AC7GAH.md
+++ b/tickets/entities/review-responses/RR-AC7GAH.md
@@ -1,0 +1,21 @@
+---
+id: RR-AC7GAH
+type: review-response
+title: World-name charset is a security control, not hygiene — and the loader comment claiming it is handled is wrong
+finding: |-
+    VERIFIED. dn37j2-plan.md §6 frames the tightening as 'hygiene, correctly sequenced'. Understated.
+
+    ValidateSchemaName (metamodel/validation.go:43-56) blocks ONLY: empty, single-quote, backslash, \x00-\x1f, \x7f, and leading/trailing whitespace. It PERMITS `/`, `..`, `%`, `?`, `#`, `&`, `=`, `:`, double-quote, internal spaces, and all non-ASCII (incl. U+2028/U+2029 and RTL overrides).
+
+    So `../admin`, `a b`, `pub%2f`, `world?x=1` all load clean TODAY. If world names ever become URL PATH segments rather than query values, `..` is a traversal primitive.
+
+    The loader comment at metamodel/loader.go:716-719 already asserts this is handled — 'A world name reaches URLs, acl.yaml and CLI flags in later steps. The empty name is the dangerous one.' That comment is WRONG ON ITS OWN TERMS: empty is not the only dangerous name, it is merely the only one currently blocked. Fix the comment along with the check.
+
+    The plan's proposed grammar [a-z][a-z0-9]*(-[a-z0-9]+)* is correct and matches entity.pointerPattern (entity/pointer.go:58) exactly — good.
+
+    TWO REQUIREMENTS THE PLAN OMITS:
+    1. Do NOT write a third copy of the regex. Reuse/export entity's pattern; confirm arch-lint allows metamodel -> entity (it currently does NOT: metamodel mayDependOn is {migration, storage}). If the boundary blocks it, validate in internal/worlds like Q6 of Step 2 did for pointer grammar — there is precedent.
+    2. §6 asserts 'no shipped or fixture metamodel declares a world outside the grammar'. VERIFY before landing, including prototypes/ and docs-project/.
+severity: significant
+status: open
+---

--- a/tickets/entities/review-responses/RR-C40NEZ.md
+++ b/tickets/entities/review-responses/RR-C40NEZ.md
@@ -1,0 +1,21 @@
+---
+id: RR-C40NEZ
+type: review-response
+title: 'PR-A code review: missing gate tests, clamp coverage guard, and three doc-vs-code mismatches'
+finding: |-
+    Five smaller findings from the PR-A code review, all verified:
+
+    1. `Request.PermitsWorld` — the one new EXPORTED security gate, and the thing PR-C builds on — had ZERO tests. The load validation around it was heavily tested; the gate itself was not.
+    2. `compiledCeiling.clamp` rewrites six fields, and a seventh grant axis added later and forgotten would produce no compile error and no test failure. RR-TFATPO asked for a coverage guard and it was skipped.
+    3. aclaudit.go godoc cited `TestGrantEntityType_MatchesACLSplit` as pinning the duplicated grantTypeOf helper. That test did not exist — a citation to a nonexistent guard is worse than none, because the next reader trusts it.
+    4. validateWorldNames rendered `invalid pointer "a b"` for a WORLD name — leaking a noun the operator never used.
+    5. An aclaudit ceiling comment forward-referenced `B10-ceiling-undeclared-world` as though coverage existed elsewhere. No such rule exists.
+severity: minor
+resolution: |-
+    1. Added TestPermitsWorld (6 cases: named grant, ungranted world, default via ordinary read, bare grant does not reach a non-default world, read wildcard does not either, no roles at all) plus TestPermitsWorld_CeilingOverridesRoleGrant covering the ceiling composition.
+    2. Added TestClampCoversEveryGrantAxis — a reflect-based guard asserting every slice field on RoleDef is either narrowed by a permit-nothing ceiling or explicitly exempted with a stated reason. Verified it bites: deleting the Worlds clamp line fails it with a message naming the fix.
+    3. Wrote the cited test, through acl's exported behaviour rather than the unexported helper.
+    4. Error message rewritten to state the grammar directly; the comment notes the grammar is reused but the vocabulary deliberately is not.
+    5. Comment now says the check is not implemented and names where it lands, instead of a rule ID that does not exist.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-DQX0H0.md
+++ b/tickets/entities/review-responses/RR-DQX0H0.md
@@ -1,0 +1,21 @@
+---
+id: RR-DQX0H0
+type: review-response
+title: 'Step 4 PR-A: stale who-can guarantee, untested create branch, and two doc omissions'
+finding: |-
+    Three further findings from the PR-A code review, all verified:
+
+    1. WHO-CAN UNDER-REPORTS, AND ITS GODOC CLAIMED IT COULD NOT. `grantingAttributions` (access.go:260) still calls the type-granular grantsVerb, which skips state grants. Post-change the runtime authorizes page@draft for a role holding `update: ["page@draft"]`, while `rela acl who-can update page` reports NOBODY. The godoc directly above asserted 'The write path IS this attribution set, so equivalence is by construction' — true when RR-Q1LI2Y chose to skip state grants, because back then they authorized nothing. This PR killed that premise. The direction is safe (a false negative in a security report, never a false all-clear) but an operator told 'nobody can update this' while a client updates it hourly stops trusting the tool, which is worse than a loud wrong answer.
+
+    2. THE CENTERPIECE TEST COVERED ONE OF TWO BRANCHES. TestExistingGrantsUnchangedByPointerField passed ID:"PAGE-1" on every case including the create one, so it always took the `s.ID != ""` branch of authorizeEntityWrite. The `else` branch — globals-only, the path a real create with no id yet takes — was never exercised, by the test whose comment claims to pin the property for 'every existing call site'.
+
+    3. Two smaller ones: `decideFromAttrs(attrs, op, s.FromType, "", ...)` passed an untyped "" that reads as an empty deny-format string at a glance (the adjacent argument IS a format string); and subject.go's sealed-sum diagram showed RelationSubject with no indication that its face-blindness is deliberate and temporary — that rationale lived only in a comment 55 lines away.
+severity: significant
+resolution: |-
+    1. Corrected the guarantee rather than papering over it: AccessRoutes' godoc now states plainly that equivalence is no longer by construction, that the divergence is deliberate ('who can update page?' is a question about a TYPE and the report has no face in hand), and that the answer is a documented LOWER BOUND. Named the fix if operators need exactness — threading a pointer through AccessRoutes. Also corrected AssertedGrants' and grantingAttributions' comments, and principalGrantsCreate's 'mirrors the resolution grantsVerb performs at write time', which is no longer true.
+
+    2. Added TestCreateWithoutIDStillAuthorized — four cases with `EntitySubject{Type: "page"}`, no ID and no Pointer, exercising the globals-only fork.
+
+    3. `entity.Pointer("")` explicit at the authorization call site; the sealed-sum diagram now annotates both variants ('Pointer zero = default face' / 'default tail only — see authorizeRelationWrite').
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-E0L2PG.md
+++ b/tickets/entities/review-responses/RR-E0L2PG.md
@@ -1,0 +1,12 @@
+---
+id: RR-E0L2PG
+type: review-response
+title: 'A2 did not share the refusal predicate: audit reported clean on a policy the server refuses'
+finding: |-
+    VERIFIED. Ruling 8 requires, verbatim, that `checkUngatedRoleRelations` call the extracted predicate 'so the linter and the boot refusal cannot diverge (TKT-T31NKT's shared-predicate property, extended)'. PR-A's first cut did not do that — A2 kept its own inline loop over p.RoleRelations using isPrivileged(role), while the refusal used UngatedPrivilegedRoleRelationOpen + roleIsEscalationRelevant.
+
+    They already disagreed by exactly the world term. A policy refused at load for `owns → viewer{read: [world:published]}` produced NO A2 finding — so `rela acl audit` reported clean on a policy the server refuses to boot. That is the worst possible operator experience here, because the refusal's own error text tells them to run that audit for the full picture.
+severity: significant
+resolution: 'Extracted `Policy.RoleRelationEscalates(relType)` as the per-relation predicate and had BOTH consume it: aclaudit''s checkUngatedRoleRelations and UngatedPrivilegedRoleRelationOpen (the refusal''s second arm). Verified by running the audit over the counterexample policy — it now emits `A2-ungated-role-relation [high] owns`, matching the refusal.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-H98VX0.md
+++ b/tickets/entities/review-responses/RR-H98VX0.md
@@ -1,0 +1,22 @@
+---
+id: RR-H98VX0
+type: review-response
+title: 'ACL provisioner migration DESTROYS a state-shaped create: grant'
+finding: |-
+    VERIFIED, and it is destructive, not merely blind. Not mentioned anywhere in the plan.
+
+    internal/migration/acl_provisioner_grant.go:
+    - hasCreateTarget (:264-277) walks the `create:` YAML SequenceNode comparing `t.Value == "*" || t.Value == userType`.
+    - On false, ensureRoleGrantsCreate (:243-259) calls SetMapNode(def, "create", createList(userType)).
+    - createList returns a ONE-ELEMENT sequence, and SetMapNode REPLACES the value node outright (`node.Content[i+1] = value`).
+
+    So `create: ["person@draft", "ticket"]` becomes `create: ["person"]`. The state-shaped grant is destroyed AND the unrelated `ticket` grant is collateral damage. Silent, on a routine migration run.
+
+    This is a YAML-node access path that never mentions RoleDef, so a struct-field grep could not see it — the blind-spot class dn37j2-plan.md §9 flagged.
+
+    Sibling checked: acl_scheduler_grant.go:114-148 (hasReadTargets) is LENGTH-only, so a world grant counts as a read target and it does not fire. Lower risk, but it writes ["*"] when it does fire — audit it in the same pass.
+
+    FIX: teach hasCreateTarget the joined form (compare on the type half). Regression test: a migration over a policy carrying `type@pointer` and `world:` grants must be a no-op.
+severity: critical
+status: open
+---

--- a/tickets/entities/review-responses/RR-J1DXK3.md
+++ b/tickets/entities/review-responses/RR-J1DXK3.md
@@ -1,0 +1,20 @@
+---
+id: RR-J1DXK3
+type: review-response
+title: Writes accepted ?world= and silently mutated the default state
+finding: |-
+    VERIFIED. worldCapablePath was METHOD-BLIND, so `/api/v1/tickets/{id}` was world-capable for every verb:
+
+      PATCH  /api/v1/tickets/TKT-1?world=published -> 200, wrote the DEFAULT state
+      DELETE /api/v1/tickets/TKT-1?world=published -> 200, deleted the entity
+      POST   /api/v1/tickets?world=published       -> 201, created in the DEFAULT world
+
+    All three reached the handler with a non-default worldHandle bound. handleV1UpdateEntity reads via the world-blind reader and writes through the entitymanager with no world in sight.
+
+    An operator editing 'the published copy' silently edits the draft. Worse for DELETE: a caller who believes they are unpublishing deletes the underlying entity. Both return success, which is what makes them dangerous — the parameter is accepted, so the caller has no reason to doubt it was honored.
+
+    This also directly contradicts design §9.4 ('writes never pass through worlds', a hard rule with its own pinning test) and my own file header calling this 'the read API' — a claim nothing enforced.
+severity: critical
+resolution: attachWorld now refuses a non-default world on anything but GET/HEAD/OPTIONS with a 422 (`world_read_only`). Pinned by TestAttachWorld_WritesRefuseAWorld across POST/PATCH/PUT/DELETE, which also asserts the same writes WITHOUT ?world= pass through untouched. Documented in the data-entry guide.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-LWE222.md
+++ b/tickets/entities/review-responses/RR-LWE222.md
@@ -1,0 +1,23 @@
+---
+id: RR-LWE222
+type: review-response
+title: normalizeWorldGrants in Policy.Validate is bypassable via NewDeclarative
+finding: |-
+    VERIFIED. dn37j2-plan.md §2.1 argues the split 'cannot be bypassed — the same argument Validate already makes for normalizeAssertedRoles'. That argument does not hold here.
+
+    acl.NewDeclarative (declarative.go:83) — the constructor that turns a *Policy into a thing that SERVES READS — does not call Validate (grep confirms zero Validate() calls in declarative.go), and its godoc does not require a validated policy.
+
+    Bypass paths:
+    - internal/visibility/visibilitytest/suite.go:150-154 — a NON-test file in the normal build — does `var p acl.Policy; yaml.Unmarshal(...); acl.NewDeclarative(&p, ...)` and exercises real read gating.
+    - internal/appbuild/appbuild.go:653-656 (NewFromCollaborators) lifts a policy out of a caller-supplied *acl.Declarative; never validated.
+    - policy.go:559-561: LoadPolicyBytes returns &Policy{} on empty input without calling Validate.
+    - ~175 test-constructed acl.Policy{...} literals reaching NewDeclarative.
+
+    Failure mode: RoleDef.Worlds stays empty and "world:published" remains inline in Read, where roleGrantsRead (readquery.go:117-123) never matches it. SILENT, and it lands in exactly the state §1.1 identifies as hazardous under filterTypes.
+
+    Same concern applies to the load REFUSAL: a refusal that only fires in Validate is not a refusal for any path that skips Validate.
+
+    FIX: make normalizeWorldGrants idempotent and ALSO call it from NewDeclarative — Validate is the LOAD chokepoint, NewDeclarative is the SERVE chokepoint, and they are different. Consider a `validated bool` set by Validate with NewDeclarative rejecting an unvalidated policy, converting silent bypasses into one loud fix-up. Note ValidateAgainstMetamodel (policy.go:836) already has an unenforced dependency on Validate having run (comment at :875).
+severity: critical
+status: open
+---

--- a/tickets/entities/review-responses/RR-LXJF8I.md
+++ b/tickets/entities/review-responses/RR-LXJF8I.md
@@ -1,0 +1,23 @@
+---
+id: RR-LXJF8I
+type: review-response
+title: 'grantsVerb widened write authority: a state grant authorized the default face'
+finding: |-
+    VERIFIED by execution before fixing. PR-A's first cut changed grantsVerb to `grantTypeOf(t) == target`, so `update: ["page@draft"]` returned TRUE from grantsVerb(role, OpUpdate, "page").
+
+    Why that is a widening and not a convenience: grantsVerb IS the live write-authorization path (decideFromAttrs, authz_write.go:103, which knows the entity type but not yet which FACE is being written). GrantsVerbOnState — the face-granular check — had ZERO production callers. So the narrowest grant the new syntax offers would have authorized MORE than the operator wrote and more than they had before: a grant must never widen by being made more specific.
+
+    Also verified two consequences of an entity type legitimately containing '@' (ValidateSchemaName is a blocklist that permits it):
+    - a grant on a type named `a@b` STOPPED matching it (regression)
+    - a grant on `a@b` STARTED matching a different type named `a` (cross-type escalation)
+severity: critical
+resolution: |-
+    Two-part fix.
+
+    1. grantsVerb now SKIPS state-shaped entries entirely (`isStateGrant` -> continue) and compares bare entries literally as before. A state grant authorizes nothing until the write path is face-aware — the fail-closed direction, costing an operator a denied write they will ask about rather than a silent over-permit nobody notices. The godoc states this is half of a two-part change and names GrantsVerbOnState as the other half.
+
+    2. Entity type names may no longer contain '@' (metamodel/loader.go, entity-type-specific rather than in the shared ValidateSchemaName, since property names are not grant subjects). This closes the ambiguity at the root in both directions.
+
+    grantForRole (access.go, backing `rela acl who-can` / `rela acl map`) got the same skip, so the operator-facing reports agree with the runtime.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-MSM79V.md
+++ b/tickets/entities/review-responses/RR-MSM79V.md
@@ -1,0 +1,24 @@
+---
+id: RR-MSM79V
+type: review-response
+title: The denied-world empty response had an obvious signature — it WAS the existence oracle it closed
+finding: |-
+    VERIFIED by diffing the two responses. writeEmptyWorldResponse hand-built `{"data":[]}`; the real list endpoint returns:
+
+      REAL:  {"data":[],"meta":{"total":0,...},"_actions":{"create":true}}
+             + Link, X-Total-Count, X-Page, X-Per-Page headers
+      FAKE:  {"data":[]}
+             + Content-Type only
+
+    Missing meta, missing _actions, five missing headers. Any client — including the SPA, which reads meta.total — distinguishes them on the first byte. Since a GRANTED-but-empty world produces the real shape, the bare body meant 'you lack the grant' and the full one meant 'the world is empty for you'. The mechanism designed to close an existence oracle was one.
+
+    The single-entity path had the same defect in miniature: my synthetic 404 used the literal 'not found' while a genuine miss uses entityNotFoundTitle.
+
+    And my test could not catch any of it: TestAttachWorld_DeniedWorldIsIndistinguishable grepped the body for the words 'denied' and 'permission' — a proxy for the property, not the property.
+severity: critical
+resolution: |-
+    Removed the synthetic writer entirely. A denied world now binds a handle marked `denied` and lets the ORDINARY handler run: the read seams (scopedSortedEntities, getVisible) return nothing, so the real code produces the real empty shape — same JSON, same meta, same _actions, same headers, same status.
+
+    The test was replaced with TestDeniedWorldIsByteIdenticalToAnEmptyWorld, which runs the real handler twice — once under a world the principal MAY read that happens to hold nothing, once under a denied world — and compares bodies, status, and five headers. Verified it bites: making the denied path return an error instead fails it on X-Total-Count.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-ND21P3.md
+++ b/tickets/entities/review-responses/RR-ND21P3.md
@@ -1,0 +1,25 @@
+---
+id: RR-ND21P3
+type: review-response
+title: Client ceiling silently deleted state-shaped grants — and the narrower ceiling was the destructive one
+finding: |-
+    VERIFIED by execution. `filterTypes` (ceilingcompile.go:283) intersected the role's grant list against the ceiling by comparing WHOLE LITERALS. A state grant is the literal "page@draft", which never equals "page" and is not "*", so under an allowlist ceiling it failed the permits check and was deleted from the role:
+
+      allowlist update:[page]  -> Update after clamp = [page]              <- page@draft GONE
+      allowlist update:[*]     -> Update after clamp = [page@draft page]
+      deny_update:[other]      -> Update after clamp = [page@draft page]
+
+    Two things make this worse than a plain fail-closed.
+
+    1. THE INVERSION. The wildcard branch returns early, so the BROAD ceiling `update: ["*"]` KEPT the state grant while the NARROWER `update: ["page"]` destroyed it. A grant surviving the broad ceiling and dying under the specific one is the same 'widening by being made more specific' inversion grantsVerb's own godoc warns against.
+
+    2. THE DENIAL BLAMED THE WRONG LAYER. Result was Allow=false with RuleKind="role-grant" and 'no role grants update on type "page"'. But the ceiling PERMITS update on page and the role HOLDS update on page@draft. An operator reading the audit log is sent to inspect an acl.yaml whose grant is plainly present. decideFromAttrs' own comment says the client-ceiling vs role-grant distinction exists precisely so that cannot happen.
+
+    Invisible before this PR because grantsVerb skipped state grants anyway — so this PR is what made the latent clamp bug reachable, which puts it in scope. It would have bitten the copy kernel first: TKT-C1XUA8's whole premise, 'published is writable only via copy definitions', is expressed as a state grant, and under any allowlist or scope-grant ceiling that grant would have evaporated.
+severity: critical
+resolution: |-
+    filterTypes now matches on the TYPE half (`v.permits(grantTypeOf(t))`), preserving the entry. A ceiling names entity TYPES, so it clamps at type granularity and lets GrantsVerbOnState adjudicate the face.
+
+    Still fail-closed: a DENIAL reaches every face regardless, because permitsVerb runs before the role loop against the subject's bare type. Pinned by TestCeilingClampsOnTypeNotLiteral across four ceiling shapes, asserting BOTH the verdict and the RuleKind — a denial must name the layer that actually caused it. Verified it bites: reverting to whole-literal matching reproduces the exact misleading denial.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-NFDPOA.md
+++ b/tickets/entities/review-responses/RR-NFDPOA.md
@@ -1,0 +1,25 @@
+---
+id: RR-NFDPOA
+type: review-response
+title: worldreader guard_test's signature pin is a no-op; plan cites it as structural
+finding: |-
+    VERIFIED. dn37j2-plan.md §3.1 and PLAN-BW4X7W's Security Considerations both lean on worldreader/guard_test.go as making it 'structurally impossible' for the grant check to live in worldreader.
+
+    The import-scan half (guard_test.go:41-48, forbidding acl/visibility/principal/affordances/aclmap with a fail-closed exemption list) is REAL and does work.
+
+    The signature half does NOT. guard_test.go:98 is:
+
+        var newResolver = worldreader.NewResolver
+
+    No type annotation — Go infers whatever NewResolver's type currently is. Adding a gate or principal parameter COMPILES CLEANLY and this test still passes. The comment above it (:92-97) claims 'Adding a gate parameter would have to change this call, which is the point' — the comment asserts a guarantee the code does not provide.
+
+    Also: the import ban would not catch a gate passed as a LOCALLY-DECLARED narrow interface (`type gate interface{ PermitsRead(...) bool }` inside worldreader imports nothing forbidden) — which is this codebase's own mandated consumer-side-interface convention.
+
+    So 'the grant check structurally cannot live in worldreader' is an overstatement: the import ban makes it awkward, nothing makes it impossible.
+
+    FIX (cheap, do it in PR-A): spell the type explicitly —
+        var newResolver func(worldreader.StateReader, store.WorldScope, worldreader.TypeCanonicalizer) (*worldreader.Resolver, error) = worldreader.NewResolver
+    That makes the claim the plan already relies on actually true. Note this is a pre-existing defect in Step 2's deliverable, not introduced here.
+severity: significant
+status: open
+---

--- a/tickets/entities/review-responses/RR-Q1LI2Y.md
+++ b/tickets/entities/review-responses/RR-Q1LI2Y.md
@@ -1,0 +1,25 @@
+---
+id: RR-Q1LI2Y
+type: review-response
+title: internal/docs/resolvers_acl.go is a second, hand-copied grant matcher the survey missed
+finding: |-
+    VERIFIED. dn37j2-plan.md §1.1 presents a table headed 'Its consumers, enumerated exhaustively' with eight rows. It is not exhaustive: internal/docs/resolvers_acl.go:116-136 reimplements the match.
+
+      func grantsList(list []string, target string) bool {
+          for _, t := range list { if t == "*" || t == target { return true } }
+          return false
+      }
+
+    Its own comment says it 'replicate[s] the policy's wildcard-or-exact match over the exported RoleDef grant lists (the policy's own helpers are unexported)'. roleGrantsVerb (:94-99) dispatches read -> grantsList(role.Read, typ), else a local grantsVerb copy (:116-127). It reads dr.policy.Roles[rn] RAW and UN-CLAMPED (:67) — i.e. it also bypasses the roleFor ceiling clamp point, though as a docs generator that is arguably in scope.
+
+    Two consequences:
+
+    1. WRITE GRANTS (kept joined per binding §8): `update: ["page@draft"]` renders in the `rela docs` role matrix as 'cannot update page' — a FALSE ALL-CLEAR in an operator-facing security document, disagreeing with what acl.grantsVerb actually permits.
+    2. RoleDef.Worlds: the matrix has no worlds axis and would silently omit the entire new grant kind.
+
+    This is exactly the blind spot dn37j2-plan.md §9 predicted (I grepped acl/aclmap/aclaudit/affordances and did not grep internal/docs).
+
+    FIX: export the canonical predicates from internal/acl and delete the copy. A duplicated authz matcher is not acceptable while the grammar changes under it.
+severity: critical
+status: open
+---

--- a/tickets/entities/review-responses/RR-SU4T68.md
+++ b/tickets/entities/review-responses/RR-SU4T68.md
@@ -1,0 +1,21 @@
+---
+id: RR-SU4T68
+type: review-response
+title: 'PR-C scope wrong: GetEntity cannot carry a world, and ~50+ raw read paths bypass the handle'
+finding: |-
+    VERIFIED on both halves. dn37j2-plan.md §3.2-3.3 claims '~3 seams change, ~0 handlers' plus entityReader flagged. Both parts are wrong.
+
+    (a) THE CHEAPEST SEAM STRUCTURALLY CANNOT WORK. visibleReader.getVisible (visiblereader.go:65) calls store.GetEntity(ctx, id). store.EntityReader.GetEntity (store.go:238) takes NO query struct — `GetEntity(ctx, id string)` — so there is nowhere to put a WorldScope. EntityQuery.World and GraphQuery.World exist; GetEntity has no equivalent. Fixing it means either a new store method or routing single-entity GETs through a list query — a store.Store interface change with storetest conformance implications. THE PLAN DOES NOT MAKE THIS DECISION, and it materially resizes PR-C.
+
+    (b) filterVisible takes already-fetched entities; 'making it world-bound' is meaningless — whoever produced the candidates already read the default face.
+
+    (c) entityReader is ~50 call sites, not 'a decision': api_v1.go (14 sites incl. computeEntityETag at :1890 — a world-bound GET with a default-face ETag is a cross-world 304 bug), relation_read_handler.go, relation_history_handler.go, history_handler.go, history_restore.go, handlers_attachment.go, views_handler.go, export.go, export_list.go, relations_direction.go, relation_visibility.go, plus write-path read-before-write sites.
+
+    (d) WHOLE SUBSYSTEMS reach the store raw and are absent from the plan: views.go traversal; document.go:460,563 render AND its cache key (computeDocumentHash is world-blind, so a world-bound render COLLIDES with the default render in the cache); commands.go:427,440 (no read gate at all); views_handler.go:320-347 sidebar counts; helpers.go:725,729 raw Searcher.Search feeding INTO scopedSortedEntities at api_v1.go:326; visibility/tracer.go; caldav; sync.go; MCP (23 sites); Lua ReadDeps (8 sites).
+
+    (d)'s search row is the sharpest: worldreader.NewSurface REFUSES searcher+non-default-world (surface.go:86-95), but the live list path feeds raw searcher hits straight into a seam the plan claims to fix. §3.3 names /_search, ?q= and _position but misses helpers.go:690/725 as the actual mechanism.
+
+    FIX: re-derive PR-C. Needs (i) an enumerated, STRUCTURALLY ENFORCED set of world-safe read paths with every other path REFUSING under a non-default world; (ii) the GetEntity question resolved as a named design decision; (iii) a guard test enumerating ungated sites so the list cannot grow silently. As specified, PR-C ships a world selector that leaks the default world through dozens of endpoints.
+severity: critical
+status: open
+---

--- a/tickets/entities/review-responses/RR-TFATPO.md
+++ b/tickets/entities/review-responses/RR-TFATPO.md
@@ -1,0 +1,22 @@
+---
+id: RR-TFATPO
+type: review-response
+title: deny_worlds cannot deny the default world through clamp — the ceiling axis has an inverted wildcard hazard
+finding: |-
+    VERIFIED, and it inverts the plan's own claim. dn37j2-plan.md §2.3 says 'there is no world wildcard by design, so the re-check is simpler'. Backwards.
+
+    THE HOLE: the default world is IMPLICIT — it is the ABSENCE of a world grant, not an entry. So a role with `Worlds: []` means 'default world only'. A ceiling with `deny_worlds: [default]` intersects [] with anything and gets [] — which STILL means the default world. The denial is a NO-OP. That is fail-open, structurally identical to the gap permitsRead exists to close (readquery.go:33-35), and it cannot be fixed inside clamp at all.
+
+    SECOND, WORSE: compiledCeiling.clamp (ceilingcompile.go:251-261) rewrites exactly five fields. A new RoleDef.Worlds that clamp merely IGNORES produces NO compile error and NO guard-test failure — ceilingguard_test.go scans for `policy.Roles[` access, not field coverage. That is precisely the fail-open the Q1 overrule was meant to prevent, and nothing structural catches it.
+
+    UNDER-SPECIFIED COMPOSITION POINTS (§2.3 says 'participates like every other axis'; that is five separate tables in ceiling.go:140-290, three of which the plan leaves undefined):
+    1. Narrows() (:153-159) — must add both, else a worlds-only baseline reads inert and A11 flags it.
+    2. denySpellings() (:163-185) — needs a deny_worlds row.
+    3. validateSpellings() (:198-227) — needs {"worlds","deny_worlds"}. Does deny_write (which fans out to three verbs at :216-241) interact with worlds? Should be no (worlds are read-side) but must be DECIDED.
+    4. validateNoBlanks() (:246-280).
+    5. expandClientAttenuation (:348-358) mutates ClientBaselines/ScopeGrants INSIDE Validate (policy.go:716); its ordering vs normalizeWorldGrants is unstated.
+
+    FIX: specify permitsWorld as a MANDATORY post-check consulted by Request.PermitsWorld, not an optional 'wildcard re-check'. Decide explicitly how the implicit default world is denied — probably it can only be enforced at PermitsWorld, never through clamp. Add a field-coverage guard for clamp.
+severity: significant
+status: open
+---

--- a/tickets/entities/review-responses/RR-VLQ5WM.md
+++ b/tickets/entities/review-responses/RR-VLQ5WM.md
@@ -1,0 +1,30 @@
+---
+id: RR-VLQ5WM
+type: review-response
+title: 'Three more PR-C criticals: phantom edge tail, missing authority-minting mitigation, unevaluated guard.when'
+finding: |-
+    Three further criticals from the PR-C review, all verified:
+
+    1. PHANTOM EDGE TAIL. copy_apply.go used `plan.to.Pointer` — the DECLARED name — while every other site routed through StoredPointer. A pointer marked `default: true` IS the zero coordinate, so a revise-into-draft wrote the entity at "" but its edges at "draft": orphaned from any face. Two failures from one line, because `replace` then queried the correct tail, found nothing, and left the stale edge:
+
+      EDGE ptr=""          cites SPEC-12   <- stale, replace missed it
+      EDGE ptr="draft"     cites SPEC-9    <- phantom tail
+
+    My own StoredPointer godoc names this exact failure ('two rows claiming to be the same face') and then the adjacent file committed it.
+
+    2. §9.2's FIRST authority-minting mitigation was MISSING ENTIRELY. The design names two: exclude identity-scoped/role-conferring relation types, AND authorize cross-entity edges per-edge. Only the second existed. validateCopyRelations never read relDef.Scope despite RelationScope.IsIdentity() being available, and nothing in aclaudit mentioned copies — so it was not relocated per Q6, it was dropped. Probe: a definition naming an identity-scoped `owned-by` loaded clean and DUPLICATED the edge onto a state tail, breaking §2.2's invariant that identity edges attach to the bare id.
+
+    3. `guard.when` was declared, godoc'd as 'False refuses the copy (422)', and NEVER EVALUATED. grep for Guard.When returns nothing outside the type definition. An operator writes `when: "source.status == 'approved'"`, the schema loads clean, and unapproved drafts publish. A silently-ignored security control is worse than an absent one, because the operator stops looking.
+
+    Also minor: the target-existence probe folded every store error into 'does not exist', so a transient read failure became a silent full overwrite whose audit record said created=true.
+severity: critical
+resolution: |-
+    1. The tail is resolved ONCE on copyPlan (sourceTail/targetTail), beside the other three resolutions, removing the chance of a fourth divergence. Pinned by TestCopy_EdgesLandOnTheStoredTail, which also gives relation copying and `replace` their first coverage; verified to bite — reintroducing the declared name fails it on both the phantom tail AND the stale edge.
+
+    2. validateCopyRelations now refuses any identity-scoped relation at load, with an error explaining that such an edge is shared by every state so copying it duplicates an edge that may confer roles. Role-conferring types live in acl.yaml which the metamodel cannot see, but they are overwhelmingly identity-scoped, so this catches the class.
+
+    3. A non-empty `guard.when` is REFUSED at load as unimplemented. Chosen over a silent accept (the one option that must not ship) and over implementing it inside a PR already carrying four security fixes — refusing costs an operator a startup message and cannot mislead.
+
+    4. The probe now distinguishes ErrNotFound from a real error and fails loud.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-WEKTVV.md
+++ b/tickets/entities/review-responses/RR-WEKTVV.md
@@ -1,0 +1,27 @@
+---
+id: RR-WEKTVV
+type: review-response
+title: Refusal misses a read-only role holding a world grant — IsPrivileged excludes Read
+finding: |-
+    VERIFIED, and sharper than the design review framed it: this is a DIRECT self-promotion into a world grant, not a chain.
+
+    acl.RoleDef.IsPrivileged (policy.go:361-363) is `len(Create)>0 || len(Update)>0 || len(Delete)>0 || len(Permissions)>0` — Read is deliberately excluded per RR-LXI3NW/RR-UR0LJU, on the reasoning that 'a read-everything role is a visibility choice, not an escalation path'.
+
+    TKT-DN37J2 INVALIDATES that reasoning. Once `read: [world:published]` exists, a read-only role can hold a non-default-world grant, and self-granting it IS the escalation — it is literally the threat docs/acl-security.md:77-93 describes.
+
+    Counterexample defeating BOTH proposed refusal arms:
+
+      role_relations:
+        member-of: { requires_permission: delegate-admin }   # A1 arm => false (gated)
+        owns:      { confers: viewer }                       # ungated
+      roles:
+        viewer: { read: [world:published] }                  # IsPrivileged => FALSE
+
+    A2's checkUngatedRoleRelations (tier_a.go:76-78) does `if !ok || !isPrivileged(role) { continue }`, so it skips `owns` entirely. My proposed arm (b) (UngatedPrivilegedRoleRelationOpen) inherits that skip. A1 is false because membership is gated. The policy loads clean — and one `owns` edge write self-grants a published-world read.
+
+    This also falsifies the plan's stated NECESSARY-CONDITION claim in dn37j2-plan.md §4.4, which the architect approved as fact in §8 Q5: 'an ungated privileged role-relation is a necessary condition of every A2-shaped chain'. It is not, because 'privileged' does not count world grants.
+
+    Secondary (weaker, but real): Policy.AssertedRoles is read by computeGlobals (resolver.go:57-65) but scanned by neither predicate (RR-8ZOICR). A role reachable only via an IdP claim is invisible to both arms.
+severity: critical
+status: open
+---

--- a/tickets/entities/review-responses/RR-X0YJAF.md
+++ b/tickets/entities/review-responses/RR-X0YJAF.md
@@ -1,0 +1,21 @@
+---
+id: RR-X0YJAF
+type: review-response
+title: 'PR-C: outage rendered as an empty world, duplicate ?world= resolved silently, ordering pinned only by source scan'
+finding: |-
+    Three further PR-C findings, all verified:
+
+    1. getWorldEntity returned real store errors and getVisible folded them into not-found -> 404. On the WORLD path the underlying read is a ListEntities iterator whose error is ALWAYS infrastructure (a genuine miss is errWorldEntityAbsent), so a backend outage under ?world=published rendered as 'this entity has no published face'. That is the exact mistake resolveWorld refuses to make one file over (RR-4TFZNL) — made in the opposite direction, in the same PR.
+
+    2. `?world=` used Query().Get(), which takes the FIRST value. So `?world=default&world=published` served the default world under a request that also asked for published — a client-side param-append bug becoming a silent wrong-face serve.
+
+    3. TestGrantCheckPrecedesResolverConstruction asserted SOURCE order only. Its premise (last wrap = outermost) is correct, but it is fooled by moving either call into a helper, and nothing in the suite exercised attachWorld through the real router at all.
+severity: significant
+resolution: |-
+    1. getVisible now propagates any non-errWorldEntityAbsent error on the world path (5xx), while the default-world branch keeps GetEntity's inherited miss-is-not-found contract unchanged.
+
+    2. More than one ?world= is now a 400 (`duplicate_world`) rather than resolved by a precedence rule nobody would remember. Pinned by TestAttachWorld_DuplicateParamRejected.
+
+    3. Added TestWorldGrantCheckThroughTheRealRouter — a real Declarative ACL denying the world, driven through app.NewRouter(). Getting it to DISCRIMINATE took a second pass: the stub world initially excluded everything, so 'denied' and 'permitted' both rendered empty and the test passed under reversed ordering. The stub now resolves to the default state, so the two outcomes genuinely differ. Verified both guards now fail when the middleware order is reversed.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-YALMJ1.md
+++ b/tickets/entities/review-responses/RR-YALMJ1.md
@@ -1,0 +1,20 @@
+---
+id: RR-YALMJ1
+type: review-response
+title: 'aclaudit: B1/B8 are the checks that break, not A9/A7; and B1 fires in PR-A not PR-B'
+finding: |-
+    VERIFIED. dn37j2-plan.md §1.5 and §2.3 point at the wrong checks.
+
+    IMMUNE (plan wrongly implicated / cited): A9-wildcard-write (tier_a.go:225-242) only calls hasWildcardWrite, testing `== "*"`; A7-dead-permission (tier_a.go:180-220) iterates Permissions, never types. Neither is affected by type@pointer.
+
+    ACTUALLY BREAKS:
+    - B1 checkUndeclaredEntityTypes (tier_b.go:29-59) consumes verbLists (aclaudit.go:233-240) INCLUDING create/update/delete. m.HasEntityType("page@draft") => false => HIGH finding. cli/acl.go gates --exit-code on High, so EVERY state-shaped write grant FAILS CI. The plan lists B1 but only for the READ arm; the WRITE arm is the one that fires under the binding §8 decision to keep write grants joined. CONSEQUENCE: this must land in PR-A, not PR-B, because PR-A introduces the syntax and must be green alone.
+    - B8 ceilingTypeFindings (aclaudit/ceiling.go:231-253): an 8-axis table doing the same `t == "*" || m.HasEntityType(t)` check at :240, emitting High. §2.3's PR-A item cites aclaudit/ceiling.go:125-135 — that is the A12 unreachableTargets table, NOT B8. WRONG CITATION in the plan; correct it to ceiling.go:231-238.
+    - A12 (ceiling.go:120-143) compares by exact string, so a baseline closing bare `page` is not seen as closing `page@draft` => Low-severity false 'reopens nothing'.
+
+    ALSO: B1 shares a `seen` dedupe map across all four verbs (tier_b.go:33,37), so a bogus string in create suppresses a genuine finding for the same string in read.
+
+    ALSO for RoleDef.Worlds: verbLists (aclaudit.go:233-240) and affordanceTypeKeys (aclaudit.go:256-283) hard-code their field lists non-reflectively — a new field is invisible with NO compile error. And A10's whitespace scan (tier_a.go:247-281) does not cover world names, so `worlds: [" prod"]` is silently inert, the exact failure class A10 exists for.
+severity: significant
+status: open
+---

--- a/tickets/entities/review-responses/RR-ZI2PF7.md
+++ b/tickets/entities/review-responses/RR-ZI2PF7.md
@@ -1,0 +1,17 @@
+---
+id: RR-ZI2PF7
+type: review-response
+title: NewDeclarative mutated the SharedBase-shared policy (concurrent map write)
+finding: |-
+    VERIFIED. normalizeWorldGrants writes `p.Roles[name] = role`, and NewDeclarative calls it. The path SharedBase.Assemble → resolveACL → buildACL(base.aclPolicy) → NewDeclarative means every assembly wrote to the *Policy pointer the base hands to EVERY tenant.
+
+    That contradicts the SharedBase godoc (appbuild.go:1088-1095), which states flatly that 'Assembly only reads them' and explains why: a mutation is visible to every other consumer of the same base — cross-tenant in a multi-tenant host, cross-project on the desktop.
+
+    The values converge (the split is idempotent), so this is not a wrong-answer bug. But two parallel Assemble calls are a concurrent map write on p.Roles, which is a hard panic, not a benign race. TestSharedBase_AssemblyDoesNotMutateSharedValues does not catch it — it compares metamodel counts and the project context, not the policy's role map.
+severity: significant
+resolution: |-
+    normalizeWorldGrants now early-continues on any role with no `world:` token still in Read (new `roleHasWorldToken` helper), so an ALREADY-SPLIT policy — which every Validate-loaded one is — never reaches the map write at all. The shared-policy path becomes a pure read.
+
+    Chosen over cloning the policy: a clone would silently drop the split for the caller's own policy, which is exactly the silent-misconfiguration shape RR-LWE222 was about. The comment at the early-continue says it is load-bearing for shared policies rather than an optimization, so it does not get 'simplified' away.
+status: addressed
+---

--- a/tickets/entities/tickets/TKT-C1XUA8.md
+++ b/tickets/entities/tickets/TKT-C1XUA8.md
@@ -5,7 +5,7 @@ title: Copy kernel and declared copy definitions (Step 4)
 kind: enhancement
 priority: high
 effort: l
-status: backlog
+status: review
 ---
 
 Design doc §9. Kernel: write fields/body/edges/attachment-links into a target

--- a/tickets/entities/tickets/TKT-DN37J2.md
+++ b/tickets/entities/tickets/TKT-DN37J2.md
@@ -5,7 +5,7 @@ title: 'ACL: world-shaped read grants, state-shaped write grants (Step 3)'
 kind: enhancement
 priority: high
 effort: l
-status: backlog
+status: review
 ---
 
 Design doc §8.

--- a/tickets/entities/tickets/TKT-F2D5U5.md
+++ b/tickets/entities/tickets/TKT-F2D5U5.md
@@ -1,10 +1,10 @@
 ---
 id: TKT-F2D5U5
 type: ticket
-title: 'ISMS demo: draft/published policy lifecycle with promote, end to end in the UI'
+title: 'Demo: one rela config exercising BOTH axes — ISMS policy lifecycle + multilingual blog posts'
 kind: enhancement
 priority: high
-effort: m
+effort: l
 status: backlog
 ---
 
@@ -43,3 +43,59 @@ on that surface or label it.
 
 **Explicitly minimal on content:** a handful of policies, enough to show
 resolution and promotion. Not a full ISO 27001 control set.
+
+---
+
+## SCOPE SET BY JEROEN 2026-08-23: both scenarios in ONE config
+
+A single axis would not prove the primitive generalises, so the demo carries
+two entity types on two different axes:
+
+- **`policy`** — the STAGE axis (`draft` → `published`). A lifecycle:
+  one-way, and the draft is CONSUMED by promotion. Published is not directly
+  editable; it changes only via the `promote-policy` copy definition.
+- **`blog-post`** — the LANGUAGE axis (`en`, `nl`, `fr`). Peers, not a
+  lifecycle: any-to-any, the source SURVIVES, several targets exist at once.
+
+**This does NOT require multi-axis** (design doc §11, deliberately not built
+in v1). Multi-axis means ONE entity holding a combined coordinate
+(`nl+draft`); here each TYPE uses ONE axis, which is exactly what shipped.
+Do not attempt `for_each` world templates either (§4.5, tentative) — declare
+the worlds concretely.
+
+## What the demo must show
+
+The same UI primitive rendering two ways, driven by which copy definitions
+name the currently-viewed face as their source:
+
+- Published policy: ONE applicable definition -> a single **"go to draft"**
+  button (operator-configurable text).
+- English blog post: THREE applicable definitions -> a **menu**, one entry
+  per language.
+
+Plus: the copy succeeding with a message and navigation to the result; the
+"other faces exist" indicator (one entry for policy, a list for blog-post);
+and a published-world reader genuinely unable to see drafts.
+
+## UX decisions — made by Jeroen, recorded as RULING 9
+
+Implement them; do not re-decide them. Promote is a button on the draft; no
+permission -> no button; a published face has NO edit button but carries a
+"go to draft" action, hidden when the draft is inaccessible; promote
+confirms by default (operator-configurable); success = message + navigate;
+creating an absent face is an EXPLICIT TARGETED action, never a silent
+auto-fork; faces the viewer may not read are OMITTED ENTIRELY.
+
+## Backend prerequisite (ships BEFORE this ticket starts)
+
+`after: discard | keep` per copy definition, default `keep` — the ISMS draft
+is consumed by promotion, the English blog post is not. Small: the kernel
+already runs in one `store.Tx`, so `discard` is a delete inside it, never a
+second operation that can half-fail. Follow-up PR on the Step-4 stack, so
+this ticket is pure SPA work over a settled backend.
+
+## Known limitation to handle honestly
+
+A world-bound surface cannot carry search until per-world indexing
+(TKT-9KZGJO, Step 5). Either omit search on that surface or label it — do
+not let it silently return default-world hits.

--- a/tickets/entities/tickets/TKT-F2D5U5.md
+++ b/tickets/entities/tickets/TKT-F2D5U5.md
@@ -1,0 +1,45 @@
+---
+id: TKT-F2D5U5
+type: ticket
+title: 'ISMS demo: draft/published policy lifecycle with promote, end to end in the UI'
+kind: enhancement
+priority: high
+effort: m
+status: backlog
+---
+
+The first real user-facing demonstration of FEAT-9CD2MX (content states and
+worlds). Requested 2026-08-23.
+
+**Scenario:** a minimal ISMS project (3-5 `policy` entities) where:
+
+- A **published** policy is served to readers and is **NOT directly
+editable** — no role holds `update` on `policy@published`; it changes only via
+the promote copy definition (design doc §9.2).
+- A **draft** face is editable by authors and invisible to published-world
+readers (existence in a world IS the publication bit, §4.1).
+- **Promote** copies draft → published as an audited, guarded operation
+(§9.1), and the published world immediately serves the new face.
+
+**Gated on Steps 3 and 4 — this cannot be demonstrated honestly before them:**
+- TKT-DN37J2 (Step 3) makes `policy@published` unwritable and introduces
+request-level world selection with its grant check. Without it, an editor can
+simply write the published state and the demo's central property is a claim
+rather than a fact.
+- TKT-C1XUA8 (Step 4) provides the copy kernel and the declared `promote`
+definition. Without it, "promotion" means hand-editing the published file.
+
+**SPA work this ticket owns** (not covered by Steps 3/4, which are backend):
+- A world selector on editor surfaces, driven by the Step-3 grant so a
+principal only sees worlds they may read.
+- A promote affordance on a draft, routed through the existing `_actions`
+machinery (UI hint, re-authorized server-side per §9.3 rule 1).
+- Showing provenance: which face is displayed and whether it arrived by
+fallback (§4.2 guard rule 2) — a reader must be able to tell "published" from
+"default, because nothing is published yet".
+- Handling the Step-2 limitation honestly: a world-bound surface cannot
+carry search until per-world indexing (Step 5, TKT-9KZGJO). Either omit search
+on that surface or label it.
+
+**Explicitly minimal on content:** a handful of policies, enough to show
+resolution and promotion. Not a full ISO 27001 control set.

--- a/tickets/entities/tickets/TKT-WRLDAPI.md
+++ b/tickets/entities/tickets/TKT-WRLDAPI.md
@@ -63,6 +63,26 @@ buildable today proceeds in parallel on the list surface.
    So: scope the detail read through the world and resolve its links via
    `Neighbors`. *Unblocks every Ruling-9 affordance having a page to live
    on.*
+4b. **World-enable `_views/` — and carry provenance on its collections
+   (RULING 14).** This is the item that makes the SPA's DETAIL PAGE work:
+   `EntityDetail.vue` reads `fetchView()` -> `GET /_views/{type}/{id}`,
+   which is `_`-prefixed and blanket-refused by `worldCapablePath`. Item 4
+   fixes the entity GET and list rows; the page the user actually opens
+   still cannot switch worlds until this lands.
+
+   **Provenance belongs HERE, not on the entity-GET relations map.**
+   `viewResult.Collections` is `map[string][]*entity.Entity` (`views.go:16`)
+   — the neighbours are already whole entities, so attaching `_world` to
+   each is additive, unlike the relations map where a neighbour is a bare
+   ID string (Ruling 13). This delivers "this link is a real Dutch page vs
+   the English fallback" with **no extra requests**, which is what the
+   Ruling 13 caveat identified as the real cost of deferring.
+
+   Known design questions, not yet decided: does a traverse rule's `where:`
+   run against the resolved face? What does the 10-pass fixpoint do when a
+   neighbour is excluded by `otherwise: exclude` mid-traversal? `views.go`
+   reads raw `store.GetEntity`, which takes no scope parameter.
+
 5. **Copies: list-by-source + invoke-by-name, and `label:` on `CopyDef`.**
    A request may only invoke a definition BY NAME (transforms-registry
    precedent); the endpoint must **re-authorize the guard server-side**

--- a/tickets/entities/tickets/TKT-WRLDAPI.md
+++ b/tickets/entities/tickets/TKT-WRLDAPI.md
@@ -40,13 +40,29 @@ buildable today proceeds in parallel on the list surface.
    published yet".*
 3. **`pointers` on `_schema`'s EntityType** — a client cannot currently learn
    that `policy` has draft/published.
-4. **World-capable detail read.** `_views/{type}/{id}` 422s under a world by
-   construction (`worldCapablePath`, `world.go:220-234`), and it cannot
-   simply be allowlisted: `views.go:21,159` read via `store.GetEntity`, which
-   takes **no scope parameter** (`store.go:238`) — world resolution exists
-   only on the `ListEntities`+`World` path. Either scope that handler or move
-   the SPA detail page to `GET /{plural}/{id}`. **Design decision, not
-   plumbing.** *Unblocks every Ruling-9 affordance having a page to live on.*
+4. **World-capable detail read, INCLUDING relations (RULING 12).** Jeroen
+   settled the shape 2026-08-23: relations resolve through the SAME world as
+   the entry, per neighbour, independently. An ISMS published view links to
+   published faces; a preview world with chain `[draft, published]` links to
+   drafts where drafts exist; a Spanish page links to Spanish where Spanish
+   exists and English where it does not. The fallback chain does this
+   automatically — it is not configured twice.
+
+   This is **not a design fork**; the previously-offered options (scope the
+   entry only / omit neighbours / move to the thin endpoint) all mis-framed
+   it as "how much of the neighbour question do we avoid". The answer is
+   none of it.
+
+   The machinery already exists: `worldreader.RelationReader.Neighbors` does
+   the per-relation-type scope dispatch (identity types query a nil tail,
+   content types the prime's pointer, merged) and its godoc states it exists
+   so the dispatch is "UNREPRESENTABLE to omit". What is missing is that the
+   detail handler does not call it: `views.go:21,159` read via
+   `store.GetEntity`, which takes **no scope parameter** (`store.go:238`).
+
+   So: scope the detail read through the world and resolve its links via
+   `Neighbors`. *Unblocks every Ruling-9 affordance having a page to live
+   on.*
 5. **Copies: list-by-source + invoke-by-name, and `label:` on `CopyDef`.**
    A request may only invoke a definition BY NAME (transforms-registry
    precedent); the endpoint must **re-authorize the guard server-side**
@@ -74,8 +90,9 @@ buildable today proceeds in parallel on the list surface.
 - Items 1-3 are small and additive. Item 4 is a design decision. Item 5
   should not have its shape chosen unilaterally by an agent.
 - Under a non-default world the backend currently refuses `?include=` (422)
-  and emits **no relations** (`api_v1.go:794-797`, `639-643`). Decide
-  deliberately whether that stays; the SPA has to honour it either way.
+  and emits **no relations** (`api_v1.go:794-797`, `639-643`). Per RULING 12
+  both are **GAPS TO CLOSE, not decisions to preserve** — neighbour titles a
+  client asks for must come from the world-resolved faces.
 - **Do not add a face-enumeration path that lets a client probe which faces
   exist.** That reconstructs the existence oracle `errWorldDenied` was
   designed to close.

--- a/tickets/entities/tickets/TKT-WRLDAPI.md
+++ b/tickets/entities/tickets/TKT-WRLDAPI.md
@@ -1,0 +1,81 @@
+---
+id: TKT-WRLDAPI
+type: ticket
+title: 'Worlds on the wire: schema discovery, face provenance, copy endpoint, world-capable detail read'
+kind: enhancement
+priority: high
+effort: l
+status: backlog
+---
+
+The content-states backend is complete and correct, but **most of it is not
+reachable from a client**. Verified live 2026-08-23 against `/tmp/isms-demo`:
+world resolution, published-world filtering, language fallback and the
+read-only refusal on a published face all work — while world *discovery*,
+face *provenance*, and the copy kernel itself have no HTTP surface at all.
+
+`entitymanager.Manager.CopyState` (`copy.go:142`) has **zero non-test callers
+repo-wide** — not HTTP, not CLI, not Lua, not MCP. Promote works in Go tests
+and nowhere else.
+
+This ticket adds the surface. It blocks TKT-F2D5U5 items 3-8 (the demo's
+promote / go-to-draft / provenance affordances); the SPA slice that IS
+buildable today proceeds in parallel on the list surface.
+
+## Work, in dependency order
+
+1. **`worlds` on `/api/v1/_schema`** — declared world names plus per-principal
+   readability. `PermitsWorld` (`dataentry/readgate.go:53`) already answers
+   per name; this needs an enumeration. Today `_schema` returns only
+   `{entities, relations}`, and `metamodel.Metamodel.Worlds`
+   (`metamodel/types.go:59`) has a yaml tag and **no JSON tag**.
+   *Unblocks the world selector.* NOTE: `world.go:144` carries a comment
+   claiming the declared worlds "are already served over the API" — that is
+   FALSE; fix it.
+2. **`pointer` + `via` on the entity GET.** `worldreader.Resolved`
+   (`worldreader.go:75-101`) computes both; `visiblereader.go:114-123`
+   discards them. `entity.Entity.Pointer` already has a JSON tag but
+   `entityserializer.go:45-103` never copies it.
+   *Unblocks provenance — "published" vs "default, because nothing is
+   published yet".*
+3. **`pointers` on `_schema`'s EntityType** — a client cannot currently learn
+   that `policy` has draft/published.
+4. **World-capable detail read.** `_views/{type}/{id}` 422s under a world by
+   construction (`worldCapablePath`, `world.go:220-234`), and it cannot
+   simply be allowlisted: `views.go:21,159` read via `store.GetEntity`, which
+   takes **no scope parameter** (`store.go:238`) — world resolution exists
+   only on the `ListEntities`+`World` path. Either scope that handler or move
+   the SPA detail page to `GET /{plural}/{id}`. **Design decision, not
+   plumbing.** *Unblocks every Ruling-9 affordance having a page to live on.*
+5. **Copies: list-by-source + invoke-by-name, and `label:` on `CopyDef`.**
+   A request may only invoke a definition BY NAME (transforms-registry
+   precedent); the endpoint must **re-authorize the guard server-side**
+   (§9.3 rule 1 — the UI affordance is a hint, never the boundary).
+   `CopyDef` (`metamodel/types.go:599-644`) has no label field, so Ruling 9's
+   "operator-configurable text" has nothing to read. **This is the big one
+   and needs a real design pass — it is a write endpoint.**
+   *Unblocks promote / go-to-draft / create-a-face.*
+6. **All-states query for the "other faces" indicator.**
+   `store.EntityQuery.AllStates` exists (`store.go:294`) but is unused by
+   `internal/dataentry`. Must respect the omit-unreadable-faces rule
+   (Ruling 9 item 8): a face the viewer may not read is OMITTED, never shown
+   as existing-but-locked.
+7. **Face-aware `computeActions` (RULING 11).** Verified live: a published
+   face carries `_actions:{update:true}` while `PATCH ?world=published`
+   returns 422 — the affordance map SAYS writable, the write path REFUSES.
+   `computeActions` (`affordances.go:127-133`) authorizes on entity id with
+   no pointer, so it cannot express the face-granular authority TKT-C1XUA8
+   PR-A gave the write path. Usability defect, not a security hole (the
+   server refuses correctly), but an affordance map that lies is a trap for
+   every future consumer.
+
+## Constraints
+
+- Items 1-3 are small and additive. Item 4 is a design decision. Item 5
+  should not have its shape chosen unilaterally by an agent.
+- Under a non-default world the backend currently refuses `?include=` (422)
+  and emits **no relations** (`api_v1.go:794-797`, `639-643`). Decide
+  deliberately whether that stays; the SPA has to honour it either way.
+- **Do not add a face-enumeration path that lets a client probe which faces
+  exist.** That reconstructs the existence oracle `errWorldDenied` was
+  designed to close.

--- a/tickets/relations/BUG-CPYTAIL--adds-measure--AM-relation-delete-addresses-the-tail.md
+++ b/tickets/relations/BUG-CPYTAIL--adds-measure--AM-relation-delete-addresses-the-tail.md
@@ -1,0 +1,5 @@
+---
+from: BUG-CPYTAIL
+relation: adds-measure
+to: AM-relation-delete-addresses-the-tail
+---

--- a/tickets/relations/BUG-CPYTAIL--affects--store-backends.md
+++ b/tickets/relations/BUG-CPYTAIL--affects--store-backends.md
@@ -1,0 +1,5 @@
+---
+from: BUG-CPYTAIL
+relation: affects
+to: store-backends
+---

--- a/tickets/relations/BUG-CPYTAIL--fixes--FEAT-9CD2MX.md
+++ b/tickets/relations/BUG-CPYTAIL--fixes--FEAT-9CD2MX.md
@@ -1,0 +1,5 @@
+---
+from: BUG-CPYTAIL
+relation: fixes
+to: FEAT-9CD2MX
+---

--- a/tickets/relations/BUG-DFLTCHAIN--affects--metamodel-types.md
+++ b/tickets/relations/BUG-DFLTCHAIN--affects--metamodel-types.md
@@ -1,0 +1,5 @@
+---
+from: BUG-DFLTCHAIN
+type: affects
+to: metamodel-types
+---

--- a/tickets/relations/BUG-DFLTCHAIN--fixes--FEAT-9CD2MX.md
+++ b/tickets/relations/BUG-DFLTCHAIN--fixes--FEAT-9CD2MX.md
@@ -1,0 +1,5 @@
+---
+from: BUG-DFLTCHAIN
+type: fixes
+to: FEAT-9CD2MX
+---

--- a/tickets/relations/BUG-FACEVER--adds-measure--AM-delete-versions-every-face.md
+++ b/tickets/relations/BUG-FACEVER--adds-measure--AM-delete-versions-every-face.md
@@ -1,0 +1,5 @@
+---
+from: BUG-FACEVER
+relation: adds-measure
+to: AM-delete-versions-every-face
+---

--- a/tickets/relations/BUG-FACEVER--affects--store-backends.md
+++ b/tickets/relations/BUG-FACEVER--affects--store-backends.md
@@ -1,0 +1,5 @@
+---
+from: BUG-FACEVER
+relation: affects
+to: store-backends
+---

--- a/tickets/relations/BUG-FACEVER--fixes--FEAT-9CD2MX.md
+++ b/tickets/relations/BUG-FACEVER--fixes--FEAT-9CD2MX.md
@@ -1,0 +1,5 @@
+---
+from: BUG-FACEVER
+relation: fixes
+to: FEAT-9CD2MX
+---

--- a/tickets/relations/BUG-YAMLDROP--adds-measure--AM-unmarshalyaml-alias-field-parity.md
+++ b/tickets/relations/BUG-YAMLDROP--adds-measure--AM-unmarshalyaml-alias-field-parity.md
@@ -1,0 +1,5 @@
+---
+from: BUG-YAMLDROP
+relation: adds-measure
+to: AM-unmarshalyaml-alias-field-parity
+---

--- a/tickets/relations/BUG-YAMLDROP--affects--store-backends.md
+++ b/tickets/relations/BUG-YAMLDROP--affects--store-backends.md
@@ -1,0 +1,5 @@
+---
+from: BUG-YAMLDROP
+relation: affects
+to: store-backends
+---

--- a/tickets/relations/BUG-YAMLDROP--fixes--FEAT-9CD2MX.md
+++ b/tickets/relations/BUG-YAMLDROP--fixes--FEAT-9CD2MX.md
@@ -1,0 +1,5 @@
+---
+from: BUG-YAMLDROP
+relation: fixes
+to: FEAT-9CD2MX
+---

--- a/tickets/relations/TKT-C1XUA8--has-review--REV-T3OXWC.md
+++ b/tickets/relations/TKT-C1XUA8--has-review--REV-T3OXWC.md
@@ -1,0 +1,5 @@
+---
+from: TKT-C1XUA8
+relation: has-review
+to: REV-T3OXWC
+---

--- a/tickets/relations/TKT-C1XUA8--has-review-response--RR-6D7P4A.md
+++ b/tickets/relations/TKT-C1XUA8--has-review-response--RR-6D7P4A.md
@@ -1,0 +1,5 @@
+---
+from: TKT-C1XUA8
+relation: has-review-response
+to: RR-6D7P4A
+---

--- a/tickets/relations/TKT-C1XUA8--has-review-response--RR-DQX0H0.md
+++ b/tickets/relations/TKT-C1XUA8--has-review-response--RR-DQX0H0.md
@@ -1,0 +1,5 @@
+---
+from: TKT-C1XUA8
+relation: has-review-response
+to: RR-DQX0H0
+---

--- a/tickets/relations/TKT-C1XUA8--has-review-response--RR-ND21P3.md
+++ b/tickets/relations/TKT-C1XUA8--has-review-response--RR-ND21P3.md
@@ -1,0 +1,5 @@
+---
+from: TKT-C1XUA8
+relation: has-review-response
+to: RR-ND21P3
+---

--- a/tickets/relations/TKT-C1XUA8--has-review-response--RR-VLQ5WM.md
+++ b/tickets/relations/TKT-C1XUA8--has-review-response--RR-VLQ5WM.md
@@ -1,0 +1,5 @@
+---
+from: TKT-C1XUA8
+relation: has-review-response
+to: RR-VLQ5WM
+---

--- a/tickets/relations/TKT-DN37J2--has-review--REV-7SY12K.md
+++ b/tickets/relations/TKT-DN37J2--has-review--REV-7SY12K.md
@@ -1,0 +1,5 @@
+---
+from: TKT-DN37J2
+relation: has-review
+to: REV-7SY12K
+---

--- a/tickets/relations/TKT-DN37J2--has-review-response--RR-3TV7F4.md
+++ b/tickets/relations/TKT-DN37J2--has-review-response--RR-3TV7F4.md
@@ -1,0 +1,5 @@
+---
+from: TKT-DN37J2
+relation: has-review-response
+to: RR-3TV7F4
+---

--- a/tickets/relations/TKT-DN37J2--has-review-response--RR-4GHZ60.md
+++ b/tickets/relations/TKT-DN37J2--has-review-response--RR-4GHZ60.md
@@ -1,0 +1,5 @@
+---
+from: TKT-DN37J2
+relation: has-review-response
+to: RR-4GHZ60
+---

--- a/tickets/relations/TKT-DN37J2--has-review-response--RR-4TFZNL.md
+++ b/tickets/relations/TKT-DN37J2--has-review-response--RR-4TFZNL.md
@@ -1,0 +1,5 @@
+---
+from: TKT-DN37J2
+relation: has-review-response
+to: RR-4TFZNL
+---

--- a/tickets/relations/TKT-DN37J2--has-review-response--RR-4TP758.md
+++ b/tickets/relations/TKT-DN37J2--has-review-response--RR-4TP758.md
@@ -1,0 +1,5 @@
+---
+from: TKT-DN37J2
+relation: has-review-response
+to: RR-4TP758
+---

--- a/tickets/relations/TKT-DN37J2--has-review-response--RR-AC7GAH.md
+++ b/tickets/relations/TKT-DN37J2--has-review-response--RR-AC7GAH.md
@@ -1,0 +1,5 @@
+---
+from: TKT-DN37J2
+relation: has-review-response
+to: RR-AC7GAH
+---

--- a/tickets/relations/TKT-DN37J2--has-review-response--RR-C40NEZ.md
+++ b/tickets/relations/TKT-DN37J2--has-review-response--RR-C40NEZ.md
@@ -1,0 +1,5 @@
+---
+from: TKT-DN37J2
+relation: has-review-response
+to: RR-C40NEZ
+---

--- a/tickets/relations/TKT-DN37J2--has-review-response--RR-E0L2PG.md
+++ b/tickets/relations/TKT-DN37J2--has-review-response--RR-E0L2PG.md
@@ -1,0 +1,5 @@
+---
+from: TKT-DN37J2
+relation: has-review-response
+to: RR-E0L2PG
+---

--- a/tickets/relations/TKT-DN37J2--has-review-response--RR-H98VX0.md
+++ b/tickets/relations/TKT-DN37J2--has-review-response--RR-H98VX0.md
@@ -1,0 +1,5 @@
+---
+from: TKT-DN37J2
+relation: has-review-response
+to: RR-H98VX0
+---

--- a/tickets/relations/TKT-DN37J2--has-review-response--RR-J1DXK3.md
+++ b/tickets/relations/TKT-DN37J2--has-review-response--RR-J1DXK3.md
@@ -1,0 +1,5 @@
+---
+from: TKT-DN37J2
+relation: has-review-response
+to: RR-J1DXK3
+---

--- a/tickets/relations/TKT-DN37J2--has-review-response--RR-LWE222.md
+++ b/tickets/relations/TKT-DN37J2--has-review-response--RR-LWE222.md
@@ -1,0 +1,5 @@
+---
+from: TKT-DN37J2
+relation: has-review-response
+to: RR-LWE222
+---

--- a/tickets/relations/TKT-DN37J2--has-review-response--RR-LXJF8I.md
+++ b/tickets/relations/TKT-DN37J2--has-review-response--RR-LXJF8I.md
@@ -1,0 +1,5 @@
+---
+from: TKT-DN37J2
+relation: has-review-response
+to: RR-LXJF8I
+---

--- a/tickets/relations/TKT-DN37J2--has-review-response--RR-MSM79V.md
+++ b/tickets/relations/TKT-DN37J2--has-review-response--RR-MSM79V.md
@@ -1,0 +1,5 @@
+---
+from: TKT-DN37J2
+relation: has-review-response
+to: RR-MSM79V
+---

--- a/tickets/relations/TKT-DN37J2--has-review-response--RR-NFDPOA.md
+++ b/tickets/relations/TKT-DN37J2--has-review-response--RR-NFDPOA.md
@@ -1,0 +1,5 @@
+---
+from: TKT-DN37J2
+relation: has-review-response
+to: RR-NFDPOA
+---

--- a/tickets/relations/TKT-DN37J2--has-review-response--RR-Q1LI2Y.md
+++ b/tickets/relations/TKT-DN37J2--has-review-response--RR-Q1LI2Y.md
@@ -1,0 +1,5 @@
+---
+from: TKT-DN37J2
+relation: has-review-response
+to: RR-Q1LI2Y
+---

--- a/tickets/relations/TKT-DN37J2--has-review-response--RR-SU4T68.md
+++ b/tickets/relations/TKT-DN37J2--has-review-response--RR-SU4T68.md
@@ -1,0 +1,5 @@
+---
+from: TKT-DN37J2
+relation: has-review-response
+to: RR-SU4T68
+---

--- a/tickets/relations/TKT-DN37J2--has-review-response--RR-TFATPO.md
+++ b/tickets/relations/TKT-DN37J2--has-review-response--RR-TFATPO.md
@@ -1,0 +1,5 @@
+---
+from: TKT-DN37J2
+relation: has-review-response
+to: RR-TFATPO
+---

--- a/tickets/relations/TKT-DN37J2--has-review-response--RR-WEKTVV.md
+++ b/tickets/relations/TKT-DN37J2--has-review-response--RR-WEKTVV.md
@@ -1,0 +1,5 @@
+---
+from: TKT-DN37J2
+relation: has-review-response
+to: RR-WEKTVV
+---

--- a/tickets/relations/TKT-DN37J2--has-review-response--RR-X0YJAF.md
+++ b/tickets/relations/TKT-DN37J2--has-review-response--RR-X0YJAF.md
@@ -1,0 +1,5 @@
+---
+from: TKT-DN37J2
+relation: has-review-response
+to: RR-X0YJAF
+---

--- a/tickets/relations/TKT-DN37J2--has-review-response--RR-YALMJ1.md
+++ b/tickets/relations/TKT-DN37J2--has-review-response--RR-YALMJ1.md
@@ -1,0 +1,5 @@
+---
+from: TKT-DN37J2
+relation: has-review-response
+to: RR-YALMJ1
+---

--- a/tickets/relations/TKT-DN37J2--has-review-response--RR-ZI2PF7.md
+++ b/tickets/relations/TKT-DN37J2--has-review-response--RR-ZI2PF7.md
@@ -1,0 +1,5 @@
+---
+from: TKT-DN37J2
+relation: has-review-response
+to: RR-ZI2PF7
+---

--- a/tickets/relations/TKT-F2D5U5--affects--data-entry-ui.md
+++ b/tickets/relations/TKT-F2D5U5--affects--data-entry-ui.md
@@ -1,0 +1,5 @@
+---
+from: TKT-F2D5U5
+relation: affects
+to: data-entry-ui
+---

--- a/tickets/relations/TKT-F2D5U5--depends-on--TKT-C1XUA8.md
+++ b/tickets/relations/TKT-F2D5U5--depends-on--TKT-C1XUA8.md
@@ -1,0 +1,5 @@
+---
+from: TKT-F2D5U5
+relation: depends-on
+to: TKT-C1XUA8
+---

--- a/tickets/relations/TKT-F2D5U5--depends-on--TKT-WRLDAPI.md
+++ b/tickets/relations/TKT-F2D5U5--depends-on--TKT-WRLDAPI.md
@@ -1,0 +1,5 @@
+---
+from: TKT-F2D5U5
+type: depends-on
+to: TKT-WRLDAPI
+---

--- a/tickets/relations/TKT-F2D5U5--implements--FEAT-9CD2MX.md
+++ b/tickets/relations/TKT-F2D5U5--implements--FEAT-9CD2MX.md
@@ -1,0 +1,5 @@
+---
+from: TKT-F2D5U5
+relation: implements
+to: FEAT-9CD2MX
+---

--- a/tickets/relations/TKT-WRLDAPI--affects--data-entry-server.md
+++ b/tickets/relations/TKT-WRLDAPI--affects--data-entry-server.md
@@ -1,0 +1,5 @@
+---
+from: TKT-WRLDAPI
+type: affects
+to: data-entry-server
+---

--- a/tickets/relations/TKT-WRLDAPI--implements--FEAT-9CD2MX.md
+++ b/tickets/relations/TKT-WRLDAPI--implements--FEAT-9CD2MX.md
@@ -1,0 +1,5 @@
+---
+from: TKT-WRLDAPI
+type: implements
+to: FEAT-9CD2MX
+---


### PR DESCRIPTION
Companion paperwork PR for **TKT-DN37J2 — ACL: world-shaped read grants, state-shaped write grants (Step 3)**.

Carries **only** `tickets/` changes, per the arc's standing rule (ARCHITECT-RULINGS Ruling 2): the code PRs carry no ticket paperwork, so the ticket-status CI gate stays meaningful for every PR that copies the pattern.

**Stays DRAFT and RED until the stack completes.** The ticket sits in `planning`/`in-progress` while the code PRs are open, and the merged tree only allows `backlog`/`done` — so the red check here is the gate working correctly, not a problem to route around.

## Contents so far

- `TKT-DN37J2` moved `backlog → ready → planning`
- `PLAN-BW4X7W` — planning checklist, filled from the survey in `.ignored/dn37j2-plan.md`
- 10 design-review responses (5 critical, 5 significant)
- 5 PR-A code-review responses (1 critical, 3 significant, 1 minor)

Two of the design-review findings invalidated premises the architect had already ruled on, and were escalated rather than coded around:

- **RR-WEKTVV** — the approved refusal condition rested on "an ungated *privileged* role-relation is a necessary condition of every chain". `RoleDef.IsPrivileged` excludes `Read` by design, so a role holding only `read: [world:published]` was invisible to both arms while being one ungated edge write from a published-world read. Ruling 8 has been amended.
- **RR-SU4T68** — PR-C's "~3 seams" scope does not survive contact: `store.GetEntity` takes no query struct and so cannot carry a world, and 50+ raw read paths bypass any handle. PR-C's scope needs re-deriving before it starts.

## Stack

- PR-A — grant syntax, load validation, the membership-gate refusal (this stack's hard acceptance criterion)
- PR-B — `aclaudit` cross-file checks (advisory)
- PR-C — request-level world selection + the read-path grant check