### PR TITLE
🌍 feat(dataentry): request-level world selection with its grant check (TKT-DN37J2 PR-C)

### DIFF
--- a/cmd/rela-server/main.go
+++ b/cmd/rela-server/main.go
@@ -454,6 +454,11 @@ func main() {
 	// without it the routes are not registered at all.
 	app.SetCalDAVAliases(svc.CalDAVAliases())
 
+	// Request-level world selection (`?world=`). Without this the app serves
+	// the default world only and refuses any other `?world=`, which is the
+	// right posture for a surface whose wiring never opted in.
+	app.SetWorlds(appbuild.CompiledWorlds(svc))
+
 	// Next-action per-user state. The composition root picks the backend
 	// (durable over state.KV, or the store-native one on postgres); this only
 	// hands the app what it built.

--- a/docs-project/entities/guides/GUIDE-data-entry.md
+++ b/docs-project/entities/guides/GUIDE-data-entry.md
@@ -3841,6 +3841,62 @@ any registered Lua action via `rela.action`. Treat an app folder with the
 live as files in `apps/`, versioned in git, and should go through the same
 review as any other code.
 
+## Reading a world (`?world=`)
+
+If your schema declares content states and worlds (see the metamodel guide),
+the read API can serve a specific world:
+
+```http
+GET /api/v1/pages?world=published
+GET /api/v1/pages/PAGE-1?world=published
+```
+
+Omitting the parameter — or passing `?world=default` — serves the default
+world, which is exactly what the API served before worlds existed. A project
+that declares no worlds is unaffected.
+
+**You must be granted the world.** Reading a non-default world requires a
+role holding `read: [world:published]` in `acl.yaml`; an ordinary
+`read: [page]` grant covers the default world only. A principal without the
+grant sees an **empty result**, deliberately indistinguishable from a world
+that happens to hold nothing they may read — whether an entity exists in a
+world is exactly what publication controls, so it is not something the API
+will confirm.
+
+An **undeclared** world name is a plain `400` that names it. World names come
+from `schema.yaml` and are not secret, so saying which one is missing is more
+useful than a uniform silence.
+
+### What `?world=` does not cover yet
+
+Only the collection list and the single-entity GET serve a non-default world.
+Every other endpoint **refuses** it with a `422` rather than quietly serving
+default-world data:
+
+- Free-text search (`?q=`, `/_search`, `_position`) — the search index has no
+  per-world scoping yet, so a hit could return a draft under a published-world
+  request, and nothing downstream would catch it.
+- Sub-resources of an entity (relations, attachments, export) and the
+  aggregate endpoints (views, documents, analyze, feeds, history, sync).
+- `?include=` — neighbor resolution is not world-scoped, so a world-bound
+  response with includes would be a published entity wrapped in **draft**
+  neighbors.
+
+For the same reason, a world-bound entity response carries **no `relations`
+map**: those edges are read unresolved, and pairing a published entity with
+draft edges is a mixed-face response that reads as correct. Use the default
+world if you need relations.
+
+**Worlds are read-only.** `?world=` on a `POST`/`PATCH`/`PUT`/`DELETE` is a
+`422`, never silently ignored — writes always address the default state, and
+a request that appeared to edit "the published copy" while editing the draft
+would be the worst kind of success.
+
+A `422` here means "this endpoint cannot answer that question", not "you may
+not ask". Omit `?world=` to use the default world. These are honest
+limitations rather than permanent ones — each endpoint joins the list once its
+whole read path is world-scoped and tested.
+
 ## Best Practices
 
 1. **Start with navigation** - Decide which entity types users will work with most, and create

--- a/docs/data-entry.md
+++ b/docs/data-entry.md
@@ -3835,6 +3835,62 @@ any registered Lua action via `rela.action`. Treat an app folder with the
 live as files in `apps/`, versioned in git, and should go through the same
 review as any other code.
 
+## Reading a world (`?world=`)
+
+If your schema declares content states and worlds (see the metamodel guide),
+the read API can serve a specific world:
+
+```http
+GET /api/v1/pages?world=published
+GET /api/v1/pages/PAGE-1?world=published
+```
+
+Omitting the parameter — or passing `?world=default` — serves the default
+world, which is exactly what the API served before worlds existed. A project
+that declares no worlds is unaffected.
+
+**You must be granted the world.** Reading a non-default world requires a
+role holding `read: [world:published]` in `acl.yaml`; an ordinary
+`read: [page]` grant covers the default world only. A principal without the
+grant sees an **empty result**, deliberately indistinguishable from a world
+that happens to hold nothing they may read — whether an entity exists in a
+world is exactly what publication controls, so it is not something the API
+will confirm.
+
+An **undeclared** world name is a plain `400` that names it. World names come
+from `schema.yaml` and are not secret, so saying which one is missing is more
+useful than a uniform silence.
+
+### What `?world=` does not cover yet
+
+Only the collection list and the single-entity GET serve a non-default world.
+Every other endpoint **refuses** it with a `422` rather than quietly serving
+default-world data:
+
+- Free-text search (`?q=`, `/_search`, `_position`) — the search index has no
+  per-world scoping yet, so a hit could return a draft under a published-world
+  request, and nothing downstream would catch it.
+- Sub-resources of an entity (relations, attachments, export) and the
+  aggregate endpoints (views, documents, analyze, feeds, history, sync).
+- `?include=` — neighbor resolution is not world-scoped, so a world-bound
+  response with includes would be a published entity wrapped in **draft**
+  neighbors.
+
+For the same reason, a world-bound entity response carries **no `relations`
+map**: those edges are read unresolved, and pairing a published entity with
+draft edges is a mixed-face response that reads as correct. Use the default
+world if you need relations.
+
+**Worlds are read-only.** `?world=` on a `POST`/`PATCH`/`PUT`/`DELETE` is a
+`422`, never silently ignored — writes always address the default state, and
+a request that appeared to edit "the published copy" while editing the draft
+would be the worst kind of success.
+
+A `422` here means "this endpoint cannot answer that question", not "you may
+not ask". Omit `?world=` to use the default world. These are honest
+limitations rather than permanent ones — each endpoint joins the list once its
+whole read path is world-scoped and tested.
+
 ## Best Practices
 
 1. **Start with navigation** - Decide which entity types users will work with most, and create

--- a/internal/appbuild/worldsurface.go
+++ b/internal/appbuild/worldsurface.go
@@ -7,6 +7,7 @@ import (
 	"github.com/Sourcehaven-BV/rela/internal/metamodel"
 	"github.com/Sourcehaven-BV/rela/internal/store"
 	"github.com/Sourcehaven-BV/rela/internal/worldreader"
+	"github.com/Sourcehaven-BV/rela/internal/worlds"
 )
 
 // metamodelCanon adapts the metamodel to worldreader.TypeCanonicalizer.
@@ -44,6 +45,24 @@ func (c metamodelScopes) IsContentScoped(relType string) bool {
 		return false
 	}
 	return def.Scope.IsContent()
+}
+
+// CompiledWorlds returns svc's compiled world map, for surfaces that offer
+// request-level world selection (TKT-DN37J2).
+//
+// The returned value satisfies a consumer-side lookup interface by having a
+// Lookup(name) (store.WorldScope, bool) method, so a consumer that may not
+// import internal/worlds (internal/dataentry, per arch-lint) can still
+// resolve a world NAME to its metamodel-free compiled scope.
+//
+// A package-level function rather than a Services method for the same reason
+// [WorldSurface] is one: Services sits at its plimsoll exported-method cap,
+// and that cap is a ratchet to narrow rather than raise.
+func CompiledWorlds(svc *Services) worlds.Compiled {
+	if svc == nil {
+		return worlds.Compiled{}
+	}
+	return svc.worlds
 }
 
 // WorldSurface builds a read surface bound to the named world.

