### PR TITLE
chore(docs): clear all doclink findings and gate the rule (TKT-3XBE7Y)

### DIFF
--- a/.commentlint.yml
+++ b/.commentlint.yml
@@ -2,11 +2,13 @@
 #
 # CI runs two steps (the "Comment lint" job in ci.yml):
 #
-#   gate   — commented-code. Clean today, so a regression fails the build.
+#   gate   — commented-code, doclink. Clean today, so a regression fails the
+#            build. Suppression is available, but read the finding first: the
+#            failure message says why, and a reason is required.
 #   report — every other enabled rule, advisory (continue-on-error).
 #
-# The advisory rules have a real backlog: nil-contract 100, duplication 119,
-# doclink 58, param-contract 5, restatement 19. They are being worked down; a gate that is
+# The advisory rules have a real backlog: duplication 120, nil-contract 105,
+# param-contract 5, restatement 17. They are being worked down; a gate that is
 # red on arrival just teaches people to ignore the job. Promote a rule to the
 # gate once its backlog reaches zero.
 #

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -180,12 +180,12 @@ jobs:
 
       - name: Install commentlint
         # Keep in sync with commentlint_version in the justfile.
-        run: go install github.com/sourcehaven-bv/commentlint@v0.2.1
+        run: go install github.com/sourcehaven-bv/commentlint@v0.3.1
 
       # Gate: clean today, so a regression fails the build. Rules are promoted
       # here from the advisory step once their backlog reaches zero.
       - name: Check comments (gate)
-        run: commentlint -rules commented-code ./internal ./cmd
+        run: commentlint -rules commented-code,doclink ./internal ./cmd
 
       # Advisory: real findings with a backlog being worked down. Visible in
       # the log, never red — see .commentlint.yml for why each rule is here.
@@ -197,7 +197,7 @@ jobs:
       - name: Comment report (advisory)
         continue-on-error: true
         run: |
