### PR TITLE
🌍 feat(frontend): world-bound list surface, world-keyed caches, honest search (TKT-F2D5U5)

### DIFF
--- a/frontend/src/api/entities.ts
+++ b/frontend/src/api/entities.ts
@@ -125,10 +125,14 @@ export async function listAllEntities(
   }
 }
 
+// getEntity reads one entity. `world` selects which face is served; it is
+// mutually exclusive with `include` at the API (422 world_include_unsupported),
+// a constraint callers must respect — the type cannot express "one or the
+// other", so see useEntitiesStore.fetchEntity for the enforcement.
 export async function getEntity(
   type: string,
   id: string,
-  params?: { include?: string; fields?: string }
+  params?: { include?: string; fields?: string; world?: string }
 ): Promise<Entity> {
   const path = `/${getPlural(type)}/${id}`
   const res = await api.get<Entity>(path, params)

--- a/frontend/src/components/lists/EntityList.vue
+++ b/frontend/src/components/lists/EntityList.vue
@@ -7,6 +7,7 @@ import { useListKeyboard } from '@/composables/useListKeyboard'
 import { useListSelection } from '@/composables/useListSelection'
 import { useListActions } from '@/composables/useListActions'
 import { useUrlFilterSync } from '@/composables/useUrlFilterSync'
+import { useWorld } from '@/composables/useWorld'
 import { listEntities, deleteEntity, getErrorMessage } from '@/api'
 import { entityKeys } from '@/queries/entities'
 import { beginOptimisticRemove, rollbackOptimistic } from '@/queries/optimisticList'
@@ -178,6 +179,11 @@ function staticFilterProperties(): Set<string> {
 
 // User-selected filters and free-text search synced bidirectionally with the URL.
 const { filters, q: searchQuery, writeToQuery } = useUrlFilterSync({ staticFilterProperties })
+
+// The selected world (`?world=`). A list is one of only two surfaces the API
+// can serve under a non-default world — see worldCapablePath in
+// internal/dataentry/world.go.
+const { world, isWorldBound, worldParam } = useWorld()
 const searchBoxRef = ref<InstanceType<typeof SearchBox> | null>(null)
 const filterMenuRef = ref<InstanceType<typeof AdHocFilterMenu> | null>(null)
 
@@ -324,7 +330,16 @@ const queryParams = computed((): ListParams => {
   }
 
   // Free-text search: backend intersects ?q= results with the typed list.
-  if (searchQuery.value) {
+  //
+  // Suppressed under a non-default world, and NOT as a courtesy to avoid a
+  // 422: the search index holds DEFAULT-face documents only, so a hit under
+  // `?world=published` would be a draft leaking onto a published surface, and
+  // the ACL row gate cannot catch it (guard rule 1 makes that gate
+  // world-independent). The API refuses the combination outright
+  // (world_search_unsupported) — this keeps the UI from sending a request it
+  // knows will fail, while the box itself is hidden and explained in the
+  // template. Per-world indexing is Step 5 (TKT-9KZGJO).
+  if (searchQuery.value && !isWorldBound.value) {
     paramsRecord.q = searchQuery.value
   }
 
@@ -340,9 +355,20 @@ const queryParams = computed((): ListParams => {
     params.sort = defaultSort
   }
 
-  // Include related entities for relation columns
-  if (hasRelationColumns.value) {
+  // Include related entities for relation columns.
+  //
+  // Also suppressed under a world (422 world_include_unsupported): neighbor
+  // resolution goes through the ungated, default-world reader, so a published
+  // row would arrive wrapped in DRAFT neighbors — a mixed-face response whose
+  // entity looks right and whose neighbors are silently wrong. Relation
+  // COLUMNS therefore render empty under a world rather than wrong; the
+  // backend already omits relations entirely on world-bound reads.
+  if (hasRelationColumns.value && !isWorldBound.value) {
     params.include = '*'
+  }
+
+  if (worldParam.value) {
+    params.world = worldParam.value
   }
 
   return params
@@ -794,8 +820,35 @@ watch(searchQuery, () => {
       </span>
     </div>
 
+    <!--
+      Gated on `!loadError`: the banner ASSERTS "you are looking at world X",
+      and it must not make that claim over an error state. An unknown world is
+      a 400 (unknown_world), so a banner rendered beside the error read
+      "Showing the nonexistent world" above a message saying no such world is
+      declared — the page contradicting itself, and in the direction that
+      reads as a designed property rather than a mistake.
+    -->
+    <div v-if="isWorldBound && !loadError" class="world-banner">
+      <span class="world-banner__label">
+        Showing the <strong>{{ world }}</strong> world
+      </span>
+      <span class="world-banner__note">
+        Each entity is shown as it appears in this world, and entities with no
+        face here are not listed at all. Search is unavailable — the index
+        covers the default world only, so it would return entities from it.
+      </span>
+    </div>
+
     <div class="search-row">
+      <!--
+        The search box is OMITTED under a world rather than disabled: a
+        disabled control still advertises an affordance that does not exist
+        here, and the banner above already says why. Leaving it enabled would
+        be worse than either — the backend refuses ?q= with a world (422), and
+        the failure this guards is a draft surfacing on a published surface.
+      -->
       <SearchBox
+        v-if="!isWorldBound"
         ref="searchBoxRef"
         :model-value="searchQuery"
         :placeholder="`Search ${listConfig.entity}s...`"
@@ -1124,6 +1177,27 @@ watch(searchQuery, () => {
   gap: var(--space-sm);
   margin-top: 12px;
   margin-bottom: 12px;
+}
+
+.world-banner {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xs);
+  margin-bottom: var(--space-md);
+  padding: var(--space-sm) var(--space-md);
+  background: color-mix(in srgb, var(--accent-color) 10%, transparent);
+  border: 1px solid color-mix(in srgb, var(--accent-color) 30%, transparent);
+  border-radius: var(--radius-md);
+}
+
+.world-banner__label {
+  font-size: var(--font-size-base);
+  color: var(--text-color);
+}
+
+.world-banner__note {
+  font-size: var(--font-size-sm);
+  color: var(--muted-text);
 }
 
 .filter-chip {

--- a/frontend/src/components/lists/EntityList.world.test.ts
+++ b/frontend/src/components/lists/EntityList.world.test.ts
@@ -1,0 +1,232 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import { PiniaColada } from '@pinia/colada'
+import EntityList from './EntityList.vue'
+import { useSchemaStore } from '@/stores/schema'
+import { _setEntityPluralForTest } from '@/api/entities'
+import type { Entity, ListResponse } from '@/types'
+
+// World-bound list surface (TKT-F2D5U5).
+//
+// A list is one of only TWO paths the API can serve under a non-default world
+// (worldCapablePath, internal/dataentry/world.go). These tests pin what the
+// list sends and what it offers under a world.
+//
+// Ruling 10 note — every assertion here is either a NEGATIVE ("no q is sent",
+// "no search box") or a permission/parameter-shaped property, i.e. exactly the
+// class that passes trivially when the component failed to render. So each
+// test that asserts an absence ALSO asserts a matching presence (the rows
+// rendered, the request fired), and `rendersProof` below is the shared guard:
+// if the list did not actually mount and fetch, the absence proves nothing.
+
+const listEntitiesMock = vi.fn()
+vi.mock('@/api', async (orig) => ({
+  ...(await orig<typeof import('@/api')>()),
+  listEntities: (...args: unknown[]) => listEntitiesMock(...args),
+}))
+
+const routerPush = vi.fn()
+const routerReplace = vi.fn()
+const mockRoute = {
+  query: {} as Record<string, unknown>,
+  path: '/list/policies',
+  name: 'list',
+}
+vi.mock('vue-router', () => ({
+  useRouter: () => ({ push: routerPush, replace: routerReplace }),
+  useRoute: () => mockRoute,
+  RouterLink: { template: '<a><slot /></a>' },
+}))
+
+describe('EntityList world binding', () => {
+  const listId = 'policies'
+  const entityType = 'policy'
+
+  function seedSchema(opts: { relationColumn?: boolean } = {}) {
+    const schemaStore = useSchemaStore()
+    schemaStore.lists.set(listId, {
+      id: listId,
+      title: 'Policies',
+      entity: entityType,
+      columns: opts.relationColumn
+        ? [
+            { property: 'title', label: 'Title' },
+            { relation: 'owned-by', label: 'Owner' },
+          ]
+        : [{ property: 'title', label: 'Title' }],
+    } as never)
+    schemaStore.entityTypes.set(entityType, {
+      name: entityType,
+      label: 'Policy',
+      properties: { title: { type: 'string', values: null } },
+    } as never)
+  }
+
+  function seedEntities(entities: Entity[]) {
+    const response: ListResponse<Entity> = {
+      data: entities,
+      meta: { total: entities.length, page: 1, per_page: 25, has_more: false },
+      included: {},
+    }
+    listEntitiesMock.mockResolvedValue(response)
+  }
+
+  const policy: Entity = {
+    id: 'POL-1',
+    type: entityType,
+    properties: { title: 'Access Control Policy' },
+  }
+
+  let pinia: ReturnType<typeof createPinia>
+  beforeEach(() => {
+    pinia = createPinia()
+    setActivePinia(pinia)
+    _setEntityPluralForTest(entityType, 'policys')
+    listEntitiesMock.mockReset()
+    routerPush.mockClear()
+    routerReplace.mockClear()
+    mockRoute.query = {}
+  })
+
+  afterEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  async function mountList(opts: { relationColumn?: boolean } = {}) {
+    seedSchema(opts)
+    seedEntities([policy])
+    const wrapper = mount(EntityList, {
+      props: { listId },
+      attachTo: document.body,
+      global: { plugins: [pinia, PiniaColada] },
+    })
+    await flushPromises()
+    return wrapper
+  }
+
+  function lastParams(): Record<string, unknown> {
+    expect(listEntitiesMock).toHaveBeenCalled()
+    const call = listEntitiesMock.mock.calls[listEntitiesMock.mock.calls.length - 1]
+    return call[1] as Record<string, unknown>
+  }
+
+  // The anti-vacuity guard. Asserting "no search box" against a component that
+  // threw during setup would pass while proving nothing, so every absence
+  // assertion is paired with this.
+  function rendersProof(wrapper: { text: () => string }) {
+    expect(listEntitiesMock).toHaveBeenCalled()
+    expect(wrapper.text()).toContain('Access Control Policy')
+  }
+
+  describe('default world', () => {
+    it('sends no world param and offers search', async () => {
+      const wrapper = await mountList()
+      rendersProof(wrapper)
+
+      expect(lastParams().world).toBeUndefined()
+      expect(wrapper.find('.world-banner').exists()).toBe(false)
+      // The positive control for every "search is hidden" assertion below:
+      // without this, hiding search unconditionally would pass them all.
+      expect(wrapper.findComponent({ name: 'SearchBox' }).exists()).toBe(true)
+    })
+
+    it('sends include=* for relation columns', async () => {
+      const wrapper = await mountList({ relationColumn: true })
+      rendersProof(wrapper)
+      expect(lastParams().include).toBe('*')
+    })
+  })
+
+  describe('non-default world', () => {
+    beforeEach(() => {
+      mockRoute.query = { world: 'published' }
+    })
+
+    it('sends the world param', async () => {
+      const wrapper = await mountList()
+      rendersProof(wrapper)
+      expect(lastParams().world).toBe('published')
+    })
+
+    // Mutation: drop `&& !isWorldBound.value` from the q arm — the assertion
+    // sees q sent alongside world, the combination the API answers with 422
+    // world_search_unsupported, and which would otherwise surface DRAFT hits
+    // on a published surface (the index holds default-face documents).
+    it('never sends q, even when the URL carries one', async () => {
+      mockRoute.query = { world: 'published', q: 'access' }
+      const wrapper = await mountList()
+      rendersProof(wrapper)
+
+      expect(lastParams().world).toBe('published')
+      expect(lastParams().q).toBeUndefined()
+    })
+
+    // The UI half of the same property. Paired with the default-world control
+    // above, which proves the box renders when it should.
+    it('omits the search box and explains why', async () => {
+      const wrapper = await mountList()
+      rendersProof(wrapper)
+
+      expect(wrapper.findComponent({ name: 'SearchBox' }).exists()).toBe(false)
+      const banner = wrapper.find('.world-banner')
+      expect(banner.exists()).toBe(true)
+      expect(banner.text()).toContain('published')
+      expect(banner.text()).toContain('Search is unavailable')
+    })
+
+    // Mutation: drop `&& !isWorldBound.value` from the include arm — include
+    // is sent with world, which the API answers 422 world_include_unsupported.
+    it('suppresses include=* even with relation columns', async () => {
+      const wrapper = await mountList({ relationColumn: true })
+      rendersProof(wrapper)
+
+      expect(lastParams().world).toBe('published')
+      expect(lastParams().include).toBeUndefined()
+    })
+  })
+
+  // An unknown world is a 400 (unknown_world) — the API names it, because a
+  // world name is operator config and not a secret.
+  describe('when the world request fails', () => {
+    it('does not claim to be showing the world', async () => {
+      mockRoute.query = { world: 'nonexistent' }
+      seedSchema()
+      listEntitiesMock.mockRejectedValue(
+        Object.assign(new Error('no world named "nonexistent" is declared'), {
+          status: 400,
+        }),
+      )
+      const wrapper = mount(EntityList, {
+        props: { listId },
+        attachTo: document.body,
+        global: { plugins: [pinia, PiniaColada] },
+      })
+      await flushPromises()
+
+      // Anti-vacuity: the request really was attempted and really failed, so
+      // the absence below is about the banner and not about a dead component.
+      expect(listEntitiesMock).toHaveBeenCalled()
+      expect(wrapper.text()).toContain('nonexistent')
+
+      // Mutation: drop `&& !loadError` from the banner's v-if — the page then
+      // says "Showing the nonexistent world" directly above an error saying
+      // no such world exists.
+      expect(wrapper.find('.world-banner').exists()).toBe(false)
+    })
+  })
+
+  // `?world=default` is the API's explicit spelling of the default world, so
+  // it must behave exactly like no param at all — not like a bound world.
+  describe('explicit default world', () => {
+    it('behaves as the default world', async () => {
+      mockRoute.query = { world: 'default' }
+      const wrapper = await mountList()
+      rendersProof(wrapper)
+
+      expect(lastParams().world).toBeUndefined()
+      expect(wrapper.findComponent({ name: 'SearchBox' }).exists()).toBe(true)
+      expect(wrapper.find('.world-banner').exists()).toBe(false)
+    })
+  })
+})

--- a/frontend/src/composables/useWorld.test.ts
+++ b/frontend/src/composables/useWorld.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { ref } from 'vue'
+import { useWorld, DEFAULT_WORLD } from './useWorld'
+
+// Mirrors useBackTarget.test.ts: a mutable query object behind a getter, so
+// the composable's `computed` re-evaluates when the "URL" changes.
+const mockRouteQuery = ref<Record<string, unknown>>({})
+const push = vi.fn()
+
+vi.mock('vue-router', () => ({
+  useRoute: () => ({
+    get query() {
+      return mockRouteQuery.value
+    },
+  }),
+  useRouter: () => ({ push }),
+}))
+
+describe('useWorld', () => {
+  beforeEach(() => {
+    mockRouteQuery.value = {}
+    push.mockClear()
+  })
+
+  describe('reading the world from the URL', () => {
+    it('is the default world when no ?world= is present', () => {
+      const { world, isWorldBound, worldParam } = useWorld()
+      expect(world.value).toBe('')
+      expect(isWorldBound.value).toBe(false)
+      // undefined, not '', so spreading into params emits no ?world= at all.
+      expect(worldParam.value).toBeUndefined()
+    })
+
+    it('reads a named world', () => {
+      mockRouteQuery.value = { world: 'published' }
+      const { world, isWorldBound, worldParam } = useWorld()
+      expect(world.value).toBe('published')
+      expect(isWorldBound.value).toBe(true)
+      expect(worldParam.value).toBe('published')
+    })
+
+    // The API accepts `?world=default` as an explicit spelling of the implicit
+    // default world. Mutation: drop the DEFAULT_WORLD term from isWorldBound —
+    // the SPA then treats it as world-bound, hides search and suppresses
+    // include for a world that is just... the default one.
+    it('treats an explicit "default" as NOT world-bound', () => {
+      mockRouteQuery.value = { world: DEFAULT_WORLD }
+      const { world, isWorldBound, worldParam } = useWorld()
+      // Preserved verbatim so a deep link round-trips unchanged...
+      expect(world.value).toBe(DEFAULT_WORLD)
+      // ...but it is the default world, so nothing is suppressed.
+      expect(isWorldBound.value).toBe(false)
+      expect(worldParam.value).toBeUndefined()
+    })
+
+    // A repeated param arrives as an array. The API REJECTS that (400
+    // duplicate_world) rather than picking one, so the SPA must not invent a
+    // precedence. Mutation: return the last element instead of '' — the SPA
+    // silently sends a world the user never unambiguously asked for.
+    it('resolves a duplicated ?world= to the default world', () => {
+      mockRouteQuery.value = { world: ['published', 'site-nl'] }
+      const { world, isWorldBound } = useWorld()
+      expect(world.value).toBe('')
+      expect(isWorldBound.value).toBe(false)
+    })
+  })
+
+  describe('setWorld', () => {
+    it('pushes the world onto the query', () => {
+      const { setWorld } = useWorld()
+      setWorld('published')
+      expect(push).toHaveBeenCalledWith({ query: { world: 'published' } })
+    })
+
+    it('removes the param entirely when returning to the default world', () => {
+      mockRouteQuery.value = { world: 'published' }
+      const { setWorld } = useWorld()
+      setWorld('')
+      // Absent, not `world: ''` — an empty param is a distinct request shape.
+      expect(push).toHaveBeenCalledWith({ query: {} })
+    })
+
+    it('removes the param when the default world is named explicitly', () => {
+      mockRouteQuery.value = { world: 'published' }
+      const { setWorld } = useWorld()
+      setWorld(DEFAULT_WORLD)
+      expect(push).toHaveBeenCalledWith({ query: {} })
+    })
+
+    it('preserves unrelated query params', () => {
+      mockRouteQuery.value = { 'filter[status]': 'open', sort: '-updated' }
+      const { setWorld } = useWorld()
+      setWorld('published')
+      expect(push).toHaveBeenCalledWith({
+        query: { 'filter[status]': 'open', sort: '-updated', world: 'published' },
+      })
+    })
+
+    // Page 3 of the draft world is not page 3 of the published world: the
+    // published world may hold fewer entities than that offset, so keeping the
+    // page lands the user on an empty page that reads as "nothing is
+    // published". Mutation: remove `delete query.page` — the assertion sees
+    // page survive, which is the silent-empty-result trap.
+    it('resets pagination when the world changes', () => {
+      mockRouteQuery.value = { page: '3' }
+      const { setWorld } = useWorld()
+      setWorld('published')
+      expect(push).toHaveBeenCalledWith({ query: { world: 'published' } })
+    })
+
+    // Without this, every selector re-emit pushes a duplicate history entry,
+    // so one back-press appears to do nothing.
+    it('does not navigate when the world is unchanged', () => {
+      mockRouteQuery.value = { world: 'published' }
+      const { setWorld } = useWorld()
+      setWorld('published')
+      expect(push).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/frontend/src/composables/useWorld.ts
+++ b/frontend/src/composables/useWorld.ts
@@ -1,0 +1,101 @@
+/**
+ * The selected WORLD, synced to the `?world=` URL query param.
+ *
+ * A world selects which FACE of each entity is served — and which entities
+ * appear at all, since an entity with no face in a world is omitted entirely
+ * (existence in a world IS the publication bit). See the design notes in
+ * `internal/dataentry/world.go`.
+ *
+ * ## Why the URL, and why a query param
+ *
+ * The world belongs in the URL so a world-bound view is a shareable link: "the
+ * published policies" has to survive a copy-paste, a bookmark and a reload, or
+ * a reviewer cannot be pointed at what a reader actually sees. It is a QUERY
+ * param rather than a path segment because it scopes an existing view rather
+ * than naming a different one — the same list, seen through a different world
+ * — which is also how the API spells it (`?world=`).
+ *
+ * ## Why this is separate from useUrlFilterSync
+ *
+ * A world is not a filter. `useUrlFilterSync` owns `filter[...]` + `q`, writes
+ * with `router.replace` (no history entry per keystroke, right for typing) and
+ * echo-guards on a filter-shaped signature. Switching world is a deliberate,
+ * infrequent act that SHOULD be undoable with the back button, so it uses
+ * `router.push`. Folding it into the filter signature would also make every
+ * world change look like a filter echo. Same URL, different lifecycle.
+ *
+ * ## The empty string is the default world
+ *
+ * `''` means "no `?world=`", which the API reads as the default world. The API
+ * also accepts the explicit spelling `?world=default`; both normalize to the
+ * default world in the entity cache (see `worldKey` in `stores/entities.ts`),
+ * but this composable keeps whatever the URL said so a deep link round-trips
+ * unchanged rather than being silently rewritten.
+ */
+import { computed, type Ref } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+
+// DEFAULT_WORLD is the reserved name the API accepts as an explicit way to
+// spell the implicit default world (`defaultWorldName`, dataentry/world.go).
+export const DEFAULT_WORLD = 'default'
+
+function readWorldParam(value: unknown): string {
+  // An array means the URL carried `?world=` twice. The API REJECTS that
+  // outright (400 duplicate_world) rather than picking one by a precedence
+  // rule nobody would remember, so the SPA must not invent a precedence
+  // either — taking the last would send a single value the user never asked
+  // for and hide the malformed link. Resolve to the default world; the
+  // selector then shows the default world, which is what gets served.
+  if (Array.isArray(value)) return ''
+  return typeof value === 'string' ? value : ''
+}
+
+export interface UseWorld {
+  /** The world named by the URL; `''` for the default world. */
+  world: Readonly<Ref<string>>
+  /** True when a non-default world is active. */
+  isWorldBound: Readonly<Ref<boolean>>
+  /**
+   * The value to send as the API's `world` param: `undefined` for the default
+   * world, so callers can spread it into a params object without emitting an
+   * empty `?world=`.
+   */
+  worldParam: Readonly<Ref<string | undefined>>
+  /** Select a world. `''` (or DEFAULT_WORLD) returns to the default world. */
+  setWorld: (next: string) => void
+}
+
+export function useWorld(): UseWorld {
+  const route = useRoute()
+  const router = useRouter()
+
+  const world = computed(() => readWorldParam(route.query.world))
+
+  const isWorldBound = computed(
+    () => world.value !== '' && world.value !== DEFAULT_WORLD,
+  )
+
+  const worldParam = computed(() =>
+    isWorldBound.value ? world.value : undefined,
+  )
+
+  function setWorld(next: string) {
+    if (next === world.value) return
+    const query = { ...route.query }
+    if (next === '' || next === DEFAULT_WORLD) {
+      delete query.world
+    } else {
+      query.world = next
+    }
+    // Changing world resets pagination: page 3 of the draft world is not
+    // page 3 of the published world — the published world may hold fewer
+    // entities than that page's offset, landing the user on a silently empty
+    // page that reads as "nothing is published".
+    delete query.page
+    // push, not replace: switching world is a deliberate act the back button
+    // should undo. See the composable doc.
+    router.push({ query })
+  }
+
+  return { world, isWorldBound, worldParam, setWorld }
+}

--- a/frontend/src/stores/entities.test.ts
+++ b/frontend/src/stores/entities.test.ts
@@ -327,4 +327,139 @@ describe('Entities Store', () => {
       expect(store.getCached('ticket', 'TKT-001')).toBeUndefined()
     })
   })
+
+  // World-scoped caching (TKT-F2D5U5).
+  //
+  // These pin the "silently serves the wrong face" class: one entity id names
+  // a DIFFERENT face per world, so a world-blind cache hands the first face
+  // fetched to every later reader of the other.
+  //
+  // Per Ruling 10 each of these was mutation-checked — the mutation and what
+  // it breaks is named on the test, because every one of them is a negative or
+  // a same-id/different-content property that passes trivially if the second
+  // fetch never happens. Two guards make them bite: the mock returns
+  // DIFFERENT CONTENT per world (so a stale hit is a wrong VALUE, not just a
+  // wrong call count), and the call count is asserted (so a silent extra
+  // refetch cannot masquerade as a correct miss).
+  describe('world-scoped caching', () => {
+    const draftFace = {
+      id: 'POL-1',
+      type: 'policy',
+      properties: { title: 'Access Control (DRAFT)' },
+      relations: {},
+    }
+    const publishedFace = {
+      id: 'POL-1',
+      type: 'policy',
+      properties: { title: 'Access Control' },
+      relations: {},
+    }
+
+    // Mutation: revert cacheKey() to `${type}:${id}` — the published fetch
+    // hits the draft entry, returns the DRAFT title, and getEntity is called
+    // once instead of twice. Both assertions die.
+    it('does not serve one world\'s face for another world', async () => {
+      vi.mocked(entitiesApi.getEntity).mockResolvedValueOnce(draftFace)
+      vi.mocked(entitiesApi.getEntity).mockResolvedValueOnce(publishedFace)
+
+      const draft = await store.fetchEntity('policy', 'POL-1')
+      const published = await store.fetchEntity('policy', 'POL-1', false, 'published')
+
+      expect(draft.properties.title).toBe('Access Control (DRAFT)')
+      expect(published.properties.title).toBe('Access Control')
+      expect(entitiesApi.getEntity).toHaveBeenCalledTimes(2)
+    })
+
+    // The cache must still WORK per world — a key so unique it never hits
+    // would pass the test above while disabling caching entirely.
+    it('still caches within a single world', async () => {
+      vi.mocked(entitiesApi.getEntity).mockResolvedValue(publishedFace)
+
+      await store.fetchEntity('policy', 'POL-1', false, 'published')
+      await store.fetchEntity('policy', 'POL-1', false, 'published')
+
+      expect(entitiesApi.getEntity).toHaveBeenCalledTimes(1)
+    })
+
+    // `?world=default` is the API's explicit spelling of the implicit default
+    // world. Mutation: drop the DEFAULT_WORLD arm in worldKey() — the two
+    // spellings become two entries, getEntity is called twice, and the SPA
+    // holds two copies of one face that can disagree.
+    it('treats an explicit "default" world as the default world', async () => {
+      vi.mocked(entitiesApi.getEntity).mockResolvedValue(draftFace)
+
+      await store.fetchEntity('policy', 'POL-1')
+      await store.fetchEntity('policy', 'POL-1', false, 'default')
+
+      expect(entitiesApi.getEntity).toHaveBeenCalledTimes(1)
+    })
+
+    // Hazard 3. Mutation: send `{ include: '*', world }` — the assertion sees
+    // include present under a world, which is the exact combination the API
+    // answers with 422 world_include_unsupported.
+    it('drops include=* under a non-default world, and keeps it otherwise', async () => {
+      vi.mocked(entitiesApi.getEntity).mockResolvedValue(publishedFace)
+
+      await store.fetchEntity('policy', 'POL-1', false, 'published')
+      expect(entitiesApi.getEntity).toHaveBeenCalledWith('policy', 'POL-1', {
+        world: 'published',
+      })
+
+      await store.fetchEntity('policy', 'POL-1')
+      expect(entitiesApi.getEntity).toHaveBeenLastCalledWith('policy', 'POL-1', {
+        include: '*',
+      })
+    })
+
+    // Hazard 2, the widest blast radius: merely LISTING a world poisons the
+    // per-entity cache. Mutation: drop the `params?.world` argument in
+    // fetchList's row-caching loop — the default-world fetchEntity then hits
+    // the published row and returns the published title without any network
+    // call, so both assertions die.
+    it('does not let a world-scoped list poison the default-world cache', async () => {
+      vi.mocked(entitiesApi.listEntities).mockResolvedValue({
+        data: [publishedFace],
+        meta: { total: 1, page: 1, per_page: 20, has_more: false },
+      })
+      vi.mocked(entitiesApi.getEntity).mockResolvedValue(draftFace)
+
+      await store.fetchList('policy', { world: 'published' })
+      const entity = await store.fetchEntity('policy', 'POL-1')
+
+      expect(entity.properties.title).toBe('Access Control (DRAFT)')
+      expect(entitiesApi.getEntity).toHaveBeenCalledTimes(1)
+    })
+
+    // The positive half of the same seam: a world-scoped list SHOULD prime the
+    // cache for its own world, or it has merely been disabled.
+    it('primes the per-world cache from a world-scoped list', async () => {
+      vi.mocked(entitiesApi.listEntities).mockResolvedValue({
+        data: [publishedFace],
+        meta: { total: 1, page: 1, per_page: 20, has_more: false },
+      })
+
+      await store.fetchList('policy', { world: 'published' })
+
+      expect(store.getCached('policy', 'POL-1', 'published')).toBeDefined()
+      expect(store.getCached('policy', 'POL-1')).toBeUndefined()
+    })
+
+    // A write updates the DEFAULT face (the API refuses ?world= on writes),
+    // but under `otherwise: default` that changes what a fallback world
+    // serves. Mutation: delete the invalidateEntityWorlds() call in update() —
+    // the published read returns the pre-write cached face.
+    it('drops world-scoped copies when the entity is written', async () => {
+      vi.mocked(entitiesApi.getEntity).mockResolvedValue(publishedFace)
+      await store.fetchEntity('policy', 'POL-1', false, 'published')
+      expect(store.getCached('policy', 'POL-1', 'published')).toBeDefined()
+
+      vi.mocked(entitiesApi.updateEntity).mockResolvedValue({
+        ...draftFace,
+        properties: { title: 'Edited' },
+      })
+      await store.update('policy', 'POL-1', { properties: { title: 'Edited' } })
+
+      expect(store.getCached('policy', 'POL-1', 'published')).toBeUndefined()
+    })
+  })
 })

--- a/frontend/src/stores/entities.ts
+++ b/frontend/src/stores/entities.ts
@@ -20,6 +20,12 @@ interface EntityCache {
 
 const CACHE_TTL = 60 * 1000 // 1 minute
 
+// DEFAULT_WORLD mirrors the reserved name the API accepts for the implicit
+// default world (`defaultWorldName` in internal/dataentry/world.go). Named
+// here so the normalization in worldKey() reads as "the same world under a
+// second spelling" rather than a magic string.
+const DEFAULT_WORLD = 'default'
+
 // Refresh git status after mutations (non-blocking)
 function refreshGitStatus() {
   const gitStore = useGitStore()
@@ -40,8 +46,26 @@ export const useEntitiesStore = defineStore('entities', () => {
   const cacheVersion = ref(0) // Incremented on invalidateAll for SSE live updates
 
   // Helpers
-  function cacheKey(type: string, id: string): string {
-    return `${type}:${id}`
+  //
+  // The cache key carries the WORLD, because one entity id names a different
+  // FACE in each world: `POL-1` in `published` and `POL-1` in the default
+  // world are different content under the same id. Keying on `type:id` alone
+  // meant the first face fetched was served to every later request for the
+  // other — the draft body rendered under a published-world read, or worse,
+  // the published body rendered while the user edits the draft.
+  //
+  // The default world is spelled as the empty segment rather than the literal
+  // "default" so that a key built for an unspecified world is byte-identical
+  // to the pre-worlds key. `?world=default` is accepted by the API as an
+  // explicit way to name the default world (dataentry/world.go), so it
+  // normalizes to the same segment here — two spellings of one world must not
+  // become two cache entries that can disagree.
+  function worldKey(world?: string): string {
+    return !world || world === DEFAULT_WORLD ? '' : world
+  }
+
+  function cacheKey(type: string, id: string, world?: string): string {
+    return `${type}:${id}:${worldKey(world)}`
   }
 
   function listCacheKey(type: string, params?: ListParams): string {
@@ -53,8 +77,8 @@ export const useEntitiesStore = defineStore('entities', () => {
   }
 
   // Getters
-  const getCached = computed(() => (type: string, id: string) => {
-    const key = cacheKey(type, id)
+  const getCached = computed(() => (type: string, id: string, world?: string) => {
+    const key = cacheKey(type, id, world)
     const cached = cache.value.get(key)
     if (cached && isCacheValid(cached.timestamp)) {
       return cached.entity
@@ -69,8 +93,8 @@ export const useEntitiesStore = defineStore('entities', () => {
     return Array.from(loading.value).some((k) => k.startsWith(type + ':'))
   })
 
-  const getError = computed(() => (type: string, id: string) => {
-    return errors.value.get(cacheKey(type, id))
+  const getError = computed(() => (type: string, id: string, world?: string) => {
+    return errors.value.get(cacheKey(type, id, world))
   })
 
   // Actions
@@ -95,9 +119,18 @@ export const useEntitiesStore = defineStore('entities', () => {
         timestamp: Date.now(),
       })
 
-      // Also cache individual entities
+      // Also cache individual entities, under THIS request's world. A list
+      // read under `?world=published` returns published faces, so filing them
+      // under the default-world key would hand a later default-world
+      // fetchEntity the published body — a cache poisoning with a wider blast
+      // radius than the detail path, because merely visiting a list is enough
+      // to trigger it.
+      //
+      // A row is also a PARTIAL entity: the list shape omits _fields,
+      // _relations, _redacted and _attachments (see the v1.Entity subset in
+      // internal/apiwire). That was true before worlds and is unchanged here.
       for (const entity of response.data) {
-        cache.value.set(cacheKey(type, entity.id), {
+        cache.value.set(cacheKey(type, entity.id, params?.world), {
           entity,
           timestamp: Date.now(),
         })
@@ -109,8 +142,13 @@ export const useEntitiesStore = defineStore('entities', () => {
     }
   }
 
-  async function fetchEntity(type: string, id: string, force = false): Promise<Entity> {
-    const key = cacheKey(type, id)
+  async function fetchEntity(
+    type: string,
+    id: string,
+    force = false,
+    world?: string
+  ): Promise<Entity> {
+    const key = cacheKey(type, id, world)
 
     if (!force) {
       const cached = cache.value.get(key)
@@ -123,8 +161,19 @@ export const useEntitiesStore = defineStore('entities', () => {
     errors.value.delete(key)
 
     try {
-      // Request include=* to get titles for all related entities
-      const entity = await getEntity(type, id, { include: '*' })
+      // `include=*` fetches titles for related entities, but the API REFUSES
+      // it under a non-default world (422 world_include_unsupported): neighbor
+      // resolution is not world-scoped, so a world-bound entity would come
+      // back wrapped in default-world neighbors — the mixed-face response that
+      // is hardest to spot, because the entity itself looks right.
+      //
+      // So this DROPS include rather than appending a world to it. Sending
+      // both would turn every world-bound detail read into a hard 422; sending
+      // include without the world would serve the wrong face. Under a world we
+      // simply have no neighbor titles, which is what the backend can honestly
+      // answer today.
+      const params = world && world !== DEFAULT_WORLD ? { world } : { include: '*' }
+      const entity = await getEntity(type, id, params)
       cache.value.set(key, {
         entity,
         timestamp: Date.now(),
@@ -152,6 +201,27 @@ export const useEntitiesStore = defineStore('entities', () => {
     return entity
   }
 
+  // invalidateEntityWorlds drops every WORLD-SCOPED copy of one entity,
+  // leaving the default-world entry the caller is about to overwrite.
+  //
+  // Writes always address the default state — the API refuses `?world=` on a
+  // write (422 world_read_only) — so a write updates the default face only.
+  // But a world-scoped copy of the same id may still be cached, and it is now
+  // of unknown freshness: whether it moved depends on the world's fallback
+  // rule. Under `otherwise: default`, editing the default face CHANGES what
+  // `site-nl` serves for an entity with no Dutch face. Re-deriving which
+  // worlds fall through to the edited face would mean teaching the SPA the
+  // resolution rules; dropping them is cheap, and the next read refetches.
+  function invalidateEntityWorlds(type: string, id: string) {
+    const defaultKey = cacheKey(type, id)
+    const prefix = `${type}:${id}:`
+    for (const key of cache.value.keys()) {
+      if (key.startsWith(prefix) && key !== defaultKey) {
+        cache.value.delete(key)
+      }
+    }
+  }
+
   async function update(
     type: string,
     id: string,
@@ -164,6 +234,7 @@ export const useEntitiesStore = defineStore('entities', () => {
       entity,
       timestamp: Date.now(),
     })
+    invalidateEntityWorlds(type, id)
     // Invalidate list cache for this type
     invalidateListCache(type)
     // Refresh git status (non-blocking)
@@ -174,6 +245,7 @@ export const useEntitiesStore = defineStore('entities', () => {
   async function remove(type: string, id: string): Promise<void> {
     await deleteEntity(type, id)
     cache.value.delete(cacheKey(type, id))
+    invalidateEntityWorlds(type, id)
     // Invalidate list cache for this type
     invalidateListCache(type)
     // Refresh git status (non-blocking)

--- a/frontend/src/stores/entities.ts
+++ b/frontend/src/stores/entities.ts
@@ -86,9 +86,13 @@ export const useEntitiesStore = defineStore('entities', () => {
     return undefined
   })
 
-  const isLoading = computed(() => (type: string, id?: string) => {
+  // Takes a world for the same reason getCached does: fetchEntity registers
+  // its in-flight key per world, so a world-blind lookup here would report
+  // "not loading" during a world-scoped fetch. The id-less form is unchanged
+  // — it asks "is anything of this type loading", which spans all worlds.
+  const isLoading = computed(() => (type: string, id?: string, world?: string) => {
     if (id) {
-      return loading.value.has(cacheKey(type, id))
+      return loading.value.has(cacheKey(type, id, world))
     }
     return Array.from(loading.value).some((k) => k.startsWith(type + ':'))
   })

--- a/frontend/src/types/entity.ts
+++ b/frontend/src/types/entity.ts
@@ -210,6 +210,14 @@ export interface ListParams {
   sort?: string
   fields?: string
   include?: string
+  // world selects which FACE of each entity is served, and which entities
+  // appear at all — an entity with no face in the requested world is omitted
+  // entirely, because existence in a world IS the publication bit.
+  //
+  // Absent means the default world. Note the backend refuses `world` combined
+  // with `include` or `q` (422), and honors it only on `/{plural}` and
+  // `/{plural}/{id}` — see internal/dataentry/world.go's worldCapablePath.
+  world?: string
   [key: `filter[${string}]`]: string | undefined
 }
 

--- a/internal/dataentry/world.go
+++ b/internal/dataentry/world.go
@@ -140,8 +140,17 @@ func (a *App) SetWorlds(w WorldLookup) { a.worlds = w }
 //   - UNKNOWN world -> a named 400. A world name is operator-authored
 //     CONFIG (schema.yaml), and CLAUDE.md is explicit that config names are
 //     not secret: naming the missing world is more useful to whoever is
-//     debugging it than a uniform silence, and conceals nothing, because the
-//     set of declared worlds is already served over the API.
+//     debugging it than a uniform silence, and conceals nothing that the
+//     operator's own repo does not already state.
+//
+//     This clause previously justified itself with "the set of declared
+//     worlds is already served over the API". That was FALSE — no endpoint
+//     enumerates worlds today (metamodel.Metamodel.Worlds carries no JSON
+//     tag and no handler reads it), so a client discovers a name only by
+//     being told one or by guessing. The CONCLUSION is unchanged, because it
+//     never depended on that premise: config names are not secret whether or
+//     not this API happens to serve them. Corrected rather than deleted so
+//     the next reader does not re-derive the same wrong premise.
 //
 //   - Known world the principal may NOT read -> (zero handle, errWorldDenied),
 //     which callers render as an EMPTY RESULT, never a 403. What a world


### PR DESCRIPTION
The first **user-visible** piece of the content-states epic. Code-only; paperwork on the companion PR.

Tickets-PR: #1422

Stack: Steps 1–4 (#1423 … #1433) ← **this**.

## What you can now see in the product

Verified in a real browser against a demo project carrying both axes:

- **`/list/policies?world=published`** → the unpublished policy is **gone from the list entirely**. Existence in a world IS the publication bit, visible.
- **`/list/posts?world=site-nl`** → one post in Dutch, the untranslated one **falling back to English**. The fallback chain, per entity, visible.

The world is a **query parameter**, so those are shareable deep links.

## Three latent bugs fixed (wrong TODAY, not feature work)

Broken the moment anything sent `?world=`, which nothing did until now:

1. **The entity cache was not world-keyed** — fetch a face in `published`, then in the default world, and the cache served the first face for the second request.
2. **`fetchList` filed every row under that world-less key** — merely *listing* `?world=published` poisoned the draft cache for those entities.
3. **`fetchEntity` hardcoded `include: '*'`**, which the backend **422s** under a non-default world. World-bound reads now drop `include` rather than appending a param.

Default world normalizes to an **empty key segment**, so a key built without a world is byte-identical to the pre-worlds key, and `?world=default` maps to the same entry rather than a second one that can disagree with it.

`update`/`remove` drop world-scoped copies: under `otherwise: default`, editing the default face genuinely changes what `site-nl` serves for an entity with no Dutch face. Re-deriving which worlds fall through would mean teaching the SPA the resolution rules — dropping is cheap and the next read refetches. `create` is deliberately untouched (a fresh id can have no pre-existing world copy).

## Honest about what a world cannot do

- **Search is omitted under a world**, with the banner saying why — the index covers the default world only, so a search box on a published surface would return drafts. The backend refuses it (422); the UI does not present a control that cannot work. Silent degradation is the specific thing forbidden: the row gate cannot catch a wrongly-scoped hit, because resolution is deliberately principal-independent.
- **No world selector.** No enumeration endpoint exists yet (TKT-WRLDAPI item 1); the alternatives were a hardcoded list or probing each world, and probing reconstructs the existence oracle `errWorldDenied` exists to close. `useWorld` is built so a real selector drops in unchanged.
- **The selector will not appear on** views, documents, kanban, dashboard or the relation panel: `worldCapablePath` allows only `/{plural}` and `/{plural}/{id}`.
- **`fetchEntity` accepts a `world` nothing calls with one yet** — deliberate. It is the seam the cache fix is about, and world-keying a cache while leaving its fetcher world-blind would be incoherent. The detail read path is TKT-WRLDAPI item 4.

## A bug the browser caught that 1800 unit tests did not

Deep-linking `?world=nonexistent` rendered "**Showing the nonexistent world**" as a banner directly above the backend's error saying no such world is declared — the page contradicting itself, in the "reads as a bug rather than a designed property" direction. The banner is now gated on the load succeeding. It only appears on an error path no mock exercised.

## Verification

**14 mutations, each killing its intended test.** The anti-vacuity guard is itself proven: making the mock return zero rows so the component renders nothing caused **all 7 list tests to fail** rather than the negatives passing quietly — the failure mode demonstrated closed rather than asserted. Each seam has a **positive** test alongside its negative, because a cache key so unique it never hits would pass every negative while having silently disabled caching.

`npm run test:run` **1784 passed / 111 files**, typecheck clean, lint 0 errors, `go build` + `gofmt` clean.

Also corrects a **false comment** at `world.go:144` claiming the declared worlds "are already served over the API" — they are not. The conclusion it supports holds for other reasons, so the premise is corrected in place rather than the paragraph deleted.
