### PR TITLE
🌍 A world selecting its type's default state matched nothing (BUG-DFLTCHAIN)

### DIFF
--- a/docs-project/entities/guides/GUIDE-metamodel.md
+++ b/docs-project/entities/guides/GUIDE-metamodel.md
@@ -989,6 +989,13 @@ worlds:
 | `otherwise` | **Required.** What to do with an entity whose type declares states but none this world selects: `exclude` (the entity is not in this world at all) or `default` (fall back to its default state). |
 | `edits` | Where edits made from this world land. Accepted and validated now; used by a later release. |
 
+A chain may name a state marked `default: true` — the `page: draft` override
+above does exactly that, and it is the ordinary way to say "this world shows
+the draft face". A default state is stored under the bare id rather than as a
+separate row, but that is storage detail: naming it in `select:` or
+`overrides:` selects it by **rule 2**, the same as any other state, and an
+entity holding only its default face is served rather than excluded.
+
 A world resolves each entity to **at most one** face. Three rules, in order:
 
 1. The type declares no states → the entity appears in every world.

--- a/docs/metamodel.md
+++ b/docs/metamodel.md
@@ -983,6 +983,13 @@ worlds:
 | `otherwise` | **Required.** What to do with an entity whose type declares states but none this world selects: `exclude` (the entity is not in this world at all) or `default` (fall back to its default state). |
 | `edits` | Where edits made from this world land. Accepted and validated now; used by a later release. |
 
+A chain may name a state marked `default: true` — the `page: draft` override
+above does exactly that, and it is the ordinary way to say "this world shows
+the draft face". A default state is stored under the bare id rather than as a
+separate row, but that is storage detail: naming it in `select:` or
+`overrides:` selects it by **rule 2**, the same as any other state, and an
+entity holding only its default face is served rather than excluded.
+
 A world resolves each entity to **at most one** face. Three rules, in order:
 
 1. The type declares no states → the entity appears in every world.

--- a/internal/appbuild/worldsurface_test.go
+++ b/internal/appbuild/worldsurface_test.go
@@ -201,3 +201,103 @@ worlds:
 			"otherwise it is an unknown type, which is rule 1, which serves "+
 			"the default face in a world that meant to exclude it")
 }