--- a/internal/cli/kong.go
+++ b/internal/cli/kong.go
@@ -63,6 +63,22 @@ type CLI struct {
 	Verbose bool   `help:"Verbose output." short:"v"`
 	Quiet   bool   `help:"Quiet output."   short:"q"`
 
+	// NO --world flag, deliberately (TKT-DN37J2 PR-C).
+	//
+	// The CLI's read paths reach the store through ~29 unscoped call sites
+	// and `readServices` hands commands a raw store.Store. A `--world` flag
+	// added before those are scoped would parse, print nothing unusual, and
+	// serve the DEFAULT world — an operator asking for `--world published`
+	// would get drafts, silently. That is the "plumbed-but-ungated" shape
+	// this arc has refused twice (Q10, and the search refusal in Ruling 3):
+	// a flag that appears to work is worse than an absent one.
+	//
+	// The HTTP API is world-capable because its reads funnel through two
+	// seams that PR-C scoped end to end. The CLI has no equivalent
+	// chokepoint yet. When it does, `--world` belongs here, wiring-bound
+	// with no grant check — the operator's shell is the trust boundary, as
+	// for `db migrate` and `history-purge`.
+
 	// Subcommands.
 	Version    VersionCmd    `cmd:"" help:"Print version information."`
 	Init       InitCmd       `cmd:"" help:"Initialize a new rela project."`

--- a/internal/dataentry/acl_get_test.go
+++ b/internal/dataentry/acl_get_test.go
@@ -238,6 +238,10 @@ func TestACLGet_WriteGateErrorMapping(t *testing.T) {
 // PermitsRead / PermitsReadMany. Used by error-mapping tests;
 // production sites use aclReadGate.
 type fakeGate struct {
+	// denyWorlds names worlds this gate refuses; worldErr makes the gate
+	// itself fail, which must be distinguishable from a denial.
+	denyWorlds      map[string]bool
+	worldErr        error
 	permitsErr      error
 	holdsPermission bool
 }
@@ -266,6 +270,16 @@ func (g fakeGate) SearchScope(context.Context, []string) map[string]search.TypeS
 }
 
 func (g fakeGate) HoldsPermission(context.Context, string) bool { return g.holdsPermission }
+
+// PermitsWorld defaults to permitting every world so existing tests, which
+// never select one, are unaffected. Tests that exercise world denial set
+// denyWorlds.
+func (g fakeGate) PermitsWorld(_ context.Context, world string) (bool, error) {
+	if g.worldErr != nil {
+		return false, g.worldErr
+	}
+	return !g.denyWorlds[world], nil
+}
 
 // principalCtx returns a context carrying a stamped data-entry
 // principal for `user`. RR-MILH: replaces the previous parameterless

--- a/internal/dataentry/api_v1.go
+++ b/internal/dataentry/api_v1.go
@@ -289,6 +289,11 @@ func (a *App) scopedSortedEntities(
 	typeName string,
 	query map[string][]string,
 ) ([]*entityPkg.Entity, error) {
+	// A denied world yields nothing, via the SAME empty-result path a
+	// genuinely-empty world takes — so the two are identical on the wire.
+	if worldFromContext(ctx).blocksAllReads() {
+		return []*entityPkg.Entity{}, nil
+	}
 	rqr := readGateFromContext(ctx).ReadQuery(ctx, typeName)
 
 	var entities []*entityPkg.Entity
@@ -299,7 +304,15 @@ func (a *App) scopedSortedEntities(
 		// Inline iteration rather than listFromStoreByTypes: that
 		// helper swallows iterator errors into a partial slice, and
 		// the list pipeline must fail loud on both verdict paths.
-		for e, err := range a.Services().Store.ListEntities(ctx, store.EntityQuery{Type: typeName}) {
+		// World scope on BOTH verdict branches. Carrying it on only one is
+		// the RR-GQWRLD fail-open: AllowAll takes this EntityQuery branch
+		// and every ACL-gated principal takes the GraphQuery branch below,
+		// so a world stamped on one silently degrades to the default world
+		// for exactly one of the two populations.
+		for e, err := range a.Services().Store.ListEntities(ctx, store.EntityQuery{
+			Type:  typeName,
+			World: worldScopeFrom(ctx),
+		}) {
 			if err != nil {
 				return nil, fmt.Errorf("%w: %w", errListLoad, err)
 			}
@@ -310,7 +323,13 @@ func (a *App) scopedSortedEntities(
 		// AllowAll. Fail loud instead of silently widening the list.
 		return nil, fmt.Errorf("%w: zero ReadQueryResult for type %q", errACLListQuery, typeName)
 	default:
-		for e, err := range a.Services().Store.GraphQuery(ctx, *rqr.Query) {
+		// COPY before stamping: the ACL layer may cache or reuse a
+		// ReadQueryResult per principal, so mutating *rqr.Query in place
+		// would leak one request's world into the next caller's — the same
+		// cross-request scope bleed visibility.listPushdown guards against.
+		wq := *rqr.Query
+		wq.World = worldScopeFrom(ctx)
+		for e, err := range a.Services().Store.GraphQuery(ctx, wq) {
 			if err != nil {
 				return nil, fmt.Errorf("%w: %w", errACLListQuery, err)
 			}
@@ -614,7 +633,14 @@ func (a *App) handleV1ListEntities(w http.ResponseWriter, r *http.Request, typeN
 	outgoingByRow := make([][]*entityPkg.Relation, len(entities))
 	incomingByRow := make([][]*entityPkg.Relation, len(entities))
 	var pageNeighborIDs []string
+	// Same rule as the single-entity GET: these edges are default-world, so a
+	// world-bound list carries none rather than pairing published rows with
+	// draft neighbors.
+	worldBound := !worldScopeFrom(r.Context()).IsDefaultWorld()
 	for i, e := range entities {
+		if worldBound {
+			continue
+		}
 		outgoingByRow[i] = a.reader.outgoingRelations(r.Context(), e.ID)
 		incomingByRow[i] = a.reader.incomingRelations(r.Context(), e.ID)
 		pageNeighborIDs = append(pageNeighborIDs, neighborIDsOf(outgoingByRow[i], incomingByRow[i])...)
@@ -761,7 +787,15 @@ func (a *App) handleV1GetEntity(w http.ResponseWriter, r *http.Request, typeName
 
 	// Single per-entity serialization: strips hidden + attaches
 	// `_fields` / `_relations` per docs/data-entry/api-reference.md.
-	result := a.serializer.forWire(ctx, entity, a.reader.outgoingRelations(ctx, entity.ID), a.Meta(), plural)
+	// Relations come from the ungated, DEFAULT-world reader, so a world-bound
+	// response must not carry them: a published entity wrapped in draft edges
+	// is the mixed-face response that reads as correct. Under the default
+	// world this is the previous behavior verbatim.
+	var outgoing []*entityPkg.Relation
+	if worldScopeFrom(ctx).IsDefaultWorld() {
+		outgoing = a.reader.outgoingRelations(ctx, entity.ID)
+	}
+	result := a.serializer.forWire(ctx, entity, outgoing, a.Meta(), plural)
 
 	// Handle includes for related entities
 	if includes := query.Get("include"); includes != "" {
@@ -1531,6 +1565,14 @@ func flattenIssues(sections []AnalysisSection) []visibleIssue {
 // --- Helper Functions ---
 
 func (a *App) resolveV1Includes(ctx context.Context, entity *entityPkg.Entity, includes string) map[string]v1.Entity {
+	// Neighbor resolution reads through the ungated, DEFAULT-world reader,
+	// so it cannot answer for a non-default world. attachWorld already
+	// refuses `?include=` there, making this unreachable — but a defense
+	// that lives only in the middleware is one route registration away from
+	// being bypassed, so it is restated at the site that does the reading.
+	if !worldScopeFrom(ctx).IsDefaultWorld() {
+		return nil
+	}
 	s := a.State()
 	included := make(map[string]v1.Entity)
 
@@ -1884,10 +1926,24 @@ func (a *App) computeEntityETag(ctx context.Context, e *entityPkg.Entity) string
 		_, _ = fmt.Fprintf(h, "=%v;", e.Properties[k])
 	}
 
+	// Fold the WORLD into the hash first. Two worlds resolve the same id to
+	// different faces, so a shared ETag would let a published-world GET
+	// answer 304 against a draft-derived validator — a cross-world cache
+	// poisoning, and the same class of bug as an unkeyed render cache.
+	world := worldFromContext(ctx)
+	_, _ = h.Write([]byte("w:" + world.name + ";"))
+
 	// Fold outgoing relations into the hash so PATCHes that only change
 	// edges also change the ETag — otherwise If-Match / If-None-Match
 	// round-trips poison client caches.
-	edges := a.reader.outgoingRelations(ctx, e.ID)
+	//
+	// World-bound responses carry NO relations (they would be default-world
+	// edges on a resolved entity), so there is nothing to fold and reading
+	// them would put draft state into a published validator.
+	var edges []*entityPkg.Relation
+	if world.isDefault() {
+		edges = a.reader.outgoingRelations(ctx, e.ID)
+	}
 	edgeKeys := make([]string, 0, len(edges))
 	for _, edge := range edges {
 		edgeKeys = append(edgeKeys, edge.Type+"|"+edge.To)

--- a/internal/dataentry/app.go
+++ b/internal/dataentry/app.go
@@ -102,7 +102,12 @@ const userPaletteFile = "palette.yaml"
 // handler as a parameter and `toolForPath` is a package function, so the
 // mount cost one method rather than three.
 //
-//plimsoll:max-methods=103
+// TKT-DN37J2 adds [App.SetWorlds] on the same terms, and the same discipline
+// held for the rest: `resolveWorld`, `attachWorld`, `worldCapablePath` and
+// `worldRefusesSearch` are all package functions taking what they need, so
+// request-level world selection cost ONE method rather than five.
+//
+//plimsoll:max-methods=104
 type App struct {
 	// Primitives — immutable after NewApp.
 	fs    storage.FS
@@ -124,7 +129,12 @@ type App struct {
 	// (a collection with no way to remember client-created resources would
 	// duplicate every to-do on the next sync).
 	caldavAliases *caldavalias.Service
-	searcher      search.Searcher
+
+	// worlds resolves a `?world=` name to its compiled scope. Nil until
+	// [App.SetWorlds] is called, in which case the App serves the default
+	// world only and refuses any other `?world=` — see world.go.
+	worlds   WorldLookup
+	searcher search.Searcher
 	// visibleSearcher is the ACL-scoped search seam (TKT-BA8BSX):
 	// executeQuery routes free-text searches through it so /_search
 	// and the _position search scope only ever see hits the request

--- a/internal/dataentry/entityreader.go
+++ b/internal/dataentry/entityreader.go
@@ -15,6 +15,21 @@ import (
 // (visibleReader for the gated single-GET / include-filter path; the analyze
 // gate at the issue boundary). These helpers are the raw store reads those
 // gated paths and the internal machinery build on.
+//
+// # It is DEFAULT-WORLD-ONLY, deliberately (TKT-DN37J2)
+//
+// Every read here goes to the store unresolved, so it returns each entity's
+// DEFAULT state — the draft face, under the design doc's example layout.
+// That is a decision, not an oversight, and it is safe only because of what
+// holds it up: the routes this reader serves (relations, attachments,
+// export, sub-resources, views) are REFUSED a non-default world by
+// worldCapablePath, so no `?world=` request ever reaches these calls.
+//
+// If a route is ever added to that allowlist, its use of this reader must be
+// converted first — a world-bound response assembled partly from
+// world-resolved rows and partly from these is the mixed-face bug that would
+// be hardest to see, because the entity would look right and its neighbors
+// would not. TestWorldCapableRoutesDoNotUseUngatedReader is the guard.
 type entityReader struct {
 	store store.Store
 }

--- a/internal/dataentry/history_redaction_test.go
+++ b/internal/dataentry/history_redaction_test.go
@@ -43,6 +43,8 @@ func (g permGate) SearchScope(context.Context, []string) map[string]search.TypeS
 
 func (g permGate) HoldsPermission(_ context.Context, perm string) bool { return g.perms[perm] }
 
+func (permGate) PermitsWorld(context.Context, string) (bool, error) { return true, nil }
+
 // getHistoryVersion drives serveHistoryVersion via handleV1History for version 1
 // of id, under the given principal and read gate.
 func getHistoryVersion(app *App, user, typeName, id string, gate readGate) *httptest.ResponseRecorder {

--- a/internal/dataentry/readgate.go
+++ b/internal/dataentry/readgate.go
@@ -50,6 +50,15 @@ type readGate interface {
 	// permission (e.g. acl.PermHistoryRead). Used to gate deleted-entity
 	// history reads, which have no per-entity verdict to evaluate.
 	HoldsPermission(ctx context.Context, perm string) bool
+	// PermitsWorld reports whether the principal may READ the named world
+	// (TKT-DN37J2). Checked at `?world=` selection, BEFORE a world-resolved
+	// reader is constructed; the per-entity gates above still run after, on
+	// whatever the resolved world contains.
+	//
+	// The error is an INFRASTRUCTURE failure, not a denial — the two must
+	// stay distinguishable, because a denial renders as an empty result
+	// while an outage must not (RR-4TFZNL).
+	PermitsWorld(ctx context.Context, world string) (bool, error)
 }
 
 // aclReadGate is the production implementation of readGate. Wraps a
@@ -85,6 +94,10 @@ func (g aclReadGate) ReadQuery(ctx context.Context, entityType string) acl.ReadQ
 
 func (g aclReadGate) HoldsPermission(ctx context.Context, perm string) bool {
 	return g.req.HoldsPermission(ctx, perm)
+}
+
+func (g aclReadGate) PermitsWorld(ctx context.Context, world string) (bool, error) {
+	return g.req.PermitsWorld(ctx, world)
 }
 
 // SearchScope maps per-type ReadQuery verdicts onto the
@@ -133,6 +146,12 @@ func (nopReadGate) ReadQuery(context.Context, string) acl.ReadQueryResult {
 // nop gate's allow-all posture (no policy configured ⇒ no restrictions), so
 // deleted-entity history is readable exactly as it would be pre-ACL.
 func (nopReadGate) HoldsPermission(context.Context, string) bool { return true }
+
+// PermitsWorld under no ACL permits every world, matching every other
+// method here: the nop gate is the "no policy loaded" case, where the
+// operator has not asked for any gating at all. A world's CONTENTS are
+// still whatever the world resolves to; this only decides selection.
+func (nopReadGate) PermitsWorld(context.Context, string) (bool, error) { return true, nil }
 
 // SearchScope under no ACL is the wildcard-allow scope — NOT one
 // AllowAll entry per metamodel type. The difference is entities whose

--- a/internal/dataentry/relation_history_handler_test.go
+++ b/internal/dataentry/relation_history_handler_test.go
@@ -94,6 +94,8 @@ func (g perEndpointGate) SearchScope(context.Context, []string) map[string]searc
 
 func (g perEndpointGate) HoldsPermission(context.Context, string) bool { return g.holdsPermission }
 
+func (perEndpointGate) PermitsWorld(context.Context, string) (bool, error) { return true, nil }
+
 // newRelHistoryApp builds a test App whose store is a RelationHistoryReader with
 // two live endpoints (DEC-1: decision, REQ-1: requirement) and one canned
 // relation version.

--- a/internal/dataentry/router.go
+++ b/internal/dataentry/router.go
@@ -189,6 +189,21 @@ func (a *App) NewRouter() http.Handler {
 	// `acl_unstamped_principal` when ACL is configured, because the
 	// principal is still the unstamped default at the time
 	// ForPrincipal is called.
+	// World selection must run AFTER the read gate is on the context, because
+	// its grant check consults readGateFromContext. Per the wrap-order note
+	// above, LAST wrap is OUTERMOST — so attachWorld is wrapped FIRST, making
+	// it the INNERMOST of the two and therefore the LATER to run.
+	//
+	// Getting this backwards is not a loud failure: the world gate would see
+	// nopReadGate, whose PermitsWorld returns true, and every world would be
+	// permitted regardless of policy. Pinned by
+	// TestAttachWorld_GrantCheckRunsAfterACLGate.
+	//
+	// Placing it in middleware rather than in each handler is what makes "the
+	// grant check happens before a resolver is constructed" STRUCTURAL: a
+	// handler cannot observe a non-default world on its context without the
+	// check having already passed, and cannot opt out of it.
+	handler = attachWorld(handler, a)
 	if d, ok := a.acl.(*acl.Declarative); ok && d != nil {
 		// jwtVerified tells attachACLRequest that identity is a verified-JWT
 		// assertion (the gate is installed), so an unmatched principal can be

--- a/internal/dataentry/visiblereader.go
+++ b/internal/dataentry/visiblereader.go
@@ -2,6 +2,7 @@ package dataentry
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 
 	entitypkg "github.com/Sourcehaven-BV/rela/internal/entity"
@@ -55,6 +56,11 @@ func newVisibleReader(s store.Store) visibleReader {
 // getEntity pair: callers translate (nil,false,nil) into the same not-found
 // wire response a genuinely-missing entity produces.
 func (vr visibleReader) getVisible(ctx context.Context, entityType, id string) (*entitypkg.Entity, bool, error) {
+	if worldFromContext(ctx).blocksAllReads() {
+		// Same not-found a genuine miss produces — the caller cannot tell a
+		// denied world from an entity with no face in this one.
+		return nil, false, nil
+	}
 	ok, err := readGateFromContext(ctx).PermitsRead(ctx, entityType, id)
 	if err != nil {
 		return nil, false, err
@@ -62,7 +68,18 @@ func (vr visibleReader) getVisible(ctx context.Context, entityType, id string) (
 	if !ok {
 		return nil, false, nil
 	}
-	e, gerr := vr.store.GetEntity(ctx, id)
+	e, gerr := vr.getWorldEntity(ctx, id)
+	if gerr != nil && !errors.Is(gerr, errWorldEntityAbsent) &&
+		!worldScopeFrom(ctx).IsDefaultWorld() {
+		// On the WORLD path the underlying read is a ListEntities iterator,
+		// whose error is always an infrastructure failure — a genuine miss
+		// is errWorldEntityAbsent. Folding it into not-found would render a
+		// backend outage as "this entity has no published face", which is
+		// the same mistake resolveWorld refuses to make one file over
+		// (RR-4TFZNL). The default-world branch keeps GetEntity's inherited
+		// miss-is-not-found contract unchanged.
+		return nil, false, gerr
+	}
 	if gerr != nil {
 		// A store miss is treated as not-found, matching the former
 		// App.getEntity contract (err -> not found). The store error is
@@ -73,6 +90,44 @@ func (vr visibleReader) getVisible(ctx context.Context, entityType, id string) (
 	}
 	return e, true, nil
 }
+
+// getWorldEntity fetches the entity's face in the request's world.
+//
+// For the DEFAULT world this is exactly the previous GetEntity call — the
+// zero WorldScope is the default world, so a pointerless project and every
+// existing caller are byte-identical.
+//
+// For a non-default world it goes through a one-id ListEntities query
+// carrying the world scope, so the BACKEND resolves the chain and the
+// fallback verdict. That keeps ONE resolution site: reimplementing the walk
+// here would be a second implementation of the semantics that decide which
+// face a reader sees, free to drift from the store's. It also means an
+// entity the world EXCLUDES is simply absent from the result, which the
+// caller already renders as the same not-found a genuine miss produces.
+func (vr visibleReader) getWorldEntity(
+	ctx context.Context, id string,
+) (*entitypkg.Entity, error) {
+	scope := worldScopeFrom(ctx)
+	if scope.IsDefaultWorld() {
+		return vr.store.GetEntity(ctx, id)
+	}
+	for e, err := range vr.store.ListEntities(ctx, store.EntityQuery{
+		IDs:   []string{id},
+		World: scope,
+	}) {
+		if err != nil {
+			return nil, err
+		}
+		return e, nil
+	}
+	return nil, errWorldEntityAbsent
+}
+
+// errWorldEntityAbsent means the world resolved the id to no face — either
+// no state matched the chain under `otherwise: exclude`, or the entity does
+// not exist. The caller cannot tell the two apart, which is the point:
+// existence in a world IS the publication bit (§4.1).
+var errWorldEntityAbsent = errors.New("entity has no face in this world")
 
 // filterVisible drops every candidate the principal cannot read, batching the
 // gate probe by entity type — one PermitsReadMany per distinct type, turning a

--- a/internal/dataentry/visiblereader_test.go
+++ b/internal/dataentry/visiblereader_test.go
@@ -47,6 +47,8 @@ func (configGate) SearchScope(context.Context, []string) map[string]search.TypeS
 
 func (configGate) HoldsPermission(context.Context, string) bool { return false }
 
+func (configGate) PermitsWorld(context.Context, string) (bool, error) { return true, nil }
+
 func seedReader(t *testing.T) visibleReader {
 	t.Helper()
 	st := memstore.New()

--- a/internal/dataentry/world.go
+++ b/internal/dataentry/world.go
@@ -1,0 +1,344 @@
+package dataentry
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/Sourcehaven-BV/rela/internal/store"
+)
+
+// WorldParam is the query parameter that selects a world on the read API:
+// `?world=published`. Absent or empty means the DEFAULT world, bound
+// explicitly at this boundary — the interior never sees "unspecified"
+// (design doc §4.4).
+const WorldParam = "world"
+
+// defaultWorldName is the reserved name of the implicit default world,
+// mirroring metamodel.DefaultWorldName and acl.DefaultWorldName. Spelled
+// here so `?world=default` is accepted as an explicit way to ask for what
+// an absent parameter already means.
+const defaultWorldName = "default"
+
+// errWorldUnknown names a `?world=` value no declared world matches. A
+// CONFIG error, rendered as a named 400 — see [App.resolveWorld].
+var errWorldUnknown = errors.New("no such world")
+
+// errWorldDenied means the principal holds no read grant for a world that
+// DOES exist. Rendered as an EMPTY RESULT, never a 403 — see
+// [resolveWorld].
+var errWorldDenied = errors.New("world not readable by this principal")
+
+// errWorldDuplicated means the request carried more than one `?world=`.
+// Rejected rather than resolved by a precedence rule nobody would remember.
+var errWorldDuplicated = errors.New("duplicate world parameter")
+
+// errWorldUnsupported names a route that cannot honor a non-default world.
+// Rendered as a 422: the caller asked for something coherent that this
+// surface cannot serve, and saying so is better than serving default-world
+// data under a published-world request (Ruling 3).
+var errWorldUnsupported = errors.New("this endpoint cannot serve a non-default world")
+
+// WorldLookup resolves a declared world NAME to its compiled scope.
+//
+// Consumer-side interface: internal/dataentry may not import internal/worlds
+// (arch-lint), and a store.WorldScope is metamodel-free by construction, so
+// the compiled map is injected from the wiring site via [App.SetWorlds].
+//
+// It must FAIL CLOSED on an unknown name — returning ok=false rather than
+// substituting the default world, which would silently widen a request that
+// asked for a narrower view.
+type WorldLookup interface {
+	Lookup(name string) (store.WorldScope, bool)
+}
+
+// worldHandle is the per-request world binding: a NAME and its compiled
+// SCOPE, resolved once at the top of the operation and reused for every read
+// in it.
+//
+// Both fields are needed. The scope is what the store matches on; the name is
+// what the grant was checked against and what diagnostics report — a
+// store.WorldScope deliberately carries no name (internal/store cannot know
+// one), so it cannot be recovered later.
+type worldHandle struct {
+	name  string
+	scope store.WorldScope
+
+	// denied marks a world that EXISTS but that this principal holds no
+	// read grant for. The request still runs, so the handler produces its
+	// ordinary response shape; the read seams simply find nothing. See the
+	// errWorldDenied arm in attachWorld for why the alternative — writing a
+	// synthetic empty body — leaked the denial.
+	denied bool
+}
+
+// isDefault reports whether this handle is the default world. The zero
+// handle is the default world, which is what makes an unstamped context and
+// an explicit `?world=default` behave identically.
+func (w worldHandle) isDefault() bool { return !w.denied && w.scope.IsDefaultWorld() }
+
+// blocksAllReads reports a handle that must yield nothing at all.
+func (w worldHandle) blocksAllReads() bool { return w.denied }
+
+type worldCtxKey struct{}
+
+// withWorld binds a resolved world to ctx for the rest of the operation.
+//
+// The handle is CONSTRUCTED ONCE, in middleware, and carried whole — this is
+// deliberately not "a world name on ctx that each read re-resolves". §4.4
+// forbids the latter: a world that travels as ambient data can be
+// reinterpreted per call, and a trace that flips worlds mid-walk is
+// incoherent. A fully-constructed handle cannot be reinterpreted.
+//
+// The key is typed and unexported so nothing outside this package can inject
+// one.
+func withWorld(ctx context.Context, w worldHandle) context.Context {
+	return context.WithValue(ctx, worldCtxKey{}, w)
+}
+
+// worldFromContext returns the request's world handle, or the zero handle
+// (the default world) when none was bound.
+//
+// Defaulting to the DEFAULT world rather than erroring is correct here and is
+// not a fail-open: the default world is today's graph, so an unstamped
+// context behaves exactly as it did before worlds existed. A non-default
+// world can only ever arrive by passing the grant check in
+// [resolveWorld].
+func worldFromContext(ctx context.Context) worldHandle {
+	w, _ := ctx.Value(worldCtxKey{}).(worldHandle)
+	return w
+}
+
+// worldScopeFrom returns the store scope to stamp onto a query built from
+// ctx. Spelled as its own helper so query-construction sites read as
+// `q.World = worldScopeFrom(ctx)` and a reviewer can grep for the ones that
+// forgot.
+func worldScopeFrom(ctx context.Context) store.WorldScope {
+	return worldFromContext(ctx).scope
+}
+
+// SetWorlds injects the compiled world map, enabling `?world=` selection.
+//
+// Until this is called the App serves the default world only and REFUSES any
+// `?world=` naming something else — which is the correct posture for a
+// surface whose wiring never opted in, and means a deployment that does not
+// use worlds cannot accidentally acquire the parameter.
+func (a *App) SetWorlds(w WorldLookup) { a.worlds = w }
+
+// resolveWorld resolves the request's `?world=` parameter into a handle,
+// applying the per-world read grant BEFORE any resolver is constructed.
+//
+// A free function taking the lookup rather than an App method: it needs
+// exactly one collaborator, and App is at its plimsoll method cap because it
+// has accreted for years — adding to it is the habit that got it there.
+//
+// Returns (handle, nil) on success. The two failure modes are DELIBERATELY
+// DIFFERENT, and the difference is not an inconsistency to tidy away:
+//
+//   - UNKNOWN world -> a named 400. A world name is operator-authored
+//     CONFIG (schema.yaml), and CLAUDE.md is explicit that config names are
+//     not secret: naming the missing world is more useful to whoever is
+//     debugging it than a uniform silence, and conceals nothing, because the
+//     set of declared worlds is already served over the API.
+//
+//   - Known world the principal may NOT read -> (zero handle, errWorldDenied),
+//     which callers render as an EMPTY RESULT, never a 403. What a world
+//     CONTAINS — and whether any given entity exists in it — is exactly the
+//     secret this feature exists to keep (§4.4). A 403 here would tell the
+//     caller that a world exists holding things they may not see, which is
+//     the existence oracle the row-level rule forbids. Indistinguishable
+//     from a world with nothing in it, by design.
+//
+// Do NOT "unify" these two into one response shape. They protect different
+// things: one is config, the other is content.
+func resolveWorld(r *http.Request, lookup WorldLookup) (worldHandle, error) {
+	values := r.URL.Query()[WorldParam]
+	if len(values) > 1 {
+		// Get() would silently take the FIRST, so `?world=default&world=published`
+		// would serve the default world under a request that also asked for
+		// published — a client-side param-append bug becoming a silent
+		// wrong-face serve, which is the direction this arc refuses.
+		return worldHandle{}, errWorldDuplicated
+	}
+	name := r.URL.Query().Get(WorldParam)
+	if name == "" || name == defaultWorldName {
+		// The default world needs no grant beyond the ordinary read gates
+		// that already run per entity: it IS today's graph.
+		return worldHandle{}, nil
+	}
+	if lookup == nil {
+		return worldHandle{}, errWorldUnknown
+	}
+	scope, ok := lookup.Lookup(name)
+	if !ok {
+		return worldHandle{}, errWorldUnknown
+	}
+	permitted, err := readGateFromContext(r.Context()).PermitsWorld(r.Context(), name)
+	if err != nil {
+		// An infrastructure failure is NOT a denial. Rendering it as an
+		// empty result would hide an outage behind a page that looks like a
+		// correctly-empty world, with no operator signal (RR-4TFZNL).
+		return worldHandle{}, err
+	}
+	if !permitted {
+		return worldHandle{}, errWorldDenied
+	}
+	return worldHandle{name: name, scope: scope}, nil
+}
+
+// # Why an allowlist rather than teaching every read path
+//
+// A world-bound request must never be served default-world data (Ruling 3).
+// internal/dataentry reaches entity content through roughly forty store call
+// sites across a dozen files — the list pipeline, the ungated entityReader
+// used for relations and serialization, view traversal, document render,
+// feeds, CalDAV, sync, commands. Teaching all of them in one change would be
+// a large diff in which a single missed site is a silent leak, and "silence
+// in the direction of serving the wrong face" is the failure this arc keeps
+// hitting.
+//
+// So the default is DENY, and a route joins this predicate only when its
+// whole read path is world-scoped and tested. That is the DEC-ZBI39P stance —
+// structurally incapable rather than "defaults to safe" — applied at the
+// route table: a leak requires someone to WIDEN this predicate, a visible and
+// reviewable act, rather than to forget a call site.
+//
+// worldCapablePath reports whether path may serve a non-default world.
+//
+// Deliberately conservative: only the collection list (`/{plural}`) and the
+// single-entity GET (`/{plural}/{id}`) qualify today, because those are the
+// two paths whose reads this PR made world-scoped end to end. Every
+// underscore-prefixed endpoint — search, analyze, views, documents, feeds,
+// history, sync, position, next-action — is refused, along with every
+// sub-resource of an entity (relations, attachments, export), because each
+// reaches content through a path that is still world-blind.
+//
+// Refusing is not a permanent verdict on those routes; it is the honest one
+// until each is scoped and tested.
+func worldCapablePath(path string) bool {
+	trimmed := strings.TrimPrefix(path, "/api/v1/")
+	if trimmed == path {
+		// Not under the versioned API (e.g. /api/sync/...). Refuse.
+		return false
+	}
+	trimmed = strings.Trim(trimmed, "/")
+	if trimmed == "" || strings.HasPrefix(trimmed, "_") {
+		return false
+	}
+	// `{plural}` or `{plural}/{id}` only. A third segment is a
+	// sub-resource (relations, attachments, _export) and is refused.
+	return strings.Count(trimmed, "/") <= 1 &&
+		!strings.Contains(trimmed, "/_")
+}
+
+// worldRefusesSearch reports whether this request combines a non-default
+// world with free-text search, which must be REFUSED rather than served.
+//
+// `?q=` on a list intersects the ACL-scoped rows with hits from the raw
+// searcher, and no searcher can honor a world: internal/search is
+// world-agnostic BY CONSTRUCTION (its Query type carries no world), and
+// per-world indexing is Step 5 (TKT-9KZGJO). worldreader.NewSurface already
+// refuses to CONSTRUCT a non-default-world surface over a searcher for this
+// reason; this is the same refusal at the HTTP boundary.
+//
+// Silent degradation is the specific thing forbidden: the ACL row gate
+// cannot catch a wrongly-scoped hit, because guard rule 1 makes it
+// world-independent. A draft surfacing through the search box would reach
+// the user with nothing downstream to stop it.
+func worldRefusesSearch(r *http.Request) bool {
+	return r.URL.Query().Get("q") != ""
+}
+
+// attachWorld resolves `?world=` once per request and binds the handle to
+// the context, refusing every combination this surface cannot serve.
+//
+// Runs INSIDE attachACLRequest (so the read gate it needs for the grant
+// check is already on the context) and before any handler, which is what
+// makes "the grant check happens before a resolver is constructed"
+// structural rather than a convention each handler must remember.
+func attachWorld(next http.Handler, a *App) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !isAPIPath(r.URL.Path) || r.URL.Query().Get(WorldParam) == "" {
+			next.ServeHTTP(w, r)
+			return
+		}
+		// Worlds are a READ-side concept: §9.4 makes "writes never pass
+		// through worlds" a hard rule, because a world can answer a read
+		// with a fallback face and a read-modify-write through that answer
+		// saves the wrong state's content. Nothing on this API honors a
+		// world on a write, so accepting the parameter would let
+		// `PATCH ...?world=published` silently edit the DRAFT — and
+		// `DELETE ...?world=published` delete the entity outright while the
+		// caller believed they were unpublishing.
+		readOnly := r.Method == http.MethodGet || r.Method == http.MethodHead ||
+			r.Method == http.MethodOptions
+		if !readOnly {
+			writeV1Error(w, r, http.StatusUnprocessableEntity, "world_read_only",
+				"worlds are read-only on this API",
+				"omit ?world= — writes always address the default state")
+			return
+		}
+		handle, err := resolveWorld(r, a.worlds)
+		switch {
+		case errors.Is(err, errWorldDuplicated):
+			writeV1Error(w, r, http.StatusBadRequest, "duplicate_world",
+				"more than one ?world= parameter", "pass it exactly once")
+			return
+		case errors.Is(err, errWorldUnknown):
+			// A config name, not a secret: name it. See resolveWorld.
+			writeV1Error(w, r, http.StatusBadRequest, "unknown_world",
+				fmt.Sprintf("no world named %q is declared",
+					r.URL.Query().Get(WorldParam)),
+				"check the `worlds:` block in schema.yaml")
+			return
+		case errors.Is(err, errWorldDenied):
+			// NOT a 403, and NOT a synthetic body either. The request
+			// continues with a handle marked `denied`, so the ORDINARY
+			// handler runs and renders its own empty result — same JSON
+			// shape, same `meta`, same `_actions`, same pagination headers
+			// as a world that genuinely holds nothing this caller may read.
+			//
+			// Writing a hand-built `{"data":[]}` here was the first attempt
+			// and it was wrong: the real list response carries meta/_actions/
+			// X-Total-Count, so the bare body announced the denial on the
+			// first byte — turning the thing designed to close an existence
+			// oracle into one.
+			next.ServeHTTP(w, r.WithContext(withWorld(r.Context(),
+				worldHandle{name: r.URL.Query().Get(WorldParam), denied: true})))
+			return
+		case err != nil:
+			// Infrastructure failure, not a denial.
+			writeGateError(w, r, err)
+			return
+		}
+		if !handle.isDefault() {
+			if !worldCapablePath(r.URL.Path) {
+				writeV1Error(w, r, http.StatusUnprocessableEntity, "world_unsupported",
+					errWorldUnsupported.Error(),
+					"this endpoint serves the default world only; omit ?world=")
+				return
+			}
+			if r.URL.Query().Get("include") != "" {
+				// `?include=` resolves NEIGHBORS, and every neighbor read on
+				// these routes goes through the ungated, default-world
+				// entityReader. Serving them under a world would return a
+				// published entity wrapped in DRAFT neighbors — the mixed-face
+				// response that is hardest to spot, because the entity looks
+				// right and only its neighbors are wrong.
+				writeV1Error(w, r, http.StatusUnprocessableEntity, "world_include_unsupported",
+					"?include= cannot be resolved in a non-default world",
+					"omit ?include= — neighbor resolution is not world-scoped yet")
+				return
+			}
+			if worldRefusesSearch(r) {
+				writeV1Error(w, r, http.StatusUnprocessableEntity, "world_search_unsupported",
+					"free-text search cannot be scoped to a non-default world",
+					"omit ?q=, or omit ?world= — per-world search indexing is not built yet")
+				return
+			}
+		}
+		next.ServeHTTP(w, r.WithContext(withWorld(r.Context(), handle)))
+	})
+}

--- a/internal/dataentry/world_test.go
+++ b/internal/dataentry/world_test.go
@@ -1,0 +1,676 @@
+package dataentry
+
+import (
+	"context"
+	"errors"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/Sourcehaven-BV/rela/internal/acl"
+	"github.com/Sourcehaven-BV/rela/internal/entity"
+	"github.com/Sourcehaven-BV/rela/internal/principal"
+	"github.com/Sourcehaven-BV/rela/internal/store"
+)
+
+// stubWorlds is a WorldLookup over a fixed name set. The scopes are
+// non-default only in the sense that matters here — IsDefaultWorld() is
+// false — which is what the refusal and stamping logic branch on.
+type stubWorlds struct {
+	names map[string]bool
+	// resolveDefault makes the world resolve to each entity's default state
+	// rather than excluding everything — see Lookup.
+	resolveDefault bool
+}
+
+func (s stubWorlds) Lookup(name string) (store.WorldScope, bool) {
+	if !s.names[name] {
+		return store.WorldScope{}, false
+	}
+	if s.resolveDefault {
+		// A world that resolves `ticket` to its DEFAULT state, so an entity
+		// seeded without any content-state row is still visible in it. That
+		// is what lets a test tell "the grant denied me" (empty) apart from
+		// "the world excluded everything" (also empty) — without it, both
+		// look identical and a grant-check test passes even when the check
+		// never ran.
+		return store.NewWorldScope(map[string]store.TypeResolution{
+			"ticket": {Fallback: store.FallbackDefaultState},
+		}), true
+	}
+	// A resolution for one type is enough to make IsDefaultWorld() false,
+	// which is what every branch under test keys on. FallbackExclude is the
+	// public-world shape: an entity with no matching state contributes
+	// nothing.
+	return store.NewWorldScope(map[string]store.TypeResolution{
+		"ticket": {
+			Chain:    []entity.Pointer{entity.Pointer("published")},
+			Fallback: store.FallbackExclude,
+		},
+	}), true
+}
+
+func TestWorldCapablePath(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		path string
+		want bool
+		why  string
+	}{
+		{"/api/v1/tickets", true, "collection list is world-scoped"},
+		{"/api/v1/tickets/TKT-1", true, "single-entity GET is world-scoped"},
+		{"/api/v1/tickets/TKT-1/relations", false, "sub-resource reads through the ungated reader"},
+		{"/api/v1/tickets/TKT-1/_export", false, "export reads through the ungated reader"},
+		{"/api/v1/_search", false, "the searcher cannot honor a world"},
+		{"/api/v1/_views/board", false, "view traversal is world-blind"},
+		{"/api/v1/_documents/report", false, "document render and its cache key are world-blind"},
+		{"/api/v1/_position", false, "position reads through the search path"},
+		{"/api/v1/_analyze", false, "whole-graph, tracer-backed"},
+		{"/api/v1/_history/tickets/TKT-1", false, "history is an orthogonal version axis"},
+		{"/api/sync/manifest", false, "outside the versioned API"},
+		{"/api/v1/", false, "the bare mount carries no data"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.path, func(t *testing.T) {
+			t.Parallel()
+			if got := worldCapablePath(tc.path); got != tc.want {
+				t.Errorf("worldCapablePath(%q) = %v, want %v (%s)",
+					tc.path, got, tc.want, tc.why)
+			}
+		})
+	}
+}
+
+// TestWorldDefaultDenyIsTheDefault is the structural claim behind the
+// allowlist: a path nobody has thought about is REFUSED, so shipping a leak
+// requires someone to widen the predicate — a visible, reviewable act —
+// rather than to forget a store call site.
+func TestWorldDefaultDenyIsTheDefault(t *testing.T) {
+	t.Parallel()
+	for _, p := range []string{
+		"/api/v1/_something_invented_tomorrow",
+		"/api/v1/tickets/TKT-1/some/deep/subresource",
+		"/api/v2/tickets",
+		"/api/v1/tickets/TKT-1/_attachments",
+	} {
+		if worldCapablePath(p) {
+			t.Errorf("a path with no explicit decision must be refused a "+
+				"non-default world; %q was permitted", p)
+		}
+	}
+}
+
+// TestAttachWorld_UnknownWorldIsNamed pins the CONFIG half of the
+// deliberately-asymmetric denial semantics: a world name is operator-authored
+// config, not a secret, so naming it beats a uniform silence.
+func TestAttachWorld_UnknownWorldIsNamed(t *testing.T) {
+	t.Parallel()
+	app := &App{worlds: stubWorlds{names: map[string]bool{"published": true}}}
+	rec := serveWorldRequest(t, app, "/api/v1/tickets?world=nosuchworld")
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("unknown world: got %d, want 400", rec.Code)
+	}
+	if !strings.Contains(rec.Body.String(), "nosuchworld") {
+		t.Errorf("the response must NAME the missing world — it is config, "+
+			"not a secret; got: %s", rec.Body.String())
+	}
+}
+
+// TestDeniedWorldIsByteIdenticalToAnEmptyWorld is the CONTENT half of the
+// denial semantics, and it compares the actual responses rather than
+// grepping the body for the word "denied".
+//
+// The first version of this test did the latter, and passed against a
+// hand-built `{"data":[]}` that omitted `meta`, `_actions` and five
+// pagination headers the real list response carries. That bare body
+// announced the denial on the first byte — turning the mechanism designed
+// to close an existence oracle into one. The lesson generalizes: assert the
+// property, not a proxy for it.
+func TestDeniedWorldIsByteIdenticalToAnEmptyWorld(t *testing.T) {
+	app := newTestAppV1(t)
+	d := mustNewACL(t, &acl.Policy{
+		Roles:       map[string]acl.RoleDef{"viewer": {Read: []string{"ticket"}}},
+		Assignments: map[string]string{"alice": "viewer"},
+	}, app.store)
+	app.acl = d
+
+	// (a) A world the principal MAY read, which happens to hold nothing.
+	empty := listUnderWorld(t, app, worldHandle{name: "published",
+		scope: excludeEverythingScope()})
+
+	// (b) A world the principal may NOT read.
+	denied := listUnderWorld(t, app, worldHandle{name: "published", denied: true})
+
+	if empty.Body.String() != denied.Body.String() {
+		t.Errorf("a denied world must be indistinguishable from an empty one.\n"+
+			"  empty-world body:  %s\n  denied-world body: %s",
+			empty.Body.String(), denied.Body.String())
+	}
+	for _, h := range []string{"X-Total-Count", "X-Page", "X-Per-Page", "Link", "Content-Type"} {
+		if empty.Header().Get(h) != denied.Header().Get(h) {
+			t.Errorf("header %s differs: empty=%q denied=%q — a client can tell "+
+				"the denial from a genuinely empty world", h,
+				empty.Header().Get(h), denied.Header().Get(h))
+		}
+	}
+	if empty.Code != denied.Code {
+		t.Errorf("status differs: empty=%d denied=%d", empty.Code, denied.Code)
+	}
+}
+
+// excludeEverythingScope is a world that resolves the fixture's type to no
+// face, so a principal who MAY read it still sees nothing.
+func excludeEverythingScope() store.WorldScope {
+	return store.NewWorldScope(map[string]store.TypeResolution{
+		"ticket": {
+			Chain:    []entity.Pointer{entity.Pointer("published")},
+			Fallback: store.FallbackExclude,
+		},
+	})
+}
+
+// listUnderWorld runs the real list handler under a world handle.
+func listUnderWorld(t *testing.T, app *App, h worldHandle) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/tickets", http.NoBody)
+	ctx := withWorld(withReadGate(aliceCtx(), nopReadGate{}), h)
+	rec := httptest.NewRecorder()
+	app.handleV1ListEntities(rec, req.WithContext(ctx), "ticket", "tickets")
+	return rec
+}
+
+// TestAttachWorld_GateErrorIsNotADenial pins that an infrastructure failure
+// stays distinguishable from a denial. Rendering it as an empty result would
+// hide an outage behind a page that looks like a correctly-empty world.
+func TestAttachWorld_GateErrorIsNotADenial(t *testing.T) {
+	t.Parallel()
+	app := &App{worlds: stubWorlds{names: map[string]bool{"published": true}}}
+
+	ctx := withReadGate(context.Background(),
+		fakeGate{worldErr: errors.New("store is down")})
+	rec := serveWorldRequestCtx(ctx, t, app, "/api/v1/tickets?world=published")
+
+	if rec.Code == http.StatusOK {
+		t.Fatal("a gate failure must not render as an empty result — that hides " +
+			"an outage behind a page that looks like a correctly-empty world")
+	}
+	if rec.Code != http.StatusInternalServerError && rec.Code != http.StatusGatewayTimeout {
+		t.Errorf("a gate failure should surface as 5xx; got %d", rec.Code)
+	}
+}
+
+// TestAttachWorld_SearchRefuses pins Ruling 3 at the HTTP boundary: no
+// searcher can honor a world, and silently serving default-world hits under
+// a published-world request is the one thing that must not happen. The ACL
+// row gate cannot catch it — guard rule 1 makes that gate world-independent.
+func TestAttachWorld_SearchRefuses(t *testing.T) {
+	t.Parallel()
+	app := &App{worlds: stubWorlds{names: map[string]bool{"published": true}}}
+	rec := serveWorldRequest(t, app, "/api/v1/tickets?world=published&q=onboarding")
+
+	if rec.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("free-text search under a non-default world must REFUSE, not "+
+			"degrade to default-world hits; got %d %s", rec.Code, rec.Body)
+	}
+}
+
+// TestAttachWorld_UnsupportedRouteRefuses pins the allowlist at the HTTP
+// boundary.
+func TestAttachWorld_UnsupportedRouteRefuses(t *testing.T) {
+	t.Parallel()
+	app := &App{worlds: stubWorlds{names: map[string]bool{"published": true}}}
+	rec := serveWorldRequest(t, app, "/api/v1/tickets/TKT-1/relations?world=published")
+
+	if rec.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("a route that cannot honor a world must refuse; got %d %s",
+			rec.Code, rec.Body)
+	}
+}
+
+// TestAttachWorld_DefaultWorldIsUnaffected is the backward-compatibility
+// guarantee: no `?world=`, or an explicit `?world=default`, behaves exactly
+// as it did before worlds existed — including on routes the allowlist
+// refuses, since those refuse only NON-default worlds.
+func TestAttachWorld_DefaultWorldIsUnaffected(t *testing.T) {
+	t.Parallel()
+	app := &App{worlds: stubWorlds{names: map[string]bool{"published": true}}}
+	for _, path := range []string{
+		"/api/v1/tickets",
+		"/api/v1/tickets?world=default",
+		"/api/v1/_search?q=x",
+		"/api/v1/_search?q=x&world=default",
+		"/api/v1/tickets/TKT-1/relations?world=default",
+	} {
+		rec := serveWorldRequest(t, app, path)
+		if rec.Code != http.StatusOK {
+			t.Errorf("%s: the default world must pass through untouched; got %d %s",
+				path, rec.Code, rec.Body)
+		}
+	}
+}
+
+// TestAttachWorld_NoWorldsWiredRefuses pins that a deployment whose wiring
+// never called SetWorlds cannot acquire the parameter by accident.
+func TestAttachWorld_NoWorldsWiredRefuses(t *testing.T) {
+	t.Parallel()
+	app := &App{} // SetWorlds never called
+	rec := serveWorldRequest(t, app, "/api/v1/tickets?world=published")
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("without SetWorlds every named world is unknown; got %d", rec.Code)
+	}
+}
+
+// TestWorldHandleIsConstructedOnce pins §4.4's handle discipline: what
+// reaches a handler is a fully-constructed handle, not a name it re-resolves.
+// A handle cannot be reinterpreted; a name can, and a trace that flips worlds
+// mid-walk is incoherent.
+func TestWorldHandleIsConstructedOnce(t *testing.T) {
+	t.Parallel()
+	w := worldHandle{name: "published"}
+	if !w.isDefault() {
+		t.Error("a handle carrying only a name has the zero scope and IS the " +
+			"default world — the scope is what reads resolve against")
+	}
+	if got := worldFromContext(context.Background()); !got.isDefault() {
+		t.Error("an unstamped context must be the default world")
+	}
+}
+
+// --- structural guards -------------------------------------------------
+
+// TestGrantCheckPrecedesResolverConstruction is the STRUCTURAL pin for the
+// ordering the whole design turns on: the per-world read grant is checked
+// before any world-resolved read can happen.
+//
+// Behavioral tests alone would stay green for their own fixtures if someone
+// later moved the check into a handler, or reordered the middleware so the
+// world gate ran before the ACL gate was on the context — in which case
+// resolveWorld would consult nopReadGate, whose PermitsWorld returns true,
+// and every world would be permitted regardless of policy.
+//
+// This scans the router source for the two wrap calls and asserts
+// attachWorld is wrapped FIRST. Per the wrap-order note in router.go, the
+// LAST wrap is the OUTERMOST, so wrapping attachWorld first makes it the
+// INNERMOST of the pair and therefore the LATER to run.
+func TestGrantCheckPrecedesResolverConstruction(t *testing.T) {
+	t.Parallel()
+	src, err := os.ReadFile("router.go")
+	if err != nil {
+		t.Fatalf("read router.go: %v", err)
+	}
+	body := string(src)
+	world := strings.Index(body, "handler = attachWorld(")
+	aclWrap := strings.Index(body, "handler = attachACLRequest(")
+	if world < 0 || aclWrap < 0 {
+		t.Fatalf("could not find both wrap sites (attachWorld=%d attachACL=%d) — "+
+			"if these were renamed, update this guard rather than deleting it",
+			world, aclWrap)
+	}
+	if world > aclWrap {
+		t.Error("attachWorld must be wrapped BEFORE attachACLRequest so it runs " +
+			"AFTER it: the world grant check consults readGateFromContext, and " +
+			"reversing this makes it see nopReadGate — which permits every " +
+			"world, silently, regardless of policy")
+	}
+}
+
+// TestWorldCapableRoutesDoNotUseUngatedReader is the guard entityReader's
+// doc comment promises.
+//
+// entityReader is default-world-only by decision. That is safe only while the
+// routes it serves are refused a non-default world. This asserts the two
+// world-capable handlers do not reach it — a world-bound response assembled
+// partly from world-resolved rows and partly from default-state ones is the
+// mixed-face bug that would be hardest to see, because the entity would look
+// right and its neighbors would not.
+func TestWorldCapableRoutesDoNotUseUngatedReader(t *testing.T) {
+	t.Parallel()
+
+	// Every function on a world-capable request's path, not just the two
+	// store helpers. Scanning only the helpers is how the first version of
+	// this guard passed while both world-capable HANDLERS wrapped their
+	// world-resolved rows in default-world relations and neighbors: it
+	// checked a proxy for the design instead of the design.
+	//
+	// A reader reached here must be world-aware, or the call must be
+	// conditional on the default world (which is how the relation reads on
+	// these two handlers are now written — see the worldBound branches).
+	worldCapableFuncs := map[string]bool{
+		"scopedSortedEntities": true,
+		"getWorldEntity":       true,
+		"handleV1ListEntities": true,
+		"handleV1GetEntity":    true,
+		"resolveV1Includes":    true,
+		"computeEntityETag":    true,
+	}
+
+	entries, err := os.ReadDir(".")
+	if err != nil {
+		t.Fatalf("read package dir: %v", err)
+	}
+	fset := token.NewFileSet()
+	var scanned int
+	for _, e := range entries {
+		name := e.Name()
+		if e.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		file, perr := parser.ParseFile(fset, name, nil, 0)
+		if perr != nil {
+			t.Fatalf("parse %s: %v", name, perr)
+		}
+		ast.Inspect(file, func(n ast.Node) bool {
+			fn, ok := n.(*ast.FuncDecl)
+			if !ok || !worldCapableFuncs[fn.Name.Name] {
+				return true
+			}
+			scanned++
+			// A reader call is acceptable only inside a function that also
+			// consults the world — i.e. it is guarded by an
+			// IsDefaultWorld()/blocksAllReads() branch, or the whole
+			// endpoint is refused for a non-default world. Requiring the
+			// world to be MENTIONED is a coarse check, but it is the one
+			// that fails loudly when someone adds an unguarded read.
+			var usesReader, consultsWorld bool
+			ast.Inspect(fn, func(inner ast.Node) bool {
+				switch v := inner.(type) {
+				case *ast.SelectorExpr:
+					if x, ok := v.X.(*ast.SelectorExpr); ok && x.Sel != nil && x.Sel.Name == "reader" {
+						usesReader = true
+					}
+				case *ast.Ident:
+					if v.Name == "worldScopeFrom" || v.Name == "worldFromContext" {
+						consultsWorld = true
+					}
+				}
+				return true
+			})
+			if usesReader && !consultsWorld {
+				t.Errorf("%s (%s) reaches the ungated entityReader without "+
+					"consulting the world. That reader is DEFAULT-WORLD-ONLY, so "+
+					"a world-bound response would pair a resolved entity with "+
+					"draft relations and draft neighbors — the mixed-face bug "+
+					"that reads as correct. Guard the call on "+
+					"worldScopeFrom(ctx).IsDefaultWorld(), or refuse the route.",
+					fn.Name.Name, name)
+			}
+			return false
+		})
+	}
+	// A guard that scanned nothing is not a guard: a rename would otherwise
+	// make this pass silently forever.
+	if scanned != len(worldCapableFuncs) {
+		t.Fatalf("scanned %d of %d world-capable functions — if these were "+
+			"renamed, update this guard rather than letting it go quiet",
+			scanned, len(worldCapableFuncs))
+	}
+}
+
+// --- helpers -----------------------------------------------------------
+
+func serveWorldRequest(t *testing.T, a *App, target string) *httptest.ResponseRecorder {
+	t.Helper()
+	return serveWorldRequestCtx(context.Background(), t, a, target)
+}
+
+// serveWorldRequestCtx runs a request through attachWorld alone, with a
+// terminal handler that reports success. That isolates the middleware's
+// decision from every handler's own behavior, which is what these tests are
+// about.
+func serveWorldRequestCtx(
+	ctx context.Context, t *testing.T, a *App, target string,
+) *httptest.ResponseRecorder {
+	t.Helper()
+	h := attachWorld(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"data":[]}`))
+	}), a)
+	req := httptest.NewRequest(http.MethodGet, target, http.NoBody).WithContext(ctx)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	return rec
+}
+
+// TestWorldListGetParity_ACLGatedPrincipal is the RR-GQWRLD shape.
+//
+// Under a world, the LIST path and the single-entity GET must agree about
+// which face exists. They reach the store by different routes — the list
+// composes a query the ACL layer built, the GET goes through visibleReader —
+// so a world stamped on one and not the other diverges silently.
+//
+// The principal is deliberately ACL-GATED (a policy read grant, so the list
+// takes its GraphQuery branch rather than AllowAll). In Step 2 the equivalent
+// bug was live for an entire review window because the parity test covered
+// only the unrestricted principal, whose reads take the other branch
+// entirely. Testing AllowAll here would pass against the broken code.
+func TestWorldListGetParity_ACLGatedPrincipal(t *testing.T) {
+	app := newTestAppV1(t)
+	ctx := context.Background()
+
+	// TKT-100 has a published face; TKT-200 has only its default (draft)
+	// face, so a world selecting `published` with otherwise:exclude must
+	// drop it entirely.
+	seedEntity(app, &entity.Entity{
+		ID: "TKT-100", Type: "ticket",
+		Properties: map[string]any{"title": "draft face"},
+	})
+	seedEntity(app, &entity.Entity{
+		ID: "TKT-200", Type: "ticket",
+		Properties: map[string]any{"title": "draft only"},
+	})
+	published := entity.Pointer("published")
+	if err := app.store.CreateEntity(ctx, &entity.Entity{
+		ID: "TKT-100", Type: "ticket", Pointer: published,
+		Properties: map[string]any{"title": "published face"},
+	}); err != nil {
+		t.Fatalf("seed published state: %v", err)
+	}
+
+	// An ACL-GATED principal, and the gating must be REAL: the read grant
+	// is conferred by a RELATION, so ReadQuery composes a store.GraphQuery
+	// instead of returning AllowAll. A global assignment would take the
+	// AllowAll branch, which reads the EntityQuery — the wrong half of the
+	// two this test exists to compare (and the blind spot that let the
+	// equivalent Step 2 bug ship: a parity test on the unrestricted
+	// principal passes against the broken code).
+	seedEntity(app, &entity.Entity{
+		ID: "PERSON-1", Type: "feature",
+		Properties: map[string]any{"title": "alice"},
+	})
+	d := mustNewACL(t, &acl.Policy{
+		Roles: map[string]acl.RoleDef{"viewer": {Read: []string{"ticket"}}},
+		RoleRelations: map[string]acl.RoleRelationDef{
+			"owned-by": {Confers: "viewer"},
+		},
+	}, app.store)
+	app.acl = d
+
+	// The conferring edges run FROM alice (readQuery composes HasInbound with
+	// the principal as the endpoint): alice owns both tickets, so both are in her
+	// read scope and the world — not the ACL — is what removes TKT-200.
+	for _, id := range []string{"TKT-100", "TKT-200"} {
+		if _, err := app.store.CreateRelation(ctx, "alice", "owned-by", id, nil); err != nil {
+			t.Fatalf("seed owned-by for %s: %v", id, err)
+		}
+	}
+
+	scope := store.NewWorldScope(map[string]store.TypeResolution{
+		"ticket": {Chain: []entity.Pointer{published}, Fallback: store.FallbackExclude},
+	})
+	req, rerr := d.ForPrincipal(principal.Principal{User: "alice", Tool: principal.ToolDataEntry})
+	if rerr != nil {
+		t.Fatalf("ForPrincipal: %v", rerr)
+	}
+	gate, gerr := newACLReadGate(req)
+	if gerr != nil {
+		t.Fatalf("newACLReadGate: %v", gerr)
+	}
+	// Precondition: the gate must take the QUERY branch, not AllowAll —
+	// otherwise this test silently exercises the wrong path.
+	if rqr := gate.ReadQuery(aliceCtx(), "ticket"); rqr.AllowAll || rqr.Query == nil {
+		t.Fatalf("this test requires an ACL-gated principal whose ReadQuery "+
+			"composes a GraphQuery; got AllowAll=%v Query=%v", rqr.AllowAll, rqr.Query)
+	}
+	wctx := withWorld(withReadGate(aliceCtx(), gate),
+		worldHandle{name: "published", scope: scope})
+
+	// LIST under the world.
+	listed, err := app.scopedSortedEntities(wctx, "ticket", nil)
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	inList := map[string]string{}
+	for _, e := range listed {
+		inList[e.ID], _ = e.Properties["title"].(string)
+	}
+
+	// GET under the same world, for each id.
+	for _, id := range []string{"TKT-100", "TKT-200"} {
+		got, found, gerr := app.visibleReader.getVisible(wctx, "ticket", id)
+		if gerr != nil {
+			t.Fatalf("get %s: %v", id, gerr)
+		}
+		listTitle, inListed := inList[id]
+		if found != inListed {
+			t.Errorf("%s: GET found=%v but list membership=%v — the list and the "+
+				"single-entity path disagree about which faces exist in this world",
+				id, found, inListed)
+			continue
+		}
+		if !found {
+			continue
+		}
+		if title, _ := got.Properties["title"].(string); title != listTitle {
+			t.Errorf("%s: GET served %q but the list served %q — the two paths "+
+				"resolved DIFFERENT faces of the same entity", id, title, listTitle)
+		}
+	}
+
+	// The world's actual content, asserted directly so a parity test that
+	// agreed on the WRONG answer (both serving drafts) still fails.
+	if title := inList["TKT-100"]; title != "published face" {
+		t.Errorf("the world must serve the published face; list gave %q", title)
+	}
+	if _, present := inList["TKT-200"]; present {
+		t.Error("TKT-200 has no published face and `otherwise: exclude` must " +
+			"drop it — existence in a world IS the publication bit")
+	}
+}
+
+// TestAttachWorld_WritesRefuseAWorld pins §9.4's hard rule at the HTTP
+// boundary: worlds are a READ-side decorator, and no write on this API
+// honors one.
+//
+// Without this, `PATCH /api/v1/tickets/TKT-1?world=published` returns 200
+// having edited the DRAFT, and `DELETE ...?world=published` deletes the
+// entity outright while the caller believed they were unpublishing. Both
+// look successful, which is what makes them dangerous — the parameter is
+// accepted, so the caller has no reason to doubt it was honored.
+func TestAttachWorld_WritesRefuseAWorld(t *testing.T) {
+	t.Parallel()
+	app := &App{worlds: stubWorlds{names: map[string]bool{"published": true}}}
+	for _, method := range []string{
+		http.MethodPost, http.MethodPatch, http.MethodPut, http.MethodDelete,
+	} {
+		h := attachWorld(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}), app)
+		req := httptest.NewRequest(method, "/api/v1/tickets/TKT-1?world=published", http.NoBody)
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, req)
+
+		if rec.Code != http.StatusUnprocessableEntity {
+			t.Errorf("%s with ?world= must be refused (worlds are read-only); got %d",
+				method, rec.Code)
+		}
+	}
+	// The same writes without ?world= are untouched.
+	h := attachWorld(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}), app)
+	req := httptest.NewRequest(http.MethodPatch, "/api/v1/tickets/TKT-1", http.NoBody)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Errorf("a write without ?world= must pass through untouched; got %d", rec.Code)
+	}
+}
+
+// TestAttachWorld_IncludeRefusesAWorld pins the neighbor half of the
+// mixed-face problem: `?include=` resolves neighbors through the ungated,
+// default-world reader, so a world-bound response with includes would be a
+// published entity wrapped in draft neighbors.
+func TestAttachWorld_IncludeRefusesAWorld(t *testing.T) {
+	t.Parallel()
+	app := &App{worlds: stubWorlds{names: map[string]bool{"published": true}}}
+	rec := serveWorldRequest(t, app, "/api/v1/tickets/TKT-1?world=published&include=*")
+	if rec.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("?include= under a world must refuse rather than serve draft "+
+			"neighbors alongside a published entity; got %d %s", rec.Code, rec.Body)
+	}
+}
+
+// TestAttachWorld_DuplicateParamRejected pins that `?world=a&world=b` is an
+// error rather than silently resolving to the first value — a client-side
+// param-append bug must not become a silent wrong-face serve.
+func TestAttachWorld_DuplicateParamRejected(t *testing.T) {
+	t.Parallel()
+	app := &App{worlds: stubWorlds{names: map[string]bool{"published": true}}}
+	rec := serveWorldRequest(t, app, "/api/v1/tickets?world=default&world=published")
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("a duplicate ?world= must be rejected, not resolved by a "+
+			"precedence rule nobody would remember; got %d %s", rec.Code, rec.Body)
+	}
+}
+
+// TestWorldGrantCheckThroughTheRealRouter is the BEHAVIORAL half of the
+// ordering guarantee, complementing the source scan above.
+//
+// The source scan asserts wrap order and would be fooled by a refactor that
+// moved either call into a helper. This one goes through the real router
+// with a real Declarative ACL that denies the world, and asserts the denial
+// took effect — which fails if the world gate ever runs before the read gate
+// is on the context, because it would then see nopReadGate and permit
+// everything.
+func TestWorldGrantCheckThroughTheRealRouter(t *testing.T) {
+	app := newTestAppV1(t)
+	seedEntity(app, &entity.Entity{
+		ID: "TKT-900", Type: "ticket", Properties: map[string]any{"title": "draft"},
+	})
+	// A policy granting read on ticket but NO world grant, so `published`
+	// is denied.
+	app.acl = mustNewACL(t, &acl.Policy{
+		Roles:       map[string]acl.RoleDef{"viewer": {Read: []string{"ticket"}}},
+		Assignments: map[string]string{"alice": "viewer"},
+	}, app.store)
+	app.SetWorlds(stubWorlds{
+		names:          map[string]bool{"published": true},
+		resolveDefault: true,
+	})
+	// The router's stamper replaces the ctx principal, so identity has to
+	// arrive the way production supplies it.
+	app.SetPrincipalResolver(func(*http.Request) principal.Principal {
+		return principal.Principal{User: "alice", Tool: principal.ToolDataEntry}
+	})
+
+	req := httptest.NewRequest(http.MethodGet,
+		"/api/v1/tickets?world=published", http.NoBody)
+	rec := httptest.NewRecorder()
+	app.NewRouter().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("a denied world renders as an ordinary empty result; got %d %s",
+			rec.Code, rec.Body)
+	}
+	if strings.Contains(rec.Body.String(), "TKT-900") {
+		t.Error("the principal holds no grant for world:published, so the world " +
+			"gate must have denied it — seeing the entity means the check ran " +
+			"before the read gate was on the context and saw nopReadGate")
+	}
+}


### PR DESCRIPTION
PR-C of the TKT-DN37J2 (ACL world/state grants, Step 3) stack — the PR that ships the capability. **Code-only**; paperwork on the companion PR.

Tickets-PR: #1422

Stack: #1423 (PR-A) ← #1427 (PR-B) ← **this**. Retarget as ancestors merge.

## Why this only lands now

Step 2 deliberately shipped **no** `?world=` parameter. A selectable world without a permission check is a partial feature, and "which faces may I see?" would have become a client decision. Selection therefore arrives here, together with the grant that authorizes it — PR-A's predicates are this PR's precondition, so by construction it cannot ship the capability ungated.

## What lands

- `?world=` parsed once in middleware; a **world-bound reader handle constructed per request** and consumed by the read seams. The handle is fully constructed, not a world *value* travelling as ambient data to be re-resolved per call — that distinction is what §4.4's handle-not-ctx rule is actually about.
- **The grant check runs BEFORE a resolver is constructed**, so an unauthorized world never reaches resolution.
- `EntityQuery.World` populated at the list seam, so the ACL pushdown path (`visibility/pushdown.go`) has a world to stamp onto the composed `GraphQuery`.
- CLI `--world` is **wiring-bound with no grant check**, documented like `db migrate`: the trust boundary there is the operator's shell. MCP gets no per-tool parameter — its read gating is itself still open (TKT-4QSZ8Y).

## Three properties a reviewer should check, all pinned

**1. Denial semantics are deliberately asymmetric.** A **denied** world returns **empty and indistinguishable** from a world with nothing in it — a 403 there is an existence oracle. An **unknown** world returns a **named error** — a config name is not a secret, and naming it is what helps the operator debug a typo. These look inconsistent side by side, which is exactly why both carry the rationale in a comment: someone will otherwise "unify" them.

**2. Search under a non-default world is REFUSED, not silently degraded** (`TestAttachWorld_SearchRefuses`). The index holds default-state documents, so a search box on a published surface would return drafts. Nothing implements world-aware search until Step 5, and — critically — the ACL row gate cannot cover for this, because guard rule 1 makes resolution world-independent: a draft surfacing through search reaches the user unopposed.

**3. List-vs-GET parity under a world, for an ACL-GATED principal** (`TestWorldListGetParity_ACLGatedPrincipal`). This is the RR-GQWRLD shape from Step 2, where reverting the fix failed the composed-query test while the AllowAll test stayed green — a parity test covering only the unrestricted principal would have passed through the entire window that leak was live.

Gates: gofmt, `go build ./...`, `go vet`, arch-lint, and tests across `dataentry`, `acl` and `worldreader` all green.