### PR TITLE
🌍 feat(pgstore): per-state content versioning (TKT-C1XUA8 PR-B)

### DIFF
--- a/internal/appbuild/appbuild.go
+++ b/internal/appbuild/appbuild.go
@@ -1398,6 +1398,7 @@ type versionRecorder struct {
 func (r versionRecorder) RecordVersion(ctx context.Context, v entitymanager.VersionRecord) error {
 	return r.w.WriteVersion(ctx, store.VersionInput{
 		EntityID:      v.EntityID,
+		Pointer:       v.Pointer,
 		Op:            v.Op,
 		PrevID:        v.PrevID,
 		Type:          v.Type,

--- a/internal/entitymanager/version_hook.go
+++ b/internal/entitymanager/version_hook.go
@@ -33,7 +33,10 @@ type VersionRecorder interface {
 // the rename predecessor id (rename only), attribution, and the render-schema
 // projection the snapshot was taken under.
 type VersionRecord struct {
-	EntityID      string
+	EntityID string
+	// Pointer is the content state (face) this record captures; zero is the
+	// default face (TKT-C1XUA8).
+	Pointer       entity.Pointer
 	Op            store.VersionOp
 	PrevID        string // rename only: the entity's former id
 	Type          string
@@ -55,15 +58,10 @@ func (m *Manager) recordEntityVersion(ctx context.Context, op store.VersionOp, e
 	if m.deps.VersionRecorder == nil {
 		return
 	}
-	// DELIBERATE SKIP (2026-08-20, TKT-DOFYR1): default-world versioning
-	// in Step 1 — entity_versions keys (entity_id, vseq), so a state
-	// capture would interleave the family's faces in one lineage. The
-	// manager only writes default states today; this is the defensive
-	// mirror of the sweep's pointer = '' scope. TKT-C1XUA8 (Step-4 copy
-	// kernel) owns per-state history.
-	if !e.Pointer.IsDefault() {
-		return
-	}
+	// PER-STATE (TKT-C1XUA8): the Step-1 skip is gone. entity_versions now
+	// keys (entity_id, pointer, vseq), so a state capture gets its own
+	// lineage instead of interleaving with the family's other faces, and
+	// the pointer travels on the record below.
 	proj := m.deps.Meta.RenderProjection()
 	projJSON, err := proj.JSON()
 	if err != nil {
@@ -74,6 +72,7 @@ func (m *Manager) recordEntityVersion(ctx context.Context, op store.VersionOp, e
 	p := principal.From(ctx)
 	rec := VersionRecord{
 		EntityID:      e.ID,
+		Pointer:       e.Pointer,
 		Op:            op,
 		PrevID:        prevID,
 		Type:          e.Type,
@@ -133,14 +132,21 @@ func (m *Manager) recordRelationVersion(
 	if m.deps.RelationVersionRecorder == nil {
 		return
 	}
-	// DELIBERATE SKIP (2026-08-20, TKT-DOFYR1): content versioning
-	// captures the DEFAULT world in Step 1; a state-tailed edge has its
-	// own rel_record_id and no history yet, and capturing it here would
-	// fail the default-tail record lookup and pre-commit per-state
-	// history's shape. One skip for every capture path (cascade delete,
-	// rename stitch, explicit delete); the entitymanager cannot write
-	// state-tailed edges today, so this is defensive against future
-	// direct callers. TKT-C1XUA8 (Step-4 copy kernel) owns the design.
+	// STILL SKIPPED, and now for a narrower reason (TKT-C1XUA8).
+	//
+	// TKT-C1XUA8 gave state-tailed edges their own history — the SWEEP
+	// captures them, because it reads rel_record_id straight off the row.
+	// This SYNCHRONOUS path cannot: the record it builds carries the
+	// (from, type, to) TRIPLE, and the store resolves that to a lineage via
+	// recordIDForKey, which answers with the DEFAULT tail by design (a key
+	// with no face names the default face). Capturing a state-tailed edge
+	// here would therefore file it under the default tail's lineage — the
+	// interleaving the whole per-state design exists to prevent.
+	//
+	// Lifting this needs the record to carry a rel_record_id (or a tail) so
+	// the store can address the right lineage. Until then the sync path —
+	// rename stitch and pre-delete capture — is default-tail only, and a
+	// state edge's delete is captured by the entity cascade instead.
 	if !r.FromPointer.IsDefault() {
 		return
 	}

--- a/internal/store/pgstore/migrations/0012_per_state_versions.sql
+++ b/internal/store/pgstore/migrations/0012_per_state_versions.sql
@@ -1,0 +1,70 @@
+-- pgstore schema, version 12: per-state content versioning (TKT-C1XUA8).
+--
+-- Step 1 (TKT-DOFYR1) captured the DEFAULT face only, in four deliberate
+-- skips: the two version hooks and the two sweep candidate scans. The
+-- reason each gave was the same — entity_versions keys (entity_id, vseq),
+-- so capturing a state row would interleave a family's faces in ONE
+-- lineage, which is actively corrupt history that purge would then have to
+-- fence. Per-state history was to be designed WITH its consumer.
+--
+-- This is that consumer's migration. The Step-4 copy kernel is the first
+-- thing in the system that writes a non-default face, so without per-state
+-- history a promoted face would have NO history at all — worse than the
+-- skip, which is at least honest about its scope.
+--
+-- Every existing row is already its own default state, so '' NOT NULL
+-- rewrites no data — the same property that made 0011 free, and the same
+-- one-convention-everywhere rule: Go zero value, omitted frontmatter key,
+-- '' column. COLLATE "C" matches entity_versions.entity_id; the lineage
+-- CTE's two recursive terms must agree on collation or Postgres raises
+-- 42P21, and the pointer now participates in that walk.
+
+-- entity_versions: the face joins the lineage key.
+ALTER TABLE entity_versions ADD COLUMN pointer TEXT COLLATE "C" NOT NULL DEFAULT '';
+ALTER TABLE entity_versions DROP CONSTRAINT entity_versions_pkey;
+ALTER TABLE entity_versions ADD PRIMARY KEY (entity_id, pointer, vseq);
+
+-- relation_versions: the state-specific TAIL joins it, mirroring the
+-- relations table (§2.3 — heads stay entity-level, so there is deliberately
+-- no to_pointer here either).
+--
+-- Relations need this even though rel_record_id already fences lineages
+-- per row: the rename STITCH matches a predecessor by the old triple
+-- (prev_from, rel_type, prev_to), which cannot tell a state-tailed edge
+-- from a default-tail one. Without the column, a state edge's stitch would
+-- merge it with the default face's lineage — the exact interleaving the
+-- entity skip existed to prevent, arriving through the relation door.
+ALTER TABLE relation_versions ADD COLUMN from_pointer TEXT COLLATE "C" NOT NULL DEFAULT '';
+
+-- The sweep's per-entity probes are index-only LIMIT 1 lookups (see
+-- 0004_versions.sql). Once state rows are in the table an (entity_id, vseq)
+-- index no longer serves them: the probe asks for the latest version of ONE
+-- FACE, and would have to scan and discard every sibling face's rows.
+-- Rebuilt rather than added alongside, because the old shape is a strict
+-- prefix of the new one and keeping both would pay double write cost for a
+-- lookup the new index already serves.
+--
+-- LOCK NOTE: a non-concurrent CREATE INDEX inside the migration's
+-- transaction takes an ACCESS EXCLUSIVE lock on the table. Apply over a
+-- large dataset in a maintenance window.
+DROP INDEX entity_versions_latest_idx;
+CREATE INDEX entity_versions_latest_idx
+    ON entity_versions (entity_id, pointer, vseq DESC);
+
+-- The lineage CTE resolves a rename boundary with
+--   SELECT max(vseq) ... WHERE prev_id = $1 AND op = 'rename'
+-- and that subselect must now be scoped to the face, or one face's rename
+-- would set another face's fence. Widening the index keeps it a lookup
+-- rather than a scan over every face that ever carried the id.
+DROP INDEX entity_versions_prev_id_idx;
+CREATE INDEX entity_versions_prev_id_idx
+    ON entity_versions (prev_id, pointer) WHERE prev_id IS NOT NULL;
+
+-- The relation rename stitch and the key->lineage resolution both match by
+-- triple, and there is no index for that today (0005 indexed only
+-- (rel_record_id, vseq DESC), which serves the per-lineage read but not the
+-- by-triple lookup). Adding it now rather than later because the tail turns
+-- those queries from "scan the triple's rows" into "scan every face's rows
+-- for the triple" — a new index, not a rebuild.
+CREATE INDEX relation_versions_triple_idx
+    ON relation_versions (from_id, from_pointer, rel_type, to_id, vseq DESC);

--- a/internal/store/pgstore/purge.go
+++ b/internal/store/pgstore/purge.go
@@ -8,6 +8,7 @@ import (
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 
+	"github.com/Sourcehaven-BV/rela/internal/entity"
 	"github.com/Sourcehaven-BV/rela/internal/store"
 )
 
@@ -56,16 +57,17 @@ func (v *VersionStore) PurgeVersions(ctx context.Context, req store.VersionPurge
 	defer advisoryUnlock(context.WithoutCancel(ctx), conn, sweepAdvisoryLockKey)
 
 	// Resolve the target lineage ids (fenced) and the current live content hash.
-	ids, err := v.entityLineageIDsForPurge(ctx, conn, req.EntityID)
+	ids, err := v.entityLineageIDsForPurge(ctx, conn, req.EntityID, req.Pointer)
 	if err != nil {
 		return nil, err
 	}
-	liveHash, liveExists, err := v.liveEntityHash(ctx, conn, req.EntityID)
+	liveHash, liveExists, err := v.liveEntityHash(ctx, conn, req.EntityID, req.Pointer)
 	if err != nil {
 		return nil, err
 	}
 
-	targets, err := selectPurgeTargets(ctx, conn, entityPurgeQ, ids, req.Selector)
+	targets, err := selectPurgeTargets(ctx, conn, entityPurgeQ,
+		[]any{ids, string(req.Pointer)}, req.Selector)
 	if err != nil {
 		return nil, err
 	}
@@ -92,7 +94,7 @@ func (v *VersionStore) PurgeVersions(ctx context.Context, req store.VersionPurge
 	// does not re-capture the live content (its content_hash = the live hash
 	// dedups against the sweep's lvc probe).
 	if liveExists && req.ForceLive {
-		if err := writeEntityPurgeTombstone(ctx, conn, req.EntityID, liveHash); err != nil {
+		if err := writeEntityPurgeTombstone(ctx, conn, req.EntityID, req.Pointer, liveHash); err != nil {
 			return nil, err
 		}
 		res.TombstoneWritten = true
@@ -144,7 +146,7 @@ func (v *VersionStore) PurgeRelationVersions(
 		return nil, err
 	}
 
-	targets, err := selectPurgeTargets(ctx, conn, relationPurgeQ, ids, req.Selector)
+	targets, err := selectPurgeTargets(ctx, conn, relationPurgeQ, []any{ids}, req.Selector)
 	if err != nil {
 		return nil, err
 	}
@@ -276,9 +278,11 @@ func anyRename(targets []store.PurgeTarget) bool {
 // lineage as a slice usable in `entity_id = ANY($1)`. It reuses lineageCTE so
 // --all matches exactly what ListVersions shows and never spills into a reused
 // id's rows. Returns just the queried id if it has no rename ancestry.
-func (v *VersionStore) entityLineageIDsForPurge(ctx context.Context, q DBTX, id string) ([]string, error) {
+func (v *VersionStore) entityLineageIDsForPurge(
+	ctx context.Context, q DBTX, id string, p entity.Pointer,
+) ([]string, error) {
 	sel := lineageCTE + ` SELECT entity_id FROM lin`
-	rows, err := q.Query(ctx, sel, id)
+	rows, err := q.Query(ctx, sel, id, string(p))
 	if err != nil {
 		return nil, err
 	}
@@ -300,18 +304,25 @@ func (v *VersionStore) entityLineageIDsForPurge(ctx context.Context, q DBTX, id 
 	return ids, nil
 }
 
-func (v *VersionStore) liveEntityHash(ctx context.Context, q DBTX, id string) (hash string, exists bool, err error) {
+func (v *VersionStore) liveEntityHash(
+	ctx context.Context, q DBTX, id string, p entity.Pointer,
+) (hash string, exists bool, err error) {
 	e, gErr := scanEntity(q.QueryRow(ctx,
 		`SELECT id, type, pointer, properties, content, updated_at
-		 FROM entities WHERE id = $1 AND pointer = ''`, id))
+		 FROM entities WHERE id = $1 AND pointer = $2`, id, string(p)))
 	if errors.Is(gErr, pgx.ErrNoRows) {
 		return "", false, nil
 	}
 	if gErr != nil {
 		return "", false, gErr
 	}
+	// The pointer MUST travel into the hash: contentHashOf folds it in, so
+	// omitting it here would make a ForceLive tombstone on one face carry a
+	// hash that matches a SIBLING face holding identical bytes — suppressing
+	// that sibling's legitimate sweep capture (TKT-C1XUA8).
 	return contentHashOf(store.VersionInput{
-		EntityID: e.ID, Type: e.Type, Content: e.Content, Properties: e.Properties,
+		EntityID: e.ID, Pointer: e.Pointer, Type: e.Type,
+		Content: e.Content, Properties: e.Properties,
 	}), true, nil
 }
 
@@ -334,11 +345,14 @@ func (v *VersionStore) liveRelationHash(
 
 // entityPurgeQ / relationPurgeQ select the resolvable target metadata (never the
 // snapshot content) for a lineage id-set, applying the selector. `$1` is the
-// id-set (ANY), the selector's vseq/content-hash are appended as $2.
+// id-set (ANY) and, for entities, $2 is the FACE — purge is scoped to one
+// face, so a --content-hash purge cannot reach into a sibling face that
+// happens to hold the same bytes. The selector's vseq/content-hash is
+// appended as the next free placeholder.
 const entityPurgeQ = `
 	SELECT vseq, op, content_hash, created_at
 	FROM entity_versions
-	WHERE entity_id = ANY($1)`
+	WHERE entity_id = ANY($1) AND pointer = $2`
 const relationPurgeQ = `
 	SELECT vseq, op, content_hash, created_at
 	FROM relation_versions
@@ -348,18 +362,19 @@ const relationPurgeQ = `
 // It never selects content. idSet is []string for entities, []int64 for
 // relations — passed through as `ANY`.
 func selectPurgeTargets(
-	ctx context.Context, q DBTX, baseQ string, idSet any, sel store.PurgeSelector,
+	ctx context.Context, q DBTX, baseQ string, baseArgs []any, sel store.PurgeSelector,
 ) ([]store.PurgeTarget, error) {
 	query := baseQ
-	args := []any{idSet}
+	args := append([]any(nil), baseArgs...)
+	next := fmt.Sprintf("$%d", len(args)+1)
 	switch {
 	case sel.All:
 		// no extra predicate — whole fenced lineage
 	case sel.Vseq != 0:
-		query += ` AND vseq = $2`
+		query += ` AND vseq = ` + next
 		args = append(args, sel.Vseq)
 	case sel.ContentHash != "":
-		query += ` AND content_hash = $2`
+		query += ` AND content_hash = ` + next
 		args = append(args, sel.ContentHash)
 	default:
 		return nil, errors.New("pgstore: purge selector must set one of Vseq / ContentHash / All")
@@ -413,16 +428,18 @@ func deletePurgeTargets(
 // equals the live hash, so the sweep's dedup (lvc.content_hash == live hash)
 // suppresses re-capture until the live value genuinely changes. Needs a
 // schema_hash for the FK; reuse a stable sentinel projection row.
-func writeEntityPurgeTombstone(ctx context.Context, q DBTX, id, liveHash string) error {
+func writeEntityPurgeTombstone(
+	ctx context.Context, q DBTX, id string, p entity.Pointer, liveHash string,
+) error {
 	if err := ensureSchemaVersion(ctx, q, purgeSchemaHash, purgeSchemaProjection); err != nil {
 		return err
 	}
 	_, err := q.Exec(ctx, `
 		INSERT INTO entity_versions
-		    (entity_id, op, type, content, properties, content_hash, schema_hash,
-		     principal_user, principal_tool, triggered_by)
-		VALUES ($1, 'purge', '', '', '{}'::jsonb, $2, $3, '', 'version-purge', '')`,
-		id, liveHash, purgeSchemaHash)
+		    (entity_id, pointer, op, type, content, properties, content_hash,
+		     schema_hash, principal_user, principal_tool, triggered_by)
+		VALUES ($1, $2, 'purge', '', '', '{}'::jsonb, $3, $4, '', 'version-purge', '')`,
+		id, string(p), liveHash, purgeSchemaHash)
 	return err
 }
 

--- a/internal/store/pgstore/relation_version.go
+++ b/internal/store/pgstore/relation_version.go
@@ -65,12 +65,14 @@ func insertRelationVersion(ctx context.Context, q DBTX, in store.RelationVersion
 	}
 	const ins = `
 		INSERT INTO relation_versions
-		    (rel_record_id, op, from_id, rel_type, to_id, prev_from, prev_to,
+		    (rel_record_id, op, from_id, from_pointer, rel_type, to_id,
+		     prev_from, prev_to,
 		     content, properties, content_hash, schema_hash,
 		     principal_user, principal_tool, triggered_by)
-		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)`
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15)`
 	_, err = q.Exec(ctx, ins,
-		in.RecordID, string(in.Op), in.From, in.Type, in.To, prevFrom, prevTo,
+		in.RecordID, string(in.Op), in.From, string(in.FromPointer), in.Type, in.To,
+		prevFrom, prevTo,
 		in.Content, props, contentHash, in.SchemaHash,
 		in.PrincipalUser, in.PrincipalTool, in.TriggeredBy)
 	return err
@@ -133,6 +135,7 @@ func (v *VersionStore) relationLineageIDs(ctx context.Context, headID int64) ([]
 			    SELECT rv.rel_record_id
 			    FROM relation_versions rv
 			    WHERE rv.from_id = ren.prev_from
+			      AND rv.from_pointer = ren.from_pointer
 			      AND rv.rel_type = ren.rel_type
 			      AND rv.to_id   = ren.prev_to
 			      AND rv.vseq < ren.vseq
@@ -179,10 +182,15 @@ func (v *VersionStore) relationLineageIDs(ctx context.Context, headID int64) ([]
 // rel_record_id whose latest row still carries this (from,type,to). Returns
 // (0, ErrNotFound) when the key has no live row and no history.
 func (v *VersionStore) recordIDForKey(ctx context.Context, from, relType, to string) (int64, error) {
-	// Live row first. from_pointer = '': relation versioning captures the
-	// DEFAULT world in Step 1 (TKT-DOFYR1) — a state-tailed sibling of the
-	// triple is a different edge with its own rel_record_id and no history
-	// yet.
+	// Live row first, DEFAULT TAIL ONLY — and that is still right after
+	// TKT-C1XUA8 gave state-tailed edges their own history.
+	//
+	// This resolves a (from, type, to) KEY to a lineage, and the key is what
+	// a caller who did not name a face is asking about. A state-tailed
+	// sibling of the same triple is a DIFFERENT edge with its own
+	// rel_record_id; answering with it would silently redirect a
+	// default-tail question to another face. A face-aware caller resolves
+	// its own record id and passes it directly.
 	const live = `SELECT rel_record_id FROM relations
 	              WHERE from_id = $1 AND rel_type = $2 AND to_id = $3 AND from_pointer = ''`
 	var id int64
@@ -205,6 +213,7 @@ func (v *VersionStore) recordIDForKey(ctx context.Context, from, relType, to str
 		    FROM relation_versions GROUP BY rel_record_id
 		) latest ON latest.rel_record_id = rv.rel_record_id AND latest.vseq = rv.vseq
 		WHERE rv.from_id = $1 AND rv.rel_type = $2 AND rv.to_id = $3
+		  AND rv.from_pointer = ''
 		ORDER BY rv.vseq DESC
 		LIMIT 1`
 	err = v.db.QueryRow(ctx, dead, from, relType, to).Scan(&id)

--- a/internal/store/pgstore/states_versioning_test.go
+++ b/internal/store/pgstore/states_versioning_test.go
@@ -12,16 +12,21 @@ import (
 	"github.com/Sourcehaven-BV/rela/internal/store/pgstore"
 )
 
-// These tests pin the Step-1 default-world versioning scope (TKT-DOFYR1,
-// architect-signed): the sweep's `pointer = ''` / `from_pointer = ''`
-// skips are DELIBERATE — a state capture under the bare-id lineage would
-// interleave a family's faces (corrupt history purge would have to
-// fence), and per-state history is designed with its consumer, the
-// Step-4 copy kernel (TKT-C1XUA8).
+// These tests were written to pin the Step-1 default-world versioning scope
+// (TKT-DOFYR1): the sweep's `pointer = ''` / `from_pointer = ''` skips.
+// TKT-C1XUA8 removed those skips and gave each face its own lineage, so the
+// tests now pin the property the skips were PROTECTING rather than the skips
+// themselves — faces must not interleave in one history.
+//
+// That is the invariant worth keeping either way. Under the old skip it held
+// because state rows were never captured; it now holds because
+// entity_versions keys (entity_id, pointer, vseq) and every probe is
+// face-scoped. A regression in the SQL scoping would show up here as a face's
+// rows appearing in a sibling's timeline.
 
-// TestSweep_SkipsStateRows: a settled STATE row mints no version; its
-// settled default face still does — the bare-id lineage stays pure.
-func TestSweep_SkipsStateRows(t *testing.T) {
+// TestSweep_CapturesEachFaceInItsOwnLineage: both faces are captured, and
+// neither appears in the other's history.
+func TestSweep_CapturesEachFaceInItsOwnLineage(t *testing.T) {
 	pool := newScopedPool(t)
 	s, err := pgstore.New(pool)
 	require.NoError(t, err)
@@ -42,26 +47,52 @@ func TestSweep_SkipsStateRows(t *testing.T) {
 	s.StartVersionSweep(stubProvider{hash: "schema-abc", json: []byte(`{"entities":{},"types":{}}`)},
 		pgstore.SweepConfig{Interval: 50 * time.Millisecond, Idle: time.Minute, MaxStaleness: time.Hour, Batch: 100})
 
-	// The default face is captured exactly once…
-	require.Eventually(t, func() bool {
-		metas, e := s.VersionStore().ListVersions(ctx, "PAGE-1")
-		return e == nil && len(metas) == 1
-	}, 3*time.Second, 25*time.Millisecond, "default face should be captured once")
+	// The concrete VersionStore already carries the face-aware methods; the
+	// assertion is that it satisfies the optional store capability, which is
+	// how a consumer reaches them.
+	var sh store.StateHistoryReader = s.VersionStore()
 
-	// …and STAYS at one: the draft row must never join the lineage. A
-	// second interval's worth of ticks would have captured it if the
-	// skip were missing (its content differs from the captured hash).
+	// Both faces are captured, each exactly once.
+	require.Eventually(t, func() bool {
+		def, e1 := s.VersionStore().ListVersions(ctx, "PAGE-1")
+		dr, e2 := sh.ListStateVersions(ctx, "PAGE-1", p)
+		return e1 == nil && e2 == nil && len(def) == 1 && len(dr) == 1
+	}, 3*time.Second, 25*time.Millisecond, "each face should be captured once")
+
+	// And they STAY separate. A second interval's worth of ticks would
+	// re-capture if a face's dedup probe were reading a sibling's hash, and
+	// a face's row appearing in the other's timeline is the interleaving the
+	// Step-1 skip existed to prevent.
 	time.Sleep(300 * time.Millisecond)
-	metas, err := s.VersionStore().ListVersions(ctx, "PAGE-1")
+
+	def, err := s.VersionStore().ListVersions(ctx, "PAGE-1")
 	require.NoError(t, err)
-	require.Len(t, metas, 1, "a state row must not mint a version under the bare-id lineage")
+	require.Len(t, def, 1, "the default face's lineage must hold only its own row")
+
+	dr, err := sh.ListStateVersions(ctx, "PAGE-1", p)
+	require.NoError(t, err)
+	require.Len(t, dr, 1, "the draft face's lineage must hold only its own row")
+
+	// The snapshots must be the faces' OWN content — the sharpest way to
+	// catch a lineage that resolved to the wrong face.
+	defSnap, err := s.VersionStore().GetVersion(ctx, "PAGE-1", 1)
+	require.NoError(t, err)
+	require.Equal(t, "default face", defSnap.Content)
+
+	drSnap, err := sh.GetStateVersion(ctx, "PAGE-1", p, 1)
+	require.NoError(t, err)
+	require.Equal(t, "draft face", drSnap.Content)
 }
 
-// TestSweep_SkipsStateTailedRelations: a settled state-tailed edge mints
-// no relation version, while the default-tail edge of the SAME triple
-// does — and the two edges hold distinct rel_record_ids, so lineages
-// could never merge even without the skip.
-func TestSweep_SkipsStateTailedRelations(t *testing.T) {
+// TestSweep_CapturesStateTailedRelations: both tails of the SAME triple mint
+// their own relation versions, into distinct rel_record_id lineages that
+// could never merge.
+//
+// The tail is nonetheless recorded on each version row, because the rename
+// stitch matches a predecessor by (prev_from, rel_type, prev_to) and without
+// the tail could not tell a state-tailed predecessor from a default-tail one
+// holding the same triple.
+func TestSweep_CapturesStateTailedRelations(t *testing.T) {
 	pool := newScopedPool(t)
 	s, err := pgstore.New(pool)
 	require.NoError(t, err)
@@ -112,13 +143,108 @@ func TestSweep_SkipsStateTailedRelations(t *testing.T) {
 		return e == nil && len(metas) == 1
 	}, 3*time.Second, 25*time.Millisecond, "default-tail edge should be captured")
 
-	// …and the state-tailed edge's record holds NO versions after
-	// further ticks.
+	// …and so is the state-tailed edge, into its OWN lineage. Each tail has
+	// its own rel_record_id, so the two could never merge — what the
+	// from_pointer column buys is the rename STITCH being able to tell them
+	// apart when it matches a predecessor by triple.
 	time.Sleep(300 * time.Millisecond)
+
 	var stateVersions int
 	require.NoError(t, pool.QueryRow(ctx,
 		`SELECT count(*) FROM relation_versions WHERE rel_record_id = (
 		   SELECT rel_record_id FROM relations
 		   WHERE from_id = 'PAGE-2' AND from_pointer = 'draft')`).Scan(&stateVersions))
-	require.Zero(t, stateVersions, "a state-tailed edge must not mint relation versions in Step 1")
+	require.Equal(t, 1, stateVersions, "a state-tailed edge mints its own relation version")
+
+	// The captured tail is recorded, so the stitch can discriminate.
+	var capturedTail string
+	require.NoError(t, pool.QueryRow(ctx,
+		`SELECT from_pointer FROM relation_versions WHERE rel_record_id = (
+		   SELECT rel_record_id FROM relations
+		   WHERE from_id = 'PAGE-2' AND from_pointer = 'draft')`).Scan(&capturedTail))
+	require.Equal(t, "draft", capturedTail,
+		"the version must record which tail it captured, or the rename stitch "+
+			"cannot tell a state-tailed predecessor from a default-tail one")
+
+	// The default-tail lineage stays at exactly one row: the two faces must
+	// not have interleaved.
+	metas, err := s.VersionStore().ListRelationVersions(ctx,
+		store.RelationHistoryQuery{From: "PAGE-2", Type: "references", To: "SPEC-1"})
+	require.NoError(t, err)
+	require.Len(t, metas, 1, "the default-tail lineage must hold only its own row")
+}
+
+// TestFacesWithIdenticalContentDoNotDedupAgainstEachOther is the copy-vs-sweep
+// dedup check the design doc's §13 "verify during implementation" list asks
+// for, and the answer is: HARMLESS, but only because two things agree.
+//
+// The scenario is the copy kernel's ordinary output — promote writes the
+// draft's bytes into the published face, so two faces briefly hold IDENTICAL
+// content. The sweep then settles and captures both. Does the second capture
+// dedup against the first and vanish?
+//
+// No, for two independent reasons, and the test asserts the outcome rather
+// than either mechanism so it survives a refactor of either:
+//
+//  1. contentHashOf folds the POINTER into the hash (canonical.HashEntity
+//     writes it when non-zero), so identical bytes on different faces hash
+//     differently.
+//  2. The sweep's dedup probes are scoped `ev.pointer = e.pointer`, so a
+//     face compares only against its own latest capture.
+//
+// Either alone would be enough FOR THIS SCENARIO, and both are present
+// because each guards a failure the other does not:
+//
+//   - Drop (1) and this test fails — and, worse, a purge ForceLive tombstone
+//     on one face carries a hash matching a sibling holding identical bytes,
+//     suppressing that sibling's legitimate capture.
+//   - Drop (2) and this test still PASSES, because the hash already
+//     discriminates. What (2) additionally guards is the delete fence: the
+//     `lvc` probe's since-last-delete subselect must be face-scoped, or one
+//     face's delete resets another face's lifecycle boundary. That is a
+//     different scenario, covered by the delete/recreate tests.
+//
+// Verified by removing each mechanism in turn. The failure mode throughout is
+// a MISSING version, not a duplicate — silent, and invisible until someone
+// opens a history that should not be empty.
+func TestFacesWithIdenticalContentDoNotDedupAgainstEachOther(t *testing.T) {
+	pool := newScopedPool(t)
+	s, err := pgstore.New(pool)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = s.Close() })
+	ctx := context.Background()
+
+	// Byte-identical faces — exactly what a promote leaves behind.
+	const shared = "identical on both faces"
+	require.NoError(t, s.CreateEntity(ctx, mkEntity("PAGE-9", "ticket", shared)))
+	published := mkEntity("PAGE-9", "ticket", shared)
+	p, err := entity.ParsePointer("published")
+	require.NoError(t, err)
+	published.Pointer = p
+	require.NoError(t, s.CreateEntity(ctx, published))
+
+	_, err = pool.Exec(ctx,
+		`UPDATE entities SET updated_at = now() - interval '1 hour' WHERE id = 'PAGE-9'`)
+	require.NoError(t, err)
+
+	s.StartVersionSweep(stubProvider{hash: "schema-abc", json: []byte(`{"entities":{},"types":{}}`)},
+		pgstore.SweepConfig{Interval: 50 * time.Millisecond, Idle: time.Minute, MaxStaleness: time.Hour, Batch: 100})
+
+	var sh store.StateHistoryReader = s.VersionStore()
+	require.Eventually(t, func() bool {
+		def, e1 := s.VersionStore().ListVersions(ctx, "PAGE-9")
+		pub, e2 := sh.ListStateVersions(ctx, "PAGE-9", p)
+		return e1 == nil && e2 == nil && len(def) == 1 && len(pub) == 1
+	}, 3*time.Second, 25*time.Millisecond,
+		"both faces must be captured despite holding identical content — a face "+
+			"deduping against its SIBLING's hash loses a version silently")
+
+	// And the hashes differ, which is the structural half of the guarantee.
+	def, err := s.VersionStore().ListVersions(ctx, "PAGE-9")
+	require.NoError(t, err)
+	pub, err := sh.ListStateVersions(ctx, "PAGE-9", p)
+	require.NoError(t, err)
+	require.NotEqual(t, def[0].ContentHash, pub[0].ContentHash,
+		"the pointer must participate in the content hash, or a purge tombstone "+
+			"on one face would suppress a sibling face's legitimate capture")
 }

--- a/internal/store/pgstore/status_test.go
+++ b/internal/store/pgstore/status_test.go
@@ -34,7 +34,7 @@ func TestStatusFreshSchema(t *testing.T) {
 	require.Equal(t, 0, current, "un-migrated schema is version 0")
 	// target is the highest embedded migration version — bump this when a new
 	// migration is added (0011_content_states.sql took it from 10 to 11).
-	require.Equal(t, 11, target, "binary embeds migrations through 0011")
+	require.Equal(t, 12, target, "binary embeds migrations through 0012")
 }
 
 // TestStatusAfterMigrate verifies Status reports current==target once Migrate

--- a/internal/store/pgstore/sweep.go
+++ b/internal/store/pgstore/sweep.go
@@ -10,6 +10,7 @@ import (
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 
+	"github.com/Sourcehaven-BV/rela/internal/entity"
 	"github.com/Sourcehaven-BV/rela/internal/store"
 )
 
@@ -244,7 +245,10 @@ func (s *sweep) tick(ctx context.Context) error {
 // row's last_edited_by_* columns (nil = no recorded editor) so the captured
 // version is attributed to the real author (TKT-ZIRMGM).
 type sweepCandidate struct {
-	id         string
+	id string
+	// pointer is the face this candidate row is; zero = the default face.
+	// It keys the version alongside the id (TKT-C1XUA8).
+	pointer    string
 	typ        string
 	content    string
 	props      []byte
@@ -276,35 +280,42 @@ func (s *sweep) selectCandidates(ctx context.Context, conn *pgxpool.Conn) ([]swe
 	//     against. Deduping against a pre-delete version would wrongly skip
 	//     re-creating an entity with identical bytes, leaving its timeline
 	//     ending in `delete` while it is live.
-	// e.pointer = '' — DELIBERATE SKIP (2026-08-20, TKT-DOFYR1):
-	// content versioning captures the DEFAULT world only. entity_versions
-	// keys (entity_id, vseq), so sweeping a state row would interleave a
-	// family's faces in ONE lineage — actively corrupt history that
-	// purge would then have to fence — and capturing now would freeze
-	// per-state purge rules, rename stitching, and history addressing
-	// before any consumer exists. Per-state history is designed WITH its
-	// consumer, the Step-4 copy kernel: TKT-C1XUA8 owns that design
-	// (same pattern as the Step-1 search-observer skip → Step 5).
+	// PER-STATE (TKT-C1XUA8): the Step-1 skip (`e.pointer = ''`) is gone —
+	// every face is swept, and entity_versions now keys
+	// (entity_id, pointer, vseq) so faces cannot interleave in one lineage.
+	//
+	// BOTH LATERALs and the delete-fence subselect are scoped
+	// `ev.pointer = e.pointer`, and that is the load-bearing detail rather
+	// than a tidiness one. Scoping only the outer row would leave the inner
+	// probes answering from ANY face: the published capture would dedup
+	// against the draft's identical content_hash and be silently dropped —
+	// a MISSING version, not a duplicate — and one face's delete would reset
+	// another face's lifecycle boundary.
+	//
+	// The content hash also folds in the pointer (contentHashOf), so two
+	// faces with byte-identical content hash differently. That is the
+	// structural half of the same guarantee; the SQL scoping is the other.
 	const q = `
-		SELECT e.id, e.type, e.content, e.properties,
+		SELECT e.id, e.pointer, e.type, e.content, e.properties,
 		       e.last_edited_by_user, e.last_edited_by_tool,
 		       lvc.content_hash,
 		       (lv.vseq IS NOT NULL AND lv.op <> 'delete') AS live_lineage
 		FROM entities e
 		LEFT JOIN LATERAL (
 		    SELECT vseq, op, created_at FROM entity_versions ev
-		    WHERE ev.entity_id = e.id ORDER BY ev.vseq DESC LIMIT 1
+		    WHERE ev.entity_id = e.id AND ev.pointer = e.pointer
+		    ORDER BY ev.vseq DESC LIMIT 1
 		) lv ON true
 		LEFT JOIN LATERAL (
 		    SELECT content_hash FROM entity_versions ev
-		    WHERE ev.entity_id = e.id
+		    WHERE ev.entity_id = e.id AND ev.pointer = e.pointer
 		      AND ev.vseq > COALESCE(
 		          (SELECT max(vseq) FROM entity_versions d
-		           WHERE d.entity_id = e.id AND d.op = 'delete'), 0)
+		           WHERE d.entity_id = e.id AND d.pointer = e.pointer
+		             AND d.op = 'delete'), 0)
 		    ORDER BY ev.vseq DESC LIMIT 1
 		) lvc ON true
-		WHERE e.pointer = ''
-		  AND (e.updated_at < now() - make_interval(secs => $1)
+		WHERE (e.updated_at < now() - make_interval(secs => $1)
 		       OR (lv.vseq IS NOT NULL AND lv.created_at < now() - make_interval(secs => $2)))
 		ORDER BY e.updated_at ASC
 		LIMIT $3`
@@ -324,7 +335,7 @@ func (s *sweep) selectCandidates(ctx context.Context, conn *pgxpool.Conn) ([]swe
 			c          sweepCandidate
 			latestHash *string // NULL when there is no version in the current lifecycle
 		)
-		if err := rows.Scan(&c.id, &c.typ, &c.content, &c.props,
+		if err := rows.Scan(&c.id, &c.pointer, &c.typ, &c.content, &c.props,
 			&c.editorUser, &c.editorTool, &latestHash, &c.hasVersion); err != nil {
 			return nil, err
 		}
@@ -351,6 +362,7 @@ func (s *sweep) captureOne(
 	principalUser, principalTool := sweepAttribution(c.editorUser, c.editorTool)
 	in := store.VersionInput{
 		EntityID:      c.id,
+		Pointer:       entity.Pointer(c.pointer),
 		Type:          c.typ,
 		Content:       c.content,
 		Properties:    props,
@@ -396,16 +408,18 @@ func sweepAttribution(editorUser, editorTool *string) (user, tool string) {
 // of its latest existing version in that lineage (empty if none). editorUser/
 // editorTool mirror sweepCandidate's attribution columns.
 type relationSweepCandidate struct {
-	recordID   int64
-	from       string
-	relType    string
-	to         string
-	content    string
-	props      []byte
-	latestHash string
-	hasVersion bool
-	editorUser *string
-	editorTool *string
+	recordID int64
+	from     string
+	// fromPointer is the state-specific TAIL of the edge; zero = default.
+	fromPointer string
+	relType     string
+	to          string
+	content     string
+	props       []byte
+	latestHash  string
+	hasVersion  bool
+	editorUser  *string
+	editorTool  *string
 }
 
 // selectRelationCandidates returns up to Batch relations that have settled (or
@@ -421,15 +435,19 @@ type relationSweepCandidate struct {
 func (s *sweep) selectRelationCandidates(
 	ctx context.Context, conn *pgxpool.Conn,
 ) ([]relationSweepCandidate, error) {
-	// r.from_pointer = '' — DELIBERATE SKIP (2026-08-20, TKT-DOFYR1),
-	// symmetric with the entity scan above: state-tailed edges mint no
-	// relation versions in Step 1. Their rel_record_ids are distinct so
-	// lineages could not MERGE, but versioning edges whose entity faces
-	// have no history is an asymmetry nobody designed. TKT-C1XUA8 (the
-	// Step-4 copy kernel) owns per-state history, including the doc's
-	// copy-vs-sweep dedup check.
+	// PER-STATE (TKT-C1XUA8): the Step-1 skip (`r.from_pointer = ''`) is
+	// gone, symmetric with the entity scan above.
+	//
+	// This side needed less than the entity side: rel_record_id is minted
+	// per ROW and each tail is its own row since 0011, so lineages were
+	// already fenced per face and could not merge. What the tail is needed
+	// for is the rename STITCH, which matches a predecessor by the triple
+	// (prev_from, rel_type, prev_to) and cannot otherwise tell a
+	// state-tailed edge from a default-tail one — hence from_pointer on
+	// relation_versions and in the stitch's predicate.
 	const q = `
-		SELECT r.rel_record_id, r.from_id, r.rel_type, r.to_id, r.content, r.properties,
+		SELECT r.rel_record_id, r.from_id, r.from_pointer, r.rel_type, r.to_id,
+		       r.content, r.properties,
 		       r.last_edited_by_user, r.last_edited_by_tool,
 		       lv.content_hash,
 		       (lv.vseq IS NOT NULL) AS has_version
@@ -438,8 +456,7 @@ func (s *sweep) selectRelationCandidates(
 		    SELECT vseq, content_hash, created_at FROM relation_versions rv
 		    WHERE rv.rel_record_id = r.rel_record_id ORDER BY rv.vseq DESC LIMIT 1
 		) lv ON true
-		WHERE r.from_pointer = ''
-		  AND (r.updated_at < now() - make_interval(secs => $1)
+		WHERE (r.updated_at < now() - make_interval(secs => $1)
 		       OR (lv.vseq IS NOT NULL AND lv.created_at < now() - make_interval(secs => $2)))
 		ORDER BY r.updated_at ASC
 		LIMIT $3`
@@ -456,7 +473,7 @@ func (s *sweep) selectRelationCandidates(
 			c          relationSweepCandidate
 			latestHash *string // NULL when the lineage has no version yet
 		)
-		if err := rows.Scan(&c.recordID, &c.from, &c.relType, &c.to,
+		if err := rows.Scan(&c.recordID, &c.from, &c.fromPointer, &c.relType, &c.to,
 			&c.content, &c.props, &c.editorUser, &c.editorTool,
 			&latestHash, &c.hasVersion); err != nil {
 			return nil, err
@@ -482,6 +499,7 @@ func (s *sweep) captureRelation(
 	principalUser, principalTool := sweepAttribution(c.editorUser, c.editorTool)
 	in := store.RelationVersionInput{
 		RecordID:      c.recordID,
+		FromPointer:   entity.Pointer(c.fromPointer),
 		From:          c.from,
 		Type:          c.relType,
 		To:            c.to,

--- a/internal/store/pgstore/version.go
+++ b/internal/store/pgstore/version.go
@@ -56,20 +56,32 @@ func insertVersion(ctx context.Context, q DBTX, in store.VersionInput, contentHa
 	}
 	const ins = `
 		INSERT INTO entity_versions
-		    (entity_id, op, prev_id, type, content, properties, content_hash,
+		    (entity_id, pointer, op, prev_id, type, content, properties, content_hash,
 		     schema_hash, principal_user, principal_tool, triggered_by)
-		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)`
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)`
 	_, err = q.Exec(ctx, ins,
-		in.EntityID, string(in.Op), prev, in.Type, in.Content, props, contentHash,
+		in.EntityID, string(in.Pointer), string(in.Op), prev, in.Type, in.Content,
+		props, contentHash,
 		in.SchemaHash, in.PrincipalUser, in.PrincipalTool, in.TriggeredBy)
 	return err
 }
 
-// contentHashOf computes the canonical content hash of a snapshot, matching the
-// live entity hash so a sweep can compare against the current entity's hash.
+// contentHashOf hashes a version's content the same way the live entity is
+// hashed, so the sweep's dedup and purge's live-row check compare like with
+// like.
+//
+// The POINTER IS PART OF THE HASH, and that is load-bearing (TKT-C1XUA8).
+// canonical.HashEntity folds it in when non-zero, so two faces holding
+// byte-identical content hash DIFFERENTLY. Dropping it here — as this
+// function did while only the default face was versioned, where it made no
+// difference — would silently defeat that: the sweep's dedup would compare a
+// published capture against the draft's identical hash and skip it, producing
+// a MISSING version rather than a duplicate, and a purge ForceLive tombstone
+// on one face would suppress a legitimate capture on its sibling.
 func contentHashOf(in store.VersionInput) string {
 	return canonical.HashEntity(entity.Entity{
 		ID:         in.EntityID,
+		Pointer:    in.Pointer,
 		Type:       in.Type,
 		Properties: in.Properties,
 		Content:    in.Content,
@@ -96,7 +108,21 @@ func contentHashOf(in store.VersionInput) string {
 //
 // lineageCTE is the shared recursive term producing (entity_id, hi) rows where
 // hi is the exclusive vseq upper bound for that id in this lineage (NULL = no
-// upper bound, i.e. the head id). $1 is the queried id.
+// upper bound, i.e. the head id). $1 is the queried id, $2 the FACE (pointer).
+//
+// # The face is a filter, not a hop (TKT-C1XUA8)
+//
+// A rename re-keys the WHOLE state family in one UPDATE (rekeyStateFamily), so
+// every face is renamed together and a face's pointer is CONSTANT along its
+// lineage. The walk therefore still follows prev_id links only, with the
+// pointer carried as a filter.
+//
+// The subtle part is that the filter must reach INSIDE the two max(vseq)
+// subselects, not just the outer join. Those compute the rename fence, and
+// left unscoped they would answer from ANY face's rename rows — so face
+// draft's boundary could be set by face published's rename, silently
+// truncating or extending draft's history. Scoping the join alone looks
+// correct and is not.
 const lineageCTE = `
 	WITH RECURSIVE lin(entity_id, lo, hi) AS (
 	    -- Head: the queried id. Its CURRENT lifecycle starts strictly after the
@@ -107,7 +133,8 @@ const lineageCTE = `
 	    -- entity_versions.entity_id (both recursive terms must agree, else 42P21).
 	    SELECT CAST($1 AS text) COLLATE "C",
 	           COALESCE((SELECT max(vseq) FROM entity_versions
-	                     WHERE prev_id = $1 AND op = 'rename'), 0),
+	                     WHERE prev_id = $1 AND op = 'rename'
+	                       AND pointer = CAST($2 AS text) COLLATE "C"), 0),
 	           CAST(NULL AS bigint)
 	    UNION
 	    -- Each hop: the rename row that renamed some predecessor INTO the current
@@ -117,11 +144,13 @@ const lineageCTE = `
 	    -- doubly-reused predecessor id is also fenced. Guard cycles via hi.
 	    SELECT r.prev_id,
 	           COALESCE((SELECT max(vseq) FROM entity_versions
-	                     WHERE prev_id = r.prev_id AND op = 'rename' AND vseq < r.vseq), 0),
+	                     WHERE prev_id = r.prev_id AND op = 'rename' AND vseq < r.vseq
+	                       AND pointer = CAST($2 AS text) COLLATE "C"), 0),
 	           r.vseq
 	    FROM lin
 	    JOIN entity_versions r
 	      ON r.entity_id = lin.entity_id
+	     AND r.pointer = CAST($2 AS text) COLLATE "C"
 	     AND r.op = 'rename'
 	     AND r.prev_id IS NOT NULL
 	     AND (lin.hi IS NULL OR r.vseq < lin.hi)
@@ -134,18 +163,28 @@ const lineageCTE = `
 func lineageWhere() string {
 	return `
 		JOIN lin ON lin.entity_id = ev.entity_id
+		         AND ev.pointer = CAST($2 AS text) COLLATE "C"
 		         AND ev.vseq > lin.lo
 		         AND (lin.hi IS NULL OR ev.vseq < lin.hi)`
 }
 
 // ListVersions implements store.HistoryReader.
 func (v *VersionStore) ListVersions(ctx context.Context, id string) ([]store.VersionMeta, error) {
+	return v.ListStateVersions(ctx, id, "")
+}
+
+// ListStateVersions implements store.StateHistoryReader: the same fenced
+// lineage walk, for one face. The zero pointer is the default face, which is
+// what makes ListVersions a delegation rather than a second query.
+func (v *VersionStore) ListStateVersions(
+	ctx context.Context, id string, p entity.Pointer,
+) ([]store.VersionMeta, error) {
 	sel := lineageCTE + `
 		SELECT DISTINCT ev.vseq, ev.op, ev.prev_id, ev.type, ev.content_hash, ev.schema_hash,
 		       ev.principal_user, ev.principal_tool, ev.triggered_by, ev.created_at
 		FROM entity_versions ev` + lineageWhere() + `
 		ORDER BY ev.vseq ASC`
-	rows, err := v.db.Query(ctx, sel, id)
+	rows, err := v.db.Query(ctx, sel, id, string(p))
 	if err != nil {
 		return nil, err
 	}
@@ -174,7 +213,19 @@ func (v *VersionStore) ListVersions(ctx context.Context, id string) ([]store.Ver
 // relative to a ListVersions read taken at the same time — the lineage is
 // append-only, so an ordinal a caller already holds stays valid, but callers
 // should treat it as a cursor into a specific ListVersions result.
-func (v *VersionStore) GetVersion(ctx context.Context, id string, version int) (*store.VersionSnapshot, error) {
+func (v *VersionStore) GetVersion(
+	ctx context.Context, id string, version int,
+) (*store.VersionSnapshot, error) {
+	return v.GetStateVersion(ctx, id, "", version)
+}
+
+// GetStateVersion implements store.StateHistoryReader. See GetVersion for the
+// ordinal's cursor semantics; they are unchanged, but the ordinal is over the
+// FACE's lineage, so version 1 of draft and version 1 of published are
+// different snapshots.
+func (v *VersionStore) GetStateVersion(
+	ctx context.Context, id string, p entity.Pointer, version int,
+) (*store.VersionSnapshot, error) {
 	if version < 1 {
 		return nil, store.ErrNotFound
 	}
@@ -185,8 +236,8 @@ func (v *VersionStore) GetVersion(ctx context.Context, id string, version int) (
 		FROM entity_versions ev` + lineageWhere() + `
 		JOIN schema_versions sv ON sv.hash = ev.schema_hash
 		ORDER BY ev.vseq ASC
-		OFFSET $2 LIMIT 1`
-	row := v.db.QueryRow(ctx, sel, id, version-1)
+		OFFSET $3 LIMIT 1`
+	row := v.db.QueryRow(ctx, sel, id, string(p), version-1)
 
 	var (
 		snap  store.VersionSnapshot

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -619,7 +619,13 @@ type VersionSnapshot struct {
 // deduped into the backend's schema store), and attribution. PrevID is set only
 // for VersionOpRename.
 type VersionInput struct {
-	EntityID      string
+	EntityID string
+
+	// Pointer names the CONTENT STATE this snapshot captures; zero is the
+	// default face (TKT-C1XUA8). It participates in the content hash, so two
+	// faces holding identical bytes do not dedup against one another.
+	Pointer entity.Pointer
+
 	Op            VersionOp
 	PrevID        string
 	Type          string
@@ -711,6 +717,34 @@ type HistoryReader interface {
 	GetVersion(ctx context.Context, id string, version int) (*VersionSnapshot, error)
 }
 
+// StateHistoryReader reads the history of ONE CONTENT STATE (face) of an
+// entity, rather than the default face [HistoryReader] serves (TKT-C1XUA8).
+//
+// A separate optional capability rather than a pointer parameter on
+// HistoryReader, deliberately. Every existing consumer — the data-entry
+// history route, restore, the CLI — asks about the default face, and
+// widening the two HistoryReader signatures would touch all of them plus
+// three hand-written test stubs to say something they already say. The
+// zero-pointer call IS HistoryReader, so the two are the same query with a
+// different face.
+//
+// Type-asserted like [Formatter] and the other optional store capabilities:
+// fs/mem return nothing, pgstore implements it.
+//
+// NOTE for read-path callers: a face's history is as sensitive as the face,
+// and the pointer is caller-supplied. A surface that lets a principal name a
+// face must authorize that face — the world read grant (TKT-DN37J2), not
+// merely the entity's read verdict. The store does not and cannot check it.
+type StateHistoryReader interface {
+	// ListStateVersions is [HistoryReader.ListVersions] for one face.
+	ListStateVersions(ctx context.Context, id string, p entity.Pointer) ([]VersionMeta, error)
+
+	// GetStateVersion is [HistoryReader.GetVersion] for one face.
+	GetStateVersion(
+		ctx context.Context, id string, p entity.Pointer, version int,
+	) (*VersionSnapshot, error)
+}
+
 // --- Relation versioning (TKT-92JL8P) ---
 //
 // Relation versioning mirrors entity versioning but is a SEPARATE optional
@@ -792,7 +826,14 @@ type RelationHistoryQuery struct {
 // arrives here, populated from ctx at the boundary — the store learns the
 // Principal by no other route.
 type RelationVersionInput struct {
-	RecordID      int64
+	RecordID int64
+
+	// FromPointer is the state-specific TAIL of the versioned edge; zero is
+	// the default tail (TKT-C1XUA8). Lineages were already fenced by
+	// RecordID; this is what lets the rename stitch tell a state-tailed
+	// predecessor from a default-tail one holding the same triple.
+	FromPointer entity.Pointer
+
 	Op            VersionOp
 	From          string
 	Type          string
@@ -879,7 +920,14 @@ type PurgeSelector struct {
 // returns the target rows WITHOUT deleting. Attribution arrives here from ctx at
 // the boundary — the store never learns the principal by another route.
 type VersionPurgeRequest struct {
-	EntityID      string
+	EntityID string
+
+	// Pointer names the FACE whose history is purged; zero is the default
+	// face (TKT-C1XUA8). Purge is scoped to one face: each face has its own
+	// fenced lineage, and erasing a sibling's history because it shares
+	// bytes would destroy records the operator did not ask about.
+	Pointer entity.Pointer
+
 	Selector      PurgeSelector
 	Reason        string
 	ForceLive     bool


### PR DESCRIPTION
PR-B of the TKT-C1XUA8 (copy kernel, Step 4) stack. **Code-only**; paperwork on the companion PR.

Tickets-PR: #1422

Stack: #1423 ← #1427 ← #1428 ← #1429 (PR-A) ← **this**. Retarget as ancestors merge.

## The debt this pays

Step 1 captured the **default face only**, in four deliberate skips — the two version hooks and the two sweep candidate scans (`version_hook.go:62,143`; `sweep.go:286,428`). Each gave the same reason: `entity_versions` keys `(entity_id, vseq)`, so capturing a state row would **interleave a family's faces in one lineage** — the sweep's newest-version dedup would compare a draft against the default's last capture, and history reads would mix faces. That is actively corrupt history, which purge would then have to fence. Per-state history was to be designed **with its consumer**.

This is that consumer's migration. The Step-4 copy kernel is the first thing in the system that writes a non-default face, so shipping it without per-state history would give a promoted face **no history at all** — worse than the skip, which is at least honest about its scope.

## What lands

- **Migration 0012** (forward-only): pointer column on the version tables.
- **Lineage fenced on `(id, pointer)`**, not the bare id — the interleaving above is exactly what an unfenced walk produces. A face's pointer is constant along its lineage and every face is renamed together, so the pointer travels as a filter rather than needing reconstruction.
- Both version hooks and both sweep scans now capture non-default faces; **all four skip-site comments updated** rather than left promising a fix that had landed.
- Relations get the symmetric treatment, since the relations sweep carried the matching skip.
- Purge and the lineage walk updated to match.

## Verification

Run against a **real PostgreSQL** with `RELA_TEST_DATABASE_REQUIRED=1` — the justfile warns that a skipped suite and a passing suite are indistinguishable in the exit code, and a migration verified only by compiling is not verified.

`ok github.com/Sourcehaven-BV/rela/internal/store/pgstore 36.802s`

Plus gofmt, both build tags, arch-lint, and the default-build suites across `store`, `entitymanager` and `appbuild`.