-          for rule in restatement param-contract doclink nil-contract duplication; do
+          for rule in restatement param-contract nil-contract duplication; do
             echo "::group::commentlint $rule"
             commentlint -rules "$rule" -rank -top 30 ./internal ./cmd || true
             echo "::endgroup::"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -575,8 +575,9 @@ type over raising the number.
 
 **Comment discipline** (`just comment-lint`, CI job "Comment lint").
 [commentlint](https://github.com/sourcehaven-bv/commentlint) checks comments
-against the scope they are attached to. Only `commented-code` is a gate; the
-rest are advisory (`just comment-report`) with a backlog being worked down:
+against the scope they are attached to. `commented-code` and `doclink` are
+**blocking gates** (both clean); the rest are advisory (`just comment-report`)
+with a backlog being worked down:
 
 - **`duplication`** — the same fact explained in two or more comments. The
   signal we act on: a fact stored three times gets corrected in one place and
@@ -584,11 +585,13 @@ rest are advisory (`just comment-report`) with a backlog being worked down:
 - **`nil-contract`** — nil behaviour as ad-hoc prose. Go cannot express this
   in a type, so the convention is `Nil: rejected|accepted|never returned —
   <why>`. Fixing one removes it permanently (the rule skips tagged comments).
-- **`doclink`** — a `[Bracketed.Reference]` that resolves to nothing. Go
-  degrades these silently (pkg.go.dev renders the literal brackets) and no
+- **`doclink`** (gate) — a `[Bracketed.Reference]` that resolves to nothing.
+  Go degrades these silently (pkg.go.dev renders the literal brackets) and no
   other linter catches them — `go vet`, `staticcheck` and `godoclint` all
   report zero on a broken link. Most are a bare `[Method]` where Go needs
-  `[Recv.Method]`; the finding names the qualified form.
+  `[Recv.Method]`; the finding names the qualified form. Note Go cannot link
+  an unexported member or a symbol from an unimported package at all — those
+  references should simply lose their brackets.
 - **`param-contract`** — a precondition asserted about a bare `string`/`int`
   parameter ("MUST already have passed containedPath"). Usually a missing
   type; this repo already does it where it matters most, e.g.
@@ -598,8 +601,15 @@ rest are advisory (`just comment-report`) with a backlog being worked down:
 
 False positives are expected (every rule is a heuristic over prose). Suppress
 with `//commentlint:ignore <rule>  <reason>` on the declaration line, or via
-`.commentlint.yml` when the same prose recurs across many sites. A reason is
-required either way.
+`.commentlint.yml` when the same prose recurs across many sites.
+
+**Read the finding before suppressing it.** A blocking check with an easy
+escape hatch makes silencing the cheapest path to green, and a reviewer
+skimming a diff cannot tell a considered suppression from a reflex one. Fixing
+the comment is the outcome the gate exists for; suppression is for findings
+that are genuinely *wrong*, and the reason must say why. "Suppressed to unblock
+CI" is not a reason. The failure message says all this too, at the moment it
+matters.
 
 ## Security
 

--- a/internal/acl/access.go
+++ b/internal/acl/access.go
@@ -9,7 +9,7 @@ import (
 // Verb is a read-or-write access verb the who-can query asks about. It
 // widens [Op] (create/update/delete/rename) with read, which has no Op
 // because the write path never authorizes reads — the read path is
-// [Request.readQuery]. VerbRead routes through the read machinery;
+// Request.readQuery. VerbRead routes through the read machinery;
 // every other verb routes through the per-verb write grant.
 type Verb string
 
@@ -95,7 +95,7 @@ type AssertedGrant struct {
 }
 
 // AssertedGrants reports every asserted_role_assignments mapping that grants
-// verb on entityType. Uses the same grantForRole helper as [EveryoneGrants] and
+// verb on entityType. Uses the same grantForRole helper as [Declarative.EveryoneGrants] and
 // Request.AccessRoutes, so a reported grant can never disagree with an actual
 // authorization decision.
 //

--- a/internal/acl/ceiling.go
+++ b/internal/acl/ceiling.go
@@ -338,12 +338,12 @@ func (p *Policy) validateClientAttenuation() error {
 	}
 
 	// Only now that every collision has been rejected is it safe to rewrite the
-	// deny_write shorthand — see [Restriction.expanded].
+	// deny_write shorthand — see Restriction.expanded.
 	p.expandClientAttenuation()
 	return nil
 }
 
-// expandClientAttenuation applies [Restriction.expanded] to every block. Called
+// expandClientAttenuation applies Restriction.expanded to every block. Called
 // at the tail of validation, never before it.
 func (p *Policy) expandClientAttenuation() {
 	for name, b := range p.ClientBaselines {
@@ -382,7 +382,7 @@ func (p *Policy) normalizeClientAttenuation() {
 
 // normalized returns r with every type name, field name and permission trimmed.
 //
-// It deliberately does NOT expand deny_write — that is [Restriction.expanded],
+// It deliberately does NOT expand deny_write — that is Restriction.expanded,
 // and the ordering matters: expanding before validation would rewrite
 // deny_write into the three per-verb lists, and the "deny_write alongside
 // deny_update" collision check would then find deny_write already gone and pass

--- a/internal/acl/declarative.go
+++ b/internal/acl/declarative.go
@@ -32,7 +32,7 @@ import (
 //     declared permission. See [RoleRelationDef.RequiresPermission].
 //   - **Unstamped principals are hard-denied.** A principal with
 //     User="" / User="unknown" or Tool="" / Tool="unknown" fails the
-//     [ForPrincipal] check; the deny surfaces as RuleKind="role-grant"
+//     [Declarative.ForPrincipal] check; the deny surfaces as RuleKind="role-grant"
 //     with a Reason that names ErrUnstampedPrincipal.
 type Declarative struct {
 	policy          *Policy

--- a/internal/acl/policy.go
+++ b/internal/acl/policy.go
@@ -92,7 +92,7 @@ func BuiltinPermissions() []string {
 //   - [Policy.MembershipRelation] names the relation type the resolver
 //     walks from a principal to resolve group membership (TKT-Z8A62F).
 //     Blank/whitespace means the default ("member-of") — read the
-//     effective value via [Policy.membershipRelation], never the raw
+//     effective value via Policy.membershipRelation, never the raw
 //     field, since a blank type would otherwise match *all* relations.
 //   - [Policy.Roles] declares the named capability bundles. The
 //     built-in role name [EveryoneRole] ("everyone") is appended to
@@ -181,7 +181,7 @@ func (p *Policy) effectiveUnmatchedPrincipal() string {
 }
 
 // EffectiveUnmatchedPrincipal is the exported form of
-// [Policy.effectiveUnmatchedPrincipal], for out-of-package callers (the
+// Policy.effectiveUnmatchedPrincipal, for out-of-package callers (the
 // data-entry provision seam) that must branch on the resolved mode.
 func (p *Policy) EffectiveUnmatchedPrincipal() string {
 	return p.effectiveUnmatchedPrincipal()
@@ -227,7 +227,7 @@ func (p *Policy) principalPropertyLookupEnabled() bool {
 }
 
 // PrincipalPropertyLookupEnabled is the exported form of
-// [Policy.principalPropertyLookupEnabled], for out-of-package callers that must
+// Policy.principalPropertyLookupEnabled, for out-of-package callers that must
 // distinguish "the resolver attempted a lookup and found no entity" from "no
 // lookup was configured" — e.g. the data-entry middleware deciding whether a
 // no-match is a genuine unmatched principal.
@@ -303,7 +303,7 @@ func (p *Policy) MembershipSelfPromotionOpen() bool {
 // mutation grants (Create / Update / Delete), Permissions, and the
 // affordance grants are honored by the write path and the affordances
 // resolver. Read drives the read-filtering path (see
-// [Declarative.ReadQuery]).
+// [Request.ReadQuery]).
 //
 // Per-verb mutation grants (TKT-4LQMWP): Create / Update / Delete each
 // list the entity types the role may create / update / delete (`"*"`
@@ -635,7 +635,7 @@ func (p *Policy) normalizeAssertedRoles() {
 // Operators can also call it before persisting a generated policy.
 //
 // It also normalizes asserted_role_assignments keys in place (see
-// [Policy.normalizeAssertedRoles]) — the one mutation it performs, placed here
+// Policy.normalizeAssertedRoles) — the one mutation it performs, placed here
 // so it cannot be bypassed by a policy that reaches the resolver through a
 // path other than LoadPolicy.
 //

--- a/internal/acl/principallookup.go
+++ b/internal/acl/principallookup.go
@@ -11,7 +11,7 @@ import (
 // resolver needs for `principal_property` substitution — declared here
 // (not next to the store) per CLAUDE.md's "interfaces at the call site"
 // rule. The wiring site supplies a store-backed implementation
-// ([StorePrincipalLookup]).
+// (StorePrincipalLookup).
 //
 // The method returns EVERY matching entity ID so the resolver can
 // distinguish the three outcomes it cares about: zero (no match — keep

--- a/internal/aclmap/can.go
+++ b/internal/aclmap/can.go
@@ -16,7 +16,7 @@ import (
 // carries the deciding route(s) when Allowed, so a "yes" is explained the
 // same way who-can/map explain a grant.
 //
-// A grant via the built-in everyone role (which [WhoCan] reports globally,
+// A grant via the built-in everyone role (which [Engine.WhoCan] reports globally,
 // not per principal) still makes Allowed true and is recorded as the
 // Everyone flag — a spot-check must answer "can this principal?" including
 // the case where the reason is "everyone can".

--- a/internal/aclmap/mapall.go
+++ b/internal/aclmap/mapall.go
@@ -9,7 +9,7 @@ import (
 
 // MapAllResult is the whole-graph inventory: every enumerated principal's
 // effective access, aggregated by type with per-entity exceptions — the
-// union of per-principal [MapPrincipalResult]s. It fixes neither the
+// union of one [MapPrincipalResult] per principal. It fixes neither the
 // principal nor the entity (the O(P·E) case), which is why it is a
 // separate slice from map --principal.
 //

--- a/internal/affordances/resolver.go
+++ b/internal/affordances/resolver.go
@@ -109,7 +109,7 @@ type compiledGrants struct {
 // The policy is read from `declarative.Policy()` — the same object
 // the resolver uses for role attribution — so the two cannot drift
 // (RR-WTLD). Callers that want an all-permissive resolver wire
-// [NopFieldVerdictResolver] at the dispatch boundary instead.
+// NopFieldVerdictResolver at the dispatch boundary instead.
 //
 // The full *metamodel.Metamodel is required (not a narrower slice):
 // the resolver can be asked about any entity type at runtime, and for
@@ -168,7 +168,7 @@ func New(
 // CONCURRENCY: this is the one mutator on an otherwise-immutable-after-[New]
 // resolver, so the "safe for concurrent use" guarantee holds only if it is
 // called during single-threaded wiring, BEFORE the resolver is shared — which
-// is the sole production call site ([ResolverFromProfile], synchronous, before
+// is the sole production call site (ResolverFromProfile, synchronous, before
 // the resolver escapes). It is a setter rather than a [New] parameter
 // deliberately: machines are optional and adding a required arg would churn all
 // [New] callers. Never call WithMachines concurrently with TransitionVerdicts.
@@ -624,7 +624,7 @@ func (r *PolicyResolver) transitionGuard(ctx context.Context) statemachine.Guard
 
 // requestGuard evaluates a transition guard against an acl.Request. A nil
 // request (unresolved/unstamped principal) holds no permission → guarded edges
-// resolve as not-performable (fail closed). See [PolicyResolver.transitionGuard]
+// resolve as not-performable (fail closed). See PolicyResolver.transitionGuard
 // for why there is no inert tier.
 type requestGuard struct{ req *acl.Request }
 
@@ -640,7 +640,7 @@ func (g requestGuard) HoldsPermission(ctx context.Context, subjectID, permission
 // this call. Returns nil bc when no policy roles apply.
 //
 // Role resolution flows through [acl.Declarative.ForPrincipal] /
-// [Request.ForEntity], which includes group expansion and containment
+// Request.ForEntity, which includes group expansion and containment
 // inheritance.
 func (r *PolicyResolver) bindingFor(ctx context.Context, e *entity.Entity) (bc *bindingContext, roles []string) {
 	p := principal.From(ctx)

--- a/internal/analysis/analysis.go
+++ b/internal/analysis/analysis.go
@@ -336,8 +336,8 @@ func (s *Service) FindGaps(ctx context.Context, opts Options) []GapResult {
 //
 // This is the single seam world-awareness (TKT-9KZGJO) will thread
 // through: subject population, counting scope, and violation identity
-// each have exactly one home — the spec, [Service.countRelations], and
-// the two emit passes in [Service.checkCardinality] (TKT-RNBLAC).
+// each have exactly one home — the spec, Service.countRelations, and
+// the two emit passes in Service.checkCardinality (TKT-RNBLAC).
 type cardinalitySpec struct {
 	relName       string // metamodel relation name — the count query key
 	direction     store.Direction

--- a/internal/appbuild/appbuild.go
+++ b/internal/appbuild/appbuild.go
@@ -274,7 +274,7 @@ func (s *Services) CalDAVAliases() *caldavalias.Service { return s.caldavAliases
 // and the docs runtime, where whoever runs the binary already has the
 // project files (RR-17DMC).
 //
-// Request-scoped and scheduled callers must use [Services.luaReadDepsFor]
+// Request-scoped and scheduled callers must use Services.luaReadDepsFor
 // instead, which binds reads to an identity (DEC-O59WM4).
 //
 // Cheap to call; rebuild per-runtime so future metamodel reloads propagate.
@@ -794,7 +794,7 @@ type options struct {
 // option always wins, even when an `acl.yaml` is present, so the
 // flag is an unconditional override.
 //
-// Tests should prefer [NewForTest] + [WithTestACL] over driving this
+// Tests should prefer NewForTest + WithTestACL over driving this
 // path directly.
 func WithACL(a acl.ACL) Option {
 	return func(o *options) { o.acl = a }

--- a/internal/audit/filesystem.go
+++ b/internal/audit/filesystem.go
@@ -51,7 +51,7 @@ type Filesystem struct {
 // long enough that a sustained failure doesn't spam slog.
 const retryAfter = 60 * time.Second
 
-// filesystemConfig is the receiver for [Option]s.
+// filesystemConfig is the receiver each [Option] configures.
 type filesystemConfig struct {
 	clock func() time.Time
 }

--- a/internal/caldavalias/caldavalias.go
+++ b/internal/caldavalias/caldavalias.go
@@ -273,7 +273,7 @@ func (s *Service) EntityRenamed(ctx context.Context, oldID, newID string) error 
 // resurrecting the entity. Dropping the alias here would destroy that evidence:
 // the next PUT would find nothing, read as a create, and undo the delete.
 //
-// This is therefore a no-op today, kept because it is the [AliasRewriter] half
+// This is therefore a no-op today, kept because it is the AliasRewriter half
 // of the rename/delete pair and the obvious place for future bookkeeping (a
 // deletion timestamp to prune on). Callers rely on the graph, not this table,
 // for what currently exists.

--- a/internal/calfeed/calfeed.go
+++ b/internal/calfeed/calfeed.go
@@ -152,7 +152,7 @@ type Todo struct {
 // It is a convenience, NOT the guarantee: the three fields stay exported and
 // individually settable, so a caller can still construct a half-completed
 // Todo. The actual guarantee is enforced downstream — [ICal.RenderTodo]
-// normalizes the trio (see [Todo.normalized]), so a half-set value can never
+// normalizes the trio (see Todo.normalized), so a half-set value can never
 // reach a client. Prefer this method anyway; it states the intent at the call
 // site.
 func (t *Todo) Complete(at time.Time) {
@@ -215,7 +215,7 @@ const (
 
 // ClampPriority bounds an RFC 5545 PRIORITY to 0-9.
 //
-// Exported for the INBOUND direction. [Todo.normalized] clamps on render, which
+// Exported for the INBOUND direction. Todo.normalized clamps on render, which
 // protects the wire but not the store: a client PUT carrying
 // `PRIORITY:2147483647` used to be written into an entity property verbatim,
 // and every other consumer of that property — the SPA, the CLI, exports,

--- a/internal/dataentry/affordances.go
+++ b/internal/dataentry/affordances.go
@@ -471,7 +471,7 @@ func knownToResolver(v FieldVerdicts, name string) bool {
 // response. The wire shape mirrors writeForbiddenIfACLDenied (the
 // ACL helper) so SPA error-handling can treat the two uniformly.
 //
-// Prefer [App.denyAffordance] when handler context is available — it
+// Prefer App.denyAffordance when handler context is available — it
 // emits the audit row in addition to writing the response.
 func writeAffordanceDenialError(w http.ResponseWriter, denial AffordanceDenialError) {
 	w.Header().Set("Content-Type", "application/json")
@@ -520,7 +520,7 @@ func (a *App) denyAffordance(
 }
 
 // RelationOp identifies which relation-write operation a caller is
-// gating. Pass via [App.validateRelationOp].
+// gating. Pass via App.validateRelationOp.
 type RelationOp int
 
 const (
@@ -1151,7 +1151,7 @@ func (svc affordanceService) applyCreateLock(
 // attachEntityAffordances writes the per-entity `_fields` and
 // `_relations` wire maps onto result. Called by paths that return a
 // per-entity response (GET, PATCH, POST, clone, action) — list rows
-// and includes get [App.stripHiddenProperties] only.
+// and includes get App.stripHiddenProperties only.
 func (svc affordanceService) attachEntityAffordances(ctx context.Context, e *entityPkg.Entity, result *v1.Entity) {
 	verdicts := svc.resolver().FieldVerdicts(ctx, e)
 	fields := computeFieldAffordancesFrom(verdicts)

--- a/internal/dataentry/api_v1.go
+++ b/internal/dataentry/api_v1.go
@@ -979,7 +979,7 @@ type relationMetaStrip struct {
 // buildRelationTypeRows builds the single-relation-type wire rows (id/type[/meta])
 // for the visible edges of relType in the given direction, plus the deferred meta
 // strips. It is the shared build step for handleV1GetRelationType; the caller
-// sorts then applies [App.redactRelationMetaStrip].
+// sorts then applies App.redactRelationMetaStrip.
 func buildRelationTypeRows(
 	ctx context.Context, reader entityReader, edges []*entityPkg.Relation,
 	relType string, incoming bool, visibleNeighbors map[string]bool,

--- a/internal/dataentry/app.go
+++ b/internal/dataentry/app.go
@@ -416,7 +416,7 @@ func appRedactor(a *App) visibility.FieldRedactor {
 //
 // This wiring was fail-open on the theory that its callers are interactive,
 // so a broken gate would surface as an immediate, human-visible outage.
-// That does not hold: of the three consumers of [App.luaWriteDeps] —
+// That does not hold: of the three consumers of App.luaWriteDeps —
 // actions.go (interactive), document.go/export_render, and webhook.go — the
 // IdP webhook is unattended machine-to-machine, running as `webhook:<event>`
 // with nobody watching the log. An unattended job quietly reverting to
@@ -585,7 +585,7 @@ func gatedScriptReader(aclImpl acl.ACL, store store.Store, redactor visibility.F
 // way — pruning happens inside the decorator.
 //
 // Construction faults REFUSE ([visibility.DenyTracer]) for the same reason
-// as [App.scriptReader]: traversal is a read, and an unattended caller must
+// as App.scriptReader: traversal is a read, and an unattended caller must
 // not silently walk the whole graph.
 func (a *App) scriptTracer(redactor visibility.FieldRedactor) tracer.Tracer {
 	d, ok := a.acl.(*acl.Declarative)

--- a/internal/dataentry/nextaction.go
+++ b/internal/dataentry/nextaction.go
@@ -28,7 +28,7 @@ import (
 //
 // # Which seam each source kind uses
 //
-//   - Query  -> [App.executeQuery], the same helper /_search and scope
+//   - Query  -> App.executeQuery, the same helper /_search and scope
 //     navigation use. It resolves SearchScope from the read gate first, and
 //     for a query with no free text (which every structural next-action query
 //     is) routes to visibleListByTypes — a type-scoped store list, NOT the

--- a/internal/entitymanager/manager.go
+++ b/internal/entitymanager/manager.go
@@ -69,7 +69,7 @@ type Manager struct {
 	// bypassACL marks this Manager as an ELEVATED write handle: its writes
 	// skip the ACL deny (TKT-D8T148, the `rela.bypass_acl(...)` path). It is
 	// false on the normal Manager and set true ONLY on the throwaway handle
-	// returned by [Manager.elevated]. Carrying elevation on the object (not
+	// returned by Manager.elevated. Carrying elevation on the object (not
 	// the context) is what makes it leak-proof: a nested cascade an elevated
 	// write triggers re-dispatches with the gated Manager (see the cascade
 	// dispatch sites, which pass `m.gated()` as the Mutator), so elevation
@@ -326,7 +326,7 @@ func New(d Deps) (*Manager, error) {
 // When this Manager is an elevated handle (`m.bypassACL` — TKT-D8T148: a
 // `rela.bypass_acl(...)` write), the ACL deny is SKIPPED: the write is allowed
 // regardless of the principal's grants. Elevation is a property of WHICH
-// Manager you hold, not of the context — see [Manager.elevated]. The real
+// Manager you hold, not of the context — see Manager.elevated. The real
 // principal is still preserved (`principal.From(ctx)`, unchanged) and the
 // bypass is recorded (recordACLBypass) so the audit trail is unambiguous about
 // which writes were elevated and on whose behalf. We do NOT recordDeniedWrite
@@ -737,7 +737,7 @@ func (m *Manager) PatchEntity(
 // Method on Manager (not a free function over [Deps] like [createCore])
 // because the cascade needs m.gated() to stop elevation propagating into
 // descendants. It deliberately contains **no ACL check and no attribution**
-// — both belong to the entry points ([UpdateEntity], [PatchEntity]), which
+// — both belong to the entry points ([Manager.UpdateEntity], [Manager.PatchEntity]), which
 // authorize with the subject shape appropriate to how they learned the
 // entity type. Putting authorize here would double-authorize PatchEntity
 // (which must authorize early, before it can merge) and emit two

--- a/internal/entitymanager/unique.go
+++ b/internal/entitymanager/unique.go
@@ -23,7 +23,7 @@ import (
 //
 // The check queries other entities and so cannot live in the pure,
 // per-entity ValidateEntity. Violations are returned as
-// [metamodel.ValidationError]s of type [metamodel.ValidationErrorUnique]
+// [metamodel.ValidationError] values of type [metamodel.ValidationErrorUnique]
 // (a HARD error) so the caller folds them into the same
 // [newValidationError] → 422 path as structural validation failures.
 //

--- a/internal/jwtauth/verifier.go
+++ b/internal/jwtauth/verifier.go
@@ -197,7 +197,7 @@ const (
 // VerifyAssertion verifies a request assertion and projects the identity claims
 // the principal resolver needs. Any signature/issuer/audience/expiry failure, or
 // an empty subject, yields an error wrapping either [ErrInvalid] or
-// [ErrKeysUnavailable] — identical to [VerifySubject], which this widens rather
+// [ErrKeysUnavailable] — identical to [Verifier.VerifySubject], which this widens rather
 // than replaces. See classify for why the distinction matters.
 //
 // Absent org/role claims are NOT an error (see [AssertionClaims]). Roles are

--- a/internal/lua/capabilities.go
+++ b/internal/lua/capabilities.go
@@ -37,7 +37,7 @@ import (
 //
 // # Secrets is a list, not a bool
 //
-// [Secrets] names the individual keys exposed, because a boolean grants the
+// [Capabilities.Secrets] names the individual keys exposed, because a boolean grants the
 // whole of .rela/secrets.yaml: an action needing one Slack webhook would also
 // receive the database DSN and every API key. Per-script `overrides:` in
 // secrets.yaml do NOT already provide this — they substitute a VALUE for a key
@@ -74,7 +74,7 @@ type Capabilities struct {
 	// nil or empty means no secrets at all.
 	Secrets []string
 
-	// AllSecrets exposes every key in .rela/secrets.yaml, ignoring [Secrets].
+	// AllSecrets exposes every key in .rela/secrets.yaml, ignoring [Capabilities.Secrets].
 	//
 	// This exists ONLY for the operator-shell boundary (see
 	// [TrustedCapabilities]), where the caller can already cat the file. It is

--- a/internal/lua/runtime.go
+++ b/internal/lua/runtime.go
@@ -487,7 +487,7 @@ func (r *Runtime) pcallWithCapture() error {
 }
 
 // collectStackFrames walks the live Lua stack and returns user-visible
-// frames (skipping built-in [G] frames with no source). Capped at
+// frames (skipping built-in G frames with no source). Capped at
 // maxStackFrames; safe to call from a message handler.
 func collectStackFrames(ls *lua.LState) []StackFrame {
 	var frames []StackFrame

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -292,7 +292,7 @@ func NewServer(deps Deps, version string, opts ...Option) (*Server, error) {
 // The returned handler serves THIS server for every request, so per-request
 // state must travel on the ctx rather than be baked in here. That is exactly
 // how identity works: the transport passes the *http.Request ctx through to
-// handlers, and [Server.principalMiddleware] preserves a principal already
+// handlers, and Server.principalMiddleware preserves a principal already
 // stamped there in preference to the construction-time one.
 func (s *Server) HTTPHandler() http.Handler {
 	return mcpgo.NewStreamableHTTPHandler(

--- a/internal/metamodel/capabilities.go
+++ b/internal/metamodel/capabilities.go
@@ -27,7 +27,7 @@ import "fmt"
 //
 // # Secrets is a list
 //
-// [Secrets] names individual keys rather than being a boolean, because a
+// [Capabilities.Secrets] names individual keys rather than being a boolean, because a
 // boolean grants the whole file: an action needing one Slack webhook would also
 // receive the database DSN. There is deliberately no "all" spelling here — the
 // broad grant exists only as a Go-side wiring choice

--- a/internal/metamodel/projection.go
+++ b/internal/metamodel/projection.go
@@ -150,7 +150,7 @@ func (p RenderProjection) Hash() string {
 }
 
 // JSON returns the projection serialized as deterministic JSON, for storage in
-// schema_versions.projection. The bytes are content-addressed by [Hash] (a
+// schema_versions.projection. The bytes are content-addressed by [RenderProjection.Hash] (a
 // separate length-prefixed digest), so this serialization is for storage and
 // re-render, not identity — encoding/json with sorted map keys is sufficient.
 //

--- a/internal/metamodel/shapeprojection.go
+++ b/internal/metamodel/shapeprojection.go
@@ -207,7 +207,7 @@ func (w *projectionHasher) optInt(p *int) {
 }
 
 // JSON returns the projection serialized as deterministic JSON, for embedding
-// in migration files and the state.KV marker. Identity is [Hash] (a separate
+// in migration files and the state.KV marker. Identity is [ShapeProjection.Hash] (a separate
 // length-prefixed digest); this serialization is for storage and re-load.
 func (p ShapeProjection) JSON() ([]byte, error) {
 	return json.Marshal(p)

--- a/internal/predicatefns/date.go
+++ b/internal/predicatefns/date.go
@@ -232,7 +232,7 @@ func daysInMonth(year int, month time.Month) int {
 // A rule that is exhausted (COUNT reached, UNTIL passed) has no next
 // occurrence, and the engine enforces declared return types
 // (eval.go:156) — a Date-returning host function may not return Nil. So
-// exhaustion is an error carrying [ErrRruleExhausted] rather than a
+// exhaustion is an error carrying ErrRruleExhausted rather than a
 // nil-ish Date. A zero date would be worse: it is a real, comparable
 // value, so `rrule_next(r, d) > today()` would silently be false for
 // year 1 and no caller could tell "finished" from "far future".

--- a/internal/script/executor.go
+++ b/internal/script/executor.go
@@ -79,7 +79,7 @@ func (e *Engine) ExecuteCodeWithCapabilities(ctx context.Context, code string, d
 
 // ExecuteFile loads and runs a script file from the scripts/ directory.
 // The path must be a local path (no ".." or absolute paths) with .lua
-// extension. ctx semantics match [ExecuteCode].
+// extension. ctx semantics match ExecuteCode.
 func (e *Engine) ExecuteFile(ctx context.Context, path string, deps lua.WriteDeps,
 	newEntity, oldEntity *entity.Entity) error {
 	return e.ExecuteFileWithCapabilities(ctx, path, deps, newEntity, oldEntity, lua.Capabilities{})

--- a/internal/script/luascriptrunner.go
+++ b/internal/script/luascriptrunner.go
@@ -37,7 +37,7 @@ type Executor interface {
 // of lua.WriteDeps — [lua.ReadDeps] (Store/Tracer/Searcher/Meta/
 // ProjectRoot) — captured at construction. The **dynamic** half — the
 // [autocascade.Mutator] that scripts call back into for graph writes —
-// is passed per-call via [Run]. That split is how the construction
+// is passed per-call via [LuaScriptRunner.Run]. That split is how the construction
 // cycle between EntityManager and the Lua write-deps bundle is broken:
 // Runner is built before EntityManager exists; EntityManager
 // (a Mutator) supplies itself when dispatching.

--- a/internal/statemachine/compile.go
+++ b/internal/statemachine/compile.go
@@ -15,7 +15,7 @@ import (
 // from/to/initial, or a `when:` predicate that fails to compile — so a bad
 // metamodel is rejected at boot, not at write time.
 //
-// A metamodel with no transitions compiles to an empty [Set]; [Set.Enforce] is
+// A metamodel with no transitions compiles to an empty [Set]; [Set.EnforceUpdate] is
 // then a no-op and every write behaves exactly as it did before this feature.
 //
 // meta must not be nil (a required input from appbuild).

--- a/internal/statemachine/enforce.go
+++ b/internal/statemachine/enforce.go
@@ -123,7 +123,7 @@ type edgeResult struct {
 
 // evalEdge evaluates an edge's guard then precondition for (principal-on-ctx,
 // entity e), in the same order and with the same semantics the write path
-// enforces. It is the single source of truth shared by [Set.applyEdge] (write,
+// enforces. It is the single source of truth shared by Set.applyEdge (write,
 // maps to errors) and [Set.Performable] (read, maps to verdicts) so the two can
 // never drift. A guard is checked first (an unheld guard short-circuits without
 // evaluating the precondition, matching enforcement). A nil guard on a guarded

--- a/internal/statemachine/statemachine.go
+++ b/internal/statemachine/statemachine.go
@@ -5,13 +5,13 @@
 // # Two phases, cleanly split
 //
 // Compile runs ONCE at startup (from appbuild), turning the metamodel's
-// declarative transition data into a [Set] of ready-to-run [Machine]s: edge
+// declarative transition data into a [Set] of ready-to-run [Machine] values: edge
 // lookups are indexed, `when:` predicates are compiled, and load-time
 // well-formedness is checked (dangling from/to/initial, bad predicate syntax)
 // so a malformed machine fails fast at boot, never at write time. Nothing here
 // consults the metamodel again after Compile.
 //
-// [Set.Enforce] runs on every entity write (from entitymanager, a required
+// [Set.EnforceUpdate] runs on every entity write (from entitymanager, a required
 // collaborator in the fixed write pipeline — as unforgettable as validation and
 // audit). Given (old, new, principal) it finds every changed state-machine
 // property, and for each:

--- a/internal/store/graphquerynaive/naive.go
+++ b/internal/store/graphquerynaive/naive.go
@@ -34,9 +34,9 @@ type Reader interface {
 // against pathological inputs (huge fan-out, deep chains) where
 // even bounded BFS would be too expensive.
 //
-// Exported so a caller that supplies a [GraphQuery.HasInbound.Depth]
+// Exported so a caller that supplies a GraphQuery.HasInbound.Depth
 // (or EntityDepth) can pin its own cap to the same value when it
-// wants symmetric behavior. Backends that implement [GraphQuery]
+// wants symmetric behavior. Backends that implement GraphQuery
 // via natural-termination primitives (recursive-CTE UNION, etc.)
 // are free to ignore this cap unless they'd expand past it.
 const DepthCap = 5

--- a/internal/store/pgstore/graphquery.go
+++ b/internal/store/pgstore/graphquery.go
@@ -230,7 +230,7 @@ func equalsCond(b *sqlBuilder, txt, jsn, value string) string {
 //     the in-package constants `"in"` / `"out"`
 //
 // User data never reaches the SQL text. The same property holds
-// when [BuildGraphQuerySQLForTest] is invoked from tests — the
+// when BuildGraphQuerySQLForTest is invoked from tests — the
 // builder treats all input the same way.
 func buildGraphQuerySQL(q store.GraphQuery, countOnly bool) (sqlText string, args []any) {
 	b := &sqlBuilder{}
@@ -270,7 +270,7 @@ func buildGraphQuerySQL(q store.GraphQuery, countOnly bool) (sqlText string, arg
 // in/out predicates don't collide when both are set.
 //
 // The endpoint and entity expansions are independent: each emits its
-// own CTE only when [Predicate.InheritThrough] / EntityInheritThrough
+// own CTE only when Predicate.InheritThrough / EntityInheritThrough
 // is non-empty AND the corresponding Depth is > 0. When omitted, the
 // EXISTS query references the seed directly.
 func buildPredicateSQL(

--- a/internal/store/pgstore/visiblesearch.go
+++ b/internal/store/pgstore/visiblesearch.go
@@ -97,7 +97,7 @@ func (s *Store) SearchVisible(
 // compile-time check: the postgres store also filters at the property level.
 var _ search.FieldVisibleSearcher = (*Store)(nil)
 
-// SearchVisibleFields is [SearchVisible] plus property-level redaction of the
+// SearchVisibleFields is [Store.SearchVisible] plus property-level redaction of the
 // match-on-hidden-field oracle. A hit whose text matched only fields the
 // principal may not see (per hidden) is dropped, so a search cannot confirm a
 // redacted property's value by returning its entity.

--- a/internal/transform/transform.go
+++ b/internal/transform/transform.go
@@ -8,7 +8,7 @@
 //
 // Two layers meet here:
 //
-//   - A [Registry] of named [Def]s. Each Def is a `from: markdown` → format byte
+//   - A [Registry] of named [Def] entries. Each Def is a `from: markdown` → format byte
 //     shuttle: an argv command template (with {in}/{out} placeholders) plus the
 //     produced content-type. Defs know nothing about entities, Lua, or the web
 //     app — pure byte conversion, executed via [github.com/Sourcehaven-BV/rela/internal/cmdexec].

--- a/internal/visibility/adapters.go
+++ b/internal/visibility/adapters.go
@@ -18,7 +18,7 @@ import (
 // closed (deny), never open.
 //
 // WIRING REQUIREMENT (RR-MXKD2O): open ONE Request per logical operation
-// and attach it with [Bind] (or acl.WithRequest) before calling into the
+// and attach it with [DeclarativeGate.Bind] (or acl.WithRequest) before calling into the
 // wrappers. Without it, every gate probe AND every field-verdict
 // resolution opens its own Request — the Globals member-of walk re-runs
 // per collaborator (the cost RR-JJYW amortizes away), and the row-gate

--- a/internal/visibility/allowall.go
+++ b/internal/visibility/allowall.go
@@ -54,7 +54,7 @@ func (r *AllowAllReader) Filter(_ context.Context, candidates []*entity.Entity) 
 }
 
 // FilterHeaders implements [HeaderFilterer]: pass-through, input returned
-// unchanged — the same allow-all capability [Filter] grants, applied to
+// unchanged — the same allow-all capability [AllowAllReader.Filter] grants, applied to
 // content-free headers.
 func (r *AllowAllReader) FilterHeaders(
 	_ context.Context, candidates []store.EntityHeader,

--- a/internal/visibility/policyreader.go
+++ b/internal/visibility/policyreader.go
@@ -88,7 +88,7 @@ func (r *PolicyReader) Filter(ctx context.Context, candidates []*entity.Entity) 
 	return out
 }
 
-// FilterHeaders implements [HeaderFilterer]: the [Filter] contract applied
+// FilterHeaders implements [HeaderFilterer]: the [PolicyReader.Filter] contract applied
 // to content-free headers.
 //
 // Identical gating — one PermitsReadMany per distinct type, order preserved,

--- a/internal/visibility/tracer.go
+++ b/internal/visibility/tracer.go
@@ -188,7 +188,7 @@ func (t *VisibleTracer) redactStepTitle(ctx context.Context, s *tracer.PathStep)
 
 // FindOrphans implements [tracer.Tracer]: the base's orphan ids minus
 // the hidden ones. Each id's TYPE is resolved (the gate needs it) via
-// [VisibleTracer.typesOf], then ids are gated with one PermitsReadMany
+// VisibleTracer.typesOf, then ids are gated with one PermitsReadMany
 // per distinct type (RR-MYLUSZ). A vanished entity drops fail-closed.
 func (t *VisibleTracer) FindOrphans(ctx context.Context) ([]string, error) {
 	ids, err := t.base.FindOrphans(ctx)

--- a/internal/visibility/visibility.go
+++ b/internal/visibility/visibility.go
@@ -109,7 +109,7 @@ type Reader interface {
 	FilterRelations(ctx context.Context, rels []*entity.Relation) []*entity.Relation
 }
 
-// HeaderFilterer is [Reader.Filter] for content-free [store.EntityHeader]s
+// HeaderFilterer is [Reader.Filter] for content-free [store.EntityHeader] values
 // (TKT-1ESTYJ).
 //
 // OPTIONAL, kept off [Reader] so a third-party or test Reader need not

--- a/justfile
+++ b/justfile
@@ -251,10 +251,10 @@ vet:
 # Comment discipline. The gate (commented-code) is clean and enforced in CI;
 # the report surfaces the advisory rules whose backlog is still being worked
 # down. Keep commentlint_version in sync with .github/workflows/ci.yml.
-commentlint_version := "v0.2.1"
+commentlint_version := "v0.3.1"
 comment-lint:
     @echo "==> commentlint (gate)"
-    go run github.com/sourcehaven-bv/commentlint@{{commentlint_version}} -rules commented-code ./internal ./cmd
+    go run github.com/sourcehaven-bv/commentlint@{{commentlint_version}} -rules commented-code,doclink ./internal ./cmd
 
 # One invocation per rule, because the cross-comment rules replace the
 # per-comment output rather than adding to it — a single run would silently
@@ -269,7 +269,7 @@ comment-report rule="":
             -rules "{{rule}}" -rank -top 40 ./internal ./cmd
         exit 0
     fi
-    for rule in restatement param-contract doclink nil-contract duplication; do
+    for rule in restatement param-contract nil-contract duplication; do
         echo "==> commentlint $rule"
         go run github.com/sourcehaven-bv/commentlint@{{commentlint_version}} \
             -rules "$rule" -rank -top 40 ./internal ./cmd || true

--- a/tickets/entities/docs-checklists/DOCS-ZPE7DG.md
+++ b/tickets/entities/docs-checklists/DOCS-ZPE7DG.md
@@ -1,0 +1,51 @@
+---
+id: DOCS-ZPE7DG
+type: docs-checklist
+title: 'Docs: Clear all doclink findings and promote the rule to a blocking CI gate'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Code Documentation
+
+- [x] Exported symbols documented — this change *is* doc-comment maintenance;
+18 references now link correctly where they previously rendered as literal
+brackets on pkg.go.dev
+- [x] Non-obvious decisions carry a WHY — the upstream `failWithGuidance` doc
+records why the message is shaped the way it is (a blocking check with an easy
+escape hatch makes silencing the cheapest path to green)
+- [x] `CLAUDE.md` updated — `doclink` marked as a gate, with a note that Go
+cannot link unexported or unimported symbols at all
+
+## Project Documentation
+
+- [x] `CLAUDE.md` — gate/advisory split refreshed; new paragraph on reading a
+finding before suppressing it
+- [x] `.commentlint.yml` — gate list now `commented-code, doclink`; advisory
+backlog counts refreshed (duplication 120, nil-contract 105, param-contract 5,
+restatement 17)
+- [x] `justfile` / `ci.yml` — `doclink` moved out of the advisory loop into
+the gate; version pin bumped to v0.3.1
+- [x] ~~`docs/` guides~~ (N/A: contributor tooling, not a user-facing rela
+feature — same treatment as plimsoll and arch-lint)
+- [x] ~~`README.md`~~ (N/A: same reasoning)
+
+## External Documentation
+
+- [x] Tool README documents blocking behaviour — new "Blocking runs" section
+explaining that `-rank` makes a run advisory, and why the failure message is
+framed fix-first
+- [x] Suppression documented — unchanged and still accurate; the failure
+message now points at it
+- [x] ~~Migration notes~~ (N/A: consumers pin a version tag; v0.3.x is
+additive apart from the backticked-span false-positive fix, which only *removes*
+findings)
+
+## Verification
+
+- [x] Every documented command was run and produces the documented output
+- [x] Counts quoted in docs match reality — `doclink` 0, and the four advisory
+counts re-measured on this branch rather than copied from the previous ticket
+- [x] The documented gate behaviour was tested, not assumed — a broken link
+was reintroduced to confirm the gate blocks and prints the guidance

--- a/tickets/entities/implementation-checklists/IMPL-TISRMZ.md
+++ b/tickets/entities/implementation-checklists/IMPL-TISRMZ.md
@@ -1,0 +1,85 @@
+---
+id: IMPL-TISRMZ
+type: implementation-checklist
+title: 'Implementation: Clear all doclink findings and promote the rule to a blocking CI gate'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Development
+
+- [x] ~~Unit tests written for new code~~ (N/A in this repo: every Go change
+is inside a comment. The two upstream changes ship with tests — `TestGuidance`,
+`TestFiredRules`, `TestStripBackticked`.)
+- [x] ~~Integration tests written~~ (N/A: the integration is the CI gate,
+verified by running it including a negative case)
+- [x] Happy path implemented — `doclink` reports zero; the gate includes it
+- [x] Edge cases from planning handled — the backticked-markdown false
+positive is fixed upstream with a test
+- [x] Error handling in place — the blocking path prints guidance rather than
+just exiting non-zero
+
+## Test Quality
+
+- [x] ~~Using fixture builders or factories for test data~~ (N/A: no tests
+added in this repo)
+- [x] ~~No hardcoded values in assertions when object is in scope~~ (N/A)
+- [x] ~~Only specifying values that matter for the test~~ (N/A)
+- [x] ~~Interpolated values constructed from objects, not hardcoded~~ (N/A)
+- [x] ~~Property comparisons use original object, not hardcoded strings~~ (N/A)
+
+## Manual Verification
+
+- [x] Feature manually tested end-to-end
+- [x] Each acceptance criterion verified with test scenario from planning
+- [x] Edge cases manually verified
+
+**Verification Evidence:**
+
+1. **Zero findings** — `commentlint -rules doclink ./internal ./cmd` →
+"no unresolvable doc links across 10351 comments" (was 64).
+2. **Gate includes it and passes** — `just comment-lint` (now
+`-rules commented-code,doclink`) → EXIT=0.
+3. **The gate actually blocks** — reverted one fix
+(`[Set.EnforceUpdate]` → `[Set.Enforce]`), re-ran: EXIT=1 with the guidance
+printed, naming `doclink` in the copy-pasteable directive. Restored after.
+Without this the promotion would be cosmetic.
+4. **No behaviour change** — all 63 added Go lines are comments:
+
+   ```
+   $ git diff -U0 -- '*.go' | grep '^+' | grep -v '^+++' | grep -vE '^\+\s*//'
+   (no output)
+   ```
+
+5. **Nothing regressed** — `golangci-lint run ./internal/...` → 0 issues;
+`go test` over every touched package → no failures; `just lint-md` → 0 issues
+across 252 files.
+
+## Quality
+
+- [x] Code follows project patterns — the gate mirrors the existing
+`commented-code` step and the plimsoll job's pinned-version convention
+- [x] Checked for DRY opportunities — the guidance message lives in one
+function (`failWithGuidance`) routed to from all five exit sites upstream,
+rather than duplicated per rule
+- [x] No security issues introduced — every edit is inside a comment. Several
+touch security-relevant packages (`acl`, `visibility`, `jwtauth`), so the diff
+was checked line-by-line to confirm nothing outside a comment moved. One comment
+is *more* accurate now: `[Declarative.ReadQuery]` was pointing at a method that
+does not exist; it is `Request.ReadQuery`.
+- [x] No silent failures — the gate fails loudly and explains what to do
+- [x] No debug code left behind
+
+**Judgement calls worth recording:**
+
+- **Cleared to zero rather than grandfathering.** The plimsoll pattern (pin
+the count, ratchet down) does not fit: the growth was existing breakage
+*propagating*, so a frozen ceiling still lets each broken reference spread.
+- **Did not suppress any of the 64.** Suppressing findings this mechanical
+would make the escape hatch the default path — exactly the reflex the guidance
+message is written to discourage.
+- **`grep` was the wrong oracle.** An earlier audit graded 7 of 8 sampled
+findings as false positives because the symbols "exist". They do — as methods —
+and Go still will not link a bare `[Method]`. Every shape was re-verified
+against `go doc` on a minimal package before being fixed.

--- a/tickets/entities/planning-checklists/PLAN-EAQQOX.md
+++ b/tickets/entities/planning-checklists/PLAN-EAQQOX.md
@@ -1,0 +1,180 @@
+---
+id: PLAN-EAQQOX
+type: planning-checklist
+title: 'Planning: Clear all doclink findings and promote the rule to a blocking CI gate'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Understanding
+
+- [x] Problem/requirements clearly understood
+- [x] Scope defined (what's in/out documented below)
+- [x] Acceptance criteria documented with specific test scenarios
+
+**Scope:**
+
+IN: clearing all 64 `doclink` findings, promoting the rule to the blocking gate,
+and the failure-message guidance that makes suppression a considered act.
+
+OUT: the other four advisory rules (duplication 120, nil-contract 105,
+param-contract 5, restatement 17).
+
+**Acceptance Criteria:**
+
+1. `doclink` reports zero on `develop`.
+2. `just comment-lint` includes `doclink` and exits 0.
+3. Reintroducing a broken link fails the gate AND prints guidance that leads
+with fixing.
+4. No behaviour change — every edit is inside a comment.
+
+## Research
+
+- [x] ~~For larger features: run `/research`~~ (N/A: `s`, mechanical)
+- [x] Searched for existing libraries that solve this problem
+- [x] Checked codebase for similar patterns or reusable code
+- [x] Looked for reference implementations in other projects
+- [x] Reviewed relevant rela concepts for prior art
+
+**Research Doc:** N/A
+
+**Existing Solutions:**
+
+Re-confirmed no existing tool reports these (`go vet`, `staticcheck`,
+`godoclint` all zero on a deliberately broken link), and went further this time:
+rather than trust commentlint, both flagged shapes were verified against `go
+doc` on a minimal package.
+
+- `[Box.unexportedHelper]` → renders with brackets. Go cannot link unexported
+members, so the 22 `Type.unexportedMember` findings are real.
+- `[Method]` → renders with brackets; `[Recv.Method]` links. So a bare method
+reference is real too.
+
+That check mattered: my first pass at auditing these graded 7 of 8 as false
+positives on the grounds that the symbols "exist". They do exist — as methods —
+and Go still refuses to link them. `grep` was the wrong oracle; `go doc` is the
+right one.
+
+Prior art: `plimsoll`'s grandfathering approach (pin the current count, ratchet
+down) was considered and rejected below.
+
+## Approach
+
+- [x] Technical approach chosen and documented
+- [x] Approach builds on existing patterns (not reinventing)
+- [x] Alternatives considered (document why rejected)
+- [x] Dependencies identified (packages, APIs, types)
+
+**Technical Approach:**
+
+Clear to zero, then gate. Findings fall into two remedies:
+
+- **Qualify** (18) — the reference names a real linkable symbol but omits its
+receiver. `[ForPrincipal]` → `[Declarative.ForPrincipal]`.
+- **Unbracket** (38) — Go cannot link the target at all (unexported member,
+cross-package symbol not imported, test-only helper). The prose still names the
+collaborator, which was the author's intent; the brackets were an unsupported
+claim.
+
+Plus 6 pluralized `[X]s` rephrased so the bracket ends the token, and 2 tool
+false positives fixed upstream.
+
+**Alternatives rejected:**
+
+1. *Grandfather the count and ratchet down* (the plimsoll pattern). Rejected:
+the growth is propagation of existing breakage, so a frozen ceiling still lets
+each broken reference spread up to its cap. Zero is the only count that stops
+copying.
+2. *Suppress the 64 with directives.* Rejected outright — that is exactly the
+reflex the guidance message is written to discourage. Suppressing a finding this
+mechanical would make the escape hatch the default path.
+3. *Leave advisory and hope.* Rejected on evidence: +6 in two days with nobody
+fixing any.
+
+**Files to modify:** 30 source files (comments only), `.commentlint.yml`,
+`justfile`, `.github/workflows/ci.yml`.
+
+## Security Considerations
+
+- [x] Input sources identified (user input, config, external APIs)
+- [x] Input validation approach defined (allowlist preferred over blocklist)
+- [x] Security-sensitive operations identified (file access, auth, crypto)
+- [x] Error handling doesn't leak sensitive information
+
+**Input Sources & Validation:** N/A for the edits — every one is inside a
+comment, so there is no runtime surface. The CI change installs a pinned version
+tag from an org-owned repo through the module proxy, unchanged in kind from the
+existing plimsoll/commentlint pins.
+
+**Security-Sensitive Operations:** None. Several edits touch comments in
+security-relevant packages (`internal/acl`, `internal/visibility`,
+`internal/jwtauth`), so the diff was checked to confirm no line outside a
+comment moved — `go build` and the full test suite both pass unchanged.
+
+## Test Plan
+
+- [x] Test scenarios documented for each acceptance criterion
+- [x] Edge cases identified and documented
+- [x] Negative test cases defined (invalid input, error conditions)
+- [x] Integration test approach defined (not just unit tests)
+
+**Test Scenarios:**
+
+1. `commentlint -rules doclink` → "no unresolvable doc links across 10351
+comments".
+2. `just comment-lint` (now `commented-code,doclink`) → exit 0.
+3. **Negative:** revert one fix (`[Set.EnforceUpdate]` → `[Set.Enforce]`), run
+the gate, confirm exit 1 and that the guidance prints. Then restore.
+4. `golangci-lint run ./internal/...` → 0 issues; `go test` over every touched
+package → no failures.
+
+**Edge Cases:**
+
+- A comment explaining markdown syntax (`` `[Title](url)` ``) must NOT be
+flagged — this was a real false positive, fixed upstream in v0.3.1 with a test.
+- Cross-package references to packages that cannot be imported without a cycle
+must stay unflagged (already handled at adoption).
+
+**Negative Tests:** scenario 3 above — the gate must actually block, or the
+promotion is cosmetic.
+
+## Risk Assessment
+
+- [x] Technical risks assessed with mitigations
+- [x] Security risks assessed (see Security Considerations)
+- [x] Effort estimated (xs/s/m/l/xl) — `s `
+
+**Risks:**
+
+1. *A blocking gate with an escape hatch trains people to suppress.* The main
+risk, and the reason the guidance message exists: it leads with reading the
+finding, presents suppression second, and rejects "to unblock CI" as a reason.
+Mitigation is social, so it is written where it will be read — at the moment of
+failure.
+2. *Unbracketing loses information.* Low: the symbol name stays in the prose,
+only the (non-functional) link markup goes.
+3. *A future rename re-breaks a link.* That is precisely what the gate now
+catches — this is the mitigation, not a residual risk.
+
+## Documentation Planning
+
+- [x] User-facing docs identified (skip if internal refactor)
+- [x] Docs-checklist will be created when entering implementation
+
+**Documentation Impact:**
+
+- [x] `.commentlint.yml ` — gate list and updated backlog counts
+- [x] `CLAUDE.md ` — already documents commentlint; the rule list needs the
+gate/advisory split refreshed
+- [x] N/A for `docs/ ` and `README.md ` — contributor tooling
+
+## Design Review
+
+- [x] ~~Run `/design-review ` before starting implementation~~ (N/A: `s `,
+mechanical comment edits. The one design decision — clear-to-zero vs.
+grandfather-and-ratchet — is recorded under Alternatives, with the evidence that
+ratcheting does not stop propagation.)
+- [x] All critical/significant findings addressed in plan
+
+**Design Review Findings:** N/A

--- a/tickets/entities/review-checklists/REV-HLF009.md
+++ b/tickets/entities/review-checklists/REV-HLF009.md
@@ -1,0 +1,98 @@
+---
+id: REV-HLF009
+type: review-checklist
+title: 'Review: Clear all doclink findings and promote the rule to a blocking CI gate'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Automated Checks
+
+- [x] All tests pass (`just test`) — every touched package `ok`, no failures
+- [x] Lint clean (`just lint`) — EXIT=0
+- [x] Comment lint gate clean (`just comment-lint`) — EXIT=0, now including
+`doclink`
+- [x] Coverage maintained (`just coverage-check`) — runs in `just ci`; this
+change adds no Go statements (comments only), so no floor can move
+
+Also EXIT=0: `arch-lint`, `plimsoll`, `lint-md` (252 files).
+
+## Code Review
+
+- [x] Run `/code-review` — reviewed the full diff, 52 files
+- [x] All critical review-responses addressed — none raised
+- [x] All significant review-responses addressed — none raised
+- [x] Self-reviewed the diff for unrelated changes
+
+**Review Responses:** none
+
+Reviewed against the failure modes that matter for a mass comment edit:
+
+- **Did anything outside a comment change?** No. All 63 added Go lines start
+with `//`, verified mechanically rather than by eye: `git diff -U0 -- '*.go' |
+grep '^+' | grep -v '^+++' | grep -vE '^\+\s*//'` returns nothing. `go build`
+and the test suite confirm it.
+- **Are the qualifications correct?** Each receiver was resolved from the
+actual declaration (`grep 'func (r \*PolicyReader) Filter'` etc.), not guessed
+from context. Two were wrong in the original comments and are now right:
+`[Set.Enforce]` → `[Set.EnforceUpdate]` and `[Declarative.ReadQuery]` →
+`[Request.ReadQuery]`.
+- **Does unbracketing lose meaning?** No — the symbol name stays in the prose;
+only non-functional markup goes. Spot-checked the results read naturally (e.g.
+`internal/acl/principallookup.go`, where the surrounding parentheses were
+already there).
+- **Does the gate actually block?** Tested, not assumed: reverting one fix
+produced EXIT=1 plus the guidance. Without that check the promotion would be
+cosmetic.
+- **Is the guidance message doing its job?** It names the rule in a
+copy-pasteable directive, orders fixing before suppressing, and rejects "to
+unblock CI". Pinned upstream by `TestGuidance`, which asserts the
+fix-before-suppress ordering rather than just the text.
+
+**One thing I want to flag rather than bury:** an earlier audit of these
+findings graded 7 of 8 samples as false positives because `grep` showed the
+symbols exist. That was wrong — they exist as *methods*, and Go still refuses to
+link a bare `[Method]`. Every shape was re-verified against `go doc` on a
+minimal package before any fix was applied. Worth recording because the same
+mistake is easy to repeat on the next rule.
+
+## Acceptance Verification
+
+- [x] Each acceptance criterion tested (reference planning checklist)
+- [x] Test evidence documented in implementation checklist
+
+**Acceptance Status:**
+
+1. `doclink` reports zero — **PASS** ("no unresolvable doc links across 10351
+comments", was 64)
+2. Gate includes it and passes — **PASS** (`-rules commented-code,doclink`,
+EXIT=0)
+3. Reintroducing a broken link blocks with guidance — **PASS** (EXIT=1, message
+printed naming `doclink`)
+4. No behaviour change — **PASS** (all 63 changed Go lines are comments)
+
+## Documentation (enhancements only)
+
+- [x] Docs-checklist created and linked via `has-docs`
+- [x] User-facing documentation updated — N/A for `docs/`, justified in the
+docs-checklist
+- [x] Docs-checklist marked as done
+
+**Docs Checklist:** DOCS-ZPE7DG
+
+## Final Checks
+
+- [x] Commit message explains the why, not just what — leads with why advisory
+failed (propagation, not new breakage) and why grandfathering was rejected
+- [x] No TODOs or FIXMEs left unaddressed
+- [x] Ready for another developer to use — a broken link now fails CI with an
+actionable message
+
+## Pull Request
+
+- [x] Run `/pr` command to create PR and monitor CI
+
+<!--
+Deliberately NOT tracked here: the PR URL and whether CI passed. See TKT-UFV01M
+— both post-date this checklist, and GitHub records them. -->

--- a/tickets/entities/tickets/TKT-3XBE7Y.md
+++ b/tickets/entities/tickets/TKT-3XBE7Y.md
@@ -5,7 +5,7 @@ title: Clear all doclink findings and promote the rule to a blocking CI gate
 kind: enhancement
 priority: medium
 effort: s
-status: in-progress
+status: done
 ---
 
 ## Problem

--- a/tickets/entities/tickets/TKT-3XBE7Y.md
+++ b/tickets/entities/tickets/TKT-3XBE7Y.md
@@ -1,0 +1,78 @@
+---
+id: TKT-3XBE7Y
+type: ticket
+title: Clear all doclink findings and promote the rule to a blocking CI gate
+kind: enhancement
+priority: medium
+effort: s
+status: in-progress
+---
+
+## Problem
+
+`doclink` was adopted as advisory (TKT-MTWQ4G) with 58 findings. Two days later
+it was 64. Diffing the finding sets showed **zero new kinds** of broken
+reference — the growth was existing breakage propagating as code got copied.
+`[Set.Enforce]`, `[Todo.normalized]`, `[Filter]` and `[Hash]` each appeared
+twice.
+
+Advisory findings do not get fixed. Clearing the rule once and making it
+blocking stops the propagation at its source.
+
+## Why these are real
+
+Go degrades an unresolvable doc link **silently**: `go/doc/comment` keeps it as
+plain text, so pkg.go.dev renders the literal characters `[Set.Enforce]`,
+brackets and all. `go vet`, `staticcheck` and golangci-lint's `godoclint` all
+report zero on a deliberately broken link.
+
+Verified against `go doc` directly that both flagged shapes are genuinely
+broken, rather than trusting the tool:
+
+- `[Box.unexportedHelper]` renders with brackets intact — Go cannot link an
+unexported member.
+- `[Method]` without a receiver renders with brackets; `[Recv.Method]` links.
+
+## The 64 findings and their fixes
+
+| Shape | Count | Fix |
+|---|---|---|
+| Backticked markdown example (`` `[Title](url)` ``) | 2 | **tool bug** — fixed upstream |
+| Bare method missing its receiver | 8 | qualify: `[ForPrincipal] ` → `[Declarative.ForPrincipal] ` |
+| Pluralized `[X]s ` | 6 | rephrase so the bracket ends the token |
+| `Type.unexportedMember ` | 22 | unbracket — Go cannot link these |
+| Method needing a receiver | 10 | qualify |
+| Cross-package / test-only symbol | 16 | unbracket — prose naming a collaborator, not a link claim |
+
+Two genuine rename casualties were among them: `[Set.Enforce] ` (the methods
+are `EnforceUpdate `/`EnforceCreate `) and `[Declarative.ReadQuery] ` (it is
+`Request.ReadQuery `).
+
+## Blocking with an escape hatch
+
+The gate is blocking, and suppression remains available — every rule is a
+heuristic over prose, so some findings will be wrong.
+
+That combination has a predictable failure mode: the cheapest path to green is
+to silence the finding, and a reviewer skimming a diff cannot tell a considered
+suppression from a reflex one. So the failure message (commentlint v0.3.0) leads
+with *reading* the finding, presents suppression as the second option, names the
+rule in a copy-pasteable directive, and states that "suppressed to unblock CI"
+is not an acceptable reason.
+
+## Scope
+
+- 30 files: doc-comment references corrected or unbracketed
+- `.commentlint.yml `, `justfile `, `.github/workflows/ci.yml ` — `doclink ` moves
+from the advisory loop to the gate; commentlint pinned to v0.3.1
+
+## Upstream changes (separate repo)
+
+- **v0.3.0** — blocking runs print fix-before-suppress guidance
+- **v0.3.1** — `doclink ` ignores bracketed text inside backticked spans, which
+was a false positive on comments explaining markdown syntax
+
+## Out of scope
+
+The remaining advisory backlog: duplication 120, nil-contract 105,
+param-contract 5, restatement 17. Each is its own follow-up.

--- a/tickets/relations/TKT-3XBE7Y--affects--ci-pipeline.md
+++ b/tickets/relations/TKT-3XBE7Y--affects--ci-pipeline.md
@@ -1,0 +1,5 @@
+---
+from: TKT-3XBE7Y
+relation: affects
+to: ci-pipeline
+---

--- a/tickets/relations/TKT-3XBE7Y--has-docs--DOCS-ZPE7DG.md
+++ b/tickets/relations/TKT-3XBE7Y--has-docs--DOCS-ZPE7DG.md
@@ -1,0 +1,5 @@
+---
+from: TKT-3XBE7Y
+relation: has-docs
+to: DOCS-ZPE7DG
+---

--- a/tickets/relations/TKT-3XBE7Y--has-implementation--IMPL-TISRMZ.md
+++ b/tickets/relations/TKT-3XBE7Y--has-implementation--IMPL-TISRMZ.md
@@ -1,0 +1,5 @@
+---
+from: TKT-3XBE7Y
+relation: has-implementation
+to: IMPL-TISRMZ
+---

--- a/tickets/relations/TKT-3XBE7Y--has-planning--PLAN-EAQQOX.md
+++ b/tickets/relations/TKT-3XBE7Y--has-planning--PLAN-EAQQOX.md
@@ -1,0 +1,5 @@
+---
+from: TKT-3XBE7Y
+relation: has-planning
+to: PLAN-EAQQOX
+---

--- a/tickets/relations/TKT-3XBE7Y--has-review--REV-HLF009.md
+++ b/tickets/relations/TKT-3XBE7Y--has-review--REV-HLF009.md
@@ -1,0 +1,5 @@
+---
+from: TKT-3XBE7Y
+relation: has-review
+to: REV-HLF009
+---

--- a/tickets/relations/TKT-3XBE7Y--implements--FEAT-GE1YY.md
+++ b/tickets/relations/TKT-3XBE7Y--implements--FEAT-GE1YY.md
@@ -1,0 +1,5 @@
+---
+from: TKT-3XBE7Y
+relation: implements
+to: FEAT-GE1YY
+---


### PR DESCRIPTION
`doclink` was adopted advisory with **58** findings (TKT-MTWQ4G). Two days
later it was **64**. Diffing the finding sets showed **zero new *kinds*** of
broken reference — the growth was existing breakage propagating as code got
copied. `[Set.Enforce]`, `[Todo.normalized]`, `[Filter]` and `[Hash]` each
appeared twice.

Advisory findings don't get fixed, so this clears the rule to **zero** and
makes it blocking.

## Why these are real

Go degrades an unresolvable doc link **silently** — pkg.go.dev renders the
literal characters `[Set.Enforce]`, brackets and all. `go vet`, `staticcheck`
and golangci-lint's `godoclint` all report zero on a deliberately broken link.

Every shape was verified against `go doc` on a minimal package rather than
trusting the tool. That mattered: an earlier audit graded 7 of 8 samples as
false positives because `grep` showed the symbols exist. They do — as
*methods* — and Go still won't link a bare `[Method]`.

## The fixes

| Shape | Count | Remedy |
|---|---|---|
| Bare method missing its receiver | 18 | qualify — `[ForPrincipal]` → `[Declarative.ForPrincipal]` |
| Unexported member / unimported pkg / test-only | 38 | unbracket — Go cannot link these at all |
| Pluralized `[X]s` | 6 | rephrase so the bracket ends the token |
| Backticked markdown example | 2 | **tool bug**, fixed upstream (v0.3.1) |

Two genuine rename casualties turned up, silently broken since their renames:
`[Set.Enforce]` (the methods are `EnforceUpdate`/`EnforceCreate`) and
`[Declarative.ReadQuery]` (it's `Request.ReadQuery`).

**All 63 changed Go lines are inside comments** — verified mechanically, not by
eye.

## Blocking, with a deliberately uncomfortable escape hatch

Suppression stays available, because every rule here is a heuristic over prose
and some findings will be wrong. But a blocking check with an easy escape hatch
makes silencing the cheapest path to green, and a reviewer skimming a diff
can't tell a considered suppression from a reflex one.

So the failure message (commentlint v0.3.0) leads with *reading* the finding,
presents suppression as option 2, names the rule in a copy-pasteable directive,
and says outright that "suppressed to unblock CI" is not a reason. `TestGuidance`
pins the fix-before-suppress ordering, not just the wording.

I applied that to myself: **none of the 64 were suppressed.**

## Rejected: grandfathering

The plimsoll pattern (pin the count, ratchet down) doesn't fit here. The growth
was *propagation*, so a frozen ceiling still lets each broken reference spread
up to its cap. Zero is the only count that stops copying.

## Verification

`comment-lint`, `lint`, `arch-lint`, `plimsoll`, `lint-md`, ticket validation —
all EXIT=0. Tests pass on every touched package.

The gate was tested by **reintroducing** a broken link: EXIT=1 with the
guidance printed. Without that check the promotion would be cosmetic.

Ticket: TKT-3XBE7Y · Planning PLAN-EAQQOX · Impl IMPL-TISRMZ · Review REV-HLF009 · Docs DOCS-ZPE7DG