### PR TITLE
docs: file TKT-0RBFN0 for relation-level visible: redaction (IB-review #1 on #1400)

### DIFF
--- a/internal/appbuild/appbuild.go
+++ b/internal/appbuild/appbuild.go
@@ -462,7 +462,10 @@ func (s *Services) ScheduledLuaWriteDeps() lua.WriteDeps {
 // `visible:` grants (acl.RelationGrant.Visible, honored on the dataentry wire
 // via affordances.RelationFieldVerdicts) are not consulted. Relations are gated
 // at the ROW level on both endpoints; their properties are not. Do not read the
-// paragraph above as covering them.
+// paragraph above as covering them. Tracked as TKT-0RBFN0 (IB-review #1 on
+// PR #1400), which also covers ListRelations: that path IS row-gated, but
+// visibility.PolicyReader implements only FilterRelations, so a surviving edge
+// still carries all of its meta.
 func (s *Services) GatedReads() GatedReadBundle {
 	reader := scriptEntityReader(s.store, s.aclDeclarative, s.fieldRedactor)
 	tr := scriptTracer(s.tracer, s.store, s.aclDeclarative, s.fieldRedactor)
@@ -514,8 +517,11 @@ type GatedGraphReader interface {
 //   - GetRelation goes to the raw store because a relation is addressed by its
 //     two endpoint ids, which the caller must already hold. Reading one
 //     therefore confirms nothing about entities the caller could not already
-//     name. Relations carry no field-level redaction today (see
-//     docs/acl-security.md), so this matches what a live relation GET exposes.
+//     name. That argument is about ROW-level exposure (whether the edge
+//     exists) and does not extend to the edge's meta VALUES: relations carry
+//     no field-level redaction on this path today (see docs/acl-security.md
+//     and TKT-0RBFN0), so this matches what a live relation GET exposes only
+//     until that ticket lands.
 //
 // If either judgement changes, this is the one type to fix.
 type gatedGraphReader struct {

--- a/tickets/entities/tickets/TKT-0RBFN0.md
+++ b/tickets/entities/tickets/TKT-0RBFN0.md
@@ -1,0 +1,89 @@
+---
+id: TKT-0RBFN0
+type: ticket
+title: 'Apply relation-level visible: redaction to the gated read paths'
+kind: enhancement
+priority: medium
+effort: s
+status: backlog
+---
+
+Relation-level `visible:` grants are honored on the dataentry wire but not on
+the appbuild-wired identity-bearing read paths (MCP, scheduler, automation
+cascade). Filed from IB-review finding #1 on PR #1400.
+
+Follow-up to [[TKT-BUYEW1]], which closed the same gap for **entity**
+properties. This is the relation-side remainder, and was named as an explicit
+carve-out in that PR's `Services.GatedReads` godoc rather than silently left.
+
+## Problem
+
+`acl.RelationGrant.Visible` compiles into the policy and
+`affordances.PolicyResolver.RelationFieldVerdicts` resolves it — but only
+`internal/dataentry` calls it (`affordances.go:987`). On the gated read paths
+relation meta is served unredacted.
+
+The gap is **wider than the review states**. It is not only `GetRelation`:
+
+| Site | Path | Row-gated? | Field-redacted? |
+|---|---|---|---|
+| `gatedGraphReader.GetRelation` | `g.raw` (store) | no | no |
+| `gatedGraphReader.ListRelations` | `g.rows` | yes | **no** |
+
+`ListRelations` goes through the gated reader, so a hidden edge is not listed —
+but `visibility.PolicyReader` implements only `FilterRelations` (row-level, both
+endpoints). There is no relation *field* redaction anywhere in
+`internal/visibility`, so a surviving edge carries all of its meta.
+
+Both sites feed the same three consumers, and all three send data onward (a
+prompt, a webhook, an automation write), so an unredacted relation property can
+leave the system entirely — the same argument that made [[TKT-BUYEW1]] worth
+doing.
+
+## Note on the existing godoc rationale
+
+`gatedGraphReader`'s comment defends the raw `GetRelation` on the grounds that
+a relation is addressed by its two endpoint ids, so reading one confirms
+nothing the caller could not already name. That argument is sound, but it is
+about **row**-level exposure (does this edge exist). It does not defend serving
+the edge's **meta values** unredacted. Fixing this ticket means correcting that
+comment's scope, not overturning its conclusion — `GetRelation` may well stay
+raw at the row level.
+
+## Design constraint (found while triaging)
+
+`RelationFieldVerdicts(ctx, from *entity.Entity, relType, metaKeys)` needs the
+**live FROM entity**, not just its id: role grants are keyed by the FROM
+entity's type and the `when:` predicates bind against it. The entity path had
+its subject in hand; here a redactor must resolve `from` first.
+
+That is the real cost, and it is what makes this ticket `s`-or-larger rather
+than a one-line rewire:
+
+- a per-relation FROM lookup on a list path is an N+1 read — needs batching or
+  a per-call cache, since `ListRelations` is an `iter.Seq2`
+- resolution must use a **raw** read, not the gated reader: the FROM entity may
+  itself be row-hidden while the relation is legitimately visible via the TO
+  side, and a nil `from` makes `RelationFieldVerdicts` return nil = redact
+  nothing, which is **fail-open**
+
+Fail-open on a nil FROM is the trap to design against explicitly.
+
+## Acceptance criteria
+
+- [ ] Relation meta is redacted per `visible:` on `GetRelation` and
+      `ListRelations` for all three gated consumers
+- [ ] A nil / unresolvable FROM entity fails **closed**, not open
+- [ ] Mutation-verified test: a relation-level `visible:` grant that hides a
+      meta field must make the test fail when the redaction is reverted
+- [ ] List-path test covers the `iter.Seq2` case, not only the single GET
+- [ ] The `gatedGraphReader` godoc scope note and `GatedReads`' SCOPE paragraph
+      are updated (both currently state this is unenforced)
+- [ ] `docs/acl-security.md` "Relations have no field-level redaction" is
+      corrected
+
+## Out of scope
+
+Relation **history** meta redaction. `RelationFieldVerdicts`' godoc records
+that a deleted-source relation history serves no meta at all, so it never
+reaches that resolver — a separate path with its own fail-closed reasoning.

--- a/tickets/relations/TKT-0RBFN0--affects--authorization.md
+++ b/tickets/relations/TKT-0RBFN0--affects--authorization.md
@@ -1,0 +1,5 @@
+---
+from: TKT-0RBFN0
+relation: affects
+to: authorization
+---

--- a/tickets/relations/TKT-0RBFN0--depends-on--TKT-BUYEW1.md
+++ b/tickets/relations/TKT-0RBFN0--depends-on--TKT-BUYEW1.md
@@ -1,0 +1,5 @@
+---
+from: TKT-0RBFN0
+relation: depends-on
+to: TKT-BUYEW1
+---

--- a/tickets/relations/TKT-0RBFN0--implements--FEAT-AESD4.md
+++ b/tickets/relations/TKT-0RBFN0--implements--FEAT-AESD4.md
@@ -1,0 +1,5 @@
+---
+from: TKT-0RBFN0
+relation: implements
+to: FEAT-AESD4
+---


### PR DESCRIPTION
Files TKT-0RBFN0 for IB-review finding #1 on #1400, and corrects two godoc scope notes that currently describe the gap as untracked.

No behaviour change — comments and ticket paperwork only.

## Context

#1400 closed the field-level read-side ACL gap for **entity** properties on the three appbuild-wired identity-bearing read paths (MCP, scheduler, automation cascade). The reviewer flagged the relation-side remainder as still open with no ticket. This files it.

## Two corrections to the review's framing

Both are in the ticket:

**It is also `ListRelations`, not only `GetRelation`.** `ListRelations` does go through the gated reader, but `visibility.PolicyReader` implements only `FilterRelations` — row-level, both endpoints. There is no relation *field* redaction anywhere in `internal/visibility`, so an edge surviving the row gate carries all of its meta. Both sites feed the same three consumers.

**The existing `gatedGraphReader` rationale defends the wrong scope.** It justifies the raw `GetRelation` on the grounds that a relation is addressed by two endpoint ids the caller must already hold. That argument is sound, but it concerns **row**-level exposure (does this edge exist) and does not extend to serving the edge's **meta values** unredacted. This PR corrects the comment's scope rather than its conclusion — `GetRelation` may well stay raw at the row level.

## Design constraint found while triaging

`RelationFieldVerdicts(ctx, from *entity.Entity, relType, metaKeys)` needs the **live FROM entity**, not just its id: role grants are keyed by the FROM entity type and the `when:` predicates bind against it. The entity path had its subject in hand; here a redactor must resolve `from` first. Recorded as acceptance criteria:

- a per-relation FROM lookup on a list path is an N+1 read (`ListRelations` is an `iter.Seq2`, so batching or a per-call cache)
- resolution must use a **raw** read: the FROM entity may itself be row-hidden while the relation is legitimately visible via the TO side — and a nil `from` makes `RelationFieldVerdicts` return nil, i.e. redact nothing, which is **fail-open**. That is the trap to design against explicitly.

Relation *history* meta is out of scope (separate fail-closed reasoning, noted in the ticket).

## Checks

`just lint` · `just arch-lint` · `go test ./internal/appbuild/` · `rela validate --project tickets` — all green.

The ticket is `backlog`, so the done-before-PR gate does not apply; this PR files work rather than completing it.
