### PR TITLE
🌍 feat(aclaudit): cross-file checks for world and content-state grants (TKT-DN37J2 PR-B)

### DIFF
--- a/docs-project/entities/guides/GUIDE-acl-security.md
+++ b/docs-project/entities/guides/GUIDE-acl-security.md
@@ -144,6 +144,11 @@ The audit reports severity-ranked findings across two tiers:
 - **Metamodel cross-check** — grants, `membership_relation`,
   `role_relations`, `inherit_roles_through`, `user_entity_type`, field,
   and option references that the schema doesn't declare (silent drift).
+  This includes the content-state grant forms: a `read: [world:X]` grant
+  naming a world no `worlds:` block declares, and a `type@pointer` write
+  grant naming a content state the type doesn't declare. Both fail
+  *closed* at runtime — the grant simply matches nothing — so without
+  the audit the only symptom is a denial nobody can explain.
 
 ```console
 $ rela acl audit

--- a/docs/acl-security.md
+++ b/docs/acl-security.md
@@ -138,6 +138,11 @@ The audit reports severity-ranked findings across two tiers:
 - **Metamodel cross-check** — grants, `membership_relation`,
   `role_relations`, `inherit_roles_through`, `user_entity_type`, field,
   and option references that the schema doesn't declare (silent drift).
+  This includes the content-state grant forms: a `read: [world:X]` grant
+  naming a world no `worlds:` block declares, and a `type@pointer` write
+  grant naming a content state the type doesn't declare. Both fail
+  *closed* at runtime — the grant simply matches nothing — so without
+  the audit the only symptom is a denial nobody can explain.
 
 ```console
 $ rela acl audit

--- a/internal/aclaudit/aclaudit.go
+++ b/internal/aclaudit/aclaudit.go
@@ -133,6 +133,13 @@ type MetamodelReader interface {
 	// EnumOptions returns the allowed values for an enum field on type t, and
 	// false if the field is absent or not an enum.
 	EnumOptions(t, field string) ([]string, bool)
+	// HasWorld reports whether name is a DECLARED world. The implicit
+	// default world is not declared and reports false; callers that accept
+	// it must say so themselves (see checkUndeclaredWorlds).
+	HasWorld(name string) bool
+	// HasPointer reports whether entity type t declares the content state
+	// named pointer.
+	HasPointer(t, pointer string) bool
 }
 
 // PermissionConsumer reports permissions referenced OUTSIDE acl.yaml. The
