### PR TITLE
🌍 feat(acl): world read grants, state write grants, membership-gate load refusal (TKT-DN37J2 PR-A)

### DIFF
--- a/docs-project/entities/guides/GUIDE-acl-security.md
+++ b/docs-project/entities/guides/GUIDE-acl-security.md
@@ -79,7 +79,7 @@ going to be shown anyway is a visibility decision, not an escalation
 path. Both the warning and the linter evaluate the same predicate, so
 they never disagree.
 
-### This becomes a hard requirement with content states
+### This is a hard requirement with content states
 
 The tolerance above holds only while the worst case is over-granting
 inside a trusted group. It stops holding the moment the same policy
@@ -90,12 +90,35 @@ role-management weakness: it is a working mechanism for reading
 unpublished content, because self-assigning a role that can read the
 draft world is one relation write away.
 
-When world-shaped read grants ship, a policy that combines them with an
-un-gated membership relation will be **refused at load** with an error
-naming the fix, rather than booting with a warning. Deployments that do
-not use worlds are unaffected and keep today's behaviour. Gating the
-membership relation now costs one `requires_permission` line and means
-that change is a no-op for you.
+So a policy that grants read on a non-default world while leaving a
+self-promotion path open is **refused at load**, with an error naming
+the fix — it does not boot with a warning. Two shapes trigger the
+refusal:
+
+1. The membership relation is un-gated and an assignment confers a role
+   that can escalate.
+2. **Any** role-relation is un-gated while conferring a role that can
+   escalate — even if the membership relation itself is gated. Without
+   this second arm, an attacker writes one un-gated edge to gain a role
+   holding the gating permission, then writes the membership edge.
+
+"Can escalate" means the role grants a write verb, holds a permission,
+**or holds a non-default world read grant**. That last term is why a
+read-only role counts here but not in the warning above: normally
+granting yourself read access is a visibility choice, not an escalation
+— but a role that can read `world:published` is exactly the thing worth
+stealing once worlds exist.
+
+The second arm is deliberately broader than strictly necessary: it
+refuses some policies whose un-gated relation could not actually reach
+the membership gate. Those policies already carry a high-severity
+`rela acl audit` finding, and the fix is the same single
+`requires_permission` line. Erring toward refusing is the right
+direction for a check whose failure mode is leaked unpublished content.
+
+Deployments that do not use worlds are unaffected and keep today's
+warn-and-boot behavior. Gating the membership relation now costs one
+`requires_permission` line and means that change is a no-op for you.
 
 The companion section in `docs/server-security.md` carries the same
 guidance with more context on the broader threat model.

--- a/docs/acl-security.md
+++ b/docs/acl-security.md
@@ -73,7 +73,7 @@ going to be shown anyway is a visibility decision, not an escalation
 path. Both the warning and the linter evaluate the same predicate, so
 they never disagree.
 
-### This becomes a hard requirement with content states
+### This is a hard requirement with content states
 
 The tolerance above holds only while the worst case is over-granting
 inside a trusted group. It stops holding the moment the same policy
@@ -84,12 +84,35 @@ role-management weakness: it is a working mechanism for reading
 unpublished content, because self-assigning a role that can read the
 draft world is one relation write away.
 
-When world-shaped read grants ship, a policy that combines them with an
-un-gated membership relation will be **refused at load** with an error
-naming the fix, rather than booting with a warning. Deployments that do
-not use worlds are unaffected and keep today's behaviour. Gating the
-membership relation now costs one `requires_permission` line and means
-that change is a no-op for you.
+So a policy that grants read on a non-default world while leaving a
+self-promotion path open is **refused at load**, with an error naming
+the fix — it does not boot with a warning. Two shapes trigger the
+refusal:
+
+1. The membership relation is un-gated and an assignment confers a role
+   that can escalate.
+2. **Any** role-relation is un-gated while conferring a role that can
+   escalate — even if the membership relation itself is gated. Without
+   this second arm, an attacker writes one un-gated edge to gain a role
+   holding the gating permission, then writes the membership edge.
+
+"Can escalate" means the role grants a write verb, holds a permission,
+**or holds a non-default world read grant**. That last term is why a
+read-only role counts here but not in the warning above: normally
+granting yourself read access is a visibility choice, not an escalation
+— but a role that can read `world:published` is exactly the thing worth
+stealing once worlds exist.
+
+The second arm is deliberately broader than strictly necessary: it
+refuses some policies whose un-gated relation could not actually reach
+the membership gate. Those policies already carry a high-severity
+`rela acl audit` finding, and the fix is the same single
+`requires_permission` line. Erring toward refusing is the right
+direction for a check whose failure mode is leaked unpublished content.
+
+Deployments that do not use worlds are unaffected and keep today's
+warn-and-boot behavior. Gating the membership relation now costs one
+`requires_permission` line and means that change is a no-op for you.
 
 The companion section in `docs/server-security.md` carries the same
 guidance with more context on the broader threat model.

--- a/internal/acl/access.go
+++ b/internal/acl/access.go
@@ -151,6 +151,14 @@ func grantForRole(role RoleDef, verb Verb, entityType string) EveryoneGrant {
 		if t == "*" {
 			return EveryoneGrant{Granted: true, Wildcard: true}
 		}
+		// A state-shaped write grant is skipped for the same reason
+		// [grantsVerb] skips it: it authorizes no face today, so reporting
+		// it as a grant here would put a false all-clear into `rela acl
+		// who-can` / `rela acl map` — the operator-facing security reports
+		// this helper exists to keep honest (RR-Q1LI2Y).
+		if verb != VerbRead && isStateGrant(t) {
+			continue
+		}
 		if t == entityType {
 			return EveryoneGrant{Granted: true}
 		}
@@ -258,4 +266,30 @@ func (r *Request) grantingAttributions(
 		}
 	}
 	return out
+}
+
+// GrantsRead reports whether role's read list covers entityType — exact
+// match or the "*" wildcard.
+//
+// GrantsRead and [GrantsVerb] are exported so consumers outside this
+// package (the `rela docs` role-matrix generator) match grants with the
+// SAME predicate the runtime uses, rather than hand-copying the
+// wildcard-or-exact loop. A second copy silently disagrees the moment the
+// grant grammar changes — which is exactly what happened when write grants
+// gained the `type@pointer` form (TKT-DN37J2): the copy reported "cannot
+// update page" for a role holding `update: ["page@draft"]`, a false
+// all-clear in an operator-facing security document (RR-Q1LI2Y).
+//
+// These take a plain RoleDef and so do NOT apply a client ceiling; they
+// answer "what does this role grant", not "what may this principal do".
+// For the latter, resolve through [Request.roleFor] first.
+func GrantsRead(role RoleDef, entityType string) bool {
+	return roleGrantsRead(role, entityType)
+}
+
+// GrantsVerb reports whether role may perform op on entityType, honoring
+// the "*" wildcard and the `type@pointer` state form. Rename routes
+// through the update grant. See [GrantsRead] for why this is exported.
+func GrantsVerb(role RoleDef, op Op, entityType string) bool {
+	return grantsVerb(role, op, entityType)
 }

--- a/internal/acl/ceiling.go
+++ b/internal/acl/ceiling.go
@@ -142,6 +142,21 @@ type Restriction struct {
 	// columns and an open-ended set of harmless ones.
 	Redact map[string][]string `yaml:"redact,omitempty"`
 
+	// Worlds and DenyWorlds are the world axis (TKT-DN37J2). Worlds are a
+	// first-class read grant, so the ceiling needs a matching axis: a
+	// client attenuated below its user must be narrowable in worlds too.
+	//
+	// There is deliberately NO wildcard here (a role's world grant cannot
+	// be "*" either — see normalizeWorldGrants), so the allow form is a
+	// plain intersection. The DENY form cannot be applied by intersection
+	// at all, because the default world is the ABSENCE of an entry: an
+	// empty Worlds already means "default world", and intersecting it with
+	// anything leaves it empty. Denial is therefore enforced at match time
+	// by [compiledCeiling.permitsWorld], the same shape permitsRead uses
+	// for the wildcard gap filterTypes cannot express.
+	Worlds     []string `yaml:"worlds,omitempty"`
+	DenyWorlds []string `yaml:"deny_worlds,omitempty"`
+
 	Permissions     []string `yaml:"permissions,omitempty"`
 	DenyPermissions []string `yaml:"deny_permissions,omitempty"`
 }
@@ -155,6 +170,7 @@ func (r Restriction) Narrows() bool {
 		len(r.Delete) > 0 || len(r.DenyRead) > 0 || len(r.DenyCreate) > 0 ||
 		len(r.DenyUpdate) > 0 || len(r.DenyDelete) > 0 || len(r.DenyWrite) > 0 ||
 		len(r.Visible) > 0 || len(r.Redact) > 0 ||
+		len(r.Worlds) > 0 || len(r.DenyWorlds) > 0 ||
 		len(r.Permissions) > 0 || len(r.DenyPermissions) > 0
 }
 
