### PR TITLE
🌍 Worlds on the wire: schema discovery, type pointers, face provenance (TKT-WRLDAPI 1-3)

### DIFF
--- a/docs-project/entities/guides/GUIDE-metamodel.md
+++ b/docs-project/entities/guides/GUIDE-metamodel.md
@@ -1020,27 +1020,82 @@ Lowercase alphanumeric runs joined by single hyphens: `draft`,
 no doubled hyphens, and `+` is reserved. Invalid names are reported at
 startup.
 
+### Selecting a world over the API
+
+The data-entry API takes `?world=<name>` on the entity list
+(`/api/v1/{plural}`) and the single-entity read
+(`/api/v1/{plural}/{id}`). Omitting it means the default world.
+
+Selection is permission-checked before anything is read: a world is
+readable only if the principal holds a `world:<name>` read grant. That
+check is why the parameter exists at all — letting any caller name a world
+would make "which faces may I see?" a client decision.
+
+**Discovering the legal values.** `GET /api/v1/_schema` lists them:
+
+```json
+{
+  "worlds": {
+    "default":   { "readable": true, "default": true },
+    "published": { "select": ["published"], "otherwise": "exclude",
+                   "readable": true },
+    "site-nl":   { "select": ["nl", "en"], "otherwise": "default",
+                   "readable": false }
+  }
+}
+```
+
+Every declared world is listed for every caller — world names are config
+in your `schema.yaml`, not secrets. `readable` says whether *this* caller
+may select it. A world you may not read is not hidden from the list; it is
+marked unreadable, and selecting it anyway returns an empty result rather
+than an error, so it cannot be used to probe what the world contains.
+
+The same endpoint reports each type's declared coordinates under
+`entities.<type>.pointers`. Like the world list, this is schema: it says
+`policy` declares `draft` and `published`, never which faces any
+particular policy has.
+
+**Knowing which face you got.** A single-entity read carries the
+provenance of the face it served:
+
+```json
+"_world": { "name": "site-nl", "pointer": "", "via": "fallback-default" }
+```
+
+`via` is the interesting part. `chain` means the world got the face it
+asked for. `fallback-default` means it did not, and `otherwise: default`
+substituted the default state — the difference between "this is the Dutch
+page" and "this is the English page, because there is no Dutch one". The
+bytes alone do not tell you, which is why the field exists. `unscoped`
+means no resolution applied: a pointerless type, or the default world.
+
 ### What worlds do NOT do yet
 
-Two limits are deliberate, and you will meet both if you try to use a
-world today.
-
-**There is no way to ask for a world per request.** No `?world=` query
-parameter, no `--world` flag. A surface is *built* over its world and
-cannot be asked to serve a different one. Request-level selection needs
-its own permission check — letting any caller name a world would make
-"which faces may I see?" a client decision — so it ships together with
-that check rather than before it.
+Three limits are deliberate, and you will meet them if you use a world
+today.
 
 **A world-bound surface cannot have search.** Search results are not
 world-scoped yet: the index holds default-state documents, so a search
 box on a `published` surface would return drafts. Rather than serve
-wrong results quietly, constructing a world-bound surface *with* a
-searcher fails outright. Access control cannot paper over this — the
-permission gate is deliberately world-independent, so nothing downstream
-would catch a draft that leaked in through search.
+wrong results quietly, a `?q=` combined with a non-default `?world=` is
+refused, and constructing a world-bound surface *with* a searcher fails
+outright. Access control cannot paper over this — the permission gate is
+deliberately world-independent, so nothing downstream would catch a draft
+that leaked in through search.
 
-Both lift when per-world indexing and request-level selection land.
+**Only the two entity routes honour a world.** Every other endpoint —
+views, documents, feeds, analyze, history, and an entity's sub-resources
+— refuses a non-default `?world=` rather than quietly serving default-world
+data under it. Each joins as its read path is scoped and tested.
+
+**`?include=` is refused under a world**, for the same reason: neighbour
+resolution is not world-scoped yet, so including them would return a
+published entity wrapped in draft neighbours.
+
+There is also no `--world` flag on the CLI.
+
+These lift as per-world indexing and per-route scoping land.
 
 ### Checking stored states
 

--- a/docs/metamodel.md
+++ b/docs/metamodel.md
@@ -1014,27 +1014,82 @@ Lowercase alphanumeric runs joined by single hyphens: `draft`,
 no doubled hyphens, and `+` is reserved. Invalid names are reported at
 startup.
 
+### Selecting a world over the API
+
+The data-entry API takes `?world=<name>` on the entity list
+(`/api/v1/{plural}`) and the single-entity read
+(`/api/v1/{plural}/{id}`). Omitting it means the default world.
+
+Selection is permission-checked before anything is read: a world is
+readable only if the principal holds a `world:<name>` read grant. That
+check is why the parameter exists at all — letting any caller name a world
+would make "which faces may I see?" a client decision.
+
+**Discovering the legal values.** `GET /api/v1/_schema` lists them:
+
+```json
+{
+  "worlds": {
+    "default":   { "readable": true, "default": true },
+    "published": { "select": ["published"], "otherwise": "exclude",
+                   "readable": true },
+    "site-nl":   { "select": ["nl", "en"], "otherwise": "default",
+                   "readable": false }
+  }
+}
+```
+
+Every declared world is listed for every caller — world names are config
+in your `schema.yaml`, not secrets. `readable` says whether *this* caller
+may select it. A world you may not read is not hidden from the list; it is
+marked unreadable, and selecting it anyway returns an empty result rather
+than an error, so it cannot be used to probe what the world contains.
+
+The same endpoint reports each type's declared coordinates under
+`entities.<type>.pointers`. Like the world list, this is schema: it says
+`policy` declares `draft` and `published`, never which faces any
+particular policy has.
+
+**Knowing which face you got.** A single-entity read carries the
+provenance of the face it served:
+
+```json
+"_world": { "name": "site-nl", "pointer": "", "via": "fallback-default" }
+```
+
+`via` is the interesting part. `chain` means the world got the face it
+asked for. `fallback-default` means it did not, and `otherwise: default`
+substituted the default state — the difference between "this is the Dutch
+page" and "this is the English page, because there is no Dutch one". The
+bytes alone do not tell you, which is why the field exists. `unscoped`
+means no resolution applied: a pointerless type, or the default world.
+
 ### What worlds do NOT do yet
 
-Two limits are deliberate, and you will meet both if you try to use a
-world today.
-
-**There is no way to ask for a world per request.** No `?world=` query
-parameter, no `--world` flag. A surface is *built* over its world and
-cannot be asked to serve a different one. Request-level selection needs
-its own permission check — letting any caller name a world would make
-"which faces may I see?" a client decision — so it ships together with
-that check rather than before it.
+Three limits are deliberate, and you will meet them if you use a world
+today.
 
 **A world-bound surface cannot have search.** Search results are not
 world-scoped yet: the index holds default-state documents, so a search
 box on a `published` surface would return drafts. Rather than serve
-wrong results quietly, constructing a world-bound surface *with* a
-searcher fails outright. Access control cannot paper over this — the
-permission gate is deliberately world-independent, so nothing downstream
-would catch a draft that leaked in through search.
+wrong results quietly, a `?q=` combined with a non-default `?world=` is
+refused, and constructing a world-bound surface *with* a searcher fails
+outright. Access control cannot paper over this — the permission gate is
+deliberately world-independent, so nothing downstream would catch a draft
+that leaked in through search.
 
-Both lift when per-world indexing and request-level selection land.
+**Only the two entity routes honour a world.** Every other endpoint —
+views, documents, feeds, analyze, history, and an entity's sub-resources
+— refuses a non-default `?world=` rather than quietly serving default-world
+data under it. Each joins as its read path is scoped and tested.
+
+**`?include=` is refused under a world**, for the same reason: neighbour
+resolution is not world-scoped yet, so including them would return a
+published entity wrapped in draft neighbours.
+
+There is also no `--world` flag on the CLI.
+
+These lift as per-world indexing and per-route scoping land.
 
 ### Checking stored states
 

