### PR TITLE
🌍 World-capable entity view, with per-collection provenance (TKT-WRLDAPI item 4b)

### DIFF
--- a/docs-project/entities/guides/GUIDE-data-entry.md
+++ b/docs-project/entities/guides/GUIDE-data-entry.md
@@ -1242,8 +1242,26 @@ where: "status = active"     # Match status property
 where: "priority != low"     # Exclude low priority
 ```
 
+#### `where:` under a world
+
+When the view is requested with `?world=<name>`, a `where:` clause is evaluated
+against the **resolved face** — the state that world selected — not against the
+entity's default state.
+
+So under a world that selects `published`, `where: "status = active"` reads the
+*published* face's `status`. A page rendering published content while filtering
+on draft values would contradict itself, so the filter follows the page.
+
+Filters on the `type` pseudo-property are unaffected: an entity's type is the
+same on every face.
+
 If a where clause is invalid or a property doesn't exist, the filter is silently
 skipped and all entities are returned (fail-open for robustness).
+
+> **Note:** that fail-open behaviour is a known defect, not a design goal — a
+> mistyped `where:` silently *widens* a clause whose purpose is to narrow. It is
+> tracked as BUG-WHEREWIDE and will become a load-time error, so a bad `where:`
+> is refused when the config parses rather than ignored at render time.
 
 ### Sections
 

--- a/docs/data-entry.md
+++ b/docs/data-entry.md
@@ -1236,8 +1236,26 @@ where: "status = active"     # Match status property
 where: "priority != low"     # Exclude low priority
 ```
 
+#### `where:` under a world
+
+When the view is requested with `?world=<name>`, a `where:` clause is evaluated
+against the **resolved face** — the state that world selected — not against the
+entity's default state.
+
+So under a world that selects `published`, `where: "status = active"` reads the
+*published* face's `status`. A page rendering published content while filtering
+on draft values would contradict itself, so the filter follows the page.
+
+Filters on the `type` pseudo-property are unaffected: an entity's type is the
+same on every face.
+
 If a where clause is invalid or a property doesn't exist, the filter is silently
 skipped and all entities are returned (fail-open for robustness).
+
+> **Note:** that fail-open behaviour is a known defect, not a design goal — a
+> mistyped `where:` silently *widens* a clause whose purpose is to narrow. It is
+> tracked as BUG-WHEREWIDE and will become a load-time error, so a bad `where:`
+> is refused when the config parses rather than ignored at render time.
 
 ### Sections
 

--- a/internal/apiwire/v1/responses.go
+++ b/internal/apiwire/v1/responses.go
@@ -745,6 +745,25 @@ type ViewEntity struct {
 	HasContent       bool                        `json:"hasContent"`
 	Props            map[string]any              `json:"_props,omitempty"`
 	FieldAffordances *map[string]FieldAffordance `json:"_fields,omitempty"`
+	// World is the PROVENANCE of this collection entity's face — which world
+	// resolved it, which coordinate it was stored at, and which rule chose it
+	// (TKT-WRLDAPI item 4b).
+	//
+	// This is the slot the per-neighbor provenance deferred in item 4 belongs
+	// in, and the reason 4b exists. A view collection carries whole ENTITIES,
+	// unlike the entity GET's `relations` map, which carries bare id strings
+	// and so had nowhere to put this without a wire-type change.
+	//
+	// It lets a client distinguish "the Dutch page" from "the English page,
+	// because no Dutch face exists" for each item in a collection — the same
+	// question [Entity.World] answers for a single entity, which arrives
+	// byte-identically either way and cannot be re-derived client-side without
+	// the chain and the fallback policy.
+	//
+	// Present only under a NON-DEFAULT world. Under the default world every
+	// entity resolves to its default state by definition, so a provenance
+	// block would be noise on every row of every existing view.
+	World *EntityWorld `json:"_world,omitempty"`
 }
 
 // ViewColumn represents a column definition.

--- a/internal/dataentry/api_v1.go
+++ b/internal/dataentry/api_v1.go
@@ -2505,5 +2505,6 @@ func sectionEntityToV1(e SectionEntityData) v1.ViewEntity {
 		fa := e.FieldVerdicts
 		v1Ent.FieldAffordances = &fa
 	}
+	v1Ent.World = e.World
 	return v1Ent
 }