+
+// TestWorldSurface_ChainNamingTheDefaultCoordinateResolves is the
+// BUG-DFLTCHAIN regression, asserted END TO END: compile a world whose chain
+// names the type's `default: true` pointer, then check the entity is actually
+// RETURNED by a real store.
+//
+// # Why it asserts a resolved row, not a compiled chain
+//
+// A test asserting `res.Chain == [...]` would pass against the broken
+// compiler as easily as the fixed one — it would simply describe whichever
+// coordinate the compiler emitted, which is the thing under test. The defect
+// only becomes visible when something tries to MATCH that coordinate against
+// storage, so the assertion has to be "the page comes back", with a real
+// store holding a real row.
+//
+// # The defect
+//
+// A `default: true` state is stored under the ZERO pointer (the bare id
+// addresses it), but the compiler mapped declared names literally, so `draft`
+// compiled to the coordinate `"draft"` — which no row carries. Under
+// `otherwise: exclude` the entity then vanished from a world that had
+// explicitly selected it, with no error and a config that reads correctly.
+//
+// `otherwise: exclude` is load-bearing HERE: under `otherwise: default` the
+// fallback silently supplies the same face, so the bug is invisible in the
+// bytes and shows up only as a mislabelled provenance rule. Excluding is what
+// turns a silent mislabel into an observable absence.
+//
+// Mutation-checked (Ruling 10), since a negative-shaped assertion about
+// silent exclusion is exactly the kind that can prove nothing. Verified to
+// die in both directions: reverting declaredPointers to the literal mapping
+// fails this test on `Found` (the silent-exclusion mode), and mapping EVERY
+// name to the zero coordinate fails the sibling world tests instead.
+//
+// # The other symptom, observed live
+//
+// Under `otherwise: default` the same defect produced a WRONG PROVENANCE
+// LABEL rather than an absence, and that is worth recording because it is
+// the form an operator is far more likely to meet.
+//
+// The isms-demo project declares `site-nl: select: [nl, en]` where `en` is
+// blog-post's default. A post with only an English face was reported as
+// `via: fallback-default` — "no face this world asked for, so here is the
+// default instead" — when the truth is `via: chain`: the world explicitly
+// named `en` and got its declared second choice. The bytes were identical
+// either way, so nothing downstream could notice.
+//
+// So the defect degraded gracefully into a lie. That is why the fix belongs
+// in the mapping and not in a load-time rejection: the config was never
+// wrong.
+func TestWorldSurface_ChainNamingTheDefaultCoordinateResolves(t *testing.T) {
+	meta, err := metamodel.Parse([]byte(`
+entities:
+  page:
+    label: Page
+    plural: pages
+    id_prefix: "PAGE-"
+    id_type: sequential
+    properties:
+      title:
+        type: string
+        required: true
+    pointers:
+      draft: {default: true}
+      published: {}
+relations: {}
+worlds:
+  editorial:
+    select: [published, draft]
+    otherwise: exclude
+`))
+	require.NoError(t, err)
+	svc := appbuildtest.New(meta)
+	defer func() { _ = svc.Close() }()
+	ctx := context.Background()
+
+	// PAGE-1 holds ONLY its default face, which `draft` names.
+	draftOnly := entity.New("PAGE-1", "page")
+	draftOnly.SetString("title", "draft only")
+	require.NoError(t, svc.Store().CreateEntity(ctx, draftOnly))
+
+	surface, err := appbuild.WorldSurface(svc, "editorial", nil)
+	require.NoError(t, err)
+
+	got, err := surface.Resolver().Resolve(ctx, "page", "PAGE-1")
+	require.NoError(t, err)
+
+	require.True(t, got.Found,
+		"the world's chain names `draft`, the page HAS a draft face, and the "+
+			"world must therefore serve it — a compiler that maps `draft` to a "+
+			"literal coordinate instead of the zero one excludes this page from "+
+			"a world that explicitly selected it (BUG-DFLTCHAIN)")
+	assert.Equal(t, "draft only", got.Entity.GetString("title"))
+	assert.Equal(t, worldreader.RuleChain, got.Via,
+		"the page was selected BY THE CHAIN, not substituted by a fallback — "+
+			"and `otherwise: exclude` means there is no fallback to hide behind")
+	assert.Equal(t, entity.Pointer(""), got.Pointer,
+		"a default-marked state lives at the ZERO coordinate; there is no "+
+			"second row named `draft`")
+}

--- a/internal/store/storetest/worlds.go
+++ b/internal/store/storetest/worlds.go
@@ -52,6 +52,26 @@ func RunWorldTests(t *testing.T, f Factory) {
 			typ: {Chain: coords, Fallback: fb},
 		})
 	}
