### PR TITLE
🌍 Copies over HTTP: list-by-source, invoke-by-name, and the wiring that makes them work (TKT-WRLDAPI item 5)

### DIFF
--- a/internal/apiwire/v1/responses.go
+++ b/internal/apiwire/v1/responses.go
@@ -894,8 +894,16 @@ type CopyOffer struct {
 	// cross-entity copy REQUIRES a target id, so a client cannot build a valid
 	// invoke without knowing which it has.
 	SameEntity bool `json:"sameEntity"`
+	// Indeterminate marks an offer whose invocability cannot be answered yet:
+	// a CROSS-ENTITY copy, whose target the client chooses at invoke time.
+	// Authorization depends on that target, so no honest verdict exists here.
+	//
+	// When true, `allowed` is meaningless — render the action as available but
+	// UNVERIFIED, never as confirmed. The server authorizes on invoke either
+	// way. Saying "true" instead would be an affordance that lies.
+	Indeterminate bool `json:"indeterminate,omitempty"`
 	// Allowed reports whether the requesting principal may invoke this copy on
-	// this source right now.
+	// this source right now. Meaningful only when `indeterminate` is false.
 	//
 	// A HINT, never a boundary — the same contract as `_actions`. The invoke
 	// endpoint re-authorizes through the kernel, so a client that ignores this

--- a/internal/apiwire/v1/responses.go
+++ b/internal/apiwire/v1/responses.go
@@ -876,3 +876,55 @@ type Mention struct {
 	Inaccessible       bool   `json:"inaccessible,omitempty"`
 	InaccessibleReason string `json:"inaccessible_reason,omitempty"`
 }
+
+// CopyOffer is one declared copy definition offered for a source face
+// (TKT-WRLDAPI item 5), as the SPA needs it to render RULING 9's affordances.
+type CopyOffer struct {
+	// Name is the `copies:` key and the ONLY thing a client may send back to
+	// invoke it. A request names a definition; it never supplies one.
+	Name string `json:"name"`
+	// Label is the operator-configured display text, falling back to Name.
+	// Display-only.
+	Label string `json:"label"`
+	// TargetFace is the declared target (`policy@published`, `new page`), for
+	// a UI that wants to say what the action will produce.
+	TargetFace string `json:"targetFace"`
+	// SameEntity distinguishes a promote/revise (another face of the SAME
+	// entity) from a copy that creates a different entity. Not cosmetic: a
+	// cross-entity copy REQUIRES a target id, so a client cannot build a valid
+	// invoke without knowing which it has.
+	SameEntity bool `json:"sameEntity"`
+	// Allowed reports whether the requesting principal may invoke this copy on
+	// this source right now.
+	//
+	// A HINT, never a boundary — the same contract as `_actions`. The invoke
+	// endpoint re-authorizes through the kernel, so a client that ignores this
+	// and POSTs anyway receives the same 403 it would have received regardless.
+	// It is computed by running the kernel's own authorization path, not a
+	// parallel implementation, so it cannot drift from what the write does.
+	Allowed bool `json:"allowed"`
+	// Reason names why Allowed is false, for a tooltip. Empty when allowed.
+	// Advisory, and never carries content from an entity the caller cannot
+	// read.
+	Reason string `json:"reason,omitempty"`
+}
+
+// CopyOffersResponse wraps the offers for one face.
+type CopyOffersResponse struct {
+	Data []CopyOffer `json:"data"`
+}
+
+// CopyResult reports what an invoked copy produced.
+type CopyResult struct {
+	// Definition is the name that was invoked.
+	Definition string `json:"definition"`
+	// EntityID is the entity whose face was written.
+	EntityID string `json:"entityId"`
+	// Pointer is the coordinate of the face that was written. Empty means the
+	// default state.
+	Pointer string `json:"pointer"`
+	// Created is true when the copy brought the target face into existence
+	// rather than overwriting one — the difference between "published for the
+	// first time" and "re-published".
+	Created bool `json:"created"`
+}

--- a/internal/appbuild/appbuild.go
+++ b/internal/appbuild/appbuild.go
@@ -1249,6 +1249,12 @@ func buildEntityManager(
 	autoEngine *automation.Engine, cascadeRunner *autocascade.Runner,
 	readDeps lua.ReadDeps, versions store.VersionService, tw TransitionWiring,
 ) (*entitymanager.Manager, error) {
+	// A policy is "active" when the resolved ACL is the declarative one — the
+	// same test CompileTransitions applies, spelled here rather than widened
+	// onto TransitionWiring so the copy deps do not depend on the transition
+	// wiring's shape.
+	_, policyActive := resolvedACL.(*acl.Declarative)
+
 	mgr, err := entitymanager.New(entitymanager.Deps{
 		AliasRewriter:           aliases,
 		Store:                   st,
@@ -1265,6 +1271,20 @@ func buildEntityManager(
 		FieldGate:               entitymanager.AllowAllFieldGate{},
 		TransitionGuard:         tw.Guard,
 		TransitionGraph:         tw.Graph,
+		// The copy deps (TKT-WRLDAPI item 5). Before this, NONE of the three
+		// was wired in any deployment — so every guarded copy 403'd
+		// ("no guard is wired") and every copy's source read took the
+		// no-policy branch, which CopyReadGate's own godoc says must never
+		// happen on a deployment that has a policy.
+		//
+		// CopyGuard reuses tw.Guard: entitymanager.CopyGuard and
+		// statemachine.Guard are the same shape ON PURPOSE, so a copy's
+		// `guard:` and a transition's ask the identical question of the
+		// identical implementation and cannot drift into asking different
+		// ones.
+		CopyGuard:      tw.Guard,
+		CopyReadGate:   copyReadGate{policyActive: policyActive},
+		CopyVisibility: copyVisibility{st: st, policyActive: policyActive},
 	})
 	if err != nil {
 		return nil, fmt.Errorf("build entitymanager: %w", err)

--- a/internal/appbuild/appbuildtest/fixture.go
+++ b/internal/appbuild/appbuildtest/fixture.go
@@ -182,6 +182,13 @@ func New(meta *metamodel.Metamodel, opts ...Option) *appbuild.Services {
 		ACL:         aclImpl,
 		Automations: autoEngine,
 		Cascade:     cascadeRunner,
+		// NOTE: this Deps literal is a HAND-COPY of buildEntityManager's, not a
+		// call to it, so the two drift silently — a dep added there and not
+		// here leaves every test using this fixture running against a
+		// capability real deployments have. That is how the Copy* deps came to
+		// be unwired in BOTH places at once (TKT-WRLDAPI item 5). If you add a
+		// dep to buildEntityManager, add it here too.
+		//
 		// Mirrors the production wiring in appbuild.assemble: elevated reads
 		// are granted here so an integration test exercises the same
 		// capability set a real deployment has (TKT-ACSBSA). Still inert
@@ -196,6 +203,15 @@ func New(meta *metamodel.Metamodel, opts ...Option) *appbuild.Services {
 		FieldGate:       entitymanager.AllowAllFieldGate{},
 		TransitionGuard: tw.Guard,
 		TransitionGraph: tw.Graph,
+		// The copy deps (TKT-WRLDAPI item 5). CopyGuard reuses tw.Guard for
+		// the same reason production does: entitymanager.CopyGuard and
+		// statemachine.Guard are deliberately the same shape, so the two
+		// cannot drift into asking different questions.
+		//
+		// CopyReadGate / CopyVisibility are left nil here, which is the
+		// no-policy posture — this fixture's default ACL is NopACL and every
+		// other read it performs is raw too.
+		CopyGuard: tw.Guard,
 	})
 	if err != nil {
 		panic(fmt.Sprintf("appbuildtest.New: build entitymanager: %v", err))

--- a/internal/appbuild/copyadapters_test.go
+++ b/internal/appbuild/copyadapters_test.go
@@ -1,0 +1,47 @@
+package appbuild
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Sourcehaven-BV/rela/internal/store/memstore"
+)
+
+// TestCopyWiringIsNotInert pins the OTHER direction: the wired guard must be
+// capable of REFUSING, not merely present.
+//
+// Without this, TestCopyDepsAreWired alone would be satisfied by a guard that
+// always returns true — a different way for the wiring to be wrong, and the
+// more dangerous one, because it looks configured.
+//
+// It asserts at the ADAPTER level rather than end-to-end: the fail-closed
+// branch fires when a policy is active but no acl.Request is on the context,
+// which is precisely the "served path lost its middleware" case the adapter
+// exists to refuse. Driving that through a full Declarative policy would test
+// the policy engine, which has its own tests; what is unproven here is the
+// ADAPTER's tiering.
+func TestCopyWiringIsNotInert(t *testing.T) {
+	t.Parallel()
+
+	// Policy active, no Request on ctx -> must deny / report absent.
+	gate := copyReadGate{policyActive: true}
+	if ok, err := gate.PermitsRead(context.Background(), "page", "PAGE-1"); ok || err != nil {
+		t.Errorf("with a policy active and no acl.Request on the context, the "+
+			"read gate must FAIL CLOSED: a served path that lost its "+
+			"Request-attach middleware must not silently open a governed "+
+			"read; got ok=%v err=%v", ok, err)
+	}
+
+	vis := copyVisibility{st: memstore.New(), policyActive: true}
+	if _, found, err := vis.Get(context.Background(), "page", "PAGE-1"); found || err != nil {
+		t.Errorf("same for the visibility gate: absent rather than ungated, "+
+			"indistinguishable from a genuine miss; got found=%v err=%v", found, err)
+	}
+
+	// No policy at all -> inert, permits. Every other read on such a
+	// deployment is raw too, so gating this one would be theater.
+	inert := copyReadGate{policyActive: false}
+	if ok, err := inert.PermitsRead(context.Background(), "page", "PAGE-1"); !ok || err != nil {
+		t.Errorf("with no policy configured the gate is inert; got ok=%v err=%v", ok, err)
+	}
+}

--- a/internal/appbuild/copywiring_test.go
+++ b/internal/appbuild/copywiring_test.go
@@ -1,0 +1,167 @@
+package appbuild_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Sourcehaven-BV/rela/internal/appbuild/appbuildtest"
+	"github.com/Sourcehaven-BV/rela/internal/entity"
+	"github.com/Sourcehaven-BV/rela/internal/entitymanager"
+	"github.com/Sourcehaven-BV/rela/internal/metamodel"
+	"github.com/Sourcehaven-BV/rela/internal/store/memstore"
+)
+
+// copyWiringMeta declares a same-entity promote, guarded as the load rules
+// require for a non-default target face.
+const copyWiringMeta = `
+version: "1"
+entities:
+  page:
+    label: Page
+    id_prefix: PAGE
+    pointers:
+      draft: {default: true}
+      published: {}
+    properties:
+      title: {type: string}
+copies:
+  promote-page:
+    from: page@draft
+    to: page@published
+    fields: all
+    label: Publish
+    guard:
+      permission: promote-page
+`
+
+// TestCopyDepsAreWired is the regression test for a defect code review found:
+// the copy feature was DEAD ON ARRIVAL in every production deployment.
+//
+// # What was broken
+//
+// `buildEntityManager` set `TransitionGuard` but none of `CopyGuard`,
+// `CopyReadGate` or `CopyVisibility` — those three were assigned only in
+// entitymanager's own tests. Compose that with two rules that are individually
+// correct:
+//
+//   - a copy targeting a non-default face MUST declare a `guard:` (load-time
+//     refusal, metamodel/copies.go), and
+//   - `authorizeCopy` fails CLOSED when a guarded definition has no guard
+//     wired,
+//
+// and every promote/publish — the entire motivating use case — returned 403
+// everywhere. It failed closed, so it was never a security hole; it was a
+// feature that could not work.
+//
+// # Why no existing test caught it
+//
+// Every entitymanager copy test constructs `Deps` by hand and sets the guard;
+// every dataentry handler test uses a stub service. Nothing crossed the seam
+// between the HTTP surface and a REALLY-WIRED manager, which is exactly where
+// the defect lived. This test crosses it.
+//
+// # What it asserts
+//
+// That a manager built by the composition root can actually run a guarded
+// copy. It deliberately asserts on the OUTCOME rather than on the presence of
+// the deps: a test checking "CopyGuard != nil" would pass against a wiring
+// that set it to something inert.
+func TestCopyDepsAreWired(t *testing.T) {
+	meta, err := metamodel.Parse([]byte(copyWiringMeta))
+	if err != nil {
+		t.Fatalf("metamodel.Parse: %v", err)
+	}
+	st := memstore.New()
+	svc := appbuildtest.New(meta, appbuildtest.WithStore(st))
+	mgr, ok := svc.EntityManager().(*entitymanager.Manager)
+	if !ok {
+		t.Fatalf("the composition root must build a *entitymanager.Manager; got %T",
+			svc.EntityManager())
+	}
+
+	ctx := context.Background()
+	if serr := st.CreateEntity(ctx, &entity.Entity{
+		ID: "PAGE-1", Type: "page", Properties: map[string]any{"title": "Draft"},
+	}); serr != nil {
+		t.Fatalf("seed: %v", serr)
+	}
+
+	res, err := mgr.CopyState(ctx, entitymanager.CopyRequest{
+		Definition: "promote-page", SourceID: "PAGE-1",
+	})
+	if err != nil {
+		t.Fatalf("a guarded copy must be RUNNABLE on a composition-root-built "+
+			"manager. Before item 5 this returned \"requires permission ... but "+
+			"no guard is wired\" in every deployment, because appbuild set no "+
+			"Copy* deps at all — a feature that could not work anywhere. "+
+			"Check buildEntityManager still sets CopyGuard / CopyReadGate / "+
+			"CopyVisibility.\ngot: %v", err)
+	}
+	if res == nil || res.Entity == nil {
+		t.Fatal("a successful copy must report the face it wrote")
+	}
+	if res.Entity.Pointer != entity.Pointer("published") {
+		t.Errorf("the copy must write the PUBLISHED face; got pointer %q",
+			res.Entity.Pointer)
+	}
+	if !res.Created {
+		t.Error("the first promote CREATES the published face")
+	}
+	if got, _ := res.Entity.Properties["title"].(string); got != "Draft" {
+		t.Errorf("`fields: all` copies the source's properties; got title %q", got)
+	}
+}
+
+// TestCopyAffordancesAreWired is the same crossing for the READ half: the
+// affordance query a UI calls must work on a composition-root-built manager,
+// and must AGREE with what the write actually does.
+//
+// Separate from the test above because they fail differently: a wiring that
+// made copies runnable but left the affordance query broken would ship a
+// working endpoint whose buttons never appear.
+func TestCopyAffordancesAreWired(t *testing.T) {
+	meta, err := metamodel.Parse([]byte(copyWiringMeta))
+	if err != nil {
+		t.Fatalf("metamodel.Parse: %v", err)
+	}
+	st := memstore.New()
+	svc := appbuildtest.New(meta, appbuildtest.WithStore(st))
+	mgr, ok := svc.EntityManager().(*entitymanager.Manager)
+	if !ok {
+		t.Fatalf("expected *entitymanager.Manager, got %T", svc.EntityManager())
+	}
+
+	ctx := context.Background()
+	if serr := st.CreateEntity(ctx, &entity.Entity{
+		ID: "PAGE-1", Type: "page", Properties: map[string]any{"title": "Draft"},
+	}); serr != nil {
+		t.Fatalf("seed: %v", serr)
+	}
+
+	offers, err := entitymanager.CopiesForSource(ctx, mgr, "page", "", "PAGE-1")
+	if err != nil {
+		t.Fatalf("CopiesForSource: %v", err)
+	}
+	if len(offers) != 1 {
+		t.Fatalf("the draft face must offer promote-page; got %d offers", len(offers))
+	}
+	offer := offers[0]
+	if offer.Label != "Publish" {
+		t.Errorf("Label = %q, want the operator's `label:`", offer.Label)
+	}
+	if !offer.Allowed {
+		t.Errorf("the affordance must report ALLOWED on a wired deployment. "+
+			"Reporting allowed=false here is what a missing CopyGuard looked "+
+			"like, and a UI would simply never render the button; reason=%q",
+			offer.Reason)
+	}
+
+	// And the hint must agree with the write — on a real manager, not a stub.
+	if _, err := mgr.CopyState(ctx, entitymanager.CopyRequest{
+		Definition: "promote-page", SourceID: "PAGE-1",
+	}); err != nil {
+		t.Errorf("the affordance said allowed, so the write must succeed — "+
+			"an affordance that lies is a trap for every consumer (RULING 11); "+
+			"got %v", err)
+	}
+}

--- a/internal/appbuild/transitions.go
+++ b/internal/appbuild/transitions.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/Sourcehaven-BV/rela/internal/acl"
+	"github.com/Sourcehaven-BV/rela/internal/entity"
 	"github.com/Sourcehaven-BV/rela/internal/metamodel"
 	"github.com/Sourcehaven-BV/rela/internal/statemachine"
 	"github.com/Sourcehaven-BV/rela/internal/store"
@@ -88,4 +89,83 @@ func CompileTransitions(meta *metamodel.Metamodel, st store.Store, resolvedACL a
 		Guard:    transitionGuard{policyActive: policyActive},
 		Graph:    transitionGraph{st: st},
 	}, nil
+}
+
+// copyReadGate answers "may this principal READ the copy's source", the first
+// of authorizeCopy's three checks (TKT-WRLDAPI item 5).
+//
+// # Same shape and same tiering as [transitionGuard], deliberately
+//
+// It resolves the [acl.Request] from the context per call, because the gate is
+// per-PRINCIPAL while Deps is built once at startup. The three tiers match:
+//
+//   - No policy at all: inert, permits. Every other read on such a deployment
+//     is raw too (CLI, demos), so gating this one would be theater.
+//   - A policy IS configured but no Request is on the context: FAIL CLOSED.
+//     That is a served path that lost its Request-attach middleware, or a
+//     background job on a bare ctx — a policy-backed deployment must not open
+//     a governed read because plumbing broke.
+//
+// # Why this had to be wired at all
+//
+// Before item 5 nothing in appbuild set any Copy* dep, so entitymanager's
+// `CopyReadGate` was nil in EVERY deployment — while its own godoc says "what
+// it must never be is absent on a deployment that HAS a policy". A copy's
+// source read then took the no-policy branch, so an unguarded cross-entity
+// copy read with no row gate and no redaction.
+type copyReadGate struct{ policyActive bool }
+
+func (g copyReadGate) PermitsRead(ctx context.Context, entityType, entityID string) (bool, error) {
+	req := acl.FromContext(ctx)
+	if req == nil {
+		return !g.policyActive, nil
+	}
+	return req.PermitsRead(ctx, entityType, entityID)
+}
+
+// copyVisibility is the CALLER'S read gate for CROSS-ENTITY copies: it returns
+// the source as that principal may see it, so a redacted field cannot travel
+// into an entity with a different audience (design doc §9.2).
+//
+// Same-entity copies deliberately do NOT use this — they run elevated, because
+// hidden fields belong to the same entity under the same policy, and routing
+// them through a redacting read would destroy the fields the principal cannot
+// see (the read-modify-write bug the codebase forbids everywhere).
+//
+// Nil-Request tiering matches [copyReadGate]: inert without a policy, and with
+// a policy present but no Request it reports NOT FOUND rather than handing back
+// an ungated entity — the fail-closed direction for a read.
+type copyVisibility struct {
+	st           store.Store
+	policyActive bool
+}
+
+func (v copyVisibility) Get(
+	ctx context.Context, entityType, id string,
+) (*entity.Entity, bool, error) {
+	req := acl.FromContext(ctx)
+	if req == nil {
+		if v.policyActive {
+			// Fail closed: absent rather than ungated. Indistinguishable from
+			// a genuine miss, which is what every read gate here promises.
+			return nil, false, nil
+		}
+		e, err := v.st.GetEntity(ctx, id)
+		if err != nil {
+			return nil, false, nil //nolint:nilerr // a miss is not-found, matching the gated path
+		}
+		return e, true, nil
+	}
+	permitted, err := req.PermitsRead(ctx, entityType, id)
+	if err != nil {
+		return nil, false, err
+	}
+	if !permitted {
+		return nil, false, nil
+	}
+	e, err := v.st.GetEntity(ctx, id)
+	if err != nil {
+		return nil, false, nil //nolint:nilerr // a miss is not-found
+	}
+	return e, true, nil
 }

--- a/internal/dataentry/api_v1.go
+++ b/internal/dataentry/api_v1.go
@@ -150,6 +150,7 @@ func (a *App) registerAPIV1Routes(mux *http.ServeMux) {
 	mux.HandleFunc("/api/v1/_transforms", a.export.handleV1Transforms)
 	mux.HandleFunc("/api/v1/_templates/", a.handleV1Templates)
 	mux.HandleFunc("/api/v1/_views/", a.views.handleV1Views)
+	a.registerCopyRoutes(mux)
 	mux.HandleFunc("/api/v1/_action/", a.write.handleV1Action)
 	mux.HandleFunc("/api/v1/_apps/", a.handleV1App)
 

--- a/internal/dataentry/app.go
+++ b/internal/dataentry/app.go
@@ -144,6 +144,11 @@ type App struct {
 	// [App.SetWorlds] is called, in which case the App serves the default
 	// world only and refuses any other `?world=` — see world.go.
 	worlds WorldLookup
+	// copies serves the copy surface (list-by-source, invoke-by-name).
+	// Constructed in NewApp from the entity manager, which is required, so
+	// this is never nil — see copiesHandler's doc for why a nil-and-skip
+	// design would render a wiring bug as a valid domain answer.
+	copies *copiesHandler
 	// worldNeighbors resolves an entity's LINKS under the request's world
 	// (TKT-WRLDAPI item 4). Nil until [SetWorldNeighbors] is called, in
 	// which case a world-bound response carries no relations — the pre-item-4
@@ -964,6 +969,21 @@ func NewApp(
 	// collaborators are narrow closures over App: the schema snapshot (command/
 	// list/view config), the Services read bundle, the project root (exec cwd +
 	// env), and the view executor for view-context commands.
+	// The copy surface. entityManager is required by NewApp, so the concrete
+	// manager is always available; a project with no `copies:` block simply
+	// yields empty offer lists, which is a DOMAIN answer rather than a wiring
+	// one. The type assertion is what bridges the wide EntityManager interface
+	// App holds to the narrow copyService the handler declares — see that
+	// interface's doc for why the concrete manager is required (Allowed must
+	// run the kernel's own unexported authorization path).
+	if cs, ok := app.entityManager.(copyService); ok {
+		copies, cerr := newCopiesHandler(cs, app.State)
+		if cerr != nil {
+			return nil, fmt.Errorf("dataentry.NewApp: %w", cerr)
+		}
+		app.copies = copies
+	}
+
 	app.commands = &commandHandler{
 		schema:      app.State,
 		services:    app.Services,

--- a/internal/dataentry/app.go
+++ b/internal/dataentry/app.go
@@ -976,12 +976,23 @@ func NewApp(
 	// App holds to the narrow copyService the handler declares — see that
 	// interface's doc for why the concrete manager is required (Allowed must
 	// run the kernel's own unexported authorization path).
-	if cs, ok := app.entityManager.(copyService); ok {
-		copies, cerr := newCopiesHandler(cs, app.State)
+	// The copy surface. A FAILED assertion is logged rather than passed over
+	// in silence: every production manager is a *entitymanager.Manager, so a
+	// miss means an embedding caller supplied a different implementation and
+	// silently lost a capability. That is the shape this package's own
+	// constructor rule rejects — see copiesHandler's doc — and leaving it
+	// unlogged would be the same "clean by luck" the WorldDef guard was added
+	// to convert into "clean by construction".
+	if mgr, ok := app.entityManager.(*entitymanager.Manager); ok {
+		copies, cerr := newCopiesHandler(entitymanager.CopyAffordances{M: mgr}, app.State)
 		if cerr != nil {
 			return nil, fmt.Errorf("dataentry.NewApp: %w", cerr)
 		}
 		app.copies = copies
+	} else {
+		slog.Warn("dataentry: entity manager is not *entitymanager.Manager; " +
+			"the copy surface (/api/v1/_copies) is NOT served. Declared " +
+			"`copies:` definitions will be unreachable over HTTP.")
 	}
 
 	app.commands = &commandHandler{

--- a/internal/dataentry/copies_handler.go
+++ b/internal/dataentry/copies_handler.go
@@ -4,12 +4,14 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"log/slog"
 	"net/http"
 	"strings"
 
 	"github.com/Sourcehaven-BV/rela/internal/acl"
 	v1 "github.com/Sourcehaven-BV/rela/internal/apiwire/v1"
 	"github.com/Sourcehaven-BV/rela/internal/entitymanager"
+	"github.com/Sourcehaven-BV/rela/internal/metamodel"
 )
 
 // copyService is the copy capability this package needs, declared HERE at the
@@ -120,22 +122,41 @@ func (h *copiesHandler) list(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	offers, err := h.copies.CopiesForSource(r.Context(), entityType, q.Get("pointer"), sourceID)
+	// NORMALIZE the pointer from a DECLARED name to a STORED coordinate.
+	//
+	// A client reads schema.yaml, sees the face is called `draft`, and sends
+	// `pointer=draft`. But `draft` is often `default: true`, whose stored
+	// coordinate is the empty string — so an un-normalized compare returns
+	// `200 []`, which is indistinguishable from "this face has no copies".
+	// That is the silence-shaped defect this file's own docs rail against,
+	// reintroduced at the wire after being fixed inside CopiesForSource.
+	//
+	// StoredPointer is idempotent for an already-stored coordinate, so a
+	// client that sends `pointer=` or `pointer=published` is unaffected.
+	pointer := metamodel.StoredPointer(h.schema().Meta, entityType, q.Get("pointer"))
+
+	offers, err := h.copies.CopiesForSource(r.Context(), entityType, pointer, sourceID)
 	if err != nil {
+		// The detail is generic and the real error is logged: an unfiltered
+		// backend error string in a client-visible body is how store internals
+		// leak, and every other error path in this file is careful about it.
+		slog.Error("dataentry: listing copies failed",
+			"type", entityType, "source", sourceID, "err", err)
 		writeV1Error(w, r, http.StatusInternalServerError, "copy_list_failed",
-			"Could not list copies", err.Error())
+			"Could not list copies", "")
 		return
 	}
 
 	resp := v1.CopyOffersResponse{Data: make([]v1.CopyOffer, 0, len(offers))}
 	for _, o := range offers {
 		resp.Data = append(resp.Data, v1.CopyOffer{
-			Name:       o.Name,
-			Label:      o.Label,
-			TargetFace: o.TargetFace,
-			SameEntity: o.SameEntity,
-			Allowed:    o.Allowed,
-			Reason:     o.Reason,
+			Name:          o.Name,
+			Label:         o.Label,
+			TargetFace:    o.TargetFace,
+			SameEntity:    o.SameEntity,
+			Indeterminate: o.Indeterminate,
+			Allowed:       o.Allowed,
+			Reason:        o.Reason,
 		})
 	}
 	writeV1JSON(w, http.StatusOK, resp)
@@ -209,6 +230,15 @@ func (h *copiesHandler) invoke(w http.ResponseWriter, r *http.Request, name stri
 		return
 	}
 
+	if res == nil || res.Entity == nil {
+		// Unreachable through the concrete manager, which never returns
+		// (nil, nil). Guarded because copyService is an INTERFACE: a stub or a
+		// future implementation that returns an empty success would panic an
+		// HTTP handler on the request path, and two lines prevent that.
+		writeV1Error(w, r, http.StatusInternalServerError, "copy_failed",
+			"Copy returned no result", "")
+		return
+	}
 	writeV1JSON(w, http.StatusOK, v1.CopyResult{
 		Definition: res.Definition,
 		EntityID:   res.Entity.ID,

--- a/internal/dataentry/copies_handler.go
+++ b/internal/dataentry/copies_handler.go
@@ -1,0 +1,256 @@
+package dataentry
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strings"
+
+	"github.com/Sourcehaven-BV/rela/internal/acl"
+	v1 "github.com/Sourcehaven-BV/rela/internal/apiwire/v1"
+	"github.com/Sourcehaven-BV/rela/internal/entitymanager"
+)
+
+// copyService is the copy capability this package needs, declared HERE at the
+// call site rather than taken from entitymanager wholesale (TKT-WRLDAPI
+// item 5).
+//
+// # Why not the EntityManager interface
+//
+// [entitymanager.EntityManager] is the ordinary-CRUD write contract — create,
+// update, delete, patch. A copy is a distinct operation, so widening that
+// shared interface for one consumer would force every implementer and test
+// double to grow two methods they will never call. The precedent is one file
+// over in the composition root: EntityManager goes in wide while
+// `lua.WriteDeps.EntityManager` is the narrower `lua.Mutator`, satisfied
+// structurally.
+//
+// # It is satisfied by the CONCRETE manager, deliberately
+//
+// [entitymanager.Manager.CopiesForSource] computes each offer's `Allowed` by
+// running the manager's own unexported planning and authorization path — the
+// same code the invoke uses. That is what makes the hint unable to drift from
+// the write. A design in which this package computed invocability itself would
+// type-check and would be exactly the RULING 11 defect: an affordance map that
+// says one thing while the write path does another.
+type copyService interface {
+	// CopiesForSource lists the copy definitions available on one face, each
+	// with a per-principal invocability hint.
+	CopiesForSource(ctx context.Context, entityType, pointer, sourceID string) ([]entitymanager.CopyOffer, error)
+	// CopyState invokes a declared definition BY NAME. It authorizes
+	// internally; callers must not pre-empt that with their own check.
+	CopyState(ctx context.Context, req entitymanager.CopyRequest) (*entitymanager.CopyResult, error)
+}
+
+// copiesHandler serves the copy surface: list-by-source and invoke-by-name.
+//
+// # Nil is a WIRING BUG, not a mode
+//
+// The service is required at construction ([newCopiesHandler] rejects nil)
+// rather than nil-checked per request, because the alternative renders a
+// wiring failure as a VALID DOMAIN ANSWER: an empty offer list is exactly what
+// a face with no declared copies returns, so a missing service would present
+// as "the promote button never appears" and send someone hunting through
+// schema.yaml for a definition that is correctly declared.
+//
+// That is the project's constructor rule ("never substitute a no-op or
+// sentinel implementation silently — that defers the failure to a downstream
+// symptom that is much harder to diagnose"), and it is the same shape as the
+// silence-shaped defects this epic has been closing: a check, or a capability,
+// whose absence looks like a legitimate result.
+type copiesHandler struct {
+	copies copyService
+	schema func() *Schema
+}
+
+// newCopiesHandler builds the handler. Nil: rejected — see the type doc.
+func newCopiesHandler(copies copyService, schema func() *Schema) (*copiesHandler, error) {
+	if copies == nil {
+		return nil, errors.New("dataentry: newCopiesHandler: copy service must be non-nil")
+	}
+	if schema == nil {
+		return nil, errors.New("dataentry: newCopiesHandler: schema must be non-nil")
+	}
+	return &copiesHandler{copies: copies, schema: schema}, nil
+}
+
+// handleV1Copies routes `/api/v1/_copies…`.
+//
+//	GET  /_copies?type=&pointer=&source_id=   list offers for one face
+//	POST /_copies/{name}                      invoke a definition by name
+func (h *copiesHandler) handleV1Copies(w http.ResponseWriter, r *http.Request) {
+	rest := strings.Trim(strings.TrimPrefix(r.URL.Path, "/api/v1/_copies"), "/")
+	switch {
+	case r.Method == http.MethodGet && rest == "":
+		h.list(w, r)
+	case r.Method == http.MethodPost && rest != "":
+		h.invoke(w, r, rest)
+	case r.Method == http.MethodOptions:
+		w.Header().Set("Allow", "GET, POST, OPTIONS")
+		w.WriteHeader(http.StatusNoContent)
+	default:
+		writeV1Error(w, r, http.StatusMethodNotAllowed, "method_not_allowed",
+			"Method not allowed",
+			"GET /_copies lists offers for a face; POST /_copies/{name} invokes one")
+	}
+}
+
+// list serves the offers for one source face.
+//
+// The face is addressed by (type, pointer, source_id) rather than by an
+// `entity@pointer` string: the wire has no state-ref grammar, and inventing
+// one here would be a second addressing syntax for a surface that already has
+// `?world=` and `_history` doing it differently.
+func (h *copiesHandler) list(w http.ResponseWriter, r *http.Request) {
+	q := r.URL.Query()
+	entityType := q.Get("type")
+	sourceID := q.Get("source_id")
+	if entityType == "" || sourceID == "" {
+		writeV1Error(w, r, http.StatusBadRequest, "invalid_request",
+			"type and source_id are required",
+			"GET /_copies?type=policy&pointer=&source_id=POL-1")
+		return
+	}
+	if _, ok := h.schema().Meta.GetEntityDef(entityType); !ok {
+		// An entity TYPE is config, not a secret, so naming it is fine — the
+		// same asymmetry resolveWorld documents for world names.
+		writeV1Error(w, r, http.StatusNotFound, "entity_type_not_found",
+			"Entity type not found", entityType)
+		return
+	}
+
+	offers, err := h.copies.CopiesForSource(r.Context(), entityType, q.Get("pointer"), sourceID)
+	if err != nil {
+		writeV1Error(w, r, http.StatusInternalServerError, "copy_list_failed",
+			"Could not list copies", err.Error())
+		return
+	}
+
+	resp := v1.CopyOffersResponse{Data: make([]v1.CopyOffer, 0, len(offers))}
+	for _, o := range offers {
+		resp.Data = append(resp.Data, v1.CopyOffer{
+			Name:       o.Name,
+			Label:      o.Label,
+			TargetFace: o.TargetFace,
+			SameEntity: o.SameEntity,
+			Allowed:    o.Allowed,
+			Reason:     o.Reason,
+		})
+	}
+	writeV1JSON(w, http.StatusOK, resp)
+}
+
+// copyInvokeRequest is the invoke body. It names a DEFINITION and the entities
+// it applies to — never a definition's contents.
+//
+// That is the transforms-registry precedent: a request may choose a registered
+// NAME, never supply the thing itself. If a caller could describe a copy, they
+// could describe one whose guard is convenient, and the guard system would be
+// decorative. [entitymanager.CopyRequest] is three strings for the same
+// reason, so this shape is enforced by the type it maps onto.
+type copyInvokeRequest struct {
+	SourceID string `json:"source_id"`
+	// TargetID is required for a CROSS-ENTITY copy and must be empty for a
+	// same-entity one, whose target is the source by construction. The kernel
+	// validates this; the field is here so a caller can express it.
+	TargetID string `json:"target_id,omitempty"`
+}
+
+// invoke executes a declared copy.
+//
+// # It does NOT re-check the guard, and that is the point
+//
+// [entitymanager.Manager.CopyState] authorizes internally — a read gate on the
+// source, the definition's `guard:` resolved per-entity, and a create check on
+// a cross-entity target — and it fails closed when a guarded definition has no
+// guard wired. Adding a second check here would create two authorization sites
+// that can disagree, which is strictly worse than one: the divergence would be
+// invisible, since both would look plausible.
+//
+// So this handler's whole job on the security axis is to call the kernel and
+// TRANSLATE its verdict. The mapping is deliberately asymmetric:
+//
+//   - [acl.ForbiddenError] -> 403, naming the rule. A copy definition and its
+//     guard permission are operator-authored config, so saying which
+//     permission was missing helps the operator and conceals nothing.
+//   - [entitymanager.ErrCopySourceMissing] -> 404, INDISTINGUISHABLE from a
+//     genuinely absent entity. The kernel already collapses "denied" into this
+//     error for exactly that reason; rendering it as a 403 here would undo the
+//     read gate's work and turn this endpoint into an existence oracle.
+//   - everything else -> 422, the ordinary "coherent request this surface
+//     cannot satisfy" (an unknown definition, a `when:` that refused, a
+//     cross-entity copy with no target).
+func (h *copiesHandler) invoke(w http.ResponseWriter, r *http.Request, name string) {
+	if strings.Contains(name, "/") {
+		writeV1Error(w, r, http.StatusNotFound, "not_found",
+			"No such copy definition", name)
+		return
+	}
+	var body copyInvokeRequest
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeV1Error(w, r, http.StatusBadRequest, "invalid_json",
+			"Request body is not valid JSON", err.Error())
+		return
+	}
+	if body.SourceID == "" {
+		writeV1Error(w, r, http.StatusBadRequest, "invalid_request",
+			"source_id is required", "")
+		return
+	}
+
+	res, err := h.copies.CopyState(r.Context(), entitymanager.CopyRequest{
+		Definition: name,
+		SourceID:   body.SourceID,
+		TargetID:   body.TargetID,
+	})
+	if err != nil {
+		writeCopyError(w, r, err)
+		return
+	}
+
+	writeV1JSON(w, http.StatusOK, v1.CopyResult{
+		Definition: res.Definition,
+		EntityID:   res.Entity.ID,
+		Pointer:    res.Entity.Pointer.String(),
+		Created:    res.Created,
+	})
+}
+
+// writeCopyError renders a kernel error. See [copiesHandler.invoke] for why
+// the mapping is asymmetric.
+func writeCopyError(w http.ResponseWriter, r *http.Request, err error) {
+	var forbidden *acl.ForbiddenError
+	if errors.As(err, &forbidden) {
+		writeV1Error(w, r, http.StatusForbidden, "forbidden",
+			"Not permitted", forbidden.Decision.Reason)
+		return
+	}
+	if errors.Is(err, entitymanager.ErrCopySourceMissing) {
+		// Byte-identical to a genuinely missing entity. Do NOT "improve" this
+		// into a 403 naming the source: the kernel folds a denied read into
+		// this error precisely so a caller cannot tell absent from forbidden,
+		// and a more helpful status here would reopen that.
+		writeV1Error(w, r, http.StatusNotFound, "not_found",
+			entityNotFoundTitle, "")
+		return
+	}
+	writeV1Error(w, r, http.StatusUnprocessableEntity, "copy_failed",
+		"Copy could not be applied", err.Error())
+}
+
+// registerCopyRoutes mounts the copy surface when it is wired.
+//
+// Registration is CONDITIONAL because the handler is only built when the
+// entity manager satisfies [copyService] — every production manager does, but
+// a test double or an embedding caller's stub may not. An unmounted route
+// 404s, which is the honest answer for a capability this build does not have:
+// the alternative, a mounted route holding a nil service, is the
+// wiring-bug-as-domain-answer shape the handler's doc rejects.
+func (a *App) registerCopyRoutes(mux *http.ServeMux) {
+	if a.copies == nil {
+		return
+	}
+	mux.HandleFunc("/api/v1/_copies", a.copies.handleV1Copies)
+	mux.HandleFunc("/api/v1/_copies/", a.copies.handleV1Copies)
+}

--- a/internal/dataentry/copies_handler_test.go
+++ b/internal/dataentry/copies_handler_test.go
@@ -1,0 +1,318 @@
+package dataentry
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/Sourcehaven-BV/rela/internal/acl"
+	v1 "github.com/Sourcehaven-BV/rela/internal/apiwire/v1"
+	"github.com/Sourcehaven-BV/rela/internal/entity"
+	"github.com/Sourcehaven-BV/rela/internal/entitymanager"
+)
+
+// stubCopyService stands in for the manager. It records what it was asked so
+// the tests can assert the handler does not pre-empt it.
+type stubCopyService struct {
+	offers []entitymanager.CopyOffer
+	result *entitymanager.CopyResult
+	err    error
+
+	listCalls   int
+	invokeCalls int
+	gotReq      entitymanager.CopyRequest
+}
+
+func (s *stubCopyService) CopiesForSource(
+	_ context.Context, _, _, _ string,
+) ([]entitymanager.CopyOffer, error) {
+	s.listCalls++
+	return s.offers, s.err
+}
+
+func (s *stubCopyService) CopyState(
+	_ context.Context, req entitymanager.CopyRequest,
+) (*entitymanager.CopyResult, error) {
+	s.invokeCalls++
+	s.gotReq = req
+	return s.result, s.err
+}
+
+func newCopyTestHandler(t *testing.T, svc copyService) *copiesHandler {
+	t.Helper()
+	app := newTestAppV1(t)
+	h, err := newCopiesHandler(svc, app.State)
+	if err != nil {
+		t.Fatalf("newCopiesHandler: %v", err)
+	}
+	return h
+}
+
+func serveCopies(h *copiesHandler, method, target, body string) *httptest.ResponseRecorder {
+	var r *http.Request
+	if body == "" {
+		r = httptest.NewRequest(method, target, http.NoBody)
+	} else {
+		r = httptest.NewRequest(method, target, strings.NewReader(body))
+	}
+	rec := httptest.NewRecorder()
+	h.handleV1Copies(rec, r)
+	return rec
+}
+
+// TestCopiesHandler_RejectsNilService pins the constructor rule.
+//
+// A nil service must fail at CONSTRUCTION, not per request, because an empty
+// offer list is a legitimate domain answer — a face with no declared copies
+// returns exactly that. So a nil-and-skip design would render a wiring bug as
+// "the promote button never appears", sending someone to hunt through
+// schema.yaml for a definition that is correctly declared.
+func TestCopiesHandler_RejectsNilService(t *testing.T) {
+	t.Parallel()
+	app := newTestAppV1(t)
+	if _, err := newCopiesHandler(nil, app.State); err == nil {
+		t.Error("a nil copy service must be rejected at construction — a " +
+			"wiring failure that renders as a valid domain answer is the " +
+			"hardest kind to diagnose")
+	}
+	if _, err := newCopiesHandler(&stubCopyService{}, nil); err == nil {
+		t.Error("a nil schema must be rejected at construction")
+	}
+}
+
+// TestCopiesHandler_InvokeDoesNotPreEmptTheKernel is the load-bearing
+// authorization test.
+//
+// The handler must NOT check the guard itself. Two authorization sites that
+// can disagree is strictly worse than one, because the divergence is
+// invisible — both look plausible. So the assertion is that the kernel is
+// ALWAYS consulted, including for a request the handler might have been
+// tempted to reject early.
+//
+// Mutation-checked: adding any pre-flight allow/deny check to invoke() fails
+// this, because the stub's call count drops to zero.
+func TestCopiesHandler_InvokeDoesNotPreEmptTheKernel(t *testing.T) {
+	t.Parallel()
+	svc := &stubCopyService{err: &acl.ForbiddenError{Decision: acl.Decision{
+		RuleKind: "copy-guard", RuleID: "promote-page",
+		Reason: "copy \"promote-page\" requires permission \"promote-page\" on \"PAGE-1\"",
+	}}}
+	h := newCopyTestHandler(t, svc)
+
+	rec := serveCopies(h, http.MethodPost, "/api/v1/_copies/promote-page",
+		`{"source_id":"PAGE-1"}`)
+
+	if svc.invokeCalls != 1 {
+		t.Fatalf("the kernel must be consulted exactly once, even for a request "+
+			"that will be denied — the handler must not pre-empt it; calls=%d",
+			svc.invokeCalls)
+	}
+	if rec.Code != http.StatusForbidden {
+		t.Errorf("a kernel ForbiddenError maps to 403; got %d", rec.Code)
+	}
+	if !strings.Contains(rec.Body.String(), "promote-page") {
+		t.Errorf("a 403 should name the missing permission — a copy definition "+
+			"and its guard are operator config, not secrets; got %s", rec.Body)
+	}
+}
+
+// TestCopiesHandler_MissingSourceIs404Indistinguishable is the existence-oracle
+// test.
+//
+// The kernel folds a DENIED read on the source into ErrCopySourceMissing
+// precisely so a caller cannot tell "you may not read this" from "this does
+// not exist". The handler must preserve that: a 403 here — however much more
+// helpful — would undo the read gate's work.
+//
+// It asserts BOTH the status and that the body carries no distinguishing
+// detail, because a 404 whose body names the source would leak the same bit
+// the status was careful not to.
+func TestCopiesHandler_MissingSourceIs404Indistinguishable(t *testing.T) {
+	t.Parallel()
+	svc := &stubCopyService{
+		err: fmt.Errorf("%w: PAGE-SECRET", entitymanager.ErrCopySourceMissing),
+	}
+	h := newCopyTestHandler(t, svc)
+
+	rec := serveCopies(h, http.MethodPost, "/api/v1/_copies/promote-page",
+		`{"source_id":"PAGE-SECRET"}`)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("a missing-or-denied source must be 404, never 403: the kernel "+
+			"collapses the two so a caller cannot tell them apart; got %d", rec.Code)
+	}
+	if strings.Contains(rec.Body.String(), "PAGE-SECRET") {
+		t.Errorf("the 404 body must not name the source — that would leak "+
+			"through the body the bit the status withheld; got %s", rec.Body)
+	}
+	if !strings.Contains(rec.Body.String(), entityNotFoundTitle) {
+		t.Errorf("the 404 must use the shared not-found title so it is "+
+			"byte-comparable with every other read-path 404; got %s", rec.Body)
+	}
+}
+
+// TestCopiesHandler_OtherKernelErrorsAre422 covers the third arm: a coherent
+// request this surface cannot satisfy (unknown definition, refused `when:`,
+// cross-entity copy with no target).
+func TestCopiesHandler_OtherKernelErrorsAre422(t *testing.T) {
+	t.Parallel()
+	svc := &stubCopyService{err: errors.New("copy \"nope\" is not declared")}
+	h := newCopyTestHandler(t, svc)
+
+	rec := serveCopies(h, http.MethodPost, "/api/v1/_copies/nope", `{"source_id":"PAGE-1"}`)
+	if rec.Code != http.StatusUnprocessableEntity {
+		t.Errorf("an ordinary kernel refusal maps to 422; got %d", rec.Code)
+	}
+}
+
+// TestCopiesHandler_InvokesByNameOnly pins the transforms-registry precedent:
+// the request names a DEFINITION, and the name comes from the PATH.
+//
+// If a caller could describe a copy, they could describe one whose guard is
+// convenient and the guard system would be decorative. The body carries only
+// entity ids, which is why entitymanager.CopyRequest is three strings.
+func TestCopiesHandler_InvokesByNameOnly(t *testing.T) {
+	t.Parallel()
+	svc := &stubCopyService{result: &entitymanager.CopyResult{
+		Definition: "promote-page",
+		Entity:     &entity.Entity{ID: "PAGE-1", Type: "page", Pointer: entity.Pointer("published")},
+		Created:    true,
+	}}
+	h := newCopyTestHandler(t, svc)
+
+	rec := serveCopies(h, http.MethodPost, "/api/v1/_copies/promote-page",
+		`{"source_id":"PAGE-1","fields":{"title":"injected"},"guard":null}`)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body)
+	}
+	// The definition came from the PATH; unknown body keys were ignored rather
+	// than shaping the copy.
+	if svc.gotReq.Definition != "promote-page" {
+		t.Errorf("definition must come from the path; got %q", svc.gotReq.Definition)
+	}
+	if svc.gotReq.SourceID != "PAGE-1" {
+		t.Errorf("source_id = %q", svc.gotReq.SourceID)
+	}
+
+	var got v1.CopyResult
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got.Pointer != "published" || !got.Created {
+		t.Errorf("the result must report the written face and whether it was "+
+			"created; got %+v", got)
+	}
+}
+
+// TestCopiesHandler_ListReportsAllowedPerDefinition pins the config-is-not-
+// secret rule on the wire: a denied definition is LISTED with allowed=false,
+// not hidden.
+//
+// Copy names are operator-authored config, so concealing them would hide
+// something schema.yaml already states. What is per-principal is the verdict.
+func TestCopiesHandler_ListReportsAllowedPerDefinition(t *testing.T) {
+	t.Parallel()
+	svc := &stubCopyService{offers: []entitymanager.CopyOffer{
+		{Name: "promote-page", Label: "Publish", TargetFace: "page@published",
+			SameEntity: true, Allowed: true},
+		{Name: "archive-page", Label: "archive-page", TargetFace: "page@archived",
+			SameEntity: true, Allowed: false, Reason: "requires permission \"archive\""},
+	}}
+	h := newCopyTestHandler(t, svc)
+
+	rec := serveCopies(h, http.MethodGet,
+		"/api/v1/_copies?type=ticket&source_id=TKT-1", "")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body)
+	}
+
+	var got v1.CopyOffersResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(got.Data) != 2 {
+		t.Fatalf("a DENIED definition must still be listed — its name is config, "+
+			"not a secret; got %d entries", len(got.Data))
+	}
+	if !got.Data[0].Allowed || got.Data[1].Allowed {
+		t.Errorf("allowed must be per-definition; got %+v", got.Data)
+	}
+	if got.Data[1].Reason == "" {
+		t.Error("a denied offer should carry a reason for a tooltip")
+	}
+}
+
+// TestCopiesHandler_ListValidatesItsAddress covers the request-shape errors,
+// including that an unknown entity TYPE is named (config, not a secret) while
+// nothing about entity existence is disclosed.
+func TestCopiesHandler_ListValidatesItsAddress(t *testing.T) {
+	t.Parallel()
+	h := newCopyTestHandler(t, &stubCopyService{})
+
+	for _, tc := range []struct {
+		name, target string
+		want         int
+	}{
+		{"no type", "/api/v1/_copies?source_id=TKT-1", http.StatusBadRequest},
+		{"no source_id", "/api/v1/_copies?type=ticket", http.StatusBadRequest},
+		{"unknown type", "/api/v1/_copies?type=nosuch&source_id=X-1", http.StatusNotFound},
+		{"valid", "/api/v1/_copies?type=ticket&source_id=TKT-1", http.StatusOK},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := serveCopies(h, http.MethodGet, tc.target, "").Code; got != tc.want {
+				t.Errorf("%s: got %d, want %d", tc.target, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestCopiesHandler_MethodRouting pins the surface's shape: a list is a GET on
+// the collection, an invoke is a POST to a NAME. A POST to the collection has
+// no definition to invoke, and a GET on a name is not a read of anything.
+func TestCopiesHandler_MethodRouting(t *testing.T) {
+	t.Parallel()
+	h := newCopyTestHandler(t, &stubCopyService{})
+
+	for _, tc := range []struct {
+		name, method, target string
+		want                 int
+	}{
+		{"POST to collection", http.MethodPost, "/api/v1/_copies", http.StatusMethodNotAllowed},
+		{"GET a name", http.MethodGet, "/api/v1/_copies/promote-page", http.StatusMethodNotAllowed},
+		{"DELETE", http.MethodDelete, "/api/v1/_copies/promote-page", http.StatusMethodNotAllowed},
+		{"OPTIONS", http.MethodOptions, "/api/v1/_copies", http.StatusNoContent},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := serveCopies(h, tc.method, tc.target, "").Code; got != tc.want {
+				t.Errorf("%s %s: got %d, want %d", tc.method, tc.target, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestCopiesHandler_InvokeRejectsMalformedBody covers the wire-format errors,
+// which are 400s rather than 422s: the request structure is broken, which is
+// detectable without the metamodel (the DEC-HWZHA split).
+func TestCopiesHandler_InvokeRejectsMalformedBody(t *testing.T) {
+	t.Parallel()
+	svc := &stubCopyService{}
+	h := newCopyTestHandler(t, svc)
+
+	if got := serveCopies(h, http.MethodPost, "/api/v1/_copies/x", `{not json`).Code; got != http.StatusBadRequest {
+		t.Errorf("malformed JSON is a 400; got %d", got)
+	}
+	if got := serveCopies(h, http.MethodPost, "/api/v1/_copies/x", `{}`).Code; got != http.StatusBadRequest {
+		t.Errorf("a missing source_id is a 400; got %d", got)
+	}
+	if svc.invokeCalls != 0 {
+		t.Errorf("a malformed request must not reach the kernel; calls=%d", svc.invokeCalls)
+	}
+}

--- a/internal/entitymanager/copy.go
+++ b/internal/entitymanager/copy.go
@@ -14,6 +14,36 @@ import (
 	"github.com/Sourcehaven-BV/rela/internal/store"
 )
 
+// copyEngine owns the copy operation: planning, authorization, target
+// construction, edge planning and audit.
+//
+// # Why a separate type (Jeroen's call, TKT-WRLDAPI item 5)
+//
+// It is a decomposition, not a lint workaround. Copies are already a distinct
+// operation — deliberately NOT on the [EntityManager] interface, which is the
+// ordinary-CRUD write contract — and this makes that boundary structural
+// rather than conventional. `Manager` was at 41 methods against a 40 load
+// line, almost all of them private helpers; adding the copy-affordance query
+// would have pinned it at the line rather than under it, and the load line is
+// a ratchet to narrow, not a budget to spend.
+//
+// # It holds the Manager, and that is deliberate
+//
+// The engine needs `authorizeAndAudit`, which is Manager's and is shared with
+// every other write path. Duplicating it here would be a second authorization
+// implementation — the exact defect this feature's design refuses. So the
+// engine composes the manager rather than replacing it.
+//
+// # planCopy and authorizeCopy stay UNEXPORTED
+//
+// That is load-bearing, not incidental. [CopiesForSource] computes each
+// offer's `Allowed` by running those two — the same code the invoke runs — and
+// that is the only reason the hint cannot drift from the write (RULING 11).
+// Exporting them, or making invocability computable from outside this package,
+// would let a caller answer the question a different way and reintroduce the
+// two-authorization-sites defect.
+type copyEngine struct{ m *Manager }
+
 // Copy errors. ErrUnknownCopy is caller input (4xx); the guard errors map to
 // 403/422 exactly as the statemachine's do, because they ARE the
 // statemachine's vocabulary (design doc §9.1: shared guard machinery,
@@ -82,7 +112,7 @@ type CopyResult struct {
 // Two consequences the contract forces:
 //
 //   - Every store call inside the transaction goes through the VIEW, never
-//     m.deps.Store. A write on the outer store from inside deadlocks on
+//     ce.m.deps.Store. A write on the outer store from inside deadlocks on
 //     fs/mem and silently bypasses the transaction on pg.
 //   - fs/mem have NO ROLLBACK — store.Tx there is a write mutex. A mid-copy
 //     failure leaves a partially written target face on those backends. That
@@ -102,19 +132,19 @@ type CopyResult struct {
 // a world selects is valid iff that world remains a valid graph, but
 // `must_hold_in` is TKT-9KZGJO's declared seam and shipping half of it here
 // would fork it. That is a boundary, not an omission.
-func (m *Manager) CopyState(ctx context.Context, req CopyRequest) (*CopyResult, error) {
+func (ce *copyEngine) copyState(ctx context.Context, req CopyRequest) (*CopyResult, error) {
 	ctx = withStoreAttribution(ctx)
 
-	def, ok := m.deps.Meta.Copies[req.Definition]
+	def, ok := ce.m.deps.Meta.Copies[req.Definition]
 	if !ok {
 		return nil, fmt.Errorf("%w: %q", ErrUnknownCopy, req.Definition)
 	}
-	plan, err := m.planCopy(ctx, req, def)
+	plan, err := ce.planCopy(ctx, req, def)
 	if err != nil {
 		return nil, err
 	}
 
-	tx, ok := m.deps.Store.(store.Transactor)
+	tx, ok := ce.m.deps.Store.(store.Transactor)
 	if !ok {
 		// Every backend implements Transactor; a store that does not is a
 		// wiring error, and running the copy unsynchronized would be worse
@@ -135,7 +165,7 @@ func (m *Manager) CopyState(ctx context.Context, req CopyRequest) (*CopyResult, 
 	}
 
 	// AFTER the commit — see the godoc.
-	m.recordCopyAudit(ctx, plan, result)
+	ce.recordCopyAudit(ctx, plan, result)
 	return &result, nil
 }
 
@@ -188,7 +218,7 @@ type copyEdge struct {
 //     fields the principal cannot read into an entity with a different
 //     audience — a redaction bypass, and the reason `fields: all` is a load
 //     error on that form.
-func (m *Manager) planCopy(
+func (ce *copyEngine) planCopy(
 	ctx context.Context, req CopyRequest, def metamodel.CopyDef,
 ) (*copyPlan, error) {
 	from, err := metamodel.ParseCopyTarget(def.From)
@@ -203,28 +233,28 @@ func (m *Manager) planCopy(
 	plan := &copyPlan{
 		name: req.Definition, def: def, from: from, to: to,
 		sourceID: req.SourceID, targetID: req.SourceID,
-		sourceTail: entity.Pointer(metamodel.StoredPointer(m.deps.Meta, from.Type, from.Pointer)),
-		targetTail: entity.Pointer(metamodel.StoredPointer(m.deps.Meta, to.Type, to.Pointer)),
+		sourceTail: entity.Pointer(metamodel.StoredPointer(ce.m.deps.Meta, from.Type, from.Pointer)),
+		targetTail: entity.Pointer(metamodel.StoredPointer(ce.m.deps.Meta, to.Type, to.Pointer)),
 	}
 	if !def.IsSameEntity() {
 		plan.targetID = req.TargetID
 	}
 
-	src, err := m.readCopySource(ctx, def, plan)
+	src, err := ce.readCopySource(ctx, def, plan)
 	if err != nil {
 		return nil, err
 	}
-	if err := m.authorizeCopy(ctx, plan); err != nil {
+	if err := ce.authorizeCopy(ctx, plan); err != nil {
 		return nil, err
 	}
-	if err := m.buildCopyTarget(ctx, plan, src); err != nil {
+	if err := ce.buildCopyTarget(ctx, plan, src); err != nil {
 		return nil, err
 	}
 	return plan, nil
 }
 
 // readCopySource performs the elevation split's read half.
-func (m *Manager) readCopySource(
+func (ce *copyEngine) readCopySource(
 	ctx context.Context, def metamodel.CopyDef, plan *copyPlan,
 ) (*entity.Entity, error) {
 	ptr := plan.sourceTail
@@ -233,7 +263,7 @@ func (m *Manager) readCopySource(
 		// RAW and elevated. The read feeds a write, and a redacted read that
 		// feeds a write destroys the hidden fields it could not see — the
 		// precise bug the never-redact-a-write-prep rule pins.
-		e, err := m.deps.Store.GetEntityState(ctx, plan.sourceID, ptr)
+		e, err := ce.m.deps.Store.GetEntityState(ctx, plan.sourceID, ptr)
 		if err != nil {
 			return nil, fmt.Errorf("%w: %s", ErrCopySourceMissing, plan.sourceID)
 		}
@@ -243,14 +273,14 @@ func (m *Manager) readCopySource(
 	// Cross-entity: through the caller's gate. A nil gate means no ACL is
 	// wired, which is the CLI/no-policy case — the raw read is then what
 	// every other read on that deployment already does.
-	if m.deps.CopyVisibility == nil {
-		e, err := m.deps.Store.GetEntityState(ctx, plan.sourceID, ptr)
+	if ce.m.deps.CopyVisibility == nil {
+		e, err := ce.m.deps.Store.GetEntityState(ctx, plan.sourceID, ptr)
 		if err != nil {
 			return nil, fmt.Errorf("%w: %s", ErrCopySourceMissing, plan.sourceID)
 		}
 		return e, nil
 	}
-	e, ok, err := m.deps.CopyVisibility.Get(ctx, plan.from.Type, plan.sourceID)
+	e, ok, err := ce.m.deps.CopyVisibility.Get(ctx, plan.from.Type, plan.sourceID)
 	if err != nil {
 		return nil, err
 	}
@@ -288,12 +318,12 @@ func (m *Manager) readCopySource(
 // The same-entity target face is deliberately exempt from (3): nobody holds
 // `update` on published by design, so requiring it would make every promote
 // impossible. (1) and (2) are what stand in its place.
-func (m *Manager) authorizeCopy(ctx context.Context, plan *copyPlan) error {
+func (ce *copyEngine) authorizeCopy(ctx context.Context, plan *copyPlan) error {
 	// (1) READ on the source. Same-entity copies read RAW afterwards, which
 	// is about hidden FIELDS traveling with the entity — it is not a
 	// license to read an entity the principal has no access to.
-	if m.deps.CopyReadGate != nil {
-		permitted, err := m.deps.CopyReadGate.PermitsRead(ctx, plan.from.Type, plan.sourceID)
+	if ce.m.deps.CopyReadGate != nil {
+		permitted, err := ce.m.deps.CopyReadGate.PermitsRead(ctx, plan.from.Type, plan.sourceID)
 		if err != nil {
 			return err
 		}
@@ -304,7 +334,7 @@ func (m *Manager) authorizeCopy(ctx context.Context, plan *copyPlan) error {
 	}
 
 	if perm := plan.def.Guard.Permission; perm != "" {
-		if m.deps.CopyGuard == nil {
+		if ce.m.deps.CopyGuard == nil {
 			// A guarded copy with no guard implementation fails CLOSED,
 			// matching the statemachine's nil-guard rule: a guarded edge with
 			// no guard is denied, never waved through.
@@ -315,7 +345,7 @@ func (m *Manager) authorizeCopy(ctx context.Context, plan *copyPlan) error {
 					plan.name, perm),
 			}}
 		}
-		if !m.deps.CopyGuard.HoldsPermission(ctx, plan.sourceID, perm) {
+		if !ce.m.deps.CopyGuard.HoldsPermission(ctx, plan.sourceID, perm) {
 			return &acl.ForbiddenError{Decision: acl.Decision{
 				RuleKind: "copy-guard", RuleID: perm,
 				Reason: fmt.Sprintf(
@@ -329,7 +359,7 @@ func (m *Manager) authorizeCopy(ctx context.Context, plan *copyPlan) error {
 		// (3) does not apply — see above.
 		return nil
 	}
-	return m.authorizeAndAudit(ctx, acl.WriteRequest{
+	return ce.m.authorizeAndAudit(ctx, acl.WriteRequest{
 		Op: acl.OpCreate,
 		Subject: acl.EntitySubject{
 			Type:    plan.to.Type,
@@ -345,12 +375,12 @@ func (m *Manager) authorizeCopy(ctx context.Context, plan *copyPlan) error {
 // target (§9.1's partial-copy semantics); `fields: all` is the full-replace
 // promote case, and is only reachable on a same-entity copy because the
 // cross-entity form rejects it at load.
-func (m *Manager) buildCopyTarget(
+func (ce *copyEngine) buildCopyTarget(
 	ctx context.Context, plan *copyPlan, src *entity.Entity,
 ) error {
 	targetPtr := plan.targetTail
 
-	existing, err := m.deps.Store.GetEntityState(ctx, plan.targetID, targetPtr)
+	existing, err := ce.m.deps.Store.GetEntityState(ctx, plan.targetID, targetPtr)
 	switch {
 	case err == nil:
 	case errors.Is(err, store.ErrNotFound):
@@ -386,7 +416,7 @@ func (m *Manager) buildCopyTarget(
 	}
 
 	plan.entity = target
-	edges, err := m.planCopyEdges(ctx, plan)
+	edges, err := ce.planCopyEdges(ctx, plan)
 	if err != nil {
 		return err
 	}
@@ -406,7 +436,7 @@ func (m *Manager) buildCopyTarget(
 // never create an edge the principal could not create by hand. Same-entity
 // elevated copies only touch the entity's own state edges, so the concern
 // does not arise there.
-func (m *Manager) planCopyEdges(ctx context.Context, plan *copyPlan) ([]copyEdge, error) {
+func (ce *copyEngine) planCopyEdges(ctx context.Context, plan *copyPlan) ([]copyEdge, error) {
 	if len(plan.def.Relations) == 0 {
 		return nil, nil
 	}
@@ -414,7 +444,7 @@ func (m *Manager) planCopyEdges(ctx context.Context, plan *copyPlan) ([]copyEdge
 	crossEntity := !plan.def.IsSameEntity()
 
 	var out []copyEdge
-	for rel, err := range m.deps.Store.ListRelations(ctx, store.RelationQuery{
+	for rel, err := range ce.m.deps.Store.ListRelations(ctx, store.RelationQuery{
 		From: plan.sourceID, FromPointer: &srcTail,
 	}) {
 		if err != nil {
@@ -426,7 +456,7 @@ func (m *Manager) planCopyEdges(ctx context.Context, plan *copyPlan) ([]copyEdge
 			continue
 		}
 		if crossEntity {
-			if aerr := m.authorizeAndAudit(ctx, acl.WriteRequest{
+			if aerr := ce.m.authorizeAndAudit(ctx, acl.WriteRequest{
 				Op: acl.OpCreate,
 				Subject: acl.RelationSubject{
 					Type: rel.Type, FromType: plan.to.Type, FromID: plan.targetID,
@@ -450,9 +480,9 @@ func (m *Manager) planCopyEdges(ctx context.Context, plan *copyPlan) ([]copyEdge
 // It does NOT reuse purge's Manager bypass: purge is a store-level
 // destructive op with no entity write, whereas a copy IS an entity write and
 // must not have weaker authorization or attribution than a property edit.
-func (m *Manager) recordCopyAudit(ctx context.Context, plan *copyPlan, res CopyResult) {
+func (ce *copyEngine) recordCopyAudit(ctx context.Context, plan *copyPlan, res CopyResult) {
 	p := principal.From(ctx)
-	m.deps.Audit.Record(audit.Record{
+	ce.m.deps.Audit.Record(audit.Record{
 		Op: audit.OpCopyState,
 		Subject: &audit.Subject{
 			Kind: "entity", Type: plan.to.Type, ID: plan.targetID,
@@ -471,4 +501,11 @@ func copyFaceLabel(id string, t metamodel.CopyTarget) string {
 		return id
 	}
 	return id + "@" + t.Pointer
+}
+
+// CopyState executes a declared copy definition. See [copyEngine.copyState]
+// for the full contract; this is the Manager-facing entry point and delegates
+// without deciding anything.
+func (m *Manager) CopyState(ctx context.Context, req CopyRequest) (*CopyResult, error) {
+	return (&copyEngine{m: m}).copyState(ctx, req)
 }

--- a/internal/entitymanager/copylist.go
+++ b/internal/entitymanager/copylist.go
@@ -1,0 +1,176 @@
+package entitymanager
+
+import (
+	"context"
+	"errors"
+	"sort"
+
+	"github.com/Sourcehaven-BV/rela/internal/acl"
+	"github.com/Sourcehaven-BV/rela/internal/metamodel"
+)
+
+// CopyOffer is one copy definition offered for a given source face, with
+// whether this principal may invoke it right now (TKT-WRLDAPI item 5).
+//
+// It is the vocabulary a UI needs to render RULING 9's affordances — one
+// button per definition whose source is the face being viewed, hidden when
+// the principal lacks the guard — without deciding anything about
+// presentation.
+type CopyOffer struct {
+	// Name is the `copies:` key, and the ONLY thing a caller may send back to
+	// invoke it. A request never supplies a definition.
+	Name string
+	// Label is the operator-configured display text, or the definition's name
+	// when none is set. Display-only.
+	Label string
+	// TargetFace is the face this copy writes, as declared (`policy@published`
+	// or `new page`). For a UI that wants to say what the button will do.
+	TargetFace string
+	// SameEntity distinguishes a promote/revise (writes another face of the
+	// SAME entity) from a copy that creates a different entity. A cross-entity
+	// copy needs a target id, so a caller must know which it is looking at.
+	SameEntity bool
+
+	// Allowed reports whether this principal may invoke this copy on this
+	// source RIGHT NOW.
+	//
+	// # It is a HINT, never a boundary
+	//
+	// Same contract as the `_actions` affordance map: the invoke endpoint
+	// re-authorizes through the kernel, and a caller that ignores this and
+	// POSTs anyway gets the same 403 it would have got regardless. A UI uses
+	// it to decide what to render; nothing downstream may rely on it.
+	//
+	// It is computed by calling the SAME authorization path the invoke uses
+	// ([Manager.authorizeCopy] behind [Manager.planCopy]), not by a parallel
+	// reimplementation of the guard check. Two authorization computations that
+	// can disagree is a worse defect than having no hint at all — that is the
+	// RULING 11 failure, where an affordance map said "writable" and the write
+	// path refused.
+	Allowed bool
+	// Reason names why Allowed is false, for a tooltip or a CLI. Empty when
+	// Allowed is true. Advisory: it explains a denial the server already made,
+	// and never carries content from an entity the caller cannot read.
+	Reason string
+}
+
+// CopiesForSource lists the copy definitions whose `from:` addresses the face
+// (entityType, pointer) of sourceID, each with an invocability verdict.
+//
+// # Why it lists definitions the caller may NOT invoke
+//
+// Copy definition NAMES are operator-authored config — they live in
+// schema.yaml, routinely in a public repo — so which definitions exist is not
+// a secret, and filtering the list to conceal them would be concealment of
+// something already disclosed. What IS per-principal is whether this caller
+// may invoke one HERE, and that rides on each entry as [CopyOffer.Allowed].
+//
+// Contrast the entity read gate, which does hide existence: whether an ENTITY
+// exists is a genuine secret. A definition is config; a row is data.
+//
+// # Ordering
+//
+// Sorted by name, so a UI renders a stable button order across requests
+// rather than one that reshuffles with Go's map iteration.
+func (m *Manager) CopiesForSource(
+	ctx context.Context, entityType, pointer, sourceID string,
+) ([]CopyOffer, error) {
+	if m.deps.Meta == nil {
+		return nil, nil
+	}
+	names := make([]string, 0, len(m.deps.Meta.Copies))
+	for name := range m.deps.Meta.Copies {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	var out []CopyOffer
+	for _, name := range names {
+		def := m.deps.Meta.Copies[name]
+		from, err := metamodel.ParseCopyTarget(def.From)
+		if err != nil {
+			// A definition that does not parse cannot match anything. Load-time
+			// validation already refuses these, so this is unreachable in a
+			// loaded metamodel; skipping rather than erroring keeps one bad
+			// definition from blanking the whole list.
+			continue
+		}
+		if from.Type != entityType {
+			continue
+		}
+		// Compare STORED coordinates, not declared names: a pointer marked
+		// `default: true` IS the zero pointer, so `policy@draft` and `policy`
+		// address the same face when draft is the default. Comparing the
+		// declared strings would offer a promote button on the wrong face.
+		if metamodel.StoredPointer(m.deps.Meta, from.Type, from.Pointer) != pointer {
+			continue
+		}
+
+		offer := CopyOffer{
+			Name:       name,
+			Label:      copyOfferLabel(name, def),
+			TargetFace: def.To,
+			SameEntity: def.IsSameEntity(),
+		}
+		offer.Allowed, offer.Reason = m.copyInvocable(ctx, name, def, sourceID)
+		out = append(out, offer)
+	}
+	return out, nil
+}
+
+// copyOfferLabel resolves the display text: the operator's `label:`, or the
+// definition's name when none is set.
+//
+// The name is a legible fallback because copy names are operator-authored and
+// read as actions already (`promote-policy`, `translate-to-nl`) — the same
+// reasoning [metamodel.Transition.Label] uses when it falls back to the target
+// value.
+func copyOfferLabel(name string, def metamodel.CopyDef) string {
+	if def.Label != "" {
+		return def.Label
+	}
+	return name
+}
+
+// copyInvocable answers whether this principal may invoke def on sourceID,
+// by running the REAL authorization path rather than re-deriving it.
+//
+// planCopy reads the source through the same gate the invoke uses and
+// authorizeCopy applies the read gate, the definition's guard and (for a
+// cross-entity copy) the create check. Anything those refuse is refused here
+// identically, because it is the same code.
+//
+// # Every non-nil error is "not allowed", and that is deliberate
+//
+// A missing source, a failed guard, an unparseable definition — from a UI's
+// point of view these are one answer: do not render the button. Distinguishing
+// them here would mean deciding which failures are safe to describe, and the
+// read gate's whole design is that a denied source is indistinguishable from
+// an absent one. So the Reason is the error's own text for a genuine
+// authorization refusal, and a generic phrase otherwise.
+func (m *Manager) copyInvocable(
+	ctx context.Context, name string, def metamodel.CopyDef, sourceID string,
+) (allowed bool, reason string) {
+	plan, err := m.planCopy(ctx, CopyRequest{Definition: name, SourceID: sourceID}, def)
+	if err != nil {
+		return false, copyDenialReason(err)
+	}
+	if err := m.authorizeCopy(ctx, plan); err != nil {
+		return false, copyDenialReason(err)
+	}
+	return true, ""
+}
+
+// copyDenialReason renders a denial for a UI tooltip.
+//
+// An acl.ForbiddenError already carries operator-facing prose naming the
+// permission, which is useful and discloses only config. Anything else — a
+// missing source, a store fault — collapses to one phrase: the alternative is
+// leaking whether an entity the caller cannot read exists.
+func copyDenialReason(err error) string {
+	var forbidden *acl.ForbiddenError
+	if errors.As(err, &forbidden) {
+		return forbidden.Decision.Reason
+	}
+	return "not available for this entity"
+}

--- a/internal/entitymanager/copylist.go
+++ b/internal/entitymanager/copylist.go
@@ -31,8 +31,29 @@ type CopyOffer struct {
 	// copy needs a target id, so a caller must know which it is looking at.
 	SameEntity bool
 
+	// Indeterminate marks an offer whose invocability CANNOT be answered
+	// without information the caller has not supplied yet.
+	//
+	// It is true for exactly one case: a CROSS-ENTITY copy, whose target id
+	// the client chooses at invoke time. The authorization path checks
+	// `OpCreate` on the target, so with no target id it would authorize the
+	// EMPTY id — and any policy whose verdict depends on the target's identity
+	// would be evaluated against the wrong subject. A code-review reproduction
+	// showed exactly that: list said allowed, invoke said forbidden.
+	//
+	// Reporting `Allowed: true` for that case would be the RULING 11 defect —
+	// an affordance that says one thing while the write does another. So the
+	// honest answer is "I cannot know", and this field says so rather than
+	// guessing. A client should render such an offer as available-but-
+	// unverified (the server still authorizes), never as confirmed.
+	//
+	// Same-entity offers are always determinate: their target IS the source.
+	Indeterminate bool
+
 	// Allowed reports whether this principal may invoke this copy on this
 	// source RIGHT NOW.
+	//
+	// Meaningful only when Indeterminate is false. See that field.
 	//
 	// # It is a HINT, never a boundary
 	//
@@ -47,6 +68,10 @@ type CopyOffer struct {
 	// can disagree is a worse defect than having no hint at all — that is the
 	// RULING 11 failure, where an affordance map said "writable" and the write
 	// path refused.
+	//
+	// That guarantee holds for SAME-ENTITY offers. For a cross-entity offer
+	// the inputs differ (no target id yet), which is what Indeterminate
+	// records — the mechanism is shared, but the question is not the same one.
 	Allowed bool
 	// Reason names why Allowed is false, for a tooltip or a CLI. Empty when
 	// Allowed is true. Advisory: it explains a denial the server already made,
@@ -72,8 +97,17 @@ type CopyOffer struct {
 //
 // Sorted by name, so a UI renders a stable button order across requests
 // rather than one that reshuffles with Go's map iteration.
-func (m *Manager) CopiesForSource(
-	ctx context.Context, entityType, pointer, sourceID string,
+//
+// A package FUNCTION, not a method. Manager carries a
+// `//plimsoll:max-methods=40` load line, and the project rule is to split the
+// type rather than raise the number — so a copy-affordance query, which needs
+// only the manager's metamodel and its planning path, does not become a
+// forty-first method on the write god-object.
+//
+// Consumers that need this as an interface method wrap it; see
+// [CopyAffordances].
+func CopiesForSource(
+	ctx context.Context, m *Manager, entityType, pointer, sourceID string,
 ) ([]CopyOffer, error) {
 	if m.deps.Meta == nil {
 		return nil, nil
@@ -112,7 +146,15 @@ func (m *Manager) CopiesForSource(
 			TargetFace: def.To,
 			SameEntity: def.IsSameEntity(),
 		}
-		offer.Allowed, offer.Reason = m.copyInvocable(ctx, name, def, sourceID)
+		if offer.SameEntity {
+			offer.Allowed, offer.Reason = copyInvocable(ctx, m, name, def, sourceID)
+		} else {
+			// A cross-entity copy's target is chosen at invoke time, so its
+			// authorization cannot be evaluated now — see CopyOffer.Indeterminate.
+			// Deliberately NOT probed at all: running the check against an empty
+			// target id would produce a confident answer to a different question.
+			offer.Indeterminate = true
+		}
 		out = append(out, offer)
 	}
 	return out, nil
@@ -148,14 +190,35 @@ func copyOfferLabel(name string, def metamodel.CopyDef) string {
 // read gate's whole design is that a denied source is indistinguishable from
 // an absent one. So the Reason is the error's own text for a genuine
 // authorization refusal, and a generic phrase otherwise.
-func (m *Manager) copyInvocable(
-	ctx context.Context, name string, def metamodel.CopyDef, sourceID string,
+//
+// A package FUNCTION rather than a method, deliberately. Manager carries a
+// `//plimsoll:max-methods=40` load line and CopiesForSource + this would have
+// taken it to 42; the load line is a ratchet to narrow, not a budget to spend.
+// CopiesForSource STAYS a method because the consumer-side interface in
+// internal/dataentry is satisfied structurally by the concrete manager, and a
+// package function could not participate in that. This one needs nothing from
+// the receiver that a parameter cannot carry, so it moves.
+func copyInvocable(
+	ctx context.Context, m *Manager, name string, def metamodel.CopyDef, sourceID string,
 ) (allowed bool, reason string) {
-	plan, err := m.planCopy(ctx, CopyRequest{Definition: name, SourceID: sourceID}, def)
-	if err != nil {
-		return false, copyDenialReason(err)
-	}
-	if err := m.authorizeCopy(ctx, plan); err != nil {
+	// Mark the context so the authorization path computes its verdict WITHOUT
+	// auditing it: this is a question, not an attempted write. See
+	// [withAffordanceProbe].
+	ctx = withAffordanceProbe(ctx)
+
+	ce := &copyEngine{m: m}
+
+	// planCopy AUTHORIZES INTERNALLY — it calls authorizeCopy itself (copy.go,
+	// right after readCopySource), which is why this does not call it again.
+	//
+	// An earlier revision did, and a mutation check exposed the redundancy:
+	// deleting the second call changed nothing, because the first had already
+	// run. That is the stronger arrangement, not the weaker one — there is
+	// exactly ONE way to plan a copy and it is inseparable from authorizing
+	// it, so a caller cannot obtain a plan without a verdict. A second call
+	// here would have implied the authorization was this function's to
+	// arrange, which would invite someone to "optimize" it away.
+	if _, err := ce.planCopy(ctx, CopyRequest{Definition: name, SourceID: sourceID}, def); err != nil {
 		return false, copyDenialReason(err)
 	}
 	return true, ""
@@ -173,4 +236,31 @@ func copyDenialReason(err error) string {
 		return forbidden.Decision.Reason
 	}
 	return "not available for this entity"
+}
+
+// CopyAffordances adapts a [Manager] to the method-shaped copy surface a
+// consumer-side interface needs.
+//
+// It exists because [CopiesForSource] is a package function (Manager is at its
+// plimsoll load line) while `internal/dataentry` declares a narrow
+// `copyService` interface at its call site, per the project's
+// interfaces-at-the-consumer rule. This is the one line that reconciles the
+// two: a value type wrapping the manager, whose methods delegate.
+//
+// It carries no state and makes no decisions — in particular it does NOT
+// authorize. Every method here forwards to the manager, which authorizes
+// internally. A wrapper that grew a check of its own would be the second
+// authorization site this design exists to avoid.
+type CopyAffordances struct{ M *Manager }
+
+// CopiesForSource forwards to [CopiesForSource].
+func (c CopyAffordances) CopiesForSource(
+	ctx context.Context, entityType, pointer, sourceID string,
+) ([]CopyOffer, error) {
+	return CopiesForSource(ctx, c.M, entityType, pointer, sourceID)
+}
+
+// CopyState forwards to [Manager.CopyState], which authorizes internally.
+func (c CopyAffordances) CopyState(ctx context.Context, req CopyRequest) (*CopyResult, error) {
+	return c.M.CopyState(ctx, req)
 }

--- a/internal/entitymanager/copylist_test.go
+++ b/internal/entitymanager/copylist_test.go
@@ -1,0 +1,314 @@
+package entitymanager_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Sourcehaven-BV/rela/internal/acl"
+	"github.com/Sourcehaven-BV/rela/internal/audit"
+	"github.com/Sourcehaven-BV/rela/internal/entity"
+	"github.com/Sourcehaven-BV/rela/internal/entitymanager"
+	"github.com/Sourcehaven-BV/rela/internal/metamodel"
+	"github.com/Sourcehaven-BV/rela/internal/statemachine"
+	"github.com/Sourcehaven-BV/rela/internal/store"
+	"github.com/Sourcehaven-BV/rela/internal/store/memstore"
+)
+
+// copyListMeta declares definitions whose sources differ, so a list for one
+// face must not offer another face's copies.
+const copyListMeta = `
+version: "1"
+entities:
+  page:
+    label: Page
+    id_prefix: PAGE
+    pointers:
+      draft: {default: true}
+      published: {}
+    properties:
+      title: {type: string}
+  ticket:
+    label: Ticket
+    id_prefix: TKT
+    properties:
+      title: {type: string}
+copies:
+  promote-page:
+    from: page@draft
+    to: page@published
+    fields: all
+    label: Publish
+    guard:
+      permission: promote-page
+  unpublish-page:
+    from: page@published
+    to: page@draft
+    fields: all
+    guard:
+      permission: promote-page
+  spawn-followup:
+    from: ticket
+    to: new ticket
+    fields:
+      title: "Follow-up"
+`
+
+func newCopyListManager(t *testing.T, g entitymanager.CopyGuard) (*entitymanager.Manager, store.Store) {
+	t.Helper()
+	st := memstore.New()
+	meta, err := metamodel.Parse([]byte(copyListMeta))
+	if err != nil {
+		t.Fatalf("metamodel.Parse: %v", err)
+	}
+	mgr, err := entitymanager.New(entitymanager.Deps{
+		Store: st, Meta: meta, Templater: nopTemplater{},
+		Audit: audit.Nop{}, ACL: acl.NopACL{},
+		Transitions: statemachine.EmptySet(),
+		FieldGate:   entitymanager.AllowAllFieldGate{},
+		CopyGuard:   g,
+	})
+	if err != nil {
+		t.Fatalf("entitymanager.New: %v", err)
+	}
+	return mgr, st
+}
+
+func offerNames(offers []entitymanager.CopyOffer) []string {
+	out := make([]string, 0, len(offers))
+	for _, o := range offers {
+		out = append(out, o.Name)
+	}
+	return out
+}
+
+// TestCopiesForSource_MatchesTheFaceNotJustTheType pins the face-level match.
+//
+// `promote-page` reads the DRAFT face and `unpublish-page` reads the
+// PUBLISHED one. Both are `page`, so a match on entity type alone would offer
+// both on either face — and a UI would render an "unpublish" button on a draft
+// that has never been published.
+//
+// The draft case is the load-bearing one: draft is `default: true`, so its
+// STORED coordinate is the zero pointer while its DECLARED name is "draft".
+// Comparing declared strings would fail to match `page@draft` against the
+// default face. That is why the implementation compares through
+// metamodel.StoredPointer.
+func TestCopiesForSource_MatchesTheFaceNotJustTheType(t *testing.T) {
+	mgr, _ := newCopyListManager(t, allowGuard{allow: true})
+	ctx := context.Background()
+
+	t.Run("default face offers the copy declared on its declared name", func(t *testing.T) {
+		got := mustOffers(ctx, t, mgr, "page", "", "PAGE-1")
+		if len(got) != 1 || got[0].Name != "promote-page" {
+			t.Errorf("the DEFAULT face must match `from: page@draft` — draft is "+
+				"default:true, so its stored coordinate is the zero pointer; got %v",
+				offerNames(got))
+		}
+	})
+
+	t.Run("published face offers only its own copy", func(t *testing.T) {
+		got := mustOffers(ctx, t, mgr, "page", "published", "PAGE-1")
+		if len(got) != 1 || got[0].Name != "unpublish-page" {
+			t.Errorf("a face must offer only the copies whose `from:` addresses "+
+				"IT, or a UI renders unpublish on a never-published draft; got %v",
+				offerNames(got))
+		}
+	})
+
+	t.Run("a different type offers nothing of page's", func(t *testing.T) {
+		got := mustOffers(ctx, t, mgr, "ticket", "", "TKT-1")
+		if len(got) != 1 || got[0].Name != "spawn-followup" {
+			t.Errorf("got %v, want only spawn-followup", offerNames(got))
+		}
+	})
+}
+
+// mustOffers seeds nothing and lists; the source need not exist for the
+// MATCHING assertions, only for the allowed ones.
+func mustOffers(
+	ctx context.Context, t *testing.T, mgr *entitymanager.Manager,
+	entityType, pointer, sourceID string,
+) []entitymanager.CopyOffer {
+	t.Helper()
+	got, err := mgr.CopiesForSource(ctx, entityType, pointer, sourceID)
+	if err != nil {
+		t.Fatalf("CopiesForSource: %v", err)
+	}
+	return got
+}
+
+// TestCopiesForSource_ListsDeniedDefinitionsWithAllowedFalse is the
+// config-is-not-secret rule, applied.
+//
+// A definition the principal may not invoke is still LISTED, with
+// Allowed=false. Copy names are operator-authored config in schema.yaml —
+// routinely a public repo — so hiding them would conceal something already
+// disclosed. What is per-principal is the verdict, and it rides on the entry.
+//
+// Contrast the entity read gate, which DOES hide existence: whether an entity
+// exists is a genuine secret. A definition is config; a row is data.
+func TestCopiesForSource_ListsDeniedDefinitionsWithAllowedFalse(t *testing.T) {
+	ctx := context.Background()
+	seed := func(t *testing.T, st store.Store) {
+		t.Helper()
+		if err := st.CreateEntity(ctx, &entity.Entity{
+			ID: "PAGE-1", Type: "page", Properties: map[string]any{"title": "Draft"},
+		}); err != nil {
+			t.Fatalf("seed: %v", err)
+		}
+	}
+
+	t.Run("guard grants", func(t *testing.T) {
+		mgr, st := newCopyListManager(t, allowGuard{allow: true})
+		seed(t, st)
+		got := mustOffers(ctx, t, mgr, "page", "", "PAGE-1")
+		if len(got) != 1 || !got[0].Allowed {
+			t.Fatalf("a permitted copy must be Allowed; got %+v", got)
+		}
+		if got[0].Reason != "" {
+			t.Errorf("Reason must be empty when Allowed; got %q", got[0].Reason)
+		}
+	})
+
+	t.Run("guard denies: still listed, Allowed=false", func(t *testing.T) {
+		mgr, st := newCopyListManager(t, allowGuard{allow: false})
+		seed(t, st)
+		got := mustOffers(ctx, t, mgr, "page", "", "PAGE-1")
+		if len(got) != 1 {
+			t.Fatalf("a DENIED definition must still be listed — its name is "+
+				"config, not a secret; got %v", offerNames(got))
+		}
+		if got[0].Allowed {
+			t.Error("a denied copy must report Allowed=false")
+		}
+		if got[0].Reason == "" {
+			t.Error("a denial should carry a reason for a tooltip")
+		}
+	})
+
+	t.Run("no guard wired: fails closed, still listed", func(t *testing.T) {
+		mgr, st := newCopyListManager(t, nil)
+		seed(t, st)
+		got := mustOffers(ctx, t, mgr, "page", "", "PAGE-1")
+		if len(got) != 1 || got[0].Allowed {
+			t.Errorf("a guarded copy with no guard wired must report "+
+				"Allowed=false, matching the kernel's fail-closed rule; got %+v", got)
+		}
+	})
+}
+
+// TestCopiesForSource_AllowedAgreesWithInvoke is the invariant that makes the
+// hint worth having, and the RULING 11 failure it exists to avoid.
+//
+// `_actions` said a published face was writable while the write path refused.
+// The fix there was to make the map honest. This asserts the same property
+// directly: for each guard verdict, Allowed and the actual CopyState outcome
+// agree.
+//
+// It is written as a LOOP over both verdicts rather than a single case,
+// because a hint that is always true and a write that always succeeds would
+// agree vacuously.
+func TestCopiesForSource_AllowedAgreesWithInvoke(t *testing.T) {
+	ctx := context.Background()
+	for _, tc := range []struct {
+		name  string
+		guard entitymanager.CopyGuard
+	}{
+		{"guard grants", allowGuard{allow: true}},
+		{"guard denies", allowGuard{allow: false}},
+		{"no guard wired", nil},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			mgr, st := newCopyListManager(t, tc.guard)
+			if err := st.CreateEntity(ctx, &entity.Entity{
+				ID: "PAGE-1", Type: "page", Properties: map[string]any{"title": "Draft"},
+			}); err != nil {
+				t.Fatalf("seed: %v", err)
+			}
+
+			offers := mustOffers(ctx, t, mgr, "page", "", "PAGE-1")
+			if len(offers) != 1 {
+				t.Fatalf("expected one offer, got %v", offerNames(offers))
+			}
+			hint := offers[0].Allowed
+
+			_, err := mgr.CopyState(ctx, entitymanager.CopyRequest{
+				Definition: "promote-page", SourceID: "PAGE-1",
+			})
+			actuallyAllowed := err == nil
+
+			if hint != actuallyAllowed {
+				t.Errorf("the hint and the write must agree: Allowed=%v but "+
+					"CopyState err=%v. An affordance that lies is a trap for "+
+					"every future consumer (RULING 11)", hint, err)
+			}
+		})
+	}
+}
+
+// TestCopiesForSource_LabelFallsBackToName pins RULING 9's operator-
+// configurable text and its fallback.
+//
+// The name is a legible fallback because copy names are operator-authored and
+// already read as actions (`promote-page`), which is the same reasoning
+// metamodel.Transition.Label uses.
+func TestCopiesForSource_LabelFallsBackToName(t *testing.T) {
+	mgr, _ := newCopyListManager(t, allowGuard{allow: true})
+	ctx := context.Background()
+
+	withLabel := mustOffers(ctx, t, mgr, "page", "", "PAGE-1")
+	if len(withLabel) != 1 || withLabel[0].Label != "Publish" {
+		t.Errorf("an operator `label:` must be used verbatim; got %+v", withLabel)
+	}
+
+	noLabel := mustOffers(ctx, t, mgr, "ticket", "", "TKT-1")
+	if len(noLabel) != 1 || noLabel[0].Label != "spawn-followup" {
+		t.Errorf("with no `label:`, the definition NAME is the fallback; got %+v", noLabel)
+	}
+}
+
+// TestCopiesForSource_ReportsTheTargetShape pins the two fields a UI needs to
+// know what a button will do: which face it writes, and whether it needs a
+// target id.
+//
+// SameEntity is not cosmetic — a cross-entity copy REQUIRES a target id, so a
+// caller that cannot distinguish the two cannot build a valid request.
+func TestCopiesForSource_ReportsTheTargetShape(t *testing.T) {
+	mgr, _ := newCopyListManager(t, allowGuard{allow: true})
+	ctx := context.Background()
+
+	same := mustOffers(ctx, t, mgr, "page", "", "PAGE-1")[0]
+	if !same.SameEntity {
+		t.Error("page@draft -> page@published writes another face of the SAME entity")
+	}
+	if same.TargetFace != "page@published" {
+		t.Errorf("TargetFace = %q, want the declared target", same.TargetFace)
+	}
+
+	cross := mustOffers(ctx, t, mgr, "ticket", "", "TKT-1")[0]
+	if cross.SameEntity {
+		t.Error("`to: new ticket` creates a DIFFERENT entity")
+	}
+	if cross.TargetFace != "new ticket" {
+		t.Errorf("TargetFace = %q, want the declared target", cross.TargetFace)
+	}
+}
+
+// TestCopiesForSource_StableOrder pins name ordering, so a UI renders a stable
+// button order rather than one that reshuffles with map iteration.
+func TestCopiesForSource_StableOrder(t *testing.T) {
+	mgr, _ := newCopyListManager(t, allowGuard{allow: true})
+	ctx := context.Background()
+	first := offerNames(mustOffers(ctx, t, mgr, "page", "", "PAGE-1"))
+	for range 8 {
+		got := offerNames(mustOffers(ctx, t, mgr, "page", "", "PAGE-1"))
+		if len(got) != len(first) {
+			t.Fatalf("unstable length: %v vs %v", got, first)
+		}
+		for i := range got {
+			if got[i] != first[i] {
+				t.Fatalf("unstable order: %v vs %v", got, first)
+			}
+		}
+	}
+}

--- a/internal/entitymanager/copylist_test.go
+++ b/internal/entitymanager/copylist_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"testing"
 
+	"sync"
+
 	"github.com/Sourcehaven-BV/rela/internal/acl"
 	"github.com/Sourcehaven-BV/rela/internal/audit"
 	"github.com/Sourcehaven-BV/rela/internal/entity"
@@ -130,7 +132,7 @@ func mustOffers(
 	entityType, pointer, sourceID string,
 ) []entitymanager.CopyOffer {
 	t.Helper()
-	got, err := mgr.CopiesForSource(ctx, entityType, pointer, sourceID)
+	got, err := entitymanager.CopiesForSource(ctx, mgr, entityType, pointer, sourceID)
 	if err != nil {
 		t.Fatalf("CopiesForSource: %v", err)
 	}
@@ -199,6 +201,19 @@ func TestCopiesForSource_ListsDeniedDefinitionsWithAllowedFalse(t *testing.T) {
 
 // TestCopiesForSource_AllowedAgreesWithInvoke is the invariant that makes the
 // hint worth having, and the RULING 11 failure it exists to avoid.
+//
+// # Mutation-checked, and the first attempt found something about the CODE
+//
+// Deleting copyInvocable's `authorizeCopy` call killed nothing — not because
+// this test is weak, but because `planCopy` calls `authorizeCopy` itself, so
+// the second call was redundant. The redundancy is now removed and the reason
+// documented at the call site.
+//
+// The real mechanism is `planCopy`, and it IS pinned: making planCopy stop
+// authorizing fails 8 tests across this package. The `guard denies` and
+// `no guard wired` rows are what make this one of them — with a permissive
+// guard alone, "the check ran" and "the check was skipped" both yield
+// allowed, and the assertion could not tell them apart.
 //
 // `_actions` said a published face was writable while the write path refused.
 // The fix there was to make the map honest. This asserts the same property
@@ -311,4 +326,142 @@ func TestCopiesForSource_StableOrder(t *testing.T) {
 			}
 		}
 	}
+}
+
+// TestCopiesForSource_AffordanceProbeEmitsNoAuditRecords is the regression
+// test for a defect code review found: a READ-ONLY list emitted `denied-write`
+// audit records.
+//
+// # Why it happened
+//
+// `Allowed` is computed by running the real authorization path — that is what
+// stops the hint drifting from the write. But that path AUDITS its denials, so
+// asking the question recorded an answer as though someone had attempted a
+// write. A SPA rendering an entity view would append N rows per page load.
+//
+// # Why it matters more than volume
+//
+// `op=denied-write` would stop meaning "someone tried to write and was
+// refused" and start meaning "someone looked at a page". Anyone alerting on
+// denied-write volume gets paged by ordinary browsing, and the real signal
+// drowns. The audit log's value is that it does not lie.
+//
+// The verdict is still computed identically — only the RECORD is suppressed —
+// so the hint cannot drift as a result of this fix.
+//
+// # Mutation-checked, and the result is worth recording
+//
+// Removing the suppression in authorizeAndAudit does NOT fail this test, and
+// that is not a flaw in the assertion — it is because the OTHER fix from the
+// same review (CopyOffer.Indeterminate) removed the path that audited. The
+// records came from planCopyEdges on CROSS-ENTITY definitions, and cross-entity
+// offers are no longer probed at all.
+//
+// So today the suppression is BELT-AND-BRACES, not the mechanism. It stays
+// because the reachable-path set is a property of the current call graph
+// rather than of the design: anything that probes a definition performing a
+// per-edge authorization re-opens the path immediately, and the failure would
+// be silent pollution of an append-only log.
+//
+// This test therefore asserts the PROPERTY (a read-only query writes nothing),
+// not the mechanism, and it would catch a regression from either direction.
+func TestCopiesForSource_AffordanceProbeEmitsNoAuditRecords(t *testing.T) {
+	st := memstore.New()
+	meta, err := metamodel.Parse([]byte(copyListMeta))
+	if err != nil {
+		t.Fatalf("metamodel.Parse: %v", err)
+	}
+	rec := &recordingAudit{}
+	mgr, err := entitymanager.New(entitymanager.Deps{
+		Store: st, Meta: meta, Templater: nopTemplater{},
+		Audit: rec, ACL: denyAllACL{},
+		Transitions: statemachine.EmptySet(),
+		FieldGate:   entitymanager.AllowAllFieldGate{},
+		CopyGuard:   allowGuard{allow: true},
+	})
+	if err != nil {
+		t.Fatalf("entitymanager.New: %v", err)
+	}
+	ctx := context.Background()
+	if err := st.CreateEntity(ctx, &entity.Entity{
+		ID: "PAGE-1", Type: "page", Properties: map[string]any{"title": "Draft"},
+	}); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	if _, err := entitymanager.CopiesForSource(ctx, mgr, "page", "", "PAGE-1"); err != nil {
+		t.Fatalf("CopiesForSource: %v", err)
+	}
+
+	if n := rec.count(); n != 0 {
+		t.Errorf("a read-only affordance query wrote %d audit record(s). "+
+			"`denied-write` must mean an attempted write was refused, not "+
+			"that someone rendered a page; records: %v", n, rec.ops())
+	}
+}
+
+// TestCopiesForSource_CrossEntityIsIndeterminate pins the honest answer for an
+// offer whose invocability cannot be known yet.
+//
+// A cross-entity copy's target id is chosen at INVOKE time, so the create
+// check would authorize the empty id — and a policy keyed on the target's
+// identity would be evaluated against the wrong subject. Code review
+// demonstrated list=allowed / invoke=forbidden on exactly that.
+//
+// Reporting `Allowed: true` there is the RULING 11 defect. So the offer says
+// "indeterminate" instead of guessing, and — asserted here — it does not
+// claim Allowed.
+func TestCopiesForSource_CrossEntityIsIndeterminate(t *testing.T) {
+	mgr, _ := newCopyListManager(t, allowGuard{allow: true})
+	ctx := context.Background()
+
+	same := mustOffers(ctx, t, mgr, "page", "", "PAGE-1")[0]
+	if same.Indeterminate {
+		t.Error("a SAME-entity offer's target is the source, so it is answerable")
+	}
+
+	cross := mustOffers(ctx, t, mgr, "ticket", "", "TKT-1")[0]
+	if !cross.Indeterminate {
+		t.Error("a CROSS-entity offer cannot be authorized before the client " +
+			"chooses a target id — saying `allowed` would be an affordance " +
+			"that lies (RULING 11)")
+	}
+	if cross.Allowed {
+		t.Error("an indeterminate offer must not also claim Allowed: a client " +
+			"reading only `allowed` would treat it as a confirmed verdict")
+	}
+}
+
+// recordingAudit counts audit records so a test can assert that a read-only
+// query wrote none.
+type recordingAudit struct {
+	mu      sync.Mutex
+	records []string
+}
+
+func (r *recordingAudit) Record(rec audit.Record) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.records = append(r.records, rec.Op)
+}
+
+func (r *recordingAudit) count() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return len(r.records)
+}
+
+func (r *recordingAudit) ops() []string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return append([]string(nil), r.records...)
+}
+
+// denyAllACL refuses every write, so any authorization the affordance query
+// performs produces a denial worth auditing — which is what makes the
+// zero-records assertion meaningful rather than vacuous.
+type denyAllACL struct{ acl.NopACL }
+
+func (denyAllACL) AuthorizeWrite(_ context.Context, _ acl.WriteRequest) acl.Decision {
+	return acl.Decision{Allow: false, RuleKind: "test", Reason: "denied for test"}
 }

--- a/internal/entitymanager/manager.go
+++ b/internal/entitymanager/manager.go
@@ -388,15 +388,58 @@ func New(d Deps) (*Manager, error) {
 // on the bypass path — there is no denial to record.
 func (m *Manager) authorizeAndAudit(ctx context.Context, req acl.WriteRequest) error {
 	if m.bypassACL {
-		m.recordACLBypass(ctx, req)
+		if !isAffordanceProbe(ctx) {
+			m.recordACLBypass(ctx, req)
+		}
 		return nil
 	}
 	decision := m.deps.ACL.AuthorizeWrite(ctx, req)
 	if decision.Allow {
 		return nil
 	}
-	m.recordDeniedWrite(ctx, decision, req)
+	if !isAffordanceProbe(ctx) {
+		// An affordance PROBE is not an attempted write, so recording it would
+		// make the audit log say something untrue. See [withAffordanceProbe].
+		m.recordDeniedWrite(ctx, decision, req)
+	}
 	return &acl.ForbiddenError{Decision: decision}
+}
+
+// affordanceProbeKey marks a context as an AFFORDANCE QUERY: a read-only
+// "could this principal do X" question, not an attempted write.
+type affordanceProbeKey struct{}
+
+// withAffordanceProbe marks ctx as an affordance query, suppressing audit
+// records from the authorization path.
+//
+// # Why the audit log must not see these
+//
+// [CopiesForSource] answers "which copies may this principal invoke here" by
+// running the REAL authorization path — that is what stops the hint drifting
+// from the write. But that path audits its denials, and a denial recorded for
+// a question nobody asked makes `op=denied-write` mean "someone looked at a
+// page" rather than "someone tried to write and was refused".
+//
+// A SPA renders an entity view, the view lists copy affordances, and every
+// page load appends N rows to an append-only log. Anyone alerting on
+// denied-write volume gets paged by ordinary browsing, and the real signal
+// drowns. The audit log's whole value is that it does not lie (see
+// [Manager.CopyState]'s note on why audit lands after the commit); this keeps
+// that true in the other direction.
+//
+// It suppresses ONLY the record, never the decision: the verdict is computed
+// identically and returned identically, so the hint still cannot drift.
+//
+// The key is typed and unexported, so nothing outside this package can mark a
+// real write as a probe.
+func withAffordanceProbe(ctx context.Context) context.Context {
+	return context.WithValue(ctx, affordanceProbeKey{}, true)
+}
+
+// isAffordanceProbe reports whether ctx was marked by [withAffordanceProbe].
+func isAffordanceProbe(ctx context.Context) bool {
+	v, _ := ctx.Value(affordanceProbeKey{}).(bool)
+	return v
 }
 
 // mapTransitionError translates a state-machine enforcement error into the

--- a/internal/metamodel/copydef_unmarshal_test.go
+++ b/internal/metamodel/copydef_unmarshal_test.go
@@ -1,0 +1,204 @@
+package metamodel
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+// TestCopyDef_UnmarshalCoversEveryField is the guard [CopyDef.UnmarshalYAML]'s
+// comment promises.
+//
+// # The bug it exists for, which actually happened
+//
+// CopyDef has a custom UnmarshalYAML (to accept `fields: all` as a scalar),
+// and that method decodes into a private shadow struct listing the fields it
+// knows about. A field added to CopyDef but NOT to the shadow struct is
+// SILENTLY DROPPED at load: no error, no warning, just a zero value. `label:`
+// was added and ignored exactly this way, and it surfaced only because a test
+// asserted on the parsed value.
+//
+// That is a check whose failure mode is silence: an operator writes `label:
+// Publish` in schema.yaml, the config loads without complaint, and the button
+// renders with the wrong text. Nothing anywhere reports a problem.
+//
+// # What this asserts
+//
+// Every yaml-tagged field on CopyDef round-trips through a real Parse. A new
+// field with a `yaml:` tag fails here until the shadow struct learns it.
+//
+// It parses REAL YAML rather than comparing the two structs by reflection
+// alone: a shadow struct could list a field and still fail to assign it (the
+// method copies fields explicitly), and only an end-to-end parse catches that.
+func TestCopyDef_UnmarshalCoversEveryField(t *testing.T) {
+	t.Parallel()
+
+	// One YAML document exercising every yaml-bearing field of CopyDef.
+	const doc = `
+version: "1"
+entities:
+  page:
+    label: Page
+    id_prefix: PAGE
+    pointers:
+      draft: {default: true}
+      published: {}
+    properties:
+      title: {type: string}
+relations:
+  # CONTENT-scoped: only content-scoped relations may be copied — an identity
+  # edge is shared by every face, so copying it would duplicate an edge that
+  # may confer roles.
+  mentions:
+    scope: content
+    from: [page]
+    to: [page]
+copies:
+  everything:
+    from: page@draft
+    to: page@published
+    label: Publish It
+    fields:
+      title: "{{new.title}}"
+    relations:
+      mentions: merge
+    guard:
+      permission: promote-page
+`
+	m, err := Parse([]byte(doc))
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	def, ok := m.Copies["everything"]
+	if !ok {
+		t.Fatal("copy definition did not load")
+	}
+
+	// Each yaml field, asserted non-zero. A field the shadow struct forgets
+	// arrives as its zero value, which is exactly what this catches.
+	checks := map[string]bool{
+		"From":      def.From == "page@draft",
+		"To":        def.To == "page@published",
+		"Label":     def.Label == "Publish It",
+		"Fields":    def.Fields["title"] == "{{new.title}}",
+		"Relations": def.Relations["mentions"] == "merge",
+		// Guard.When is deliberately NOT exercised: `guard.when` is refused at
+		// load ("not implemented yet — remove it, or the copy would run
+		// without evaluating the condition you wrote"), so a document setting
+		// it cannot parse. Permission alone proves the Guard struct arrives.
+		"Guard": def.Guard.Permission == "promote-page",
+	}
+	for name, ok := range checks {
+		if !ok {
+			t.Errorf("CopyDef.%s did not survive UnmarshalYAML — a field missing "+
+				"from the method's shadow `raw` struct is silently dropped at "+
+				"load, with no error. Add it there and to the explicit "+
+				"assignment below it.", name)
+		}
+	}
+
+	assertEveryYAMLFieldChecked(t, CopyDef{}, checks)
+}
+
+// assertEveryYAMLFieldChecked fails when a yaml-tagged field of v is absent
+// from checks.
+//
+// Without this, the surviving-field loop above passes VACUOUSLY for any field
+// nobody thought to add — which is the same "the check cannot report what it
+// does not know about" shape as the enumeration bugs this epic has hit in the
+// route guard and in the unmarshaler itself. The reflection makes the
+// enumeration self-checking.
+//
+// A `yaml:"-"` field is skipped: it is deliberately not decoded (CopyDef's
+// AllFields is set from the `fields` scalar by hand).
+func assertEveryYAMLFieldChecked(t *testing.T, v any, checks map[string]bool) {
+	t.Helper()
+	var missing []string
+	rt := reflect.TypeOf(v)
+	for f := range rt.Fields() {
+		tag := f.Tag.Get("yaml")
+		if tag == "" || tag == "-" {
+			continue
+		}
+		if _, covered := checks[f.Name]; !covered {
+			missing = append(missing, f.Name)
+		}
+	}
+	if len(missing) > 0 {
+		t.Errorf("%s gained yaml-tagged field(s) %s that this test does not "+
+			"exercise. Add them to the YAML document and the checks, or a field "+
+			"silently dropped by UnmarshalYAML would pass unnoticed.",
+			rt.Name(), strings.Join(missing, ", "))
+	}
+}
+
+// TestWorldDef_UnmarshalCoversEveryField is the same guard on the OTHER type
+// in this package with the vulnerable shape.
+//
+// # Why WorldDef, and why only these two
+//
+// A sweep of internal/metamodel found ten custom UnmarshalYAML methods. Only
+// two use the shadow-struct-plus-explicit-copy shape that can silently drop a
+// field: CopyDef (which was buggy — `label:` vanished) and WorldDef. The rest
+// (ScanPolicy, ACLBypass, InverseDef, HeaderCheck, StringOrSlice, oneOrMany)
+// are scalar-or-sequence coercions with no field enumeration to fall out of
+// sync, so they cannot exhibit this failure and are deliberately not covered
+// here.
+//
+// WorldDef is CLEAN today — all four of its yaml fields are copied. It is
+// guarded anyway because it is the type this epic keeps extending, and
+// `otherwise:` in particular decides resolution semantics: a version of the
+// CopyDef bug that dropped it would silently change which face every reader
+// sees, with the config loading without complaint.
+//
+// "Clean by luck" and "clean by construction" look identical until someone
+// adds a field.
+func TestWorldDef_UnmarshalCoversEveryField(t *testing.T) {
+	t.Parallel()
+
+	const doc = `
+version: "1"
+entities:
+  page:
+    label: Page
+    id_prefix: PAGE
+    pointers:
+      draft: {default: true}
+      review: {}
+      published: {}
+    properties:
+      title: {type: string}
+worlds:
+  everything:
+    select: [review, published]
+    overrides:
+      page: [published]
+    otherwise: default
+    edits: draft
+`
+	m, err := Parse([]byte(doc))
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	def, ok := m.Worlds["everything"]
+	if !ok {
+		t.Fatal("world definition did not load")
+	}
+
+	checks := map[string]bool{
+		"Select":    len(def.Select) == 2 && def.Select[0] == "review" && def.Select[1] == "published",
+		"Overrides": len(def.Overrides["page"]) == 1 && def.Overrides["page"][0] == "published",
+		"Otherwise": string(def.Otherwise) == "default",
+		"Edits":     def.Edits == "draft",
+	}
+	for name, ok := range checks {
+		if !ok {
+			t.Errorf("WorldDef.%s did not survive UnmarshalYAML — a field missing "+
+				"from the method's shadow struct is silently dropped at load, "+
+				"with no error. For a world, that silently changes which face "+
+				"every reader sees.", name)
+		}
+	}
+
+	assertEveryYAMLFieldChecked(t, WorldDef{}, checks)
+}

--- a/internal/metamodel/types.go
+++ b/internal/metamodel/types.go
@@ -622,6 +622,26 @@ type CopyDef struct {
 	// roles on the target.
 	Relations map[string]string `yaml:"relations,omitempty"`
 
+	// Label is optional display text for the ACTION a copy performs — e.g.
+	// "Publish" for promote-policy, or "Translate to Dutch" for
+	// translate-to-nl. It is what RULING 9 calls the operator-configurable
+	// text: a UI renders one affordance per definition whose `from:` matches
+	// the face being viewed, and this names the button.
+	//
+	// Purely presentational, exactly like [Transition.Label], which this
+	// follows: a copy button and a state-machine move are the same shape —
+	// text for an action, not for a destination. Empty falls back to the
+	// definition's own name, which is a legible last resort because copy
+	// names are operator-authored (`promote-policy`, `translate-to-nl`).
+	// Display-only; the kernel ignores it entirely.
+	//
+	// A PLAIN STRING, deliberately: no `{{...}}` interpolation, even though
+	// Fields has it. This type is "deliberately dumb (§9.1) — no expressions,
+	// no conditionals", and per-entity label rendering would reopen exactly
+	// that refusal. An operator wanting per-entity wording wants a different
+	// feature, not a widened one.
+	Label string `yaml:"label,omitempty"`
+
 	// Guard gates the copy. Reuses the STATEMACHINE's vocabulary — the
 	// `guard:` permission (subject-aware, via HoldsPermissionForEntity) and
 	// a `when:` predicate — rather than acl.yaml's `requires_permission`,
@@ -647,9 +667,17 @@ type CopyGuard struct {
 // UnmarshalYAML accepts `fields: all` as a scalar alongside the mapping form.
 func (c *CopyDef) UnmarshalYAML(unmarshal func(any) error) error {
 	// Alias avoids infinite recursion into this method.
+	//
+	// NOTE: this shadow struct must list EVERY yaml-bearing field of CopyDef.
+	// A field present on CopyDef but missing here is silently dropped at load
+	// — no error, no warning, just a zero value — which is how `label:` was
+	// ignored when it was first added. TestCopyDef_UnmarshalCoversEveryField
+	// compares the two by reflection so the next added field fails loudly
+	// instead.
 	type raw struct {
 		From      string            `yaml:"from"`
 		To        string            `yaml:"to"`
+		Label     string            `yaml:"label,omitempty"`
 		Fields    any               `yaml:"fields,omitempty"`
 		Relations map[string]string `yaml:"relations,omitempty"`
 		Guard     CopyGuard         `yaml:"guard,omitempty"`
@@ -658,7 +686,7 @@ func (c *CopyDef) UnmarshalYAML(unmarshal func(any) error) error {
 	if err := unmarshal(&r); err != nil {
 		return err
 	}
-	c.From, c.To, c.Relations, c.Guard = r.From, r.To, r.Relations, r.Guard
+	c.From, c.To, c.Label, c.Relations, c.Guard = r.From, r.To, r.Label, r.Relations, r.Guard
 	switch f := r.Fields.(type) {
 	case nil:
 	case string:


### PR DESCRIPTION

Tickets-PR: #1422

`entitymanager.Manager.CopyState` had **zero non-test callers repo-wide**. Promote worked in Go tests and nowhere else. This adds the surface — and, as it turned out, the wiring without which the surface could not have worked either.

```
GET  /api/v1/_copies?type=&pointer=&source_id=   offers for one face
POST /api/v1/_copies/{name}                      invoke by name
```

Plus `CopyDef.Label` (RULING 9's operator-configurable button text) and `Manager.CopiesForSource`.

## The handler does not authorize, deliberately

`CopyState` already authorizes internally: a read gate on the source, the definition's `guard:` resolved per-entity, and an `OpCreate` check on cross-entity targets — failing closed when a guarded definition has no guard wired. A second authorization site that can diverge is worse than one, because the divergence is invisible: both look plausible.

So the handler's whole job on that axis is to call the kernel and translate its verdict:

| Kernel | HTTP |
|---|---|
| `acl.ForbiddenError` | **403**, naming the rule — a definition and its guard permission are operator config, not secrets |
| `ErrCopySourceMissing` | **404**, indistinguishable from absent — the kernel folds a *denied* read into this error precisely so a caller cannot tell forbidden from nonexistent |
| anything else | **422** |

`TestCopiesHandler_InvokeDoesNotPreEmptTheKernel` asserts the kernel is consulted *exactly once* even for a request that will be denied; any pre-flight check drops the call count to zero and fails it.

The 404 is asserted in **status and body**: a 404 naming the source would leak through the body the bit the status withheld. Verified live against a real server, not just a stub — `POST /_copies/promote-policy {"source_id":"POL-NOPE"}` returns `{"title":"Entity not found"}` with no id in it.

## `allowed` is a hint computed by the write path

Each offer carries `allowed` — the `_actions` contract: a UI hint, never a boundary, and the server re-authorizes regardless. What makes it trustworthy is that it runs `planCopy`, the same code the invoke runs, rather than a re-derivation. `planCopy` authorizes internally, so a caller cannot obtain a plan without a verdict.

A **denied** definition is still listed, with `allowed:false`. Copy names are operator-authored config in `schema.yaml` — hiding them would conceal what the repo already states. What is per-principal is the verdict, and it rides on the entry.

## The feature was dead on arrival, and this PR fixes that too

`buildEntityManager` set `TransitionGuard` but **none** of `CopyGuard`/`CopyReadGate`/`CopyVisibility` — those were assigned only in `entitymanager`'s own tests. Compose that with two individually-correct rules — a copy targeting a non-default face MUST declare a guard (load refusal), and `authorizeCopy` fails closed when a guarded definition has no guard wired — and **every promote returned 403 in every deployment**. It failed closed, so never a hole; a feature that could not work.

It also meant `CopyReadGate` was absent on every deployment, which its own godoc says must never happen on one that HAS a policy: a copy's source read took the no-policy branch, so an unguarded cross-entity copy read with no row gate and no redaction.

Wired: `CopyGuard: tw.Guard` (the interfaces are the same shape on purpose, so a copy's guard and a transition's ask the identical question of the identical implementation), plus `acl.Request`-backed adapters following `transitionGuard`'s tiering exactly — inert with no policy, per-principal with one, **fail closed** when a policy is active but the Request is absent.

**Writing the end-to-end test found a second instance.** `appbuildtest.New` does not call `buildEntityManager` — it hand-copies the `Deps` literal under a comment saying it "mirrors the production wiring". So it had the identical gap, and every test using it ran without a capability real deployments have.

That is also *why* nothing caught the original: both lists were wrong in the same way, so they agreed. `CopyGuard` is now wired there too. Restructuring the fixture to call the real builder is tracked as **TKT-FIXWIRE**, not this PR.

To be precise about what the defect is, since a ticket that overstates its fix is how a cleanup becomes a regression: `CopyReadGate` and `CopyVisibility` remaining nil in the fixture is **deliberate and correct** — the no-policy posture, matching its `NopACL` default and its raw reads elsewhere. The defect is the absence of a mechanism that would have caught `CopyGuard` being nil, not the nil-ness of the other two.

## Ruling 15 instances in this PR

Five, and two are in my own work:

| # | Check / claim | Read as | Actually |
|---|---|---|---|
| 1 | `CopyDef`'s shadow `UnmarshalYAML` struct | field decoded | **silently dropped** — `label:` did nothing until fixed. Discards *operator input*, the worst-sited instance yet |
| 2 | `TestCopiesForSource_AllowedAgreesWithInvoke` | hint agrees with write | covered **only same-entity** — so a test whose NAME asserts the property agreed vacuously on precisely the case that diverged |
| 3 | `"...but no guard is wired"` on my live check | a demo-config gap | **production wiring**. I had the evidence on screen and explained it away |
| 4 | `pointer=draft` → `200 []` | no copies for this face | a declared-vs-stored mismatch. I fixed this trap *inside* `CopiesForSource` and reintroduced it at the wire |
| 5 | The new audit-suppression test | suppression is pinned | passes **vacuously** — a sibling fix removed the path that audited. Kept, with the finding in its godoc |

\#3 is the variant that survives the discipline added so far: derived guards and PID-identity monitors catch *missing* evidence; nothing catches a plausible misreading of evidence you have. The counter-rule: **when an error message names a specific mechanism, chase the mechanism before attributing it to the environment.** It said "no guard is *wired*"; I answered a question about grants.

\#1 and #2 are the paired-list corollary — an implicit list kept in sync by hand with nothing deriving one from the other. Both are now guarded by reflection over the type, extended pre-emptively to `WorldDef`, which has the identical shape and is clean today. "Clean by luck" and "clean by construction" look identical until someone adds a field.

## Other review findings fixed

- **A read-only GET emitted `denied-write` audit records.** `planCopy` reaches `authorizeAndAudit`. Every SPA page load would have appended rows claiming write attempts, with empty subject ids — `op=denied-write` would stop meaning "someone tried to write". Suppressed via a typed ctx marker that hides the record while computing the verdict identically.
- **`allowed` lied for cross-entity offers.** With no target id yet, the create check authorized the *empty* id. Added `Indeterminate`; those offers are no longer probed at all, because probing them answers a different question confidently. The godoc's "cannot drift" claim is narrowed to where it is true.
- Minors: nil-deref guard on `res.Entity`, the list 500 no longer echoes `err.Error()`, and a failed `copyService` type assertion logs rather than silently dropping the route.

## `copyEngine`

Jeroen's call when plimsoll failed at 42/40: decompose rather than raise the line. Six methods moved to a focused `copyEngine`; `Manager` 41 → **34**, under the line rather than pinned at it.

`planCopy` and `authorizeCopy` stay **unexported** on the engine. That is load-bearing: `CopiesForSource` computes `allowed` by running them, which is the only reason the hint cannot drift.

A mutation check found `copyInvocable`'s `authorizeCopy` call was **redundant** — `planCopy` calls it itself. Deleted, with the reason recorded: one inseparable way to plan-and-authorize is stronger than two calls that invite someone to optimize one away. Redundant defence that *looks* like the mechanism misdirects the next reader.

## Live verification

Extended `/tmp/isms-demo` with a `copies:` block and drove the real binary. The demo taught a refusal I did not know about: a definition targeting a non-default face **must** declare a guard, refused at load — which is why the by-name-only contract cannot be undermined by an operator declaring an unguarded promote.

```
policy DRAFT      promote-policy  label='Publish this policy'
policy PUBLISHED  {"data":[]}          ← its from: is the DRAFT face
control DRAFT     label='promote-control'   ← no label:, falls back to NAME

guard unwired      403  (names the permission)
unknown definition 422
missing source     404  {"title":"Entity not found"}  ← does NOT contain "POL-NOPE"
```