--- a/internal/dataentry/command_handler.go
+++ b/internal/dataentry/command_handler.go
@@ -30,8 +30,12 @@ type commandHandler struct {
 	projectRoot func() string
 	// schemaFile yields the resolved schema basename for the command stdin
 	// payload. Optional: nil falls back to the canonical name.
-	schemaFile  func() string
-	executeView func(ctx context.Context, view ViewConfig, entryID string) (*viewResult, error)
+	schemaFile func() string
+	// executeView runs a view for `kind: view` commands. The viewWorld
+	// parameter is passed explicitly by the caller (always defaultViewWorld()
+	// here — see commands.go), never read from ctx: this handler's output
+	// leaves the process.
+	executeView func(ctx context.Context, view ViewConfig, entryID string, w viewWorld) (*viewResult, error)
 
 	// aclImpl yields the active ACL, consulted by authorizeCommand to gate
 	// execution (TKT-MJ02AO). A closure, not a value, for the same reason as

--- a/internal/dataentry/commands.go
+++ b/internal/dataentry/commands.go
@@ -448,7 +448,14 @@ func (h *commandHandler) handleCommandExec(w http.ResponseWriter, r *http.Reques
 			http.Error(w, "View not found: "+viewID, http.StatusNotFound)
 			return
 		}
-		vr, err := h.executeView(r.Context(), viewCfg, entityID)
+		// DEFAULT WORLD, named explicitly — and this is the call site the
+		// explicit-parameter design exists for. The viewResult below is
+		// marshaled to JSON and piped to an operator shell script's stdin, so
+		// a world applied here changes what an EXTERNAL PROCESS receives, past
+		// any layer that could observe it. Scoping the command surface for
+		// worlds is its own ticket, with its own thinking about what a
+		// world-bound command even means.
+		vr, err := h.executeView(r.Context(), viewCfg, entityID, defaultViewWorld())
 		if err != nil {
 			http.Error(w, "View error: "+err.Error(), http.StatusBadRequest)
 			return

--- a/internal/dataentry/commands_test.go
+++ b/internal/dataentry/commands_test.go
@@ -318,7 +318,7 @@ func TestBuildViewInput(t *testing.T) {
 			{From: "entry", Follow: "belongs_to", CollectAs: "components"},
 		},
 	}
-	vr, err := app.views.executeView(context.Background(), view, "TKT-001")
+	vr, err := app.views.executeView(context.Background(), view, "TKT-001", defaultViewWorld())
 	if err != nil {
 		t.Fatalf("executeView: %v", err)
 	}

--- a/internal/dataentry/sections.go
+++ b/internal/dataentry/sections.go
@@ -139,6 +139,9 @@ type SectionEntityData struct {
 	HasContent    bool
 	Props         map[string]any
 	FieldVerdicts map[string]v1.FieldAffordance
+	// World is the face-provenance of this entity under the view's world
+	// (TKT-WRLDAPI item 4b). Nil under the default world.
+	World *v1.EntityWorld
 }
 
 // SectionColumnData holds a resolved table cell for template rendering.
@@ -221,9 +224,12 @@ type SectionData struct {
 //
 // sectionRender is the containing section's `render:` default; each field's
 // own `render:` overrides it (TKT-HOIX1).
+//
+// w is the world the containing view executed in; it labels each row's face
+// provenance (TKT-WRLDAPI item 4b) and is nil-stamped under the default world.
 func (h *viewsHandler) buildSectionEntityData(
 	ctx context.Context, e *entity.Entity, secFields []ViewSectionField, eDef *metamodel.EntityDef,
-	sectionRender string,
+	sectionRender string, w viewWorld,
 ) SectionEntityData {
 	s := h.schema()
 	sed := SectionEntityData{
@@ -233,6 +239,7 @@ func (h *viewsHandler) buildSectionEntityData(
 		EditFormID:    h.editFormForType(e.Type),
 		Props:         h.affordances.copyVisibleProperties(ctx, e),
 		FieldVerdicts: h.affordances.computeFieldAffordances(ctx, e),
+		World:         w.provenanceFor(e),
 	}
 	for _, f := range secFields {
 		sed.Fields = append(sed.Fields, buildSectionFieldData(f, e, eDef, sectionRender))
@@ -280,7 +287,7 @@ func (h *viewsHandler) buildSections(ctx context.Context, sections []ViewSection
 			case "properties", "list":
 				for _, e := range entities {
 					eDef, _ := s.Meta.GetEntityDef(e.Type)
-					sed := h.buildSectionEntityData(ctx, e, sec.Fields, eDef, sec.Render)
+					sed := h.buildSectionEntityData(ctx, e, sec.Fields, eDef, sec.Render, result.World)
 					sd.Entities = append(sd.Entities, sed)
 				}
 			case "table":
@@ -345,7 +352,7 @@ func (h *viewsHandler) buildSections(ctx context.Context, sections []ViewSection
 			case "content", "cards":
 				for _, e := range entities {
 					eDef, _ := s.Meta.GetEntityDef(e.Type)
-					sed := h.buildSectionEntityData(ctx, e, sec.Fields, eDef, sec.Render)
+					sed := h.buildSectionEntityData(ctx, e, sec.Fields, eDef, sec.Render, result.World)
 					sed.Content = e.Content
 					sed.HasContent = e.Content != ""
 					sd.Entities = append(sd.Entities, sed)
@@ -375,7 +382,12 @@ func (h *viewsHandler) executeSidePanel(
 		Sections: panel.Sections,
 	}
 
-	result, err := h.executeView(ctx, viewCfg, entityID)
+	// DEFAULT WORLD, named explicitly. The side panel has not been scoped for
+	// worlds (TKT-WRLDAPI item 4b covers `_views` only), and `_sidepanel` is
+	// refused a `?world=` by worldCapablePath — but a surface must DECLARE its
+	// world rather than inherit one, or scoping `_views` silently drags every
+	// executeView caller along with it.
+	result, err := h.executeView(ctx, viewCfg, entityID, defaultViewWorld())
 	if err != nil {
 		return nil
 	}

--- a/internal/dataentry/sections_ihc7d_test.go
+++ b/internal/dataentry/sections_ihc7d_test.go
@@ -86,7 +86,7 @@ func TestBuildSectionEntityData_PopulatesPropsAndFieldVerdicts(t *testing.T) {
 		{Property: "title"},
 		{Property: "status"},
 	}
-	sed := app.views.buildSectionEntityData(context.Background(), e, secFields, eDef, "")
+	sed := app.views.buildSectionEntityData(context.Background(), e, secFields, eDef, "", defaultViewWorld())
 
 	// Props carries the typed values.
 	if !reflect.DeepEqual(sed.Props, map[string]any{"title": "First", "status": "open"}) {
@@ -119,7 +119,7 @@ func TestBuildSectionEntityData_HiddenAbsentFromBothMaps(t *testing.T) {
 		Properties: map[string]any{"title": "First", "status": "open"},
 	}
 	eDef, _ := st.Meta.GetEntityDef(e.Type)
-	sed := app.views.buildSectionEntityData(context.Background(), e, nil, eDef, "")
+	sed := app.views.buildSectionEntityData(context.Background(), e, nil, eDef, "", defaultViewWorld())
 	if _, ok := sed.Props["status"]; ok {
 		t.Errorf("hidden 'status' must not appear in Props; got %+v", sed.Props)
 	}
@@ -144,7 +144,7 @@ func TestBuildSectionEntityData_KeySetInvariant(t *testing.T) {
 		},
 	}
 	eDef, _ := st.Meta.GetEntityDef(e.Type)
-	sed := app.views.buildSectionEntityData(context.Background(), e, nil, eDef, "")
+	sed := app.views.buildSectionEntityData(context.Background(), e, nil, eDef, "", defaultViewWorld())
 
 	hidden := app.affordances.hiddenProperties(context.Background(), e)
 	for k := range sed.Props {
@@ -239,7 +239,7 @@ func TestBuildSectionEntityData_LabelIsAuthoredNeverDerived(t *testing.T) {
 		{Property: "title"},                         // no label -> raw
 		{Property: "status", Label: "Eigen status"}, // authored -> preserved
 	}
-	sed := app.views.buildSectionEntityData(context.Background(), e, secFields, eDef, "")
+	sed := app.views.buildSectionEntityData(context.Background(), e, secFields, eDef, "", defaultViewWorld())
 
 	if len(sed.Fields) != 2 {
 		t.Fatalf("Fields: got %d, want 2", len(sed.Fields))

--- a/internal/dataentry/sections_render_test.go
+++ b/internal/dataentry/sections_render_test.go
@@ -59,7 +59,7 @@ func TestBuildSectionEntityData_ResolvesRender(t *testing.T) {
 			}
 
 			sed := app.views.buildSectionEntityData(
-				context.Background(), e, secFields, eDef, tc.sectionRender)
+				context.Background(), e, secFields, eDef, tc.sectionRender, defaultViewWorld())
 
 			if len(sed.Fields) != len(tc.want) {
 				t.Fatalf("got %d fields, want %d", len(sed.Fields), len(tc.want))
@@ -121,7 +121,7 @@ func TestSectionEntityToV1_CarriesRender(t *testing.T) {
 		{Property: "status"},
 	}
 
-	sed := app.views.buildSectionEntityData(context.Background(), e, secFields, eDef, "")
+	sed := app.views.buildSectionEntityData(context.Background(), e, secFields, eDef, "", defaultViewWorld())
 	v1Ent := sectionEntityToV1(sed)
 
 	if len(v1Ent.Fields) != 2 {

--- a/internal/dataentry/sections_span_test.go
+++ b/internal/dataentry/sections_span_test.go
@@ -36,7 +36,7 @@ func TestSectionFieldSpan_SurvivesBothConstructionSites(t *testing.T) {
 	}
 
 	t.Run("buildSectionEntityData (cards/list rows)", func(t *testing.T) {
-		sed := app.views.buildSectionEntityData(context.Background(), e, secFields, eDef, "")
+		sed := app.views.buildSectionEntityData(context.Background(), e, secFields, eDef, "", defaultViewWorld())
 		assertSpans(t, sed.Fields, map[string]int{"title": 0, "status": 4})
 	})
 
@@ -90,7 +90,7 @@ func TestSectionFieldSpan_ZeroMeansFullWidth(t *testing.T) {
 	eDef, _ := st.Meta.GetEntityDef(e.Type)
 
 	sed := app.views.buildSectionEntityData(
-		context.Background(), e, []ViewSectionField{{Property: "title"}}, eDef, "")
+		context.Background(), e, []ViewSectionField{{Property: "title"}}, eDef, "", defaultViewWorld())
 
 	if len(sed.Fields) != 1 {
 		t.Fatalf("got %d fields, want 1", len(sed.Fields))

--- a/internal/dataentry/sections_widget_test.go
+++ b/internal/dataentry/sections_widget_test.go
@@ -51,7 +51,7 @@ func TestBuildSectionEntityData_CarriesWidget(t *testing.T) {
 			}
 
 			sed := app.views.buildSectionEntityData(
-				context.Background(), e, secFields, eDef, "input")
+				context.Background(), e, secFields, eDef, "input", defaultViewWorld())
 
 			if len(sed.Fields) != len(tc.want) {
 				t.Fatalf("got %d fields, want %d", len(sed.Fields), len(tc.want))

--- a/internal/dataentry/views.go
+++ b/internal/dataentry/views.go
@@ -14,13 +14,28 @@ import (
 type viewResult struct {
 	Entry       *entity.Entity
 	Collections map[string][]*entity.Entity
+	// World is the world this result was executed in, carried so the section
+	// builders can label each entity's face provenance (TKT-WRLDAPI item 4b).
+	//
+	// On the RESULT rather than threaded through every builder because the
+	// answer is the same for every entity in the result — the world resolved
+	// them all — and because a builder that took a world parameter it did not
+	// otherwise need would invite someone to pass a different one.
+	World viewWorld
 }
 
 // executeView runs a view's traversal rules and returns the result.
-func (h *viewsHandler) executeView(ctx context.Context, view ViewConfig, entryID string) (*viewResult, error) {
-	entry, err := h.store.GetEntity(ctx, entryID)
+//
+// It is a SHARED ENGINE, not the `_views` handler's private helper: three
+// surfaces call it (the `_views` route, `_sidepanel` via executeSidePanel, and
+// the command runner's `kind: view`). That is why the world arrives as an
+// explicit PARAMETER rather than being read off ctx — see [viewWorld].
+func (h *viewsHandler) executeView(
+	ctx context.Context, view ViewConfig, entryID string, w viewWorld,
+) (*viewResult, error) {
+	entry, err := h.viewEntry(ctx, entryID, w)
 	if err != nil {
-		return nil, fmt.Errorf("entry entity not found: %s", entryID)
+		return nil, err
 	}
 	if entry.Type != view.Entry.Type {
 		return nil, fmt.Errorf("entry entity %s is type %s, expected %s", entryID, entry.Type, view.Entry.Type)
@@ -29,6 +44,7 @@ func (h *viewsHandler) executeView(ctx context.Context, view ViewConfig, entryID
 	result := &viewResult{
 		Entry:       entry,
 		Collections: map[string][]*entity.Entity{"entry": {entry}},
+		World:       w,
 	}
 
 	// Multi-pass traversal (up to 10 passes until stable)
@@ -36,7 +52,7 @@ func (h *viewsHandler) executeView(ctx context.Context, view ViewConfig, entryID
 	for range maxPasses {
 		before := countViewEntities(result.Collections)
 		for _, rule := range view.Traverse {
-			h.applyViewTraverse(ctx, rule, result)
+			h.applyViewTraverse(ctx, rule, result, w)
 		}
 		if countViewEntities(result.Collections) == before {
 			break
@@ -70,7 +86,9 @@ func (h *viewsHandler) executeView(ctx context.Context, view ViewConfig, entryID
 	return result, nil
 }
 
-func (h *viewsHandler) applyViewTraverse(ctx context.Context, rule ViewTraverse, result *viewResult) {
+func (h *viewsHandler) applyViewTraverse(
+	ctx context.Context, rule ViewTraverse, result *viewResult, w viewWorld,
+) {
 	// Gather source entities
 	var sources []*entity.Entity
 	if rule.From == "*" {
@@ -87,28 +105,52 @@ func (h *viewsHandler) applyViewTraverse(ctx context.Context, rule ViewTraverse,
 		sources = entities
 	}
 
-	// Traverse from each source
+	// Traverse from each source, collecting NEIGHBOR IDS rather than entities.
+	//
+	// Splitting id-collection from entity-loading is what makes the world path
+	// affordable: ids are cheap and the recursive walk needs them anyway to
+	// decide where to step next, while LOADING an entity under a world costs a
+	// resolution. Collect the whole rule's ids first, then resolve once.
 	maxRecursionDepth := 10
-	var found []*entity.Entity
+	var foundIDs []string
 	for _, src := range sources {
 		if rule.Recursive {
 			maxD := rule.MaxDepth
 			if maxD <= 0 {
 				maxD = maxRecursionDepth
 			}
-			found = append(found, h.traverseViewRecursive(ctx, src.ID, rule, 0, maxD, map[string]bool{})...)
+			foundIDs = append(foundIDs,
+				h.traverseViewRecursive(ctx, src.ID, rule, 0, maxD, map[string]bool{})...)
 		} else {
-			found = append(found, h.traverseViewOnce(ctx, src.ID, rule)...)
+			foundIDs = append(foundIDs, h.traverseViewOnce(ctx, src.ID, rule)...)
 		}
 	}
 
-	// Apply where filter if specified
+	// ONE resolution for the whole rule application, not one per hop.
+	//
+	// The per-hop shape would be an N+1 multiplied by the 10-pass fixpoint and
+	// again by the recursive walk's depth — materially worse than the per-row
+	// cost item 4 documented as known. Batching here is a design choice made up
+	// front rather than an optimisation deferred (see the PR body).
+	found := h.loadViewEntities(ctx, foundIDs, w)
+
+	// Apply where filter if specified.
+	//
+	// RULING 16: this runs against the RESOLVED FACES, because `found` now
+	// holds whatever face the world selected. A `where:` filtering on draft
+	// values while the page renders published content would contradict its own
+	// page. filterEntities itself needed no change — it reads e.Properties off
+	// whatever it is handed, so feeding it faces makes it filter faces.
 	if rule.Where != "" {
 		filtered, err := h.filterEntities(found, rule.Where)
 		if err == nil {
 			found = filtered
 		}
-		// On error, continue with unfiltered results (silent failure for robustness)
+		// On error, continue with unfiltered results (silent failure for
+		// robustness). This SILENTLY WIDENS a construct whose job is to narrow
+		// — tracked as BUG-WHEREWIDE, decided (RULING 17) to become a load-time
+		// error. Deliberately not fixed here: it predates worlds and deserves
+		// its own change rather than riding along in a world PR.
 	}
 
 	// Deduplicate into collection
@@ -127,9 +169,29 @@ func (h *viewsHandler) applyViewTraverse(ctx context.Context, rule ViewTraverse,
 	}
 }
 
-func (h *viewsHandler) traverseViewOnce(ctx context.Context, sourceID string, rule ViewTraverse) []*entity.Entity {
+// traverseViewOnce returns the neighbor IDS one hop from sourceID.
+//
+// It returns IDS, not entities, so the caller can resolve the whole rule's
+// neighbors in one batch — see applyViewTraverse. It also means this function
+// does no entity read at all, which is what removes the per-hop
+// default-world `GetEntity` that made the traversal world-blind.
+//
+// The relation query keeps a NIL tail deliberately. A view traverses the
+// entity GRAPH: it follows an edge to reach a neighbor, and per design §2.3
+// heads are entity-level, so which face the SOURCE is standing on does not
+// change which ids it can reach. Filtering by the source's pointer here would
+// hide identity edges from any entity whose prime is not the default state —
+// the "fallback trap" documented on worldreader.RelationReader.Neighbors,
+// where the zero pointer as a FromPointer VALUE means default-tail-only rather
+// than unfiltered.
+//
+// (Content-scoped edges are therefore over-returned here relative to what item
+// 4's entity GET shows. That is a known divergence, not an oversight: making
+// view traversal honor edge scope needs the per-type dispatch, which is its
+// own change with its own tests. Recorded in the PR body.)
+func (h *viewsHandler) traverseViewOnce(ctx context.Context, sourceID string, rule ViewTraverse) []string {
 	st := h.store
-	var out []*entity.Entity
+	var out []string
 
 	var relType string
 	var direction store.Direction
@@ -156,25 +218,28 @@ func (h *viewsHandler) traverseViewOnce(ctx context.Context, sourceID string, ru
 		if !useTarget {
 			targetID = r.From
 		}
-		if e, err := st.GetEntity(ctx, targetID); err == nil {
-			out = append(out, e)
+		if targetID != "" {
+			out = append(out, targetID)
 		}
 	}
 	return out
 }
 
+// traverseViewRecursive walks the relation graph depth-first, returning the
+// neighbor IDS found. Like traverseViewOnce it loads no entities — the walk
+// steps by id, so it never needed them.
 func (h *viewsHandler) traverseViewRecursive(
 	ctx context.Context, sourceID string, rule ViewTraverse, depth, maxDepth int, visited map[string]bool,
-) []*entity.Entity {
+) []string {
 	if depth >= maxDepth || visited[sourceID] {
 		return nil
 	}
 	visited[sourceID] = true
 	immediate := h.traverseViewOnce(ctx, sourceID, rule)
-	var all []*entity.Entity
+	var all []string
 	all = append(all, immediate...)
-	for _, e := range immediate {
-		all = append(all, h.traverseViewRecursive(ctx, e.ID, rule, depth+1, maxDepth, visited)...)
+	for _, id := range immediate {
+		all = append(all, h.traverseViewRecursive(ctx, id, rule, depth+1, maxDepth, visited)...)
 	}
 	return all
 }

--- a/internal/dataentry/views_handler.go
+++ b/internal/dataentry/views_handler.go
@@ -547,8 +547,12 @@ func (h *viewsHandler) handleV1Views(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	// Execute view
-	result, err := h.executeView(r.Context(), viewCfg, entityID)
+	// Execute view. This is the ONE surface that opts into worlds
+	// (TKT-WRLDAPI item 4b); the other two executeView callers pass
+	// defaultViewWorld() explicitly. See the viewWorld doc for why the world
+	// is a parameter rather than something the engine reads off ctx.
+	result, err := h.executeView(r.Context(), viewCfg, entityID,
+		viewWorldFromRequest(r.Context()))
 	if err != nil {
 		writeV1Error(w, r, http.StatusUnprocessableEntity, "view_execution_failed", "View execution failed", err.Error())
 		return
@@ -561,7 +565,21 @@ func (h *viewsHandler) handleV1Views(w http.ResponseWriter, r *http.Request) {
 	entityDef := s.Meta.Entities[result.Entry.Type]
 	plural := entityDef.GetPlural(result.Entry.Type)
 
-	entryRels := h.reader.outgoingRelations(r.Context(), result.Entry.ID)
+	// The entry's relations. Under the DEFAULT world this is the ungated
+	// reader, exactly as before. Under a world it must NOT be: that reader is
+	// default-world-only, so it would pair a resolved entry with draft edges —
+	// the mixed-face response item 4 exists to prevent. A world-bound view
+	// carries no entry relations until the view surface resolves them through
+	// the world, which is deliberately NOT in this ticket's scope (item 4b is
+	// the entry face, collections, and provenance).
+	//
+	// Emitting nothing is the honest placeholder, and it is the same posture
+	// the entity GET held between item 2 and item 4. Recorded in the PR body
+	// as a known gap rather than left for a reader to discover.
+	var entryRels []*entityPkg.Relation
+	if !worldBoundRelations(r.Context()) {
+		entryRels = h.reader.outgoingRelations(r.Context(), result.Entry.ID)
+	}
 	resp := v1.ViewResponse{
 		Entry:    h.serializer.forWire(r.Context(), result.Entry, entryRels, h.schema().Meta, plural),
 		Sections: make([]v1.ViewSection, 0, len(sections)),

--- a/internal/dataentry/views_test.go
+++ b/internal/dataentry/views_test.go
@@ -88,7 +88,7 @@ func TestExecuteView(t *testing.T) {
 				{From: "entry", Follow: "depends_on", CollectAs: "dependencies"},
 			},
 		}
-		result, err := app.views.executeView(context.Background(), view, "TKT-001")
+		result, err := app.views.executeView(context.Background(), view, "TKT-001", defaultViewWorld())
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -109,7 +109,7 @@ func TestExecuteView(t *testing.T) {
 				{From: "entry", FollowIncoming: "depends_on", CollectAs: "dependents"},
 			},
 		}
-		result, err := app.views.executeView(context.Background(), view, "TKT-002")
+		result, err := app.views.executeView(context.Background(), view, "TKT-002", defaultViewWorld())
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -127,7 +127,7 @@ func TestExecuteView(t *testing.T) {
 				{From: "entry", Follow: "depends_on", CollectAs: "all_deps", Recursive: true},
 			},
 		}
-		result, err := app.views.executeView(context.Background(), view, "TKT-001")
+		result, err := app.views.executeView(context.Background(), view, "TKT-001", defaultViewWorld())
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -145,7 +145,7 @@ func TestExecuteView(t *testing.T) {
 				{From: "entry", Follow: "depends_on", CollectAs: "limited_deps", Recursive: true, MaxDepth: 1},
 			},
 		}
-		result, err := app.views.executeView(context.Background(), view, "TKT-001")
+		result, err := app.views.executeView(context.Background(), view, "TKT-001", defaultViewWorld())
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -164,7 +164,7 @@ func TestExecuteView(t *testing.T) {
 				{From: "*", Follow: "depends_on", CollectAs: "transitive_deps"},
 			},
 		}
-		result, err := app.views.executeView(context.Background(), view, "TKT-001")
+		result, err := app.views.executeView(context.Background(), view, "TKT-001", defaultViewWorld())
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -179,7 +179,7 @@ func TestExecuteView(t *testing.T) {
 
 	t.Run("entry not found", func(t *testing.T) {
 		view := ViewConfig{Entry: ViewEntry{Type: "ticket"}}
-		_, err := app.views.executeView(context.Background(), view, "NONEXISTENT")
+		_, err := app.views.executeView(context.Background(), view, "NONEXISTENT", defaultViewWorld())
 		if err == nil {
 			t.Error("expected error for nonexistent entry")
 		}
@@ -187,7 +187,7 @@ func TestExecuteView(t *testing.T) {
 
 	t.Run("wrong entry type", func(t *testing.T) {
 		view := ViewConfig{Entry: ViewEntry{Type: "component"}}
-		_, err := app.views.executeView(context.Background(), view, "TKT-001")
+		_, err := app.views.executeView(context.Background(), view, "TKT-001", defaultViewWorld())
 		if err == nil {
 			t.Error("expected error for wrong entry type")
 		}
@@ -197,7 +197,7 @@ func TestExecuteView(t *testing.T) {
 		view := ViewConfig{
 			Entry: ViewEntry{Type: "ticket"},
 		}
-		result, err := app.views.executeView(context.Background(), view, "TKT-001")
+		result, err := app.views.executeView(context.Background(), view, "TKT-001", defaultViewWorld())
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -214,7 +214,7 @@ func TestExecuteView(t *testing.T) {
 				{From: "entry", Follow: "belongs_to", CollectAs: "components"},
 			},
 		}
-		result, err := app.views.executeView(context.Background(), view, "TKT-001")
+		result, err := app.views.executeView(context.Background(), view, "TKT-001", defaultViewWorld())
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -239,7 +239,7 @@ func TestExecuteView(t *testing.T) {
 				{From: "entry", Follow: "depends_on", CollectAs: "collected"}, // same rule again
 			},
 		}
-		result, err := app.views.executeView(context.Background(), view, "TKT-001")
+		result, err := app.views.executeView(context.Background(), view, "TKT-001", defaultViewWorld())
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -348,7 +348,7 @@ func TestExecuteViewWithWhere(t *testing.T) {
 				},
 			},
 		}
-		result, err := app.views.executeView(context.Background(), view, "BOUWBLOK-001")
+		result, err := app.views.executeView(context.Background(), view, "BOUWBLOK-001", defaultViewWorld())
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -376,7 +376,7 @@ func TestExecuteViewWithWhere(t *testing.T) {
 				},
 			},
 		}
-		result, err := app.views.executeView(context.Background(), view, "BOUWBLOK-001")
+		result, err := app.views.executeView(context.Background(), view, "BOUWBLOK-001", defaultViewWorld())
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -399,7 +399,7 @@ func TestExecuteViewWithWhere(t *testing.T) {
 				},
 			},
 		}
-		result, err := app.views.executeView(context.Background(), view, "BOUWBLOK-001")
+		result, err := app.views.executeView(context.Background(), view, "BOUWBLOK-001", defaultViewWorld())
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -427,7 +427,7 @@ func TestExecuteViewWithWhere(t *testing.T) {
 				},
 			},
 		}
-		result, err := app.views.executeView(context.Background(), view, "BOUWBLOK-001")
+		result, err := app.views.executeView(context.Background(), view, "BOUWBLOK-001", defaultViewWorld())
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -464,7 +464,7 @@ func TestExecuteViewWithWhere(t *testing.T) {
 				},
 			},
 		}
-		result, err := app.views.executeView(context.Background(), view, "BOUWBLOK-001")
+		result, err := app.views.executeView(context.Background(), view, "BOUWBLOK-001", defaultViewWorld())
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -491,7 +491,7 @@ func TestExecuteViewWithWhere(t *testing.T) {
 				},
 			},
 		}
-		result, err := app.views.executeView(context.Background(), view, "BOUWBLOK-001")
+		result, err := app.views.executeView(context.Background(), view, "BOUWBLOK-001", defaultViewWorld())
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}

--- a/internal/dataentry/viewworld.go
+++ b/internal/dataentry/viewworld.go
@@ -1,0 +1,254 @@
+package dataentry
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	v1 "github.com/Sourcehaven-BV/rela/internal/apiwire/v1"
+	entityPkg "github.com/Sourcehaven-BV/rela/internal/entity"
+	"github.com/Sourcehaven-BV/rela/internal/store"
+)
+
+// viewWorld is the world a view executes in, passed EXPLICITLY to
+// [viewsHandler.executeView] rather than read from the request context
+// (TKT-WRLDAPI item 4b).
+//
+// # Why a parameter and not ctx
+//
+// executeView is a shared engine with three callers, and only ONE of them is
+// world-capable:
+//
+//   - `GET /_views/{type}/{id}` — world-capable (this ticket).
+//   - `_sidepanel`, via executeSidePanel — NOT yet scoped.
+//   - the command runner's `kind: view` — NOT yet scoped, and the most
+//     consequential: `commands.go` marshals the viewResult to JSON and pipes
+//     it to an operator shell script's stdin. A world applied there changes
+//     what an EXTERNAL PROCESS receives, past the point where anything in this
+//     codebase can observe that a world was involved at all.
+//
+// If executeView read the world off ctx, the moment a request carrying
+// `?world=` reached the command path the engine would silently world-resolve
+// its output — the two unscoped surfaces would inherit world-awareness rather
+// than opting into it. That is the difference between an allowlist and an
+// accident, and it is the same default-deny discipline [worldCapablePath]
+// applies at the route table, moved one layer in.
+//
+// So the world is a value a caller must NAME. `defaultViewWorld()` is spelled
+// out at the two unscoped call sites, so a reader sees a choice rather than an
+// omission, and `TestExecuteViewCallersDeclareTheirWorld` fails if a new
+// caller appears that does not make one.
+//
+// # The zero value is the default world
+//
+// A zero viewWorld is the default world, which is what makes a pointerless
+// project and every pre-item-4b caller behave identically. That is safe
+// BECAUSE it is also inert: the zero scope resolves every entity to its
+// default state, exactly as `store.GetEntity` did.
+type viewWorld struct {
+	// name is the declared world name, for provenance labeling. Empty means
+	// the default world.
+	name string
+	// scope is the compiled resolution this world applies. The zero scope is
+	// the default world.
+	scope store.WorldScope
+}
+
+// defaultViewWorld returns the world a surface that has not been scoped for
+// worlds must use.
+//
+// Spelled as a named constructor rather than a bare `viewWorld{}` so the call
+// sites read as a decision. `executeView(ctx, cfg, id, defaultViewWorld())`
+// says "this surface serves the default world"; `executeView(ctx, cfg, id,
+// viewWorld{})` says nothing, and a reader cannot tell whether the author
+// considered worlds at all.
+func defaultViewWorld() viewWorld { return viewWorld{} }
+
+// viewWorldFromRequest builds the world for a world-capable view route.
+//
+// This is the ONLY constructor that reads the request's world. Keeping it
+// distinct from [defaultViewWorld] is what makes the two populations legible:
+// a grep for this function finds every surface that has opted in.
+func viewWorldFromRequest(ctx context.Context) viewWorld {
+	h := worldFromContext(ctx)
+	return viewWorld{name: h.name, scope: h.scope}
+}
+
+// isDefault reports whether this is the default world.
+func (w viewWorld) isDefault() bool { return w.scope.IsDefaultWorld() }
+
+// viewEntry resolves the view's ENTRY entity to its face in world w.
+//
+// Under the default world this is exactly the previous `store.GetEntity` call,
+// error text included, so every existing caller is byte-identical.
+//
+// Under a non-default world it goes through the same one-id ListEntities query
+// [visibleReader.getWorldEntity] uses, so the BACKEND resolves the chain and
+// the fallback verdict. One resolution site, not two — reimplementing the walk
+// here would be a second copy of the semantics deciding which face a reader
+// sees.
+//
+// The entry is NOT row-gated here, deliberately: the handler already gated it
+// (`views_handler.go`, TKT-BNX2PN) and re-gating could 404 an entry the caller
+// was just cleared to read. That reasoning is unchanged by worlds — but note
+// what IS changed: a world that EXCLUDES the entry yields a not-found here,
+// which is correct (in this world the entity does not exist) and is not an ACL
+// decision.
+func (h *viewsHandler) viewEntry(
+	ctx context.Context, entryID string, w viewWorld,
+) (*entityPkg.Entity, error) {
+	if w.isDefault() {
+		e, err := h.store.GetEntity(ctx, entryID)
+		if err != nil {
+			return nil, errViewEntryNotFound(entryID)
+		}
+		return e, nil
+	}
+	for e, err := range h.store.ListEntities(ctx, store.EntityQuery{
+		IDs:   []string{entryID},
+		World: w.scope,
+	}) {
+		if err != nil {
+			// An infrastructure failure is NOT "this entity has no face in
+			// this world". Surfacing it keeps a backend outage from reading
+			// as a correctly-empty published view (RR-4TFZNL).
+			return nil, err
+		}
+		return e, nil
+	}
+	return nil, errViewEntryNotFound(entryID)
+}
+
+// errViewEntryNotFound is the entry-missing error, spelled once so the
+// default-world and world paths cannot drift in wording. The message is
+// preserved verbatim from before item 4b: it reaches the wire as a 422
+// `view_execution_failed` detail, and callers' tests match on it.
+func errViewEntryNotFound(entryID string) error {
+	return fmt.Errorf("entry entity not found: %s", entryID)
+}
+
+// loadViewEntities resolves neighbor ids to their faces in world w, preserving
+// the caller's id order and dropping ids that resolve to nothing.
+//
+// # One batch per rule application
+//
+// The traversal collects ids across every source and every recursion depth
+// before calling this, so a rule that walks a hundred edges costs ONE
+// resolution rather than a hundred. That ordering is deliberate and is why
+// traverseViewOnce returns ids: the per-hop shape would multiply an N+1 by the
+// 10-pass fixpoint AND by the recursive depth.
+//
+// # Order and duplicates
+//
+// Input order is preserved because the caller's dedup-into-collection step
+// runs afterwards and callers observe collection order. Duplicate ids collapse
+// to one entity, which is what the dedup step would have done anyway.
+//
+// # Absence is normal
+//
+// An id that resolves to no face is DROPPED, exactly as the previous
+// `GetEntity`-error-skip did. Under a world that is the `otherwise: exclude`
+// verdict — the neighbor has no face here — and under the default world it is
+// a dangling edge. Both were silent before and stay silent, because a view is
+// a presentation surface and a missing neighbor is not an error a page can act
+// on.
+//
+// A store FAULT is different and is logged: it would otherwise read as "this
+// world excludes everything", the RR-4TFZNL shape.
+func (h *viewsHandler) loadViewEntities(
+	ctx context.Context, ids []string, w viewWorld,
+) []*entityPkg.Entity {
+	if len(ids) == 0 {
+		return nil
+	}
+	byID := make(map[string]*entityPkg.Entity, len(ids))
+
+	if w.isDefault() {
+		// Point reads, as before. The default world has no chain to resolve, so
+		// a batch query would buy nothing and would change the error handling
+		// of a path this ticket must leave byte-identical.
+		for _, id := range ids {
+			if _, seen := byID[id]; seen {
+				continue
+			}
+			if e, err := h.store.GetEntity(ctx, id); err == nil {
+				byID[id] = e
+			}
+		}
+	} else {
+		unique := make([]string, 0, len(ids))
+		seen := make(map[string]struct{}, len(ids))
+		for _, id := range ids {
+			if _, dup := seen[id]; dup {
+				continue
+			}
+			seen[id] = struct{}{}
+			unique = append(unique, id)
+		}
+		for e, err := range h.store.ListEntities(ctx, store.EntityQuery{
+			IDs:   unique,
+			World: w.scope,
+		}) {
+			if err != nil {
+				slog.Warn("dataentry: view traversal: world resolution failed; "+
+					"collection truncated",
+					"world", w.name, "ids", len(unique), "err", err)
+				break
+			}
+			byID[e.ID] = e
+		}
+	}
+
+	out := make([]*entityPkg.Entity, 0, len(byID))
+	emitted := make(map[string]struct{}, len(byID))
+	for _, id := range ids {
+		e, ok := byID[id]
+		if !ok {
+			continue // no face in this world, or a dangling edge
+		}
+		if _, dup := emitted[id]; dup {
+			continue
+		}
+		emitted[id] = struct{}{}
+		out = append(out, e)
+	}
+	return out
+}
+
+// provenanceFor labels how this world resolved e's face, or nil under the
+// default world (TKT-WRLDAPI item 4b).
+//
+// # Labeling, not re-resolving
+//
+// Resolution happened once, in the store: the world scope rode the query and
+// the backend picked the face. This reads the answer back — the coordinate the
+// returned row was stored at — and names the rule that must have produced it.
+// It never fetches and never walks the chain, so it cannot disagree with the
+// store about WHICH face was served, because it is handed that face.
+//
+// It shares [resolutionRule] with the entity GET's `_world` block rather than
+// deriving the rule again, so a view row and a GET of the same entity under
+// the same world report identical provenance. Two implementations of that
+// mapping would be free to drift, and the drift would be invisible — both
+// would look plausible.
+//
+// # Nil under the default world, deliberately
+//
+// Every entity resolves to its default state there by definition, so a block
+// on every row of every existing view would be noise — and, worse, would imply
+// a world was applied when none was. The entity GET makes the opposite choice
+// (it always labels, including `via: unscoped`) because a single-entity
+// response has room for one block and a client asking for provenance asked
+// about that entity. A collection is a different shape with a different cost.
+//
+// e must be non-nil; callers hold a resolved entity by construction.
+func (w viewWorld) provenanceFor(e *entityPkg.Entity) *v1.EntityWorld {
+	if w.isDefault() || e == nil {
+		return nil
+	}
+	return &v1.EntityWorld{
+		Name:    w.name,
+		Pointer: e.Pointer.String(),
+		Via:     resolutionRule(w.scope, e.Type, e.Pointer),
+	}
+}

--- a/internal/dataentry/viewworld_guard_test.go
+++ b/internal/dataentry/viewworld_guard_test.go
@@ -1,0 +1,126 @@
+package dataentry
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"strings"
+	"testing"
+)
+
+// TestExecuteViewCallersDeclareTheirWorld is the guard [viewWorld]'s doc
+// promises, and the reason the world is a parameter rather than a ctx read.
+//
+// # What it protects
+//
+// executeView is a SHARED ENGINE with three callers, only one of which is
+// world-capable. The other two — `_sidepanel` and the command runner — must
+// pass defaultViewWorld() EXPLICITLY. If a future caller (or a refactor of an
+// existing one) forgets, the engine would still compile, and the surface would
+// inherit whatever world the argument happened to carry.
+//
+// The command path is why this is a guard rather than a convention: its
+// viewResult is marshaled to JSON and piped to an operator shell script's
+// stdin, so a world applied there changes what an EXTERNAL PROCESS receives,
+// past any layer that could observe it.
+//
+// # Why it scans for the argument rather than counting callers
+//
+// A test that merely counted call sites would pass when someone changed one
+// from defaultViewWorld() to viewWorldFromRequest() — the exact regression it
+// exists to catch. So it reads the fourth argument of every executeView call
+// and requires it to name a world constructor.
+//
+// Mutation-checked: swapping either unscoped call site to
+// viewWorldFromRequest() fails this test.
+func TestExecuteViewCallersDeclareTheirWorld(t *testing.T) {
+	t.Parallel()
+
+	// The ONE file permitted to pass a request-derived world. Anything else
+	// must pass defaultViewWorld().
+	worldCapableFile := "views_handler.go"
+
+	entries, err := os.ReadDir(".")
+	if err != nil {
+		t.Fatalf("read package dir: %v", err)
+	}
+	fset := token.NewFileSet()
+	var checked int
+	for _, entry := range entries {
+		name := entry.Name()
+		if entry.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		file, perr := parser.ParseFile(fset, name, nil, 0)
+		if perr != nil {
+			t.Fatalf("parse %s: %v", name, perr)
+		}
+		ast.Inspect(file, func(n ast.Node) bool {
+			call, ok := n.(*ast.CallExpr)
+			if !ok {
+				return true
+			}
+			sel, ok := call.Fun.(*ast.SelectorExpr)
+			if !ok || sel.Sel == nil || sel.Sel.Name != "executeView" {
+				return true
+			}
+			checked++
+			if len(call.Args) != 4 {
+				t.Errorf("%s: executeView called with %d args, want 4 — the "+
+					"world must be passed explicitly", name, len(call.Args))
+				return true
+			}
+			got := worldArgName(call.Args[3])
+			switch got {
+			case "defaultViewWorld":
+				// Always fine: this surface declares it serves the default world.
+			case "viewWorldFromRequest":
+				if name != worldCapableFile {
+					t.Errorf("%s passes a REQUEST-derived world to executeView, but "+
+						"only %s is world-capable. executeView is shared with the "+
+						"side panel and the command runner — and the command runner "+
+						"pipes its result to an external process, where a world "+
+						"cannot be observed downstream. Pass defaultViewWorld() "+
+						"unless this surface has been scoped and tested for worlds.",
+						name, worldCapableFile)
+				}
+			default:
+				t.Errorf("%s: executeView's world argument is %q, which names neither "+
+					"defaultViewWorld() nor viewWorldFromRequest(). A surface must "+
+					"DECLARE its world at the call site so a reader sees a choice "+
+					"rather than an omission.", name, got)
+			}
+			return true
+		})
+	}
+
+	// A guard that scanned nothing is not a guard: a rename would otherwise
+	// make this pass silently forever.
+	if checked < 3 {
+		t.Fatalf("found only %d executeView call sites, expected at least 3 "+
+			"(_views, _sidepanel, command runner). If they were renamed or "+
+			"removed, update this guard rather than letting it go quiet", checked)
+	}
+}
+
+// worldArgName renders the callee name of a world argument, or a description
+// of why it is not a plain constructor call.
+func worldArgName(arg ast.Expr) string {
+	call, ok := arg.(*ast.CallExpr)
+	if !ok {
+		if ident, isIdent := arg.(*ast.Ident); isIdent {
+			return ident.Name
+		}
+		return "<not a constructor call>"
+	}
+	switch fn := call.Fun.(type) {
+	case *ast.Ident:
+		return fn.Name
+	case *ast.SelectorExpr:
+		if fn.Sel != nil {
+			return fn.Sel.Name
+		}
+	}
+	return "<unrecognized>"
+}

--- a/internal/dataentry/viewworld_test.go
+++ b/internal/dataentry/viewworld_test.go
@@ -1,0 +1,410 @@
+package dataentry
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Sourcehaven-BV/rela/internal/entity"
+	"github.com/Sourcehaven-BV/rela/internal/store"
+)
+
+// publishedViewWorld is the ISMS-shaped world for view tests: select the
+// `published` face, exclude anything that has none.
+func publishedViewWorld(types ...string) viewWorld {
+	res := make(map[string]store.TypeResolution, len(types))
+	for _, typ := range types {
+		res[typ] = store.TypeResolution{
+			Chain:    []entity.Pointer{entity.Pointer("published")},
+			Fallback: store.FallbackExclude,
+		}
+	}
+	return viewWorld{name: "published", scope: store.NewWorldScope(res)}
+}
+
+// seedViewGraph builds the fixture the world view tests share:
+//
+//	TKT-1 (draft + published) --implements--> FEAT-PUB   (draft + published)
+//	                          --implements--> FEAT-DRAFT (draft only)
+//
+// Under `published`, FEAT-DRAFT has no face and must vanish from collections.
+func seedViewGraph(t *testing.T, app *App) {
+	t.Helper()
+	ctx := context.Background()
+
+	seedEntity(app, &entity.Entity{
+		ID: "TKT-1", Type: "ticket",
+		Properties: map[string]any{"title": "draft entry", "status": "open"},
+	})
+	if err := app.store.CreateEntity(ctx, &entity.Entity{
+		ID: "TKT-1", Type: "ticket", Pointer: entity.Pointer("published"),
+		Properties: map[string]any{"title": "published entry", "status": "closed"},
+	}); err != nil {
+		t.Fatalf("seed TKT-1@published: %v", err)
+	}
+
+	seedEntity(app, &entity.Entity{
+		ID: "FEAT-PUB", Type: "feature",
+		Properties: map[string]any{"title": "draft feature"},
+	})
+	if err := app.store.CreateEntity(ctx, &entity.Entity{
+		ID: "FEAT-PUB", Type: "feature", Pointer: entity.Pointer("published"),
+		Properties: map[string]any{"title": "published feature"},
+	}); err != nil {
+		t.Fatalf("seed FEAT-PUB@published: %v", err)
+	}
+	seedEntity(app, &entity.Entity{
+		ID: "FEAT-DRAFT", Type: "feature",
+		Properties: map[string]any{"title": "unpublished feature"},
+	})
+
+	for _, to := range []string{"FEAT-PUB", "FEAT-DRAFT"} {
+		if _, err := app.store.CreateRelation(ctx, "TKT-1", "implements", to, nil); err != nil {
+			t.Fatalf("seed edge to %s: %v", to, err)
+		}
+	}
+}
+
+func implementsView() ViewConfig {
+	return ViewConfig{
+		Entry: ViewEntry{Type: "ticket"},
+		Traverse: []ViewTraverse{
+			{From: "entry", Follow: "implements", CollectAs: "features"},
+		},
+	}
+}
+
+// collectionIDs lists the ids collected under the fixture's one collection.
+//
+// The name is fixed rather than a parameter: every test here uses the same
+// single-rule fixture, and a parameter that only ever receives one value is a
+// generality nothing exercises.
+func collectionIDs(result *viewResult) []string {
+	var out []string
+	for _, e := range result.Collections["features"] {
+		out = append(out, e.ID)
+	}
+	return out
+}
+
+// TestExecuteView_EntryResolvesToTheWorldsFace pins that the view's ENTRY is
+// the world's face, not the default state.
+//
+// This is the first thing item 4b had to fix: executeView read the entry via a
+// raw store.GetEntity, which under any world yields the wrong object — the
+// page would render draft content while claiming to be a published view.
+//
+// It asserts on the entry's PROPERTIES rather than its pointer, because the
+// pointer being right while the content is stale is not a failure mode this
+// code can produce, whereas a reader who only checked the pointer would not
+// notice if the wrong row were returned.
+//
+// Mutation-checked: `viewWorld.isDefault() → true` fails this.
+func TestExecuteView_EntryResolvesToTheWorldsFace(t *testing.T) {
+	app := newTestAppV1(t)
+	seedViewGraph(t, app)
+
+	def, err := app.views.executeView(
+		context.Background(), implementsView(), "TKT-1", defaultViewWorld())
+	if err != nil {
+		t.Fatalf("default world: %v", err)
+	}
+	if got, _ := def.Entry.Properties["title"].(string); got != "draft entry" {
+		t.Fatalf("precondition: the default world must serve the draft face, "+
+			"or the world assertion below proves nothing; got %q", got)
+	}
+
+	pub, err := app.views.executeView(
+		context.Background(), implementsView(), "TKT-1",
+		publishedViewWorld("ticket", "feature"))
+	if err != nil {
+		t.Fatalf("published world: %v", err)
+	}
+	if got, _ := pub.Entry.Properties["title"].(string); got != "published entry" {
+		t.Errorf("the entry must be the WORLD's face; got %q, want %q",
+			got, "published entry")
+	}
+	if pub.Entry.Pointer != entity.Pointer("published") {
+		t.Errorf("entry pointer = %q, want published", pub.Entry.Pointer)
+	}
+}
+
+// TestExecuteView_ExcludedCollectionEntityIsAbsent is the RULING 12 case for
+// collections: a traversed neighbor with no face in this world must not
+// appear, even though the EDGE to it exists in storage.
+//
+// The edge is genuinely there — traversal finds the id either way — so this
+// fails if head resolution is skipped or done in the wrong world. That is
+// exactly the shape item 4 fixed for the entity GET's relations map, now for
+// view collections.
+//
+// Mutation-checked: dropping `World: w.scope` from loadViewEntities fails this.
+func TestExecuteView_ExcludedCollectionEntityIsAbsent(t *testing.T) {
+	app := newTestAppV1(t)
+	seedViewGraph(t, app)
+
+	def, err := app.views.executeView(
+		context.Background(), implementsView(), "TKT-1", defaultViewWorld())
+	if err != nil {
+		t.Fatalf("default world: %v", err)
+	}
+	if len(collectionIDs(def)) != 2 {
+		t.Fatalf("precondition: the default world must collect BOTH features, "+
+			"or the exclusion below is vacuous; got %v", collectionIDs(def))
+	}
+
+	pub, err := app.views.executeView(
+		context.Background(), implementsView(), "TKT-1",
+		publishedViewWorld("ticket", "feature"))
+	if err != nil {
+		t.Fatalf("published world: %v", err)
+	}
+	got := map[string]bool{}
+	for _, id := range collectionIDs(pub) {
+		got[id] = true
+	}
+	if !got["FEAT-PUB"] {
+		t.Errorf("a neighbor WITH a published face must be collected; got %v", got)
+	}
+	if got["FEAT-DRAFT"] {
+		t.Errorf("a neighbor with NO published face must be ABSENT from the "+
+			"collection — under otherwise:exclude it does not exist in this "+
+			"world, so a link to it points at nothing (RULING 12); got %v", got)
+	}
+}
+
+// TestExecuteView_CollectionEntitiesAreTheWorldsFaces pins that a collected
+// entity is the world's FACE, not the default row that happens to share its id.
+//
+// Separate from the exclusion test because the two fail differently: a build
+// that resolved heads in the DEFAULT world would pass the exclusion test's
+// FEAT-PUB assertion (the id is present) while serving draft content under a
+// published view — the mixed-face bug, which reads as correct.
+func TestExecuteView_CollectionEntitiesAreTheWorldsFaces(t *testing.T) {
+	app := newTestAppV1(t)
+	seedViewGraph(t, app)
+
+	pub, err := app.views.executeView(
+		context.Background(), implementsView(), "TKT-1",
+		publishedViewWorld("ticket", "feature"))
+	if err != nil {
+		t.Fatalf("published world: %v", err)
+	}
+	for _, e := range pub.Collections["features"] {
+		if e.ID != "FEAT-PUB" {
+			continue
+		}
+		if got, _ := e.Properties["title"].(string); got != "published feature" {
+			t.Errorf("a collected entity must be the WORLD's face, not the "+
+				"default row with the same id; got title %q", got)
+		}
+		if e.Pointer != entity.Pointer("published") {
+			t.Errorf("collected FEAT-PUB pointer = %q, want published", e.Pointer)
+		}
+		return
+	}
+	t.Fatal("FEAT-PUB missing from the collection — the precondition for this test")
+}
+
+// TestExecuteView_WhereFiltersTheResolvedFace is RULING 16, proved rather than
+// asserted.
+//
+// The fixture's two faces differ in `status`: draft is `open`, published is
+// `closed`. A `where: "status = closed"` therefore matches ONLY if the filter
+// sees the published face. Filtering the draft values while rendering a
+// published page would produce a collection that contradicts its own page.
+//
+// This is a TEST obligation rather than an implementation one: filterEntities
+// reads e.Properties off whatever it is handed, so feeding it faces makes it
+// filter faces. That is precisely why it needs a test — nothing in the filter
+// code would look wrong if the faces stopped arriving.
+//
+// The entry itself is the subject here (`from: entry`), so the assertion is
+// about the entry's own face reaching the filter.
+func TestExecuteView_WhereFiltersTheResolvedFace(t *testing.T) {
+	app := newTestAppV1(t)
+	seedViewGraph(t, app)
+
+	// A traversal filtered on a property whose value DIFFERS between the two
+	// faces of the neighbor: FEAT-PUB is "draft feature" by default and
+	// "published feature" on its published face.
+	//
+	// The filter value is UNQUOTED. internal/filter treats quotes as literal
+	// characters rather than string delimiters, so `title = "x"` looks for a
+	// title containing the quote marks and matches nothing — which is how the
+	// first version of this test failed against correct code. Verified by
+	// probing filterEntities directly with both forms.
+	view := ViewConfig{
+		Entry: ViewEntry{Type: "ticket"},
+		Traverse: []ViewTraverse{{
+			From: "entry", Follow: "implements", CollectAs: "features",
+			Where: `title = published feature`,
+		}},
+	}
+
+	pub, err := app.views.executeView(
+		context.Background(), view, "TKT-1", publishedViewWorld("ticket", "feature"))
+	if err != nil {
+		t.Fatalf("published world: %v", err)
+	}
+	if ids := collectionIDs(pub); len(ids) != 1 || ids[0] != "FEAT-PUB" {
+		t.Errorf("`where:` must match against the RESOLVED FACE (RULING 16): "+
+			"the published face's title is %q and the draft's is %q, so this "+
+			"matches only if the filter sees faces rather than default rows; got %v",
+			"published feature", "draft feature", ids)
+	}
+
+	// The same filter under the DEFAULT world matches nothing, because the
+	// default rows carry the draft titles. This is the half that proves the
+	// test is discriminating rather than passing on a coincidence.
+	def, err := app.views.executeView(
+		context.Background(), view, "TKT-1", defaultViewWorld())
+	if err != nil {
+		t.Fatalf("default world: %v", err)
+	}
+	if ids := collectionIDs(def); len(ids) != 0 {
+		t.Errorf("under the default world the published title matches nothing; got %v", ids)
+	}
+}
+
+// TestViewWorld_ProvenanceOnCollectionEntities pins the RULING 14 payload —
+// the reason item 4b exists.
+//
+// Item 4 deferred per-neighbor provenance because the entity GET's
+// `relations` map carries bare id STRINGS with nowhere to put it. A view
+// collection carries whole ENTITIES, so the slot is natural, and this is where
+// it lands.
+//
+// Asserts all three fields, and both worlds: present and correct under a
+// world, ABSENT under the default one (where every entity is its default state
+// by definition, so a block on every row would be noise).
+func TestViewWorld_ProvenanceOnCollectionEntities(t *testing.T) {
+	t.Parallel()
+
+	pub := publishedViewWorld("ticket", "feature")
+	face := &entity.Entity{
+		ID: "FEAT-PUB", Type: "feature", Pointer: entity.Pointer("published"),
+	}
+
+	got := pub.provenanceFor(face)
+	if got == nil {
+		t.Fatal("a non-default world must label its faces — this block is the " +
+			"whole reason item 4b exists (RULING 14)")
+	}
+	if got.Name != "published" {
+		t.Errorf("Name = %q, want published", got.Name)
+	}
+	if got.Pointer != "published" {
+		t.Errorf("Pointer = %q, want the coordinate the face was stored at", got.Pointer)
+	}
+	if got.Via != ruleChain {
+		t.Errorf("Via = %q, want %q: `published` is in this world's chain",
+			got.Via, ruleChain)
+	}
+
+	if defaultViewWorld().provenanceFor(face) != nil {
+		t.Error("the DEFAULT world must not label: every entity is its default " +
+			"state there by definition, so a block on every row of every " +
+			"existing view is noise — and implies a world was applied")
+	}
+}
+
+// TestViewWorld_ProvenanceDistinguishesFallbackFromChain is the distinction
+// the provenance block exists to make, and the one a client cannot re-derive.
+//
+// A chain-resolved face and a fallback-resolved one arrive BYTE-IDENTICALLY —
+// same id, same type, same shape. Only `via` separates "the Dutch page" from
+// "the English page, because no Dutch page exists". A provenance block that
+// reported the same value for both would be worse than none: it would look
+// like an answer.
+func TestViewWorld_ProvenanceDistinguishesFallbackFromChain(t *testing.T) {
+	t.Parallel()
+
+	// chain [nl], fallback DEFAULT — the multilingual shape.
+	w := viewWorld{name: "site-nl", scope: store.NewWorldScope(
+		map[string]store.TypeResolution{
+			"feature": {
+				Chain:    []entity.Pointer{entity.Pointer("nl")},
+				Fallback: store.FallbackDefaultState,
+			},
+		})}
+
+	dutch := w.provenanceFor(&entity.Entity{
+		ID: "FEAT-NL", Type: "feature", Pointer: entity.Pointer("nl"),
+	})
+	fallback := w.provenanceFor(&entity.Entity{
+		ID: "FEAT-EN", Type: "feature", Pointer: entity.Pointer(""),
+	})
+
+	if dutch.Via != ruleChain {
+		t.Errorf("a face from the chain reports %q, want %q", dutch.Via, ruleChain)
+	}
+	if fallback.Via != ruleFallbackDefault {
+		t.Errorf("a face the FALLBACK stood in reports %q, want %q — this is "+
+			"the distinction the block exists for, and the one a client cannot "+
+			"re-derive without the chain and the fallback policy",
+			fallback.Via, ruleFallbackDefault)
+	}
+	if dutch.Via == fallback.Via {
+		t.Error("chain and fallback must not report the same rule")
+	}
+}
+
+// TestViewEntry_ExcludedEntryIsNotFound pins that a world excluding the ENTRY
+// yields a not-found rather than falling back to the default state.
+//
+// Absence IS the publication bit (§4.1): an entity with no published face does
+// not exist in the published world, and serving its draft instead would be the
+// exact leak `otherwise: exclude` exists to prevent.
+func TestViewEntry_ExcludedEntryIsNotFound(t *testing.T) {
+	app := newTestAppV1(t)
+
+	// Draft face only — nothing published.
+	seedEntity(app, &entity.Entity{
+		ID: "TKT-9", Type: "ticket", Properties: map[string]any{"title": "draft only"},
+	})
+
+	if _, err := app.views.executeView(
+		context.Background(), implementsView(), "TKT-9", defaultViewWorld()); err != nil {
+		t.Fatalf("precondition: the entry must exist in the default world; got %v", err)
+	}
+
+	_, err := app.views.executeView(
+		context.Background(), implementsView(), "TKT-9",
+		publishedViewWorld("ticket", "feature"))
+	if err == nil {
+		t.Error("an entry the world EXCLUDES must not resolve — serving its " +
+			"draft face instead is the leak otherwise:exclude prevents")
+	}
+}
+
+// TestExecuteView_DefaultWorldUnchanged is the compat assertion.
+//
+// Every change in item 4b sits behind a default-world branch, and a branch
+// written the wrong way round would route ordinary traffic through the world
+// path — where a zero WorldScope resolves everything to its default face and
+// would LOOK correct while taking a different route with different error
+// handling and different batching.
+func TestExecuteView_DefaultWorldUnchanged(t *testing.T) {
+	app := newTestAppV1(t)
+	seedViewGraph(t, app)
+
+	result, err := app.views.executeView(
+		context.Background(), implementsView(), "TKT-1", defaultViewWorld())
+	if err != nil {
+		t.Fatalf("default world: %v", err)
+	}
+	if got, _ := result.Entry.Properties["title"].(string); got != "draft entry" {
+		t.Errorf("the default world serves the default state, as before; got %q", got)
+	}
+	ids := collectionIDs(result)
+	if len(ids) != 2 {
+		t.Errorf("the default world collects every neighbor regardless of "+
+			"which faces exist; got %v", ids)
+	}
+	for _, e := range result.Collections["features"] {
+		if e.Pointer != entity.Pointer("") {
+			t.Errorf("%s: the default world serves default-state rows; got pointer %q",
+				e.ID, e.Pointer)
+		}
+	}
+}

--- a/internal/dataentry/world.go
+++ b/internal/dataentry/world.go
@@ -236,13 +236,39 @@ func worldCapablePath(path string) bool {
 		return false
 	}
 	trimmed = strings.Trim(trimmed, "/")
-	if trimmed == "" || strings.HasPrefix(trimmed, "_") {
+	if trimmed == "" {
+		return false
+	}
+	// The ONE underscore route that is world-capable: the entity view
+	// (TKT-WRLDAPI item 4b). It is named exactly rather than admitted by a
+	// prefix rule, so widening the underscore family stays a deliberate act —
+	// every other `_`-prefixed endpoint remains refused by the clause below.
+	if isWorldCapableViewPath(trimmed) {
+		return true
+	}
+	if strings.HasPrefix(trimmed, "_") {
 		return false
 	}
 	// `{plural}` or `{plural}/{id}` only. A third segment is a
 	// sub-resource (relations, attachments, _export) and is refused.
 	return strings.Count(trimmed, "/") <= 1 &&
 		!strings.Contains(trimmed, "/_")
+}
+
+// isWorldCapableViewPath matches `_views/{type}/{id}` — the entity view, whose
+// whole read path was world-scoped in TKT-WRLDAPI item 4b.
+//
+// EXACTLY three segments, and the id must be non-empty. `_views/{name}` (a
+// standalone view by config name) is a DIFFERENT surface reached through a
+// different handler, and it is not scoped: it is refused here rather than
+// admitted by a looser prefix match.
+//
+// `_sidepanel` and the command runner's `kind: view` share executeView but are
+// not routes this admits — and they pass defaultViewWorld() explicitly, so
+// even a future routing mistake could not hand them a world. See [viewWorld].
+func isWorldCapableViewPath(trimmed string) bool {
+	parts := strings.Split(trimmed, "/")
+	return len(parts) == 3 && parts[0] == "_views" && parts[1] != "" && parts[2] != ""
 }
 
 // worldRefusesSearch reports whether this request combines a non-default

--- a/internal/dataentry/world_test.go
+++ b/internal/dataentry/world_test.go
@@ -67,7 +67,16 @@ func TestWorldCapablePath(t *testing.T) {
 		{"/api/v1/tickets/TKT-1/relations", false, "sub-resource reads through the ungated reader"},
 		{"/api/v1/tickets/TKT-1/_export", false, "export reads through the ungated reader"},
 		{"/api/v1/_search", false, "the searcher cannot honor a world"},
-		{"/api/v1/_views/board", false, "view traversal is world-blind"},
+		{"/api/v1/_views/board", false,
+			"a two-segment _views path is the standalone-view surface, which is NOT scoped"},
+		{"/api/v1/_views/policy/POL-1", true,
+			"the ENTITY view is world-scoped end to end (TKT-WRLDAPI item 4b)"},
+		{"/api/v1/_views/policy/POL-1/extra", false,
+			"a fourth segment is not the entity view; the match is exact, not a prefix"},
+		{"/api/v1/_views//POL-1", false, "an empty type segment is not a view path"},
+		{"/api/v1/_views/policy/", false, "an empty id segment is not the entity view"},
+		{"/api/v1/_sidepanel/policy/POL-1", false,
+			"the side panel shares executeView but was never scoped; it passes defaultViewWorld()"},
 		{"/api/v1/_documents/report", false, "document render and its cache key are world-blind"},
 		{"/api/v1/_position", false, "position reads through the search path"},
 		{"/api/v1/_analyze", false, "whole-graph, tracer-backed"},
@@ -364,6 +373,20 @@ func TestWorldCapableRoutesDoNotUseUngatedReader(t *testing.T) {
 		"includeCandidates":      true,
 		"defaultWorldCandidates": true,
 		"worldCandidates":        true,
+		// TKT-WRLDAPI item 4b made `_views/{type}/{id}` world-capable, so its
+		// handler joins the scanned set. It reached the ungated reader for the
+		// entry's relations, which under a world would pair a resolved entry
+		// with default-world edges — the mixed-face bug. Adding the route to
+		// worldCapablePath without adding the handler here would have shipped
+		// that silently, which is exactly what this guard is for.
+		"handleV1Views": true,
+		// The catch-all dispatcher for `/api/v1/{plural}[/{id}]` — the
+		// world-capable family. It only parses the path and delegates, so it
+		// reaches no reader today; it is listed because the DERIVED check below
+		// requires every world-capable route's handler to be scanned, and
+		// because a dispatcher that grows a reader call is exactly the change
+		// that should fail loudly.
+		"handleV1DynamicRoutes": true,
 	}
 
 	entries, err := os.ReadDir(".")
@@ -443,6 +466,142 @@ func TestWorldCapableRoutesDoNotUseUngatedReader(t *testing.T) {
 		t.Fatalf("scanned %d of %d world-capable functions — if these were "+
 			"renamed, update this guard rather than letting it go quiet",
 			scanned, len(worldCapableFuncs))
+	}
+
+	// And the enumeration itself must be COMPLETE — see
+	// TestWorldCapableRoutesAreAllScanned.
+	assertEveryWorldCapableRouteIsScanned(t, worldCapableFuncs)
+}
+
+// assertEveryWorldCapableRouteIsScanned derives the set of world-capable
+// ROUTE HANDLERS from the route table and fails on any that
+// TestWorldCapableRoutesDoNotUseUngatedReader does not scan.
+//
+// # Why this exists (RULING 15, applied to a test)
+//
+// The scanned set above is a hand-written literal. That makes the guard a
+// check whose FAILURE MODE IS SILENCE: when a route becomes world-capable and
+// its handler is not in the list, the guard does not fail — it passes while
+// checking nothing.
+//
+// That is not hypothetical. It happened TWICE in this epic:
+//
+//   - item 4 extracted a reader-using loop into a helper, which left the
+//     guard's view entirely; and
+//   - item 4b admitted `_views/{type}/{id}` to worldCapablePath while
+//     handleV1Views stayed unlisted — hiding a real leak (the entry's
+//     relations were still read through the ungated, default-world reader)
+//     that was found by READING the code, not by testing it.
+//
+// The third instance is the one that ships, because by then the guard is
+// trusted. So the enumeration is now derived rather than asserted: a new
+// world-capable route fails HERE, loudly, naming the route and the handler.
+func assertEveryWorldCapableRouteIsScanned(t *testing.T, scanned map[string]bool) {
+	t.Helper()
+
+	for _, route := range registeredAPIRoutes(t) {
+		if !worldCapablePath(probePathFor(route.pattern)) {
+			continue
+		}
+		if !scanned[route.handler] {
+			t.Errorf("route %q is WORLD-CAPABLE but its handler %q is not in "+
+				"the scanned set of TestWorldCapableRoutesDoNotUseUngatedReader.\n"+
+				"A world-capable handler that nobody scans can reach the "+
+				"ungated, DEFAULT-WORLD entityReader and pair a resolved entity "+
+				"with draft relations — the mixed-face bug — with no test "+
+				"failing. Add %q to worldCapableFuncs (and make sure it "+
+				"consults the world), or narrow worldCapablePath.",
+				route.pattern, route.handler, route.handler)
+		}
+	}
+}
+
+// apiRoute is one `mux.HandleFunc(pattern, handler)` registration.
+type apiRoute struct {
+	pattern string // e.g. "/api/v1/_views/"
+	handler string // the final selector, e.g. "handleV1Views"
+}
+
+// registeredAPIRoutes parses the route table out of the package source.
+//
+// Parsing rather than calling the registration function: building a real App
+// needs a project on disk and a store, and this assertion is about the STATIC
+// shape of the route table, which is exactly what the source states.
+func registeredAPIRoutes(t *testing.T) []apiRoute {
+	t.Helper()
+	entries, err := os.ReadDir(".")
+	if err != nil {
+		t.Fatalf("read package dir: %v", err)
+	}
+	fset := token.NewFileSet()
+	var routes []apiRoute
+	for _, entry := range entries {
+		name := entry.Name()
+		if entry.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		file, perr := parser.ParseFile(fset, name, nil, 0)
+		if perr != nil {
+			t.Fatalf("parse %s: %v", name, perr)
+		}
+		ast.Inspect(file, func(n ast.Node) bool {
+			call, ok := n.(*ast.CallExpr)
+			if !ok || len(call.Args) != 2 {
+				return true
+			}
+			sel, ok := call.Fun.(*ast.SelectorExpr)
+			if !ok || sel.Sel == nil || sel.Sel.Name != "HandleFunc" {
+				return true
+			}
+			lit, ok := call.Args[0].(*ast.BasicLit)
+			if !ok || lit.Kind != token.STRING {
+				return true
+			}
+			pattern := strings.Trim(lit.Value, `"`)
+			if !strings.HasPrefix(pattern, "/api/v1/") {
+				return true
+			}
+			if h := handlerName(call.Args[1]); h != "" {
+				routes = append(routes, apiRoute{pattern: pattern, handler: h})
+			}
+			return true
+		})
+	}
+	if len(routes) == 0 {
+		t.Fatal("parsed no /api/v1/ routes — the registration shape changed; " +
+			"update this derivation rather than letting the guard go quiet")
+	}
+	return routes
+}
+
+// handlerName renders the final selector of a handler expression
+// (`a.views.handleV1Views` -> "handleV1Views").
+func handlerName(arg ast.Expr) string {
+	switch fn := arg.(type) {
+	case *ast.SelectorExpr:
+		if fn.Sel != nil {
+			return fn.Sel.Name
+		}
+	case *ast.Ident:
+		return fn.Name
+	}
+	return ""
+}
+
+// probePathFor turns a mux pattern into a concrete path to ask
+// worldCapablePath about.
+//
+// A trailing slash means a prefix route, so it is probed with plausible
+// segments; `/api/v1/` (the dynamic catch-all) is probed as an entity path,
+// since that is what it actually serves.
+func probePathFor(pattern string) string {
+	switch {
+	case pattern == "/api/v1/":
+		return "/api/v1/tickets/TKT-1"
+	case strings.HasSuffix(pattern, "/"):
+		return pattern + "sometype/SOME-1"
+	default:
+		return pattern
 	}
 }
 


### PR DESCRIPTION
🌍 World-capable entity view, with per-collection provenance (TKT-WRLDAPI item 4b)

Tickets-PR: #1422

`GET /_views/{type}/{id}` now serves a world. This is the surface the SPA's detail page actually calls, so it is what makes item 4's API-level correctness visible to a user.

## What changed

1. **The entry resolves to the world's face.** `executeView` read it via a raw `store.GetEntity`, which under any world yields the wrong object — the page rendered draft content while claiming to be a published view.
2. **Collections resolve per neighbour** (RULING 12), so a traversed entity with no face in this world is absent rather than shown as its default state.
3. **`_world` provenance on every collection entity** — the RULING 14 payload, and the reason 4b exists.
4. **`where:` evaluates against the resolved face** (RULING 16).

## Per-collection provenance: the slot item 4 did not have

Item 4 deferred per-neighbour provenance because the entity GET's `relations` map carries bare **id strings**, with nowhere to put a provenance block short of a wire-type change. A view collection carries whole **entities**, so the field is additive:

```
ViewEntity._world  {name, pointer, via}
```

It shares `resolutionRule` with the entity GET's block rather than deriving the rule again — a view row and a GET of the same entity under the same world cannot disagree. Present only under a non-default world: under the default, every entity is its default state by definition, so a block on every row would be noise *and* would imply a world was applied.

## The shared-engine problem, and why the world is a parameter

`executeView` has **three** callers, and only one is world-capable:

| Caller | Route | World |
|---|---|---|
| `handleV1Views` | `GET /_views/{type}/{id}` | request's |
| `executeSidePanel` | `_sidepanel` | `defaultViewWorld()` |
| command runner | `kind: view` | `defaultViewWorld()` |

The command runner marshals its `viewResult` to JSON and pipes it to an operator shell script's stdin (`exec.CommandContext(ctx, "sh", "-c", cmd.Script)`). A world applied there would change **what an external process receives**, past any layer that could observe it.

So the world arrives as an explicit **parameter**, never read from ctx: if the engine read it, the two unscoped surfaces would *inherit* world-awareness rather than opting into it. `defaultViewWorld()` is spelled at both unscoped call sites so a reader sees a choice, not an omission. `TestExecuteViewCallersDeclareTheirWorld` parses the fourth argument of every `executeView` call — a caller *count* would pass through exactly the swap it exists to catch.

## Traversal: ids first, one resolution per rule

`traverseViewOnce`/`traverseViewRecursive` now return **ids**, and `applyViewTraverse` resolves them once per rule application. The per-hop shape would multiply an N+1 by the 10-pass fixpoint *and* by the recursive depth. The walk already stepped by id and never needed the entities, so this fell out cleanly rather than fighting the structure.

`traverseViewOnce` keeps a **nil-tail** relation query, deliberately: a view traverses the entity graph, heads are entity-level (§2.3), and filtering by the source's pointer would hit the "fallback trap" and hide identity edges. **Consequence, in user terms: a view's traversal can surface a neighbour the same entity's GET would not show under that world.** Two surfaces disagreeing about one graph reads as a bug when someone hits it — naming it here means the next person recognises it instead of "fixing" it into the trap.

## The guard now derives its own enumeration

`TestWorldCapableRoutesDoNotUseUngatedReader` trusted a hand-written list of handlers. That is a check whose failure mode is silence: when a route becomes world-capable and its handler is not listed, the guard passes while checking nothing.

That is not hypothetical — it happened **twice**, and the second time it hid a live leak in this PR (`handleV1Views` still read the entry's relations through the ungated, default-world reader). The guard now parses the route table and fails on any world-capable route whose handler is unscanned. On its first run it found a **second** unscanned handler, `handleV1DynamicRoutes` — the catch-all serving every entity path, clean today but never checked by anything.

Residual, stated rather than implied: it **parses** rather than executes (executing needs a project and store on disk). A wholesale registration-shape change fails loudly; a *partial* one would silently shrink the derived set.

## Mutation checks (RULING 10)

Behavioural world tests did not exist before this PR — `viewWorld.isDefault() → true` killed nothing, which I reported as the honest state rather than shipping a green suite that proved nothing.

| Mutation | Tests killed |
|---|---|
| `isDefault() → true` | **7** (was 0) |
| `World:` dropped from `loadViewEntities` | 4 |
| `World:` dropped from `viewEntry` | 5 |
| `provenanceFor` → always nil | 2 |
| `Via` hardcoded to `chain` | 2 |
| Remove world check from `defaultWorldCandidates` | route guard |
| Drop `handleV1Views` from the scanned set | derived guard |

All verified in a **detached worktree** with build-aware counting: a mutant that fails to compile is reported `BUILD-BROKEN` from an observed non-zero build exit, never scored as a test result.

**One test of mine failed against correct code**, and the diagnosis order matters: `internal/filter` treats quotes as literal characters, so `title = "x"` searches for a title *containing quote marks*. I probed `filterEntities` directly with both forms rather than assuming the implementation was wrong. The unquoted requirement is now noted in the test so nobody "fixes" it into quotes and silently matches nothing.

## Known gaps, tracked

- **Entry relations under a world are empty** — the ungated reader would pair a resolved entry with default-world edges (the mixed-face bug). Guarded, not closed; tracked as **item 4c**. A visible absence beats a subtly-wrong relation shape on a surface whose response differs from the entity GET's.
- **`_sidepanel` and the command runner** remain default-world by explicit declaration, each its own scoping decision.

## Docs

`docs-project/entities/guides/GUIDE-data-entry.md` updated for the new `where:` semantics and regenerated via `just docs`. The pre-existing fail-open on an unparseable `where:` is now documented as a known defect naming BUG-WHEREWIDE, rather than as design.

## CI

Full `just ci` on a detached worktree at `dab2772b`: `EXIT=0`, 581 lines, zero `FAIL`. Lint `0 issues`, arch-lint `OK - No warnings found`, commentlint `no findings across 10847 comments`, package + total coverage thresholds `PASS` (78.0%), `✓ Docs are up to date`.