+	// coordScope is scope's sibling for chains containing the ZERO
+	// coordinate, which `scope` structurally cannot build: it maps every
+	// element through entity.ParsePointer, and that codec REJECTS the empty
+	// string (it is not a parseable name — it is the absence of one).
+	//
+	// The shape is reachable in production: a pointer declared `default:
+	// true` is stored under the zero pointer, so a world selecting it by name
+	// compiles to a chain carrying "" (internal/worlds, BUG-DFLTCHAIN). Before
+	// that fix the compiler emitted the literal name instead, which no row
+	// could match — so this suite never saw a zero-coordinate chain and could
+	// not have caught the divergence if one existed.
+	//
+	// Taking []entity.Pointer directly rather than widening `scope` keeps the
+	// common case honest: a test naming coordinates as STRINGS still goes
+	// through the codec, so a typo in an ordinary chain is still caught.
+	coordScope := func(typ string, fb store.Fallback, chain ...entity.Pointer) store.WorldScope {
+		return store.NewWorldScope(map[string]store.TypeResolution{
+			typ: {Chain: chain, Fallback: fb},
+		})
+	}
 	// titles collects the resolved faces, keyed by bare id, and asserts
 	// the at-most-one-prime invariant on the way through.
 	titles := func(t *testing.T, s store.Store, q store.EntityQuery) map[string]string {
@@ -393,6 +413,79 @@ func RunWorldTests(t *testing.T, f Factory) {
 	// storage truth versus resolution. The refusal is shared so every
 	// backend inherits it; silently honoring one would be a precedence
 	// rule nobody remembers.
+	// A chain carrying the ZERO coordinate must be matched at its own RANK,
+	// like any other coordinate — not diverted into the rule-1/rule-3 path by
+	// a default-ness special case.
+	//
+	// This is the shape internal/worlds newly emits for a world that selects a
+	// `default: true` pointer by name (BUG-DFLTCHAIN). It is a CROSS-BACKEND
+	// contract because the two implementations reach the answer differently:
+	// storeutil.WorldPrimes has an explicit `Pointer.IsDefault()` branch that
+	// must fall THROUGH to the rank loop rather than short-circuit, while
+	// pgstore builds a CASE whose arms rank the coordinates — and under
+	// `otherwise: default` that CASE ends up with two arms matching the same
+	// row, so it relies on first-match-wins agreeing with the Go ranking.
+	//
+	// Neither property is obvious, both are currently correct, and until this
+	// case existed nothing held them together: the suite could not construct
+	// the chain at all, so a future edit to either side could have diverged
+	// while every test stayed green.
+	//
+	// Both fallbacks are exercised, and the `exclude` arm is what gives the
+	// case teeth: under `otherwise: default` a zero-coordinate row would be
+	// served either way — by the chain if the rank matched, by the fallback if
+	// it did not — so the two outcomes are indistinguishable. Under `exclude`
+	// there is no fallback to hide behind, so serving PAGE-2 at all proves the
+	// rank actually matched. Do not "simplify" this to the default arm alone.
+	//
+	// Mutation-checked (Ruling 10): adding a `continue` to WorldPrimes'
+	// IsDefault branch — diverting the default row past the rank loop, which
+	// is the exact divergence described above — fails THIS CASE AND NOTHING
+	// ELSE across the whole conformance suite. That is the measure of the gap
+	// it closes.
+	t.Run("Rule2_ZeroCoordinateIsRankedLikeAnyOther", func(t *testing.T) {
+		const def = entity.Pointer("")
+		for _, fb := range []struct {
+			name string
+			fb   store.Fallback
+		}{
+			{"exclude", store.FallbackExclude},
+			{"default", store.FallbackDefaultState},
+		} {
+			t.Run(fb.name, func(t *testing.T) {
+				s := f(t)
+				// PAGE-1 holds both faces; PAGE-2 only its default.
+				mustCreate(t, s, newState(t, "PAGE-1", "page", "", "1 default"))
+				mustCreate(t, s, newState(t, "PAGE-1", "page", "published", "1 published"))
+				mustCreate(t, s, newState(t, "PAGE-2", "page", "", "2 default"))
+
+				// The zero coordinate LAST: published outranks it for PAGE-1,
+				// and PAGE-2 is still served — via the CHAIN, not the fallback,
+				// which is why the exclude arm must return it too.
+				last := titles(t, s, store.EntityQuery{
+					Type:  "page",
+					World: coordScope("page", fb.fb, "published", def),
+				})
+				assert.Equal(t, "1 published", last["PAGE-1"],
+					"a higher-ranked coordinate still wins over the zero one")
+				assert.Equal(t, "2 default", last["PAGE-2"],
+					"the zero coordinate is IN the chain, so PAGE-2 resolves by "+
+						"rule 2 — under `exclude` there is no fallback that could "+
+						"have produced this, so serving it proves the rank matched")
+
+				// The zero coordinate FIRST: it now outranks published.
+				first := titles(t, s, store.EntityQuery{
+					Type:  "page",
+					World: coordScope("page", fb.fb, def, "published"),
+				})
+				assert.Equal(t, "1 default", first["PAGE-1"],
+					"chain ORDER governs the zero coordinate exactly as it does "+
+						"any other — reversing the chain reverses the winner")
+				assert.Equal(t, "2 default", first["PAGE-2"])
+			})
+		}
+	})
+
 	t.Run("AllStatesWithWorldIsRejected", func(t *testing.T) {
 		s := f(t)
 		mustCreate(t, s, newState(t, "PAGE-1", "page", "", "default"))

--- a/internal/worlds/worlds.go
+++ b/internal/worlds/worlds.go
@@ -164,10 +164,35 @@ func validateWorldNames(m *metamodel.Metamodel) []error {
 	return errs
 }
 
-// declaredPointers validates every declared pointer name against the
-// codec grammar and returns them as parsed coordinates, keyed by entity
-// type. Types declaring no pointers are absent from the result — that
+// declaredPointers validates every declared pointer name against the codec
+// grammar and returns the STORED COORDINATE each name addresses, keyed by
+// entity type. Types declaring no pointers are absent from the result — that
 // absence is what rule 1 compiles to.
+//
+// # A declared NAME is not a stored COORDINATE (BUG-DFLTCHAIN)
+//
+// The two differ for exactly one name per type: the one marked
+// `default: true`. A default-marked state is stored under the ZERO pointer —
+// the bare id addresses it (design doc §2.1) — so `page@draft` where `draft`
+// is the default names a row that does not exist. There are exactly N states
+// and nothing else; marking a name default does not mint a second row.
+//
+// This function used to parse names literally and skip that step, so a world
+// naming its type's default coordinate compiled to a chain entry NO ROW COULD
+// EVER MATCH. Under `otherwise: exclude` the entity vanished from a world
+// that had explicitly selected it; under `otherwise: default` it was served
+// via the fallback and mislabelled as such. Both failed silently, with a
+// config that reads correctly.
+//
+// So the mapping goes through [metamodel.StoredPointer], the one definition
+// of "declared name -> stored coordinate" — the same function the copy kernel
+// applies (internal/entitymanager/copy.go). Two functions answering that
+// question differently is the root cause; there is now one.
+//
+// Note the ORDER: grammar is checked on the DECLARED name, then the name is
+// mapped. Validating the mapped value instead would run [entity.ParsePointer]
+// over the empty string for every default coordinate, which it correctly
+// rejects — turning a valid schema into a load error.
 func declaredPointers(m *metamodel.Metamodel) (map[string]map[string]entity.Pointer, []error) {
 	var errs []error
 	out := make(map[string]map[string]entity.Pointer)
@@ -178,13 +203,14 @@ func declaredPointers(m *metamodel.Metamodel) (map[string]map[string]entity.Poin
 		}
 		parsed := make(map[string]entity.Pointer, len(def.Pointers))
 		for _, name := range sortedPointerNames(def) {
-			p, err := entity.ParsePointer(name)
-			if err != nil {
+			if _, err := entity.ParsePointer(name); err != nil {
 				errs = append(errs, fmt.Errorf(
 					"entity %q: invalid pointer name %q: %w", typeName, name, err))
 				continue
 			}
-			parsed[name] = p
+			// The declared name passed the grammar; the COORDINATE it
+			// addresses is what a chain must carry.
+			parsed[name] = entity.Pointer(metamodel.StoredPointer(m, typeName, name))
 		}
 		out[typeName] = parsed
 	}

--- a/internal/worlds/worlds_test.go
+++ b/internal/worlds/worlds_test.go
@@ -60,6 +60,18 @@ func ptr(t *testing.T, s string) entity.Pointer {
 	return p
 }
 
+// defaultCoord is the coordinate a `default: true` pointer compiles to: the
+// ZERO pointer, because a default-marked state is the one the bare id
+// addresses (design doc §2.1). Deliberately NOT expressible via ptr() —
+// entity.ParsePointer rejects the empty string, which is why a test that
+// reached for ptr("draft") to describe a default coordinate was describing
+// something that cannot exist in storage (BUG-DFLTCHAIN).
+//
+// Spelled as a named constant rather than a bare "" at each site so the
+// assertion reads as a claim about DEFAULTNESS rather than as an empty value
+// someone might tidy away.
+const defaultCoord = entity.Pointer("")
+
 // TestCompile_PointerlessProjectIsTheDefaultWorld pins AC1 and the whole
 // compatibility story: a metamodel with no worlds and no pointers yields
 // nothing to resolve, and the default world stays available and total.
@@ -121,11 +133,20 @@ func TestCompile_ChainsAndFallback(t *testing.T) {
 		assert.Equal(t, []entity.Pointer{ptr(t, "review"), ptr(t, "published")}, res.Chain)
 
 		// page declares published, which the world's global chain selects —
-		// but the per-type override replaces that chain entirely.
+		// but the per-type override (`page: draft`) replaces that chain
+		// entirely.
+		//
+		// The override names `draft`, which page marks `default: true`, so it
+		// compiles to the ZERO coordinate — not to the literal name. That is
+		// BUG-DFLTCHAIN: this assertion previously expected ptr("draft"), a
+		// coordinate no page row can ever carry, so the override selected
+		// nothing and every page fell through to `otherwise`. The world read
+		// as configured and resolved as if it were not.
 		res, ok = scope.For("page")
 		require.True(t, ok)
-		assert.Equal(t, []entity.Pointer{ptr(t, "draft")}, res.Chain,
-			"the override replaces the global chain, it does not extend it")
+		assert.Equal(t, []entity.Pointer{defaultCoord}, res.Chain,
+			"the override replaces the global chain, it does not extend it — "+
+				"and `draft` is page's default, so it addresses the zero coordinate")
 	})
 
 	t.Run("rule 3: otherwise compiles to the fallback verdict", func(t *testing.T) {
@@ -212,6 +233,18 @@ worlds:
 // TestCompile_ChainDedup pins that a repeated coordinate collapses rather
 // than being ranked twice (design doc §4.5's dedup rule, which applies
 // even without templates).
+//
+// It ALSO pins the default-coordinate mapping, because `draft` here is
+// `default: true`. This test previously expected the literal ptr("draft") and
+// so DEFENDED BUG-DFLTCHAIN: a chain entry no row could match, under
+// `otherwise: exclude`, silently removing every draft-only page from a world
+// that had explicitly selected drafts. A bug with a passing test guarding it
+// is worse than a bare bug — the test is what a future reader trusts — so the
+// old expectation is recorded here rather than quietly swapped.
+//
+// Dedup and the mapping interact: dedup runs AFTER mapping (see
+// resolveChain), so two names collapsing onto the same coordinate collapse
+// correctly. That is why this test can carry both properties at once.
 func TestCompile_ChainDedup(t *testing.T) {
 	c, err := worlds.Compile(parseSchema(t, `version: "1.0"
 namespace: https://example.org/test#
@@ -233,7 +266,9 @@ worlds:
 	require.True(t, ok)
 	res, ok := scope.For("page")
 	require.True(t, ok)
-	assert.Equal(t, []entity.Pointer{ptr(t, "published"), ptr(t, "draft")}, res.Chain)
+	assert.Equal(t, []entity.Pointer{ptr(t, "published"), defaultCoord}, res.Chain,
+		"`published` is an ordinary coordinate; `draft` is this type's default "+
+			"and so addresses the zero coordinate")
 }
 
 // TestCompile_RejectsBadPointerGrammar pins that the pointer grammar is


### PR DESCRIPTION
Tickets-PR: #1422

Fixes **BUG-DFLTCHAIN**. Stacked on #1438 (TKT-WRLDAPI items 1-3).

A world that selects its type's default state **by name** compiled to a chain entry that no stored row could ever match:

```yaml
entities:
  page:
    pointers: { draft: {default: true}, published: {} }
worlds:
  editorial:
    select: [published, draft]     # `draft` here matched NOTHING
    otherwise: exclude
```

A page holding only a draft was **excluded from a world that had explicitly selected drafts**. No error, no warning, and a config that reads exactly right.

## Root cause: two functions, one question, different answers

A state marked `default: true` is stored under the **zero pointer** — the bare id addresses it, and there is no second row named `draft`. `metamodel.StoredPointer` implements that mapping, and its godoc says getting it wrong "is not a cosmetic bug".

`worlds.declaredPointers` never called it. It mapped declared names literally via `entity.ParsePointer`, so `draft` became the coordinate `"draft"` — a value no row carries.

The fix routes the mapping through `StoredPointer` so **"declared name → stored coordinate" has one definition**.

**This is the third instance of this exact root cause in the content-states arc**, after the A1/A2 predicates (TKT-T31NKT) and `DeleteRelation`/`DeleteRelationState` (TKT-C1XUA8 PR-D): two callers deriving the same fact independently, and one of them not knowing about a special case. Worth making visible.

### One ordering subtlety

Grammar is still validated on the **declared name**, then the name is mapped. Validating the mapped value instead would run `ParsePointer` over `""` for every default coordinate — which it correctly rejects — turning a valid schema into a load error.

## Two symptoms, and the second is the likelier one

`otherwise: exclude` → the entity **vanishes**. That is the dramatic form.

`otherwise: default` → the fallback quietly supplies the same face, so the entity is served but the provenance is a **lie**. Observed live on the demo project, whose `site-nl: select: [nl, en]` has `en` as blog-post's default:

```
before:  POST-2 ?world=site-nl -> via: fallback-default
after:   POST-2 ?world=site-nl -> via: chain
```

"No face this world asked for, so here is the default instead" versus "the world named `en` and got its declared second choice". The bytes are identical either way, which is why nothing downstream could notice. A genuine fallback still reports as one — verified with a world selecting only `nl`, where POST-2 correctly reports `fallback-default`.

So the defect degraded gracefully into a wrong answer. That is also why the fix belongs in the mapping rather than in a load-time rejection: **the config was never wrong.**

## Tests

**The two tests that defended the bug.** `TestCompile_ChainDedup` and `TestCompile_ChainsAndFallback` both asserted the broken output as intended. A bug with a passing test guarding it is worse than a bare bug, because the test is what the next reader trusts — so both now record what the old expectation was and why it was wrong, rather than being quietly swapped.

**The regression test is end-to-end** (`internal/appbuild`, real compiler + real store) and asserts the entity is **returned**, not that the chain has some shape. A chain-contents assertion would have described whatever the compiler emitted, which is the thing under test — precisely why `TestCompile_ChainDedup` passed while defending the bug. `otherwise: exclude` is load-bearing in it: under `otherwise: default` the fallback masks the defect.

**A conformance gap this fix opens, now closed.** `storetest.RunWorldTests` could not express a zero-coordinate chain at all — its `scope` helper maps every element through `ParsePointer`, which rejects `""`. The backends agree today (verified against fs, mem, and real PostgreSQL), but nothing held them there: `WorldPrimes`' `IsDefault` branch must fall *through* to the rank loop rather than short-circuit, and pgstore's `CASE` relies on first-match-wins agreeing with that ranking. Both are non-obvious and were untested.

`Rule2_ZeroCoordinateIsRankedLikeAnyOther` pins it across all three backends. The sibling `coordScope` takes `[]entity.Pointer` directly rather than widening `scope`, so ordinary string-named chains still go through the codec and a typo is still caught.

**Mutation-checked (Ruling 10), three mutations:**

| Mutation | Result |
|---|---|
| revert `declaredPointers` to the literal mapping | end-to-end test fails on `Found` — the silent-exclusion mode |
| map every name to the zero coordinate | the two compile-side tests fail instead |
| `continue` in `WorldPrimes`' `IsDefault` branch | fails the new conformance case **and nothing else in the suite** |

That last row is the measure of the gap: before this PR, that mutation shipped green.

## Considered and rejected: a load-time check

A rejection of "unmatchable chain entries" would now have **no reachable input**. `validateWorldChains` already requires every chain entry to name a declared pointer, and after this fix every declared name maps to a coordinate rows genuinely carry — so "declared" implies "matchable". Verified across plain chains, mixed chains and per-type overrides. Adding the check would be dead code that reads as protection, the failure mode Ruling 3 rejected for the search refusal.

## Scope

No repo-tracked YAML declares `worlds:` or `pointers:` (`git grep` → zero hits), so **no in-repo behavior changes**. The affected artefacts are the shipped docs example and the local demo project. The docs example is correct as written; added a note that naming a default state in a chain is legitimate and selects by rule 2, since a reader could otherwise take it for a mistake.