@@ -169,6 +176,14 @@ type PermissionConsumer interface {
 // asserting config is dead on incomplete information. This deliberately
 // differs from meta's nil handling, where a missing metamodel can only make a
 // check unformable, never wrong.
+// PRECONDITION: p must have passed [acl.Policy.Validate] (which
+// [acl.LoadPolicy] runs). World grants are read from RoleDef.Worlds, which
+// only the validating load populates by splitting `read: [world:X]` out of
+// Read — so on an unvalidated policy B10 would examine nothing and B1 would
+// instead report the world token as an undeclared ENTITY TYPE, which is
+// misleading advice at High severity. checkUndeclaredWorlds re-scans Read
+// for a residual world prefix so that mistake is diagnosed correctly rather
+// than merely undetected, but callers should validate first regardless.
 func Audit(p *acl.Policy, meta MetamodelReader, perms PermissionConsumer) []Finding {
 	if p == nil {
 		return nil
@@ -238,8 +253,22 @@ func permissionGranted(p *acl.Policy, perm string) bool {
 // keeps its own narrow view of the policy — but the two must agree, which
 // is what TestGrantEntityType_MatchesACLSplit pins.
 func grantEntityType(entry string) string {
-	typeName, _, _ := strings.Cut(entry, "@")
+	typeName, _, _ := splitStateGrant(entry)
 	return typeName
+}
+
+// splitStateGrant splits a `type@pointer` write grant into its parts,
+// reporting isState=false for a plain type grant.
+//
+// Mirrors internal/acl's parseStateGrant, minus the grammar validation —
+// acl rejects a malformed pointer at policy load, so by the time the audit
+// runs the only question left is whether the metamodel declares it.
+func splitStateGrant(entry string) (typeName, pointer string, isState bool) {
+	typeName, pointer, isState = strings.Cut(entry, "@")
+	if !isState {
+		return entry, "", false
+	}
+	return typeName, pointer, true
 }
 
 // verbLists returns the four grant lists of a role for iteration.

--- a/internal/aclaudit/aclaudit_test.go
+++ b/internal/aclaudit/aclaudit_test.go
@@ -14,9 +14,17 @@ type fakeMetamodel struct {
 	types     map[string]bool
 	relations map[string][]string            // rel -> from types
 	fields    map[string]map[string][]string // type -> field -> enum options (nil = non-enum/declared field)
+	worlds    map[string]bool                // declared world names
+	pointers  map[string][]string            // type -> declared content states
 }
 
 func (m fakeMetamodel) HasEntityType(t string) bool { return m.types[t] }
+
+func (m fakeMetamodel) HasWorld(name string) bool { return m.worlds[name] }
+
+func (m fakeMetamodel) HasPointer(t, pointer string) bool {
+	return slices.Contains(m.pointers[t], pointer)
+}
 
 func (m fakeMetamodel) GetRelation(name string) (RelationView, bool) {
 	from, ok := m.relations[name]
@@ -728,4 +736,208 @@ func mergeRoles(a, b map[string]acl.RoleDef) map[string]acl.RoleDef {
 	maps.Copy(out, a)
 	maps.Copy(out, b)
 	return out
+}
+
+// findingRules returns the rule ids present in findings, for assertions
+// that care about which checks fired rather than their prose.
+func findingRules(findings []Finding) []string {
+	out := make([]string, 0, len(findings))
+	for _, f := range findings {
+		out = append(out, f.Rule)
+	}
+	slices.Sort(out)
+	return out
+}
+
+// TestB10_UndeclaredWorld covers the cross-file half of the world grant
+// syntax: internal/acl validates the SPELLING at load but cannot see the
+// schema, so "does this world exist" lands here.
+func TestB10_UndeclaredWorld(t *testing.T) {
+	meta := fakeMetamodel{
+		types:  map[string]bool{"page": true},
+		worlds: map[string]bool{"published": true},
+	}
+	tests := []struct {
+		name    string
+		read    []string
+		wantB10 bool
+	}{
+		{"declared world is fine", []string{"world:published"}, false},
+		{"undeclared world is flagged", []string{"world:pubished"}, true},
+		{
+			name: "the implicit default world needs no declaration",
+			read: []string{"world:default"}, wantB10: false,
+		},
+		{"a bare type grant is not a world grant", []string{"page"}, false},
+		{
+			name: "one good and one bad world: only the bad one fires",
+			read: []string{"world:published", "world:nope"}, wantB10: true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			p := &acl.Policy{Roles: map[string]acl.RoleDef{"r": {Read: tc.read}}}
+			if err := p.Validate(); err != nil {
+				t.Fatalf("Validate: %v", err)
+			}
+			got := slices.Contains(findingRules(Audit(p, meta, nil)), "B10-undeclared-world")
+			if got != tc.wantB10 {
+				t.Errorf("B10 fired = %v, want %v (read: %v)", got, tc.wantB10, tc.read)
+			}
+		})
+	}
+}
+
+// TestB11_UndeclaredPointer covers the write-grant equivalent.
+func TestB11_UndeclaredPointer(t *testing.T) {
+	meta := fakeMetamodel{
+		types:    map[string]bool{"page": true, "ticket": true},
+		pointers: map[string][]string{"page": {"draft", "published"}},
+	}
+	tests := []struct {
+		name    string
+		update  []string
+		wantB11 bool
+	}{
+		{"declared pointer is fine", []string{"page@draft"}, false},
+		{"undeclared pointer is flagged", []string{"page@nosuchstate"}, true},
+		{"a bare type grant carries no pointer", []string{"page"}, false},
+		{
+			name:   "a type declaring NO pointers cannot carry one",
+			update: []string{"ticket@draft"}, wantB11: true,
+		},
+		{
+			name: "an undeclared TYPE is B1's business, not B11's — one " +
+				"mistake must not produce two findings with different fixes",
+			update: []string{"nosuchtype@draft"}, wantB11: false,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			p := &acl.Policy{Roles: map[string]acl.RoleDef{
+				"r": {Update: tc.update, Read: []string{"*"}},
+			}}
+			if err := p.Validate(); err != nil {
+				t.Fatalf("Validate: %v", err)
+			}
+			got := slices.Contains(findingRules(Audit(p, meta, nil)), "B11-undeclared-pointer")
+			if got != tc.wantB11 {
+				t.Errorf("B11 fired = %v, want %v (update: %v)", got, tc.wantB11, tc.update)
+			}
+		})
+	}
+}
+
+// TestB1_DoesNotFlagWellFormedGrantSyntax is the regression guard for the
+// reason these checks had to land alongside PR-A's syntax: B1 is High, and
+// `rela acl audit --exit-code` gates CI on High. If B1 reported a correct
+// world or state grant as an undeclared entity type, every policy adopting
+// the new syntax would fail CI.
+func TestB1_DoesNotFlagWellFormedGrantSyntax(t *testing.T) {
+	meta := fakeMetamodel{
+		types:    map[string]bool{"page": true},
+		worlds:   map[string]bool{"published": true},
+		pointers: map[string][]string{"page": {"draft"}},
+	}
+	p := &acl.Policy{Roles: map[string]acl.RoleDef{
+		"author": {
+			Read:   []string{"page", "world:published"},
+			Update: []string{"page@draft"},
+		},
+	}}
+	if err := p.Validate(); err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+	if got := findingRules(Audit(p, meta, nil)); len(got) != 0 {
+		t.Errorf("a fully well-formed policy must produce no findings; got %v", got)
+	}
+}
+
+// TestB11_TypeWildcardWithState pins the grant that used to be reported by
+// NOTHING: `*@draft` grants nothing at runtime (acl.GrantsVerbOnState
+// honors "*" only for the default state), loads clean, and was skipped by
+// both B1 (wildcard) and B11 (not a declared type).
+func TestB11_TypeWildcardWithState(t *testing.T) {
+	meta := fakeMetamodel{
+		types:    map[string]bool{"page": true},
+		pointers: map[string][]string{"page": {"draft"}},
+	}
+	p := &acl.Policy{Roles: map[string]acl.RoleDef{
+		"r": {Update: []string{"*@draft"}, Read: []string{"*"}},
+	}}
+	if err := p.Validate(); err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+	if !slices.Contains(findingRules(Audit(p, meta, nil)), "B11-undeclared-pointer") {
+		t.Error("`*@draft` grants nothing at runtime and must be reported — " +
+			"the wildcard ranges over TYPES and only ever grants the default state")
+	}
+	// A bare wildcard is still the ordinary, correct grant.
+	q := &acl.Policy{Roles: map[string]acl.RoleDef{
+		"r": {Update: []string{"*"}, Read: []string{"*"}},
+	}}
+	if err := q.Validate(); err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+	// A9-wildcard-write still fires — that is its own, pre-existing
+	// judgement about wildcard sprawl. What must NOT fire is B11: a bare
+	// wildcard addresses the default state, which is a real grant.
+	if got := findingRules(Audit(q, meta, nil)); slices.Contains(got, "B11-undeclared-pointer") {
+		t.Errorf("a bare `*` write grant addresses the default state and must "+
+			"not be flagged as an undeclared pointer; got %v", got)
+	}
+}
+
+// TestB10_DefaultWorldCaseVariant pins that a mis-cased default world gets
+// a fix the operator can actually follow. The ordinary B10 remedy — declare
+// it — is one the schema loader REFUSES, since it rejects any world whose
+// name case-folds to "default" as reserved.
+func TestB10_DefaultWorldCaseVariant(t *testing.T) {
+	meta := fakeMetamodel{types: map[string]bool{"page": true}}
+	p := &acl.Policy{Roles: map[string]acl.RoleDef{
+		"r": {Read: []string{"page", "world:Default"}},
+	}}
+	if err := p.Validate(); err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+	var found bool
+	for _, f := range Audit(p, meta, nil) {
+		if f.Rule != "B10-undeclared-world" {
+			continue
+		}
+		found = true
+		if strings.Contains(f.Fix, `declare world "Default"`) {
+			t.Errorf("the fix tells the operator to declare a world the loader "+
+				"rejects as reserved; got: %s", f.Fix)
+		}
+		if !strings.Contains(f.Fix, "lowercase") {
+			t.Errorf("the fix must point at the lowercase spelling; got: %s", f.Fix)
+		}
+	}
+	if !found {
+		t.Error("a mis-cased default world is dead at runtime and must be reported")
+	}
+}
+
+// TestB10_DiagnosesUnvalidatedPolicy pins the fallback: on a policy that
+// skipped Validate, world tokens are still inline in Read. B10 scans for
+// them so the operator gets the right diagnosis, and B1 skips them so they
+// are not ALSO reported as undeclared entity types — advice that would send
+// someone to declare `world:published` under `entities:`.
+func TestB10_DiagnosesUnvalidatedPolicy(t *testing.T) {
+	meta := fakeMetamodel{
+		types:  map[string]bool{"page": true},
+		worlds: map[string]bool{"published": true},
+	}
+	p := &acl.Policy{Roles: map[string]acl.RoleDef{
+		"r": {Read: []string{"page", "world:typoworld"}},
+	}}
+	// Deliberately NOT validated.
+	got := findingRules(Audit(p, meta, nil))
+	if !slices.Contains(got, "B10-undeclared-world") {
+		t.Errorf("B10 must diagnose an inline world token; got %v", got)
+	}
+	if slices.Contains(got, "B1-undeclared-type") {
+		t.Errorf("B1 must not report a world token as an undeclared entity type; got %v", got)
+	}
 }

--- a/internal/aclaudit/ceiling.go
+++ b/internal/aclaudit/ceiling.go
@@ -212,11 +212,53 @@ func checkCeilingsAgainstMetamodel(p *acl.Policy, m MetamodelReader) []Finding {
 		b := p.ClientBaselines[name]
 		f = append(f, ceilingTypeFindings(
 			"client baseline", name, b.Restriction, m)...)
+		f = append(f, ceilingWorldFindings(
+			"client baseline", name, b.Restriction, m)...)
 	}
 	for _, scope := range sortedScopeGrantNames(p) {
 		g := p.ScopeGrants[scope]
 		f = append(f, ceilingTypeFindings(
 			"scope grant", scope, g.Restriction, m)...)
+		f = append(f, ceilingWorldFindings(
+			"scope grant", scope, g.Restriction, m)...)
+	}
+	return f
+}
+
+// ceilingWorldFindings reports a client-attenuation block naming a world the
+// metamodel does not declare (B10, sharing the rule id with the role-grant
+// check — same mistake, same fix, and an operator should not have to learn
+// two rule names for "that world does not exist").
+//
+// A ceiling entry naming a nonexistent world is inert in the direction that
+// matters: an allowlist naming only unknown worlds permits nothing, and a
+// denylist denies nothing. Neither leaks, but both read as protection.
+func ceilingWorldFindings(
+	kind, name string, r acl.Restriction, m MetamodelReader,
+) []Finding {
+	var f []Finding
+	seen := map[string]bool{}
+	for _, c := range []struct {
+		axis   string
+		worlds []string
+	}{{"worlds", r.Worlds}, {"deny_worlds", r.DenyWorlds}} {
+		for _, world := range c.worlds {
+			if world == acl.DefaultWorldName || m.HasWorld(world) || seen[world] {
+				continue
+			}
+			seen[world] = true
+			if cv, isCaseVariant := defaultWorldCaseVariant(name, world); isCaseVariant {
+				f = append(f, cv)
+				continue
+			}
+			f = append(f, Finding{
+				Rule: "B10-undeclared-world", Severity: High, Subject: name,
+				Detail: fmt.Sprintf("%s %q names world %q (under %s) which the metamodel does "+
+					"not declare; the restriction matches nothing", kind, name, world, c.axis),
+				Fix: fmt.Sprintf("declare world %q under `worlds:` in schema.yaml, or fix the "+
+					"%s entry (check for a typo)", world, c.axis),
+			})
+		}
 	}
 	return f
 }
@@ -238,11 +280,7 @@ func ceilingTypeFindings(
 		// worlds/deny_worlds are deliberately ABSENT: their entries are
 		// world names, not entity types, so HasEntityType is the wrong
 		// question and would report every one of them as undeclared.
-		//
-		// A ceiling naming a world the metamodel does not declare is
-		// therefore checked by NOTHING today. That needs a world-aware
-		// MetamodelReader, which lands with the rest of the world
-		// cross-checks in TKT-DN37J2 PR-B; it is not implemented here.
+		// Checked separately by ceilingWorldFindings (B10).
 	} {
 		for _, entry := range c.types {
 			// TYPE half only — a ceiling axis may name a state-shaped

--- a/internal/aclaudit/ceiling_test.go
+++ b/internal/aclaudit/ceiling_test.go
@@ -279,3 +279,48 @@ assignments:
 		}
 	}
 }
+
+// TestB10_CeilingUndeclaredWorld covers the client-attenuation half of the
+// world existence check. Shares the B10 rule id with the role-grant check
+// deliberately: same mistake, same fix.
+func TestB10_CeilingUndeclaredWorld(t *testing.T) {
+	meta := fakeMetamodel{
+		types:  map[string]bool{"page": true},
+		worlds: map[string]bool{"published": true},
+	}
+	tests := []struct {
+		name    string
+		r       acl.Restriction
+		wantB10 bool
+	}{
+		{"declared world", acl.Restriction{Worlds: []string{"published"}}, false},
+		{"undeclared world in allowlist", acl.Restriction{Worlds: []string{"nope"}}, true},
+		{"undeclared world in denylist", acl.Restriction{DenyWorlds: []string{"nope"}}, true},
+		{
+			name: "the implicit default world needs no declaration",
+			r:    acl.Restriction{DenyWorlds: []string{"default"}}, wantB10: false,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			p := &acl.Policy{
+				Roles: map[string]acl.RoleDef{"r": {Read: []string{"page"}}},
+				ClientBaselines: map[string]acl.ClientBaseline{
+					"app": {AppliesTo: []string{"app"}, Restriction: tc.r},
+				},
+			}
+			if err := p.Validate(); err != nil {
+				t.Fatalf("Validate: %v", err)
+			}
+			var got bool
+			for _, f := range Audit(p, meta, nil) {
+				if f.Rule == "B10-undeclared-world" {
+					got = true
+				}
+			}
+			if got != tc.wantB10 {
+				t.Errorf("B10 fired = %v, want %v", got, tc.wantB10)
+			}
+		})
+	}
+}

