### PR TITLE
🌍 World-capable detail read, including relations (TKT-WRLDAPI item 4)

### DIFF
--- a/.go-arch-lint.yml
+++ b/.go-arch-lint.yml
@@ -378,6 +378,19 @@ deps:
       - transform
       - validator
       - visibility
+      # The world-scoped RELATION dispatch only (TKT-WRLDAPI item 4).
+      # worldreader.RelationReader.Neighbors is the sole implementation of
+      # the identity-vs-content scope split, and its godoc exists to make
+      # reimplementation UNREPRESENTABLE — a caller handed that capability
+      # cannot issue a raw nil-tail query through it. Reimplementing the
+      # dispatch here to avoid this edge would be the exact mistake that
+      # doc is written against, so the edge is the cheaper of the two.
+      #
+      # ENTITY resolution deliberately does NOT come through here: it stays
+      # on the store path (store.EntityQuery.World), which is the second of
+      # the two mechanisms worldreader's own package doc names. Two sites,
+      # neither duplicated.
+      - worldreader
     canUse:
       - goldmark
       - gogit

--- a/cmd/rela-server/main.go
+++ b/cmd/rela-server/main.go
@@ -459,6 +459,15 @@ func main() {
 	// right posture for a surface whose wiring never opted in.
 	app.SetWorlds(appbuild.CompiledWorlds(svc))
 
+	// World-scoped LINK resolution, wired together with the world lookup
+	// above and never separately: a surface that can SELECT a world but
+	// cannot resolve that world's links renders every page with no
+	// relations, which looks like a data problem rather than a wiring gap.
+	if err := dataentry.SetWorldNeighbors(app, svc.Store(), appbuild.RelationScopes(svc)); err != nil {
+		slog.Error("failed to wire world-scoped relations", "error", err)
+		os.Exit(1)
+	}
+
 	// Next-action per-user state. The composition root picks the backend
 	// (durable over state.KV, or the store-native one on postgres); this only
 	// hands the app what it built.

--- a/internal/appbuild/worldsurface.go
+++ b/internal/appbuild/worldsurface.go
@@ -47,6 +47,23 @@ func (c metamodelScopes) IsContentScoped(relType string) bool {
 	return def.Scope.IsContent()
 }
 
+// RelationScopes returns svc's relation scope classifier, for surfaces that
+// resolve LINKS through a world (TKT-WRLDAPI item 4).
+//
+// Returned as the metamodel-free [worldreader.ScopeClassifier] interface, so
+// a consumer that may not import internal/metamodel's relation defs — and
+// must not reimplement the identity-vs-content dispatch — can supply the one
+// metamodel fact worldreader.RelationReader needs.
+//
+// A package-level function for the same reason [WorldSurface] and
+// [CompiledWorlds] are: Services sits at its plimsoll exported-method cap.
+func RelationScopes(svc *Services) worldreader.ScopeClassifier {
+	if svc == nil {
+		return metamodelScopes{}
+	}
+	return metamodelScopes{meta: svc.meta}
+}
+
 // CompiledWorlds returns svc's compiled world map, for surfaces that offer
 // request-level world selection (TKT-DN37J2).
 //

--- a/internal/dataentry/api_v1.go
+++ b/internal/dataentry/api_v1.go
@@ -670,26 +670,34 @@ func (a *App) handleV1ListEntities(w http.ResponseWriter, r *http.Request, typeN
 	outgoingByRow := make([][]*entityPkg.Relation, len(entities))
 	incomingByRow := make([][]*entityPkg.Relation, len(entities))
 	var pageNeighborIDs []string
-	// Same rule as the single-entity GET: these edges are default-world, so a
-	// world-bound list carries none rather than pairing published rows with
-	// draft neighbors.
-	worldBound := !worldScopeFrom(r.Context()).IsDefaultWorld()
-	for i, e := range entities {
-		if worldBound {
-			continue
+	// Same two-reader split as the single-entity GET. Under a world, each
+	// row's links resolve through THAT world, per neighbor (RULING 12); under
+	// the default world this is the previous behavior verbatim.
+	var visibleNeighbors map[string]bool
+	if worldScopeFrom(r.Context()).IsDefaultWorld() {
+		for i, e := range entities {
+			outgoingByRow[i] = a.reader.outgoingRelations(r.Context(), e.ID)
+			incomingByRow[i] = a.reader.incomingRelations(r.Context(), e.ID)
+			pageNeighborIDs = append(pageNeighborIDs, neighborIDsOf(outgoingByRow[i], incomingByRow[i])...)
 		}
-		outgoingByRow[i] = a.reader.outgoingRelations(r.Context(), e.ID)
-		incomingByRow[i] = a.reader.incomingRelations(r.Context(), e.ID)
-		pageNeighborIDs = append(pageNeighborIDs, neighborIDsOf(outgoingByRow[i], incomingByRow[i])...)
+		// Gate neighbor IDs for the WHOLE page in one type-batched pass
+		// (RR-HJV8CP + RR-FRK1): a neighbor's ID may appear in a row's relations
+		// map only if its entity is visible to the caller, so `relations` and the
+		// visibility-filtered `included` map can never disagree. Outgoing targets
+		// (edge.To) and incoming sources (edge.From) are gated together — an
+		// entity's visibility is direction-independent.
+		visibleNeighbors = visibleRelationIDs(r.Context(), a.reader, a.visibleReader, pageNeighborIDs)
+	} else {
+		var werr error
+		outgoingByRow, incomingByRow, visibleNeighbors, werr = worldNeighborsForPage(
+			r.Context(), a.worldNeighbors, a.visibleReader, entities)
+		if werr != nil {
+			// Infrastructure failure, not an empty page. See the same arm on
+			// the single-entity GET.
+			writeGateError(w, r, werr)
+			return
+		}
 	}
-
-	// Gate neighbor IDs for the WHOLE page in one type-batched pass
-	// (RR-HJV8CP + RR-FRK1): a neighbor's ID may appear in a row's relations
-	// map only if its entity is visible to the caller, so `relations` and the
-	// visibility-filtered `included` map can never disagree. Outgoing targets
-	// (edge.To) and incoming sources (edge.From) are gated together — an
-	// entity's visibility is direction-independent.
-	visibleNeighbors := visibleRelationIDs(r.Context(), a.reader, a.visibleReader, pageNeighborIDs)
 
 	// Build response - always include relations for relation column support
 	data := make([]v1.Entity, 0, len(entities))
@@ -824,15 +832,35 @@ func (a *App) handleV1GetEntity(w http.ResponseWriter, r *http.Request, typeName
 
 	// Single per-entity serialization: strips hidden + attaches
 	// `_fields` / `_relations` per docs/data-entry/api-reference.md.
-	// Relations come from the ungated, DEFAULT-world reader, so a world-bound
-	// response must not carry them: a published entity wrapped in draft edges
-	// is the mixed-face response that reads as correct. Under the default
-	// world this is the previous behavior verbatim.
+	//
+	// Two readers, chosen by world. The DEFAULT world takes the ungated
+	// reader — the previous behavior verbatim. A non-default world takes the
+	// world-scoped seam, which resolves each link through the SAME world as
+	// the entry, per neighbor, independently (RULING 12): a published view
+	// links to published faces, and a link whose head has no face in this
+	// world is ABSENT rather than pointing at a 404.
+	//
+	// Reaching the ungated reader here under a world would pair a published
+	// entity with draft edges — the mixed-face response that reads as
+	// correct because the entity looks right and only its links are wrong.
 	var outgoing []*entityPkg.Relation
+	var visibleNeighbors map[string]bool
 	if worldScopeFrom(ctx).IsDefaultWorld() {
 		outgoing = a.reader.outgoingRelations(ctx, entity.ID)
+	} else {
+		var werr error
+		outgoing, visibleNeighbors, werr = worldOutgoingForEntity(
+			ctx, a.worldNeighbors, a.visibleReader, entity)
+		if werr != nil {
+			// A neighbor-resolution fault is an infrastructure failure, not
+			// an empty link set. Rendering it as "this world links to
+			// nothing" would hide an outage behind a page that looks like a
+			// correctly-sparse published face (RR-4TFZNL).
+			writeGateError(w, r, werr)
+			return
+		}
 	}
-	result := a.serializer.forWire(ctx, entity, outgoing, a.Meta(), plural)
+	result := a.serializer.forWireScoped(ctx, entity, outgoing, visibleNeighbors, a.Meta(), plural)
 
 	// Face provenance (TKT-WRLDAPI item 2). Attached HERE rather than inside
 	// forWire, even though forWire is the shared per-entity serializer,
@@ -1582,15 +1610,19 @@ func flattenIssues(sections []AnalysisSection) []visibleIssue {
 
 // --- Helper Functions ---
 
+// resolveV1Includes expands `?include=` into the `included` map.
+//
+// Candidate collection is world-aware (TKT-WRLDAPI item 4): under a
+// non-default world the neighbors come from the world-scoped seam, so an
+// included peer is THAT world's face of the neighbor and a neighbor with no
+// face in this world is absent. Under the default world it is the ungated
+// reader, byte-identical to before.
+//
+// Everything after collection — the batched ACL gate, nested recursion,
+// serialization — is shared by both paths deliberately. The world decides
+// WHICH entities are candidates; it does not change how they are gated or
+// rendered, and forking that would be two visibility rules to keep in step.
 func (a *App) resolveV1Includes(ctx context.Context, entity *entityPkg.Entity, includes string) map[string]v1.Entity {
-	// Neighbor resolution reads through the ungated, DEFAULT-world reader,
-	// so it cannot answer for a non-default world. attachWorld already
-	// refuses `?include=` there, making this unreachable — but a defense
-	// that lives only in the middleware is one route registration away from
-	// being bypassed, so it is restated at the site that does the reading.
-	if !worldScopeFrom(ctx).IsDefaultWorld() {
-		return nil
-	}
 	s := a.State()
 	included := make(map[string]v1.Entity)
 
@@ -1600,46 +1632,22 @@ func (a *App) resolveV1Includes(ctx context.Context, entity *entityPkg.Entity, i
 	// must respect the per-entity visibility rule) AND RR-FRK1 (a
 	// hub entity with 50 neighbors must not cost 50 GraphCount
 	// round-trips).
-	var candidates []*entityPkg.Entity
+	//
 	// nestedFor maps target.ID → the remaining nested-include
 	// expression (e.g. "implements.requires" → "requires" stored
-	// against the implements target). Recurses after the visibility
-	// filter so hidden neighbors don't trigger hidden nested probes.
-	nestedFor := make(map[string]string)
-
-	if includes == "*" { //nolint:nestif // include-all vs. named-include expansion is inherently nested; flattening would obscure the two-mode logic.
-		for _, edge := range a.reader.outgoingRelations(ctx, entity.ID) {
-			if target, found := a.reader.getEntity(ctx, edge.To); found {
-				candidates = append(candidates, target)
-			}
-		}
-		for _, edge := range a.reader.incomingRelations(ctx, entity.ID) {
-			if source, found := a.reader.getEntity(ctx, edge.From); found {
-				candidates = append(candidates, source)
-			}
-		}
-	} else {
-		for part := range strings.SplitSeq(includes, ",") {
-			part = strings.TrimSpace(part)
-			if part == "" {
-				continue
-			}
-			relParts := strings.SplitN(part, ".", 2)
-			relType := relParts[0]
-			for _, edge := range a.reader.outgoingRelations(ctx, entity.ID) {
-				if edge.Type != relType {
-					continue
-				}
-				target, found := a.reader.getEntity(ctx, edge.To)
-				if !found {
-					continue
-				}
-				candidates = append(candidates, target)
-				if len(relParts) > 1 {
-					nestedFor[target.ID] = relParts[1]
-				}
-			}
-		}
+	// against the implements target). Recursion happens after the
+	// visibility filter so hidden neighbors don't trigger hidden nested
+	// probes.
+	candidates, nestedFor, err := includeCandidates(ctx, a.reader, a.worldNeighbors, entity, includes)
+	if err != nil {
+		// The include channel is a best-effort affordance (see
+		// filterVisibleIncludes): the authoritative read is the explicit GET.
+		// A world-resolution fault drops the block and logs rather than
+		// failing the whole entity response — but it must not be silent, or
+		// an outage reads as "this entity has no neighbors in this world".
+		slog.Warn("dataentry: resolving world-scoped includes failed; include block omitted",
+			"entity", entity.ID, "include", includes, "err", err)
+		return nil
 	}
 
 	visible := a.filterVisibleIncludes(ctx, candidates)
@@ -1955,12 +1963,26 @@ func (a *App) computeEntityETag(ctx context.Context, e *entityPkg.Entity) string
 	// edges also change the ETag — otherwise If-Match / If-None-Match
 	// round-trips poison client caches.
 	//
-	// World-bound responses carry NO relations (they would be default-world
-	// edges on a resolved entity), so there is nothing to fold and reading
-	// them would put draft state into a published validator.
+	// The edges must come from the SAME reader the response body used, or the
+	// validator describes a different document than the one served. Until
+	// TKT-WRLDAPI item 4 a world-bound response carried no relations at all,
+	// so this folded nothing under a world; now it carries world-resolved
+	// ones, and folding nothing would mean an edge change under a world never
+	// moved the ETag — a stale 304 on a response whose links had changed.
+	//
+	// Reading the DEFAULT-world reader here instead would be the mirror bug:
+	// draft edges in a published validator, so publishing a face would not
+	// invalidate it while an unrelated draft edit would.
 	var edges []*entityPkg.Relation
 	if world.isDefault() {
 		edges = a.reader.outgoingRelations(ctx, e.ID)
+	} else if a.worldNeighbors != nil {
+		// Errors are swallowed deliberately: this is a cache validator, not a
+		// read. A resolution fault yields a hash over fewer edges, which is
+		// weaker (a missed 304) and never wrong in the dangerous direction —
+		// and the GET that produced this response has already surfaced the
+		// same fault as a 5xx if it mattered.
+		edges, _, _ = worldOutgoingForEntity(ctx, a.worldNeighbors, a.visibleReader, e)
 	}
 	edgeKeys := make([]string, 0, len(edges))
 	for _, edge := range edges {

--- a/internal/dataentry/api_v1.go
+++ b/internal/dataentry/api_v1.go
@@ -674,7 +674,7 @@ func (a *App) handleV1ListEntities(w http.ResponseWriter, r *http.Request, typeN
 	// row's links resolve through THAT world, per neighbor (RULING 12); under
 	// the default world this is the previous behavior verbatim.
 	var visibleNeighbors map[string]bool
-	if worldScopeFrom(r.Context()).IsDefaultWorld() {
+	if !worldBoundRelations(r.Context()) {
 		for i, e := range entities {
 			outgoingByRow[i] = a.reader.outgoingRelations(r.Context(), e.ID)
 			incomingByRow[i] = a.reader.incomingRelations(r.Context(), e.ID)
@@ -845,7 +845,7 @@ func (a *App) handleV1GetEntity(w http.ResponseWriter, r *http.Request, typeName
 	// correct because the entity looks right and only its links are wrong.
 	var outgoing []*entityPkg.Relation
 	var visibleNeighbors map[string]bool
-	if worldScopeFrom(ctx).IsDefaultWorld() {
+	if !worldBoundRelations(ctx) {
 		outgoing = a.reader.outgoingRelations(ctx, entity.ID)
 	} else {
 		var werr error
@@ -879,7 +879,14 @@ func (a *App) handleV1GetEntity(w http.ResponseWriter, r *http.Request, typeName
 	}
 
 	// ETag for caching (visible-only path; deny-path above emits no ETag).
-	etag := a.computeEntityETag(ctx, entity)
+	//
+	// The edges computed for the BODY above are reused rather than re-read.
+	// Under a world, re-deriving them costs a second head-resolution query,
+	// two more relation queries and a second ACL pass per request — the
+	// RR-FRK1 duplication this PR is careful to avoid one function over — and
+	// it also opens a window in which the validator could describe a
+	// different edge set than the body it is validating.
+	etag := entityETagWithEdges(ctx, entity, outgoing)
 	w.Header().Set("ETag", etag)
 
 	// Check If-None-Match
@@ -1935,7 +1942,41 @@ func addPaginationLinks(w http.ResponseWriter, _ *http.Request, page, perPage, t
 	w.Header().Set("Link", strings.Join(links, ", "))
 }
 
+// computeEntityETag reads the entity's edges itself. Callers that ALREADY hold
+// the edges they served should use [App.entityETagWithEdges] instead — see the
+// duplication note at the single-entity GET's call site.
 func (a *App) computeEntityETag(ctx context.Context, e *entityPkg.Entity) string {
+	edges, err := etagEdges(ctx, a.reader, a.worldNeighbors, a.visibleReader, e)
+	if err != nil {
+		return etagUnresolved(ctx, e)
+	}
+	return entityETagWithEdges(ctx, e, edges)
+}
+
+// etagUnresolved is the validator for an entity whose edges could not be
+// resolved. See the sentinel rationale on [entityETagWithEdges].
+func etagUnresolved(ctx context.Context, e *entityPkg.Entity) string {
+	slog.Warn("dataentry: ETag: world-scoped edge read failed; "+
+		"folding a sentinel so the validator matches nothing",
+		"entity", e.ID, "world", worldFromContext(ctx).name)
+	return entityETagWithEdges(ctx, e, []*entityPkg.Relation{
+		{Type: "!unresolved", To: "!unresolved"},
+	})
+}
+
+// entityETagWithEdges hashes e together with the edges the response actually
+// carried.
+//
+// Taking the edges as a PARAMETER rather than reading them is what keeps the
+// validator and the body describing the same document: the GET computes them
+// once, for both.
+//
+// A package function, not a method: it needs nothing from App, and App is
+// pinned at its plimsoll cap. (The ETag split briefly took it to 105, which is
+// the load line doing its job — see the App type doc.)
+func entityETagWithEdges(
+	ctx context.Context, e *entityPkg.Entity, edges []*entityPkg.Relation,
+) string {
 	h := sha256.New()
 	_, _ = h.Write([]byte(e.ID))
 	_, _ = h.Write([]byte(e.Type))
@@ -1963,27 +2004,14 @@ func (a *App) computeEntityETag(ctx context.Context, e *entityPkg.Entity) string
 	// edges also change the ETag — otherwise If-Match / If-None-Match
 	// round-trips poison client caches.
 	//
-	// The edges must come from the SAME reader the response body used, or the
-	// validator describes a different document than the one served. Until
-	// TKT-WRLDAPI item 4 a world-bound response carried no relations at all,
-	// so this folded nothing under a world; now it carries world-resolved
-	// ones, and folding nothing would mean an edge change under a world never
-	// moved the ETag — a stale 304 on a response whose links had changed.
-	//
-	// Reading the DEFAULT-world reader here instead would be the mirror bug:
-	// draft edges in a published validator, so publishing a face would not
-	// invalidate it while an unrelated draft edit would.
-	var edges []*entityPkg.Relation
-	if world.isDefault() {
-		edges = a.reader.outgoingRelations(ctx, e.ID)
-	} else if a.worldNeighbors != nil {
-		// Errors are swallowed deliberately: this is a cache validator, not a
-		// read. A resolution fault yields a hash over fewer edges, which is
-		// weaker (a missed 304) and never wrong in the dangerous direction —
-		// and the GET that produced this response has already surfaced the
-		// same fault as a 5xx if it mattered.
-		edges, _, _ = worldOutgoingForEntity(ctx, a.worldNeighbors, a.visibleReader, e)
-	}
+	// The edges are the caller's, and must be the ones the response BODY
+	// carried. Until TKT-WRLDAPI item 4 a world-bound response carried no
+	// relations at all, so nothing was folded under a world; now it carries
+	// world-resolved ones, and folding nothing would mean an edge change under
+	// a world never moved the ETag — a stale 304 on a response whose links had
+	// changed. Folding DEFAULT-world edges instead is the mirror bug: a draft
+	// edit would invalidate a published validator, and publishing a face would
+	// not.
 	edgeKeys := make([]string, 0, len(edges))
 	for _, edge := range edges {
 		edgeKeys = append(edgeKeys, edge.Type+"|"+edge.To)

--- a/internal/dataentry/api_v1_test.go
+++ b/internal/dataentry/api_v1_test.go
@@ -2896,6 +2896,19 @@ func newTestAppV1(t *testing.T) *App {
 				From:  []string{"ticket"},
 				To:    []string{"ticket"},
 			},
+			// CONTENT-scoped: the edge attaches to one face's tail, so a
+			// draft may cite different targets than the published face
+			// (design §2.2). Declared in the SHARED fixture so the
+			// world-neighbor tests exercise the identity-vs-content dispatch
+			// against the same metamodel every other test uses — a dispatch
+			// tested only against a bespoke fixture proves the fixture works,
+			// not the app.
+			"cites": {
+				Label: "cites",
+				From:  []string{"ticket"},
+				To:    []string{"feature"},
+				Scope: metamodel.ScopeContent,
+			},
 		},
 	}
 

--- a/internal/dataentry/app.go
+++ b/internal/dataentry/app.go
@@ -107,6 +107,16 @@ const userPaletteFile = "palette.yaml"
 // `worldRefusesSearch` are all package functions taking what they need, so
 // request-level world selection cost ONE method rather than five.
 //
+// TKT-WRLDAPI item 4 (world-scoped relations) cost ZERO methods, and that was
+// not free discipline — it was written as five methods first and plimsoll
+// failed the build at 108/104. They became package functions taking their
+// seams explicitly (`worldOutgoingForEntity`, `worldNeighborsForPage`,
+// `includeCandidates`, `defaultWorldCandidates`, `worldCandidates`, plus
+// `SetWorldNeighbors`), which reads better anyway: the seams a world-scoped
+// link read depends on are named in the signature rather than reached through
+// this struct. The load line doing its job is worth recording, because the
+// habit it interrupts is the one that produced the 104.
+//
 //plimsoll:max-methods=104
 type App struct {
 	// Primitives — immutable after NewApp.
@@ -133,8 +143,15 @@ type App struct {
 	// worlds resolves a `?world=` name to its compiled scope. Nil until
 	// [App.SetWorlds] is called, in which case the App serves the default
 	// world only and refuses any other `?world=` — see world.go.
-	worlds   WorldLookup
-	searcher search.Searcher
+	worlds WorldLookup
+	// worldNeighbors resolves an entity's LINKS under the request's world
+	// (TKT-WRLDAPI item 4). Nil until [SetWorldNeighbors] is called, in
+	// which case a world-bound response carries no relations — the pre-item-4
+	// behavior, which is safe but is the gap RULING 12 closed. Separate from
+	// `worlds` because the two are injected from different places: the world
+	// LOOKUP is a compiled map, this is a store-backed capability.
+	worldNeighbors *worldNeighbors
+	searcher       search.Searcher
 	// visibleSearcher is the ACL-scoped search seam (TKT-BA8BSX):
 	// executeQuery routes free-text searches through it so /_search
 	// and the _position search scope only ever see hits the request

--- a/internal/dataentry/entityreader.go
+++ b/internal/dataentry/entityreader.go
@@ -20,10 +20,17 @@ import (
 //
 // Every read here goes to the store unresolved, so it returns each entity's
 // DEFAULT state — the draft face, under the design doc's example layout.
-// That is a decision, not an oversight, and it is safe only because of what
-// holds it up: the routes this reader serves (relations, attachments,
-// export, sub-resources, views) are REFUSED a non-default world by
-// worldCapablePath, so no `?world=` request ever reaches these calls.
+// That is a decision, not an oversight, and it is safe because of two things
+// together:
+//
+//   - The routes this reader serves (relations, attachments, export,
+//     sub-resources, views) are REFUSED a non-default world by
+//     worldCapablePath, so no `?world=` request reaches those calls.
+//   - The two world-CAPABLE handlers (the collection list and the
+//     single-entity GET) call this reader only on their DEFAULT-world branch.
+//     Since TKT-WRLDAPI item 4 they have a world branch that goes through
+//     worldNeighbors instead, which resolves each link through the request's
+//     world (RULING 12).
 //
 // If a route is ever added to that allowlist, its use of this reader must be
 // converted first — a world-bound response assembled partly from

--- a/internal/dataentry/entityserializer.go
+++ b/internal/dataentry/entityserializer.go
@@ -106,14 +106,39 @@ func (s entitySerializer) toV1(
 // v1.Entity should use: toV1 + strip hidden properties + attach the affordance
 // maps. Use forWireRelated for entities that appear as list rows or under
 // `included` (no affordance maps, but still strip).
+//
+// The edges passed here are assumed ALREADY GATED — it forwards a nil
+// neighbor filter. A caller holding edges whose heads have not been through
+// the row gate must use [entitySerializer.forWireScoped] instead.
 func (s entitySerializer) forWire(
 	ctx context.Context, e *entityPkg.Entity, outgoing []*entityPkg.Relation,
 	meta *metamodel.Metamodel, plural string,
 ) v1.Entity {
+	return s.forWireScoped(ctx, e, outgoing, nil, meta, plural)
+}
+
+// forWireScoped is forWire with an explicit neighbor-visibility filter.
+//
+// It exists for the world path (TKT-WRLDAPI item 4), where the edges reaching
+// the serializer were resolved by the world-scoped seam and their heads gated
+// as a batch. Passing that set through means the `relations` map can only
+// name a neighbor that this world resolves AND the principal may read —
+// the same guarantee forWireRelated already gives list rows via
+// visibleNeighbors, which the per-entity path previously had no way to
+// express.
+//
+// visibleNeighbors nil disables the filter, which is what forWire passes: the
+// default-world path's edges come from a reader whose heads the caller has
+// already accounted for, and threading an empty (non-nil) map there would
+// silently blank every relation.
+func (s entitySerializer) forWireScoped(
+	ctx context.Context, e *entityPkg.Entity, outgoing []*entityPkg.Relation,
+	visibleNeighbors map[string]bool, meta *metamodel.Metamodel, plural string,
+) v1.Entity {
 	// Per-entity responses carry outgoing edges only; incoming edges reach the
 	// SPA via the dedicated /relations endpoint, not the top-level relations
 	// map. Incoming list columns are served by forWireRelated (list rows).
-	result := s.toV1(ctx, e, outgoing, nil, nil, meta, plural)
+	result := s.toV1(ctx, e, outgoing, nil, visibleNeighbors, meta, plural)
 	s.affordances.stripHiddenProperties(ctx, e, &result)
 	s.affordances.attachEntityAffordances(ctx, e, &result)
 	return result

--- a/internal/dataentry/world.go
+++ b/internal/dataentry/world.go
@@ -332,18 +332,15 @@ func attachWorld(next http.Handler, a *App) http.Handler {
 					"this endpoint serves the default world only; omit ?world=")
 				return
 			}
-			if r.URL.Query().Get("include") != "" {
-				// `?include=` resolves NEIGHBORS, and every neighbor read on
-				// these routes goes through the ungated, default-world
-				// entityReader. Serving them under a world would return a
-				// published entity wrapped in DRAFT neighbors — the mixed-face
-				// response that is hardest to spot, because the entity looks
-				// right and only its neighbors are wrong.
-				writeV1Error(w, r, http.StatusUnprocessableEntity, "world_include_unsupported",
-					"?include= cannot be resolved in a non-default world",
-					"omit ?include= — neighbor resolution is not world-scoped yet")
-				return
-			}
+			// `?include=` was REFUSED here until TKT-WRLDAPI item 4. It no
+			// longer is: neighbor resolution is world-scoped now, so an
+			// included peer is this world's face of the neighbor and a
+			// neighbor with no face in this world is absent (RULING 12).
+			// The refusal existed because every neighbor read went through
+			// the ungated, default-world entityReader; the world-capable
+			// handlers no longer reach it. Do not restore the refusal
+			// without also reverting worldneighbors.go — a bare refusal
+			// here would leave the resolution built and unreachable.
 			if worldRefusesSearch(r) {
 				writeV1Error(w, r, http.StatusUnprocessableEntity, "world_search_unsupported",
 					"free-text search cannot be scoped to a non-default world",

--- a/internal/dataentry/world_test.go
+++ b/internal/dataentry/world_test.go
@@ -411,7 +411,15 @@ func TestWorldCapableRoutesDoNotUseUngatedReader(t *testing.T) {
 						usesReader = true
 					}
 				case *ast.Ident:
-					if v.Name == "worldScopeFrom" || v.Name == "worldFromContext" {
+					// worldBoundRelations is the NAMED predicate the relation
+					// branches share (it wraps worldFromContext so a denied
+					// handle answers consistently). It counts as consulting
+					// the world — otherwise introducing one shared predicate,
+					// which is strictly better than three open-coded copies,
+					// would fail this guard and pressure the next author back
+					// into copying.
+					switch v.Name {
+					case "worldScopeFrom", "worldFromContext", "worldBoundRelations":
 						consultsWorld = true
 					}
 				}

--- a/internal/dataentry/world_test.go
+++ b/internal/dataentry/world_test.go
@@ -348,6 +348,22 @@ func TestWorldCapableRoutesDoNotUseUngatedReader(t *testing.T) {
 		"handleV1GetEntity":    true,
 		"resolveV1Includes":    true,
 		"computeEntityETag":    true,
+		// TKT-WRLDAPI item 4 moved neighbor collection out of
+		// resolveV1Includes and down into includeCandidates, which dispatches
+		// to one of two collectors. Without these entries the guard would
+		// keep scanning resolveV1Includes — which no longer reaches the
+		// reader at all — and pass while the reader call it was written to
+		// catch sat two frames down. The `scanned` assertion below does not
+		// protect against that: it counts what was found, not what was moved.
+		//
+		// defaultWorldCandidates is the one that USES the reader, and it is
+		// listed precisely so the guard has something to check: it is
+		// reader-using and world-consulting, which is the shape the guard
+		// permits. worldCandidates must never appear in the reader-using set
+		// at all.
+		"includeCandidates":      true,
+		"defaultWorldCandidates": true,
+		"worldCandidates":        true,
 	}
 
 	entries, err := os.ReadDir(".")
@@ -382,6 +398,16 @@ func TestWorldCapableRoutesDoNotUseUngatedReader(t *testing.T) {
 				switch v := inner.(type) {
 				case *ast.SelectorExpr:
 					if x, ok := v.X.(*ast.SelectorExpr); ok && x.Sel != nil && x.Sel.Name == "reader" {
+						usesReader = true
+					}
+					// The reader is also passed BY VALUE into package functions
+					// now (item 4 moved these off App to stay under the
+					// plimsoll cap), so `a.reader.X` is no longer the only
+					// shape a reader call takes. A bare `reader.X` selector
+					// counts too — without this, extracting a reader-using
+					// loop into a helper silently leaves the guard's view,
+					// which is exactly what happened once during item 4.
+					if ident, ok := v.X.(*ast.Ident); ok && ident.Name == "reader" {
 						usesReader = true
 					}
 				case *ast.Ident:
@@ -602,17 +628,27 @@ func TestAttachWorld_WritesRefuseAWorld(t *testing.T) {
 	}
 }
 
-// TestAttachWorld_IncludeRefusesAWorld pins the neighbor half of the
-// mixed-face problem: `?include=` resolves neighbors through the ungated,
-// default-world reader, so a world-bound response with includes would be a
-// published entity wrapped in draft neighbors.
-func TestAttachWorld_IncludeRefusesAWorld(t *testing.T) {
+// TestAttachWorld_IncludeIsAcceptedUnderAWorld pins the REMOVAL of the
+// `?include=` refusal (TKT-WRLDAPI item 4, RULING 12).
+//
+// The refusal existed because neighbor resolution went through the ungated,
+// default-world reader, so a world-bound response with includes would have
+// been a published entity wrapped in draft neighbors. Neighbor resolution is
+// world-scoped now, so the combination is served rather than refused.
+//
+// This asserts the middleware LETS IT THROUGH; that what comes back is
+// actually this world's faces is the job of the end-to-end tests in
+// worldneighbors_test.go. Both halves are needed: a middleware that accepts
+// the parameter while the handler ignores it would pass this test and serve
+// the wrong faces, which is why this one is deliberately not the only
+// coverage of the removal.
+func TestAttachWorld_IncludeIsAcceptedUnderAWorld(t *testing.T) {
 	t.Parallel()
 	app := &App{worlds: stubWorlds{names: map[string]bool{"published": true}}}
 	rec := serveWorldRequest(t, app, "/api/v1/tickets/TKT-1?world=published&include=*")
-	if rec.Code != http.StatusUnprocessableEntity {
-		t.Fatalf("?include= under a world must refuse rather than serve draft "+
-			"neighbors alongside a published entity; got %d %s", rec.Code, rec.Body)
+	if rec.Code == http.StatusUnprocessableEntity {
+		t.Fatalf("?include= under a world is no longer refused — neighbor "+
+			"resolution is world-scoped (RULING 12); got %d %s", rec.Code, rec.Body)
 	}
 }
 

--- a/internal/dataentry/worldneighbors.go
+++ b/internal/dataentry/worldneighbors.go
@@ -149,14 +149,28 @@ func (wn *worldNeighbors) worldScopedNeighbors(
 	}
 
 	ids := headIDsOf(edges, res.Entity.ID)
-	if len(ids) == 0 {
-		return edges, nil, nil
+	if len(ids) > 0 {
+		heads, err = wn.resolveHeads(ctx, ids)
+		if err != nil {
+			return nil, nil, err
+		}
+	} else {
+		heads = make(map[string]*entityPkg.Entity, 1)
 	}
 
-	heads, err = wn.resolveHeads(ctx, ids)
-	if err != nil {
-		return nil, nil, err
-	}
+	// SEED THE ENTRY'S OWN FACE. A SELF-EDGE (from == to == this entity) names
+	// the entry as its own head, and headIDsOf deliberately omits it — there
+	// is nothing to look up, the face is already in hand. But `heads` is also
+	// the CONSUMER'S test for "does this world resolve that link", so an
+	// unseeded self id reads as EXCLUDED and the edge is dropped.
+	//
+	// That was a real bug, not a theoretical one: `blocks: ticket -> ticket`
+	// is an ordinary shape (dependency, supersedes, related-to), and a
+	// self-edge visible in the default world silently vanished under every
+	// non-default one. The two functions disagreed about what an absent key
+	// meant — headIDsOf said "already known", headOnWire said "unresolvable".
+	// Seeding here makes them agree, at the one place that holds the face.
+	heads[res.Entity.ID] = res.Entity
 	return edges, heads, nil
 }
 
@@ -472,6 +486,20 @@ func worldNeighborsForPage(
 			return nil, nil, nil, err
 		}
 	}
+	if heads == nil {
+		heads = make(map[string]*entityPkg.Entity, len(entities))
+	}
+	// Seed each row's OWN face, for the same reason worldScopedNeighbors does:
+	// a self-edge names its row as its own head, headIDsOf omits it, and an
+	// unseeded id reads as "excluded by this world" to worldEdgesForWire. A row
+	// already IS a resolved face, so this needs no query.
+	//
+	// This path does not call worldScopedNeighbors (it batches across rows
+	// instead), so the seeding cannot be inherited and has to be restated —
+	// which is precisely how the self-edge bug reached two call sites.
+	for _, e := range entities {
+		heads[e.ID] = e
+	}
 	visible = visibleWorldNeighbors(ctx, visReader, heads)
 
 	// Pass 3: split each row's edges by direction, dropping heads this world
@@ -505,7 +533,7 @@ func includeCandidates(
 	e *entityPkg.Entity, includes string,
 ) (candidates []*entityPkg.Entity, nestedFor map[string]string, err error) {
 	wanted, all := parseIncludeSpec(includes)
-	if worldScopeFrom(ctx).IsDefaultWorld() {
+	if !worldBoundRelations(ctx) {
 		candidates, nestedFor = defaultWorldCandidates(ctx, reader, e, wanted, all)
 		return candidates, nestedFor, nil
 	}
@@ -524,7 +552,7 @@ func defaultWorldCandidates(
 	wanted map[string]string, all bool,
 ) (candidates []*entityPkg.Entity, nestedFor map[string]string) {
 	nestedFor = make(map[string]string)
-	if !worldScopeFrom(ctx).IsDefaultWorld() {
+	if worldBoundRelations(ctx) {
 		// Unreachable through includeCandidates, which branches on exactly
 		// this. Restated HERE because the reader below is default-world-only
 		// and this function is now the one that touches it: a defense that
@@ -604,16 +632,33 @@ func worldCandidates(
 	return candidates, nestedFor, nil
 }
 
-// peerOf returns the endpoint of edge that is not selfID.
+// peerOf returns the endpoint of edge that is not selfID, or "" when the edge
+// names selfID on neither side.
 //
 // Derived rather than assumed to be edge.To, because a DirectionBoth query
-// returns edges naming the entry on either side. A self-edge yields selfID,
-// which resolves to the entry's own already-resolved face and is harmless.
+// returns edges naming the entry on either side.
+//
+// A SELF-EDGE yields selfID, and that is correct rather than merely harmless:
+// worldScopedNeighbors seeds the entry's own face into `heads`, so the lookup
+// finds it and the self-link is included. (An earlier revision of this comment
+// called it harmless when it was not — the face was unseeded, so a self-edge
+// was silently dropped under every non-default world. Fixed at the seeding
+// site; recorded here because this doc asserted the opposite.)
+//
+// An edge naming NEITHER endpoint returns "" rather than defaulting to
+// edge.To. Unreachable — the Neighbors query is endpoint-scoped — but
+// worldEdgesForWire already treats that case as worth refusing, and a sibling
+// that silently admitted a third party instead would be the divergence a
+// reader is entitled to assume does not exist.
 func peerOf(edge *entityPkg.Relation, selfID string) string {
-	if edge.To == selfID {
+	switch selfID {
+	case edge.From:
+		return edge.To
+	case edge.To:
 		return edge.From
+	default:
+		return ""
 	}
-	return edge.To
 }
 
 // parseIncludeSpec splits an `?include=` expression into the relation types
@@ -624,20 +669,27 @@ func peerOf(edge *entityPkg.Relation, selfID string) string {
 // remainder after the first dot ("implements.requires" → wanted["implements"]
 // = "requires"), or "" when there is no nesting.
 //
-// A duplicate relation type keeps the FIRST nested expression rather than the
-// last, matching the pre-existing loop order — `include=a.b,a.c` was never a
-// documented form, and silently switching which one wins would be a behavior
-// change smuggled in under a refactor.
+// # Two rules preserved from the loop this replaced, both verified rather than assumed
 //
-// One deliberate divergence from the pre-refactor loop, recorded because it
-// IS a difference even though nothing observes it: a TRAILING DOT
-// (`include=implements.`) used to set an empty nested expression, which
-// recursed once and returned an empty map (the recursion splits "" into a
-// single empty part and skips it). Here an empty remainder simply records no
-// nesting, so the pointless recursion does not happen. The `included` map is
-// identical either way; only the wasted call is gone.
+// A DUPLICATE relation type keeps the LAST nested expression, not the first.
+// The pre-refactor inner loop wrote `nestedFor[target.ID] = relParts[1]`
+// unconditionally on every pass, so a later clause overwrote an earlier one:
+// `include=a.b,a.c` recursed with "c". An earlier revision of this function
+// kept the FIRST and claimed in a comment that doing so "matched the
+// pre-existing loop order" — it did not, and code review caught the
+// contradiction. Undocumented behavior is still behavior; a refactor does not
+// get to change it silently in either direction.
+//
+// The `*` form is matched WITHOUT trimming, likewise deliberately. The old
+// code tested `includes == "*"` on the raw string, so `" * "` fell through to
+// the named branch, trimmed to "*", matched no relation type, and produced an
+// EMPTY include block. Trimming here would turn that stray space into a full
+// expansion — including incoming peers — which is a widening of the default
+// world triggered by a client's query-string builder. Whether `" * "` ought to
+// mean `*` is a real question; it is not one this PR gets to answer by
+// accident.
 func parseIncludeSpec(includes string) (wanted map[string]string, all bool) {
-	if strings.TrimSpace(includes) == "*" {
+	if includes == "*" {
 		return nil, true
 	}
 	wanted = make(map[string]string)
@@ -647,10 +699,59 @@ func parseIncludeSpec(includes string) (wanted map[string]string, all bool) {
 			continue
 		}
 		relType, nested, _ := strings.Cut(part, ".")
-		if _, dup := wanted[relType]; dup {
-			continue
-		}
+		// Last wins, matching the pre-refactor unconditional map write.
 		wanted[relType] = nested
 	}
 	return wanted, false
+}
+
+// worldBoundRelations reports whether this request's relation reads must go
+// through the world-scoped seam rather than the ungated, default-world reader.
+//
+// # Why this is not `worldScopeFrom(ctx).IsDefaultWorld()`
+//
+// A DENIED world handle carries a ZERO scope (see [worldHandle]), so the raw
+// scope says "default world" while the handle says otherwise. The two
+// predicates therefore disagree for exactly one input, and code that mixed
+// them would send a denied request down the default-world relation path while
+// a sibling site sent it down the world path.
+//
+// That is unreachable today — getVisible and scopedSortedEntities both bail on
+// blocksAllReads() before any relation code runs — so this is latent rather
+// than live. It is still worth one named predicate: the alternative is three
+// call sites that happen to agree, held together by an invariant enforced
+// somewhere else entirely.
+//
+// A denied handle answers TRUE (world-bound). That is the safe direction: the
+// world seam resolves nothing for a request that may read nothing, whereas the
+// ungated reader would happily return default-world edges.
+func worldBoundRelations(ctx context.Context) bool {
+	return !worldFromContext(ctx).isDefault()
+}
+
+// etagEdges returns the outgoing edges a cache validator must hash for e
+// under world w.
+//
+// It mirrors the branch [App.handleV1GetEntity] takes for the response body,
+// because a validator computed from a different edge set than the body
+// describes a different document — which is the whole failure mode an ETag
+// exists to prevent.
+//
+// Errors are RETURNED, not swallowed. The tempting shortcut is to treat a
+// resolution fault as "no edges", but the hash of an edge-less entity is a
+// perfectly valid validator for a real document state, so a fault would mint
+// a validator that a later If-None-Match matches against a body that does have
+// edges. The caller folds a sentinel instead. See the call site.
+func etagEdges(
+	ctx context.Context, reader entityReader, wn *worldNeighbors,
+	visReader visibleReader, e *entityPkg.Entity,
+) ([]*entityPkg.Relation, error) {
+	if !worldBoundRelations(ctx) {
+		return reader.outgoingRelations(ctx, e.ID), nil
+	}
+	if wn == nil {
+		return nil, nil
+	}
+	edges, _, err := worldOutgoingForEntity(ctx, wn, visReader, e)
+	return edges, err
 }

--- a/internal/dataentry/worldneighbors.go
+++ b/internal/dataentry/worldneighbors.go
@@ -1,0 +1,656 @@
+package dataentry
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"strings"
+
+	entityPkg "github.com/Sourcehaven-BV/rela/internal/entity"
+	"github.com/Sourcehaven-BV/rela/internal/store"
+	"github.com/Sourcehaven-BV/rela/internal/worldreader"
+)
+
+// worldNeighbors is the world-scoped neighbor seam: it answers "what does
+// this entity link to IN THIS WORLD", for both the edges and the entities
+// those edges point at (TKT-WRLDAPI item 4, RULING 12).
+//
+// # Why this exists at all
+//
+// A world resolves the entry AND every link through the same rule, per
+// neighbor, independently. An ISMS `published` view links to published
+// faces, and a linked control with no published face is ABSENT under
+// `otherwise: exclude`. A preview world with chain [draft, published] links
+// to drafts where drafts exist and published otherwise. A Spanish page links
+// to Spanish where Spanish exists and English where it does not — per-LINK
+// fallback, not per-page.
+//
+// Before this type, a world-bound response carried NO relations at all: the
+// only relation reader on these handlers was the ungated, default-world
+// [entityReader], and pairing a published entity with draft edges is the
+// mixed-face bug that reads as correct. Emitting nothing was the honest
+// placeholder; it is not the answer, and RULING 12 closed it.
+//
+// # Two reads, not one
+//
+// Resolving a link is TWO steps, and collapsing them is the trap:
+//
+//  1. The EDGES of the entry's resolved face, via
+//     [worldreader.RelationReader.Neighbors]. Per design-doc §2.3 a content
+//     edge carries a state-specific TAIL, so which edges exist depends on
+//     which face you are standing on.
+//  2. The HEADS those edges name, resolved through the world. §2.3 also
+//     says heads are ENTITY-LEVEL — an edge points at `SPEC-9`, never at
+//     `SPEC-9@published` — so step 1 alone yields an id, not a face.
+//
+// Step 2 is where `otherwise: exclude` bites. Without it a published view
+// emits a link to a control that has no published face: a link pointing at a
+// 404, which is precisely the case RULING 12 says must be absent. Step 1
+// cannot do this itself, because the edge is genuinely there — it is the
+// HEAD that this world does not resolve.
+//
+// # Ordering: world, THEN gate. Non-negotiable.
+//
+// [worldScopedNeighbors] resolves heads before the ACL row gate runs, never
+// after. This is guard rule 1 (see the [worldreader] package doc) applied one
+// layer out: resolution must be PRINCIPAL-INDEPENDENT.
+//
+// Gate-first would be an existence oracle. If the gate ran before the world,
+// a head the principal may not read would be dropped early — and under a
+// fallback chain the world would then have nothing to resolve, so the
+// RESULT SET a caller sees would differ depending on what the ACL denied
+// them. World-first means a denied neighbor is absent for exactly one
+// reason (the gate said no), indistinguishable from a neighbor that has no
+// face in this world. Pinned by TestWorldNeighbors_WorldResolvesBeforeGate.
+type worldNeighbors struct {
+	// relations is the world-scoped relation capability. It is a
+	// *worldreader.RelationReader rather than a store handle DELIBERATELY:
+	// that type exists so the identity-vs-content scope dispatch is
+	// unrepresentable to omit, and taking a store here would hand this
+	// package the raw nil-tail query the dispatch is written to prevent.
+	relations *worldreader.RelationReader
+
+	// store resolves neighbor HEADS through the world. This is the same
+	// store path visibleReader.getWorldEntity uses — deliberately, so entity
+	// resolution has ONE implementation and this type adds no second one.
+	store store.Store
+}
+
+// SetWorldNeighbors enables world-scoped LINK resolution (`?world=` on a
+// response's relations and `?include=`).
+//
+// A package-level FUNCTION rather than a method on App, for the reason the
+// world code has taken this shape throughout: App carries a
+// `//plimsoll:max-methods=104` directive pinning it at its current count, and
+// the project rule is to split the type rather than raise the number. The
+// world feature has added ONE method to App so far ([App.SetWorlds]) and five
+// package functions (resolveWorld, attachWorld, worldCapablePath,
+// worldRefusesSearch, and this), which is the discipline recorded on the App
+// type doc.
+//
+// Not calling this is a valid state: relations then behave as they did before
+// TKT-WRLDAPI item 4 — present under the default world, absent under any
+// other. That is safe but incomplete, which is why the composition root wires
+// it whenever it wires [App.SetWorlds].
+//
+// classes classifies a relation type as content- or identity-scoped; it is
+// supplied by the wiring site because the dispatch it feeds
+// ([worldreader.RelationReader]) must not be reimplemented here.
+//
+// Nil: rejected — a nil app, store or classifier returns an error rather than
+// silently leaving link resolution off, which would present as "this world
+// has no links" on every page.
+func SetWorldNeighbors(a *App, s store.Store, classes worldreader.ScopeClassifier) error {
+	if a == nil {
+		return errors.New("dataentry: SetWorldNeighbors: app must be non-nil")
+	}
+	if s == nil {
+		return errors.New("dataentry: SetWorldNeighbors: store must be non-nil")
+	}
+	rr, err := worldreader.NewRelationReader(s, classes)
+	if err != nil {
+		return fmt.Errorf("dataentry: SetWorldNeighbors: %w", err)
+	}
+	a.worldNeighbors = &worldNeighbors{relations: rr, store: s}
+	return nil
+}
+
+// worldScopedNeighbors returns the entity's edges under the request's world,
+// together with the world-resolved heads those edges name.
+//
+// Returns (edges, headsByID, error). headsByID holds ONLY the neighbors this
+// world resolves to a face: an id present in an edge but absent from the map
+// is a link the world excludes, and the caller MUST drop that edge rather
+// than emit it. That asymmetry is the point — see the type doc.
+//
+// The heads are resolved in ONE batched query over the whole id set, not a
+// point read per neighbor. A hub entity with fifty links must not cost fifty
+// round-trips (the RR-FRK1 shape, applied to world resolution).
+//
+// The ACL row gate is NOT applied here. Callers gate the returned heads —
+// world first, then gate, per the type doc.
+func (wn *worldNeighbors) worldScopedNeighbors(
+	ctx context.Context, res worldreader.Resolved, dir store.Direction,
+) (edges []*entityPkg.Relation, heads map[string]*entityPkg.Entity, err error) {
+	if !res.Found || res.Entity == nil {
+		// The world excludes the ENTRY, so it has no edges in this world.
+		// Neighbors() makes the same judgement internally; restating the
+		// guard here keeps the two-read contract legible at this level.
+		return nil, nil, nil
+	}
+
+	edges, err = wn.relations.Neighbors(ctx, res, dir)
+	if err != nil {
+		return nil, nil, fmt.Errorf("world-scoped neighbors for %s: %w", res.Entity.ID, err)
+	}
+	if len(edges) == 0 {
+		return nil, nil, nil
+	}
+
+	ids := headIDsOf(edges, res.Entity.ID)
+	if len(ids) == 0 {
+		return edges, nil, nil
+	}
+
+	heads, err = wn.resolveHeads(ctx, ids)
+	if err != nil {
+		return nil, nil, err
+	}
+	return edges, heads, nil
+}
+
+// resolveHeads resolves neighbor ids to their face in the request's world.
+//
+// One ListEntities carrying the world scope, so the BACKEND resolves the
+// chain and the fallback verdict. This is the same route
+// visibleReader.getWorldEntity takes for the entry, which is what keeps
+// entity resolution to a single implementation: a chain walk written here
+// would be a second copy of the semantics that decide which face a reader
+// sees, free to drift from the store's.
+//
+// An id absent from the result is a neighbor this world excludes. That is a
+// normal outcome, not an error — under `otherwise: exclude` it IS the
+// publication bit.
+//
+// An iterator error is returned, never swallowed into a short map. Truncating
+// here would silently drop links and read as "this world excludes them",
+// which is a backend outage wearing the costume of a correct answer — the
+// mistake resolveWorld refuses to make one file over (RR-4TFZNL).
+func (wn *worldNeighbors) resolveHeads(
+	ctx context.Context, ids []string,
+) (map[string]*entityPkg.Entity, error) {
+	out := make(map[string]*entityPkg.Entity, len(ids))
+	for e, err := range wn.store.ListEntities(ctx, store.EntityQuery{
+		IDs:   ids,
+		World: worldScopeFrom(ctx),
+	}) {
+		if err != nil {
+			return nil, fmt.Errorf("resolving neighbor heads: %w", err)
+		}
+		out[e.ID] = e
+	}
+	return out, nil
+}
+
+// headIDsOf collects the DISTINCT neighbor ids an edge set names, from
+// whichever endpoint is not selfID.
+//
+// Keying on selfID rather than on the direction is what makes this correct
+// for [store.DirectionBoth], where an edge may name the entry on either side.
+// A self-referential edge (From == To == selfID) contributes nothing, which
+// is right: the entry's own face is already resolved.
+func headIDsOf(edges []*entityPkg.Relation, selfID string) []string {
+	seen := make(map[string]struct{}, len(edges))
+	var ids []string
+	add := func(id string) {
+		if id == "" || id == selfID {
+			return
+		}
+		if _, dup := seen[id]; dup {
+			return
+		}
+		seen[id] = struct{}{}
+		ids = append(ids, id)
+	}
+	for _, edge := range edges {
+		add(edge.From)
+		add(edge.To)
+	}
+	return ids
+}
+
+// visibleWorldNeighbors runs the ACL row gate over already-world-resolved
+// heads and returns the id set that may appear on the wire.
+//
+// This is the world-path counterpart of [visibleRelationIDs], and the split
+// is deliberate rather than duplication: visibleRelationIDs loads its
+// candidates through the ungated, DEFAULT-world entityReader, which is
+// exactly what a world-bound response must not do. Here the candidates are
+// already the world's faces, so this only gates them.
+//
+// Gating happens AFTER resolution, never before — see the [worldNeighbors]
+// type doc for why the order is load-bearing.
+func visibleWorldNeighbors(
+	ctx context.Context, visible visibleReader, heads map[string]*entityPkg.Entity,
+) map[string]bool {
+	if len(heads) == 0 {
+		return map[string]bool{}
+	}
+	candidates := make([]*entityPkg.Entity, 0, len(heads))
+	for _, e := range heads {
+		candidates = append(candidates, e)
+	}
+	vis := visible.filterVisible(ctx, candidates)
+	out := make(map[string]bool, len(vis))
+	for _, e := range vis {
+		out[e.ID] = true
+	}
+	return out
+}
+
+// worldEdgesForWire splits world-resolved edges into the outgoing/incoming
+// pair the serializer takes, dropping every edge whose head this world does
+// not resolve or whose head the principal may not read.
+//
+// Dropping an unresolved head is the ISMS case from RULING 12: a published
+// view must not link to a control that has no published face. Dropping a
+// gated head is the ordinary row-gate rule. The wire cannot distinguish
+// them, which is correct — a neighbor absent because the world excludes it
+// and one absent because the ACL hid it must look the same, or the response
+// becomes an oracle for whichever is the rarer cause.
+func worldEdgesForWire(
+	edges []*entityPkg.Relation, selfID string,
+	heads map[string]*entityPkg.Entity, visible map[string]bool,
+) (outgoing, incoming []*entityPkg.Relation) {
+	for _, edge := range edges {
+		switch {
+		case edge.From == selfID:
+			if headOnWire(edge.To, heads, visible) {
+				outgoing = append(outgoing, edge)
+			}
+		case edge.To == selfID:
+			if headOnWire(edge.From, heads, visible) {
+				incoming = append(incoming, edge)
+			}
+		default:
+			// An edge naming neither endpoint cannot be attributed to a
+			// direction for this entity. Logged rather than guessed: a
+			// silent drop here would look like a world exclusion.
+			slog.Warn("dataentry: world neighbors: edge names neither endpoint; dropped",
+				"entity", selfID, "from", edge.From, "type", edge.Type, "to", edge.To)
+		}
+	}
+	return outgoing, incoming
+}
+
+// headOnWire reports whether a neighbor id may be emitted: the world must
+// resolve it to a face AND the principal must be permitted to read it.
+//
+// # The heads check is defense in depth, and saying so is the point
+//
+// On the production paths the `visible` set is BUILT FROM `heads`
+// ([visibleWorldNeighbors] gates the resolved faces), so an id the world
+// excluded is already absent from `visible` and the first condition is
+// redundant there. Removing it changes nothing today — verified by mutation:
+// deleting this check leaves every test in this package green.
+//
+// It stays for two reasons. It makes the function total over any
+// (heads, visible) pair rather than correct only for the pair the current
+// callers happen to build, which is what lets
+// TestWorldEdgesForWire_DropsUnresolvedAndHidden pin all four combinations
+// directly. And the redundancy runs in the SAFE direction: the failure it
+// guards against is emitting a link to a face this world excluded, and the
+// cost of keeping it is one map lookup.
+//
+// What it is NOT is the mechanism that implements RULING 12's exclusion rule.
+// That is the world scope on [worldNeighbors.resolveHeads] — mutating THAT is
+// what fails TestWorldNeighbors_ExcludedHeadIsAbsent. A future reader tracing
+// the exclusion should look there, not here.
+func headOnWire(id string, heads map[string]*entityPkg.Entity, visible map[string]bool) bool {
+	if _, resolved := heads[id]; !resolved {
+		return false
+	}
+	return visible[id]
+}
+
+// resolvedFromStoreFace rebuilds a [worldreader.Resolved] from a face the
+// STORE already resolved.
+//
+// The entity on these handlers does not come from a worldreader.Resolver — it
+// comes from the store path (store.EntityQuery.World), which is the second of
+// the two resolution mechanisms worldreader's package doc names. So the
+// Resolved handed to Neighbors is reconstructed rather than produced, and
+// exactly ONE field of it is load-bearing here: Pointer, the coordinate the
+// returned row was stored at, which Neighbors uses as the content-edge tail.
+//
+// Via is filled for completeness and is NOT consulted by Neighbors — it
+// labels provenance for callers that render a badge. It is computed by the
+// same total mapping [worldProvenance] uses, so a Resolved built here and a
+// `_world` block on the same response cannot disagree.
+//
+// Found is true unconditionally: this is only ever called with a face the
+// store actually returned. A world that excluded the entity produces no
+// entity at all, and the handler has already rendered a 404 by then.
+func resolvedFromStoreFace(ctx context.Context, e *entityPkg.Entity) worldreader.Resolved {
+	return worldreader.Resolved{
+		Entity:  e,
+		Pointer: e.Pointer,
+		Via:     ruleFromName(resolutionRule(worldScopeFrom(ctx), e.Type, e.Pointer)),
+		Found:   true,
+	}
+}
+
+// ruleFromName maps the wire vocabulary back to [worldreader.Rule].
+//
+// The two vocabularies are deliberately the same strings (see the
+// resolutionRule constants in world.go), so this is a lookup rather than a
+// translation. RuleUnscoped is the default arm because it is the rule for a
+// type the world applies no resolution to — the same direction
+// resolutionRule takes for an unknown type, and the one that keeps a
+// pointerless project unchanged.
+func ruleFromName(name string) worldreader.Rule {
+	switch name {
+	case ruleChain:
+		return worldreader.RuleChain
+	case ruleFallbackDefault:
+		return worldreader.RuleFallbackDefault
+	default:
+		return worldreader.RuleUnscoped
+	}
+}
+
+// worldOutgoingForEntity resolves one entity's OUTGOING links under the
+// request's world, returning the edges plus the gated neighbor-id set the
+// serializer filters against.
+//
+// Outgoing only, matching what a per-entity response has always carried:
+// incoming edges reach the SPA through the dedicated /relations endpoint,
+// which is not a world-capable route.
+//
+// Returns (nil, nil, nil) when no world-neighbor capability is wired. That is
+// the pre-item-4 behavior — a world-bound response with no relations — and it
+// is reachable only in a deployment that never called [SetWorldNeighbors],
+// not through any request path.
+//
+// A package FUNCTION taking its three seams explicitly, not an App method:
+// App is pinned at its plimsoll method cap, and every world helper in this
+// package has taken the same shape for that reason. It also reads better —
+// the seams a world-scoped link read depends on are named in the signature
+// rather than reached through a god object.
+func worldOutgoingForEntity(
+	ctx context.Context, wn *worldNeighbors, visReader visibleReader, e *entityPkg.Entity,
+) (outgoing []*entityPkg.Relation, visible map[string]bool, err error) {
+	if wn == nil {
+		return nil, nil, nil
+	}
+	edges, heads, err := wn.worldScopedNeighbors(
+		ctx, resolvedFromStoreFace(ctx, e), store.DirectionOutgoing)
+	if err != nil {
+		return nil, nil, err
+	}
+	// World FIRST, gate SECOND. See the worldNeighbors type doc: the reverse
+	// order makes the served result set depend on what the ACL denied, which
+	// is the existence oracle guard rule 1 exists to close.
+	visible = visibleWorldNeighbors(ctx, visReader, heads)
+	outgoing, _ = worldEdgesForWire(edges, e.ID, heads, visible)
+	return outgoing, visible, nil
+}
+
+// worldNeighborsForPage resolves the links of a whole list page under the
+// request's world, returning per-row outgoing/incoming edge slices plus the
+// one gated neighbor-id set the serializer filters every row against.
+//
+// # Why the page is one batch, not a loop of single-entity calls
+//
+// The obvious implementation — call worldOutgoingForEntity per row — would
+// issue one head-resolution query AND one ACL gate pass per row, turning a
+// 50-row page into 50 of each. That is the RR-FRK1 shape the default-world
+// path already avoids by collecting the page's neighbor ids before gating,
+// and the world path has no reason to be worse. So: edges per row, then ONE
+// head resolution and ONE gate pass over the union.
+//
+// # What is NOT batched, stated plainly
+//
+// The EDGE queries are still per row, and [worldreader.RelationReader.Neighbors]
+// issues two apiece (identity-tail and content-tail), so a 50-row page costs
+// 100 relation queries. That is not a regression — the default-world path also
+// queries per row (outgoingRelations + incomingRelations) — but it is not an
+// improvement either, and the doc should not imply the whole thing is one
+// round-trip.
+//
+// It is not batchable through Neighbors as it stands: the content-tail query
+// filters on the row's OWN resolved pointer, so fifty rows can carry fifty
+// different tails, and store.RelationQuery has no multi-endpoint selector to
+// express that in one shot. Widening it is a store-layer change (and DOFYR1's
+// FromPointer contract is deliberately frozen), so it belongs in its own
+// ticket rather than being smuggled in here.
+//
+// Rows are matched to their edges positionally, so the returned slices are
+// index-aligned with entities — a row with no links keeps a nil entry rather
+// than shifting its neighbors onto another row.
+//
+// Both directions, unlike the single-entity GET: list rows carry incoming
+// edges too, keyed by the relation's inverse name, so a `direction: incoming`
+// relation column has a wire key to resolve against.
+func worldNeighborsForPage(
+	ctx context.Context, wn *worldNeighbors, visReader visibleReader,
+	entities []*entityPkg.Entity,
+) (outgoing, incoming [][]*entityPkg.Relation, visible map[string]bool, err error) {
+	outgoing = make([][]*entityPkg.Relation, len(entities))
+	incoming = make([][]*entityPkg.Relation, len(entities))
+	if wn == nil {
+		return outgoing, incoming, nil, nil
+	}
+
+	// Pass 1: each row's edges, under that row's own resolved face.
+	edgesByRow := make([][]*entityPkg.Relation, len(entities))
+	var headIDs []string
+	seen := make(map[string]struct{})
+	for i, e := range entities {
+		edges, nerr := wn.relations.Neighbors(
+			ctx, resolvedFromStoreFace(ctx, e), store.DirectionBoth)
+		if nerr != nil {
+			return nil, nil, nil, fmt.Errorf("world neighbors for %s: %w", e.ID, nerr)
+		}
+		edgesByRow[i] = edges
+		for _, id := range headIDsOf(edges, e.ID) {
+			if _, dup := seen[id]; dup {
+				continue
+			}
+			seen[id] = struct{}{}
+			headIDs = append(headIDs, id)
+		}
+	}
+
+	// Pass 2: ONE world resolution over the page's whole neighbor set, then
+	// ONE gate pass. World first, gate second — see the worldNeighbors doc.
+	var heads map[string]*entityPkg.Entity
+	if len(headIDs) > 0 {
+		heads, err = wn.resolveHeads(ctx, headIDs)
+		if err != nil {
+			return nil, nil, nil, err
+		}
+	}
+	visible = visibleWorldNeighbors(ctx, visReader, heads)
+
+	// Pass 3: split each row's edges by direction, dropping heads this world
+	// does not resolve and heads the principal may not read.
+	for i, e := range entities {
+		outgoing[i], incoming[i] = worldEdgesForWire(edgesByRow[i], e.ID, heads, visible)
+	}
+	return outgoing, incoming, visible, nil
+}
+
+// includeCandidates collects the neighbor entities an `?include=` expression
+// names, resolved through the request's world.
+//
+// Returns the candidates (UNGATED — the caller gates them) and the nested
+// include expression to recurse with per candidate id.
+//
+// Two collection paths, chosen by world, sharing one expression parser:
+//
+//   - DEFAULT world: the ungated reader, exactly as before.
+//   - NON-DEFAULT world: the world-scoped seam, so a candidate is that
+//     world's face of the neighbor. A neighbor the world excludes never
+//     becomes a candidate, which is what makes an ISMS published view's
+//     `include` agree with its `relations` map instead of listing a peer the
+//     relations map dropped.
+//
+// The agreement between `relations` and `included` is the invariant worth
+// naming: RR-HJV8CP made them agree under the ACL gate, and a world that
+// filtered one but not the other would break it again from the other side.
+func includeCandidates(
+	ctx context.Context, reader entityReader, wn *worldNeighbors,
+	e *entityPkg.Entity, includes string,
+) (candidates []*entityPkg.Entity, nestedFor map[string]string, err error) {
+	wanted, all := parseIncludeSpec(includes)
+	if worldScopeFrom(ctx).IsDefaultWorld() {
+		candidates, nestedFor = defaultWorldCandidates(ctx, reader, e, wanted, all)
+		return candidates, nestedFor, nil
+	}
+	return worldCandidates(ctx, wn, e, wanted, all)
+}
+
+// defaultWorldCandidates collects include peers through the ungated reader —
+// the pre-item-4 path, byte-identical.
+//
+// `all` (the `*` form) pulls INCOMING peers too, so a list row's
+// inverse-keyed relation columns can resolve their sources. A NAMED include
+// stays outgoing-only, which is the pre-existing contract: `include=blocks`
+// means "the things this blocks".
+func defaultWorldCandidates(
+	ctx context.Context, reader entityReader, e *entityPkg.Entity,
+	wanted map[string]string, all bool,
+) (candidates []*entityPkg.Entity, nestedFor map[string]string) {
+	nestedFor = make(map[string]string)
+	if !worldScopeFrom(ctx).IsDefaultWorld() {
+		// Unreachable through includeCandidates, which branches on exactly
+		// this. Restated HERE because the reader below is default-world-only
+		// and this function is now the one that touches it: a defense that
+		// lives only in the caller is one refactor away from being bypassed,
+		// and the failure would be a published entity wrapped in draft peers.
+		// TestWorldCapableRoutesDoNotUseUngatedReader requires it too — it
+		// caught the absence of this check when the collection loop was
+		// extracted out of includeCandidates, which is the guard working.
+		return nil, nestedFor
+	}
+	for _, edge := range reader.outgoingRelations(ctx, e.ID) {
+		nested, want := wanted[edge.Type]
+		if !all && !want {
+			continue
+		}
+		target, found := reader.getEntity(ctx, edge.To)
+		if !found {
+			continue
+		}
+		candidates = append(candidates, target)
+		if nested != "" {
+			nestedFor[target.ID] = nested
+		}
+	}
+	if !all {
+		return candidates, nestedFor
+	}
+	for _, edge := range reader.incomingRelations(ctx, e.ID) {
+		if source, found := reader.getEntity(ctx, edge.From); found {
+			candidates = append(candidates, source)
+		}
+	}
+	return candidates, nestedFor
+}
+
+// worldCandidates collects include peers through the world-scoped seam, so a
+// candidate is THIS world's face of the neighbor and a neighbor the world
+// excludes never becomes one.
+//
+// That exclusion is what keeps `included` agreeing with the `relations` map:
+// both reach the same verdict from the same resolution, rather than one being
+// filtered and the other not (the RR-HJV8CP invariant, now spanning the world
+// filter as well as the ACL one).
+func worldCandidates(
+	ctx context.Context, wn *worldNeighbors, e *entityPkg.Entity,
+	wanted map[string]string, all bool,
+) (candidates []*entityPkg.Entity, nestedFor map[string]string, err error) {
+	nestedFor = make(map[string]string)
+	if wn == nil {
+		return nil, nestedFor, nil
+	}
+	dir := store.DirectionOutgoing
+	if all {
+		dir = store.DirectionBoth
+	}
+	edges, heads, err := wn.worldScopedNeighbors(
+		ctx, resolvedFromStoreFace(ctx, e), dir)
+	if err != nil {
+		return nil, nil, err
+	}
+	for _, edge := range edges {
+		nested, want := wanted[edge.Type]
+		if !all && !want {
+			continue
+		}
+		head, resolved := heads[peerOf(edge, e.ID)]
+		if !resolved {
+			// No face in this world — not a candidate. Same verdict
+			// worldEdgesForWire reaches for the relations map.
+			continue
+		}
+		candidates = append(candidates, head)
+		if nested != "" {
+			nestedFor[head.ID] = nested
+		}
+	}
+	return candidates, nestedFor, nil
+}
+
+// peerOf returns the endpoint of edge that is not selfID.
+//
+// Derived rather than assumed to be edge.To, because a DirectionBoth query
+// returns edges naming the entry on either side. A self-edge yields selfID,
+// which resolves to the entry's own already-resolved face and is harmless.
+func peerOf(edge *entityPkg.Relation, selfID string) string {
+	if edge.To == selfID {
+		return edge.From
+	}
+	return edge.To
+}
+
+// parseIncludeSpec splits an `?include=` expression into the relation types
+// it names and the nested expression under each.
+//
+// Returns (wanted, all). `all` is the `*` form, which takes every relation
+// type and both directions. Otherwise `wanted` maps a relation type to the
+// remainder after the first dot ("implements.requires" → wanted["implements"]
+// = "requires"), or "" when there is no nesting.
+//
+// A duplicate relation type keeps the FIRST nested expression rather than the
+// last, matching the pre-existing loop order — `include=a.b,a.c` was never a
+// documented form, and silently switching which one wins would be a behavior
+// change smuggled in under a refactor.
+//
+// One deliberate divergence from the pre-refactor loop, recorded because it
+// IS a difference even though nothing observes it: a TRAILING DOT
+// (`include=implements.`) used to set an empty nested expression, which
+// recursed once and returned an empty map (the recursion splits "" into a
+// single empty part and skips it). Here an empty remainder simply records no
+// nesting, so the pointless recursion does not happen. The `included` map is
+// identical either way; only the wasted call is gone.
+func parseIncludeSpec(includes string) (wanted map[string]string, all bool) {
+	if strings.TrimSpace(includes) == "*" {
+		return nil, true
+	}
+	wanted = make(map[string]string)
+	for part := range strings.SplitSeq(includes, ",") {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+		relType, nested, _ := strings.Cut(part, ".")
+		if _, dup := wanted[relType]; dup {
+			continue
+		}
+		wanted[relType] = nested
+	}
+	return wanted, false
+}

--- a/internal/dataentry/worldneighbors_test.go
+++ b/internal/dataentry/worldneighbors_test.go
@@ -1,0 +1,801 @@
+package dataentry
+
+import (
+	"context"
+	"iter"
+	"slices"
+	"testing"
+
+	"github.com/Sourcehaven-BV/rela/internal/acl"
+	"github.com/Sourcehaven-BV/rela/internal/entity"
+	"github.com/Sourcehaven-BV/rela/internal/metamodel"
+	"github.com/Sourcehaven-BV/rela/internal/principal"
+	"github.com/Sourcehaven-BV/rela/internal/store"
+	"github.com/Sourcehaven-BV/rela/internal/worldreader"
+)
+
+// metaScopes classifies relation types from the test metamodel, mirroring
+// what appbuild.RelationScopes supplies in production. Identity is the
+// default, matching metamodelScopes.
+type metaScopes struct{ meta *metamodel.Metamodel }
+
+func (c metaScopes) IsContentScoped(relType string) bool {
+	def, ok := c.meta.Relations[relType]
+	return ok && def.Scope.IsContent()
+}
+
+// withWorldNeighbors wires the world-scoped link capability onto a test app,
+// the way the composition root does.
+func withWorldNeighbors(t *testing.T, app *App) *App {
+	t.Helper()
+	if err := SetWorldNeighbors(app, app.store, metaScopes{meta: app.Meta()}); err != nil {
+		t.Fatalf("SetWorldNeighbors: %v", err)
+	}
+	return app
+}
+
+// publishedScope is the ISMS-shaped world: select the `published` face, and
+// exclude anything that has none. Exclusion is what makes a link to an
+// unpublished neighbor a link to nothing.
+func publishedScope(types ...string) store.WorldScope {
+	res := make(map[string]store.TypeResolution, len(types))
+	for _, typ := range types {
+		res[typ] = store.TypeResolution{
+			Chain:    []entity.Pointer{entity.Pointer("published")},
+			Fallback: store.FallbackExclude,
+		}
+	}
+	return store.NewWorldScope(res)
+}
+
+// seedFace writes one content state of an entity.
+func seedFace(t *testing.T, app *App, id, typ string, p entity.Pointer, title string) {
+	t.Helper()
+	if err := app.store.CreateEntity(context.Background(), &entity.Entity{
+		ID: id, Type: typ, Pointer: p,
+		Properties: map[string]any{"title": title},
+	}); err != nil {
+		t.Fatalf("seed %s@%s: %v", id, p, err)
+	}
+}
+
+// worldCtx binds a world handle plus a permit-all read gate, which is the
+// combination the handlers see for an unrestricted principal.
+func worldCtx(scope store.WorldScope) context.Context {
+	return withWorld(context.Background(), worldHandle{name: "published", scope: scope})
+}
+
+// TestWorldNeighbors_ExcludedHeadIsAbsent is the ISMS case from RULING 12,
+// and the one the whole two-read design exists for.
+//
+// A published policy links to a control that has NO published face. The edge
+// EXISTS in storage, so a design that resolved only the entry's edges would
+// happily emit it — a link pointing at an entity that 404s in this world.
+// Under `otherwise: exclude` the link must be ABSENT.
+//
+// This is the test that fails if head resolution is dropped, which is why it
+// is written against the wire output rather than against the seam: the seam
+// could be correct while the handler ignored it.
+//
+// # Mutation-checked (RULING 10), and the first attempt proved nothing
+//
+// The obvious mutation — deleting the `heads` lookup in headOnWire — leaves
+// this test GREEN, because the visible set is built from heads, so an
+// excluded neighbor is already gone by then. That check is defense in depth,
+// not the mechanism.
+//
+// The mechanism is the world scope on the head-resolution query. Dropping
+// `World: worldScopeFrom(ctx)` from worldNeighbors.resolveHeads makes
+// FEAT-DRAFT resolve in the default world and survive, and THAT fails this
+// test. Verified in both directions. If you are changing the exclusion
+// behavior, mutate that line to confirm this test still bites.
+func TestWorldNeighbors_ExcludedHeadIsAbsent(t *testing.T) {
+	app := withWorldNeighbors(t, newTestAppV1(t))
+
+	// TKT-1 has a published face and links to two features.
+	seedEntity(app, &entity.Entity{
+		ID: "TKT-1", Type: "ticket", Properties: map[string]any{"title": "draft"},
+	})
+	seedFace(t, app, "TKT-1", "ticket", "published", "published policy")
+	// FEAT-PUB is published; FEAT-DRAFT is not.
+	seedEntity(app, &entity.Entity{
+		ID: "FEAT-PUB", Type: "feature", Properties: map[string]any{"title": "pub draft"},
+	})
+	seedFace(t, app, "FEAT-PUB", "feature", "published", "published control")
+	seedEntity(app, &entity.Entity{
+		ID: "FEAT-DRAFT", Type: "feature", Properties: map[string]any{"title": "unpublished control"},
+	})
+
+	ctx := context.Background()
+	for _, to := range []string{"FEAT-PUB", "FEAT-DRAFT"} {
+		if _, err := app.store.CreateRelation(ctx, "TKT-1", "implements", to, nil); err != nil {
+			t.Fatalf("seed edge to %s: %v", to, err)
+		}
+	}
+
+	wctx := worldCtx(publishedScope("ticket", "feature"))
+	face, found, err := app.visibleReader.getVisible(wctx, "ticket", "TKT-1")
+	if err != nil || !found {
+		t.Fatalf("resolve entry: found=%v err=%v", found, err)
+	}
+	outgoing, visible, err := worldOutgoingForEntity(wctx, app.worldNeighbors, app.visibleReader, face)
+	if err != nil {
+		t.Fatalf("worldOutgoingForEntity: %v", err)
+	}
+
+	got := map[string]bool{}
+	for _, edge := range outgoing {
+		got[edge.To] = true
+	}
+	if !got["FEAT-PUB"] {
+		t.Errorf("a neighbor WITH a published face must be linked; got %v", got)
+	}
+	if got["FEAT-DRAFT"] {
+		t.Errorf("a neighbor with NO published face must be absent — under "+
+			"otherwise:exclude the link points at nothing in this world "+
+			"(RULING 12, the ISMS case); got %v", got)
+	}
+	if visible["FEAT-DRAFT"] {
+		t.Errorf("an excluded head must not reach the visible set either, or "+
+			"the serializer would emit it; got %v", visible)
+	}
+}
+
+// TestWorldNeighbors_PerLinkFallback is Jeroen's Spanish-page case: links
+// resolve to the world's preferred face WHERE IT EXISTS and fall back
+// PER LINK, not per page.
+//
+// The distinction is the whole point. A per-PAGE rule would decide once
+// ("this page has no Dutch, so serve everything in English") and be
+// self-consistent but wrong. This asserts one response carrying BOTH a
+// chain-resolved neighbor and a fallback-resolved one — which is only
+// possible if the decision is made per neighbor.
+func TestWorldNeighbors_PerLinkFallback(t *testing.T) {
+	app := withWorldNeighbors(t, newTestAppV1(t))
+
+	seedEntity(app, &entity.Entity{
+		ID: "TKT-1", Type: "ticket", Properties: map[string]any{"title": "en entry"},
+	})
+	seedFace(t, app, "TKT-1", "ticket", "nl", "nl entry")
+
+	// FEAT-NL has a Dutch face; FEAT-EN has only the default (English) one.
+	seedEntity(app, &entity.Entity{
+		ID: "FEAT-NL", Type: "feature", Properties: map[string]any{"title": "english title"},
+	})
+	seedFace(t, app, "FEAT-NL", "feature", "nl", "nederlandse titel")
+	seedEntity(app, &entity.Entity{
+		ID: "FEAT-EN", Type: "feature", Properties: map[string]any{"title": "english only"},
+	})
+
+	ctx := context.Background()
+	for _, to := range []string{"FEAT-NL", "FEAT-EN"} {
+		if _, err := app.store.CreateRelation(ctx, "TKT-1", "implements", to, nil); err != nil {
+			t.Fatalf("seed edge to %s: %v", to, err)
+		}
+	}
+
+	// chain [nl], fallback DEFAULT — the multilingual shape: prefer Dutch,
+	// serve English where no Dutch exists.
+	scope := store.NewWorldScope(map[string]store.TypeResolution{
+		"ticket":  {Chain: []entity.Pointer{"nl"}, Fallback: store.FallbackDefaultState},
+		"feature": {Chain: []entity.Pointer{"nl"}, Fallback: store.FallbackDefaultState},
+	})
+	wctx := withWorld(context.Background(), worldHandle{name: "site-nl", scope: scope})
+
+	face, found, err := app.visibleReader.getVisible(wctx, "ticket", "TKT-1")
+	if err != nil || !found {
+		t.Fatalf("resolve entry: found=%v err=%v", found, err)
+	}
+	edges, heads, err := app.worldNeighbors.worldScopedNeighbors(
+		wctx, resolvedFromStoreFace(wctx, face), store.DirectionOutgoing)
+	if err != nil {
+		t.Fatalf("worldScopedNeighbors: %v", err)
+	}
+	if len(edges) != 2 {
+		t.Fatalf("both links must survive — neither neighbor is excluded under "+
+			"otherwise:default; got %d", len(edges))
+	}
+
+	// The load-bearing assertion: two neighbors, resolved DIFFERENTLY, in one
+	// response.
+	nl, ok := heads["FEAT-NL"]
+	if !ok {
+		t.Fatal("FEAT-NL must resolve")
+	}
+	if nl.Pointer != entity.Pointer("nl") {
+		t.Errorf("a neighbor WITH a Dutch face must resolve to it; got pointer %q", nl.Pointer)
+	}
+	if got, _ := nl.Properties["title"].(string); got != "nederlandse titel" {
+		t.Errorf("FEAT-NL title = %q, want the Dutch face's title", got)
+	}
+	en, ok := heads["FEAT-EN"]
+	if !ok {
+		t.Fatal("FEAT-EN must resolve via the fallback, not vanish")
+	}
+	if en.Pointer != entity.Pointer("") {
+		t.Errorf("a neighbor with NO Dutch face must fall back to the default "+
+			"face PER LINK, not drag the whole page to English; got pointer %q",
+			en.Pointer)
+	}
+}
+
+// TestWorldNeighbors_ContentEdgesAreFaceSpecific pins the identity-vs-content
+// dispatch that worldreader.RelationReader.Neighbors performs, observed
+// through this package's seam.
+//
+// A CONTENT-scoped edge belongs to one face's tail, so the published face's
+// links must not include an edge stored on the draft tail. An IDENTITY-scoped
+// edge belongs to the entity and must be visible from EVERY face.
+//
+// Both halves are asserted together on purpose: a dispatch that returned
+// everything would pass the identity half alone, and one that returned only
+// the pointer-matched edges would pass the content half alone.
+func TestWorldNeighbors_ContentEdgesAreFaceSpecific(t *testing.T) {
+	app := withWorldNeighbors(t, newTestAppV1(t))
+	ctx := context.Background()
+
+	seedEntity(app, &entity.Entity{
+		ID: "TKT-1", Type: "ticket", Properties: map[string]any{"title": "draft"},
+	})
+	seedFace(t, app, "TKT-1", "ticket", "published", "published")
+	for _, id := range []string{"FEAT-IDENT", "FEAT-DRAFTCITE", "FEAT-PUBCITE"} {
+		seedEntity(app, &entity.Entity{
+			ID: id, Type: "feature", Properties: map[string]any{"title": id},
+		})
+		seedFace(t, app, id, "feature", "published", id+" published")
+	}
+
+	// An IDENTITY edge (implements): no tail, belongs to the entity.
+	if _, err := app.store.CreateRelation(ctx, "TKT-1", "implements", "FEAT-IDENT", nil); err != nil {
+		t.Fatalf("seed identity edge: %v", err)
+	}
+	// CONTENT edges (cites): one on the DRAFT tail, one on the PUBLISHED tail.
+	draftTail := entity.Pointer("")
+	pubTail := entity.Pointer("published")
+	if _, err := app.store.CreateRelation(ctx, "TKT-1", "cites", "FEAT-DRAFTCITE",
+		&store.RelationData{FromPointer: draftTail}); err != nil {
+		t.Fatalf("seed draft-tail content edge: %v", err)
+	}
+	if _, err := app.store.CreateRelation(ctx, "TKT-1", "cites", "FEAT-PUBCITE",
+		&store.RelationData{FromPointer: pubTail}); err != nil {
+		t.Fatalf("seed published-tail content edge: %v", err)
+	}
+
+	wctx := worldCtx(publishedScope("ticket", "feature"))
+	face, found, err := app.visibleReader.getVisible(wctx, "ticket", "TKT-1")
+	if err != nil || !found {
+		t.Fatalf("resolve entry: found=%v err=%v", found, err)
+	}
+	if face.Pointer != pubTail {
+		t.Fatalf("precondition: the entry must resolve to the PUBLISHED face, "+
+			"or the content-tail assertions below test the wrong tail; got %q", face.Pointer)
+	}
+	outgoing, _, err := worldOutgoingForEntity(wctx, app.worldNeighbors, app.visibleReader, face)
+	if err != nil {
+		t.Fatalf("worldOutgoingForEntity: %v", err)
+	}
+
+	got := map[string]bool{}
+	for _, edge := range outgoing {
+		got[edge.To] = true
+	}
+	if !got["FEAT-IDENT"] {
+		t.Errorf("an IDENTITY edge belongs to the entity and must be visible "+
+			"from every face, including a non-default one; got %v", got)
+	}
+	if !got["FEAT-PUBCITE"] {
+		t.Errorf("a CONTENT edge on the published tail must appear on the "+
+			"published face; got %v", got)
+	}
+	if got["FEAT-DRAFTCITE"] {
+		t.Errorf("a CONTENT edge on the DRAFT tail must NOT appear on the "+
+			"published face — that is the draft's citation, and showing it "+
+			"is the mixed-face bug; got %v", got)
+	}
+}
+
+// TestWorldNeighbors_WorldResolvesBeforeGate is the ORDERING test RULING 10
+// governs, and it is written to be mutation-sensitive in a specific way.
+//
+// # Why this ordering is a security property, not a preference
+//
+// Guard rule 1: world resolution must be PRINCIPAL-INDEPENDENT. If the ACL
+// gate ran first, the set of ids handed to the world would depend on what the
+// principal may read — so a neighbor's presence would confound two facts
+// ("no face in this world" and "you may not read it") in a way the caller
+// could pull apart by comparing across principals.
+//
+// # The injection point, and why it is this one
+//
+// The assertion is that the WORLD-RESOLUTION query sees the id of a neighbor
+// the principal cannot read. That is the only observation that distinguishes
+// the two orderings: under gate-first, that id is filtered out BEFORE
+// resolveHeads runs, so the query never sees it. Asserting only on the final
+// wire output would prove nothing — the neighbor is absent under BOTH
+// orderings (gated out either way), which is exactly the "passes trivially"
+// shape RULING 10 names.
+//
+// Mutation-checked: moving visibleWorldNeighbors ahead of resolveHeads in
+// worldOutgoingForEntity fails this test and no other.
+func TestWorldNeighbors_WorldResolvesBeforeGate(t *testing.T) {
+	app := withWorldNeighbors(t, newTestAppV1(t))
+	ctx := context.Background()
+
+	seedEntity(app, &entity.Entity{
+		ID: "TKT-1", Type: "ticket", Properties: map[string]any{"title": "entry"},
+	})
+	seedFace(t, app, "TKT-1", "ticket", "published", "published entry")
+	// FEAT-HIDDEN is published, so the WORLD resolves it happily; the ACL is
+	// what removes it. That separation is what the test turns on.
+	seedEntity(app, &entity.Entity{
+		ID: "FEAT-HIDDEN", Type: "feature", Properties: map[string]any{"title": "secret"},
+	})
+	seedFace(t, app, "FEAT-HIDDEN", "feature", "published", "published secret")
+	if _, err := app.store.CreateRelation(ctx, "TKT-1", "implements", "FEAT-HIDDEN", nil); err != nil {
+		t.Fatalf("seed edge: %v", err)
+	}
+
+	// A principal who may read tickets but NOT features.
+	d := mustNewACL(t, &acl.Policy{
+		Roles:       map[string]acl.RoleDef{"viewer": {Read: []string{"ticket"}}},
+		Assignments: map[string]string{"alice": "viewer"},
+	}, app.store)
+	req, rerr := d.ForPrincipal(principal.Principal{User: "alice", Tool: principal.ToolDataEntry})
+	if rerr != nil {
+		t.Fatalf("ForPrincipal: %v", rerr)
+	}
+	gate, gerr := newACLReadGate(req)
+	if gerr != nil {
+		t.Fatalf("newACLReadGate: %v", gerr)
+	}
+
+	// Observe the ids the WORLD resolution is asked about, by wrapping the
+	// store the neighbor seam reads through.
+	spy := &headSpyStore{Store: app.store}
+	app.worldNeighbors.store = spy
+
+	wctx := withWorld(withReadGate(aliceCtx(), gate),
+		worldHandle{name: "published", scope: publishedScope("ticket", "feature")})
+	face, found, err := app.visibleReader.getVisible(wctx, "ticket", "TKT-1")
+	if err != nil || !found {
+		t.Fatalf("resolve entry: found=%v err=%v", found, err)
+	}
+	outgoing, visible, err := worldOutgoingForEntity(wctx, app.worldNeighbors, app.visibleReader, face)
+	if err != nil {
+		t.Fatalf("worldOutgoingForEntity: %v", err)
+	}
+
+	// THE ordering assertion.
+	if !spy.asked("FEAT-HIDDEN") {
+		t.Errorf("the world must resolve a neighbor BEFORE the ACL gate sees "+
+			"it (guard rule 1: resolution is principal-independent). "+
+			"FEAT-HIDDEN never reached the world-resolution query, which "+
+			"means the gate ran first. Asked about: %v", spy.ids)
+	}
+	// And the gate still removes it — world-first must not widen anything.
+	if visible["FEAT-HIDDEN"] {
+		t.Error("resolving before the gate must not let a hidden neighbor " +
+			"through; the gate still decides what reaches the wire")
+	}
+	for _, edge := range outgoing {
+		if edge.To == "FEAT-HIDDEN" {
+			t.Error("a neighbor the principal may not read must be absent from the wire")
+		}
+	}
+}
+
+// headSpyStore records the ids passed to the world head-resolution query.
+// It wraps rather than replaces the store so every other read behaves
+// normally — a stub returning nothing would make the test pass for the wrong
+// reason.
+type headSpyStore struct {
+	store.Store
+	ids []string
+}
+
+func (s *headSpyStore) ListEntities(
+	ctx context.Context, q store.EntityQuery,
+) iter.Seq2[*entity.Entity, error] {
+	s.ids = append(s.ids, q.IDs...)
+	return s.Store.ListEntities(ctx, q)
+}
+
+func (s *headSpyStore) asked(id string) bool {
+	return slices.Contains(s.ids, id)
+}
+
+// TestWorldNeighbors_IncludeAgreesWithRelations pins the invariant RR-HJV8CP
+// established for the ACL gate, now that a SECOND filter (the world) can
+// remove a neighbor.
+//
+// `relations` and `included` must never disagree: a peer named in the
+// relations map must be resolvable in `included`, and a peer absent from
+// `included` must not be named. A world that filtered one but not the other
+// would reopen the leak from the other side — the relations map would carry
+// the raw id of an entity the response cannot show.
+func TestWorldNeighbors_IncludeAgreesWithRelations(t *testing.T) {
+	app := withWorldNeighbors(t, newTestAppV1(t))
+	ctx := context.Background()
+
+	seedEntity(app, &entity.Entity{
+		ID: "TKT-1", Type: "ticket", Properties: map[string]any{"title": "draft"},
+	})
+	seedFace(t, app, "TKT-1", "ticket", "published", "published")
+	seedEntity(app, &entity.Entity{
+		ID: "FEAT-PUB", Type: "feature", Properties: map[string]any{"title": "d"},
+	})
+	seedFace(t, app, "FEAT-PUB", "feature", "published", "published feature")
+	seedEntity(app, &entity.Entity{
+		ID: "FEAT-DRAFT", Type: "feature", Properties: map[string]any{"title": "unpublished"},
+	})
+	for _, to := range []string{"FEAT-PUB", "FEAT-DRAFT"} {
+		if _, err := app.store.CreateRelation(ctx, "TKT-1", "implements", to, nil); err != nil {
+			t.Fatalf("seed edge: %v", err)
+		}
+	}
+
+	wctx := worldCtx(publishedScope("ticket", "feature"))
+	face, found, err := app.visibleReader.getVisible(wctx, "ticket", "TKT-1")
+	if err != nil || !found {
+		t.Fatalf("resolve entry: found=%v err=%v", found, err)
+	}
+	outgoing, visible, err := worldOutgoingForEntity(wctx, app.worldNeighbors, app.visibleReader, face)
+	if err != nil {
+		t.Fatalf("worldOutgoingForEntity: %v", err)
+	}
+	wire := app.serializer.forWireScoped(wctx, face, outgoing, visible, app.Meta(), "tickets")
+	included := app.resolveV1Includes(wctx, face, "*")
+
+	for _, ids := range wire.Relations {
+		for _, id := range ids {
+			if _, ok := included[id]; !ok {
+				t.Errorf("relations names %q but included cannot resolve it — "+
+					"the two must agree (RR-HJV8CP, now across the world filter "+
+					"as well as the ACL one)", id)
+			}
+		}
+	}
+	if _, leaked := included["FEAT-DRAFT"]; leaked {
+		t.Error("a neighbor with no face in this world must not appear in included")
+	}
+	if len(included) == 0 {
+		t.Error("the published neighbor must be included — an empty map would " +
+			"satisfy the agreement check vacuously")
+	}
+}
+
+// TestWorldNeighbors_DefaultWorldUnchanged is the compat assertion: a
+// pointerless request must behave exactly as it did before item 4.
+//
+// Worth its own test because every change here is guarded by an
+// IsDefaultWorld() branch, and a branch written the wrong way round would
+// send ordinary traffic through the world path — where a zero WorldScope
+// resolves everything to its default face and would LOOK correct while
+// taking a different route with different error handling.
+func TestWorldNeighbors_DefaultWorldUnchanged(t *testing.T) {
+	app := withWorldNeighbors(t, newTestAppV1(t))
+	ctx := context.Background()
+
+	seedEntity(app, &entity.Entity{
+		ID: "TKT-1", Type: "ticket", Properties: map[string]any{"title": "t"},
+	})
+	seedEntity(app, &entity.Entity{
+		ID: "FEAT-1", Type: "feature", Properties: map[string]any{"title": "f"},
+	})
+	if _, err := app.store.CreateRelation(ctx, "TKT-1", "implements", "FEAT-1", nil); err != nil {
+		t.Fatalf("seed edge: %v", err)
+	}
+
+	// No world on the context at all — the zero handle, i.e. the default world.
+	e, found, err := app.visibleReader.getVisible(ctx, "ticket", "TKT-1")
+	if err != nil || !found {
+		t.Fatalf("get: found=%v err=%v", found, err)
+	}
+	outgoing := app.reader.outgoingRelations(ctx, e.ID)
+	wire := app.serializer.forWire(ctx, e, outgoing, app.Meta(), "tickets")
+	if got := wire.Relations["implements"]; len(got) != 1 || got[0] != "FEAT-1" {
+		t.Errorf("the default world must carry relations exactly as before; got %v", got)
+	}
+	if included := app.resolveV1Includes(ctx, e, "*"); len(included) != 1 {
+		t.Errorf("the default world's include block is unchanged; got %d entries", len(included))
+	}
+}
+
+// TestParseIncludeSpec covers the expression parser the two collection paths
+// share, including the duplicate-type rule that preserves the pre-refactor
+// first-wins order.
+func TestParseIncludeSpec(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name       string
+		in         string
+		wantAll    bool
+		wantWanted map[string]string
+	}{
+		{"star", "*", true, nil},
+		{"star with spaces", " * ", true, nil},
+		{"single", "implements", false, map[string]string{"implements": ""}},
+		{"nested", "implements.requires", false, map[string]string{"implements": "requires"}},
+		{"several", "a,b", false, map[string]string{"a": "", "b": ""}},
+		{"spaces trimmed", " a , b ", false, map[string]string{"a": "", "b": ""}},
+		{"empty parts skipped", "a,,b", false, map[string]string{"a": "", "b": ""}},
+		{"deep nesting keeps remainder", "a.b.c", false, map[string]string{"a": "b.c"}},
+		// First wins, matching the pre-refactor loop order.
+		{"duplicate keeps first", "a.b,a.c", false, map[string]string{"a": "b"}},
+		// A trailing dot records NO nesting. The pre-refactor loop recorded an
+		// empty one and recursed once for nothing; see parseIncludeSpec.
+		{"trailing dot is not nesting", "a.", false, map[string]string{"a": ""}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			wanted, all := parseIncludeSpec(tc.in)
+			if all != tc.wantAll {
+				t.Fatalf("all = %v, want %v", all, tc.wantAll)
+			}
+			if all {
+				return
+			}
+			if len(wanted) != len(tc.wantWanted) {
+				t.Fatalf("wanted = %v, want %v", wanted, tc.wantWanted)
+			}
+			for k, v := range tc.wantWanted {
+				if wanted[k] != v {
+					t.Errorf("wanted[%q] = %q, want %q", k, wanted[k], v)
+				}
+			}
+		})
+	}
+}
+
+// TestHeadIDsOf_SkipsSelfAndDedupes covers the id collector, including the
+// self-reference case that DirectionBoth makes reachable.
+func TestHeadIDsOf_SkipsSelfAndDedupes(t *testing.T) {
+	t.Parallel()
+	edges := []*entity.Relation{
+		{From: "TKT-1", Type: "implements", To: "FEAT-1"},
+		{From: "TKT-1", Type: "blocks", To: "FEAT-1"}, // duplicate head
+		{From: "TKT-2", Type: "blocks", To: "TKT-1"},  // incoming: peer is From
+		{From: "TKT-1", Type: "blocks", To: "TKT-1"},  // self-edge: no peer
+	}
+	got := headIDsOf(edges, "TKT-1")
+	want := map[string]bool{"FEAT-1": true, "TKT-2": true}
+	if len(got) != len(want) {
+		t.Fatalf("headIDsOf = %v, want exactly %v", got, want)
+	}
+	for _, id := range got {
+		if !want[id] {
+			t.Errorf("unexpected id %q", id)
+		}
+	}
+}
+
+// TestWorldEdgesForWire_DropsUnresolvedAndHidden pins that BOTH conditions
+// are required, and that they are indistinguishable on the wire.
+//
+// A table rather than one case because the interesting content is the
+// combination: resolved-but-hidden and hidden-but-resolved must both drop,
+// and a single-case test would pin only whichever the author thought of.
+func TestWorldEdgesForWire_DropsUnresolvedAndHidden(t *testing.T) {
+	t.Parallel()
+	edge := func(to string) *entity.Relation {
+		return &entity.Relation{From: "TKT-1", Type: "implements", To: to}
+	}
+	tests := []struct {
+		name     string
+		resolved bool
+		visible  bool
+		wantKept bool
+	}{
+		{"resolved and visible", true, true, true},
+		{"resolved but hidden", true, false, false},
+		{"visible but unresolved in this world", false, true, false},
+		{"neither", false, false, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			heads := map[string]*entity.Entity{}
+			if tc.resolved {
+				heads["FEAT-1"] = &entity.Entity{ID: "FEAT-1", Type: "feature"}
+			}
+			visible := map[string]bool{"FEAT-1": tc.visible}
+			out, in := worldEdgesForWire([]*entity.Relation{edge("FEAT-1")}, "TKT-1", heads, visible)
+			if len(in) != 0 {
+				t.Errorf("an edge FROM the entry is outgoing, not incoming; got %d", len(in))
+			}
+			if got := len(out) == 1; got != tc.wantKept {
+				t.Errorf("kept = %v, want %v", got, tc.wantKept)
+			}
+		})
+	}
+}
+
+// TestResolvedFromStoreFace_CarriesPointer pins the one field Neighbors
+// actually consults.
+//
+// Pointer is the content-edge tail. If it were dropped (or defaulted to the
+// zero pointer), a published face would query the DEFAULT tail — and per the
+// "fallback trap" in worldreader.RelationReader.Neighbors, the zero pointer
+// as a FromPointer value is not "unfiltered", it is "default-tail only". So
+// the failure would be a published face silently showing the draft's content
+// edges: wrong, and quiet.
+func TestResolvedFromStoreFace_CarriesPointer(t *testing.T) {
+	t.Parallel()
+	scope := publishedScope("ticket")
+	ctx := withWorld(context.Background(), worldHandle{name: "published", scope: scope})
+	e := &entity.Entity{ID: "TKT-1", Type: "ticket", Pointer: entity.Pointer("published")}
+
+	res := resolvedFromStoreFace(ctx, e)
+	if res.Pointer != entity.Pointer("published") {
+		t.Errorf("Pointer = %q, want the coordinate the face was stored at — "+
+			"it is the content-edge tail Neighbors queries", res.Pointer)
+	}
+	if !res.Found || res.Entity != e {
+		t.Error("a face the store returned is Found, carrying that entity")
+	}
+	if res.Via != worldreader.RuleChain {
+		t.Errorf("Via = %v, want chain: `published` is in this world's chain", res.Via)
+	}
+}
+
+// TestRuleFromName_MatchesWireVocabulary pins that the two vocabularies stay
+// in step. They are separate constants in separate packages, so nothing but a
+// test stops them drifting — and a drift would mislabel provenance rather
+// than fail, which is the quiet kind.
+func TestRuleFromName_MatchesWireVocabulary(t *testing.T) {
+	t.Parallel()
+	cases := map[string]worldreader.Rule{
+		ruleUnscoped:        worldreader.RuleUnscoped,
+		ruleChain:           worldreader.RuleChain,
+		ruleFallbackDefault: worldreader.RuleFallbackDefault,
+	}
+	for name, want := range cases {
+		if got := ruleFromName(name); got != want {
+			t.Errorf("ruleFromName(%q) = %v, want %v", name, got, want)
+		}
+		if want.String() != name {
+			t.Errorf("worldreader.Rule %v stringifies as %q but the wire "+
+				"constant is %q — the two vocabularies must match",
+				want, want.String(), name)
+		}
+	}
+}
+
+// TestIncludeTrailingDot_MatchesPreRefactorOutput pins the one place this
+// refactor diverges from the loop it replaced.
+//
+// `include=implements.` used to record an EMPTY nested expression and recurse
+// once; it now records no nesting and does not recurse. The claim is that the
+// `included` map is identical either way — the old recursion split "" into a
+// single empty part and skipped it, so it contributed nothing. A comment
+// asserting that would be a claim; this checks it, by comparing the trailing-
+// dot form against the plain form that has always been equivalent.
+func TestIncludeTrailingDot_MatchesPreRefactorOutput(t *testing.T) {
+	app := withWorldNeighbors(t, newTestAppV1(t))
+	ctx := context.Background()
+
+	seedEntity(app, &entity.Entity{
+		ID: "TKT-1", Type: "ticket", Properties: map[string]any{"title": "t"},
+	})
+	seedEntity(app, &entity.Entity{
+		ID: "FEAT-1", Type: "feature", Properties: map[string]any{"title": "f"},
+	})
+	if _, err := app.store.CreateRelation(ctx, "TKT-1", "implements", "FEAT-1", nil); err != nil {
+		t.Fatalf("seed edge: %v", err)
+	}
+	e, found, err := app.visibleReader.getVisible(ctx, "ticket", "TKT-1")
+	if err != nil || !found {
+		t.Fatalf("get: found=%v err=%v", found, err)
+	}
+
+	plain := app.resolveV1Includes(ctx, e, "implements")
+	dotted := app.resolveV1Includes(ctx, e, "implements.")
+	if len(plain) != len(dotted) {
+		t.Fatalf("a trailing dot must not change the included set: "+
+			"plain=%d dotted=%d", len(plain), len(dotted))
+	}
+	for id := range plain {
+		if _, ok := dotted[id]; !ok {
+			t.Errorf("included %q present without the trailing dot, absent with it", id)
+		}
+	}
+	if len(plain) != 1 {
+		t.Fatalf("precondition: the plain form must include exactly the one "+
+			"neighbor, or this proves nothing; got %d", len(plain))
+	}
+}
+
+// TestWorldETag_ReflectsWorldResolvedEdges pins that the cache validator
+// describes the document actually served.
+//
+// Before TKT-WRLDAPI item 4 a world-bound response carried no relations, so
+// computeEntityETag folded no edges under a world and that was correct. Item 4
+// made those responses carry world-resolved links WITHOUT updating the ETag,
+// which meant an edge change under a world did not move the validator — a
+// stale 304 on a response whose links had changed. This is the regression
+// test for that.
+//
+// # Why it asserts a DIFFERENCE rather than a specific hash
+//
+// Pinning a literal hash would break on any unrelated hashing change and
+// prove nothing about the property. The property is "changing a world-visible
+// edge changes the validator", so the test changes one and compares.
+//
+// Mutation-checked (RULING 10): reverting the world arm to fold no edges
+// makes both hashes identical and fails this test. A test that only checked
+// "the ETag is non-empty" would have passed against that.
+func TestWorldETag_ReflectsWorldResolvedEdges(t *testing.T) {
+	app := withWorldNeighbors(t, newTestAppV1(t))
+	ctx := context.Background()
+
+	seedEntity(app, &entity.Entity{
+		ID: "TKT-1", Type: "ticket", Properties: map[string]any{"title": "draft"},
+	})
+	seedFace(t, app, "TKT-1", "ticket", "published", "published")
+	seedEntity(app, &entity.Entity{
+		ID: "FEAT-1", Type: "feature", Properties: map[string]any{"title": "f"},
+	})
+	seedFace(t, app, "FEAT-1", "feature", "published", "published f")
+
+	wctx := worldCtx(publishedScope("ticket", "feature"))
+	face, found, err := app.visibleReader.getVisible(wctx, "ticket", "TKT-1")
+	if err != nil || !found {
+		t.Fatalf("resolve entry: found=%v err=%v", found, err)
+	}
+
+	before := app.computeEntityETag(wctx, face)
+
+	// Add an edge that IS visible in this world (both endpoints published).
+	if _, err := app.store.CreateRelation(ctx, "TKT-1", "implements", "FEAT-1", nil); err != nil {
+		t.Fatalf("seed edge: %v", err)
+	}
+	after := app.computeEntityETag(wctx, face)
+
+	if before == after {
+		t.Error("adding a world-visible edge must change the ETag — otherwise " +
+			"a client holding the old validator gets a 304 for a response " +
+			"whose relations map has changed")
+	}
+}
+
+// TestWorldETag_DoesNotFoldDefaultWorldEdges is the mirror half: a world-bound
+// validator must not be moved by an edge that is invisible in that world.
+//
+// Both halves are needed. Folding the DEFAULT-world reader under a world would
+// pass the test above (any edge moves the hash) while being wrong in the other
+// direction: publishing a face would not invalidate the validator, and an
+// unrelated draft-only edit would.
+func TestWorldETag_DoesNotFoldDefaultWorldEdges(t *testing.T) {
+	app := withWorldNeighbors(t, newTestAppV1(t))
+	ctx := context.Background()
+
+	seedEntity(app, &entity.Entity{
+		ID: "TKT-1", Type: "ticket", Properties: map[string]any{"title": "draft"},
+	})
+	seedFace(t, app, "TKT-1", "ticket", "published", "published")
+	// FEAT-DRAFT has NO published face, so an edge to it is invisible in the
+	// published world.
+	seedEntity(app, &entity.Entity{
+		ID: "FEAT-DRAFT", Type: "feature", Properties: map[string]any{"title": "unpublished"},
+	})
+
+	wctx := worldCtx(publishedScope("ticket", "feature"))
+	face, found, err := app.visibleReader.getVisible(wctx, "ticket", "TKT-1")
+	if err != nil || !found {
+		t.Fatalf("resolve entry: found=%v err=%v", found, err)
+	}
+
+	before := app.computeEntityETag(wctx, face)
+	if _, err := app.store.CreateRelation(ctx, "TKT-1", "implements", "FEAT-DRAFT", nil); err != nil {
+		t.Fatalf("seed edge: %v", err)
+	}
+	after := app.computeEntityETag(wctx, face)
+
+	if before != after {
+		t.Error("an edge INVISIBLE in this world must not move the world's " +
+			"ETag — folding default-world edges into a published validator " +
+			"means a draft-only edit invalidates a published cache entry, " +
+			"and publishing a face does not")
+	}
+}

--- a/internal/dataentry/worldneighbors_test.go
+++ b/internal/dataentry/worldneighbors_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/Sourcehaven-BV/rela/internal/acl"
+	v1 "github.com/Sourcehaven-BV/rela/internal/apiwire/v1"
 	"github.com/Sourcehaven-BV/rela/internal/entity"
 	"github.com/Sourcehaven-BV/rela/internal/metamodel"
 	"github.com/Sourcehaven-BV/rela/internal/principal"
@@ -513,15 +514,19 @@ func TestParseIncludeSpec(t *testing.T) {
 		wantWanted map[string]string
 	}{
 		{"star", "*", true, nil},
-		{"star with spaces", " * ", true, nil},
+		// NOT the star form: the pre-refactor code compared the RAW string, so
+		// a padded star fell through to the named branch and matched nothing.
+		// Trimming here would widen the default world on a stray space.
+		{"padded star is not the star form", " * ", false, map[string]string{"*": ""}},
 		{"single", "implements", false, map[string]string{"implements": ""}},
 		{"nested", "implements.requires", false, map[string]string{"implements": "requires"}},
 		{"several", "a,b", false, map[string]string{"a": "", "b": ""}},
 		{"spaces trimmed", " a , b ", false, map[string]string{"a": "", "b": ""}},
 		{"empty parts skipped", "a,,b", false, map[string]string{"a": "", "b": ""}},
 		{"deep nesting keeps remainder", "a.b.c", false, map[string]string{"a": "b.c"}},
-		// First wins, matching the pre-refactor loop order.
-		{"duplicate keeps first", "a.b,a.c", false, map[string]string{"a": "b"}},
+		// LAST wins: the pre-refactor inner loop wrote nestedFor
+		// unconditionally per pass, so a later clause overwrote an earlier one.
+		{"duplicate keeps last", "a.b,a.c", false, map[string]string{"a": "c"}},
 		// A trailing dot records NO nesting. The pre-refactor loop recorded an
 		// empty one and recursed once for nothing; see parseIncludeSpec.
 		{"trailing dot is not nesting", "a.", false, map[string]string{"a": ""}},
@@ -797,5 +802,241 @@ func TestWorldETag_DoesNotFoldDefaultWorldEdges(t *testing.T) {
 			"ETag — folding default-world edges into a published validator " +
 			"means a draft-only edit invalidates a published cache entry, " +
 			"and publishing a face does not")
+	}
+}
+
+// TestWorldNeighbors_SelfEdgeSurvives is the regression test for a real bug
+// found in code review: a self-referential edge present in the default world
+// VANISHED under every non-default world.
+//
+// # The mechanism, because it is not obvious
+//
+// headIDsOf deliberately omits selfID — there is nothing to look up, the
+// entry's face is already in hand. But `heads` doubles as the consumer's test
+// for "does this world resolve that link", so an unseeded self id read as
+// EXCLUDED and worldEdgesForWire dropped the edge. Two functions disagreed
+// about what an absent key meant.
+//
+// `blocks: ticket -> ticket` is in the shared fixture, and self-edges are an
+// ordinary shape (dependency, supersedes, related-to), so this was silent data
+// loss on real graphs — not a theoretical corner.
+//
+// # Why it asserts default-vs-world PARITY
+//
+// Asserting only "the world shows the self-edge" would pass against a build
+// that showed it in neither. The property is that the world does not LOSE a
+// link the default world shows, so both are read and compared.
+//
+// Mutation-checked: removing the `heads[res.Entity.ID] = res.Entity` seeding
+// in worldScopedNeighbors fails this; removing the per-row seeding in
+// worldNeighborsForPage fails the list half below.
+func TestWorldNeighbors_SelfEdgeSurvives(t *testing.T) {
+	app := withWorldNeighbors(t, newTestAppV1(t))
+	ctx := context.Background()
+
+	seedEntity(app, &entity.Entity{
+		ID: "TKT-1", Type: "ticket", Properties: map[string]any{"title": "draft"},
+	})
+	seedFace(t, app, "TKT-1", "ticket", "published", "published")
+	if _, err := app.store.CreateRelation(ctx, "TKT-1", "blocks", "TKT-1", nil); err != nil {
+		t.Fatalf("seed self edge: %v", err)
+	}
+
+	// Default world: the baseline this must not regress from.
+	e, found, err := app.visibleReader.getVisible(ctx, "ticket", "TKT-1")
+	if err != nil || !found {
+		t.Fatalf("default get: found=%v err=%v", found, err)
+	}
+	def := app.serializer.forWire(ctx, e, app.reader.outgoingRelations(ctx, e.ID), app.Meta(), "tickets")
+	if got := def.Relations["blocks"]; len(got) != 1 || got[0] != "TKT-1" {
+		t.Fatalf("precondition: the default world must show the self-edge, "+
+			"or this test proves nothing; got %v", def.Relations)
+	}
+
+	// Single-entity GET under a world.
+	wctx := worldCtx(publishedScope("ticket"))
+	face, found, err := app.visibleReader.getVisible(wctx, "ticket", "TKT-1")
+	if err != nil || !found {
+		t.Fatalf("world get: found=%v err=%v", found, err)
+	}
+	out, vis, err := worldOutgoingForEntity(wctx, app.worldNeighbors, app.visibleReader, face)
+	if err != nil {
+		t.Fatalf("worldOutgoingForEntity: %v", err)
+	}
+	wire := app.serializer.forWireScoped(wctx, face, out, vis, app.Meta(), "tickets")
+	if got := wire.Relations["blocks"]; len(got) != 1 || got[0] != "TKT-1" {
+		t.Errorf("a self-edge must survive world resolution — the entry IS its "+
+			"own head and is already resolved; got %v", wire.Relations)
+	}
+
+	// The LIST path batches across rows and does its own seeding, so it needs
+	// its own assertion rather than inheriting this one.
+	outRows, _, visRows, err := worldNeighborsForPage(
+		wctx, app.worldNeighbors, app.visibleReader, []*entity.Entity{face})
+	if err != nil {
+		t.Fatalf("worldNeighborsForPage: %v", err)
+	}
+	if len(outRows[0]) != 1 {
+		t.Errorf("the list path must keep the self-edge too; got %d edges", len(outRows[0]))
+	}
+	if !visRows["TKT-1"] {
+		t.Error("the entry's own id must be in the visible set — it passed the " +
+			"gate to be in the page at all")
+	}
+
+	// And the include block must agree with the relations map.
+	included := app.resolveV1Includes(wctx, face, "*")
+	if _, ok := included["TKT-1"]; !ok {
+		t.Error("include=* must resolve the self-edge peer, or `included` and " +
+			"`relations` disagree (the RR-HJV8CP invariant)")
+	}
+}
+
+// TestIncludeSpec_DefaultWorldParityWithPreRefactor pins the two default-world
+// behaviors that the parseIncludeSpec extraction changed and code review
+// caught.
+//
+// Both were silent widenings/reorderings of the DEFAULT world — the branch this
+// PR claimed was byte-identical. The claim was false, and asserting it in a
+// comment while a five-line test falsified it is worse than not claiming it. So
+// the behaviors are now asserted rather than described.
+//
+// Expected values were taken by RUNNING the pre-refactor code on this exact
+// graph, not by reading it. The duplicate-nesting rule in particular reads the
+// opposite way round in the source: the old inner loop looks like it sets
+// nesting once per clause, but it runs per matching EDGE and writes
+// unconditionally, so the last clause wins.
+func TestIncludeSpec_DefaultWorldParityWithPreRefactor(t *testing.T) {
+	app := withWorldNeighbors(t, newTestAppV1(t))
+	ctx := context.Background()
+
+	// TKT-1 -blocks-> TKT-2 -blocks-> TKT-3, and TKT-2 -implements-> FEAT-1.
+	for _, id := range []string{"TKT-1", "TKT-2", "TKT-3"} {
+		seedEntity(app, &entity.Entity{
+			ID: id, Type: "ticket", Properties: map[string]any{"title": id},
+		})
+	}
+	seedEntity(app, &entity.Entity{
+		ID: "FEAT-1", Type: "feature", Properties: map[string]any{"title": "f"},
+	})
+	for _, e := range []struct{ from, typ, to string }{
+		{"TKT-1", "blocks", "TKT-2"},
+		{"TKT-2", "blocks", "TKT-3"},
+		{"TKT-2", "implements", "FEAT-1"},
+	} {
+		if _, err := app.store.CreateRelation(ctx, e.from, e.typ, e.to, nil); err != nil {
+			t.Fatalf("seed %s-%s->%s: %v", e.from, e.typ, e.to, err)
+		}
+	}
+	entry, found, err := app.visibleReader.getVisible(ctx, "ticket", "TKT-1")
+	if err != nil || !found {
+		t.Fatalf("get: found=%v err=%v", found, err)
+	}
+
+	ids := func(m map[string]v1.Entity) []string {
+		out := make([]string, 0, len(m))
+		for id := range m {
+			out = append(out, id)
+		}
+		slices.Sort(out)
+		return out
+	}
+
+	t.Run("duplicate relation type keeps the LAST nesting", func(t *testing.T) {
+		// Pre-refactor output on this graph, MEASURED by running PR-B rather
+		// than read off the source: [FEAT-1 TKT-2]. The ".implements" clause
+		// is the later duplicate, so it wins and the recursion follows
+		// implements from TKT-2, yielding FEAT-1.
+		got := ids(app.resolveV1Includes(ctx, entry, "blocks.blocks,blocks.implements"))
+		want := []string{"FEAT-1", "TKT-2"}
+		if !slices.Equal(got, want) {
+			t.Errorf("include=blocks.blocks,blocks.implements = %v, want %v "+
+				"(last duplicate wins, as the pre-refactor loop did)", got, want)
+		}
+	})
+
+	t.Run("padded star does not expand", func(t *testing.T) {
+		// Pre-refactor output: empty. `includes == "*"` was a RAW comparison,
+		// so " * " took the named branch and matched no relation type.
+		if got := ids(app.resolveV1Includes(ctx, entry, " * ")); len(got) != 0 {
+			t.Errorf("include=%q must not expand — trimming it into the star "+
+				"form widens the default world on a stray space; got %v", " * ", got)
+		}
+		// The unpadded form still works, so the test above is not passing
+		// because expansion is broken generally.
+		if got := ids(app.resolveV1Includes(ctx, entry, "*")); len(got) == 0 {
+			t.Error("precondition: the bare star must still expand")
+		}
+	})
+}
+
+// TestWorldETag_ResolutionFaultDoesNotForgeAValidValidator pins the failure
+// mode code review found: an ETag computed during a resolution fault must not
+// equal the ETag of a legitimately edge-less entity.
+//
+// # Why "swallow the error and hash zero edges" was wrong
+//
+// The hash of an edge-less entity is a perfectly VALID validator for a real
+// document state. So swallowing the fault does not merely weaken the ETag — it
+// mints one that a later If-None-Match matches, winning a 304 against a body
+// that does have edges. That is an infrastructure failure wearing the costume
+// of a correct answer, which this codebase has a named rule against
+// (RR-4TFZNL).
+//
+// The fix folds a sentinel, so a fault produces a validator that matches
+// nothing: a MISSED 304, which is the harmless direction.
+func TestWorldETag_ResolutionFaultDoesNotForgeAValidValidator(t *testing.T) {
+	app := withWorldNeighbors(t, newTestAppV1(t))
+
+	seedEntity(app, &entity.Entity{
+		ID: "TKT-1", Type: "ticket", Properties: map[string]any{"title": "draft"},
+	})
+	seedFace(t, app, "TKT-1", "ticket", "published", "published")
+
+	wctx := worldCtx(publishedScope("ticket", "feature"))
+	face, found, err := app.visibleReader.getVisible(wctx, "ticket", "TKT-1")
+	if err != nil || !found {
+		t.Fatalf("resolve entry: found=%v err=%v", found, err)
+	}
+
+	// The validator for a genuinely edge-less entity.
+	edgeless := entityETagWithEdges(wctx, face, nil)
+	// The validator produced when edges could not be resolved.
+	faulted := etagUnresolved(wctx, face)
+
+	if edgeless == faulted {
+		t.Error("a resolution fault must not produce the SAME validator as a " +
+			"genuinely edge-less entity — that value is valid for a real " +
+			"document state, so a later If-None-Match would win a 304 " +
+			"against a body that does have edges")
+	}
+}
+
+// TestWorldETag_UsesTheEdgesItIsGiven pins that the validator is derived from
+// the caller's edges rather than re-read.
+//
+// This is what keeps the ETag describing the same document as the body: the
+// GET computes the edges once and hands the same slice to both. It also
+// removes a per-request duplicate head-resolution query and ACL pass under a
+// world (the RR-FRK1 shape).
+func TestWorldETag_UsesTheEdgesItIsGiven(t *testing.T) {
+	app := withWorldNeighbors(t, newTestAppV1(t))
+	ctx := context.Background()
+
+	seedEntity(app, &entity.Entity{
+		ID: "TKT-1", Type: "ticket", Properties: map[string]any{"title": "t"},
+	})
+	e, found, err := app.visibleReader.getVisible(ctx, "ticket", "TKT-1")
+	if err != nil || !found {
+		t.Fatalf("get: found=%v err=%v", found, err)
+	}
+
+	none := entityETagWithEdges(ctx, e, nil)
+	one := entityETagWithEdges(ctx, e, []*entity.Relation{
+		{From: "TKT-1", Type: "implements", To: "FEAT-1"},
+	})
+	if none == one {
+		t.Error("the supplied edges must reach the hash — otherwise the " +
+			"validator does not describe the body it was computed for")
 	}
 }


### PR DESCRIPTION
🌍 World-capable detail read, including relations (TKT-WRLDAPI item 4)

Tickets-PR: #1422

Implements RULING 12: **relations resolve through the SAME world as the entry, per neighbour, independently.** An ISMS `published` view links to published faces; a linked control with no published face is absent under `otherwise: exclude`. A preview world with chain `[draft, published]` links to drafts where drafts exist. A Spanish page links to Spanish where Spanish exists and English where it does not — per-link fallback, not per-page.

## What changed

Two gaps closed on the world-capable routes (`/{plural}` and `/{plural}/{id}`):

1. **Relations are no longer dropped** under a non-default world. They were emitted as nothing, because the only relation reader on these handlers was the ungated, default-world `entityReader`.
2. **`?include=` is no longer refused** (422 `world_include_unsupported`). Included peers are now this world's faces of the neighbours.

New seam: `internal/dataentry/worldneighbors.go`.

## Design notes

**Resolving a link is TWO reads, not one.** `worldreader.RelationReader.Neighbors` gives the entry face's *edges* — it performs the identity-vs-content scope dispatch, which is why it is used rather than reimplemented. But per design §2.3 heads are **entity-level** (an edge points at `SPEC-9`, never `SPEC-9@published`), so resolving each head through the world is a second, batched read. Without it, a published view emits a link to a control with no published face: a link pointing at a 404, which is the exact case RULING 12 says must be absent.

**Ordering is world → gate, and it is load-bearing.** Guard rule 1: resolution must be principal-independent. Gate-first would make the served result set depend on what the ACL denied. Pinned by `TestWorldNeighbors_WorldResolvesBeforeGate`, whose assertion is that the *world-resolution query sees* the id of a neighbour the principal cannot read — the only observation that distinguishes the two orderings (asserting on the wire output would pass under both).

**Two resolution mechanisms, neither duplicated.** Relation *dispatch* goes through `worldreader.RelationReader` (an arch-lint edge was added for this, with a comment saying why); entity *resolution* stays on the existing `store.EntityQuery.World` path that `visibleReader.getWorldEntity` uses. These are the two mechanisms `worldreader`'s own package doc names.

**Per-neighbour provenance is deliberately sited on item 4b, not missing here** (Rulings 13 and 14).

No information is lost by omitting it. Neighbours *are* resolved through the world, so a client that wants a specific link's provenance fetches that entity through the same world and gets it:

```
GET /blog-posts/POST-2?world=site-nl
  -> _world {name: site-nl, pointer: "", via: fallback-default}
```

The capability is **composable**, not merely deferred: it costs one request per link a client actually inspects, instead of inflating every list response with provenance for links nobody looks at.

It belongs on 4b because that is where the wire has a slot for it:

| Surface | Neighbour on the wire | Provenance slot |
|---|---|---|
| entity GET `relations` (this PR) | bare **ID string** (`map[string][]string`) | none — adding one is a wire-type change |
| `_views` `Collections` (item 4b) | **whole entity** (`viewResult.Collections`, `views.go:16`) | natural — the same additive `_world` field `forWire` consumers already handle |

**The existence-oracle argument is explicitly NOT the rationale.** I raised it while recommending the deferral and then argued it down: per-neighbour `Via` would disclose which faces exist for ids the caller can already see, which is not the entity-existence secret the row gate protects. It is recorded here so nobody later cites safety as the reason and builds on a property that was never the basis for the decision.

## Mutation checks (RULING 10)

Every load-bearing test was mutated and confirmed to die:

| Mutation | Test that failed |
|---|---|
| Drop `World:` from head resolution | `ExcludedHeadIsAbsent`, `PerLinkFallback`, `IncludeAgreesWithRelations` |
| Gate before world | `WorldResolvesBeforeGate` (only this one) |
| Zero the content-edge tail | `ContentEdgesAreFaceSpecific`, `ResolvedFromStoreFace_CarriesPointer` |
| Remove world check from `defaultWorldCandidates` | `TestWorldCapableRoutesDoNotUseUngatedReader` |
| Fold no edges into a world ETag | `WorldETag_ReflectsWorldResolvedEdges` |
| Fold default-world edges into a world ETag | `WorldETag_DoesNotFoldDefaultWorldEdges` |

All mutations were re-verified against the final committed tree with **build-aware counting**: a mutant that fails to compile is now reported as `BUILD-BROKEN` from an observed non-zero build exit, never scored as a test result.

The harness previously counted with `grep -c '^--- FAIL'`, which cannot distinguish *"the mutant survived"* from *"nothing ran"* — a non-compiling mutant scores identically to a surviving implementation. Same class as the false-green CI runs below: a check whose failure mode is silence, counted as success.

**One mutation exposed a test that proved nothing**, and it is recorded in the code: deleting the `heads` lookup in `headOnWire` leaves everything green, because the visible set is *built from* heads. That check is defence in depth; the mechanism is the world scope on the head-resolution query. Both facts are now in the godoc so the next reader looks in the right place.

**A real bug was found while reviewing this diff**: `computeEntityETag` skipped edge-folding under a world, with a comment justifying it by "world-bound responses carry NO relations". True before this PR, false after it — an edge change under a world would not have moved the validator, serving a stale 304. Fixed, with tests in both directions.

## Second commit: code-review findings

`/code-review` found one **critical** bug and several real defects. All addressed.

**Self-edges vanished under every non-default world.** `TKT-1 --blocks--> TKT-1` with a published face returned `{"blocks":["TKT-1"]}` in the default world and `{}` under `?world=published`. `headIDsOf` omits `selfID` (nothing to look up), but `heads` also serves as the "does this world resolve it" test, so an unseeded self id read as *excluded*. Two functions disagreed about what an absent key meant. Fixed by seeding the entry's own face at **both** resolution sites (the page path batches across rows, so it could not inherit the fix); each site independently mutation-checked.

`blocks: ticket -> ticket` is in the repo's own test fixture — this was silent data loss on an ordinary shape, not a corner case.

**`parseIncludeSpec` silently changed two default-world behaviours**, falsifying this PR's "byte-identical" claim:
- a duplicate relation type kept the *first* nesting; the pre-refactor loop wrote unconditionally per matching edge, so the **last** wins. My comment asserted the opposite of both the old code and my new code.
- `" * "` (padded) expanded to a full include with incoming peers, where the old raw `includes == "*"` comparison produced an empty block — a default-world widening triggered by whitespace.

Both reverted to measured pre-refactor behaviour and pinned by a parity test whose expected values were obtained by **running PR-B**, not by reading it. (Worth recording: the review's own reproduction table had these two columns swapped, so taking it at face value would have moved the code away from correct. Measuring settled it.)

**`computeEntityETag`, two more defects.** It re-derived edges the GET was still holding — measured at 2 head-resolutions + 4 relation queries + 2 ACL passes per world GET, now **1** — and it swallowed resolution faults into the hash of an edge-less entity. That value is a *valid validator for a real document state*, so a fault minted an ETag a later `If-None-Match` would match, winning a 304 against a body that does have edges. A fault now folds a sentinel that matches nothing.

**Minor:** one named predicate (`worldBoundRelations`) for all relation branches — a `denied` handle carries a zero scope, so `worldScopeFrom(ctx).IsDefaultWorld()` and `handle.isDefault()` disagree for exactly that input (latent, not live). `peerOf` returns `""` for an edge naming neither endpoint, matching `worldEdgesForWire` rather than silently admitting a third party.

## Live verification against `/tmp/isms-demo`

The demo had **zero relations and no relation types**, so there was nothing to test RULING 12 against. Extended it (permanently) with a `control` type, an identity-scoped `owned-by`, a content-scoped `implements`, and a `preview` world — including the case that must vanish, a policy linking to a control with no published face.

```
world=published : implements → [CTL-1]        owned-by → [CTL-1]
world=preview   : implements → [CTL-2]        owned-by → [CTL-1]
```

`CTL-2` (no published face) is absent under `published` and present under `preview`; the identity edge is constant across faces while the content edge changes. `?include=*` returns the world's faces ("MFA enforcement" vs "MFA enforcement (draft)"). Search, `_views`, sub-resources and writes are still refused (422), as intended.

## Known cost: edge queries are per row

Head resolution and ACL gating are batched once per page, but the **edge** queries are not: `worldreader.RelationReader.Neighbors` issues two per entity (identity-tail and content-tail), so a 50-row page costs 100 relation queries. Not a regression — the default-world path also queries per row — but not an improvement either.

It is not batchable as things stand: the content-tail query filters on each row's **own resolved pointer**, so fifty rows can carry fifty different tails, and `store.RelationQuery` has no multi-endpoint selector to express that in one shot. Widening it is a store-layer change against DOFYR1's deliberately frozen `FromPointer` contract, so it is not smuggled in here. The analysis is in the `worldNeighborsForPage` godoc so the next person finds it rather than rediscovering it.

## ⚠️ The SPA's detail page still cannot show a world — this is NOT closed here

`EntityDetail.vue` renders via `GET /_views/{type}/{id}`, which is `_`-prefixed and therefore refused a `?world=`. **This PR makes the API correct without changing what the detail page displays.** World-enabling `_views` is a separate, larger change (a 10-pass fixpoint traversal engine on raw `store.GetEntity`, with its own open question about whether a traverse rule's `where:` runs against the resolved face), and RULING 12 says nothing about it.

Tracked as **TKT-WRLDAPI item 4b** ("world-enable `_views/` with provenance on collections"), which is also where per-neighbour provenance lands per the table above.

## A pattern worth naming (RULING 15): a terminal state must be OBSERVED, never inferred from silence

Several defects here were not wrong *code* so much as **a check whose failure mode was silence, read as a conclusion**. The architect recorded it as RULING 15 in `.ignored/ARCHITECT-RULINGS.md`. Six instances arose while building this PR:

| # | Check | Silence read as | Actually |
|---|---|---|---|
| 1 | `// world-bound responses carry NO relations` (ETag) | invariant holds | true before this PR; false the moment item 4 made them carry relations. Cost: a stale 304 |
| 2 | `// keeps the FIRST nested expression, matching the pre-existing loop order` | invariant holds | never true — the old loop wrote unconditionally per matching edge, so the LAST won |
| 3 | ETag faults are `// never wrong in the dangerous direction` | invariant holds | false — an edge-less hash is a *valid validator for a real document state*, so a fault could win a 304 against a body with edges |
| 4 | `grep -c '^--- FAIL'` in the mutation harness | mutant survived | the package didn't compile; no test ran |
| 5 | missing `EXIT=` line + a log that stopped growing | CI run was killed | alive and healthy; `go test` buffers per package |
| 6 | `pgrep -f "/private/tmp/ci-verify"` as a liveness probe | process dead | `ps` renders the path as `/tmp/...`; the pattern never matched |

Instances 1–4 are the implementer's, 5 is the implementer's, and **6 is the architect's** — written minutes after sending the rule. That symmetry is the point: this is a property of the verification *style*, not of any one author. A tidier story that attributed them all to one side would be false.

Three consequences, all applied here:

- **The three comments (1–3) are now asserted by tests rather than by prose.** This epic is actively falsifying invariants that existing comments encode, so a reader should distrust a comment asserting a world-related property and check it against the code. Two of the three were caught by review scepticism about the *comment*, not the code.
- **The harness (4) now reports `BUILD-BROKEN` from an observed non-zero build exit**, never from a predicted one.
- **Liveness checks (5–6) check identity, not a pattern that happens to describe it** — `kill -0 <pid>` rather than a `pgrep` string match, which cannot be defeated by path rendering.
