### PR TITLE
🌍 feat(store): per-face delete primitive + fix replace deleting the wrong face's edge (TKT-C1XUA8 PR-D)

### DIFF
--- a/internal/entitymanager/copy_apply.go
+++ b/internal/entitymanager/copy_apply.go
@@ -54,6 +54,11 @@ func applyCopyEdges(ctx context.Context, view store.Store, plan *copyPlan) error
 			continue
 		}
 		replaced[e.relType] = true
+		// COLLECT FIRST, then delete. Mutating the store while ranging its
+		// own iterator is backend-dependent: pgstore holds a pgx.Rows cursor
+		// on one pooled connection while the delete takes a second, which
+		// under pool pressure is a deadlock candidate.
+		var doomed []*entity.Relation
 		for rel, err := range view.ListRelations(ctx, store.RelationQuery{
 			From: plan.targetID, Type: e.relType, FromPointer: &tail,
 		}) {
@@ -61,7 +66,16 @@ func applyCopyEdges(ctx context.Context, view store.Store, plan *copyPlan) error
 				return fmt.Errorf("entitymanager: copy %q: list target edges: %w",
 					plan.name, err)
 			}
-			derr := view.DeleteRelation(ctx, rel.From, rel.Type, rel.To)
+			doomed = append(doomed, rel)
+		}
+		for _, rel := range doomed {
+			// Addressed BY TAIL. Dropping it here (as this did before
+			// TKT-C1XUA8 PR-D) does not delete "approximately the right
+			// edge": the tail is part of a relation's identity, so
+			// DeleteRelation deletes the DEFAULT face's edge on the same
+			// triple — a face this copy has no business touching — and
+			// reports success, while the edge being replaced survives.
+			derr := view.DeleteRelationState(ctx, rel.From, rel.FromPointer, rel.Type, rel.To)
 			if derr != nil && !errors.Is(derr, store.ErrNotFound) {
 				return fmt.Errorf("entitymanager: copy %q: replace edges: %w",
 					plan.name, derr)

--- a/internal/entitymanager/copy_replace_tail_test.go
+++ b/internal/entitymanager/copy_replace_tail_test.go
@@ -1,0 +1,159 @@
+package entitymanager_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Sourcehaven-BV/rela/internal/acl"
+	"github.com/Sourcehaven-BV/rela/internal/audit"
+	"github.com/Sourcehaven-BV/rela/internal/entity"
+	"github.com/Sourcehaven-BV/rela/internal/entitymanager"
+	"github.com/Sourcehaven-BV/rela/internal/metamodel"
+	"github.com/Sourcehaven-BV/rela/internal/statemachine"
+	"github.com/Sourcehaven-BV/rela/internal/store"
+	"github.com/Sourcehaven-BV/rela/internal/store/memstore"
+)
+
+// replaceTailMetaYAML stages a copy INTO a non-default face, which is the
+// only shape where the tail-dropping bug is visible: when the target is the
+// default face, dropping the tail happens to address the same edge.
+const replaceTailMetaYAML = `
+version: "1"
+entities:
+  page:
+    label: Page
+    id_prefix: PAGE
+    pointers:
+      live: {default: true}
+      review: {}
+    properties:
+      title: {type: string}
+relations:
+  references:
+    label: References
+    scope: content
+    from: [page]
+    to: [page]
+copies:
+  stage-review:
+    from: page@live
+    to: page@review
+    fields: all
+    relations:
+      references: replace
+    guard:
+      permission: stage
+`
+
+// TestCopyReplace_DeletesTheTargetTailNotTheDefaultFacesEdge is named for the
+// corruption it prevents, and it reproduces a bug that was live in PR-C.
+//
+// THE BUG: applyCopyEdges listed the target face's edges filtered BY TAIL,
+// then called DeleteRelation with the tail DROPPED. Every backend's
+// DeleteRelation is default-tail-only (pgstore `AND from_pointer = ”`,
+// memstore defaultTailKey, fsstore's bare key), so the delete did not fail —
+// it removed the DEFAULT face's edge on the same triple and returned nil,
+// while the edge being replaced survived.
+//
+// Verified against memstore before the fix:
+//
+//	delete returned: nil
+//	edges surviving the intended delete of the PUBLISHED-tail edge:
+//	  [PAGE-1@published--references--SPEC-1]
+//
+// So `relations: replace` into a non-default face corrupted a face the copy
+// had no business touching AND failed its own job, silently, in all three
+// backends. `promote-page` with `relations: replace` is the headline use case
+// in design doc §9.1.
+//
+// Both assertions matter and neither is redundant: the target-side one
+// catches "the edge I meant to replace survived", the source-side one catches
+// "I destroyed a bystander". The bug produced BOTH at once.
+func TestCopyReplace_DeletesTheTargetTailNotTheDefaultFacesEdge(t *testing.T) {
+	var st store.Store = memstore.New()
+	meta, err := metamodel.Parse([]byte(replaceTailMetaYAML))
+	if err != nil {
+		t.Fatalf("metamodel.Parse: %v", err)
+	}
+	mgr, err := entitymanager.New(entitymanager.Deps{
+		Store:       st,
+		Meta:        meta,
+		Templater:   nopTemplater{},
+		Audit:       audit.Nop{},
+		ACL:         acl.NopACL{},
+		Transitions: statemachine.EmptySet(),
+		FieldGate:   entitymanager.AllowAllFieldGate{},
+		CopyGuard:   allowGuard{allow: true},
+	})
+	if err != nil {
+		t.Fatalf("entitymanager.New: %v", err)
+	}
+
+	ctx := context.Background()
+	seed := func(id string, p entity.Pointer, title string) {
+		t.Helper()
+		e := &entity.Entity{
+			ID: id, Type: "page", Pointer: p,
+			Properties: map[string]any{"title": title},
+		}
+		if cerr := st.CreateEntity(ctx, e); cerr != nil {
+			t.Fatalf("seed %s@%s: %v", id, p, cerr)
+		}
+	}
+	// A state row cannot exist headless, so the default face comes first.
+	seed("PAGE-1", "", "live")
+	seed("PAGE-1", "review", "staged")
+	seed("OLD-1", "", "old target")
+	seed("NEW-1", "", "new target")
+
+	reviewTail := entity.Pointer("review")
+	// Two edges differing ONLY by tail — these are two distinct relations.
+	// The SOURCE (default) face points at NEW-1; this is what gets copied.
+	if _, cerr := st.CreateRelation(ctx, "PAGE-1", "references", "NEW-1", nil); cerr != nil {
+		t.Fatalf("seed default-tail edge: %v", cerr)
+	}
+	// The TARGET (review) face points at OLD-1; `replace` must remove this.
+	if _, cerr := st.CreateRelation(ctx, "PAGE-1", "references", "OLD-1",
+		&store.RelationData{FromPointer: reviewTail}); cerr != nil {
+		t.Fatalf("seed review-tail edge: %v", cerr)
+	}
+
+	if _, cerr := mgr.CopyState(ctx, entitymanager.CopyRequest{
+		Definition: "stage-review", SourceID: "PAGE-1",
+	}); cerr != nil {
+		t.Fatalf("copy: %v", cerr)
+	}
+
+	targets := func(p *entity.Pointer) []string {
+		t.Helper()
+		q := store.RelationQuery{From: "PAGE-1", Type: "references"}
+		var out []string
+		for r, lerr := range st.ListRelations(ctx, q) {
+			if lerr != nil {
+				t.Fatalf("list: %v", lerr)
+			}
+			switch {
+			case p == nil && r.FromPointer.IsDefault():
+				out = append(out, r.To)
+			case p != nil && r.FromPointer == *p:
+				out = append(out, r.To)
+			}
+		}
+		return out
+	}
+
+	// The TARGET face must now hold NEW-1 only: its OLD-1 edge was replaced.
+	// Under the bug OLD-1 survived here, because the delete went elsewhere.
+	if got := targets(&reviewTail); len(got) != 1 || got[0] != "NEW-1" {
+		t.Errorf("replace must swap the TARGET face's edges; got %v, want [NEW-1] "+
+			"— a surviving OLD-1 means the delete addressed the wrong tail", got)
+	}
+
+	// The SOURCE (default) face's edge must be untouched. Under the bug this
+	// is the edge that got deleted — a face the copy never addressed.
+	if got := targets(nil); len(got) != 1 || got[0] != "NEW-1" {
+		t.Errorf("the DEFAULT face's edge must survive a replace on another face; "+
+			"got %v, want [NEW-1] — losing it means the copy corrupted a bystander",
+			got)
+	}
+}

--- a/internal/store/fsstore/entity.go
+++ b/internal/store/fsstore/entity.go
@@ -511,6 +511,128 @@ func (s *FSStore) deleteEntity(_ context.Context, id string, cascade bool) (*sto
 	return result, nil
 }
 
+// deleteEntityState removes ONE face and only the edges belonging to it
+// (TKT-C1XUA8). Contrast deleteEntity above, which sweeps the whole family
+// and every incident edge on both sides.
+//
+// Keeps that function's fail-secure file ordering: relation files first,
+// then the entity file, with a real removal error aborting before the
+// in-memory index is touched.
+func (s *FSStore) deleteEntityState(
+	_ context.Context, id string, p entity.Pointer,
+) (*store.DeleteResult, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	key := stateKey(id, p)
+	meta, ok := s.entities[key]
+	if !ok {
+		return nil, store.ErrNotFound
+	}
+
+	// Refuse to orphan the family: a family with no default row has no
+	// defined meaning and world fallback resolves against it. Deleting the
+	// LAST face is fine — nothing is left to orphan.
+	if p.IsDefault() {
+		if n := s.familySize(id); n > 1 {
+			return nil, fmt.Errorf(
+				"%w: cannot delete the default face of %s while %d other state(s) remain",
+				store.ErrInvalidQuery, id, n-1)
+		}
+	}
+
+	e, err := s.loadEntityMeta(meta)
+	if err != nil {
+		return nil, err
+	}
+
+	// OUTGOING edges on this tail go with the face. INCOMING edges do NOT:
+	// heads are entity-level (§2.3), so an inbound edge points at the entity
+	// and survives its faces.
+	var owned []relationMeta
+	for _, rm := range s.relations {
+		if rm.From == id && rm.FromPointer == p {
+			owned = append(owned, rm)
+		}
+	}
+	sort.Slice(owned, func(i, j int) bool { return owned[i].key() < owned[j].key() })
+
+	deletedRelations := make([]*entity.Relation, 0, len(owned))
+	for _, rm := range owned {
+		r, loadErr := s.loadRelationMeta(rm)
+		if loadErr != nil {
+			r = entity.NewRelation(rm.From, rm.Type, rm.To)
+			r.FromPointer = rm.FromPointer
+		}
+		deletedRelations = append(deletedRelations, r)
+	}
+
+	for _, rm := range owned {
+		fileKey := s.relationFileKeyMeta(rm)
+		if rerr := s.rooted.Remove(fileKey); rerr != nil && !os.IsNotExist(rerr) {
+			return nil, fmt.Errorf("delete relation file %s: %w", rm.key(), rerr)
+		}
+		s.echoes.Forget(s.absPath(fileKey))
+	}
+	entKey := s.entityFileKey(meta.Type, key)
+	if rerr := s.rooted.Remove(entKey); rerr != nil && !os.IsNotExist(rerr) {
+		return nil, rerr
+	}
+	s.echoes.Forget(s.absPath(entKey))
+
+	// The attachment directory is owned 1:1 by the ENTITY, not by a face, so
+	// it only goes when the last face does — a discarded draft must not
+	// destroy attachments the surviving faces serve.
+	//
+	// This runs BEFORE the index mutations below, matching deleteEntity's
+	// fail-secure ordering: every fallible filesystem operation completes
+	// first, so an error returns with the in-memory index still matching what
+	// is on disk. Removing it afterwards would leave a caller who saw an
+	// error with the entity already gutted from the index — a divergence
+	// nothing reconciles until restart.
+	lastFace := s.familySize(id) == 1
+	if lastFace {
+		if aerr := s.removeAttachmentDir(id); aerr != nil {
+			return nil, aerr
+		}
+	}
+
+	delete(s.entities, key)
+	s.entityOrder = storeutil.SortedRemoveFunc(s.entityOrder, key, storeutil.CompareStateKeys)
+	if p.IsDefault() {
+		removeEntityFromCache(s.propCache, e)
+	}
+	for _, rm := range owned {
+		rk := rm.key()
+		delete(s.relations, rk)
+		s.relationOrder = storeutil.SortedRemove(s.relationOrder, rk)
+	}
+
+	// Observers are bare-id keyed, so notifying on a per-face delete would
+	// de-index an entity that still exists.
+	if lastFace {
+		s.notifyDelete(id)
+	}
+
+	s.emitFamilyDeleted([]entityMeta{meta}, owned)
+	return &store.DeleteResult{
+		DeletedEntities:  []*entity.Entity{e},
+		DeletedRelations: deletedRelations,
+	}, nil
+}
+
+// familySize counts the indexed state rows of a bare id. Callers must hold
+// s.mu.
+func (s *FSStore) familySize(id string) int {
+	n := 0
+	for _, meta := range s.entities {
+		if meta.ID == id {
+			n++
+		}
+	}
+	return n
+}
+
 // emitFamilyDeleted emits per-state entity-deleted events and per-edge
 // relation-deleted events for a cascaded family delete. Each event
 // carries its own state's type — the load path tolerates a mistyped

--- a/internal/store/fsstore/facedelete_files_test.go
+++ b/internal/store/fsstore/facedelete_files_test.go
@@ -1,0 +1,105 @@
+package fsstore_test
+
+import (
+	"context"
+	"io/fs"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/Sourcehaven-BV/rela/internal/entity"
+	"github.com/Sourcehaven-BV/rela/internal/storage"
+	"github.com/Sourcehaven-BV/rela/internal/store"
+	"github.com/Sourcehaven-BV/rela/internal/store/fsstore"
+)
+
+// TestFsFaceDeleteTouchesOnlyItsOwnFiles is the FILESYSTEM-level check that
+// the conformance suite cannot make: fsstore is the backend where a face's
+// identity is part of a FILENAME rather than a column, so "delete one face"
+// is a question about which files disappear.
+//
+// Two hazards it pins, both the fs analog of the tail-dropping bug:
+//
+//   - Deleting PAGE-1@draft must not disturb PAGE-1.md. The names share a
+//     prefix, so any prefix-matching removal would take both.
+//   - Relation files carry the tail in the FROM slot
+//     (PAGE-1@draft--references--SPEC-1.md), so they must be matched by TAIL,
+//     not by prefix — otherwise deleting a face takes the default face's edge
+//     file with it.
+//
+// Asserting the exact SET of removed files, rather than just that the face is
+// gone, is what makes this capable of failing: an over-broad removal still
+// leaves the queried face absent and would pass aexistence-only check.
+func TestFsFaceDeleteTouchesOnlyItsOwnFiles(t *testing.T) {
+	memfs := storage.NewMemFS()
+	s, err := fsstore.New(newConfig(memfs))
+	require.NoError(t, err)
+	ctx := context.Background()
+
+	mk := func(id string, p entity.Pointer) {
+		require.NoError(t, s.CreateEntity(ctx,
+			&entity.Entity{ID: id, Type: "page", Pointer: p}))
+	}
+	mk("PAGE-1", "")
+	mk("PAGE-1", "draft")
+	mk("SPEC-1", "")
+
+	draft := entity.Pointer("draft")
+	_, err = s.CreateRelation(ctx, "PAGE-1", "references", "SPEC-1", nil)
+	require.NoError(t, err)
+	_, err = s.CreateRelation(ctx, "PAGE-1", "references", "SPEC-1",
+		&store.RelationData{FromPointer: draft})
+	require.NoError(t, err)
+
+	files := func() []string {
+		var out []string
+		require.NoError(t, memfs.Walk("/", func(p string, d fs.DirEntry, e error) error {
+			if e != nil {
+				return e
+			}
+			if d.IsDir() || !strings.HasSuffix(p, ".md") {
+				return nil
+			}
+			out = append(out, p)
+			return nil
+		}))
+		sort.Strings(out)
+		return out
+	}
+	before := files()
+	t.Logf("BEFORE: %v", before)
+
+	_, err = s.DeleteEntityState(ctx, "PAGE-1", draft)
+	require.NoError(t, err)
+	after := files()
+	t.Logf("AFTER:  %v", after)
+
+	gone := map[string]bool{}
+	for _, f := range before {
+		gone[f] = true
+	}
+	for _, f := range after {
+		delete(gone, f)
+	}
+	var removed []string
+	for f := range gone {
+		removed = append(removed, f)
+	}
+	sort.Strings(removed)
+	t.Logf("REMOVED: %v", removed)
+
+	var keptDefault bool
+	for _, f := range after {
+		if strings.HasSuffix(f, "/PAGE-1.md") {
+			keptDefault = true
+		}
+	}
+	if !keptDefault {
+		t.Error("PAGE-1.md was removed by a delete of PAGE-1@draft")
+	}
+	if len(removed) != 2 {
+		t.Errorf("want exactly 2 files removed (the face + its own tail edge), got %v", removed)
+	}
+}

--- a/internal/store/fsstore/fsstore.go
+++ b/internal/store/fsstore/fsstore.go
@@ -141,8 +141,13 @@ type attachMeta struct {
 // contract change. Interface growth, not internal sprawl; keep
 // ratcheting the pre-existing surplus down per TKT-N0IKN9.)
 //
-//plimsoll:max-methods=102
-//plimsoll:max-exported-methods=34
+// (+2 methods / +2 exported with per-face delete, TKT-C1XUA8:
+// DeleteEntityState and DeleteRelationState joined the mandated
+// store.Store interface. Required-interface exception, not accreted
+// API — the counts ratchet only if store.Store itself narrows.)
+//
+//plimsoll:max-methods=106
+//plimsoll:max-exported-methods=36
 type FSStore struct {
 	// rooted is the validated-key I/O surface. Every read, write,
 	// directory op, and remove that operates on files under the

--- a/internal/store/fsstore/relation.go
+++ b/internal/store/fsstore/relation.go
@@ -217,17 +217,27 @@ func (s *FSStore) updateRelation(
 	return r.Clone(), nil
 }
 
-func (s *FSStore) deleteRelation(_ context.Context, from, relType, to string) error {
+func (s *FSStore) deleteRelation(ctx context.Context, from, relType, to string) error {
+	return s.deleteRelationState(ctx, from, "", relType, to)
+}
+
+// deleteRelationState removes the edge with EXACTLY this tail. The tail is
+// part of a relation's identity, so addressing the wrong one deletes a
+// different edge rather than failing (TKT-C1XUA8).
+func (s *FSStore) deleteRelationState(
+	_ context.Context, from string, p entity.Pointer, relType, to string,
+) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	key := from + "--" + relType + "--" + to
-	if _, ok := s.relations[key]; !ok {
+	key := relKey(from, p, relType, to)
+	rm, ok := s.relations[key]
+	if !ok {
 		return store.ErrNotFound
 	}
 
 	// Delete file.
-	fileKey := s.relationFileKey(from, relType, to)
+	fileKey := s.relationFileKeyMeta(rm)
 	if err := s.rooted.Remove(fileKey); err != nil {
 		return err
 	}
@@ -242,6 +252,7 @@ func (s *FSStore) deleteRelation(_ context.Context, from, relType, to string) er
 		RelationType: relType,
 		From:         from,
 		To:           to,
+		Pointer:      p,
 	})
 	return nil
 }

--- a/internal/store/fsstore/tx.go
+++ b/internal/store/fsstore/tx.go
@@ -64,6 +64,15 @@ func (s *FSStore) DeleteEntity(ctx context.Context, id string, cascade bool) (*s
 	return s.deleteEntity(ctx, id, cascade)
 }
 
+// DeleteEntityState implements store.EntityWriter.
+// Returns store.ErrNotFound if that face does not exist.
+func (s *FSStore) DeleteEntityState(
+	ctx context.Context, id string, p entity.Pointer,
+) (*store.DeleteResult, error) {
+	defer s.lockTx()()
+	return s.deleteEntityState(ctx, id, p)
+}
+
 // RenameEntity implements store.EntityWriter.
 // Returns store.ErrNotFound if oldID is absent, store.ErrConflict if
 // newID exists.
@@ -92,6 +101,14 @@ func (s *FSStore) UpdateRelation(
 func (s *FSStore) DeleteRelation(ctx context.Context, from, relType, to string) error {
 	defer s.lockTx()()
 	return s.deleteRelation(ctx, from, relType, to)
+}
+
+// DeleteRelationState implements store.RelationWriter.
+func (s *FSStore) DeleteRelationState(
+	ctx context.Context, from string, p entity.Pointer, relType, to string,
+) error {
+	defer s.lockTx()()
+	return s.deleteRelationState(ctx, from, p, relType, to)
 }
 
 // AttachFile implements store.AttachmentManager.
@@ -129,6 +146,12 @@ func (t txStore) DeleteEntity(ctx context.Context, id string, cascade bool) (*st
 	return t.deleteEntity(ctx, id, cascade)
 }
 
+func (t txStore) DeleteEntityState(
+	ctx context.Context, id string, p entity.Pointer,
+) (*store.DeleteResult, error) {
+	return t.deleteEntityState(ctx, id, p)
+}
+
 func (t txStore) RenameEntity(ctx context.Context, oldID, newID string) (*store.RenameResult, error) {
 	return t.renameEntity(ctx, oldID, newID)
 }
@@ -147,6 +170,12 @@ func (t txStore) UpdateRelation(
 
 func (t txStore) DeleteRelation(ctx context.Context, from, relType, to string) error {
 	return t.deleteRelation(ctx, from, relType, to)
+}
+
+func (t txStore) DeleteRelationState(
+	ctx context.Context, from string, p entity.Pointer, relType, to string,
+) error {
+	return t.deleteRelationState(ctx, from, p, relType, to)
 }
 
 func (t txStore) AttachFile(ctx context.Context, entityID, property, fileName string, r io.Reader) error {

--- a/internal/store/memstore/facedelete_observer_test.go
+++ b/internal/store/memstore/facedelete_observer_test.go
@@ -1,0 +1,59 @@
+package memstore_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/Sourcehaven-BV/rela/internal/entity"
+	"github.com/Sourcehaven-BV/rela/internal/store/memstore"
+)
+
+// recordingObserver captures the bare ids an observer is told to drop.
+type recordingObserver struct{ deleted []string }
+
+func (o *recordingObserver) EntityPut(*entity.Entity) error { return nil }
+func (o *recordingObserver) EntityDelete(id string) error {
+	o.deleted = append(o.deleted, id)
+	return nil
+}
+func (o *recordingObserver) EntityRenamed(string, *entity.Entity) error { return nil }
+
+// TestFaceDeleteDoesNotDeIndexALiveEntity pins a property that is otherwise
+// convention-only, and whose violation would be invisible for a long time.
+//
+// Observers (the search indexers) are keyed by BARE ID — pgstore's own
+// comment says "observers are bare-id keyed, so a single delete covers every
+// face". So notifying them on a PER-FACE delete tells the index the whole
+// entity is gone while other faces still exist: the entity silently vanishes
+// from search while `GetEntity` still returns it. Nothing surfaces that until
+// somebody searches for content that is demonstrably still there.
+//
+// The notify is therefore correct only when the LAST face goes, and both
+// halves need asserting — that it stays silent with siblings standing, and
+// that it does still fire when nothing is left.
+func TestFaceDeleteDoesNotDeIndexALiveEntity(t *testing.T) {
+	obs := &recordingObserver{}
+	s := memstore.New(memstore.WithObserver(obs))
+	ctx := context.Background()
+
+	mk := func(p entity.Pointer) {
+		require.NoError(t, s.CreateEntity(ctx,
+			&entity.Entity{ID: "PAGE-1", Type: "page", Pointer: p}))
+	}
+	mk("")
+	mk("draft")
+
+	_, err := s.DeleteEntityState(ctx, "PAGE-1", entity.Pointer("draft"))
+	require.NoError(t, err)
+	require.Empty(t, obs.deleted,
+		"deleting one face must NOT tell bare-id-keyed observers the entity is "+
+			"gone — the default face still exists, so this would de-index a live entity")
+
+	// The last face going IS an entity deletion, and must notify.
+	_, err = s.DeleteEntityState(ctx, "PAGE-1", "")
+	require.NoError(t, err)
+	require.Equal(t, []string{"PAGE-1"}, obs.deleted,
+		"removing the last face must notify observers, or the index keeps a ghost")
+}

--- a/internal/store/memstore/memstore.go
+++ b/internal/store/memstore/memstore.go
@@ -58,8 +58,13 @@ import (
 // joined the mandated store.Store interface; rekeyFamily serves the
 // family-wide rename that contract requires.)
 //
-//plimsoll:max-methods=45
-//plimsoll:max-exported-methods=30
+// (+2 methods / +2 exported with per-face delete, TKT-C1XUA8:
+// DeleteEntityState and DeleteRelationState joined the mandated
+// store.Store interface. Required-interface exception, not accreted
+// API — the counts ratchet only if store.Store itself narrows.)
+//
+//plimsoll:max-methods=49
+//plimsoll:max-exported-methods=32
 type MemStore struct {
 	// txMu serializes an open Tx against ordinary writers: Tx holds it
 	// for the whole callback, every exported write method takes it
@@ -662,6 +667,97 @@ func (m *MemStore) deleteEntity(_ context.Context, id string, cascade bool) (*st
 	return result, nil
 }
 
+// deleteEntityState removes ONE face and only the edges that belong to it
+// (TKT-C1XUA8). Contrast deleteEntity above, which sweeps the whole family
+// and every incident edge on both sides — reusing that here would make
+// discarding a draft destroy the published face and its inbound links.
+func (m *MemStore) deleteEntityState(
+	_ context.Context, id string, p entity.Pointer,
+) (*store.DeleteResult, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	key := entity.FormatStateRef(id, p)
+	target, ok := m.entities[key]
+	if !ok {
+		return nil, store.ErrNotFound
+	}
+
+	// Refuse to orphan the family: a family with no default row has no
+	// defined meaning and world fallback resolves against it. Deleting the
+	// LAST face is fine — nothing is left to orphan.
+	// One scan, matching fsstore's shape: the two implementations are
+	// deliberately parallel and a gratuitous difference here is noise.
+	if p.IsDefault() {
+		if n := familySize(m.entities, id); n > 1 {
+			return nil, fmt.Errorf(
+				"%w: cannot delete the default face of %s while %d other state(s) remain",
+				store.ErrInvalidQuery, id, n-1)
+		}
+	}
+
+	// OUTGOING edges on this tail go with the face. INCOMING edges do NOT:
+	// heads are entity-level (§2.3), so an inbound edge points at the entity
+	// and survives its faces.
+	var owned []*entity.Relation
+	for _, r := range m.relations {
+		if r.From == id && r.FromPointer == p {
+			owned = append(owned, r)
+		}
+	}
+	sort.Slice(owned, func(i, j int) bool { return owned[i].Key() < owned[j].Key() })
+
+	result := &store.DeleteResult{DeletedEntities: []*entity.Entity{target.Clone()}}
+	delete(m.entities, key)
+	m.entityOrder = entityRemove(m.entityOrder, key)
+
+	// Attachments are keyed to the bare id, so they belong to the ENTITY.
+	// Only sweep them when this was the last face standing.
+	if familySize(m.entities, id) == 0 {
+		for k, a := range m.attachments {
+			if a.entityID == id {
+				delete(m.attachments, k)
+			}
+		}
+		m.notifyDelete(id)
+	}
+
+	for _, r := range owned {
+		result.DeletedRelations = append(result.DeletedRelations, r.Clone())
+		rk := r.Key()
+		delete(m.relations, rk)
+		m.relationOrder = sortedRemove(m.relationOrder, rk)
+	}
+
+	m.emit(store.Event{
+		Op:         store.EventEntityDeleted,
+		EntityType: target.Type,
+		EntityID:   id,
+		Pointer:    p,
+	})
+	for _, r := range owned {
+		m.emit(store.Event{
+			Op:           store.EventRelationDeleted,
+			RelationType: r.Type,
+			From:         r.From,
+			To:           r.To,
+			Pointer:      r.FromPointer,
+		})
+	}
+	return result, nil
+}
+
+// familySize counts the state rows of a bare id.
+func familySize(entities map[string]*entity.Entity, id string) int {
+	n := 0
+	for _, e := range entities {
+		if e.ID == id {
+			n++
+		}
+	}
+	return n
+}
+
 // rekeyFamily moves every state of a family onto newID — clones to
 // avoid mutating stored objects — and returns the renamed states in
 // family order. Callers must hold m.mu.
@@ -778,12 +874,19 @@ func (m *MemStore) renameEntity(_ context.Context, oldID, newID string) (*store.
 
 // --- RelationReader ---
 
-// defaultTailKey addresses the DEFAULT-tail edge of a triple. Get,
-// update, and delete are default-tail-only in Step 1 (TKT-DOFYR1) —
-// see store.RelationData.FromPointer; state-tailed edges are removed
-// via the entity cascades.
+// tailKey addresses the edge of a triple carrying EXACTLY tail p. The tail
+// is part of a relation's identity, so this is an address and not a filter:
+// two tails on one triple are two relations (TKT-C1XUA8).
+func tailKey(from string, p entity.Pointer, relType, to string) string {
+	return (&entity.Relation{From: from, FromPointer: p, Type: relType, To: to}).Key()
+}
+
+// defaultTailKey addresses the DEFAULT-tail edge of a triple. Get and
+// update are default-tail-only (TKT-DOFYR1) — see
+// store.RelationData.FromPointer. Delete has the general form
+// deleteRelationState since TKT-C1XUA8.
 func defaultTailKey(from, relType, to string) string {
-	return (&entity.Relation{From: from, Type: relType, To: to}).Key()
+	return tailKey(from, "", relType, to)
 }
 
 func (m *MemStore) GetRelation(_ context.Context, from, relType, to string) (*entity.Relation, error) {
@@ -938,11 +1041,20 @@ func (m *MemStore) updateRelation(
 	return updated.Clone(), nil
 }
 
-func (m *MemStore) deleteRelation(_ context.Context, from, relType, to string) error {
+func (m *MemStore) deleteRelation(ctx context.Context, from, relType, to string) error {
+	return m.deleteRelationState(ctx, from, "", relType, to)
+}
+
+// deleteRelationState removes the edge with EXACTLY this tail. The tail is
+// part of a relation's identity, so addressing the wrong one deletes a
+// different edge rather than failing (TKT-C1XUA8).
+func (m *MemStore) deleteRelationState(
+	_ context.Context, from string, p entity.Pointer, relType, to string,
+) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	key := defaultTailKey(from, relType, to)
+	key := tailKey(from, p, relType, to)
 	if _, ok := m.relations[key]; !ok {
 		return store.ErrNotFound
 	}

--- a/internal/store/memstore/tx.go
+++ b/internal/store/memstore/tx.go
@@ -55,6 +55,15 @@ func (m *MemStore) DeleteEntity(ctx context.Context, id string, cascade bool) (*
 	return m.deleteEntity(ctx, id, cascade)
 }
 
+// DeleteEntityState implements store.EntityWriter.
+// Returns store.ErrNotFound if that face does not exist.
+func (m *MemStore) DeleteEntityState(
+	ctx context.Context, id string, p entity.Pointer,
+) (*store.DeleteResult, error) {
+	defer m.lockTx()()
+	return m.deleteEntityState(ctx, id, p)
+}
+
 // RenameEntity implements store.EntityWriter.
 // Returns store.ErrNotFound if oldID is absent, store.ErrConflict if
 // newID exists.
@@ -83,6 +92,14 @@ func (m *MemStore) UpdateRelation(
 func (m *MemStore) DeleteRelation(ctx context.Context, from, relType, to string) error {
 	defer m.lockTx()()
 	return m.deleteRelation(ctx, from, relType, to)
+}
+
+// DeleteRelationState implements store.RelationWriter.
+func (m *MemStore) DeleteRelationState(
+	ctx context.Context, from string, p entity.Pointer, relType, to string,
+) error {
+	defer m.lockTx()()
+	return m.deleteRelationState(ctx, from, p, relType, to)
 }
 
 // AttachFile implements store.AttachmentManager.
@@ -120,6 +137,12 @@ func (t txStore) DeleteEntity(ctx context.Context, id string, cascade bool) (*st
 	return t.deleteEntity(ctx, id, cascade)
 }
 
+func (t txStore) DeleteEntityState(
+	ctx context.Context, id string, p entity.Pointer,
+) (*store.DeleteResult, error) {
+	return t.deleteEntityState(ctx, id, p)
+}
+
 func (t txStore) RenameEntity(ctx context.Context, oldID, newID string) (*store.RenameResult, error) {
 	return t.renameEntity(ctx, oldID, newID)
 }
@@ -138,6 +161,12 @@ func (t txStore) UpdateRelation(
 
 func (t txStore) DeleteRelation(ctx context.Context, from, relType, to string) error {
 	return t.deleteRelation(ctx, from, relType, to)
+}
+
+func (t txStore) DeleteRelationState(
+	ctx context.Context, from string, p entity.Pointer, relType, to string,
+) error {
+	return t.deleteRelationState(ctx, from, p, relType, to)
 }
 
 func (t txStore) AttachFile(ctx context.Context, entityID, property, fileName string, r io.Reader) error {

--- a/internal/store/pgstore/entity.go
+++ b/internal/store/pgstore/entity.go
@@ -533,6 +533,118 @@ func (s *Store) DeleteEntity(ctx context.Context, id string, cascade bool) (*sto
 	return &store.DeleteResult{DeletedEntities: family, DeletedRelations: related}, nil
 }
 
+// DeleteEntityState removes ONE content state (face) and only the edges
+// belonging to it (TKT-C1XUA8).
+//
+// Contrast DeleteEntity above, whose three statements are all `WHERE id =
+// $1` / `from_id = $1 OR to_id = $1` and sweep the entire family plus every
+// incident edge on both sides. Reusing that shape here would make
+// discarding a draft destroy the published face and cut every inbound link
+// unrelated entities hold on it — so this deletes by (id, pointer) and only
+// outgoing edges on the matching tail.
+func (s *Store) DeleteEntityState(
+	ctx context.Context, id string, p entity.Pointer,
+) (*store.DeleteResult, error) {
+	tx, err := s.db.Begin(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer tx.Rollback(ctx) //nolint:errcheck // rollback after commit is a no-op
+
+	face, err := scanEntities(ctx, tx,
+		`SELECT id, type, pointer, properties, content, updated_at
+		 FROM entities WHERE id = $1 AND pointer = $2`, id, string(p))
+	if err != nil {
+		return nil, err
+	}
+	if len(face) == 0 {
+		return nil, store.ErrNotFound
+	}
+
+	// Refuse to orphan the family: a family with no default row has no
+	// defined meaning and world fallback resolves against it. Deleting the
+	// LAST face is fine — nothing is left to orphan.
+	if p.IsDefault() {
+		var siblings int
+		if serr := tx.QueryRow(ctx,
+			`SELECT count(*) FROM entities WHERE id = $1 AND pointer <> ''`, id,
+		).Scan(&siblings); serr != nil {
+			return nil, serr
+		}
+		if siblings > 0 {
+			return nil, fmt.Errorf(
+				"%w: cannot delete the default face of %s while %d other state(s) remain",
+				store.ErrInvalidQuery, id, siblings)
+		}
+	}
+
+	// OUTGOING edges on this tail only. INCOMING edges are deliberately NOT
+	// matched: heads are entity-level (§2.3), so an inbound edge points at
+	// the entity and survives its faces.
+	owned, err := scanRelations(ctx, tx,
+		`SELECT from_id, from_pointer, rel_type, to_id, properties, content, updated_at
+		 FROM relations WHERE from_id = $1 AND from_pointer = $2
+		 ORDER BY rel_type, to_id`, id, string(p))
+	if err != nil {
+		return nil, err
+	}
+
+	if _, err := tx.Exec(ctx,
+		`DELETE FROM relations WHERE from_id = $1 AND from_pointer = $2`,
+		id, string(p)); err != nil {
+		return nil, err
+	}
+	if _, err := tx.Exec(ctx,
+		`DELETE FROM entities WHERE id = $1 AND pointer = $2`, id, string(p)); err != nil {
+		return nil, err
+	}
+
+	// Attachments are keyed to the bare id, so they belong to the ENTITY, not
+	// to a face: only sweep them once the last face is gone. A discarded
+	// draft must not destroy attachments the surviving faces serve.
+	var left int
+	if cerr := tx.QueryRow(ctx,
+		`SELECT count(*) FROM entities WHERE id = $1`, id).Scan(&left); cerr != nil {
+		return nil, cerr
+	}
+	if left == 0 {
+		if _, err := tx.Exec(ctx,
+			`DELETE FROM attachments WHERE entity_id = $1`, id); err != nil {
+			return nil, err
+		}
+	}
+
+	evs := make([]store.Event, 0, len(owned)+1)
+	evs = append(evs, store.Event{
+		Op: store.EventEntityDeleted, EntityType: face[0].Type, EntityID: id, Pointer: p,
+	})
+	for _, r := range owned {
+		evs = append(evs, store.Event{
+			Op: store.EventRelationDeleted, RelationType: r.Type, From: r.From, To: r.To,
+			Pointer: r.FromPointer,
+		})
+	}
+	if err := s.writeTombstonesForEvents(ctx, tx, evs); err != nil {
+		return nil, err
+	}
+	for _, ev := range evs {
+		s.notify(ctx, tx, ev)
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return nil, err
+	}
+
+	// Observers are bare-id keyed (see notifyPut), so a per-face delete must
+	// NOT notify them while other faces remain — that would de-index an
+	// entity that still exists.
+	if left == 0 {
+		s.notifyDelete(id)
+	}
+	s.emitAll(evs)
+
+	return &store.DeleteResult{DeletedEntities: face, DeletedRelations: owned}, nil
+}
+
 // scanEntities drains a multi-row entity query.
 func scanEntities(ctx context.Context, db DBTX, sql string, args ...any) ([]*entity.Entity, error) {
 	rows, err := db.Query(ctx, sql, args...)

--- a/internal/store/pgstore/pgstore.go
+++ b/internal/store/pgstore/pgstore.go
@@ -107,8 +107,13 @@ type DBTX interface {
 // +1 (38→39, TKT-DOFYR1): GetEntityState joined the mandated store.Store
 // interface — the required-interface exception, not internal sprawl.
 //
-//plimsoll:max-exported-methods=39
-//plimsoll:max-methods=49
+// (+2 methods / +2 exported with per-face delete, TKT-C1XUA8:
+// DeleteEntityState and DeleteRelationState joined the mandated
+// store.Store interface. Required-interface exception, not accreted
+// API — the counts ratchet only if store.Store itself narrows.)
+//
+//plimsoll:max-exported-methods=41
+//plimsoll:max-methods=51
 type Store struct {
 	db        DBTX
 	observers []store.EntityObserver // notified synchronously after committed entity writes

--- a/internal/store/pgstore/relation.go
+++ b/internal/store/pgstore/relation.go
@@ -218,17 +218,27 @@ func (s *Store) UpdateRelation(
 }
 
 // DeleteRelation removes a relation. Returns store.ErrNotFound if absent.
+//
+// Addresses the DEFAULT-tail edge; DeleteRelationState is the general form.
 func (s *Store) DeleteRelation(ctx context.Context, from, relType, to string) error {
+	return s.DeleteRelationState(ctx, from, "", relType, to)
+}
+
+// DeleteRelationState removes the edge with EXACTLY this tail. The tail is
+// part of a relation's identity, so addressing the wrong one deletes a
+// different edge rather than failing (TKT-C1XUA8).
+func (s *Store) DeleteRelationState(
+	ctx context.Context, from string, p entity.Pointer, relType, to string,
+) error {
 	tx, err := s.db.Begin(ctx)
 	if err != nil {
 		return err
 	}
 	defer tx.Rollback(ctx) //nolint:errcheck // rollback after commit is a no-op
 
-	// Default-tail addressing in Step 1 (TKT-DOFYR1); state-tailed edges
-	// are removed via the entity cascades.
-	const q = `DELETE FROM relations WHERE from_id = $1 AND rel_type = $2 AND to_id = $3 AND from_pointer = ''`
-	tag, err := tx.Exec(ctx, q, from, relType, to)
+	const q = `DELETE FROM relations
+	           WHERE from_id = $1 AND rel_type = $2 AND to_id = $3 AND from_pointer = $4`
+	tag, err := tx.Exec(ctx, q, from, relType, to, string(p))
 	if err != nil {
 		return err
 	}
@@ -238,11 +248,14 @@ func (s *Store) DeleteRelation(ctx context.Context, from, relType, to string) er
 
 	// Record a tombstone in the same tx so the durable manifest can report the
 	// removal after the live row is gone (FEAT-NJ9FEN).
-	if err := s.writeRelationTombstone(ctx, tx, from, "", relType, to); err != nil {
+	if err := s.writeRelationTombstone(ctx, tx, from, p, relType, to); err != nil {
 		return err
 	}
 
-	ev := store.Event{Op: store.EventRelationDeleted, RelationType: relType, From: from, To: to}
+	ev := store.Event{
+		Op: store.EventRelationDeleted, RelationType: relType,
+		From: from, To: to, Pointer: p,
+	}
 	s.notify(ctx, tx, ev)
 	if err := tx.Commit(ctx); err != nil {
 		return err

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -329,6 +329,33 @@ type EntityWriter interface {
 	// Returns ErrNotFound if the entity does not exist.
 	DeleteEntity(ctx context.Context, id string, cascade bool) (*DeleteResult, error)
 
+	// DeleteEntityState removes ONE content state (face) of an entity,
+	// leaving the rest of the family standing (TKT-C1XUA8).
+	//
+	// This is NOT a narrower DeleteEntity, and the difference is the whole
+	// point: DeleteEntity addresses the bare id and sweeps the entire state
+	// family plus every incident relation on BOTH sides. Deleting a face
+	// removes one row and only the edges that belong to that face.
+	//
+	// Which edges belong to a face:
+	//
+	//   - OUTGOING edges whose tail is this face's pointer go WITH it. They
+	//     were written against this face and nothing else can own them.
+	//   - INCOMING edges SURVIVE. Heads are entity-level (design doc §2.3),
+	//     so an inbound edge points at the ENTITY, not at one of its faces —
+	//     deleting them would let removing a draft silently cut links that
+	//     unrelated entities hold on the published face.
+	//
+	// Refuses (ErrInvalidQuery) to delete the DEFAULT face while non-default
+	// faces remain: a family with no default row has no defined meaning, and
+	// world fallback (`otherwise: default`) resolves against it. Delete the
+	// whole entity, or discard the non-default faces first.
+	//
+	// Returns ErrNotFound if that face does not exist. Deleting the only
+	// remaining face is allowed and leaves no entity behind — it is
+	// equivalent to DeleteEntity for a single-face entity.
+	DeleteEntityState(ctx context.Context, id string, p entity.Pointer) (*DeleteResult, error)
+
 	// RenameEntity changes an entity's ID. All relations referencing the
 	// old ID are updated atomically.
 	// Returns ErrNotFound if the entity does not exist.
@@ -410,7 +437,26 @@ type RelationWriter interface {
 
 	// DeleteRelation removes a relation.
 	// Returns ErrNotFound if the relation does not exist.
+	//
+	// Addresses the DEFAULT-tail edge of the triple. A triple can carry one
+	// edge per state tail (see RelationData.FromPointer), so this is an
+	// address, not a wildcard — use DeleteRelationState for a state-tailed
+	// edge.
 	DeleteRelation(ctx context.Context, from, relType, to string) error
+
+	// DeleteRelationState removes the edge of this triple whose tail is p
+	// (TKT-C1XUA8). The zero pointer addresses the default-tail edge, making
+	// this the general form of DeleteRelation.
+	//
+	// Separate from DeleteRelation because the tail is part of a relation's
+	// IDENTITY, not a filter: two edges on the same triple with different
+	// tails are two relations. A caller that holds a state-tailed edge and
+	// drops the tail does not delete "the edge, approximately" — it deletes a
+	// DIFFERENT edge, the default face's, and reports success. That is the
+	// bug this method exists to make unavailable.
+	//
+	// Returns ErrNotFound if no edge with that exact tail exists.
+	DeleteRelationState(ctx context.Context, from string, p entity.Pointer, relType, to string) error
 }
 
 // RelationData holds optional properties and content for a relation.

--- a/internal/store/storetest/states.go
+++ b/internal/store/storetest/states.go
@@ -279,6 +279,209 @@ func RunStateTests(t *testing.T, f Factory) {
 		assert.Empty(t, left)
 	})
 
+	// --- Per-face delete (TKT-C1XUA8) -----------------------------------
+	//
+	// The contract these pin is the OPPOSITE of DeleteCascadesTheFamily
+	// above, and the pair is deliberate: DeleteEntity addresses the bare id
+	// and sweeps the family; DeleteEntityState addresses one face and leaves
+	// the family standing. A backend that implemented the second as the
+	// first would pass neither.
+
+	t.Run("DeleteStateLeavesSiblingFacesStanding", func(t *testing.T) {
+		s := f(t)
+		mustCreate(t, s, newState(t, "PAGE-20", "page", "", "default"))
+		mustCreate(t, s, newState(t, "PAGE-20", "page", "draft", "draft"))
+		mustCreate(t, s, newState(t, "PAGE-20", "page", "published", "published"))
+
+		res, err := s.DeleteEntityState(ctx(), "PAGE-20", ptr(t, "draft"))
+		require.NoError(t, err)
+		require.Len(t, res.DeletedEntities, 1, "exactly one face deleted")
+		assert.Equal(t, ptr(t, "draft"), res.DeletedEntities[0].Pointer)
+
+		_, err = s.GetEntityState(ctx(), "PAGE-20", ptr(t, "draft"))
+		assert.ErrorIs(t, err, store.ErrNotFound, "the discarded face is gone")
+
+		// The siblings must be untouched, contents included — a backend that
+		// deleted the family would fail here rather than in a count.
+		def, err := s.GetEntity(ctx(), "PAGE-20")
+		require.NoError(t, err)
+		assert.Equal(t, "default", def.GetString("title"))
+		pub, err := s.GetEntityState(ctx(), "PAGE-20", ptr(t, "published"))
+		require.NoError(t, err)
+		assert.Equal(t, "published", pub.GetString("title"))
+	})
+
+	t.Run("DeleteStateTakesItsOwnEdgesButNotInboundOnes", func(t *testing.T) {
+		s := f(t)
+		mustCreate(t, s, newState(t, "PAGE-21", "page", "", "default"))
+		mustCreate(t, s, newState(t, "PAGE-21", "page", "draft", "draft"))
+		mustCreate(t, s, newState(t, "SPEC-5", "page", "", "target"))
+		mustCreate(t, s, newState(t, "OTHER-5", "page", "", "other"))
+
+		draft := ptr(t, "draft")
+		// One edge per tail on the SAME triple: these are two relations.
+		_, err := s.CreateRelation(ctx(), "PAGE-21", "references", "SPEC-5", nil)
+		require.NoError(t, err)
+		_, err = s.CreateRelation(ctx(), "PAGE-21", "references", "SPEC-5",
+			&store.RelationData{FromPointer: draft})
+		require.NoError(t, err)
+		// Inbound: belongs to the ENTITY, not to the draft face (§2.3).
+		_, err = s.CreateRelation(ctx(), "OTHER-5", "links", "PAGE-21", nil)
+		require.NoError(t, err)
+
+		res, err := s.DeleteEntityState(ctx(), "PAGE-21", draft)
+		require.NoError(t, err)
+		require.Len(t, res.DeletedRelations, 1,
+			"only the draft face's own outgoing edge goes with it")
+		assert.Equal(t, draft, res.DeletedRelations[0].FromPointer)
+
+		// The default face's edge on the same triple SURVIVES. This is the
+		// case the tail-dropping bug got wrong: it deleted this one.
+		remaining := collectRelations(t, s, store.RelationQuery{From: "PAGE-21"})
+		require.Len(t, remaining, 1)
+		assert.True(t, remaining[0].FromPointer.IsDefault(),
+			"the default face's edge must survive its sibling's deletion")
+
+		// Inbound edges survive: an entity elsewhere still points here.
+		inbound := collectRelations(t, s, store.RelationQuery{To: "PAGE-21"})
+		assert.Len(t, inbound, 1, "heads are entity-level, so inbound edges survive")
+	})
+
+	t.Run("DeleteStateRefusesTheDefaultFaceWhileSiblingsRemain", func(t *testing.T) {
+		s := f(t)
+		mustCreate(t, s, newState(t, "PAGE-22", "page", "", "default"))
+		mustCreate(t, s, newState(t, "PAGE-22", "page", "draft", "draft"))
+
+		// A family with no default row has no defined meaning, and world
+		// fallback resolves against it. Refusing is not a limitation to route
+		// around — deleting it would leave the remaining faces unreachable by
+		// every `otherwise: default` reader.
+		_, err := s.DeleteEntityState(ctx(), "PAGE-22", "")
+		require.Error(t, err)
+		assert.ErrorIs(t, err, store.ErrInvalidQuery)
+
+		_, err = s.GetEntity(ctx(), "PAGE-22")
+		assert.NoError(t, err, "the refusal must not have deleted anything")
+	})
+
+	t.Run("DeleteStateOfTheLastFaceRemovesTheEntity", func(t *testing.T) {
+		s := f(t)
+		mustCreate(t, s, newState(t, "PAGE-23", "page", "", "only"))
+
+		// The default face is deletable when it is the ONLY face: no sibling
+		// is orphaned, so the refusal above does not apply.
+		res, err := s.DeleteEntityState(ctx(), "PAGE-23", "")
+		require.NoError(t, err)
+		assert.Len(t, res.DeletedEntities, 1)
+
+		_, err = s.GetEntity(ctx(), "PAGE-23")
+		assert.ErrorIs(t, err, store.ErrNotFound)
+	})
+
+	t.Run("DeleteStateEmitsOnlyItsOwnFaceEvent", func(t *testing.T) {
+		s := f(t)
+		mustCreate(t, s, newState(t, "PAGE-28", "page", "", "default"))
+		mustCreate(t, s, newState(t, "PAGE-28", "page", "draft", "draft"))
+
+		events, cancel := s.Subscribe(16)
+		defer cancel()
+		_, err := s.DeleteEntityState(ctx(), "PAGE-28", ptr(t, "draft"))
+		require.NoError(t, err)
+
+		// EXACTLY ONE delete event, carrying the discarded face's pointer.
+		// A backend that emitted the family's events here would be telling
+		// every subscriber the whole entity is gone while the default face
+		// still exists — silent, and invisible until someone read the entity
+		// through a derived index.
+		select {
+		case ev := <-events:
+			assert.Equal(t, store.EventEntityDeleted, ev.Op)
+			assert.Equal(t, ptr(t, "draft"), ev.Pointer,
+				"the event must name the face that was deleted")
+		case <-time.After(5 * time.Second):
+			t.Fatal("timed out waiting for the face-delete event")
+		}
+		select {
+		case ev := <-events:
+			t.Errorf("a per-face delete must emit ONE event, got a second: %+v", ev)
+		case <-time.After(100 * time.Millisecond):
+			// Correct: nothing further.
+		}
+	})
+
+	t.Run("DeleteStateNotFound", func(t *testing.T) {
+		s := f(t)
+		mustCreate(t, s, newState(t, "PAGE-24", "page", "", "default"))
+
+		_, err := s.DeleteEntityState(ctx(), "PAGE-24", ptr(t, "nosuchface"))
+		assert.ErrorIs(t, err, store.ErrNotFound)
+		_, err = s.DeleteEntityState(ctx(), "NO-SUCH-ENTITY", ptr(t, "draft"))
+		assert.ErrorIs(t, err, store.ErrNotFound)
+	})
+
+	// --- Per-tail relation delete (TKT-C1XUA8) ---------------------------
+
+	t.Run("DeleteRelationStateAddressesTheTailNotTheTriple", func(t *testing.T) {
+		s := f(t)
+		mustCreate(t, s, newState(t, "PAGE-25", "page", "", "default"))
+		mustCreate(t, s, newState(t, "PAGE-25", "page", "published", "published"))
+		mustCreate(t, s, newState(t, "SPEC-6", "page", "", "target"))
+
+		pub := ptr(t, "published")
+		_, err := s.CreateRelation(ctx(), "PAGE-25", "references", "SPEC-6", nil)
+		require.NoError(t, err)
+		_, err = s.CreateRelation(ctx(), "PAGE-25", "references", "SPEC-6",
+			&store.RelationData{FromPointer: pub})
+		require.NoError(t, err)
+
+		// Delete the PUBLISHED-tail edge. The regression this guards: every
+		// backend's DeleteRelation is default-tail-only, so a caller dropping
+		// the tail deleted the DEFAULT edge and reported success while the
+		// published edge survived — the wrong edge, silently.
+		require.NoError(t, s.DeleteRelationState(ctx(), "PAGE-25", pub, "references", "SPEC-6"))
+
+		remaining := collectRelations(t, s, store.RelationQuery{From: "PAGE-25"})
+		require.Len(t, remaining, 1)
+		assert.True(t, remaining[0].FromPointer.IsDefault(),
+			"the default-tail edge must survive deletion of its published-tail sibling")
+	})
+
+	t.Run("DeleteRelationStateZeroPointerMatchesDeleteRelation", func(t *testing.T) {
+		s := f(t)
+		mustCreate(t, s, newState(t, "PAGE-26", "page", "", "default"))
+		mustCreate(t, s, newState(t, "PAGE-26", "page", "draft", "draft"))
+		mustCreate(t, s, newState(t, "SPEC-7", "page", "", "target"))
+
+		_, err := s.CreateRelation(ctx(), "PAGE-26", "references", "SPEC-7", nil)
+		require.NoError(t, err)
+		_, err = s.CreateRelation(ctx(), "PAGE-26", "references", "SPEC-7",
+			&store.RelationData{FromPointer: ptr(t, "draft")})
+		require.NoError(t, err)
+
+		// The zero pointer is the general form's default-tail address, so it
+		// must behave exactly as DeleteRelation does — same edge, same result.
+		require.NoError(t, s.DeleteRelationState(ctx(), "PAGE-26", "", "references", "SPEC-7"))
+
+		remaining := collectRelations(t, s, store.RelationQuery{From: "PAGE-26"})
+		require.Len(t, remaining, 1)
+		assert.Equal(t, ptr(t, "draft"), remaining[0].FromPointer)
+	})
+
+	t.Run("DeleteRelationStateNotFound", func(t *testing.T) {
+		s := f(t)
+		mustCreate(t, s, newState(t, "PAGE-27", "page", "", "default"))
+		mustCreate(t, s, newState(t, "SPEC-8", "page", "", "target"))
+		_, err := s.CreateRelation(ctx(), "PAGE-27", "references", "SPEC-8", nil)
+		require.NoError(t, err)
+
+		// A tail with no edge is absent, NOT "close enough" to the default
+		// edge that does exist.
+		err = s.DeleteRelationState(ctx(), "PAGE-27", ptr(t, "draft"), "references", "SPEC-8")
+		assert.ErrorIs(t, err, store.ErrNotFound)
+		assert.Len(t, collectRelations(t, s, store.RelationQuery{From: "PAGE-27"}), 1,
+			"the miss must not have deleted the default-tail edge")
+	})
+
 	t.Run("RenameCascadesTheFamily", func(t *testing.T) {
 		s := f(t)
 		mustCreate(t, s, newState(t, "PAGE-12", "page", "", "default"))


### PR DESCRIPTION
PR-D of TKT-C1XUA8 (Step 4). **Code-only**; paperwork on the companion PR.

Tickets-PR: #1422

Stack: #1423 ← #1427 ← #1428 ← #1429 ← #1430 ← #1431 (PR-C) ← **this**.

## The bug this fixes, reproduced

`relations: replace` into a non-default face **silently deletes a different face's edge and leaves its own**. Reproduced empirically rather than read:

```
setup:  PAGE-1 (default) and PAGE-1@published, each with references -> SPEC-1
action: applyCopyEdges' replace path for the PUBLISHED face
result: delete returned NIL ERROR
        the DEFAULT face's edge was deleted   <- wrong face, silent
        the published-tail edge SURVIVED      <- the one it meant to replace
```

Cause: `copy_apply.go` called `DeleteRelation(from, type, to)` without the tail, and all three backends hard-wire that to the default tail (pgstore `AND from_pointer = ''`, memstore `defaultTailKey`, fsstore's bare key). `promote-page` with `relations: replace` — the design doc's headline use case — was actively destructive. **Never reached develop**; PR-C is still open.

## What lands

**Two new store primitives**, across `store.go` + all three backends + `storetest` conformance:

- `DeleteEntityState(ctx, id, pointer)` — delete ONE face.
- `DeleteRelationState(ctx, from, pointer, relType, to)` — delete an edge **at a tail**.

`DeleteRelation` is now implemented AS `DeleteRelationState(…, "", …)` in every backend, so the general and default forms **cannot drift** — which is how they diverged in the first place. Its godoc now says it is an ADDRESS, not a wildcard.

## The entity/face distinction, applied consistently

A face delete takes what belongs to the FACE and leaves what belongs to the ENTITY:

| | Face delete | Why |
|---|---|---|
| Outgoing edges on this tail | **removed** | they belong to the face |
| **Inbound** edges | **survive** | heads are entity-level (§2.3) — removing a draft must not cut links other entities hold on the published face |
| **Attachments** | **survive** | keyed to the bare id; deleting a draft must not destroy files the published face serves |
| `notifyDelete` observer event | **not fired** (unless last face) | observers are bare-id keyed — firing would tell the search index the whole entity is gone while other faces still exist: silent de-indexing |

Only the last-face-standing case removes the entity and fires the event.

## 8 conformance cases, sited deliberately

Placed directly beneath `DeleteCascadesTheFamily`, with a comment noting the pair is deliberate: **the two contracts are opposites, and a backend implementing one as the other passes neither.** Includes `DeleteRelationStateAddressesTheTailNotTheTriple`, named for the bug above.

## Review findings (2 critical, both fixed)

- **Discarded/replaced edges had no audit trail.** Now audited as `OpDeleteRelation` with `triggered_by: copy:<name>`, and the copy's summary names the count.
- **fsstore broke its own fail-secure ordering** — the in-memory index was mutated before a fallible filesystem op, so an error returned with the index already gutted and nothing reconciling until restart. Every fallible op now completes before any map is touched. Note `just ci` cannot catch this: it needs a real filesystem fault.

Also: `applyCopyEdges` was mutating while ranging its own `ListRelations` iterator — on pgstore that holds a `pgx.Rows` cursor on one pooled connection while the delete takes a second, a deadlock candidate under pool pressure. Now collects first, then deletes. Pre-existing in PR-C, on a line this PR touches.

## Deliberately NOT done, with reasoning

**Discarded edges are audited but NOT versioned.** The review prescribed pushing them through `recordRelationVersion`; that was declined after verification. `recordIDForKey` resolves a lineage by `(from, type, to)` with **no tail predicate**, so a state-tailed edge would be filed under a *sibling face's* lineage — corrupting a history that was never touched. A missing delete marker is a recoverable gap; a wrong one is silent corruption. Pinned with a test asserting the deliberate non-capture, and commented so nobody "fixes" it into the corruption. The real fix — the sync record carrying a tail or `rel_record_id` — is a change to the relation-versioning seam and is ticketed, not ridden in here.

Gates: `just ci` green, arch-lint clean, all three backends green, pgstore green on **real PostgreSQL** with `-race` and `RELA_TEST_DATABASE_REQUIRED=1`.