--- a/internal/aclaudit/tier_b.go
+++ b/internal/aclaudit/tier_b.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"slices"
 	"sort"
+	"strings"
 
 	"github.com/Sourcehaven-BV/rela/internal/acl"
 )
@@ -20,6 +21,154 @@ func tierB(p *acl.Policy, m MetamodelReader) []Finding {
 	f = append(f, checkUndeclaredOptions(p, m)...)        // B5
 	f = append(f, checkUserEntityTypeDeclared(p, m)...)   // B7
 	f = append(f, checkCeilingsAgainstMetamodel(p, m)...) // B8 / B9
+	f = append(f, checkUndeclaredWorlds(p, m)...)         // B10
+	f = append(f, checkUndeclaredPointers(p, m)...)       // B11
+	return f
+}
+
+// B10 — a `read: [world:X]` grant names a world the metamodel does not
+// declare, so it grants access to nothing.
+//
+// This is the cross-file half of the world grant syntax. internal/acl
+// validates the SPELLING at load (non-empty, no glob) but structurally
+// cannot check EXISTENCE — arch-lint forbids it a metamodel dependency, so
+// a world name is just a string there. The runtime is already fail-closed
+// on an unknown world (worlds.Compiled.Lookup returns ok=false), which
+// means the failure mode is a silent denial rather than a leak: exactly the
+// shape an operator needs a linter to explain.
+//
+// The implicit DEFAULT world is accepted without being declared — it is
+// total, always exists, and `read: [world:default]` is a legal way to spell
+// what a bare read grant already means.
+func checkUndeclaredWorlds(p *acl.Policy, m MetamodelReader) []Finding {
+	var f []Finding
+	for _, name := range sortedRoleNames(p) {
+		role := p.Roles[name]
+		seen := map[string]bool{}
+		// Worlds is populated only by the validating load. A caller that
+		// skipped Validate still has its world tokens inline in Read, where
+		// B1 would report them as undeclared ENTITY TYPES — misleading
+		// advice at High severity. Scanning both means the diagnosis is
+		// right either way. Audit's godoc still states the precondition.
+		worlds := role.Worlds
+		for _, entry := range role.Read {
+			if w, found := strings.CutPrefix(entry, acl.WorldGrantPrefix); found {
+				worlds = append(worlds, strings.TrimSpace(w))
+			}
+		}
+		for _, world := range worlds {
+			if world == acl.DefaultWorldName || m.HasWorld(world) || seen[world] {
+				continue
+			}
+			seen[world] = true
+			if f2, isCaseVariant := defaultWorldCaseVariant(name, world); isCaseVariant {
+				f = append(f, f2)
+				continue
+			}
+			f = append(f, Finding{
+				Rule: "B10-undeclared-world", Severity: High, Subject: name,
+				Detail: fmt.Sprintf("role %q grants read on world %q which the metamodel does not "+
+					"declare; the grant matches nothing and every read in that world is denied",
+					name, world),
+				Fix: fmt.Sprintf("declare world %q under `worlds:` in schema.yaml, or fix the "+
+					"`read: [world:%s]` grant (check for a typo)", world, world),
+			})
+		}
+	}
+	return f
+}
+
+// defaultWorldCaseVariant reports a world grant that spells the default
+// world with the wrong casing, and returns the finding that explains it.
+//
+// This case needs its own message because the ordinary B10 remedy is
+// IMPOSSIBLE to follow: the metamodel loader rejects any world whose name
+// case-folds to "default" as reserved, so telling the operator to declare
+// `Default` sends them to a schema that will refuse to load. The grant is
+// genuinely dead — roleGrantsWorldRead compares case-sensitively — so
+// flagging it is right; only the fix differs.
+func defaultWorldCaseVariant(role, world string) (Finding, bool) {
+	if world == acl.DefaultWorldName || !strings.EqualFold(world, acl.DefaultWorldName) {
+		return Finding{}, false
+	}
+	return Finding{
+		Rule: "B10-undeclared-world", Severity: High, Subject: role,
+		Detail: fmt.Sprintf("role %q grants read on world %q; the default world is spelled %q "+
+			"in lowercase and cannot be redeclared under any other casing (the schema "+
+			"loader rejects the name as reserved), so this grant matches nothing",
+			role, world, acl.DefaultWorldName),
+		Fix: fmt.Sprintf("write `read: [world:%s]` in lowercase, or drop the grant entirely "+
+			"— an ordinary read grant already covers the default world",
+			acl.DefaultWorldName),
+	}, true
+}
+
+// B11 — a `type@pointer` write grant names a content state the type does
+// not declare, so it grants write access to nothing.
+//
+// Same division of labor as B10: internal/acl parses the pointer NAME
+// against the codec grammar at load, but only the metamodel knows which
+// pointers a type actually declares. A grant on an undeclared state is
+// fail-closed at runtime (no state row will ever match it), so again the
+// symptom is a denial nobody can explain without this finding.
+//
+// Skips a type the metamodel does not declare at all — B1 reports that, and
+// reporting both would give one mistake two findings with different fixes.
+func checkUndeclaredPointers(p *acl.Policy, m MetamodelReader) []Finding {
+	var f []Finding
+	for _, name := range sortedRoleNames(p) {
+		role := p.Roles[name]
+		seen := map[string]bool{}
+		for _, verb := range []string{"create", "update", "delete"} {
+			for _, entry := range verbLists(role)[verb] {
+				typeName, pointer, isState := splitStateGrant(entry)
+				if !isState || seen[entry] {
+					continue
+				}
+				// The type WILDCARD cannot carry a state. `*` ranges over
+				// types and grants each one's DEFAULT state
+				// (acl.GrantsVerbOnState honors it only for the zero
+				// pointer), so `*@draft` matches an entity whose type is
+				// literally named "*" and nothing else. It grants nothing,
+				// loads clean, and would otherwise be reported by NOTHING:
+				// B1 skips "*" as a wildcard and the HasEntityType gate
+				// below skips it as undeclared.
+				if typeName == "*" {
+					seen[entry] = true
+					f = append(f, Finding{
+						Rule: "B11-undeclared-pointer", Severity: High, Subject: name,
+						Detail: fmt.Sprintf("role %q grants %s on %q, but %q ranges over entity "+
+							"TYPES and only ever grants each type's default state; it never "+
+							"addresses a named content state, so this grant matches nothing",
+							name, verb, entry, "*"),
+						Fix: fmt.Sprintf("name each type explicitly (e.g. `page@%s`), or drop "+
+							"the `@%s` to grant the default state of every type",
+							pointer, pointer),
+					})
+					continue
+				}
+				if !m.HasEntityType(typeName) {
+					continue
+				}
+				if m.HasPointer(typeName, pointer) {
+					continue
+				}
+				seen[entry] = true
+				f = append(f, Finding{
+					Rule: "B11-undeclared-pointer", Severity: High, Subject: name,
+					Detail: fmt.Sprintf("role %q grants %s on %q but entity type %q declares no "+
+						"content state %q; the grant matches nothing",
+						name, verb, entry, typeName, pointer),
+					Fix: fmt.Sprintf("fix the %s grant (check for a typo), or declare %q under "+
+						"the `pointers:` block of entity type %q in schema.yaml — note that "+
+						"adding a `pointers:` block to a type that has none makes every entity "+
+						"of that type subject to world resolution, so a plain `%s: [%s]` grant "+
+						"is the likelier fix",
+						verb, pointer, typeName, verb, typeName),
+				})
+			}
+		}
+	}
 	return f
 }
 
