### PR TITLE
docs(tickets): mark FEAT-79DTF9 implemented

### DIFF
--- a/tickets/entities/features/FEAT-79DTF9.md
+++ b/tickets/entities/features/FEAT-79DTF9.md
@@ -5,7 +5,7 @@ title: Declarative next-action layer
 summary: Operator-configured rules that derive one suggested follow-up from graph state and surface it as an advisory hint in the UI.
 description: Operator-configured sources derive a suggested follow-up from graph state and surface one at a time in the UI — advisory ("could do"), never a task queue. Sources yield entity-shaped candidates; operator-defined ordered bands rank them, with stable-random selection within a band. Snooze/mute/cooldown live in a per-user state service (mem/disk/postgres), never in the graph, and resolved suggestions are never cached because a cross-principal cache would defeat the ACL gate. Phase 0 ships without store changes; Phase 1 extends store.GraphQuery with property predicates.
 priority: medium
-status: in-progress
+status: implemented
 ---
 
 ## What


### PR DESCRIPTION
#1398 landed the `condition:` key, which closed the last gap. Verified against
`develop` rather than assumed — S1, the scenario that motivated the feature,
now validates verbatim from RES-09YLLL:

```yaml
chase-proposal:
  band: blocking
  query: "type:proposal prop:status=sent"
  condition: "days_between(entity.sent_on, today()) >= 11"
```

and a typo still fails at load:
`unknown attribute "sentt_on" on record`.

Seven of the eight grounding scenarios are now expressible:

| | Scenario | Status |
|---|---|---|
| S6 | first run (`count`) | works |
| S8 | quip (ambient, stable-random) | works |
| S2 | `pick_one` | works |
| S3 | no billing contact (relation negation) | works |
| S5 | completed without invoice | works |
| S1 | proposal out 11 days | works (#1398) |
| S4 | SOW in draft a while | works (#1398) |
| S7 | far-side recency | **out of scope**, as recorded in the research |

The remaining research items (analytics log, permission-filtered candidates,
set-shaped sources) are recorded there as deferred or not-planned, each
independently schedulable — not unfinished scope of this feature.

`rela validate --project tickets` green.

Note: TKT-N8XQ2R is still `backlog` despite being built and merged. Moving it to
`done` needs the implementation/review checklist flow rather than a status flip,
so it is deliberately left alone here.