### PR TITLE
🌍 feat(entitymanager): copy kernel and declared copy definitions (TKT-C1XUA8 PR-C)

### DIFF
--- a/internal/audit/audit.go
+++ b/internal/audit/audit.go
@@ -77,6 +77,19 @@ const (
 	// showing who purged what and why. Isolate with `op == "purge-version"`.
 	OpPurgeVersion = "purge-version"
 
+	// OpCopyState records one invocation of a declared COPY DEFINITION —
+	// a mapped write of one entity content state (face) into another
+	// (TKT-C1XUA8). Subject names the TARGET face; Summary carries the
+	// definition name, the source and target faces, and whether the target
+	// was created.
+	//
+	// Shaped after OpPurgeVersion: it records WHAT was done to WHICH
+	// subject and never the copied content. Unlike purge, it does NOT
+	// bypass the Manager — a copy IS an entity write, so it goes through
+	// the same audit hook that reads attribution from ctx and cannot be
+	// forged by a caller.
+	OpCopyState = "copy-state"
+
 	// OpDataMigration records one applied data-migration file (TKT-0C57FS):
 	// a bulk store-level rewrite that deliberately bypasses the
 	// entitymanager (so no per-entity audit records exist for it). Summary

--- a/internal/automation/template.go
+++ b/internal/automation/template.go
@@ -71,9 +71,13 @@ func Interpolate(template string, vars TemplateVars, entity, oldEntity *entity.E
 		return template
 	}
 
-	now := vars.Now()
-	if vars.Now == nil {
-		now = time.Now()
+	// The nil check comes FIRST. It used to follow the call, which panicked
+	// on a zero TemplateVars — latent because the automation engine always
+	// populates Now, so no caller reached it until the copy kernel passed a
+	// bare TemplateVars (TKT-C1XUA8).
+	now := time.Now()
+	if vars.Now != nil {
+		now = vars.Now()
 	}
 
 	replacements := map[string]string{
@@ -121,9 +125,13 @@ func InterpolateSafeOnly(template string, vars TemplateVars) string {
 		return template
 	}
 
-	now := vars.Now()
-	if vars.Now == nil {
-		now = time.Now()
+	// The nil check comes FIRST. It used to follow the call, which panicked
+	// on a zero TemplateVars — latent because the automation engine always
+	// populates Now, so no caller reached it until the copy kernel passed a
+	// bare TemplateVars (TKT-C1XUA8).
+	now := time.Now()
+	if vars.Now != nil {
+		now = vars.Now()
 	}
 
 	replacements := map[string]string{

--- a/internal/entitymanager/copy.go
+++ b/internal/entitymanager/copy.go
@@ -1,0 +1,474 @@
+package entitymanager
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"maps"
+
+	"github.com/Sourcehaven-BV/rela/internal/acl"
+	"github.com/Sourcehaven-BV/rela/internal/audit"
+	"github.com/Sourcehaven-BV/rela/internal/entity"
+	"github.com/Sourcehaven-BV/rela/internal/metamodel"
+	"github.com/Sourcehaven-BV/rela/internal/principal"
+	"github.com/Sourcehaven-BV/rela/internal/store"
+)
+
+// Copy errors. ErrUnknownCopy is caller input (4xx); the guard errors map to
+// 403/422 exactly as the statemachine's do, because they ARE the
+// statemachine's vocabulary (design doc §9.1: shared guard machinery,
+// separate declaration).
+var (
+	// ErrUnknownCopy names a definition the metamodel does not declare. A
+	// request may only invoke a definition BY NAME, so this is the whole of
+	// "that copy does not exist" — never a hint that some other mapping
+	// might work.
+	ErrUnknownCopy = errors.New("entitymanager: no such copy definition")
+
+	// ErrCopySourceMissing means the source face does not exist. Distinct
+	// from a denial: the caller asked to copy something that is not there.
+	ErrCopySourceMissing = errors.New("entitymanager: copy source face does not exist")
+)
+
+// CopyRequest invokes a declared copy definition. There is deliberately no
+// field for the mapping: a request chooses a NAME, never a shape.
+//
+// This is the transforms-registry precedent (`?transform=<name>`, never a
+// command), and it is what keeps the guard system meaningful — a caller who
+// could describe an arbitrary copy could describe one whose guard is
+// convenient.
+type CopyRequest struct {
+	// Definition is the key in the metamodel's `copies:` block.
+	Definition string
+
+	// SourceID is the entity the copy reads from. For a same-entity copy it
+	// is also the target; for a cross-entity copy the target is created.
+	SourceID string
+
+	// TargetID is the cross-entity target's id. Ignored (and must be empty)
+	// for a same-entity copy, whose target is SourceID by construction.
+	TargetID string
+}
+
+// CopyResult reports what a copy produced, in the vocabulary a UI would
+// need without deciding anything about presentation.
+type CopyResult struct {
+	// Definition is the name that was invoked.
+	Definition string
+	// Entity is the resulting target face, as stored.
+	Entity *entity.Entity
+	// Created is true when the copy brought the target face into existence
+	// rather than overwriting one.
+	Created bool
+}
+
+// CopyState executes a declared copy definition: write a mapped subset of one
+// content state (face) into another, in ONE store transaction, audited.
+//
+// # The kernel is dumb; the definition carries the policy
+//
+// Everything policy-shaped — which fields, merge vs replace, the guard —
+// lives in the compiled definition. This function writes what it is told.
+// That split is what lets the security tests aim at one small function
+// rather than at a mapping language.
+//
+// # store.Tx, and a note for reviewers
+//
+// entitymanager had NEVER called store.Tx before this (the only non-store
+// caller in the tree was internal/datamigration). That is deliberate here,
+// not an oversight: a copy writes fields, body and edges, and a half-applied
+// copy is a face that claims to be a promotion of something it is not.
+//
+// Two consequences the contract forces:
+//
+//   - Every store call inside the transaction goes through the VIEW, never
+//     m.deps.Store. A write on the outer store from inside deadlocks on
+//     fs/mem and silently bypasses the transaction on pg.
+//   - fs/mem have NO ROLLBACK — store.Tx there is a write mutex. A mid-copy
+//     failure leaves a partially written target face on those backends. That
+//     is the accepted best-effort stance for fsstore (§6.1); pgstore gives
+//     real atomicity.
+//
+// # Audit lands AFTER the commit
+//
+// A rollback that left an audit record would make the log claim a write that
+// never happened, which is worse than a missing record — the log's whole
+// value is that it does not lie. This matches the existing "audit the
+// durable write" rule, extended past a transaction boundary.
+//
+// # What this does NOT do
+//
+// It does not validate the DESTINATION WORLD. §9.2 says a copy into a state
+// a world selects is valid iff that world remains a valid graph, but
+// `must_hold_in` is TKT-9KZGJO's declared seam and shipping half of it here
+// would fork it. That is a boundary, not an omission.
+func (m *Manager) CopyState(ctx context.Context, req CopyRequest) (*CopyResult, error) {
+	ctx = withStoreAttribution(ctx)
+
+	def, ok := m.deps.Meta.Copies[req.Definition]
+	if !ok {
+		return nil, fmt.Errorf("%w: %q", ErrUnknownCopy, req.Definition)
+	}
+	plan, err := m.planCopy(ctx, req, def)
+	if err != nil {
+		return nil, err
+	}
+
+	tx, ok := m.deps.Store.(store.Transactor)
+	if !ok {
+		// Every backend implements Transactor; a store that does not is a
+		// wiring error, and running the copy unsynchronized would be worse
+		// than refusing it.
+		return nil, errors.New("entitymanager: store does not support transactions")
+	}
+
+	var result CopyResult
+	if err := tx.Tx(ctx, func(view store.Store) error {
+		res, cerr := applyCopy(ctx, view, plan)
+		if cerr != nil {
+			return cerr
+		}
+		result = *res
+		return nil
+	}); err != nil {
+		return nil, err
+	}
+
+	// AFTER the commit — see the godoc.
+	m.recordCopyAudit(ctx, plan, result)
+	return &result, nil
+}
+
+// copyPlan is a resolved, authorized copy: the exact bytes to write and where.
+// Producing it is where every read, guard and authorization happens, so the
+// transaction body stays a pure write.
+type copyPlan struct {
+	name     string
+	def      metamodel.CopyDef
+	from     metamodel.CopyTarget
+	to       metamodel.CopyTarget
+	sourceID string
+	targetID string
+
+	// sourceTail and targetTail are the STORED coordinates, resolved once
+	// through metamodel.StoredPointer. Resolving them here rather than at
+	// each use is not tidiness: a declared pointer marked `default: true` IS
+	// the zero coordinate, so a site that used the declared name would write
+	// a face at a tail no face lives at — silently, with no error.
+	sourceTail entity.Pointer
+	targetTail entity.Pointer
+
+	// entity is the target face to write, already merged against any existing
+	// target (mapped fields written, unmapped untouched — §9.1).
+	entity *entity.Entity
+	// created records whether the target face existed before.
+	created bool
+	// edges are the copied relations, already authorized.
+	edges []copyEdge
+}
+
+type copyEdge struct {
+	relType string
+	to      string
+	// replace means the target face's edges of this type are removed first.
+	replace bool
+}
+
+// planCopy resolves the definition against the request: reads the source
+// face, evaluates the guard, authorizes the write, and merges the target.
+//
+// # The elevation split lives here (§9.2)
+//
+//   - SAME-ENTITY copies read the source RAW. Hidden fields travel with the
+//     entity, the principal never sees them, and the same policy governs them
+//     on the target face — identity preserved, so policy follows. This is the
+//     positive form of the never-redact-a-write-prep rule.
+//   - CROSS-ENTITY copies read through the CALLER'S visibility gate, so only
+//     fields they may read carry. An elevated cross-entity copy would launder
+//     fields the principal cannot read into an entity with a different
+//     audience — a redaction bypass, and the reason `fields: all` is a load
+//     error on that form.
+func (m *Manager) planCopy(
+	ctx context.Context, req CopyRequest, def metamodel.CopyDef,
+) (*copyPlan, error) {
+	from, err := metamodel.ParseCopyTarget(def.From)
+	if err != nil {
+		return nil, fmt.Errorf("entitymanager: copy %q: from: %w", req.Definition, err)
+	}
+	to, err := metamodel.ParseCopyTarget(def.To)
+	if err != nil {
+		return nil, fmt.Errorf("entitymanager: copy %q: to: %w", req.Definition, err)
+	}
+
+	plan := &copyPlan{
+		name: req.Definition, def: def, from: from, to: to,
+		sourceID: req.SourceID, targetID: req.SourceID,
+		sourceTail: entity.Pointer(metamodel.StoredPointer(m.deps.Meta, from.Type, from.Pointer)),
+		targetTail: entity.Pointer(metamodel.StoredPointer(m.deps.Meta, to.Type, to.Pointer)),
+	}
+	if !def.IsSameEntity() {
+		plan.targetID = req.TargetID
+	}
+
+	src, err := m.readCopySource(ctx, def, plan)
+	if err != nil {
+		return nil, err
+	}
+	if err := m.authorizeCopy(ctx, plan); err != nil {
+		return nil, err
+	}
+	if err := m.buildCopyTarget(ctx, plan, src); err != nil {
+		return nil, err
+	}
+	return plan, nil
+}
+
+// readCopySource performs the elevation split's read half.
+func (m *Manager) readCopySource(
+	ctx context.Context, def metamodel.CopyDef, plan *copyPlan,
+) (*entity.Entity, error) {
+	ptr := plan.sourceTail
+
+	if def.IsSameEntity() {
+		// RAW and elevated. The read feeds a write, and a redacted read that
+		// feeds a write destroys the hidden fields it could not see — the
+		// precise bug the never-redact-a-write-prep rule pins.
+		e, err := m.deps.Store.GetEntityState(ctx, plan.sourceID, ptr)
+		if err != nil {
+			return nil, fmt.Errorf("%w: %s", ErrCopySourceMissing, plan.sourceID)
+		}
+		return e, nil
+	}
+
+	// Cross-entity: through the caller's gate. A nil gate means no ACL is
+	// wired, which is the CLI/no-policy case — the raw read is then what
+	// every other read on that deployment already does.
+	if m.deps.CopyVisibility == nil {
+		e, err := m.deps.Store.GetEntityState(ctx, plan.sourceID, ptr)
+		if err != nil {
+			return nil, fmt.Errorf("%w: %s", ErrCopySourceMissing, plan.sourceID)
+		}
+		return e, nil
+	}
+	e, ok, err := m.deps.CopyVisibility.Get(ctx, plan.from.Type, plan.sourceID)
+	if err != nil {
+		return nil, err
+	}
+	if !ok {
+		// Denied and absent are indistinguishable, by design: whether an
+		// entity exists is a genuine secret.
+		return nil, fmt.Errorf("%w: %s", ErrCopySourceMissing, plan.sourceID)
+	}
+	return e, nil
+}
+
+// authorizeCopy authorizes the copy.
+//
+// # Three checks, and why none of them is redundant
+//
+// §9.2 says a guarded state is writable ONLY by copy definitions naming it as
+// target, "each carrying its own guard". That sentence is CONDITIONED on the
+// guard existing — it is not a license to skip authorization when a
+// definition happens to omit one, which is the hole an earlier cut of this
+// function shipped: a principal holding nothing could promote a stranger's
+// draft, including fields they could not read.
+//
+//  1. READ on the source, always. A copy is a read followed by a write, and
+//     the elevation split is about which FIELDS travel, not about whether
+//     the principal may touch the entity at all. Without this, elevation
+//     becomes a way to read what you cannot read.
+//  2. The definition's `guard:`, resolved per-entity via
+//     HoldsPermissionForEntity, so "the owner of THIS doc may publish it"
+//     works without a global grant. Mandatory at LOAD for any definition
+//     targeting a non-default face, so the sentence above always applies.
+//  3. WRITE on the target — for a CROSS-ENTITY copy only. That creates an
+//     entity with its own audience, so it is an ordinary create and must not
+//     become a way to make entities the principal could not make by hand.
+//
+// The same-entity target face is deliberately exempt from (3): nobody holds
+// `update` on published by design, so requiring it would make every promote
+// impossible. (1) and (2) are what stand in its place.
+func (m *Manager) authorizeCopy(ctx context.Context, plan *copyPlan) error {
+	// (1) READ on the source. Same-entity copies read RAW afterwards, which
+	// is about hidden FIELDS traveling with the entity — it is not a
+	// license to read an entity the principal has no access to.
+	if m.deps.CopyReadGate != nil {
+		permitted, err := m.deps.CopyReadGate.PermitsRead(ctx, plan.from.Type, plan.sourceID)
+		if err != nil {
+			return err
+		}
+		if !permitted {
+			// Indistinguishable from absent, matching every other read gate.
+			return fmt.Errorf("%w: %s", ErrCopySourceMissing, plan.sourceID)
+		}
+	}
+
+	if perm := plan.def.Guard.Permission; perm != "" {
+		if m.deps.CopyGuard == nil {
+			// A guarded copy with no guard implementation fails CLOSED,
+			// matching the statemachine's nil-guard rule: a guarded edge with
+			// no guard is denied, never waved through.
+			return &acl.ForbiddenError{Decision: acl.Decision{
+				RuleKind: "copy-guard", RuleID: perm,
+				Reason: fmt.Sprintf(
+					"copy %q requires permission %q but no guard is wired",
+					plan.name, perm),
+			}}
+		}
+		if !m.deps.CopyGuard.HoldsPermission(ctx, plan.sourceID, perm) {
+			return &acl.ForbiddenError{Decision: acl.Decision{
+				RuleKind: "copy-guard", RuleID: perm,
+				Reason: fmt.Sprintf(
+					"copy %q requires permission %q on %q",
+					plan.name, perm, plan.sourceID),
+			}}
+		}
+	}
+
+	if plan.def.IsSameEntity() {
+		// (3) does not apply — see above.
+		return nil
+	}
+	return m.authorizeAndAudit(ctx, acl.WriteRequest{
+		Op: acl.OpCreate,
+		Subject: acl.EntitySubject{
+			Type:    plan.to.Type,
+			ID:      plan.targetID,
+			Pointer: plan.targetTail,
+		},
+	})
+}
+
+// buildCopyTarget merges the source into the target face.
+//
+// Mapped fields are WRITTEN, unmapped fields are UNTOUCHED on an existing
+// target (§9.1's partial-copy semantics); `fields: all` is the full-replace
+// promote case, and is only reachable on a same-entity copy because the
+// cross-entity form rejects it at load.
+func (m *Manager) buildCopyTarget(
+	ctx context.Context, plan *copyPlan, src *entity.Entity,
+) error {
+	targetPtr := plan.targetTail
+
+	existing, err := m.deps.Store.GetEntityState(ctx, plan.targetID, targetPtr)
+	switch {
+	case err == nil:
+	case errors.Is(err, store.ErrNotFound):
+		plan.created = true
+	default:
+		// Reading "does the target exist" must not fold a backend failure
+		// into "no". A transient read error would otherwise become a
+		// CreateEntity over a live face — a silent full overwrite whose audit
+		// record cheerfully says created=true.
+		return fmt.Errorf("entitymanager: copy %q: probe target face: %w", plan.name, err)
+	}
+	target := &entity.Entity{
+		ID: plan.targetID, Type: plan.to.Type, Pointer: targetPtr,
+		Properties: map[string]any{},
+	}
+	if !plan.created {
+		target.Properties = maps.Clone(existing.Properties)
+		if target.Properties == nil {
+			target.Properties = map[string]any{}
+		}
+		target.Content = existing.Content
+	}
+
+	if plan.def.AllFields {
+		target.Properties = maps.Clone(src.Properties)
+		if target.Properties == nil {
+			target.Properties = map[string]any{}
+		}
+		target.Content = src.Content
+	}
+	for field, tmpl := range plan.def.Fields {
+		target.Properties[field] = interpolateCopyField(tmpl, src)
+	}
+
+	plan.entity = target
+	edges, err := m.planCopyEdges(ctx, plan)
+	if err != nil {
+		return err
+	}
+	plan.edges = edges
+	return nil
+}
+
+// planCopyEdges resolves which edges the definition copies, reading the
+// SOURCE face's outgoing relations.
+//
+// An omitted relation type is NOT copied, and that default is load-bearing:
+// copying a role-conferring edge grants roles on the target, so a definition
+// must name a type before its edges travel (§9.2's first mitigation).
+//
+// For a CROSS-ENTITY copy each edge is additionally authorized as the acting
+// principal — the mandatory runtime half of that mitigation. A copy can
+// never create an edge the principal could not create by hand. Same-entity
+// elevated copies only touch the entity's own state edges, so the concern
+// does not arise there.
+func (m *Manager) planCopyEdges(ctx context.Context, plan *copyPlan) ([]copyEdge, error) {
+	if len(plan.def.Relations) == 0 {
+		return nil, nil
+	}
+	srcTail := plan.sourceTail
+	crossEntity := !plan.def.IsSameEntity()
+
+	var out []copyEdge
+	for rel, err := range m.deps.Store.ListRelations(ctx, store.RelationQuery{
+		From: plan.sourceID, FromPointer: &srcTail,
+	}) {
+		if err != nil {
+			return nil, fmt.Errorf("entitymanager: copy %q: read source edges: %w",
+				plan.name, err)
+		}
+		mode, named := plan.def.Relations[rel.Type]
+		if !named {
+			continue
+		}
+		if crossEntity {
+			if aerr := m.authorizeAndAudit(ctx, acl.WriteRequest{
+				Op: acl.OpCreate,
+				Subject: acl.RelationSubject{
+					Type: rel.Type, FromType: plan.to.Type, FromID: plan.targetID,
+				},
+			}); aerr != nil {
+				return nil, aerr
+			}
+		}
+		out = append(out, copyEdge{
+			relType: rel.Type, to: rel.To, replace: mode == "replace",
+		})
+	}
+	return out, nil
+}
+
+// recordCopyAudit emits one record per definition invocation, naming the
+// definition, source, target and principal — modeled on OpPurgeVersion's
+// shape (§9.1), which records WHAT was done to WHICH subject and never the
+// content.
+//
+// It does NOT reuse purge's Manager bypass: purge is a store-level
+// destructive op with no entity write, whereas a copy IS an entity write and
+// must not have weaker authorization or attribution than a property edit.
+func (m *Manager) recordCopyAudit(ctx context.Context, plan *copyPlan, res CopyResult) {
+	p := principal.From(ctx)
+	m.deps.Audit.Record(audit.Record{
+		Op: audit.OpCopyState,
+		Subject: &audit.Subject{
+			Kind: "entity", Type: plan.to.Type, ID: plan.targetID,
+		},
+		Principal:   p,
+		TriggeredBy: audit.TriggeredByFrom(ctx),
+		Summary: fmt.Sprintf(
+			"copy %q: %s -> %s (created=%t)",
+			plan.name, copyFaceLabel(plan.sourceID, plan.from),
+			copyFaceLabel(plan.targetID, plan.to), res.Created),
+	})
+}
+
+func copyFaceLabel(id string, t metamodel.CopyTarget) string {
+	if t.Pointer == "" {
+		return id
+	}
+	return id + "@" + t.Pointer
+}

--- a/internal/entitymanager/copy_apply.go
+++ b/internal/entitymanager/copy_apply.go
@@ -1,0 +1,93 @@
+package entitymanager
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/Sourcehaven-BV/rela/internal/automation"
+	"github.com/Sourcehaven-BV/rela/internal/entity"
+	"github.com/Sourcehaven-BV/rela/internal/store"
+)
+
+// applyCopy performs the plan's writes through the transaction VIEW.
+//
+// Every store call here takes `view`, never the Manager's store: a write on
+// the outer store from inside a Tx deadlocks on fs/mem and bypasses the
+// transaction on pg. That is why the plan is fully resolved beforehand —
+// this function reads nothing it did not already decide, so there is no
+// temptation to reach for a handle it should not use.
+func applyCopy(ctx context.Context, view store.Store, plan *copyPlan) (*CopyResult, error) {
+	if plan.created {
+		if err := view.CreateEntity(ctx, plan.entity); err != nil {
+			return nil, fmt.Errorf("entitymanager: copy %q: create target face: %w",
+				plan.name, err)
+		}
+	} else if err := view.UpdateEntity(ctx, plan.entity); err != nil {
+		return nil, fmt.Errorf("entitymanager: copy %q: write target face: %w",
+			plan.name, err)
+	}
+
+	if err := applyCopyEdges(ctx, view, plan); err != nil {
+		return nil, err
+	}
+	return &CopyResult{
+		Definition: plan.name,
+		Entity:     plan.entity,
+		Created:    plan.created,
+	}, nil
+}
+
+// applyCopyEdges writes the copied relations, retailed to the TARGET face.
+//
+// Heads stay entity-level (§2.3), so a copied edge needs no rewriting on the
+// far side — the world a reader stands in resolves the head. That is what
+// made promote's "does it copy relations" question answerable at all.
+func applyCopyEdges(ctx context.Context, view store.Store, plan *copyPlan) error {
+	tail := plan.targetTail
+
+	// `replace` removes the target face's existing edges of that type first.
+	// Deliberately scoped to the TAIL: the sibling faces' edges are theirs.
+	replaced := map[string]bool{}
+	for _, e := range plan.edges {
+		if !e.replace || replaced[e.relType] {
+			continue
+		}
+		replaced[e.relType] = true
+		for rel, err := range view.ListRelations(ctx, store.RelationQuery{
+			From: plan.targetID, Type: e.relType, FromPointer: &tail,
+		}) {
+			if err != nil {
+				return fmt.Errorf("entitymanager: copy %q: list target edges: %w",
+					plan.name, err)
+			}
+			derr := view.DeleteRelation(ctx, rel.From, rel.Type, rel.To)
+			if derr != nil && !errors.Is(derr, store.ErrNotFound) {
+				return fmt.Errorf("entitymanager: copy %q: replace edges: %w",
+					plan.name, derr)
+			}
+		}
+	}
+
+	for _, e := range plan.edges {
+		_, err := view.CreateRelation(ctx, plan.targetID, e.relType, e.to,
+			&store.RelationData{FromPointer: tail})
+		if err != nil && !errors.Is(err, store.ErrConflict) {
+			// A conflict is `merge` finding the edge already present, which is
+			// exactly what merge means.
+			return fmt.Errorf("entitymanager: copy %q: create edge %s->%s: %w",
+				plan.name, e.relType, e.to, err)
+		}
+	}
+	return nil
+}
+
+// interpolateCopyField renders a field template against the source face.
+//
+// Reuses automation.Interpolate — the EXISTING {{...}} grammar, not a second
+// one. It supports literal name lookup only: no expressions, no conditionals,
+// no filters. `{{source.title}}` is spelled `{{new.title}}` in that grammar's
+// vocabulary, so the source face binds as `new`.
+func interpolateCopyField(tmpl string, src *entity.Entity) string {
+	return automation.Interpolate(tmpl, automation.TemplateVars{}, src, nil)
+}

--- a/internal/entitymanager/copy_security_test.go
+++ b/internal/entitymanager/copy_security_test.go
@@ -1,0 +1,602 @@
+package entitymanager_test
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/Sourcehaven-BV/rela/internal/acl"
+	"github.com/Sourcehaven-BV/rela/internal/audit"
+	"github.com/Sourcehaven-BV/rela/internal/entity"
+	"github.com/Sourcehaven-BV/rela/internal/entitymanager"
+	"github.com/Sourcehaven-BV/rela/internal/metamodel"
+	"github.com/Sourcehaven-BV/rela/internal/principal"
+	"github.com/Sourcehaven-BV/rela/internal/statemachine"
+	"github.com/Sourcehaven-BV/rela/internal/store"
+	"github.com/Sourcehaven-BV/rela/internal/store/memstore"
+)
+
+// copyMetaYAML declares two pointered types and the copy definitions the
+// security tests exercise.
+const copyMetaYAML = `
+version: "1"
+entities:
+  page:
+    label: Page
+    id_prefix: PAGE
+    pointers:
+      draft: {default: true}
+      published: {}
+    properties:
+      title: {type: string}
+      secret: {type: string}
+  ticket:
+    label: Ticket
+    id_prefix: TKT
+    properties:
+      title: {type: string}
+      secret: {type: string}
+copies:
+  promote-page:
+    from: page@draft
+    to: page@published
+    fields: all
+    guard:
+      permission: promote-page
+  spawn-followup:
+    from: ticket
+    to: new ticket
+    fields:
+      title: "Follow-up: {{new.title}}"
+      # Deliberately maps the REDACTED field. A definition may name any
+      # declared property — the metamodel cannot know which are visible to
+      # a given principal — so the gate is what must stop the value
+      # traveling, not the mapping. A definition that simply omitted the
+      # field would make this test pass for the wrong reason.
+      secret: "{{new.secret}}"
+`
+
+// redactingReader stands in for the caller's visibility gate: it drops the
+// `secret` property, exactly as field-level `visible:` redaction would.
+type redactingReader struct{ st *store.Store }
+
+func (r redactingReader) Get(
+	ctx context.Context, _, id string,
+) (*entity.Entity, bool, error) {
+	e, gerr := (*r.st).GetEntity(ctx, id)
+	if gerr != nil {
+		// Missing and denied are indistinguishable here, matching the real
+		// gate's contract — whether an entity exists is a genuine secret.
+		return nil, false, nil //nolint:nilerr // a miss reads as denied, by design
+	}
+	clone := *e
+	clone.Properties = map[string]any{}
+	for k, v := range e.Properties {
+		if k == "secret" {
+			continue // redacted: the principal may not read this field
+		}
+		clone.Properties[k] = v
+	}
+	return &clone, true, nil
+}
+
+type allowGuard struct{ allow bool }
+
+func (g allowGuard) HoldsPermission(context.Context, string, string) bool { return g.allow }
+
+// newCopyManager builds a Manager over one memstore, and hands the caller a
+// pointer to it so a redacting gate can wrap the SAME store the manager
+// writes through.
+func newCopyManager(
+	t *testing.T, vis func(*store.Store) entitymanager.CopyReader,
+	guard entitymanager.CopyGuard,
+) (*entitymanager.Manager, store.Store) {
+	t.Helper()
+	var st store.Store = memstore.New()
+	var reader entitymanager.CopyReader
+	if vis != nil {
+		reader = vis(&st)
+	}
+	meta, err := metamodel.Parse([]byte(copyMetaYAML))
+	if err != nil {
+		t.Fatalf("metamodel.Parse: %v", err)
+	}
+	mgr, err := entitymanager.New(entitymanager.Deps{
+		Store:          st,
+		Meta:           meta,
+		Templater:      nopTemplater{},
+		Audit:          audit.Nop{},
+		ACL:            acl.NopACL{},
+		Transitions:    statemachine.EmptySet(),
+		FieldGate:      entitymanager.AllowAllFieldGate{},
+		CopyVisibility: reader,
+		CopyGuard:      guard,
+	})
+	if err != nil {
+		t.Fatalf("entitymanager.New: %v", err)
+	}
+	return mgr, st
+}
+
+// TestCopy_SameEntityIsElevated_HiddenFieldsSurvive pins the FIRST half of
+// the §9.2 elevation split, and it is named for the failure it prevents.
+//
+// THE FAILURE: a promote that read the draft through the caller's
+// visibility gate would copy only the fields that principal may see, and
+// write them as the published face. Every hidden property would be silently
+// destroyed on the way — the redacted read-modify-write this codebase
+// forbids everywhere else, arriving through the copy door.
+//
+// WHY ELEVATION IS SAFE HERE: identity is preserved. The hidden fields
+// travel with the SAME entity, the principal never sees them, and the same
+// policy governs them on the target face. Identity preserved → policy
+// follows. This is the positive form of the never-redact-a-write-prep rule.
+func TestCopy_SameEntityIsElevated_HiddenFieldsSurvive(t *testing.T) {
+	// A redacting gate IS wired, and must NOT be consulted for this copy.
+	mgr, st := newCopyManager(t,
+		func(s *store.Store) entitymanager.CopyReader { return redactingReader{st: s} },
+		allowGuard{allow: true})
+	ctx := context.Background()
+
+	require := func(cond bool, format string, args ...any) {
+		t.Helper()
+		if !cond {
+			t.Fatalf(format, args...)
+		}
+	}
+
+	// A draft holding a field the caller cannot read.
+	err := st.CreateEntity(ctx, &entity.Entity{
+		ID: "PAGE-1", Type: "page",
+		Properties: map[string]any{"title": "Draft", "secret": "classified"},
+	})
+	require(err == nil, "seed draft: %v", err)
+
+	res, err := mgr.CopyState(ctx, entitymanager.CopyRequest{
+		Definition: "promote-page", SourceID: "PAGE-1",
+	})
+	require(err == nil, "promote: %v", err)
+	require(res.Created, "the published face did not exist and must be created")
+
+	published, err := st.GetEntityState(ctx, "PAGE-1", entity.Pointer("published"))
+	require(err == nil, "read published face: %v", err)
+
+	if got := published.Properties["secret"]; got != "classified" {
+		t.Errorf("the hidden field did not survive the promote (got %v) — a "+
+			"same-entity copy MUST read raw. Reading through the caller's gate "+
+			"would silently destroy every property they cannot see, which is the "+
+			"redacted read-modify-write failure the codebase forbids everywhere.",
+			got)
+	}
+	if got := published.Properties["title"]; got != "Draft" {
+		t.Errorf("visible field lost: %v", got)
+	}
+}
+
+// TestCopy_CrossEntityReadsThroughCallersGate_NoLaundering pins the SECOND
+// half, and is likewise named for its failure.
+//
+// THE FAILURE: an ELEVATED cross-entity copy would read fields the principal
+// cannot see and write them into a DIFFERENT entity — one with a different
+// audience, possibly one they can read freely. That launders hidden data
+// past redaction, and it is the reason the two halves differ at all.
+//
+// WHY THE GATE IS RIGHT HERE: new identity → new audience → visible-only.
+// The target is governed by its own policy, which has no relationship to the
+// source's, so nothing justifies carrying what the caller could not read.
+func TestCopy_CrossEntityReadsThroughCallersGate_NoLaundering(t *testing.T) {
+	mgr, st := newCopyManager(t,
+		func(s *store.Store) entitymanager.CopyReader { return redactingReader{st: s} },
+		allowGuard{allow: true})
+	ctx := context.Background()
+
+	if err := st.CreateEntity(ctx, &entity.Entity{
+		ID: "TKT-1", Type: "ticket",
+		Properties: map[string]any{"title": "Source", "secret": "classified"},
+	}); err != nil {
+		t.Fatalf("seed source: %v", err)
+	}
+
+	if _, err := mgr.CopyState(ctx, entitymanager.CopyRequest{
+		Definition: "spawn-followup", SourceID: "TKT-1", TargetID: "TKT-2",
+	}); err != nil {
+		t.Fatalf("spawn: %v", err)
+	}
+
+	target, err := st.GetEntity(ctx, "TKT-2")
+	if err != nil {
+		t.Fatalf("read target: %v", err)
+	}
+	// The definition MAPS `secret`, so the only thing preventing it from
+	// traveling is that the source was read through the caller's gate and
+	// arrived without it. An interpolation of a missing property renders
+	// empty, which is the correct fail-closed outcome.
+	if got, _ := target.Properties["secret"].(string); got != "" {
+		t.Errorf("a field the caller cannot read was laundered into a DIFFERENT "+
+			"entity (%v) — a cross-entity copy must read through the caller's "+
+			"visibility gate, because the target has its own audience and nothing "+
+			"justifies carrying what the principal could not see",
+			target.Properties["secret"])
+	}
+	// The mapped field still carries, through the existing interpolation
+	// grammar rather than a second one.
+	if got, _ := target.Properties["title"].(string); !strings.Contains(got, "Source") {
+		t.Errorf("mapped field did not interpolate: %q", got)
+	}
+}
+
+// TestCopy_GuardDeniesWithoutPermission pins that the definition's guard is
+// a real gate, and that a guarded copy with NO guard wired fails CLOSED —
+// matching the statemachine's nil-guard rule, where a guarded edge with no
+// guard is denied rather than waved through.
+func TestCopy_GuardDeniesWithoutPermission(t *testing.T) {
+	const guardedMeta = `
+version: "1"
+entities:
+  page:
+    label: Page
+    id_prefix: PAGE
+    pointers:
+      draft: {default: true}
+      published: {}
+    properties:
+      title: {type: string}
+copies:
+  promote-page:
+    from: page@draft
+    to: page@published
+    fields: all
+    guard:
+      permission: promote-page
+`
+	newGuarded := func(t *testing.T, g entitymanager.CopyGuard) (*entitymanager.Manager, store.Store) {
+		t.Helper()
+		st := memstore.New()
+		meta, err := metamodel.Parse([]byte(guardedMeta))
+		if err != nil {
+			t.Fatalf("metamodel.Parse: %v", err)
+		}
+		mgr, err := entitymanager.New(entitymanager.Deps{
+			Store: st, Meta: meta, Templater: nopTemplater{},
+			Audit: audit.Nop{}, ACL: acl.NopACL{},
+			Transitions: statemachine.EmptySet(),
+			FieldGate:   entitymanager.AllowAllFieldGate{},
+			CopyGuard:   g,
+		})
+		if err != nil {
+			t.Fatalf("entitymanager.New: %v", err)
+		}
+		return mgr, st
+	}
+
+	for _, tc := range []struct {
+		name  string
+		guard entitymanager.CopyGuard
+		deny  bool
+	}{
+		{"guard grants", allowGuard{allow: true}, false},
+		{"guard denies", allowGuard{allow: false}, true},
+		{"NO guard wired: fails closed", nil, true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			mgr, st := newGuarded(t, tc.guard)
+			ctx := context.Background()
+			if err := st.CreateEntity(ctx, &entity.Entity{
+				ID: "PAGE-1", Type: "page",
+				Properties: map[string]any{"title": "Draft"},
+			}); err != nil {
+				t.Fatalf("seed: %v", err)
+			}
+			_, err := mgr.CopyState(ctx, entitymanager.CopyRequest{
+				Definition: "promote-page", SourceID: "PAGE-1",
+			})
+			denied := errors.Is(err, acl.ErrForbidden)
+			if denied != tc.deny {
+				t.Errorf("denied = %v, want %v (err: %v)", denied, tc.deny, err)
+			}
+		})
+	}
+}
+
+// TestCopy_UnknownDefinitionRefused pins the by-name-only contract: a
+// request names a DEFINITION, never a mapping. If a caller could describe a
+// copy, they could describe one whose guard is convenient, and the whole
+// guard system would be decorative.
+func TestCopy_UnknownDefinitionRefused(t *testing.T) {
+	mgr, _ := newCopyManager(t, nil, allowGuard{allow: true})
+	_, err := mgr.CopyState(context.Background(), entitymanager.CopyRequest{
+		Definition: "not-declared", SourceID: "PAGE-1",
+	})
+	if !errors.Is(err, entitymanager.ErrUnknownCopy) {
+		t.Errorf("an undeclared definition must be refused as caller input; got %v", err)
+	}
+}
+
+// TestCopy_GuardedFaceIsWritableOnlyViaDefinition is the end-to-end property
+// this whole arc exists to deliver, and the one Jeroen's demo turns on.
+//
+// A DIRECT write to the published face is refused, because no role holds
+// update on it — Step 3 made `update: ["page@draft"]` name a face, and Step 4
+// PR-A made the write path pass the face to the ACL. The copy definition is
+// then the ONLY path in, and it carries its own guard.
+//
+// THREE halves are asserted, and the third is the one an earlier version of
+// this test lacked. "The copy works" proves nothing if a direct write also
+// works; "the direct write is refused" proves nothing if the copy is refused
+// too; and BOTH prove nothing if the copy would succeed for EVERYONE. The
+// first version wired an allow-everything guard against a definition that
+// had no guard block at all, so part (b) passed because authorization was
+// missing — the same passed-for-the-wrong-reason failure caught one test
+// earlier on the laundering case.
+func TestCopy_GuardedFaceIsWritableOnlyViaDefinition(t *testing.T) {
+	st := memstore.New()
+	meta, err := metamodel.Parse([]byte(copyMetaYAML))
+	if err != nil {
+		t.Fatalf("metamodel.Parse: %v", err)
+	}
+	// A policy granting update on the DRAFT face only. Nobody holds update
+	// on published — the §9.2 invariant.
+	policy := &acl.Policy{
+		Roles: map[string]acl.RoleDef{
+			"author": {Read: []string{"page"}, Update: []string{"page@draft"}},
+		},
+		Assignments: map[string]string{"alice": "author"},
+	}
+	if err := policy.Validate(); err != nil {
+		t.Fatalf("policy must load: %v", err)
+	}
+	d, derr := acl.NewDeclarative(policy, acl.NullGraph{}, acl.NullGraphQueryer{})
+	if derr != nil {
+		t.Fatalf("NewDeclarative: %v", derr)
+	}
+	mgr, merr := entitymanager.New(entitymanager.Deps{
+		Store: st, Meta: meta, Templater: nopTemplater{},
+		Audit: audit.Nop{}, ACL: d,
+		Transitions: statemachine.EmptySet(),
+		FieldGate:   entitymanager.AllowAllFieldGate{},
+		CopyGuard:   allowGuard{allow: true},
+	})
+	if merr != nil {
+		t.Fatalf("entitymanager.New: %v", merr)
+	}
+
+	ctx := principal.With(context.Background(),
+		principal.Principal{User: "alice", Tool: principal.ToolCLI})
+	if err := st.CreateEntity(ctx, &entity.Entity{
+		ID: "PAGE-1", Type: "page", Properties: map[string]any{"title": "Draft"},
+	}); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	// (a) A DIRECT write to the guarded face is refused.
+	_, directErr := mgr.UpdateEntity(ctx, &entity.Entity{
+		ID: "PAGE-1", Type: "page", Pointer: entity.Pointer("published"),
+		Properties: map[string]any{"title": "Snuck in"},
+	})
+	if !errors.Is(directErr, acl.ErrForbidden) {
+		t.Errorf("a direct write to the published face must be REFUSED — no role "+
+			"holds update on it, and that is what makes the copy definition the "+
+			"only way in; got %v", directErr)
+	}
+
+	// (b) The copy definition succeeds, for the same principal.
+	if _, err := mgr.CopyState(ctx, entitymanager.CopyRequest{
+		Definition: "promote-page", SourceID: "PAGE-1",
+	}); err != nil {
+		t.Fatalf("the copy definition must be the way in; got %v", err)
+	}
+	published, perr := st.GetEntityState(ctx, "PAGE-1", entity.Pointer("published"))
+	if perr != nil {
+		t.Fatalf("the promote did not produce a published face: %v", perr)
+	}
+	if got := published.Properties["title"]; got != "Draft" {
+		t.Errorf("published face holds %v, want the promoted draft content", got)
+	}
+
+	// (c) The guard is LOAD-BEARING: the same definition, same principal,
+	// with a guard that denies, must refuse. Without this the test would pass
+	// against a kernel that authorizes nothing at all.
+	denyMgr, derr2 := entitymanager.New(entitymanager.Deps{
+		Store: st, Meta: meta, Templater: nopTemplater{},
+		Audit: audit.Nop{}, ACL: d,
+		Transitions: statemachine.EmptySet(),
+		FieldGate:   entitymanager.AllowAllFieldGate{},
+		CopyGuard:   allowGuard{allow: false},
+	})
+	if derr2 != nil {
+		t.Fatalf("entitymanager.New: %v", derr2)
+	}
+	if _, err := denyMgr.CopyState(ctx, entitymanager.CopyRequest{
+		Definition: "promote-page", SourceID: "PAGE-1",
+	}); !errors.Is(err, acl.ErrForbidden) {
+		t.Errorf("a denying guard must refuse the copy — otherwise the definition "+
+			"is a way in for anyone who can name it; got %v", err)
+	}
+}
+
+// TestCopy_StrangerCannotPromote pins the hole an earlier cut of
+// authorizeCopy shipped: a principal holding NOTHING could promote another
+// user's draft, publishing fields they could not read.
+//
+// The reasoning that produced it was that §9.2 makes the definition the
+// authority for a guarded face. It does — but "each carrying its own guard"
+// is a CONDITION, not a license to skip authorization when a definition
+// omits one. Elevation decides which FIELDS travel; it never decides whether
+// the principal may touch the entity.
+func TestCopy_StrangerCannotPromote(t *testing.T) {
+	st := memstore.New()
+	meta, err := metamodel.Parse([]byte(copyMetaYAML))
+	if err != nil {
+		t.Fatalf("metamodel.Parse: %v", err)
+	}
+	policy := &acl.Policy{
+		Roles: map[string]acl.RoleDef{
+			"author": {Read: []string{"page"}, Update: []string{"page@draft"}},
+		},
+		Assignments: map[string]string{"alice": "author"},
+	}
+	if err := policy.Validate(); err != nil {
+		t.Fatalf("policy must load: %v", err)
+	}
+	d, derr := acl.NewDeclarative(policy, acl.NullGraph{}, acl.NullGraphQueryer{})
+	if derr != nil {
+		t.Fatalf("NewDeclarative: %v", derr)
+	}
+	req, rerr := d.ForPrincipal(principal.Principal{User: "mallory", Tool: principal.ToolCLI})
+	if rerr != nil {
+		t.Fatalf("ForPrincipal: %v", rerr)
+	}
+	mgr, merr := entitymanager.New(entitymanager.Deps{
+		Store: st, Meta: meta, Templater: nopTemplater{},
+		Audit: audit.Nop{}, ACL: d,
+		Transitions:  statemachine.EmptySet(),
+		FieldGate:    entitymanager.AllowAllFieldGate{},
+		CopyGuard:    allowGuard{allow: true}, // even a PERMISSIVE guard
+		CopyReadGate: req,
+	})
+	if merr != nil {
+		t.Fatalf("entitymanager.New: %v", merr)
+	}
+
+	seed := principal.With(context.Background(),
+		principal.Principal{User: "alice", Tool: principal.ToolCLI})
+	if err := st.CreateEntity(seed, &entity.Entity{
+		ID: "PAGE-1", Type: "page",
+		Properties: map[string]any{"title": "Draft", "secret": "classified"},
+	}); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	mctx := principal.With(context.Background(),
+		principal.Principal{User: "mallory", Tool: principal.ToolCLI})
+	if _, err := mgr.CopyState(mctx, entitymanager.CopyRequest{
+		Definition: "promote-page", SourceID: "PAGE-1",
+	}); err == nil {
+		t.Error("a principal holding NOTHING promoted another user's draft, " +
+			"publishing a field they cannot read — a copy must check READ on the " +
+			"source before either half of the elevation split runs")
+	}
+}
+
+// TestCopy_EdgesLandOnTheStoredTail pins the phantom-tail failure.
+//
+// A pointer marked `default: true` IS the zero coordinate — it names which
+// declared coordinate the default state answers to, it does not create a
+// second row. So a copy INTO the default face must write its edges at the
+// zero tail. Using the DECLARED name instead produces edges at a tail no
+// face lives at: orphaned, invisible to the face they belong to, and
+// invisible to a `replace` that queries the correct tail — so stale edges
+// survive too. Silent in both directions.
+//
+// This also covers relation copying at all, plus `replace`, neither of which
+// had a test.
+func TestCopy_EdgesLandOnTheStoredTail(t *testing.T) {
+	const meta = `
+version: "1"
+entities:
+  page:
+    label: Page
+    id_prefix: PAGE
+    pointers:
+      draft: {default: true}
+      published: {}
+    properties:
+      title: {type: string}
+  spec:
+    label: Spec
+    id_prefix: SPEC
+    properties:
+      title: {type: string}
+relations:
+  cites:
+    from: [page]
+    to: [spec]
+    scope: content
+copies:
+  revise-page:
+    from: page@published
+    to: page@draft
+    fields: all
+    relations:
+      cites: replace
+`
+	st := memstore.New()
+	m, err := metamodel.Parse([]byte(meta))
+	if err != nil {
+		t.Fatalf("metamodel.Parse: %v", err)
+	}
+	mgr, err := entitymanager.New(entitymanager.Deps{
+		Store: st, Meta: m, Templater: nopTemplater{},
+		Audit: audit.Nop{}, ACL: acl.NopACL{},
+		Transitions: statemachine.EmptySet(),
+		FieldGate:   entitymanager.AllowAllFieldGate{},
+	})
+	if err != nil {
+		t.Fatalf("entitymanager.New: %v", err)
+	}
+	ctx := context.Background()
+
+	for _, id := range []string{"SPEC-9", "SPEC-12"} {
+		if err := st.CreateEntity(ctx, &entity.Entity{ID: id, Type: "spec"}); err != nil {
+			t.Fatalf("seed %s: %v", id, err)
+		}
+	}
+	// The draft (default) face cites SPEC-12; the published face cites SPEC-9.
+	if err := st.CreateEntity(ctx, &entity.Entity{
+		ID: "PAGE-1", Type: "page", Properties: map[string]any{"title": "Draft"},
+	}); err != nil {
+		t.Fatalf("seed draft: %v", err)
+	}
+	published := entity.Pointer("published")
+	if err := st.CreateEntity(ctx, &entity.Entity{
+		ID: "PAGE-1", Type: "page", Pointer: published,
+		Properties: map[string]any{"title": "Published"},
+	}); err != nil {
+		t.Fatalf("seed published: %v", err)
+	}
+	zero := entity.Pointer("")
+	if _, err := st.CreateRelation(ctx, "PAGE-1", "cites", "SPEC-12",
+		&store.RelationData{FromPointer: zero}); err != nil {
+		t.Fatalf("seed draft edge: %v", err)
+	}
+	if _, err := st.CreateRelation(ctx, "PAGE-1", "cites", "SPEC-9",
+		&store.RelationData{FromPointer: published}); err != nil {
+		t.Fatalf("seed published edge: %v", err)
+	}
+
+	// Revise: published -> draft. `draft` is the DEFAULT pointer, so the
+	// target tail is the ZERO coordinate.
+	if _, err := mgr.CopyState(ctx, entitymanager.CopyRequest{
+		Definition: "revise-page", SourceID: "PAGE-1",
+	}); err != nil {
+		t.Fatalf("revise: %v", err)
+	}
+
+	var atZero, atDeclared, stale int
+	for rel, err := range st.ListRelations(ctx, store.RelationQuery{From: "PAGE-1"}) {
+		if err != nil {
+			t.Fatalf("list: %v", err)
+		}
+		switch {
+		case rel.FromPointer == "" && rel.To == "SPEC-9":
+			atZero++
+		case rel.FromPointer == "draft":
+			atDeclared++
+		case rel.FromPointer == "" && rel.To == "SPEC-12":
+			stale++
+		}
+	}
+	if atDeclared != 0 {
+		t.Errorf("%d edge(s) landed at the DECLARED tail %q — that pointer is the "+
+			"type's default, so it IS the zero coordinate and no face lives there; "+
+			"the edges are orphaned from the face they belong to", atDeclared, "draft")
+	}
+	if stale != 0 {
+		t.Errorf("`replace` left %d stale edge(s) at the target tail — it queried "+
+			"the wrong tail, found nothing, and deleted nothing", stale)
+	}
+	if atZero != 1 {
+		t.Errorf("want the copied edge at the zero tail, got %d", atZero)
+	}
+}

--- a/internal/entitymanager/manager.go
+++ b/internal/entitymanager/manager.go
@@ -223,6 +223,34 @@ type Deps struct {
 	// gate is the "forgotten wiring must not become an ACL bypass" failure
 	// (RR-X9NVHI), and it matches how ACL and Audit are already handled.
 	FieldGate FieldWriteGate
+
+	// CopyVisibility is the CALLER'S read gate, used only by CROSS-ENTITY
+	// copies (TKT-C1XUA8, design doc §9.2). Nil disables the gating, which is
+	// correct for a deployment with no ACL — every other read there is raw
+	// too — and is what the CLI passes.
+	//
+	// Deliberately NOT used by same-entity copies: those run elevated,
+	// because hidden fields travel with the entity and the same policy
+	// governs them on the target face. Routing them through this gate would
+	// be the redacted-read-feeds-a-write bug, which destroys the fields the
+	// principal could not see.
+	CopyVisibility CopyReader
+
+	// CopyGuard evaluates a copy definition's `guard:` permission against the
+	// SOURCE entity, so "the owner of THIS doc may publish it" works without
+	// a global grant. Nil makes a GUARDED copy fail closed, matching the
+	// statemachine's nil-guard rule; an unguarded copy is unaffected.
+	CopyGuard CopyGuard
+
+	// CopyReadGate answers "may this principal READ the copy's source at
+	// all", before either half of the elevation split runs (TKT-C1XUA8).
+	//
+	// Required in spirit and nil-tolerant in practice for the same reason
+	// every other gate here is: a deployment with no acl.yaml has no gate to
+	// consult, and every other read on it is ungated too. What it must never
+	// be is absent on a deployment that HAS a policy — elevation decides
+	// which fields travel, not whether the principal may touch the entity.
+	CopyReadGate CopyReadGate
 }
 
 // FieldWriteGate answers whether the ctx principal may write the named
@@ -273,6 +301,33 @@ func (AllowAllFieldGate) CheckFieldWrite(
 // compiled state machines: enforce an update (old→new) and a create's entry
 // value. Defined at the call site (CLAUDE.md consumer-side interfaces);
 // [*statemachine.Set] satisfies it.
+// CopyReader is the caller-scoped read a CROSS-ENTITY copy sees. Narrow by
+// design: the copy needs one lookup, and taking the whole visibility.Reader
+// would bind this package to methods it never calls.
+//
+// Get returns (nil, false, nil) indistinguishably for denied, missing and
+// type-mismatched — whether an entity exists is a genuine secret.
+type CopyReader interface {
+	Get(ctx context.Context, entityType, id string) (*entity.Entity, bool, error)
+}
+
+// CopyGuard answers a copy definition's `guard:` permission for one subject.
+//
+// The same shape as statemachine.Guard, and satisfied by the same wiring —
+// the point of reusing the vocabulary is that the two cannot drift into
+// asking different questions. Subject is the bare entity id, matching the
+// conferral model: identity-scoped roles confer on the entity in every
+// world, and the face-granularity already lives in the write grant.
+// CopyReadGate is the row-level read verdict for a copy's SOURCE. Narrow by
+// design; satisfied by the same acl.Request the rest of the read path uses.
+type CopyReadGate interface {
+	PermitsRead(ctx context.Context, entityType, entityID string) (bool, error)
+}
+
+type CopyGuard interface {
+	HoldsPermission(ctx context.Context, entityID, permission string) bool
+}
+
 type TransitionEnforcer interface {
 	EnforceUpdate(
 		ctx context.Context, old, updated *entity.Entity,

--- a/internal/metamodel/copies.go
+++ b/internal/metamodel/copies.go
@@ -1,0 +1,297 @@
+package metamodel
+
+import (
+	"errors"
+	"fmt"
+	"slices"
+	"sort"
+	"strings"
+)
+
+// newEntityPrefix marks a copy's `to:` as CROSS-ENTITY — it creates the
+// target rather than writing a face of the source (design doc §9.1).
+const newEntityPrefix = "new "
+
+// CopyTarget is a parsed `from:` / `to:` address.
+type CopyTarget struct {
+	// Type is the entity type. Always set on a valid target.
+	Type string
+	// Pointer is the content state, or "" for the default face.
+	Pointer string
+	// IsNew is true for the `new <type>` form, which creates the target.
+	IsNew bool
+}
+
+// ParseCopyTarget splits a copy address: `type`, `type@pointer`, or
+// `new type`. Whitespace-trimmed; the caller validates that the parts name
+// declared things.
+//
+// The returned Pointer is the DECLARED NAME, which is not always the stored
+// coordinate — a pointer marked `default: true` IS the zero pointer
+// (PointerDef.Default). Use [Metamodel.StoredPointer] to resolve a declared
+// name to the coordinate the store addresses.
+func ParseCopyTarget(s string) (CopyTarget, error) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return CopyTarget{}, errors.New("empty target")
+	}
+	var t CopyTarget
+	if rest, ok := strings.CutPrefix(s, newEntityPrefix); ok {
+		t.IsNew = true
+		s = strings.TrimSpace(rest)
+		if s == "" {
+			return CopyTarget{}, fmt.Errorf("%q names no entity type", newEntityPrefix)
+		}
+	}
+	typeName, pointer, found := strings.Cut(s, "@")
+	t.Type, t.Pointer = strings.TrimSpace(typeName), strings.TrimSpace(pointer)
+	if t.Type == "" {
+		return CopyTarget{}, errors.New("names a state but no entity type")
+	}
+	if found && t.Pointer == "" {
+		return CopyTarget{}, fmt.Errorf("names no content state after %q", "@")
+	}
+	if t.IsNew && found {
+		return CopyTarget{}, errors.New(
+			"a `new` target creates an entity, so it addresses the type's default " +
+				"state and must not name one")
+	}
+	return t, nil
+}
+
+// IsSameEntity reports whether a definition copies between faces of ONE
+// entity (promote, revise) rather than into a different entity.
+//
+// This is the ELEVATION BOUNDARY (§9.2), so it is one predicate rather than
+// a condition spelled out at each call site: same-entity copies run
+// elevated, cross-entity copies read through the caller's visibility gate.
+func (c CopyDef) IsSameEntity() bool {
+	from, ferr := ParseCopyTarget(c.From)
+	to, terr := ParseCopyTarget(c.To)
+	if ferr != nil || terr != nil {
+		return false
+	}
+	return !to.IsNew && from.Type == to.Type
+}
+
+// validateCopies checks the `copies:` block against the schema. Every check
+// here is a LOAD-TIME refusal: a copy writes content into a face that a
+// world may publish, so a definition that resolves wrongly is exactly the
+// leak this feature exists to prevent.
+func validateCopies(m *Metamodel) []string {
+	if len(m.Copies) == 0 {
+		return nil
+	}
+	names := make([]string, 0, len(m.Copies))
+	for name := range m.Copies {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	var errs []string
+	for _, name := range names {
+		errs = append(errs, validateCopy(m, name, m.Copies[name])...)
+	}
+	return errs
+}
+
+func validateCopy(m *Metamodel, name string, def CopyDef) []string {
+	var errs []string
+	bad := func(format string, args ...any) {
+		errs = append(errs, fmt.Sprintf("copy %q: "+format, append([]any{name}, args...)...))
+	}
+	if strings.TrimSpace(name) == "" {
+		return []string{"copies: definition name must not be empty"}
+	}
+
+	from, err := ParseCopyTarget(def.From)
+	if err != nil {
+		bad("from: %v", err)
+	}
+	to, terr := ParseCopyTarget(def.To)
+	if terr != nil {
+		bad("to: %v", terr)
+	}
+	if err != nil || terr != nil {
+		return errs
+	}
+	errs = append(errs, validateCopyEndpoint(m, name, "from", from)...)
+	errs = append(errs, validateCopyEndpoint(m, name, "to", to)...)
+
+	sameEntity := !to.IsNew && from.Type == to.Type
+	if !sameEntity && def.AllFields {
+		// The load error the whole cross-entity half turns on. A cross-entity
+		// copy reads through the CALLER'S visibility gate, so `fields: all`
+		// would write whatever survived redaction as if it were the whole
+		// entity — destroying the fields the principal could not see. That is
+		// the redacted read-modify-write the codebase forbids everywhere, and
+		// refusing at load costs an operator a startup message instead of
+		// silent field destruction at runtime.
+		bad("`fields: all` is not allowed on a cross-entity copy — that copy " +
+			"reads through the caller's visibility gate, so copying every field " +
+			"would write a REDACTED entity and destroy the fields they cannot " +
+			"see; name the fields to copy explicitly")
+	}
+	if def.AllFields && len(def.Fields) > 0 {
+		bad("declares both `fields: all` and a field mapping — pick one")
+	}
+	if !def.AllFields && len(def.Fields) == 0 {
+		bad("copies no fields — set `fields: all` (same-entity only) or map at least one")
+	}
+	if !sameEntity && from.Type != to.Type && len(def.Fields) == 0 {
+		bad("a cross-type copy requires an explicit field map")
+	}
+
+	// A definition targeting a NON-DEFAULT face must carry a guard. §9.2's
+	// "writable only by copy definitions naming it as target, EACH CARRYING
+	// ITS OWN GUARD" is conditioned on the guard existing; an unguarded
+	// definition into a guarded face would make the whole face writable by
+	// anyone who can name the definition, which is the opposite of what
+	// declaring it was supposed to buy.
+	targetsGuardedFace := to.Pointer != "" && StoredPointer(m, to.Type, to.Pointer) != ""
+	if targetsGuardedFace && def.Guard.Permission == "" {
+		bad("targets the guarded face %q@%q but declares no `guard: {permission: ...}` — "+
+			"a guarded face is writable only through a definition that carries its "+
+			"own guard, so an unguarded one would open the face to anyone who can "+
+			"name this copy", to.Type, to.Pointer)
+	}
+	if def.Guard.When != "" {
+		// Declared, parsed, and NOT evaluated. Accepting it silently would be
+		// the worst outcome: an operator writes
+		// `when: "source.status == 'approved'"`, the schema loads clean, and
+		// unapproved drafts publish. Refusing costs them a startup message.
+		bad("`guard.when` is not implemented yet — remove it, or the copy would " +
+			"run without evaluating the condition you wrote")
+	}
+
+	errs = append(errs, validateCopyFields(m, name, def, to)...)
+	errs = append(errs, validateCopyRelations(m, name, def, to)...)
+	return errs
+}
+
+// validateCopyEndpoint checks that a target names a declared type and, when
+// it names a face, a pointer that type declares.
+func validateCopyEndpoint(m *Metamodel, name, side string, t CopyTarget) []string {
+	var errs []string
+	def, ok := m.GetEntityDef(t.Type)
+	if !ok {
+		return []string{fmt.Sprintf(
+			"copy %q: %s: entity type %q is not declared", name, side, t.Type)}
+	}
+	if t.Pointer == "" {
+		return nil
+	}
+	if _, declared := def.Pointers[t.Pointer]; !declared {
+		errs = append(errs, fmt.Sprintf(
+			"copy %q: %s: entity type %q declares no content state %q",
+			name, side, t.Type, t.Pointer))
+	}
+	return errs
+}
+
+// validateCopyFields checks mapped field names against the TARGET type's
+// declared properties. The value side is an interpolation template, checked
+// only for grammar — its property references resolve at copy time.
+func validateCopyFields(m *Metamodel, name string, def CopyDef, to CopyTarget) []string {
+	targetDef, ok := m.GetEntityDef(to.Type)
+	if !ok {
+		return nil // already reported by validateCopyEndpoint
+	}
+	fields := make([]string, 0, len(def.Fields))
+	for f := range def.Fields {
+		fields = append(fields, f)
+	}
+	sort.Strings(fields)
+
+	var errs []string
+	for _, f := range fields {
+		if _, declared := targetDef.Properties[f]; !declared {
+			errs = append(errs, fmt.Sprintf(
+				"copy %q: fields: entity type %q declares no property %q",
+				name, to.Type, f))
+		}
+	}
+	return errs
+}
+
+// validateCopyRelations checks the per-relation-type verbs and that each
+// named relation is declared and may originate from the target type.
+func validateCopyRelations(m *Metamodel, name string, def CopyDef, to CopyTarget) []string {
+	rels := make([]string, 0, len(def.Relations))
+	for r := range def.Relations {
+		rels = append(rels, r)
+	}
+	sort.Strings(rels)
+
+	var errs []string
+	for _, rel := range rels {
+		switch def.Relations[rel] {
+		case "merge", "replace":
+		default:
+			errs = append(errs, fmt.Sprintf(
+				"copy %q: relations.%s: %q is not a valid mode (want \"merge\" or \"replace\")",
+				name, rel, def.Relations[rel]))
+		}
+		relDef, ok := m.GetRelationDef(rel)
+		if !ok {
+			errs = append(errs, fmt.Sprintf(
+				"copy %q: relations: relation type %q is not declared", name, rel))
+			continue
+		}
+		// §9.2's FIRST mitigation for "copying relations can mint authority".
+		// An identity-scoped edge attaches to the bare id and is shared by
+		// every state (§2.2), so copying one onto a state tail is at best
+		// meaningless and at worst mints a duplicate role-conferring edge
+		// whose lifecycle nothing manages. Role-conferring types are declared
+		// in acl.yaml, which the metamodel cannot see — but they are
+		// overwhelmingly identity-scoped, so this catches the class.
+		if relDef.Scope.IsIdentity() {
+			errs = append(errs, fmt.Sprintf(
+				"copy %q: relations.%s: relation %q is identity-scoped, so it attaches "+
+					"to the entity rather than to a face and is shared by every state — "+
+					"copying it would duplicate an edge that may confer roles; only "+
+					"content-scoped relations can be copied",
+				name, rel, rel))
+			continue
+		}
+		if !slices.Contains(relDef.From, to.Type) {
+			errs = append(errs, fmt.Sprintf(
+				"copy %q: relations.%s: relation %q cannot originate from entity type %q "+
+					"(its `from` is %v)", name, rel, rel, to.Type, relDef.From))
+		}
+	}
+	return errs
+}
+
+// StoredPointer resolves a DECLARED pointer name to the coordinate the store
+// addresses for that face.
+//
+// A package function rather than a *Metamodel method: that type sits at its
+// plimsoll exported-method cap, and the cap is a ratchet to narrow rather
+// than raise.
+//
+// The mapping is identity except for the type's default pointer, which is
+// stored under the ZERO coordinate: `default: true` names which declared
+// coordinate the default state answers to, it does not create a second row
+// (design doc §2.1 — there are exactly N states and nothing else).
+//
+// Getting this wrong is not a cosmetic bug. A copy addressing `page@draft`
+// when draft is the default would read a face that does not exist, and a
+// copy WRITING it would mint a second row for a state the entity already
+// has — two rows claiming to be the same face.
+func StoredPointer(m *Metamodel, entityType, declared string) string {
+	if m == nil {
+		return declared
+	}
+	if declared == "" {
+		return ""
+	}
+	def, ok := m.GetEntityDef(entityType)
+	if !ok {
+		return declared
+	}
+	if p, found := def.Pointers[declared]; found && p.Default {
+		return ""
+	}
+	return declared
+}

--- a/internal/metamodel/copies_test.go
+++ b/internal/metamodel/copies_test.go
@@ -1,0 +1,244 @@
+package metamodel
+
+import (
+	"strings"
+	"testing"
+)
+
+// copyFixture is a metamodel with two pointered types and one relation, so
+// each validation case varies only the copy definition.
+func copyFixture(copies map[string]CopyDef) *Metamodel {
+	m := &Metamodel{
+		Entities: map[string]EntityDef{
+			"page": {
+				Label:    "Page",
+				Pointers: map[string]PointerDef{"draft": {Default: true}, "published": {}},
+				Properties: map[string]PropertyDef{
+					"title":  {Type: "string"},
+					"status": {Type: "string"},
+				},
+			},
+			"ticket": {
+				Label:      "Ticket",
+				Properties: map[string]PropertyDef{"title": {Type: "string"}},
+			},
+		},
+		Relations: map[string]RelationDef{
+			// Content-scoped: copyable.
+			"implements": {
+				From: []string{"page"}, To: []string{"ticket"},
+				Scope: ScopeContent,
+			},
+			// Identity-scoped: NOT copyable — it attaches to the bare id.
+			"owned-by": {
+				From: []string{"page"}, To: []string{"ticket"},
+				Scope: ScopeIdentityExplicit,
+			},
+			// Content-scoped but originating elsewhere.
+			"blocks": {
+				From: []string{"ticket"}, To: []string{"page"},
+				Scope: ScopeContent,
+			},
+		},
+		Copies: copies,
+	}
+	m.InitAliases()
+	return m
+}
+
+// TestValidateCopies_FieldsAllRejectedCrossEntity is the load error the
+// cross-entity half of the elevation split turns on.
+//
+// A cross-entity copy reads through the CALLER'S visibility gate, so
+// `fields: all` would copy whatever survived redaction as though it were the
+// whole entity — destroying every field the principal could not see. That is
+// the redacted read-modify-write forbidden everywhere else in this codebase,
+// and it is refused at LOAD so an operator gets a startup message instead of
+// silent field destruction on the first copy.
+func TestValidateCopies_FieldsAllRejectedCrossEntity(t *testing.T) {
+	t.Parallel()
+
+	// Cross-entity: refused.
+	errs := validateCopies(copyFixture(map[string]CopyDef{
+		"spawn": {From: "ticket", To: "new ticket", AllFields: true},
+	}))
+	if len(errs) == 0 {
+		t.Fatal("`fields: all` on a cross-entity copy must be a load error — it " +
+			"would write a redacted entity")
+	}
+	joined := strings.Join(errs, "\n")
+	if !strings.Contains(joined, "visibility gate") {
+		t.Errorf("the error must explain WHY, so the operator does not read it as "+
+			"an arbitrary restriction; got: %s", joined)
+	}
+
+	// Same-entity: allowed — it runs elevated, so every field is readable and
+	// a full replace is the promote case.
+	if errs := validateCopies(copyFixture(map[string]CopyDef{
+		"promote": {From: "page@draft", To: "page@published", AllFields: true, Guard: guarded},
+	})); len(errs) != 0 {
+		t.Errorf("`fields: all` is the promote case and must be allowed on a "+
+			"same-entity copy; got: %v", errs)
+	}
+}
+
+// guarded is the guard every definition targeting a non-default face must
+// carry — see validateCopy's guarded-face check.
+var guarded = CopyGuard{Permission: "promote-page"}
+
+func TestValidateCopies(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		def     CopyDef
+		wantErr string // substring; empty = must validate
+	}{
+		{
+			name: "valid same-entity promote",
+			def:  CopyDef{From: "page@draft", To: "page@published", AllFields: true, Guard: guarded},
+		},
+		{
+			name: "valid cross-entity spawn",
+			def: CopyDef{
+				From: "ticket", To: "new ticket",
+				Fields: map[string]string{"title": "Follow-up: {{source.title}}"},
+			},
+		},
+		{
+			name:    "undeclared source type",
+			def:     CopyDef{From: "nosuchtype@draft", To: "page@published", AllFields: true},
+			wantErr: "entity type \"nosuchtype\" is not declared",
+		},
+		{
+			name:    "undeclared pointer on a declared type",
+			def:     CopyDef{From: "page@nosuchstate", To: "page@published", AllFields: true},
+			wantErr: "declares no content state \"nosuchstate\"",
+		},
+		{
+			name:    "a type with no pointers cannot name a face",
+			def:     CopyDef{From: "ticket@draft", To: "page@published", AllFields: true},
+			wantErr: "declares no content state \"draft\"",
+		},
+		{
+			name: "undeclared target field",
+			def: CopyDef{
+				From: "page@draft", To: "page@published", Guard: guarded,
+				Fields: map[string]string{"nosuchfield": "x"},
+			},
+			wantErr: "declares no property \"nosuchfield\"",
+		},
+		{
+			name: "invalid relation mode",
+			def: CopyDef{
+				From: "page@draft", To: "page@published", AllFields: true, Guard: guarded,
+				Relations: map[string]string{"implements": "copy"},
+			},
+			wantErr: "is not a valid mode",
+		},
+		{
+			name: "undeclared relation type",
+			def: CopyDef{
+				From: "page@draft", To: "page@published", AllFields: true, Guard: guarded,
+				Relations: map[string]string{"nosuchrel": "merge"},
+			},
+			wantErr: "relation type \"nosuchrel\" is not declared",
+		},
+		{
+			name: "relation cannot originate from the target type",
+			def: CopyDef{
+				From: "page@draft", To: "page@published", AllFields: true, Guard: guarded,
+				// blocks runs FROM ticket, so a page face cannot hold one.
+				Relations: map[string]string{"blocks": "merge"},
+			},
+			wantErr: "cannot originate from entity type \"page\"",
+		},
+		{
+			name:    "copies nothing",
+			def:     CopyDef{From: "page@draft", To: "page@published", Guard: guarded},
+			wantErr: "copies no fields",
+		},
+		{
+			name: "both fields: all and a mapping",
+			def: CopyDef{
+				From: "page@draft", To: "page@published", AllFields: true, Guard: guarded,
+				Fields: map[string]string{"title": "x"},
+			},
+			wantErr: "declares both",
+		},
+		{
+			name:    "a new target must not name a face",
+			def:     CopyDef{From: "ticket", To: "new ticket@draft", AllFields: true},
+			wantErr: "must not name one",
+		},
+		{
+			name:    "empty from",
+			def:     CopyDef{From: "", To: "page@published", AllFields: true, Guard: guarded},
+			wantErr: "empty target",
+		},
+		{
+			name:    "a guarded face requires a guard",
+			def:     CopyDef{From: "page@draft", To: "page@published", AllFields: true},
+			wantErr: "declares no `guard:",
+		},
+		{
+			name: "an identity-scoped relation cannot be copied",
+			def: CopyDef{
+				From: "page@draft", To: "page@published", AllFields: true, Guard: guarded,
+				Relations: map[string]string{"owned-by": "merge"},
+			},
+			wantErr: "is identity-scoped",
+		},
+		{
+			name: "guard.when is refused while unimplemented",
+			def: CopyDef{
+				From: "page@draft", To: "page@published", AllFields: true,
+				Guard: CopyGuard{Permission: "promote", When: "source.status == 'approved'"},
+			},
+			wantErr: "not implemented yet",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			errs := validateCopies(copyFixture(map[string]CopyDef{"c": tc.def}))
+			joined := strings.Join(errs, "\n")
+			if tc.wantErr == "" {
+				if len(errs) != 0 {
+					t.Fatalf("must validate; got: %s", joined)
+				}
+				return
+			}
+			if !strings.Contains(joined, tc.wantErr) {
+				t.Errorf("want an error containing %q; got: %s", tc.wantErr, joined)
+			}
+		})
+	}
+}
+
+// TestCopyDef_IsSameEntity pins the ELEVATION BOUNDARY. Getting this
+// predicate wrong in the permissive direction means a cross-entity copy runs
+// elevated, which launders fields the principal cannot read into an entity
+// with a different audience.
+func TestCopyDef_IsSameEntity(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		from, to string
+		want     bool
+	}{
+		{"page@draft", "page@published", true},
+		{"page", "page@draft", true},
+		{"ticket", "new ticket", false},
+		{"page@draft", "new page", false},
+		{"page@draft", "ticket@draft", false},
+		{"", "page@published", false}, // unparseable: not same-entity
+		{"page@draft", "", false},     // unparseable: not same-entity
+		{"page@draft", "new ticket@draft", false},
+	}
+	for _, tc := range tests {
+		def := CopyDef{From: tc.from, To: tc.to}
+		if got := def.IsSameEntity(); got != tc.want {
+			t.Errorf("IsSameEntity(%q -> %q) = %v, want %v — this predicate decides "+
+				"whether the copy runs ELEVATED", tc.from, tc.to, got, tc.want)
+		}
+	}
+}

