### PR TITLE
🌍 feat(acl): face-granular write authorization (TKT-C1XUA8 PR-A)

### DIFF
--- a/internal/acl/access.go
+++ b/internal/acl/access.go
@@ -179,8 +179,21 @@ func grantForRole(role RoleDef, verb Verb, entityType string) EveryoneGrant {
 // runtime exactly — no false negatives:
 //
 //   - Write verbs (create/update/delete): an attribution's role grants
-//     the verb via the same grantsVerb the write path uses. The write
-//     path IS this attribution set, so equivalence is by construction.
+//     the verb via grantsVerb, the TYPE-granular predicate.
+//
+//     Equivalence with the runtime is no longer by construction, and the
+//     divergence is deliberate: since TKT-C1XUA8 the write path is
+//     face-granular (decideFromAttrs → GrantsVerbOnState), while this
+//     report has no face in hand — "who can update page?" is a question
+//     about a type. So a role holding ONLY a face-specific grant
+//     (`update: ["page@draft"]`) is not credited here, and this answer is
+//     a LOWER BOUND on write access rather than an exact one.
+//
+//     That is the safe direction for an attestation tool — a false
+//     negative, never a false all-clear — but it is a real limitation, not
+//     a guarantee. A report that names a face is the fix if operators need
+//     one; it needs a pointer threaded through AccessRoutes.
+//
 //   - Read: gated by [Request.PermitsRead] — the actual runtime read
 //     decision. If PermitsRead is false the result is empty; if true,
 //     the returned attributions are those whose role grants read
@@ -214,9 +227,10 @@ func (r *Request) AccessRoutes(
 
 // grantingAttributions filters the per-entity attribution set to those
 // whose role grants verb on entityType, excluding the everyone role.
-// The verb→predicate mapping is the same one the runtime uses
-// (roleGrantsRead / grantsVerb), so the routes it credits are the real
-// reasons access was granted.
+// The verb→predicate mapping matches the runtime for reads; for writes it is
+// the TYPE-granular grantsVerb, so a face-specific grant is not credited.
+// Every route it credits is a real reason access was granted; it may omit a
+// face-specific one. See [Request.AccessRoutes] for why.
 //
 // Create is intentionally computed with the concrete entityID, same as
 // every other write verb — NOT globals-only. This mirrors the production

--- a/internal/acl/authz_write.go
+++ b/internal/acl/authz_write.go
@@ -3,6 +3,8 @@ package acl
 import (
 	"context"
 	"fmt"
+
+	"github.com/Sourcehaven-BV/rela/internal/entity"
 )
 
 // authorizeWrite implements per-Request write authz. v1 only:
@@ -40,7 +42,7 @@ func (r *Request) authorizeEntityWrite(ctx context.Context, op Op, s EntitySubje
 	} else {
 		attrs = r.Globals(ctx).Attributions
 	}
-	return r.decideFromAttrs(attrs, op, s.Type, "no role grants %s on type %q")
+	return r.decideFromAttrs(attrs, op, s.Type, s.Pointer, "no role grants %s on type %q")
 }
 
 func (r *Request) authorizeRelationWrite(ctx context.Context, op Op, s RelationSubject) Decision {
@@ -61,7 +63,12 @@ func (r *Request) authorizeRelationWrite(ctx context.Context, op Op, s RelationS
 	// (consistent with entity create); the To side is not part of
 	// RelationSubject — see that type's godoc for the rationale (RR-F9M9).
 	attrs := r.Globals(ctx).Attributions
-	return r.decideFromAttrs(attrs, op, s.FromType,
+	// Relation writes address the DEFAULT tail today: RelationSubject carries
+	// no pointer, and store.RelationData.FromPointer is consumed by
+	// CreateRelation only. State-tailed relation writes arrive with the copy
+	// kernel; until then the zero pointer here is the accurate statement, not
+	// a placeholder.
+	return r.decideFromAttrs(attrs, op, s.FromType, entity.Pointer(""),
 		"no role grants %s on relations from type %q")
 }
 
@@ -73,7 +80,9 @@ func (r *Request) authorizeRelationWrite(ctx context.Context, op Op, s RelationS
 // both branches so audit consumers can record every (role, source)
 // the resolver considered (AC7). The wire 403 path
 // ([ForbiddenError.Error]) ignores Attributions — only audit reads it.
-func (r *Request) decideFromAttrs(attrs []RoleAttribution, op Op, target, denyFmt string) Decision {
+func (r *Request) decideFromAttrs(
+	attrs []RoleAttribution, op Op, target string, ptr entity.Pointer, denyFmt string,
+) Decision {
 	// The client ceiling is checked before any role, because it can only
 	// remove: if it denies this verb on this type, no role can grant it. The
 	// deny names the ceiling rather than a role, so an operator reading the
@@ -100,7 +109,7 @@ func (r *Request) decideFromAttrs(attrs []RoleAttribution, op Op, target, denyFm
 		if !ok {
 			continue
 		}
-		if grantsVerb(role, op, target) {
+		if GrantsVerbOnState(role, op, target, ptr) {
 			return Decision{
 				Allow:        true,
 				RuleKind:     "role-grant",

--- a/internal/acl/ceilingcompile.go
+++ b/internal/acl/ceilingcompile.go
@@ -324,7 +324,23 @@ func filterTypes(roleTypes []string, v verbCeiling) []string {
 			out = append(out, t)
 			continue
 		}
-		if v.permits(t) {
+		// Match on the TYPE half. A ceiling names entity TYPES, so it
+		// clamps at type granularity and leaves the face to
+		// [GrantsVerbOnState]; comparing the whole literal would drop a
+		// state grant entirely, because "page@draft" never equals "page".
+		//
+		// That failure had an inversion in it worth remembering: the
+		// wildcard branch above returns early, so `update: ["*"]` KEPT the
+		// state grant while the narrower `update: ["page"]` destroyed it —
+		// a grant surviving the broad ceiling and dying under the specific
+		// one. And the resulting denial named the ROLE, not the ceiling,
+		// so an operator reading the audit log was sent to inspect an
+		// acl.yaml whose grant was plainly present.
+		//
+		// Still fail-closed: a DENIAL reaches every face regardless,
+		// because permitsVerb runs before the role loop against the
+		// subject's bare type.
+		if v.permits(grantTypeOf(t)) {
 			out = append(out, t)
 		}
 	}

--- a/internal/acl/pointersubject_test.go
+++ b/internal/acl/pointersubject_test.go
@@ -1,0 +1,345 @@
+package acl_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Sourcehaven-BV/rela/internal/acl"
+	"github.com/Sourcehaven-BV/rela/internal/entity"
+	"github.com/Sourcehaven-BV/rela/internal/principal"
+)
+
+// requestFor opens a Request for alice under the given policy.
+func requestFor(t *testing.T, p *acl.Policy) *acl.Request {
+	t.Helper()
+	if err := p.Validate(); err != nil {
+		t.Fatalf("policy must load: %v", err)
+	}
+	d, err := acl.NewDeclarative(p, acl.NullGraph{}, acl.NullGraphQueryer{})
+	if err != nil {
+		t.Fatalf("NewDeclarative: %v", err)
+	}
+	req, err := d.ForPrincipal(principal.Principal{User: "alice", Tool: "test"})
+	if err != nil {
+		t.Fatalf("ForPrincipal: %v", err)
+	}
+	return req
+}
+
+// TestExistingGrantsUnchangedByPointerField is the CENTERPIECE of this
+// change, and the property that makes it safe to land under every existing
+// caller.
+//
+// [acl.EntitySubject] gained a Pointer, and decideFromAttrs switched from
+// grantsVerb to GrantsVerbOnState. Every existing write site constructs an
+// EntitySubject WITHOUT naming a pointer, so it arrives here as the zero
+// value — the default face. This asserts that such a write gets byte-for-byte
+// the verdict it got before: a bare-type grant still authorizes it, a
+// wildcard still authorizes it, and an unrelated grant still does not.
+//
+// If this ever fails, the change has altered the meaning of grants in every
+// deployed acl.yaml — which is the one thing it must not do.
+func TestExistingGrantsUnchangedByPointerField(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name      string
+		grants    acl.RoleDef
+		op        acl.Op
+		target    string
+		wantAllow bool
+	}{
+		{
+			name:   "bare-type update grant authorizes an unpointered update",
+			grants: acl.RoleDef{Read: []string{"page"}, Update: []string{"page"}},
+			op:     acl.OpUpdate, target: "page", wantAllow: true,
+		},
+		{
+			name:   "wildcard update grant authorizes an unpointered update",
+			grants: acl.RoleDef{Read: []string{"*"}, Update: []string{"*"}},
+			op:     acl.OpUpdate, target: "page", wantAllow: true,
+		},
+		{
+			name:   "a grant on another type does not authorize",
+			grants: acl.RoleDef{Read: []string{"ticket"}, Update: []string{"ticket"}},
+			op:     acl.OpUpdate, target: "page", wantAllow: false,
+		},
+		{
+			name:   "create grant authorizes create",
+			grants: acl.RoleDef{Create: []string{"page"}},
+			op:     acl.OpCreate, target: "page", wantAllow: true,
+		},
+		{
+			name:   "delete grant authorizes delete",
+			grants: acl.RoleDef{Read: []string{"page"}, Delete: []string{"page"}},
+			op:     acl.OpDelete, target: "page", wantAllow: true,
+		},
+		{
+			name:   "rename routes through the update grant",
+			grants: acl.RoleDef{Read: []string{"page"}, Update: []string{"page"}},
+			op:     acl.OpRename, target: "page", wantAllow: true,
+		},
+		{
+			name:   "no grants at all denies",
+			grants: acl.RoleDef{},
+			op:     acl.OpUpdate, target: "page", wantAllow: false,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			req := requestFor(t, &acl.Policy{
+				Roles:       map[string]acl.RoleDef{"r": tc.grants},
+				Assignments: map[string]string{"alice": "r"},
+			})
+			// EntitySubject WITHOUT a Pointer — exactly how every existing
+			// call site constructs it.
+			d := req.AuthorizeWrite(context.Background(), acl.WriteRequest{
+				Op:      tc.op,
+				Subject: acl.EntitySubject{Type: tc.target, ID: "PAGE-1"},
+			})
+			if d.Allow != tc.wantAllow {
+				t.Errorf("Allow = %v, want %v (reason: %s)", d.Allow, tc.wantAllow, d.Reason)
+			}
+		})
+	}
+}
+
+// TestPointerSubjectIsFaceGranular pins the capability the field exists for:
+// a state grant authorizes the face it names and nothing else.
+//
+// This is what makes "a guarded state is writable only via copy definitions"
+// expressible at all — before this, `update: ["page@draft"]` authorized
+// nothing (grantsVerb skipped it) and `update: ["page"]` authorized every
+// face, so there was no way to say "draft yes, published no".
+func TestPointerSubjectIsFaceGranular(t *testing.T) {
+	t.Parallel()
+	draft := entity.Pointer("draft")
+	published := entity.Pointer("published")
+
+	tests := []struct {
+		name      string
+		update    []string
+		read      []string // defaults to ["page"]; the wildcard cases need ["*"]
+		pointer   entity.Pointer
+		wantAllow bool
+	}{
+		{name: "state grant authorizes its own face", update: []string{"page@draft"}, pointer: draft, wantAllow: true},
+		{name: "state grant does NOT authorize a sibling face", update: []string{"page@draft"}, pointer: published, wantAllow: false},
+		{name: "state grant does NOT authorize the default face", update: []string{"page@draft"}, pointer: "", wantAllow: false},
+		{name: "bare grant authorizes the default face", update: []string{"page"}, pointer: "", wantAllow: true},
+		{name: "bare grant does NOT authorize a named face", update: []string{"page"}, pointer: draft, wantAllow: false},
+		{
+			// The invariant the whole feature turns on: nobody holds update
+			// on published by accident. `update: ["*"]` is the grant every
+			// admin policy already has, and it must NOT acquire authority
+			// over every face the moment a type declares pointers.
+			name:   "the wildcard does NOT authorize a named face",
+			update: []string{"*"}, read: []string{"*"},
+			pointer: published, wantAllow: false,
+		},
+		{
+			name:   "the wildcard still authorizes the default face",
+			update: []string{"*"}, read: []string{"*"}, pointer: "", wantAllow: true,
+		},
+		{
+			name:   "both faces granted explicitly",
+			update: []string{"page@draft", "page@published"}, pointer: published, wantAllow: true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			read := tc.read
+			if read == nil {
+				read = []string{"page"}
+			}
+			req := requestFor(t, &acl.Policy{
+				Roles: map[string]acl.RoleDef{
+					"r": {Read: read, Update: tc.update},
+				},
+				Assignments: map[string]string{"alice": "r"},
+			})
+			d := req.AuthorizeWrite(context.Background(), acl.WriteRequest{
+				Op: acl.OpUpdate,
+				Subject: acl.EntitySubject{
+					Type: "page", ID: "PAGE-1", Pointer: tc.pointer,
+				},
+			})
+			if d.Allow != tc.wantAllow {
+				t.Errorf("update %v on face %q: Allow = %v, want %v (reason: %s)",
+					tc.update, tc.pointer, d.Allow, tc.wantAllow, d.Reason)
+			}
+		})
+	}
+}
+
+// TestCeilingStillClampsFaceGranularWrites pins that the client ceiling is
+// consulted before any role, unchanged by the pointer.
+//
+// The ceiling can only ever REMOVE, and it is checked ahead of the role loop
+// precisely so a wildcard grant cannot slip past it. Adding a face dimension
+// must not create a path around that.
+func TestCeilingStillClampsFaceGranularWrites(t *testing.T) {
+	t.Parallel()
+	p := &acl.Policy{
+		Roles: map[string]acl.RoleDef{
+			"r": {Read: []string{"page"}, Update: []string{"page@draft"}},
+		},
+		Assignments: map[string]string{"alice": "r"},
+		ClientBaselines: map[string]acl.ClientBaseline{
+			"app": {
+				AppliesTo:   []string{"app"},
+				Restriction: acl.Restriction{DenyUpdate: []string{"page"}},
+			},
+		},
+	}
+	if err := p.Validate(); err != nil {
+		t.Fatalf("policy must load: %v", err)
+	}
+	d, err := acl.NewDeclarative(p, acl.NullGraph{}, acl.NullGraphQueryer{})
+	if err != nil {
+		t.Fatalf("NewDeclarative: %v", err)
+	}
+	req, err := d.ForPrincipal(principal.VerifiedFrom("alice", "test",
+		principal.Claims{PrincipalType: "app"}))
+	if err != nil {
+		t.Fatalf("ForPrincipal: %v", err)
+	}
+	dec := req.AuthorizeWrite(context.Background(), acl.WriteRequest{
+		Op: acl.OpUpdate,
+		Subject: acl.EntitySubject{
+			Type: "page", ID: "PAGE-1", Pointer: entity.Pointer("draft"),
+		},
+	})
+	if dec.Allow {
+		t.Error("a ceiling denying update on page must deny every FACE of page — " +
+			"the ceiling is checked before any role and can only remove")
+	}
+	if dec.RuleKind != "client-ceiling" {
+		t.Errorf("the denial must name the ceiling, not a role: RuleKind=%q", dec.RuleKind)
+	}
+}
+
+// TestCeilingClampsOnTypeNotLiteral pins the fix for the clamp bug this PR
+// made reachable.
+//
+// A ceiling names entity TYPES. Before the fix, filterTypes compared whole
+// literals, so a state grant ("page@draft") never matched a ceiling entry
+// ("page") and was silently deleted from the role — leaving the face
+// permanently unwritable, with the denial naming the ROLE rather than the
+// ceiling. An operator would inspect an acl.yaml whose grant was plainly
+// present and find nothing wrong with it.
+//
+// The inversion is the part worth remembering: the wildcard branch returns
+// early, so `update: ["*"]` KEPT the state grant while the narrower
+// `update: ["page"]` destroyed it.
+//
+// This was invisible before this PR because grantsVerb skipped state grants
+// anyway. It matters now, and it matters most for the copy kernel, whose
+// whole premise — "published is writable only via copy definitions" — is
+// expressed as a state grant.
+func TestCeilingClampsOnTypeNotLiteral(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name        string
+		restriction acl.Restriction
+		wantAllow   bool
+		wantRule    string
+	}{
+		{
+			name:        "an allowlist naming the type permits its faces",
+			restriction: acl.Restriction{Update: []string{"page"}},
+			wantAllow:   true, wantRule: "role-grant",
+		},
+		{
+			name:        "a wildcard allowlist permits its faces",
+			restriction: acl.Restriction{Update: []string{"*"}},
+			wantAllow:   true, wantRule: "role-grant",
+		},
+		{
+			name:        "a DENIAL on the type reaches every face",
+			restriction: acl.Restriction{DenyUpdate: []string{"page"}},
+			wantAllow:   false, wantRule: "client-ceiling",
+		},
+		{
+			name:        "an allowlist naming another type denies",
+			restriction: acl.Restriction{Update: []string{"ticket"}},
+			wantAllow:   false, wantRule: "client-ceiling",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			p := &acl.Policy{
+				Roles: map[string]acl.RoleDef{
+					"r": {Read: []string{"page"}, Update: []string{"page@draft"}},
+				},
+				Assignments: map[string]string{"alice": "r"},
+				ClientBaselines: map[string]acl.ClientBaseline{
+					"app": {AppliesTo: []string{"app"}, Restriction: tc.restriction},
+				},
+			}
+			if err := p.Validate(); err != nil {
+				t.Fatalf("policy must load: %v", err)
+			}
+			d, err := acl.NewDeclarative(p, acl.NullGraph{}, acl.NullGraphQueryer{})
+			if err != nil {
+				t.Fatalf("NewDeclarative: %v", err)
+			}
+			req, err := d.ForPrincipal(principal.VerifiedFrom("alice", "test",
+				principal.Claims{PrincipalType: "app"}))
+			if err != nil {
+				t.Fatalf("ForPrincipal: %v", err)
+			}
+			dec := req.AuthorizeWrite(context.Background(), acl.WriteRequest{
+				Op: acl.OpUpdate,
+				Subject: acl.EntitySubject{
+					Type: "page", ID: "PAGE-1", Pointer: entity.Pointer("draft"),
+				},
+			})
+			if dec.Allow != tc.wantAllow {
+				t.Errorf("Allow = %v, want %v (reason: %s)", dec.Allow, tc.wantAllow, dec.Reason)
+			}
+			if dec.RuleKind != tc.wantRule {
+				t.Errorf("RuleKind = %q, want %q — a denial must name the layer "+
+					"that actually caused it, or the operator debugs the wrong file",
+					dec.RuleKind, tc.wantRule)
+			}
+		})
+	}
+}
+
+// TestCreateWithoutIDStillAuthorized covers the OTHER branch of
+// authorizeEntityWrite's `s.ID != ""` fork: a create carries no id yet, so it
+// resolves globals-only and never runs the local-role probes.
+//
+// The compatibility test above passes an ID on every case, which means it
+// exercises one of the two branches. This is the one a real create takes.
+func TestCreateWithoutIDStillAuthorized(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name      string
+		create    []string
+		wantAllow bool
+	}{
+		{"bare-type create grant, no id", []string{"page"}, true},
+		{"wildcard create grant, no id", []string{"*"}, true},
+		{"create grant on another type, no id", []string{"ticket"}, false},
+		{"no create grant, no id", nil, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			req := requestFor(t, &acl.Policy{
+				Roles:       map[string]acl.RoleDef{"r": {Create: tc.create}},
+				Assignments: map[string]string{"alice": "r"},
+			})
+			d := req.AuthorizeWrite(context.Background(), acl.WriteRequest{
+				Op:      acl.OpCreate,
+				Subject: acl.EntitySubject{Type: "page"}, // no ID, no Pointer
+			})
+			if d.Allow != tc.wantAllow {
+				t.Errorf("Allow = %v, want %v (reason: %s)", d.Allow, tc.wantAllow, d.Reason)
+			}
+		})
+	}
+}

--- a/internal/acl/policy.go
+++ b/internal/acl/policy.go
@@ -390,22 +390,23 @@ func (r RoleDef) IsPrivileged() bool {
 // routes through Update (it is a modification). Read is handled
 // separately via roleGrantsRead. An unknown op grants nothing.
 //
-// STATE GRANTS GRANT NOTHING HERE, deliberately, and this is the
-// fail-closed half of a two-part change.
+// STATE GRANTS GRANT NOTHING HERE, deliberately.
 //
-// This function IS the live write-authorization path (decideFromAttrs in
-// authz_write.go, which knows the entity type but not yet which FACE is
-// being written). [GrantsVerbOnState] is the face-granular check, and it
-// has no production caller until the write path learns to pass a pointer.
+// This is the TYPE-granular question — "may this role write this type at
+// all" — and its remaining callers ask exactly that: the provisioner
+// create-check ([Policy.principalGrantsCreate]) and the who-can reporting
+// in access.go, both of which report per type and have no face in hand.
 //
-// So if a state-shaped entry matched here on its type half, `update:
-// ["page@draft"]` — the NARROWEST grant the new syntax offers — would
-// authorize writing page's DEFAULT face, which is more authority than the
-// operator wrote and more than they had before. A grant must never widen
-// by being made more specific. Until the write path is face-aware, a
-// state-shaped grant authorizes nothing at all; that direction costs an
-// operator a denied write they must then ask about, rather than a silent
-// over-permit nobody notices.
+// It is NO LONGER the write-authorization path. Since TKT-C1XUA8,
+// decideFromAttrs calls [GrantsVerbOnState] with the subject's pointer, so
+// the live path is face-granular and a state grant authorizes exactly the
+// face it names.
+//
+// A state-shaped entry is skipped rather than matched on its type half,
+// because matching would answer "yes" to a question about the DEFAULT face
+// on the strength of a grant that names only `page@draft` — a grant
+// widening by being made more specific. Skipping keeps this function's
+// answer a lower bound: everything it grants is genuinely granted.
 func grantsVerb(role RoleDef, op Op, target string) bool {
 	var list []string
 	switch op {
@@ -987,8 +988,10 @@ func (p *Policy) validateProvisionerGrant(userType string) error {
 
 // principalGrantsCreate reports whether principalUser is assigned — via
 // `assignments` or `asserted_role_assignments` — a defined role that grants
-// create on target. Mirrors the resolution grantsVerb performs at write time,
-// but for the single provisioner-load check.
+// create on target. Type-granular, which is the right question here: the
+// provisioner creates DEFAULT-face user entities, and a face-specific grant
+// would not be one it could act on. (The write path itself became
+// face-granular in TKT-C1XUA8; this deliberately did not.)
 func (p *Policy) principalGrantsCreate(principalUser, target string) bool {
 	roleGrants := func(roleName string) bool {
 		role, ok := p.Roles[roleName]

--- a/internal/acl/subject.go
+++ b/internal/acl/subject.go
@@ -1,5 +1,7 @@
 package acl
 
+import "github.com/Sourcehaven-BV/rela/internal/entity"
+
 // Subject is what's being written. Sealed: only EntitySubject and
 // RelationSubject implement it (via the unexported isSubject method).
 // The sum exists so RelationSubject can carry both endpoints
@@ -9,9 +11,11 @@ package acl
 // The sealed sum, visually:
 //
 //	Subject (sealed)
-//	├── EntitySubject   { Type, ID }
+//	├── EntitySubject   { Type, ID, Pointer }
+//	│                   (Pointer zero = default face)
 //	│       used for: Create / Update / Delete / Rename of an entity
 //	└── RelationSubject { Type, FromType, FromID }
+//	                    (default tail only — see authorizeRelationWrite)
 //	        used for: Create / Delete of a relation
 //
 // A nil Subject is a programmer error. AuthorizeWrite panics so the
@@ -28,6 +32,23 @@ type Subject interface{ isSubject() }
 type EntitySubject struct {
 	Type string
 	ID   string
+
+	// Pointer names the CONTENT STATE (face) being written; the zero value
+	// is the default state (TKT-C1XUA8).
+	//
+	// The zero value is what makes this field safe to add under every
+	// existing caller: a write that does not name a face addresses the
+	// default one, and [GrantsVerbOnState] treats a bare-type grant as
+	// covering exactly that. So every grant in every existing acl.yaml
+	// keeps its meaning, which is the property
+	// TestExistingGrantsUnchangedByPointerField pins.
+	//
+	// Why the subject and not the Op: a copy is not a new verb (the copy's
+	// own guard is the real gate), and adding one would need grant syntax
+	// nobody has asked for in four switch sites. What changes between
+	// writing a draft and writing a published face is WHICH FACE, which is
+	// a property of the subject.
+	Pointer entity.Pointer
 }
 
 func (EntitySubject) isSubject() {}


### PR DESCRIPTION
PR-A of the TKT-C1XUA8 (copy kernel, Step 4) stack — the prerequisite everything else rests on. **Code-only**; paperwork on the companion PR.

Tickets-PR: #1422

Stack: Step 3's #1423 ← #1427 ← #1428 ← **this**. Retarget as ancestors merge.

## Why this lands first

The write-authorization path has been structurally **face-blind**: `acl.EntitySubject` was `{Type, ID}` with no pointer, so `decideFromAttrs` could not tell which *face* of an entity a write targeted. That is why Step 3 (#1423) made state-shaped write grants authorize **nothing** — `grantsVerb` skips them deliberately, fail-closed, and `acl.GrantsVerbOnState` shipped with **zero production callers, waiting for exactly this PR**.

Making `policy@published` writable-only-via-copy-definitions requires the write path to know which face it is authorizing. This PR closes that half.

## What lands

- `EntitySubject` gains `Pointer`; `decideFromAttrs` routes through `GrantsVerbOnState`, which now has its production caller (`authz_write.go:112`).
- The client ceiling still clamps face-granular writes, and clamps **on the type, not the literal grant string** — otherwise a `page@draft` grant would compare as an opaque literal and drop out of a ceiling written in terms of `page`.

## The centrepiece property

**Every existing write behaves identically.** A zero pointer means the default face, so all current call sites — none of which know about faces — authorize exactly as before. That is what makes this safe to land underneath the entire existing write path, and it is pinned first in the file:

- `TestExistingGrantsUnchangedByPointerField`
- `TestPointerSubjectIsFaceGranular`
- `TestCeilingStillClampsFaceGranularWrites`
- `TestCeilingClampsOnTypeNotLiteral`
- `TestCreateWithoutIDStillAuthorized`

Same shape as the zero-value `WorldScope` compatibility pin in Step 1: the new axis is invisible until something opts into it.

Gates: gofmt, `go build ./...`, arch-lint, and tests across `acl`, `aclaudit`, `entitymanager` and `dataentry` all green.