@@ -32,6 +181,14 @@ func checkUndeclaredEntityTypes(p *acl.Policy, m MetamodelReader) []Finding {
 		role := p.Roles[name]
 		seen := map[string]bool{}
 		flag := func(verb, entry string) {
+			// A world token is never an entity type. It should already have
+			// been split out of Read by the validating load; if the caller
+			// skipped Validate it is still here, and reporting it as an
+			// undeclared TYPE would send the operator to declare
+			// `world:published` in `entities:`. B10 diagnoses it properly.
+			if strings.HasPrefix(entry, acl.WorldGrantPrefix) {
+				return
+			}
 			// Check the TYPE half. A write grant may be state-shaped
 			// (`page@draft`, TKT-DN37J2); the type is what the metamodel
 			// declares, and reporting the joined string as an undeclared

--- a/internal/cli/acl.go
+++ b/internal/cli/acl.go
@@ -167,6 +167,42 @@ func (r *metamodelReader) GetRelation(name string) (aclaudit.RelationView, bool)
 	return aclaudit.RelationView{From: def.From}, true
 }
 
+// HasWorld reports whether the metamodel declares a world by this name.
+//
+// The implicit DEFAULT world is NOT declared and therefore reports false —
+// the audit special-cases that name itself, which keeps "did the operator
+// write this world in schema.yaml" a different question from "is this world
+// usable". Case-sensitive, like every other name lookup; the loader rejects
+// a declared world named "default" case-INSENSITIVELY, so no declared world
+// can shadow the implicit one under any spelling.
+//
+// Reads the exported map rather than going through a Metamodel method: this
+// adapter is the only consumer, and *Metamodel is already at its plimsoll
+// exported-method cap.
+func (r *metamodelReader) HasWorld(name string) bool {
+	if r.m == nil {
+		return false
+	}
+	_, ok := r.m.Worlds[name]
+	return ok
+}
+
+// HasPointer reports whether entity type t declares the content state named
+// pointer. Resolves aliases via GetEntityDef, so a grant written against a
+// type alias answers about the canonical type. A type with no `pointers:`
+// block declares none, including the empty one.
+func (r *metamodelReader) HasPointer(t, pointer string) bool {
+	if r.m == nil {
+		return false
+	}
+	def, ok := r.m.GetEntityDef(t)
+	if !ok {
+		return false
+	}
+	_, declared := def.Pointers[pointer]
+	return declared
+}
+
 func (r *metamodelReader) HasField(t, field string) bool {
 	if r.m == nil {
 		return false

--- a/internal/cli/worldpointer_test.go
+++ b/internal/cli/worldpointer_test.go
@@ -1,0 +1,105 @@
+package cli
+
+import (
+	"testing"
+
+	"github.com/Sourcehaven-BV/rela/internal/metamodel"
+)
+
+// TestHasWorld covers the metamodelReader adapter's world lookup — the declaration lookup the ACL audit's B10 check
+// consumes. The implicit default world is NOT declared and must report
+// false — callers that accept it special-case the name themselves, which
+// is what keeps "is this world declared" a different question from "is
+// this world usable".
+func TestHasWorld(t *testing.T) {
+	t.Parallel()
+	m := &metamodel.Metamodel{Worlds: map[string]metamodel.WorldDef{
+		"published": {Select: []string{"published"}, Otherwise: metamodel.OtherwiseExclude},
+	}}
+	tests := []struct {
+		name  string
+		world string
+		want  bool
+	}{
+		{"declared world", "published", true},
+		{"undeclared world", "editorial", false},
+		{"the implicit default world is not DECLARED", "default", false},
+		{
+			// The loader rejects a declared world whose name case-folds to
+			// "default", so no declared world can shadow the implicit one
+			// under any spelling — but this lookup is case-SENSITIVE, so a
+			// case variant is simply undeclared. B10 gives it its own
+			// message because the ordinary "go declare it" fix is one the
+			// loader would refuse.
+			name: "a case variant of default is undeclared", world: "Default", want: false,
+		},
+		{"empty name", "", false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := (&metamodelReader{m: m}).HasWorld(tc.world); got != tc.want {
+				t.Errorf("HasWorld(%q) = %v, want %v", tc.world, got, tc.want)
+			}
+		})
+	}
+	t.Run("nil metamodel", func(t *testing.T) {
+		t.Parallel()
+		var nilM *metamodel.Metamodel
+		if (&metamodelReader{m: nilM}).HasWorld("published") {
+			t.Error("a nil metamodel declares nothing")
+		}
+	})
+}
+
+// TestHasPointer covers the adapter's content-state lookup — the content-state lookup B11 consumes.
+//
+// The ALIAS case is the load-bearing one: HasPointer's doc claims it
+// resolves aliases through GetEntityDef, so a grant written against a type
+// alias must answer about the canonical type. Nothing else in the tree
+// exercises that claim — the audit's own tests use a fake whose HasPointer
+// has no alias handling at all.
+func TestHasPointer(t *testing.T) {
+	t.Parallel()
+	m := &metamodel.Metamodel{Entities: map[string]metamodel.EntityDef{
+		"page": {
+			Aliases:  []string{"pg"},
+			Pointers: map[string]metamodel.PointerDef{"draft": {Default: true}, "published": {}},
+		},
+		"ticket": {}, // no pointers block at all
+	}}
+	// The alias map is built at load, not from the literal above, so a
+	// hand-constructed metamodel must initialize it or ResolveAlias is a
+	// no-op and the alias case below would pass vacuously.
+	m.InitAliases()
+	tests := []struct {
+		name            string
+		entityType, ptr string
+		want            bool
+	}{
+		{"declared pointer", "page", "draft", true},
+		{"second declared pointer", "page", "published", true},
+		{"undeclared pointer on a pointered type", "page", "review", false},
+		{"ALIAS resolves to the canonical type", "pg", "draft", true},
+		{"alias with an undeclared pointer", "pg", "review", false},
+		{"a type with no pointers block declares none", "ticket", "draft", false},
+		{"the empty pointer is not a declaration", "page", "", false},
+		{"undeclared type", "nosuchtype", "draft", false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := (&metamodelReader{m: m}).HasPointer(tc.entityType, tc.ptr); got != tc.want {
+				t.Errorf("HasPointer(%q, %q) = %v, want %v",
+					tc.entityType, tc.ptr, got, tc.want)
+			}
+		})
+	}
+	t.Run("nil metamodel", func(t *testing.T) {
+		t.Parallel()
+		var nilM *metamodel.Metamodel
+		if (&metamodelReader{m: nilM}).HasPointer("page", "draft") {
+			t.Error("a nil metamodel declares nothing")
+		}
+	})
+}


### PR DESCRIPTION
Step 3 of the content-states/worlds arc, PR 2 of 3. Stacked on #1423.

Tickets-PR: #1422

## What this is

`internal/acl` validates the **spelling** of PR-A's new grant forms at load, but structurally cannot check **existence** — arch-lint forbids it a metamodel dependency, so a world name is just a string there. These are the cross-file checks, and they are **advisory**: `aclaudit` has one CLI caller and an opt-in `--fail-on` exit code.

Both new findings are High, because the grants fail **closed** at runtime — an unknown world or content state matches nothing — so without the audit the only symptom is a denial nobody can explain.

| Rule | Detects |
| --- | --- |
| `B10-undeclared-world` | `read: [world:X]` naming a world no `worlds:` block declares, and the same for a client-ceiling `worlds:`/`deny_worlds:` entry |
| `B11-undeclared-pointer` | `type@pointer` naming a content state the type does not declare |

B10 is one rule id across both surfaces deliberately — one mistake, one fix — following the existing B4 precedent.

## Three grants the first cut failed to explain

Found by code review, each verified by execution before fixing:

- **`*@draft` produced zero findings while granting nothing.** `GrantsVerbOnState` honors `*` only for the default state, so `*@draft` matches an entity whose type is literally named `*`. B1 skipped it as a wildcard, B11 skipped it as an undeclared type. An operator writing it reasonably believes they granted draft-write across every type.
- **`world:Default` got a fix the loader refuses.** The ordinary "go declare it" remedy is impossible — `validateWorlds` rejects any name case-folding to `default` as reserved. The grant *is* dead, so flagging it was right; only the remedy was wrong.
- **On an unvalidated policy, B1 reported a world token as an undeclared entity type** — advice sending the operator to declare `world:published` under `entities:`, at High severity.

## Also

`metamodel.HasWorld` / `HasPointer` with **direct** tests. `HasPointer`'s alias-resolution claim was previously asserted by a comment and verified by nothing — the audit's own fake has no alias handling. Writing the test caught that a hand-built `Metamodel` literal needs `InitAliases()`, without which the case would have passed vacuously.

`TestB1_DoesNotFlagWellFormedGrantSyntax` is the regression guard for why this lands next to PR-A: B1 is High and `acl audit --exit-code` gates CI on High, so a well-formed world or state grant reported as an undeclared type would fail CI for every policy adopting the syntax.

`just ci` green.