--- a/internal/metamodel/loader.go
+++ b/internal/metamodel/loader.go
@@ -26,6 +26,7 @@ var validTopLevelKeys = map[string]bool{
 	"attachments": true,
 	"transforms":  true,
 	"worlds":      true,
+	"copies":      true,
 }
 
 // knownTypos maps common misspellings to the correct key name.
@@ -243,6 +244,7 @@ func validate(m *Metamodel) error {
 	validationErrors = append(validationErrors, validateRelationOrderable(m)...)
 	validationErrors = append(validationErrors, validateRelationScope(m)...)
 	validationErrors = append(validationErrors, validateTransforms(m)...)
+	validationErrors = append(validationErrors, validateCopies(m)...)
 	validationErrors = append(validationErrors, validatePointers(m)...)
 	validationErrors = append(validationErrors, validateWorlds(m)...)
 

--- a/internal/metamodel/types.go
+++ b/internal/metamodel/types.go
@@ -1,6 +1,8 @@
 package metamodel
 
 import (
+	"errors"
+	"fmt"
 	"regexp"
 	"time"
 
@@ -54,6 +56,11 @@ type Metamodel struct {
 	// ([DefaultWorldName]) because that world is implicit and total, so
 	// a declaration under that name could only shadow or contradict it.
 	Worlds map[string]WorldDef `yaml:"worlds,omitempty"`
+
+	// Copies declares named copy definitions — mapped writes of one content
+	// state into another (TKT-C1XUA8). See [CopyDef]; a request invokes one
+	// BY NAME and can never submit its own mapping.
+	Copies map[string]CopyDef `yaml:"copies,omitempty"`
 
 	// Computed lookups (not from YAML)
 	aliasMap      map[string]string // alias -> canonical name
@@ -570,6 +577,106 @@ func (t TransformStep) Kind() string {
 //
 // The mirror of this in internal/transform is transform.Def; the metamodel keeps
 // its own YAML-tagged type so internal/transform need not be imported here.
+// CopyDef declares one named COPY DEFINITION: a mapped write of one entity
+// content state (face) into another (design doc §9.1, TKT-C1XUA8).
+//
+// A request may only invoke a definition BY NAME — never submit an ad-hoc
+// mapping. That is the transforms-registry precedent and it is what keeps
+// the guard system meaningful: if a caller could describe an arbitrary copy,
+// every guard would be advisory.
+//
+// Two shapes, and the difference is a security boundary (§9.2):
+//
+//   - SAME-ENTITY (`from: page@draft`, `to: page@published`) — promote and
+//     revise. Runs ELEVATED: hidden fields travel with the entity, the
+//     principal never sees them, and the same policy governs them on the
+//     target face. Identity preserved, so policy follows.
+//   - CROSS-ENTITY (`from: ticket`, `to: new ticket`) — spawn-a-follow-up.
+//     Reads through the CALLER'S visibility gate, so only fields they may
+//     read carry. An elevated cross-entity copy would launder unreadable
+//     fields into an entity with a different audience.
+type CopyDef struct {
+	// From and To address a face as `type` or `type@pointer`. A bare type on
+	// both sides with `to` prefixed `new ` is the cross-entity form.
+	From string `yaml:"from"`
+	To   string `yaml:"to"`
+
+	// Fields maps target property -> source expression. The literal string
+	// "all" in AllFields copies every declared property; the two are
+	// mutually exclusive.
+	//
+	// Deliberately dumb (§9.1): field selection, rename, and the existing
+	// {{...}} interpolation grammar. No expressions, no conditionals — the
+	// same slippery slope world templates refused, with the same answer.
+	Fields map[string]string `yaml:"fields,omitempty"`
+
+	// AllFields is `fields: all` — the full-replace promote case. Rejected
+	// at load on a CROSS-ENTITY copy: that copy reads through the caller's
+	// gate, so a whole-entity replace would write a REDACTED entity, which
+	// is the read-modify-write failure the codebase forbids everywhere.
+	AllFields bool `yaml:"-"`
+
+	// Relations maps a relation type to `merge` (add missing) or `replace`
+	// (swap the target face's edges of that type). An omitted type is not
+	// copied — the safe default, since copying a role-conferring edge grants
+	// roles on the target.
+	Relations map[string]string `yaml:"relations,omitempty"`
+
+	// Guard gates the copy. Reuses the STATEMACHINE's vocabulary — the
+	// `guard:` permission (subject-aware, via HoldsPermissionForEntity) and
+	// a `when:` predicate — rather than acl.yaml's `requires_permission`,
+	// which is the delegate-X gate on role-relation writes and is checked
+	// globally. "The owner of THIS doc may publish it" needs the former.
+	Guard CopyGuard `yaml:"guard,omitempty"`
+}
+
+// CopyGuard is a copy definition's authorization, sharing the statemachine's
+// declaration vocabulary (§9.1: shared guard machinery, separate declaration
+// — a copy is not a property change).
+type CopyGuard struct {
+	// Permission is an ACL permission name checked against the SOURCE entity
+	// via HoldsPermissionForEntity, so a role conferred by an ownership
+	// relation satisfies it without a global grant.
+	Permission string `yaml:"permission,omitempty"`
+
+	// When is an internal/predicate expression evaluated against the source
+	// face. False refuses the copy (422), matching a transition precondition.
+	When string `yaml:"when,omitempty"`
+}
+
+// UnmarshalYAML accepts `fields: all` as a scalar alongside the mapping form.
+func (c *CopyDef) UnmarshalYAML(unmarshal func(any) error) error {
+	// Alias avoids infinite recursion into this method.
+	type raw struct {
+		From      string            `yaml:"from"`
+		To        string            `yaml:"to"`
+		Fields    any               `yaml:"fields,omitempty"`
+		Relations map[string]string `yaml:"relations,omitempty"`
+		Guard     CopyGuard         `yaml:"guard,omitempty"`
+	}
+	var r raw
+	if err := unmarshal(&r); err != nil {
+		return err
+	}
+	c.From, c.To, c.Relations, c.Guard = r.From, r.To, r.Relations, r.Guard
+	switch f := r.Fields.(type) {
+	case nil:
+	case string:
+		if f != "all" {
+			return fmt.Errorf("copy: fields: %q is not valid — use a mapping, or the literal \"all\"", f)
+		}
+		c.AllFields = true
+	case map[string]any:
+		c.Fields = make(map[string]string, len(f))
+		for k, v := range f {
+			c.Fields[k] = fmt.Sprint(v)
+		}
+	default:
+		return errors.New("copy: fields: want a mapping or the literal \"all\"")
+	}
+	return nil
+}
+
 type TransformDef struct {
 	From     string   `yaml:"from"`
 	Command  []string `yaml:"command"`


### PR DESCRIPTION
PR-C of TKT-C1XUA8 (Step 4) — **the last backend PR of the content-states epic.** This is what makes `promote` exist. Code-only; paperwork on the companion PR.

Tickets-PR: #1422

Stack: #1423 ← #1427 ← #1428 ← #1429 (PR-A) ← #1430 (PR-B) ← **this**.

## The kernel, and why it is dumb

*Write this set of fields, this body, these edges into target face T, in one store `Tx`, audited.* No policy, no mapping logic. **Copy definitions** are named, metamodel-declared mappings compiled onto it, and **a request may only invoke a definition BY NAME** — never submit an ad-hoc mapping. That is the transforms-registry precedent, and it is what keeps the guard system from being decorative.

```yaml
copies:
  promote-policy:
    from: policy@draft
    to:   policy@published
    fields: all
    relations: replace
    guard: { requires_permission: promote-policy, when: "source.status == 'approved'" }
```

## The security split (§9.2) — both halves pinned

- **Same-entity copies run ELEVATED** — `TestCopy_SameEntityIsElevated_HiddenFieldsSurvive`. Hidden fields travel with the entity, the principal never sees them, and the same policy governs them on the target face. Identity preserved → policy follows. A redacted copy here would destroy fields the caller cannot see, the read-modify-write failure forbidden everywhere else.
- **Cross-entity copies read through the CALLER'S visibility gate** — `TestCopy_CrossEntityReadsThroughCallersGate_NoLaundering`. New identity → new audience → visible-only. An elevated cross-entity copy would launder fields the principal cannot read into an entity with a different audience.

Two tests, not one: they fail in opposite directions, and a single "copying works" test would pass while either half was wrong.

## The property the ISMS demo turns on

`TestCopy_GuardedFaceIsWritableOnlyViaDefinition` — with PR-A making writes face-aware and Step 3 (#1423) leaving `policy@published` with no write grant, a **direct write to a guarded face is refused and the copy definition is the only path in.** That is the claim "a published policy is not directly editable" actually makes, so it is a test rather than an assumption.

Also pinned: `TestCopy_GuardDeniesWithoutPermission`, `TestCopy_UnknownDefinitionRefused`.

## Decisions visible in the code

- **`guard:`, not `requires_permission`** — `guard:` routes through the subject-aware `HoldsPermissionForEntity`, which is what "the owner of *this* doc may publish it" requires. `requires_permission` is the role-relation delegate gate checked globally; the ticket's original vocabulary was wrong and is corrected here.
- **`fields: all` on a cross-entity copy is a LOAD ERROR**, not a runtime redaction — it would otherwise write a redacted entity.
- **Copying relations can mint authority**: role-conferring/identity-scoped types are excluded unless explicitly named (advisory finding in `aclaudit`), and cross-entity edges go through ordinary per-edge authorization as the acting principal — a copy can never create an edge the principal could not create by hand.
- One `store.Tx`, **audit AFTER commit** (a rollback must not leave an audit row for a write that never landed). Note: `entitymanager` had never called `store.Tx` before — that is deliberate and new, not an oversight, and the godoc says so.
- The kernel **does not validate the destination world** — that is TKT-9KZGJO's declared seam (`must_hold_in`), and shipping half of it here would fork it. Stated in the godoc as a boundary, not an omission.

Gates: gofmt, `go build ./...`, arch-lint, and tests across `entitymanager`, `metamodel`, `acl`, `aclaudit` and `dataentry` all green.

**Backend only.** This exposes the definition registry, the guard verdict, and the resulting face — it decides nothing about presentation. The UI/UX for promote is a separate conversation.