--- a/internal/apiwire/v1/responses.go
+++ b/internal/apiwire/v1/responses.go
@@ -84,8 +84,21 @@ type Entity struct {
 	// per-type overrides and the fallback policy, which is a second
 	// implementation of the semantics that decide which face a reader sees.
 	//
-	// Same pointer / per-entity semantics as FieldAffordances: present on
-	// per-entity GET responses, nil on list rows.
+	// Present on the single-entity GET ONLY — deliberately NOT on every
+	// per-entity response the way FieldAffordances is. The distinction is
+	// worth stating because a client will otherwise look for it on a PATCH:
+	//
+	//   - Writes are refused a `?world=` outright (worlds are read-only on
+	//     this API), so a create / update / clone response is default-world
+	//     by construction and a provenance block would be noise.
+	//   - A history snapshot is rebuilt from a stored version and carries no
+	//     pointer, so labelling it would state a coordinate the code cannot
+	//     back — the "affordance map that lies" failure, one layer down.
+	//   - Views, attachments and restore are not world-capable routes.
+	//
+	// The single-entity GET is the only response whose pointer is the
+	// store's actual answer to a world query, which is why it is the only
+	// one that carries this.
 	World *EntityWorld `json:"_world,omitempty"`
 	// Transitions maps a state-machine-typed property name to the LIST of its
 	// outgoing transitions resolved for the requesting principal on this entity
@@ -263,6 +276,11 @@ type Schema struct {
 // exactly the existence oracle the read gate closes, and nothing here
 // narrows it: a type's declared coordinates ([EntityType.Pointers]) say what
 // the schema permits, never what any row holds.
+// Note the field set is deliberately incomplete: a world's `edits:` key
+// (which state edits made from it land in) is NOT surfaced. It is a
+// write-side concept, and the affordance a client actually needs — "which
+// faces can I create from here" — is a separate gated query over the
+// declared copy definitions (Ruling 9), not something derivable from a world.
 type World struct {
 	// Select is the ordered candidate chain: the first coordinate that
 	// EXISTS for an entity is the face served. Empty for the default world,
@@ -283,6 +301,12 @@ type World struct {
 	// A UI hint, never a boundary: the server re-checks the grant on every
 	// request (`resolveWorld`), so a client ignoring this learns nothing it
 	// could not learn by asking.
+	//
+	// NO omitempty, unlike Default below, and the asymmetry is deliberate:
+	// `false` is the load-bearing answer here — it is precisely what a
+	// selector needs — and an omitted key would be indistinguishable from a
+	// server too old to compute it. `default: false`, by contrast, is noise
+	// on every declared world.
 	Readable bool `json:"readable"`
 	// Default marks the implicit default world — today's graph, total by
 	// construction, always present and always selectable. Spelled as a flag

--- a/internal/apiwire/v1/responses.go
+++ b/internal/apiwire/v1/responses.go
@@ -92,7 +92,7 @@ type Entity struct {
 	//     this API), so a create / update / clone response is default-world
 	//     by construction and a provenance block would be noise.
 	//   - A history snapshot is rebuilt from a stored version and carries no
-	//     pointer, so labelling it would state a coordinate the code cannot
+	//     pointer, so labeling it would state a coordinate the code cannot
 	//     back — the "affordance map that lies" failure, one layer down.
 	//   - Views, attachments and restore are not world-capable routes.
 	//

--- a/internal/apiwire/v1/responses.go
+++ b/internal/apiwire/v1/responses.go
@@ -71,6 +71,22 @@ type Entity struct {
 	// non-per-entity shapes. The SPA's file widget reads this to render the
 	// download links / previews instead of the raw stored path string(s).
 	Attachments *map[string][]Attachment `json:"_attachments,omitempty"`
+	// World carries the PROVENANCE of the face in this response: which world
+	// resolved it, which coordinate it was stored at, and which resolution
+	// rule chose it (TKT-WRLDAPI item 2).
+	//
+	// It exists because the bytes alone do not say. Under a world with a
+	// fallback chain, "the Dutch face" and "the English face, because no
+	// Dutch face exists" arrive byte-identically — same id, same type, same
+	// shape — and a client rendering a publication badge, offering a
+	// translate affordance, or deciding whether an edit is safe has to tell
+	// them apart. Re-deriving it client-side would require the chain, the
+	// per-type overrides and the fallback policy, which is a second
+	// implementation of the semantics that decide which face a reader sees.
+	//
+	// Same pointer / per-entity semantics as FieldAffordances: present on
+	// per-entity GET responses, nil on list rows.
+	World *EntityWorld `json:"_world,omitempty"`
 	// Transitions maps a state-machine-typed property name to the LIST of its
 	// outgoing transitions resolved for the requesting principal on this entity
 	// (TKT-3G93B8): each carries the target value, an optional action label,
@@ -153,6 +169,48 @@ type InaccessibleField struct {
 	Reason string `json:"reason"`
 }
 
+// EntityWorld is the provenance of a resolved face — see [Entity.World] for
+// why a client needs it.
+//
+// It describes the RESOLUTION that produced this response, never the entity's
+// other faces. A client learns which coordinate it is looking at; it learns
+// nothing about which coordinates exist for this id. That distinction is the
+// existence oracle the read gate closes, and this shape stays on the safe
+// side of it deliberately.
+type EntityWorld struct {
+	// Name is the world this response was resolved in — `default` for the
+	// implicit total world. Matches a key of [Schema.Worlds].
+	Name string `json:"name"`
+	// Pointer is the coordinate the served state was stored at. EMPTY means
+	// the default state, which is not the same claim as "the default world":
+	// a fallback under `otherwise: default` also serves the default state.
+	// Via is what separates those, which is why Pointer alone is not enough.
+	Pointer string `json:"pointer"`
+	// Via names the resolution rule that chose this face:
+	//
+	//   - "unscoped"         — this world applies no per-type resolution, so
+	//                          the entity contributes its default state.
+	//                          Covers BOTH a type that declares no content
+	//                          states and the total default world, which
+	//                          resolves everything this way — the default
+	//                          world is exactly "no resolution applied", and
+	//                          worldreader.Rule reports it identically.
+	//   - "chain"            — a coordinate the world SELECTS exists; this is
+	//                          the face the world asked for.
+	//   - "fallback-default" — no selected coordinate exists, and the world's
+	//                          `otherwise: default` stood the default state
+	//                          in. The reader is seeing a substitute.
+	//
+	// The third value is the load-bearing one: it is the difference between
+	// "published" and "not published, showing you the draft".
+	//
+	// There is deliberately no "excluded" value. A world that excludes an
+	// entity produces no response to carry provenance on — it is a 404,
+	// indistinguishable from a genuine miss, because existence in a world IS
+	// the publication bit.
+	Via string `json:"via"`
+}
+
 // ListResponse is the response for listing entities.
 type ListResponse struct {
 	Data    []Entity        `json:"data"`
@@ -173,6 +231,64 @@ type Schema struct {
 	Entities  map[string]EntityType   `json:"entities"`
 	Relations map[string]RelationType `json:"relations"`
 	Types     map[string]CustomType   `json:"types,omitempty"`
+	// Worlds enumerates the declared worlds a client may pass to `?world=`,
+	// keyed by world name, plus the implicit `default` world (TKT-WRLDAPI).
+	//
+	// Present even for a project declaring no `worlds:` block, where it holds
+	// the single `default` entry: a client needs to distinguish "this server
+	// has no other worlds" from "this server is too old to tell me", and an
+	// omitted key cannot say the first.
+	Worlds map[string]World `json:"worlds,omitempty"`
+}
+
+// World is the JSON representation of one declared world — a named
+// resolution function picking at most one content state per entity (design
+// doc §4.1).
+//
+// # The declared set is NOT filtered per principal
+//
+// Every world the schema declares appears here for every caller. World names
+// are operator-authored config living in `schema.yaml`, routinely a public
+// repo, so their contents are already disclosed and CLAUDE.md is explicit
+// that code must not contort to conceal a config name. What IS per-principal
+// is [World.Readable] — which says whether this caller may SELECT the world,
+// never whether it exists.
+//
+// The distinction is load-bearing: what a world CONTAINS is secret (a denied
+// world serves an empty result, never a 403, precisely so it cannot be told
+// apart from a world holding nothing), while the fact that the operator
+// declared a world named `published` is not.
+//
+// This carries no per-ENTITY information. Which faces a given entity has is
+// exactly the existence oracle the read gate closes, and nothing here
+// narrows it: a type's declared coordinates ([EntityType.Pointers]) say what
+// the schema permits, never what any row holds.
+type World struct {
+	// Select is the ordered candidate chain: the first coordinate that
+	// EXISTS for an entity is the face served. Empty for the default world,
+	// which resolves every entity to its default state by construction.
+	Select []string `json:"select,omitempty"`
+	// Overrides replaces Select for the named entity types, keyed by type.
+	Overrides map[string][]string `json:"overrides,omitempty"`
+	// Otherwise is the rule-3 policy for a type that declares pointers but
+	// none this world selects: `exclude` (contributes nothing) or `default`
+	// (falls back to the type's default state). Empty for the default world,
+	// which never reaches rule 3.
+	Otherwise string `json:"otherwise,omitempty"`
+	// Readable reports whether THIS caller may select the world via
+	// `?world=`. False means a request naming it is served an empty result
+	// rather than a 403 — so a client that respects this flag shows the user
+	// an honest selector instead of a world that silently returns nothing.
+	//
+	// A UI hint, never a boundary: the server re-checks the grant on every
+	// request (`resolveWorld`), so a client ignoring this learns nothing it
+	// could not learn by asking.
+	Readable bool `json:"readable"`
+	// Default marks the implicit default world — today's graph, total by
+	// construction, always present and always selectable. Spelled as a flag
+	// rather than left for the client to infer from the reserved name, so a
+	// selector can label it without hardcoding the string.
+	Default bool `json:"default,omitempty"`
 }
 
 // EntityType is the JSON representation of an entity type.
@@ -185,6 +301,34 @@ type EntityType struct {
 	IDPrefix    string                 `json:"id_prefix,omitempty"`
 	IDPrefixes  []string               `json:"id_prefixes,omitempty"`
 	Properties  map[string]PropertyDef `json:"properties"`
+	// Pointers declares this type's content-state coordinates, keyed by
+	// coordinate name ("draft", "published", "en", "nl"). ABSENT for the
+	// common case of a type with no content states, which contributes its
+	// single default state to every world.
+	//
+	// This is SCHEMA, not data: it says which coordinates the operator
+	// declared for the type, never which faces any particular entity holds.
+	// Two entities of the same type report identical pointers whether one has
+	// a published face and the other does not.
+	//
+	// DO NOT add the per-entity variant here — "which faces does THIS id
+	// have" is the existence oracle the row gate exists to close, since
+	// existence in a world IS the publication bit. An "other faces" indicator
+	// is a real product need (Ruling 9 item 8), but it has to omit faces the
+	// viewer may not read, which makes it a gated per-entity query rather
+	// than a field on the type's schema.
+	Pointers map[string]Pointer `json:"pointers,omitempty"`
+}
+
+// Pointer is the JSON representation of one declared content state.
+//
+// Deliberately near-empty, mirroring metamodel.PointerDef: a state is
+// identified by its coordinate and nothing else. Per-state knobs (labels,
+// retention) are not added speculatively.
+type Pointer struct {
+	// Default marks the coordinate stored under the ZERO pointer — the
+	// state a bare id addresses. At most one per type.
+	Default bool `json:"default,omitempty"`
 }
 
 // PropertyDef is the JSON representation of a property definition.

--- a/internal/dataentry/api_v1.go
+++ b/internal/dataentry/api_v1.go
@@ -31,7 +31,44 @@ import (
 
 // --- API v1 Types ---
 
-func (a *App) toV1PropertyDef(meta *metamodel.Metamodel, propDef metamodel.PropertyDef) v1.PropertyDef {
+// toV1EntityType renders one entity type for the wire.
+//
+// Shared by BOTH schema surfaces — the `entities` map of `/api/v1/_schema`
+// and the single-type `/api/v1/_schema/types/{name}` — which previously each
+// built the shape inline. Two copies of a serializer is two places to add a
+// field and one place to forget it: the `pointers` key (TKT-WRLDAPI item 3)
+// would have been exactly such a field, since a client that discovers a
+// type's content states from one endpoint and not the other has no way to
+// tell which answer is authoritative. Extracted so they cannot drift.
+//
+// A free function, like its sibling toV1CustomType: it is a pure transform
+// over its arguments and touches no App state. toV1PropertyDef was converted
+// alongside it for the same reason — it never used its receiver either, and
+// App sits at its plimsoll method cap precisely because methods accrete there
+// by habit rather than by need.
+func toV1EntityType(
+	meta *metamodel.Metamodel, name string, def metamodel.EntityDef,
+) v1.EntityType {
+	et := v1.EntityType{
+		Label:       def.Label,
+		Plural:      def.GetPlural(name),
+		Description: def.Description,
+		Primary:     def.GetPrimaryProperty(),
+		IDType:      def.GetIDType(),
+		Properties:  make(map[string]v1.PropertyDef, len(def.Properties)),
+		Pointers:    schemaPointers(def),
+	}
+	if prefixes := def.GetIDPrefixes(); len(prefixes) > 0 {
+		et.IDPrefix = prefixes[0]
+		et.IDPrefixes = prefixes
+	}
+	for propName, propDef := range def.Properties {
+		et.Properties[propName] = toV1PropertyDef(meta, propDef)
+	}
+	return et
+}
+
+func toV1PropertyDef(meta *metamodel.Metamodel, propDef metamodel.PropertyDef) v1.PropertyDef {
 	pd := v1.PropertyDef{
 		Type:        propDef.Type,
 		Required:    propDef.Required,
@@ -797,6 +834,17 @@ func (a *App) handleV1GetEntity(w http.ResponseWriter, r *http.Request, typeName
 	}
 	result := a.serializer.forWire(ctx, entity, outgoing, a.Meta(), plural)
 
+	// Face provenance (TKT-WRLDAPI item 2). Attached HERE rather than inside
+	// forWire, even though forWire is the shared per-entity serializer,
+	// because this is the only path whose Pointer is the STORE's answer to a
+	// world query. Its other callers would produce a label the code cannot
+	// back: the history handler serializes a snapshot built by
+	// entityPkg.New(), whose Pointer is always zero, so a historical version
+	// of a PUBLISHED face would report the default coordinate. An affordance
+	// map that lies is a trap for every future consumer (Ruling 11); so is a
+	// provenance block.
+	result.World = worldProvenance(ctx, entity)
+
 	// Handle includes for related entities
 	if includes := query.Get("include"); includes != "" {
 		result.Included = a.resolveV1Includes(ctx, entity, includes)
@@ -1200,26 +1248,11 @@ func (a *App) handleV1Schema(w http.ResponseWriter, r *http.Request) {
 		Entities:  make(map[string]v1.EntityType),
 		Relations: make(map[string]v1.RelationType),
 		Types:     make(map[string]v1.CustomType),
+		Worlds:    schemaWorlds(r.Context(), s.Meta),
 	}
 
 	for name, def := range s.Meta.Entities {
-		et := v1.EntityType{
-			Label:       def.Label,
-			Plural:      def.GetPlural(name),
-			Description: def.Description,
-			Primary:     def.GetPrimaryProperty(),
-			IDType:      def.GetIDType(),
-			Properties:  make(map[string]v1.PropertyDef),
-		}
-		prefixes := def.GetIDPrefixes()
-		if len(prefixes) > 0 {
-			et.IDPrefix = prefixes[0]
-			et.IDPrefixes = prefixes
-		}
-		for propName, propDef := range def.Properties {
-			et.Properties[propName] = a.toV1PropertyDef(s.Meta, propDef)
-		}
-		schema.Entities[name] = et
+		schema.Entities[name] = toV1EntityType(s.Meta, name, def)
 	}
 
 	for name, def := range s.Meta.Relations {
@@ -1240,7 +1273,7 @@ func (a *App) handleV1Schema(w http.ResponseWriter, r *http.Request) {
 		if len(def.Properties) > 0 {
 			rt.Properties = make(map[string]v1.PropertyDef, len(def.Properties))
 			for propName, propDef := range def.Properties {
-				rt.Properties[propName] = a.toV1PropertyDef(s.Meta, propDef)
+				rt.Properties[propName] = toV1PropertyDef(s.Meta, propDef)
 			}
 		}
 		if def.OutgoingOrderProperty() != "" || def.IncomingOrderProperty() != "" {
@@ -1281,22 +1314,7 @@ func (a *App) handleV1SchemaRoutes(w http.ResponseWriter, r *http.Request) {
 			writeV1Error(w, r, http.StatusNotFound, "not_found", "Entity type not found", "")
 			return
 		}
-		et := v1.EntityType{
-			Label:       def.Label,
-			Plural:      def.GetPlural(typeName),
-			Description: def.Description,
-			Primary:     def.GetPrimaryProperty(),
-			IDType:      def.GetIDType(),
-			Properties:  make(map[string]v1.PropertyDef),
-		}
-		if prefixes := def.GetIDPrefixes(); len(prefixes) > 0 {
-			et.IDPrefix = prefixes[0]
-			et.IDPrefixes = prefixes
-		}
-		for propName, propDef := range def.Properties {
-			et.Properties[propName] = a.toV1PropertyDef(s.Meta, propDef)
-		}
-		writeV1JSON(w, http.StatusOK, et)
+		writeV1JSON(w, http.StatusOK, toV1EntityType(s.Meta, typeName, def))
 
 	case path == "relations":
 		writeV1JSON(w, http.StatusOK, s.Meta.Relations)

--- a/internal/dataentry/schemaworlds.go
+++ b/internal/dataentry/schemaworlds.go
@@ -75,7 +75,7 @@ func schemaWorlds(ctx context.Context, meta *metamodel.Metamodel) map[string]v1.
 	// selector lying in the other direction.
 	//
 	// The two are ONE decision and must not drift. When the request path
-	// starts honouring a default-world denial, this must switch to asking
+	// starts honoring a default-world denial, this must switch to asking
 	// the gate in the same change — and the test named for this
 	// (TestSchemaWorlds_DefaultWorldAgreesWithTheRequestPath) is what will
 	// fail to remind you.

--- a/internal/dataentry/schemaworlds.go
+++ b/internal/dataentry/schemaworlds.go
@@ -1,0 +1,133 @@
+package dataentry
+
+import (
+	"context"
+	"log/slog"
+
+	v1 "github.com/Sourcehaven-BV/rela/internal/apiwire/v1"
+	"github.com/Sourcehaven-BV/rela/internal/metamodel"
+)
+
+// schemaWorlds builds the `worlds` block of `/api/v1/_schema` (TKT-WRLDAPI
+// item 1): every DECLARED world, plus the implicit `default` world, each
+// marked with whether THIS caller may select it.
+//
+// # Why enumerate at all
+//
+// `?world=` selection has existed since TKT-DN37J2 with no way to discover a
+// legal value: a client had to be told a name out of band or guess one, and a
+// guess is answered by a 400. A world selector cannot be built against that.
+// This is the enumeration `PermitsWorld` already answers per name.
+//
+// # The declared set is principal-independent; only `readable` is not
+//
+// Every declared world appears for every caller. World names are
+// operator-authored `schema.yaml` config — routinely a public repo — so their
+// existence is already disclosed, and CLAUDE.md is explicit that code must
+// not filter a config surface per principal or contort to conceal a config
+// name. Filtering here would also be the wrong shape for the UI: a selector
+// that silently omits a world leaves the user unable to tell "no such world"
+// from "not for you", which is worse than saying so.
+//
+// What stays secret is unchanged: a world's CONTENTS. Selecting a world this
+// caller cannot read still yields an empty result rather than a 403
+// (`errWorldDenied`), precisely so it is indistinguishable from a world
+// holding nothing readable. `readable` is a UI hint about SELECTION, and the
+// server re-checks the grant on every request regardless — a client ignoring
+// this flag learns nothing it could not learn by asking.
+//
+// # This is not a face-enumeration path
+//
+// Nothing here is per-entity. A world's chain says which coordinates it would
+// PREFER; it never says which faces any row actually holds. Two entities of
+// the same type produce identical output whether one has a published face and
+// the other does not — the existence oracle stays closed.
+//
+// A gate error is logged and rendered as not-readable: an outage must not
+// widen a selector into offering a world whose grant could not be confirmed.
+func schemaWorlds(ctx context.Context, meta *metamodel.Metamodel) map[string]v1.World {
+	gate := readGateFromContext(ctx)
+
+	// The default world is always present and always selectable. Emitted
+	// explicitly rather than left implicit so a client need not hardcode the
+	// reserved name to offer it.
+	//
+	// Readable is a CONSTANT true here, and deliberately not a gate call.
+	// `resolveWorld` short-circuits `default` (and an absent parameter)
+	// BEFORE any grant check, because the default world is today's graph and
+	// gating it would gate the whole product. Asking the gate anyway would
+	// make this enumeration contradict the server: acl.Request.PermitsWorld
+	// has no default-world arm, so it answers false for `default` unless a
+	// role happens to grant the `world:default` token — and the selector
+	// would then report today's graph as unreadable while every request for
+	// it succeeds.
+	//
+	// So this is not "trusting the default"; it is reporting the same
+	// short-circuit the request path takes. If the request path ever starts
+	// gating the default world, this must start asking too — the two are one
+	// decision and must not drift.
+	out := map[string]v1.World{
+		defaultWorldName: {Readable: true, Default: true},
+	}
+
+	for name, def := range meta.Worlds {
+		readable, err := gate.PermitsWorld(ctx, name)
+		if err != nil {
+			// Fail closed on an infrastructure failure. Reporting readable on
+			// an unanswerable grant check is the fail-open direction: the
+			// selector would offer a world whose requests then come back
+			// empty, which reads as "nothing is published" rather than as the
+			// outage it is. Logged loud so the operator sees the cause.
+			slog.Warn("dataentry: schemaWorlds: PermitsWorld failed; reporting world as not readable",
+				"world", name, "err", err)
+			readable = false
+		}
+		out[name] = v1.World{
+			// Copied, not aliased — see worldOverrides for why the shared
+			// metamodel's slices must not reach a response.
+			Select:    append([]string(nil), def.Select...),
+			Overrides: worldOverrides(def),
+			Otherwise: string(def.Otherwise),
+			Readable:  readable,
+		}
+	}
+	return out
+}
+
+// worldOverrides copies a world's per-type chain overrides for the wire.
+//
+// Copied rather than handed over: the metamodel is a pointer shared by every
+// assembled Services (appbuild.SharedBase), and a serializer that exposed its
+// backing maps would let one response's consumer re-scope every reader's
+// world. Nil for the common case of a world with no overrides, so the key is
+// omitted entirely.
+func worldOverrides(def metamodel.WorldDef) map[string][]string {
+	if len(def.Overrides) == 0 {
+		return nil
+	}
+	out := make(map[string][]string, len(def.Overrides))
+	for typeName, chain := range def.Overrides {
+		out[typeName] = append([]string(nil), chain...)
+	}
+	return out
+}
+
+// schemaPointers renders one entity type's declared content-state
+// coordinates for `/api/v1/_schema` (TKT-WRLDAPI item 3).
+//
+// Nil — hence an omitted key — for the common pointerless type, keeping a
+// project that declares no content states byte-identical on the wire.
+//
+// SCHEMA, not data: this reports what the operator declared for the TYPE.
+// Which faces a given ENTITY holds is a different question, and deliberately
+// not answerable here.
+func schemaPointers(def metamodel.EntityDef) map[string]v1.Pointer {
+	if len(def.Pointers) == 0 {
+		return nil
+	}
+	out := make(map[string]v1.Pointer, len(def.Pointers))
+	for name, p := range def.Pointers {
+		out[name] = v1.Pointer{Default: p.Default}
+	}
+	return out
+}

--- a/internal/dataentry/schemaworlds.go
+++ b/internal/dataentry/schemaworlds.go
@@ -52,20 +52,33 @@ func schemaWorlds(ctx context.Context, meta *metamodel.Metamodel) map[string]v1.
 	// explicitly rather than left implicit so a client need not hardcode the
 	// reserved name to offer it.
 	//
-	// Readable is a CONSTANT true here, and deliberately not a gate call.
-	// `resolveWorld` short-circuits `default` (and an absent parameter)
-	// BEFORE any grant check, because the default world is today's graph and
-	// gating it would gate the whole product. Asking the gate anyway would
-	// make this enumeration contradict the server: acl.Request.PermitsWorld
-	// has no default-world arm, so it answers false for `default` unless a
-	// role happens to grant the `world:default` token — and the selector
-	// would then report today's graph as unreadable while every request for
-	// it succeeds.
+	// Readable is a CONSTANT true here, and deliberately not a gate call:
+	// this endpoint reports what the REQUEST PATH does, and `resolveWorld`
+	// short-circuits `default` (and an absent parameter) before any grant
+	// check. Asking the gate here would make the selector disagree with the
+	// server about a request the server will in fact serve.
 	//
-	// So this is not "trusting the default"; it is reporting the same
-	// short-circuit the request path takes. If the request path ever starts
-	// gating the default world, this must start asking too — the two are one
-	// decision and must not drift.
+	// # A known gap this constant inherits, stated plainly
+	//
+	// The gate CAN express a default-world denial, contrary to what an
+	// earlier revision of this comment claimed. `acl.roleGrantsWorldRead`
+	// has an explicit default arm (any read grant covers the default world),
+	// and `compiledCeiling.permitsWorld` implements `deny_worlds: [default]`
+	// — its godoc calls itself MANDATORY precisely because that denial
+	// cannot be expressed any other way.
+	//
+	// `resolveWorld` never consults either, so `deny_worlds: [default]` is
+	// currently inert on this API. That is a PRE-EXISTING gap in the request
+	// path, not one introduced here, and this enumeration deliberately
+	// mirrors the gap rather than papering over it: reporting the default
+	// world unreadable while every request for it succeeds would be the
+	// selector lying in the other direction.
+	//
+	// The two are ONE decision and must not drift. When the request path
+	// starts honouring a default-world denial, this must switch to asking
+	// the gate in the same change — and the test named for this
+	// (TestSchemaWorlds_DefaultWorldAgreesWithTheRequestPath) is what will
+	// fail to remind you.
 	out := map[string]v1.World{
 		defaultWorldName: {Readable: true, Default: true},
 	}

--- a/internal/dataentry/schemaworlds_test.go
+++ b/internal/dataentry/schemaworlds_test.go
@@ -1,0 +1,624 @@
+package dataentry
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Sourcehaven-BV/rela/internal/acl"
+	v1 "github.com/Sourcehaven-BV/rela/internal/apiwire/v1"
+	"github.com/Sourcehaven-BV/rela/internal/entity"
+	"github.com/Sourcehaven-BV/rela/internal/metamodel"
+	"github.com/Sourcehaven-BV/rela/internal/search"
+	"github.com/Sourcehaven-BV/rela/internal/store"
+)
+
+// worldsMeta is a metamodel with both content-state axes the demo project
+// carries: a lifecycle (draft -> published, `otherwise: exclude`) and a
+// language family (en/nl/fr, `otherwise: default`). The two differ in the
+// answer they give to rule 3, which is the whole point of having both.
+func worldsMeta() *metamodel.Metamodel {
+	return &metamodel.Metamodel{
+		Entities: map[string]metamodel.EntityDef{
+			"policy": {
+				Label: "Policy",
+				Pointers: map[string]metamodel.PointerDef{
+					"draft":     {Default: true},
+					"published": {},
+				},
+			},
+			"blog-post": {
+				Label: "Blog post",
+				Pointers: map[string]metamodel.PointerDef{
+					"en": {Default: true},
+					"nl": {},
+					"fr": {},
+				},
+			},
+			// A pointerless type, present so the tests cover resolution
+			// rule 1 alongside the two pointered ones.
+			"ticket": {Label: "Ticket"},
+		},
+		Worlds: map[string]metamodel.WorldDef{
+			"published": {
+				Select:    []string{"published"},
+				Otherwise: metamodel.OtherwiseExclude,
+			},
+			"site-nl": {
+				Select:    []string{"nl", "en"},
+				Otherwise: metamodel.OtherwiseDefault,
+				Overrides: map[string][]string{"policy": {"published"}},
+			},
+		},
+	}
+}
+
+// TestSchemaWorlds_EnumeratesDeclaredPlusDefault pins TKT-WRLDAPI item 1: a
+// client can discover every legal `?world=` value, including the implicit
+// default world it would otherwise have to know by convention.
+func TestSchemaWorlds_EnumeratesDeclaredPlusDefault(t *testing.T) {
+	got := schemaWorlds(context.Background(), worldsMeta())
+
+	for _, name := range []string{"default", "published", "site-nl"} {
+		if _, ok := got[name]; !ok {
+			t.Errorf("world %q missing from the enumeration; a client cannot "+
+				"select a world it cannot discover", name)
+		}
+	}
+	if len(got) != 3 {
+		t.Errorf("got %d worlds, want exactly the 2 declared + the default one: %v",
+			len(got), got)
+	}
+
+	def := got["default"]
+	if !def.Default || !def.Readable {
+		t.Errorf("the default world is always present and always selectable; got %+v", def)
+	}
+	if len(def.Select) != 0 || def.Otherwise != "" {
+		t.Errorf("the default world resolves every entity to its default state by "+
+			"construction and never reaches rule 3, so it carries no chain or "+
+			"otherwise; got %+v", def)
+	}
+
+	pub := got["published"]
+	if len(pub.Select) != 1 || pub.Select[0] != "published" {
+		t.Errorf("published.select = %v, want [published]", pub.Select)
+	}
+	if pub.Otherwise != string(metamodel.OtherwiseExclude) {
+		t.Errorf("published.otherwise = %q, want %q — a public world excludes, and "+
+			"a client that renders this wrong tells the user an unpublished entity "+
+			"is merely missing", pub.Otherwise, metamodel.OtherwiseExclude)
+	}
+	if pub.Default {
+		t.Error("only the implicit default world carries default=true")
+	}
+
+	nl := got["site-nl"]
+	if len(nl.Select) != 2 || nl.Select[0] != "nl" || nl.Select[1] != "en" {
+		t.Errorf("site-nl.select = %v, want [nl en] — chain ORDER is the entire "+
+			"semantic content of a world, so a serializer that reorders it "+
+			"describes a different world", nl.Select)
+	}
+	if chain := nl.Overrides["policy"]; len(chain) != 1 || chain[0] != "published" {
+		t.Errorf("site-nl.overrides[policy] = %v, want [published]", chain)
+	}
+}
+
+// TestSchemaWorlds_DeclaredSetIsPrincipalIndependent pins the CLAUDE.md
+// config-is-not-secret rule at this surface: a principal who may not read a
+// world still SEES that it is declared, and learns only that they may not
+// select it.
+//
+// The failure this guards is a well-meant "filter what they can't use", which
+// would leave a UI unable to distinguish "no such world" from "not for you"
+// while concealing nothing — the world names live in the operator's
+// schema.yaml, routinely a public repo.
+//
+// Mutation-checked (Ruling 10): this is a NEGATIVE assertion about a security
+// posture, so it would pass trivially against code that never ran the branch.
+// Verified to die when schemaWorlds skips a world whose readable is false.
+func TestSchemaWorlds_DeclaredSetIsPrincipalIndependent(t *testing.T) {
+	// A gate that permits `published` and denies `site-nl`.
+	ctx := withReadGate(context.Background(), worldGate{
+		permit: map[string]bool{"published": true},
+	})
+	got := schemaWorlds(ctx, worldsMeta())
+
+	if _, ok := got["site-nl"]; !ok {
+		t.Fatal("a world the principal may not READ must still be ENUMERATED: " +
+			"its name is operator-authored config, not a secret")
+	}
+	if got["site-nl"].Readable {
+		t.Error("site-nl is denied by the gate, so readable must be false")
+	}
+	if !got["published"].Readable {
+		t.Error("published is permitted by the gate, so readable must be true")
+	}
+	// The chain of a denied world is still described: it says which
+	// coordinates the world would prefer, never which faces any row holds.
+	if len(got["site-nl"].Select) != 2 {
+		t.Error("a denied world still carries its declared chain — that is config, " +
+			"and describing it discloses nothing about the world's CONTENTS")
+	}
+}
+
+// TestSchemaWorlds_GateErrorFailsClosed pins the direction of the failure: an
+// unanswerable grant check reports NOT readable.
+//
+// Reporting readable would be fail-open in effect rather than in form — the
+// selector would offer a world whose every request then comes back empty,
+// which a user reads as "nothing is published" rather than as the outage it
+// is. That silent-in-the-direction-of-the-wrong-answer shape is the one this
+// arc keeps hitting.
+//
+// Mutation-checked (Ruling 10): verified to die when the error arm is flipped
+// to `readable = true`, and again when the arm drops the world entirely.
+func TestSchemaWorlds_GateErrorFailsClosed(t *testing.T) {
+	ctx := withReadGate(context.Background(), worldGate{fail: true})
+	got := schemaWorlds(ctx, worldsMeta())
+
+	if got["published"].Readable {
+		t.Error("PermitsWorld failed, so readability is UNKNOWN and must be " +
+			"reported as not-readable")
+	}
+	if _, ok := got["published"]; !ok {
+		t.Error("a gate failure must not drop the world from the enumeration — " +
+			"existence is config and does not depend on the gate")
+	}
+	if !got["default"].Readable {
+		t.Error("the default world short-circuits the grant check entirely, so a " +
+			"gate outage must not make today's graph unselectable")
+	}
+}
+
+// TestSchemaWorlds_DefaultWorldAgreesWithTheRequestPath pins that the
+// enumeration and the request path make the SAME decision about the default
+// world.
+//
+// This is the drift the constant `Readable: true` exists to prevent, and it is
+// counter-intuitive enough to be worth a test: acl.Request.PermitsWorld has no
+// default-world arm, so it answers FALSE for `default` unless a role happens to
+// grant the `world:default` token. Computing readability from the gate — the
+// obvious-looking "consistency" fix — would therefore report today's graph as
+// unreadable to nearly every principal, while `resolveWorld` short-circuits and
+// serves it. The selector would contradict the server.
+//
+// So: a gate that denies EVERY world, including `default`, must still leave the
+// default world readable, because the request path never asks it.
+func TestSchemaWorlds_DefaultWorldAgreesWithTheRequestPath(t *testing.T) {
+	denyAll := withReadGate(context.Background(), worldGate{permit: nil})
+	got := schemaWorlds(denyAll, worldsMeta())
+
+	if !got["default"].Readable {
+		t.Error("the request path short-circuits `default` before any grant " +
+			"check, so the enumeration must report it readable too — asking " +
+			"the gate here reports today's graph as unreadable while every " +
+			"request for it succeeds")
+	}
+	if got["published"].Readable {
+		t.Error("precondition: this gate denies every DECLARED world, so the " +
+			"default arm above is the only thing under test")
+	}
+}
+
+// TestSchemaWorlds_DoesNotAliasTheMetamodel pins that a response cannot
+// re-scope every reader's world.
+//
+// The metamodel is a pointer shared by every assembled Services
+// (appbuild.SharedBase), so a serializer handing out its backing slices lets
+// one consumer's in-place sort turn `select: [nl, en]` into `select: [en, nl]`
+// for every tenant. That is the unbounded direction: it silently serves the
+// wrong face.
+//
+// Mutation-checked (Ruling 10): a copy-assertion passes trivially if the
+// mutation cannot reach the source. Verified to die when both Select and
+// Overrides are assigned straight from the metamodel.
+func TestSchemaWorlds_DoesNotAliasTheMetamodel(t *testing.T) {
+	meta := worldsMeta()
+	got := schemaWorlds(context.Background(), meta)
+
+	got["site-nl"].Select[0] = "MUTATED"
+	got["site-nl"].Overrides["policy"][0] = "MUTATED"
+
+	if chain := meta.Worlds["site-nl"].Select; chain[0] != "nl" {
+		t.Errorf("mutating the response re-scoped the shared metamodel: "+
+			"select is now %v", chain)
+	}
+	if chain := meta.Worlds["site-nl"].Overrides["policy"]; chain[0] != "published" {
+		t.Errorf("mutating the response re-scoped the shared metamodel: "+
+			"override is now %v", chain)
+	}
+}
+
+// TestSchemaPointers pins TKT-WRLDAPI item 3, including the byte-parity floor:
+// a pointerless type must emit NO key, so a project that declares no content
+// states is unchanged on the wire.
+func TestSchemaPointers(t *testing.T) {
+	meta := worldsMeta()
+
+	policy := schemaPointers(meta.Entities["policy"])
+	if len(policy) != 2 {
+		t.Fatalf("policy declares draft+published; got %v", policy)
+	}
+	if !policy["draft"].Default {
+		t.Error("draft is policy's default coordinate — the state a bare id addresses")
+	}
+	if policy["published"].Default {
+		t.Error("only one coordinate per type may be the default")
+	}
+
+	if got := schemaPointers(meta.Entities["ticket"]); got != nil {
+		t.Errorf("a pointerless type must emit no pointers key, keeping a "+
+			"content-state-free project byte-identical on the wire; got %v", got)
+	}
+}
+
+// TestSchemaEndpoint_ServesWorldsAndPointers is the wire-level check: the two
+// additive keys actually reach a client, through the real router.
+//
+// It also pins that BOTH schema surfaces agree about a type's pointers. They
+// were two inline copies of the same serializer before this change, and a
+// client that discovers a type's content states from one endpoint and not the
+// other has no way to tell which answer is authoritative.
+func TestSchemaEndpoint_ServesWorldsAndPointers(t *testing.T) {
+	app := newTestAppV1(t)
+	meta := app.State().Meta
+	meta.Worlds = map[string]metamodel.WorldDef{
+		"published": {Select: []string{"published"}, Otherwise: metamodel.OtherwiseExclude},
+	}
+	td := meta.Entities["ticket"]
+	td.Pointers = map[string]metamodel.PointerDef{
+		"draft": {Default: true}, "published": {},
+	}
+	meta.Entities["ticket"] = td
+
+	var schema v1.Schema
+	getJSON(t, app, "/api/v1/_schema", &schema)
+
+	if _, ok := schema.Worlds["published"]; !ok {
+		t.Errorf("the schema handshake must enumerate declared worlds; got %v",
+			schema.Worlds)
+	}
+	if _, ok := schema.Worlds["default"]; !ok {
+		t.Error("the implicit default world must be enumerated too")
+	}
+	if got := schema.Entities["ticket"].Pointers; len(got) != 2 {
+		t.Errorf("ticket declares draft+published; the schema served %v", got)
+	}
+	if !schema.Entities["ticket"].Pointers["draft"].Default {
+		t.Error("draft is the default coordinate")
+	}
+
+	// The single-type route must agree, field for field.
+	var single v1.EntityType
+	getJSON(t, app, "/api/v1/_schema/types/ticket", &single)
+	if len(single.Pointers) != len(schema.Entities["ticket"].Pointers) {
+		t.Errorf("the two schema surfaces disagree about ticket's pointers: "+
+			"/_schema says %v, /_schema/types/ticket says %v",
+			schema.Entities["ticket"].Pointers, single.Pointers)
+	}
+	if single.Label != schema.Entities["ticket"].Label ||
+		single.Plural != schema.Entities["ticket"].Plural ||
+		len(single.Properties) != len(schema.Entities["ticket"].Properties) {
+
+		t.Error("the two schema surfaces must render an entity type identically; " +
+			"they share toV1EntityType precisely so they cannot drift")
+	}
+}
+
+// TestSchemaEndpoint_PointerlessProjectUnchanged is the backward-compatibility
+// floor: a project declaring no worlds and no pointers gains exactly ONE key
+// (the default world) and no per-type ones.
+func TestSchemaEndpoint_PointerlessProjectUnchanged(t *testing.T) {
+	app := newTestAppV1(t) // fixture metamodel declares neither
+
+	var schema v1.Schema
+	getJSON(t, app, "/api/v1/_schema", &schema)
+
+	if len(schema.Worlds) != 1 || !schema.Worlds["default"].Default {
+		t.Errorf("a project with no worlds: block has exactly the default world; got %v",
+			schema.Worlds)
+	}
+	for name, et := range schema.Entities {
+		if et.Pointers != nil {
+			t.Errorf("type %q declares no pointers, so the key must be absent; got %v",
+				name, et.Pointers)
+		}
+	}
+}
+
+// --- item 2: face provenance -------------------------------------------
+
+// TestResolutionRule pins the (scope, pointer) -> rule mapping that labels a
+// served face (TKT-WRLDAPI item 2).
+//
+// The mapping is total over what the store can hand back, which is why it is a
+// lookup rather than a chain walk: resolution already happened in the store,
+// and a second walk here would be a second implementation of the semantics
+// that decide which face a reader sees.
+func TestResolutionRule(t *testing.T) {
+	// `site-nl`: blog-post prefers nl then en, falling back to the default
+	// state; policy is overridden to published-or-exclude.
+	scope := store.NewWorldScope(map[string]store.TypeResolution{
+		"blog-post": {
+			Chain:    []entity.Pointer{"nl", "en"},
+			Fallback: store.FallbackDefaultState,
+		},
+		"policy": {
+			Chain:    []entity.Pointer{"published"},
+			Fallback: store.FallbackExclude,
+		},
+	})
+
+	tests := []struct {
+		name       string
+		scope      store.WorldScope
+		entityType string
+		pointer    entity.Pointer
+		want       string
+		why        string
+	}{
+		{
+			name: "default world resolves everything unscoped",
+			// The zero scope applies no per-type resolution, so every entity
+			// arrives via its default state — matching worldreader.Rule,
+			// which reports the default world identically.
+			scope: store.DefaultWorld(), entityType: "blog-post", pointer: "",
+			want: ruleUnscoped,
+			why:  "the default world applies no resolution at all",
+		},
+		{
+			name:  "pointerless type in a non-default world",
+			scope: scope, entityType: "ticket", pointer: "",
+			want: ruleUnscoped,
+			why: "a type absent from the scope contributes its default state " +
+				"in every world (rule 1) — absence is NOT exclusion",
+		},
+		{
+			name:  "first chain coordinate",
+			scope: scope, entityType: "blog-post", pointer: "nl",
+			want: ruleChain,
+			why:  "nl is what site-nl asked for",
+		},
+		{
+			name:  "later chain coordinate is still the chain",
+			scope: scope, entityType: "blog-post", pointer: "en",
+			want: ruleChain,
+			why: "en is DECLARED in site-nl's chain, so serving it is the world " +
+				"getting its second choice — not a fallback. Reporting this as " +
+				"fallback-default would tell a client the world was overridden " +
+				"when it was obeyed",
+		},
+		{
+			name:  "default state under otherwise:default is a fallback",
+			scope: scope, entityType: "blog-post", pointer: "",
+			want: ruleFallbackDefault,
+			why: "no chain coordinate exists, so the default state stood in — " +
+				"THE case this field exists for, since the bytes are " +
+				"indistinguishable from a real nl face",
+		},
+		{
+			name:  "override chain is honored",
+			scope: scope, entityType: "policy", pointer: "published",
+			want: ruleChain,
+			why:  "policy's per-type override selects published",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := resolutionRule(tc.scope, tc.entityType, tc.pointer); got != tc.want {
+				t.Errorf("resolutionRule(%q, %q) = %q, want %q — %s",
+					tc.entityType, tc.pointer, got, tc.want, tc.why)
+			}
+		})
+	}
+}
+
+// TestWorldProvenance_NamesTheWorld pins that provenance reports the world the
+// request was resolved in, and that an unstamped context reads as the default
+// world rather than as an empty name.
+func TestWorldProvenance_NamesTheWorld(t *testing.T) {
+	e := &entity.Entity{ID: "POST-1", Type: "blog-post", Pointer: "nl"}
+
+	if got := worldProvenance(context.Background(), e); got.Name != defaultWorldName {
+		t.Errorf("an unstamped context is the default world; got name %q", got.Name)
+	}
+
+	scope := store.NewWorldScope(map[string]store.TypeResolution{
+		"blog-post": {Chain: []entity.Pointer{"nl", "en"}, Fallback: store.FallbackDefaultState},
+	})
+	ctx := withWorld(context.Background(), worldHandle{name: "site-nl", scope: scope})
+	got := worldProvenance(ctx, e)
+	if got.Name != "site-nl" {
+		t.Errorf("name = %q, want site-nl — the world NAME lives only on the "+
+			"handle; a store.WorldScope carries none and it cannot be recovered "+
+			"later", got.Name)
+	}
+	if got.Pointer != "nl" || got.Via != ruleChain {
+		t.Errorf("got %+v, want pointer=nl via=chain", got)
+	}
+
+	if worldProvenance(ctx, nil) != nil {
+		t.Error("a nil entity yields nil, so a not-found result passes through " +
+			"without the caller branching")
+	}
+}
+
+// TestGetEntity_ProvenanceDistinguishesFallbackFromSelectedFace is the
+// load-bearing wire test for item 2, and the reason the field exists.
+//
+// Two entities of the SAME type, read through the SAME world, both served
+// under a bare id with identical JSON shape. One is the world's actual choice;
+// the other is a substitute the world fell back to. Before this change a
+// client could not tell them apart at all — which is exactly the
+// "published" vs "not published, showing you the draft" distinction Ruling 9
+// needs to decide whether to offer an edit affordance.
+//
+// Mutation-checked per Ruling 10: this test's failure mode is "proves nothing"
+// — a provenance block asserted against ONE entity passes trivially if the
+// derivation is a constant. Verified to die in BOTH directions: with
+// resolutionRule stubbed to return ruleChain unconditionally, and with it
+// stubbed to return ruleFallbackDefault unconditionally. One direction would
+// not have been enough; a constant is only caught by asserting two entities
+// that must disagree, which is why both live in this one test rather than in
+// two that could each pass against a different constant.
+func TestGetEntity_ProvenanceDistinguishesFallbackFromSelectedFace(t *testing.T) {
+	app := newTestAppV1(t)
+	ctx := t.Context()
+
+	// TKT-1 has a `published` face; TKT-2 has only its default state.
+	seedEntity(app, &entity.Entity{
+		ID: "TKT-1", Type: "ticket", Properties: map[string]any{"title": "draft face"},
+	})
+	seedEntity(app, &entity.Entity{
+		ID: "TKT-2", Type: "ticket", Properties: map[string]any{"title": "only face"},
+	})
+	pubFace := &entity.Entity{
+		ID: "TKT-1", Type: "ticket", Pointer: "published",
+		Properties: map[string]any{"title": "published face"},
+	}
+	if err := app.store.CreateEntity(ctx, pubFace); err != nil {
+		t.Fatalf("seed published face: %v", err)
+	}
+
+	// A world preferring `published` but falling back to the default state,
+	// so BOTH entities resolve — which is what makes the two verdicts
+	// comparable on the same wire shape.
+	app.SetWorlds(fixedWorlds{scope: store.NewWorldScope(
+		map[string]store.TypeResolution{
+			"ticket": {
+				Chain:    []entity.Pointer{"published"},
+				Fallback: store.FallbackDefaultState,
+			},
+		})})
+
+	var selected, fallback v1.Entity
+	getJSON(t, app, "/api/v1/tickets/TKT-1?world=preview", &selected)
+	getJSON(t, app, "/api/v1/tickets/TKT-2?world=preview", &fallback)
+
+	// Precondition: without this the test compares two identical fallbacks and
+	// proves nothing about the distinction it exists to pin.
+	if selected.Properties["title"] != "published face" {
+		t.Fatalf("TKT-1 must resolve to its published face; got %q — the world "+
+			"is not resolving, so the provenance assertions below are vacuous",
+			selected.Properties["title"])
+	}
+	if fallback.Properties["title"] != "only face" {
+		t.Fatalf("TKT-2 must resolve via the fallback; got %q",
+			fallback.Properties["title"])
+	}
+
+	if selected.World == nil || fallback.World == nil {
+		t.Fatal("a per-entity GET carries face provenance")
+	}
+	if selected.World.Via != ruleChain {
+		t.Errorf("TKT-1 was served the face the world SELECTED; via = %q, want %q",
+			selected.World.Via, ruleChain)
+	}
+	if selected.World.Pointer != "published" {
+		t.Errorf("TKT-1 pointer = %q, want published", selected.World.Pointer)
+	}
+	if fallback.World.Via != ruleFallbackDefault {
+		t.Errorf("TKT-2 has no published face, so the world SUBSTITUTED its "+
+			"default state; via = %q, want %q — reporting %q here would tell a "+
+			"client an unpublished entity is published",
+			fallback.World.Via, ruleFallbackDefault, selected.World.Via)
+	}
+	if fallback.World.Pointer != "" {
+		t.Errorf("TKT-2 pointer = %q, want the empty default coordinate",
+			fallback.World.Pointer)
+	}
+	// The distinction is the entire point: if these two ever agree, the field
+	// conveys nothing and every consumer built on it is silently wrong.
+	if selected.World.Via == fallback.World.Via {
+		t.Error("both entities reported the same provenance, so the field cannot " +
+			"distinguish a published face from a fallback — which is the ONLY " +
+			"thing it exists to do")
+	}
+	if selected.World.Name != "preview" || fallback.World.Name != "preview" {
+		t.Errorf("both were read through world `preview`; got %q and %q",
+			selected.World.Name, fallback.World.Name)
+	}
+}
+
+// TestGetEntity_ProvenanceInDefaultWorld pins that the field is present and
+// honest on an ordinary, world-free request.
+//
+// Present rather than omitted, deliberately: a client cannot tell an absent
+// `_world` on a default-world response apart from an absent one on a server
+// too old to have the field, and would have to probe to find out.
+func TestGetEntity_ProvenanceInDefaultWorld(t *testing.T) {
+	app := newTestAppV1(t)
+	seedEntity(app, &entity.Entity{
+		ID: "TKT-1", Type: "ticket", Properties: map[string]any{"title": "t"},
+	})
+
+	var got v1.Entity
+	getJSON(t, app, "/api/v1/tickets/TKT-1", &got)
+
+	if got.World == nil {
+		t.Fatal("a default-world GET still carries provenance")
+	}
+	if got.World.Name != defaultWorldName {
+		t.Errorf("name = %q, want %q", got.World.Name, defaultWorldName)
+	}
+	if got.World.Pointer != "" || got.World.Via != ruleUnscoped {
+		t.Errorf("got %+v, want the default coordinate resolved unscoped", got.World)
+	}
+}
+
+// --- helpers ------------------------------------------------------------
+
+// worldGate is a readGate whose only interesting method is PermitsWorld.
+// Everything else answers permissively, matching nopReadGate, so a test using
+// it exercises the world decision and nothing else.
+type worldGate struct {
+	permit map[string]bool
+	fail   bool
+}
+
+func (g worldGate) PermitsWorld(_ context.Context, world string) (bool, error) {
+	if g.fail {
+		return false, errWorldUnknown // any infrastructure-shaped failure
+	}
+	return g.permit[world], nil
+}
+
+func (worldGate) PermitsRead(context.Context, string, string) (bool, error) { return true, nil }
+
+func (worldGate) PermitsReadMany(ctx context.Context, entityType string, ids []string) (map[string]bool, error) {
+	return nopReadGate{}.PermitsReadMany(ctx, entityType, ids)
+}
+
+func (worldGate) ReadQuery(ctx context.Context, entityType string) acl.ReadQueryResult {
+	return nopReadGate{}.ReadQuery(ctx, entityType)
+}
+
+func (worldGate) SearchScope(ctx context.Context, types []string) map[string]search.TypeScope {
+	return nopReadGate{}.SearchScope(ctx, types)
+}
+
+func (worldGate) HoldsPermission(context.Context, string) bool { return true }
+
+// fixedWorlds resolves EVERY name to one scope, so a test may name its world
+// freely without the name having to match a compiled map.
+type fixedWorlds struct{ scope store.WorldScope }
+
+func (f fixedWorlds) Lookup(string) (store.WorldScope, bool) { return f.scope, true }
+
+// getJSON performs a GET through the real router and decodes a 200 body.
+// Going through the router (not the handler) is what keeps the world
+// middleware, the ACL middleware and the route table in the path.
+func getJSON(t *testing.T, app *App, path string, into any) {
+	t.Helper()
+	rec := httptest.NewRecorder()
+	app.NewRouter().ServeHTTP(rec, httptest.NewRequest(http.MethodGet, path, http.NoBody))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET %s: %d %s", path, rec.Code, rec.Body)
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), into); err != nil {
+		t.Fatalf("GET %s: decode: %v (body %s)", path, err, rec.Body)
+	}
+}

--- a/internal/dataentry/schemaworlds_test.go
+++ b/internal/dataentry/schemaworlds_test.go
@@ -195,7 +195,7 @@ func TestSchemaWorlds_GateErrorFailsClosed(t *testing.T) {
 // enumeration mirrors rather than papers over.
 //
 // So this test pins AGREEMENT between two paths, not a claim about the ACL.
-// When the request path starts honouring a default-world denial, this test
+// When the request path starts honoring a default-world denial, this test
 // SHOULD fail, and the correct response is to make this endpoint ask the gate
 // too — not to weaken the assertion.
 func TestSchemaWorlds_DefaultWorldAgreesWithTheRequestPath(t *testing.T) {

--- a/internal/dataentry/schemaworlds_test.go
+++ b/internal/dataentry/schemaworlds_test.go
@@ -177,16 +177,27 @@ func TestSchemaWorlds_GateErrorFailsClosed(t *testing.T) {
 // enumeration and the request path make the SAME decision about the default
 // world.
 //
-// This is the drift the constant `Readable: true` exists to prevent, and it is
-// counter-intuitive enough to be worth a test: acl.Request.PermitsWorld has no
-// default-world arm, so it answers FALSE for `default` unless a role happens to
-// grant the `world:default` token. Computing readability from the gate — the
-// obvious-looking "consistency" fix — would therefore report today's graph as
-// unreadable to nearly every principal, while `resolveWorld` short-circuits and
-// serves it. The selector would contradict the server.
+// `resolveWorld` short-circuits `default` before any grant check, so a request
+// for the default world is always served. This endpoint must therefore report
+// it readable, or the selector contradicts the server about a request the
+// server will in fact answer.
 //
-// So: a gate that denies EVERY world, including `default`, must still leave the
-// default world readable, because the request path never asks it.
+// The gate is NOT consulted, and that is the whole point of the test: a gate
+// denying every world must still leave the default world readable here,
+// because the request path never asks it.
+//
+// # What this test does NOT claim
+//
+// It does not claim a default-world denial is inexpressible. It is:
+// `acl.roleGrantsWorldRead` has an explicit default arm and
+// `compiledCeiling.permitsWorld` implements `deny_worlds: [default]`. The
+// request path simply does not consult them — a pre-existing gap this
+// enumeration mirrors rather than papers over.
+//
+// So this test pins AGREEMENT between two paths, not a claim about the ACL.
+// When the request path starts honouring a default-world denial, this test
+// SHOULD fail, and the correct response is to make this endpoint ask the gate
+// too — not to weaken the assertion.
 func TestSchemaWorlds_DefaultWorldAgreesWithTheRequestPath(t *testing.T) {
 	denyAll := withReadGate(context.Background(), worldGate{permit: nil})
 	got := schemaWorlds(denyAll, worldsMeta())

--- a/internal/dataentry/world.go
+++ b/internal/dataentry/world.go
@@ -5,8 +5,11 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"slices"
 	"strings"
 
+	v1 "github.com/Sourcehaven-BV/rela/internal/apiwire/v1"
+	"github.com/Sourcehaven-BV/rela/internal/entity"
 	"github.com/Sourcehaven-BV/rela/internal/store"
 )
 
@@ -143,14 +146,14 @@ func (a *App) SetWorlds(w WorldLookup) { a.worlds = w }
 //     debugging it than a uniform silence, and conceals nothing that the
 //     operator's own repo does not already state.
 //
-//     This clause previously justified itself with "the set of declared
-//     worlds is already served over the API". That was FALSE — no endpoint
-//     enumerates worlds today (metamodel.Metamodel.Worlds carries no JSON
-//     tag and no handler reads it), so a client discovers a name only by
-//     being told one or by guessing. The CONCLUSION is unchanged, because it
-//     never depended on that premise: config names are not secret whether or
-//     not this API happens to serve them. Corrected rather than deleted so
-//     the next reader does not re-derive the same wrong premise.
+//     `/api/v1/_schema` now enumerates the declared worlds (TKT-WRLDAPI), so
+//     this 400 names something the same caller can already list. Note the
+//     ORDER of that argument: the conclusion does not rest on the
+//     enumeration. Config names are not secret whether or not this API
+//     happens to serve them, and the enumeration exists because a client
+//     cannot build a world selector by guessing — not to make the 400 safe.
+//     An earlier revision of this comment asserted the enumeration before it
+//     was built; it is recorded here as fact only now that it is one.
 //
 //   - Known world the principal may NOT read -> (zero handle, errWorldDenied),
 //     which callers render as an EMPTY RESULT, never a 403. What a world
@@ -350,4 +353,77 @@ func attachWorld(next http.Handler, a *App) http.Handler {
 		}
 		next.ServeHTTP(w, r.WithContext(withWorld(r.Context(), handle)))
 	})
+}
+
+// worldProvenance labels HOW the request's world resolved this face
+// (TKT-WRLDAPI item 2).
+//
+// # Labeling, not re-resolving
+//
+// Resolution itself happens exactly once, in the store: the world scope rides
+// the query ([store.EntityQuery.World]) and the backend picks the prime. This
+// function reads the answer back — the coordinate the returned row was stored
+// at — and names the rule that must have produced it. It never fetches, never
+// walks the chain, and cannot disagree with the store about WHICH face was
+// served, because it is handed that face.
+//
+// That distinction matters: a second chain walk here would be a second
+// implementation of the semantics deciding which face a reader sees, free to
+// drift from the store's. The mapping below is total over the states the
+// store can return, so there is nothing left to decide:
+//
+//   - type absent from the scope -> rule 1, "unscoped".
+//   - pointer present in the chain -> rule 2, "chain".
+//   - otherwise -> rule 3 under `otherwise: default`, "fallback-default".
+//
+// The third arm is reachable only when the fallback actually fired: under
+// `otherwise: exclude` the store returns NOTHING, so there is no response to
+// label and the handler has already rendered a 404.
+//
+// Returns nil for a nil entity, so a caller may pass a not-found result
+// through without branching.
+func worldProvenance(ctx context.Context, e *entity.Entity) *v1.EntityWorld {
+	if e == nil {
+		return nil
+	}
+	handle := worldFromContext(ctx)
+	name := handle.name
+	if name == "" {
+		name = defaultWorldName
+	}
+	return &v1.EntityWorld{
+		Name:    name,
+		Pointer: e.Pointer.String(),
+		Via:     resolutionRule(handle.scope, e.Type, e.Pointer),
+	}
+}
+
+// Resolution rule names, mirroring worldreader.Rule's String(). Spelled here
+// rather than imported because internal/dataentry does not depend on
+// internal/worldreader (the HTTP path resolves through the store query, not
+// through a Resolver) — but the VOCABULARY is deliberately the same one, so a
+// wire value and a server log line about the same resolution read alike.
+const (
+	ruleUnscoped        = "unscoped"
+	ruleChain           = "chain"
+	ruleFallbackDefault = "fallback-default"
+)
+
+// resolutionRule names the rule that produced a face stored at p, for an
+// entity of entityType, under scope. See [worldProvenance] for why this is a
+// total mapping rather than a walk.
+//
+// entityType MUST be canonical: [store.WorldScope] is keyed on canonical
+// names only, and an alias reaching For() reads as an unknown type, which is
+// rule 1. The route resolves the type by iterating the metamodel's own keys,
+// so every caller on this path is canonical by construction.
+func resolutionRule(scope store.WorldScope, entityType string, p entity.Pointer) string {
+	res, scoped := scope.For(entityType)
+	if !scoped {
+		return ruleUnscoped
+	}
+	if slices.Contains(res.Chain, p) {
+		return ruleChain
+	}
+	return ruleFallbackDefault
 }

--- a/internal/dataentry/world.go
+++ b/internal/dataentry/world.go
@@ -376,6 +376,23 @@ func attachWorld(next http.Handler, a *App) http.Handler {
 //   - pointer present in the chain -> rule 2, "chain".
 //   - otherwise -> rule 3 under `otherwise: default`, "fallback-default".
 //
+// # The invariant this depends on
+//
+// Totality rests on one property of the compiled scope: A CHAIN NEVER
+// CONTAINS THE ZERO POINTER. Every backend returns a pointer drawn from
+// `Chain ∪ {""}` (storeutil.WorldPrimes writes exactly three values: the
+// matched chain coordinate, or "" for rules 1 and 3; pgstore's worldSQL
+// builds the same candidate set), so the third arm is only ever reached by a
+// genuine rule-3 fallback. internal/worlds upholds this because it maps
+// declared names through entity.ParsePointer, which rejects "".
+//
+// The dependency is named because it lives in a package this one does not
+// import: store.NewWorldScope is exported and a non-worlds producer could
+// construct a chain containing "". That would not corrupt the label — such a
+// coordinate resolves via rule 2 in every backend and slices.Contains agrees
+// — but the reasoning above would no longer be the reason, so a future
+// reader deserves to know which property is load-bearing.
+//
 // The third arm is reachable only when the fallback actually fired: under
 // `otherwise: exclude` the store returns NOTHING, so there is no response to
 // label and the handler has already rendered a 404.


### PR DESCRIPTION
Tickets-PR: #1422

A page can now say **"showing English — no Dutch translation yet"** instead of silently presenting a fallback as the real thing:

```
GET /blog-posts/POST-1?world=site-nl -> {"name":"site-nl","pointer":"nl","via":"chain"}            | Uw toeleveringsketen beveiligen
GET /blog-posts/POST-2?world=site-nl -> {"name":"site-nl","pointer":"","via":"fallback-default"}   | Threat modelling basics
```

Those two responses were **byte-identical** before this PR. POST-1 really is the Dutch face; POST-2 is the English one, served because no Dutch face exists. Nothing on the wire distinguished them, so no client could.

The content-states backend has been complete and correct for several PRs — worlds resolve, `?world=published` filters, language fallback works. But almost none of it was reachable from a client. This adds the three small, additive read surfaces that make it so. Items 4-7 of TKT-WRLDAPI (world-capable detail read, the copy endpoint, all-states, face-aware `_actions`) are deliberately **not** here.

## What's on the wire

**1. `worlds` on `GET /api/v1/_schema`** — you could pass `?world=` since TKT-DN37J2, but there was no way to discover a legal value; a guess got a 400. *Unblocks the world selector.*

```json
"worlds": {
  "default":   {"readable": true, "default": true},
  "published": {"select": ["published"], "otherwise": "exclude", "readable": true},
  "site-nl":   {"select": ["nl", "en"],  "otherwise": "default", "readable": false}
}
```

The **declared set is never filtered per principal** — world names are operator-authored `schema.yaml` config, and CLAUDE.md is explicit that config names are not secret. What varies is `readable`. A world you may not read is not hidden; it is marked, and selecting it anyway still returns an empty result rather than a 403, so it cannot be used to probe what the world holds.

**2. `pointers` on `_schema`'s EntityType** — a client could not learn that `policy` declares draft/published. This is **schema, not data**: it says what the operator declared for the *type*, never which faces a given *entity* has. That second question is the existence oracle the row gate closes, and the field's godoc says so explicitly, because the per-entity variant is the tempting next step and must not be taken here.

**3. `_world` on the per-entity GET** — `{name, pointer, via}`, where `via` is `chain` / `fallback-default` / `unscoped`.

## Two design notes worth a reviewer's eye

**Provenance is derived by LABELLING, not by re-resolving.** Resolution happens exactly once, in the store (the world scope rides the query; the backend picks the prime). `worldProvenance` reads the answer back and names the rule that produced it — it never fetches and never walks the chain. A second chain walk here would be a second implementation of the semantics deciding which face a reader sees, free to drift. The godoc names the one invariant this rests on (a chain never contains the zero pointer) because that invariant lives in a package `dataentry` does not import.

**It is attached in the GET handler, not in the shared `forWire` serializer.** `forWire` has nine callers and putting it there would look tidier, but the history handler serializes a snapshot built via `entityPkg.New()` — Pointer always zero — so a historical version of a *published* face would have reported the default coordinate. Ruling 11's "an affordance map that lies is a trap" applies to a provenance block just as much. The single-entity GET is the only caller whose pointer is the store's actual answer to a world query.

## Testing

Verified live with curl against a real server on `/tmp/isms-demo` (both axes: policy draft/published, blog-post en/nl/fr), not only in unit tests — including that `POL-2?world=published` still 404s, so an excluded face stays indistinguishable from a missing one.

**Six mutations run per Ruling 10**, each confirmed to kill its test:

| Mutation | Test killed |
|---|---|
| `resolutionRule` → constant `chain` | provenance wire test + 3 subtests |
| `resolutionRule` → constant `fallback-default` | provenance wire test + 3 other subtests |
| gate error → `readable = true` | `GateErrorFailsClosed` |
| response aliases the metamodel's slices | `DoesNotAliasTheMetamodel` |
| filter denied worlds out of the enumeration | `DeclaredSetIsPrincipalIndependent` |
| compute the default world's `readable` from the gate | `DefaultWorldAgreesWithTheRequestPath` |

Both directions of the first were needed: a single constant is only caught by asserting two entities that must *disagree*, which is why the fallback and selected faces live in one test rather than two that could each pass against a different constant.

## Also in here

- **A stale doc claim, corrected.** `GUIDE-metamodel.md` still said *"There is no way to ask for a world per request. No `?world=` query parameter"* — false since TKT-DN37J2. A reader would have concluded the whole feature was unreachable. Rewritten to document `?world=`, its grant check, discovery, provenance, and the three *real* remaining limits (no world-scoped search, only the two entity routes, `?include=` refused). `docs/metamodel.md` regenerated; never hand-edited.
- **A comment corrected twice.** `world.go` justified its unknown-world 400 with "the declared worlds are already served over the API" (false); the UI PR corrected it to "that was FALSE"; item 1 makes it true again, so it now states the fact — while noting the conclusion never depended on the premise.
- `toV1PropertyDef` and the new `toV1EntityType` are free functions. Adding a method pushed `App` to 105, over its plimsoll line of 104; neither ever touched the receiver, so converting both removes a method rather than raising the cap.

## Reviewer note: BUG-DFLTCHAIN found here, fixed in the follow-up

`internal/worlds.declaredPointers` maps declared pointer names through `entity.ParsePointer` and never consults `PointerDef.Default`, while `metamodel.StoredPointer` maps a default-marked name to `""`. So `select: [published, draft]` where `draft` is `{default: true}` compiles to chain `["published","draft"]` — but that face is stored at `""`, so no row can ever match it, and an entity holding only a draft is **excluded** from a world that explicitly selected `draft`. Confirmed against the real compiler.

**Not reachable by any operator.** `internal/worlds` does not exist on `develop` — the content-states epic is entirely unmerged, and the defect was introduced by #1393 (commit `d5ef3c66`) within this same stack. So this is a stack-internal defect, not a live one.

Filed as **BUG-DFLTCHAIN** and fixed in a follow-up PR on top of this one, rather than by amending #1393 — rebasing the stack for a defect nobody can reach is not worth the churn. Out of scope here; noted so it reads as seen rather than missed.