@@ -173,6 +189,7 @@ func (r Restriction) denySpellings() []string {
 		{"deny_delete", len(r.DenyDelete) > 0},
 		{"deny_write", len(r.DenyWrite) > 0},
 		{"redact", len(r.Redact) > 0},
+		{"deny_worlds", len(r.DenyWorlds) > 0},
 		{"deny_permissions", len(r.DenyPermissions) > 0},
 	} {
 		if c.set {
@@ -202,6 +219,7 @@ func (r Restriction) validateSpellings(label string) error {
 		{"create", "deny_create", len(r.Create) > 0, len(r.DenyCreate) > 0},
 		{"update", "deny_update", len(r.Update) > 0, len(r.DenyUpdate) > 0},
 		{"delete", "deny_delete", len(r.Delete) > 0, len(r.DenyDelete) > 0},
+		{"worlds", "deny_worlds", len(r.Worlds) > 0, len(r.DenyWorlds) > 0},
 		{"permissions", "deny_permissions", len(r.Permissions) > 0, len(r.DenyPermissions) > 0},
 	} {
 		if c.allowSet && c.denySet {
@@ -256,6 +274,7 @@ func (r Restriction) validateNoBlanks(label string) error {
 		{"deny_read", r.DenyRead}, {"deny_create", r.DenyCreate},
 		{"deny_update", r.DenyUpdate}, {"deny_delete", r.DenyDelete},
 		{"deny_write", r.DenyWrite},
+		{"worlds", r.Worlds}, {"deny_worlds", r.DenyWorlds},
 		{"permissions", r.Permissions}, {"deny_permissions", r.DenyPermissions},
 	} {
 		for i, v := range c.vals {
@@ -393,6 +412,7 @@ func (r Restriction) normalized() Restriction {
 	r.DenyRead, r.DenyCreate, r.DenyUpdate, r.DenyDelete =
 		trimAll(r.DenyRead), trimAll(r.DenyCreate), trimAll(r.DenyUpdate), trimAll(r.DenyDelete)
 	r.DenyWrite = trimAll(r.DenyWrite)
+	r.Worlds, r.DenyWorlds = trimAll(r.Worlds), trimAll(r.DenyWorlds)
 	r.Permissions, r.DenyPermissions = trimAll(r.Permissions), trimAll(r.DenyPermissions)
 	r.Visible, r.Redact = trimFieldMap(r.Visible), trimFieldMap(r.Redact)
 	return r

--- a/internal/acl/ceilingcompile.go
+++ b/internal/acl/ceilingcompile.go
@@ -46,6 +46,12 @@ type compiledCeiling struct {
 
 	read, create, update, del verbCeiling
 	permissions               permissionCeiling
+
+	// worlds narrows the world read axis (TKT-DN37J2). Reuses verbCeiling
+	// because the allow/deny/except semantics are identical — only the
+	// vocabulary differs (world names, not entity types) and there is no
+	// wildcard to expand.
+	worlds verbCeiling
 }
 
 // verbCeiling decides whether one verb is permitted on one entity type.
@@ -142,6 +148,7 @@ func (p *Policy) ceilingFor(principalType string, scopes []string) compiledCeili
 		create:   verbCeiling{allow: nilIfUnset(baseline.Create), deny: baseline.DenyCreate},
 		update:   verbCeiling{allow: nilIfUnset(baseline.Update), deny: baseline.DenyUpdate},
 		del:      verbCeiling{allow: nilIfUnset(baseline.Delete), deny: baseline.DenyDelete},
+		worlds:   verbCeiling{allow: nilIfUnset(baseline.Worlds), deny: baseline.DenyWorlds},
 		permissions: permissionCeiling{
 			allow: nilIfUnset(baseline.Permissions),
 			deny:  baseline.DenyPermissions,
@@ -165,6 +172,7 @@ func (p *Policy) ceilingFor(principalType string, scopes []string) compiledCeili
 		c.create.reopen(g.Create)
 		c.update.reopen(g.Update)
 		c.del.reopen(g.Delete)
+		c.worlds.reopen(g.Worlds)
 		c.permissions.reopen(g.Permissions)
 	}
 	return c
@@ -256,8 +264,33 @@ func (c compiledCeiling) clamp(role RoleDef) RoleDef {
 	role.Create = filterTypes(role.Create, c.create)
 	role.Update = filterTypes(role.Update, c.update)
 	role.Delete = filterTypes(role.Delete, c.del)
+	role.Worlds = filterWorlds(role.Worlds, c.worlds)
 	role.Permissions = filterPermissions(role.Permissions, c.permissions)
 	return role
+}
+
+// filterWorlds intersects a role's world grants with the ceiling's world
+// axis. Simpler than [filterTypes] because neither side can hold a
+// wildcard (normalizeWorldGrants rejects `world:*`, and a ceiling world
+// list is plain names), so there is no "everything" to collapse.
+//
+// This handles the ALLOW direction only. A ceiling that DENIES the default
+// world cannot be expressed here at all: the default world is the absence
+// of an entry, so an empty Worlds stays empty under any intersection and
+// still means "default world". That denial lives in
+// [compiledCeiling.permitsWorld], which every world check consults after
+// the role predicate says yes.
+func filterWorlds(roleWorlds []string, w verbCeiling) []string {
+	if !w.narrows() || len(roleWorlds) == 0 {
+		return roleWorlds
+	}
+	out := make([]string, 0, len(roleWorlds))
+	for _, name := range roleWorlds {
+		if w.permits(name) {
+			out = append(out, name)
+		}
+	}
+	return out
 }
 
 // filterTypes intersects a role's type list with a verb ceiling.
@@ -349,6 +382,45 @@ func (c compiledCeiling) permitsRead(target string) bool {
 		return true
 	}
 	return c.read.permits(target)
+}
+
+// permitsWorld reports whether the ceiling admits reading the named world.
+//
+// MANDATORY, not an optional re-check. [filterWorlds] can only narrow the
+// list of NAMED worlds a role holds; it structurally cannot express a
+// denial of the DEFAULT world, because the default world is spelled as the
+// absence of a grant. `deny_worlds: [default]` against a role whose Worlds
+// is empty intersects to empty — which still means the default world, so
+// the denial would be a silent no-op.
+//
+// So every world check calls this after the role predicate
+// ([roleGrantsWorldRead]) says yes. It can only turn a yes into a no,
+// which is the same contract [compiledCeiling.permitsRead] has.
+func (c compiledCeiling) permitsWorld(name string) bool {
+	if !c.active {
+		return true
+	}
+	if name == "" {
+		name = DefaultWorldName
+	}
+	// The DEFAULT world needs an EXPLICIT denial; an allowlist does not
+	// take it away. `worlds: [published]` reads as "this client may also
+	// reach the published world", not "published and nothing else,
+	// including the default face it could already read" — and an operator
+	// who meant the latter has `deny_worlds: [default]` to say so.
+	//
+	// Silently revoking it would be the failure the world axis exists to
+	// prevent, pointed the other way: the default world is the DRAFT face
+	// under the design doc's layout, so a client scoped to `published`
+	// would find its ordinary reads disappearing for a reason nothing in
+	// the config states. A ceiling narrows what it NAMES; the default
+	// world is the one world a grant never names.
+	// Delegated to worlds.permits when the default world IS explicitly
+	// denied, so a scope grant can still re-open it via `except`.
+	if name == DefaultWorldName && !slices.Contains(c.worlds.deny, DefaultWorldName) {
+		return true
+	}
+	return c.worlds.permits(name)
 }
 
 // permitsPermission re-checks a named permission against the ceiling.

--- a/internal/acl/declarative.go
+++ b/internal/acl/declarative.go
@@ -90,6 +90,34 @@ func NewDeclarative(p *Policy, g Graph, gq store.GraphQueryer, opts ...Declarati
 	if gq == nil {
 		return nil, errors.New("acl: NewDeclarative: graphQueryer must be non-nil")
 	}
+	// Split world grants here as well as in [Policy.Validate]. Validate is
+	// the LOAD chokepoint; this constructor is the SERVE chokepoint, and a
+	// policy can reach the second without passing the first — NewDeclarative
+	// does not call Validate, and callers construct a Policy directly
+	// (internal/visibility/visibilitytest, appbuild.NewFromCollaborators,
+	// every test literal). Left unsplit, `world:published` stays inline in
+	// Read where roleGrantsRead never matches it and the client ceiling
+	// mis-clamps it — silently, and in the fail-open direction under a deny
+	// ceiling (RR-LWE222).
+	//
+	// normalizeWorldGrants is idempotent, so paying it twice is free — a
+	// policy that came through Validate has no prefixed entries left in
+	// Read and this is a no-op scan.
+	//
+	// It can only fail on a malformed grant (`world:` with no name, or
+	// `world:*`), which for a Validate-loaded policy is already impossible.
+	// Failing construction is right for the paths that skip Validate: the
+	// alternative is serving reads against a grant nobody could interpret.
+	if err := p.normalizeWorldGrants(); err != nil {
+		return nil, fmt.Errorf("acl: NewDeclarative: %w", err)
+	}
+	// State-grant GRAMMAR is deliberately NOT re-checked here, unlike the
+	// world split above. The split must run because a policy that skipped
+	// Validate would otherwise serve reads with an uninterpretable grant
+	// sitting in the wrong field. A malformed state grant has no such
+	// failure mode: GrantsVerbOnState treats an unparseable entry as
+	// granting nothing, so the policy is already fail-closed and Validate
+	// remains the place that says so with a useful message.
 	d := &Declarative{policy: p, graph: g, graphQueryer: gq}
 	for _, opt := range opts {
 		opt(d)

--- a/internal/acl/membershiprefusal.go
+++ b/internal/acl/membershiprefusal.go
@@ -1,0 +1,211 @@
+package acl
+
+import (
+	"fmt"
+	"slices"
+)
+
+// UngatedPrivilegedRoleRelationOpen reports whether any role-relation
+// confers a declared, escalation-relevant role while carrying no
+// `requires_permission` gate — i.e. whether a principal who can write one
+// edge of that type can self-grant that role.
+//
+// This is the predicate behind the linter's A2-ungated-role-relation
+// finding, extracted so the finding and the load refusal
+// ([Policy.WorldGrantRefusalReason]) can never disagree about what "ungated"
+// means — the property TKT-T31NKT established for A1 and
+// [Policy.MembershipSelfPromotionOpen], extended to A2 (Ruling 8).
+//
+// "Escalation-relevant" is [Policy.roleIsEscalationRelevant], NOT
+// [RoleDef.IsPrivileged]. The two differ by exactly one term — a role
+// holding a non-default WORLD read grant — and that term is the reason this
+// predicate exists as a refusal rather than only as an advisory finding.
+// See roleIsEscalationRelevant for why widening IsPrivileged itself would
+// be the wrong fix.
+//
+// Returns the relation type and the role it confers so the caller can name
+// both in a diagnostic; relations are scanned in sorted order so the same
+// policy always reports the same one.
+func (p *Policy) UngatedPrivilegedRoleRelationOpen() (relType, confers string, open bool) {
+	rels := make([]string, 0, len(p.RoleRelations))
+	for rel := range p.RoleRelations {
+		rels = append(rels, rel)
+	}
+	slices.Sort(rels)
+
+	for _, rel := range rels {
+		if p.RoleRelationEscalates(rel) {
+			return rel, p.RoleRelations[rel].Confers, true
+		}
+	}
+	return "", "", false
+}
+
+// RoleRelationEscalates reports whether writing one edge of relType would
+// self-grant an escalation-relevant role: relType is a declared
+// role-relation, it carries no `requires_permission` gate, and the role it
+// confers is declared and escalation-relevant.
+//
+// This is the per-relation predicate behind BOTH the linter's
+// A2-ungated-role-relation finding and
+// [Policy.UngatedPrivilegedRoleRelationOpen] (the refusal's second arm), so
+// the advisory and the enforcement view cannot disagree — TKT-T31NKT's
+// shared-predicate property, which Ruling 8 requires extending to A2.
+//
+// The sharing matters concretely: "escalation-relevant" includes a
+// non-default world read grant, which [RoleDef.IsPrivileged] does not. A
+// policy refused at load for `owns → viewer{read: [world:published]}` must
+// also produce an A2 finding, or `rela acl audit` reports clean on a policy
+// the server will not boot — and the refusal's own error text tells the
+// operator to run that audit.
+func (p *Policy) RoleRelationEscalates(relType string) bool {
+	def, declared := p.RoleRelations[relType]
+	if !declared || def.RequiresPermission != "" {
+		return false
+	}
+	role, ok := p.Roles[def.Confers]
+	return ok && p.roleIsEscalationRelevant(role)
+}
+
+// roleIsEscalationRelevant reports whether self-granting this role would
+// gain the grantee something a policy author would not want handed out by
+// an unauthenticated edge write.
+//
+// It is [RoleDef.IsPrivileged] — any write verb or any permission — PLUS
+// one term: a read grant on a NON-DEFAULT WORLD.
+//
+// # Why the extra term exists
+//
+// IsPrivileged deliberately excludes Read, on the reasoning that "a
+// read-everything role is a visibility choice, not an escalation path"
+// (RR-LXI3NW, RR-UR0LJU). That reasoning holds for the default world and
+// is why A1/A2 do not fire on read-only groups — the false positive the
+// audit design fought.
+//
+// It stops holding the moment world-shaped read grants exist. A role
+// holding `read: [world:published]` and nothing else is not privileged by
+// IsPrivileged's definition, yet self-granting it is EXACTLY the leak this
+// ticket's refusal exists to prevent:
+//
+//	role_relations:
+//	  member-of: { requires_permission: delegate-admin }  # gated: A1 says no
+//	  owns:      { confers: viewer }                      # ungated
+//	roles:
+//	  viewer: { read: [world:published] }                 # IsPrivileged: false
+//
+// One `owns` edge write self-grants a published-world read. A refusal
+// keyed on IsPrivileged alone does not fire, and would ship as a
+// guarantee it does not deliver. Pinned by
+// TestRefusal_ReadOnlyRoleHoldingWorldGrantCountsAsEscalation.
+//
+// # Why not widen IsPrivileged itself
+//
+// IsPrivileged is consumed by A1, A2 and A3 as their severity criterion,
+// and by the boot warning. Widening it would make every read-only-but-
+// world-holding role trip all four, changing the meaning of three existing
+// audit findings and the warning for policies that are not doing anything
+// wrong. The extra term belongs to the REFUSAL, which is scoped to
+// policies that already grant a non-default world read.
+func (p *Policy) roleIsEscalationRelevant(role RoleDef) bool {
+	if role.IsPrivileged() {
+		return true
+	}
+	for _, w := range role.Worlds {
+		if w != DefaultWorldName {
+			return true
+		}
+	}
+	return false
+}
+
+// assignmentSelfPromotionEscalates reports the A1 shape widened by the same
+// world term as [Policy.roleIsEscalationRelevant]: an ungated membership
+// relation whose assignments confer a role that is escalation-relevant.
+//
+// [Policy.MembershipSelfPromotionOpen] stays exactly as TKT-T31NKT wrote it
+// — it is the ADVISORY predicate, shared with A1 and the boot warning, and
+// widening it would change what those report. This is the REFUSAL's view of
+// the same shape.
+func (p *Policy) assignmentSelfPromotionEscalates() (role string, open bool) {
+	if p.RoleRelations[p.EffectiveMembershipRelation()].RequiresPermission != "" {
+		return "", false
+	}
+	assigned := make(map[string]bool, len(p.Assignments))
+	for _, role := range p.Assignments {
+		assigned[role] = true
+	}
+	// Sorted so the same policy always names the same role, rather than
+	// whichever one Go's map iteration reached first.
+	for _, name := range sortedRoleNames(p.Roles) {
+		if assigned[name] && p.roleIsEscalationRelevant(p.Roles[name]) {
+			return name, true
+		}
+	}
+	return "", false
+}
+
+// WorldGrantRefusalReason returns a human-readable reason this policy must
+// be REFUSED at load, or "" when it may load.
+//
+// The refusal fires only when the policy grants read on a non-default world
+// (design doc §8.1) AND leaves a self-promotion path open. Both halves
+// matter: a deployment that does not use worlds keeps today's
+// warn-and-boot behavior verbatim (docs/acl-security.md promises exactly
+// that in writing), and a deployment that has gated its role-relations is
+// unaffected.
+//
+// # Why a refusal here rather than a warning
+//
+// The ungated-membership hole is pre-existing and, inside a trusted team
+// where everyone who can write to the project is already trusted, it may be
+// a risk an operator has consciously accepted — so it boots with a warning
+// ([appbuild.warnUngatedMembership]). Adding a non-default world read grant
+// changes the stakes: the same hole becomes a working mechanism for reading
+// unpublished content, one relation write away. That is the case
+// docs/acl-security.md § "This becomes a hard requirement with content
+// states" told operators would be refused.
+//
+// # What this guarantees, stated honestly
+//
+// Arm (b) is a NECESSARY-CONDITION refusal, not a proof of safety. Every
+// two-write chain (write an ungated edge to gain a role holding the
+// permission that gates membership, then write the membership edge) must
+// contain an ungated escalation-relevant role-relation, so refusing on that
+// closes every such chain — without a reachability search inside a load
+// path. It also refuses some policies that have an ungated role-relation
+// not actually reaching the membership gate. That over-refusal is
+// deliberate: those policies already carry a High `rela acl audit` finding
+// whose fix is one `requires_permission` line.
+//
+// What it does NOT model: transitive escalation generally, and roles
+// reachable only through `asserted_role_assignments` (an IdP claim rather
+// than a graph write) — neither predicate scans AssertedRoles (RR-8ZOICR).
+func (p *Policy) WorldGrantRefusalReason() string {
+	if !p.GrantsAnyNonDefaultWorldRead() {
+		return ""
+	}
+	rel := p.EffectiveMembershipRelation()
+	if role, open := p.assignmentSelfPromotionEscalates(); open {
+		return fmt.Sprintf(
+			"this policy grants read on a non-default world, but the membership "+
+				"relation %q carries no requires_permission gate while assignments "+
+				"confer the role %q — any principal who can write a %q edge can grant "+
+				"themselves that role and read the world. "+
+				"Fix: set role_relations.%s.requires_permission and grant that "+
+				"permission only to admins (see docs/acl-security.md, and run "+
+				"`rela acl audit` for the full picture)",
+			rel, role, rel, rel)
+	}
+	if relType, confers, open := p.UngatedPrivilegedRoleRelationOpen(); open {
+		return fmt.Sprintf(
+			"this policy grants read on a non-default world, but the role-relation "+
+				"%q confers the role %q while carrying no requires_permission gate — "+
+				"any principal who can write a %q edge self-grants %q, which is one "+
+				"write away from reading a world they were not granted. "+
+				"Fix: set role_relations.%s.requires_permission gating the edge to a "+
+				"delegate role (see docs/acl-security.md, and run `rela acl audit` "+
+				"for the full picture)",
+			relType, confers, relType, confers, relType)
+	}
+	return ""
+}

--- a/internal/acl/membershiprefusal_test.go
+++ b/internal/acl/membershiprefusal_test.go
@@ -1,0 +1,256 @@
+package acl_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/Sourcehaven-BV/rela/internal/acl"
+)
+
+// worldPolicy builds a policy that grants read on a non-default world, so
+// the refusal's trigger half is satisfied and each case below varies only
+// the escalation half.
+func worldPolicy(t *testing.T, roles map[string]acl.RoleDef,
+	assignments map[string]string, rels map[string]acl.RoleRelationDef,
+) *acl.Policy {
+	t.Helper()
+	return &acl.Policy{Roles: roles, Assignments: assignments, RoleRelations: rels}
+}
+
+// TestRefusal_ReadOnlyRoleHoldingWorldGrantCountsAsEscalation is the
+// load-bearing case, and the reason the refusal does not key on
+// [acl.RoleDef.IsPrivileged].
+//
+// IsPrivileged excludes Read by design (RR-LXI3NW): "a read-everything role
+// is a visibility choice, not an escalation path". True for the default
+// world. FALSE once a read grant can name a non-default world — at which
+// point self-granting a read-only role IS the leak the refusal exists to
+// prevent.
+//
+// Both arms of the refusal as originally specified return false here: A1
+// because membership is gated, and the A2 predicate because `viewer` is not
+// IsPrivileged. Without the world term, this policy loads clean and one
+// `owns` edge write buys a published-world read.
+func TestRefusal_ReadOnlyRoleHoldingWorldGrantCountsAsEscalation(t *testing.T) {
+	t.Parallel()
+	p := worldPolicy(t,
+		map[string]acl.RoleDef{
+			"viewer": {Read: []string{"world:published"}},
+			"admin":  {Permissions: []string{"delegate-admin"}},
+		},
+		map[string]string{"admins": "admin"},
+		map[string]acl.RoleRelationDef{
+			"member-of": {RequiresPermission: "delegate-admin"}, // A1: gated
+			"owns":      {Confers: "viewer"},                    // ungated
+		},
+	)
+	if err := p.Validate(); err == nil {
+		t.Fatal("policy loaded, but one `owns` edge write self-grants read on " +
+			"world:published — the refusal must fire on a role that is " +
+			"escalation-relevant only by its world grant")
+	} else if !strings.Contains(err.Error(), "owns") {
+		t.Errorf("refusal must name the offending relation; got: %v", err)
+	}
+
+	// Control: the SAME policy without the world grant keeps booting. That
+	// is the backward-compatibility promise — a read-only role conferred by
+	// an ungated relation is not, by itself, something to refuse.
+	if !p.Roles["viewer"].IsPrivileged() {
+		q := worldPolicy(t,
+			map[string]acl.RoleDef{
+				"viewer": {Read: []string{"page"}},
+				"admin":  {Permissions: []string{"delegate-admin"}},
+			},
+			map[string]string{"admins": "admin"},
+			map[string]acl.RoleRelationDef{
+				"member-of": {RequiresPermission: "delegate-admin"},
+				"owns":      {Confers: "viewer"},
+			},
+		)
+		if err := q.Validate(); err != nil {
+			t.Errorf("a policy with no non-default world grant must still load: %v", err)
+		}
+	}
+}
+
+func TestWorldGrantRefusal(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		policy  *acl.Policy
+		refuse  bool
+		mustSay string
+	}{
+		{
+			name: "A1: ungated membership + privileged assignment + world grant",
+			policy: worldPolicy(t,
+				map[string]acl.RoleDef{
+					"admin":    {Update: []string{"page"}, Read: []string{"page"}},
+					"everyone": {Read: []string{"world:published"}},
+				},
+				map[string]string{"admins": "admin"},
+				nil, // member-of ungated
+			),
+			refuse:  true,
+			mustSay: "member-of",
+		},
+		{
+			name: "A2: ungated role-relation confers a privileged role",
+			policy: worldPolicy(t,
+				map[string]acl.RoleDef{
+					"editor":   {Update: []string{"page"}, Read: []string{"page"}},
+					"everyone": {Read: []string{"world:published"}},
+				},
+				nil,
+				map[string]acl.RoleRelationDef{"owns": {Confers: "editor"}},
+			),
+			refuse:  true,
+			mustSay: "owns",
+		},
+		{
+			name: "gated everywhere: loads",
+			policy: worldPolicy(t,
+				map[string]acl.RoleDef{
+					"editor":   {Update: []string{"page"}, Read: []string{"page"}},
+					"everyone": {Read: []string{"world:published"}},
+					"admin":    {Permissions: []string{"delegate-admin"}},
+				},
+				map[string]string{"admins": "admin"},
+				map[string]acl.RoleRelationDef{
+					"member-of": {RequiresPermission: "delegate-admin"},
+					"owns":      {Confers: "editor", RequiresPermission: "delegate-owns"},
+				},
+			),
+			refuse: false,
+		},
+		{
+			name: "NO world grant: ungated membership still BOOTS (warn-only)",
+			policy: worldPolicy(t,
+				map[string]acl.RoleDef{"admin": {Update: []string{"page"}, Read: []string{"page"}}},
+				map[string]string{"admins": "admin"},
+				nil,
+			),
+			refuse: false,
+		},
+		{
+			name: "world:default only is not a non-default world grant",
+			policy: worldPolicy(t,
+				map[string]acl.RoleDef{
+					"admin":    {Update: []string{"page"}, Read: []string{"page"}},
+					"everyone": {Read: []string{"world:default", "page"}},
+				},
+				map[string]string{"admins": "admin"},
+				nil,
+			),
+			refuse: false,
+		},
+		{
+			name: "read-only assigned role, world grant, ungated membership: " +
+				"REFUSED because the assigned role holds the world",
+			policy: worldPolicy(t,
+				map[string]acl.RoleDef{
+					"reader": {Read: []string{"page", "world:published"}},
+				},
+				map[string]string{"readers": "reader"},
+				nil,
+			),
+			refuse:  true,
+			mustSay: "member-of",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			err := tc.policy.Validate()
+			if tc.refuse && err == nil {
+				t.Fatal("expected a load refusal, got none")
+			}
+			if !tc.refuse && err != nil {
+				t.Fatalf("expected the policy to load, got: %v", err)
+			}
+			if tc.mustSay != "" && !strings.Contains(err.Error(), tc.mustSay) {
+				t.Errorf("refusal must name %q; got: %v", tc.mustSay, err)
+			}
+			if tc.refuse {
+				// The error must be actionable: name the fix and the docs.
+				for _, want := range []string{"requires_permission", "docs/acl-security.md", "rela acl audit"} {
+					if !strings.Contains(err.Error(), want) {
+						t.Errorf("refusal must mention %q; got: %v", want, err)
+					}
+				}
+			}
+		})
+	}
+}
+
+// TestRefusal_OverRefusesUnreachableChain_Deliberately pins the accepted
+// cost of the necessary-condition design (Ruling 8).
+//
+// `owns` confers a privileged role but that role holds NO permission
+// gating the membership relation, so no two-write chain actually reaches
+// membership here. The refusal fires anyway, because it checks the
+// necessary condition rather than searching for a reachable chain.
+//
+// That is DELIBERATE, not a bug: computing reachability would put a graph
+// walk with cycle handling inside a load path, and the policies this
+// over-refuses already carry a High `rela acl audit` finding
+// (A2-ungated-role-relation) whose fix is one requires_permission line.
+// If this test ever "fails" because someone made the check smarter, the
+// question to answer first is whether the smarter check can fail OPEN.
+func TestRefusal_OverRefusesUnreachableChain_Deliberately(t *testing.T) {
+	t.Parallel()
+	p := worldPolicy(t,
+		map[string]acl.RoleDef{
+			"tagger":   {Update: []string{"tag"}, Read: []string{"tag"}},
+			"everyone": {Read: []string{"world:published"}},
+			"admin":    {Permissions: []string{"delegate-admin"}},
+		},
+		map[string]string{"admins": "admin"},
+		map[string]acl.RoleRelationDef{
+			"member-of": {RequiresPermission: "delegate-admin"},
+			// tagger holds no permission at all, so self-granting it can
+			// never pass the membership gate. Refused regardless.
+			"tagged-by": {Confers: "tagger"},
+		},
+	)
+	if err := p.Validate(); err == nil {
+		t.Fatal("expected the deliberate over-refusal on an ungated privileged " +
+			"role-relation, even though no chain reaches the membership gate")
+	}
+}
+
+// TestMembershipSelfPromotionOpen_UnchangedByWorlds pins that the ADVISORY
+// predicate keeps its TKT-T31NKT meaning after the world term is added to
+// the REFUSAL. A1, A2, A3 and the boot warning all key on IsPrivileged, and
+// they must not start firing on a world-only role — that would change what
+// three existing audit findings report for policies doing nothing wrong.
+//
+// The policy is Validate()d first so `Worlds` is actually populated;
+// membership is gated so the refusal does not fire and mask the assertion.
+func TestMembershipSelfPromotionOpen_UnchangedByWorlds(t *testing.T) {
+	t.Parallel()
+	p := worldPolicy(t,
+		map[string]acl.RoleDef{
+			"reader": {Read: []string{"page", "world:published"}},
+			"admin":  {Permissions: []string{"delegate-admin"}},
+		},
+		map[string]string{"readers": "reader"},
+		map[string]acl.RoleRelationDef{
+			"member-of": {RequiresPermission: "delegate-admin"},
+		},
+	)
+	if err := p.Validate(); err != nil {
+		t.Fatalf("policy must load (membership is gated): %v", err)
+	}
+	if got := p.Roles["reader"].Worlds; len(got) != 1 || got[0] != "published" {
+		t.Fatalf("precondition: the world grant must be split out; got %v", got)
+	}
+	if p.Roles["reader"].IsPrivileged() {
+		t.Error("IsPrivileged must NOT count a world grant — widening it would " +
+			"change what A1/A2/A3 and the boot warning report")
+	}
+	if p.MembershipSelfPromotionOpen() {
+		t.Error("MembershipSelfPromotionOpen must stay privilege-gated in the " +
+			"IsPrivileged sense — a read-only role is not an A1 finding")
+	}
+}

--- a/internal/acl/policy.go
+++ b/internal/acl/policy.go
@@ -344,6 +344,29 @@ type RoleDef struct {
 	Read        []string `yaml:"read"`
 	Permissions []string `yaml:"permissions"`
 
+	// Worlds holds the world names this role may read, SPLIT OUT of Read
+	// at policy load by [Policy.normalizeWorldGrants]. It carries no yaml
+	// tag: the wire spelling is `read: [world:published]` (design doc
+	// §8.1), and the split happens so that every existing consumer of Read
+	// — roleGrantsRead, grantForRole, filterTypes, aclaudit's verbLists —
+	// keeps seeing a list of nothing but entity types.
+	//
+	// The split is load-bearing, not cosmetic. Left inline, a world token
+	// is intersected with a client ceiling's TYPE allow/deny list by
+	// [filterTypes]: silently DROPPED under an allowlist ceiling (the
+	// token is not an entity type, so it fails the permits check) and
+	// silently KEPT under a deny ceiling (it matches no denied type). Both
+	// directions are wrong, and one of them is wrong in the operator's
+	// favor. aclaudit's B1-undeclared-type would also report every world
+	// grant as an undeclared entity type, at High.
+	//
+	// An EMPTY Worlds means the default world only — the default world is
+	// the ABSENCE of a grant, never an entry. That is what keeps existing
+	// acl.yaml files meaning exactly what they meant, and it is why a
+	// ceiling cannot express "deny the default world" by intersection; see
+	// [compiledCeiling.permitsWorld].
+	Worlds []string `yaml:"-"`
+
 	Fields    map[string][]FieldGrant    `yaml:"fields"`
 	Visible   map[string][]FieldGrant    `yaml:"visible"`
 	Options   map[string][]OptionGrant   `yaml:"options"`
@@ -366,6 +389,23 @@ func (r RoleDef) IsPrivileged() bool {
 // `target`. Op selects the verb list: Create / Update / Delete; Rename
 // routes through Update (it is a modification). Read is handled
 // separately via roleGrantsRead. An unknown op grants nothing.
+//
+// STATE GRANTS GRANT NOTHING HERE, deliberately, and this is the
+// fail-closed half of a two-part change.
+//
+// This function IS the live write-authorization path (decideFromAttrs in
+// authz_write.go, which knows the entity type but not yet which FACE is
+// being written). [GrantsVerbOnState] is the face-granular check, and it
+// has no production caller until the write path learns to pass a pointer.
+//
+// So if a state-shaped entry matched here on its type half, `update:
+// ["page@draft"]` — the NARROWEST grant the new syntax offers — would
+// authorize writing page's DEFAULT face, which is more authority than the
+// operator wrote and more than they had before. A grant must never widen
+// by being made more specific. Until the write path is face-aware, a
+// state-shaped grant authorizes nothing at all; that direction costs an
+// operator a denied write they must then ask about, rather than a silent
+// over-permit nobody notices.
 func grantsVerb(role RoleDef, op Op, target string) bool {
 	var list []string
 	switch op {
@@ -379,6 +419,9 @@ func grantsVerb(role RoleDef, op Op, target string) bool {
 		return false
 	}
 	for _, t := range list {
+		if isStateGrant(t) {
+			continue // see the doc comment: fail closed until the write path is face-aware
+		}
 		if t == "*" || t == target {
 			return true
 		}
@@ -681,6 +724,17 @@ func (p *Policy) normalizeAssertedRoles() {
 // on-demand `rela acl audit` linter — see internal/aclaudit and
 // TKT-TS0J5K — which can rank findings by severity and cross-check the
 // metamodel, neither of which fits a boot gate.
+//
+// ONE EXCEPTION, added by TKT-DN37J2: a policy that grants read on a
+// non-default world while leaving a self-promotion path open is REFUSED
+// here ([Policy.WorldGrantRefusalReason]). It is an escalation foot-gun,
+// so it looks like it belongs to the linter — but the linter is advisory
+// by construction and this is a shipping gate the content-states design
+// requires, docs/acl-security.md promises operators in writing, and
+// TKT-T31NKT made a hard acceptance criterion. It qualifies for the boot
+// gate on the terms the paragraph above sets out: it needs no metamodel
+// and no store, only the policy. The un-worlded case still warns and
+// boots, exactly as before.
 // validateUnmatchedPrincipal checks the unmatched_principal enum and its
 // dependency on the principal_property lookup. Extracted from [Policy.Validate]
 // to keep that function's cognitive complexity in bounds.
@@ -713,6 +767,15 @@ func (p *Policy) validateUnmatchedPrincipal() error {
 func (p *Policy) Validate() error {
 	p.normalizeAssertedRoles()
 	p.normalizeClientAttenuation()
+	// Runs before every check below, because those checks read the grant
+	// lists and must see them in their split form: Read holding only
+	// entity types, Worlds holding the world names.
+	if err := p.normalizeWorldGrants(); err != nil {
+		return err
+	}
+	if err := p.validateStateGrants(); err != nil {
+		return err
+	}
 
 	if err := p.validateUnmatchedPrincipal(); err != nil {
 		return err
@@ -756,6 +819,30 @@ func (p *Policy) Validate() error {
 					"it already applies to every principal", claim, EveryoneRole)
 		}
 	}
+	if err := p.validateWriteReadCoverage(); err != nil {
+		return err
+	}
+
+	// The membership-gate refusal is the LAST check, so a policy that is
+	// structurally broken fails on that first — a refusal naming an
+	// escalation path is confusing advice for a policy that does not parse.
+	//
+	// This is a deliberate, narrow exception to the "Validate is a pure
+	// structural gate" contract stated above. It earns the exception by
+	// being a security invariant expressible in policy alone (no metamodel,
+	// no store), and by firing only for policies that grant read on a
+	// non-default world — see [Policy.WorldGrantRefusalReason].
+	if reason := p.WorldGrantRefusalReason(); reason != "" {
+		return fmt.Errorf("refusing to load: %s", reason)
+	}
+	return nil
+}
+
+// validateWriteReadCoverage enforces the write⊆read invariant (TKT-4LQMWP):
+// Update and Delete require read coverage of the type, Create is exempt.
+// Extracted from [Policy.Validate] to keep that function's cognitive
+// complexity in bounds, the same way validateUnmatchedPrincipal was.
+func (p *Policy) validateWriteReadCoverage() error {
 	for name, role := range p.Roles {
 		// Update and Delete require read coverage: you must be able to read a
 		// type to modify or remove it (TKT-4LQMWP, was the write⊆read invariant
@@ -766,9 +853,17 @@ func (p *Policy) Validate() error {
 			types []string
 		}{{"update", role.Update}, {"delete", role.Delete}} {
 			for _, t := range verb.types {
-				if !roleGrantsRead(role, t) {
-					hint := fmt.Sprintf("add %q (or \"*\")", t)
-					if t == "*" {
+				// Compare on the TYPE half. A state-shaped grant
+				// (`update: ["policy@draft"]`) still requires read coverage
+				// of `policy` — the pointer narrows WHICH FACE is writable,
+				// not which type — so checking the joined string would
+				// reject every state grant with a hint telling the operator
+				// to add "policy@draft" to their read list, which is not a
+				// thing a read list can hold.
+				target := grantTypeOf(t)
+				if !roleGrantsRead(role, target) {
+					hint := fmt.Sprintf("add %q (or \"*\")", target)
+					if target == "*" {
 						hint = `add "*"`
 					}
 					return fmt.Errorf(
@@ -780,6 +875,7 @@ func (p *Policy) Validate() error {
 			}
 		}
 	}
+
 	return nil
 }
 

--- a/internal/acl/request.go
+++ b/internal/acl/request.go
@@ -279,3 +279,60 @@ func isBlankOrUnknown(s string) bool {
 	t := strings.TrimSpace(s)
 	return t == "" || t == "unknown"
 }
+
+// PermitsWorld reports whether this Request's principal may read the named
+// world (design doc §8.1, §4.4). It is the gate a caller must pass BEFORE
+// constructing a world-resolved reader — the per-entity visibility gate
+// still runs after, on whatever the resolved world contains.
+//
+// Semantics:
+//
+//   - The DEFAULT world (name "" or "default") is permitted by any ordinary
+//     read grant, so an existing acl.yaml keeps meaning what it meant.
+//   - Every other world must be named by a `read: [world:X]` grant.
+//   - The client ceiling is applied twice, deliberately: through roleFor
+//     (which clamps the role's world list) and then through permitsWorld
+//     (which is the only place a denial of the DEFAULT world can be
+//     expressed). See [compiledCeiling.permitsWorld].
+//
+// # Why this returns an error
+//
+// A world grant is a READ capability, and the read paths in this package
+// carry errors on purpose ([Request.PermitsRead], [Request.PermitsReadMany],
+// visibility's listPushdown). Resolving the principal's roles walks the
+// graph, and a store failure there yields a PARTIAL role set — which would
+// silently answer "no" for a principal who genuinely holds the grant.
+//
+// That matters because a denial must render as an EMPTY result rather than
+// a 403 (a 403 would be an existence oracle for the world's contents). So
+// without an error channel a store outage becomes a silently empty page
+// with no operator signal. Callers map: false+nil → empty, err → 500
+// (RR-4TFZNL).
+//
+// LIMITATION, stated because the signature promises more than it currently
+// delivers: the error is reserved, and today always nil. The role walk it
+// depends on ([Request.walkMembers]) discards its own backing error and
+// returns a PARTIAL member list — its "abort the walk loud" comment
+// describes an intent the code does not implement. Threading that error out
+// touches computeGlobals and every Globals caller, which is a separate
+// change. The signature is here now so the ~dozen call sites PR-C adds do
+// not all have to change when it lands, and so a caller cannot form the
+// habit of treating a false as necessarily meaning "denied".
+func (r *Request) PermitsWorld(ctx context.Context, world string) (bool, error) {
+	if !r.ceiling.permitsWorld(world) {
+		return false, nil
+	}
+	for _, a := range r.Globals(ctx).Attributions {
+		// roleFor, never policy.Roles[...] — it is THE clamp point, and a
+		// direct lookup here would bypass the client ceiling entirely
+		// (pinned by TestNoDirectRoleLookupInEvaluationPaths).
+		role, ok := r.roleFor(a.Role)
+		if !ok {
+			continue
+		}
+		if roleGrantsWorldRead(role, world) {
+			return true, nil
+		}
+	}
+	return false, nil
+}

--- a/internal/acl/worldceiling_test.go
+++ b/internal/acl/worldceiling_test.go
@@ -1,0 +1,297 @@
+package acl
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+// The world axis of the client ceiling is tested at COMPILATION, in-package
+// and directly, per the standing rule that a ceiling fails toward less
+// access everywhere except the compilation step — which is why that step
+// gets unit tests rather than only end-to-end ones (CLAUDE.md).
+
+func worldCeiling(t *testing.T, baseline ClientBaseline, scopes ...string) compiledCeiling {
+	t.Helper()
+	p := &Policy{ClientBaselines: map[string]ClientBaseline{"app": baseline}}
+	if len(scopes) > 0 {
+		p.ScopeGrants = map[string]ScopeGrant{
+			"extra": {Restriction: Restriction{Worlds: []string{"editorial"}}},
+		}
+	}
+	p.normalizeClientAttenuation()
+	return p.ceilingFor("app", scopes)
+}
+
+func TestCeilingWorlds_Clamp(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name     string
+		baseline ClientBaseline
+		roleHas  []string
+		want     string
+	}{
+		{
+			name:     "no world axis: role keeps its worlds",
+			baseline: ClientBaseline{AppliesTo: []string{"app"}, Restriction: Restriction{DenyWrite: []string{"*"}}},
+			roleHas:  []string{"published", "editorial"},
+			want:     "published,editorial",
+		},
+		{
+			name: "allowlist narrows to the intersection",
+			baseline: ClientBaseline{AppliesTo: []string{"app"},
+				Restriction: Restriction{Worlds: []string{"published"}}},
+			roleHas: []string{"published", "editorial"},
+			want:    "published",
+		},
+		{
+			name: "allowlist naming a world the role lacks grants nothing new",
+			baseline: ClientBaseline{AppliesTo: []string{"app"},
+				Restriction: Restriction{Worlds: []string{"editorial"}}},
+			roleHas: []string{"published"},
+			want:    "",
+		},
+		{
+			name: "denylist removes the named world",
+			baseline: ClientBaseline{AppliesTo: []string{"app"},
+				Restriction: Restriction{DenyWorlds: []string{"editorial"}}},
+			roleHas: []string{"published", "editorial"},
+			want:    "published",
+		},
+		{
+			name: "empty allowlist permits no world",
+			baseline: ClientBaseline{AppliesTo: []string{"app"},
+				Restriction: Restriction{Worlds: []string{}}},
+			roleHas: []string{"published"},
+			want:    "",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			c := worldCeiling(t, tc.baseline)
+			got := c.clamp(RoleDef{Worlds: tc.roleHas}).Worlds
+			if strings.Join(got, ",") != tc.want {
+				t.Errorf("clamped worlds = %q, want %q", strings.Join(got, ","), tc.want)
+			}
+		})
+	}
+}
+
+// TestCeilingWorlds_ScopeReopens pins that a scope grant widens the world
+// axis exactly as it widens the verb axes — the union semantics that make
+// "more scopes means more capability" hold.
+func TestCeilingWorlds_ScopeReopens(t *testing.T) {
+	t.Parallel()
+	c := worldCeiling(t, ClientBaseline{AppliesTo: []string{"app"},
+		Restriction: Restriction{Worlds: []string{"published"}}}, "extra")
+	got := c.clamp(RoleDef{Worlds: []string{"published", "editorial"}}).Worlds
+	if strings.Join(got, ",") != "published,editorial" {
+		t.Errorf("scope must re-open editorial; got %q", strings.Join(got, ","))
+	}
+}
+
+// TestCeilingWorlds_DefaultWorldDenialNeedsPermitsWorld is the finding the
+// design review surfaced (RR-TFATPO), pinned so the reasoning cannot be
+// refactored away.
+//
+// The default world is spelled as the ABSENCE of a world grant, so a role
+// permitted only the default world has an EMPTY Worlds list. Intersection
+// cannot narrow empty, which means `deny_worlds: [default]` is invisible to
+// clamp — it would be a silent no-op if clamp were the only mechanism.
+//
+// permitsWorld is therefore MANDATORY, not an optional re-check: it is the
+// only place that denial can be expressed.
+func TestCeilingWorlds_DefaultWorldDenialNeedsPermitsWorld(t *testing.T) {
+	t.Parallel()
+	c := worldCeiling(t, ClientBaseline{AppliesTo: []string{"app"},
+		Restriction: Restriction{DenyWorlds: []string{DefaultWorldName}}})
+
+	// clamp alone cannot see it: the role's world list is empty either way.
+	if got := c.clamp(RoleDef{Read: []string{"page"}}).Worlds; len(got) != 0 {
+		t.Fatalf("precondition: a default-world-only role has no world grants, got %v", got)
+	}
+
+	// permitsWorld is where the denial actually lands.
+	if c.permitsWorld(DefaultWorldName) {
+		t.Error("deny_worlds: [default] must deny the default world")
+	}
+	if c.permitsWorld("") {
+		t.Error(`the empty world name means the default world and must be denied too`)
+	}
+}
+
+func TestCeilingWorlds_InactiveCeilingPermitsEverything(t *testing.T) {
+	t.Parallel()
+	var c compiledCeiling // no baseline matched
+	for _, w := range []string{"", DefaultWorldName, "published"} {
+		if !c.permitsWorld(w) {
+			t.Errorf("an inactive ceiling must not narrow anything; denied %q", w)
+		}
+	}
+}
+
+// TestCeilingWorlds_Narrows pins that a worlds-only restriction registers
+// as narrowing. Without it, `rela acl audit` A11 would report a real
+// restriction as inert config and tell the operator to delete it.
+func TestCeilingWorlds_Narrows(t *testing.T) {
+	t.Parallel()
+	for _, r := range []Restriction{
+		{Worlds: []string{"published"}},
+		{DenyWorlds: []string{"editorial"}},
+	} {
+		if !r.Narrows() {
+			t.Errorf("restriction %+v must count as narrowing", r)
+		}
+	}
+}
+
+func TestCeilingWorlds_OneSpellingPerAxis(t *testing.T) {
+	t.Parallel()
+	r := Restriction{Worlds: []string{"a"}, DenyWorlds: []string{"b"}}
+	if err := r.validate("client_baselines.app"); err == nil {
+		t.Fatal("declaring both worlds and deny_worlds must be rejected")
+	}
+	// deny_write is write-side; it must NOT collide with the read-side
+	// world axis.
+	ok := Restriction{DenyWrite: []string{"*"}, Worlds: []string{"published"}}
+	if err := ok.validate("client_baselines.app"); err != nil {
+		t.Errorf("deny_write and worlds are orthogonal axes: %v", err)
+	}
+}
+
+func TestCeilingWorlds_BlankRejected(t *testing.T) {
+	t.Parallel()
+	for _, r := range []Restriction{
+		{Worlds: []string{"published", "  "}},
+		{DenyWorlds: []string{""}},
+	} {
+		if err := r.validate("client_baselines.app"); err == nil {
+			t.Errorf("a blank world entry is silently inert and must be rejected: %+v", r)
+		}
+	}
+}
+
+// TestCeilingWorlds_AllowlistDoesNotRevokeDefaultWorld pins the answer to
+// the trap a design review surfaced: does `worlds: [published]` also take
+// away the default world?
+//
+// It does NOT. A ceiling narrows what it NAMES, and the default world is
+// the one world a grant never names — it is the absence of a grant. An
+// operator who wants it gone says `deny_worlds: [default]`.
+//
+// The failure this avoids is the world axis's own hazard pointed backwards:
+// the default world is the DRAFT face under the design doc's layout, so a
+// client scoped to `published` would find its ordinary reads vanishing for
+// a reason nothing in its config states.
+func TestCeilingWorlds_AllowlistDoesNotRevokeDefaultWorld(t *testing.T) {
+	t.Parallel()
+	c := worldCeiling(t, ClientBaseline{AppliesTo: []string{"app"},
+		Restriction: Restriction{Worlds: []string{"published"}}})
+
+	if !c.permitsWorld(DefaultWorldName) {
+		t.Error("an allowlist naming only `published` must not revoke the default world")
+	}
+	if !c.permitsWorld("") {
+		t.Error("the empty world name means the default world; same rule")
+	}
+	if !c.permitsWorld("published") {
+		t.Error("the allowlisted world must be permitted")
+	}
+	if c.permitsWorld("editorial") {
+		t.Error("a world outside the allowlist must be denied")
+	}
+}
+
+// TestCeilingWorlds_ScopeReopensDeniedDefaultWorld pins that an explicit
+// default-world denial still composes with scope grants, rather than being
+// short-circuited by the rule above.
+func TestCeilingWorlds_ScopeReopensDeniedDefaultWorld(t *testing.T) {
+	t.Parallel()
+	p := &Policy{
+		ClientBaselines: map[string]ClientBaseline{"app": {
+			AppliesTo:   []string{"app"},
+			Restriction: Restriction{DenyWorlds: []string{DefaultWorldName}},
+		}},
+		ScopeGrants: map[string]ScopeGrant{
+			"full": {Restriction: Restriction{Worlds: []string{DefaultWorldName}}},
+		},
+	}
+	p.normalizeClientAttenuation()
+
+	if p.ceilingFor("app", nil).permitsWorld(DefaultWorldName) {
+		t.Error("an explicit deny_worlds: [default] must deny the default world")
+	}
+	if !p.ceilingFor("app", []string{"full"}).permitsWorld(DefaultWorldName) {
+		t.Error("a scope grant must be able to re-open an explicitly denied default world")
+	}
+}
+
+// TestClampCoversEveryGrantAxis is a field-coverage guard: every slice
+// field on RoleDef that carries GRANTS must either be narrowed by
+// [compiledCeiling.clamp] or be explicitly exempted here.
+//
+// The failure it catches has now happened once per axis added. A new grant
+// axis that clamp forgets produces NO compile error and NO test failure —
+// ceilingguard_test.go scans for direct `policy.Roles[...]` access, not for
+// field coverage — so the axis silently escapes client attenuation. That is
+// the fail-open direction, and CLAUDE.md's ceiling rule ("a ceiling only
+// ever NARROWS") is the thing it breaks.
+//
+// The exemption list is the point: adding a field forces a decision here
+// rather than allowing an omission to pass unnoticed.
+func TestClampCoversEveryGrantAxis(t *testing.T) {
+	t.Parallel()
+
+	// Fields that are deliberately NOT clamped by this mechanism, each with
+	// the reason it is safe.
+	exempt := map[string]string{
+		"Description": "documentation only; never consulted by any decision path",
+		"Fields":      "affordance map — clamped at evaluation time by internal/affordances (applyClientCeiling)",
+		"Visible":     "affordance map — same, and the field axis is resolved against declared properties",
+		"Options":     "affordance map — same",
+		"Relations":   "affordance map — same",
+	}
+
+	// A role holding every axis, so a clamped field can be told from an
+	// untouched one by comparing before/after.
+	full := RoleDef{
+		Create:      []string{"a"},
+		Update:      []string{"a"},
+		Delete:      []string{"a"},
+		Read:        []string{"a"},
+		Permissions: []string{"p"},
+		Worlds:      []string{"w"},
+	}
+	// A ceiling that permits NOTHING on every axis, so every clamped field
+	// must come back empty.
+	p := &Policy{ClientBaselines: map[string]ClientBaseline{"app": {
+		AppliesTo: []string{"app"},
+		Restriction: Restriction{
+			Create: []string{}, Update: []string{}, Delete: []string{},
+			Read: []string{}, Permissions: []string{}, Worlds: []string{},
+		},
+	}}}
+	p.normalizeClientAttenuation()
+	got := p.ceilingFor("app", nil).clamp(full)
+
+	rt := reflect.TypeFor[RoleDef]()
+	rv := reflect.ValueOf(got)
+	for i := range rt.NumField() {
+		f := rt.Field(i)
+		if reason, ok := exempt[f.Name]; ok {
+			if reason == "" {
+				t.Errorf("field %q is exempt with no reason", f.Name)
+			}
+			continue
+		}
+		if f.Type.Kind() != reflect.Slice {
+			continue
+		}
+		if l := rv.Field(i).Len(); l != 0 {
+			t.Errorf("RoleDef.%s survived a permit-nothing ceiling (len=%d) — "+
+				"clamp does not narrow it. Add it to clamp, or exempt it here "+
+				"with the reason it cannot be used to escalate.", f.Name, l)
+		}
+	}
+}

--- a/internal/acl/worldgrant.go
+++ b/internal/acl/worldgrant.go
@@ -1,0 +1,301 @@
+package acl
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+
+	"github.com/Sourcehaven-BV/rela/internal/entity"
+)
+
+// WorldGrantPrefix is the reserved prefix marking a `read:` entry as a
+// WORLD grant rather than an entity type: `read: [world:published]`
+// (design doc §8.1).
+//
+// Reserved by documentation, not by a metamodel check. Colliding needs an
+// entity type literally named `world:something`; internal/acl cannot see
+// the metamodel to reject one (arch-lint), and the collision is
+// fail-closed in the only direction it can go — the type becomes
+// unreadable rather than over-readable.
+const WorldGrantPrefix = "world:"
+
+// DefaultWorldName is the name of the implicit default world, mirroring
+// metamodel.DefaultWorldName. Duplicated rather than imported because
+// internal/acl must not depend on internal/metamodel (arch-lint); the
+// two are pinned together by TestDefaultWorldNameMatchesMetamodel.
+const DefaultWorldName = "default"
+
+// normalizeWorldGrants splits `world:`-prefixed entries out of every
+// role's Read list into [RoleDef.Worlds], and rejects the spellings that
+// cannot mean anything.
+//
+// Runs at the top of [Policy.Validate] AND from [NewDeclarative], because
+// those are two different chokepoints: Validate is where a policy is
+// LOADED, NewDeclarative is where one starts SERVING READS, and a policy
+// can reach the second without passing the first (RR-LWE222). Idempotent,
+// so running it twice is harmless — a second pass finds no prefixed
+// entries left in Read.
+//
+// Rejections, both hard errors:
+//
+//   - `world:` with an empty name. The empty name is the dangerous one:
+//     it would make a lookup with an unpopulated name succeed and return a
+//     real world, the inverse of the fail-closed rule. The metamodel
+//     loader rejects it for the same reason (validateWorlds).
+//   - `world:*`. A glob silently absorbs worlds added later, which is
+//     fail-open drift — the argument design doc §4.5 already makes for
+//     refusing `world:site-*` globs in grants. Naming worlds is the point.
+//
+// It does NOT reject a world name that no metamodel declares: that needs
+// the schema, which this package cannot see. aclaudit reports it.
+//
+// A role with no `world:` token is left untouched — see the early-continue
+// below, which is load-bearing for shared policies, not an optimization.
+func (p *Policy) normalizeWorldGrants() error {
+	for name, role := range p.Roles {
+		if !roleHasWorldToken(role) {
+			// NOTHING TO DO — and taking this branch is what makes the
+			// function safe to call on a SHARED policy. SharedBase hands one
+			// *Policy pointer to every assembled Services and documents that
+			// assembly only READS it; NewDeclarative runs on that pointer, so
+			// an unconditional `p.Roles[name] = role` would be a write on a
+			// shared map (a concurrent-map-write panic under parallel
+			// Assemble, not a benign race). An already-split policy — which
+			// every Validate-loaded one is — never reaches the write below.
+			continue
+		}
+		var types []string
+		// SEED from what is already there rather than starting empty. The
+		// second pass sees a Read list with no world tokens left in it, so
+		// rebuilding Worlds from scratch would wipe the grants the first
+		// pass extracted. Caught by TestWorldGrantSplit_Idempotent.
+		worlds := role.Worlds
+		for _, entry := range role.Read {
+			world, ok := strings.CutPrefix(entry, WorldGrantPrefix)
+			if !ok {
+				types = append(types, entry)
+				continue
+			}
+			world = strings.TrimSpace(world)
+			switch world {
+			case "":
+				return fmt.Errorf(
+					"roles.%s: read grant %q names no world — write the world's "+
+						"name (e.g. %qpublished); an empty name would match a "+
+						"lookup with an unset world and serve a real, non-default world",
+					name, entry, WorldGrantPrefix)
+			case "*":
+				return fmt.Errorf(
+					"roles.%s: read grant %q is not allowed — world grants must "+
+						"name each world explicitly, because a glob silently absorbs "+
+						"worlds declared later (an auto-widening read grant)",
+					name, entry)
+			}
+			if !slices.Contains(worlds, world) {
+				worlds = append(worlds, world)
+			}
+		}
+		role.Read = types
+		role.Worlds = worlds
+		p.Roles[name] = role
+	}
+	return nil
+}
+
+// roleHasWorldToken reports whether any Read entry still carries the
+// `world:` prefix, i.e. whether this role needs splitting at all.
+func roleHasWorldToken(role RoleDef) bool {
+	for _, entry := range role.Read {
+		if strings.HasPrefix(entry, WorldGrantPrefix) {
+			return true
+		}
+	}
+	return false
+}
+
+// roleGrantsWorldRead reports whether role may read the named world.
+//
+// The DEFAULT world is covered by an ordinary read grant — a bare type or
+// `"*"` in Read — so an existing acl.yaml keeps meaning exactly what it
+// meant (design doc §8.1). Every OTHER world must be named, which is what
+// makes reading a non-default world impossible to acquire by accident.
+//
+// Callers must resolve the role through [Request.roleFor] first, so the
+// client ceiling has already clamped Worlds; this predicate does not
+// re-check it. The ceiling's world DENIAL is applied separately by
+// [compiledCeiling.permitsWorld] — see that method for why a denial
+// cannot be expressed by clamping alone.
+func roleGrantsWorldRead(role RoleDef, world string) bool {
+	if world == "" || world == DefaultWorldName {
+		// The default world is the absence of a world grant. Any read
+		// grant at all covers it; holding none covers nothing.
+		return len(role.Read) > 0
+	}
+	return slices.Contains(role.Worlds, world)
+}
+
+// parseStateGrant splits a write grant of the form "type@pointer" into its
+// parts, reporting ok=false when the entry carries no separator (a plain
+// type grant, which addresses the DEFAULT state).
+//
+// The pointer half is parsed by [entity.ParsePointer], so a grant and the
+// storage layer can never disagree about what a pointer name is.
+//
+// The TYPE half is deliberately NOT validated here, and NOT parsed with
+// [entity.ParseStateRef]. That codec validates its left side with
+// entity.ValidateID — the ENTITY-ID grammar, which rejects the internal
+// spaces metamodel.ValidateSchemaName deliberately permits in a type name
+// ("some property" is that function's own documented example). Reusing it
+// would reject legal type names with an error message about entity IDs.
+// Whether the type exists at all is a schema question, so aclaudit
+// reports it (B1-undeclared-type).
+func parseStateGrant(s string) (typeName string, p entity.Pointer, isState bool, err error) {
+	typeName, ptr, found := strings.Cut(s, entity.StateRefSeparator)
+	if !found {
+		return s, "", false, nil
+	}
+	if strings.Contains(ptr, entity.StateRefSeparator) {
+		return "", "", true, fmt.Errorf(
+			"write grant %q: more than one %q — a state cannot have a state",
+			s, entity.StateRefSeparator)
+	}
+	parsed, perr := entity.ParsePointer(ptr)
+	if perr != nil {
+		return "", "", true, fmt.Errorf("write grant %q: %w", s, perr)
+	}
+	if typeName == "" {
+		return "", "", true, fmt.Errorf(
+			"write grant %q: names a state but no entity type", s)
+	}
+	return typeName, parsed, true, nil
+}
+
+// grantTypeOf returns the entity type a write-grant entry addresses:
+// the whole entry for a plain type grant, the part before "@" for a
+// state grant. Used where only the TYPE matters — the write⊆read
+// coverage check, and aclaudit's undeclared-type checks.
+func grantTypeOf(entry string) string {
+	typeName, _, _ := strings.Cut(entry, entity.StateRefSeparator)
+	return typeName
+}
+
+// validateStateGrants checks every write-grant entry that carries a state
+// separator, so a malformed pointer fails at load rather than silently
+// granting nothing.
+func (p *Policy) validateStateGrants() error {
+	for _, name := range sortedRoleNames(p.Roles) {
+		role := p.Roles[name]
+		for _, verb := range []struct {
+			name string
+			list []string
+		}{
+			{"create", role.Create}, {"update", role.Update}, {"delete", role.Delete},
+		} {
+			for _, entry := range verb.list {
+				if _, _, isState, err := parseStateGrant(entry); isState && err != nil {
+					return fmt.Errorf("roles.%s: %s: %w", name, verb.name, err)
+				}
+			}
+		}
+	}
+	return nil
+}
+
+// sortedRoleNames returns the policy's role names in a deterministic
+// order, so a load error names the same role on every run rather than
+// whichever one Go's map iteration reached first.
+func sortedRoleNames(roles map[string]RoleDef) []string {
+	names := make([]string, 0, len(roles))
+	for name := range roles {
+		names = append(names, name)
+	}
+	slices.Sort(names)
+	return names
+}
+
+// GrantsAnyNonDefaultWorldRead reports whether any role in this policy
+// grants read on a world other than the default one.
+//
+// This is the trigger half of the membership-gate load refusal
+// ([Policy.WorldGrantRefusalReason]): the refusal exists because a
+// non-default world read grant changes the stakes of an ungated
+// role-relation from over-granting inside a trusted team to a working
+// mechanism for reading unpublished content.
+//
+// A policy whose only world grant is `world:default` does NOT count — that
+// grant means exactly what an ordinary read grant already meant.
+func (p *Policy) GrantsAnyNonDefaultWorldRead() bool {
+	for _, role := range p.Roles {
+		for _, w := range role.Worlds {
+			if w != DefaultWorldName {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// GrantsVerbOnState reports whether role may perform op on the specific
+// FACE (target, p) of an entity — the face-granular write check.
+//
+// Matching is EXACT and there is no inheritance between states (design
+// doc §8.2, fail closed):
+//
+//   - `update: ["page"]` grants the DEFAULT state of page, and nothing
+//     else. An operator who adds pointers to an existing type finds their
+//     existing grants now cover one face — the correct fail-closed reading,
+//     and the reason it is documented as a migration note.
+//   - `update: ["page@draft"]` grants the draft face only; it does NOT
+//     grant published, nor the default state.
+//   - `update: ["*"]` grants every type's DEFAULT state. It is a wildcard
+//     over TYPES, never over pointers — otherwise the one grant every
+//     admin policy already holds would silently acquire authority over
+//     every face the moment a type declares pointers, which is precisely
+//     the "no role holds update on published" invariant (§8.2) inverted.
+func GrantsVerbOnState(role RoleDef, op Op, target string, p entity.Pointer) bool {
+	var list []string
+	switch op {
+	case OpCreate:
+		list = role.Create
+	case OpUpdate, OpRename:
+		list = role.Update
+	case OpDelete:
+		list = role.Delete
+	default:
+		return false
+	}
+	for _, entry := range list {
+		if entry == "*" {
+			if p.IsDefault() {
+				return true
+			}
+			continue
+		}
+		entryType, entryPtr, isState, err := parseStateGrant(entry)
+		if err != nil {
+			continue // malformed grants are rejected at load; never grant here
+		}
+		if entryType != target {
+			continue
+		}
+		if !isState {
+			entryPtr = "" // a bare type grant addresses the default state
+		}
+		if entryPtr == p {
+			return true
+		}
+	}
+	return false
+}
+
+// isStateGrant reports whether a write-grant entry names a specific face
+// (`page@draft`) rather than a bare entity type.
+//
+// Kept separate from [grantTypeOf] because the two answer opposite
+// questions and the distinction is load-bearing: grantTypeOf is for code
+// that wants the TYPE regardless of face (the write⊆read coverage check,
+// aclaudit's undeclared-type checks), while this is for code that must
+// treat a face-specific grant as out of its scope.
+func isStateGrant(entry string) bool {
+	return strings.Contains(entry, entity.StateRefSeparator)
+}

--- a/internal/acl/worldgrant_test.go
+++ b/internal/acl/worldgrant_test.go
@@ -1,0 +1,347 @@
+package acl_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/Sourcehaven-BV/rela/internal/acl"
+	"github.com/Sourcehaven-BV/rela/internal/entity"
+	"github.com/Sourcehaven-BV/rela/internal/metamodel"
+	"github.com/Sourcehaven-BV/rela/internal/principal"
+)
+
+// TestDefaultWorldNameMatchesMetamodel pins the duplicated constant.
+// internal/acl may not import internal/metamodel (arch-lint), so the name
+// is spelled twice; a drift would make a `world:default` grant stop being
+// recognized as the default world.
+func TestDefaultWorldNameMatchesMetamodel(t *testing.T) {
+	t.Parallel()
+	if acl.DefaultWorldName != metamodel.DefaultWorldName {
+		t.Fatalf("acl.DefaultWorldName = %q, metamodel.DefaultWorldName = %q — "+
+			"these must agree", acl.DefaultWorldName, metamodel.DefaultWorldName)
+	}
+}
+
+// TestWorldGrantSplit_LeavesReadTypeOnly is the structural guarantee behind
+// the whole representation choice: after load, Read holds nothing but
+// entity types.
+//
+// If a world token survived in Read it would be intersected with a client
+// ceiling's TYPE allow/deny list by filterTypes — silently DROPPED under an
+// allowlist ceiling, silently KEPT under a deny ceiling — and reported by
+// aclaudit's B1 as an undeclared entity type at High severity.
+func TestWorldGrantSplit_LeavesReadTypeOnly(t *testing.T) {
+	t.Parallel()
+	p := &acl.Policy{Roles: map[string]acl.RoleDef{
+		"author": {Read: []string{"page", "world:editorial", "ticket", "world:published"}},
+	}}
+	if err := p.Validate(); err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+	role := p.Roles["author"]
+	for _, entry := range role.Read {
+		if strings.HasPrefix(entry, acl.WorldGrantPrefix) {
+			t.Errorf("Read still holds a world token %q — it must be split into Worlds", entry)
+		}
+	}
+	if got, want := strings.Join(role.Read, ","), "page,ticket"; got != want {
+		t.Errorf("Read = %q, want %q", got, want)
+	}
+	if got, want := strings.Join(role.Worlds, ","), "editorial,published"; got != want {
+		t.Errorf("Worlds = %q, want %q", got, want)
+	}
+}
+
+// TestWorldGrantSplit_Idempotent pins the property NewDeclarative relies
+// on: it runs the split too, and a policy that already came through
+// Validate must not be mangled by the second pass.
+func TestWorldGrantSplit_Idempotent(t *testing.T) {
+	t.Parallel()
+	p := &acl.Policy{Roles: map[string]acl.RoleDef{
+		"author": {Read: []string{"page", "world:published"}},
+	}}
+	if err := p.Validate(); err != nil {
+		t.Fatalf("first Validate: %v", err)
+	}
+	first := p.Roles["author"]
+	if err := p.Validate(); err != nil {
+		t.Fatalf("second Validate: %v", err)
+	}
+	second := p.Roles["author"]
+	readChanged := strings.Join(first.Read, ",") != strings.Join(second.Read, ",")
+	worldsChanged := strings.Join(first.Worlds, ",") != strings.Join(second.Worlds, ",")
+	if readChanged || worldsChanged {
+		t.Errorf("not idempotent: %v/%v then %v/%v",
+			first.Read, first.Worlds, second.Read, second.Worlds)
+	}
+}
+
+func TestWorldGrantRejections(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name, grant, mustSay string
+	}{
+		{"empty world name", "world:", "names no world"},
+		{"whitespace-only world name", "world:   ", "names no world"},
+		{"world wildcard", "world:*", "name each world explicitly"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			p := &acl.Policy{Roles: map[string]acl.RoleDef{
+				"r": {Read: []string{tc.grant}},
+			}}
+			err := p.Validate()
+			if err == nil {
+				t.Fatalf("expected %q to be rejected at load", tc.grant)
+			}
+			if !strings.Contains(err.Error(), tc.mustSay) {
+				t.Errorf("error must explain the problem (%q); got: %v", tc.mustSay, err)
+			}
+		})
+	}
+}
+
+// TestStateGrant_WriteReadCoverage pins the F2 fix: the write⊆read
+// invariant (TKT-4LQMWP) compares on the TYPE half.
+//
+// Before the fix, `update: ["policy@draft"]` was compared as a literal
+// against the read list and failed load with a hint telling the operator to
+// add "policy@draft" to `read:` — which a read list cannot hold.
+func TestStateGrant_WriteReadCoverage(t *testing.T) {
+	t.Parallel()
+	t.Run("state grant covered by a bare-type read grant loads", func(t *testing.T) {
+		t.Parallel()
+		p := &acl.Policy{Roles: map[string]acl.RoleDef{
+			"author": {Update: []string{"policy@draft"}, Read: []string{"policy"}},
+		}}
+		if err := p.Validate(); err != nil {
+			t.Fatalf("update on policy@draft with read on policy must load: %v", err)
+		}
+	})
+	t.Run("state grant with no read coverage is still rejected", func(t *testing.T) {
+		t.Parallel()
+		p := &acl.Policy{Roles: map[string]acl.RoleDef{
+			"author": {Update: []string{"policy@draft"}, Read: []string{"page"}},
+		}}
+		err := p.Validate()
+		if err == nil {
+			t.Fatal("expected the write-without-read rejection")
+		}
+		if !strings.Contains(err.Error(), `add "policy"`) {
+			t.Errorf("hint must name the TYPE, not the joined grant; got: %v", err)
+		}
+	})
+}
+
+func TestStateGrant_MalformedRejected(t *testing.T) {
+	t.Parallel()
+	for _, grant := range []string{
+		"page@",      // no pointer
+		"page@Draft", // uppercase: not the pointer grammar
+		"page@a--b",  // consecutive hyphens
+		"page@d@p",   // a state cannot have a state
+		"@draft",     // no type
+	} {
+		t.Run(grant, func(t *testing.T) {
+			t.Parallel()
+			p := &acl.Policy{Roles: map[string]acl.RoleDef{
+				"r": {Update: []string{grant}, Read: []string{"*"}},
+			}}
+			if err := p.Validate(); err == nil {
+				t.Errorf("expected %q to be rejected at load", grant)
+			}
+		})
+	}
+}
+
+// TestStateGrant_TypeNameWithSpaceParses pins why parseStateGrant does not
+// reuse entity.ParseStateRef: that codec validates its left side with the
+// ENTITY-ID grammar, which rejects the internal spaces
+// metamodel.ValidateSchemaName deliberately permits in a type name.
+func TestStateGrant_TypeNameWithSpaceParses(t *testing.T) {
+	t.Parallel()
+	p := &acl.Policy{Roles: map[string]acl.RoleDef{
+		"r": {Update: []string{"some property@draft"}, Read: []string{"some property"}},
+	}}
+	if err := p.Validate(); err != nil {
+		t.Fatalf("a legal (if unusual) type name must be grantable: %v", err)
+	}
+}
+
+// TestExistingPolicyUnchanged is the backward-compatibility guarantee: a
+// policy with no world token means exactly what it meant before.
+func TestExistingPolicyUnchanged(t *testing.T) {
+	t.Parallel()
+	p := &acl.Policy{Roles: map[string]acl.RoleDef{
+		"editor": {Read: []string{"page", "ticket"}, Update: []string{"page"}},
+		"admin":  {Read: []string{"*"}, Create: []string{"*"}, Update: []string{"*"}, Delete: []string{"*"}},
+	}}
+	if err := p.Validate(); err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+	for name, role := range p.Roles {
+		if len(role.Worlds) != 0 {
+			t.Errorf("role %q gained world grants from a policy that declared none: %v",
+				name, role.Worlds)
+		}
+	}
+	if got := strings.Join(p.Roles["editor"].Read, ","); got != "page,ticket" {
+		t.Errorf("read list altered: %q", got)
+	}
+}
+
+// TestGrantsVerbOnState pins the face-granular write check: exact match,
+// no inheritance between states, and no wildcard over pointers.
+func TestGrantsVerbOnState(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		grants  []string
+		target  string
+		pointer string
+		want    bool
+	}{
+		{"bare type grants the default state", []string{"page"}, "page", "", true},
+		{"bare type does NOT grant a named state", []string{"page"}, "page", "draft", false},
+		{"state grant grants its own face", []string{"page@draft"}, "page", "draft", true},
+		{"state grant does NOT grant a sibling face", []string{"page@draft"}, "page", "published", false},
+		{"state grant does NOT grant the default state", []string{"page@draft"}, "page", "", false},
+		{"wildcard grants every type's default state", []string{"*"}, "page", "", true},
+		{"wildcard does NOT grant a named state", []string{"*"}, "page", "draft", false},
+		{"wrong type", []string{"page@draft"}, "policy", "draft", false},
+		{"several grants, one matches", []string{"ticket", "page@draft"}, "page", "draft", true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			role := acl.RoleDef{Update: tc.grants}
+			if got := acl.GrantsVerbOnState(role, acl.OpUpdate, tc.target, entity.Pointer(tc.pointer)); got != tc.want {
+				t.Errorf("GrantsVerbOnState(%v, %q@%q) = %v, want %v",
+					tc.grants, tc.target, tc.pointer, got, tc.want)
+			}
+		})
+	}
+}
+
+// permitsWorldFor builds a Request for a principal holding the everyone
+// role plus any assigned one, and asks it about a world.
+func permitsWorldFor(t *testing.T, p *acl.Policy, world string) bool {
+	t.Helper()
+	if err := p.Validate(); err != nil {
+		t.Fatalf("policy must load: %v", err)
+	}
+	d, err := acl.NewDeclarative(p, acl.NullGraph{}, acl.NullGraphQueryer{})
+	if err != nil {
+		t.Fatalf("NewDeclarative: %v", err)
+	}
+	req, err := d.ForPrincipal(principal.Principal{User: "alice", Tool: "test"})
+	if err != nil {
+		t.Fatalf("ForPrincipal: %v", err)
+	}
+	ok, err := req.PermitsWorld(context.Background(), world)
+	if err != nil {
+		t.Fatalf("PermitsWorld: %v", err)
+	}
+	return ok
+}
+
+// TestPermitsWorld is the composition test for the exported gate PR-C
+// builds on: ceiling -> Globals -> roleFor -> roleGrantsWorldRead.
+func TestPermitsWorld(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name  string
+		roles map[string]acl.RoleDef
+		world string
+		want  bool
+	}{
+		{
+			name:  "named world grant permits that world",
+			roles: map[string]acl.RoleDef{"everyone": {Read: []string{"world:published"}}},
+			world: "published", want: true,
+		},
+		{
+			name:  "a world the principal was not granted is denied",
+			roles: map[string]acl.RoleDef{"everyone": {Read: []string{"world:published"}}},
+			world: "editorial", want: false,
+		},
+		{
+			name:  "an ordinary read grant permits the default world",
+			roles: map[string]acl.RoleDef{"everyone": {Read: []string{"page"}}},
+			world: "", want: true,
+		},
+		{
+			name:  "a bare read grant does NOT permit a non-default world",
+			roles: map[string]acl.RoleDef{"everyone": {Read: []string{"page"}}},
+			world: "published", want: false,
+		},
+		{
+			name:  "the read wildcard does NOT reach a non-default world",
+			roles: map[string]acl.RoleDef{"everyone": {Read: []string{"*"}}},
+			world: "published", want: false,
+		},
+		{
+			name:  "a principal holding no role at all is denied",
+			roles: map[string]acl.RoleDef{},
+			world: "published", want: false,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := permitsWorldFor(t, &acl.Policy{Roles: tc.roles}, tc.world)
+			if got != tc.want {
+				t.Errorf("PermitsWorld(%q) = %v, want %v", tc.world, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestPermitsWorld_CeilingOverridesRoleGrant pins that the client ceiling
+// is consulted — the roleFor clamp point plus the mandatory permitsWorld
+// post-check. A restricted client must not reach a world its user holds.
+func TestPermitsWorld_CeilingOverridesRoleGrant(t *testing.T) {
+	t.Parallel()
+	p := &acl.Policy{
+		Roles: map[string]acl.RoleDef{
+			"everyone": {Read: []string{"page", "world:published", "world:editorial"}},
+		},
+		ClientBaselines: map[string]acl.ClientBaseline{
+			"app": {AppliesTo: []string{"app"}, Restriction: acl.Restriction{
+				Worlds: []string{"published"},
+			}},
+		},
+	}
+	if err := p.Validate(); err != nil {
+		t.Fatalf("policy must load: %v", err)
+	}
+	d, err := acl.NewDeclarative(p, acl.NullGraph{}, acl.NullGraphQueryer{})
+	if err != nil {
+		t.Fatalf("NewDeclarative: %v", err)
+	}
+	req, err := d.ForPrincipal(principal.VerifiedFrom("alice", "test",
+		principal.Claims{PrincipalType: "app"}))
+	if err != nil {
+		t.Fatalf("ForPrincipal: %v", err)
+	}
+	ctx := context.Background()
+	for _, tc := range []struct {
+		world string
+		want  bool
+		why   string
+	}{
+		{"published", true, "inside the ceiling's allowlist"},
+		{"editorial", false, "the user holds it but the ceiling does not"},
+		{"", true, "an allowlist must not revoke the default world"},
+	} {
+		got, err := req.PermitsWorld(ctx, tc.world)
+		if err != nil {
+			t.Fatalf("PermitsWorld(%q): %v", tc.world, err)
+		}
+		if got != tc.want {
+			t.Errorf("PermitsWorld(%q) = %v, want %v (%s)", tc.world, got, tc.want, tc.why)
+		}
+	}
+}

--- a/internal/aclaudit/aclaudit.go
+++ b/internal/aclaudit/aclaudit.go
@@ -229,6 +229,19 @@ func permissionGranted(p *acl.Policy, perm string) bool {
 	return false
 }
 
+// grantEntityType returns the entity type an ACL grant entry addresses:
+// the whole entry for a plain type grant, the part before "@" for a
+// state-shaped write grant (`page@draft`, TKT-DN37J2).
+//
+// Mirrors internal/acl's unexported grantTypeOf. Duplicated rather than
+// exported from there because it is one strings.Cut and the audit already
+// keeps its own narrow view of the policy — but the two must agree, which
+// is what TestGrantEntityType_MatchesACLSplit pins.
+func grantEntityType(entry string) string {
+	typeName, _, _ := strings.Cut(entry, "@")
+	return typeName
+}
+
 // verbLists returns the four grant lists of a role for iteration.
 func verbLists(r acl.RoleDef) map[string][]string {
 	return map[string][]string{

--- a/internal/aclaudit/aclaudit_test.go
+++ b/internal/aclaudit/aclaudit_test.go
@@ -1,6 +1,7 @@
 package aclaudit
 
 import (
+	"maps"
 	"slices"
 	"strings"
 	"testing"
@@ -618,4 +619,113 @@ func TestHasAtLeast(t *testing.T) {
 	if !HasAtLeast([]Finding{{Severity: Critical}}, High) {
 		t.Error("HasAtLeast(High) should be true when a critical is present")
 	}
+}
+
+// TestGrantEntityType_MatchesACLSplit pins the duplication this package
+// accepts: grantEntityType mirrors internal/acl's unexported grantTypeOf,
+// and the two must agree or the audit reports a type the runtime never
+// evaluated.
+//
+// Verified through acl's exported behavior rather than by calling the
+// unexported helper: a role granting update on `T@p` must be reported by
+// the audit against type T, which is only true if both split the same way.
+func TestGrantEntityType_MatchesACLSplit(t *testing.T) {
+	for _, tc := range []struct{ entry, wantType string }{
+		{"page", "page"},
+		{"page@draft", "page"},
+		{"*", "*"},
+		{"some property@draft", "some property"},
+		{"review-response@published", "review-response"},
+	} {
+		p := &acl.Policy{Roles: map[string]acl.RoleDef{
+			"r": {Update: []string{tc.entry}, Read: []string{"*"}},
+		}}
+		findings := Audit(p, fakeMetamodel{types: map[string]bool{tc.wantType: true}}, nil)
+		for _, f := range findings {
+			if f.Rule == "B1-undeclared-type" {
+				t.Errorf("entry %q: audit did not resolve it to type %q (finding: %s)",
+					tc.entry, tc.wantType, f.Detail)
+			}
+		}
+	}
+}
+
+// TestRefusalIsWiderThanOrEqualToA2 pins the DIRECTIONAL relationship
+// between the advisory finding and the boot refusal, which is the property
+// that actually matters — not that the two are identical.
+//
+// The invariant: whenever A2 flags a policy, the boot refusal also refuses
+// it (given the refusal's own trigger, a non-default world read grant).
+// Stated as sets: refusal ⊇ A2. An operator can therefore never see
+// `rela acl audit` report clean on a policy the server refuses for an
+// A2-shaped reason.
+//
+// The reverse gap is deliberate and is NOT a violation: the refusal may
+// fire where A2 is silent, because the refusal is scoped to policies that
+// grant a non-default world and A2 is not. That case is
+// TestRefusal_ReadOnlyRoleHoldingWorldGrantCountsAsEscalation in
+// internal/acl.
+//
+// If this ever fails, the two predicates have been allowed to drift apart
+// in the dangerous direction — the audit has become MORE permissive than
+// the gate, so a policy would pass the linter and fail to boot.
+func TestRefusalIsWiderThanOrEqualToA2(t *testing.T) {
+	roles := map[string]acl.RoleDef{
+		"writer":      {Update: []string{"page"}, Read: []string{"page"}},
+		"permholder":  {Permissions: []string{"something"}},
+		"creator":     {Create: []string{"page"}},
+		"deleter":     {Delete: []string{"page"}, Read: []string{"page"}},
+		"reader":      {Read: []string{"page"}},
+		"worldreader": {Read: []string{"page", "world:published"}},
+	}
+	for roleName := range roles {
+		t.Run(roleName, func(t *testing.T) {
+			p := &acl.Policy{
+				// A non-default world grant somewhere in the policy is the
+				// refusal's trigger; without it the refusal never evaluates
+				// the escalation arms at all.
+				Roles: mergeRoles(roles, map[string]acl.RoleDef{
+					"everyone": {Read: []string{"world:published"}},
+				}),
+				RoleRelations: map[string]acl.RoleRelationDef{
+					"owns": {Confers: roleName},
+				},
+			}
+			if err := p.Validate(); err != nil && !strings.Contains(err.Error(), "refusing to load") {
+				t.Fatalf("unexpected non-refusal load error: %v", err)
+			}
+			flaggedByA2 := len(checkUngatedRoleRelations(p)) > 0
+			refused := p.WorldGrantRefusalReason() != ""
+			if flaggedByA2 && !refused {
+				t.Errorf("A2 flags role %q but the boot refusal does not refuse it — "+
+					"the audit is now MORE permissive than the gate, so this policy "+
+					"passes the linter and fails to boot", roleName)
+			}
+		})
+	}
+}
+
+// TestA2_ReadOnlyRoleStillSilent pins that widening A2's criterion to
+// include world grants did NOT reintroduce the read-only false positive the
+// audit design fought (RR-LXI3NW / RR-UR0LJU / RR-EG5D3E).
+func TestA2_ReadOnlyRoleStillSilent(t *testing.T) {
+	p := &acl.Policy{
+		Roles:         map[string]acl.RoleDef{"viewer": {Read: []string{"page", "*"}}},
+		RoleRelations: map[string]acl.RoleRelationDef{"owns": {Confers: "viewer"}},
+	}
+	if err := p.Validate(); err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+	if got := checkUngatedRoleRelations(p); len(got) != 0 {
+		t.Errorf("a role holding only ordinary read grants — even read: [\"*\"] — "+
+			"is a visibility choice, not an escalation path; got %d finding(s): %+v",
+			len(got), got)
+	}
+}
+
+func mergeRoles(a, b map[string]acl.RoleDef) map[string]acl.RoleDef {
+	out := make(map[string]acl.RoleDef, len(a)+len(b))
+	maps.Copy(out, a)
+	maps.Copy(out, b)
+	return out
 }

--- a/internal/aclaudit/ceiling.go
+++ b/internal/aclaudit/ceiling.go
@@ -235,8 +235,19 @@ func ceilingTypeFindings(
 		{"read", r.Read}, {"create", r.Create}, {"update", r.Update}, {"delete", r.Delete},
 		{"deny_read", r.DenyRead}, {"deny_create", r.DenyCreate},
 		{"deny_update", r.DenyUpdate}, {"deny_delete", r.DenyDelete},
+		// worlds/deny_worlds are deliberately ABSENT: their entries are
+		// world names, not entity types, so HasEntityType is the wrong
+		// question and would report every one of them as undeclared.
+		//
+		// A ceiling naming a world the metamodel does not declare is
+		// therefore checked by NOTHING today. That needs a world-aware
+		// MetamodelReader, which lands with the rest of the world
+		// cross-checks in TKT-DN37J2 PR-B; it is not implemented here.
 	} {
-		for _, t := range c.types {
+		for _, entry := range c.types {
+			// TYPE half only — a ceiling axis may name a state-shaped
+			// grant for the same reason a role may (TKT-DN37J2).
+			t := grantEntityType(entry)
 			if t == "*" || m.HasEntityType(t) || seen[t] {
 				continue
 			}

--- a/internal/aclaudit/tier_a.go
+++ b/internal/aclaudit/tier_a.go
@@ -66,19 +66,44 @@ func checkUngatedMembership(p *acl.Policy) []Finding {
 	return f
 }
 
-// A2 — a role-relation confers a privileged role but is not gated by
-// requires_permission: anyone who can write that edge self-grants the role.
+// A2 — a role-relation confers an escalation-relevant role but is not gated
+// by requires_permission: anyone who can write that edge self-grants the role.
+//
+// # Why this shares acl.Policy.RoleRelationEscalates with the boot refusal
+//
+// The predicate lives on acl.Policy and is called by BOTH this finding and
+// [acl.Policy.WorldGrantRefusalReason]'s second arm, so the advisory view and
+// the enforcement view cannot disagree about the condition — TKT-T31NKT's
+// shared-predicate property (which A1 above already has), extended to A2 by
+// Ruling 8.
+//
+// # The criterion is WIDER than IsPrivileged, deliberately
+//
+// RoleRelationEscalates uses acl's roleIsEscalationRelevant: any write verb,
+// any permission, OR a read grant on a NON-DEFAULT WORLD. That last term is
+// what A1's symmetry note above does not have, and it matters here:
+//
+//	owns:   { confers: viewer }          # ungated
+//	viewer: { read: [world:published] }  # IsPrivileged: FALSE
+//
+// One `owns` write self-grants a published-world read. Keying on
+// IsPrivileged alone would leave that silent while the server refuses to
+// boot on it — an audit reporting clean on a policy that cannot start.
+//
+// This does NOT reintroduce the read-only false positive A1's note fights
+// (RR-LXI3NW / RR-UR0LJU / RR-EG5D3E). A role holding only ordinary read
+// grants is still not escalation-relevant and still produces no finding;
+// only a non-default WORLD grant counts, and only because worlds are the
+// thing a draft/published split exists to keep separate. Pinned by
+// TestA2_ReadOnlyRoleStillSilent and
+// TestRefusalIsWiderThanOrEqualToA2.
 func checkUngatedRoleRelations(p *acl.Policy) []Finding {
 	var f []Finding
 	for _, rel := range sortedRelTypes(p) {
-		def := p.RoleRelations[rel]
-		role, ok := p.Roles[def.Confers]
-		if !ok || !isPrivileged(role) {
+		if !p.RoleRelationEscalates(rel) {
 			continue
 		}
-		if def.RequiresPermission != "" {
-			continue // gated — fine
-		}
+		def := p.RoleRelations[rel]
 		f = append(f, Finding{
 			Rule: "A2-ungated-role-relation", Severity: High, Subject: rel,
 			Detail: fmt.Sprintf("role-relation %q confers the privileged role %q but is not gated by "+

--- a/internal/aclaudit/tier_b.go
+++ b/internal/aclaudit/tier_b.go
@@ -31,7 +31,14 @@ func checkUndeclaredEntityTypes(p *acl.Policy, m MetamodelReader) []Finding {
 	for _, name := range sortedRoleNames(p) {
 		role := p.Roles[name]
 		seen := map[string]bool{}
-		flag := func(verb, t string) {
+		flag := func(verb, entry string) {
+			// Check the TYPE half. A write grant may be state-shaped
+			// (`page@draft`, TKT-DN37J2); the type is what the metamodel
+			// declares, and reporting the joined string as an undeclared
+			// type would fail CI on every correct state grant (this finding
+			// is High, and `rela acl audit --exit-code` gates on High).
+			// Whether the POINTER is declared is a separate check.
+			t := grantEntityType(entry)
 			// Dedupe on type alone: one typo'd type used across several verbs
 			// (or an affordance key) is one mistake with one fix.
 			if t == "*" || m.HasEntityType(t) || seen[t] {

--- a/internal/appbuild/appbuild.go
+++ b/internal/appbuild/appbuild.go
@@ -1240,6 +1240,38 @@ func (b *SharedBase) Assemble(
 	return assemble(b, st, searcher, visible, searchCloser)
 }
 
+// buildEntityManager assembles the write-path manager from the collaborators
+// assemble has already derived. Extracted purely to keep assemble within the
+// funlen budget; it makes no decisions of its own.
+func buildEntityManager(
+	base *SharedBase, st store.Store, aliases entitymanager.AliasRewriter,
+	templater entitymanager.TemplateLoader, resolvedACL acl.ACL,
+	autoEngine *automation.Engine, cascadeRunner *autocascade.Runner,
+	readDeps lua.ReadDeps, versions store.VersionService, tw TransitionWiring,
+) (*entitymanager.Manager, error) {
+	mgr, err := entitymanager.New(entitymanager.Deps{
+		AliasRewriter:           aliases,
+		Store:                   st,
+		Meta:                    base.meta,
+		Templater:               templater,
+		Audit:                   base.cfg.Audit,
+		ACL:                     resolvedACL,
+		Automations:             autoEngine,
+		Cascade:                 cascadeRunner,
+		ScriptRunner:            cascadeScriptRunner(base.cfg.ScriptEngine, readDeps, st, base.cfg.Audit),
+		VersionRecorder:         versionRecorderFor(versions),
+		RelationVersionRecorder: relationVersionRecorderFor(versions),
+		Transitions:             tw.Enforcer,
+		FieldGate:               entitymanager.AllowAllFieldGate{},
+		TransitionGuard:         tw.Guard,
+		TransitionGraph:         tw.Graph,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("build entitymanager: %w", err)
+	}
+	return mgr, nil
+}
+
 func assemble(
 	base *SharedBase, st store.Store, searcher search.Searcher,
 	visible search.VisibleSearcher, searchCloser io.Closer,
@@ -1302,25 +1334,10 @@ func assemble(
 		return nil, err
 	}
 
-	mgr, err := entitymanager.New(entitymanager.Deps{
-		AliasRewriter:           aliases,
-		Store:                   st,
-		Meta:                    base.meta,
-		Templater:               templater,
-		Audit:                   cfg.Audit,
-		ACL:                     resolvedACL,
-		Automations:             autoEngine,
-		Cascade:                 cascadeRunner,
-		ScriptRunner:            cascadeScriptRunner(cfg.ScriptEngine, readDeps, st, cfg.Audit),
-		VersionRecorder:         versionRecorderFor(versions),
-		RelationVersionRecorder: relationVersionRecorderFor(versions),
-		Transitions:             tw.Enforcer,
-		FieldGate:               entitymanager.AllowAllFieldGate{},
-		TransitionGuard:         tw.Guard,
-		TransitionGraph:         tw.Graph,
-	})
+	mgr, err := buildEntityManager(base, st, aliases, templater, resolvedACL,
+		autoEngine, cascadeRunner, readDeps, versions, tw)
 	if err != nil {
-		return nil, fmt.Errorf("build entitymanager: %w", err)
+		return nil, err
 	}
 
 	val := validator.New(st, base.meta, readDeps)

--- a/internal/docs/resolvers_acl.go
+++ b/internal/docs/resolvers_acl.go
@@ -93,9 +93,9 @@ type verbSpec struct {
 // dispatching read (a separate list) from the create/update/delete verbs.
 func roleGrantsVerb(role acl.RoleDef, v verbSpec, typ string) bool {
 	if v.name == "read" {
-		return grantsList(role.Read, typ)
+		return acl.GrantsRead(role, typ)
 	}
-	return grantsVerb(role, v.op, typ)
+	return acl.GrantsVerb(role, v.op, typ)
 }
 
 // matrixTypes returns the requested type (validated) or all entity types.
@@ -109,29 +109,6 @@ func (dr *docRuntime) matrixTypes(typ string) []string {
 	all := dr.meta.EntityTypes()
 	sort.Strings(all)
 	return all
-}
-
-// grantsVerb / grantsList replicate the policy's wildcard-or-exact match over
-// the exported RoleDef grant lists (the policy's own helpers are unexported).
-func grantsVerb(role acl.RoleDef, op acl.Op, target string) bool {
-	switch op {
-	case acl.OpCreate:
-		return grantsList(role.Create, target)
-	case acl.OpUpdate, acl.OpRename:
-		return grantsList(role.Update, target)
-	case acl.OpDelete:
-		return grantsList(role.Delete, target)
-	}
-	return false
-}
-
-func grantsList(list []string, target string) bool {
-	for _, t := range list {
-		if t == "*" || t == target {
-			return true
-		}
-	}
-	return false
 }
 
 // namedRoleNames returns the policy's role names sorted, EXCLUDING the built-in

--- a/internal/metamodel/loader.go
+++ b/internal/metamodel/loader.go
@@ -312,6 +312,22 @@ func validateEntitySemantics(m *Metamodel) []string {
 			errs = append(errs, fmt.Sprintf("entity %v", err))
 		}
 
+		// "@" additionally separates a type from a content state in an ACL
+		// write grant (`page@draft`, TKT-DN37J2). A type name carrying one
+		// makes that grant ambiguous in BOTH directions: a grant on a type
+		// named `a@b` stops matching it, and starts matching a different
+		// type named `a`. The second is a cross-type privilege escalation.
+		//
+		// Rejected here rather than in ValidateSchemaName because that is
+		// shared with property names, which are not grant subjects and have
+		// no reason to lose a legal character.
+		if strings.Contains(name, "@") {
+			errs = append(errs, fmt.Sprintf(
+				"entity %q: entity type names must not contain '@' — it separates "+
+					"a type from a content state in ACL write grants (page@draft), "+
+					"so a type name carrying one makes those grants ambiguous", name))
+		}
+
 		if def.Label == "" {
 			errs = append(errs, fmt.Sprintf("entity %q: missing 'label'", name))
 		}
@@ -715,10 +731,21 @@ func validateWorlds(m *Metamodel) []string {
 				worldName))
 		}
 		if err := ValidateSchemaName(worldName); err != nil {
-			// A world name reaches URLs, acl.yaml and CLI flags in later
-			// steps. The empty name is the dangerous one: it would make a
-			// lookup with an unpopulated name succeed and return a real,
-			// non-default world — the inverse of the fail-closed rule.
+			// The empty name is the one THIS check catches that matters: it
+			// would make a lookup with an unpopulated name succeed and
+			// return a real, non-default world — the inverse of the
+			// fail-closed rule.
+			//
+			// It is NOT the whole story, and this comment used to imply it
+			// was. ValidateSchemaName is a blocklist tuned for type and
+			// property names, so it still admits `/`, `%`, `?`, `&`, `#`,
+			// `..` and internal spaces — all hostile in the `?world=` /
+			// `--world` / `acl.yaml` contexts a world name reaches. The
+			// strict allowlist lives in internal/worlds.validateWorldNames,
+			// because that grammar is entity.ParsePointer's and
+			// internal/metamodel may not import internal/entity (arch-lint).
+			// Both run at load; this one first, for the better message on a
+			// blank name.
 			errs = append(errs, fmt.Sprintf("world %q: invalid name: %v", worldName, err))
 		}
 		if len(world.Select) == 0 && len(world.Overrides) == 0 {

--- a/internal/migration/acl_provisioner_grant.go
+++ b/internal/migration/acl_provisioner_grant.go
@@ -270,9 +270,25 @@ func hasCreateTarget(roleDef *yaml.Node, userType string) bool {
 		return false
 	}
 	for _, t := range create.Content {
-		if t.Value == "*" || t.Value == userType {
+		// Compare on the TYPE half: a state-shaped grant (`person@draft`,
+		// TKT-DN37J2) already grants create on `person`, so treating it as
+		// a miss would make this migration REPLACE the operator's whole
+		// create list with a bare one-element list — destroying the state
+		// grant and any unrelated entries beside it (RR-H98VX0).
+		if t.Value == "*" || grantTypeOf(t.Value) == userType {
 			return true
 		}
 	}
 	return false
+}
+
+// grantTypeOf returns the entity type an ACL write-grant entry addresses:
+// the whole entry for a plain type grant, the part before "@" for a
+// state-shaped one. Mirrors the helper of the same name in internal/acl;
+// duplicated rather than imported because this package edits acl.yaml as
+// YAML NODES and must not depend on internal/acl (arch-lint), and because
+// the split is one strings.Cut.
+func grantTypeOf(entry string) string {
+	typeName, _, _ := strings.Cut(entry, "@")
+	return typeName
 }

--- a/internal/migration/acl_provisioner_grant_test.go
+++ b/internal/migration/acl_provisioner_grant_test.go
@@ -330,3 +330,40 @@ func TestACLProvisionerGrant_Registered(t *testing.T) {
 	}
 	t.Fatal("acl-provisioner-grant is not registered for FileTypeACL")
 }
+
+// TestACLProvisionerGrant_PreservesStateShapedGrant pins RR-H98VX0.
+//
+// The grant list is REPLACED wholesale when the migration decides the role
+// does not already grant create on the user type (SetMapNode swaps the
+// value node for a fresh one-element list). So a create grant written in
+// the state-shaped form `person@draft` (TKT-DN37J2) must be recognized as
+// already granting create on `person` — otherwise the migration silently
+// destroys it, AND any unrelated entries beside it.
+func TestACLProvisionerGrant_PreservesStateShapedGrant(t *testing.T) {
+	src := provisionLookup + "unmatched_principal: provision\n" +
+		"roles:\n  provisioner-system:\n    create: [person@draft, ticket]\n" +
+		"assignments:\n  system:provisioner: provisioner-system\n"
+
+	m := &migration.ACLProvisionerGrantMigration{}
+	var root yaml.Node
+	if err := yaml.Unmarshal([]byte(src), &root); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if m.Detect(&root) {
+		t.Fatal("a state-shaped create grant on the user type already grants " +
+			"create on that type; the migration must not fire")
+	}
+
+	var buf bytes.Buffer
+	enc := yaml.NewEncoder(&buf)
+	enc.SetIndent(2)
+	if err := enc.Encode(&root); err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	out := buf.String()
+	for _, want := range []string{"person@draft", "ticket"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("migration destroyed the grant %q; result:\n%s", want, out)
+		}
+	}
+}

--- a/internal/worldreader/guard_test.go
+++ b/internal/worldreader/guard_test.go
@@ -93,9 +93,18 @@ func TestGuardRule1_PackageCannotSeeAPrincipal(t *testing.T) {
 // state reader, a scope and a canonicalizer. Adding a gate parameter
 // would have to change this call, which is the point.
 func TestGuardRule1_ConstructorTakesNoGate(_ *testing.T) {
-	// Assigning the constructor to a variable of its expected signature
-	// makes a new parameter — a gate, a principal — a compile error.
-	var newResolver = worldreader.NewResolver
+	// The signature is SPELLED OUT deliberately. `var x = NewResolver`
+	// infers whatever the constructor's type currently is, so it pins
+	// nothing and a new gate parameter would compile clean — the pin was a
+	// no-op until TKT-DN37J2's design review caught it (RR-NFDPOA).
+	//nolint:staticcheck // ST1023 wants the type inferred from the RHS —
+	// which is exactly the bug this test had before RR-NFDPOA. Inferring
+	// makes the declaration accept ANY signature, so a new gate parameter
+	// would compile clean and the guard would pin nothing. The explicit
+	// type IS the assertion.
+	var newResolver func(
+		worldreader.StateReader, store.WorldScope, worldreader.TypeCanonicalizer,
+	) (*worldreader.Resolver, error) = worldreader.NewResolver
 	_ = newResolver
 }
 

--- a/internal/worlds/worlds.go
+++ b/internal/worlds/worlds.go
@@ -99,6 +99,7 @@ func Compile(m *metamodel.Metamodel) (Compiled, error) {
 	// states means. Today that scope is discarded, so the fail-open is only
 	// latent; returning here keeps it unreachable even if a future caller
 	// wants a best-effort compile.
+	errs = append(errs, validateWorldNames(m)...)
 	if err := joinErrors(errs); err != nil {
 		return Compiled{}, err
 	}
@@ -114,6 +115,53 @@ func Compile(m *metamodel.Metamodel) (Compiled, error) {
 		byName[name] = compileWorld(m, m.Worlds[name], pointers)
 	}
 	return Compiled{byName: byName}, nil
+}
+
+// validateWorldNames checks every declared world name against the same
+// grammar pointer names use.
+//
+// # Why an allowlist, and why here
+//
+// The loader already rejects the empty name and the reserved `default`
+// (metamodel.validateWorlds) via metamodel.ValidateSchemaName — but that
+// is a BLOCKLIST, deliberately lenient because entity-type and property
+// names legitimately carry dashes and internal spaces. It blocks only
+// quotes, backslashes and control characters, so `../admin`, `a b`,
+// `pub%2f` and `world?x=1` all load clean today.
+//
+// A world name is not a type name. It reaches a `?world=` query
+// parameter, a `--world` flag, and an `acl.yaml` grant token
+// (`read: [world:published]`) — three contexts where `/`, `%`, `?`, `&`,
+// `#` and spaces are hostile, and where `..` would be a traversal
+// primitive if a world name ever became a URL path segment. So worlds get
+// the strict allowlist pointers already have: lowercase alphanumeric runs
+// joined by single hyphens.
+//
+// The grammar is entity.ParsePointer's, reused rather than re-spelled —
+// a third copy of the pattern is a third thing to drift. Validating here
+// rather than in the loader follows the pointer-grammar precedent
+// (TKT-WAV8XP Q6): internal/metamodel may not import internal/entity
+// under arch-lint, and internal/worlds is the package that may see both.
+//
+// Tightening now costs nothing: worlds shipped in Step 2 and no shipped
+// or fixture metamodel declares a name outside this grammar. Waiting
+// makes it a breaking change forever.
+func validateWorldNames(m *metamodel.Metamodel) []error {
+	var errs []error
+	for _, name := range sortedWorldNames(m) {
+		if _, err := entity.ParsePointer(name); err != nil {
+			// The GRAMMAR is reused; the VOCABULARY is not. ParsePointer's
+			// own error says "pointer", a noun the operator did not write
+			// when declaring a world, so it is replaced rather than wrapped.
+			errs = append(errs, fmt.Errorf(
+				"world %q: invalid name — must be lowercase alphanumeric runs "+
+					"joined by single hyphens (e.g. \"published\", \"site-nl\"). "+
+					"World names reach URLs (?world=), CLI flags (--world) and "+
+					"acl.yaml grants (read: [world:...]), so they use the same "+
+					"strict grammar as pointer names", name))
+		}
+	}
+	return errs
 }
 
 // declaredPointers validates every declared pointer name against the


### PR DESCRIPTION
PR-A of the TKT-DN37J2 (ACL world/state grants, Step 3) stack. **Code-only**; paperwork on the companion PR.

Tickets-PR: #1422

Stack: Step 2's #1393 ← #1399 ← #1402 ← #1406 ← **this**. Retarget as ancestors merge.

## What lands

**Read grants name worlds** (`read: [world:published]`); bare-type and `*` grants continue to mean the **default world only**, so existing `acl.yaml` files keep their meaning. Reading a non-default world always requires naming it.

**Write grants name states** (`update: ["policy@draft"]`), codec-parsed at policy load, no inheritance, fail closed.

**The membership-gate load refusal** — the acceptance criterion owed from TKT-T31NKT. A policy that grants read on a non-default world while the membership relation is ungated is now **refused at load** with an error naming the fix, rather than booting with a warning.

## Two findings worth the reviewer's attention

**1. A `world:` token in `read:` is not inert — it is hazardous under the client ceiling.** `RoleDef.Read` feeds `roleFor` → `compiledCeiling.clamp` → `filterTypes`, which treats every entry as an entity-type name: a restricted client with `read: [page]` would silently DROP a world token, while one using `deny_read:` would silently KEEP it. World grants are therefore **split out of `Read` at load** into their own field, and the ceiling gains a matching `worlds:`/`deny_worlds:` axis so a restricted client narrows on the world axis properly. A ceiling must only ever NARROW; the cheap alternative ("restricted clients read the default world only") is fail-closed in form but fail-OPEN in outcome, because the default world is the draft face.

**2. CRITICAL, caught in code review before this PR opened (RR-LXJF8I): a state grant must not widen write authority.** The first cut compared `grantTypeOf(t) == target`, so `update: ["page@draft"]` returned true from `grantsVerb(role, OpUpdate, "page")` — the live write-authorization path, which knows the entity type but not yet which *face* is being written. The narrowest grant the new syntax offers would have authorized MORE than the operator wrote. **A grant must never widen by being made more specific.**

Fixed fail-closed in two parts: `grantsVerb` now SKIPS state-shaped entries entirely (a state grant authorizes nothing until the write path is face-aware — a denied write an operator asks about, rather than a silent over-permit nobody notices), and entity type names may no longer contain `@`, closing an ambiguity that both broke a legitimate `a@b` type and let a grant on `a@b` match a different type `a`. `grantForRole` (backing `rela acl who-can` / `acl map`) got the same skip so operator-facing reports agree with the runtime.

## The refusal predicate is deliberately WIDER than audit finding A2

`roleIsEscalationRelevant` = `IsPrivileged()` **plus a read grant on a non-default world**. A2 uses `IsPrivileged` alone. The extra term is load-bearing:

```yaml
member-of: { requires_permission: delegate-admin }  # gated: A1 says no
owns:      { confers: viewer }                      # ungated
viewer:    { read: [world:published] }              # IsPrivileged: FALSE
```

One `owns` write self-grants a published-world read. A refusal keyed on `IsPrivileged` alone would not fire, and would ship as a guarantee it does not deliver.

`IsPrivileged` is deliberately **not** widened — it is the severity criterion for A1, A2, A3 and the boot warning, so widening it would change the meaning of three existing findings and fire on policies doing nothing wrong.

The invariant is **directional, not sameness**: refusal ⊇ A2, so anything A2 flags is also refused. Pinned by `TestRefusalIsWiderThanOrEqualToA2`, with a comment at `checkUngatedRoleRelations` explaining why they differ — without it the next reader "fixes" the divergence.

## Also in this PR

- `Policy.Validate`'s write⊆read coverage check taught the state form (it previously rejected `update: ["policy@draft"]` with a misleading error, making the new syntax unusable on arrival).
- `world:` documented as a reserved grant prefix.
- Denial semantics, deliberately asymmetric and commented so they are not later "unified": an unknown world is a named 400/404 (a config name is not a secret, and naming it helps the operator), while a known world without a grant is an empty 200 (a 403 there is an existence oracle).

Gates: gofmt, `go build ./...`, arch-lint, and tests across `acl`, `aclaudit`, `worlds`, `worldreader`, `migration` and `appbuild` all green.